### PR TITLE
Add getMappedRangeV2 API with byte array in request/reply

### DIFF
--- a/bindings/c/fdb_c.cpp
+++ b/bindings/c/fdb_c.cpp
@@ -307,6 +307,16 @@ extern "C" DLLEXPORT fdb_error_t fdb_future_get_mappedkeyvalue_array(FDBFuture* 
 	                 *out_more = rrr.more;);
 }
 
+extern "C" DLLEXPORT fdb_error_t fdb_future_get_mappedkeyvalue_array_v2(FDBFuture* f,
+                                                                        FDBMappedKeyValueV2 const** out_kvm,
+                                                                        int* out_count,
+                                                                        fdb_bool_t* out_more) {
+	CATCH_AND_RETURN(Standalone<MappedRangeResultRefV2> rrr = TSAV(Standalone<MappedRangeResultRefV2>, f)->get();
+	                 *out_kvm = (FDBMappedKeyValueV2*)rrr.begin();
+	                 *out_count = rrr.size();
+	                 *out_more = rrr.more;);
+}
+
 extern "C" DLLEXPORT fdb_error_t fdb_future_get_shared_state(FDBFuture* f, DatabaseSharedState** outPtr) {
 	CATCH_AND_RETURN(*outPtr = (DatabaseSharedState*)((TSAV(DatabaseSharedState*, f)->get())););
 }
@@ -901,6 +911,41 @@ FDBFuture* fdb_transaction_get_range_impl(FDBTransaction* tr,
 	                    .extractPtr());
 }
 
+extern "C" DLLEXPORT FDBFuture* fdb_transaction_get_mapped_range_v2(FDBTransaction* tr,
+                                                                    uint8_t const* begin_key_name,
+                                                                    int begin_key_name_length,
+                                                                    fdb_bool_t begin_or_equal,
+                                                                    int begin_offset,
+                                                                    uint8_t const* end_key_name,
+                                                                    int end_key_name_length,
+                                                                    fdb_bool_t end_or_equal,
+                                                                    int end_offset,
+                                                                    uint8_t const* mapper_name,
+                                                                    int mapper_name_length,
+                                                                    int limit,
+                                                                    int target_bytes,
+                                                                    FDBStreamingMode mode,
+                                                                    int iteration,
+                                                                    fdb_bool_t snapshot,
+                                                                    fdb_bool_t reverse,
+                                                                    uint8_t const* mapped_range_params,
+                                                                    int mapped_range_params_length) {
+	FDBFuture* r = validate_and_update_parameters(limit, target_bytes, mode, iteration, reverse);
+	if (r != nullptr)
+		return r;
+	return (
+	    FDBFuture*)(TXN(tr)
+	                    ->getMappedRangeV2(
+	                        KeySelectorRef(KeyRef(begin_key_name, begin_key_name_length), begin_or_equal, begin_offset),
+	                        KeySelectorRef(KeyRef(end_key_name, end_key_name_length), end_or_equal, end_offset),
+	                        StringRef(mapper_name, mapper_name_length),
+	                        StringRef(mapped_range_params, mapped_range_params_length),
+	                        GetRangeLimits(limit, target_bytes),
+	                        snapshot,
+	                        reverse)
+	                    .extractPtr());
+}
+
 extern "C" DLLEXPORT FDBFuture* fdb_transaction_get_mapped_range(FDBTransaction* tr,
                                                                  uint8_t const* begin_key_name,
                                                                  int begin_key_name_length,
@@ -916,7 +961,6 @@ extern "C" DLLEXPORT FDBFuture* fdb_transaction_get_mapped_range(FDBTransaction*
                                                                  int target_bytes,
                                                                  FDBStreamingMode mode,
                                                                  int iteration,
-                                                                 int matchIndex,
                                                                  fdb_bool_t snapshot,
                                                                  fdb_bool_t reverse) {
 	FDBFuture* r = validate_and_update_parameters(limit, target_bytes, mode, iteration, reverse);
@@ -929,7 +973,6 @@ extern "C" DLLEXPORT FDBFuture* fdb_transaction_get_mapped_range(FDBTransaction*
 	                        KeySelectorRef(KeyRef(end_key_name, end_key_name_length), end_or_equal, end_offset),
 	                        StringRef(mapper_name, mapper_name_length),
 	                        GetRangeLimits(limit, target_bytes),
-	                        matchIndex,
 	                        snapshot,
 	                        reverse)
 	                    .extractPtr());

--- a/bindings/c/foundationdb/fdb_c.h
+++ b/bindings/c/foundationdb/fdb_c.h
@@ -115,6 +115,8 @@ typedef struct keyvalue {
 } FDBKeyValue;
 #endif
 
+#pragma pack(pop)
+
 /* Memory layout of KeySelectorRef. */
 typedef struct keyselector {
 	FDBKey key;
@@ -169,6 +171,7 @@ typedef struct mappedkeyvalue {
 	unsigned char buffer[32];
 } FDBMappedKeyValue;
 
+#pragma pack(push, 4)
 /* Memory layout of MappedKeyValueRefV2.
 
 Total 128 bytes

--- a/bindings/c/test/unit/fdb_api.cpp
+++ b/bindings/c/test/unit/fdb_api.cpp
@@ -104,6 +104,12 @@ void Future::cancel() {
 	return fdb_future_get_mappedkeyvalue_array(future_, out_kv, out_count, out_more);
 }
 
+[[nodiscard]] fdb_error_t MappedKeyValueArrayFutureV2::get(const FDBMappedKeyValueV2** out_kv,
+                                                           int* out_count,
+                                                           fdb_bool_t* out_more) {
+	return fdb_future_get_mappedkeyvalue_array_v2(future_, out_kv, out_count, out_more);
+}
+
 // Result
 
 Result::~Result() {
@@ -300,7 +306,6 @@ MappedKeyValueArrayFuture Transaction::get_mapped_range(const uint8_t* begin_key
                                                         int target_bytes,
                                                         FDBStreamingMode mode,
                                                         int iteration,
-                                                        int matchIndex,
                                                         fdb_bool_t snapshot,
                                                         fdb_bool_t reverse) {
 	return MappedKeyValueArrayFuture(fdb_transaction_get_mapped_range(tr_,
@@ -318,9 +323,47 @@ MappedKeyValueArrayFuture Transaction::get_mapped_range(const uint8_t* begin_key
 	                                                                  target_bytes,
 	                                                                  mode,
 	                                                                  iteration,
-	                                                                  matchIndex,
 	                                                                  snapshot,
 	                                                                  reverse));
+}
+
+MappedKeyValueArrayFutureV2 Transaction::get_mapped_range_v2(const uint8_t* begin_key_name,
+                                                             int begin_key_name_length,
+                                                             fdb_bool_t begin_or_equal,
+                                                             int begin_offset,
+                                                             const uint8_t* end_key_name,
+                                                             int end_key_name_length,
+                                                             fdb_bool_t end_or_equal,
+                                                             int end_offset,
+                                                             const uint8_t* mapper_name,
+                                                             int mapper_name_length,
+                                                             int limit,
+                                                             int target_bytes,
+                                                             FDBStreamingMode mode,
+                                                             int iteration,
+                                                             fdb_bool_t snapshot,
+                                                             fdb_bool_t reverse,
+                                                             uint8_t const* mapped_range_params,
+                                                             int mapped_range_params_length) {
+	return MappedKeyValueArrayFutureV2(fdb_transaction_get_mapped_range_v2(tr_,
+	                                                                       begin_key_name,
+	                                                                       begin_key_name_length,
+	                                                                       begin_or_equal,
+	                                                                       begin_offset,
+	                                                                       end_key_name,
+	                                                                       end_key_name_length,
+	                                                                       end_or_equal,
+	                                                                       end_offset,
+	                                                                       mapper_name,
+	                                                                       mapper_name_length,
+	                                                                       limit,
+	                                                                       target_bytes,
+	                                                                       mode,
+	                                                                       iteration,
+	                                                                       snapshot,
+	                                                                       reverse,
+	                                                                       mapped_range_params,
+	                                                                       mapped_range_params_length));
 }
 
 EmptyFuture Transaction::watch(std::string_view key) {

--- a/bindings/c/test/unit/fdb_api.hpp
+++ b/bindings/c/test/unit/fdb_api.hpp
@@ -149,6 +149,18 @@ private:
 	MappedKeyValueArrayFuture(FDBFuture* f) : Future(f) {}
 };
 
+class MappedKeyValueArrayFutureV2 : public Future {
+public:
+	// Call this function instead of fdb_future_get_mappedkeyvalue_array when using
+	// the MappedKeyValueArrayFuture type. Its behavior is identical to
+	// fdb_future_get_mappedkeyvalue_array.
+	fdb_error_t get(const FDBMappedKeyValueV2** out_kv, int* out_count, fdb_bool_t* out_more);
+
+private:
+	friend class Transaction;
+	MappedKeyValueArrayFutureV2(FDBFuture* f) : Future(f) {}
+};
+
 class KeyRangeArrayFuture : public Future {
 public:
 	// Call this function instead of fdb_future_get_keyrange_array when using
@@ -329,10 +341,27 @@ public:
 	                                           int target_bytes,
 	                                           FDBStreamingMode mode,
 	                                           int iteration,
-	                                           int matchIndex,
 	                                           fdb_bool_t snapshot,
 	                                           fdb_bool_t reverse);
 
+	MappedKeyValueArrayFutureV2 get_mapped_range_v2(const uint8_t* begin_key_name,
+	                                                int begin_key_name_length,
+	                                                fdb_bool_t begin_or_equal,
+	                                                int begin_offset,
+	                                                const uint8_t* end_key_name,
+	                                                int end_key_name_length,
+	                                                fdb_bool_t end_or_equal,
+	                                                int end_offset,
+	                                                const uint8_t* mapper_name,
+	                                                int mapper_name_length,
+	                                                int limit,
+	                                                int target_bytes,
+	                                                FDBStreamingMode mode,
+	                                                int iteration,
+	                                                fdb_bool_t snapshot,
+	                                                fdb_bool_t reverse,
+	                                                uint8_t const* mapped_range_params,
+	                                                int mapped_range_params_length);
 	// Wrapper around fdb_transaction_watch. Returns a future representing an
 	// empty value.
 	EmptyFuture watch(std::string_view key);

--- a/bindings/c/test/unit/unit_tests.cpp
+++ b/bindings/c/test/unit/unit_tests.cpp
@@ -49,6 +49,9 @@
 
 #include "fdb_api.hpp"
 
+const int code_int = 1;
+const int code_bool = 2;
+
 void fdb_check(fdb_error_t e) {
 	if (e) {
 		std::cerr << fdb_get_error(e) << std::endl;
@@ -198,6 +201,31 @@ struct GetMappedRangeResult {
 	fdb_error_t err;
 };
 
+struct GetMappedRangeResultV2 {
+	struct MappedKVV2 {
+		MappedKVV2(const std::string& key,
+		           const std::string& value,
+		           const std::string& begin,
+		           const std::string& end,
+		           const std::vector<std::pair<std::string, std::string>>& range_results,
+		           const std::string& responseBytes)
+		  : key(key), value(value), begin(begin), end(end), range_results(range_results), responseBytes(responseBytes) {
+		}
+
+		std::string key;
+		std::string value;
+		std::string begin;
+		std::string end;
+		std::vector<std::pair<std::string, std::string>> range_results;
+		std::string responseBytes;
+	};
+	std::vector<MappedKVV2> mkvs;
+	// True if values remain in the key range requested.
+	bool more;
+	// Set to a non-zero value if an error occurred during the transaction.
+	fdb_error_t err;
+};
+
 // Helper function to get a range of kv pairs. Returns a GetRangeResult struct
 // containing the results of the range read. Caller is responsible for checking
 // error on failure and retrying if necessary.
@@ -269,7 +297,6 @@ GetMappedRangeResult get_mapped_range(fdb::Transaction& tr,
                                       int target_bytes,
                                       FDBStreamingMode mode,
                                       int iteration,
-                                      int matchIndex,
                                       fdb_bool_t snapshot,
                                       fdb_bool_t reverse) {
 	fdb::MappedKeyValueArrayFuture f1 = tr.get_mapped_range(begin_key_name,
@@ -286,7 +313,6 @@ GetMappedRangeResult get_mapped_range(fdb::Transaction& tr,
 	                                                        target_bytes,
 	                                                        mode,
 	                                                        iteration,
-	                                                        matchIndex,
 	                                                        snapshot,
 	                                                        reverse);
 
@@ -305,8 +331,7 @@ GetMappedRangeResult get_mapped_range(fdb::Transaction& tr,
 	result.more = (out_more != 0);
 	result.err = 0;
 
-	//	std::cout << "out_count:" << out_count << " out_more:" << out_more << " out_mkv:" << (void*)out_mkv <<
-	// std::endl;
+	// std::cout << "out_count:" << out_count << " out_more:" << out_more << " out_mkv:" << (void*)out_mkv << std::endl;
 
 	for (int i = 0; i < out_count; ++i) {
 		FDBMappedKeyValue mkv = out_mkv[i];
@@ -325,6 +350,79 @@ GetMappedRangeResult get_mapped_range(fdb::Transaction& tr,
 			// std::cout << "[" << i << "]" << k << " -> " << v << std::endl;
 		}
 		result.mkvs.emplace_back(key, value, begin, end, range_results);
+	}
+	return result;
+}
+
+GetMappedRangeResultV2 get_mapped_range_v2(fdb::Transaction& tr,
+                                           const uint8_t* begin_key_name,
+                                           int begin_key_name_length,
+                                           fdb_bool_t begin_or_equal,
+                                           int begin_offset,
+                                           const uint8_t* end_key_name,
+                                           int end_key_name_length,
+                                           fdb_bool_t end_or_equal,
+                                           int end_offset,
+                                           const uint8_t* mapper_name,
+                                           int mapper_name_length,
+                                           int limit,
+                                           int target_bytes,
+                                           FDBStreamingMode mode,
+                                           int iteration,
+                                           fdb_bool_t snapshot,
+                                           fdb_bool_t reverse,
+                                           const uint8_t* mapped_range_params,
+                                           int mapped_range_params_length) {
+	fdb::MappedKeyValueArrayFutureV2 f1 = tr.get_mapped_range_v2(begin_key_name,
+	                                                             begin_key_name_length,
+	                                                             begin_or_equal,
+	                                                             begin_offset,
+	                                                             end_key_name,
+	                                                             end_key_name_length,
+	                                                             end_or_equal,
+	                                                             end_offset,
+	                                                             mapper_name,
+	                                                             mapper_name_length,
+	                                                             limit,
+	                                                             target_bytes,
+	                                                             mode,
+	                                                             iteration,
+	                                                             snapshot,
+	                                                             reverse,
+	                                                             mapped_range_params,
+	                                                             mapped_range_params_length);
+	fdb_error_t err = wait_future(f1);
+	if (err) {
+		return GetMappedRangeResultV2{ {}, false, err };
+	}
+
+	const FDBMappedKeyValueV2* out_mkv;
+	int out_count;
+	fdb_bool_t out_more;
+
+	fdb_check(f1.get(&out_mkv, &out_count, &out_more));
+
+	GetMappedRangeResultV2 result;
+	result.more = (out_more != 0);
+	result.err = 0;
+
+	for (int i = 0; i < out_count; ++i) {
+		FDBMappedKeyValueV2 mkv = out_mkv[i];
+		auto key = extractString(mkv.key);
+		auto value = extractString(mkv.value);
+		auto begin = extractString(mkv.getRange.begin.key);
+		auto end = extractString(mkv.getRange.end.key);
+		// std::cout << "key:" << key << " value:" << value << " begin:" << begin << " end:" << end << std::endl;
+
+		std::vector<std::pair<std::string, std::string>> range_results;
+		for (int i = 0; i < mkv.getRange.m_size; ++i) {
+			const auto& kv = mkv.getRange.data[i];
+			std::string k((const char*)kv.key, kv.key_length);
+			std::string v((const char*)kv.value, kv.value_length);
+			range_results.emplace_back(k, v);
+		}
+		auto responseBytes = extractString(mkv.responseBytes);
+		result.mkvs.emplace_back(key, value, begin, end, range_results, responseBytes);
 	}
 	return result;
 }
@@ -946,6 +1044,11 @@ static std::string recordValue(const int i, const int split) {
 	return Tuple::makeTuple(dataOfRecord(i), split).pack().toString();
 }
 
+static std::unordered_map<int, int> versionToPosMatchIndex = { std::make_pair(2, 1) };
+static std::unordered_map<int, int> versionToPosFetchLocalOnly = { std::make_pair(2, 6) };
+static std::unordered_map<int, int> versionToLength = { std::make_pair(2, 8) };
+static std::unordered_map<int, int> versionToPosLocal = { std::make_pair(2, 1) };
+
 const static int SPLIT_SIZE = 3;
 std::map<std::string, std::string> fillInRecords(int n) {
 	// Note: The user requested `prefix` should be added as the first element of the tuple that forms the key, rather
@@ -961,14 +1064,9 @@ std::map<std::string, std::string> fillInRecords(int n) {
 	return data;
 }
 
-GetMappedRangeResult getMappedIndexEntries(int beginId,
-                                           int endId,
-                                           fdb::Transaction& tr,
-                                           std::string mapper,
-                                           int matchIndex) {
+GetMappedRangeResult getMappedIndexEntriesInternal(int beginId, int endId, fdb::Transaction& tr, std::string mapper) {
 	std::string indexEntryKeyBegin = indexEntryKey(beginId);
 	std::string indexEntryKeyEnd = indexEntryKey(endId);
-
 	return get_mapped_range(
 	    tr,
 	    FDB_KEYSEL_FIRST_GREATER_OR_EQUAL((const uint8_t*)indexEntryKeyBegin.c_str(), indexEntryKeyBegin.size()),
@@ -979,19 +1077,60 @@ GetMappedRangeResult getMappedIndexEntries(int beginId,
 	    /* target_bytes */ 0,
 	    /* FDBStreamingMode */ FDB_STREAMING_MODE_WANT_ALL,
 	    /* iteration */ 0,
-	    /* matchIndex */ matchIndex,
 	    /* snapshot */ false,
 	    /* reverse */ 0);
 }
 
-GetMappedRangeResult getMappedIndexEntries(int beginId,
-                                           int endId,
-                                           fdb::Transaction& tr,
-                                           int matchIndex,
-                                           bool allMissing) {
+GetMappedRangeResultV2 getMappedIndexEntriesInternalV2(int beginId,
+                                                       int endId,
+                                                       fdb::Transaction& tr,
+                                                       std::string mapper,
+                                                       int matchIndex,
+                                                       bool fetchLocalOnly) {
+	std::string indexEntryKeyBegin = indexEntryKey(beginId);
+	std::string indexEntryKeyEnd = indexEntryKey(endId);
+	int version = 2;
+	int paramsBytesLength = versionToLength[version];
+	uint8_t paramsBytes[paramsBytesLength];
+	memset(paramsBytes, 0, paramsBytesLength);
+	paramsBytes[0] = version; // API protocol version
+	int posMatchIndex = versionToPosMatchIndex[version];
+	int posFetchLocalOnly = versionToPosFetchLocalOnly[version];
+	paramsBytes[posMatchIndex] = code_int;
+	paramsBytes[posMatchIndex + 1] = matchIndex; // little endian
+	paramsBytes[posFetchLocalOnly] = code_bool;
+	paramsBytes[posFetchLocalOnly + 1] = fetchLocalOnly;
+	return get_mapped_range_v2(
+	    tr,
+	    FDB_KEYSEL_FIRST_GREATER_OR_EQUAL((const uint8_t*)indexEntryKeyBegin.c_str(), indexEntryKeyBegin.size()),
+	    FDB_KEYSEL_FIRST_GREATER_OR_EQUAL((const uint8_t*)indexEntryKeyEnd.c_str(), indexEntryKeyEnd.size()),
+	    (const uint8_t*)mapper.c_str(),
+	    mapper.size(),
+	    /* limit */ 0,
+	    /* target_bytes */ 0,
+	    /* FDBStreamingMode */ FDB_STREAMING_MODE_WANT_ALL,
+	    /* iteration */ 0,
+	    /* snapshot */ false,
+	    /* reverse */ 0,
+	    paramsBytes,
+	    paramsBytesLength);
+}
+
+GetMappedRangeResult getMappedIndexEntries(int beginId, int endId, fdb::Transaction& tr, bool allMissing) {
 	std::string mapper =
 	    Tuple::makeTuple(prefix, RECORD, (allMissing ? "{K[2]}"_sr : "{K[3]}"_sr), "{...}"_sr).pack().toString();
-	return getMappedIndexEntries(beginId, endId, tr, mapper, matchIndex);
+	return getMappedIndexEntriesInternal(beginId, endId, tr, mapper);
+}
+
+GetMappedRangeResultV2 getMappedIndexEntries(int beginId,
+                                             int endId,
+                                             fdb::Transaction& tr,
+                                             bool allMissing,
+                                             int matchIndex,
+                                             bool fetchLocalOnly) {
+	std::string mapper =
+	    Tuple::makeTuple(prefix, RECORD, (allMissing ? "{K[2]}"_sr : "{K[3]}"_sr), "{...}"_sr).pack().toString();
+	return getMappedIndexEntriesInternalV2(beginId, endId, tr, mapper, matchIndex, fetchLocalOnly);
 }
 
 TEST_CASE("versionstamp_unit_test") {
@@ -1061,6 +1200,47 @@ TEST_CASE("tuple_fail_to_append_longer_versionstamp") {
 	UNREACHABLE();
 }
 
+int getMatchIndexRandom() {
+	const double r = deterministicRandom()->random01();
+	int matchIndex = MATCH_INDEX_ALL;
+	if (r < 0.5) {
+		matchIndex = MATCH_INDEX_NONE;
+	} else if (r < 0.5) {
+		matchIndex = MATCH_INDEX_MATCHED_ONLY;
+	} else if (r < 0.75) {
+		matchIndex = MATCH_INDEX_UNMATCHED_ONLY;
+	}
+	return matchIndex;
+}
+
+bool localMiss(const GetMappedRangeResultV2::MappedKVV2& mkv, int posLocal) {
+	return mkv.responseBytes[posLocal + 1] == 0;
+}
+
+void validate(const GetMappedRangeResultV2::MappedKVV2& mkv,
+              int id,
+              int matchIndex,
+              int i,
+              int expectSize,
+              bool allMissing,
+              bool fetchLocalOnly) {
+	int version = 2;
+	int posLocal = versionToPosLocal[version];
+	if (matchIndex == MATCH_INDEX_ALL || i == 0 || i == expectSize - 1 ||
+	    (fetchLocalOnly && localMiss(mkv, posLocal))) {
+		CHECK(indexEntryKey(id).compare(mkv.key) == 0);
+	} else if ((matchIndex == MATCH_INDEX_MATCHED_ONLY && !allMissing) ||
+	           (matchIndex == MATCH_INDEX_UNMATCHED_ONLY && allMissing)) {
+		CHECK(indexEntryKey(id).compare(mkv.key) == 0);
+	} else {
+		CHECK(EMPTY.compare(mkv.key) == 0);
+	}
+	CHECK(EMPTY.compare(mkv.value) == 0);
+	CHECK(mkv.responseBytes[0] == version);
+	CHECK(mkv.responseBytes[posLocal] == code_bool);
+	CHECK((mkv.responseBytes[posLocal + 1] == 1 || mkv.responseBytes[posLocal + 1] == 0));
+}
+
 TEST_CASE("fdb_transaction_get_mapped_range") {
 	const int TOTAL_RECORDS = 20;
 	fillInRecords(TOTAL_RECORDS);
@@ -1070,16 +1250,10 @@ TEST_CASE("fdb_transaction_get_mapped_range") {
 	while (1) {
 		int beginId = 1;
 		int endId = 19;
-		const double r = deterministicRandom()->random01();
-		int matchIndex = MATCH_INDEX_ALL;
-		if (r < 0.25) {
-			matchIndex = MATCH_INDEX_NONE;
-		} else if (r < 0.5) {
-			matchIndex = MATCH_INDEX_MATCHED_ONLY;
-		} else if (r < 0.75) {
-			matchIndex = MATCH_INDEX_UNMATCHED_ONLY;
-		}
-		auto result = getMappedIndexEntries(beginId, endId, tr, matchIndex, false);
+		int matchIndex = getMatchIndexRandom();
+		bool fetchLocalOnly = deterministicRandom()->random01() < 0.5;
+		int allMissing = false;
+		auto result = getMappedIndexEntries(beginId, endId, tr, allMissing, matchIndex, fetchLocalOnly);
 
 		if (result.err) {
 			fdb::EmptyFuture f1 = tr.on_error(result.err);
@@ -1094,16 +1268,45 @@ TEST_CASE("fdb_transaction_get_mapped_range") {
 		int id = beginId;
 		for (int i = 0; i < expectSize; i++, id++) {
 			const auto& mkv = result.mkvs[i];
-			if (matchIndex == MATCH_INDEX_ALL || i == 0 || i == expectSize - 1) {
-				CHECK(indexEntryKey(id).compare(mkv.key) == 0);
-			} else if (matchIndex == MATCH_INDEX_MATCHED_ONLY) {
-				CHECK(indexEntryKey(id).compare(mkv.key) == 0);
-			} else if (matchIndex == MATCH_INDEX_UNMATCHED_ONLY) {
-				CHECK(EMPTY.compare(mkv.key) == 0);
-			} else {
-				CHECK(EMPTY.compare(mkv.key) == 0);
+			validate(mkv, id, matchIndex, i, expectSize, allMissing, fetchLocalOnly);
+			// TODO: compare the whole byte array
+			CHECK(mkv.range_results.size() == SPLIT_SIZE);
+			for (int split = 0; split < SPLIT_SIZE; split++) {
+				auto& kv = mkv.range_results[split];
+				CHECK(recordKey(id, split).compare(kv.first) == 0);
+				CHECK(recordValue(id, split).compare(kv.second) == 0);
 			}
-			CHECK(EMPTY.compare(mkv.value) == 0);
+		}
+		break;
+	}
+}
+
+TEST_CASE("fdb_transaction_get_mapped_range_old") {
+	const int TOTAL_RECORDS = 20;
+	fillInRecords(TOTAL_RECORDS);
+
+	fdb::Transaction tr(db);
+	// RYW should be enabled.
+	while (1) {
+		int beginId = 1;
+		int endId = 19;
+		int allMissing = false;
+		auto result = getMappedIndexEntries(beginId, endId, tr, allMissing);
+
+		if (result.err) {
+			fdb::EmptyFuture f1 = tr.on_error(result.err);
+			fdb_check(wait_future(f1));
+			continue;
+		}
+
+		int expectSize = endId - beginId;
+		CHECK(result.mkvs.size() == expectSize);
+		CHECK(!result.more);
+
+		int id = beginId;
+		for (int i = 0; i < expectSize; i++, id++) {
+			const auto& mkv = result.mkvs[i];
+			CHECK(indexEntryKey(id).compare(mkv.key) == 0);
 			CHECK(mkv.range_results.size() == SPLIT_SIZE);
 			for (int split = 0; split < SPLIT_SIZE; split++) {
 				auto& kv = mkv.range_results[split];
@@ -1124,16 +1327,10 @@ TEST_CASE("fdb_transaction_get_mapped_range_missing_all_secondary") {
 	while (1) {
 		int beginId = 1;
 		int endId = 19;
-		const double r = deterministicRandom()->random01();
-		int matchIndex = MATCH_INDEX_ALL;
-		if (r < 0.25) {
-			matchIndex = MATCH_INDEX_NONE;
-		} else if (r < 0.5) {
-			matchIndex = MATCH_INDEX_MATCHED_ONLY;
-		} else if (r < 0.75) {
-			matchIndex = MATCH_INDEX_UNMATCHED_ONLY;
-		}
-		auto result = getMappedIndexEntries(beginId, endId, tr, matchIndex, true);
+		int matchIndex = getMatchIndexRandom();
+		bool fetchLocalOnly = deterministicRandom()->random01() < 0.5;
+		int allMissing = true;
+		auto result = getMappedIndexEntries(beginId, endId, tr, allMissing, matchIndex, fetchLocalOnly);
 
 		if (result.err) {
 			fdb::EmptyFuture f1 = tr.on_error(result.err);
@@ -1147,17 +1344,37 @@ TEST_CASE("fdb_transaction_get_mapped_range_missing_all_secondary") {
 
 		int id = beginId;
 		for (int i = 0; i < expectSize; i++, id++) {
-			const auto& mkv = result.mkvs[i];
-			if (matchIndex == MATCH_INDEX_ALL || i == 0 || i == expectSize - 1) {
-				CHECK(indexEntryKey(id).compare(mkv.key) == 0);
-			} else if (matchIndex == MATCH_INDEX_MATCHED_ONLY) {
-				CHECK(EMPTY.compare(mkv.key) == 0);
-			} else if (matchIndex == MATCH_INDEX_UNMATCHED_ONLY) {
-				CHECK(indexEntryKey(id).compare(mkv.key) == 0);
-			} else {
-				CHECK(EMPTY.compare(mkv.key) == 0);
-			}
-			CHECK(EMPTY.compare(mkv.value) == 0);
+			validate(result.mkvs[i], id, matchIndex, i, expectSize, allMissing, fetchLocalOnly);
+		}
+		break;
+	}
+}
+
+TEST_CASE("fdb_transaction_get_mapped_range_missing_all_secondary_old") {
+	const int TOTAL_RECORDS = 20;
+	fillInRecords(TOTAL_RECORDS);
+
+	fdb::Transaction tr(db);
+	// RYW should be enabled.
+	while (1) {
+		int beginId = 1;
+		int endId = 19;
+		int allMissing = true;
+		auto result = getMappedIndexEntries(beginId, endId, tr, allMissing);
+
+		if (result.err) {
+			fdb::EmptyFuture f1 = tr.on_error(result.err);
+			fdb_check(wait_future(f1));
+			continue;
+		}
+
+		int expectSize = endId - beginId;
+		CHECK(result.mkvs.size() == expectSize);
+		CHECK(!result.more);
+
+		int id = beginId;
+		for (int i = 0; i < expectSize; i++, id++) {
+			CHECK(indexEntryKey(id).compare(result.mkvs[i].key) == 0);
 		}
 		break;
 	}
@@ -1166,7 +1383,7 @@ TEST_CASE("fdb_transaction_get_mapped_range_missing_all_secondary") {
 TEST_CASE("fdb_transaction_get_mapped_range_restricted_to_serializable") {
 	std::string mapper = Tuple::makeTuple(prefix, RECORD, "{K[3]}"_sr).pack().toString();
 	fdb::Transaction tr(db);
-	auto result = get_mapped_range(
+	auto result = get_mapped_range_v2(
 	    tr,
 	    FDB_KEYSEL_FIRST_GREATER_OR_EQUAL((const uint8_t*)indexEntryKey(0).c_str(), indexEntryKey(0).size()),
 	    FDB_KEYSEL_FIRST_GREATER_THAN((const uint8_t*)indexEntryKey(1).c_str(), indexEntryKey(1).size()),
@@ -1176,9 +1393,10 @@ TEST_CASE("fdb_transaction_get_mapped_range_restricted_to_serializable") {
 	    /* target_bytes */ 0,
 	    /* FDBStreamingMode */ FDB_STREAMING_MODE_WANT_ALL,
 	    /* iteration */ 0,
-	    /* matchIndex */ MATCH_INDEX_ALL,
 	    /* snapshot */ true, // Set snapshot to true
-	    /* reverse */ 0);
+	    /* reverse */ 0,
+	    (const uint8_t*)mapper.c_str(),
+	    mapper.size());
 	ASSERT(result.err == error_code_unsupported_operation);
 }
 
@@ -1186,7 +1404,7 @@ TEST_CASE("fdb_transaction_get_mapped_range_restricted_to_ryw_enable") {
 	std::string mapper = Tuple::makeTuple(prefix, RECORD, "{K[3]}"_sr).pack().toString();
 	fdb::Transaction tr(db);
 	fdb_check(tr.set_option(FDB_TR_OPTION_READ_YOUR_WRITES_DISABLE, nullptr, 0)); // Not disable RYW
-	auto result = get_mapped_range(
+	auto result = get_mapped_range_v2(
 	    tr,
 	    FDB_KEYSEL_FIRST_GREATER_OR_EQUAL((const uint8_t*)indexEntryKey(0).c_str(), indexEntryKey(0).size()),
 	    FDB_KEYSEL_FIRST_GREATER_THAN((const uint8_t*)indexEntryKey(1).c_str(), indexEntryKey(1).size()),
@@ -1196,9 +1414,10 @@ TEST_CASE("fdb_transaction_get_mapped_range_restricted_to_ryw_enable") {
 	    /* target_bytes */ 0,
 	    /* FDBStreamingMode */ FDB_STREAMING_MODE_WANT_ALL,
 	    /* iteration */ 0,
-	    /* matchIndex */ MATCH_INDEX_ALL,
 	    /* snapshot */ false,
-	    /* reverse */ 0);
+	    /* reverse */ 0,
+	    (const uint8_t*)mapper.c_str(),
+	    mapper.size());
 	ASSERT(result.err == error_code_unsupported_operation);
 }
 
@@ -1225,7 +1444,7 @@ TEST_CASE("fdb_transaction_get_mapped_range_fail_on_mapper_not_tuple") {
 	};
 	assertNotTuple(mapper);
 	fdb::Transaction tr(db);
-	auto result = getMappedIndexEntries(1, 3, tr, mapper, MATCH_INDEX_ALL);
+	auto result = getMappedIndexEntriesInternal(1, 3, tr, mapper);
 	ASSERT(result.err == error_code_mapper_not_tuple);
 }
 

--- a/bindings/c/test/unit/unit_tests.cpp
+++ b/bindings/c/test/unit/unit_tests.cpp
@@ -42,15 +42,13 @@
 #include <rapidjson/document.h>
 #include "doctest.h"
 #include "fdbclient/Tuple.h"
+#include "fdbclient/MappedRange.h"
 
 #include "flow/config.h"
 #include "flow/DeterministicRandom.h"
 #include "flow/IRandom.h"
 
 #include "fdb_api.hpp"
-
-const int code_int = 1;
-const int code_bool = 2;
 
 void fdb_check(fdb_error_t e) {
 	if (e) {
@@ -1044,11 +1042,6 @@ static std::string recordValue(const int i, const int split) {
 	return Tuple::makeTuple(dataOfRecord(i), split).pack().toString();
 }
 
-static std::unordered_map<int, int> versionToPosMatchIndex = { std::make_pair(2, 1) };
-static std::unordered_map<int, int> versionToPosFetchLocalOnly = { std::make_pair(2, 6) };
-static std::unordered_map<int, int> versionToLength = { std::make_pair(2, 8) };
-static std::unordered_map<int, int> versionToPosLocal = { std::make_pair(2, 1) };
-
 const static int SPLIT_SIZE = 3;
 std::map<std::string, std::string> fillInRecords(int n) {
 	// Note: The user requested `prefix` should be added as the first element of the tuple that forms the key, rather
@@ -1096,7 +1089,7 @@ GetMappedRangeResultV2 getMappedIndexEntriesInternalV2(int beginId,
 	paramsBytes[0] = version; // API protocol version
 	int posMatchIndex = versionToPosMatchIndex[version];
 	int posFetchLocalOnly = versionToPosFetchLocalOnly[version];
-	paramsBytes[posMatchIndex] = code_int;
+	paramsBytes[posMatchIndex] = code_uint8;
 	paramsBytes[posMatchIndex + 1] = matchIndex; // little endian
 	paramsBytes[posFetchLocalOnly] = code_bool;
 	paramsBytes[posFetchLocalOnly + 1] = fetchLocalOnly;

--- a/bindings/java/CMakeLists.txt
+++ b/bindings/java/CMakeLists.txt
@@ -29,6 +29,7 @@ set(JAVA_BINDING_SRCS
   src/main/com/apple/foundationdb/DirectBufferIterator.java
   src/main/com/apple/foundationdb/RangeResultDirectBufferIterator.java
   src/main/com/apple/foundationdb/MappedRangeResultDirectBufferIterator.java
+  src/main/com/apple/foundationdb/MappedRangeResultDirectBufferIteratorV2.java
   src/main/com/apple/foundationdb/DirectBufferPool.java
   src/main/com/apple/foundationdb/FDB.java
   src/main/com/apple/foundationdb/FDBDatabase.java
@@ -42,12 +43,14 @@ set(JAVA_BINDING_SRCS
   src/main/com/apple/foundationdb/FutureResult.java
   src/main/com/apple/foundationdb/FutureResults.java
   src/main/com/apple/foundationdb/FutureMappedResults.java
+  src/main/com/apple/foundationdb/FutureMappedResultsV2.java
   src/main/com/apple/foundationdb/FutureStrings.java
   src/main/com/apple/foundationdb/FutureVoid.java
   src/main/com/apple/foundationdb/JNIUtil.java
   src/main/com/apple/foundationdb/KeySelector.java
   src/main/com/apple/foundationdb/KeyValue.java
   src/main/com/apple/foundationdb/MappedKeyValue.java
+  src/main/com/apple/foundationdb/MappedKeyValueV2.java
   src/main/com/apple/foundationdb/LocalityUtil.java
   src/main/com/apple/foundationdb/NativeFuture.java
   src/main/com/apple/foundationdb/NativeObjectWrapper.java
@@ -57,12 +60,15 @@ set(JAVA_BINDING_SRCS
   src/main/com/apple/foundationdb/Range.java
   src/main/com/apple/foundationdb/RangeQuery.java
   src/main/com/apple/foundationdb/MappedRangeQuery.java
+  src/main/com/apple/foundationdb/MappedRangeQueryV2.java
   src/main/com/apple/foundationdb/KeyArrayResult.java
   src/main/com/apple/foundationdb/KeyRangeArrayResult.java
   src/main/com/apple/foundationdb/RangeResult.java
   src/main/com/apple/foundationdb/MappedRangeResult.java
+  src/main/com/apple/foundationdb/MappedRangeResultV2.java
   src/main/com/apple/foundationdb/RangeResultInfo.java
   src/main/com/apple/foundationdb/MappedRangeResultInfo.java
+  src/main/com/apple/foundationdb/MappedRangeResultInfoV2.java
   src/main/com/apple/foundationdb/RangeResultSummary.java
   src/main/com/apple/foundationdb/ReadTransaction.java
   src/main/com/apple/foundationdb/ReadTransactionContext.java

--- a/bindings/java/fdbJNI.cpp
+++ b/bindings/java/fdbJNI.cpp
@@ -39,7 +39,6 @@
 #define FDB_API_VERSION 720
 
 #include <foundationdb/fdb_c.h>
-#include <iostream>
 
 #define JNI_NULL nullptr
 

--- a/bindings/java/fdbJNI.cpp
+++ b/bindings/java/fdbJNI.cpp
@@ -39,6 +39,7 @@
 #define FDB_API_VERSION 720
 
 #include <foundationdb/fdb_c.h>
+#include <iostream>
 
 #define JNI_NULL nullptr
 
@@ -55,7 +56,9 @@ static thread_local bool is_external = false;
 static jclass range_result_summary_class;
 static jclass range_result_class;
 static jclass mapped_range_result_class;
+static jclass mapped_range_result_class_v2;
 static jclass mapped_key_value_class;
+static jclass mapped_key_value_class_v2;
 static jclass string_class;
 static jclass key_array_result_class;
 static jclass keyrange_class;
@@ -65,9 +68,10 @@ static jmethodID keyrange_init;
 static jmethodID keyrange_array_result_init;
 static jmethodID range_result_init;
 static jmethodID mapped_range_result_init;
+static jmethodID mapped_range_result_init_v2;
 static jmethodID mapped_key_value_from_bytes;
+static jmethodID mapped_key_value_from_bytes_v2;
 static jmethodID range_result_summary_init;
-
 void detachIfExternalThread(void* ignore) {
 	if (is_external && g_thread_jenv != nullptr) {
 		g_thread_jenv = nullptr;
@@ -132,6 +136,39 @@ void throwRuntimeEx(JNIEnv* jenv, const char* message) {
 
 void throwParamNotNull(JNIEnv* jenv) {
 	throwNamedException(jenv, "java/lang/IllegalArgumentException", "Argument cannot be null");
+}
+
+bool getBytes(JNIEnv* jenv,
+              uint8_t*& barrBegin,
+              uint8_t*& barrEnd,
+              uint8_t*& barrMapper,
+              jbyteArray keyBeginBytes,
+              jbyteArray keyEndBytes,
+              jbyteArray mapperBytes) {
+	barrBegin = (uint8_t*)jenv->GetByteArrayElements(keyBeginBytes, JNI_NULL);
+	if (!barrBegin) {
+		if (!jenv->ExceptionOccurred())
+			throwRuntimeEx(jenv, "Error getting handle to native resources");
+		return false;
+	}
+
+	barrEnd = (uint8_t*)jenv->GetByteArrayElements(keyEndBytes, JNI_NULL);
+	if (!barrEnd) {
+		jenv->ReleaseByteArrayElements(keyBeginBytes, (jbyte*)barrBegin, JNI_ABORT);
+		if (!jenv->ExceptionOccurred())
+			throwRuntimeEx(jenv, "Error getting handle to native resources");
+		return false;
+	}
+
+	barrMapper = (uint8_t*)jenv->GetByteArrayElements(mapperBytes, JNI_NULL);
+	if (!barrMapper) {
+		jenv->ReleaseByteArrayElements(keyBeginBytes, (jbyte*)barrBegin, JNI_ABORT);
+		jenv->ReleaseByteArrayElements(keyEndBytes, (jbyte*)barrEnd, JNI_ABORT);
+		if (!jenv->ExceptionOccurred())
+			throwRuntimeEx(jenv, "Error getting handle to native resources");
+		return false;
+	}
+	return true;
 }
 
 #ifdef __cplusplus
@@ -682,6 +719,114 @@ JNIEXPORT jobject JNICALL Java_com_apple_foundationdb_FutureMappedResults_Future
 	}
 
 	jobject mrr = jenv->NewObject(mapped_range_result_class, mapped_range_result_init, mrr_values, (jboolean)more);
+	if (jenv->ExceptionOccurred())
+		return JNI_NULL;
+
+	return mrr;
+}
+
+JNIEXPORT jobject JNICALL Java_com_apple_foundationdb_FutureMappedResultsV2_Result_1get(JNIEnv* jenv,
+                                                                                        jobject,
+                                                                                        jlong future) {
+	if (!future) {
+		throwParamNotNull(jenv);
+		return JNI_NULL;
+	}
+
+	FDBFuture* f = (FDBFuture*)future;
+
+	const FDBMappedKeyValueV2* kvms;
+	int count;
+	fdb_bool_t more;
+	fdb_error_t err = fdb_future_get_mappedkeyvalue_array_v2(f, &kvms, &count, &more);
+	if (err) {
+		safeThrow(jenv, getThrowable(jenv, err));
+		return JNI_NULL;
+	}
+
+	jobjectArray mrr_values = jenv->NewObjectArray(count, mapped_key_value_class_v2, NULL);
+	if (!mrr_values) {
+		if (!jenv->ExceptionOccurred())
+			throwOutOfMem(jenv);
+		return JNI_NULL;
+	}
+
+	for (int i = 0; i < count; i++) {
+		FDBMappedKeyValueV2 kvm = kvms[i];
+		int kvm_count = kvm.getRange.m_size;
+
+		// now it has 4 field, key, value, getRange.begin, getRange.end
+		// this needs to change if FDBMappedKeyValue definition is changed.
+		const int totalFieldFDBMappedKeyValue = 5;
+
+		const int totalLengths = totalFieldFDBMappedKeyValue + kvm_count * 2;
+
+		int totalBytes = kvm.key.key_length + kvm.value.key_length + kvm.responseBytes.key_length +
+		                 kvm.getRange.begin.key.key_length + kvm.getRange.end.key.key_length;
+		for (int i = 0; i < kvm_count; i++) {
+			auto kv = kvm.getRange.data[i];
+			totalBytes += kv.key_length + kv.value_length;
+		}
+
+		jbyteArray bytesArray = jenv->NewByteArray(totalBytes);
+		if (!bytesArray) {
+			if (!jenv->ExceptionOccurred())
+				throwOutOfMem(jenv);
+			return JNI_NULL;
+		}
+
+		jintArray lengthArray = jenv->NewIntArray(totalLengths);
+		if (!lengthArray) {
+			if (!jenv->ExceptionOccurred())
+				throwOutOfMem(jenv);
+			return JNI_NULL;
+		}
+
+		uint8_t* bytes_barr = (uint8_t*)jenv->GetByteArrayElements(bytesArray, JNI_NULL);
+		if (!bytes_barr) {
+			throwRuntimeEx(jenv, "Error getting handle to native resources");
+			return JNI_NULL;
+		}
+		{
+			ExecuteOnLeave e([&]() { jenv->ReleaseByteArrayElements(bytesArray, (jbyte*)bytes_barr, 0); });
+
+			jint* length_barr = jenv->GetIntArrayElements(lengthArray, JNI_NULL);
+			if (!length_barr) {
+				if (!jenv->ExceptionOccurred())
+					throwOutOfMem(jenv);
+				return JNI_NULL;
+			}
+			{
+				ExecuteOnLeave e([&]() { jenv->ReleaseIntArrayElements(lengthArray, length_barr, 0); });
+
+				uint8_t* pByte = bytes_barr;
+				jint* pLength = length_barr;
+
+				cpBytesAndLength(pByte, pLength, kvm.key);
+				cpBytesAndLength(pByte, pLength, kvm.value);
+				cpBytesAndLength(pByte, pLength, kvm.responseBytes);
+				cpBytesAndLength(pByte, pLength, kvm.getRange.begin.key);
+				cpBytesAndLength(pByte, pLength, kvm.getRange.end.key);
+				for (int kvm_i = 0; kvm_i < kvm_count; kvm_i++) {
+					auto kv = kvm.getRange.data[kvm_i];
+					cpBytesAndLengthInner(pByte, pLength, kv.key, kv.key_length);
+					cpBytesAndLengthInner(pByte, pLength, kv.value, kv.value_length);
+				}
+			}
+		}
+		// After native arrays are released
+		// call public static method MappedKeyValueV2::fromBytes()
+		jobject mkv = jenv->CallStaticObjectMethod(
+		    mapped_key_value_class_v2, mapped_key_value_from_bytes_v2, (jbyteArray)bytesArray, (jintArray)lengthArray);
+		if (jenv->ExceptionOccurred())
+			return JNI_NULL;
+		jenv->SetObjectArrayElement(mrr_values, i, mkv);
+		if (jenv->ExceptionOccurred())
+			return JNI_NULL;
+	}
+
+	jobject mrr =
+	    jenv->NewObject(mapped_range_result_class_v2, mapped_range_result_init_v2, mrr_values, (jboolean)more);
 	if (jenv->ExceptionOccurred())
 		return JNI_NULL;
 
@@ -1452,60 +1597,108 @@ JNIEXPORT jlong JNICALL Java_com_apple_foundationdb_FDBTransaction_Transaction_1
                                                                                                jint targetBytes,
                                                                                                jint streamingMode,
                                                                                                jint iteration,
-                                                                                               jint matchIndex,
                                                                                                jboolean snapshot,
                                                                                                jboolean reverse) {
 	if (!tPtr || !keyBeginBytes || !keyEndBytes || !mapperBytes) {
 		throwParamNotNull(jenv);
 		return 0;
 	}
+
+	uint8_t* barrBegin;
+	uint8_t* barrEnd;
+	uint8_t* barrMapper;
+	if (!getBytes(jenv, barrBegin, barrEnd, barrMapper, keyBeginBytes, keyEndBytes, mapperBytes)) {
+		return 0;
+	}
+	FDBFuture* f;
 	FDBTransaction* tr = (FDBTransaction*)tPtr;
+	f = fdb_transaction_get_mapped_range(tr,
+	                                     barrBegin,
+	                                     jenv->GetArrayLength(keyBeginBytes),
+	                                     orEqualBegin,
+	                                     offsetBegin,
+	                                     barrEnd,
+	                                     jenv->GetArrayLength(keyEndBytes),
+	                                     orEqualEnd,
+	                                     offsetEnd,
+	                                     barrMapper,
+	                                     jenv->GetArrayLength(mapperBytes),
+	                                     rowLimit,
+	                                     targetBytes,
+	                                     (FDBStreamingMode)streamingMode,
+	                                     iteration,
+	                                     snapshot,
+	                                     reverse);
 
-	uint8_t* barrBegin = (uint8_t*)jenv->GetByteArrayElements(keyBeginBytes, JNI_NULL);
-	if (!barrBegin) {
-		if (!jenv->ExceptionOccurred())
-			throwRuntimeEx(jenv, "Error getting handle to native resources");
-		return 0;
-	}
-
-	uint8_t* barrEnd = (uint8_t*)jenv->GetByteArrayElements(keyEndBytes, JNI_NULL);
-	if (!barrEnd) {
-		jenv->ReleaseByteArrayElements(keyBeginBytes, (jbyte*)barrBegin, JNI_ABORT);
-		if (!jenv->ExceptionOccurred())
-			throwRuntimeEx(jenv, "Error getting handle to native resources");
-		return 0;
-	}
-
-	uint8_t* barrMapper = (uint8_t*)jenv->GetByteArrayElements(mapperBytes, JNI_NULL);
-	if (!barrMapper) {
-		jenv->ReleaseByteArrayElements(keyBeginBytes, (jbyte*)barrBegin, JNI_ABORT);
-		jenv->ReleaseByteArrayElements(keyEndBytes, (jbyte*)barrEnd, JNI_ABORT);
-		if (!jenv->ExceptionOccurred())
-			throwRuntimeEx(jenv, "Error getting handle to native resources");
-		return 0;
-	}
-
-	FDBFuture* f = fdb_transaction_get_mapped_range(tr,
-	                                                barrBegin,
-	                                                jenv->GetArrayLength(keyBeginBytes),
-	                                                orEqualBegin,
-	                                                offsetBegin,
-	                                                barrEnd,
-	                                                jenv->GetArrayLength(keyEndBytes),
-	                                                orEqualEnd,
-	                                                offsetEnd,
-	                                                barrMapper,
-	                                                jenv->GetArrayLength(mapperBytes),
-	                                                rowLimit,
-	                                                targetBytes,
-	                                                (FDBStreamingMode)streamingMode,
-	                                                iteration,
-	                                                matchIndex,
-	                                                snapshot,
-	                                                reverse);
 	jenv->ReleaseByteArrayElements(keyBeginBytes, (jbyte*)barrBegin, JNI_ABORT);
 	jenv->ReleaseByteArrayElements(keyEndBytes, (jbyte*)barrEnd, JNI_ABORT);
 	jenv->ReleaseByteArrayElements(mapperBytes, (jbyte*)barrMapper, JNI_ABORT);
+	return (jlong)f;
+}
+
+JNIEXPORT jlong JNICALL
+Java_com_apple_foundationdb_FDBTransaction_Transaction_1getMappedRangeV2(JNIEnv* jenv,
+                                                                         jobject,
+                                                                         jlong tPtr,
+                                                                         jbyteArray keyBeginBytes,
+                                                                         jboolean orEqualBegin,
+                                                                         jint offsetBegin,
+                                                                         jbyteArray keyEndBytes,
+                                                                         jboolean orEqualEnd,
+                                                                         jint offsetEnd,
+                                                                         jbyteArray mapperBytes,
+                                                                         jint rowLimit,
+                                                                         jint targetBytes,
+                                                                         jint streamingMode,
+                                                                         jint iteration,
+                                                                         jboolean snapshot,
+                                                                         jboolean reverse,
+                                                                         jbyteArray mappedRangeParams) {
+	if (!tPtr || !keyBeginBytes || !keyEndBytes || !mapperBytes || !mappedRangeParams) {
+		throwParamNotNull(jenv);
+		return 0;
+	}
+
+	uint8_t* barrBegin;
+	uint8_t* barrEnd;
+	uint8_t* barrMapper;
+	uint8_t* barrParamsBytes;
+	if (!getBytes(jenv, barrBegin, barrEnd, barrMapper, keyBeginBytes, keyEndBytes, mapperBytes)) {
+		return 0;
+	}
+	barrParamsBytes = (uint8_t*)jenv->GetByteArrayElements(mappedRangeParams, JNI_NULL);
+	if (!barrParamsBytes) {
+		if (!jenv->ExceptionOccurred())
+			throwRuntimeEx(jenv, "Error getting handle to native resources");
+		return false;
+	}
+
+	FDBFuture* f;
+	FDBTransaction* tr = (FDBTransaction*)tPtr;
+	f = fdb_transaction_get_mapped_range_v2(tr,
+	                                        barrBegin,
+	                                        jenv->GetArrayLength(keyBeginBytes),
+	                                        orEqualBegin,
+	                                        offsetBegin,
+	                                        barrEnd,
+	                                        jenv->GetArrayLength(keyEndBytes),
+	                                        orEqualEnd,
+	                                        offsetEnd,
+	                                        barrMapper,
+	                                        jenv->GetArrayLength(mapperBytes),
+	                                        rowLimit,
+	                                        targetBytes,
+	                                        (FDBStreamingMode)streamingMode,
+	                                        iteration,
+	                                        snapshot,
+	                                        reverse,
+	                                        barrParamsBytes,
+	                                        jenv->GetArrayLength(mappedRangeParams));
+	// TODO: release mappedRangeParams here
+	jenv->ReleaseByteArrayElements(keyBeginBytes, (jbyte*)barrBegin, JNI_ABORT);
+	jenv->ReleaseByteArrayElements(keyEndBytes, (jbyte*)barrEnd, JNI_ABORT);
+	jenv->ReleaseByteArrayElements(mapperBytes, (jbyte*)barrMapper, JNI_ABORT);
+	jenv->ReleaseByteArrayElements(mappedRangeParams, (jbyte*)barrParamsBytes, JNI_ABORT);
 	return (jlong)f;
 }
 
@@ -1644,6 +1837,82 @@ Java_com_apple_foundationdb_FutureMappedResults_FutureMappedResults_1getDirect(J
 		const FDBMappedKeyValue& kvm = kvms[i];
 		memcpyString(buffer, offset, kvm.key);
 		memcpyString(buffer, offset, kvm.value);
+		memcpyString(buffer, offset, kvm.getRange.begin.key);
+		memcpyString(buffer, offset, kvm.getRange.end.key);
+
+		int kvm_count = kvm.getRange.m_size;
+		memcpy(buffer + offset, &kvm_count, sizeof(jint));
+		offset += sizeof(jint);
+
+		for (int i = 0; i < kvm_count; i++) {
+			auto kv = kvm.getRange.data[i];
+			memcpyStringInner(buffer, offset, kv.key, kv.key_length);
+			memcpyStringInner(buffer, offset, kv.value, kv.value_length);
+		}
+	}
+}
+
+// TODO: test this
+JNIEXPORT void JNICALL Java_com_apple_foundationdb_FutureMappedResultsV2_Result_1getDirect(JNIEnv* jenv,
+                                                                                           jobject,
+                                                                                           jlong future,
+                                                                                           jobject jbuffer,
+                                                                                           jint bufferCapacity) {
+
+	if (!future) {
+		throwParamNotNull(jenv);
+		return;
+	}
+
+	uint8_t* buffer = (uint8_t*)jenv->GetDirectBufferAddress(jbuffer);
+	if (!buffer) {
+		if (!jenv->ExceptionOccurred())
+			throwRuntimeEx(jenv, "Error getting handle to native resources");
+		return;
+	}
+
+	FDBFuture* f = (FDBFuture*)future;
+	const FDBMappedKeyValueV2* kvms;
+	int count;
+	fdb_bool_t more;
+	fdb_error_t err = fdb_future_get_mappedkeyvalue_array_v2(f, &kvms, &count, &more);
+	if (err) {
+		safeThrow(jenv, getThrowable(jenv, err));
+		return;
+	}
+
+	int totalCapacityNeeded = 2 * sizeof(jint);
+	for (int i = 0; i < count; i++) {
+		const FDBMappedKeyValueV2& kvm = kvms[i];
+		totalCapacityNeeded += kvm.key.key_length + kvm.value.key_length + kvm.getRange.begin.key.key_length +
+		                       kvm.getRange.end.key.key_length + kvm.responseBytes.key_length +
+		                       6 * sizeof(jint); // Besides the 5 lengths above, also one for kvm_count.
+		int kvm_count = kvm.getRange.m_size;
+		for (int i = 0; i < kvm_count; i++) {
+			auto kv = kvm.getRange.data[i];
+			totalCapacityNeeded += kv.key_length + kv.value_length + 2 * sizeof(jint);
+		}
+		if (bufferCapacity < totalCapacityNeeded) {
+			count = i; /* Only fit first `i` K/V pairs */
+			more = true;
+			break;
+		}
+	}
+
+	int offset = 0;
+
+	// First copy RangeResultSummary, i.e. [keyCount, more]
+	memcpy(buffer + offset, &count, sizeof(jint));
+	offset += sizeof(jint);
+
+	memcpy(buffer + offset, &more, sizeof(jint));
+	offset += sizeof(jint);
+
+	for (int i = 0; i < count; i++) {
+		const FDBMappedKeyValueV2& kvm = kvms[i];
+		memcpyString(buffer, offset, kvm.key);
+		memcpyString(buffer, offset, kvm.value);
+		memcpyString(buffer, offset, kvm.responseBytes);
 		memcpyString(buffer, offset, kvm.getRange.begin.key);
 		memcpyString(buffer, offset, kvm.getRange.end.key);
 
@@ -2193,10 +2462,20 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved) {
 		    env->GetMethodID(local_mapped_range_result_class, "<init>", "([Lcom/apple/foundationdb/MappedKeyValue;Z)V");
 		mapped_range_result_class = (jclass)(env)->NewGlobalRef(local_mapped_range_result_class);
 
+		jclass local_mapped_range_result_class_v2 = env->FindClass("com/apple/foundationdb/MappedRangeResultV2");
+		mapped_range_result_init_v2 = env->GetMethodID(
+		    local_mapped_range_result_class_v2, "<init>", "([Lcom/apple/foundationdb/MappedKeyValueV2;Z)V");
+		mapped_range_result_class_v2 = (jclass)(env)->NewGlobalRef(local_mapped_range_result_class_v2);
+
 		jclass local_mapped_key_value_class = env->FindClass("com/apple/foundationdb/MappedKeyValue");
 		mapped_key_value_from_bytes = env->GetStaticMethodID(
 		    local_mapped_key_value_class, "fromBytes", "([B[I)Lcom/apple/foundationdb/MappedKeyValue;");
 		mapped_key_value_class = (jclass)(env)->NewGlobalRef(local_mapped_key_value_class);
+
+		jclass local_mapped_key_value_class_v2 = env->FindClass("com/apple/foundationdb/MappedKeyValueV2");
+		mapped_key_value_from_bytes_v2 = env->GetStaticMethodID(
+		    local_mapped_key_value_class_v2, "fromBytes", "([B[I)Lcom/apple/foundationdb/MappedKeyValueV2;");
+		mapped_key_value_class_v2 = (jclass)(env)->NewGlobalRef(local_mapped_key_value_class_v2);
 
 		jclass local_key_array_result_class = env->FindClass("com/apple/foundationdb/KeyArrayResult");
 		key_array_result_init = env->GetMethodID(local_key_array_result_class, "<init>", "([B[I)V");
@@ -2244,8 +2523,14 @@ void JNI_OnUnload(JavaVM* vm, void* reserved) {
 		if (mapped_range_result_class != JNI_NULL) {
 			env->DeleteGlobalRef(mapped_range_result_class);
 		}
+		if (mapped_range_result_class_v2 != JNI_NULL) {
+			env->DeleteGlobalRef(mapped_range_result_class_v2);
+		}
 		if (mapped_key_value_class != JNI_NULL) {
 			env->DeleteGlobalRef(mapped_key_value_class);
+		}
+		if (mapped_key_value_class_v2 != JNI_NULL) {
+			env->DeleteGlobalRef(mapped_key_value_class_v2);
 		}
 		if (string_class != JNI_NULL) {
 			env->DeleteGlobalRef(string_class);

--- a/bindings/java/src/integration/com/apple/foundationdb/MappedRangeQueryIntegrationTest.java
+++ b/bindings/java/src/integration/com/apple/foundationdb/MappedRangeQueryIntegrationTest.java
@@ -60,31 +60,48 @@ class MappedRangeQueryIntegrationTest {
 		}
 	}
 
-	static private final byte[] EMPTY = Tuple.from().pack();
-	static private final String PREFIX = "prefix";
-	static private final String RECORD = "RECORD";
-	static private final String INDEX = "INDEX";
-	static private String primaryKey(int i) { return String.format("primary-key-of-record-%08d", i); }
-	static private String indexKey(int i) { return String.format("index-key-of-record-%08d", i); }
-	static private String dataOfRecord(int i) { return String.format("data-of-record-%08d", i); }
+	private static final byte[] EMPTY = Tuple.from().pack();
+	private static final String PREFIX = "prefix";
+	private static final String RECORD = "RECORD";
+	private static final String INDEX = "INDEX";
+	private static final String NOTFOUND = "NOT_FOUND";
+	private static String primaryKey(int i) { return String.format("primary-key-of-record-%08d", i); }
+	private static String indexKey(int i) { return String.format("index-key-of-record-%08d", i); }
+	private static String dataOfRecord(int i) { return String.format("data-of-record-%08d", i); }
 
 	static byte[] MAPPER = Tuple.from(PREFIX, RECORD, "{K[3]}", "{...}").pack();
+	static byte[] MAPPER_ALL_MISSING = Tuple.from(PREFIX, NOTFOUND, "{K[3]}", "{...}").pack();
+
 	static int SPLIT_SIZE = 3;
 
-	static private byte[] indexEntryKey(final int i) {
+	private static byte[] notFoundMapperEntryKey(final int i) {
+		return Tuple.from(PREFIX, NOTFOUND, primaryKey(i)).pack();
+	}
+	private static byte[] indexEntryKey(final int i) {
 		return Tuple.from(PREFIX, INDEX, indexKey(i), primaryKey(i)).pack();
 	}
-	static private byte[] recordKeyPrefix(final int i) {
-		return Tuple.from(PREFIX, RECORD, primaryKey(i)).pack();
-	}
-	static private byte[] recordKey(final int i, final int split) {
+	private static byte[] recordKeyPrefix(final int i) { return Tuple.from(PREFIX, RECORD, primaryKey(i)).pack(); }
+	private static byte[] recordKey(final int i, final int split) {
 		return Tuple.from(PREFIX, RECORD, primaryKey(i), split).pack();
 	}
-	static private byte[] recordValue(final int i, final int split) {
+	private static byte[] recordValue(final int i, final int split) {
 		return Tuple.from(dataOfRecord(i), split).pack();
 	}
 
-	static private void insertRecordWithIndex(final Transaction tr, final int i) {
+	private static int getRandomMatchIndex() {
+		double r = Math.random();
+		if (r < 0.25) {
+			return Transaction.MATCH_INDEX_ALL;
+		} else if (r < 0.5) {
+			return Transaction.MATCH_INDEX_NONE;
+		} else if (r < 0.75) {
+			return Transaction.MATCH_INDEX_MATCHED_ONLY;
+		} else {
+			return Transaction.MATCH_INDEX_UNMATCHED_ONLY;
+		}
+	}
+
+	private static void insertRecordWithIndex(final Transaction tr, final int i) {
 		tr.set(indexEntryKey(i), EMPTY);
 		for (int split = 0; split < SPLIT_SIZE; split++) {
 			tr.set(recordKey(i, split), recordValue(i, split));
@@ -116,6 +133,7 @@ class MappedRangeQueryIntegrationTest {
 			insertRecordsWithIndexes(numRecords, db);
 			instrument(rangeQueryAndThenRangeQueries, "rangeQueryAndThenRangeQueries", db);
 			instrument(mappedRangeQuery, "mappedRangeQuery", db);
+			instrument(mappedRangeQueryV2, "mappedRangeQueryV2", db);
 		}
 	}
 
@@ -131,8 +149,8 @@ class MappedRangeQueryIntegrationTest {
 		                  numQueries * 1000L / time);
 	}
 
-	static private final int RECORDS_PER_TXN = 100;
-	static private void insertRecordsWithIndexes(int n, Database db) {
+	private static final int RECORDS_PER_TXN = 100;
+	private static void insertRecordsWithIndexes(int n, Database db) {
 		int i = 0;
 		while (i < n) {
 			int begin = i;
@@ -180,7 +198,7 @@ class MappedRangeQueryIntegrationTest {
 
 					Assertions.assertTrue(records.hasNext());
 					List<KeyValue> rangeResult = records.next().get();
-					validateRangeResult(id, rangeResult);
+					validateRangeResult(id, rangeResult, false);
 				}
 				Assertions.assertFalse(indexes.hasNext());
 				Assertions.assertFalse(records.hasNext());
@@ -191,14 +209,65 @@ class MappedRangeQueryIntegrationTest {
 		return null;
 	});
 
+	RangeQueryWithIndex mappedRangeQueryV2 = (int begin, int end, Database db) -> db.run(tr -> {
+		try {
+			int matchIndex = getRandomMatchIndex();
+			boolean fetchLocalOnly = Math.random() < 0.5;
+			boolean missing = Math.random() < 0.5;
+			byte[] m = missing ? MAPPER_ALL_MISSING : MAPPER;
+			List<MappedKeyValueV2> kvs = tr.getMappedRangeV2(KeySelector.firstGreaterOrEqual(indexEntryKey(begin)),
+			                                                 KeySelector.firstGreaterOrEqual(indexEntryKey(end)), m,
+			                                                 ReadTransaction.ROW_LIMIT_UNLIMITED, false,
+			                                                 StreamingMode.WANT_ALL, matchIndex, fetchLocalOnly)
+			                                 .asList()
+			                                 .get();
+			Assertions.assertEquals(end - begin, kvs.size());
+			// assuming "local" is always true in the reply
+			byte[] expectResponseBytes = new byte[] { 0x02, 0x02, 0x01 };
+
+			if (validate) {
+				final Iterator<MappedKeyValueV2> results = kvs.iterator();
+				for (int id = begin; id < end; id++) {
+					Assertions.assertTrue(results.hasNext());
+					MappedKeyValueV2 mappedKeyValue = results.next();
+					if (matchIndex == Transaction.MATCH_INDEX_ALL || id == begin || id == end - 1) {
+						assertByteArrayEquals(indexEntryKey(id), mappedKeyValue.getKey());
+					} else if (matchIndex == Transaction.MATCH_INDEX_MATCHED_ONLY) {
+						assertByteArrayEquals(missing ? EMPTY : indexEntryKey(id), mappedKeyValue.getKey());
+					} else if (matchIndex == Transaction.MATCH_INDEX_UNMATCHED_ONLY) {
+						assertByteArrayEquals(missing ? indexEntryKey(id) : EMPTY, mappedKeyValue.getKey());
+					} else {
+						assertByteArrayEquals(EMPTY, mappedKeyValue.getKey());
+					}
+					assertByteArrayEquals(EMPTY, mappedKeyValue.getValue());
+					byte[] prefix = missing ? notFoundMapperEntryKey(id) : recordKeyPrefix(id);
+					assertByteArrayEquals(prefix, mappedKeyValue.getRangeBegin());
+					prefix[prefix.length - 1] = (byte)0x01;
+					assertByteArrayEquals(prefix, mappedKeyValue.getRangeEnd());
+
+					List<KeyValue> rangeResult = mappedKeyValue.getRangeResult();
+					validateRangeResult(id, rangeResult, missing);
+
+					byte[] responseBytes = mappedKeyValue.getResponseBytes();
+					assertByteArrayEquals(expectResponseBytes, responseBytes);
+				}
+				Assertions.assertFalse(results.hasNext());
+			}
+		} catch (Exception e) {
+			Assertions.fail("Unexpected exception", e);
+		}
+		return null;
+	});
+
 	RangeQueryWithIndex mappedRangeQuery = (int begin, int end, Database db) -> db.run(tr -> {
 		try {
-			List<MappedKeyValue> kvs = tr.getMappedRange(KeySelector.firstGreaterOrEqual(indexEntryKey(begin)),
-			                                             KeySelector.firstGreaterOrEqual(indexEntryKey(end)), MAPPER,
-			                                             ReadTransaction.ROW_LIMIT_UNLIMITED,
-			                                             FDBTransaction.MATCH_INDEX_ALL, false, StreamingMode.WANT_ALL)
-			                               .asList()
-			                               .get();
+
+			List<MappedKeyValue> kvs =
+			    tr.getMappedRange(KeySelector.firstGreaterOrEqual(indexEntryKey(begin)),
+			                      KeySelector.firstGreaterOrEqual(indexEntryKey(end)), MAPPER,
+			                      ReadTransaction.ROW_LIMIT_UNLIMITED, false, StreamingMode.WANT_ALL)
+			        .asList()
+			        .get();
 			Assertions.assertEquals(end - begin, kvs.size());
 
 			if (validate) {
@@ -215,7 +284,7 @@ class MappedRangeQueryIntegrationTest {
 					assertByteArrayEquals(prefix, mappedKeyValue.getRangeEnd());
 
 					List<KeyValue> rangeResult = mappedKeyValue.getRangeResult();
-					validateRangeResult(id, rangeResult);
+					validateRangeResult(id, rangeResult, false);
 				}
 				Assertions.assertFalse(results.hasNext());
 			}
@@ -225,7 +294,11 @@ class MappedRangeQueryIntegrationTest {
 		return null;
 	});
 
-	void validateRangeResult(int id, List<KeyValue> rangeResult) {
+	void validateRangeResult(int id, List<KeyValue> rangeResult, boolean missing) {
+		if (missing) {
+			Assertions.assertEquals(rangeResult.size(), 0);
+			return;
+		}
 		Assertions.assertEquals(rangeResult.size(), SPLIT_SIZE);
 		for (int split = 0; split < SPLIT_SIZE; split++) {
 			KeyValue keyValue = rangeResult.get(split);

--- a/bindings/java/src/main/com/apple/foundationdb/FDBTransaction.java
+++ b/bindings/java/src/main/com/apple/foundationdb/FDBTransaction.java
@@ -33,11 +33,6 @@ import com.apple.foundationdb.tuple.ByteArrayUtil;
 
 class FDBTransaction extends NativeObjectWrapper implements Transaction, OptionConsumer {
 
-	static public final int MATCH_INDEX_ALL = 0;
-	static public final int MATCH_INDEX_NONE = 1;
-	static public final int MATCH_INDEX_MATCHED_ONLY = 2;
-	static public final int MATCH_INDEX_UNMATCHED_ONLY = 3;
-
 	private final Database database;
 	private final Executor executor;
 	private final TransactionOptions options;
@@ -104,8 +99,15 @@ class FDBTransaction extends NativeObjectWrapper implements Transaction, OptionC
 
 		@Override
 		public AsyncIterable<MappedKeyValue> getMappedRange(KeySelector begin, KeySelector end, byte[] mapper,
-		                                                    int limit, int matchIndex, boolean reverse,
-		                                                    StreamingMode mode) {
+		                                                    int limit, boolean reverse, StreamingMode mode) {
+
+			throw new UnsupportedOperationException("getMappedRange is only supported in serializable");
+		}
+
+		@Override
+		public AsyncIterable<MappedKeyValueV2> getMappedRangeV2(KeySelector begin, KeySelector end, byte[] mapper,
+		                                                        int limit, boolean reverse, StreamingMode mode,
+		                                                        int matchIndex, boolean fetchLocalOnly) {
 
 			throw new UnsupportedOperationException("getMappedRange is only supported in serializable");
 		}
@@ -369,12 +371,22 @@ class FDBTransaction extends NativeObjectWrapper implements Transaction, OptionC
 
 	@Override
 	public AsyncIterable<MappedKeyValue> getMappedRange(KeySelector begin, KeySelector end, byte[] mapper, int limit,
-	                                                    int matchIndex, boolean reverse, StreamingMode mode) {
+	                                                    boolean reverse, StreamingMode mode) {
 		if (mapper == null) {
 			throw new IllegalArgumentException("Mapper must be non-null");
 		}
-		return new MappedRangeQuery(FDBTransaction.this, false, begin, end, mapper, limit, matchIndex, reverse, mode,
-		                            eventKeeper);
+		return new MappedRangeQuery(FDBTransaction.this, false, begin, end, mapper, limit, reverse, mode, eventKeeper);
+	}
+
+	@Override
+	public AsyncIterable<MappedKeyValueV2> getMappedRangeV2(KeySelector begin, KeySelector end, byte[] mapper,
+	                                                        int limit, boolean reverse, StreamingMode mode,
+	                                                        int matchIndex, boolean fetchLocalOnly) {
+		if (mapper == null) {
+			throw new IllegalArgumentException("Mapper must be non-null");
+		}
+		return new MappedRangeQueryV2(FDBTransaction.this, false, begin, end, mapper, limit, matchIndex, fetchLocalOnly,
+		                              reverse, mode, eventKeeper);
 	}
 
 	///////////////////
@@ -479,8 +491,7 @@ class FDBTransaction extends NativeObjectWrapper implements Transaction, OptionC
 	protected FutureMappedResults getMappedRange_internal(KeySelector begin, KeySelector end,
 	                                                      byte[] mapper, // Nullable
 	                                                      int rowLimit, int targetBytes, int streamingMode,
-	                                                      int iteration, boolean isSnapshot, boolean reverse,
-	                                                      int matchIndex) {
+	                                                      int iteration, boolean isSnapshot, boolean reverse) {
 		if (eventKeeper != null) {
 			eventKeeper.increment(Events.JNI_CALL);
 		}
@@ -490,10 +501,35 @@ class FDBTransaction extends NativeObjectWrapper implements Transaction, OptionC
 			        " -- range get: (%s, %s) limit: %d, bytes: %d, mode: %d, iteration: %d, snap: %s, reverse %s",
 			    begin.toString(), end.toString(), rowLimit, targetBytes, streamingMode,
 			    iteration, Boolean.toString(isSnapshot), Boolean.toString(reverse)));*/
-			return new FutureMappedResults(
-			    Transaction_getMappedRange(getPtr(), begin.getKey(), begin.orEqual(), begin.getOffset(), end.getKey(),
-			                               end.orEqual(), end.getOffset(), mapper, rowLimit, targetBytes, streamingMode,
-			                               iteration, matchIndex, isSnapshot, reverse),
+			return new FutureMappedResults(Transaction_getMappedRange(getPtr(), begin.getKey(), begin.orEqual(),
+			                                                          begin.getOffset(), end.getKey(), end.orEqual(),
+			                                                          end.getOffset(), mapper, rowLimit, targetBytes,
+			                                                          streamingMode, iteration, isSnapshot, reverse),
+			                               FDB.instance().isDirectBufferQueriesEnabled(), executor, eventKeeper);
+
+		} finally {
+			pointerReadLock.unlock();
+		}
+	}
+
+	protected FutureMappedResultsV2 getMappedRange_internal_v2(KeySelector begin, KeySelector end,
+	                                                           byte[] mapper, // Nullable
+	                                                           byte[] paramsBytes, int rowLimit, int targetBytes,
+	                                                           int streamingMode, int iteration, boolean isSnapshot,
+	                                                           boolean reverse) {
+		if (eventKeeper != null) {
+			eventKeeper.increment(Events.JNI_CALL);
+		}
+		pointerReadLock.lock();
+		try {
+			/*System.out.println(String.format(
+			" -- range get: (%s, %s) limit: %d, bytes: %d, mode: %d, iteration: %d, snap: %s, reverse %s",
+			begin.toString(), end.toString(), rowLimit, targetBytes, streamingMode,
+			iteration, Boolean.toString(isSnapshot), Boolean.toString(reverse)));*/
+			return new FutureMappedResultsV2(
+			    Transaction_getMappedRangeV2(getPtr(), begin.getKey(), begin.orEqual(), begin.getOffset(), end.getKey(),
+			                                 end.orEqual(), end.getOffset(), mapper, rowLimit, targetBytes,
+			                                 streamingMode, iteration, isSnapshot, reverse, paramsBytes),
 			    FDB.instance().isDirectBufferQueriesEnabled(), executor, eventKeeper);
 		} finally {
 			pointerReadLock.unlock();
@@ -837,7 +873,12 @@ class FDBTransaction extends NativeObjectWrapper implements Transaction, OptionC
 	                                               byte[] keyEnd, boolean orEqualEnd, int offsetEnd,
 	                                               byte[] mapper, // Nonnull
 	                                               int rowLimit, int targetBytes, int streamingMode, int iteration,
-	                                               int matchIndex, boolean isSnapshot, boolean reverse);
+	                                               boolean isSnapshot, boolean reverse);
+	private native long Transaction_getMappedRangeV2(long cPtr, byte[] keyBegin, boolean orEqualBegin, int offsetBegin,
+	                                                 byte[] keyEnd, boolean orEqualEnd, int offsetEnd,
+	                                                 byte[] mapper, // Nonnull
+	                                                 int rowLimit, int targetBytes, int streamingMode, int iteration,
+	                                                 boolean isSnapshot, boolean reverse, byte[] paramsBytes);
 	private native void Transaction_addConflictRange(long cPtr,
 			byte[] keyBegin, byte[] keyEnd, int conflictRangeType);
 	private native void Transaction_set(long cPtr, byte[] key, byte[] value);

--- a/bindings/java/src/main/com/apple/foundationdb/FutureMappedResultsV2.java
+++ b/bindings/java/src/main/com/apple/foundationdb/FutureMappedResultsV2.java
@@ -1,0 +1,86 @@
+/*
+ * FutureMappedResultsV2.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.Executor;
+
+import com.apple.foundationdb.EventKeeper.Events;
+
+class FutureMappedResultsV2 extends NativeFuture<MappedRangeResultInfoV2> {
+	private final EventKeeper eventKeeper;
+	FutureMappedResultsV2(long cPtr, boolean enableDirectBufferQueries, Executor executor, EventKeeper eventKeeper) {
+		super(cPtr);
+		registerMarshalCallback(executor);
+		this.enableDirectBufferQueries = enableDirectBufferQueries;
+		this.eventKeeper = eventKeeper;
+	}
+
+	@Override
+	protected void postMarshal(MappedRangeResultInfoV2 rri) {
+		// We can't close because this class actually marshals on-demand
+	}
+
+	@Override
+	protected MappedRangeResultInfoV2 getIfDone_internal(long cPtr) throws FDBException {
+		if (eventKeeper != null) {
+			eventKeeper.increment(Events.JNI_CALL);
+		}
+		FDBException err = Future_getError(cPtr);
+
+		if (err != null && !err.isSuccess()) {
+			throw err;
+		}
+
+		return new MappedRangeResultInfoV2(this);
+	}
+
+	public MappedRangeResultV2 getResults() {
+		ByteBuffer buffer = enableDirectBufferQueries ? DirectBufferPool.getInstance().poll() : null;
+		if (buffer != null && eventKeeper != null) {
+			eventKeeper.increment(Events.RANGE_QUERY_DIRECT_BUFFER_HIT);
+			eventKeeper.increment(Events.JNI_CALL);
+		} else if (eventKeeper != null) {
+			eventKeeper.increment(Events.RANGE_QUERY_DIRECT_BUFFER_MISS);
+			eventKeeper.increment(Events.JNI_CALL);
+		}
+
+		try {
+			pointerReadLock.lock();
+			if (buffer != null) {
+				try (MappedRangeResultDirectBufferIteratorV2 directIterator =
+				         new MappedRangeResultDirectBufferIteratorV2(buffer)) {
+					Result_getDirect(getPtr(), directIterator.getBuffer(), directIterator.getBuffer().capacity());
+					return new MappedRangeResultV2(directIterator);
+				}
+			} else {
+				return Result_get(getPtr());
+			}
+		} finally {
+			pointerReadLock.unlock();
+		}
+	}
+
+	private boolean enableDirectBufferQueries = false;
+
+	private native MappedRangeResultV2 Result_get(long cPtr) throws FDBException;
+	private native void Result_getDirect(long cPtr, ByteBuffer buffer, int capacity) throws FDBException;
+}

--- a/bindings/java/src/main/com/apple/foundationdb/MappedKeyValueV2.java
+++ b/bindings/java/src/main/com/apple/foundationdb/MappedKeyValueV2.java
@@ -1,0 +1,128 @@
+/*
+ * MappedKeyValueV2.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb;
+
+import com.apple.foundationdb.tuple.ByteArrayUtil;
+
+import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+public class MappedKeyValueV2 extends KeyValue {
+	private final byte[] rangeBegin;
+	private final byte[] rangeEnd;
+	private final byte[] responseBytes;
+	private final List<KeyValue> rangeResult;
+
+	// now it has 4 fields, key, value, getRange.begin, getRange.end
+	// this needs to change if FDBMappedKeyValueV2 definition is changed.
+	private static final int TOTAL_SERIALIZED_FIELD_FDBMappedKeyValueV2 = 5;
+
+	public MappedKeyValueV2(byte[] key, byte[] value, byte[] rangeBegin, byte[] rangeEnd, List<KeyValue> rangeResult,
+	                        byte[] responseBytes) {
+		super(key, value);
+		this.rangeBegin = rangeBegin;
+		this.rangeEnd = rangeEnd;
+		this.rangeResult = rangeResult;
+		this.responseBytes = responseBytes;
+	}
+
+	public byte[] getRangeBegin() { return rangeBegin; }
+
+	public byte[] getRangeEnd() { return rangeEnd; }
+
+	public List<KeyValue> getRangeResult() { return rangeResult; }
+
+	public byte[] getResponseBytes() { return responseBytes; }
+
+	public static MappedKeyValueV2 fromBytes(byte[] bytes, int[] lengths) {
+		// Lengths include: key, value, rangeBegin, rangeEnd, count * (underlying key, underlying value)
+		if (lengths.length < TOTAL_SERIALIZED_FIELD_FDBMappedKeyValueV2) {
+			throw new IllegalArgumentException("There needs to be at least " +
+			                                   TOTAL_SERIALIZED_FIELD_FDBMappedKeyValueV2 +
+			                                   " lengths to cover the metadata");
+		}
+
+		Offset offset = new Offset();
+		byte[] key = takeBytes(offset, bytes, lengths);
+		byte[] value = takeBytes(offset, bytes, lengths);
+		byte[] responseBytes = takeBytes(offset, bytes, lengths);
+		byte[] rangeBegin = takeBytes(offset, bytes, lengths);
+		byte[] rangeEnd = takeBytes(offset, bytes, lengths);
+
+		if ((lengths.length - TOTAL_SERIALIZED_FIELD_FDBMappedKeyValueV2) % 2 != 0) {
+			throw new IllegalArgumentException("There needs to be an even number of lengths!");
+		}
+		int count = (lengths.length - TOTAL_SERIALIZED_FIELD_FDBMappedKeyValueV2) / 2;
+		List<KeyValue> rangeResult = new ArrayList<>(count);
+		for (int i = 0; i < count; i++) {
+			byte[] k = takeBytes(offset, bytes, lengths);
+			byte[] v = takeBytes(offset, bytes, lengths);
+			rangeResult.add(new KeyValue(k, v));
+		}
+		return new MappedKeyValueV2(key, value, rangeBegin, rangeEnd, rangeResult, responseBytes);
+	}
+
+	static class Offset {
+		int bytes = 0;
+		int lengths = 0;
+	}
+
+	static byte[] takeBytes(Offset offset, byte[] bytes, int[] lengths) {
+		int len = lengths[offset.lengths];
+		byte[] b = new byte[len];
+		System.arraycopy(bytes, offset.bytes, b, 0, len);
+		offset.lengths++;
+		offset.bytes += len;
+		return b;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (obj == null) return false;
+		if (obj == this) return true;
+		if (!(obj instanceof MappedKeyValueV2)) return false;
+
+		MappedKeyValueV2 rhs = (MappedKeyValueV2)obj;
+		return Arrays.equals(rangeBegin, rhs.rangeBegin) && Arrays.equals(rangeEnd, rhs.rangeEnd) &&
+		    Objects.equals(rangeResult, rhs.rangeResult) && Arrays.equals(responseBytes, rhs.responseBytes);
+	}
+
+	@Override
+	public int hashCode() {
+		int hashForResult = rangeResult == null ? 0 : rangeResult.hashCode();
+		return 17 + (29 * hashForResult + +37 * Arrays.hashCode(rangeBegin) + Arrays.hashCode(rangeEnd) +
+		             3 * Arrays.hashCode(responseBytes));
+	}
+
+	@Override
+	public String toString() {
+		final StringBuilder sb = new StringBuilder("MappedKeyValueV2{");
+		sb.append("rangeBegin=").append(ByteArrayUtil.printable(rangeBegin));
+		sb.append(", rangeEnd=").append(ByteArrayUtil.printable(rangeEnd));
+		sb.append(", responseBytes=").append(ByteArrayUtil.printable(responseBytes));
+		sb.append(", rangeResult=").append(rangeResult);
+		sb.append('}');
+		return super.toString() + "->" + sb.toString();
+	}
+}

--- a/bindings/java/src/main/com/apple/foundationdb/MappedRangeQueryV2.java
+++ b/bindings/java/src/main/com/apple/foundationdb/MappedRangeQueryV2.java
@@ -60,11 +60,11 @@ class MappedRangeQueryV2 implements AsyncIterable<MappedKeyValueV2> {
 	private final StreamingMode streamingMode;
 	private final EventKeeper eventKeeper;
 
-	private final int code_int = 1;
+	private final int code_uint8 = 1;
 	private final int code_bool = 2;
 
 	private static final int matchIndexPos = 1;
-	private static final int fetchLocalOnlyPos = 6;
+	private static final int fetchLocalOnlyPos = 3;
 
 	MappedRangeQueryV2(FDBTransaction transaction, boolean isSnapshot, KeySelector begin, KeySelector end,
 	                   byte[] mapper, int rowLimit, int matchIndex, boolean fetchLocalOnly, boolean reverse,
@@ -83,8 +83,8 @@ class MappedRangeQueryV2 implements AsyncIterable<MappedKeyValueV2> {
 	}
 
 	byte[] getParamsBytes(int matchIndex, boolean fetchLocalOnly) {
-		byte[] paramsBytes = new byte[] { 0x02, 0, 0, 0, 0, 0, 0, 0 };
-		paramsBytes[matchIndexPos] = code_int;
+		byte[] paramsBytes = new byte[] { 0x02, 0, 0, 0, 0 };
+		paramsBytes[matchIndexPos] = code_uint8;
 		paramsBytes[matchIndexPos + 1] = (byte)matchIndex;
 		paramsBytes[fetchLocalOnlyPos] = code_bool;
 		paramsBytes[fetchLocalOnlyPos + 1] = (byte)(fetchLocalOnly ? 1 : 0);

--- a/bindings/java/src/main/com/apple/foundationdb/MappedRangeResultDirectBufferIteratorV2.java
+++ b/bindings/java/src/main/com/apple/foundationdb/MappedRangeResultDirectBufferIteratorV2.java
@@ -1,0 +1,72 @@
+/*
+ * MappedRangeResultDirectBufferIterator.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb;
+
+import java.io.Closeable;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+/**
+ * Holds the direct buffer that is shared with JNI wrapper.
+ */
+class MappedRangeResultDirectBufferIteratorV2 extends DirectBufferIterator implements Iterator<KeyValue> {
+
+	MappedRangeResultDirectBufferIteratorV2(ByteBuffer buffer) { super(buffer); }
+
+	@Override
+	public boolean hasNext() {
+		return super.hasNext();
+	}
+
+	@Override
+	public MappedKeyValueV2 next() {
+		assert (hasResultReady()); // Must be called once its ready.
+		if (!hasNext()) {
+			throw new NoSuchElementException();
+		}
+
+		final byte[] key = getString();
+		final byte[] value = getString();
+		final byte[] responseBytes = getString();
+		final byte[] rangeBegin = getString();
+		final byte[] rangeEnd = getString();
+		final int rangeResultSize = byteBuffer.getInt();
+		List<KeyValue> rangeResult = new ArrayList();
+		for (int i = 0; i < rangeResultSize; i++) {
+			final byte[] k = getString();
+			final byte[] v = getString();
+			rangeResult.add(new KeyValue(k, v));
+		}
+		current += 1;
+		return new MappedKeyValueV2(key, value, rangeBegin, rangeEnd, rangeResult, responseBytes);
+	}
+
+	private byte[] getString() {
+		final int len = byteBuffer.getInt();
+		byte[] s = new byte[len];
+		byteBuffer.get(s);
+		return s;
+	}
+}

--- a/bindings/java/src/main/com/apple/foundationdb/MappedRangeResultInfoV2.java
+++ b/bindings/java/src/main/com/apple/foundationdb/MappedRangeResultInfoV2.java
@@ -1,0 +1,29 @@
+/*
+ * MappedRangeResultInfoV2.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb;
+
+class MappedRangeResultInfoV2 {
+	MappedRangeResultV2 get() { return f.getResults(); }
+
+	MappedRangeResultInfoV2(FutureMappedResultsV2 f) { this.f = f; }
+
+	private FutureMappedResultsV2 f;
+}

--- a/bindings/java/src/main/com/apple/foundationdb/MappedRangeResultV2.java
+++ b/bindings/java/src/main/com/apple/foundationdb/MappedRangeResultV2.java
@@ -1,0 +1,64 @@
+/*
+ * MappedRangeResultV2.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb;
+
+import com.apple.foundationdb.tuple.ByteArrayUtil;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+class MappedRangeResultV2 {
+	final List<MappedKeyValueV2> values;
+	final boolean more;
+
+	public MappedRangeResultV2(MappedKeyValueV2[] values, boolean more) {
+		this.values = Arrays.asList(values);
+		this.more = more;
+	}
+
+	MappedRangeResultV2(MappedRangeResultDirectBufferIteratorV2 iterator) {
+		iterator.readResultsSummary();
+		more = iterator.hasMore();
+
+		int count = iterator.count();
+		values = new ArrayList<>(count);
+
+		for (int i = 0; i < count; ++i) {
+			values.add(iterator.next());
+		}
+	}
+
+	public RangeResultSummary getSummary() {
+		final int keyCount = values.size();
+		final byte[] lastKey = keyCount > 0 ? values.get(keyCount - 1).getKey() : null;
+		return new RangeResultSummary(lastKey, keyCount, more);
+	}
+
+	@Override
+	public String toString() {
+		final StringBuilder sb = new StringBuilder("MappedRangeResultV2{");
+		sb.append("values=").append(values);
+		sb.append(", more=").append(more);
+		sb.append('}');
+		return sb.toString();
+	}
+}

--- a/bindings/java/src/main/com/apple/foundationdb/NativeFuture.java
+++ b/bindings/java/src/main/com/apple/foundationdb/NativeFuture.java
@@ -127,9 +127,7 @@ abstract class NativeFuture<T> extends CompletableFuture<T> implements AutoClose
 		//  the result must inherently have the read lock itself.
 		assert(rwl.getReadHoldCount() > 0);
 
-		if(cPtr == 0)
-			throw new IllegalStateException("Cannot access closed object");
-
+		if (cPtr == 0) throw new IllegalStateException("Cannot access closed object");
 		return cPtr;
 	}
 

--- a/bindings/java/src/main/com/apple/foundationdb/ReadTransaction.java
+++ b/bindings/java/src/main/com/apple/foundationdb/ReadTransaction.java
@@ -440,12 +440,6 @@ public interface ReadTransaction extends ReadTransactionContext {
 	 *  <i>first</i> keys in the range. Pass {@link #ROW_LIMIT_UNLIMITED} if this query
 	 *  should not limit the number of results. If {@code reverse} is {@code true} rows
 	 *  will be limited starting at the end of the range.
-	 * @param matchIndex the mode to return index entries based on whether their
-	 *  corresponding records are present, examples:
-	 *     {@link FDBTransaction#MATCH_INDEX_ALL}
-	 *     {@link FDBTransaction#MATCH_INDEX_NONE}
-	 *     {@link FDBTransaction#MATCH_INDEX_MATCHED_ONLY}
-	 *     {@link FDBTransaction#MATCH_INDEX_UNMATCHED_ONLY}
 	 * @param reverse return results starting at the end of the range in reverse order.
 	 *  Reading ranges in reverse is supported natively by the database and should
 	 *  have minimal extra cost.
@@ -466,8 +460,50 @@ public interface ReadTransaction extends ReadTransactionContext {
 	 * @return a handle to access the results of the asynchronous call
 	 */
 	AsyncIterable<MappedKeyValue> getMappedRange(KeySelector begin, KeySelector end, byte[] mapper, int limit,
-	                                             int matchIndex, boolean reverse, StreamingMode mode);
-
+	                                             boolean reverse, StreamingMode mode);
+	/**
+	 * WARNING: This feature is considered experimental at this time. It is only allowed when using snapshot isolation
+	 * AND disabling read-your-writes.
+	 *
+	 * @see KeySelector
+	 * @see AsyncIterator
+	 *
+	 * @param begin the beginning of the range (inclusive)
+	 * @param end the end of the range (exclusive)
+	 * @param mapper defines how to map a key-value pair (one of the key-value pairs got
+	 *  from the first range query) to a GetRange (or GetValue) request.
+	 *  more details: https://github.com/apple/foundationdb/wiki/Everything-about-GetMappedRange
+	 * @param limit the maximum number of results to return. Limits results to the
+	 *  <i>first</i> keys in the range. Pass {@link #ROW_LIMIT_UNLIMITED} if this query
+	 *  should not limit the number of results. If {@code reverse} is {@code true} rows
+	 *  will be limited starting at the end of the range.
+	 * @param reverse return results starting at the end of the range in reverse order.
+	 *  Reading ranges in reverse is supported natively by the database and should
+	 *  have minimal extra cost.
+	 * @param mode provide a hint about how the results are to be used. This
+	 *  can provide speed improvements or efficiency gains based on the caller's
+	 *  knowledge of the upcoming access pattern.
+	 * @param matchIndex the mode to return index entries based on whether their
+	 *  corresponding records are present, examples:
+	 *     {@link Transaction#MATCH_INDEX_ALL}
+	 *     {@link Transaction#MATCH_INDEX_NONE}
+	 *     {@link Transaction#MATCH_INDEX_MATCHED_ONLY}
+	 *     {@link Transaction#MATCH_INDEX_UNMATCHED_ONLY}
+	 * <p>
+	 *     When converting the result of this query to a list using {@link AsyncIterable#asList()} with the {@code
+	 * ITERATOR} streaming mode, the query is automatically modified to fetch results in larger batches. This is done
+	 * because it is known in advance that the {@link AsyncIterable#asList()} function will fetch all results in the
+	 * range. If a limit is specified, the {@code EXACT} streaming mode will be used, and otherwise it will use {@code
+	 * WANT_ALL}.
+	 *
+	 *     To achieve comparable performance when iterating over an entire range without using {@link
+	 * AsyncIterable#asList()}, the same streaming mode would need to be used.
+	 * </p>
+	 * @return a handle to access the results of the asynchronous call
+	 */
+	AsyncIterable<MappedKeyValueV2> getMappedRangeV2(KeySelector begin, KeySelector end, byte[] mapper, int limit,
+	                                                 boolean reverse, StreamingMode mode, int matchIndex,
+	                                                 boolean fetchLocalOnly);
 	/**
 	 * Gets an estimate for the number of bytes stored in the given range.
 	 * Note: the estimated size is calculated based on the sampling done by FDB server. The sampling

--- a/bindings/java/src/main/com/apple/foundationdb/Transaction.java
+++ b/bindings/java/src/main/com/apple/foundationdb/Transaction.java
@@ -76,6 +76,11 @@ import com.apple.foundationdb.tuple.Tuple;
  */
 public interface Transaction extends AutoCloseable, ReadTransaction, TransactionContext {
 
+	static public final int MATCH_INDEX_ALL = 0;
+	static public final int MATCH_INDEX_NONE = 1;
+	static public final int MATCH_INDEX_MATCHED_ONLY = 2;
+	static public final int MATCH_INDEX_UNMATCHED_ONLY = 3;
+
 	/**
 	 * Adds a range of keys to the transaction's read conflict ranges as if you
 	 * had read the range. As a result, other transactions that write a key in

--- a/fdbclient/MappedRange.cpp
+++ b/fdbclient/MappedRange.cpp
@@ -1,0 +1,43 @@
+#include "fdbclient/MappedRange.h"
+
+const int MATCH_INDEX_ALL = 0;
+const int MATCH_INDEX_NONE = 1;
+const int MATCH_INDEX_MATCHED_ONLY = 2;
+const int MATCH_INDEX_UNMATCHED_ONLY = 3;
+
+/*
+Request Schema:
+The first byte is always version.
+Each field is a type code followed by the contents.
+V = 2:
+    byte[0] = version
+    byte[1] = type code of int *matchIndex*
+    byte[2-5] = *matchIndex* content in little endian
+    byte[6] = type code of bool *fetchLocalOnly*
+    byte[7] = *fetchLocalOnly* content
+*/
+
+std::unordered_map<int, int> versionToLength = { std::make_pair(2, 5) };
+
+std::unordered_map<int, int> versionToPosMatchIndex = { std::make_pair(2, 1) };
+std::unordered_map<int, int> versionToPosFetchLocalOnly = { std::make_pair(2, 3) };
+std::set<int> supportedVersions{ 2 };
+
+const int code_uint8 = 1;
+const int code_bool = 2;
+
+// bytes array in the response of GetMappedRange have certain length for each version
+// for version 2, the length is 3
+const int MAPPED_KEY_VALUE_RESPONSE_BYTES_LENGTH_V2 = 3;
+
+/*
+Reply Schema:
+The first byte is always version.
+Each field is a type code followed by the contents.
+V = 2:
+    byte[0] = version
+    byte[1] = type code of int *local*
+    byte[2] = *local* content
+*/
+
+std::unordered_map<int, int> versionToPosLocal = { std::make_pair(2, 1) };

--- a/fdbclient/ReadYourWrites.actor.cpp
+++ b/fdbclient/ReadYourWrites.actor.cpp
@@ -77,13 +77,22 @@ public:
 
 	template <bool reverse>
 	struct GetMappedRangeReq {
-		GetMappedRangeReq(KeySelector begin, KeySelector end, Key mapper, int matchIndex, GetRangeLimits limits)
-		  : begin(begin), end(end), mapper(mapper), limits(limits), matchIndex(matchIndex) {}
+		GetMappedRangeReq(KeySelector begin, KeySelector end, Key mapper, GetRangeLimits limits)
+		  : begin(begin), end(end), mapper(mapper), limits(limits) {}
 		KeySelector begin, end;
 		Key mapper;
 		GetRangeLimits limits;
-		int matchIndex;
 		using Result = MappedRangeResult;
+	};
+
+	template <bool reverse>
+	struct GetMappedRangeReqV2 {
+		GetMappedRangeReqV2(KeySelector begin, KeySelector end, Key mapper, Key paramsBytes, GetRangeLimits limits)
+		  : begin(begin), end(end), mapper(mapper), limits(limits), paramsBytes(paramsBytes) {}
+		KeySelector begin, end;
+		Key mapper, paramsBytes;
+		GetRangeLimits limits;
+		using Result = MappedRangeResultV2;
 	};
 
 	// read() Performs a read (get, getKey, getRange, etc), in the context of the given transaction.  Snapshot or RYW
@@ -1131,18 +1140,6 @@ public:
 #pragma region GetMappedRange
 #endif
 
-	template <class Iter>
-	static Future<MappedRangeResult> read(ReadYourWritesTransaction* ryw, GetMappedRangeReq<false> read, Iter* it) {
-		return getMappedRangeValue(ryw, read.begin, read.end, read.mapper, read.limits, it);
-	};
-
-	template <class Iter>
-	static Future<MappedRangeResult> read(ReadYourWritesTransaction* ryw, GetMappedRangeReq<true> read, Iter* it) {
-		throw unsupported_operation();
-		// TODO: Support reverse. return getMappedRangeValueBack(ryw, read.begin, read.end, read.mapper,
-		// read.limits, it);
-	};
-
 	ACTOR template <bool backwards>
 	static Future<MappedRangeResult> readThrough(ReadYourWritesTransaction* ryw,
 	                                             GetMappedRangeReq<backwards> read,
@@ -1156,14 +1153,32 @@ public:
 			else
 				read.end = KeySelector(firstGreaterOrEqual(key), key.arena());
 		}
-		MappedRangeResult v = wait(ryw->tr.getMappedRange(read.begin,
-		                                                  read.end,
-		                                                  read.mapper,
-		                                                  read.limits,
-		                                                  read.matchIndex,
-		                                                  snapshot,
-		                                                  backwards ? Reverse::True : Reverse::False));
-		return v;
+		MappedRangeResult res = wait(ryw->tr.getMappedRange(
+		    read.begin, read.end, read.mapper, read.limits, snapshot, backwards ? Reverse::True : Reverse::False));
+		return res;
+	}
+
+	ACTOR template <bool backwards>
+	static Future<MappedRangeResultV2> readThrough(ReadYourWritesTransaction* ryw,
+	                                               GetMappedRangeReqV2<backwards> read,
+	                                               Snapshot snapshot) {
+		if (backwards && read.end.offset > 1) {
+			// FIXME: Optimistically assume that this will not run into the system keys, and only reissue if the result
+			// actually does.
+			Key key = wait(ryw->tr.getKey(read.end, snapshot));
+			if (key > ryw->getMaxReadKey())
+				read.end = firstGreaterOrEqual(ryw->getMaxReadKey());
+			else
+				read.end = KeySelector(firstGreaterOrEqual(key), key.arena());
+		}
+		MappedRangeResultV2 res = wait(ryw->tr.getMappedRangeV2(read.begin,
+		                                                        read.end,
+		                                                        read.mapper,
+		                                                        read.paramsBytes,
+		                                                        read.limits,
+		                                                        snapshot,
+		                                                        backwards ? Reverse::True : Reverse::False));
+		return res;
 	}
 
 	template <bool backwards>
@@ -1173,6 +1188,37 @@ public:
 	                                              MappedRangeResult result) {
 		// Primary getRange.
 		addConflictRange<true, MappedRangeResult>(
+		    ryw, GetRangeReq<backwards>(read.begin, read.end, read.limits), it, result);
+
+		// Secondary getValue/getRanges.
+		for (const auto& mappedKeyValue : result) {
+			const auto& reqAndResult = mappedKeyValue.reqAndResult;
+			if (std::holds_alternative<GetValueReqAndResultRef>(reqAndResult)) {
+				auto getValue = std::get<GetValueReqAndResultRef>(reqAndResult);
+				// GetValueReq variation of addConflictRange require it to point at the right segment.
+				it.skip(getValue.key);
+				// The result is not used in GetValueReq variation of addConflictRange. Let's just pass in a
+				// placeholder.
+				addConflictRange<true>(ryw, GetValueReq(getValue.key), it, Optional<Value>());
+			} else if (std::holds_alternative<GetRangeReqAndResultRef>(reqAndResult)) {
+				auto getRange = std::get<GetRangeReqAndResultRef>(reqAndResult);
+				// We only support forward scan for secondary getRange requests.
+				// The limits are not used in addConflictRange. Let's just pass in a placeholder.
+				addConflictRange<true>(
+				    ryw, GetRangeReq<false>(getRange.begin, getRange.end, GetRangeLimits()), it, getRange.result);
+			} else {
+				throw internal_error();
+			}
+		}
+	}
+
+	template <bool backwards>
+	static void addConflictRangeAndMustUnmodified(ReadYourWritesTransaction* ryw,
+	                                              GetMappedRangeReqV2<backwards> read,
+	                                              WriteMap::iterator& it,
+	                                              MappedRangeResultV2 result) {
+		// Primary getRange.
+		addConflictRange<true, MappedRangeResultV2>(
 		    ryw, GetRangeReq<backwards>(read.begin, read.end, read.limits), it, result);
 
 		// Secondary getValue/getRanges.
@@ -1217,6 +1263,25 @@ public:
 		}
 	}
 
+	ACTOR template <bool backwards>
+	static Future<MappedRangeResultV2> readWithConflictRangeRYW(ReadYourWritesTransaction* ryw,
+	                                                            GetMappedRangeReqV2<backwards> req,
+	                                                            Snapshot snapshot) {
+		choose {
+			when(MappedRangeResultV2 result = wait(readThrough(ryw, req, Snapshot::True))) {
+				// Insert read conflicts (so that it supported Snapshot::True) and check it is not modified (so it masks
+				// sure not break RYW semantic while not implementing RYW) for both the primary getRange and all
+				// underlying getValue/getRanges.
+				WriteMap::iterator writes(&ryw->writes);
+				addConflictRangeAndMustUnmodified<backwards>(ryw, req, writes, result);
+				return result;
+			}
+			when(wait(ryw->resetPromise.getFuture())) {
+				throw internal_error();
+			}
+		}
+	}
+
 	template <bool backwards>
 	static inline Future<MappedRangeResult> readWithConflictRangeForGetMappedRange(
 	    ReadYourWritesTransaction* ryw,
@@ -1239,9 +1304,33 @@ public:
 			throw unsupported_operation();
 		}
 
-		return readWithConflictRangeRYW(ryw, req, snapshot);
+		return readWithConflictRangeRYW<backwards>(ryw, req, snapshot);
 	}
 
+	template <bool backwards>
+	static inline Future<MappedRangeResultV2> readWithConflictRangeForGetMappedRange(
+	    ReadYourWritesTransaction* ryw,
+	    GetMappedRangeReqV2<backwards> const& req,
+	    Snapshot snapshot) {
+		// For now, getMappedRange requires serializable isolation. (Technically it is trivial to add snapshot
+		// isolation support. But it is not default and is rarely used. So we disallow it until we have thorough test
+		// coverage for it.)
+		if (snapshot) {
+			CODE_PROBE(true, "getMappedRange not supported for snapshot.", probe::decoration::rare);
+			throw unsupported_operation();
+		}
+		// For now, getMappedRange requires read-your-writes being NOT disabled. But the support of RYW is limited
+		// to throwing get_mapped_range_reads_your_writes error when getMappedRange actually reads your own writes.
+		// Applications should fall back in their own ways. This is different from what is usually expected from RYW,
+		// which returns the written value transparently. In another word, it makes sure not break RYW semantics without
+		// actually implementing reading from the writes.
+		if (ryw->options.readYourWritesDisabled) {
+			CODE_PROBE(true, "getMappedRange not supported for read-your-writes disabled.", probe::decoration::rare);
+			throw unsupported_operation();
+		}
+
+		return readWithConflictRangeRYW<backwards>(ryw, req, snapshot);
+	}
 #ifndef __INTEL_COMPILER
 #pragma endregion
 #endif
@@ -1708,7 +1797,6 @@ Future<MappedRangeResult> ReadYourWritesTransaction::getMappedRange(KeySelector 
                                                                     KeySelector end,
                                                                     Key mapper,
                                                                     GetRangeLimits limits,
-                                                                    int matchIndex,
                                                                     Snapshot snapshot,
                                                                     Reverse reverse) {
 	if (getDatabase()->apiVersionAtLeast(630)) {
@@ -1755,10 +1843,68 @@ Future<MappedRangeResult> ReadYourWritesTransaction::getMappedRange(KeySelector 
 	}
 
 	Future<MappedRangeResult> result =
-	    reverse ? RYWImpl::readWithConflictRangeForGetMappedRange(
-	                  this, RYWImpl::GetMappedRangeReq<true>(begin, end, mapper, matchIndex, limits), snapshot)
-	            : RYWImpl::readWithConflictRangeForGetMappedRange(
-	                  this, RYWImpl::GetMappedRangeReq<false>(begin, end, mapper, matchIndex, limits), snapshot);
+	    reverse ? RYWImpl::readWithConflictRangeForGetMappedRange<true>(
+	                  this, RYWImpl::GetMappedRangeReq<true>(begin, end, mapper, limits), snapshot)
+	            : RYWImpl::readWithConflictRangeForGetMappedRange<false>(
+	                  this, RYWImpl::GetMappedRangeReq<false>(begin, end, mapper, limits), snapshot);
+
+	return result;
+}
+
+Future<MappedRangeResultV2> ReadYourWritesTransaction::getMappedRangeV2(KeySelector begin,
+                                                                        KeySelector end,
+                                                                        Key mapper,
+                                                                        Key paramsBytes,
+                                                                        GetRangeLimits limits,
+                                                                        Snapshot snapshot,
+                                                                        Reverse reverse) {
+	if (getDatabase()->apiVersionAtLeast(630)) {
+		if (specialKeys.contains(begin.getKey()) && specialKeys.begin <= end.getKey() &&
+		    end.getKey() <= specialKeys.end) {
+			CODE_PROBE(true, "Special key space get range (getMappedRange)", probe::decoration::rare);
+			throw client_invalid_operation(); // Not support special keys.
+		}
+	} else {
+		if (begin.getKey() == "\xff\xff/worker_interfaces"_sr) {
+			throw client_invalid_operation(); // Not support special keys.
+		}
+	}
+	if (checkUsedDuringCommit()) {
+		return used_during_commit();
+	}
+
+	if (resetPromise.isSet())
+		return resetPromise.getFuture().getError();
+
+	KeyRef maxKey = getMaxReadKey();
+	if (begin.getKey() > maxKey || end.getKey() > maxKey)
+		return key_outside_legal_range();
+
+	// This optimization prevents nullptr operations from being added to the conflict range
+	if (limits.isReached()) {
+		CODE_PROBE(true, "RYW range read limit 0 (getMappedRange)", probe::decoration::rare);
+		return MappedRangeResultV2();
+	}
+
+	if (!limits.isValid())
+		return range_limits_invalid();
+
+	if (begin.orEqual)
+		begin.removeOrEqual(begin.arena());
+
+	if (end.orEqual)
+		end.removeOrEqual(end.arena());
+
+	if (begin.offset >= end.offset && begin.getKey() >= end.getKey()) {
+		CODE_PROBE(true, "RYW range inverted (getMappedRange)", probe::decoration::rare);
+		return MappedRangeResultV2();
+	}
+
+	Future<MappedRangeResultV2> result =
+	    reverse ? RYWImpl::readWithConflictRangeForGetMappedRange<true>(
+	                  this, RYWImpl::GetMappedRangeReqV2<true>(begin, end, mapper, paramsBytes, limits), snapshot)
+	            : RYWImpl::readWithConflictRangeForGetMappedRange<false>(
+	                  this, RYWImpl::GetMappedRangeReqV2<false>(begin, end, mapper, paramsBytes, limits), snapshot);
 
 	return result;
 }

--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -836,7 +836,6 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( ENABLE_CLEAR_RANGE_EAGER_READS,                       true ); if( randomize && BUGGIFY ) ENABLE_CLEAR_RANGE_EAGER_READS = deterministicRandom()->coinflip();
 	init( CHECKPOINT_TRANSFER_BLOCK_BYTES,                      40e6 );
 	init( QUICK_GET_VALUE_FALLBACK,                             true );
-	init( QUICK_GET_KEY_VALUES_FALLBACK,                        true );
 	init( STRICTLY_ENFORCE_BYTE_LIMIT,                          false); if( randomize && BUGGIFY ) STRICTLY_ENFORCE_BYTE_LIMIT = deterministicRandom()->coinflip();
 	init( FRACTION_INDEX_BYTELIMIT_PREFETCH,                      0.2); if( randomize && BUGGIFY ) FRACTION_INDEX_BYTELIMIT_PREFETCH = 0.01 + deterministicRandom()->random01();
 	init( MAX_PARALLEL_QUICK_GET_VALUE,                           10 ); if ( randomize && BUGGIFY ) MAX_PARALLEL_QUICK_GET_VALUE = deterministicRandom()->randomInt(1, 100);

--- a/fdbclient/StorageServerInterface.cpp
+++ b/fdbclient/StorageServerInterface.cpp
@@ -206,8 +206,18 @@ bool TSS_doCompare(const GetMappedKeyValuesReply& src, const GetMappedKeyValuesR
 }
 
 template <>
+bool TSS_doCompare(const GetMappedKeyValuesReplyV2& src, const GetMappedKeyValuesReplyV2& tss) {
+	return src.more == tss.more && src.data == tss.data;
+}
+
+template <>
 const char* TSS_mismatchTraceName(const GetMappedKeyValuesRequest& req) {
 	return "TSSMismatchGetMappedKeyValues";
+}
+
+template <>
+const char* TSS_mismatchTraceName(const GetMappedKeyValuesRequestV2& req) {
+	return "TSSMismatchGetMappedKeyValuesV2";
 }
 
 template <>
@@ -215,6 +225,25 @@ void TSS_traceMismatch(TraceEvent& event,
                        const GetMappedKeyValuesRequest& req,
                        const GetMappedKeyValuesReply& src,
                        const GetMappedKeyValuesReply& tss) {
+	traceKeyValuesSummary(event,
+	                      req.begin,
+	                      req.end,
+	                      req.tenantInfo.tenantId,
+	                      req.version,
+	                      req.limit,
+	                      req.limitBytes,
+	                      src.data.size(),
+	                      src.more,
+	                      tss.data.size(),
+	                      tss.more);
+	// FIXME: trace details for TSS mismatch of mapped data
+}
+
+template <>
+void TSS_traceMismatch(TraceEvent& event,
+                       const GetMappedKeyValuesRequestV2& req,
+                       const GetMappedKeyValuesReplyV2& src,
+                       const GetMappedKeyValuesReplyV2& tss) {
 	traceKeyValuesSummary(event,
 	                      req.begin,
 	                      req.end,
@@ -425,6 +454,12 @@ void TSSMetrics::recordLatency(const GetKeyValuesRequest& req, double ssLatency,
 
 template <>
 void TSSMetrics::recordLatency(const GetMappedKeyValuesRequest& req, double ssLatency, double tssLatency) {
+	SSgetMappedKeyValuesLatency.addSample(ssLatency);
+	TSSgetMappedKeyValuesLatency.addSample(tssLatency);
+}
+
+template <>
+void TSSMetrics::recordLatency(const GetMappedKeyValuesRequestV2& req, double ssLatency, double tssLatency) {
 	SSgetMappedKeyValuesLatency.addSample(ssLatency);
 	TSSgetMappedKeyValuesLatency.addSample(tssLatency);
 }

--- a/fdbclient/ThreadSafeTransaction.cpp
+++ b/fdbclient/ThreadSafeTransaction.cpp
@@ -456,17 +456,33 @@ ThreadFuture<MappedRangeResult> ThreadSafeTransaction::getMappedRange(const KeyS
                                                                       const KeySelectorRef& end,
                                                                       const StringRef& mapper,
                                                                       GetRangeLimits limits,
-                                                                      int matchIndex,
                                                                       bool snapshot,
                                                                       bool reverse) {
 	KeySelector b = begin;
 	KeySelector e = end;
 	Key h = mapper;
-
 	ISingleThreadTransaction* tr = this->tr;
-	return onMainThread([tr, b, e, h, limits, matchIndex, snapshot, reverse]() -> Future<MappedRangeResult> {
+	return onMainThread([tr, b, e, h, limits, snapshot, reverse]() -> Future<MappedRangeResult> {
 		tr->checkDeferredError();
-		return tr->getMappedRange(b, e, h, limits, matchIndex, Snapshot{ snapshot }, Reverse{ reverse });
+		return tr->getMappedRange(b, e, h, limits, Snapshot{ snapshot }, Reverse{ reverse });
+	});
+}
+
+ThreadFuture<MappedRangeResultV2> ThreadSafeTransaction::getMappedRangeV2(const KeySelectorRef& begin,
+                                                                          const KeySelectorRef& end,
+                                                                          const StringRef& mapper,
+                                                                          const StringRef& paramsBytes,
+                                                                          GetRangeLimits limits,
+                                                                          bool snapshot,
+                                                                          bool reverse) {
+	KeySelector b = begin;
+	KeySelector e = end;
+	Key h = mapper;
+	Key m = paramsBytes;
+	ISingleThreadTransaction* tr = this->tr;
+	return onMainThread([tr, b, e, h, limits, snapshot, reverse, m]() -> Future<MappedRangeResultV2> {
+		tr->checkDeferredError();
+		return tr->getMappedRangeV2(b, e, h, m, limits, Snapshot{ snapshot }, Reverse{ reverse });
 	});
 }
 

--- a/fdbclient/include/fdbclient/FDBTypes.h
+++ b/fdbclient/include/fdbclient/FDBTypes.h
@@ -153,6 +153,7 @@ const int MATCH_INDEX_ALL = 0;
 const int MATCH_INDEX_NONE = 1;
 const int MATCH_INDEX_MATCHED_ONLY = 2;
 const int MATCH_INDEX_UNMATCHED_ONLY = 3;
+const int MAPPED_KEY_VALUE_RESPONSE_BYTES_LENGTH_V2 = 3;
 
 enum { txsTagOld = -1, invalidTagOld = -100 };
 
@@ -533,6 +534,7 @@ using KeyValue = Standalone<KeyValueRef>;
 using KeySelector = Standalone<struct KeySelectorRef>;
 using RangeResult = Standalone<struct RangeResultRef>;
 using MappedRangeResult = Standalone<struct MappedRangeResultRef>;
+using MappedRangeResultV2 = Standalone<struct MappedRangeResultRefV2>;
 
 namespace std {
 template <>
@@ -707,6 +709,7 @@ KeyRangeWith<Val> keyRangeWith(const KeyRangeRef& range, const Val& value) {
 }
 
 struct MappedKeyValueRef;
+struct MappedKeyValueRefV2;
 
 struct GetRangeLimits {
 	enum { ROW_LIMIT_UNLIMITED = -1, BYTE_LIMIT_UNLIMITED = -1 };
@@ -723,6 +726,8 @@ struct GetRangeLimits {
 	void decrement(KeyValueRef const& data);
 	void decrement(VectorRef<MappedKeyValueRef> const& data);
 	void decrement(MappedKeyValueRef const& data);
+	void decrement(VectorRef<MappedKeyValueRefV2> const& data);
+	void decrement(MappedKeyValueRefV2 const& data);
 
 	// True if either the row or byte limit has been reached
 	bool isReached() const;
@@ -860,6 +865,43 @@ struct MappedKeyValueRef : KeyValueRef {
 	}
 };
 
+struct MappedKeyValueRefV2 : KeyValueRef {
+	// Save the original key value at the base (KeyValueRef).
+
+	KeyRef responseBytes;
+	MappedReqAndResultRef reqAndResult;
+
+	MappedKeyValueRefV2() = default;
+	MappedKeyValueRefV2(Arena& a, const MappedKeyValueRefV2& copyFrom) : KeyValueRef(a, copyFrom) {
+		responseBytes = StringRef(a, copyFrom.responseBytes);
+		const auto& reqAndResultCopyFrom = copyFrom.reqAndResult;
+		if (std::holds_alternative<GetValueReqAndResultRef>(reqAndResultCopyFrom)) {
+			auto getValue = std::get<GetValueReqAndResultRef>(reqAndResultCopyFrom);
+			reqAndResult = GetValueReqAndResultRef(a, getValue);
+		} else if (std::holds_alternative<GetRangeReqAndResultRef>(reqAndResultCopyFrom)) {
+			auto getRange = std::get<GetRangeReqAndResultRef>(reqAndResultCopyFrom);
+			reqAndResult = GetRangeReqAndResultRef(a, getRange);
+		} else {
+			throw internal_error();
+		}
+	}
+
+	bool operator==(const MappedKeyValueRefV2& rhs) const {
+		return static_cast<const KeyValueRef&>(*this) == static_cast<const KeyValueRef&>(rhs) &&
+		       reqAndResult == rhs.reqAndResult && responseBytes == rhs.responseBytes;
+	}
+	bool operator!=(const MappedKeyValueRefV2& rhs) const { return !(rhs == *this); }
+
+	// It relies on the base to provide the expectedSize. TODO: Consider add the underlying request and key values into
+	// expected size?
+	//	int expectedSize() const { return ((KeyValueRef*)this)->expectedSisze() + reqA }
+
+	template <class Ar>
+	void serialize(Ar& ar) {
+		serializer(ar, ((KeyValueRef&)*this), reqAndResult, responseBytes);
+	}
+};
+
 struct MappedRangeResultRef : VectorRef<MappedKeyValueRef> {
 	// Additional information on range result. See comments on RangeResultRef.
 	bool more;
@@ -883,6 +925,38 @@ struct MappedRangeResultRef : VectorRef<MappedKeyValueRef> {
 	template <class Ar>
 	void serialize(Ar& ar) {
 		serializer(ar, ((VectorRef<MappedKeyValueRef>&)*this), more, readThrough, readToBegin, readThroughEnd);
+	}
+
+	std::string toString() const {
+		return "more:" + std::to_string(more) +
+		       " readThrough:" + (readThrough.present() ? readThrough.get().toString() : "[unset]") +
+		       " readToBegin:" + std::to_string(readToBegin) + " readThroughEnd:" + std::to_string(readThroughEnd);
+	}
+};
+
+struct MappedRangeResultRefV2 : VectorRef<MappedKeyValueRefV2> {
+	// Additional information on range result. See comments on RangeResultRef.
+	bool more;
+	Optional<KeyRef> readThrough;
+	bool readToBegin;
+	bool readThroughEnd;
+
+	MappedRangeResultRefV2() : more(false), readToBegin(false), readThroughEnd(false) {}
+	MappedRangeResultRefV2(Arena& p, const MappedRangeResultRefV2& toCopy)
+	  : VectorRef<MappedKeyValueRefV2>(p, toCopy), more(toCopy.more),
+	    readThrough(toCopy.readThrough.present() ? KeyRef(p, toCopy.readThrough.get()) : Optional<KeyRef>()),
+	    readToBegin(toCopy.readToBegin), readThroughEnd(toCopy.readThroughEnd) {}
+	MappedRangeResultRefV2(const VectorRef<MappedKeyValueRefV2>& value,
+	                       bool more,
+	                       Optional<KeyRef> readThrough = Optional<KeyRef>())
+	  : VectorRef<MappedKeyValueRefV2>(value), more(more), readThrough(readThrough), readToBegin(false),
+	    readThroughEnd(false) {}
+	MappedRangeResultRefV2(bool readToBegin, bool readThroughEnd)
+	  : more(false), readToBegin(readToBegin), readThroughEnd(readThroughEnd) {}
+
+	template <class Ar>
+	void serialize(Ar& ar) {
+		serializer(ar, ((VectorRef<MappedKeyValueRefV2>&)*this), more, readThrough, readToBegin, readThroughEnd);
 	}
 
 	std::string toString() const {

--- a/fdbclient/include/fdbclient/FDBTypes.h
+++ b/fdbclient/include/fdbclient/FDBTypes.h
@@ -149,12 +149,6 @@ static const Tag invalidTag{ tagLocalitySpecial, 0 };
 static const Tag txsTag{ tagLocalitySpecial, 1 };
 static const Tag cacheTag{ tagLocalitySpecial, 2 };
 
-const int MATCH_INDEX_ALL = 0;
-const int MATCH_INDEX_NONE = 1;
-const int MATCH_INDEX_MATCHED_ONLY = 2;
-const int MATCH_INDEX_UNMATCHED_ONLY = 3;
-const int MAPPED_KEY_VALUE_RESPONSE_BYTES_LENGTH_V2 = 3;
-
 enum { txsTagOld = -1, invalidTagOld = -100 };
 
 struct TagsAndMessage {
@@ -839,10 +833,10 @@ struct MappedKeyValueRef : KeyValueRef {
 	MappedKeyValueRef(Arena& a, const MappedKeyValueRef& copyFrom) : KeyValueRef(a, copyFrom) {
 		const auto& reqAndResultCopyFrom = copyFrom.reqAndResult;
 		if (std::holds_alternative<GetValueReqAndResultRef>(reqAndResultCopyFrom)) {
-			auto getValue = std::get<GetValueReqAndResultRef>(reqAndResultCopyFrom);
+			const auto& getValue = std::get<GetValueReqAndResultRef>(reqAndResultCopyFrom);
 			reqAndResult = GetValueReqAndResultRef(a, getValue);
 		} else if (std::holds_alternative<GetRangeReqAndResultRef>(reqAndResultCopyFrom)) {
-			auto getRange = std::get<GetRangeReqAndResultRef>(reqAndResultCopyFrom);
+			const auto& getRange = std::get<GetRangeReqAndResultRef>(reqAndResultCopyFrom);
 			reqAndResult = GetRangeReqAndResultRef(a, getRange);
 		} else {
 			throw internal_error();
@@ -868,7 +862,7 @@ struct MappedKeyValueRef : KeyValueRef {
 struct MappedKeyValueRefV2 : KeyValueRef {
 	// Save the original key value at the base (KeyValueRef).
 
-	KeyRef responseBytes;
+	KeyRef responseBytes; // schema is defined in MappedRange.h
 	MappedReqAndResultRef reqAndResult;
 
 	MappedKeyValueRefV2() = default;
@@ -938,8 +932,8 @@ struct MappedRangeResultRefV2 : VectorRef<MappedKeyValueRefV2> {
 	// Additional information on range result. See comments on RangeResultRef.
 	bool more;
 	Optional<KeyRef> readThrough;
-	bool readToBegin;
-	bool readThroughEnd;
+	bool readToBegin; // it contains the result reading to the begin of allKeys (e.g.normalKeys.begin)
+	bool readThroughEnd; // it contains the result reading to the end of allKeys (e.g. systemKeys.end)
 
 	MappedRangeResultRefV2() : more(false), readToBegin(false), readThroughEnd(false) {}
 	MappedRangeResultRefV2(Arena& p, const MappedRangeResultRefV2& toCopy)

--- a/fdbclient/include/fdbclient/IClientApi.h
+++ b/fdbclient/include/fdbclient/IClientApi.h
@@ -68,9 +68,15 @@ public:
 	                                                       const KeySelectorRef& end,
 	                                                       const StringRef& mapper,
 	                                                       GetRangeLimits limits,
-	                                                       int matchIndex = MATCH_INDEX_ALL,
 	                                                       bool snapshot = false,
 	                                                       bool reverse = false) = 0;
+	virtual ThreadFuture<MappedRangeResultV2> getMappedRangeV2(const KeySelectorRef& begin,
+	                                                           const KeySelectorRef& end,
+	                                                           const StringRef& mapper,
+	                                                           const StringRef& paramsBytes,
+	                                                           GetRangeLimits limits,
+	                                                           bool snapshot = false,
+	                                                           bool reverse = false) = 0;
 	virtual ThreadFuture<Standalone<VectorRef<const char*>>> getAddressesForKey(const KeyRef& key) = 0;
 	virtual ThreadFuture<Standalone<StringRef>> getVersionstamp() = 0;
 

--- a/fdbclient/include/fdbclient/ISingleThreadTransaction.h
+++ b/fdbclient/include/fdbclient/ISingleThreadTransaction.h
@@ -74,9 +74,15 @@ public:
 	                                                 KeySelector end,
 	                                                 Key mapper,
 	                                                 GetRangeLimits limits,
-	                                                 int matchIndex = MATCH_INDEX_ALL,
 	                                                 Snapshot = Snapshot::False,
 	                                                 Reverse = Reverse::False) = 0;
+	virtual Future<MappedRangeResultV2> getMappedRangeV2(KeySelector begin,
+	                                                     KeySelector end,
+	                                                     Key mapper,
+	                                                     Key paramsBytes,
+	                                                     GetRangeLimits limits,
+	                                                     Snapshot = Snapshot::False,
+	                                                     Reverse = Reverse::False) = 0;
 	virtual Future<Standalone<VectorRef<const char*>>> getAddressesForKey(Key const& key) = 0;
 	virtual Future<Standalone<VectorRef<KeyRef>>> getRangeSplitPoints(KeyRange const& range, int64_t chunkSize) = 0;
 	virtual Future<int64_t> getEstimatedRangeSizeBytes(KeyRange const& keys) = 0;

--- a/fdbclient/include/fdbclient/MappedRange.h
+++ b/fdbclient/include/fdbclient/MappedRange.h
@@ -1,0 +1,53 @@
+#ifndef MAPPEDRANGE_H
+#define MAPPEDRANGE_H
+
+#include <unordered_map>
+#include <set>
+
+extern const int MATCH_INDEX_ALL;
+extern const int MATCH_INDEX_NONE;
+extern const int MATCH_INDEX_MATCHED_ONLY;
+extern const int MATCH_INDEX_UNMATCHED_ONLY;
+
+extern const int code_uint8;
+extern const int code_bool;
+
+/*
+Request section:
+
+Request Schema:
+The first byte is always version.
+Each field is a type code followed by the contents.
+V = 2:
+    byte[0] = version
+    byte[1] = type code of int *matchIndex*
+    byte[2-5] = *matchIndex* content in little endian
+    byte[6] = type code of bool *fetchLocalOnly*
+    byte[7] = *fetchLocalOnly* content
+*/
+
+extern std::unordered_map<int, int> versionToLength;
+
+extern std::unordered_map<int, int> versionToPosMatchIndex;
+extern std::unordered_map<int, int> versionToPosFetchLocalOnly;
+extern std::set<int> supportedVersions;
+
+/*
+Reply section
+
+Reply Schema:
+The first byte is always version.
+Each field is a type code followed by the contents.
+V = 2:
+    byte[0] = version
+    byte[1] = type code of int *local*
+    byte[2] = *local* content
+*/
+
+extern std::unordered_map<int, int> versionToPosLocal;
+
+// bytes array in the response of GetMappedRange have certain length for each version
+// for version 2, the length is 3
+extern const int MAPPED_KEY_VALUE_RESPONSE_BYTES_LENGTH_V2;
+
+#endif

--- a/fdbclient/include/fdbclient/MultiVersionTransaction.h
+++ b/fdbclient/include/fdbclient/MultiVersionTransaction.h
@@ -88,9 +88,10 @@ struct FdbCApi : public ThreadSafeReferenceCounted<FdbCApi> {
 		FDBKey value;
 		/* It's complicated to map a std::variant to C. For now we assume the underlying requests are always getRange
 		 * and take the shortcut. */
+		FDBKey responseBytes;
+		unsigned char padding[4];
 		FDBGetRangeReqAndResult getRange;
 		unsigned char buffer[32];
-		FDBKey responseBytes;
 	} FDBMappedKeyValueV2;
 
 #pragma pack(push, 4)

--- a/fdbclient/include/fdbclient/MultiVersionTransaction.h
+++ b/fdbclient/include/fdbclient/MultiVersionTransaction.h
@@ -83,6 +83,16 @@ struct FdbCApi : public ThreadSafeReferenceCounted<FdbCApi> {
 		unsigned char buffer[32];
 	} FDBMappedKeyValue;
 
+	typedef struct mappedkeyvaluev2 {
+		FDBKey key;
+		FDBKey value;
+		/* It's complicated to map a std::variant to C. For now we assume the underlying requests are always getRange
+		 * and take the shortcut. */
+		FDBGetRangeReqAndResult getRange;
+		unsigned char buffer[32];
+		FDBKey responseBytes;
+	} FDBMappedKeyValueV2;
+
 #pragma pack(push, 4)
 	typedef struct keyrange {
 		const void* beginKey;
@@ -300,9 +310,27 @@ struct FdbCApi : public ThreadSafeReferenceCounted<FdbCApi> {
 	                                        int targetBytes,
 	                                        FDBStreamingMode mode,
 	                                        int iteration,
-	                                        int matchIndex,
 	                                        fdb_bool_t snapshot,
 	                                        fdb_bool_t reverse);
+	FDBFuture* (*transactiongetMappedRangeV2)(FDBTransaction* tr,
+	                                          uint8_t const* beginKeyName,
+	                                          int beginKeyNameLength,
+	                                          fdb_bool_t beginOrEqual,
+	                                          int beginOffset,
+	                                          uint8_t const* endKeyName,
+	                                          int endKeyNameLength,
+	                                          fdb_bool_t endOrEqual,
+	                                          int endOffset,
+	                                          uint8_t const* mapper_name,
+	                                          int mapper_name_length,
+	                                          int limit,
+	                                          int targetBytes,
+	                                          FDBStreamingMode mode,
+	                                          int iteration,
+	                                          fdb_bool_t snapshot,
+	                                          fdb_bool_t reverse,
+	                                          uint8_t const* paramsBytes,
+	                                          int paramsBytes_length);
 	FDBFuture* (*transactionGetVersionstamp)(FDBTransaction* tr);
 
 	void (*transactionSet)(FDBTransaction* tr,
@@ -410,6 +438,10 @@ struct FdbCApi : public ThreadSafeReferenceCounted<FdbCApi> {
 	                                            FDBMappedKeyValue const** outKVM,
 	                                            int* outCount,
 	                                            fdb_bool_t* outMore);
+	fdb_error_t (*futureGetMappedKeyValueArrayV2)(FDBFuture* f,
+	                                              FDBMappedKeyValueV2 const** outKVM,
+	                                              int* outCount,
+	                                              fdb_bool_t* outMore);
 	fdb_error_t (*futureGetGranuleSummaryArray)(FDBFuture* f, const FDBGranuleSummary** out_summaries, int* outCount);
 	fdb_error_t (*futureGetSharedState)(FDBFuture* f, DatabaseSharedState** outPtr);
 	fdb_error_t (*futureSetCallback)(FDBFuture* f, FDBCallback callback, void* callback_parameter);
@@ -461,9 +493,15 @@ public:
 	                                               const KeySelectorRef& end,
 	                                               const StringRef& mapper,
 	                                               GetRangeLimits limits,
-	                                               int matchIndex,
 	                                               bool snapshot,
 	                                               bool reverse) override;
+	ThreadFuture<MappedRangeResultV2> getMappedRangeV2(const KeySelectorRef& begin,
+	                                                   const KeySelectorRef& end,
+	                                                   const StringRef& mapper,
+	                                                   const StringRef& paramsBytes,
+	                                                   GetRangeLimits limits,
+	                                                   bool snapshot,
+	                                                   bool reverse) override;
 	ThreadFuture<Standalone<VectorRef<const char*>>> getAddressesForKey(const KeyRef& key) override;
 	ThreadFuture<Standalone<StringRef>> getVersionstamp() override;
 	ThreadFuture<int64_t> getEstimatedRangeSizeBytes(const KeyRangeRef& keys) override;
@@ -692,9 +730,15 @@ public:
 	                                               const KeySelectorRef& end,
 	                                               const StringRef& mapper,
 	                                               GetRangeLimits limits,
-	                                               int matchIndex,
 	                                               bool snapshot,
 	                                               bool reverse) override;
+	ThreadFuture<MappedRangeResultV2> getMappedRangeV2(const KeySelectorRef& begin,
+	                                                   const KeySelectorRef& end,
+	                                                   const StringRef& mapper,
+	                                                   const StringRef& paramsBytes,
+	                                                   GetRangeLimits limits,
+	                                                   bool snapshot,
+	                                                   bool reverse) override;
 	ThreadFuture<Standalone<VectorRef<const char*>>> getAddressesForKey(const KeyRef& key) override;
 	ThreadFuture<Standalone<StringRef>> getVersionstamp() override;
 

--- a/fdbclient/include/fdbclient/NativeAPI.actor.h
+++ b/fdbclient/include/fdbclient/NativeAPI.actor.h
@@ -392,17 +392,24 @@ public:
 	                                                       const KeySelector& end,
 	                                                       const Key& mapper,
 	                                                       GetRangeLimits limits,
-	                                                       int matchIndex = MATCH_INDEX_ALL,
 	                                                       Snapshot = Snapshot::False,
 	                                                       Reverse = Reverse::False);
+
+	[[nodiscard]] Future<MappedRangeResultV2> getMappedRangeV2(const KeySelector& begin,
+	                                                           const KeySelector& end,
+	                                                           const Key& mapper,
+	                                                           const Key& paramsBytes,
+	                                                           GetRangeLimits limits,
+	                                                           Snapshot = Snapshot::False,
+	                                                           Reverse = Reverse::False);
 
 private:
 	template <class GetKeyValuesFamilyRequest, class GetKeyValuesFamilyReply, class RangeResultFamily>
 	Future<RangeResultFamily> getRangeInternal(const KeySelector& begin,
 	                                           const KeySelector& end,
 	                                           const Key& mapper,
+	                                           const Key& paramsBytes,
 	                                           GetRangeLimits limits,
-	                                           int matchIndex,
 	                                           Snapshot snapshot,
 	                                           Reverse reverse);
 

--- a/fdbclient/include/fdbclient/PaxosConfigTransaction.h
+++ b/fdbclient/include/fdbclient/PaxosConfigTransaction.h
@@ -54,9 +54,17 @@ public:
 	                                         KeySelector end,
 	                                         Key mapper,
 	                                         GetRangeLimits limits,
-	                                         int matchIndex = MATCH_INDEX_ALL,
 	                                         Snapshot = Snapshot::False,
 	                                         Reverse = Reverse::False) override {
+		throw client_invalid_operation();
+	}
+	Future<MappedRangeResultV2> getMappedRangeV2(KeySelector begin,
+	                                             KeySelector end,
+	                                             Key mapper,
+	                                             Key paramsBytes,
+	                                             GetRangeLimits limits,
+	                                             Snapshot = Snapshot::False,
+	                                             Reverse = Reverse::False) override {
 		throw client_invalid_operation();
 	}
 	void set(KeyRef const& key, ValueRef const& value) override;

--- a/fdbclient/include/fdbclient/ReadYourWrites.h
+++ b/fdbclient/include/fdbclient/ReadYourWrites.h
@@ -114,10 +114,15 @@ public:
 	                                         KeySelector end,
 	                                         Key mapper,
 	                                         GetRangeLimits limits,
-	                                         int matchIndex,
 	                                         Snapshot = Snapshot::False,
 	                                         Reverse = Reverse::False) override;
-
+	Future<MappedRangeResultV2> getMappedRangeV2(KeySelector begin,
+	                                             KeySelector end,
+	                                             Key mapper,
+	                                             Key paramsBytes,
+	                                             GetRangeLimits limits,
+	                                             Snapshot = Snapshot::False,
+	                                             Reverse = Reverse::False) override;
 	[[nodiscard]] Future<Standalone<VectorRef<const char*>>> getAddressesForKey(const Key& key) override;
 	Future<Standalone<VectorRef<KeyRef>>> getRangeSplitPoints(const KeyRange& range, int64_t chunkSize) override;
 	Future<int64_t> getEstimatedRangeSizeBytes(const KeyRange& keys) override;

--- a/fdbclient/include/fdbclient/SimpleConfigTransaction.h
+++ b/fdbclient/include/fdbclient/SimpleConfigTransaction.h
@@ -63,9 +63,17 @@ public:
 	                                         KeySelector end,
 	                                         Key mapper,
 	                                         GetRangeLimits limits,
-	                                         int matchIndex,
 	                                         Snapshot = Snapshot::False,
 	                                         Reverse = Reverse::False) override {
+		throw client_invalid_operation();
+	}
+	Future<MappedRangeResultV2> getMappedRangeV2(KeySelector begin,
+	                                             KeySelector end,
+	                                             Key mapper,
+	                                             Key paramsBytes,
+	                                             GetRangeLimits limits,
+	                                             Snapshot = Snapshot::False,
+	                                             Reverse = Reverse::False) override {
 		throw client_invalid_operation();
 	}
 	Future<Void> commit() override;

--- a/fdbclient/include/fdbclient/ThreadSafeTransaction.h
+++ b/fdbclient/include/fdbclient/ThreadSafeTransaction.h
@@ -161,9 +161,15 @@ public:
 	                                               const KeySelectorRef& end,
 	                                               const StringRef& mapper,
 	                                               GetRangeLimits limits,
-	                                               int matchIndex,
 	                                               bool snapshot,
 	                                               bool reverse) override;
+	ThreadFuture<MappedRangeResultV2> getMappedRangeV2(const KeySelectorRef& begin,
+	                                                   const KeySelectorRef& end,
+	                                                   const StringRef& mapper,
+	                                                   const StringRef& paramsBytes,
+	                                                   GetRangeLimits limits,
+	                                                   bool snapshot,
+	                                                   bool reverse) override;
 	ThreadFuture<Standalone<VectorRef<const char*>>> getAddressesForKey(const KeyRef& key) override;
 	ThreadFuture<Standalone<StringRef>> getVersionstamp() override;
 	ThreadFuture<int64_t> getEstimatedRangeSizeBytes(const KeyRangeRef& keys) override;

--- a/fdbserver/StorageCache.actor.cpp
+++ b/fdbserver/StorageCache.actor.cpp
@@ -2279,6 +2279,9 @@ ACTOR Future<Void> storageCacheServer(StorageServerInterface ssi,
 			when(GetMappedKeyValuesRequest req = waitNext(ssi.getMappedKeyValues.getFuture())) {
 				ASSERT(false);
 			}
+			when(GetMappedKeyValuesRequestV2 req = waitNext(ssi.getMappedKeyValuesV2.getFuture())) {
+				ASSERT(false);
+			}
 			when(WaitMetricsRequest req = waitNext(ssi.waitMetrics.getFuture())) {
 				ASSERT(false);
 			}

--- a/fdbserver/include/fdbserver/workloads/ApiWorkload.h
+++ b/fdbserver/include/fdbserver/workloads/ApiWorkload.h
@@ -55,10 +55,16 @@ struct TransactionWrapper : public ReferenceCounted<TransactionWrapper> {
 	                                                 KeySelector& end,
 	                                                 Key& mapper,
 	                                                 GetRangeLimits limits,
-	                                                 int matchIndex,
 	                                                 Snapshot snapshot,
 	                                                 Reverse reverse) = 0;
 
+	virtual Future<MappedRangeResultV2> getMappedRangeV2(KeySelector& begin,
+	                                                     KeySelector& end,
+	                                                     Key& mapper,
+	                                                     Key& paramsBytes,
+	                                                     GetRangeLimits limits,
+	                                                     Snapshot snapshot,
+	                                                     Reverse reverse) = 0;
 	// Gets the key from the database specified by a given key selector
 	virtual Future<Key> getKey(KeySelectorRef& key) = 0;
 
@@ -128,10 +134,19 @@ struct FlowTransactionWrapper : public TransactionWrapper {
 	                                         KeySelector& end,
 	                                         Key& mapper,
 	                                         GetRangeLimits limits,
-	                                         int matchIndex,
 	                                         Snapshot snapshot,
 	                                         Reverse reverse) override {
-		return transaction.getMappedRange(begin, end, mapper, limits, matchIndex, snapshot, reverse);
+		return transaction.getMappedRange(begin, end, mapper, limits, snapshot, reverse);
+	}
+
+	Future<MappedRangeResultV2> getMappedRangeV2(KeySelector& begin,
+	                                             KeySelector& end,
+	                                             Key& mapper,
+	                                             Key& paramsBytes,
+	                                             GetRangeLimits limits,
+	                                             Snapshot snapshot,
+	                                             Reverse reverse) override {
+		return transaction.getMappedRangeV2(begin, end, mapper, paramsBytes, limits, snapshot, reverse);
 	}
 
 	// Gets the key from the database specified by a given key selector
@@ -204,11 +219,20 @@ struct ThreadTransactionWrapper : public TransactionWrapper {
 	                                         KeySelector& end,
 	                                         Key& mapper,
 	                                         GetRangeLimits limits,
-	                                         int matchIndex,
 	                                         Snapshot snapshot,
 	                                         Reverse reverse) override {
+		return unsafeThreadFutureToFuture(transaction->getMappedRange(begin, end, mapper, limits, snapshot, reverse));
+	}
+
+	Future<MappedRangeResultV2> getMappedRangeV2(KeySelector& begin,
+	                                             KeySelector& end,
+	                                             Key& mapper,
+	                                             Key& paramsBytes,
+	                                             GetRangeLimits limits,
+	                                             Snapshot snapshot,
+	                                             Reverse reverse) override {
 		return unsafeThreadFutureToFuture(
-		    transaction->getMappedRange(begin, end, mapper, limits, matchIndex, snapshot, reverse));
+		    transaction->getMappedRangeV2(begin, end, mapper, paramsBytes, limits, snapshot, reverse));
 	}
 
 	// Gets the key from the database specified by a given key selector

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -153,6 +153,8 @@ bool canReplyWith(Error e) {
 	case error_code_key_not_tuple:
 	case error_code_value_not_tuple:
 	case error_code_mapper_not_tuple:
+	case error_code_get_mapped_range_version_not_support:
+	case error_code_get_mapped_range_parsing_error:
 		// case error_code_all_alternatives_failed:
 		return true;
 	default:
@@ -3725,12 +3727,14 @@ static inline void copyOptionalValue(Arena* a,
 		a->dependsOn(optionalValue.get().arena());
 	}
 }
-ACTOR Future<GetValueReqAndResultRef> quickGetValue(StorageServer* data,
-                                                    StringRef key,
-                                                    Version version,
-                                                    Arena* a,
-                                                    // To provide span context, tags, debug ID to underlying lookups.
-                                                    GetMappedKeyValuesRequest* pOriginalReq) {
+ACTOR template <class Req>
+Future<GetValueReqAndResultRef> quickGetValue(StorageServer* data,
+                                              StringRef key,
+                                              Version version,
+                                              bool fetchLocalOnly,
+                                              Arena* a,
+                                              // To provide span context, tags, debug ID to underlying lookups.
+                                              Req* pOriginalReq) {
 	state GetValueReqAndResultRef getValue;
 	state double getValueStart = g_network->timer();
 	getValue.key = key;
@@ -3765,7 +3769,7 @@ ACTOR Future<GetValueReqAndResultRef> quickGetValue(StorageServer* data,
 	// Otherwise fallback.
 
 	++data->counters.quickGetValueMiss;
-	if (SERVER_KNOBS->QUICK_GET_VALUE_FALLBACK) {
+	if (!fetchLocalOnly) {
 		Optional<Reference<Tenant>> tenant = pOriginalReq->tenantInfo.hasTenant()
 		                                         ? makeReference<Tenant>(pOriginalReq->tenantInfo.tenantId)
 		                                         : Optional<Reference<Tenant>>();
@@ -4384,13 +4388,14 @@ ACTOR Future<Void> getKeyValuesQ(StorageServer* data, GetKeyValuesRequest req)
 	return Void();
 }
 
-ACTOR Future<GetRangeReqAndResultRef> quickGetKeyValues(
-    StorageServer* data,
-    StringRef prefix,
-    Version version,
-    Arena* a,
-    // To provide span context, tags, debug ID to underlying lookups.
-    GetMappedKeyValuesRequest* pOriginalReq) {
+ACTOR template <class Req>
+Future<GetRangeReqAndResultRef> quickGetKeyValues(StorageServer* data,
+                                                  StringRef prefix,
+                                                  Version version,
+                                                  bool fetchLocalOnly,
+                                                  Arena* a,
+                                                  // To provide span context, tags, debug ID to underlying lookups.
+                                                  Req* pOriginalReq) {
 	state GetRangeReqAndResultRef getRange;
 	state double getValuesStart = g_network->timer();
 	getRange.begin = firstGreaterOrEqual(KeyRef(*a, prefix));
@@ -4442,7 +4447,7 @@ ACTOR Future<GetRangeReqAndResultRef> quickGetKeyValues(
 	}
 
 	++data->counters.quickGetKeyValuesMiss;
-	if (SERVER_KNOBS->QUICK_GET_KEY_VALUES_FALLBACK) {
+	if (!fetchLocalOnly) {
 		Optional<Reference<Tenant>> tenant = pOriginalReq->tenantInfo.hasTenant()
 		                                         ? makeReference<Tenant>(pOriginalReq->tenantInfo.tenantId)
 		                                         : Optional<Reference<Tenant>>();
@@ -5043,33 +5048,145 @@ TEST_CASE("/fdbserver/storageserver/constructMappedKey") {
 	return Void();
 }
 
+/*
+Request Schema:
+The first byte is always version.
+Each field is a type code followed by the contents.
+V = 2:
+    byte[0] = version
+    byte[1] = type code of int *matchIndex*
+    byte[2-5] = *matchIndex* content in little endian
+    byte[6] = type code of bool *fetchLocalOnly*
+    byte[7] = *fetchLocalOnly* content
+*/
+
+/*
+Reply Schema:
+The first byte is always version.
+Each field is a type code followed by the contents.
+V = 2:
+    byte[0] = version
+    byte[1] = type code of int *local*
+    byte[2] = *local* content
+*/
+
+std::unordered_map<int, int> versionToPosMatchIndex = { std::make_pair(2, 1) };
+std::unordered_map<int, int> versionToPosFetchLocalOnly = { std::make_pair(2, 6) };
+std::unordered_map<int, int> versionToPosLocal = { std::make_pair(2, 1) };
+std::set<int> supportedVersions{ 2 };
+
+const int code_int = 1;
+const int code_bool = 2;
+
+void fillReply(Arena* a, int getMappedRangeProtocolVersion, MappedKeyValueRef* kvm, int local) {
+	return;
+}
+
+void setLocal(Arena* a, int getMappedRangeProtocolVersion, MappedKeyValueRefV2* kvm, int local) {
+	uint8_t replyBytes[MAPPED_KEY_VALUE_RESPONSE_BYTES_LENGTH_V2];
+	memset(replyBytes, 0, MAPPED_KEY_VALUE_RESPONSE_BYTES_LENGTH_V2);
+	int localPos = versionToPosLocal[getMappedRangeProtocolVersion];
+	replyBytes[0] = getMappedRangeProtocolVersion;
+	replyBytes[localPos] = code_bool;
+	replyBytes[localPos + 1] = local;
+	kvm->responseBytes = StringRef(*a, replyBytes, MAPPED_KEY_VALUE_RESPONSE_BYTES_LENGTH_V2);
+}
+
+void fillReply(Arena* a, int getMappedRangeProtocolVersion, MappedKeyValueRefV2* kvm, int local) {
+	setLocal(a, getMappedRangeProtocolVersion, kvm, local);
+}
+
+// returns protocol version for getMappedRange
+int parseParams(GetMappedKeyValuesRequest* req, int* matchIndex, bool* fetchLocalOnly) {
+	*matchIndex = MATCH_INDEX_ALL;
+	*fetchLocalOnly = false;
+	return 0;
+}
+
+void parseMatchIndex(KeyRef paramsBytes, int* matchIndex, int version) {
+	int pos = versionToPosMatchIndex[version];
+	if (paramsBytes[pos] != code_int) {
+		TraceEvent("ErrorParsingMatchIndex").detail("Version", version);
+		throw get_mapped_range_parsing_error();
+	}
+	std::memcpy(matchIndex,
+	            paramsBytes.begin() + pos + 1,
+	            sizeof(int)); // assuming to have little endian, if not, then build the int with customized method
+}
+
+void parseFetchLocalOnly(KeyRef paramsBytes, bool* fetchLocalOnly, int version) {
+	int pos = versionToPosFetchLocalOnly[version];
+	if (paramsBytes[pos] != code_bool) {
+		TraceEvent("ErrorParsingFetchLocalOnly").detail("Version", version);
+		throw get_mapped_range_parsing_error();
+	}
+	*fetchLocalOnly = paramsBytes[pos + 1];
+}
+
+// returns protocol version for getMappedRange
+int parseParams(GetMappedKeyValuesRequestV2* req, int* matchIndex, bool* fetchLocalOnly) {
+	KeyRef paramsBytes = req->paramsBytes;
+	int v = paramsBytes[0];
+
+	if (v < *supportedVersions.begin() || v > *supportedVersions.rbegin()) {
+		TraceEvent("ErrorVersionNotSupport").detail("Version", v);
+		throw get_mapped_range_version_not_support();
+	}
+	parseMatchIndex(paramsBytes, matchIndex, v);
+	parseFetchLocalOnly(paramsBytes, fetchLocalOnly, v);
+	return v;
+}
+
 // Issues a secondary query (either range and point read) and fills results into "kvm".
-ACTOR Future<Void> mapSubquery(StorageServer* data,
-                               Version version,
-                               GetMappedKeyValuesRequest* pOriginalReq,
-                               Arena* pArena,
-                               int matchIndex,
-                               bool isRangeQuery,
-                               KeyValueRef* it,
-                               MappedKeyValueRef* kvm,
-                               Key mappedKey) {
+ACTOR template <class Req, class MappedKV>
+Future<Void> mapSubquery(StorageServer* data,
+                         Version version,
+                         Req* pOriginalReq,
+                         Arena* pArena,
+                         int matchIndex,
+                         bool fetchLocalOnly,
+                         bool isRangeQuery,
+                         KeyValueRef* it,
+                         MappedKV* kvm,
+                         Key mappedKey,
+                         int getMappedRangeProtocolVersion,
+                         int index) {
 	if (isRangeQuery) {
 		// Use the mappedKey as the prefix of the range query.
-		GetRangeReqAndResultRef getRange = wait(quickGetKeyValues(data, mappedKey, version, pArena, pOriginalReq));
-		if ((!getRange.result.empty() && matchIndex == MATCH_INDEX_MATCHED_ONLY) ||
-		    (getRange.result.empty() && matchIndex == MATCH_INDEX_UNMATCHED_ONLY) || matchIndex == MATCH_INDEX_ALL) {
-			kvm->key = it->key;
-			kvm->value = it->value;
+		// if MappedKV is MappedKeyValueRefV2, then set it
+		try {
+			GetRangeReqAndResultRef getRange =
+			    wait(quickGetKeyValues(data, mappedKey, version, fetchLocalOnly, pArena, pOriginalReq));
+			if ((!getRange.result.empty() && matchIndex == MATCH_INDEX_MATCHED_ONLY) ||
+			    (getRange.result.empty() && matchIndex == MATCH_INDEX_UNMATCHED_ONLY) ||
+			    matchIndex == MATCH_INDEX_ALL || std::is_same<Req, GetMappedKeyValuesRequest>::value) {
+				kvm->key = it->key;
+				kvm->value = it->value;
+			}
+			kvm->reqAndResult = getRange;
+			fillReply(pArena, getMappedRangeProtocolVersion, kvm, true);
+		} catch (Error& e) {
+			if (e.code() == error_code_quick_get_key_values_miss) {
+				// for a local miss when remote fetch is disabled, catch the error and always add index KV
+				kvm->key = it->key;
+				kvm->value = it->value;
+				kvm->reqAndResult = GetRangeReqAndResultRef();
+				fillReply(pArena, getMappedRangeProtocolVersion, kvm, false);
+			} else {
+				// pop up other errors to client(e.g. transaction_too_old)
+				throw;
+			}
 		}
-		kvm->reqAndResult = getRange;
 	} else {
-		GetValueReqAndResultRef getValue = wait(quickGetValue(data, mappedKey, version, pArena, pOriginalReq));
+		GetValueReqAndResultRef getValue =
+		    wait(quickGetValue(data, mappedKey, version, fetchLocalOnly, pArena, pOriginalReq));
 		kvm->reqAndResult = getValue;
 	}
 	return Void();
 }
 
-int getMappedKeyValueSize(MappedKeyValueRef mappedKeyValue) {
+template <class MappedKV>
+int getMappedKeyValueSize(MappedKV mappedKeyValue) {
 	auto& reqAndResult = mappedKeyValue.reqAndResult;
 	int bytes = 0;
 	if (std::holds_alternative<GetValueReqAndResultRef>(reqAndResult)) {
@@ -5084,18 +5201,17 @@ int getMappedKeyValueSize(MappedKeyValueRef mappedKeyValue) {
 	return bytes;
 }
 
-ACTOR Future<GetMappedKeyValuesReply> mapKeyValues(StorageServer* data,
-                                                   GetKeyValuesReply input,
-                                                   StringRef mapper,
-                                                   // To provide span context, tags, debug ID to underlying lookups.
-                                                   GetMappedKeyValuesRequest* pOriginalReq,
-                                                   int matchIndex,
-                                                   int* remainingLimitBytes) {
-	state GetMappedKeyValuesReply result;
+ACTOR template <class Req, class Reply, class MappedKV>
+Future<Reply> mapKeyValues(StorageServer* data,
+                           GetKeyValuesReply input,
+                           StringRef mapper,
+                           // To provide span context, tags, debug ID to underlying lookups.
+                           Req* pOriginalReq,
+                           int* remainingLimitBytes) {
+	state Reply result;
 	result.version = input.version;
 	result.cached = input.cached;
 	result.arena.dependsOn(input.arena);
-
 	result.data.reserve(result.arena, input.data.size());
 	if (pOriginalReq->options.present() && pOriginalReq->options.get().debugID.present())
 		g_traceBatch.addEvent(
@@ -5110,11 +5226,14 @@ ACTOR Future<GetMappedKeyValuesReply> mapKeyValues(StorageServer* data,
 	}
 	state std::vector<Optional<Tuple>> vt;
 	state bool isRangeQuery = false;
+	state int matchIndex;
+	state bool fetchLocalOnly;
+	state int getMappedRangeProtocolVersion = parseParams(pOriginalReq, &matchIndex, &fetchLocalOnly);
 	preprocessMappedKey(mappedKeyFormatTuple, vt, isRangeQuery);
 
 	state int sz = input.data.size();
 	const int k = std::min(sz, SERVER_KNOBS->MAX_PARALLEL_QUICK_GET_VALUE);
-	state std::vector<MappedKeyValueRef> kvms(k);
+	state std::vector<MappedKV> kvms(k);
 	state std::vector<Future<Void>> subqueries;
 	state int offset = 0;
 	if (pOriginalReq->options.present() && pOriginalReq->options.get().debugID.present())
@@ -5126,7 +5245,7 @@ ACTOR Future<GetMappedKeyValuesReply> mapKeyValues(StorageServer* data,
 		// Divide into batches of MAX_PARALLEL_QUICK_GET_VALUE subqueries
 		for (int i = 0; i + offset < sz && i < SERVER_KNOBS->MAX_PARALLEL_QUICK_GET_VALUE; i++) {
 			KeyValueRef* it = &input.data[i + offset];
-			MappedKeyValueRef* kvm = &kvms[i];
+			MappedKV* kvm = &kvms[i];
 			// Clear key value to the default.
 			kvm->key = ""_sr;
 			kvm->value = ""_sr;
@@ -5136,9 +5255,18 @@ ACTOR Future<GetMappedKeyValuesReply> mapKeyValues(StorageServer* data,
 
 			// std::cout << "key:" << printable(kvm->key) << ", value:" << printable(kvm->value)
 			//          << ", mappedKey:" << printable(mappedKey) << std::endl;
-
-			subqueries.push_back(mapSubquery(
-			    data, input.version, pOriginalReq, &result.arena, matchIndex, isRangeQuery, it, kvm, mappedKey));
+			subqueries.push_back(mapSubquery(data,
+			                                 input.version,
+			                                 pOriginalReq,
+			                                 &result.arena,
+			                                 matchIndex,
+			                                 fetchLocalOnly,
+			                                 isRangeQuery,
+			                                 it,
+			                                 kvm,
+			                                 mappedKey,
+			                                 getMappedRangeProtocolVersion,
+			                                 i + offset));
 		}
 		wait(waitForAll(subqueries));
 		if (pOriginalReq->options.present() && pOriginalReq->options.get().debugID.present())
@@ -5157,8 +5285,8 @@ ACTOR Future<GetMappedKeyValuesReply> mapKeyValues(StorageServer* data,
 			}
 		}
 	}
-
 	int resultSize = result.data.size();
+
 	if (resultSize > 0) {
 		// keep index for boundary index entries, so that caller can use it as a continuation.
 		result.data[0].key = input.data[0].key;
@@ -5352,7 +5480,8 @@ TEST_CASE("/fdbserver/storageserver/randomRangeIntersectsAnyTenant") {
 
 // Most of the actor is copied from getKeyValuesQ. I tried to use templates but things become nearly impossible after
 // combining actor shenanigans with template shenanigans.
-ACTOR Future<Void> getMappedKeyValuesQ(StorageServer* data, GetMappedKeyValuesRequest req)
+ACTOR template <class Req, class Reply, class MappedKV>
+Future<Void> getMappedKeyValuesQ(StorageServer* data, Req req)
 // Throws a wrong_shard_server if the keys in the request or result depend on data outside this server OR if a large
 // selector offset prevents all data from being read in one range read
 {
@@ -5468,7 +5597,7 @@ ACTOR Future<Void> getMappedKeyValuesQ(StorageServer* data, GetMappedKeyValuesRe
 				                      "storageserver.getMappedKeyValues.Send");
 			//.detail("Begin",begin).detail("End",end);
 
-			GetMappedKeyValuesReply none;
+			Reply none;
 			none.version = version;
 			none.more = false;
 			none.penalty = data->getPenalty();
@@ -5491,17 +5620,16 @@ ACTOR Future<Void> getMappedKeyValuesQ(StorageServer* data, GetMappedKeyValuesRe
 			                                                     span.context,
 			                                                     req.options,
 			                                                     req.tenantInfo.prefix));
-
 			// Unlock read lock before the subqueries because each
 			// subquery will route back to getValueQ or getKeyValuesQ with a new request having the same
 			// read options which will each acquire the ssLock.
 			readLock.release();
 
-			state GetMappedKeyValuesReply r;
+			state Reply r;
 			try {
 				// Map the scanned range to another list of keys and look up.
-				GetMappedKeyValuesReply _r =
-				    wait(mapKeyValues(data, getKeyValuesReply, req.mapper, &req, req.matchIndex, &remainingLimitBytes));
+				Reply _r = wait(mapKeyValues<Req, Reply, MappedKV>(
+				    data, getKeyValuesReply, req.mapper, &req, &remainingLimitBytes));
 				r = _r;
 			} catch (Error& e) {
 				// catch txn_too_old here if prefetch runs for too long, and returns it back to client
@@ -10979,10 +11107,22 @@ ACTOR Future<Void> serveGetMappedKeyValuesRequests(StorageServer* self,
 	getCurrentLineage()->modify(&TransactionLineage::operation) = TransactionLineage::Operation::GetKeyValues;
 	loop {
 		GetMappedKeyValuesRequest req = waitNext(getMappedKeyValues);
-
 		// Warning: This code is executed at extremely high priority (TaskPriority::LoadBalancedEndpoint), so downgrade
 		// before doing real work
-		self->actors.add(self->readGuard(req, getMappedKeyValuesQ));
+		self->actors.add(
+		    getMappedKeyValuesQ<GetMappedKeyValuesRequest, GetMappedKeyValuesReply, MappedKeyValueRef>(self, req));
+	}
+}
+
+ACTOR Future<Void> serveGetMappedKeyValuesRequestsV2(StorageServer* self,
+                                                     FutureStream<GetMappedKeyValuesRequestV2> getMappedKeyValuesV2) {
+	// TODO: Is it fine to keep TransactionLineage::Operation::GetKeyValues here?
+	getCurrentLineage()->modify(&TransactionLineage::operation) = TransactionLineage::Operation::GetKeyValues;
+	loop {
+		GetMappedKeyValuesRequestV2 req = waitNext(getMappedKeyValuesV2);
+		self->actors.add(
+		    getMappedKeyValuesQ<GetMappedKeyValuesRequestV2, GetMappedKeyValuesReplyV2, MappedKeyValueRefV2>(self,
+		                                                                                                     req));
 	}
 }
 
@@ -11218,6 +11358,7 @@ ACTOR Future<Void> storageServerCore(StorageServer* self, StorageServerInterface
 	self->actors.add(serveGetValueRequests(self, ssi.getValue.getFuture()));
 	self->actors.add(serveGetKeyValuesRequests(self, ssi.getKeyValues.getFuture()));
 	self->actors.add(serveGetMappedKeyValuesRequests(self, ssi.getMappedKeyValues.getFuture()));
+	self->actors.add(serveGetMappedKeyValuesRequestsV2(self, ssi.getMappedKeyValuesV2.getFuture()));
 	self->actors.add(serveGetKeyValuesStreamRequests(self, ssi.getKeyValuesStream.getFuture()));
 	self->actors.add(serveGetKeyRequests(self, ssi.getKey.getFuture()));
 	self->actors.add(serveWatchValueRequests(self, ssi.watchValue.getFuture()));

--- a/fdbserver/worker.actor.cpp
+++ b/fdbserver/worker.actor.cpp
@@ -2375,6 +2375,7 @@ ACTOR Future<Void> workerServer(Reference<IClusterConnectionRecord> connRecord,
 					DUMPTOKEN(recruited.ssi.getKey);
 					DUMPTOKEN(recruited.ssi.getKeyValues);
 					DUMPTOKEN(recruited.ssi.getMappedKeyValues);
+					DUMPTOKEN(recruited.ssi.getMappedKeyValuesV2);
 					DUMPTOKEN(recruited.ssi.getShardState);
 					DUMPTOKEN(recruited.ssi.waitMetrics);
 					DUMPTOKEN(recruited.ssi.splitMetrics);

--- a/fdbserver/workloads/GetMappedRange.actor.cpp
+++ b/fdbserver/workloads/GetMappedRange.actor.cpp
@@ -21,6 +21,7 @@
 #include <algorithm>
 #include "fdbclient/MutationLogReader.actor.h"
 #include "fdbclient/Tuple.h"
+#include "fdbclient/MappedRange.h"
 #include "fdbserver/workloads/ApiWorkload.h"
 #include "fdbserver/workloads/workloads.actor.h"
 #include "fdbserver/Knobs.h"
@@ -37,15 +38,9 @@ const KeyRef prefix = "prefix"_sr;
 const KeyRef RECORD = "RECORD"_sr;
 const KeyRef INDEX = "INDEX"_sr;
 const int MATCH_INDEX_TEST_710_API = -1;
-const int code_int = 1;
-const int code_bool = 2;
 const int code_invalid = 0;
 const int VERSION = 2;
 const int INVALID_VERSION = 1;
-static std::unordered_map<int, int> versionToPosMatchIndex = { std::make_pair(2, 1) };
-static std::unordered_map<int, int> versionToPosFetchLocalOnly = { std::make_pair(2, 6) };
-static std::unordered_map<int, int> versionToPosLocal = { std::make_pair(2, 1) };
-static std::unordered_map<int, int> versionToLength = { std::make_pair(2, 8) };
 
 int recordSize;
 int indexSize;
@@ -289,7 +284,7 @@ struct GetMappedRangeWorkload : ApiWorkload {
 
 		state bool fetchLocalOnly = deterministicRandom()->random01() < 0.5;
 		state int currentVersion = deterministicRandom()->random01() < 0.9 ? VERSION : INVALID_VERSION;
-		state int codeMatchIndex = deterministicRandom()->random01() < 0.95 ? code_int : code_invalid;
+		state int codeMatchIndex = deterministicRandom()->random01() < 0.95 ? code_uint8 : code_invalid;
 		state int codeFetchLocalOnly = deterministicRandom()->random01() < 0.95 ? code_bool : code_invalid;
 		std::cout << "start scanMappedRangeWithLimits beginSelector:" << beginSelector.toString()
 		          << " endSelector:" << endSelector.toString() << " expectedBeginId:" << expectedBeginId

--- a/flow/include/flow/error_definitions.h
+++ b/flow/include/flow/error_definitions.h
@@ -216,6 +216,8 @@ ERROR( invalid_checkpoint_format, 2044, "Invalid checkpoint format" )
 ERROR( invalid_throttle_quota_value, 2045, "Invalid quota value. Note that reserved_throughput cannot exceed total_throughput" )
 ERROR( failed_to_create_checkpoint, 2046, "Failed to create a checkpoint" )
 ERROR( failed_to_restore_checkpoint, 2047, "Failed to restore a checkpoint" )
+ERROR( get_mapped_range_version_not_support, 2048, "Get mapped range API-defined-version is not supported" )
+ERROR( get_mapped_range_parsing_error, 2049, "Failed to parse byte arrary in get mapped range request" )
 
 ERROR( incompatible_protocol_version, 2100, "Incompatible protocol version" )
 ERROR( transaction_too_large, 2101, "Transaction exceeds byte limit" )

--- a/tests/TestRunner/tmp_cluster.py
+++ b/tests/TestRunner/tmp_cluster.py
@@ -147,6 +147,7 @@ if __name__ == "__main__":
             cmd_args.append(cmd)
         env = dict(**os.environ)
         env["FDB_CLUSTER_FILE"] = env.get("FDB_CLUSTER_FILE", cluster.cluster_file)
+        env["FDB_CLUSTERS"] = env.get("FDB_CLUSTERS", cluster.cluster_file)
         print("command: {}".format(cmd_args))
         errcode = subprocess.run(
             cmd_args, stdout=sys.stdout, stderr=sys.stderr, env=env

--- a/tests/TestRunner/tmp_multi_cluster.py
+++ b/tests/TestRunner/tmp_multi_cluster.py
@@ -71,6 +71,7 @@ if __name__ == "__main__":
         print(cluster_paths)
         env = dict(**os.environ)
         env["FDB_CLUSTERS"] = env.get("FDB_CLUSTERS", cluster_paths)
+        env["FDB_CLUSTER_FILE"] = env.get("FDB_CLUSTER_FILE", cluster_paths)
         cmd_args = []
         for cmd in args.cmd:
             cmd_args.append(cmd)


### PR DESCRIPTION
Two more features are added in V2:
* optionally return index
* indicate whether a primary record is served by this SS taking prefetch index query

A new API is needed because the struct of req/rep have changed and is not backward compatible.

To achieve this, Java takes parameters to indicate how to return index and whether to do a server to server call in the case of a local miss, then encode them in a byte array. C API takes a byte array and knows how to parse it. The reason to have byte array is for extendability -- new fields can be encoded in the byte array without a signature/protocol change.

It is easy to add new fields to request or reply of getMappedRangeV2 API: instead of creating another API, we only need to bump the API-defined protocol version, as long as the client and server both know how to parse the byte array in req/rep.

QUICK_GET_KEY_VALUES_FALLBACK is removed, old API will always try to do server to server call to fetch KV from other SS. While new API can specify this parameter.

g++: 20230127-165936-haofu-8d06b832dc7f0c58, 20230128-001904-haofu-625beece285c9dbb, 20230128-013639-haofu-e84f2a61583422a4

clang: 20230127-170644-haofu-18da7da534f23610, 20230128-000811-haofu-327dac4b735093f8 , 20230128-014224-haofu-f275ec6abc4e5617

 20230201-231332-haofu-3b845ffbe31d8522 

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
