### PR TITLE
Adds more detailed mutation logging to commit proxy

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -540,6 +540,9 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	bool buggfyUseResolverPrivateMutations = randomize && BUGGIFY && !ENABLE_VERSION_VECTOR_TLOG_UNICAST;
 	init( PROXY_USE_RESOLVER_PRIVATE_MUTATIONS,                 false ); if( buggfyUseResolverPrivateMutations ) PROXY_USE_RESOLVER_PRIVATE_MUTATIONS = deterministicRandom()->coinflip();
 
+	init( BURSTINESS_METRICS_ENABLED  ,                         false );
+	init( BURSTINESS_METRICS_LOG_INTERVAL,                        0.1 );
+
 	init( RESET_MASTER_BATCHES,                                   200 );
 	init( RESET_RESOLVER_BATCHES,                                 200 );
 	init( RESET_MASTER_DELAY,                                   300.0 );

--- a/fdbclient/include/fdbclient/ServerKnobs.h
+++ b/fdbclient/include/fdbclient/ServerKnobs.h
@@ -446,6 +446,10 @@ public:
 	double REPORT_TRANSACTION_COST_ESTIMATION_DELAY;
 	bool PROXY_REJECT_BATCH_QUEUED_TOO_LONG;
 	bool PROXY_USE_RESOLVER_PRIVATE_MUTATIONS;
+	bool BURSTINESS_METRICS_ENABLED;
+	// Interval on which to emit burstiness metrics on the commit proxy (in
+	// seconds).
+	double BURSTINESS_METRICS_LOG_INTERVAL;
 
 	int RESET_MASTER_BATCHES;
 	int RESET_RESOLVER_BATCHES;

--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -419,6 +419,7 @@ ACTOR Future<Void> commitBatcher(ProxyCommitData* commitData,
 					}
 
 					++commitData->stats.txnCommitIn;
+					commitData->stats.uniqueClients.insert(req.reply.getEndpoint().getPrimaryAddress());
 
 					if (req.debugID.present()) {
 						g_traceBatch.addEvent("CommitDebug", req.debugID.get().first(), "CommitProxyServer.batcher");
@@ -3489,6 +3490,66 @@ ACTOR Future<Void> processTransactionStateRequestPart(TransactionStateResolveCon
 
 } // anonymous namespace
 
+//
+// Metrics related to the commit proxy are logged on a five second interval in
+// the `ProxyMetrics` trace. However, it can be hard to determine workload
+// burstiness when looking at such a large time range. This function adds much
+// more frequent logging for certain metrics to provide fine-grained insight
+// into workload patterns. The metrics logged by this function break down into
+// two categories:
+//
+//   * existing counters reported by `ProxyMetrics`
+//   * new counters that are only reported by this function
+//
+// Neither is implemented optimally, but the data collected should be helpful
+// in identifying workload patterns on the server.
+//
+// Metrics reporting by this function can be disabled by setting the
+// `BURSTINESS_METRICS_ENABLED` knob to false. The reporting interval can be
+// adjusted by modifying the knob `BURSTINESS_METRICS_LOG_INTERVAL`.
+//
+ACTOR Future<Void> logDetailedMetrics(ProxyCommitData* commitData) {
+	state double startTime = 0;
+	state int64_t commitBatchInBaseline = 0;
+	state int64_t txnCommitInBaseline = 0;
+	state int64_t mutationsBaseline = 0;
+	state int64_t mutationBytesBaseline = 0;
+
+	loop {
+		if (!SERVER_KNOBS->BURSTINESS_METRICS_ENABLED) {
+			return Void();
+		}
+
+		startTime = now();
+		commitBatchInBaseline = commitData->stats.commitBatchIn.getValue();
+		txnCommitInBaseline = commitData->stats.txnCommitIn.getValue();
+		mutationsBaseline = commitData->stats.mutations.getValue();
+		mutationBytesBaseline = commitData->stats.mutationBytes.getValue();
+
+		wait(delay(SERVER_KNOBS->BURSTINESS_METRICS_LOG_INTERVAL));
+
+		int64_t commitBatchInReal = commitData->stats.commitBatchIn.getValue();
+		int64_t txnCommitInReal = commitData->stats.txnCommitIn.getValue();
+		int64_t mutationsReal = commitData->stats.mutations.getValue();
+		int64_t mutationBytesReal = commitData->stats.mutationBytes.getValue();
+
+		// Don't log anything if any of the counters got reset during the wait
+		// interval. Assume that typically all the counters get reset at once.
+		if (commitBatchInReal < commitBatchInBaseline || txnCommitInReal < txnCommitInBaseline ||
+		    mutationsReal < mutationsBaseline || mutationBytesReal < mutationBytesBaseline) {
+			continue;
+		}
+
+		TraceEvent("ProxyDetailedMetrics")
+		    .detail("Elapsed", now() - startTime)
+		    .detail("CommitBatchIn", commitBatchInReal - commitBatchInBaseline)
+		    .detail("TxnCommitIn", txnCommitInReal - txnCommitInBaseline)
+		    .detail("Mutations", mutationsReal - mutationsBaseline)
+		    .detail("MutationBytes", mutationBytesReal - mutationBytesBaseline)
+		    .detail("UniqueClients", commitData->stats.getSizeAndResetUniqueClients());
+	}
+}
+
 ACTOR Future<Void> commitProxyServerCore(CommitProxyInterface proxy,
                                          MasterInterface master,
                                          LifetimeToken masterLifetime,
@@ -3580,6 +3641,7 @@ ACTOR Future<Void> commitProxyServerCore(CommitProxyInterface proxy,
 	addActor.send(rejoinServer(proxy, &commitData));
 	addActor.send(ddMetricsRequestServer(proxy, db));
 	addActor.send(reportTxnTagCommitCost(proxy.id(), db, &commitData.ssTrTagCommitCost));
+	addActor.send(logDetailedMetrics(&commitData));
 
 	auto openDb = openDBOnServer(db);
 

--- a/fdbserver/include/fdbserver/ProxyCommitData.actor.h
+++ b/fdbserver/include/fdbserver/ProxyCommitData.actor.h
@@ -93,6 +93,12 @@ struct ProxyStats {
 	Reference<Histogram> tlogLoggingDist;
 	Reference<Histogram> replyCommitDist;
 
+	// These metrics are only logged as part of `ProxyDetailedMetrics`. Since
+	// the detailed proxy metrics combine data from different sources, we can't
+	// use a `Counter` along with a `CounterCollection` here, and instead have
+	// to reimplement the basic functionality.
+	std::unordered_set<NetworkAddress> uniqueClients;
+
 	int64_t getAndResetMaxCompute() {
 		int64_t r = maxComputeNS;
 		maxComputeNS = 0;
@@ -102,6 +108,12 @@ struct ProxyStats {
 	int64_t getAndResetMinCompute() {
 		int64_t r = minComputeNS;
 		minComputeNS = 1e12;
+		return r;
+	}
+
+	int64_t getSizeAndResetUniqueClients() {
+		int64_t r = uniqueClients.size();
+		uniqueClients.clear();
 		return r;
 	}
 


### PR DESCRIPTION
The commit proxy writes a `ProxyMetrics` trace every 5 seconds. This event contains a lot of useful information, such as the number of commit batches that arrived and exited, the number of mutations processed, the number of bytes those mutations made up, etc.. However, it is difficult to tell what the workload pattern looks like within these 5 second intervals when the metrics are being calculated.

This PR adds a new trace, `ProxyDetailedMetrics`, which logs itself every 100ms. It currently only writes the number of mutations and the number of mutation bytes that arrived during the 100ms time period. But it should be easy to add more metrics in the future.

It's possible this increased logging could cause issues. Based off a simulation run of the `WriteDuringRead` test, I got the following results:

```
$ rg ProxyDetailedMetrics trace.json | wc -l
    6877
$ rg "Roles\": \".*CP.*\"" trace.json | wc -l
   11402
$ wc -l trace.json
   96147 trace.json
```

So on processes running as a commit proxy, this approximately doubled the number of lines logged. But relative to the cluster overall, it only added about 5% overhead.

If we want to reduce this number, one possibility would be to not write a trace if all the values being written are 0. I'm not sure if this would help much in production, but in simulation the large majority of the traces (99%+) consist of zero values.

Replace this text with your description here...

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
