### PR TITLE
Fix Java GetClientStatusIntegrationTest

### DIFF
--- a/bindings/java/src/integration/com/apple/foundationdb/GetClientStatusIntegrationTest.java
+++ b/bindings/java/src/integration/com/apple/foundationdb/GetClientStatusIntegrationTest.java
@@ -35,7 +35,7 @@ class GetClientStatusIntegrationTest {
 		try (Database db = fdb.open()) {
 			// Run a simple transaction to make sure the database is fully initialized
 			db.run(tr -> {
-				return tr.getReadVersion();
+				return tr.getReadVersion().join();
 			});
 
 			// Here we just check if a meaningful client report status is returned


### PR DESCRIPTION
Java GetClientStatusIntegrationTest was sporadically failing. The test was assuming that the database connection is fully initialized after executing a simple transaction, so the getClientStatus should report that the connection is in a healthy state. 
However, the transaction implementation was missing a wait on the future, so it sometimes happened that the getClientStatus was called on not yet initialized connection.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
