### PR TITLE
Disallow uniform initialization syntax for state variables

### DIFF
--- a/flow/actorcompiler/ActorParser.cs
+++ b/flow/actorcompiler/ActorParser.cs
@@ -483,6 +483,12 @@ namespace actorcompiler
                     initializer = 
                         range(paren.Position + 1, tokens.End)
                             .TakeWhile(t => t.ParenDepth > paren.ParenDepth);
+                } else {
+                    Token brace = AngleBracketParser.NotInsideAngleBrackets(tokens).FirstOrDefault(t => t.Value == "{");
+                    if (brace != null) {
+                        // type name{initializer};
+                        throw new Error(brace.SourceLine, "Uniform initialization syntax is not currently supported for state variables (use '(' instead of '}}' ?)");
+                    }
                 }
             }
             name = beforeInitializer.Last(NonWhitespace);


### PR DESCRIPTION
The actor compiler does not handle this correctly, so disallow it for now. We could probably support this someday if someone is sufficiently motivated.

Previously this would miscompile and hopefully cause some kind of syntax error in the generated code. Now it issues a helpful diagnostic.

Tested by adding an actor with a state variable that tries to use uniform initialization syntax and observing the error message looks good. We don't have any infrastructure for testing that the ActorCompiler rejects something, so I'm not including a test in this change. We could probably add that relatively easily though.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
