### PR TITLE
Assert that storage server is reading tenantMap at a legal version

### DIFF
--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -2071,9 +2071,7 @@ ACTOR Future<Version> waitForMinVersion(StorageServer* data, Version version) {
 
 void StorageServer::checkTenantEntry(Version version, TenantInfo tenantInfo) {
 	if (tenantInfo.hasTenant()) {
-		if (version < tenantMap.oldestVersion) {
-			version = tenantMap.oldestVersion;
-		}
+		ASSERT(version >= tenantMap.oldestVersion && version <= tenantMap.latestVersion);
 		auto view = tenantMap.at(version);
 		auto itr = view.find(tenantInfo.tenantId);
 		if (itr == view.end()) {


### PR DESCRIPTION
Assert that storage server is reading `tenantMap` at a legal version in `checkTenantEntry()` to prevent undefined behavior when reading from the map.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
