### PR TITLE
Fix DiskQueue close before shutdown/push is done

### DIFF
--- a/fdbserver/DiskQueue.actor.cpp
+++ b/fdbserver/DiskQueue.actor.cpp
@@ -339,6 +339,8 @@ public:
 	ACTOR static UNCANCELLABLE Future<Future<Void>> push(RawDiskQueue_TwoFiles* self,
 	                                                     Standalone<StringRef> pageData,
 	                                                     std::vector<Reference<SyncQueue>>* toSync) {
+		state TrackMe trackMe(self);
+
 		// Write the given data (pageData) to the queue files, swapping or extending them if necessary.
 		// Don't do any syncs, but push the modified file(s) onto toSync.
 		ASSERT(self->readingFile == 2);
@@ -440,6 +442,7 @@ public:
 	                                                      Standalone<StringRef> pageData,
 	                                                      StringBuffer* pageMem,
 	                                                      uint64_t poppedPages) {
+		state TrackMe trackMe(self);
 		state Promise<Void> pushing, committed;
 		state Promise<Void> errorPromise = self->error;
 		state std::string filename = self->files[0].dbgFilename;
@@ -594,6 +597,8 @@ public:
 	}
 
 	ACTOR static void shutdown(RawDiskQueue_TwoFiles* self, bool deleteFiles) {
+		state TrackMe trackMe(self);
+
 		// Wait for all reads and writes on the file, and all actors referencing self, to be finished
 		state Error error = success();
 		try {


### PR DESCRIPTION
Otherwise, pushAndCommit() can get broken_promise error.

20221112-232143-jzhou-dc63e3442d34db1e

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
