### PR TITLE
Mako: Add CPU Usage statistics

### DIFF
--- a/bindings/c/test/mako/async.hpp
+++ b/bindings/c/test/mako/async.hpp
@@ -41,7 +41,7 @@ struct ResumableStateForPopulate : std::enable_shared_from_this<ResumableStateFo
 	fdb::Transaction tx;
 	boost::asio::io_context& io_context;
 	Arguments const& args;
-	WorkerStatistics& stats;
+	WorkflowStatistics& stats;
 	std::atomic<int>& stopcount;
 	int key_begin;
 	int key_end;
@@ -57,7 +57,7 @@ struct ResumableStateForPopulate : std::enable_shared_from_this<ResumableStateFo
 	                          fdb::Transaction tx,
 	                          boost::asio::io_context& io_context,
 	                          Arguments const& args,
-	                          WorkerStatistics& stats,
+	                          WorkflowStatistics& stats,
 	                          std::atomic<int>& stopcount,
 	                          int key_begin,
 	                          int key_end)
@@ -79,7 +79,7 @@ struct ResumableStateForRunWorkload : std::enable_shared_from_this<ResumableStat
 	fdb::Transaction tx;
 	boost::asio::io_context& io_context;
 	Arguments const& args;
-	WorkerStatistics& stats;
+	WorkflowStatistics& stats;
 	int64_t total_xacts;
 	std::atomic<int>& stopcount;
 	std::atomic<int> const& signal;
@@ -99,7 +99,7 @@ struct ResumableStateForRunWorkload : std::enable_shared_from_this<ResumableStat
 	                             fdb::Transaction tx,
 	                             boost::asio::io_context& io_context,
 	                             Arguments const& args,
-	                             WorkerStatistics& stats,
+	                             WorkflowStatistics& stats,
 	                             std::atomic<int>& stopcount,
 	                             std::atomic<int> const& signal,
 	                             int max_iters,

--- a/bindings/c/test/mako/async.hpp
+++ b/bindings/c/test/mako/async.hpp
@@ -41,7 +41,7 @@ struct ResumableStateForPopulate : std::enable_shared_from_this<ResumableStateFo
 	fdb::Transaction tx;
 	boost::asio::io_context& io_context;
 	Arguments const& args;
-	ThreadStatistics& stats;
+	WorkerStatistics& stats;
 	std::atomic<int>& stopcount;
 	int key_begin;
 	int key_end;
@@ -57,7 +57,7 @@ struct ResumableStateForPopulate : std::enable_shared_from_this<ResumableStateFo
 	                          fdb::Transaction tx,
 	                          boost::asio::io_context& io_context,
 	                          Arguments const& args,
-	                          ThreadStatistics& stats,
+	                          WorkerStatistics& stats,
 	                          std::atomic<int>& stopcount,
 	                          int key_begin,
 	                          int key_end)
@@ -79,7 +79,7 @@ struct ResumableStateForRunWorkload : std::enable_shared_from_this<ResumableStat
 	fdb::Transaction tx;
 	boost::asio::io_context& io_context;
 	Arguments const& args;
-	ThreadStatistics& stats;
+	WorkerStatistics& stats;
 	int64_t total_xacts;
 	std::atomic<int>& stopcount;
 	std::atomic<int> const& signal;
@@ -99,7 +99,7 @@ struct ResumableStateForRunWorkload : std::enable_shared_from_this<ResumableStat
 	                             fdb::Transaction tx,
 	                             boost::asio::io_context& io_context,
 	                             Arguments const& args,
-	                             ThreadStatistics& stats,
+	                             WorkerStatistics& stats,
 	                             std::atomic<int>& stopcount,
 	                             std::atomic<int> const& signal,
 	                             int max_iters,

--- a/bindings/c/test/mako/mako.cpp
+++ b/bindings/c/test/mako/mako.cpp
@@ -20,7 +20,6 @@
 
 #include <array>
 #include <cassert>
-#include <chrono>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
@@ -69,7 +68,6 @@
 #include "time.hpp"
 #include "rapidjson/document.h"
 #include "rapidjson/error/en.h"
-#include "flow/Platform.h"
 
 namespace mako {
 

--- a/bindings/c/test/mako/mako.cpp
+++ b/bindings/c/test/mako/mako.cpp
@@ -1573,8 +1573,16 @@ int Arguments::validate() {
 		logr.error("--num_databases ({}) must be >= number of clusters({})", num_databases, num_fdb_clusters);
 		return -1;
 	}
-	if (num_threads < num_databases) {
-		logr.error("--threads ({}) must be >= number of databases ({})", num_threads, num_databases);
+	if (async_xacts == 0 && num_threads < num_databases) {
+		logr.error("--threads ({}) must be >= number of databases ({}) in sync mode", num_threads, num_databases);
+		return -1;
+	}
+	if (async_xacts > 0 && async_xacts < num_databases) {
+		logr.error("--async_xacts ({}) must be >= number of databases ({}) in async mode", async_xacts, num_databases);
+		return -1;
+	}
+	if (async_xacts > 0 && num_threads > async_xacts) {
+		logr.error("--threads ({}) must be <= --async_xacts", num_threads);
 		return -1;
 	}
 	if (key_length < 4 /* "mako" */ + row_digits) {

--- a/bindings/c/test/mako/stats.hpp
+++ b/bindings/c/test/mako/stats.hpp
@@ -22,7 +22,6 @@
 #define MAKO_STATS_HPP
 
 #include <array>
-#include <chrono>
 #include <cstdint>
 #include <cstring>
 #include <fstream>

--- a/bindings/c/test/mako/stats.hpp
+++ b/bindings/c/test/mako/stats.hpp
@@ -88,7 +88,7 @@ public:
 	}
 };
 
-class alignas(64) WorkerStatistics {
+class alignas(64) WorkflowStatistics {
 	uint64_t conflicts{ 0 };
 	uint64_t total_errors{ 0 };
 	uint64_t total_timeouts{ 0 };
@@ -100,7 +100,7 @@ class alignas(64) WorkerStatistics {
 	std::vector<DDSketchMako> sketches;
 
 public:
-	WorkerStatistics() noexcept {
+	WorkflowStatistics() noexcept {
 		std::fill(ops.begin(), ops.end(), 0);
 		std::fill(errors.begin(), errors.end(), 0);
 		std::fill(timeouts.begin(), timeouts.end(), 0);
@@ -109,8 +109,8 @@ public:
 		sketches.resize(MAX_OP);
 	}
 
-	WorkerStatistics(const WorkerStatistics& other) = default;
-	WorkerStatistics& operator=(const WorkerStatistics& other) = default;
+	WorkflowStatistics(const WorkflowStatistics& other) = default;
+	WorkflowStatistics& operator=(const WorkflowStatistics& other) = default;
 
 	uint64_t getConflictCount() const noexcept { return conflicts; }
 
@@ -137,7 +137,7 @@ public:
 	uint64_t mean(int op) const noexcept { return sketches[op].mean(); }
 
 	// with 'this' as final aggregation, factor in 'other'
-	void combine(const WorkerStatistics& other) {
+	void combine(const WorkflowStatistics& other) {
 		conflicts += other.conflicts;
 		for (auto op = 0; op < MAX_OP; op++) {
 			sketches[op].mergeWith(other.sketches[op]);
@@ -183,11 +183,11 @@ public:
 
 	void updateLatencies(const std::vector<DDSketchMako> other_sketches) { sketches = other_sketches; }
 
-	friend std::ofstream& operator<<(std::ofstream& os, WorkerStatistics& stats);
-	friend std::ifstream& operator>>(std::ifstream& is, WorkerStatistics& stats);
+	friend std::ofstream& operator<<(std::ofstream& os, WorkflowStatistics& stats);
+	friend std::ifstream& operator>>(std::ifstream& is, WorkflowStatistics& stats);
 };
 
-inline std::ofstream& operator<<(std::ofstream& os, WorkerStatistics& stats) {
+inline std::ofstream& operator<<(std::ofstream& os, WorkflowStatistics& stats) {
 	rapidjson::StringBuffer ss;
 	rapidjson::Writer<rapidjson::StringBuffer> writer(ss);
 	writer.StartObject();
@@ -254,7 +254,7 @@ inline void populateArray(std::array<uint64_t, MAX_OP>& arr,
 	}
 }
 
-inline std::ifstream& operator>>(std::ifstream& is, WorkerStatistics& stats) {
+inline std::ifstream& operator>>(std::ifstream& is, WorkflowStatistics& stats) {
 	std::stringstream buffer;
 	buffer << is.rdbuf();
 	rapidjson::Document doc;


### PR DESCRIPTION
With this PR, different CPU usage statistics are tracked in mako. This change required some small refactoring of the statistics accumulator classes. In particular, there are now three different classes for this purpose: one class to track statistics on the worker level, another class to track statistics on the thread level, and a third class to track statistics on the process level.  

Testing was done by running mako and comparing the final results with what I observed in `top` and `top -H`. 

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
