### PR TITLE
Fix some metacluster issues [snowflake/release-71.3]

### DIFF
--- a/fdbclient/include/fdbclient/MetaclusterManagement.actor.h
+++ b/fdbclient/include/fdbclient/MetaclusterManagement.actor.h
@@ -1767,7 +1767,11 @@ struct RestoreClusterImpl {
 		// If we had to break a rename cycle using temporary tenant names, use that in the updated
 		// entry here since the rename will be completed later.
 		if (existingEntry.tenantName != updatedEntry.tenantName) {
-			ASSERT(existingEntry.tenantName.startsWith(metaclusterTemporaryRenamePrefix));
+			if (!existingEntry.tenantName.startsWith(metaclusterTemporaryRenamePrefix)) {
+				// This transaction is going to fail due to the restore ID check, so we don't need to do anything
+				CODE_PROBE(true, "tenant restore rename mismatch due to concurrency", probe::decoration::rare);
+				return Void();
+			}
 			updatedEntry.tenantName = existingEntry.tenantName;
 		}
 

--- a/fdbclient/include/fdbclient/MetaclusterManagement.actor.h
+++ b/fdbclient/include/fdbclient/MetaclusterManagement.actor.h
@@ -1517,7 +1517,6 @@ struct RestoreClusterImpl {
 	// Store the cluster entry for the restored cluster
 	ACTOR static Future<Void> registerRestoringClusterInManagementCluster(RestoreClusterImpl* self,
 	                                                                      Reference<typename DB::TransactionT> tr) {
-
 		state Optional<DataClusterMetadata> dataClusterMetadata = wait(tryGetClusterTransaction(tr, self->clusterName));
 		if (dataClusterMetadata.present() &&
 		    (dataClusterMetadata.get().entry.clusterState != DataClusterState::RESTORING ||
@@ -1528,7 +1527,10 @@ struct RestoreClusterImpl {
 			MetaclusterMetadata::activeRestoreIds().addReadConflictKey(tr, self->clusterName);
 			MetaclusterMetadata::activeRestoreIds().set(tr, self->clusterName, self->restoreId);
 
-			self->dataClusterId = deterministicRandom()->randomUniqueID();
+			if (!dataClusterMetadata.present()) {
+				self->dataClusterId = deterministicRandom()->randomUniqueID();
+			}
+
 			DataClusterEntry clusterEntry;
 			clusterEntry.id = self->dataClusterId;
 			clusterEntry.clusterState = DataClusterState::RESTORING;

--- a/fdbserver/include/fdbserver/workloads/MetaclusterData.actor.h
+++ b/fdbserver/include/fdbserver/workloads/MetaclusterData.actor.h
@@ -153,6 +153,7 @@ private:
 			}
 		}
 
+		self->managementMetadata.clusterAllocatedMap.clear();
 		for (auto t : clusterCapacityTuples.results) {
 			ASSERT_EQ(t.size(), 2);
 			int64_t capacity = t.getInt(0);
@@ -160,6 +161,7 @@ private:
 			ASSERT(self->managementMetadata.clusterAllocatedMap.try_emplace(clusterName, capacity).second);
 		}
 
+		self->managementMetadata.clusterTenantMap.clear();
 		for (auto t : clusterTenantTuples.results) {
 			ASSERT_EQ(t.size(), 3);
 			TenantName tenantName = t.getString(1);
@@ -179,6 +181,7 @@ private:
 			}
 		}
 
+		self->managementMetadata.clusterTenantGroupMap.clear();
 		for (auto t : clusterTenantGroupTuples.results) {
 			ASSERT_EQ(t.size(), 2);
 			TenantGroupName tenantGroupName = t.getString(1);

--- a/fdbserver/include/fdbserver/workloads/TenantData.actor.h
+++ b/fdbserver/include/fdbserver/workloads/TenantData.actor.h
@@ -109,6 +109,7 @@ private:
 		self->storageQuotas =
 		    std::map<TenantGroupName, int64_t>(storageQuotaList.results.begin(), storageQuotaList.results.end());
 
+		self->tenantGroupIndex.clear();
 		for (auto t : tenantGroupTenantTuples.results) {
 			ASSERT_EQ(t.size(), 2);
 			TenantGroupName tenantGroupName = t.getString(0);

--- a/fdbserver/workloads/MetaclusterManagementWorkload.actor.cpp
+++ b/fdbserver/workloads/MetaclusterManagementWorkload.actor.cpp
@@ -358,8 +358,9 @@ struct MetaclusterManagementWorkload : TestWorkload {
 
 				state std::vector<Future<Void>> deleteFutures;
 				for (auto const& f : getFutures) {
-					ASSERT(f.get().present());
-					deleteFutures.push_back(TenantAPI::deleteTenantTransaction(tr, f.get().get()));
+					if (f.get().present()) {
+						deleteFutures.push_back(TenantAPI::deleteTenantTransaction(tr, f.get().get()));
+					}
 				}
 
 				wait(waitForAll(deleteFutures));

--- a/tests/slow/MetaclusterRecovery.toml
+++ b/tests/slow/MetaclusterRecovery.toml
@@ -2,7 +2,7 @@
 allowDefaultTenant = false
 allowCreatingTenants = false
 extraDatabaseMode = 'Multiple'
-extraDatabaseCount = 5
+extraDatabaseCount = 4
 extraDatabaseBackupAgents = true
 tenantModes = ['optional', 'required']
 
@@ -15,5 +15,5 @@ simBackupAgents = 'BackupToFile'
 
     [[test.workload]]
     testName = 'MetaclusterRestore'
-	maxTenants = 1000
-	maxTenantGroups = 20
+	maxTenants = 500
+	maxTenantGroups = 10


### PR DESCRIPTION
This is a cherry-pick of #9521 

1. When retrying the transaction to register a restoring cluster, don't choose a new ID if the current ID matches the one already recorded for the restoring cluster 
2. Fix a couple test issues where we were incorrectly handling the case where a transaction was retried with unknown result
3. An assertion could be triggered during a concurrent metacluster restore if a tenant was being renamed. The anomalous condition would only arise if the transaction was already going to be failed anyway
4. Change some test parameters to try to avoid rare occurrences of a test tracing too many lines

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
