### PR TITLE
Add a default value for `minVersion` in `WaitMetricsRequest`

### DIFF
--- a/fdbclient/include/fdbclient/StorageServerInterface.h
+++ b/fdbclient/include/fdbclient/StorageServerInterface.h
@@ -715,10 +715,10 @@ struct WaitMetricsRequest {
 	// Send a reversed range for min, max to receive an immediate report
 	constexpr static FileIdentifier file_identifier = 1795961;
 	Arena arena;
-	// Setting the tenantInfo makes the request tenant-aware. Need to set `minVersion` to a version where
-	// the tenant info was read.
+	// Setting the tenantInfo makes the request tenant-aware.
 	TenantInfo tenantInfo;
-	Version minVersion;
+	// Set `minVersion` to a version where the tenant info was read. Not needed for non-tenant-aware request.
+	Version minVersion = 0;
 	KeyRangeRef keys;
 	StorageMetrics min, max;
 	ReplyPromise<StorageMetrics> reply;


### PR DESCRIPTION
Add a default value for `minVersion` in `WaitMetricsRequest`. This is useful for callers that use the default `WaitMetricsRequest()` constructor and don't need to set `tenantInfo` and `minVersion`.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
