### PR TITLE
Decrease the number of HCA test rounds to decrease the test time

### DIFF
--- a/fdbserver/workloads/HighContentionPrefixAllocatorWorkload.actor.cpp
+++ b/fdbserver/workloads/HighContentionPrefixAllocatorWorkload.actor.cpp
@@ -38,7 +38,7 @@ struct HighContentionPrefixAllocatorWorkload : TestWorkload {
 
 	HighContentionPrefixAllocatorWorkload(WorkloadContext const& wcx)
 	  : TestWorkload(wcx), allocatorSubspace("test_subspace"_sr), allocator(allocatorSubspace) {
-		numRounds = getOption(options, "numRounds"_sr, 500);
+		numRounds = getOption(options, "numRounds"_sr, 100);
 		maxTransactionsPerRound = getOption(options, "maxTransactionsPerRound"_sr, 20);
 		maxAllocationsPerTransaction = getOption(options, "maxAllocationsPerTransaction"_sr, 20);
 	}


### PR DESCRIPTION
The high contention allocator test sometimes times out in CI. I can't easily reproduce the 30 minute runtimes, though I did observe that the test does often take many minutes. In an attempt to resolve the CI issues, I'm decreasing the length of the main portion of the test by a factor of 5.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
