### PR TITLE
Allow code to act on test timeouts

### DIFF
--- a/fdbrpc/include/fdbrpc/SimulatorMachineInfo.h
+++ b/fdbrpc/include/fdbrpc/SimulatorMachineInfo.h
@@ -27,6 +27,7 @@
 #include <vector>
 
 #include "flow/Optional.h"
+#include "flow/IAsyncFile.h"
 
 namespace simulator {
 

--- a/fdbrpc/include/fdbrpc/SimulatorProcessInfo.h
+++ b/fdbrpc/include/fdbrpc/SimulatorProcessInfo.h
@@ -27,6 +27,8 @@
 #include "flow/NetworkAddress.h"
 #include "flow/IConnection.h"
 #include "flow/IUDPSocket.h"
+#include "flow/TDMetric.actor.h"
+#include "flow/ChaosMetrics.h"
 
 #include "fdbrpc/SimulatorMachineInfo.h"
 #include "fdbrpc/SimulatorKillType.h"

--- a/fdbserver/QuietDatabase.actor.cpp
+++ b/fdbserver/QuietDatabase.actor.cpp
@@ -645,7 +645,7 @@ ACTOR Future<bool> getStorageServersRecruiting(Database cx, WorkerInterface dist
 				return true;
 			}
 		}
-		return now() > 500;
+		return false;
 	} catch (Error& e) {
 		TraceEvent("QuietDatabaseFailure", distributorWorker.id())
 		    .detail("Reason", "Failed to extract StorageServersRecruiting")
@@ -878,8 +878,7 @@ ACTOR Future<Void> waitForQuietDatabase(Database cx,
                                         int64_t maxDataDistributionQueueSize = 0,
                                         int64_t maxPoppedVersionLag = 30e6,
                                         int64_t maxVersionOffset = 1e6) {
-	// state QuietDatabaseChecker checker(isBuggifyEnabled(BuggifyType::General) ? 4000.0 : 1000.0);
-	state QuietDatabaseChecker checker(1000000);
+	state QuietDatabaseChecker checker(isBuggifyEnabled(BuggifyType::General) ? 4000.0 : 1000.0);
 	state Future<Void> reconfig =
 	    reconfigureAfter(cx, 100 + (deterministicRandom()->random01() * 100), dbInfo, "QuietDatabase");
 	state Future<int64_t> dataInFlight;

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -45,6 +45,7 @@
 #include "fdbclient/versions.h"
 #include "flow/IRandom.h"
 #include "flow/MkCert.h"
+#include "flow/ProcessEvents.h"
 #include "fdbrpc/WellKnownEndpoints.h"
 #include "flow/ProtocolVersion.h"
 #include "flow/network.h"
@@ -2807,6 +2808,10 @@ ACTOR void setupAndRun(std::string dataFolder,
 		                                                   ? testConfig.simulationBuggifyRunTestsTimeoutSeconds
 		                                                   : testConfig.simulationNormalRunTestsTimeoutSeconds));
 	} catch (Error& e) {
+		auto timeoutVal = isBuggifyEnabled(BuggifyType::General) ? testConfig.simulationBuggifyRunTestsTimeoutSeconds
+		                                                         : testConfig.simulationNormalRunTestsTimeoutSeconds;
+		auto msg = fmt::format("Timeout after {} simulated seconds", timeoutVal);
+		ProcessEvents::trigger("Timeout"_sr, StringRef(msg), e);
 		TraceEvent(SevError, "SetupAndRunError").error(e);
 	}
 

--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -21,9 +21,7 @@
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/directory.hpp>
-#include <boost/filesystem/file_status.hpp>
 #include <boost/filesystem/path.hpp>
-#include <boost/range/iterator_range.hpp>
 #include <boost/range/iterator_range_core.hpp>
 #include <cinttypes>
 #include <fstream>
@@ -35,11 +33,9 @@
 #include <toml.hpp>
 
 #include "flow/ActorCollection.h"
-#include "flow/ChaosMetrics.h"
 #include "flow/DeterministicRandom.h"
 #include "flow/Histogram.h"
-#include "flow/IAsyncFile.h"
-#include "flow/TDMetric.actor.h"
+#include "flow/ProcessEvents.h"
 #include "fdbrpc/Locality.h"
 #include "fdbrpc/SimulatorProcessInfo.h"
 #include "fdbrpc/sim_validation.h"
@@ -54,13 +50,10 @@
 #include "fdbserver/TesterInterface.actor.h"
 #include "fdbserver/WorkerInterface.actor.h"
 #include "fdbserver/workloads/workloads.actor.h"
-#include "fdbserver/Status.actor.h"
 #include "fdbserver/QuietDatabase.h"
 #include "fdbclient/MonitorLeader.h"
-#include "fdbserver/CoordinationInterface.h"
 #include "fdbclient/ManagementAPI.actor.h"
 #include "fdbserver/Knobs.h"
-#include "fdbserver/WorkerInterface.actor.h"
 #include "flow/Platform.h"
 
 #include "flow/actorcompiler.h" // This must be the last #include.
@@ -1285,6 +1278,8 @@ ACTOR Future<bool> runTest(Database cx,
 		testResults = _testResults;
 		logMetrics(testResults.metrics);
 	} catch (Error& e) {
+		auto msg = fmt::format("Process timed out after {} seconds", spec.timeout);
+		ProcessEvents::trigger("Timeout"_sr, StringRef(msg), e);
 		if (e.code() == error_code_timed_out) {
 			TraceEvent(SevError, "TestFailure")
 			    .error(e)

--- a/fdbserver/workloads/ConsistencyCheck.actor.cpp
+++ b/fdbserver/workloads/ConsistencyCheck.actor.cpp
@@ -22,7 +22,7 @@
 #include "boost/lexical_cast.hpp"
 
 #include "flow/IRandom.h"
-#include "fdbclient/Tracing.h"
+#include "flow/ProcessEvents.h"
 #include "fdbclient/NativeAPI.actor.h"
 #include "fdbclient/FDBTypes.h"
 #include "fdbserver/TesterInterface.actor.h"
@@ -46,6 +46,18 @@
 #define SevCCheckInfo SevInfo
 
 struct ConsistencyCheckWorkload : TestWorkload {
+	struct OnTimeout {
+		ConsistencyCheckWorkload& self;
+		explicit OnTimeout(ConsistencyCheckWorkload& self) : self(self) {}
+		void operator()(StringRef name, StringRef msg, Error const& e) {
+			TraceEvent(SevError, "ConsistencyCheckFailure")
+			    .error(e)
+			    .detail("EventName", name)
+			    .detail("EventMessage", msg)
+			    .log();
+		}
+	};
+
 	static constexpr auto NAME = "ConsistencyCheck";
 	// Whether or not we should perform checks that will only pass if the database is in a quiescent state
 	bool performQuiescentChecks;
@@ -99,7 +111,11 @@ struct ConsistencyCheckWorkload : TestWorkload {
 
 	Future<Void> monitorConsistencyCheckSettingsActor;
 
-	ConsistencyCheckWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
+	OnTimeout onTimeout;
+	ProcessEvents::Event onTimeoutEvent;
+
+	ConsistencyCheckWorkload(WorkloadContext const& wcx)
+	  : TestWorkload(wcx), onTimeout(*this), onTimeoutEvent({ "Timeout"_sr, "TracedTooManyLines"_sr }, onTimeout) {
 		performQuiescentChecks = getOption(options, "performQuiescentChecks"_sr, false);
 		performCacheCheck = getOption(options, "performCacheCheck"_sr, false);
 		performTSSCheck = getOption(options, "performTSSCheck"_sr, true);

--- a/flow/ProcessEvents.cpp
+++ b/flow/ProcessEvents.cpp
@@ -1,0 +1,96 @@
+/*
+ * ProcessEvents.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2023 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "flow/ProcessEvents.h"
+
+#include <unordered_map>
+#include <vector>
+
+namespace {
+
+struct EventImpl {
+	using Id = intptr_t;
+	std::vector<StringRef> names;
+	ProcessEvents::Callback callback;
+
+	EventImpl(std::vector<StringRef> names, ProcessEvents::Callback callback)
+	  : names(std::move(names)), callback(std::move(callback)) {
+		addEvent();
+	}
+	~EventImpl() { removeEvent(); }
+	Id id() const { return reinterpret_cast<intptr_t>(this); }
+	void addEvent();
+	void removeEvent();
+};
+
+struct ProcessEventsImpl {
+	std::unordered_map<StringRef, std::unordered_map<EventImpl::Id, EventImpl*>> events;
+
+	void trigger(StringRef name, StringRef msg, Error const& e) const {
+		auto iter = events.find(name);
+		// strictly speaking this isn't a bug, but having callbacks that aren't caught
+		// by anyone could mean that something was misspelled. Therefore, the safe thing
+		// to do is to abort.
+		ASSERT(iter != events.end());
+		std::unordered_map<EventImpl::Id, EventImpl*> callbacks;
+		// These two iterations are necessary, since some callbacks might appear in multiple maps
+		for (auto const& c : iter->second) {
+			callbacks.insert(c);
+		}
+		// after we collected all unique callbacks we can call each
+		for (auto const& c : callbacks) {
+			c.second->callback(name, msg, e);
+		}
+	}
+};
+
+ProcessEventsImpl impl;
+
+void EventImpl::addEvent() {
+	for (auto const& name : names) {
+		impl.events[name].emplace(this->id(), this);
+	}
+}
+
+void EventImpl::removeEvent() {
+	for (auto const& name : names) {
+		impl.events[name].erase(this->id());
+	}
+}
+
+} // namespace
+
+namespace ProcessEvents {
+
+void trigger(StringRef name, StringRef msg, Error const& e) {
+	impl.trigger(name, msg, e);
+}
+
+Event::Event(StringRef name, Callback callback) {
+	impl = new EventImpl({ std::move(name) }, std::move(callback));
+}
+Event::Event(std::vector<StringRef> names, Callback callback) {
+	impl = new EventImpl(std::move(names), std::move(callback));
+}
+Event::~Event() {
+	delete reinterpret_cast<EventImpl*>(impl);
+}
+
+} // namespace ProcessEvents

--- a/flow/Trace.cpp
+++ b/flow/Trace.cpp
@@ -25,7 +25,7 @@
 #include "flow/JsonTraceLogFormatter.h"
 #include "flow/flow.h"
 #include "flow/DeterministicRandom.h"
-#include "flow/UnitTest.h"
+#include "flow/ProcessEvents.h"
 #include <exception>
 #include <stdlib.h>
 #include <stdarg.h>
@@ -1361,6 +1361,8 @@ BaseTraceEvent::~BaseTraceEvent() {
 	log();
 	if (failedLineOverflow == 1) {
 		failedLineOverflow = 2;
+		auto msg = fmt::format("Traced {} lines", tracedLines);
+		ProcessEvents::trigger("TracedTooManyLines"_sr, StringRef(msg), unknown_error());
 		TraceEvent(SevError, "TracedTooManyLines").log();
 		crashAndDie();
 	}

--- a/flow/include/flow/ProcessEvents.h
+++ b/flow/include/flow/ProcessEvents.h
@@ -1,0 +1,43 @@
+/*
+ * ProcessEvents.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2023 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FLOW_PROCESS_EVENTS_H
+#define FLOW_PROCESS_EVENTS_H
+#include <functional>
+#include "flow/flow.h"
+
+namespace ProcessEvents {
+
+using Callback = std::function<void(StringRef, StringRef, Error const&)>;
+
+class Event : NonCopyable {
+	void* impl;
+
+public:
+	Event(StringRef name, Callback callback);
+	Event(std::vector<StringRef> name, Callback callback);
+	~Event();
+};
+
+void trigger(StringRef name, StringRef msg, Error const& e);
+
+} // namespace ProcessEvents
+
+#endif // FLOW_PROCESS_EVENTS_H


### PR DESCRIPTION
Added a new ProcessEvents framwork which allows one to be called on events on the process level. This is meant for debugging things like timeouts.

In addition this PR adds code so that if a test times out due to consistency check or quiet database, it will produce additional sev40s. This will allow for better triaging when looking at Joshua failures.

An example failure looks like this:

```
      {
        "Type": "ConsistencyCheckFailure",
        "Severity": "40",
        "ErrorKind": "Unset",
        "Time": "5401.000000",
        "DateTime": "2023-03-07T00:37:25Z",
        "Machine": "0.0.0.0:0",
        "ID": "0000000000000000",
        "Error": "timed_out",
        "ErrorDescription": "Operation timed out",
        "ErrorCode": "1004",
        "EventName": "Timeout",
        "EventMessage": "Timeout after 5400 simulated seconds",
        "ThreadID": "7130078269793056488",
        "Backtrace": "addr2line -e fdbserver.debug -p -C -f -i 0x4a1191d 0x4a11bdd 0x3501849 0x49ee027 0x2aafdc3 0x2aa96db 0x194bda9 0x20b70f4 0x19615c8 0x48f4141 0x48f3c5a 0x2e9cfac 0x7f0ec04f3555",
        "LogGroup": "default"
      },
      {
        "Type": "QuietDatabaseFailure",
        "Severity": "40",
        "ErrorKind": "Unset",
        "Time": "5401.000000",
        "DateTime": "2023-03-07T00:37:25Z",
        "Machine": "0.0.0.0:0",
        "ID": "0000000000000000",
        "Error": "timed_out",
        "ErrorDescription": "Operation timed out",
        "ErrorCode": "1004",
        "EventName": "Timeout",
        "EventMessage": "Timeout after 5400 simulated seconds",
        "Reasons": "StorageServersRecruiting",
        "ThreadID": "7130078269793056488",
        "Backtrace": "addr2line -e fdbserver.debug -p -C -f -i 0x4a1191d 0x4a11bdd 0x287f6cd 0x49ee027 0x2aafdc3 0x2aa96db 0x194bda9 0x20b70f4 0x19615c8 0x48f4141 0x48f3c5a 0x2e9cfac 0x7f0ec04f3555",
        "LogGroup": "default"
      },
      {
        "Type": "SetupAndRunError",
        "Severity": "40",
        "ErrorKind": "Unset",
        "Time": "5401.000000",
        "DateTime": "2023-03-07T00:37:25Z",
        "Machine": "0.0.0.0:0",
        "ID": "0000000000000000",
        "Error": "timed_out",
        "ErrorDescription": "Operation timed out",
        "ErrorCode": "1004",
        "ThreadID": "7130078269793056488",
        "Backtrace": "addr2line -e fdbserver.debug -p -C -f -i 0x4a1191d 0x4a11bdd 0x4a0bcd4 0x2aafdfb 0x2aa96db 0x194bda9 0x20b70f4 0x19615c8 0x48f4141 0x48f3c5a 0x2e9cfac 0x7f0ec04f3555",
        "LogGroup": "default"
      }
```

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
