### PR TITLE
Aggregate all key range metrics into single physical shard stats

### DIFF
--- a/fdbserver/DDShardTracker.actor.cpp
+++ b/fdbserver/DDShardTracker.actor.cpp
@@ -1553,8 +1553,9 @@ FDB_DEFINE_BOOLEAN_PARAM(InOverSizePhysicalShard);
 FDB_DEFINE_BOOLEAN_PARAM(PhysicalShardAvailable);
 FDB_DEFINE_BOOLEAN_PARAM(MoveKeyRangeOutPhysicalShard);
 
-// Tracks storage metrics for `keys`. This function is similar to `trackShardMetrics()` and altered for physical shard.
-// This meant to be temporary. Eventually, we want a new interface to track physical shard metrics more efficiently.
+// Tracks storage metrics for `keys` and updates `physicalShardStats` which is the stats for the physical shard owning
+// this key range. This function is similar to `trackShardMetrics()` and altered for physical shard. This meant to be
+// temporary. Eventually, we want a new interface to track physical shard metrics more efficiently.
 ACTOR Future<Void> trackKeyRangeInPhysicalShardMetrics(
     Reference<IDDTxnProcessor> db,
     KeyRange keys,
@@ -1599,6 +1600,7 @@ ACTOR Future<Void> trackKeyRangeInPhysicalShardMetrics(
 					physicalShardStats->set(metrics.first.get());
 				} else {
 					if (!shardMetrics->get().present()) {
+						// We collect key range stats for the first time.
 						physicalShardStats->set(physicalShardStats->get().get() + metrics.first.get());
 					} else {
 						physicalShardStats->set(physicalShardStats->get().get() - shardMetrics->get().get().metrics +

--- a/fdbserver/DDShardTracker.actor.cpp
+++ b/fdbserver/DDShardTracker.actor.cpp
@@ -1555,9 +1555,11 @@ FDB_DEFINE_BOOLEAN_PARAM(MoveKeyRangeOutPhysicalShard);
 
 // Tracks storage metrics for `keys`. This function is similar to `trackShardMetrics()` and altered for physical shard.
 // This meant to be temporary. Eventually, we want a new interface to track physical shard metrics more efficiently.
-ACTOR Future<Void> trackKeyRangeInPhysicalShardMetrics(Reference<IDDTxnProcessor> db,
-                                                       KeyRange keys,
-                                                       Reference<AsyncVar<Optional<ShardMetrics>>> shardMetrics) {
+ACTOR Future<Void> trackKeyRangeInPhysicalShardMetrics(
+    Reference<IDDTxnProcessor> db,
+    KeyRange keys,
+    Reference<AsyncVar<Optional<ShardMetrics>>> shardMetrics,
+    Reference<AsyncVar<Optional<StorageMetrics>>> physicalShardStats) {
 	state BandwidthStatus bandwidthStatus =
 	    shardMetrics->get().present() ? getBandwidthStatus(shardMetrics->get().get().metrics) : BandwidthStatusNormal;
 	state double lastLowBandwidthStartTime =
@@ -1591,6 +1593,19 @@ ACTOR Future<Void> trackKeyRangeInPhysicalShardMetrics(Reference<IDDTxnProcessor
 					lastLowBandwidthStartTime = now();
 				}
 				bandwidthStatus = newBandwidthStatus;
+
+				// Update current physical shard aggregated stats;
+				if (!physicalShardStats->get().present()) {
+					physicalShardStats->set(metrics.first.get());
+				} else {
+					if (!shardMetrics->get().present()) {
+						physicalShardStats->set(physicalShardStats->get().get() + metrics.first.get());
+					} else {
+						physicalShardStats->set(physicalShardStats->get().get() - shardMetrics->get().get().metrics +
+						                        metrics.first.get());
+					}
+				}
+
 				shardMetrics->set(ShardMetrics(metrics.first.get(), lastLowBandwidthStartTime, shardCount));
 				break;
 			} else {
@@ -1605,6 +1620,14 @@ ACTOR Future<Void> trackKeyRangeInPhysicalShardMetrics(Reference<IDDTxnProcessor
 	}
 }
 
+void PhysicalShardCollection::PhysicalShard::insertNewRangeData(const KeyRange& newRange) {
+	RangeData data;
+	data.stats = makeReference<AsyncVar<Optional<ShardMetrics>>>();
+	data.trackMetrics = trackKeyRangeInPhysicalShardMetrics(txnProcessor, newRange, data.stats, stats);
+	auto it = rangeData.emplace(newRange, data);
+	ASSERT(it.second);
+}
+
 void PhysicalShardCollection::PhysicalShard::addRange(const KeyRange& newRange) {
 	if (g_network->isSimulated()) {
 		// Test that new range must not overlap with any existing range in this shard.
@@ -1613,10 +1636,7 @@ void PhysicalShardCollection::PhysicalShard::addRange(const KeyRange& newRange) 
 		}
 	}
 
-	RangeData data;
-	data.stats = makeReference<AsyncVar<Optional<ShardMetrics>>>();
-	data.trackMetrics = trackKeyRangeInPhysicalShardMetrics(txnProcessor, newRange, data.stats);
-	rangeData.emplace(newRange, data);
+	insertNewRangeData(newRange);
 }
 
 void PhysicalShardCollection::PhysicalShard::removeRange(const KeyRange& outRange) {
@@ -1631,10 +1651,7 @@ void PhysicalShardCollection::PhysicalShard::removeRange(const KeyRange& outRang
 		std::vector<KeyRangeRef> remainingRanges = range - outRange;
 		for (auto& r : remainingRanges) {
 			ASSERT(r != range);
-			RangeData data;
-			data.stats = makeReference<AsyncVar<Optional<ShardMetrics>>>();
-			data.trackMetrics = trackKeyRangeInPhysicalShardMetrics(txnProcessor, r, data.stats);
-			rangeData.emplace(r, data);
+			insertNewRangeData(r);
 		}
 		// Must erase last since `remainingRanges` uses data in `range`.
 		rangeData.erase(range);

--- a/fdbserver/include/fdbserver/DataDistribution.actor.h
+++ b/fdbserver/include/fdbserver/DataDistribution.actor.h
@@ -298,7 +298,8 @@ public:
 		Reference<IDDTxnProcessor> txnProcessor;
 		uint64_t id; // physical shard id (never changed)
 		StorageMetrics metrics; // current metrics, updated by shardTracker
-		Reference<AsyncVar<Optional<StorageMetrics>>> stats;
+		// todo(zhewu): combine above metrics with stats. They are redundant.
+		Reference<AsyncVar<Optional<StorageMetrics>>> stats; // Stats of this physical shard.
 		std::vector<ShardsAffectedByTeamFailure::Team> teams; // which team owns this physical shard (never changed)
 		PhysicalShardCreationTime whenCreated; // when this physical shard is created (never changed)
 
@@ -309,6 +310,7 @@ public:
 		std::unordered_map<KeyRange, RangeData> rangeData;
 
 	private:
+		// Inserts a new key range into this physical shard. `newRange` must not exist in this shard already.
 		void insertNewRangeData(const KeyRange& newRange);
 	};
 


### PR DESCRIPTION
Create a single stats per physical shard instance and updated by trackKeyRangeInPhysicalShardMetrics.

This metrics is currently redundant to the `metrics` in physical shard instance and meant to replace it.

20221220-005908-zhewu_9067-df0df76ab9f4c491

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
