### PR TITLE
Disable delete-native-lib-after-loading client knob for some C API tests

### DIFF
--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -290,8 +290,8 @@ if(NOT WIN32)
       @TMP_DIR@
       --log-dir
       @LOG_DIR@
-      --knob-delete-native-lib-after-loading # for properly symbolizing xSAN errors
-      false
+      --knob
+      delete-native-lib-after-loading=false # for properly symbolizing xSAN errors
     )
 
     add_fdbclient_test(
@@ -354,8 +354,8 @@ if(NOT WIN32)
       @CLIENT_KEY_FILE@
       --tls-ca-file
       @SERVER_CA_FILE@
-      --knob-delete-native-lib-after-loading # for properly symbolizing xSAN errors
-      false
+      --knob
+      delete-native-lib-after-loading=false # for properly symbolizing xSAN errors
     )
 
     add_test(NAME fdb_c_upgrade_to_future_version

--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -290,6 +290,8 @@ if(NOT WIN32)
       @TMP_DIR@
       --log-dir
       @LOG_DIR@
+      --knob-delete-native-lib-after-loading # for properly symbolizing xSAN errors
+      false
     )
 
     add_fdbclient_test(
@@ -352,6 +354,8 @@ if(NOT WIN32)
       @CLIENT_KEY_FILE@
       --tls-ca-file
       @SERVER_CA_FILE@
+      --knob-delete-native-lib-after-loading # for properly symbolizing xSAN errors
+      false
     )
 
     add_test(NAME fdb_c_upgrade_to_future_version

--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -308,6 +308,8 @@ if(NOT WIN32)
       @TMP_DIR@
       --log-dir
       @LOG_DIR@
+      --knob
+      delete-native-lib-after-loading=false # for properly symbolizing xSAN errors
     )
 
     add_fdbclient_test(
@@ -329,6 +331,8 @@ if(NOT WIN32)
       @TMP_DIR@
       --log-dir
       @LOG_DIR@
+      --knob
+      delete-native-lib-after-loading=false # for properly symbolizing xSAN errors
     )
 
     add_fdbclient_test(

--- a/bindings/c/test/apitester/run_c_api_tests.py
+++ b/bindings/c/test/apitester/run_c_api_tests.py
@@ -93,6 +93,10 @@ def run_tester(args, test_file):
     if args.tls_cert_file is not None:
         cmd += ["--tls-cert-file", args.tls_cert_file]
 
+    for knob in args.knobs:
+        knob_name, knob_value = knob.split("=")
+        cmd += ["--knob-" + knob_name, knob_value]
+
     get_logger().info('\nRunning tester \'%s\'...' % ' '.join(cmd))
     proc = Popen(cmd, stdout=sys.stdout, stderr=sys.stderr)
     timed_out = False
@@ -164,6 +168,8 @@ def parse_args(argv):
                         help='Path to client\'s TLS certificate file')
     parser.add_argument('--tls-key-file', type=str, default=None,
                         help='Path to client\'s TLS private key file')
+    parser.add_argument('--knob', type=str, default=[], action="append", dest="knobs",
+                        help='[lowercase-knob-name]=[knob-value] (there may be multiple --knob options)')
 
     return parser.parse_args(argv)
 


### PR DESCRIPTION
To have symbolized stack traces when xSAN error reproduces

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
