### PR TITLE
Fix unintended behavior in Mako

### DIFF
--- a/bindings/c/test/mako/async.cpp
+++ b/bindings/c/test/mako/async.cpp
@@ -184,7 +184,7 @@ void ResumableStateForRunWorkload::updateStepStats() {
 	}
 }
 
-force_inline void ResumableStateForRunWorkload::updateErrorStats(const fdb::Error& err, int op) {
+void ResumableStateForRunWorkload::updateErrorStats(const fdb::Error& err, int op) {
 	if (err) {
 		if (err.is(1020 /*not_commited*/)) {
 			stats.incrConflictCount();
@@ -240,7 +240,7 @@ void ResumableStateForRunWorkload::onTransactionSuccess() {
 		restartIteration(FutureRC::OK);
 	}
 }
-force_inline void ResumableStateForRunWorkload::restartIteration(FutureRC rc) {
+void ResumableStateForRunWorkload::restartIteration(FutureRC rc) {
 	// restart current iteration from beginning unless ended
 	if (rc == FutureRC::OK || rc == FutureRC::ABORT) {
 		total_xacts++;

--- a/bindings/c/test/mako/async.cpp
+++ b/bindings/c/test/mako/async.cpp
@@ -134,7 +134,7 @@ repeat_immediate_steps:
 					updateErrorStats(stats, err, iter.op);
 					tx.onError(err).then([this, state = shared_from_this()](Future f) {
 						const auto rc = handleForOnError(tx, f, fmt::format("{}:{}", iter.opName(), iter.step));
-						restartIteration(rc);
+						onIterationEnd(rc);
 					});
 				} else {
 					// async step succeeded
@@ -150,7 +150,7 @@ repeat_immediate_steps:
 				// blob granules op error
 				updateErrorStats(stats, f.error(), iter.op);
 				FutureRC rc = handleForOnError(tx, f, "BG_ON_ERROR");
-				restartIteration(rc);
+				onIterationEnd(rc);
 			}
 		});
 	}
@@ -198,7 +198,7 @@ void ResumableStateForRunWorkload::onTransactionSuccess() {
 				updateErrorStats(stats, err, OP_COMMIT);
 				tx.onError(err).then([this, state = shared_from_this()](Future f) {
 					const auto rc = handleForOnError(tx, f, "ON_ERROR");
-					restartIteration(rc);
+					onIterationEnd(rc);
 				});
 			} else {
 				// commit successful
@@ -214,7 +214,7 @@ void ResumableStateForRunWorkload::onTransactionSuccess() {
 				stats.incrOpCount(OP_TRANSACTION);
 				tx.reset();
 				watch_tx.startFromStop();
-				restartIteration(FutureRC::OK);
+				onIterationEnd(FutureRC::OK);
 			}
 		});
 	} else {
@@ -227,10 +227,10 @@ void ResumableStateForRunWorkload::onTransactionSuccess() {
 		stats.incrOpCount(OP_TRANSACTION);
 		watch_tx.startFromStop();
 		tx.reset();
-		restartIteration(FutureRC::OK);
+		onIterationEnd(FutureRC::OK);
 	}
 }
-void ResumableStateForRunWorkload::restartIteration(FutureRC rc) {
+void ResumableStateForRunWorkload::onIterationEnd(FutureRC rc) {
 	// restart current iteration from beginning unless ended
 	if (rc == FutureRC::OK || rc == FutureRC::ABORT) {
 		total_xacts++;

--- a/bindings/c/test/mako/async.cpp
+++ b/bindings/c/test/mako/async.cpp
@@ -133,7 +133,7 @@ repeat_immediate_steps:
 					                       err.what());
 					updateErrorStats(err, iter.op);
 					tx.onError(err).then([this, state = shared_from_this()](Future f) {
-						const FutureRC rc = handleForOnError(tx, f, fmt::format("{}:{}", iter.opName(), iter.step));
+						const auto rc = handleForOnError(tx, f, fmt::format("{}:{}", iter.opName(), iter.step));
 						restartIteration(rc);
 					});
 				} else {
@@ -207,7 +207,7 @@ void ResumableStateForRunWorkload::onTransactionSuccess() {
 				                       err.what());
 				updateErrorStats(err, OP_COMMIT);
 				tx.onError(err).then([this, state = shared_from_this()](Future f) {
-					FutureRC rc = handleForOnError(tx, f, "ON_ERROR");
+					const auto rc = handleForOnError(tx, f, "ON_ERROR");
 					restartIteration(rc);
 				});
 			} else {
@@ -240,7 +240,7 @@ void ResumableStateForRunWorkload::onTransactionSuccess() {
 		restartIteration(FutureRC::OK);
 	}
 }
-void ResumableStateForRunWorkload::restartIteration(FutureRC rc) {
+force_inline void ResumableStateForRunWorkload::restartIteration(FutureRC rc) {
 	// restart current iteration from beginning unless ended
 	if (rc == FutureRC::OK || rc == FutureRC::ABORT) {
 		total_xacts++;

--- a/bindings/c/test/mako/async.hpp
+++ b/bindings/c/test/mako/async.hpp
@@ -115,7 +115,7 @@ struct ResumableStateForRunWorkload : std::enable_shared_from_this<ResumableStat
 	void postNextTick();
 	void runOneTick();
 	void updateStepStats();
-	force_inline void updateErrorStats(fdb::Error& err, int op);
+	force_inline void updateErrorStats(const fdb::Error& err, int op);
 	void onTransactionSuccess();
 	void restartIteration(FutureRC rc);
 };

--- a/bindings/c/test/mako/async.hpp
+++ b/bindings/c/test/mako/async.hpp
@@ -115,7 +115,9 @@ struct ResumableStateForRunWorkload : std::enable_shared_from_this<ResumableStat
 	void postNextTick();
 	void runOneTick();
 	void updateStepStats();
+	force_inline void updateErrorStats(fdb::Error& err, int op);
 	void onTransactionSuccess();
+	void restartIteration();
 };
 
 using RunWorkloadStateHandle = std::shared_ptr<ResumableStateForRunWorkload>;

--- a/bindings/c/test/mako/async.hpp
+++ b/bindings/c/test/mako/async.hpp
@@ -117,7 +117,7 @@ struct ResumableStateForRunWorkload : std::enable_shared_from_this<ResumableStat
 	void updateStepStats();
 	force_inline void updateErrorStats(const fdb::Error& err, int op);
 	void onTransactionSuccess();
-	void restartIteration(FutureRC rc);
+	force_inline void restartIteration(FutureRC rc);
 };
 
 using RunWorkloadStateHandle = std::shared_ptr<ResumableStateForRunWorkload>;

--- a/bindings/c/test/mako/async.hpp
+++ b/bindings/c/test/mako/async.hpp
@@ -26,6 +26,7 @@
 #include <boost/asio.hpp>
 #include "logger.hpp"
 #include "mako.hpp"
+#include "mako/future.hpp"
 #include "shm.hpp"
 #include "stats.hpp"
 #include "time.hpp"
@@ -79,6 +80,7 @@ struct ResumableStateForRunWorkload : std::enable_shared_from_this<ResumableStat
 	boost::asio::io_context& io_context;
 	Arguments const& args;
 	ThreadStatistics& stats;
+	int64_t total_xacts;
 	std::atomic<int>& stopcount;
 	std::atomic<int> const& signal;
 	int max_iters;
@@ -102,22 +104,20 @@ struct ResumableStateForRunWorkload : std::enable_shared_from_this<ResumableStat
 	                             std::atomic<int> const& signal,
 	                             int max_iters,
 	                             OpIterator iter)
-	  : logr(logr), db(db), tx(tx), io_context(io_context), args(args), stats(stats), stopcount(stopcount),
-	    signal(signal), max_iters(max_iters), iter(iter), needs_commit(false) {
+	  : logr(logr), db(db), tx(tx), io_context(io_context), args(args), stats(stats), total_xacts(0),
+	    stopcount(stopcount), signal(signal), max_iters(max_iters), iter(iter), needs_commit(false) {
 		key1.resize(args.key_length);
 		key2.resize(args.key_length);
 		val.resize(args.value_length);
 	}
 	void signalEnd() noexcept { stopcount.fetch_add(1); }
-	bool ended() noexcept {
-		return (max_iters != -1 && max_iters >= stats.getOpCount(OP_TRANSACTION)) || signal.load() == SIGNAL_RED;
-	}
+	bool ended() noexcept { return (max_iters != -1 && total_xacts >= max_iters) || signal.load() == SIGNAL_RED; }
 	void postNextTick();
 	void runOneTick();
 	void updateStepStats();
 	force_inline void updateErrorStats(fdb::Error& err, int op);
 	void onTransactionSuccess();
-	void restartIteration();
+	void restartIteration(FutureRC rc);
 };
 
 using RunWorkloadStateHandle = std::shared_ptr<ResumableStateForRunWorkload>;

--- a/bindings/c/test/mako/async.hpp
+++ b/bindings/c/test/mako/async.hpp
@@ -116,7 +116,7 @@ struct ResumableStateForRunWorkload : std::enable_shared_from_this<ResumableStat
 	void runOneTick();
 	void updateStepStats();
 	void onTransactionSuccess();
-	void restartIteration(FutureRC rc);
+	void onIterationEnd(FutureRC rc);
 };
 
 using RunWorkloadStateHandle = std::shared_ptr<ResumableStateForRunWorkload>;

--- a/bindings/c/test/mako/async.hpp
+++ b/bindings/c/test/mako/async.hpp
@@ -26,7 +26,7 @@
 #include <boost/asio.hpp>
 #include "logger.hpp"
 #include "mako.hpp"
-#include "mako/future.hpp"
+#include "future.hpp"
 #include "shm.hpp"
 #include "stats.hpp"
 #include "time.hpp"
@@ -115,9 +115,9 @@ struct ResumableStateForRunWorkload : std::enable_shared_from_this<ResumableStat
 	void postNextTick();
 	void runOneTick();
 	void updateStepStats();
-	force_inline void updateErrorStats(const fdb::Error& err, int op);
+	void updateErrorStats(const fdb::Error& err, int op);
 	void onTransactionSuccess();
-	force_inline void restartIteration(FutureRC rc);
+	void restartIteration(FutureRC rc);
 };
 
 using RunWorkloadStateHandle = std::shared_ptr<ResumableStateForRunWorkload>;

--- a/bindings/c/test/mako/async.hpp
+++ b/bindings/c/test/mako/async.hpp
@@ -117,6 +117,7 @@ struct ResumableStateForRunWorkload : std::enable_shared_from_this<ResumableStat
 	void updateStepStats();
 	void onTransactionSuccess();
 	void onIterationEnd(FutureRC rc);
+	void updateErrorStats(fdb::Error err, int op);
 };
 
 using RunWorkloadStateHandle = std::shared_ptr<ResumableStateForRunWorkload>;

--- a/bindings/c/test/mako/async.hpp
+++ b/bindings/c/test/mako/async.hpp
@@ -115,7 +115,6 @@ struct ResumableStateForRunWorkload : std::enable_shared_from_this<ResumableStat
 	void postNextTick();
 	void runOneTick();
 	void updateStepStats();
-	void updateErrorStats(const fdb::Error& err, int op);
 	void onTransactionSuccess();
 	void restartIteration(FutureRC rc);
 };

--- a/bindings/c/test/mako/future.hpp
+++ b/bindings/c/test/mako/future.hpp
@@ -84,7 +84,10 @@ force_inline bool waitFuture(FutureType& f, std::string_view step) {
 	auto err = fdb::Error{};
 	if ((err = f.blockUntilReady())) {
 		const auto retry = err.retryable();
-		logr.error("{} error '{}' found during step: {}", (retry ? "Retryable" : "Unretryable"), err.what(), step);
+		logr.error("{} error '{}' found while waiting for future during step: {}",
+		           (retry ? "Retryable" : "Unretryable"),
+		           err.what(),
+		           step);
 		return false;
 	}
 	err = f.error();

--- a/bindings/c/test/mako/future.hpp
+++ b/bindings/c/test/mako/future.hpp
@@ -59,8 +59,8 @@ force_inline FutureRC waitAndHandleForOnError(fdb::Transaction& tx, FutureType& 
 template <class FutureType>
 force_inline FutureRC waitAndHandleError(fdb::Transaction& tx, FutureType& f, std::string_view step) {
 	assert(f);
-	auto err = fdb::Error{};
-	if ((err = f.blockUntilReady())) {
+	auto err = f.blockUntilReady();
+	if (err) {
 		const auto retry = err.retryable();
 		logr.error("{} error '{}' found during step: {}", (retry ? "Retryable" : "Unretryable"), err.what(), step);
 		return retry ? FutureRC::RETRY : FutureRC::ABORT;
@@ -81,8 +81,8 @@ force_inline FutureRC waitAndHandleError(fdb::Transaction& tx, FutureType& f, st
 template <class FutureType>
 force_inline bool waitFuture(FutureType& f, std::string_view step) {
 	assert(f);
-	auto err = fdb::Error{};
-	if ((err = f.blockUntilReady())) {
+	auto err = f.blockUntilReady();
+	if (err) {
 		const auto retry = err.retryable();
 		logr.error("{} error '{}' found while waiting for future during step: {}",
 		           (retry ? "Retryable" : "Unretryable"),

--- a/bindings/c/test/mako/mako.cpp
+++ b/bindings/c/test/mako/mako.cpp
@@ -656,8 +656,10 @@ int runWorkload(Database db,
 			logr.warn("runOneTransaction failed ({})", rc);
 		}
 
+		xacts++;
+		total_xacts++;
 		if (thread_iters != -1) {
-			if (thread_iters >= total_xacts) {
+			if (total_xacts >= thread_iters) {
 				/* xact limit reached */
 				break;
 			}
@@ -665,8 +667,6 @@ int runWorkload(Database db,
 			/* signal turned red, target duration reached */
 			break;
 		}
-		xacts++;
-		total_xacts++;
 	}
 	return rc;
 }
@@ -1045,7 +1045,7 @@ Arguments::Arguments() {
 	rows = 100000;
 	load_factor = 1.0;
 	row_digits = digits(rows);
-	seconds = 30;
+	seconds = 0;
 	iteration = 0;
 	tpsmax = 0;
 	tpsmin = -1;
@@ -2371,6 +2371,11 @@ int main(int argc, char* argv[]) {
 	// Allow specifying only the number of active tenants, in which case # active = # total
 	if (args.active_tenants > 0 && args.total_tenants == 0) {
 		args.total_tenants = args.active_tenants;
+	}
+
+	// set --seconds in case not ending condition has been set
+	if (args.seconds == 0 && args.iteration == 0) {
+		args.seconds = 30; // default value accodring to documentation
 	}
 
 	rc = args.validate();

--- a/bindings/c/test/mako/mako.cpp
+++ b/bindings/c/test/mako/mako.cpp
@@ -571,7 +571,6 @@ int runWorkload(Database db,
 
 	/* main transaction loop */
 	while (1) {
-		Transaction tx = createNewTransaction(db, args, -1, args.active_tenants > 0 ? tenants : nullptr);
 		if ((thread_tps > 0 /* iff throttling on */) && (xacts >= current_tps)) {
 			/* throttle on */
 			auto time_now = steady_clock::now();
@@ -589,6 +588,7 @@ int runWorkload(Database db,
 		}
 
 		if (current_tps > 0 || thread_tps == 0 /* throttling off */) {
+			Transaction tx = createNewTransaction(db, args, -1, args.active_tenants > 0 ? tenants : nullptr);
 
 			/* enable transaction trace */
 			if (dotrace) {


### PR DESCRIPTION
- The error statistics in mako has previously been updated with the error returned by the `onError` call. I fixed this such that the original error is now used for this. This is relevant for retryable errors since the `onError` call does not return an error in the retryable case. Note that for operations of the kind `StepKind::ON_ERROR`, the old behavior has been kept for now.
-  In the async run mode, an iteration has previously not been restarted in case of an abort error (because the async actor did not register a new callback in this case). The new behavior is that the transaction is reset and the iteration is restarted.
-  In the async run mode, the ending condition is now checked after every iteration. Previously this check has only been performed in `ResumableStateForRunWorkload::onTransactionSuccess`. This, in some cases, has prevented the actor from finishing after the time limit was met. 
- In both async and sync run mode, the ending condition check had a bug when number of iterations was specified.  This has been fixed.
- It was previously not possible to specify the number of iterations as the ending condition because of a bug in the argument validation algorithm. This has been fixed. 
- The function `handleForOnError` has been changed such that it implements the recommended behavior from the API reference. 
- Previously, throttling in sync mode could result in infinite loops if the time limit is reached while `current_tps = 0`. This has been fixed by slightly changing the throttling loop. 
- Additional checks in the argument validation function have been added to ensure that every thread gets at least `1` as `maxtps` and at least `1` iteration. This prevents cases where there are threads without such a limit despite specifying one.  

Testing was done by comparing the output to the output of `mako` from the `main` branch for argument specifications that should cover my changes.  

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
