### PR TITLE
No RK throttling on blob workers if no blob ranges

### DIFF
--- a/fdbserver/include/fdbserver/Ratekeeper.h
+++ b/fdbserver/include/fdbserver/Ratekeeper.h
@@ -206,6 +206,7 @@ class Ratekeeper {
 	std::map<Version, Ratekeeper::VersionInfo> version_transactions;
 	std::map<Version, std::pair<double, Optional<double>>> version_recovery;
 	Deque<std::pair<double, Version>> blobWorkerVersionHistory;
+	bool anyBlobRanges;
 	Optional<Key> remoteDC;
 
 	double getRecoveryDuration(Version ver) const {


### PR DESCRIPTION

Passes 10k BlobGranule* correctness, and confirmed with local testing that ratekeeper does nothing if blob_granules_enabled=1 but there are no blob workers.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
