### PR TITLE
Add Golang binding for FreeBSD

### DIFF
--- a/bindings/go/src/fdb/fdb_freebsd.go
+++ b/bindings/go/src/fdb/fdb_freebsd.go
@@ -1,0 +1,5 @@
+package fdb
+
+//#cgo CFLAGS: -I/usr/local/include/
+//#cgo LDFLAGS: -L/usr/local/lib/
+import "C"


### PR DESCRIPTION
The build of Go language bindings for FoundationDB has failed on FreeBSD.
I added new binding for FreeBSD using the Darwin (MacOS) binding as an example.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.
