### PR TITLE
Improve space estimation in checkExclusion() (cherry-pick #9449 to snowflake/release-71.2)

### DIFF
--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -1060,8 +1060,9 @@ ACTOR Future<bool> checkExclusion(Database db,
 	// The numerator is the total space in use by FDB that is not immediately reusable.
 	// This is calculated as: used + free - available = used + free - (free - reusable) = used - reusable.
 	// The denominator is the total capacity usable by FDB (either used or unused currently).
-	double finalUnavailableRatio = (totalKvStoreUsedBytes + totalKvStoreFreeBytes - totalKvStoreAvailableBytes) /
-	                               (totalKvStoreUsedBytesNonExcluded + totalKvStoreFreeBytesNotExcluded);
+	double finalUnavailableRatio =
+	    (totalKvStoreUsedBytes + totalKvStoreFreeBytes - totalKvStoreAvailableBytes) /
+	    std::max((totalKvStoreUsedBytesNonExcluded + totalKvStoreFreeBytesNotExcluded), (int64_t)1);
 
 	if (ssExcludedCount == ssTotalCount || finalUnavailableRatio > 0.9) {
 		std::string temp = "ERROR: This exclude may cause the total available space in the cluster to drop below 10%.\n"

--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -957,9 +957,9 @@ ACTOR Future<bool> checkExclusion(Database db,
 	}
 	StatusObject status = wait(StatusClient::statusFetcher(db));
 	state std::string errorString =
-	    "ERROR: Could not calculate the impact of this exclude on the total free space in the cluster.\n"
+	    "ERROR: Could not calculate the impact of this exclude on the total available space in the cluster.\n"
 	    "Please try the exclude again in 30 seconds.\n"
-	    "Call set(\"0xff0xff/management/options/exclude/force\", ...) first to exclude without checking free "
+	    "Call set(\"0xff0xff/management/options/exclude/force\", ...) first to exclude without checking available "
 	    "space.\n";
 
 	StatusObjectReader statusObj(status);
@@ -981,8 +981,11 @@ ACTOR Future<bool> checkExclusion(Database db,
 
 	state std::unordered_set<std::string> diskLocalities();
 	state int64_t totalKvStoreFreeBytes = 0;
+	state int64_t totalKvStoreFreeBytesNotExcluded = 0;
 	state int64_t totalKvStoreUsedBytes = 0;
 	state int64_t totalKvStoreUsedBytesNonExcluded = 0;
+	state int64_t totalKvStoreAvailableBytes = 0;
+
 	try {
 		for (auto proc : processesMap.obj()) {
 			StatusObjectReader process(proc.second);
@@ -1020,13 +1023,22 @@ ACTOR Future<bool> checkExclusion(Database db,
 						return false;
 					}
 
+					int64_t available_bytes;
+					if (!role.get("kvstore_available_bytes", available_bytes)) {
+						*msg = ManagementAPIError::toJsonString(
+						    false, markFailed ? "exclude failed" : "exclude", errorString);
+						return false;
+					}
+
 					totalKvStoreUsedBytes += used_bytes;
+					totalKvStoreFreeBytes += free_bytes;
+					totalKvStoreAvailableBytes += available_bytes;
 
 					if (!excluded) {
 						totalKvStoreUsedBytesNonExcluded += used_bytes;
 
 						if (disk_id.empty() || diskLocalities.find(disk_id) == diskLocalities.end()) {
-							totalKvStoreFreeBytes += free_bytes;
+							totalKvStoreFreeBytesNotExcluded += free_bytes;
 							if (!disk_id.empty()) {
 								diskLocalities.insert(disk_id);
 							}
@@ -1045,11 +1057,15 @@ ACTOR Future<bool> checkExclusion(Database db,
 		return false;
 	}
 
-	double finalFreeRatio = 1 - (totalKvStoreUsedBytes / (totalKvStoreUsedBytesNonExcluded + totalKvStoreFreeBytes));
-	if (ssExcludedCount == ssTotalCount || finalFreeRatio <= 0.1) {
-		std::string temp = "ERROR: This exclude may cause the total free space in the cluster to drop below 10%.\n"
+	// The numerator is the total space in use by FDB that is not immediately reusable;
+	// the denominator is the total space usable by FDB (either used or unused currently)
+	double finalUnavailableRatio = (totalKvStoreUsedBytes + totalKvStoreFreeBytes - totalKvStoreAvailableBytes) /
+	                               (totalKvStoreUsedBytesNonExcluded + totalKvStoreFreeBytesNotExcluded);
+
+	if (ssExcludedCount == ssTotalCount || finalUnavailableRatio > 0.9) {
+		std::string temp = "ERROR: This exclude may cause the total available space in the cluster to drop below 10%.\n"
 		                   "Call set(\"0xff0xff/management/options/exclude/force\", ...) first to exclude without "
-		                   "checking free space.\n";
+		                   "checking available space.\n";
 		*msg = ManagementAPIError::toJsonString(false, markFailed ? "exclude failed" : "exclude", temp);
 		return false;
 	}

--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -1057,8 +1057,9 @@ ACTOR Future<bool> checkExclusion(Database db,
 		return false;
 	}
 
-	// The numerator is the total space in use by FDB that is not immediately reusable;
-	// the denominator is the total space usable by FDB (either used or unused currently)
+	// The numerator is the total space in use by FDB that is not immediately reusable.
+	// This is calculated as: used + free - available = used + free - (free - reusable) = used - reusable.
+	// The denominator is the total capacity usable by FDB (either used or unused currently).
 	double finalUnavailableRatio = (totalKvStoreUsedBytes + totalKvStoreFreeBytes - totalKvStoreAvailableBytes) /
 	                               (totalKvStoreUsedBytesNonExcluded + totalKvStoreFreeBytesNotExcluded);
 


### PR DESCRIPTION
Improve space estimation in checkExclusion()

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
