### PR TITLE
Disable all failure injection workloads for special key space correctness workload

### DIFF
--- a/fdbserver/workloads/SpecialKeySpaceCorrectness.actor.cpp
+++ b/fdbserver/workloads/SpecialKeySpaceCorrectness.actor.cpp
@@ -70,14 +70,12 @@ struct SpecialKeySpaceCorrectnessWorkload : TestWorkload {
 	double getCheckTimeout() const override { return std::numeric_limits<double>::max(); }
 
 	void disableFailureInjectionWorkloads(std::set<std::string>& out) const override {
-		out.insert("RandomMoveKeys");
-
-		// Rollback interferes with the
-		// \xff\xff/worker_interfaces test, since it can
-		// trigger a cluster recvoery, causing the worker
-		// interface for a machine to be updated in the middle
-		// of the test.
-		out.insert("RollbackWorkload");
+		// Failure injection workloads like Rollback, Attrition and so on are interfering with the test.
+		// In particular, the test aims to test special keys' functions on monitoring and managing the cluster.
+		// It expects the FDB cluster is healthy and not doing unexpected configuration changes.
+		// All changes should come from special keys' operations' outcome.
+		// Consequently, we disable all failure injection workloads in backgroud for this test
+		out.insert("all");
 	}
 
 	Future<Void> _setup(Database cx, SpecialKeySpaceCorrectnessWorkload* self) {


### PR DESCRIPTION
As the `SpecialKeySpaceCorrectnessWorkload` is testing special keys' functions to monitor and change the cluster configurations,
we do not want to see cluster changes like recoveries not caused by the special keys' operations.
Disable all failure injection workloads for it.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
