### PR TITLE
USE GO_EXECUTABLE - don't assume go is on path

### DIFF
--- a/contrib/mockkms/CMakeLists.txt
+++ b/contrib/mockkms/CMakeLists.txt
@@ -2,14 +2,14 @@ if(WITH_GO_BINDING)
   set(MOCK_KMS_SRC fault_injection.go get_encryption_keys.go mock_kms.go utils.go)
   set(MOCK_KMS_TEST_SRC ${MOCK_KMS_SRC} mockkms_test.go)
   add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/bin/mockkms
-    COMMAND go build -o ${CMAKE_BINARY_DIR}/bin/mockkms ${MOCK_KMS_SRC}
+    COMMAND ${GO_EXECUTABLE} build -o ${CMAKE_BINARY_DIR}/bin/mockkms ${MOCK_KMS_SRC}
     DEPENDS ${MOCK_KMS_SRC}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
   add_custom_target(mockkms ALL DEPENDS ${CMAKE_BINARY_DIR}/bin/mockkms)
   fdb_install(PROGRAMS ${CMAKE_BINARY_DIR}/bin/mockkms DESTINATION bin COMPONENT server)
 
   add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/bin/mockkms_test
-    COMMAND go test -c -o ${CMAKE_BINARY_DIR}/bin/mockkms_test ${MOCK_KMS_TEST_SRC}
+    COMMAND ${GO_EXECUTABLE} test -c -o ${CMAKE_BINARY_DIR}/bin/mockkms_test ${MOCK_KMS_TEST_SRC}
     DEPENDS ${MOCK_KMS_TEST_SRC}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
   add_custom_target(mockkms_test ALL DEPENDS ${CMAKE_BINARY_DIR}/bin/mockkms_test)


### PR DESCRIPTION
Since #8504 was merged, we now have a situation in cmake where we try to use the go executable but it's not on the path. Instead use the GO_EXECUTABLE found by cmake.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
