### PR TITLE
fix fdbcli status error

### DIFF
--- a/fdbcli/StatusCommand.actor.cpp
+++ b/fdbcli/StatusCommand.actor.cpp
@@ -1127,12 +1127,14 @@ void printStatus(StatusObjectReader statusObj,
 					outputString += "\n  Number of Key Ranges   - " + format("%d", numKeyRanges);
 					if (statusObjCluster.has("blob_restore")) {
 						StatusObjectReader statusObjBlobRestore = statusObjCluster["blob_restore"];
-						std::string restoreStatus = statusObjBlobRestore["blob_full_restore_phase"].get_str();
-						if (statusObjBlobRestore.has("blob_full_restore_progress")) {
-							auto progress = statusObjBlobRestore["blob_full_restore_progress"].get_int();
-							restoreStatus += " " + format("%d%%", progress);
+						if (statusObjBlobRestore.has("blob_full_restore_phase")) {
+							std::string restoreStatus = statusObjBlobRestore["blob_full_restore_phase"].get_str();
+							if (statusObjBlobRestore.has("blob_full_restore_progress")) {
+								auto progress = statusObjBlobRestore["blob_full_restore_progress"].get_int();
+								restoreStatus += " " + format("%d%%", progress);
+							}
+							outputString += "\n  Full Restore           - " + restoreStatus;
 						}
-						outputString += "\n  Full Restore           - " + restoreStatus;
 					}
 				}
 			}


### PR DESCRIPTION
It's a fix for fdbcli "status details" error when blob_granules is enabled. The following is error message:

fdb> status details
ERROR: An unknown error occurred (4000)

The fix is to check if some field is included in status json first before accessing it. The error disappears after the fix. 

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
