### PR TITLE
Disable machine attrition in DiskFailure workload.

### DIFF
--- a/fdbserver/workloads/DiskFailureInjection.actor.cpp
+++ b/fdbserver/workloads/DiskFailureInjection.actor.cpp
@@ -65,6 +65,9 @@ struct DiskFailureInjectionWorkload : FailureInjectionWorkload {
 		periodicBroadcastInterval = getOption(options, "periodicBroadcastInterval"_sr, periodicBroadcastInterval);
 	}
 
+	// TODO: Currently this workload doesn't play well with MachineAttrition.
+	void disableFailureInjectionWorkloads(std::set<std::string>& out) const override { out.insert("Attrition"); }
+
 	void initFailureInjectionMode(DeterministicRandom& random) override { enabled = clientId == 0; }
 
 	Future<Void> setup(Database const& cx) override { return Void(); }


### PR DESCRIPTION
The machine attrition logic doesn't take into account the possibility that a disk corruption could an unrecoverable failure in the cluster.

Before disabling attrition during the DiskFailure workload, the failure rate was >10/100,000 in the DiskFailureCycle test. Afterwards, there were no failures in 100,000 runs.

Replace this text with your description here...

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
