### PR TITLE
Fix arena dependOn and timing in simulation [release-7.2]

### DIFF
--- a/fdbrpc/include/fdbrpc/TimedRequest.h
+++ b/fdbrpc/include/fdbrpc/TimedRequest.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include <fdbrpc/fdbrpc.h>
+#include "flow/network.h"
 
 class TimedRequest {
 	double _requestTime;
@@ -35,7 +36,7 @@ public:
 
 	TimedRequest() {
 		if (!FlowTransport::isClient()) {
-			_requestTime = timer();
+			_requestTime = g_network->timer();
 		} else {
 			_requestTime = 0.0;
 		}

--- a/flow/Arena.cpp
+++ b/flow/Arena.cpp
@@ -297,6 +297,7 @@ void* ArenaBlock::make4kAlignedBuffer(uint32_t size) {
 }
 
 void ArenaBlock::dependOn(Reference<ArenaBlock>& self, ArenaBlock* other) {
+	ASSERT(self->getData() != other->getData());
 	other->addref();
 	if (!self || self->isTiny() || self->unused() < sizeof(ArenaBlockRef))
 		create(SMALL, self)->makeReference(other);


### PR DESCRIPTION
Cherrypick #8753 #8696

Fixes `slow/ParallelRestoreNewBackupWriteDuringReadAtomicRestore.toml -s 416410271 -b off` at [62970b37](https://github.com/FoundationDB/foundationdb-nightly-clang/commit/62970b374d31405fe94dfb63dd58da8186b2cbef)

20221114-202540-jzhou-defd79e723ffe943

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
