### PR TITLE
Reworking getBlobGranuleRanges to also use commit proxy rpc for authz…

### DIFF
--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -3216,10 +3216,12 @@ ACTOR Future<std::vector<std::pair<KeyRange, BlobWorkerInterface>>> getBlobGranu
     KeyRange keys,
     int limit,
     Reverse reverse,
+    bool justGranules,
     SpanContext spanContext,
     Optional<UID> debugID,
     UseProvisionalProxies useProvisionalProxies,
-    Version version) {
+    Version version,
+    bool* more) {
 	state Span span("NAPI:getBlobGranuleLocations"_loc, spanContext);
 	if (debugID.present())
 		g_traceBatch.addEvent("TransactionDebug", debugID.get().first(), "NativeAPI.getBlobGranuleLocations.Before");
@@ -3228,26 +3230,38 @@ ACTOR Future<std::vector<std::pair<KeyRange, BlobWorkerInterface>>> getBlobGranu
 		++cx->transactionBlobGranuleLocationRequests;
 		choose {
 			when(wait(cx->onProxiesChanged())) {}
-			when(GetBlobGranuleLocationsReply _rep = wait(basicLoadBalance(
-			         cx->getCommitProxies(useProvisionalProxies),
-			         &CommitProxyInterface::getBlobGranuleLocations,
-			         GetBlobGranuleLocationsRequest(
-			             span.context, tenant, keys.begin, keys.end, limit, reverse, version, keys.arena()),
-			         TaskPriority::DefaultPromiseEndpoint))) {
+			when(GetBlobGranuleLocationsReply _rep =
+			         wait(basicLoadBalance(cx->getCommitProxies(useProvisionalProxies),
+			                               &CommitProxyInterface::getBlobGranuleLocations,
+			                               GetBlobGranuleLocationsRequest(span.context,
+			                                                              tenant,
+			                                                              keys.begin,
+			                                                              keys.end,
+			                                                              limit,
+			                                                              reverse,
+			                                                              justGranules,
+			                                                              version,
+			                                                              keys.arena()),
+			                               TaskPriority::DefaultPromiseEndpoint))) {
 				++cx->transactionBlobGranuleLocationRequestsCompleted;
 				state GetBlobGranuleLocationsReply rep = _rep;
 				if (debugID.present())
 					g_traceBatch.addEvent(
 					    "TransactionDebug", debugID.get().first(), "NativeAPI.getBlobGranuleLocations.After");
-				ASSERT(rep.results.size());
+				// if justGranules, we can get an empty mapping, otherwise, an empty mapping should have been an error
+				ASSERT(justGranules || rep.results.size());
+				ASSERT(!rep.more || !rep.results.empty());
+				*more = rep.more;
 
 				state std::vector<std::pair<KeyRange, BlobWorkerInterface>> results;
 				state int granule = 0;
 				for (; granule < rep.results.size(); granule++) {
 					// FIXME: cache mapping?
-					results.emplace_back(
-					    KeyRange(toPrefixRelativeRange(rep.results[granule].first, tenant.prefix) & keys),
-					    rep.results[granule].second);
+					KeyRange range(toPrefixRelativeRange(rep.results[granule].first, tenant.prefix));
+					if (!justGranules) {
+						range = range & keys;
+					}
+					results.emplace_back(range, rep.results[granule].second);
 					wait(yield());
 				}
 
@@ -3264,16 +3278,18 @@ Future<std::vector<std::pair<KeyRange, BlobWorkerInterface>>> getBlobGranuleLoca
     KeyRange const& keys,
     int limit,
     Reverse reverse,
+    bool justGranules,
     SpanContext const& spanContext,
     Optional<UID> const& debugID,
     UseProvisionalProxies useProvisionalProxies,
-    Version version) {
+    Version version,
+    bool* more) {
 
 	ASSERT(!keys.empty());
 
 	// FIXME: wrap this with location caching for blob workers like getKeyRangeLocations has
 	return getBlobGranuleLocations_internal(
-	    cx, tenant, keys, limit, reverse, spanContext, debugID, useProvisionalProxies, version);
+	    cx, tenant, keys, limit, reverse, justGranules, spanContext, debugID, useProvisionalProxies, version, more);
 }
 
 Future<std::vector<std::pair<KeyRange, BlobWorkerInterface>>> getBlobGranuleLocations(
@@ -3281,18 +3297,22 @@ Future<std::vector<std::pair<KeyRange, BlobWorkerInterface>>> getBlobGranuleLoca
     KeyRange const& keys,
     int limit,
     Reverse reverse,
-    UseTenant useTenant) {
+    UseTenant useTenant,
+    bool justGranules,
+    bool* more) {
 	return getBlobGranuleLocations(
 	    trState->cx,
 	    useTenant ? trState->getTenantInfo(AllowInvalidTenantID::True) : TenantInfo(),
 	    keys,
 	    limit,
 	    reverse,
+	    justGranules,
 	    trState->spanContext,
 	    trState->readOptions.present() ? trState->readOptions.get().debugID : Optional<UID>(),
 	    trState->useProvisionalProxies,
 	    trState->readVersionFuture.isValid() && trState->readVersionFuture.isReady() ? trState->readVersion()
-	                                                                                 : latestVersion);
+	                                                                                 : latestVersion,
+	    more);
 }
 
 ACTOR Future<Void> warmRange_impl(Reference<TransactionState> trState, KeyRange keys) {
@@ -8109,66 +8129,51 @@ Future<Standalone<VectorRef<KeyRef>>> Transaction::getRangeSplitPoints(KeyRange 
 
 #define BG_REQUEST_DEBUG false
 
-// FIXME: make this use getBlobGranuleLocations!
-// the blob granule requests are a bit funky because they piggyback off the existing transaction to read from the system
-// keyspace
 ACTOR Future<Standalone<VectorRef<KeyRangeRef>>> getBlobGranuleRangesActor(Transaction* self,
                                                                            KeyRange keyRange,
                                                                            int rangeLimit) {
-	// FIXME: use streaming range read
+
 	state KeyRange currentRange = keyRange;
 	state Standalone<VectorRef<KeyRangeRef>> results;
-	state Optional<KeyRef> tenantPrefix;
+	state bool more = false;
 	if (BG_REQUEST_DEBUG) {
 		fmt::print("Getting Blob Granules for [{0} - {1})\n", keyRange.begin.printable(), keyRange.end.printable());
 	}
 
 	if (self->getTenant().present()) {
 		wait(self->getTenant().get()->ready());
-		tenantPrefix = self->getTenant().get()->prefix();
-	} else {
-		self->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 	}
 	loop {
-		state RangeResult blobGranuleMapping;
-		if (tenantPrefix.present()) {
-			state Standalone<StringRef> mappingPrefix = tenantPrefix.get().withPrefix(blobGranuleMappingKeys.begin);
-
-			// basically krmGetRangeUnaligned, but enable it to not use tenant without RAW_ACCESS by doing manual
-			// getRange with UseTenant::False
-			GetRangeLimits limits(2 * rangeLimit + 2);
-			limits.minRows = 2;
-
-			RangeResult rawMapping = wait(getRange(self->trState,
-			                                       lastLessOrEqual(keyRange.begin.withPrefix(mappingPrefix)),
-			                                       KeySelectorRef(keyRange.end.withPrefix(mappingPrefix), false, +2),
-			                                       limits,
-			                                       Reverse::False,
-			                                       UseTenant::False));
-			// strip off mapping prefix
-			blobGranuleMapping = krmDecodeRanges(mappingPrefix, currentRange, rawMapping, false);
-		} else {
-			wait(store(
-			    blobGranuleMapping,
-			    krmGetRangesUnaligned(
-			        self, blobGranuleMappingKeys.begin, currentRange, 1000, GetRangeLimits::BYTE_LIMIT_UNLIMITED)));
+		int remaining = std::max(0, rangeLimit - results.size()) + 1;
+		// TODO: knob
+		remaining = std::min(1000, remaining);
+		if (BUGGIFY_WITH_PROB(0.01)) {
+			remaining = std::min(remaining, deterministicRandom()->randomInt(1, 10));
 		}
-
-		for (int i = 0; i < blobGranuleMapping.size() - 1; i++) {
-			if (blobGranuleMapping[i].value.size()) {
-				results.push_back(results.arena(),
-				                  KeyRangeRef(blobGranuleMapping[i].key, blobGranuleMapping[i + 1].key));
-				if (results.size() == rangeLimit) {
-					return results;
+		std::vector<std::pair<KeyRange, BlobWorkerInterface>> blobGranuleMapping = wait(getBlobGranuleLocations(
+		    self->trState, currentRange, remaining, Reverse::False, UseTenant::True, true, &more));
+		for (auto& it : blobGranuleMapping) {
+			if (!results.empty() && results.back().end > it.first.end) {
+				ASSERT(results.back().end > it.first.begin);
+				ASSERT(results.back().end <= it.first.end);
+				CODE_PROBE(true, "Merge while reading granules", probe::decoration::rare);
+				while (!results.empty() && results.back().begin >= it.first.begin) {
+					// TODO: we can't easily un-allocate the data in the arena for these guys, but that's ok as this
+					// should be rare
+					results.pop_back();
 				}
+				ASSERT(results.empty() || results.back().end == it.first.begin);
+			}
+			results.push_back_deep(results.arena(), it.first);
+			if (results.size() == rangeLimit) {
+				return results;
 			}
 		}
-		results.arena().dependsOn(blobGranuleMapping.arena());
-		if (blobGranuleMapping.more) {
-			currentRange = KeyRangeRef(blobGranuleMapping.back().key, currentRange.end);
-		} else {
+		if (!more) {
 			return results;
 		}
+		CODE_PROBE(more, "partial granule mapping");
+		currentRange = KeyRangeRef(results.back().end, currentRange.end);
 	}
 }
 
@@ -8224,14 +8229,22 @@ ACTOR Future<Standalone<VectorRef<BlobGranuleChunkRef>>> readBlobGranulesActor(
 		wait(self->getTenant().get()->ready());
 	}
 
-	state std::vector<std::pair<KeyRange, BlobWorkerInterface>> blobGranuleMapping = wait(getBlobGranuleLocations(
-	    self->trState, keyRange, CLIENT_KNOBS->BG_TOO_MANY_GRANULES, Reverse::False, UseTenant::True));
+	state bool moreMapping = false;
+	state std::vector<std::pair<KeyRange, BlobWorkerInterface>> blobGranuleMapping =
+	    wait(getBlobGranuleLocations(self->trState,
+	                                 keyRange,
+	                                 CLIENT_KNOBS->BG_TOO_MANY_GRANULES,
+	                                 Reverse::False,
+	                                 UseTenant::True,
+	                                 false,
+	                                 &moreMapping));
 
 	if (blobGranuleMapping.empty()) {
 		throw blob_granule_transaction_too_old();
 	}
 	ASSERT(blobGranuleMapping.front().first.begin <= keyRange.begin);
-	if (blobGranuleMapping.back().first.end < keyRange.end) {
+	ASSERT(moreMapping == blobGranuleMapping.back().first.end < keyRange.end);
+	if (moreMapping) {
 		if (BG_REQUEST_DEBUG) {
 			fmt::print("BG Mapping for [{0} - {1}) too large! ({2}) LastRange=[{3} - {4}): {5}\n",
 			           keyRange.begin.printable(),

--- a/fdbclient/include/fdbclient/CommitProxyInterface.h
+++ b/fdbclient/include/fdbclient/CommitProxyInterface.h
@@ -476,10 +476,13 @@ struct GetBlobGranuleLocationsReply {
 	constexpr static FileIdentifier file_identifier = 2923309;
 	Arena arena;
 	std::vector<std::pair<KeyRangeRef, BlobWorkerInterface>> results;
+	bool more;
+
+	// FIXME: change to vector of <KeyRangeRef, UID> and then separate map UID->BWInterf
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, results, arena);
+		serializer(ar, results, more, arena);
 	}
 };
 
@@ -492,6 +495,7 @@ struct GetBlobGranuleLocationsRequest {
 	Optional<KeyRef> end;
 	int limit;
 	bool reverse;
+	bool justGranules;
 	ReplyPromise<GetBlobGranuleLocationsReply> reply;
 
 	// This version is used to specify the minimum metadata version a proxy must have in order to declare that
@@ -500,23 +504,24 @@ struct GetBlobGranuleLocationsRequest {
 	// updates from other proxies before answering.
 	Version minTenantVersion;
 
-	GetBlobGranuleLocationsRequest() : limit(0), reverse(false), minTenantVersion(latestVersion) {}
+	GetBlobGranuleLocationsRequest() : limit(0), reverse(false), justGranules(false), minTenantVersion(latestVersion) {}
 	GetBlobGranuleLocationsRequest(SpanContext spanContext,
 	                               TenantInfo const& tenant,
 	                               KeyRef const& begin,
 	                               Optional<KeyRef> const& end,
 	                               int limit,
 	                               bool reverse,
+	                               bool justGranules,
 	                               Version minTenantVersion,
 	                               Arena const& arena)
 	  : arena(arena), spanContext(spanContext), tenant(tenant), begin(begin), end(end), limit(limit), reverse(reverse),
-	    minTenantVersion(minTenantVersion) {}
+	    justGranules(justGranules), minTenantVersion(minTenantVersion) {}
 
 	bool verify() const { return tenant.isAuthorized(); }
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, begin, end, limit, reverse, reply, spanContext, tenant, minTenantVersion, arena);
+		serializer(ar, begin, end, limit, reverse, reply, spanContext, tenant, minTenantVersion, justGranules, arena);
 	}
 };
 

--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -2788,9 +2788,27 @@ ACTOR static Future<Void> doBlobGranuleLocationRequest(GetBlobGranuleLocationsRe
 	try {
 		// TODO: could skip GRV, and keeps consistent with tenant mapping? Appears to be other issues though
 		// tr.setVersion(minVersion);
-		state RangeResult blobGranuleMapping = wait(krmGetRanges(
-		    &tr, blobGranuleMappingKeys.begin, keyRange, req.limit + 1, GetRangeLimits::BYTE_LIMIT_UNLIMITED));
+		// FIXME: could use streaming range read for large mappings?
+		state RangeResult blobGranuleMapping;
+		// add +1 to convert from range limit to boundary limit, 3 to allow for sequnce of:
+		// end of previous range - query begin key - start of granule - query end key - end of granule
+		// to pick up the intersecting granule
+		req.limit = std::max(3, req.limit + 1);
+		if (req.justGranules) {
+			// use krm unaligned for granules
+			wait(store(
+			    blobGranuleMapping,
+			    krmGetRangesUnaligned(
+			        &tr, blobGranuleMappingKeys.begin, keyRange, req.limit, GetRangeLimits::BYTE_LIMIT_UNLIMITED)));
+		} else {
+			// use aligned mapping for reads
+			wait(store(
+			    blobGranuleMapping,
+			    krmGetRanges(
+			        &tr, blobGranuleMappingKeys.begin, keyRange, req.limit, GetRangeLimits::BYTE_LIMIT_UNLIMITED)));
+		}
 		rep.arena.dependsOn(blobGranuleMapping.arena());
+		ASSERT(blobGranuleMapping.empty() || blobGranuleMapping.size() >= 2);
 
 		// load and decode worker interfaces if not cached
 		// FIXME: potentially remove duplicate racing requests for same BW interface? Should only happen at CP startup
@@ -2799,15 +2817,21 @@ ACTOR static Future<Void> doBlobGranuleLocationRequest(GetBlobGranuleLocationsRe
 		state std::vector<Future<Optional<Value>>> bwiLookupFutures;
 		for (i = 0; i < blobGranuleMapping.size() - 1; i++) {
 			if (!blobGranuleMapping[i].value.size()) {
+				if (req.justGranules) {
+					// skip non-blobbified ranges if justGranules
+					continue;
+				}
 				throw blob_granule_transaction_too_old();
 			}
 
 			UID workerId = decodeBlobGranuleMappingValue(blobGranuleMapping[i].value);
-			if (workerId == UID()) {
+			if (workerId == UID() && !req.justGranules) {
+				// range with no worker but set for blobbification counts for granule boundaries but not readability
 				throw blob_granule_transaction_too_old();
 			}
 
-			if (!commitData->blobWorkerInterfCache.count(workerId) && !bwiLookedUp.count(workerId)) {
+			if (!req.justGranules && !commitData->blobWorkerInterfCache.count(workerId) &&
+			    !bwiLookedUp.count(workerId)) {
 				bwiLookedUp.insert(workerId);
 				bwiLookupFutures.push_back(tr.get(blobWorkerListKeyFor(workerId)));
 			}
@@ -2830,12 +2854,20 @@ ACTOR static Future<Void> doBlobGranuleLocationRequest(GetBlobGranuleLocationsRe
 
 		// Mapping is valid, all worker interfaces are cached, we can populate response
 		for (i = 0; i < blobGranuleMapping.size() - 1; i++) {
-			// FIXME: avoid duplicate decode?
-			UID workerId = decodeBlobGranuleMappingValue(blobGranuleMapping[i].value);
-			rep.results.push_back({ KeyRangeRef(blobGranuleMapping[i].key, blobGranuleMapping[i + 1].key),
-			                        commitData->blobWorkerInterfCache[workerId] });
+			KeyRangeRef granule(blobGranuleMapping[i].key, blobGranuleMapping[i + 1].key);
+			if (req.justGranules) {
+				if (!blobGranuleMapping[i].value.size()) {
+					continue;
+				}
+				rep.results.push_back({ granule, BlobWorkerInterface() });
+			} else {
+				// FIXME: avoid duplicate decode?
+				UID workerId = decodeBlobGranuleMappingValue(blobGranuleMapping[i].value);
+				rep.results.push_back({ granule, commitData->blobWorkerInterfCache[workerId] });
+			}
 		}
 
+		rep.more = blobGranuleMapping.more;
 	} catch (Error& e) {
 		++commitData->stats.blobGranuleLocationOut;
 		if (e.code() == error_code_operation_cancelled) {

--- a/fdbserver/workloads/BlobGranuleCorrectnessWorkload.actor.cpp
+++ b/fdbserver/workloads/BlobGranuleCorrectnessWorkload.actor.cpp
@@ -917,7 +917,6 @@ struct BlobGranuleCorrectnessWorkload : TestWorkload {
 
 	ACTOR Future<Void> checkTenantRanges(BlobGranuleCorrectnessWorkload* self,
 	                                     Database cx,
-
 	                                     Reference<ThreadData> threadData) {
 		// check that reading ranges with tenant name gives valid result of ranges just for tenant, with no tenant
 		// prefix


### PR DESCRIPTION
In order to allow a tenant to get their own granules, the get getBlobGranuleRanges call had to also go through the same commit proxy getBlobGranuleLocations call as readBlobGranules.
This also meant adding some complexity/modality ("justGranules") to the call, as while they both read the same database mapping, they have slightly different semantics and requirements.
I also added the "more" flag for better pagination/discovery of the complete mapping to the response.

Passes 100k BlobGranule* with unrelated failures, and 10k AuthzSecurity* tests.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
