### PR TITLE
Mako: Timeout Support on Transaction Level

### DIFF
--- a/bindings/c/test/mako/async.cpp
+++ b/bindings/c/test/mako/async.cpp
@@ -74,8 +74,8 @@ void ResumableStateForPopulate::runOneTick() {
 					stats.incrOpCount(OP_COMMIT);
 					stats.incrOpCount(OP_TRANSACTION);
 					tx.reset();
-					if (args.transaction_timeout_txn > 0) {
-						tx.setOption(FDB_TR_OPTION_TIMEOUT, args.transaction_timeout_txn);
+					if (args.transaction_timeout_tx > 0) {
+						tx.setOption(FDB_TR_OPTION_TIMEOUT, args.transaction_timeout_tx);
 					}
 					watch_tx.startFromStop();
 					key_checkpoint = i + 1;
@@ -140,7 +140,7 @@ repeat_immediate_steps:
 						    handleForOnError(tx,
 						                     f,
 						                     fmt::format("{}:{}", iter.opName(), iter.step),
-						                     args.transaction_timeout_txn > 0 || args.transaction_timeout_db > 0);
+						                     args.transaction_timeout_tx > 0 || args.transaction_timeout_db > 0);
 						onIterationEnd(rc);
 					});
 				} else {
@@ -157,7 +157,7 @@ repeat_immediate_steps:
 				// blob granules op error
 				updateErrorStats(f.error(), iter.op);
 				FutureRC rc = handleForOnError(
-				    tx, f, "BG_ON_ERROR", args.transaction_timeout_txn > 0 || args.transaction_timeout_db > 0);
+				    tx, f, "BG_ON_ERROR", args.transaction_timeout_tx > 0 || args.transaction_timeout_db > 0);
 				onIterationEnd(rc);
 			}
 		});
@@ -176,8 +176,8 @@ void ResumableStateForRunWorkload::updateStepStats() {
 			stats.addLatency(OP_COMMIT, step_latency);
 		}
 		tx.reset();
-		if (args.transaction_timeout_txn > 0) {
-			tx.setOption(FDB_TR_OPTION_TIMEOUT, args.transaction_timeout_txn);
+		if (args.transaction_timeout_tx > 0) {
+			tx.setOption(FDB_TR_OPTION_TIMEOUT, args.transaction_timeout_tx);
 		}
 		stats.incrOpCount(OP_COMMIT);
 		needs_commit = false;
@@ -209,7 +209,7 @@ void ResumableStateForRunWorkload::onTransactionSuccess() {
 				updateErrorStats(err, OP_COMMIT);
 				tx.onError(err).then([this, state = shared_from_this()](Future f) {
 					const auto rc = handleForOnError(
-					    tx, f, "ON_ERROR", args.transaction_timeout_txn > 0 || args.transaction_timeout_db > 0);
+					    tx, f, "ON_ERROR", args.transaction_timeout_tx > 0 || args.transaction_timeout_db > 0);
 					onIterationEnd(rc);
 				});
 			} else {
@@ -225,8 +225,8 @@ void ResumableStateForRunWorkload::onTransactionSuccess() {
 				stats.incrOpCount(OP_COMMIT);
 				stats.incrOpCount(OP_TRANSACTION);
 				tx.reset();
-				if (args.transaction_timeout_txn > 0) {
-					tx.setOption(FDB_TR_OPTION_TIMEOUT, args.transaction_timeout_txn);
+				if (args.transaction_timeout_tx > 0) {
+					tx.setOption(FDB_TR_OPTION_TIMEOUT, args.transaction_timeout_tx);
 				}
 				watch_tx.startFromStop();
 				onIterationEnd(FutureRC::OK);
@@ -242,8 +242,8 @@ void ResumableStateForRunWorkload::onTransactionSuccess() {
 		stats.incrOpCount(OP_TRANSACTION);
 		watch_tx.startFromStop();
 		tx.reset();
-		if (args.transaction_timeout_txn > 0) {
-			tx.setOption(FDB_TR_OPTION_TIMEOUT, args.transaction_timeout_txn);
+		if (args.transaction_timeout_tx > 0) {
+			tx.setOption(FDB_TR_OPTION_TIMEOUT, args.transaction_timeout_tx);
 		}
 		onIterationEnd(FutureRC::OK);
 	}
@@ -275,7 +275,7 @@ void ResumableStateForRunWorkload::updateErrorStats(fdb::Error err, int op) {
 }
 bool ResumableStateForRunWorkload::isExpectedError(fdb::Error err) {
 	return err.retryable() ||
-	       ((args.transaction_timeout_txn > 0 || args.transaction_timeout_db > 0) && err.is(1031 /*timeout*/));
+	       ((args.transaction_timeout_tx > 0 || args.transaction_timeout_db > 0) && err.is(1031 /*timeout*/));
 }
 
 } // namespace mako

--- a/bindings/c/test/mako/async.cpp
+++ b/bindings/c/test/mako/async.cpp
@@ -74,9 +74,7 @@ void ResumableStateForPopulate::runOneTick() {
 					stats.incrOpCount(OP_COMMIT);
 					stats.incrOpCount(OP_TRANSACTION);
 					tx.reset();
-					if (args.transaction_timeout_tx > 0) {
-						tx.setOption(FDB_TR_OPTION_TIMEOUT, args.transaction_timeout_tx);
-					}
+					args.setTransactionTimeoutIfEnabled(tx);
 					watch_tx.startFromStop();
 					key_checkpoint = i + 1;
 					if (i != key_end) {
@@ -136,11 +134,8 @@ repeat_immediate_steps:
 					                       err.what());
 					updateErrorStats(err, iter.op);
 					tx.onError(err).then([this, state = shared_from_this()](Future f) {
-						const auto rc =
-						    handleForOnError(tx,
-						                     f,
-						                     fmt::format("{}:{}", iter.opName(), iter.step),
-						                     args.transaction_timeout_tx > 0 || args.transaction_timeout_db > 0);
+						const auto rc = handleForOnError(
+						    tx, f, fmt::format("{}:{}", iter.opName(), iter.step), args.isAnyTimeoutEnabled());
 						onIterationEnd(rc);
 					});
 				} else {
@@ -156,8 +151,7 @@ repeat_immediate_steps:
 			} else {
 				// blob granules op error
 				updateErrorStats(f.error(), iter.op);
-				FutureRC rc = handleForOnError(
-				    tx, f, "BG_ON_ERROR", args.transaction_timeout_tx > 0 || args.transaction_timeout_db > 0);
+				FutureRC rc = handleForOnError(tx, f, "BG_ON_ERROR", args.isAnyTimeoutEnabled());
 				onIterationEnd(rc);
 			}
 		});
@@ -176,9 +170,7 @@ void ResumableStateForRunWorkload::updateStepStats() {
 			stats.addLatency(OP_COMMIT, step_latency);
 		}
 		tx.reset();
-		if (args.transaction_timeout_tx > 0) {
-			tx.setOption(FDB_TR_OPTION_TIMEOUT, args.transaction_timeout_tx);
-		}
+		args.setTransactionTimeoutIfEnabled(tx);
 		stats.incrOpCount(OP_COMMIT);
 		needs_commit = false;
 	}
@@ -208,8 +200,7 @@ void ResumableStateForRunWorkload::onTransactionSuccess() {
 				                       err.what());
 				updateErrorStats(err, OP_COMMIT);
 				tx.onError(err).then([this, state = shared_from_this()](Future f) {
-					const auto rc = handleForOnError(
-					    tx, f, "ON_ERROR", args.transaction_timeout_tx > 0 || args.transaction_timeout_db > 0);
+					const auto rc = handleForOnError(tx, f, "ON_ERROR", args.isAnyTimeoutEnabled());
 					onIterationEnd(rc);
 				});
 			} else {
@@ -225,9 +216,7 @@ void ResumableStateForRunWorkload::onTransactionSuccess() {
 				stats.incrOpCount(OP_COMMIT);
 				stats.incrOpCount(OP_TRANSACTION);
 				tx.reset();
-				if (args.transaction_timeout_tx > 0) {
-					tx.setOption(FDB_TR_OPTION_TIMEOUT, args.transaction_timeout_tx);
-				}
+				args.setTransactionTimeoutIfEnabled(tx);
 				watch_tx.startFromStop();
 				onIterationEnd(FutureRC::OK);
 			}
@@ -242,9 +231,7 @@ void ResumableStateForRunWorkload::onTransactionSuccess() {
 		stats.incrOpCount(OP_TRANSACTION);
 		watch_tx.startFromStop();
 		tx.reset();
-		if (args.transaction_timeout_tx > 0) {
-			tx.setOption(FDB_TR_OPTION_TIMEOUT, args.transaction_timeout_tx);
-		}
+		args.setTransactionTimeoutIfEnabled(tx);
 		onIterationEnd(FutureRC::OK);
 	}
 }
@@ -274,8 +261,7 @@ void ResumableStateForRunWorkload::updateErrorStats(fdb::Error err, int op) {
 	}
 }
 bool ResumableStateForRunWorkload::isExpectedError(fdb::Error err) {
-	return err.retryable() ||
-	       ((args.transaction_timeout_tx > 0 || args.transaction_timeout_db > 0) && err.is(1031 /*timeout*/));
+	return err.retryable() || (args.isAnyTimeoutEnabled() && err.is(1031 /*timeout*/));
 }
 
 } // namespace mako

--- a/bindings/c/test/mako/async.cpp
+++ b/bindings/c/test/mako/async.cpp
@@ -74,7 +74,7 @@ void ResumableStateForPopulate::runOneTick() {
 					stats.incrOpCount(OP_COMMIT);
 					stats.incrOpCount(OP_TRANSACTION);
 					tx.reset();
-					args.setTransactionTimeoutIfEnabled(tx);
+					setTransactionTimeoutIfEnabled(args, tx);
 					watch_tx.startFromStop();
 					key_checkpoint = i + 1;
 					if (i != key_end) {
@@ -170,7 +170,7 @@ void ResumableStateForRunWorkload::updateStepStats() {
 			stats.addLatency(OP_COMMIT, step_latency);
 		}
 		tx.reset();
-		args.setTransactionTimeoutIfEnabled(tx);
+		setTransactionTimeoutIfEnabled(args, tx);
 		stats.incrOpCount(OP_COMMIT);
 		needs_commit = false;
 	}
@@ -216,7 +216,7 @@ void ResumableStateForRunWorkload::onTransactionSuccess() {
 				stats.incrOpCount(OP_COMMIT);
 				stats.incrOpCount(OP_TRANSACTION);
 				tx.reset();
-				args.setTransactionTimeoutIfEnabled(tx);
+				setTransactionTimeoutIfEnabled(args, tx);
 				watch_tx.startFromStop();
 				onIterationEnd(FutureRC::OK);
 			}
@@ -231,7 +231,7 @@ void ResumableStateForRunWorkload::onTransactionSuccess() {
 		stats.incrOpCount(OP_TRANSACTION);
 		watch_tx.startFromStop();
 		tx.reset();
-		args.setTransactionTimeoutIfEnabled(tx);
+		setTransactionTimeoutIfEnabled(args, tx);
 		onIterationEnd(FutureRC::OK);
 	}
 }

--- a/bindings/c/test/mako/async.hpp
+++ b/bindings/c/test/mako/async.hpp
@@ -109,7 +109,7 @@ struct ResumableStateForRunWorkload : std::enable_shared_from_this<ResumableStat
 		key1.resize(args.key_length);
 		key2.resize(args.key_length);
 		val.resize(args.value_length);
-		args.setTransactionTimeoutIfEnabled(tx);
+		setTransactionTimeoutIfEnabled(args, tx);
 	}
 	void signalEnd() noexcept { stopcount.fetch_add(1); }
 	bool ended() noexcept { return (max_iters != -1 && total_xacts >= max_iters) || signal.load() == SIGNAL_RED; }

--- a/bindings/c/test/mako/async.hpp
+++ b/bindings/c/test/mako/async.hpp
@@ -109,8 +109,8 @@ struct ResumableStateForRunWorkload : std::enable_shared_from_this<ResumableStat
 		key1.resize(args.key_length);
 		key2.resize(args.key_length);
 		val.resize(args.value_length);
-		if (args.transaction_timeout_txn > 0) {
-			tx.setOption(FDB_TR_OPTION_TIMEOUT, args.transaction_timeout_txn);
+		if (args.transaction_timeout_tx > 0) {
+			tx.setOption(FDB_TR_OPTION_TIMEOUT, args.transaction_timeout_tx);
 		}
 	}
 	void signalEnd() noexcept { stopcount.fetch_add(1); }

--- a/bindings/c/test/mako/async.hpp
+++ b/bindings/c/test/mako/async.hpp
@@ -109,9 +109,7 @@ struct ResumableStateForRunWorkload : std::enable_shared_from_this<ResumableStat
 		key1.resize(args.key_length);
 		key2.resize(args.key_length);
 		val.resize(args.value_length);
-		if (args.transaction_timeout_tx > 0) {
-			tx.setOption(FDB_TR_OPTION_TIMEOUT, args.transaction_timeout_tx);
-		}
+		args.setTransactionTimeoutIfEnabled(tx);
 	}
 	void signalEnd() noexcept { stopcount.fetch_add(1); }
 	bool ended() noexcept { return (max_iters != -1 && total_xacts >= max_iters) || signal.load() == SIGNAL_RED; }

--- a/bindings/c/test/mako/async.hpp
+++ b/bindings/c/test/mako/async.hpp
@@ -109,6 +109,9 @@ struct ResumableStateForRunWorkload : std::enable_shared_from_this<ResumableStat
 		key1.resize(args.key_length);
 		key2.resize(args.key_length);
 		val.resize(args.value_length);
+		if (args.transaction_timeout_txn > 0) {
+			tx.setOption(FDB_TR_OPTION_TIMEOUT, args.transaction_timeout_txn);
+		}
 	}
 	void signalEnd() noexcept { stopcount.fetch_add(1); }
 	bool ended() noexcept { return (max_iters != -1 && total_xacts >= max_iters) || signal.load() == SIGNAL_RED; }

--- a/bindings/c/test/mako/mako.cpp
+++ b/bindings/c/test/mako/mako.cpp
@@ -496,9 +496,11 @@ transaction_begin:
 		auto future_rc = FutureRC::OK;
 		if (f) {
 			if (step_kind != StepKind::ON_ERROR) {
-				future_rc = waitAndHandleError(tx, f, opTable[op].name(), args.transaction_timeout > 0);
+				future_rc = waitAndHandleError(
+				    tx, f, opTable[op].name(), args.transaction_timeout_txn > 0 || args.transaction_timeout_db > 0);
 			} else {
-				future_rc = waitAndHandleForOnError(tx, f, opTable[op].name(), args.transaction_timeout > 0);
+				future_rc = waitAndHandleForOnError(
+				    tx, f, opTable[op].name(), args.transaction_timeout_txn > 0 || args.transaction_timeout_db > 0);
 			}
 			updateErrorStatsRunMode(stats, f.error(), op);
 		}
@@ -544,7 +546,8 @@ transaction_begin:
 	if (needs_commit || args.commit_get) {
 		auto watch_commit = Stopwatch(StartAtCtor{});
 		auto f = tx.commit();
-		const auto rc = waitAndHandleError(tx, f, "COMMIT_AT_TX_END", args.transaction_timeout > 0);
+		const auto rc = waitAndHandleError(
+		    tx, f, "COMMIT_AT_TX_END", args.transaction_timeout_txn > 0 || args.transaction_timeout_db > 0);
 		updateErrorStatsRunMode(stats, f.error(), OP_COMMIT);
 		watch_commit.stop();
 		auto tx_resetter = ExitGuard([&tx]() { tx.reset(); });
@@ -639,6 +642,9 @@ int runWorkload(Database db,
 
 		if (current_tps > 0 || thread_tps == 0 /* throttling off */) {
 			Transaction tx = createNewTransaction(db, args, -1, args.active_tenants > 0 ? tenants : nullptr);
+			if (args.transaction_timeout_txn > 0) {
+				tx.setOption(FDB_TR_OPTION_TIMEOUT, args.transaction_timeout_txn);
+			}
 
 			/* enable transaction trace */
 			if (dotrace) {
@@ -1002,8 +1008,8 @@ int workerProcessMain(Arguments const& args, int worker_id, shared_memory::Acces
 		if (args.disable_ryw) {
 			databases[i].setOption(FDB_DB_OPTION_SNAPSHOT_RYW_DISABLE, BytesRef{});
 		}
-		if (args.transaction_timeout > 0 && args.mode == MODE_RUN) {
-			databases[i].setOption(FDB_DB_OPTION_TRANSACTION_TIMEOUT, args.transaction_timeout);
+		if (args.transaction_timeout_db > 0 && args.mode == MODE_RUN) {
+			databases[i].setOption(FDB_DB_OPTION_TRANSACTION_TIMEOUT, args.transaction_timeout_db);
 		}
 	}
 
@@ -1117,7 +1123,8 @@ Arguments::Arguments() {
 	bg_materialize_files = false;
 	bg_file_path[0] = '\0';
 	distributed_tracer_client = 0;
-	transaction_timeout = 0;
+	transaction_timeout_db = 0;
+	transaction_timeout_txn = 0;
 	num_report_files = 0;
 }
 
@@ -1308,8 +1315,11 @@ void usage() {
 	printf(
 	    "%-24s %s\n", "    --distributed_tracer_client=CLIENT", "Specify client (disabled, network_lossy, log_file)");
 	printf("%-24s %s\n",
-	       "    --transaction_timeout=DURATION",
-	       "Duration in milliseconds after which a transaction times out in run mode.");
+	       "    --transaction_timeout_db=DURATION",
+	       "Duration in milliseconds after which a transaction times out in run mode. Set as database option.");
+	printf("%-24s %s\n",
+	       "    --transaction_timeout_tx=DURATION",
+	       "Duration in milliseconds after which a transaction times out in run mode. Set as transaction option");
 }
 
 /* parse benchmark paramters */
@@ -1372,7 +1382,8 @@ int parseArguments(int argc, char* argv[], Arguments& args) {
 			{ "tls_key_file", required_argument, NULL, ARG_TLS_KEY_FILE },
 			{ "tls_ca_file", required_argument, NULL, ARG_TLS_CA_FILE },
 			{ "authorization_token_file", required_argument, NULL, ARG_AUTHORIZATION_TOKEN_FILE },
-			{ "transaction_timeout", required_argument, NULL, ARG_TRANSACTION_TIMEOUT },
+			{ "transaction_timeout_txn", required_argument, NULL, ARG_TRANSACTION_TIMEOUT_TXN },
+			{ "transaction_timeout_db", required_argument, NULL, ARG_TRANSACTION_TIMEOUT_DB },
 			{ NULL, 0, NULL, 0 }
 		};
 
@@ -1657,8 +1668,11 @@ int parseArguments(int argc, char* argv[], Arguments& args) {
 			          args.authorization_tokens.size(),
 			          tokenFilename);
 		} break;
-		case ARG_TRANSACTION_TIMEOUT:
-			args.transaction_timeout = atoi(optarg);
+		case ARG_TRANSACTION_TIMEOUT_TXN:
+			args.transaction_timeout_txn = atoi(optarg);
+			break;
+		case ARG_TRANSACTION_TIMEOUT_DB:
+			args.transaction_timeout_db = atoi(optarg);
 			break;
 		}
 	}
@@ -1747,14 +1761,14 @@ int Arguments::validate() {
 				return -1;
 			}
 		}
-		if (transaction_timeout < 0) {
-			logr.error("--transaction_timeout must be a non-negative integer");
+		if (transaction_timeout_db < 0 || transaction_timeout_txn < 0) {
+			logr.error("--transaction_timeout_[db|txn] must be a non-negative integer");
 			return -1;
 		}
 	}
 
-	if (mode != MODE_RUN && transaction_timeout != 0) {
-		logr.error("--transaction_timeout only supported in run mode");
+	if (mode != MODE_RUN && (transaction_timeout_db != 0 || transaction_timeout_txn != 0)) {
+		logr.error("--transaction_timeout_[txn|db] only supported in run mode");
 		return -1;
 	}
 
@@ -2367,7 +2381,8 @@ int statsProcessMain(Arguments const& args,
 		fmt::fprintf(fp, "\"txntagging_prefix\": \"%s\",", args.txntagging_prefix);
 		fmt::fprintf(fp, "\"streaming_mode\": %d,", args.streaming_mode);
 		fmt::fprintf(fp, "\"disable_ryw\": %d,", args.disable_ryw);
-		fmt::fprintf(fp, "\"transaction_timeout\": %d,", args.transaction_timeout);
+		fmt::fprintf(fp, "\"transaction_timeout_db\": %d,", args.transaction_timeout_db);
+		fmt::fprintf(fp, "\"transaction_timeout_txn\": %d,", args.transaction_timeout_txn);
 		fmt::fprintf(fp, "\"json_output_path\": \"%s\"", args.json_output_path);
 		fmt::fprintf(fp, "},\"samples\": [");
 	}

--- a/bindings/c/test/mako/mako.cpp
+++ b/bindings/c/test/mako/mako.cpp
@@ -639,7 +639,7 @@ int runWorkload(Database db,
 
 		if (current_tps > 0 || thread_tps == 0 /* throttling off */) {
 			Transaction tx = createNewTransaction(db, args, -1, args.active_tenants > 0 ? tenants : nullptr);
-			args.setTransactionTimeoutIfEnabled(tx);
+			setTransactionTimeoutIfEnabled(args, tx);
 
 			/* enable transaction trace */
 			if (dotrace) {
@@ -1121,12 +1121,6 @@ Arguments::Arguments() {
 	transaction_timeout_db = 0;
 	transaction_timeout_tx = 0;
 	num_report_files = 0;
-}
-
-void Arguments::setTransactionTimeoutIfEnabled(Transaction& tx) const {
-	if (transaction_timeout_tx > 0) {
-		tx.setOption(FDB_TR_OPTION_TIMEOUT, transaction_timeout_tx);
-	}
 }
 
 bool Arguments::isAnyTimeoutEnabled() const {

--- a/bindings/c/test/mako/mako.hpp
+++ b/bindings/c/test/mako/mako.hpp
@@ -85,7 +85,7 @@ enum ArgKind {
 	ARG_TLS_KEY_FILE,
 	ARG_TLS_CA_FILE,
 	ARG_AUTHORIZATION_TOKEN_FILE,
-	ARG_TRANSACTION_TIMEOUT_TXN,
+	ARG_TRANSACTION_TIMEOUT_TX,
 	ARG_TRANSACTION_TIMEOUT_DB,
 };
 
@@ -195,7 +195,7 @@ struct Arguments {
 	std::optional<std::string> tls_ca_file;
 	std::map<std::string, std::string> authorization_tokens; // maps tenant name to token string
 	int transaction_timeout_db;
-	int transaction_timeout_txn;
+	int transaction_timeout_tx;
 };
 
 } // namespace mako

--- a/bindings/c/test/mako/mako.hpp
+++ b/bindings/c/test/mako/mako.hpp
@@ -141,7 +141,6 @@ struct Arguments {
 	Arguments();
 	int validate();
 	bool isAnyTimeoutEnabled() const;
-	void setTransactionTimeoutIfEnabled(fdb::Transaction& tx) const;
 
 	int api_version;
 	int json;
@@ -199,6 +198,13 @@ struct Arguments {
 	int transaction_timeout_db;
 	int transaction_timeout_tx;
 };
+
+// helper functions
+inline void setTransactionTimeoutIfEnabled(const Arguments& args, fdb::Transaction& tx) {
+	if (args.transaction_timeout_tx > 0) {
+		tx.setOption(FDB_TR_OPTION_TIMEOUT, args.transaction_timeout_tx);
+	}
+}
 
 } // namespace mako
 

--- a/bindings/c/test/mako/mako.hpp
+++ b/bindings/c/test/mako/mako.hpp
@@ -85,7 +85,8 @@ enum ArgKind {
 	ARG_TLS_KEY_FILE,
 	ARG_TLS_CA_FILE,
 	ARG_AUTHORIZATION_TOKEN_FILE,
-	ARG_TRANSACTION_TIMEOUT,
+	ARG_TRANSACTION_TIMEOUT_TXN,
+	ARG_TRANSACTION_TIMEOUT_DB,
 };
 
 constexpr const int OP_COUNT = 0;
@@ -193,7 +194,8 @@ struct Arguments {
 	std::optional<std::string> tls_key_file;
 	std::optional<std::string> tls_ca_file;
 	std::map<std::string, std::string> authorization_tokens; // maps tenant name to token string
-	int transaction_timeout;
+	int transaction_timeout_db;
+	int transaction_timeout_txn;
 };
 
 } // namespace mako

--- a/bindings/c/test/mako/mako.hpp
+++ b/bindings/c/test/mako/mako.hpp
@@ -140,6 +140,8 @@ constexpr const int MAX_REPORT_FILES = 200;
 struct Arguments {
 	Arguments();
 	int validate();
+	bool isAnyTimeoutEnabled() const;
+	void setTransactionTimeoutIfEnabled(fdb::Transaction& tx) const;
 
 	int api_version;
 	int json;

--- a/bindings/c/test/mako/mako.rst
+++ b/bindings/c/test/mako/mako.rst
@@ -141,8 +141,11 @@ Arguments
   | Use authorization token JSON file located in ``<path>``
   | Expected content is a JSON object where each key is a tenant name and the mapped value is a token string
 
-- | ``--transaction_timeout <duration>``
-  | Duration in milliseconds after which a transaction times out in run mode.
+- | ``--transaction_timeout_tx <duration>``
+  | Duration in milliseconds after which a transaction times out in run mode. Set as transaction option.
+
+- | ``--transaction_timeout_db <duration>``
+  | Duration in milliseconds after which a transaction times out in run mode. Set as database option.
 
 Transaction Specification
 =========================


### PR DESCRIPTION
This PR adds the possibility to specify timeouts via the transaction option. Previously, timeouts were always set via the database option. For testing, I ran mako and verified that timeouts occur with both possibilities to set them and in both modes (sync and async). 

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
