### PR TITLE
Make startMoveShards and finishMoveShards to take a list of ranges

### DIFF
--- a/fdbserver/DDRelocationQueue.actor.cpp
+++ b/fdbserver/DDRelocationQueue.actor.cpp
@@ -1860,18 +1860,18 @@ ACTOR Future<Void> dataDistributionRelocator(DDQueue* self,
 			state Promise<Void> dataMovementComplete;
 			// Move keys from source to destination by changing the serverKeyList and keyServerList system keys
 			state Future<Void> doMoveKeys =
-			    self->txnProcessor->moveKeys(MoveKeysParams{ rd.dataMoveId,
-			                                                 rd.keys,
-			                                                 destIds,
-			                                                 healthyIds,
-			                                                 self->lock,
-			                                                 dataMovementComplete,
-			                                                 &self->startMoveKeysParallelismLock,
-			                                                 &self->finishMoveKeysParallelismLock,
-			                                                 self->teamCollections.size() > 1,
-			                                                 relocateShardInterval.pairID,
-			                                                 ddEnabledState,
-			                                                 CancelConflictingDataMoves::False });
+			    self->txnProcessor->moveKeys(MoveKeysParams(rd.dataMoveId,
+			                                                rd.keys,
+			                                                destIds,
+			                                                healthyIds,
+			                                                self->lock,
+			                                                dataMovementComplete,
+			                                                &self->startMoveKeysParallelismLock,
+			                                                &self->finishMoveKeysParallelismLock,
+			                                                self->teamCollections.size() > 1,
+			                                                relocateShardInterval.pairID,
+			                                                ddEnabledState,
+			                                                CancelConflictingDataMoves::False));
 			state Future<Void> pollHealth =
 			    signalledTransferComplete ? Never()
 			                              : delay(SERVER_KNOBS->HEALTH_POLL_TIME, TaskPriority::DataDistributionLaunch);
@@ -1885,18 +1885,18 @@ ACTOR Future<Void> dataDistributionRelocator(DDQueue* self,
 								extraIds.clear();
 								ASSERT(totalIds == destIds.size()); // Sanity check the destIDs before we move keys
 								doMoveKeys =
-								    self->txnProcessor->moveKeys(MoveKeysParams{ rd.dataMoveId,
-								                                                 rd.keys,
-								                                                 destIds,
-								                                                 healthyIds,
-								                                                 self->lock,
-								                                                 Promise<Void>(),
-								                                                 &self->startMoveKeysParallelismLock,
-								                                                 &self->finishMoveKeysParallelismLock,
-								                                                 self->teamCollections.size() > 1,
-								                                                 relocateShardInterval.pairID,
-								                                                 ddEnabledState,
-								                                                 CancelConflictingDataMoves::False });
+								    self->txnProcessor->moveKeys(MoveKeysParams(rd.dataMoveId,
+								                                                rd.keys,
+								                                                destIds,
+								                                                healthyIds,
+								                                                self->lock,
+								                                                Promise<Void>(),
+								                                                &self->startMoveKeysParallelismLock,
+								                                                &self->finishMoveKeysParallelismLock,
+								                                                self->teamCollections.size() > 1,
+								                                                relocateShardInterval.pairID,
+								                                                ddEnabledState,
+								                                                CancelConflictingDataMoves::False));
 							} else {
 								self->fetchKeysComplete.insert(rd);
 								if (SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA) {

--- a/fdbserver/DDRelocationQueue.actor.cpp
+++ b/fdbserver/DDRelocationQueue.actor.cpp
@@ -1859,19 +1859,35 @@ ACTOR Future<Void> dataDistributionRelocator(DDQueue* self,
 			state Error error = success();
 			state Promise<Void> dataMovementComplete;
 			// Move keys from source to destination by changing the serverKeyList and keyServerList system keys
-			state Future<Void> doMoveKeys =
-			    self->txnProcessor->moveKeys(MoveKeysParams(rd.dataMoveId,
-			                                                rd.keys,
-			                                                destIds,
-			                                                healthyIds,
-			                                                self->lock,
-			                                                dataMovementComplete,
-			                                                &self->startMoveKeysParallelismLock,
-			                                                &self->finishMoveKeysParallelismLock,
-			                                                self->teamCollections.size() > 1,
-			                                                relocateShardInterval.pairID,
-			                                                ddEnabledState,
-			                                                CancelConflictingDataMoves::False));
+			std::unique_ptr<MoveKeysParams> params;
+			if (SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA) {
+				params = std::make_unique<MoveKeysParams>(rd.dataMoveId,
+				                                          std::vector<KeyRange>{ rd.keys },
+				                                          destIds,
+				                                          healthyIds,
+				                                          self->lock,
+				                                          dataMovementComplete,
+				                                          &self->startMoveKeysParallelismLock,
+				                                          &self->finishMoveKeysParallelismLock,
+				                                          self->teamCollections.size() > 1,
+				                                          relocateShardInterval.pairID,
+				                                          ddEnabledState,
+				                                          CancelConflictingDataMoves::False);
+			} else {
+				params = std::make_unique<MoveKeysParams>(rd.dataMoveId,
+				                                          rd.keys,
+				                                          destIds,
+				                                          healthyIds,
+				                                          self->lock,
+				                                          dataMovementComplete,
+				                                          &self->startMoveKeysParallelismLock,
+				                                          &self->finishMoveKeysParallelismLock,
+				                                          self->teamCollections.size() > 1,
+				                                          relocateShardInterval.pairID,
+				                                          ddEnabledState,
+				                                          CancelConflictingDataMoves::False);
+			}
+			state Future<Void> doMoveKeys = self->txnProcessor->moveKeys(*params);
 			state Future<Void> pollHealth =
 			    signalledTransferComplete ? Never()
 			                              : delay(SERVER_KNOBS->HEALTH_POLL_TIME, TaskPriority::DataDistributionLaunch);
@@ -1884,19 +1900,35 @@ ACTOR Future<Void> dataDistributionRelocator(DDQueue* self,
 								healthyIds.insert(healthyIds.end(), extraIds.begin(), extraIds.end());
 								extraIds.clear();
 								ASSERT(totalIds == destIds.size()); // Sanity check the destIDs before we move keys
-								doMoveKeys =
-								    self->txnProcessor->moveKeys(MoveKeysParams(rd.dataMoveId,
-								                                                rd.keys,
-								                                                destIds,
-								                                                healthyIds,
-								                                                self->lock,
-								                                                Promise<Void>(),
-								                                                &self->startMoveKeysParallelismLock,
-								                                                &self->finishMoveKeysParallelismLock,
-								                                                self->teamCollections.size() > 1,
-								                                                relocateShardInterval.pairID,
-								                                                ddEnabledState,
-								                                                CancelConflictingDataMoves::False));
+								std::unique_ptr<MoveKeysParams> params;
+								if (SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA) {
+									params = std::make_unique<MoveKeysParams>(rd.dataMoveId,
+									                                          std::vector<KeyRange>{ rd.keys },
+									                                          destIds,
+									                                          healthyIds,
+									                                          self->lock,
+									                                          Promise<Void>(),
+									                                          &self->startMoveKeysParallelismLock,
+									                                          &self->finishMoveKeysParallelismLock,
+									                                          self->teamCollections.size() > 1,
+									                                          relocateShardInterval.pairID,
+									                                          ddEnabledState,
+									                                          CancelConflictingDataMoves::False);
+								} else {
+									params = std::make_unique<MoveKeysParams>(rd.dataMoveId,
+									                                          rd.keys,
+									                                          destIds,
+									                                          healthyIds,
+									                                          self->lock,
+									                                          Promise<Void>(),
+									                                          &self->startMoveKeysParallelismLock,
+									                                          &self->finishMoveKeysParallelismLock,
+									                                          self->teamCollections.size() > 1,
+									                                          relocateShardInterval.pairID,
+									                                          ddEnabledState,
+									                                          CancelConflictingDataMoves::False);
+								}
+								doMoveKeys = self->txnProcessor->moveKeys(*params);
 							} else {
 								self->fetchKeysComplete.insert(rd);
 								if (SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA) {

--- a/fdbserver/DDTxnProcessor.actor.cpp
+++ b/fdbserver/DDTxnProcessor.actor.cpp
@@ -723,12 +723,11 @@ struct DDMockTxnProcessorImpl {
 		return Void();
 	}
 
-	Future<Void> rawCheckFetchingState(DDMockTxnProcessor* self, MoveKeysParams params) {
-		state KeyRange keys;
+	static Future<Void> rawCheckFetchingState(DDMockTxnProcessor* self, const MoveKeysParams& params) {
 		if (SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA) {
 			ASSERT(params.ranges.present());
 			// TODO: make startMoveShards work with multiple ranges.
-			ASSERT(params.ranges.size() == 1);
+			ASSERT(params.ranges.get().size() == 1);
 			return checkFetchingState(self, params.destinationTeam, params.ranges.get().at(0));
 		}
 		ASSERT(params.keys.present());
@@ -744,7 +743,7 @@ struct DDMockTxnProcessorImpl {
 		wait(self->rawStartMovement(params, tssMapping));
 		ASSERT(tssMapping.empty());
 
-		wait(rawCheckFetchingState(self, params.destinationTeam, params.keys));
+		wait(rawCheckFetchingState(self, params));
 
 		wait(self->rawFinishMovement(params, tssMapping));
 		if (!params.dataMovementComplete.isSet())
@@ -931,7 +930,7 @@ ACTOR Future<Void> rawStartMovement(std::shared_ptr<MockGlobalState> mgs,
 	if (SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA) {
 		ASSERT(params.ranges.present());
 		// TODO: make startMoveShards work with multiple ranges.
-		ASSERT(params.ranges.size() == 1);
+		ASSERT(params.ranges.get().size() == 1);
 		keys = params.ranges.get().at(0);
 	} else {
 		ASSERT(params.keys.present());
@@ -985,7 +984,7 @@ ACTOR Future<Void> rawFinishMovement(std::shared_ptr<MockGlobalState> mgs,
 	if (SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA) {
 		ASSERT(params.ranges.present());
 		// TODO: make startMoveShards work with multiple ranges.
-		ASSERT(params.ranges.size() == 1);
+		ASSERT(params.ranges.get().size() == 1);
 		keys = params.ranges.get().at(0);
 	} else {
 		ASSERT(params.keys.present());

--- a/fdbserver/MoveKeys.actor.cpp
+++ b/fdbserver/MoveKeys.actor.cpp
@@ -2513,14 +2513,14 @@ Future<Void> rawStartMovement(Database occ,
 	                     params.ddEnabledState);
 }
 
-Future<Void> rawCheckFetchingState(Database cx,
+Future<Void> rawCheckFetchingState(const Database& cx,
                                    const MoveKeysParams& params,
                                    const std::map<UID, StorageServerInterface>& tssMapping) {
 	if (SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA) {
 		ASSERT(params.ranges.present());
 		// TODO: make startMoveShards work with multiple ranges.
-		ASSERT(params.ranges.size() == 1);
-		return checkFetchingState(occ,
+		ASSERT(params.ranges.get().size() == 1);
+		return checkFetchingState(cx,
 		                          params.healthyDestinations,
 		                          params.ranges.get().at(0),
 		                          params.dataMovementComplete,
@@ -2528,7 +2528,7 @@ Future<Void> rawCheckFetchingState(Database cx,
 		                          tssMapping);
 	}
 	ASSERT(params.keys.present());
-	return checkFetchingState(occ,
+	return checkFetchingState(cx,
 	                          params.healthyDestinations,
 	                          params.keys.get(),
 	                          params.dataMovementComplete,

--- a/fdbserver/include/fdbserver/MoveKeys.actor.h
+++ b/fdbserver/include/fdbserver/MoveKeys.actor.h
@@ -58,7 +58,8 @@ public:
 
 struct MoveKeysParams {
 	UID dataMoveId;
-	KeyRange keys;
+	Optional<KeyRange> keys;
+	Optional<std::vector<KeyRange>> ranges;
 	std::vector<UID> destinationTeam, healthyDestinations;
 	MoveKeysLock lock;
 	Promise<Void> dataMovementComplete;
@@ -68,6 +69,44 @@ struct MoveKeysParams {
 	UID relocationIntervalId;
 	const DDEnabledState* ddEnabledState = nullptr;
 	CancelConflictingDataMoves cancelConflictingDataMoves = CancelConflictingDataMoves::False;
+
+	MoveKeysParams(UID dataMoveId,
+	               const KeyRange& keys,
+	               const std::vector<UID>& destinationTeam,
+	               const std::vector<UID>& healthyDestinations,
+	               const MoveKeysLock& lock,
+	               const Promise<Void>& dataMovementComplete,
+	               FlowLock* startMoveKeysParallelismLock,
+	               FlowLock* finishMoveKeysParallelismLock,
+	               bool hasRemove,
+	               UID relocationIntervalId,
+	               const DDEnabledState* ddEnabledState,
+	               CancelConflictingDataMoves cancelConflictingDataMoves)
+	  : dataMoveId(dataMoveId), keys(keys), destinationTeam(destinationTeam), healthyDestinations(healthyDestinations),
+	    lock(lock), dataMovementComplete(dataMovementComplete),
+	    startMoveKeysParallelismLock(startMoveKeysParallelismLock),
+	    finishMoveKeysParallelismLock(finishMoveKeysParallelismLock), hasRemote(hasRemote),
+	    relocationIntervalId(relocationIntervalId), ddEnabledState(ddEnabledState),
+	    cancelConflictingDataMoves(cancelConflictingDataMoves) {}
+
+	MoveKeysParams(UID dataMoveId,
+	               const std::vector<KeyRange>& ranges,
+	               const std::vector<UID>& destinationTeam,
+	               const std::vector<UID>& healthyDestinations,
+	               const MoveKeysLock& lock,
+	               const Promise<Void>& dataMovementComplete,
+	               FlowLock* startMoveKeysParallelismLock,
+	               FlowLock* finishMoveKeysParallelismLock,
+	               bool hasRemove,
+	               UID relocationIntervalId,
+	               const DDEnabledState* ddEnabledState,
+	               CancelConflictingDataMoves cancelConflictingDataMoves)
+	  : dataMoveId(dataMoveId), ranges(ranges), destinationTeam(destinationTeam),
+	    healthyDestinations(healthyDestinations), lock(lock), dataMovementComplete(dataMovementComplete),
+	    startMoveKeysParallelismLock(startMoveKeysParallelismLock),
+	    finishMoveKeysParallelismLock(finishMoveKeysParallelismLock), hasRemote(hasRemote),
+	    relocationIntervalId(relocationIntervalId), ddEnabledState(ddEnabledState),
+	    cancelConflictingDataMoves(cancelConflictingDataMoves) {}
 };
 
 // read the lock value in system keyspace but do not change anything

--- a/fdbserver/include/fdbserver/MoveKeys.actor.h
+++ b/fdbserver/include/fdbserver/MoveKeys.actor.h
@@ -58,8 +58,12 @@ public:
 
 struct MoveKeysParams {
 	UID dataMoveId;
+
+	// Only one of `keys` and `ranges` can be set. `ranges` is created mainly for physical shard moves to move a full
+	// physical shard with multiple key ranges.
 	Optional<KeyRange> keys;
 	Optional<std::vector<KeyRange>> ranges;
+
 	std::vector<UID> destinationTeam, healthyDestinations;
 	MoveKeysLock lock;
 	Promise<Void> dataMovementComplete;
@@ -80,7 +84,7 @@ struct MoveKeysParams {
 	               const Promise<Void>& dataMovementComplete,
 	               FlowLock* startMoveKeysParallelismLock,
 	               FlowLock* finishMoveKeysParallelismLock,
-	               bool hasRemove,
+	               bool hasRemote,
 	               UID relocationIntervalId,
 	               const DDEnabledState* ddEnabledState,
 	               CancelConflictingDataMoves cancelConflictingDataMoves)
@@ -99,7 +103,7 @@ struct MoveKeysParams {
 	               const Promise<Void>& dataMovementComplete,
 	               FlowLock* startMoveKeysParallelismLock,
 	               FlowLock* finishMoveKeysParallelismLock,
-	               bool hasRemove,
+	               bool hasRemote,
 	               UID relocationIntervalId,
 	               const DDEnabledState* ddEnabledState,
 	               CancelConflictingDataMoves cancelConflictingDataMoves)

--- a/fdbserver/include/fdbserver/MoveKeys.actor.h
+++ b/fdbserver/include/fdbserver/MoveKeys.actor.h
@@ -70,6 +70,8 @@ struct MoveKeysParams {
 	const DDEnabledState* ddEnabledState = nullptr;
 	CancelConflictingDataMoves cancelConflictingDataMoves = CancelConflictingDataMoves::False;
 
+	MoveKeysParams() {}
+
 	MoveKeysParams(UID dataMoveId,
 	               const KeyRange& keys,
 	               const std::vector<UID>& destinationTeam,

--- a/fdbserver/workloads/DataLossRecovery.actor.cpp
+++ b/fdbserver/workloads/DataLossRecovery.actor.cpp
@@ -216,18 +216,18 @@ struct DataLossRecoveryWorkload : TestWorkload {
 
 				TraceEvent("DataLossRecovery").detail("Phase", "StartMoveKeys");
 				wait(moveKeys(cx,
-				              MoveKeysParams{ deterministicRandom()->randomUniqueID(),
-				                              keys,
-				                              dest,
-				                              dest,
-				                              moveKeysLock,
-				                              Promise<Void>(),
-				                              &self->startMoveKeysParallelismLock,
-				                              &self->finishMoveKeysParallelismLock,
-				                              false,
-				                              UID(), // for logging only
-				                              &ddEnabledState,
-				                              CancelConflictingDataMoves::True }));
+				              MoveKeysParams(deterministicRandom()->randomUniqueID(),
+				                             keys,
+				                             dest,
+				                             dest,
+				                             moveKeysLock,
+				                             Promise<Void>(),
+				                             &self->startMoveKeysParallelismLock,
+				                             &self->finishMoveKeysParallelismLock,
+				                             false,
+				                             UID(), // for logging only
+				                             &ddEnabledState,
+				                             CancelConflictingDataMoves::True)));
 				break;
 			} catch (Error& e) {
 				TraceEvent("DataLossRecovery").error(e).detail("Phase", "MoveRangeError");

--- a/fdbserver/workloads/IDDTxnProcessorApiCorrectness.actor.cpp
+++ b/fdbserver/workloads/IDDTxnProcessorApiCorrectness.actor.cpp
@@ -332,18 +332,18 @@ struct IDDTxnProcessorApiWorkload : TestWorkload {
 		KeyRange keys = self->getRandomKeys();
 		std::vector<UID> destTeam = self->getRandomTeam();
 		std::sort(destTeam.begin(), destTeam.end());
-		return MoveKeysParams{ deterministicRandom()->randomUniqueID(),
-			                   keys,
-			                   destTeam,
-			                   destTeam,
-			                   lock,
-			                   Promise<Void>(),
-			                   nullptr,
-			                   nullptr,
-			                   false,
-			                   UID(),
-			                   self->ddContext.ddEnabledState.get(),
-			                   CancelConflictingDataMoves::True };
+		return MoveKeysParams(deterministicRandom()->randomUniqueID(),
+		                      keys,
+		                      destTeam,
+		                      destTeam,
+		                      lock,
+		                      Promise<Void>(),
+		                      nullptr,
+		                      nullptr,
+		                      false,
+		                      UID(),
+		                      self->ddContext.ddEnabledState.get(),
+		                      CancelConflictingDataMoves::True);
 	}
 
 	ACTOR static Future<Void> testMoveKeys(IDDTxnProcessorApiWorkload* self) {

--- a/fdbserver/workloads/IDDTxnProcessorApiCorrectness.actor.cpp
+++ b/fdbserver/workloads/IDDTxnProcessorApiCorrectness.actor.cpp
@@ -262,9 +262,20 @@ struct IDDTxnProcessorApiWorkload : TestWorkload {
 	}
 
 	void verifyServerKeyDest(MoveKeysParams& params) const {
+		KeyRangeRef keys;
+		if (SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA) {
+			ASSERT(params.ranges.present());
+			// TODO: make startMoveShards work with multiple ranges.
+			ASSERT(params.ranges.get().size() == 1);
+			keys = params.ranges.get().at(0);
+		} else {
+			ASSERT(params.keys.present());
+			keys = params.keys.get();
+		}
+
 		// check destination servers
 		for (auto& id : params.destinationTeam) {
-			ASSERT(mgs->serverIsDestForShard(id, params.keys));
+			ASSERT(mgs->serverIsDestForShard(id, keys));
 		}
 	}
 	ACTOR static Future<Void> testRawMovementApi(IDDTxnProcessorApiWorkload* self) {

--- a/fdbserver/workloads/PhysicalShardMove.actor.cpp
+++ b/fdbserver/workloads/PhysicalShardMove.actor.cpp
@@ -344,17 +344,17 @@ struct PhysicalShardMoveWorkLoad : TestWorkload {
 
 				TraceEvent("TestMoveShardStartMoveKeys").detail("DataMove", dataMoveId);
 				wait(moveKeys(cx,
-				              MoveKeysParams{ dataMoveId,
-				                              keys,
-				                              dests,
-				                              dests,
-				                              moveKeysLock,
-				                              Promise<Void>(),
-				                              &self->startMoveKeysParallelismLock,
-				                              &self->finishMoveKeysParallelismLock,
-				                              false,
-				                              deterministicRandom()->randomUniqueID(), // for logging only
-				                              &ddEnabledState }));
+				              MoveKeysParams(dataMoveId,
+				                             keys,
+				                             dests,
+				                             dests,
+				                             moveKeysLock,
+				                             Promise<Void>(),
+				                             &self->startMoveKeysParallelismLock,
+				                             &self->finishMoveKeysParallelismLock,
+				                             false,
+				                             deterministicRandom()->randomUniqueID(), // for logging only
+				                             &ddEnabledState)));
 				break;
 			} catch (Error& e) {
 				if (e.code() == error_code_movekeys_conflict) {

--- a/fdbserver/workloads/PhysicalShardMove.actor.cpp
+++ b/fdbserver/workloads/PhysicalShardMove.actor.cpp
@@ -354,7 +354,8 @@ struct PhysicalShardMoveWorkLoad : TestWorkload {
 				                             &self->finishMoveKeysParallelismLock,
 				                             false,
 				                             deterministicRandom()->randomUniqueID(), // for logging only
-				                             &ddEnabledState)));
+				                             &ddEnabledState,
+				                             CancelConflictingDataMoves::False)));
 				break;
 			} catch (Error& e) {
 				if (e.code() == error_code_movekeys_conflict) {

--- a/fdbserver/workloads/PhysicalShardMove.actor.cpp
+++ b/fdbserver/workloads/PhysicalShardMove.actor.cpp
@@ -345,7 +345,7 @@ struct PhysicalShardMoveWorkLoad : TestWorkload {
 				TraceEvent("TestMoveShardStartMoveKeys").detail("DataMove", dataMoveId);
 				wait(moveKeys(cx,
 				              MoveKeysParams(dataMoveId,
-				                             keys,
+				                             std::vector<KeyRange>{ keys },
 				                             dests,
 				                             dests,
 				                             moveKeysLock,

--- a/fdbserver/workloads/RandomMoveKeys.actor.cpp
+++ b/fdbserver/workloads/RandomMoveKeys.actor.cpp
@@ -25,6 +25,7 @@
 #include "fdbserver/MoveKeys.actor.h"
 #include "fdbclient/NativeAPI.actor.h"
 #include "fdbserver/workloads/workloads.actor.h"
+#include "fdbserver/Knobs.h"
 #include "fdbserver/ServerDBInfo.h"
 #include "fdbserver/QuietDatabase.h"
 #include "flow/DeterministicRandom.h"
@@ -155,19 +156,35 @@ struct MoveKeysWorkload : FailureInjectionWorkload {
 		try {
 			state Promise<Void> signal;
 			state DDEnabledState ddEnabledState;
-			wait(moveKeys(cx,
-			              MoveKeysParams(deterministicRandom()->randomUniqueID(),
-			                             keys,
-			                             destinationTeamIDs,
-			                             destinationTeamIDs,
-			                             lock,
-			                             signal,
-			                             &fl1,
-			                             &fl2,
-			                             false,
-			                             relocateShardInterval.pairID,
-			                             &ddEnabledState,
-			                             CancelConflictingDataMoves::True)));
+			std::unique_ptr<MoveKeysParams> params;
+			if (SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA) {
+				params = std::make_unique<MoveKeysParams>(deterministicRandom()->randomUniqueID(),
+				                                          std::vector<KeyRange>{ keys },
+				                                          destinationTeamIDs,
+				                                          destinationTeamIDs,
+				                                          lock,
+				                                          signal,
+				                                          &fl1,
+				                                          &fl2,
+				                                          false,
+				                                          relocateShardInterval.pairID,
+				                                          &ddEnabledState,
+				                                          CancelConflictingDataMoves::True);
+			} else {
+				params = std::make_unique<MoveKeysParams>(deterministicRandom()->randomUniqueID(),
+				                                          keys,
+				                                          destinationTeamIDs,
+				                                          destinationTeamIDs,
+				                                          lock,
+				                                          signal,
+				                                          &fl1,
+				                                          &fl2,
+				                                          false,
+				                                          relocateShardInterval.pairID,
+				                                          &ddEnabledState,
+				                                          CancelConflictingDataMoves::True);
+			}
+			wait(moveKeys(cx, *params));
 			TraceEvent(relocateShardInterval.end()).detail("Result", "Success");
 			return Void();
 		} catch (Error& e) {

--- a/fdbserver/workloads/RandomMoveKeys.actor.cpp
+++ b/fdbserver/workloads/RandomMoveKeys.actor.cpp
@@ -156,18 +156,18 @@ struct MoveKeysWorkload : FailureInjectionWorkload {
 			state Promise<Void> signal;
 			state DDEnabledState ddEnabledState;
 			wait(moveKeys(cx,
-			              MoveKeysParams{ deterministicRandom()->randomUniqueID(),
-			                              keys,
-			                              destinationTeamIDs,
-			                              destinationTeamIDs,
-			                              lock,
-			                              signal,
-			                              &fl1,
-			                              &fl2,
-			                              false,
-			                              relocateShardInterval.pairID,
-			                              &ddEnabledState,
-			                              CancelConflictingDataMoves::True }));
+			              MoveKeysParams(deterministicRandom()->randomUniqueID(),
+			                             keys,
+			                             destinationTeamIDs,
+			                             destinationTeamIDs,
+			                             lock,
+			                             signal,
+			                             &fl1,
+			                             &fl2,
+			                             false,
+			                             relocateShardInterval.pairID,
+			                             &ddEnabledState,
+			                             CancelConflictingDataMoves::True)));
 			TraceEvent(relocateShardInterval.end()).detail("Result", "Success");
 			return Void();
 		} catch (Error& e) {


### PR DESCRIPTION
Adding `Optional<std::vector<KeyRange>> ranges` into `MoveKeysParams`.

20221129-060111-zhewu_8938-077bd68211e3ef29        compressed=True data_size=41277190 duration=4077067 ended=100000 fail=6 fail_fast=10 max_runs=100000 pass=99994 priority=100 remaining=0 runtime=0:50:34 sanity=False started=100231 stopped=20221129-065145 submitted=20221129-060111 timeout=5400 username=zhewu_8938

All test failures are due to `Traced too many lines`, and seems unrelated to this PR.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
