### PR TITLE
Disable TENANT_DELETE in binding tester

### DIFF
--- a/bindings/bindingtester/tests/api.py
+++ b/bindings/bindingtester/tests/api.py
@@ -224,7 +224,9 @@ class ApiTest(Test):
         storage_metrics = ["GET_ESTIMATED_RANGE_SIZE", "GET_RANGE_SPLIT_POINTS"]
         tenants = [
             "TENANT_CREATE",
-            "TENANT_DELETE",
+            # FIXME: Disabling because causes sporadic conflicts in
+            # the transactions following tenant deletion
+            # "TENANT_DELETE",
             "TENANT_SET_ACTIVE",
             "TENANT_CLEAR_ACTIVE",
             "TENANT_LIST",


### PR DESCRIPTION
Disabling TENANT_DELETE instruction to avoid the sporadic errors in transactions following tenant deletion. The transactions are expected to fail with tenant_not_found, but sometimes they are failing with not_committed. 

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
