### PR TITLE
Mako: fix token not being reassigned after every reset

### DIFF
--- a/bindings/c/test/mako/mako.cpp
+++ b/bindings/c/test/mako/mako.cpp
@@ -116,12 +116,14 @@ createNewTransaction(Database db, Arguments const& args, int id, std::optional<s
 		auto token_map_iter = args.authorization_tokens.find(tenant_name);
 		if (token_map_iter != args.authorization_tokens.end()) {
 			tr.setOption(FDB_TR_OPTION_AUTHORIZATION_TOKEN, token_map_iter->second);
+			return { tr, { token_map_iter->second } };
 		} else {
 			logr.error("could not find token for tenant '{}'", tenant_name);
 			_exit(1);
 		}
+	} else {
+		return { tr, {} };
 	}
-	return { tr, { tenant_name } };
 }
 
 int cleanupTenants(ipc::AdminServer& server, Arguments const& args, int db_id) {

--- a/bindings/c/test/mako/operations.cpp
+++ b/bindings/c/test/mako/operations.cpp
@@ -187,7 +187,6 @@ const std::array<Operation, MAX_OP> opTable{
 	        } },
 	      { StepKind::IMM,
 	        [](Transaction& tx, Arguments const& args, ByteString& key, ByteString&, ByteString&) {
-	            tx.reset(); // assuming commit from step 0 worked.
 	            tx.clear(key); // key should forward unchanged from step 0
 	            return Future();
 	        } } },
@@ -222,7 +221,6 @@ const std::array<Operation, MAX_OP> opTable{
 	        } },
 	      { StepKind::IMM,
 	        [](Transaction& tx, Arguments const& args, ByteString& begin, ByteString& end, ByteString&) {
-	            tx.reset();
 	            tx.clearRange(begin, end);
 	            return Future();
 	        } } },


### PR DESCRIPTION
`AUTHORIZATION_TOKEN` transaction option gets cleared upon call to `Transaction::reset()` and needs to be assigned again.

This PR implements that for Mako and also removes redundant calls to `Transaction::reset()` in Mako benchmark step functions which could cause subsequent operations to fail.
Also fix the bug where `createNewTransaction()` returns, along with the new transaction object, a tenant name instead of a token.

(Correctness-tested via Mako run with write workload)

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
