### PR TITLE
Fix `-Wformat` warning

### DIFF
--- a/fdbrpc/HTTP.actor.cpp
+++ b/fdbrpc/HTTP.actor.cpp
@@ -481,17 +481,18 @@ ACTOR Future<Reference<HTTP::Response>> doRequest(Reference<IConnection> conn,
 		}
 
 		if (FLOW_KNOBS->HTTP_VERBOSE_LEVEL > 0) {
-			printf("[%s] HTTP %scode=%d early=%d, time=%fs %s %s contentLen=%d [%d out, response content len %lld]\n",
-			       conn->getDebugID().toString().c_str(),
-			       (err.present() ? format("*ERROR*=%s ", err.get().name()).c_str() : ""),
-			       r->code,
-			       earlyResponse,
-			       elapsed,
-			       verb.c_str(),
-			       resource.c_str(),
-			       contentLen,
-			       total_sent,
-			       r->contentLen);
+			fmt::print("[{0}] HTTP {1}code={2} early={3}, time={4} {5} {6} contentLen={7} [{8} out, response content "
+			           "len {9}]\n",
+			           conn->getDebugID().toString(),
+			           (err.present() ? format("*ERROR*=%s ", err.get().name()).c_str() : ""),
+			           r->code,
+			           earlyResponse,
+			           elapsed,
+			           verb,
+			           resource,
+			           contentLen,
+			           total_sent,
+			           r->contentLen);
 		}
 		if (FLOW_KNOBS->HTTP_VERBOSE_LEVEL > 2) {
 			printf("[%s] HTTP RESPONSE:  %s %s\n%s\n",


### PR DESCRIPTION
This PR resolves a `-Wformat` warning from `HTTP.actor.cpp` by using `fmt::print` instead of `printf`.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
