### PR TITLE
Fix memory error from using invalidated iterator

### DIFF
--- a/fdbserver/workloads/MetaclusterManagementWorkload.actor.cpp
+++ b/fdbserver/workloads/MetaclusterManagementWorkload.actor.cpp
@@ -998,20 +998,21 @@ struct MetaclusterManagementWorkload : TestWorkload {
 
 			MetaclusterTenantMapEntry newEntry = wait(MetaclusterAPI::getTenant(self->managementDb, newTenantName));
 
-			auto tenantData = self->createdTenants.find(tenant);
-			ASSERT(tenantData != self->createdTenants.end());
-			ASSERT(tenantData->second->tenantGroup == newEntry.tenantGroup);
-			ASSERT(tenantData->second->cluster == newEntry.assignedCluster);
+			auto tenantDataItr = self->createdTenants.find(tenant);
+			ASSERT(tenantDataItr != self->createdTenants.end());
 
-			self->createdTenants[newTenantName] = tenantData->second;
-			ASSERT(tenantData->second);
-			self->createdTenants.erase(tenantData);
+			Reference<TenantTestData> tenantData = tenantDataItr->second;
+			ASSERT(tenantData->tenantGroup == newEntry.tenantGroup);
+			ASSERT(tenantData->cluster == newEntry.assignedCluster);
+
+			self->createdTenants[newTenantName] = tenantData;
+			self->createdTenants.erase(tenantDataItr);
 
 			auto& dataDb = self->dataDbs[newEntry.assignedCluster];
 			ASSERT(dataDb->registered);
 
 			dataDb->tenants.erase(tenant);
-			dataDb->tenants[newTenantName] = tenantData->second;
+			dataDb->tenants[newTenantName] = tenantData;
 
 			if (newEntry.tenantGroup.present()) {
 				auto& tenantGroup = self->tenantGroups[newEntry.tenantGroup.get()];


### PR DESCRIPTION
A test workload was erasing an iterator from a map and then trying to use it

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
