### PR TITLE
Update BlobManager epoc after restore

### DIFF
--- a/fdbserver/BlobManifest.actor.cpp
+++ b/fdbserver/BlobManifest.actor.cpp
@@ -263,6 +263,14 @@ public:
 		return Void();
 	}
 
+	// Return max epoch from all manifest files
+	ACTOR static Future<int64_t> lastBlobEpoc(Reference<BlobManifestLoader> self) {
+		state Reference<BackupContainerFileSystem> container = self->blobConn_->getForRead(MANIFEST_FOLDER);
+		std::vector<BlobManifestFile> files = wait(BlobManifestFile::list(container));
+		ASSERT(!files.empty());
+		return files.front().epoch;
+	}
+
 private:
 	// Read data from a manifest file
 	ACTOR static Future<Value> readFromFile(Reference<BlobManifestLoader> self) {
@@ -437,4 +445,11 @@ ACTOR Future<BlobGranuleRestoreVersionVector> listBlobGranules(Database db,
 	Reference<BlobManifestLoader> loader = makeReference<BlobManifestLoader>(db, blobConn);
 	BlobGranuleRestoreVersionVector result = wait(BlobManifestLoader::listGranules(loader));
 	return result;
+}
+
+// API to get max blob manager epoc from manifest files
+ACTOR Future<int64_t> lastBlobEpoc(Database db, Reference<BlobConnectionProvider> blobConn) {
+	Reference<BlobManifestLoader> loader = makeReference<BlobManifestLoader>(db, blobConn);
+	int64_t epoc = wait(BlobManifestLoader::lastBlobEpoc(loader));
+	return epoc;
 }

--- a/fdbserver/include/fdbserver/BlobGranuleServerCommon.actor.h
+++ b/fdbserver/include/fdbserver/BlobGranuleServerCommon.actor.h
@@ -161,6 +161,8 @@ ACTOR Future<Void> dumpManifest(Database db, Reference<BlobConnectionProvider> b
 ACTOR Future<Void> loadManifest(Database db, Reference<BlobConnectionProvider> blobConn);
 ACTOR Future<Void> printRestoreSummary(Database db, Reference<BlobConnectionProvider> blobConn);
 ACTOR Future<BlobGranuleRestoreVersionVector> listBlobGranules(Database db, Reference<BlobConnectionProvider> blobConn);
+ACTOR Future<int64_t> lastBlobEpoc(Database db, Reference<BlobConnectionProvider> blobConn);
+
 inline bool isFullRestoreMode() {
 	return SERVER_KNOBS->BLOB_FULL_RESTORE_MODE;
 };


### PR DESCRIPTION
Blob Manager epoc need to be updated after blob restore.. otherwise it starts to generate blob manifest files with epoc 1, which breaks the epoc order of manifest files

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
