### PR TITLE
Disable tenants in downgrade tests to versions before 7.3

### DIFF
--- a/tests/restarting/to_7.1.0_until_7.2.0/ConfigureStorageMigrationTestRestart-1.toml
+++ b/tests/restarting/to_7.1.0_until_7.2.0/ConfigureStorageMigrationTestRestart-1.toml
@@ -4,8 +4,7 @@ maxTLogVersion=6
 disableHostname=true
 disableEncryption=true
 storageEngineExcludeTypes=[3, 4]
-allowDefaultTenant=false
-allowCreatingTenants=false
+tenantModes=['disabled']
 
 [[knobs]]
 # This can be removed once the lower bound of this downgrade test is a version that understands the new protocol

--- a/tests/restarting/to_7.1.0_until_7.2.0/CycleTestRestart-1.toml
+++ b/tests/restarting/to_7.1.0_until_7.2.0/CycleTestRestart-1.toml
@@ -4,8 +4,7 @@ maxTLogVersion = 6
 disableTss = true
 disableHostname = true
 disableEncryption = true
-allowDefaultTenant = false
-allowCreatingTenants = false
+tenantModes=['disabled']
 
 [[knobs]]
 # This can be removed once the lower bound of this downgrade test is a version that understands the new protocol

--- a/tests/restarting/to_7.2.0_until_7.3.0/ConfigureStorageMigrationTestRestart-1.toml
+++ b/tests/restarting/to_7.2.0_until_7.3.0/ConfigureStorageMigrationTestRestart-1.toml
@@ -4,8 +4,7 @@ maxTLogVersion=6
 disableHostname=true
 disableEncryption=true
 storageEngineExcludeTypes=[4]
-allowDefaultTenant=false
-allowCreatingTenants=false
+tenantModes=['disabled']
 
 [[knobs]]
 # This can be removed once the lower bound of this downgrade test is a version that understands the new protocol

--- a/tests/restarting/to_7.2.0_until_7.3.0/CycleTestRestart-1.toml
+++ b/tests/restarting/to_7.2.0_until_7.3.0/CycleTestRestart-1.toml
@@ -3,6 +3,7 @@ maxTLogVersion = 6
 disableTss = true
 disableHostname = true
 disableEncryption = true
+tenantModes=['disabled']
 
 [[knobs]]
 # This can be removed once the lower bound of this downgrade test is a version that understands the new protocol

--- a/tests/restarting/to_7.3.0/ConfigureStorageMigrationTestRestart-1.toml
+++ b/tests/restarting/to_7.3.0/ConfigureStorageMigrationTestRestart-1.toml
@@ -3,8 +3,7 @@ extraMachineCountDC = 2
 maxTLogVersion=6
 disableHostname=true
 storageEngineExcludeTypes=[4]
-allowDefaultTenant=false
-allowCreatingTenants=false
+tenantModes=['disabled']
 
 [[knobs]]
 # This can be removed once the lower bound of this downgrade test is a version that understands the new protocol


### PR DESCRIPTION
Some downgrade tests were already disabling tenants, but I changed them to use a different parameter to disable them.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
