### PR TITLE
mako: improve argument validation

### DIFF
--- a/bindings/c/test/mako/mako.cpp
+++ b/bindings/c/test/mako/mako.cpp
@@ -1573,8 +1573,8 @@ int Arguments::validate() {
 		logr.error("--num_databases ({}) must be >= number of clusters({})", num_databases, num_fdb_clusters);
 		return -1;
 	}
-	// In sync mode, threads, and in async mode, async workers are assigned to databases. Having more databases than
-	// threads or async workers leads to unused databases.
+	// In sync mode, threads, and in async mode, async states / workflows are assigned to databases. Having more
+	// databases than threads or async states / workflows leads to unused databases.
 	if (async_xacts == 0 && num_threads < num_databases) {
 		logr.error("--threads ({}) must be >= number of databases ({}) in sync mode", num_threads, num_databases);
 		return -1;
@@ -1583,7 +1583,7 @@ int Arguments::validate() {
 		logr.error("--async_xacts ({}) must be >= number of databases ({}) in async mode", async_xacts, num_databases);
 		return -1;
 	}
-	// Having more threads than async workers in the async mode does lead to unused threads.
+	// Having more threads than async workflows in the async mode does lead to unused threads.
 	if (async_xacts > 0 && num_threads > async_xacts) {
 		logr.error("--threads ({}) must be <= --async_xacts", num_threads);
 		return -1;


### PR DESCRIPTION
- To my understanding of the code, the `num_threads < num_databases` check is only useful in the sync mode (and I uncommented this check when testing the scalability of the FDB client with the async mode). I modified this check and added a similar check for the async mode. 
- I furthermore added a check that `--threads <= --async_xacts`. This is, in my opinion, useful, and is helpful for ensuring the the correctness of another PR that I am currently working on.  

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
