### PR TITLE
Report restore phase start time and eta

### DIFF
--- a/fdbcli/StatusCommand.actor.cpp
+++ b/fdbcli/StatusCommand.actor.cpp
@@ -19,7 +19,9 @@
  */
 
 #include "fdbcli/fdbcli.actor.h"
-
+#include "fmt/chrono.h"
+#include "fmt/core.h"
+#include "fmt/format.h"
 #include "fdbclient/FDBOptions.g.h"
 #include "fdbclient/IClientApi.h"
 #include "fdbclient/Knobs.h"
@@ -1118,20 +1120,68 @@ void printStatus(StatusObjectReader statusObj,
 
 				if (blobGranuleEnabled) {
 					outputString += "\n\nBlob Granules:";
-					StatusObjectReader statusObjBlobGranules = statusObjCluster["blob_granules"];
-					auto numWorkers = statusObjBlobGranules["number_of_blob_workers"].get_int();
-					outputString += "\n  Number of Workers      - " + format("%d", numWorkers);
-					auto numKeyRanges = statusObjBlobGranules["number_of_key_ranges"].get_int();
-					outputString += "\n  Number of Key Ranges   - " + format("%d", numKeyRanges);
+					if (statusObjCluster.has("blob_granules")) {
+						StatusObjectReader statusObjBlobGranules = statusObjCluster["blob_granules"];
+						if (statusObjBlobGranules.has("number_of_blob_workers")) {
+							auto numWorkers = statusObjBlobGranules["number_of_blob_workers"].get_int();
+							outputString += "\n  Number of Workers      - " + format("%d", numWorkers);
+						}
+						if (statusObjBlobGranules.has("number_of_key_ranges")) {
+							auto numKeyRanges = statusObjBlobGranules["number_of_key_ranges"].get_int();
+							outputString += "\n  Number of Key Ranges   - " + format("%d", numKeyRanges);
+						}
+					}
+
 					if (statusObjCluster.has("blob_restore")) {
 						StatusObjectReader statusObjBlobRestore = statusObjCluster["blob_restore"];
 						if (statusObjBlobRestore.has("blob_full_restore_phase")) {
-							std::string restoreStatus = statusObjBlobRestore["blob_full_restore_phase"].get_str();
-							if (statusObjBlobRestore.has("blob_full_restore_progress")) {
-								auto progress = statusObjBlobRestore["blob_full_restore_progress"].get_int();
-								restoreStatus += " " + format("%d%%", progress);
+							std::string statusStr;
+							int progress = statusObjBlobRestore["blob_full_restore_phase_progress"].get_int();
+							std::string error = statusObjBlobRestore["blob_full_restore_error"].get_str();
+							int64_t startTs = statusObjBlobRestore["blob_full_restore_start_ts"].get_int64();
+							int64_t phaseStartTs = statusObjBlobRestore["blob_full_restore_phase_start_ts"].get_int64();
+							std::string tsShortStr = fmt::format("{:%H:%M}", fmt::localtime(phaseStartTs));
+							std::string tsLongStr = fmt::format("{:%m/%d/%y %H:%M:%S}", fmt::localtime(phaseStartTs));
+
+							switch (statusObjBlobRestore["blob_full_restore_phase"].get_int()) {
+							case BlobRestorePhase::INIT:
+								statusStr = "Initializing";
+								break;
+							case BlobRestorePhase::STARTING_MIGRATOR:
+								statusStr = "Starting migrator";
+								break;
+							case BlobRestorePhase::LOADING_MANIFEST:
+								statusStr = fmt::format("Loading manifest. Started at {}", progress, tsShortStr);
+								break;
+							case BlobRestorePhase::LOADED_MANIFEST:
+								statusStr = "Manifest is loaded";
+								break;
+							case BlobRestorePhase::COPYING_DATA:
+								statusStr = fmt::format("Copying data {}%. Started at {}", progress, tsShortStr);
+								if (progress > 0) {
+									int eta = (100 - progress) * (now() - phaseStartTs) / progress / 60;
+									if (eta > 1) {
+										statusStr += fmt::format(". ETA {} minutes", eta);
+									} else {
+										statusStr += fmt::format(". ETA about one minute");
+									}
+								}
+								break;
+							case BlobRestorePhase::APPLYING_MLOGS:
+								statusStr = fmt::format("Applying mutation logs. Started at {}", progress, tsShortStr);
+								break;
+							case BlobRestorePhase::DONE:
+								statusStr = fmt::format(
+								    "Completed at {}. Total {} minutes used", tsLongStr, int(now() - startTs) / 60);
+								break;
+							case BlobRestorePhase::ERROR:
+								statusStr = fmt::format("Aborted with fatal error at {}. {}", tsLongStr, error);
+								break;
+							default:
+								statusStr = "Unexpected phase";
 							}
-							outputString += "\n  Full Restore           - " + restoreStatus;
+
+							outputString += "\n  Full Restore           - " + statusStr;
 						}
 					}
 				}

--- a/fdbclient/include/fdbclient/BlobGranuleCommon.h
+++ b/fdbclient/include/fdbclient/BlobGranuleCommon.h
@@ -356,20 +356,24 @@ enum BlobRestorePhase {
 	COPYING_DATA = 4,
 	APPLYING_MLOGS = 5,
 	DONE = 6,
-	ERROR = 7
+	ERROR = 7,
+	MAX = 8
 };
 struct BlobRestoreStatus {
 	constexpr static FileIdentifier file_identifier = 378657;
 	BlobRestorePhase phase;
-	int status;
+	int progress;
+	VectorRef<int64_t> phaseStartTs;
+	Optional<StringRef> error;
 
 	BlobRestoreStatus() : phase(BlobRestorePhase::INIT){};
-	BlobRestoreStatus(BlobRestorePhase pha) : phase(pha), status(0){};
-	BlobRestoreStatus(BlobRestorePhase pha, int prog) : phase(pha), status(prog){};
+	BlobRestoreStatus(BlobRestorePhase phase) : phase(phase), progress(0){};
+	BlobRestoreStatus(BlobRestorePhase phase, int progress) : phase(phase), progress(progress){};
+	BlobRestoreStatus(BlobRestorePhase phase, Optional<StringRef> error) : phase(phase), error(error){};
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, phase, status);
+		serializer(ar, phase, progress, phaseStartTs, error);
 	}
 };
 

--- a/fdbserver/BlobManager.actor.cpp
+++ b/fdbserver/BlobManager.actor.cpp
@@ -3526,13 +3526,17 @@ ACTOR Future<Void> recoverBlobManager(Reference<BlobManagerData> bmData) {
 		ASSERT(status.present());
 		state BlobRestorePhase phase = status.get().phase;
 		if (phase == BlobRestorePhase::STARTING_MIGRATOR || phase == BlobRestorePhase::LOADING_MANIFEST) {
-			wait(updateRestoreStatus(bmData->db, normalKeys, BlobRestoreStatus(LOADING_MANIFEST), {}));
+			wait(updateRestoreStatus(bmData->db, normalKeys, LOADING_MANIFEST, 0, {}, {}));
 			try {
 				wait(loadManifest(bmData->db, bmData->manifestStore));
 				int64_t epoc = wait(lastBlobEpoc(bmData->db, bmData->manifestStore));
 				wait(updateEpoch(bmData, epoc + 1));
-				BlobRestoreStatus completedStatus(BlobRestorePhase::LOADED_MANIFEST);
-				wait(updateRestoreStatus(bmData->db, normalKeys, completedStatus, BlobRestorePhase::LOADING_MANIFEST));
+				wait(updateRestoreStatus(bmData->db,
+				                         normalKeys,
+				                         BlobRestorePhase::LOADED_MANIFEST,
+				                         0,
+				                         {},
+				                         BlobRestorePhase::LOADING_MANIFEST));
 				TraceEvent("BlobManifestLoaded", bmData->id).log();
 			} catch (Error& e) {
 				if (e.code() != error_code_restore_missing_data &&
@@ -3541,8 +3545,8 @@ ACTOR Future<Void> recoverBlobManager(Reference<BlobManagerData> bmData) {
 				}
 				// terminate blob restore for non-retryable errors
 				TraceEvent("ManifestLoadError", bmData->id).error(e).detail("Phase", phase);
-				BlobRestoreStatus error(BlobRestorePhase::ERROR, e.code());
-				wait(updateRestoreStatus(bmData->db, normalKeys, error, {}));
+				std::string errorMessage = fmt::format("Manifest loading error '{}'", e.what());
+				wait(updateRestoreStatus(bmData->db, normalKeys, BlobRestorePhase::ERROR, 0, errorMessage, {}));
 			}
 		}
 	}

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -2378,8 +2378,7 @@ ACTOR Future<Void> watchBlobRestoreCommand(ClusterControllerData* self) {
 				TraceEvent("WatchBlobRestore", self->id).detail("Phase", status.phase);
 				if (status.phase == BlobRestorePhase::INIT) {
 					if (self->db.blobGranulesEnabled.get()) {
-						wait(updateRestoreStatus(
-						    self->cx, normalKeys, BlobRestoreStatus(BlobRestorePhase::STARTING_MIGRATOR), {}));
+						wait(updateRestoreStatus(self->cx, normalKeys, BlobRestorePhase::STARTING_MIGRATOR, 0, {}, {}));
 						const auto& blobManager = self->db.serverInfo->get().blobManager;
 						if (blobManager.present()) {
 							BlobManagerSingleton(blobManager)
@@ -2391,7 +2390,7 @@ ACTOR Future<Void> watchBlobRestoreCommand(ClusterControllerData* self) {
 						}
 					} else {
 						TraceEvent("SkipBlobRestoreInitCommand", self->id).log();
-						BlobRestoreStatus error(BlobRestorePhase::ERROR, error_code_restore_error);
+						BlobRestoreStatus error(BlobRestorePhase::ERROR, "Blob granules should be enabled first.");
 						Value value = blobRestoreCommandValueFor(error);
 						tr->set(blobRestoreCommandKey, value);
 					}

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -2488,41 +2488,16 @@ ACTOR static Future<JsonBuilderObject> blobWorkerStatusFetcher(
 ACTOR static Future<JsonBuilderObject> blobRestoreStatusFetcher(Database db, std::set<std::string>* incompleteReason) {
 
 	state JsonBuilderObject statusObj;
-	state std::vector<Future<Optional<TraceEventFields>>> futures;
 
 	try {
 		Optional<BlobRestoreStatus> status = wait(getRestoreStatus(db, normalKeys));
 		if (status.present()) {
-			switch (status.get().phase) {
-			case BlobRestorePhase::INIT:
-				statusObj["blob_full_restore_phase"] = "Initializing";
-				break;
-			case BlobRestorePhase::STARTING_MIGRATOR:
-				statusObj["blob_full_restore_phase"] = "Starting migrator";
-				break;
-			case BlobRestorePhase::LOADING_MANIFEST:
-				statusObj["blob_full_restore_phase"] = "Loading manifest";
-				break;
-			case BlobRestorePhase::LOADED_MANIFEST:
-				statusObj["blob_full_restore_phase"] = "Manifest is loaded";
-				break;
-			case BlobRestorePhase::COPYING_DATA:
-				statusObj["blob_full_restore_phase"] = "Copying data";
-				statusObj["blob_full_restore_progress"] = status.get().status;
-				break;
-			case BlobRestorePhase::APPLYING_MLOGS:
-				statusObj["blob_full_restore_phase"] = "Applying mutation logs";
-				break;
-			case BlobRestorePhase::DONE:
-				statusObj["blob_full_restore_phase"] = "Completed successfully";
-				break;
-			case BlobRestorePhase::ERROR:
-				statusObj["blob_full_restore_phase"] =
-				    "Completed with fatal error: " + std::string(Error(status.get().status).what());
-				break;
-			default:
-				statusObj["blob_full_restore_phase"] = "Unexpected phase";
-			}
+			BlobRestoreStatus restoreStatus = status.get();
+			statusObj["blob_full_restore_phase"] = restoreStatus.phase;
+			statusObj["blob_full_restore_phase_progress"] = restoreStatus.progress;
+			statusObj["blob_full_restore_phase_start_ts"] = restoreStatus.phaseStartTs[restoreStatus.phase];
+			statusObj["blob_full_restore_start_ts"] = restoreStatus.phaseStartTs[BlobRestorePhase::STARTING_MIGRATOR];
+			statusObj["blob_full_restore_error"] = restoreStatus.error.present() ? restoreStatus.error.get() : ""_sr;
 		}
 	} catch (Error& e) {
 		if (e.code() == error_code_actor_cancelled)

--- a/fdbserver/include/fdbserver/BlobGranuleServerCommon.actor.h
+++ b/fdbserver/include/fdbserver/BlobGranuleServerCommon.actor.h
@@ -167,7 +167,9 @@ ACTOR Future<int64_t> lastBlobEpoc(Database db, Reference<BlobConnectionProvider
 ACTOR Future<bool> isFullRestoreMode(Database db, KeyRangeRef range);
 ACTOR Future<Void> updateRestoreStatus(Database db,
                                        KeyRangeRef range,
-                                       BlobRestoreStatus status,
+                                       BlobRestorePhase phase,
+                                       int progress,
+                                       Optional<StringRef> error,
                                        Optional<BlobRestorePhase> expectedPhase);
 ACTOR Future<std::pair<KeyRange, BlobRestoreStatus>> getRestoreRangeStatus(Database db, KeyRangeRef keys);
 ACTOR Future<Optional<BlobRestoreStatus>> getRestoreStatus(Database db, KeyRangeRef range);

--- a/fdbserver/workloads/BlobRestoreWorkload.actor.cpp
+++ b/fdbserver/workloads/BlobRestoreWorkload.actor.cpp
@@ -107,7 +107,7 @@ struct BlobRestoreWorkload : TestWorkload {
 				}
 				// TODO need to define more specific error handling
 				if (s.phase == BlobRestorePhase::ERROR) {
-					fmt::print("Unexpected restore error code = {}\n", s.status);
+					fmt::print("Unexpected restore error code = {}\n", s.error.get());
 					return Void();
 				}
 			}


### PR DESCRIPTION
This PR is mostly fdbcli changes. It shows when we start each phase of restore, so that we can record the time easier for perf testing. 

Some examples:

```
Blob Granules:
  Number of Workers      - 2
  Number of Key Ranges   - 258
  Full Restore           - Completed at 03/03/23 18:02:53. Total 4 minutes used
```

```
Blob Granules:
  Number of Workers      - 2
  Number of Key Ranges   - 258
  Full Restore           - Copying data 30%. Started at 17:58. ETA about one minute
```
```

Blob Granules:
  Number of Workers      - 2
  Number of Key Ranges   - 258
  Full Restore           - Aborted with fatal error at 03/03/23 17:39:53: migrator failure on 127.0.0.1:4100
```

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
