### PR TITLE
Disable client memory wipe test for all XSAN builds

### DIFF
--- a/flow/Arena.cpp
+++ b/flow/Arena.cpp
@@ -22,6 +22,8 @@
 
 #include "flow/UnitTest.h"
 
+#include "flow/config.h"
+
 // We don't align memory properly, and we need to tell lsan about that.
 extern "C" const char* __lsan_default_options(void) {
 	return "use_unaligned=1";
@@ -998,7 +1000,7 @@ TEST_CASE("/flow/Arena/OptionalMap") {
 }
 
 TEST_CASE("/flow/Arena/Secure") {
-#ifndef ADDRESS_SANITIZER
+#ifndef USE_SANITIZER
 	// Note: Assumptions underlying this unit test are speculative.
 	//       Disable for a build configuration or entirely if deemed flaky.
 	//       As of writing, below equivalency of (buf == newBuf) holds except for ASAN builds.
@@ -1051,6 +1053,6 @@ TEST_CASE("/flow/Arena/Secure") {
 		}
 	}
 	fmt::print("Total iterations: {}, # of times check passed: {}\n", totalIters, samePtrCount);
-#endif // ADDRESS_SANITIZER
+#endif // USE_SANITIZER
 	return Void();
 }


### PR DESCRIPTION
UBSAN build fails the existing test, not just ASAN.
Disable `/flow/Arena/Secure` unit test for all sanitizer builds.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
