### PR TITLE
    Let materializeBlobGranule accept a std::vector<StringRef> instead of StringRef[]

### DIFF
--- a/fdbclient/BlobGranuleFiles.cpp
+++ b/fdbclient/BlobGranuleFiles.cpp
@@ -2462,7 +2462,7 @@ TEST_CASE("/blobgranule/files/deltaFormatUnitTest") {
 	}*/
 	Value serialized = serializeChunkedDeltaFile(
 	    fileNameRef, data, kvGen.allRange, targetChunkSize, kvGen.compressFilter, kvGen.cipherKeys);
-	std::vector<StringRef> deltaPtr{serialized};
+	std::vector<StringRef> deltaPtr{ serialized };
 
 	// check whole file
 	checkDeltaRead(kvGen, kvGen.allRange, 0, data.back().version, data, deltaPtr);

--- a/fdbclient/BlobGranuleFiles.cpp
+++ b/fdbclient/BlobGranuleFiles.cpp
@@ -2381,7 +2381,7 @@ void checkDeltaRead(const KeyValueGen& kvGen,
 	    deterministicRandom()->randomUniqueID(), deterministicRandom()->randomUniqueID(), readVersion, ".delta");
 	Standalone<BlobGranuleChunkRef> chunk;
 	chunk.deltaFiles.emplace_back_deep(
-	    chunk.arena(), filename, 0, serialized[0]->size(), serialized[0]->size(), kvGen.cipherKeys);
+	    chunk.arena(), filename, 0, serialized[0].size(), serialized[0].size(), kvGen.cipherKeys);
 	chunk.keyRange = kvGen.allRange;
 	chunk.includedVersion = readVersion;
 	chunk.snapshotVersion = invalidVersion;

--- a/fdbclient/BlobGranuleReader.actor.cpp
+++ b/fdbclient/BlobGranuleReader.actor.cpp
@@ -93,13 +93,13 @@ ACTOR Future<RangeResult> readBlobGranule(BlobGranuleChunkRef chunk,
 		}
 
 		state int numDeltaFiles = chunk.deltaFiles.size();
-		state StringRef* deltaData = new (arena) StringRef[numDeltaFiles];
+		state std::vector<StringRef> deltaData;
 		state int deltaIdx;
 
-		// for (Future<Standalone<StringRef>> deltaFuture : readDeltaFutures) {
+		deltaData.reserve(numDeltaFiles);
 		for (deltaIdx = 0; deltaIdx < numDeltaFiles; deltaIdx++) {
 			Standalone<StringRef> data = wait(readDeltaFutures[deltaIdx]);
-			deltaData[deltaIdx] = data;
+			deltaData.push_back(data);
 			arena.dependsOn(data.arena());
 		}
 

--- a/fdbclient/include/fdbclient/BlobGranuleFiles.h
+++ b/fdbclient/include/fdbclient/BlobGranuleFiles.h
@@ -51,7 +51,7 @@ RangeResult materializeBlobGranule(const BlobGranuleChunkRef& chunk,
                                    Version beginVersion,
                                    Version readVersion,
                                    Optional<StringRef> snapshotData,
-                                   StringRef deltaFileData[],
+                                   const std::vector<StringRef>& deltaFileData,
                                    GranuleMaterializeStats& stats);
 
 std::string randomBGFilename(UID blobWorkerID, UID granuleID, Version version, std::string suffix);


### PR DESCRIPTION
The deltaFileData parameter was type StringRef[], this indirectly causes
issue #9206. By setting the incoming parameter type to be
std::vector<StringRef>, the issue might be fixed plus adding extra
memory safety.

Please let me know how do I test this patch

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
