### PR TITLE
[snowflake/release-71.2] Rewrote ActorCollection to be O(1) instead of O(log n) for actor add and completion

### DIFF
--- a/fdbserver/workloads/UnitTests.actor.cpp
+++ b/fdbserver/workloads/UnitTests.actor.cpp
@@ -42,6 +42,7 @@ void forceLinkRESTClientTests();
 void forceLinkRESTUtilsTests();
 void forceLinkRESTKmsConnectorTest();
 void forceLinkCompressionUtilsTest();
+void forceLinkActorCollectionTests();
 
 struct UnitTestWorkload : TestWorkload {
 	bool enabled;
@@ -94,6 +95,7 @@ struct UnitTestWorkload : TestWorkload {
 		forceLinkRESTUtilsTests();
 		forceLinkRESTKmsConnectorTest();
 		forceLinkCompressionUtilsTest();
+		forceLinkActorCollectionTests();
 	}
 
 	std::string description() const override { return "UnitTests"; }

--- a/flow/ActorCollection.actor.cpp
+++ b/flow/ActorCollection.actor.cpp
@@ -132,7 +132,9 @@ void forceLinkActorCollectionTests() {}
 TEST_CASE("/flow/actorCollection/chooseWhen") {
 	state Promise<Void> promise;
 	choose {
-		when(wait(delay(0))) { promise.send(Void()); }
+		when(wait(delay(0))) {
+			promise.send(Void());
+		}
 		when(wait(promise.getFuture())) {
 			// Should be cancelled, since another when clause in this choose block has executed
 			ASSERT(false);

--- a/flow/ActorCollection.actor.cpp
+++ b/flow/ActorCollection.actor.cpp
@@ -21,7 +21,42 @@
 #include "flow/ActorCollection.h"
 #include "flow/IndexedSet.h"
 #include "flow/UnitTest.h"
+#include <boost/intrusive/list.hpp>
 #include "flow/actorcompiler.h" // This must be the last #include.
+
+struct Runner : public boost::intrusive::list_base_hook<>, FastAllocated<Runner>, NonCopyable {
+	Future<Void> handler;
+};
+
+// An intrusive list of Runners, which are FastAllocated.  Each runner holds a handler future
+typedef boost::intrusive::list<Runner, boost::intrusive::constant_time_size<false>> RunnerList;
+
+// The runners list in the ActorCollection must be destroyed when the actor is destructed rather
+// than before returning or throwing
+struct RunnerListDestroyer : NonCopyable {
+	RunnerListDestroyer(RunnerList* list) : list(list) {}
+
+	~RunnerListDestroyer() {
+		list->clear_and_dispose([](Runner* r) { delete r; });
+	}
+
+	RunnerList* list;
+};
+
+ACTOR Future<Void> runnerHandler(PromiseStream<RunnerList::iterator> output,
+                                 PromiseStream<Error> errors,
+                                 Future<Void> task,
+                                 RunnerList::iterator runner) {
+	try {
+		wait(task);
+		output.send(runner);
+	} catch (Error& e) {
+		if (e.code() == error_code_actor_cancelled)
+			throw;
+		errors.send(e);
+	}
+	return Void();
+}
 
 ACTOR Future<Void> actorCollection(FutureStream<Future<Void>> addActor,
                                    int* pCount,
@@ -29,9 +64,9 @@ ACTOR Future<Void> actorCollection(FutureStream<Future<Void>> addActor,
                                    double* idleTime,
                                    double* allTime,
                                    bool returnWhenEmptied) {
-	state int64_t nextTag = 0;
-	state Map<int64_t, Future<Void>> tag_streamHelper;
-	state PromiseStream<int64_t> complete;
+	state RunnerList runners;
+	state RunnerListDestroyer runnersDestroyer(&runners);
+	state PromiseStream<RunnerList::iterator> complete;
 	state PromiseStream<Error> errors;
 	state int count = 0;
 	if (!pCount)
@@ -39,8 +74,13 @@ ACTOR Future<Void> actorCollection(FutureStream<Future<Void>> addActor,
 
 	loop choose {
 		when(Future<Void> f = waitNext(addActor)) {
-			int64_t t = nextTag++;
-			tag_streamHelper[t] = streamHelper(complete, errors, tag(f, t));
+			// Insert new Runner at the end of the instrusive list and get an iterator to it
+			auto i = runners.insert(runners.end(), *new Runner());
+
+			// Start the handler for completions or errors from f, sending runner to complete stream
+			Future<Void> handler = runnerHandler(complete, errors, f, i);
+			i->handler = handler;
+
 			++*pCount;
 			if (*pCount == 1 && lastChangeTime && idleTime && allTime) {
 				double currentTime = now();
@@ -49,7 +89,7 @@ ACTOR Future<Void> actorCollection(FutureStream<Future<Void>> addActor,
 				*lastChangeTime = currentTime;
 			}
 		}
-		when(int64_t t = waitNext(complete.getFuture())) {
+		when(RunnerList::iterator i = waitNext(complete.getFuture())) {
 			if (!--*pCount) {
 				if (lastChangeTime && idleTime && allTime) {
 					double currentTime = now();
@@ -59,7 +99,8 @@ ACTOR Future<Void> actorCollection(FutureStream<Future<Void>> addActor,
 				if (returnWhenEmptied)
 					return Void();
 			}
-			tag_streamHelper.erase(t);
+			// If we didn't return then the entire list wasn't destroyed so erase/destroy i
+			runners.erase_and_dispose(i, [](Runner* r) { delete r; });
 		}
 		when(Error e = waitNext(errors.getFuture())) {
 			throw e;
@@ -83,3 +124,19 @@ struct Traceable<std::pair<T, U>> {
 		return result;
 	}
 };
+
+void forceLinkActorCollectionTests() {}
+
+// The above implementation relies on the behavior that fulfilling a promise
+// that another when clause in the same choose block is waiting on is not fired synchronously.
+TEST_CASE("/flow/actorCollection/chooseWhen") {
+	state Promise<Void> promise;
+	choose {
+		when(wait(delay(0))) { promise.send(Void()); }
+		when(wait(promise.getFuture())) {
+			// Should be cancelled, since another when clause in this choose block has executed
+			ASSERT(false);
+		}
+	}
+	return Void();
+}


### PR DESCRIPTION
Cherry-pick #8833

Replace this text with your description here...

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
