### PR TITLE
Metacluster restore fixes

### DIFF
--- a/fdbcli/MetaclusterCommands.actor.cpp
+++ b/fdbcli/MetaclusterCommands.actor.cpp
@@ -171,13 +171,13 @@ ACTOR Future<bool> metaclusterRemoveCommand(Reference<IDatabase> db, std::vector
 	}
 
 	state ClusterNameRef clusterName = tokens[tokens.size() - 1];
-	state ForceRemove forceRemove = ForceRemove(tokens.size() == 4);
 
 	state ClusterType clusterType = wait(runTransaction(db, [](Reference<ITransaction> tr) {
 		tr->setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
 		return TenantAPI::getClusterType(tr);
 	}));
 
+	ForceRemove forceRemove(tokens.size() == 4);
 	if (clusterType == ClusterType::METACLUSTER_DATA && !forceRemove) {
 		if (tokens[2] == "FORCE"_sr) {
 			fmt::print("ERROR: a cluster name must be specified.\n");

--- a/fdbcli/MetaclusterCommands.actor.cpp
+++ b/fdbcli/MetaclusterCommands.actor.cpp
@@ -171,14 +171,14 @@ ACTOR Future<bool> metaclusterRemoveCommand(Reference<IDatabase> db, std::vector
 	}
 
 	state ClusterNameRef clusterName = tokens[tokens.size() - 1];
-	state bool force = tokens.size() == 4;
+	state ForceRemove forceRemove = ForceRemove(tokens.size() == 4);
 
 	state ClusterType clusterType = wait(runTransaction(db, [](Reference<ITransaction> tr) {
 		tr->setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
 		return TenantAPI::getClusterType(tr);
 	}));
 
-	if (clusterType == ClusterType::METACLUSTER_DATA && !force) {
+	if (clusterType == ClusterType::METACLUSTER_DATA && !forceRemove) {
 		if (tokens[2] == "FORCE"_sr) {
 			fmt::print("ERROR: a cluster name must be specified.\n");
 		} else {
@@ -190,8 +190,7 @@ ACTOR Future<bool> metaclusterRemoveCommand(Reference<IDatabase> db, std::vector
 		return false;
 	}
 
-	bool updatedDataCluster =
-	    wait(MetaclusterAPI::removeCluster(db, clusterName, clusterType, tokens.size() == 4, 15.0));
+	bool updatedDataCluster = wait(MetaclusterAPI::removeCluster(db, clusterName, clusterType, forceRemove, 15.0));
 
 	if (clusterType == ClusterType::METACLUSTER_MANAGEMENT) {
 		fmt::print("The cluster `{}' has been removed\n", printable(clusterName).c_str());
@@ -211,7 +210,7 @@ ACTOR Future<bool> metaclusterRemoveCommand(Reference<IDatabase> db, std::vector
 
 void printRestoreUsage() {
 	fmt::print("Usage: metacluster restore <NAME> [dryrun] connection_string=<CONNECTION_STRING>\n"
-	           "<restore_known_data_cluster|repopulate_from_data_cluster> [force_join_new_metacluster]\n\n");
+	           "<restore_known_data_cluster|repopulate_from_data_cluster> [force_join]\n\n");
 
 	fmt::print("Add a restored data cluster back to a metacluster.\n\n");
 
@@ -223,8 +222,9 @@ void printRestoreUsage() {
 	fmt::print("that the metacluster is already tracking. This mode should be used if only data\n");
 	fmt::print("clusters are being restored, and any discrepancies between the management and\n");
 	fmt::print("data clusters will be resolved using the management cluster metadata.\n");
-	fmt::print("If `force_join_new_metacluster' is specified, the cluster will try to restore\n");
-	fmt::print("to a different metacluster than it was originally registered to.\n\n");
+	fmt::print("If `force_join' is specified, the cluster will try to restore to a different\n");
+	fmt::print("metacluster than it was originally registered to or with a different ID than\n");
+	fmt::print("is associated with the given cluster name.\n\n");
 
 	fmt::print("Use `repopulate_from_data_cluster' to rebuild a lost management cluster from the\n");
 	fmt::print("data clusters in a metacluster. This mode should be used if the management\n");
@@ -244,7 +244,7 @@ ACTOR Future<bool> metaclusterRestoreCommand(Reference<IDatabase> db, std::vecto
 	}
 
 	state bool dryRun = tokens[3] == "dryrun"_sr;
-	state bool forceJoin = tokens[tokens.size() - 1] == "force_join_new_metacluster"_sr;
+	state bool forceJoin = tokens[tokens.size() - 1] == "force_join"_sr;
 
 	if (tokens.size() < 5 + (int)dryRun + (int)forceJoin) {
 		printRestoreUsage();
@@ -274,7 +274,7 @@ ACTOR Future<bool> metaclusterRestoreCommand(Reference<IDatabase> db, std::vecto
 			                                    config.get().first.get(),
 			                                    ApplyManagementClusterUpdates::True,
 			                                    RestoreDryRun(dryRun),
-			                                    ForceJoinNewMetacluster(forceJoin),
+			                                    ForceJoin(forceJoin),
 			                                    &messages));
 		} else if (restoreType == "repopulate_from_data_cluster"_sr) {
 			wait(MetaclusterAPI::restoreCluster(db,
@@ -282,7 +282,7 @@ ACTOR Future<bool> metaclusterRestoreCommand(Reference<IDatabase> db, std::vecto
 			                                    config.get().first.get(),
 			                                    ApplyManagementClusterUpdates::False,
 			                                    RestoreDryRun(dryRun),
-			                                    ForceJoinNewMetacluster(forceJoin),
+			                                    ForceJoin(forceJoin),
 			                                    &messages));
 		} else {
 			fmt::print(stderr, "ERROR: unrecognized restore mode `{}'\n", printable(restoreType));
@@ -589,7 +589,7 @@ void metaclusterGenerator(const char* text,
 				const char* opts[] = { "restore_known_data_cluster", "repopulate_from_data_cluster", nullptr };
 				arrayGenerator(text, line, opts, lc);
 			} else if (tokens.size() == 5 + (int)dryrun) {
-				const char* opts[] = { "force_join_new_metacluster", nullptr };
+				const char* opts[] = { "force_join", nullptr };
 				arrayGenerator(text, line, opts, lc);
 			}
 		}
@@ -624,7 +624,7 @@ std::vector<const char*> metaclusterHintGenerator(std::vector<StringRef> const& 
 			                                     "[dryrun]",
 			                                     "connection_string=<CONNECTION_STRING>",
 			                                     "<restore_known_data_cluster|repopulate_from_data_cluster>",
-			                                     "[force_join_new_metacluster]" };
+			                                     "[force_join]" };
 		if (tokens.size() < 4 || (tokens[3].size() <= 6 && "dryrun"_sr.startsWith(tokens[3]))) {
 			return std::vector<const char*>(opts.begin() + tokens.size() - 2, opts.end());
 		} else if (tokens.size() < 6) {

--- a/fdbclient/Metacluster.cpp
+++ b/fdbclient/Metacluster.cpp
@@ -31,7 +31,8 @@ FDB_DEFINE_BOOLEAN_PARAM(IsRestoring);
 FDB_DEFINE_BOOLEAN_PARAM(RunOnDisconnectedCluster);
 FDB_DEFINE_BOOLEAN_PARAM(RunOnMismatchedCluster);
 FDB_DEFINE_BOOLEAN_PARAM(RestoreDryRun);
-FDB_DEFINE_BOOLEAN_PARAM(ForceJoinNewMetacluster);
+FDB_DEFINE_BOOLEAN_PARAM(ForceJoin);
+FDB_DEFINE_BOOLEAN_PARAM(ForceRemove);
 
 namespace MetaclusterAPI {
 

--- a/fdbclient/include/fdbclient/MetaclusterManagement.actor.h
+++ b/fdbclient/include/fdbclient/MetaclusterManagement.actor.h
@@ -1512,7 +1512,8 @@ struct RestoreClusterImpl {
 					}
 
 					TraceEvent(SevWarn, "MetaclusterRestoreClusterAlreadyRegistered")
-					    .detail("ExistingRegistration", metaclusterRegistration.get());
+					    .detail("ExistingRegistration", metaclusterRegistration.get())
+					    .detail("NewRegistration", dataClusterEntry);
 					throw cluster_already_registered();
 				}
 

--- a/fdbserver/include/fdbserver/workloads/MetaclusterConsistency.actor.h
+++ b/fdbserver/include/fdbserver/workloads/MetaclusterConsistency.actor.h
@@ -98,10 +98,11 @@ private:
 			auto allocatedItr = data.clusterAllocatedMap.find(clusterName);
 			if (!clusterMetadata.entry.hasCapacity()) {
 				ASSERT(allocatedItr == data.clusterAllocatedMap.end());
-			} else if (clusterMetadata.entry.clusterState == DataClusterState::READY) {
-				ASSERT(allocatedItr != data.clusterAllocatedMap.end());
+			} else if (allocatedItr != data.clusterAllocatedMap.end()) {
 				ASSERT_EQ(allocatedItr->second, clusterMetadata.entry.allocated.numTenantGroups);
 				++numFoundInAllocatedMap;
+			} else {
+				ASSERT_NE(clusterMetadata.entry.clusterState, DataClusterState::READY);
 			}
 
 			// Check that the number of tenant groups in the cluster is smaller than the allocated number of tenant

--- a/fdbserver/include/fdbserver/workloads/MetaclusterConsistency.actor.h
+++ b/fdbserver/include/fdbserver/workloads/MetaclusterConsistency.actor.h
@@ -98,7 +98,7 @@ private:
 			auto allocatedItr = data.clusterAllocatedMap.find(clusterName);
 			if (!clusterMetadata.entry.hasCapacity()) {
 				ASSERT(allocatedItr == data.clusterAllocatedMap.end());
-			} else {
+			} else if (clusterMetadata.entry.clusterState == DataClusterState::READY) {
 				ASSERT(allocatedItr != data.clusterAllocatedMap.end());
 				ASSERT_EQ(allocatedItr->second, clusterMetadata.entry.allocated.numTenantGroups);
 				++numFoundInAllocatedMap;

--- a/fdbserver/include/fdbserver/workloads/MetaclusterData.actor.h
+++ b/fdbserver/include/fdbserver/workloads/MetaclusterData.actor.h
@@ -164,7 +164,7 @@ private:
 			ASSERT_EQ(t.size(), 3);
 			TenantName tenantName = t.getString(1);
 			int64_t tenantId = t.getInt(2);
-			MetaclusterTenantMapEntry const& entry = self->managementMetadata.tenantMap[tenantId];
+			MetaclusterTenantMapEntry const& entry = self->managementMetadata.tenantData.tenantMap[tenantId];
 			bool renaming =
 			    entry.tenantState == MetaclusterAPI::TenantState::RENAMING && entry.renameDestination == tenantName;
 			ASSERT(tenantName == entry.tenantName || renaming);

--- a/fdbserver/include/fdbserver/workloads/MetaclusterData.actor.h
+++ b/fdbserver/include/fdbserver/workloads/MetaclusterData.actor.h
@@ -164,14 +164,19 @@ private:
 			ASSERT_EQ(t.size(), 3);
 			TenantName tenantName = t.getString(1);
 			int64_t tenantId = t.getInt(2);
-			ASSERT(tenantName == self->managementMetadata.tenantData.tenantMap[tenantId].tenantName);
-			self->managementMetadata.clusterTenantMap[t.getString(0)].insert(tenantId);
+			MetaclusterTenantMapEntry const& entry = self->managementMetadata.tenantMap[tenantId];
+			bool renaming =
+			    entry.tenantState == MetaclusterAPI::TenantState::RENAMING && entry.renameDestination == tenantName;
+			ASSERT(tenantName == entry.tenantName || renaming);
+			if (!renaming) {
+				ASSERT(self->managementMetadata.clusterTenantMap[t.getString(0)].insert(tenantId).second);
+			}
 		}
 
 		for (auto t : clusterTenantGroupTuples.results) {
 			ASSERT_EQ(t.size(), 2);
 			TenantGroupName tenantGroupName = t.getString(1);
-			self->managementMetadata.clusterTenantGroupMap[t.getString(0)].insert(tenantGroupName);
+			ASSERT(self->managementMetadata.clusterTenantGroupMap[t.getString(0)].insert(tenantGroupName).second);
 		}
 
 		return Void();

--- a/fdbserver/workloads/MetaclusterManagementConcurrencyWorkload.actor.cpp
+++ b/fdbserver/workloads/MetaclusterManagementConcurrencyWorkload.actor.cpp
@@ -143,7 +143,7 @@ struct MetaclusterManagementConcurrencyWorkload : TestWorkload {
 				TraceEvent(SevDebug, "MetaclusterManagementConcurrencyRemovingCluster", debugId)
 				    .detail("ClusterName", clusterName);
 				Future<bool> removeFuture = MetaclusterAPI::removeCluster(
-				    self->managementDb, clusterName, ClusterType::METACLUSTER_MANAGEMENT, false);
+				    self->managementDb, clusterName, ClusterType::METACLUSTER_MANAGEMENT, ForceRemove::False);
 				Optional<bool> result = wait(timeout(removeFuture, deterministicRandom()->randomInt(1, 30)));
 				if (result.present()) {
 					ASSERT(result.get());

--- a/fdbserver/workloads/MetaclusterManagementWorkload.actor.cpp
+++ b/fdbserver/workloads/MetaclusterManagementWorkload.actor.cpp
@@ -219,7 +219,7 @@ struct MetaclusterManagementWorkload : TestWorkload {
 		try {
 			loop {
 				Future<bool> removeFuture = MetaclusterAPI::removeCluster(
-				    self->managementDb, clusterName, ClusterType::METACLUSTER_MANAGEMENT, detachCluster);
+				    self->managementDb, clusterName, ClusterType::METACLUSTER_MANAGEMENT, ForceRemove(detachCluster));
 				try {
 					Optional<bool> result = wait(timeout(removeFuture, deterministicRandom()->randomInt(1, 30)));
 					if (result.present()) {
@@ -288,7 +288,7 @@ struct MetaclusterManagementWorkload : TestWorkload {
 				                                   dataDb->db->getConnectionRecord()->getConnectionString(),
 				                                   ApplyManagementClusterUpdates::True,
 				                                   RestoreDryRun(dryRun),
-				                                   ForceJoinNewMetacluster(forceJoin),
+				                                   ForceJoin(forceJoin),
 				                                   &messages);
 				Optional<Void> result = wait(timeout(restoreFuture, deterministicRandom()->randomInt(1, 30)));
 				if (result.present()) {
@@ -1001,7 +1001,7 @@ struct MetaclusterManagementWorkload : TestWorkload {
 		std::vector<Future<Void>> removeClusterFutures;
 		for (auto [clusterName, clusterMetadata] : dataClusters) {
 			removeClusterFutures.push_back(success(MetaclusterAPI::removeCluster(
-			    self->managementDb, clusterName, ClusterType::METACLUSTER_MANAGEMENT, !deleteTenants)));
+			    self->managementDb, clusterName, ClusterType::METACLUSTER_MANAGEMENT, ForceRemove(!deleteTenants))));
 		}
 
 		wait(waitForAll(removeClusterFutures));


### PR DESCRIPTION
A set of fixes and improvements to metacluster restore.

1. Add a boolean parameter for `ForceRemove` and rename `ForceJoinNewMetacluster` to `ForceJoin` to account for other uses cases of `ForceJoin`.
2. Some updates to tenant and metacluster consistency checks to account for tenant counts during renames
3. Prevent operations on clusters that are restoring
4. Properly fail certain cases where it is illegal to restore a cluster
5. Check for registration tombstones when restoring a cluster
6. Attempt to roll back a cluster register operation if the attempt to update the data cluster fails

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
