### PR TITLE
Add an option to allow exceeding the tenant group capacity limit when changing tenant configuration

### DIFF
--- a/fdbcli/TenantCommands.actor.cpp
+++ b/fdbcli/TenantCommands.actor.cpp
@@ -43,9 +43,9 @@ const KeyRangeRef tenantRenameSpecialKeyRange("\xff\xff/management/tenant/rename
                                               "\xff\xff/management/tenant/rename0"_sr);
 
 Optional<std::map<Standalone<StringRef>, Optional<Value>>>
-parseTenantConfiguration(std::vector<StringRef> const& tokens, int startIndex, bool allowUnset) {
+parseTenantConfiguration(std::vector<StringRef> const& tokens, int startIndex, int endIndex, bool allowUnset) {
 	std::map<Standalone<StringRef>, Optional<Value>> configParams;
-	for (int tokenNum = startIndex; tokenNum < tokens.size(); ++tokenNum) {
+	for (int tokenNum = startIndex; tokenNum < endIndex; ++tokenNum) {
 		Optional<Value> value;
 
 		StringRef token = tokens[tokenNum];
@@ -173,7 +173,7 @@ ACTOR Future<bool> tenantCreateCommand(Reference<IDatabase> db, std::vector<Stri
 	state bool doneExistenceCheck = false;
 
 	state Optional<std::map<Standalone<StringRef>, Optional<Value>>> configuration =
-	    parseTenantConfiguration(tokens, 3, false);
+	    parseTenantConfiguration(tokens, 3, tokens.size(), false);
 
 	if (!configuration.present()) {
 		return false;
@@ -523,16 +523,21 @@ ACTOR Future<bool> tenantGetCommand(Reference<IDatabase> db, std::vector<StringR
 // tenant configure command
 ACTOR Future<bool> tenantConfigureCommand(Reference<IDatabase> db, std::vector<StringRef> tokens) {
 	if (tokens.size() < 4) {
-		fmt::print("Usage: tenant configure <TENANT_NAME> <[unset] tenant_group[=<GROUP_NAME>]> ...\n\n");
+		fmt::print(
+		    "Usage: tenant configure <TENANT_NAME> <[unset] tenant_group[=<GROUP_NAME>]> [ignore_capacity_limit]\n\n");
 		fmt::print("Updates the configuration for a tenant.\n");
 		fmt::print("Use `tenant_group=<GROUP_NAME>' to change the tenant group that a\n");
 		fmt::print("tenant is assigned to or `unset tenant_group' to remove a tenant from\n");
-		fmt::print("its tenant group.");
+		fmt::print("its tenant group.\n");
+		fmt::print("If `ignore_capacity_limit' is specified, a new tenant group can be\n");
+		fmt::print("created or the tenant can be ungrouped on a cluster with no tenant group\n");
+		fmt::print("capacity remaining\n");
 		return false;
 	}
 
+	state bool ignoreCapacityLimit = tokens[tokens.size() - 1] == "ignore_capacity_limit";
 	state Optional<std::map<Standalone<StringRef>, Optional<Value>>> configuration =
-	    parseTenantConfiguration(tokens, 3, true);
+	    parseTenantConfiguration(tokens, 3, tokens.size() - ignoreCapacityLimit, true);
 
 	if (!configuration.present()) {
 		return false;
@@ -546,7 +551,8 @@ ACTOR Future<bool> tenantConfigureCommand(Reference<IDatabase> db, std::vector<S
 			tr->setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
 			ClusterType clusterType = wait(TenantAPI::getClusterType(tr));
 			if (clusterType == ClusterType::METACLUSTER_MANAGEMENT) {
-				wait(MetaclusterAPI::configureTenant(db, tokens[2], configuration.get()));
+				wait(MetaclusterAPI::configureTenant(
+				    db, tokens[2], configuration.get(), IgnoreCapacityLimit(ignoreCapacityLimit)));
 			} else {
 				applyConfigurationToSpecialKeys(tr, tokens[2], configuration.get());
 				wait(safeThreadFutureToFuture(tr->commit()));
@@ -712,7 +718,10 @@ void tenantGenerator(const char* text,
 			const char* opts[] = { "tenant_group=", "unset", nullptr };
 			arrayGenerator(text, line, opts, lc);
 		} else if (tokens.size() == 4 && tokencmp(tokens[3], "unset")) {
-			const char* opts[] = { "tenant_group", nullptr };
+			const char* opts[] = { "tenant_group=", nullptr };
+			arrayGenerator(text, line, opts, lc);
+		} else if (tokens.size() == 4 + tokencmp(tokens[3], "unset")) {
+			const char* opts[] = { "ignore_capacity_limit", nullptr };
 			arrayGenerator(text, line, opts, lc);
 		}
 	}
@@ -742,11 +751,17 @@ std::vector<const char*> tenantHintGenerator(std::vector<StringRef> const& token
 		return std::vector<const char*>(opts.begin() + tokens.size() - 2, opts.end());
 	} else if (tokencmp(tokens[1], "configure")) {
 		if (tokens.size() < 4) {
-			static std::vector<const char*> opts = { "<TENANT_NAME>", "<[unset] tenant_group[=<GROUP_NAME>]>" };
+			static std::vector<const char*> opts = { "<TENANT_NAME>",
+				                                     "<[unset] tenant_group[=<GROUP_NAME>]>",
+				                                     "[ignore_capacity_limit]" };
 			return std::vector<const char*>(opts.begin() + tokens.size() - 2, opts.end());
-		} else if (tokens.size() == 4 && tokencmp(tokens[3], "unset")) {
-			static std::vector<const char*> opts = { "<tenant_group[=<GROUP_NAME>]>" };
+		} else if (tokens.size() >= 4 && tokens.size() < 6 && "unset"_sr.startsWith(tokens[3]) &&
+		           tokens[3].size() <= 5) {
+			static std::vector<const char*> opts = { "<tenant_group[=<GROUP_NAME>]>", "[ignore_capacity_limit]" };
 			return std::vector<const char*>(opts.begin() + tokens.size() - 4, opts.end());
+		} else if (tokens.size() < 5) {
+			static std::vector<const char*> opts = { "[ignore_capacity_limit]" };
+			return opts;
 		}
 		return {};
 	} else if (tokencmp(tokens[1], "rename") && tokens.size() < 4) {

--- a/fdbcli/tests/fdbcli_tests.py
+++ b/fdbcli/tests/fdbcli_tests.py
@@ -1115,6 +1115,14 @@ def tenant_configure(logger):
     )
 
     output = run_fdbcli_command_and_get_error(
+        "tenant configure tenant tenant_group=tenant1 unknown_token"
+    )
+    assert (
+        output
+        == "ERROR: invalid configuration string `unknown_token'. String must specify a value using `='."
+    )
+
+    output = run_fdbcli_command_and_get_error(
         "tenant configure tenant3 tenant_group=tenant_group1"
     )
     assert output == "ERROR: Tenant does not exist (2131)"

--- a/fdbcli/tests/fdbcli_tests.py
+++ b/fdbcli/tests/fdbcli_tests.py
@@ -1067,12 +1067,22 @@ def tenant_configure(logger):
     output = run_fdbcli_command("tenant configure tenant tenant_group=tenant_group1")
     assert output == "The configuration for tenant `tenant' has been updated"
 
+    output = run_fdbcli_command(
+        "tenant configure tenant tenant_group=tenant_group1 ignore_capacity_limit"
+    )
+    assert output == "The configuration for tenant `tenant' has been updated"
+
     output = run_fdbcli_command("tenant get tenant")
     lines = output.split("\n")
     assert len(lines) == 3
     assert lines[2].strip() == "tenant group: tenant_group1"
 
     output = run_fdbcli_command("tenant configure tenant unset tenant_group")
+    assert output == "The configuration for tenant `tenant' has been updated"
+
+    output = run_fdbcli_command(
+        "tenant configure tenant unset tenant_group ignore_capacity_limit"
+    )
     assert output == "The configuration for tenant `tenant' has been updated"
 
     output = run_fdbcli_command("tenant get tenant")
@@ -1109,13 +1119,15 @@ def tenant_configure(logger):
     )
     assert output == "ERROR: Tenant does not exist (2131)"
 
-
     expected_output = """
 ERROR: assigned_cluster is only valid in metacluster configuration.
 ERROR: Tenant configuration is invalid (2140)
     """.strip()
-    output = run_fdbcli_command_and_get_error('tenant configure tenant assigned_cluster=nonexist')
+    output = run_fdbcli_command_and_get_error(
+        "tenant configure tenant assigned_cluster=nonexist"
+    )
     assert output == expected_output
+
 
 @enable_logging()
 def tenant_rename(logger):

--- a/fdbclient/Metacluster.cpp
+++ b/fdbclient/Metacluster.cpp
@@ -33,6 +33,7 @@ FDB_DEFINE_BOOLEAN_PARAM(RunOnMismatchedCluster);
 FDB_DEFINE_BOOLEAN_PARAM(RestoreDryRun);
 FDB_DEFINE_BOOLEAN_PARAM(ForceJoin);
 FDB_DEFINE_BOOLEAN_PARAM(ForceRemove);
+FDB_DEFINE_BOOLEAN_PARAM(IgnoreCapacityLimit);
 
 namespace MetaclusterAPI {
 

--- a/fdbserver/workloads/MetaclusterRestoreWorkload.actor.cpp
+++ b/fdbserver/workloads/MetaclusterRestoreWorkload.actor.cpp
@@ -859,7 +859,8 @@ struct MetaclusterRestoreWorkload : TestWorkload {
 
 		loop {
 			try {
-				wait(MetaclusterAPI::configureTenant(self->managementDb, tenantName, configurationParams));
+				wait(MetaclusterAPI::configureTenant(
+				    self->managementDb, tenantName, configurationParams, IgnoreCapacityLimit::False));
 
 				auto& tenantData = self->createdTenants[tenantId];
 

--- a/fdbserver/workloads/TenantManagementWorkload.actor.cpp
+++ b/fdbserver/workloads/TenantManagementWorkload.actor.cpp
@@ -1521,7 +1521,8 @@ struct TenantManagementWorkload : TestWorkload {
 			wait(tr->commit());
 			ASSERT(!specialKeysUseInvalidTuple);
 		} else if (operationType == OperationType::METACLUSTER) {
-			wait(MetaclusterAPI::configureTenant(self->mvDb, tenant, configParameters));
+			wait(MetaclusterAPI::configureTenant(
+			    self->mvDb, tenant, configParameters, IgnoreCapacityLimit(deterministicRandom()->coinflip())));
 		} else {
 			// We don't have a transaction or database variant of this function
 			ASSERT(false);


### PR DESCRIPTION
This can be used to temporarily move a tenant out of a tenant group prior to moving it to another cluster. Without this option, we would have to temporarily raise the capacity limit of a cluster and then risk the possibility that another group takes the extra allocation.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
