### PR TITLE
Do not compress debug sections in release builds

### DIFF
--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -166,18 +166,24 @@ else()
   set(SANITIZER_COMPILE_OPTIONS)
   set(SANITIZER_LINK_OPTIONS)
 
-  # we always compile with debug symbols. For release builds CPack will strip them out
-  # and create a debuginfo rpm
-  add_compile_options(-fno-omit-frame-pointer -gz)
-  add_link_options(-gz)
+  add_compile_options(-fno-omit-frame-pointer)
+
   if(FDB_RELEASE OR FULL_DEBUG_SYMBOLS OR CMAKE_BUILD_TYPE STREQUAL "Debug")
     # Configure with FULL_DEBUG_SYMBOLS=ON to generate all symbols for debugging with gdb
-    # Also generating full debug symbols in release builds, because they are packaged
-    # separately and installed optionally
+    # Also generating full debug symbols in release builds. CPack will strip them out
+    # and create a debuginfo rpm
     add_compile_options(-ggdb)
   else()
     # Generating minimal debug symbols by default. They are sufficient for testing purposes
     add_compile_options(-ggdb1)
+  endif()
+
+  if(NOT FDB_RELEASE)
+    # Enable compression of the debug sections. This reduces the size of the binaries several times. 
+    # We do not enable it release builds, because CPack fails to generate debuginfo packages when
+    # compression is enabled
+    add_compile_options(-gz)
+    add_link_options(-gz)
   endif()
 
   if(TRACE_PC_GUARD_INSTRUMENTATION_LIB)


### PR DESCRIPTION
In release builds (i.e. with FDB_RELEASE on), we use cpack to strip debug sections from the binaries and create separate debuginfo RPMs. This process was failing on the main branch. 

After I disabled debug section compression, the debuginfo  packages could be successfully generated again, so this PR is removing debug section compression for release builds. However, I was not able to find any information about support for debug section compression in cpack. 

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
