### PR TITLE
temporarily fix the heap use after free problem

### DIFF
--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -786,9 +786,9 @@ ACTOR Future<Void> dataDistribution(Reference<DataDistributor> self,
 				}
 				shards.clear();
 				throw e;
-			} else {
-				wait(shards.clearAsync());
 			}
+
+			wait(shards.clearAsync());
 			TraceEvent("DataDistributorTeamCollectionsDestroyed").error(err);
 			if (removeFailedServer.getFuture().isReady() && !removeFailedServer.getFuture().isError()) {
 				TraceEvent("RemoveFailedServer", removeFailedServer.getFuture().get()).error(err);


### PR DESCRIPTION
Fix #8610

Through copying the reference so that after DDTeamCollection destruction, the uncancelled `trackExcludedServers` still can access the legal IDDTxnProcessor Reference.

However, the real problem is coming from the `~WatchRefCountUpdater` throw a `broken_promise` which causes the `trackExcludedServers` to throw a `transaction_cancelled` exception so that the `DDTeamCollection` is destroyed and also leaves a SevError trace event. 
Two additional problems I observe:
1. When enabling ASAN, some trace events weren't flushed to the log file.
2. The lifetime of `trackExcludedServers` is longer than `DDTeamCollection` is not expected given the way we hold the future.

backtrace:
```BaseTraceEvent::backtrace(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) at /mnt/ephemeral/xwang/buildCopFfdb/flow/Trace.cpp:?
__is_long at /usr/local/bin/../include/c++/v1/string:1456
 (inlined by) ~basic_string at /usr/local/bin/../include/c++/v1/string:2267
 (inlined by) a_body1loopBody1Catch1 at /mnt/ephemeral/xwang/buildCopFfdb/fdbserver/DDTeamCollection.actor.cpp:1925
DDTeamCollectionImpl::TrackExcludedServersActorState<DDTeamCollectionImpl::TrackExcludedServersActor>::a_callback_error(ActorCallback<DDTeamCollectionImpl::TrackExcludedServersActor, 3, Void>*, Error) at /mnt/ephemeral/xwang/build/buildCopFfdb.linux.clang.asan.x86_64/fdbserver/DDTeamCollection.actor.g.cpp:11362
SAV<Void>::sendErrorAndDelPromiseRef(Error) at /mnt/ephemeral/xwang/buildCopFfdb/flow/include/flow/flow.h:711
ActorCallback<(anonymous namespace)::ChooseActorActor<Void>, 1, Void>::error(Error) at /mnt/ephemeral/xwang/buildCopFfdb/flow/include/flow/flow.h:1313
SAV<Void>::sendErrorAndDelPromiseRef(Error) at /mnt/ephemeral/xwang/buildCopFfdb/flow/include/flow/flow.h:711
RYWImpl::WatchActorState<RYWImpl::WatchActor>::a_callback_error(ActorCallback<RYWImpl::WatchActor, 1, Void>*, Error) at /mnt/ephemeral/xwang/build/buildCopFfdb.linux.clang.asan.x86_64/fdbclient/ReadYourWrites.actor.g.cpp:5825
SAV<Void>::sendErrorAndDelPromiseRef(Error) at /mnt/ephemeral/xwang/buildCopFfdb/flow/include/flow/flow.h:711
(anonymous namespace)::WatchActorState<(anonymous namespace)::WatchActor>::a_body1Catch2(Error const&, int) at /mnt/ephemeral/xwang/build/buildCopFfdb.linux.clang.asan.x86_64/fdbclient/NativeAPI.actor.g.cpp:24990
(anonymous namespace)::WatchActorState<(anonymous namespace)::WatchActor>::a_callback_error(ActorCallback<(anonymous namespace)::WatchActor, 3, Void>*, Error) at /mnt/ephemeral/xwang/build/buildCopFfdb.linux.clang.asan.x86_64/fdbclient/NativeAPI.actor.g.cpp:25312
SAV<Void>::sendErrorAndDelPromiseRef(Error) at /mnt/ephemeral/xwang/buildCopFfdb/flow/include/flow/flow.h:711
(anonymous namespace)::WatchValueMapActorState<(anonymous namespace)::WatchValueMapActor>::a_callback_error(ActorCallback<(anonymous namespace)::WatchValueMapActor, 1, Void>*, Error) at /mnt/ephemeral/xwang/build/buildCopFfdb.linux.clang.asan.x86_64/fdbclient/NativeAPI.actor.g.cpp:17856
SAV<Void>::sendErrorAndDelPromiseRef(Error) at /mnt/ephemeral/xwang/buildCopFfdb/flow/include/flow/flow.h:711
(anonymous namespace)::SuccessActorState<long, (anonymous namespace)::SuccessActor<long> >::a_callback_error(ActorCallback<(anonymous namespace)::SuccessActor<long>, 0, long>*, Error) at /mnt/ephemeral/xwang/build/buildCopFfdb.linux.clang.asan.x86_64/flow/include/flow/genericactors.actor.g.h:12105
SAV<long>::sendError(Error) at /mnt/ephemeral/xwang/buildCopFfdb/flow/include/flow/flow.h:667
SAV<long>::delPromiseRef() at /mnt/ephemeral/xwang/buildCopFfdb/flow/include/flow/flow.h:725
WatchMetadata::~WatchMetadata() at /mnt/ephemeral/xwang/buildCopFfdb/fdbclient/include/fdbclient/DatabaseContext.h:149
delref at /mnt/ephemeral/xwang/buildCopFfdb/flow/include/flow/FastRef.h:70
 (inlined by) delref<WatchMetadata> at /mnt/ephemeral/xwang/buildCopFfdb/flow/include/flow/FastRef.h:95
 (inlined by) ~Reference at /mnt/ephemeral/xwang/buildCopFfdb/flow/include/flow/FastRef.h:126
 (inlined by) decreaseWatchRefCount at /mnt/ephemeral/xwang/buildCopFfdb/fdbclient/DatabaseContext.cpp:62
~Reference at /mnt/ephemeral/xwang/buildCopFfdb/flow/include/flow/FastRef.h:125
 (inlined by) ~Database at /mnt/ephemeral/xwang/buildCopFfdb/fdbclient/include/fdbclient/NativeAPI.actor.h:83
 (inlined by) ~WatchRefCountUpdater at /mnt/ephemeral/xwang/buildCopFfdb/fdbclient/NativeAPI.actor.cpp:3936
data at /usr/local/bin/../include/c++/v1/vector:722
 (inlined by) __annotate_delete at /usr/local/bin/../include/c++/v1/vector:901
 (inlined by) ~vector at /usr/local/bin/../include/c++/v1/vector:575
 (inlined by) ~TagSet at /mnt/ephemeral/xwang/buildCopFfdb/fdbclient/include/fdbclient/TagThrottle.actor.h:46
 (inlined by) ~WatchValueMapActorState at /mnt/ephemeral/xwang/build/buildCopFfdb.linux.clang.asan.x86_64/fdbclient/NativeAPI.actor.g.cpp:17653
a_body1Catch1 at /mnt/ephemeral/xwang/build/buildCopFfdb.linux.clang.asan.x86_64/fdbclient/NativeAPI.actor.g.cpp:17680
 (inlined by) (anonymous namespace)::WatchValueMapActorState<(anonymous namespace)::WatchValueMapActor>::a_callback_error(ActorCallback<(anonymous namespace)::WatchValueMapActor, 1, Void>*, Error) at /mnt/ephemeral/xwang/build/buildCopFfdb.linux.clang.asan.x86_64/fdbclient/NativeAPI.actor.g.cpp:17847
(anonymous namespace)::WatchValueMapActor::cancel() at /mnt/ephemeral/xwang/build/buildCopFfdb.linux.clang.asan.x86_64/fdbclient/NativeAPI.actor.g.cpp:17920
~Promise at /mnt/ephemeral/xwang/buildCopFfdb/flow/include/flow/flow.h:915
 (inlined by) ~Watch at /mnt/ephemeral/xwang/buildCopFfdb/fdbclient/include/fdbclient/NativeAPI.actor.h:221
delref at /mnt/ephemeral/xwang/buildCopFfdb/flow/include/flow/FastRef.h:70
 (inlined by) delref<Watch> at /mnt/ephemeral/xwang/buildCopFfdb/flow/include/flow/FastRef.h:95
 (inlined by) ~Reference at /mnt/ephemeral/xwang/buildCopFfdb/flow/include/flow/FastRef.h:126
 (inlined by) destroy at /usr/local/bin/../include/c++/v1/__memory/allocator.h:159
 (inlined by) destroy<Reference<Watch>, void> at /usr/local/bin/../include/c++/v1/__memory/allocator_traits.h:309
 (inlined by) __destruct_at_end at /usr/local/bin/../include/c++/v1/vector:450
 (inlined by) clear at /usr/local/bin/../include/c++/v1/vector:374
 (inlined by) ~__vector_base at /usr/local/bin/../include/c++/v1/vector:487
 (inlined by) ~vector at /usr/local/bin/../include/c++/v1/vector:579
 (inlined by) ~MapPair at /mnt/ephemeral/xwang/buildCopFfdb/flow/include/flow/IndexedSet.h:368
operator delete at /mnt/ephemeral/xwang/buildCopFfdb/flow/include/flow/FastAlloc.h:229
 (inlined by) ~Node at /mnt/ephemeral/xwang/buildCopFfdb/flow/include/flow/IndexedSet.h:80
operator delete at /mnt/ephemeral/xwang/buildCopFfdb/flow/include/flow/FastAlloc.h:229
 (inlined by) ~Node at /mnt/ephemeral/xwang/buildCopFfdb/flow/include/flow/IndexedSet.h:80
operator delete at /mnt/ephemeral/xwang/buildCopFfdb/flow/include/flow/FastAlloc.h:229
 (inlined by) clear at /mnt/ephemeral/xwang/buildCopFfdb/flow/include/flow/IndexedSet.h:179
 (inlined by) clear at /mnt/ephemeral/xwang/buildCopFfdb/flow/include/flow/IndexedSet.h:468
 (inlined by) resetRyow at /mnt/ephemeral/xwang/buildCopFfdb/fdbclient/ReadYourWrites.actor.cpp:2615
ReadYourWritesTransaction::reset() at /mnt/ephemeral/xwang/buildCopFfdb/fdbclient/ReadYourWrites.actor.cpp:2650
a_body1loopBody1cont16 at /mnt/ephemeral/xwang/build/buildCopFfdb.linux.clang.asan.x86_64/fdbserver/DDTeamCollection.actor.g.cpp:11287
 (inlined by) a_body1loopBody1cont8when1 at /mnt/ephemeral/xwang/build/buildCopFfdb.linux.clang.asan.x86_64/fdbserver/DDTeamCollection.actor.g.cpp:11302
 (inlined by) a_callback_fire at /mnt/ephemeral/xwang/build/buildCopFfdb.linux.clang.asan.x86_64/fdbserver/DDTeamCollection.actor.g.cpp:11323
finishSendAndDelPromiseRef at /mnt/ephemeral/xwang/buildCopFfdb/flow/include/flow/flow.h:688
 (inlined by) a_body1when1 at /mnt/ephemeral/xwang/build/buildCopFfdb.linux.clang.asan.x86_64/flow/include/flow/genericactors.actor.g.h:14227
 (inlined by) a_callback_fire at /mnt/ephemeral/xwang/build/buildCopFfdb.linux.clang.asan.x86_64/flow/include/flow/genericactors.actor.g.h:14280
 (inlined by) fire at /mnt/ephemeral/xwang/buildCopFfdb/flow/include/flow/flow.h:1306
finishSendAndDelPromiseRef at /mnt/ephemeral/xwang/buildCopFfdb/flow/include/flow/flow.h:688
 (inlined by) a_body1when2 at /mnt/ephemeral/xwang/build/buildCopFfdb.linux.clang.asan.x86_64/flow/include/flow/genericactors.actor.g.h:14251
 (inlined by) a_callback_fire at /mnt/ephemeral/xwang/build/buildCopFfdb.linux.clang.asan.x86_64/flow/include/flow/genericactors.actor.g.h:14325
 (inlined by) fire at /mnt/ephemeral/xwang/buildCopFfdb/flow/include/flow/flow.h:1306
finishSendAndDelPromiseRef at /mnt/ephemeral/xwang/buildCopFfdb/flow/include/flow/flow.h:688
 (inlined by) a_body1cont12 at /mnt/ephemeral/xwang/build/buildCopFfdb.linux.clang.asan.x86_64/fdbclient/ReadYourWrites.actor.g.cpp:5746
 (inlined by) a_body1cont6when1 at /mnt/ephemeral/xwang/build/buildCopFfdb.linux.clang.asan.x86_64/fdbclient/ReadYourWrites.actor.g.cpp:5765
 (inlined by) a_callback_fire at /mnt/ephemeral/xwang/build/buildCopFfdb.linux.clang.asan.x86_64/fdbclient/ReadYourWrites.actor.g.cpp:5786
finishSendAndDelPromiseRef at /mnt/ephemeral/xwang/buildCopFfdb/flow/include/flow/flow.h:688
 (inlined by) a_body1cont1 at /mnt/ephemeral/xwang/build/buildCopFfdb.linux.clang.asan.x86_64/fdbclient/NativeAPI.actor.g.cpp:24969
 (inlined by) a_body1cont3 at /mnt/ephemeral/xwang/build/buildCopFfdb.linux.clang.asan.x86_64/fdbclient/NativeAPI.actor.g.cpp:25406
 (inlined by) a_body1cont2 at /mnt/ephemeral/xwang/build/buildCopFfdb.linux.clang.asan.x86_64/fdbclient/NativeAPI.actor.g.cpp:24993
(anonymous namespace)::WatchActorState<(anonymous namespace)::WatchActor>::a_body1when2cont1loopBody1when1(Void const&, int) at /mnt/ephemeral/xwang/build/buildCopFfdb.linux.clang.asan.x86_64/fdbclient/NativeAPI.actor.g.cpp:25225
ActorCallback<(anonymous namespace)::WatchActor, 3, Void>::fire(Void const&) at /mnt/ephemeral/xwang/buildCopFfdb/flow/include/flow/flow.h:1307
finishSendAndDelPromiseRef at /mnt/ephemeral/xwang/buildCopFfdb/flow/include/flow/flow.h:688
 (inlined by) a_body1cont2 at /mnt/ephemeral/xwang/build/buildCopFfdb.linux.clang.asan.x86_64/fdbclient/NativeAPI.actor.g.cpp:17777
 (inlined by) a_body1cont1when1 at /mnt/ephemeral/xwang/build/buildCopFfdb.linux.clang.asan.x86_64/fdbclient/NativeAPI.actor.g.cpp:17796
 (inlined by) a_callback_fire at /mnt/ephemeral/xwang/build/buildCopFfdb.linux.clang.asan.x86_64/fdbclient/NativeAPI.actor.g.cpp:17817
 (inlined by) fire at /mnt/ephemeral/xwang/buildCopFfdb/flow/include/flow/flow.h:1306
finishSendAndDelPromiseRef at /mnt/ephemeral/xwang/buildCopFfdb/flow/include/flow/flow.h:688
 (inlined by) a_body1cont1 at /mnt/ephemeral/xwang/build/buildCopFfdb.linux.clang.asan.x86_64/flow/include/flow/genericactors.actor.g.h:12024
 (inlined by) a_body1when1 at /mnt/ephemeral/xwang/build/buildCopFfdb.linux.clang.asan.x86_64/flow/include/flow/genericactors.actor.g.h:12045
ActorCallback<(anonymous namespace)::SuccessActor<long>, 0, long>::fire(long const&) at /mnt/ephemeral/xwang/buildCopFfdb/flow/include/flow/flow.h:1307
void SAV<long>::send<long const&>(long const&) at /mnt/ephemeral/xwang/buildCopFfdb/flow/include/flow/flow.h:654
a_body1loopBody1cont1 at /mnt/ephemeral/xwang/build/buildCopFfdb.linux.clang.asan.x86_64/fdbclient/NativeAPI.actor.g.cpp:16758
 (inlined by) a_body1loopBody1cont10 at /mnt/ephemeral/xwang/build/buildCopFfdb.linux.clang.asan.x86_64/fdbclient/NativeAPI.actor.g.cpp:16991
 (inlined by) a_body1loopBody1cont2 at /mnt/ephemeral/xwang/build/buildCopFfdb.linux.clang.asan.x86_64/fdbclient/NativeAPI.actor.g.cpp:16873
ActorCallback<(anonymous namespace)::WatchStorageServerRespActor, 0, long>::fire(long const&) at /mnt/ephemeral/xwang/buildCopFfdb/flow/include/flow/flow.h:1307
finishSendAndDelPromiseRef at /mnt/ephemeral/xwang/buildCopFfdb/flow/include/flow/flow.h:688
 (inlined by) a_body1loopBody1cont6 at /mnt/ephemeral/xwang/build/buildCopFfdb.linux.clang.asan.x86_64/fdbclient/NativeAPI.actor.g.cpp:16068
ActorCallback<(anonymous namespace)::WatchValueActor, 4, long>::fire(long const&) at /mnt/ephemeral/xwang/buildCopFfdb/flow/include/flow/flow.h:1307
finishSendAndDelPromiseRef at /mnt/ephemeral/xwang/buildCopFfdb/flow/include/flow/flow.h:688
 (inlined by) a_body1loopBody1when2 at /mnt/ephemeral/xwang/build/buildCopFfdb.linux.clang.asan.x86_64/fdbclient/NativeAPI.actor.g.cpp:14774
ActorCallback<(anonymous namespace)::WaitForCommittedVersionActor, 1, GetReadVersionReply>::fire(GetReadVersionReply const&) at /mnt/ephemeral/xwang/buildCopFfdb/flow/include/flow/flow.h:1307
?? ??:0
```
# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
