### PR TITLE
cherrypick multiple fixes and improvement [release-7.2]

### DIFF
--- a/fdbclient/BlobGranuleFiles.cpp
+++ b/fdbclient/BlobGranuleFiles.cpp
@@ -2466,7 +2466,7 @@ void checkGranuleRead(const KeyValueGen& kvGen,
 		}
 		deltaIdx++;
 	}
-	StringRef deltaPtrs[deltaPtrsVector.size()];
+	StringRef deltaPtrs[deltaPtrsVector.size() + 1];
 	for (int i = 0; i < deltaPtrsVector.size(); i++) {
 		deltaPtrs[i] = deltaPtrsVector[i];
 	}

--- a/fdbclient/include/fdbclient/VersionedMap.h
+++ b/fdbclient/include/fdbclient/VersionedMap.h
@@ -284,12 +284,17 @@ void insert(Reference<PTree<T>>& p, Version at, const T& x) {
 	if (!p) {
 		p = makeReference<PTree<T>>(x, at);
 	} else {
-		bool direction = !(x < p->data);
-		Reference<PTree<T>> child = p->child(direction, at);
-		insert(child, at, x);
-		p = update(p, direction, child, at);
-		if (p->child(direction, at)->priority > p->priority)
-			rotate(p, at, !direction);
+		int c = ::compare(x, p->data);
+		if (c == 0) {
+			p = makeReference<PTree<T>>(p->priority, x, p->left(at), p->right(at), at);
+		} else {
+			const bool direction = !(c < 0);
+			Reference<PTree<T>> child = p->child(direction, at);
+			insert(child, at, x);
+			p = update(p, direction, child, at);
+			if (p->child(direction, at)->priority > p->priority)
+				rotate(p, at, !direction);
+		}
 	}
 }
 
@@ -731,10 +736,6 @@ public:
 	// insert() and erase() invalidate atLatest() and all iterators into it
 	void insert(const K& k, const T& t) { insert(k, t, latestVersion); }
 	void insert(const K& k, const T& t, Version insertAt) {
-		if (PTreeImpl::contains(roots.back().second, latestVersion, k))
-			PTreeImpl::remove(roots.back().second,
-			                  latestVersion,
-			                  k); // FIXME: Make PTreeImpl::insert do this automatically  (see also WriteMap.h FIXME)
 		PTreeImpl::insert(
 		    roots.back().second, latestVersion, MapPair<K, std::pair<T, Version>>(k, std::make_pair(t, insertAt)));
 	}

--- a/fdbclient/include/fdbclient/WriteMap.h
+++ b/fdbclient/include/fdbclient/WriteMap.h
@@ -90,6 +90,8 @@ struct WriteMapEntry {
 
 	int compare(ExtStringRef const& r) const { return -r.compare(key); }
 
+	int compare(WriteMapEntry const& r) const { return key.compare(r.key); }
+
 	std::string toString() const { return printable(key); }
 };
 

--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -1503,17 +1503,20 @@ public:
 					if (processInfo->locality.dcId() == primaryDcId) {
 						primaryProcessesLeft.add(processInfo->locality);
 						primaryLocalitiesLeft.push_back(processInfo->locality);
-					} else if (processInfo->locality.dcId() == remoteDcId) {
+					}
+					if (processInfo->locality.dcId() == remoteDcId) {
 						remoteProcessesLeft.add(processInfo->locality);
 						remoteLocalitiesLeft.push_back(processInfo->locality);
-					} else if (std::find(primarySatelliteDcIds.begin(),
-					                     primarySatelliteDcIds.end(),
-					                     processInfo->locality.dcId()) != primarySatelliteDcIds.end()) {
+					}
+					if (std::find(primarySatelliteDcIds.begin(),
+					              primarySatelliteDcIds.end(),
+					              processInfo->locality.dcId()) != primarySatelliteDcIds.end()) {
 						primarySatelliteProcessesLeft.add(processInfo->locality);
 						primarySatelliteLocalitiesLeft.push_back(processInfo->locality);
-					} else if (std::find(remoteSatelliteDcIds.begin(),
-					                     remoteSatelliteDcIds.end(),
-					                     processInfo->locality.dcId()) != remoteSatelliteDcIds.end()) {
+					}
+					if (std::find(remoteSatelliteDcIds.begin(),
+					              remoteSatelliteDcIds.end(),
+					              processInfo->locality.dcId()) != remoteSatelliteDcIds.end()) {
 						remoteSatelliteProcessesLeft.add(processInfo->locality);
 						remoteSatelliteLocalitiesLeft.push_back(processInfo->locality);
 					}
@@ -1522,17 +1525,20 @@ public:
 					if (processInfo->locality.dcId() == primaryDcId) {
 						primaryProcessesDead.add(processInfo->locality);
 						primaryLocalitiesDead.push_back(processInfo->locality);
-					} else if (processInfo->locality.dcId() == remoteDcId) {
+					}
+					if (processInfo->locality.dcId() == remoteDcId) {
 						remoteProcessesDead.add(processInfo->locality);
 						remoteLocalitiesDead.push_back(processInfo->locality);
-					} else if (std::find(primarySatelliteDcIds.begin(),
-					                     primarySatelliteDcIds.end(),
-					                     processInfo->locality.dcId()) != primarySatelliteDcIds.end()) {
+					}
+					if (std::find(primarySatelliteDcIds.begin(),
+					              primarySatelliteDcIds.end(),
+					              processInfo->locality.dcId()) != primarySatelliteDcIds.end()) {
 						primarySatelliteProcessesDead.add(processInfo->locality);
 						primarySatelliteLocalitiesDead.push_back(processInfo->locality);
-					} else if (std::find(remoteSatelliteDcIds.begin(),
-					                     remoteSatelliteDcIds.end(),
-					                     processInfo->locality.dcId()) != remoteSatelliteDcIds.end()) {
+					}
+					if (std::find(remoteSatelliteDcIds.begin(),
+					              remoteSatelliteDcIds.end(),
+					              processInfo->locality.dcId()) != remoteSatelliteDcIds.end()) {
 						remoteSatelliteProcessesDead.add(processInfo->locality);
 						remoteSatelliteLocalitiesDead.push_back(processInfo->locality);
 					}

--- a/fdbserver/BlobManager.actor.cpp
+++ b/fdbserver/BlobManager.actor.cpp
@@ -210,7 +210,10 @@ struct BlobWorkerInfo {
 	BlobWorkerInfo(int numGranulesAssigned = 0) : numGranulesAssigned(numGranulesAssigned) {}
 };
 
-enum BoundaryEvalType { UNKNOWN, MERGE, SPLIT };
+// recover is when the BM assigns an ambiguously owned range on recovery
+// merge is when the BM initiated a merge candidate for the range
+// split is when the BM initiated a split check for the range
+enum BoundaryEvalType { UNKNOWN, RECOVER, MERGE, SPLIT };
 
 struct BoundaryEvaluation {
 	int64_t epoch;
@@ -3781,6 +3784,11 @@ ACTOR Future<Void> recoverBlobManager(Reference<BlobManagerData> bmData) {
 		// if worker id is already set to a known worker that replied with it in the mapping, range is already assigned
 		// there. If not, need to explicitly assign it to someone
 		if (workerId == UID() || epoch == 0 || !endingWorkers.count(workerId)) {
+			// prevent racing status updates from old owner from causing issues until this request gets sent out
+			// properly
+			bmData->boundaryEvaluations.insert(
+			    range.range(), BoundaryEvaluation(bmData->epoch, 0, BoundaryEvalType::RECOVER, bmData->epoch, 0));
+
 			RangeAssignment raAssign;
 			raAssign.isAssign = true;
 			raAssign.worker = workerId;

--- a/fdbserver/QuietDatabase.actor.cpp
+++ b/fdbserver/QuietDatabase.actor.cpp
@@ -673,8 +673,6 @@ ACTOR Future<Void> repairDeadDatacenter(Database cx,
 			    .detail("RemoteDead", remoteDead)
 			    .detail("PrimaryDead", primaryDead);
 			g_simulator->usableRegions = 1;
-			g_simulator->killDataCenter(
-			    primaryDead ? g_simulator->primaryDcId : g_simulator->remoteDcId, ISimulator::KillInstantly, true);
 			wait(success(ManagementAPI::changeConfig(
 			    cx.getReference(),
 			    (primaryDead ? g_simulator->disablePrimary : g_simulator->disableRemote) + " repopulate_anti_quorum=1",

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -426,6 +426,7 @@ public:
 		    .add("buggify", &buggify)
 		    .add("StderrSeverity", &stderrSeverity)
 		    .add("machineCount", &machineCount)
+		    .add("asanMachineCount", &asanMachineCount)
 		    .add("processesPerMachine", &processesPerMachine)
 		    .add("coordinators", &coordinators)
 		    .add("configDB", &configDBType)
@@ -1785,6 +1786,11 @@ void SimulationConfig::setRegions(const TestConfig& testConfig) {
 void SimulationConfig::setMachineCount(const TestConfig& testConfig) {
 	if (testConfig.machineCount.present()) {
 		machine_count = testConfig.machineCount.get();
+#ifdef ADDRESS_SANITIZER
+		if (testConfig.asanMachineCount.present()) {
+			machine_count = testConfig.asanMachineCount.get();
+		}
+#endif
 	} else if (generateFearless && testConfig.minimumReplication > 1) {
 		// low latency tests in fearless configurations need 4 machines per datacenter (3 for triple replication, 1 that
 		// is down during failures).

--- a/fdbserver/coroimpl/CoroFlow.actor.cpp
+++ b/fdbserver/coroimpl/CoroFlow.actor.cpp
@@ -57,8 +57,11 @@ struct Coroutine /*: IThreadlike*/ {
 	Coroutine() = default;
 	~Coroutine() { *alive = false; }
 
+	static constexpr auto kStackSize = 32 * (1 << 10);
+
 	void start() {
-		coro.reset(new coro_t::pull_type([this](coro_t::push_type& sink) { entry(sink); }));
+		coro.reset(new coro_t::pull_type(boost::coroutines2::fixedsize_stack(kStackSize),
+		                                 [this](coro_t::push_type& sink) { entry(sink); }));
 		switcher(this);
 	}
 

--- a/fdbserver/include/fdbserver/SimulatedCluster.h
+++ b/fdbserver/include/fdbserver/SimulatedCluster.h
@@ -36,6 +36,9 @@ public:
 	bool simpleConfig = false;
 	Optional<int> desiredTLogCount, commitProxyCount, grvProxyCount, resolverCount, storageEngineType, machineCount,
 	    coordinators;
+	// ASAN uses more memory, so adding too many machines can cause OOMs. Tests can set this if they need to lower
+	// machineCount specifically for ASAN. Only has an effect if `machineCount` is set and this is an ASAN build.
+	Optional<int> asanMachineCount;
 };
 
 DatabaseConfiguration generateNormalDatabaseConfiguration(const BasicTestConfig& testConfig);

--- a/flow/SystemMonitor.cpp
+++ b/flow/SystemMonitor.cpp
@@ -30,6 +30,10 @@
 #include <cxxabi.h>
 #endif
 
+#ifdef ADDRESS_SANITIZER
+#include <sanitizer/asan_interface.h>
+#endif
+
 SystemMonitorMachineState machineState;
 
 void initializeSystemMonitorMachineState(SystemMonitorMachineState machineState) {
@@ -459,6 +463,9 @@ Future<Void> startMemoryUsageMonitor(uint64_t memLimit) {
 	}
 	auto checkMemoryUsage = [=]() {
 		if (getResidentMemoryUsage() > memLimit) {
+#if defined(ADDRESS_SANITIZER) && defined(__linux__)
+			__sanitizer_print_memory_profile(/*top percent*/ 100, /*max contexts*/ 10);
+#endif
 			platform::outOfMemory();
 		}
 	};

--- a/tests/fast/DataLossRecovery.toml
+++ b/tests/fast/DataLossRecovery.toml
@@ -5,6 +5,7 @@ storageEngineType = 0
 processesPerMachine = 2
 coordinators = 3
 machineCount = 45
+asanMachineCount = 20
 allowDefaultTenant = false
 
 [[test]]


### PR DESCRIPTION
cherrypick 
- [x] https://github.com/apple/foundationdb/pull/9244 fixing racing BM assignment and split update from previous owner
- [x] https://github.com/apple/foundationdb/pull/9216/ Lower ASAN memory usage
- [x] https://github.com/apple/foundationdb/pull/9205 Set VLA minimum length to 1
- [x] https://github.com/apple/foundationdb/pull/9138 Change PTreeImpl::insert to overwrite existing entries
- [x] https://github.com/apple/foundationdb/pull/9238 A Fix to give the correct behavior of canKillProcesses when primary and remote use the same dcid

20230126-181542-jzhou-4b12c5e57375f971

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
