### PR TITLE
When clearing the database after a test, delete all tenants except the default tenant

### DIFF
--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -871,7 +871,7 @@ ACTOR Future<Void> testerServerCore(TesterInterface interf,
 	}
 }
 
-ACTOR Future<Void> clearData(Database cx) {
+ACTOR Future<Void> clearData(Database cx, Optional<TenantName> defaultTenant) {
 	state Transaction tr(cx);
 	state UID debugID = debugRandom()->randomUniqueID();
 	tr.debugTransaction(debugID);
@@ -893,6 +893,41 @@ ACTOR Future<Void> clearData(Database cx) {
 			wait(tr.onError(e));
 			debugID = debugRandom()->randomUniqueID();
 			tr.debugTransaction(debugID);
+		}
+	}
+
+	tr = Transaction(cx);
+	loop {
+		try {
+			TraceEvent("TesterClearingTenantsStart", debugID);
+			state KeyBackedRangeResult<std::pair<int64_t, TenantMapEntry>> tenants =
+			    wait(TenantMetadata::tenantMap().getRange(&tr, {}, {}, 1000));
+
+			TraceEvent("TesterClearingTenantsDeletingBatch", debugID)
+			    .detail("FirstTenant", tenants.results.empty() ? "<none>"_sr : tenants.results[0].second.tenantName)
+			    .detail("BatchSize", tenants.results.size());
+
+			std::vector<Future<Void>> deleteFutures;
+			for (auto const& [id, entry] : tenants.results) {
+				if (entry.tenantName != defaultTenant) {
+					deleteFutures.push_back(TenantAPI::deleteTenantTransaction(&tr, id));
+				}
+			}
+
+			wait(waitForAll(deleteFutures));
+			wait(tr.commit());
+
+			TraceEvent("TesterClearingTenantsDeletedBatch", debugID)
+			    .detail("FirstTenant", tenants.results.empty() ? "<none>"_sr : tenants.results[0].second.tenantName)
+			    .detail("BatchSize", tenants.results.size());
+
+			if (!tenants.more) {
+				TraceEvent("TesterClearingTenantsComplete", debugID).detail("AtVersion", tr.getCommittedVersion());
+				break;
+			}
+		} catch (Error& e) {
+			TraceEvent(SevWarn, "TesterClearingTenantsError", debugID).error(e);
+			wait(tr.onError(e));
 		}
 	}
 
@@ -1300,7 +1335,7 @@ ACTOR Future<bool> runTest(Database cx,
 	if (spec.useDB && spec.clearAfterTest) {
 		try {
 			TraceEvent("TesterClearingDatabase").log();
-			wait(timeoutError(clearData(cx), 1000.0));
+			wait(timeoutError(clearData(cx, defaultTenant), 1000.0));
 		} catch (Error& e) {
 			TraceEvent(SevError, "ErrorClearingDatabaseAfterTest").error(e);
 			throw; // If we didn't do this, we don't want any later tests to run on this DB

--- a/tests/fast/AuthzSecurity.toml
+++ b/tests/fast/AuthzSecurity.toml
@@ -8,6 +8,7 @@ max_trace_lines = 2000000
 
 [[test]]
 testTitle = 'TenantCreation'
+clearAfterTest = false
 
     [[test.workload]]
     testName = 'CreateTenant'

--- a/tests/fast/GetEstimatedRangeSize.toml
+++ b/tests/fast/GetEstimatedRangeSize.toml
@@ -4,6 +4,7 @@ tenantModes = ['optional', 'required']
 
 [[test]]
 testTitle = 'TenantCreation'
+clearAfterTest = false
 
     [[test.workload]]
     testName = 'CreateTenant'

--- a/tests/fast/RawTenantAccessClean.toml
+++ b/tests/fast/RawTenantAccessClean.toml
@@ -8,7 +8,6 @@ proxy_use_resolver_private_mutations = false
 
 [[test]]
 testTitle = 'RawTenantAccessClean'
-clearAfterTest = false
 runSetup = true
 
     [[test.workload]]

--- a/tests/fast/TenantCycle.toml
+++ b/tests/fast/TenantCycle.toml
@@ -8,6 +8,7 @@ max_trace_lines = 2000000
 
 [[test]]
 testTitle = 'TenantCreation'
+clearAfterTest = false
 
     [[test.workload]]
     testName = 'CreateTenant'

--- a/tests/fast/TenantCycleTokenless.toml
+++ b/tests/fast/TenantCycleTokenless.toml
@@ -9,6 +9,7 @@ max_trace_lines = 2000000
 
 [[test]]
 testTitle = 'TenantCreation'
+clearAfterTest = false
 
     [[test.workload]]
     testName = 'CreateTenant'

--- a/tests/rare/StorageQuotaTest.toml
+++ b/tests/rare/StorageQuotaTest.toml
@@ -4,6 +4,7 @@ tenantModes = ['optional', 'required']
 
 [[test]]
 testTitle = 'TenantCreation'
+clearAfterTest = false
 
     [[test.workload]]
     testName = 'CreateTenant'


### PR DESCRIPTION
This allows the clear database check that reads the entire database to complete without having to scan a lot of shards

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
