### PR TITLE
Add Options to restore user/system keys in backup agent

### DIFF
--- a/documentation/sphinx/source/backups.rst
+++ b/documentation/sphinx/source/backups.rst
@@ -525,7 +525,7 @@ The ``start`` command will start a new restore on the specified (or default) tag
   Ignore mutation log files during the restore to speedup the process. Because only range files are restored, this option gives an inconsistent snapshot in most cases and is not recommended to use.
 
 ``--user_data``
-  Restore only the user keyspace. This option should NOT be used alongside --system_metadata (below) and CANNOT be used alongside other specified key ranges
+  Restore only the user keyspace. This option should NOT be used alongside --system-metadata (below) and CANNOT be used alongside other specified key ranges.
 
 ``--system_data``
   Restore only the relevant system keyspace (currently only tenant metadata). This option should NOT be used alongside --user_data (above) and CANNOT be used alongside other specified key ranges

--- a/documentation/sphinx/source/backups.rst
+++ b/documentation/sphinx/source/backups.rst
@@ -527,7 +527,7 @@ The ``start`` command will start a new restore on the specified (or default) tag
 ``--user-data``
   Restore only the user keyspace. This option should NOT be used alongside --system-metadata (below) and CANNOT be used alongside other specified key ranges.
 
-``--system_data``
+``--system-metadata``
   Restore only the relevant system keyspace (currently only tenant metadata). This option should NOT be used alongside --user-data (above) and CANNOT be used alongside other specified key ranges.
 
 .. program:: fdbrestore abort

--- a/documentation/sphinx/source/backups.rst
+++ b/documentation/sphinx/source/backups.rst
@@ -524,6 +524,12 @@ The ``start`` command will start a new restore on the specified (or default) tag
 ``--inconsistent-snapshot-only``
   Ignore mutation log files during the restore to speedup the process. Because only range files are restored, this option gives an inconsistent snapshot in most cases and is not recommended to use.
 
+``--user_data``
+  Restore only the user keyspace. This option should NOT be used alongside --system_metadata (below) and CANNOT be used alongside other specified key ranges
+
+``--system_data``
+  Restore only the relevant system keyspace (currently only tenant metadata). This option should NOT be used alongside --user_data (above) and CANNOT be used alongside other specified key ranges
+
 .. program:: fdbrestore abort
 
 ``abort``

--- a/documentation/sphinx/source/backups.rst
+++ b/documentation/sphinx/source/backups.rst
@@ -524,7 +524,7 @@ The ``start`` command will start a new restore on the specified (or default) tag
 ``--inconsistent-snapshot-only``
   Ignore mutation log files during the restore to speedup the process. Because only range files are restored, this option gives an inconsistent snapshot in most cases and is not recommended to use.
 
-``--user_data``
+``--user-data``
   Restore only the user keyspace. This option should NOT be used alongside --system-metadata (below) and CANNOT be used alongside other specified key ranges.
 
 ``--system_data``

--- a/documentation/sphinx/source/backups.rst
+++ b/documentation/sphinx/source/backups.rst
@@ -528,7 +528,7 @@ The ``start`` command will start a new restore on the specified (or default) tag
   Restore only the user keyspace. This option should NOT be used alongside --system-metadata (below) and CANNOT be used alongside other specified key ranges.
 
 ``--system-metadata``
-  Restore only the relevant system keyspace (currently only tenant metadata). This option should NOT be used alongside --user-data (above) and CANNOT be used alongside other specified key ranges.
+  Restore only the relevant system keyspace. This option should NOT be used alongside --user-data (above) and CANNOT be used alongside other specified key ranges.
 
 .. program:: fdbrestore abort
 

--- a/documentation/sphinx/source/backups.rst
+++ b/documentation/sphinx/source/backups.rst
@@ -528,7 +528,7 @@ The ``start`` command will start a new restore on the specified (or default) tag
   Restore only the user keyspace. This option should NOT be used alongside --system-metadata (below) and CANNOT be used alongside other specified key ranges.
 
 ``--system_data``
-  Restore only the relevant system keyspace (currently only tenant metadata). This option should NOT be used alongside --user_data (above) and CANNOT be used alongside other specified key ranges
+  Restore only the relevant system keyspace (currently only tenant metadata). This option should NOT be used alongside --user-data (above) and CANNOT be used alongside other specified key ranges.
 
 .. program:: fdbrestore abort
 

--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -47,6 +47,7 @@
 #include "fdbclient/IKnobCollection.h"
 #include "fdbclient/RunTransaction.actor.h"
 #include "fdbclient/S3BlobStore.h"
+#include "fdbclient/SystemData.h"
 #include "fdbclient/json_spirit/json_spirit_writer_template.h"
 
 #include "flow/Platform.h"
@@ -155,6 +156,8 @@ enum {
 	OPT_RESTORE_CLUSTERFILE_ORIG,
 	OPT_RESTORE_BEGIN_VERSION,
 	OPT_RESTORE_INCONSISTENT_SNAPSHOT_ONLY,
+	OPT_RESTORE_USER_DATA,
+	OPT_RESTORE_SYSTEM_DATA,
 
 	// Shared constants
 	OPT_CLUSTERFILE,
@@ -696,6 +699,8 @@ CSimpleOpt::SOption g_rgRestoreOptions[] = {
 	{ OPT_BACKUPKEYS, "--keys", SO_REQ_SEP },
 	{ OPT_WAITFORDONE, "-w", SO_NONE },
 	{ OPT_WAITFORDONE, "--waitfordone", SO_NONE },
+	{ OPT_RESTORE_USER_DATA, "--user-data", SO_NONE },
+	{ OPT_RESTORE_SYSTEM_DATA, "--system-metadata", SO_NONE },
 	{ OPT_RESTORE_VERSION, "--version", SO_REQ_SEP },
 	{ OPT_RESTORE_VERSION, "-v", SO_REQ_SEP },
 	{ OPT_TRACE, "--log", SO_NONE },
@@ -1187,6 +1192,13 @@ static void printRestoreUsage(bool devhelp) {
 	printf("                 The cluster file for the original database from which the backup was created.  The "
 	       "original database\n");
 	printf("                 is only needed to convert a --timestamp argument to a database version.\n");
+	printf("  --user-data"
+	       "                  Restore only the user keyspace. This option should NOT be used alongside "
+	       "--system-metadata (below) and CANNOT be used alongside other specified key ranges.\n");
+	printf(
+	    "  --system-metadata"
+	    "                 Restore only the relevant system keyspace (currently only tenant metadata). This option "
+	    "should NOT be used alongside --user-data (above) and CANNOT be used alongside other specified key ranges.\n");
 
 	if (devhelp) {
 #ifdef _WIN32
@@ -3367,6 +3379,8 @@ int main(int argc, char* argv[]) {
 		bool trace = false;
 		bool quietDisplay = false;
 		bool dryRun = false;
+		bool restoreSystemKeys = false;
+		bool restoreUserKeys = false;
 		// TODO (Nim): Set this value when we add optional encrypt_files CLI argument to backup agent start
 		bool encryptionEnabled = true;
 		std::string traceDir = "";
@@ -3691,6 +3705,14 @@ int main(int argc, char* argv[]) {
 				restoreVersion = ver;
 				break;
 			}
+			case OPT_RESTORE_USER_DATA: {
+				restoreUserKeys = true;
+				break;
+			}
+			case OPT_RESTORE_SYSTEM_DATA: {
+				restoreSystemKeys = true;
+				break;
+			}
 			case OPT_RESTORE_INCONSISTENT_SNAPSHOT_ONLY: {
 				inconsistentSnapshotOnly.set(true);
 				break;
@@ -3838,6 +3860,11 @@ int main(int argc, char* argv[]) {
 			}
 		}
 
+		if (restoreSystemKeys && restoreUserKeys) {
+			fprintf(stderr, "ERROR: Please only specify one of: --user-data or --system-metadata not both\n");
+			return FDB_EXIT_ERROR;
+		}
+
 		if (trace) {
 			if (!traceLogGroup.empty())
 				setNetworkOption(FDBNetworkOptions::TRACE_LOG_GROUP, StringRef(traceLogGroup));
@@ -3938,8 +3965,14 @@ int main(int argc, char* argv[]) {
 
 		// The fastrestore tool does not yet support multiple ranges and is incompatible with tenants
 		// or other features that back up data in the system keys
-		if (backupKeys.empty() && programExe != ProgramExe::FASTRESTORE_TOOL) {
+		if (!restoreSystemKeys && !restoreUserKeys && backupKeys.empty() &&
+		    programExe != ProgramExe::FASTRESTORE_TOOL) {
 			addDefaultBackupRanges(backupKeys);
+		}
+
+		if ((restoreSystemKeys || restoreUserKeys) && programExe == ProgramExe::FASTRESTORE_TOOL) {
+			fprintf(stderr, "ERROR: Options: --user-data and --system-metadata are not supported with fastrestore\n");
+			return FDB_EXIT_ERROR;
 		}
 
 		switch (programExe) {
@@ -4135,6 +4168,19 @@ int main(int argc, char* argv[]) {
 
 			switch (restoreType) {
 			case RestoreType::START:
+				if ((restoreUserKeys || restoreSystemKeys) && !backupKeys.empty()) {
+					fprintf(stderr,
+					        "ERROR: Cannot specify additional ranges when using: --user-data or --system-metadata "
+					        "options\n");
+					return FDB_EXIT_ERROR;
+				}
+				if (restoreUserKeys) {
+					backupKeys.push_back_deep(backupKeys.arena(), normalKeys);
+				} else if (restoreSystemKeys) {
+					for (const auto& r : getSystemBackupRanges()) {
+						backupKeys.push_back_deep(backupKeys.arena(), r);
+					}
+				}
 				f = stopAfter(runRestore(db,
 				                         restoreClusterFileOrig,
 				                         tagName,

--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -156,6 +156,9 @@ enum {
 	OPT_RESTORE_CLUSTERFILE_ORIG,
 	OPT_RESTORE_BEGIN_VERSION,
 	OPT_RESTORE_INCONSISTENT_SNAPSHOT_ONLY,
+	// The two restore options below allow callers of fdbrestore to divide a normal restore into one which restores just
+	// the system keyspace and another that restores just the user key space. This is unlike the backup command where
+	// all keys (both system and user) will be backed up together
 	OPT_RESTORE_USER_DATA,
 	OPT_RESTORE_SYSTEM_DATA,
 
@@ -1192,11 +1195,11 @@ static void printRestoreUsage(bool devhelp) {
 	printf("                 The cluster file for the original database from which the backup was created.  The "
 	       "original database\n");
 	printf("                 is only needed to convert a --timestamp argument to a database version.\n");
-	printf("  --user-data"
+	printf("  --user-data\n"
 	       "                  Restore only the user keyspace. This option should NOT be used alongside "
 	       "--system-metadata (below) and CANNOT be used alongside other specified key ranges.\n");
 	printf(
-	    "  --system-metadata"
+	    "  --system-metadata\n"
 	    "                 Restore only the relevant system keyspace (currently only tenant metadata). This option "
 	    "should NOT be used alongside --user-data (above) and CANNOT be used alongside other specified key ranges.\n");
 

--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -4173,7 +4173,7 @@ int main(int argc, char* argv[]) {
 			case RestoreType::START:
 				if ((restoreUserKeys || restoreSystemKeys) && !backupKeys.empty()) {
 					fprintf(stderr,
-					        "ERROR: Cannot specify additional ranges when using: --user-data or --system-metadata "
+					        "ERROR: Cannot specify additional ranges when using --user-data or --system-metadata "
 					        "options\n");
 					return FDB_EXIT_ERROR;
 				}

--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -3864,7 +3864,7 @@ int main(int argc, char* argv[]) {
 		}
 
 		if (restoreSystemKeys && restoreUserKeys) {
-			fprintf(stderr, "ERROR: Please only specify one of: --user-data or --system-metadata not both\n");
+			fprintf(stderr, "ERROR: Please only specify one of --user-data or --system-metadata, not both\n");
 			return FDB_EXIT_ERROR;
 		}
 


### PR DESCRIPTION
Currently we need a way to restore tenant metadata before restoring user data, otherwise we encounter errors in the storage server when encryption is enabled. This PR adds `--user-data` and `system-metadata` options to the `fdbrestore` CLI utility to make it easier to restore tenant (system) and user data separately.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
