### PR TITLE
set clearAfterTest=false in RawTenantAccessClean test

### DIFF
--- a/tests/fast/RawTenantAccessClean.toml
+++ b/tests/fast/RawTenantAccessClean.toml
@@ -8,7 +8,7 @@ proxy_use_resolver_private_mutations = false
 
 [[test]]
 testTitle = 'RawTenantAccessClean'
-clearAfterTest = true
+clearAfterTest = false
 runSetup = true
 
     [[test.workload]]


### PR DESCRIPTION
The `tr->readRange()` in the `TesterCheckDatabase` phase keeps getting transaction_too_old() until timeout. This has no apparent causal relation with the tenant check in Commit Proxy.
And this happens in buggify scenarios, though not sure whether this is the correct fix, mark this phase to false solve the timeout problem.
(Also, I noticed that there are other test toml file also set `clearAfterTest=false`, whether they are getting the same problem?
# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
