### PR TITLE
Add parameter for test_causal_read_risky database option

### DIFF
--- a/bindings/go/src/fdb/generated.go
+++ b/bindings/go/src/fdb/generated.go
@@ -422,9 +422,11 @@ func (o DatabaseOptions) SetUseConfigDatabase() error {
 	return o.setOpt(800, nil)
 }
 
-// An integer between 0 and 100 (default is 0) expressing the probability that a client will verify it can't read stale data whenever it detects a recovery.
-func (o DatabaseOptions) SetTestCausalReadRisky() error {
-	return o.setOpt(900, nil)
+// Enables verification of causal read risky by checking whether clients are able to read stale data when they detect a recovery, and logging an error if so.
+//
+// Parameter: integer between 0 and 100 expressing the probability a client will verify it can't read stale data
+func (o DatabaseOptions) SetTestCausalReadRisky(param int64) error {
+	return o.setOpt(900, int64ToBytes(param))
 }
 
 // The transaction, if not self-conflicting, may be committed a second time after commit succeeds, in the event of a fault

--- a/fdbclient/vexillographer/fdb.options
+++ b/fdbclient/vexillographer/fdb.options
@@ -216,7 +216,8 @@ description is not currently required but encouraged.
     <Option name="use_config_database" code="800"
             description="Use configuration database." />
     <Option name="test_causal_read_risky" code="900"
-            description="An integer between 0 and 100 (default is 0) expressing the probability that a client will verify it can't read stale data whenever it detects a recovery." />
+            paramType="Int" paramDescription="integer between 0 and 100 expressing the probability a client will verify it can't read stale data"
+            description="Enables verification of causal read risky by checking whether clients are able to read stale data when they detect a recovery, and logging an error if so." />
   </Scope>
   
   <Scope name="TransactionOption">


### PR DESCRIPTION
`test_causal_read_risky` expects an argument specifying the probability the client checks whether its read is stale. The database option specification should include this parameter so it gets included in the generated bindings.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
