### PR TITLE
fixing racing BM assignment and split update from previous owner

### DIFF
--- a/fdbserver/BlobManager.actor.cpp
+++ b/fdbserver/BlobManager.actor.cpp
@@ -210,7 +210,10 @@ struct BlobWorkerInfo {
 	BlobWorkerInfo(int numGranulesAssigned = 0) : numGranulesAssigned(numGranulesAssigned) {}
 };
 
-enum BoundaryEvalType { UNKNOWN, MERGE, SPLIT };
+// recover is when the BM assigns an ambiguously owned range on recovery
+// merge is when the BM initiated a merge candidate for the range
+// split is when the BM initiated a split check for the range
+enum BoundaryEvalType { UNKNOWN, RECOVER, MERGE, SPLIT };
 
 struct BoundaryEvaluation {
 	int64_t epoch;
@@ -3835,6 +3838,9 @@ ACTOR Future<Void> recoverBlobManager(Reference<BlobManagerData> bmData) {
 		// if worker id is already set to a known worker that replied with it in the mapping, range is already assigned
 		// there. If not, need to explicitly assign it to someone
 		if (workerId == UID() || epoch == 0 || !endingWorkers.count(workerId)) {
+			// prevent racing status updates from old owner from causing issues until this request gets sent out properly
+			bmData->boundaryEvaluations.insert(range.range(),  BoundaryEvaluation(bmData->epoch, 0, BoundaryEvalType::RECOVER, bmData->epoch, 0));
+
 			RangeAssignment raAssign;
 			raAssign.isAssign = true;
 			raAssign.worker = workerId;

--- a/fdbserver/BlobManager.actor.cpp
+++ b/fdbserver/BlobManager.actor.cpp
@@ -3838,8 +3838,10 @@ ACTOR Future<Void> recoverBlobManager(Reference<BlobManagerData> bmData) {
 		// if worker id is already set to a known worker that replied with it in the mapping, range is already assigned
 		// there. If not, need to explicitly assign it to someone
 		if (workerId == UID() || epoch == 0 || !endingWorkers.count(workerId)) {
-			// prevent racing status updates from old owner from causing issues until this request gets sent out properly
-			bmData->boundaryEvaluations.insert(range.range(),  BoundaryEvaluation(bmData->epoch, 0, BoundaryEvalType::RECOVER, bmData->epoch, 0));
+			// prevent racing status updates from old owner from causing issues until this request gets sent out
+			// properly
+			bmData->boundaryEvaluations.insert(
+			    range.range(), BoundaryEvaluation(bmData->epoch, 0, BoundaryEvalType::RECOVER, bmData->epoch, 0));
 
 			RangeAssignment raAssign;
 			raAssign.isAssign = true;


### PR DESCRIPTION
Fixes one case of `now() - stableTimestamp.get() <= checkTimeoutOnceStable` failure

Passed 100k correctness with only unrelated #9242 failure

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
