### PR TITLE
Fix the bug of variable int32 overflow.

### DIFF
--- a/fdbrpc/HTTP.actor.cpp
+++ b/fdbrpc/HTTP.actor.cpp
@@ -243,7 +243,7 @@ ACTOR Future<Void> read_http_response(Reference<HTTP::Response> r, Reference<ICo
 
 	auto i = r->headers.find("Content-Length");
 	if (i != r->headers.end())
-		r->contentLen = atoi(i->second.c_str());
+		r->contentLen = strtoll(i->second.c_str());
 	else
 		r->contentLen = -1; // Content length unknown
 
@@ -481,7 +481,7 @@ ACTOR Future<Reference<HTTP::Response>> doRequest(Reference<IConnection> conn,
 		}
 
 		if (FLOW_KNOBS->HTTP_VERBOSE_LEVEL > 0) {
-			printf("[%s] HTTP %scode=%d early=%d, time=%fs %s %s contentLen=%d [%d out, response content len %d]\n",
+			printf("[%s] HTTP %scode=%d early=%d, time=%fs %s %s contentLen=%d [%d out, response content len %lld]\n",
 			       conn->getDebugID().toString().c_str(),
 			       (err.present() ? format("*ERROR*=%s ", err.get().name()).c_str() : ""),
 			       r->code,
@@ -491,7 +491,7 @@ ACTOR Future<Reference<HTTP::Response>> doRequest(Reference<IConnection> conn,
 			       resource.c_str(),
 			       contentLen,
 			       total_sent,
-			       (int)r->contentLen);
+			       r->contentLen);
 		}
 		if (FLOW_KNOBS->HTTP_VERBOSE_LEVEL > 2) {
 			printf("[%s] HTTP RESPONSE:  %s %s\n%s\n",

--- a/fdbrpc/include/fdbrpc/AsyncFileReadAhead.actor.h
+++ b/fdbrpc/include/fdbrpc/AsyncFileReadAhead.actor.h
@@ -102,7 +102,7 @@ public:
 			// If not found, start the read.
 			if (i == f->m_blocks.end() || (i->second.isValid() && i->second.isError())) {
 				// printf("starting read of %s block %d\n", f->getFilename().c_str(), blockNum);
-				fblock = readBlock(f.getPtr(), f->m_block_size, f->m_block_size * blockNum);
+				fblock = readBlock(f.getPtr(), f->m_block_size, (int64_t)f->m_block_size * blockNum);
 				f->m_blocks[blockNum] = fblock;
 			} else
 				fblock = i->second;
@@ -121,7 +121,7 @@ public:
 			// Calculate the block-relative read range.  It's a given that the offset / length range touches this block
 			// so readStart will never be greater than blocksize (though it could be past the actual end of a short
 			// block).
-			int64_t blockStart = blockNum * f->m_block_size;
+			int64_t blockStart = (int64_t)blockNum * f->m_block_size;
 			int64_t readStart = std::max<int64_t>(0, offset - blockStart);
 			int64_t readEnd = std::min<int64_t>(f->m_block_size, offset + length - blockStart);
 			int rlen = readEnd - readStart;


### PR DESCRIPTION
1.the content length from http response transformed using 'atoi' would rise int32 overflow.
2.the offset's aligning would rise int32 overflow.