### PR TITLE
Use real clock source for trace events in real fdbserver, but now() in simulation.

### DIFF
--- a/fdbserver/fdbserver.actor.cpp
+++ b/fdbserver/fdbserver.actor.cpp
@@ -707,9 +707,9 @@ static void printUsage(const char* name, bool devhelp) {
 		                 " `net2-threadpool'.");
 		printOptionUsage("--unbufferedout", " Do not buffer stdout and stderr.");
 		printOptionUsage("--bufferedout", " Buffer stdout and stderr.");
-		printOptionUsage("--traceclock CLOCKIMPL",
-		                 " Select clock source for trace files, `now' (default) or"
-		                 " `realtime'.");
+		printOptionUsage("--traceclock [now,realtime]",
+		                 " Select clock source for trace events, defaults to `now' in simulation"
+		                 " and `realtime' otherwise.");
 		printOptionUsage("--num-testers NUM",
 		                 " A multitester will wait for NUM testers before starting"
 		                 " (defaults to 1).");

--- a/flow/include/flow/Trace.h
+++ b/flow/include/flow/Trace.h
@@ -683,7 +683,7 @@ class Future;
 class Void;
 Future<Void> pingTraceLogWriterThread();
 
-enum trace_clock_t { TRACE_CLOCK_NOW, TRACE_CLOCK_REALTIME };
+enum trace_clock_t { TRACE_CLOCK_DEFAULT, TRACE_CLOCK_NOW, TRACE_CLOCK_REALTIME };
 extern std::atomic<trace_clock_t> g_trace_clock;
 extern TraceBatch g_traceBatch;
 

--- a/flowbench/BenchTimer.cpp
+++ b/flowbench/BenchTimer.cpp
@@ -36,5 +36,13 @@ static void bench_timer_monotonic(benchmark::State& state) {
 	state.SetItemsProcessed(static_cast<long>(state.iterations()));
 }
 
+static void bench_timestamp_counter(benchmark::State& state) {
+	for (auto _ : state) {
+		benchmark::DoNotOptimize(timestampCounter());
+	}
+	state.SetItemsProcessed(static_cast<long>(state.iterations()));
+}
+
 BENCHMARK(bench_timer)->ReportAggregatesOnly(true);
 BENCHMARK(bench_timer_monotonic)->ReportAggregatesOnly(true);
+BENCHMARK(bench_timestamp_counter)->ReportAggregatesOnly(true);


### PR DESCRIPTION
    CommitDebug trace events are useful for measuring, in detail, the time spent in
    the various parts of a single transaction. Like all log events, they have a time
    associated with them. This time comes for now(), which in a real fdb system is
    only updated in the run loop. This renders the timestamps inaccurate in certain
    CPU bound sections which don't have a wait, e.g. in the resolver.
    
    We want to preserve the current behavior in simulation, where the timestamps are
    artificial, deterministic between runs, and only updated in the run loop.
    
    In a real system, we prefer to use a real clock so we can use the difference
    between two trace events in the logs as a measurement of elapsed time.
    
    This does not modify the behavior of other parts of the system, which use the
    cached now() for various purposes.


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
