### PR TITLE
Fix Windows build broken by #8904

### DIFF
--- a/cmake/CompileBoost.cmake
+++ b/cmake/CompileBoost.cmake
@@ -145,7 +145,7 @@ if(WIN32)
   # properly for config mode. So we use the old way on Windows
   #  find_package(Boost 1.72.0 EXACT QUIET REQUIRED CONFIG PATHS ${BOOST_HINT_PATHS})
   # I think depending on the cmake version this will cause weird warnings
-  find_package(Boost 1.72 COMPONENTS filesystem iostreams)
+  find_package(Boost 1.78 COMPONENTS filesystem iostreams serialization system)
   add_library(boost_target INTERFACE)
   target_link_libraries(boost_target INTERFACE Boost::boost Boost::filesystem Boost::iostreams Boost::serialization Boost::system)
   return()


### PR DESCRIPTION
Fix Windows build broken by #8904
- Add missing boost libraries
- Add missing flow dependencies