### PR TITLE
Reusing existing physical shard for data movement as much as possible

### DIFF
--- a/fdbserver/include/fdbserver/DataDistribution.actor.h
+++ b/fdbserver/include/fdbserver/DataDistribution.actor.h
@@ -270,16 +270,18 @@ public:
 		PhysicalShardCreationTime whenCreated; // when this physical shard is created (never changed)
 	};
 
-	// Two-step team selection
-	// Usage: getting primary dest team and remote dest team in dataDistributionRelocator()
-	// The overall process has two steps:
-	// Step 1: get a physical shard id given the input primary team
-	// Return a new physical shard id if the input primary team is new or the team has no available physical shard
-	// checkPhysicalShardAvailable() defines whether a physical shard is available
-	uint64_t determinePhysicalShardIDGivenPrimaryTeam(ShardsAffectedByTeamFailure::Team primaryTeam,
-	                                                  StorageMetrics const& metrics,
-	                                                  bool forceToUseNewPhysicalShard,
-	                                                  uint64_t debugID);
+	// Generate a random physical shard ID, which is not UID().first() nor anonymousShardId.first()
+	uint64_t generateNewPhysicalShardID(uint64_t debugID);
+
+	// If the input team has any available physical shard, return an available physical shard from the input team and
+	// not in `excludedPhysicalShards`. This method is used for two-step team selection The overall process has two
+	// steps: Step 1: get a physical shard id given the input primary team Return a new physical shard id if the input
+	// primary team is new or the team has no available physical shard checkPhysicalShardAvailable() defines whether a
+	// physical shard is available
+	Optional<uint64_t> trySelectAvailablePhysicalShardFor(ShardsAffectedByTeamFailure::Team team,
+	                                                      StorageMetrics const& metrics,
+	                                                      const std::unordered_set<uint64_t>& excludedPhysicalShards,
+	                                                      uint64_t debugID);
 
 	// Step 2: get a remote team which has the input physical shard
 	// Return empty if no such remote team
@@ -345,17 +347,9 @@ private:
 	// Note that if the physical shard only contains the keyRange, always return FALSE
 	InOverSizePhysicalShard isInOverSizePhysicalShard(KeyRange keyRange);
 
-	// Generate a random physical shard ID, which is not UID().first() nor anonymousShardId.first()
-	uint64_t generateNewPhysicalShardID(uint64_t debugID);
-
 	// Check whether the input physical shard is available
 	// A physical shard is available if the current metric + moveInMetrics <= a threshold
 	PhysicalShardAvailable checkPhysicalShardAvailable(uint64_t physicalShardID, StorageMetrics const& moveInMetrics);
-
-	// If the input team has any available physical shard, return an available physical shard of the input team
-	Optional<uint64_t> trySelectAvailablePhysicalShardFor(ShardsAffectedByTeamFailure::Team team,
-	                                                      StorageMetrics const& metrics,
-	                                                      uint64_t debugID);
 
 	// Reduce the metics of input physical shard by the input metrics
 	void reduceMetricsForMoveOut(uint64_t physicalShardID, StorageMetrics const& metrics);


### PR DESCRIPTION
The goal is to reduce new physical shard creation and reuse existing physical shards as much as possible.

Before, every time when the first attempt to find destination physical shard fails, it tries to create new physical shard. This is not ideal since there may be other physical shard candidates that we can move data to.

This PR change the behavior to retry reusing other existing physical shard, until a new shard is required to finish the move (e.g., there is no available physical shard in the selected dst team, or we have tried enough number of times).

Before this PR, in a cluster testing, there can be hundreds of physical shards in a SS. After this PR, it can be reduced to 20s.

before
<img width="1266" alt="Screen Shot 2022-11-15 at 8 22 59 PM" src="https://user-images.githubusercontent.com/9200652/202083450-e69c4c49-af47-4227-b58a-e768ecd43779.png">

after
<img width="1270" alt="Screen Shot 2022-11-15 at 8 23 03 PM" src="https://user-images.githubusercontent.com/9200652/202083464-4204493e-ec9c-4175-be90-d4e878ce5334.png">


20221116-041547-zhewu_8840-d70448ea07bcee73

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
