### PR TITLE
Fail SnapTestWorkload if taking a snapshot fails

### DIFF
--- a/fdbserver/workloads/SnapTest.actor.cpp
+++ b/fdbserver/workloads/SnapTest.actor.cpp
@@ -105,8 +105,9 @@ public: // variables
 	UID snapUID; // UID used for snap name
 	std::string restartInfoLocation; // file location to store the snap restore info
 	int maxRetryCntToRetrieveMessage; // number of retires to do trackLatest
-	bool skipCheck; // disable check if the exec fails
+	bool skipCheck = false; // disable check if the exec fails
 	int retryLimit; // -1 if no limit
+	bool snapSucceeded = false; // When taking snapshot, tracks snapshot success
 
 public: // ctor & dtor
 	SnapTestWorkload(WorkloadContext const& wcx)
@@ -119,7 +120,6 @@ public: // ctor & dtor
 		maxSnapDelay = getOption(options, "maxSnapDelay"_sr, 25.0);
 		testID = getOption(options, "testID"_sr, 0);
 		restartInfoLocation = getOption(options, "restartInfoLocation"_sr, "simfdb/restartInfo.ini"_sr).toString();
-		skipCheck = false;
 		retryLimit = getOption(options, "retryLimit"_sr, 5);
 		g_simulator->allowLogSetKills = false;
 	}
@@ -137,41 +137,15 @@ public: // workload functions
 		return Void();
 	}
 
-	ACTOR Future<bool> _check(Database cx, SnapTestWorkload* self) {
-		if (self->skipCheck) {
-			TraceEvent(SevWarnAlways, "SnapCheckIgnored").log();
-			return true;
-		}
-		state Transaction tr(cx);
-		// read the key SnapFailedTLog.$UID
-		loop {
-			try {
-				Standalone<StringRef> keyStr =
-				    "\xff/SnapTestFailStatus/"_sr.withSuffix(StringRef(self->snapUID.toString()));
-				TraceEvent("TestKeyStr").detail("Value", keyStr);
-				tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
-				Optional<Value> val = wait(tr.get(keyStr));
-				if (val.present()) {
-					break;
-				}
-				// wait for the key to be written out by TLogs
-				wait(delay(0.1));
-			} catch (Error& e) {
-				wait(tr.onError(e));
-			}
-		}
-		return true;
-	}
-
 	Future<bool> check(Database const& cx) override {
-		TraceEvent("SnapTestWorkloadCheck").detail("ClientID", clientId);
+		TraceEvent("SnapTestWorkloadCheck").detail("ClientID", clientId).detail("TestID", testID);
 		if (clientId != 0) {
 			return true;
 		}
-		if (this->testID != 5 && this->testID != 6) {
-			return true;
+		if (testID == 1) {
+			return snapSucceeded;
 		}
-		return _check(cx, this);
+		return true;
 	}
 
 	void getMetrics(std::vector<PerfMetric>& m) override { TraceEvent("SnapTestWorkloadGetMetrics"); }
@@ -258,7 +232,9 @@ public: // workload functions
 			ini.SetValue("RESTORE", "BackupFailed", format("%d", snapFailed).c_str());
 			ini.SaveFile(self->restartInfoLocation.c_str());
 			// write the snapUID to a file
-			TraceEvent("SnapshotCreateStatus").detail("Status", !snapFailed ? "Success" : "Failure");
+			auto const severity = snapFailed ? SevError : SevInfo;
+			TraceEvent(severity, "SnapshotCreateStatus").detail("Status", !snapFailed ? "Success" : "Failure");
+			self->snapSucceeded = !snapFailed;
 		} else if (self->testID == 2) {
 			// create odd keys after the snapshot
 			wait(self->_create_keys(cx, "snapKey", false /*even*/));


### PR DESCRIPTION
This PR ensures that if a `SnapTestWorkload` is meant to take a snapshot (i.e. `testID == 1`), and the snapshot fails, then the workload will fail. Without this change, the restore would attempt to run, and fail with more confusing error messages, because there's no valid snapshot to restore.

Also, some deprecated code is removed from `SnapTestWorkload`.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
