### PR TITLE
Blob metadata refresh

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -987,7 +987,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	// Blob Metadata
 	init( BLOB_METADATA_CACHE_TTL, isSimulated ? 120 : 24 * 60 * 60 );
 	if ( randomize && BUGGIFY) { BLOB_METADATA_CACHE_TTL = deterministicRandom()->randomInt(50, 100); }
-	init( BLOB_METADATA_REFRESH_INTERVAL,   isSimulated ? 60 : 12 * 60 * 60 );
+	init( BLOB_METADATA_REFRESH_INTERVAL,   isSimulated ? 60 : 60 * 60 );
 	if ( randomize && BUGGIFY) { BLOB_METADATA_REFRESH_INTERVAL = deterministicRandom()->randomInt(20, 40); }
 
 	// HTTP KMS Connector

--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -988,7 +988,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( BLOB_METADATA_CACHE_TTL, isSimulated ? 120 : 24 * 60 * 60 );
 	if ( randomize && BUGGIFY) { BLOB_METADATA_CACHE_TTL = deterministicRandom()->randomInt(50, 100); }
 	init( BLOB_METADATA_REFRESH_INTERVAL,   isSimulated ? 60 : 60 * 60 );
-	if ( randomize && BUGGIFY) { BLOB_METADATA_REFRESH_INTERVAL = deterministicRandom()->randomInt(20, 40); }
+	if ( randomize && BUGGIFY) { BLOB_METADATA_REFRESH_INTERVAL = deterministicRandom()->randomInt(5, 120); }
 
 	// HTTP KMS Connector
 	init( REST_KMS_CONNECTOR_KMS_DISCOVERY_URL_MODE,           "file");

--- a/fdbclient/include/fdbclient/BlobConnectionProvider.h
+++ b/fdbclient/include/fdbclient/BlobConnectionProvider.h
@@ -33,13 +33,15 @@ struct BlobConnectionProvider : NonCopyable, ReferenceCounted<BlobConnectionProv
 	// something returned from createForWrite
 	virtual Reference<BackupContainerFileSystem> getForRead(std::string filePath) = 0;
 
+	virtual bool isExpired() const = 0;
+	virtual bool needsRefresh() const = 0;
+	virtual void update(Standalone<BlobMetadataDetailsRef> newBlobMetadata) = 0;
+
 	virtual ~BlobConnectionProvider() {}
 
 	static Reference<BlobConnectionProvider> newBlobConnectionProvider(std::string blobUrl);
 
 	static Reference<BlobConnectionProvider> newBlobConnectionProvider(Standalone<BlobMetadataDetailsRef> blobMetadata);
-
-	// TODO add update impl
 };
 
 #endif

--- a/fdbclient/include/fdbclient/BlobMetadataUtils.h
+++ b/fdbclient/include/fdbclient/BlobMetadataUtils.h
@@ -44,9 +44,14 @@ struct BlobMetadataDetailsRef {
 	Optional<StringRef> base;
 	VectorRef<StringRef> partitions;
 
+	// cache options
+	int64_t refreshAt;
+	int64_t expireAt;
+
 	BlobMetadataDetailsRef() {}
 	BlobMetadataDetailsRef(Arena& arena, const BlobMetadataDetailsRef& from)
-	  : domainId(from.domainId), domainName(arena, from.domainName), partitions(arena, from.partitions) {
+	  : domainId(from.domainId), domainName(arena, from.domainName), partitions(arena, from.partitions),
+	    refreshAt(from.refreshAt), expireAt(from.expireAt) {
 		if (from.base.present()) {
 			base = StringRef(arena, from.base.get());
 		}
@@ -54,8 +59,11 @@ struct BlobMetadataDetailsRef {
 	explicit BlobMetadataDetailsRef(BlobMetadataDomainId domainId,
 	                                BlobMetadataDomainNameRef domainName,
 	                                Optional<StringRef> base,
-	                                VectorRef<StringRef> partitions)
-	  : domainId(domainId), domainName(domainName), base(base), partitions(partitions) {}
+	                                VectorRef<StringRef> partitions,
+	                                int64_t refreshAt,
+	                                int64_t expireAt)
+	  : domainId(domainId), domainName(domainName), base(base), partitions(partitions), refreshAt(refreshAt),
+	    expireAt(expireAt) {}
 
 	int expectedSize() const {
 		return sizeof(BlobMetadataDetailsRef) + domainName.size() + (base.present() ? base.get().size() : 0) +
@@ -64,7 +72,7 @@ struct BlobMetadataDetailsRef {
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, domainId, domainName, base, partitions);
+		serializer(ar, domainId, domainName, base, partitions, refreshAt, expireAt);
 	}
 };
 

--- a/fdbclient/include/fdbclient/BlobMetadataUtils.h
+++ b/fdbclient/include/fdbclient/BlobMetadataUtils.h
@@ -45,8 +45,8 @@ struct BlobMetadataDetailsRef {
 	VectorRef<StringRef> partitions;
 
 	// cache options
-	int64_t refreshAt;
-	int64_t expireAt;
+	double refreshAt;
+	double expireAt;
 
 	BlobMetadataDetailsRef() {}
 	BlobMetadataDetailsRef(Arena& arena, const BlobMetadataDetailsRef& from)
@@ -60,8 +60,8 @@ struct BlobMetadataDetailsRef {
 	                                BlobMetadataDomainNameRef domainName,
 	                                Optional<StringRef> base,
 	                                VectorRef<StringRef> partitions,
-	                                int64_t refreshAt,
-	                                int64_t expireAt)
+	                                double refreshAt,
+	                                double expireAt)
 	  : domainId(domainId), domainName(domainName), base(base), partitions(partitions), refreshAt(refreshAt),
 	    expireAt(expireAt) {}
 

--- a/fdbserver/BlobGranuleServerCommon.actor.cpp
+++ b/fdbserver/BlobGranuleServerCommon.actor.cpp
@@ -483,13 +483,21 @@ ACTOR Future<Void> loadBlobMetadataForTenants(
 					}
 					auto dataEntry = self->tenantData.rangeContaining(info->second.prefix);
 					ASSERT(dataEntry.begin() == info->second.prefix);
-					dataEntry.cvalue()->setBStore(BlobConnectionProvider::newBlobConnectionProvider(metadata));
+					dataEntry.cvalue()->updateBStore(metadata);
 				}
 				return Void();
 			}
 			when(wait(self->dbInfo->onChange())) {}
 		}
 	}
+}
+
+Future<Void> loadBlobMetadataForTenant(BGTenantMap* self,
+                                       BlobMetadataDomainId domainId,
+                                       BlobMetadataDomainName domainName) {
+	std::vector<std::pair<BlobMetadataDomainId, BlobMetadataDomainName>> toLoad;
+	toLoad.push_back({ domainId, domainName });
+	return loadBlobMetadataForTenants(self, toLoad);
 }
 
 // list of tenants that may or may not already exist
@@ -526,11 +534,41 @@ Optional<TenantMapEntry> BGTenantMap::getTenantById(int64_t id) {
 	}
 }
 
-// TODO: handle case where tenant isn't loaded yet
-Reference<GranuleTenantData> BGTenantMap::getDataForGranule(const KeyRangeRef& keyRange) {
-	auto tenant = tenantData.rangeContaining(keyRange.begin);
-	ASSERT(tenant.begin() <= keyRange.begin);
-	ASSERT(tenant.end() >= keyRange.end);
+// FIXME: batch requests for refresh?
+// FIXME: don't double fetch if multiple accesses to refreshing/expired metadata
+// FIXME: log warning if after refresh, data is still expired!
+ACTOR Future<Reference<GranuleTenantData>> getDataForGranuleActor(BGTenantMap* self, KeyRange keyRange) {
+	state int loopCount = 0;
+	loop {
+		loopCount++;
+		auto tenant = self->tenantData.rangeContaining(keyRange.begin);
+		ASSERT(tenant.begin() <= keyRange.begin);
+		ASSERT(tenant.end() >= keyRange.end);
 
-	return tenant.cvalue();
+		if (!tenant.cvalue().isValid() || !tenant.cvalue()->bstore.isValid()) {
+			return tenant.cvalue();
+		} else if (tenant.cvalue()->bstore->isExpired()) {
+			CODE_PROBE(true, "re-fetching expired blob metadata");
+			// fetch again
+			Future<Void> reload = loadBlobMetadataForTenant(self, tenant.cvalue()->entry.id, tenant->cvalue()->name);
+			wait(reload);
+			if (loopCount > 1) {
+				TraceEvent(SevWarn, "BlobMetadataStillExpired").suppressFor(5.0).detail("LoopCount", loopCount);
+				wait(delay(0.001));
+			}
+		} else {
+			// handle refresh in background if tenant needs refres
+			if (tenant.cvalue()->bstore->needsRefresh()) {
+				Future<Void> reload =
+				    loadBlobMetadataForTenant(self, tenant.cvalue()->entry.id, tenant->cvalue()->name);
+				self->addActor.send(reload);
+			}
+			return tenant.cvalue();
+		}
+	}
+}
+
+// TODO: handle case where tenant isn't loaded yet
+Future<Reference<GranuleTenantData>> BGTenantMap::getDataForGranule(const KeyRangeRef& keyRange) {
+	return getDataForGranuleActor(this, keyRange);
 }

--- a/fdbserver/BlobWorker.actor.cpp
+++ b/fdbserver/BlobWorker.actor.cpp
@@ -367,7 +367,7 @@ ACTOR Future<BlobGranuleCipherKeysCtx> getLatestGranuleCipherKeys(Reference<Blob
                                                                   KeyRange keyRange,
                                                                   Arena* arena) {
 	state BlobGranuleCipherKeysCtx cipherKeysCtx;
-	state Reference<GranuleTenantData> tenantData = bwData->tenantData.getDataForGranule(keyRange);
+	state Reference<GranuleTenantData> tenantData = wait(bwData->tenantData.getDataForGranule(keyRange));
 
 	ASSERT(tenantData.isValid());
 
@@ -4097,7 +4097,8 @@ ACTOR Future<Reference<BlobConnectionProvider>> loadBStoreForTenant(Reference<Bl
                                                                     KeyRange keyRange) {
 	state int retryCount = 0;
 	loop {
-		state Reference<GranuleTenantData> data = bwData->tenantData.getDataForGranule(keyRange);
+		state Reference<GranuleTenantData> data;
+		wait(store(data, bwData->tenantData.getDataForGranule(keyRange)));
 		if (data.isValid()) {
 			wait(data->bstoreLoaded.getFuture());
 			wait(delay(0));

--- a/fdbserver/EncryptKeyProxy.actor.cpp
+++ b/fdbserver/EncryptKeyProxy.actor.cpp
@@ -716,7 +716,8 @@ ACTOR Future<Void> getLatestBlobMetadata(Reference<EncryptKeyProxyData> ekpProxy
 
 	for (auto& info : dedupedDomainInfos) {
 		const auto itr = ekpProxyData->blobMetadataDomainIdCache.find(info.first);
-		if (itr != ekpProxyData->blobMetadataDomainIdCache.end() && itr->second.isValid()) {
+		if (itr != ekpProxyData->blobMetadataDomainIdCache.end() && itr->second.isValid() &&
+		    now() <= itr->second.metadataDetails.expireAt) {
 			metadataDetails.arena().dependsOn(itr->second.metadataDetails.arena());
 			metadataDetails.push_back(metadataDetails.arena(), itr->second.metadataDetails);
 

--- a/fdbserver/EncryptKeyProxy.actor.cpp
+++ b/fdbserver/EncryptKeyProxy.actor.cpp
@@ -595,11 +595,17 @@ bool isCipherKeyEligibleForRefresh(const EncryptBaseCipherKey& cipherKey, int64_
 	// Candidate eligible for refresh iff either is true:
 	// 1. CipherKey cell is either expired/needs-refresh right now.
 	// 2. CipherKey cell 'will' be expired/needs-refresh before next refresh cycle interval (proactive refresh)
+	if (BUGGIFY_WITH_PROB(0.01)) {
+		return true;
+	}
 	int64_t nextRefreshCycleTS = currTS + FLOW_KNOBS->ENCRYPT_KEY_REFRESH_INTERVAL;
 	return nextRefreshCycleTS > cipherKey.expireAt || nextRefreshCycleTS > cipherKey.refreshAt;
 }
 
 bool isBlobMetadataEligibleForRefresh(const BlobMetadataDetailsRef& blobMetadata, int64_t currTS) {
+	if (BUGGIFY_WITH_PROB(0.01)) {
+		return true;
+	}
 	int64_t nextRefreshCycleTS = currTS + SERVER_KNOBS->BLOB_METADATA_REFRESH_INTERVAL;
 	return nextRefreshCycleTS > blobMetadata.expireAt || nextRefreshCycleTS > blobMetadata.refreshAt;
 }

--- a/fdbserver/SimKmsConnector.actor.cpp
+++ b/fdbserver/SimKmsConnector.actor.cpp
@@ -38,6 +38,7 @@
 #include "flow/network.h"
 #include "flow/UnitTest.h"
 
+#include <limits>
 #include <memory>
 #include <unordered_map>
 #include <utility>
@@ -228,8 +229,14 @@ static Standalone<BlobMetadataDetailsRef> createBlobMetadata(BlobMetadataDomainI
 	}
 
 	// set random refresh + expire time
-	metadata.refreshAt = now() + deterministicRandom()->random01() * 30;
-	metadata.expireAt = metadata.refreshAt + deterministicRandom()->random01() * 10;
+	if (deterministicRandom()->coinflip()) {
+		metadata.refreshAt = now() + deterministicRandom()->random01() * SERVER_KNOBS->BLOB_METADATA_REFRESH_INTERVAL;
+		metadata.expireAt =
+		    metadata.refreshAt + deterministicRandom()->random01() * SERVER_KNOBS->BLOB_METADATA_REFRESH_INTERVAL;
+	} else {
+		metadata.refreshAt = std::numeric_limits<double>::max();
+		metadata.expireAt = metadata.refreshAt;
+	}
 
 	return metadata;
 }
@@ -249,6 +256,10 @@ ACTOR Future<Void> blobMetadataLookup(KmsConnectorInterface interf, KmsConnBlobM
 			it = simBlobMetadataStore
 			         .insert({ domainInfo.domainId, createBlobMetadata(domainInfo.domainId, domainInfo.domainName) })
 			         .first;
+		} else if (now() >= it->second.expireAt) {
+			// update random refresh and expire time
+			it->second.refreshAt = now() + deterministicRandom()->random01() * 30;
+			it->second.expireAt = it->second.refreshAt + deterministicRandom()->random01() * 10;
 		}
 		rep.metadataDetails.arena().dependsOn(it->second.arena());
 		rep.metadataDetails.push_back(rep.metadataDetails.arena(), it->second);

--- a/fdbserver/SimKmsConnector.actor.cpp
+++ b/fdbserver/SimKmsConnector.actor.cpp
@@ -226,6 +226,11 @@ static Standalone<BlobMetadataDetailsRef> createBlobMetadata(BlobMetadataDomainI
 			ev.detail("P" + std::to_string(i), metadata.partitions.back());
 		}
 	}
+
+	// set random refresh + expire time
+	metadata.refreshAt = now() + deterministicRandom()->random01() * 30;
+	metadata.expireAt = metadata.refreshAt + deterministicRandom()->random01() * 10;
+
 	return metadata;
 }
 

--- a/fdbserver/include/fdbserver/BlobGranuleServerCommon.actor.h
+++ b/fdbserver/include/fdbserver/BlobGranuleServerCommon.actor.h
@@ -105,10 +105,15 @@ struct GranuleTenantData : NonCopyable, ReferenceCounted<GranuleTenantData> {
 	GranuleTenantData() {}
 	GranuleTenantData(TenantName name, TenantMapEntry entry) : name(name), entry(entry) {}
 
-	void setBStore(Reference<BlobConnectionProvider> bs) {
-		ASSERT(bstoreLoaded.canBeSet());
-		bstore = bs;
-		bstoreLoaded.send(Void());
+	void updateBStore(const BlobMetadataDetailsRef& metadata) {
+		if (bstoreLoaded.canBeSet()) {
+			// new
+			bstore = BlobConnectionProvider::newBlobConnectionProvider(metadata);
+			bstoreLoaded.send(Void());
+		} else {
+			// update existing
+			bstore->update(metadata);
+		}
 	}
 };
 
@@ -119,7 +124,7 @@ public:
 	void removeTenants(std::vector<int64_t> tenantIds);
 
 	Optional<TenantMapEntry> getTenantById(int64_t id);
-	Reference<GranuleTenantData> getDataForGranule(const KeyRangeRef& keyRange);
+	Future<Reference<GranuleTenantData>> getDataForGranule(const KeyRangeRef& keyRange);
 
 	KeyRangeMap<Reference<GranuleTenantData>> tenantData;
 	std::unordered_map<int64_t, TenantMapEntry> tenantInfoById;

--- a/fdbserver/workloads/BlobGranuleCorrectnessWorkload.actor.cpp
+++ b/fdbserver/workloads/BlobGranuleCorrectnessWorkload.actor.cpp
@@ -281,6 +281,7 @@ struct BlobGranuleCorrectnessWorkload : TestWorkload {
 		state int directoryIdx = 0;
 		state std::vector<std::pair<TenantName, TenantMapEntry>> tenants;
 		state BGTenantMap tenantData(self->dbInfo);
+		state Reference<GranuleTenantData> data;
 		for (; directoryIdx < self->directories.size(); directoryIdx++) {
 			// Set up the blob range first
 			TenantMapEntry tenantEntry = wait(self->setUpTenant(cx, self->directories[directoryIdx]->tenantName));
@@ -297,8 +298,7 @@ struct BlobGranuleCorrectnessWorkload : TestWorkload {
 		// wait for tenant data to be loaded
 
 		for (directoryIdx = 0; directoryIdx < self->directories.size(); directoryIdx++) {
-			state Reference<GranuleTenantData> data =
-			    tenantData.getDataForGranule(self->directories[directoryIdx]->directoryRange);
+			wait(store(data, tenantData.getDataForGranule(self->directories[directoryIdx]->directoryRange)));
 			wait(data->bstoreLoaded.getFuture());
 			wait(delay(0));
 			self->directories[directoryIdx]->bstore = data->bstore;


### PR DESCRIPTION
Added blob metadata expiration and refresh to EKP and process-local cache.

Passed 20k BlobGranuleCorrectness* with 1 unrelated failure (InvalidPeerReferences)

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
