### PR TITLE
adding metadata-only update for empty delta files to avoid blob storage writes

### DIFF
--- a/fdbserver/BlobWorker.actor.cpp
+++ b/fdbserver/BlobWorker.actor.cpp
@@ -953,6 +953,84 @@ ACTOR Future<BlobFileIndex> writeDeltaFile(Reference<BlobWorkerData> bwData,
 	}
 }
 
+ACTOR Future<BlobFileIndex> writeEmptyDeltaFile(Reference<BlobWorkerData> bwData,
+                                                KeyRange keyRange,
+                                                UID granuleID,
+                                                int64_t epoch,
+                                                int64_t seqno,
+                                                Version previousVersion,
+                                                Version currentDeltaVersion,
+                                                Future<BlobFileIndex> previousDeltaFileFuture,
+                                                Future<Void> waitCommitted,
+                                                Optional<std::pair<KeyRange, UID>> oldGranuleComplete) {
+	ASSERT(previousVersion < currentDeltaVersion);
+	wait(delay(0, TaskPriority::BlobWorkerUpdateStorage));
+
+	// before updating FDB, wait for the delta file version to be committed and previous delta files to finish
+	wait(waitCommitted);
+	BlobFileIndex prev = wait(previousDeltaFileFuture);
+	wait(delay(0, TaskPriority::BlobWorkerUpdateFDB));
+
+	// update FDB with new file
+	state Key oldDFKey = blobGranuleFileKeyFor(granuleID, previousVersion, 'D');
+	state Key newDFKey = blobGranuleFileKeyFor(granuleID, currentDeltaVersion, 'D');
+	state Reference<ReadYourWritesTransaction> tr = makeReference<ReadYourWritesTransaction>(bwData->db);
+	state Optional<Value> dfValue;
+	loop {
+		tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+		tr->setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
+		tr->setOption(FDBTransactionOptions::LOCK_AWARE);
+		try {
+			wait(readAndCheckGranuleLock(tr, keyRange, epoch, seqno));
+
+			// FIXME: could construct this value from the prev BlobFileIndex, but checking that the key exists in the DB
+			// is a good sanity check anyway
+			if (!dfValue.present()) {
+				// Only check if not seen yet. If we get commit unknown result and then retry, we'd see our own delete
+				wait(store(dfValue, tr->get(oldDFKey)));
+				ASSERT(dfValue.present());
+			} else {
+				tr->addReadConflictRange(singleKeyRange(oldDFKey));
+			}
+
+			tr->clear(oldDFKey);
+			tr->set(newDFKey, dfValue.get());
+
+			if (oldGranuleComplete.present()) {
+				wait(updateGranuleSplitState(&tr->getTransaction(),
+				                             oldGranuleComplete.get().first,
+				                             oldGranuleComplete.get().second,
+				                             granuleID,
+				                             BlobGranuleSplitState::Done));
+			}
+
+			wait(tr->commit());
+			if (BW_DEBUG) {
+				fmt::print(
+				    "Granule {0} [{1} - {2}) empty delta file bumped version last delta file from {3} -> {4}, cv={5}\n",
+				    granuleID.toString(),
+				    keyRange.begin.printable(),
+				    keyRange.end.printable(),
+				    previousVersion,
+				    currentDeltaVersion,
+				    tr->getCommittedVersion());
+			}
+
+			if (BUGGIFY && bwData->maybeInjectTargetedRestart()) {
+				wait(Never());
+			}
+
+			if (BUGGIFY_WITH_PROB(0.01)) {
+				wait(delay(deterministicRandom()->random01()));
+			}
+
+			return BlobFileIndex(currentDeltaVersion, "", 0, 0, 0, {});
+		} catch (Error& e) {
+			wait(tr->onError(e));
+		}
+	}
+}
+
 ACTOR Future<Void> reevaluateInitialSplit(Reference<BlobWorkerData> bwData,
                                           UID granuleID,
                                           KeyRange keyRange,
@@ -1755,8 +1833,16 @@ void handleCompletedDeltaFile(Reference<BlobWorkerData> bwData,
                               Key cfKey,
                               Version cfStartVersion,
                               std::deque<std::pair<Version, Version>>* rollbacksCompleted,
-                              std::deque<Future<Void>>& inFlightPops) {
-	metadata->files.deltaFiles.push_back(completedDeltaFile);
+                              std::deque<Future<Void>>& inFlightPops,
+                              bool emptyDeltaFile) {
+	if (emptyDeltaFile) {
+		ASSERT(!metadata->files.deltaFiles.empty());
+		ASSERT(completedDeltaFile.length == 0);
+		ASSERT(metadata->files.deltaFiles.back().version < completedDeltaFile.version);
+		metadata->files.deltaFiles.back().version = completedDeltaFile.version;
+	} else {
+		metadata->files.deltaFiles.push_back(completedDeltaFile);
+	}
 	ASSERT(metadata->durableDeltaVersion.get() < completedDeltaFile.version);
 	metadata->durableDeltaVersion.set(completedDeltaFile.version);
 
@@ -1813,9 +1899,10 @@ struct InFlightFile {
 	Version version;
 	uint64_t bytes;
 	bool snapshot;
+	bool emptyDeltaFile;
 
-	InFlightFile(Future<BlobFileIndex> future, Version version, uint64_t bytes, bool snapshot)
-	  : future(future), version(version), bytes(bytes), snapshot(snapshot) {}
+	InFlightFile(Future<BlobFileIndex> future, Version version, uint64_t bytes, bool snapshot, bool emptyDeltaFile)
+	  : future(future), version(version), bytes(bytes), snapshot(snapshot), emptyDeltaFile(emptyDeltaFile) {}
 };
 
 namespace {
@@ -2233,7 +2320,7 @@ ACTOR Future<Void> blobGranuleUpdateFiles(Reference<BlobWorkerData> bwData,
 				startVersion = startState.previousDurableVersion;
 				Future<BlobFileIndex> inFlightBlobSnapshot = compactFromBlob(
 				    bwData, bstore, metadata, startState.granuleID, startState.blobFilesToSnapshot, startVersion);
-				inFlightFiles.push_back(InFlightFile(inFlightBlobSnapshot, startVersion, 0, true));
+				inFlightFiles.push_back(InFlightFile(inFlightBlobSnapshot, startVersion, 0, true, false));
 				pendingSnapshots++;
 
 				metadata->durableSnapshotVersion.set(minDurableSnapshotV);
@@ -2260,6 +2347,7 @@ ACTOR Future<Void> blobGranuleUpdateFiles(Reference<BlobWorkerData> bwData,
 				if (inFlightFiles.front().future.isReady()) {
 					BlobFileIndex completedFile = wait(inFlightFiles.front().future);
 					if (inFlightFiles.front().snapshot) {
+						ASSERT(!inFlightFiles.front().emptyDeltaFile);
 						if (metadata->files.deltaFiles.empty()) {
 							ASSERT(completedFile.version == metadata->initialSnapshotVersion);
 						} else {
@@ -2343,6 +2431,7 @@ ACTOR Future<Void> blobGranuleUpdateFiles(Reference<BlobWorkerData> bwData,
 				if (inFlightFiles.front().future.isReady()) {
 					BlobFileIndex completedFile = wait(inFlightFiles.front().future);
 					if (inFlightFiles.front().snapshot) {
+						ASSERT(!inFlightFiles.front().emptyDeltaFile);
 						if (metadata->files.deltaFiles.empty()) {
 							ASSERT(completedFile.version == metadata->initialSnapshotVersion);
 						} else {
@@ -2360,7 +2449,8 @@ ACTOR Future<Void> blobGranuleUpdateFiles(Reference<BlobWorkerData> bwData,
 						                         cfKey,
 						                         startState.changeFeedStartVersion,
 						                         &rollbacksCompleted,
-						                         inFlightPops);
+						                         inFlightPops,
+						                         inFlightFiles.front().emptyDeltaFile);
 					}
 
 					inFlightFiles.pop_front();
@@ -2733,8 +2823,6 @@ ACTOR Future<Void> blobGranuleUpdateFiles(Reference<BlobWorkerData> bwData,
 					ASSERT(lastDeltaVersion >= metadata->currentDeltas.back().version);
 					ASSERT(metadata->pendingDeltaVersion < metadata->currentDeltas.front().version);
 				} else {
-					// FIXME: could always write special metadata for empty file, so we don't actually
-					// write/read a bunch of empty blob files
 					ASSERT(forceFlush);
 					ASSERT(!forceFlushVersions.empty());
 					CODE_PROBE(true, "Force flushing empty delta file!");
@@ -2767,24 +2855,40 @@ ACTOR Future<Void> blobGranuleUpdateFiles(Reference<BlobWorkerData> bwData,
 					           oldChangeFeedDataComplete.present() ? ". Finalizing " : "");
 				}
 
-				int64_t deltaFileBudget =
-				    std::min((int64_t)metadata->bufferedDeltaBytes, SERVER_KNOBS->BLOB_WORKER_DELTA_WRITE_BUDGET_BYTES);
-				startDeltaFileWrite = bwData->deltaWritesBudget->take(TaskPriority::DefaultYield, deltaFileBudget);
-				Future<BlobFileIndex> dfFuture =
-				    writeDeltaFile(bwData,
-				                   bstore,
-				                   metadata->keyRange,
-				                   startState.granuleID,
-				                   metadata->originalEpoch,
-				                   metadata->originalSeqno,
-				                   metadata->currentDeltas,
-				                   lastDeltaVersion,
-				                   previousFuture,
-				                   waitVersionCommitted(bwData, metadata, lastDeltaVersion),
-				                   oldChangeFeedDataComplete,
-				                   startDeltaFileWrite,
-				                   deltaFileBudget);
-				inFlightFiles.push_back(InFlightFile(dfFuture, lastDeltaVersion, metadata->bufferedDeltaBytes, false));
+				Future<BlobFileIndex> dfFuture;
+				bool emptyDeltaFile = metadata->bytesInNewDeltaFiles > 0 && metadata->currentDeltas.empty();
+				if (emptyDeltaFile) {
+					// Optimization to do a metadata-only update if flushing an empty delta file
+					dfFuture = writeEmptyDeltaFile(bwData,
+					                               metadata->keyRange,
+					                               startState.granuleID,
+					                               metadata->originalEpoch,
+					                               metadata->originalSeqno,
+					                               metadata->pendingDeltaVersion,
+					                               lastDeltaVersion,
+					                               previousFuture,
+					                               waitVersionCommitted(bwData, metadata, lastDeltaVersion),
+					                               oldChangeFeedDataComplete);
+				} else {
+					int64_t deltaFileBudget = std::min((int64_t)metadata->bufferedDeltaBytes,
+					                                   SERVER_KNOBS->BLOB_WORKER_DELTA_WRITE_BUDGET_BYTES);
+					startDeltaFileWrite = bwData->deltaWritesBudget->take(TaskPriority::DefaultYield, deltaFileBudget);
+					dfFuture = writeDeltaFile(bwData,
+					                          bstore,
+					                          metadata->keyRange,
+					                          startState.granuleID,
+					                          metadata->originalEpoch,
+					                          metadata->originalSeqno,
+					                          metadata->currentDeltas,
+					                          lastDeltaVersion,
+					                          previousFuture,
+					                          waitVersionCommitted(bwData, metadata, lastDeltaVersion),
+					                          oldChangeFeedDataComplete,
+					                          startDeltaFileWrite,
+					                          deltaFileBudget);
+				}
+				inFlightFiles.push_back(
+				    InFlightFile(dfFuture, lastDeltaVersion, metadata->bufferedDeltaBytes, false, emptyDeltaFile));
 
 				// add new pending delta file
 				ASSERT(metadata->pendingDeltaVersion < lastDeltaVersion);
@@ -2864,7 +2968,8 @@ ACTOR Future<Void> blobGranuleUpdateFiles(Reference<BlobWorkerData> bwData,
 					    reSnapshotNoCheck(bwData, bstore, metadata, startState.granuleID, previousFuture);
 					writeAmpTarget.decrease(metadata->bytesInNewDeltaFiles);
 				}
-				inFlightFiles.push_back(InFlightFile(inFlightBlobSnapshot, metadata->pendingDeltaVersion, 0, true));
+				inFlightFiles.push_back(
+				    InFlightFile(inFlightBlobSnapshot, metadata->pendingDeltaVersion, 0, true, false));
 				pendingSnapshots++;
 
 				metadata->pendingSnapshotVersion = metadata->pendingDeltaVersion;
@@ -2903,6 +3008,7 @@ ACTOR Future<Void> blobGranuleUpdateFiles(Reference<BlobWorkerData> bwData,
 						// TODO don't duplicate code
 						BlobFileIndex completedFile = wait(inFlightFiles.front().future);
 						if (inFlightFiles.front().snapshot) {
+							ASSERT(!inFlightFiles.front().emptyDeltaFile);
 							if (metadata->files.deltaFiles.empty()) {
 								ASSERT(completedFile.version == metadata->initialSnapshotVersion);
 							} else {
@@ -2919,7 +3025,8 @@ ACTOR Future<Void> blobGranuleUpdateFiles(Reference<BlobWorkerData> bwData,
 							                         cfKey,
 							                         startState.changeFeedStartVersion,
 							                         &rollbacksCompleted,
-							                         inFlightPops);
+							                         inFlightPops,
+							                         inFlightFiles.front().emptyDeltaFile);
 						}
 
 						inFlightFiles.pop_front();


### PR DESCRIPTION
Passes 50k BlobGranule* correctness with 1 unrelated error.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
