### PR TITLE
Lower ASAN memory usage

### DIFF
--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -499,6 +499,7 @@ public:
 		    .add("buggify", &buggify)
 		    .add("StderrSeverity", &stderrSeverity)
 		    .add("machineCount", &machineCount)
+		    .add("asanMachineCount", &asanMachineCount)
 		    .add("processesPerMachine", &processesPerMachine)
 		    .add("coordinators", &coordinators)
 		    .add("configDB", &configDBType)
@@ -1910,6 +1911,11 @@ void SimulationConfig::setRegions(const TestConfig& testConfig) {
 void SimulationConfig::setMachineCount(const TestConfig& testConfig) {
 	if (testConfig.machineCount.present()) {
 		machine_count = testConfig.machineCount.get();
+#ifdef ADDRESS_SANITIZER
+		if (testConfig.asanMachineCount.present()) {
+			machine_count = testConfig.asanMachineCount.get();
+		}
+#endif
 	} else if (generateFearless && testConfig.minimumReplication > 1) {
 		// low latency tests in fearless configurations need 4 machines per datacenter (3 for triple replication, 1 that
 		// is down during failures).

--- a/fdbserver/coroimpl/CoroFlow.actor.cpp
+++ b/fdbserver/coroimpl/CoroFlow.actor.cpp
@@ -57,8 +57,11 @@ struct Coroutine /*: IThreadlike*/ {
 	Coroutine() = default;
 	~Coroutine() { *alive = false; }
 
+	static constexpr auto kStackSize = 32 * (1 << 10);
+
 	void start() {
-		coro.reset(new coro_t::pull_type([this](coro_t::push_type& sink) { entry(sink); }));
+		coro.reset(new coro_t::pull_type(boost::coroutines2::fixedsize_stack(kStackSize),
+		                                 [this](coro_t::push_type& sink) { entry(sink); }));
 		switcher(this);
 	}
 

--- a/fdbserver/include/fdbserver/SimulatedCluster.h
+++ b/fdbserver/include/fdbserver/SimulatedCluster.h
@@ -37,6 +37,9 @@ public:
 	bool simpleConfig = false;
 	Optional<int> desiredTLogCount, commitProxyCount, grvProxyCount, resolverCount, storageEngineType, machineCount,
 	    coordinators;
+	// ASAN uses more memory, so adding too many machines can cause OOMs. Tests can set this if they need to lower
+	// machineCount specifically for ASAN. Only has an effect if `machineCount` is set and this is an ASAN build.
+	Optional<int> asanMachineCount;
 };
 
 DatabaseConfiguration generateNormalDatabaseConfiguration(const BasicTestConfig& testConfig);

--- a/flow/SystemMonitor.cpp
+++ b/flow/SystemMonitor.cpp
@@ -30,6 +30,10 @@
 #include <cxxabi.h>
 #endif
 
+#ifdef ADDRESS_SANITIZER
+#include <sanitizer/asan_interface.h>
+#endif
+
 SystemMonitorMachineState machineState;
 
 void initializeSystemMonitorMachineState(SystemMonitorMachineState machineState) {
@@ -460,6 +464,9 @@ Future<Void> startMemoryUsageMonitor(uint64_t memLimit) {
 	}
 	auto checkMemoryUsage = [=]() {
 		if (getResidentMemoryUsage() > memLimit) {
+#if defined(ADDRESS_SANITIZER) && defined(__linux__)
+			__sanitizer_print_memory_profile(/*top percent*/ 50, /*max contexts*/ 100);
+#endif
 			platform::outOfMemory();
 		}
 	};

--- a/flow/SystemMonitor.cpp
+++ b/flow/SystemMonitor.cpp
@@ -465,7 +465,7 @@ Future<Void> startMemoryUsageMonitor(uint64_t memLimit) {
 	auto checkMemoryUsage = [=]() {
 		if (getResidentMemoryUsage() > memLimit) {
 #if defined(ADDRESS_SANITIZER) && defined(__linux__)
-			__sanitizer_print_memory_profile(/*top percent*/ 50, /*max contexts*/ 100);
+			__sanitizer_print_memory_profile(/*top percent*/ 100, /*max contexts*/ 10);
 #endif
 			platform::outOfMemory();
 		}

--- a/tests/fast/DataLossRecovery.toml
+++ b/tests/fast/DataLossRecovery.toml
@@ -4,7 +4,7 @@ config = 'triple'
 storageEngineType = 0
 processesPerMachine = 2
 coordinators = 3
-machineCount = 45
+machineCount = 30
 allowDefaultTenant = false
 
 [[test]]

--- a/tests/fast/DataLossRecovery.toml
+++ b/tests/fast/DataLossRecovery.toml
@@ -4,7 +4,8 @@ config = 'triple'
 storageEngineType = 0
 processesPerMachine = 2
 coordinators = 3
-machineCount = 30
+machineCount = 45
+asanMachineCount = 20
 allowDefaultTenant = false
 
 [[test]]


### PR DESCRIPTION
Previously this test would routinely OOM by using more than 8GiB resident memory in the ASAN build

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
