### PR TITLE
Change Attrition to be added only once

### DIFF
--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -406,6 +406,11 @@ void CompoundWorkload::addFailureInjection(WorkloadRequest& work) {
 		while (shouldInjectFailure(random, work, workload)) {
 			workload->initFailureInjectionMode(random);
 			failureInjection.push_back(workload);
+			TraceEvent("AddFailureInjectionWorkload")
+			    .detail("Name", workload->description())
+			    .detail("ClientID", work.clientId)
+			    .detail("ClientCount", clientCount)
+			    .detail("Title", work.title);
 			workload = factory->create(*this);
 		}
 	}

--- a/fdbserver/workloads/MachineAttrition.actor.cpp
+++ b/fdbserver/workloads/MachineAttrition.actor.cpp
@@ -125,7 +125,7 @@ struct MachineAttritionWorkload : FailureInjectionWorkload {
 			// Remove this as soon as we track extra databases properly
 			return false;
 		}
-		return work.useDatabase && random.random01() < 1.0 / (2.0 + alreadyAdded);
+		return work.useDatabase && alreadyAdded < 1;
 	}
 
 	void initializeForInjection(DeterministicRandom& random) {
@@ -363,7 +363,7 @@ struct MachineAttritionWorkload : FailureInjectionWorkload {
 				auto target = self->targetIds.front();
 
 				auto kt = ISimulator::KillInstantly;
-				TraceEvent("Assassination").detail("TargetDataHall", target).detail("KillType", kt);
+				TraceEvent("AssassinationDataHall").detail("TargetDataHall", target).detail("KillType", kt);
 
 				g_simulator->killDataHall(target, kt);
 			} else if (self->killAll) {


### PR DESCRIPTION
Otherwise, the workload can be added multiple times for a clientID, causing excessive killing of machines that makes the database unavailable.

E.g., in a simulation run, there are 3 Attrition workloads being added to each client, which is not needed.
```
81.747888 AddFailureInjectionWorkload ID=0000000000000000 Name=Attrition ClientID=3 ClientCount=4 Title=MutationLogReaderCorrectness TS
81.747888 AddFailureInjectionWorkload ID=0000000000000000 Name=Attrition ClientID=3 ClientCount=4 Title=MutationLogReaderCorrectness TS
81.747888 AddFailureInjectionWorkload ID=0000000000000000 Name=Attrition ClientID=3 ClientCount=4 Title=MutationLogReaderCorrectness TS
81.748007 AddFailureInjectionWorkload ID=0000000000000000 Name=Attrition ClientID=0 ClientCount=4 Title=MutationLogReaderCorrectness TS
81.748007 AddFailureInjectionWorkload ID=0000000000000000 Name=Attrition ClientID=0 ClientCount=4 Title=MutationLogReaderCorrectness TS
81.748007 AddFailureInjectionWorkload ID=0000000000000000 Name=Attrition ClientID=0 ClientCount=4 Title=MutationLogReaderCorrectness TS
81.748158 AddFailureInjectionWorkload ID=0000000000000000 Name=Attrition ClientID=2 ClientCount=4 Title=MutationLogReaderCorrectness TS
81.748158 AddFailureInjectionWorkload ID=0000000000000000 Name=Attrition ClientID=2 ClientCount=4 Title=MutationLogReaderCorrectness TS
81.748158 AddFailureInjectionWorkload ID=0000000000000000 Name=Attrition ClientID=2 ClientCount=4 Title=MutationLogReaderCorrectness TS
81.749199 AddFailureInjectionWorkload ID=0000000000000000 Name=Attrition ClientID=1 ClientCount=4 Title=MutationLogReaderCorrectness TS
81.749199 AddFailureInjectionWorkload ID=0000000000000000 Name=Attrition ClientID=1 ClientCount=4 Title=MutationLogReaderCorrectness TS
81.749199 AddFailureInjectionWorkload ID=0000000000000000 Name=Attrition ClientID=1 ClientCount=4 Title=MutationLogReaderCorrectness TS
```


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
