### PR TITLE
Implement mock mode moveKeys in MockDDTxnProcessor and simulation test

### DIFF
--- a/fdbserver/DDTxnProcessor.actor.cpp
+++ b/fdbserver/DDTxnProcessor.actor.cpp
@@ -243,7 +243,7 @@ class DDTxnProcessorImpl {
 	    MoveKeysLock moveKeysLock,
 	    std::vector<Optional<Key>> remoteDcIds,
 	    const DDEnabledState* ddEnabledState,
-	    bool skipDDModeCheck = false) {
+	    SkipDDModeCheck skipDDModeCheck) {
 		state Reference<InitialDataDistribution> result = makeReference<InitialDataDistribution>();
 		state Key beginKey = allKeys.begin;
 
@@ -256,7 +256,7 @@ class DDTxnProcessorImpl {
 		state std::vector<std::pair<StorageServerInterface, ProcessClass>> tss_servers;
 		state int numDataMoves = 0;
 
-		CODE_PROBE(skipDDModeCheck, "DD Mode won't prevent read initial data distribution.");
+		CODE_PROBE((bool)skipDDModeCheck, "DD Mode won't prevent read initial data distribution.");
 		// Get the server list in its own try/catch block since it modifies result.  We don't want a subsequent failure
 		// causing entries to be duplicated
 		loop {
@@ -627,7 +627,7 @@ Future<Reference<InitialDataDistribution>> DDTxnProcessor::getInitialDataDistrib
     const DDEnabledState* ddEnabledState,
     SkipDDModeCheck skipDDModeCheck) {
 	return DDTxnProcessorImpl::getInitialDataDistribution(
-	    cx, distributorId, moveKeysLock, remoteDcIds, ddEnabledState, (bool)skipDDModeCheck);
+	    cx, distributorId, moveKeysLock, remoteDcIds, ddEnabledState, skipDDModeCheck);
 }
 
 Future<Void> DDTxnProcessor::waitForDataDistributionEnabled(const DDEnabledState* ddEnabledState) const {

--- a/fdbserver/DDTxnProcessor.actor.cpp
+++ b/fdbserver/DDTxnProcessor.actor.cpp
@@ -25,6 +25,8 @@
 #include "fdbclient/DatabaseContext.h"
 #include "flow/actorcompiler.h" // This must be the last #include.
 
+FDB_DEFINE_BOOLEAN_PARAM(SkipDDModeCheck);
+
 class DDTxnProcessorImpl {
 	friend class DDTxnProcessor;
 
@@ -623,9 +625,9 @@ Future<Reference<InitialDataDistribution>> DDTxnProcessor::getInitialDataDistrib
     const MoveKeysLock& moveKeysLock,
     const std::vector<Optional<Key>>& remoteDcIds,
     const DDEnabledState* ddEnabledState,
-    bool skipDDModeCheck) {
+    SkipDDModeCheck skipDDModeCheck) {
 	return DDTxnProcessorImpl::getInitialDataDistribution(
-	    cx, distributorId, moveKeysLock, remoteDcIds, ddEnabledState, skipDDModeCheck);
+	    cx, distributorId, moveKeysLock, remoteDcIds, ddEnabledState, (bool)skipDDModeCheck);
 }
 
 Future<Void> DDTxnProcessor::waitForDataDistributionEnabled(const DDEnabledState* ddEnabledState) const {
@@ -792,7 +794,7 @@ Future<Reference<InitialDataDistribution>> DDMockTxnProcessor::getInitialDataDis
     const MoveKeysLock& moveKeysLock,
     const std::vector<Optional<Key>>& remoteDcIds,
     const DDEnabledState* ddEnabledState,
-    bool skipDDModeCheck) {
+    SkipDDModeCheck skipDDModeCheck) {
 
 	// FIXME: now we just ignore ddEnabledState and moveKeysLock, will fix it in the future
 	Reference<InitialDataDistribution> res = makeReference<InitialDataDistribution>();

--- a/fdbserver/DDTxnProcessor.actor.cpp
+++ b/fdbserver/DDTxnProcessor.actor.cpp
@@ -896,7 +896,7 @@ Future<Void> DDMockTxnProcessor::rawStartMovement(MoveKeysParams& params,
 	mgs->shardMapping->moveShard(params.keys, destTeams);
 
 	for (auto& id : params.destinationTeam) {
-		mgs->allServers.at(id).setShardStatus(params.keys, MockShardStatus::INFLIGHT);
+		mgs->allServers.at(id).setShardStatus(params.keys, MockShardStatus::INFLIGHT, mgs->restrictSize);
 	}
 	return Void();
 }
@@ -918,7 +918,7 @@ Future<Void> DDMockTxnProcessor::rawFinishMovement(MoveKeysParams& params,
 	}
 
 	for (auto& id : params.destinationTeam) {
-		mgs->allServers.at(id).setShardStatus(params.keys, MockShardStatus::COMPLETED);
+		mgs->allServers.at(id).setShardStatus(params.keys, MockShardStatus::COMPLETED, mgs->restrictSize);
 	}
 
 	ASSERT_EQ(srcTeams.size(), 0);

--- a/fdbserver/DDTxnProcessor.actor.cpp
+++ b/fdbserver/DDTxnProcessor.actor.cpp
@@ -683,12 +683,12 @@ Future<std::vector<ProcessData>> DDTxnProcessor::getWorkers() const {
 
 Future<Void> DDTxnProcessor::rawStartMovement(MoveKeysParams& params,
                                               std::map<UID, StorageServerInterface>& tssMapping) {
-	UNREACHABLE();
+	return ::rawStartMovement(cx, params, tssMapping);
 }
 
 Future<Void> DDTxnProcessor::rawFinishMovement(MoveKeysParams& params,
                                                const std::map<UID, StorageServerInterface>& tssMapping) {
-	UNREACHABLE();
+	return ::rawFinishMovement(cx, params, tssMapping);
 }
 
 struct DDMockTxnProcessorImpl {

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -317,7 +317,7 @@ public:
 		                 lock,
 		                 configuration.usableRegions > 1 ? remoteDcIds : std::vector<Optional<Key>>(),
 		                 context->ddEnabledState.get(),
-		                 false));
+		                 SkipDDModeCheck::False));
 	}
 
 	void initDcInfo() {

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -316,7 +316,8 @@ public:
 		                 ddId,
 		                 lock,
 		                 configuration.usableRegions > 1 ? remoteDcIds : std::vector<Optional<Key>>(),
-		                 context->ddEnabledState.get()));
+		                 context->ddEnabledState.get(),
+		                 false));
 	}
 
 	void initDcInfo() {

--- a/fdbserver/MockGlobalState.cpp
+++ b/fdbserver/MockGlobalState.cpp
@@ -31,6 +31,8 @@ bool MockStorageServer::allShardStatusEqual(KeyRangeRef range, MockShardStatus s
 	return true;
 }
 
+void MockStorageServer::setShardStatus(KeyRangeRef range, MockShardStatus status) {}
+
 void MockGlobalState::initializeAsEmptyDatabaseMGS(const DatabaseConfiguration& conf, uint64_t defaultDiskSpace) {
 	ASSERT(conf.storageTeamSize > 0);
 	configuration = conf;

--- a/fdbserver/MockGlobalState.cpp
+++ b/fdbserver/MockGlobalState.cpp
@@ -93,6 +93,12 @@ void MockStorageServer::twoWayShardSplitting(KeyRangeRef range, KeyRef splitPoin
 	serverKeys[left].shardSize = leftSize;
 }
 
+void MockStorageServer::removeShard(KeyRangeRef range) {
+	auto ranges = serverKeys.containedRanges(range);
+	ASSERT(ranges.begin().range() == range);
+	serverKeys.rawErase(range);
+}
+
 void MockGlobalState::initializeAsEmptyDatabaseMGS(const DatabaseConfiguration& conf, uint64_t defaultDiskSpace) {
 	ASSERT(conf.storageTeamSize > 0);
 	configuration = conf;

--- a/fdbserver/MoveKeys.actor.cpp
+++ b/fdbserver/MoveKeys.actor.cpp
@@ -765,7 +765,6 @@ ACTOR static Future<Void> startMoveKeys(Database occ,
                                   const DDEnabledState* ddEnabledState) {
 	state TraceInterval interval("RelocateShard_StartMoveKeys");
 	state Future<Void> warningLogger = logWarningAfter("StartMoveKeysTooLong", 600, servers);
-	// state TraceInterval waitInterval("");
 
 	wait(startMoveKeysLock->take(TaskPriority::DataDistributionLaunch));
 	state FlowLock::Releaser releaser(*startMoveKeysLock);
@@ -906,6 +905,322 @@ ACTOR Future<Void> checkFetchingState(Database cx,
 // keyServers[k].dest must be the same for all k in keys
 // Set serverKeys[dest][keys] = true; serverKeys[src][keys] = false for all src not in dest
 // Should be cancelled and restarted if keyServers[keys].dest changes (?so this is no longer true?)
+ACTOR static Future<Key> finishMoveKeysTransaction(Database occ,
+                                                   KeyRange keys,
+                                                   std::vector<UID>* destinationTeam,
+                                                   MoveKeysLock lock,
+                                                   FlowLock* finishMoveKeysParallelismLock,
+                                                   bool hasRemote,
+                                                   UID relocationIntervalId,
+                                                   std::map<UID, StorageServerInterface>* tssMapping,
+                                                   const DDEnabledState* ddEnabledState,
+                                                   Key begin) {
+	state TraceInterval waitInterval("");
+	state Key endKey;
+	state int retries = 0;
+	state FlowLock::Releaser releaser;
+	state std::unordered_set<UID> tssToIgnore;
+	// try waiting for tss for a 2 loops, give up if they're behind to not affect the rest of the cluster
+	state int waitForTSSCounter = 2;
+
+	state Transaction tr(occ);
+
+	// printf("finishMoveKeys( '%s'-'%s' )\n", begin.toString().c_str(), keys.end.toString().c_str());
+	loop {
+		try {
+
+			tr.trState->taskID = TaskPriority::MoveKeys;
+			tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
+			tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+
+			releaser.release();
+			wait(finishMoveKeysParallelismLock->take(TaskPriority::DataDistributionLaunch));
+			releaser = FlowLock::Releaser(*finishMoveKeysParallelismLock);
+
+			wait(checkMoveKeysLock(&tr, lock, ddEnabledState));
+
+			state KeyRange currentKeys = KeyRangeRef(begin, keys.end);
+			state RangeResult UIDtoTagMap = wait(tr.getRange(serverTagKeys, CLIENT_KNOBS->TOO_MANY));
+			ASSERT(!UIDtoTagMap.more && UIDtoTagMap.size() < CLIENT_KNOBS->TOO_MANY);
+			state RangeResult keyServers = wait(krmGetRanges(&tr,
+			                                                 keyServersPrefix,
+			                                                 currentKeys,
+			                                                 SERVER_KNOBS->MOVE_KEYS_KRM_LIMIT,
+			                                                 SERVER_KNOBS->MOVE_KEYS_KRM_LIMIT_BYTES));
+
+			// Determine the last processed key (which will be the beginning for the next iteration)
+			endKey = keyServers.end()[-1].key;
+			currentKeys = KeyRangeRef(currentKeys.begin, endKey);
+
+			// printf("  finishMoveKeys( '%s'-'%s' ): read keyServers at %lld\n", keys.begin.toString().c_str(),
+			// keys.end.toString().c_str(), tr.getReadVersion().get());
+
+			// Decode and sanity check the result (dest must be the same for all ranges)
+			bool alreadyMoved = true;
+
+			state std::__1::vector<UID> dest;
+			state std::__1::set<UID> allServers;
+			state std::__1::set<UID> intendedTeam(destinationTeam->begin(), destinationTeam->end());
+			state std::__1::vector<UID> src;
+			std::__1::vector<UID> completeSrc;
+
+			// Iterate through the beginning of keyServers until we find one that hasn't already been processed
+			int currentIndex;
+			for (currentIndex = 0; currentIndex < keyServers.size() - 1 && alreadyMoved; currentIndex++) {
+				decodeKeyServersValue(UIDtoTagMap, keyServers[currentIndex].value, src, dest);
+
+				std::__1::set<UID> srcSet;
+				for (int s = 0; s < src.size(); s++) {
+					srcSet.insert(src[s]);
+				}
+
+				if (currentIndex == 0) {
+					completeSrc = src;
+				} else {
+					for (int i = 0; i < completeSrc.size(); i++) {
+						if (!srcSet.count(completeSrc[i])) {
+							swapAndPop(&completeSrc, i--);
+						}
+					}
+				}
+
+				std::__1::set<UID> destSet;
+				for (int s = 0; s < dest.size(); s++) {
+					destSet.insert(dest[s]);
+				}
+
+				allServers.insert(srcSet.begin(), srcSet.end());
+				allServers.insert(destSet.begin(), destSet.end());
+
+				// Because marking a server as failed can shrink a team, do not check for exact equality
+				// Instead, check for a subset of the intended team, which also covers the equality case
+				bool isSubset = std::includes(intendedTeam.begin(), intendedTeam.end(), srcSet.begin(), srcSet.end());
+				alreadyMoved = destSet.empty() && isSubset;
+				if (destSet != intendedTeam && !alreadyMoved) {
+					TraceEvent(SevWarn, "MoveKeysDestTeamNotIntended", relocationIntervalId)
+					    .detail("KeyBegin", keys.begin)
+					    .detail("KeyEnd", keys.end)
+					    .detail("IterationBegin", begin)
+					    .detail("IterationEnd", endKey)
+					    .detail("SrcSet", describe(srcSet))
+					    .detail("DestSet", describe(destSet))
+					    .detail("IntendedTeam", describe(intendedTeam))
+					    .detail("KeyServers", keyServers);
+					// ASSERT( false );
+
+					ASSERT(!dest.empty()); // The range has already been moved, but to a different dest (or
+					                       // maybe dest was cleared)
+
+					intendedTeam.clear();
+					for (int i = 0; i < dest.size(); i++)
+						intendedTeam.insert(dest[i]);
+				} else if (alreadyMoved) {
+					dest.clear();
+					src.clear();
+					CODE_PROBE(true, "FinishMoveKeys first key in iteration sub-range has already been processed");
+				}
+			}
+
+			// Process the rest of the key servers
+			for (; currentIndex < keyServers.size() - 1; currentIndex++) {
+				std::__1::vector<UID> src2, dest2;
+				decodeKeyServersValue(UIDtoTagMap, keyServers[currentIndex].value, src2, dest2);
+
+				std::__1::set<UID> srcSet;
+				for (int s = 0; s < src2.size(); s++)
+					srcSet.insert(src2[s]);
+
+				for (int i = 0; i < completeSrc.size(); i++) {
+					if (!srcSet.count(completeSrc[i])) {
+						swapAndPop(&completeSrc, i--);
+					}
+				}
+
+				allServers.insert(srcSet.begin(), srcSet.end());
+
+				// Because marking a server as failed can shrink a team, do not check for exact equality
+				// Instead, check for a subset of the intended team, which also covers the equality case
+				bool isSubset = std::includes(intendedTeam.begin(), intendedTeam.end(), srcSet.begin(), srcSet.end());
+				alreadyMoved = dest2.empty() && isSubset;
+				if (dest2 != dest && !alreadyMoved) {
+					TraceEvent(SevError, "FinishMoveKeysError", relocationIntervalId)
+					    .detail("Reason", "dest mismatch")
+					    .detail("Dest", describe(dest))
+					    .detail("Dest2", describe(dest2));
+					ASSERT(false);
+				}
+			}
+			if (!dest.size()) {
+				CODE_PROBE(true,
+				           "A previous finishMoveKeys for this range committed just as it was cancelled to "
+				           "start this one?");
+				TraceEvent("FinishMoveKeysNothingToDo", relocationIntervalId)
+				    .detail("KeyBegin", keys.begin)
+				    .detail("KeyEnd", keys.end)
+				    .detail("IterationBegin", begin)
+				    .detail("IterationEnd", endKey);
+				begin = keyServers.end()[-1].key;
+				break;
+			}
+
+			waitInterval = TraceInterval("RelocateShard_FinishMoveKeysWaitDurable");
+			TraceEvent(SevDebug, waitInterval.begin(), relocationIntervalId)
+			    .detail("KeyBegin", keys.begin)
+			    .detail("KeyEnd", keys.end);
+
+			// Wait for a durable quorum of servers in destServers to have keys available (readWrite)
+			// They must also have at least the transaction read version so they can't "forget" the shard
+			// between now and when this transaction commits.
+			state std::__1::vector<Future<Void>> serverReady; // only for count below
+			state std::__1::vector<Future<Void>> tssReady; // for waiting in parallel with tss
+			state std::__1::vector<StorageServerInterface> tssReadyInterfs;
+			state std::__1::vector<UID> newDestinations;
+			std::__1::set<UID> completeSrcSet(completeSrc.begin(), completeSrc.end());
+			for (auto& it : dest) {
+				if (!hasRemote || !completeSrcSet.count(it)) {
+					newDestinations.push_back(it);
+				}
+			}
+
+			// for smartQuorum
+			state std::__1::vector<StorageServerInterface> storageServerInterfaces;
+			std::__1::vector<Future<Optional<Value>>> serverListEntries;
+			serverListEntries.reserve(newDestinations.size());
+			for (int s = 0; s < newDestinations.size(); s++)
+				serverListEntries.push_back(tr.get(serverListKeyFor(newDestinations[s])));
+			state std::__1::vector<Optional<Value>> serverListValues = wait(getAll(serverListEntries));
+
+			releaser.release();
+
+			for (int s = 0; s < serverListValues.size(); s++) {
+				ASSERT(serverListValues[s]
+				           .present()); // There should always be server list entries for servers in keyServers
+				auto si = decodeServerListValue(serverListValues[s].get());
+				ASSERT(si.id() == newDestinations[s]);
+				storageServerInterfaces.push_back(si);
+			}
+
+			// update client info in case tss mapping changed or server got updated
+
+			// Wait for new destination servers to fetch the keys
+
+			serverReady.reserve(storageServerInterfaces.size());
+			tssReady.reserve(storageServerInterfaces.size());
+			tssReadyInterfs.reserve(storageServerInterfaces.size());
+			for (int s = 0; s < storageServerInterfaces.size(); s++) {
+				serverReady.push_back(waitForShardReady(
+				    storageServerInterfaces[s], keys, tr.getReadVersion().get(), GetShardStateRequest::READABLE));
+
+				auto tssPair = tssMapping->find(storageServerInterfaces[s].id());
+
+				if (tssPair != tssMapping->end() && waitForTSSCounter > 0 && !tssToIgnore.count(tssPair->second.id())) {
+					tssReadyInterfs.push_back(tssPair->second);
+					tssReady.push_back(waitForShardReady(
+					    tssPair->second, keys, tr.getReadVersion().get(), GetShardStateRequest::READABLE));
+				}
+			}
+
+			// Wait for all storage server moves, and explicitly swallow errors for tss ones with
+			// waitForAllReady If this takes too long the transaction will time out and retry, which is ok
+			wait(timeout(waitForAll(serverReady) && waitForAllReady(tssReady),
+			             SERVER_KNOBS->SERVER_READY_QUORUM_TIMEOUT,
+			             Void(),
+			             TaskPriority::MoveKeys));
+
+			// Check to see if we're waiting only on tss. If so, decrement the waiting counter.
+			// If the waiting counter is zero, ignore the slow/non-responsive tss processes before finalizing
+			// the data move.
+			if (tssReady.size()) {
+				bool allSSDone = true;
+				for (auto& f : serverReady) {
+					allSSDone &= f.isReady() && !f.isError();
+					if (!allSSDone) {
+						break;
+					}
+				}
+
+				if (allSSDone) {
+					bool anyTssNotDone = false;
+
+					for (auto& f : tssReady) {
+						if (!f.isReady() || f.isError()) {
+							anyTssNotDone = true;
+							waitForTSSCounter--;
+							break;
+						}
+					}
+
+					if (anyTssNotDone && waitForTSSCounter == 0) {
+						for (int i = 0; i < tssReady.size(); i++) {
+							if (!tssReady[i].isReady() || tssReady[i].isError()) {
+								tssToIgnore.insert(tssReadyInterfs[i].id());
+							}
+						}
+					}
+				}
+			}
+
+			int count = dest.size() - newDestinations.size();
+			for (int s = 0; s < serverReady.size(); s++)
+				count += serverReady[s].isReady() && !serverReady[s].isError();
+
+			int tssCount = 0;
+			for (int s = 0; s < tssReady.size(); s++)
+				tssCount += tssReady[s].isReady() && !tssReady[s].isError();
+
+			TraceEvent readyServersEv(SevDebug, waitInterval.end(), relocationIntervalId);
+			readyServersEv.detail("ReadyServers", count);
+			if (tssReady.size()) {
+				readyServersEv.detail("ReadyTSS", tssCount);
+			}
+
+			if (count == dest.size()) {
+				// update keyServers, serverKeys
+				// SOMEDAY: Doing these in parallel is safe because none of them overlap or touch (one per
+				// server)
+				wait(krmSetRangeCoalescing(
+				    &tr, keyServersPrefix, currentKeys, keys, keyServersValue(UIDtoTagMap, dest)));
+
+				std::__1::set<UID>::iterator asi = allServers.begin();
+				std::__1::vector<Future<Void>> actors;
+				while (asi != allServers.end()) {
+					bool destHasServer = std::find(dest.begin(), dest.end(), *asi) != dest.end();
+					actors.push_back(krmSetRangeCoalescing(&tr,
+					                                       serverKeysPrefixFor(*asi),
+					                                       currentKeys,
+					                                       allKeys,
+					                                       destHasServer ? serverKeysTrue : serverKeysFalse));
+					++asi;
+				}
+
+				wait(waitForAll(actors));
+				wait(tr.commit());
+
+				begin = endKey;
+				break;
+			}
+			tr.reset();
+		} catch (Error& error) {
+			if (error.code() == error_code_actor_cancelled)
+				throw;
+			state Error err = error;
+			wait(tr.onError(error));
+			retries++;
+			if (retries % 10 == 0) {
+				TraceEvent(retries == 20 ? SevWarnAlways : SevWarn,
+				           "RelocateShard_FinishMoveKeysRetrying",
+				           relocationIntervalId)
+				    .error(err)
+				    .detail("KeyBegin", keys.begin)
+				    .detail("KeyEnd", keys.end)
+				    .detail("IterationBegin", begin)
+				    .detail("IterationEnd", endKey);
+			}
+		}
+	}
+	return begin;
+}
+
 ACTOR static Future<Void> finishMoveKeys(Database occ,
                                          KeyRange keys,
                                          std::vector<UID> destinationTeam,
@@ -916,16 +1231,9 @@ ACTOR static Future<Void> finishMoveKeys(Database occ,
                                          std::map<UID, StorageServerInterface> tssMapping,
                                          const DDEnabledState* ddEnabledState) {
 	state TraceInterval interval("RelocateShard_FinishMoveKeys");
-	state TraceInterval waitInterval("");
 	state Future<Void> warningLogger = logWarningAfter("FinishMoveKeysTooLong", 600, destinationTeam);
 	state Key begin = keys.begin;
-	state Key endKey;
-	state int retries = 0;
-	state FlowLock::Releaser releaser;
 
-	state std::unordered_set<UID> tssToIgnore;
-	// try waiting for tss for a 2 loops, give up if they're behind to not affect the rest of the cluster
-	state int waitForTSSCounter = 2;
 
 	ASSERT(!destinationTeam.empty());
 
@@ -938,308 +1246,17 @@ ACTOR static Future<Void> finishMoveKeys(Database occ,
 		// In that case, each iteration of this loop will have begin set to the end of the last processed shard
 		while (begin < keys.end) {
 			CODE_PROBE(begin > keys.begin, "Multi-transactional finishMoveKeys");
-
-			state Transaction tr(occ);
-
-			// printf("finishMoveKeys( '%s'-'%s' )\n", begin.toString().c_str(), keys.end.toString().c_str());
-			loop {
-				try {
-
-					tr.trState->taskID = TaskPriority::MoveKeys;
-					tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
-					tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
-
-					releaser.release();
-					wait(finishMoveKeysParallelismLock->take(TaskPriority::DataDistributionLaunch));
-					releaser = FlowLock::Releaser(*finishMoveKeysParallelismLock);
-
-					wait(checkMoveKeysLock(&tr, lock, ddEnabledState));
-
-					state KeyRange currentKeys = KeyRangeRef(begin, keys.end);
-					state RangeResult UIDtoTagMap = wait(tr.getRange(serverTagKeys, CLIENT_KNOBS->TOO_MANY));
-					ASSERT(!UIDtoTagMap.more && UIDtoTagMap.size() < CLIENT_KNOBS->TOO_MANY);
-					state RangeResult keyServers = wait(krmGetRanges(&tr,
-					                                                 keyServersPrefix,
-					                                                 currentKeys,
-					                                                 SERVER_KNOBS->MOVE_KEYS_KRM_LIMIT,
-					                                                 SERVER_KNOBS->MOVE_KEYS_KRM_LIMIT_BYTES));
-
-					// Determine the last processed key (which will be the beginning for the next iteration)
-					endKey = keyServers.end()[-1].key;
-					currentKeys = KeyRangeRef(currentKeys.begin, endKey);
-
-					// printf("  finishMoveKeys( '%s'-'%s' ): read keyServers at %lld\n", keys.begin.toString().c_str(),
-					// keys.end.toString().c_str(), tr.getReadVersion().get());
-
-					// Decode and sanity check the result (dest must be the same for all ranges)
-					bool alreadyMoved = true;
-
-					state std::vector<UID> dest;
-					state std::set<UID> allServers;
-					state std::set<UID> intendedTeam(destinationTeam.begin(), destinationTeam.end());
-					state std::vector<UID> src;
-					std::vector<UID> completeSrc;
-
-					// Iterate through the beginning of keyServers until we find one that hasn't already been processed
-					int currentIndex;
-					for (currentIndex = 0; currentIndex < keyServers.size() - 1 && alreadyMoved; currentIndex++) {
-						decodeKeyServersValue(UIDtoTagMap, keyServers[currentIndex].value, src, dest);
-
-						std::set<UID> srcSet;
-						for (int s = 0; s < src.size(); s++) {
-							srcSet.insert(src[s]);
-						}
-
-						if (currentIndex == 0) {
-							completeSrc = src;
-						} else {
-							for (int i = 0; i < completeSrc.size(); i++) {
-								if (!srcSet.count(completeSrc[i])) {
-									swapAndPop(&completeSrc, i--);
-								}
-							}
-						}
-
-						std::set<UID> destSet;
-						for (int s = 0; s < dest.size(); s++) {
-							destSet.insert(dest[s]);
-						}
-
-						allServers.insert(srcSet.begin(), srcSet.end());
-						allServers.insert(destSet.begin(), destSet.end());
-
-						// Because marking a server as failed can shrink a team, do not check for exact equality
-						// Instead, check for a subset of the intended team, which also covers the equality case
-						bool isSubset =
-						    std::includes(intendedTeam.begin(), intendedTeam.end(), srcSet.begin(), srcSet.end());
-						alreadyMoved = destSet.empty() && isSubset;
-						if (destSet != intendedTeam && !alreadyMoved) {
-							TraceEvent(SevWarn, "MoveKeysDestTeamNotIntended", relocationIntervalId)
-							    .detail("KeyBegin", keys.begin)
-							    .detail("KeyEnd", keys.end)
-							    .detail("IterationBegin", begin)
-							    .detail("IterationEnd", endKey)
-							    .detail("SrcSet", describe(srcSet))
-							    .detail("DestSet", describe(destSet))
-							    .detail("IntendedTeam", describe(intendedTeam))
-							    .detail("KeyServers", keyServers);
-							// ASSERT( false );
-
-							ASSERT(!dest.empty()); // The range has already been moved, but to a different dest (or
-							                       // maybe dest was cleared)
-
-							intendedTeam.clear();
-							for (int i = 0; i < dest.size(); i++)
-								intendedTeam.insert(dest[i]);
-						} else if (alreadyMoved) {
-							dest.clear();
-							src.clear();
-							CODE_PROBE(true,
-							           "FinishMoveKeys first key in iteration sub-range has already been processed");
-						}
-					}
-
-					// Process the rest of the key servers
-					for (; currentIndex < keyServers.size() - 1; currentIndex++) {
-						std::vector<UID> src2, dest2;
-						decodeKeyServersValue(UIDtoTagMap, keyServers[currentIndex].value, src2, dest2);
-
-						std::set<UID> srcSet;
-						for (int s = 0; s < src2.size(); s++)
-							srcSet.insert(src2[s]);
-
-						for (int i = 0; i < completeSrc.size(); i++) {
-							if (!srcSet.count(completeSrc[i])) {
-								swapAndPop(&completeSrc, i--);
-							}
-						}
-
-						allServers.insert(srcSet.begin(), srcSet.end());
-
-						// Because marking a server as failed can shrink a team, do not check for exact equality
-						// Instead, check for a subset of the intended team, which also covers the equality case
-						bool isSubset =
-						    std::includes(intendedTeam.begin(), intendedTeam.end(), srcSet.begin(), srcSet.end());
-						alreadyMoved = dest2.empty() && isSubset;
-						if (dest2 != dest && !alreadyMoved) {
-							TraceEvent(SevError, "FinishMoveKeysError", relocationIntervalId)
-							    .detail("Reason", "dest mismatch")
-							    .detail("Dest", describe(dest))
-							    .detail("Dest2", describe(dest2));
-							ASSERT(false);
-						}
-					}
-					if (!dest.size()) {
-						CODE_PROBE(true,
-						           "A previous finishMoveKeys for this range committed just as it was cancelled to "
-						           "start this one?");
-						TraceEvent("FinishMoveKeysNothingToDo", relocationIntervalId)
-						    .detail("KeyBegin", keys.begin)
-						    .detail("KeyEnd", keys.end)
-						    .detail("IterationBegin", begin)
-						    .detail("IterationEnd", endKey);
-						begin = keyServers.end()[-1].key;
-						break;
-					}
-
-					waitInterval = TraceInterval("RelocateShard_FinishMoveKeysWaitDurable");
-					TraceEvent(SevDebug, waitInterval.begin(), relocationIntervalId)
-					    .detail("KeyBegin", keys.begin)
-					    .detail("KeyEnd", keys.end);
-
-					// Wait for a durable quorum of servers in destServers to have keys available (readWrite)
-					// They must also have at least the transaction read version so they can't "forget" the shard
-					// between now and when this transaction commits.
-					state std::vector<Future<Void>> serverReady; // only for count below
-					state std::vector<Future<Void>> tssReady; // for waiting in parallel with tss
-					state std::vector<StorageServerInterface> tssReadyInterfs;
-					state std::vector<UID> newDestinations;
-					std::set<UID> completeSrcSet(completeSrc.begin(), completeSrc.end());
-					for (auto& it : dest) {
-						if (!hasRemote || !completeSrcSet.count(it)) {
-							newDestinations.push_back(it);
-						}
-					}
-
-					// for smartQuorum
-					state std::vector<StorageServerInterface> storageServerInterfaces;
-					std::vector<Future<Optional<Value>>> serverListEntries;
-					serverListEntries.reserve(newDestinations.size());
-					for (int s = 0; s < newDestinations.size(); s++)
-						serverListEntries.push_back(tr.get(serverListKeyFor(newDestinations[s])));
-					state std::vector<Optional<Value>> serverListValues = wait(getAll(serverListEntries));
-
-					releaser.release();
-
-					for (int s = 0; s < serverListValues.size(); s++) {
-						ASSERT(serverListValues[s]
-						           .present()); // There should always be server list entries for servers in keyServers
-						auto si = decodeServerListValue(serverListValues[s].get());
-						ASSERT(si.id() == newDestinations[s]);
-						storageServerInterfaces.push_back(si);
-					}
-
-					// update client info in case tss mapping changed or server got updated
-
-					// Wait for new destination servers to fetch the keys
-
-					serverReady.reserve(storageServerInterfaces.size());
-					tssReady.reserve(storageServerInterfaces.size());
-					tssReadyInterfs.reserve(storageServerInterfaces.size());
-					for (int s = 0; s < storageServerInterfaces.size(); s++) {
-						serverReady.push_back(waitForShardReady(storageServerInterfaces[s],
-						                                        keys,
-						                                        tr.getReadVersion().get(),
-						                                        GetShardStateRequest::READABLE));
-
-						auto tssPair = tssMapping.find(storageServerInterfaces[s].id());
-
-						if (tssPair != tssMapping.end() && waitForTSSCounter > 0 &&
-						    !tssToIgnore.count(tssPair->second.id())) {
-							tssReadyInterfs.push_back(tssPair->second);
-							tssReady.push_back(waitForShardReady(
-							    tssPair->second, keys, tr.getReadVersion().get(), GetShardStateRequest::READABLE));
-						}
-					}
-
-					// Wait for all storage server moves, and explicitly swallow errors for tss ones with
-					// waitForAllReady If this takes too long the transaction will time out and retry, which is ok
-					wait(timeout(waitForAll(serverReady) && waitForAllReady(tssReady),
-					             SERVER_KNOBS->SERVER_READY_QUORUM_TIMEOUT,
-					             Void(),
-					             TaskPriority::MoveKeys));
-
-					// Check to see if we're waiting only on tss. If so, decrement the waiting counter.
-					// If the waiting counter is zero, ignore the slow/non-responsive tss processes before finalizing
-					// the data move.
-					if (tssReady.size()) {
-						bool allSSDone = true;
-						for (auto& f : serverReady) {
-							allSSDone &= f.isReady() && !f.isError();
-							if (!allSSDone) {
-								break;
-							}
-						}
-
-						if (allSSDone) {
-							bool anyTssNotDone = false;
-
-							for (auto& f : tssReady) {
-								if (!f.isReady() || f.isError()) {
-									anyTssNotDone = true;
-									waitForTSSCounter--;
-									break;
-								}
-							}
-
-							if (anyTssNotDone && waitForTSSCounter == 0) {
-								for (int i = 0; i < tssReady.size(); i++) {
-									if (!tssReady[i].isReady() || tssReady[i].isError()) {
-										tssToIgnore.insert(tssReadyInterfs[i].id());
-									}
-								}
-							}
-						}
-					}
-
-					int count = dest.size() - newDestinations.size();
-					for (int s = 0; s < serverReady.size(); s++)
-						count += serverReady[s].isReady() && !serverReady[s].isError();
-
-					int tssCount = 0;
-					for (int s = 0; s < tssReady.size(); s++)
-						tssCount += tssReady[s].isReady() && !tssReady[s].isError();
-
-					TraceEvent readyServersEv(SevDebug, waitInterval.end(), relocationIntervalId);
-					readyServersEv.detail("ReadyServers", count);
-					if (tssReady.size()) {
-						readyServersEv.detail("ReadyTSS", tssCount);
-					}
-
-					if (count == dest.size()) {
-						// update keyServers, serverKeys
-						// SOMEDAY: Doing these in parallel is safe because none of them overlap or touch (one per
-						// server)
-						wait(krmSetRangeCoalescing(
-						    &tr, keyServersPrefix, currentKeys, keys, keyServersValue(UIDtoTagMap, dest)));
-
-						std::set<UID>::iterator asi = allServers.begin();
-						std::vector<Future<Void>> actors;
-						while (asi != allServers.end()) {
-							bool destHasServer = std::find(dest.begin(), dest.end(), *asi) != dest.end();
-							actors.push_back(krmSetRangeCoalescing(&tr,
-							                                       serverKeysPrefixFor(*asi),
-							                                       currentKeys,
-							                                       allKeys,
-							                                       destHasServer ? serverKeysTrue : serverKeysFalse));
-							++asi;
-						}
-
-						wait(waitForAll(actors));
-						wait(tr.commit());
-
-						begin = endKey;
-						break;
-					}
-					tr.reset();
-				} catch (Error& error) {
-					if (error.code() == error_code_actor_cancelled)
-						throw;
-					state Error err = error;
-					wait(tr.onError(error));
-					retries++;
-					if (retries % 10 == 0) {
-						TraceEvent(retries == 20 ? SevWarnAlways : SevWarn,
-						           "RelocateShard_FinishMoveKeysRetrying",
-						           relocationIntervalId)
-						    .error(err)
-						    .detail("KeyBegin", keys.begin)
-						    .detail("KeyEnd", keys.end)
-						    .detail("IterationBegin", begin)
-						    .detail("IterationEnd", endKey);
-					}
-				}
-			}
+			wait(store(begin,
+			           finishMoveKeysTransaction(occ,
+			                                     keys,
+			                                     &destinationTeam,
+			                                     lock,
+			                                     finishMoveKeysParallelismLock,
+			                                     hasRemote,
+			                                     relocationIntervalId,
+			                                     &tssMapping,
+			                                     ddEnabledState,
+			                                     begin)));
 		}
 
 		TraceEvent(SevDebug, interval.end(), relocationIntervalId);

--- a/fdbserver/MoveKeys.actor.cpp
+++ b/fdbserver/MoveKeys.actor.cpp
@@ -765,6 +765,7 @@ ACTOR static Future<Void> startMoveKeys(Database occ,
                                         const DDEnabledState* ddEnabledState) {
 	state TraceInterval interval("RelocateShard_StartMoveKeys");
 	state Future<Void> warningLogger = logWarningAfter("StartMoveKeysTooLong", 600, servers);
+	// state TraceInterval waitInterval("");
 
 	wait(startMoveKeysLock->take(TaskPriority::DataDistributionLaunch));
 	state FlowLock::Releaser releaser(*startMoveKeysLock);
@@ -905,322 +906,6 @@ ACTOR Future<Void> checkFetchingState(Database cx,
 // keyServers[k].dest must be the same for all k in keys
 // Set serverKeys[dest][keys] = true; serverKeys[src][keys] = false for all src not in dest
 // Should be cancelled and restarted if keyServers[keys].dest changes (?so this is no longer true?)
-ACTOR static Future<Key> finishMoveKeysTransaction(Database occ,
-                                                   KeyRange keys,
-                                                   std::vector<UID>* destinationTeam,
-                                                   MoveKeysLock lock,
-                                                   FlowLock* finishMoveKeysParallelismLock,
-                                                   bool hasRemote,
-                                                   UID relocationIntervalId,
-                                                   std::map<UID, StorageServerInterface>* tssMapping,
-                                                   const DDEnabledState* ddEnabledState,
-                                                   Key begin) {
-	state TraceInterval waitInterval("");
-	state Key endKey;
-	state int retries = 0;
-	state FlowLock::Releaser releaser;
-	state std::unordered_set<UID> tssToIgnore;
-	// try waiting for tss for a 2 loops, give up if they're behind to not affect the rest of the cluster
-	state int waitForTSSCounter = 2;
-
-	state Transaction tr(occ);
-
-	// printf("finishMoveKeys( '%s'-'%s' )\n", begin.toString().c_str(), keys.end.toString().c_str());
-	loop {
-		try {
-
-			tr.trState->taskID = TaskPriority::MoveKeys;
-			tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
-			tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
-
-			releaser.release();
-			wait(finishMoveKeysParallelismLock->take(TaskPriority::DataDistributionLaunch));
-			releaser = FlowLock::Releaser(*finishMoveKeysParallelismLock);
-
-			wait(checkMoveKeysLock(&tr, lock, ddEnabledState));
-
-			state KeyRange currentKeys = KeyRangeRef(begin, keys.end);
-			state RangeResult UIDtoTagMap = wait(tr.getRange(serverTagKeys, CLIENT_KNOBS->TOO_MANY));
-			ASSERT(!UIDtoTagMap.more && UIDtoTagMap.size() < CLIENT_KNOBS->TOO_MANY);
-			state RangeResult keyServers = wait(krmGetRanges(&tr,
-			                                                 keyServersPrefix,
-			                                                 currentKeys,
-			                                                 SERVER_KNOBS->MOVE_KEYS_KRM_LIMIT,
-			                                                 SERVER_KNOBS->MOVE_KEYS_KRM_LIMIT_BYTES));
-
-			// Determine the last processed key (which will be the beginning for the next iteration)
-			endKey = keyServers.end()[-1].key;
-			currentKeys = KeyRangeRef(currentKeys.begin, endKey);
-
-			// printf("  finishMoveKeys( '%s'-'%s' ): read keyServers at %lld\n", keys.begin.toString().c_str(),
-			// keys.end.toString().c_str(), tr.getReadVersion().get());
-
-			// Decode and sanity check the result (dest must be the same for all ranges)
-			bool alreadyMoved = true;
-
-			state std::__1::vector<UID> dest;
-			state std::__1::set<UID> allServers;
-			state std::__1::set<UID> intendedTeam(destinationTeam->begin(), destinationTeam->end());
-			state std::__1::vector<UID> src;
-			std::__1::vector<UID> completeSrc;
-
-			// Iterate through the beginning of keyServers until we find one that hasn't already been processed
-			int currentIndex;
-			for (currentIndex = 0; currentIndex < keyServers.size() - 1 && alreadyMoved; currentIndex++) {
-				decodeKeyServersValue(UIDtoTagMap, keyServers[currentIndex].value, src, dest);
-
-				std::__1::set<UID> srcSet;
-				for (int s = 0; s < src.size(); s++) {
-					srcSet.insert(src[s]);
-				}
-
-				if (currentIndex == 0) {
-					completeSrc = src;
-				} else {
-					for (int i = 0; i < completeSrc.size(); i++) {
-						if (!srcSet.count(completeSrc[i])) {
-							swapAndPop(&completeSrc, i--);
-						}
-					}
-				}
-
-				std::__1::set<UID> destSet;
-				for (int s = 0; s < dest.size(); s++) {
-					destSet.insert(dest[s]);
-				}
-
-				allServers.insert(srcSet.begin(), srcSet.end());
-				allServers.insert(destSet.begin(), destSet.end());
-
-				// Because marking a server as failed can shrink a team, do not check for exact equality
-				// Instead, check for a subset of the intended team, which also covers the equality case
-				bool isSubset = std::includes(intendedTeam.begin(), intendedTeam.end(), srcSet.begin(), srcSet.end());
-				alreadyMoved = destSet.empty() && isSubset;
-				if (destSet != intendedTeam && !alreadyMoved) {
-					TraceEvent(SevWarn, "MoveKeysDestTeamNotIntended", relocationIntervalId)
-					    .detail("KeyBegin", keys.begin)
-					    .detail("KeyEnd", keys.end)
-					    .detail("IterationBegin", begin)
-					    .detail("IterationEnd", endKey)
-					    .detail("SrcSet", describe(srcSet))
-					    .detail("DestSet", describe(destSet))
-					    .detail("IntendedTeam", describe(intendedTeam))
-					    .detail("KeyServers", keyServers);
-					// ASSERT( false );
-
-					ASSERT(!dest.empty()); // The range has already been moved, but to a different dest (or
-					                       // maybe dest was cleared)
-
-					intendedTeam.clear();
-					for (int i = 0; i < dest.size(); i++)
-						intendedTeam.insert(dest[i]);
-				} else if (alreadyMoved) {
-					dest.clear();
-					src.clear();
-					CODE_PROBE(true, "FinishMoveKeys first key in iteration sub-range has already been processed");
-				}
-			}
-
-			// Process the rest of the key servers
-			for (; currentIndex < keyServers.size() - 1; currentIndex++) {
-				std::__1::vector<UID> src2, dest2;
-				decodeKeyServersValue(UIDtoTagMap, keyServers[currentIndex].value, src2, dest2);
-
-				std::__1::set<UID> srcSet;
-				for (int s = 0; s < src2.size(); s++)
-					srcSet.insert(src2[s]);
-
-				for (int i = 0; i < completeSrc.size(); i++) {
-					if (!srcSet.count(completeSrc[i])) {
-						swapAndPop(&completeSrc, i--);
-					}
-				}
-
-				allServers.insert(srcSet.begin(), srcSet.end());
-
-				// Because marking a server as failed can shrink a team, do not check for exact equality
-				// Instead, check for a subset of the intended team, which also covers the equality case
-				bool isSubset = std::includes(intendedTeam.begin(), intendedTeam.end(), srcSet.begin(), srcSet.end());
-				alreadyMoved = dest2.empty() && isSubset;
-				if (dest2 != dest && !alreadyMoved) {
-					TraceEvent(SevError, "FinishMoveKeysError", relocationIntervalId)
-					    .detail("Reason", "dest mismatch")
-					    .detail("Dest", describe(dest))
-					    .detail("Dest2", describe(dest2));
-					ASSERT(false);
-				}
-			}
-			if (!dest.size()) {
-				CODE_PROBE(true,
-				           "A previous finishMoveKeys for this range committed just as it was cancelled to "
-				           "start this one?");
-				TraceEvent("FinishMoveKeysNothingToDo", relocationIntervalId)
-				    .detail("KeyBegin", keys.begin)
-				    .detail("KeyEnd", keys.end)
-				    .detail("IterationBegin", begin)
-				    .detail("IterationEnd", endKey);
-				begin = keyServers.end()[-1].key;
-				break;
-			}
-
-			waitInterval = TraceInterval("RelocateShard_FinishMoveKeysWaitDurable");
-			TraceEvent(SevDebug, waitInterval.begin(), relocationIntervalId)
-			    .detail("KeyBegin", keys.begin)
-			    .detail("KeyEnd", keys.end);
-
-			// Wait for a durable quorum of servers in destServers to have keys available (readWrite)
-			// They must also have at least the transaction read version so they can't "forget" the shard
-			// between now and when this transaction commits.
-			state std::__1::vector<Future<Void>> serverReady; // only for count below
-			state std::__1::vector<Future<Void>> tssReady; // for waiting in parallel with tss
-			state std::__1::vector<StorageServerInterface> tssReadyInterfs;
-			state std::__1::vector<UID> newDestinations;
-			std::__1::set<UID> completeSrcSet(completeSrc.begin(), completeSrc.end());
-			for (auto& it : dest) {
-				if (!hasRemote || !completeSrcSet.count(it)) {
-					newDestinations.push_back(it);
-				}
-			}
-
-			// for smartQuorum
-			state std::__1::vector<StorageServerInterface> storageServerInterfaces;
-			std::__1::vector<Future<Optional<Value>>> serverListEntries;
-			serverListEntries.reserve(newDestinations.size());
-			for (int s = 0; s < newDestinations.size(); s++)
-				serverListEntries.push_back(tr.get(serverListKeyFor(newDestinations[s])));
-			state std::__1::vector<Optional<Value>> serverListValues = wait(getAll(serverListEntries));
-
-			releaser.release();
-
-			for (int s = 0; s < serverListValues.size(); s++) {
-				ASSERT(serverListValues[s]
-				           .present()); // There should always be server list entries for servers in keyServers
-				auto si = decodeServerListValue(serverListValues[s].get());
-				ASSERT(si.id() == newDestinations[s]);
-				storageServerInterfaces.push_back(si);
-			}
-
-			// update client info in case tss mapping changed or server got updated
-
-			// Wait for new destination servers to fetch the keys
-
-			serverReady.reserve(storageServerInterfaces.size());
-			tssReady.reserve(storageServerInterfaces.size());
-			tssReadyInterfs.reserve(storageServerInterfaces.size());
-			for (int s = 0; s < storageServerInterfaces.size(); s++) {
-				serverReady.push_back(waitForShardReady(
-				    storageServerInterfaces[s], keys, tr.getReadVersion().get(), GetShardStateRequest::READABLE));
-
-				auto tssPair = tssMapping->find(storageServerInterfaces[s].id());
-
-				if (tssPair != tssMapping->end() && waitForTSSCounter > 0 && !tssToIgnore.count(tssPair->second.id())) {
-					tssReadyInterfs.push_back(tssPair->second);
-					tssReady.push_back(waitForShardReady(
-					    tssPair->second, keys, tr.getReadVersion().get(), GetShardStateRequest::READABLE));
-				}
-			}
-
-			// Wait for all storage server moves, and explicitly swallow errors for tss ones with
-			// waitForAllReady If this takes too long the transaction will time out and retry, which is ok
-			wait(timeout(waitForAll(serverReady) && waitForAllReady(tssReady),
-			             SERVER_KNOBS->SERVER_READY_QUORUM_TIMEOUT,
-			             Void(),
-			             TaskPriority::MoveKeys));
-
-			// Check to see if we're waiting only on tss. If so, decrement the waiting counter.
-			// If the waiting counter is zero, ignore the slow/non-responsive tss processes before finalizing
-			// the data move.
-			if (tssReady.size()) {
-				bool allSSDone = true;
-				for (auto& f : serverReady) {
-					allSSDone &= f.isReady() && !f.isError();
-					if (!allSSDone) {
-						break;
-					}
-				}
-
-				if (allSSDone) {
-					bool anyTssNotDone = false;
-
-					for (auto& f : tssReady) {
-						if (!f.isReady() || f.isError()) {
-							anyTssNotDone = true;
-							waitForTSSCounter--;
-							break;
-						}
-					}
-
-					if (anyTssNotDone && waitForTSSCounter == 0) {
-						for (int i = 0; i < tssReady.size(); i++) {
-							if (!tssReady[i].isReady() || tssReady[i].isError()) {
-								tssToIgnore.insert(tssReadyInterfs[i].id());
-							}
-						}
-					}
-				}
-			}
-
-			int count = dest.size() - newDestinations.size();
-			for (int s = 0; s < serverReady.size(); s++)
-				count += serverReady[s].isReady() && !serverReady[s].isError();
-
-			int tssCount = 0;
-			for (int s = 0; s < tssReady.size(); s++)
-				tssCount += tssReady[s].isReady() && !tssReady[s].isError();
-
-			TraceEvent readyServersEv(SevDebug, waitInterval.end(), relocationIntervalId);
-			readyServersEv.detail("ReadyServers", count);
-			if (tssReady.size()) {
-				readyServersEv.detail("ReadyTSS", tssCount);
-			}
-
-			if (count == dest.size()) {
-				// update keyServers, serverKeys
-				// SOMEDAY: Doing these in parallel is safe because none of them overlap or touch (one per
-				// server)
-				wait(krmSetRangeCoalescing(
-				    &tr, keyServersPrefix, currentKeys, keys, keyServersValue(UIDtoTagMap, dest)));
-
-				std::__1::set<UID>::iterator asi = allServers.begin();
-				std::__1::vector<Future<Void>> actors;
-				while (asi != allServers.end()) {
-					bool destHasServer = std::find(dest.begin(), dest.end(), *asi) != dest.end();
-					actors.push_back(krmSetRangeCoalescing(&tr,
-					                                       serverKeysPrefixFor(*asi),
-					                                       currentKeys,
-					                                       allKeys,
-					                                       destHasServer ? serverKeysTrue : serverKeysFalse));
-					++asi;
-				}
-
-				wait(waitForAll(actors));
-				wait(tr.commit());
-
-				begin = endKey;
-				break;
-			}
-			tr.reset();
-		} catch (Error& error) {
-			if (error.code() == error_code_actor_cancelled)
-				throw;
-			state Error err = error;
-			wait(tr.onError(error));
-			retries++;
-			if (retries % 10 == 0) {
-				TraceEvent(retries == 20 ? SevWarnAlways : SevWarn,
-				           "RelocateShard_FinishMoveKeysRetrying",
-				           relocationIntervalId)
-				    .error(err)
-				    .detail("KeyBegin", keys.begin)
-				    .detail("KeyEnd", keys.end)
-				    .detail("IterationBegin", begin)
-				    .detail("IterationEnd", endKey);
-			}
-		}
-	}
-	return begin;
-}
-
 ACTOR static Future<Void> finishMoveKeys(Database occ,
                                          KeyRange keys,
                                          std::vector<UID> destinationTeam,
@@ -1231,8 +916,16 @@ ACTOR static Future<Void> finishMoveKeys(Database occ,
                                          std::map<UID, StorageServerInterface> tssMapping,
                                          const DDEnabledState* ddEnabledState) {
 	state TraceInterval interval("RelocateShard_FinishMoveKeys");
+	state TraceInterval waitInterval("");
 	state Future<Void> warningLogger = logWarningAfter("FinishMoveKeysTooLong", 600, destinationTeam);
 	state Key begin = keys.begin;
+	state Key endKey;
+	state int retries = 0;
+	state FlowLock::Releaser releaser;
+
+	state std::unordered_set<UID> tssToIgnore;
+	// try waiting for tss for a 2 loops, give up if they're behind to not affect the rest of the cluster
+	state int waitForTSSCounter = 2;
 
 	ASSERT(!destinationTeam.empty());
 
@@ -1245,17 +938,308 @@ ACTOR static Future<Void> finishMoveKeys(Database occ,
 		// In that case, each iteration of this loop will have begin set to the end of the last processed shard
 		while (begin < keys.end) {
 			CODE_PROBE(begin > keys.begin, "Multi-transactional finishMoveKeys");
-			wait(store(begin,
-			           finishMoveKeysTransaction(occ,
-			                                     keys,
-			                                     &destinationTeam,
-			                                     lock,
-			                                     finishMoveKeysParallelismLock,
-			                                     hasRemote,
-			                                     relocationIntervalId,
-			                                     &tssMapping,
-			                                     ddEnabledState,
-			                                     begin)));
+
+			state Transaction tr(occ);
+
+			// printf("finishMoveKeys( '%s'-'%s' )\n", begin.toString().c_str(), keys.end.toString().c_str());
+			loop {
+				try {
+
+					tr.trState->taskID = TaskPriority::MoveKeys;
+					tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
+					tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+
+					releaser.release();
+					wait(finishMoveKeysParallelismLock->take(TaskPriority::DataDistributionLaunch));
+					releaser = FlowLock::Releaser(*finishMoveKeysParallelismLock);
+
+					wait(checkMoveKeysLock(&tr, lock, ddEnabledState));
+
+					state KeyRange currentKeys = KeyRangeRef(begin, keys.end);
+					state RangeResult UIDtoTagMap = wait(tr.getRange(serverTagKeys, CLIENT_KNOBS->TOO_MANY));
+					ASSERT(!UIDtoTagMap.more && UIDtoTagMap.size() < CLIENT_KNOBS->TOO_MANY);
+					state RangeResult keyServers = wait(krmGetRanges(&tr,
+					                                                 keyServersPrefix,
+					                                                 currentKeys,
+					                                                 SERVER_KNOBS->MOVE_KEYS_KRM_LIMIT,
+					                                                 SERVER_KNOBS->MOVE_KEYS_KRM_LIMIT_BYTES));
+
+					// Determine the last processed key (which will be the beginning for the next iteration)
+					endKey = keyServers.end()[-1].key;
+					currentKeys = KeyRangeRef(currentKeys.begin, endKey);
+
+					// printf("  finishMoveKeys( '%s'-'%s' ): read keyServers at %lld\n", keys.begin.toString().c_str(),
+					// keys.end.toString().c_str(), tr.getReadVersion().get());
+
+					// Decode and sanity check the result (dest must be the same for all ranges)
+					bool alreadyMoved = true;
+
+					state std::vector<UID> dest;
+					state std::set<UID> allServers;
+					state std::set<UID> intendedTeam(destinationTeam.begin(), destinationTeam.end());
+					state std::vector<UID> src;
+					std::vector<UID> completeSrc;
+
+					// Iterate through the beginning of keyServers until we find one that hasn't already been processed
+					int currentIndex;
+					for (currentIndex = 0; currentIndex < keyServers.size() - 1 && alreadyMoved; currentIndex++) {
+						decodeKeyServersValue(UIDtoTagMap, keyServers[currentIndex].value, src, dest);
+
+						std::set<UID> srcSet;
+						for (int s = 0; s < src.size(); s++) {
+							srcSet.insert(src[s]);
+						}
+
+						if (currentIndex == 0) {
+							completeSrc = src;
+						} else {
+							for (int i = 0; i < completeSrc.size(); i++) {
+								if (!srcSet.count(completeSrc[i])) {
+									swapAndPop(&completeSrc, i--);
+								}
+							}
+						}
+
+						std::set<UID> destSet;
+						for (int s = 0; s < dest.size(); s++) {
+							destSet.insert(dest[s]);
+						}
+
+						allServers.insert(srcSet.begin(), srcSet.end());
+						allServers.insert(destSet.begin(), destSet.end());
+
+						// Because marking a server as failed can shrink a team, do not check for exact equality
+						// Instead, check for a subset of the intended team, which also covers the equality case
+						bool isSubset =
+						    std::includes(intendedTeam.begin(), intendedTeam.end(), srcSet.begin(), srcSet.end());
+						alreadyMoved = destSet.empty() && isSubset;
+						if (destSet != intendedTeam && !alreadyMoved) {
+							TraceEvent(SevWarn, "MoveKeysDestTeamNotIntended", relocationIntervalId)
+							    .detail("KeyBegin", keys.begin)
+							    .detail("KeyEnd", keys.end)
+							    .detail("IterationBegin", begin)
+							    .detail("IterationEnd", endKey)
+							    .detail("SrcSet", describe(srcSet))
+							    .detail("DestSet", describe(destSet))
+							    .detail("IntendedTeam", describe(intendedTeam))
+							    .detail("KeyServers", keyServers);
+							// ASSERT( false );
+
+							ASSERT(!dest.empty()); // The range has already been moved, but to a different dest (or
+							                       // maybe dest was cleared)
+
+							intendedTeam.clear();
+							for (int i = 0; i < dest.size(); i++)
+								intendedTeam.insert(dest[i]);
+						} else if (alreadyMoved) {
+							dest.clear();
+							src.clear();
+							CODE_PROBE(true,
+							           "FinishMoveKeys first key in iteration sub-range has already been processed");
+						}
+					}
+
+					// Process the rest of the key servers
+					for (; currentIndex < keyServers.size() - 1; currentIndex++) {
+						std::vector<UID> src2, dest2;
+						decodeKeyServersValue(UIDtoTagMap, keyServers[currentIndex].value, src2, dest2);
+
+						std::set<UID> srcSet;
+						for (int s = 0; s < src2.size(); s++)
+							srcSet.insert(src2[s]);
+
+						for (int i = 0; i < completeSrc.size(); i++) {
+							if (!srcSet.count(completeSrc[i])) {
+								swapAndPop(&completeSrc, i--);
+							}
+						}
+
+						allServers.insert(srcSet.begin(), srcSet.end());
+
+						// Because marking a server as failed can shrink a team, do not check for exact equality
+						// Instead, check for a subset of the intended team, which also covers the equality case
+						bool isSubset =
+						    std::includes(intendedTeam.begin(), intendedTeam.end(), srcSet.begin(), srcSet.end());
+						alreadyMoved = dest2.empty() && isSubset;
+						if (dest2 != dest && !alreadyMoved) {
+							TraceEvent(SevError, "FinishMoveKeysError", relocationIntervalId)
+							    .detail("Reason", "dest mismatch")
+							    .detail("Dest", describe(dest))
+							    .detail("Dest2", describe(dest2));
+							ASSERT(false);
+						}
+					}
+					if (!dest.size()) {
+						CODE_PROBE(true,
+						           "A previous finishMoveKeys for this range committed just as it was cancelled to "
+						           "start this one?");
+						TraceEvent("FinishMoveKeysNothingToDo", relocationIntervalId)
+						    .detail("KeyBegin", keys.begin)
+						    .detail("KeyEnd", keys.end)
+						    .detail("IterationBegin", begin)
+						    .detail("IterationEnd", endKey);
+						begin = keyServers.end()[-1].key;
+						break;
+					}
+
+					waitInterval = TraceInterval("RelocateShard_FinishMoveKeysWaitDurable");
+					TraceEvent(SevDebug, waitInterval.begin(), relocationIntervalId)
+					    .detail("KeyBegin", keys.begin)
+					    .detail("KeyEnd", keys.end);
+
+					// Wait for a durable quorum of servers in destServers to have keys available (readWrite)
+					// They must also have at least the transaction read version so they can't "forget" the shard
+					// between now and when this transaction commits.
+					state std::vector<Future<Void>> serverReady; // only for count below
+					state std::vector<Future<Void>> tssReady; // for waiting in parallel with tss
+					state std::vector<StorageServerInterface> tssReadyInterfs;
+					state std::vector<UID> newDestinations;
+					std::set<UID> completeSrcSet(completeSrc.begin(), completeSrc.end());
+					for (auto& it : dest) {
+						if (!hasRemote || !completeSrcSet.count(it)) {
+							newDestinations.push_back(it);
+						}
+					}
+
+					// for smartQuorum
+					state std::vector<StorageServerInterface> storageServerInterfaces;
+					std::vector<Future<Optional<Value>>> serverListEntries;
+					serverListEntries.reserve(newDestinations.size());
+					for (int s = 0; s < newDestinations.size(); s++)
+						serverListEntries.push_back(tr.get(serverListKeyFor(newDestinations[s])));
+					state std::vector<Optional<Value>> serverListValues = wait(getAll(serverListEntries));
+
+					releaser.release();
+
+					for (int s = 0; s < serverListValues.size(); s++) {
+						ASSERT(serverListValues[s]
+						           .present()); // There should always be server list entries for servers in keyServers
+						auto si = decodeServerListValue(serverListValues[s].get());
+						ASSERT(si.id() == newDestinations[s]);
+						storageServerInterfaces.push_back(si);
+					}
+
+					// update client info in case tss mapping changed or server got updated
+
+					// Wait for new destination servers to fetch the keys
+
+					serverReady.reserve(storageServerInterfaces.size());
+					tssReady.reserve(storageServerInterfaces.size());
+					tssReadyInterfs.reserve(storageServerInterfaces.size());
+					for (int s = 0; s < storageServerInterfaces.size(); s++) {
+						serverReady.push_back(waitForShardReady(storageServerInterfaces[s],
+						                                        keys,
+						                                        tr.getReadVersion().get(),
+						                                        GetShardStateRequest::READABLE));
+
+						auto tssPair = tssMapping.find(storageServerInterfaces[s].id());
+
+						if (tssPair != tssMapping.end() && waitForTSSCounter > 0 &&
+						    !tssToIgnore.count(tssPair->second.id())) {
+							tssReadyInterfs.push_back(tssPair->second);
+							tssReady.push_back(waitForShardReady(
+							    tssPair->second, keys, tr.getReadVersion().get(), GetShardStateRequest::READABLE));
+						}
+					}
+
+					// Wait for all storage server moves, and explicitly swallow errors for tss ones with
+					// waitForAllReady If this takes too long the transaction will time out and retry, which is ok
+					wait(timeout(waitForAll(serverReady) && waitForAllReady(tssReady),
+					             SERVER_KNOBS->SERVER_READY_QUORUM_TIMEOUT,
+					             Void(),
+					             TaskPriority::MoveKeys));
+
+					// Check to see if we're waiting only on tss. If so, decrement the waiting counter.
+					// If the waiting counter is zero, ignore the slow/non-responsive tss processes before finalizing
+					// the data move.
+					if (tssReady.size()) {
+						bool allSSDone = true;
+						for (auto& f : serverReady) {
+							allSSDone &= f.isReady() && !f.isError();
+							if (!allSSDone) {
+								break;
+							}
+						}
+
+						if (allSSDone) {
+							bool anyTssNotDone = false;
+
+							for (auto& f : tssReady) {
+								if (!f.isReady() || f.isError()) {
+									anyTssNotDone = true;
+									waitForTSSCounter--;
+									break;
+								}
+							}
+
+							if (anyTssNotDone && waitForTSSCounter == 0) {
+								for (int i = 0; i < tssReady.size(); i++) {
+									if (!tssReady[i].isReady() || tssReady[i].isError()) {
+										tssToIgnore.insert(tssReadyInterfs[i].id());
+									}
+								}
+							}
+						}
+					}
+
+					int count = dest.size() - newDestinations.size();
+					for (int s = 0; s < serverReady.size(); s++)
+						count += serverReady[s].isReady() && !serverReady[s].isError();
+
+					int tssCount = 0;
+					for (int s = 0; s < tssReady.size(); s++)
+						tssCount += tssReady[s].isReady() && !tssReady[s].isError();
+
+					TraceEvent readyServersEv(SevDebug, waitInterval.end(), relocationIntervalId);
+					readyServersEv.detail("ReadyServers", count);
+					if (tssReady.size()) {
+						readyServersEv.detail("ReadyTSS", tssCount);
+					}
+
+					if (count == dest.size()) {
+						// update keyServers, serverKeys
+						// SOMEDAY: Doing these in parallel is safe because none of them overlap or touch (one per
+						// server)
+						wait(krmSetRangeCoalescing(
+						    &tr, keyServersPrefix, currentKeys, keys, keyServersValue(UIDtoTagMap, dest)));
+
+						std::set<UID>::iterator asi = allServers.begin();
+						std::vector<Future<Void>> actors;
+						while (asi != allServers.end()) {
+							bool destHasServer = std::find(dest.begin(), dest.end(), *asi) != dest.end();
+							actors.push_back(krmSetRangeCoalescing(&tr,
+							                                       serverKeysPrefixFor(*asi),
+							                                       currentKeys,
+							                                       allKeys,
+							                                       destHasServer ? serverKeysTrue : serverKeysFalse));
+							++asi;
+						}
+
+						wait(waitForAll(actors));
+						wait(tr.commit());
+
+						begin = endKey;
+						break;
+					}
+					tr.reset();
+				} catch (Error& error) {
+					if (error.code() == error_code_actor_cancelled)
+						throw;
+					state Error err = error;
+					wait(tr.onError(error));
+					retries++;
+					if (retries % 10 == 0) {
+						TraceEvent(retries == 20 ? SevWarnAlways : SevWarn,
+						           "RelocateShard_FinishMoveKeysRetrying",
+						           relocationIntervalId)
+						    .error(err)
+						    .detail("KeyBegin", keys.begin)
+						    .detail("KeyEnd", keys.end)
+						    .detail("IterationBegin", begin)
+						    .detail("IterationEnd", endKey);
+					}
+				}
+			}
 		}
 
 		TraceEvent(SevDebug, interval.end(), relocationIntervalId);

--- a/fdbserver/MoveKeys.actor.cpp
+++ b/fdbserver/MoveKeys.actor.cpp
@@ -2505,7 +2505,7 @@ ACTOR Future<Void> cleanUpDataMove(Database occ,
 	return Void();
 }
 
-Future<Void> startMovement(Database occ, MoveKeysParams& params, std::map<UID, StorageServerInterface>& tssMapping) {
+Future<Void> rawStartMovement(Database occ, MoveKeysParams& params, std::map<UID, StorageServerInterface>& tssMapping) {
 	if (SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA) {
 		return startMoveShards(std::move(occ),
 		                       params.dataMoveId,
@@ -2527,7 +2527,7 @@ Future<Void> startMovement(Database occ, MoveKeysParams& params, std::map<UID, S
 	                     params.ddEnabledState);
 }
 
-Future<Void> finishMovement(Database occ,
+Future<Void> rawFinishMovement(Database occ,
                             MoveKeysParams& params,
                             const std::map<UID, StorageServerInterface>& tssMapping) {
 	if (SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA) {
@@ -2559,7 +2559,7 @@ ACTOR Future<Void> moveKeys(Database occ, MoveKeysParams params) {
 
 	state std::map<UID, StorageServerInterface> tssMapping;
 
-	wait(startMovement(occ, params, tssMapping));
+	wait(rawStartMovement(occ, params, tssMapping));
 
 	state Future<Void> completionSignaller = checkFetchingState(occ,
 	                                                            params.healthyDestinations,
@@ -2568,7 +2568,7 @@ ACTOR Future<Void> moveKeys(Database occ, MoveKeysParams params) {
 	                                                            params.relocationIntervalId,
 	                                                            tssMapping);
 
-	wait(finishMovement(occ, params, tssMapping));
+	wait(rawFinishMovement(occ, params, tssMapping));
 
 	// This is defensive, but make sure that we always say that the movement is complete before moveKeys completes
 	completionSignaller.cancel();

--- a/fdbserver/MoveKeys.actor.cpp
+++ b/fdbserver/MoveKeys.actor.cpp
@@ -756,13 +756,13 @@ ACTOR static Future<MoveKeysBatchInfo> startMoveKeysTransaction(Database occ,
 }
 
 ACTOR static Future<Void> startMoveKeys(Database occ,
-                                  KeyRange keys,
-                                  std::vector<UID> servers,
-                                  MoveKeysLock lock,
-                                  FlowLock* startMoveKeysLock,
-                                  UID relocationIntervalId,
-                                  std::map<UID, StorageServerInterface>* tssMapping,
-                                  const DDEnabledState* ddEnabledState) {
+                                        KeyRange keys,
+                                        std::vector<UID> servers,
+                                        MoveKeysLock lock,
+                                        FlowLock* startMoveKeysLock,
+                                        UID relocationIntervalId,
+                                        std::map<UID, StorageServerInterface>* tssMapping,
+                                        const DDEnabledState* ddEnabledState) {
 	state TraceInterval interval("RelocateShard_StartMoveKeys");
 	state Future<Void> warningLogger = logWarningAfter("StartMoveKeysTooLong", 600, servers);
 
@@ -1233,7 +1233,6 @@ ACTOR static Future<Void> finishMoveKeys(Database occ,
 	state TraceInterval interval("RelocateShard_FinishMoveKeys");
 	state Future<Void> warningLogger = logWarningAfter("FinishMoveKeysTooLong", 600, destinationTeam);
 	state Key begin = keys.begin;
-
 
 	ASSERT(!destinationTeam.empty());
 
@@ -2528,8 +2527,8 @@ Future<Void> rawStartMovement(Database occ, MoveKeysParams& params, std::map<UID
 }
 
 Future<Void> rawFinishMovement(Database occ,
-                            MoveKeysParams& params,
-                            const std::map<UID, StorageServerInterface>& tssMapping) {
+                               MoveKeysParams& params,
+                               const std::map<UID, StorageServerInterface>& tssMapping) {
 	if (SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA) {
 		return finishMoveShards(std::move(occ),
 		                        params.dataMoveId,

--- a/fdbserver/MoveKeys.actor.cpp
+++ b/fdbserver/MoveKeys.actor.cpp
@@ -578,183 +578,12 @@ ACTOR Future<Void> logWarningAfter(const char* context, double duration, std::ve
 	}
 }
 
-struct MoveKeysBatchInfo {
-	Key batchEnd;
-	int batchShards = 0;
-};
-
 // keyServer: map from keys to destination servers
 // serverKeys: two-dimension map: [servers][keys], value is the servers' state of having the keys: active(not-have),
 // complete(already has), ""(). Set keyServers[keys].dest = servers Set serverKeys[servers][keys] = active for each
 // subrange of keys that the server did not already have, complete for each subrange that it already has Set
 // serverKeys[dest][keys] = "" for the dest servers of each existing shard in keys (unless that destination is a member
 // of servers OR if the source list is sufficiently degraded)
-ACTOR static Future<MoveKeysBatchInfo> startMoveKeysTransaction(Database occ,
-                                                                KeyRange keys,
-                                                                std::vector<UID>* servers,
-                                                                MoveKeysLock lock,
-                                                                UID relocationIntervalId,
-                                                                std::map<UID, StorageServerInterface>* tssMapping,
-                                                                const DDEnabledState* ddEnabledState,
-                                                                bool loadedTssMapping,
-                                                                Key begin,
-                                                                int shards) {
-	state int retries = 0; // RYW to optimize re-reading the same key ranges
-	state Reference<ReadYourWritesTransaction> tr = makeReference<ReadYourWritesTransaction>(occ);
-	loop {
-		try {
-			retries++;
-
-			// Keep track of old dests that may need to have ranges removed from serverKeys
-			state std::__1::set<UID> oldDests;
-
-			// Keep track of shards for all src servers so that we can preserve their values in serverKeys
-			state Map<UID, VectorRef<KeyRangeRef>> shardMap;
-
-			tr->getTransaction().trState->taskID = TaskPriority::MoveKeys;
-			tr->setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
-			tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
-
-			wait(checkMoveKeysLock(&(tr->getTransaction()), lock, ddEnabledState));
-
-			if (!loadedTssMapping) {
-				// share transaction for loading tss mapping with the rest of start move keys
-				wait(readTSSMappingRYW(tr, tssMapping));
-				loadedTssMapping = true;
-			}
-
-			std::__1::vector<Future<Optional<Value>>> serverListEntries;
-			serverListEntries.reserve(servers->size());
-			for (int s = 0; s < servers->size(); s++)
-				serverListEntries.push_back(tr->get(serverListKeyFor(servers->at(s))));
-			state std::__1::vector<Optional<Value>> serverListValues = wait(getAll(serverListEntries));
-
-			for (int s = 0; s < serverListValues.size(); s++) {
-				if (!serverListValues[s].present()) {
-					// Attempt to move onto a server that isn't in serverList (removed or never added to the
-					// database) This can happen (why?) and is handled by the data distribution algorithm
-					// FIXME: Answer why this can happen?
-					CODE_PROBE(true, "start move keys moving to a removed server", probe::decoration::rare);
-					throw move_to_removed_server();
-				}
-			}
-
-			// Get all existing shards overlapping keys (exclude any that have been processed in a previous
-			// iteration of the outer loop)
-			state KeyRange currentKeys = KeyRangeRef(begin, keys.end);
-
-			state RangeResult old = wait(krmGetRanges(tr,
-			                                          keyServersPrefix,
-			                                          currentKeys,
-			                                          SERVER_KNOBS->MOVE_KEYS_KRM_LIMIT,
-			                                          SERVER_KNOBS->MOVE_KEYS_KRM_LIMIT_BYTES));
-
-			// Determine the last processed key (which will be the beginning for the next iteration)
-			state Key endKey = old.end()[-1].key;
-			currentKeys = KeyRangeRef(currentKeys.begin, endKey);
-
-			// TraceEvent("StartMoveKeysBatch", relocationIntervalId)
-			//     .detail("KeyBegin", currentKeys.begin.toString())
-			//     .detail("KeyEnd", currentKeys.end.toString());
-
-			// printf("Moving '%s'-'%s' (%d) to %d servers\n", keys.begin.toString().c_str(),
-			// keys.end.toString().c_str(), old.size(), servers.size()); for(int i=0; i<old.size(); i++)
-			// 	printf("'%s': '%s'\n", old[i].key.toString().c_str(), old[i].value.toString().c_str());
-
-			// Check that enough servers for each shard are in the correct state
-			state RangeResult UIDtoTagMap = wait(tr->getRange(serverTagKeys, CLIENT_KNOBS->TOO_MANY));
-			ASSERT(!UIDtoTagMap.more && UIDtoTagMap.size() < CLIENT_KNOBS->TOO_MANY);
-			std::__1::vector<std::__1::vector<UID>> addAsSource = wait(additionalSources(
-			    old, tr, servers->size(), SERVER_KNOBS->MAX_ADDED_SOURCES_MULTIPLIER * servers->size()));
-
-			// For each intersecting range, update keyServers[range] dest to be servers and clear existing dest
-			// servers from serverKeys
-			for (int i = 0; i < old.size() - 1; ++i) {
-				KeyRangeRef rangeIntersectKeys(old[i].key, old[i + 1].key);
-				std::__1::vector<UID> src;
-				std::__1::vector<UID> dest;
-				decodeKeyServersValue(UIDtoTagMap, old[i].value, src, dest);
-
-				// TraceEvent("StartMoveKeysOldRange", relocationIntervalId)
-				//     .detail("KeyBegin", rangeIntersectKeys.begin.toString())
-				//     .detail("KeyEnd", rangeIntersectKeys.end.toString())
-				//     .detail("OldSrc", describe(src))
-				//     .detail("OldDest", describe(dest))
-				//     .detail("ReadVersion", tr->getReadVersion().get());
-
-				for (auto& uid : addAsSource[i]) {
-					src.push_back(uid);
-				}
-				uniquify(src);
-
-				// Update dest servers for this range to be equal to servers
-				krmSetPreviouslyEmptyRange(&(tr->getTransaction()),
-				                           keyServersPrefix,
-				                           rangeIntersectKeys,
-				                           keyServersValue(UIDtoTagMap, src, *servers),
-				                           old[i + 1].value);
-
-				// Track old destination servers.  They may be removed from serverKeys soon, since they are
-				// about to be overwritten in keyServers
-				for (auto s = dest.begin(); s != dest.end(); ++s) {
-					oldDests.insert(*s);
-					// TraceEvent("StartMoveKeysOldDestAdd", relocationIntervalId).detail("Server", *s);
-				}
-
-				// Keep track of src shards so that we can preserve their values when we overwrite serverKeys
-				for (auto& uid : src) {
-					shardMap[uid].push_back(old.arena(), rangeIntersectKeys);
-					// TraceEvent("StartMoveKeysShardMapAdd", relocationIntervalId).detail("Server", uid);
-				}
-			}
-
-			state std::__1::set<UID>::iterator oldDest;
-
-			// Remove old dests from serverKeys.  In order for krmSetRangeCoalescing to work correctly in the
-			// same prefix for a single transaction, we must do most of the coalescing ourselves.  Only the
-			// shards on the boundary of currentRange are actually coalesced with the ranges outside of
-			// currentRange. For all shards internal to currentRange, we overwrite all consecutive keys whose
-			// value is or should be serverKeysFalse in a single write
-			std::__1::vector<Future<Void>> actors;
-			for (oldDest = oldDests.begin(); oldDest != oldDests.end(); ++oldDest)
-				if (std::__1::find(servers->begin(), servers->end(), *oldDest) == servers->end())
-					actors.push_back(removeOldDestinations(tr, *oldDest, shardMap[*oldDest], currentKeys));
-
-			// Update serverKeys to include keys (or the currently processed subset of keys) for each SS in
-			// servers
-			for (int i = 0; i < servers->size(); i++) {
-				// Since we are setting this for the entire range, serverKeys and keyServers aren't guaranteed
-				// to have the same shard boundaries If that invariant was important, we would have to move this
-				// inside the loop above and also set it for the src servers
-				actors.push_back(krmSetRangeCoalescing(
-				    tr, serverKeysPrefixFor(servers->at(i)), currentKeys, allKeys, serverKeysTrue));
-			}
-
-			wait(waitForAll(actors));
-
-			wait(tr->commit());
-
-			/*TraceEvent("StartMoveKeysCommitDone", relocationIntervalId)
-			    .detail("CommitVersion", tr.getCommittedVersion())
-			    .detail("ShardsInBatch", old.size() - 1);*/
-			return MoveKeysBatchInfo{ endKey, old.size() - 1 };
-		} catch (Error& e) {
-			state Error err = e;
-			if (err.code() == error_code_move_to_removed_server)
-				throw;
-			wait(tr->onError(e));
-
-			if (retries % 10 == 0) {
-				TraceEvent(retries == 50 ? SevWarnAlways : SevWarn, "StartMoveKeysRetrying", relocationIntervalId)
-				    .error(err)
-				    .detail("Keys", keys)
-				    .detail("BeginKey", begin)
-				    .detail("NumTries", retries);
-			}
-		}
-	}
-}
-
 ACTOR static Future<Void> startMoveKeys(Database occ,
                                         KeyRange keys,
                                         std::vector<UID> servers,
@@ -785,18 +614,170 @@ ACTOR static Future<Void> startMoveKeys(Database occ,
 		while (begin < keys.end) {
 			CODE_PROBE(begin > keys.begin, "Multi-transactional startMoveKeys");
 			batches++;
-			MoveKeysBatchInfo batchInfo = wait(startMoveKeysTransaction(occ,
-			                                                            keys,
-			                                                            &servers,
-			                                                            lock,
-			                                                            relocationIntervalId,
-			                                                            tssMapping,
-			                                                            ddEnabledState,
-			                                                            loadedTssMapping,
-			                                                            begin,
-			                                                            shards));
-			shards += batchInfo.batchShards;
-			begin = batchInfo.batchEnd;
+
+			// RYW to optimize re-reading the same key ranges
+			state Reference<ReadYourWritesTransaction> tr = makeReference<ReadYourWritesTransaction>(occ);
+			state int retries = 0;
+
+			loop {
+				try {
+					retries++;
+
+					// Keep track of old dests that may need to have ranges removed from serverKeys
+					state std::set<UID> oldDests;
+
+					// Keep track of shards for all src servers so that we can preserve their values in serverKeys
+					state Map<UID, VectorRef<KeyRangeRef>> shardMap;
+
+					tr->getTransaction().trState->taskID = TaskPriority::MoveKeys;
+					tr->setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
+					tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+
+					wait(checkMoveKeysLock(&(tr->getTransaction()), lock, ddEnabledState));
+
+					if (!loadedTssMapping) {
+						// share transaction for loading tss mapping with the rest of start move keys
+						wait(readTSSMappingRYW(tr, tssMapping));
+						loadedTssMapping = true;
+					}
+
+					std::vector<Future<Optional<Value>>> serverListEntries;
+					serverListEntries.reserve(servers.size());
+					for (int s = 0; s < servers.size(); s++)
+						serverListEntries.push_back(tr->get(serverListKeyFor(servers[s])));
+					state std::vector<Optional<Value>> serverListValues = wait(getAll(serverListEntries));
+
+					for (int s = 0; s < serverListValues.size(); s++) {
+						if (!serverListValues[s].present()) {
+							// Attempt to move onto a server that isn't in serverList (removed or never added to the
+							// database) This can happen (why?) and is handled by the data distribution algorithm
+							// FIXME: Answer why this can happen?
+							CODE_PROBE(true, "start move keys moving to a removed server", probe::decoration::rare);
+							throw move_to_removed_server();
+						}
+					}
+
+					// Get all existing shards overlapping keys (exclude any that have been processed in a previous
+					// iteration of the outer loop)
+					state KeyRange currentKeys = KeyRangeRef(begin, keys.end);
+
+					state RangeResult old = wait(krmGetRanges(tr,
+					                                          keyServersPrefix,
+					                                          currentKeys,
+					                                          SERVER_KNOBS->MOVE_KEYS_KRM_LIMIT,
+					                                          SERVER_KNOBS->MOVE_KEYS_KRM_LIMIT_BYTES));
+
+					// Determine the last processed key (which will be the beginning for the next iteration)
+					state Key endKey = old.end()[-1].key;
+					currentKeys = KeyRangeRef(currentKeys.begin, endKey);
+
+					// TraceEvent("StartMoveKeysBatch", relocationIntervalId)
+					//     .detail("KeyBegin", currentKeys.begin.toString())
+					//     .detail("KeyEnd", currentKeys.end.toString());
+
+					// printf("Moving '%s'-'%s' (%d) to %d servers\n", keys.begin.toString().c_str(),
+					// keys.end.toString().c_str(), old.size(), servers.size()); for(int i=0; i<old.size(); i++)
+					// 	printf("'%s': '%s'\n", old[i].key.toString().c_str(), old[i].value.toString().c_str());
+
+					// Check that enough servers for each shard are in the correct state
+					state RangeResult UIDtoTagMap = wait(tr->getRange(serverTagKeys, CLIENT_KNOBS->TOO_MANY));
+					ASSERT(!UIDtoTagMap.more && UIDtoTagMap.size() < CLIENT_KNOBS->TOO_MANY);
+					std::vector<std::vector<UID>> addAsSource = wait(additionalSources(
+					    old, tr, servers.size(), SERVER_KNOBS->MAX_ADDED_SOURCES_MULTIPLIER * servers.size()));
+
+					// For each intersecting range, update keyServers[range] dest to be servers and clear existing dest
+					// servers from serverKeys
+					for (int i = 0; i < old.size() - 1; ++i) {
+						KeyRangeRef rangeIntersectKeys(old[i].key, old[i + 1].key);
+						std::vector<UID> src;
+						std::vector<UID> dest;
+						decodeKeyServersValue(UIDtoTagMap, old[i].value, src, dest);
+
+						// TraceEvent("StartMoveKeysOldRange", relocationIntervalId)
+						//     .detail("KeyBegin", rangeIntersectKeys.begin.toString())
+						//     .detail("KeyEnd", rangeIntersectKeys.end.toString())
+						//     .detail("OldSrc", describe(src))
+						//     .detail("OldDest", describe(dest))
+						//     .detail("ReadVersion", tr->getReadVersion().get());
+
+						for (auto& uid : addAsSource[i]) {
+							src.push_back(uid);
+						}
+						uniquify(src);
+
+						// Update dest servers for this range to be equal to servers
+						krmSetPreviouslyEmptyRange(&(tr->getTransaction()),
+						                           keyServersPrefix,
+						                           rangeIntersectKeys,
+						                           keyServersValue(UIDtoTagMap, src, servers),
+						                           old[i + 1].value);
+
+						// Track old destination servers.  They may be removed from serverKeys soon, since they are
+						// about to be overwritten in keyServers
+						for (auto s = dest.begin(); s != dest.end(); ++s) {
+							oldDests.insert(*s);
+							// TraceEvent("StartMoveKeysOldDestAdd", relocationIntervalId).detail("Server", *s);
+						}
+
+						// Keep track of src shards so that we can preserve their values when we overwrite serverKeys
+						for (auto& uid : src) {
+							shardMap[uid].push_back(old.arena(), rangeIntersectKeys);
+							// TraceEvent("StartMoveKeysShardMapAdd", relocationIntervalId).detail("Server", uid);
+						}
+					}
+
+					state std::set<UID>::iterator oldDest;
+
+					// Remove old dests from serverKeys.  In order for krmSetRangeCoalescing to work correctly in the
+					// same prefix for a single transaction, we must do most of the coalescing ourselves.  Only the
+					// shards on the boundary of currentRange are actually coalesced with the ranges outside of
+					// currentRange. For all shards internal to currentRange, we overwrite all consecutive keys whose
+					// value is or should be serverKeysFalse in a single write
+					std::vector<Future<Void>> actors;
+					for (oldDest = oldDests.begin(); oldDest != oldDests.end(); ++oldDest)
+						if (std::find(servers.begin(), servers.end(), *oldDest) == servers.end())
+							actors.push_back(removeOldDestinations(tr, *oldDest, shardMap[*oldDest], currentKeys));
+
+					// Update serverKeys to include keys (or the currently processed subset of keys) for each SS in
+					// servers
+					for (int i = 0; i < servers.size(); i++) {
+						// Since we are setting this for the entire range, serverKeys and keyServers aren't guaranteed
+						// to have the same shard boundaries If that invariant was important, we would have to move this
+						// inside the loop above and also set it for the src servers
+						actors.push_back(krmSetRangeCoalescing(
+						    tr, serverKeysPrefixFor(servers[i]), currentKeys, allKeys, serverKeysTrue));
+					}
+
+					wait(waitForAll(actors));
+
+					wait(tr->commit());
+
+					/*TraceEvent("StartMoveKeysCommitDone", relocationIntervalId)
+					    .detail("CommitVersion", tr.getCommittedVersion())
+					    .detail("ShardsInBatch", old.size() - 1);*/
+					begin = endKey;
+					shards += old.size() - 1;
+					break;
+				} catch (Error& e) {
+					state Error err = e;
+					if (err.code() == error_code_move_to_removed_server)
+						throw;
+					wait(tr->onError(e));
+
+					if (retries % 10 == 0) {
+						TraceEvent(
+						    retries == 50 ? SevWarnAlways : SevWarn, "StartMoveKeysRetrying", relocationIntervalId)
+						    .error(err)
+						    .detail("Keys", keys)
+						    .detail("BeginKey", begin)
+						    .detail("NumTries", retries);
+					}
+				}
+			}
+
+			if (retries > maxRetries) {
+				maxRetries = retries;
+			}
 		}
 
 		// printf("Committed moving '%s'-'%s' (version %lld)\n", keys.begin.toString().c_str(),

--- a/fdbserver/MoveKeys.actor.cpp
+++ b/fdbserver/MoveKeys.actor.cpp
@@ -606,7 +606,7 @@ ACTOR static Future<MoveKeysBatchInfo> startMoveKeysTransaction(Database occ,
 			retries++;
 
 			// Keep track of old dests that may need to have ranges removed from serverKeys
-			state std::set<UID> oldDests;
+			state std::__1::set<UID> oldDests;
 
 			// Keep track of shards for all src servers so that we can preserve their values in serverKeys
 			state Map<UID, VectorRef<KeyRangeRef>> shardMap;
@@ -623,11 +623,11 @@ ACTOR static Future<MoveKeysBatchInfo> startMoveKeysTransaction(Database occ,
 				loadedTssMapping = true;
 			}
 
-			std::vector<Future<Optional<Value>>> serverListEntries;
+			std::__1::vector<Future<Optional<Value>>> serverListEntries;
 			serverListEntries.reserve(servers->size());
 			for (int s = 0; s < servers->size(); s++)
 				serverListEntries.push_back(tr->get(serverListKeyFor(servers->at(s))));
-			state std::vector<Optional<Value>> serverListValues = wait(getAll(serverListEntries));
+			state std::__1::vector<Optional<Value>> serverListValues = wait(getAll(serverListEntries));
 
 			for (int s = 0; s < serverListValues.size(); s++) {
 				if (!serverListValues[s].present()) {
@@ -664,7 +664,7 @@ ACTOR static Future<MoveKeysBatchInfo> startMoveKeysTransaction(Database occ,
 			// Check that enough servers for each shard are in the correct state
 			state RangeResult UIDtoTagMap = wait(tr->getRange(serverTagKeys, CLIENT_KNOBS->TOO_MANY));
 			ASSERT(!UIDtoTagMap.more && UIDtoTagMap.size() < CLIENT_KNOBS->TOO_MANY);
-			std::vector<std::__1::vector<UID>> addAsSource = wait(additionalSources(
+			std::__1::vector<std::__1::vector<UID>> addAsSource = wait(additionalSources(
 			    old, tr, servers->size(), SERVER_KNOBS->MAX_ADDED_SOURCES_MULTIPLIER * servers->size()));
 
 			// For each intersecting range, update keyServers[range] dest to be servers and clear existing dest
@@ -708,7 +708,7 @@ ACTOR static Future<MoveKeysBatchInfo> startMoveKeysTransaction(Database occ,
 				}
 			}
 
-			state std::set<UID>::iterator oldDest;
+			state std::__1::set<UID>::iterator oldDest;
 
 			// Remove old dests from serverKeys.  In order for krmSetRangeCoalescing to work correctly in the
 			// same prefix for a single transaction, we must do most of the coalescing ourselves.  Only the
@@ -958,11 +958,11 @@ ACTOR static Future<Key> finishMoveKeysTransaction(Database occ,
 			// Decode and sanity check the result (dest must be the same for all ranges)
 			bool alreadyMoved = true;
 
-			state std::vector<UID> dest;
-			state std::set<UID> allServers;
-			state std::set<UID> intendedTeam(destinationTeam->begin(), destinationTeam->end());
-			state std::vector<UID> src;
-			std::vector<UID> completeSrc;
+			state std::__1::vector<UID> dest;
+			state std::__1::set<UID> allServers;
+			state std::__1::set<UID> intendedTeam(destinationTeam->begin(), destinationTeam->end());
+			state std::__1::vector<UID> src;
+			std::__1::vector<UID> completeSrc;
 
 			// Iterate through the beginning of keyServers until we find one that hasn't already been processed
 			int currentIndex;
@@ -1071,11 +1071,11 @@ ACTOR static Future<Key> finishMoveKeysTransaction(Database occ,
 			// Wait for a durable quorum of servers in destServers to have keys available (readWrite)
 			// They must also have at least the transaction read version so they can't "forget" the shard
 			// between now and when this transaction commits.
-			state std::vector<Future<Void>> serverReady; // only for count below
-			state std::vector<Future<Void>> tssReady; // for waiting in parallel with tss
-			state std::vector<StorageServerInterface> tssReadyInterfs;
-			state std::vector<UID> newDestinations;
-			std::set<UID> completeSrcSet(completeSrc.begin(), completeSrc.end());
+			state std::__1::vector<Future<Void>> serverReady; // only for count below
+			state std::__1::vector<Future<Void>> tssReady; // for waiting in parallel with tss
+			state std::__1::vector<StorageServerInterface> tssReadyInterfs;
+			state std::__1::vector<UID> newDestinations;
+			std::__1::set<UID> completeSrcSet(completeSrc.begin(), completeSrc.end());
 			for (auto& it : dest) {
 				if (!hasRemote || !completeSrcSet.count(it)) {
 					newDestinations.push_back(it);
@@ -1083,12 +1083,12 @@ ACTOR static Future<Key> finishMoveKeysTransaction(Database occ,
 			}
 
 			// for smartQuorum
-			state std::vector<StorageServerInterface> storageServerInterfaces;
-			std::vector<Future<Optional<Value>>> serverListEntries;
+			state std::__1::vector<StorageServerInterface> storageServerInterfaces;
+			std::__1::vector<Future<Optional<Value>>> serverListEntries;
 			serverListEntries.reserve(newDestinations.size());
 			for (int s = 0; s < newDestinations.size(); s++)
 				serverListEntries.push_back(tr.get(serverListKeyFor(newDestinations[s])));
-			state std::vector<Optional<Value>> serverListValues = wait(getAll(serverListEntries));
+			state std::__1::vector<Optional<Value>> serverListValues = wait(getAll(serverListEntries));
 
 			releaser.release();
 
@@ -1181,8 +1181,8 @@ ACTOR static Future<Key> finishMoveKeysTransaction(Database occ,
 				wait(krmSetRangeCoalescing(
 				    &tr, keyServersPrefix, currentKeys, keys, keyServersValue(UIDtoTagMap, dest)));
 
-				std::set<UID>::iterator asi = allServers.begin();
-				std::vector<Future<Void>> actors;
+				std::__1::set<UID>::iterator asi = allServers.begin();
+				std::__1::vector<Future<Void>> actors;
 				while (asi != allServers.end()) {
 					bool destHasServer = std::find(dest.begin(), dest.end(), *asi) != dest.end();
 					actors.push_back(krmSetRangeCoalescing(&tr,

--- a/fdbserver/include/fdbserver/DDTxnProcessor.h
+++ b/fdbserver/include/fdbserver/DDTxnProcessor.h
@@ -141,13 +141,6 @@ public:
 	virtual Future<Void> waitDDTeamInfoPrintSignal() const { return Never(); }
 
 	virtual Future<std::vector<ProcessData>> getWorkers() const = 0;
-
-protected:
-	virtual Future<Void> rawStartMovement(MoveKeysParams& params,
-	                                      std::map<UID, StorageServerInterface>& tssMapping) = 0;
-
-	virtual Future<Void> rawFinishMovement(MoveKeysParams& params,
-	                                       const std::map<UID, StorageServerInterface>& tssMapping) = 0;
 };
 
 class DDTxnProcessorImpl;
@@ -235,10 +228,9 @@ public:
 	Future<std::vector<ProcessData>> getWorkers() const override;
 
 protected:
-	Future<Void> rawStartMovement(MoveKeysParams& params, std::map<UID, StorageServerInterface>& tssMapping) override;
+	Future<Void> rawStartMovement(MoveKeysParams& params, std::map<UID, StorageServerInterface>& tssMapping);
 
-	Future<Void> rawFinishMovement(MoveKeysParams& params,
-	                               const std::map<UID, StorageServerInterface>& tssMapping) override;
+	Future<Void> rawFinishMovement(MoveKeysParams& params, const std::map<UID, StorageServerInterface>& tssMapping);
 };
 
 struct DDMockTxnProcessorImpl;
@@ -303,10 +295,9 @@ public:
 	Future<std::vector<ProcessData>> getWorkers() const override;
 
 protected:
-	Future<Void> rawStartMovement(MoveKeysParams& params, std::map<UID, StorageServerInterface>& tssMapping) override;
+	void rawStartMovement(MoveKeysParams& params, std::map<UID, StorageServerInterface>& tssMapping);
 
-	Future<Void> rawFinishMovement(MoveKeysParams& params,
-	                               const std::map<UID, StorageServerInterface>& tssMapping) override;
+	void rawFinishMovement(MoveKeysParams& params, const std::map<UID, StorageServerInterface>& tssMapping);
 };
 
 #endif // FOUNDATIONDB_DDTXNPROCESSOR_H

--- a/fdbserver/include/fdbserver/DDTxnProcessor.h
+++ b/fdbserver/include/fdbserver/DDTxnProcessor.h
@@ -26,6 +26,8 @@
 #include "fdbserver/MoveKeys.actor.h"
 #include "fdbserver/MockGlobalState.h"
 
+FDB_DECLARE_BOOLEAN_PARAM(SkipDDModeCheck);
+
 struct InitialDataDistribution;
 struct DDShardInfo;
 
@@ -71,7 +73,7 @@ public:
 	    const MoveKeysLock& moveKeysLock,
 	    const std::vector<Optional<Key>>& remoteDcIds,
 	    const DDEnabledState* ddEnabledState,
-	    bool skipDDModeCheck) = 0;
+	    SkipDDModeCheck skipDDModeCheck) = 0;
 
 	virtual ~IDDTxnProcessor() = default;
 
@@ -174,7 +176,7 @@ public:
 	                                                                      const MoveKeysLock& moveKeysLock,
 	                                                                      const std::vector<Optional<Key>>& remoteDcIds,
 	                                                                      const DDEnabledState* ddEnabledState,
-	                                                                      bool skipDDModeCheck) override;
+	                                                                      SkipDDModeCheck skipDDModeCheck) override;
 
 	Future<MoveKeysLock> takeMoveKeysLock(UID const& ddId) const override;
 
@@ -259,7 +261,7 @@ public:
 	                                                                      const MoveKeysLock& moveKeysLock,
 	                                                                      const std::vector<Optional<Key>>& remoteDcIds,
 	                                                                      const DDEnabledState* ddEnabledState,
-	                                                                      bool skipDDModeCheck) override;
+	                                                                      SkipDDModeCheck skipDDModeCheck) override;
 
 	Future<Void> removeKeysFromFailedServer(const UID& serverID,
 	                                        const std::vector<UID>& teamForDroppedRange,

--- a/fdbserver/include/fdbserver/DDTxnProcessor.h
+++ b/fdbserver/include/fdbserver/DDTxnProcessor.h
@@ -112,6 +112,11 @@ public:
 	                                         const MoveKeysLock& lock,
 	                                         const DDEnabledState* ddEnabledState) const = 0;
 
+	virtual Future<Void> rawStartMovement(MoveKeysParams& params, std::map<UID, StorageServerInterface>& tssMapping) = 0;
+
+	virtual Future<Void> rawFinishMovement(MoveKeysParams& params,
+	                                    const std::map<UID, StorageServerInterface>& tssMapping) = 0;
+
 	virtual Future<Void> moveKeys(const MoveKeysParams& params) = 0;
 
 	virtual Future<std::pair<Optional<StorageMetrics>, int>> waitStorageMetrics(KeyRange const& keys,
@@ -198,6 +203,11 @@ public:
 		return ::removeStorageServer(cx, serverID, tssPairID, lock, ddEnabledState);
 	}
 
+	Future<Void> rawStartMovement(MoveKeysParams& params, std::map<UID, StorageServerInterface>& tssMapping) override;
+
+	Future<Void> rawFinishMovement(MoveKeysParams& params,
+	                            const std::map<UID, StorageServerInterface>& tssMapping) override;
+
 	Future<Void> moveKeys(const MoveKeysParams& params) override { return ::moveKeys(cx, params); }
 
 	Future<std::pair<Optional<StorageMetrics>, int>> waitStorageMetrics(KeyRange const& keys,
@@ -256,6 +266,11 @@ public:
 
 	// test only
 	void setupMockGlobalState(Reference<InitialDataDistribution> initData);
+
+	Future<Void> rawStartMovement(MoveKeysParams& params, std::map<UID, StorageServerInterface>& tssMapping) override;
+
+	Future<Void> rawFinishMovement(MoveKeysParams& params,
+	                            const std::map<UID, StorageServerInterface>& tssMapping) override;
 
 	Future<Void> moveKeys(const MoveKeysParams& params) override;
 

--- a/fdbserver/include/fdbserver/DDTxnProcessor.h
+++ b/fdbserver/include/fdbserver/DDTxnProcessor.h
@@ -70,7 +70,8 @@ public:
 	    const UID& distributorId,
 	    const MoveKeysLock& moveKeysLock,
 	    const std::vector<Optional<Key>>& remoteDcIds,
-	    const DDEnabledState* ddEnabledState) = 0;
+	    const DDEnabledState* ddEnabledState,
+	    bool skipDDModeCheck) = 0;
 
 	virtual ~IDDTxnProcessor() = default;
 
@@ -140,7 +141,8 @@ public:
 	virtual Future<std::vector<ProcessData>> getWorkers() const = 0;
 
 protected:
-	virtual Future<Void> rawStartMovement(MoveKeysParams& params, std::map<UID, StorageServerInterface>& tssMapping) = 0;
+	virtual Future<Void> rawStartMovement(MoveKeysParams& params,
+	                                      std::map<UID, StorageServerInterface>& tssMapping) = 0;
 
 	virtual Future<Void> rawFinishMovement(MoveKeysParams& params,
 	                                       const std::map<UID, StorageServerInterface>& tssMapping) = 0;
@@ -168,11 +170,11 @@ public:
 	// Call NativeAPI implementation directly
 	Future<ServerWorkerInfos> getServerListAndProcessClasses() override;
 
-	Future<Reference<InitialDataDistribution>> getInitialDataDistribution(
-	    const UID& distributorId,
-	    const MoveKeysLock& moveKeysLock,
-	    const std::vector<Optional<Key>>& remoteDcIds,
-	    const DDEnabledState* ddEnabledState) override;
+	Future<Reference<InitialDataDistribution>> getInitialDataDistribution(const UID& distributorId,
+	                                                                      const MoveKeysLock& moveKeysLock,
+	                                                                      const std::vector<Optional<Key>>& remoteDcIds,
+	                                                                      const DDEnabledState* ddEnabledState,
+	                                                                      bool skipDDModeCheck) override;
 
 	Future<MoveKeysLock> takeMoveKeysLock(UID const& ddId) const override;
 
@@ -253,11 +255,11 @@ public:
 
 	Future<ServerWorkerInfos> getServerListAndProcessClasses() override;
 
-	Future<Reference<InitialDataDistribution>> getInitialDataDistribution(
-	    const UID& distributorId,
-	    const MoveKeysLock& moveKeysLock,
-	    const std::vector<Optional<Key>>& remoteDcIds,
-	    const DDEnabledState* ddEnabledState) override;
+	Future<Reference<InitialDataDistribution>> getInitialDataDistribution(const UID& distributorId,
+	                                                                      const MoveKeysLock& moveKeysLock,
+	                                                                      const std::vector<Optional<Key>>& remoteDcIds,
+	                                                                      const DDEnabledState* ddEnabledState,
+	                                                                      bool skipDDModeCheck) override;
 
 	Future<Void> removeKeysFromFailedServer(const UID& serverID,
 	                                        const std::vector<UID>& teamForDroppedRange,

--- a/fdbserver/include/fdbserver/MockGlobalState.h
+++ b/fdbserver/include/fdbserver/MockGlobalState.h
@@ -45,7 +45,10 @@ inline bool isStatusTransitionValid(MockShardStatus from, MockShardStatus to) {
 		return to == MockShardStatus::COMPLETED || to == MockShardStatus::INFLIGHT || to == MockShardStatus::EMPTY;
 	case MockShardStatus::COMPLETED:
 		return to == MockShardStatus::EMPTY;
+	default:
+		ASSERT(false);
 	}
+	return false;
 }
 
 class MockStorageServer {

--- a/fdbserver/include/fdbserver/MockGlobalState.h
+++ b/fdbserver/include/fdbserver/MockGlobalState.h
@@ -90,7 +90,7 @@ public:
 
 	bool allShardStatusEqual(KeyRangeRef range, MockShardStatus status);
 
-	void setShardStatus(KeyRangeRef range, MockShardStatus status);
+	void setShardStatus(KeyRangeRef range, MockShardStatus status, bool restrictSize);
 
 	// this function removed an aligned range from server
 	void removeShard(KeyRangeRef range);
@@ -98,9 +98,12 @@ public:
 	uint64_t sumRangeSize(KeyRangeRef range) const;
 
 protected:
-	void threeWayShardSplitting(KeyRangeRef outerRange, KeyRangeRef innerRange, uint64_t outerRangeSize);
+	void threeWayShardSplitting(KeyRangeRef outerRange,
+	                            KeyRangeRef innerRange,
+	                            uint64_t outerRangeSize,
+	                            bool restrictSize);
 
-	void twoWayShardSplitting(KeyRangeRef range, KeyRef splitPoint, uint64_t rangeSize);
+	void twoWayShardSplitting(KeyRangeRef range, KeyRef splitPoint, uint64_t rangeSize, bool restrictSize);
 };
 
 class MockGlobalState {
@@ -117,6 +120,7 @@ public:
 	// user defined parameters for mock workload purpose
 	double emptyProb; // probability of doing an empty read
 	uint32_t minByteSize, maxByteSize; // the size band of a point data operation
+	bool restrictSize = true;
 
 	MockGlobalState() : shardMapping(new ShardsAffectedByTeamFailure) {}
 

--- a/fdbserver/include/fdbserver/MockGlobalState.h
+++ b/fdbserver/include/fdbserver/MockGlobalState.h
@@ -90,6 +90,9 @@ public:
 
 	bool allShardStatusEqual(KeyRangeRef range, MockShardStatus status);
 
+	// change the status of range. This function may result in split to make the shard boundary align with range.begin
+	// and range.end. In this case, if restrictSize==true, the sum of the split shard size is strictly equal to the old
+	// large shard. Otherwise, the size are randomly generated between (min_shard_size, max_shard_size)
 	void setShardStatus(KeyRangeRef range, MockShardStatus status, bool restrictSize);
 
 	// this function removed an aligned range from server

--- a/fdbserver/include/fdbserver/MockGlobalState.h
+++ b/fdbserver/include/fdbserver/MockGlobalState.h
@@ -30,10 +30,11 @@
 
 struct MockGlobalStateTester;
 
-enum class MockShardStatus { UNSET = -1, EMPTY = 0, COMPLETED, INFLIGHT };
+enum class MockShardStatus { EMPTY = 0, COMPLETED, INFLIGHT, UNSET };
 
 class MockStorageServer {
 	friend struct MockGlobalStateTester;
+
 public:
 	struct ShardInfo {
 		MockShardStatus status;

--- a/fdbserver/include/fdbserver/MockGlobalState.h
+++ b/fdbserver/include/fdbserver/MockGlobalState.h
@@ -30,14 +30,6 @@
 
 struct MockGlobalStateTester;
 
-template <class Metric>
-struct ShardSizeMetric {
-	template <typename pair_type>
-	Metric operator()(pair_type const& p) const {
-		return Metric(p.value.shardSize);
-	}
-};
-
 enum class MockShardStatus { UNSET = -1, EMPTY = 0, COMPLETED, INFLIGHT };
 
 class MockStorageServer {
@@ -57,8 +49,9 @@ public:
 	uint64_t usedDiskSpace = 0, availableDiskSpace = DEFAULT_DISK_SPACE;
 
 	// In-memory counterpart of the `serverKeys` in system keyspace
-	// the value ShardStatus is [InFlight, Completed, Empty] and metrics uint64_t is the shard size
-	KeyRangeMap<ShardInfo, uint64_t, ShardSizeMetric<uint64_t>> serverKeys;
+	// the value ShardStatus is [InFlight, Completed, Empty] and metrics uint64_t is the shard size, the caveat is the
+	// size() and nthRange() would use the metrics as index instead
+	KeyRangeMap<ShardInfo> serverKeys;
 
 	// sampled metrics
 	StorageServerMetrics metrics;
@@ -84,6 +77,8 @@ public:
 
 	// this function removed an aligned range from server
 	void removeShard(KeyRangeRef range);
+
+	uint64_t sumRangeSize(KeyRangeRef range) const;
 
 protected:
 	void threeWayShardSplitting(KeyRangeRef outerRange, KeyRangeRef innerRange, uint64_t outerRangeSize);

--- a/fdbserver/include/fdbserver/MockGlobalState.h
+++ b/fdbserver/include/fdbserver/MockGlobalState.h
@@ -73,6 +73,8 @@ public:
 	decltype(serverKeys)::Ranges getAllRanges() { return serverKeys.ranges(); }
 
 	bool allShardStatusEqual(KeyRangeRef range, MockShardStatus status);
+
+	void setShardStatus(KeyRangeRef range, MockShardStatus status);
 };
 
 class MockGlobalState {

--- a/fdbserver/include/fdbserver/MockGlobalState.h
+++ b/fdbserver/include/fdbserver/MockGlobalState.h
@@ -79,6 +79,9 @@ public:
 
 	void setShardStatus(KeyRangeRef range, MockShardStatus status);
 
+	// this function removed an aligned range from server
+	void removeShard(KeyRangeRef range);
+
 protected:
 	void threeWayShardSplitting(KeyRangeRef outerRange, KeyRangeRef innerRange, uint64_t outerRangeSize);
 

--- a/fdbserver/include/fdbserver/MockGlobalState.h
+++ b/fdbserver/include/fdbserver/MockGlobalState.h
@@ -28,6 +28,8 @@
 #include "SimulatedCluster.h"
 #include "ShardsAffectedByTeamFailure.h"
 
+struct MockGlobalStateTester;
+
 template <class Metric>
 struct ShardSizeMetric {
 	template <typename pair_type>
@@ -39,6 +41,7 @@ struct ShardSizeMetric {
 enum class MockShardStatus { UNSET = -1, EMPTY = 0, COMPLETED, INFLIGHT };
 
 class MockStorageServer {
+	friend struct MockGlobalStateTester;
 public:
 	struct ShardInfo {
 		MockShardStatus status;
@@ -89,6 +92,8 @@ protected:
 };
 
 class MockGlobalState {
+	friend struct MockGlobalStateTester;
+
 public:
 	typedef ShardsAffectedByTeamFailure::Team Team;
 	// In-memory counterpart of the `keyServers` in system keyspace

--- a/fdbserver/include/fdbserver/MockGlobalState.h
+++ b/fdbserver/include/fdbserver/MockGlobalState.h
@@ -36,13 +36,16 @@ struct ShardSizeMetric {
 	}
 };
 
-enum class MockShardStatus { EMPTY = 0, COMPLETED, INFLIGHT };
+enum class MockShardStatus { UNSET = -1, EMPTY = 0, COMPLETED, INFLIGHT };
 
 class MockStorageServer {
 public:
 	struct ShardInfo {
 		MockShardStatus status;
 		uint64_t shardSize;
+
+		bool operator==(const ShardInfo& a) const { return shardSize == a.shardSize && status == a.status; }
+		bool operator!=(const ShardInfo& a) const { return !(a == *this); }
 	};
 
 	static constexpr uint64_t DEFAULT_DISK_SPACE = 1000LL * 1024 * 1024 * 1024;
@@ -75,6 +78,11 @@ public:
 	bool allShardStatusEqual(KeyRangeRef range, MockShardStatus status);
 
 	void setShardStatus(KeyRangeRef range, MockShardStatus status);
+
+protected:
+	void threeWayShardSplitting(KeyRangeRef outerRange, KeyRangeRef innerRange, uint64_t outerRangeSize);
+
+	void twoWayShardSplitting(KeyRangeRef range, KeyRef splitPoint, uint64_t rangeSize);
 };
 
 class MockGlobalState {

--- a/fdbserver/include/fdbserver/MockGlobalState.h
+++ b/fdbserver/include/fdbserver/MockGlobalState.h
@@ -30,7 +30,23 @@
 
 struct MockGlobalStateTester;
 
-enum class MockShardStatus { EMPTY = 0, COMPLETED, INFLIGHT, UNSET };
+enum class MockShardStatus {
+	EMPTY = 0, // data loss
+	COMPLETED,
+	INFLIGHT,
+	UNSET
+};
+
+inline bool isStatusTransitionValid(MockShardStatus from, MockShardStatus to) {
+	switch (from) {
+	case MockShardStatus::UNSET:
+	case MockShardStatus::EMPTY:
+	case MockShardStatus::INFLIGHT:
+		return to == MockShardStatus::COMPLETED || to == MockShardStatus::INFLIGHT || to == MockShardStatus::EMPTY;
+	case MockShardStatus::COMPLETED:
+		return to == MockShardStatus::EMPTY;
+	}
+}
 
 class MockStorageServer {
 	friend struct MockGlobalStateTester;
@@ -118,7 +134,7 @@ public:
 	 * Shard is in-flight.
 	 * * In mgs.shardMapping,the destination teams is non-empty for a given shard;
 	 * * For each MSS belonging to the source teams, mss.serverKeys[shard] = Completed
-	 * * For each MSS belonging to the destination teams, mss.serverKeys[shard] = InFlight
+	 * * For each MSS belonging to the destination teams, mss.serverKeys[shard] = InFlight|Completed
 	 * Shard is lost.
 	 * * In mgs.shardMapping,  the destination teams is empty for the given shard;
 	 * * For each MSS belonging to the source teams, mss.serverKeys[shard] = Empty

--- a/fdbserver/include/fdbserver/MoveKeys.actor.h
+++ b/fdbserver/include/fdbserver/MoveKeys.actor.h
@@ -86,6 +86,11 @@ void seedShardServers(Arena& trArena, CommitTransactionRef& tr, std::vector<Stor
 // Called by the master server to write the very first transaction to the database
 // establishing a set of shard servers and all invariants of the systemKeys.
 
+Future<Void> rawStartMovement(Database occ, MoveKeysParams& params, std::map<UID, StorageServerInterface>& tssMapping);
+
+Future<Void> rawFinishMovement(Database occ,
+                               MoveKeysParams& params,
+                               const std::map<UID, StorageServerInterface>& tssMapping);
 // Eventually moves the given keys to the given destination team
 // Caller is responsible for cancelling it before issuing an overlapping move,
 // for restarting the remainder, and for not otherwise cancelling it before

--- a/fdbserver/workloads/IDDTxnProcessorApiCorrectness.actor.cpp
+++ b/fdbserver/workloads/IDDTxnProcessorApiCorrectness.actor.cpp
@@ -59,11 +59,11 @@ class DDMockTxnProcessorTester : public DDMockTxnProcessor {
 public:
 	explicit DDMockTxnProcessorTester(std::shared_ptr<MockGlobalState> mgs = nullptr) : DDMockTxnProcessor(mgs) {}
 	void testRawStartMovement(MoveKeysParams& params, std::map<UID, StorageServerInterface>& tssMapping) {
-		ASSERT(this->rawStartMovement(params, tssMapping).isReady());
+		rawStartMovement(params, tssMapping);
 	}
 
 	void testRawFinishMovement(MoveKeysParams& params, const std::map<UID, StorageServerInterface>& tssMapping) {
-		ASSERT(this->rawFinishMovement(params, tssMapping).isReady());
+		rawFinishMovement(params, tssMapping);
 	}
 };
 

--- a/fdbserver/workloads/IDDTxnProcessorApiCorrectness.actor.cpp
+++ b/fdbserver/workloads/IDDTxnProcessorApiCorrectness.actor.cpp
@@ -116,10 +116,12 @@ struct IDDTxnProcessorApiWorkload : TestWorkload {
 			wait(store(self->ddContext.lock, ::readMoveKeysLock(self->real->context())));
 			// read real InitialDataDistribution
 			try {
-				wait(store(
-				    self->realInitDD,
-				    self->real->getInitialDataDistribution(
-				        self->ddContext.id(), self->ddContext.lock, {}, self->ddContext.ddEnabledState.get(), true)));
+				wait(store(self->realInitDD,
+				           self->real->getInitialDataDistribution(self->ddContext.id(),
+				                                                  self->ddContext.lock,
+				                                                  {},
+				                                                  self->ddContext.ddEnabledState.get(),
+				                                                  SkipDDModeCheck::True)));
 				std::cout << "Finish read real InitialDataDistribution: server size "
 				          << self->realInitDD->allServers.size() << ", shard size: " << self->realInitDD->shards.size()
 				          << std::endl;
@@ -178,8 +180,11 @@ struct IDDTxnProcessorApiWorkload : TestWorkload {
 
 		Reference<InitialDataDistribution> mockInitData =
 		    self->mock
-		        ->getInitialDataDistribution(
-		            self->ddContext.id(), self->ddContext.lock, {}, self->ddContext.ddEnabledState.get(), true)
+		        ->getInitialDataDistribution(self->ddContext.id(),
+		                                     self->ddContext.lock,
+		                                     {},
+		                                     self->ddContext.ddEnabledState.get(),
+		                                     SkipDDModeCheck::True)
 		        .get();
 
 		verifyInitDataEqual(self->realInitDD, mockInitData);
@@ -211,11 +216,13 @@ struct IDDTxnProcessorApiWorkload : TestWorkload {
 
 		// read initial data again
 		wait(readRealInitialDataDistribution(self));
-		mockInitData =
-		    self->mock
-		        ->getInitialDataDistribution(
-		            self->ddContext.id(), self->ddContext.lock, {}, self->ddContext.ddEnabledState.get(), true)
-		        .get();
+		mockInitData = self->mock
+		                   ->getInitialDataDistribution(self->ddContext.id(),
+		                                                self->ddContext.lock,
+		                                                {},
+		                                                self->ddContext.ddEnabledState.get(),
+		                                                SkipDDModeCheck::True)
+		                   .get();
 
 		verifyInitDataEqual(self->realInitDD, mockInitData);
 
@@ -230,11 +237,13 @@ struct IDDTxnProcessorApiWorkload : TestWorkload {
 
 		// read initial data again
 		wait(readRealInitialDataDistribution(self));
-		mockInitData =
-		    self->mock
-		        ->getInitialDataDistribution(
-		            self->ddContext.id(), self->ddContext.lock, {}, self->ddContext.ddEnabledState.get(), true)
-		        .get();
+		mockInitData = self->mock
+		                   ->getInitialDataDistribution(self->ddContext.id(),
+		                                                self->ddContext.lock,
+		                                                {},
+		                                                self->ddContext.ddEnabledState.get(),
+		                                                SkipDDModeCheck::True)
+		                   .get();
 
 		verifyInitDataEqual(self->realInitDD, mockInitData);
 		return Void();
@@ -275,11 +284,13 @@ struct IDDTxnProcessorApiWorkload : TestWorkload {
 
 		// read initial data again
 		wait(readRealInitialDataDistribution(self));
-		mockInitData =
-		    self->mock
-		        ->getInitialDataDistribution(
-		            self->ddContext.id(), self->ddContext.lock, {}, self->ddContext.ddEnabledState.get(), true)
-		        .get();
+		mockInitData = self->mock
+		                   ->getInitialDataDistribution(self->ddContext.id(),
+		                                                self->ddContext.lock,
+		                                                {},
+		                                                self->ddContext.ddEnabledState.get(),
+		                                                SkipDDModeCheck::True)
+		                   .get();
 
 		verifyInitDataEqual(self->realInitDD, mockInitData);
 

--- a/fdbserver/workloads/IDDTxnProcessorApiCorrectness.actor.cpp
+++ b/fdbserver/workloads/IDDTxnProcessorApiCorrectness.actor.cpp
@@ -55,6 +55,8 @@ struct IDDTxnProcessorApiWorkload : TestWorkload {
 	static constexpr auto NAME = "IDDTxnProcessorApiCorrectness";
 	bool enabled;
 	double testDuration;
+	double meanDelay = 0.05;
+	double maxKeyspace = 0.1;
 	DDSharedContext ddContext;
 
 	std::shared_ptr<IDDTxnProcessor> real;
@@ -66,6 +68,8 @@ struct IDDTxnProcessorApiWorkload : TestWorkload {
 	IDDTxnProcessorApiWorkload(WorkloadContext const& wcx) : TestWorkload(wcx), ddContext(UID()) {
 		enabled = !clientId && g_network->isSimulated(); // only do this on the "first" client
 		testDuration = getOption(options, "testDuration"_sr, 10.0);
+		meanDelay = getOption(options, "meanDelay"_sr, meanDelay);
+		maxKeyspace = getOption(options, "maxKeyspace"_sr, maxKeyspace);
 	}
 
 	Future<Void> setup(Database const& cx) override { return enabled ? _setup(cx, this) : Void(); }
@@ -76,21 +80,15 @@ struct IDDTxnProcessorApiWorkload : TestWorkload {
 	// real world key-server mappings. It's not harmful to leave other workload injection enabled for now, though.
 	void disableFailureInjectionWorkloads(std::set<std::string>& out) const override { out.insert("RandomMoveKeys"); }
 
-	ACTOR Future<Void> _setup(Database cx, IDDTxnProcessorApiWorkload* self) {
-		self->real = std::make_shared<DDTxnProcessor>(cx);
-		// Get the database configuration so as to use proper team size
-		wait(store(self->ddContext.configuration, self->real->getDatabaseConfiguration()));
-		ASSERT(self->ddContext.configuration.storageTeamSize > 0);
-		// FIXME: add support for generating random teams across DCs
-		ASSERT_EQ(self->ddContext.usableRegions(), 1);
-
+	ACTOR static Future<Void> readRealInitialDataDistribution(IDDTxnProcessorApiWorkload* self) {
 		loop {
-			wait(store(self->ddContext.lock, ::readMoveKeysLock(cx)));
+			wait(store(self->ddContext.lock, ::readMoveKeysLock(self->real->context())));
 			// read real InitialDataDistribution
 			try {
-				wait(store(self->realInitDD,
-				           self->real->getInitialDataDistribution(
-				               self->ddContext.id(), self->ddContext.lock, {}, self->ddContext.ddEnabledState.get())));
+				wait(store(
+				    self->realInitDD,
+				    self->real->getInitialDataDistribution(
+				        self->ddContext.id(), self->ddContext.lock, {}, self->ddContext.ddEnabledState.get(), true)));
 				std::cout << "Finish read real InitialDataDistribution: server size "
 				          << self->realInitDD->allServers.size() << ", shard size: " << self->realInitDD->shards.size()
 				          << std::endl;
@@ -103,9 +101,29 @@ struct IDDTxnProcessorApiWorkload : TestWorkload {
 		return Void();
 	}
 
-	ACTOR Future<Void> _start(Database cx, IDDTxnProcessorApiWorkload* self) {
+	KeyRange getRandomKeys() const {
+		double len = deterministicRandom()->random01() * this->maxKeyspace;
+		double pos = deterministicRandom()->random01() * (1.0 - len);
+		return KeyRangeRef(doubleToTestKey(pos), doubleToTestKey(pos + len));
+	}
+
+	ACTOR Future<Void> _setup(Database cx, IDDTxnProcessorApiWorkload* self) {
 		int oldMode = wait(setDDMode(cx, 0));
 		TraceEvent("IDDTxnApiTestStartModeSetting").detail("OldValue", oldMode).log();
+
+		self->real = std::make_shared<DDTxnProcessor>(cx);
+		// Get the database configuration so as to use proper team size
+		wait(store(self->ddContext.configuration, self->real->getDatabaseConfiguration()));
+		ASSERT(self->ddContext.configuration.storageTeamSize > 0);
+		// FIXME: add support for generating random teams across DCs
+		ASSERT_EQ(self->ddContext.usableRegions(), 1);
+		wait(readRealInitialDataDistribution(self));
+
+		return Void();
+	}
+
+	ACTOR Future<Void> _start(Database cx, IDDTxnProcessorApiWorkload* self) {
+
 		self->mgs = std::make_shared<MockGlobalState>();
 		self->mgs->configuration = self->ddContext.configuration;
 		self->mock = std::make_shared<DDMockTxnProcessor>(self->mgs);
@@ -114,7 +132,7 @@ struct IDDTxnProcessorApiWorkload : TestWorkload {
 		Reference<InitialDataDistribution> mockInitData =
 		    self->mock
 		        ->getInitialDataDistribution(
-		            self->ddContext.id(), self->ddContext.lock, {}, self->ddContext.ddEnabledState.get())
+		            self->ddContext.id(), self->ddContext.lock, {}, self->ddContext.ddEnabledState.get(), true)
 		        .get();
 
 		verifyInitDataEqual(self->realInitDD, mockInitData);
@@ -129,11 +147,22 @@ struct IDDTxnProcessorApiWorkload : TestWorkload {
 		return Void();
 	}
 
-	// ACTOR Future<Void> worker(Database cx, IDDTxnProcessorApiWorkload* self) { return Void(); }
+	ACTOR Future<Void> worker(Database cx, IDDTxnProcessorApiWorkload* self) {
+		state KeyRangeMap<std::vector<StorageServerInterface>> inFlight;
+		state KeyRangeActorMap inFlightActors;
+		state double lastTime = now();
+
+		loop {
+
+			wait(delay(FLOW_KNOBS->PREVENT_FAST_SPIN_DELAY));
+			// Keep trying to get the moveKeysLock
+		}
+	}
 
 	Future<bool> check(Database const& cx) override {
 		return tag(delay(testDuration / 2), true);
 	} // Give the database time to recover from our damage
+
 	void getMetrics(std::vector<PerfMetric>& m) override {}
 };
 

--- a/fdbserver/workloads/IDDTxnProcessorApiCorrectness.actor.cpp
+++ b/fdbserver/workloads/IDDTxnProcessorApiCorrectness.actor.cpp
@@ -151,9 +151,17 @@ struct IDDTxnProcessorApiWorkload : TestWorkload {
 		state KeyRangeMap<std::vector<StorageServerInterface>> inFlight;
 		state KeyRangeActorMap inFlightActors;
 		state double lastTime = now();
-
+		state int choice = 0;
 		loop {
+			choice = deterministicRandom()->randomInt(0, 2);
 
+			if (choice == 0) {
+
+			} else if (choice == 1) {
+
+			} else {
+				ASSERT(false);
+			}
 			wait(delay(FLOW_KNOBS->PREVENT_FAST_SPIN_DELAY));
 			// Keep trying to get the moveKeysLock
 		}

--- a/fdbserver/workloads/IDDTxnProcessorApiCorrectness.actor.cpp
+++ b/fdbserver/workloads/IDDTxnProcessorApiCorrectness.actor.cpp
@@ -282,7 +282,7 @@ struct IDDTxnProcessorApiWorkload : TestWorkload {
 		        .get();
 
 		verifyInitDataEqual(self->realInitDD, mockInitData);
-		
+
 		return Void();
 	}
 	ACTOR Future<Void> worker(Database cx, IDDTxnProcessorApiWorkload* self) {

--- a/fdbserver/workloads/IDDTxnProcessorApiCorrectness.actor.cpp
+++ b/fdbserver/workloads/IDDTxnProcessorApiCorrectness.actor.cpp
@@ -170,6 +170,8 @@ struct IDDTxnProcessorApiWorkload : TestWorkload {
 
 		self->mgs = std::make_shared<MockGlobalState>();
 		self->mgs->configuration = self->ddContext.configuration;
+		self->mgs->restrictSize = false; // no need to check the validity of shard size
+
 		self->mock = std::make_shared<DDMockTxnProcessorTester>(self->mgs);
 		self->mock->setupMockGlobalState(self->realInitDD);
 

--- a/flow/DeterministicRandom.cpp
+++ b/flow/DeterministicRandom.cpp
@@ -45,7 +45,7 @@ double DeterministicRandom::random01() {
 }
 
 int DeterministicRandom::randomInt(int min, int maxPlusOne) {
-	ASSERT(min < maxPlusOne);
+	ASSERT_LT(min , maxPlusOne);
 	unsigned int range;
 	if (maxPlusOne < 0)
 		range = std::abs(maxPlusOne - min);
@@ -65,7 +65,7 @@ int DeterministicRandom::randomInt(int min, int maxPlusOne) {
 }
 
 int64_t DeterministicRandom::randomInt64(int64_t min, int64_t maxPlusOne) {
-	ASSERT(min < maxPlusOne);
+	ASSERT_LT(min , maxPlusOne);
 	uint64_t range;
 	if (maxPlusOne < 0)
 		range = std::abs(maxPlusOne - min);
@@ -93,7 +93,7 @@ uint64_t DeterministicRandom::randomUInt64() {
 }
 
 uint32_t DeterministicRandom::randomSkewedUInt32(uint32_t min, uint32_t maxPlusOne) {
-	ASSERT(min < maxPlusOne);
+	ASSERT_LT(min , maxPlusOne);
 	std::uniform_real_distribution<double> distribution(std::log(std::max<double>(min, 1.0 / M_E)),
 	                                                    std::log(maxPlusOne));
 	double exponent = distribution(random);

--- a/flow/DeterministicRandom.cpp
+++ b/flow/DeterministicRandom.cpp
@@ -45,7 +45,7 @@ double DeterministicRandom::random01() {
 }
 
 int DeterministicRandom::randomInt(int min, int maxPlusOne) {
-	ASSERT_LT(min , maxPlusOne);
+	ASSERT_LT(min, maxPlusOne);
 	unsigned int range;
 	if (maxPlusOne < 0)
 		range = std::abs(maxPlusOne - min);
@@ -65,7 +65,7 @@ int DeterministicRandom::randomInt(int min, int maxPlusOne) {
 }
 
 int64_t DeterministicRandom::randomInt64(int64_t min, int64_t maxPlusOne) {
-	ASSERT_LT(min , maxPlusOne);
+	ASSERT_LT(min, maxPlusOne);
 	uint64_t range;
 	if (maxPlusOne < 0)
 		range = std::abs(maxPlusOne - min);
@@ -93,7 +93,7 @@ uint64_t DeterministicRandom::randomUInt64() {
 }
 
 uint32_t DeterministicRandom::randomSkewedUInt32(uint32_t min, uint32_t maxPlusOne) {
-	ASSERT_LT(min , maxPlusOne);
+	ASSERT_LT(min, maxPlusOne);
 	std::uniform_real_distribution<double> distribution(std::log(std::max<double>(min, 1.0 / M_E)),
 	                                                    std::log(maxPlusOne));
 	double exponent = distribution(random);

--- a/tests/fast/IDDTxnProcessorApiCorrectness.toml
+++ b/tests/fast/IDDTxnProcessorApiCorrectness.toml
@@ -7,4 +7,4 @@ testTitle = 'IDDTxnProcessorApiCorrectness'
 
     [[test.workload]]
     testName = 'IDDTxnProcessorApiCorrectness'
-    testDuration = 10.0
+    testDuration = 50.0


### PR DESCRIPTION
There are mainly 2 changes in this PR:
* `MockDDTxnProcessor` and `MockGlobalState` get the code for mock mode `moveKeys` implementation
* Add test in `IDDTxnProcessorApiWorkload` to verify the consistency of mock and real-world after moveKeys

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
