### PR TITLE
Assert that we don't try to have an ArenaBlock depend on itself.

### DIFF
--- a/flow/Arena.cpp
+++ b/flow/Arena.cpp
@@ -297,6 +297,7 @@ void* ArenaBlock::make4kAlignedBuffer(uint32_t size) {
 }
 
 void ArenaBlock::dependOn(Reference<ArenaBlock>& self, ArenaBlock* other) {
+	ASSERT(self->getData() != other->getData());
 	other->addref();
 	if (!self || self->isTiny() || self->unused() < sizeof(ArenaBlockRef))
 		create(SMALL, self)->makeReference(other);


### PR DESCRIPTION
It introduces a cycle in the `next` pointers in the ArenaBlockRef's, which results in infinite recursion as we follow them in `getTotalSize`.

Instead, make Arena::dependOn(Arena) a no-op in case they're referring to the same ArenaBlock.

The intent is to have one ArenaBlock live at least at long as another. If they're
the same, that's accomplished without doing any additional bookkeeping.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
