### PR TITLE
Improve restore support in the metacluster management workload

### DIFF
--- a/fdbserver/workloads/MetaclusterManagementWorkload.actor.cpp
+++ b/fdbserver/workloads/MetaclusterManagementWorkload.actor.cpp
@@ -176,9 +176,9 @@ struct MetaclusterManagementWorkload : TestWorkload {
 					state Error registerError = e;
 					if (registerError.code() == error_code_cluster_removed ||
 					    registerError.code() == error_code_cluster_not_empty) {
-						if (e.code() == error_code_cluster_removed) {
+						if (registerError.code() == error_code_cluster_removed) {
 							ASSERT(retried);
-						} else if (e.code() == error_code_cluster_not_empty) {
+						} else if (registerError.code() == error_code_cluster_not_empty) {
 							ASSERT(dataDb->detached);
 						}
 
@@ -430,15 +430,15 @@ struct MetaclusterManagementWorkload : TestWorkload {
 				break;
 			} catch (Error& e) {
 				state Error error = e;
-				if (e.code() == error_code_conflicting_restore) {
+				if (error.code() == error_code_conflicting_restore) {
 					ASSERT(retried);
 					CODE_PROBE(true, "MetaclusterManagementWorkload: timed out restore conflicts with retried restore");
 					continue;
-				} else if (e.code() == error_code_cluster_not_found) {
+				} else if (error.code() == error_code_cluster_not_found) {
 					ASSERT(!dataDb->registered);
 					return Void();
-				} else if (e.code() == error_code_tenant_already_exists ||
-				           e.code() == error_code_invalid_tenant_configuration) {
+				} else if (error.code() == error_code_tenant_already_exists ||
+				           error.code() == error_code_invalid_tenant_configuration) {
 					ASSERT(dataDb->detached);
 					wait(removeFailedRestoredCluster(self, clusterName));
 					wait(resolveCollisions(self, clusterName, dataDb));

--- a/fdbserver/workloads/MetaclusterManagementWorkload.actor.cpp
+++ b/fdbserver/workloads/MetaclusterManagementWorkload.actor.cpp
@@ -45,21 +45,7 @@ FDB_DEFINE_BOOLEAN_PARAM(AllowPartialMetaclusterOperations);
 struct MetaclusterManagementWorkload : TestWorkload {
 	static constexpr auto NAME = "MetaclusterManagement";
 
-	struct DataClusterData {
-		Database db;
-		bool registered = false;
-		bool detached = false;
-		int tenantGroupCapacity = 0;
-
-		std::set<TenantName> tenants;
-		std::set<TenantGroupName> tenantGroups;
-		std::set<TenantName> ungroupedTenants;
-
-		DataClusterData() {}
-		DataClusterData(Database db) : db(db) {}
-	};
-
-	struct TenantData {
+	struct TenantData : ReferenceCounted<TenantData> {
 		ClusterName cluster;
 		Optional<TenantGroupName> tenantGroup;
 
@@ -68,7 +54,7 @@ struct MetaclusterManagementWorkload : TestWorkload {
 		  : cluster(cluster), tenantGroup(tenantGroup) {}
 	};
 
-	struct TenantGroupData {
+	struct TenantGroupData : ReferenceCounted<TenantGroupData> {
 		ClusterName cluster;
 		std::set<TenantName> tenants;
 
@@ -76,14 +62,28 @@ struct MetaclusterManagementWorkload : TestWorkload {
 		TenantGroupData(ClusterName cluster) : cluster(cluster) {}
 	};
 
+	struct DataClusterData : ReferenceCounted<DataClusterData> {
+		Database db;
+		bool registered = false;
+		bool detached = false;
+		int tenantGroupCapacity = 0;
+
+		std::map<TenantName, Reference<TenantData>> tenants;
+		std::map<TenantGroupName, Reference<TenantGroupData>> tenantGroups;
+		std::set<TenantName> ungroupedTenants;
+
+		DataClusterData() {}
+		DataClusterData(Database db) : db(db) {}
+	};
+
 	Reference<IDatabase> managementDb;
-	std::map<ClusterName, DataClusterData> dataDbs;
-	std::map<TenantGroupName, TenantGroupData> tenantGroups;
+	std::map<ClusterName, Reference<DataClusterData>> dataDbs;
+	std::map<TenantGroupName, Reference<TenantGroupData>> tenantGroups;
 	std::set<TenantName> ungroupedTenants;
 	std::vector<ClusterName> dataDbIndex;
 
 	int64_t totalTenantGroupCapacity = 0;
-	std::map<TenantName, TenantData> createdTenants;
+	std::map<TenantName, Reference<TenantData>> createdTenants;
 
 	int maxTenants;
 	int maxTenantGroups;
@@ -124,8 +124,8 @@ struct MetaclusterManagementWorkload : TestWorkload {
 		for (auto connectionString : g_simulator->extraDatabases) {
 			ClusterConnectionString ccs(connectionString);
 			self->dataDbIndex.push_back(ClusterName(format("cluster_%08d", self->dataDbs.size())));
-			self->dataDbs[self->dataDbIndex.back()] =
-			    DataClusterData(Database::createSimulatedExtraDatabase(connectionString, cx->defaultTenant));
+			self->dataDbs[self->dataDbIndex.back()] = makeReference<DataClusterData>(
+			    Database::createSimulatedExtraDatabase(connectionString, cx->defaultTenant));
 		}
 		wait(success(
 		    MetaclusterAPI::createMetacluster(cx.getReference(), "management_cluster"_sr, self->tenantIdPrefix)));
@@ -151,7 +151,7 @@ struct MetaclusterManagementWorkload : TestWorkload {
 
 	ACTOR static Future<Void> registerCluster(MetaclusterManagementWorkload* self) {
 		state ClusterName clusterName = self->chooseClusterName();
-		state DataClusterData* dataDb = &self->dataDbs[clusterName];
+		state Reference<DataClusterData> dataDb = self->dataDbs[clusterName];
 		state bool retried = false;
 
 		try {
@@ -173,13 +173,27 @@ struct MetaclusterManagementWorkload : TestWorkload {
 						retried = true;
 					}
 				} catch (Error& e) {
-					if (e.code() == error_code_cluster_already_exists && retried && !dataDb->registered) {
+					state Error registerError = e;
+					if (registerError.code() == error_code_cluster_removed ||
+					    registerError.code() == error_code_cluster_not_empty) {
+						if (e.code() == error_code_cluster_removed) {
+							ASSERT(retried);
+						} else if (e.code() == error_code_cluster_not_empty) {
+							ASSERT(dataDb->detached);
+						}
+
+						wait(success(errorOr(MetaclusterAPI::removeCluster(
+						    self->managementDb, clusterName, ClusterType::METACLUSTER_MANAGEMENT, ForceRemove::True))));
+
+						return Void();
+					} else if (registerError.code() == error_code_cluster_already_exists && retried &&
+					           !dataDb->registered) {
 						Optional<DataClusterMetadata> clusterMetadata =
 						    wait(MetaclusterAPI::tryGetCluster(self->managementDb, clusterName));
 						ASSERT(clusterMetadata.present());
 						break;
 					} else {
-						throw;
+						throw registerError;
 					}
 				}
 			}
@@ -190,6 +204,7 @@ struct MetaclusterManagementWorkload : TestWorkload {
 			dataDb->tenantGroupCapacity = entry.capacity.numTenantGroups;
 			self->totalTenantGroupCapacity += entry.capacity.numTenantGroups;
 			dataDb->registered = true;
+			dataDb->detached = false;
 
 			// Get a version to know that the cluster has recovered
 			wait(success(runTransaction(dataDb->db.getReference(),
@@ -212,9 +227,9 @@ struct MetaclusterManagementWorkload : TestWorkload {
 
 	ACTOR static Future<Void> removeCluster(MetaclusterManagementWorkload* self) {
 		state ClusterName clusterName = self->chooseClusterName();
-		state DataClusterData* dataDb = &self->dataDbs[clusterName];
+		state Reference<DataClusterData> dataDb = self->dataDbs[clusterName];
 		state bool retried = false;
-		state bool detachCluster = false;
+		state ForceRemove detachCluster = ForceRemove(deterministicRandom()->coinflip());
 
 		try {
 			loop {
@@ -244,13 +259,22 @@ struct MetaclusterManagementWorkload : TestWorkload {
 			ASSERT(dataDb->registered);
 			ASSERT(detachCluster || dataDb->tenants.empty());
 
-			self->totalTenantGroupCapacity -= dataDb->tenantGroupCapacity;
-			if (!detachCluster) {
-				dataDb->tenantGroupCapacity = 0;
-				dataDb->registered = false;
-			} else {
-				dataDb->registered = false;
+			self->totalTenantGroupCapacity -= std::max<int64_t>(
+			    dataDb->tenantGroups.size() + dataDb->ungroupedTenants.size(), dataDb->tenantGroupCapacity);
+			dataDb->tenantGroupCapacity = 0;
+			dataDb->registered = false;
+
+			if (detachCluster) {
 				dataDb->detached = true;
+				for (auto const& t : dataDb->ungroupedTenants) {
+					self->ungroupedTenants.erase(t);
+				}
+				for (auto const& t : dataDb->tenantGroups) {
+					self->tenantGroups.erase(t.first);
+				}
+				for (auto const& t : dataDb->tenants) {
+					self->createdTenants.erase(t.first);
+				}
 			}
 
 			// Get a version to know that the cluster has recovered
@@ -260,7 +284,7 @@ struct MetaclusterManagementWorkload : TestWorkload {
 			if (e.code() == error_code_cluster_not_found) {
 				ASSERT(!dataDb->registered);
 				return Void();
-			} else if (e.code() == error_code_cluster_not_empty) {
+			} else if (e.code() == error_code_cluster_not_empty && !detachCluster) {
 				ASSERT(!dataDb->tenants.empty());
 				return Void();
 			}
@@ -272,9 +296,87 @@ struct MetaclusterManagementWorkload : TestWorkload {
 		return Void();
 	}
 
+	ACTOR static Future<Void> removeFailedRestoredCluster(MetaclusterManagementWorkload* self,
+	                                                      ClusterName clusterName) {
+		// On retries, we need to remove the cluster if it was partially added
+		try {
+			wait(success(MetaclusterAPI::removeCluster(
+			    self->managementDb, clusterName, ClusterType::METACLUSTER_MANAGEMENT, ForceRemove::True)));
+		} catch (Error& e) {
+			if (e.code() != error_code_cluster_not_found) {
+				throw;
+			}
+		}
+
+		return Void();
+	}
+
+	ACTOR static Future<Void> resolveCollisions(MetaclusterManagementWorkload* self,
+	                                            ClusterName clusterName,
+	                                            Reference<DataClusterData> dataDb) {
+		state std::set<TenantName> tenantsToRemove;
+
+		state bool foundTenantCollision = false;
+		for (auto t : dataDb->tenants) {
+			if (self->createdTenants.count(t.first)) {
+				foundTenantCollision = true;
+				tenantsToRemove.insert(t.first);
+			}
+		}
+
+		state bool foundGroupCollision = false;
+		for (auto t : dataDb->tenantGroups) {
+			if (self->tenantGroups.count(t.first)) {
+				foundGroupCollision = true;
+				tenantsToRemove.insert(t.second->tenants.begin(), t.second->tenants.end());
+			}
+		}
+
+		state Reference<ReadYourWritesTransaction> tr = dataDb->db->createTransaction();
+		loop {
+			try {
+				tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+				state std::vector<Future<Optional<int64_t>>> getFutures;
+				for (auto const& t : tenantsToRemove) {
+					getFutures.push_back(TenantMetadata::tenantNameIndex().get(tr, t));
+					auto tenantItr = dataDb->tenants.find(t);
+					if (tenantItr != dataDb->tenants.end()) {
+						if (tenantItr->second->tenantGroup.present()) {
+							auto groupItr = dataDb->tenantGroups.find(tenantItr->second->tenantGroup.get());
+							ASSERT(groupItr != dataDb->tenantGroups.end());
+							groupItr->second->tenants.erase(t);
+							if (groupItr->second->tenants.empty()) {
+								dataDb->tenantGroups.erase(groupItr);
+							}
+						}
+						dataDb->tenants.erase(tenantItr);
+					}
+					dataDb->ungroupedTenants.erase(t);
+				}
+
+				wait(waitForAll(getFutures));
+
+				state std::vector<Future<Void>> deleteFutures;
+				for (auto const& f : getFutures) {
+					ASSERT(f.get().present());
+					deleteFutures.push_back(TenantAPI::deleteTenantTransaction(tr, f.get().get()));
+				}
+
+				wait(waitForAll(deleteFutures));
+				wait(tr->commit());
+				break;
+			} catch (Error& e) {
+				wait(tr->onError(e));
+			}
+		}
+
+		ASSERT(foundTenantCollision || foundGroupCollision);
+		return Void();
+	}
+
 	ACTOR static Future<Void> restoreCluster(MetaclusterManagementWorkload* self) {
 		state ClusterName clusterName = self->chooseClusterName();
-		state DataClusterData* dataDb = &self->dataDbs[clusterName];
+		state Reference<DataClusterData> dataDb = self->dataDbs[clusterName];
 		state bool dryRun = deterministicRandom()->coinflip();
 		state bool forceJoin = deterministicRandom()->coinflip();
 
@@ -282,20 +384,52 @@ struct MetaclusterManagementWorkload : TestWorkload {
 		state bool retried = false;
 		loop {
 			try {
+				if (dataDb->detached) {
+					if (retried) {
+						wait(removeFailedRestoredCluster(self, clusterName));
+					} else {
+						// On the first try, we need to remove the metacluster registration entry from the data
+						// cluster
+						wait(success(MetaclusterAPI::removeCluster(
+						    dataDb->db.getReference(), clusterName, ClusterType::METACLUSTER_DATA, ForceRemove::True)));
+					}
+				}
+
 				Future<Void> restoreFuture =
 				    MetaclusterAPI::restoreCluster(self->managementDb,
 				                                   clusterName,
 				                                   dataDb->db->getConnectionRecord()->getConnectionString(),
-				                                   ApplyManagementClusterUpdates::True,
+				                                   ApplyManagementClusterUpdates(!dataDb->detached),
 				                                   RestoreDryRun(dryRun),
 				                                   ForceJoin(forceJoin),
 				                                   &messages);
 				Optional<Void> result = wait(timeout(restoreFuture, deterministicRandom()->randomInt(1, 30)));
-				if (result.present()) {
-					break;
+				if (!result.present()) {
+					retried = true;
+					continue;
 				}
-				retried = true;
+
+				ASSERT(dataDb->registered || dataDb->detached);
+				if (dataDb->detached && !dryRun) {
+					dataDb->detached = false;
+					dataDb->registered = true;
+					for (auto const& t : dataDb->ungroupedTenants) {
+						self->ungroupedTenants.insert(t);
+					}
+					for (auto const& t : dataDb->tenantGroups) {
+						ASSERT(self->tenantGroups.try_emplace(t.first, t.second).second);
+					}
+					for (auto const& t : dataDb->tenants) {
+						ASSERT(self->createdTenants.try_emplace(t.first, t.second).second);
+						ASSERT(self->createdTenants[t.first]->cluster == clusterName);
+					}
+
+					self->totalTenantGroupCapacity += dataDb->ungroupedTenants.size() + dataDb->tenantGroups.size();
+				}
+
+				break;
 			} catch (Error& e) {
+				state Error error = e;
 				if (e.code() == error_code_conflicting_restore) {
 					ASSERT(retried);
 					CODE_PROBE(true, "MetaclusterManagementWorkload: timed out restore conflicts with retried restore");
@@ -303,9 +437,14 @@ struct MetaclusterManagementWorkload : TestWorkload {
 				} else if (e.code() == error_code_cluster_not_found) {
 					ASSERT(!dataDb->registered);
 					return Void();
+				} else if (e.code() == error_code_tenant_already_exists ||
+				           e.code() == error_code_invalid_tenant_configuration) {
+					ASSERT(dataDb->detached);
+					wait(removeFailedRestoredCluster(self, clusterName));
+					wait(resolveCollisions(self, clusterName, dataDb));
+					continue;
 				}
-
-				TraceEvent(SevError, "RestoreClusterFailure").error(e).detail("ClusterName", clusterName);
+				TraceEvent(SevError, "RestoreClusterFailure").error(error).detail("ClusterName", clusterName);
 				ASSERT(false);
 			}
 		}
@@ -330,11 +469,11 @@ struct MetaclusterManagementWorkload : TestWorkload {
 			for (auto localItr = self->dataDbs.find(clusterName1);
 			     localItr != self->dataDbs.find(clusterName2) && count < limit;
 			     ++localItr) {
-				if (localItr->second.registered) {
+				if (localItr->second->registered) {
 					ASSERT(resultItr != clusterList.end());
 					ASSERT(resultItr->first == localItr->first);
 					ASSERT(resultItr->second.connectionString ==
-					       localItr->second.db->getConnectionRecord()->getConnectionString());
+					       localItr->second->db->getConnectionRecord()->getConnectionString());
 					++resultItr;
 					++count;
 				}
@@ -359,7 +498,7 @@ struct MetaclusterManagementWorkload : TestWorkload {
 
 	ACTOR static Future<Void> getCluster(MetaclusterManagementWorkload* self) {
 		state ClusterName clusterName = self->chooseClusterName();
-		state DataClusterData* dataDb = &self->dataDbs[clusterName];
+		state Reference<DataClusterData> dataDb = self->dataDbs[clusterName];
 
 		try {
 			DataClusterMetadata clusterMetadata = wait(MetaclusterAPI::getCluster(self->managementDb, clusterName));
@@ -379,7 +518,7 @@ struct MetaclusterManagementWorkload : TestWorkload {
 
 	ACTOR static Future<Optional<DataClusterEntry>> configureImpl(MetaclusterManagementWorkload* self,
 	                                                              ClusterName clusterName,
-	                                                              DataClusterData* dataDb,
+	                                                              Reference<DataClusterData> dataDb,
 	                                                              Optional<int64_t> numTenantGroups,
 	                                                              Optional<ClusterConnectionString> connectionString) {
 		state Reference<ITransaction> tr = self->managementDb->createTransaction();
@@ -410,7 +549,7 @@ struct MetaclusterManagementWorkload : TestWorkload {
 
 	ACTOR static Future<Void> configureCluster(MetaclusterManagementWorkload* self) {
 		state ClusterName clusterName = self->chooseClusterName();
-		state DataClusterData* dataDb = &self->dataDbs[clusterName];
+		state Reference<DataClusterData> dataDb = self->dataDbs[clusterName];
 		state Optional<DataClusterEntry> updatedEntry;
 
 		state Optional<int64_t> newNumTenantGroups;
@@ -570,30 +709,30 @@ struct MetaclusterManagementWorkload : TestWorkload {
 			ASSERT(entry.tenantGroup == tenantGroup);
 			ASSERT(TenantAPI::getTenantIdPrefix(entry.id) == self->tenantIdPrefix);
 
-			if (tenantGroup.present()) {
-				auto tenantGroupData = self->tenantGroups.try_emplace(tenantGroup.get(), entry.assignedCluster).first;
-				ASSERT(tenantGroupData->second.cluster == entry.assignedCluster);
-				tenantGroupData->second.tenants.insert(tenant);
-			} else {
-				self->ungroupedTenants.insert(tenant);
-			}
+			Reference<TenantData> tenantData = makeReference<TenantData>(entry.assignedCluster, tenantGroup);
+			self->createdTenants[tenant] = tenantData;
 
 			auto assignedCluster = self->dataDbs.find(entry.assignedCluster);
 			ASSERT(assignClusterAutomatically || tenantMapEntry.assignedCluster == assignedCluster->first);
 			ASSERT(assignedCluster != self->dataDbs.end());
-			ASSERT(assignedCluster->second.tenants.insert(tenant).second);
+			ASSERT(assignedCluster->second->tenants.try_emplace(tenant, tenantData).second);
 
 			if (tenantGroup.present()) {
-				assignedCluster->second.tenantGroups.insert(tenantGroup.get());
+				auto tenantGroupData =
+				    self->tenantGroups
+				        .try_emplace(tenantGroup.get(), makeReference<TenantGroupData>(entry.assignedCluster))
+				        .first;
+				ASSERT(tenantGroupData->second->cluster == entry.assignedCluster);
+				tenantGroupData->second->tenants.insert(tenant);
+				assignedCluster->second->tenantGroups[tenantGroup.get()] = tenantGroupData->second;
 			} else {
-				assignedCluster->second.ungroupedTenants.insert(tenant);
+				self->ungroupedTenants.insert(tenant);
+				assignedCluster->second->ungroupedTenants.insert(tenant);
 			}
 
 			ASSERT(tenantGroupExists ||
-			       assignedCluster->second.tenantGroupCapacity >=
-			           assignedCluster->second.tenantGroups.size() + assignedCluster->second.ungroupedTenants.size());
-
-			self->createdTenants[tenant] = TenantData(entry.assignedCluster, tenantGroup);
+			       assignedCluster->second->tenantGroupCapacity >=
+			           assignedCluster->second->tenantGroups.size() + assignedCluster->second->ungroupedTenants.size());
 		} catch (Error& e) {
 			if (e.code() == error_code_tenant_already_exists) {
 				ASSERT(exists);
@@ -611,7 +750,7 @@ struct MetaclusterManagementWorkload : TestWorkload {
 				ASSERT(tenantGroup.present());
 				auto itr = self->tenantGroups.find(tenantGroup.get());
 				ASSERT(itr != self->tenantGroups.end());
-				ASSERT(itr->second.cluster != tenantMapEntry.assignedCluster);
+				ASSERT(itr->second->cluster != tenantMapEntry.assignedCluster);
 				return Void();
 			}
 
@@ -658,37 +797,37 @@ struct MetaclusterManagementWorkload : TestWorkload {
 			ASSERT(tenantData != self->createdTenants.end());
 
 			bool erasedTenantGroup = false;
-			if (tenantData->second.tenantGroup.present()) {
-				auto tenantGroupData = self->tenantGroups.find(tenantData->second.tenantGroup.get());
+			if (tenantData->second->tenantGroup.present()) {
+				auto tenantGroupData = self->tenantGroups.find(tenantData->second->tenantGroup.get());
 				ASSERT(tenantGroupData != self->tenantGroups.end());
-				tenantGroupData->second.tenants.erase(tenant);
-				if (tenantGroupData->second.tenants.empty()) {
+				tenantGroupData->second->tenants.erase(tenant);
+				if (tenantGroupData->second->tenants.empty()) {
 					erasedTenantGroup = true;
-					self->tenantGroups.erase(tenantData->second.tenantGroup.get());
+					self->tenantGroups.erase(tenantData->second->tenantGroup.get());
 				}
 			} else {
 				self->ungroupedTenants.erase(tenant);
 			}
 
-			auto& dataDb = self->dataDbs[tenantData->second.cluster];
-			ASSERT(dataDb.registered);
-			auto tenantItr = dataDb.tenants.find(tenant);
-			ASSERT(tenantItr != dataDb.tenants.end());
+			auto dataDb = self->dataDbs[tenantData->second->cluster];
+			ASSERT(dataDb->registered);
+			auto tenantItr = dataDb->tenants.find(tenant);
+			ASSERT(tenantItr != dataDb->tenants.end());
 
 			bool reducedAllocatedCount = false;
 			if (erasedTenantGroup) {
 				reducedAllocatedCount = true;
-				dataDb.tenantGroups.erase(tenantData->second.tenantGroup.get());
-			} else if (!tenantData->second.tenantGroup.present()) {
+				dataDb->tenantGroups.erase(tenantData->second->tenantGroup.get());
+			} else if (!tenantData->second->tenantGroup.present()) {
 				reducedAllocatedCount = true;
-				dataDb.ungroupedTenants.erase(tenant);
+				dataDb->ungroupedTenants.erase(tenant);
 			}
 
 			if (reducedAllocatedCount &&
-			    dataDb.ungroupedTenants.size() + dataDb.tenantGroups.size() >= dataDb.tenantGroupCapacity) {
+			    dataDb->ungroupedTenants.size() + dataDb->tenantGroups.size() >= dataDb->tenantGroupCapacity) {
 				--self->totalTenantGroupCapacity;
 			}
-			dataDb.tenants.erase(tenantItr);
+			dataDb->tenants.erase(tenantItr);
 			self->createdTenants.erase(tenant);
 		} catch (Error& e) {
 			if (e.code() == error_code_tenant_not_found) {
@@ -715,9 +854,9 @@ struct MetaclusterManagementWorkload : TestWorkload {
 		state bool hasCapacity = false;
 		state Optional<ClusterName> oldClusterName;
 		if (exists) {
-			auto& dataDb = self->dataDbs[itr->second.cluster];
-			hasCapacity = dataDb.ungroupedTenants.size() + dataDb.tenantGroups.size() < dataDb.tenantGroupCapacity;
-			oldClusterName = itr->second.cluster;
+			auto& dataDb = self->dataDbs[itr->second->cluster];
+			hasCapacity = dataDb->ungroupedTenants.size() + dataDb->tenantGroups.size() < dataDb->tenantGroupCapacity;
+			oldClusterName = itr->second->cluster;
 		}
 
 		state Optional<ClusterName> newClusterName = oldClusterName;
@@ -745,46 +884,47 @@ struct MetaclusterManagementWorkload : TestWorkload {
 			auto tenantData = self->createdTenants.find(tenant);
 			ASSERT(tenantData != self->createdTenants.end());
 
-			auto& dataDb = self->dataDbs[tenantData->second.cluster];
-			ASSERT(dataDb.registered);
+			auto& dataDb = self->dataDbs[tenantData->second->cluster];
+			ASSERT(dataDb->registered);
 
 			bool allocationRemoved = false;
 			bool allocationAdded = false;
-			if (tenantData->second.tenantGroup != newTenantGroup) {
-				if (tenantData->second.tenantGroup.present()) {
-					auto& tenantGroupData = self->tenantGroups[tenantData->second.tenantGroup.get()];
-					tenantGroupData.tenants.erase(tenant);
-					if (tenantGroupData.tenants.empty()) {
+			if (tenantData->second->tenantGroup != newTenantGroup) {
+				if (tenantData->second->tenantGroup.present()) {
+					auto& tenantGroupData = self->tenantGroups[tenantData->second->tenantGroup.get()];
+					tenantGroupData->tenants.erase(tenant);
+					if (tenantGroupData->tenants.empty()) {
 						allocationRemoved = true;
-						self->tenantGroups.erase(tenantData->second.tenantGroup.get());
-						dataDb.tenantGroups.erase(tenantData->second.tenantGroup.get());
+						self->tenantGroups.erase(tenantData->second->tenantGroup.get());
+						dataDb->tenantGroups.erase(tenantData->second->tenantGroup.get());
 					}
 				} else {
 					allocationRemoved = true;
 					self->ungroupedTenants.erase(tenant);
-					dataDb.ungroupedTenants.erase(tenant);
+					dataDb->ungroupedTenants.erase(tenant);
 				}
 
 				if (newTenantGroup.present()) {
 					auto [tenantGroupData, inserted] = self->tenantGroups.try_emplace(
-					    newTenantGroup.get(), TenantGroupData(tenantData->second.cluster));
-					tenantGroupData->second.tenants.insert(tenant);
+					    newTenantGroup.get(), makeReference<TenantGroupData>(tenantData->second->cluster));
+					tenantGroupData->second->tenants.insert(tenant);
 					if (inserted) {
 						allocationAdded = true;
-						dataDb.tenantGroups.insert(newTenantGroup.get());
+						ASSERT(dataDb->tenantGroups.try_emplace(newTenantGroup.get(), tenantGroupData->second).second);
 					}
 				} else {
 					allocationAdded = true;
 					self->ungroupedTenants.insert(tenant);
-					dataDb.ungroupedTenants.insert(tenant);
+					dataDb->ungroupedTenants.insert(tenant);
 				}
 
-				tenantData->second.tenantGroup = newTenantGroup;
+				tenantData->second->tenantGroup = newTenantGroup;
 
 				if (allocationAdded && !allocationRemoved) {
 					ASSERT(hasCapacity);
 				} else if (allocationRemoved && !allocationAdded &&
-				           dataDb.ungroupedTenants.size() + dataDb.tenantGroups.size() >= dataDb.tenantGroupCapacity) {
+				           dataDb->ungroupedTenants.size() + dataDb->tenantGroups.size() >=
+				               dataDb->tenantGroupCapacity) {
 					--self->totalTenantGroupCapacity;
 				}
 			}
@@ -800,7 +940,7 @@ struct MetaclusterManagementWorkload : TestWorkload {
 				ASSERT(exists);
 				if (oldClusterName == newClusterName) {
 					ASSERT(tenantGroupExists &&
-					       self->createdTenants[tenant].cluster != self->tenantGroups[newTenantGroup.get()].cluster);
+					       self->createdTenants[tenant]->cluster != self->tenantGroups[newTenantGroup.get()]->cluster);
 				}
 				return Void();
 			}
@@ -859,25 +999,26 @@ struct MetaclusterManagementWorkload : TestWorkload {
 
 			auto tenantData = self->createdTenants.find(tenant);
 			ASSERT(tenantData != self->createdTenants.end());
-			ASSERT(tenantData->second.tenantGroup == newEntry.tenantGroup);
-			ASSERT(tenantData->second.cluster == newEntry.assignedCluster);
+			ASSERT(tenantData->second->tenantGroup == newEntry.tenantGroup);
+			ASSERT(tenantData->second->cluster == newEntry.assignedCluster);
 
 			self->createdTenants[newTenantName] = tenantData->second;
+			ASSERT(tenantData->second);
 			self->createdTenants.erase(tenantData);
 
 			auto& dataDb = self->dataDbs[newEntry.assignedCluster];
-			ASSERT(dataDb.registered);
+			ASSERT(dataDb->registered);
 
-			dataDb.tenants.erase(tenant);
-			dataDb.tenants.insert(newTenantName);
+			dataDb->tenants.erase(tenant);
+			dataDb->tenants[newTenantName] = tenantData->second;
 
 			if (newEntry.tenantGroup.present()) {
 				auto& tenantGroup = self->tenantGroups[newEntry.tenantGroup.get()];
-				tenantGroup.tenants.erase(tenant);
-				tenantGroup.tenants.insert(newTenantName);
+				tenantGroup->tenants.erase(tenant);
+				tenantGroup->tenants.insert(newTenantName);
 			} else {
-				dataDb.ungroupedTenants.erase(tenant);
-				dataDb.ungroupedTenants.insert(newTenantName);
+				dataDb->ungroupedTenants.erase(tenant);
+				dataDb->ungroupedTenants.insert(newTenantName);
 				self->ungroupedTenants.erase(tenant);
 				self->ungroupedTenants.insert(newTenantName);
 			}
@@ -942,10 +1083,10 @@ struct MetaclusterManagementWorkload : TestWorkload {
 	// Checks that the data cluster state matches our local state
 	ACTOR static Future<Void> checkDataCluster(MetaclusterManagementWorkload* self,
 	                                           ClusterName clusterName,
-	                                           DataClusterData clusterData) {
+	                                           Reference<DataClusterData> clusterData) {
 		state Optional<MetaclusterRegistrationEntry> metaclusterRegistration;
 		state std::vector<std::pair<TenantName, TenantMapEntry>> tenants;
-		state Reference<ReadYourWritesTransaction> tr = clusterData.db->createTransaction();
+		state Reference<ReadYourWritesTransaction> tr = clusterData->db->createTransaction();
 
 		loop {
 			try {
@@ -953,26 +1094,33 @@ struct MetaclusterManagementWorkload : TestWorkload {
 				wait(store(metaclusterRegistration, MetaclusterMetadata::metaclusterRegistration().get(tr)) &&
 				     store(tenants,
 				           TenantAPI::listTenantMetadataTransaction(
-				               tr, ""_sr, "\xff\xff"_sr, clusterData.tenants.size() + 1)));
+				               tr, ""_sr, "\xff\xff"_sr, clusterData->tenants.size() + 1)));
 				break;
 			} catch (Error& e) {
 				wait(safeThreadFutureToFuture(tr->onError(e)));
 			}
 		}
 
-		if (clusterData.registered) {
+		if (clusterData->registered) {
 			ASSERT(metaclusterRegistration.present() &&
 			       metaclusterRegistration.get().clusterType == ClusterType::METACLUSTER_DATA);
 		} else {
 			ASSERT(!metaclusterRegistration.present());
 		}
 
-		ASSERT(tenants.size() == clusterData.tenants.size());
+		ASSERT_EQ(tenants.size(), clusterData->tenants.size());
 		for (auto [tenantName, tenantEntry] : tenants) {
-			ASSERT(clusterData.tenants.count(tenantName));
-			auto tenantData = self->createdTenants[tenantName];
-			ASSERT(tenantData.cluster == clusterName);
-			ASSERT(tenantData.tenantGroup == tenantEntry.tenantGroup);
+			ASSERT(clusterData->tenants.count(tenantName));
+			auto tenantData = clusterData->tenants.find(tenantName);
+			ASSERT(tenantData != clusterData->tenants.end());
+			ASSERT(tenantData->second->cluster == clusterName);
+			ASSERT(tenantData->second->tenantGroup == tenantEntry.tenantGroup);
+
+			if (!clusterData->detached) {
+				auto itr = self->createdTenants.find(tenantName);
+				ASSERT(itr != self->createdTenants.end());
+				ASSERT(itr->second == tenantData->second);
+			}
 		}
 
 		return Void();
@@ -1034,11 +1182,11 @@ struct MetaclusterManagementWorkload : TestWorkload {
 		std::vector<Future<Void>> dataClusterChecks;
 		for (auto [clusterName, dataClusterData] : self->dataDbs) {
 			auto dataClusterItr = dataClusters.find(clusterName);
-			if (dataClusterData.registered) {
+			if (dataClusterData->registered) {
 				ASSERT(dataClusterItr != dataClusters.end());
-				ASSERT(dataClusterItr->second.entry.capacity.numTenantGroups == dataClusterData.tenantGroupCapacity);
+				ASSERT(dataClusterItr->second.entry.capacity.numTenantGroups == dataClusterData->tenantGroupCapacity);
 				totalTenantGroupsAllocated +=
-				    dataClusterData.tenantGroups.size() + dataClusterData.ungroupedTenants.size();
+				    dataClusterData->tenantGroups.size() + dataClusterData->ungroupedTenants.size();
 			} else {
 				ASSERT(dataClusterItr == dataClusters.end());
 			}


### PR DESCRIPTION
This adds support for force removal of clusters and repopulating a management cluster in the metacluster managament workload.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
