### PR TITLE
fixup! Fix the clang error in bindings/c

### DIFF
--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -224,7 +224,11 @@ if(NOT WIN32)
     # Make sure that fdb_c.h is compatible with c90
     add_executable(fdb_c90_test test/fdb_c90_test.c)
     set_property(TARGET fdb_c90_test PROPERTY C_STANDARD 90)
-    target_compile_options(fdb_c90_test PRIVATE -Wall -Wextra -Wpedantic -Werror)
+	if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+	  target_compile_options(fdb_c90_test PRIVATE -Wall -Wextra -Wpedantic -Wno-gnu-line-marker -Werror)
+	else ()
+	  target_compile_options(fdb_c90_test PRIVATE -Wall -Wextra -Wpedantic -Werror)
+	endif ()
     target_link_libraries(fdb_c90_test PRIVATE fdb_c)
   endif()
 


### PR DESCRIPTION
clang15 will recognize some of the GNU extensions and mark the warnings as errors. This patch will set the errors back to warnings so they will not fail the build.

The warnings/errors are:

```
FAILED: bindings/c/CMakeFiles/fdb_c90_test.dir/test/fdb_c90_test.c.o
ccache /usr/local/bin/clang -DBOOST_ERROR_CODE_HEADER_ONLY -DBOOST_SYSTEM_NO_DEPRECATED -DNO_INTELLISENSE -I/root/release-7.2/bindings/c -I/root/src/bindings/c -I/root/release-7.2/bindings/c/foundationdb -O3 -DNDEBUG -DCMAKE_BUILD -ggdb -fno-omit-frame-pointer -mavx -Wall -Wextra -Wredundant-move -Wpessimizing-move -Woverloaded-virtual -Wshift-sign-overflow -Wno-sign-compare -Wno-undefined-var-template -Wno-unknown-warning-option -Wno-unused-parameter -Wno-constant-logical-operand -Wno-deprecated-copy -Wno-delete-non-abstract-non-virtual-dtor -Wno-range-loop-construct -Wno-reorder-ctor -Wno-unused-command-line-argument -Wno-register -Werror -Wno-error=format -Wunused-variable -Wno-deprecated -fvisibility=hidden -Wreturn-type -fPIC -DHAVE_OPENSSL -Wpedantic -std=gnu90 -MD -MT bindings/c/CMakeFiles/fdb_c90_test.dir/test/fdb_c90_test.c.o -MF bindings/c/CMakeFiles/fdb_c90_test.dir/test/fdb_c90_test.c.o.d -o bindings/c/CMakeFiles/fdb_c90_test.dir/test/fdb_c90_test.c.o -c /root/src/bindings/c/test/fdb_c90_test.c
distcc[22523] ERROR: compile /root/src/bindings/c/test/fdb_c90_test.c on distcc.default.svc.cluster.local/84 failed
distcc[22523] (dcc_build_somewhere) Warning: remote compilation of '/root/src/bindings/c/test/fdb_c90_test.c' failed, retrying locally
distcc[22523] (dcc_build_somewhere) ERROR: failed to distribute and fallbacks are disabled
/tmp/distccd_0d6d8c4b.i:1:5: error: this style of line directive is a GNU extension [-Werror,-Wgnu-line-marker]
# 1 "/root/src/bindings/c/test/fdb_c90_test.c"
    ^
/root/src/bindings/c/test/fdb_c90_test.c:1:5: error: this style of line directive is a GNU extension [-Werror,-Wgnu-line-marker]
# 1 "<built-in>" 1
    ^
/root/src/bindings/c/test/fdb_c90_test.c:2:5: error: this style of line directive is a GNU extension [-Werror,-Wgnu-line-marker]
# 1 "/root/src/bindings/c/foundationdb/fdb_c.h" 1
    ^
In file included from /root/src/bindings/c/test/fdb_c90_test.c:2:
/root/src/bindings/c/foundationdb/fdb_c.h:1:6: error: this style of line directive is a GNU extension [-Werror,-Wgnu-line-marker]
# 58 "/root/src/bindings/c/foundationdb/fdb_c.h"
     ^
/root/src/bindings/c/foundationdb/fdb_c.h:58:5: error: this style of line directive is a GNU extension [-Werror,-Wgnu-line-marker]
# 1 "/usr/local/lib/clang/15.0.6/include/stdint.h" 1 3
    ^
/root/src/bindings/c/foundationdb/fdb_c.h:60:5: error: this style of line directive is a GNU extension [-Werror,-Wgnu-line-marker]
# 1 "/root/release-7.2/bindings/c/foundationdb/fdb_c_options.g.h" 1
    ^
In file included from /root/src/bindings/c/test/fdb_c90_test.c:2:
In file included from /root/src/bindings/c/foundationdb/fdb_c.h:60:
/root/release-7.2/bindings/c/foundationdb/fdb_c_options.g.h:1:6: error: this style of line directive is a GNU extension [-Werror,-Wgnu-line-marker]
# 26 "/root/release-7.2/bindings/c/foundationdb/fdb_c_options.g.h"
     ^
/root/release-7.2/bindings/c/foundationdb/fdb_c_options.g.h:564:6: error: this style of line directive is a GNU extension [-Werror,-Wgnu-line-marker]
# 61 "/root/src/bindings/c/foundationdb/fdb_c.h" 2
     ^
In file included from /root/src/bindings/c/test/fdb_c90_test.c:2:
/root/src/bindings/c/foundationdb/fdb_c.h:61:5: error: this style of line directive is a GNU extension [-Werror,-Wgnu-line-marker]
# 1 "/root/src/bindings/c/foundationdb/fdb_c_types.h" 1
    ^
In file included from /root/src/bindings/c/test/fdb_c90_test.c:2:
In file included from /root/src/bindings/c/foundationdb/fdb_c.h:61:
/root/src/bindings/c/foundationdb/fdb_c_types.h:1:6: error: this style of line directive is a GNU extension [-Werror,-Wgnu-line-marker]
# 34 "/root/src/bindings/c/foundationdb/fdb_c_types.h"
     ^
/root/src/bindings/c/foundationdb/fdb_c_types.h:43:6: error: this style of line directive is a GNU extension [-Werror,-Wgnu-line-marker]
# 62 "/root/src/bindings/c/foundationdb/fdb_c.h" 2
     ^
In file included from /root/src/bindings/c/test/fdb_c90_test.c:2:
/root/src/bindings/c/foundationdb/fdb_c.h:100:7: error: this style of line directive is a GNU extension [-Werror,-Wgnu-line-marker]
# 109 "/root/src/bindings/c/foundationdb/fdb_c.h"
      ^
/root/src/bindings/c/foundationdb/fdb_c.h:126:7: error: this style of line directive is a GNU extension [-Werror,-Wgnu-line-marker]
# 156 "/root/src/bindings/c/foundationdb/fdb_c.h"
      ^
/root/src/bindings/c/foundationdb/fdb_c.h:506:7: error: this style of line directive is a GNU extension [-Werror,-Wgnu-line-marker]
# 514 "/root/src/bindings/c/foundationdb/fdb_c.h"
      ^
/root/src/bindings/c/foundationdb/fdb_c.h:577:5: error: this style of line directive is a GNU extension [-Werror,-Wgnu-line-marker]
# 3 "/root/src/bindings/c/test/fdb_c90_test.c" 2
    ^
15 errors generated.
```

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
