### PR TITLE
Track individual key range metrics in each physical shard

### DIFF
--- a/fdbserver/DDShardTracker.actor.cpp
+++ b/fdbserver/DDShardTracker.actor.cpp
@@ -334,6 +334,7 @@ ACTOR Future<Void> trackShardMetrics(DataDistributionTracker::SafeAccessor self,
 							        keys, metrics.first.get(), shardMetrics->get().get().metrics, initWithNewMetrics);
 							if (needToMove) {
 								// Do we need to update shardsAffectedByTeamFailure here?
+								// TODO(zhewu): move this to physical shard tracker that does shard split based on size.
 								self()->output.send(
 								    RelocateShard(keys,
 								                  DataMovementReason::ENFORCE_MOVE_OUT_OF_PHYSICAL_SHARD,
@@ -1551,6 +1552,8 @@ FDB_DEFINE_BOOLEAN_PARAM(InOverSizePhysicalShard);
 FDB_DEFINE_BOOLEAN_PARAM(PhysicalShardAvailable);
 FDB_DEFINE_BOOLEAN_PARAM(MoveKeyRangeOutPhysicalShard);
 
+// Tracks storage metrics fir `keys`. This function is similar to `trackShardMetrics()` and altered for physical shard.
+// This meant to be temporary. Eventually, we want a new interface to track physical shard metrics more efficiently.
 ACTOR Future<Void> trackKeyRangeInPhysicalShardMetrics(Reference<IDDTxnProcessor> db,
                                                        KeyRange keys,
                                                        Reference<AsyncVar<Optional<ShardMetrics>>> shardMetrics) {

--- a/fdbserver/DDShardTracker.actor.cpp
+++ b/fdbserver/DDShardTracker.actor.cpp
@@ -208,6 +208,7 @@ int64_t getMaxShardSize(double dbSizeEstimate) {
 	                (int64_t)SERVER_KNOBS->MAX_SHARD_BYTES);
 }
 
+// Returns the shard size bounds as well as whether `keys` a read hot shard.
 std::pair<ShardSizeBounds, bool> calculateShardSizeBounds(
     const KeyRange& keys,
     const Reference<AsyncVar<Optional<ShardMetrics>>>& shardMetrics,
@@ -1552,7 +1553,7 @@ FDB_DEFINE_BOOLEAN_PARAM(InOverSizePhysicalShard);
 FDB_DEFINE_BOOLEAN_PARAM(PhysicalShardAvailable);
 FDB_DEFINE_BOOLEAN_PARAM(MoveKeyRangeOutPhysicalShard);
 
-// Tracks storage metrics fir `keys`. This function is similar to `trackShardMetrics()` and altered for physical shard.
+// Tracks storage metrics for `keys`. This function is similar to `trackShardMetrics()` and altered for physical shard.
 // This meant to be temporary. Eventually, we want a new interface to track physical shard metrics more efficiently.
 ACTOR Future<Void> trackKeyRangeInPhysicalShardMetrics(Reference<IDDTxnProcessor> db,
                                                        KeyRange keys,

--- a/fdbserver/include/fdbserver/DataDistribution.actor.h
+++ b/fdbserver/include/fdbserver/DataDistribution.actor.h
@@ -279,11 +279,12 @@ public:
 	struct PhysicalShard {
 		PhysicalShard() : id(UID().first()) {}
 
-		PhysicalShard(uint64_t id,
+		PhysicalShard(Reference<IDDTxnProcessor> txnProcessor,
+		              uint64_t id,
 		              StorageMetrics const& metrics,
 		              std::vector<ShardsAffectedByTeamFailure::Team> teams,
 		              PhysicalShardCreationTime whenCreated)
-		  : id(id), metrics(metrics), teams(teams), whenCreated(whenCreated) {}
+		  : txnProcessor(txnProcessor), id(id), metrics(metrics), teams(teams), whenCreated(whenCreated) {}
 
 		// Adds `newRange` to this physical shard and starts monitoring the shard.
 		void addRange(const KeyRange& newRange);
@@ -293,13 +294,14 @@ public:
 
 		std::string toString() const { return fmt::format("{}", std::to_string(id)); }
 
+		Reference<IDDTxnProcessor> txnProcessor;
 		uint64_t id; // physical shard id (never changed)
 		StorageMetrics metrics; // current metrics, updated by shardTracker
 		std::vector<ShardsAffectedByTeamFailure::Team> teams; // which team owns this physical shard (never changed)
 		PhysicalShardCreationTime whenCreated; // when this physical shard is created (never changed)
 
 		struct RangeData {
-			Future<Void> trackMetrics; // TODO(zhewu): add shard tracking actor.
+			Future<Void> trackMetrics;
 			Reference<AsyncVar<Optional<ShardMetrics>>>
 			    stats; // TODO(zhewu): aggregate all metrics to a single physical shard metrics.
 		};


### PR DESCRIPTION
Create a key range metrics tracker for each range inside a physical shard. This meant to be temporary until we have a new interface that tracks physical shard metrics more efficiently.

20221214-235000-zhewu_9055-1cb01857d3668458

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
