### PR TITLE
Metacluster tenant lock support

### DIFF
--- a/fdbcli/tests/fdbcli_tests.py
+++ b/fdbcli/tests/fdbcli_tests.py
@@ -1009,58 +1009,61 @@ def tenant_list(logger):
     assert output == "ERROR: unrecognized tenant state(s) `14z'."
 
 
-
 @enable_logging()
 def tenant_lock(logger):
-    logger.debug('Create tenant')
-    setup_tenants(['tenant'])
+    logger.debug("Create tenant")
+    setup_tenants(["tenant"])
 
-    logger.debug('Write test key')
-    run_fdbcli_command('usetenant tenant; writemode on; set foo bar')
-    logger.debug('Lock tenant in read-only mode')
-    output = run_fdbcli_command('tenant lock tenant w')
+    logger.debug("Write test key")
+    run_fdbcli_command("usetenant tenant; writemode on; set foo bar")
+    logger.debug("Lock tenant in read-only mode")
+    output = run_fdbcli_command("tenant lock tenant w")
     output = output.strip()
-    logger.debug('output: {}'.format(output))
+    logger.debug("output: {}".format(output))
     start_string = "Locked tenant `tenant' with UID `"
     assert output.startswith(start_string)
     assert output.endswith("'")
-    uid_str = output[len(start_string):-1]
+    uid_str = output[len(start_string) : -1]
     assert len(uid_str) == 32
 
-    logger.debug('Verify tenant is readable')
-    output = run_fdbcli_command('usetenant tenant; get foo').strip()
-    logger.debug('output: {}'.format(output))
-    lines = output.split('\n')
+    logger.debug("Verify tenant is readable")
+    output = run_fdbcli_command("usetenant tenant; get foo").strip()
+    logger.debug("output: {}".format(output))
+    lines = output.split("\n")
     assert lines[-1] == "`foo' is `bar'"
 
-    logger.debug('Verify tenant is NOT writeable')
-    output = run_fdbcli_command_and_get_error('usetenant tenant; writemode on; set foo bar2').strip()
-    logger.debug('output: {}'.format(output))
-    assert output == 'ERROR: Tenant is locked (2144)'
+    logger.debug("Verify tenant is NOT writeable")
+    output = run_fdbcli_command_and_get_error(
+        "usetenant tenant; writemode on; set foo bar2"
+    ).strip()
+    logger.debug("output: {}".format(output))
+    assert output == "ERROR: Tenant is locked (2144)"
 
     logger.debug('Unlock tenant with UID "{}"'.format(uid_str))
-    output = run_fdbcli_command('tenant unlock tenant {}'.format(uid_str))
-    logger.debug('output: {}'.format(output.strip()))
+    output = run_fdbcli_command("tenant unlock tenant {}".format(uid_str))
+    logger.debug("output: {}".format(output.strip()))
     assert output.strip() == "Unlocked tenant `tenant'"
 
-    logger.debug('Lock tenant in rw mode')
-    output = run_fdbcli_command('tenant lock tenant rw {}'.format(uid_str)).strip()
-    logger.debug('output: {}'.format(output))
+    logger.debug("Lock tenant in rw mode")
+    output = run_fdbcli_command("tenant lock tenant rw {}".format(uid_str)).strip()
+    logger.debug("output: {}".format(output))
     assert output == "Locked tenant `tenant' with UID `{}'".format(uid_str)
 
-    logger.debug('Verify tenant is NOT readable')
-    output = run_fdbcli_command_and_get_error('usetenant tenant; get foo').strip()
-    logger.debug('output: {}'.format(output))
-    assert output == 'ERROR: Tenant is locked (2144)'
+    logger.debug("Verify tenant is NOT readable")
+    output = run_fdbcli_command_and_get_error("usetenant tenant; get foo").strip()
+    logger.debug("output: {}".format(output))
+    assert output == "ERROR: Tenant is locked (2144)"
 
-    logger.debug('Verify tenant is NOT writeable')
-    output = run_fdbcli_command_and_get_error('usetenant tenant; writemode on; set foo bar2').strip()
-    logger.debug('output: {}'.format(output))
-    assert output == 'ERROR: Tenant is locked (2144)'
+    logger.debug("Verify tenant is NOT writeable")
+    output = run_fdbcli_command_and_get_error(
+        "usetenant tenant; writemode on; set foo bar2"
+    ).strip()
+    logger.debug("output: {}".format(output))
+    assert output == "ERROR: Tenant is locked (2144)"
 
-    logger.debug('Unlock tenant')
-    output = run_fdbcli_command('tenant unlock tenant {}'.format(uid_str))
-    logger.debug('output: {}'.format(output.strip()))
+    logger.debug("Unlock tenant")
+    output = run_fdbcli_command("tenant unlock tenant {}".format(uid_str))
+    logger.debug("output: {}".format(output.strip()))
     assert output.strip() == "Unlocked tenant `tenant'"
 
 
@@ -1070,9 +1073,10 @@ def tenant_get(logger):
 
     output = run_fdbcli_command("tenant get tenant")
     lines = output.split("\n")
-    assert len(lines) == 2
+    assert len(lines) == 3
     assert lines[0].strip().startswith("id: ")
     assert lines[1].strip().startswith("prefix: ")
+    assert lines[2].strip() == "lock state: unlocked"
 
     output = run_fdbcli_command("tenant get tenant JSON")
     json_output = json.loads(output, strict=False)
@@ -1089,13 +1093,16 @@ def tenant_get(logger):
     assert len(json_output["tenant"]["prefix"]) == 2
     assert "base64" in json_output["tenant"]["prefix"]
     assert "printable" in json_output["tenant"]["prefix"]
+    assert "lock_state" in json_output["tenant"]
+    assert json_output["tenant"]["lock_state"] == "unlocked"
 
     output = run_fdbcli_command("tenant get tenant2")
     lines = output.split("\n")
-    assert len(lines) == 3
+    assert len(lines) == 4
     assert lines[0].strip().startswith("id: ")
     assert lines[1].strip().startswith("prefix: ")
-    assert lines[2].strip() == "tenant group: tenant_group2"
+    assert lines[2].strip() == "lock state: unlocked"
+    assert lines[3].strip() == "tenant group: tenant_group2"
 
     output = run_fdbcli_command("tenant get tenant2 JSON")
     json_output = json.loads(output, strict=False)
@@ -1109,6 +1116,8 @@ def tenant_get(logger):
     assert "base64" in json_output["tenant"]["name"]
     assert "printable" in json_output["tenant"]["name"]
     assert "prefix" in json_output["tenant"]
+    assert "lock_state" in json_output["tenant"]
+    assert json_output["tenant"]["lock_state"] == "unlocked"
     assert "tenant_group" in json_output["tenant"]
     assert len(json_output["tenant"]["tenant_group"]) == 2
     assert "base64" in json_output["tenant"]["tenant_group"]
@@ -1129,8 +1138,8 @@ def tenant_configure(logger):
 
     output = run_fdbcli_command("tenant get tenant")
     lines = output.split("\n")
-    assert len(lines) == 3
-    assert lines[2].strip() == "tenant group: tenant_group1"
+    assert len(lines) == 4
+    assert lines[3].strip() == "tenant group: tenant_group1"
 
     output = run_fdbcli_command("tenant configure tenant unset tenant_group")
     assert output == "The configuration for tenant `tenant' has been updated"
@@ -1142,7 +1151,7 @@ def tenant_configure(logger):
 
     output = run_fdbcli_command("tenant get tenant")
     lines = output.split("\n")
-    assert len(lines) == 2
+    assert len(lines) == 3
 
     output = run_fdbcli_command_and_get_error(
         "tenant configure tenant tenant_group=tenant_group1 tenant_group=tenant_group2"

--- a/fdbclient/Metacluster.cpp
+++ b/fdbclient/Metacluster.cpp
@@ -152,6 +152,7 @@ TenantMapEntry MetaclusterTenantMapEntry::toTenantMapEntry() const {
 	TenantMapEntry entry;
 	entry.tenantName = tenantName;
 	entry.tenantLockState = tenantLockState;
+	entry.tenantLockId = tenantLockId;
 	entry.tenantGroup = tenantGroup;
 	entry.configurationSequenceNum = configurationSequenceNum;
 	if (id >= 0) {
@@ -165,6 +166,7 @@ MetaclusterTenantMapEntry MetaclusterTenantMapEntry::fromTenantMapEntry(TenantMa
 	MetaclusterTenantMapEntry entry;
 	entry.tenantName = source.tenantName;
 	entry.tenantLockState = source.tenantLockState;
+	entry.tenantLockId = source.tenantLockId;
 	entry.tenantGroup = source.tenantGroup;
 	entry.configurationSequenceNum = source.configurationSequenceNum;
 	if (source.id >= 0) {
@@ -195,6 +197,10 @@ std::string MetaclusterTenantMapEntry::toJson() const {
 	}
 
 	tenantEntry["lock_state"] = TenantAPI::tenantLockStateToString(tenantLockState);
+	if (tenantLockId.present()) {
+		tenantEntry["lock_id"] = tenantLockId.get().toString();
+	}
+
 	if (tenantState == MetaclusterAPI::TenantState::RENAMING) {
 		ASSERT(renameDestination.present());
 		tenantEntry["rename_destination"] = binaryToJson(renameDestination.get());
@@ -206,11 +212,13 @@ std::string MetaclusterTenantMapEntry::toJson() const {
 }
 
 bool MetaclusterTenantMapEntry::matchesConfiguration(MetaclusterTenantMapEntry const& other) const {
-	return tenantGroup == other.tenantGroup;
+	return tenantGroup == other.tenantGroup && tenantLockState == other.tenantLockState &&
+	       tenantLockId == other.tenantLockId;
 }
 
 bool MetaclusterTenantMapEntry::matchesConfiguration(TenantMapEntry const& other) const {
-	return tenantGroup == other.tenantGroup;
+	return tenantGroup == other.tenantGroup && tenantLockState == other.tenantLockState &&
+	       tenantLockId == other.tenantLockId;
 }
 
 void MetaclusterTenantMapEntry::configure(Standalone<StringRef> parameter, Optional<Value> value) {
@@ -226,9 +234,10 @@ void MetaclusterTenantMapEntry::configure(Standalone<StringRef> parameter, Optio
 
 bool MetaclusterTenantMapEntry::operator==(MetaclusterTenantMapEntry const& other) const {
 	return id == other.id && tenantName == other.tenantName && tenantState == other.tenantState &&
-	       tenantLockState == other.tenantLockState && tenantGroup == other.tenantGroup &&
-	       assignedCluster == other.assignedCluster && configurationSequenceNum == other.configurationSequenceNum &&
-	       renameDestination == other.renameDestination && error == other.error;
+	       tenantLockState == other.tenantLockState && tenantLockId == other.tenantLockId &&
+	       tenantGroup == other.tenantGroup && assignedCluster == other.assignedCluster &&
+	       configurationSequenceNum == other.configurationSequenceNum && renameDestination == other.renameDestination &&
+	       error == other.error;
 }
 
 bool MetaclusterTenantMapEntry::operator!=(MetaclusterTenantMapEntry const& other) const {

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -6691,7 +6691,8 @@ ACTOR static Future<Void> tryCommit(Reference<TransactionState> trState, CommitT
 			    e.code() != error_code_batch_transaction_throttled && e.code() != error_code_tag_throttled &&
 			    e.code() != error_code_process_behind && e.code() != error_code_future_version &&
 			    e.code() != error_code_tenant_not_found && e.code() != error_code_illegal_tenant_access &&
-			    e.code() != error_code_proxy_tag_throttled && e.code() != error_code_storage_quota_exceeded) {
+			    e.code() != error_code_proxy_tag_throttled && e.code() != error_code_storage_quota_exceeded &&
+			    e.code() != error_code_tenant_locked) {
 				TraceEvent(SevError, "TryCommitError").error(e);
 			}
 			if (trState->trLogInfo)

--- a/fdbclient/Tenant.cpp
+++ b/fdbclient/Tenant.cpp
@@ -147,7 +147,8 @@ std::string TenantMapEntry::toJson() const {
 }
 
 bool TenantMapEntry::matchesConfiguration(TenantMapEntry const& other) const {
-	return tenantGroup == other.tenantGroup;
+	return tenantGroup == other.tenantGroup && tenantLockState == other.tenantLockState &&
+	       tenantLockId == other.tenantLockId;
 }
 
 void TenantMapEntry::configure(Standalone<StringRef> parameter, Optional<Value> value) {

--- a/fdbclient/include/fdbclient/Metacluster.h
+++ b/fdbclient/include/fdbclient/Metacluster.h
@@ -140,6 +140,7 @@ struct MetaclusterTenantMapEntry {
 	TenantName tenantName;
 	MetaclusterAPI::TenantState tenantState = MetaclusterAPI::TenantState::READY;
 	TenantAPI::TenantLockState tenantLockState = TenantAPI::TenantLockState::UNLOCKED;
+	Optional<UID> tenantLockId;
 	Optional<TenantGroupName> tenantGroup;
 	ClusterName assignedCluster;
 	int64_t configurationSequenceNum = 0;
@@ -180,6 +181,7 @@ struct MetaclusterTenantMapEntry {
 		           tenantName,
 		           tenantState,
 		           tenantLockState,
+		           tenantLockId,
 		           tenantGroup,
 		           assignedCluster,
 		           configurationSequenceNum,

--- a/fdbclient/include/fdbclient/Tenant.h
+++ b/fdbclient/include/fdbclient/Tenant.h
@@ -59,10 +59,14 @@ struct TenantMapEntryTxnStateStore {
 	int64_t id = -1;
 	TenantName tenantName;
 	TenantAPI::TenantLockState tenantLockState = TenantAPI::TenantLockState::UNLOCKED;
+	Optional<UID> tenantLockId;
 
 	TenantMapEntryTxnStateStore() {}
-	TenantMapEntryTxnStateStore(int64_t id, TenantName tenantName, TenantAPI::TenantLockState tenantLockState)
-	  : id(id), tenantName(tenantName), tenantLockState(tenantLockState) {}
+	TenantMapEntryTxnStateStore(int64_t id,
+	                            TenantName tenantName,
+	                            TenantAPI::TenantLockState tenantLockState,
+	                            Optional<UID> tenantLockId)
+	  : id(id), tenantName(tenantName), tenantLockState(tenantLockState), tenantLockId(tenantLockId) {}
 
 	Value encode() const { return ObjectWriter::toValue(*this, IncludeVersion()); }
 	static TenantMapEntryTxnStateStore decode(ValueRef const& value) {
@@ -71,7 +75,7 @@ struct TenantMapEntryTxnStateStore {
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, id, tenantLockState, tenantName);
+		serializer(ar, id, tenantLockState, tenantLockId, tenantName);
 	}
 };
 
@@ -102,7 +106,7 @@ struct TenantMapEntry {
 	}
 
 	TenantMapEntryTxnStateStore toTxnStateStoreEntry() const {
-		return TenantMapEntryTxnStateStore(id, tenantName, tenantLockState);
+		return TenantMapEntryTxnStateStore(id, tenantName, tenantLockState, tenantLockId);
 	}
 
 	bool operator==(TenantMapEntry const& other) const;

--- a/fdbclient/include/fdbclient/TenantManagement.actor.h
+++ b/fdbclient/include/fdbclient/TenantManagement.actor.h
@@ -487,35 +487,39 @@ Future<Void> configureTenantTransaction(Transaction tr,
 		}
 	}
 
+	ASSERT_EQ(updatedTenantEntry.tenantLockId.present(),
+	          updatedTenantEntry.tenantLockState != TenantLockState::UNLOCKED);
+
 	return Void();
 }
 
+template <class TenantMapEntryT>
+bool checkLockState(TenantMapEntryT entry, TenantLockState desiredLockState, UID lockId) {
+	if (entry.tenantLockId == lockId && entry.tenantLockState == desiredLockState) {
+		return true;
+	}
+
+	if (entry.tenantLockId.present() && entry.tenantLockId.get() != lockId) {
+		throw tenant_locked();
+	}
+
+	return false;
+}
+
 ACTOR template <class Transaction>
-Future<Void> changeLockState(Transaction* tr, int64_t tenant, TenantLockState desiredLockState, UID lockID) {
-	state TenantMapEntry entry;
-	tr->setOption(FDBTransactionOptions::RAW_ACCESS);
-	tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
-	tr->setOption(FDBTransactionOptions::LOCK_AWARE);
-	tr->setOption(FDBTransactionOptions::READ_LOCK_AWARE);
-	wait(store(entry, TenantAPI::getTenantTransaction(tr, tenant)));
-	auto currLockID = entry.tenantLockId;
-	if (currLockID.present()) {
-		if (currLockID.get() != lockID) {
-			throw tenant_locked();
-		} else if (desiredLockState != TenantLockState::UNLOCKED) {
-			// already executed -- this can happen if we're in a retry loop
-			return Void();
-		}
-		// otherwise we can now continue with unlock
+Future<Void> changeLockState(Transaction tr, int64_t tenant, TenantLockState desiredLockState, UID lockId) {
+	state Future<Void> tenantModeCheck = TenantAPI::checkTenantMode(tr, ClusterType::STANDALONE);
+	state TenantMapEntry entry = wait(TenantAPI::getTenantTransaction(tr, tenant));
+
+	wait(tenantModeCheck);
+
+	if (!checkLockState(entry, desiredLockState, lockId)) {
+		TenantMapEntry newState = entry;
+		newState.tenantLockState = desiredLockState;
+		newState.tenantLockId = (desiredLockState == TenantLockState::UNLOCKED) ? Optional<UID>() : lockId;
+		wait(configureTenantTransaction(tr, entry, newState));
 	}
-	TenantMapEntry newState = entry;
-	newState.tenantLockState = desiredLockState;
-	if (desiredLockState == TenantLockState::UNLOCKED) {
-		newState.tenantLockId = {};
-	} else {
-		newState.tenantLockId = lockID;
-	}
-	wait(configureTenantTransaction(tr, entry, newState));
+
 	return Void();
 }
 

--- a/fdbserver/include/fdbserver/workloads/MetaclusterConsistency.actor.h
+++ b/fdbserver/include/fdbserver/workloads/MetaclusterConsistency.actor.h
@@ -240,6 +240,8 @@ private:
 
 			if (entry.configurationSequenceNum == metaclusterEntry.configurationSequenceNum) {
 				ASSERT(entry.tenantGroup == metaclusterEntry.tenantGroup);
+				ASSERT_EQ(entry.tenantLockState, metaclusterEntry.tenantLockState);
+				ASSERT(entry.tenantLockId == metaclusterEntry.tenantLockId);
 			}
 		}
 

--- a/fdbserver/include/fdbserver/workloads/TenantConsistency.actor.h
+++ b/fdbserver/include/fdbserver/workloads/TenantConsistency.actor.h
@@ -76,6 +76,8 @@ private:
 			} else {
 				ASSERT(!tenantsInTenantGroupIndex.count(tenantId));
 			}
+			ASSERT_NE(tenantMapEntry.tenantLockState == TenantAPI::TenantLockState::UNLOCKED,
+			          tenantMapEntry.tenantLockId.present());
 		}
 	}
 

--- a/fdbserver/workloads/TenantLock.actor.cpp
+++ b/fdbserver/workloads/TenantLock.actor.cpp
@@ -85,9 +85,9 @@ struct TenantLock : TestWorkload {
 	                                          UID lockID) {
 		state Reference<Tenant> tenant = makeReference<Tenant>(db, name);
 		state ReadYourWritesTransaction tr(db);
-		tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 		loop {
 			try {
+				tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 				wait(tenant->ready());
 				wait(TenantAPI::changeLockState(&tr, tenant->id(), desiredState, lockID));
 				wait(tr.commit());

--- a/fdbserver/workloads/TenantManagementConcurrencyWorkload.actor.cpp
+++ b/fdbserver/workloads/TenantManagementConcurrencyWorkload.actor.cpp
@@ -25,6 +25,7 @@
 #include "fdbclient/GenericManagementAPI.actor.h"
 #include "fdbclient/MetaclusterManagement.actor.h"
 #include "fdbclient/ReadYourWrites.h"
+#include "fdbclient/Tenant.h"
 #include "fdbclient/TenantManagement.actor.h"
 #include "fdbclient/ThreadSafeTransaction.h"
 #include "fdbrpc/simulator.h"
@@ -387,6 +388,89 @@ struct TenantManagementConcurrencyWorkload : TestWorkload {
 		}
 	}
 
+	ACTOR static Future<Void> changeLockStateImpl(TenantManagementConcurrencyWorkload* self,
+	                                              TenantName tenant,
+	                                              TenantAPI::TenantLockState lockState,
+	                                              bool useExistingId) {
+		state UID lockId;
+		if (self->useMetacluster) {
+			MetaclusterTenantMapEntry entry = wait(MetaclusterAPI::getTenant(self->mvDb, tenant));
+			if (useExistingId && entry.tenantLockId.present()) {
+				lockId = entry.tenantLockId.get();
+			} else {
+				lockId = deterministicRandom()->randomUniqueID();
+			}
+
+			wait(MetaclusterAPI::changeTenantLockState(self->mvDb, tenant, lockState, lockId));
+		} else {
+			state Reference<ReadYourWritesTransaction> tr = self->dataDb->createTransaction();
+			loop {
+				try {
+					tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+					TenantMapEntry entry = wait(TenantAPI::getTenantTransaction(tr, tenant));
+					if (useExistingId && entry.tenantLockId.present()) {
+						lockId = entry.tenantLockId.get();
+					} else {
+						lockId = deterministicRandom()->randomUniqueID();
+					}
+
+					wait(TenantAPI::changeLockState(tr, entry.id, lockState, lockId));
+					wait(buggifiedCommit(tr, BUGGIFY_WITH_PROB(0.1)));
+					break;
+				} catch (Error& e) {
+					wait(tr->onError(e));
+				}
+			}
+		}
+
+		return Void();
+	}
+
+	ACTOR static Future<Void> changeLockState(TenantManagementConcurrencyWorkload* self) {
+		state TenantName tenant = self->chooseTenantName();
+		state TenantAPI::TenantLockState lockState = (TenantAPI::TenantLockState)deterministicRandom()->randomInt(0, 3);
+		state bool useExistingId = deterministicRandom()->coinflip();
+		state UID debugId = deterministicRandom()->randomUniqueID();
+
+		try {
+			loop {
+				TraceEvent(SevDebug, "TenantManagementConcurrencyChangingTenantLockState", debugId)
+				    .detail("TenantName", tenant)
+				    .detail("TenantLockState", TenantAPI::tenantLockStateToString(lockState))
+				    .detail("UseExistingId", useExistingId);
+
+				Optional<Void> result = wait(timeout(changeLockStateImpl(self, tenant, lockState, useExistingId), 30));
+
+				if (result.present()) {
+					TraceEvent(SevDebug, "TenantManagementConcurrencyChangedTenantLockState", debugId)
+					    .detail("TenantName", tenant)
+					    .detail("TenantLockState", TenantAPI::tenantLockStateToString(lockState))
+					    .detail("UseExistingId", useExistingId);
+					break;
+				}
+			}
+
+			return Void();
+		} catch (Error& e) {
+			TraceEvent(SevDebug, "TenantManagementConcurrencyChangeLockStateError", debugId)
+			    .error(e)
+			    .detail("TenantName", tenant)
+			    .detail("TenantLockState", TenantAPI::tenantLockStateToString(lockState))
+			    .detail("UseExistingId", useExistingId);
+			if (e.code() == error_code_cluster_removed) {
+				ASSERT(self->useMetacluster && !self->createMetacluster);
+			} else if (e.code() != error_code_tenant_not_found && e.code() != error_code_tenant_locked) {
+				TraceEvent(SevError, "TenantManagementConcurrencyChangeLockStateFailure", debugId)
+				    .error(e)
+				    .detail("TenantName", tenant)
+				    .detail("TenantLockState", TenantAPI::tenantLockStateToString(lockState))
+				    .detail("UseExistingId", useExistingId);
+				ASSERT(false);
+			}
+			return Void();
+		}
+	}
+
 	Future<Void> start(Database const& cx) override { return _start(cx, this); }
 	ACTOR static Future<Void> _start(Database cx, TenantManagementConcurrencyWorkload* self) {
 		state double start = now();
@@ -402,6 +486,8 @@ struct TenantManagementConcurrencyWorkload : TestWorkload {
 				wait(configureTenant(self));
 			} else if (operation == 3) {
 				wait(renameTenant(self));
+			} else if (operation == 4) {
+				wait(changeLockState(self));
 			}
 		}
 


### PR DESCRIPTION
Adds support at the metacluster level for tenant locking. Also adds some tenant lock testing to a couple tenant workloads.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
