### PR TITLE
Remove rare annotation from some code probes

### DIFF
--- a/fdbclient/MonitorLeader.actor.cpp
+++ b/fdbclient/MonitorLeader.actor.cpp
@@ -965,8 +965,7 @@ ACTOR Future<MonitorLeaderInfo> monitorProxiesOneGeneration(
 			allConnectionsFailed = false;
 		} else {
 			CODE_PROBE(rep.getError().code() == error_code_failed_to_progress,
-			           "Coordinator cant talk to cluster controller",
-			           probe::decoration::rare);
+			           "Coordinator cant talk to cluster controller");
 			TraceEvent("MonitorProxiesConnectFailed")
 			    .detail("Error", rep.getError().name())
 			    .detail("Coordinator", clientLeaderServer.getAddressString());

--- a/fdbclient/MonitorLeader.actor.cpp
+++ b/fdbclient/MonitorLeader.actor.cpp
@@ -965,7 +965,7 @@ ACTOR Future<MonitorLeaderInfo> monitorProxiesOneGeneration(
 			allConnectionsFailed = false;
 		} else {
 			CODE_PROBE(rep.getError().code() == error_code_failed_to_progress,
-			           "Coordinator cant talk to cluster controller");
+			           "Coordinator cannot talk to cluster controller");
 			TraceEvent("MonitorProxiesConnectFailed")
 			    .detail("Error", rep.getError().name())
 			    .detail("Coordinator", clientLeaderServer.getAddressString());

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -4813,7 +4813,7 @@ maybeDuplicateTSSStreamFragment(Request& req, QueueModel* model, RequestStream<R
 		Optional<TSSEndpointData> tssData = model->getTssData(ssStream->getEndpoint().token.first());
 
 		if (tssData.present()) {
-			CODE_PROBE(true, "duplicating stream to TSS", probe::decoration::rare);
+			CODE_PROBE(true, "duplicating stream to TSS");
 			resetReply(req);
 			// FIXME: optimize to avoid creating new netNotifiedQueueWithAcknowledgements for each stream duplication
 			RequestStream<Request> tssRequestStream(tssData.get().endpoint);

--- a/fdbrpc/TokenCache.actor.cpp
+++ b/fdbrpc/TokenCache.actor.cpp
@@ -320,7 +320,7 @@ bool TokenCacheImpl::validate(TenantNameRef name, StringRef token) {
 		}
 	}
 	if (!tenantFound) {
-		CODE_PROBE(true, "Valid token doesn't reference tenant", probe::decoration::rare);
+		CODE_PROBE(true, "Valid token doesn't reference tenant");
 		TraceEvent(SevWarn, "TenantTokenMismatch").detail("From", peer).detail("Tenant", name.toString());
 		return false;
 	}

--- a/fdbserver/GrvProxyTagThrottler.actor.cpp
+++ b/fdbserver/GrvProxyTagThrottler.actor.cpp
@@ -49,7 +49,7 @@ bool GrvProxyTagThrottler::TagQueue::isMaxThrottled(double maxThrottleDuration) 
 }
 
 void GrvProxyTagThrottler::TagQueue::rejectRequests(LatencyBandsMap& latencyBandsMap) {
-	CODE_PROBE(true, "GrvProxyTagThrottler rejecting requests", probe::decoration::rare);
+	CODE_PROBE(true, "GrvProxyTagThrottler rejecting requests");
 	while (!requests.empty()) {
 		auto& delayedReq = requests.front();
 		delayedReq.updateProxyTagThrottledDuration(latencyBandsMap);

--- a/fdbserver/MockGlobalState.actor.cpp
+++ b/fdbserver/MockGlobalState.actor.cpp
@@ -200,11 +200,11 @@ void MockStorageServer::setShardStatus(const KeyRangeRef& range, MockShardStatus
 
 	// change the old status
 	if (ranges.begin().begin() < range.begin && ranges.begin().end() > range.end) {
-		CODE_PROBE(true, "Implicitly split single shard to 3 pieces", probe::decoration::rare);
+		CODE_PROBE(true, "Implicitly split single shard to 3 pieces");
 		threeWayShardSplitting(ranges.begin().range(), range, ranges.begin().cvalue().shardSize, restrictSize);
 	} else {
 		if (ranges.begin().begin() < range.begin) {
-			CODE_PROBE(true, "Implicitly split begin range to 2 pieces", probe::decoration::rare);
+			CODE_PROBE(true, "Implicitly split begin range to 2 pieces");
 			twoWayShardSplitting(ranges.begin().range(), range.begin, ranges.begin().cvalue().shardSize, restrictSize);
 		}
 		if (ranges.end().begin() > range.end) {

--- a/fdbserver/Resolver.actor.cpp
+++ b/fdbserver/Resolver.actor.cpp
@@ -366,7 +366,7 @@ ACTOR Future<Void> resolveBatch(Reference<Resolver> self,
 				                       isEncryptionOpSupported(EncryptOperationType::TLOG_ENCRYPTION) ? &cipherKeys
 				                                                                                      : nullptr);
 			}
-			CODE_PROBE(self->forceRecovery, "Resolver detects forced recovery", probe::decoration::rare);
+			CODE_PROBE(self->forceRecovery, "Resolver detects forced recovery");
 		}
 
 		self->resolvedStateTransactions += req.txnStateTransactions.size();

--- a/fdbserver/workloads/IDDTxnProcessorApiCorrectness.actor.cpp
+++ b/fdbserver/workloads/IDDTxnProcessorApiCorrectness.actor.cpp
@@ -304,7 +304,7 @@ struct IDDTxnProcessorApiWorkload : TestWorkload {
 				self->verifyServerKeyDest(params);
 				// test finish or started but cancelled movement
 				if (self->testStartOnly || deterministicRandom()->coinflip()) {
-					CODE_PROBE(true, "RawMovementApi partial started", probe::decoration::rare);
+					CODE_PROBE(true, "RawMovementApi partial started");
 					break;
 				}
 


### PR DESCRIPTION
These code probes are now hit regularly in nightly correctness testing, so the rare annotation no longer applies to them.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
