### PR TITLE
Fix circular reference in SSLConnection

### DIFF
--- a/flow/Net2.actor.cpp
+++ b/flow/Net2.actor.cpp
@@ -881,8 +881,8 @@ public:
 
 		try {
 			Future<Void> onHandshook;
-			ConfigureSSLStream(N2::g_net2->activeTlsPolicy, self->ssl_sock, [self = self](bool verifyOk) {
-				self->has_trusted_peer = verifyOk;
+			ConfigureSSLStream(N2::g_net2->activeTlsPolicy, self->ssl_sock, [conn = self.getPtr()](bool verifyOk) {
+				conn->has_trusted_peer = verifyOk;
 			});
 
 			// If the background handshakers are not all busy, use one
@@ -959,8 +959,8 @@ public:
 
 		try {
 			Future<Void> onHandshook;
-			ConfigureSSLStream(N2::g_net2->activeTlsPolicy, self->ssl_sock, [self = self](bool verifyOk) {
-				self->has_trusted_peer = verifyOk;
+			ConfigureSSLStream(N2::g_net2->activeTlsPolicy, self->ssl_sock, [conn = self.getPtr()](bool verifyOk) {
+				conn->has_trusted_peer = verifyOk;
 			});
 
 			// If the background handshakers are not all busy, use one


### PR DESCRIPTION
TLS verify-callback lambda holds reference to `SSLConnection`, its containing object, preventing SSLConnection memory from being freed and leaking memory up to ~124KB per connection, which includes OpenSSL data structures, asio SSL streams, etc.

Based on repeated ASAN test run outcome, normal TLS-enabled servers vs normal trusted/untrusted TLS clients don't seem to suffer from this issue. Only in the case when servers/clients are configured with bad certificates or didn't speak TLS was the memory left allocated even after network has stopped. This is likely due to the fact that `FlowTransport` closes the connection explicitly in non-adversarial cases, closing the `asio::ssl_stream` and destroying verify-callback object holding the reference, instead of simply letting connection references go out of scope.

This fix was confirmed to remove all leaks in the unit test.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
