### PR TITLE
Fix build issue with awssdk_target

### DIFF
--- a/fdbclient/CMakeLists.txt
+++ b/fdbclient/CMakeLists.txt
@@ -94,7 +94,7 @@ if(BUILD_AZURE_BACKUP)
   target_link_libraries(fdbclient_sampling PRIVATE curl azure-storage-lite)
 endif()
 
-if(BUILD_AWS_BACKUP)
+if(WITH_AWS_BACKUP)
   target_link_libraries(fdbclient PUBLIC awssdk_target)
   target_link_libraries(fdbclient_sampling PUBLIC awssdk_target)
 endif()


### PR DESCRIPTION
As of today the awssdk doesn't work on ARM so the intend was to have this disabled. But the code that was supposed to do that is wrong

Cherry-pick of #9463

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
