### PR TITLE
Add `/GrvProxyTransactionTagThrottler/Fifo` unit test

### DIFF
--- a/fdbserver/GrvProxyTransactionTagThrottler.actor.cpp
+++ b/fdbserver/GrvProxyTransactionTagThrottler.actor.cpp
@@ -90,8 +90,7 @@ void GrvProxyTransactionTagThrottler::releaseTransactions(double elapsed,
 		uint32_t* numReleased;
 		// Sequence number of the first queued request
 		int64_t nextSeqNo;
-		// Reverse order because std::priority_queue is a max heap
-		bool operator<(TagQueueHandle const& rhs) const { return nextSeqNo > rhs.nextSeqNo; }
+		bool operator>(TagQueueHandle const& rhs) const { return nextSeqNo > rhs.nextSeqNo; }
 		explicit TagQueueHandle(TagQueue& queue, uint32_t& numReleased) : queue(&queue), numReleased(&numReleased) {
 			ASSERT(!this->queue->requests.empty());
 			nextSeqNo = this->queue->requests.front().sequenceNumber;
@@ -100,7 +99,7 @@ void GrvProxyTransactionTagThrottler::releaseTransactions(double elapsed,
 
 	// Priority queue of queues for each tag, ordered by the sequence number of the
 	// next request to process in each queue
-	std::priority_queue<TagQueueHandle> pqOfQueues;
+	std::priority_queue<TagQueueHandle, std::vector<TagQueueHandle>, std::greater<TagQueueHandle>> pqOfQueues;
 
 	// Track transactions released for each tag
 	std::vector<std::pair<TransactionTag, uint32_t>> transactionsReleased;

--- a/fdbserver/include/fdbserver/GrvProxyTransactionTagThrottler.h
+++ b/fdbserver/include/fdbserver/GrvProxyTransactionTagThrottler.h
@@ -52,7 +52,8 @@ class GrvProxyTransactionTagThrottler {
 		Optional<GrvTransactionRateInfo> rateInfo;
 		Deque<DelayedRequest> requests;
 
-		explicit TagQueue(double rate = 0.0) : rateInfo(rate) {}
+		TagQueue() = default;
+		explicit TagQueue(double rate) : rateInfo(rate) {}
 
 		void setRate(double rate);
 	};

--- a/tests/rare/SpecificUnitTests.toml
+++ b/tests/rare/SpecificUnitTests.toml
@@ -6,5 +6,5 @@ startDelay = 0
 
     [[test.workload]]
     testName = 'UnitTests'
-    maxTestCases = 1
-    testsMatching = '/'
+    maxTestCases = 0
+    testsMatching = '/GrvProxyTransactionTagThrottler/Fifo'


### PR DESCRIPTION
This PR adds a unit test to ensure that the `GrvProxyTransactionTagThrottler::releaseTransactions` function preserves FIFO ordering of transactions, even when these transactions have different tags. It also fixes two bugs uncovered by this test:
- `TagQueueHandle::operator<` was assuming `std::priority_queue` was a min heap
- `GrvProxyTransactionTagThrottler::TagQueue::TagQueue()` was always initializing a `GrvTransactionRateInfo` object, even when a tag was not meant to be throttled.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
