### PR TITLE
Track commit costs while `ReportCommitCostEstimationRequest` is in-flight

### DIFF
--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -2563,14 +2563,14 @@ ACTOR Future<Void> reportTxnTagCommitCost(UID myID,
 			nextRequestTimer = Never();
 			if (db->get().ratekeeper.present()) {
 				nextReply = brokenPromiseToNever(db->get().ratekeeper.get().reportCommitCostEstimation.getReply(
-				    ReportCommitCostEstimationRequest(*ssTrTagCommitCost)));
+				    ReportCommitCostEstimationRequest(std::move(*ssTrTagCommitCost))));
+				ssTrTagCommitCost->clear();
 			} else {
 				nextReply = Never();
 			}
 		}
 		when(wait(nextReply)) {
 			nextReply = Never();
-			ssTrTagCommitCost->clear();
 			nextRequestTimer = delay(SERVER_KNOBS->REPORT_TRANSACTION_COST_ESTIMATION_DELAY);
 		}
 	}

--- a/fdbserver/include/fdbserver/RatekeeperInterface.h
+++ b/fdbserver/include/fdbserver/RatekeeperInterface.h
@@ -150,8 +150,9 @@ struct ReportCommitCostEstimationRequest {
 	ReplyPromise<Void> reply;
 
 	ReportCommitCostEstimationRequest() {}
-	ReportCommitCostEstimationRequest(UIDTransactionTagMap<TransactionCommitCostEstimation> ssTrTagCommitCost)
-	  : ssTrTagCommitCost(ssTrTagCommitCost) {}
+	explicit ReportCommitCostEstimationRequest(
+	    UIDTransactionTagMap<TransactionCommitCostEstimation>&& ssTrTagCommitCost)
+	  : ssTrTagCommitCost(std::move(ssTrTagCommitCost)) {}
 
 	template <class Ar>
 	void serialize(Ar& ar) {


### PR DESCRIPTION
Previously, there was a short gap between when commit costs were reported to ratekeeper and when these costs were cleared. During this gap, commit costs were not recorded. This PR fixes this issue, and only removes some unnecessary copies.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
