### PR TITLE
Make mapAsync usable without specifying template parameters

### DIFF
--- a/fdbrpc/AsyncFileCached.actor.cpp
+++ b/fdbrpc/AsyncFileCached.actor.cpp
@@ -245,8 +245,7 @@ Future<Void> AsyncFileCached::changeFileSize(int64_t size) {
 
 	// Wait for the page truncations to finish, then truncate the underlying file
 	// Template types are being provided explicitly because they can't be automatically deduced for some reason.
-	return mapAsync<Void, std::function<Future<Void>(Void)>, Void>(
-	    waitForAll(actors), [=](Void _) -> Future<Void> { return uncached->truncate(size); });
+	return mapAsync(waitForAll(actors), [=](Void _) -> Future<Void> { return uncached->truncate(size); });
 }
 
 Future<Void> AsyncFileCached::flush() {

--- a/fdbrpc/include/fdbrpc/LoadBalance.actor.h
+++ b/fdbrpc/include/fdbrpc/LoadBalance.actor.h
@@ -299,14 +299,13 @@ struct RequestData : NonCopyable {
 		requestStarted = false;
 
 		if (backoff > 0) {
-			response = mapAsync<Void, std::function<Future<Reply>(Void)>, Reply>(
-			    delay(backoff), [this, stream, &request, model, alternatives, channel](Void _) {
-				    requestStarted = true;
-				    modelHolder = Reference<ModelHolder>(new ModelHolder(model, stream->getEndpoint().token.first()));
-				    Future<Reply> resp = stream->tryGetReply(request);
-				    maybeDuplicateTSSRequest(stream, request, model, resp, alternatives, channel);
-				    return resp;
-			    });
+			response = mapAsync(delay(backoff), [this, stream, &request, model, alternatives, channel](Void _) {
+				requestStarted = true;
+				modelHolder = Reference<ModelHolder>(new ModelHolder(model, stream->getEndpoint().token.first()));
+				Future<Reply> resp = stream->tryGetReply(request);
+				maybeDuplicateTSSRequest(stream, request, model, resp, alternatives, channel);
+				return resp;
+			});
 		} else {
 			requestStarted = true;
 			modelHolder = Reference<ModelHolder>(new ModelHolder(model, stream->getEndpoint().token.first()));

--- a/flow/include/flow/genericactors.actor.h
+++ b/flow/include/flow/genericactors.actor.h
@@ -344,10 +344,10 @@ Future<Void> storeOrThrow(T& out, Future<Optional<T>> what, Error e = key_not_fo
 }
 
 // Waits for a future to be ready, and then applies an asynchronous function to it.
-ACTOR template <class T, class F, class U = decltype(std::declval<F>()(std::declval<T>()).getValue())>
-Future<U> mapAsync(Future<T> what, F actorFunc) {
+ACTOR template <class T, class F>
+Future<decltype(std::declval<F>()(std::declval<T>()).getValue())> mapAsync(Future<T> what, F actorFunc) {
 	T val = wait(what);
-	U ret = wait(actorFunc(val));
+	decltype(std::declval<F>()(std::declval<T>()).getValue()) ret = wait(actorFunc(val));
 	return ret;
 }
 

--- a/flow/network.cpp
+++ b/flow/network.cpp
@@ -289,11 +289,9 @@ Future<Reference<IConnection>> INetworkConnections::connect(const std::string& h
 
 	// Wait for the endpoint to return, then wait for connect(endpoint) and return it.
 	// Template types are being provided explicitly because they can't be automatically deduced for some reason.
-	return mapAsync<NetworkAddress,
-	                std::function<Future<Reference<IConnection>>(NetworkAddress const&)>,
-	                Reference<IConnection>>(
-	    pickEndpoint,
-	    [=](NetworkAddress const& addr) -> Future<Reference<IConnection>> { return connectExternal(addr); });
+	return mapAsync(pickEndpoint, [=](NetworkAddress const& addr) -> Future<Reference<IConnection>> {
+		return connectExternal(addr);
+	});
 }
 
 IUDPSocket::~IUDPSocket() {}


### PR DESCRIPTION
`mapAsync` specified a third parameter that it tried to set to a default, but usage of the function was trying to deduce the third parameter and generally failed. This change removes the third parameter and replaces it's usage with the default value everywhere.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
