### PR TITLE
Add a counter to track physical shard creation through moves

### DIFF
--- a/fdbserver/DDShardTracker.actor.cpp
+++ b/fdbserver/DDShardTracker.actor.cpp
@@ -2081,6 +2081,10 @@ void PhysicalShardCollection::logPhysicalShardCollection() {
 	}
 }
 
+bool PhysicalShardCollection::physicalShardExists(uint64_t physicalShardID) {
+	return physicalShardInstances.find(physicalShardID) != physicalShardInstances.end();
+}
+
 // FIXME: complete this test with non-empty range
 TEST_CASE("/DataDistributor/Tracker/FetchTopK") {
 	state DataDistributionTracker self;

--- a/fdbserver/include/fdbserver/DataDistribution.actor.h
+++ b/fdbserver/include/fdbserver/DataDistribution.actor.h
@@ -322,6 +322,9 @@ public:
 	// Log physicalShard
 	void logPhysicalShardCollection();
 
+	// Checks if a physical shard exists.
+	bool physicalShardExists(uint64_t physicalShardID);
+
 private:
 	// Track physicalShard metrics by tracking keyRange metrics
 	void updatePhysicalShardMetricsByKeyRange(KeyRange keyRange,


### PR DESCRIPTION
This is to trace how frequent we reuse existing physical shard.

20221020-051032-zhewu_8510-85b5aba5c499f12d        compressed=True data_size=39211132 duration=4618722 ended=100000 fail=1 fail_fast=10 max_runs=100000 pass=99999 priority=100 remaining=0 runtime=0:46:08 sanity=False started=100086 stopped=20221020-055640 submitted=20221020-051032 timeout=5400 username=zhewu_8510

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
