### PR TITLE
Sfc gh dadkins/resolver metrics

### DIFF
--- a/fdbserver/Resolver.actor.cpp
+++ b/fdbserver/Resolver.actor.cpp
@@ -170,7 +170,7 @@ struct Resolver : ReferenceCounted<Resolver> {
 	Counter splitRequests;
 	int numLogs;
 
-	// Distribution of end-to-end latency of resolver requests.
+	// Distribution of end-to-end server latency of resolver requests.
 	LatencySample resolverLatency;
 
 	Future<Void> logger;

--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -358,6 +358,7 @@ struct TLogData : NonCopyable {
 	Reference<AsyncVar<bool>> degraded;
 	std::vector<TagsAndMessage> tempTagMessages;
 
+	// Distribution of end-to-end server latency of tlog commit requests.
 	Reference<Histogram> commitLatencyDist;
 
 	TLogData(UID dbgid,
@@ -548,9 +549,6 @@ struct LogData : NonCopyable, public ReferenceCounted<LogData> {
 	std::map<Tag, LatencySample> blockingPeekLatencies;
 	std::map<Tag, LatencySample> peekVersionCounts;
 
-	// Distribution of end-to-end server latency of tlog commit requests.
-	LatencySample tlogCommitLatency;
-
 	UID logId;
 	ProtocolVersion protocolVersion;
 	Version newPersistentDataVersion;
@@ -637,16 +635,13 @@ struct LogData : NonCopyable, public ReferenceCounted<LogData> {
 	    unpoppedRecoveredTagCount(0), cc("TLog", interf.id().toString()), bytesInput("BytesInput", cc),
 	    bytesDurable("BytesDurable", cc), blockingPeeks("BlockingPeeks", cc),
 	    blockingPeekTimeouts("BlockingPeekTimeouts", cc), emptyPeeks("EmptyPeeks", cc),
-	    nonEmptyPeeks("NonEmptyPeeks", cc), tlogCommitLatency("TLogCommitLatencyMetrics",
-	                                                          interf.id(),
-	                                                          SERVER_KNOBS->LATENCY_METRICS_LOGGING_INTERVAL,
-	                                                          SERVER_KNOBS->LATENCY_SKETCH_ACCURACY),
-	    logId(interf.id()), protocolVersion(protocolVersion), newPersistentDataVersion(invalidVersion),
-	    tLogData(tLogData), unrecoveredBefore(1), recoveredAt(1), recoveryTxnVersion(1),
-	    logSystem(new AsyncVar<Reference<ILogSystem>>()), remoteTag(remoteTag), isPrimary(isPrimary),
-	    logRouterTags(logRouterTags), logRouterPoppedVersion(0), logRouterPopToVersion(0), locality(tagLocalityInvalid),
-	    recruitmentID(recruitmentID), logSpillType(logSpillType), allTags(tags.begin(), tags.end()),
-	    terminated(tLogData->terminated.getFuture()), execOpCommitInProgress(false), txsTags(txsTags) {
+	    nonEmptyPeeks("NonEmptyPeeks", cc), logId(interf.id()), protocolVersion(protocolVersion),
+	    newPersistentDataVersion(invalidVersion), tLogData(tLogData), unrecoveredBefore(1), recoveredAt(1),
+	    recoveryTxnVersion(1), logSystem(new AsyncVar<Reference<ILogSystem>>()), remoteTag(remoteTag),
+	    isPrimary(isPrimary), logRouterTags(logRouterTags), logRouterPoppedVersion(0), logRouterPopToVersion(0),
+	    locality(tagLocalityInvalid), recruitmentID(recruitmentID), logSpillType(logSpillType),
+	    allTags(tags.begin(), tags.end()), terminated(tLogData->terminated.getFuture()), execOpCommitInProgress(false),
+	    txsTags(txsTags) {
 		startRole(Role::TRANSACTION_LOG,
 		          interf.id(),
 		          tLogData->workerID,
@@ -2335,8 +2330,6 @@ ACTOR Future<Void> tLogCommit(TLogData* self,
 		return Void();
 	}
 
-	state double beforeCommitT = g_network->timer();
-
 	// Not a duplicate (check relies on critical section between here self->version.set() below!)
 	state bool isNotDuplicate = (logData->version.get() == req.prevVersion);
 	if (isNotDuplicate) {
@@ -2389,8 +2382,7 @@ ACTOR Future<Void> tLogCommit(TLogData* self,
 	const double endTime = g_network->timer();
 
 	if (isNotDuplicate) {
-		self->commitLatencyDist->sampleSeconds(endTime - beforeCommitT);
-		logData->tlogCommitLatency.addMeasurement(endTime - req.requestTime());
+		self->commitLatencyDist->sampleSeconds(endTime - req.requestTime());
 	}
 
 	if (req.debugID.present())

--- a/fdbserver/include/fdbserver/ResolverInterface.h
+++ b/fdbserver/include/fdbserver/ResolverInterface.h
@@ -29,6 +29,7 @@
 #include "fdbclient/FDBTypes.h"
 #include "fdbrpc/Locality.h"
 #include "fdbrpc/fdbrpc.h"
+#include "fdbrpc/TimedRequest.h"
 
 struct ResolverInterface {
 	constexpr static FileIdentifier file_identifier = 1755944;
@@ -121,7 +122,7 @@ struct ResolveTransactionBatchReply {
 	}
 };
 
-struct ResolveTransactionBatchRequest {
+struct ResolveTransactionBatchRequest : TimedRequest {
 	constexpr static FileIdentifier file_identifier = 16462858;
 	Arena arena;
 

--- a/fdbserver/include/fdbserver/TLogInterface.h
+++ b/fdbserver/include/fdbserver/TLogInterface.h
@@ -26,6 +26,7 @@
 #include "fdbclient/CommitTransaction.h"
 #include "fdbclient/MutationList.h"
 #include "fdbclient/StorageServerInterface.h"
+#include "fdbrpc/TimedRequest.h"
 #include <iterator>
 
 struct TLogInterface {
@@ -294,7 +295,7 @@ struct TLogCommitReply {
 	}
 };
 
-struct TLogCommitRequest {
+struct TLogCommitRequest : TimedRequest {
 	constexpr static FileIdentifier file_identifier = 4022206;
 	SpanContext spanContext;
 	Arena arena;


### PR DESCRIPTION
Add some missing metrics to help better understand time spent during commit.

There are already pretty good metrics on the commit proxy, so this set focuses on the resolver and tlog.

* server-side RPC latency metrics for resolver and tlog.
* breakdown of time spent waiting and computing on the resolver, per-request.
* queue depth observed on the resolver.

I've decided to use Histogram over LatencySample, because Histogram is implemented as
32, power-of-2 buckets, while LatencySample is a couple thousand buckets at the default
accuracy of 1% for percentiles. I'd rather have the lower memory footprint plus the full
distribution into buckets, over accurate percentiles for 5 second intervals.

The last one is a proxy for a short-lived backlog on the resolver. Hopefully, that metric plus
time spent waiting or computing on the resolver will paint a picture of whether transactions
are waiting for compute time or just waiting for older transactions to arrive in the first place.

Testing: I ran some local simulation tests and observed the metrics in the log.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
