### PR TITLE
[Release 7.2] Enhance fdbbackup query command to estimate data processing from a specific snapshot to a target version

### DIFF
--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -1046,7 +1046,7 @@ static void printBackupUsage(bool devhelp) {
 	       "the backup.\n");
 	printf("  -qrv --query-restore-version VERSION\n"
 	       "                 For query operations, set target version for restoring a backup. Set -1 for maximum\n"
-	       "                 restorable version (default) and -2 for minimum restorable version.\n");
+	       "                 restorable version (default) and -3 for minimum restorable version.\n");
 	printf(
 	    "  --query-restore-timestamp DATETIME\n"
 	    "                 For query operations, instead of a numeric version, use this to specify a timestamp in %s\n",
@@ -2736,9 +2736,10 @@ ACTOR Future<Void> queryBackup(const char* name,
 				    result,
 				    errorMessage = format("the backup for the specified key ranges is not restorable to any version"));
 			}
+			TraceEvent("BackupQueryResolveMaxRestoreVersion").detail("Version", restoreVersion);
 		}
 
-		if (restoreVersion < 0 && restoreVersion != latestVersion) {
+		if (restoreVersion < 0 && restoreVersion != earliestVersion) {
 			reportBackupQueryError(operationId,
 			                       result,
 			                       errorMessage =

--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -2826,7 +2826,8 @@ ACTOR Future<Void> queryBackup(const char* name,
 			}
 
 			// We only need to know all the mutation logs from `snapshotVersion` to `restoreVersion`.
-			wait(store(fileSet, bc->getRestoreSet(restoreVersion, cx, keyRangesFilter, /*logOnly=*/true, snapshotVersion)));
+			wait(store(fileSet,
+			           bc->getRestoreSet(restoreVersion, cx, keyRangesFilter, /*logOnly=*/true, snapshotVersion)));
 		} else {
 			// When a snapshot version is not specified, we use the latest snapshot to restore to the `restoreVersion`.
 			wait(store(fileSet, bc->getRestoreSet(restoreVersion, cx, keyRangesFilter)));

--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -2746,6 +2746,10 @@ ACTOR Future<Void> queryBackup(const char* name,
 		restoreVersion = v;
 	}
 
+	state int64_t totalRangeFilesSize = 0;
+	state int64_t totalLogFilesSize = 0;
+	state JsonBuilderArray rangeFilesJson;
+	state JsonBuilderArray logFilesJson;
 	try {
 		state Reference<IBackupContainer> bc = openBackupContainer(name, destinationContainer, proxy, {});
 		BackupDescription desc = wait(bc->describeBackup());
@@ -2770,10 +2774,6 @@ ACTOR Future<Void> queryBackup(const char* name,
 			return Void();
 		}
 
-		state int64_t totalRangeFilesSize = 0;
-		state int64_t totalLogFilesSize = 0;
-		state JsonBuilderArray rangeFilesJson;
-		state JsonBuilderArray logFilesJson;
 		if (snapshotVersion != invalidVersion) {
 			Optional<RestorableFileSet> fileSet = wait(bc->getRestoreSet(snapshotVersion, keyRangesFilter));
 			if (fileSet.present()) {

--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -2781,7 +2781,7 @@ ACTOR Future<Void> queryBackup(const char* name,
 		if (snapshotVersion != invalidVersion) {
 			// When a snapshot version is specified, we will first get a restore set using the latest snapshot file to
 			// restore to the snapshot version. After snapshot version, we will only use mutation logs to restore.
-			wait(store(fileSet, bc->getRestoreSet(snapshotVersion, keyRangesFilter)));
+			wait(store(fileSet, bc->getRestoreSet(snapshotVersion, cx, keyRangesFilter)));
 			if (fileSet.present()) {
 				result["snapshot_version"] = fileSet.get().targetVersion;
 				for (const auto& rangeFile : fileSet.get().ranges) {
@@ -2826,10 +2826,10 @@ ACTOR Future<Void> queryBackup(const char* name,
 			}
 
 			// We only need to know all the mutation logs from `snapshotVersion` to `restoreVersion`.
-			wait(store(fileSet, bc->getRestoreSet(restoreVersion, keyRangesFilter, /*logOnly=*/true, snapshotVersion)));
+			wait(store(fileSet, bc->getRestoreSet(restoreVersion, cx, keyRangesFilter, /*logOnly=*/true, snapshotVersion)));
 		} else {
 			// When a snapshot version is not specified, we use the latest snapshot to restore to the `restoreVersion`.
-			wait(store(fileSet, bc->getRestoreSet(restoreVersion, keyRangesFilter)));
+			wait(store(fileSet, bc->getRestoreSet(restoreVersion, cx, keyRangesFilter)));
 		}
 
 		if (fileSet.present()) {

--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -2762,7 +2762,7 @@ ACTOR Future<Void> queryBackup(const char* name,
 			Optional<RestorableFileSet> fileSet = wait(bc->getRestoreSet(snapshotVersion, keyRangesFilter));
 			if (fileSet.present()) {
 				result["snapshot_version"] = fileSet.get().targetVersion;
-				result["restore_version"] = fileSet.get().targetVersion;  // In case there isn't any more log files.
+				result["restore_version"] = fileSet.get().targetVersion; // In case there isn't any more log files.
 				for (const auto& rangeFile : fileSet.get().ranges) {
 					JsonBuilderObject object;
 					object["file_name"] = rangeFile.fileName;
@@ -2787,7 +2787,7 @@ ACTOR Future<Void> queryBackup(const char* name,
 				snapshotVersion = fileSet.get().targetVersion;
 
 				TraceEvent("BackupQueryReceivedRestorableFilesSetFromSnapshot")
-					.detail("SnapshotVersion", snapshotVersion)
+				    .detail("SnapshotVersion", snapshotVersion)
 				    .detail("DestinationContainer", destinationContainer)
 				    .detail("KeyRangesFilter", printable(keyRangesFilter))
 				    .detail("ActualRestoreVersion", fileSet.get().targetVersion)

--- a/fdbclient/BackupContainerFileSystem.actor.cpp
+++ b/fdbclient/BackupContainerFileSystem.actor.cpp
@@ -928,6 +928,9 @@ public:
 		// Find the most recent keyrange snapshot through which we can restore filtered key ranges into targetVersion.
 		state std::vector<KeyspaceSnapshotFile> snapshots = wait(bc->listKeyspaceSnapshots());
 		state int i = snapshots.size() - 1;
+		if (targetVersion == earliestVersion) {
+			i = 0;
+		}
 		for (; i >= 0; i--) {
 			// The smallest version of filtered range files >= snapshot beginVersion > targetVersion
 			if (targetVersion >= 0 && snapshots[i].beginVersion > targetVersion) {
@@ -968,7 +971,7 @@ public:
 				}
 			}
 			// 'latestVersion' represents using the minimum restorable version in a snapshot.
-			restorable.targetVersion = targetVersion == latestVersion ? maxKeyRangeVersion : targetVersion;
+			restorable.targetVersion = targetVersion == earliestVersion ? maxKeyRangeVersion : targetVersion;
 			// Any version < maxKeyRangeVersion is not restorable.
 			if (restorable.targetVersion < maxKeyRangeVersion)
 				continue;

--- a/fdbclient/BackupContainerFileSystem.actor.cpp
+++ b/fdbclient/BackupContainerFileSystem.actor.cpp
@@ -915,6 +915,7 @@ public:
 
 		if (logsOnly) {
 			state RestorableFileSet restorableSet;
+			restorableSet.targetVersion = targetVersion;
 			state std::vector<LogFile> logFiles;
 			Version begin = beginVersion == invalidVersion ? 0 : beginVersion;
 			wait(store(logFiles, bc->listLogFiles(begin, targetVersion, false)));
@@ -928,9 +929,6 @@ public:
 		// Find the most recent keyrange snapshot through which we can restore filtered key ranges into targetVersion.
 		state std::vector<KeyspaceSnapshotFile> snapshots = wait(bc->listKeyspaceSnapshots());
 		state int i = snapshots.size() - 1;
-		if (targetVersion == earliestVersion) {
-			i = 0;
-		}
 		for (; i >= 0; i--) {
 			// The smallest version of filtered range files >= snapshot beginVersion > targetVersion
 			if (targetVersion >= 0 && snapshots[i].beginVersion > targetVersion) {
@@ -971,7 +969,7 @@ public:
 				}
 			}
 			// 'latestVersion' represents using the minimum restorable version in a snapshot.
-			restorable.targetVersion = targetVersion == earliestVersion ? maxKeyRangeVersion : targetVersion;
+			restorable.targetVersion = targetVersion == latestVersion ? maxKeyRangeVersion : targetVersion;
 			// Any version < maxKeyRangeVersion is not restorable.
 			if (restorable.targetVersion < maxKeyRangeVersion)
 				continue;

--- a/fdbclient/include/fdbclient/BackupContainer.h
+++ b/fdbclient/include/fdbclient/BackupContainer.h
@@ -288,7 +288,7 @@ public:
 	                                            Version end = std::numeric_limits<Version>::max()) = 0;
 
 	// Get exactly the files necessary to restore the key space filtered by the specified key ranges to targetVersion.
-	// If targetVersion is 'earliestVersion', use the minimum restorable version in a snapshot.
+	// If targetVersion is 'latestVersion', use the minimum restorable version in a snapshot.
 	// If logsOnly is set, only use log files in [beginVersion, targetVervions) in restore set.
 	// Returns non-present if restoring to the given version is not possible.
 	virtual Future<Optional<RestorableFileSet>> getRestoreSet(Version targetVersion,

--- a/fdbclient/include/fdbclient/BackupContainer.h
+++ b/fdbclient/include/fdbclient/BackupContainer.h
@@ -288,7 +288,7 @@ public:
 	                                            Version end = std::numeric_limits<Version>::max()) = 0;
 
 	// Get exactly the files necessary to restore the key space filtered by the specified key ranges to targetVersion.
-	// If targetVersion is 'latestVersion', use the minimum restorable version in a snapshot.
+	// If targetVersion is 'earliestVersion', use the minimum restorable version in a snapshot.
 	// If logsOnly is set, only use log files in [beginVersion, targetVervions) in restore set.
 	// Returns non-present if restoring to the given version is not possible.
 	virtual Future<Optional<RestorableFileSet>> getRestoreSet(Version targetVersion,

--- a/fdbclient/include/fdbclient/FDBTypes.h
+++ b/fdbclient/include/fdbclient/FDBTypes.h
@@ -543,7 +543,12 @@ struct hash<KeyRange> {
 };
 } // namespace std
 
-enum { invalidVersion = -1, latestVersion = -2, MAX_VERSION = std::numeric_limits<int64_t>::max() };
+enum {
+	invalidVersion = -1,
+	latestVersion = -2,
+	earliestVersion = -3,
+	MAX_VERSION = std::numeric_limits<int64_t>::max()
+};
 
 inline KeyRef keyAfter(const KeyRef& key, Arena& arena) {
 	// Don't include fdbclient/SystemData.h for the allKeys symbol to avoid a cyclic include


### PR DESCRIPTION
Cherry-pick #9485 

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
