### PR TITLE
remove javadoc errors/warnings -- this needs to be cleaned up.

### DIFF
--- a/bindings/java/src/main/com/apple/foundationdb/Database.java
+++ b/bindings/java/src/main/com/apple/foundationdb/Database.java
@@ -162,11 +162,11 @@ public interface Database extends AutoCloseable, TransactionContext {
 	double getMainThreadBusyness();
 
 	/**
-	 * Runs {@link #purgeBlobGranules(Function)} on the default executor.
+	 * Runs {@link #purgeBlobGranules(byte[] beginKey, byte[] endKey, boolean force)} on the default executor.
 	 *
 	 * @param beginKey start of the key range
 	 * @param endKey end of the key range
-	 * @param force if true delete all data, if not keep data >= purgeVersion
+	 * @param force if true delete all data, if not keep data &gt;= purgeVersion
 	 *
 	 * @return the key to watch for purge complete
 	 */
@@ -175,12 +175,12 @@ public interface Database extends AutoCloseable, TransactionContext {
 	}
 
 	/**
-	 * Runs {@link #purgeBlobGranules(Function)} on the default executor.
+	 * Runs {@link #purgeBlobGranules(byte[] beginKey, byte[] endKey, long purgeVersion, boolean force)} on the default executor.
 	 *
 	 * @param beginKey start of the key range
 	 * @param endKey end of the key range
 	 * @param purgeVersion version to purge at
-	 * @param force if true delete all data, if not keep data >= purgeVersion
+	 * @param force if true delete all data, if not keep data &gt;= purgeVersion
 	 *
 	 * @return the key to watch for purge complete
 	 */
@@ -194,7 +194,7 @@ public interface Database extends AutoCloseable, TransactionContext {
 	 * @param beginKey start of the key range
 	 * @param endKey end of the key range
 	 * @param purgeVersion version to purge at
-	 * @param force if true delete all data, if not keep data >= purgeVersion
+	 * @param force if true delete all data, if not keep data &gt;= purgeVersion
 	 * @param e the {@link Executor} to use for asynchronous callbacks
 
 	 * @return the key to watch for purge complete
@@ -203,9 +203,11 @@ public interface Database extends AutoCloseable, TransactionContext {
 
 
 	/**
-	 * Runs {@link #waitPurgeGranulesComplete(Function)} on the default executor.
+	 * Runs {@link #waitPurgeGranulesComplete(byte[] purgeKey)} on the default executor.
 	 *
 	 * @param purgeKey key to watch
+	 *
+	 * @return void
 	 */
 	default CompletableFuture<Void> waitPurgeGranulesComplete(byte[] purgeKey) {
 		return waitPurgeGranulesComplete(purgeKey, getExecutor());
@@ -216,11 +218,13 @@ public interface Database extends AutoCloseable, TransactionContext {
 	 *
 	 * @param purgeKey key to watch
 	 * @param e the {@link Executor} to use for asynchronous callbacks
+	 *
+	 * @return void
 	 */
 	CompletableFuture<Void> waitPurgeGranulesComplete(byte[] purgeKey, Executor e);
 
 	/**
-	 * Runs {@link #blobbifyRange(Function)} on the default executor.
+	 * Runs {@link #blobbifyRange(byte[] beginKey, byte[] endKey)} on the default executor.
 	 *
 	 * @param beginKey start of the key range
 	 * @param endKey end of the key range
@@ -243,7 +247,7 @@ public interface Database extends AutoCloseable, TransactionContext {
 	CompletableFuture<Boolean> blobbifyRange(byte[] beginKey, byte[] endKey, Executor e);
 
 	/**
-	 * Runs {@link #unblobbifyRange(Function)} on the default executor.
+	 * Runs {@link #unblobbifyRange(byte[] beginKey, byte[] endKey)} on the default executor.
 	 *
 	 * @param beginKey start of the key range
 	 * @param endKey end of the key range
@@ -266,12 +270,11 @@ public interface Database extends AutoCloseable, TransactionContext {
 	CompletableFuture<Boolean> unblobbifyRange(byte[] beginKey, byte[] endKey, Executor e);
 
 	/**
-	 * Runs {@link #listBlobbifiedRanges(Function)} on the default executor.
+	 * Runs {@link #listBlobbifiedRanges(byte[] beginKey, byte[] endKey, int rangeLimit)} on the default executor.
 	 *
 	 * @param beginKey start of the key range
 	 * @param endKey end of the key range
 	 * @param rangeLimit batch size
-	 * @param e the {@link Executor} to use for asynchronous callbacks
 
 	 * @return a future with the list of blobbified ranges: [lastLessThan(beginKey), firstGreaterThanOrEqual(endKey)]
 	 */
@@ -292,7 +295,7 @@ public interface Database extends AutoCloseable, TransactionContext {
 	 CompletableFuture<KeyRangeArrayResult> listBlobbifiedRanges(byte[] beginKey, byte[] endKey, int rangeLimit, Executor e);
 
 	/**
-	 * Runs {@link #verifyBlobRange(Function)} on the default executor.
+	 * Runs {@link #verifyBlobRange(byte[] beginKey, byte[] endKey)} on the default executor.
 	 *
 	 * @param beginKey start of the key range
 	 * @param endKey end of the key range
@@ -304,7 +307,7 @@ public interface Database extends AutoCloseable, TransactionContext {
 	}
 
 	/**
-	 * Runs {@link #verifyBlobRange(Function)} on the default executor.
+	 * Runs {@link #verifyBlobRange(byte[] beginKey, byte[] endKey, long version)} on the default executor.
 	 *
 	 * @param beginKey start of the key range
 	 * @param endKey end of the key range
@@ -322,6 +325,7 @@ public interface Database extends AutoCloseable, TransactionContext {
 	 * @param beginKey start of the key range
 	 * @param endKey end of the key range
 	 * @param version version to read at
+	 * @param e the {@link Executor} to use for asynchronous callbacks
 	 *
 	 * @return a future with the version of the last blob granule.
 	 */

--- a/bindings/java/src/main/com/apple/foundationdb/JNIUtil.java
+++ b/bindings/java/src/main/com/apple/foundationdb/JNIUtil.java
@@ -115,6 +115,7 @@ public class JNIUtil {
 	 * @param libName the name of the library to attempt to export. This name should be
 	 *  undecorated with file extensions and, in the case of *nix, "lib" prefixes.
 	 * @return the exported temporary file
+	 * @throws IOException because {@link File}
 	 */
 	public static File exportLibrary(String libName) throws IOException {
 		OS os = getRunningOS();
@@ -143,7 +144,7 @@ public class JNIUtil {
 	 * @param name an optional descriptive name to include in the temporary file's path
 	 *
 	 * @return the absolute path to the exported file
-	 * @throws IOException
+	 * @throws IOException because {@link File}
 	 */
 	private static File exportResource(String path, String name) throws IOException {
 		InputStream resource = JNIUtil.class.getResourceAsStream(path);

--- a/bindings/java/src/main/com/apple/foundationdb/ReadTransaction.java
+++ b/bindings/java/src/main/com/apple/foundationdb/ReadTransaction.java
@@ -440,6 +440,12 @@ public interface ReadTransaction extends ReadTransactionContext {
 	 *  <i>first</i> keys in the range. Pass {@link #ROW_LIMIT_UNLIMITED} if this query
 	 *  should not limit the number of results. If {@code reverse} is {@code true} rows
 	 *  will be limited starting at the end of the range.
+	 * @param matchIndex the mode to return index entries based on whether their
+	 *  corresponding records are present, examples:
+	 *     {@link FDBTransaction#MATCH_INDEX_ALL}
+	 *     {@link FDBTransaction#MATCH_INDEX_NONE}
+	 *     {@link FDBTransaction#MATCH_INDEX_MATCHED_ONLY}
+	 *     {@link FDBTransaction#MATCH_INDEX_UNMATCHED_ONLY}
 	 * @param reverse return results starting at the end of the range in reverse order.
 	 *  Reading ranges in reverse is supported natively by the database and should
 	 *  have minimal extra cost.
@@ -498,6 +504,7 @@ public interface ReadTransaction extends ReadTransactionContext {
 	 *
 	 * @param begin the beginning of the range (inclusive)
 	 * @param end the end of the range (exclusive)
+	 * @param chunkSize -- undocumented
 	 *
 	 * @return a handle to access the results of the asynchronous call
 	 */
@@ -508,6 +515,7 @@ public interface ReadTransaction extends ReadTransactionContext {
 	 * Note: the returned split points contain the start key and end key of the given range.
 	 *
 	 * @param range the range of the keys
+	 * @param chunkSize -- undocumented
 	 *
 	 * @return a handle to access the results of the asynchronous call
 	 */
@@ -519,6 +527,7 @@ public interface ReadTransaction extends ReadTransactionContext {
 	 *
 	 * @param begin beginning of the range (inclusive)
 	 * @param end end of the range (exclusive)
+	 * @param rowLimit the limit on the number of returned rows
 
 	 * @return list of blob granules in the given range. May not be all.
 	 */

--- a/bindings/java/src/main/com/apple/foundationdb/Tenant.java
+++ b/bindings/java/src/main/com/apple/foundationdb/Tenant.java
@@ -249,11 +249,11 @@ public interface Tenant extends AutoCloseable, TransactionContext {
 
 
 	/**
-	 * Runs {@link #purgeBlobGranules(Function)} on the default executor.
+	 * Runs {@link #purgeBlobGranules(byte[] beginKey, byte[] endKey, boolean force)} on the default executor.
 	 *
 	 * @param beginKey start of the key range
 	 * @param endKey end of the key range
-	 * @param force if true delete all data, if not keep data >= purgeVersion
+	 * @param force if true delete all data, if not keep data &gt;= purgeVersion
 	 *
 	 * @return the key to watch for purge complete
 	 */
@@ -262,12 +262,12 @@ public interface Tenant extends AutoCloseable, TransactionContext {
 	}
 
 	/**
-	 * Runs {@link #purgeBlobGranules(Function)} on the default executor.
+	 * Runs {@link #purgeBlobGranules(byte[] beginKey, byte[] endKey, long purgeVersion, boolean force)} on the default executor.
 	 *
 	 * @param beginKey start of the key range
 	 * @param endKey end of the key range
 	 * @param purgeVersion version to purge at
-	 * @param force if true delete all data, if not keep data >= purgeVersion
+	 * @param force if true delete all data, if not keep data &gt;= purgeVersion
 	 *
 	 * @return the key to watch for purge complete
 	 */
@@ -281,7 +281,7 @@ public interface Tenant extends AutoCloseable, TransactionContext {
 	 * @param beginKey start of the key range
 	 * @param endKey end of the key range
 	 * @param purgeVersion version to purge at
-	 * @param force if true delete all data, if not keep data >= purgeVersion
+	 * @param force if true delete all data, if not keep data &gt;= purgeVersion
 	 * @param e the {@link Executor} to use for asynchronous callbacks
 
 	 * @return the key to watch for purge complete
@@ -290,9 +290,11 @@ public interface Tenant extends AutoCloseable, TransactionContext {
 
 
 	/**
-	 * Runs {@link #waitPurgeGranulesComplete(Function)} on the default executor.
+	 * Runs {@link #waitPurgeGranulesComplete(byte[] purgeKey)} on the default executor.
 	 *
 	 * @param purgeKey key to watch
+
+	 * @return void
 	 */
 	default CompletableFuture<Void> waitPurgeGranulesComplete(byte[] purgeKey) {
 		return waitPurgeGranulesComplete(purgeKey, getExecutor());
@@ -303,11 +305,13 @@ public interface Tenant extends AutoCloseable, TransactionContext {
 	 *
 	 * @param purgeKey key to watch
 	 * @param e the {@link Executor} to use for asynchronous callbacks
+
+	 * @return void
 	 */
 	CompletableFuture<Void> waitPurgeGranulesComplete(byte[] purgeKey, Executor e);
 
 	/**
-	 * Runs {@link #blobbifyRange(Function)} on the default executor.
+	 * Runs {@link #blobbifyRange(byte[] beginKey, byte[] endKey)} on the default executor.
 	 *
 	 * @param beginKey start of the key range
 	 * @param endKey end of the key range
@@ -330,7 +334,7 @@ public interface Tenant extends AutoCloseable, TransactionContext {
 	CompletableFuture<Boolean> blobbifyRange(byte[] beginKey, byte[] endKey, Executor e);
 
 	/**
-	 * Runs {@link #unblobbifyRange(Function)} on the default executor.
+	 * Runs {@link #unblobbifyRange(byte[] beginKey, byte[] endKey)} on the default executor.
 	 *
 	 * @param beginKey start of the key range
 	 * @param endKey end of the key range
@@ -353,12 +357,11 @@ public interface Tenant extends AutoCloseable, TransactionContext {
 	CompletableFuture<Boolean> unblobbifyRange(byte[] beginKey, byte[] endKey, Executor e);
 
 	/**
-	 * Runs {@link #listBlobbifiedRanges(Function)} on the default executor.
+	 * Runs {@link #listBlobbifiedRanges(byte[] beginKey, byte[] endKey, int rangeLimit)} on the default executor.
 	 *
 	 * @param beginKey start of the key range
 	 * @param endKey end of the key range
 	 * @param rangeLimit batch size
-	 * @param e the {@link Executor} to use for asynchronous callbacks
 
 	 * @return a future with the list of blobbified ranges: [lastLessThan(beginKey), firstGreaterThanOrEqual(endKey)]
 	 */
@@ -379,7 +382,7 @@ public interface Tenant extends AutoCloseable, TransactionContext {
 	 CompletableFuture<KeyRangeArrayResult> listBlobbifiedRanges(byte[] beginKey, byte[] endKey, int rangeLimit, Executor e);
 
 	/**
-	 * Runs {@link #verifyBlobRange(Function)} on the default executor.
+	 * Runs {@link #verifyBlobRange(byte[] beginKey, byte[] endKey)} on the default executor.
 	 *
 	 * @param beginKey start of the key range
 	 * @param endKey end of the key range
@@ -391,7 +394,7 @@ public interface Tenant extends AutoCloseable, TransactionContext {
 	}
 
 	/**
-	 * Runs {@link #verifyBlobRange(Function)} on the default executor.
+	 * Runs {@link #verifyBlobRange(byte[] beginKey, byte[] endKey, long version)} on the default executor.
 	 *
 	 * @param beginKey start of the key range
 	 * @param endKey end of the key range
@@ -409,6 +412,7 @@ public interface Tenant extends AutoCloseable, TransactionContext {
 	 * @param beginKey start of the key range
 	 * @param endKey end of the key range
 	 * @param version version to read at
+	 * @param e the executor
 	 *
 	 * @return a future with the version of the last blob granule.
 	 */


### PR DESCRIPTION
Malformed javadocs broke the latest release build. This makes the errors/warnings go away, but does not pass really help with meaningful documentation. 

I'd appreciate some help from reviewers to get this fixed up before merging. 


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
