### PR TITLE
adding version metadata to blob granule file pointers

### DIFF
--- a/bindings/c/fdb_c.cpp
+++ b/bindings/c/fdb_c.cpp
@@ -386,8 +386,7 @@ void setBlobFilePointer(FDBBGFilePointer* dest, const BlobFilePointerRef& source
 	dest->file_offset = source.offset;
 	dest->file_length = source.length;
 	dest->full_file_length = source.fullFileLength;
-	// FIXME: add version info to each source file pointer
-	dest->file_version = 0;
+	dest->file_version = source.fileVersion;
 
 	// handle encryption
 	if (source.cipherKeysCtx.present()) {

--- a/bindings/c/test/fdb_api.hpp
+++ b/bindings/c/test/fdb_api.hpp
@@ -86,6 +86,7 @@ struct GranuleFilePointer {
 	int64_t offset;
 	int64_t length;
 	int64_t fullFileLength;
+	int64_t fileVersion;
 
 	// just keep raw data structures to pass to callbacks
 	native::FDBBGEncryptionCtx encryptionCtx;
@@ -95,6 +96,7 @@ struct GranuleFilePointer {
 		offset = nativePointer.file_offset;
 		length = nativePointer.file_length;
 		fullFileLength = nativePointer.full_file_length;
+		fileVersion = nativePointer.file_version;
 		encryptionCtx = nativePointer.encryption_ctx;
 	}
 };

--- a/fdbserver/BlobGranuleServerCommon.actor.cpp
+++ b/fdbserver/BlobGranuleServerCommon.actor.cpp
@@ -209,6 +209,7 @@ void GranuleFiles::getFiles(Version beginVersion,
 		                       snapshotF->offset,
 		                       snapshotF->length,
 		                       snapshotF->fullFileLength,
+		                       snapshotF->version,
 		                       summarize ? Optional<BlobGranuleCipherKeysMeta>() : snapshotF->cipherKeysMeta);
 		lastIncluded = chunk.snapshotVersion;
 	} else {
@@ -221,6 +222,7 @@ void GranuleFiles::getFiles(Version beginVersion,
 		                                   deltaF->offset,
 		                                   deltaF->length,
 		                                   deltaF->fullFileLength,
+		                                   deltaF->version,
 		                                   summarize ? Optional<BlobGranuleCipherKeysMeta>() : deltaF->cipherKeysMeta);
 		deltaBytesCounter += deltaF->length;
 		ASSERT(lastIncluded < deltaF->version);
@@ -235,6 +237,7 @@ void GranuleFiles::getFiles(Version beginVersion,
 		                                   deltaF->offset,
 		                                   deltaF->length,
 		                                   deltaF->fullFileLength,
+		                                   deltaF->version,
 		                                   deltaF->cipherKeysMeta);
 		deltaBytesCounter += deltaF->length;
 		lastIncluded = deltaF->version;

--- a/fdbserver/BlobWorker.actor.cpp
+++ b/fdbserver/BlobWorker.actor.cpp
@@ -1401,6 +1401,7 @@ ACTOR Future<BlobFileIndex> compactFromBlob(Reference<BlobWorkerData> bwData,
 		                                        snapshotF.offset,
 		                                        snapshotF.length,
 		                                        snapshotF.fullFileLength,
+		                                        snapshotF.version,
 		                                        snapCipherKeysCtx);
 
 		compactBytesRead += snapshotF.length;
@@ -1432,6 +1433,7 @@ ACTOR Future<BlobFileIndex> compactFromBlob(Reference<BlobWorkerData> bwData,
 			                                   deltaF.offset,
 			                                   deltaF.length,
 			                                   deltaF.fullFileLength,
+			                                   deltaF.version,
 			                                   deltaCipherKeysCtx);
 			compactBytesRead += deltaF.length;
 			lastDeltaVersion = files.deltaFiles[deltaIdx].version;


### PR DESCRIPTION
Addressing fixme in new blob granule files client and native code.

Passes 1k BlobGranule* correctness, 10k /blobgranule/files unit tests, and the client api tests.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
