### PR TITLE
Use consistencyScanInfoFetcher function and add a timeout

### DIFF
--- a/documentation/sphinx/source/mr-status-json-schemas.rst.inc
+++ b/documentation/sphinx/source/mr-status-json-schemas.rst.inc
@@ -528,7 +528,8 @@
                   "duplicate_mutation_fetch_timeout",
                   "primary_dc_missing",
                   "fetch_primary_dc_timeout",
-                  "fetch_storage_wiggler_stats_timeout"
+                  "fetch_storage_wiggler_stats_timeout",
+                  "fetch_consistency_scan_info_timeout"
                ]
             },
             "issues":[

--- a/fdbclient/Schemas.cpp
+++ b/fdbclient/Schemas.cpp
@@ -582,7 +582,8 @@ const KeyRef JSONSchemas::statusSchema = R"statusSchema(
                   "duplicate_mutation_fetch_timeout",
                   "primary_dc_missing",
                   "fetch_primary_dc_timeout",
-                  "fetch_storage_wiggler_stats_timeout"
+                  "fetch_storage_wiggler_stats_timeout",
+                  "fetch_consistency_scan_info_timeout"
                ]
             },
             "issues":[

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -3431,23 +3431,19 @@ ACTOR Future<StatusReply> clusterGetStatus(
 		}
 
 		// Fetch Consistency Scan Information
-		state Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
-		state Optional<Value> val;
-		loop {
-			try {
-				tr->setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
-				wait(store(val, ConsistencyScanInfo::getInfo(tr)));
-				wait(tr->commit());
-				break;
-			} catch (Error& e) {
-				wait(tr->onError(e));
+		try {
+			Optional<Value> val = wait(timeoutError(consistencyScanInfoFetcher(cx), 2.0));
+			if (val.present()) {
+				ConsistencyScanInfo consistencyScanInfo =
+				    ObjectReader::fromStringRef<ConsistencyScanInfo>(val.get(), IncludeVersion());
+				TraceEvent("StatusConsistencyScanGotVal").log();
+				statusObj["consistency_scan_info"] = consistencyScanInfo.toJSON();
 			}
-		}
-		if (val.present()) {
-			ConsistencyScanInfo consistencyScanInfo =
-			    ObjectReader::fromStringRef<ConsistencyScanInfo>(val.get(), IncludeVersion());
-			TraceEvent("StatusConsistencyScanGotVal").log();
-			statusObj["consistency_scan_info"] = consistencyScanInfo.toJSON();
+		} catch (Error& e) {
+			if (e.code() == error_code_actor_cancelled)
+				throw;
+			messages.push_back(JsonString::makeMessage("fetch_consistency_scan_info_timeout",
+			                                           "Fetching consistency scan information timed out."));
 		}
 
 		// Create the status_incomplete message if there were any reasons that the status is incomplete.

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -2912,7 +2912,7 @@ ACTOR Future<Optional<Value>> consistencyScanInfoFetcher(Database cx) {
 	}
 
 	TraceEvent("ConsistencyScanInfoFetcher").log();
-	return val.get();
+	return val;
 }
 
 // constructs the cluster section of the json status output


### PR DESCRIPTION
Otherwise, it blocks getting status when there is no database running in the cluster.

20221017-212241-zhewu_8489_3-4835b329114a3d59      compressed=True data_size=38444136 duration=3487281 ended=100004 fail=1 fail_fast=10 max_runs=100000 pass=100003 priority=100 remaining=0 runtime=1:05:28 sanity=False started=100286 stopped=20221017-222809 submitted=20221017-212241 timeout=5400 username=zhewu_8489_3

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
