### PR TITLE
Metacluster/tenant fixes (snowflake/release-71.3)

### DIFF
--- a/documentation/sphinx/source/command-line-interface.rst
+++ b/documentation/sphinx/source/command-line-interface.rst
@@ -483,8 +483,6 @@ status json
 
 ``status json`` will provide the cluster status in its JSON format. For a detailed description of this format, see :doc:`mr-status`.
 
-.. _cli-throttle:
-
 tenant
 ------
 
@@ -625,6 +623,8 @@ In the event of an error, the JSON output will include an error message::
         "error": "...",
         "type": "error"
     }
+
+.. _cli-throttle:
 
 throttle
 --------

--- a/fdbcli/TenantCommands.actor.cpp
+++ b/fdbcli/TenantCommands.actor.cpp
@@ -324,7 +324,8 @@ ACTOR Future<bool> tenantDeleteIdCommand(Reference<IDatabase> db, std::vector<St
 // tenant list command
 ACTOR Future<bool> tenantListCommand(Reference<IDatabase> db, std::vector<StringRef> tokens) {
 	if (tokens.size() > 7) {
-		fmt::print("Usage: tenant list [BEGIN] [END] [limit=LIMIT] [offset=OFFSET] [state=<STATE1>,<STATE2>,...]\n\n");
+		fmt::print(
+		    "Usage: tenant list [BEGIN] [END] [limit=<LIMIT>|offset=<OFFSET>|state=<STATE1>,<STATE2>,...] ...\n\n");
 		fmt::print("Lists the tenants in a cluster.\n");
 		fmt::print("Only tenants in the range BEGIN - END will be printed.\n");
 		fmt::print("An optional LIMIT can be specified to limit the number of results (default 100).\n");
@@ -896,7 +897,7 @@ std::vector<const char*> tenantHintGenerator(std::vector<StringRef> const& token
 }
 
 CommandFactory tenantRegisterFactory("tenant",
-                                     CommandHelp("tenant <create|delete|list|get|configure|rename> [ARGS]",
+                                     CommandHelp("tenant <create|delete|list|get|configure|rename|lock|unlock> [ARGS]",
                                                  "view and manage tenants in a cluster or metacluster",
                                                  "`create' and `delete' add and remove tenants from the cluster.\n"
                                                  "`list' prints a list of tenants in the cluster.\n"

--- a/fdbclient/include/fdbclient/MetaclusterManagement.actor.h
+++ b/fdbclient/include/fdbclient/MetaclusterManagement.actor.h
@@ -550,6 +550,10 @@ Future<Optional<std::string>> createMetacluster(Reference<DB> db,
 	ASSERT(tenantIdPrefix >= TenantAPI::TENANT_ID_PREFIX_MIN_VALUE &&
 	       tenantIdPrefix <= TenantAPI::TENANT_ID_PREFIX_MAX_VALUE);
 
+	if (name.startsWith("\xff"_sr)) {
+		throw invalid_cluster_name();
+	}
+
 	loop {
 		try {
 			tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
@@ -1208,6 +1212,10 @@ struct RegisterClusterImpl {
 		// Used if we need to rollback
 		state RemoveClusterImpl<DB> removeCluster(
 		    self->ctx.managementDb, self->clusterName, ClusterType::METACLUSTER_MANAGEMENT, ForceRemove::True, 5.0);
+
+		if (self->clusterName.startsWith("\xff"_sr)) {
+			throw invalid_cluster_name();
+		}
 
 		wait(self->ctx.runManagementTransaction(
 		    [self = self](Reference<typename DB::TransactionT> tr) { return registerInManagementCluster(self, tr); }));

--- a/fdbserver/workloads/MetaclusterManagementWorkload.actor.cpp
+++ b/fdbserver/workloads/MetaclusterManagementWorkload.actor.cpp
@@ -154,6 +154,10 @@ struct MetaclusterManagementWorkload : TestWorkload {
 		state Reference<DataClusterData> dataDb = self->dataDbs[clusterName];
 		state bool retried = false;
 
+		if (deterministicRandom()->random01() < 0.1) {
+			clusterName = "\xff"_sr.withSuffix(clusterName);
+		}
+
 		try {
 			state DataClusterEntry entry;
 			entry.capacity.numTenantGroups = deterministicRandom()->randomInt(0, 4);
@@ -198,6 +202,7 @@ struct MetaclusterManagementWorkload : TestWorkload {
 				}
 			}
 
+			ASSERT(!clusterName.startsWith("\xff"_sr));
 			ASSERT(!dataDb->registered);
 			ASSERT(!dataDb->detached || dataDb->tenants.empty());
 
@@ -215,6 +220,9 @@ struct MetaclusterManagementWorkload : TestWorkload {
 				return Void();
 			} else if (e.code() == error_code_cluster_not_empty) {
 				ASSERT(dataDb->detached && !dataDb->tenants.empty());
+				return Void();
+			} else if (e.code() == error_code_invalid_cluster_name) {
+				ASSERT(clusterName.startsWith("\xff"_sr));
 				return Void();
 			}
 


### PR DESCRIPTION
This is a cherry-pick of #9613.

This fixes a few minor issues with the metacluster and tenants:

1. Throw an error if a cluster name starts with `\xff`
2. Improve the help text in fdbcli for some tenant commands
3. Fix a link in the fdbcli documentation that was incorrectly placed above the tenant section

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
