### PR TITLE
Show blob restore in fdbcli status command

### DIFF
--- a/fdbcli/BlobRestoreCommand.actor.cpp
+++ b/fdbcli/BlobRestoreCommand.actor.cpp
@@ -36,7 +36,8 @@ ACTOR Future<bool> blobRestoreCommandActor(Database localDb, std::vector<StringR
 	state bool success = false;
 	wait(store(success, localDb->blobRestore(normalKeys)));
 	if (success) {
-		fmt::print("Started blob restore for the full cluster. Please use 'status' command to check progress.\n");
+		fmt::print(
+		    "Started blob restore for the full cluster. Please use 'status details' command to check progress.\n");
 	} else {
 		fmt::print("Fail to start a new blob restore while there is a pending one.\n");
 	}

--- a/fdbcli/StatusCommand.actor.cpp
+++ b/fdbcli/StatusCommand.actor.cpp
@@ -1125,6 +1125,15 @@ void printStatus(StatusObjectReader statusObj,
 					outputString += "\n  Number of Workers      - " + format("%d", numWorkers);
 					auto numKeyRanges = statusObjBlobGranules["number_of_key_ranges"].get_int();
 					outputString += "\n  Number of Key Ranges   - " + format("%d", numKeyRanges);
+					if (statusObjCluster.has("blob_restore")) {
+						StatusObjectReader statusObjBlobRestore = statusObjCluster["blob_restore"];
+						std::string restoreStatus = statusObjBlobRestore["blob_full_restore_phase"].get_str();
+						if (statusObjBlobRestore.has("blob_full_restore_progress")) {
+							auto progress = statusObjBlobRestore["blob_full_restore_progress"].get_int();
+							restoreStatus += " " + format("%d%%", progress);
+						}
+						outputString += "\n  Full Restore           - " + restoreStatus;
+					}
 				}
 			}
 

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -10932,8 +10932,7 @@ ACTOR Future<bool> blobRestoreActor(Reference<DatabaseContext> cx, KeyRange rang
 					return false; // stop if there is in-progress restore.
 				}
 			}
-			Standalone<BlobRestoreStatus> status;
-			status.progress = 0;
+			BlobRestoreStatus status(BlobRestorePhase::INIT);
 			Value newValue = blobRestoreCommandValueFor(status);
 			tr->set(key, newValue);
 			wait(tr->commit());

--- a/fdbclient/include/fdbclient/BlobGranuleCommon.h
+++ b/fdbclient/include/fdbclient/BlobGranuleCommon.h
@@ -314,13 +314,19 @@ struct BlobManifest {
 };
 
 // Defines blob restore status
+enum BlobRestorePhase { INIT = 0, LOAD_MANIFEST = 1, MANIFEST_DONE = 2, MIGRATE = 3, APPLY_MLOGS = 4, DONE = 5 };
 struct BlobRestoreStatus {
 	constexpr static FileIdentifier file_identifier = 378657;
+	BlobRestorePhase phase;
 	int progress;
+
+	BlobRestoreStatus() : phase(BlobRestorePhase::INIT){};
+	BlobRestoreStatus(BlobRestorePhase pha) : phase(pha), progress(0){};
+	BlobRestoreStatus(BlobRestorePhase pha, int prog) : phase(pha), progress(prog){};
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, progress);
+		serializer(ar, phase, progress);
 	}
 };
 

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -26,6 +26,7 @@
 #include <tuple>
 #include <vector>
 
+#include "fdbclient/BlobGranuleCommon.h"
 #include "fdbclient/FDBTypes.h"
 #include "fdbclient/SystemData.h"
 #include "fdbclient/DatabaseContext.h"
@@ -2565,8 +2566,8 @@ ACTOR Future<Void> watchBlobRestoreCommand(ClusterControllerData* self) {
 			Optional<Value> blobRestoreCommand = wait(tr->get(blobRestoreCommandKey));
 			if (blobRestoreCommand.present()) {
 				Standalone<BlobRestoreStatus> status = decodeBlobRestoreStatus(blobRestoreCommand.get());
-				TraceEvent("WatchBlobRestoreCommand").detail("Progress", status.progress);
-				if (status.progress == 0) {
+				TraceEvent("WatchBlobRestoreCommand").detail("Progress", status.progress).detail("Phase", status.phase);
+				if (status.phase == BlobRestorePhase::INIT) {
 					self->db.blobRestoreEnabled.set(true);
 					if (self->db.blobGranulesEnabled.get()) {
 						const auto& blobManager = self->db.serverInfo->get().blobManager;

--- a/fdbserver/include/fdbserver/BlobGranuleServerCommon.actor.h
+++ b/fdbserver/include/fdbserver/BlobGranuleServerCommon.actor.h
@@ -163,7 +163,8 @@ ACTOR Future<Void> printRestoreSummary(Database db, Reference<BlobConnectionProv
 ACTOR Future<BlobGranuleRestoreVersionVector> listBlobGranules(Database db, Reference<BlobConnectionProvider> blobConn);
 ACTOR Future<int64_t> lastBlobEpoc(Database db, Reference<BlobConnectionProvider> blobConn);
 ACTOR Future<bool> isFullRestoreMode(Database db, KeyRangeRef range);
-
+ACTOR Future<Void> updateRestoreStatus(Database db, KeyRangeRef range, BlobRestoreStatus status);
+ACTOR Future<Optional<BlobRestoreStatus>> getRestoreStatus(Database db, KeyRangeRef range);
 #include "flow/unactorcompiler.h"
 
 #endif


### PR DESCRIPTION
This PR shows blob restore status in fdbcli like the following
> status details
...
Blob Granules:
  Number of Workers      - 2
  Number of Key Ranges   - 86
  Full Restore           - Copying data 40%
...

The key changes are:
1) add BlobRestorePhase to BlobRestoreStatus 
2) add api to update/get restore status
3) fdbcli changes to show status
4) a misc fix to use krmSetRangeCoalescing to replace krmSetRange in blob migrator.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
