### PR TITLE
Add initial documentation for automatic idempotency

### DIFF
--- a/bindings/go/src/fdb/generated.go
+++ b/bindings/go/src/fdb/generated.go
@@ -407,6 +407,11 @@ func (o DatabaseOptions) SetTransactionIncludePortInAddress() error {
 	return o.setOpt(505, nil)
 }
 
+// Set a random idempotency id for all transactions. See the transaction option description for more information. This feature is in development and not ready for general use.
+func (o DatabaseOptions) SetTransactionAutomaticIdempotency() error {
+	return o.setOpt(506, nil)
+}
+
 // Allows ``get`` operations to read from sections of keyspace that have become unreadable because of versionstamp operations. This sets the ``bypass_unreadable`` option of each transaction created by this database. See the transaction option description for more information.
 func (o DatabaseOptions) SetTransactionBypassUnreadable() error {
 	return o.setOpt(700, nil)
@@ -569,6 +574,11 @@ func (o TransactionOptions) SetMaxRetryDelay(param int64) error {
 // Parameter: value in bytes
 func (o TransactionOptions) SetSizeLimit(param int64) error {
 	return o.setOpt(503, int64ToBytes(param))
+}
+
+// Automatically assign a random 16 byte idempotency id for this transaction. Prevents commits from failing with ``commit_unknown_result``. WARNING: If you are also using the multiversion client or transaction timeouts, if either cluster_version_changed or transaction_timed_out was thrown during a commit, then that commit may have already succeeded or may succeed in the future. This feature is in development and not ready for general use.
+func (o TransactionOptions) SetAutomaticIdempotency() error {
+	return o.setOpt(505, nil)
 }
 
 // Snapshot read operations will see the results of writes done in the same transaction. This is the default behavior.

--- a/design/idempotency_ids.md
+++ b/design/idempotency_ids.md
@@ -6,12 +6,22 @@ As an intermediate goal, I plan to introduce this feature disabled by default. T
 
 # API
 
-Introduce a new transaction option `IDEMPOTENCY_ID`, which will be validated to be at most 255 bytes.
+Introduce a new transaction option `AUTOMATIC_IDEMPOTENCY`, which sets the transaction's idempotency id to 16 random bytes if there's no idempotency id yet. Setting this also instructs the fdb client to manage the full lifecycle of the idempotency id (expiring the id automatically after a commit acknowledgement).
+
+Introduce a new transaction option `IDEMPOTENCY_ID`, which will be validated to be at most 255 bytes. This option sets the idempotency id for the transaction, and also instructs the fdb client _not to_ expire this id automatically. The user is responsible for calling `fdb_database_expire_idempotency_id` to expire it.
+
 Add 
 ```
-FDBFuture* fdb_transaction_commit_result(FDBTransaction* tr, uint8_t const* idempotency_id, int idempotency_id_length)
+FDBFuture* fdb_database_commit_result(FDBDatabase* db, uint8_t const* idempotency_id, int idempotency_id_length, int64_t read_snapshot)
 ```
-, which can be used to determine the result of a commit that failed with `transaction_timed_out`.
+, which can be used to determine the result of a commit with the given read snapshot and idempotency id.
+
+Add
+```
+void fdb_database_expire_idempotency_id(FDBDatabase* db, uint8_t const* idempotency_id, int idempotency_id_length)
+```
+
+This lets the client know that the caller is done with this idempotency id and that the cluster may purge it.
 
 Commits for transactions with idempotency ids would not fail with `commit_unknown_result`, but in (extremely) rare cases could fail with a new error that clients are expected to handle by restarting the process.
 # Background
@@ -49,10 +59,9 @@ in that id and the cluster can reclaim the space used to store the idempotency
 id. The commit proxy that committed a batch is responsible for cleaning all
 idempotency kv pairs from that batch, so clients must tell that specific proxy
 that they're done with the id. The first proxy will also periodically clean up
-the oldest idempotency ids, based on a policy determined by two knobs.  One knob
+the oldest idempotency ids, based on a policy determined by knobs.  One knob
 will control the minimum lifetime of an idempotency id (i.e. don't delete
-anything younger than 1 day), and the other will control the target byte size of
-the idempotency keys (e.g. keep 100 MB of idempotency keys around).
+anything younger than 1 day). More knobs may be considered in the future.
 
 # Commit protocol
 
@@ -76,12 +85,28 @@ If a transaction learns that it has been in-flight so long that its idempotency 
 
 # Considerations
 
-- Additional storage space on the cluster. This can be controlled directly via an idempotency id target bytes knob/config.
+- Additional storage space on the cluster.
 - Potential write hot spot.
 
 # Multi-version client
 
 The multi-version client will generate its own idempotency id for a transaction and manage its lifecycle. It will duplicate the logic in NativeApi to achieve the same guarantees. As part of this change we will also ensure that the previous commit attempt is no longer in-flight before allowing the commit future to become ready. This will fix a potential "causal-write-risky" issue if a commit attempt fails with `cluster_version_changed`.
+
+# Implementation
+
+```
+FDBFuture* fdb_database_commit_result(FDBDatabase* db, uint8_t const* idempotency_id, int idempotency_id_length, int64_t read_snapshot)
+```
+
+The implementation would first commit a transaction that conflicts with any transaction with the same idempotency id (recall that the idempotency id is added to the conflict ranges), to ensure that none are in flight.
+
+The implementation would then search storage servers for the idempotency id to determine the commit result. The range of keys that need to be read is bounded by the range of possible commit versions for a transaction with `read_snapshot`.
+
+```
+void fdb_database_expire_idempotency_id(FDBDatabase* db, uint8_t const* idempotency_id, int idempotency_id_length)
+```
+
+The fdb client would need to keep track of which commit proxies are responsible for recently committed transactions with idempotency ids, so it knows where to direct the expire requests. Proactively expiring idempotency ids is done on a best-effort basis, but this needs to work well enough that the storage used by the cluster for idempotency ids is acceptable.
 
 # Experiments
 

--- a/documentation/sphinx/source/automatic-idempotency.rst
+++ b/documentation/sphinx/source/automatic-idempotency.rst
@@ -50,7 +50,7 @@ For example::
                 tr.add(key, struct.pack("<q", 1))
         do_it(db)
         # Clean up unique state
-        del tr[b"ids/" + tr_id]
+        del db[b"ids/" + tr_id]
 
 This approach has several problems
 

--- a/documentation/sphinx/source/automatic-idempotency.rst
+++ b/documentation/sphinx/source/automatic-idempotency.rst
@@ -1,0 +1,81 @@
+#####################
+Automatic Idempotency
+#####################
+
+.. automatic-idempotency:
+
+.. warning :: Automatic idempotency is currently experimental and not recommended for use in production.
+
+Synopsis
+~~~~~~~~
+
+Use the ``automatic_idempotency`` transaction option to prevent commits from
+failing with ``commit_unknown_result`` at a small performance cost.
+``transaction_timed_out`` and ``cluster_version_changed`` still indicate an
+unknown commit status.
+
+Details
+~~~~~~~
+
+Transactions are generally run in retry loops that retry the error
+``commit_unknown_result``. When an attempt fails with
+``commit_unknown_result`` it's possible that the attempt succeeded, and the
+retry will perform the effect of the transaction twice!  This behavior can be
+surprising at first, and difficult to reason
+about.
+
+As an example, consider this simple transaction::
+
+    @fdb.transactional
+    def atomic_increment(tr, key):
+        tr.add(key, struct.pack("<q", 1))
+
+This transaction appears to be correct, and behaves as expected most of the
+time, but incorrectly adds to the key multiple times if
+``commit_unknown_result`` is thrown.
+
+To mitigate this, it's common to write something unique to a transaction, so
+that retries can detect whether or not a commit succeeded by reading the
+database and looking for the unique change.
+
+For example::
+
+    def atomic_increment(db, key):
+        tr_id = uuid.UUID(int=random.getrandbits(128)).bytes
+        # tr_id can be used to detect whether or not this transaction has already committed
+        @fdb.transactional
+        def do_it(tr):
+            if tr[b"ids/" + tr_id] == None:
+                tr[b"ids/" + tr_id] = b""
+                tr.add(key, struct.pack("<q", 1))
+        do_it(db)
+        # Clean up unique state
+        del tr[b"ids/" + tr_id]
+
+This approach has several problems
+
+#. We're now doing about twice the work as before, and we need an extra transaction to clean up.
+#. This will slowly leak space over time if clients fail before cleaning up their unique state.
+
+Automatic Idempotency is an implementation of a conceptually similar pattern,
+but taking advantage of fdb implementation details to provide better
+performance and clean up after itself. Here's our atomic increment with Automatic Idempotency::
+
+    @fdb.transactional
+    def atomic_increment(tr, key):
+        tr.options.set_automatic_idempotency()
+        tr.add(key, struct.pack("<q", 1))
+
+This will correctly add exactly once, provided you allow it to retry until success.
+
+Caveats
+~~~~~~~
+
+Automatic Idempotency only prevents ``commit_unknown_result``, and it does not
+prevent ``transaction_timed_out`` or ``cluster_version_changed``.
+Each of these can indicate an unknown commit status. To mitigate this, the
+current recommendation is *do not* retry transactions that fail with
+``transaction_timed_out``. The default retry loop does not retry
+``transaction_timed_out``, so this is mostly relevant if you have a custom retry
+loop. This feature is not recommended for users of the :ref:`multi-version-client-api` at
+this time since it does not prevent ``cluster_version_changed``. Support may be added in the future.

--- a/documentation/sphinx/source/client-design.rst
+++ b/documentation/sphinx/source/client-design.rst
@@ -28,6 +28,8 @@ FoundationDB supports language bindings for application development using the or
 
 * :doc:`tenants` describes the use of the tenants feature to define named transaction domains.
 
+* :doc:`automatic-idempotency` describes the use of a transaction option to prevent transactions from failing with ``commit_unknown_result``.
+
 .. toctree::
     :maxdepth: 1
     :titlesonly:
@@ -45,3 +47,4 @@ FoundationDB supports language bindings for application development using the or
     transaction-profiler-analyzer
     api-version-upgrade-guide
     tenants
+    automatic-idempotency

--- a/documentation/sphinx/source/developer-guide.rst
+++ b/documentation/sphinx/source/developer-guide.rst
@@ -606,6 +606,8 @@ The following example illustrates both techniques. Together, they make a transac
         balanceKey = fdb.tuple.pack(('account', acctId))
         tr.add(balanceKey, amount)
 
+There is experimental support for preventing ``commit_unknown_result`` altogether using a transaction option. See :doc:`automatic-idempotency` for more details. Note: there are other errors which indicate an unknown commit status. See :ref:`non-retryable errors`.
+
 .. _conflict-ranges:
 
 Conflict ranges
@@ -953,6 +955,10 @@ The ``commit_unknown_result`` Error
 #. There was a FoundationDB failure - for example a commit proxy failed during the commit. In that case there is no way for the client know whether the transaction succeeded or not.
 
 However, there is one guarantee FoundationDB gives to the caller: at the point of time where you receive this error, the transaction either committed or not and if it didn't commit, it will never commit in the future. Or: it is guaranteed that the transaction is not in-flight anymore. This is an important guarantee as it means that if your transaction is idempotent you can simply retry. For more explanations see developer-guide-unknown-results_.
+
+There is experimental support for preventing ``commit_unknown_result`` altogether using a transaction option. See :doc:`automatic-idempotency` for more details. Note: there are other errors which indicate an unknown commit status. See :ref:`non-retryable errors`.
+
+.. _non-retryable errors:
 
 Non-Retryable Errors
 ~~~~~~~~~~~~~~~~~~~~

--- a/fdbclient/vexillographer/fdb.options
+++ b/fdbclient/vexillographer/fdb.options
@@ -290,8 +290,7 @@ description is not currently required but encouraged.
             description="Associate this transaction with this ID for the purpose of checking whether or not this transaction has already committed. Must be at least 16 bytes and less than 256 bytes. This feature is in development and not ready for general use. Unless the automatic_idempotency option is set after this option, the client will not automatically attempt to remove this id from the cluster after a successful commit."
             hidden="true" />
     <Option name="automatic_idempotency" code="505"
-            description="Automatically assign a random 16 byte idempotency id for this transaction. Prevents commits from failing with ``commit_unknown_result``. WARNING: If you are also using the multiversion client or transaction timeouts, if either cluster_version_changed or transaction_timed_out was thrown during a commit, then that commit may have already succeeded or may succeed in the future. This feature is in development and not ready for general use."
-            hidden="true" />
+            description="Automatically assign a random 16 byte idempotency id for this transaction. Prevents commits from failing with ``commit_unknown_result``. WARNING: If you are also using the multiversion client or transaction timeouts, if either cluster_version_changed or transaction_timed_out was thrown during a commit, then that commit may have already succeeded or may succeed in the future. This feature is in development and not ready for general use." />
     <Option name="snapshot_ryw_enable" code="600"
             description="Snapshot read operations will see the results of writes done in the same transaction. This is the default behavior." />
     <Option name="snapshot_ryw_disable" code="601"

--- a/fdbclient/vexillographer/fdb.options
+++ b/fdbclient/vexillographer/fdb.options
@@ -209,8 +209,7 @@ description is not currently required but encouraged.
             defaultFor="23"/>
     <Option name="transaction_automatic_idempotency" code="506"
             description="Set a random idempotency id for all transactions. See the transaction option description for more information. This feature is in development and not ready for general use." 
-            defaultFor="505"
-            hidden="true"/>
+            defaultFor="505" />
     <Option name="transaction_bypass_unreadable" code="700"
             description="Allows ``get`` operations to read from sections of keyspace that have become unreadable because of versionstamp operations. This sets the ``bypass_unreadable`` option of each transaction created by this database. See the transaction option description for more information."
             defaultFor="1100"/>


### PR DESCRIPTION
- Add user-facing documentation for the AUTOMATIC_IDEMPOTENCY transaction option
- Update the design doc. I believe the design is now sufficient for higher-level retry loops (e.g. the multi-version client, or a custom retry loop that wants to retry `transaction_timed_out`) to provide automatic idempotency.
- Mark AUTOMATIC_IDEMPOTENCY as not hidden (but still not recommended for production use). The reason for doing this is to make the example code in the user docs valid. I do think it's close enough to ready for folks to experiment with.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
