### PR TITLE
Fix a build failure on APPLE platform

### DIFF
--- a/bindings/c/symbolify.py
+++ b/bindings/c/symbolify.py
@@ -1,7 +1,7 @@
 if __name__ == '__main__':
     import re
     import sys
-    r = re.compile('DLLEXPORT[^(]*(fdb_[^(]*)[(]')
+    r = re.compile('DLLEXPORT[^(\n]*(fdb_[^(]*)[(]')
     header_files = sys.argv[1:-1]
     symbols_file = sys.argv[-1]
     symbols = set()


### PR DESCRIPTION
`symbolify.py` generates invalid symbols after PR #9492 which breaks the build on macos:
```
Undefined symbols for architecture arm64:
  "_fdb_c_apiversion.g.h"", referenced from:
     -exported_symbol[s_list] command line option
```
The fix is to avoid matching newline after `DLLEXPORT`, otherwise the symbols file will include invalid symbols like:
```
_fdb_add_network_thread_completion_hook
_fdb_c_apiversion.g.h"
_fdb_cluster_create_database
```
It should fix the CI failure for macos.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
