### PR TITLE
Version Bump from 71.2.1 to 71.2.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ else()
 endif()
 
 project(foundationdb
-  VERSION 71.2.2
+  VERSION 71.2.3
   DESCRIPTION "FoundationDB is a scalable, fault-tolerant, ordered key-value store with full ACID transactions."
   HOMEPAGE_URL "http://www.foundationdb.org/"
   LANGUAGES C CXX ASM)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ else()
 endif()
 
 project(foundationdb
-  VERSION 71.2.1
+  VERSION 71.2.2
   DESCRIPTION "FoundationDB is a scalable, fault-tolerant, ordered key-value store with full ACID transactions."
   HOMEPAGE_URL "http://www.foundationdb.org/"
   LANGUAGES C CXX ASM)

--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -343,7 +343,7 @@ if(NOT WIN32)
     COMMAND ${CMAKE_SOURCE_DIR}/tests/TestRunner/upgrade_test.py
         --build-dir ${CMAKE_BINARY_DIR}
         --test-file ${CMAKE_SOURCE_DIR}/bindings/c/test/apitester/tests/upgrade/MixedApiWorkloadMultiThr.toml
-        --upgrade-path "71.2.2" "71.3.0" "71.2.2"
+        --upgrade-path "71.2.3" "71.3.0" "71.2.3"
         --process-number 3
       )
   set_tests_properties("fdb_c_upgrade_to_future_version" PROPERTIES ENVIRONMENT "${SANITIZER_OPTIONS}")
@@ -352,7 +352,7 @@ if(NOT WIN32)
     COMMAND ${CMAKE_SOURCE_DIR}/tests/TestRunner/upgrade_test.py
         --build-dir ${CMAKE_BINARY_DIR}
         --test-file ${CMAKE_SOURCE_DIR}/bindings/c/test/apitester/tests/upgrade/ApiBlobGranulesCorrectness.toml
-        --upgrade-path "71.2.2" "71.3.0" "71.2.2"
+        --upgrade-path "71.2.3" "71.3.0" "71.2.3"
         --blob-granules-enabled
         --process-number 3
       )

--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -343,7 +343,7 @@ if(NOT WIN32)
     COMMAND ${CMAKE_SOURCE_DIR}/tests/TestRunner/upgrade_test.py
         --build-dir ${CMAKE_BINARY_DIR}
         --test-file ${CMAKE_SOURCE_DIR}/bindings/c/test/apitester/tests/upgrade/MixedApiWorkloadMultiThr.toml
-        --upgrade-path "71.2.1" "71.3.0" "71.2.1"
+        --upgrade-path "71.2.2" "71.3.0" "71.2.2"
         --process-number 3
       )
   set_tests_properties("fdb_c_upgrade_to_future_version" PROPERTIES ENVIRONMENT "${SANITIZER_OPTIONS}")
@@ -352,7 +352,7 @@ if(NOT WIN32)
     COMMAND ${CMAKE_SOURCE_DIR}/tests/TestRunner/upgrade_test.py
         --build-dir ${CMAKE_BINARY_DIR}
         --test-file ${CMAKE_SOURCE_DIR}/bindings/c/test/apitester/tests/upgrade/ApiBlobGranulesCorrectness.toml
-        --upgrade-path "71.2.1" "71.3.0" "71.2.1"
+        --upgrade-path "71.2.2" "71.3.0" "71.2.2"
         --blob-granules-enabled
         --process-number 3
       )

--- a/tests/TestRunner/binary_download.py
+++ b/tests/TestRunner/binary_download.py
@@ -10,7 +10,7 @@ import hashlib
 
 from local_cluster import random_secret_string
 
-CURRENT_VERSION = "71.2.1"
+CURRENT_VERSION = "71.2.2"
 FUTURE_VERSION = "71.3.0"
 
 SUPPORTED_PLATFORMS = ["x86_64", "aarch64"]

--- a/tests/TestRunner/binary_download.py
+++ b/tests/TestRunner/binary_download.py
@@ -10,7 +10,7 @@ import hashlib
 
 from local_cluster import random_secret_string
 
-CURRENT_VERSION = "71.2.2"
+CURRENT_VERSION = "71.2.3"
 FUTURE_VERSION = "71.3.0"
 
 SUPPORTED_PLATFORMS = ["x86_64", "aarch64"]


### PR DESCRIPTION
This version will be 71.2.3 which will be all fixes  after 71.2.1  including Steve's guard fix.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
