### PR TITLE
Disable Rollback fault injection workload for SpecialKeySpaceCorrectness test.

### DIFF
--- a/fdbserver/workloads/SpecialKeySpaceCorrectness.actor.cpp
+++ b/fdbserver/workloads/SpecialKeySpaceCorrectness.actor.cpp
@@ -68,7 +68,17 @@ struct SpecialKeySpaceCorrectnessWorkload : TestWorkload {
 	void getMetrics(std::vector<PerfMetric>& m) override {}
 	// disable the default timeout setting
 	double getCheckTimeout() const override { return std::numeric_limits<double>::max(); }
-	void disableFailureInjectionWorkloads(std::set<std::string>& out) const override { out.insert("RandomMoveKeys"); }
+
+	void disableFailureInjectionWorkloads(std::set<std::string>& out) const override {
+		out.insert("RandomMoveKeys");
+
+		// Rollback interferes with the
+		// \xff\xff/worker_interfaces test, since it can
+		// trigger a cluster recvoery, causing the worker
+		// interface for a machine to be updated in the middle
+		// of the test.
+		out.insert("RollbackWorkload");
+	}
 
 	Future<Void> _setup(Database cx, SpecialKeySpaceCorrectnessWorkload* self) {
 		cx->specialKeySpace = std::make_unique<SpecialKeySpace>();


### PR DESCRIPTION
One of the special keyspace tests reads values from `\xff\xff/worker_interfaces' in two different ways. The rollback workload can trigger a cluster recovery between the two reads. The cluster controller can update the worker interface for a machine in that time, causing the test to fail.

It's not expected that the worker_interfaces keyspace will remain unchanged through a cluster reconfiguration. The purpose of the test was to check that 'get' and 'getRange' returned consistent results for this special keyspace.

Therefore, we've disabled Rollback failures in this test.

Testing: 100,000 runs of SpecialKeyspaceCorrectness test.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
