### PR TITLE
Fixed error type.

### DIFF
--- a/fdbserver/MoveKeys.actor.cpp
+++ b/fdbserver/MoveKeys.actor.cpp
@@ -1297,7 +1297,7 @@ ACTOR static Future<Void> startMoveShards(Database occ,
 						dataMove.setPhase(DataMoveMetaData::Deleting);
 						tr.set(dataMoveKeyFor(dataMoveId), dataMoveValue(dataMove));
 						wait(tr.commit());
-						throw data_move_cancelled();
+						throw movekeys_conflict();
 					}
 					if (dataMove.getPhase() == DataMoveMetaData::Deleting) {
 						TraceEvent(SevVerbose, "StartMoveShardsDataMove", relocationIntervalId)
@@ -1313,7 +1313,7 @@ ACTOR static Future<Void> startMoveShards(Database occ,
 					begin = dataMove.ranges.front().end;
 				} else {
 					if (cancelDataMove) {
-						throw data_move_cancelled();
+						throw movekeys_conflict();
 					}
 					dataMove = DataMoveMetaData();
 					dataMove.id = dataMoveId;


### PR DESCRIPTION
The data_move_cancelled error doesn't cause DD to restart.

test: passed 100k `tests/fast/KillRegionCycle.toml`: 20230106-072712-heliu-75de1cfcd92e17d1

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
