### PR TITLE
Fix excessive killing for HA configuration [release-7.2]

### DIFF
--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -1675,7 +1675,7 @@ public:
 			}
 
 			// Reboot if dead machines do fulfill policies
-			if (tooManyDead) {
+			if (tooManyDead || (usableRegions > 1 && notEnoughLeft)) {
 				newKt = KillType::Reboot;
 				canSurvive = false;
 				TraceEvent("KillChanged")

--- a/flow/FastAlloc.cpp
+++ b/flow/FastAlloc.cpp
@@ -32,11 +32,11 @@
 #include <cstdint>
 #include <unordered_map>
 
-// #ifdef WIN32
-// #include <windows.h>
-// #undef min
-// #undef max
-// #endif
+#ifdef WIN32
+#include <windows.h>
+#undef min
+#undef max
+#endif
 
 #ifdef __linux__
 #include <sys/mman.h>

--- a/flow/test_memcpy_perf.cpp
+++ b/flow/test_memcpy_perf.cpp
@@ -6,7 +6,6 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
-#include <sys/time.h>
 
 #include "flow/rte_memcpy.h"
 #include "flow/IRandom.h"
@@ -14,6 +13,9 @@
 #include "flow/flow.h"
 
 #if (defined(__linux__) || defined(__FreeBSD__)) && defined(__AVX__)
+
+#include <sys/time.h>
+
 extern "C" {
 void* folly_memcpy(void* dst, const void* src, uint32_t length);
 }


### PR DESCRIPTION
cherrypick #9289 https://github.com/apple/foundationdb/pull/9273

In the HA configuration, it's possible the remote DC was killed 2 out of 3 machines, left not enough machines for a successful recovery. So this PR changes to Reboot to avoid such excessive killings.

20230201-230737-jzhou-d19151dd278b614b

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
