### PR TITLE
Adding support to pass custom fdb_build timestamp, required to achieve uniform naming across different builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,10 @@ else()
     set(FDB_VERSION ${PROJECT_VERSION})
 endif()
 if (NOT FDB_RELEASE)
-    string(TIMESTAMP FDB_BUILDTIME %Y%m%d%H%M%S)
+    string(TIMESTAMP FDB_BUILD_TIMESTMAP %Y%m%d%H%M%S)
+    # Adding support to pass custom fdb_build timestamp,
+    # required to achieve uniform naming across different builds
+    set(FDB_BUILDTIME "${FDB_BUILD_TIMESTMAP}" CACHE STRING "A timestamp for packages")
     set(FDB_BUILDTIME_STRING ".${FDB_BUILDTIME}")
     set(PRERELEASE_TAG "prerelease")
 endif()


### PR DESCRIPTION
Adding support to pass custom fdb_build timestamp, required to achieve uniform naming across different builds.

Motivation :
---
Release Team is running into issue with fdb prerelease packaging. The naming for a specific version isn't consistent between CPU architectures i.e. the daily builds are named slightly differently on arm vs x86 because the timestamp portion differs.

So in order to make timestamp portion uniform adding support to pass  `FDB_BUILDTIME` as string parameter to cmake.
It can be passed as for example `-DFDB_BUILDTIME=202302345678`

**Note**: Default existing behavior will not change. 

Testing
---
* Tested with default behavior without passing any external `-DFDB_BUILDTIME` parameter
* Tested with passing `-DFDB_BUILDTIME=202302345678` as external arguments to Cmake.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [x] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
