### PR TITLE
Fix manifest file list issue on s3

### DIFF
--- a/fdbserver/BlobManifest.actor.cpp
+++ b/fdbserver/BlobManifest.actor.cpp
@@ -97,7 +97,7 @@ struct BlobManifestFile {
 			BlobManifestFile file(path);
 			return file.epoch > 0 && file.seqNo > 0 && file.segmentNo > 0;
 		};
-		BackupContainerFileSystem::FilesAndSizesT filesAndSizes = wait(reader->listFiles("/", filter));
+		BackupContainerFileSystem::FilesAndSizesT filesAndSizes = wait(reader->listFiles("", filter));
 
 		std::vector<BlobManifestFile> result;
 		for (auto& f : filesAndSizes) {
@@ -425,7 +425,7 @@ private:
 	ACTOR static Future<Void> cleanup(Reference<BlobManifestDumper> self) {
 		state Reference<BackupContainerFileSystem> writer;
 		state std::string fullPath;
-		std::tie(writer, fullPath) = self->blobConn_->createForWrite(MANIFEST);
+		std::tie(writer, fullPath) = self->blobConn_->createForWrite("");
 
 		loop {
 			state std::vector<BlobManifestFile> allFiles = wait(BlobManifestFile::listAll(writer));
@@ -537,7 +537,7 @@ public:
 
 	// Return max epoch from all manifest files
 	ACTOR static Future<int64_t> lastBlobEpoc(Reference<BlobManifestLoader> self) {
-		state Reference<BackupContainerFileSystem> container = self->blobConn_->getForRead(MANIFEST);
+		state Reference<BackupContainerFileSystem> container = self->blobConn_->getForRead("");
 		std::vector<BlobManifestFile> files = wait(BlobManifestFile::listAll(container));
 		ASSERT(!files.empty());
 		return files.front().epoch;
@@ -546,7 +546,7 @@ public:
 private:
 	// Load latest manifest to system space
 	ACTOR static Future<Void> load(Reference<BlobManifestLoader> self) {
-		state Reference<BackupContainerFileSystem> container = self->blobConn_->getForRead(MANIFEST);
+		state Reference<BackupContainerFileSystem> container = self->blobConn_->getForRead("");
 		std::vector<BlobManifestFile> files = wait(BlobManifestFile::listAll(container));
 
 		// Load tailer


### PR DESCRIPTION
A few caller for BackupContainerFileSystem need to be adjusted for S3. The implementation for local directory and S3 are not consistent.

Tested ok with 100K BlobRestoreCorrectness tests

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
