### PR TITLE
Fix mutation log s3 url for blob restore

### DIFF
--- a/fdbserver/BlobMigrator.actor.cpp
+++ b/fdbserver/BlobMigrator.actor.cpp
@@ -333,12 +333,18 @@ private:
 		// check last version in mutation logs
 
 		state std::string baseUrl = SERVER_KNOBS->BLOB_RESTORE_MLOGS_URL;
-		state std::vector<std::string> containers = wait(IBackupContainer::listContainers(baseUrl, {}));
-		if (containers.size() == 0) {
-			TraceEvent("MissingMutationLogs", self->interf_.id()).detail("Url", baseUrl);
-			throw restore_missing_data();
+		state std::string mlogsUrl;
+		if (baseUrl.starts_with("file://")) {
+			state std::vector<std::string> containers = wait(IBackupContainer::listContainers(baseUrl, {}));
+			if (containers.size() == 0) {
+				TraceEvent("MissingMutationLogs", self->interf_.id()).detail("Url", baseUrl);
+				throw restore_missing_data();
+			}
+			mlogsUrl = containers.front();
+		} else {
+			mlogsUrl = baseUrl;
 		}
-		state Reference<IBackupContainer> bc = IBackupContainer::openContainer(containers.front(), {}, {});
+		state Reference<IBackupContainer> bc = IBackupContainer::openContainer(mlogsUrl, {}, {});
 		BackupDescription desc = wait(bc->describeBackup());
 		if (!desc.contiguousLogEnd.present()) {
 			TraceEvent("InvalidMutationLogs").detail("Url", baseUrl);
@@ -406,7 +412,7 @@ private:
 		    .detail("MinVer", minLogVersion)
 		    .detail("MaxVer", maxLogVersion);
 
-		wait(submitRestore(self, KeyRef(tagName), KeyRef(containers.front()), ranges, beginVersions, targetVersion));
+		wait(submitRestore(self, KeyRef(tagName), KeyRef(mlogsUrl), ranges, beginVersions, targetVersion));
 		return Void();
 	}
 


### PR DESCRIPTION
This is a fix for the following restore error caused by s3 url. We don't need to call listContainers for s3 url
"Invalid backup container base URL, resource aka path should be blank.". 

100K correctness tests passed for BlobRestore*.toml

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
