### PR TITLE
ddsketch: Fix undefined behaviour in DDSketch::getValue

### DIFF
--- a/fdbrpc/DDSketchTest.actor.cpp
+++ b/fdbrpc/DDSketchTest.actor.cpp
@@ -43,9 +43,8 @@ TEST_CASE("/fdbrpc/ddsketch/correctness") {
 	DDSketch<double> dd;
 
 	for (int i = 0; i < 4000; i++) {
-		// This generates a uniform real disitribution between the range of
-		// [0.0004, 0.01]
-		double sample = (static_cast<double>(deterministicRandom()->randomSkewedUInt32(40, 1000)) / 100000);
+		// The samples should be on the smaller end
+		double sample = deterministicRandom()->random01() * 0.004;
 		dd.addSample(sample);
 	}
 	double p50 = dd.percentile(0.5);


### PR DESCRIPTION
There was unsigned integer underflow occuring in DDSketch::getValue, resulting in percentile sometimes returning `inf` as a value.

This PR adds an additional unit test to ensure that no `inf` values are present in `percentile`.


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
