### PR TITLE
Check transaction validity with respect to tenants even if it will fail with a conflict [snowflake/release-71.3]

### DIFF
--- a/fdbserver/workloads/SpecialKeySpaceRobustness.actor.cpp
+++ b/fdbserver/workloads/SpecialKeySpaceRobustness.actor.cpp
@@ -472,8 +472,8 @@ struct SpecialKeySpaceRobustnessWorkload : TestWorkload {
 					// both of them should be grabbed when changing dd mode
 					wait(success(
 					    tr2->get(deterministicRandom()->coinflip() ? moveKeysLockOwnerKey : moveKeysLockWriteKey)));
-					// tr2 shoulde never succeed, just write to a key to make it not a read-only transaction
-					tr2->set("unused_key"_sr, ""_sr);
+					// tr2 should never succeed, just write to a key to make it not a read-only transaction
+					tr2->addWriteConflictRange(singleKeyRange(""_sr));
 					wait(tr2->commit());
 					ASSERT(false); // commit should always fail due to conflict
 				} catch (Error& e) {


### PR DESCRIPTION
This is a cherry-pick of #9523 

This allows us to report the appropriate non-retryable error instead.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
