### PR TITLE
Implement SplitMetric pagination in blob migrator

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -851,7 +851,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	// This exists for flexibility but assigning each ReadType to its own unique priority number makes the most sense
 	// The enumeration is currently: eager, fetch, low, normal, high
 	init( STORAGESERVER_READTYPE_PRIORITY_MAP,           "0,1,2,3,4" );
-	init( SPLIT_METRICS_MAX_ROWS,                              10000 );
+	init( SPLIT_METRICS_MAX_ROWS,                              10000 ); if( randomize && BUGGIFY ) SPLIT_METRICS_MAX_ROWS = 10;
 
 	//Wait Failure
 	init( MAX_OUTSTANDING_WAIT_FAILURE_REQUESTS,                 250 ); if( randomize && BUGGIFY ) MAX_OUTSTANDING_WAIT_FAILURE_REQUESTS = 2;

--- a/fdbserver/BlobMigrator.actor.cpp
+++ b/fdbserver/BlobMigrator.actor.cpp
@@ -22,6 +22,7 @@
 #include <string>
 #include "fdbclient/ClientBooleanParams.h"
 #include "fdbserver/RestoreUtil.h"
+#include "flow/CodeProbe.h"
 #include "flow/network.h"
 #include "flow/flow.h"
 #include "flow/ActorCollection.h"
@@ -477,14 +478,8 @@ private:
 						self->actors_.add(processWaitMetricsRequest(self, req));
 					}
 					when(SplitMetricsRequest req = waitNext(ssi.splitMetrics.getFuture())) {
-						dprint("Handle SplitMetrics {}\n", req.keys.toString());
-						SplitMetricsReply rep;
-						for (auto granule : self->blobGranules_) {
-							// TODO: Use granule boundary as split point. A better approach is to split by size
-							if (granule.keyRange.begin > req.keys.begin && granule.keyRange.end < req.keys.end)
-								rep.splits.push_back_deep(rep.splits.arena(), granule.keyRange.begin);
-						}
-						req.reply.send(rep);
+						dprint("Handle SplitMetrics {} limit {} bytes\n", req.keys.toString(), req.limits.bytes);
+						processSplitMetricsRequest(self, req);
 					}
 					when(GetStorageMetricsRequest req = waitNext(ssi.getStorageMetrics.getFuture())) {
 						StorageMetrics metrics;
@@ -573,6 +568,34 @@ private:
 		}
 	}
 
+	// This API is used by DD to figure out split points for data movement.
+	static void processSplitMetricsRequest(Reference<BlobMigrator> self, SplitMetricsRequest req) {
+		SplitMetricsReply rep;
+		int64_t bytes = 0; // number of bytes accumulated for current split
+		for (auto& granule : self->blobGranules_) {
+			if (!req.keys.contains(granule.keyRange)) {
+				continue;
+			}
+			bytes += granule.sizeInBytes;
+			if (bytes < req.limits.bytes) {
+				continue;
+			}
+			// Add a split point if the key range exceeds expected minimal size in bytes
+			rep.splits.push_back_deep(rep.splits.arena(), granule.keyRange.end);
+			bytes = 0;
+			// Limit number of splits in single response for fast RPC processing
+			if (rep.splits.size() > SERVER_KNOBS->SPLIT_METRICS_MAX_ROWS) {
+				CODE_PROBE(true, "Blob Migrator SplitMetrics API has more");
+				TraceEvent("BlobMigratorSplitMetricsContinued", self->interf_.id())
+				    .detail("Range", req.keys)
+				    .detail("Splits", rep.splits.size());
+				rep.more = true;
+				break;
+			}
+		}
+		req.reply.send(rep);
+	}
+
 	ACTOR static Future<Void> processWaitMetricsRequest(Reference<BlobMigrator> self, WaitMetricsRequest req) {
 		state WaitMetricsRequest waitMetricsRequest = req;
 		// FIXME get rid of this delay. it's a temp solution to avoid starvaion scheduling of DD
@@ -600,7 +623,7 @@ private:
 	static int64_t sizeInBytes(Reference<BlobMigrator> self, KeyRangeRef range) {
 		int64_t bytes = 0;
 		for (auto granule : self->blobGranules_) {
-			if (range.intersects(granule.keyRange))
+			if (range.contains(granule.keyRange))
 				bytes += granule.sizeInBytes;
 		}
 		return bytes;


### PR DESCRIPTION
Implement splitmetrics pagination api for blob migrator to avoid large response for blob restore. 

Passed 100K BlobRestore correctness tests for

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
