### PR TITLE
version vector - broadcast to all tlogs only when a private mutation is present

### DIFF
--- a/fdbserver/Resolver.actor.cpp
+++ b/fdbserver/Resolver.actor.cpp
@@ -282,7 +282,6 @@ ACTOR Future<Void> resolveBatch(Reference<Resolver> self,
 
 		ResolveTransactionBatchReply& reply = proxyInfo.outstandingBatches[req.version];
 		reply.writtenTags = req.writtenTags;
-
 		std::vector<int> commitList;
 		std::vector<int> tooOldList;
 
@@ -441,7 +440,7 @@ ACTOR Future<Void> resolveBatch(Reference<Resolver> self,
 				reply.tpcvMap.clear();
 			} else {
 				std::set<uint16_t> writtenTLogs;
-				if (shardChanged || reply.privateMutationCount) {
+				if (shardChanged || toCommit->getAllMessages().size() > 1) {
 					for (int i = 0; i < self->numLogs; i++) {
 						writtenTLogs.insert(i);
 					}


### PR DESCRIPTION
When version vector is enabled, no empty messages should be sent to tlogs. The exception is when there are private mutations, as all underlying SS need to be informed of shard changes. This PR fixes a bug where we did not check for the presence of private mutations in the batch correctly, so always broadcasted to all tlogs. That probably hurt vv performance.

`20221110-193414-henrylambright-fccbb431d494e874`

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
