### PR TITLE
adding wait parameter to blobbify api

### DIFF
--- a/bindings/c/fdb_c.cpp
+++ b/bindings/c/fdb_c.cpp
@@ -625,6 +625,19 @@ extern "C" DLLEXPORT FDBFuture* fdb_database_blobbify_range(FDBDatabase* db,
 	                        .extractPtr());
 }
 
+extern "C" DLLEXPORT FDBFuture* fdb_database_blobbify_range_v2(FDBDatabase* db,
+                                                               uint8_t const* begin_key_name,
+                                                               int begin_key_name_length,
+                                                               uint8_t const* end_key_name,
+                                                               int end_key_name_length,
+                                                               fdb_bool_t wait) {
+	return (FDBFuture*)(DB(db)
+	                        ->blobbifyRangeV2(KeyRangeRef(StringRef(begin_key_name, begin_key_name_length),
+	                                                      StringRef(end_key_name, end_key_name_length)),
+	                                          wait)
+	                        .extractPtr());
+}
+
 extern "C" DLLEXPORT FDBFuture* fdb_database_unblobbify_range(FDBDatabase* db,
                                                               uint8_t const* begin_key_name,
                                                               int begin_key_name_length,
@@ -704,6 +717,19 @@ extern "C" DLLEXPORT FDBFuture* fdb_tenant_blobbify_range(FDBTenant* tenant,
 	return (FDBFuture*)(TENANT(tenant)
 	                        ->blobbifyRange(KeyRangeRef(StringRef(begin_key_name, begin_key_name_length),
 	                                                    StringRef(end_key_name, end_key_name_length)))
+	                        .extractPtr());
+}
+
+extern "C" DLLEXPORT FDBFuture* fdb_tenant_blobbify_range_v2(FDBTenant* tenant,
+                                                             uint8_t const* begin_key_name,
+                                                             int begin_key_name_length,
+                                                             uint8_t const* end_key_name,
+                                                             int end_key_name_length,
+                                                             fdb_bool_t wait) {
+	return (FDBFuture*)(TENANT(tenant)
+	                        ->blobbifyRangeV2(KeyRangeRef(StringRef(begin_key_name, begin_key_name_length),
+	                                                      StringRef(end_key_name, end_key_name_length)),
+	                                          wait)
 	                        .extractPtr());
 }
 

--- a/bindings/c/fdb_c.cpp
+++ b/bindings/c/fdb_c.cpp
@@ -625,16 +625,14 @@ extern "C" DLLEXPORT FDBFuture* fdb_database_blobbify_range(FDBDatabase* db,
 	                        .extractPtr());
 }
 
-extern "C" DLLEXPORT FDBFuture* fdb_database_blobbify_range_v2(FDBDatabase* db,
-                                                               uint8_t const* begin_key_name,
-                                                               int begin_key_name_length,
-                                                               uint8_t const* end_key_name,
-                                                               int end_key_name_length,
-                                                               fdb_bool_t wait) {
+extern "C" DLLEXPORT FDBFuture* fdb_database_blobbify_range_blocking(FDBDatabase* db,
+                                                                     uint8_t const* begin_key_name,
+                                                                     int begin_key_name_length,
+                                                                     uint8_t const* end_key_name,
+                                                                     int end_key_name_length) {
 	return (FDBFuture*)(DB(db)
-	                        ->blobbifyRangeV2(KeyRangeRef(StringRef(begin_key_name, begin_key_name_length),
-	                                                      StringRef(end_key_name, end_key_name_length)),
-	                                          wait)
+	                        ->blobbifyRangeBlocking(KeyRangeRef(StringRef(begin_key_name, begin_key_name_length),
+	                                                            StringRef(end_key_name, end_key_name_length)))
 	                        .extractPtr());
 }
 
@@ -720,16 +718,14 @@ extern "C" DLLEXPORT FDBFuture* fdb_tenant_blobbify_range(FDBTenant* tenant,
 	                        .extractPtr());
 }
 
-extern "C" DLLEXPORT FDBFuture* fdb_tenant_blobbify_range_v2(FDBTenant* tenant,
-                                                             uint8_t const* begin_key_name,
-                                                             int begin_key_name_length,
-                                                             uint8_t const* end_key_name,
-                                                             int end_key_name_length,
-                                                             fdb_bool_t wait) {
+extern "C" DLLEXPORT FDBFuture* fdb_tenant_blobbify_range_blocking(FDBTenant* tenant,
+                                                                   uint8_t const* begin_key_name,
+                                                                   int begin_key_name_length,
+                                                                   uint8_t const* end_key_name,
+                                                                   int end_key_name_length) {
 	return (FDBFuture*)(TENANT(tenant)
-	                        ->blobbifyRangeV2(KeyRangeRef(StringRef(begin_key_name, begin_key_name_length),
-	                                                      StringRef(end_key_name, end_key_name_length)),
-	                                          wait)
+	                        ->blobbifyRangeBlocking(KeyRangeRef(StringRef(begin_key_name, begin_key_name_length),
+	                                                            StringRef(end_key_name, end_key_name_length)))
 	                        .extractPtr());
 }
 

--- a/bindings/c/foundationdb/fdb_c.h
+++ b/bindings/c/foundationdb/fdb_c.h
@@ -383,11 +383,19 @@ DLLEXPORT WARN_UNUSED_RESULT FDBFuture* fdb_database_wait_purge_granules_complet
                                                                                   uint8_t const* purge_key_name,
                                                                                   int purge_key_name_length);
 
+// FIXME: deprecated, clean up in release following this one!
 DLLEXPORT WARN_UNUSED_RESULT FDBFuture* fdb_database_blobbify_range(FDBDatabase* db,
                                                                     uint8_t const* begin_key_name,
                                                                     int begin_key_name_length,
                                                                     uint8_t const* end_key_name,
                                                                     int end_key_name_length);
+
+DLLEXPORT WARN_UNUSED_RESULT FDBFuture* fdb_database_blobbify_range_v2(FDBDatabase* db,
+                                                                       uint8_t const* begin_key_name,
+                                                                       int begin_key_name_length,
+                                                                       uint8_t const* end_key_name,
+                                                                       int end_key_name_length,
+                                                                       fdb_bool_t wait);
 
 DLLEXPORT WARN_UNUSED_RESULT FDBFuture* fdb_database_unblobbify_range(FDBDatabase* db,
                                                                       uint8_t const* begin_key_name,
@@ -426,11 +434,19 @@ DLLEXPORT WARN_UNUSED_RESULT FDBFuture* fdb_tenant_wait_purge_granules_complete(
                                                                                 uint8_t const* purge_key_name,
                                                                                 int purge_key_name_length);
 
+// FIXME: deprecated, clean up in release following this one!
 DLLEXPORT WARN_UNUSED_RESULT FDBFuture* fdb_tenant_blobbify_range(FDBTenant* tenant,
                                                                   uint8_t const* begin_key_name,
                                                                   int begin_key_name_length,
                                                                   uint8_t const* end_key_name,
                                                                   int end_key_name_length);
+
+DLLEXPORT WARN_UNUSED_RESULT FDBFuture* fdb_tenant_blobbify_range_v2(FDBTenant* tenant,
+                                                                     uint8_t const* begin_key_name,
+                                                                     int begin_key_name_length,
+                                                                     uint8_t const* end_key_name,
+                                                                     int end_key_name_length,
+                                                                     fdb_bool_t wait);
 
 DLLEXPORT WARN_UNUSED_RESULT FDBFuture* fdb_tenant_unblobbify_range(FDBTenant* tenant,
                                                                     uint8_t const* begin_key_name,

--- a/bindings/c/foundationdb/fdb_c.h
+++ b/bindings/c/foundationdb/fdb_c.h
@@ -383,7 +383,7 @@ DLLEXPORT WARN_UNUSED_RESULT FDBFuture* fdb_database_wait_purge_granules_complet
                                                                                   uint8_t const* purge_key_name,
                                                                                   int purge_key_name_length);
 
-// FIXME: deprecated, clean up in release following this one!
+/* FIXME: deprecated, clean up in release following this one! */
 DLLEXPORT WARN_UNUSED_RESULT FDBFuture* fdb_database_blobbify_range(FDBDatabase* db,
                                                                     uint8_t const* begin_key_name,
                                                                     int begin_key_name_length,
@@ -434,7 +434,7 @@ DLLEXPORT WARN_UNUSED_RESULT FDBFuture* fdb_tenant_wait_purge_granules_complete(
                                                                                 uint8_t const* purge_key_name,
                                                                                 int purge_key_name_length);
 
-// FIXME: deprecated, clean up in release following this one!
+/* FIXME: deprecated, clean up in release following this one! */
 DLLEXPORT WARN_UNUSED_RESULT FDBFuture* fdb_tenant_blobbify_range(FDBTenant* tenant,
                                                                   uint8_t const* begin_key_name,
                                                                   int begin_key_name_length,

--- a/bindings/c/foundationdb/fdb_c.h
+++ b/bindings/c/foundationdb/fdb_c.h
@@ -383,7 +383,6 @@ DLLEXPORT WARN_UNUSED_RESULT FDBFuture* fdb_database_wait_purge_granules_complet
                                                                                   uint8_t const* purge_key_name,
                                                                                   int purge_key_name_length);
 
-/* FIXME: deprecated, clean up in release following this one! */
 DLLEXPORT WARN_UNUSED_RESULT FDBFuture* fdb_database_blobbify_range(FDBDatabase* db,
                                                                     uint8_t const* begin_key_name,
                                                                     int begin_key_name_length,
@@ -433,7 +432,6 @@ DLLEXPORT WARN_UNUSED_RESULT FDBFuture* fdb_tenant_wait_purge_granules_complete(
                                                                                 uint8_t const* purge_key_name,
                                                                                 int purge_key_name_length);
 
-/* FIXME: deprecated, clean up in release following this one! */
 DLLEXPORT WARN_UNUSED_RESULT FDBFuture* fdb_tenant_blobbify_range(FDBTenant* tenant,
                                                                   uint8_t const* begin_key_name,
                                                                   int begin_key_name_length,

--- a/bindings/c/foundationdb/fdb_c.h
+++ b/bindings/c/foundationdb/fdb_c.h
@@ -390,12 +390,11 @@ DLLEXPORT WARN_UNUSED_RESULT FDBFuture* fdb_database_blobbify_range(FDBDatabase*
                                                                     uint8_t const* end_key_name,
                                                                     int end_key_name_length);
 
-DLLEXPORT WARN_UNUSED_RESULT FDBFuture* fdb_database_blobbify_range_v2(FDBDatabase* db,
-                                                                       uint8_t const* begin_key_name,
-                                                                       int begin_key_name_length,
-                                                                       uint8_t const* end_key_name,
-                                                                       int end_key_name_length,
-                                                                       fdb_bool_t wait);
+DLLEXPORT WARN_UNUSED_RESULT FDBFuture* fdb_database_blobbify_range_blocking(FDBDatabase* db,
+                                                                             uint8_t const* begin_key_name,
+                                                                             int begin_key_name_length,
+                                                                             uint8_t const* end_key_name,
+                                                                             int end_key_name_length);
 
 DLLEXPORT WARN_UNUSED_RESULT FDBFuture* fdb_database_unblobbify_range(FDBDatabase* db,
                                                                       uint8_t const* begin_key_name,
@@ -441,12 +440,11 @@ DLLEXPORT WARN_UNUSED_RESULT FDBFuture* fdb_tenant_blobbify_range(FDBTenant* ten
                                                                   uint8_t const* end_key_name,
                                                                   int end_key_name_length);
 
-DLLEXPORT WARN_UNUSED_RESULT FDBFuture* fdb_tenant_blobbify_range_v2(FDBTenant* tenant,
-                                                                     uint8_t const* begin_key_name,
-                                                                     int begin_key_name_length,
-                                                                     uint8_t const* end_key_name,
-                                                                     int end_key_name_length,
-                                                                     fdb_bool_t wait);
+DLLEXPORT WARN_UNUSED_RESULT FDBFuture* fdb_tenant_blobbify_range_blocking(FDBTenant* tenant,
+                                                                           uint8_t const* begin_key_name,
+                                                                           int begin_key_name_length,
+                                                                           uint8_t const* end_key_name,
+                                                                           int end_key_name_length);
 
 DLLEXPORT WARN_UNUSED_RESULT FDBFuture* fdb_tenant_unblobbify_range(FDBTenant* tenant,
                                                                     uint8_t const* begin_key_name,

--- a/bindings/c/test/apitester/TesterApiWorkload.cpp
+++ b/bindings/c/test/apitester/TesterApiWorkload.cpp
@@ -388,7 +388,7 @@ void ApiWorkload::blobbifyTenant(std::optional<int> tenantId,
 		    info(fmt::format("setup: blobbifying {}: [\\x00 - \\xff)\n", debugTenantStr(tenantId)));
 
 		    // wait for blobbification before returning
-		    fdb::Future f = ctx->dbOps()->blobbifyRange(begin, end, true).eraseType();
+		    fdb::Future f = ctx->dbOps()->blobbifyRangeBlocking(begin, end).eraseType();
 		    ctx->continueAfter(f, [ctx, f]() {
 			    bool success = f.get<fdb::future_var::Bool>();
 			    ASSERT(success);

--- a/bindings/c/test/apitester/TesterApiWorkload.cpp
+++ b/bindings/c/test/apitester/TesterApiWorkload.cpp
@@ -380,7 +380,6 @@ void ApiWorkload::setupBlobGranules(TTaskFct cont) {
 void ApiWorkload::blobbifyTenant(std::optional<int> tenantId,
                                  std::shared_ptr<std::atomic<int>> blobbifiedCount,
                                  TTaskFct cont) {
-	auto retBlobbifyRange = std::make_shared<bool>(false);
 	execOperation(
 	    [=](auto ctx) {
 		    fdb::Key begin(1, '\x00');
@@ -388,48 +387,17 @@ void ApiWorkload::blobbifyTenant(std::optional<int> tenantId,
 
 		    info(fmt::format("setup: blobbifying {}: [\\x00 - \\xff)\n", debugTenantStr(tenantId)));
 
-		    fdb::Future f = ctx->dbOps()->blobbifyRange(begin, end).eraseType();
-		    ctx->continueAfter(f, [ctx, retBlobbifyRange, f]() {
-			    *retBlobbifyRange = f.get<fdb::future_var::Bool>();
+		    // wait for blobbification before returning
+		    fdb::Future f = ctx->dbOps()->blobbifyRange(begin, end, true).eraseType();
+		    ctx->continueAfter(f, [ctx, f]() {
+			    bool success = f.get<fdb::future_var::Bool>();
+			    ASSERT(success);
 			    ctx->done();
 		    });
 	    },
 	    [=]() {
-		    if (!*retBlobbifyRange) {
-			    schedule([=]() { blobbifyTenant(tenantId, blobbifiedCount, cont); });
-		    } else {
-			    schedule([=]() { verifyTenant(tenantId, blobbifiedCount, cont); });
-		    }
-	    },
-	    /*tenant=*/getTenant(tenantId),
-	    /* failOnError = */ false);
-}
-
-void ApiWorkload::verifyTenant(std::optional<int> tenantId,
-                               std::shared_ptr<std::atomic<int>> blobbifiedCount,
-                               TTaskFct cont) {
-	auto retVerifyVersion = std::make_shared<int64_t>(-1);
-
-	execOperation(
-	    [=](auto ctx) {
-		    fdb::Key begin(1, '\x00');
-		    fdb::Key end(1, '\xff');
-
-		    info(fmt::format("setup: verifying {}: [\\x00 - \\xff)\n", debugTenantStr(tenantId)));
-
-		    fdb::Future f = ctx->dbOps()->verifyBlobRange(begin, end, /*latest_version*/ -2).eraseType();
-		    ctx->continueAfter(f, [ctx, retVerifyVersion, f]() {
-			    *retVerifyVersion = f.get<fdb::future_var::Int64>();
-			    ctx->done();
-		    });
-	    },
-	    [=]() {
-		    if (*retVerifyVersion == -1) {
-			    schedule([=]() { verifyTenant(tenantId, blobbifiedCount, cont); });
-		    } else {
-			    if (blobbifiedCount->fetch_sub(1) == 1) {
-				    schedule(cont);
-			    }
+		    if (blobbifiedCount->fetch_sub(1) == 1) {
+			    schedule(cont);
 		    }
 	    },
 	    /*tenant=*/getTenant(tenantId),

--- a/bindings/c/test/apitester/TesterApiWorkload.h
+++ b/bindings/c/test/apitester/TesterApiWorkload.h
@@ -135,7 +135,6 @@ protected:
 	// Generic BlobGranules setup.
 	void setupBlobGranules(TTaskFct cont);
 	void blobbifyTenant(std::optional<int> tenantId, std::shared_ptr<std::atomic<int>> blobbifiedCount, TTaskFct cont);
-	void verifyTenant(std::optional<int> tenantId, std::shared_ptr<std::atomic<int>> blobbifiedCount, TTaskFct cont);
 
 private:
 	void populateDataTx(TTaskFct cont, std::optional<int> tenantId);

--- a/bindings/c/test/apitester/TesterBlobGranuleErrorsWorkload.cpp
+++ b/bindings/c/test/apitester/TesterBlobGranuleErrorsWorkload.cpp
@@ -152,7 +152,7 @@ private:
 		auto success = std::make_shared<bool>(false);
 		execOperation(
 		    [begin, end, blobbify, success](auto ctx) {
-			    fdb::Future f = blobbify ? ctx->db().blobbifyRange(begin, end).eraseType()
+			    fdb::Future f = blobbify ? ctx->db().blobbifyRange(begin, end, false).eraseType()
 			                             : ctx->db().unblobbifyRange(begin, end).eraseType();
 			    ctx->continueAfter(
 			        f,
@@ -232,7 +232,7 @@ private:
 		}
 		execOperation(
 		    [begin, end](auto ctx) {
-			    fdb::Future f = ctx->db().blobbifyRange(begin, end).eraseType();
+			    fdb::Future f = ctx->db().blobbifyRange(begin, end, false).eraseType();
 			    ctx->done();
 		    },
 		    [this, cont]() { schedule(cont); });

--- a/bindings/c/test/apitester/TesterBlobGranuleErrorsWorkload.cpp
+++ b/bindings/c/test/apitester/TesterBlobGranuleErrorsWorkload.cpp
@@ -152,7 +152,7 @@ private:
 		auto success = std::make_shared<bool>(false);
 		execOperation(
 		    [begin, end, blobbify, success](auto ctx) {
-			    fdb::Future f = blobbify ? ctx->db().blobbifyRange(begin, end, false).eraseType()
+			    fdb::Future f = blobbify ? ctx->db().blobbifyRange(begin, end).eraseType()
 			                             : ctx->db().unblobbifyRange(begin, end).eraseType();
 			    ctx->continueAfter(
 			        f,
@@ -232,7 +232,12 @@ private:
 		}
 		execOperation(
 		    [begin, end](auto ctx) {
-			    fdb::Future f = ctx->db().blobbifyRange(begin, end, Random::get().randomBool(0.5)).eraseType();
+			    fdb::Future f;
+			    if (Random::get().randomBool(0.5)) {
+				    f = ctx->db().blobbifyRange(begin, end).eraseType();
+			    } else {
+				    f = ctx->db().blobbifyRangeBlocking(begin, end).eraseType();
+			    }
 			    ctx->done();
 		    },
 		    [this, cont]() { schedule(cont); });

--- a/bindings/c/test/apitester/TesterBlobGranuleErrorsWorkload.cpp
+++ b/bindings/c/test/apitester/TesterBlobGranuleErrorsWorkload.cpp
@@ -232,7 +232,7 @@ private:
 		}
 		execOperation(
 		    [begin, end](auto ctx) {
-			    fdb::Future f = ctx->db().blobbifyRange(begin, end, false).eraseType();
+			    fdb::Future f = ctx->db().blobbifyRange(begin, end, Random::get().randomBool(0.5)).eraseType();
 			    ctx->done();
 		    },
 		    [this, cont]() { schedule(cont); });

--- a/bindings/c/test/fdb_api.hpp
+++ b/bindings/c/test/fdb_api.hpp
@@ -814,7 +814,7 @@ public:
 
 	virtual Transaction createTransaction() = 0;
 
-	virtual TypedFuture<future_var::Bool> blobbifyRange(KeyRef begin, KeyRef end) = 0;
+	virtual TypedFuture<future_var::Bool> blobbifyRange(KeyRef begin, KeyRef end, bool wait) = 0;
 	virtual TypedFuture<future_var::Bool> unblobbifyRange(KeyRef begin, KeyRef end) = 0;
 	virtual TypedFuture<future_var::KeyRangeRefArray> listBlobbifiedRanges(KeyRef begin,
 	                                                                       KeyRef end,
@@ -881,10 +881,10 @@ public:
 		return Transaction(tx_native);
 	}
 
-	TypedFuture<future_var::Bool> blobbifyRange(KeyRef begin, KeyRef end) override {
+	TypedFuture<future_var::Bool> blobbifyRange(KeyRef begin, KeyRef end, bool wait) override {
 		if (!tenant)
 			throw std::runtime_error("blobbifyRange() from null tenant");
-		return native::fdb_tenant_blobbify_range(tenant.get(), begin.data(), intSize(begin), end.data(), intSize(end));
+		return native::fdb_tenant_blobbify_range_v2(tenant.get(), begin.data(), intSize(begin), end.data(), intSize(end), wait);
 	}
 
 	TypedFuture<future_var::Bool> unblobbifyRange(KeyRef begin, KeyRef end) override {
@@ -1012,10 +1012,10 @@ public:
 		    db.get(), begin.data(), intSize(begin), end.data(), intSize(end), version);
 	}
 
-	TypedFuture<future_var::Bool> blobbifyRange(KeyRef begin, KeyRef end) override {
+	TypedFuture<future_var::Bool> blobbifyRange(KeyRef begin, KeyRef end, bool wait) override {
 		if (!db)
 			throw std::runtime_error("blobbifyRange from null database");
-		return native::fdb_database_blobbify_range(db.get(), begin.data(), intSize(begin), end.data(), intSize(end));
+		return native::fdb_database_blobbify_range_v2(db.get(), begin.data(), intSize(begin), end.data(), intSize(end), wait);
 	}
 
 	TypedFuture<future_var::Bool> unblobbifyRange(KeyRef begin, KeyRef end) override {

--- a/bindings/c/test/fdb_api.hpp
+++ b/bindings/c/test/fdb_api.hpp
@@ -814,7 +814,8 @@ public:
 
 	virtual Transaction createTransaction() = 0;
 
-	virtual TypedFuture<future_var::Bool> blobbifyRange(KeyRef begin, KeyRef end, bool wait) = 0;
+	virtual TypedFuture<future_var::Bool> blobbifyRange(KeyRef begin, KeyRef end) = 0;
+	virtual TypedFuture<future_var::Bool> blobbifyRangeBlocking(KeyRef begin, KeyRef end) = 0;
 	virtual TypedFuture<future_var::Bool> unblobbifyRange(KeyRef begin, KeyRef end) = 0;
 	virtual TypedFuture<future_var::KeyRangeRefArray> listBlobbifiedRanges(KeyRef begin,
 	                                                                       KeyRef end,
@@ -881,11 +882,18 @@ public:
 		return Transaction(tx_native);
 	}
 
-	TypedFuture<future_var::Bool> blobbifyRange(KeyRef begin, KeyRef end, bool wait) override {
+	TypedFuture<future_var::Bool> blobbifyRange(KeyRef begin, KeyRef end) override {
 		if (!tenant)
 			throw std::runtime_error("blobbifyRange() from null tenant");
-		return native::fdb_tenant_blobbify_range_v2(
-		    tenant.get(), begin.data(), intSize(begin), end.data(), intSize(end), wait);
+		return native::fdb_tenant_blobbify_range(
+		    tenant.get(), begin.data(), intSize(begin), end.data(), intSize(end));
+	}
+
+	TypedFuture<future_var::Bool> blobbifyRangeBlocking(KeyRef begin, KeyRef end) override {
+		if (!tenant)
+			throw std::runtime_error("blobbifyRangeBlocking() from null tenant");
+		return native::fdb_tenant_blobbify_range_blocking(
+		    tenant.get(), begin.data(), intSize(begin), end.data(), intSize(end));
 	}
 
 	TypedFuture<future_var::Bool> unblobbifyRange(KeyRef begin, KeyRef end) override {
@@ -1013,11 +1021,19 @@ public:
 		    db.get(), begin.data(), intSize(begin), end.data(), intSize(end), version);
 	}
 
-	TypedFuture<future_var::Bool> blobbifyRange(KeyRef begin, KeyRef end, bool wait) override {
+	TypedFuture<future_var::Bool> blobbifyRange(KeyRef begin, KeyRef end) override {
 		if (!db)
 			throw std::runtime_error("blobbifyRange from null database");
-		return native::fdb_database_blobbify_range_v2(
-		    db.get(), begin.data(), intSize(begin), end.data(), intSize(end), wait);
+		return native::fdb_database_blobbify_range(
+		    db.get(), begin.data(), intSize(begin), end.data(), intSize(end));
+	}
+
+
+	TypedFuture<future_var::Bool> blobbifyRangeBlocking(KeyRef begin, KeyRef end) override {
+		if (!db)
+			throw std::runtime_error("blobbifyRangeBlocking from null database");
+		return native::fdb_database_blobbify_range_blocking(
+		    db.get(), begin.data(), intSize(begin), end.data(), intSize(end));
 	}
 
 	TypedFuture<future_var::Bool> unblobbifyRange(KeyRef begin, KeyRef end) override {

--- a/bindings/c/test/fdb_api.hpp
+++ b/bindings/c/test/fdb_api.hpp
@@ -885,8 +885,7 @@ public:
 	TypedFuture<future_var::Bool> blobbifyRange(KeyRef begin, KeyRef end) override {
 		if (!tenant)
 			throw std::runtime_error("blobbifyRange() from null tenant");
-		return native::fdb_tenant_blobbify_range(
-		    tenant.get(), begin.data(), intSize(begin), end.data(), intSize(end));
+		return native::fdb_tenant_blobbify_range(tenant.get(), begin.data(), intSize(begin), end.data(), intSize(end));
 	}
 
 	TypedFuture<future_var::Bool> blobbifyRangeBlocking(KeyRef begin, KeyRef end) override {
@@ -1024,10 +1023,8 @@ public:
 	TypedFuture<future_var::Bool> blobbifyRange(KeyRef begin, KeyRef end) override {
 		if (!db)
 			throw std::runtime_error("blobbifyRange from null database");
-		return native::fdb_database_blobbify_range(
-		    db.get(), begin.data(), intSize(begin), end.data(), intSize(end));
+		return native::fdb_database_blobbify_range(db.get(), begin.data(), intSize(begin), end.data(), intSize(end));
 	}
-
 
 	TypedFuture<future_var::Bool> blobbifyRangeBlocking(KeyRef begin, KeyRef end) override {
 		if (!db)

--- a/bindings/c/test/fdb_api.hpp
+++ b/bindings/c/test/fdb_api.hpp
@@ -884,7 +884,8 @@ public:
 	TypedFuture<future_var::Bool> blobbifyRange(KeyRef begin, KeyRef end, bool wait) override {
 		if (!tenant)
 			throw std::runtime_error("blobbifyRange() from null tenant");
-		return native::fdb_tenant_blobbify_range_v2(tenant.get(), begin.data(), intSize(begin), end.data(), intSize(end), wait);
+		return native::fdb_tenant_blobbify_range_v2(
+		    tenant.get(), begin.data(), intSize(begin), end.data(), intSize(end), wait);
 	}
 
 	TypedFuture<future_var::Bool> unblobbifyRange(KeyRef begin, KeyRef end) override {
@@ -1015,7 +1016,8 @@ public:
 	TypedFuture<future_var::Bool> blobbifyRange(KeyRef begin, KeyRef end, bool wait) override {
 		if (!db)
 			throw std::runtime_error("blobbifyRange from null database");
-		return native::fdb_database_blobbify_range_v2(db.get(), begin.data(), intSize(begin), end.data(), intSize(end), wait);
+		return native::fdb_database_blobbify_range_v2(
+		    db.get(), begin.data(), intSize(begin), end.data(), intSize(end), wait);
 	}
 
 	TypedFuture<future_var::Bool> unblobbifyRange(KeyRef begin, KeyRef end) override {

--- a/bindings/c/test/mako/admin_server.cpp
+++ b/bindings/c/test/mako/admin_server.cpp
@@ -186,7 +186,7 @@ boost::optional<std::string> AdminServer::createTenant(fdb::Database db, int id_
 			while (true) {
 				auto tenant = db.openTenant(fdb::toBytesRef(getTenantNameByIndex(id)));
 				std::string range_end = "\xff";
-				auto blobbify_future = tenant.blobbifyRange(fdb::BytesRef(), fdb::toBytesRef(range_end));
+				auto blobbify_future = tenant.blobbifyRange(fdb::BytesRef(), fdb::toBytesRef(range_end), false);
 				const auto rc = waitAndHandleError(tx, blobbify_future);
 				if (rc == FutureRC::OK) {
 					if (!blobbify_future.get()) {

--- a/bindings/c/test/mako/admin_server.cpp
+++ b/bindings/c/test/mako/admin_server.cpp
@@ -186,7 +186,7 @@ boost::optional<std::string> AdminServer::createTenant(fdb::Database db, int id_
 			while (true) {
 				auto tenant = db.openTenant(fdb::toBytesRef(getTenantNameByIndex(id)));
 				std::string range_end = "\xff";
-				auto blobbify_future = tenant.blobbifyRange(fdb::BytesRef(), fdb::toBytesRef(range_end), false);
+				auto blobbify_future = tenant.blobbifyRange(fdb::BytesRef(), fdb::toBytesRef(range_end));
 				const auto rc = waitAndHandleError(tx, blobbify_future);
 				if (rc == FutureRC::OK) {
 					if (!blobbify_future.get()) {

--- a/bindings/java/fdbJNI.cpp
+++ b/bindings/java/fdbJNI.cpp
@@ -912,8 +912,7 @@ JNIEXPORT jlong JNICALL Java_com_apple_foundationdb_FDBDatabase_Database_1blobbi
                                                                                         jobject,
                                                                                         jlong dbPtr,
                                                                                         jbyteArray beginKeyBytes,
-                                                                                        jbyteArray endKeyBytes,
-                                                                                        jboolean wait) {
+                                                                                        jbyteArray endKeyBytes) {
 	if (!dbPtr || !beginKeyBytes || !endKeyBytes) {
 		throwParamNotNull(jenv);
 		return 0;
@@ -936,8 +935,43 @@ JNIEXPORT jlong JNICALL Java_com_apple_foundationdb_FDBDatabase_Database_1blobbi
 		return 0;
 	}
 
-	FDBFuture* f = fdb_database_blobbify_range_v2(
-	    database, beginKeyArr, jenv->GetArrayLength(beginKeyBytes), endKeyArr, jenv->GetArrayLength(endKeyBytes), wait);
+	FDBFuture* f = fdb_database_blobbify_range(
+	    database, beginKeyArr, jenv->GetArrayLength(beginKeyBytes), endKeyArr, jenv->GetArrayLength(endKeyBytes));
+	jenv->ReleaseByteArrayElements(beginKeyBytes, (jbyte*)beginKeyArr, JNI_ABORT);
+	jenv->ReleaseByteArrayElements(endKeyBytes, (jbyte*)endKeyArr, JNI_ABORT);
+	return (jlong)f;
+}
+
+JNIEXPORT jlong JNICALL
+Java_com_apple_foundationdb_FDBDatabase_Database_1blobbifyRangeBlocking(JNIEnv* jenv,
+                                                                        jobject,
+                                                                        jlong dbPtr,
+                                                                        jbyteArray beginKeyBytes,
+                                                                        jbyteArray endKeyBytes) {
+	if (!dbPtr || !beginKeyBytes || !endKeyBytes) {
+		throwParamNotNull(jenv);
+		return 0;
+	}
+
+	FDBDatabase* database = (FDBDatabase*)dbPtr;
+
+	uint8_t* beginKeyArr = (uint8_t*)jenv->GetByteArrayElements(beginKeyBytes, JNI_NULL);
+	if (!beginKeyArr) {
+		if (!jenv->ExceptionOccurred())
+			throwRuntimeEx(jenv, "Error getting handle to native resources");
+		return 0;
+	}
+
+	uint8_t* endKeyArr = (uint8_t*)jenv->GetByteArrayElements(endKeyBytes, JNI_NULL);
+	if (!endKeyArr) {
+		jenv->ReleaseByteArrayElements(beginKeyBytes, (jbyte*)beginKeyArr, JNI_ABORT);
+		if (!jenv->ExceptionOccurred())
+			throwRuntimeEx(jenv, "Error getting handle to native resources");
+		return 0;
+	}
+
+	FDBFuture* f = fdb_database_blobbify_range_blocking(
+	    database, beginKeyArr, jenv->GetArrayLength(beginKeyBytes), endKeyArr, jenv->GetArrayLength(endKeyBytes));
 	jenv->ReleaseByteArrayElements(beginKeyBytes, (jbyte*)beginKeyArr, JNI_ABORT);
 	jenv->ReleaseByteArrayElements(endKeyBytes, (jbyte*)endKeyArr, JNI_ABORT);
 	return (jlong)f;
@@ -1170,8 +1204,7 @@ JNIEXPORT jlong JNICALL Java_com_apple_foundationdb_FDBTenant_Tenant_1blobbifyRa
                                                                                     jobject,
                                                                                     jlong tPtr,
                                                                                     jbyteArray beginKeyBytes,
-                                                                                    jbyteArray endKeyBytes,
-                                                                                    jboolean wait) {
+                                                                                    jbyteArray endKeyBytes) {
 	if (!tPtr || !beginKeyBytes || !endKeyBytes) {
 		throwParamNotNull(jenv);
 		return 0;
@@ -1193,8 +1226,41 @@ JNIEXPORT jlong JNICALL Java_com_apple_foundationdb_FDBTenant_Tenant_1blobbifyRa
 		return 0;
 	}
 
-	FDBFuture* f = fdb_tenant_blobbify_range_v2(
-	    tenant, beginKeyArr, jenv->GetArrayLength(beginKeyBytes), endKeyArr, jenv->GetArrayLength(endKeyBytes), wait);
+	FDBFuture* f = fdb_tenant_blobbify_range(
+	    tenant, beginKeyArr, jenv->GetArrayLength(beginKeyBytes), endKeyArr, jenv->GetArrayLength(endKeyBytes));
+	jenv->ReleaseByteArrayElements(beginKeyBytes, (jbyte*)beginKeyArr, JNI_ABORT);
+	jenv->ReleaseByteArrayElements(endKeyBytes, (jbyte*)endKeyArr, JNI_ABORT);
+	return (jlong)f;
+}
+
+JNIEXPORT jlong JNICALL Java_com_apple_foundationdb_FDBTenant_Tenant_1blobbifyRangeBlocking(JNIEnv* jenv,
+                                                                                            jobject,
+                                                                                            jlong tPtr,
+                                                                                            jbyteArray beginKeyBytes,
+                                                                                            jbyteArray endKeyBytes) {
+	if (!tPtr || !beginKeyBytes || !endKeyBytes) {
+		throwParamNotNull(jenv);
+		return 0;
+	}
+	FDBTenant* tenant = (FDBTenant*)tPtr;
+
+	uint8_t* beginKeyArr = (uint8_t*)jenv->GetByteArrayElements(beginKeyBytes, JNI_NULL);
+	if (!beginKeyArr) {
+		if (!jenv->ExceptionOccurred())
+			throwRuntimeEx(jenv, "Error getting handle to native resources");
+		return 0;
+	}
+
+	uint8_t* endKeyArr = (uint8_t*)jenv->GetByteArrayElements(endKeyBytes, JNI_NULL);
+	if (!endKeyArr) {
+		jenv->ReleaseByteArrayElements(beginKeyBytes, (jbyte*)beginKeyArr, JNI_ABORT);
+		if (!jenv->ExceptionOccurred())
+			throwRuntimeEx(jenv, "Error getting handle to native resources");
+		return 0;
+	}
+
+	FDBFuture* f = fdb_tenant_blobbify_range_blocking(
+	    tenant, beginKeyArr, jenv->GetArrayLength(beginKeyBytes), endKeyArr, jenv->GetArrayLength(endKeyBytes));
 	jenv->ReleaseByteArrayElements(beginKeyBytes, (jbyte*)beginKeyArr, JNI_ABORT);
 	jenv->ReleaseByteArrayElements(endKeyBytes, (jbyte*)endKeyArr, JNI_ABORT);
 	return (jlong)f;

--- a/bindings/java/fdbJNI.cpp
+++ b/bindings/java/fdbJNI.cpp
@@ -912,7 +912,8 @@ JNIEXPORT jlong JNICALL Java_com_apple_foundationdb_FDBDatabase_Database_1blobbi
                                                                                         jobject,
                                                                                         jlong dbPtr,
                                                                                         jbyteArray beginKeyBytes,
-                                                                                        jbyteArray endKeyBytes) {
+                                                                                        jbyteArray endKeyBytes,
+                                                                                        jboolean wait) {
 	if (!dbPtr || !beginKeyBytes || !endKeyBytes) {
 		throwParamNotNull(jenv);
 		return 0;
@@ -935,8 +936,8 @@ JNIEXPORT jlong JNICALL Java_com_apple_foundationdb_FDBDatabase_Database_1blobbi
 		return 0;
 	}
 
-	FDBFuture* f = fdb_database_blobbify_range(
-	    database, beginKeyArr, jenv->GetArrayLength(beginKeyBytes), endKeyArr, jenv->GetArrayLength(endKeyBytes));
+	FDBFuture* f = fdb_database_blobbify_range_v2(
+	    database, beginKeyArr, jenv->GetArrayLength(beginKeyBytes), endKeyArr, jenv->GetArrayLength(endKeyBytes), wait);
 	jenv->ReleaseByteArrayElements(beginKeyBytes, (jbyte*)beginKeyArr, JNI_ABORT);
 	jenv->ReleaseByteArrayElements(endKeyBytes, (jbyte*)endKeyArr, JNI_ABORT);
 	return (jlong)f;
@@ -1169,7 +1170,8 @@ JNIEXPORT jlong JNICALL Java_com_apple_foundationdb_FDBTenant_Tenant_1blobbifyRa
                                                                                     jobject,
                                                                                     jlong tPtr,
                                                                                     jbyteArray beginKeyBytes,
-                                                                                    jbyteArray endKeyBytes) {
+                                                                                    jbyteArray endKeyBytes,
+                                                                                    jboolean wait) {
 	if (!tPtr || !beginKeyBytes || !endKeyBytes) {
 		throwParamNotNull(jenv);
 		return 0;
@@ -1191,8 +1193,8 @@ JNIEXPORT jlong JNICALL Java_com_apple_foundationdb_FDBTenant_Tenant_1blobbifyRa
 		return 0;
 	}
 
-	FDBFuture* f = fdb_tenant_blobbify_range(
-	    tenant, beginKeyArr, jenv->GetArrayLength(beginKeyBytes), endKeyArr, jenv->GetArrayLength(endKeyBytes));
+	FDBFuture* f = fdb_tenant_blobbify_range_v2(
+	    tenant, beginKeyArr, jenv->GetArrayLength(beginKeyBytes), endKeyArr, jenv->GetArrayLength(endKeyBytes), wait);
 	jenv->ReleaseByteArrayElements(beginKeyBytes, (jbyte*)beginKeyArr, JNI_ABORT);
 	jenv->ReleaseByteArrayElements(endKeyBytes, (jbyte*)endKeyArr, JNI_ABORT);
 	return (jlong)f;

--- a/bindings/java/src/integration/com/apple/foundationdb/BlobGranuleIntegrationTest.java
+++ b/bindings/java/src/integration/com/apple/foundationdb/BlobGranuleIntegrationTest.java
@@ -50,20 +50,6 @@ class BlobGranuleIntegrationTest {
         }
     }
 
-    void waitForVerify(Database db, Range blobRange) throws InterruptedException {
-        System.out.println("Verifying");
-        while (true) {
-            Long verifyVersion = db.verifyBlobRange(blobRange.begin, blobRange.end).join();
-            if (verifyVersion != null && verifyVersion > 0) {
-                System.out.println("Verify succeeded @ " + verifyVersion);
-                return;
-            } else {
-                System.out.println("Verify failed, sleeping");
-                Thread.sleep(100);
-            }
-        }
-    }
-
     @Test
     void blobManagementFunctionsTest() throws Exception {
         /*
@@ -79,9 +65,12 @@ class BlobGranuleIntegrationTest {
 
         Range blobRange = Range.startsWith(key);
         try (Database db = fdb.open()) {
-            db.blobbifyRange(blobRange.begin, blobRange.end).join();
+            boolean blobbifySuccess = db.blobbifyRange(blobRange.begin, blobRange.end, true).join();
+            Assertions.assertTrue(blobbifySuccess);
 
-            waitForVerify(db, blobRange);
+            Long verifyVersion = db.verifyBlobRange(blobRange.begin, blobRange.end).join();
+
+            Assertions.assertTrue(verifyVersion >= 0);
 
             // list blob ranges
             KeyRangeArrayResult blobRanges = db.listBlobbifiedRanges(blobRange.begin, blobRange.end, 2).join();
@@ -94,18 +83,21 @@ class BlobGranuleIntegrationTest {
             db.waitPurgeGranulesComplete(purgeKey).join();
 
             // verify again
-            waitForVerify(db, blobRange);
+            Long verifyVersionAfterPurge = db.verifyBlobRange(blobRange.begin, blobRange.end).join();
+            Assertions.assertTrue(verifyVersionAfterPurge >= 0);
+            Assertions.assertTrue(verifyVersionAfterPurge >= verifyVersion);
 
             // force purge/wait
             byte[] forcePurgeKey = db.purgeBlobGranules(blobRange.begin, blobRange.end, -2, true).join();
             db.waitPurgeGranulesComplete(forcePurgeKey).join();
 
             // check verify fails
-            Long verifyVersion = db.verifyBlobRange(blobRange.begin, blobRange.end).join();
-            Assertions.assertEquals(-1, verifyVersion);
+            Long verifyVersionLast = db.verifyBlobRange(blobRange.begin, blobRange.end).join();
+            Assertions.assertEquals(-1, verifyVersionLast);
 
             // unblobbify
-            db.unblobbifyRange(blobRange.begin, blobRange.end).join();
+            boolean unblobbifySuccess = db.unblobbifyRange(blobRange.begin, blobRange.end).join();
+            Assertions.assertTrue(unblobbifySuccess);
 
             System.out.println("Blob granule management tests complete!");
         }

--- a/bindings/java/src/integration/com/apple/foundationdb/BlobGranuleIntegrationTest.java
+++ b/bindings/java/src/integration/com/apple/foundationdb/BlobGranuleIntegrationTest.java
@@ -65,7 +65,7 @@ class BlobGranuleIntegrationTest {
 
         Range blobRange = Range.startsWith(key);
         try (Database db = fdb.open()) {
-            boolean blobbifySuccess = db.blobbifyRange(blobRange.begin, blobRange.end, true).join();
+            boolean blobbifySuccess = db.blobbifyRangeBlocking(blobRange.begin, blobRange.end).join();
             Assertions.assertTrue(blobbifySuccess);
 
             Long verifyVersion = db.verifyBlobRange(blobRange.begin, blobRange.end).join();

--- a/bindings/java/src/main/com/apple/foundationdb/Database.java
+++ b/bindings/java/src/main/com/apple/foundationdb/Database.java
@@ -231,7 +231,6 @@ public interface Database extends AutoCloseable, TransactionContext {
 
 	 * @return if the recording of the range was successful
 	 */
-	@Deprecated
 	default CompletableFuture<Boolean> blobbifyRange(byte[] beginKey, byte[] endKey) {
 		return blobbifyRange(beginKey, endKey, getExecutor());
 	}
@@ -245,10 +244,7 @@ public interface Database extends AutoCloseable, TransactionContext {
 
 	 * @return if the recording of the range was successful
 	 */
-	@Deprecated
-	default CompletableFuture<Boolean> blobbifyRange(byte[] beginKey, byte[] endKey, Executor e) {
-		return blobbifyRange(beginKey, endKey, false, e);
-	}
+	CompletableFuture<Boolean> blobbifyRange(byte[] beginKey, byte[] endKey, Executor e);
 
 	/**
 	 * Runs {@link #blobbifyRange(byte[] beginKey, byte[] endKey, boolean wait)} on the default executor.
@@ -259,8 +255,8 @@ public interface Database extends AutoCloseable, TransactionContext {
 
 	 * @return if the recording of the range was successful
 	 */
-	default CompletableFuture<Boolean> blobbifyRange(byte[] beginKey, byte[] endKey, boolean wait) {
-		return blobbifyRange(beginKey, endKey, wait, getExecutor());
+	default CompletableFuture<Boolean> blobbifyRangeBlocking(byte[] beginKey, byte[] endKey) {
+		return blobbifyRangeBlocking(beginKey, endKey, getExecutor());
 	}
 
 	/**
@@ -273,7 +269,7 @@ public interface Database extends AutoCloseable, TransactionContext {
 
 	 * @return if the recording of the range was successful
 	 */
-	CompletableFuture<Boolean> blobbifyRange(byte[] beginKey, byte[] endKey, boolean wait, Executor e);
+	CompletableFuture<Boolean> blobbifyRangeBlocking(byte[] beginKey, byte[] endKey, Executor e);
 
 	/**
 	 * Runs {@link #unblobbifyRange(byte[] beginKey, byte[] endKey)} on the default executor.

--- a/bindings/java/src/main/com/apple/foundationdb/Database.java
+++ b/bindings/java/src/main/com/apple/foundationdb/Database.java
@@ -231,6 +231,7 @@ public interface Database extends AutoCloseable, TransactionContext {
 
 	 * @return if the recording of the range was successful
 	 */
+	@Deprecated
 	default CompletableFuture<Boolean> blobbifyRange(byte[] beginKey, byte[] endKey) {
 		return blobbifyRange(beginKey, endKey, getExecutor());
 	}
@@ -244,7 +245,35 @@ public interface Database extends AutoCloseable, TransactionContext {
 
 	 * @return if the recording of the range was successful
 	 */
-	CompletableFuture<Boolean> blobbifyRange(byte[] beginKey, byte[] endKey, Executor e);
+	@Deprecated
+	default CompletableFuture<Boolean> blobbifyRange(byte[] beginKey, byte[] endKey, Executor e) {
+		return blobbifyRange(beginKey, endKey, false, e);
+	}
+
+	/**
+	 * Runs {@link #blobbifyRange(byte[] beginKey, byte[] endKey, boolean wait)} on the default executor.
+	 *
+	 * @param beginKey start of the key range
+	 * @param endKey end of the key range
+	 * @param wait wait for blobbification to complete
+
+	 * @return if the recording of the range was successful
+	 */
+	default CompletableFuture<Boolean> blobbifyRange(byte[] beginKey, byte[] endKey, boolean wait) {
+		return blobbifyRange(beginKey, endKey, wait, getExecutor());
+	}
+
+	/**
+	 * Sets a range to be blobbified in the database. Must be a completely unblobbified range.
+	 *
+	 * @param beginKey start of the key range
+	 * @param endKey end of the key range
+	 * @param wait wait for blobbification to complete
+	 * @param e the {@link Executor} to use for asynchronous callbacks
+
+	 * @return if the recording of the range was successful
+	 */
+	CompletableFuture<Boolean> blobbifyRange(byte[] beginKey, byte[] endKey, boolean wait, Executor e);
 
 	/**
 	 * Runs {@link #unblobbifyRange(byte[] beginKey, byte[] endKey)} on the default executor.

--- a/bindings/java/src/main/com/apple/foundationdb/FDBDatabase.java
+++ b/bindings/java/src/main/com/apple/foundationdb/FDBDatabase.java
@@ -221,10 +221,20 @@ class FDBDatabase extends NativeObjectWrapper implements Database, OptionConsume
 	}
 
 	@Override
-	public CompletableFuture<Boolean> blobbifyRange(byte[] beginKey, byte[] endKey, boolean wait, Executor e) {
+	public CompletableFuture<Boolean> blobbifyRange(byte[] beginKey, byte[] endKey, Executor e) {
 		pointerReadLock.lock();
 		try {
-			return new FutureBool(Database_blobbifyRange(getPtr(), beginKey, endKey, wait), e);
+			return new FutureBool(Database_blobbifyRange(getPtr(), beginKey, endKey), e);
+		} finally {
+			pointerReadLock.unlock();
+		}
+	}
+
+	@Override
+	public CompletableFuture<Boolean> blobbifyRangeBlocking(byte[] beginKey, byte[] endKey, Executor e) {
+		pointerReadLock.lock();
+		try {
+			return new FutureBool(Database_blobbifyRangeBlocking(getPtr(), beginKey, endKey), e);
 		} finally {
 			pointerReadLock.unlock();
 		}
@@ -277,7 +287,8 @@ class FDBDatabase extends NativeObjectWrapper implements Database, OptionConsume
 	private native double Database_getMainThreadBusyness(long cPtr);
 	private native long Database_purgeBlobGranules(long cPtr, byte[] beginKey, byte[] endKey, long purgeVersion, boolean force);
 	private native long Database_waitPurgeGranulesComplete(long cPtr, byte[] purgeKey);
-	private native long Database_blobbifyRange(long cPtr, byte[] beginKey, byte[] endKey, boolean wait);
+	private native long Database_blobbifyRange(long cPtr, byte[] beginKey, byte[] endKey);
+	private native long Database_blobbifyRangeBlocking(long cPtr, byte[] beginKey, byte[] endKey);
 	private native long Database_unblobbifyRange(long cPtr, byte[] beginKey, byte[] endKey);
 	private native long Database_listBlobbifiedRanges(long cPtr, byte[] beginKey, byte[] endKey, int rangeLimit);
 	private native long Database_verifyBlobRange(long cPtr, byte[] beginKey, byte[] endKey, long version);

--- a/bindings/java/src/main/com/apple/foundationdb/FDBDatabase.java
+++ b/bindings/java/src/main/com/apple/foundationdb/FDBDatabase.java
@@ -221,10 +221,10 @@ class FDBDatabase extends NativeObjectWrapper implements Database, OptionConsume
 	}
 
 	@Override
-	public CompletableFuture<Boolean> blobbifyRange(byte[] beginKey, byte[] endKey, Executor e) {
+	public CompletableFuture<Boolean> blobbifyRange(byte[] beginKey, byte[] endKey, boolean wait, Executor e) {
 		pointerReadLock.lock();
 		try {
-			return new FutureBool(Database_blobbifyRange(getPtr(), beginKey, endKey), e);
+			return new FutureBool(Database_blobbifyRange(getPtr(), beginKey, endKey, wait), e);
 		} finally {
 			pointerReadLock.unlock();
 		}
@@ -277,7 +277,7 @@ class FDBDatabase extends NativeObjectWrapper implements Database, OptionConsume
 	private native double Database_getMainThreadBusyness(long cPtr);
 	private native long Database_purgeBlobGranules(long cPtr, byte[] beginKey, byte[] endKey, long purgeVersion, boolean force);
 	private native long Database_waitPurgeGranulesComplete(long cPtr, byte[] purgeKey);
-	private native long Database_blobbifyRange(long cPtr, byte[] beginKey, byte[] endKey);
+	private native long Database_blobbifyRange(long cPtr, byte[] beginKey, byte[] endKey, boolean wait);
 	private native long Database_unblobbifyRange(long cPtr, byte[] beginKey, byte[] endKey);
 	private native long Database_listBlobbifiedRanges(long cPtr, byte[] beginKey, byte[] endKey, int rangeLimit);
 	private native long Database_verifyBlobRange(long cPtr, byte[] beginKey, byte[] endKey, long version);

--- a/bindings/java/src/main/com/apple/foundationdb/FDBTenant.java
+++ b/bindings/java/src/main/com/apple/foundationdb/FDBTenant.java
@@ -161,10 +161,20 @@ class FDBTenant extends NativeObjectWrapper implements Tenant {
 	}
 
 	@Override
-	public CompletableFuture<Boolean> blobbifyRange(byte[] beginKey, byte[] endKey, boolean wait, Executor e) {
+	public CompletableFuture<Boolean> blobbifyRange(byte[] beginKey, byte[] endKey, Executor e) {
 		pointerReadLock.lock();
 		try {
-			return new FutureBool(Tenant_blobbifyRange(getPtr(), beginKey, endKey, wait), e);
+			return new FutureBool(Tenant_blobbifyRange(getPtr(), beginKey, endKey), e);
+		} finally {
+			pointerReadLock.unlock();
+		}
+	}
+
+	@Override
+	public CompletableFuture<Boolean> blobbifyRangeBlocking(byte[] beginKey, byte[] endKey, Executor e) {
+		pointerReadLock.lock();
+		try {
+			return new FutureBool(Tenant_blobbifyRangeBlocking(getPtr(), beginKey, endKey), e);
 		} finally {
 			pointerReadLock.unlock();
 		}
@@ -232,7 +242,8 @@ class FDBTenant extends NativeObjectWrapper implements Tenant {
 	private native void Tenant_dispose(long cPtr);
 	private native long Tenant_purgeBlobGranules(long cPtr, byte[] beginKey, byte[] endKey, long purgeVersion, boolean force);
 	private native long Tenant_waitPurgeGranulesComplete(long cPtr, byte[] purgeKey);
-	private native long Tenant_blobbifyRange(long cPtr, byte[] beginKey, byte[] endKey, boolean wait);
+	private native long Tenant_blobbifyRange(long cPtr, byte[] beginKey, byte[] endKey);
+	private native long Tenant_blobbifyRangeBlocking(long cPtr, byte[] beginKey, byte[] endKey);
 	private native long Tenant_unblobbifyRange(long cPtr, byte[] beginKey, byte[] endKey);
 	private native long Tenant_listBlobbifiedRanges(long cPtr, byte[] beginKey, byte[] endKey, int rangeLimit);
 	private native long Tenant_verifyBlobRange(long cPtr, byte[] beginKey, byte[] endKey, long version);

--- a/bindings/java/src/main/com/apple/foundationdb/FDBTenant.java
+++ b/bindings/java/src/main/com/apple/foundationdb/FDBTenant.java
@@ -161,10 +161,10 @@ class FDBTenant extends NativeObjectWrapper implements Tenant {
 	}
 
 	@Override
-	public CompletableFuture<Boolean> blobbifyRange(byte[] beginKey, byte[] endKey, Executor e) {
+	public CompletableFuture<Boolean> blobbifyRange(byte[] beginKey, byte[] endKey, boolean wait, Executor e) {
 		pointerReadLock.lock();
 		try {
-			return new FutureBool(Tenant_blobbifyRange(getPtr(), beginKey, endKey), e);
+			return new FutureBool(Tenant_blobbifyRange(getPtr(), beginKey, endKey, wait), e);
 		} finally {
 			pointerReadLock.unlock();
 		}
@@ -232,7 +232,7 @@ class FDBTenant extends NativeObjectWrapper implements Tenant {
 	private native void Tenant_dispose(long cPtr);
 	private native long Tenant_purgeBlobGranules(long cPtr, byte[] beginKey, byte[] endKey, long purgeVersion, boolean force);
 	private native long Tenant_waitPurgeGranulesComplete(long cPtr, byte[] purgeKey);
-	private native long Tenant_blobbifyRange(long cPtr, byte[] beginKey, byte[] endKey);
+	private native long Tenant_blobbifyRange(long cPtr, byte[] beginKey, byte[] endKey, boolean wait);
 	private native long Tenant_unblobbifyRange(long cPtr, byte[] beginKey, byte[] endKey);
 	private native long Tenant_listBlobbifiedRanges(long cPtr, byte[] beginKey, byte[] endKey, int rangeLimit);
 	private native long Tenant_verifyBlobRange(long cPtr, byte[] beginKey, byte[] endKey, long version);

--- a/bindings/java/src/main/com/apple/foundationdb/Tenant.java
+++ b/bindings/java/src/main/com/apple/foundationdb/Tenant.java
@@ -318,6 +318,7 @@ public interface Tenant extends AutoCloseable, TransactionContext {
 
 	 * @return if the recording of the range was successful
 	 */
+	@Deprecated
 	default CompletableFuture<Boolean> blobbifyRange(byte[] beginKey, byte[] endKey) {
 		return blobbifyRange(beginKey, endKey, getExecutor());
 	}
@@ -331,7 +332,35 @@ public interface Tenant extends AutoCloseable, TransactionContext {
 
 	 * @return if the recording of the range was successful
 	 */
-	CompletableFuture<Boolean> blobbifyRange(byte[] beginKey, byte[] endKey, Executor e);
+	@Deprecated
+	default CompletableFuture<Boolean> blobbifyRange(byte[] beginKey, byte[] endKey, Executor e) {
+		return blobbifyRange(beginKey, endKey, false, e);
+	}
+
+	/**
+	 * Runs {@link #blobbifyRange(byte[] beginKey, byte[] endKey, boolean wait)} on the default executor.
+	 *
+	 * @param beginKey start of the key range
+	 * @param endKey end of the key range
+	 * @param wait wait for blobbification to complete
+
+	 * @return if the recording of the range was successful
+	 */
+	default CompletableFuture<Boolean> blobbifyRange(byte[] beginKey, byte[] endKey, boolean wait) {
+		return blobbifyRange(beginKey, endKey, wait, getExecutor());
+	}
+
+	/**
+	 * Sets a range to be blobbified in this tenant. Must be a completely unblobbified range.
+	 *
+	 * @param beginKey start of the key range
+	 * @param endKey end of the key range
+	 * @param wait wait for blobbification to complete
+	 * @param e the {@link Executor} to use for asynchronous callbacks
+
+	 * @return if the recording of the range was successful
+	 */
+	CompletableFuture<Boolean> blobbifyRange(byte[] beginKey, byte[] endKey, boolean wait, Executor e);
 
 	/**
 	 * Runs {@link #unblobbifyRange(byte[] beginKey, byte[] endKey)} on the default executor.

--- a/bindings/java/src/main/com/apple/foundationdb/Tenant.java
+++ b/bindings/java/src/main/com/apple/foundationdb/Tenant.java
@@ -318,7 +318,6 @@ public interface Tenant extends AutoCloseable, TransactionContext {
 
 	 * @return if the recording of the range was successful
 	 */
-	@Deprecated
 	default CompletableFuture<Boolean> blobbifyRange(byte[] beginKey, byte[] endKey) {
 		return blobbifyRange(beginKey, endKey, getExecutor());
 	}
@@ -332,10 +331,7 @@ public interface Tenant extends AutoCloseable, TransactionContext {
 
 	 * @return if the recording of the range was successful
 	 */
-	@Deprecated
-	default CompletableFuture<Boolean> blobbifyRange(byte[] beginKey, byte[] endKey, Executor e) {
-		return blobbifyRange(beginKey, endKey, false, e);
-	}
+	CompletableFuture<Boolean> blobbifyRange(byte[] beginKey, byte[] endKey, Executor e);
 
 	/**
 	 * Runs {@link #blobbifyRange(byte[] beginKey, byte[] endKey, boolean wait)} on the default executor.
@@ -346,8 +342,8 @@ public interface Tenant extends AutoCloseable, TransactionContext {
 
 	 * @return if the recording of the range was successful
 	 */
-	default CompletableFuture<Boolean> blobbifyRange(byte[] beginKey, byte[] endKey, boolean wait) {
-		return blobbifyRange(beginKey, endKey, wait, getExecutor());
+	default CompletableFuture<Boolean> blobbifyRangeBlocking(byte[] beginKey, byte[] endKey) {
+		return blobbifyRangeBlocking(beginKey, endKey, getExecutor());
 	}
 
 	/**
@@ -360,7 +356,7 @@ public interface Tenant extends AutoCloseable, TransactionContext {
 
 	 * @return if the recording of the range was successful
 	 */
-	CompletableFuture<Boolean> blobbifyRange(byte[] beginKey, byte[] endKey, boolean wait, Executor e);
+	CompletableFuture<Boolean> blobbifyRangeBlocking(byte[] beginKey, byte[] endKey, Executor e);
 
 	/**
 	 * Runs {@link #unblobbifyRange(byte[] beginKey, byte[] endKey)} on the default executor.

--- a/fdbclient/MultiVersionTransaction.actor.cpp
+++ b/fdbclient/MultiVersionTransaction.actor.cpp
@@ -549,17 +549,13 @@ ThreadFuture<bool> DLTenant::blobbifyRange(const KeyRangeRef& keyRange) {
 	});
 }
 
-ThreadFuture<bool> DLTenant::blobbifyRangeV2(const KeyRangeRef& keyRange, bool wait) {
-	if (!api->tenantBlobbifyRangeV2) {
-		// in case a client called the new version of this function with an old external client
-		if (api->tenantBlobbifyRange && !wait) {
-			return blobbifyRange(keyRange);
-		}
+ThreadFuture<bool> DLTenant::blobbifyRangeBlocking(const KeyRangeRef& keyRange) {
+	if (!api->tenantBlobbifyRangeBlocking) {
 		return unsupported_operation();
 	}
 
-	FdbCApi::FDBFuture* f = api->tenantBlobbifyRangeV2(
-	    tenant, keyRange.begin.begin(), keyRange.begin.size(), keyRange.end.begin(), keyRange.end.size(), wait);
+	FdbCApi::FDBFuture* f = api->tenantBlobbifyRangeBlocking(
+	    tenant, keyRange.begin.begin(), keyRange.begin.size(), keyRange.end.begin(), keyRange.end.size());
 
 	return toThreadFuture<bool>(api, f, [](FdbCApi::FDBFuture* f, FdbCApi* api) {
 		FdbCApi::fdb_bool_t ret = false;
@@ -787,17 +783,13 @@ ThreadFuture<bool> DLDatabase::blobbifyRange(const KeyRangeRef& keyRange) {
 	});
 }
 
-ThreadFuture<bool> DLDatabase::blobbifyRangeV2(const KeyRangeRef& keyRange, bool wait) {
-	if (!api->databaseBlobbifyRangeV2) {
-		// in case a client called the new version of this function with an old external client
-		if (api->databaseBlobbifyRange && !wait) {
-			return blobbifyRange(keyRange);
-		}
+ThreadFuture<bool> DLDatabase::blobbifyRangeBlocking(const KeyRangeRef& keyRange) {
+	if (!api->databaseBlobbifyRangeBlocking) {
 		return unsupported_operation();
 	}
 
-	FdbCApi::FDBFuture* f = api->databaseBlobbifyRangeV2(
-	    db, keyRange.begin.begin(), keyRange.begin.size(), keyRange.end.begin(), keyRange.end.size(), wait);
+	FdbCApi::FDBFuture* f = api->databaseBlobbifyRangeBlocking(
+	    db, keyRange.begin.begin(), keyRange.begin.size(), keyRange.end.begin(), keyRange.end.size());
 
 	return toThreadFuture<bool>(api, f, [](FdbCApi::FDBFuture* f, FdbCApi* api) {
 		FdbCApi::fdb_bool_t ret = false;
@@ -969,10 +961,10 @@ void DLApi::init() {
 	                   fdbCPath,
 	                   "fdb_database_blobbify_range",
 	                   headerVersion >= ApiVersion::withBlobRangeApi().version());
-	loadClientFunction(&api->databaseBlobbifyRangeV2,
+	loadClientFunction(&api->databaseBlobbifyRangeBlocking,
 	                   lib,
 	                   fdbCPath,
-	                   "fdb_database_blobbify_range_v2",
+	                   "fdb_database_blobbify_range_blocking",
 	                   headerVersion >= ApiVersion::withTenantBlobRangeApi().version());
 	loadClientFunction(&api->databaseUnblobbifyRange,
 	                   lib,
@@ -1011,10 +1003,10 @@ void DLApi::init() {
 	                   fdbCPath,
 	                   "fdb_tenant_blobbify_range",
 	                   headerVersion >= ApiVersion::withTenantBlobRangeApi().version());
-	loadClientFunction(&api->tenantBlobbifyRangeV2,
+	loadClientFunction(&api->tenantBlobbifyRangeBlocking,
 	                   lib,
 	                   fdbCPath,
-	                   "fdb_tenant_blobbify_range_v2",
+	                   "fdb_tenant_blobbify_range_blocking",
 	                   headerVersion >= ApiVersion::withTenantBlobRangeApi().version());
 	loadClientFunction(&api->tenantUnblobbifyRange,
 	                   lib,
@@ -1876,8 +1868,8 @@ ThreadFuture<bool> MultiVersionTenant::blobbifyRange(const KeyRangeRef& keyRange
 	return executeOperation(&ITenant::blobbifyRange, keyRange);
 }
 
-ThreadFuture<bool> MultiVersionTenant::blobbifyRangeV2(const KeyRangeRef& keyRange, bool wait) {
-	return executeOperation(&ITenant::blobbifyRangeV2, keyRange, std::forward<bool>(wait));
+ThreadFuture<bool> MultiVersionTenant::blobbifyRangeBlocking(const KeyRangeRef& keyRange) {
+	return executeOperation(&ITenant::blobbifyRangeBlocking, keyRange);
 }
 
 ThreadFuture<bool> MultiVersionTenant::unblobbifyRange(const KeyRangeRef& keyRange) {
@@ -2114,8 +2106,8 @@ ThreadFuture<bool> MultiVersionDatabase::blobbifyRange(const KeyRangeRef& keyRan
 	return executeOperation(&IDatabase::blobbifyRange, keyRange);
 }
 
-ThreadFuture<bool> MultiVersionDatabase::blobbifyRangeV2(const KeyRangeRef& keyRange, bool wait) {
-	return executeOperation(&IDatabase::blobbifyRangeV2, keyRange, std::forward<bool>(wait));
+ThreadFuture<bool> MultiVersionDatabase::blobbifyRangeBlocking(const KeyRangeRef& keyRange) {
+	return executeOperation(&IDatabase::blobbifyRangeBlocking, keyRange);
 }
 
 ThreadFuture<bool> MultiVersionDatabase::unblobbifyRange(const KeyRangeRef& keyRange) {

--- a/fdbclient/MultiVersionTransaction.actor.cpp
+++ b/fdbclient/MultiVersionTransaction.actor.cpp
@@ -796,8 +796,8 @@ ThreadFuture<bool> DLDatabase::blobbifyRangeV2(const KeyRangeRef& keyRange, bool
 		return unsupported_operation();
 	}
 
-	FdbCApi::FDBFuture* f = api->databaseBlobbifyRange(
-	    db, keyRange.begin.begin(), keyRange.begin.size(), keyRange.end.begin(), keyRange.end.size());
+	FdbCApi::FDBFuture* f = api->databaseBlobbifyRangeV2(
+	    db, keyRange.begin.begin(), keyRange.begin.size(), keyRange.end.begin(), keyRange.end.size(), wait);
 
 	return toThreadFuture<bool>(api, f, [](FdbCApi::FDBFuture* f, FdbCApi* api) {
 		FdbCApi::fdb_bool_t ret = false;

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -10930,7 +10930,10 @@ ACTOR Future<bool> blobbifyRangeActor(Reference<DatabaseContext> cx,
 		Version verifyVersion = wait(cx->verifyBlobRange(range, latestVersion, tenant));
 		if (verifyVersion != invalidVersion) {
 			if (BG_REQUEST_DEBUG) {
-				fmt::print("BlobbifyRange [{0} - {1}) got complete @ {2}\n", range.begin.printable(), range.end.printable(), verifyVersion);
+				fmt::print("BlobbifyRange [{0} - {1}) got complete @ {2}\n",
+				           range.begin.printable(),
+				           range.end.printable(),
+				           verifyVersion);
 			}
 			return result;
 		}

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -10941,8 +10941,12 @@ ACTOR Future<bool> blobbifyRangeActor(Reference<DatabaseContext> cx,
 	}
 }
 
-Future<bool> DatabaseContext::blobbifyRange(KeyRange range, bool doWait, Optional<Reference<Tenant>> tenant) {
-	return blobbifyRangeActor(Reference<DatabaseContext>::addRef(this), range, doWait, tenant);
+Future<bool> DatabaseContext::blobbifyRange(KeyRange range, Optional<Reference<Tenant>> tenant) {
+	return blobbifyRangeActor(Reference<DatabaseContext>::addRef(this), range, false, tenant);
+}
+
+Future<bool> DatabaseContext::blobbifyRangeBlocking(KeyRange range, Optional<Reference<Tenant>> tenant) {
+	return blobbifyRangeActor(Reference<DatabaseContext>::addRef(this), range, true, tenant);
 }
 
 Future<bool> DatabaseContext::unblobbifyRange(KeyRange range, Optional<Reference<Tenant>> tenant) {

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -10918,6 +10918,9 @@ ACTOR Future<bool> blobbifyRangeActor(Reference<DatabaseContext> cx,
                                       KeyRange range,
                                       bool doWait,
                                       Optional<Reference<Tenant>> tenant) {
+	if (BG_REQUEST_DEBUG) {
+		fmt::print("BlobbifyRange [{0} - {1}) ({2})\n", range.begin.printable(), range.end.printable(), doWait);
+	}
 	state bool result = wait(setBlobRangeActor(cx, range, true, tenant));
 	if (!doWait || !result) {
 		return result;
@@ -10926,6 +10929,9 @@ ACTOR Future<bool> blobbifyRangeActor(Reference<DatabaseContext> cx,
 	loop {
 		Version verifyVersion = wait(cx->verifyBlobRange(range, latestVersion, tenant));
 		if (verifyVersion != invalidVersion) {
+			if (BG_REQUEST_DEBUG) {
+				fmt::print("BlobbifyRange [{0} - {1}) got complete @ {2}\n", range.begin.printable(), range.end.printable(), verifyVersion);
+			}
 			return result;
 		}
 		wait(delay(0.1));

--- a/fdbclient/ThreadSafeTransaction.cpp
+++ b/fdbclient/ThreadSafeTransaction.cpp
@@ -159,15 +159,20 @@ ThreadFuture<Void> ThreadSafeDatabase::waitPurgeGranulesComplete(const KeyRef& p
 }
 
 ThreadFuture<bool> ThreadSafeDatabase::blobbifyRange(const KeyRangeRef& keyRange) {
-	return blobbifyRangeV2(keyRange, false);
-}
-
-ThreadFuture<bool> ThreadSafeDatabase::blobbifyRangeV2(const KeyRangeRef& keyRange, bool wait) {
 	DatabaseContext* db = this->db;
 	KeyRange range = keyRange;
 	return onMainThread([=]() -> Future<bool> {
 		db->checkDeferredError();
-		return db->blobbifyRange(range, wait);
+		return db->blobbifyRange(range);
+	});
+}
+
+ThreadFuture<bool> ThreadSafeDatabase::blobbifyRangeBlocking(const KeyRangeRef& keyRange) {
+	DatabaseContext* db = this->db;
+	KeyRange range = keyRange;
+	return onMainThread([=]() -> Future<bool> {
+		db->checkDeferredError();
+		return db->blobbifyRangeBlocking(range);
 	});
 }
 
@@ -272,16 +277,22 @@ ThreadFuture<Void> ThreadSafeTenant::waitPurgeGranulesComplete(const KeyRef& pur
 }
 
 ThreadFuture<bool> ThreadSafeTenant::blobbifyRange(const KeyRangeRef& keyRange) {
-	return blobbifyRangeV2(keyRange, false);
-}
-
-ThreadFuture<bool> ThreadSafeTenant::blobbifyRangeV2(const KeyRangeRef& keyRange, bool wait) {
 	DatabaseContext* db = this->db->db;
 	KeyRange range = keyRange;
 	return onMainThread([=]() -> Future<bool> {
 		db->checkDeferredError();
 		db->addref();
-		return db->blobbifyRange(range, wait, Reference<Tenant>::addRef(tenant));
+		return db->blobbifyRange(range, Reference<Tenant>::addRef(tenant));
+	});
+}
+
+ThreadFuture<bool> ThreadSafeTenant::blobbifyRangeBlocking(const KeyRangeRef& keyRange) {
+	DatabaseContext* db = this->db->db;
+	KeyRange range = keyRange;
+	return onMainThread([=]() -> Future<bool> {
+		db->checkDeferredError();
+		db->addref();
+		return db->blobbifyRangeBlocking(range, Reference<Tenant>::addRef(tenant));
 	});
 }
 

--- a/fdbclient/ThreadSafeTransaction.cpp
+++ b/fdbclient/ThreadSafeTransaction.cpp
@@ -159,11 +159,15 @@ ThreadFuture<Void> ThreadSafeDatabase::waitPurgeGranulesComplete(const KeyRef& p
 }
 
 ThreadFuture<bool> ThreadSafeDatabase::blobbifyRange(const KeyRangeRef& keyRange) {
+	return blobbifyRangeV2(keyRange, false);
+}
+
+ThreadFuture<bool> ThreadSafeDatabase::blobbifyRangeV2(const KeyRangeRef& keyRange, bool wait) {
 	DatabaseContext* db = this->db;
 	KeyRange range = keyRange;
 	return onMainThread([=]() -> Future<bool> {
 		db->checkDeferredError();
-		return db->blobbifyRange(range);
+		return db->blobbifyRange(range, wait);
 	});
 }
 
@@ -268,12 +272,16 @@ ThreadFuture<Void> ThreadSafeTenant::waitPurgeGranulesComplete(const KeyRef& pur
 }
 
 ThreadFuture<bool> ThreadSafeTenant::blobbifyRange(const KeyRangeRef& keyRange) {
+	return blobbifyRangeV2(keyRange, false);
+}
+
+ThreadFuture<bool> ThreadSafeTenant::blobbifyRangeV2(const KeyRangeRef& keyRange, bool wait) {
 	DatabaseContext* db = this->db->db;
 	KeyRange range = keyRange;
 	return onMainThread([=]() -> Future<bool> {
 		db->checkDeferredError();
 		db->addref();
-		return db->blobbifyRange(range, Reference<Tenant>::addRef(tenant));
+		return db->blobbifyRange(range, wait, Reference<Tenant>::addRef(tenant));
 	});
 }
 

--- a/fdbclient/include/fdbclient/DatabaseContext.h
+++ b/fdbclient/include/fdbclient/DatabaseContext.h
@@ -405,7 +405,8 @@ public:
 	                              bool force = false);
 	Future<Void> waitPurgeGranulesComplete(Key purgeKey);
 
-	Future<bool> blobbifyRange(KeyRange range, bool doWait = false, Optional<Reference<Tenant>> tenant = {});
+	Future<bool> blobbifyRange(KeyRange range, Optional<Reference<Tenant>> tenant = {});
+	Future<bool> blobbifyRangeBlocking(KeyRange range, Optional<Reference<Tenant>> tenant = {});
 	Future<bool> unblobbifyRange(KeyRange range, Optional<Reference<Tenant>> tenant = {});
 	Future<Standalone<VectorRef<KeyRangeRef>>> listBlobbifiedRanges(KeyRange range,
 	                                                                int rangeLimit,

--- a/fdbclient/include/fdbclient/DatabaseContext.h
+++ b/fdbclient/include/fdbclient/DatabaseContext.h
@@ -405,7 +405,7 @@ public:
 	                              bool force = false);
 	Future<Void> waitPurgeGranulesComplete(Key purgeKey);
 
-	Future<bool> blobbifyRange(KeyRange range, Optional<Reference<Tenant>> tenant = {});
+	Future<bool> blobbifyRange(KeyRange range, bool doWait = false, Optional<Reference<Tenant>> tenant = {});
 	Future<bool> unblobbifyRange(KeyRange range, Optional<Reference<Tenant>> tenant = {});
 	Future<Standalone<VectorRef<KeyRangeRef>>> listBlobbifiedRanges(KeyRange range,
 	                                                                int rangeLimit,

--- a/fdbclient/include/fdbclient/IClientApi.h
+++ b/fdbclient/include/fdbclient/IClientApi.h
@@ -153,7 +153,7 @@ public:
 	virtual ThreadFuture<Void> waitPurgeGranulesComplete(const KeyRef& purgeKey) = 0;
 
 	virtual ThreadFuture<bool> blobbifyRange(const KeyRangeRef& keyRange) = 0;
-	virtual ThreadFuture<bool> blobbifyRangeV2(const KeyRangeRef& keyRange, bool wait) = 0;
+	virtual ThreadFuture<bool> blobbifyRangeBlocking(const KeyRangeRef& keyRange) = 0;
 	virtual ThreadFuture<bool> unblobbifyRange(const KeyRangeRef& keyRange) = 0;
 	virtual ThreadFuture<Standalone<VectorRef<KeyRangeRef>>> listBlobbifiedRanges(const KeyRangeRef& keyRange,
 	                                                                              int rangeLimit) = 0;
@@ -201,7 +201,7 @@ public:
 	virtual ThreadFuture<Void> waitPurgeGranulesComplete(const KeyRef& purgeKey) = 0;
 
 	virtual ThreadFuture<bool> blobbifyRange(const KeyRangeRef& keyRange) = 0;
-	virtual ThreadFuture<bool> blobbifyRangeV2(const KeyRangeRef& keyRange, bool wait) = 0;
+	virtual ThreadFuture<bool> blobbifyRangeBlocking(const KeyRangeRef& keyRange) = 0;
 	virtual ThreadFuture<bool> unblobbifyRange(const KeyRangeRef& keyRange) = 0;
 	virtual ThreadFuture<Standalone<VectorRef<KeyRangeRef>>> listBlobbifiedRanges(const KeyRangeRef& keyRange,
 	                                                                              int rangeLimit) = 0;

--- a/fdbclient/include/fdbclient/IClientApi.h
+++ b/fdbclient/include/fdbclient/IClientApi.h
@@ -153,6 +153,7 @@ public:
 	virtual ThreadFuture<Void> waitPurgeGranulesComplete(const KeyRef& purgeKey) = 0;
 
 	virtual ThreadFuture<bool> blobbifyRange(const KeyRangeRef& keyRange) = 0;
+	virtual ThreadFuture<bool> blobbifyRangeV2(const KeyRangeRef& keyRange, bool wait) = 0;
 	virtual ThreadFuture<bool> unblobbifyRange(const KeyRangeRef& keyRange) = 0;
 	virtual ThreadFuture<Standalone<VectorRef<KeyRangeRef>>> listBlobbifiedRanges(const KeyRangeRef& keyRange,
 	                                                                              int rangeLimit) = 0;
@@ -200,6 +201,7 @@ public:
 	virtual ThreadFuture<Void> waitPurgeGranulesComplete(const KeyRef& purgeKey) = 0;
 
 	virtual ThreadFuture<bool> blobbifyRange(const KeyRangeRef& keyRange) = 0;
+	virtual ThreadFuture<bool> blobbifyRangeV2(const KeyRangeRef& keyRange, bool wait) = 0;
 	virtual ThreadFuture<bool> unblobbifyRange(const KeyRangeRef& keyRange) = 0;
 	virtual ThreadFuture<Standalone<VectorRef<KeyRangeRef>>> listBlobbifiedRanges(const KeyRangeRef& keyRange,
 	                                                                              int rangeLimit) = 0;

--- a/fdbclient/include/fdbclient/MultiVersionTransaction.h
+++ b/fdbclient/include/fdbclient/MultiVersionTransaction.h
@@ -186,12 +186,11 @@ struct FdbCApi : public ThreadSafeReferenceCounted<FdbCApi> {
 	                                    uint8_t const* end_key_name,
 	                                    int end_key_name_length);
 
-	FDBFuture* (*databaseBlobbifyRangeV2)(FDBDatabase* db,
-	                                      uint8_t const* begin_key_name,
-	                                      int begin_key_name_length,
-	                                      uint8_t const* end_key_name,
-	                                      int end_key_name_length,
-	                                      fdb_bool_t wait);
+	FDBFuture* (*databaseBlobbifyRangeBlocking)(FDBDatabase* db,
+	                                            uint8_t const* begin_key_name,
+	                                            int begin_key_name_length,
+	                                            uint8_t const* end_key_name,
+	                                            int end_key_name_length);
 
 	FDBFuture* (*databaseUnblobbifyRange)(FDBDatabase* db,
 	                                      uint8_t const* begin_key_name,
@@ -236,12 +235,11 @@ struct FdbCApi : public ThreadSafeReferenceCounted<FdbCApi> {
 	                                  uint8_t const* end_key_name,
 	                                  int end_key_name_length);
 
-	FDBFuture* (*tenantBlobbifyRangeV2)(FDBTenant* tenant,
-	                                    uint8_t const* begin_key_name,
-	                                    int begin_key_name_length,
-	                                    uint8_t const* end_key_name,
-	                                    int end_key_name_length,
-	                                    fdb_bool_t wait);
+	FDBFuture* (*tenantBlobbifyRangeBlocking)(FDBTenant* tenant,
+	                                          uint8_t const* begin_key_name,
+	                                          int begin_key_name_length,
+	                                          uint8_t const* end_key_name,
+	                                          int end_key_name_length);
 
 	FDBFuture* (*tenantUnblobbifyRange)(FDBTenant* tenant,
 	                                    uint8_t const* begin_key_name,
@@ -560,7 +558,7 @@ public:
 	ThreadFuture<Void> waitPurgeGranulesComplete(const KeyRef& purgeKey) override;
 
 	ThreadFuture<bool> blobbifyRange(const KeyRangeRef& keyRange) override;
-	ThreadFuture<bool> blobbifyRangeV2(const KeyRangeRef& keyRange, bool wait) override;
+	ThreadFuture<bool> blobbifyRangeBlocking(const KeyRangeRef& keyRange) override;
 	ThreadFuture<bool> unblobbifyRange(const KeyRangeRef& keyRange) override;
 	ThreadFuture<Standalone<VectorRef<KeyRangeRef>>> listBlobbifiedRanges(const KeyRangeRef& keyRange,
 	                                                                      int rangeLimit) override;
@@ -611,7 +609,7 @@ public:
 	ThreadFuture<Void> waitPurgeGranulesComplete(const KeyRef& purgeKey) override;
 
 	ThreadFuture<bool> blobbifyRange(const KeyRangeRef& keyRange) override;
-	ThreadFuture<bool> blobbifyRangeV2(const KeyRangeRef& keyRange, bool wait) override;
+	ThreadFuture<bool> blobbifyRangeBlocking(const KeyRangeRef& keyRange) override;
 	ThreadFuture<bool> unblobbifyRange(const KeyRangeRef& keyRange) override;
 	ThreadFuture<Standalone<VectorRef<KeyRangeRef>>> listBlobbifiedRanges(const KeyRangeRef& keyRange,
 	                                                                      int rangeLimit) override;
@@ -880,7 +878,7 @@ public:
 	ThreadFuture<Void> waitPurgeGranulesComplete(const KeyRef& purgeKey) override;
 
 	ThreadFuture<bool> blobbifyRange(const KeyRangeRef& keyRange) override;
-	ThreadFuture<bool> blobbifyRangeV2(const KeyRangeRef& keyRange, bool wait) override;
+	ThreadFuture<bool> blobbifyRangeBlocking(const KeyRangeRef& keyRange) override;
 	ThreadFuture<bool> unblobbifyRange(const KeyRangeRef& keyRange) override;
 	ThreadFuture<Standalone<VectorRef<KeyRangeRef>>> listBlobbifiedRanges(const KeyRangeRef& keyRange,
 	                                                                      int rangeLimit) override;
@@ -1009,7 +1007,7 @@ public:
 	ThreadFuture<Void> waitPurgeGranulesComplete(const KeyRef& purgeKey) override;
 
 	ThreadFuture<bool> blobbifyRange(const KeyRangeRef& keyRange) override;
-	ThreadFuture<bool> blobbifyRangeV2(const KeyRangeRef& keyRange, bool wait) override;
+	ThreadFuture<bool> blobbifyRangeBlocking(const KeyRangeRef& keyRange) override;
 	ThreadFuture<bool> unblobbifyRange(const KeyRangeRef& keyRange) override;
 	ThreadFuture<Standalone<VectorRef<KeyRangeRef>>> listBlobbifiedRanges(const KeyRangeRef& keyRange,
 	                                                                      int rangeLimit) override;

--- a/fdbclient/include/fdbclient/MultiVersionTransaction.h
+++ b/fdbclient/include/fdbclient/MultiVersionTransaction.h
@@ -186,6 +186,13 @@ struct FdbCApi : public ThreadSafeReferenceCounted<FdbCApi> {
 	                                    uint8_t const* end_key_name,
 	                                    int end_key_name_length);
 
+	FDBFuture* (*databaseBlobbifyRangeV2)(FDBDatabase* db,
+	                                      uint8_t const* begin_key_name,
+	                                      int begin_key_name_length,
+	                                      uint8_t const* end_key_name,
+	                                      int end_key_name_length,
+	                                      fdb_bool_t wait);
+
 	FDBFuture* (*databaseUnblobbifyRange)(FDBDatabase* db,
 	                                      uint8_t const* begin_key_name,
 	                                      int begin_key_name_length,
@@ -228,6 +235,13 @@ struct FdbCApi : public ThreadSafeReferenceCounted<FdbCApi> {
 	                                  int begin_key_name_length,
 	                                  uint8_t const* end_key_name,
 	                                  int end_key_name_length);
+
+	FDBFuture* (*tenantBlobbifyRangeV2)(FDBTenant* tenant,
+	                                    uint8_t const* begin_key_name,
+	                                    int begin_key_name_length,
+	                                    uint8_t const* end_key_name,
+	                                    int end_key_name_length,
+	                                    fdb_bool_t wait);
 
 	FDBFuture* (*tenantUnblobbifyRange)(FDBTenant* tenant,
 	                                    uint8_t const* begin_key_name,
@@ -546,6 +560,7 @@ public:
 	ThreadFuture<Void> waitPurgeGranulesComplete(const KeyRef& purgeKey) override;
 
 	ThreadFuture<bool> blobbifyRange(const KeyRangeRef& keyRange) override;
+	ThreadFuture<bool> blobbifyRangeV2(const KeyRangeRef& keyRange, bool wait) override;
 	ThreadFuture<bool> unblobbifyRange(const KeyRangeRef& keyRange) override;
 	ThreadFuture<Standalone<VectorRef<KeyRangeRef>>> listBlobbifiedRanges(const KeyRangeRef& keyRange,
 	                                                                      int rangeLimit) override;
@@ -596,6 +611,7 @@ public:
 	ThreadFuture<Void> waitPurgeGranulesComplete(const KeyRef& purgeKey) override;
 
 	ThreadFuture<bool> blobbifyRange(const KeyRangeRef& keyRange) override;
+	ThreadFuture<bool> blobbifyRangeV2(const KeyRangeRef& keyRange, bool wait) override;
 	ThreadFuture<bool> unblobbifyRange(const KeyRangeRef& keyRange) override;
 	ThreadFuture<Standalone<VectorRef<KeyRangeRef>>> listBlobbifiedRanges(const KeyRangeRef& keyRange,
 	                                                                      int rangeLimit) override;
@@ -864,6 +880,7 @@ public:
 	ThreadFuture<Void> waitPurgeGranulesComplete(const KeyRef& purgeKey) override;
 
 	ThreadFuture<bool> blobbifyRange(const KeyRangeRef& keyRange) override;
+	ThreadFuture<bool> blobbifyRangeV2(const KeyRangeRef& keyRange, bool wait) override;
 	ThreadFuture<bool> unblobbifyRange(const KeyRangeRef& keyRange) override;
 	ThreadFuture<Standalone<VectorRef<KeyRangeRef>>> listBlobbifiedRanges(const KeyRangeRef& keyRange,
 	                                                                      int rangeLimit) override;
@@ -992,6 +1009,7 @@ public:
 	ThreadFuture<Void> waitPurgeGranulesComplete(const KeyRef& purgeKey) override;
 
 	ThreadFuture<bool> blobbifyRange(const KeyRangeRef& keyRange) override;
+	ThreadFuture<bool> blobbifyRangeV2(const KeyRangeRef& keyRange, bool wait) override;
 	ThreadFuture<bool> unblobbifyRange(const KeyRangeRef& keyRange) override;
 	ThreadFuture<Standalone<VectorRef<KeyRangeRef>>> listBlobbifiedRanges(const KeyRangeRef& keyRange,
 	                                                                      int rangeLimit) override;

--- a/fdbclient/include/fdbclient/ThreadSafeTransaction.h
+++ b/fdbclient/include/fdbclient/ThreadSafeTransaction.h
@@ -64,7 +64,7 @@ public:
 	ThreadFuture<Void> waitPurgeGranulesComplete(const KeyRef& purgeKey) override;
 
 	ThreadFuture<bool> blobbifyRange(const KeyRangeRef& keyRange) override;
-	ThreadFuture<bool> blobbifyRangeV2(const KeyRangeRef& keyRange, bool wait) override;
+	ThreadFuture<bool> blobbifyRangeBlocking(const KeyRangeRef& keyRange) override;
 	ThreadFuture<bool> unblobbifyRange(const KeyRangeRef& keyRange) override;
 	ThreadFuture<Standalone<VectorRef<KeyRangeRef>>> listBlobbifiedRanges(const KeyRangeRef& keyRange,
 	                                                                      int rangeLimit) override;
@@ -102,7 +102,7 @@ public:
 	ThreadFuture<Void> waitPurgeGranulesComplete(const KeyRef& purgeKey) override;
 
 	ThreadFuture<bool> blobbifyRange(const KeyRangeRef& keyRange) override;
-	ThreadFuture<bool> blobbifyRangeV2(const KeyRangeRef& keyRange, bool wait) override;
+	ThreadFuture<bool> blobbifyRangeBlocking(const KeyRangeRef& keyRange) override;
 	ThreadFuture<bool> unblobbifyRange(const KeyRangeRef& keyRange) override;
 	ThreadFuture<Standalone<VectorRef<KeyRangeRef>>> listBlobbifiedRanges(const KeyRangeRef& keyRange,
 	                                                                      int rangeLimit) override;

--- a/fdbclient/include/fdbclient/ThreadSafeTransaction.h
+++ b/fdbclient/include/fdbclient/ThreadSafeTransaction.h
@@ -64,6 +64,7 @@ public:
 	ThreadFuture<Void> waitPurgeGranulesComplete(const KeyRef& purgeKey) override;
 
 	ThreadFuture<bool> blobbifyRange(const KeyRangeRef& keyRange) override;
+	ThreadFuture<bool> blobbifyRangeV2(const KeyRangeRef& keyRange, bool wait) override;
 	ThreadFuture<bool> unblobbifyRange(const KeyRangeRef& keyRange) override;
 	ThreadFuture<Standalone<VectorRef<KeyRangeRef>>> listBlobbifiedRanges(const KeyRangeRef& keyRange,
 	                                                                      int rangeLimit) override;
@@ -101,6 +102,7 @@ public:
 	ThreadFuture<Void> waitPurgeGranulesComplete(const KeyRef& purgeKey) override;
 
 	ThreadFuture<bool> blobbifyRange(const KeyRangeRef& keyRange) override;
+	ThreadFuture<bool> blobbifyRangeV2(const KeyRangeRef& keyRange, bool wait) override;
 	ThreadFuture<bool> unblobbifyRange(const KeyRangeRef& keyRange) override;
 	ThreadFuture<Standalone<VectorRef<KeyRangeRef>>> listBlobbifiedRanges(const KeyRangeRef& keyRange,
 	                                                                      int rangeLimit) override;

--- a/fdbserver/workloads/BlobGranuleCorrectnessWorkload.actor.cpp
+++ b/fdbserver/workloads/BlobGranuleCorrectnessWorkload.actor.cpp
@@ -302,7 +302,7 @@ struct BlobGranuleCorrectnessWorkload : TestWorkload {
 			self->directories[directoryIdx]->directoryRange =
 			    KeyRangeRef(tenantEntry.prefix, tenantEntry.prefix.withSuffix(normalKeys.end));
 			tenants.push_back({ self->directories[directoryIdx]->tenant->id(), tenantEntry });
-			bool _success = wait(cx->blobbifyRange(self->directories[directoryIdx]->directoryRange));
+			bool _success = wait(cx->blobbifyRange(self->directories[directoryIdx]->directoryRange, false));
 			ASSERT(_success);
 		}
 		tenantData.addTenants(tenants);

--- a/fdbserver/workloads/BlobGranuleCorrectnessWorkload.actor.cpp
+++ b/fdbserver/workloads/BlobGranuleCorrectnessWorkload.actor.cpp
@@ -302,7 +302,7 @@ struct BlobGranuleCorrectnessWorkload : TestWorkload {
 			self->directories[directoryIdx]->directoryRange =
 			    KeyRangeRef(tenantEntry.prefix, tenantEntry.prefix.withSuffix(normalKeys.end));
 			tenants.push_back({ self->directories[directoryIdx]->tenant->id(), tenantEntry });
-			bool _success = wait(cx->blobbifyRange(self->directories[directoryIdx]->directoryRange, false));
+			bool _success = wait(cx->blobbifyRange(self->directories[directoryIdx]->directoryRange));
 			ASSERT(_success);
 		}
 		tenantData.addTenants(tenants);

--- a/fdbserver/workloads/BlobGranuleRangesWorkload.actor.cpp
+++ b/fdbserver/workloads/BlobGranuleRangesWorkload.actor.cpp
@@ -117,8 +117,7 @@ struct BlobGranuleRangesWorkload : TestWorkload {
 
 		// don't put in active ranges until AFTER set range command succeeds, to avoid checking a range that maybe
 		// wasn't initialized
-		bool success =
-		    wait(cx->blobbifyRange(range, false, alternateTenant.present() ? alternateTenant : self->tenant));
+		bool success = wait(cx->blobbifyRange(range, alternateTenant.present() ? alternateTenant : self->tenant));
 		ASSERT(success);
 
 		if (BGRW_DEBUG) {
@@ -368,7 +367,7 @@ struct BlobGranuleRangesWorkload : TestWorkload {
 		if (BGRW_DEBUG) {
 			fmt::print("VerifyRangeUnit: [{0} - {1})\n", range.begin.printable(), range.end.printable());
 		}
-		bool setSuccess = wait(cx->blobbifyRange(activeRange, false, self->tenant));
+		bool setSuccess = wait(cx->blobbifyRange(activeRange, self->tenant));
 		ASSERT(setSuccess);
 		wait(self->checkRange(cx, self, activeRange, true));
 
@@ -421,7 +420,7 @@ struct BlobGranuleRangesWorkload : TestWorkload {
 		for (i = 0; i < rangeCount; i++) {
 			state KeyRange subRange(KeyRangeRef(boundaries[i], boundaries[i + 1]));
 			if (i != rangeToNotBlobbify) {
-				bool setSuccess = wait(cx->blobbifyRange(subRange, false, self->tenant));
+				bool setSuccess = wait(cx->blobbifyRange(subRange, self->tenant));
 				ASSERT(setSuccess);
 				wait(self->checkRange(cx, self, subRange, true));
 			} else {
@@ -468,7 +467,7 @@ struct BlobGranuleRangesWorkload : TestWorkload {
 	}
 
 	ACTOR Future<Void> rangesMisalignedUnit(Database cx, BlobGranuleRangesWorkload* self, KeyRange range) {
-		bool setSuccess = wait(cx->blobbifyRange(range, false, self->tenant));
+		bool setSuccess = wait(cx->blobbifyRange(range, self->tenant));
 		ASSERT(setSuccess);
 		state KeyRange subRange(KeyRangeRef(range.begin.withSuffix("A"_sr), range.begin.withSuffix("B"_sr)));
 
@@ -521,42 +520,42 @@ struct BlobGranuleRangesWorkload : TestWorkload {
 
 		// unblobbifying range that already doesn't exist should be no-op
 		if (deterministicRandom()->coinflip()) {
-			bool unblobbifyStartSuccess = wait(cx->blobbifyRange(activeRange, false, self->tenant));
+			bool unblobbifyStartSuccess = wait(cx->blobbifyRange(activeRange, self->tenant));
 			ASSERT(unblobbifyStartSuccess);
 		}
 
-		bool success = wait(cx->blobbifyRange(activeRange, false, self->tenant));
+		bool success = wait(cx->blobbifyRange(activeRange, self->tenant));
 		ASSERT(success);
 		wait(self->checkRange(cx, self, activeRange, true));
 
 		// check that re-blobbifying same range is successful
-		bool retrySuccess = wait(cx->blobbifyRange(activeRange, false, self->tenant));
+		bool retrySuccess = wait(cx->blobbifyRange(activeRange, self->tenant));
 		ASSERT(retrySuccess);
 		wait(self->checkRange(cx, self, activeRange, true));
 
 		// check that blobbifying range that overlaps but does not match existing blob range fails
-		bool fail1 = wait(cx->blobbifyRange(range, false, self->tenant));
+		bool fail1 = wait(cx->blobbifyRange(range, self->tenant));
 		ASSERT(!fail1);
 
-		bool fail2 = wait(cx->blobbifyRange(KeyRangeRef(range.begin, activeRange.end), false, self->tenant));
+		bool fail2 = wait(cx->blobbifyRange(KeyRangeRef(range.begin, activeRange.end), self->tenant));
 		ASSERT(!fail2);
 
-		bool fail3 = wait(cx->blobbifyRange(KeyRangeRef(activeRange.begin, range.end), false, self->tenant));
+		bool fail3 = wait(cx->blobbifyRange(KeyRangeRef(activeRange.begin, range.end), self->tenant));
 		ASSERT(!fail3);
 
-		bool fail4 = wait(cx->blobbifyRange(KeyRangeRef(range.begin, middleKey), false, self->tenant));
+		bool fail4 = wait(cx->blobbifyRange(KeyRangeRef(range.begin, middleKey), self->tenant));
 		ASSERT(!fail4);
 
-		bool fail5 = wait(cx->blobbifyRange(KeyRangeRef(middleKey, range.end), false, self->tenant));
+		bool fail5 = wait(cx->blobbifyRange(KeyRangeRef(middleKey, range.end), self->tenant));
 		ASSERT(!fail5);
 
-		bool fail6 = wait(cx->blobbifyRange(KeyRangeRef(activeRange.begin, middleKey), false, self->tenant));
+		bool fail6 = wait(cx->blobbifyRange(KeyRangeRef(activeRange.begin, middleKey), self->tenant));
 		ASSERT(!fail6);
 
-		bool fail7 = wait(cx->blobbifyRange(KeyRangeRef(middleKey, activeRange.end), false, self->tenant));
+		bool fail7 = wait(cx->blobbifyRange(KeyRangeRef(middleKey, activeRange.end), self->tenant));
 
 		ASSERT(!fail7);
-		bool fail8 = wait(cx->blobbifyRange(KeyRangeRef(middleKey, middleKey2), false, self->tenant));
+		bool fail8 = wait(cx->blobbifyRange(KeyRangeRef(middleKey, middleKey2), self->tenant));
 		ASSERT(!fail8);
 
 		{
@@ -631,7 +630,7 @@ struct BlobGranuleRangesWorkload : TestWorkload {
 	}
 
 	ACTOR Future<Void> reBlobbifyUnit(Database cx, BlobGranuleRangesWorkload* self, KeyRange range) {
-		bool setSuccess = wait(cx->blobbifyRange(range, false, self->tenant));
+		bool setSuccess = wait(cx->blobbifyRange(range, self->tenant));
 		ASSERT(setSuccess);
 		wait(self->checkRange(cx, self, range, true));
 
@@ -644,7 +643,7 @@ struct BlobGranuleRangesWorkload : TestWorkload {
 		ASSERT(unsetSuccess);
 		wait(self->checkRange(cx, self, range, false));
 
-		bool reSetSuccess = wait(cx->blobbifyRange(range, false, self->tenant));
+		bool reSetSuccess = wait(cx->blobbifyRange(range, self->tenant));
 		ASSERT(reSetSuccess);
 		wait(self->checkRange(cx, self, range, true));
 
@@ -660,10 +659,10 @@ struct BlobGranuleRangesWorkload : TestWorkload {
 		state KeyRange range2(KeyRangeRef(midKey, range.end));
 
 		state bool setSuccess = false;
-		wait(store(setSuccess, cx->blobbifyRange(range1, false, self->tenant)));
+		wait(store(setSuccess, cx->blobbifyRange(range1, self->tenant)));
 		ASSERT(setSuccess);
 		wait(self->checkRange(cx, self, range1, true));
-		wait(store(setSuccess, cx->blobbifyRange(range2, false, self->tenant)));
+		wait(store(setSuccess, cx->blobbifyRange(range2, self->tenant)));
 		ASSERT(setSuccess);
 		wait(self->checkRange(cx, self, range2, true));
 
@@ -682,8 +681,8 @@ struct BlobGranuleRangesWorkload : TestWorkload {
 		return Void();
 	}
 
-	ACTOR Future<Void> blobbifyWaitUnit(Database cx, BlobGranuleRangesWorkload* self, KeyRange range) {
-		bool setSuccess = wait(cx->blobbifyRange(range, true, self->tenant));
+	ACTOR Future<Void> blobbifyBlockingUnit(Database cx, BlobGranuleRangesWorkload* self, KeyRange range) {
+		bool setSuccess = wait(cx->blobbifyRangeBlocking(range, self->tenant));
 		ASSERT(setSuccess);
 		bool verifySuccess = wait(self->isRangeActive(cx, range, self->tenant));
 		ASSERT(verifySuccess);
@@ -698,7 +697,7 @@ struct BlobGranuleRangesWorkload : TestWorkload {
 		BLOBBIFY_IDEMPOTENT,
 		RE_BLOBBIFY,
 		ADJACENT_PURGE,
-		BLOBBIFY_WAIT_UNIT,
+		BLOBBIFY_BLOCKING_UNIT,
 		OP_COUNT = 7 /* keep this last */
 	};
 
@@ -743,8 +742,8 @@ struct BlobGranuleRangesWorkload : TestWorkload {
 				wait(self->reBlobbifyUnit(cx, self, range));
 			} else if (op == ADJACENT_PURGE) {
 				wait(self->adjacentPurge(cx, self, range));
-			} else if (op == BLOBBIFY_WAIT_UNIT) {
-				wait(self->blobbifyWaitUnit(cx, self, range));
+			} else if (op == BLOBBIFY_BLOCKING_UNIT) {
+				wait(self->blobbifyBlockingUnit(cx, self, range));
 			} else {
 				ASSERT(false);
 			}

--- a/fdbserver/workloads/BlobGranuleVerifier.actor.cpp
+++ b/fdbserver/workloads/BlobGranuleVerifier.actor.cpp
@@ -168,10 +168,9 @@ struct BlobGranuleVerifierWorkload : TestWorkload {
 		}
 	}
 
-	// FIXME: run the actual FDBCLI command instead of copy/pasting its implementation
 	// Sets the whole user keyspace to be blobified
 	ACTOR Future<Void> setUpBlobRange(Database cx) {
-		bool success = wait(cx->blobbifyRange(normalKeys, false));
+		bool success = wait(cx->blobbifyRange(normalKeys));
 		ASSERT(success);
 		return Void();
 	}


### PR DESCRIPTION
Adding wait parameter to blobbify api, via the method of adding a new function type for this release and deprecating the old one in the next release.
The API just wraps the previous behavior a user would have to do of calling blobbify and then verify in a loop until success, but this can be improved transparently to the user in the future.

Passes 1k BlobGranule* correctness, 1k BlobGranuleRange* correctness, the api tester BlobGranule* tests, and the java integration test.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
