### PR TITLE
Backport machine attrition code to release-7.2

### DIFF
--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -1010,9 +1010,7 @@ ACTOR Future<Optional<CoordinatorsResult>> changeQuorumChecker(Transaction* tr,
 
 	choose {
 		when(wait(waitForAll(leaderServers))) {}
-		when(wait(delay(5.0))) {
-			return CoordinatorsResult::COORDINATOR_UNREACHABLE;
-		}
+		when(wait(delay(5.0))) { return CoordinatorsResult::COORDINATOR_UNREACHABLE; }
 	}
 	TraceEvent("ChangeQuorumCheckerSetCoordinatorsKey")
 	    .detail("CurrentCoordinators", old.toString())
@@ -1114,9 +1112,7 @@ ACTOR Future<CoordinatorsResult> changeQuorum(Database cx, Reference<IQuorumChan
 				                                           TaskPriority::CoordinationReply));
 			choose {
 				when(wait(waitForAll(leaderServers))) {}
-				when(wait(delay(5.0))) {
-					return CoordinatorsResult::COORDINATOR_UNREACHABLE;
-				}
+				when(wait(delay(5.0))) { return CoordinatorsResult::COORDINATOR_UNREACHABLE; }
 			}
 
 			tr.set(coordinatorsKey, newClusterConnectionString.toString());

--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -2149,6 +2149,9 @@ ACTOR Future<Void> lockDatabase(Reference<ReadYourWritesTransaction> tr, UID id)
 
 ACTOR Future<Void> lockDatabase(Database cx, UID id) {
 	state Transaction tr(cx);
+	UID debugID = deterministicRandom()->randomUniqueID();
+	TraceEvent("LockDatabaseTransaction", debugID).log();
+	tr.debugTransaction(debugID);
 	loop {
 		try {
 			wait(lockDatabase(&tr, id));

--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -1010,7 +1010,9 @@ ACTOR Future<Optional<CoordinatorsResult>> changeQuorumChecker(Transaction* tr,
 
 	choose {
 		when(wait(waitForAll(leaderServers))) {}
-		when(wait(delay(5.0))) { return CoordinatorsResult::COORDINATOR_UNREACHABLE; }
+		when(wait(delay(5.0))) {
+			return CoordinatorsResult::COORDINATOR_UNREACHABLE;
+		}
 	}
 	TraceEvent("ChangeQuorumCheckerSetCoordinatorsKey")
 	    .detail("CurrentCoordinators", old.toString())
@@ -1112,7 +1114,9 @@ ACTOR Future<CoordinatorsResult> changeQuorum(Database cx, Reference<IQuorumChan
 				                                           TaskPriority::CoordinationReply));
 			choose {
 				when(wait(waitForAll(leaderServers))) {}
-				when(wait(delay(5.0))) { return CoordinatorsResult::COORDINATOR_UNREACHABLE; }
+				when(wait(delay(5.0))) {
+					return CoordinatorsResult::COORDINATOR_UNREACHABLE;
+				}
 			}
 
 			tr.set(coordinatorsKey, newClusterConnectionString.toString());

--- a/fdbrpc/AsyncFileChaos.cpp
+++ b/fdbrpc/AsyncFileChaos.cpp
@@ -1,0 +1,146 @@
+/*
+ * AsyncFileChaos.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "fdbrpc/AsyncFileChaos.h"
+#include "fdbrpc/simulator.h"
+
+double AsyncFileChaos::getDelay() const {
+	double delayFor = 0.0;
+	if (!enabled)
+		return delayFor;
+
+	auto res = g_network->global(INetwork ::enDiskFailureInjector);
+	if (res) {
+		DiskFailureInjector* delayInjector = static_cast<DiskFailureInjector*>(res);
+		delayFor = delayInjector->getDiskDelay();
+
+		// increment the metric for disk delays
+		if (delayFor > 0.0) {
+			auto res = g_network->global(INetwork ::enChaosMetrics);
+			if (res) {
+				ChaosMetrics* chaosMetrics = static_cast<ChaosMetrics*>(res);
+				chaosMetrics->diskDelays++;
+			}
+		}
+	}
+	return delayFor;
+}
+
+Future<int> AsyncFileChaos::read(void* data, int length, int64_t offset) {
+	double diskDelay = getDelay();
+
+	if (diskDelay == 0.0)
+		return file->read(data, length, offset);
+
+	// Wait for diskDelay before submitting the I/O
+	// Template types are being provided explicitly because they can't be automatically deduced for some reason.
+	// Capture file by value in case this is destroyed during the delay
+	return mapAsync<Void, std ::function<Future<int>(Void)>, int>(
+	    delay(diskDelay), [=, file = file](Void _) -> Future<int> { return file->read(data, length, offset); });
+}
+
+Future<Void> AsyncFileChaos::write(void const* data, int length, int64_t offset) {
+	Arena arena;
+	char* pdata = nullptr;
+	Optional<uint64_t> corruptedBytePosition;
+
+	// Check if a bit flip event was injected, if so, copy the buffer contents
+	// with a random bit flipped in a new buffer and use that for the write
+	auto res = g_network->global(INetwork ::enBitFlipper);
+	if (enabled && res) {
+		auto bitFlipPercentage = static_cast<BitFlipper*>(res)->getBitFlipPercentage();
+		if (bitFlipPercentage > 0.0) {
+			auto bitFlipProb = bitFlipPercentage / 100;
+			if (deterministicRandom()->random01() < bitFlipProb) {
+				pdata = (char*)arena.allocate4kAlignedBuffer(length);
+				memcpy(pdata, data, length);
+				// flip a random bit in the copied buffer
+				auto corruptedPos = deterministicRandom()->randomInt(0, length);
+				pdata[corruptedPos] ^= (1 << deterministicRandom()->randomInt(0, 8));
+				// mark the block as corrupted
+				corruptedBytePosition = offset + corruptedPos;
+				TraceEvent("CorruptedByteInjection")
+				    .detail("Filename", file->getFilename())
+				    .detail("Position", corruptedBytePosition)
+				    .log();
+
+				// increment the metric for bit flips
+				auto res = g_network->global(INetwork ::enChaosMetrics);
+				if (res) {
+					ChaosMetrics* chaosMetrics = static_cast<ChaosMetrics*>(res);
+					chaosMetrics->bitFlips++;
+				}
+			}
+		}
+	}
+
+	// Wait for diskDelay before submitting the write
+	// Capture file by value in case this is destroyed during the delay
+	return mapAsync<Void, std ::function<Future<Void>(Void)>, Void>(
+	    delay(getDelay()), [=, file = file](Void _) -> Future<Void> {
+		    if (pdata) {
+			    return map(holdWhile(arena, file->write(pdata, length, offset)),
+			               [corruptedBytePosition, file = file](auto res) {
+				               if (g_network->isSimulated() && corruptedBytePosition.present()) {
+					               g_simulator->corruptedBytes.mark(file->getFilename(), corruptedBytePosition.get());
+				               }
+				               return res;
+			               });
+		    }
+
+		    return file->write(data, length, offset);
+	    });
+}
+
+Future<Void> AsyncFileChaos::truncate(int64_t size) {
+	double diskDelay = getDelay();
+	if (diskDelay == 0.0)
+		return file->truncate(size);
+
+	// Wait for diskDelay before submitting the I/O
+	// Capture file by value in case this is destroyed during the delay
+	return mapAsync<Void, std ::function<Future<Void>(Void)>, Void>(
+	    delay(diskDelay), [size, file = file](Void _) -> Future<Void> {
+		    g_simulator->corruptedBytes.truncate(file->getFilename(), size);
+		    return file->truncate(size);
+	    });
+}
+
+Future<Void> AsyncFileChaos::sync() {
+	double diskDelay = getDelay();
+	if (diskDelay == 0.0)
+		return file->sync();
+
+	// Wait for diskDelay before submitting the I/O
+	// Capture file by value in case this is destroyed during the delay
+	return mapAsync<Void, std ::function<Future<Void>(Void)>, Void>(
+	    delay(diskDelay), [=, file = file](Void _) -> Future<Void> { return file->sync(); });
+}
+
+Future<int64_t> AsyncFileChaos::size() const {
+	double diskDelay = getDelay();
+	if (diskDelay == 0.0)
+		return file->size();
+
+	// Wait for diskDelay before submitting the I/O
+	// Capture file by value in case this is destroyed during the delay
+	return mapAsync<Void, std ::function<Future<int64_t>(Void)>, int64_t>(
+	    delay(diskDelay), [=, file = file](Void _) -> Future<int64_t> { return file->size(); });
+}

--- a/fdbrpc/FailureMonitor.actor.cpp
+++ b/fdbrpc/FailureMonitor.actor.cpp
@@ -53,9 +53,7 @@ ACTOR Future<Void> waitForContinuousFailure(IFailureMonitor* monitor,
 		choose {
 			when(wait(monitor->onStateEqual(endpoint, FailureStatus(false)))) {
 			} // SOMEDAY: Use onStateChanged() for efficiency
-			when(wait(delay(waitDelay))) {
-				return Void();
-			}
+			when(wait(delay(waitDelay))) { return Void(); }
 		}
 	}
 }

--- a/fdbrpc/FailureMonitor.actor.cpp
+++ b/fdbrpc/FailureMonitor.actor.cpp
@@ -154,7 +154,6 @@ void SimpleFailureMonitor::notifyDisconnect(NetworkAddress const& address) {
 }
 
 Future<Void> SimpleFailureMonitor::onDisconnectOrFailure(Endpoint const& endpoint) {
-	static int numWeirdTokens = 0;
 	// If the endpoint or address is already failed, return right away
 	auto i = addressStatus.find(endpoint.getPrimaryAddress());
 	if (i == addressStatus.end() || i->second.isFailed() || failedEndpoints.count(endpoint)) {

--- a/fdbrpc/FailureMonitor.actor.cpp
+++ b/fdbrpc/FailureMonitor.actor.cpp
@@ -53,7 +53,9 @@ ACTOR Future<Void> waitForContinuousFailure(IFailureMonitor* monitor,
 		choose {
 			when(wait(monitor->onStateEqual(endpoint, FailureStatus(false)))) {
 			} // SOMEDAY: Use onStateChanged() for efficiency
-			when(wait(delay(waitDelay))) { return Void(); }
+			when(wait(delay(waitDelay))) {
+				return Void();
+			}
 		}
 	}
 }

--- a/fdbrpc/include/fdbrpc/AsyncFileChaos.h
+++ b/fdbrpc/include/fdbrpc/AsyncFileChaos.h
@@ -114,13 +114,13 @@ public:
 		}
 		return mapAsync<Void, std::function<Future<Void>(Void)>, Void>(delay(getDelay()), [=](Void _) -> Future<Void> {
 			if (pdata) {
-				// if (g_network->isSimulated())
-				return map(holdWhile(arena, file->write(pdata, length, offset)), [corruptedBlock, this](auto res) {
-					if (g_network->isSimulated()) {
-						g_simulator->corruptedBlocks.emplace(file->getFilename(), corruptedBlock);
-					}
-					return res;
-				});
+				return map(holdWhile(arena, file->write(pdata, length, offset)),
+				           [corruptedBlock, file = file](auto res) {
+					           if (g_network->isSimulated()) {
+						           g_simulator->corruptedBlocks.emplace(file->getFilename(), corruptedBlock);
+					           }
+					           return res;
+				           });
 			}
 
 			return file->write(data, length, offset);

--- a/fdbrpc/include/fdbrpc/AsyncFileChaos.h
+++ b/fdbrpc/include/fdbrpc/AsyncFileChaos.h
@@ -143,7 +143,7 @@ public:
 		// Wait for diskDelay before submitting the I/O
 		// Capture file by value in case this is destroyed during the delay
 		return mapAsync<Void, std::function<Future<Void>(Void)>, Void>(
-		    delay(diskDelay), [this, size, file = file](Void _) -> Future<Void> {
+		    delay(diskDelay), [size, file = file](Void _) -> Future<Void> {
 			    constexpr auto maxBlockValue =
 			        std::numeric_limits<decltype(g_simulator->corruptedBlocks)::key_type::second_type>::max();
 			    auto firstDeletedBlock =

--- a/fdbrpc/include/fdbrpc/AsyncFileChaos.h
+++ b/fdbrpc/include/fdbrpc/AsyncFileChaos.h
@@ -122,7 +122,7 @@ public:
 				});
 			}
 
-			return map(file->write(data, length, offset), [this, pdata, offset, length](auto res) {
+			return map(file->write(data, length, offset), [pdata, offset, length](auto res) {
 				if (pdata != nullptr || !g_network->isSimulated()) {
 					return res;
 				}

--- a/fdbrpc/include/fdbrpc/AsyncFileChaos.h
+++ b/fdbrpc/include/fdbrpc/AsyncFileChaos.h
@@ -112,7 +112,10 @@ public:
 				}
 			}
 		}
-		return mapAsync<Void, std::function<Future<Void>(Void)>, Void>(delay(getDelay()), [=](Void _) -> Future<Void> {
+
+		// Wait for diskDelay before submitting the write
+		// Capture file by value in case this is destroyed during the delay
+		return mapAsync<Void, std::function<Future<Void>(Void)>, Void>(delay(getDelay()), [=, file = file](Void _) -> Future<Void> {
 			if (pdata) {
 				return map(holdWhile(arena, file->write(pdata, length, offset)),
 				           [corruptedBlock, file = file](auto res) {

--- a/fdbrpc/include/fdbrpc/AsyncFileChaos.h
+++ b/fdbrpc/include/fdbrpc/AsyncFileChaos.h
@@ -122,7 +122,7 @@ public:
 				});
 			}
 
-			return map(file->write(data, length, offset), [pdata, offset, length](auto res) {
+			return map(file->write(data, length, offset), [this, pdata, offset, length](auto res) {
 				if (pdata != nullptr || !g_network->isSimulated()) {
 					return res;
 				}

--- a/fdbrpc/include/fdbrpc/AsyncFileChaos.h
+++ b/fdbrpc/include/fdbrpc/AsyncFileChaos.h
@@ -36,7 +36,8 @@ private:
 public:
 	explicit AsyncFileChaos(Reference<IAsyncFile> file) : file(file) {
 		// We only allow chaos events on storage files
-		enabled = (file->getFilename().find("storage-") != std::string::npos);
+		enabled = file->getFilename().find("storage-") != std::string::npos &&
+		          file->getFilename().find("sqlite-wal") == std::string::npos;
 	}
 
 	void addref() override { ReferenceCounted<AsyncFileChaos>::addref(); }

--- a/fdbrpc/include/fdbrpc/AsyncFileChaos.h
+++ b/fdbrpc/include/fdbrpc/AsyncFileChaos.h
@@ -123,16 +123,7 @@ public:
 				});
 			}
 
-			return map(file->write(data, length, offset), [this, pdata, offset, length](auto res) {
-				if (pdata != nullptr || !g_network->isSimulated()) {
-					return res;
-				}
-				g_simulator->corruptedBlocks.erase(
-				    g_simulator->corruptedBlocks.lower_bound(std::make_pair(file->getFilename(), offset / 4096)),
-				    g_simulator->corruptedBlocks.upper_bound(
-				        std::make_pair(file->getFilename(), (offset + length) / 4096)));
-				return res;
-			});
+			return file->write(data, length, offset);
 		});
 	}
 

--- a/fdbrpc/include/fdbrpc/AsyncFileChaos.h
+++ b/fdbrpc/include/fdbrpc/AsyncFileChaos.h
@@ -25,15 +25,18 @@
 #include "flow/IAsyncFile.h"
 #include "flow/network.h"
 #include "flow/ActorCollection.h"
+#include "fdbrpc/simulator.h"
 
 // template <class AsyncFileType>
 class AsyncFileChaos final : public IAsyncFile, public ReferenceCounted<AsyncFileChaos> {
 private:
 	Reference<IAsyncFile> file;
+	// since we have to read this often, we cache the filename here
+	std::string filename;
 	bool enabled;
 
 public:
-	explicit AsyncFileChaos(Reference<IAsyncFile> file) : file(file) {
+	explicit AsyncFileChaos(Reference<IAsyncFile> file) : file(file), filename(file->getFilename()) {
 		// We only allow chaos events on storage files
 		enabled = (file->getFilename().find("storage-") != std::string::npos);
 	}
@@ -79,6 +82,7 @@ public:
 	Future<Void> write(void const* data, int length, int64_t offset) override {
 		Arena arena;
 		char* pdata = nullptr;
+		unsigned corruptedBlock = 0;
 
 		// Check if a bit flip event was injected, if so, copy the buffer contents
 		// with a random bit flipped in a new buffer and use that for the write
@@ -91,7 +95,10 @@ public:
 					pdata = (char*)arena.allocate4kAlignedBuffer(length);
 					memcpy(pdata, data, length);
 					// flip a random bit in the copied buffer
-					pdata[deterministicRandom()->randomInt(0, length)] ^= (1 << deterministicRandom()->randomInt(0, 8));
+					auto corruptedPos = deterministicRandom()->randomInt(0, length);
+					pdata[corruptedPos] ^= (1 << deterministicRandom()->randomInt(0, 8));
+					// mark the block as corrupted
+					corruptedBlock = offset + corruptedPos / (4 * 1024);
 
 					// increment the metric for bit flips
 					auto res = g_network->global(INetwork::enChaosMetrics);
@@ -102,24 +109,27 @@ public:
 				}
 			}
 		}
+		return mapAsync<Void, std::function<Future<Void>(Void)>, Void>(delay(getDelay()), [=](Void _) -> Future<Void> {
+			if (pdata) {
+				// if (g_network->isSimulated())
+				return map(holdWhile(arena, file->write(pdata, length, offset)), [corruptedBlock, this](auto res) {
+					if (g_network->isSimulated()) {
+						g_simulator->corruptedBlocks.template emplace(filename, corruptedBlock);
+					}
+					return res;
+				});
+			}
 
-		double diskDelay = getDelay();
-		if (diskDelay == 0.0) {
-			if (pdata)
-				return holdWhile(arena, file->write(pdata, length, offset));
-
-			return file->write(data, length, offset);
-		}
-
-		// Wait for diskDelay before submitting the I/O
-		// Capture file by value in case this is destroyed during the delay
-		return mapAsync<Void, std::function<Future<Void>(Void)>, Void>(
-		    delay(diskDelay), [=, file = file](Void _) -> Future<Void> {
-			    if (pdata)
-				    return holdWhile(arena, file->write(pdata, length, offset));
-
-			    return file->write(data, length, offset);
-		    });
+			return map(file->write(data, length, offset), [this, pdata, offset, length](auto res) {
+				if (pdata != nullptr || !g_network->isSimulated()) {
+					return res;
+				}
+				g_simulator->corruptedBlocks.erase(
+				    g_simulator->corruptedBlocks.lower_bound(std::make_pair(filename, offset / 4096)),
+				    g_simulator->corruptedBlocks.upper_bound(std::make_pair(filename, (offset + length) / 4096)));
+				return res;
+			});
+ 		});
 	}
 
 	Future<Void> truncate(int64_t size) override {

--- a/fdbrpc/include/fdbrpc/AsyncFileChaos.h
+++ b/fdbrpc/include/fdbrpc/AsyncFileChaos.h
@@ -117,7 +117,7 @@ public:
 				// if (g_network->isSimulated())
 				return map(holdWhile(arena, file->write(pdata, length, offset)), [corruptedBlock, this](auto res) {
 					if (g_network->isSimulated()) {
-						g_simulator->corruptedBlocks.template emplace(file->getFilename(), corruptedBlock);
+						g_simulator->corruptedBlocks.emplace(file->getFilename(), corruptedBlock);
 					}
 					return res;
 				});

--- a/fdbrpc/include/fdbrpc/genericactors.actor.h
+++ b/fdbrpc/include/fdbrpc/genericactors.actor.h
@@ -133,7 +133,7 @@ Future<REPLY_TYPE(Req)> retryGetReplyFromHostname(Req request, Hostname hostname
 	// Like tryGetReplyFromHostname, except that request_maybe_delivered results in re-resolving the hostname.
 	// Suitable for use with hostname, where RequestStream is NOT initialized yet.
 	// Not normally useful for endpoints initialized with NetworkAddress.
-	state double reconnetInterval = FLOW_KNOBS->HOSTNAME_RECONNECT_INIT_INTERVAL;
+	state double reconnectInterval = FLOW_KNOBS->HOSTNAME_RECONNECT_INIT_INTERVAL;
 	state std::unique_ptr<RequestStream<Req>> to;
 	loop {
 		NetworkAddress address = wait(hostname.resolveWithRetry());
@@ -145,8 +145,8 @@ Future<REPLY_TYPE(Req)> retryGetReplyFromHostname(Req request, Hostname hostname
 			resetReply(request);
 			if (reply.getError().code() == error_code_request_maybe_delivered) {
 				// Connection failure.
-				wait(delay(reconnetInterval));
-				reconnetInterval = std::min(2 * reconnetInterval, FLOW_KNOBS->HOSTNAME_RECONNECT_MAX_INTERVAL);
+				wait(delay(reconnectInterval));
+				reconnectInterval = std::min(2 * reconnectInterval, FLOW_KNOBS->HOSTNAME_RECONNECT_MAX_INTERVAL);
 				INetworkConnections::net()->removeCachedDNS(hostname.host, hostname.service);
 			} else {
 				throw reply.getError();
@@ -165,7 +165,7 @@ Future<REPLY_TYPE(Req)> retryGetReplyFromHostname(Req request,
 	// Like tryGetReplyFromHostname, except that request_maybe_delivered results in re-resolving the hostname.
 	// Suitable for use with hostname, where RequestStream is NOT initialized yet.
 	// Not normally useful for endpoints initialized with NetworkAddress.
-	state double reconnetInterval = FLOW_KNOBS->HOSTNAME_RECONNECT_INIT_INTERVAL;
+	state double reconnectInitInterval = FLOW_KNOBS->HOSTNAME_RECONNECT_INIT_INTERVAL;
 	state std::unique_ptr<RequestStream<Req>> to;
 	loop {
 		NetworkAddress address = wait(hostname.resolveWithRetry());
@@ -177,8 +177,9 @@ Future<REPLY_TYPE(Req)> retryGetReplyFromHostname(Req request,
 			resetReply(request);
 			if (reply.getError().code() == error_code_request_maybe_delivered) {
 				// Connection failure.
-				wait(delay(reconnetInterval));
-				reconnetInterval = std::min(2 * reconnetInterval, FLOW_KNOBS->HOSTNAME_RECONNECT_MAX_INTERVAL);
+				wait(delay(reconnectInitInterval));
+				reconnectInitInterval =
+				    std::min(2 * reconnectInitInterval, FLOW_KNOBS->HOSTNAME_RECONNECT_MAX_INTERVAL);
 				INetworkConnections::net()->removeCachedDNS(hostname.host, hostname.service);
 			} else {
 				throw reply.getError();

--- a/fdbrpc/include/fdbrpc/simulator.h
+++ b/fdbrpc/include/fdbrpc/simulator.h
@@ -66,7 +66,6 @@ public:
 
 	// Check if any bytes in the range [begin, end) is corrupted
 	bool isByteCorruptedInRange(const std::string& fileName, const uint64_t begin, const uint64_t end) const;
-
 };
 
 class ISimulator : public INetwork {

--- a/fdbrpc/include/fdbrpc/simulator.h
+++ b/fdbrpc/include/fdbrpc/simulator.h
@@ -26,6 +26,8 @@
 #include <random>
 #include <limits>
 
+#include <boost/unordered_set.hpp>
+
 #include "flow/flow.h"
 #include "flow/Histogram.h"
 #include "flow/ProtocolVersion.h"
@@ -508,6 +510,8 @@ public:
 	double injectTargetedBWRestartTime = std::numeric_limits<double>::max();
 
 	std::unordered_map<Standalone<StringRef>, PrivateKey> authKeys;
+
+	std::set<std::pair<std::string, unsigned>> corruptedBlocks;
 
 	flowGlobalType global(int id) const final { return getCurrentProcess()->global(id); };
 	void setGlobal(size_t id, flowGlobalType v) final { getCurrentProcess()->setGlobal(id, v); };

--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -1232,13 +1232,15 @@ public:
 
 	static void runLoop(Sim2* self) {
 		ISimulator::ProcessInfo* callingMachine = self->currentProcess;
+		int lastPrintTime = 0;
 		while (!self->isStopped) {
 			if (self->taskQueue.canSleep()) {
 				double sleepTime = self->taskQueue.getSleepTime(self->time);
 				self->time +=
 				    sleepTime + FLOW_KNOBS->MAX_RUNLOOP_SLEEP_DELAY * pow(deterministicRandom()->random01(), 1000.0);
-				if (self->printSimTime) {
+				if (self->printSimTime && (int)self->time > lastPrintTime) {
 					printf("Time: %d\n", (int)self->time);
+					lastPrintTime = (int)self->time;
 				}
 				self->timerTime = std::max(self->timerTime, self->time);
 			}

--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -1351,8 +1351,7 @@ public:
 	bool isAvailable() const override {
 		std::vector<ProcessInfo*> processesLeft, processesDead;
 		for (auto processInfo : getAllProcesses()) {
-			if (processInfo->isAvailableClass() &&
-			    !processInfo->drProcess) { // Only checks availability of main cluster
+			if (processInfo->isAvailableClass()) { // Only checks availability of main cluster
 				if (processInfo->isExcluded() || processInfo->isCleared() || !processInfo->isAvailable()) {
 					processesDead.push_back(processInfo);
 				} else {
@@ -1868,7 +1867,7 @@ public:
 			int protectedWorker = 0, unavailable = 0, excluded = 0, cleared = 0;
 
 			for (auto processInfo : getAllProcesses()) {
-				if (processInfo->isAvailableClass() && processInfo->drProcess != isMainCluster) {
+				if (processInfo->isAvailableClass()) {
 					if (processInfo->isExcluded()) {
 						processesDead.push_back(processInfo);
 						excluded++;
@@ -2085,7 +2084,7 @@ public:
 		                   (kt == RebootAndDelete) || (kt == RebootProcessAndDelete))) {
 			std::vector<ProcessInfo*> processesLeft, processesDead;
 			for (auto processInfo : getAllProcesses()) {
-				if (processInfo->isAvailableClass() && !processInfo->drProcess) { // TODO: Reboot DR processes as well
+				if (processInfo->isAvailableClass()) {
 					if (processInfo->isExcluded() || processInfo->isCleared() || !processInfo->isAvailable()) {
 						processesDead.push_back(processInfo);
 					} else if (protectedAddresses.count(processInfo->address) ||

--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -789,6 +789,19 @@ private:
 				    .detail("To", self->filename)
 				    .detail("SourceCount", machineCache.count(sourceFilename))
 				    .detail("FileCount", machineCache.count(self->filename));
+				auto maxBlockValue =
+				    std::numeric_limits<decltype(g_simulator->corruptedBlocks)::key_type::second_type>::max();
+				g_simulator->corruptedBlocks.erase(
+				    g_simulator->corruptedBlocks.lower_bound(std::make_pair(sourceFilename, 0u)),
+				    g_simulator->corruptedBlocks.upper_bound(std::make_pair(self->filename, maxBlockValue)));
+				// next we need to rename all files. In practice, the number of corruptions for a given file should be
+				// very small
+				auto begin = g_simulator->corruptedBlocks.lower_bound(std::make_pair(sourceFilename, 0u)),
+				     end = g_simulator->corruptedBlocks.upper_bound(std::make_pair(sourceFilename, maxBlockValue));
+				for (auto iter = begin; iter != end; ++iter) {
+					g_simulator->corruptedBlocks.emplace(self->filename, iter->second);
+				}
+				g_simulator->corruptedBlocks.erase(begin, end);
 				renameFile(sourceFilename.c_str(), self->filename.c_str());
 
 				machineCache[self->filename] = machineCache[sourceFilename];
@@ -2735,6 +2748,20 @@ Future<Void> Sim2FileSystem::deleteFile(const std::string& filename, bool mustBe
 
 ACTOR Future<Void> renameFileImpl(std::string from, std::string to) {
 	wait(delay(0.5 * deterministicRandom()->random01()));
+	// rename all keys in the corrupted list
+	// first we have to delete all corruption of the destination, since this file will be unlinked if it exists
+	TraceEvent("RenamingFile").detail("From", from).detail("To", to).log();
+	auto maxBlockValue = std::numeric_limits<decltype(g_simulator->corruptedBlocks)::key_type::second_type>::max();
+	g_simulator->corruptedBlocks.erase(g_simulator->corruptedBlocks.lower_bound(std::make_pair(to, 0u)),
+	                                   g_simulator->corruptedBlocks.upper_bound(std::make_pair(to, maxBlockValue)));
+	// next we need to rename all files. In practice, the number of corruptions for a given file should be very small
+	auto begin = g_simulator->corruptedBlocks.lower_bound(std::make_pair(from, 0u)),
+	     end = g_simulator->corruptedBlocks.upper_bound(std::make_pair(from, maxBlockValue));
+	for (auto iter = begin; iter != end; ++iter) {
+		g_simulator->corruptedBlocks.emplace(to, iter->second);
+	}
+	g_simulator->corruptedBlocks.erase(begin, end);
+	// do the rename
 	::renameFile(from, to);
 	wait(delay(0.5 * deterministicRandom()->random01()));
 	return Void();

--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -1338,7 +1338,8 @@ public:
 	bool isAvailable() const override {
 		std::vector<ProcessInfo*> processesLeft, processesDead;
 		for (auto processInfo : getAllProcesses()) {
-			if (processInfo->isAvailableClass()) {
+			if (processInfo->isAvailableClass() &&
+			    !processInfo->drProcess) { // Only checks availability of main cluster
 				if (processInfo->isExcluded() || processInfo->isCleared() || !processInfo->isAvailable()) {
 					processesDead.push_back(processInfo);
 				} else {
@@ -1854,7 +1855,7 @@ public:
 			int protectedWorker = 0, unavailable = 0, excluded = 0, cleared = 0;
 
 			for (auto processInfo : getAllProcesses()) {
-				if (processInfo->isAvailableClass()) {
+				if (processInfo->isAvailableClass() && processInfo->drProcess != isMainCluster) {
 					if (processInfo->isExcluded()) {
 						processesDead.push_back(processInfo);
 						excluded++;
@@ -2071,7 +2072,7 @@ public:
 		                   (kt == RebootAndDelete) || (kt == RebootProcessAndDelete))) {
 			std::vector<ProcessInfo*> processesLeft, processesDead;
 			for (auto processInfo : getAllProcesses()) {
-				if (processInfo->isAvailableClass()) {
+				if (processInfo->isAvailableClass() && !processInfo->drProcess) { // TODO: Reboot DR processes as well
 					if (processInfo->isExcluded() || processInfo->isCleared() || !processInfo->isAvailable()) {
 						processesDead.push_back(processInfo);
 					} else if (protectedAddresses.count(processInfo->address) ||

--- a/fdbserver/KeyValueStoreSQLite.actor.cpp
+++ b/fdbserver/KeyValueStoreSQLite.actor.cpp
@@ -721,7 +721,7 @@ struct IntKeyCursor {
 				db.checkError("BtreeCloseCursor", sqlite3BtreeCloseCursor(cursor));
 			} catch (...) {
 			}
-			delete[] (char*)cursor;
+			delete[](char*) cursor;
 		}
 	}
 };
@@ -759,7 +759,7 @@ struct RawCursor {
 			} catch (...) {
 				TraceEvent(SevError, "RawCursorDestructionError").log();
 			}
-			delete[] (char*)cursor;
+			delete[](char*) cursor;
 		}
 	}
 	void moveFirst() {

--- a/fdbserver/KeyValueStoreSQLite.actor.cpp
+++ b/fdbserver/KeyValueStoreSQLite.actor.cpp
@@ -713,7 +713,7 @@ struct IntKeyCursor {
 				db.checkError("BtreeCloseCursor", sqlite3BtreeCloseCursor(cursor));
 			} catch (...) {
 			}
-			delete[] (char*)cursor;
+			delete[](char*) cursor;
 		}
 	}
 };
@@ -751,7 +751,7 @@ struct RawCursor {
 			} catch (...) {
 				TraceEvent(SevError, "RawCursorDestructionError").log();
 			}
-			delete[] (char*)cursor;
+			delete[](char*) cursor;
 		}
 	}
 	void moveFirst() {

--- a/fdbserver/KeyValueStoreSQLite.actor.cpp
+++ b/fdbserver/KeyValueStoreSQLite.actor.cpp
@@ -720,7 +720,7 @@ struct IntKeyCursor {
 				db.checkError("BtreeCloseCursor", sqlite3BtreeCloseCursor(cursor));
 			} catch (...) {
 			}
-			delete[](char*) cursor;
+			delete[] (char*)cursor;
 		}
 	}
 };
@@ -758,7 +758,7 @@ struct RawCursor {
 			} catch (...) {
 				TraceEvent(SevError, "RawCursorDestructionError").log();
 			}
-			delete[](char*) cursor;
+			delete[] (char*)cursor;
 		}
 	}
 	void moveFirst() {

--- a/fdbserver/KeyValueStoreSQLite.actor.cpp
+++ b/fdbserver/KeyValueStoreSQLite.actor.cpp
@@ -149,6 +149,13 @@ struct PageChecksumCodec {
 		}
 
 		if (!silent) {
+			auto severity = SevError;
+			if (g_network->isSimulated()) {
+				if (g_simulator->corruptedBlocks.count(std::make_pair(filename, pageNumber - 1))) {
+					// this corruption was caused by failure injection
+					severity = SevWarnAlways;
+				}
+			}
 			TraceEvent trEvent(SevError, "SQLitePageChecksumFailure");
 			trEvent.error(checksum_failed())
 			    .detail("CodecPageSize", pageSize)

--- a/fdbserver/KeyValueStoreSQLite.actor.cpp
+++ b/fdbserver/KeyValueStoreSQLite.actor.cpp
@@ -156,7 +156,7 @@ struct PageChecksumCodec {
 					severity = SevWarnAlways;
 				}
 			}
-			TraceEvent trEvent(SevError, "SQLitePageChecksumFailure");
+			TraceEvent trEvent(severity, "SQLitePageChecksumFailure");
 			trEvent.error(checksum_failed())
 			    .detail("CodecPageSize", pageSize)
 			    .detail("CodecReserveSize", reserveSize)

--- a/fdbserver/KeyValueStoreSQLite.actor.cpp
+++ b/fdbserver/KeyValueStoreSQLite.actor.cpp
@@ -27,7 +27,6 @@
 #include "flow/Hash3.h"
 #include "flow/xxhash.h"
 
-#include "flow/DebugPrint.h"
 // for unprintable
 #include "fdbclient/NativeAPI.actor.h"
 

--- a/fdbserver/KeyValueStoreSQLite.actor.cpp
+++ b/fdbserver/KeyValueStoreSQLite.actor.cpp
@@ -151,12 +151,18 @@ struct PageChecksumCodec {
 		if (!silent) {
 			auto severity = SevError;
 			if (g_network->isSimulated()) {
-				auto firstBlock = ((pageNumber - 1) * pageLen) / 4096, lastBlock = (pageNumber * pageLen) / 4096;
+				auto firstBlock = pageNumber == 1 ? 0 : ((pageNumber - 1) * pageLen) / 4096,
+				     lastBlock = (pageNumber * pageLen) / 4096;
 				auto iter = g_simulator->corruptedBlocks.lower_bound(std::make_pair(filename, firstBlock));
 				if (iter != g_simulator->corruptedBlocks.end() && iter->first == filename && iter->second < lastBlock) {
 					severity = SevWarnAlways;
 				}
-				TraceEvent("CheckCorruption").detail("NextFile", iter->first).detail("NextBlock", iter->second);
+				TraceEvent("CheckCorruption")
+				    .detail("Filename", filename)
+				    .detail("NextFile", iter->first)
+				    .detail("FirstBlock", firstBlock)
+				    .detail("LastBlock", lastBlock)
+				    .detail("NextBlock", iter->second);
 			}
 			TraceEvent trEvent(severity, "SQLitePageChecksumFailure");
 			trEvent.error(checksum_failed())

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -2172,6 +2172,19 @@ void setupSimulatedSystem(std::vector<Future<Void>>* systemActors,
 	}
 	deterministicRandom()->randomShuffle(coordinatorAddresses);
 
+	for (const auto& coordinators : extraCoordinatorAddresses) {
+		for (int i = 0; i < (coordinators.size() / 2) + 1; i++) {
+			TraceEvent("ProtectCoordinator")
+			    .detail("Address", coordinators[i])
+			    .detail("Coordinators", describe(coordinators));
+			g_simulator->protectedAddresses.insert(
+			    NetworkAddress(coordinators[i].ip, coordinators[i].port, true, coordinators[i].isTLS()));
+			if (coordinators[i].port == 2) {
+				g_simulator->protectedAddresses.insert(NetworkAddress(coordinators[i].ip, 1, true, true));
+			}
+		}
+	}
+
 	ASSERT_EQ(coordinatorAddresses.size(), coordinatorCount);
 	ClusterConnectionString conn(coordinatorAddresses, "TestCluster:0"_sr);
 	if (useHostname) {

--- a/fdbserver/VersionedBTree.actor.cpp
+++ b/fdbserver/VersionedBTree.actor.cpp
@@ -8136,9 +8136,9 @@ RedwoodRecordRef VersionedBTree::dbEnd("\xff\xff\xff\xff\xff"_sr);
 
 class KeyValueStoreRedwood : public IKeyValueStore {
 public:
-	KeyValueStoreRedwood(std::string filename, UID logID, Reference<IPageEncryptionKeyProvider> encryptionKeyProvider)
+	KeyValueStoreRedwood(std::string filename, UID logID_, Reference<IPageEncryptionKeyProvider> encryptionKeyProvider)
 	  : m_filename(filename), m_concurrentReads(SERVER_KNOBS->REDWOOD_KVSTORE_CONCURRENT_READS, 0),
-	    prefetch(SERVER_KNOBS->REDWOOD_KVSTORE_RANGE_PREFETCH) {
+	    prefetch(SERVER_KNOBS->REDWOOD_KVSTORE_RANGE_PREFETCH), logID(logID_) {
 
 		int pageSize =
 		    BUGGIFY ? deterministicRandom()->randomInt(1000, 4096 * 4) : SERVER_KNOBS->REDWOOD_DEFAULT_PAGE_SIZE;
@@ -8471,6 +8471,7 @@ private:
 	Version m_nextCommitVersion;
 	Reference<IPageEncryptionKeyProvider> m_keyProvider;
 	Future<Void> m_lastCommit = Void();
+	const UID logID;
 
 	template <typename T>
 	inline Future<T> catchError(Future<T> f) {

--- a/fdbserver/VersionedBTree.actor.cpp
+++ b/fdbserver/VersionedBTree.actor.cpp
@@ -1233,13 +1233,11 @@ public:
 				} catch (Error& e) {
 					bool isInjected = false;
 					if (g_network->isSimulated()) {
-						auto num4kBlocks = std::max(self->pager->getPhysicalPageSize() / 4096, 1);
-						auto startBlock = (c.pageID * self->pager->getPhysicalPageSize()) / 4096;
-						auto iter = g_simulator->corruptedBlocks.lower_bound(
-						    std::make_pair(self->pager->getName(), startBlock));
-						if (iter->first == self->pager->getName() && iter->second < startBlock + num4kBlocks) {
-							isInjected = true;
-						}
+						const auto fileName = self->pager->getName();
+						const auto physicalPageSize = self->pager->getPhysicalPageSize();
+						const auto begin = c.pageID * physicalPageSize;
+						const auto end = begin + physicalPageSize;
+						isInjected |= g_simulator->corruptedBytes.isByteCorruptedInRange(fileName, begin, end);
 					}
 					TraceEvent(isInjected ? SevWarnAlways : SevError, "RedwoodChecksumFailed")
 					    .error(e)

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -964,6 +964,11 @@ public:
 	                                      // when the disk permits
 	NotifiedVersion oldestVersion; // See also storageVersion()
 	NotifiedVersion durableVersion; // At least this version will be readable from storage after a power failure
+	// In the event of the disk corruption, sqlite and redwood will either not recover, recover to durableVersion
+	// but be unable to read some data, or they could lose the last commit. If we lose the last commit, the storage
+	// might not be able to peek from the tlog (depending on when it sent the last pop). So this version just keeps
+	// track of the version we committed to the storage engine before we did commit durableVersion.
+	Version storageMinRecoverVersion = 0;
 	Version rebootAfterDurableVersion;
 	int8_t primaryLocality;
 	NotifiedVersion knownCommittedVersion;
@@ -1377,6 +1382,7 @@ public:
 		desiredOldestVersion = ver;
 		oldestVersion = ver;
 		durableVersion = ver;
+		storageMinRecoverVersion = ver;
 		lastVersionWithData = ver;
 		restoredVersion = ver;
 
@@ -5552,6 +5558,7 @@ bool changeDurableVersion(StorageServer* data, Version desiredDurableVersion) {
 	data->freeable.erase(data->freeable.begin(), data->freeable.lower_bound(nextDurableVersion));
 
 	Future<Void> checkFatalError = data->otherError.getFuture();
+	data->storageMinRecoverVersion = data->durableVersion.get();
 	data->durableVersion.set(nextDurableVersion);
 	setDataDurableVersion(data->thisServerID, data->durableVersion.get());
 	if (checkFatalError.isReady())
@@ -9267,7 +9274,7 @@ ACTOR Future<Void> updateStorage(StorageServer* data) {
 		wait(ioTimeoutError(durable, SERVER_KNOBS->MAX_STORAGE_COMMIT_TIME));
 		data->storageCommitLatencyHistogram->sampleSeconds(now() - beforeStorageCommit);
 
-		debug_advanceMinCommittedVersion(data->thisServerID, newOldestVersion);
+		debug_advanceMinCommittedVersion(data->thisServerID, data->storageMinRecoverVersion);
 
 		if (removeKVSRanges) {
 			TraceEvent(SevDebug, "RemoveKVSRangesComitted", data->thisServerID)
@@ -9409,7 +9416,7 @@ ACTOR Future<Void> updateStorage(StorageServer* data) {
 		// loaded.
 		state double beforeSSDurableVersionUpdate = now();
 		wait(data->durableVersionLock.take());
-		data->popVersion(data->durableVersion.get() + 1);
+		data->popVersion(data->storageMinRecoverVersion + 1);
 
 		while (!changeDurableVersion(data, newOldestVersion)) {
 			if (g_network->check_yield(TaskPriority::UpdateStorage)) {
@@ -10732,7 +10739,7 @@ ACTOR Future<Void> storageServerCore(StorageServer* self, StorageServerInterface
 						}
 						self->logCursor = self->logSystem->peekSingle(
 						    self->thisServerID, self->version.get() + 1, self->tag, self->history);
-						self->popVersion(self->durableVersion.get() + 1, true);
+						self->popVersion(self->storageMinRecoverVersion + 1, true);
 					}
 					// If update() is waiting for results from the tlog, it might never get them, so needs to be
 					// cancelled.  But if it is waiting later, cancelling it could cause problems (e.g. fetchKeys

--- a/fdbserver/workloads/BlobGranuleCorrectnessWorkload.actor.cpp
+++ b/fdbserver/workloads/BlobGranuleCorrectnessWorkload.actor.cpp
@@ -248,7 +248,7 @@ struct BlobGranuleCorrectnessWorkload : TestWorkload {
 			}
 		}
 	}
-	
+
 	ACTOR Future<TenantMapEntry> setUpTenant(Database cx, TenantName name) {
 		if (BGW_DEBUG) {
 			fmt::print("Setting up blob granule range for tenant {0}\n", name.printable());

--- a/fdbserver/workloads/BlobGranuleCorrectnessWorkload.actor.cpp
+++ b/fdbserver/workloads/BlobGranuleCorrectnessWorkload.actor.cpp
@@ -249,6 +249,8 @@ struct BlobGranuleCorrectnessWorkload : TestWorkload {
 		}
 	}
 
+	void disableFailureInjectionWorkloads(std::set<std::string>& out) const override { out.insert("Attrition"); }
+
 	ACTOR Future<TenantMapEntry> setUpTenant(Database cx, TenantName name) {
 		if (BGW_DEBUG) {
 			fmt::print("Setting up blob granule range for tenant {0}\n", name.printable());

--- a/fdbserver/workloads/BlobGranuleCorrectnessWorkload.actor.cpp
+++ b/fdbserver/workloads/BlobGranuleCorrectnessWorkload.actor.cpp
@@ -248,9 +248,7 @@ struct BlobGranuleCorrectnessWorkload : TestWorkload {
 			}
 		}
 	}
-
-	void disableFailureInjectionWorkloads(std::set<std::string>& out) const override { out.insert("Attrition"); }
-
+	
 	ACTOR Future<TenantMapEntry> setUpTenant(Database cx, TenantName name) {
 		if (BGW_DEBUG) {
 			fmt::print("Setting up blob granule range for tenant {0}\n", name.printable());

--- a/fdbserver/workloads/BlobGranuleVerifier.actor.cpp
+++ b/fdbserver/workloads/BlobGranuleVerifier.actor.cpp
@@ -172,6 +172,7 @@ struct BlobGranuleVerifierWorkload : TestWorkload {
 			}
 		}
 	}
+	void disableFailureInjectionWorkloads(std::set<std::string>& out) const override { out.emplace("Attrition"); }
 
 	Future<Void> setup(Database const& cx) override { return _setup(cx, this); }
 

--- a/fdbserver/workloads/DataLossRecovery.actor.cpp
+++ b/fdbserver/workloads/DataLossRecovery.actor.cpp
@@ -62,7 +62,9 @@ struct DataLossRecoveryWorkload : TestWorkload {
 
 	Future<Void> setup(Database const& cx) override { return Void(); }
 
-	void disableFailureInjectionWorkloads(std::set<std::string>& out) const override { out.insert("RandomMoveKeys"); }
+	void disableFailureInjectionWorkloads(std::set<std::string>& out) const override {
+		out.insert({ "RandomMoveKeys", "Attrition" });
+	}
 
 	Future<Void> start(Database const& cx) override {
 		if (!enabled) {

--- a/fdbserver/workloads/FastTriggeredWatches.actor.cpp
+++ b/fdbserver/workloads/FastTriggeredWatches.actor.cpp
@@ -43,6 +43,12 @@ struct FastTriggeredWatchesWorkload : TestWorkload {
 		keyBytes = std::max(getOption(options, "keyBytes"_sr, 16), 16);
 	}
 
+	void disableFailureInjectionWorkloads(std::set<std::string>& out) const override {
+		// This test asserts that watches fire within a certain version range. Attrition will make this assertion fail
+		// since it can cause recoveries which will bump the cluster version significantly
+		out.emplace("Attrition");
+	}
+
 	Future<Void> setup(Database const& cx) override {
 		if (clientId == 0)
 			return _setup(cx, this);

--- a/fdbserver/workloads/GetMappedRange.actor.cpp
+++ b/fdbserver/workloads/GetMappedRange.actor.cpp
@@ -63,6 +63,11 @@ struct GetMappedRangeWorkload : ApiWorkload {
 		return Void();
 	}
 
+	// TODO: Currently this workload doesn't play well with MachineAttrition, but it probably should
+	void disableFailureInjectionWorkloads(std::set<std::string>& out) const override {
+		out.insert("Attrition");
+	}
+
 	ACTOR Future<Void> performSetup(Database cx, GetMappedRangeWorkload* self) {
 		std::vector<TransactionType> types;
 		types.push_back(NATIVE);

--- a/fdbserver/workloads/GetMappedRange.actor.cpp
+++ b/fdbserver/workloads/GetMappedRange.actor.cpp
@@ -61,9 +61,7 @@ struct GetMappedRangeWorkload : ApiWorkload {
 	}
 
 	// TODO: Currently this workload doesn't play well with MachineAttrition, but it probably should
-	void disableFailureInjectionWorkloads(std::set<std::string>& out) const override {
-		out.insert("Attrition");
-	}
+	void disableFailureInjectionWorkloads(std::set<std::string>& out) const override { out.insert("Attrition"); }
 
 	ACTOR Future<Void> performSetup(Database cx, GetMappedRangeWorkload* self) {
 		std::vector<TransactionType> types;

--- a/fdbserver/workloads/GetMappedRange.actor.cpp
+++ b/fdbserver/workloads/GetMappedRange.actor.cpp
@@ -18,10 +18,7 @@
  * limitations under the License.
  */
 
-#include <cstdint>
-#include <limits>
 #include <algorithm>
-#include "fdbrpc/simulator.h"
 #include "fdbclient/MutationLogReader.actor.h"
 #include "fdbclient/Tuple.h"
 #include "fdbserver/workloads/ApiWorkload.h"

--- a/fdbserver/workloads/LowLatency.actor.cpp
+++ b/fdbserver/workloads/LowLatency.actor.cpp
@@ -49,9 +49,7 @@ struct LowLatencyWorkload : TestWorkload {
 		testKey = getOption(options, "testKey"_sr, "testKey"_sr);
 	}
 
-	void disableFailureInjectionWorkloads(std::set<std::string>& out) const override {
-		out.insert("Attrition");
-	}
+	void disableFailureInjectionWorkloads(std::set<std::string>& out) const override { out.insert("Attrition"); }
 
 	Future<Void> setup(Database const& cx) override {
 		if (g_network->isSimulated()) {

--- a/fdbserver/workloads/LowLatency.actor.cpp
+++ b/fdbserver/workloads/LowLatency.actor.cpp
@@ -49,6 +49,10 @@ struct LowLatencyWorkload : TestWorkload {
 		testKey = getOption(options, "testKey"_sr, "testKey"_sr);
 	}
 
+	void disableFailureInjectionWorkloads(std::set<std::string>& out) const override {
+		out.insert("Attrition");
+	}
+
 	Future<Void> setup(Database const& cx) override {
 		if (g_network->isSimulated()) {
 			IKnobCollection::getMutableGlobalKnobCollection().setKnob("min_delay_cc_worst_fit_candidacy_seconds",

--- a/fdbserver/workloads/MachineAttrition.actor.cpp
+++ b/fdbserver/workloads/MachineAttrition.actor.cpp
@@ -474,4 +474,4 @@ struct MachineAttritionWorkload : FailureInjectionWorkload {
 
 WorkloadFactory<MachineAttritionWorkload> MachineAttritionWorkloadFactory;
 // TODO: Enable MachineAttritionWorkload injection once this is bug-free
-// FailureInjectorFactory<MachineAttritionWorkload> MachineAttritionFailureWorkloadFactory;
+FailureInjectorFactory<MachineAttritionWorkload> MachineAttritionFailureWorkloadFactory;

--- a/fdbserver/workloads/MachineAttrition.actor.cpp
+++ b/fdbserver/workloads/MachineAttrition.actor.cpp
@@ -470,4 +470,4 @@ struct MachineAttritionWorkload : FailureInjectionWorkload {
 
 WorkloadFactory<MachineAttritionWorkload> MachineAttritionWorkloadFactory;
 // TODO: Enable MachineAttritionWorkload injection once this is bug-free
-// FailureInjectorFactory<MachineAttritionWorkload> MachineAttritionFailureWorkloadFactory;
+FailureInjectorFactory<MachineAttritionWorkload> MachineAttritionFailureWorkloadFactory;

--- a/fdbserver/workloads/MachineAttrition.actor.cpp
+++ b/fdbserver/workloads/MachineAttrition.actor.cpp
@@ -474,4 +474,4 @@ struct MachineAttritionWorkload : FailureInjectionWorkload {
 
 WorkloadFactory<MachineAttritionWorkload> MachineAttritionWorkloadFactory;
 // TODO: Enable MachineAttritionWorkload injection once this is bug-free
-FailureInjectorFactory<MachineAttritionWorkload> MachineAttritionFailureWorkloadFactory;
+// FailureInjectorFactory<MachineAttritionWorkload> MachineAttritionFailureWorkloadFactory;

--- a/fdbserver/workloads/MachineAttrition.actor.cpp
+++ b/fdbserver/workloads/MachineAttrition.actor.cpp
@@ -473,5 +473,4 @@ struct MachineAttritionWorkload : FailureInjectionWorkload {
 };
 
 WorkloadFactory<MachineAttritionWorkload> MachineAttritionWorkloadFactory;
-// TODO: Enable MachineAttritionWorkload injection once this is bug-free
 FailureInjectorFactory<MachineAttritionWorkload> MachineAttritionFailureWorkloadFactory;

--- a/fdbserver/workloads/MachineAttrition.actor.cpp
+++ b/fdbserver/workloads/MachineAttrition.actor.cpp
@@ -116,6 +116,10 @@ struct MachineAttritionWorkload : FailureInjectionWorkload {
 	bool shouldInject(DeterministicRandom& random,
 	                  const WorkloadRequest& work,
 	                  const unsigned alreadyAdded) const override {
+		if (g_network->isSimulated() && !g_simulator->extraDatabases.empty()) {
+			// Remove this as soon as we track extra databases properly
+			return false;
+		}
 		return work.useDatabase && random.random01() < 1.0 / (2.0 + alreadyAdded);
 	}
 

--- a/fdbserver/workloads/PhysicalShardMove.actor.cpp
+++ b/fdbserver/workloads/PhysicalShardMove.actor.cpp
@@ -70,7 +70,10 @@ struct PhysicalShardMoveWorkLoad : TestWorkload {
 		return _start(this, cx);
 	}
 
-	void disableFailureInjectionWorkloads(std::set<std::string>& out) const override { out.insert("RandomMoveKeys"); }
+	void disableFailureInjectionWorkloads(std::set<std::string>& out) const override {
+		out.insert("RandomMoveKeys");
+		out.insert("Attrition");
+	}
 
 	ACTOR Future<Void> _start(PhysicalShardMoveWorkLoad* self, Database cx) {
 		int ignore = wait(setDDMode(cx, 0));

--- a/fdbserver/workloads/StorageServerCheckpointRestoreTest.actor.cpp
+++ b/fdbserver/workloads/StorageServerCheckpointRestoreTest.actor.cpp
@@ -66,7 +66,10 @@ struct SSCheckpointRestoreWorkload : TestWorkload {
 		return _start(this, cx);
 	}
 
-	void disableFailureInjectionWorkloads(std::set<std::string>& out) const override { out.insert("RandomMoveKeys"); }
+	void disableFailureInjectionWorkloads(std::set<std::string>& out) const override {
+		out.insert("RandomMoveKeys");
+		out.insert("Attrition");
+	}
 
 	ACTOR Future<Void> _start(SSCheckpointRestoreWorkload* self, Database cx) {
 		state Key key = "TestKey"_sr;

--- a/flow/include/flow/network.h
+++ b/flow/include/flow/network.h
@@ -29,7 +29,7 @@
 #include <stdint.h>
 #include <variant>
 #include <atomic>
-#include "boost/asio.hpp"
+#include <boost/asio.hpp>
 #include "flow/Arena.h"
 #include "flow/BooleanParam.h"
 #include "flow/IRandom.h"


### PR DESCRIPTION
This is to fix the issue that if bit flipping is injected, StorageServer backend may not recognize the error is caused by DiskFailure injector, and raise a SevError. By differentiating an injected error (which raises SevWarnAlways) and a real error
(which raises SevError), the correctness false failure should disappear.
 
# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
