### PR TITLE
Fix exclusion in repairDeadDatacenter to be remote only [release-7.2]

### DIFF
--- a/fdbserver/QuietDatabase.actor.cpp
+++ b/fdbserver/QuietDatabase.actor.cpp
@@ -658,7 +658,7 @@ ACTOR Future<Void> repairDeadDatacenter(Database cx,
                                         std::string context) {
 	if (g_network->isSimulated() && g_simulator->usableRegions > 1 && !g_simulator->quiesced) {
 		state bool primaryDead = g_simulator->datacenterDead(g_simulator->primaryDcId);
-		bool remoteDead = g_simulator->datacenterDead(g_simulator->remoteDcId);
+		state bool remoteDead = g_simulator->datacenterDead(g_simulator->remoteDcId);
 
 		// FIXME: the primary and remote can both be considered dead because excludes are not handled properly by the
 		// datacenterDead function
@@ -667,22 +667,22 @@ ACTOR Future<Void> repairDeadDatacenter(Database cx,
 			return Void();
 		}
 		if (primaryDead || remoteDead) {
+			if (remoteDead) {
+				std::vector<AddressExclusion> servers =
+				    g_simulator->getAllAddressesInDCToExclude(g_simulator->remoteDcId);
+				TraceEvent(SevWarnAlways, "DisablingFearlessConfiguration")
+				    .detail("Location", context)
+				    .detail("Stage", "ExcludeServers")
+				    .detail("Servers", describe(servers));
+				wait(excludeServers(cx, servers, false));
+			}
+
 			TraceEvent(SevWarnAlways, "DisablingFearlessConfiguration")
 			    .detail("Location", context)
 			    .detail("Stage", "Repopulate")
 			    .detail("RemoteDead", remoteDead)
 			    .detail("PrimaryDead", primaryDead);
 			g_simulator->usableRegions = 1;
-
-			if (remoteDead) {
-				state std::vector<AddressExclusion> servers =
-				    g_simulator->getAllAddressesInDCToExclude(g_simulator->remoteDcId);
-				wait(excludeServers(cx, servers, false));
-				TraceEvent(SevWarnAlways, "DisablingFearlessConfiguration")
-				    .detail("Location", context)
-				    .detail("Stage", "ServerExcluded")
-				    .detail("Servers", describe(servers));
-			}
 
 			wait(success(ManagementAPI::changeConfig(
 			    cx.getReference(),

--- a/fdbserver/QuietDatabase.actor.cpp
+++ b/fdbserver/QuietDatabase.actor.cpp
@@ -674,13 +674,15 @@ ACTOR Future<Void> repairDeadDatacenter(Database cx,
 			    .detail("PrimaryDead", primaryDead);
 			g_simulator->usableRegions = 1;
 
-			state std::vector<AddressExclusion> servers = g_simulator->getAllAddressesInDCToExclude(
-			    primaryDead ? g_simulator->primaryDcId : g_simulator->remoteDcId);
-			wait(excludeServers(cx, servers, false));
-			TraceEvent(SevWarnAlways, "DisablingFearlessConfiguration")
-			    .detail("Location", context)
-			    .detail("Stage", "ServerExcluded")
-			    .detail("Servers", describe(servers));
+			if (remoteDead) {
+				state std::vector<AddressExclusion> servers =
+				    g_simulator->getAllAddressesInDCToExclude(g_simulator->remoteDcId);
+				wait(excludeServers(cx, servers, false));
+				TraceEvent(SevWarnAlways, "DisablingFearlessConfiguration")
+				    .detail("Location", context)
+				    .detail("Stage", "ServerExcluded")
+				    .detail("Servers", describe(servers));
+			}
 
 			wait(success(ManagementAPI::changeConfig(
 			    cx.getReference(),

--- a/fdbserver/workloads/SkewedReadWrite.actor.cpp
+++ b/fdbserver/workloads/SkewedReadWrite.actor.cpp
@@ -99,21 +99,26 @@ struct SkewedReadWriteWorkload : ReadWriteCommon {
 	}
 
 	ACTOR static Future<Void> updateServerShards(Database cx, SkewedReadWriteWorkload* self) {
-		state Future<RangeResult> serverList =
-		    runRYWTransaction(cx, [](Reference<ReadYourWritesTransaction> tr) -> Future<RangeResult> {
-			    tr->setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
-			    return tr->getRange(serverListKeys, CLIENT_KNOBS->TOO_MANY);
-		    });
-		state RangeResult range =
-		    wait(runRYWTransaction(cx, [](Reference<ReadYourWritesTransaction> tr) -> Future<RangeResult> {
-			    tr->setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
-			    return tr->getRange(serverKeysRange, CLIENT_KNOBS->TOO_MANY);
-		    }));
-		wait(success(serverList));
+		state RangeResult serverList;
+		state RangeResult range;
+		state Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
+		loop {
+			// read in transaction to ensure two key ranges are transactionally consistent
+			try {
+				tr->setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
+				state Future<RangeResult> serverListF = tr->getRange(serverListKeys, CLIENT_KNOBS->TOO_MANY);
+				state Future<RangeResult> rangeF = tr->getRange(serverKeysRange, CLIENT_KNOBS->TOO_MANY);
+				wait(store(serverList, serverListF));
+				wait(store(range, rangeF));
+				break;
+			} catch (Error& e) {
+				wait(tr->onError(e));
+			}
+		}
 		// decode server interfaces
 		self->serverInterfaces.clear();
-		for (int i = 0; i < serverList.get().size(); i++) {
-			auto ssi = decodeServerListValue(serverList.get()[i].value);
+		for (int i = 0; i < serverList.size(); i++) {
+			auto ssi = decodeServerListValue(serverList[i].value);
 			self->serverInterfaces.emplace(ssi.id(), ssi);
 		}
 		// clear self->serverShards


### PR DESCRIPTION
cherrypick #9388 #9274

If primary is excluded, the recovery will become stuck because no servers can be recruited in the next time, i.e., stuck in the `recruiting_transaction_servers` state.

20230215-181043-jzhou-04396677dee49560

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
