### PR TITLE
fix uninitialised byte(s) field in NumberDataPoint

### DIFF
--- a/flow/include/flow/OTELMetrics.h
+++ b/flow/include/flow/OTELMetrics.h
@@ -66,7 +66,7 @@ enum DataPointFlags { FLAG_NONE = 0, FLAG_NO_RECORDED_VALUE };
 
 class NumberDataPoint {
 public:
-	double startTime; // 9 bytes in msgpack
+	double startTime = -1; // 9 bytes in msgpack
 	double recordTime; // 9 bytes in msgpack
 	std::vector<Attribute> attributes; // Variable size: assume to be 23 bytes
 	std::variant<int64_t, double> val; // 9 bytes in msgpack


### PR DESCRIPTION
Fix #9046
I think in OTEL point the startTime is not used, so I set the default value to -1. Correct me if I am wrong.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
