### PR TITLE
Fix exported symbol extraction in Apple builds

### DIFF
--- a/bindings/c/symbolify.py
+++ b/bindings/c/symbolify.py
@@ -2,7 +2,7 @@ if __name__ == "__main__":
     import re
     import sys
 
-    r = re.compile("DLLEXPORT[^(]*(fdb_[^(]*)[(]")
+    r = re.compile("^DLLEXPORT[^(]*(fdb_[^(]*)[(].*$", re.MULTILINE)
     header_files = sys.argv[1:-1]
     symbols_file = sys.argv[-1]
     symbols = set()

--- a/bindings/c/symbolify.py
+++ b/bindings/c/symbolify.py
@@ -1,14 +1,15 @@
-if __name__ == '__main__':
+if __name__ == "__main__":
     import re
     import sys
-    r = re.compile('DLLEXPORT[^(]*(fdb_[^(]*)[(]')
+
+    r = re.compile("DLLEXPORT[^(]*(fdb_[^(]*)[(]")
     header_files = sys.argv[1:-1]
     symbols_file = sys.argv[-1]
     symbols = set()
     for header_file in header_files:
-        with open(header_file, 'r') as f:
-            symbols.update('_' + m.group(1) for m in r.finditer(f.read()))
+        with open(header_file, "r") as f:
+            symbols.update("_" + m.group(1) for m in r.finditer(f.read()))
     symbols = sorted(symbols)
-    with open(symbols_file, 'w') as f:
-        f.write('\n'.join(symbols))
-        f.write('\n')
+    with open(symbols_file, "w") as f:
+        f.write("\n".join(symbols))
+        f.write("\n")


### PR DESCRIPTION
Apple builds use symbolify.py to extract the exported symbols from C API headers. After a recent change to the headers, the pattern matching have taken some wrong strings. This PR improves the pattern matching to avoid these false positives.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
