### PR TITLE
Allow to close database in go bindings

### DIFF
--- a/bindings/go/src/fdb/database.go
+++ b/bindings/go/src/fdb/database.go
@@ -42,6 +42,7 @@ import (
 // usually created and committed automatically by the (Database).Transact
 // method.
 type Database struct {
+	clusterFile string
 	*database
 }
 
@@ -54,6 +55,18 @@ type database struct {
 // (Database).Options method.
 type DatabaseOptions struct {
 	d *database
+}
+
+// Close will close the Database and clean up all resources.
+// You have to ensure that you're not resuing this database.
+func (d *Database) Close() {
+	// Remove database object from the cached databases
+	if d.clusterFile != "" {
+		delete(openDatabases, d.clusterFile)
+	}
+
+	// Destroy the database
+	d.destroy()
 }
 
 func (opt DatabaseOptions) setOpt(code int, param []byte) error {

--- a/bindings/go/src/fdb/database.go
+++ b/bindings/go/src/fdb/database.go
@@ -42,6 +42,7 @@ import (
 // usually created and committed automatically by the (Database).Transact
 // method.
 type Database struct {
+	// String reference to the cluster file.
 	clusterFile string
 	*database
 }
@@ -61,9 +62,7 @@ type DatabaseOptions struct {
 // You have to ensure that you're not resuing this database.
 func (d *Database) Close() {
 	// Remove database object from the cached databases
-	if d.clusterFile != "" {
-		delete(openDatabases, d.clusterFile)
-	}
+	delete(openDatabases, d.clusterFile)
 
 	// Destroy the database
 	d.destroy()
@@ -76,6 +75,10 @@ func (opt DatabaseOptions) setOpt(code int, param []byte) error {
 }
 
 func (d *database) destroy() {
+	if d.ptr == nil {
+		return
+	}
+
 	C.fdb_database_destroy(d.ptr)
 }
 

--- a/bindings/go/src/fdb/fdb.go
+++ b/bindings/go/src/fdb/fdb.go
@@ -39,6 +39,7 @@ import (
 // Would put this in futures.go but for the documented issue with
 // exports and functions in preamble
 // (https://code.google.com/p/go-wiki/wiki/cgo#Global_functions)
+//
 //export unlockMutex
 func unlockMutex(p unsafe.Pointer) {
 	m := (*sync.Mutex)(p)
@@ -337,7 +338,7 @@ func createDatabase(clusterFile string) (Database, error) {
 	db := &database{outdb}
 	runtime.SetFinalizer(db, (*database).destroy)
 
-	return Database{db}, nil
+	return Database{clusterFile, db}, nil
 }
 
 // Deprecated: Use OpenDatabase instead.

--- a/bindings/go/src/fdb/fdb_test.go
+++ b/bindings/go/src/fdb/fdb_test.go
@@ -320,24 +320,26 @@ func ExamplePrintable() {
 func TestDatabaseCloseRemovesResources(t *testing.T) {
 	err := fdb.APIVersion(API_VERSION)
 	if err != nil {
-		t.Fatalf("Unable to set API version: %v\n", e)
+		t.Fatalf("Unable to set API version: %v\n", err)
 	}
 
 	// OpenDefault opens the database described by the platform-specific default
 	// cluster file
 	db, err := fdb.OpenDefault()
 	if err != nil {
-		t.Fatalf("Unable to set API version: %v\n", e)
+		t.Fatalf("Unable to set API version: %v\n", err)
 	}
 
-	clusterFile := db.clusterFile
-
 	// Close the database after usage
-	defer db.Close()
+	db.Close()
 
-	_, ok := openDatabases[clusterFile]
+	// Open the same database again, if the database is still in the cache we would return the same object, if not we create a new object with a new pointer
+	newDB, err := fdb.OpenDefault()
+	if err != nil {
+		t.Fatalf("Unable to set API version: %v\n", err)
+	}
 
-	if ok {
-		t.Fatalf("Expected key: %s doesn't exist\n", clusterFile)
+	if db == newDB {
+		t.Fatalf("Expected a different database object, got: %v and %v\n", db, newDB)
 	}
 }

--- a/bindings/go/src/fdb/fdb_test.go
+++ b/bindings/go/src/fdb/fdb_test.go
@@ -48,7 +48,10 @@ func ExampleOpenDefault() {
 		return
 	}
 
-	_ = db
+	// Close the database after usage
+	defer db.Close()
+
+	// Do work here
 
 	// Output:
 }
@@ -312,4 +315,29 @@ func TestKeyToString(t *testing.T) {
 func ExamplePrintable() {
 	fmt.Println(fdb.Printable([]byte{0, 1, 2, 'a', 'b', 'c', '1', '2', '3', '!', '?', 255}))
 	// Output: \x00\x01\x02abc123!?\xff
+}
+
+func TestDatabaseCloseRemovesResources(t *testing.T) {
+	err := fdb.APIVersion(API_VERSION)
+	if err != nil {
+		t.Fatalf("Unable to set API version: %v\n", e)
+	}
+
+	// OpenDefault opens the database described by the platform-specific default
+	// cluster file
+	db, err := fdb.OpenDefault()
+	if err != nil {
+		t.Fatalf("Unable to set API version: %v\n", e)
+	}
+
+	clusterFile := db.clusterFile
+
+	// Close the database after usage
+	defer db.Close()
+
+	_, ok := openDatabases[clusterFile]
+
+	if ok {
+		t.Fatalf("Expected key: %s doesn't exist\n", clusterFile)
+	}
 }


### PR DESCRIPTION
Fixes: https://github.com/apple/foundationdb/issues/8388 for go bindings. This allows to close a database after using it. For testing I ran the unit tests for go and they passed locally.

We can think about back porting those changes to 7.1 if we want. I can look at the other bindings in a separate PR, the go bindings are currently the most interesting one for us.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
