### PR TITLE
Add new database option to allow toggling of causal read risky

### DIFF
--- a/bindings/flow/tester/Tester.actor.cpp
+++ b/bindings/flow/tester/Tester.actor.cpp
@@ -1638,6 +1638,7 @@ struct UnitTestsFunc : InstructionFunc {
 		const uint64_t maxRetryDelay = 100;
 		const uint64_t sizeLimit = 100000;
 		const uint64_t maxFieldLength = 1000;
+		const uint64_t alwaysConfirmProxyValid = 1;
 
 		data->db->setDatabaseOption(FDBDatabaseOption::FDB_DB_OPTION_LOCATION_CACHE_SIZE,
 		                            Optional<StringRef>(StringRef((const uint8_t*)&locationCacheSize, 8)));
@@ -1661,8 +1662,9 @@ struct UnitTestsFunc : InstructionFunc {
 		                            Optional<StringRef>(StringRef((const uint8_t*)&retryLimit, 8)));
 		data->db->setDatabaseOption(FDBDatabaseOption::FDB_DB_OPTION_TRANSACTION_RETRY_LIMIT,
 		                            Optional<StringRef>(StringRef((const uint8_t*)&noRetryLimit, 8)));
-		data->db->setDatabaseOption(FDBDatabaseOption::FDB_DB_OPTION_TRANSACTION_CAUSAL_READ_RISKY);
 		data->db->setDatabaseOption(FDBDatabaseOption::FDB_DB_OPTION_TRANSACTION_INCLUDE_PORT_IN_ADDRESS);
+		data->db->setDatabaseOption(FDBDatabaseOption::FDB_DB_OPTION_ALWAYS_CONFIRM_PROXY_VALID,
+		                            Optional<StringRef>(StringRef((const uint8_t*)&alwaysConfirmProxyValid, 8)));
 
 		state Reference<Transaction> tr = data->db->createTransaction();
 		tr->setOption(FDBTransactionOption::FDB_TR_OPTION_PRIORITY_SYSTEM_IMMEDIATE);

--- a/bindings/go/src/_stacktester/stacktester.go
+++ b/bindings/go/src/_stacktester/stacktester.go
@@ -825,8 +825,8 @@ func (sm *StackMachine) processInst(idx int, inst tuple.Tuple) {
 		db.Options().SetTransactionMaxRetryDelay(100)
 		db.Options().SetTransactionRetryLimit(10)
 		db.Options().SetTransactionRetryLimit(-1)
-		db.Options().SetTransactionCausalReadRisky()
 		db.Options().SetTransactionIncludePortInAddress()
+		db.Options().SetAlwaysConfirmProxyValid(true)
 
 		if !fdb.IsAPIVersionSelected() {
 			log.Fatal("API version should be selected")

--- a/bindings/go/src/fdb/generated.go
+++ b/bindings/go/src/fdb/generated.go
@@ -402,7 +402,7 @@ func (o DatabaseOptions) SetTransactionSizeLimit(param int64) error {
 	return o.setOpt(503, int64ToBytes(param))
 }
 
-// The read version will be committed, and usually will be the latest committed, but might not be the latest committed in the event of a simultaneous fault and misbehaving clock.
+// Deprecated. See ``always_confirm_proxy_valid``.
 func (o DatabaseOptions) SetTransactionCausalReadRisky() error {
 	return o.setOpt(504, nil)
 }
@@ -432,6 +432,13 @@ func (o DatabaseOptions) SetUseConfigDatabase() error {
 // Parameter: integer between 0 and 100 expressing the probability a client will verify it can't read stale data
 func (o DatabaseOptions) SetTestCausalReadRisky(param int64) error {
 	return o.setOpt(900, int64ToBytes(param))
+}
+
+// When disabled, the read version will be committed, and usually will be the latest committed, but might not be the latest committed in the event of a simultaneous fault and misbehaving clock. Defaults to true.
+//
+// Parameter: true if the proxy should always confirm it is part of the current generation
+func (o DatabaseOptions) SetAlwaysConfirmProxyValid(param int64) error {
+	return o.setOpt(1000, int64ToBytes(param))
 }
 
 // The transaction, if not self-conflicting, may be committed a second time after commit succeeds, in the event of a fault

--- a/bindings/java/src/test/com/apple/foundationdb/test/AsyncStackTester.java
+++ b/bindings/java/src/test/com/apple/foundationdb/test/AsyncStackTester.java
@@ -564,8 +564,8 @@ public class AsyncStackTester {
 				db.options().setTransactionMaxRetryDelay(100);
 				db.options().setTransactionRetryLimit(10);
 				db.options().setTransactionRetryLimit(-1);
-				db.options().setTransactionCausalReadRisky();
 				db.options().setTransactionIncludePortInAddress();
+				db.options().setAlwaysConfirmProxyValid(1);
 
 				// Test network busyness
 				double busyness = db.getMainThreadBusyness();

--- a/bindings/java/src/test/com/apple/foundationdb/test/StackTester.java
+++ b/bindings/java/src/test/com/apple/foundationdb/test/StackTester.java
@@ -503,8 +503,8 @@ public class StackTester {
 						db.options().setTransactionMaxRetryDelay(100);
 						db.options().setTransactionRetryLimit(10);
 						db.options().setTransactionRetryLimit(-1);
-						db.options().setTransactionCausalReadRisky();
 						db.options().setTransactionIncludePortInAddress();
+						db.options().setAlwaysConfirmProxyValid(1);
 
 						tr.options().setPrioritySystemImmediate();
 						tr.options().setPriorityBatch();

--- a/bindings/ruby/tests/tester.rb
+++ b/bindings/ruby/tests/tester.rb
@@ -474,8 +474,8 @@ class Tester
             @db.options.set_transaction_size_limit(100000)
             @db.options.set_transaction_retry_limit(10)
             @db.options.set_transaction_retry_limit(-1)
-            @db.options.set_transaction_causal_read_risky()
             @db.options.set_transaction_include_port_in_address()
+            @db.options.set_always_confirm_proxy_valid(true)
 
             @db.transact do |tr|
               tr.options.set_priority_system_immediate

--- a/fdbclient/include/fdbclient/DatabaseContext.h
+++ b/fdbclient/include/fdbclient/DatabaseContext.h
@@ -616,6 +616,7 @@ public:
 	int snapshotRywEnabled;
 
 	bool transactionTracingSample;
+	bool alwaysConfirmProxyValid = true;
 	double verifyCausalReadsProp = 0.0;
 	bool blobGranuleNoMaterialize = false;
 

--- a/fdbclient/include/fdbclient/FDBOptions.h
+++ b/fdbclient/include/fdbclient/FDBOptions.h
@@ -95,11 +95,17 @@ private:
 	std::map<typename T::Option, typename OptionList::iterator> optionsIndexMap;
 
 public:
-	void addOption(typename T::Option option, Optional<Standalone<StringRef>> value) {
+	bool removeOption(typename T::Option option) {
 		auto itr = optionsIndexMap.find(option);
-		if (itr != optionsIndexMap.end()) {
+		bool exists = itr != optionsIndexMap.end();
+		if (exists) {
 			options.erase(itr->second);
 		}
+		return exists;
+	}
+
+	void addOption(typename T::Option option, Optional<Standalone<StringRef>> value) {
+		removeOption(option);
 		options.emplace_back(option, value);
 		optionsIndexMap[option] = --options.end();
 	}

--- a/fdbclient/vexillographer/fdb.options
+++ b/fdbclient/vexillographer/fdb.options
@@ -204,7 +204,7 @@ description is not currently required but encouraged.
             description="Set the maximum transaction size in bytes. This sets the ``size_limit`` option on each transaction created by this database. See the transaction option description for more information." 
             defaultFor="503"/>
     <Option name="transaction_causal_read_risky" code="504"
-            description="The read version will be committed, and usually will be the latest committed, but might not be the latest committed in the event of a simultaneous fault and misbehaving clock."
+            description="Deprecated. See ``always_confirm_proxy_valid``."
             defaultFor="20"/>
     <Option name="transaction_include_port_in_address" code="505"
             description="Deprecated. Addresses returned by get_addresses_for_key include the port when enabled. As of api version 630, this option is enabled by default and setting this has no effect."
@@ -220,6 +220,9 @@ description is not currently required but encouraged.
     <Option name="test_causal_read_risky" code="900"
             paramType="Int" paramDescription="integer between 0 and 100 expressing the probability a client will verify it can't read stale data"
             description="Enables verification of causal read risky by checking whether clients are able to read stale data when they detect a recovery, and logging an error if so." />
+    <Option name="always_confirm_proxy_valid" code="1000"
+            paramType="Int" paramDescription="true if the proxy should always confirm it is part of the current generation before serving requests"
+            description="When disabled, the read version will be committed, and usually will be the latest committed, but might not be the latest committed in the event of a simultaneous fault and misbehaving clock. Defaults to true." />
   </Scope>
   
   <Scope name="TransactionOption">


### PR DESCRIPTION
The `transaction_causal_read_risky` database option cannot be disabled once enabled. This commit adds a new database option `always_confirm_proxy_valid`, which accepts a boolean parameter on whether the GRV proxies should always confirm they are valid before returning a read version. It defaults to true.

Setting `always_confirm_proxy_valid` to false is equivalent to setting the old option, `transaction_causal_read_risky`, to true. The effect is GRV proxies no longer have to talk to transaction logs to ensure they are current, and therefore can, in certain circumstances, return stale read versions.

I tested the change using a Python script[0] along with a print statement in the GRV proxy to check whether the `CAUSAL_READ_RISKY` flag had been set.

[0]:

```
import fdb

fdb.api_version(720)

@fdb.transactional
def set_val(tr, value):
        tr.get(b'foo')        # Required to ensure the transaction
                              # fetches a read version from the GRV
                              # proxies
        tr.set(b'foo', value)

db = fdb.open()
db.options.set_always_confirm_proxy_valid(False)
set_value(db, b'bar')
```

The script can be run with `PYTHONPATH=./bindings/python/ python3 script.py`.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
