### PR TITLE
Set VLA minimum length to 1

### DIFF
--- a/fdbclient/BlobGranuleFiles.cpp
+++ b/fdbclient/BlobGranuleFiles.cpp
@@ -2518,7 +2518,7 @@ void checkGranuleRead(const KeyValueGen& kvGen,
 		}
 		deltaIdx++;
 	}
-	StringRef deltaPtrs[deltaPtrsVector.size()];
+	StringRef deltaPtrs[deltaPtrsVector.size() + 1];
 	for (int i = 0; i < deltaPtrsVector.size(); i++) {
 		deltaPtrs[i] = deltaPtrsVector[i];
 	}


### PR DESCRIPTION
Fixes issue https://github.com/apple/foundationdb/issues/9206 where code hits UBSAN error from case when `deltaPtrs` length == 0.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
