### PR TITLE
Cancel watch when the key is not being waited

### DIFF
--- a/fdbclient/DatabaseContext.cpp
+++ b/fdbclient/DatabaseContext.cpp
@@ -1,0 +1,82 @@
+/*
+ * DatabaseContext.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "fdbclient/DatabaseContext.h"
+
+Reference<WatchMetadata> DatabaseContext::getWatchMetadata(int64_t tenantId, KeyRef key) const {
+	const auto it = watchMap.find(std::make_pair(tenantId, key));
+	if (it == watchMap.end())
+		return Reference<WatchMetadata>();
+	return it->second;
+}
+
+void DatabaseContext::setWatchMetadata(Reference<WatchMetadata> metadata) {
+	const WatchMapKey key(metadata->parameters->tenant.tenantId, metadata->parameters->key);
+	watchMap[key] = metadata;
+	// NOTE Here we do *NOT* update/reset the reference count for the key, see the source code in getWatchFuture.
+	// Basically the reference count could be increased, or the same watch is refreshed, or the watch might be cancelled
+}
+
+int32_t DatabaseContext::increaseWatchRefCount(const int64_t tenantID, KeyRef key, const Version& version) {
+	const WatchMapKey mapKey(tenantID, key);
+	watchCounterMap[mapKey].insert(version);
+	return watchCounterMap[mapKey].size();
+}
+
+int32_t DatabaseContext::decreaseWatchRefCount(const int64_t tenantID, KeyRef key, const Version& version) {
+	const WatchMapKey mapKey(tenantID, key);
+	auto mapKeyIter = watchCounterMap.find(mapKey);
+	if (mapKeyIter == std::end(watchCounterMap)) {
+		// Key does not exist. The metadata might be removed by deleteWatchMetadata already.
+		return 0;
+	}
+
+	auto& versionSet = mapKeyIter->second;
+	auto versionIter = versionSet.find(version);
+
+	if (versionIter == std::end(versionSet)) {
+		// Version not found, the watch might be cleared before.
+		return versionSet.size();
+	}
+	versionSet.erase(versionIter);
+
+	const auto count = versionSet.size();
+	// The metadata might be deleted somewhere else, before calling this decreaseWatchRefCount
+	if (auto metadata = getWatchMetadata(tenantID, key); metadata.isValid() && versionSet.size() == 0) {
+		// It is a *must* to cancel the watchFutureSS manually. watchFutureSS waits for watchStorageServerResp, which
+		// holds a reference to the metadata. If the ACTOR is not cancelled, it indirectly holds a Future waiting for
+		// itself.
+		metadata->watchFutureSS.cancel();
+		deleteWatchMetadata(tenantID, key);
+	}
+
+	return count;
+}
+
+void DatabaseContext::deleteWatchMetadata(int64_t tenantId, KeyRef key) {
+	const WatchMapKey mapKey(tenantId, key);
+	watchMap.erase(mapKey);
+	watchCounterMap.erase(mapKey);
+}
+
+void DatabaseContext::clearWatchMetadata() {
+	watchMap.clear();
+	watchCounterMap.clear();
+}

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -2171,14 +2171,14 @@ void DatabaseContext::setOption(FDBDatabaseOptions::Option option, Optional<Stri
 	}
 }
 
-void DatabaseContext::addWatch() {
+void DatabaseContext::addWatchCounter() {
 	if (outstandingWatches >= maxOutstandingWatches)
 		throw too_many_watches();
 
 	++outstandingWatches;
 }
 
-void DatabaseContext::removeWatch() {
+void DatabaseContext::removeWatchCounter() {
 	--outstandingWatches;
 	ASSERT(outstandingWatches >= 0);
 }
@@ -2398,15 +2398,44 @@ Reference<WatchMetadata> DatabaseContext::getWatchMetadata(int64_t tenantId, Key
 }
 
 void DatabaseContext::setWatchMetadata(Reference<WatchMetadata> metadata) {
-	watchMap[std::make_pair(metadata->parameters->tenant.tenantId, metadata->parameters->key)] = metadata;
+	const WatchMapKey key(metadata->parameters->tenant.tenantId, metadata->parameters->key);
+	watchMap[key] = metadata;
+	// NOTE Here we do *NOT* update/reset the reference count for the key, see the source code in getWatchFuture
+}
+
+int32_t DatabaseContext::increaseWatchRefCount(const int64_t tenantID, KeyRef key) {
+	const WatchMapKey mapKey(tenantID, key);
+	if (watchCounterMap.count(mapKey) == 0) {
+		watchCounterMap[mapKey] = 0;
+	}
+	const auto count = ++watchCounterMap[mapKey];
+	return count;
+}
+
+int32_t DatabaseContext::decreaseWatchRefCount(const int64_t tenantID, KeyRef key) {
+	const WatchMapKey mapKey(tenantID, key);
+	if (watchCounterMap.count(mapKey) == 0) {
+		// Key does not exist. The metadata might be removed by deleteWatchMetadata already.
+		return 0;
+	}
+	const auto count = --watchCounterMap[mapKey];
+	ASSERT(watchCounterMap[mapKey] >= 0);
+	if (watchCounterMap[mapKey] == 0) {
+		getWatchMetadata(tenantID, key)->watchFutureSS.cancel();
+		deleteWatchMetadata(tenantID, key);
+	}
+	return count;
 }
 
 void DatabaseContext::deleteWatchMetadata(int64_t tenantId, KeyRef key) {
-	watchMap.erase(std::make_pair(tenantId, key));
+	const WatchMapKey mapKey(tenantId, key);
+	watchMap.erase(mapKey);
+	watchCounterMap.erase(mapKey);
 }
 
 void DatabaseContext::clearWatchMetadata() {
 	watchMap.clear();
+	watchCounterMap.clear();
 }
 
 const UniqueOrderedOptionList<FDBTransactionOptions>& Database::getTransactionDefaults() const {
@@ -3921,6 +3950,56 @@ Future<Void> getWatchFuture(Database cx, Reference<WatchParameters> parameters) 
 	return Void();
 }
 
+namespace {
+
+// NOTE: Since an ACTOR could receive multiple exceptions for a single catch clause, e.g. broken promise together with
+// operation cancelled, If the decreaseWatchRefCount is placed at the catch clause, it might be triggered for multiple
+// times. One could check if the SAV isSet, but seems a more intuitive way is to use RAII-style constructor/destructor
+// pair. Yet the object has to be constructed after a wait statement, so it must be trivially-constructible. This
+// requires move-assignment operator implemented.
+class WatchRefCountUpdater {
+	Database cx;
+	int64_t tenantID;
+	KeyRef key;
+
+	void tryAddRefCount() {
+		if (cx.getReference()) {
+			cx->increaseWatchRefCount(tenantID, key);
+		}
+	}
+
+	void tryDelRefCount() {
+		if (cx.getReference()) {
+			cx->decreaseWatchRefCount(tenantID, key);
+		}
+	}
+
+public:
+	WatchRefCountUpdater() {}
+
+	WatchRefCountUpdater(const Database& cx_, const int64_t tenantID_, KeyRef key_)
+	  : cx(cx_), tenantID(tenantID_), key(key_) {
+		tryAddRefCount();
+	}
+
+	WatchRefCountUpdater& operator=(WatchRefCountUpdater&& other) {
+		tryDelRefCount();
+
+		// NOTE: Do not use move semantic, this copy allows other delete the reference count properly.
+		cx = other.cx;
+		tenantID = other.tenantID;
+		key = other.key;
+
+		tryAddRefCount();
+
+		return *this;
+	}
+
+	~WatchRefCountUpdater() { tryDelRefCount(); }
+};
+
+} // namespace
+
 ACTOR Future<Void> watchValueMap(Future<Version> version,
                                  TenantInfo tenant,
                                  Key key,
@@ -3932,6 +4011,7 @@ ACTOR Future<Void> watchValueMap(Future<Version> version,
                                  Optional<UID> debugID,
                                  UseProvisionalProxies useProvisionalProxies) {
 	state Version ver = wait(version);
+	state WatchRefCountUpdater watchRefCountUpdater(cx, tenant.tenantId, key);
 
 	wait(getWatchFuture(cx,
 	                    makeReference<WatchParameters>(
@@ -5464,11 +5544,11 @@ ACTOR Future<Void> watch(Reference<Watch> watch,
 			}
 		}
 	} catch (Error& e) {
-		cx->removeWatch();
+		cx->removeWatchCounter();
 		throw;
 	}
 
-	cx->removeWatch();
+	cx->removeWatchCounter();
 	return Void();
 }
 
@@ -5479,7 +5559,7 @@ Future<Version> Transaction::getRawReadVersion() {
 Future<Void> Transaction::watch(Reference<Watch> watch) {
 	++trState->cx->transactionWatchRequests;
 
-	trState->cx->addWatch();
+	trState->cx->addWatchCounter();
 	watches.push_back(watch);
 	return ::watch(
 	    watch,

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -3916,7 +3916,7 @@ class WatchRefCountUpdater {
 	Version version;
 
 public:
-	WatchRefCountUpdater() {}
+	WatchRefCountUpdater() = default;
 
 	WatchRefCountUpdater(const Database& cx_, const int64_t tenantID_, KeyRef key_, const Version& ver)
 	  : cx(cx_), tenantID(tenantID_), key(key_), version(ver) {}

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -5434,26 +5434,17 @@ ACTOR Future<Void> restartWatch(Database cx,
 		tenantInfo.tenantId = locationInfo.tenantEntry.id;
 	}
 
-	if (key == "anotherKey"_sr)
-		std::cout << cx->dbId.toString() << " restartWatch" << std::endl;
+	wait(watchValueMap(cx->minAcceptableReadVersion,
+	                   tenantInfo,
+	                   key,
+	                   value,
+	                   cx,
+	                   tags,
+	                   spanContext,
+	                   taskID,
+	                   debugID,
+	                   useProvisionalProxies));
 
-	try {
-		wait(watchValueMap(cx->minAcceptableReadVersion,
-		                   tenantInfo,
-		                   key,
-		                   value,
-		                   cx,
-		                   tags,
-		                   spanContext,
-		                   taskID,
-		                   debugID,
-		                   useProvisionalProxies));
-	} catch (Error& err) {
-		std::cout << cx->dbId.toString() << " restartWatch fail " << err.code() << std::endl;
-		return Void();
-	}
-
-	std::cout << cx->dbId.toString() << " restartWatch pass" << std::endl;
 	return Void();
 }
 

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -2390,54 +2390,6 @@ Database Database::createSimulatedExtraDatabase(std::string connectionString, Op
 	return db;
 }
 
-Reference<WatchMetadata> DatabaseContext::getWatchMetadata(int64_t tenantId, KeyRef key) const {
-	const auto it = watchMap.find(std::make_pair(tenantId, key));
-	if (it == watchMap.end())
-		return Reference<WatchMetadata>();
-	return it->second;
-}
-
-void DatabaseContext::setWatchMetadata(Reference<WatchMetadata> metadata) {
-	const WatchMapKey key(metadata->parameters->tenant.tenantId, metadata->parameters->key);
-	watchMap[key] = metadata;
-	// NOTE Here we do *NOT* update/reset the reference count for the key, see the source code in getWatchFuture
-}
-
-int32_t DatabaseContext::increaseWatchRefCount(const int64_t tenantID, KeyRef key) {
-	const WatchMapKey mapKey(tenantID, key);
-	if (watchCounterMap.count(mapKey) == 0) {
-		watchCounterMap[mapKey] = 0;
-	}
-	const auto count = ++watchCounterMap[mapKey];
-	return count;
-}
-
-int32_t DatabaseContext::decreaseWatchRefCount(const int64_t tenantID, KeyRef key) {
-	const WatchMapKey mapKey(tenantID, key);
-	if (watchCounterMap.count(mapKey) == 0) {
-		// Key does not exist. The metadata might be removed by deleteWatchMetadata already.
-		return 0;
-	}
-	const auto count = --watchCounterMap[mapKey];
-	ASSERT(watchCounterMap[mapKey] >= 0);
-	if (watchCounterMap[mapKey] == 0) {
-		getWatchMetadata(tenantID, key)->watchFutureSS.cancel();
-		deleteWatchMetadata(tenantID, key);
-	}
-	return count;
-}
-
-void DatabaseContext::deleteWatchMetadata(int64_t tenantId, KeyRef key) {
-	const WatchMapKey mapKey(tenantId, key);
-	watchMap.erase(mapKey);
-	watchCounterMap.erase(mapKey);
-}
-
-void DatabaseContext::clearWatchMetadata() {
-	watchMap.clear();
-	watchCounterMap.clear();
-}
-
 const UniqueOrderedOptionList<FDBTransactionOptions>& Database::getTransactionDefaults() const {
 	ASSERT(db);
 	return db->transactionDefaults;
@@ -3961,41 +3913,35 @@ class WatchRefCountUpdater {
 	Database cx;
 	int64_t tenantID;
 	KeyRef key;
-
-	void tryAddRefCount() {
-		if (cx.getReference()) {
-			cx->increaseWatchRefCount(tenantID, key);
-		}
-	}
-
-	void tryDelRefCount() {
-		if (cx.getReference()) {
-			cx->decreaseWatchRefCount(tenantID, key);
-		}
-	}
+	Version version;
 
 public:
 	WatchRefCountUpdater() {}
 
-	WatchRefCountUpdater(const Database& cx_, const int64_t tenantID_, KeyRef key_)
-	  : cx(cx_), tenantID(tenantID_), key(key_) {
-		tryAddRefCount();
-	}
+	WatchRefCountUpdater(const Database& cx_, const int64_t tenantID_, KeyRef key_, const Version& ver)
+	  : cx(cx_), tenantID(tenantID_), key(key_), version(ver) {}
 
 	WatchRefCountUpdater& operator=(WatchRefCountUpdater&& other) {
-		tryDelRefCount();
+		// Since this class is only used by watchValueMap, and it is used *AFTER* a wait statement, this class is first
+		// initialized by default constructor, then, after the wait, this function is called to assign the actual
+		// database, key, etc., to re-initialize this object. At this stage, the reference count can be increased. And
+		// since the database object is moved, the rvalue will have null reference to the DatabaseContext and will not
+		// reduce the reference count.
+		cx = std::move(other.cx);
+		tenantID = std::move(other.tenantID);
+		key = std::move(other.key);
+		version = std::move(other.version);
 
-		// NOTE: Do not use move semantic, this copy allows other delete the reference count properly.
-		cx = other.cx;
-		tenantID = other.tenantID;
-		key = other.key;
-
-		tryAddRefCount();
+		cx->increaseWatchRefCount(tenantID, key, version);
 
 		return *this;
 	}
 
-	~WatchRefCountUpdater() { tryDelRefCount(); }
+	~WatchRefCountUpdater() {
+		if (cx.getReference()) {
+			cx->decreaseWatchRefCount(tenantID, key, version);
+		}
+	}
 };
 
 } // namespace
@@ -4011,7 +3957,7 @@ ACTOR Future<Void> watchValueMap(Future<Version> version,
                                  Optional<UID> debugID,
                                  UseProvisionalProxies useProvisionalProxies) {
 	state Version ver = wait(version);
-	state WatchRefCountUpdater watchRefCountUpdater(cx, tenant.tenantId, key);
+	state WatchRefCountUpdater watchRefCountUpdater(cx, tenant.tenantId, key, ver);
 
 	wait(getWatchFuture(cx,
 	                    makeReference<WatchParameters>(
@@ -5488,17 +5434,26 @@ ACTOR Future<Void> restartWatch(Database cx,
 		tenantInfo.tenantId = locationInfo.tenantEntry.id;
 	}
 
-	wait(watchValueMap(cx->minAcceptableReadVersion,
-	                   tenantInfo,
-	                   key,
-	                   value,
-	                   cx,
-	                   tags,
-	                   spanContext,
-	                   taskID,
-	                   debugID,
-	                   useProvisionalProxies));
+	if (key == "anotherKey"_sr)
+		std::cout << cx->dbId.toString() << " restartWatch" << std::endl;
 
+	try {
+		wait(watchValueMap(cx->minAcceptableReadVersion,
+		                   tenantInfo,
+		                   key,
+		                   value,
+		                   cx,
+		                   tags,
+		                   spanContext,
+		                   taskID,
+		                   debugID,
+		                   useProvisionalProxies));
+	} catch (Error& err) {
+		std::cout << cx->dbId.toString() << " restartWatch fail " << err.code() << std::endl;
+		return Void();
+	}
+
+	std::cout << cx->dbId.toString() << " restartWatch pass" << std::endl;
 	return Void();
 }
 

--- a/fdbclient/include/fdbclient/DatabaseContext.h
+++ b/fdbclient/include/fdbclient/DatabaseContext.h
@@ -157,7 +157,7 @@ public:
 	WatchMetadata(Reference<const WatchParameters> parameters)
 	  : watchFuture(watchPromise.getFuture()), parameters(parameters) {}
 
-	~WatchMetadata() { watchFutureSS.cancel(); }
+	~WatchMetadata() { /*watchFutureSS.cancel();*/ }
 };
 
 struct MutationAndVersionStream {
@@ -350,11 +350,11 @@ public:
 	void deleteWatchMetadata(int64_t tenant, KeyRef key);
 
 	// Increases reference count to the given watch. Returns the number of references to the watch.
-	int32_t increaseWatchRefCount(const int64_t tenant, KeyRef key);
+	int32_t increaseWatchRefCount(const int64_t tenant, KeyRef key, const Version& version);
 
 	// Decreases reference count to the given watch. If the reference count is dropped to 0, the watch metadata will be
 	// removed. Returns the number of references to the watch.
-	int32_t decreaseWatchRefCount(const int64_t tenant, KeyRef key);
+	int32_t decreaseWatchRefCount(const int64_t tenant, KeyRef key, const Version& version);
 
 	void clearWatchMetadata();
 
@@ -730,7 +730,17 @@ private:
 
 	WatchMap_t watchMap;
 
-	using WatchCounterMap_t = std::unordered_map<WatchMapKey, int32_t, WatchMapKeyHasher>;
+	// The reason of using a multiset of Versions as counter instead of a simpler integer counter is due to the
+	// possible race condition:
+	//
+	//    1. A watch to key A is set, the watchValueMap ACTOR, noted as X, starts waiting.
+	//    2. All watches are cleared due to connection string change.
+	//    3. The watch to key A is restarted with watchValueMap ACTOR Y.
+	//    4. X receives the cancel exception, and tries to dereference the counter. This causes Y gets cancelled.
+	//
+	// By introducing versions, this race condition is solved.
+	using WatchCounterMapValue = std::multiset<Version>;
+	using WatchCounterMap_t = std::unordered_map<WatchMapKey, WatchCounterMapValue, WatchMapKeyHasher>;
 	// Maps the number of the WatchMapKey being used.
 	WatchCounterMap_t watchCounterMap;
 };

--- a/fdbclient/include/fdbclient/DatabaseContext.h
+++ b/fdbclient/include/fdbclient/DatabaseContext.h
@@ -156,8 +156,6 @@ public:
 
 	WatchMetadata(Reference<const WatchParameters> parameters)
 	  : watchFuture(watchPromise.getFuture()), parameters(parameters) {}
-
-	~WatchMetadata() { /*watchFutureSS.cancel();*/ }
 };
 
 struct MutationAndVersionStream {

--- a/fdbclient/include/fdbclient/DatabaseContext.h
+++ b/fdbclient/include/fdbclient/DatabaseContext.h
@@ -156,6 +156,8 @@ public:
 
 	WatchMetadata(Reference<const WatchParameters> parameters)
 	  : watchFuture(watchPromise.getFuture()), parameters(parameters) {}
+
+	~WatchMetadata() { watchFutureSS.cancel(); }
 };
 
 struct MutationAndVersionStream {
@@ -328,14 +330,32 @@ public:
 	// Note: this will never return if the server is running a protocol from FDB 5.0 or older
 	Future<ProtocolVersion> getClusterProtocol(Optional<ProtocolVersion> expectedVersion = Optional<ProtocolVersion>());
 
-	// Update the watch counter for the database
-	void addWatch();
-	void removeWatch();
+	// Increases the counter of the number of watches in this DatabaseContext by 1. If the number of watches is too
+	// many, throws too_many_watches.
+	void addWatchCounter();
+
+	// Decrease the counter of the number of watches in this DatabaseContext by 1
+	void removeWatchCounter();
 
 	// watch map operations
+
+	// Gets the watch metadata per tenant id and key
 	Reference<WatchMetadata> getWatchMetadata(int64_t tenantId, KeyRef key) const;
+
+	// Refreshes the watch metadata. If the same watch is used (this is determined by the tenant id and the key), the
+	// metadata will be updated.
 	void setWatchMetadata(Reference<WatchMetadata> metadata);
+
+	// Removes the watch metadata
 	void deleteWatchMetadata(int64_t tenant, KeyRef key);
+
+	// Increases reference count to the given watch. Returns the number of references to the watch.
+	int32_t increaseWatchRefCount(const int64_t tenant, KeyRef key);
+
+	// Decreases reference count to the given watch. If the reference count is dropped to 0, the watch metadata will be
+	// removed. Returns the number of references to the watch.
+	int32_t decreaseWatchRefCount(const int64_t tenant, KeyRef key);
+
 	void clearWatchMetadata();
 
 	void setOption(FDBDatabaseOptions::Option option, Optional<StringRef> value);
@@ -703,8 +723,16 @@ public:
 	EventCacheHolder connectToDatabaseEventCacheHolder;
 
 private:
-	std::unordered_map<std::pair<int64_t, Key>, Reference<WatchMetadata>, boost::hash<std::pair<int64_t, Key>>>
-	    watchMap;
+	using WatchMapKey = std::pair<int64_t, Key>;
+	using WatchMapKeyHasher = boost::hash<WatchMapKey>;
+	using WatchMapValue = Reference<WatchMetadata>;
+	using WatchMap_t = std::unordered_map<WatchMapKey, WatchMapValue, WatchMapKeyHasher>;
+
+	WatchMap_t watchMap;
+
+	using WatchCounterMap_t = std::unordered_map<WatchMapKey, int32_t, WatchMapKeyHasher>;
+	// Maps the number of the WatchMapKey being used.
+	WatchCounterMap_t watchCounterMap;
 };
 
 // Similar to tr.onError(), but doesn't require a DatabaseContext.

--- a/fdbserver/ClusterRecovery.actor.cpp
+++ b/fdbserver/ClusterRecovery.actor.cpp
@@ -567,44 +567,106 @@ ACTOR Future<Void> changeCoordinators(Reference<ClusterRecoveryData> self) {
 	}
 }
 
-ACTOR Future<Void> configurationMonitor(Reference<ClusterRecoveryData> self, Database cx) {
+namespace {
+
+// NOTE: This vector may not be initialized here as the keys might be initialized *AFTER* this vector, causing all
+// keys empty. The reason is that the order of the initialization of keys and this vector might not be ordered as wished
+// so the vector might be initialized before the keys receives values; thus, all values inside the vector are copied
+// from uninitialized KeyRefs..
+// See C++11 standard 3.6.2 for more info.
+std::vector<KeyRef> configurationMonitorWatchKeys;
+
+ACTOR Future<Void> configurationMonitorImpl(Reference<ClusterRecoveryData> self,
+                                            Database cx,
+                                            Optional<int64_t>* pTenantId) {
+	state ReadYourWritesTransaction tr(cx);
 	loop {
-		state ReadYourWritesTransaction tr(cx);
+		try {
+			tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+			RangeResult results = wait(tr.getRange(configKeys, CLIENT_KNOBS->TOO_MANY));
+			ASSERT(!results.more && results.size() < CLIENT_KNOBS->TOO_MANY);
 
-		loop {
-			try {
-				tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
-				RangeResult results = wait(tr.getRange(configKeys, CLIENT_KNOBS->TOO_MANY));
-				ASSERT(!results.more && results.size() < CLIENT_KNOBS->TOO_MANY);
-
-				DatabaseConfiguration conf;
-				conf.fromKeyValues((VectorRef<KeyValueRef>)results);
-				TraceEvent("ConfigurationMonitor", self->dbgid)
-				    .detail(getRecoveryEventName(ClusterRecoveryEventType::CLUSTER_RECOVERY_STATE_EVENT_NAME).c_str(),
-				            self->recoveryState);
-				if (conf != self->configuration) {
-					if (self->recoveryState != RecoveryState::ALL_LOGS_RECRUITED &&
-					    self->recoveryState != RecoveryState::FULLY_RECOVERED) {
-						self->controllerData->shouldCommitSuicide = true;
-						throw restart_cluster_controller();
-					}
-
-					self->configuration = conf;
-					self->registrationTrigger.trigger();
+			DatabaseConfiguration conf;
+			conf.fromKeyValues((VectorRef<KeyValueRef>)results);
+			TraceEvent("ConfigurationMonitor", self->dbgid)
+			    .detail(getRecoveryEventName(ClusterRecoveryEventType::CLUSTER_RECOVERY_STATE_EVENT_NAME).c_str(),
+			            self->recoveryState);
+			if (conf != self->configuration) {
+				if (self->recoveryState != RecoveryState::ALL_LOGS_RECRUITED &&
+				    self->recoveryState != RecoveryState::FULLY_RECOVERED) {
+					self->controllerData->shouldCommitSuicide = true;
+					throw restart_cluster_controller();
 				}
 
-				state Future<Void> watchFuture =
-				    tr.watch(moveKeysLockOwnerKey) || tr.watch(excludedServersVersionKey) ||
-				    tr.watch(failedServersVersionKey) || tr.watch(excludedLocalityVersionKey) ||
-				    tr.watch(failedLocalityVersionKey);
-				wait(tr.commit());
-				wait(watchFuture);
-				break;
-			} catch (Error& e) {
-				wait(tr.onError(e));
+				self->configuration = conf;
+				self->registrationTrigger.trigger();
 			}
+
+			std::vector<Future<Void>> watchFutures;
+			std::transform(std::begin(configurationMonitorWatchKeys),
+			               std::end(configurationMonitorWatchKeys),
+			               std::back_inserter(watchFutures),
+			               [this](KeyRef key) { return tr.watch(key); });
+			// Only after this stage, where getKeyLocation is called indirectly, the tenant information is updated and
+			// set to the transaction state.
+			(*pTenantId) = tr.getTransactionState()->tenantId();
+			state Future<Void> watchFuture = waitForAny(watchFutures);
+
+			wait(tr.commit());
+
+			wait(watchFuture);
+			break;
+		} catch (Error& e) {
+			if (e.code() == error_code_actor_cancelled) {
+				throw e;
+			}
+			wait(tr.onError(e));
 		}
 	}
+
+	return Void();
+}
+
+} // anonymous namespace
+
+ACTOR Future<Void> configurationMonitor(Reference<ClusterRecoveryData> self, Database cx) {
+	state Optional<int64_t> tenantId;
+
+	// The keys cannot be initialized where it is defined. see comments at the definition.
+	if (configurationMonitorWatchKeys.empty()) {
+		configurationMonitorWatchKeys = std::vector<KeyRef>{ moveKeysLockOwnerKey,
+			                                                 excludedServersVersionKey,
+			                                                 failedServersVersionKey,
+			                                                 excludedLocalityVersionKey,
+			                                                 failedLocalityVersionKey };
+	}
+
+	try {
+		while (true) {
+			wait(configurationMonitorImpl(self, cx, &tenantId));
+		}
+	} catch (Error& e) {
+		if (e.code() != error_code_actor_cancelled) {
+			throw e;
+		}
+
+		// Cancel all watches created by configurationMonitorImpl. Due to a circular reference issue, if the watches are
+		// not cancelled manually, the DatabaseContext object in cx will not be able to destructed properly, see
+		//
+		//		https://github.com/apple/foundationdb/issues/8321
+		//
+		// for more detailed discussion.
+
+		if (!tenantId.present()) {
+			// Tenant ID not set, no watches are created in this case, no cleanup required.
+			return Void();
+		}
+		std::for_each(std::begin(configurationMonitorWatchKeys),
+		              std::end(configurationMonitorWatchKeys),
+		              [this](KeyRef key) { cx->decreaseWatchRefCount(tenantId.get(), key); });
+	}
+
+	return Void();
 }
 
 ACTOR static Future<Optional<Version>> getMinBackupVersion(Reference<ClusterRecoveryData> self, Database cx) {

--- a/flow/include/flow/flow.h
+++ b/flow/include/flow/flow.h
@@ -788,7 +788,7 @@ public:
 	T const& get() const { return sav->get(); }
 	T getValue() const { return get(); }
 
-	bool isValid() const { return sav != 0; }
+	bool isValid() const { return sav != nullptr; }
 	bool isReady() const { return sav->isSet(); }
 	bool isError() const { return sav->isError(); }
 	// returns true if get can be called on this future (counterpart of canBeSet on Promises)
@@ -798,12 +798,12 @@ public:
 		return sav->error_state;
 	}
 
-	Future() : sav(0) {}
+	Future() : sav(nullptr) {}
 	Future(const Future<T>& rhs) : sav(rhs.sav) {
 		if (sav)
 			sav->addFutureRef();
 	}
-	Future(Future<T>&& rhs) noexcept : sav(rhs.sav) { rhs.sav = 0; }
+	Future(Future<T>&& rhs) noexcept : sav(rhs.sav) { rhs.sav = nullptr; }
 	Future(const T& presentValue) : sav(new SAV<T>(1, 0)) { sav->send(presentValue); }
 	Future(T&& presentValue) : sav(new SAV<T>(1, 0)) { sav->send(std::move(presentValue)); }
 	Future(Never) : sav(new SAV<T>(1, 0)) { sav->send(Never()); }
@@ -830,7 +830,7 @@ public:
 			if (sav)
 				sav->delFutureRef();
 			sav = rhs.sav;
-			rhs.sav = 0;
+			rhs.sav = nullptr;
 		}
 	}
 	bool operator==(const Future& rhs) { return rhs.sav == sav; }
@@ -843,17 +843,17 @@ public:
 
 	void addCallbackAndClear(Callback<T>* cb) {
 		sav->addCallbackAndDelFutureRef(cb);
-		sav = 0;
+		sav = nullptr;
 	}
 
 	void addYieldedCallbackAndClear(Callback<T>* cb) {
 		sav->addYieldedCallbackAndDelFutureRef(cb);
-		sav = 0;
+		sav = nullptr;
 	}
 
 	void addCallbackChainAndClear(Callback<T>* cb) {
 		sav->addCallbackChainAndDelFutureRef(cb);
-		sav = 0;
+		sav = nullptr;
 	}
 
 	int getFutureReferenceCount() const { return sav->getFutureReferenceCount(); }

--- a/flow/include/flow/flow.h
+++ b/flow/include/flow/flow.h
@@ -802,12 +802,8 @@ public:
 	Future(const Future<T>& rhs) : sav(rhs.sav) {
 		if (sav)
 			sav->addFutureRef();
-		// if (sav->endpoint.isValid()) std::cout << "Future copied for " << sav->endpoint.key << std::endl;
 	}
-	Future(Future<T>&& rhs) noexcept : sav(rhs.sav) {
-		rhs.sav = 0;
-		// if (sav->endpoint.isValid()) std::cout << "Future moved for " << sav->endpoint.key << std::endl;
-	}
+	Future(Future<T>&& rhs) noexcept : sav(rhs.sav) { rhs.sav = 0; }
 	Future(const T& presentValue) : sav(new SAV<T>(1, 0)) { sav->send(presentValue); }
 	Future(T&& presentValue) : sav(new SAV<T>(1, 0)) { sav->send(std::move(presentValue)); }
 	Future(Never) : sav(new SAV<T>(1, 0)) { sav->send(Never()); }
@@ -819,7 +815,6 @@ public:
 #endif
 
 	~Future() {
-		// if (sav && sav->endpoint.isValid()) std::cout << "Future destroyed for " << sav->endpoint.key << std::endl;
 		if (sav)
 			sav->delFutureRef();
 	}
@@ -864,9 +859,7 @@ public:
 	int getFutureReferenceCount() const { return sav->getFutureReferenceCount(); }
 	int getPromiseReferenceCount() const { return sav->getPromiseReferenceCount(); }
 
-	explicit Future(SAV<T>* sav) : sav(sav) {
-		// if (sav->endpoint.isValid()) std::cout << "Future created for " << sav->endpoint.key << std::endl;
-	}
+	explicit Future(SAV<T>* sav) : sav(sav) {}
 
 private:
 	SAV<T>* sav;


### PR DESCRIPTION
    Currently, there is a cyclic reference situation in

        DatabaseContext -> WatchMetadata -> watchStorageServerResp ->
        DatabaseContext

    If there is a watch created in the DatabaseContext, even the
    corresponding wait ACTOR is cancelled, the WatchMetadata will still hold
    a reference to watchStorageServerResp ACTOR, which holds a reference to
    DatabaseContext.

    In this situation, any DatabaseContext who held a watch will not be
    automatically destructed since its reference count will never reduce to
    0 until the watch value is changed. Every time the cluster recoveries,
    several watches are created, and when the cluster restarts, the
    DatabaseContext which not being used, will not be able to destructed due
    to these watches.

    With this patch, each wait to the watch will be counted. Either the
    watch is triggered or cancelled, the corresponding count will be
    reduced. If a watch is not being waited, the watch will be cancelled,
    effectively reduce the reference count of DatabaseContext. This will
    hopefully fix the issue mentioned above.

    The code is tested by 1) Manually change the number of logs of a local
    cluster, see the cluster recovery and previous DatabaseContext being
    destructed; 2) 100K joshua run, with 1 failure, the same test will fail
    on the current git main branch.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
