### PR TITLE
version vector fixes for tlog unicast (draft)

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -35,8 +35,8 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( VERSIONS_PER_SECOND,                                   1e6 );
 	init( MAX_VERSIONS_IN_FLIGHT,                100 * VERSIONS_PER_SECOND );
 	init( MAX_VERSIONS_IN_FLIGHT_FORCED,         6e5 * VERSIONS_PER_SECOND ); //one week of versions
-	init( ENABLE_VERSION_VECTOR_TLOG_UNICAST,                  false ); if (randomize && BUGGIFY) ENABLE_VERSION_VECTOR_TLOG_UNICAST = true;
-	init( ENABLE_VERSION_VECTOR,                               false ); if (ENABLE_VERSION_VECTOR_TLOG_UNICAST == true) ENABLE_VERSION_VECTOR = true;
+	init( ENABLE_VERSION_VECTOR_TLOG_UNICAST,                  true ); if (randomize && BUGGIFY) ENABLE_VERSION_VECTOR_TLOG_UNICAST = true;
+	init( ENABLE_VERSION_VECTOR,                               true ); if (ENABLE_VERSION_VECTOR_TLOG_UNICAST == true) ENABLE_VERSION_VECTOR = true;
 
 	bool buggifyShortReadWindow = randomize && BUGGIFY && !ENABLE_VERSION_VECTOR;
 	init( MAX_READ_TRANSACTION_LIFE_VERSIONS,      5 * VERSIONS_PER_SECOND ); if (randomize && BUGGIFY) MAX_READ_TRANSACTION_LIFE_VERSIONS = VERSIONS_PER_SECOND; else if (buggifyShortReadWindow) MAX_READ_TRANSACTION_LIFE_VERSIONS = std::max<int>(1, 0.1 * VERSIONS_PER_SECOND); else if( randomize && BUGGIFY ) MAX_READ_TRANSACTION_LIFE_VERSIONS = 10 * VERSIONS_PER_SECOND;

--- a/fdbserver/ApplyMetadataMutation.cpp
+++ b/fdbserver/ApplyMetadataMutation.cpp
@@ -84,12 +84,12 @@ public:
 
 	ApplyMetadataMutationsImpl(const SpanID& spanContext_,
 	                           ResolverData& resolverData_,
-	                           const VectorRef<MutationRef>& mutations_)
+	                           const VectorRef<MutationRef>& mutations_, Version v=invalidVersion)
 	  : spanContext(spanContext_), dbgid(resolverData_.dbgid), arena(resolverData_.arena), mutations(mutations_),
 	    txnStateStore(resolverData_.txnStateStore), toCommit(resolverData_.toCommit),
 	    confChange(resolverData_.confChanges), logSystem(resolverData_.logSystem), popVersion(resolverData_.popVersion),
 	    keyInfo(resolverData_.keyInfo), storageCache(resolverData_.storageCache),
-	    initialCommit(resolverData_.initialCommit), forResolver(true) {}
+	    initialCommit(resolverData_.initialCommit), forResolver(true), version(v) {}
 
 private:
 	// The following variables are incoming parameters
@@ -1245,6 +1245,12 @@ void applyMetadataMutations(SpanID const& spanContext,
                             ResolverData& resolverData,
                             const VectorRef<MutationRef>& mutations) {
 	ApplyMetadataMutationsImpl(spanContext, resolverData, mutations).apply();
+}
+
+void applyMetadataMutations(SpanID const& spanContext,
+                            ResolverData& resolverData,
+                            const VectorRef<MutationRef>& mutations, Version v) {
+	ApplyMetadataMutationsImpl(spanContext, resolverData, mutations, v).apply();
 }
 
 void applyMetadataMutations(SpanID const& spanContext,

--- a/fdbserver/ApplyMetadataMutation.cpp
+++ b/fdbserver/ApplyMetadataMutation.cpp
@@ -84,7 +84,8 @@ public:
 
 	ApplyMetadataMutationsImpl(const SpanID& spanContext_,
 	                           ResolverData& resolverData_,
-	                           const VectorRef<MutationRef>& mutations_, Version v=invalidVersion)
+	                           const VectorRef<MutationRef>& mutations_,
+	                           Version v = invalidVersion)
 	  : spanContext(spanContext_), dbgid(resolverData_.dbgid), arena(resolverData_.arena), mutations(mutations_),
 	    txnStateStore(resolverData_.txnStateStore), toCommit(resolverData_.toCommit),
 	    confChange(resolverData_.confChanges), logSystem(resolverData_.logSystem), popVersion(resolverData_.popVersion),
@@ -1249,7 +1250,8 @@ void applyMetadataMutations(SpanID const& spanContext,
 
 void applyMetadataMutations(SpanID const& spanContext,
                             ResolverData& resolverData,
-                            const VectorRef<MutationRef>& mutations, Version v) {
+                            const VectorRef<MutationRef>& mutations,
+                            Version v) {
 	ApplyMetadataMutationsImpl(spanContext, resolverData, mutations, v).apply();
 }
 

--- a/fdbserver/ApplyMetadataMutation.h
+++ b/fdbserver/ApplyMetadataMutation.h
@@ -104,7 +104,8 @@ void applyMetadataMutations(SpanID const& spanContext,
                             IKeyValueStore* txnStateStore);
 void applyMetadataMutations(SpanID const& spanContext,
                             ResolverData& resolverData,
-                            const VectorRef<MutationRef>& mutations, Version v);
+                            const VectorRef<MutationRef>& mutations,
+                            Version v);
 inline bool isSystemKey(KeyRef key) {
 	return key.size() && key[0] == systemKeys.begin[0];
 }

--- a/fdbserver/ApplyMetadataMutation.h
+++ b/fdbserver/ApplyMetadataMutation.h
@@ -102,7 +102,9 @@ void applyMetadataMutations(SpanID const& spanContext,
                             Arena& arena,
                             const VectorRef<MutationRef>& mutations,
                             IKeyValueStore* txnStateStore);
-
+void applyMetadataMutations(SpanID const& spanContext,
+                            ResolverData& resolverData,
+                            const VectorRef<MutationRef>& mutations, Version v);
 inline bool isSystemKey(KeyRef key) {
 	return key.size() && key[0] == systemKeys.begin[0];
 }

--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -854,7 +854,8 @@ ACTOR Future<Void> getResolution(CommitBatchContext* self) {
 	return Void();
 }
 
-void assertResolutionStateMutationsSizeConsistent(CommitBatchContext* self, const std::vector<ResolveTransactionBatchReply>& resolution) {
+void assertResolutionStateMutationsSizeConsistent(CommitBatchContext* self,
+                                                  const std::vector<ResolveTransactionBatchReply>& resolution) {
 	for (int r = 1; r < resolution.size(); r++) {
 		ASSERT(resolution[r].stateMutations.size() == resolution[0].stateMutations.size());
 		if (SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST) {
@@ -1271,7 +1272,7 @@ ACTOR Future<Void> postResolution(CommitBatchContext* self) {
 		g_traceBatch.addEvent(
 		    "CommitDebug", debugID.get().first(), "CommitProxyServer.commitBatch.ApplyMetadaToCommittedTxn");
 	}
-				self->preliminaryCount = self->toCommit.getMutationCount();
+	self->preliminaryCount = self->toCommit.getMutationCount();
 	// Second pass
 	wait(assignMutationsToStorageServers(self));
 
@@ -1393,7 +1394,9 @@ ACTOR Future<Void> postResolution(CommitBatchContext* self) {
 	                                                          self->debugID,
 	                                                          tpcvMap);
 
-	TraceEvent(SevWarn,"MutationCount4",pProxyCommitData->dbgid).detail("O",self->preliminaryCount).detail("N",self->toCommit.getMutationCount());
+	TraceEvent(SevWarn, "MutationCount4", pProxyCommitData->dbgid)
+	    .detail("O", self->preliminaryCount)
+	    .detail("N", self->toCommit.getMutationCount());
 	float ratio = self->toCommit.getEmptyMessageRatio();
 	pProxyCommitData->stats.commitBatchingEmptyMessageRatio.addMeasurement(ratio);
 

--- a/fdbserver/LogSystem.cpp
+++ b/fdbserver/LogSystem.cpp
@@ -278,6 +278,10 @@ LogPushData::LogPushData(Reference<ILogSystem> logSystem, int tlogCount) : logSy
 	messagesWritten = std::vector<bool>(tlogCount, false);
 }
 
+void LogPushData::addThisTxsTag(int tagId) {
+	next_message_tags.push_back(Tag(tagLocalityTxs,tagId));
+}
+
 void LogPushData::addTxsTag() {
 	if (logSystem->getTLogVersion() >= TLogVersion::V4) {
 		next_message_tags.push_back(logSystem->getRandomTxsTag());
@@ -335,6 +339,10 @@ void LogPushData::recordEmptyMessage(int loc, const Standalone<StringRef>& value
 			messagesWritten[loc] = true;
 		}
 	}
+}
+
+bool LogPushData::getMessageWrittenForLoc(int loc) {
+	return messagesWritten[loc];
 }
 
 float LogPushData::getEmptyMessageRatio() const {

--- a/fdbserver/LogSystem.h
+++ b/fdbserver/LogSystem.h
@@ -745,6 +745,8 @@ struct LogPushData : NonCopyable {
 
 	void addTxsTag();
 
+	void addThisTxsTag(int id);
+
 	// addTag() adds a tag for the *next* message to be added
 	void addTag(Tag tag) { next_message_tags.push_back(tag); }
 
@@ -799,6 +801,7 @@ struct LogPushData : NonCopyable {
 	// Records if a tlog (specified by "loc") will receive an empty version batch message.
 	// "value" is the message returned by getMessages() call.
 	void recordEmptyMessage(int loc, const Standalone<StringRef>& value);
+	bool getMessageWrittenForLoc(int loc);
 
 	// Returns the ratio of empty messages in this version batch.
 	// MUST be called after getMessages() and recordEmptyMessage().

--- a/fdbserver/Resolver.actor.cpp
+++ b/fdbserver/Resolver.actor.cpp
@@ -418,7 +418,7 @@ ACTOR Future<Void> resolveBatch(Reference<Resolver> self, ResolveTransactionBatc
 				reply.tpcvMap.clear();
 			} else {
 				std::set<uint16_t> writtenTLogs;
-				if (shardChanged || reply.privateMutationCount) {
+				if (shardChanged || reply.privateMutationCount > 1) {
 					for (int i = 0; i < self->numLogs; i++) {
 						writtenTLogs.insert(i);
 					}

--- a/fdbserver/Resolver.actor.cpp
+++ b/fdbserver/Resolver.actor.cpp
@@ -348,7 +348,7 @@ ACTOR Future<Void> resolveBatch(Reference<Resolver> self, ResolveTransactionBatc
 				SpanID spanContext =
 				    req.transactions[t].spanContext.present() ? req.transactions[t].spanContext.get() : SpanID();
 
-				applyMetadataMutations(spanContext, *resolverData, req.transactions[t].mutations);
+				applyMetadataMutations(spanContext, *resolverData, req.transactions[t].mutations, req.version);
 			}
 			TEST(self->forceRecovery); // Resolver detects forced recovery
 		}
@@ -432,6 +432,8 @@ ACTOR Future<Void> resolveBatch(Reference<Resolver> self, ResolveTransactionBatc
 					reply.tpcvMap[tLog] = self->tpcvVector[tLog];
 					self->tpcvVector[tLog] = req.version;
 				}
+				TraceEvent("VVTEMPDEBUG", self->dbgid).detail("C",reply.tpcvMap.size()).detail("X",reply.privateMutationCount).detail("W",toCommit->isShardChanged()).detail("R",req.version)
+				.detail("S",shardChanged).detail("I",stateMutations).detail("T",req.txnStateTransactions.size());
 			}
 		}
 		self->version.set(req.version);

--- a/fdbserver/Resolver.actor.cpp
+++ b/fdbserver/Resolver.actor.cpp
@@ -432,8 +432,14 @@ ACTOR Future<Void> resolveBatch(Reference<Resolver> self, ResolveTransactionBatc
 					reply.tpcvMap[tLog] = self->tpcvVector[tLog];
 					self->tpcvVector[tLog] = req.version;
 				}
-				TraceEvent("VVTEMPDEBUG", self->dbgid).detail("C",reply.tpcvMap.size()).detail("X",reply.privateMutationCount).detail("W",toCommit->isShardChanged()).detail("R",req.version)
-				.detail("S",shardChanged).detail("I",stateMutations).detail("T",req.txnStateTransactions.size());
+				TraceEvent("VVTEMPDEBUG", self->dbgid)
+				    .detail("C", reply.tpcvMap.size())
+				    .detail("X", reply.privateMutationCount)
+				    .detail("W", toCommit->isShardChanged())
+				    .detail("R", req.version)
+				    .detail("S", shardChanged)
+				    .detail("I", stateMutations)
+				    .detail("T", req.txnStateTransactions.size());
 			}
 		}
 		self->version.set(req.version);

--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -555,6 +555,9 @@ Future<Version> TagPartitionedLogSystem::push(Version prevVersion,
 					if (tpcvMap.get().find(location) != tpcvMap.get().end()) {
 						prevVersion = tpcvMap.get()[location];
 					} else {
+						Standalone<StringRef> msg = data.getMessages(location);
+						data.recordEmptyMessage(location, msg);
+						ASSERT(!data.getMessageWrittenForLoc(location));
 						location++;
 						continue;
 					}
@@ -580,7 +583,7 @@ Future<Version> TagPartitionedLogSystem::push(Version prevVersion,
 				tLogCommitResults.push_back(commitSuccess);
 				location++;
 			}
-			quorumResults.push_back(quorum(tLogCommitResults, tLogCommitResults.size() - it->tLogWriteAntiQuorum));
+			quorumResults.push_back(quorum(tLogCommitResults, tLogCommitResults.size() /*- it->tLogWriteAntiQuorum*/));
 			logGroupLocal++;
 		}
 	}


### PR DESCRIPTION
version vector fixes for tlog unicast, send mutations to subset of tlogs

1. send same mutations to all resolvers
2. handle txn tags
3. wait for all tlogs to commit
4. debugging logs

this draft PR is for communicating work in progress.