### PR TITLE
Fix compile error with VSCode

### DIFF
--- a/fdbserver/coroimpl/CoroFlow.actor.cpp
+++ b/fdbserver/coroimpl/CoroFlow.actor.cpp
@@ -22,6 +22,7 @@
 #include "flow/ActorCollection.h"
 #include "flow/TDMetric.actor.h"
 #include "fdbrpc/simulator.h"
+#include "fdbrpc/SimulatorProcessInfo.h"
 #include <boost/coroutine2/all.hpp>
 #include <boost/coroutine2/coroutine.hpp>
 #include <functional>

--- a/flow/include/flow/network.h
+++ b/flow/include/flow/network.h
@@ -29,6 +29,7 @@
 #include <string>
 #include <stdint.h>
 #include <atomic>
+#include <unordered_map>
 #include "flow/IRandom.h"
 #include "flow/ProtocolVersion.h"
 #include "flow/WriteOnlySet.h"


### PR DESCRIPTION
This PR fixed the following 2 compile errors with VSCode on MacOS

[build] In file included from /Users/huliu/fdb_repos/foundationdb/flow/Hostname.actor.cpp:21:
[build] In file included from /Users/huliu/fdb_repos/foundationdb/flow/include/flow/Hostname.h:26:
[build] /Users/huliu/fdb_repos/foundationdb/flow/include/flow/network.h:67:7: error: no template named 'unordered_map' in namespace 'std'
[build]         std::unordered_map<TaskPriority, struct PriorityStats> activeTrackers;
[build]         ~~~~~^
[build] 1 error generated.

[build] /Users/huliu/fdb_repos/foundationdb/fdbserver/coroimpl/CoroFlow.actor.cpp:109:67: error: member access into incomplete type 'ISimulator::ProcessInfo' (aka 'simulator::ProcessInfo')
[build]                 if (g_network->isSimulated() && g_simulator->getCurrentProcess()->rebooting)
[build]                                                                                 ^
[build] /Users/huliu/fdb_repos/foundationdb/fdbrpc/include/fdbrpc/simulator.h:53:8: note: forward declaration of 'simulator::ProcessInfo'
[build] struct ProcessInfo;
[build]        ^
[build] 1 error generated.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
