### PR TITLE
server/status: fix cgroup reporting to fail silently for cgroup v2

### DIFF
--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -293,10 +293,19 @@ namespace {
 
 void reportCgroupCpuStat(JsonBuilderObject& object, const TraceEventFields& eventFields) {
 	JsonBuilderObject cgroupCpuStatObj;
-	cgroupCpuStatObj.setKeyRawNumber("nr_periods", eventFields.getValue("NrPeriods"));
-	cgroupCpuStatObj.setKeyRawNumber("nr_throttled", eventFields.getValue("NrThrottled"));
-	cgroupCpuStatObj.setKeyRawNumber("throttled_time", eventFields.getValue("ThrottledTime"));
-	object["cgroup_cpu_stat"] = cgroupCpuStatObj;
+	std::string val;
+	if (eventFields.tryGetValue("NrPeriods", val)) {
+		cgroupCpuStatObj.setKeyRawNumber("nr_periods", val);
+	}
+	if (eventFields.tryGetValue("NrThrottled", val)) {
+		cgroupCpuStatObj.setKeyRawNumber("nr_throttled", val);
+	}
+	if (eventFields.tryGetValue("ThrottledTime", val)) {
+		cgroupCpuStatObj.setKeyRawNumber("throttled_time", val);
+	}
+	if (!cgroupCpuStatObj.empty()) {
+		object["cgroup_cpu_stat"] = cgroupCpuStatObj;
+	}
 }
 
 JsonBuilderObject machineStatusFetcher(WorkerEvents mMetrics,

--- a/flow/Trace.cpp
+++ b/flow/Trace.cpp
@@ -1612,44 +1612,75 @@ void parseNumericValue(std::string const& s, uint64_t& outValue, bool permissive
 	throw attribute_not_found();
 }
 
-template <class T>
-T getNumericValue(TraceEventFields const& fields, std::string key, bool permissive) {
+template <class T, bool tryError>
+bool getNumericValue(TraceEventFields const& fields, std::string key, T& outValue, bool permissive) {
 	std::string field = fields.getValue(key);
 
 	try {
-		T value;
-		parseNumericValue(field, value, permissive);
-		return value;
+		parseNumericValue(field, outValue, permissive);
+		return true;
 	} catch (Error& e) {
-		std::string type;
+		if (tryError) {
+			std::string type;
 
-		TraceEvent ev(SevWarn, "ErrorParsingNumericTraceEventField");
-		ev.error(e);
-		if (fields.tryGetValue("Type", type)) {
-			ev.detail("Event", type);
+			TraceEvent ev(SevWarn, "ErrorParsingNumericTraceEventField");
+			ev.error(e);
+			if (fields.tryGetValue("Type", type)) {
+				ev.detail("Event", type);
+			}
+			ev.detail("FieldName", key);
+			ev.detail("FieldValue", field);
+
+			throw;
+		} else {
+			return false;
 		}
-		ev.detail("FieldName", key);
-		ev.detail("FieldValue", field);
-
-		throw;
 	}
 }
 } // namespace
 
+bool TraceEventFields::tryGetInt(std::string key, int& outVal, bool permissive) const {
+	bool success = getNumericValue<int, false>(*this, key, outVal, permissive);
+	return success;
+}
+
 int TraceEventFields::getInt(std::string key, bool permissive) const {
-	return getNumericValue<int>(*this, key, permissive);
+	int outVal;
+	getNumericValue<int, true>(*this, key, outVal, permissive);
+	return outVal;
+}
+
+bool TraceEventFields::tryGetInt64(std::string key, int64_t& outVal, bool permissive) const {
+	bool success = getNumericValue<int64_t, false>(*this, key, outVal, permissive);
+	return success;
 }
 
 int64_t TraceEventFields::getInt64(std::string key, bool permissive) const {
-	return getNumericValue<int64_t>(*this, key, permissive);
+	int64_t outVal;
+	getNumericValue<int64_t, true>(*this, key, outVal, permissive);
+	return outVal;
+}
+
+bool TraceEventFields::tryGetUint64(std::string key, uint64_t& outVal, bool permissive) const {
+	bool success = getNumericValue<uint64_t, false>(*this, key, outVal, permissive);
+	return success;
 }
 
 uint64_t TraceEventFields::getUint64(std::string key, bool permissive) const {
-	return getNumericValue<uint64_t>(*this, key, permissive);
+	uint64_t outVal;
+	getNumericValue<uint64_t, true>(*this, key, outVal, permissive);
+	return outVal;
+}
+
+bool TraceEventFields::tryGetDouble(std::string key, double& outVal, bool permissive) const {
+	bool success = getNumericValue<double, false>(*this, key, outVal, permissive);
+	return success;
 }
 
 double TraceEventFields::getDouble(std::string key, bool permissive) const {
-	return getNumericValue<double>(*this, key, permissive);
+	double outVal;
+	getNumericValue<double, true>(*this, key, outVal, permissive);
+	return outVal;
 }
 
 std::string TraceEventFields::toString() const {

--- a/flow/include/flow/Trace.h
+++ b/flow/include/flow/Trace.h
@@ -119,9 +119,13 @@ public:
 	const Field& operator[](int index) const;
 	bool tryGetValue(std::string key, std::string& outValue) const;
 	std::string getValue(std::string key) const;
+	bool tryGetInt(std::string key, int& outVal, bool permissive = false) const;
 	int getInt(std::string key, bool permissive = false) const;
+	bool tryGetInt64(std::string key, int64_t& outVal, bool permissive = false) const;
 	int64_t getInt64(std::string key, bool permissive = false) const;
+	bool tryGetUint64(std::string key, uint64_t& outVal, bool permissive = false) const;
 	uint64_t getUint64(std::string key, bool permissive = false) const;
+	bool tryGetDouble(std::string key, double& outVal, bool permissive = false) const;
 	double getDouble(std::string key, bool permissive = false) const;
 
 	Field& mutate(int index);


### PR DESCRIPTION
server/status: fix cgroup reporting to fail silently for v2

There are a few issues here:
1. The cgroup reporting added looks for top level metrics of cgroup v1.
2. Looking at the whole machine tells us nothing about fdbserver.
3. The reporting itself expects the values to be there rather than
   failing silently if we're not on v1. As cgroup v2 is significantly
   more prominent.

This fixes 3, but 1 and 2 are open and quite questionable. These really
ought to be reported by a 3rd party observer and not fdb itself.

While I'm here also add tryget helpers to TraceEventFields.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
