### PR TITLE
Clarify WITH_AWS_BACKUP vs BUILD_AWS_BACKUP and re-enable aws sdk with arm (snowflake/release-71.2)

### DIFF
--- a/cmake/FDBComponents.cmake
+++ b/cmake/FDBComponents.cmake
@@ -229,12 +229,7 @@ set(COROUTINE_IMPL ${DEFAULT_COROUTINE_IMPL} CACHE STRING "Which coroutine imple
 
 set(BUILD_AWS_BACKUP OFF CACHE BOOL "Build AWS S3 SDK backup client")
 if (BUILD_AWS_BACKUP)
-  if (CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
-    set(WITH_AWS_BACKUP ON)
-  else()
-    message(WARNING "BUILD_AWS_BACKUP set but ignored ${CMAKE_SYSTEM_PROCESSOR} is not supported yet")
-    set(WITH_AWS_BACKUP OFF)
-  endif()
+  set(WITH_AWS_BACKUP ON)
 else()
   set(WITH_AWS_BACKUP OFF)
 endif()

--- a/fdbclient/CMakeLists.txt
+++ b/fdbclient/CMakeLists.txt
@@ -64,7 +64,7 @@ endif()
 
 
 if(WITH_AWS_BACKUP)
-  add_compile_definitions(BUILD_AWS_BACKUP)
+  add_compile_definitions(WITH_AWS_BACKUP)
   include(awssdk)
 endif()
 

--- a/fdbclient/FDBAWSCredentialsProvider.cpp
+++ b/fdbclient/FDBAWSCredentialsProvider.cpp
@@ -22,7 +22,7 @@
 #include "fdbclient/FDBAWSCredentialsProvider.h"
 #include "fdbclient/Tracing.h"
 
-#ifdef BUILD_AWS_BACKUP
+#ifdef WITH_AWS_BACKUP
 
 // You're supposed to call AWS::ShutdownAPI(options); once done
 // But we want this to live for the lifetime of the process, so we don't do that

--- a/fdbclient/include/fdbclient/FDBAWSCredentialsProvider.h
+++ b/fdbclient/include/fdbclient/FDBAWSCredentialsProvider.h
@@ -18,11 +18,11 @@
  * limitations under the License.
  */
 
-#if (!defined FDB_AWS_CREDENTIALS_PROVIDER_H) && (defined BUILD_AWS_BACKUP)
+#if (!defined FDB_AWS_CREDENTIALS_PROVIDER_H) && (defined WITH_AWS_BACKUP)
 #define FDB_AWS_CREDENTIALS_PROVIDER_H
 #pragma once
 
-#ifdef BUILD_AWS_BACKUP
+#ifdef WITH_AWS_BACKUP
 
 #include "aws/core/Aws.h"
 #include "aws/core/auth/AWSCredentialsProviderChain.h"


### PR DESCRIPTION
Cherry pick https://github.com/apple/foundationdb/pull/8426 to snowflake/release-71.2



- Use WITH_AWS_BACKUP instead of BUILD_AWS_BACKUP
- Re-enable aws sdk + arm

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
