### PR TITLE
When clearing tenants at the end of a simulation test, reset the transaction when looping

### DIFF
--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -925,6 +925,8 @@ ACTOR Future<Void> clearData(Database cx, Optional<TenantName> defaultTenant) {
 				TraceEvent("TesterClearingTenantsComplete", debugID).detail("AtVersion", tr.getCommittedVersion());
 				break;
 			}
+
+			tr.reset();
 		} catch (Error& e) {
 			TraceEvent(SevWarn, "TesterClearingTenantsError", debugID).error(e);
 			wait(tr.onError(e));


### PR DESCRIPTION
The tenant deletion at the end of simulated tests is done in batches, but we weren't reseting the transaction between batches.

This was discovered and fixed by @sfc-gh-jfu in a larger PR, and I've extracted it so we can get it merged faster.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
