### PR TITLE
Add restore to the metacluster management concurrency workload

### DIFF
--- a/fdbclient/include/fdbclient/MetaclusterManagement.actor.h
+++ b/fdbclient/include/fdbclient/MetaclusterManagement.actor.h
@@ -2140,21 +2140,21 @@ struct RestoreClusterImpl {
 			}
 
 			if (tenantBatch.size() == CLIENT_KNOBS->METACLUSTER_RESTORE_BATCH_SIZE) {
-				wait(runTransaction(self->ctx.managementDb,
-				                    [self = self, tenantBatch = tenantBatch](Reference<typename DB::TransactionT> tr) {
-					                    tr->setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
-					                    return addTenantBatchToManagementCluster(self, tr, tenantBatch);
-				                    }));
+				wait(self->runRestoreManagementTransaction(
+				    [self = self, tenantBatch = tenantBatch](Reference<typename DB::TransactionT> tr) {
+					    tr->setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
+					    return addTenantBatchToManagementCluster(self, tr, tenantBatch);
+				    }));
 				tenantBatch.clear();
 			}
 		}
 
 		if (!tenantBatch.empty()) {
-			wait(runTransaction(self->ctx.managementDb,
-			                    [self = self, tenantBatch = tenantBatch](Reference<typename DB::TransactionT> tr) {
-				                    tr->setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
-				                    return addTenantBatchToManagementCluster(self, tr, tenantBatch);
-			                    }));
+			wait(self->runRestoreManagementTransaction(
+			    [self = self, tenantBatch = tenantBatch](Reference<typename DB::TransactionT> tr) {
+				    tr->setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
+				    return addTenantBatchToManagementCluster(self, tr, tenantBatch);
+			    }));
 		}
 
 		if (self->restoreDryRun) {

--- a/fdbclient/include/fdbclient/MetaclusterManagement.actor.h
+++ b/fdbclient/include/fdbclient/MetaclusterManagement.actor.h
@@ -1854,7 +1854,6 @@ struct RestoreClusterImpl {
 			bool configurationChanged = !managementTenant.matchesConfiguration(tenantEntry);
 			if (configurationChanged ||
 			    managementTenant.configurationSequenceNum != tenantEntry.configurationSequenceNum) {
-				ASSERT(managementTenant.configurationSequenceNum >= tenantEntry.configurationSequenceNum);
 				if (self->restoreDryRun) {
 					// If this is an update to the internal sequence number only and we are also renaming the tenant,
 					// we don't need to report anything. The internal metadata update is (at least partially) caused
@@ -1869,7 +1868,9 @@ struct RestoreClusterImpl {
 				} else {
 					wait(self->runRestoreDataClusterTransaction([self = self,
 					                                             managementTenant = managementTenant,
+					                                             tenantEntry = tenantEntry,
 					                                             tenantName = tenantName](Reference<ITransaction> tr) {
+						ASSERT_GE(managementTenant.configurationSequenceNum, tenantEntry.configurationSequenceNum);
 						TenantMapEntry updatedEntry = managementTenant.toTenantMapEntry();
 						updatedEntry.tenantName = tenantName;
 						return updateTenantConfiguration(self, tr, managementTenant.id, updatedEntry);

--- a/fdbserver/include/fdbserver/workloads/MetaclusterConsistency.actor.h
+++ b/fdbserver/include/fdbserver/workloads/MetaclusterConsistency.actor.h
@@ -226,10 +226,12 @@ private:
 			ASSERT(tenantMapItr != managementData.tenantData.tenantMap.end());
 			MetaclusterTenantMapEntry const& metaclusterEntry = tenantMapItr->second;
 			ASSERT_EQ(entry.id, metaclusterEntry.id);
-			ASSERT(entry.tenantName == metaclusterEntry.tenantName);
 
 			if (!self->allowPartialMetaclusterOperations) {
 				ASSERT_EQ(metaclusterEntry.tenantState, MetaclusterAPI::TenantState::READY);
+				ASSERT(entry.tenantName == metaclusterEntry.tenantName);
+			} else if (entry.tenantName != metaclusterEntry.tenantName) {
+				ASSERT(entry.tenantName == metaclusterEntry.renameDestination);
 			}
 			if (metaclusterEntry.tenantState != MetaclusterAPI::TenantState::UPDATING_CONFIGURATION &&
 			    metaclusterEntry.tenantState != MetaclusterAPI::TenantState::REMOVING) {

--- a/fdbserver/workloads/TenantManagementConcurrencyWorkload.actor.cpp
+++ b/fdbserver/workloads/TenantManagementConcurrencyWorkload.actor.cpp
@@ -214,7 +214,8 @@ struct TenantManagementConcurrencyWorkload : TestWorkload {
 			    .error(e)
 			    .detail("TenantName", entry.tenantName)
 			    .detail("TenantGroup", entry.tenantGroup);
-			if (e.code() == error_code_metacluster_no_capacity || e.code() == error_code_cluster_removed) {
+			if (e.code() == error_code_metacluster_no_capacity || e.code() == error_code_cluster_removed ||
+			    e.code() == error_code_cluster_restoring) {
 				ASSERT(self->useMetacluster && !self->createMetacluster);
 			} else if (e.code() == error_code_tenant_removed) {
 				ASSERT(self->useMetacluster);
@@ -254,7 +255,7 @@ struct TenantManagementConcurrencyWorkload : TestWorkload {
 			TraceEvent(SevDebug, "TenantManagementConcurrencyDeleteTenantError", debugId)
 			    .error(e)
 			    .detail("TenantName", tenant);
-			if (e.code() == error_code_cluster_removed) {
+			if (e.code() == error_code_cluster_removed || e.code() == error_code_cluster_restoring) {
 				ASSERT(self->useMetacluster && !self->createMetacluster);
 			} else if (e.code() != error_code_tenant_not_found) {
 				TraceEvent(SevError, "TenantManagementConcurrencyDeleteTenantFailure", debugId)
@@ -326,7 +327,7 @@ struct TenantManagementConcurrencyWorkload : TestWorkload {
 			    .error(e)
 			    .detail("TenantName", tenant)
 			    .detail("TenantGroup", tenantGroup);
-			if (e.code() == error_code_cluster_removed) {
+			if (e.code() == error_code_cluster_removed || e.code() == error_code_cluster_restoring) {
 				ASSERT(self->useMetacluster && !self->createMetacluster);
 			} else if (e.code() == error_code_cluster_no_capacity ||
 			           e.code() == error_code_invalid_tenant_configuration) {
@@ -371,7 +372,7 @@ struct TenantManagementConcurrencyWorkload : TestWorkload {
 			    .error(e)
 			    .detail("OldTenantName", oldTenant)
 			    .detail("NewTenantName", newTenant);
-			if (e.code() == error_code_cluster_removed) {
+			if (e.code() == error_code_cluster_removed || e.code() == error_code_cluster_restoring) {
 				ASSERT(self->useMetacluster && !self->createMetacluster);
 			} else if (e.code() == error_code_invalid_tenant_state || e.code() == error_code_tenant_removed ||
 			           e.code() == error_code_cluster_no_capacity) {


### PR DESCRIPTION
This adds the restore operation to the metacluster management concurrency workload and fixes various bugs that it found.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
