### PR TITLE
Add `/GrvProxyTagThrottler/MultiTag` unit test

### DIFF
--- a/fdbserver/GrvProxyTagThrottler.actor.cpp
+++ b/fdbserver/GrvProxyTagThrottler.actor.cpp
@@ -311,7 +311,6 @@ ACTOR static Future<Void> mockServer(GrvProxyTagThrottler* throttler) {
 			outBatchPriority.front().reply.send(GetReadVersionReply{});
 			outBatchPriority.pop_front();
 		}
-		TraceEvent("HERE_ServerProcessing").detail("Size", outDefaultPriority.size());
 		while (!outDefaultPriority.empty()) {
 			outDefaultPriority.front().reply.send(GetReadVersionReply{});
 			outDefaultPriority.pop_front();

--- a/fdbserver/GrvProxyTagThrottler.actor.cpp
+++ b/fdbserver/GrvProxyTagThrottler.actor.cpp
@@ -378,6 +378,32 @@ TEST_CASE("/GrvProxyTagThrottler/MultiClient") {
 	return Void();
 }
 
+// Each tag receives 10 transaction/second budget
+TEST_CASE("/GrvProxyTagThrottler/MultiTag") {
+	state GrvProxyTagThrottler throttler(5.0);
+	state TagSet tagSet1;
+	state TagSet tagSet2;
+	state TransactionTagMap<uint32_t> counters;
+	{
+		TransactionTagMap<double> rates;
+		rates["sampleTag1"_sr] = 10.0;
+		rates["sampleTag2"_sr] = 10.0;
+		throttler.updateRates(rates);
+	}
+	tagSet1.addTag("sampleTag1"_sr);
+	tagSet2.addTag("sampleTag2"_sr);
+	state Future<Void> client1 = mockClient(&throttler, TransactionPriority::DEFAULT, tagSet1, 5, 20.0, &counters);
+	state Future<Void> client2 = mockClient(&throttler, TransactionPriority::DEFAULT, tagSet2, 5, 20.0, &counters);
+	state Future<Void> server = mockServer(&throttler);
+	wait(timeout(client1 && client2 && server, 60.0, Void()));
+	TraceEvent("TagQuotaTest_MultiTag")
+	    .detail("Counter1", counters["sampleTag1"_sr])
+	    .detail("Counter2", counters["sampleTag2"_sr]);
+	ASSERT(isNear(counters["sampleTag1"_sr], 60 * 10.0));
+	ASSERT(isNear(counters["sampleTag2"_sr], 60 * 10.0));
+	return Void();
+}
+
 // Test processing GetReadVersionRequests that batch several transactions
 TEST_CASE("/GrvProxyTagThrottler/Batch") {
 	state GrvProxyTagThrottler throttler(5.0);


### PR DESCRIPTION
This test validates that multiple tags can concurrently be throttled to the correct rate.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
