### PR TITLE
GRV Proxy converts broken_promise errors to master_failed or tlog_failed

### DIFF
--- a/fdbserver/GrvProxyServer.actor.cpp
+++ b/fdbserver/GrvProxyServer.actor.cpp
@@ -1137,8 +1137,10 @@ ACTOR Future<Void> grvProxyServer(GrvProxyInterface proxy,
 		wait(core || checkRemoved(db, req.recoveryCount, proxy));
 	} catch (Error& e) {
 		TraceEvent("GrvProxyTerminated", proxy.id()).errorUnsuppressed(e);
-		CODE_PROBE(e.code() == error_code_master_failed, "master_failed");
-		CODE_PROBE(e.code() == error_code_tlog_failed, "tlog_failed");
+		ASSERT(e.code() !=
+		       error_code_broken_promise); // all broken_promise should be transformed to the correct error code
+		CODE_PROBE(e.code() == error_code_master_failed, "GrvProxyServer master failed");
+		CODE_PROBE(e.code() == error_code_tlog_failed, "GrvProxyServer tlog failed");
 		if (e.code() != error_code_worker_removed && e.code() != error_code_tlog_stopped &&
 		    e.code() != error_code_tlog_failed && e.code() != error_code_coordinators_changed &&
 		    e.code() != error_code_coordinated_state_conflict && e.code() != error_code_new_coordinators_timed_out &&

--- a/flow/include/flow/error_definitions.h
+++ b/flow/include/flow/error_definitions.h
@@ -137,6 +137,7 @@ ERROR( proxy_tag_throttled, 1223, "Exceeded maximum proxy tag throttling duratio
 ERROR( key_value_store_deadline_exceeded, 1224, "Exceeded maximum time allowed to read or write.")
 ERROR( storage_quota_exceeded, 1225, "Exceeded the maximum storage quota allocated to the tenant.")
 ERROR( audit_storage_error, 1226, "Found data corruption" )
+ERROR( master_failed, 1227, "Cluster recovery terminating because master has failed")
 
 // 15xx Platform errors
 ERROR( platform_error, 1500, "Platform error" )


### PR DESCRIPTION
GRV Proxy can convert a broken_promise errors to tlog_failed or master_failed depending on the role that was actually responsible for the broken promise.
# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
