### PR TITLE
Fix cmake config so boost does not rebuild every time

### DIFF
--- a/cmake/CompileBoost.cmake
+++ b/cmake/CompileBoost.cmake
@@ -74,7 +74,7 @@ function(compile_boost)
     BUILD_IN_SOURCE    ON
     INSTALL_COMMAND    ""
     UPDATE_COMMAND     ""
-    BUILD_BYPRODUCTS   "${BOOST_INSTALL_DIR}/boost/config.hpp"
+    BUILD_BYPRODUCTS   "${BOOST_INSTALL_DIR}/include/boost/config.hpp"
                        "${BOOST_INSTALL_DIR}/lib/libboost_context.a"
                        "${BOOST_INSTALL_DIR}/lib/libboost_filesystem.a"
                        "${BOOST_INSTALL_DIR}/lib/libboost_iostreams.a")


### PR DESCRIPTION
The location of the boost build artifact config.hpp was wrong, so since no file at that path is ever created boost is always rebuilt.  Found this from `ninja -d explain`

```
ninja explain: output boost_install/boost/config.hpp doesn't exist
```

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
