### PR TITLE
decreasing granule size knobs to enable more granules in local cluster tests

### DIFF
--- a/tests/TestRunner/local_cluster.py
+++ b/tests/TestRunner/local_cluster.py
@@ -121,6 +121,10 @@ logdir = {logdir}
 {authz_public_key_config}
 {custom_config}
 {use_future_protocol_version}
+# configure smaller granules by default for local testing
+knob_bg_snapshot_file_target_bytes=1000000
+knob_bg_delta_file_target_bytes=50000
+knob_bg_delta_bytes_before_compact=500000
 # logsize = 10MiB
 # maxlogssize = 100MiB
 # machine-id =


### PR DESCRIPTION
- Added knobs to decrease granule size/increase granule count
- Refactored blob granule and encryption config to be simpler
- A couple unrelated changes from flake/black

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
