### PR TITLE
Allow the binding tester API test to generate reads and writes on tenant objects

### DIFF
--- a/bindings/bindingtester/tests/api.py
+++ b/bindings/bindingtester/tests/api.py
@@ -154,6 +154,8 @@ class ApiTest(Test):
         snapshot_reads = [x + '_SNAPSHOT' for x in reads]
         database_reads = [x + '_DATABASE' for x in reads]
         database_mutations = [x + '_DATABASE' for x in mutations]
+        tenant_reads = [x + '_TENANT' for x in reads]
+        tenant_mutations = [x + '_TENANT' for x in mutations]
         mutations += ['VERSIONSTAMP']
         versions = ['GET_READ_VERSION', 'SET_READ_VERSION', 'GET_COMMITTED_VERSION']
         snapshot_versions = ['GET_READ_VERSION_SNAPSHOT']
@@ -183,6 +185,8 @@ class ApiTest(Test):
 
         if not args.no_tenants:
             op_choices += tenants
+            op_choices += tenant_reads
+            op_choices += tenant_mutations
 
         idempotent_atomic_ops = ['BIT_AND', 'BIT_OR', 'MAX', 'MIN', 'BYTE_MIN', 'BYTE_MAX']
         atomic_ops = idempotent_atomic_ops + ['ADD', 'BIT_XOR', 'APPEND_IF_FITS']


### PR DESCRIPTION
The API tester was intended to generate operations with the _TENANT suffix, but it was not doing so.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
