### PR TITLE
BlobRestore - only fetch keys from blob storage for those are restoring

### DIFF
--- a/fdbserver/include/fdbserver/BlobGranuleServerCommon.actor.h
+++ b/fdbserver/include/fdbserver/BlobGranuleServerCommon.actor.h
@@ -164,6 +164,7 @@ ACTOR Future<BlobGranuleRestoreVersionVector> listBlobGranules(Database db, Refe
 ACTOR Future<int64_t> lastBlobEpoc(Database db, Reference<BlobConnectionProvider> blobConn);
 ACTOR Future<bool> isFullRestoreMode(Database db, KeyRangeRef range);
 ACTOR Future<Void> updateRestoreStatus(Database db, KeyRangeRef range, BlobRestoreStatus status);
+ACTOR Future<KeyRange> getRestoringRange(Database db, KeyRangeRef keys);
 ACTOR Future<Optional<BlobRestoreStatus>> getRestoreStatus(Database db, KeyRangeRef range);
 #include "flow/unactorcompiler.h"
 

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -7139,7 +7139,8 @@ ACTOR Future<Void> fetchKeys(StorageServer* data, AddingShard* shard) {
 			state PromiseStream<RangeResult> results;
 			state Future<Void> hold;
 			if (isFullRestore) {
-				hold = tryGetRangeFromBlob(results, &tr, keys, fetchVersion, data->blobConn);
+				KeyRange range = wait(getRestoringRange(data->cx, keys));
+				hold = tryGetRangeFromBlob(results, &tr, range, fetchVersion, data->blobConn);
 			} else {
 				hold = tryGetRange(results, &tr, keys);
 			}


### PR DESCRIPTION
It's a fix for an edge case. FetchKeys may get a continuous key range which includes blobfied and non-blobfied ranges. If we pass the whole range to blob workers, It causes failures when reading from blob storage. So the fix is to only fetch keys for restoring ranges. Others will be handled in next fetch key request. 


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
