### PR TITLE
Increase coverage for slow tests in TestHarness2

### DIFF
--- a/contrib/TestHarness2/test_harness/run.py
+++ b/contrib/TestHarness2/test_harness/run.py
@@ -223,15 +223,29 @@ class TestPicker:
         return res
 
     def choose_test(self) -> List[Path]:
-        min_runtime: float | None = None
         candidates: List[TestDescription] = []
-        for _, v in self.tests.items():
-            this_time = v.total_runtime * v.priority
-            if min_runtime is None or this_time < min_runtime:
-                min_runtime = this_time
-                candidates = [v]
-            elif this_time == min_runtime:
-                candidates.append(v)
+
+        if config.random.random() < 0.99:
+            # 99% of the time, select a test with the least runtime
+            min_runtime: float | None = None
+            for _, v in self.tests.items():
+                this_time = v.total_runtime * v.priority
+                if min_runtime is None or this_time < min_runtime:
+                    min_runtime = this_time
+                    candidates = [v]
+                elif this_time == min_runtime:
+                    candidates.append(v)
+        else:
+            # 1% of the time, select the test with the fewest runs, rather than the test
+            # with the least runtime. This is to improve coverage for long-running tests
+            min_runs: int | None = None
+            for _, v in self.tests.items():
+                if min_runs is None or v.num_runs < min_runs:
+                    min_runs = v.num_runs
+                    candidates = [v]
+                elif v.num_runs == min_runs:
+                    candidates.append(v)
+
         candidates.sort()
         choice = config.random.randint(0, len(candidates) - 1)
         test = candidates[choice]


### PR DESCRIPTION
For 1% of test selections, select the test that's been run the fewest number of times, ignoring CPU statistics (in TestHarness2).

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
