### PR TITLE
Properly generate operations with the _TENANT suffix

### DIFF
--- a/bindings/bindingtester/tests/api.py
+++ b/bindings/bindingtester/tests/api.py
@@ -35,6 +35,7 @@ fdb.api_version(FDB_API_VERSION)
 def matches_op(op, target_op):
     return op == target_op or op == target_op + '_SNAPSHOT' or op == target_op + '_DATABASE' or op == target_op + '_TENANT'
 
+
 def is_non_transaction_op(op):
     return op.endswith('_DATABASE') or op.endswith('_TENANT')
 

--- a/bindings/python/fdb/impl.py
+++ b/bindings/python/fdb/impl.py
@@ -166,6 +166,7 @@ def add_operation(fname, v):
     )
     setattr(globals()["Database"], fname, f)
     setattr(globals()["Transaction"], fname, f)
+    setattr(globals()["Tenant"], fname, f)
 
 
 def fill_operations():

--- a/bindings/python/tests/tester.py
+++ b/bindings/python/tests/tester.py
@@ -453,7 +453,7 @@ class Tester:
                     else:
                         obj.set(key, value)
 
-                    if obj == self.db:
+                    if isDatabase or isTenant:
                         inst.push(b"RESULT_NOT_PRESENT")
                 elif inst.op == six.u("LOG_STACK"):
                     prefix = inst.pop()
@@ -470,7 +470,7 @@ class Tester:
                     opType, key, value = inst.pop(3)
                     getattr(obj, opType.lower())(key, value)
 
-                    if obj == self.db:
+                    if isDatabase or isTenant:
                         inst.push(b"RESULT_NOT_PRESENT")
                 elif inst.op == six.u("SET_READ_VERSION"):
                     inst.tr.set_read_version(self.last_version)
@@ -480,7 +480,7 @@ class Tester:
                     else:
                         obj.clear(inst.pop())
 
-                    if obj == self.db:
+                    if isDatabase or isTenant:
                         inst.push(b"RESULT_NOT_PRESENT")
                 elif inst.op == six.u("CLEAR_RANGE"):
                     begin, end = inst.pop(2)
@@ -492,11 +492,11 @@ class Tester:
                     else:
                         obj.__delitem__(slice(begin, end))
 
-                    if obj == self.db:
+                    if isDatabase or isTenant:
                         inst.push(b"RESULT_NOT_PRESENT")
                 elif inst.op == six.u("CLEAR_RANGE_STARTS_WITH"):
                     obj.clear_range_startswith(inst.pop())
-                    if obj == self.db:
+                    if isDatabase or isTenant:
                         inst.push(b"RESULT_NOT_PRESENT")
                 elif inst.op == six.u("READ_CONFLICT_RANGE"):
                     inst.tr.add_read_conflict_range(inst.pop(), inst.pop())

--- a/cmake/AddFdbTest.cmake
+++ b/cmake/AddFdbTest.cmake
@@ -441,6 +441,7 @@ function(package_bindingtester)
     add_custom_command(
       TARGET copy_binding_output_files
       COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/bindings/go/bin/_stacktester ${bdir}/tests/go/build/bin/_stacktester
+      COMMAND ${CMAKE_COMMAND} -E make_directory ${bdir}/tests/go/src/fdb/
       COMMAND ${CMAKE_COMMAND} -E copy
         ${CMAKE_BINARY_DIR}/bindings/go/src/github.com/apple/foundationdb/bindings/go/src/fdb/generated.go # SRC
         ${bdir}/tests/go/src/fdb/ # DEST


### PR DESCRIPTION
The binding tester was not properly handling operations that had the _TENANT suffix. This fixes that problem and a few related bugs.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
