### PR TITLE
msgpack: Refactor msgpack encoding in tracing

### DIFF
--- a/fdbclient/Tracing.actor.cpp
+++ b/fdbclient/Tracing.actor.cpp
@@ -18,6 +18,7 @@
  * limitations under the License.
  */
 
+#include "fdbrpc/Msgpack.h"
 #include "fdbclient/Tracing.h"
 #include "flow/IRandom.h"
 #include "flow/UnitTest.h"
@@ -79,41 +80,6 @@ struct LogfileTracer : ITracer {
 	}
 };
 
-struct TraceRequest {
-	std::unique_ptr<uint8_t[]> buffer;
-	// Amount of data in buffer (bytes).
-	std::size_t data_size;
-	// Size of buffer (bytes).
-	std::size_t buffer_size;
-
-	void write_byte(uint8_t byte) { write_bytes(&byte, 1); }
-
-	void write_bytes(const uint8_t* buf, std::size_t n) {
-		resize(n);
-		std::copy(buf, buf + n, buffer.get() + data_size);
-		data_size += n;
-	}
-
-	void resize(std::size_t n) {
-		if (data_size + n <= buffer_size) {
-			return;
-		}
-
-		std::size_t size = buffer_size;
-		while (size < data_size + n) {
-			size *= 2;
-		}
-
-		TraceEvent(SevInfo, "TracingSpanResizedBuffer").detail("OldSize", buffer_size).detail("NewSize", size);
-		auto new_buffer = std::make_unique<uint8_t[]>(size);
-		std::copy(buffer.get(), buffer.get() + data_size, new_buffer.get());
-		buffer = std::move(new_buffer);
-		buffer_size = size;
-	}
-
-	void reset() { data_size = 0; }
-};
-
 // A server listening for UDP trace messages, run only in simulation.
 ACTOR Future<Void> simulationStartServer() {
 	// We're going to force the address to be loopback regardless of FLOW_KNOBS->TRACING_UDP_LISTENER_ADDR
@@ -167,146 +133,89 @@ ACTOR Future<Void> traceLog(int* pendingMessages, bool* sendError) {
 struct UDPTracer : public ITracer {
 	// Serializes span fields as an array into the supplied TraceRequest
 	// buffer.
-	void serialize_span(const Span& span, TraceRequest& request) {
+	void serialize_span(const Span& span, MsgpackBuffer& buf) {
 		uint16_t size = 12;
-		request.write_byte(size | 0b10010000); // write as array
-		serialize_value(span.context.traceID.first(), request, 0xcf); // trace id
-		serialize_value(span.context.traceID.second(), request, 0xcf); // trace id
-		serialize_value(span.context.spanID, request, 0xcf); // spanid
+		buf.write_byte(size | 0b10010000); // write as array
+		serialize_value(span.context.traceID.first(), buf, 0xcf); // trace id
+		serialize_value(span.context.traceID.second(), buf, 0xcf); // trace id
+		serialize_value(span.context.spanID, buf, 0xcf); // spanid
 		// parent span id
-		serialize_value(span.parentContext.spanID, request, 0xcf); // spanId
+		serialize_value(span.parentContext.spanID, buf, 0xcf); // spanId
 		// Payload
-		serialize_string(span.location.name.toString(), request);
-		serialize_value(span.begin, request, 0xcb); // start time
-		serialize_value(span.end, request, 0xcb); // end
+		serialize_string(span.location.name.toString(), buf);
+		serialize_value(span.begin, buf, 0xcb); // start time
+		serialize_value(span.end, buf, 0xcb); // end
 		// Kind
-		serialize_value(span.kind, request, 0xcc);
+		serialize_value(span.kind, buf, 0xcc);
 		// Status
-		serialize_value(span.status, request, 0xcc);
+		serialize_value(span.status, buf, 0xcc);
 		// Links
-		serialize_vector(span.links, request);
+		serialize_vector(span.links, buf);
 		// Events
-		serialize_vector(span.events, request);
+		serialize_vector(span.events, buf);
 		// Attributes
-		serialize_map(span.attributes, request);
+		serialize_map(span.attributes, buf);
 	}
 
 private:
-	// Writes the given value in big-endian format to the request. Sets the
-	// first byte to msgpack_type.
-	template <typename T>
-	inline void serialize_value(const T& val, TraceRequest& request, uint8_t msgpack_type) {
-		request.write_byte(msgpack_type);
-
-		const uint8_t* p = reinterpret_cast<const uint8_t*>(std::addressof(val));
-		for (size_t i = 0; i < sizeof(T); ++i) {
-			request.write_byte(p[sizeof(T) - i - 1]);
-		}
-	}
-
-	// Writes the given string to the request as a sequence of bytes. Inserts a
-	// format byte at the beginning of the string according to the its length,
-	// as specified by the msgpack specification.
-	inline void serialize_string(const uint8_t* c, int length, TraceRequest& request) {
-		if (length <= 31) {
-			// A size 0 string is ok. We still need to write a byte
-			// identifiying the item as a string, but can set the size to 0.
-			request.write_byte(static_cast<uint8_t>(length) | 0b10100000);
-		} else if (length <= 255) {
-			request.write_byte(0xd9);
-			request.write_byte(static_cast<uint8_t>(length));
-		} else if (length <= 65535) {
-			request.write_byte(0xda);
-			request.write_byte(reinterpret_cast<const uint8_t*>(&length)[1]);
-			request.write_byte(reinterpret_cast<const uint8_t*>(&length)[0]);
-		} else {
-			TraceEvent(SevWarn, "TracingSpanSerializeString")
-			    .detail("Failed to MessagePack encode very large string", length);
-			ASSERT_WE_THINK(false);
-		}
-
-		request.write_bytes(c, length);
-	}
-
-	inline void serialize_string(const std::string& str, TraceRequest& request) {
-		serialize_string(reinterpret_cast<const uint8_t*>(str.data()), str.size(), request);
-	}
-
 	// Writes the given vector of linked SpanContext's to the request. If the vector is
 	// empty, the request is not modified.
-	inline void serialize_vector(const SmallVectorRef<SpanContext>& vec, TraceRequest& request) {
+	inline void serialize_vector(const SmallVectorRef<SpanContext>& vec, MsgpackBuffer& buf) {
 		int size = vec.size();
 		if (size <= 15) {
-			request.write_byte(static_cast<uint8_t>(size) | 0b10010000);
+			buf.write_byte(static_cast<uint8_t>(size) | 0b10010000);
 		} else if (size <= 65535) {
-			request.write_byte(0xdc);
-			request.write_byte(reinterpret_cast<const uint8_t*>(&size)[1]);
-			request.write_byte(reinterpret_cast<const uint8_t*>(&size)[0]);
+			buf.write_byte(0xdc);
+			buf.write_byte(reinterpret_cast<const uint8_t*>(&size)[1]);
+			buf.write_byte(reinterpret_cast<const uint8_t*>(&size)[0]);
 		} else {
 			TraceEvent(SevWarn, "TracingSpanSerializeVector").detail("Failed to MessagePack encode large vector", size);
 			ASSERT_WE_THINK(false);
 		}
 
 		for (const auto& link : vec) {
-			serialize_value(link.traceID.first(), request, 0xcf); // trace id
-			serialize_value(link.traceID.second(), request, 0xcf); // trace id
-			serialize_value(link.spanID, request, 0xcf); // spanid
+			serialize_value(link.traceID.first(), buf, 0xcf); // trace id
+			serialize_value(link.traceID.second(), buf, 0xcf); // trace id
+			serialize_value(link.spanID, buf, 0xcf); // spanid
 		}
 	}
 
-	// Writes the given vector of linked SpanContext's to the request. If the vector is
+	// Writes the given vector of linked SpanEventRef's to the request. If the vector is
 	// empty, the request is not modified.
-	inline void serialize_vector(const SmallVectorRef<SpanEventRef>& vec, TraceRequest& request) {
+	inline void serialize_vector(const SmallVectorRef<SpanEventRef>& vec, MsgpackBuffer& buf) {
 		int size = vec.size();
 		if (size <= 15) {
-			request.write_byte(static_cast<uint8_t>(size) | 0b10010000);
+			buf.write_byte(static_cast<uint8_t>(size) | 0b10010000);
 		} else if (size <= 65535) {
-			request.write_byte(0xdc);
-			request.write_byte(reinterpret_cast<const uint8_t*>(&size)[1]);
-			request.write_byte(reinterpret_cast<const uint8_t*>(&size)[0]);
+			buf.write_byte(0xdc);
+			buf.write_byte(reinterpret_cast<const uint8_t*>(&size)[1]);
+			buf.write_byte(reinterpret_cast<const uint8_t*>(&size)[0]);
 		} else {
 			TraceEvent(SevWarn, "TracingSpanSerializeVector").detail("Failed to MessagePack encode large vector", size);
 			ASSERT_WE_THINK(false);
 		}
 
 		for (const auto& event : vec) {
-			serialize_string(event.name.toString(), request); // event name
-			serialize_value(event.time, request, 0xcb); // event time
-			serialize_vector(event.attributes, request);
+			serialize_string(event.name.toString(), buf); // event name
+			serialize_value(event.time, buf, 0xcb); // event time
+			serialize_vector(event.attributes, buf);
 		}
 	}
 
-	inline void serialize_vector(const SmallVectorRef<KeyValueRef>& vals, TraceRequest& request) {
+	inline void serialize_vector(const SmallVectorRef<KeyValueRef>& vals, MsgpackBuffer& buf) {
 		int size = vals.size();
 		if (size <= 15) {
 			// N.B. We're actually writing this out as a fixmap here in messagepack format!
 			// fixmap	1000xxxx	0x80 - 0x8f
-			request.write_byte(static_cast<uint8_t>(size) | 0b10000000);
+			buf.write_byte(static_cast<uint8_t>(size) | 0b10000000);
 		} else {
 			TraceEvent(SevWarn, "TracingSpanSerializeVector").detail("Failed to MessagePack encode large vector", size);
 			ASSERT_WE_THINK(false);
 		}
 
 		for (const auto& kv : vals) {
-			serialize_string(kv.key.toString(), request);
-			serialize_string(kv.value.toString(), request);
-		}
-	}
-
-	template <class Map>
-	inline void serialize_map(const Map& map, TraceRequest& request) {
-		int size = map.size();
-
-		if (size <= 15) {
-			request.write_byte(static_cast<uint8_t>(size) | 0b10000000);
-		} else {
-			TraceEvent(SevWarn, "TracingSpanSerializeMap").detail("Failed to MessagePack encode large map", size);
-			ASSERT_WE_THINK(false);
-		}
-
-		for (const auto& [key, value] : map) {
-			serialize_string(key.begin(), key.size(), request);
-			serialize_string(value.begin(), value.size(), request);
+			serialize_string(kv.key.toString(), buf);
+			serialize_string(kv.value.toString(), buf);
 		}
 	}
 };
@@ -336,9 +245,9 @@ ACTOR Future<Void> fastTraceLogger(int* unreadyMessages, int* failedMessages, in
 struct FastUDPTracer : public UDPTracer {
 	FastUDPTracer()
 	  : unready_socket_messages_(0), failed_messages_(0), total_messages_(0), socket_fd_(-1), send_error_(false) {
-		request_ = TraceRequest{ .buffer = std::make_unique<uint8_t[]>(kTraceBufferSize),
-			                     .data_size = 0,
-			                     .buffer_size = kTraceBufferSize };
+		request_ = MsgpackBuffer{ .buffer = std::make_unique<uint8_t[]>(kTraceBufferSize),
+			                      .data_size = 0,
+			                      .buffer_size = kTraceBufferSize };
 	}
 
 	TracerType type() const override { return TracerType::NETWORK_LOSSY; }
@@ -394,7 +303,7 @@ struct FastUDPTracer : public UDPTracer {
 	}
 
 private:
-	TraceRequest request_;
+	MsgpackBuffer request_;
 
 	int unready_socket_messages_;
 	int failed_messages_;
@@ -657,9 +566,9 @@ TEST_CASE("/flow/Tracing/FastUDPMessagePackEncoding") {
 	IKnobCollection::getMutableGlobalKnobCollection().setKnob("tracing_span_attributes_enabled",
 	                                                          KnobValueRef::create(bool{ true }));
 	Span span1("encoded_span"_loc);
-	auto request = TraceRequest{ .buffer = std::make_unique<uint8_t[]>(kTraceBufferSize),
-		                         .data_size = 0,
-		                         .buffer_size = kTraceBufferSize };
+	auto request = MsgpackBuffer{ .buffer = std::make_unique<uint8_t[]>(kTraceBufferSize),
+		                          .data_size = 0,
+		                          .buffer_size = kTraceBufferSize };
 	auto tracer = FastUDPTracer();
 	tracer.serialize_span(span1, request);
 	auto data = request.buffer.get();

--- a/fdbrpc/include/fdbrpc/Msgpack.h
+++ b/fdbrpc/include/fdbrpc/Msgpack.h
@@ -1,0 +1,157 @@
+/*
+ * Msgpack.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef FDBRPC_MSGPACK_H
+#define FDBRPC_MSGPACK_H
+#include <limits>
+#pragma once
+
+#include <memory>
+#include <algorithm>
+#include "flow/Trace.h"
+#include "flow/Error.h"
+#include "flow/network.h"
+
+struct MsgpackBuffer {
+	std::unique_ptr<uint8_t[]> buffer;
+	// Amount of data in buffer (bytes).
+	std::size_t data_size;
+	// Size of buffer (bytes).
+	std::size_t buffer_size;
+
+	void write_byte(uint8_t byte) { write_bytes(&byte, 1); }
+
+	// This assumes that pos <= data_size
+	void edit_byte(uint8_t byte, size_t pos) { buffer[pos] = byte; }
+
+	void write_bytes(const uint8_t* buf, std::size_t n) {
+		resize(n);
+		std::copy(buf, buf + n, buffer.get() + data_size);
+		data_size += n;
+	}
+
+	void resize(std::size_t n) {
+		if (data_size + n <= buffer_size) {
+			return;
+		}
+
+		std::size_t size = buffer_size;
+		while (size < data_size + n) {
+			size *= 2;
+		}
+
+		TraceEvent(SevInfo, "MsgpackResizedBuffer").detail("OldSize", buffer_size).detail("NewSize", size);
+		auto new_buffer = std::make_unique<uint8_t[]>(size);
+		std::copy(buffer.get(), buffer.get() + data_size, new_buffer.get());
+		buffer = std::move(new_buffer);
+		buffer_size = size;
+	}
+
+	void reset() { data_size = 0; }
+};
+
+inline void serialize_bool(bool val, MsgpackBuffer& buf) {
+	if (val) {
+		buf.write_byte(0xc3);
+	} else {
+		buf.write_byte(0xc2);
+	}
+}
+
+// Writes the given value in big-endian format to the request. Sets the
+// first byte to msgpack_type.
+template <typename T>
+inline void serialize_value(const T& val, MsgpackBuffer& buf, uint8_t msgpack_type) {
+	buf.write_byte(msgpack_type);
+
+	const uint8_t* p = reinterpret_cast<const uint8_t*>(std::addressof(val));
+	for (size_t i = 0; i < sizeof(T); ++i) {
+		buf.write_byte(p[sizeof(T) - i - 1]);
+	}
+}
+
+// Writes the given string to the request as a sequence of bytes. Inserts a
+// format byte at the beginning of the string according to the its length,
+// as specified by the msgpack specification.
+inline void serialize_string(const uint8_t* c, int length, MsgpackBuffer& buf) {
+	if (length <= 31) {
+		// A size 0 string is ok. We still need to write a byte
+		// identifiying the item as a string, but can set the size to 0.
+		buf.write_byte(static_cast<uint8_t>(length) | 0b10100000);
+	} else if (length <= 255) {
+		buf.write_byte(0xd9);
+		buf.write_byte(static_cast<uint8_t>(length));
+	} else if (length <= 65535) {
+		buf.write_byte(0xda);
+		buf.write_byte(reinterpret_cast<const uint8_t*>(&length)[1]);
+		buf.write_byte(reinterpret_cast<const uint8_t*>(&length)[0]);
+	} else {
+		TraceEvent(SevWarn, "MsgpackSerializeString").detail("Failed to MessagePack encode very large string", length);
+		ASSERT_WE_THINK(false);
+	}
+
+	buf.write_bytes(c, length);
+}
+
+inline void serialize_string(const std::string& str, MsgpackBuffer& buf) {
+	serialize_string(reinterpret_cast<const uint8_t*>(str.data()), str.size(), buf);
+}
+
+template <typename T, typename F>
+inline void serialize_vector(const std::vector<T>& vec, MsgpackBuffer& buf, F f) {
+	size_t size = vec.size();
+	if (size <= 15) {
+		buf.write_byte(static_cast<uint8_t>(size) | 0b10010000);
+	} else if (size <= 65535) {
+		buf.write_byte(0xdc);
+		buf.write_byte(reinterpret_cast<const uint8_t*>(&size)[1]);
+		buf.write_byte(reinterpret_cast<const uint8_t*>(&size)[0]);
+	} else if (size <= std::numeric_limits<uint32_t>::max()) {
+		buf.write_byte(0xdd);
+		buf.write_byte(reinterpret_cast<const uint8_t*>(&size)[3]);
+		buf.write_byte(reinterpret_cast<const uint8_t*>(&size)[2]);
+		buf.write_byte(reinterpret_cast<const uint8_t*>(&size)[1]);
+		buf.write_byte(reinterpret_cast<const uint8_t*>(&size)[0]);
+	} else {
+		TraceEvent(SevWarn, "MsgPackSerializeVector").detail("Failed to MessagePack encode large vector", size);
+		ASSERT_WE_THINK(false);
+	}
+	// Use the provided serializer function to serialize the individual types of the vector
+	for (const auto& val : vec) {
+		f(val, buf);
+	}
+}
+
+template <class Map>
+inline void serialize_map(const Map& map, MsgpackBuffer& buf) {
+	int size = map.size();
+
+	if (size <= 15) {
+		buf.write_byte(static_cast<uint8_t>(size) | 0b10000000);
+	} else {
+		TraceEvent(SevWarn, "MsgPackSerializeMap").detail("Failed to MessagePack encode large map", size);
+		ASSERT_WE_THINK(false);
+	}
+
+	for (const auto& [key, value] : map) {
+		serialize_string(key.begin(), key.size(), buf);
+		serialize_string(value.begin(), value.size(), buf);
+	}
+}
+#endif


### PR DESCRIPTION

This PR refactors the msgpack encoding logic into its own file and generalizes the serialization to work with arbitrary types (given a function to serialize such type). 

This has passed 100K Joshua tests

20221029-011545-khoxha-foundationdb-01df101581403c3c


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
