### PR TITLE
Add support to close the database in go and to use a connection string to open a database

### DIFF
--- a/bindings/c/foundationdb/fdb_c.h
+++ b/bindings/c/foundationdb/fdb_c.h
@@ -288,6 +288,8 @@ DLLEXPORT WARN_UNUSED_RESULT fdb_error_t fdb_result_get_keyvalue_array(FDBResult
 
 DLLEXPORT WARN_UNUSED_RESULT fdb_error_t fdb_create_database(const char* cluster_file_path, FDBDatabase** out_database);
 
+DLLEXPORT WARN_UNUSED_RESULT fdb_error_t fdb_create_database_from_connection_string(const char* connection_string, FDBDatabase** out_database);
+
 DLLEXPORT void fdb_database_destroy(FDBDatabase* d);
 
 DLLEXPORT WARN_UNUSED_RESULT fdb_error_t fdb_database_set_option(FDBDatabase* d,

--- a/bindings/go/src/fdb/database.go
+++ b/bindings/go/src/fdb/database.go
@@ -42,6 +42,7 @@ import (
 // usually created and committed automatically by the (Database).Transact
 // method.
 type Database struct {
+	clusterFile string
 	*database
 }
 
@@ -64,6 +65,18 @@ func (opt DatabaseOptions) setOpt(code int, param []byte) error {
 
 func (d *database) destroy() {
 	C.fdb_database_destroy(d.ptr)
+}
+
+// Close will close the Database and clean up all resources.
+// You have to ensure that you're not resuing this database.
+func (d *Database) Close() {
+	// Remove database object from the cached databases
+	if d.clusterFile != "" {
+		delete(openDatabases, d.clusterFile)
+	}
+
+	// Destroy the database
+	d.destroy()
 }
 
 // CreateTransaction returns a new FoundationDB transaction. It is generally

--- a/bindings/go/src/fdb/fdb.go
+++ b/bindings/go/src/fdb/fdb.go
@@ -29,6 +29,7 @@ import "C"
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"log"
 	"runtime"
@@ -39,6 +40,7 @@ import (
 // Would put this in futures.go but for the documented issue with
 // exports and functions in preamble
 // (https://code.google.com/p/go-wiki/wiki/cgo#Global_functions)
+//
 //export unlockMutex
 func unlockMutex(p unsafe.Pointer) {
 	m := (*sync.Mutex)(p)
@@ -264,20 +266,8 @@ func MustOpenDefault() Database {
 // To connect to multiple clusters running at different, incompatible versions,
 // the multi-version client API must be used.
 func OpenDatabase(clusterFile string) (Database, error) {
-	networkMutex.Lock()
-	defer networkMutex.Unlock()
-
-	if apiVersion == 0 {
-		return Database{}, errAPIVersionUnset
-	}
-
-	var e error
-
-	if !networkStarted {
-		e = startNetwork()
-		if e != nil {
-			return Database{}, e
-		}
+	if err := ensureNetworkIsStarted(); err != nil {
+		return Database{}, err
 	}
 
 	db, ok := openDatabases[clusterFile]
@@ -290,6 +280,22 @@ func OpenDatabase(clusterFile string) (Database, error) {
 	}
 
 	return db, nil
+}
+
+// ensureNetworkIsStarted starts the network if not already done and ensures that the API version is set.
+func ensureNetworkIsStarted() error {
+	networkMutex.Lock()
+	defer networkMutex.Unlock()
+
+	if apiVersion == 0 {
+		return errAPIVersionUnset
+	}
+
+	if !networkStarted {
+		return startNetwork()
+	}
+
+	return nil
 }
 
 // MustOpenDatabase is like OpenDatabase but panics if the default database cannot
@@ -337,7 +343,35 @@ func createDatabase(clusterFile string) (Database, error) {
 	db := &database{outdb}
 	runtime.SetFinalizer(db, (*database).destroy)
 
-	return Database{db}, nil
+	return Database{clusterFile, db}, nil
+}
+
+// OpenWithConnectionString returns a database handle to the FoundationDB cluster identified
+// by the provided connection string. This method can be useful for scenarios where you want to connect
+// to the database only for a short time e.g. to test different connection strings.
+func OpenWithConnectionString(connectionString string) (Database, error) {
+	if err := ensureNetworkIsStarted(); err != nil {
+		return Database{}, err
+	}
+
+	var cf *C.char
+
+	if connectionString == "" {
+		return Database{}, errors.New("connection string must be a non-empty string")
+	}
+
+	cf = C.CString(connectionString)
+	defer C.free(unsafe.Pointer(cf))
+
+	var outdb *C.FDBDatabase
+	if err := C.fdb_create_database_from_connection_string(cf, &outdb); err != 0 {
+		return Database{}, Error{int(err)}
+	}
+
+	db := &database{outdb}
+	runtime.SetFinalizer(db, (*database).destroy)
+
+	return Database{"", db}, nil
 }
 
 // Deprecated: Use OpenDatabase instead.

--- a/bindings/go/src/fdb/fdb_test.go
+++ b/bindings/go/src/fdb/fdb_test.go
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2013-2018 Apple Inc. and the FoundationDB project authors
+ * Copyright 2013-2022 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,7 +48,10 @@ func ExampleOpenDefault() {
 		return
 	}
 
-	_ = db
+	// Close the database after usage
+	defer db.Close()
+
+	// Do work here
 
 	// Output:
 }
@@ -312,4 +315,25 @@ func TestKeyToString(t *testing.T) {
 func ExamplePrintable() {
 	fmt.Println(fdb.Printable([]byte{0, 1, 2, 'a', 'b', 'c', '1', '2', '3', '!', '?', 255}))
 	// Output: \x00\x01\x02abc123!?\xff
+}
+
+func ExampleOpenWithConnectionString() {
+	var e error
+
+	e = fdb.APIVersion(API_VERSION)
+	if e != nil {
+		fmt.Printf("Unable to set API version: %v\n", e)
+		return
+	}
+
+	// OpenWithConnectionString opens the database described by the connection string
+	db, e := fdb.OpenWithConnectionString("")
+	if e != nil {
+		fmt.Printf("Unable to open database: %v\n", e)
+		return
+	}
+
+	_ = db
+
+	// Output:
 }


### PR DESCRIPTION
Fixes: https://github.com/apple/foundationdb/issues/8388 for go bindings

Those changes allow to close a database and free the resources in the go bindings. In addition I added support to open a database with a connection string. The latter will be helpful for tools (like the fdb-kubernetes-operator) that need to connect to the database infrequently.

I build everything and I didn't get an error but I have to investigate how to run the actual tests.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
