### PR TITLE
Fix TupleCodec with std::pair

### DIFF
--- a/fdbclient/FileBackupAgent.actor.cpp
+++ b/fdbclient/FileBackupAgent.actor.cpp
@@ -6658,3 +6658,11 @@ void simulateBlobFailure() {
 		}
 	}
 }
+
+TEST_CASE("/FileBackupAgent/TupleCodecPair") {
+	std::pair<KeyRange, Version> src(KeyRangeRef("begin"_sr, "end"_sr), Version(100));
+	Standalone<StringRef> bytes = TupleCodec<std::pair<KeyRange, Version>>::pack(src);
+	auto dest = TupleCodec<std::pair<KeyRange, Version>>::unpack(bytes);
+	ASSERT(src == dest);
+	return Void();
+}

--- a/fdbclient/include/fdbclient/KeyBackedTypes.h
+++ b/fdbclient/include/fdbclient/KeyBackedTypes.h
@@ -109,14 +109,12 @@ inline std::string TupleCodec<std::string>::unpack(Standalone<StringRef> const& 
 template <typename First, typename Second>
 struct TupleCodec<std::pair<First, Second>> {
 	static Standalone<StringRef> pack(typename std::pair<First, Second> const& val) {
-		// Packing a concatenated tuple is the same as concatenating two packed tuples
-		return TupleCodec<First>::pack(val.first).withSuffix(TupleCodec<Second>::pack(val.second));
+		return Tuple::makeTuple(TupleCodec<First>::pack(val.first), TupleCodec<Second>::pack(val.second)).pack();
 	}
 	static std::pair<First, Second> unpack(Standalone<StringRef> const& val) {
 		Tuple t = Tuple::unpack(val);
 		ASSERT(t.size() == 2);
-		return { TupleCodec<First>::unpack(t.subTupleRawString(0)),
-			     TupleCodec<Second>::unpack(t.subTupleRawString(1)) };
+		return { TupleCodec<First>::unpack(t.getString(0)), TupleCodec<Second>::unpack(t.getString(1)) };
 	}
 };
 


### PR DESCRIPTION
This PR is to fix a bug with TupleCodec<std::pair>. Before the fix, the unit test fails as the following:

Testing /FileBackupAgent/TupleCodecPair
Assertion t.size() == 2 failed @ /Users/huliu/fdb_repos/foundationdb/fdbclient/include/fdbclient/KeyBackedTypes.h 117:

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
