### PR TITLE
Enable RocksDB restarting tests

### DIFF
--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -2483,22 +2483,14 @@ ACTOR void setupAndRun(std::string dataFolder,
 	// snapshot of the storage engine without a snapshotting file system.
 	// https://github.com/apple/foundationdb/issues/5155
 	if (std::string_view(testFile).find("restarting") != std::string_view::npos) {
-		testConfig.storageEngineExcludeTypes.push_back(4);
-		testConfig.storageEngineExcludeTypes.push_back(5);
+		// testConfig.storageEngineExcludeTypes.push_back(4);
+		// testConfig.storageEngineExcludeTypes.push_back(5);
 
 		// Disable the default tenant in restarting tests for now
 		// TODO: persist the chosen default tenant in the restartInfo.ini file for the second test
 		allowDefaultTenant = false;
 		allowCreatingTenants = false;
 		tenantModeRequired = false;
-	}
-
-	// TODO: Currently backup and restore related simulation tests are failing when run with rocksDB storage engine
-	// possibly due to running the rocksdb in single thread in simulation.
-	// Re-enable the backup and restore related simulation tests when the tests are passing again.
-	if (std::string_view(testFile).find("Backup") != std::string_view::npos) {
-		testConfig.storageEngineExcludeTypes.push_back(4);
-		testConfig.storageEngineExcludeTypes.push_back(5);
 	}
 
 	// The RocksDB engine is not always built with the rest of fdbserver. Don't try to use it if it is not included

--- a/fdbserver/workloads/MutationLogReaderCorrectness.actor.cpp
+++ b/fdbserver/workloads/MutationLogReaderCorrectness.actor.cpp
@@ -42,7 +42,7 @@ struct MutationLogReaderCorrectnessWorkload : TestWorkload {
 	Version endVersion;
 	Key uid;
 	Key baLogRangePrefix;
-	bool debug = true;
+	bool debug = false;
 
 	Version recordVersion(int index) { return beginVersion + versionIncrement * index; }
 
@@ -102,16 +102,13 @@ struct MutationLogReaderCorrectnessWorkload : TestWorkload {
 					iStart = iEnd;
 					break;
 				} catch (Error& e) {
-					TraceEvent("MutationLogReaderError").errorUnsuppressed(e);
 					wait(tr.onError(e));
 				}
 			}
 		}
-		fmt::print("Loop 1 done\n");
 
 		state Reference<MutationLogReader> reader = wait(MutationLogReader::Create(
 		    cx, self->beginVersion, self->endVersion, self->uid, backupLogKeys.begin, /*pipelineDepth=*/1));
-		fmt::print("Loop 2\n");
 
 		state int nextExpectedRecord = 0;
 
@@ -146,7 +143,6 @@ struct MutationLogReaderCorrectnessWorkload : TestWorkload {
 			if (e.code() != error_code_end_of_stream) {
 				throw e;
 			}
-			TraceEvent("MutationLogReaderError2").errorUnsuppressed(e);
 		}
 
 		printf("records expected: %d\n", self->records);

--- a/tests/fast/BlobGranuleMoveVerifyCycle.toml
+++ b/tests/fast/BlobGranuleMoveVerifyCycle.toml
@@ -3,7 +3,7 @@ testClass = "BlobGranule"
 blobGranulesEnabled = true 
 allowDefaultTenant = false
 # FIXME: re-enable rocks at some point
-storageEngineExcludeTypes = [4]
+# storageEngineExcludeTypes = [4]
 
 [[test]]
 testTitle = 'BlobGranuleMoveVerifyCycle'

--- a/tests/fast/BlobGranuleVerifyAtomicOps.toml
+++ b/tests/fast/BlobGranuleVerifyAtomicOps.toml
@@ -5,7 +5,7 @@ allowDefaultTenant = false
 injectTargetedSSRestart = true
 injectSSDelay = true
 # FIXME: re-enable rocks at some point
-storageEngineExcludeTypes = [4, 5]
+# storageEngineExcludeTypes = [4, 5]
 
 [[test]]
 testTitle = 'BlobGranuleVerifyAtomicOps'

--- a/tests/fast/BlobGranuleVerifyCycle.toml
+++ b/tests/fast/BlobGranuleVerifyCycle.toml
@@ -5,7 +5,7 @@ allowDefaultTenant = false
 injectTargetedSSRestart = true
 injectSSDelay = true
 # FIXME: re-enable rocks at some point
-storageEngineExcludeTypes = [4, 5]
+# storageEngineExcludeTypes = [4, 5]
 
 [[test]]
 testTitle = 'BlobGranuleVerifyCycle'

--- a/tests/fast/BlobGranuleVerifySmall.toml
+++ b/tests/fast/BlobGranuleVerifySmall.toml
@@ -5,7 +5,7 @@ allowDefaultTenant = false
 injectTargetedSSRestart = true
 injectSSDelay = true
 # FIXME: re-enable rocks at some point
-storageEngineExcludeTypes = [4, 5]
+# storageEngineExcludeTypes = [4, 5]
 
 [[test]]
 testTitle = 'BlobGranuleVerifySmall'

--- a/tests/fast/BlobGranuleVerifySmallClean.toml
+++ b/tests/fast/BlobGranuleVerifySmallClean.toml
@@ -2,7 +2,7 @@
 blobGranulesEnabled = true
 allowDefaultTenant = false
 # FIXME: re-enable rocks at some point
-storageEngineExcludeTypes = [4, 5]
+# storageEngineExcludeTypes = [4, 5]
 testClass = "BlobGranule"
 
 [[test]]

--- a/tests/rare/BlobGranuleRanges.toml
+++ b/tests/rare/BlobGranuleRanges.toml
@@ -4,7 +4,7 @@ allowDefaultTenant = false
 injectTargetedSSRestart = true
 injectSSDelay = true
 # FIXME: re-enable rocks at some point
-storageEngineExcludeTypes = [4, 5]
+# storageEngineExcludeTypes = [4, 5]
 
 [[test]]
 testTitle = 'BlobGranuleRanges'

--- a/tests/restarting/to_7.1.0/ConfigureStorageMigrationTestRestart-1.toml
+++ b/tests/restarting/to_7.1.0/ConfigureStorageMigrationTestRestart-1.toml
@@ -3,7 +3,7 @@ extraMachineCountDC = 2
 maxTLogVersion=6
 disableHostname=true
 disableEncryption=true
-storageEngineExcludeTypes=[3,4]
+storageEngineExcludeTypes=[3,4,5]
 
 [[knobs]]
 # This can be removed once the lower bound of this downgrade test is a version that understands the new protocol

--- a/tests/restarting/to_7.1.0/CycleTestRestart-1.toml
+++ b/tests/restarting/to_7.1.0/CycleTestRestart-1.toml
@@ -1,5 +1,5 @@
 [configuration]
-storageEngineExcludeTypes = [3]
+storageEngineExcludeTypes = [3, 5]
 maxTLogVersion = 6
 disableTss = true
 disableHostname = true

--- a/tests/slow/BlobGranuleCorrectness.toml
+++ b/tests/slow/BlobGranuleCorrectness.toml
@@ -5,7 +5,7 @@ allowDisablingTenants = false
 injectTargetedSSRestart = true
 injectSSDelay = true
 # FIXME: re-enable rocks at some point
-storageEngineExcludeTypes = [4, 5]
+# storageEngineExcludeTypes = [4, 5]
 
 [[knobs]]
 bg_metadata_source = "tenant"

--- a/tests/slow/BlobGranuleCorrectnessClean.toml
+++ b/tests/slow/BlobGranuleCorrectnessClean.toml
@@ -3,7 +3,7 @@ blobGranulesEnabled = true
 allowDefaultTenant = false
 allowDisablingTenants = false
 # FIXME: re-enable rocks at some point
-storageEngineExcludeTypes = [4, 5]
+# storageEngineExcludeTypes = [4, 5]
 
 [[knobs]]
 bg_metadata_source = "tenant"

--- a/tests/slow/BlobGranuleVerifyBalance.toml
+++ b/tests/slow/BlobGranuleVerifyBalance.toml
@@ -4,7 +4,7 @@ allowDefaultTenant = false
 injectTargetedSSRestart = true
 injectSSDelay = true
 # FIXME: re-enable rocks at some point
-storageEngineExcludeTypes = [4, 5]
+# storageEngineExcludeTypes = [4, 5]
 
 [[test]]
 testTitle = 'BlobGranuleVerifyBalance'

--- a/tests/slow/BlobGranuleVerifyBalanceClean.toml
+++ b/tests/slow/BlobGranuleVerifyBalanceClean.toml
@@ -2,7 +2,7 @@
 blobGranulesEnabled = true
 allowDefaultTenant = false
 # FIXME: re-enable rocks at some point
-storageEngineExcludeTypes = [4, 5]
+# storageEngineExcludeTypes = [4, 5]
 
 [[test]]
 testTitle = 'BlobGranuleVerifyBalanceClean'

--- a/tests/slow/BlobGranuleVerifyLarge.toml
+++ b/tests/slow/BlobGranuleVerifyLarge.toml
@@ -4,7 +4,7 @@ allowDefaultTenant = false
 injectTargetedSSRestart = true
 injectSSDelay = true
 # FIXME: re-enable rocks at some point
-storageEngineExcludeTypes = [4, 5]
+# storageEngineExcludeTypes = [4, 5]
 
 [[test]]
 testTitle = 'BlobGranuleVerifyLarge'

--- a/tests/slow/BlobGranuleVerifyLargeClean.toml
+++ b/tests/slow/BlobGranuleVerifyLargeClean.toml
@@ -2,7 +2,7 @@
 blobGranulesEnabled = true 
 allowDefaultTenant = false
 # FIXME: re-enable rocks at some point
-storageEngineExcludeTypes = [4, 5]
+# storageEngineExcludeTypes = [4, 5]
 
 [[test]]
 testTitle = 'BlobGranuleVerifyLargeClean'


### PR DESCRIPTION
20230214-014647-jzhou-da0e685bce302964

Failed seeds
```
-f tests/fast/BackupToDBCorrectness.toml -s 950440709 -b on
-f tests/restarting/from_7.2.0/DrUpgradeRestart-1.txt -s 644311832 -b on
-f tests/restarting/from_7.2.0/DrUpgradeRestart-2.txt --restarting -s 644311833 -b on
```

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
