### PR TITLE
Fix clang-tidy string warnings

### DIFF
--- a/bindings/c/test/mako/mako.cpp
+++ b/bindings/c/test/mako/mako.cpp
@@ -120,7 +120,7 @@ Transaction createNewTransaction(Database db, Arguments const& args, int id = -1
 
 uint64_t byteswapHelper(uint64_t input) {
 	uint64_t output = 0;
-	for (int i = 0; i < 8; ++i) {
+	for (unsigned int i = 0; i < 8; ++i) {
 		output <<= 8;
 		output += input & 0xFF;
 		input >>= 8;
@@ -744,7 +744,7 @@ void runAsyncWorkload(Arguments const& args,
 	auto stopcount = std::atomic<int>{};
 	if (args.mode == MODE_BUILD) {
 		auto states = std::vector<PopulateStateHandle>(args.async_xacts);
-		for (auto i = 0; i < args.async_xacts; i++) {
+		for (int i = 0; i < args.async_xacts; i++) {
 			const auto key_begin = insertBegin(args.rows, worker_id, i, args.num_processes, args.async_xacts);
 			const auto key_end = insertEnd(args.rows, worker_id, i, args.num_processes, args.async_xacts);
 			auto db = databases[i % args.num_databases];
@@ -1121,8 +1121,8 @@ Arguments::Arguments() {
 	txntrace = 0;
 	txntagging = 0;
 	memset(txntagging_prefix, 0, TAGPREFIXLENGTH_MAX);
-	for (auto i = 0; i < MAX_OP; i++) {
-		txnspec.ops[i][OP_COUNT] = 0;
+	for (auto& op : txnspec.ops) {
+		op[OP_COUNT] = 0;
 	}
 	client_threads_per_version = 0;
 	disable_client_bypass = false;
@@ -1340,7 +1340,7 @@ int parseArguments(int argc, char* argv[], Arguments& args) {
 	int rc;
 	int c;
 	int idx;
-	while (1) {
+	while (true) {
 		const char* short_options = "a:c:d:p:t:r:s:i:x:v:m:hz";
 		static struct option long_options[] = {
 			/* name, has_arg, flag, val */
@@ -1474,8 +1474,7 @@ int parseArguments(int argc, char* argv[], Arguments& args) {
 				args.mode = MODE_RUN;
 			} else if (strcmp(optarg, "report") == 0) {
 				args.mode = MODE_REPORT;
-				int i = optind;
-				for (; i < argc; i++) {
+				for (int i = optind; i < argc; i++) {
 					if (argv[i][0] != '-') {
 						const std::string report_file = argv[i];
 						strncpy(args.report_files[args.num_report_files], report_file.c_str(), report_file.size());
@@ -1557,9 +1556,9 @@ int parseArguments(int argc, char* argv[], Arguments& args) {
 			memcpy(args.tracepath, optarg, strlen(optarg) + 1);
 			break;
 		case ARG_TRACEFORMAT:
-			if (strncmp(optarg, "json", 5) == 0) {
+			if (strncmp(optarg, "json", 4) == 0) {
 				args.traceformat = 1;
-			} else if (strncmp(optarg, "xml", 4) == 0) {
+			} else if (strncmp(optarg, "xml", 3) == 0) {
 				args.traceformat = 0;
 			} else {
 				logr.error("Invalid trace_format {}", optarg);
@@ -1903,8 +1902,8 @@ void printStatsHeader(Arguments const& args, bool show_commit, bool is_first_hea
 	fmt::print("\n");
 
 	putTitleBar();
-	for (auto op = 0; op < MAX_OP; op++) {
-		if (args.txnspec.ops[op][OP_COUNT] > 0) {
+	for (auto op : args.txnspec.ops) {
+		if (op[OP_COUNT] > 0) {
 			putFieldBar();
 		}
 	}
@@ -2262,7 +2261,7 @@ void printReport(Arguments const& args,
 	fmt::print("\n");
 
 	if (fp) {
-		fmt::fprintf(fp, "}, \"tps\": %.2f, \"conflictsPerSec\": %.2f, \"errors\": {", tps, conflicts_rate);
+		fmt::fprintf(fp, R"(}, "tps": %.2f, "conflictsPerSec": %.2f, "errors": {)", tps, conflicts_rate);
 	}
 
 	/* Errors */
@@ -2381,22 +2380,22 @@ int statsProcessMain(Arguments const& args,
 		fmt::fprintf(fp, "\"total_tenants\": %d,", args.total_tenants);
 		fmt::fprintf(fp, "\"commit_get\": %d,", args.commit_get);
 		fmt::fprintf(fp, "\"verbose\": %d,", args.verbose);
-		fmt::fprintf(fp, "\"cluster_files\": \"%s\",", args.cluster_files[0]);
-		fmt::fprintf(fp, "\"log_group\": \"%s\",", args.log_group);
+		fmt::fprintf(fp, R"("cluster_files": "%s",)", args.cluster_files[0]);
+		fmt::fprintf(fp, R"("log_group": "%s",)", args.log_group);
 		fmt::fprintf(fp, "\"prefixpadding\": %d,", args.prefixpadding);
 		fmt::fprintf(fp, "\"trace\": %d,", args.trace);
-		fmt::fprintf(fp, "\"tracepath\": \"%s\",", args.tracepath);
+		fmt::fprintf(fp, R"("tracepath": "%s",)", args.tracepath);
 		fmt::fprintf(fp, "\"traceformat\": %d,", args.traceformat);
-		fmt::fprintf(fp, "\"knobs\": \"%s\",", args.knobs);
+		fmt::fprintf(fp, R"("knobs": "%s",)", args.knobs);
 		fmt::fprintf(fp, "\"flatbuffers\": %d,", args.flatbuffers);
 		fmt::fprintf(fp, "\"txntrace\": %d,", args.txntrace);
 		fmt::fprintf(fp, "\"txntagging\": %d,", args.txntagging);
-		fmt::fprintf(fp, "\"txntagging_prefix\": \"%s\",", args.txntagging_prefix);
+		fmt::fprintf(fp, R"("txntagging_prefix": "%s",)", args.txntagging_prefix);
 		fmt::fprintf(fp, "\"streaming_mode\": %d,", args.streaming_mode);
 		fmt::fprintf(fp, "\"disable_ryw\": %d,", args.disable_ryw);
 		fmt::fprintf(fp, "\"transaction_timeout_db\": %d,", args.transaction_timeout_db);
 		fmt::fprintf(fp, "\"transaction_timeout_tx\": %d,", args.transaction_timeout_tx);
-		fmt::fprintf(fp, "\"json_output_path\": \"%s\"", args.json_output_path);
+		fmt::fprintf(fp, R"("json_output_path": "%s")", args.json_output_path);
 		fmt::fprintf(fp, "},\"samples\": [");
 	}
 
@@ -2492,7 +2491,7 @@ ThreadStatistics mergeSketchReport(Arguments& args) {
 int main(int argc, char* argv[]) {
 	setlinebuf(stdout);
 
-	auto rc = int{};
+	int rc = 0;
 	auto args = Arguments{};
 	rc = parseArguments(argc, argv, args);
 	if (rc < 0) {
@@ -2587,7 +2586,7 @@ int main(int argc, char* argv[]) {
 	/* fork worker processes + 1 stats process */
 	auto worker_pids = std::vector<pid_t>(args.num_processes + 1);
 
-	auto worker_id = int{};
+	int worker_id = 0;
 
 	/* forking (num_process + 1) children */
 	/* last process is the stats handler */
@@ -2669,9 +2668,9 @@ int main(int argc, char* argv[]) {
 		}
 	}
 
-	auto status = int{};
+	int status = 0;
 	/* wait for worker processes to exit */
-	for (auto p = 0; p < args.num_processes; p++) {
+	for (int p = 0; p < args.num_processes; p++) {
 		logr.debug("waiting for worker process {} (PID:{}) to exit", p + 1, worker_pids[p]);
 		auto pid = waitpid(worker_pids[p], &status, 0 /* or what? */);
 		if (pid < 0) {

--- a/fdbcli/ExcludeCommand.actor.cpp
+++ b/fdbcli/ExcludeCommand.actor.cpp
@@ -67,7 +67,7 @@ ACTOR Future<bool> excludeServersAndLocalities(Reference<IDatabase> db,
 			if (e.code() == error_code_special_keys_api_failure) {
 				std::string errorMsgStr = wait(fdb_cli::getSpecialKeysFailureErrorMessage(tr));
 				// last character is \n
-				auto pos = errorMsgStr.find_last_of("\n", errorMsgStr.size() - 2);
+				auto pos = errorMsgStr.find_last_of('\n', errorMsgStr.size() - 2);
 				auto last_line = errorMsgStr.substr(pos + 1);
 				// customized the error message for fdbcli
 				fprintf(stderr,

--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -333,17 +333,17 @@ public:
 static std::string formatStringRef(StringRef item, bool fullEscaping = false) {
 	std::string ret;
 
-	for (int i = 0; i < item.size(); i++) {
-		if (fullEscaping && item[i] == '\\')
+	for (unsigned char i : item) {
+		if (fullEscaping && i == '\\')
 			ret += "\\\\";
-		else if (fullEscaping && item[i] == '"')
+		else if (fullEscaping && i == '"')
 			ret += "\\\"";
-		else if (fullEscaping && item[i] == ' ')
-			ret += format("\\x%02x", item[i]);
-		else if (item[i] >= 32 && item[i] < 127)
-			ret += item[i];
+		else if (fullEscaping && i == ' ')
+			ret += format("\\x%02x", i);
+		else if (i >= 32 && i < 127)
+			ret += i;
 		else
-			ret += format("\\x%02x", item[i]);
+			ret += format("\\x%02x", i);
 	}
 
 	return ret;
@@ -708,7 +708,7 @@ ACTOR Future<Void> commitTransaction(Reference<ITransaction> tr) {
 ACTOR Future<bool> createSnapshot(Database db, std::vector<StringRef> tokens) {
 	state Standalone<StringRef> snapCmd;
 	state UID snapUID = deterministicRandom()->randomUniqueID();
-	for (int i = 1; i < tokens.size(); i++) {
+	for (size_t i = 1; i < tokens.size(); i++) {
 		snapCmd = snapCmd.withSuffix(tokens[i]);
 		if (i != tokens.size() - 1) {
 			snapCmd = snapCmd.withSuffix(" "_sr);
@@ -755,7 +755,7 @@ std::string newCompletion(const char* base, const char* name) {
 
 void compGenerator(const char* text, bool help, std::vector<std::string>& lc) {
 	std::map<std::string, CommandHelp>::const_iterator iter;
-	int len = strlen(text);
+	size_t len = strlen(text);
 
 	const char* helpExtra[] = { "escaping", "options", nullptr };
 
@@ -770,8 +770,7 @@ void compGenerator(const char* text, bool help, std::vector<std::string>& lc) {
 
 	if (help) {
 		while (*he) {
-			const char* name = *he;
-			he++;
+			const char* name = *he++;
 			if (!strncmp(name, text, len))
 				lc.push_back(newCompletion("help ", name));
 		}
@@ -787,7 +786,7 @@ void helpGenerator(const char* text, std::vector<std::string>& lc) {
 }
 
 void optionGenerator(const char* text, const char* line, std::vector<std::string>& lc) {
-	int len = strlen(text);
+	size_t len = strlen(text);
 
 	for (auto iter = validOptions.begin(); iter != validOptions.end(); ++iter) {
 		const char* name = (*iter).c_str();
@@ -800,11 +799,10 @@ void optionGenerator(const char* text, const char* line, std::vector<std::string
 namespace fdb_cli {
 void arrayGenerator(const char* text, const char* line, const char** options, std::vector<std::string>& lc) {
 	const char** iter = options;
-	int len = strlen(text);
+	size_t len = strlen(text);
 
 	while (*iter) {
-		const char* name = *iter;
-		iter++;
+		const char* name = *iter++;
 		if (!strncmp(name, text, len)) {
 			lc.push_back(newCompletion(line, name));
 		}
@@ -825,10 +823,10 @@ void fdbcliCompCmd(std::string const& text, std::vector<std::string>& lc) {
 		return;
 
 	auto tokens = parsed.back();
-	int count = tokens.size();
+	size_t count = tokens.size();
 
-	// for(int i = 0; i < count; i++) {
-	//	printf("Token (%d): `%s'\n", i, tokens[i].toString().c_str());
+	// for(unsigned int i = 0; i < count; i++) {
+	//	printf("Token (%u): `%s'\n", i, tokens[i].toString().c_str());
 	// }
 
 	std::string ntext = "";
@@ -856,7 +854,7 @@ void fdbcliCompCmd(std::string const& text, std::vector<std::string>& lc) {
 	if (tokencmp(tokens[0], "option")) {
 		if (count == 1)
 			onOffGenerator(ntext.c_str(), base_input.c_str(), lc);
-		if (count == 2)
+		else if (count == 2)
 			optionGenerator(ntext.c_str(), base_input.c_str(), lc);
 	}
 
@@ -1710,7 +1708,7 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise, Reference<ClusterCo
 							}
 							limit = 0;
 							int place = 1;
-							for (int i = tokens[3].size(); i > 0; i--) {
+							for (auto i = tokens[3].size(); i > 0; i--) {
 								int val = int(tokens[3][i - 1]) - int('0');
 								if (val < 0 || val > 9) {
 									valid = false;
@@ -2161,10 +2159,13 @@ ACTOR Future<int> runCli(CLIOptions opt, Reference<ClusterConnectionFile> ccf) {
 		    bool partial = false;
 		    std::string linecopy = line;
 		    std::vector<std::vector<StringRef>> parsed = parseLine(linecopy, error, partial);
-		    if (parsed.size() == 0 || parsed.back().size() == 0)
+		    if (parsed.empty() || parsed.back().empty())
 			    return LineNoise::Hint();
 		    StringRef command = parsed.back().front();
-		    int finishedParameters = parsed.back().size() + error;
+		    auto finishedParameters = parsed.back().size();
+
+		    if (error)
+			    finishedParameters++;
 
 		    // As a user is typing an escaped character, e.g. \", after the \ and before the " is typed
 		    // the string will be a parse error.  Ignore this parse error to avoid flipping the hint to
@@ -2189,7 +2190,7 @@ ACTOR Future<int> runCli(CLIOptions opt, Reference<ClusterConnectionFile> ccf) {
 			    if (iter != helpMap.end()) {
 				    std::string helpLine = iter->second.usage;
 				    std::vector<std::vector<StringRef>> parsedHelp = parseLine(helpLine, error, partial);
-				    for (int i = finishedParameters; i < parsedHelp.back().size(); i++) {
+				    for (auto i = finishedParameters; i < parsedHelp.back().size(); i++) {
 					    hintLine = hintLine + parsedHelp.back()[i].toString() + " ";
 				    }
 			    } else {
@@ -2241,8 +2242,8 @@ const char* checkTlsConfigAgainstCoordAddrs(const ClusterConnectionString& ccs) 
 	auto const loaded = tlsConfig.loadSync();
 	const bool tlsConfigured =
 	    !loaded.getCertificateBytes().empty() || !loaded.getKeyBytes().empty() || !loaded.getCABytes().empty();
-	int tlsAddrs = 0;
-	int totalAddrs = 0;
+	size_t tlsAddrs = 0;
+	size_t totalAddrs = 0;
 	for (const auto& addr : ccs.coords) {
 		if (addr.isTLS())
 			tlsAddrs++;

--- a/fdbclient/RESTUtils.actor.cpp
+++ b/fdbclient/RESTUtils.actor.cpp
@@ -35,7 +35,7 @@ bool isProtocolSupported(const std::string& protocol) {
 }
 
 bool isSecurePrototol(const std::string& protocol) {
-	return protocol.compare("https") == 0;
+	return protocol == "https";
 }
 } // namespace
 

--- a/fdbclient/S3BlobStore.actor.cpp
+++ b/fdbclient/S3BlobStore.actor.cpp
@@ -178,9 +178,7 @@ std::string guessRegionFromDomain(std::string domain) {
 	static const std::vector<const char*> knownServices = { "s3.", "cos.", "oss-", "obs." };
 	boost::algorithm::to_lower(domain);
 
-	for (int i = 0; i < knownServices.size(); ++i) {
-		const char* service = knownServices[i];
-
+	for (const auto& service : knownServices) {
 		std::size_t p = domain.find(service);
 
 		if (p == std::string::npos || (p >= 1 && domain[p - 1] != '.')) {
@@ -1318,11 +1316,11 @@ std::string S3BlobStoreEndpoint::hmac_sha1(Credentials const& creds, std::string
 	key.append(64 - key.size(), '\0');
 
 	std::string kipad = key;
-	for (int i = 0; i < 64; ++i)
+	for (unsigned int i = 0; i < 64; ++i)
 		kipad[i] ^= '\x36';
 
 	std::string kopad = key;
-	for (int i = 0; i < 64; ++i)
+	for (unsigned int i = 0; i < 64; ++i)
 		kopad[i] ^= '\x5c';
 
 	kipad.append(msg);
@@ -1338,8 +1336,8 @@ std::string sha256_hex(std::string str) {
 	SHA256_Update(&sha256, str.c_str(), str.size());
 	SHA256_Final(hash, &sha256);
 	std::stringstream ss;
-	for (int i = 0; i < SHA256_DIGEST_LENGTH; i++) {
-		ss << std::hex << std::setw(2) << std::setfill('0') << (int)hash[i];
+	for (unsigned char i : hash) {
+		ss << std::hex << std::setw(2) << std::setfill('0') << i;
 	}
 	return ss.str();
 }
@@ -1356,8 +1354,8 @@ std::string hmac_sha256_hex(std::string key, std::string msg) {
 
 	std::stringstream ss;
 	ss << std::hex << std::setfill('0');
-	for (int i = 0; i < len; i++) {
-		ss << std::hex << std::setw(2) << (unsigned int)hash[i];
+	for (const auto& i : hash) {
+		ss << std::hex << std::setw(2) << i;
 	}
 	return (ss.str());
 }
@@ -1374,7 +1372,7 @@ std::string hmac_sha256(std::string key, std::string msg) {
 
 	std::stringstream ss;
 	ss << std::setfill('0');
-	for (int i = 0; i < len; i++) {
+	for (const auto& i : hash) {
 		ss << hash[i];
 	}
 	return (ss.str());

--- a/fdbclient/VersionedMap.cpp
+++ b/fdbclient/VersionedMap.cpp
@@ -60,7 +60,7 @@ struct VersionedMapHarness {
 TEST_CASE("performance/map/int/VersionedMap") {
 	VersionedMapHarness<int> tree;
 
-	treeBenchmark(tree, *randomInt);
+	treeBenchmark(tree, randomInt);
 
 	return Void();
 }

--- a/fdbclient/sha1/SHA1.cpp
+++ b/fdbclient/sha1/SHA1.cpp
@@ -71,8 +71,8 @@ std::string SHA1::final() {
 	uint64 total_bits = (transforms * BLOCK_BYTES + buffer.size()) * 8;
 
 	/* Padding */
-	buffer += 0x80;
-	std::string::size_type orig_size = (unsigned int)buffer.size();
+	buffer += (char)0x80;
+	auto orig_size = buffer.size();
 	while (buffer.size() < BLOCK_BYTES) {
 		buffer += (char)0x00;
 	}
@@ -96,8 +96,7 @@ std::string SHA1::final() {
 	std::string result;
 	result.reserve(16);
 
-	for (unsigned int i = 0; i < DIGEST_INTS; i++) {
-		uint32 v = digest[i];
+	for (unsigned int v : digest) {
 		result.append(1, (char)(v >> 24));
 		result.append(1, (char)(v >> 16));
 		result.append(1, (char)(v >> 8));

--- a/fdbrpc/include/fdbrpc/Stats.h
+++ b/fdbrpc/include/fdbrpc/Stats.h
@@ -189,7 +189,7 @@ struct SpecialCounter final : ICounter, FastAllocated<SpecialCounter<F>>, NonCop
 };
 template <class F>
 static void specialCounter(CounterCollection& collection, std::string const& name, F&& f) {
-	new SpecialCounter<F>(collection, name, std::move(f));
+	new SpecialCounter<F>(collection, name, std::forward<F>(f));
 }
 
 FDB_DECLARE_BOOLEAN_PARAM(Filtered);

--- a/fdbserver/ConsistencyScan.actor.cpp
+++ b/fdbserver/ConsistencyScan.actor.cpp
@@ -280,7 +280,7 @@ ACTOR Future<std::vector<int64_t>> getStorageSizeEstimate(std::vector<StorageSer
 
 	try {
 		// Check the size of the shard on each storage server
-		for (int i = 0; i < storageServers.size(); i++) {
+		for (size_t i = 0; i < storageServers.size(); i++) {
 			resetReply(req);
 			metricFutures.push_back(storageServers[i].waitMetrics.getReplyUnlessFailedFor(req, 2, 0));
 		}
@@ -291,7 +291,7 @@ ACTOR Future<std::vector<int64_t>> getStorageSizeEstimate(std::vector<StorageSer
 		int firstValidStorageServer = -1;
 
 		// Retrieve the size from the storage server responses
-		for (int i = 0; i < storageServers.size(); i++) {
+		for (size_t i = 0; i < storageServers.size(); i++) {
 			ErrorOr<StorageMetrics> reply = metricFutures[i].get();
 
 			// If the storage server doesn't reply, then return -1
@@ -404,7 +404,7 @@ ACTOR Future<bool> checkDataConsistency(Database cx,
 
 	state std::vector<KeyRangeRef> ranges;
 
-	for (int k = 0; k < keyLocations.size() - 1; k++) {
+	for (size_t k = 0; k < keyLocations.size() - 1; k++) {
 		// TODO: check if this is sufficient
 		if (resume && keyLocations[k].key < progressKey) {
 			TraceEvent("ConsistencyCheck_SkippingRange")
@@ -469,10 +469,10 @@ ACTOR Future<bool> checkDataConsistency(Database cx,
 			try {
 				std::vector<Future<Optional<Value>>> serverListEntries;
 				serverListEntries.reserve(storageServers.size());
-				for (int s = 0; s < storageServers.size(); s++)
+				for (size_t s = 0; s < storageServers.size(); s++)
 					serverListEntries.push_back(tr.get(serverListKeyFor(storageServers[s])));
 				state std::vector<Optional<Value>> serverListValues = wait(getAll(serverListEntries));
-				for (int s = 0; s < serverListValues.size(); s++) {
+				for (size_t s = 0; s < serverListValues.size(); s++) {
 					if (serverListValues[s].present())
 						storageServerInterfaces.push_back(decodeServerListValue(serverListValues[s].get()));
 					else if (performQuiescentChecks)
@@ -488,8 +488,8 @@ ACTOR Future<bool> checkDataConsistency(Database cx,
 
 		// add TSS to end of list, if configured and if not relocating
 		if (!isRelocating && performTSSCheck) {
-			int initialSize = storageServers.size();
-			for (int i = 0; i < initialSize; i++) {
+			size_t initialSize = storageServers.size();
+			for (size_t i = 0; i < initialSize; i++) {
 				auto tssPair = tssMapping.find(storageServers[i]);
 				if (tssPair != tssMapping.end()) {
 					CODE_PROBE(true, "TSS checked in consistency check");
@@ -511,8 +511,8 @@ ACTOR Future<bool> checkDataConsistency(Database cx,
 				testFailure("Error fetching storage metrics", performQuiescentChecks, failureIsError);
 
 			// If running a distributed test, storage server size is an accumulation of shard estimates
-			else if (distributed && firstClient)
-				for (int j = 0; j < storageServers.size(); j++)
+			else if (distributed)
+				for (size_t j = 0; j < storageServers.size(); j++)
 					storageServerSizes[storageServers[j]] += std::max(estimatedBytes[j], (int64_t)0);
 		}
 
@@ -857,12 +857,12 @@ ACTOR Future<bool> checkDataConsistency(Database cx,
 			// This is only done in a non-distributed consistency check; the distributed check uses shard size
 			// estimates
 			if (!distributed)
-				for (int j = 0; j < storageServers.size(); j++)
+				for (size_t j = 0; j < storageServers.size(); j++)
 					storageServerSizes[storageServers[j]] += shardBytes;
 
 			// If the storage servers' sampled estimate of shard size is different from ours
 			if (performQuiescentChecks) {
-				for (int j = 0; j < estimatedBytes.size(); j++) {
+				for (size_t j = 0; j < estimatedBytes.size(); j++) {
 					if (estimatedBytes[j] >= 0 && estimatedBytes[j] != sampledBytes) {
 						TraceEvent("ConsistencyCheck_IncorrectEstimate")
 						    .detail("EstimatedBytes", estimatedBytes[j])

--- a/fdbserver/EncryptKeyProxy.actor.cpp
+++ b/fdbserver/EncryptKeyProxy.actor.cpp
@@ -818,9 +818,9 @@ void refreshBlobMetadata(Reference<EncryptKeyProxyData> ekpProxyData, KmsConnect
 void activateKmsConnector(Reference<EncryptKeyProxyData> ekpProxyData, KmsConnectorInterface kmsConnectorInf) {
 	if (g_network->isSimulated()) {
 		ekpProxyData->kmsConnector = std::make_unique<SimKmsConnector>(FDB_SIM_KMS_CONNECTOR_TYPE_STR);
-	} else if (SERVER_KNOBS->KMS_CONNECTOR_TYPE.compare(FDB_PREF_KMS_CONNECTOR_TYPE_STR) == 0) {
+	} else if (SERVER_KNOBS->KMS_CONNECTOR_TYPE == FDB_PREF_KMS_CONNECTOR_TYPE_STR) {
 		ekpProxyData->kmsConnector = std::make_unique<SimKmsConnector>(FDB_PREF_KMS_CONNECTOR_TYPE_STR);
-	} else if (SERVER_KNOBS->KMS_CONNECTOR_TYPE.compare(REST_KMS_CONNECTOR_TYPE_STR) == 0) {
+	} else if (SERVER_KNOBS->KMS_CONNECTOR_TYPE == REST_KMS_CONNECTOR_TYPE_STR) {
 		ekpProxyData->kmsConnector = std::make_unique<RESTKmsConnector>(REST_KMS_CONNECTOR_TYPE_STR);
 	} else {
 		throw not_implemented();

--- a/fdbserver/include/fdbserver/workloads/BlobStoreWorkload.h
+++ b/fdbserver/include/fdbserver/workloads/BlobStoreWorkload.h
@@ -34,11 +34,11 @@ inline void updateBackupURL(std::string& backupURL,
 	ASSERT(platform::getEnvironmentVar(accessKeyEnvVar.c_str(), accessKey));
 	ASSERT(platform::getEnvironmentVar(secretKeyEnvVar.c_str(), secretKey));
 	{
-		auto pos = backupURL.find(accessKeyPlaceholder.c_str());
+		auto pos = backupURL.find(accessKeyPlaceholder);
 		backupURL.replace(pos, accessKeyPlaceholder.size(), accessKey);
 	}
 	{
-		auto pos = backupURL.find(secretKeyPlaceholder.c_str());
+		auto pos = backupURL.find(secretKeyPlaceholder);
 		backupURL.replace(pos, secretKeyPlaceholder.size(), secretKey);
 	}
 }

--- a/fdbserver/workloads/ChangeFeedOperations.actor.cpp
+++ b/fdbserver/workloads/ChangeFeedOperations.actor.cpp
@@ -414,10 +414,10 @@ struct ChangeFeedOperationsWorkload : TestWorkload {
 
 		clearFrequency = deterministicRandom()->random01();
 
-		for (int i = 0; i < Op::OP_COUNT; i++) {
+		for (int& opWeight : opWeights) {
 			int randWeight = deterministicRandom()->randomExp(0, 5);
 			ASSERT(randWeight > 0);
-			opWeights[i] = randWeight;
+			opWeight = randWeight;
 		}
 
 		if (!doStops) {
@@ -432,9 +432,9 @@ struct ChangeFeedOperationsWorkload : TestWorkload {
 
 		std::string weightString = "|";
 		totalOpWeight = 0;
-		for (int i = 0; i < Op::OP_COUNT; i++) {
-			totalOpWeight += opWeights[i];
-			weightString += std::to_string(opWeights[i]) + "|";
+		for (int& opWeight : opWeights) {
+			totalOpWeight += opWeight;
+			weightString += std::to_string(opWeight) + "|";
 		}
 
 		TraceEvent("ChangeFeedOperationsInit")
@@ -575,14 +575,14 @@ struct ChangeFeedOperationsWorkload : TestWorkload {
 		TraceEvent("ChangeFeedOperationsCheck").detail("FeedCount", self->data.size()).log();
 		fmt::print("Checking {0} feeds\n", self->data.size()); // TODO REMOVE
 		state std::vector<Future<Void>> feedChecks;
-		for (int i = 0; i < self->data.size(); i++) {
-			if (self->data[i]->destroying) {
+		for (const auto& i : self->data) {
+			if (i->destroying) {
 				continue;
 			}
-			if (DEBUG_CF(self->data[i]->key)) {
-				fmt::print("Final check {0}\n", self->data[i]->key.printable());
+			if (DEBUG_CF(i->key)) {
+				fmt::print("Final check {0}\n", i->key.printable());
 			}
-			feedChecks.push_back(self->checkFeed(cx, self, self->data[i]));
+			feedChecks.push_back(self->checkFeed(cx, self, i));
 		}
 		wait(waitForAll(feedChecks));
 		// FIXME: check that all destroyed feeds are actually destroyed?

--- a/fdbserver/workloads/StatusWorkload.actor.cpp
+++ b/fdbserver/workloads/StatusWorkload.actor.cpp
@@ -116,8 +116,8 @@ struct StatusWorkload : TestWorkload {
 		}
 
 		std::string result = "\"bands\":[";
-		for (int i = 0; i < bands.size(); ++i) {
-			if (i > 0) {
+		for (size_t i = 0; i < bands.size(); ++i) {
+			if (i) {
 				result += ",";
 			}
 
@@ -142,7 +142,7 @@ struct StatusWorkload : TestWorkload {
 					    "},"
 					    "\"read\":{" +
 					    generateBands() +
-					    format(", \"max_key_selector_offset\":%d, \"max_read_bytes\":%d},",
+					    format(R"(, "max_key_selector_offset":%d, "max_read_bytes":%d},)",
 					           deterministicRandom()->randomInt(0, 10000),
 					           deterministicRandom()->randomInt(0, 1000000)) +
 					    ""
@@ -222,16 +222,16 @@ TEST_CASE("/fdbserver/status/schema/basic") {
 	};
 	check(true, "{}");
 	check(true, "{\"apple\":4}");
-	check(false, "{\"apple\":\"wrongtype\"}");
+	check(false, R"({"apple":"wrongtype"})");
 	check(false, "{\"extrathingy\":1}");
-	check(true, "{\"banana\":\"b\",\"sub\":{\"thing\":false}}");
-	check(false, "{\"banana\":\"b\",\"sub\":{\"thing\":false, \"x\":0}}");
-	check(true, "{\"arr\":[{},{\"a\":0}]}");
-	check(false, "{\"arr\":[{\"a\":0},{\"c\":0}]}");
-	check(true, "{\"en\":\"bar\"}");
-	check(false, "{\"en\":\"baz\"}");
-	check(true, "{\"mapped\":{\"item1\":{\"x\":false},\"item2\":{}}}");
-	check(false, "{\"mapped\":{\"item1\":{\"x\":false},\"item2\":{\"y\":1}}}");
+	check(true, R"({"banana":"b","sub":{"thing":false}})");
+	check(false, R"({"banana":"b","sub":{"thing":false, "x":0}})");
+	check(true, R"({"arr":[{},{"a":0}]})");
+	check(false, R"({"arr":[{"a":0},{"c":0}]})");
+	check(true, R"({"en":"bar"})");
+	check(false, R"({"en":"baz"})");
+	check(true, R"({"mapped":{"item1":{"x":false},"item2":{}}})");
+	check(false, R"({"mapped":{"item1":{"x":false},"item2":{"y":1}}})");
 
 	return Void();
 }

--- a/flow/Histogram.cpp
+++ b/flow/Histogram.cpp
@@ -56,7 +56,7 @@ void HistogramRegistry::unregisterHistogram(Histogram* h) {
 	if (histograms.find(name) == histograms.end()) {
 		TraceEvent(SevError, "HistogramNotRegistered").detail("group", h->group).detail("op", h->op);
 	}
-	int count = histograms.erase(name);
+	size_t count = histograms.erase(name);
 	ASSERT(count == 1);
 }
 
@@ -90,8 +90,8 @@ const char* const Histogram::UnitToStringMapper[] = { "milliseconds", "bytes", "
 
 void Histogram::writeToLog(double elapsed) {
 	bool active = false;
-	for (uint32_t i = 0; i < 32; i++) {
-		if (buckets[i]) {
+	for (unsigned int bucket : buckets) {
+		if (bucket) {
 			active = true;
 			break;
 		}
@@ -104,7 +104,7 @@ void Histogram::writeToLog(double elapsed) {
 	e.detail("Group", group).detail("Op", op).detail("Unit", UnitToStringMapper[(size_t)unit]);
 	if (elapsed > 0)
 		e.detail("Elapsed", elapsed);
-	int totalCount = 0;
+	uint32_t totalCount = 0;
 	for (uint32_t i = 0; i < 32; i++) {
 		uint64_t value = uint64_t(1) << (i + 1);
 
@@ -150,17 +150,17 @@ std::string Histogram::drawHistogram() {
 	const char* xFull = "---▀▀▀\0";
 	const char* xEmpty = "------\0";
 	const char* lineEnd = "--- \0";
-	const unsigned int width = std::strlen(emptyCell);
+	static const size_t width = std::strlen(emptyCell);
 
-	int max_lines = 23;
-	uint32_t total = 0;
+	constexpr unsigned int max_lines = 23;
+	unsigned int total = 0;
 	double maxPct = 0;
 
-	for (int i = 0; i < 32; i++) {
-		total += buckets[i];
+	for (unsigned int bucket : buckets) {
+		total += bucket;
 	}
-	for (int i = 0; i < 32; i++) {
-		maxPct = std::max(maxPct, (100.0 * buckets[i]) / total);
+	for (unsigned int bucket : buckets) {
+		maxPct = std::max(maxPct, (100.0 * bucket) / total);
 	}
 
 	double intervalSize = (maxPct < (max_lines - 3)) ? 1 : maxPct / (max_lines - 3);
@@ -169,12 +169,12 @@ std::string Histogram::drawHistogram() {
 	result << "Total Inputs: " << total << std::fixed << "\n";
 	result << "Percent"
 	       << "\n";
-	for (int l = 0; l < lines; l++) {
+	for (unsigned int l = 0; l < lines; l++) {
 		double currHeight = (lines - l) * intervalSize;
 		double halfFullHeight = currHeight - intervalSize / 4;
 		result << std::setw(6) << std::setprecision(2) << currHeight << " " << verticalLine;
-		for (int i = 0; i < 32; i++) {
-			double pct = (100.0 * buckets[i]) / total;
+		for (unsigned int bucket : buckets) {
+			double pct = (100.0 * bucket) / total;
 			if (pct > currHeight)
 				result << fullCell;
 			else if (pct > halfFullHeight)
@@ -186,8 +186,8 @@ std::string Histogram::drawHistogram() {
 	}
 
 	result << "  0.00 " << origin;
-	for (int i = 0; i < 32; i++) {
-		double pct = (100.0 * buckets[i]) / total;
+	for (unsigned int bucket : buckets) {
+		double pct = (100.0 * bucket) / total;
 		if (pct > intervalSize / 4)
 			result << xFull;
 		else
@@ -196,8 +196,8 @@ std::string Histogram::drawHistogram() {
 	result << lineEnd << "\n";
 
 	result << std::string(9, ' ');
-	for (int i = 0; i < 32; i++) {
-		result << std::left << std::setw(width) << "  B" + std::to_string(i);
+	for (unsigned int i = 0; i < 32; i++) {
+		result << std::left << std::setw(width) << "  B" + i;
 	}
 	result << "\n";
 	return result.str();

--- a/flow/Net2.actor.cpp
+++ b/flow/Net2.actor.cpp
@@ -1487,7 +1487,7 @@ void Net2::run() {
 		taskBegin = timer_monotonic();
 		numYields = 0;
 		TaskPriority minTaskID = TaskPriority::Max;
-		[[maybe_unused]] int queueSize = taskQueue.getNumReadyTasks();
+		[[maybe_unused]] size_t queueSize = taskQueue.getNumReadyTasks();
 
 		FDB_TRACE_PROBE(run_loop_tasks_start, queueSize);
 		while (taskQueue.hasReadyTask()) {
@@ -2072,7 +2072,7 @@ THREAD_HANDLE startThreadF(F&& func) {
 			THREAD_RETURN;
 		}
 	};
-	Thing* t = new Thing(std::move(func));
+	Thing* t = new Thing(std::forward<F>(func));
 	return g_network->startThread(Thing::start, t);
 }
 

--- a/flow/Trace.cpp
+++ b/flow/Trace.cpp
@@ -480,7 +480,7 @@ public:
 			writer->post(o);
 
 			std::vector<TraceEventFields> events = latestEventCache.getAllUnsafe();
-			for (int idx = 0; idx < events.size(); idx++) {
+			for (size_t idx = 0; idx < events.size(); idx++) {
 				if (events[idx].size() > 0) {
 					TraceEventFields rolledFields;
 					for (auto itr = events[idx].begin(); itr != events[idx].end(); ++itr) {
@@ -888,7 +888,7 @@ BaseTraceEvent& BaseTraceEvent::operator=(BaseTraceEvent&& ev) {
 	type = ev.type;
 	timeIndex = ev.timeIndex;
 
-	for (int i = 0; i < 5; i++) {
+	for (unsigned int i = 0; i < 5; i++) {
 		eventCounts[i] = ev.eventCounts[i];
 	}
 
@@ -1426,25 +1426,25 @@ void TraceBatch::dump() {
 		machine = formatIpPort(local.ip, local.port);
 	}
 
-	for (int i = 0; i < attachBatch.size(); i++) {
+	for (auto& i : attachBatch) {
 		if (g_network->isSimulated()) {
-			attachBatch[i].fields.addField("Machine", machine);
+			i.fields.addField("Machine", machine);
 		}
-		g_traceLog.writeEvent(attachBatch[i].fields, "", false);
+		g_traceLog.writeEvent(i.fields, "", false);
 	}
 
-	for (int i = 0; i < eventBatch.size(); i++) {
+	for (auto& i : eventBatch) {
 		if (g_network->isSimulated()) {
-			eventBatch[i].fields.addField("Machine", machine);
+			i.fields.addField("Machine", machine);
 		}
-		g_traceLog.writeEvent(eventBatch[i].fields, "", false);
+		g_traceLog.writeEvent(i.fields, "", false);
 	}
 
-	for (int i = 0; i < buggifyBatch.size(); i++) {
+	for (auto& i : buggifyBatch) {
 		if (g_network->isSimulated()) {
-			buggifyBatch[i].fields.addField("Machine", machine);
+			i.fields.addField("Machine", machine);
 		}
-		g_traceLog.writeEvent(buggifyBatch[i].fields, "", false);
+		g_traceLog.writeEvent(i.fields, "", false);
 	}
 
 	onMainThreadVoid([]() { g_traceLog.flush(); });
@@ -1692,7 +1692,7 @@ std::string TraceEventFields::toString() const {
 		}
 		first = false;
 
-		str += format("\"%s\"=\"%s\"", itr->first.c_str(), itr->second.c_str());
+		str += format(R"("%s"="%s")", itr->first.c_str(), itr->second.c_str());
 	}
 
 	return str;

--- a/flow/include/flow/Hostname.h
+++ b/flow/include/flow/Hostname.h
@@ -53,8 +53,8 @@ struct Hostname {
 	//    host-name:1234
 	//    host-name_part1.host-name_part2:1234:tls
 	static bool isHostname(const std::string& s) {
-		std::regex validation("^([\\w\\-]+\\.?)+:([\\d]+){1,}(:tls)?$");
-		std::regex ipv4Validation("^([\\d]{1,3}\\.?){4,}:([\\d]+){1,}(:tls)?$");
+		std::regex validation(R"(^([\w\-]+\.?)+:([\d]+){1,}(:tls)?$)");
+		std::regex ipv4Validation(R"(^([\d]{1,3}\.?){4,}:([\d]+){1,}(:tls)?$)");
 		return !std::regex_match(s, ipv4Validation) && std::regex_match(s, validation);
 	}
 


### PR DESCRIPTION
These changes greatly simplify the code and makes the intent more clear.