### PR TITLE
Fix a consistency scan infinite looping without progress

### DIFF
--- a/fdbserver/ConsistencyScan.actor.cpp
+++ b/fdbserver/ConsistencyScan.actor.cpp
@@ -728,7 +728,7 @@ ACTOR Future<bool> checkDataConsistency(Database cx,
 							    .detail("ShardEnd", printable(range.end))
 							    .detail("Address", storageServerInterfaces[j].address())
 							    .detail("UID", storageServerInterfaces[j].id())
-							    .detail("Quiesed", performQuiescentChecks)
+							    .detail("Quiesced", performQuiescentChecks)
 							    .detail("GetKeyValuesToken",
 							            storageServerInterfaces[j].getKeyValues.getEndpoint().token)
 							    .detail("IsTSS", storageServerInterfaces[j].isTss() ? "True" : "False");

--- a/fdbserver/ConsistencyScan.actor.cpp
+++ b/fdbserver/ConsistencyScan.actor.cpp
@@ -728,10 +728,15 @@ ACTOR Future<bool> checkDataConsistency(Database cx,
 							    .detail("ShardEnd", printable(range.end))
 							    .detail("Address", storageServerInterfaces[j].address())
 							    .detail("UID", storageServerInterfaces[j].id())
+							    .detail("Quiesed", performQuiescentChecks)
 							    .detail("GetKeyValuesToken",
 							            storageServerInterfaces[j].getKeyValues.getEndpoint().token)
 							    .detail("IsTSS", storageServerInterfaces[j].isTss() ? "True" : "False");
 
+							if (e.code() == error_code_request_maybe_delivered) {
+								// SS in the team may be removed and we get this error.
+								return false;
+							}
 							// All shards should be available in quiscence
 							if (performQuiescentChecks && !storageServerInterfaces[j].isTss()) {
 								testFailure("Storage server unavailable", performQuiescentChecks, failureIsError);


### PR DESCRIPTION
If a storage server was removed, the consistency scan may be looping forever, because "request_maybe_delivered" was not handled and the team's SS interfaces are not updated.

20230114-175225-jzhou-a22c9e64753db47c

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
