### PR TITLE
Fix race between auditStorage and resumeAuditStorage (snowflake/release-71.3)

### DIFF
--- a/fdbclient/include/fdbclient/MetaclusterManagement.actor.h
+++ b/fdbclient/include/fdbclient/MetaclusterManagement.actor.h
@@ -1517,7 +1517,6 @@ struct RestoreClusterImpl {
 	// Store the cluster entry for the restored cluster
 	ACTOR static Future<Void> registerRestoringClusterInManagementCluster(RestoreClusterImpl* self,
 	                                                                      Reference<typename DB::TransactionT> tr) {
-
 		state Optional<DataClusterMetadata> dataClusterMetadata = wait(tryGetClusterTransaction(tr, self->clusterName));
 		if (dataClusterMetadata.present() &&
 		    (dataClusterMetadata.get().entry.clusterState != DataClusterState::RESTORING ||
@@ -1528,7 +1527,10 @@ struct RestoreClusterImpl {
 			MetaclusterMetadata::activeRestoreIds().addReadConflictKey(tr, self->clusterName);
 			MetaclusterMetadata::activeRestoreIds().set(tr, self->clusterName, self->restoreId);
 
-			self->dataClusterId = deterministicRandom()->randomUniqueID();
+			if (!dataClusterMetadata.present()) {
+				self->dataClusterId = deterministicRandom()->randomUniqueID();
+			}
+
 			DataClusterEntry clusterEntry;
 			clusterEntry.id = self->dataClusterId;
 			clusterEntry.clusterState = DataClusterState::RESTORING;

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -305,7 +305,7 @@ public:
 	Promise<Void> initialized;
 
 	std::unordered_map<AuditType, std::unordered_map<UID, std::shared_ptr<DDAudit>>> audits;
-	Future<Void> auditInitialized;
+	Promise<Void> auditInitialized;
 
 	Optional<Reference<TenantCache>> ddTenantCache;
 
@@ -578,6 +578,26 @@ ACTOR Future<Void> doAuditOnStorageServer(Reference<DataDistributor> self,
                                           StorageServerInterface ssi,
                                           AuditStorageRequest req);
 
+ACTOR Future<Void> resumeStorageAudits(Reference<DataDistributor> self) {
+	state std::vector<Future<Void>> fs;
+	for (const auto& auditState : self->initData->auditStates) {
+		if (self->audits.contains(auditState.getType())) {
+			if (self->audits[auditState.getType()].contains(auditState.id)) {
+				continue; // ignore outdated resume
+			}
+		}
+		if (auditState.getPhase() == AuditPhase::Complete || auditState.getPhase() == AuditPhase::Error) {
+			continue;
+		}
+		TraceEvent("ResumingAuditStorage", self->ddId).detail("AuditID", auditState.id);
+		fs.push_back(resumeAuditStorage(self, auditState));
+	}
+	wait(waitForAll(fs));
+	self->auditInitialized.send(Void());
+	TraceEvent("ResumingAuditStorageDone", self->ddId);
+	return Void();
+}
+
 // Periodically check and log the physicalShard status; clean up empty physicalShard;
 ACTOR Future<Void> monitorPhysicalShardStatus(Reference<PhysicalShardCollection> self) {
 	ASSERT(SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA);
@@ -609,6 +629,7 @@ ACTOR Future<Void> dataDistribution(Reference<DataDistributor> self,
 	loop {
 		trackerCancelled = false;
 		self->initialized = Promise<Void>();
+		self->auditInitialized = Promise<Void>();
 
 		// Stored outside of data distribution tracker to avoid slow tasks
 		// when tracker is cancelled
@@ -619,11 +640,6 @@ ACTOR Future<Void> dataDistribution(Reference<DataDistributor> self,
 
 			// When/If this assertion fails, Evan owes Ben a pat on the back for his foresight
 			ASSERT(self->configuration.storageTeamSize > 0);
-
-			for (const auto& auditState : self->initData->auditStates) {
-				TraceEvent("ResumingAuditStorage", self->ddId).detail("AuditID", auditState.id);
-				self->addActor.send(resumeAuditStorage(self, auditState));
-			}
 
 			state PromiseStream<Promise<int64_t>> getAverageShardBytes;
 			state PromiseStream<Promise<int>> getUnhealthyRelocationCount;
@@ -660,6 +676,8 @@ ACTOR Future<Void> dataDistribution(Reference<DataDistributor> self,
 			} else {
 				anyZeroHealthyTeams = zeroHealthyTeams[0];
 			}
+
+			actors.push_back(resumeStorageAudits(self));
 
 			actors.push_back(self->pollMoveKeysLock());
 			actors.push_back(reportErrorsExcept(dataDistributionTracker(self->initData,
@@ -1378,47 +1396,54 @@ ACTOR Future<Void> ddGetMetrics(GetDataDistributorMetricsRequest req,
 }
 
 ACTOR Future<Void> resumeAuditStorage(Reference<DataDistributor> self, AuditStorageState auditState) {
-	if (auditState.getPhase() == AuditPhase::Complete) {
-		return Void();
-	}
-
 	state std::shared_ptr<DDAudit> audit =
 	    std::make_shared<DDAudit>(auditState.id, auditState.range, auditState.getType());
 	self->audits[auditState.getType()][audit->id] = audit;
 	audit->actors.add(loadAndDispatchAuditRange(self, audit, auditState.range));
-	TraceEvent(SevDebug, "DDResumAuditStorageBegin", self->ddId)
+	TraceEvent(SevDebug, "DDResumeAuditStorageBegin", self->ddId)
 	    .detail("AuditID", audit->id)
 	    .detail("Range", auditState.range)
 	    .detail("AuditType", auditState.type);
-
-	try {
-		wait(audit->actors.getResult());
-		TraceEvent(SevDebug, "DDResumeAuditStorageEnd", self->ddId)
-		    .detail("AuditID", audit->id)
-		    .detail("Range", auditState.range)
-		    .detail("AuditType", auditState.type);
-		auditState.setPhase(AuditPhase::Complete);
-		wait(persistAuditState(self->txnProcessor->context(), auditState));
-	} catch (Error& e) {
-		TraceEvent(SevInfo, "DDResumeAuditStorageOperationError", self->ddId)
-		    .errorUnsuppressed(e)
-		    .detail("AuditID", audit->id)
-		    .detail("Range", auditState.range)
-		    .detail("AuditType", auditState.type);
-		if (e.code() == error_code_audit_storage_error) {
-			auditState.setPhase(AuditPhase::Error);
+	state int retryTime = 0;
+	loop {
+		try {
+			wait(audit->actors.getResult());
+			TraceEvent(SevDebug, "DDResumeAuditStorageEnd", self->ddId)
+			    .detail("AuditID", audit->id)
+			    .detail("Range", auditState.range)
+			    .detail("AuditType", auditState.type);
+			auditState.setPhase(AuditPhase::Complete);
 			wait(persistAuditState(self->txnProcessor->context(), auditState));
-		} else if (e.code() != error_code_actor_cancelled) {
-			wait(delay(30));
-			self->addActor.send(resumeAuditStorage(self, auditState));
+		} catch (Error& e) {
+			TraceEvent(SevInfo, "DDResumeAuditStorageOperationError", self->ddId)
+			    .errorUnsuppressed(e)
+			    .detail("AuditID", audit->id)
+			    .detail("Range", auditState.range)
+			    .detail("AuditType", auditState.type);
+			if (e.code() == error_code_audit_storage_error) {
+				auditState.setPhase(AuditPhase::Error);
+				wait(persistAuditState(self->txnProcessor->context(), auditState));
+			} else if (retryTime > 10) {
+				auditState.setPhase(AuditPhase::Failed);
+				wait(persistAuditState(self->txnProcessor->context(), auditState));
+			} else if (e.code() != error_code_actor_cancelled) {
+				wait(delay(30));
+				retryTime++;
+				continue;
+			}
 		}
+		break;
 	}
 	self->audits[auditState.getType()].erase(audit->id);
-
 	return Void();
 }
 
 ACTOR Future<Void> auditStorage(Reference<DataDistributor> self, TriggerAuditRequest req) {
+	std::vector<Future<Void>> fs;
+	fs.push_back(self->auditInitialized.getFuture());
+	fs.push_back(self->initialized.getFuture());
+	wait(waitForAll(fs));
+
 	state std::shared_ptr<DDAudit> audit;
 	// TODO: store AuditStorageState in DDAudit.
 	state AuditStorageState auditState;

--- a/fdbserver/workloads/MetaclusterManagementWorkload.actor.cpp
+++ b/fdbserver/workloads/MetaclusterManagementWorkload.actor.cpp
@@ -358,8 +358,9 @@ struct MetaclusterManagementWorkload : TestWorkload {
 
 				state std::vector<Future<Void>> deleteFutures;
 				for (auto const& f : getFutures) {
-					ASSERT(f.get().present());
-					deleteFutures.push_back(TenantAPI::deleteTenantTransaction(tr, f.get().get()));
+					if (f.get().present()) {
+						deleteFutures.push_back(TenantAPI::deleteTenantTransaction(tr, f.get().get()));
+					}
 				}
 
 				wait(waitForAll(deleteFutures));

--- a/fdbserver/workloads/ValidateStorage.actor.cpp
+++ b/fdbserver/workloads/ValidateStorage.actor.cpp
@@ -125,12 +125,15 @@ struct ValidateStorage : TestWorkload {
 					throw audit_storage_failed();
 				}
 				ASSERT(auditId_ != auditId);
+				TraceEvent("TestValidateEnd").detail("AuditID", auditId_);
 				break;
 			} catch (Error& e) {
 				TraceEvent(SevWarn, "StartAuditStorageError").errorUnsuppressed(e);
 				wait(delay(1));
 			}
 		}
+
+		TraceEvent("TestValidateEndAll");
 
 		return Void();
 	}


### PR DESCRIPTION
Cherry picks #9555 

Problem: auditStorage and resumeAuditStorage can interleave with each other. As a result, resumeAuditStorage can pollute the state updated by auditStorage.

Solution:

A resumeAuditStorage should not overwrite any ongoing auditStorage triggered before the resumeAuditStorage;
Any auditStorage triggered after a resumeAuditStorage must wait for the completion of resumeAuditStorage;
Initialization of DD does not wait on resumeAuditStorage.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
