### PR TITLE
Fix a memory issue in getKeyLocation functions

### DIFF
--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -3015,7 +3015,9 @@ Future<KeyRangeLocationInfo> getKeyLocation(Reference<TransactionState> trState,
 	                      trState->readOptions.present() ? trState->readOptions.get().debugID : Optional<UID>(),
 	                      trState->useProvisionalProxies,
 	                      isBackward,
-	                      trState->readVersionFuture.isReady() ? trState->readVersion() : latestVersion);
+	                      trState->readVersionFuture.isValid() && trState->readVersionFuture.isReady()
+	                          ? trState->readVersion()
+	                          : latestVersion);
 }
 
 ACTOR Future<std::vector<KeyRangeLocationInfo>> getKeyRangeLocations_internal(
@@ -3132,7 +3134,9 @@ Future<std::vector<KeyRangeLocationInfo>> getKeyRangeLocations(Reference<Transac
 	                            trState->spanContext,
 	                            trState->readOptions.present() ? trState->readOptions.get().debugID : Optional<UID>(),
 	                            trState->useProvisionalProxies,
-	                            trState->readVersionFuture.isReady() ? trState->readVersion() : latestVersion);
+	                            trState->readVersionFuture.isValid() && trState->readVersionFuture.isReady()
+	                                ? trState->readVersion()
+	                                : latestVersion);
 }
 
 ACTOR Future<Void> warmRange_impl(Reference<TransactionState> trState, KeyRange keys) {


### PR DESCRIPTION
The `getKeyLocation` functions were checking if the read version future was ready, but it was also possible for the future to not be set at all (e.g. in getRangeSplitPoints). If that were to happen, then an invalid memory access would result.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
