### PR TITLE
Enable RocksDB restarting tests

### DIFF
--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -2666,14 +2666,6 @@ ACTOR void setupAndRun(std::string dataFolder,
 		testConfig.storageEngineExcludeTypes.push_back(5);
 	}
 
-	// The RocksDB storage engine does not support the restarting tests because you cannot consistently get a clean
-	// snapshot of the storage engine without a snapshotting file system.
-	// https://github.com/apple/foundationdb/issues/5155
-	if (std::string_view(testFile).find("restarting") != std::string_view::npos) {
-		testConfig.storageEngineExcludeTypes.push_back(4);
-		testConfig.storageEngineExcludeTypes.push_back(5);
-	}
-
 	// The RocksDB engine is not always built with the rest of fdbserver. Don't try to use it if it is not included
 	// in the build.
 	if (!rocksDBEnabled) {

--- a/fdbserver/fdbserver.actor.cpp
+++ b/fdbserver/fdbserver.actor.cpp
@@ -2270,6 +2270,9 @@ int main(int argc, char* argv[]) {
 				g_knobs.setKnob("encrypt_header_auth_token_algo",
 				                KnobValue::create((int)ini.GetLongValue(
 				                    "META", "encryptHeaderAuthTokenAlgo", FLOW_KNOBS->ENCRYPT_HEADER_AUTH_TOKEN_ALGO)));
+				g_knobs.setKnob(
+				    "shard_encode_location_metadata",
+				    KnobValue::create(ini.GetBoolValue("META", "enableShardEncodeLocationMetadata", false)));
 			}
 			setupAndRun(dataFolder, opts.testFile, opts.restarting, (isRestoring >= 1), opts.whitelistBinPaths);
 			g_simulator->run();

--- a/fdbserver/workloads/SaveAndKill.actor.cpp
+++ b/fdbserver/workloads/SaveAndKill.actor.cpp
@@ -84,6 +84,7 @@ struct SaveAndKillWorkload : TestWorkload {
 		ini.SetBoolValue("META", "enableTLogEncryption", SERVER_KNOBS->ENABLE_TLOG_ENCRYPTION);
 		ini.SetBoolValue("META", "enableStorageServerEncryption", SERVER_KNOBS->ENABLE_STORAGE_SERVER_ENCRYPTION);
 		ini.SetBoolValue("META", "enableBlobGranuleEncryption", SERVER_KNOBS->ENABLE_BLOB_GRANULE_ENCRYPTION);
+		ini.SetBoolValue("META", "enableShardEncodeLocationMetadata", SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA);
 
 		ini.SetBoolValue("META", "encryptHeaderAuthTokenEnabled", FLOW_KNOBS->ENCRYPT_HEADER_AUTH_TOKEN_ENABLED);
 		ini.SetLongValue("META", "encryptHeaderAuthTokenAlgo", FLOW_KNOBS->ENCRYPT_HEADER_AUTH_TOKEN_ALGO);

--- a/tests/fast/BlobGranuleMoveVerifyCycle.toml
+++ b/tests/fast/BlobGranuleMoveVerifyCycle.toml
@@ -3,7 +3,7 @@ testClass = "BlobGranule"
 blobGranulesEnabled = true 
 allowDefaultTenant = false
 # FIXME: re-enable rocks at some point
-storageEngineExcludeTypes = [4]
+# storageEngineExcludeTypes = [4]
 
 [[test]]
 testTitle = 'BlobGranuleMoveVerifyCycle'

--- a/tests/fast/BlobGranuleMoveVerifyCycle.toml
+++ b/tests/fast/BlobGranuleMoveVerifyCycle.toml
@@ -2,8 +2,6 @@
 testClass = "BlobGranule"
 blobGranulesEnabled = true 
 allowDefaultTenant = false
-# FIXME: re-enable rocks at some point
-# storageEngineExcludeTypes = [4]
 
 [[test]]
 testTitle = 'BlobGranuleMoveVerifyCycle'

--- a/tests/fast/BlobGranuleVerifyAtomicOps.toml
+++ b/tests/fast/BlobGranuleVerifyAtomicOps.toml
@@ -5,7 +5,7 @@ allowDefaultTenant = false
 injectTargetedSSRestart = true
 injectSSDelay = true
 # FIXME: re-enable rocks at some point
-storageEngineExcludeTypes = [4, 5]
+# storageEngineExcludeTypes = [4, 5]
 
 [[test]]
 testTitle = 'BlobGranuleVerifyAtomicOps'

--- a/tests/fast/BlobGranuleVerifyAtomicOps.toml
+++ b/tests/fast/BlobGranuleVerifyAtomicOps.toml
@@ -4,8 +4,6 @@ blobGranulesEnabled = true
 allowDefaultTenant = false
 injectTargetedSSRestart = true
 injectSSDelay = true
-# FIXME: re-enable rocks at some point
-# storageEngineExcludeTypes = [4, 5]
 
 [[test]]
 testTitle = 'BlobGranuleVerifyAtomicOps'

--- a/tests/fast/BlobGranuleVerifyCycle.toml
+++ b/tests/fast/BlobGranuleVerifyCycle.toml
@@ -5,7 +5,7 @@ allowDefaultTenant = false
 injectTargetedSSRestart = true
 injectSSDelay = true
 # FIXME: re-enable rocks at some point
-storageEngineExcludeTypes = [4, 5]
+# storageEngineExcludeTypes = [4, 5]
 
 [[test]]
 testTitle = 'BlobGranuleVerifyCycle'

--- a/tests/fast/BlobGranuleVerifyCycle.toml
+++ b/tests/fast/BlobGranuleVerifyCycle.toml
@@ -4,8 +4,6 @@ blobGranulesEnabled = true
 allowDefaultTenant = false
 injectTargetedSSRestart = true
 injectSSDelay = true
-# FIXME: re-enable rocks at some point
-# storageEngineExcludeTypes = [4, 5]
 
 [[test]]
 testTitle = 'BlobGranuleVerifyCycle'

--- a/tests/fast/BlobGranuleVerifySmall.toml
+++ b/tests/fast/BlobGranuleVerifySmall.toml
@@ -5,7 +5,7 @@ allowDefaultTenant = false
 injectTargetedSSRestart = true
 injectSSDelay = true
 # FIXME: re-enable rocks at some point
-storageEngineExcludeTypes = [4, 5]
+# storageEngineExcludeTypes = [4, 5]
 
 [[test]]
 testTitle = 'BlobGranuleVerifySmall'

--- a/tests/fast/BlobGranuleVerifySmall.toml
+++ b/tests/fast/BlobGranuleVerifySmall.toml
@@ -4,8 +4,6 @@ blobGranulesEnabled = true
 allowDefaultTenant = false
 injectTargetedSSRestart = true
 injectSSDelay = true
-# FIXME: re-enable rocks at some point
-# storageEngineExcludeTypes = [4, 5]
 
 [[test]]
 testTitle = 'BlobGranuleVerifySmall'

--- a/tests/fast/BlobGranuleVerifySmallClean.toml
+++ b/tests/fast/BlobGranuleVerifySmallClean.toml
@@ -2,7 +2,7 @@
 blobGranulesEnabled = true
 allowDefaultTenant = false
 # FIXME: re-enable rocks at some point
-storageEngineExcludeTypes = [4, 5]
+# storageEngineExcludeTypes = [4, 5]
 testClass = "BlobGranule"
 
 [[test]]

--- a/tests/fast/BlobGranuleVerifySmallClean.toml
+++ b/tests/fast/BlobGranuleVerifySmallClean.toml
@@ -1,8 +1,6 @@
 [configuration]
 blobGranulesEnabled = true
 allowDefaultTenant = false
-# FIXME: re-enable rocks at some point
-# storageEngineExcludeTypes = [4, 5]
 testClass = "BlobGranule"
 
 [[test]]

--- a/tests/rare/BlobGranuleRanges.toml
+++ b/tests/rare/BlobGranuleRanges.toml
@@ -3,8 +3,6 @@ blobGranulesEnabled = true
 allowDefaultTenant = false
 injectTargetedSSRestart = true
 injectSSDelay = true
-# FIXME: re-enable rocks at some point
-# storageEngineExcludeTypes = [4, 5]
 
 [[test]]
 testTitle = 'BlobGranuleRanges'

--- a/tests/rare/BlobGranuleRanges.toml
+++ b/tests/rare/BlobGranuleRanges.toml
@@ -4,7 +4,7 @@ allowDefaultTenant = false
 injectTargetedSSRestart = true
 injectSSDelay = true
 # FIXME: re-enable rocks at some point
-storageEngineExcludeTypes = [4, 5]
+# storageEngineExcludeTypes = [4, 5]
 
 [[test]]
 testTitle = 'BlobGranuleRanges'

--- a/tests/restarting/to_7.1.0_until_7.2.0/ConfigureStorageMigrationTestRestart-1.toml
+++ b/tests/restarting/to_7.1.0_until_7.2.0/ConfigureStorageMigrationTestRestart-1.toml
@@ -3,7 +3,7 @@ extraMachineCountDC = 2
 maxTLogVersion=6
 disableHostname=true
 disableEncryption=true
-storageEngineExcludeTypes=[3, 4]
+storageEngineExcludeTypes=[3, 4, 5]
 tenantModes=['disabled']
 
 [[knobs]]

--- a/tests/restarting/to_7.1.0_until_7.2.0/CycleTestRestart-1.toml
+++ b/tests/restarting/to_7.1.0_until_7.2.0/CycleTestRestart-1.toml
@@ -1,5 +1,5 @@
 [configuration]
-storageEngineExcludeTypes = [3]
+storageEngineExcludeTypes = [3, 5]
 maxTLogVersion = 6
 disableTss = true
 disableHostname = true

--- a/tests/restarting/to_7.2.0_until_7.3.0/ConfigureStorageMigrationTestRestart-1.toml
+++ b/tests/restarting/to_7.2.0_until_7.3.0/ConfigureStorageMigrationTestRestart-1.toml
@@ -6,10 +6,6 @@ disableEncryption=true
 storageEngineExcludeTypes=[4]
 tenantModes=['disabled']
 
-[[knobs]]
-# This can be removed once the lower bound of this downgrade test is a version that understands the new protocol
-shard_encode_location_metadata = false
-
 [[test]]
 testTitle = 'CloggedConfigureDatabaseTest'
 clearAfterTest = false

--- a/tests/restarting/to_7.2.0_until_7.3.0/CycleTestRestart-1.toml
+++ b/tests/restarting/to_7.2.0_until_7.3.0/CycleTestRestart-1.toml
@@ -5,10 +5,6 @@ disableHostname = true
 disableEncryption = true
 tenantModes=['disabled']
 
-[[knobs]]
-# This can be removed once the lower bound of this downgrade test is a version that understands the new protocol
-shard_encode_location_metadata = false
-
 [[test]]
 testTitle = 'Clogged'
 clearAfterTest = false

--- a/tests/restarting/to_7.3.0/ConfigureStorageMigrationTestRestart-1.toml
+++ b/tests/restarting/to_7.3.0/ConfigureStorageMigrationTestRestart-1.toml
@@ -5,10 +5,6 @@ disableHostname=true
 storageEngineExcludeTypes=[4]
 tenantModes=['disabled']
 
-[[knobs]]
-# This can be removed once the lower bound of this downgrade test is a version that understands the new protocol
-shard_encode_location_metadata = false
-
 [[test]]
 testTitle = 'CloggedConfigureDatabaseTest'
 clearAfterTest = false

--- a/tests/restarting/to_7.3.0/CycleTestRestart-1.toml
+++ b/tests/restarting/to_7.3.0/CycleTestRestart-1.toml
@@ -3,10 +3,6 @@ maxTLogVersion = 6
 disableTss = true
 disableHostname = true
 
-[[knobs]]
-# This can be removed once the lower bound of this downgrade test is a version that understands the new protocol
-shard_encode_location_metadata = false
-
 [[test]]
 testTitle = 'Clogged'
 clearAfterTest = false

--- a/tests/slow/BlobGranuleCorrectness.toml
+++ b/tests/slow/BlobGranuleCorrectness.toml
@@ -5,7 +5,7 @@ tenantModes = ['optional', 'required']
 injectTargetedSSRestart = true
 injectSSDelay = true
 # FIXME: re-enable rocks at some point
-storageEngineExcludeTypes = [4, 5]
+# storageEngineExcludeTypes = [4, 5]
 encryptModes = ['domain_aware', 'cluster_aware']
 
 [[knobs]]

--- a/tests/slow/BlobGranuleCorrectness.toml
+++ b/tests/slow/BlobGranuleCorrectness.toml
@@ -4,8 +4,6 @@ allowDefaultTenant = false
 tenantModes = ['optional', 'required']
 injectTargetedSSRestart = true
 injectSSDelay = true
-# FIXME: re-enable rocks at some point
-# storageEngineExcludeTypes = [4, 5]
 encryptModes = ['domain_aware', 'cluster_aware']
 
 [[knobs]]

--- a/tests/slow/BlobGranuleCorrectnessClean.toml
+++ b/tests/slow/BlobGranuleCorrectnessClean.toml
@@ -3,7 +3,7 @@ blobGranulesEnabled = true
 allowDefaultTenant = false
 tenantModes = ['optional', 'required']
 # FIXME: re-enable rocks at some point
-storageEngineExcludeTypes = [4, 5]
+# storageEngineExcludeTypes = [4, 5]
 encryptModes = ['domain_aware', 'cluster_aware']
 
 [[knobs]]

--- a/tests/slow/BlobGranuleCorrectnessClean.toml
+++ b/tests/slow/BlobGranuleCorrectnessClean.toml
@@ -2,8 +2,6 @@
 blobGranulesEnabled = true 
 allowDefaultTenant = false
 tenantModes = ['optional', 'required']
-# FIXME: re-enable rocks at some point
-# storageEngineExcludeTypes = [4, 5]
 encryptModes = ['domain_aware', 'cluster_aware']
 
 [[knobs]]

--- a/tests/slow/BlobGranuleVerifyBalance.toml
+++ b/tests/slow/BlobGranuleVerifyBalance.toml
@@ -3,8 +3,6 @@ blobGranulesEnabled = true
 allowDefaultTenant = false
 injectTargetedSSRestart = true
 injectSSDelay = true
-# FIXME: re-enable rocks at some point
-# storageEngineExcludeTypes = [4, 5]
 
 [[test]]
 testTitle = 'BlobGranuleVerifyBalance'

--- a/tests/slow/BlobGranuleVerifyBalance.toml
+++ b/tests/slow/BlobGranuleVerifyBalance.toml
@@ -4,7 +4,7 @@ allowDefaultTenant = false
 injectTargetedSSRestart = true
 injectSSDelay = true
 # FIXME: re-enable rocks at some point
-storageEngineExcludeTypes = [4, 5]
+# storageEngineExcludeTypes = [4, 5]
 
 [[test]]
 testTitle = 'BlobGranuleVerifyBalance'

--- a/tests/slow/BlobGranuleVerifyBalanceClean.toml
+++ b/tests/slow/BlobGranuleVerifyBalanceClean.toml
@@ -1,8 +1,6 @@
 [configuration]
 blobGranulesEnabled = true
 allowDefaultTenant = false
-# FIXME: re-enable rocks at some point
-# storageEngineExcludeTypes = [4, 5]
 
 [[test]]
 testTitle = 'BlobGranuleVerifyBalanceClean'

--- a/tests/slow/BlobGranuleVerifyBalanceClean.toml
+++ b/tests/slow/BlobGranuleVerifyBalanceClean.toml
@@ -2,7 +2,7 @@
 blobGranulesEnabled = true
 allowDefaultTenant = false
 # FIXME: re-enable rocks at some point
-storageEngineExcludeTypes = [4, 5]
+# storageEngineExcludeTypes = [4, 5]
 
 [[test]]
 testTitle = 'BlobGranuleVerifyBalanceClean'

--- a/tests/slow/BlobGranuleVerifyLarge.toml
+++ b/tests/slow/BlobGranuleVerifyLarge.toml
@@ -3,8 +3,6 @@ blobGranulesEnabled = true
 allowDefaultTenant = false
 injectTargetedSSRestart = true
 injectSSDelay = true
-# FIXME: re-enable rocks at some point
-# storageEngineExcludeTypes = [4, 5]
 
 [[test]]
 testTitle = 'BlobGranuleVerifyLarge'

--- a/tests/slow/BlobGranuleVerifyLarge.toml
+++ b/tests/slow/BlobGranuleVerifyLarge.toml
@@ -4,7 +4,7 @@ allowDefaultTenant = false
 injectTargetedSSRestart = true
 injectSSDelay = true
 # FIXME: re-enable rocks at some point
-storageEngineExcludeTypes = [4, 5]
+# storageEngineExcludeTypes = [4, 5]
 
 [[test]]
 testTitle = 'BlobGranuleVerifyLarge'

--- a/tests/slow/BlobGranuleVerifyLargeClean.toml
+++ b/tests/slow/BlobGranuleVerifyLargeClean.toml
@@ -2,7 +2,7 @@
 blobGranulesEnabled = true 
 allowDefaultTenant = false
 # FIXME: re-enable rocks at some point
-storageEngineExcludeTypes = [4, 5]
+# storageEngineExcludeTypes = [4, 5]
 
 [[test]]
 testTitle = 'BlobGranuleVerifyLargeClean'

--- a/tests/slow/BlobGranuleVerifyLargeClean.toml
+++ b/tests/slow/BlobGranuleVerifyLargeClean.toml
@@ -1,8 +1,6 @@
 [configuration]
 blobGranulesEnabled = true 
 allowDefaultTenant = false
-# FIXME: re-enable rocks at some point
-# storageEngineExcludeTypes = [4, 5]
 
 [[test]]
 testTitle = 'BlobGranuleVerifyLargeClean'


### PR DESCRIPTION
Disable sharded rocks storage for downgrade tests where we need to keep knob "shard_encode_location_metadata" so that downgrade tests can pass the second phase.

If sharded rocks is used in part 1, then `shard_encode_location_metadata` has to be set in part-2.

20230214-040949-jzhou-b418b49ed351b9e7

```
-f tests/fast/AtomicBackupCorrectness.toml -s 656346199 -b on
-f tests/fast/FuzzApiCorrectnessClean.toml -s 2066162177 -b on
```

20230214-183911-jzhou-ad9829c30fc9d965 restarting tests only
```
-f tests/restarting/from_7.2.0/DrUpgradeRestart-1.toml -s 2771988862 -b on
-f tests/restarting/from_7.2.0/DrUpgradeRestart-2.toml --restarting -s 2771988863 -b on (OOM)
```

20230214-213555-jzhou-f3198b8626f11838

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
