### PR TITLE
Add timer_monotonic() to CommitDebug trace events.

### DIFF
--- a/flow/Trace.cpp
+++ b/flow/Trace.cpp
@@ -1481,7 +1481,7 @@ TraceBatch::EventInfo::EventInfo(double time,
 	fields.addField("Time", format("%.6f", time));
 	// Include monotonic time for computing elapsed time between events on the same machine.
 	// The Time field is based on now(), which doesn't advance between wait()'s.
-	fields.addField("MonotonicTime", format(">%.6f", monotonicTime));
+	fields.addField("MonotonicTime", format("%.6f", monotonicTime));
 	if (FLOW_KNOBS && FLOW_KNOBS->TRACE_DATETIME_ENABLED) {
 		fields.addField("DateTime", TraceEvent::printRealTime(time));
 	}

--- a/flow/include/flow/Trace.h
+++ b/flow/include/flow/Trace.h
@@ -175,7 +175,7 @@ public:
 private:
 	struct EventInfo {
 		TraceEventFields fields;
-		EventInfo(double time, const char* name, uint64_t id, const char* location);
+		EventInfo(double time, double monotonicTime, const char* name, uint64_t id, const char* location);
 	};
 
 	struct AttachInfo {


### PR DESCRIPTION
CommitDebug trace events are useful for measuring, in detail, the time spent in the various parts of a single transaction. Like all log events, they have a time associated with them. This time comes for now(), which in a real fdb system is only updated in the run loop. This renders the timestamps inaccurate in certain CPU bound sections which don't have a wait, e.g. in the resolver.

The desired solution is to directly call ::timer_monotonic() instead of now() for a timestamp, since ::timer_monotonic() is what now() ultimately uses in the run loop, but is updated between waits as well.

In order to not disrupt any current uses of the logs which might depend on the current behavior of the Time field, we introduced the `MonotonicTime` field.

This change only affects CommitDebug trace events, not trace events in general.

Replace this text with your description here...

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
