### PR TITLE
Enable rocksdb in simulation in 7.1. Exclude FuzzApi and HighContention tests temporarily for rocksdb.

### DIFF
--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -1369,9 +1369,7 @@ void SimulationConfig::setDatacenters(const TestConfig& testConfig) {
 
 // Sets storage engine based on testConfig details
 void SimulationConfig::setStorageEngine(const TestConfig& testConfig) {
-	// Using [0, 4) to disable the RocksDB storage engine.
-	// TODO: Figure out what is broken with the RocksDB engine in simulation.
-	int storage_engine_type = deterministicRandom()->randomInt(0, 4);
+	int storage_engine_type = deterministicRandom()->randomInt(0, 5);
 	if (testConfig.storageEngineType.present()) {
 		storage_engine_type = testConfig.storageEngineType.get();
 	} else {

--- a/tests/fast/FuzzApiCorrectness.toml
+++ b/tests/fast/FuzzApiCorrectness.toml
@@ -2,6 +2,8 @@
 StderrSeverity = 30
 allowDisablingTenants = false
 allowDefaultTenant = false
+# FIXME: re-enable rocks at some point
+storageEngineExcludeTypes = [4]
 
 [[test]]
 testTitle = 'FuzzApiCorrectness'

--- a/tests/fast/FuzzApiCorrectnessClean.toml
+++ b/tests/fast/FuzzApiCorrectnessClean.toml
@@ -2,6 +2,8 @@
 StderrSeverity = 30
 allowDisablingTenants = false
 allowDefaultTenant = false
+# FIXME: re-enable rocks at some point
+storageEngineExcludeTypes = [4]
 
 [[test]]
 testTitle = 'FuzzApiCorrectness'

--- a/tests/rare/HighContentionPrefixAllocator.toml
+++ b/tests/rare/HighContentionPrefixAllocator.toml
@@ -1,3 +1,7 @@
+[configuration]
+# FIXME: re-enable rocks at some point
+storageEngineExcludeTypes = [4]
+
 [[test]]
 testTitle = 'HighContentionPrefixAllocator'
 


### PR DESCRIPTION
Enable rocksdb in simulation in 7.1. Exclude FuzzApi and HighContention tests temporarily for rocksdb.


Replace this text with your description here...

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
