### PR TITLE
Fix Redwood xor encoding incompatibility with 7.1

### DIFF
--- a/fdbserver/include/fdbserver/IPageEncryptionKeyProvider.actor.h
+++ b/fdbserver/include/fdbserver/IPageEncryptionKeyProvider.actor.h
@@ -39,6 +39,7 @@
 #include "flow/xxhash.h"
 
 #include <functional>
+#include <limits>
 #include <tuple>
 
 #include "flow/actorcompiler.h" // This must be the last #include.
@@ -154,12 +155,14 @@ public:
 		const EncodingHeader* h = reinterpret_cast<const EncodingHeader*>(encodingHeader);
 		EncryptionKey s;
 		s.xorKey = h->xorKey;
+		s.xorWith = xorWith;
 		return s;
 	}
 
 	Future<EncryptionKey> getLatestDefaultEncryptionKey() override {
 		EncryptionKey s;
-		s.xorKey = xorWith;
+		s.xorKey = static_cast<uint8_t>(deterministicRandom()->randomInt(0, std::numeric_limits<uint8_t>::max() + 1));
+		s.xorWith = xorWith;
 		return s;
 	}
 

--- a/fdbserver/include/fdbserver/IPager.h
+++ b/fdbserver/include/fdbserver/IPager.h
@@ -228,6 +228,7 @@ public:
 	struct EncryptionKeyRef {
 		TextAndHeaderCipherKeys aesKey; // For AESEncryptionV1
 		uint8_t xorKey; // For XOREncryption_TestOnly
+		uint8_t xorWith; // For XOREncryption_TestOnly
 	};
 	using EncryptionKey = Standalone<EncryptionKeyRef>;
 
@@ -345,8 +346,9 @@ public:
 			Header* h = reinterpret_cast<Header*>(header);
 			h->checksum = XXH3_64bits_withSeed(payload, len, seed);
 			h->xorKey = encryptionKey.xorKey;
+			uint8_t xorMask = ~encryptionKey.xorKey ^ encryptionKey.xorWith;
 			for (int i = 0; i < len; ++i) {
-				payload[i] ^= h->xorKey;
+				payload[i] ^= xorMask;
 			}
 		}
 
@@ -356,8 +358,9 @@ public:
 		                   int len,
 		                   PhysicalPageID seed) {
 			Header* h = reinterpret_cast<Header*>(header);
+			uint8_t xorMask = ~encryptionKey.xorKey ^ encryptionKey.xorWith;
 			for (int i = 0; i < len; ++i) {
-				payload[i] ^= h->xorKey;
+				payload[i] ^= xorMask;
 			}
 			if (h->checksum != XXH3_64bits_withSeed(payload, len, seed)) {
 				throw page_decoding_failed();

--- a/tests/restarting/from_7.1.0/ConfigureStorageMigrationTestRestart-1.toml
+++ b/tests/restarting/from_7.1.0/ConfigureStorageMigrationTestRestart-1.toml
@@ -1,6 +1,5 @@
 [configuration]
 extraMachineCountDC = 2
-storageEngineExcludeTypes = [3]
 
 [[test]]
 testTitle = 'CloggedConfigureDatabaseTest'

--- a/tests/restarting/from_7.1.0/ConfigureTestRestart-1.toml
+++ b/tests/restarting/from_7.1.0/ConfigureTestRestart-1.toml
@@ -1,6 +1,3 @@
-[configuration]
-storageEngineExcludeTypes = [3]
-
 [[test]]
 testTitle='CloggedConfigureDatabaseTest'
 clearAfterTest=false

--- a/tests/restarting/from_7.1.0/SnapCycleRestart-1.txt
+++ b/tests/restarting/from_7.1.0/SnapCycleRestart-1.txt
@@ -1,4 +1,4 @@
-storageEngineExcludeTypes=3,4,5
+storageEngineExcludeTypes=4,5
 
 ;Take snap and do cycle test
 testTitle=SnapCyclePre

--- a/tests/restarting/from_7.1.0/SnapIncrementalRestore-1.txt
+++ b/tests/restarting/from_7.1.0/SnapIncrementalRestore-1.txt
@@ -1,4 +1,4 @@
-storageEngineExcludeTypes=3,4,5
+storageEngineExcludeTypes=4,5
 
 logAntiQuorum = 0
 

--- a/tests/restarting/from_7.1.0/SnapTestAttrition-1.txt
+++ b/tests/restarting/from_7.1.0/SnapTestAttrition-1.txt
@@ -1,4 +1,4 @@
-storageEngineExcludeTypes=3,4,5
+storageEngineExcludeTypes=4,5
 
 ;write 1000 Keys ending with even numbers
 testTitle=SnapTestPre

--- a/tests/restarting/from_7.1.0/SnapTestRestart-1.txt
+++ b/tests/restarting/from_7.1.0/SnapTestRestart-1.txt
@@ -1,4 +1,4 @@
-storageEngineExcludeTypes=3,4,5
+storageEngineExcludeTypes=4,5
 
 ;write 1000 Keys ending with even numbers
 testTitle=SnapTestPre

--- a/tests/restarting/from_7.1.0/SnapTestSimpleRestart-1.txt
+++ b/tests/restarting/from_7.1.0/SnapTestSimpleRestart-1.txt
@@ -1,4 +1,4 @@
-storageEngineExcludeTypes=3,4,5
+storageEngineExcludeTypes=4,5
 
 ;write 1000 Keys ending with even number
 testTitle=SnapSimplePre

--- a/tests/restarting/from_7.1.0/VersionVectorDisableRestart-1.toml
+++ b/tests/restarting/from_7.1.0/VersionVectorDisableRestart-1.toml
@@ -1,6 +1,3 @@
-[configuration]
-storageEngineExcludeTypes = [3]
-
 [[knobs]]
 enable_version_vector = true
 enable_version_vector_tlog_unicast = true

--- a/tests/restarting/from_7.1.0/VersionVectorEnableRestart-1.toml
+++ b/tests/restarting/from_7.1.0/VersionVectorEnableRestart-1.toml
@@ -1,6 +1,3 @@
-[configuration]
-storageEngineExcludeTypes = [3]
-
 [[knobs]]
 enable_version_vector = false
 enable_version_vector_tlog_unicast = false

--- a/tests/restarting/from_7.2.0/DrUpgradeRestart-1.txt
+++ b/tests/restarting/from_7.2.0/DrUpgradeRestart-1.txt
@@ -1,4 +1,3 @@
-storageEngineExcludeTypes=3
 extraDatabaseMode=Local
 
 testTitle=DrUpgrade

--- a/tests/restarting/to_7.1.0/ConfigureStorageMigrationTestRestart-1.toml
+++ b/tests/restarting/to_7.1.0/ConfigureStorageMigrationTestRestart-1.toml
@@ -3,7 +3,7 @@ extraMachineCountDC = 2
 maxTLogVersion=6
 disableHostname=true
 disableEncryption=true
-storageEngineExcludeTypes=[3,4]
+storageEngineExcludeTypes=[4]
 
 [[knobs]]
 # This can be removed once the lower bound of this downgrade test is a version that understands the new protocol


### PR DESCRIPTION
Fixing XOR encryption encoding format change due to #8172. The XOR encryption encoding is simulation only though.

Also enabling Redwood for all restart test to/from 7.1.

Tested with 100K normal correctness run and 100K restart test only correctness run.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
