### PR TITLE
Add knob to control emission of DDSketch buckets

### DIFF
--- a/flow/Knobs.cpp
+++ b/flow/Knobs.cpp
@@ -95,6 +95,7 @@ void FlowKnobs::initialize(Randomize randomize, IsSimulated isSimulated) {
 	init( STATSD_UDP_EMISSION_PORT,                           8125 );
 	init( OTEL_UDP_EMISSION_ADDR,                       "127.0.0.1");
 	init( OTEL_UDP_EMISSION_PORT,                             8903 );
+	init( METRICS_EMIT_DDSKETCH,                             false ); // Determines if DDSketch buckets will get emitted
 
 	//connectionMonitor
 	init( CONNECTION_MONITOR_LOOP_TIME,   isSimulated ? 0.75 : 1.0 ); if( randomize && BUGGIFY ) CONNECTION_MONITOR_LOOP_TIME = 6.0;

--- a/flow/include/flow/Knobs.h
+++ b/flow/include/flow/Knobs.h
@@ -152,6 +152,7 @@ public:
 	std::string OTEL_UDP_EMISSION_ADDR;
 	int STATSD_UDP_EMISSION_PORT;
 	int OTEL_UDP_EMISSION_PORT;
+	bool METRICS_EMIT_DDSKETCH;
 
 	// run loop profiling
 	double RUN_LOOP_PROFILING_INTERVAL;


### PR DESCRIPTION
We don't always need to emit all DDSketch buckets. Since it might be a costly operation, the default is false. The knob `METRICS_EMIT_DDSKETCH` determines whether or not the buckets get emitted. 

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
