### PR TITLE
Avoid race between `ConfigNodeImpl::getChanges` and `ConfigNodeImpl::commitMutations`

### DIFF
--- a/fdbserver/ConfigNode.actor.cpp
+++ b/fdbserver/ConfigNode.actor.cpp
@@ -113,6 +113,7 @@ TEST_CASE("/fdbserver/ConfigDB/ConfigNode/Internal/versionedMutationKeyOrdering"
 
 class ConfigNodeImpl {
 	UID id;
+	FlowLock lock;
 	OnDemandStore kvStore;
 	CounterCollection cc;
 
@@ -218,6 +219,8 @@ class ConfigNodeImpl {
 	}
 
 	ACTOR static Future<Void> getChanges(ConfigNodeImpl* self, ConfigFollowerGetChangesRequest req) {
+		wait(self->lock.take());
+		state FlowLock::Releaser releaser(self->lock);
 		Version lastCompactedVersion = wait(getLastCompactedVersion(self));
 		if (req.lastSeenVersion < lastCompactedVersion) {
 			++self->failedChangeRequests;
@@ -413,6 +416,8 @@ class ConfigNodeImpl {
 	                                          Standalone<VectorRef<VersionedConfigCommitAnnotationRef>> annotations,
 	                                          Version commitVersion,
 	                                          Version liveVersion = ::invalidVersion) {
+		wait(self->lock.take());
+		state FlowLock::Releaser releaser(self->lock);
 		Version latestVersion = 0;
 		int index = 0;
 		for (const auto& mutation : mutations) {

--- a/fdbserver/SimpleConfigConsumer.actor.cpp
+++ b/fdbserver/SimpleConfigConsumer.actor.cpp
@@ -111,6 +111,8 @@ class SimpleConfigConsumerImpl {
 				if (e.code() == error_code_version_already_compacted) {
 					CODE_PROBE(true, "SimpleConfigConsumer get version_already_compacted error");
 					wait(getSnapshotAndChanges(self, broadcaster));
+				} else if (e.code() == error_code_broken_promise) {
+					CODE_PROBE(true, "SimpleConfigConsumer::fetchChanges retrying on broken promise");
 				} else {
 					throw e;
 				}


### PR DESCRIPTION
This PR adds a `FlowLock` to `ConfigNodeImpl`, to fix a potential race condition when `commitMutations` and `getChanges` are accessing the on-disk state concurrently. This fixes several correctness failures we've seen in nightly testing. The PR also changes `SimpleConfigConsumerImpl::fetchChanges` to retry `broken_promise` errors.

Replace this text with your description here...

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
