### PR TITLE
Snapshot Backup Bug Fix

### DIFF
--- a/fdbclient/FileBackupAgent.actor.cpp
+++ b/fdbclient/FileBackupAgent.actor.cpp
@@ -1067,7 +1067,8 @@ ACTOR static Future<Void> decodeKVPairs(StringRefReader* reader,
 
 		// make sure that all keys in a block belong to exactly one tenant,
 		// unless its the last key in which case it can be a truncated (different) tenant prefix
-		if (encryptedBlock && g_network && g_network->isSimulated()) {
+		if (encryptedBlock && g_network && g_network->isSimulated() &&
+		    !isReservedEncryptDomain(encryptHeader.get().cipherTextDetails.encryptDomainId)) {
 			ASSERT(encryptHeader.present());
 			state KeyRef curKey = KeyRef(k, kLen);
 			if (!prevDomainId.present()) {

--- a/fdbclient/include/fdbclient/TenantEntryCache.actor.h
+++ b/fdbclient/include/fdbclient/TenantEntryCache.actor.h
@@ -559,7 +559,7 @@ public:
 		mapByTenantId[entry.id] = payload;
 		mapByTenantName[entry.tenantName] = payload;
 
-		TraceEvent("TenantEntryCachePut")
+		TraceEvent("TenantEntryCachePut", uid)
 		    .detail("TenantName", entry.tenantName)
 		    .detail("TenantNameExisting", existingName)
 		    .detail("TenantID", entry.id)

--- a/fdbserver/workloads/RestoreBackup.actor.cpp
+++ b/fdbserver/workloads/RestoreBackup.actor.cpp
@@ -121,20 +121,16 @@ struct RestoreBackupWorkload : TestWorkload {
 
 		if (config.tenantMode == TenantMode::REQUIRED) {
 			// restore system keys
-			state VectorRef<KeyRangeRef> systemBackupRanges = getSystemBackupRanges();
-			state int i;
-			for (i = 0; i < systemBackupRanges.size(); i++) {
-				wait(success(self->backupAgent.restore(cx,
-				                                       cx,
-				                                       "system_restore"_sr,
-				                                       Key(self->backupContainer->getURL()),
-				                                       self->backupContainer->getProxy(),
-				                                       WaitForComplete::True,
-				                                       ::invalidVersion,
-				                                       Verbose::True,
-				                                       systemBackupRanges[i])));
-			}
-			// restore non-system keys
+			wait(success(self->backupAgent.restore(cx,
+			                                       cx,
+			                                       "system_restore"_sr,
+			                                       Key(self->backupContainer->getURL()),
+			                                       self->backupContainer->getProxy(),
+			                                       getSystemBackupRanges(),
+			                                       WaitForComplete::True,
+			                                       ::invalidVersion,
+			                                       Verbose::True)));
+			// restore user data
 			wait(success(self->backupAgent.restore(cx,
 			                                       cx,
 			                                       self->tag,


### PR DESCRIPTION
For empty key ranges we would attempt to fetch a tenant id which is not possible since they don't belong to a tenant. This PR fixes this issue by assuming empty key ranges belong to the default encryption domain

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
