### PR TITLE
Fix metacluster create error msg (snowflake/release-71.3)

### DIFF
--- a/fdbclient/include/fdbclient/MetaclusterManagement.actor.h
+++ b/fdbclient/include/fdbclient/MetaclusterManagement.actor.h
@@ -578,7 +578,7 @@ Future<Optional<std::string>> createMetacluster(Reference<DB> db,
 			TenantMode tenantMode = wait(tenantModeFuture);
 			if (tenantMode != TenantMode::DISABLED) {
 				return fmt::format("cluster is configured with tenant mode `{}' when tenants should be disabled",
-				                   tenantMode);
+				                   tenantMode.toString());
 			}
 
 			if (!metaclusterUid.present()) {


### PR DESCRIPTION
Cherry-pick #9584 

Print the tenant mode string rather than integer value when reporting that we couldn't create a metacluster. Example new output:

```
ERROR: cluster is configured with tenant mode `required_experimental' when tenants should be disabled.
```

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
