### PR TITLE
Don't block the exclusion of stateless processes by the free capacity check

### DIFF
--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -1001,6 +1001,8 @@ ACTOR Future<bool> checkExclusion(Database db,
 	state int64_t totalKvStoreUsedBytes = 0;
 	state int64_t totalKvStoreUsedBytesNonExcluded = 0;
 	state int64_t totalKvStoreAvailableBytes = 0;
+	// Keep track if we exclude any storage process with the provided adddresses
+	state bool excludedAddressesContainsStorageRole = false;
 
 	try {
 		for (auto proc : processesMap.obj()) {
@@ -1024,6 +1026,18 @@ ACTOR Future<bool> checkExclusion(Database db,
 			for (StatusObjectReader role : rolesArray) {
 				if (role["role"].get_str() == "storage") {
 					ssTotalCount++;
+
+					// Check if we are excluding a process that serves the storage role. If this check was true once, we don't have to check any further
+					// since we don't case in this variable about the count of excluded storage servers but only about if we exclude any storage server with the
+					// provided addresses.
+					if !excludedAddressesContainsStorageRole {
+						for (auto exclusion : addresses) {
+							if (exclusion.excludes(addr)) {
+								excludedAddressesContainsStorageRole = true;
+								break;
+							}
+						}
+					}
 
 					int64_t used_bytes;
 					if (!role.get("kvstore_used_bytes", used_bytes)) {
@@ -1071,6 +1085,12 @@ ACTOR Future<bool> checkExclusion(Database db,
 	{
 		*msg = ManagementAPIError::toJsonString(false, markFailed ? "exclude failed" : "exclude", errorString);
 		return false;
+	}
+
+	// If the exclusion command only contains processes that serve a non storage role we can skip the free capacity check in order to not
+	// block those exclusions.
+	if ! excludedAddressesContainsStorageRole {
+		return true;
 	}
 
 	// The numerator is the total space in use by FDB that is not immediately reusable.

--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -1013,8 +1013,9 @@ ACTOR Future<bool> checkExclusion(Database db,
 				return false;
 			}
 			NetworkAddress addr = NetworkAddress::parse(addrStr);
+			bool includedInExclusion =  addressExcluded(*exclusions, addr);
 			bool excluded =
-			    (process.has("excluded") && process.last().get_bool()) || addressExcluded(*exclusions, addr);
+			    (process.has("excluded") && process.last().get_bool()) || includedInExclusion;
 
 			StatusObjectReader localityObj;
 			std::string disk_id;
@@ -1030,7 +1031,7 @@ ACTOR Future<bool> checkExclusion(Database db,
 					// Check if we are excluding a process that serves the storage role. If this check was true once, we
 					// don't have to check any further since we don't case in this variable about the count of excluded
 					// storage servers but only about if we exclude any storage server with the provided addresses.
-					if (!excludedAddressesContainsStorageRole && excluded) {
+					if (!excludedAddressesContainsStorageRole && includedInExclusion) {
 						excludedAddressesContainsStorageRole = true;
 						break;
 					}

--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -1013,9 +1013,8 @@ ACTOR Future<bool> checkExclusion(Database db,
 				return false;
 			}
 			NetworkAddress addr = NetworkAddress::parse(addrStr);
-			bool includedInExclusion =  addressExcluded(*exclusions, addr);
-			bool excluded =
-			    (process.has("excluded") && process.last().get_bool()) || includedInExclusion;
+			bool includedInExclusion = addressExcluded(*exclusions, addr);
+			bool excluded = (process.has("excluded") && process.last().get_bool()) || includedInExclusion;
 
 			StatusObjectReader localityObj;
 			std::string disk_id;
@@ -1028,9 +1027,8 @@ ACTOR Future<bool> checkExclusion(Database db,
 				if (role["role"].get_str() == "storage") {
 					ssTotalCount++;
 
-					// Check if we are excluding a process that serves the storage role. If this check was true once, we
-					// don't have to check any further since we don't case in this variable about the count of excluded
-					// storage servers but only about if we exclude any storage server with the provided addresses.
+					// Check if we are excluding a process that serves the storage role. We only have to check the free
+					// capacity if we are excluding at least one process that serves the storage role.
 					if (!excludedAddressesContainsStorageRole && includedInExclusion) {
 						excludedAddressesContainsStorageRole = true;
 						break;

--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -1027,9 +1027,9 @@ ACTOR Future<bool> checkExclusion(Database db,
 				if (role["role"].get_str() == "storage") {
 					ssTotalCount++;
 
-					// Check if we are excluding a process that serves the storage role. If this check was true once, we don't have to check any further
-					// since we don't case in this variable about the count of excluded storage servers but only about if we exclude any storage server with the
-					// provided addresses.
+					// Check if we are excluding a process that serves the storage role. If this check was true once, we
+					// don't have to check any further since we don't case in this variable about the count of excluded
+					// storage servers but only about if we exclude any storage server with the provided addresses.
 					if (!excludedAddressesContainsStorageRole && excluded) {
 						excludedAddressesContainsStorageRole = true;
 						break;
@@ -1083,8 +1083,8 @@ ACTOR Future<bool> checkExclusion(Database db,
 		return false;
 	}
 
-	// If the exclusion command only contains processes that serve a non storage role we can skip the free capacity check in order to not
-	// block those exclusions.
+	// If the exclusion command only contains processes that serve a non storage role we can skip the free capacity
+	// check in order to not block those exclusions.
 	if (!excludedAddressesContainsStorageRole) {
 		return true;
 	}

--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -1030,13 +1030,9 @@ ACTOR Future<bool> checkExclusion(Database db,
 					// Check if we are excluding a process that serves the storage role. If this check was true once, we don't have to check any further
 					// since we don't case in this variable about the count of excluded storage servers but only about if we exclude any storage server with the
 					// provided addresses.
-					if (!excludedAddressesContainsStorageRole) {
-						for (auto exclusion : addresses) {
-							if (exclusion.excludes(addr)) {
-								excludedAddressesContainsStorageRole = true;
-								break;
-							}
-						}
+					if (!excludedAddressesContainsStorageRole && excluded) {
+						excludedAddressesContainsStorageRole = true;
+						break;
 					}
 
 					int64_t used_bytes;

--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -1030,7 +1030,7 @@ ACTOR Future<bool> checkExclusion(Database db,
 					// Check if we are excluding a process that serves the storage role. If this check was true once, we don't have to check any further
 					// since we don't case in this variable about the count of excluded storage servers but only about if we exclude any storage server with the
 					// provided addresses.
-					if !excludedAddressesContainsStorageRole {
+					if (!excludedAddressesContainsStorageRole) {
 						for (auto exclusion : addresses) {
 							if (exclusion.excludes(addr)) {
 								excludedAddressesContainsStorageRole = true;
@@ -1089,7 +1089,7 @@ ACTOR Future<bool> checkExclusion(Database db,
 
 	// If the exclusion command only contains processes that serve a non storage role we can skip the free capacity check in order to not
 	// block those exclusions.
-	if ! excludedAddressesContainsStorageRole {
+	if (!excludedAddressesContainsStorageRole) {
 		return true;
 	}
 


### PR DESCRIPTION
Currently the exclude command will block exclusions if the (new) free capacity is below 10%. This also blocks exclusions for processes that don't serve a storage role e.g. stateless processes. I don't think it make sense to block the exclusion of a stateless process based on the free capacity. With those changes the free capacity check will be skipped if no process in the exclusion set is serving a storage role, if at least one process is serving a storage role the free capacity check will be done.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
