### PR TITLE
boundaryAndExist needs to be in the end of memory layout

### DIFF
--- a/bindings/java/fdbJNI.cpp
+++ b/bindings/java/fdbJNI.cpp
@@ -663,12 +663,12 @@ JNIEXPORT jobject JNICALL Java_com_apple_foundationdb_FutureMappedResults_Future
 				cpBytesAndLength(pByte, pLength, kvm.value);
 				cpBytesAndLength(pByte, pLength, kvm.getRange.begin.key);
 				cpBytesAndLength(pByte, pLength, kvm.getRange.end.key);
-				cpBytesAndLengthInner(pByte, pLength, (uint8_t*)&(kvm.boundaryAndExist), sizeof(kvm.boundaryAndExist));
 				for (int kvm_i = 0; kvm_i < kvm_count; kvm_i++) {
 					auto kv = kvm.getRange.data[kvm_i];
 					cpBytesAndLengthInner(pByte, pLength, kv.key, kv.key_length);
 					cpBytesAndLengthInner(pByte, pLength, kv.value, kv.value_length);
 				}
+				cpBytesAndLengthInner(pByte, pLength, (uint8_t*)&(kvm.boundaryAndExist), sizeof(kvm.boundaryAndExist));
 			}
 		}
 		// After native arrays are released

--- a/bindings/java/src/integration/com/apple/foundationdb/MultiClientHelper.java
+++ b/bindings/java/src/integration/com/apple/foundationdb/MultiClientHelper.java
@@ -38,7 +38,7 @@ public class MultiClientHelper implements BeforeAllCallback,AfterEachCallback{
 		 * Reads the cluster file lists from the ENV variable
 		 * FDB_CLUSTERS.
 		 */
-		String clusterFilesProp = System.getenv("FDB_CLUSTERS");
+		String clusterFilesProp = System.getenv("FDB_CLUSTER_FILE");
 		if (clusterFilesProp == null) {
 			throw new IllegalStateException("Missing FDB cluster connection file names");
 		}

--- a/bindings/java/src/main/com/apple/foundationdb/MappedKeyValue.java
+++ b/bindings/java/src/main/com/apple/foundationdb/MappedKeyValue.java
@@ -69,9 +69,6 @@ public class MappedKeyValue extends KeyValue {
 		byte[] value = takeBytes(offset, bytes, lengths);
 		byte[] rangeBegin = takeBytes(offset, bytes, lengths);
 		byte[] rangeEnd = takeBytes(offset, bytes, lengths);
-		byte[] boundaryAndExistBytes = takeBytes(offset, bytes, lengths);
-		int boundaryAndExist = ByteBuffer.wrap(boundaryAndExistBytes).order(ByteOrder.LITTLE_ENDIAN).getInt();
-
 		if ((lengths.length - TOTAL_SERIALIZED_FIELD_FDBMappedKeyValue) % 2 != 0) {
 			throw new IllegalArgumentException("There needs to be an even number of lengths!");
 		}
@@ -82,6 +79,8 @@ public class MappedKeyValue extends KeyValue {
 			byte[] v = takeBytes(offset, bytes, lengths);
 			rangeResult.add(new KeyValue(k, v));
 		}
+		byte[] boundaryAndExistBytes = takeBytes(offset, bytes, lengths);
+		int boundaryAndExist = ByteBuffer.wrap(boundaryAndExistBytes).order(ByteOrder.LITTLE_ENDIAN).getInt();
 		return new MappedKeyValue(key, value, rangeBegin, rangeEnd, rangeResult, boundaryAndExist);
 	}
 

--- a/bindings/java/src/main/com/apple/foundationdb/MappedRangeResultDirectBufferIterator.java
+++ b/bindings/java/src/main/com/apple/foundationdb/MappedRangeResultDirectBufferIterator.java
@@ -51,8 +51,6 @@ class MappedRangeResultDirectBufferIterator extends DirectBufferIterator impleme
 		final byte[] value = getString();
 		final byte[] rangeBegin = getString();
 		final byte[] rangeEnd = getString();
-		final byte[] boundaryAndExistBytes = getString();
-		final int boundaryAndExist = ByteBuffer.wrap(boundaryAndExistBytes).getInt();
 		final int rangeResultSize = byteBuffer.getInt();
 		List<KeyValue> rangeResult = new ArrayList();
 		for (int i = 0; i < rangeResultSize; i++) {
@@ -60,6 +58,8 @@ class MappedRangeResultDirectBufferIterator extends DirectBufferIterator impleme
 			final byte[] v = getString();
 			rangeResult.add(new KeyValue(k, v));
 		}
+		final byte[] boundaryAndExistBytes = getString();
+		final int boundaryAndExist = ByteBuffer.wrap(boundaryAndExistBytes).getInt();
 		current += 1;
 		return new MappedKeyValue(key, value, rangeBegin, rangeEnd, rangeResult, boundaryAndExist);
 	}

--- a/tests/TestRunner/tmp_multi_cluster.py
+++ b/tests/TestRunner/tmp_multi_cluster.py
@@ -80,7 +80,7 @@ if __name__ == "__main__":
     )
     print(cluster_paths)
     env = dict(**os.environ)
-    env["FDB_CLUSTERS"] = env.get("FDB_CLUSTERS", cluster_paths)
+    env["FDB_CLUSTER_FILE"] = env.get("FDB_CLUSTER_FILE", cluster_paths)
     errcode = subprocess.run(
         args.cmd, stdout=sys.stdout, stderr=sys.stderr, env=env
     ).returncode


### PR DESCRIPTION
Otherwise older client might fail to deserialize the data structure.

This change also fixes FDB cluster env variable.

https://github.com/FoundationDB/fdb-kubernetes-tests/blob/main/tests/fixtures/multithread_client_fixture.go#L81 also needs to be fixed

Replace this text with your description here...

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
