### PR TITLE
Allow ruby bindings on arm64

### DIFF
--- a/bindings/ruby/lib/fdbimpl.rb
+++ b/bindings/ruby/lib/fdbimpl.rb
@@ -36,8 +36,8 @@ module FDB
   module FDBC
     require 'rbconfig'
 
-    if RbConfig::CONFIG['host_cpu'] != "x86_64"
-      raise LoadError, "FoundationDB API only supported on x86_64 (not #{RbConfig::CONFIG['host_cpu']})"
+    unless ["x86_64", "arm64"].include? RbConfig::CONFIG['host_cpu']
+      raise LoadError, "FoundationDB API only supported on x86_64 and arm64 (not #{RbConfig::CONFIG['host_cpu']})"
     end
 
     case RbConfig::CONFIG['host_os']


### PR DESCRIPTION
PR from [Andrew Hayworth](https://forums.foundationdb.org/u/ahayworth)

While fixing the gem build, I noticed that the gem will not run on arm64 machines, like the new spiffy M1/M2 MacBooks. On a whim, I tried just removing that restriction... and it does seem to work:

```
foundationdb/bindings/ruby/lib on  ahayworth/fix-ruby-binding-build [?] via 💎 v3.2.1 took 2s
zsh ❯ pry
[1] pry(main)> require 'fdb'
=> true
[2] pry(main)> FDB.api_version 720
LoadError: FoundationDB API only supported on x86_64 (not arm64)
from /Users/andrew/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/fdb-7.3.0/lib/fdbimpl.rb:40:in `<module:FDBC>'
[3] pry(main)>
```

Replace this text with your description here...

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
