### PR TITLE
Temporarily disable the default tenant in DifferentClustersSameRV

### DIFF
--- a/tests/slow/DifferentClustersSameRV.toml
+++ b/tests/slow/DifferentClustersSameRV.toml
@@ -1,5 +1,7 @@
 [configuration]
 extraDatabaseMode = 'Single'
+# Temporarily disable default tenants in this test pending tenant implementation changes
+allowDefaultTenant = false
 
 [[test]]
 testTitle = 'DifferentClustersSameRV'


### PR DESCRIPTION
Temporarily disable the default tenant in different clusters same RV until some tenant related changes are made.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
