### PR TITLE
Make the timing consistent in simulation

### DIFF
--- a/fdbrpc/include/fdbrpc/TimedRequest.h
+++ b/fdbrpc/include/fdbrpc/TimedRequest.h
@@ -20,6 +20,7 @@
 
 #ifndef FDBRPC_TIMED_REQUEST_H
 #define FDBRPC_TIMED_REQUEST_H
+#include "flow/network.h"
 #pragma once
 
 #include <fdbrpc/fdbrpc.h>
@@ -35,7 +36,7 @@ public:
 
 	TimedRequest() {
 		if (!FlowTransport::isClient()) {
-			_requestTime = timer();
+			_requestTime = g_network->timer();
 		} else {
 			_requestTime = 0.0;
 		}


### PR DESCRIPTION
There is a discrepancy between certain times in simulation.

In [GRVProxy server](https://github.com/apple/foundationdb/blob/ca1f3140c4018e147c778ce46df28fca6c7bb8f5/fdbserver/GrvProxyServer.actor.cpp#L949), we add a time entry to defaultTxnGRVTimeInQueue  LatencySample. The way it works is it takes the difference from the current time g_network->timer() vs the time of the request req.requestTime() . However, in simulation these times are way off since simulation time is set back to beginning of unix epoch. This means that a negative time is entered into the LatencySample which doesn't really make sense.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
