### PR TITLE
Refactor decoder to read file as a whole once

### DIFF
--- a/fdbbackup/FileDecoder.actor.cpp
+++ b/fdbbackup/FileDecoder.actor.cpp
@@ -783,6 +783,7 @@ ACTOR Future<Void> process_range_file(Reference<IBackupContainer> container,
 		}
 	}
 
+	TraceEvent("ProcessRangeFileDone", uid).detail("File", file.fileName);
 	return Void();
 }
 
@@ -892,6 +893,8 @@ ACTOR Future<Void> decode_logs(Reference<DecodeParams> params) {
 		rangeFiles = files;
 		printLogFiles("Releavant range files are: ", rangeFiles);
 	}
+
+	TraceEvent("TotalFiles", uid).detail("LogFiles", logFiles.size()).detail("RangeFiles", rangeFiles.size());
 
 	if (params->list_only)
 		return Void();

--- a/fdbclient/BackupAgent.actor.h
+++ b/fdbclient/BackupAgent.actor.h
@@ -1002,9 +1002,13 @@ struct StringRefReader {
 };
 
 namespace fileBackup {
+Standalone<VectorRef<KeyValueRef>> decodeRangeFileBlock(const Standalone<StringRef>& buf);
+
 ACTOR Future<Standalone<VectorRef<KeyValueRef>>> decodeRangeFileBlock(Reference<IAsyncFile> file,
                                                                       int64_t offset,
                                                                       int len);
+
+Standalone<VectorRef<KeyValueRef>> decodeMutationLogFileBlock(const Standalone<StringRef>& buf);
 
 // Reads a mutation log block from file and parses into batch mutation blocks for further parsing.
 ACTOR Future<Standalone<VectorRef<KeyValueRef>>> decodeMutationLogFileBlock(Reference<IAsyncFile> file,


### PR DESCRIPTION
cherrypick part of #9505

To reduce the number of network requests. The network saving reduces 30~50% time.

20230303-171733-jzhou-944d463f9681e635

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
