### PR TITLE
Add version epoch to status json

### DIFF
--- a/documentation/sphinx/source/mr-status-json-schemas.rst.inc
+++ b/documentation/sphinx/source/mr-status-json-schemas.rst.inc
@@ -909,6 +909,10 @@
          "expired_age" : 0, // The age in seconds of expired_version.
          "oldest_id_version" : 0, // The version of the oldest idempotency id still stored in the database.
          "oldest_id_age" : 0 // The age in seconds of the oldest_id_version.
+      },
+      "version_epoch":{
+         "enabled": true,
+         "epoch": 0 // The version epoch, as an offset from the Unix epoch. This field will be excluded if enabled is false.
       }
    },
    "client":{

--- a/fdbclient/Schemas.cpp
+++ b/fdbclient/Schemas.cpp
@@ -981,6 +981,10 @@ const KeyRef JSONSchemas::statusSchema = R"statusSchema(
          "expired_age": 0,
          "oldest_id_version": 0,
          "oldest_id_age": 0
+      },
+      "version_epoch":{
+         "enabled": false,
+         "epoch": 0
       }
    },
    "client":{


### PR DESCRIPTION
Adds a new `version_epoch` object to `status json`, which includes the status of the feature, and the current epoch if it is enabled. If the version epoch is disabled, the `epoch` field will not be present.

```
{
    "client" : {
        ...
    },
    "cluster" : {
        ...
        "version_epoch" : {
            "enabled" : "true",
            "epoch" : "100000"
        },
        ...
    }
}
```

Replace this text with your description here...

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
