### PR TITLE
Bug fix: Use-after-destruct in PriorityMultiLock

### DIFF
--- a/flow/include/flow/PriorityMultiLock.actor.h
+++ b/flow/include/flow/PriorityMultiLock.actor.h
@@ -144,7 +144,6 @@ public:
 		available = 0;
 
 		waitingPriorities.clear();
-		priorities.clear();
 	}
 
 	std::string toString() const {

--- a/flow/include/flow/PriorityMultiLock.actor.h
+++ b/flow/include/flow/PriorityMultiLock.actor.h
@@ -144,6 +144,9 @@ public:
 		available = 0;
 
 		waitingPriorities.clear();
+		for (auto& p : priorities) {
+			p.queue.clear();
+		}
 	}
 
 	std::string toString() const {


### PR DESCRIPTION
Bug fix: Use-after-destruct in PriorityMultiLock because kill() was clearing the priorities vector which can no longer be done because release handlers can still hold a reference to the instance and point into the vector.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
