### PR TITLE
Allow performing assert comparisons with any traceable type

### DIFF
--- a/fdbclient/include/fdbclient/FDBTypes.h
+++ b/fdbclient/include/fdbclient/FDBTypes.h
@@ -1429,6 +1429,11 @@ struct TenantMode {
 	uint32_t mode;
 };
 
+template <>
+struct Traceable<TenantMode> : std::true_type {
+	static std::string toString(const TenantMode& value) { return value.toString(); }
+};
+
 struct EncryptionAtRestMode {
 	// These enumerated values are stored in the database configuration, so can NEVER be changed.  Only add new ones
 	// just before END.

--- a/flow/Arena.cpp
+++ b/flow/Arena.cpp
@@ -1030,7 +1030,7 @@ TEST_CASE("/flow/Arena/Secure") {
 				} else {
 					newBuf = new (arena) uint8_t[len];
 				}
-				ASSERT_EQ(newBuf, buf);
+				ASSERT(newBuf == buf);
 				// there's no hard guarantee about the above equality and the result could vary by platform,
 				// malloc implementation, and tooling instrumentation (e.g. ASAN, valgrind)
 				// but it is practically likely because of

--- a/flow/Error.cpp
+++ b/flow/Error.cpp
@@ -77,10 +77,10 @@ Error internal_error_impl(const char* msg, const char* file, int line) {
 }
 
 Error internal_error_impl(const char* a_nm,
-                          std::string a,
+                          std::string const& a,
                           const char* op_nm,
                           const char* b_nm,
-                          std::string b,
+                          std::string const& b,
                           const char* file,
                           int line) {
 	fprintf(stderr, "Assertion failed @ %s %d:\n", file, line);

--- a/flow/Error.cpp
+++ b/flow/Error.cpp
@@ -77,17 +77,17 @@ Error internal_error_impl(const char* msg, const char* file, int line) {
 }
 
 Error internal_error_impl(const char* a_nm,
-                          long long a,
+                          std::string a,
                           const char* op_nm,
                           const char* b_nm,
-                          long long b,
+                          std::string b,
                           const char* file,
                           int line) {
 	fprintf(stderr, "Assertion failed @ %s %d:\n", file, line);
 	fprintf(stderr, "  expression:\n");
 	fprintf(stderr, "              %s %s %s\n", a_nm, op_nm, b_nm);
 	fprintf(stderr, "  expands to:\n");
-	fprintf(stderr, "              %lld %s %lld\n\n", a, op_nm, b);
+	fprintf(stderr, "              %s %s %s\n\n", a.c_str(), op_nm, b.c_str());
 	fprintf(stderr, "  %s\n", platform::get_backtrace().c_str());
 
 	TraceEvent(SevError, "InternalError")

--- a/flow/include/flow/Error.h
+++ b/flow/include/flow/Error.h
@@ -145,8 +145,7 @@ void assert_impl(char const* a_nm,
                  char const* file,
                  int line) {
 	if (!success) {
-		throw internal_error_impl(
-		    a_nm, Traceable<T>::toString(a), opName, b_nm, Traceable<U>::toString(b), file, line);
+		throw internal_error_impl(a_nm, Traceable<T>::toString(a), opName, b_nm, Traceable<U>::toString(b), file, line);
 	}
 }
 

--- a/flow/include/flow/Error.h
+++ b/flow/include/flow/Error.h
@@ -30,6 +30,7 @@
 #include "flow/Knobs.h"
 #include "flow/FileIdentifier.h"
 #include "flow/ObjectSerializerTraits.h"
+#include "flow/Traceable.h"
 
 enum { invalid_error_code = 0xffff };
 
@@ -97,10 +98,10 @@ enum { error_code_actor_cancelled = error_code_operation_cancelled };
 extern Error internal_error_impl(const char* file, int line);
 extern Error internal_error_impl(const char* msg, const char* file, int line);
 extern Error internal_error_impl(const char* a_nm,
-                                 long long a,
+                                 std::string a,
                                  const char* op_nm,
                                  const char* b_nm,
-                                 long long b,
+                                 std::string b,
                                  const char* file,
                                  int line);
 
@@ -135,73 +136,43 @@ enum assert_op { EQ, NE, LT, GT, LE, GE };
 
 // TODO: magic so this works even if const-ness doesn't not match.
 template <typename T, typename U>
-void assert_num_impl(char const* a_nm,
-                     T const& a,
-                     assert_op op,
-                     char const* b_nm,
-                     U const& b,
-                     char const* file,
-                     int line) {
-	bool success;
-	char const* op_name;
-	switch (op) {
-	case EQ:
-		success = a == b;
-		op_name = "==";
-		break;
-	case NE:
-		success = a != b;
-		op_name = "!=";
-		break;
-	case LT:
-		success = a < b;
-		op_name = "<";
-		break;
-	case GT:
-		success = a > b;
-		op_name = ">";
-		break;
-	case LE:
-		success = a <= b;
-		op_name = "<=";
-		break;
-	case GE:
-		success = a >= b;
-		op_name = ">=";
-		break;
-	default:
-		success = false;
-		op_name = "UNKNOWN OP";
-	}
-
+void assert_impl(char const* a_nm,
+                 T const& a,
+                 const char* opName,
+                 char const* b_nm,
+                 U const& b,
+                 bool success,
+                 char const* file,
+                 int line) {
 	if (!success) {
-		throw internal_error_impl(a_nm, (long long)a, op_name, b_nm, (long long)b, file, line);
+		throw internal_error_impl(
+		    a_nm, Traceable<T>::toString(a), opName, b_nm, Traceable<U>::toString(b), file, line);
 	}
 }
 
 #define ASSERT_EQ(a, b)                                                                                                \
 	do {                                                                                                               \
-		assert_num_impl((#a), (a), assert_op::EQ, (#b), (b), __FILE__, __LINE__);                                      \
+		assert_impl((#a), (a), "==", (#b), (b), a == b, __FILE__, __LINE__);                                           \
 	} while (0)
 #define ASSERT_NE(a, b)                                                                                                \
 	do {                                                                                                               \
-		assert_num_impl((#a), (a), assert_op::NE, (#b), (b), __FILE__, __LINE__);                                      \
+		assert_impl((#a), (a), "!=", (#b), (b), a != b, __FILE__, __LINE__);                                           \
 	} while (0)
 #define ASSERT_LT(a, b)                                                                                                \
 	do {                                                                                                               \
-		assert_num_impl((#a), (a), assert_op::LT, (#b), (b), __FILE__, __LINE__);                                      \
+		assert_impl((#a), (a), "<", (#b), (b), a < b, __FILE__, __LINE__);                                             \
 	} while (0)
 #define ASSERT_LE(a, b)                                                                                                \
 	do {                                                                                                               \
-		assert_num_impl((#a), (a), assert_op::LE, (#b), (b), __FILE__, __LINE__);                                      \
+		assert_impl((#a), (a), "<=", (#b), (b), a <= b, __FILE__, __LINE__);                                           \
 	} while (0)
 #define ASSERT_GT(a, b)                                                                                                \
 	do {                                                                                                               \
-		assert_num_impl((#a), (a), assert_op::GT, (#b), (b), __FILE__, __LINE__);                                      \
+		assert_impl((#a), (a), ">", (#b), (b), a > b, __FILE__, __LINE__);                                             \
 	} while (0)
 #define ASSERT_GE(a, b)                                                                                                \
 	do {                                                                                                               \
-		assert_num_impl((#a), (a), assert_op::GE, (#b), (b), __FILE__, __LINE__);                                      \
+		assert_impl((#a), (a), ">=", (#b), (b), a >= b, __FILE__, __LINE__);                                           \
 	} while (0)
 
 // ASSERT_WE_THINK() is to be used for assertions that we want to validate in testing, but which are judged too

--- a/flow/include/flow/Error.h
+++ b/flow/include/flow/Error.h
@@ -98,10 +98,10 @@ enum { error_code_actor_cancelled = error_code_operation_cancelled };
 extern Error internal_error_impl(const char* file, int line);
 extern Error internal_error_impl(const char* msg, const char* file, int line);
 extern Error internal_error_impl(const char* a_nm,
-                                 std::string a,
+                                 std::string const& a,
                                  const char* op_nm,
                                  const char* b_nm,
-                                 std::string b,
+                                 std::string const& b,
                                  const char* file,
                                  int line);
 

--- a/flow/include/flow/Error.h
+++ b/flow/include/flow/Error.h
@@ -132,8 +132,6 @@ extern bool isAssertDisabled(int line);
 #define UNREACHABLE()                                                                                                  \
 	{ throw internal_error_impl("unreachable", __FILE__, __LINE__); }
 
-enum assert_op { EQ, NE, LT, GT, LE, GE };
-
 // TODO: magic so this works even if const-ness doesn't not match.
 template <typename T, typename U>
 void assert_impl(char const* a_nm,
@@ -141,37 +139,67 @@ void assert_impl(char const* a_nm,
                  const char* opName,
                  char const* b_nm,
                  U const& b,
-                 bool success,
+                 bool (*compare)(T const&, U const&),
                  char const* file,
                  int line) {
-	if (!success) {
+	if (!compare(a, b)) {
 		throw internal_error_impl(a_nm, Traceable<T>::toString(a), opName, b_nm, Traceable<U>::toString(b), file, line);
 	}
 }
 
+template <typename T, typename U>
+bool assert_check_eq(T const& a, U const& b) {
+	return a == b;
+}
+
+template <typename T, typename U>
+bool assert_check_ne(T const& a, U const& b) {
+	return a != b;
+}
+
+template <typename T, typename U>
+bool assert_check_lt(T const& a, U const& b) {
+	return a < b;
+}
+
+template <typename T, typename U>
+bool assert_check_le(T const& a, U const& b) {
+	return a <= b;
+}
+
+template <typename T, typename U>
+bool assert_check_gt(T const& a, U const& b) {
+	return a > b;
+}
+
+template <typename T, typename U>
+bool assert_check_ge(T const& a, U const& b) {
+	return a >= b;
+}
+
 #define ASSERT_EQ(a, b)                                                                                                \
 	do {                                                                                                               \
-		assert_impl((#a), (a), "==", (#b), (b), a == b, __FILE__, __LINE__);                                           \
+		assert_impl((#a), (a), "==", (#b), (b), &assert_check_eq, __FILE__, __LINE__);                                 \
 	} while (0)
 #define ASSERT_NE(a, b)                                                                                                \
 	do {                                                                                                               \
-		assert_impl((#a), (a), "!=", (#b), (b), a != b, __FILE__, __LINE__);                                           \
+		assert_impl((#a), (a), "!=", (#b), (b), &assert_check_ne, __FILE__, __LINE__);                                 \
 	} while (0)
 #define ASSERT_LT(a, b)                                                                                                \
 	do {                                                                                                               \
-		assert_impl((#a), (a), "<", (#b), (b), a < b, __FILE__, __LINE__);                                             \
+		assert_impl((#a), (a), "<", (#b), (b), &assert_check_lt, __FILE__, __LINE__);                                  \
 	} while (0)
 #define ASSERT_LE(a, b)                                                                                                \
 	do {                                                                                                               \
-		assert_impl((#a), (a), "<=", (#b), (b), a <= b, __FILE__, __LINE__);                                           \
+		assert_impl((#a), (a), "<=", (#b), (b), &assert_check_le, __FILE__, __LINE__);                                 \
 	} while (0)
 #define ASSERT_GT(a, b)                                                                                                \
 	do {                                                                                                               \
-		assert_impl((#a), (a), ">", (#b), (b), a > b, __FILE__, __LINE__);                                             \
+		assert_impl((#a), (a), ">", (#b), (b), &assert_check_gt, __FILE__, __LINE__);                                  \
 	} while (0)
 #define ASSERT_GE(a, b)                                                                                                \
 	do {                                                                                                               \
-		assert_impl((#a), (a), ">=", (#b), (b), a >= b, __FILE__, __LINE__);                                           \
+		assert_impl((#a), (a), ">=", (#b), (b), &assert_check_ge, __FILE__, __LINE__);                                 \
 	} while (0)
 
 // ASSERT_WE_THINK() is to be used for assertions that we want to validate in testing, but which are judged too

--- a/flow/include/flow/FastRef.h
+++ b/flow/include/flow/FastRef.h
@@ -182,7 +182,7 @@ private:
 };
 
 template <class T>
-struct Traceable<Reference<T>> : std::conditional<Traceable<T>::value, std::true_type, std::false_type>::type {
+struct Traceable<Reference<T>> : std::bool_constant<Traceable<T>::value> {
 	static std::string toString(const Reference<T>& value) {
 		return value ? Traceable<T>::toString(*value) : "[not set]";
 	}

--- a/flow/include/flow/FastRef.h
+++ b/flow/include/flow/FastRef.h
@@ -24,6 +24,7 @@
 
 #include <atomic>
 #include <cstdint>
+#include "flow/Traceable.h"
 
 // The thread safety this class provides is that it's safe to call addref and
 // delref on the same object concurrently in different threads. Subclass does
@@ -178,6 +179,13 @@ public:
 
 private:
 	P* ptr;
+};
+
+template <class T>
+struct Traceable<Reference<T>> : std::conditional<Traceable<T>::value, std::true_type, std::false_type>::type {
+	static std::string toString(const Reference<T>& value) {
+		return value ? Traceable<T>::toString(*value) : "[not set]";
+	}
 };
 
 template <class P, class... Args>

--- a/flow/include/flow/IRandom.h
+++ b/flow/include/flow/IRandom.h
@@ -125,6 +125,11 @@ struct scalar_traits<UID> : std::true_type {
 	}
 };
 
+template <>
+struct Traceable<UID> : std::true_type {
+	static std::string toString(const UID& value) { return format("%016llx", value.first()); }
+};
+
 namespace std {
 template <>
 class hash<UID> {

--- a/flow/include/flow/Trace.h
+++ b/flow/include/flow/Trace.h
@@ -33,10 +33,10 @@
 #include "flow/IRandom.h"
 #include "flow/Error.h"
 #include "flow/ITrace.h"
+#include "flow/Traceable.h"
 
 #define TRACE_DEFAULT_ROLL_SIZE (10 << 20)
 #define TRACE_DEFAULT_MAX_LOGS_SIZE (10 * TRACE_DEFAULT_ROLL_SIZE)
-#define PRINTABLE_COMPRESS_NULLS 0
 
 inline int fastrand() {
 	static int g_seed = 0;
@@ -196,222 +196,6 @@ private:
 
 struct DynamicEventMetric;
 
-template <class IntType>
-char base16Char(IntType c) {
-	switch ((c % 16 + 16) % 16) {
-	case 0:
-		return '0';
-	case 1:
-		return '1';
-	case 2:
-		return '2';
-	case 3:
-		return '3';
-	case 4:
-		return '4';
-	case 5:
-		return '5';
-	case 6:
-		return '6';
-	case 7:
-		return '7';
-	case 8:
-		return '8';
-	case 9:
-		return '9';
-	case 10:
-		return 'a';
-	case 11:
-		return 'b';
-	case 12:
-		return 'c';
-	case 13:
-		return 'd';
-	case 14:
-		return 'e';
-	case 15:
-		return 'f';
-	default:
-		UNSTOPPABLE_ASSERT(false);
-	}
-}
-
-// forward declare format from flow.h as we
-// can't include flow.h here
-std::string format(const char* form, ...);
-
-template <class T>
-struct Traceable : std::false_type {};
-
-#define FORMAT_TRACEABLE(type, fmt)                                                                                    \
-	template <>                                                                                                        \
-	struct Traceable<type> : std::true_type {                                                                          \
-		static std::string toString(type value) { return format(fmt, value); }                                         \
-	}
-
-FORMAT_TRACEABLE(bool, "%d");
-FORMAT_TRACEABLE(signed char, "%d");
-FORMAT_TRACEABLE(unsigned char, "%d");
-FORMAT_TRACEABLE(short, "%d");
-FORMAT_TRACEABLE(unsigned short, "%d");
-FORMAT_TRACEABLE(int, "%d");
-FORMAT_TRACEABLE(unsigned, "%u");
-FORMAT_TRACEABLE(long int, "%ld");
-FORMAT_TRACEABLE(unsigned long int, "%lu");
-FORMAT_TRACEABLE(long long int, "%lld");
-FORMAT_TRACEABLE(unsigned long long int, "%llu");
-FORMAT_TRACEABLE(float, "%g");
-FORMAT_TRACEABLE(double, "%g");
-FORMAT_TRACEABLE(void*, "%p");
-FORMAT_TRACEABLE(volatile long, "%ld");
-FORMAT_TRACEABLE(volatile unsigned long, "%lu");
-FORMAT_TRACEABLE(volatile long long, "%lld");
-FORMAT_TRACEABLE(volatile unsigned long long, "%llu");
-FORMAT_TRACEABLE(volatile double, "%g");
-
-template <>
-struct Traceable<UID> : std::true_type {
-	static std::string toString(const UID& value) { return format("%016llx", value.first()); }
-};
-
-template <class Str>
-struct TraceableString {
-	static auto begin(const Str& value) -> decltype(value.begin()) { return value.begin(); }
-
-	static bool atEnd(const Str& value, decltype(value.begin()) iter) { return iter == value.end(); }
-
-	static std::string toString(const Str& value) { return value.toString(); }
-};
-
-template <>
-struct TraceableString<std::string> {
-	static auto begin(const std::string& value) -> decltype(value.begin()) { return value.begin(); }
-
-	static bool atEnd(const std::string& value, decltype(value.begin()) iter) { return iter == value.end(); }
-
-	template <class S>
-	static std::string toString(S&& value) {
-		return std::forward<S>(value);
-	}
-};
-
-template <>
-struct TraceableString<std::string_view> {
-	static auto begin(const std::string_view& value) -> decltype(value.begin()) { return value.begin(); }
-
-	static bool atEnd(const std::string_view& value, decltype(value.begin()) iter) { return iter == value.end(); }
-
-	static std::string toString(const std::string_view& value) { return std::string(value); }
-};
-
-template <>
-struct TraceableString<const char*> {
-	static const char* begin(const char* value) { return value; }
-
-	static bool atEnd(const char* value, const char* iter) { return *iter == '\0'; }
-
-	static std::string toString(const char* value) { return std::string(value); }
-};
-
-std::string traceableStringToString(const char* value, size_t S);
-
-template <size_t S>
-struct TraceableString<char[S]> {
-	static_assert(S > 0, "Only string literals are supported.");
-	static const char* begin(const char* value) { return value; }
-
-	static bool atEnd(const char* value, const char* iter) {
-		return iter - value == S - 1; // Exclude trailing \0 byte
-	}
-
-	static std::string toString(const char* value) { return traceableStringToString(value, S); }
-};
-
-template <>
-struct TraceableString<char*> {
-	static const char* begin(char* value) { return value; }
-
-	static bool atEnd(char* value, const char* iter) { return *iter == '\0'; }
-
-	static std::string toString(char* value) { return std::string(value); }
-};
-
-template <class T>
-struct TraceableStringImpl : std::true_type {
-	static constexpr bool isPrintable(char c) { return 32 <= c && c <= 126; }
-
-	template <class Str>
-	static std::string toString(Str&& value) {
-		// if all characters are printable ascii, we simply return the string
-		int nonPrintables = 0;
-		int numBackslashes = 0;
-		int size = 0;
-		for (auto iter = TraceableString<T>::begin(value); !TraceableString<T>::atEnd(value, iter); ++iter) {
-			++size;
-			if (!isPrintable(char(*iter))) {
-				++nonPrintables;
-			} else if (*iter == '\\') {
-				++numBackslashes;
-			}
-		}
-		if (nonPrintables == 0 && numBackslashes == 0) {
-			return TraceableString<T>::toString(std::forward<Str>(value));
-		}
-		std::string result;
-		result.reserve(size - nonPrintables + (nonPrintables * 4) + numBackslashes);
-		int numNull = 0;
-		for (auto iter = TraceableString<T>::begin(value); !TraceableString<T>::atEnd(value, iter); ++iter) {
-			if (*iter == '\\') {
-				if (numNull > 0) {
-					result += format("[%d]", numNull);
-					numNull = 0;
-				}
-				result.push_back('\\');
-				result.push_back('\\');
-			} else if (isPrintable(*iter)) {
-				if (numNull > 0) {
-					result += format("[%d]", numNull);
-					numNull = 0;
-				}
-				result.push_back(*iter);
-			} else {
-				const uint8_t byte = *iter;
-				if (PRINTABLE_COMPRESS_NULLS && byte == 0) {
-					numNull++;
-				} else {
-					result.push_back('\\');
-					result.push_back('x');
-					result.push_back(base16Char(byte / 16));
-					result.push_back(base16Char(byte));
-				}
-			}
-		}
-		if (numNull > 0) {
-			result += format("[%d]", numNull);
-			numNull = 0;
-		}
-		return result;
-	}
-};
-
-template <>
-struct Traceable<const char*> : TraceableStringImpl<const char*> {};
-template <>
-struct Traceable<char*> : TraceableStringImpl<char*> {};
-template <size_t S>
-struct Traceable<char[S]> : TraceableStringImpl<char[S]> {};
-template <>
-struct Traceable<std::string> : TraceableStringImpl<std::string> {};
-template <>
-struct Traceable<std::string_view> : TraceableStringImpl<std::string_view> {};
-
-template <class T>
-struct Traceable<Reference<T>> : std::conditional<Traceable<T>::value, std::true_type, std::false_type>::type {
-	static std::string toString(const Reference<T>& value) {
-		return value ? Traceable<T>::toString(*value) : "[not set]";
-	}
-};
-
 template <class T>
 struct SpecialTraceMetricType
   : std::conditional<std::is_integral<T>::value || std::is_enum<T>::value, std::true_type, std::false_type>::type {
@@ -443,7 +227,8 @@ struct BaseTraceEvent {
 	static std::string printRealTime(double time);
 
 	template <class T>
-	typename std::enable_if<Traceable<T>::value, BaseTraceEvent&>::type detail(std::string&& key, const T& value) {
+	typename std::enable_if<Traceable<T>::value && !std::is_enum_v<T>, BaseTraceEvent&>::type detail(std::string&& key,
+	                                                                                                 const T& value) {
 		if (enabled && init()) {
 			auto s = Traceable<T>::toString(value);
 			addMetric(key.c_str(), value, s);
@@ -453,7 +238,8 @@ struct BaseTraceEvent {
 	}
 
 	template <class T>
-	typename std::enable_if<Traceable<T>::value, BaseTraceEvent&>::type detail(const char* key, const T& value) {
+	typename std::enable_if<Traceable<T>::value && !std::is_enum_v<T>, BaseTraceEvent&>::type detail(const char* key,
+	                                                                                                 const T& value) {
 		if (enabled && init()) {
 			auto s = Traceable<T>::toString(value);
 			addMetric(key, value, s);

--- a/flow/include/flow/Traceable.h
+++ b/flow/include/flow/Traceable.h
@@ -1,0 +1,247 @@
+/*
+ * Traceable.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2023 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FLOW_TRACEABLE_H
+#define FLOW_TRACEABLE_H
+#pragma once
+
+#include <stdarg.h>
+#include <stdint.h>
+#include <string>
+#include <string_view>
+#include <type_traits>
+
+#define PRINTABLE_COMPRESS_NULLS 0
+
+template <class IntType>
+char base16Char(IntType c) {
+	switch ((c % 16 + 16) % 16) {
+	case 0:
+		return '0';
+	case 1:
+		return '1';
+	case 2:
+		return '2';
+	case 3:
+		return '3';
+	case 4:
+		return '4';
+	case 5:
+		return '5';
+	case 6:
+		return '6';
+	case 7:
+		return '7';
+	case 8:
+		return '8';
+	case 9:
+		return '9';
+	case 10:
+		return 'a';
+	case 11:
+		return 'b';
+	case 12:
+		return 'c';
+	case 13:
+		return 'd';
+	case 14:
+		return 'e';
+	case 15:
+		return 'f';
+	default:
+		std::abort();
+	}
+}
+
+// forward declare format from flow.h as we
+// can't include flow.h here
+std::string format(const char* form, ...);
+
+template <class T, class T2 = void>
+struct Traceable : std::false_type {};
+
+#define FORMAT_TRACEABLE(type, fmt)                                                                                    \
+	template <>                                                                                                        \
+	struct Traceable<type> : std::true_type {                                                                          \
+		static std::string toString(type value) { return format(fmt, value); }                                         \
+	}
+
+FORMAT_TRACEABLE(bool, "%d");
+FORMAT_TRACEABLE(signed char, "%d");
+FORMAT_TRACEABLE(unsigned char, "%d");
+FORMAT_TRACEABLE(short, "%d");
+FORMAT_TRACEABLE(unsigned short, "%d");
+FORMAT_TRACEABLE(int, "%d");
+FORMAT_TRACEABLE(unsigned, "%u");
+FORMAT_TRACEABLE(long int, "%ld");
+FORMAT_TRACEABLE(unsigned long int, "%lu");
+FORMAT_TRACEABLE(long long int, "%lld");
+FORMAT_TRACEABLE(unsigned long long int, "%llu");
+FORMAT_TRACEABLE(float, "%g");
+FORMAT_TRACEABLE(double, "%g");
+FORMAT_TRACEABLE(void*, "%p");
+FORMAT_TRACEABLE(volatile long, "%ld");
+FORMAT_TRACEABLE(volatile unsigned long, "%lu");
+FORMAT_TRACEABLE(volatile long long, "%lld");
+FORMAT_TRACEABLE(volatile unsigned long long, "%llu");
+FORMAT_TRACEABLE(volatile double, "%g");
+
+template <class Enum>
+struct Traceable<Enum, std::enable_if_t<std::is_enum_v<Enum>>> : std::true_type {
+	static std::string toString(Enum e) { return format("%lld", (int64_t)e); }
+};
+
+template <class Str>
+struct TraceableString {
+	static auto begin(const Str& value) -> decltype(value.begin()) { return value.begin(); }
+
+	static bool atEnd(const Str& value, decltype(value.begin()) iter) { return iter == value.end(); }
+
+	static std::string toString(const Str& value) { return value.toString(); }
+};
+
+template <>
+struct TraceableString<std::string> {
+	static auto begin(const std::string& value) -> decltype(value.begin()) { return value.begin(); }
+
+	static bool atEnd(const std::string& value, decltype(value.begin()) iter) { return iter == value.end(); }
+
+	template <class S>
+	static std::string toString(S&& value) {
+		return std::forward<S>(value);
+	}
+};
+
+template <>
+struct TraceableString<std::string_view> {
+	static auto begin(const std::string_view& value) -> decltype(value.begin()) { return value.begin(); }
+
+	static bool atEnd(const std::string_view& value, decltype(value.begin()) iter) { return iter == value.end(); }
+
+	static std::string toString(const std::string_view& value) { return std::string(value); }
+};
+
+template <>
+struct TraceableString<const char*> {
+	static const char* begin(const char* value) { return value; }
+
+	static bool atEnd(const char* value, const char* iter) { return *iter == '\0'; }
+
+	static std::string toString(const char* value) { return std::string(value); }
+};
+
+std::string traceableStringToString(const char* value, size_t S);
+
+template <size_t S>
+struct TraceableString<char[S]> {
+	static_assert(S > 0, "Only string literals are supported.");
+	static const char* begin(const char* value) { return value; }
+
+	static bool atEnd(const char* value, const char* iter) {
+		return iter - value == S - 1; // Exclude trailing \0 byte
+	}
+
+	static std::string toString(const char* value) { return traceableStringToString(value, S); }
+};
+
+template <>
+struct TraceableString<char*> {
+	static const char* begin(char* value) { return value; }
+
+	static bool atEnd(char* value, const char* iter) { return *iter == '\0'; }
+
+	static std::string toString(char* value) { return std::string(value); }
+};
+
+template <class T>
+struct TraceableStringImpl : std::true_type {
+	static constexpr bool isPrintable(char c) { return 32 <= c && c <= 126; }
+
+	template <class Str>
+	static std::string toString(Str&& value) {
+		// if all characters are printable ascii, we simply return the string
+		int nonPrintables = 0;
+		int numBackslashes = 0;
+		int size = 0;
+		for (auto iter = TraceableString<T>::begin(value); !TraceableString<T>::atEnd(value, iter); ++iter) {
+			++size;
+			if (!isPrintable(char(*iter))) {
+				++nonPrintables;
+			} else if (*iter == '\\') {
+				++numBackslashes;
+			}
+		}
+		if (nonPrintables == 0 && numBackslashes == 0) {
+			return TraceableString<T>::toString(std::forward<Str>(value));
+		}
+		std::string result;
+		result.reserve(size - nonPrintables + (nonPrintables * 4) + numBackslashes);
+		int numNull = 0;
+		for (auto iter = TraceableString<T>::begin(value); !TraceableString<T>::atEnd(value, iter); ++iter) {
+			if (*iter == '\\') {
+				if (numNull > 0) {
+					result += format("[%d]", numNull);
+					numNull = 0;
+				}
+				result.push_back('\\');
+				result.push_back('\\');
+			} else if (isPrintable(*iter)) {
+				if (numNull > 0) {
+					result += format("[%d]", numNull);
+					numNull = 0;
+				}
+				result.push_back(*iter);
+			} else {
+				const uint8_t byte = *iter;
+				if (PRINTABLE_COMPRESS_NULLS && byte == 0) {
+					numNull++;
+				} else {
+					result.push_back('\\');
+					result.push_back('x');
+					result.push_back(base16Char(byte / 16));
+					result.push_back(base16Char(byte));
+				}
+			}
+		}
+		if (numNull > 0) {
+			result += format("[%d]", numNull);
+			numNull = 0;
+		}
+		return result;
+	}
+};
+
+template <>
+struct Traceable<const char*> : TraceableStringImpl<const char*> {};
+template <>
+struct Traceable<char*> : TraceableStringImpl<char*> {};
+template <size_t S>
+struct Traceable<char[S]> : TraceableStringImpl<char[S]> {};
+template <>
+struct Traceable<std::string> : TraceableStringImpl<std::string> {};
+template <>
+struct Traceable<std::string_view> : TraceableStringImpl<std::string_view> {};
+
+template <class T>
+struct Traceable<std::atomic<T>> : std::true_type {
+	static std::string toString(const std::atomic<T>& value) { return Traceable<T>::toString(value); }
+};
+
+#endif

--- a/flow/include/flow/Traceable.h
+++ b/flow/include/flow/Traceable.h
@@ -241,7 +241,7 @@ struct Traceable<std::string_view> : TraceableStringImpl<std::string_view> {};
 
 template <class T>
 struct Traceable<std::atomic<T>> : std::true_type {
-	static std::string toString(const std::atomic<T>& value) { return Traceable<T>::toString(value); }
+	static std::string toString(const std::atomic<T>& value) { return Traceable<T>::toString(value.load()); }
 };
 
 #endif


### PR DESCRIPTION
This updates `ASSERT_EQ`, etc., to work with any type that is traceable and supports the target comparison operator.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
