### PR TITLE
StorageCache: Expand test coverage

### DIFF
--- a/fdbserver/include/fdbserver/workloads/ApiWorkload.h
+++ b/fdbserver/include/fdbserver/workloads/ApiWorkload.h
@@ -275,8 +275,10 @@ struct ApiWorkload : TestWorkload {
 	  : TestWorkload(wcx), maxClients(maxClients), success(true), transactionFactory(nullptr) {
 		clientPrefixInt = getOption(options, "clientId"_sr, clientId);
 		// StorageCache if enabled, simulate partial keycache caching
-		clientPrefix = clientId < 2 ? format("apiworkload/cached/%010d", clientPrefixInt)
-		                            : format("apiworkload/uncached/%010d", clientPrefixInt);
+		clientPrefix = clientId < 2 ? fmt::format("apiworkload/cached/{0:>10}", clientPrefixInt)
+		                            : fmt::format("apiworkload/uncached/{0:>10}", clientPrefixInt);
+
+		printf("%s\n", clientPrefix.c_str());
 
 		numKeys = getOption(options, "numKeys"_sr, 5000);
 		onlyLowerCase = getOption(options, "onlyLowerCase"_sr, false);

--- a/fdbserver/include/fdbserver/workloads/ApiWorkload.h
+++ b/fdbserver/include/fdbserver/workloads/ApiWorkload.h
@@ -274,7 +274,9 @@ struct ApiWorkload : TestWorkload {
 	ApiWorkload(WorkloadContext const& wcx, int maxClients = -1)
 	  : TestWorkload(wcx), maxClients(maxClients), success(true), transactionFactory(nullptr) {
 		clientPrefixInt = getOption(options, "clientId"_sr, clientId);
-		clientPrefix = format("%010d", clientPrefixInt);
+		// StorageCache if enabled, simulate partial keycache caching
+		clientPrefix = clientId < 2 ? format("apiworkload/cached/%010d", clientPrefixInt)
+		                            : format("apiworkload/uncached/%010d", clientPrefixInt);
 
 		numKeys = getOption(options, "numKeys"_sr, 5000);
 		onlyLowerCase = getOption(options, "onlyLowerCase"_sr, false);

--- a/tests/fast/AtomicOps.toml
+++ b/tests/fast/AtomicOps.toml
@@ -1,4 +1,11 @@
 [[test]]
+testTitle = 'Cached'
+
+    [[test.workload]]
+    testName = 'Cache'
+    keyPrefix = 'log'
+
+[[test]]
 testTitle = 'Clogged'
 
     [[test.workload]]

--- a/tests/fast/CacheTest.toml
+++ b/tests/fast/CacheTest.toml
@@ -14,3 +14,12 @@ testTitle = 'Cycle'
     testDuration = 10.0
     expectedRate = 0.01
     keyPrefix = 'foo/'
+
+[[test]]
+testTitle = 'Cycle'
+
+    [[test.workload]]
+    testName = 'Cycle'
+    transactionsPerSecond = 2500.0
+    testDuration = 10.0
+    expectedRate = 0.01

--- a/tests/fast/ReportConflictingKeys.toml
+++ b/tests/fast/ReportConflictingKeys.toml
@@ -2,6 +2,13 @@
 buggify = false
 
 [[test]]
+testTitle = 'Cached'
+
+    [[test.workload]]
+    testName = 'Cache'
+    keyPrefix = 'RCK'
+
+[[test]]
 testTitle = 'ReportConflictingKeysTest'
 connectionFailuresDisableDuration = 100000
 

--- a/tests/fast/WriteDuringRead.toml
+++ b/tests/fast/WriteDuringRead.toml
@@ -2,6 +2,13 @@
 StderrSeverity = 30
 
 [[test]]
+testTitle = 'Cached'
+
+    [[test.workload]]
+    testName = 'Cache'
+    keyPrefix = '\x02'
+
+[[test]]
 testTitle = 'WriteDuringReadTest'
 
     [[test.workload]]

--- a/tests/rare/LargeApiCorrectness.toml
+++ b/tests/rare/LargeApiCorrectness.toml
@@ -1,4 +1,11 @@
 [[test]]
+testTitle = 'Cached'
+
+    [[test.workload]]
+    testName = 'Cache'
+    keyPrefix = 'apiworkload/cached/' # Partial KeyRange caching in storageCache
+
+[[test]]
 testTitle = 'ApiCorrectnessTest'
 clearAfterTest = true
 timeout = 2100

--- a/tests/slow/ApiCorrectness.toml
+++ b/tests/slow/ApiCorrectness.toml
@@ -1,4 +1,11 @@
 [[test]]
+testTitle = 'Cached'
+
+    [[test.workload]]
+    testName = 'Cache'
+    keyPrefix = 'apiworkload/cached/' # Partial KeyRange caching in storageCache
+
+[[test]]
 testTitle = 'ApiCorrectnessTest'
 clearAfterTest = true
 timeout = 2100

--- a/tests/slow/ApiCorrectnessAtomicRestore.toml
+++ b/tests/slow/ApiCorrectnessAtomicRestore.toml
@@ -8,6 +8,13 @@ rocksdb_read_value_prefix_timeout=300.0
 rocksdb_read_range_timeout=300.0
 
 [[test]]
+testTitle = 'Cached'
+
+    [[test.workload]]
+    testName = 'Cache'
+    keyPrefix = 'apiworkload/cached/' # Partial KeyRange caching in storageCache
+
+[[test]]
 testTitle = 'ApiCorrectnessTest'
 clearAfterTest = false
 simBackupAgents = 'BackupToFile'

--- a/tests/slow/ApiCorrectnessSwitchover.toml
+++ b/tests/slow/ApiCorrectnessSwitchover.toml
@@ -4,6 +4,13 @@ extraDatabaseMode = 'Single'
 tenantModes = ['disabled', 'optional']
 
 [[test]]
+testTitle = 'Cached'
+
+    [[test.workload]]
+    testName = 'Cache'
+    keyPrefix = 'apiworkload/cached/' # Partial KeyRange caching in storageCache
+
+[[test]]
 testTitle = 'ApiCorrectnessTest'
 clearAfterTest = false
 simBackupAgents = 'BackupToDB'


### PR DESCRIPTION
Description

Test updated to support StorageCache testing are:
1. Partial Caching scenario:= ApiWorkload derivative tests - 'prefix' caching is supported for subset of the KeyRange; simulating patial keyrange caching scenario.

Updates test includes:
a) ApiCorrectness
b) ApiCorrectnessAtomicRestore
c) ApiCorrectnessSwitchover
d) LargeApiCorrectness

2. Full KeyRange Caching:= Updated tests include:
a) AtomicOps
b) ReportConflictingKeys
c) WriteDuringRead

Testing

Replace this text with your description here...

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
