### PR TITLE
Track whether an AndFuture has begun

### DIFF
--- a/fdbclient/ReadYourWrites.actor.cpp
+++ b/fdbclient/ReadYourWrites.actor.cpp
@@ -2446,7 +2446,7 @@ void ReadYourWritesTransaction::setOptionImpl(FDBTransactionOptions::Option opti
 	case FDBTransactionOptions::READ_YOUR_WRITES_DISABLE:
 		validateOptionValueNotPresent(value);
 
-		if (!reading.isReady() || !cache.empty() || !writes.empty())
+		if (reading.began() || !cache.empty() || !writes.empty())
 			throw client_invalid_operation();
 
 		options.readYourWritesDisabled = true;

--- a/fdbclient/ReadYourWrites.actor.cpp
+++ b/fdbclient/ReadYourWrites.actor.cpp
@@ -2446,7 +2446,7 @@ void ReadYourWritesTransaction::setOptionImpl(FDBTransactionOptions::Option opti
 	case FDBTransactionOptions::READ_YOUR_WRITES_DISABLE:
 		validateOptionValueNotPresent(value);
 
-		if (reading.began() || !cache.empty() || !writes.empty())
+		if (reading.getFutureCount() > 0 || !cache.empty() || !writes.empty())
 			throw client_invalid_operation();
 
 		options.readYourWritesDisabled = true;

--- a/fdbserver/workloads/WriteDuringRead.actor.cpp
+++ b/fdbserver/workloads/WriteDuringRead.actor.cpp
@@ -565,8 +565,12 @@ struct WriteDuringReadWorkload : TestWorkload {
 			self->finished.trigger();
 			self->dataWritten += txnSize;
 
-			if (readYourWritesDisabled)
-				tr->setOption(FDBTransactionOptions::READ_YOUR_WRITES_DISABLE);
+			// It's not legal to set readYourWritesDisabled after performing
+			// reads on a transaction, even if all those reads have completed
+			// and there are none in-flight.
+			// if (readYourWritesDisabled)
+			// 	tr->setOption(FDBTransactionOptions::READ_YOUR_WRITES_DISABLE);
+
 			if (snapshotRYWDisabled)
 				tr->setOption(FDBTransactionOptions::SNAPSHOT_RYW_DISABLE);
 			if (readAheadDisabled)

--- a/flow/include/flow/genericactors.actor.h
+++ b/flow/include/flow/genericactors.actor.h
@@ -1801,16 +1801,6 @@ public:
 
 	operator Future<Void>() { return getFuture(); }
 
-	void operator=(Future<Void> const& f) {
-		began_ = true;
-		futures.push_back(f);
-	}
-
-	void operator=(Error const& e) {
-		began_ = true;
-		futures.push_back(e);
-	}
-
 	Future<Void> getFuture() {
 		if (futures.empty())
 			return Void();

--- a/flow/include/flow/genericactors.actor.h
+++ b/flow/include/flow/genericactors.actor.h
@@ -1789,25 +1789,27 @@ Future<T> delayActionJittered(Future<T> what, double time) {
 
 class AndFuture {
 public:
-	AndFuture() {}
+	AndFuture() = default;
+	AndFuture(AndFuture const& f) = default;
+	AndFuture(AndFuture&& f) noexcept = default;
+	AndFuture& operator=(AndFuture const& f) = default;
+	AndFuture& operator=(AndFuture&& f) noexcept = default;
 
-	AndFuture(AndFuture const& f) { futures = f.futures; }
+	AndFuture(Future<Void> const& f) : began_(true), futures{ f } {}
 
-	AndFuture(AndFuture&& f) noexcept { futures = std::move(f.futures); }
-
-	AndFuture(Future<Void> const& f) { futures.push_back(f); }
-
-	AndFuture(Error const& e) { futures.push_back(e); }
+	AndFuture(Error const& e) : began_(true), futures{ Future<Void>(e) } {}
 
 	operator Future<Void>() { return getFuture(); }
 
-	void operator=(AndFuture const& f) { futures = f.futures; }
+	void operator=(Future<Void> const& f) {
+		began_ = true;
+		futures.push_back(f);
+	}
 
-	void operator=(AndFuture&& f) noexcept { futures = std::move(f.futures); }
-
-	void operator=(Future<Void> const& f) { futures.push_back(f); }
-
-	void operator=(Error const& e) { futures.push_back(e); }
+	void operator=(Error const& e) {
+		began_ = true;
+		futures.push_back(e);
+	}
 
 	Future<Void> getFuture() {
 		if (futures.empty())
@@ -1848,13 +1850,18 @@ public:
 	}
 
 	void add(Future<Void> const& f) {
+		began_ = true;
 		if (!f.isReady() || f.isError())
 			futures.push_back(f);
 	}
 
 	void add(AndFuture f) { add(f.getFuture()); }
 
+	// Whether or not there has ever been a future associated with this AndFuture
+	bool began() const { return began_; }
+
 private:
+	bool began_ = false;
 	std::vector<Future<Void>> futures;
 };
 

--- a/flow/include/flow/genericactors.actor.h
+++ b/flow/include/flow/genericactors.actor.h
@@ -1795,9 +1795,9 @@ public:
 	AndFuture& operator=(AndFuture const& f) = default;
 	AndFuture& operator=(AndFuture&& f) noexcept = default;
 
-	AndFuture(Future<Void> const& f) : began_(true), futures{ f } {}
+	AndFuture(Future<Void> const& f) : futureCount(1), futures{ f } {}
 
-	AndFuture(Error const& e) : began_(true), futures{ Future<Void>(e) } {}
+	AndFuture(Error const& e) : futureCount(1), futures{ Future<Void>(e) } {}
 
 	operator Future<Void>() { return getFuture(); }
 
@@ -1850,18 +1850,18 @@ public:
 	}
 
 	void add(Future<Void> const& f) {
-		began_ = true;
+		++futureCount;
 		if (!f.isReady() || f.isError())
 			futures.push_back(f);
 	}
 
 	void add(AndFuture f) { add(f.getFuture()); }
 
-	// Whether or not there has ever been a future associated with this AndFuture
-	bool began() const { return began_; }
+	// The total number of futures which have ever been added to this AndFuture
+	int64_t getFutureCount() const { return futureCount; }
 
 private:
-	bool began_ = false;
+	int64_t futureCount = 0;
 	std::vector<Future<Void>> futures;
 };
 


### PR DESCRIPTION
Track whether an AndFuture has begun

Previously, for deciding whether or not it was legal to set READ_YOUR_WRITES_DISABLE, it was allowed as long as no reads were in-flight. It's possible that a read can have been initiated, but the RYW caches are empty and no reads are in-flight. See #8925 for an example.

Reviewers: @sfc-gh-tclinkenbeard for c++ style and @sfc-gh-etschannen for the functional change.

Closes #8925


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
