### PR TITLE
Enhance fdbbackup query command to estimate data processing from a specific snapshot to a target version

### DIFF
--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -1056,7 +1056,7 @@ static void printBackupUsage(bool devhelp) {
 	       "the backup.\n");
 	printf("  -qrv --query-restore-version VERSION\n"
 	       "                 For query operations, set target version for restoring a backup. Set -1 for maximum\n"
-	       "                 restorable version (default) and -2 for minimum restorable version.\n");
+	       "                 restorable version (default) and -3 for minimum restorable version.\n");
 	printf(
 	    "  --query-restore-timestamp DATETIME\n"
 	    "                 For query operations, instead of a numeric version, use this to specify a timestamp in %s\n",
@@ -2759,9 +2759,10 @@ ACTOR Future<Void> queryBackup(const char* name,
 				    result,
 				    errorMessage = format("the backup for the specified key ranges is not restorable to any version"));
 			}
+			TraceEvent("BackupQueryResolveMaxRestoreVersion").detail("Version", restoreVersion);
 		}
 
-		if (restoreVersion < 0 && restoreVersion != latestVersion) {
+		if (restoreVersion < 0 && restoreVersion != earliestVersion) {
 			reportBackupQueryError(operationId,
 			                       result,
 			                       errorMessage =

--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -1057,8 +1057,9 @@ static void printBackupUsage(bool devhelp) {
 	       "                 version approximately NUM_DAYS days worth of versions prior to the latest log version in "
 	       "the backup.\n");
 	printf("  --query-restore-snapshot-version VERSION\n"
-	       "                 For query operations, set snapshot version for restoring a backup. Set -1 for maximum\n"
-	       "                 restorable version (default) and -3 for minimum restorable version.\n");
+	       "                 For query operations, set the snapshot version, inclusive, used to restore a backup.\n"
+	       "                 Set -1 to use the latest valid snapshot,\n"
+	       "                 Set -3 to use the oldest valid snapshot.\n");
 	printf("  -qrv --query-restore-version VERSION\n"
 	       "                 For query operations, set target version for restoring a backup. Set -1 for maximum\n"
 	       "                 restorable version (default) and -3 for minimum restorable version.\n");
@@ -2776,6 +2777,8 @@ ACTOR Future<Void> queryBackup(const char* name,
 	try {
 		state Reference<IBackupContainer> bc = openBackupContainer(name, destinationContainer, proxy, {});
 		BackupDescription desc = wait(bc->describeBackup());
+		// Use continuous log end version for the maximum restorable version for the key ranges when a restorable
+		// version doesn't exist.
 		auto [maxRestorableVersion, minRestorableVersion] = getMaxMinRestorableVersions(desc, !keyRangesFilter.empty());
 		if (restoreVersion == invalidVersion) {
 			restoreVersion = maxRestorableVersion;
@@ -2797,8 +2800,11 @@ ACTOR Future<Void> queryBackup(const char* name,
 			return Void();
 		}
 
+		state Optional<RestorableFileSet> fileSet;
 		if (snapshotVersion != invalidVersion) {
-			Optional<RestorableFileSet> fileSet = wait(bc->getRestoreSet(snapshotVersion, keyRangesFilter));
+			// When a snapshot version is specified, we will first get a restore set using the latest snapshot file to
+			// restore to the snapshot version. After snapshot version, we will only use mutation logs to restore.
+			wait(store(fileSet, bc->getRestoreSet(snapshotVersion, keyRangesFilter)));
 			if (fileSet.present()) {
 				result["snapshot_version"] = fileSet.get().targetVersion;
 				for (const auto& rangeFile : fileSet.get().ranges) {
@@ -2841,16 +2847,14 @@ ACTOR Future<Void> queryBackup(const char* name,
 				           snapshotVersion));
 				return Void();
 			}
+
+			// We only need to know all the mutation logs from `snapshotVersion` to `restoreVersion`.
+			wait(store(fileSet, bc->getRestoreSet(restoreVersion, keyRangesFilter, /*logOnly=*/true, snapshotVersion)));
+		} else {
+			// When a snapshot version is not specified, we use the latest snapshot to restore to the `restoreVersion`.
+			wait(store(fileSet, bc->getRestoreSet(restoreVersion, keyRangesFilter)));
 		}
 
-		state Optional<RestorableFileSet> fileSet;
-		if (snapshotVersion == invalidVersion) {
-			// Using the latest snapshot.
-			wait(store(fileSet, bc->getRestoreSet(restoreVersion, keyRangesFilter)));
-		} else {
-			// We only need to know all the log files from snapshotVersion to restoreVersion.
-			wait(store(fileSet, bc->getRestoreSet(restoreVersion, keyRangesFilter, /*logOnly=*/true, snapshotVersion)));
-		}
 		if (fileSet.present()) {
 			result["restore_version"] = fileSet.get().targetVersion;
 			for (const auto& rangeFile : fileSet.get().ranges) {

--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -2697,6 +2697,24 @@ static void reportBackupQueryError(UID operationId, JsonBuilderObject& result, s
 	TraceEvent("BackupQueryFailure").detail("OperationId", operationId).detail("Reason", errorMessage);
 }
 
+std::pair<Version, Version> getMaxMinRestorableVersions(const BackupDescription& desc, bool mayOnlyApplyMutationLog) {
+	Version maxRestorableVersion = invalidVersion;
+	Version minRestorableVersion = invalidVersion;
+	if (desc.maxRestorableVersion.present()) {
+		maxRestorableVersion = desc.maxRestorableVersion.get();
+	} else if (mayOnlyApplyMutationLog && desc.contiguousLogEnd.present()) {
+		maxRestorableVersion = desc.contiguousLogEnd.get();
+	}
+
+	if (desc.minRestorableVersion.present()) {
+		minRestorableVersion = desc.minRestorableVersion.get();
+	} else if (mayOnlyApplyMutationLog && desc.minLogBegin.present()) {
+		minRestorableVersion = desc.minLogBegin.get();
+	}
+
+	return std::make_pair(maxRestorableVersion, minRestorableVersion);
+}
+
 // If restoreVersion is invalidVersion or latestVersion, use the maximum or minimum restorable version respectively for
 // selected key ranges. If restoreTimestamp is specified, any specified restoreVersion will be overriden to the version
 // resolved to that timestamp.
@@ -2753,23 +2771,21 @@ ACTOR Future<Void> queryBackup(const char* name,
 
 	try {
 		state Reference<IBackupContainer> bc = openBackupContainer(name, destinationContainer, proxy, {});
+		BackupDescription desc = wait(bc->describeBackup());
+		auto [maxRestorableVersion, minRestorableVersion] = getMaxMinRestorableVersions(desc, !keyRangesFilter.empty());
 		if (restoreVersion == invalidVersion) {
-			BackupDescription desc = wait(bc->describeBackup());
-			if (desc.maxRestorableVersion.present()) {
-				restoreVersion = desc.maxRestorableVersion.get();
-				// Use continuous log end version for the maximum restorable version for the key ranges.
-			} else if (keyRangesFilter.size() && desc.contiguousLogEnd.present()) {
-				restoreVersion = desc.contiguousLogEnd.get();
-			} else {
-				reportBackupQueryError(
-				    operationId,
-				    result,
-				    errorMessage = format("the backup for the specified key ranges is not restorable to any version"));
-			}
-			TraceEvent("BackupQueryResolveMaxRestoreVersion").detail("Version", restoreVersion);
+			restoreVersion = maxRestorableVersion;
 		}
-
-		if (restoreVersion < 0 && restoreVersion != earliestVersion) {
+		if (restoreVersion == earliestVersion) {
+			restoreVersion = minRestorableVersion;
+		}
+		if (snapshotVersion == earliestVersion) {
+			snapshotVersion = minRestorableVersion;
+		}
+		TraceEvent("BackupQueryResolveRestoreVersion")
+		    .detail("RestoreVersion", restoreVersion)
+		    .detail("SnapshotVersion", snapshotVersion);
+		if (restoreVersion < 0) {
 			reportBackupQueryError(operationId,
 			                       result,
 			                       errorMessage =
@@ -2785,7 +2801,6 @@ ACTOR Future<Void> queryBackup(const char* name,
 			Optional<RestorableFileSet> fileSet = wait(bc->getRestoreSet(snapshotVersion, keyRangesFilter));
 			if (fileSet.present()) {
 				result["snapshot_version"] = fileSet.get().targetVersion;
-				result["restore_version"] = fileSet.get().targetVersion; // In case there isn't any more log files.
 				for (const auto& rangeFile : fileSet.get().ranges) {
 					JsonBuilderObject object;
 					object["file_name"] = rangeFile.fileName;
@@ -2830,6 +2845,7 @@ ACTOR Future<Void> queryBackup(const char* name,
 
 		state Optional<RestorableFileSet> fileSet;
 		if (snapshotVersion == invalidVersion) {
+			// Using the latest snapshot.
 			wait(store(fileSet, bc->getRestoreSet(restoreVersion, keyRangesFilter)));
 		} else {
 			// We only need to know all the log files from snapshotVersion to restoreVersion.

--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -2769,6 +2769,10 @@ ACTOR Future<Void> queryBackup(const char* name,
 		restoreVersion = v;
 	}
 
+	state int64_t totalRangeFilesSize = 0;
+	state int64_t totalLogFilesSize = 0;
+	state JsonBuilderArray rangeFilesJson;
+	state JsonBuilderArray logFilesJson;
 	try {
 		state Reference<IBackupContainer> bc = openBackupContainer(name, destinationContainer, proxy, {});
 		BackupDescription desc = wait(bc->describeBackup());
@@ -2793,10 +2797,6 @@ ACTOR Future<Void> queryBackup(const char* name,
 			return Void();
 		}
 
-		state int64_t totalRangeFilesSize = 0;
-		state int64_t totalLogFilesSize = 0;
-		state JsonBuilderArray rangeFilesJson;
-		state JsonBuilderArray logFilesJson;
 		if (snapshotVersion != invalidVersion) {
 			Optional<RestorableFileSet> fileSet = wait(bc->getRestoreSet(snapshotVersion, keyRangesFilter));
 			if (fileSet.present()) {

--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -150,6 +150,7 @@ enum {
 	// Restore constants
 	OPT_RESTORECONTAINER,
 	OPT_RESTORE_VERSION,
+	OPT_RESTORE_SNAPSHOT_VERSION,
 	OPT_RESTORE_TIMESTAMP,
 	OPT_PREFIX_ADD,
 	OPT_PREFIX_REMOVE,
@@ -661,6 +662,7 @@ CSimpleOpt::SOption g_rgBackupQueryOptions[] = {
 	{ OPT_PROXY, "--proxy", SO_REQ_SEP },
 	{ OPT_RESTORE_VERSION, "-qrv", SO_REQ_SEP },
 	{ OPT_RESTORE_VERSION, "--query-restore-version", SO_REQ_SEP },
+	{ OPT_RESTORE_SNAPSHOT_VERSION, "--query-restore-snapshot-version", SO_REQ_SEP },
 	{ OPT_BACKUPKEYS_FILTER, "-k", SO_REQ_SEP },
 	{ OPT_BACKUPKEYS_FILTER, "--keys", SO_REQ_SEP },
 	{ OPT_TRACE, "--log", SO_NONE },
@@ -1054,6 +1056,9 @@ static void printBackupUsage(bool devhelp) {
 	       "containing no data at or after a\n"
 	       "                 version approximately NUM_DAYS days worth of versions prior to the latest log version in "
 	       "the backup.\n");
+	printf("  --query-restore-snapshot-version VERSION\n"
+	       "                 For query operations, set snapshot version for restoring a backup. Set -1 for maximum\n"
+	       "                 restorable version (default) and -3 for minimum restorable version.\n");
 	printf("  -qrv --query-restore-version VERSION\n"
 	       "                 For query operations, set target version for restoring a backup. Set -1 for maximum\n"
 	       "                 restorable version (default) and -3 for minimum restorable version.\n");
@@ -2700,6 +2705,7 @@ ACTOR Future<Void> queryBackup(const char* name,
                                Optional<std::string> proxy,
                                Standalone<VectorRef<KeyRangeRef>> keyRangesFilter,
                                Version restoreVersion,
+                               Version snapshotVersion,
                                std::string originalClusterFile,
                                std::string restoreTimestamp,
                                Verbose verbose,
@@ -2715,6 +2721,7 @@ ACTOR Future<Void> queryBackup(const char* name,
 	    .detail("DestinationContainer", destinationContainer)
 	    .detail("KeyRangesFilter", printable(keyRangesFilter))
 	    .detail("SpecifiedRestoreVersion", restoreVersion)
+	    .detail("SpecifiedSnapshotVersion", snapshotVersion)
 	    .detail("RestoreTimestamp", restoreTimestamp)
 	    .detail("BackupClusterFile", originalClusterFile);
 
@@ -2769,12 +2776,67 @@ ACTOR Future<Void> queryBackup(const char* name,
 			                           format("the specified restorable version %lld is not valid", restoreVersion));
 			return Void();
 		}
-		Optional<RestorableFileSet> fileSet = wait(bc->getRestoreSet(restoreVersion, keyRangesFilter));
+
+		state int64_t totalRangeFilesSize = 0;
+		state int64_t totalLogFilesSize = 0;
+		state JsonBuilderArray rangeFilesJson;
+		state JsonBuilderArray logFilesJson;
+		if (snapshotVersion != invalidVersion) {
+			Optional<RestorableFileSet> fileSet = wait(bc->getRestoreSet(snapshotVersion, keyRangesFilter));
+			if (fileSet.present()) {
+				result["snapshot_version"] = fileSet.get().targetVersion;
+				result["restore_version"] = fileSet.get().targetVersion;  // In case there isn't any more log files.
+				for (const auto& rangeFile : fileSet.get().ranges) {
+					JsonBuilderObject object;
+					object["file_name"] = rangeFile.fileName;
+					object["file_size"] = rangeFile.fileSize;
+					object["version"] = rangeFile.version;
+					object["key_range"] = fileSet.get().keyRanges.count(rangeFile.fileName) == 0
+					                          ? "none"
+					                          : fileSet.get().keyRanges.at(rangeFile.fileName).toString();
+					rangeFilesJson.push_back(object);
+					totalRangeFilesSize += rangeFile.fileSize;
+				}
+				for (const auto& log : fileSet.get().logs) {
+					JsonBuilderObject object;
+					object["file_name"] = log.fileName;
+					object["file_size"] = log.fileSize;
+					object["begin_version"] = log.beginVersion;
+					object["end_version"] = log.endVersion;
+					logFilesJson.push_back(object);
+					totalLogFilesSize += log.fileSize;
+				}
+
+				snapshotVersion = fileSet.get().targetVersion;
+
+				TraceEvent("BackupQueryReceivedRestorableFilesSetFromSnapshot")
+					.detail("SnapshotVersion", snapshotVersion)
+				    .detail("DestinationContainer", destinationContainer)
+				    .detail("KeyRangesFilter", printable(keyRangesFilter))
+				    .detail("ActualRestoreVersion", fileSet.get().targetVersion)
+				    .detail("NumRangeFiles", fileSet.get().ranges.size())
+				    .detail("NumLogFiles", fileSet.get().logs.size())
+				    .detail("RangeFilesBytes", totalRangeFilesSize)
+				    .detail("LogFilesBytes", totalLogFilesSize);
+			} else {
+				reportBackupQueryError(
+				    operationId,
+				    result,
+				    format("no restorable files set found for specified key ranges from snapshotVersion %lld",
+				           snapshotVersion));
+				return Void();
+			}
+		}
+
+		state Optional<RestorableFileSet> fileSet;
+		if (snapshotVersion == invalidVersion) {
+			wait(store(fileSet, bc->getRestoreSet(restoreVersion, keyRangesFilter)));
+		} else {
+			// We only need to know all the log files from snapshotVersion to restoreVersion.
+			wait(store(fileSet, bc->getRestoreSet(restoreVersion, keyRangesFilter, /*logOnly=*/true, snapshotVersion)));
+		}
 		if (fileSet.present()) {
-			int64_t totalRangeFilesSize = 0, totalLogFilesSize = 0;
 			result["restore_version"] = fileSet.get().targetVersion;
-			JsonBuilderArray rangeFilesJson;
-			JsonBuilderArray logFilesJson;
 			for (const auto& rangeFile : fileSet.get().ranges) {
 				JsonBuilderObject object;
 				object["file_name"] = rangeFile.fileName;
@@ -2796,14 +2858,6 @@ ACTOR Future<Void> queryBackup(const char* name,
 				totalLogFilesSize += log.fileSize;
 			}
 
-			result["total_range_files_size"] = totalRangeFilesSize;
-			result["total_log_files_size"] = totalLogFilesSize;
-
-			if (verbose) {
-				result["ranges"] = rangeFilesJson;
-				result["logs"] = logFilesJson;
-			}
-
 			TraceEvent("BackupQueryReceivedRestorableFilesSet")
 			    .detail("DestinationContainer", destinationContainer)
 			    .detail("KeyRangesFilter", printable(keyRangesFilter))
@@ -2812,7 +2866,7 @@ ACTOR Future<Void> queryBackup(const char* name,
 			    .detail("NumLogFiles", fileSet.get().logs.size())
 			    .detail("RangeFilesBytes", totalRangeFilesSize)
 			    .detail("LogFilesBytes", totalLogFilesSize);
-		} else {
+		} else if (snapshotVersion == invalidVersion) {
 			reportBackupQueryError(operationId, result, "no restorable files set found for specified key ranges");
 			return Void();
 		}
@@ -2820,6 +2874,14 @@ ACTOR Future<Void> queryBackup(const char* name,
 	} catch (Error& e) {
 		reportBackupQueryError(operationId, result, e.what());
 		return Void();
+	}
+
+	result["total_range_files_size"] = totalRangeFilesSize;
+	result["total_log_files_size"] = totalLogFilesSize;
+
+	if (verbose) {
+		result["ranges"] = rangeFilesJson;
+		result["logs"] = logFilesJson;
 	}
 
 	printf("%s\n", result.getJson().c_str());
@@ -3384,6 +3446,7 @@ int main(int argc, char* argv[]) {
 		int maxErrors = 20;
 		Version beginVersion = invalidVersion;
 		Version restoreVersion = invalidVersion;
+		Version snapshotVersion = invalidVersion;
 		std::string restoreTimestamp;
 		WaitForComplete waitForDone{ false };
 		StopWhenDone stopWhenDone{ true };
@@ -3738,6 +3801,17 @@ int main(int argc, char* argv[]) {
 					return FDB_EXIT_ERROR;
 				}
 				restoreVersion = ver;
+				break;
+			}
+			case OPT_RESTORE_SNAPSHOT_VERSION: {
+				const char* a = args->OptionArg();
+				long long ver = 0;
+				if (!sscanf(a, "%lld", &ver)) {
+					fprintf(stderr, "ERROR: Could not parse database version `%s'\n", a);
+					printHelpTeaser(argv[0]);
+					return FDB_EXIT_ERROR;
+				}
+				snapshotVersion = ver;
 				break;
 			}
 			case OPT_RESTORE_USER_DATA: {
@@ -4166,6 +4240,7 @@ int main(int argc, char* argv[]) {
 				                          proxy,
 				                          backupKeysFilter,
 				                          restoreVersion,
+				                          snapshotVersion,
 				                          restoreClusterFileOrig,
 				                          restoreTimestamp,
 				                          Verbose{ !quietDisplay },

--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -2785,7 +2785,7 @@ ACTOR Future<Void> queryBackup(const char* name,
 			Optional<RestorableFileSet> fileSet = wait(bc->getRestoreSet(snapshotVersion, keyRangesFilter));
 			if (fileSet.present()) {
 				result["snapshot_version"] = fileSet.get().targetVersion;
-				result["restore_version"] = fileSet.get().targetVersion;  // In case there isn't any more log files.
+				result["restore_version"] = fileSet.get().targetVersion; // In case there isn't any more log files.
 				for (const auto& rangeFile : fileSet.get().ranges) {
 					JsonBuilderObject object;
 					object["file_name"] = rangeFile.fileName;
@@ -2810,7 +2810,7 @@ ACTOR Future<Void> queryBackup(const char* name,
 				snapshotVersion = fileSet.get().targetVersion;
 
 				TraceEvent("BackupQueryReceivedRestorableFilesSetFromSnapshot")
-					.detail("SnapshotVersion", snapshotVersion)
+				    .detail("SnapshotVersion", snapshotVersion)
 				    .detail("DestinationContainer", destinationContainer)
 				    .detail("KeyRangesFilter", printable(keyRangesFilter))
 				    .detail("ActualRestoreVersion", fileSet.get().targetVersion)

--- a/fdbclient/BackupContainerFileSystem.actor.cpp
+++ b/fdbclient/BackupContainerFileSystem.actor.cpp
@@ -927,6 +927,9 @@ public:
 		// Find the most recent keyrange snapshot through which we can restore filtered key ranges into targetVersion.
 		state std::vector<KeyspaceSnapshotFile> snapshots = wait(bc->listKeyspaceSnapshots());
 		state int i = snapshots.size() - 1;
+		if (targetVersion == earliestVersion) {
+			i = 0;
+		}
 		for (; i >= 0; i--) {
 			// The smallest version of filtered range files >= snapshot beginVersion > targetVersion
 			if (targetVersion >= 0 && snapshots[i].beginVersion > targetVersion) {
@@ -967,7 +970,7 @@ public:
 				}
 			}
 			// 'latestVersion' represents using the minimum restorable version in a snapshot.
-			restorable.targetVersion = targetVersion == latestVersion ? maxKeyRangeVersion : targetVersion;
+			restorable.targetVersion = targetVersion == earliestVersion ? maxKeyRangeVersion : targetVersion;
 			// Any version < maxKeyRangeVersion is not restorable.
 			if (restorable.targetVersion < maxKeyRangeVersion)
 				continue;

--- a/fdbclient/BackupContainerFileSystem.actor.cpp
+++ b/fdbclient/BackupContainerFileSystem.actor.cpp
@@ -914,6 +914,7 @@ public:
 
 		if (logsOnly) {
 			state RestorableFileSet restorableSet;
+			restorableSet.targetVersion = targetVersion;
 			state std::vector<LogFile> logFiles;
 			Version begin = beginVersion == invalidVersion ? 0 : beginVersion;
 			wait(store(logFiles, bc->listLogFiles(begin, targetVersion, false)));
@@ -927,9 +928,6 @@ public:
 		// Find the most recent keyrange snapshot through which we can restore filtered key ranges into targetVersion.
 		state std::vector<KeyspaceSnapshotFile> snapshots = wait(bc->listKeyspaceSnapshots());
 		state int i = snapshots.size() - 1;
-		if (targetVersion == earliestVersion) {
-			i = 0;
-		}
 		for (; i >= 0; i--) {
 			// The smallest version of filtered range files >= snapshot beginVersion > targetVersion
 			if (targetVersion >= 0 && snapshots[i].beginVersion > targetVersion) {
@@ -970,7 +968,7 @@ public:
 				}
 			}
 			// 'latestVersion' represents using the minimum restorable version in a snapshot.
-			restorable.targetVersion = targetVersion == earliestVersion ? maxKeyRangeVersion : targetVersion;
+			restorable.targetVersion = targetVersion == latestVersion ? maxKeyRangeVersion : targetVersion;
 			// Any version < maxKeyRangeVersion is not restorable.
 			if (restorable.targetVersion < maxKeyRangeVersion)
 				continue;

--- a/fdbclient/include/fdbclient/BackupContainer.h
+++ b/fdbclient/include/fdbclient/BackupContainer.h
@@ -288,7 +288,7 @@ public:
 	                                            Version end = std::numeric_limits<Version>::max()) = 0;
 
 	// Get exactly the files necessary to restore the key space filtered by the specified key ranges to targetVersion.
-	// If targetVersion is 'earliestVersion', use the minimum restorable version in a snapshot.
+	// If targetVersion is 'latestVersion', use the minimum restorable version in a snapshot.
 	// If logsOnly is set, only use log files in [beginVersion, targetVervions) in restore set.
 	// Returns non-present if restoring to the given version is not possible.
 	virtual Future<Optional<RestorableFileSet>> getRestoreSet(Version targetVersion,

--- a/fdbclient/include/fdbclient/BackupContainer.h
+++ b/fdbclient/include/fdbclient/BackupContainer.h
@@ -288,7 +288,7 @@ public:
 	                                            Version end = std::numeric_limits<Version>::max()) = 0;
 
 	// Get exactly the files necessary to restore the key space filtered by the specified key ranges to targetVersion.
-	// If targetVersion is 'latestVersion', use the minimum restorable version in a snapshot.
+	// If targetVersion is 'earliestVersion', use the minimum restorable version in a snapshot.
 	// If logsOnly is set, only use log files in [beginVersion, targetVervions) in restore set.
 	// Returns non-present if restoring to the given version is not possible.
 	virtual Future<Optional<RestorableFileSet>> getRestoreSet(Version targetVersion,

--- a/fdbclient/include/fdbclient/FDBTypes.h
+++ b/fdbclient/include/fdbclient/FDBTypes.h
@@ -560,7 +560,12 @@ struct hash<KeyRange> {
 };
 } // namespace std
 
-enum { invalidVersion = -1, latestVersion = -2, MAX_VERSION = std::numeric_limits<int64_t>::max() };
+enum {
+	invalidVersion = -1,
+	latestVersion = -2,
+	earliestVersion = -3,
+	MAX_VERSION = std::numeric_limits<int64_t>::max()
+};
 
 inline KeyRef keyAfter(const KeyRef& key, Arena& arena) {
 	// Don't include fdbclient/SystemData.h for the allKeys symbol to avoid a cyclic include


### PR DESCRIPTION
- Previously, it always uses the closest snapshot from the restore version. Now, it can uses --query-restore-snapshot-version to set which snapshot version to use. It will pick the latest snapshot version prior to that version.
- Also fix --query-restore-version == -2, which doesn't produce minimum restore version (rather, it produces just the latest snapshot).
- Introduce `earliestVersion` constant.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
