### PR TITLE
Fix transaction_too_old error when version vector is enabled

### DIFF
--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -3113,7 +3113,7 @@ ACTOR Future<GetKeyValuesReply> readRange(StorageServer* data,
 
 			ASSERT(atStorageVersion.size() <= -limit);
 			if (data->storageVersion() > version) {
-				TraceEvent("SS_TTO", data->thisServerID)
+				DisabledTraceEvent("SS_TTO", data->thisServerID)
 				    .detail("StorageVersion", data->storageVersion())
 				    .detail("Version", version)
 				    .detail("Range", range);

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -2978,7 +2978,8 @@ ACTOR Future<GetKeyValuesReply> readRange(StorageServer* data,
 
 		while (limit > 0 && *pLimitBytes > 0 && readBegin < range.end) {
 			ASSERT(!vCurrent || vCurrent.key() >= readBegin);
-			ASSERT(data->storageVersion() <= version);
+			ASSERT((!SERVER_KNOBS->ENABLE_VERSION_VECTOR && data->storageVersion() <= version) ||
+			       (SERVER_KNOBS->ENABLE_VERSION_VECTOR && data->storageVersion() <= origVersion));
 
 			/* Traverse the PTree further, if thare are no unconsumed resultCache items */
 			if (pos == resultCache.size()) {
@@ -3078,7 +3079,8 @@ ACTOR Future<GetKeyValuesReply> readRange(StorageServer* data,
 
 		while (limit < 0 && *pLimitBytes > 0 && readEnd > range.begin) {
 			ASSERT(!vCurrent || vCurrent.key() < readEnd);
-			ASSERT(data->storageVersion() <= version);
+			ASSERT((!SERVER_KNOBS->ENABLE_VERSION_VECTOR && data->storageVersion() <= version) ||
+			       (SERVER_KNOBS->ENABLE_VERSION_VECTOR && data->storageVersion() <= origVersion));
 
 			/* Traverse the PTree further, if thare are no unconsumed resultCache items */
 			if (pos == resultCache.size()) {

--- a/fdbserver/workloads/ConsistencyCheck.actor.cpp
+++ b/fdbserver/workloads/ConsistencyCheck.actor.cpp
@@ -1343,6 +1343,8 @@ struct ConsistencyCheckWorkload : TestWorkload {
 						req.limitBytes = CLIENT_KNOBS->REPLY_BYTE_LIMIT;
 						req.version = version;
 						req.tags = TagSet();
+						req.debugID = debugRandom()->randomUniqueID();
+						DisabledTraceEvent("CCD", req.debugID.get()).detail("Version", version);
 
 						// Try getting the entries in the specified range
 						state std::vector<Future<ErrorOr<GetKeyValuesReply>>> keyValueFutures;


### PR DESCRIPTION
Cherrypick #8745

When VV is enabled, ~~the comparison of storage server version and read version should use the original read version, otherwise, the client may get the wrong transaction_too_old error. In the failed seed, this prevents the consistency check from finishing.~~ the `waitForVersion()` may use the oldest version in the MVCC window as the actual read version, which may often result in the `transaction_too_old` if the MVCC moved, especially during a `readRange()`. The change here is to try using a higher read version that is still valid, but not likely to cause  `transaction_too_old` error.

commit: 333a8bfbe
seed:  -f ./foundationdb/tests/fast/MutationLogReaderCorrectness.toml -s 728034139 -b on
clang

500k 20221105-190436-jzhou-52ae8ebf0861e8bd passed.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
