### PR TITLE
Allow to create database in go bindings with connection string

### DIFF
--- a/bindings/c/foundationdb/fdb_c.h
+++ b/bindings/c/foundationdb/fdb_c.h
@@ -288,7 +288,8 @@ DLLEXPORT WARN_UNUSED_RESULT fdb_error_t fdb_result_get_keyvalue_array(FDBResult
 
 DLLEXPORT WARN_UNUSED_RESULT fdb_error_t fdb_create_database(const char* cluster_file_path, FDBDatabase** out_database);
 
-DLLEXPORT WARN_UNUSED_RESULT fdb_error_t fdb_create_database_from_connection_string(const char* connection_string, FDBDatabase** out_database);
+DLLEXPORT WARN_UNUSED_RESULT fdb_error_t fdb_create_database_from_connection_string(const char* connection_string,
+                                                                                    FDBDatabase** out_database);
 
 DLLEXPORT void fdb_database_destroy(FDBDatabase* d);
 

--- a/bindings/c/foundationdb/fdb_c.h
+++ b/bindings/c/foundationdb/fdb_c.h
@@ -288,6 +288,8 @@ DLLEXPORT WARN_UNUSED_RESULT fdb_error_t fdb_result_get_keyvalue_array(FDBResult
 
 DLLEXPORT WARN_UNUSED_RESULT fdb_error_t fdb_create_database(const char* cluster_file_path, FDBDatabase** out_database);
 
+DLLEXPORT WARN_UNUSED_RESULT fdb_error_t fdb_create_database_from_connection_string(const char* connection_string, FDBDatabase** out_database);
+
 DLLEXPORT void fdb_database_destroy(FDBDatabase* d);
 
 DLLEXPORT WARN_UNUSED_RESULT fdb_error_t fdb_database_set_option(FDBDatabase* d,

--- a/bindings/c/foundationdb/fdb_c_internal.h
+++ b/bindings/c/foundationdb/fdb_c_internal.h
@@ -46,9 +46,6 @@ DLLEXPORT void fdb_database_set_shared_state(FDBDatabase* db, DatabaseSharedStat
 
 DLLEXPORT WARN_UNUSED_RESULT fdb_error_t fdb_future_get_shared_state(FDBFuture* f, DatabaseSharedState** outPtr);
 
-DLLEXPORT WARN_UNUSED_RESULT fdb_error_t fdb_create_database_from_connection_string(const char* connection_string,
-                                                                                    FDBDatabase** out_database);
-
 DLLEXPORT void fdb_use_future_protocol_version();
 
 // the logical read_blob_granules is broken out (at different points depending on the client type) into the asynchronous

--- a/bindings/go/src/fdb/database.go
+++ b/bindings/go/src/fdb/database.go
@@ -44,6 +44,10 @@ import (
 type Database struct {
 	// String reference to the cluster file.
 	clusterFile string
+	// This variable is to track if we have to remove the database from the cached
+	// database structs. We can't use clusterFile alone, since the default clusterFile
+	// would be an empty string.
+	isCached bool
 	*database
 }
 
@@ -62,7 +66,9 @@ type DatabaseOptions struct {
 // You have to ensure that you're not resuing this database.
 func (d *Database) Close() {
 	// Remove database object from the cached databases
-	delete(openDatabases, d.clusterFile)
+	if d.isCached {
+		delete(openDatabases, d.clusterFile)
+	}
 
 	// Destroy the database
 	d.destroy()

--- a/bindings/go/src/fdb/fdb.go
+++ b/bindings/go/src/fdb/fdb.go
@@ -344,7 +344,7 @@ func createDatabase(clusterFile string) (Database, error) {
 	db := &database{outdb}
 	runtime.SetFinalizer(db, (*database).destroy)
 
-	return Database{clusterFile, db}, nil
+	return Database{clusterFile, true, db}, nil
 }
 
 // OpenWithConnectionString returns a database handle to the FoundationDB cluster identified
@@ -372,7 +372,7 @@ func OpenWithConnectionString(connectionString string) (Database, error) {
 	db := &database{outdb}
 	runtime.SetFinalizer(db, (*database).destroy)
 
-	return Database{db}, nil
+	return Database{"", false, db}, nil
 }
 
 // Deprecated: Use OpenDatabase instead.

--- a/bindings/go/src/fdb/fdb_test.go
+++ b/bindings/go/src/fdb/fdb_test.go
@@ -361,7 +361,10 @@ func ExampleOpenWithConnectionString() {
 		return
 	}
 
-	_ = db
+	// Close the database after usage
+	defer db.Close()
+
+	// Do work here
 
 	// Output:
 }

--- a/bindings/go/src/fdb/fdb_test.go
+++ b/bindings/go/src/fdb/fdb_test.go
@@ -24,6 +24,7 @@ package fdb_test
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/apple/foundationdb/bindings/go/src/fdb"
@@ -345,18 +346,18 @@ func TestDatabaseCloseRemovesResources(t *testing.T) {
 }
 
 func ExampleOpenWithConnectionString() {
-	var e error
+	fdb.MustAPIVersion(API_VERSION)
 
-	e = fdb.APIVersion(API_VERSION)
-	if e != nil {
-		fmt.Printf("Unable to set API version: %v\n", e)
+	clusterFileContent, err := os.ReadFile(os.Getenv("FDB_CLUSTER_FILE"))
+	if err != nil {
+		fmt.Errorf("Unable to read cluster file: %v\n", err)
 		return
 	}
 
 	// OpenWithConnectionString opens the database described by the connection string
-	db, e := fdb.OpenWithConnectionString("")
-	if e != nil {
-		fmt.Printf("Unable to open database: %v\n", e)
+	db, err := fdb.OpenWithConnectionString(string(clusterFileContent))
+	if err != nil {
+		fmt.Errorf("Unable to open database: %v\n", err)
 		return
 	}
 

--- a/bindings/go/src/fdb/fdb_test.go
+++ b/bindings/go/src/fdb/fdb_test.go
@@ -343,3 +343,24 @@ func TestDatabaseCloseRemovesResources(t *testing.T) {
 		t.Fatalf("Expected a different database object, got: %v and %v\n", db, newDB)
 	}
 }
+
+func ExampleOpenWithConnectionString() {
+	var e error
+
+	e = fdb.APIVersion(API_VERSION)
+	if e != nil {
+		fmt.Printf("Unable to set API version: %v\n", e)
+		return
+	}
+
+	// OpenWithConnectionString opens the database described by the connection string
+	db, e := fdb.OpenWithConnectionString("")
+	if e != nil {
+		fmt.Printf("Unable to open database: %v\n", e)
+		return
+	}
+
+	_ = db
+
+	// Output:
+}


### PR DESCRIPTION
This allows to create a database from a connection string inside the go bindings. That feature is useful for tools that try to connect with different connection strings to database, or if they use the database structure only for a short time e.g. like the operator is using the go bindings.

I added a new example to test the new setup.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
