### PR TITLE
Break cyclic reference created by mapThreadFuture when the future is cancelled

### DIFF
--- a/fdbclient/include/fdbclient/MultiVersionAssignmentVars.h
+++ b/fdbclient/include/fdbclient/MultiVersionAssignmentVars.h
@@ -260,8 +260,15 @@ public:
 	}
 
 	void cancel() override {
-		source.getPtr()->addref(); // Cancel will delref our future, but we don't want to destroy it until this callback
-		                           // gets destroyed
+		// Break the cyclic reference between this and the source future
+		if (source.clearCallback(this)) {
+			// If we successfully cleared the callback, it was not fired yet.
+			// In that case, set operation_cancelled() as the result of the future
+			sendResult(mapValue(operation_cancelled()));
+			ThreadSingleAssignmentVar<T>::delref();
+		}
+		source.getPtr()->addref(); // Cancel will delref the source future, but we don't want
+		                           // to destroy it until this callback gets destroyed
 		source.getPtr()->cancel();
 		ThreadSingleAssignmentVar<T>::cancel();
 	}


### PR DESCRIPTION
mapThreadFuture creates a cyclic dependency between the map future and the source future. Normally this cycle is broken when the result of the future is set. However, certain futures may be cancelled and destroyed without notifying the callbacks. 

In particular this was causing memory leaks in `fdb_c_api_test_CApiMultiTenantCorrectnessMultiThr`, which were caused by the reference cycles between `MultiVersionTenant::TenantState::tenantUpdater` and the `currentDb.onChange` future it is wrapping.

Such cycle has caused a memory leak in the API tests using multi-tenancy. ``

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
