### PR TITLE
Update the storage quota mechanisms to set quota on tenant groups instead of tenants

### DIFF
--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -2559,15 +2559,15 @@ bool schemaMatch(json_spirit::mValue const& schemaValue,
 	}
 }
 
-void setStorageQuota(Transaction& tr, StringRef tenantName, int64_t quota) {
+void setStorageQuota(Transaction& tr, StringRef tenantGroupName, int64_t quota) {
 	tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
-	auto key = storageQuotaKey(tenantName);
+	auto key = storageQuotaKey(tenantGroupName);
 	tr.set(key, BinaryWriter::toValue<int64_t>(quota, Unversioned()));
 }
 
-ACTOR Future<Optional<int64_t>> getStorageQuota(Transaction* tr, StringRef tenantName) {
+ACTOR Future<Optional<int64_t>> getStorageQuota(Transaction* tr, StringRef tenantGroupName) {
 	tr->setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
-	state Optional<Value> v = wait(tr->get(storageQuotaKey(tenantName)));
+	state Optional<Value> v = wait(tr->get(storageQuotaKey(tenantGroupName)));
 	if (!v.present()) {
 		return Optional<int64_t>();
 	}

--- a/fdbclient/SystemData.cpp
+++ b/fdbclient/SystemData.cpp
@@ -1663,8 +1663,8 @@ BlobWorkerInterface decodeBlobWorkerListValue(ValueRef const& value) {
 const KeyRangeRef storageQuotaKeys("\xff/storageQuota/"_sr, "\xff/storageQuota0"_sr);
 const KeyRef storageQuotaPrefix = storageQuotaKeys.begin;
 
-Key storageQuotaKey(StringRef tenantName) {
-	return tenantName.withPrefix(storageQuotaPrefix);
+Key storageQuotaKey(StringRef tenantGroupName) {
+	return tenantGroupName.withPrefix(storageQuotaPrefix);
 }
 
 const KeyRangeRef idempotencyIdKeys("\xff\x02/idmp/"_sr, "\xff\x02/idmp0"_sr);

--- a/fdbclient/include/fdbclient/ManagementAPI.actor.h
+++ b/fdbclient/include/fdbclient/ManagementAPI.actor.h
@@ -163,9 +163,9 @@ bool schemaMatch(json_spirit::mValue const& schema,
 // storage nodes
 ACTOR Future<Void> mgmtSnapCreate(Database cx, Standalone<StringRef> snapCmd, UID snapUID);
 
-// Set and get the storage quota per tenant
-void setStorageQuota(Transaction& tr, StringRef tenantName, int64_t quota);
-ACTOR Future<Optional<int64_t>> getStorageQuota(Transaction* tr, StringRef tenantName);
+// Set and get the storage quota per tenant group
+void setStorageQuota(Transaction& tr, StringRef tenantGroupName, int64_t quota);
+ACTOR Future<Optional<int64_t>> getStorageQuota(Transaction* tr, StringRef tenantGroupName);
 
 #include "flow/unactorcompiler.h"
 #endif

--- a/fdbclient/include/fdbclient/SystemData.h
+++ b/fdbclient/include/fdbclient/SystemData.h
@@ -711,10 +711,10 @@ const Value blobWorkerListValue(BlobWorkerInterface const& interface);
 BlobWorkerInterface decodeBlobWorkerListValue(ValueRef const& value);
 
 // Storage quota per tenant
-// "\xff/storageQuota/[[tenantName]]" := "[[quota]]"
+// "\xff/storageQuota/[[tenantGroupName]]" := "[[quota]]"
 extern const KeyRangeRef storageQuotaKeys;
 extern const KeyRef storageQuotaPrefix;
-Key storageQuotaKey(StringRef tenantName);
+Key storageQuotaKey(StringRef tenantGroupName);
 
 extern const KeyRangeRef idempotencyIdKeys;
 extern const KeyRef idempotencyIdsExpiredVersion;

--- a/fdbserver/TenantCache.actor.cpp
+++ b/fdbserver/TenantCache.actor.cpp
@@ -127,25 +127,38 @@ public:
 
 		loop {
 			state double fetchStartTime = now();
-			state std::vector<TenantName> tenants = tenantCache->getTenantList();
+			state std::vector<TenantGroupName> groups;
+			for (const auto& [group, storage] : tenantCache->tenantStorageMap) {
+				groups.push_back(group);
+			}
 			state int i;
-			for (i = 0; i < tenants.size(); i++) {
-				state ReadYourWritesTransaction tr(tenantCache->dbcx(), tenants[i]);
-				loop {
-					try {
-						state int64_t size = wait(tr.getEstimatedRangeSizeBytes(normalKeys));
-						tenantCache->tenantStorageMap[tenants[i]].usage = size;
-						break;
-					} catch (Error& e) {
-						if (e.code() == error_code_tenant_not_found) {
-							tenantCache->tenantStorageMap.erase(tenants[i]);
+			for (i = 0; i < groups.size(); i++) {
+				state TenantGroupName group = groups[i];
+				state int64_t usage = 0;
+				// `tenants` needs to be a copy so that the erase (below) or inserts/erases from other
+				// functions (when this actor yields) do not interfere with the iteration
+				state std::unordered_set<TenantName> tenants = tenantCache->tenantStorageMap[group].tenants;
+				state std::unordered_set<TenantName>::iterator iter = tenants.begin();
+				for (; iter != tenants.end(); iter++) {
+					state TenantName tenant = *iter;
+					state ReadYourWritesTransaction tr(tenantCache->dbcx(), tenant);
+					loop {
+						try {
+							state int64_t size = wait(tr.getEstimatedRangeSizeBytes(normalKeys));
+							usage += size;
 							break;
-						} else {
-							TraceEvent("TenantCacheGetStorageUsageError", tenantCache->id()).error(e);
-							wait(tr.onError(e));
+						} catch (Error& e) {
+							if (e.code() == error_code_tenant_not_found) {
+								tenantCache->tenantStorageMap[group].tenants.erase(tenant);
+								break;
+							} else {
+								TraceEvent("TenantCacheGetStorageUsageError", tenantCache->id()).error(e);
+								wait(tr.onError(e));
+							}
 						}
 					}
 				}
+				tenantCache->tenantStorageMap[group].usage = usage;
 			}
 
 			lastTenantListFetchTime = now();
@@ -162,22 +175,19 @@ public:
 		state Transaction tr(tenantCache->dbcx());
 
 		loop {
-			loop {
-				try {
-					state RangeResult currentQuotas = wait(tr.getRange(storageQuotaKeys, CLIENT_KNOBS->TOO_MANY));
-					for (auto const kv : currentQuotas) {
-						TenantName const tenant = kv.key.removePrefix(storageQuotaPrefix);
-						int64_t const quota = BinaryReader::fromStringRef<int64_t>(kv.value, Unversioned());
-						tenantCache->tenantStorageMap[tenant].quota = quota;
-					}
-					tr.reset();
-					break;
-				} catch (Error& e) {
-					TraceEvent("TenantCacheGetStorageQuotaError", tenantCache->id()).error(e);
-					wait(tr.onError(e));
+			try {
+				state RangeResult currentQuotas = wait(tr.getRange(storageQuotaKeys, CLIENT_KNOBS->TOO_MANY));
+				for (const auto kv : currentQuotas) {
+					const TenantGroupName group = kv.key.removePrefix(storageQuotaPrefix);
+					const int64_t quota = BinaryReader::fromStringRef<int64_t>(kv.value, Unversioned());
+					tenantCache->tenantStorageMap[group].quota = quota;
 				}
+				tr.reset();
+				wait(delay(SERVER_KNOBS->TENANT_CACHE_STORAGE_QUOTA_REFRESH_INTERVAL));
+			} catch (Error& e) {
+				TraceEvent("TenantCacheGetStorageQuotaError", tenantCache->id()).error(e);
+				wait(tr.onError(e));
 			}
-			wait(delay(SERVER_KNOBS->TENANT_CACHE_STORAGE_QUOTA_REFRESH_INTERVAL));
 		}
 	}
 };
@@ -189,6 +199,10 @@ void TenantCache::insert(TenantName& tenantName, TenantMapEntry& tenant) {
 	TenantInfo tenantInfo(tenantName, Optional<Standalone<StringRef>>(), tenant.id);
 	tenantCache[tenantPrefix] = makeReference<TCTenantInfo>(tenantInfo, tenant.prefix);
 	tenantCache[tenantPrefix]->updateCacheGeneration(generation);
+
+	if (tenant.tenantGroup.present()) {
+		tenantStorageMap[tenant.tenantGroup.get()].tenants.insert(tenantName);
+	}
 }
 
 void TenantCache::startRefresh() {
@@ -289,13 +303,13 @@ Optional<Reference<TCTenantInfo>> TenantCache::tenantOwning(KeyRef key) const {
 }
 
 std::unordered_set<TenantName> TenantCache::getTenantsOverQuota() const {
-	std::unordered_set<TenantName> tenants;
-	for (const auto& [tenant, storage] : tenantStorageMap) {
+	std::unordered_set<TenantName> tenantsOverQuota;
+	for (const auto& [tenantGroup, storage] : tenantStorageMap) {
 		if (storage.usage > storage.quota) {
-			tenants.insert(tenant);
+			tenantsOverQuota.insert(storage.tenants.begin(), storage.tenants.end());
 		}
 	}
-	return tenants;
+	return tenantsOverQuota;
 }
 
 Future<Void> TenantCache::monitorTenantMap() {

--- a/fdbserver/include/fdbserver/TenantCache.h
+++ b/fdbserver/include/fdbserver/TenantCache.h
@@ -35,8 +35,9 @@ typedef Map<KeyRef, Reference<TCTenantInfo>> TenantMapByPrefix;
 struct Storage {
 	int64_t quota = std::numeric_limits<int64_t>::max();
 	int64_t usage = 0;
+	std::unordered_set<TenantName> tenants;
 };
-typedef std::unordered_map<TenantName, Storage> TenantStorageMap;
+typedef std::unordered_map<TenantGroupName, Storage> TenantStorageMap;
 
 struct TenantCacheTenantCreated {
 	KeyRange keys;
@@ -56,7 +57,8 @@ private:
 	uint64_t generation;
 	TenantMapByPrefix tenantCache;
 
-	// Map from tenant names to storage quota and usage
+	// Map from tenant group names to the list of tenants, cumumlative storage used by
+	// all the tenants in the group, and its storage quota.
 	TenantStorageMap tenantStorageMap;
 
 	// mark the start of a new sweep of the tenant cache

--- a/fdbserver/workloads/CreateTenant.actor.cpp
+++ b/fdbserver/workloads/CreateTenant.actor.cpp
@@ -20,7 +20,9 @@
 
 #include <cstdint>
 
+#include "fdbclient/Tenant.h"
 #include "fdbclient/TenantManagement.actor.h"
+#include "fdbserver/Knobs.h"
 #include "fdbserver/workloads/workloads.actor.h"
 
 #include "flow/actorcompiler.h" // This must be the last #include.
@@ -28,9 +30,13 @@
 struct CreateTenantWorkload : TestWorkload {
 	static constexpr auto NAME = "CreateTenant";
 	TenantName tenant;
+	Optional<TenantGroupName> tenantGroup;
 
 	CreateTenantWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
 		tenant = getOption(options, "name"_sr, "DefaultTenant"_sr);
+		if (hasOption(options, "group"_sr)) {
+			tenantGroup = getOption(options, "group"_sr, "DefaultGroup"_sr);
+		}
 	}
 
 	Future<Void> setup(Database const& cx) override {
@@ -46,7 +52,12 @@ struct CreateTenantWorkload : TestWorkload {
 
 	ACTOR static Future<Void> _setup(CreateTenantWorkload* self, Database db) {
 		try {
-			Optional<TenantMapEntry> entry = wait(TenantAPI::createTenant(db.getReference(), self->tenant));
+			TenantMapEntry givenEntry;
+			if (self->tenantGroup.present()) {
+				givenEntry.tenantGroup = self->tenantGroup.get();
+				givenEntry.encrypted = SERVER_KNOBS->ENABLE_ENCRYPTION;
+			}
+			Optional<TenantMapEntry> entry = wait(TenantAPI::createTenant(db.getReference(), self->tenant, givenEntry));
 			ASSERT(entry.present());
 		} catch (Error& e) {
 			TraceEvent(SevError, "TenantCreationFailed").error(e);

--- a/fdbserver/workloads/StorageQuota.actor.cpp
+++ b/fdbserver/workloads/StorageQuota.actor.cpp
@@ -18,9 +18,10 @@
  * limitations under the License.
  */
 
-#include "fdbrpc/TenantName.h"
 #include "fdbclient/ManagementAPI.actor.h"
 #include "fdbclient/SystemData.h"
+#include "fdbclient/Tenant.h"
+#include "fdbclient/TenantManagement.actor.h"
 #include "fdbrpc/TenantName.h"
 #include "fdbserver/Knobs.h"
 #include "fdbserver/workloads/workloads.actor.h"
@@ -31,12 +32,16 @@
 
 struct StorageQuotaWorkload : TestWorkload {
 	static constexpr auto NAME = "StorageQuota";
+	TenantGroupName group;
 	TenantName tenant;
 	int nodeCount;
+	TenantName emptyTenant;
 
 	StorageQuotaWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
-		nodeCount = getOption(options, "nodeCount"_sr, 10000);
+		group = getOption(options, "group"_sr, "DefaultGroup"_sr);
 		tenant = getOption(options, "tenant"_sr, "DefaultTenant"_sr);
+		nodeCount = getOption(options, "nodeCount"_sr, 10000);
+		emptyTenant = getOption(options, "emptyTenant"_sr, "DefaultTenant"_sr);
 	}
 
 	Future<Void> setup(Database const& cx) override {
@@ -67,27 +72,38 @@ struct StorageQuotaWorkload : TestWorkload {
 	Standalone<KeyValueRef> operator()(int n) { return KeyValueRef(keyForIndex(n), value((n + 1) % nodeCount)); }
 
 	ACTOR Future<Void> _start(StorageQuotaWorkload* self, Database cx) {
-		// Check that the quota set/get functions work as expected.
-		// Set the quota to just below the current size.
+		state TenantMapEntry entry1 = wait(TenantAPI::getTenant(cx.getReference(), self->tenant));
+		state TenantMapEntry entry2 = wait(TenantAPI::getTenant(cx.getReference(), self->emptyTenant));
+		ASSERT(entry1.tenantGroup.present() && entry1.tenantGroup.get() == self->group &&
+		       entry2.tenantGroup.present() && entry2.tenantGroup.get() == self->group);
+
+		// Get the size of the non-empty tenant. We will set the quota of the tenant group
+		// to just below the current size of this tenant.
 		state int64_t size = wait(getSize(cx, self->tenant));
 		state int64_t quota = size - 1;
-		wait(setStorageQuotaHelper(cx, self->tenant, quota));
-		state Optional<int64_t> quotaRead = wait(getStorageQuotaHelper(cx, self->tenant));
+
+		// Check that the quota set/get functions work as expected.
+		wait(setStorageQuotaHelper(cx, self->group, quota));
+		state Optional<int64_t> quotaRead = wait(getStorageQuotaHelper(cx, self->group));
 		ASSERT(quotaRead.present() && quotaRead.get() == quota);
 
 		if (!SERVER_KNOBS->DD_TENANT_AWARENESS_ENABLED) {
 			return Void();
 		}
 
-		// Check that writes are rejected when the tenant is over quota.
-		state bool rejected = wait(tryWrite(self, cx, /*expectOk=*/false));
-		ASSERT(rejected);
+		// Check that writes to both the tenants are rejected when the group is over quota.
+		state bool rejected1 = wait(tryWrite(self, cx, self->tenant, /*expectOk=*/false));
+		ASSERT(rejected1);
+		state bool rejected2 = wait(tryWrite(self, cx, self->emptyTenant, /*expectOk=*/false));
+		ASSERT(rejected2);
 
-		// Increase the quota. Check that writes are now able to commit.
+		// Increase the quota. Check that writes to both the tenants are now able to commit.
 		quota = size * 2;
-		wait(setStorageQuotaHelper(cx, self->tenant, quota));
-		state bool committed = wait(tryWrite(self, cx, /*expectOk=*/true));
-		ASSERT(committed);
+		wait(setStorageQuotaHelper(cx, self->group, quota));
+		state bool committed1 = wait(tryWrite(self, cx, self->tenant, /*expectOk=*/true));
+		ASSERT(committed1);
+		state bool committed2 = wait(tryWrite(self, cx, self->emptyTenant, /*expectOk=*/true));
+		ASSERT(committed2);
 
 		return Void();
 	}
@@ -115,11 +131,11 @@ struct StorageQuotaWorkload : TestWorkload {
 		}
 	}
 
-	ACTOR static Future<Void> setStorageQuotaHelper(Database cx, TenantName tenantName, int64_t quota) {
+	ACTOR static Future<Void> setStorageQuotaHelper(Database cx, TenantGroupName tenantGroupName, int64_t quota) {
 		state Transaction tr(cx);
 		loop {
 			try {
-				setStorageQuota(tr, tenantName, quota);
+				setStorageQuota(tr, tenantGroupName, quota);
 				wait(tr.commit());
 				return Void();
 			} catch (Error& e) {
@@ -128,11 +144,11 @@ struct StorageQuotaWorkload : TestWorkload {
 		}
 	}
 
-	ACTOR static Future<Optional<int64_t>> getStorageQuotaHelper(Database cx, TenantName tenantName) {
+	ACTOR static Future<Optional<int64_t>> getStorageQuotaHelper(Database cx, TenantGroupName tenantGroupName) {
 		state Transaction tr(cx);
 		loop {
 			try {
-				state Optional<int64_t> quota = wait(getStorageQuota(&tr, tenantName));
+				state Optional<int64_t> quota = wait(getStorageQuota(&tr, tenantGroupName));
 				wait(tr.commit());
 				return quota;
 			} catch (Error& e) {
@@ -141,13 +157,13 @@ struct StorageQuotaWorkload : TestWorkload {
 		}
 	}
 
-	ACTOR static Future<bool> tryWrite(StorageQuotaWorkload* self, Database cx, bool expectOk) {
+	ACTOR static Future<bool> tryWrite(StorageQuotaWorkload* self, Database cx, TenantName tenant, bool expectOk) {
 		state int i;
 		// Retry the transaction a few times if needed; this allows us wait for a while for all
 		// the storage usage and quota related monitors to fetch and propagate the latest information
 		// about the tenants that are over storage quota.
 		for (i = 0; i < 10; i++) {
-			state Transaction tr(cx, self->tenant);
+			state Transaction tr(cx, tenant);
 			loop {
 				try {
 					Standalone<KeyValueRef> kv =

--- a/tests/rare/StorageQuotaTest.toml
+++ b/tests/rare/StorageQuotaTest.toml
@@ -8,20 +8,36 @@ testTitle = 'TenantCreation'
     [[test.workload]]
     testName = 'CreateTenant'
     name = 'First'
+    group = 'GroupA'
 
     [[test.workload]]
     testName = 'CreateTenant'
     name = 'Second'
+    group = 'GroupA'
+
+    [[test.workload]]
+    testName = 'CreateTenant'
+    name = 'Third'
+    group = 'GroupB'
+
+    [[test.workload]]
+    testName = 'CreateTenant'
+    name = 'Fourth'
+    group = 'GroupB'
 
 [[test]]
 testTitle = 'StorageQuota'
 
     [[test.workload]]
     testName = 'StorageQuota'
+    group = 'GroupA'
     tenant = 'First'
     nodeCount = 250000
+    emptyTenant = 'Second'
 
     [[test.workload]]
     testName = 'StorageQuota'
-    tenant = 'Second'
+    group = 'GroupB'
+    tenant = 'Third'
     nodeCount = 25000
+    emptyTenant = 'Fourth'


### PR DESCRIPTION
This PR changes the storage quota mechanisms to set quota on tenant groups instead of tenants.

* Set the storage quota on tenant groups instead of tenants. Update all the relevant data structures and monitors accordingly.
* Update the CreateTenant workload to allow specifying a tenant group.
* Update the simulation testing for storage quota to use tenant groups (with multiple tenants in a group).

The quota metadata that is stored in the special keyspace will be moved to be part of the tenant metadata keyspace in a separate PR.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
