### PR TITLE
Enforce Disabled Tenant Mode in Metacluster

### DIFF
--- a/fdbcli/MetaclusterCommands.actor.cpp
+++ b/fdbcli/MetaclusterCommands.actor.cpp
@@ -104,7 +104,7 @@ ACTOR Future<bool> metaclusterCreateCommand(Reference<IDatabase> db, std::vector
 		return false;
 	}
 
-	Optional<std::string> errorStr = wait(MetaclusterAPI::createMetacluster(db, tokens[2], tenantIdPrefix));
+	Optional<std::string> errorStr = wait(MetaclusterAPI::createMetacluster(db, tokens[2], tenantIdPrefix, true));
 	if (errorStr.present()) {
 		fmt::print("ERROR: {}.\n", errorStr.get());
 	} else {

--- a/fdbcli/tests/metacluster_fdbcli_tests.py
+++ b/fdbcli/tests/metacluster_fdbcli_tests.py
@@ -64,6 +64,11 @@ def get_cluster_connection_str(cluster_file_path):
 
 @enable_logging()
 def metacluster_create(logger, cluster_file, name, tenant_id_prefix):
+    # set the tenant mode to disabled for the metacluster otherwise creation will fail
+    rc, out, err = run_fdbcli_command(cluster_file, "configure tenant_mode=disabled")
+    logger.debug('Metacluster tenant mode set to disabled')
+    if rc != 0:
+        raise Exception(err)
     rc, out, err = run_fdbcli_command(cluster_file, "metacluster create_experimental", name, str(tenant_id_prefix))
     if rc != 0:
         raise Exception(err)

--- a/fdbcli/tests/metacluster_fdbcli_tests.py
+++ b/fdbcli/tests/metacluster_fdbcli_tests.py
@@ -64,6 +64,13 @@ def get_cluster_connection_str(cluster_file_path):
 
 @enable_logging()
 def metacluster_create(logger, cluster_file, name, tenant_id_prefix):
+    # creating a metacluster with optional tenant mode should fail
+    rc, out, err = run_fdbcli_command(cluster_file, "configure tenant_mode=optional_experimental")
+    if rc != 0:
+        raise Exception(err)
+    rc, out, err = run_fdbcli_command(cluster_file, "metacluster create_experimental", name, str(tenant_id_prefix))
+    if "ERROR" not in out:
+        raise Exception("Metacluster creation should have failed")
     # set the tenant mode to disabled for the metacluster otherwise creation will fail
     rc, out, err = run_fdbcli_command(cluster_file, "configure tenant_mode=disabled")
     logger.debug('Metacluster tenant mode set to disabled')

--- a/fdbclient/include/fdbclient/MetaclusterManagement.actor.h
+++ b/fdbclient/include/fdbclient/MetaclusterManagement.actor.h
@@ -530,8 +530,19 @@ Future<Void> managementClusterCheckEmpty(Transaction tr) {
 	return Void();
 }
 
+ACTOR template <class Transaction>
+Future<TenantMode> getManagementClusterTenantMode(Transaction tr) {
+	state typename transaction_future_type<Transaction, Optional<Value>>::type tenantModeFuture =
+	    tr->get(tenantModeConfKey);
+	Optional<Value> tenantModeValue = wait(safeThreadFutureToFuture(tenantModeFuture));
+	return TenantMode::fromValue(tenantModeValue.castTo<ValueRef>());
+}
+
 ACTOR template <class DB>
-Future<Optional<std::string>> createMetacluster(Reference<DB> db, ClusterName name, int64_t tenantIdPrefix) {
+Future<Optional<std::string>> createMetacluster(Reference<DB> db,
+                                                ClusterName name,
+                                                int64_t tenantIdPrefix,
+                                                bool enableTenantModeCheck) {
 	state Reference<typename DB::TransactionT> tr = db->createTransaction();
 	state Optional<UID> metaclusterUid;
 	ASSERT(tenantIdPrefix >= TenantAPI::TENANT_ID_PREFIX_MIN_VALUE &&
@@ -545,6 +556,8 @@ Future<Optional<std::string>> createMetacluster(Reference<DB> db, ClusterName na
 			    MetaclusterMetadata::metaclusterRegistration().get(tr);
 
 			state Future<Void> metaclusterEmptinessCheck = managementClusterCheckEmpty(tr);
+			state Future<TenantMode> tenantModeFuture =
+			    enableTenantModeCheck ? getManagementClusterTenantMode(tr) : Future<TenantMode>(TenantMode::DISABLED);
 
 			Optional<MetaclusterRegistrationEntry> existingRegistration = wait(metaclusterRegistrationFuture);
 			if (existingRegistration.present()) {
@@ -560,6 +573,11 @@ Future<Optional<std::string>> createMetacluster(Reference<DB> db, ClusterName na
 			}
 
 			wait(metaclusterEmptinessCheck);
+			TenantMode tenantMode = wait(tenantModeFuture);
+			if (tenantMode != TenantMode::DISABLED) {
+				return fmt::format("cluster is configured with tenant mode: {} when tenants should be disabled",
+				                   tenantMode);
+			}
 
 			if (!metaclusterUid.present()) {
 				metaclusterUid = deterministicRandom()->randomUniqueID();

--- a/fdbclient/include/fdbclient/MetaclusterManagement.actor.h
+++ b/fdbclient/include/fdbclient/MetaclusterManagement.actor.h
@@ -575,7 +575,7 @@ Future<Optional<std::string>> createMetacluster(Reference<DB> db,
 			wait(metaclusterEmptinessCheck);
 			TenantMode tenantMode = wait(tenantModeFuture);
 			if (tenantMode != TenantMode::DISABLED) {
-				return fmt::format("cluster is configured with tenant mode: `{}' when tenants should be disabled",
+				return fmt::format("cluster is configured with tenant mode `{}' when tenants should be disabled",
 				                   tenantMode);
 			}
 

--- a/fdbclient/include/fdbclient/MetaclusterManagement.actor.h
+++ b/fdbclient/include/fdbclient/MetaclusterManagement.actor.h
@@ -531,7 +531,7 @@ Future<Void> managementClusterCheckEmpty(Transaction tr) {
 }
 
 ACTOR template <class Transaction>
-Future<TenantMode> getManagementClusterTenantMode(Transaction tr) {
+Future<TenantMode> getClusterConfiguredTenantMode(Transaction tr) {
 	state typename transaction_future_type<Transaction, Optional<Value>>::type tenantModeFuture =
 	    tr->get(tenantModeConfKey);
 	Optional<Value> tenantModeValue = wait(safeThreadFutureToFuture(tenantModeFuture));
@@ -557,7 +557,7 @@ Future<Optional<std::string>> createMetacluster(Reference<DB> db,
 
 			state Future<Void> metaclusterEmptinessCheck = managementClusterCheckEmpty(tr);
 			state Future<TenantMode> tenantModeFuture =
-			    enableTenantModeCheck ? getManagementClusterTenantMode(tr) : Future<TenantMode>(TenantMode::DISABLED);
+			    enableTenantModeCheck ? getClusterConfiguredTenantMode(tr) : Future<TenantMode>(TenantMode::DISABLED);
 
 			Optional<MetaclusterRegistrationEntry> existingRegistration = wait(metaclusterRegistrationFuture);
 			if (existingRegistration.present()) {
@@ -575,7 +575,7 @@ Future<Optional<std::string>> createMetacluster(Reference<DB> db,
 			wait(metaclusterEmptinessCheck);
 			TenantMode tenantMode = wait(tenantModeFuture);
 			if (tenantMode != TenantMode::DISABLED) {
-				return fmt::format("cluster is configured with tenant mode: {} when tenants should be disabled",
+				return fmt::format("cluster is configured with tenant mode: `{}' when tenants should be disabled",
 				                   tenantMode);
 			}
 

--- a/fdbserver/workloads/MetaclusterManagementConcurrencyWorkload.actor.cpp
+++ b/fdbserver/workloads/MetaclusterManagementConcurrencyWorkload.actor.cpp
@@ -48,11 +48,9 @@ struct MetaclusterManagementConcurrencyWorkload : TestWorkload {
 	std::vector<ClusterName> dataDbIndex;
 
 	double testDuration;
-	bool enableMetaclusterTenantModeCheck;
 
 	MetaclusterManagementConcurrencyWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
 		testDuration = getOption(options, "testDuration"_sr, 120.0);
-		enableMetaclusterTenantModeCheck = getOption(options, "enableMetaclusterTenantModeCheck"_sr, false);
 	}
 
 	Future<Void> setup(Database const& cx) override { return _setup(cx, this); }
@@ -78,7 +76,7 @@ struct MetaclusterManagementConcurrencyWorkload : TestWorkload {
 			    "management_cluster"_sr,
 			    deterministicRandom()->randomInt(TenantAPI::TENANT_ID_PREFIX_MIN_VALUE,
 			                                     TenantAPI::TENANT_ID_PREFIX_MAX_VALUE + 1),
-			    self->enableMetaclusterTenantModeCheck)));
+			    false)));
 		}
 		return Void();
 	}

--- a/fdbserver/workloads/MetaclusterManagementConcurrencyWorkload.actor.cpp
+++ b/fdbserver/workloads/MetaclusterManagementConcurrencyWorkload.actor.cpp
@@ -48,9 +48,11 @@ struct MetaclusterManagementConcurrencyWorkload : TestWorkload {
 	std::vector<ClusterName> dataDbIndex;
 
 	double testDuration;
+	bool enableMetaclusterTenantModeCheck;
 
 	MetaclusterManagementConcurrencyWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
 		testDuration = getOption(options, "testDuration"_sr, 120.0);
+		enableMetaclusterTenantModeCheck = getOption(options, "enableMetaclusterTenantModeCheck"_sr, false);
 	}
 
 	Future<Void> setup(Database const& cx) override { return _setup(cx, this); }
@@ -75,7 +77,8 @@ struct MetaclusterManagementConcurrencyWorkload : TestWorkload {
 			    cx.getReference(),
 			    "management_cluster"_sr,
 			    deterministicRandom()->randomInt(TenantAPI::TENANT_ID_PREFIX_MIN_VALUE,
-			                                     TenantAPI::TENANT_ID_PREFIX_MAX_VALUE + 1))));
+			                                     TenantAPI::TENANT_ID_PREFIX_MAX_VALUE + 1),
+			    self->enableMetaclusterTenantModeCheck)));
 		}
 		return Void();
 	}

--- a/fdbserver/workloads/MetaclusterManagementWorkload.actor.cpp
+++ b/fdbserver/workloads/MetaclusterManagementWorkload.actor.cpp
@@ -89,7 +89,6 @@ struct MetaclusterManagementWorkload : TestWorkload {
 	int maxTenantGroups;
 	int64_t tenantIdPrefix;
 	double testDuration;
-	bool enableMetaclusterTenantModeCheck;
 
 	MetaclusterManagementWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
 		maxTenants = std::min<int>(1e8 - 1, getOption(options, "maxTenants"_sr, 1000));
@@ -99,7 +98,6 @@ struct MetaclusterManagementWorkload : TestWorkload {
 		                           "tenantIdPrefix"_sr,
 		                           deterministicRandom()->randomInt(TenantAPI::TENANT_ID_PREFIX_MIN_VALUE,
 		                                                            TenantAPI::TENANT_ID_PREFIX_MAX_VALUE + 1));
-		enableMetaclusterTenantModeCheck = getOption(options, "enableMetaclusterTenantModeCheck"_sr, false);
 	}
 
 	void disableFailureInjectionWorkloads(std::set<std::string>& out) const override { out.insert("Attrition"); }
@@ -130,7 +128,7 @@ struct MetaclusterManagementWorkload : TestWorkload {
 			    Database::createSimulatedExtraDatabase(connectionString, cx->defaultTenant));
 		}
 		wait(success(MetaclusterAPI::createMetacluster(
-		    cx.getReference(), "management_cluster"_sr, self->tenantIdPrefix, self->enableMetaclusterTenantModeCheck)));
+		    cx.getReference(), "management_cluster"_sr, self->tenantIdPrefix, false)));
 		return Void();
 	}
 

--- a/fdbserver/workloads/MetaclusterManagementWorkload.actor.cpp
+++ b/fdbserver/workloads/MetaclusterManagementWorkload.actor.cpp
@@ -89,6 +89,7 @@ struct MetaclusterManagementWorkload : TestWorkload {
 	int maxTenantGroups;
 	int64_t tenantIdPrefix;
 	double testDuration;
+	bool enableMetaclusterTenantModeCheck;
 
 	MetaclusterManagementWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
 		maxTenants = std::min<int>(1e8 - 1, getOption(options, "maxTenants"_sr, 1000));
@@ -98,6 +99,7 @@ struct MetaclusterManagementWorkload : TestWorkload {
 		                           "tenantIdPrefix"_sr,
 		                           deterministicRandom()->randomInt(TenantAPI::TENANT_ID_PREFIX_MIN_VALUE,
 		                                                            TenantAPI::TENANT_ID_PREFIX_MAX_VALUE + 1));
+		enableMetaclusterTenantModeCheck = getOption(options, "enableMetaclusterTenantModeCheck"_sr, false);
 	}
 
 	void disableFailureInjectionWorkloads(std::set<std::string>& out) const override { out.insert("Attrition"); }
@@ -127,8 +129,8 @@ struct MetaclusterManagementWorkload : TestWorkload {
 			self->dataDbs[self->dataDbIndex.back()] = makeReference<DataClusterData>(
 			    Database::createSimulatedExtraDatabase(connectionString, cx->defaultTenant));
 		}
-		wait(success(
-		    MetaclusterAPI::createMetacluster(cx.getReference(), "management_cluster"_sr, self->tenantIdPrefix)));
+		wait(success(MetaclusterAPI::createMetacluster(
+		    cx.getReference(), "management_cluster"_sr, self->tenantIdPrefix, self->enableMetaclusterTenantModeCheck)));
 		return Void();
 	}
 

--- a/fdbserver/workloads/MetaclusterRestoreWorkload.actor.cpp
+++ b/fdbserver/workloads/MetaclusterRestoreWorkload.actor.cpp
@@ -97,13 +97,11 @@ struct MetaclusterRestoreWorkload : TestWorkload {
 
 	bool backupComplete = false;
 	double endTime = std::numeric_limits<double>::max();
-	bool enableMetaclusterTenantModeCheck;
 
 	MetaclusterRestoreWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
 		maxTenants = std::min<int>(1e8 - 1, getOption(options, "maxTenants"_sr, 1000));
 		initialTenants = std::min<int>(maxTenants, getOption(options, "initialTenants"_sr, 40));
 		maxTenantGroups = std::min<int>(2 * maxTenants, getOption(options, "maxTenantGroups"_sr, 20));
-		enableMetaclusterTenantModeCheck = getOption(options, "enableMetaclusterTenantModeCheck"_sr, false);
 
 		tenantGroupCapacity = (initialTenants / 2 + maxTenantGroups - 1) / g_simulator->extraDatabases.size();
 		int mode = deterministicRandom()->randomInt(0, 3);
@@ -185,7 +183,7 @@ struct MetaclusterRestoreWorkload : TestWorkload {
 		    "management_cluster"_sr,
 		    deterministicRandom()->randomInt(TenantAPI::TENANT_ID_PREFIX_MIN_VALUE,
 		                                     TenantAPI::TENANT_ID_PREFIX_MAX_VALUE + 1),
-		    self->enableMetaclusterTenantModeCheck)));
+		    false)));
 
 		ASSERT(g_simulator->extraDatabases.size() > 0);
 		state std::vector<std::string>::iterator extraDatabasesItr;
@@ -542,7 +540,7 @@ struct MetaclusterRestoreWorkload : TestWorkload {
 		    "management_cluster"_sr,
 		    deterministicRandom()->randomInt(TenantAPI::TENANT_ID_PREFIX_MIN_VALUE,
 		                                     TenantAPI::TENANT_ID_PREFIX_MAX_VALUE + 1),
-		    self->enableMetaclusterTenantModeCheck)));
+		    false)));
 		state std::map<ClusterName, DataClusterData>::iterator clusterItr;
 		for (clusterItr = self->dataDbs.begin(); clusterItr != self->dataDbs.end(); ++clusterItr) {
 			TraceEvent("MetaclusterRestoreWorkloadProcessDataCluster").detail("FromCluster", clusterItr->first);

--- a/fdbserver/workloads/MetaclusterRestoreWorkload.actor.cpp
+++ b/fdbserver/workloads/MetaclusterRestoreWorkload.actor.cpp
@@ -97,11 +97,13 @@ struct MetaclusterRestoreWorkload : TestWorkload {
 
 	bool backupComplete = false;
 	double endTime = std::numeric_limits<double>::max();
+	bool enableMetaclusterTenantModeCheck;
 
 	MetaclusterRestoreWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
 		maxTenants = std::min<int>(1e8 - 1, getOption(options, "maxTenants"_sr, 1000));
 		initialTenants = std::min<int>(maxTenants, getOption(options, "initialTenants"_sr, 40));
 		maxTenantGroups = std::min<int>(2 * maxTenants, getOption(options, "maxTenantGroups"_sr, 20));
+		enableMetaclusterTenantModeCheck = getOption(options, "enableMetaclusterTenantModeCheck"_sr, false);
 
 		tenantGroupCapacity = (initialTenants / 2 + maxTenantGroups - 1) / g_simulator->extraDatabases.size();
 		int mode = deterministicRandom()->randomInt(0, 3);
@@ -182,7 +184,8 @@ struct MetaclusterRestoreWorkload : TestWorkload {
 		    self->managementDb,
 		    "management_cluster"_sr,
 		    deterministicRandom()->randomInt(TenantAPI::TENANT_ID_PREFIX_MIN_VALUE,
-		                                     TenantAPI::TENANT_ID_PREFIX_MAX_VALUE + 1))));
+		                                     TenantAPI::TENANT_ID_PREFIX_MAX_VALUE + 1),
+		    self->enableMetaclusterTenantModeCheck)));
 
 		ASSERT(g_simulator->extraDatabases.size() > 0);
 		state std::vector<std::string>::iterator extraDatabasesItr;
@@ -538,7 +541,8 @@ struct MetaclusterRestoreWorkload : TestWorkload {
 		    self->managementDb,
 		    "management_cluster"_sr,
 		    deterministicRandom()->randomInt(TenantAPI::TENANT_ID_PREFIX_MIN_VALUE,
-		                                     TenantAPI::TENANT_ID_PREFIX_MAX_VALUE + 1))));
+		                                     TenantAPI::TENANT_ID_PREFIX_MAX_VALUE + 1),
+		    self->enableMetaclusterTenantModeCheck)));
 		state std::map<ClusterName, DataClusterData>::iterator clusterItr;
 		for (clusterItr = self->dataDbs.begin(); clusterItr != self->dataDbs.end(); ++clusterItr) {
 			TraceEvent("MetaclusterRestoreWorkloadProcessDataCluster").detail("FromCluster", clusterItr->first);

--- a/fdbserver/workloads/TenantCapacityLimits.actor.cpp
+++ b/fdbserver/workloads/TenantCapacityLimits.actor.cpp
@@ -54,14 +54,12 @@ struct TenantCapacityLimits : TestWorkload {
 	const Key specialKeysTenantMapPrefix = SpecialKeySpace::getModuleRange(SpecialKeySpace::MODULE::MANAGEMENT)
 	                                           .begin.withSuffix(TenantRangeImpl::submoduleRange.begin)
 	                                           .withSuffix(TenantRangeImpl::mapSubRange.begin);
-	bool enableMetaclusterTenantModeCheck;
 
 	TenantCapacityLimits(WorkloadContext const& wcx) : TestWorkload(wcx) {
 		tenantIdPrefix = getOption(options,
 		                           "tenantIdPrefix"_sr,
 		                           deterministicRandom()->randomInt(TenantAPI::TENANT_ID_PREFIX_MIN_VALUE,
 		                                                            TenantAPI::TENANT_ID_PREFIX_MAX_VALUE + 1));
-		enableMetaclusterTenantModeCheck = getOption(options, "enableMetaclusterTenantModeCheck"_sr, false);
 		if (clientId == 0) {
 			useMetacluster = deterministicRandom()->coinflip();
 		}
@@ -82,10 +80,8 @@ struct TenantCapacityLimits : TestWorkload {
 			MultiVersionApi::api->selectApiVersion(cx->apiVersion.version());
 			self->managementDb = MultiVersionDatabase::debugCreateFromExistingDatabase(threadSafeHandle);
 
-			wait(success(MetaclusterAPI::createMetacluster(cx.getReference(),
-			                                               "management_cluster"_sr,
-			                                               self->tenantIdPrefix,
-			                                               self->enableMetaclusterTenantModeCheck)));
+			wait(success(MetaclusterAPI::createMetacluster(
+			    cx.getReference(), "management_cluster"_sr, self->tenantIdPrefix, false)));
 
 			DataClusterEntry entry;
 			entry.capacity.numTenantGroups = 1e9;

--- a/fdbserver/workloads/TenantManagementConcurrencyWorkload.actor.cpp
+++ b/fdbserver/workloads/TenantManagementConcurrencyWorkload.actor.cpp
@@ -48,7 +48,6 @@ struct TenantManagementConcurrencyWorkload : TestWorkload {
 	double testDuration;
 	bool useMetacluster;
 	bool createMetacluster;
-	bool enableMetaclusterTenantModeCheck;
 
 	Reference<IDatabase> mvDb;
 	Database dataDb;
@@ -58,7 +57,6 @@ struct TenantManagementConcurrencyWorkload : TestWorkload {
 		maxTenantGroups = std::min<int>(2 * maxTenants, getOption(options, "maxTenantGroups"_sr, 20));
 		testDuration = getOption(options, "testDuration"_sr, 120.0);
 		createMetacluster = getOption(options, "createMetacluster"_sr, true);
-		enableMetaclusterTenantModeCheck = getOption(options, "enableMetaclusterTenantModeCheck"_sr, false);
 
 		if (hasOption(options, "useMetacluster"_sr)) {
 			useMetacluster = getOption(options, "useMetacluster"_sr, false);
@@ -112,7 +110,7 @@ struct TenantManagementConcurrencyWorkload : TestWorkload {
 			    "management_cluster"_sr,
 			    deterministicRandom()->randomInt(TenantAPI::TENANT_ID_PREFIX_MIN_VALUE,
 			                                     TenantAPI::TENANT_ID_PREFIX_MAX_VALUE + 1),
-			    self->enableMetaclusterTenantModeCheck)));
+			    false)));
 
 			state int extraDatabaseIdx;
 			for (extraDatabaseIdx = 0; extraDatabaseIdx < g_simulator->extraDatabases.size(); ++extraDatabaseIdx) {

--- a/fdbserver/workloads/TenantManagementConcurrencyWorkload.actor.cpp
+++ b/fdbserver/workloads/TenantManagementConcurrencyWorkload.actor.cpp
@@ -48,6 +48,7 @@ struct TenantManagementConcurrencyWorkload : TestWorkload {
 	double testDuration;
 	bool useMetacluster;
 	bool createMetacluster;
+	bool enableMetaclusterTenantModeCheck;
 
 	Reference<IDatabase> mvDb;
 	Database dataDb;
@@ -57,6 +58,7 @@ struct TenantManagementConcurrencyWorkload : TestWorkload {
 		maxTenantGroups = std::min<int>(2 * maxTenants, getOption(options, "maxTenantGroups"_sr, 20));
 		testDuration = getOption(options, "testDuration"_sr, 120.0);
 		createMetacluster = getOption(options, "createMetacluster"_sr, true);
+		enableMetaclusterTenantModeCheck = getOption(options, "enableMetaclusterTenantModeCheck"_sr, false);
 
 		if (hasOption(options, "useMetacluster"_sr)) {
 			useMetacluster = getOption(options, "useMetacluster"_sr, false);
@@ -109,7 +111,8 @@ struct TenantManagementConcurrencyWorkload : TestWorkload {
 			    cx.getReference(),
 			    "management_cluster"_sr,
 			    deterministicRandom()->randomInt(TenantAPI::TENANT_ID_PREFIX_MIN_VALUE,
-			                                     TenantAPI::TENANT_ID_PREFIX_MAX_VALUE + 1))));
+			                                     TenantAPI::TENANT_ID_PREFIX_MAX_VALUE + 1),
+			    self->enableMetaclusterTenantModeCheck)));
 
 			state int extraDatabaseIdx;
 			for (extraDatabaseIdx = 0; extraDatabaseIdx < g_simulator->extraDatabases.size(); ++extraDatabaseIdx) {

--- a/fdbserver/workloads/TenantManagementWorkload.actor.cpp
+++ b/fdbserver/workloads/TenantManagementWorkload.actor.cpp
@@ -104,7 +104,6 @@ struct TenantManagementWorkload : TestWorkload {
 	Database dataDb;
 	bool hasNoTenantKey = false; // whether this workload has non-tenant key
 	int64_t tenantIdPrefix = 0;
-	bool enableMetaclusterTenantModeCheck;
 
 	// This test exercises multiple different ways to work with tenants
 	enum class OperationType {
@@ -134,7 +133,6 @@ struct TenantManagementWorkload : TestWorkload {
 		maxTenantGroups = std::min<int>(2 * maxTenants, getOption(options, "maxTenantGroups"_sr, 20));
 		testDuration = getOption(options, "testDuration"_sr, 120.0);
 		singleClient = getOption(options, "singleClient"_sr, false);
-		enableMetaclusterTenantModeCheck = getOption(options, "enableMetaclusterTenantModeCheck"_sr, false);
 
 		localTenantNamePrefix = format("%stenant_%d_", tenantNamePrefix.toString().c_str(), clientId);
 		localTenantGroupNamePrefix = format("%stenantgroup_%d_", tenantNamePrefix.toString().c_str(), clientId);
@@ -239,10 +237,8 @@ struct TenantManagementWorkload : TestWorkload {
 		if (self->useMetacluster) {
 			fmt::print("Create metacluster and register data cluster ... \n");
 			// Configure the metacluster (this changes the tenant mode)
-			wait(success(MetaclusterAPI::createMetacluster(cx.getReference(),
-			                                               "management_cluster"_sr,
-			                                               self->tenantIdPrefix,
-			                                               self->enableMetaclusterTenantModeCheck)));
+			wait(success(MetaclusterAPI::createMetacluster(
+			    cx.getReference(), "management_cluster"_sr, self->tenantIdPrefix, false)));
 
 			DataClusterEntry entry;
 			entry.capacity.numTenantGroups = 1e9;

--- a/fdbserver/workloads/TenantManagementWorkload.actor.cpp
+++ b/fdbserver/workloads/TenantManagementWorkload.actor.cpp
@@ -104,6 +104,7 @@ struct TenantManagementWorkload : TestWorkload {
 	Database dataDb;
 	bool hasNoTenantKey = false; // whether this workload has non-tenant key
 	int64_t tenantIdPrefix = 0;
+	bool enableMetaclusterTenantModeCheck;
 
 	// This test exercises multiple different ways to work with tenants
 	enum class OperationType {
@@ -133,6 +134,7 @@ struct TenantManagementWorkload : TestWorkload {
 		maxTenantGroups = std::min<int>(2 * maxTenants, getOption(options, "maxTenantGroups"_sr, 20));
 		testDuration = getOption(options, "testDuration"_sr, 120.0);
 		singleClient = getOption(options, "singleClient"_sr, false);
+		enableMetaclusterTenantModeCheck = getOption(options, "enableMetaclusterTenantModeCheck"_sr, false);
 
 		localTenantNamePrefix = format("%stenant_%d_", tenantNamePrefix.toString().c_str(), clientId);
 		localTenantGroupNamePrefix = format("%stenantgroup_%d_", tenantNamePrefix.toString().c_str(), clientId);
@@ -237,8 +239,10 @@ struct TenantManagementWorkload : TestWorkload {
 		if (self->useMetacluster) {
 			fmt::print("Create metacluster and register data cluster ... \n");
 			// Configure the metacluster (this changes the tenant mode)
-			wait(success(
-			    MetaclusterAPI::createMetacluster(cx.getReference(), "management_cluster"_sr, self->tenantIdPrefix)));
+			wait(success(MetaclusterAPI::createMetacluster(cx.getReference(),
+			                                               "management_cluster"_sr,
+			                                               self->tenantIdPrefix,
+			                                               self->enableMetaclusterTenantModeCheck)));
 
 			DataClusterEntry entry;
 			entry.capacity.numTenantGroups = 1e9;


### PR DESCRIPTION
Enforces that when a metacluster is created the tenant mode for it is disabled. This check is currently disabled in simulation due to needing to refactor alot of workloads but this work will need to be done soon in a followup PR.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
