### PR TITLE
Arena: avoid null-pointer reference in ASSERT

### DIFF
--- a/flow/Arena.cpp
+++ b/flow/Arena.cpp
@@ -297,12 +297,13 @@ void* ArenaBlock::make4kAlignedBuffer(uint32_t size) {
 }
 
 void ArenaBlock::dependOn(Reference<ArenaBlock>& self, ArenaBlock* other) {
-	ASSERT(self->getData() != other->getData());
 	other->addref();
-	if (!self || self->isTiny() || self->unused() < sizeof(ArenaBlockRef))
+	if (!self || self->isTiny() || self->unused() < sizeof(ArenaBlockRef)) {
 		create(SMALL, self)->makeReference(other);
-	else
+	} else {
+		ASSERT(self->getData() != other->getData());
 		self->makeReference(other);
+	}
 }
 
 void* ArenaBlock::dependOn4kAlignedBuffer(Reference<ArenaBlock>& self, uint32_t size) {


### PR DESCRIPTION
Narrow the self-reference ASSERT in ArenaBlock::dependOn to only the cases where we're trying to make a reference from self -> other.

It's allowed for self.getPtr() to be null, in which case we create the ArenaBlock anew and there's no danger of self-reference.

Fixes Issue #8869.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
