### PR TITLE
Fix exclusion in repairDeadDatacenter to be remote only

### DIFF
--- a/fdbserver/QuietDatabase.actor.cpp
+++ b/fdbserver/QuietDatabase.actor.cpp
@@ -715,7 +715,7 @@ ACTOR Future<Void> repairDeadDatacenter(Database cx,
                                         std::string context) {
 	if (g_network->isSimulated() && g_simulator->usableRegions > 1 && !g_simulator->quiesced) {
 		state bool primaryDead = g_simulator->datacenterDead(g_simulator->primaryDcId);
-		bool remoteDead = g_simulator->datacenterDead(g_simulator->remoteDcId);
+		state bool remoteDead = g_simulator->datacenterDead(g_simulator->remoteDcId);
 
 		// FIXME: the primary and remote can both be considered dead because excludes are not handled properly by the
 		// datacenterDead function
@@ -724,22 +724,22 @@ ACTOR Future<Void> repairDeadDatacenter(Database cx,
 			return Void();
 		}
 		if (primaryDead || remoteDead) {
+			if (remoteDead) {
+				std::vector<AddressExclusion> servers =
+				    g_simulator->getAllAddressesInDCToExclude(g_simulator->remoteDcId);
+				TraceEvent(SevWarnAlways, "DisablingFearlessConfiguration")
+				    .detail("Location", context)
+				    .detail("Stage", "ExcludeServers")
+				    .detail("Servers", describe(servers));
+				wait(excludeServers(cx, servers, false));
+			}
+
 			TraceEvent(SevWarnAlways, "DisablingFearlessConfiguration")
 			    .detail("Location", context)
 			    .detail("Stage", "Repopulate")
 			    .detail("RemoteDead", remoteDead)
 			    .detail("PrimaryDead", primaryDead);
 			g_simulator->usableRegions = 1;
-
-			if (remoteDead) {
-				state std::vector<AddressExclusion> servers =
-				    g_simulator->getAllAddressesInDCToExclude(g_simulator->remoteDcId);
-				wait(excludeServers(cx, servers, false));
-				TraceEvent(SevWarnAlways, "DisablingFearlessConfiguration")
-				    .detail("Location", context)
-				    .detail("Stage", "ServerExcluded")
-				    .detail("Servers", describe(servers));
-			}
 
 			wait(success(ManagementAPI::changeConfig(
 			    cx.getReference(),

--- a/fdbserver/QuietDatabase.actor.cpp
+++ b/fdbserver/QuietDatabase.actor.cpp
@@ -731,13 +731,15 @@ ACTOR Future<Void> repairDeadDatacenter(Database cx,
 			    .detail("PrimaryDead", primaryDead);
 			g_simulator->usableRegions = 1;
 
-			state std::vector<AddressExclusion> servers = g_simulator->getAllAddressesInDCToExclude(
-			    primaryDead ? g_simulator->primaryDcId : g_simulator->remoteDcId);
-			wait(excludeServers(cx, servers, false));
-			TraceEvent(SevWarnAlways, "DisablingFearlessConfiguration")
-			    .detail("Location", context)
-			    .detail("Stage", "ServerExcluded")
-			    .detail("Servers", describe(servers));
+			if (remoteDead) {
+				state std::vector<AddressExclusion> servers =
+				    g_simulator->getAllAddressesInDCToExclude(g_simulator->remoteDcId);
+				wait(excludeServers(cx, servers, false));
+				TraceEvent(SevWarnAlways, "DisablingFearlessConfiguration")
+				    .detail("Location", context)
+				    .detail("Stage", "ServerExcluded")
+				    .detail("Servers", describe(servers));
+			}
 
 			wait(success(ManagementAPI::changeConfig(
 			    cx.getReference(),


### PR DESCRIPTION
If primary is excluded, the recovery will become stuck because no servers can be recruited in the next time, i.e., stuck in the `recruiting_transaction_servers` state.

Testing done in #9385

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
