### PR TITLE
support --load_factor

### DIFF
--- a/bindings/c/test/mako/mako.cpp
+++ b/bindings/c/test/mako/mako.cpp
@@ -323,9 +323,9 @@ int populate(Database db,
 		auto key_checkpoint = key_begin; // in case of commit failure, restart from this key
 		double required_keys = (key_end - key_begin + 1) * args.load_factor;
 		for (auto i = key_begin; i <= key_end; i++) {
-			// Choose required_keys out of (key_end -i + 1) randomly, so the probability is required_keys / (key_end - i + 1).
-			// Generate a random number in range [0, 1), if the generated number is smaller or equal to required_keys / (key_end - i + 1),
-			// then choose this key.
+			// Choose required_keys out of (key_end -i + 1) randomly, so the probability is required_keys / (key_end - i
+			// + 1). Generate a random number in range [0, 1), if the generated number is smaller or equal to
+			// required_keys / (key_end - i + 1), then choose this key.
 			double r = rand() / (1.0 + RAND_MAX);
 			if (r > required_keys / (key_end - i + 1)) {
 				continue;
@@ -993,7 +993,7 @@ int initArguments(Arguments& args) {
 	args.async_xacts = 0;
 	args.mode = MODE_INVALID;
 	args.rows = 100000;
-        args.load_factor = 1.0;
+	args.load_factor = 1.0;
 	args.row_digits = digits(args.rows);
 	args.seconds = 30;
 	args.iteration = 0;
@@ -1239,7 +1239,7 @@ int parseArguments(int argc, char* argv[], Arguments& args) {
 			{ "threads", required_argument, NULL, 't' },
 			{ "async_xacts", required_argument, NULL, ARG_ASYNC },
 			{ "rows", required_argument, NULL, 'r' },
-                        { "load_factor", required_argument, NULL, 'l'},
+			{ "load_factor", required_argument, NULL, 'l' },
 			{ "seconds", required_argument, NULL, 's' },
 			{ "iteration", required_argument, NULL, 'i' },
 			{ "keylen", required_argument, NULL, ARG_KEYLEN },
@@ -1316,9 +1316,9 @@ int parseArguments(int argc, char* argv[], Arguments& args) {
 			args.rows = atoi(optarg);
 			args.row_digits = digits(args.rows);
 			break;
-                case 'l':
-                        args.load_factor = atof(optarg);
-                        break;
+		case 'l':
+			args.load_factor = atof(optarg);
+			break;
 		case 's':
 			args.seconds = atoi(optarg);
 			break;
@@ -1538,8 +1538,8 @@ int validateArguments(Arguments const& args) {
 		logr.error("--rows must be a positive integer");
 		return -1;
 	}
-        if (args.load_factor <= 0 || args.load_factor > 1) {
-	        logr.error("--load_factor must be in range (0, 1]");
+	if (args.load_factor <= 0 || args.load_factor > 1) {
+		logr.error("--load_factor must be in range (0, 1]");
 		return -1;
 	}
 	if (args.key_length < 0) {

--- a/bindings/c/test/mako/mako.cpp
+++ b/bindings/c/test/mako/mako.cpp
@@ -323,12 +323,16 @@ int populate(Database db,
 		auto key_checkpoint = key_begin; // in case of commit failure, restart from this key
 		double required_keys = (key_end - key_begin + 1) * args.load_factor;
 		for (auto i = key_begin; i <= key_end; i++) {
+			// Choose required_keys out of (key_end -i + 1) randomly, so the probability is required_keys / (key_end - i + 1).
+			// Generate a random number in range [0, 1), if the generated number is smaller or equal to required_keys / (key_end - i + 1),
+			// then choose this key.
 			double r = rand() / (1.0 + RAND_MAX);
-			if (r > required_keys / (key_end - i + 1)) continue;
+			if (r > required_keys / (key_end - i + 1)) {
+				continue;
+			}
 			--required_keys;
 			/* sequential keys */
 			genKey(keystr.data(), KEY_PREFIX, args, i);
-			printf("Gen key : %s\n", keystr.c_str());
 			/* random values */
 			randomString(valstr.data(), args.value_length);
 

--- a/bindings/c/test/mako/mako.cpp
+++ b/bindings/c/test/mako/mako.cpp
@@ -1172,7 +1172,7 @@ void usage() {
 	printf("%-24s %s\n", "-t, --threads=THREADS", "Specify number of worker threads");
 	printf("%-24s %s\n", "    --async_xacts", "Specify number of concurrent transactions to be run in async mode");
 	printf("%-24s %s\n", "-r, --rows=ROWS", "Specify number of records");
-	printf("%-24s %s\n", "-r, --rows=LOAD_FACTOR", "Specify load factor");
+	printf("%-24s %s\n", "-l, --load_factor=LOAD_FACTOR", "Specify load factor");
 	printf("%-24s %s\n", "-s, --seconds=SECONDS", "Specify the test duration in seconds\n");
 	printf("%-24s %s\n", "", "This option cannot be specified with --iteration.");
 	printf("%-24s %s\n", "-i, --iteration=ITERS", "Specify the number of iterations.\n");

--- a/bindings/c/test/mako/mako.hpp
+++ b/bindings/c/test/mako/mako.hpp
@@ -138,6 +138,7 @@ struct Arguments {
 	int async_xacts;
 	int mode;
 	int rows; /* is 2 billion enough? */
+	double load_factor;
 	int row_digits;
 	int seconds;
 	int iteration;


### PR DESCRIPTION
Support --load_factor, its default value is 1.0, it works together with --rows, the final rows inserted into database in build stage is rows * load_factor, if load_factor < 1, will pick up keys randomly in range [0, rows - 1].


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
