### PR TITLE
Revert "Use real clock source for trace events in real fdbserver, but now() in simulation. (#9270)

### DIFF
--- a/fdbserver/fdbserver.actor.cpp
+++ b/fdbserver/fdbserver.actor.cpp
@@ -707,9 +707,9 @@ static void printUsage(const char* name, bool devhelp) {
 		                 " `net2-threadpool'.");
 		printOptionUsage("--unbufferedout", " Do not buffer stdout and stderr.");
 		printOptionUsage("--bufferedout", " Buffer stdout and stderr.");
-		printOptionUsage("--traceclock [now,realtime]",
-		                 " Select clock source for trace events, defaults to `now' in simulation"
-		                 " and `realtime' otherwise.");
+		printOptionUsage("--traceclock CLOCKIMPL",
+		                 " Select clock source for trace files, `now' (default) or"
+		                 " `realtime'.");
 		printOptionUsage("--num-testers NUM",
 		                 " A multitester will wait for NUM testers before starting"
 		                 " (defaults to 1).");

--- a/flow/Trace.cpp
+++ b/flow/Trace.cpp
@@ -93,7 +93,7 @@ struct SuppressionMap {
 
 #define TRACE_BATCH_IMPLICIT_SEVERITY SevInfo
 TraceBatch g_traceBatch;
-std::atomic<trace_clock_t> g_trace_clock{ TRACE_CLOCK_DEFAULT };
+std::atomic<trace_clock_t> g_trace_clock{ TRACE_CLOCK_NOW };
 
 LatestEventCache latestEventCache;
 SuppressionMap suppressedEvents;
@@ -1350,30 +1350,14 @@ bool BaseTraceEvent::isNetworkThread() {
 }
 
 double BaseTraceEvent::getCurrentTime() {
-	switch (g_trace_clock.load()) {
-	case TRACE_CLOCK_REALTIME:
-		return timer();
-
-	case TRACE_CLOCK_DEFAULT:
-		// Unless we're simulated, use the real timer for trace events.
-		if (!(g_network && g_network->isSimulated())) {
-			return timer();
-		}
-		// Fallthrough to now() in simulation.
-
-	case TRACE_CLOCK_NOW:
-		// Avoid the problem of accessing the current time from multiple
-		// threads by have non-network threads use a real-time clock.
-		// See: https://github.com/apple/foundationdb/pull/1875
+	if (g_trace_clock.load() == TRACE_CLOCK_NOW) {
 		if (!isNetworkThread() || !g_network) {
 			return timer_monotonic();
+		} else {
+			return now();
 		}
-
-		return now();
-
-	default:
-		UNSTOPPABLE_ASSERT(false);
-		return 0;
+	} else {
+		return timer();
 	}
 }
 

--- a/flow/include/flow/Trace.h
+++ b/flow/include/flow/Trace.h
@@ -687,7 +687,7 @@ class Future;
 class Void;
 Future<Void> pingTraceLogWriterThread();
 
-enum trace_clock_t { TRACE_CLOCK_DEFAULT, TRACE_CLOCK_NOW, TRACE_CLOCK_REALTIME };
+enum trace_clock_t { TRACE_CLOCK_NOW, TRACE_CLOCK_REALTIME };
 extern std::atomic<trace_clock_t> g_trace_clock;
 extern TraceBatch g_traceBatch;
 

--- a/flowbench/BenchTimer.cpp
+++ b/flowbench/BenchTimer.cpp
@@ -36,13 +36,5 @@ static void bench_timer_monotonic(benchmark::State& state) {
 	state.SetItemsProcessed(static_cast<long>(state.iterations()));
 }
 
-static void bench_timestamp_counter(benchmark::State& state) {
-	for (auto _ : state) {
-		benchmark::DoNotOptimize(timestampCounter());
-	}
-	state.SetItemsProcessed(static_cast<long>(state.iterations()));
-}
-
 BENCHMARK(bench_timer)->ReportAggregatesOnly(true);
 BENCHMARK(bench_timer_monotonic)->ReportAggregatesOnly(true);
-BENCHMARK(bench_timestamp_counter)->ReportAggregatesOnly(true);


### PR DESCRIPTION
This reverts commit 02f78500b50a4e29fae00965fc7509b6966c8353.

That changed the default behavior of the clock used for trace logs, which might break some tooling or workflows.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
