### PR TITLE
Fix incorrect assertion in MetaclusterRestore workload

### DIFF
--- a/fdbserver/workloads/MetaclusterRestoreWorkload.actor.cpp
+++ b/fdbserver/workloads/MetaclusterRestoreWorkload.actor.cpp
@@ -653,7 +653,7 @@ struct MetaclusterRestoreWorkload : TestWorkload {
 							break;
 						}
 
-						ASSERT_GT(restoreFutures.size(), 1);
+						ASSERT_GE(restoreFutures.size(), 1);
 
 						numRestores = 1;
 						wait(success(MetaclusterAPI::removeCluster(clusterItr->second.db.getReference(),


### PR DESCRIPTION
Failed assertion: effectively `ASSERT_GT([1 or 2], 1)`
Change to: `ASSERT_GE`

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
