### PR TITLE
TestHarness2: fix reproduce command missing --restarting param

### DIFF
--- a/contrib/TestHarness2/test_harness/joshua.py
+++ b/contrib/TestHarness2/test_harness/joshua.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import collections
 import io
+import re
 import sys
 import xml.sax
 import xml.sax.handler
@@ -50,6 +51,8 @@ def _print_summary(summary: SummaryTree, commands: Set[str]):
         file_name = summary.attributes['TestFile']
         role = 'test' if test_harness.run.is_no_sim(Path(file_name)) else 'simulation'
         cmd += ['-r', role, '-f', file_name]
+        if re.search(r'restarting\/.*-2\.', file_name):
+            cmd += ["--restarting"]
     else:
         cmd += ['-r', 'simulation', '-f', '<ERROR>']
     if 'RandomSeed' in summary.attributes:


### PR DESCRIPTION
Fix restart test command missing --restarting params.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
