### PR TITLE
Fix misc blob restore error messages

### DIFF
--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -10911,7 +10911,7 @@ ACTOR Future<bool> blobRestoreActor(Reference<DatabaseContext> cx, KeyRange rang
 			Optional<Value> value = wait(tr->get(key));
 			if (value.present()) {
 				Standalone<BlobRestoreStatus> status = decodeBlobRestoreStatus(value.get());
-				if (status.phase != BlobRestorePhase::DONE) {
+				if (status.phase < BlobRestorePhase::DONE) {
 					return false; // stop if there is in-progress restore.
 				}
 			}

--- a/fdbserver/BlobMigrator.actor.cpp
+++ b/fdbserver/BlobMigrator.actor.cpp
@@ -348,11 +348,11 @@ private:
 		BackupDescription desc = wait(bc->describeBackup());
 		if (!desc.contiguousLogEnd.present()) {
 			TraceEvent("InvalidMutationLogs").detail("Url", baseUrl);
-			throw restore_missing_data();
+			throw blob_restore_missing_logs();
 		}
 		if (!desc.minLogBegin.present()) {
 			TraceEvent("InvalidMutationLogs").detail("Url", baseUrl);
-			throw restore_missing_data();
+			throw blob_restore_missing_logs();
 		}
 		state Version minLogVersion = desc.minLogBegin.get();
 		state Version maxLogVersion = desc.contiguousLogEnd.get() - 1;
@@ -369,7 +369,7 @@ private:
 			TraceEvent("MissingMutationLogs")
 			    .detail("MinLogVersion", minLogVersion)
 			    .detail("TargetVersion", maxLogVersion);
-			throw restore_missing_data();
+			throw blob_restore_missing_logs();
 		}
 		if (targetVersion > maxLogVersion) {
 			TraceEvent("SkipTargetVersion")
@@ -388,7 +388,7 @@ private:
 				    .detail("MinLogVersion", minLogVersion)
 				    .detail("MaxLogVersion", maxLogVersion)
 				    .detail("TargetVersion", targetVersion);
-				throw restore_missing_data();
+				throw blob_restore_corrupted_logs();
 			}
 			// no need to apply mutation logs if granule is already on that version
 			if (granule.version < targetVersion) {
@@ -405,7 +405,7 @@ private:
 			TraceEvent("InvalidMutationLogs")
 			    .detail("MinLogVersion", minLogVersion)
 			    .detail("MaxLogVersion", maxLogVersion);
-			throw restore_missing_data();
+			throw blob_restore_corrupted_logs();
 		}
 		std::string tagName = "blobrestore-" + self->interf_.id().shortString();
 		TraceEvent("ApplyMutationLogs", self->interf_.id())

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -2481,13 +2481,13 @@ ACTOR static Future<JsonBuilderObject> blobRestoreStatusFetcher(Database db, std
 				break;
 			case BlobRestorePhase::APPLYING_MLOGS:
 				statusObj["blob_full_restore_phase"] = "Applying mutation logs";
-				statusObj["blob_full_restore_progress"] = status.get().status;
 				break;
 			case BlobRestorePhase::DONE:
 				statusObj["blob_full_restore_phase"] = "Completed successfully";
 				break;
 			case BlobRestorePhase::ERROR:
-				statusObj["blob_full_restore_phase"] = "Completed with fatal error";
+				statusObj["blob_full_restore_phase"] =
+				    "Completed with fatal error: " + std::string(Error(status.get().status).what());
 				break;
 			default:
 				statusObj["blob_full_restore_phase"] = "Unexpected phase";

--- a/flow/include/flow/error_definitions.h
+++ b/flow/include/flow/error_definitions.h
@@ -326,6 +326,8 @@ ERROR( restore_duplicate_uid, 2371, "Attempted to restore using a UID that had b
 ERROR( task_invalid_version, 2381, "Invalid task version")
 ERROR( task_interrupted, 2382, "Task execution stopped due to timeout, abort, or completion by another worker")
 ERROR( invalid_encryption_key_file, 2383, "The provided encryption key file has invalid contents" )
+ERROR( blob_restore_missing_logs, 2384, "Missing mutation logs" )
+ERROR( blob_restore_corrupted_logs, 2385, "Corrupted mutation logs" )
 
 ERROR( key_not_found, 2400, "Expected key is missing")
 ERROR( json_malformed, 2401, "JSON string was malformed")


### PR DESCRIPTION
Fix a few blob restore errors:
1) Added a few error code to indicate missing or corrupted mutation logs
2) Print the error message when blob restore fails
3) Don't show mutation log applying progress because we don't have this progress number yet 

Tested ok in a local cluster

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
