### PR TITLE
Add functionality to get tenants over storage quota and improve the relevant monitors

### DIFF
--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -2559,19 +2559,19 @@ bool schemaMatch(json_spirit::mValue const& schemaValue,
 	}
 }
 
-void setStorageQuota(Transaction& tr, StringRef tenantName, uint64_t quota) {
+void setStorageQuota(Transaction& tr, StringRef tenantName, int64_t quota) {
 	tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 	auto key = storageQuotaKey(tenantName);
-	tr.set(key, BinaryWriter::toValue<uint64_t>(quota, Unversioned()));
+	tr.set(key, BinaryWriter::toValue<int64_t>(quota, Unversioned()));
 }
 
-ACTOR Future<Optional<uint64_t>> getStorageQuota(Transaction* tr, StringRef tenantName) {
+ACTOR Future<Optional<int64_t>> getStorageQuota(Transaction* tr, StringRef tenantName) {
 	tr->setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
 	state Optional<Value> v = wait(tr->get(storageQuotaKey(tenantName)));
 	if (!v.present()) {
-		return Optional<uint64_t>();
+		return Optional<int64_t>();
 	}
-	return BinaryReader::fromStringRef<uint64_t>(v.get(), Unversioned());
+	return BinaryReader::fromStringRef<int64_t>(v.get(), Unversioned());
 }
 
 std::string ManagementAPI::generateErrorMessage(const CoordinatorsResult& res) {

--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -297,7 +297,8 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( DD_STORAGE_WIGGLE_MIN_SS_AGE_SEC,   isSimulated ? 2 : 21 * 60 * 60 * 24 ); if(randomize && BUGGIFY) DD_STORAGE_WIGGLE_MIN_SS_AGE_SEC = isSimulated ? 0: 120;
 	init( DD_TENANT_AWARENESS_ENABLED,                         false );
 	init( TENANT_CACHE_LIST_REFRESH_INTERVAL,                      2 ); if( randomize && BUGGIFY ) TENANT_CACHE_LIST_REFRESH_INTERVAL = deterministicRandom()->randomInt(1, 10);
-	init( TENANT_CACHE_STORAGE_REFRESH_INTERVAL,                   2 ); if( randomize && BUGGIFY ) TENANT_CACHE_STORAGE_REFRESH_INTERVAL = deterministicRandom()->randomInt(1, 10);
+	init( TENANT_CACHE_STORAGE_USAGE_REFRESH_INTERVAL,             2 ); if( randomize && BUGGIFY ) TENANT_CACHE_STORAGE_USAGE_REFRESH_INTERVAL = deterministicRandom()->randomInt(1, 10);
+	init( TENANT_CACHE_STORAGE_QUOTA_REFRESH_INTERVAL,            10 ); if( randomize && BUGGIFY ) TENANT_CACHE_STORAGE_QUOTA_REFRESH_INTERVAL = deterministicRandom()->randomInt(1, 10);
 
 	// TeamRemover
 	init( TR_FLAG_DISABLE_MACHINE_TEAM_REMOVER,                false ); if( randomize && BUGGIFY ) TR_FLAG_DISABLE_MACHINE_TEAM_REMOVER = deterministicRandom()->random01() < 0.1 ? true : false; // false by default. disable the consistency check when it's true

--- a/fdbclient/include/fdbclient/ManagementAPI.actor.h
+++ b/fdbclient/include/fdbclient/ManagementAPI.actor.h
@@ -164,8 +164,8 @@ bool schemaMatch(json_spirit::mValue const& schema,
 ACTOR Future<Void> mgmtSnapCreate(Database cx, Standalone<StringRef> snapCmd, UID snapUID);
 
 // Set and get the storage quota per tenant
-void setStorageQuota(Transaction& tr, StringRef tenantName, uint64_t quota);
-ACTOR Future<Optional<uint64_t>> getStorageQuota(Transaction* tr, StringRef tenantName);
+void setStorageQuota(Transaction& tr, StringRef tenantName, int64_t quota);
+ACTOR Future<Optional<int64_t>> getStorageQuota(Transaction* tr, StringRef tenantName);
 
 #include "flow/unactorcompiler.h"
 #endif

--- a/fdbclient/include/fdbclient/ServerKnobs.h
+++ b/fdbclient/include/fdbclient/ServerKnobs.h
@@ -237,8 +237,10 @@ public:
 	    DD_STORAGE_WIGGLE_MIN_SS_AGE_SEC; // Minimal age of a correct-configured server before it's chosen to be wiggled
 	bool DD_TENANT_AWARENESS_ENABLED;
 	int TENANT_CACHE_LIST_REFRESH_INTERVAL; // How often the TenantCache is refreshed
-	int TENANT_CACHE_STORAGE_REFRESH_INTERVAL; // How often the storage bytes used by each tenant in the TenantCache is
-	                                           // refreshed
+	int TENANT_CACHE_STORAGE_USAGE_REFRESH_INTERVAL; // How often the storage bytes used by each tenant is refreshed
+	                                                 // in the TenantCache
+	int TENANT_CACHE_STORAGE_QUOTA_REFRESH_INTERVAL; // How often the storage quota allocated to each tenant is
+	                                                 // refreshed in the TenantCache
 
 	// TeamRemover to remove redundant teams
 	bool TR_FLAG_DISABLE_MACHINE_TEAM_REMOVER; // disable the machineTeamRemover actor

--- a/fdbrpc/include/fdbrpc/TenantInfo.h
+++ b/fdbrpc/include/fdbrpc/TenantInfo.h
@@ -42,8 +42,6 @@ struct TenantInfo {
 	// Is set during deserialization. It will be set to true if the tenant
 	// name is set and the client is authorized to use this tenant.
 	bool tenantAuthorized = false;
-	// Number of storage bytes currently used by this tenant.
-	int64_t storageUsage = 0;
 
 	// Helper function for most endpoints that read/write data. This returns true iff
 	// the client is either a) a trusted peer or b) is accessing keyspace belonging to a tenant,

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -665,7 +665,7 @@ ACTOR Future<Void> dataDistribution(Reference<DataDistributor> self,
 				                                    "DDTenantCacheMonitor",
 				                                    self->ddId,
 				                                    &normalDDQueueErrors()));
-				actors.push_back(reportErrorsExcept(ddTenantCache.get()->monitorstorageQuota(),
+				actors.push_back(reportErrorsExcept(ddTenantCache.get()->monitorStorageQuota(),
 				                                    "StorageQuotaTracker",
 				                                    self->ddId,
 				                                    &normalDDQueueErrors()));

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -286,8 +286,6 @@ public:
 	PromiseStream<RelocateShard> relocationProducer, relocationConsumer;
 	Reference<PhysicalShardCollection> physicalShardCollection;
 
-	StorageQuotaInfo storageQuotaInfo;
-
 	Promise<Void> initialized;
 
 	std::unordered_map<AuditType, std::vector<std::shared_ptr<DDAudit>>> audits;
@@ -542,27 +540,6 @@ public:
 	}
 };
 
-ACTOR Future<Void> storageQuotaTracker(Database cx, StorageQuotaInfo* storageQuotaInfo) {
-	loop {
-		state Transaction tr(cx);
-		loop {
-			try {
-				state RangeResult currentQuotas = wait(tr.getRange(storageQuotaKeys, CLIENT_KNOBS->TOO_MANY));
-				TraceEvent("StorageQuota_ReadCurrentQuotas").detail("Size", currentQuotas.size());
-				for (auto const kv : currentQuotas) {
-					Key const key = kv.key.removePrefix(storageQuotaPrefix);
-					uint64_t const quota = BinaryReader::fromStringRef<uint64_t>(kv.value, Unversioned());
-					storageQuotaInfo->quotaMap[key] = quota;
-				}
-				wait(delay(5.0));
-				break;
-			} catch (Error& e) {
-				wait(tr.onError(e));
-			}
-		}
-	}
-}
-
 // Periodically check and log the physicalShard status; clean up empty physicalShard;
 ACTOR Future<Void> monitorPhysicalShardStatus(Reference<PhysicalShardCollection> self) {
 	ASSERT(SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA);
@@ -683,14 +660,13 @@ ACTOR Future<Void> dataDistribution(Reference<DataDistributor> self,
 			                                    self->ddId,
 			                                    &normalDDQueueErrors()));
 
-			actors.push_back(reportErrorsExcept(storageQuotaTracker(cx, &self->storageQuotaInfo),
-			                                    "StorageQuotaTracker",
-			                                    self->ddId,
-			                                    &normalDDQueueErrors()));
-
 			if (ddIsTenantAware) {
 				actors.push_back(reportErrorsExcept(ddTenantCache.get()->monitorTenantMap(),
 				                                    "DDTenantCacheMonitor",
+				                                    self->ddId,
+				                                    &normalDDQueueErrors()));
+				actors.push_back(reportErrorsExcept(ddTenantCache.get()->monitorstorageQuota(),
+				                                    "StorageQuotaTracker",
 				                                    self->ddId,
 				                                    &normalDDQueueErrors()));
 				actors.push_back(reportErrorsExcept(ddTenantCache.get()->monitorStorageUsage(),

--- a/fdbserver/TenantCache.actor.cpp
+++ b/fdbserver/TenantCache.actor.cpp
@@ -160,7 +160,7 @@ public:
 					state RangeResult currentQuotas = wait(tr.getRange(storageQuotaKeys, CLIENT_KNOBS->TOO_MANY));
 					for (auto const kv : currentQuotas) {
 						TenantName const tenant = kv.key.removePrefix(storageQuotaPrefix);
-						uint64_t const quota = BinaryReader::fromStringRef<uint64_t>(kv.value, Unversioned());
+						int64_t const quota = BinaryReader::fromStringRef<int64_t>(kv.value, Unversioned());
 						tenantCache->tenantStorageMap[tenant].quota = quota;
 					}
 					wait(delay(SERVER_KNOBS->TENANT_CACHE_STORAGE_QUOTA_REFRESH_INTERVAL));

--- a/fdbserver/TenantCache.actor.cpp
+++ b/fdbserver/TenantCache.actor.cpp
@@ -280,6 +280,16 @@ Optional<Reference<TCTenantInfo>> TenantCache::tenantOwning(KeyRef key) const {
 	return it->value;
 }
 
+std::vector<TenantName> TenantCache::getTenantsOverQuota() const {
+	std::vector<TenantName> tenants;
+	for (const auto& [tenant, storage] : tenantStorageMap) {
+		if (storage.usage > storage.quota) {
+			tenants.push_back(tenant);
+		}
+	}
+	return tenants;
+}
+
 Future<Void> TenantCache::monitorTenantMap() {
 	return TenantCacheImpl::monitorTenantMap(this);
 }

--- a/fdbserver/include/fdbserver/DataDistribution.actor.h
+++ b/fdbserver/include/fdbserver/DataDistribution.actor.h
@@ -484,10 +484,6 @@ ShardSizeBounds getShardSizeBounds(KeyRangeRef shard, int64_t maxShardSize);
 // Determines the maximum shard size based on the size of the database
 int64_t getMaxShardSize(double dbSizeEstimate);
 
-struct StorageQuotaInfo {
-	std::map<Key, uint64_t> quotaMap;
-};
-
 #ifndef __INTEL_COMPILER
 #pragma endregion
 #endif

--- a/fdbserver/include/fdbserver/TCInfo.h
+++ b/fdbserver/include/fdbserver/TCInfo.h
@@ -268,5 +268,4 @@ public:
 	void removeTeam(TCTeamInfo team);
 	void updateCacheGeneration(int64_t generation) { m_cacheGeneration = generation; }
 	int64_t cacheGeneration() const { return m_cacheGeneration; }
-	void updateStorageUsage(int64_t size) { m_tenantInfo.storageUsage = size; }
 };

--- a/fdbserver/include/fdbserver/TenantCache.h
+++ b/fdbserver/include/fdbserver/TenantCache.h
@@ -33,8 +33,8 @@
 typedef Map<KeyRef, Reference<TCTenantInfo>> TenantMapByPrefix;
 
 struct Storage {
-	int64_t quota;
-	int64_t usage;
+	int64_t quota = std::numeric_limits<int64_t>::max();
+	int64_t usage = 0;
 };
 typedef std::unordered_map<TenantName, Storage> TenantStorageMap;
 
@@ -98,4 +98,7 @@ public:
 	bool isTenantKey(KeyRef key) const;
 
 	Optional<Reference<TCTenantInfo>> tenantOwning(KeyRef key) const;
+
+	// Get the list of tenants where the storage bytes currently used is greater than the quota allocated
+	std::vector<TenantName> getTenantsOverQuota() const;
 };

--- a/fdbserver/include/fdbserver/TenantCache.h
+++ b/fdbserver/include/fdbserver/TenantCache.h
@@ -33,7 +33,7 @@
 typedef Map<KeyRef, Reference<TCTenantInfo>> TenantMapByPrefix;
 
 struct Storage {
-	uint64_t quota;
+	int64_t quota;
 	int64_t usage;
 };
 typedef std::unordered_map<TenantName, Storage> TenantStorageMap;

--- a/fdbserver/include/fdbserver/TenantCache.h
+++ b/fdbserver/include/fdbserver/TenantCache.h
@@ -32,6 +32,8 @@
 
 typedef Map<KeyRef, Reference<TCTenantInfo>> TenantMapByPrefix;
 
+typedef std::unordered_map<TenantName, uint64_t> TenantStorageMap;
+
 struct TenantCacheTenantCreated {
 	KeyRange keys;
 	Promise<bool> reply;
@@ -51,9 +53,7 @@ private:
 	TenantMapByPrefix tenantCache;
 
 	// Map from tenant names to storage quota
-	struct StorageQuotaInfo {
-		std::map<Key, uint64_t> quotaMap;
-	} storageQuotaInfo;
+	TenantStorageMap tenantStorageMap;
 
 	// mark the start of a new sweep of the tenant cache
 	void startRefresh();
@@ -90,7 +90,7 @@ public:
 
 	Future<Void> monitorStorageUsage();
 
-	Future<Void> monitorstorageQuota();
+	Future<Void> monitorStorageQuota();
 
 	std::string desc() const;
 

--- a/fdbserver/include/fdbserver/TenantCache.h
+++ b/fdbserver/include/fdbserver/TenantCache.h
@@ -50,6 +50,11 @@ private:
 	uint64_t generation;
 	TenantMapByPrefix tenantCache;
 
+	// Map from tenant names to storage quota
+	struct StorageQuotaInfo {
+		std::map<Key, uint64_t> quotaMap;
+	} storageQuotaInfo;
+
 	// mark the start of a new sweep of the tenant cache
 	void startRefresh();
 
@@ -84,6 +89,8 @@ public:
 	Future<Void> monitorTenantMap();
 
 	Future<Void> monitorStorageUsage();
+
+	Future<Void> monitorstorageQuota();
 
 	std::string desc() const;
 

--- a/fdbserver/include/fdbserver/TenantCache.h
+++ b/fdbserver/include/fdbserver/TenantCache.h
@@ -32,7 +32,11 @@
 
 typedef Map<KeyRef, Reference<TCTenantInfo>> TenantMapByPrefix;
 
-typedef std::unordered_map<TenantName, uint64_t> TenantStorageMap;
+struct Storage {
+	uint64_t quota;
+	int64_t usage;
+};
+typedef std::unordered_map<TenantName, Storage> TenantStorageMap;
 
 struct TenantCacheTenantCreated {
 	KeyRange keys;
@@ -52,7 +56,7 @@ private:
 	uint64_t generation;
 	TenantMapByPrefix tenantCache;
 
-	// Map from tenant names to storage quota
+	// Map from tenant names to storage quota and usage
 	TenantStorageMap tenantStorageMap;
 
 	// mark the start of a new sweep of the tenant cache
@@ -67,11 +71,8 @@ private:
 	// return count of tenants that were found to be stale and removed from the cache
 	int cleanup();
 
-	// return the mapping from prefix -> tenant name for all tenants stored in the cache
-	std::vector<std::pair<KeyRef, TenantName>> getTenantList() const;
-
-	// update the size for a tenant; do nothing if the tenant doesn't exist in the map
-	void updateStorageUsage(KeyRef prefix, int64_t size);
+	// return all the TenantName for all tenants stored in the cache
+	std::vector<TenantName> getTenantList() const;
 
 	UID id() const { return distributorID; }
 

--- a/fdbserver/workloads/StorageQuota.actor.cpp
+++ b/fdbserver/workloads/StorageQuota.actor.cpp
@@ -38,17 +38,17 @@ struct StorageQuotaWorkload : TestWorkload {
 		wait(setStorageQuotaHelper(cx, "name2"_sr, 200));
 		wait(setStorageQuotaHelper(cx, "name1"_sr, 300));
 
-		state Optional<uint64_t> quota1 = wait(getStorageQuotaHelper(cx, "name1"_sr));
+		state Optional<int64_t> quota1 = wait(getStorageQuotaHelper(cx, "name1"_sr));
 		ASSERT(quota1.present() && quota1.get() == 300);
-		state Optional<uint64_t> quota2 = wait(getStorageQuotaHelper(cx, "name2"_sr));
+		state Optional<int64_t> quota2 = wait(getStorageQuotaHelper(cx, "name2"_sr));
 		ASSERT(quota2.present() && quota2.get() == 200);
-		state Optional<uint64_t> quota3 = wait(getStorageQuotaHelper(cx, "name3"_sr));
+		state Optional<int64_t> quota3 = wait(getStorageQuotaHelper(cx, "name3"_sr));
 		ASSERT(!quota3.present());
 
 		return Void();
 	}
 
-	ACTOR static Future<Void> setStorageQuotaHelper(Database cx, StringRef tenantName, uint64_t quota) {
+	ACTOR static Future<Void> setStorageQuotaHelper(Database cx, StringRef tenantName, int64_t quota) {
 		state Transaction tr(cx);
 		loop {
 			try {
@@ -61,11 +61,11 @@ struct StorageQuotaWorkload : TestWorkload {
 		}
 	}
 
-	ACTOR static Future<Optional<uint64_t>> getStorageQuotaHelper(Database cx, StringRef tenantName) {
+	ACTOR static Future<Optional<int64_t>> getStorageQuotaHelper(Database cx, StringRef tenantName) {
 		state Transaction tr(cx);
 		loop {
 			try {
-				state Optional<uint64_t> quota = wait(getStorageQuota(&tr, tenantName));
+				state Optional<int64_t> quota = wait(getStorageQuota(&tr, tenantName));
 				wait(tr.commit());
 				return quota;
 			} catch (Error& e) {


### PR DESCRIPTION
Add functionality to get tenants over storage quota. Additionally, refactor the code to simplify and improve the relevant monitors and simplify the data stored in TenantCache.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
