### PR TITLE
Fix a test timeout

### DIFF
--- a/fdbclient/IdempotencyId.cpp
+++ b/fdbclient/IdempotencyId.cpp
@@ -122,6 +122,7 @@ IdempotencyIdRef generate(Arena& arena) {
 TEST_CASE("/fdbclient/IdempotencyId/basic") {
 	Arena arena;
 	uint16_t firstBatchIndex = deterministicRandom()->randomUInt32();
+	firstBatchIndex &= 0xff7f; // ensure firstBatchIndex+5 won't change the higher order byte
 	uint16_t batchIndex = firstBatchIndex;
 	Version commitVersion = deterministicRandom()->randomInt64(0, std::numeric_limits<Version>::max());
 	std::vector<IdempotencyIdRef> idVector; // Reference

--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -39,11 +39,12 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( ENABLE_VERSION_VECTOR,                               false );
 	init( ENABLE_VERSION_VECTOR_TLOG_UNICAST,                  false );
 
-        bool buggifyShortReadWindow = randomize && BUGGIFY && !ENABLE_VERSION_VECTOR;
+	bool buggifyShortReadWindow = randomize && BUGGIFY && !ENABLE_VERSION_VECTOR;
 	init( MAX_READ_TRANSACTION_LIFE_VERSIONS,      5 * VERSIONS_PER_SECOND ); if (randomize && BUGGIFY) MAX_READ_TRANSACTION_LIFE_VERSIONS = VERSIONS_PER_SECOND; else if (buggifyShortReadWindow) MAX_READ_TRANSACTION_LIFE_VERSIONS = std::max<int>(1, 0.1 * VERSIONS_PER_SECOND); else if( randomize && BUGGIFY ) MAX_READ_TRANSACTION_LIFE_VERSIONS = 10 * VERSIONS_PER_SECOND;
 	init( MAX_WRITE_TRANSACTION_LIFE_VERSIONS,     5 * VERSIONS_PER_SECOND ); if (randomize && BUGGIFY) MAX_WRITE_TRANSACTION_LIFE_VERSIONS=std::max<int>(1, 1 * VERSIONS_PER_SECOND);
 	init( MAX_COMMIT_BATCH_INTERVAL,                             2.0 ); if( randomize && BUGGIFY ) MAX_COMMIT_BATCH_INTERVAL = 0.5; // Each commit proxy generates a CommitTransactionBatchRequest at least this often, so that versions always advance smoothly
 	MAX_COMMIT_BATCH_INTERVAL = std::min(MAX_COMMIT_BATCH_INTERVAL, MAX_READ_TRANSACTION_LIFE_VERSIONS/double(2*VERSIONS_PER_SECOND)); // Ensure that the proxy commits 2 times every MAX_READ_TRANSACTION_LIFE_VERSIONS, otherwise the master will not give out versions fast enough
+	MAX_COMMIT_BATCH_INTERVAL = std::min(MAX_COMMIT_BATCH_INTERVAL, MAX_WRITE_TRANSACTION_LIFE_VERSIONS/double(2*VERSIONS_PER_SECOND)); // Ensure that the proxy commits 2 times every MAX_WRITE_TRANSACTION_LIFE_VERSIONS, otherwise the master will not give out versions fast enough
 	init( MAX_VERSION_RATE_MODIFIER,                             0.1 );
 	init( MAX_VERSION_RATE_OFFSET,               VERSIONS_PER_SECOND ); // If the calculated version is more than this amount away from the expected version, it will be clamped to this value. This prevents huge version jumps.
 	init( ENABLE_VERSION_VECTOR_HA_OPTIMIZATION,               false );

--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -840,7 +840,6 @@ ACTOR Future<Void> clearData(Database cx) {
 	state UID debugID = debugRandom()->randomUniqueID();
 	tr.debugTransaction(debugID);
 
-	const_cast<ServerKnobs*>(SERVER_KNOBS)->MAX_WRITE_TRANSACTION_LIFE_VERSIONS = 5 * SERVER_KNOBS->VERSIONS_PER_SECOND;
 	loop {
 		try {
 			TraceEvent("TesterClearingDatabaseStart", debugID).log();

--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -838,21 +838,26 @@ ACTOR Future<Void> testerServerCore(TesterInterface interf,
 ACTOR Future<Void> clearData(Database cx) {
 	state Transaction tr(cx);
 	state UID debugID = debugRandom()->randomUniqueID();
-	TraceEvent("TesterClearingDatabaseStart", debugID).log();
 	tr.debugTransaction(debugID);
+
+	const_cast<ServerKnobs*>(SERVER_KNOBS)->MAX_WRITE_TRANSACTION_LIFE_VERSIONS = 5 * SERVER_KNOBS->VERSIONS_PER_SECOND;
 	loop {
 		try {
+			TraceEvent("TesterClearingDatabaseStart", debugID).log();
 			// This transaction needs to be self-conflicting, but not conflict consistently with
 			// any other transactions
 			tr.clear(normalKeys);
 			tr.makeSelfConflicting();
-			wait(success(tr.getReadVersion())); // required since we use addReadConflictRange but not get
+			Version rv = wait(tr.getReadVersion()); // required since we use addReadConflictRange but not get
+			TraceEvent("TesterClearingDatabaseRV", debugID).detail("RV", rv);
 			wait(tr.commit());
 			TraceEvent("TesterClearingDatabase", debugID).detail("AtVersion", tr.getCommittedVersion());
 			break;
 		} catch (Error& e) {
 			TraceEvent(SevWarn, "TesterClearingDatabaseError", debugID).error(e);
 			wait(tr.onError(e));
+			debugID = debugRandom()->randomUniqueID();
+			tr.debugTransaction(debugID);
 		}
 	}
 


### PR DESCRIPTION
The buggified knob MAX_WRITE_TRANSACTION_LIFE_VERSIONS can be only 1M and cause test timeout.

Seed: `-f ./foundationdb/tests/fast/AutomaticIdempotency.toml -s 2280218520 -b on`
Commit: 50b425389
Compiler: Clang

20221017-223440-jzhou-4100dfead7f16827 passed.
20221018-215838-jzhou-4cb75a57999a7acb has an unrelated random unit test `/fdbclient/IdempotencyId/basic` failure.
`-r simulation --crash --logsize 1024MB -f ./foundationdb/tests/fast/RandomUnitTests.toml -s 3581842356 -b on`

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
