### PR TITLE
Fix determinism in the generated bindingtester API tests

### DIFF
--- a/bindings/bindingtester/tests/api.py
+++ b/bindings/bindingtester/tests/api.py
@@ -168,7 +168,10 @@ class ApiTest(Test):
         if len(self.allocated_tenants) == 0 or random.random() < new_tenant_probability:
             return self.random.random_string(random.randint(0, 30))
         else:
-            return random.choice(list(self.allocated_tenants))
+            tenant_list = list(self.allocated_tenants)
+            # sort to ensure deterministic selection of a tenant
+            tenant_list.sort()
+            return random.choice(tenant_list)
 
     def generate(self, args, thread_number):
         instructions = InstructionSet()

--- a/bindings/bindingtester/tests/api.py
+++ b/bindings/bindingtester/tests/api.py
@@ -33,23 +33,32 @@ fdb.api_version(FDB_API_VERSION)
 
 
 def matches_op(op, target_op):
-    return op == target_op or op == target_op + '_SNAPSHOT' or op == target_op + '_DATABASE' or op == target_op + '_TENANT'
+    return (
+        op == target_op
+        or op == target_op + "_SNAPSHOT"
+        or op == target_op + "_DATABASE"
+        or op == target_op + "_TENANT"
+    )
 
 
 def is_non_transaction_op(op):
-    return op.endswith('_DATABASE') or op.endswith('_TENANT')
+    return op.endswith("_DATABASE") or op.endswith("_TENANT")
 
 
 class ApiTest(Test):
     def __init__(self, subspace):
         super(ApiTest, self).__init__(subspace)
-        self.workspace = self.subspace['workspace']  # The keys and values here must match between subsequent runs of the same test
-        self.scratch = self.subspace['scratch']  # The keys and values here can differ between runs
-        self.stack_subspace = self.subspace['stack']
+        self.workspace = self.subspace[
+            "workspace"
+        ]  # The keys and values here must match between subsequent runs of the same test
+        self.scratch = self.subspace[
+            "scratch"
+        ]  # The keys and values here can differ between runs
+        self.stack_subspace = self.subspace["stack"]
 
-        self.versionstamped_values = self.scratch['versionstamped_values']
-        self.versionstamped_values_2 = self.scratch['versionstamped_values_2']
-        self.versionstamped_keys = self.scratch['versionstamped_keys']
+        self.versionstamped_values = self.scratch["versionstamped_values"]
+        self.versionstamped_values_2 = self.scratch["versionstamped_values_2"]
+        self.versionstamped_keys = self.scratch["versionstamped_keys"]
 
     def setup(self, args):
         self.stack_size = 0
@@ -64,7 +73,9 @@ class ApiTest(Test):
 
         self.generated_keys = []
         self.outstanding_ops = []
-        self.random = test_util.RandomGenerator(args.max_int_bits, args.api_version, args.types)
+        self.random = test_util.RandomGenerator(
+            args.max_int_bits, args.api_version, args.types
+        )
         self.api_version = args.api_version
         self.allocated_tenants = set()
 
@@ -88,7 +99,9 @@ class ApiTest(Test):
         self.string_depth = max(0, self.string_depth - num)
         self.key_depth = max(0, self.key_depth - num)
 
-        self.outstanding_ops = [i for i in self.outstanding_ops if i[0] <= self.stack_size]
+        self.outstanding_ops = [
+            i for i in self.outstanding_ops if i[0] <= self.stack_size
+        ]
 
     def ensure_string(self, instructions, num):
         while self.string_depth < num:
@@ -101,7 +114,7 @@ class ApiTest(Test):
         if random.random() < float(len(self.generated_keys)) / self.max_keys:
             tup = random.choice(self.generated_keys)
             if random.random() < 0.3:
-                return self.workspace.pack(tup[0:random.randint(0, len(tup))])
+                return self.workspace.pack(tup[0 : random.randint(0, len(tup))])
 
             return self.workspace.pack(tup)
 
@@ -119,7 +132,9 @@ class ApiTest(Test):
 
     def ensure_key_value(self, instructions):
         if self.string_depth == 0:
-            instructions.push_args(self.choose_key(), self.random.random_string(random.randint(0, 100)))
+            instructions.push_args(
+                self.choose_key(), self.random.random_string(random.randint(0, 100))
+            )
 
         elif self.string_depth == 1 or self.key_depth == 0:
             self.ensure_key(instructions, 1)
@@ -131,7 +146,7 @@ class ApiTest(Test):
     def preload_database(self, instructions, num):
         for i in range(num):
             self.ensure_key_value(instructions)
-            instructions.append('SET')
+            instructions.append("SET")
 
             if i % 100 == 99:
                 test_util.blocking_commit(instructions)
@@ -140,11 +155,14 @@ class ApiTest(Test):
         self.add_stack_items(1)
 
     def wait_for_reads(self, instructions):
-        while len(self.outstanding_ops) > 0 and self.outstanding_ops[-1][0] <= self.stack_size:
+        while (
+            len(self.outstanding_ops) > 0
+            and self.outstanding_ops[-1][0] <= self.stack_size
+        ):
             read = self.outstanding_ops.pop()
             # print '%d. waiting for read at instruction %r' % (len(instructions), read)
             test_util.to_front(instructions, self.stack_size - read[0])
-            instructions.append('WAIT_FUTURE')
+            instructions.append("WAIT_FUTURE")
 
     def choose_tenant(self, new_tenant_probability):
         if len(self.allocated_tenants) == 0 or random.random() < new_tenant_probability:
@@ -155,27 +173,60 @@ class ApiTest(Test):
     def generate(self, args, thread_number):
         instructions = InstructionSet()
 
-        op_choices = ['NEW_TRANSACTION', 'COMMIT']
+        op_choices = ["NEW_TRANSACTION", "COMMIT"]
 
-        reads = ['GET', 'GET_KEY', 'GET_RANGE', 'GET_RANGE_STARTS_WITH', 'GET_RANGE_SELECTOR']
-        mutations = ['SET', 'CLEAR', 'CLEAR_RANGE', 'CLEAR_RANGE_STARTS_WITH', 'ATOMIC_OP']
-        snapshot_reads = [x + '_SNAPSHOT' for x in reads]
-        database_reads = [x + '_DATABASE' for x in reads]
-        database_mutations = [x + '_DATABASE' for x in mutations]
-        tenant_reads = [x + '_TENANT' for x in reads]
-        tenant_mutations = [x + '_TENANT' for x in mutations]
-        mutations += ['VERSIONSTAMP']
-        versions = ['GET_READ_VERSION', 'SET_READ_VERSION', 'GET_COMMITTED_VERSION']
-        snapshot_versions = ['GET_READ_VERSION_SNAPSHOT']
-        tuples = ['TUPLE_PACK', 'TUPLE_UNPACK', 'TUPLE_RANGE', 'TUPLE_SORT', 'SUB', 'ENCODE_FLOAT', 'ENCODE_DOUBLE', 'DECODE_DOUBLE', 'DECODE_FLOAT']
-        if 'versionstamp' in args.types:
-            tuples.append('TUPLE_PACK_WITH_VERSIONSTAMP')
-        resets = ['ON_ERROR', 'RESET', 'CANCEL']
-        read_conflicts = ['READ_CONFLICT_RANGE', 'READ_CONFLICT_KEY']
-        write_conflicts = ['WRITE_CONFLICT_RANGE', 'WRITE_CONFLICT_KEY', 'DISABLE_WRITE_CONFLICT']
-        txn_sizes = ['GET_APPROXIMATE_SIZE']
-        storage_metrics = ['GET_ESTIMATED_RANGE_SIZE', 'GET_RANGE_SPLIT_POINTS']
-        tenants = ['TENANT_CREATE', 'TENANT_DELETE', 'TENANT_SET_ACTIVE', 'TENANT_CLEAR_ACTIVE', 'TENANT_LIST', 'TENANT_GET_ID']
+        reads = [
+            "GET",
+            "GET_KEY",
+            "GET_RANGE",
+            "GET_RANGE_STARTS_WITH",
+            "GET_RANGE_SELECTOR",
+        ]
+        mutations = [
+            "SET",
+            "CLEAR",
+            "CLEAR_RANGE",
+            "CLEAR_RANGE_STARTS_WITH",
+            "ATOMIC_OP",
+        ]
+        snapshot_reads = [x + "_SNAPSHOT" for x in reads]
+        database_reads = [x + "_DATABASE" for x in reads]
+        database_mutations = [x + "_DATABASE" for x in mutations]
+        tenant_reads = [x + "_TENANT" for x in reads]
+        tenant_mutations = [x + "_TENANT" for x in mutations]
+        mutations += ["VERSIONSTAMP"]
+        versions = ["GET_READ_VERSION", "SET_READ_VERSION", "GET_COMMITTED_VERSION"]
+        snapshot_versions = ["GET_READ_VERSION_SNAPSHOT"]
+        tuples = [
+            "TUPLE_PACK",
+            "TUPLE_UNPACK",
+            "TUPLE_RANGE",
+            "TUPLE_SORT",
+            "SUB",
+            "ENCODE_FLOAT",
+            "ENCODE_DOUBLE",
+            "DECODE_DOUBLE",
+            "DECODE_FLOAT",
+        ]
+        if "versionstamp" in args.types:
+            tuples.append("TUPLE_PACK_WITH_VERSIONSTAMP")
+        resets = ["ON_ERROR", "RESET", "CANCEL"]
+        read_conflicts = ["READ_CONFLICT_RANGE", "READ_CONFLICT_KEY"]
+        write_conflicts = [
+            "WRITE_CONFLICT_RANGE",
+            "WRITE_CONFLICT_KEY",
+            "DISABLE_WRITE_CONFLICT",
+        ]
+        txn_sizes = ["GET_APPROXIMATE_SIZE"]
+        storage_metrics = ["GET_ESTIMATED_RANGE_SIZE", "GET_RANGE_SPLIT_POINTS"]
+        tenants = [
+            "TENANT_CREATE",
+            "TENANT_DELETE",
+            "TENANT_SET_ACTIVE",
+            "TENANT_CLEAR_ACTIVE",
+            "TENANT_LIST",
+            "TENANT_GET_ID",
+        ]
 
         op_choices += reads
         op_choices += mutations
@@ -196,16 +247,23 @@ class ApiTest(Test):
             op_choices += tenant_reads
             op_choices += tenant_mutations
 
-        idempotent_atomic_ops = ['BIT_AND', 'BIT_OR', 'MAX', 'MIN', 'BYTE_MIN', 'BYTE_MAX']
-        atomic_ops = idempotent_atomic_ops + ['ADD', 'BIT_XOR', 'APPEND_IF_FITS']
+        idempotent_atomic_ops = [
+            "BIT_AND",
+            "BIT_OR",
+            "MAX",
+            "MIN",
+            "BYTE_MIN",
+            "BYTE_MAX",
+        ]
+        atomic_ops = idempotent_atomic_ops + ["ADD", "BIT_XOR", "APPEND_IF_FITS"]
 
         if args.concurrency > 1:
             self.max_keys = random.randint(100, 1000)
         else:
             self.max_keys = random.randint(100, 10000)
 
-        instructions.append('NEW_TRANSACTION')
-        instructions.append('GET_READ_VERSION')
+        instructions.append("NEW_TRANSACTION")
+        instructions.append("GET_READ_VERSION")
 
         self.preload_database(instructions, self.max_keys)
 
@@ -218,25 +276,29 @@ class ApiTest(Test):
 
             # print 'Adding instruction %s at %d' % (op, index)
 
-            if args.concurrency == 1 and (op in database_mutations or op in tenant_mutations or op in ['TENANT_CREATE', 'TENANT_DELETE']):
+            if args.concurrency == 1 and (
+                op in database_mutations
+                or op in tenant_mutations
+                or op in ["TENANT_CREATE", "TENANT_DELETE"]
+            ):
                 self.wait_for_reads(instructions)
                 test_util.blocking_commit(instructions)
                 self.can_get_commit_version = False
                 self.add_stack_items(1)
 
-            if op in resets or op == 'NEW_TRANSACTION':
+            if op in resets or op == "NEW_TRANSACTION":
                 if args.concurrency == 1:
                     self.wait_for_reads(instructions)
 
                 self.outstanding_ops = []
 
-            if op == 'NEW_TRANSACTION':
+            if op == "NEW_TRANSACTION":
                 instructions.append(op)
                 self.can_get_commit_version = True
                 self.can_set_version = True
                 self.can_use_key_selectors = True
 
-            elif op == 'ON_ERROR':
+            elif op == "ON_ERROR":
                 instructions.push_args(random.randint(0, 5000))
                 instructions.append(op)
 
@@ -244,20 +306,20 @@ class ApiTest(Test):
                 if args.concurrency == 1:
                     self.wait_for_reads(instructions)
 
-                instructions.append('NEW_TRANSACTION')
+                instructions.append("NEW_TRANSACTION")
                 self.can_get_commit_version = True
                 self.can_set_version = True
                 self.can_use_key_selectors = True
                 self.add_strings(1)
 
-            elif matches_op(op, 'GET'):
+            elif matches_op(op, "GET"):
                 self.ensure_key(instructions, 1)
                 instructions.append(op)
                 self.add_strings(1)
                 self.can_set_version = False
                 read_performed = True
 
-            elif matches_op(op, 'GET_KEY'):
+            elif matches_op(op, "GET_KEY"):
                 if is_non_transaction_op(op) or self.can_use_key_selectors:
                     self.ensure_key(instructions, 1)
                     instructions.push_args(self.workspace.key())
@@ -270,7 +332,7 @@ class ApiTest(Test):
                     self.can_set_version = False
                     read_performed = True
 
-            elif matches_op(op, 'GET_RANGE'):
+            elif matches_op(op, "GET_RANGE"):
                 self.ensure_key(instructions, 2)
                 range_params = self.random.random_range_params()
                 instructions.push_args(*range_params)
@@ -278,7 +340,9 @@ class ApiTest(Test):
                 test_util.to_front(instructions, 4)
                 instructions.append(op)
 
-                if range_params[0] >= 1 and range_params[0] <= 1000:  # avoid adding a string if the limit is large
+                if (
+                    range_params[0] >= 1 and range_params[0] <= 1000
+                ):  # avoid adding a string if the limit is large
                     self.add_strings(1)
                 else:
                     self.add_stack_items(1)
@@ -286,7 +350,7 @@ class ApiTest(Test):
                 self.can_set_version = False
                 read_performed = True
 
-            elif matches_op(op, 'GET_RANGE_STARTS_WITH'):
+            elif matches_op(op, "GET_RANGE_STARTS_WITH"):
                 # TODO: not tested well
                 self.ensure_key(instructions, 1)
                 range_params = self.random.random_range_params()
@@ -294,7 +358,9 @@ class ApiTest(Test):
                 test_util.to_front(instructions, 3)
                 instructions.append(op)
 
-                if range_params[0] >= 1 and range_params[0] <= 1000:  # avoid adding a string if the limit is large
+                if (
+                    range_params[0] >= 1 and range_params[0] <= 1000
+                ):  # avoid adding a string if the limit is large
                     self.add_strings(1)
                 else:
                     self.add_stack_items(1)
@@ -302,7 +368,7 @@ class ApiTest(Test):
                 self.can_set_version = False
                 read_performed = True
 
-            elif matches_op(op, 'GET_RANGE_SELECTOR'):
+            elif matches_op(op, "GET_RANGE_SELECTOR"):
                 if is_non_transaction_op(op) or self.can_use_key_selectors:
                     self.ensure_key(instructions, 2)
                     instructions.push_args(self.workspace.key())
@@ -314,7 +380,9 @@ class ApiTest(Test):
                     test_util.to_front(instructions, 9)
                     instructions.append(op)
 
-                    if range_params[0] >= 1 and range_params[0] <= 1000:  # avoid adding a string if the limit is large
+                    if (
+                        range_params[0] >= 1 and range_params[0] <= 1000
+                    ):  # avoid adding a string if the limit is large
                         self.add_strings(1)
                     else:
                         self.add_stack_items(1)
@@ -322,29 +390,29 @@ class ApiTest(Test):
                     self.can_set_version = False
                     read_performed = True
 
-            elif matches_op(op, 'GET_READ_VERSION'):
+            elif matches_op(op, "GET_READ_VERSION"):
                 instructions.append(op)
                 self.has_version = self.can_set_version
                 self.add_strings(1)
 
-            elif matches_op(op, 'SET'):
+            elif matches_op(op, "SET"):
                 self.ensure_key_value(instructions)
                 instructions.append(op)
                 if is_non_transaction_op(op):
                     self.add_stack_items(1)
 
-            elif op == 'SET_READ_VERSION':
+            elif op == "SET_READ_VERSION":
                 if self.has_version and self.can_set_version:
                     instructions.append(op)
                     self.can_set_version = False
 
-            elif matches_op(op, 'CLEAR'):
+            elif matches_op(op, "CLEAR"):
                 self.ensure_key(instructions, 1)
                 instructions.append(op)
                 if is_non_transaction_op(op):
                     self.add_stack_items(1)
 
-            elif matches_op(op, 'CLEAR_RANGE'):
+            elif matches_op(op, "CLEAR_RANGE"):
                 # Protect against inverted range
                 key1 = self.workspace.pack(self.random.random_tuple(5))
                 key2 = self.workspace.pack(self.random.random_tuple(5))
@@ -358,13 +426,13 @@ class ApiTest(Test):
                 if is_non_transaction_op(op):
                     self.add_stack_items(1)
 
-            elif matches_op(op, 'CLEAR_RANGE_STARTS_WITH'):
+            elif matches_op(op, "CLEAR_RANGE_STARTS_WITH"):
                 self.ensure_key(instructions, 1)
                 instructions.append(op)
                 if is_non_transaction_op(op):
                     self.add_stack_items(1)
 
-            elif matches_op(op, 'ATOMIC_OP'):
+            elif matches_op(op, "ATOMIC_OP"):
                 self.ensure_key_value(instructions)
                 if is_non_transaction_op(op) and args.concurrency == 1:
                     instructions.push_args(random.choice(idempotent_atomic_ops))
@@ -375,50 +443,58 @@ class ApiTest(Test):
                 if is_non_transaction_op(op):
                     self.add_stack_items(1)
 
-            elif op == 'VERSIONSTAMP':
+            elif op == "VERSIONSTAMP":
                 rand_str1 = self.random.random_string(100)
                 key1 = self.versionstamped_values.pack((rand_str1,))
                 key2 = self.versionstamped_values_2.pack((rand_str1,))
 
                 split = random.randint(0, 70)
                 prefix = self.random.random_string(20 + split)
-                if prefix.endswith(b'\xff'):
+                if prefix.endswith(b"\xff"):
                     # Necessary to make sure that the SET_VERSIONSTAMPED_VALUE check
                     # correctly finds where the version is supposed to fit in.
-                    prefix += b'\x00'
+                    prefix += b"\x00"
                 suffix = self.random.random_string(70 - split)
                 rand_str2 = prefix + fdb.tuple.Versionstamp._UNSET_TR_VERSION + suffix
                 key3 = self.versionstamped_keys.pack() + rand_str2
                 index = len(self.versionstamped_keys.pack()) + len(prefix)
                 key3 = self.versionstamp_key(key3, index)
 
-                instructions.push_args('SET_VERSIONSTAMPED_VALUE',
-                                       key1,
-                                       self.versionstamp_value(fdb.tuple.Versionstamp._UNSET_TR_VERSION + rand_str2))
-                instructions.append('ATOMIC_OP')
+                instructions.push_args(
+                    "SET_VERSIONSTAMPED_VALUE",
+                    key1,
+                    self.versionstamp_value(
+                        fdb.tuple.Versionstamp._UNSET_TR_VERSION + rand_str2
+                    ),
+                )
+                instructions.append("ATOMIC_OP")
 
                 if args.api_version >= 520:
-                    instructions.push_args('SET_VERSIONSTAMPED_VALUE', key2, self.versionstamp_value(rand_str2, len(prefix)))
-                    instructions.append('ATOMIC_OP')
+                    instructions.push_args(
+                        "SET_VERSIONSTAMPED_VALUE",
+                        key2,
+                        self.versionstamp_value(rand_str2, len(prefix)),
+                    )
+                    instructions.append("ATOMIC_OP")
 
-                instructions.push_args('SET_VERSIONSTAMPED_KEY', key3, rand_str1)
-                instructions.append('ATOMIC_OP')
+                instructions.push_args("SET_VERSIONSTAMPED_KEY", key3, rand_str1)
+                instructions.append("ATOMIC_OP")
                 self.can_use_key_selectors = False
 
-            elif op == 'READ_CONFLICT_RANGE' or op == 'WRITE_CONFLICT_RANGE':
+            elif op == "READ_CONFLICT_RANGE" or op == "WRITE_CONFLICT_RANGE":
                 self.ensure_key(instructions, 2)
                 instructions.append(op)
                 self.add_strings(1)
 
-            elif op == 'READ_CONFLICT_KEY' or op == 'WRITE_CONFLICT_KEY':
+            elif op == "READ_CONFLICT_KEY" or op == "WRITE_CONFLICT_KEY":
                 self.ensure_key(instructions, 1)
                 instructions.append(op)
                 self.add_strings(1)
 
-            elif op == 'DISABLE_WRITE_CONFLICT':
+            elif op == "DISABLE_WRITE_CONFLICT":
                 instructions.append(op)
 
-            elif op == 'COMMIT':
+            elif op == "COMMIT":
                 if args.concurrency == 1 or i < self.max_keys or random.random() < 0.9:
                     if args.concurrency == 1:
                         self.wait_for_reads(instructions)
@@ -431,23 +507,23 @@ class ApiTest(Test):
                     instructions.append(op)
                     self.add_strings(1)
 
-            elif op == 'RESET':
+            elif op == "RESET":
                 instructions.append(op)
                 self.can_get_commit_version = False
                 self.can_set_version = True
                 self.can_use_key_selectors = True
 
-            elif op == 'CANCEL':
+            elif op == "CANCEL":
                 instructions.append(op)
                 self.can_set_version = False
 
-            elif op == 'GET_COMMITTED_VERSION':
+            elif op == "GET_COMMITTED_VERSION":
                 if self.can_get_commit_version:
                     do_commit = random.random() < 0.5
 
                     if do_commit:
-                        instructions.append('COMMIT')
-                        instructions.append('WAIT_FUTURE')
+                        instructions.append("COMMIT")
+                        instructions.append("WAIT_FUTURE")
                         self.add_stack_items(1)
 
                     instructions.append(op)
@@ -456,35 +532,47 @@ class ApiTest(Test):
                     self.add_strings(1)
 
                     if do_commit:
-                        instructions.append('RESET')
+                        instructions.append("RESET")
                         self.can_get_commit_version = False
                         self.can_set_version = True
                         self.can_use_key_selectors = True
 
-            elif op == 'GET_APPROXIMATE_SIZE':
+            elif op == "GET_APPROXIMATE_SIZE":
                 instructions.append(op)
                 self.add_strings(1)
 
-            elif op == 'TUPLE_PACK' or op == 'TUPLE_RANGE':
+            elif op == "TUPLE_PACK" or op == "TUPLE_RANGE":
                 tup = self.random.random_tuple(10)
                 instructions.push_args(len(tup), *tup)
                 instructions.append(op)
-                if op == 'TUPLE_PACK':
+                if op == "TUPLE_PACK":
                     self.add_strings(1)
                 else:
                     self.add_strings(2)
 
-            elif op == 'TUPLE_PACK_WITH_VERSIONSTAMP':
-                tup = (self.random.random_string(20),) + self.random.random_tuple(10, incomplete_versionstamps=True)
+            elif op == "TUPLE_PACK_WITH_VERSIONSTAMP":
+                tup = (self.random.random_string(20),) + self.random.random_tuple(
+                    10, incomplete_versionstamps=True
+                )
                 prefix = self.versionstamped_keys.pack()
                 instructions.push_args(prefix, len(tup), *tup)
                 instructions.append(op)
                 self.add_strings(1)
 
                 versionstamp_param = prefix + fdb.tuple.pack(tup)
-                first_incomplete = versionstamp_param.find(fdb.tuple.Versionstamp._UNSET_TR_VERSION)
-                second_incomplete = -1 if first_incomplete < 0 else \
-                    versionstamp_param.find(fdb.tuple.Versionstamp._UNSET_TR_VERSION, first_incomplete + len(fdb.tuple.Versionstamp._UNSET_TR_VERSION) + 1)
+                first_incomplete = versionstamp_param.find(
+                    fdb.tuple.Versionstamp._UNSET_TR_VERSION
+                )
+                second_incomplete = (
+                    -1
+                    if first_incomplete < 0
+                    else versionstamp_param.find(
+                        fdb.tuple.Versionstamp._UNSET_TR_VERSION,
+                        first_incomplete
+                        + len(fdb.tuple.Versionstamp._UNSET_TR_VERSION)
+                        + 1,
+                    )
+                )
 
                 # If there is exactly one incomplete versionstamp, perform the versionstamp operation.
                 if first_incomplete >= 0 and second_incomplete < 0:
@@ -492,76 +580,90 @@ class ApiTest(Test):
 
                     instructions.push_args(rand_str)
                     test_util.to_front(instructions, 1)
-                    instructions.push_args('SET_VERSIONSTAMPED_KEY')
-                    instructions.append('ATOMIC_OP')
+                    instructions.push_args("SET_VERSIONSTAMPED_KEY")
+                    instructions.append("ATOMIC_OP")
 
                     if self.api_version >= 520:
-                        version_value_key_2 = self.versionstamped_values_2.pack((rand_str,))
-                        versionstamped_value = self.versionstamp_value(fdb.tuple.pack(tup), first_incomplete - len(prefix))
-                        instructions.push_args('SET_VERSIONSTAMPED_VALUE', version_value_key_2, versionstamped_value)
-                        instructions.append('ATOMIC_OP')
+                        version_value_key_2 = self.versionstamped_values_2.pack(
+                            (rand_str,)
+                        )
+                        versionstamped_value = self.versionstamp_value(
+                            fdb.tuple.pack(tup), first_incomplete - len(prefix)
+                        )
+                        instructions.push_args(
+                            "SET_VERSIONSTAMPED_VALUE",
+                            version_value_key_2,
+                            versionstamped_value,
+                        )
+                        instructions.append("ATOMIC_OP")
 
                     version_value_key = self.versionstamped_values.pack((rand_str,))
-                    instructions.push_args('SET_VERSIONSTAMPED_VALUE', version_value_key,
-                                           self.versionstamp_value(fdb.tuple.Versionstamp._UNSET_TR_VERSION + fdb.tuple.pack(tup)))
-                    instructions.append('ATOMIC_OP')
+                    instructions.push_args(
+                        "SET_VERSIONSTAMPED_VALUE",
+                        version_value_key,
+                        self.versionstamp_value(
+                            fdb.tuple.Versionstamp._UNSET_TR_VERSION
+                            + fdb.tuple.pack(tup)
+                        ),
+                    )
+                    instructions.append("ATOMIC_OP")
                     self.can_use_key_selectors = False
 
-            elif op == 'TUPLE_UNPACK':
+            elif op == "TUPLE_UNPACK":
                 tup = self.random.random_tuple(10)
                 instructions.push_args(len(tup), *tup)
-                instructions.append('TUPLE_PACK')
+                instructions.append("TUPLE_PACK")
                 instructions.append(op)
                 self.add_strings(len(tup))
 
-            elif op == 'TUPLE_SORT':
+            elif op == "TUPLE_SORT":
                 tups = self.random.random_tuple_list(10, 30)
                 for tup in tups:
                     instructions.push_args(len(tup), *tup)
-                    instructions.append('TUPLE_PACK')
+                    instructions.append("TUPLE_PACK")
                 instructions.push_args(len(tups))
                 instructions.append(op)
                 self.add_strings(len(tups))
 
             # Use SUB to test if integers are correctly unpacked
-            elif op == 'SUB':
+            elif op == "SUB":
                 a = self.random.random_int() // 2
                 b = self.random.random_int() // 2
                 instructions.push_args(0, a, b)
                 instructions.append(op)
                 instructions.push_args(1)
-                instructions.append('SWAP')
+                instructions.append("SWAP")
                 instructions.append(op)
                 instructions.push_args(1)
-                instructions.append('TUPLE_PACK')
+                instructions.append("TUPLE_PACK")
                 self.add_stack_items(1)
 
-            elif op == 'ENCODE_FLOAT':
+            elif op == "ENCODE_FLOAT":
                 f = self.random.random_float(8)
-                f_bytes = struct.pack('>f', f)
+                f_bytes = struct.pack(">f", f)
                 instructions.push_args(f_bytes)
                 instructions.append(op)
                 self.add_stack_items(1)
 
-            elif op == 'ENCODE_DOUBLE':
+            elif op == "ENCODE_DOUBLE":
                 d = self.random.random_float(11)
-                d_bytes = struct.pack('>d', d)
+                d_bytes = struct.pack(">d", d)
                 instructions.push_args(d_bytes)
                 instructions.append(op)
                 self.add_stack_items(1)
 
-            elif op == 'DECODE_FLOAT':
+            elif op == "DECODE_FLOAT":
                 f = self.random.random_float(8)
                 instructions.push_args(fdb.tuple.SingleFloat(f))
                 instructions.append(op)
                 self.add_strings(1)
 
-            elif op == 'DECODE_DOUBLE':
+            elif op == "DECODE_DOUBLE":
                 d = self.random.random_float(11)
                 instructions.push_args(d)
                 instructions.append(op)
                 self.add_strings(1)
-            elif op == 'GET_ESTIMATED_RANGE_SIZE':
+            elif op == "GET_ESTIMATED_RANGE_SIZE":
                 # Protect against inverted range and identical keys
                 key1 = self.workspace.pack(self.random.random_tuple(1))
                 key2 = self.workspace.pack(self.random.random_tuple(1))
@@ -576,7 +678,7 @@ class ApiTest(Test):
                 instructions.push_args(key1, key2)
                 instructions.append(op)
                 self.add_strings(1)
-            elif op == 'GET_RANGE_SPLIT_POINTS':
+            elif op == "GET_RANGE_SPLIT_POINTS":
                 # Protect against inverted range and identical keys
                 key1 = self.workspace.pack(self.random.random_tuple(1))
                 key2 = self.workspace.pack(self.random.random_tuple(1))
@@ -593,27 +695,27 @@ class ApiTest(Test):
                 instructions.push_args(key1, key2, chunkSize)
                 instructions.append(op)
                 self.add_strings(1)
-            elif op == 'TENANT_CREATE':
+            elif op == "TENANT_CREATE":
                 tenant_name = self.choose_tenant(0.8)
                 self.allocated_tenants.add(tenant_name)
                 instructions.push_args(tenant_name)
                 instructions.append(op)
                 self.add_strings(1)
-            elif op == 'TENANT_DELETE':
+            elif op == "TENANT_DELETE":
                 tenant_name = self.choose_tenant(0.2)
                 if tenant_name in self.allocated_tenants:
                     self.allocated_tenants.remove(tenant_name)
                 instructions.push_args(tenant_name)
                 instructions.append(op)
                 self.add_strings(1)
-            elif op == 'TENANT_SET_ACTIVE':
+            elif op == "TENANT_SET_ACTIVE":
                 tenant_name = self.choose_tenant(0.8)
                 instructions.push_args(tenant_name)
                 instructions.append(op)
                 self.add_strings(1)
-            elif op == 'TENANT_CLEAR_ACTIVE':
+            elif op == "TENANT_CLEAR_ACTIVE":
                 instructions.append(op)
-            elif op == 'TENANT_LIST':
+            elif op == "TENANT_LIST":
                 self.ensure_string(instructions, 2)
                 instructions.push_args(self.random.random_int())
                 test_util.to_front(instructions, 2)
@@ -624,27 +726,33 @@ class ApiTest(Test):
                 instructions.append(op)
                 self.add_strings(1)
             else:
-                assert False, 'Unknown operation: ' + op
+                assert False, "Unknown operation: " + op
 
             if read_performed and op not in database_reads and op not in tenant_reads:
                 self.outstanding_ops.append((self.stack_size, len(instructions) - 1))
 
-            if args.concurrency == 1 and (op in database_reads or op in database_mutations or op in tenant_reads or op in tenant_mutations or op in ['TENANT_CREATE', 'TENANT_DELETE']):
-                instructions.append('WAIT_FUTURE')
+            if args.concurrency == 1 and (
+                op in database_reads
+                or op in database_mutations
+                or op in tenant_reads
+                or op in tenant_mutations
+                or op in ["TENANT_CREATE", "TENANT_DELETE"]
+            ):
+                instructions.append("WAIT_FUTURE")
 
         instructions.begin_finalization()
 
         if not args.no_tenants:
-            instructions.append('TENANT_CLEAR_ACTIVE')
+            instructions.append("TENANT_CLEAR_ACTIVE")
 
         if args.concurrency == 1:
             self.wait_for_reads(instructions)
             test_util.blocking_commit(instructions)
             self.add_stack_items(1)
 
-        instructions.append('NEW_TRANSACTION')
+        instructions.append("NEW_TRANSACTION")
         instructions.push_args(self.stack_subspace.key())
-        instructions.append('LOG_STACK')
+        instructions.append("LOG_STACK")
 
         test_util.blocking_commit(instructions)
 
@@ -654,22 +762,30 @@ class ApiTest(Test):
     def check_versionstamps(self, tr, begin_key, limit):
         next_begin = None
         incorrect_versionstamps = 0
-        for k, v in tr.get_range(begin_key, self.versionstamped_values.range().stop, limit=limit):
-            next_begin = k + b'\x00'
+        for k, v in tr.get_range(
+            begin_key, self.versionstamped_values.range().stop, limit=limit
+        ):
+            next_begin = k + b"\x00"
             random_id = self.versionstamped_values.unpack(k)[0]
-            versioned_value = v[10:].replace(fdb.tuple.Versionstamp._UNSET_TR_VERSION, v[:10], 1)
+            versioned_value = v[10:].replace(
+                fdb.tuple.Versionstamp._UNSET_TR_VERSION, v[:10], 1
+            )
 
             versioned_key = self.versionstamped_keys.pack() + versioned_value
             if tr[versioned_key] != random_id:
-                util.get_logger().error('  INCORRECT VERSIONSTAMP:')
-                util.get_logger().error('    %s != %s', repr(tr[versioned_key]), repr(random_id))
+                util.get_logger().error("  INCORRECT VERSIONSTAMP:")
+                util.get_logger().error(
+                    "    %s != %s", repr(tr[versioned_key]), repr(random_id)
+                )
                 incorrect_versionstamps += 1
 
             if self.api_version >= 520:
                 k2 = self.versionstamped_values_2.pack((random_id,))
                 if tr[k2] != versioned_value:
-                    util.get_logger().error('  INCORRECT VERSIONSTAMP:')
-                    util.get_logger().error('    %s != %s', repr(tr[k2]), repr(versioned_value))
+                    util.get_logger().error("  INCORRECT VERSIONSTAMP:")
+                    util.get_logger().error(
+                        "    %s != %s", repr(tr[k2]), repr(versioned_value)
+                    )
                     incorrect_versionstamps += 1
 
         return (next_begin, incorrect_versionstamps)
@@ -681,16 +797,26 @@ class ApiTest(Test):
         incorrect_versionstamps = 0
 
         while begin is not None:
-            (begin, current_incorrect_versionstamps) = self.check_versionstamps(db, begin, 100)
+            (begin, current_incorrect_versionstamps) = self.check_versionstamps(
+                db, begin, 100
+            )
             incorrect_versionstamps += current_incorrect_versionstamps
 
         if incorrect_versionstamps > 0:
-            errors.append('There were %d failed version stamp operations' % incorrect_versionstamps)
+            errors.append(
+                "There were %d failed version stamp operations"
+                % incorrect_versionstamps
+            )
 
         return errors
 
     def get_result_specifications(self):
         return [
             ResultSpecification(self.workspace, global_error_filter=[1007, 1009, 1021]),
-            ResultSpecification(self.stack_subspace, key_start_index=1, ordering_index=1, global_error_filter=[1007, 1009, 1021])
+            ResultSpecification(
+                self.stack_subspace,
+                key_start_index=1,
+                ordering_index=1,
+                global_error_filter=[1007, 1009, 1021],
+            ),
         ]

--- a/bindings/bindingtester/tests/test_util.py
+++ b/bindings/bindingtester/tests/test_util.py
@@ -90,7 +90,7 @@ class RandomGenerator(object):
             elif choice == "string":
                 tup.append(self.random_unicode_str(random.randint(0, 100)))
             elif choice == "uuid":
-                tup.append(uuid.uuid4())
+                tup.append(uuid.UUID(int=random.getrandbits(128)))
             elif choice == "bool":
                 b = random.random() < 0.5
                 if self.api_version < 500:

--- a/bindings/bindingtester/tests/test_util.py
+++ b/bindings/bindingtester/tests/test_util.py
@@ -33,16 +33,20 @@ from bindingtester.known_testers import COMMON_TYPES
 
 
 class RandomGenerator(object):
-    def __init__(self, max_int_bits=64, api_version=FDB_API_VERSION, types=COMMON_TYPES):
+    def __init__(
+        self, max_int_bits=64, api_version=FDB_API_VERSION, types=COMMON_TYPES
+    ):
         self.max_int_bits = max_int_bits
         self.api_version = api_version
         self.types = list(types)
 
     def random_unicode_str(self, length):
-        return ''.join(self.random_unicode_char() for i in range(0, length))
+        return "".join(self.random_unicode_char() for i in range(0, length))
 
     def random_int(self):
-        num_bits = random.randint(0, self.max_int_bits)  # This way, we test small numbers with higher probability
+        num_bits = random.randint(
+            0, self.max_int_bits
+        )  # This way, we test small numbers with higher probability
 
         max_value = (1 << num_bits) - 1
         min_value = -max_value - 1
@@ -54,11 +58,15 @@ class RandomGenerator(object):
     def random_float(self, exp_bits):
         if random.random() < 0.05:
             # Choose a special value.
-            return random.choice([float('-nan'), float('-inf'), -0.0, 0.0, float('inf'), float('nan')])
+            return random.choice(
+                [float("-nan"), float("-inf"), -0.0, 0.0, float("inf"), float("nan")]
+            )
         else:
             # Choose a value from all over the range of acceptable floats for this precision.
             sign = -1 if random.random() < 0.5 else 1
-            exponent = random.randint(-(1 << (exp_bits - 1)) - 10, (1 << (exp_bits - 1) - 1))
+            exponent = random.randint(
+                -(1 << (exp_bits - 1)) - 10, (1 << (exp_bits - 1) - 1)
+            )
             mantissa = random.random()
 
             result = sign * math.pow(2, exponent) * mantissa
@@ -73,38 +81,38 @@ class RandomGenerator(object):
 
         for i in range(size):
             choice = random.choice(self.types)
-            if choice == 'int':
+            if choice == "int":
                 tup.append(self.random_int())
-            elif choice == 'null':
+            elif choice == "null":
                 tup.append(None)
-            elif choice == 'bytes':
+            elif choice == "bytes":
                 tup.append(self.random_string(random.randint(0, 100)))
-            elif choice == 'string':
+            elif choice == "string":
                 tup.append(self.random_unicode_str(random.randint(0, 100)))
-            elif choice == 'uuid':
+            elif choice == "uuid":
                 tup.append(uuid.uuid4())
-            elif choice == 'bool':
+            elif choice == "bool":
                 b = random.random() < 0.5
                 if self.api_version < 500:
                     tup.append(int(b))
                 else:
                     tup.append(b)
-            elif choice == 'float':
+            elif choice == "float":
                 tup.append(fdb.tuple.SingleFloat(self.random_float(8)))
-            elif choice == 'double':
+            elif choice == "double":
                 tup.append(self.random_float(11))
-            elif choice == 'tuple':
+            elif choice == "tuple":
                 length = random.randint(0, max_size - size)
                 if length == 0:
                     tup.append(())
                 else:
                     tup.append(self.random_tuple(length))
-            elif choice == 'versionstamp':
+            elif choice == "versionstamp":
                 if incomplete_versionstamps and random.random() < 0.5:
                     tr_version = fdb.tuple.Versionstamp._UNSET_TR_VERSION
                 else:
                     tr_version = self.random_string(10)
-                user_version = random.randint(0, 0xffff)
+                user_version = random.randint(0, 0xFFFF)
                 tup.append(fdb.tuple.Versionstamp(tr_version, user_version))
             else:
                 assert False
@@ -123,12 +131,19 @@ class RandomGenerator(object):
                 smaller_size = random.randint(1, len(to_add))
                 tuples.append(to_add[:smaller_size])
             else:
-                non_empty = [x for x in enumerate(to_add) if (isinstance(x[1], list) or isinstance(x[1], tuple)) and len(x[1]) > 0]
+                non_empty = [
+                    x
+                    for x in enumerate(to_add)
+                    if (isinstance(x[1], list) or isinstance(x[1], tuple))
+                    and len(x[1]) > 0
+                ]
                 if len(non_empty) > 0 and random.random() < 0.25:
                     # Add a smaller list to test prefixes of nested structures.
                     idx, choice = random.choice(non_empty)
                     smaller_size = random.randint(0, len(to_add[idx]))
-                    tuples.append(to_add[:idx] + (choice[:smaller_size],) + to_add[idx + 1:])
+                    tuples.append(
+                        to_add[:idx] + (choice[:smaller_size],) + to_add[idx + 1 :]
+                    )
 
         random.shuffle(tuples)
         return tuples
@@ -153,30 +168,40 @@ class RandomGenerator(object):
 
     def random_string(self, length):
         if length == 0:
-            return b''
+            return b""
 
-        return bytes([random.randint(0, 254)] + [random.randint(0, 255) for i in range(0, length - 1)])
+        return bytes(
+            [random.randint(0, 254)]
+            + [random.randint(0, 255) for i in range(0, length - 1)]
+        )
 
     def random_unicode_char(self):
         while True:
             if random.random() < 0.05:
                 # Choose one of these special character sequences.
-                specials = ['\U0001f4a9', '\U0001f63c', '\U0001f3f3\ufe0f\u200d\U0001f308', '\U0001f1f5\U0001f1f2', '\uf8ff',
-                            '\U0002a2b2', '\u05e9\u05dc\u05d5\u05dd']
+                specials = [
+                    "\U0001f4a9",
+                    "\U0001f63c",
+                    "\U0001f3f3\ufe0f\u200d\U0001f308",
+                    "\U0001f1f5\U0001f1f2",
+                    "\uf8ff",
+                    "\U0002a2b2",
+                    "\u05e9\u05dc\u05d5\u05dd",
+                ]
                 return random.choice(specials)
-            c = random.randint(0, 0xffff)
-            if unicodedata.category(chr(c))[0] in 'LMNPSZ':
+            c = random.randint(0, 0xFFFF)
+            if unicodedata.category(chr(c))[0] in "LMNPSZ":
                 return chr(c)
 
 
 def error_string(error_code):
-    return fdb.tuple.pack((b'ERROR', bytes(str(error_code), 'utf-8')))
+    return fdb.tuple.pack((b"ERROR", bytes(str(error_code), "utf-8")))
 
 
 def blocking_commit(instructions):
-    instructions.append('COMMIT')
-    instructions.append('WAIT_FUTURE')
-    instructions.append('RESET')
+    instructions.append("COMMIT")
+    instructions.append("WAIT_FUTURE")
+    instructions.append("RESET")
 
 
 def to_front(instructions, index):
@@ -184,19 +209,19 @@ def to_front(instructions, index):
         pass
     elif index == 1:
         instructions.push_args(1)
-        instructions.append('SWAP')
+        instructions.append("SWAP")
     elif index == 2:
         instructions.push_args(index - 1)
-        instructions.append('SWAP')
+        instructions.append("SWAP")
         instructions.push_args(index)
-        instructions.append('SWAP')
+        instructions.append("SWAP")
     else:
         instructions.push_args(index - 1)
-        instructions.append('SWAP')
+        instructions.append("SWAP")
         instructions.push_args(index)
-        instructions.append('SWAP')
+        instructions.append("SWAP")
         instructions.push_args(index - 1)
-        instructions.append('SWAP')
+        instructions.append("SWAP")
         to_front(instructions, index - 1)
 
 


### PR DESCRIPTION
Fixing generation of the bindingtester API tests, so that deterministic for the given random seed:
- Fix determinism of tenant selection
- Generate deterministic UUIDs

The relevant python files are reformatted in a separate commit

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
