### PR TITLE
Fix EncryptedBackupCorrectness Workload

### DIFF
--- a/fdbserver/workloads/BulkLoadWithTenants.actor.cpp
+++ b/fdbserver/workloads/BulkLoadWithTenants.actor.cpp
@@ -36,6 +36,7 @@ struct BulkSetupWorkload : TestWorkload {
 	double maxNumTenants;
 	double minNumTenants;
 	std::vector<TenantName> tenantNames;
+	double testDuration;
 
 	BulkSetupWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
 		transactionsPerSecond = getOption(options, "transactionsPerSecond"_sr, 5000.0) / clientCount;
@@ -45,6 +46,7 @@ struct BulkSetupWorkload : TestWorkload {
 		maxNumTenants = getOption(options, "maxNumTenants"_sr, 0);
 		minNumTenants = getOption(options, "minNumTenants"_sr, 0);
 		ASSERT(minNumTenants <= maxNumTenants);
+		testDuration = getOption(options, "testDuration"_sr, 10.0);
 	}
 
 	void getMetrics(std::vector<PerfMetric>& m) override {}
@@ -74,32 +76,28 @@ struct BulkSetupWorkload : TestWorkload {
 			}
 			wait(waitForAll(tenantFutures));
 		}
+		wait(bulkSetup(cx,
+		               workload,
+		               workload->nodeCount,
+		               Promise<double>(),
+		               false,
+		               0.0,
+		               1e12,
+		               std::vector<uint64_t>(),
+		               Promise<std::vector<std::pair<uint64_t, double>>>(),
+		               0,
+		               0.1,
+		               0,
+		               0,
+		               workload->tenantNames));
 		return Void();
 	}
 
-	Future<Void> start(Database const& cx) override {
-		if (clientId == 0) {
-			return bulkSetup(cx,
-			                 this,
-			                 nodeCount,
-			                 Promise<double>(),
-			                 false,
-			                 0.0,
-			                 1e12,
-			                 std::vector<uint64_t>(),
-			                 Promise<std::vector<std::pair<uint64_t, double>>>(),
-			                 0,
-			                 0.1,
-			                 0,
-			                 0,
-			                 tenantNames);
-		}
-		return Void();
-	}
+	Future<Void> start(Database const& cx) override { return Void(); }
 
 	Future<Void> setup(Database const& cx) override {
 		if (clientId == 0) {
-			return _setup(this, cx);
+			return timeout(_setup(this, cx), testDuration, Void());
 		}
 		return Void();
 	}

--- a/tests/fast/EncryptedBackupCorrectness.toml
+++ b/tests/fast/EncryptedBackupCorrectness.toml
@@ -19,6 +19,7 @@ simBackupAgents = 'BackupToFile'
     maxNumTenants = 100
     minNumTenants = 0
     transactionsPerSecond = 2500.0
+    testDuration = 30.0
 
     [[test.workload]]
     testName = 'BackupAndRestoreCorrectness'


### PR DESCRIPTION
Currently this workload can fail if a restore is started before the bulk load is done. This PR adds support to limit the test duration of the bulk load to avoid this issue.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
