### PR TITLE
Redwood: fix encryption mode assert failure with partial B-tree header

### DIFF
--- a/fdbserver/VersionedBTree.actor.cpp
+++ b/fdbserver/VersionedBTree.actor.cpp
@@ -2081,6 +2081,12 @@ public:
 		lastCommittedHeader = header;
 	}
 
+	void initCommitRecord(Value commitRecord) override {
+		header.userCommitRecord = commitRecord;
+		updateHeaderPage();
+		updateLastCommittedHeader();
+	}
+
 	ACTOR static Future<Void> recover(DWALPager* self) {
 		ASSERT(!self->recoverFuture.isValid());
 
@@ -5297,6 +5303,10 @@ public:
 			debug_printf("BTree recovered.\n");
 		}
 		self->m_lazyClearActor = 0;
+
+		// Update the b-tree header, which will be written to the backup header page by the pager on the first commit.
+		// In this way, if
+		self->m_pager->initCommitRecord(ObjectWriter::toValue(self->m_header, Unversioned()));
 
 		TraceEvent e(SevInfo, "RedwoodRecoveredBTree");
 		e.detail("FileName", self->m_name);

--- a/fdbserver/include/fdbserver/IPager.h
+++ b/fdbserver/include/fdbserver/IPager.h
@@ -873,6 +873,10 @@ public:
 	// TODO: Document further.
 	virtual Future<Void> init() = 0;
 
+	// Setting initial commit record, which the pager can persist before the first commit.
+	// It is supposed to be called after init() and before the first commit().
+	virtual void initCommitRecord(Value commitRecord) = 0;
+
 	// Returns latest committed version
 	virtual Version getLastCommittedVersion() const = 0;
 


### PR DESCRIPTION
The PR fixes Redwood assert failure `self->m_expectedEncryptionMode.present()` in simulation. The issue is that, on the very first commit, Redwood will persist a backup header page with an empty B-tree header (a.k.a. `commitRecord`). If the Redwood instance was shutdown before the primary header page is persistent, on restart it will read the backup header page and see an empty B-tree header. However, the encryption logic in Redwood rely on the B-tree header to supply the encryption mode on restart. The PR fixes the issue by setting a valid B-tree header with encryption mode to the initial backup header page.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
