### PR TITLE
Create the skeleton for physical shard metrics tracking

### DIFF
--- a/fdbclient/FDBTypes.cpp
+++ b/fdbclient/FDBTypes.cpp
@@ -181,7 +181,7 @@ TEST_CASE("/KeyRangeUtil/KeyRangeComplement") {
 		Key b = "1"_sr;
 		Key e = "9"_sr;
 		std::vector<KeyRangeRef> result = range - KeyRangeRef(b, e);
-		ASSERT(result.size() == 1);	
+		ASSERT(result.size() == 1);
 		ASSERT(result[0] == KeyRangeRef("b"_sr, "y"_sr));
 	}
 
@@ -201,7 +201,7 @@ TEST_CASE("/KeyRangeUtil/KeyRangeComplement") {
 		ASSERT(result[0] == KeyRangeRef("b"_sr, "f"_sr));
 	}
 
-		{
+	{
 		Key b = "a"_sr;
 		Key e = "z"_sr;
 		std::vector<KeyRangeRef> result = range - KeyRangeRef(b, e);

--- a/fdbclient/FDBTypes.cpp
+++ b/fdbclient/FDBTypes.cpp
@@ -162,3 +162,51 @@ std::string describe(const std::string& s) {
 std::string describe(UID const& item) {
 	return item.shortString();
 }
+
+TEST_CASE("/KeyRangeUtil/KeyRangeComplement") {
+	Key begin = "b"_sr;
+	Key end = "y"_sr;
+	KeyRangeRef range(begin, end);
+
+	{
+		Key b = "c"_sr;
+		Key e = "f"_sr;
+		std::vector<KeyRangeRef> result = range - KeyRangeRef(b, e);
+		ASSERT(result.size() == 2);
+		ASSERT(result[0] == KeyRangeRef("b"_sr, "c"_sr));
+		ASSERT(result[1] == KeyRangeRef("f"_sr, "y"_sr));
+	}
+
+	{
+		Key b = "1"_sr;
+		Key e = "9"_sr;
+		std::vector<KeyRangeRef> result = range - KeyRangeRef(b, e);
+		ASSERT(result.size() == 1);	
+		ASSERT(result[0] == KeyRangeRef("b"_sr, "y"_sr));
+	}
+
+	{
+		Key b = "a"_sr;
+		Key e = "f"_sr;
+		std::vector<KeyRangeRef> result = range - KeyRangeRef(b, e);
+		ASSERT(result.size() == 1);
+		ASSERT(result[0] == KeyRangeRef("f"_sr, "y"_sr));
+	}
+
+	{
+		Key b = "f"_sr;
+		Key e = "z"_sr;
+		std::vector<KeyRangeRef> result = range - KeyRangeRef(b, e);
+		ASSERT(result.size() == 1);
+		ASSERT(result[0] == KeyRangeRef("b"_sr, "f"_sr));
+	}
+
+		{
+		Key b = "a"_sr;
+		Key e = "z"_sr;
+		std::vector<KeyRangeRef> result = range - KeyRangeRef(b, e);
+		ASSERT(result.size() == 0);
+	}
+
+	return Void();
+}

--- a/fdbclient/include/fdbclient/FDBTypes.h
+++ b/fdbclient/include/fdbclient/FDBTypes.h
@@ -425,6 +425,21 @@ inline KeyRangeRef operator&(const KeyRangeRef& lhs, const KeyRangeRef& rhs) {
 	return KeyRangeRef(b, e);
 }
 
+inline std::vector<KeyRangeRef> operator-(const KeyRangeRef& lhs, const KeyRangeRef& rhs) {
+	if ((lhs & rhs).empty()) {
+		return { lhs };
+	}
+
+	std::vector<KeyRangeRef> result;
+	if (lhs.begin < rhs.begin) {
+		result.push_back(KeyRangeRef(lhs.begin, rhs.begin));
+	}
+	if (lhs.end > rhs.end) {
+		result.push_back(KeyRangeRef(rhs.end, lhs.end));
+	}
+	return result;
+}
+
 struct KeyValueRef {
 	KeyRef key;
 	ValueRef value;

--- a/fdbclient/include/fdbclient/FDBTypes.h
+++ b/fdbclient/include/fdbclient/FDBTypes.h
@@ -425,6 +425,7 @@ inline KeyRangeRef operator&(const KeyRangeRef& lhs, const KeyRangeRef& rhs) {
 	return KeyRangeRef(b, e);
 }
 
+// Calculates the complement of `lhs` from `rhs`.
 inline std::vector<KeyRangeRef> operator-(const KeyRangeRef& lhs, const KeyRangeRef& rhs) {
 	if ((lhs & rhs).empty()) {
 		return { lhs };

--- a/fdbserver/DDShardTracker.actor.cpp
+++ b/fdbserver/DDShardTracker.actor.cpp
@@ -1566,12 +1566,13 @@ void PhysicalShardCollection::PhysicalShard::removeRange(const KeyRange& outRang
 
 	for (auto& range : updateRanges) {
 		std::vector<KeyRangeRef> remainingRanges = range - outRange;
-		rangeData.erase(range);
 		for (auto& r : remainingRanges) {
+			ASSERT(r != range);
 			// TODO(zhewu): add metrics tracking actor.
 			RangeData data;
 			rangeData.emplace(r, data);
 		}
+		rangeData.erase(range);
 	}
 }
 

--- a/fdbserver/DDShardTracker.actor.cpp
+++ b/fdbserver/DDShardTracker.actor.cpp
@@ -1629,6 +1629,9 @@ void PhysicalShardCollection::updatekeyRangePhysicalShardIDMap(KeyRange keyRange
 	std::set<uint64_t> physicalShardIDSet;
 	for (auto it = ranges.begin(); it != ranges.end(); ++it) {
 		uint64_t shardID = it->value();
+		if (shardID == UID().first()) {
+			continue;
+		}
 		ASSERT(physicalShardInstances.find(shardID) != physicalShardInstances.end());
 		physicalShardInstances[shardID].removeRange(keyRange);
 	}
@@ -1647,8 +1650,11 @@ void PhysicalShardCollection::checkKeyRangePhysicalShardMapping() {
 	KeyRangeMap<uint64_t>::iterator it = keyRangePhysicalShardIDRanges.begin();
 	for (; it != keyRangePhysicalShardIDRanges.end(); ++it) {
 		uint64_t shardID = it->value();
-		ASSERT(physicalShardInstances.find(shardID) != physicalShardInstances.end());
+		if (shardID == UID().first()) {
+			continue;
+		}
 		auto keyRangePiece = KeyRangeRef(it->range().begin, it->range().end);
+		ASSERT(physicalShardInstances.find(shardID) != physicalShardInstances.end());
 		bool exist = false;
 		for (const auto& [range, data] : physicalShardInstances[shardID].rangeData) {
 			if (range == keyRangePiece) {

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -626,7 +626,7 @@ ACTOR Future<Void> dataDistribution(Reference<DataDistributor> self,
 			}
 
 			self->shardsAffectedByTeamFailure = makeReference<ShardsAffectedByTeamFailure>();
-			self->physicalShardCollection = makeReference<PhysicalShardCollection>();
+			self->physicalShardCollection = makeReference<PhysicalShardCollection>(self->txnProcessor);
 			wait(self->resumeRelocations());
 
 			std::vector<TeamCollectionInterface> tcis; // primary and remote region interface

--- a/fdbserver/include/fdbserver/DataDistribution.actor.h
+++ b/fdbserver/include/fdbserver/DataDistribution.actor.h
@@ -272,7 +272,7 @@ class PhysicalShardCollection : public ReferenceCounted<PhysicalShardCollection>
 public:
 	PhysicalShardCollection() : lastTransitionStartTime(now()), requireTransition(false) {}
 	PhysicalShardCollection(Reference<IDDTxnProcessor> db)
-	  : db(db), lastTransitionStartTime(now()), requireTransition(false) {}
+	  : txnProcessor(db), lastTransitionStartTime(now()), requireTransition(false) {}
 
 	enum class PhysicalShardCreationTime { DDInit, DDRelocator };
 
@@ -440,7 +440,7 @@ private:
 
 	inline bool requireTransitionCheck() { return requireTransition; }
 
-	Reference<IDDTxnProcessor> db;
+	Reference<IDDTxnProcessor> txnProcessor;
 
 	// Core data structures
 	// Physical shard instances indexed by physical shard id

--- a/fdbserver/include/fdbserver/DataDistribution.actor.h
+++ b/fdbserver/include/fdbserver/DataDistribution.actor.h
@@ -285,8 +285,10 @@ public:
 		              PhysicalShardCreationTime whenCreated)
 		  : id(id), metrics(metrics), teams(teams), whenCreated(whenCreated) {}
 
+		// Adds `newRange` to this physical shard and starts monitoring the shard.
 		void addRange(const KeyRange& newRange);
 
+		// Removes `outRange` from this physical shard and updates monitored shards.
 		void removeRange(const KeyRange& outRange);
 
 		std::string toString() const { return fmt::format("{}", std::to_string(id)); }
@@ -297,8 +299,9 @@ public:
 		PhysicalShardCreationTime whenCreated; // when this physical shard is created (never changed)
 
 		struct RangeData {
-			Future<Void> trackMetrics;
-			Reference<AsyncVar<Optional<ShardMetrics>>> stats;
+			Future<Void> trackMetrics; // TODO(zhewu): add shard tracking actor.
+			Reference<AsyncVar<Optional<ShardMetrics>>>
+			    stats; // TODO(zhewu): aggregate all metrics to a single physical shard metrics.
 		};
 		std::unordered_map<KeyRange, RangeData> rangeData;
 	};
@@ -405,6 +408,7 @@ private:
 	// In keyRangePhysicalShardIDMap, set the input physical shard id to the input key range
 	void updatekeyRangePhysicalShardIDMap(KeyRange keyRange, uint64_t physicalShardID, uint64_t debugID);
 
+	// Checks the consistency between the mapping of physical shards and key ranges.
 	void checkKeyRangePhysicalShardMapping();
 
 	// Return a string concating the input IDs interleaving with " "


### PR DESCRIPTION
Create the basic structure for tracking physical shard metrics.

The basic idea is that for each physical shard, we want to track the data metrics (size, bandwidth, etc.) of all the key ranges in it. Therefore, in each physical shard instances, we keep track of all the key ranges that belong to this physical shard, and use existing per key range metrics tracking to aggregate all the metrics.

This PR creates the basic structure: for each physical shard instance, it needs to maintain the list of key ranges it owns, and such list needs to be consistent with keyRangePhysicalShardIDMap.

In the next PR, we wii add per range metrics tracking and aggregation.

20221207-190355-zhewu_8999-2775a849c1d144da

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
