### PR TITLE
Change PTreeImpl::insert to overwrite existing entries

### DIFF
--- a/fdbclient/include/fdbclient/VersionedMap.h
+++ b/fdbclient/include/fdbclient/VersionedMap.h
@@ -285,12 +285,17 @@ void insert(Reference<PTree<T>>& p, Version at, const T& x) {
 	if (!p) {
 		p = makeReference<PTree<T>>(x, at);
 	} else {
-		bool direction = !(x < p->data);
-		Reference<PTree<T>> child = p->child(direction, at);
-		insert(child, at, x);
-		p = update(p, direction, child, at);
-		if (p->child(direction, at)->priority > p->priority)
-			rotate(p, at, !direction);
+		int c = ::compare(x, p->data);
+		if (c == 0) {
+			p = makeReference<PTree<T>>(p->priority, x, p->left(at), p->right(at), at);
+		} else {
+			bool direction = !(c < 0);
+			Reference<PTree<T>> child = p->child(direction, at);
+			insert(child, at, x);
+			p = update(p, direction, child, at);
+			if (p->child(direction, at)->priority > p->priority)
+				rotate(p, at, !direction);
+		}
 	}
 }
 
@@ -732,10 +737,6 @@ public:
 	// insert() and erase() invalidate atLatest() and all iterators into it
 	void insert(const K& k, const T& t) { insert(k, t, latestVersion); }
 	void insert(const K& k, const T& t, Version insertAt) {
-		if (PTreeImpl::contains(roots.back().second, latestVersion, k))
-			PTreeImpl::remove(roots.back().second,
-			                  latestVersion,
-			                  k); // FIXME: Make PTreeImpl::insert do this automatically  (see also WriteMap.h FIXME)
 		PTreeImpl::insert(
 		    roots.back().second, latestVersion, MapPair<K, std::pair<T, Version>>(k, std::make_pair(t, insertAt)));
 	}

--- a/fdbclient/include/fdbclient/VersionedMap.h
+++ b/fdbclient/include/fdbclient/VersionedMap.h
@@ -289,7 +289,7 @@ void insert(Reference<PTree<T>>& p, Version at, const T& x) {
 		if (c == 0) {
 			p = makeReference<PTree<T>>(p->priority, x, p->left(at), p->right(at), at);
 		} else {
-			bool direction = !(c < 0);
+			const bool direction = !(c < 0);
 			Reference<PTree<T>> child = p->child(direction, at);
 			insert(child, at, x);
 			p = update(p, direction, child, at);

--- a/fdbclient/include/fdbclient/WriteMap.h
+++ b/fdbclient/include/fdbclient/WriteMap.h
@@ -90,6 +90,8 @@ struct WriteMapEntry {
 
 	int compare(ExtStringRef const& r) const { return -r.compare(key); }
 
+	int compare(WriteMapEntry const& r) const { return key.compare(r.key); }
+
 	std::string toString() const { return printable(key); }
 };
 


### PR DESCRIPTION
Maintaining partial persistence of course.

We can theoretically also avoid creating a new node if the insert version of the node comparing equal to `x` is the latestVersion. There isn't a generic way to tell from the ptree though since insertAt is a concept that only exists within VersionedMap. Either way, avoiding the `contains` call and the tree rotations is already a big improvement.

The old node should only be reachable from old roots, and so it should get cleaned up as part of forgetVersions in the storage server.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
