### PR TITLE
Fix list tenant name bug

### DIFF
--- a/fdbclient/include/fdbclient/MetaclusterManagement.actor.h
+++ b/fdbclient/include/fdbclient/MetaclusterManagement.actor.h
@@ -1591,7 +1591,7 @@ Future<std::vector<std::pair<TenantName, TenantMapEntry>>> listTenantMetadataTra
 	results.reserve(futures.size());
 	for (int i = 0; i < futures.size(); ++i) {
 		const TenantMapEntry& entry = futures[i].get().get();
-		results.emplace_back(entry.tenantName, entry);
+		results.emplace_back(tenantIds[i].first, entry);
 	}
 
 	return results;

--- a/fdbclient/include/fdbclient/TenantManagement.actor.h
+++ b/fdbclient/include/fdbclient/TenantManagement.actor.h
@@ -501,7 +501,8 @@ Future<std::vector<std::pair<TenantName, TenantMapEntry>>> listTenantMetadataTra
                                                                                          TenantName begin,
                                                                                          TenantName end,
                                                                                          int limit) {
-	std::vector<std::pair<TenantName, int64_t>> matchingTenants = wait(listTenantsTransaction(tr, begin, end, limit));
+	state std::vector<std::pair<TenantName, int64_t>> matchingTenants =
+	    wait(listTenantsTransaction(tr, begin, end, limit));
 
 	state std::vector<Future<TenantMapEntry>> tenantEntryFutures;
 	for (auto const& [name, id] : matchingTenants) {
@@ -511,8 +512,10 @@ Future<std::vector<std::pair<TenantName, TenantMapEntry>>> listTenantMetadataTra
 	wait(waitForAll(tenantEntryFutures));
 
 	std::vector<std::pair<TenantName, TenantMapEntry>> results;
-	for (auto const& f : tenantEntryFutures) {
-		results.emplace_back(f.get().tenantName, f.get());
+	state int idx = 0;
+	for (; idx < tenantEntryFutures.size(); ++idx) {
+		auto const& f = tenantEntryFutures[idx];
+		results.emplace_back(matchingTenants[idx].first, f.get());
 	}
 
 	return results;

--- a/fdbclient/include/fdbclient/TenantManagement.actor.h
+++ b/fdbclient/include/fdbclient/TenantManagement.actor.h
@@ -501,8 +501,7 @@ Future<std::vector<std::pair<TenantName, TenantMapEntry>>> listTenantMetadataTra
                                                                                          TenantName begin,
                                                                                          TenantName end,
                                                                                          int limit) {
-	state std::vector<std::pair<TenantName, int64_t>> matchingTenants =
-	    wait(listTenantsTransaction(tr, begin, end, limit));
+	std::vector<std::pair<TenantName, int64_t>> matchingTenants = wait(listTenantsTransaction(tr, begin, end, limit));
 
 	state std::vector<Future<TenantMapEntry>> tenantEntryFutures;
 	for (auto const& [name, id] : matchingTenants) {
@@ -512,10 +511,8 @@ Future<std::vector<std::pair<TenantName, TenantMapEntry>>> listTenantMetadataTra
 	wait(waitForAll(tenantEntryFutures));
 
 	std::vector<std::pair<TenantName, TenantMapEntry>> results;
-	state int idx = 0;
-	for (; idx < tenantEntryFutures.size(); ++idx) {
-		auto const& f = tenantEntryFutures[idx];
-		results.emplace_back(matchingTenants[idx].first, f.get());
+	for (auto const& f : tenantEntryFutures) {
+		results.emplace_back(f.get().tenantName, f.get());
 	}
 
 	return results;

--- a/fdbserver/workloads/MetaclusterManagementWorkload.actor.cpp
+++ b/fdbserver/workloads/MetaclusterManagementWorkload.actor.cpp
@@ -392,7 +392,9 @@ struct MetaclusterManagementWorkload : TestWorkload {
 		return Void();
 	}
 
-	ACTOR static Future<Void> verifyListFilter(MetaclusterManagementWorkload* self, TenantName tenant) {
+	ACTOR static Future<Void> verifyListFilter(MetaclusterManagementWorkload* self,
+	                                           TenantName tenant,
+	                                           const char* context) {
 		try {
 			state TenantMapEntry checkEntry = wait(MetaclusterAPI::getTenant(self->managementDb, tenant));
 			state TenantState checkState = checkEntry.tenantState;
@@ -404,6 +406,13 @@ struct MetaclusterManagementWorkload : TestWorkload {
 			wait(store(checkEntry2, MetaclusterAPI::getTenant(self->managementDb, tenant)) &&
 			     store(tenantList,
 			           MetaclusterAPI::listTenantMetadata(self->managementDb, ""_sr, "\xff\xff"_sr, 10e6, 0, filters)));
+
+			DisabledTraceEvent(SevDebug, "VerifyListFilter")
+			    .detail("Context", context)
+			    .detail("Tenant", tenant)
+			    .detail("CheckState", (int)checkState)
+			    .detail("Entry2State", (int)checkEntry2.tenantState);
+
 			bool found = false;
 			for (auto pair : tenantList) {
 				ASSERT(pair.second.tenantState == checkState);
@@ -463,7 +472,7 @@ struct MetaclusterManagementWorkload : TestWorkload {
 						break;
 					} else {
 						retried = true;
-						wait(verifyListFilter(self, tenant));
+						wait(verifyListFilter(self, tenant, "createTenant"));
 					}
 				} catch (Error& e) {
 					if (e.code() == error_code_tenant_already_exists && retried && !exists) {
@@ -564,7 +573,7 @@ struct MetaclusterManagementWorkload : TestWorkload {
 						break;
 					} else {
 						retried = true;
-						wait(verifyListFilter(self, tenant));
+						wait(verifyListFilter(self, tenant, "deleteTenant"));
 					}
 				} catch (Error& e) {
 					if (e.code() == error_code_tenant_not_found && retried && exists) {
@@ -654,7 +663,7 @@ struct MetaclusterManagementWorkload : TestWorkload {
 				if (result.present()) {
 					break;
 				}
-				wait(verifyListFilter(self, tenant));
+				wait(verifyListFilter(self, tenant, "configureTenant"));
 			}
 
 			ASSERT(exists);
@@ -749,8 +758,8 @@ struct MetaclusterManagementWorkload : TestWorkload {
 					}
 
 					retried = true;
-					wait(verifyListFilter(self, tenant));
-					wait(verifyListFilter(self, newTenantName));
+					wait(verifyListFilter(self, tenant, "renameTenant"));
+					wait(verifyListFilter(self, newTenantName, "renameTenantNew"));
 				} catch (Error& e) {
 					// If we retry the rename after it had succeeded, we will get an error that we should ignore
 					if (e.code() == error_code_tenant_not_found && exists && !newTenantExists && retried) {


### PR DESCRIPTION
Fix the failed assertion 
```
ASSERT(found || checkEntry2.tenantState != checkState);
```

The failure appears because the renamed tenant is in `TenantMapEntry.renameDestination` not `TenantMapEntry.tenantName`. So the returned name should come from the original tenant name list.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
