### PR TITLE
Accept open-source FDB versions as valid versions in Snowflake releases

### DIFF
--- a/flow/ProtocolVersion.h.cmake
+++ b/flow/ProtocolVersion.h.cmake
@@ -36,10 +36,6 @@ constexpr uint64_t minCompatibleProtocolVersionValue = @FDB_PV_MIN_COMPATIBLE_VE
 // Used only for testing upgrades to the future version
 constexpr uint64_t futureProtocolVersionValue = @FDB_PV_FUTURE_VERSION@;
 
-// Snowflake specific incompatible window (lastValid, invalidRange, firstValid).
-constexpr uint64_t minIncompatibleSFCWindow = 0x0FDB00B0710A0000LL;
-constexpr uint64_t maxIncompatibleSFCWindow = 0x0FDB00C071200000LL;
-
 // The first check second expression version doesn't need to change because it's just for earlier protocol versions.
 #define PROTOCOL_VERSION_FEATURE(v, x)                                                                                 \
 	static_assert((v & @FDB_PV_LSB_MASK@) == 0 || v < 0x0FDB00B071000000LL, "Unexpected feature protocol version");             \
@@ -79,8 +75,7 @@ public:
 	}
 
 	constexpr bool isValid() const {
-		return (version() >= minValidProtocolVersion &&
-				(version() <= minIncompatibleSFCWindow || version() >= maxIncompatibleSFCWindow));
+		return version() >= minValidProtocolVersion;
 	}
 
 	constexpr bool isInvalid() const { return version() == invalidProtocolVersion; }


### PR DESCRIPTION
Enable Multi-Version Client configurations with external clients of both open-source and Snowflake releases, enabling application to communicate with both kinds of clusters.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
