### PR TITLE
fixing bytesInNewDeltaFiles calculation when a snapshot file is rolle…

### DIFF
--- a/fdbserver/BlobWorker.actor.cpp
+++ b/fdbserver/BlobWorker.actor.cpp
@@ -1028,6 +1028,14 @@ ACTOR Future<BlobFileIndex> writeEmptyDeltaFile(Reference<BlobWorkerData> bwData
 			if (!dfValue.present()) {
 				// Only check if not seen yet. If we get commit unknown result and then retry, we'd see our own delete
 				wait(store(dfValue, tr->get(oldDFKey)));
+				if (!dfValue.present()) {
+					TraceEvent("MissingFileEmptyWrite", bwData->id)
+					    .detail("Granule", keyRange)
+					    .detail("PrevVersion", previousVersion)
+					    .detail("CurrentVersion", currentDeltaVersion)
+					    .detail("PrevKey", oldDFKey)
+					    .detail("NewKey", newDFKey);
+				}
 				ASSERT(dfValue.present());
 			} else {
 				tr->addReadConflictRange(singleKeyRange(oldDFKey));
@@ -1962,7 +1970,9 @@ Version doGranuleRollback(Reference<GranuleMetadata> metadata,
 		cfRollbackVersion = metadata->durableDeltaVersion.get();
 		metadata->pendingSnapshotVersion = metadata->durableSnapshotVersion.get();
 		int toPop = 0;
-		bool pendingSnapshot = false;
+		// keep bytes in delta files pending here, then add back already durable delta files at end
+		metadata->bytesInNewDeltaFiles = 0;
+
 		for (auto& f : inFlightFiles) {
 			if (f.snapshot) {
 				if (f.version > rollbackVersion) {
@@ -1978,14 +1988,10 @@ Version doGranuleRollback(Reference<GranuleMetadata> metadata,
 				} else {
 					metadata->pendingSnapshotVersion = f.version;
 					metadata->bytesInNewDeltaFiles = 0;
-					pendingSnapshot = true;
 				}
 			} else {
 				if (f.version > rollbackVersion) {
 					f.future.cancel();
-					if (!pendingSnapshot) {
-						metadata->bytesInNewDeltaFiles -= f.bytes;
-					}
 					toPop++;
 					CODE_PROBE(true, "Granule rollback cancelling delta file");
 					if (BW_DEBUG) {
@@ -1997,9 +2003,7 @@ Version doGranuleRollback(Reference<GranuleMetadata> metadata,
 				} else {
 					ASSERT(f.version > cfRollbackVersion);
 					cfRollbackVersion = f.version;
-					if (pendingSnapshot) {
-						metadata->bytesInNewDeltaFiles += f.bytes;
-					}
+					metadata->bytesInNewDeltaFiles += f.bytes;
 				}
 			}
 		}
@@ -2025,6 +2029,14 @@ Version doGranuleRollback(Reference<GranuleMetadata> metadata,
 		metadata->currentDeltas = Standalone<GranuleDeltas>();
 		metadata->bufferedDeltaBytes = 0;
 		metadata->bufferedDeltaVersion = cfRollbackVersion;
+
+		// calculate number of bytes in durable delta files after last snapshot
+		// FIXME: this assumes delta file serialized size ~= logical size, which is false with compression
+		for (int i = metadata->files.deltaFiles.size() - 1;
+		     i >= 0 && metadata->files.deltaFiles[i].version > metadata->pendingSnapshotVersion;
+		     i--) {
+			metadata->bytesInNewDeltaFiles += metadata->files.deltaFiles[i].length;
+		}
 
 		// Track that this rollback happened, since we have to re-read mutations up to the rollback
 		// Add this rollback to in progress, and put all completed ones back in progress
@@ -2359,6 +2371,8 @@ ACTOR Future<Void> blobGranuleUpdateFiles(Reference<BlobWorkerData> bwData,
 				Version snapshotVersion = files.snapshotFiles.back().version;
 				for (int i = files.deltaFiles.size() - 1; i >= 0; i--) {
 					if (files.deltaFiles[i].version > snapshotVersion) {
+						// FIXME: this assumes delta file serialized size ~= logical size, which is false with
+						// compression
 						metadata->bytesInNewDeltaFiles += files.deltaFiles[i].length;
 					}
 				}


### PR DESCRIPTION
This logic was correct when there was no snapshot file rolled back (either the rollback didn't cross a snapshot boundary, or the snapshot file was kept in-flight instead of cancelled).

Passes 100k BlobGranule* correctness with no related errors

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
