### PR TITLE
[snowflake/release-71.2] Fix BlobGranuleCorrectness.toml undefined behavior in mergeDeltaStreams

### DIFF
--- a/fdbclient/BlobGranuleFiles.cpp
+++ b/fdbclient/BlobGranuleFiles.cpp
@@ -1376,6 +1376,10 @@ static RangeResult mergeDeltaStreams(const BlobGranuleChunkRef& chunk,
 	ASSERT(streams.size() < std::numeric_limits<int16_t>::max());
 	ASSERT(startClears.size() == streams.size());
 
+	if (streams.empty()) {
+		return RangeResult{};
+	}
+
 	int prefixLen = commonPrefixLength(chunk.keyRange.begin, chunk.keyRange.end);
 
 	// next element for each stream


### PR DESCRIPTION
Cherry-pick #9059

I think ubsan tests had been broken on the release-71.2 nightlies, since this fix was made in december on main and only now showed up on the release branch.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
