### PR TITLE
Add support for pre-built googlebenchmark

### DIFF
--- a/bindings/c/test/unit/third_party/CMakeLists.txt
+++ b/bindings/c/test/unit/third_party/CMakeLists.txt
@@ -1,21 +1,28 @@
 # Download doctest repo.
-include(ExternalProject)
-find_package(Git REQUIRED)
+if(EXISTS /opt/doctest_proj_2.4.8)
+    set(DOCTEST_INCLUDE_DIR "/opt/doctest_proj_2.4.8/doctest" CACHE INTERNAL "Path to include folder for doctest")
+    add_library(doctest INTERFACE)
+    add_dependencies(doctest doctest_proj)
+    target_include_directories(doctest INTERFACE "${DOCTEST_INCLUDE_DIR}")
+else()
+    include(ExternalProject)
+    find_package(Git REQUIRED)
 
-ExternalProject_Add(
-    doctest_proj
-    PREFIX ${CMAKE_BINARY_DIR}/doctest
-    GIT_REPOSITORY https://github.com/onqtam/doctest.git
-    GIT_TAG 7b9885133108ae301ddd16e2651320f54cafeba7 # v2.4.8
-    TIMEOUT 10
-    CONFIGURE_COMMAND ""
-    BUILD_COMMAND ""
-    INSTALL_COMMAND ""
-    LOG_DOWNLOAD ON
-)
+    ExternalProject_Add(
+        doctest_proj
+        PREFIX ${CMAKE_BINARY_DIR}/doctest
+        GIT_REPOSITORY https://github.com/onqtam/doctest.git
+        GIT_TAG 7b9885133108ae301ddd16e2651320f54cafeba7 # v2.4.8
+        TIMEOUT 10
+        CONFIGURE_COMMAND ""
+        BUILD_COMMAND ""
+        INSTALL_COMMAND ""
+        LOG_DOWNLOAD ON
+    )
 
-ExternalProject_Get_Property(doctest_proj source_dir)
-set(DOCTEST_INCLUDE_DIR "${source_dir}/doctest" CACHE INTERNAL "Path to include folder for doctest")
-add_library(doctest INTERFACE)
-add_dependencies(doctest doctest_proj)
-target_include_directories(doctest INTERFACE "${DOCTEST_INCLUDE_DIR}")
+    ExternalProject_Get_Property(doctest_proj source_dir)
+    set(DOCTEST_INCLUDE_DIR "${source_dir}/doctest" CACHE INTERNAL "Path to include folder for doctest")
+    add_library(doctest INTERFACE)
+    add_dependencies(doctest doctest_proj)
+    target_include_directories(doctest INTERFACE "${DOCTEST_INCLUDE_DIR}")
+endif()

--- a/bindings/go/go.mod
+++ b/bindings/go/go.mod
@@ -2,5 +2,3 @@ module github.com/apple/foundationdb/bindings/go
 
 // The FoundationDB go bindings currently have no external golang dependencies outside of
 // the go standard library.
-
-require golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 // indirect

--- a/bindings/go/src/fdb/database.go
+++ b/bindings/go/src/fdb/database.go
@@ -29,8 +29,6 @@ import "C"
 import (
 	"errors"
 	"runtime"
-
-	"golang.org/x/xerrors"
 )
 
 // Database is a handle to a FoundationDB database. Database is a lightweight
@@ -143,7 +141,7 @@ func retryable(wrapped func() (interface{}, error), onError func(Error) FutureNi
 		// Check if the error chain contains an
 		// fdb.Error
 		var ep Error
-		if xerrors.As(e, &ep) {
+		if errors.As(e, &ep) {
 			e = onError(ep).Get()
 		}
 
@@ -167,8 +165,7 @@ func retryable(wrapped func() (interface{}, error), onError func(Error) FutureNi
 // error.
 //
 // The transaction is retried if the error is or wraps a retryable Error.
-// The error is unwrapped with the xerrors.Wrapper. See https://godoc.org/golang.org/x/xerrors#Wrapper
-// for details.
+// The error is unwrapped.
 //
 // Do not return Future objects from the function provided to Transact. The
 // Transaction created by Transact may be finalized at any point after Transact
@@ -211,8 +208,7 @@ func (d Database) Transact(f func(Transaction) (interface{}, error)) (interface{
 // transaction or return the error.
 //
 // The transaction is retried if the error is or wraps a retryable Error.
-// The error is unwrapped with the xerrors.Wrapper. See https://godoc.org/golang.org/x/xerrors#Wrapper
-// for details.
+// The error is unwrapped.
 //
 // Do not return Future objects from the function provided to ReadTransact. The
 // Transaction created by ReadTransact may be finalized at any point after

--- a/bindings/java/CMakeLists.txt
+++ b/bindings/java/CMakeLists.txt
@@ -295,39 +295,44 @@ if(NOT OPEN_FOR_IDE)
       message(WARNING "Cannot run java tests with sanitizer builds")
       return()
     endif()
-    # We use Junit libraries for both JUnit and integration testing structures, so download in either case
-    # https://search.maven.org/remotecontent?filepath=org/junit/jupiter/junit-jupiter-engine/5.7.1/junit-jupiter-engine-5.7.1.jar
-    file(DOWNLOAD "https://search.maven.org/remotecontent?filepath=org/junit/jupiter/junit-jupiter-engine/5.7.1/junit-jupiter-engine-5.7.1.jar"
-      ${CMAKE_BINARY_DIR}/packages/junit-jupiter-engine-5.7.1.jar
-      EXPECTED_HASH SHA256=56616c9350b3624f76cffef6b24ce7bb222915bfd5688f96d3cf4cef34f077cb)
-    # https://search.maven.org/remotecontent?filepath=org/junit/jupiter/junit-jupiter-api/5.7.1/junit-jupiter-api-5.7.1.jar
-    file(DOWNLOAD "https://search.maven.org/remotecontent?filepath=org/junit/jupiter/junit-jupiter-api/5.7.1/junit-jupiter-api-5.7.1.jar"
-      ${CMAKE_BINARY_DIR}/packages/junit-jupiter-api-5.7.1.jar
-      EXPECTED_HASH SHA256=ce7b985bc469e2625759a4ebc45533c70581a05a348278c1d6408e9b2e35e314)
-    file(DOWNLOAD "https://search.maven.org/remotecontent?filepath=org/junit/jupiter/junit-jupiter-params/5.7.1/junit-jupiter-params-5.7.1.jar"
-      ${CMAKE_BINARY_DIR}/packages/junit-jupiter-params-5.7.1.jar
-      EXPECTED_HASH SHA256=8effdd7f8a4ba5558b568184dee08008b2443c86c673ef81de5861fbc7ef0613)
-    file(DOWNLOAD "https://search.maven.org/remotecontent?filepath=org/junit/platform/junit-platform-commons/1.7.1/junit-platform-commons-1.7.1.jar"
-      ${CMAKE_BINARY_DIR}/packages/junit-platform-commons-1.7.1.jar
-      EXPECTED_HASH SHA256=7c546be86864718fbaceb79fa84ff1d3a516500fc428f1b21d061c2e0fbc5a4b)
-    file(DOWNLOAD "https://search.maven.org/remotecontent?filepath=org/junit/platform/junit-platform-engine/1.7.1/junit-platform-engine-1.7.1.jar"
-      ${CMAKE_BINARY_DIR}/packages/junit-platform-engine-1.7.1.jar
-      EXPECTED_HASH SHA256=37df5a9cd6dbc1f754ba2b46f96b8874a83660e1796bf38c738f022dcf86c23f)
-    file(DOWNLOAD "https://search.maven.org/remotecontent?filepath=org/junit/platform/junit-platform-launcher/1.7.1/junit-platform-launcher-1.7.1.jar"
-      ${CMAKE_BINARY_DIR}/packages/junit-platform-launcher-1.7.1.jar
-      EXPECTED_HASH SHA256=3122ac6fb284bc50e3afe46419fc977f94d580e9d3d1ea58805d200b510a99ee)
-    file(DOWNLOAD "https://search.maven.org/remotecontent?filepath=org/junit/platform/junit-platform-console/1.7.1/junit-platform-console-1.7.1.jar"
-      ${CMAKE_BINARY_DIR}/packages/junit-platform-console-1.7.1.jar
-      EXPECTED_HASH SHA256=11ed48fcdfcea32f2fa98872db7ecba2d49d178f76493e7a149a2242363ad12e)
-    file(DOWNLOAD "https://search.maven.org/remotecontent?filepath=org/apiguardian/apiguardian-api/1.1.1/apiguardian-api-1.1.1.jar"
-      ${CMAKE_BINARY_DIR}/packages/apiguardian-api-1.1.1.jar
-      EXPECTED_HASH SHA256=fc68f0d28633caccf3980fdf1e99628fba9c49424ee56dc685cd8b4d2a9fefde)
-    file(DOWNLOAD "https://search.maven.org/remotecontent?filepath=org/opentest4j/opentest4j/1.2.0/opentest4j-1.2.0.jar"
-      ${CMAKE_BINARY_DIR}/packages/opentest4j-1.2.0.jar)
+    if(EXISTS /opt/junit_dependencies)
+      set(JUNIT_JARS /opt/junit_dependencies)
+    else()
+      set(JUNIT_JARS "${CMAKE_BINARY_DIR}/packages")
+      # We use Junit libraries for both JUnit and integration testing structures, so download in either case
+      # https://search.maven.org/remotecontent?filepath=org/junit/jupiter/junit-jupiter-engine/5.7.1/junit-jupiter-engine-5.7.1.jar
+      file(DOWNLOAD "https://search.maven.org/remotecontent?filepath=org/junit/jupiter/junit-jupiter-engine/5.7.1/junit-jupiter-engine-5.7.1.jar"
+        ${JUNIT_JARS}/junit-jupiter-engine-5.7.1.jar
+        EXPECTED_HASH SHA256=56616c9350b3624f76cffef6b24ce7bb222915bfd5688f96d3cf4cef34f077cb)
+      # https://search.maven.org/remotecontent?filepath=org/junit/jupiter/junit-jupiter-api/5.7.1/junit-jupiter-api-5.7.1.jar
+      file(DOWNLOAD "https://search.maven.org/remotecontent?filepath=org/junit/jupiter/junit-jupiter-api/5.7.1/junit-jupiter-api-5.7.1.jar"
+        ${JUNIT_JARS}/junit-jupiter-api-5.7.1.jar
+        EXPECTED_HASH SHA256=ce7b985bc469e2625759a4ebc45533c70581a05a348278c1d6408e9b2e35e314)
+      file(DOWNLOAD "https://search.maven.org/remotecontent?filepath=org/junit/jupiter/junit-jupiter-params/5.7.1/junit-jupiter-params-5.7.1.jar"
+        ${JUNIT_JARS}/junit-jupiter-params-5.7.1.jar
+        EXPECTED_HASH SHA256=8effdd7f8a4ba5558b568184dee08008b2443c86c673ef81de5861fbc7ef0613)
+      file(DOWNLOAD "https://search.maven.org/remotecontent?filepath=org/junit/platform/junit-platform-commons/1.7.1/junit-platform-commons-1.7.1.jar"
+        ${JUNIT_JARS}/junit-platform-commons-1.7.1.jar
+        EXPECTED_HASH SHA256=7c546be86864718fbaceb79fa84ff1d3a516500fc428f1b21d061c2e0fbc5a4b)
+      file(DOWNLOAD "https://search.maven.org/remotecontent?filepath=org/junit/platform/junit-platform-engine/1.7.1/junit-platform-engine-1.7.1.jar"
+        ${JUNIT_JARS}/junit-platform-engine-1.7.1.jar
+        EXPECTED_HASH SHA256=37df5a9cd6dbc1f754ba2b46f96b8874a83660e1796bf38c738f022dcf86c23f)
+      file(DOWNLOAD "https://search.maven.org/remotecontent?filepath=org/junit/platform/junit-platform-launcher/1.7.1/junit-platform-launcher-1.7.1.jar"
+        ${JUNIT_JARS}/junit-platform-launcher-1.7.1.jar
+        EXPECTED_HASH SHA256=3122ac6fb284bc50e3afe46419fc977f94d580e9d3d1ea58805d200b510a99ee)
+      file(DOWNLOAD "https://search.maven.org/remotecontent?filepath=org/junit/platform/junit-platform-console/1.7.1/junit-platform-console-1.7.1.jar"
+        ${JUNIT_JARS}/junit-platform-console-1.7.1.jar
+        EXPECTED_HASH SHA256=11ed48fcdfcea32f2fa98872db7ecba2d49d178f76493e7a149a2242363ad12e)
+      file(DOWNLOAD "https://search.maven.org/remotecontent?filepath=org/apiguardian/apiguardian-api/1.1.1/apiguardian-api-1.1.1.jar"
+        ${JUNIT_JARS}/apiguardian-api-1.1.1.jar
+        EXPECTED_HASH SHA256=fc68f0d28633caccf3980fdf1e99628fba9c49424ee56dc685cd8b4d2a9fefde)
+      file(DOWNLOAD "https://search.maven.org/remotecontent?filepath=org/opentest4j/opentest4j/1.2.0/opentest4j-1.2.0.jar"
+        ${JUNIT_JARS}/opentest4j-1.2.0.jar)
+    endif()
 
-    set(JUNIT_CLASSPATH "${CMAKE_BINARY_DIR}/packages/junit-jupiter-api-5.7.1.jar:${CMAKE_BINARY_DIR}/packages/junit-jupiter-engine-5.7.1.jar:${CMAKE_BINARY_DIR}/packages/junit-jupiter-params-5.7.1.jar:${CMAKE_BINARY_DIR}/packages/opentest4j-1.2.0.jar:${CMAKE_BINARY_DIR}/packages/apiguardian-api-1.1.1.jar")
-    set(JUNIT_CLASSPATH "${JUNIT_CLASSPATH}:${CMAKE_BINARY_DIR}/packages/junit-platform-console-1.7.1.jar:${CMAKE_BINARY_DIR}/packages/junit-platform-commons-1.7.1.jar")
-    set(JUNIT_CLASSPATH "${JUNIT_CLASSPATH}:${CMAKE_BINARY_DIR}/packages/junit-platform-engine-1.7.1.jar:${CMAKE_BINARY_DIR}/packages/junit-platform-launcher-1.7.1.jar")
+    set(JUNIT_CLASSPATH "${JUNIT_JARS}/junit-jupiter-api-5.7.1.jar:${JUNIT_JARS}/junit-jupiter-engine-5.7.1.jar:${JUNIT_JARS}/junit-jupiter-params-5.7.1.jar:${JUNIT_JARS}/opentest4j-1.2.0.jar:${JUNIT_JARS}/apiguardian-api-1.1.1.jar")
+    set(JUNIT_CLASSPATH "${JUNIT_CLASSPATH}:${JUNIT_JARS}/junit-platform-console-1.7.1.jar:${JUNIT_JARS}/junit-platform-commons-1.7.1.jar")
+    set(JUNIT_CLASSPATH "${JUNIT_CLASSPATH}:${JUNIT_JARS}/junit-platform-engine-1.7.1.jar:${JUNIT_JARS}/junit-platform-launcher-1.7.1.jar")
   endif()
 
   if(RUN_JUNIT_TESTS)
@@ -351,11 +356,11 @@ if(NOT OPEN_FOR_IDE)
     # can be found at https://cmake.org/cmake/help/v3.19/manual/ctest.1.html)
 
     add_jar(fdb-junit SOURCES ${JAVA_JUNIT_TESTS} ${JUNIT_RESOURCES} INCLUDE_JARS fdb-java
-      ${CMAKE_BINARY_DIR}/packages/junit-jupiter-api-5.7.1.jar
-      ${CMAKE_BINARY_DIR}/packages/junit-jupiter-engine-5.7.1.jar
-      ${CMAKE_BINARY_DIR}/packages/junit-jupiter-params-5.7.1.jar
-      ${CMAKE_BINARY_DIR}/packages/opentest4j-1.2.0.jar
-      ${CMAKE_BINARY_DIR}/packages/apiguardian-api-1.1.1.jar
+      ${JUNIT_JARS}/junit-jupiter-api-5.7.1.jar
+      ${JUNIT_JARS}/junit-jupiter-engine-5.7.1.jar
+      ${JUNIT_JARS}/junit-jupiter-params-5.7.1.jar
+      ${JUNIT_JARS}/opentest4j-1.2.0.jar
+      ${JUNIT_JARS}/apiguardian-api-1.1.1.jar
       )
     get_property(junit_jar_path TARGET fdb-junit PROPERTY JAR_FILE)
 
@@ -394,11 +399,11 @@ if(NOT OPEN_FOR_IDE)
     # the directory layer with a unique path, etc.)
     #
     add_jar(fdb-integration SOURCES ${JAVA_INTEGRATION_TESTS} ${JAVA_INTEGRATION_RESOURCES} INCLUDE_JARS fdb-java
-      ${CMAKE_BINARY_DIR}/packages/junit-jupiter-api-5.7.1.jar
-      ${CMAKE_BINARY_DIR}/packages/junit-jupiter-engine-5.7.1.jar
-      ${CMAKE_BINARY_DIR}/packages/junit-jupiter-params-5.7.1.jar
-      ${CMAKE_BINARY_DIR}/packages/opentest4j-1.2.0.jar
-      ${CMAKE_BINARY_DIR}/packages/apiguardian-api-1.1.1.jar)
+      ${JUNIT_JARS}/junit-jupiter-api-5.7.1.jar
+      ${JUNIT_JARS}/junit-jupiter-engine-5.7.1.jar
+      ${JUNIT_JARS}/junit-jupiter-params-5.7.1.jar
+      ${JUNIT_JARS}/opentest4j-1.2.0.jar
+      ${JUNIT_JARS}/apiguardian-api-1.1.1.jar)
     get_property(integration_jar_path TARGET fdb-integration PROPERTY JAR_FILE)
 
     # add_fdbclient_test will set FDB_CLUSTER_FILE if it's not set already

--- a/cmake/CompileBoost.cmake
+++ b/cmake/CompileBoost.cmake
@@ -154,7 +154,20 @@ endif()
 find_package(Boost 1.78.0 EXACT QUIET COMPONENTS context filesystem iostreams serialization system CONFIG PATHS ${BOOST_HINT_PATHS})
 set(FORCE_BOOST_BUILD OFF CACHE BOOL "Forces cmake to build boost and ignores any installed boost")
 
-if(Boost_FOUND AND Boost_filesystem_FOUND AND Boost_context_FOUND AND Boost_iostreams_FOUND AND Boost_system_FOUND AND Boost_serialization_FOUND AND NOT FORCE_BOOST_BUILD)
+# The precompiled boost silently broke in CI.  While investigating, I considered extending
+# the old check with something like this, so that it would fail loudly if it found a bad
+# pre-existing boost.  It turns out the error messages we get from CMake explain what is
+# wrong with Boost.  Rather than reimplementing that, I just deleted this logic.  This
+# approach is simpler, has better ergonomics and should be easier to maintain.  If the build
+# is picking up your locally installed or partial version of boost, and you don't want
+# to / cannot fix it, pass in -DFORCE_BOOST_BUILD=on as a workaround.
+#
+#    if(Boost_FOUND AND Boost_filesystem_FOUND AND Boost_context_FOUND AND Boost_iostreams_FOUND AND Boost_system_FOUND AND Boost_serialization_FOUND AND NOT FORCE_BOOST_BUILD)
+#      ...
+#    elseif(Boost_FOUND AND NOT FORCE_BOOST_BUILD)
+#      message(FATAL_ERROR "Unacceptable precompiled boost found")
+#
+if(Boost_FOUND AND NOT FORCE_BOOST_BUILD)
   add_library(boost_target INTERFACE)
   target_link_libraries(boost_target INTERFACE Boost::boost Boost::context Boost::filesystem Boost::iostreams Boost::serialization Boost::system)
 elseif(WIN32)

--- a/cmake/Jemalloc.cmake
+++ b/cmake/Jemalloc.cmake
@@ -6,19 +6,23 @@ endif()
 
 add_library(im_jemalloc_pic STATIC IMPORTED)
 add_library(im_jemalloc STATIC IMPORTED)
-include(ExternalProject)
-set(JEMALLOC_DIR "${CMAKE_BINARY_DIR}/jemalloc")
-ExternalProject_add(Jemalloc_project
-  URL "https://github.com/jemalloc/jemalloc/releases/download/5.3.0/jemalloc-5.3.0.tar.bz2"
-  URL_HASH SHA256=2db82d1e7119df3e71b7640219b6dfe84789bc0537983c3b7ac4f7189aecfeaa
-  BUILD_BYPRODUCTS "${JEMALLOC_DIR}/include/jemalloc/jemalloc.h"
-  "${JEMALLOC_DIR}/lib/libjemalloc.a"
-  "${JEMALLOC_DIR}/lib/libjemalloc_pic.a"
-  CONFIGURE_COMMAND CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER} ./configure --prefix=${JEMALLOC_DIR} --enable-static --disable-cxx --enable-prof
-  BUILD_IN_SOURCE ON
-  BUILD_COMMAND make
-  INSTALL_DIR "${JEMALLOC_DIR}"
-  INSTALL_COMMAND make install)
+if(EXISTS /opt/jemalloc_5.3.0)
+  set(JEMALLOC_DIR /opt/jemalloc_5.3.0)
+else()
+  include(ExternalProject)
+  set(JEMALLOC_DIR "${CMAKE_BINARY_DIR}/jemalloc")
+  ExternalProject_add(Jemalloc_project
+    URL "https://github.com/jemalloc/jemalloc/releases/download/5.3.0/jemalloc-5.3.0.tar.bz2"
+    URL_HASH SHA256=2db82d1e7119df3e71b7640219b6dfe84789bc0537983c3b7ac4f7189aecfeaa
+    BUILD_BYPRODUCTS "${JEMALLOC_DIR}/include/jemalloc/jemalloc.h"
+    "${JEMALLOC_DIR}/lib/libjemalloc.a"
+    "${JEMALLOC_DIR}/lib/libjemalloc_pic.a"
+    CONFIGURE_COMMAND CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER} ./configure --prefix=${JEMALLOC_DIR} --enable-static --disable-cxx --enable-prof
+    BUILD_IN_SOURCE ON
+    BUILD_COMMAND make
+    INSTALL_DIR "${JEMALLOC_DIR}"
+    INSTALL_COMMAND make install)
+endif()
 add_dependencies(im_jemalloc Jemalloc_project)
 add_dependencies(im_jemalloc_pic Jemalloc_project)
 set_target_properties(im_jemalloc_pic PROPERTIES IMPORTED_LOCATION "${JEMALLOC_DIR}/lib/libjemalloc_pic.a")

--- a/fdbcli/FlowLineNoise.actor.cpp
+++ b/fdbcli/FlowLineNoise.actor.cpp
@@ -24,8 +24,12 @@
 #ifndef BOOST_SYSTEM_NO_LIB
 #define BOOST_SYSTEM_NO_LIB
 #endif
+#ifndef BOOST_DATE_TIME_NO_LIB
 #define BOOST_DATE_TIME_NO_LIB
+#endif
+#ifndef BOOST_REGEX_NO_LIB
 #define BOOST_REGEX_NO_LIB
+#endif
 #include "boost/asio.hpp"
 
 #include "flow/ThreadHelper.actor.h"

--- a/fdbclient/AutoPublicAddress.cpp
+++ b/fdbclient/AutoPublicAddress.cpp
@@ -24,8 +24,12 @@
 #ifndef BOOST_SYSTEM_NO_LIB
 #define BOOST_SYSTEM_NO_LIB
 #endif
+#ifndef BOOST_DATE_TIME_NO_LIB
 #define BOOST_DATE_TIME_NO_LIB
+#endif
+#ifndef BOOST_REGEX_NO_LIB
 #define BOOST_REGEX_NO_LIB
+#endif
 #include "boost/asio.hpp"
 
 #include "fdbclient/CoordinationInterface.h"

--- a/fdbrpc/Net2FileSystem.cpp
+++ b/fdbrpc/Net2FileSystem.cpp
@@ -25,8 +25,12 @@
 #ifndef BOOST_SYSTEM_NO_LIB
 #define BOOST_SYSTEM_NO_LIB
 #endif
+#ifndef BOOST_DATE_TIME_NO_LIB
 #define BOOST_DATE_TIME_NO_LIB
+#endif
+#ifndef BOOST_REGEX_NO_LIB
 #define BOOST_REGEX_NO_LIB
+#endif
 #include <boost/asio.hpp>
 
 #define FILESYSTEM_IMPL 1

--- a/fdbrpc/SimExternalConnection.actor.cpp
+++ b/fdbrpc/SimExternalConnection.actor.cpp
@@ -21,8 +21,12 @@
 #ifndef BOOST_SYSTEM_NO_LIB
 #define BOOST_SYSTEM_NO_LIB
 #endif
+#ifndef BOOST_DATE_TIME_NO_LIB
 #define BOOST_DATE_TIME_NO_LIB
+#endif
+#ifndef BOOST_REGEX_NO_LIB
 #define BOOST_REGEX_NO_LIB
+#endif
 #include <boost/asio.hpp>
 #include <boost/range.hpp>
 #include <thread>

--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -29,8 +29,12 @@
 #ifndef BOOST_SYSTEM_NO_LIB
 #define BOOST_SYSTEM_NO_LIB
 #endif
+#ifndef BOOST_DATE_TIME_NO_LIB
 #define BOOST_DATE_TIME_NO_LIB
+#endif
+#ifndef BOOST_REGEX_NO_LIB
 #define BOOST_REGEX_NO_LIB
+#endif
 #include "fdbrpc/SimExternalConnection.h"
 #include "flow/ActorCollection.h"
 #include "flow/IRandom.h"

--- a/fdbserver/FDBExecHelper.actor.cpp
+++ b/fdbserver/FDBExecHelper.actor.cpp
@@ -22,8 +22,12 @@
 #ifndef BOOST_SYSTEM_NO_LIB
 #define BOOST_SYSTEM_NO_LIB
 #endif
+#ifndef BOOST_DATE_TIME_NO_LIB
 #define BOOST_DATE_TIME_NO_LIB
+#endif
+#ifndef BOOST_REGEX_NO_LIB
 #define BOOST_REGEX_NO_LIB
+#endif
 #include <boost/process.hpp>
 #endif
 #include <boost/algorithm/string.hpp>

--- a/flow/IThreadPool.cpp
+++ b/flow/IThreadPool.cpp
@@ -21,11 +21,20 @@
 #include "flow/IThreadPool.h"
 
 #include <algorithm>
+// The ifndef's allow us to compile with pre-built boost.  Otherwise, we get
+// errors about double-defines.  As of this writing, the automatically downloaded
+// build of boost doesn't define these, but the pre-built version does.  (The old
+// prebuilt version was being silently ignored by cmake, so it's unclear when the
+// compatibility divergence started)
 #ifndef BOOST_SYSTEM_NO_LIB
 #define BOOST_SYSTEM_NO_LIB
 #endif
+#ifndef BOOST_DATE_TIME_NO_LIB
 #define BOOST_DATE_TIME_NO_LIB
+#endif
+#ifndef BOOST_REGEX_NO_LIB
 #define BOOST_REGEX_NO_LIB
+#endif
 #include "boost/asio.hpp"
 
 class ThreadPool final : public IThreadPool, public ReferenceCounted<ThreadPool> {

--- a/flow/Net2.actor.cpp
+++ b/flow/Net2.actor.cpp
@@ -29,8 +29,12 @@
 #ifndef BOOST_SYSTEM_NO_LIB
 #define BOOST_SYSTEM_NO_LIB
 #endif
+#ifndef BOOST_DATE_TIME_NO_LIB
 #define BOOST_DATE_TIME_NO_LIB
+#endif
+#ifndef BOOST_REGEX_NO_LIB
 #define BOOST_REGEX_NO_LIB
+#endif
 #include <boost/asio.hpp>
 #if defined(HAVE_WOLFSSL)
 #include <wolfssl/options.h>

--- a/flowbench/CMakeLists.txt
+++ b/flowbench/CMakeLists.txt
@@ -5,10 +5,14 @@ fdb_find_sources(FLOWBENCH_SRCS)
 # There is no good way to incorporate the recommended googlebenchmark download + build
 # process with one that checks to see if googlebenchmark has already been downloaded
 # and built.
-if(EXISTS /opt/googlebenchmark-f91b6b)
+if(EXISTS /opt/googlebenchmark-f91b6b AND CLANG)
   add_flow_target(EXECUTABLE NAME flowbench SRCS ${FLOWBENCH_SRCS})
   target_include_directories(flowbench PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/include" "${CMAKE_CURRENT_BINARY_DIR}/include" /opt/googlebenchmark-f91b6b/include)
   target_link_directories(flowbench PRIVATE /opt/googlebenchmark-f91b6b/src)
+elseif(EXISTS /opt/googlebenchmark-f91b6b-g++ AND NOT CLANG)
+  add_flow_target(EXECUTABLE NAME flowbench SRCS ${FLOWBENCH_SRCS})
+  target_include_directories(flowbench PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/include" "${CMAKE_CURRENT_BINARY_DIR}/include" /opt/googlebenchmark-f91b6b-g++/include)
+  target_link_directories(flowbench PRIVATE /opt/googlebenchmark-f91b6b-g++/src)
 else()
   ## This seems to be copy-pasted from the the google benchmark documentation.
   ## It breaks if you attempt to re-use a build of googlebenchmark across FDB

--- a/flowbench/CMakeLists.txt
+++ b/flowbench/CMakeLists.txt
@@ -2,36 +2,49 @@ project (flowbench)
 
 fdb_find_sources(FLOWBENCH_SRCS)
 
-# include the configurations from benchmark.cmake
-configure_file(benchmark.cmake googlebenchmark-download/CMakeLists.txt)
-# executing the configuration step
-execute_process(
-    COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
-    RESULT_VARIABLE results
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googlebenchmark-download
-)
-# checking if the configuration step passed
-if(results)
-    message(FATAL_ERROR "Configuration step for Benchmark has Failed. ${results}")
+# There is no good way to incorporate the recommended googlebenchmark download + build
+# process with one that checks to see if googlebenchmark has already been downloaded
+# and built.
+if(EXISTS /opt/googlebenchmark-f91b6b)
+  add_flow_target(EXECUTABLE NAME flowbench SRCS ${FLOWBENCH_SRCS})
+  target_include_directories(flowbench PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/include" "${CMAKE_CURRENT_BINARY_DIR}/include" /opt/googlebenchmark-f91b6b/include)
+  target_link_directories(flowbench PRIVATE /opt/googlebenchmark-f91b6b/src)
+else()
+  ## This seems to be copy-pasted from the the google benchmark documentation.
+  ## It breaks if you attempt to re-use a build of googlebenchmark across FDB
+  ## builds.
+
+  # include the configurations from benchmark.cmake
+  configure_file(benchmark.cmake googlebenchmark-download/CMakeLists.txt)
+  # executing the configuration step
+  execute_process(
+      COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+      RESULT_VARIABLE results
+      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googlebenchmark-download
+  )
+  # checking if the configuration step passed
+  if(results)
+      message(FATAL_ERROR "Configuration step for Benchmark has Failed. ${results}")
+  endif()
+  # executing the build step
+  execute_process(
+      COMMAND ${CMAKE_COMMAND} --build . --config Release
+      RESULT_VARIABLE results
+      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googlebenchmark-download
+  )
+  # checking if the build step passed
+  if(results)
+    message(FATAL_ERROR "Build step for Benchmark has Failed. ${results}")
+  endif()
+  set(BENCHMARK_ENABLE_TESTING OFF)
+  add_subdirectory(
+    ${CMAKE_CURRENT_BINARY_DIR}/googlebenchmark-src
+    ${CMAKE_CURRENT_BINARY_DIR}/googlebenchmark-build
+    EXCLUDE_FROM_ALL
+  )
+  add_flow_target(EXECUTABLE NAME flowbench SRCS ${FLOWBENCH_SRCS})
+  target_include_directories(flowbench PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/include" "${CMAKE_CURRENT_BINARY_DIR}/include"  ${CMAKE_CURRENT_BINARY_DIR}/googlebenchmark-src/include)
 endif()
-# executing the build step
-execute_process(
-    COMMAND ${CMAKE_COMMAND} --build . --config Release
-    RESULT_VARIABLE results
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googlebenchmark-download
-)
-# checking if the build step passed
-if(results)
-  message(FATAL_ERROR "Build step for Benchmark has Failed. ${results}")
-endif()
-set(BENCHMARK_ENABLE_TESTING OFF)
-add_subdirectory(
-  ${CMAKE_CURRENT_BINARY_DIR}/googlebenchmark-src
-  ${CMAKE_CURRENT_BINARY_DIR}/googlebenchmark-build
-  EXCLUDE_FROM_ALL
-)
-add_flow_target(EXECUTABLE NAME flowbench SRCS ${FLOWBENCH_SRCS})
-target_include_directories(flowbench PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/include" "${CMAKE_CURRENT_BINARY_DIR}/include"  ${CMAKE_CURRENT_BINARY_DIR}/googlebenchmark-src/include)
 if(FLOW_USE_ZSTD)
    target_include_directories(flowbench PRIVATE ${ZSTD_LIB_INCLUDE_DIR})
 endif()

--- a/flowbench/benchmark.cmake
+++ b/flowbench/benchmark.cmake
@@ -4,6 +4,8 @@ project(googlebenchmark-download NONE)
 include(ExternalProject)
 ExternalProject_Add(googlebenchmark
   GIT_REPOSITORY    https://github.com/google/benchmark.git
+  # If you change this, then be sure to also update the directory name (which contains this SHA) in flowbench/CMakeLists.txt,
+  # and the fdb-build-support Dockerfile (which downloads + compiles the prebuilt version)
   GIT_TAG           f91b6b42b1b9854772a90ae9501464a161707d1e # v1.6.0
   GIT_SHALLOW       ON
   GIT_CONFIG        advice.detachedHead=false
@@ -19,6 +21,8 @@ ExternalProject_Add(googlebenchmark
 include(ExternalProject)
 ExternalProject_Add(googletest DEPENDS googlebenchmark
   GIT_REPOSITORY    https://github.com/google/googletest.git
+  # If you change this, be sure to update the perl one-liner in the part of fdb-build-support Dockerfile that downloads
+  # googlebenchmark.  That one-liner determines which SHA will be used in the pre-built version of googlebenchmark.
   GIT_TAG           2fe3bd994b3189899d93f1d5a881e725e046fdc2 # release-1.8.1
   GIT_SHALLOW       ON
   GIT_CONFIG        advice.detachedHead=false

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,9 +16,8 @@ set(SANITIZER_OPTIONS "UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1;TSAN_OPT
 # to test upgrades
 if(WITH_PYTHON)
   find_program(OLD_FDBSERVER_BINARY
-    fdbserver fdbserver.exe
-    HINTS /opt/foundationdb/old /usr/sbin /usr/libexec /usr/local/sbin /usr/local/libexec)
-
+    fdbserver-7.1.23 fdbserver fdbserver.exe
+    HINTS /opt/foundationdb/old/7.1.23/bin/ /opt/foundationdb/old /usr/sbin /usr/libexec /usr/local/sbin /usr/local/libexec)
   if(OLD_FDBSERVER_BINARY)
     message(STATUS "Use old fdb at ${OLD_FDBSERVER_BINARY}")
   else()


### PR DESCRIPTION
This PR makes it possible for FDB to use a pre-build version of googlebenchmark.  The pre-built version is not included in the FDB build image yet.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
