### PR TITLE
Fix disk queue read lifetime issue a more simple but equivalent way

### DIFF
--- a/fdbserver/DiskQueue.actor.cpp
+++ b/fdbserver/DiskQueue.actor.cpp
@@ -749,8 +749,8 @@ public:
 		state Standalone<StringRef> result = makeAlignedString(sizeof(Page), bytesRequested);
 		if (file == 1)
 			ASSERT_WE_THINK(pageOffset * sizeof(Page) + bytesRequested <= self->writingPos);
-		int bytesRead =
-		    wait(self->files[file].f->read(mutateString(result), bytesRequested, pageOffset * sizeof(Page)));
+		int bytesRead = wait(uncancellable(holdWhile(
+		    result, self->files[file].f->read(mutateString(result), bytesRequested, pageOffset * sizeof(Page)))));
 		ASSERT_WE_THINK(bytesRead == bytesRequested);
 		return result;
 	}


### PR DESCRIPTION
The actor can simply be made uncancellable because DiskQueue has protection to prevent the destruction of self until actors containing `state TrackMe` are completed.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
