### PR TITLE
Encryption: fix potential deadlock on cluster restart

### DIFF
--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -2434,8 +2434,7 @@ ACTOR Future<Void> startEncryptKeyProxy(ClusterControllerData* self, double wait
 			// hence, the process only waits for the master recruitment and not the full cluster recovery.
 			state bool noEncryptKeyServer = !self->db.serverInfo->get().encryptKeyProxy.present();
 			while (!self->masterProcessId.present() ||
-			       self->masterProcessId != self->db.serverInfo->get().master.locality.processId() ||
-			       self->db.serverInfo->get().recoveryState < RecoveryState::LOCKING_CSTATE) {
+			       self->masterProcessId != self->db.serverInfo->get().master.locality.processId()) {
 				wait(self->db.serverInfo->onChange() || delay(SERVER_KNOBS->WAIT_FOR_GOOD_RECRUITMENT_DELAY));
 			}
 			if (noEncryptKeyServer && self->db.serverInfo->get().encryptKeyProxy.present()) {

--- a/fdbserver/worker.actor.cpp
+++ b/fdbserver/worker.actor.cpp
@@ -3363,7 +3363,14 @@ ACTOR Future<Void> monitorLeaderWithDelayedCandidacy(
 	state Future<Void> monitor = monitorLeaderWithDelayedCandidacyImpl(connRecord, currentCC);
 	state Future<Void> timeout;
 
-	wait(recoveredDiskFiles);
+	// When encryption is enabled, and if the worker is a storage node, it needs to get the cluster controller
+	// interface in order to further obtain the updated EncryptKeyProxy interface to open local storage engine.
+	// Waiting for recoveredDiskFiles here will prevent the worker receive cluster controller interface,
+	// and create a deadlock.
+	// TODO(yiwu): can we remove the wait even when encryption is not enabled?
+	if (!SERVER_KNOBS->ENABLE_ENCRYPTION) {
+		wait(recoveredDiskFiles);
+	}
 
 	loop {
 		if (currentCC->get().present() && dbInfo->get().clusterInterface == currentCC->get().get() &&


### PR DESCRIPTION
There's a deadlock on FDB cluster restart when encryption is enabled, if there are worker servers have both of TLog role and storage server role, where:
(1) These workers waits on `recoveredDiskFiles` promise before monitor and receiving CC interface
(2) `recoveredDiskFiles` blocked on local storage engine being opened, which is waiting for EKP (EncryptKeyProxy) being available
(3) EKP is not recruited for waiting for cluster recovery reaching LOCKING_CSTATE.
(4) The master does not receive updated cluster recovery state due to no enough TLogs being recruited.

If we remove the EKP's wait on LOCKING_CSTATE, EKP will be able to be recruited. However it does not break the deadlock, because the updated EKP interface in ServerDBInfo it not being broadcast to the workers in (1) since they haven't got the CC interface. To break the deadlock, these worker servers should be not waiting for `recoveredDiskFiles`.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
