### PR TITLE
Publish private endpoints used in MVC mode

### DIFF
--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -3225,7 +3225,6 @@ Reference<TransactionState> TransactionState::cloneAndReset(Reference<Transactio
 	newState->startTime = startTime;
 	newState->committedVersion = committedVersion;
 	newState->conflictingKeys = conflictingKeys;
-	newState->authToken = authToken;
 	newState->tenantSet = tenantSet;
 
 	return newState;

--- a/fdbclient/include/fdbclient/CommitProxyInterface.h
+++ b/fdbclient/include/fdbclient/CommitProxyInterface.h
@@ -593,6 +593,8 @@ struct GlobalConfigRefreshRequest {
 	GlobalConfigRefreshRequest() {}
 	explicit GlobalConfigRefreshRequest(Version lastKnown) : lastKnown(lastKnown) {}
 
+	bool verify() const noexcept { return true; }
+
 	template <class Ar>
 	void serialize(Ar& ar) {
 		serializer(ar, lastKnown, reply);

--- a/fdbclient/include/fdbclient/CoordinationInterface.h
+++ b/fdbclient/include/fdbclient/CoordinationInterface.h
@@ -313,6 +313,9 @@ struct ProtocolInfoRequest {
 	constexpr static FileIdentifier file_identifier = 13261233;
 	ReplyPromise<ProtocolInfoReply> reply{ PeerCompatibilityPolicy{ RequirePeer::AtLeast,
 		                                                            ProtocolVersion::withStableInterfaces() } };
+
+	bool verify() const noexcept { return true; }
+
 	template <class Ar>
 	void serialize(Ar& ar) {
 		serializer(ar, reply);

--- a/fdbclient/include/fdbclient/GrvProxyInterface.h
+++ b/fdbclient/include/fdbclient/GrvProxyInterface.h
@@ -43,7 +43,7 @@ struct GrvProxyInterface {
 	//   committed)
 	RequestStream<ReplyPromise<Void>> waitFailure; // reports heartbeat to master.
 	RequestStream<struct GetHealthMetricsRequest> getHealthMetrics;
-	RequestStream<struct GlobalConfigRefreshRequest> refreshGlobalConfig;
+	PublicRequestStream<struct GlobalConfigRefreshRequest> refreshGlobalConfig;
 
 	UID id() const { return getConsistentReadVersion.getEndpoint().token; }
 	std::string toString() const { return id().shortString(); }
@@ -60,7 +60,7 @@ struct GrvProxyInterface {
 			    RequestStream<ReplyPromise<Void>>(getConsistentReadVersion.getEndpoint().getAdjustedEndpoint(1));
 			getHealthMetrics = RequestStream<struct GetHealthMetricsRequest>(
 			    getConsistentReadVersion.getEndpoint().getAdjustedEndpoint(2));
-			refreshGlobalConfig = RequestStream<struct GlobalConfigRefreshRequest>(
+			refreshGlobalConfig = PublicRequestStream<struct GlobalConfigRefreshRequest>(
 			    getConsistentReadVersion.getEndpoint().getAdjustedEndpoint(3));
 		}
 	}

--- a/fdbclient/vexillographer/fdb.options
+++ b/fdbclient/vexillographer/fdb.options
@@ -307,7 +307,8 @@ description is not currently required but encouraged.
             hidden="true"/>
     <Option name="authorization_token" code="2000"
             description="Attach given authorization token to the transaction such that subsequent tenant-aware requests are authorized"
-            paramType="String" paramDescription="A JSON Web Token authorized to access data belonging to one or more tenants, indicated by 'tenants' claim of the token's payload."/>
+            paramType="String" paramDescription="A JSON Web Token authorized to access data belonging to one or more tenants, indicated by 'tenants' claim of the token's payload."
+            persistent="true"/>
   </Scope>
 
   <!-- The enumeration values matter - do not change them without

--- a/fdbserver/worker.actor.cpp
+++ b/fdbserver/worker.actor.cpp
@@ -3232,7 +3232,7 @@ ACTOR Future<Void> monitorLeaderWithDelayedCandidacy(
 extern void setupStackSignal();
 
 ACTOR Future<Void> serveProtocolInfo() {
-	state RequestStream<ProtocolInfoRequest> protocolInfo(
+	state PublicRequestStream<ProtocolInfoRequest> protocolInfo(
 	    PeerCompatibilityPolicy{ RequirePeer::AtLeast, ProtocolVersion::withStableInterfaces() });
 	protocolInfo.makeWellKnownEndpoint(WLTOKEN_PROTOCOL_INFO, TaskPriority::DefaultEndpoint);
 	loop {

--- a/fdbserver/workloads/Cycle.actor.cpp
+++ b/fdbserver/workloads/Cycle.actor.cpp
@@ -165,7 +165,6 @@ struct CycleWorkload : TestWorkload, CycleMembers<MultiTenancy> {
 				state double tstart = now();
 				state int r = deterministicRandom()->randomInt(0, self->nodeCount);
 				state Transaction tr(cx);
-				self->setAuthToken(tr);
 				if (deterministicRandom()->random01() <= self->traceParentProbability) {
 					state Span span("CycleClient"_loc);
 					TraceEvent("CycleTracingTransaction", span.context.traceID).log();
@@ -174,6 +173,7 @@ struct CycleWorkload : TestWorkload, CycleMembers<MultiTenancy> {
 				}
 				while (true) {
 					try {
+						self->setAuthToken(tr);
 						// Reverse next and next^2 node
 						Optional<Value> v = wait(tr.get(self->key(r)));
 						if (!v.present())
@@ -312,9 +312,9 @@ struct CycleWorkload : TestWorkload, CycleMembers<MultiTenancy> {
 			// One client checks the validity of the cycle
 			state Transaction tr(cx);
 			state int retryCount = 0;
-			self->setAuthToken(tr);
 			loop {
 				try {
+					self->setAuthToken(tr);
 					state Version v = wait(tr.getReadVersion());
 					RangeResult data = wait(tr.getRange(firstGreaterOrEqual(doubleToTestKey(0.0, self->keyPrefix)),
 					                                    firstGreaterOrEqual(doubleToTestKey(1.0, self->keyPrefix)),

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -423,14 +423,26 @@ if(WITH_PYTHON)
     set_tests_properties(authorization_venv_setup PROPERTIES FIXTURES_SETUP authz_virtual_env TIMEOUT 60)
 
     set(authz_script_dir ${CMAKE_SOURCE_DIR}/tests/authorization)
-    set(authz_test_cmd "${authz_venv_activate} && pytest ${authz_script_dir}/authz_test.py -rA --build-dir ${CMAKE_BINARY_DIR} -vvv")
-    add_test(
-      NAME token_based_tenant_authorization
-      WORKING_DIRECTORY ${authz_venv_dir}
-      COMMAND bash -c ${authz_test_cmd})
-    set_tests_properties(token_based_tenant_authorization PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_SOURCE_DIR}/tests/TestRunner;${ld_env_name}=${CMAKE_BINARY_DIR}/lib")
-    set_tests_properties(token_based_tenant_authorization PROPERTIES FIXTURES_REQUIRED authz_virtual_env)
-    set_tests_properties(token_based_tenant_authorization PROPERTIES TIMEOUT 120)
+
+    set(force_mvc 0 1)
+    foreach(is_mvc_forced IN LISTS force_mvc)
+        set(authz_test_name "authz")
+        set(test_opt "")
+        if(is_mvc_forced)
+            string(APPEND authz_test_name "_with_forced_multi_version_client")
+            string(APPEND test_opt " --force-multi-version-client")
+        else()
+            string(APPEND authz_test_name "_without_forced_multi_version_client")
+        endif()
+        set(authz_test_cmd "${authz_venv_activate} && pytest ${authz_script_dir}/authz_test.py -rA --build-dir ${CMAKE_BINARY_DIR} -vvv${test_opt}")
+        add_test(
+          NAME ${authz_test_name}
+          WORKING_DIRECTORY ${authz_venv_dir}
+          COMMAND bash -c ${authz_test_cmd})
+        set_tests_properties(${authz_test_name} PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_SOURCE_DIR}/tests/TestRunner;${ld_env_name}=${CMAKE_BINARY_DIR}/lib")
+        set_tests_properties(${authz_test_name} PROPERTIES FIXTURES_REQUIRED authz_virtual_env)
+        set_tests_properties(${authz_test_name} PROPERTIES TIMEOUT 120)
+    endforeach()
   endif()
 else()
   message(WARNING "Python not found, won't configure ctest")

--- a/tests/authorization/authz_test.py
+++ b/tests/authorization/authz_test.py
@@ -58,6 +58,12 @@ def test_token_option(private_key, token_gen, default_tenant, tenant_tr_gen):
         assert False, f"expected permission denied, but read transaction went through, value: {value}"
     except fdb.FDBError as e:
         assert e.code == 6000, f"expected permission_denied, got {e} instead"
+
+    # setting token again after reset should work normally
+    tr.options.set_authorization_token(token)
+    assert tr[b"abc"].value == b"def"
+
+    tr.reset() # to clear any read cache
     tr.options.set_authorization_token(token)
     tr.options.set_authorization_token() # setting empty option should invalidate any set token
     try:

--- a/tests/authorization/authz_test.py
+++ b/tests/authorization/authz_test.py
@@ -42,6 +42,30 @@ special_key_ranges = [
     ("kill storage", b"/globals/killStorage", b"/globals/killStorage\x00"),
 ]
 
+def test_token_option(private_key, token_gen, default_tenant, tenant_tr_gen):
+    token = token_gen(private_key, token_claim_1h(default_tenant))
+    tr = tenant_tr_gen(default_tenant)
+    tr.options.set_authorization_token(token)
+    tr[b"abc"] = b"def"
+    tr.commit().wait()
+    tr.on_error(fdb.FDBError(1020)).wait() # fake a transaction conflict (not_committed)
+    # token should survive a soft reset by on_error
+    assert tr[b"abc"].value == b"def"
+    # token should not survive a hard reset
+    tr.reset()
+    try:
+        value = tr[b"abc"].value
+        assert False, f"expected permission denied, but read transaction went through, value: {value}"
+    except fdb.FDBError as e:
+        assert e.code == 6000, f"expected permission_denied, got {e} instead"
+    tr.options.set_authorization_token(token)
+    tr.options.set_authorization_token() # setting empty option should invalidate any set token
+    try:
+        value = tr[b"abc"].value
+        assert False, f"expected permission denied, but read transaction went through, value: {value}"
+    except fdb.FDBError as e:
+        assert e.code == 6000, f"expected permission_denied, got {e} instead"
+
 def test_simple_tenant_access(private_key, token_gen, default_tenant, tenant_tr_gen):
     token = token_gen(private_key, token_claim_1h(default_tenant))
     tr = tenant_tr_gen(default_tenant)

--- a/tests/authorization/conftest.py
+++ b/tests/authorization/conftest.py
@@ -23,6 +23,7 @@ import pytest
 import subprocess
 import admin_server
 import os
+import sys
 from authlib.jose import JsonWebKey, KeySet, jwt
 from local_cluster import TLSConfig
 from tmp_cluster import TempCluster
@@ -63,7 +64,7 @@ def build_dir(request):
 
 @pytest.fixture(scope="session")
 def external_lib_path(build_dir):
-    return os.path.join(build_dir, "bindings/c/libfdb_c_external.so")
+    return os.path.join(build_dir, "bindings/c/libfdb_c_external.{}".format("dylib" if sys.platform.startswith("darwin") else "so"))
 
 @pytest.fixture(scope="session")
 def kty(request):
@@ -155,7 +156,6 @@ def cluster(admin_ipc, build_dir, public_key_jwks_str, public_key_refresh_interv
 @pytest.fixture
 def db(cluster, admin_ipc):
     db = fdb.open(str(cluster.cluster_file))
-    # db.options.set_transaction_timeout(2000) # 2 seconds
     db.options.set_transaction_retry_limit(3)
     yield db
     admin_ipc.request("cleanup_database")


### PR DESCRIPTION
- Make public the private endpoints that are only used in multi-version client mode: `ProtocolInfoRequest` and `GlobalConfigRefreshRequest` RPC endpoints are affected.
- Make authz token option a persistent option that survives soft reset but not hard reset of transaction objects. Add matching tests to verify.
- Increase Authz test coverage to include forced multi-version client usage


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
