### PR TITLE
Improve error messages for `fdbcli` quota commands

### DIFF
--- a/fdbcli/QuotaCommand.actor.cpp
+++ b/fdbcli/QuotaCommand.actor.cpp
@@ -93,8 +93,12 @@ ACTOR Future<Void> setQuota(Reference<IDatabase> db, TransactionTag tag, LimitTy
 			} else if (limitType == LimitType::RESERVED) {
 				quota.reservedQuota = (value - 1) / CLIENT_KNOBS->READ_COST_BYTE_FACTOR + 1;
 			}
+			if (!quota.isValid()) {
+				throw invalid_throttle_quota_value();
+			}
 			ThrottleApi::setTagQuota(tr, tag, quota.reservedQuota, quota.totalQuota);
 			wait(safeThreadFutureToFuture(tr->commit()));
+			fmt::print("Successfully updated quota.\n");
 			return Void();
 		} catch (Error& e) {
 			wait(safeThreadFutureToFuture(tr->onError(e)));

--- a/fdbcli/QuotaCommand.actor.cpp
+++ b/fdbcli/QuotaCommand.actor.cpp
@@ -113,6 +113,7 @@ ACTOR Future<Void> clearQuota(Reference<IDatabase> db, TransactionTag tag) {
 		try {
 			tr->clear(ThrottleApi::getTagQuotaKey(tag));
 			wait(safeThreadFutureToFuture(tr->commit()));
+			fmt::print("Successfully cleared quota.\n");
 			return Void();
 		} catch (Error& e) {
 			wait(safeThreadFutureToFuture(tr->onError(e)));

--- a/fdbcli/tests/fdbcli_tests.py
+++ b/fdbcli/tests/fdbcli_tests.py
@@ -109,7 +109,7 @@ def quota(logger):
     command = 'quota clear green'
     output = run_fdbcli_command(command)
     logger.debug(command + ' : ' + output)
-    assert output == ''
+    assert output == 'Successfully cleared quota.'
 
     command = 'quota get green total_throughput'
     output = run_fdbcli_command(command)
@@ -120,17 +120,17 @@ def quota(logger):
     command = 'quota set red total_throughput 49152'
     output = run_fdbcli_command(command)
     logger.debug(command + ' : ' + output)
-    assert output == ''
+    assert output == 'Successfully updated quota.'
 
     command = 'quota set green total_throughput 32768'
     output = run_fdbcli_command(command)
     logger.debug(command + ' : ' + output)
-    assert output == ''
+    assert output == 'Successfully updated quota.'
 
     command = 'quota set green reserved_throughput 16384'
     output = run_fdbcli_command(command)
     logger.debug(command + ' : ' + output)
-    assert output == ''
+    assert output == 'Successfully updated quota.'
 
     command = 'quota get green total_throughput'
     output = run_fdbcli_command(command)
@@ -145,7 +145,7 @@ def quota(logger):
     command = 'quota clear green'
     output = run_fdbcli_command(command)
     logger.debug(command + ' : ' + output)
-    assert output == ''
+    assert output == 'Successfully cleared quota.'
 
     command = 'quota get green total_throughput'
     output = run_fdbcli_command(command)

--- a/flow/include/flow/error_definitions.h
+++ b/flow/include/flow/error_definitions.h
@@ -205,7 +205,7 @@ ERROR( key_not_tuple, 2041, "The key cannot be parsed as a tuple" );
 ERROR( value_not_tuple, 2042, "The value cannot be parsed as a tuple" );
 ERROR( mapper_not_tuple, 2043, "The mapper cannot be parsed as a tuple" );
 ERROR( invalid_checkpoint_format, 2044, "Invalid checkpoint format" )
-ERROR( invalid_throttle_quota_value, 2045, "Failed to deserialize or initialize throttle quota value" )
+ERROR( invalid_throttle_quota_value, 2045, "Invalid quota value. Note that reserved_throughput cannot exceed total_throughput" )
 
 ERROR( incompatible_protocol_version, 2100, "Incompatible protocol version" )
 ERROR( transaction_too_large, 2101, "Transaction exceeds byte limit" )


### PR DESCRIPTION
This PR contains three changes:
- Fail the `quota set` command if the quota is invalid (instead of waiting until the quota is used to throw an error)
- Print when a `quota set` or `quota clear` command is successful
- Make the `invalid_throttle_quota_value` error message more descriptive.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
