### PR TITLE
After speedUpSimulation, start using a 5s write transaction window.

### DIFF
--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -2031,6 +2031,12 @@ ACTOR Future<Void> reply(CommitBatchContext* self) {
 		int lastSize = pProxyCommitData->keyResolvers.size();
 		auto rs = pProxyCommitData->keyResolvers.ranges();
 		Version oldestVersion = self->prevVersion - SERVER_KNOBS->MAX_WRITE_TRANSACTION_LIFE_VERSIONS;
+
+		// After speedUpSimulation, start using the default 5s max transaction life
+		if (g_network->isSimulated() && g_simulator->speedUpSimulation) {
+			oldestVersion = self->prevVersion - 5 * SERVER_KNOBS->VERSIONS_PER_SECOND;
+		}
+
 		for (auto r = rs.begin(); r != rs.end(); ++r) {
 			while (r->value().size() > 1 && r->value()[1].first < oldestVersion)
 				r->value().pop_front();

--- a/fdbserver/Resolver.actor.cpp
+++ b/fdbserver/Resolver.actor.cpp
@@ -290,10 +290,13 @@ ACTOR Future<Void> resolveBatch(Reference<Resolver> self,
 		double expire = now() + SERVER_KNOBS->SAMPLE_EXPIRATION_TIME;
 		ConflictBatch conflictBatch(self->conflictSet, &reply.conflictingKeyRangeMap, &reply.arena);
 		Version newOldestVersion = req.version - SERVER_KNOBS->MAX_WRITE_TRANSACTION_LIFE_VERSIONS;
+
+		// After speedUpSimulation, start using the default 5s max transaction life
 		if (g_network->isSimulated() && g_simulator->speedUpSimulation) {
-			newOldestVersion = req.version - std::max(5 * SERVER_KNOBS->VERSIONS_PER_SECOND,
-			                                          SERVER_KNOBS->MAX_WRITE_TRANSACTION_LIFE_VERSIONS);
+			newOldestVersion =
+			    std::max(conflictBatch.oldestConflictSetVersion(), req.version - 5 * SERVER_KNOBS->VERSIONS_PER_SECOND);
 		}
+
 		for (int t = 0; t < req.transactions.size(); t++) {
 			conflictBatch.addTransaction(req.transactions[t], newOldestVersion);
 			self->resolvedReadConflictRanges += req.transactions[t].read_conflict_ranges.size();

--- a/fdbserver/SkipList.cpp
+++ b/fdbserver/SkipList.cpp
@@ -816,6 +816,10 @@ struct TransactionInfo {
 	bool reportConflictingKeys;
 };
 
+Version ConflictBatch::oldestConflictSetVersion() const {
+	return cs->oldestVersion;
+}
+
 void ConflictBatch::addTransaction(const CommitTransactionRef& tr, Version newOldestVersion) {
 	const int t = transactionCount++;
 

--- a/fdbserver/include/fdbserver/ConflictSet.h
+++ b/fdbserver/include/fdbserver/ConflictSet.h
@@ -45,6 +45,7 @@ struct ConflictBatch {
 		TransactionCommitted,
 	};
 
+	Version oldestConflictSetVersion() const;
 	void addTransaction(const CommitTransactionRef& transaction, Version newOldestVersion);
 	void detectConflicts(Version now,
 	                     Version newOldestVersion,


### PR DESCRIPTION
This may have a bug in it, or exposing existing bugs or test shortcomings.

With `MAX_WRITE_TRANSACTION_LIFE_VERSIONS` buggification forced ON, this has 5 failures in 500k tests, one of them looks serious.  I'm not sure how clean 500k tests would normally be with this buggify forced on so I'll try that.

```
InternalError		newOldestVersion <= latestVersion	1	a5dd7b0bafe365d8275af405dec3a9af36504c50	devRetryCorrectnessTest bin/fdbserver -r simulation -f tests/fast/SelectorCorrectness.toml -s 3599440561 -b on  --crash --trace_format json	20221112-202756-satherton-2e7687f36b7c173d
SetupAndRunError			1	a5dd7b0bafe365d8275af405dec3a9af36504c50	devRetryCorrectnessTest bin/fdbserver -r simulation -f tests/fast/ConfigIncrementWithKills.toml -s 3788213048 -b off  --crash --trace_format json	20221112-202756-satherton-2e7687f36b7c173d
ExternalTimeout			1	a5dd7b0bafe365d8275af405dec3a9af36504c50	devRetryCorrectnessTest bin/fdbserver -r simulation -f tests/fast/RandomUnitTests.toml -s 1059229418 -b on  --crash --trace_format json	20221112-202756-satherton-2e7687f36b7c173d
TestFailure	Error starting workload		1	a5dd7b0bafe365d8275af405dec3a9af36504c50	devRetryCorrectnessTest bin/fdbserver -r simulation -f tests/rare/TransactionTagSwizzledApiCorrectness.toml -s 3151000967 -b on  --crash --trace_format json	20221112-202756-satherton-2e7687f36b7c173d
InternalError		(active > 0 || amount == 0) && active - amount >= 0	1	a5dd7b0bafe365d8275af405dec3a9af36504c50	devRetryCorrectnessTest bin/fdbserver -r simulation -f tests/slow/ParallelRestoreNewBackupCorrectnessCycle.toml -s 2554737136 -b off  --crash --trace_format json	20221112-202756-satherton-2e7687f36b7c173d
```

Without forcing `MAX_WRITE_TRANSACTION_LIFE_VERSIONS` to be buggified, 500k tests has 2 errors, the second one could be serious.
```
InternalError		seed != 0	1	a5dd7b0bafe365d8275af405dec3a9af36504c50	devRetryCorrectnessTest bin/fdbserver -r simulation -f tests/fast/RESTKmsConnectorUnit.toml -s 2593193109 -b on  --crash --trace_format json	20221112-212508-satherton-423b0ce41832fbe9
SystemError		map::at:  key not found	1	a5dd7b0bafe365d8275af405dec3a9af36504c50	devRetryCorrectnessTest bin/fdbserver -r simulation -f tests/rare/ReadSkewReadWrite.toml -s 767165138 -b on  --crash --trace_format json	20221112-212508-satherton-423b0ce41832fbe9
```



# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
