### PR TITLE
Remove the `std::function` use in ObjectWriter

### DIFF
--- a/flow/include/flow/FastRef.h
+++ b/flow/include/flow/FastRef.h
@@ -24,7 +24,6 @@
 
 #include <atomic>
 #include <cstdint>
-#include <utility>
 
 // The thread safety this class provides is that it's safe to call addref and
 // delref on the same object concurrently in different threads. Subclass does

--- a/flow/include/flow/ObjectSerializer.h
+++ b/flow/include/flow/ObjectSerializer.h
@@ -185,7 +185,7 @@ class ObjectWriter {
 
 	class AllocateFunctor {
 	public:
-		AllocateFunctor(ObjectWriter* pObjectWriter) : pObjectWriter(pObjectWriter) {}
+		explicit AllocateFunctor(ObjectWriter* pObjectWriter) : pObjectWriter(pObjectWriter), numAllocations(0) {}
 
 		uint8_t* operator()(const size_t size) {
 			++numAllocations;
@@ -208,8 +208,8 @@ class ObjectWriter {
 		int getNumAllocations() const { return numAllocations; }
 
 	private:
-		ObjectWriter* pObjectWriter;
-		int numAllocations;
+		ObjectWriter* pObjectWriter = nullptr;
+		int numAllocations = 0;
 	};
 
 	friend class AllocateFunctor;

--- a/flow/include/flow/ObjectSerializer.h
+++ b/flow/include/flow/ObjectSerializer.h
@@ -233,6 +233,8 @@ class ObjectWriter {
 	};
 
 public:
+	typedef uint8_t* (*CustomAllocatorFunc_t)(const size_t, void*);
+
 	template <class VersionOptions>
 	explicit ObjectWriter(VersionOptions vo) : customAllocator(nullptr), customAllocatorContext(nullptr) {
 		vo.write(*this);
@@ -242,7 +244,7 @@ public:
 	// capture. By downgrading it to a function pointer, the compile time can be reduced. The trade is an additional
 	// void* must be used to carry the captured environment.
 	template <class VersionOptions>
-	explicit ObjectWriter(uint8_t* (*customAllocator_)(size_t, void*), void* customAllocatorContext_, VersionOptions vo)
+	explicit ObjectWriter(CustomAllocatorFunc_t customAllocator_, void* customAllocatorContext_, VersionOptions vo)
 	  : customAllocator(customAllocator_), customAllocatorContext(customAllocatorContext_) {
 		vo.write(*this);
 	}
@@ -283,7 +285,7 @@ public:
 
 private:
 	Arena arena;
-	uint8_t* (*customAllocator)(size_t, void*) = nullptr;
+	CustomAllocatorFunc_t customAllocator = nullptr;
 	void* customAllocatorContext = nullptr;
 	uint8_t* data = nullptr;
 	int size = 0;

--- a/flow/include/flow/ObjectSerializer.h
+++ b/flow/include/flow/ObjectSerializer.h
@@ -237,6 +237,9 @@ public:
 		vo.write(*this);
 	}
 
+	// NOTE: It is known that clang compiler will spend long time on instantiating std::function objects when there is
+	// capture. By downgrading it to a function pointer, the compile time can be reduced. The trade is an additional
+	// void* must be used to carry the captured environment.
 	template <class VersionOptions>
 	explicit ObjectWriter(uint8_t* (*customAllocator_)(size_t, void*), void* customAllocatorContext_, VersionOptions vo)
 	  : customAllocator(customAllocator_), customAllocatorContext(customAllocatorContext_) {

--- a/flow/include/flow/ObjectSerializer.h
+++ b/flow/include/flow/ObjectSerializer.h
@@ -26,6 +26,7 @@
 
 #include <unordered_map>
 #include <any>
+#include <iostream>
 
 using ContextVariableMap = std::unordered_map<std::string_view, std::any>;
 
@@ -217,10 +218,10 @@ class ObjectWriter {
 	class SaveContext {
 	private:
 		ObjectWriter* ar;
-		AllocateFunctor allocator;
+		AllocateFunctor& allocator;
 
 	public:
-		SaveContext(ObjectWriter* ar, const AllocateFunctor& allocator) : ar(ar), allocator(allocator) {}
+		SaveContext(ObjectWriter* ar, AllocateFunctor& allocator) : ar(ar), allocator(allocator) {}
 
 		ProtocolVersion protocolVersion() const { return ar->protocolVersion(); }
 
@@ -233,7 +234,7 @@ class ObjectWriter {
 
 public:
 	template <class VersionOptions>
-	explicit ObjectWriter(VersionOptions vo) : customAllocator(nullptr) {
+	explicit ObjectWriter(VersionOptions vo) : customAllocator(nullptr), customAllocatorContext(nullptr) {
 		vo.write(*this);
 	}
 
@@ -282,8 +283,8 @@ public:
 
 private:
 	Arena arena;
-	uint8_t* (*customAllocator)(size_t, void*);
-	void* customAllocatorContext;
+	uint8_t* (*customAllocator)(size_t, void*) = nullptr;
+	void* customAllocatorContext = nullptr;
 	uint8_t* data = nullptr;
 	int size = 0;
 };

--- a/flow/include/flow/serialize.h
+++ b/flow/include/flow/serialize.h
@@ -889,7 +889,7 @@ public:
 	void serializePacketWriter(PacketWriter& w) const override {
 		ObjectWriter writer(
 		    +[](size_t size, void* pPacketWriter) {
-			    return (*reinterpret_cast<PacketWriter*>(pPacketWriter)).writeBytes(size);
+			    return static_cast<PacketWriter*>(pPacketWriter)->writeBytes(size);
 		    },
 		    &w,
 		    AssumeVersion(w.protocolVersion()));

--- a/flow/include/flow/serialize.h
+++ b/flow/include/flow/serialize.h
@@ -890,7 +890,8 @@ public:
 		ObjectWriter writer(
 		    +[](size_t size, void* pPacketWriter) {
 			    return (*reinterpret_cast<PacketWriter*>(pPacketWriter)).writeBytes(size);
-		    }, &w,
+		    },
+		    &w,
 		    AssumeVersion(w.protocolVersion()));
 		writer.serialize(get()); // Writes directly into buffer supplied by |w|
 	}

--- a/flow/include/flow/serialize.h
+++ b/flow/include/flow/serialize.h
@@ -868,6 +868,9 @@ struct PacketWriter {
 		return result;
 	}
 
+	// This is used by MakeSerializeSource::serializePacketWriter
+	static uint8_t* packetWriterAlloc(const size_t size, void* self);
+
 private:
 	void serializeBytesAcrossBoundary(const void* data, int bytes);
 	void nextBuffer(size_t size = 0 /* downstream it will default to at least 4k minus some padding */);
@@ -886,14 +889,12 @@ template <class T, class V>
 class MakeSerializeSource : public ISerializeSource {
 public:
 	using value_type = V;
-	void serializePacketWriter(PacketWriter& w) const override {
-		ObjectWriter writer(
-		    +[](size_t size, void* pPacketWriter) {
-			    return static_cast<PacketWriter*>(pPacketWriter)->writeBytes(size);
-		    },
-		    &w,
-		    AssumeVersion(w.protocolVersion()));
-		writer.serialize(get()); // Writes directly into buffer supplied by |w|
+	void serializePacketWriter(PacketWriter& packetWriter) const override {
+		ObjectWriter objectWriter(
+		    PacketWriter::packetWriterAlloc, &packetWriter, AssumeVersion(packetWriter.protocolVersion()));
+
+		// Writes directly into buffer supplied by packetWriter
+		objectWriter.serialize(get());
 	}
 	virtual value_type const& get() const = 0;
 };

--- a/flow/include/flow/serialize.h
+++ b/flow/include/flow/serialize.h
@@ -887,7 +887,11 @@ class MakeSerializeSource : public ISerializeSource {
 public:
 	using value_type = V;
 	void serializePacketWriter(PacketWriter& w) const override {
-		ObjectWriter writer([&](size_t size) { return w.writeBytes(size); }, AssumeVersion(w.protocolVersion()));
+		ObjectWriter writer(
+		    +[](size_t size, void* pPacketWriter) {
+			    return (*reinterpret_cast<PacketWriter*>(pPacketWriter)).writeBytes(size);
+		    }, &w,
+		    AssumeVersion(w.protocolVersion()));
 		writer.serialize(get()); // Writes directly into buffer supplied by |w|
 	}
 	virtual value_type const& get() const = 0;

--- a/flow/serialize.cpp
+++ b/flow/serialize.cpp
@@ -42,6 +42,10 @@ const void* BinaryReader::readBytes(int bytes) {
 	return b;
 }
 
+uint8_t* PacketWriter::packetWriterAlloc(const size_t size, void* self) {
+	return static_cast<PacketWriter*>(self)->writeBytes(size);
+}
+
 namespace {
 
 struct _Struct {


### PR DESCRIPTION
clang takes long time to instantiate the `std::function`, by replacing it by a function pointer, the compile time is reduced.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
