### PR TITLE
increasing timeout since simulated recovery can take >30s, and adding comment

### DIFF
--- a/fdbserver/workloads/DataLossRecovery.actor.cpp
+++ b/fdbserver/workloads/DataLossRecovery.actor.cpp
@@ -81,6 +81,7 @@ struct DataLossRecoveryWorkload : TestWorkload {
 		state Value oldValue = "TestValue"_sr;
 		state Value newValue = "TestNewValue"_sr;
 
+		TraceEvent("DataLossRecovery").detail("Phase", "Starting");
 		wait(self->writeAndVerify(self, cx, key, oldValue));
 
 		TraceEvent("DataLossRecovery").detail("Phase", "InitialWrites");
@@ -118,7 +119,8 @@ struct DataLossRecoveryWorkload : TestWorkload {
 
 		loop {
 			try {
-				state Optional<Value> res = wait(timeoutError(tr.get(key), 30.0));
+				// add timeout to read so test fails faster if something goes wrong
+				state Optional<Value> res = wait(timeoutError(tr.get(key), 90.0));
 				const bool equal = !expectedValue.isError() && res == expectedValue.get();
 				if (!equal) {
 					self->validationFailed(expectedValue, ErrorOr<Optional<Value>>(res));


### PR DESCRIPTION
Due to buggifies and fault injection (for example, [this one](https://github.com/apple/foundationdb/blob/main/fdbserver/ClusterRecovery.actor.cpp#L1391) ), a recovery caused this read to take ~33s, longer than this 30s timeout. Since the timeout is just an optimization to end the test earlier if something goes wrong, I increased the timeout.

Passes 1k DataLossRecovery tests.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
