### PR TITLE
Fix out-of-bounds access in SkewedReadWrite test workload

### DIFF
--- a/fdbserver/workloads/SkewedReadWrite.actor.cpp
+++ b/fdbserver/workloads/SkewedReadWrite.actor.cpp
@@ -62,17 +62,6 @@ struct SkewedReadWriteWorkload : ReadWriteCommon {
 
 	Future<Void> start(Database const& cx) override { return _start(cx, this); }
 
-	void debugPrintServerShards() const {
-		std::cout << std::hex;
-		for (auto it : this->serverShards) {
-			std::cout << serverInterfaces.at(it.first).address().toString() << ": [";
-			for (auto p : it.second) {
-				std::cout << "[" << p.first << "," << p.second << "], ";
-			}
-			std::cout << "] \n";
-		}
-	}
-
 	// for each boundary except the last one in boundaries, found the first existed key generated from keyForIndex as
 	// beginIdx, found the last existed key generated from keyForIndex the endIdx.
 	ACTOR static Future<IndexRangeVec> convertKeyBoundaryToIndexShard(Database cx,
@@ -170,9 +159,6 @@ struct SkewedReadWriteWorkload : ReadWriteCommon {
 		for (auto it : serverShards) {
 			self->serverShards.emplace_back(it);
 		}
-		//		if (self->clientId == 0) {
-		//			self->debugPrintServerShards();
-		//		}
 		return Void();
 	}
 
@@ -225,14 +211,7 @@ struct SkewedReadWriteWorkload : ReadWriteCommon {
 	// calculate hot server count
 	void setHotServers() {
 		hotServerCount = ceil(hotServerFraction * serverShards.size());
-		std::cout << "Choose " << hotServerCount << "/" << serverShards.size() << "/" << serverInterfaces.size()
-		          << " hot servers: [";
-		int begin = currentHotRound * hotServerCount;
-		for (int i = 0; i < hotServerCount; ++i) {
-			int idx = (begin + i) % serverShards.size();
-			std::cout << serverInterfaces.at(serverShards[idx].first).address().toString() << ",";
-		}
-		std::cout << "]\n";
+		std::cout << "Choose " << hotServerCount << "/" << serverShards.size() << "/" << serverInterfaces.size();
 	}
 
 	int64_t getRandomKeyFromHotServer(bool hotServerRead = true) {


### PR DESCRIPTION
Passed 50k runs of tests/rare/ReadSkewReadWrite.toml.

Fixes https://github.com/apple/foundationdb/issues/8891

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
