### PR TITLE
Avoid port collisions in ctests

### DIFF
--- a/tests/TestRunner/local_cluster.py
+++ b/tests/TestRunner/local_cluster.py
@@ -6,35 +6,59 @@ import subprocess
 import os
 import socket
 import time
+import fcntl
+import sys
 
 CLUSTER_UPDATE_TIMEOUT_SEC = 10
 EXCLUDE_SERVERS_TIMEOUT_SEC = 120
 RETRY_INTERVAL_SEC = 0.5
+PORT_LOCK_DIR = Path("/tmp/fdb_local_cluster_port_locks")
+MAX_PORT_ACQUIRE_ATTEMPTS = 1000
 
 
-def _get_free_port_internal():
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("0.0.0.0", 0))
-        return s.getsockname()[1]
+class PortProvider:
+    def __init__(self):
+        self._used_ports = set()
+        self._lock_files = []
+        PORT_LOCK_DIR.mkdir(exist_ok=True)
 
+    def get_free_port(self):
+        counter = 0
+        while True:
+            counter += 1
+            if counter > MAX_PORT_ACQUIRE_ATTEMPTS:
+                assert False, "Failed to acquire a free port after {} attempts".format(MAX_PORT_ACQUIRE_ATTEMPTS)
+            port = PortProvider._get_free_port_internal()
+            if port in self._used_ports:
+                continue
+            lock_path = PORT_LOCK_DIR.joinpath("{}.lock".format(port))
+            try:
+                locked_fd = open(lock_path, "w+")
+                self._lock_files.append(locked_fd)
+                fcntl.lockf(locked_fd, fcntl.LOCK_EX)
+                self._used_ports.add(port)
+                return port
+            except OSError:
+                print("Failed to lock file {}. Trying to aquire another port".format(lock_path), file=sys.stderr)
+                pass
 
-_used_ports = set()
+    def is_port_in_use(port):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            return s.connect_ex(("localhost", port)) == 0
 
+    def _get_free_port_internal():
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(("0.0.0.0", 0))
+            return s.getsockname()[1]
 
-def get_free_port():
-    global _used_ports
-    port = _get_free_port_internal()
-    while port in _used_ports:
-        port = _get_free_port_internal()
-    _used_ports.add(port)
-    return port
-
-
-def is_port_in_use(port):
-    import socket
-
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        return s.connect_ex(("localhost", port)) == 0
+    def release_locks(self):
+        for fd in self._lock_files:
+            fd.close()
+            try:
+                os.remove(fd.name)
+            except:
+                pass
+        self._lock_files.clear()
 
 
 valid_letters_for_secret = string.ascii_letters + string.digits
@@ -122,6 +146,7 @@ logdir = {logdir}
         custom_config: dict = {},
         public_key_json_str: str = "",
     ):
+        self.port_provider = PortProvider()
         self.basedir = Path(basedir)
         self.etc = self.basedir.joinpath("etc")
         self.log = self.basedir.joinpath("log")
@@ -188,7 +213,7 @@ logdir = {logdir}
 
     def __next_port(self):
         if self.first_port is None:
-            return get_free_port()
+            return self.port_provider.get_free_port()
         else:
             self.last_used_port += 1
             return self.last_used_port
@@ -284,7 +309,7 @@ logdir = {logdir}
             in_use = False
             for server_id in self.active_servers:
                 port = self.server_ports[server_id]
-                if is_port_in_use(port):
+                if PortProvider.is_port_in_use(port):
                     print("Port {} in use. Waiting for it to be released".format(port))
                     in_use = True
                     break
@@ -300,6 +325,10 @@ logdir = {logdir}
 
     def __exit__(self, xc_type, exc_value, traceback):
         self.stop_cluster()
+        self.release_ports()
+
+    def release_ports(self):
+        self.port_provider.release_locks()
 
     def __fdbcli_exec(self, cmd, stdout, stderr, timeout):
         args = [self.fdbcli_binary, "-C", self.cluster_file, "--exec", cmd]

--- a/tests/TestRunner/local_cluster.py
+++ b/tests/TestRunner/local_cluster.py
@@ -8,11 +8,12 @@ import socket
 import time
 import fcntl
 import sys
+import tempfile
 
 CLUSTER_UPDATE_TIMEOUT_SEC = 10
 EXCLUDE_SERVERS_TIMEOUT_SEC = 120
 RETRY_INTERVAL_SEC = 0.5
-PORT_LOCK_DIR = Path("/tmp/fdb_local_cluster_port_locks")
+PORT_LOCK_DIR = Path(tempfile.gettempdir()).joinpath("fdb_local_cluster_port_locks")
 MAX_PORT_ACQUIRE_ATTEMPTS = 1000
 
 

--- a/tests/TestRunner/upgrade_test.py
+++ b/tests/TestRunner/upgrade_test.py
@@ -168,6 +168,7 @@ class UpgradeTest:
 
     def __exit__(self, xc_type, exc_value, traceback):
         self.cluster.stop_cluster()
+        self.cluster.release_ports()
         if CLEANUP_ON_EXIT:
             shutil.rmtree(self.tmp_dir)
 


### PR DESCRIPTION
The FDB client tests based on local cluster dynamically detects free ports and uses them for the cluster processes. When multiple such tests are executed in parallel, it may happen that different tests try to use the same port which leads to one of the tests failing. 

The local cluster now reserves ports by locking corresponding files in /tmp/fdb_local_cluster_port_locks. The locks are released and files are deleted upon completion of the test. The locks are also automatically released by the operating system upon termination of the python process. 

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
