### PR TITLE
Blob Worker Encryption doesn't use BG_METADATA_SOURCE

### DIFF
--- a/fdbserver/ApplyMetadataMutation.cpp
+++ b/fdbserver/ApplyMetadataMutation.cpp
@@ -1333,7 +1333,6 @@ void applyMetadataMutations(SpanContext const& spanContext,
                             Version version,
                             Version popVersion,
                             bool initialCommit) {
-	TraceEvent("ApplyMetadataMutationsEncryptMode").detail("Mode", encryptMode.toString());
 	ApplyMetadataMutationsImpl(spanContext,
 	                           arena,
 	                           mutations,
@@ -1354,7 +1353,6 @@ void applyMetadataMutations(SpanContext const& spanContext,
                             const VectorRef<MutationRef>& mutations,
                             const std::unordered_map<EncryptCipherDomainId, Reference<BlobCipherKey>>* pCipherKeys,
                             EncryptionAtRestMode encryptMode) {
-	TraceEvent("ApplyMetadataMutationsEncryptMode").detail("Mode", encryptMode.toString());
 	ApplyMetadataMutationsImpl(spanContext, resolverData, mutations, pCipherKeys, encryptMode).apply();
 }
 

--- a/fdbserver/BlobWorker.actor.cpp
+++ b/fdbserver/BlobWorker.actor.cpp
@@ -439,9 +439,6 @@ void checkGranuleLock(int64_t epoch, int64_t seqno, int64_t ownerEpoch, int64_t 
 	}
 }
 
-bool isEncryptionOpSupported(EncryptionAtRestMode encryptMode) {
-	return encryptMode.isEncryptionEnabled() && SERVER_KNOBS->BG_METADATA_SOURCE == "tenant";
-}
 } // namespace
 
 // Below actors asssit in fetching/lookup desired encryption keys. Following steps are done for an encryption key
@@ -829,7 +826,7 @@ ACTOR Future<BlobFileIndex> writeDeltaFile(Reference<BlobWorkerData> bwData,
 	state Optional<BlobGranuleCipherKeysMeta> cipherKeysMeta;
 	state Arena arena;
 
-	if (isEncryptionOpSupported(bwData->encryptMode)) {
+	if (bwData->encryptMode.isEncryptionEnabled()) {
 		BlobGranuleCipherKeysCtx ciphKeysCtx = wait(getLatestGranuleCipherKeys(bwData, keyRange, &arena));
 		cipherKeysCtx = std::move(ciphKeysCtx);
 		cipherKeysMeta = BlobGranuleCipherKeysCtx::toCipherKeysMeta(cipherKeysCtx.get());
@@ -1042,7 +1039,7 @@ ACTOR Future<BlobFileIndex> writeSnapshot(Reference<BlobWorkerData> bwData,
 	state Optional<BlobGranuleCipherKeysMeta> cipherKeysMeta;
 	state Arena arena;
 
-	if (isEncryptionOpSupported(bwData->encryptMode)) {
+	if (bwData->encryptMode.isEncryptionEnabled()) {
 		BlobGranuleCipherKeysCtx ciphKeysCtx = wait(getLatestGranuleCipherKeys(bwData, keyRange, &arena));
 		cipherKeysCtx = std::move(ciphKeysCtx);
 		cipherKeysMeta = BlobGranuleCipherKeysCtx::toCipherKeysMeta(cipherKeysCtx.get());
@@ -1288,12 +1285,10 @@ ACTOR Future<BlobFileIndex> compactFromBlob(Reference<BlobWorkerData> bwData,
 		ASSERT(snapshotVersion < version);
 
 		state Optional<BlobGranuleCipherKeysCtx> snapCipherKeysCtx;
-		if (g_network && g_network->isSimulated() && isEncryptionOpSupported(bwData->encryptMode) &&
-		    !snapshotF.cipherKeysMeta.present()) {
-			ASSERT(false);
-		}
+		ASSERT(!(g_network && g_network->isSimulated() && bwData->encryptMode.isEncryptionEnabled() &&
+		         !snapshotF.cipherKeysMeta.present()));
 		if (snapshotF.cipherKeysMeta.present()) {
-			ASSERT(isEncryptionOpSupported(bwData->encryptMode));
+			ASSERT(bwData->encryptMode.isEncryptionEnabled());
 			CODE_PROBE(true, "fetching cipher keys for blob snapshot file");
 			BlobGranuleCipherKeysCtx keysCtx =
 			    wait(getGranuleCipherKeysFromKeysMeta(bwData, snapshotF.cipherKeysMeta.get(), &filenameArena));
@@ -1320,13 +1315,11 @@ ACTOR Future<BlobFileIndex> compactFromBlob(Reference<BlobWorkerData> bwData,
 
 			deltaF = files.deltaFiles[deltaIdx];
 
-			if (g_network && g_network->isSimulated() && isEncryptionOpSupported(bwData->encryptMode) &&
-			    !deltaF.cipherKeysMeta.present()) {
-				ASSERT(false);
-			}
+			ASSERT(!(g_network && g_network->isSimulated() && bwData->encryptMode.isEncryptionEnabled() &&
+			         !deltaF.cipherKeysMeta.present()));
 
 			if (deltaF.cipherKeysMeta.present()) {
-				ASSERT(isEncryptionOpSupported(bwData->encryptMode));
+				ASSERT(bwData->encryptMode.isEncryptionEnabled());
 				CODE_PROBE(true, "fetching cipher keys for delta file");
 				BlobGranuleCipherKeysCtx keysCtx =
 				    wait(getGranuleCipherKeysFromKeysMeta(bwData, deltaF.cipherKeysMeta.get(), &filenameArena));
@@ -3825,13 +3818,10 @@ ACTOR Future<Void> doBlobGranuleFileRequest(Reference<BlobWorkerData> bwData, Bl
 							    .detail("FileName", chunk.snapshotFile.get().filename.toString())
 							    .detail("Encrypted", encrypted);
 						}
-
-						if (g_network && g_network->isSimulated() && isEncryptionOpSupported(bwData->encryptMode) &&
-						    !encrypted) {
-							ASSERT(false);
-						}
+						ASSERT(!(g_network && g_network->isSimulated() && bwData->encryptMode.isEncryptionEnabled() &&
+						         !encrypted));
 						if (encrypted) {
-							ASSERT(isEncryptionOpSupported(bwData->encryptMode));
+							ASSERT(bwData->encryptMode.isEncryptionEnabled());
 							ASSERT(!chunk.snapshotFile.get().cipherKeysCtx.present());
 							CODE_PROBE(true, "fetching cipher keys from meta ref for snapshot file");
 							snapCipherKeysCtx = getGranuleCipherKeysFromKeysMetaRef(
@@ -3848,12 +3838,10 @@ ACTOR Future<Void> doBlobGranuleFileRequest(Reference<BlobWorkerData> bwData, Bl
 							    .detail("Encrypted", encrypted);
 						}
 
-						if (g_network && g_network->isSimulated() && isEncryptionOpSupported(bwData->encryptMode) &&
-						    !encrypted) {
-							ASSERT(false);
-						}
+						ASSERT(!(g_network && g_network->isSimulated() && bwData->encryptMode.isEncryptionEnabled() &&
+						         !encrypted));
 						if (encrypted) {
-							ASSERT(isEncryptionOpSupported(bwData->encryptMode));
+							ASSERT(bwData->encryptMode.isEncryptionEnabled());
 							ASSERT(!chunk.deltaFiles[deltaIdx].cipherKeysCtx.present());
 							CODE_PROBE(true, "fetching cipher keys from meta ref for delta files");
 							deltaCipherKeysCtxs.emplace(
@@ -5127,8 +5115,8 @@ ACTOR Future<Void> blobWorker(BlobWorkerInterface bwInterf,
 	state Reference<BlobWorkerData> self(new BlobWorkerData(bwInterf.id(), dbInfo, cx));
 	self->id = bwInterf.id();
 	self->locality = bwInterf.locality;
-	// Since the blob worker gets initalized through the blob manager it is easier to fetch the encryption state using
-	// the DB Config rather than passing it through the initalization request for the blob manager and blob worker
+	// Since the blob worker gets initalized through the blob manager it is more reliable to fetch the encryption state
+	// using the DB Config rather than passing it through the initalization request for the blob manager and blob worker
 	DatabaseConfiguration config = wait(getDatabaseConfiguration(cx));
 	self->encryptMode = config.encryptionAtRestMode;
 	TraceEvent("BWEncryptionAtRestMode").detail("Mode", self->encryptMode.toString());

--- a/fdbserver/Resolver.actor.cpp
+++ b/fdbserver/Resolver.actor.cpp
@@ -668,7 +668,9 @@ ACTOR Future<Void> resolverCore(ResolverInterface resolver,
 	actors.add(waitFailureServer(resolver.waitFailure.getFuture()));
 	actors.add(traceRole(Role::RESOLVER, resolver.id()));
 
-	TraceEvent("ResolverInit", resolver.id()).detail("RecoveryCount", initReq.recoveryCount);
+	TraceEvent("ResolverInit", resolver.id())
+	    .detail("RecoveryCount", initReq.recoveryCount)
+	    .detail("EncryptMode", initReq.encryptMode.toString());
 
 	// Wait until we can load the "real" logsystem, since we don't support switching them currently
 	while (!(initReq.masterLifetime.isEqual(db->get().masterLifetime) &&
@@ -749,7 +751,6 @@ ACTOR Future<Void> resolver(ResolverInterface resolver,
                             InitializeResolverRequest initReq,
                             Reference<AsyncVar<ServerDBInfo> const> db) {
 	try {
-		TraceEvent("ResolverEncryptionAtRestMode").detail("Mode", initReq.encryptMode.toString());
 		state Future<Void> core = resolverCore(resolver, initReq, db);
 		loop choose {
 			when(wait(core)) {


### PR DESCRIPTION
Blob worker encryption is no longer dependent on the `BG_METADATA_SOURCE` knob

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
