### PR TITLE
Include configure string in test harness output

### DIFF
--- a/contrib/TestHarness2/test_harness/summarize.py
+++ b/contrib/TestHarness2/test_harness/summarize.py
@@ -528,6 +528,11 @@ class Summary:
 
         self.handler.add_handler(('Type', 'ProgramStart'), program_start)
 
+        def config_string(attrs: Dict[str, str]):
+            self.out.attributes['ConfigString'] = attrs['ConfigString']
+
+        self.handler.add_handler(('Type', 'SimulatorConfig'), config_string)
+
         def set_test_file(attrs: Dict[str, str]):
             test_file = Path(attrs['TestFile'])
             cwd = Path('.').absolute()


### PR DESCRIPTION
In order to cluster test failures more efficiently having the `configure` string is often useful. This is a simple change and will include the configure string.

Sample output:

```
 "devRetryCorrectnessTest bin/fdbserver -r simulation -f tests/fast/ConfigIncrementWithKills.toml -s 2859554869 -b on --crash --trace_format json": {
    "Type": "Test",
    "Command": "devRetryCorrectnessTest bin/fdbserver -r simulation -f tests/fast/ConfigIncrementWithKills.toml -s 2859554869 -b on --crash --trace_format json",
    "TestUID": "882c527a-1dce-4b0c-89da-d82334f21e37",
    "Statistics": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
    "JoshuaSeed": "302769587172551977",
    "WillRestart": "0",
    "RandomSeed": "2859554869",
    "SourceVersion": "2497aa5701b1bef8a9a422b75ba80ab091907a4a",
    "Time": "1677004710",
    "BuggifyEnabled": "1",
    "DeterminismCheck": "0",
    "FaultInjectionEnabled": "1",
    "TestFile": "tests/fast/ConfigIncrementWithKills.toml",
    "ConfigString": "new backup_worker_enabled:=1 blob_granules_enabled:=0 commit_proxies:=6 encryption_at_rest_mode=disabled log_spill:=1 log_version:=6 logs:=6 perpetual_storage_wiggle:=0 proxies:=6 double memory-radixtree-beta storage_migration_type=disabled tenant_mode=optional_experimental usable_regions:=1",
    "SimElapsedTime": "171.363",
    "RealElapsedTime": "4.26984",
    "RandomUnseed": "38468",
    "PeakMemory": "142028",
    "Ok": "1",
    "TotalTestTime": "5",
    "TestRunCount": "0",
    "Buggifies": {
      "/mnt/ephemeral/mpilman/foundationdb/flow/Knobs.cpp": "57 58 86 109 296 308 314",
      "/mnt/ephemeral/mpilman/foundationdb/fdbclient/ClientKnobs.cpp": "63 65 101 107 122 277 299 301 302",
      "/mnt/ephemeral/mpilman/foundationdb/fdbclient/ServerKnobs.cpp": "45 57 73 74 77 78 80 84 89 107 108 167 168 175 278 279 292 300 301 303 308 310 314 339 341 373 379 383 425 427 448 502 549 560 567 585 635 672 679 751 759 808 809 818 833 842 882 889 913 937 940 953 958 977 1014 1015 1017 1021 1029 1031 1035 1036 1065",
      "/mnt/ephemeral/mpilman/foundationdb/fdbrpc/AsyncFileCached.actor.cpp": "60",
      "/mnt/ephemeral/mpilman/foundationdb/fdbserver/LeaderElection.actor.cpp": "133",
      "/mnt/ephemeral/mpilman/foundationdb/fdbclient/NativeAPI.actor.cpp": "5928",
      "/mnt/ephemeral/mpilman/foundationdb/fdbserver/worker.actor.cpp": "309",
      "/mnt/ephemeral/mpilman/foundationdb/fdbserver/ClusterRecovery.actor.cpp": "1142 1247 1391",
      "/mnt/ephemeral/mpilman/foundationdb/fdbserver/TagPartitionedLogSystem.actor.cpp": "3074",
      "/mnt/ephemeral/mpilman/foundationdb/fdbserver/storageserver.actor.cpp": "2332",
      "/mnt/ephemeral/mpilman/foundationdb/flow/include/flow/ThreadHelper.actor.h": "807",
      "/mnt/ephemeral/mpilman/foundationdb/fdbclient/include/fdbclient/TenantManagement.actor.h": "290",
      "/mnt/ephemeral/mpilman/foundationdb/fdbserver/PaxosConfigConsumer.actor.cpp": "537",
      "/mnt/ephemeral/mpilman/foundationdb/fdbserver/workloads/MachineAttrition.actor.cpp": "408 412",
      "/mnt/ephemeral/mpilman/foundationdb/fdbclient/ManagementAPI.actor.cpp": "1130"
    }
  },
```

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
