### PR TITLE
Cherrypick Remember disk corruptions and downgrade trace severity if a corruption was injected

### DIFF
--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -1010,9 +1010,7 @@ ACTOR Future<Optional<CoordinatorsResult>> changeQuorumChecker(Transaction* tr,
 
 	choose {
 		when(wait(waitForAll(leaderServers))) {}
-		when(wait(delay(5.0))) {
-			return CoordinatorsResult::COORDINATOR_UNREACHABLE;
-		}
+		when(wait(delay(5.0))) { return CoordinatorsResult::COORDINATOR_UNREACHABLE; }
 	}
 	TraceEvent("ChangeQuorumCheckerSetCoordinatorsKey")
 	    .detail("CurrentCoordinators", old.toString())
@@ -1114,9 +1112,7 @@ ACTOR Future<CoordinatorsResult> changeQuorum(Database cx, Reference<IQuorumChan
 				                                           TaskPriority::CoordinationReply));
 			choose {
 				when(wait(waitForAll(leaderServers))) {}
-				when(wait(delay(5.0))) {
-					return CoordinatorsResult::COORDINATOR_UNREACHABLE;
-				}
+				when(wait(delay(5.0))) { return CoordinatorsResult::COORDINATOR_UNREACHABLE; }
 			}
 
 			tr.set(coordinatorsKey, newClusterConnectionString.toString());

--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -1010,7 +1010,9 @@ ACTOR Future<Optional<CoordinatorsResult>> changeQuorumChecker(Transaction* tr,
 
 	choose {
 		when(wait(waitForAll(leaderServers))) {}
-		when(wait(delay(5.0))) { return CoordinatorsResult::COORDINATOR_UNREACHABLE; }
+		when(wait(delay(5.0))) {
+			return CoordinatorsResult::COORDINATOR_UNREACHABLE;
+		}
 	}
 	TraceEvent("ChangeQuorumCheckerSetCoordinatorsKey")
 	    .detail("CurrentCoordinators", old.toString())
@@ -1112,7 +1114,9 @@ ACTOR Future<CoordinatorsResult> changeQuorum(Database cx, Reference<IQuorumChan
 				                                           TaskPriority::CoordinationReply));
 			choose {
 				when(wait(waitForAll(leaderServers))) {}
-				when(wait(delay(5.0))) { return CoordinatorsResult::COORDINATOR_UNREACHABLE; }
+				when(wait(delay(5.0))) {
+					return CoordinatorsResult::COORDINATOR_UNREACHABLE;
+				}
 			}
 
 			tr.set(coordinatorsKey, newClusterConnectionString.toString());
@@ -2145,6 +2149,9 @@ ACTOR Future<Void> lockDatabase(Reference<ReadYourWritesTransaction> tr, UID id)
 
 ACTOR Future<Void> lockDatabase(Database cx, UID id) {
 	state Transaction tr(cx);
+	UID debugID = deterministicRandom()->randomUniqueID();
+	TraceEvent("LockDatabaseTransaction", debugID).log();
+	tr.debugTransaction(debugID);
 	loop {
 		try {
 			wait(lockDatabase(&tr, id));

--- a/fdbrpc/include/fdbrpc/AsyncFileChaos.h
+++ b/fdbrpc/include/fdbrpc/AsyncFileChaos.h
@@ -25,15 +25,18 @@
 #include "flow/IAsyncFile.h"
 #include "flow/network.h"
 #include "flow/ActorCollection.h"
+#include "fdbrpc/simulator.h"
 
 // template <class AsyncFileType>
 class AsyncFileChaos final : public IAsyncFile, public ReferenceCounted<AsyncFileChaos> {
 private:
 	Reference<IAsyncFile> file;
+	// since we have to read this often, we cache the filename here
+	std::string filename;
 	bool enabled;
 
 public:
-	explicit AsyncFileChaos(Reference<IAsyncFile> file) : file(file) {
+	explicit AsyncFileChaos(Reference<IAsyncFile> file) : file(file), filename(file->getFilename()) {
 		// We only allow chaos events on storage files
 		enabled = (file->getFilename().find("storage-") != std::string::npos);
 	}
@@ -79,6 +82,7 @@ public:
 	Future<Void> write(void const* data, int length, int64_t offset) override {
 		Arena arena;
 		char* pdata = nullptr;
+		unsigned corruptedBlock = 0;
 
 		// Check if a bit flip event was injected, if so, copy the buffer contents
 		// with a random bit flipped in a new buffer and use that for the write
@@ -91,7 +95,10 @@ public:
 					pdata = (char*)arena.allocate4kAlignedBuffer(length);
 					memcpy(pdata, data, length);
 					// flip a random bit in the copied buffer
-					pdata[deterministicRandom()->randomInt(0, length)] ^= (1 << deterministicRandom()->randomInt(0, 8));
+					auto corruptedPos = deterministicRandom()->randomInt(0, length);
+					pdata[corruptedPos] ^= (1 << deterministicRandom()->randomInt(0, 8));
+					// mark the block as corrupted
+					corruptedBlock = offset + corruptedPos / (4 * 1024);
 
 					// increment the metric for bit flips
 					auto res = g_network->global(INetwork::enChaosMetrics);
@@ -103,23 +110,28 @@ public:
 			}
 		}
 
-		double diskDelay = getDelay();
-		if (diskDelay == 0.0) {
-			if (pdata)
-				return holdWhile(arena, file->write(pdata, length, offset));
-
-			return file->write(data, length, offset);
-		}
-
 		// Wait for diskDelay before submitting the I/O
-		// Capture file by value in case this is destroyed during the delay
-		return mapAsync<Void, std::function<Future<Void>(Void)>, Void>(
-		    delay(diskDelay), [=, file = file](Void _) -> Future<Void> {
-			    if (pdata)
-				    return holdWhile(arena, file->write(pdata, length, offset));
+		return mapAsync<Void, std::function<Future<Void>(Void)>, Void>(delay(getDelay()), [=](Void _) -> Future<Void> {
+			if (pdata) {
+				// if (g_network->isSimulated())
+				return map(holdWhile(arena, file->write(pdata, length, offset)), [corruptedBlock, this](auto res) {
+					if (g_network->isSimulated()) {
+						g_simulator->corruptedBlocks.template emplace(filename, corruptedBlock);
+					}
+					return res;
+				});
+			}
 
-			    return file->write(data, length, offset);
-		    });
+			return map(file->write(data, length, offset), [this, pdata, offset, length](auto res) {
+				if (pdata != nullptr || !g_network->isSimulated()) {
+					return res;
+				}
+				g_simulator->corruptedBlocks.erase(
+				    g_simulator->corruptedBlocks.lower_bound(std::make_pair(filename, offset / 4096)),
+				    g_simulator->corruptedBlocks.upper_bound(std::make_pair(filename, (offset + length) / 4096)));
+				return res;
+			});
+		});
 	}
 
 	Future<Void> truncate(int64_t size) override {

--- a/fdbrpc/include/fdbrpc/simulator.h
+++ b/fdbrpc/include/fdbrpc/simulator.h
@@ -26,6 +26,8 @@
 #include <random>
 #include <limits>
 
+#include <boost/unordered_set.hpp>
+
 #include "flow/flow.h"
 #include "flow/Histogram.h"
 #include "flow/ProtocolVersion.h"
@@ -508,6 +510,8 @@ public:
 	double injectTargetedBWRestartTime = std::numeric_limits<double>::max();
 
 	std::unordered_map<Standalone<StringRef>, PrivateKey> authKeys;
+
+	std::set<std::pair<std::string, unsigned>> corruptedBlocks;
 
 	flowGlobalType global(int id) const final { return getCurrentProcess()->global(id); };
 	void setGlobal(size_t id, flowGlobalType v) final { getCurrentProcess()->setGlobal(id, v); };

--- a/fdbserver/KeyValueStoreSQLite.actor.cpp
+++ b/fdbserver/KeyValueStoreSQLite.actor.cpp
@@ -713,7 +713,7 @@ struct IntKeyCursor {
 				db.checkError("BtreeCloseCursor", sqlite3BtreeCloseCursor(cursor));
 			} catch (...) {
 			}
-			delete[] (char*)cursor;
+			delete[](char*) cursor;
 		}
 	}
 };
@@ -751,7 +751,7 @@ struct RawCursor {
 			} catch (...) {
 				TraceEvent(SevError, "RawCursorDestructionError").log();
 			}
-			delete[] (char*)cursor;
+			delete[](char*) cursor;
 		}
 	}
 	void moveFirst() {

--- a/fdbserver/workloads/MachineAttrition.actor.cpp
+++ b/fdbserver/workloads/MachineAttrition.actor.cpp
@@ -116,6 +116,10 @@ struct MachineAttritionWorkload : FailureInjectionWorkload {
 	bool shouldInject(DeterministicRandom& random,
 	                  const WorkloadRequest& work,
 	                  const unsigned alreadyAdded) const override {
+		if (g_network->isSimulated() && !g_simulator->extraDatabases.empty()) {
+			// Remove this as soon as we track extra databases properly
+			return false;
+		}
 		return work.useDatabase && random.random01() < 1.0 / (2.0 + alreadyAdded);
 	}
 


### PR DESCRIPTION
This is to fix the correctness failure for

bin/fdbserver -r simulation -b off -s 56692670 -f /root/src/tests/slow/DiskFailureCycle.toml

where injected disk failure (bit flip) caused SQLite KV store reports SevError. The cycle test is not failing, so the code is correctly behaving when there is disk corruption, yet it should not report SevError.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
