### PR TITLE
Automatically clean old idempotency ids

### DIFF
--- a/fdbclient/IdempotencyId.actor.cpp
+++ b/fdbclient/IdempotencyId.actor.cpp
@@ -228,7 +228,7 @@ ACTOR static Future<Optional<Key>> getBoundary(Reference<ReadYourWritesTransacti
 	return result.front().key;
 }
 
-ACTOR Future<Void> cleanIdempotencyIds(Database db, int64_t minAgeSeconds) {
+ACTOR Future<Void> cleanIdempotencyIds(Database db, double minAgeSeconds) {
 	state int64_t idmpKeySize;
 	state int64_t candidateDeleteSize;
 	state KeyRange candidateRangeToClean;

--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -1062,6 +1062,10 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	// Drop in-memory state associated with an idempotency id after this many seconds. Once dropped, this id cannot be
 	// expired proactively, but will eventually get cleaned up by the idempotency id cleaner.
 	init( IDEMPOTENCY_ID_IN_MEMORY_LIFETIME,                       10);
+	// Attempt to clean old idempotency ids automatically this often
+ 	init( IDEMPOTENCY_IDS_CLEANER_POLLING_INTERVAL,                10);
+	// Don't clean idempotency ids younger than this
+ 	init( IDEMPOTENCY_IDS_MIN_AGE_SECONDS,              3600 * 24 * 7);
 
 	// clang-format on
 

--- a/fdbclient/include/fdbclient/IdempotencyId.actor.h
+++ b/fdbclient/include/fdbclient/IdempotencyId.actor.h
@@ -188,7 +188,7 @@ KeyRangeRef makeIdempotencySingleKeyRange(Arena& arena, Version version, uint8_t
 void decodeIdempotencyKey(KeyRef key, Version& commitVersion, uint8_t& highOrderBatchIndex);
 
 // Delete zero or more idempotency ids older than minAgeSeconds
-ACTOR Future<Void> idempotencyIdsCleaner(Database db, int64_t minAgeSeconds);
+ACTOR Future<Void> cleanIdempotencyIds(Database db, double minAgeSeconds);
 
 #include "flow/unactorcompiler.h"
 #endif

--- a/fdbclient/include/fdbclient/IdempotencyId.actor.h
+++ b/fdbclient/include/fdbclient/IdempotencyId.actor.h
@@ -43,6 +43,8 @@ struct CommitResult {
 // The type of the value stored at the key |idempotencyIdsExpiredVersion|
 struct IdempotencyIdsExpiredVersion {
 	static constexpr auto file_identifier = 3746945;
+	// Any version at or below expired might have had its idempotency id expired. Any version greater than `expired`
+	// definitely has not had it's idempotency id expired.
 	Version expired = 0;
 
 	template <class Archive>
@@ -184,6 +186,9 @@ Optional<CommitResult> kvContainsIdempotencyId(const KeyValueRef& kv, const Idem
 KeyRangeRef makeIdempotencySingleKeyRange(Arena& arena, Version version, uint8_t highOrderBatchIndex);
 
 void decodeIdempotencyKey(KeyRef key, Version& commitVersion, uint8_t& highOrderBatchIndex);
+
+// Delete zero or more idempotency ids older than minAgeSeconds
+ACTOR Future<Void> idempotencyIdsCleaner(Database db, int64_t minAgeSeconds);
 
 #include "flow/unactorcompiler.h"
 #endif

--- a/fdbclient/include/fdbclient/IdempotencyId.actor.h
+++ b/fdbclient/include/fdbclient/IdempotencyId.actor.h
@@ -188,6 +188,10 @@ KeyRangeRef makeIdempotencySingleKeyRange(Arena& arena, Version version, uint8_t
 void decodeIdempotencyKey(KeyRef key, Version& commitVersion, uint8_t& highOrderBatchIndex);
 
 // Delete zero or more idempotency ids older than minAgeSeconds
+//
+// Normally idempotency ids are deleted as part of the normal commit process, so this only needs to clean ids that
+// leaked during a failure scenario. The rate of leaked idempotency ids should be low. The rate is zero during normal
+// operation, and proportional to the number of in-flight transactions during a failure scenario.
 ACTOR Future<Void> cleanIdempotencyIds(Database db, double minAgeSeconds);
 
 #include "flow/unactorcompiler.h"

--- a/fdbclient/include/fdbclient/ServerKnobs.h
+++ b/fdbclient/include/fdbclient/ServerKnobs.h
@@ -1018,8 +1018,8 @@ public:
 
 	// Idempotency ids
 	double IDEMPOTENCY_ID_IN_MEMORY_LIFETIME;
- 	double IDEMPOTENCY_IDS_CLEANER_POLLING_INTERVAL;
- 	double IDEMPOTENCY_IDS_MIN_AGE_SECONDS;
+	double IDEMPOTENCY_IDS_CLEANER_POLLING_INTERVAL;
+	double IDEMPOTENCY_IDS_MIN_AGE_SECONDS;
 
 	ServerKnobs(Randomize, ClientKnobs*, IsSimulated);
 	void initialize(Randomize, ClientKnobs*, IsSimulated);

--- a/fdbclient/include/fdbclient/ServerKnobs.h
+++ b/fdbclient/include/fdbclient/ServerKnobs.h
@@ -1018,6 +1018,8 @@ public:
 
 	// Idempotency ids
 	double IDEMPOTENCY_ID_IN_MEMORY_LIFETIME;
+ 	double IDEMPOTENCY_IDS_CLEANER_POLLING_INTERVAL;
+ 	double IDEMPOTENCY_IDS_MIN_AGE_SECONDS;
 
 	ServerKnobs(Randomize, ClientKnobs*, IsSimulated);
 	void initialize(Randomize, ClientKnobs*, IsSimulated);

--- a/fdbserver/workloads/AutomaticIdempotencyWorkload.actor.cpp
+++ b/fdbserver/workloads/AutomaticIdempotencyWorkload.actor.cpp
@@ -46,14 +46,19 @@ struct AutomaticIdempotencyWorkload : TestWorkload {
 	static constexpr auto NAME = "AutomaticIdempotencyCorrectness";
 	int64_t numTransactions;
 	Key keyPrefix;
+	int64_t minMinAgeSeconds;
 	double automaticPercentage;
+	constexpr static double slop = 2.0;
+	double pollingInterval;
 
 	bool ok = true;
 
 	AutomaticIdempotencyWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
 		numTransactions = getOption(options, "numTransactions"_sr, 2500);
 		keyPrefix = KeyRef(getOption(options, "keyPrefix"_sr, "/autoIdempotency/"_sr));
+		minMinAgeSeconds = getOption(options, "minMinAgeSeconds"_sr, 15);
 		automaticPercentage = getOption(options, "automaticPercentage"_sr, 0.1);
+		pollingInterval = getOption(options, "pollingInterval"_sr, 5.0);
 	}
 
 	Future<Void> setup(Database const& cx) override { return Void(); }
@@ -101,6 +106,7 @@ struct AutomaticIdempotencyWorkload : TestWorkload {
 		wait(runRYWTransaction(db,
 		                       [=](Reference<ReadYourWritesTransaction> tr) { return logIdempotencyIds(self, tr); }));
 		wait(runRYWTransaction(db, [=](Reference<ReadYourWritesTransaction> tr) { return testIdempotency(self, tr); }));
+		wait(testCleaner(self, db));
 		return self->ok;
 	}
 
@@ -161,6 +167,165 @@ struct AutomaticIdempotencyWorkload : TestWorkload {
 			self->ok = false;
 		}
 		ASSERT_EQ(ids.size(), self->clientCount * self->numTransactions);
+		return Void();
+	}
+
+	ACTOR static Future<int64_t> getOldestCreatedTime(AutomaticIdempotencyWorkload* self, Database db) {
+		state ReadYourWritesTransaction tr(db);
+		state RangeResult result;
+		state Key key;
+		state Version commitVersion;
+		loop {
+			try {
+				tr.setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
+				wait(store(result, tr.getRange(idempotencyIdKeys, /*limit*/ 1)));
+				if (result.empty()) {
+					TraceEvent("AutomaticIdempotencyNoIdsLeft").log();
+					return -1;
+				}
+				for (const auto& [k, v] : result) {
+					uint8_t highOrderBatchIndex;
+					decodeIdempotencyKey(k, commitVersion, highOrderBatchIndex);
+
+					// Decode the first idempotency id in the value
+					BinaryReader valReader(v.begin(), v.size(), IncludeVersion());
+					int64_t timeStamp; // ignored
+					valReader >> timeStamp;
+					uint8_t length;
+					valReader >> length;
+					StringRef id{ reinterpret_cast<const uint8_t*>(valReader.readBytes(length)), length };
+					uint8_t lowOrderBatchIndex;
+					valReader >> lowOrderBatchIndex;
+
+					// Recover the key written in the transaction associated with this idempotency id
+					BinaryWriter keyWriter(Unversioned());
+					keyWriter.serializeBytes(self->keyPrefix);
+					keyWriter.serializeBinaryItem(bigEndian64(commitVersion));
+					keyWriter.serializeBinaryItem(highOrderBatchIndex);
+					keyWriter.serializeBinaryItem(lowOrderBatchIndex);
+					key = keyWriter.toValue();
+
+					// We need to use a different transaction because we set READ_SYSTEM_KEYS on this one, and we might
+					// be using a tenant.
+					Optional<Value> entry = wait(runRYWTransaction(
+					    db, [key = key](Reference<ReadYourWritesTransaction> tr) { return tr->get(key); }));
+					if (!entry.present()) {
+						TraceEvent(SevError, "AutomaticIdempotencyKeyMissing")
+						    .detail("Key", key)
+						    .detail("CommitVersion", commitVersion)
+						    .detail("ReadVersion", tr.getReadVersion().get());
+					}
+					ASSERT(entry.present());
+					auto e = ObjectReader::fromStringRef<ValueType>(entry.get(), Unversioned());
+					return e.createdTime;
+				}
+				ASSERT(false);
+			} catch (Error& e) {
+				wait(tr.onError(e));
+			}
+		}
+	}
+
+	ACTOR static Future<bool> testCleanerOneIteration(AutomaticIdempotencyWorkload* self,
+	                                                  Database db,
+	                                                  ActorCollection* actors,
+	                                                  int64_t minAgeSeconds,
+	                                                  const std::vector<int64_t>* createdTimes) {
+		state Future<Void> cleaner = recurringAsync(
+		    [db = db, minAgeSeconds = minAgeSeconds]() { return cleanIdempotencyIds(db, minAgeSeconds); },
+		    self->pollingInterval,
+		    true,
+		    self->pollingInterval);
+
+		state int64_t oldestCreatedTime;
+		state int64_t successes = 0;
+		actors->add(cleaner);
+		loop {
+			// Oldest created time of a transaction from the workload which still has an idempotency id
+			wait(store(oldestCreatedTime, getOldestCreatedTime(self, db)));
+			if (oldestCreatedTime == -1) {
+				return true; // Test can't make meaningful progress anymore
+			}
+
+			// oldestCreatedTime could seem too high if there's a large gap in the age
+			// of entries, so account for this by making oldestCreatedTime one more than
+			// the youngest entry that actually got deleted.
+			auto iter = std::lower_bound(createdTimes->begin(), createdTimes->end(), oldestCreatedTime);
+			if (iter != createdTimes->begin()) {
+				--iter;
+				oldestCreatedTime = *iter + 1;
+			}
+			auto maxActualAge = int64_t(now()) - oldestCreatedTime;
+			if (maxActualAge > minAgeSeconds * self->slop) {
+				CODE_PROBE(true, "Idempotency cleaner more to clean");
+				TraceEvent("AutomaticIdempotencyCleanerMoreToClean")
+				    .detail("MaxActualAge", maxActualAge)
+				    .detail("MinAgePolicy", minAgeSeconds);
+				successes = 0;
+				// Cleaning should happen eventually
+			} else if (maxActualAge < minAgeSeconds / self->slop) {
+				TraceEvent(SevError, "AutomaticIdempotencyCleanedTooMuch")
+				    .detail("MaxActualAge", maxActualAge)
+				    .detail("MinAgePolicy", minAgeSeconds);
+				self->ok = false;
+				ASSERT(false);
+			} else {
+				++successes;
+				TraceEvent("AutomaticIdempotencyCleanerSuccess")
+				    .detail("MaxActualAge", maxActualAge)
+				    .detail("MinAgePolicy", minAgeSeconds)
+				    .detail("Successes", successes);
+				if (successes >= 10) {
+					break;
+				}
+			}
+			wait(delay(self->pollingInterval));
+		}
+		cleaner.cancel();
+		return false;
+	}
+
+	ACTOR static Future<std::vector<int64_t>> getCreatedTimes(AutomaticIdempotencyWorkload* self,
+	                                                          Reference<ReadYourWritesTransaction> tr) {
+		RangeResult result = wait(tr->getRange(prefixRange(self->keyPrefix), CLIENT_KNOBS->TOO_MANY));
+		ASSERT(!result.more);
+		std::vector<int64_t> createdTimes;
+		for (const auto& [k, v] : result) {
+			auto e = ObjectReader::fromStringRef<ValueType>(v, Unversioned());
+			createdTimes.emplace_back(e.createdTime);
+		}
+		std::sort(createdTimes.begin(), createdTimes.end());
+		return createdTimes;
+	}
+
+	// Check that min age is respected. Also test that we can tolerate concurrent cleaners.
+	ACTOR static Future<Void> testCleaner(AutomaticIdempotencyWorkload* self, Database db) {
+		state ActorCollection actors;
+		state int64_t minAgeSeconds;
+		state std::vector<int64_t> createdTimes;
+
+		// Initialize minAgeSeconds to match the current status
+		wait(store(minAgeSeconds, fmap([](int64_t t) { return int64_t(now()) - t; }, getOldestCreatedTime(self, db))) &&
+		     store(createdTimes, runRYWTransaction(db, [self = self](Reference<ReadYourWritesTransaction> tr) {
+			           return getCreatedTimes(self, tr);
+		           })));
+
+		// Slowly and somewhat randomly allow the cleaner to do more cleaning. Observe that it cleans some, but not too
+		// much.
+		loop {
+			minAgeSeconds *= 1 / (self->slop * 2);
+			if (minAgeSeconds < self->minMinAgeSeconds) {
+				break;
+			}
+			choose {
+				when(bool done = wait(testCleanerOneIteration(self, db, &actors, minAgeSeconds, &createdTimes))) {
+					if (done) {
+						break;
+					}
+				}
+				when(wait(actors.getResult())) { ASSERT(false); }
+			}
+		}
 		return Void();
 	}
 

--- a/fdbserver/workloads/AutomaticIdempotencyWorkload.actor.cpp
+++ b/fdbserver/workloads/AutomaticIdempotencyWorkload.actor.cpp
@@ -323,7 +323,9 @@ struct AutomaticIdempotencyWorkload : TestWorkload {
 						break;
 					}
 				}
-				when(wait(actors.getResult())) { ASSERT(false); }
+				when(wait(actors.getResult())) {
+					ASSERT(false);
+				}
 			}
 		}
 		return Void();

--- a/tests/fast/AutomaticIdempotency.toml
+++ b/tests/fast/AutomaticIdempotency.toml
@@ -3,6 +3,8 @@ testTitle = 'AutomaticIdempotency'
 
     [[test.workload]]
     testName = 'AutomaticIdempotencyCorrectness'
+    minMinAgeSeconds = 15
+    pollingInterval = 5.0
 
     [[test.workload]]
     testName='Attrition'


### PR DESCRIPTION
Add a new actor to the first proxy which periodically checks for old idempotency ids and deletes them. Tested by adding a new workload which validates that the cleaner cleans ids older than a min age configurable via a knob, and does not clean ids younger than that knob.

Normally idempotency ids are deleted as part of the normal commit process, so this only needs to clean ids that leaked during a failure scenario. The rate of leaked idempotency ids should be low. The rate is zero during normal operation, and proportional to the number of in-flight transactions during a failure scenario.

New knobs:

1. IDEMPOTENCY_IDS_CLEANER_POLLING_INTERVAL
1. IDEMPOTENCY_IDS_MIN_AGE_SECONDS

Co-authored by @sfc-gh-akejriwal and Santosh Porwal

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
