### PR TITLE
Enable EncryptKeyProxy test and add code probes

### DIFF
--- a/fdbserver/EncryptKeyProxy.actor.cpp
+++ b/fdbserver/EncryptKeyProxy.actor.cpp
@@ -31,6 +31,7 @@
 #include "fdbserver/WorkerInterface.actor.h"
 #include "fdbserver/ServerDBInfo.h"
 #include "flow/Arena.h"
+#include "flow/CodeProbe.h"
 #include "flow/EncryptUtils.h"
 #include "flow/Error.h"
 #include "flow/EventTypes.actor.h"
@@ -452,6 +453,8 @@ ACTOR Future<Void> getCipherKeysByBaseCipherKeyIds(Reference<EncryptKeyProxyData
 	keyIdsReply.numHits = cachedCipherDetails.size();
 	keysByIds.reply.send(keyIdsReply);
 
+	CODE_PROBE(!lookupCipherInfoMap.empty(), "EKP fetch cipherKeys by KeyId from KMS");
+
 	return Void();
 }
 
@@ -475,13 +478,13 @@ ACTOR Future<Void> getLatestCipherKeys(Reference<EncryptKeyProxyData> ekpProxyDa
 	// Dedup the requested domainIds.
 	// TODO: endpoint serialization of std::unordered_set isn't working at the moment
 	std::unordered_map<EncryptCipherDomainId, EKPGetLatestCipherKeysRequestInfo> dedupedDomainInfos;
-	for (const auto info : req.encryptDomainInfos) {
+	for (const auto& info : req.encryptDomainInfos) {
 		dedupedDomainInfos.emplace(info.domainId, info);
 	}
 
 	if (dbgTrace.present()) {
 		dbgTrace.get().detail("NKeys", dedupedDomainInfos.size());
-		for (const auto info : dedupedDomainInfos) {
+		for (const auto& info : dedupedDomainInfos) {
 			// log encryptDomainIds queried
 			dbgTrace.get().detail(
 			    getEncryptDbgTraceKey(ENCRYPT_DBG_TRACE_QUERY_PREFIX, info.first, info.second.domainName), "");
@@ -588,6 +591,8 @@ ACTOR Future<Void> getLatestCipherKeys(Reference<EncryptKeyProxyData> ekpProxyDa
 	latestCipherReply.numHits = cachedCipherDetails.size();
 	latestKeysReq.reply.send(latestCipherReply);
 
+	CODE_PROBE(!lookupCipherDomains.empty(), "EKP fetch latest cipherKeys from KMS");
+
 	return Void();
 }
 
@@ -610,7 +615,7 @@ bool isBlobMetadataEligibleForRefresh(const BlobMetadataDetailsRef& blobMetadata
 	return nextRefreshCycleTS > blobMetadata.expireAt || nextRefreshCycleTS > blobMetadata.refreshAt;
 }
 
-ACTOR Future<Void> refreshEncryptionKeysCore(Reference<EncryptKeyProxyData> ekpProxyData,
+ACTOR Future<Void> refreshEncryptionKeysImpl(Reference<EncryptKeyProxyData> ekpProxyData,
                                              KmsConnectorInterface kmsConnectorInf) {
 	state UID debugId = deterministicRandom()->randomUniqueID();
 
@@ -672,6 +677,7 @@ ACTOR Future<Void> refreshEncryptionKeysCore(Reference<EncryptKeyProxyData> ekpP
 		ekpProxyData->baseCipherKeysRefreshed += rep.cipherKeyDetails.size();
 
 		t.detail("NumKeys", rep.cipherKeyDetails.size());
+		CODE_PROBE(!rep.cipherKeyDetails.empty(), "EKP refresh cipherKeys");
 	} catch (Error& e) {
 		if (!canReplyWith(e)) {
 			TraceEvent(SevWarn, "RefreshEKsError").error(e);
@@ -685,7 +691,7 @@ ACTOR Future<Void> refreshEncryptionKeysCore(Reference<EncryptKeyProxyData> ekpP
 }
 
 Future<Void> refreshEncryptionKeys(Reference<EncryptKeyProxyData> ekpProxyData, KmsConnectorInterface kmsConnectorInf) {
-	return refreshEncryptionKeysCore(ekpProxyData, kmsConnectorInf);
+	return refreshEncryptionKeysImpl(ekpProxyData, kmsConnectorInf);
 }
 
 ACTOR Future<Void> getLatestBlobMetadata(Reference<EncryptKeyProxyData> ekpProxyData,
@@ -775,7 +781,7 @@ ACTOR Future<Void> refreshBlobMetadataCore(Reference<EncryptKeyProxyData> ekpPro
 	state UID debugId = deterministicRandom()->randomUniqueID();
 	state double startTime;
 
-	state TraceEvent t("RefreshBlobMetadata_Start", ekpProxyData->myId);
+	state TraceEvent t("RefreshBlobMetadataStart", ekpProxyData->myId);
 	t.setMaxEventLength(SERVER_KNOBS->ENCRYPT_PROXY_MAX_DBG_TRACE_LENGTH);
 	t.detail("KmsConnInf", kmsConnectorInf.id());
 	t.detail("DebugId", debugId);
@@ -817,7 +823,7 @@ ACTOR Future<Void> refreshBlobMetadataCore(Reference<EncryptKeyProxyData> ekpPro
 		t.detail("nKeys", rep.metadataDetails.size());
 	} catch (Error& e) {
 		if (!canReplyWith(e)) {
-			TraceEvent("RefreshBlobMetadata_Error").error(e);
+			TraceEvent("RefreshBlobMetadataError").error(e);
 			throw e;
 		}
 		TraceEvent("RefreshBlobMetadata").detail("ErrorCode", e.code());
@@ -832,24 +838,25 @@ void refreshBlobMetadata(Reference<EncryptKeyProxyData> ekpProxyData, KmsConnect
 }
 
 void activateKmsConnector(Reference<EncryptKeyProxyData> ekpProxyData, KmsConnectorInterface kmsConnectorInf) {
-	if (g_network->isSimulated() || (SERVER_KNOBS->KMS_CONNECTOR_TYPE.compare(FDB_PREF_KMS_CONNECTOR_TYPE_STR) == 0)) {
-		ekpProxyData->kmsConnector = std::make_unique<SimKmsConnector>();
+	if (g_network->isSimulated()) {
+		ekpProxyData->kmsConnector = std::make_unique<SimKmsConnector>(FDB_SIM_KMS_CONNECTOR_TYPE_STR);
+	} else if (SERVER_KNOBS->KMS_CONNECTOR_TYPE.compare(FDB_PREF_KMS_CONNECTOR_TYPE_STR) == 0) {
+		ekpProxyData->kmsConnector = std::make_unique<SimKmsConnector>(FDB_PREF_KMS_CONNECTOR_TYPE_STR);
 	} else if (SERVER_KNOBS->KMS_CONNECTOR_TYPE.compare(REST_KMS_CONNECTOR_TYPE_STR) == 0) {
-		ekpProxyData->kmsConnector = std::make_unique<RESTKmsConnector>();
+		ekpProxyData->kmsConnector = std::make_unique<RESTKmsConnector>(REST_KMS_CONNECTOR_TYPE_STR);
 	} else {
 		throw not_implemented();
 	}
 
 	TraceEvent("EKPActiveKmsConnector", ekpProxyData->myId)
-	    .detail("ConnectorType",
-	            g_network->isSimulated() ? FDB_SIM_KMS_CONNECTOR_TYPE_STR : SERVER_KNOBS->KMS_CONNECTOR_TYPE)
+	    .detail("ConnectorType", ekpProxyData->kmsConnector->getConnectorStr())
 	    .detail("InfId", kmsConnectorInf.id());
 
 	ekpProxyData->addActor.send(ekpProxyData->kmsConnector->connectorCore(kmsConnectorInf));
 }
 
 ACTOR Future<Void> encryptKeyProxyServer(EncryptKeyProxyInterface ekpInterface, Reference<AsyncVar<ServerDBInfo>> db) {
-	state Reference<EncryptKeyProxyData> self(new EncryptKeyProxyData(ekpInterface.id()));
+	state Reference<EncryptKeyProxyData> self = makeReference<EncryptKeyProxyData>(ekpInterface.id());
 	state Future<Void> collection = actorCollection(self->addActor.getFuture());
 	self->addActor.send(traceRole(Role::ENCRYPT_KEY_PROXY, ekpInterface.id()));
 

--- a/fdbserver/SimKmsConnector.actor.cpp
+++ b/fdbserver/SimKmsConnector.actor.cpp
@@ -18,13 +18,14 @@
  * limitations under the License.
  */
 
-#include "fdbserver/SimKmsConnector.h"
-
-#include "fmt/format.h"
-#include "fdbrpc/sim_validation.h"
 #include "fdbclient/BlobCipher.h"
+
+#include "fdbrpc/sim_validation.h"
+
 #include "fdbserver/KmsConnectorInterface.h"
 #include "fdbserver/Knobs.h"
+#include "fdbserver/SimKmsConnector.h"
+
 #include "flow/ActorCollection.h"
 #include "flow/Arena.h"
 #include "flow/EncryptUtils.h"
@@ -37,6 +38,8 @@
 #include "flow/flow.h"
 #include "flow/network.h"
 #include "flow/UnitTest.h"
+
+#include "fmt/format.h"
 
 #include <limits>
 #include <memory>
@@ -116,7 +119,7 @@ ACTOR Future<Void> ekLookupByIds(Reference<SimKmsConnectorContext> ctx,
 	const int64_t defaultTtl = FLOW_KNOBS->ENCRYPT_CIPHER_KEY_CACHE_TTL;
 	Optional<int64_t> refAtTS = getRefreshInterval(currTS, defaultTtl);
 	Optional<int64_t> expAtTS = getExpireInterval(refAtTS, defaultTtl);
-	TraceEvent("SimKms.EKLookupById").detail("RefreshAt", refAtTS).detail("ExpireAt", expAtTS);
+	TraceEvent("SimKmsEKLookupById").detail("RefreshAt", refAtTS).detail("ExpireAt", expAtTS);
 	for (const auto& item : req.encryptKeyInfos) {
 		const auto& itr = ctx->simEncryptKeyStore.find(item.baseCipherId);
 		if (itr != ctx->simEncryptKeyStore.end()) {
@@ -136,9 +139,7 @@ ACTOR Future<Void> ekLookupByIds(Reference<SimKmsConnectorContext> ctx,
 	}
 
 	wait(delayJittered(1.0)); // simulate network delay
-
 	success ? req.reply.send(rep) : req.reply.sendError(encrypt_key_not_found());
-
 	return Void();
 }
 
@@ -162,8 +163,14 @@ ACTOR Future<Void> ekLookupByDomainIds(Reference<SimKmsConnectorContext> ctx,
 	const int64_t defaultTtl = FLOW_KNOBS->ENCRYPT_CIPHER_KEY_CACHE_TTL;
 	Optional<int64_t> refAtTS = getRefreshInterval(currTS, defaultTtl);
 	Optional<int64_t> expAtTS = getExpireInterval(refAtTS, defaultTtl);
-	TraceEvent("SimKms.EKLookupByDomainId").detail("RefreshAt", refAtTS).detail("ExpireAt", expAtTS);
+	TraceEvent("SimKmsEKLookupByDomainId").detail("RefreshAt", refAtTS).detail("ExpireAt", expAtTS);
 	for (const auto& info : req.encryptDomainInfos) {
+		// Ensure domainIds are acceptable
+		if (info.domainId < FDB_DEFAULT_ENCRYPT_DOMAIN_ID) {
+			success = false;
+			break;
+		}
+
 		EncryptCipherBaseKeyId keyId = 1 + abs(info.domainId) % SERVER_KNOBS->SIM_KMS_MAX_KEYS;
 		const auto& itr = ctx->simEncryptKeyStore.find(keyId);
 		if (itr != ctx->simEncryptKeyStore.end()) {
@@ -175,15 +182,14 @@ ACTOR Future<Void> ekLookupByDomainIds(Reference<SimKmsConnectorContext> ctx,
 				    getEncryptDbgTraceKey(ENCRYPT_DBG_TRACE_RESULT_PREFIX, info.domainId, info.domainName, keyId), "");
 			}
 		} else {
+			TraceEvent("SimKmsEKLookupByDomainIdKeyNotFound").detail("DomId", info.domainId);
 			success = false;
 			break;
 		}
 	}
 
 	wait(delayJittered(1.0)); // simulate network delay
-
 	success ? req.reply.send(rep) : req.reply.sendError(encrypt_key_not_found());
-
 	return Void();
 }
 // TODO: switch this to use bg_url instead of hardcoding file://fdbblob, so it works as FDBPerfKmsConnector
@@ -273,8 +279,8 @@ ACTOR Future<Void> blobMetadataLookup(KmsConnectorInterface interf, KmsConnBlobM
 	return Void();
 }
 
-ACTOR Future<Void> simKmsConnectorCore_impl(KmsConnectorInterface interf) {
-	TraceEvent("SimEncryptKmsProxy_Init", interf.id()).detail("MaxEncryptKeys", SERVER_KNOBS->SIM_KMS_MAX_KEYS);
+ACTOR Future<Void> simconnectorCoreImpl(KmsConnectorInterface interf) {
+	TraceEvent("SimEncryptKmsProxyInit", interf.id()).detail("MaxEncryptKeys", SERVER_KNOBS->SIM_KMS_MAX_KEYS);
 
 	state Reference<SimKmsConnectorContext> ctx = makeReference<SimKmsConnectorContext>(SERVER_KNOBS->SIM_KMS_MAX_KEYS);
 
@@ -282,7 +288,6 @@ ACTOR Future<Void> simKmsConnectorCore_impl(KmsConnectorInterface interf) {
 
 	state PromiseStream<Future<Void>> addActor;
 	state Future<Void> collection = actorCollection(addActor.getFuture());
-
 	loop {
 		choose {
 			when(KmsConnLookupEKsByKeyIdsReq req = waitNext(interf.ekLookupByIds.getFuture())) {
@@ -294,12 +299,16 @@ ACTOR Future<Void> simKmsConnectorCore_impl(KmsConnectorInterface interf) {
 			when(KmsConnBlobMetadataReq req = waitNext(interf.blobMetadataReq.getFuture())) {
 				addActor.send(blobMetadataLookup(interf, req));
 			}
+			when(wait(collection)) {
+				// this should throw an error, not complete
+				ASSERT(false);
+			}
 		}
 	}
 }
 
 Future<Void> SimKmsConnector::connectorCore(KmsConnectorInterface interf) {
-	return simKmsConnectorCore_impl(interf);
+	return simconnectorCoreImpl(interf);
 }
 void forceLinkSimKmsConnectorTests() {}
 
@@ -377,7 +386,7 @@ ACTOR Future<Void> testRunWorkload(KmsConnectorInterface inf, uint32_t nEncrypti
 TEST_CASE("fdbserver/SimKmsConnector") {
 	state KmsConnectorInterface inf;
 	state uint32_t maxEncryptKeys = 64;
-	state SimKmsConnector connector;
+	state SimKmsConnector connector("SimKmsConnector");
 
 	loop choose {
 		when(wait(connector.connectorCore(inf))) { throw internal_error(); }

--- a/fdbserver/include/fdbserver/KmsConnector.h
+++ b/fdbserver/include/fdbserver/KmsConnector.h
@@ -34,10 +34,15 @@
 
 class KmsConnector : public NonCopyable {
 public:
-	KmsConnector() {}
+	KmsConnector(const std::string& conStr) : connectorStr(conStr) {}
 	virtual ~KmsConnector() {}
 
 	virtual Future<Void> connectorCore(struct KmsConnectorInterface interf) = 0;
+
+	std::string getConnectorStr() const { return connectorStr; }
+
+protected:
+	std::string connectorStr;
 };
 
 #endif

--- a/fdbserver/include/fdbserver/RESTKmsConnector.h
+++ b/fdbserver/include/fdbserver/RESTKmsConnector.h
@@ -26,7 +26,7 @@
 
 class RESTKmsConnector : public KmsConnector {
 public:
-	RESTKmsConnector() = default;
+	RESTKmsConnector(const std::string& conStr) : KmsConnector(conStr) {}
 	Future<Void> connectorCore(KmsConnectorInterface interf);
 };
 

--- a/fdbserver/include/fdbserver/SimKmsConnector.h
+++ b/fdbserver/include/fdbserver/SimKmsConnector.h
@@ -27,7 +27,7 @@
 
 class SimKmsConnector : public KmsConnector {
 public:
-	SimKmsConnector() = default;
+	SimKmsConnector(const std::string& conStr) : KmsConnector(conStr) {}
 	Future<Void> connectorCore(KmsConnectorInterface interf);
 };
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -152,7 +152,6 @@ if(WITH_PYTHON)
   add_fdb_test(TEST_FILES fast/ChangeFeedOperationsMove.toml)
   add_fdb_test(TEST_FILES fast/DataLossRecovery.toml)
   add_fdb_test(TEST_FILES fast/EncryptionOps.toml)
-  # TODO: fix failures and renable the test
   add_fdb_test(TEST_FILES fast/EncryptKeyProxyTest.toml)
   add_fdb_test(TEST_FILES fast/FuzzApiCorrectness.toml)
   add_fdb_test(TEST_FILES fast/FuzzApiCorrectnessClean.toml)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -153,7 +153,7 @@ if(WITH_PYTHON)
   add_fdb_test(TEST_FILES fast/DataLossRecovery.toml)
   add_fdb_test(TEST_FILES fast/EncryptionOps.toml)
   # TODO: fix failures and renable the test
-  add_fdb_test(TEST_FILES fast/EncryptKeyProxyTest.toml IGNORE)
+  add_fdb_test(TEST_FILES fast/EncryptKeyProxyTest.toml)
   add_fdb_test(TEST_FILES fast/FuzzApiCorrectness.toml)
   add_fdb_test(TEST_FILES fast/FuzzApiCorrectnessClean.toml)
   add_fdb_test(TEST_FILES fast/IncrementalBackup.toml)


### PR DESCRIPTION
Description

Major changes include:
1. Enable EncryptKeyProxyTest, the test was modified to leverage GetEncryptCipherKey actor, as existing code wouldn't work if EKP process gets restarted while test is running.
2. Add code probes to EKP
3. Minor refactoring.

Testing

EncryptKeyProxyTest - 100K

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
