### PR TITLE
added c and java apis for granule flush

### DIFF
--- a/bindings/c/fdb_c.cpp
+++ b/bindings/c/fdb_c.cpp
@@ -768,6 +768,25 @@ extern "C" DLLEXPORT WARN_UNUSED_RESULT FDBFuture* fdb_database_verify_blob_rang
 	                        .extractPtr());
 }
 
+extern "C" DLLEXPORT WARN_UNUSED_RESULT FDBFuture* fdb_database_flush_blob_range(FDBDatabase* db,
+                                                                                 uint8_t const* begin_key_name,
+                                                                                 int begin_key_name_length,
+                                                                                 uint8_t const* end_key_name,
+                                                                                 int end_key_name_length,
+                                                                                 fdb_bool_t compact,
+                                                                                 int64_t version) {
+	Optional<Version> rv;
+	if (version != latestVersion) {
+		rv = version;
+	}
+	return (FDBFuture*)(DB(db)
+	                        ->flushBlobRange(KeyRangeRef(StringRef(begin_key_name, begin_key_name_length),
+	                                                     StringRef(end_key_name, end_key_name_length)),
+	                                         compact,
+	                                         rv)
+	                        .extractPtr());
+}
+
 extern "C" DLLEXPORT WARN_UNUSED_RESULT FDBFuture* fdb_database_get_client_status(FDBDatabase* db) {
 	return (FDBFuture*)(DB(db)->getClientStatus().extractPtr());
 }
@@ -858,6 +877,25 @@ extern "C" DLLEXPORT WARN_UNUSED_RESULT FDBFuture* fdb_tenant_verify_blob_range(
 	                        ->verifyBlobRange(KeyRangeRef(StringRef(begin_key_name, begin_key_name_length),
 	                                                      StringRef(end_key_name, end_key_name_length)),
 	                                          rv)
+	                        .extractPtr());
+}
+
+extern "C" DLLEXPORT WARN_UNUSED_RESULT FDBFuture* fdb_tenant_flush_blob_range(FDBTenant* tenant,
+                                                                               uint8_t const* begin_key_name,
+                                                                               int begin_key_name_length,
+                                                                               uint8_t const* end_key_name,
+                                                                               int end_key_name_length,
+                                                                               fdb_bool_t compact,
+                                                                               int64_t version) {
+	Optional<Version> rv;
+	if (version != latestVersion) {
+		rv = version;
+	}
+	return (FDBFuture*)(TENANT(tenant)
+	                        ->flushBlobRange(KeyRangeRef(StringRef(begin_key_name, begin_key_name_length),
+	                                                     StringRef(end_key_name, end_key_name_length)),
+	                                         compact,
+	                                         rv)
 	                        .extractPtr());
 }
 

--- a/bindings/c/foundationdb/fdb_c.h
+++ b/bindings/c/foundationdb/fdb_c.h
@@ -443,6 +443,14 @@ DLLEXPORT WARN_UNUSED_RESULT FDBFuture* fdb_database_verify_blob_range(FDBDataba
                                                                        int end_key_name_length,
                                                                        int64_t version);
 
+DLLEXPORT WARN_UNUSED_RESULT FDBFuture* fdb_database_flush_blob_range(FDBDatabase* db,
+                                                                      uint8_t const* begin_key_name,
+                                                                      int begin_key_name_length,
+                                                                      uint8_t const* end_key_name,
+                                                                      int end_key_name_length,
+                                                                      fdb_bool_t compact,
+                                                                      int64_t version);
+
 DLLEXPORT WARN_UNUSED_RESULT FDBFuture* fdb_database_get_client_status(FDBDatabase* db);
 
 DLLEXPORT WARN_UNUSED_RESULT fdb_error_t fdb_tenant_create_transaction(FDBTenant* tenant,
@@ -498,6 +506,14 @@ DLLEXPORT WARN_UNUSED_RESULT FDBFuture* fdb_tenant_verify_blob_range(FDBTenant* 
                                                                      uint8_t const* end_key_name,
                                                                      int end_key_name_length,
                                                                      int64_t version);
+
+DLLEXPORT WARN_UNUSED_RESULT FDBFuture* fdb_tenant_flush_blob_range(FDBTenant* tenant,
+                                                                    uint8_t const* begin_key_name,
+                                                                    int begin_key_name_length,
+                                                                    uint8_t const* end_key_name,
+                                                                    int end_key_name_length,
+                                                                    fdb_bool_t compact,
+                                                                    int64_t version);
 
 DLLEXPORT WARN_UNUSED_RESULT FDBFuture* fdb_tenant_get_id(FDBTenant* tenant);
 

--- a/bindings/c/test/apitester/TesterBlobGranuleErrorsWorkload.cpp
+++ b/bindings/c/test/apitester/TesterBlobGranuleErrorsWorkload.cpp
@@ -44,7 +44,9 @@ private:
 		OP_CANCEL_BLOBBIFY,
 		OP_CANCEL_UNBLOBBIFY,
 		OP_CANCEL_PURGE,
-		OP_LAST = OP_CANCEL_PURGE
+		OP_CANCEL_FLUSH,
+		OP_FLUSH_TOO_OLD,
+		OP_LAST = OP_FLUSH_TOO_OLD
 	};
 
 	void setup(TTaskFct cont) override { setupBlobGranules(cont); }
@@ -122,14 +124,10 @@ private:
 
 	void randomPurgeUnalignedOp(TTaskFct cont) {
 		// blobbify/unblobbify need to be aligned to blob range boundaries, so this should always fail
-		fdb::Key begin = randomKeyName();
-		fdb::Key end = randomKeyName();
-		if (begin > end) {
-			std::swap(begin, end);
-		}
+		fdb::KeyRange keyRange = randomNonEmptyKeyRange();
 		execOperation(
-		    [this, begin, end](auto ctx) {
-			    fdb::Future f = ctx->db().purgeBlobGranules(begin, end, -2, false).eraseType();
+		    [this, keyRange](auto ctx) {
+			    fdb::Future f = ctx->db().purgeBlobGranules(keyRange.beginKey, keyRange.endKey, -2, false).eraseType();
 			    ctx->continueAfter(
 			        f,
 			        [this, ctx, f]() {
@@ -144,16 +142,12 @@ private:
 
 	void randomBlobbifyUnalignedOp(bool blobbify, TTaskFct cont) {
 		// blobbify/unblobbify need to be aligned to blob range boundaries, so this should always return false
-		fdb::Key begin = randomKeyName();
-		fdb::Key end = randomKeyName();
-		if (begin > end) {
-			std::swap(begin, end);
-		}
+		fdb::KeyRange keyRange = randomNonEmptyKeyRange();
 		auto success = std::make_shared<bool>(false);
 		execOperation(
-		    [begin, end, blobbify, success](auto ctx) {
-			    fdb::Future f = blobbify ? ctx->db().blobbifyRange(begin, end).eraseType()
-			                             : ctx->db().unblobbifyRange(begin, end).eraseType();
+		    [keyRange, blobbify, success](auto ctx) {
+			    fdb::Future f = blobbify ? ctx->db().blobbifyRange(keyRange.beginKey, keyRange.endKey).eraseType()
+			                             : ctx->db().unblobbifyRange(keyRange.beginKey, keyRange.endKey).eraseType();
 			    ctx->continueAfter(
 			        f,
 			        [ctx, f, success]() {
@@ -169,74 +163,56 @@ private:
 	}
 
 	void randomCancelGetGranulesOp(TTaskFct cont) {
-		fdb::Key begin = randomKeyName();
-		fdb::Key end = randomKeyName();
-		if (begin > end) {
-			std::swap(begin, end);
-		}
+		fdb::KeyRange keyRange = randomNonEmptyKeyRange();
 		execTransaction(
-		    [begin, end](auto ctx) {
-			    fdb::Future f = ctx->tx().getBlobGranuleRanges(begin, end, 1000).eraseType();
+		    [keyRange](auto ctx) {
+			    fdb::Future f = ctx->tx().getBlobGranuleRanges(keyRange.beginKey, keyRange.endKey, 1000).eraseType();
 			    ctx->done();
 		    },
 		    [this, cont]() { schedule(cont); });
 	}
 
 	void randomCancelGetRangesOp(TTaskFct cont) {
-		fdb::Key begin = randomKeyName();
-		fdb::Key end = randomKeyName();
-		if (begin > end) {
-			std::swap(begin, end);
-		}
+		fdb::KeyRange keyRange = randomNonEmptyKeyRange();
 		execOperation(
-		    [begin, end](auto ctx) {
-			    fdb::Future f = ctx->db().listBlobbifiedRanges(begin, end, 1000).eraseType();
+		    [keyRange](auto ctx) {
+			    fdb::Future f = ctx->db().listBlobbifiedRanges(keyRange.beginKey, keyRange.endKey, 1000).eraseType();
 			    ctx->done();
 		    },
 		    [this, cont]() { schedule(cont); });
 	}
 
 	void randomCancelVerifyOp(TTaskFct cont) {
-		fdb::Key begin = randomKeyName();
-		fdb::Key end = randomKeyName();
-		if (begin > end) {
-			std::swap(begin, end);
-		}
+		fdb::KeyRange keyRange = randomNonEmptyKeyRange();
 		execOperation(
-		    [begin, end](auto ctx) {
-			    fdb::Future f = ctx->db().verifyBlobRange(begin, end, -2 /* latest version*/).eraseType();
+		    [keyRange](auto ctx) {
+			    fdb::Future f =
+			        ctx->db().verifyBlobRange(keyRange.beginKey, keyRange.endKey, -2 /* latest version*/).eraseType();
 			    ctx->done();
 		    },
 		    [this, cont]() { schedule(cont); });
 	}
 
 	void randomCancelSummarizeOp(TTaskFct cont) {
-		fdb::Key begin = randomKeyName();
-		fdb::Key end = randomKeyName();
-		if (begin > end) {
-			std::swap(begin, end);
-		}
+		fdb::KeyRange keyRange = randomNonEmptyKeyRange();
 		execTransaction(
-		    [begin, end](auto ctx) {
-			    fdb::Future f = ctx->tx().summarizeBlobGranules(begin, end, -2, 1000).eraseType();
+		    [keyRange](auto ctx) {
+			    fdb::Future f =
+			        ctx->tx().summarizeBlobGranules(keyRange.beginKey, keyRange.endKey, -2, 1000).eraseType();
 			    ctx->done();
 		    },
 		    [this, cont]() { schedule(cont); });
 	}
 
 	void randomCancelBlobbifyOp(TTaskFct cont) {
-		fdb::Key begin = randomKeyName();
-		fdb::Key end = randomKeyName();
-		if (begin > end) {
-			std::swap(begin, end);
-		}
+		fdb::KeyRange keyRange = randomNonEmptyKeyRange();
 		execOperation(
-		    [begin, end](auto ctx) {
+		    [keyRange](auto ctx) {
 			    fdb::Future f;
 			    if (Random::get().randomBool(0.5)) {
-				    f = ctx->db().blobbifyRange(begin, end).eraseType();
+				    f = ctx->db().blobbifyRange(keyRange.beginKey, keyRange.endKey).eraseType();
 			    } else {
-				    f = ctx->db().blobbifyRangeBlocking(begin, end).eraseType();
+				    f = ctx->db().blobbifyRangeBlocking(keyRange.beginKey, keyRange.endKey).eraseType();
 			    }
 			    ctx->done();
 		    },
@@ -244,31 +220,57 @@ private:
 	}
 
 	void randomCancelUnblobbifyOp(TTaskFct cont) {
-		fdb::Key begin = randomKeyName();
-		fdb::Key end = randomKeyName();
-		if (begin > end) {
-			std::swap(begin, end);
-		}
+		fdb::KeyRange keyRange = randomNonEmptyKeyRange();
 		execOperation(
-		    [begin, end](auto ctx) {
-			    fdb::Future f = ctx->db().unblobbifyRange(begin, end).eraseType();
+		    [keyRange](auto ctx) {
+			    fdb::Future f = ctx->db().unblobbifyRange(keyRange.beginKey, keyRange.endKey).eraseType();
 			    ctx->done();
 		    },
 		    [this, cont]() { schedule(cont); });
 	}
 
 	void randomCancelPurgeOp(TTaskFct cont) {
-		fdb::Key begin = randomKeyName();
-		fdb::Key end = randomKeyName();
-		if (begin > end) {
-			std::swap(begin, end);
-		}
+		fdb::KeyRange keyRange = randomNonEmptyKeyRange();
 		execOperation(
-		    [begin, end](auto ctx) {
-			    fdb::Future f = ctx->db().purgeBlobGranules(begin, end, -2, false).eraseType();
+		    [keyRange](auto ctx) {
+			    fdb::Future f = ctx->db().purgeBlobGranules(keyRange.beginKey, keyRange.endKey, -2, false).eraseType();
 			    ctx->done();
 		    },
 		    [this, cont]() { schedule(cont); });
+	}
+
+	void randomCancelFlushOp(TTaskFct cont) {
+		fdb::KeyRange keyRange = randomNonEmptyKeyRange();
+		fdb::native::fdb_bool_t compact = Random::get().randomBool(0.5);
+		execOperation(
+		    [keyRange, compact](auto ctx) {
+			    fdb::Future f = ctx->db().flushBlobRange(keyRange.beginKey, keyRange.endKey, compact, -2).eraseType();
+			    ctx->done();
+		    },
+		    [this, cont]() { schedule(cont); });
+	}
+
+	void randomFlushTooOldOp(TTaskFct cont) {
+		fdb::KeyRange keyRange = randomNonEmptyKeyRange();
+		fdb::native::fdb_bool_t compact = Random::get().randomBool(0.5);
+
+		auto success = std::make_shared<bool>(false);
+		execOperation(
+		    [keyRange, compact, success](auto ctx) {
+			    // version of 1 should be too old
+			    fdb::Future f = ctx->db().flushBlobRange(keyRange.beginKey, keyRange.endKey, compact, 1).eraseType();
+			    ctx->continueAfter(
+			        f,
+			        [ctx, f, success]() {
+				        *success = f.get<fdb::future_var::Bool>();
+				        ctx->done();
+			        },
+			        true);
+		    },
+		    [this, cont, success]() {
+			    ASSERT(!(*success));
+			    schedule(cont);
+		    });
 	}
 
 	void randomOperation(TTaskFct cont) override {
@@ -312,6 +314,12 @@ private:
 			randomCancelUnblobbifyOp(cont);
 			break;
 		case OP_CANCEL_PURGE:
+			randomCancelPurgeOp(cont);
+			break;
+		case OP_CANCEL_FLUSH:
+			randomCancelPurgeOp(cont);
+			break;
+		case OP_FLUSH_TOO_OLD:
 			randomCancelPurgeOp(cont);
 			break;
 		}

--- a/bindings/c/test/fdb_api.hpp
+++ b/bindings/c/test/fdb_api.hpp
@@ -837,6 +837,7 @@ public:
 	                                                                       KeyRef end,
 	                                                                       int rangeLimit) = 0;
 	virtual TypedFuture<future_var::Int64> verifyBlobRange(KeyRef begin, KeyRef end, int64_t version) = 0;
+	virtual TypedFuture<future_var::Bool> flushBlobRange(KeyRef begin, KeyRef end, bool compact, int64_t version) = 0;
 	virtual TypedFuture<future_var::KeyRef> purgeBlobGranules(KeyRef begin,
 	                                                          KeyRef end,
 	                                                          int64_t version,
@@ -930,6 +931,13 @@ public:
 			throw std::runtime_error("verifyBlobRange() from null tenant");
 		return native::fdb_tenant_verify_blob_range(
 		    tenant.get(), begin.data(), intSize(begin), end.data(), intSize(end), version);
+	}
+
+	TypedFuture<future_var::Bool> flushBlobRange(KeyRef begin, KeyRef end, bool compact, int64_t version) override {
+		if (!tenant)
+			throw std::runtime_error("flushBlobRange() from null tenant");
+		return native::fdb_tenant_flush_blob_range(
+		    tenant.get(), begin.data(), intSize(begin), end.data(), intSize(end), compact, version);
 	}
 
 	TypedFuture<future_var::Int64> getId() {
@@ -1034,6 +1042,13 @@ public:
 			throw std::runtime_error("verifyBlobRange from null database");
 		return native::fdb_database_verify_blob_range(
 		    db.get(), begin.data(), intSize(begin), end.data(), intSize(end), version);
+	}
+
+	TypedFuture<future_var::Bool> flushBlobRange(KeyRef begin, KeyRef end, bool compact, int64_t version) override {
+		if (!db)
+			throw std::runtime_error("flushBlobRange from null database");
+		return native::fdb_database_flush_blob_range(
+		    db.get(), begin.data(), intSize(begin), end.data(), intSize(end), compact, version);
 	}
 
 	TypedFuture<future_var::Bool> blobbifyRange(KeyRef begin, KeyRef end) override {

--- a/bindings/java/fdbJNI.cpp
+++ b/bindings/java/fdbJNI.cpp
@@ -1093,6 +1093,46 @@ JNIEXPORT jlong JNICALL Java_com_apple_foundationdb_FDBDatabase_Database_1getCli
 	return (jlong)f;
 }
 
+JNIEXPORT jlong JNICALL Java_com_apple_foundationdb_FDBDatabase_Database_1flushBlobRange(JNIEnv* jenv,
+                                                                                         jobject,
+                                                                                         jlong dbPtr,
+                                                                                         jbyteArray beginKeyBytes,
+                                                                                         jbyteArray endKeyBytes,
+                                                                                         jboolean compact,
+                                                                                         jlong version) {
+	if (!dbPtr || !beginKeyBytes || !endKeyBytes) {
+		throwParamNotNull(jenv);
+		return 0;
+	}
+	FDBDatabase* tr = (FDBDatabase*)dbPtr;
+
+	uint8_t* startKey = (uint8_t*)jenv->GetByteArrayElements(beginKeyBytes, JNI_NULL);
+	if (!startKey) {
+		if (!jenv->ExceptionOccurred())
+			throwRuntimeEx(jenv, "Error getting handle to native resources");
+		return 0;
+	}
+
+	uint8_t* endKey = (uint8_t*)jenv->GetByteArrayElements(endKeyBytes, JNI_NULL);
+	if (!endKey) {
+		jenv->ReleaseByteArrayElements(beginKeyBytes, (jbyte*)startKey, JNI_ABORT);
+		if (!jenv->ExceptionOccurred())
+			throwRuntimeEx(jenv, "Error getting handle to native resources");
+		return 0;
+	}
+
+	FDBFuture* f = fdb_database_flush_blob_range(tr,
+	                                             startKey,
+	                                             jenv->GetArrayLength(beginKeyBytes),
+	                                             endKey,
+	                                             jenv->GetArrayLength(endKeyBytes),
+	                                             (fdb_bool_t)compact,
+	                                             version);
+	jenv->ReleaseByteArrayElements(beginKeyBytes, (jbyte*)startKey, JNI_ABORT);
+	jenv->ReleaseByteArrayElements(endKeyBytes, (jbyte*)endKey, JNI_ABORT);
+	return (jlong)f;
+}
+
 JNIEXPORT jboolean JNICALL Java_com_apple_foundationdb_FDB_Error_1predicate(JNIEnv* jenv,
                                                                             jobject,
                                                                             jint predicate,
@@ -1376,6 +1416,46 @@ JNIEXPORT jlong JNICALL Java_com_apple_foundationdb_FDBTenant_Tenant_1verifyBlob
 
 	FDBFuture* f = fdb_tenant_verify_blob_range(
 	    tenant, startKey, jenv->GetArrayLength(beginKeyBytes), endKey, jenv->GetArrayLength(endKeyBytes), version);
+	jenv->ReleaseByteArrayElements(beginKeyBytes, (jbyte*)startKey, JNI_ABORT);
+	jenv->ReleaseByteArrayElements(endKeyBytes, (jbyte*)endKey, JNI_ABORT);
+	return (jlong)f;
+}
+
+JNIEXPORT jlong JNICALL Java_com_apple_foundationdb_FDBTenant_Tenant_1flushBlobRange(JNIEnv* jenv,
+                                                                                     jobject,
+                                                                                     jlong tPtr,
+                                                                                     jbyteArray beginKeyBytes,
+                                                                                     jbyteArray endKeyBytes,
+                                                                                     jboolean compact,
+                                                                                     jlong version) {
+	if (!tPtr || !beginKeyBytes || !endKeyBytes) {
+		throwParamNotNull(jenv);
+		return 0;
+	}
+	FDBTenant* tenant = (FDBTenant*)tPtr;
+
+	uint8_t* startKey = (uint8_t*)jenv->GetByteArrayElements(beginKeyBytes, JNI_NULL);
+	if (!startKey) {
+		if (!jenv->ExceptionOccurred())
+			throwRuntimeEx(jenv, "Error getting handle to native resources");
+		return 0;
+	}
+
+	uint8_t* endKey = (uint8_t*)jenv->GetByteArrayElements(endKeyBytes, JNI_NULL);
+	if (!endKey) {
+		jenv->ReleaseByteArrayElements(beginKeyBytes, (jbyte*)startKey, JNI_ABORT);
+		if (!jenv->ExceptionOccurred())
+			throwRuntimeEx(jenv, "Error getting handle to native resources");
+		return 0;
+	}
+
+	FDBFuture* f = fdb_tenant_flush_blob_range(tenant,
+	                                           startKey,
+	                                           jenv->GetArrayLength(beginKeyBytes),
+	                                           endKey,
+	                                           jenv->GetArrayLength(endKeyBytes),
+	                                           (fdb_bool_t)compact,
+	                                           version);
 	jenv->ReleaseByteArrayElements(beginKeyBytes, (jbyte*)startKey, JNI_ABORT);
 	jenv->ReleaseByteArrayElements(endKeyBytes, (jbyte*)endKey, JNI_ABORT);
 	return (jlong)f;

--- a/bindings/java/src/main/com/apple/foundationdb/Database.java
+++ b/bindings/java/src/main/com/apple/foundationdb/Database.java
@@ -357,6 +357,46 @@ public interface Database extends AutoCloseable, TransactionContext {
 	CompletableFuture<Long> verifyBlobRange(byte[] beginKey, byte[] endKey, long version, Executor e);
 
 	/**
+	 * Runs {@link #flushBlobRange(byte[] beginKey, byte[] endKey)} on the default executor.
+	 *
+	 * @param beginKey start of the key range
+	 * @param endKey end of the key range
+	 * @param compact force compact or just flush
+	 *
+	 * @return a future with a boolean for success or failure
+	 */
+	default CompletableFuture<Boolean> flushBlobRange(byte[] beginKey, byte[] endKey, boolean compact) {
+		return flushBlobRange(beginKey, endKey, compact, -2, getExecutor());
+	}
+
+	/**
+	 * Runs {@link #flushBlobRange(byte[] beginKey, byte[] endKey, long version)} on the default executor.
+	 *
+	 * @param beginKey start of the key range
+	 * @param endKey end of the key range
+	 * @param compact force compact or just flush
+	 * @param version version to flush at
+	 *
+	 * @return a future with a boolean for success or failure
+	 */
+	default CompletableFuture<Boolean> flushBlobRange(byte[] beginKey, byte[] endKey, boolean compact, long version) {
+		return flushBlobRange(beginKey, endKey, compact, version, getExecutor());
+	}
+
+	/**
+	 * Checks if a blob range is blobbified.
+	 *
+	 * @param beginKey start of the key range
+	 * @param endKey end of the key range
+	 * @param compact force compact or just flush
+	 * @param version version to flush at
+	 * @param e the {@link Executor} to use for asynchronous callbacks
+	 *
+	 * @return a future with a boolean for success or failure
+	 */
+	CompletableFuture<Boolean> flushBlobRange(byte[] beginKey, byte[] endKey, boolean compact, long version, Executor e);
+
+	/**
 	 * Runs a read-only transactional function against this {@code Database} with retry logic.
 	 *  {@link Function#apply(Object) apply(ReadTransaction)} will be called on the
 	 *  supplied {@link Function} until a non-retryable

--- a/bindings/java/src/main/com/apple/foundationdb/FDBDatabase.java
+++ b/bindings/java/src/main/com/apple/foundationdb/FDBDatabase.java
@@ -270,6 +270,16 @@ class FDBDatabase extends NativeObjectWrapper implements Database, OptionConsume
 	}
 
 	@Override
+	public CompletableFuture<Boolean> flushBlobRange(byte[] beginKey, byte[] endKey, boolean compact, long version, Executor e) {
+		pointerReadLock.lock();
+		try {
+			return new FutureBool(Database_flushBlobRange(getPtr(), beginKey, endKey, compact, version), e);
+		} finally {
+			pointerReadLock.unlock();
+		}
+	}
+
+	@Override
 	public Executor getExecutor() {
 		return executor;
 	}
@@ -301,5 +311,6 @@ class FDBDatabase extends NativeObjectWrapper implements Database, OptionConsume
 	private native long Database_unblobbifyRange(long cPtr, byte[] beginKey, byte[] endKey);
 	private native long Database_listBlobbifiedRanges(long cPtr, byte[] beginKey, byte[] endKey, int rangeLimit);
 	private native long Database_verifyBlobRange(long cPtr, byte[] beginKey, byte[] endKey, long version);
+	private native long Database_flushBlobRange(long cPtr, byte[] beginKey, byte[] endKey, boolean compact, long version);
 	private native long Database_getClientStatus(long cPtr);
 }

--- a/bindings/java/src/main/com/apple/foundationdb/FDBTenant.java
+++ b/bindings/java/src/main/com/apple/foundationdb/FDBTenant.java
@@ -211,6 +211,16 @@ class FDBTenant extends NativeObjectWrapper implements Tenant {
 	}
 
 	@Override
+	public CompletableFuture<Boolean> flushBlobRange(byte[] beginKey, byte[] endKey, boolean compact, long version, Executor e) {
+		pointerReadLock.lock();
+		try {
+			return new FutureBool(Tenant_flushBlobRange(getPtr(), beginKey, endKey, compact, version), e);
+		} finally {
+			pointerReadLock.unlock();
+		}
+	}
+
+	@Override
 	public CompletableFuture<Long> getId(Executor e) {
 		pointerReadLock.lock();
 		try {
@@ -247,5 +257,6 @@ class FDBTenant extends NativeObjectWrapper implements Tenant {
 	private native long Tenant_unblobbifyRange(long cPtr, byte[] beginKey, byte[] endKey);
 	private native long Tenant_listBlobbifiedRanges(long cPtr, byte[] beginKey, byte[] endKey, int rangeLimit);
 	private native long Tenant_verifyBlobRange(long cPtr, byte[] beginKey, byte[] endKey, long version);
+	private native long Tenant_flushBlobRange(long cPtr, byte[] beginKey, byte[] endKey, boolean compact, long version);
 	private native long Tenant_getId(long cPtr);
 }

--- a/bindings/java/src/main/com/apple/foundationdb/Tenant.java
+++ b/bindings/java/src/main/com/apple/foundationdb/Tenant.java
@@ -444,6 +444,46 @@ public interface Tenant extends AutoCloseable, TransactionContext {
 	CompletableFuture<Long> verifyBlobRange(byte[] beginKey, byte[] endKey, long version, Executor e);
 
 	/**
+	 * Runs {@link #flushBlobRange(byte[] beginKey, byte[] endKey)} on the default executor.
+	 *
+	 * @param beginKey start of the key range
+	 * @param endKey end of the key range
+	 * @param compact force compact or just flush
+	 *
+	 * @return a future with a boolean for success or failure
+	 */
+	default CompletableFuture<Boolean> flushBlobRange(byte[] beginKey, byte[] endKey, boolean compact) {
+		return flushBlobRange(beginKey, endKey, compact, -2, getExecutor());
+	}
+
+	/**
+	 * Runs {@link #flushBlobRange(byte[] beginKey, byte[] endKey, long version)} on the default executor.
+	 *
+	 * @param beginKey start of the key range
+	 * @param endKey end of the key range
+	 * @param compact force compact or just flush
+	 * @param version version to flush at
+	 *
+	 * @return a future with a boolean for success or failure
+	 */
+	default CompletableFuture<Boolean> flushBlobRange(byte[] beginKey, byte[] endKey, boolean compact, long version) {
+		return flushBlobRange(beginKey, endKey, compact, version, getExecutor());
+	}
+
+	/**
+	 * Checks if a blob range is blobbified.
+	 *
+	 * @param beginKey start of the key range
+	 * @param endKey end of the key range
+	 * @param compact force compact or just flush
+	 * @param version version to flush at
+	 * @param e the {@link Executor} to use for asynchronous callbacks
+	 *
+	 * @return a future with a boolean for success or failure
+	 */
+	CompletableFuture<Boolean> flushBlobRange(byte[] beginKey, byte[] endKey, boolean compact, long version, Executor e);
+
+	/**
 	 * Runs {@link #getId()} on the default executor.
 	 *
 	 * @return a future with the tenant ID

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -47,6 +47,7 @@
 #include "fdbclient/AnnotateActor.h"
 #include "fdbclient/Atomic.h"
 #include "fdbclient/BlobGranuleCommon.h"
+#include "fdbclient/BlobGranuleRequest.actor.h"
 #include "fdbclient/ClusterInterface.h"
 #include "fdbclient/ClusterConnectionFile.h"
 #include "fdbclient/ClusterConnectionMemoryRecord.h"
@@ -8524,6 +8525,41 @@ Future<Version> DatabaseContext::verifyBlobRange(const KeyRange& range,
                                                  Optional<Version> version,
                                                  Optional<Reference<Tenant>> tenant) {
 	return verifyBlobRangeActor(Reference<DatabaseContext>::addRef(this), range, version, tenant);
+}
+
+ACTOR Future<bool> flushBlobRangeActor(Reference<DatabaseContext> cx,
+                                       KeyRange range,
+                                       bool compact,
+                                       Optional<Version> version,
+                                       Optional<Reference<Tenant>> tenant) {
+	if (tenant.present()) {
+		wait(tenant.get()->ready());
+		range = range.withPrefix(tenant.get()->prefix());
+	}
+	state Database db(cx);
+	if (!version.present()) {
+		state Transaction tr(db);
+		Version _v = wait(tr.getReadVersion());
+		version = _v;
+	}
+	FlushGranuleRequest req(-1, range, version.get(), compact);
+	try {
+		wait(success(doBlobGranuleRequests(db, range, req, &BlobWorkerInterface::flushGranuleRequest)));
+		return true;
+	} catch (Error& e) {
+		if (e.code() == error_code_blob_granule_transaction_too_old) {
+			// can't flush data at this version, because no granules
+			return false;
+		}
+		throw e;
+	}
+}
+
+Future<bool> DatabaseContext::flushBlobRange(const KeyRange& range,
+                                             bool compact,
+                                             Optional<Version> version,
+                                             Optional<Reference<Tenant>> tenant) {
+	return flushBlobRangeActor(Reference<DatabaseContext>::addRef(this), range, compact, version, tenant);
 }
 
 ACTOR Future<std::vector<std::pair<UID, StorageWiggleValue>>> readStorageWiggleValues(Database cx,

--- a/fdbclient/ThreadSafeTransaction.cpp
+++ b/fdbclient/ThreadSafeTransaction.cpp
@@ -204,6 +204,17 @@ ThreadFuture<Version> ThreadSafeDatabase::verifyBlobRange(const KeyRangeRef& key
 	});
 }
 
+ThreadFuture<bool> ThreadSafeDatabase::flushBlobRange(const KeyRangeRef& keyRange,
+                                                      bool compact,
+                                                      Optional<Version> version) {
+	DatabaseContext* db = this->db;
+	KeyRange range = keyRange;
+	return onMainThread([=]() -> Future<bool> {
+		db->checkDeferredError();
+		return db->flushBlobRange(range, compact, version);
+	});
+}
+
 ThreadSafeDatabase::ThreadSafeDatabase(ConnectionRecordType connectionRecordType,
                                        std::string connectionRecordString,
                                        int apiVersion) {
@@ -324,6 +335,18 @@ ThreadFuture<Version> ThreadSafeTenant::verifyBlobRange(const KeyRangeRef& keyRa
 		db->checkDeferredError();
 		db->addref();
 		return db->verifyBlobRange(range, version, Reference<Tenant>::addRef(tenant));
+	});
+}
+
+ThreadFuture<bool> ThreadSafeTenant::flushBlobRange(const KeyRangeRef& keyRange,
+                                                    bool compact,
+                                                    Optional<Version> version) {
+	DatabaseContext* db = this->db->db;
+	KeyRange range = keyRange;
+	return onMainThread([=]() -> Future<bool> {
+		db->checkDeferredError();
+		db->addref();
+		return db->flushBlobRange(range, compact, version, Reference<Tenant>::addRef(tenant));
 	});
 }
 

--- a/fdbclient/include/fdbclient/DatabaseContext.h
+++ b/fdbclient/include/fdbclient/DatabaseContext.h
@@ -414,6 +414,10 @@ public:
 	Future<Version> verifyBlobRange(const KeyRange& range,
 	                                Optional<Version> version,
 	                                Optional<Reference<Tenant>> tenant = {});
+	Future<bool> flushBlobRange(const KeyRange& range,
+	                            bool compact,
+	                            Optional<Version> version,
+	                            Optional<Reference<Tenant>> tenant = {});
 	Future<bool> blobRestore(const KeyRange range, Optional<Version> version);
 
 	// private:

--- a/fdbclient/include/fdbclient/IClientApi.h
+++ b/fdbclient/include/fdbclient/IClientApi.h
@@ -159,6 +159,7 @@ public:
 	                                                                              int rangeLimit) = 0;
 
 	virtual ThreadFuture<Version> verifyBlobRange(const KeyRangeRef& keyRange, Optional<Version> version) = 0;
+	virtual ThreadFuture<bool> flushBlobRange(const KeyRangeRef& keyRange, bool compact, Optional<Version> version) = 0;
 
 	virtual void addref() = 0;
 	virtual void delref() = 0;
@@ -207,6 +208,7 @@ public:
 	                                                                              int rangeLimit) = 0;
 
 	virtual ThreadFuture<Version> verifyBlobRange(const KeyRangeRef& keyRange, Optional<Version> version) = 0;
+	virtual ThreadFuture<bool> flushBlobRange(const KeyRangeRef& keyRange, bool compact, Optional<Version> version) = 0;
 
 	// Interface to manage shared state across multiple connections to the same Database
 	virtual ThreadFuture<DatabaseSharedState*> createSharedState() = 0;

--- a/fdbclient/include/fdbclient/MultiVersionTransaction.h
+++ b/fdbclient/include/fdbclient/MultiVersionTransaction.h
@@ -213,6 +213,14 @@ struct FdbCApi : public ThreadSafeReferenceCounted<FdbCApi> {
 	                                      int end_key_name_length,
 	                                      int64_t version);
 
+	FDBFuture* (*databaseFlushBlobRange)(FDBDatabase* db,
+	                                     uint8_t const* begin_key_name,
+	                                     int begin_key_name_length,
+	                                     uint8_t const* end_key_name,
+	                                     int end_key_name_length,
+	                                     fdb_bool_t compact,
+	                                     int64_t version);
+
 	FDBFuture* (*databaseGetClientStatus)(FDBDatabase* db);
 
 	// Tenant
@@ -261,6 +269,14 @@ struct FdbCApi : public ThreadSafeReferenceCounted<FdbCApi> {
 	                                    uint8_t const* end_key_name,
 	                                    int end_key_name_length,
 	                                    int64_t version);
+
+	FDBFuture* (*tenantFlushBlobRange)(FDBTenant* db,
+	                                   uint8_t const* begin_key_name,
+	                                   int begin_key_name_length,
+	                                   uint8_t const* end_key_name,
+	                                   int end_key_name_length,
+	                                   fdb_bool_t compact,
+	                                   int64_t version);
 
 	FDBFuture* (*tenantGetId)(FDBTenant* tenant);
 	void (*tenantDestroy)(FDBTenant* tenant);
@@ -565,6 +581,7 @@ public:
 	                                                                      int rangeLimit) override;
 
 	ThreadFuture<Version> verifyBlobRange(const KeyRangeRef& keyRange, Optional<Version> version) override;
+	ThreadFuture<bool> flushBlobRange(const KeyRangeRef& keyRange, bool compact, Optional<Version> version) override;
 
 	void addref() override { ThreadSafeReferenceCounted<DLTenant>::addref(); }
 	void delref() override { ThreadSafeReferenceCounted<DLTenant>::delref(); }
@@ -616,6 +633,7 @@ public:
 	                                                                      int rangeLimit) override;
 
 	ThreadFuture<Version> verifyBlobRange(const KeyRangeRef& keyRange, Optional<Version> version) override;
+	ThreadFuture<bool> flushBlobRange(const KeyRangeRef& keyRange, bool compact, Optional<Version> version) override;
 
 	ThreadFuture<DatabaseSharedState*> createSharedState() override;
 	void setSharedState(DatabaseSharedState* p) override;
@@ -885,6 +903,7 @@ public:
 	ThreadFuture<Standalone<VectorRef<KeyRangeRef>>> listBlobbifiedRanges(const KeyRangeRef& keyRange,
 	                                                                      int rangeLimit) override;
 	ThreadFuture<Version> verifyBlobRange(const KeyRangeRef& keyRange, Optional<Version> version) override;
+	ThreadFuture<bool> flushBlobRange(const KeyRangeRef& keyRange, bool compact, Optional<Version> version) override;
 
 	void addref() override { ThreadSafeReferenceCounted<MultiVersionTenant>::addref(); }
 	void delref() override { ThreadSafeReferenceCounted<MultiVersionTenant>::delref(); }
@@ -1014,6 +1033,7 @@ public:
 	ThreadFuture<Standalone<VectorRef<KeyRangeRef>>> listBlobbifiedRanges(const KeyRangeRef& keyRange,
 	                                                                      int rangeLimit) override;
 	ThreadFuture<Version> verifyBlobRange(const KeyRangeRef& keyRange, Optional<Version> version) override;
+	ThreadFuture<bool> flushBlobRange(const KeyRangeRef& keyRange, bool compact, Optional<Version> version) override;
 
 	ThreadFuture<DatabaseSharedState*> createSharedState() override;
 	void setSharedState(DatabaseSharedState* p) override;

--- a/fdbclient/include/fdbclient/ThreadSafeTransaction.h
+++ b/fdbclient/include/fdbclient/ThreadSafeTransaction.h
@@ -70,6 +70,7 @@ public:
 	                                                                      int rangeLimit) override;
 
 	ThreadFuture<Version> verifyBlobRange(const KeyRangeRef& keyRange, Optional<Version> version) override;
+	ThreadFuture<bool> flushBlobRange(const KeyRangeRef& keyRange, bool compact, Optional<Version> version) override;
 
 	ThreadFuture<DatabaseSharedState*> createSharedState() override;
 	void setSharedState(DatabaseSharedState* p) override;
@@ -108,6 +109,7 @@ public:
 	                                                                      int rangeLimit) override;
 
 	ThreadFuture<Version> verifyBlobRange(const KeyRangeRef& keyRange, Optional<Version> version) override;
+	ThreadFuture<bool> flushBlobRange(const KeyRangeRef& keyRange, bool compact, Optional<Version> version) override;
 
 	void addref() override { ThreadSafeReferenceCounted<ThreadSafeTenant>::addref(); }
 	void delref() override { ThreadSafeReferenceCounted<ThreadSafeTenant>::delref(); }


### PR DESCRIPTION
Passes 1k blobgranule* correctness, c api tester and java integration test

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
