### PR TITLE
EaR: storage server uses encryption DB config

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -975,7 +975,6 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( REDWOOD_EVICT_UPDATED_PAGES,                          true ); if( randomize && BUGGIFY ) { REDWOOD_EVICT_UPDATED_PAGES = false; }
 	init( REDWOOD_DECODECACHE_REUSE_MIN_HEIGHT,                    2 ); if( randomize && BUGGIFY ) { REDWOOD_DECODECACHE_REUSE_MIN_HEIGHT = deterministicRandom()->randomInt(1, 7); }
 	init( REDWOOD_IO_PRIORITIES,                       "32,32,32,32" );
-	init( REDWOOD_SPLIT_ENCRYPTED_PAGES_BY_TENANT,             false );
 
 	// Server request latency measurement
 	init( LATENCY_SKETCH_ACCURACY,                              0.01 );

--- a/fdbclient/include/fdbclient/CommitProxyInterface.h
+++ b/fdbclient/include/fdbclient/CommitProxyInterface.h
@@ -512,10 +512,11 @@ struct GetStorageServerRejoinInfoReply {
 	Optional<Tag> newTag;
 	bool newLocality;
 	std::vector<std::pair<Version, Tag>> history;
+	EncryptionAtRestMode encryptMode;
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, version, tag, newTag, newLocality, history);
+		serializer(ar, version, tag, newTag, newLocality, history, encryptMode);
 	}
 };
 

--- a/fdbclient/include/fdbclient/FDBTypes.h
+++ b/fdbclient/include/fdbclient/FDBTypes.h
@@ -1520,6 +1520,8 @@ struct EncryptionAtRestMode {
 
 	bool operator==(const EncryptionAtRestMode& e) const { return isEquals(e); }
 	bool operator!=(const EncryptionAtRestMode& e) const { return !isEquals(e); }
+	bool operator==(Mode m) const { return mode == m; }
+	bool operator!=(Mode m) const { return mode != m; }
 
 	bool isEncryptionEnabled() const { return mode != EncryptionAtRestMode::DISABLED; }
 
@@ -1546,6 +1548,11 @@ struct EncryptionAtRestMode {
 	}
 
 	uint32_t mode;
+};
+
+template <>
+struct Traceable<EncryptionAtRestMode> : std::true_type {
+	static std::string toString(const EncryptionAtRestMode& mode) { return mode.toString(); }
 };
 
 typedef StringRef ClusterNameRef;

--- a/fdbclient/include/fdbclient/ServerKnobs.h
+++ b/fdbclient/include/fdbclient/ServerKnobs.h
@@ -938,7 +938,6 @@ public:
 	double REDWOOD_HISTOGRAM_INTERVAL;
 	bool REDWOOD_EVICT_UPDATED_PAGES; // Whether to prioritize eviction of updated pages from cache.
 	int REDWOOD_DECODECACHE_REUSE_MIN_HEIGHT; // Minimum height for which to keep and reuse page decode caches
-	bool REDWOOD_SPLIT_ENCRYPTED_PAGES_BY_TENANT; // Whether to split pages by tenant if encryption is enabled
 
 	std::string REDWOOD_IO_PRIORITIES;
 

--- a/fdbserver/ClusterRecovery.actor.cpp
+++ b/fdbserver/ClusterRecovery.actor.cpp
@@ -363,6 +363,7 @@ ACTOR Future<Void> newSeedServers(Reference<ClusterRecoveryData> self,
 		isr.reqId = deterministicRandom()->randomUniqueID();
 		isr.interfaceId = deterministicRandom()->randomUniqueID();
 		isr.initialClusterVersion = self->recoveryTransactionVersion;
+		isr.encryptMode = self->configuration.encryptionAtRestMode;
 
 		ErrorOr<InitializeStorageReply> newServer = wait(recruits.storageServers[idx].storage.tryGetReply(isr));
 

--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -2472,6 +2472,7 @@ ACTOR static Future<Void> rejoinServer(CommitProxyInterface proxy, ProxyCommitDa
 				}
 				rep.newTag = Tag(maxTagLocality + 1, 0);
 			}
+			rep.encryptMode = commitData->encryptMode;
 			req.reply.send(rep);
 		} else {
 			req.reply.sendError(worker_removed());
@@ -3059,7 +3060,7 @@ ACTOR Future<Void> commitProxyServerCore(CommitProxyInterface proxy,
 	state GetHealthMetricsReply healthMetricsReply;
 	state GetHealthMetricsReply detailedHealthMetricsReply;
 
-	TraceEvent("CPEncryptionAtRestMode").detail("Mode", commitData.encryptMode.toString());
+	TraceEvent("CPEncryptionAtRestMode", proxy.id()).detail("Mode", commitData.encryptMode);
 
 	addActor.send(waitFailureServer(proxy.waitFailure.getFuture()));
 	addActor.send(traceRole(Role::COMMIT_PROXY, proxy.id()));

--- a/fdbserver/DDTeamCollection.actor.cpp
+++ b/fdbserver/DDTeamCollection.actor.cpp
@@ -2355,6 +2355,7 @@ public:
 			isr.seedTag = invalidTag;
 			isr.reqId = deterministicRandom()->randomUniqueID();
 			isr.interfaceId = interfaceId;
+			isr.encryptMode = self->configuration.encryptionAtRestMode;
 
 			// if tss, wait for pair ss to finish and add its id to isr. If pair fails, don't recruit tss
 			state bool doRecruit = true;

--- a/fdbserver/KeyValueStoreCompressTestData.actor.cpp
+++ b/fdbserver/KeyValueStoreCompressTestData.actor.cpp
@@ -81,6 +81,10 @@ struct KeyValueStoreCompressTestData final : IKeyValueStore {
 		return doReadRange(store, keys, rowLimit, byteLimit, options);
 	}
 
+	Future<EncryptionAtRestMode> encryptionMode() override {
+		return EncryptionAtRestMode(EncryptionAtRestMode::DISABLED);
+	}
+
 private:
 	ACTOR static Future<Optional<Value>> doReadValue(IKeyValueStore* store, Key key, Optional<ReadOptions> options) {
 		Optional<Value> v = wait(store->readValue(key, options));

--- a/fdbserver/KeyValueStoreMemory.actor.cpp
+++ b/fdbserver/KeyValueStoreMemory.actor.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "fdbclient/BlobCipher.h"
+#include "fdbclient/FDBTypes.h"
 #include "fdbclient/Knobs.h"
 #include "fdbclient/Notified.h"
 #include "fdbclient/SystemData.h"
@@ -289,6 +290,12 @@ public:
 	void enableSnapshot() override { disableSnapshot = false; }
 
 	int uncommittedBytes() { return queue.totalSize(); }
+
+	// KeyValueStoreMemory does not support encryption-at-rest in general, despite it supports encryption
+	// when being used as TxnStateStore backend.
+	Future<EncryptionAtRestMode> encryptionMode() override {
+		return EncryptionAtRestMode(EncryptionAtRestMode::DISABLED);
+	}
 
 private:
 	enum OpType {

--- a/fdbserver/KeyValueStoreRocksDB.actor.cpp
+++ b/fdbserver/KeyValueStoreRocksDB.actor.cpp
@@ -18,6 +18,7 @@
  * limitations under the License.
  */
 
+#include "fdbclient/FDBTypes.h"
 #ifdef SSD_ROCKSDB_EXPERIMENTAL
 
 #include <rocksdb/c.h>
@@ -2265,6 +2266,10 @@ struct RocksDBKeyValueStore : IKeyValueStore {
 			throw internal_error();
 		}
 		return Void();
+	}
+
+	Future<EncryptionAtRestMode> encryptionMode() override {
+		return EncryptionAtRestMode(EncryptionAtRestMode::DISABLED);
 	}
 
 	DB db = nullptr;

--- a/fdbserver/KeyValueStoreSQLite.actor.cpp
+++ b/fdbserver/KeyValueStoreSQLite.actor.cpp
@@ -18,6 +18,7 @@
  * limitations under the License.
  */
 
+#include "fdbclient/FDBTypes.h"
 #define SQLITE_THREADSAFE 0 // also in sqlite3.amalgamation.c!
 #include "fmt/format.h"
 #include "crc32/crc32c.h"
@@ -1638,6 +1639,10 @@ public:
 
 	Future<SpringCleaningWorkPerformed> doClean();
 	void startReadThreads();
+
+	Future<EncryptionAtRestMode> encryptionMode() override {
+		return EncryptionAtRestMode(EncryptionAtRestMode::DISABLED);
+	}
 
 private:
 	KeyValueStoreType type;

--- a/fdbserver/KeyValueStoreShardedRocksDB.actor.cpp
+++ b/fdbserver/KeyValueStoreShardedRocksDB.actor.cpp
@@ -1,3 +1,4 @@
+#include "fdbclient/FDBTypes.h"
 #ifdef SSD_ROCKSDB_EXPERIMENTAL
 
 #include "fdbclient/KeyRangeMap.h"
@@ -3101,6 +3102,10 @@ struct ShardedRocksDBKeyValueStore : IKeyValueStore {
 
 	// Used for debugging shard mapping issue.
 	std::vector<std::pair<KeyRange, std::string>> getDataMapping() { return shardManager.getDataMapping(); }
+
+	Future<EncryptionAtRestMode> encryptionMode() override {
+		return EncryptionAtRestMode(EncryptionAtRestMode::DISABLED);
+	}
 
 	std::shared_ptr<ShardedRocksDBState> rState;
 	rocksdb::Options dbOptions;

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -2744,13 +2744,18 @@ ACTOR void setupAndRun(std::string dataFolder,
 			                     &tenantMode);
 			wait(delay(1.0)); // FIXME: WHY!!!  //wait for machines to boot
 		}
-		// setupSimulatedSystem/restartSimulatedSystem should fill tenantMode with valid value.
-		ASSERT(tenantMode.present());
+
 		// restartSimulatedSystem can adjust some testConfig params related to tenants
 		// so set/overwrite those options if necessary here
-		if (rebooting && testConfig.tenantModes.size()) {
-			tenantMode = TenantMode::fromString(testConfig.tenantModes[0]);
+		if (rebooting) {
+			if (testConfig.tenantModes.size()) {
+				tenantMode = TenantMode::fromString(testConfig.tenantModes[0]);
+			} else {
+				tenantMode = TenantMode::DISABLED;
+			}
 		}
+		// setupSimulatedSystem/restartSimulatedSystem should fill tenantMode with valid value.
+		ASSERT(tenantMode.present());
 		if (tenantMode != TenantMode::DISABLED && allowDefaultTenant) {
 			// Default tenant set by testConfig or restarting data in restartInfo.ini
 			if (testConfig.defaultTenant.present()) {

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -2120,7 +2120,7 @@ void setupSimulatedSystem(std::vector<Future<Void>>* systemActors,
                           std::string whitelistBinPaths,
                           TestConfig testConfig,
                           ProtocolVersion protocolVersion,
-                          TenantMode* tenantMode) {
+                          Optional<TenantMode>* tenantMode) {
 	auto& g_knobs = IKnobCollection::getMutableGlobalKnobCollection();
 	// SOMEDAY: this does not test multi-interface configurations
 	SimulationConfig simconfig(testConfig);
@@ -2713,7 +2713,7 @@ ACTOR void setupAndRun(std::string dataFolder,
 
 	state Optional<TenantName> defaultTenant;
 	state Standalone<VectorRef<TenantNameRef>> tenantsToCreate;
-	state TenantMode tenantMode = TenantMode::END;
+	state Optional<TenantMode> tenantMode;
 
 	try {
 		// systemActors.push_back( startSystemMonitor(dataFolder) );
@@ -2745,7 +2745,7 @@ ACTOR void setupAndRun(std::string dataFolder,
 			wait(delay(1.0)); // FIXME: WHY!!!  //wait for machines to boot
 		}
 		// setupSimulatedSystem/restartSimulatedSystem should fill tenantMode with valid value.
-		ASSERT(tenantMode < TenantMode::END);
+		ASSERT(tenantMode.present());
 		// restartSimulatedSystem can adjust some testConfig params related to tenants
 		// so set/overwrite those options if necessary here
 		if (rebooting && testConfig.tenantModes.size()) {
@@ -2773,7 +2773,7 @@ ACTOR void setupAndRun(std::string dataFolder,
 		}
 		TraceEvent("SimulatedClusterTenantMode")
 		    .detail("UsingTenant", defaultTenant)
-		    .detail("TenantMode", tenantMode.toString())
+		    .detail("TenantMode", tenantMode.get().toString())
 		    .detail("TotalTenants", tenantsToCreate.size());
 		std::string clusterFileDir = joinPath(dataFolder, deterministicRandom()->randomUniqueID().toString());
 		platform::createDirectory(clusterFileDir);

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -1595,8 +1595,11 @@ void SimulationConfig::setTenantMode(const TestConfig& testConfig) {
 
 void SimulationConfig::setEncryptionAtRestMode(const TestConfig& testConfig) {
 	EncryptionAtRestMode encryptionMode = EncryptionAtRestMode::DISABLED;
+	// Only Redwood support encryption. Disable encryption if non-Redwood storage engine is explicitly specified.
+	bool disableEncryption = testConfig.disableEncryption ||
+	                         (testConfig.storageEngineType.present() && testConfig.storageEngineType.get() != 3);
 	// TODO: Remove check on the ENABLE_ENCRYPTION knob once the EKP can start using the db config
-	if (!testConfig.disableEncryption && (SERVER_KNOBS->ENABLE_ENCRYPTION || !testConfig.encryptModes.empty())) {
+	if (!disableEncryption && (SERVER_KNOBS->ENABLE_ENCRYPTION || !testConfig.encryptModes.empty())) {
 		TenantMode tenantMode = db.tenantMode;
 		if (!testConfig.encryptModes.empty()) {
 			std::vector<EncryptionAtRestMode> validEncryptModes;

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -2713,7 +2713,7 @@ ACTOR void setupAndRun(std::string dataFolder,
 
 	state Optional<TenantName> defaultTenant;
 	state Standalone<VectorRef<TenantNameRef>> tenantsToCreate;
-	state TenantMode tenantMode = TenantMode::DISABLED;
+	state TenantMode tenantMode = TenantMode::END;
 
 	try {
 		// systemActors.push_back( startSystemMonitor(dataFolder) );
@@ -2744,6 +2744,8 @@ ACTOR void setupAndRun(std::string dataFolder,
 			                     &tenantMode);
 			wait(delay(1.0)); // FIXME: WHY!!!  //wait for machines to boot
 		}
+		// setupSimulatedSystem/restartSimulatedSystem should fill tenantMode with valid value.
+		ASSERT(tenantMode < TenantMode::END);
 		// restartSimulatedSystem can adjust some testConfig params related to tenants
 		// so set/overwrite those options if necessary here
 		if (rebooting && testConfig.tenantModes.size()) {

--- a/fdbserver/VersionedBTree.actor.cpp
+++ b/fdbserver/VersionedBTree.actor.cpp
@@ -5495,8 +5495,8 @@ public:
 			// for it in which case we would have returned above.
 			iterator iPrevious = ib;
 			--iPrevious;
-			// If the range we just divided was being cleared, then the dividing boundary key and range after it
-			// must also be cleared
+			// If the range we just divided was being cleared, then the dividing boundary key and range after it must
+			// also be cleared
 			if (iPrevious.mutation().clearAfterBoundary) {
 				ib.mutation().clearAll();
 			}
@@ -5626,8 +5626,8 @@ private:
 
 		int startIndex; // Index of the first record
 		int count; // Number of records added to the page
-		int pageSize; // Page or Multipage size required to hold a BTreePage of the added records, which is a
-		              // multiple of blockSize
+		int pageSize; // Page or Multipage size required to hold a BTreePage of the added records, which is a multiple
+		              // of blockSize
 		int bytesLeft; // Bytes in pageSize that are unused by the BTreePage so far
 		bool largeDeltaTree; // Whether or not the tree in the generated page is in the 'large' size range
 		int blockSize; // Base block size by which pageSize can be incremented
@@ -5653,8 +5653,7 @@ private:
 		// Unused fraction of pageSize bytes
 		double slackFraction() const { return (double)bytesLeft / pageSize; }
 
-		// Fraction of PageSize in use by key or value string bytes, disregarding all overhead including string
-		// sizes
+		// Fraction of PageSize in use by key or value string bytes, disregarding all overhead including string sizes
 		double kvFraction() const { return (double)kvBytes / pageSize; }
 
 		// Index of the last record to be included in this page
@@ -6580,8 +6579,8 @@ private:
 					const RedwoodRecordRef& rec = recs[i];
 					debug_printf("internal page (updating) insert: %s\n", rec.toString(false).c_str());
 
-					// Fail if the inserted record does not belong to the same encryption domain as the existing
-					// page data.
+					// Fail if the inserted record does not belong to the same encryption domain as the existing page
+					// data.
 					bool canInsert = true;
 					if (page->isEncrypted() && keyProvider->enableEncryptionDomain()) {
 						ASSERT(keyProvider && pageDomainId.present());
@@ -6595,8 +6594,8 @@ private:
 						debug_printf("internal page: failed to insert %s, switching to rebuild\n",
 						             rec.toString(false).c_str());
 
-						// Update failed, so populate rebuild vector with everything up to but not including end,
-						// which may include items from recs that were already added.
+						// Update failed, so populate rebuild vector with everything up to but not including end, which
+						// may include items from recs that were already added.
 						auto c = end;
 						if (c.moveFirst()) {
 							rebuild.reserve(rebuild.arena(), c.tree->numItems);
@@ -6671,8 +6670,8 @@ private:
 					insert({}, u.newLinks);
 				}
 
-				// cBegin has been erased so interating from the first entry forward will never see cBegin to use as
-				// an endpoint.
+				// cBegin has been erased so interating from the first entry forward will never see cBegin to use as an
+				// endpoint.
 				changesMade = true;
 			} else {
 
@@ -6840,8 +6839,8 @@ private:
 					bool shouldInsertBoundary = mBegin.mutation().boundarySet();
 
 					// Optimization:  In-place value update of new same-sized value
-					// If the boundary exists in the page and we're in update mode and the boundary is being set to
-					// a new value of the same length as the old value then just update the value bytes.
+					// If the boundary exists in the page and we're in update mode and the boundary is being set to a
+					// new value of the same length as the old value then just update the value bytes.
 					if (boundaryExists && updatingDeltaTree && shouldInsertBoundary &&
 					    mBegin.mutation().boundaryValue.get().size() == cursor.get().value.get().size()) {
 						changesMade = true;
@@ -6877,8 +6876,7 @@ private:
 						}
 					}
 
-					// If the boundary value is being set and we must insert it, add it to the page or the output
-					// set
+					// If the boundary value is being set and we must insert it, add it to the page or the output set
 					if (shouldInsertBoundary) {
 						RedwoodRecordRef rec(mBegin.key(), mBegin.mutation().boundaryValue.get());
 						changesMade = true;
@@ -6905,9 +6903,9 @@ private:
 								             rec.toString().c_str());
 
 								// Since the insert failed we must switch to a linear merge of existing data and
-								// mutations, accumulating the new record set in the merge vector and build new
-								// pages from it. First, we must populate the merged vector with all the records up
-								// to but not including the current mutation boundary key.
+								// mutations, accumulating the new record set in the merge vector and build new pages
+								// from it. First, we must populate the merged vector with all the records up to but not
+								// including the current mutation boundary key.
 								auto c = cursor;
 								c.moveFirst();
 								while (c != cursor) {
@@ -6941,8 +6939,7 @@ private:
 					}
 				}
 
-				// Before advancing the iterator, get whether or not the records in the following range must be
-				// removed
+				// Before advancing the iterator, get whether or not the records in the following range must be removed
 				bool remove = mBegin.mutation().clearAfterBoundary;
 				// Advance to the next boundary because we need to know the end key for the current range.
 				++mBegin;
@@ -7010,8 +7007,8 @@ private:
 					             updatingDeltaTree);
 				} else {
 					// If updating and the key is changing, we must visit the records to erase them.
-					// If not updating and the key is not changing, we must visit the records to add them to the
-					// output set.
+					// If not updating and the key is not changing, we must visit the records to add them to the output
+					// set.
 					while (cursor.valid()) {
 						if (updatingDeltaTree) {
 							debug_printf(
@@ -7132,10 +7129,9 @@ private:
 				} else {
 					u.subtreeLowerBound = u.decodeLowerBound;
 					mBegin = mEnd;
-					// mBegin is either at or greater than subtreeLowerBound->key, which was the
-					// subtreeUpperBound->key for the previous subtree slice.  But we need it to be at or *before*
-					// subtreeLowerBound->key so if mBegin.key() is not exactly the subtree lower bound key then
-					// decrement it.
+					// mBegin is either at or greater than subtreeLowerBound->key, which was the subtreeUpperBound->key
+					// for the previous subtree slice.  But we need it to be at or *before* subtreeLowerBound->key
+					// so if mBegin.key() is not exactly the subtree lower bound key then decrement it.
 					if (mBegin.key() != u.subtreeLowerBound.key) {
 						--mBegin;
 					}
@@ -7152,9 +7148,9 @@ private:
 					// subtree boundary that is now needed for reading the subtree at cBegin.
 					if (!cursor.get().value.present()) {
 						// If the upper bound is provided by a dummy record in [cBegin, cEnd) then there is no
-						// requirement on the next subtree range or the parent page to have a specific upper
-						// boundary for decoding the subtree.  The expected upper bound has not yet been set so it
-						// can remain empty.
+						// requirement on the next subtree range or the parent page to have a specific upper boundary
+						// for decoding the subtree.  The expected upper bound has not yet been set so it can remain
+						// empty.
 						cursor.moveNext();
 						// If there is another record after the null child record, it must have a child page value
 						ASSERT(!cursor.valid() || cursor.get().value.present());
@@ -7183,9 +7179,8 @@ private:
 					const RangeMutation& range = mBegin.mutation();
 					bool uniform;
 					if (range.clearAfterBoundary) {
-						// If the mutation range after the boundary key is cleared, then the mutation boundary key
-						// must be cleared or must be different than the subtree lower bound key so that it doesn't
-						// matter
+						// If the mutation range after the boundary key is cleared, then the mutation boundary key must
+						// be cleared or must be different than the subtree lower bound key so that it doesn't matter
 						uniform = range.boundaryCleared() || mutationBoundaryKey != u.subtreeLowerBound.key;
 					} else {
 						// If the mutation range after the boundary key is unchanged, then the mutation boundary key
@@ -7196,10 +7191,10 @@ private:
 
 					// If u's subtree is either all cleared or all unchanged
 					if (uniform) {
-						// We do not need to recurse to this subtree.  Next, let's see if we can embiggen u's range
-						// to include sibling subtrees also covered by (mBegin, mEnd) so we can not recurse to
-						// those, too. If the cursor is valid, u.subtreeUpperBound is the cursor's position, which
-						// is >= mEnd.key(). If equal, no range expansion is possible.
+						// We do not need to recurse to this subtree.  Next, let's see if we can embiggen u's range to
+						// include sibling subtrees also covered by (mBegin, mEnd) so we can not recurse to those, too.
+						// If the cursor is valid, u.subtreeUpperBound is the cursor's position, which is >= mEnd.key().
+						// If equal, no range expansion is possible.
 						if (cursor.valid() && mEnd.key() != u.subtreeUpperBound.key) {
 							// TODO:  If cursor hints are available, use (cursor, 1)
 							cursor.seekLessThanOrEqual(mEnd.key(), update->skipLen);
@@ -7207,9 +7202,8 @@ private:
 							// If this seek moved us ahead, to something other than cEnd, then update subtree range
 							// boundaries
 							if (cursor != u.cEnd) {
-								// If the cursor is at a record with a null child, back up one step because it is in
-								// the middle of the next logical subtree, as null child records are not subtree
-								// boundaries.
+								// If the cursor is at a record with a null child, back up one step because it is in the
+								// middle of the next logical subtree, as null child records are not subtree boundaries.
 								ASSERT(cursor.valid());
 								if (!cursor.get().value.present()) {
 									cursor.movePrev();
@@ -7219,8 +7213,8 @@ private:
 								u.subtreeUpperBound = cursor.get();
 								u.skipLen = 0; // TODO: set this
 
-								// The new decode upper bound is either cEnd or the record before it if it has no
-								// child link
+								// The new decode upper bound is either cEnd or the record before it if it has no child
+								// link
 								auto c = u.cEnd;
 								c.movePrev();
 								ASSERT(c.valid());
@@ -7264,8 +7258,8 @@ private:
 						debug_printf("%s Not recursing, one mutation range covers this slice:\n", context.c_str());
 						debug_print(addPrefix(context, u.toString()));
 
-						// u has already been initialized with the correct result, no recursion needed, so restart
-						// the loop.
+						// u has already been initialized with the correct result, no recursion needed, so restart the
+						// loop.
 						continue;
 					}
 				}
@@ -7312,8 +7306,8 @@ private:
 			// The expected next record for the final range is checked against one of the upper boundaries passed to
 			// this commitSubtree() instance.  If changes have already been made, then the subtree upper boundary is
 			// passed, so in the event a different upper boundary is needed it will be added to the already-modified
-			// page.  Otherwise, the decode boundary is used which will prevent this page from being modified for
-			// the sole purpose of adding a dummy upper bound record.
+			// page.  Otherwise, the decode boundary is used which will prevent this page from being modified for the
+			// sole purpose of adding a dummy upper bound record.
 			debug_printf("%s Applying final child range update. changesMade=%d\nSubtree Root Update:\n",
 			             context.c_str(),
 			             modifier.changesMade);
@@ -7362,8 +7356,7 @@ private:
 					self->freeBTreePage(height, rootID, batch->writeVersion);
 				} else {
 					if (modifier.updating) {
-						// Page was updated in place (or being forced to be updated in place to update child page
-						// ids)
+						// Page was updated in place (or being forced to be updated in place to update child page ids)
 						debug_printf(
 						    "%s Internal page modified in-place tryToUpdate=%d forceUpdate=%d detachChildren=%d\n",
 						    context.c_str(),
@@ -7447,8 +7440,8 @@ private:
 											PhysicalPageID newID =
 											    self->m_pager->detachRemappedPage(p, batch->writeVersion);
 											if (newID != invalidPhysicalPageID) {
-												// Records in the rebuild vector reference original page memory so
-												// make a new child link in the rebuild arena
+												// Records in the rebuild vector reference original page memory so make
+												// a new child link in the rebuild arena
 												BTreeNodeLinkRef newPages = BTreeNodeLinkRef(
 												    modifier.rebuild.arena(), BTreeNodeLinkRef(&newID, 1));
 												rec.setChildPage(newPages);
@@ -7775,8 +7768,7 @@ public:
 
 		Future<Void> seekGTE(RedwoodRecordRef query) { return seekGTE_impl(this, query); }
 
-		// Start fetching sibling nodes in the forward or backward direction, stopping after recordLimit or
-		// byteLimit
+		// Start fetching sibling nodes in the forward or backward direction, stopping after recordLimit or byteLimit
 		void prefetch(KeyRef rangeEnd, bool directionForward, int recordLimit, int byteLimit) {
 			// Prefetch scans level 2 so if there are less than 2 nodes in the path there is no level 2
 			if (path.size() < 2) {
@@ -7856,8 +7848,7 @@ public:
 					success = forward ? entry.cursor.moveFirst() : false;
 				}
 
-				// Skip over internal page entries that do not link to child pages.  There should never be two in a
-				// row.
+				// Skip over internal page entries that do not link to child pages.  There should never be two in a row.
 				if (success && !entry.btPage()->isLeaf() && !entry.cursor.get().value.present()) {
 					success = forward ? entry.cursor.moveNext() : entry.cursor.movePrev();
 					ASSERT(!success || entry.cursor.get().value.present());
@@ -8113,8 +8104,8 @@ public:
 				BTreePage::BinaryTree::Cursor& leafCursor = cur.back().cursor;
 
 				// we can bypass the bounds check for each key in the leaf if the entire leaf is in range
-				// > because both query end and page upper bound are exclusive of the query results and page
-				// contents, respectively
+				// > because both query end and page upper bound are exclusive of the query results and page contents,
+				// respectively
 				bool checkBounds = leafCursor.cache->upperBound > keys.end;
 				// Whether or not any results from this page were added to results
 				bool usedPage = false;
@@ -8168,8 +8159,8 @@ public:
 				BTreePage::BinaryTree::Cursor& leafCursor = cur.back().cursor;
 
 				// we can bypass the bounds check for each key in the leaf if the entire leaf is in range
-				// < because both query begin and page lower bound are inclusive of the query results and page
-				// contents, respectively
+				// < because both query begin and page lower bound are inclusive of the query results and page contents,
+				// respectively
 				bool checkBounds = leafCursor.cache->lowerBound < keys.begin;
 				// Whether or not any results from this page were added to results
 				bool usedPage = false;
@@ -8434,8 +8425,8 @@ ACTOR Future<Void> verifyRangeBTreeCursor(VersionedBTree* btree,
 	debug_printf(
 	    "VerifyRangeReverse(@%" PRId64 ", %s, %s): start\n", v, start.printable().c_str(), end.printable().c_str());
 
-	// Randomly use a new cursor at the same version for the reverse range read, if the version is still available
-	// for opening new cursors
+	// Randomly use a new cursor at the same version for the reverse range read, if the version is still available for
+	// opening new cursors
 	if (v >= btree->getOldestReadableVersion() && deterministicRandom()->coinflip()) {
 		cur = VersionedBTree::BTreeCursor();
 		wait(btree->initBTreeCursor(&cur, v, PagerEventReasons::RangeRead));

--- a/fdbserver/fdbserver.actor.cpp
+++ b/fdbserver/fdbserver.actor.cpp
@@ -2265,10 +2265,6 @@ int main(int argc, char* argv[]) {
 				                KnobValue::create(ini.GetBoolValue("META", "enableBlobGranuleEncryption", false)));
 				g_knobs.setKnob("enable_blob_granule_compression",
 				                KnobValue::create(ini.GetBoolValue("META", "enableBlobGranuleEncryption", false)));
-				// Restart test does not preserve encryption mode (tenant-aware or domain-aware).
-				// Disable domain-aware encryption in Redwood until encryption mode from db config is being handled.
-				// TODO(yiwu): clean it up once we cleanup the knob.
-				g_knobs.setKnob("redwood_split_encrypted_pages_by_tenant", KnobValue::create(bool{ false }));
 				g_knobs.setKnob("encrypt_header_auth_token_enabled",
 				                KnobValue::create(ini.GetBoolValue("META", "encryptHeaderAuthTokenEnabled", false)));
 				g_knobs.setKnob("encrypt_header_auth_token_algo",

--- a/fdbserver/include/fdbserver/IKeyValueStore.h
+++ b/fdbserver/include/fdbserver/IKeyValueStore.h
@@ -20,6 +20,7 @@
 
 #ifndef FDBSERVER_IKEYVALUESTORE_H
 #define FDBSERVER_IKEYVALUESTORE_H
+#include "flow/Trace.h"
 #pragma once
 
 #include "fdbclient/FDBTypes.h"
@@ -134,9 +135,7 @@ public:
 	virtual Future<Void> init() { return Void(); }
 
 	// Obtain the encryption mode of the storage. The encryption mode needs to match the encryption mode of the cluster.
-	virtual Future<EncryptionAtRestMode> encryptionMode() {
-		return EncryptionAtRestMode(EncryptionAtRestMode::DISABLED);
-	}
+	virtual Future<EncryptionAtRestMode> encryptionMode() = 0;
 
 protected:
 	virtual ~IKeyValueStore() {}
@@ -194,7 +193,7 @@ inline IKeyValueStore* openKVStore(KeyValueStoreType storeType,
 	// Only Redwood support encryption currently.
 	if (encryptionMode.present() && encryptionMode.get().isEncryptionEnabled() &&
 	    storeType != KeyValueStoreType::SSD_REDWOOD_V1) {
-		TraceEvent("KVStoreTypeNotSupportingEncryption")
+		TraceEvent(SevWarn, "KVStoreTypeNotSupportingEncryption")
 		    .detail("KVStoreType", storeType)
 		    .detail("EncryptionMode", encryptionMode);
 		throw encrypt_mode_mismatch();

--- a/fdbserver/include/fdbserver/IPageEncryptionKeyProvider.actor.h
+++ b/fdbserver/include/fdbserver/IPageEncryptionKeyProvider.actor.h
@@ -70,8 +70,8 @@ public:
 	// Expected encoding type being used with the encryption key provider.
 	virtual EncodingType expectedEncodingType() const = 0;
 
-	// Whether domain-aware encryption is enabled.
-	virtual bool isDomainAware() const { return false; }
+	// Whether encryption domain is enabled.
+	virtual bool enableEncryptionDomain() const = 0;
 
 	// Get an encryption key from given encoding header.
 	virtual Future<EncryptionKey> getEncryptionKey(const void* encodingHeader) { throw not_implemented(); }
@@ -97,7 +97,7 @@ public:
 
 	// Check if a key fits in an encryption domain.
 	bool keyFitsInDomain(int64_t domainId, const KeyRef& key, bool canUseDefaultDomain) {
-		ASSERT(isDomainAware());
+		ASSERT(enableEncryptionDomain());
 		int64_t keyDomainId;
 		size_t prefixLength;
 		std::tie(keyDomainId, prefixLength) = getEncryptionDomain(key);
@@ -112,6 +112,7 @@ class NullEncryptionKeyProvider : public IPageEncryptionKeyProvider {
 public:
 	virtual ~NullEncryptionKeyProvider() {}
 	EncodingType expectedEncodingType() const override { return EncodingType::XXHash64; }
+	bool enableEncryptionDomain() const override { return false; }
 };
 
 // Key provider for dummy XOR encryption scheme
@@ -135,6 +136,8 @@ public:
 	virtual ~XOREncryptionKeyProvider_TestOnly() {}
 
 	EncodingType expectedEncodingType() const override { return EncodingType::XOREncryption_TestOnly; }
+
+	bool enableEncryptionDomain() const override { return false; }
 
 	Future<EncryptionKey> getEncryptionKey(const void* encodingHeader) override {
 
@@ -183,7 +186,7 @@ public:
 
 	EncodingType expectedEncodingType() const override { return encodingType; }
 
-	bool isDomainAware() const override { return mode > 0; }
+	bool enableEncryptionDomain() const override { return mode > 0; }
 
 	Future<EncryptionKey> getEncryptionKey(const void* encodingHeader) override {
 		using Header = typename ArenaPage::AESEncryptionEncoder<encodingType>::Header;
@@ -293,7 +296,7 @@ public:
 
 	EncodingType expectedEncodingType() const override { return encodingType; }
 
-	bool isDomainAware() const override {
+	bool enableEncryptionDomain() const override {
 		// Regardless of encryption mode, system keys always encrypted using system key space domain.
 		// Because of this, AESEncryptionKeyProvider always appears to be domain-aware.
 		return true;

--- a/fdbserver/include/fdbserver/IPageEncryptionKeyProvider.actor.h
+++ b/fdbserver/include/fdbserver/IPageEncryptionKeyProvider.actor.h
@@ -18,7 +18,8 @@
  * limitations under the License.
  */
 
-#include "fdbclient/FDBTypes.h"
+#include "fdbclient/TenantManagement.actor.h"
+#include "fdbrpc/TenantInfo.h"
 #if defined(NO_INTELLISENSE) && !defined(FDBSERVER_IPAGEENCRYPTIONKEYPROVIDER_ACTOR_G_H)
 #define FDBSERVER_IPAGEENCRYPTIONKEYPROVIDER_ACTOR_G_H
 #include "fdbserver/IPageEncryptionKeyProvider.actor.g.h"
@@ -343,10 +344,8 @@ public:
 		if (key.size() < TenantAPI::PREFIX_SIZE) {
 			return { FDB_DEFAULT_ENCRYPT_DOMAIN_ID, 0 };
 		}
-		StringRef prefix = key.substr(0, TenantAPI::PREFIX_SIZE);
-		int64_t tenantId = TenantAPI::prefixToId(prefix, EnforceValidTenantId::False);
-		// Tenant id must be non-negative.
-		if (tenantId < 0) {
+		int64_t tenantId = TenantAPI::extractTenantIdFromKeyRef(key);
+		if (tenantId == TenantInfo::INVALID_TENANT) {
 			return { FDB_DEFAULT_ENCRYPT_DOMAIN_ID, 0 };
 		}
 		return { tenantId, TenantAPI::PREFIX_SIZE };

--- a/fdbserver/include/fdbserver/IPager.h
+++ b/fdbserver/include/fdbserver/IPager.h
@@ -22,8 +22,6 @@
 #ifndef FDBSERVER_IPAGER_H
 #define FDBSERVER_IPAGER_H
 
-#include <cstddef>
-#include <stdint.h>
 #include "fdbclient/BlobCipher.h"
 #include "fdbclient/FDBTypes.h"
 #include "fdbclient/GetEncryptCipherKeys.actor.h"
@@ -38,6 +36,10 @@
 
 #define XXH_INLINE_ALL
 #include "flow/xxhash.h"
+
+#include <array>
+#include <cstddef>
+#include <stdint.h>
 
 typedef uint32_t LogicalPageID;
 typedef uint32_t PhysicalPageID;
@@ -101,6 +103,16 @@ enum EncodingType : uint8_t {
 	AESEncryptionWithAuth = 3,
 	MAX_ENCODING_TYPE = 4
 };
+
+inline bool isEncodingTypeEncrypted(EncodingType encoding) {
+	constexpr std::array encryptedEncodingTypes = { AESEncryption, AESEncryptionWithAuth, XOREncryption_TestOnly };
+	return std::count(encryptedEncodingTypes.begin(), encryptedEncodingTypes.end(), encoding) > 0;
+}
+
+inline bool isEncodingTypeAESEncrypted(EncodingType encoding) {
+	constexpr std::array aesEncryptedEncodingTypes = { AESEncryption, AESEncryptionWithAuth };
+	return std::count(aesEncryptedEncodingTypes.begin(), aesEncryptedEncodingTypes.end(), encoding) > 0;
+}
 
 enum PageType : uint8_t {
 	HeaderPage = 0,
@@ -615,11 +627,6 @@ public:
 
 	const Arena& getArena() const { return arena; }
 
-	static bool isEncodingTypeEncrypted(EncodingType t) {
-		return t == EncodingType::AESEncryption || t == EncodingType::AESEncryptionWithAuth ||
-		       t == EncodingType::XOREncryption_TestOnly;
-	}
-
 	// Returns true if the page's encoding type employs encryption
 	bool isEncrypted() const { return isEncodingTypeEncrypted(getEncodingType()); }
 
@@ -707,10 +714,15 @@ public:
 	ArbitraryObject extra;
 };
 
+class IPageEncryptionKeyProvider;
+
 // This API is probably too customized to the behavior of DWALPager and probably needs some changes to be more generic.
 class IPager2 : public IClosable {
 public:
 	virtual std::string getName() const = 0;
+
+	// Set an encryption key provider.
+	virtual void setEncryptionKeyProvider(Reference<IPageEncryptionKeyProvider> keyProvider) = 0;
 
 	// Returns an ArenaPage that can be passed to writePage. The data in the returned ArenaPage might not be zeroed.
 	virtual Reference<ArenaPage> newPageBuffer(size_t blocks = 1) = 0;

--- a/fdbserver/include/fdbserver/IPager.h
+++ b/fdbserver/include/fdbserver/IPager.h
@@ -104,14 +104,13 @@ enum EncodingType : uint8_t {
 	MAX_ENCODING_TYPE = 4
 };
 
+static constexpr std::array EncryptedEncodingTypes = { AESEncryption, AESEncryptionWithAuth, XOREncryption_TestOnly };
 inline bool isEncodingTypeEncrypted(EncodingType encoding) {
-	constexpr std::array encryptedEncodingTypes = { AESEncryption, AESEncryptionWithAuth, XOREncryption_TestOnly };
-	return std::count(encryptedEncodingTypes.begin(), encryptedEncodingTypes.end(), encoding) > 0;
+	return std::count(EncryptedEncodingTypes.begin(), EncryptedEncodingTypes.end(), encoding) > 0;
 }
 
 inline bool isEncodingTypeAESEncrypted(EncodingType encoding) {
-	constexpr std::array aesEncryptedEncodingTypes = { AESEncryption, AESEncryptionWithAuth };
-	return std::count(aesEncryptedEncodingTypes.begin(), aesEncryptedEncodingTypes.end(), encoding) > 0;
+	return encoding == AESEncryption || encoding == AESEncryptionWithAuth;
 }
 
 enum PageType : uint8_t {

--- a/fdbserver/include/fdbserver/RemoteIKeyValueStore.actor.h
+++ b/fdbserver/include/fdbserver/RemoteIKeyValueStore.actor.h
@@ -492,6 +492,10 @@ struct RemoteIKeyValueStore : public IKeyValueStore {
 		}
 		return Void();
 	}
+
+	Future<EncryptionAtRestMode> encryptionMode() override {
+		return EncryptionAtRestMode(EncryptionAtRestMode::DISABLED);
+	}
 };
 
 Future<Void> runFlowProcess(std::string const& name, Endpoint endpoint);

--- a/fdbserver/include/fdbserver/WorkerInterface.actor.h
+++ b/fdbserver/include/fdbserver/WorkerInterface.actor.h
@@ -866,10 +866,12 @@ struct InitializeStorageRequest {
 	    tssPairIDAndVersion; // Only set if recruiting a tss. Will be the UID and Version of its SS pair.
 	Version initialClusterVersion;
 	ReplyPromise<InitializeStorageReply> reply;
+	EncryptionAtRestMode encryptMode;
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, seedTag, reqId, interfaceId, storeType, reply, tssPairIDAndVersion, initialClusterVersion);
+		serializer(
+		    ar, seedTag, reqId, interfaceId, storeType, reply, tssPairIDAndVersion, initialClusterVersion, encryptMode);
 	}
 };
 
@@ -1186,7 +1188,6 @@ ACTOR Future<Void> encryptKeyProxyServer(EncryptKeyProxyInterface ei, Reference<
 class IKeyValueStore;
 class ServerCoordinators;
 class IDiskQueue;
-class IPageEncryptionKeyProvider;
 ACTOR Future<Void> storageServer(IKeyValueStore* persistentData,
                                  StorageServerInterface ssi,
                                  Tag seedTag,
@@ -1194,8 +1195,7 @@ ACTOR Future<Void> storageServer(IKeyValueStore* persistentData,
                                  Version tssSeedVersion,
                                  ReplyPromise<InitializeStorageReply> recruitReply,
                                  Reference<AsyncVar<ServerDBInfo> const> db,
-                                 std::string folder,
-                                 Reference<IPageEncryptionKeyProvider> encryptionKeyProvider);
+                                 std::string folder);
 ACTOR Future<Void> storageServer(
     IKeyValueStore* persistentData,
     StorageServerInterface ssi,
@@ -1203,8 +1203,7 @@ ACTOR Future<Void> storageServer(
     std::string folder,
     Promise<Void> recovered,
     Reference<IClusterConnectionRecord>
-        connRecord, // changes pssi->id() to be the recovered ID); // changes pssi->id() to be the recovered ID
-    Reference<IPageEncryptionKeyProvider> encryptionKeyProvider);
+        connRecord); // changes pssi->id() to be the recovered ID); // changes pssi->id() to be the recovered ID
 ACTOR Future<Void> masterServer(MasterInterface mi,
                                 Reference<AsyncVar<ServerDBInfo> const> db,
                                 Reference<AsyncVar<Optional<ClusterControllerFullInterface>> const> ccInterface,

--- a/fdbserver/worker.actor.cpp
+++ b/fdbserver/worker.actor.cpp
@@ -1350,8 +1350,7 @@ ACTOR Future<Void> storageServerRollbackRebooter(std::set<std::pair<UID, KeyValu
                                                  int64_t memoryLimit,
                                                  IKeyValueStore* store,
                                                  bool validateDataFiles,
-                                                 Promise<Void>* rebootKVStore,
-                                                 Reference<IPageEncryptionKeyProvider> encryptionKeyProvider) {
+                                                 Promise<Void>* rebootKVStore) {
 	state TrackRunningStorage _(id, storeType, runningStorages);
 	loop {
 		ErrorOr<Void> e = wait(errorOr(prevStorageServer));
@@ -1418,13 +1417,8 @@ ACTOR Future<Void> storageServerRollbackRebooter(std::set<std::pair<UID, KeyValu
 		DUMPTOKEN(recruited.changeFeedPop);
 		DUMPTOKEN(recruited.changeFeedVersionUpdate);
 
-		prevStorageServer = storageServer(store,
-		                                  recruited,
-		                                  db,
-		                                  folder,
-		                                  Promise<Void>(),
-		                                  Reference<IClusterConnectionRecord>(nullptr),
-		                                  encryptionKeyProvider);
+		prevStorageServer =
+		    storageServer(store, recruited, db, folder, Promise<Void>(), Reference<IClusterConnectionRecord>(nullptr));
 		prevStorageServer = handleIOErrors(prevStorageServer, store, id, store->onClosed());
 	}
 }
@@ -1888,14 +1882,6 @@ ACTOR Future<Void> workerServer(Reference<IClusterConnectionRecord> connRecord,
 				LocalLineage _;
 				getCurrentLineage()->modify(&RoleLineage::role) = ProcessClass::ClusterRole::Storage;
 
-				Reference<IPageEncryptionKeyProvider> encryptionKeyProvider;
-				if (FLOW_KNOBS->ENCRYPT_HEADER_AUTH_TOKEN_ENABLED) {
-					encryptionKeyProvider =
-					    makeReference<TenantAwareEncryptionKeyProvider<EncodingType::AESEncryptionWithAuth>>(dbInfo);
-				} else {
-					encryptionKeyProvider =
-					    makeReference<TenantAwareEncryptionKeyProvider<EncodingType::AESEncryption>>(dbInfo);
-				}
 				IKeyValueStore* kv = openKVStore(
 				    s.storeType,
 				    s.filename,
@@ -1909,7 +1895,7 @@ ACTOR Future<Void> workerServer(Reference<IClusterConnectionRecord> connRecord,
 				                s.storeType != KeyValueStoreType::SSD_SHARDED_ROCKSDB &&
 				                deterministicRandom()->coinflip())
 				             : true),
-				    encryptionKeyProvider);
+				    dbInfo);
 				Future<Void> kvClosed =
 				    kv->onClosed() ||
 				    rebootKVSPromise.getFuture() /* clear the onClosed() Future in actorCollection when rebooting */;
@@ -1957,8 +1943,7 @@ ACTOR Future<Void> workerServer(Reference<IClusterConnectionRecord> connRecord,
 				DUMPTOKEN(recruited.changeFeedVersionUpdate);
 
 				Promise<Void> recovery;
-				Future<Void> f =
-				    storageServer(kv, recruited, dbInfo, folder, recovery, connRecord, encryptionKeyProvider);
+				Future<Void> f = storageServer(kv, recruited, dbInfo, folder, recovery, connRecord);
 				recoveries.push_back(recovery.getFuture());
 				f = handleIOErrors(f, kv, s.storeID, kvClosed);
 				f = storageServerRollbackRebooter(&runningStorages,
@@ -1974,8 +1959,7 @@ ACTOR Future<Void> workerServer(Reference<IClusterConnectionRecord> connRecord,
 				                                  memoryLimit,
 				                                  kv,
 				                                  validateDataFiles,
-				                                  &rebootKVSPromise,
-				                                  encryptionKeyProvider);
+				                                  &rebootKVSPromise);
 				errorForwarders.add(forwardError(errors, ssRole, recruited.id(), f));
 			} else if (s.storedComponent == DiskStore::TLogData) {
 				LocalLineage _;
@@ -2581,15 +2565,6 @@ ACTOR Future<Void> workerServer(Reference<IClusterConnectionRecord> connRecord,
 					                   folder,
 					                   isTss ? testingStoragePrefix.toString() : fileStoragePrefix.toString(),
 					                   recruited.id());
-					Reference<IPageEncryptionKeyProvider> encryptionKeyProvider;
-					if (FLOW_KNOBS->ENCRYPT_HEADER_AUTH_TOKEN_ENABLED) {
-						encryptionKeyProvider =
-						    makeReference<TenantAwareEncryptionKeyProvider<EncodingType::AESEncryptionWithAuth>>(
-						        dbInfo);
-					} else {
-						encryptionKeyProvider =
-						    makeReference<TenantAwareEncryptionKeyProvider<EncodingType::AESEncryption>>(dbInfo);
-					}
 					IKeyValueStore* data = openKVStore(
 					    req.storeType,
 					    filename,
@@ -2603,7 +2578,8 @@ ACTOR Future<Void> workerServer(Reference<IClusterConnectionRecord> connRecord,
 					                req.storeType != KeyValueStoreType::SSD_SHARDED_ROCKSDB &&
 					                deterministicRandom()->coinflip())
 					             : true),
-					    encryptionKeyProvider);
+					    dbInfo,
+					    req.encryptMode);
 
 					Future<Void> kvClosed =
 					    data->onClosed() ||
@@ -2619,8 +2595,7 @@ ACTOR Future<Void> workerServer(Reference<IClusterConnectionRecord> connRecord,
 					                               isTss ? req.tssPairIDAndVersion.get().second : 0,
 					                               storageReady,
 					                               dbInfo,
-					                               folder,
-					                               encryptionKeyProvider);
+					                               folder);
 					s = handleIOErrors(s, data, recruited.id(), kvClosed);
 					s = storageCache.removeOnReady(req.reqId, s);
 					s = storageServerRollbackRebooter(&runningStorages,
@@ -2636,8 +2611,7 @@ ACTOR Future<Void> workerServer(Reference<IClusterConnectionRecord> connRecord,
 					                                  memoryLimit,
 					                                  data,
 					                                  false,
-					                                  &rebootKVSPromise2,
-					                                  encryptionKeyProvider);
+					                                  &rebootKVSPromise2);
 					errorForwarders.add(forwardError(errors, ssRole, recruited.id(), s));
 				} else if (storageCache.exists(req.reqId)) {
 					forwardPromise(req.reply, storageCache.get(req.reqId));

--- a/fdbserver/workloads/ConfigureDatabase.actor.cpp
+++ b/fdbserver/workloads/ConfigureDatabase.actor.cpp
@@ -285,6 +285,13 @@ struct ConfigureDatabaseWorkload : TestWorkload {
 	}
 
 	ACTOR Future<Void> _start(ConfigureDatabaseWorkload* self, Database cx) {
+		// Redwood is the only storage engine type supporting encryption.
+		DatabaseConfiguration config = wait(getDatabaseConfiguration(cx));
+		TraceEvent("ConfigureDatabase_Config").detail("Config", config.toString());
+		if (config.encryptionAtRestMode.isEncryptionEnabled()) {
+			TraceEvent("ConfigureDatabase_EncryptionEnabled");
+			self->storageEngineExcludeTypes = { 0, 1, 2, 4, 5 };
+		}
 		if (self->clientId == 0) {
 			self->clients.push_back(timeout(self->singleDB(self, cx), self->testDuration, Void()));
 			wait(waitForAll(self->clients));

--- a/fdbserver/workloads/ConfigureDatabase.actor.cpp
+++ b/fdbserver/workloads/ConfigureDatabase.actor.cpp
@@ -273,14 +273,6 @@ struct ConfigureDatabaseWorkload : TestWorkload {
 
 	ACTOR Future<Void> _setup(Database cx, ConfigureDatabaseWorkload* self) {
 		wait(success(ManagementAPI::changeConfig(cx.getReference(), "single storage_migration_type=aggressive", true)));
-
-		// Redwood is the only storage engine type supporting encryption.
-		DatabaseConfiguration config = wait(getDatabaseConfiguration(cx));
-		if (config.encryptionAtRestMode.isEncryptionEnabled()) {
-			self->storageEngineExcludeTypes = { 0, 1, 2, 4, 5 };
-			wait(success(ManagementAPI::changeConfig(cx.getReference(), "ssd-redwood-1-experimental", true)));
-		}
-
 		return Void();
 	}
 

--- a/fdbserver/workloads/SaveAndKill.actor.cpp
+++ b/fdbserver/workloads/SaveAndKill.actor.cpp
@@ -25,6 +25,8 @@
 #include "fdbserver/TesterInterface.actor.h"
 #include "fdbserver/workloads/workloads.actor.h"
 #include "fdbrpc/simulator.h"
+#include "flow/Knobs.h"
+
 #include "boost/algorithm/string/predicate.hpp"
 #include "flow/IConnection.h"
 #include "fdbrpc/SimulatorProcessInfo.h"

--- a/fdbserver/workloads/SaveAndKill.actor.cpp
+++ b/fdbserver/workloads/SaveAndKill.actor.cpp
@@ -30,7 +30,6 @@
 #include "boost/algorithm/string/predicate.hpp"
 #include "flow/IConnection.h"
 #include "fdbrpc/SimulatorProcessInfo.h"
-#include "flow/Knobs.h"
 
 #undef state
 #include "fdbclient/SimpleIni.h"

--- a/flow/include/flow/error_definitions.h
+++ b/flow/include/flow/error_definitions.h
@@ -356,6 +356,7 @@ ERROR( encrypt_invalid_id, 2706, "Invalid encryption cipher details" )
 ERROR( encrypt_keys_fetch_failed, 2707, "Encryption keys fetch from external KMS failed" )
 ERROR( encrypt_invalid_kms_config, 2708, "Invalid encryption/kms configuration: discovery-url, validation-token, endpoint etc." )
 ERROR( encrypt_unsupported, 2709, "Encryption not supported" )
+ERROR( encrypt_mode_mismatch, 2710, "Encryption mode mismatch with configuration")
 
 // 4xxx Internal errors (those that should be generated only by bugs) are decimal 4xxx
 ERROR( unknown_error, 4000, "An unknown error occurred" )  // C++ exception not of type Error


### PR DESCRIPTION
The PR is updating storage server and Redwood to enable encryption based on the encryption mode in DB config, which was previously controlled by a knob. High level changes are
1. Passing encryption mode in DB config to storage server
    1.1 If it is a new storage server, pass the encryption mode through `InitializeStorageRequest`. the encryption mode is pass to Redwood for initialization
    1.2 If it is an existing storage server, on restart the storage server will send `GetStorageServerRejoinInfoRequest` to commit proxy, and commit proxy will return the current encryption mode, which it get from DB config on its own initialization. Storage server will compare the DB config encryption mode to the local storage encryption mode, and fail if they don't match
2. Adding a new `encryptionMode()` method to `IKeyValueStore`, which return a future of local encryption mode of the KV store instance. A KV store supporting encryption would need to persist its own encryption mode, and return the mode via the API.
3. Redwood accepts encryption mode from its constructor. For a new Redwood instance, caller has to specific the encryption mode, which will be stored in Redwood per-instance file header. For existing instance, caller is supposed to not passing the encryption mode, and let Redwood find it out from its own header.
4. Refactoring in Redwood to accommodate the above changes.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
