### PR TITLE
Blob granule restarting tests

### DIFF
--- a/contrib/TestHarness2/test_harness/run.py
+++ b/contrib/TestHarness2/test_harness/run.py
@@ -504,9 +504,7 @@ class TestRunner:
                 and config.random.random() < config.unseed_check_ratio
             )
             buggify_enabled: bool = config.random.random() < config.buggify_on_ratio
-            if unseed_check and count != 0:
-                # for restarting tests we will need to restore the sim2 directory after the first run
-                self.backup_sim_dir(seed + count - 1)
+            # FIXME: support unseed checks for restarting tests
             run = TestRun(
                 binary,
                 file.absolute(),
@@ -525,9 +523,7 @@ class TestRunner:
             run.summary.out.dump(sys.stdout)
             if not result:
                 return False
-            if unseed_check and run.summary.unseed is not None:
-                if count != 0:
-                    self.restore_sim_dir(seed + count - 1)
+            if count == 0 and unseed_check and run.summary.unseed is not None:
                 run2 = TestRun(
                     binary,
                     file.absolute(),

--- a/fdbserver/workloads/BlobGranuleVerifier.actor.cpp
+++ b/fdbserver/workloads/BlobGranuleVerifier.actor.cpp
@@ -111,7 +111,7 @@ struct BlobGranuleVerifierWorkload : TestWorkload {
 		sharedRandomNumber /= 3;
 
 		// randomly some tests write data first and then turn on blob granules later, to test conversion of existing DB
-		initAtEnd = !enablePurging && sharedRandomNumber % 10 == 0;
+		initAtEnd = getOption(options, "initAtEnd"_sr, sharedRandomNumber % 10 == 0);
 		sharedRandomNumber /= 10;
 		// FIXME: enable and fix bugs!
 		// granuleSizeCheck = initAtEnd;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -346,6 +346,9 @@ if(WITH_PYTHON)
     TEST_FILES restarting/from_7.3.0/VersionVectorEnableRestart-1.toml
     restarting/from_7.3.0/VersionVectorEnableRestart-2.toml)
   add_fdb_test(
+    TEST_FILES restarting/from_7.3.0/BlobGranuleRestartCycle-1.toml
+    restarting/from_7.3.0/BlobGranuleRestartCycle-2.toml)
+  add_fdb_test(
     TEST_FILES restarting/to_7.1.0_until_7.2.0/ConfigureStorageMigrationTestRestart-1.toml
     restarting/to_7.1.0_until_7.2.0/ConfigureStorageMigrationTestRestart-2.toml)
   add_fdb_test(

--- a/tests/restarting/from_7.3.0/BlobGranuleRestartCycle-1.toml
+++ b/tests/restarting/from_7.3.0/BlobGranuleRestartCycle-1.toml
@@ -1,0 +1,33 @@
+# Blob Granules are only upgrade-able as of snowflake/release-71.2.3 and release
+
+[configuration]
+testClass = "BlobGranuleRestart"
+blobGranulesEnabled = true
+allowDefaultTenant = false
+injectTargetedSSRestart = true
+injectSSDelay = true
+# FIXME: re-enable rocks at some point
+storageEngineExcludeTypes = [4, 5]
+
+[[test]]
+testTitle = 'BlobGranuleRestartCycle'
+clearAfterTest=false
+
+    [[test.workload]]
+    testName = 'Cycle'
+    transactionsPerSecond = 250.0
+    testDuration = 30.0
+    expectedRate = 0
+
+    [[test.workload]]
+    testName = 'BlobGranuleVerifier'
+    testDuration = 30.0
+    # don't delete state after test
+    clearAndMergeCheck = false
+    doForcePurge = false
+    initAtEnd = false
+
+    [[test.workload]]
+    testName='SaveAndKill'
+    restartInfoLocation='simfdb/restartInfo.ini'
+    testDuration=90.0

--- a/tests/restarting/from_7.3.0/BlobGranuleRestartCycle-2.toml
+++ b/tests/restarting/from_7.3.0/BlobGranuleRestartCycle-2.toml
@@ -1,0 +1,27 @@
+# Blob Granules are only upgrade-able as of snowflake/release-71.2.3 and release-7.2
+
+[configuration]
+testClass = "BlobGranuleRestart"
+blobGranulesEnabled = true
+allowDefaultTenant = false
+injectTargetedSSRestart = true
+injectSSDelay = true
+# FIXME: re-enable rocks at some point
+storageEngineExcludeTypes = [4, 5]
+
+[[test]]
+testTitle = 'BlobGranuleRestartCycle'
+clearAfterTest=false
+runSetup=false
+
+    [[test.workload]]
+    testName = 'Cycle'
+    transactionsPerSecond = 250.0
+    testDuration = 30.0
+    expectedRate = 0
+
+    [[test.workload]]
+    testName = 'BlobGranuleVerifier'
+    testDuration = 30.0
+    # cycle does its own workload checking, don't want clear racing with its checking
+    clearAndMergeCheck = false


### PR DESCRIPTION
Added basic blob granule granule restarting tests.
I'll add chaos to the cycle test, and add other workload tests in future PR(s).

Passes 10k of the new test.
To validate the test harness change, it also passed 10k normal correctness, and correctly found unseed errors in non-restarting tests when i injected non-determinism.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
