### PR TITLE
Disable log anti quorum for snapshot tests

### DIFF
--- a/fdbserver/workloads/SnapTest.actor.cpp
+++ b/fdbserver/workloads/SnapTest.actor.cpp
@@ -210,10 +210,6 @@ public: // workload functions
 					wait(status);
 					break;
 				} catch (Error& e) {
-					if (e.code() == error_code_snap_log_anti_quorum_unsupported) {
-						snapFailed = true;
-						break;
-					}
 					TraceEvent("SnapCreateError").error(e);
 					++retry;
 					// snap v2 can fail for many reasons, so retry for 5 times and then fail it
@@ -301,8 +297,7 @@ public: // workload functions
 					wait(status);
 					break;
 				} catch (Error& e) {
-					if (e.code() == error_code_snap_not_fully_recovered_unsupported ||
-					    e.code() == error_code_snap_log_anti_quorum_unsupported) {
+					if (e.code() == error_code_snap_not_fully_recovered_unsupported) {
 						snapFailed = true;
 						break;
 					}

--- a/tests/restarting/from_7.1.0/SnapCycleRestart-1.txt
+++ b/tests/restarting/from_7.1.0/SnapCycleRestart-1.txt
@@ -1,4 +1,5 @@
 storageEngineExcludeTypes=4,5
+logAntiQuorum=0
 
 ;Take snap and do cycle test
 testTitle=SnapCyclePre

--- a/tests/restarting/from_7.1.0/SnapTestAttrition-1.txt
+++ b/tests/restarting/from_7.1.0/SnapTestAttrition-1.txt
@@ -1,4 +1,5 @@
 storageEngineExcludeTypes=4,5
+logAntiQuorum=0
 
 ;write 1000 Keys ending with even numbers
 testTitle=SnapTestPre

--- a/tests/restarting/from_7.1.0/SnapTestRestart-1.txt
+++ b/tests/restarting/from_7.1.0/SnapTestRestart-1.txt
@@ -1,4 +1,5 @@
 storageEngineExcludeTypes=4,5
+logAntiQuorum=0
 
 ;write 1000 Keys ending with even numbers
 testTitle=SnapTestPre

--- a/tests/restarting/from_7.1.0/SnapTestSimpleRestart-1.txt
+++ b/tests/restarting/from_7.1.0/SnapTestSimpleRestart-1.txt
@@ -1,4 +1,5 @@
 storageEngineExcludeTypes=4,5
+logAntiQuorum=0
 
 ;write 1000 Keys ending with even number
 testTitle=SnapSimplePre


### PR DESCRIPTION
Snapshots are already not supported when `logAntiQuorum > 0`, so we should mandate that `logAntiQuorum = 0` when running snapshot tests, to avoid test failures.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
