### PR TITLE
Fixing SkewedReadWrite to load its metadata in a transactionally consistent way

### DIFF
--- a/fdbserver/workloads/SkewedReadWrite.actor.cpp
+++ b/fdbserver/workloads/SkewedReadWrite.actor.cpp
@@ -99,21 +99,26 @@ struct SkewedReadWriteWorkload : ReadWriteCommon {
 	}
 
 	ACTOR static Future<Void> updateServerShards(Database cx, SkewedReadWriteWorkload* self) {
-		state Future<RangeResult> serverList =
-		    runRYWTransaction(cx, [](Reference<ReadYourWritesTransaction> tr) -> Future<RangeResult> {
-			    tr->setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
-			    return tr->getRange(serverListKeys, CLIENT_KNOBS->TOO_MANY);
-		    });
-		state RangeResult range =
-		    wait(runRYWTransaction(cx, [](Reference<ReadYourWritesTransaction> tr) -> Future<RangeResult> {
-			    tr->setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
-			    return tr->getRange(serverKeysRange, CLIENT_KNOBS->TOO_MANY);
-		    }));
-		wait(success(serverList));
+		state RangeResult serverList;
+		state RangeResult range;
+		state Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
+		loop {
+			// read in transaction to ensure two key ranges are transactionally consistent
+			try {
+				tr->setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
+				state Future<RangeResult> serverListF = tr->getRange(serverListKeys, CLIENT_KNOBS->TOO_MANY);
+				state Future<RangeResult> rangeF = tr->getRange(serverKeysRange, CLIENT_KNOBS->TOO_MANY);
+				wait(store(serverList, serverListF));
+				wait(store(range, rangeF));
+				break;
+			} catch (Error& e) {
+				wait(tr->onError(e));
+			}
+		}
 		// decode server interfaces
 		self->serverInterfaces.clear();
-		for (int i = 0; i < serverList.get().size(); i++) {
-			auto ssi = decodeServerListValue(serverList.get()[i].value);
+		for (int i = 0; i < serverList.size(); i++) {
+			auto ssi = decodeServerListValue(serverList[i].value);
 			self->serverInterfaces.emplace(ssi.id(), ssi);
 		}
 		// clear self->serverShards


### PR DESCRIPTION
The servers and key mapping weren't being loaded in a way that was guaranteed to be transactionally consistent.
This lead to a concrete problem where "range" was loaded with version A, "serverList" was loaded with version C, and a server was removed by DD from the cluster at version B, where A < B < C.
This resulted in serverShards having a mapping to a server not in serverInterfaces, which caused serverInterfaces.at in setHotServers to segfault.

This fixes the problem by loading both as part of the same transaction with the same read version, guaranteeing they are transactionally consistent.

Correctness in progress.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
