### PR TITLE
Report the most logged event in trace when a simulation run fails for exceeding the trace lines limit

### DIFF
--- a/flow/include/flow/Trace.h
+++ b/flow/include/flow/Trace.h
@@ -170,11 +170,13 @@ public:
 
 private:
 	struct EventInfo {
+		const char* name;
 		TraceEventFields fields;
 		EventInfo(double time, const char* name, uint64_t id, const char* location);
 	};
 
 	struct AttachInfo {
+		const char* name;
 		TraceEventFields fields;
 		AttachInfo(double time, const char* name, uint64_t id, uint64_t to);
 	};


### PR DESCRIPTION
This allows us to easily view the most logged trace event when triaging output from test harness.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
