### PR TITLE
Parameter to Build with a Protocol Version Compatible with Snowflake Releases

### DIFF
--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -27,6 +27,7 @@ env_set(PROFILE_INSTR_GENERATE OFF BOOL "If set, build FDB as an instrumentation
 env_set(PROFILE_INSTR_USE "" STRING "If set, build FDB with profile")
 env_set(FULL_DEBUG_SYMBOLS OFF BOOL "Generate full debug symbols")
 env_set(ENABLE_LONG_RUNNING_TESTS OFF BOOL "Add a long running tests package")
+env_set(COMPATIBLE_WITH_SNOWFLAKE_RELEASES OFF BOOL "Build binaries compatible with Snowflake releases")
 
 set(USE_SANITIZER OFF)
 if(USE_ASAN OR USE_VALGRIND OR USE_MSAN OR USE_TSAN OR USE_UBSAN)

--- a/flow/ProtocolVersions.cmake
+++ b/flow/ProtocolVersions.cmake
@@ -8,11 +8,20 @@
 # used and should not be changed from 0.
 #                                                          xyzdev
 #                                                          vvvv
+
+if (COMPATIBLE_WITH_SNOWFLAKE_RELEASES)
+set(FDB_PV_DEFAULT_VERSION                      "0x0FDB00C072000000LL")
+set(FDB_PV_FUTURE_VERSION                       "0x0FDB00C073000000LL")
+set(FDB_PV_MIN_INVALID_VERSION                  "0x0FDB00C074000000LL")
+set(FDB_PV_LEFT_MOST_CHECK                      "0x0FDB00C100000000LL")
+else()
 set(FDB_PV_DEFAULT_VERSION                      "0x0FDB00B072000000LL")
 set(FDB_PV_FUTURE_VERSION                       "0x0FDB00B073000000LL")
-set(FDB_PV_MIN_COMPATIBLE_VERSION               "0x0FDB00B071000000LL")
 set(FDB_PV_MIN_INVALID_VERSION                  "0x0FDB00B074000000LL")
 set(FDB_PV_LEFT_MOST_CHECK                      "0x0FDB00B100000000LL")
+endif()
+
+set(FDB_PV_MIN_COMPATIBLE_VERSION               "0x0FDB00B071000000LL")
 set(FDB_PV_LSB_MASK                             "0xF0FFFFLL")
 
 # The 5th digit from right is dev version, for example, 2 in 0x0FDB00B061020000LL;

--- a/tests/TestRunner/upgrade_test.py
+++ b/tests/TestRunner/upgrade_test.py
@@ -33,7 +33,11 @@ def version_from_str(ver_str):
 
 def api_version_from_str(ver_str):
     ver_tuple = version_from_str(ver_str)
-    return ver_tuple[0] * 100 + ver_tuple[1] * 10
+    if ver_tuple[0] > 70:
+        # Latest open-source API Version supported by the Snowflake release
+        return ver_tuple[0] * 10
+    else:
+        return ver_tuple[0] * 100 + ver_tuple[1] * 10
 
 
 def version_before(ver_str1, ver_str2):


### PR DESCRIPTION
Snowflake uses protocol versions that are incompatible with open-source releases in order to avoid accidental mistakes of configuring deployments with binaries of incompatible releases. However, since main is being used a the development branch both for open-source and Snowflake releases, we need a way to test Multi-Version-Client built from main in combination with existing Snowflake releases. 

The PR introduces a CMake option COMPATIBLE_WITH_SNOWFLAKE_RELEASES. When this option is set, the build produces binaries with protocol versions that are compatible with Snowflake releases. 

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
