### PR TITLE
Test that the metacluster restore dry-run mode doesn't change anything

### DIFF
--- a/fdbclient/Tenant.cpp
+++ b/fdbclient/Tenant.cpp
@@ -203,6 +203,10 @@ bool TenantMapEntry::operator==(TenantMapEntry const& other) const {
 	       renameDestination == other.renameDestination && error == other.error;
 }
 
+bool TenantMapEntry::operator!=(TenantMapEntry const& other) const {
+	return !(*this == other);
+}
+
 json_spirit::mObject TenantGroupEntry::toJson() const {
 	json_spirit::mObject tenantGroupEntry;
 	if (assignedCluster.present()) {
@@ -210,6 +214,23 @@ json_spirit::mObject TenantGroupEntry::toJson() const {
 	}
 
 	return tenantGroupEntry;
+}
+
+bool TenantGroupEntry::operator==(TenantGroupEntry const& other) const {
+	return assignedCluster == other.assignedCluster;
+}
+bool TenantGroupEntry::operator!=(TenantGroupEntry const& other) const {
+	return !(*this == other);
+}
+
+bool TenantTombstoneCleanupData::operator==(TenantTombstoneCleanupData const& other) const {
+	return tombstonesErasedThrough == other.tombstonesErasedThrough &&
+	       nextTombstoneEraseVersion == other.nextTombstoneEraseVersion &&
+	       nextTombstoneEraseId == other.nextTombstoneEraseId;
+}
+
+bool TenantTombstoneCleanupData::operator!=(TenantTombstoneCleanupData const& other) const {
+	return !(*this == other);
 }
 
 TenantMetadataSpecification& TenantMetadata::instance() {

--- a/fdbclient/include/fdbclient/KeyBackedTypes.h
+++ b/fdbclient/include/fdbclient/KeyBackedTypes.h
@@ -168,6 +168,9 @@ template <typename ResultType>
 struct KeyBackedRangeResult {
 	std::vector<ResultType> results;
 	bool more;
+
+	bool operator==(KeyBackedRangeResult const& other) const { return results == other.results && more == other.more; }
+	bool operator!=(KeyBackedRangeResult const& other) const { return !(*this == other); }
 };
 
 // Convenient read/write access to a single value of type T stored at key

--- a/fdbclient/include/fdbclient/Metacluster.h
+++ b/fdbclient/include/fdbclient/Metacluster.h
@@ -93,6 +93,13 @@ struct DataClusterEntry {
 
 	json_spirit::mObject toJson() const;
 
+	bool operator==(DataClusterEntry const& other) const {
+		return id == other.id && capacity == other.capacity && allocated == other.allocated &&
+		       clusterState == other.clusterState;
+	}
+
+	bool operator!=(DataClusterEntry const& other) const { return !(*this == other); }
+
 	template <class Ar>
 	void serialize(Ar& ar) {
 		serializer(ar, id, capacity, allocated, clusterState);
@@ -172,6 +179,13 @@ struct MetaclusterRegistrationEntry {
 			                   id.shortString());
 		}
 	}
+
+	bool operator==(MetaclusterRegistrationEntry const& other) const {
+		return clusterType == other.clusterType && metaclusterName == other.metaclusterName && name == other.name &&
+		       metaclusterId == other.metaclusterId && id == other.id;
+	}
+
+	bool operator!=(MetaclusterRegistrationEntry const& other) const { return !(*this == other); }
 
 	template <class Ar>
 	void serialize(Ar& ar) {

--- a/fdbclient/include/fdbclient/MetaclusterManagement.actor.h
+++ b/fdbclient/include/fdbclient/MetaclusterManagement.actor.h
@@ -80,6 +80,12 @@ struct DataClusterMetadata {
 		return obj;
 	}
 
+	bool operator==(DataClusterMetadata const& other) const {
+		return entry == other.entry && connectionString == other.connectionString;
+	}
+
+	bool operator!=(DataClusterMetadata const& other) const { return !(*this == other); }
+
 	template <class Ar>
 	void serialize(Ar& ar) {
 		serializer(ar, connectionString, entry);
@@ -1537,6 +1543,7 @@ struct RestoreClusterImpl {
 	ACTOR static Future<Void> markManagementTenantsAsError(RestoreClusterImpl* self,
 	                                                       Reference<typename DB::TransactionT> tr,
 	                                                       std::vector<int64_t> tenants) {
+		ASSERT(!self->restoreDryRun);
 		state std::vector<Future<Optional<TenantMapEntry>>> getFutures;
 		for (auto tenantId : tenants) {
 			getFutures.push_back(tryGetTenantTransaction(tr, tenantId));

--- a/fdbclient/include/fdbclient/MetaclusterManagement.actor.h
+++ b/fdbclient/include/fdbclient/MetaclusterManagement.actor.h
@@ -2103,7 +2103,9 @@ struct RestoreClusterImpl {
 
 		// Record the data cluster in the management cluster
 		wait(self->ctx.runManagementTransaction([self = self](Reference<typename DB::TransactionT> tr) {
-			MetaclusterMetadata::activeRestoreIds().set(tr, self->clusterName, self->restoreId);
+			if (!self->restoreDryRun) {
+				MetaclusterMetadata::activeRestoreIds().set(tr, self->clusterName, self->restoreId);
+			}
 
 			DataClusterEntry entry;
 			entry.id = self->dataClusterId;

--- a/fdbclient/include/fdbclient/Tenant.h
+++ b/fdbclient/include/fdbclient/Tenant.h
@@ -107,6 +107,7 @@ struct TenantMapEntry {
 	}
 
 	bool operator==(TenantMapEntry const& other) const;
+	bool operator!=(TenantMapEntry const& other) const;
 
 	template <class Ar>
 	void serialize(Ar& ar) {
@@ -144,6 +145,9 @@ struct TenantGroupEntry {
 		return ObjectReader::fromStringRef<TenantGroupEntry>(value, IncludeVersion());
 	}
 
+	bool operator==(TenantGroupEntry const& other) const;
+	bool operator!=(TenantGroupEntry const& other) const;
+
 	template <class Ar>
 	void serialize(Ar& ar) {
 		serializer(ar, assignedCluster);
@@ -162,6 +166,9 @@ struct TenantTombstoneCleanupData {
 
 	// When we reach the nextTombstoneEraseVersion, we will erase tombstones up through this ID.
 	int64_t nextTombstoneEraseId = -1;
+
+	bool operator==(TenantTombstoneCleanupData const& other) const;
+	bool operator!=(TenantTombstoneCleanupData const& other) const;
 
 	template <class Ar>
 	void serialize(Ar& ar) {

--- a/fdbserver/include/fdbserver/workloads/MetaclusterData.actor.h
+++ b/fdbserver/include/fdbserver/workloads/MetaclusterData.actor.h
@@ -1,0 +1,252 @@
+
+/*
+ * MetaclusterData.actor.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2023 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+// When actually compiled (NO_INTELLISENSE), include the generated version of this file.  In intellisense use the source
+// version.
+#include "fdbclient/FDBOptions.g.h"
+#include "fdbclient/Tenant.h"
+#include "fdbclient/TenantManagement.actor.h"
+#include "flow/BooleanParam.h"
+#if defined(NO_INTELLISENSE) && !defined(WORKLOADS_METACLUSTER_DATA_ACTOR_G_H)
+#define WORKLOADS_METACLUSTER_DATA_ACTOR_G_H
+#include "fdbserver/workloads/MetaclusterData.actor.g.h"
+#elif !defined(WORKLOADS_METACLUSTER_DATA_ACTOR_H)
+#define WORKLOADS_METACLUSTER_DATA_ACTOR_H
+
+#include "fdbclient/Metacluster.h"
+#include "fdbclient/MetaclusterManagement.actor.h"
+#include "fdbserver/workloads/TenantData.actor.h"
+#include "flow/actorcompiler.h" // This must be the last #include.
+
+template <class DB>
+class MetaclusterData {
+public:
+	struct ManagementClusterData {
+		Optional<MetaclusterRegistrationEntry> metaclusterRegistration;
+		std::map<ClusterName, DataClusterMetadata> dataClusters;
+		KeyBackedRangeResult<std::pair<ClusterName, int64_t>> clusterTenantCounts;
+		KeyBackedRangeResult<UID> registrationTombstones;
+		KeyBackedRangeResult<std::pair<ClusterName, UID>> activeRestoreIds;
+
+		std::map<ClusterName, int64_t> clusterCapacityMap;
+		std::map<ClusterName, std::set<int64_t>> clusterTenantMap;
+		std::map<ClusterName, std::set<TenantGroupName>> clusterTenantGroupMap;
+
+		Optional<int64_t> tenantIdPrefix;
+		TenantData<DB> tenantData;
+
+		// Similar to operator==, but useful in assertions for identifying which member is different
+		void assertEquals(ManagementClusterData const& other) const {
+			ASSERT(metaclusterRegistration == other.metaclusterRegistration);
+			ASSERT(dataClusters == other.dataClusters);
+			ASSERT(clusterTenantCounts == other.clusterTenantCounts);
+			ASSERT(registrationTombstones == other.registrationTombstones);
+			ASSERT(activeRestoreIds == other.activeRestoreIds);
+			ASSERT(clusterCapacityMap == other.clusterCapacityMap);
+			ASSERT(clusterTenantMap == other.clusterTenantMap);
+			ASSERT(clusterTenantGroupMap == other.clusterTenantGroupMap);
+			ASSERT(tenantIdPrefix == other.tenantIdPrefix);
+			tenantData.assertEquals(other.tenantData);
+		}
+
+		bool operator==(ManagementClusterData const& other) const {
+			return metaclusterRegistration == other.metaclusterRegistration && dataClusters == other.dataClusters &&
+			       clusterTenantCounts == other.clusterTenantCounts &&
+			       registrationTombstones == other.registrationTombstones &&
+			       activeRestoreIds == other.activeRestoreIds && clusterCapacityMap == other.clusterCapacityMap &&
+			       clusterTenantMap == other.clusterTenantMap && clusterTenantGroupMap == other.clusterTenantGroupMap &&
+			       tenantIdPrefix == other.tenantIdPrefix && tenantData == other.tenantData;
+		}
+
+		bool operator!=(ManagementClusterData const& other) const { return !(*this == other); }
+	};
+
+	struct DataClusterData {
+		Optional<MetaclusterRegistrationEntry> metaclusterRegistration;
+		TenantData<DB> tenantData;
+
+		// Similar to operator==, but useful in assertions for identifying which member is different
+		void assertEquals(DataClusterData const& other) const {
+			ASSERT(metaclusterRegistration == other.metaclusterRegistration);
+			tenantData.assertEquals(other.tenantData);
+		}
+
+		bool operator==(DataClusterData const& other) const {
+			return metaclusterRegistration == other.metaclusterRegistration;
+		}
+
+		bool operator!=(DataClusterData const& other) const { return !(*this == other); }
+	};
+
+	Reference<DB> managementDb;
+	ManagementClusterData managementMetadata;
+	std::map<ClusterName, DataClusterData> dataClusterMetadata;
+
+private:
+	// Note: this check can only be run on metaclusters with a reasonable number of tenants, as should be
+	// the case with the current metacluster simulation workloads
+	static inline const int metaclusterMaxTenants = 10e6;
+
+	ACTOR static Future<Void> loadManagementClusterMetadata(MetaclusterData* self) {
+		state Reference<typename DB::TransactionT> managementTr = self->managementDb->createTransaction();
+
+		state KeyBackedRangeResult<Tuple> clusterCapacityTuples;
+		state KeyBackedRangeResult<Tuple> clusterTenantTuples;
+		state KeyBackedRangeResult<Tuple> clusterTenantGroupTuples;
+
+		self->managementMetadata.tenantData =
+		    TenantData<DB>(self->managementDb, &MetaclusterAPI::ManagementClusterMetadata::tenantMetadata());
+
+		loop {
+			try {
+				managementTr->setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
+				wait(store(self->managementMetadata.tenantIdPrefix,
+				           TenantMetadata::tenantIdPrefix().get(managementTr)) &&
+				     store(self->managementMetadata.metaclusterRegistration,
+				           MetaclusterMetadata::metaclusterRegistration().get(managementTr)) &&
+				     store(self->managementMetadata.dataClusters,
+				           MetaclusterAPI::listClustersTransaction(
+				               managementTr, ""_sr, "\xff\xff"_sr, CLIENT_KNOBS->MAX_DATA_CLUSTERS + 1)) &&
+				     store(self->managementMetadata.clusterTenantCounts,
+				           MetaclusterAPI::ManagementClusterMetadata::clusterTenantCount.getRange(
+				               managementTr, {}, {}, CLIENT_KNOBS->MAX_DATA_CLUSTERS)) &&
+				     store(self->managementMetadata.registrationTombstones,
+				           MetaclusterMetadata::registrationTombstones().getRange(
+				               managementTr, {}, {}, CLIENT_KNOBS->TOO_MANY)) &&
+				     store(self->managementMetadata.activeRestoreIds,
+				           MetaclusterMetadata::activeRestoreIds().getRange(
+				               managementTr, {}, {}, CLIENT_KNOBS->MAX_DATA_CLUSTERS)) &&
+				     store(clusterCapacityTuples,
+				           MetaclusterAPI::ManagementClusterMetadata::clusterCapacityIndex.getRange(
+				               managementTr, {}, {}, CLIENT_KNOBS->MAX_DATA_CLUSTERS)) &&
+				     store(clusterTenantTuples,
+				           MetaclusterAPI::ManagementClusterMetadata::clusterTenantIndex.getRange(
+				               managementTr, {}, {}, metaclusterMaxTenants)) &&
+				     store(clusterTenantGroupTuples,
+				           MetaclusterAPI::ManagementClusterMetadata::clusterTenantGroupIndex.getRange(
+				               managementTr, {}, {}, metaclusterMaxTenants)) &&
+				     self->managementMetadata.tenantData.load(managementTr));
+
+				break;
+			} catch (Error& e) {
+				wait(safeThreadFutureToFuture(managementTr->onError(e)));
+			}
+		}
+
+		for (auto t : clusterCapacityTuples.results) {
+			ASSERT_EQ(t.size(), 2);
+			int64_t capacity = t.getInt(0);
+			ClusterName clusterName = t.getString(1);
+			ASSERT(self->managementMetadata.clusterCapacityMap.try_emplace(clusterName, capacity).second);
+		}
+
+		for (auto t : clusterTenantTuples.results) {
+			ASSERT_EQ(t.size(), 3);
+			TenantName tenantName = t.getString(1);
+			int64_t tenantId = t.getInt(2);
+			// ASSERT(tenantName == self->managementMetadata.tenantMap[tenantId].tenantName);
+			self->managementMetadata.clusterTenantMap[t.getString(0)].insert(tenantId);
+		}
+
+		for (auto t : clusterTenantGroupTuples.results) {
+			ASSERT_EQ(t.size(), 2);
+			TenantGroupName tenantGroupName = t.getString(1);
+			self->managementMetadata.clusterTenantGroupMap[t.getString(0)].insert(tenantGroupName);
+		}
+
+		return Void();
+	}
+
+	ACTOR static Future<Void> loadDataClusterMetadata(MetaclusterData* self,
+	                                                  ClusterName clusterName,
+	                                                  ClusterConnectionString connectionString) {
+		state std::pair<typename std::map<ClusterName, DataClusterData>::iterator, bool> clusterItr =
+		    self->dataClusterMetadata.try_emplace(clusterName);
+
+		if (clusterItr.second) {
+			state Reference<IDatabase> dataDb = wait(MetaclusterAPI::openDatabase(connectionString));
+			state Reference<ITransaction> tr = dataDb->createTransaction();
+
+			clusterItr.first->second.tenantData = TenantData<IDatabase>(dataDb, &TenantMetadata::instance());
+			loop {
+				try {
+					tr->setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
+					wait(store(clusterItr.first->second.metaclusterRegistration,
+					           MetaclusterMetadata::metaclusterRegistration().get(tr)) &&
+					     clusterItr.first->second.tenantData.load(tr));
+
+					break;
+				} catch (Error& e) {
+					wait(safeThreadFutureToFuture(tr->onError(e)));
+				}
+			}
+		}
+
+		return Void();
+	}
+
+	ACTOR static Future<Void> load(MetaclusterData* self) {
+		wait(loadManagementClusterMetadata(self));
+
+		state std::vector<Future<Void>> dataClusterFutures;
+		for (auto [clusterName, clusterMetadata] : self->managementMetadata.dataClusters) {
+			dataClusterFutures.push_back(loadDataClusterMetadata(self, clusterName, clusterMetadata.connectionString));
+		}
+
+		wait(waitForAll(dataClusterFutures));
+
+		return Void();
+	}
+
+public:
+	MetaclusterData() {}
+	MetaclusterData(Reference<DB> managementDb) : managementDb(managementDb) {}
+
+	Future<Void> load() { return load(this); }
+	Future<Void> loadDataCluster(ClusterName clusterName, ClusterConnectionString connectionString) {
+		return loadDataClusterMetadata(this, clusterName, connectionString);
+	}
+
+	// Similar to operator==, but useful in assertions for identifying which member is different
+	void assertEquals(MetaclusterData const& other) const {
+		managementMetadata.assertEquals(other.managementMetadata);
+
+		for (auto const& [name, data] : dataClusterMetadata) {
+			auto itr = other.dataClusterMetadata.find(name);
+			ASSERT(itr != other.dataClusterMetadata.end());
+			data.assertEquals(itr->second);
+		}
+
+		ASSERT(dataClusterMetadata.size() == other.dataClusterMetadata.size());
+	}
+
+	bool operator==(MetaclusterData const& other) const {
+		return managementMetadata == other.managementMetadata && dataClusterMetadata == other.dataClusterMetadata;
+	}
+
+	bool operator!=(MetaclusterData const& other) const { return !(*this == other); }
+};
+
+#include "flow/unactorcompiler.h"
+
+#endif

--- a/fdbserver/include/fdbserver/workloads/TenantData.actor.h
+++ b/fdbserver/include/fdbserver/workloads/TenantData.actor.h
@@ -1,0 +1,166 @@
+
+/*
+ * TenantData.actor.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2023 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+// When actually compiled (NO_INTELLISENSE), include the generated version of this file.  In intellisense use the source
+// version.
+#include "fdbclient/FDBOptions.g.h"
+#include "fdbclient/KeyBackedTypes.h"
+#include "flow/BooleanParam.h"
+#if defined(NO_INTELLISENSE) && !defined(WORKLOADS_TENANT_DATA_ACTOR_G_H)
+#define WORKLOADS_TENANT_DATA_ACTOR_G_H
+#include "fdbserver/workloads/TenantData.actor.g.h"
+#elif !defined(WORKLOADS_TENANT_DATA_ACTOR_H)
+#define WORKLOADS_TENANT_DATA_ACTOR_H
+
+#include "fdbclient/Metacluster.h"
+#include "fdbclient/MetaclusterManagement.actor.h"
+#include "fdbclient/Tenant.h"
+#include "fdbclient/TenantManagement.actor.h"
+#include "flow/actorcompiler.h" // This must be the last #include.
+
+template <class DB>
+class TenantData {
+	Reference<DB> db;
+	TenantMetadataSpecification* tenantMetadata;
+
+	Optional<MetaclusterRegistrationEntry> metaclusterRegistration;
+	ClusterType clusterType;
+
+	std::map<int64_t, TenantMapEntry> tenantMap;
+	std::map<TenantName, int64_t> tenantNameIndex;
+	int64_t lastTenantId;
+	int64_t tenantCount;
+	std::set<int64_t> tenantTombstones;
+	Optional<TenantTombstoneCleanupData> tombstoneCleanupData;
+	std::map<TenantGroupName, TenantGroupEntry> tenantGroupMap;
+	std::map<TenantGroupName, std::set<int64_t>> tenantGroupIndex;
+	std::map<TenantGroupName, int64_t> storageQuotas;
+
+private:
+	// Note: this check can only be run on metaclusters with a reasonable number of tenants, as should be
+	// the case with the current metacluster simulation workloads
+	static inline const int metaclusterMaxTenants = 10e6;
+
+	ACTOR template <class Transaction>
+	static Future<Void> loadTenantMetadata(TenantData* self, Transaction tr) {
+		state KeyBackedRangeResult<std::pair<int64_t, TenantMapEntry>> tenantList;
+		state KeyBackedRangeResult<std::pair<TenantName, int64_t>> tenantNameIndexList;
+		state KeyBackedRangeResult<int64_t> tenantTombstoneList;
+		state KeyBackedRangeResult<std::pair<TenantGroupName, TenantGroupEntry>> tenantGroupList;
+		state KeyBackedRangeResult<Tuple> tenantGroupTenantTuples;
+		state KeyBackedRangeResult<std::pair<TenantGroupName, int64_t>> storageQuotaList;
+
+		wait(store(self->metaclusterRegistration, MetaclusterMetadata::metaclusterRegistration().get(tr)));
+
+		self->clusterType = self->metaclusterRegistration.present() ? self->metaclusterRegistration.get().clusterType
+		                                                            : ClusterType::STANDALONE;
+
+		wait(store(tenantList, self->tenantMetadata->tenantMap.getRange(tr, {}, {}, metaclusterMaxTenants)) &&
+		     store(tenantNameIndexList,
+		           self->tenantMetadata->tenantNameIndex.getRange(tr, {}, {}, metaclusterMaxTenants)) &&
+		     store(self->lastTenantId, self->tenantMetadata->lastTenantId.getD(tr, Snapshot::False, -1)) &&
+		     store(self->tenantCount, self->tenantMetadata->tenantCount.getD(tr, Snapshot::False, 0)) &&
+		     store(tenantTombstoneList,
+		           self->tenantMetadata->tenantTombstones.getRange(tr, {}, {}, metaclusterMaxTenants)) &&
+		     store(self->tombstoneCleanupData, self->tenantMetadata->tombstoneCleanupData.get(tr)) &&
+		     store(tenantGroupTenantTuples,
+		           self->tenantMetadata->tenantGroupTenantIndex.getRange(tr, {}, {}, metaclusterMaxTenants)) &&
+		     store(tenantGroupList, self->tenantMetadata->tenantGroupMap.getRange(tr, {}, {}, metaclusterMaxTenants)) &&
+		     store(storageQuotaList, self->tenantMetadata->storageQuota.getRange(tr, {}, {}, metaclusterMaxTenants)));
+
+		ASSERT(!tenantList.more);
+		self->tenantMap = std::map<int64_t, TenantMapEntry>(tenantList.results.begin(), tenantList.results.end());
+
+		ASSERT(!tenantNameIndexList.more);
+		self->tenantNameIndex =
+		    std::map<TenantName, int64_t>(tenantNameIndexList.results.begin(), tenantNameIndexList.results.end());
+
+		ASSERT(!tenantTombstoneList.more);
+		self->tenantTombstones =
+		    std::set<int64_t>(tenantTombstoneList.results.begin(), tenantTombstoneList.results.end());
+
+		ASSERT(!tenantGroupList.more);
+		self->tenantGroupMap =
+		    std::map<TenantGroupName, TenantGroupEntry>(tenantGroupList.results.begin(), tenantGroupList.results.end());
+
+		ASSERT(!storageQuotaList.more);
+		self->storageQuotas =
+		    std::map<TenantGroupName, int64_t>(storageQuotaList.results.begin(), storageQuotaList.results.end());
+
+		for (auto t : tenantGroupTenantTuples.results) {
+			ASSERT_EQ(t.size(), 2);
+			TenantGroupName tenantGroupName = t.getString(0);
+			int64_t tenantId = t.getInt(1);
+			ASSERT(self->tenantGroupMap.count(tenantGroupName));
+			ASSERT(self->tenantMap.count(tenantId));
+			self->tenantGroupIndex[tenantGroupName].insert(tenantId);
+		}
+		ASSERT_EQ(self->tenantGroupIndex.size(), self->tenantGroupMap.size());
+
+		return Void();
+	}
+
+public:
+	TenantData() {}
+	TenantData(Reference<DB> db, TenantMetadataSpecification* tenantMetadata)
+	  : db(db), tenantMetadata(tenantMetadata) {}
+
+	Future<Void> load() {
+		return runTransaction([this](Reference<typename DB::TransactionT> tr) { return loadTenantMetadata(this); });
+	}
+
+	template <class Transaction>
+	Future<Void> load(Transaction tr) {
+		return loadTenantMetadata(this, tr);
+	}
+
+	// Similar to operator==, but useful in assertions for identifying which member is different
+	void assertEquals(TenantData const& other) const {
+		ASSERT(metaclusterRegistration == other.metaclusterRegistration);
+		ASSERT_EQ(clusterType, other.clusterType);
+		ASSERT(tenantMap == other.tenantMap);
+		ASSERT(tenantNameIndex == other.tenantNameIndex);
+		ASSERT_EQ(lastTenantId, other.lastTenantId);
+		ASSERT_EQ(tenantCount, other.tenantCount);
+		ASSERT(tenantTombstones == other.tenantTombstones);
+		ASSERT(tombstoneCleanupData == other.tombstoneCleanupData);
+		ASSERT(tenantGroupMap == other.tenantGroupMap);
+		ASSERT(tenantGroupIndex == other.tenantGroupIndex);
+		ASSERT(storageQuotas == other.storageQuotas);
+	}
+
+	bool operator==(TenantData const& other) const {
+		return metaclusterRegistration == other.metaclusterRegistration && clusterType == other.clusterType &&
+		       tenantMap == other.tenantMap && tenantNameIndex == other.tenantNameIndex &&
+		       lastTenantId == other.lastTenantId && tenantCount == other.tenantCount &&
+		       tenantTombstones == other.tenantTombstones && tombstoneCleanupData == other.tombstoneCleanupData &&
+		       tenantGroupMap == other.tenantGroupMap && tenantGroupIndex == other.tenantGroupIndex &&
+		       storageQuotas == other.storageQuotas;
+	}
+
+	bool operator!=(TenantData const& other) const { return !(*this == other); }
+};
+
+#include "flow/unactorcompiler.h"
+
+#endif


### PR DESCRIPTION
Add testing to verify that nothing gets changed when running a metacluster restore dry-run. This uses a couple new classes that can be used to load all metacluster and tenant metadata.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
