### PR TITLE
Store a smaller tenant object in the txn state store

### DIFF
--- a/fdbclient/include/fdbclient/Tenant.h
+++ b/fdbclient/include/fdbclient/Tenant.h
@@ -54,6 +54,29 @@ TenantLockState stringToTenantLockState(std::string stateStr);
 json_spirit::mObject binaryToJson(StringRef bytes);
 
 struct MetaclusterTenantMapEntry;
+
+struct TenantMapEntryTxnStateStore {
+	constexpr static FileIdentifier file_identifier = 11267001;
+
+	int64_t id = -1;
+	TenantName tenantName;
+	TenantAPI::TenantLockState tenantLockState = TenantAPI::TenantLockState::UNLOCKED;
+
+	TenantMapEntryTxnStateStore() {}
+	TenantMapEntryTxnStateStore(int64_t id, TenantName tenantName, TenantAPI::TenantLockState tenantLockState)
+	  : id(id), tenantName(tenantName), tenantLockState(tenantLockState) {}
+
+	Value encode() const { return ObjectWriter::toValue(*this, IncludeVersion()); }
+	static TenantMapEntryTxnStateStore decode(ValueRef const& value) {
+		return ObjectReader::fromStringRef<TenantMapEntryTxnStateStore>(value, IncludeVersion());
+	}
+
+	template <class Ar>
+	void serialize(Ar& ar) {
+		serializer(ar, id, tenantLockState, tenantName);
+	}
+};
+
 struct TenantMapEntry {
 	constexpr static FileIdentifier file_identifier = 7054389;
 
@@ -78,6 +101,10 @@ struct TenantMapEntry {
 	Value encode() const { return ObjectWriter::toValue(*this, IncludeVersion()); }
 	static TenantMapEntry decode(ValueRef const& value) {
 		return ObjectReader::fromStringRef<TenantMapEntry>(value, IncludeVersion());
+	}
+
+	TenantMapEntryTxnStateStore toTxnStateStoreEntry() const {
+		return TenantMapEntryTxnStateStore(id, tenantName, tenantLockState);
 	}
 
 	bool operator==(TenantMapEntry const& other) const;


### PR DESCRIPTION
We don't need all of the tenant fields to be stored in the txn state store for use on the CP and SS, so store a subset containing only the needed fields.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
