### PR TITLE
disallow workload injection in IDDTxnProcessorApiCorrectness

### DIFF
--- a/fdbserver/workloads/IDDTxnProcessorApiCorrectness.actor.cpp
+++ b/fdbserver/workloads/IDDTxnProcessorApiCorrectness.actor.cpp
@@ -71,7 +71,11 @@ struct IDDTxnProcessorApiWorkload : TestWorkload {
 	std::string description() const override { return desc; }
 	Future<Void> setup(Database const& cx) override { return enabled ? _setup(cx, this) : Void(); }
 	Future<Void> start(Database const& cx) override { return enabled ? _start(cx, this) : Void(); }
-	void disableFailureInjectionWorkloads(std::set<std::string>& out) const override { out.insert("all"); }
+
+	// This workload is not compatible with RandomMoveKeys workload because they will race in changing the DD mode.
+	// Other workload injections may make no sense because this workload only use the DB at beginning to reading the
+	// real world key-server mappings. It's not harmful to leave other workload injection enabled for now, though.
+	void disableFailureInjectionWorkloads(std::set<std::string>& out) const override { out.insert("RandomMoveKeys"); }
 
 	ACTOR Future<Void> _setup(Database cx, IDDTxnProcessorApiWorkload* self) {
 		self->real = std::make_shared<DDTxnProcessor>(cx);
@@ -101,8 +105,8 @@ struct IDDTxnProcessorApiWorkload : TestWorkload {
 	}
 
 	ACTOR Future<Void> _start(Database cx, IDDTxnProcessorApiWorkload* self) {
-		state int oldMode = wait(setDDMode(cx, 0));
-		TraceEvent("IDDTxnApiTestStartModeSetting").log();
+		int oldMode = wait(setDDMode(cx, 0));
+		TraceEvent("IDDTxnApiTestStartModeSetting").detail("OldValue", oldMode).log();
 		self->mgs = std::make_shared<MockGlobalState>();
 		self->mgs->configuration = self->ddContext.configuration;
 		self->mock = std::make_shared<DDMockTxnProcessor>(self->mgs);
@@ -121,7 +125,7 @@ struct IDDTxnProcessorApiWorkload : TestWorkload {
 
 		// Always set the DD mode back, even if we die with an error
 		TraceEvent("IDDTxnApiTestDoneMoving").log();
-		wait(success(setDDMode(cx, oldMode)));
+		wait(success(setDDMode(cx, 1)));
 		TraceEvent("IDDTxnApiTestDoneModeSetting").log();
 		return Void();
 	}

--- a/fdbserver/workloads/IDDTxnProcessorApiCorrectness.actor.cpp
+++ b/fdbserver/workloads/IDDTxnProcessorApiCorrectness.actor.cpp
@@ -71,6 +71,7 @@ struct IDDTxnProcessorApiWorkload : TestWorkload {
 	std::string description() const override { return desc; }
 	Future<Void> setup(Database const& cx) override { return enabled ? _setup(cx, this) : Void(); }
 	Future<Void> start(Database const& cx) override { return enabled ? _start(cx, this) : Void(); }
+	void disableFailureInjectionWorkloads(std::set<std::string>& out) const override { out.insert("all"); }
 
 	ACTOR Future<Void> _setup(Database cx, IDDTxnProcessorApiWorkload* self) {
 		self->real = std::make_shared<DDTxnProcessor>(cx);
@@ -101,7 +102,7 @@ struct IDDTxnProcessorApiWorkload : TestWorkload {
 
 	ACTOR Future<Void> _start(Database cx, IDDTxnProcessorApiWorkload* self) {
 		state int oldMode = wait(setDDMode(cx, 0));
-		TraceEvent("RMKStartModeSetting").log();
+		TraceEvent("IDDTxnApiTestStartModeSetting").log();
 		self->mgs = std::make_shared<MockGlobalState>();
 		self->mgs->configuration = self->ddContext.configuration;
 		self->mock = std::make_shared<DDMockTxnProcessor>(self->mgs);
@@ -119,9 +120,9 @@ struct IDDTxnProcessorApiWorkload : TestWorkload {
 		// Void()));
 
 		// Always set the DD mode back, even if we die with an error
-		TraceEvent("RMKDoneMoving").log();
+		TraceEvent("IDDTxnApiTestDoneMoving").log();
 		wait(success(setDDMode(cx, oldMode)));
-		TraceEvent("RMKDoneModeSetting").log();
+		TraceEvent("IDDTxnApiTestDoneModeSetting").log();
 		return Void();
 	}
 

--- a/tests/fast/IDDTxnProcessorApiCorrectness.toml
+++ b/tests/fast/IDDTxnProcessorApiCorrectness.toml
@@ -4,6 +4,7 @@ disableTss = true # There's no TSS in MGS this prevent the DD operate TSS mappin
 
 [[test]]
 testTitle = 'IDDTxnProcessorApiCorrectness'
+
     [[test.workload]]
     testName = 'IDDTxnProcessorApiCorrectness'
     testDuration = 10.0


### PR DESCRIPTION
This fixes the timeout failure in `IDDTxnProcessorApiCorrectness`. 
The root cause is when `RandomMoveKeys` is injected, both workloads will change the DD mode and cause DD mode race.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
