### PR TITLE
Don't store lockid in txnStateStore

### DIFF
--- a/contrib/mockkms/CMakeLists.txt
+++ b/contrib/mockkms/CMakeLists.txt
@@ -1,4 +1,4 @@
-if(BUILD_GO_BINDING)
+if(WITH_GO_BINDING)
   set(MOCK_KMS_SRC fault_injection.go get_encryption_keys.go mock_kms.go utils.go)
   set(MOCK_KMS_TEST_SRC ${MOCK_KMS_SRC} mockkms_test.go)
   add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/bin/mockkms

--- a/fdbclient/include/fdbclient/Tenant.h
+++ b/fdbclient/include/fdbclient/Tenant.h
@@ -59,14 +59,10 @@ struct TenantMapEntryTxnStateStore {
 	int64_t id = -1;
 	TenantName tenantName;
 	TenantAPI::TenantLockState tenantLockState = TenantAPI::TenantLockState::UNLOCKED;
-	Optional<UID> tenantLockId;
 
 	TenantMapEntryTxnStateStore() {}
-	TenantMapEntryTxnStateStore(int64_t id,
-	                            TenantName tenantName,
-	                            TenantAPI::TenantLockState tenantLockState,
-	                            Optional<UID> tenantLockId)
-	  : id(id), tenantName(tenantName), tenantLockState(tenantLockState), tenantLockId(tenantLockId) {}
+	TenantMapEntryTxnStateStore(int64_t id, TenantName tenantName, TenantAPI::TenantLockState tenantLockState)
+	  : id(id), tenantName(tenantName), tenantLockState(tenantLockState) {}
 
 	Value encode() const { return ObjectWriter::toValue(*this, IncludeVersion()); }
 	static TenantMapEntryTxnStateStore decode(ValueRef const& value) {
@@ -75,7 +71,7 @@ struct TenantMapEntryTxnStateStore {
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, id, tenantLockState, tenantLockId, tenantName);
+		serializer(ar, id, tenantLockState, tenantName);
 	}
 };
 
@@ -106,7 +102,7 @@ struct TenantMapEntry {
 	}
 
 	TenantMapEntryTxnStateStore toTxnStateStoreEntry() const {
-		return TenantMapEntryTxnStateStore(id, tenantName, tenantLockState, tenantLockId);
+		return TenantMapEntryTxnStateStore(id, tenantName, tenantLockState);
 	}
 
 	bool operator==(TenantMapEntry const& other) const;

--- a/fdbserver/KeyValueStoreShardedRocksDB.actor.cpp
+++ b/fdbserver/KeyValueStoreShardedRocksDB.actor.cpp
@@ -1352,7 +1352,7 @@ public:
 
 			existingRanges.insert(it.range(), it.value()->physicalShard->id);
 		}
-		return std::move(existingRanges);
+		return existingRanges;
 	}
 
 	void validate() {


### PR DESCRIPTION
The lock id doesn't have to be stored in the txnStateStore, this PR removes that.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
