### PR TITLE
Increase default `GLOBAL_TAG_THROTTLING_FOLDING_TIME` value

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -739,6 +739,12 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( GLOBAL_TAG_THROTTLING,                               false ); if(isSimulated) GLOBAL_TAG_THROTTLING = deterministicRandom()->coinflip();
 	init( ENFORCE_TAG_THROTTLING_ON_PROXIES,   GLOBAL_TAG_THROTTLING );
 	init( GLOBAL_TAG_THROTTLING_MIN_RATE,                        1.0 );
+	// 60 seconds was chosen as a default value to ensure that
+	// the global tag throttler does not react too drastically to
+	// changes in workload. To make the global tag throttler more reactive,
+	// lower this knob. To make global tag throttler more smooth, raise this knob.
+	// Setting this knob lower than TAG_MEASUREMENT_INTERVAL can cause erratic
+	// behaviour and is not recommended.
 	init( GLOBAL_TAG_THROTTLING_FOLDING_TIME,                   60.0 );
 	init( GLOBAL_TAG_THROTTLING_MAX_TAGS_TRACKED,                 10 );
 	init( GLOBAL_TAG_THROTTLING_TAG_EXPIRE_AFTER,              240.0 );

--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -739,7 +739,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( GLOBAL_TAG_THROTTLING,                               false ); if(isSimulated) GLOBAL_TAG_THROTTLING = deterministicRandom()->coinflip();
 	init( ENFORCE_TAG_THROTTLING_ON_PROXIES,   GLOBAL_TAG_THROTTLING );
 	init( GLOBAL_TAG_THROTTLING_MIN_RATE,                        1.0 );
-	init( GLOBAL_TAG_THROTTLING_FOLDING_TIME,                   10.0 );
+	init( GLOBAL_TAG_THROTTLING_FOLDING_TIME,                   60.0 );
 	init( GLOBAL_TAG_THROTTLING_MAX_TAGS_TRACKED,                 10 );
 	init( GLOBAL_TAG_THROTTLING_TAG_EXPIRE_AFTER,              240.0 );
 	init( PROXY_MAX_TAG_THROTTLE_DURATION,          5.0 ); if( randomize && BUGGIFY ) PROXY_MAX_TAG_THROTTLE_DURATION = 0.5;

--- a/fdbserver/GlobalTagThrottler.actor.cpp
+++ b/fdbserver/GlobalTagThrottler.actor.cpp
@@ -641,7 +641,7 @@ class MockStorageServer {
 		Smoother smoother;
 
 	public:
-		Cost() : smoother(5.0) {}
+		Cost() : smoother(60.0) {}
 		Cost& operator+=(double delta) {
 			smoother.addDelta(delta);
 			return *this;
@@ -930,9 +930,9 @@ TEST_CASE("/GlobalTagThrottler/MultiClientThrottling") {
 
 // 10 storage servers can handle 100 pages/second each.
 // Total quota set to 100 pages/second.
-// 2 clients each attempt 20 10-byte transactions per second.
+// 2 clients each attempt 20 10-page transactions per second.
 // Target rate should adjust to allow 100/10 transactions per second.
-// Each client is throttled to only perform 100/20 transactions per second.
+// Each client is throttled to only perform (100/10)/2 transactions per second.
 TEST_CASE("/GlobalTagThrottler/MultiClientThrottling2") {
 	state GlobalTagThrottler globalTagThrottler(Database{}, UID{}, 0);
 	state StorageServerCollection storageServers(10, 100);
@@ -952,8 +952,8 @@ TEST_CASE("/GlobalTagThrottler/MultiClientThrottling2") {
 
 // 10 storage servers can handle 100 pages/second each.
 // Total quota set to 100 pages/second.
-// One client attempts 5 5-byte read transactions per second.
-// Another client attempts 25 5-byte read transactions per second.
+// One client attempts 5 5-page read transactions per second.
+// Another client attempts 25 5-page read transactions per second.
 // Target rate should adjust to allow 100/5 transactions per second.
 // This 20 transactions/second limit is split with a distribution of (5, 15) between the 2 clients.
 TEST_CASE("/GlobalTagThrottler/SkewedMultiClientThrottling") {
@@ -975,7 +975,7 @@ TEST_CASE("/GlobalTagThrottler/SkewedMultiClientThrottling") {
 
 // 10 storage servers can handle 100 pages/second each.
 // Total quota is initially set to 100 pages/second.
-// Client attempts 5 6-byte transactions per second.
+// Client attempts 5 6-page transactions per second.
 // Test that the tag throttler can reach equilibrium, then adjust to a new equilibrium once the quota is changed
 // Target rate should adjust to allow 100/6 transactions per second.
 // Total quota is modified to 50 pages/second.
@@ -1002,7 +1002,7 @@ TEST_CASE("/GlobalTagThrottler/UpdateQuota") {
 
 // 10 storage servers can handle 100 pages/second each.
 // Total quota is initially set to 100 pages/second.
-// Client attempts 5 6-byte read transactions per second.
+// Client attempts 5 6-page read transactions per second.
 // Target limit adjusts to allow 100/6 transactions per second.
 // Then Quota is removed.
 // Target limit is removed as a result.
@@ -1026,7 +1026,7 @@ TEST_CASE("/GlobalTagThrottler/RemoveQuota") {
 
 // 10 storage servers can handle 5 pages/second each.
 // Total quota is set to 100 pages/second.
-// Client attempts 10 6-byte transactions per second
+// Client attempts 10 6-page transactions per second
 // Target is adjusted to 50/6 transactions per second, to match the total capacity all storage servers.
 TEST_CASE("/GlobalTagThrottler/ActiveThrottling") {
 	state GlobalTagThrottler globalTagThrottler(Database{}, UID{}, 0);
@@ -1046,7 +1046,7 @@ TEST_CASE("/GlobalTagThrottler/ActiveThrottling") {
 
 // 10 storage servers can handle 5 pages/second each.
 // Total quota is set to 50 pages/second for one tag, 100 pages/second for another.
-// For each tag, a client attempts to execute 10 6-byte read transactions per second.
+// For each tag, a client attempts to execute 10 6-page read transactions per second.
 // Target rates are adjusted to utilize the full 50 pages/second capacity of the
 //   add storage servers. The two tags receive this capacity with a 2:1 ratio,
 //   matching the ratio of their total quotas.
@@ -1075,7 +1075,7 @@ TEST_CASE("/GlobalTagThrottler/MultiTagActiveThrottling") {
 
 // 3 storage servers can handle 50 pages/second each.
 // Total quota is set to 100 pages/second for each tag.
-// Each client attempts 10 6-byte read transactions per second.
+// Each client attempts 10 6-page read transactions per second.
 // This workload is sent to 2 storage servers per client (with an overlap of one storage server).
 // Target rates for both tags are adjusted to 50/6 transactions per second to match the throughput
 //   that the busiest server can handle.
@@ -1104,8 +1104,8 @@ TEST_CASE("/GlobalTagThrottler/MultiTagActiveThrottling2") {
 
 // 3 storage servers can handle 50 pages/second each.
 // Total quota is set to 100 pages/second for each tag.
-// One client attempts 10 6-byte read transactions per second, all directed towards a single storage server.
-// Another client, using a different tag, attempts 10 6-byte read transactions split across the other two storage
+// One client attempts 10 6-page read transactions per second, all directed towards a single storage server.
+// Another client, using a different tag, attempts 10 6-page read transactions split across the other two storage
 // servers. Target rates adjust to 50/6 and 100/6 transactions per second for the two clients, based on the capacities
 // of the
 //   storage servers being accessed.
@@ -1135,7 +1135,7 @@ TEST_CASE("/GlobalTagThrottler/MultiTagActiveThrottling3") {
 // 10 storage servers can serve 5 pages/second each.
 // Total quota is set to 100 pages/second.
 // Reserved quota is set to 70 pages/second.
-// A client attempts to execute 10 6-byte read transactions per second.
+// A client attempts to execute 10 6-page read transactions per second.
 // Despite the storage server only having capacity to serve 50/6 transactions per second,
 //   the reserved quota will ensure the target rate adjusts to 70/6 transactions per second.
 TEST_CASE("/GlobalTagThrottler/ReservedQuota") {
@@ -1194,12 +1194,12 @@ TEST_CASE("/GlobalTagThrottler/TagLimit") {
 }
 
 // 9 storage servers can handle 100 pages/second each.
-// 1 unhealthy storage server can only handle 1 byte/second.
+// 1 unhealthy storage server can only handle 1 page/second.
 // Total quota is set to 100 pages/second.
-// Client attempts 5 6-byte transactions per second.
+// Client attempts 5 6-page transactions per second.
 // Target rate adjusts to 100/6 transactions per second, ignoring the worst storage server.
-// Then, a second storage server becomes unhealthy and can only handle 1 byte/second.
-// Target rate adjusts down to its minimum rate, because only one bad zone can be ignored.
+// Then, a second storage server becomes unhealthy and can only handle 1 page/second.
+// Target rate adjusts down to 10/6 transactions per second, because only one bad zone can be ignored.
 TEST_CASE("/GlobalTagThrottler/IgnoreWorstZone") {
 	state GlobalTagThrottler globalTagThrottler(Database{}, UID{}, 1);
 	state StorageServerCollection storageServers(10, 100);
@@ -1214,9 +1214,8 @@ TEST_CASE("/GlobalTagThrottler/IgnoreWorstZone") {
 	state Future<Void> updater = updateGlobalTagThrottler(&globalTagThrottler, &storageServers);
 	wait(timeoutError(monitor || client || updater, 600.0));
 	storageServers.setCapacity(1, 1);
-	monitor = monitorActor(&globalTagThrottler, [](auto& gtt) {
-		return targetRateIsNear(gtt, "sampleTag1"_sr, SERVER_KNOBS->GLOBAL_TAG_THROTTLING_MIN_RATE);
-	});
+	monitor =
+	    monitorActor(&globalTagThrottler, [](auto& gtt) { return targetRateIsNear(gtt, "sampleTag1"_sr, 10.0 / 6.0); });
 	wait(timeoutError(monitor || client || updater, 600.0));
 	return Void();
 }

--- a/fdbserver/GlobalTagThrottler.actor.cpp
+++ b/fdbserver/GlobalTagThrottler.actor.cpp
@@ -641,7 +641,7 @@ class MockStorageServer {
 		Smoother smoother;
 
 	public:
-		Cost() : smoother(60.0) {}
+		Cost() : smoother(SERVER_KNOBS->GLOBAL_TAG_THROTTLING_FOLDING_TIME) {}
 		Cost& operator+=(double delta) {
 			smoother.addDelta(delta);
 			return *this;


### PR DESCRIPTION
This PR makes the following changes:
- Increase default `GLOBAL_TAG_THROTTLING_FOLDING_TIME` value to 60.0, for more stable tag throttling behaviour
- Fixes a failing `/GlobalTagThrottler/IgnoreWorstZone` unit test
- Updates comments for `GlobalTagThrottler` unit tests

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
