### PR TITLE
Fix the way retry commands are generated

### DIFF
--- a/contrib/TestHarness2/test_harness/joshua.py
+++ b/contrib/TestHarness2/test_harness/joshua.py
@@ -42,9 +42,10 @@ class ToSummaryTree(xml.sax.handler.ContentHandler):
 
 def _print_summary(summary: SummaryTree, commands: Set[str]):
     cmd = []
+    is_valgrind_run = False
     if config.reproduce_prefix is not None:
         cmd.append(config.reproduce_prefix)
-    cmd.append('fdbserver')
+    cmd.append('bin/fdbserver')
     if 'TestFile' in summary.attributes:
         file_name = summary.attributes['TestFile']
         role = 'test' if test_harness.run.is_no_sim(Path(file_name)) else 'simulation'
@@ -63,11 +64,6 @@ def _print_summary(summary: SummaryTree, commands: Set[str]):
     else:
         cmd += ['b', '<ERROR>']
     cmd += ['--crash', '--trace_format', config.trace_format]
-    key = ' '.join(cmd)
-    count = 1
-    while key in commands:
-        key = '{} # {}'.format(' '.join(cmd), count)
-        count += 1
     # we want the command as the first attribute
     attributes = {'Command': ' '.join(cmd)}
     for k, v in summary.attributes.items():
@@ -76,18 +72,6 @@ def _print_summary(summary: SummaryTree, commands: Set[str]):
         else:
             attributes[k] = v
     summary.attributes = attributes
-    if config.details:
-        key = str(len(commands))
-        str_io = io.StringIO()
-        summary.dump(str_io, prefix=('  ' if config.pretty_print else ''))
-        if config.output_format == 'json':
-            sys.stdout.write('{}"Test{}": {}'.format('  ' if config.pretty_print else '',
-                                                     key, str_io.getvalue()))
-        else:
-            sys.stdout.write(str_io.getvalue())
-        if config.pretty_print:
-            sys.stdout.write('\n' if config.output_format == 'xml' else ',\n')
-        return key
     error_count = 0
     warning_count = 0
     small_summary = SummaryTree('Test')
@@ -98,6 +82,8 @@ def _print_summary(summary: SummaryTree, commands: Set[str]):
     for child in summary.children:
         if 'Severity' in child.attributes and child.attributes['Severity'] == '40' and error_count < config.max_errors:
             error_count += 1
+            if errors.name == 'ValgrindError':
+                is_valgrind_run = True
             errors.append(child)
         if 'Severity' in child.attributes and child.attributes[
             'Severity'] == '30' and warning_count < config.max_warnings:
@@ -122,6 +108,26 @@ def _print_summary(summary: SummaryTree, commands: Set[str]):
         small_summary.children.append(errors)
     if len(warnings.children) > 0:
         small_summary.children.append(warnings)
+    if is_valgrind_run:
+        idx = 0 if config.reproduce_prefix is None else 1
+        cmd.insert(idx, 'valgrind')
+    key = ' '.join(cmd)
+    count = 1
+    while key in commands:
+        key = '{} # {}'.format(' '.join(cmd), count)
+        count += 1
+    if config.details:
+        key = str(len(commands))
+        str_io = io.StringIO()
+        summary.dump(str_io, prefix=('  ' if config.pretty_print else ''))
+        if config.output_format == 'json':
+            sys.stdout.write('{}"Test{}": {}'.format('  ' if config.pretty_print else '',
+                                                     key, str_io.getvalue()))
+        else:
+            sys.stdout.write(str_io.getvalue())
+        if config.pretty_print:
+            sys.stdout.write('\n' if config.output_format == 'xml' else ',\n')
+        return key
     output = io.StringIO()
     small_summary.dump(output, prefix=('  ' if config.pretty_print else ''))
     if config.output_format == 'json':


### PR DESCRIPTION
* `valgrind` was not prepended to the command for valgrind requests
* we call `bin/fdbserver`, not `fdbserver`

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
