### PR TITLE
Fix overflow/underflow in Histogram.sampleSeconds.

### DIFF
--- a/fdbserver/Resolver.actor.cpp
+++ b/fdbserver/Resolver.actor.cpp
@@ -285,14 +285,14 @@ ACTOR Future<Void> resolveBatch(Reference<Resolver> self,
 	}
 
 	// Time until now has been spent waiting in the queue to do actual work.
-	double queueWaitEndTime = g_network->timer();
+	const double queueWaitEndTime = timer();
 	self->queueWaitLatencyDist->sampleSeconds(queueWaitEndTime - req.requestTime());
 
 	if (self->version.get() ==
 	    req.prevVersion) { // Not a duplicate (check relies on no waiting between here and self->version.set() below!)
 		// This is the beginning of the compute phase of the
 		// resolver. There's no wait before it's done.
-		const double beginComputeTime = g_network->timer();
+		const double beginComputeTime = timer();
 
 		++self->resolveBatchStart;
 		self->resolvedTransactions += req.transactions.size();
@@ -487,7 +487,7 @@ ACTOR Future<Void> resolveBatch(Reference<Resolver> self,
 		}
 
 		// Measure the time spent doing actual work in the resolver.
-		const double endComputeTime = g_network->timer();
+		const double endComputeTime = timer();
 		self->computeTimeDist->sampleSeconds(endComputeTime - beginComputeTime);
 
 		if (req.debugID.present())
@@ -516,7 +516,7 @@ ACTOR Future<Void> resolveBatch(Reference<Resolver> self,
 
 	// Measure server-side RPC latency from the time a request was
 	// received to time the response was sent.
-	const double endTime = g_network->timer();
+	const double endTime = timer();
 	self->resolverLatencyDist->sampleSeconds(endTime - req.requestTime());
 
 	++self->resolveBatchOut;

--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -2358,7 +2358,7 @@ ACTOR Future<Void> tLogCommit(TLogData* self,
 
 	// Measure server-side RPC latency from the time a request was
 	// received to time the response was sent.
-	const double endTime = g_network->timer();
+	const double endTime = timer();
 
 	if (isNotDuplicate) {
 		self->commitLatencyDist->sampleSeconds(endTime - req.requestTime());

--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -2303,7 +2303,7 @@ ACTOR Future<Void> tLogCommit(TLogData* self,
 	wait(logData->version.whenAtLeast(req.prevVersion));
 
 	// Time until now has been spent waiting in the queue to do actual work.
-	state double queueWaitEndTime = g_network->timer();
+	state double queueWaitEndTime = timer();
 	self->queueWaitLatencyDist->sampleSeconds(queueWaitEndTime - req.requestTime());
 
 	// Calling check_yield instead of yield to avoid a destruction ordering problem in simulation
@@ -2370,7 +2370,7 @@ ACTOR Future<Void> tLogCommit(TLogData* self,
 	    timeoutWarning(logData->queueCommittedVersion.whenAtLeast(req.version) || stopped, 0.1, warningCollectorInput));
 
 	// This is the point at which the transaction is durable (unless it timed out, or the tlog stopped).
-	const double durableTime = g_network->timer();
+	const double durableTime = timer();
 
 	if (stopped.isReady()) {
 		ASSERT(logData->stopped());

--- a/flow/include/flow/Histogram.h
+++ b/flow/include/flow/Histogram.h
@@ -123,13 +123,18 @@ public:
 	}
 
 	inline void sampleSeconds(double delta) {
-		uint64_t delta_usec = (delta * 1000000);
-		if (delta_usec > UINT32_MAX) {
+		// convert to microseconds and truncate to integer
+		double delta_usec = delta * 1e6;
+		if (delta_usec < 0) {
+			// Timers can sometimes go backwards. Clamp to 0.
+			sample(0);
+		} else if (delta_usec > UINT32_MAX) {
 			sample(UINT32_MAX);
 		} else {
-			sample((uint32_t)(delta * 1000000)); // convert to microseconds and truncate to integer
+			sample((uint32_t)delta_usec);
 		}
 	}
+
 	// Histogram buckets samples into linear interval of size 4 percent.
 	inline void samplePercentage(double pct) {
 		ASSERT(pct >= 0.0);


### PR DESCRIPTION
The conversion from double -> uint32_t in sampleSeconds is potentially
undefined behavior for very large or negative values. We safely clamp
the value to [0, UINT32_MAX] before converting to integer.

Note: negative values are possible here, because timers can go backwards.
That case should be clamped to zero rather than underflowing.

This problem was discovered because we were mixing g_network->timer() and
timer(). Normally, these are the same and comparable. In simulation, they
are not and subtracting them led to the undefined behavior above. These
sites are now fixed.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
