### PR TITLE
Define FDB client configuration tests as python unit tests

### DIFF
--- a/bindings/c/test/fdb_c_client_config_tests.py
+++ b/bindings/c/test/fdb_c_client_config_tests.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
-from argparse import ArgumentParser, RawDescriptionHelpFormatter
+import argparse
 from pathlib import Path
-import platform
 import shutil
 import subprocess
 import sys
 import os
 import glob
+import unittest
 
 sys.path[:0] = [os.path.join(os.path.dirname(__file__), "..", "..", "..", "tests", "TestRunner")]
 
@@ -17,6 +17,9 @@ from local_cluster import LocalCluster, random_secret_string
 
 PREV_RELEASE_VERSION = "7.1.5"
 PREV_PREV_RELEASE_VERSION = "7.0.0"
+
+args = None
+downloader = None
 
 
 def version_from_str(ver_str):
@@ -30,11 +33,9 @@ def api_version_from_str(ver_str):
     return ver_tuple[0] * 100 + ver_tuple[1] * 10
 
 
-class TestEnv(LocalCluster):
+class TestCluster(LocalCluster):
     def __init__(
         self,
-        args,
-        downloader: FdbBinaryDownloader,
         version: str,
     ):
         self.client_config_tester_bin = Path(args.client_config_tester_bin).resolve()
@@ -44,35 +45,33 @@ class TestEnv(LocalCluster):
         assert self.build_dir.is_dir(), "{} is not a directory".format(args.build_dir)
         self.tmp_dir = self.build_dir.joinpath("tmp", random_secret_string(16))
         self.tmp_dir.mkdir(parents=True)
-        self.downloader = downloader
         self.version = version
         super().__init__(
             self.tmp_dir,
-            self.downloader.binary_path(version, "fdbserver"),
-            self.downloader.binary_path(version, "fdbmonitor"),
-            self.downloader.binary_path(version, "fdbcli"),
+            downloader.binary_path(version, "fdbserver"),
+            downloader.binary_path(version, "fdbmonitor"),
+            downloader.binary_path(version, "fdbcli"),
             1,
         )
-        self.set_env_var("LD_LIBRARY_PATH", self.downloader.lib_dir(version))
-        self.failed_cnt = 0
+        self.set_env_var("LD_LIBRARY_PATH", downloader.lib_dir(version))
 
-    def __enter__(self):
-        super().__enter__()
-        super().create_database()
-        return self
+    def setup(self):
+        self.__enter__()
+        self.create_database()
 
-    def __exit__(self, xc_type, exc_value, traceback):
-        super().__exit__(xc_type, exc_value, traceback)
+    def tearDown(self):
+        self.__exit__(None, None, None)
         shutil.rmtree(self.tmp_dir)
 
 
+# Client configuration tests using a cluster of the current version
 class ClientConfigTest:
-    def __init__(self, test_env: TestEnv, title: str):
-        self.test_env = test_env
-        self.title = title
+    def __init__(self, tc: unittest.TestCase):
+        self.tc = tc
+        self.cluster = tc.cluster
         self.external_lib_dir = None
         self.external_lib_path = None
-        self.test_dir = self.test_env.tmp_dir.joinpath(random_secret_string(16))
+        self.test_dir = self.cluster.tmp_dir.joinpath(random_secret_string(16))
         self.test_dir.mkdir(parents=True)
         self.log_dir = self.test_dir.joinpath("log")
         self.log_dir.mkdir(parents=True)
@@ -88,31 +87,28 @@ class ClientConfigTest:
         self.external_lib_dir = self.test_dir.joinpath("extclients")
         self.external_lib_dir.mkdir(parents=True)
         for version in versions:
-            src_file_path = self.test_env.downloader.lib_path(version)
-            assert src_file_path.exists(), "{} does not exist".format(src_file_path)
+            src_file_path = downloader.lib_path(version)
+            self.tc.assertTrue(src_file_path.exists(), "{} does not exist".format(src_file_path))
             target_file_path = self.external_lib_dir.joinpath("libfdb_c.{}.so".format(version))
             shutil.copyfile(src_file_path, target_file_path)
-            assert target_file_path.exists(), "{} does not exist".format(target_file_path)
+            self.tc.assertTrue(target_file_path.exists(), "{} does not exist".format(target_file_path))
 
     def create_external_lib_path(self, version):
-        src_file_path = self.test_env.downloader.lib_path(version)
-        assert src_file_path.exists(), "{} does not exist".format(src_file_path)
+        src_file_path = downloader.lib_path(version)
+        self.tc.assertTrue(src_file_path.exists(), "{} does not exist".format(src_file_path))
         self.external_lib_path = self.test_dir.joinpath("libfdb_c.{}.so".format(version))
         shutil.copyfile(src_file_path, self.external_lib_path)
-        assert self.external_lib_path.exists(), "{} does not exist".format(self.external_lib_path)
+        self.tc.assertTrue(self.external_lib_path.exists(), "{} does not exist".format(self.external_lib_path))
 
     def dump_client_logs(self):
         for log_file in glob.glob(os.path.join(self.log_dir, "*")):
-            print(">>>>>>>>>>>>>>>>>>>> Contents of {}:".format(log_file))
+            print(">>>>>>>>>>>>>>>>>>>> Contents of {}:".format(log_file), file=sys.stderr)
             with open(log_file, "r") as f:
-                print(f.read())
-            print(">>>>>>>>>>>>>>>>>>>> End of {}:".format(log_file))
+                print(f.read(), file=sys.stderr)
+            print(">>>>>>>>>>>>>>>>>>>> End of {}:".format(log_file), file=sys.stderr)
 
     def exec(self):
-        print("-" * 80)
-        print(self.title)
-        print("-" * 80)
-        cmd_args = [self.test_env.client_config_tester_bin, "--cluster-file", self.test_env.cluster_file]
+        cmd_args = [self.cluster.client_config_tester_bin, "--cluster-file", self.cluster.cluster_file]
 
         if self.tmp_dir is not None:
             cmd_args += ["--tmp-dir", self.tmp_dir]
@@ -141,61 +137,66 @@ class ClientConfigTest:
         if self.transaction_timeout is not None:
             cmd_args += ["--transaction-timeout", str(self.transaction_timeout)]
 
-        print("Executing test command: {}".format(" ".join([str(c) for c in cmd_args])))
-        tester_proc = subprocess.Popen(cmd_args, stdout=sys.stdout, stderr=sys.stderr)
-        tester_retcode = tester_proc.wait()
-        if tester_retcode != 0:
-            print("Test '{}' failed".format(self.title))
-            self.test_env.failed_cnt += 1
-
-        self.cleanup()
+        print("\nExecuting test command: {}".format(" ".join([str(c) for c in cmd_args])), file=sys.stderr)
+        try:
+            tester_proc = subprocess.Popen(cmd_args, stdout=sys.stdout, stderr=sys.stderr)
+            tester_retcode = tester_proc.wait()
+            self.tc.assertEqual(0, tester_retcode)
+        finally:
+            self.cleanup()
 
     def cleanup(self):
         shutil.rmtree(self.test_dir)
 
 
-class ClientConfigTests:
-    def __init__(self, args):
-        self.args = args
-        self.downloader = FdbBinaryDownloader(args.build_dir)
-        # binary downloads are currently available only for x86_64
-        self.platform = platform.machine()
-        if self.platform == "x86_64":
-            self.downloader.download_old_binaries(PREV_RELEASE_VERSION)
-            self.downloader.download_old_binaries(PREV_PREV_RELEASE_VERSION)
+class ClientConfigTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.cluster = TestCluster(CURRENT_VERSION)
+        cls.cluster.setup()
 
-    def test_local_client_only(self, test_env):
-        test = ClientConfigTest(test_env, "Local client only")
+    @classmethod
+    def tearDownClass(cls):
+        cls.cluster.tearDown()
+
+    def test_local_client_only(self):
+        # Local client only
+        test = ClientConfigTest(self)
         test.exec()
 
-    def test_single_external_client_only(self, test_env):
-        test = ClientConfigTest(test_env, "Single external client")
+    def test_single_external_client_only(self):
+        # Single external client only
+        test = ClientConfigTest(self)
         test.create_external_lib_path(CURRENT_VERSION)
         test.disable_local_client = True
         test.exec()
 
-    def test_same_local_and_external_client(self, test_env):
-        test = ClientConfigTest(test_env, "Same Local & External Client")
+    def test_same_local_and_external_client(self):
+        # Same version local & external client
+        test = ClientConfigTest(self)
         test.create_external_lib_path(CURRENT_VERSION)
         test.exec()
 
-    def test_multiple_external_clients(self, test_env):
-        test = ClientConfigTest(test_env, "Multiple external clients")
+    def test_multiple_external_clients(self):
+        # Multiple external clients, normal case
+        test = ClientConfigTest(self)
         test.create_external_lib_dir([CURRENT_VERSION, PREV_RELEASE_VERSION, PREV_PREV_RELEASE_VERSION])
         test.disable_local_client = True
         test.api_version = api_version_from_str(PREV_PREV_RELEASE_VERSION)
         test.exec()
 
-    def test_no_external_client_support_api_version(self, test_env):
-        test = ClientConfigTest(test_env, "Multiple external clients; API version supported by none")
+    def test_no_external_client_support_api_version(self):
+        # Multiple external clients, API version supported by none of them
+        test = ClientConfigTest(self)
         test.create_external_lib_dir([PREV_PREV_RELEASE_VERSION, PREV_RELEASE_VERSION])
         test.disable_local_client = True
         test.api_version = api_version_from_str(CURRENT_VERSION)
         test.expected_error = 2204  # API function missing
         test.exec()
 
-    def test_no_external_client_support_api_version_ignore(self, test_env):
-        test = ClientConfigTest(test_env, "Multiple external clients; API version supported by none; Ignore failures")
+    def test_no_external_client_support_api_version_ignore(self):
+        # Multiple external clients; API version supported by none of them; Ignore failures
+        test = ClientConfigTest(self)
         test.create_external_lib_dir([PREV_PREV_RELEASE_VERSION, PREV_RELEASE_VERSION])
         test.disable_local_client = True
         test.api_version = api_version_from_str(CURRENT_VERSION)
@@ -203,79 +204,66 @@ class ClientConfigTests:
         test.expected_error = 2124  # All external clients failed
         test.exec()
 
-    def test_one_external_client_wrong_api_version(self, test_env):
-        test = ClientConfigTest(test_env, "Multiple external clients: API version unsupported by one")
+    def test_one_external_client_wrong_api_version(self):
+        # Multiple external clients, API version unsupported by one of othem
+        test = ClientConfigTest(self)
         test.create_external_lib_dir([CURRENT_VERSION, PREV_RELEASE_VERSION, PREV_PREV_RELEASE_VERSION])
         test.disable_local_client = True
         test.api_version = api_version_from_str(CURRENT_VERSION)
         test.expected_error = 2204  # API function missing
         test.exec()
 
-    def test_one_external_client_wrong_api_version_ignore(self, test_env):
-        test = ClientConfigTest(test_env, "Multiple external clients;  API version unsupported by one; Ignore failures")
+    def test_one_external_client_wrong_api_version_ignore(self):
+        # Multiple external clients;  API version unsupported by one of them; Ignore failures
+        test = ClientConfigTest(self)
         test.create_external_lib_dir([CURRENT_VERSION, PREV_RELEASE_VERSION, PREV_PREV_RELEASE_VERSION])
         test.disable_local_client = True
         test.api_version = api_version_from_str(CURRENT_VERSION)
         test.ignore_external_client_failures = True
         test.exec()
 
-    def test_prev_release_with_ext_client(self, test_env):
-        test = ClientConfigTest(test_env, "Cluster with previous release version")
+
+# Client configuration tests using a cluster of previous release version
+class ClientConfigPrevVersionTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.cluster = TestCluster(PREV_RELEASE_VERSION)
+        cls.cluster.setup()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.cluster.tearDown()
+
+    def test_external_client(self):
+        # Using an external client to connect
+        test = ClientConfigTest(self)
         test.create_external_lib_path(PREV_RELEASE_VERSION)
         test.api_version = api_version_from_str(PREV_RELEASE_VERSION)
         test.exec()
 
-    def test_prev_release_with_ext_client_unsupported_api(self, test_env):
-        test = ClientConfigTest(test_env, "Cluster with previous release version; Unsupported API version")
+    def test_prev_release_with_ext_client_unsupported_api(self):
+        # Leaving an unsupported API version
+        test = ClientConfigTest(self)
         test.create_external_lib_path(PREV_RELEASE_VERSION)
         test.expected_error = 2204  # API function missing
         test.exec()
 
-    def test_prev_release_with_ext_client_unsupported_api_ignore(self, test_env):
-        test = ClientConfigTest(
-            test_env, "Cluster with previous release version; Unsupported API version; Ignore failures"
-        )
+    def test_prev_release_with_ext_client_unsupported_api_ignore(self):
+        # Leaving an unsupported API version, ignore failures
+        test = ClientConfigTest(self)
         test.create_external_lib_path(PREV_RELEASE_VERSION)
         test.transaction_timeout = 100
         test.expected_error = 1031  # Timeout
         test.ignore_external_client_failures = True
         test.exec()
 
-    def run_tests(self):
-        failed_cnt = 0
-        with TestEnv(self.args, self.downloader, CURRENT_VERSION) as test_env:
-            self.test_local_client_only(test_env)
-            self.test_single_external_client_only(test_env)
-            self.test_same_local_and_external_client(test_env)
-            self.test_multiple_external_clients(test_env)
-            self.test_no_external_client_support_api_version(test_env)
-            self.test_no_external_client_support_api_version_ignore(test_env)
-            self.test_one_external_client_wrong_api_version(test_env)
-            self.test_one_external_client_wrong_api_version_ignore(test_env)
-            failed_cnt += test_env.failed_cnt
-
-        if self.platform == "x86_64":
-            with TestEnv(self.args, self.downloader, PREV_RELEASE_VERSION) as test_env:
-                self.test_prev_release_with_ext_client(test_env)
-                self.test_prev_release_with_ext_client_unsupported_api(test_env)
-                self.test_prev_release_with_ext_client_unsupported_api_ignore(test_env)
-                failed_cnt += test_env.failed_cnt
-
-        if failed_cnt > 0:
-            print("{} tests failed".format(failed_cnt))
-        else:
-            print("All tests successful")
-        return failed_cnt
-
 
 if __name__ == "__main__":
-    parser = ArgumentParser(
-        formatter_class=RawDescriptionHelpFormatter,
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
         description="""
-        A script for testing FDB multi-version client in upgrade scenarios. Creates a local cluster,
-        generates a workload using fdb_c_api_tester with a specified test file, and performs
-        cluster upgrade according to the specified upgrade path. Checks if the workload successfully
-        progresses after each upgrade step.
+        Unit tests for running FDB client with different configurations. 
+        Also accepts python unit tests command line arguments.
         """,
     )
     parser.add_argument(
@@ -291,7 +279,13 @@ if __name__ == "__main__":
         help="Path to the fdb_c_client_config_tester executable.",
         required=True,
     )
+    parser.add_argument("unittest_args", nargs=argparse.REMAINDER)
+
     args = parser.parse_args()
-    test = ClientConfigTests(args)
-    failed_cnt = test.run_tests()
-    sys.exit(failed_cnt)
+    sys.argv[1:] = args.unittest_args
+
+    downloader = FdbBinaryDownloader(args.build_dir)
+    downloader.download_old_binaries(PREV_RELEASE_VERSION)
+    downloader.download_old_binaries(PREV_PREV_RELEASE_VERSION)
+
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Defining the new client configuration tests as proper python unit tests. This way we can reuse the python unit test framework for reporting failed tests and executing individual tests when necessary.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
