### PR TITLE
Remove the time guard on fdbcli commands in tests

### DIFF
--- a/fdbcli/tests/fdbcli_tests.py
+++ b/fdbcli/tests/fdbcli_tests.py
@@ -50,14 +50,10 @@ def run_fdbcli_command(*args):
         string: Console output from fdbcli
     """
     commands = command_template + ["{}".format(" ".join(args))]
-    try:
-        # if the fdbcli command is stuck for more than 20 seconds, the database is definitely unavailable
-        process = subprocess.run(
-            commands, stdout=subprocess.PIPE, env=fdbcli_env, timeout=20
-        )
-        return process.stdout.decode("utf-8").strip()
-    except subprocess.TimeoutExpired:
-        raise Exception("The fdbcli command is stuck, database is unavailable")
+    process = subprocess.run(
+        commands, stdout=subprocess.PIPE, env=fdbcli_env
+    )
+    return process.stdout.decode("utf-8").strip()
 
 
 def run_fdbcli_command_and_get_error(*args):


### PR DESCRIPTION
20 seconds look long enough,
but I will remove this to see if the `coordinators` change is just slow or bring the cluster down.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
