### PR TITLE
Fix build for ruby bindings

### DIFF
--- a/bindings/ruby/CMakeLists.txt
+++ b/bindings/ruby/CMakeLists.txt
@@ -3,6 +3,35 @@
 vexillographer_compile(TARGET ruby_options LANG ruby
   OUT ${CMAKE_CURRENT_SOURCE_DIR}/lib/fdboptions.rb ALL)
 configure_file(fdb.gemspec.cmake fdb.gemspec)
+configure_file(${CMAKE_SOURCE_DIR}/LICENSE ${CMAKE_CURRENT_BINARY_DIR}/LICENSE COPYONLY)
+
+set(SRCS
+  lib/fdb.rb
+  lib/fdbdirectory.rb
+  lib/fdbimpl.rb
+  lib/fdbimpl_v609.rb
+  lib/fdblocality.rb
+  lib/fdboptions.rb
+  lib/fdbsubspace.rb
+  lib/fdbtuple.rb)
+
+set(out_files "")
+foreach(src ${SRCS})
+  get_filename_component(dirname ${src} DIRECTORY)
+  get_filename_component(extname ${src} EXT)
+  if(NOT EXISTS ${dirname})
+    file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/bindings/ruby/${dirname})
+  endif()
+  set(from_path ${CMAKE_CURRENT_SOURCE_DIR}/${src})
+  set(to_path ${CMAKE_CURRENT_BINARY_DIR}/${src})
+  add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/bindings/ruby/${src}
+    COMMAND ${CMAKE_COMMAND} -E copy ${from_path} ${to_path}
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${src}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    COMMENT "copy ${src}")
+  set(out_files "${out_files};${PROJECT_BINARY_DIR}/bindings/ruby/${src}")
+endforeach()
+add_custom_target(ruby_binding ALL DEPENDS ${out_files})
 
 if(NOT FDB_RELEASE)
   set(not_fdb_release_string "SNAPSHOT")
@@ -19,4 +48,5 @@ add_custom_command(OUTPUT ${gem_target}
   COMMENT "Building ruby gem")
 add_custom_target(gem_package DEPENDS ${gem_target})
 add_dependencies(gem_package ruby_options)
+add_dependencies(gem_package ruby_binding)
 add_dependencies(packages gem_package)

--- a/bindings/ruby/fdb.gemspec.cmake
+++ b/bindings/ruby/fdb.gemspec.cmake
@@ -13,7 +13,7 @@ https://apple.github.io/foundationdb/api-ruby.html.
 EOF
   s.authors = ["FoundationDB"]
   s.email = 'fdb-dist@apple.com'
-  s.files = ["${CMAKE_SOURCE_DIR}/LICENSE", "${CMAKE_CURRENT_SOURCE_DIR}/lib/fdb.rb", "${CMAKE_CURRENT_SOURCE_DIR}/lib/fdbdirectory.rb", "${CMAKE_CURRENT_SOURCE_DIR}/lib/fdbimpl.rb", "${CMAKE_CURRENT_SOURCE_DIR}/lib/fdblocality.rb", "${CMAKE_CURRENT_SOURCE_DIR}/lib/fdboptions.rb", "${CMAKE_CURRENT_SOURCE_DIR}/lib/fdbsubspace.rb", "${CMAKE_CURRENT_SOURCE_DIR}/lib/fdbtuple.rb", "${CMAKE_CURRENT_SOURCE_DIR}/lib/fdbimpl_v609.rb"]
+  s.files = ["LICENSE", "lib/fdb.rb", "lib/fdbdirectory.rb", "lib/fdbimpl.rb", "lib/fdblocality.rb", "lib/fdboptions.rb", "lib/fdbsubspace.rb", "lib/fdbtuple.rb", "lib/fdbimpl_v609.rb"]
   s.homepage = 'https://www.foundationdb.org'
   s.license = 'Apache-2.0'
   s.add_dependency('ffi', '~> 1.1', '>= 1.1.5')


### PR DESCRIPTION
PR from [Andrew Hayworth](https://forums.foundationdb.org/u/ahayworth)

The ruby bindings are not currently installable. We can reproduce this with a build from source:

```
foundationdb/tmp on  main [$?] via △ v3.25.2
zsh ❯ gem install ./bindings/ruby/fdb-7.3.0.gem
ERROR:  While executing gem ... (Gem::Package::PathError)
    installing into parent path /Users/andrew/projects/foundationdb/LICENSE of /Users/andrew/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/fdb-7.3.0 is not allowed
```

The problem is that the gemspec is interpolating the source directory into the `files` array - and while this allows the gem to build, it prevents it from actually being installed.

To fix it, we borrow similar code from the python bindings to copy the necessary files and license into the build directory before building the gem. This allows the gem to be installed:

```
foundationdb/tmp on  main [!?] via △ v3.25.2
zsh ❯ gem install ./bindings/ruby/fdb-7.3.0.gem
Successfully installed fdb-7.3.0
Parsing documentation for fdb-7.3.0
Installing ri documentation for fdb-7.3.0
Done installing documentation for fdb after 0 seconds
1 gem installed
```

Replace this text with your description here...

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
