### PR TITLE
Fix auto-retry error check in Java binding.

### DIFF
--- a/bindings/java/src/main/com/apple/foundationdb/FDBDatabase.java
+++ b/bindings/java/src/main/com/apple/foundationdb/FDBDatabase.java
@@ -60,7 +60,7 @@ class FDBDatabase extends NativeObjectWrapper implements Database, OptionConsume
 					T returnVal = retryable.apply(t);
 					t.commit().join();
 					return returnVal;
-				} catch (RuntimeException err) {
+				} catch (Exception err) {
 					t = t.onError(err).join();
 				}
 			}


### PR DESCRIPTION
The auto-retry loop in `run()` was not passing `ExecutionException` to `onError`, because this type is not a subclass of `RuntimeException`.

The `onError` method on `FDBTransaction` unwraps `CompletionException` and `ExecutionException`, so it should be a reasonable behavior to have `run()` also handle both these two exception types.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
