### PR TITLE
IndexSet and TransientStorageMetricSample optimization - change parameter type from KeyRef to Key to avoid extra copy in sampler (Cherry-Pick #9571 to snowflake/release-71.3)

### DIFF
--- a/fdbserver/include/fdbserver/StorageMetrics.actor.h
+++ b/fdbserver/include/fdbserver/StorageMetrics.actor.h
@@ -63,7 +63,7 @@ struct TransientStorageMetricSample : StorageMetricSample {
 
 	explicit TransientStorageMetricSample(int64_t metricUnitsPerSample) : StorageMetricSample(metricUnitsPerSample) {}
 
-	int64_t addAndExpire(KeyRef key, int64_t metric, double expiration);
+	int64_t addAndExpire(const Key& key, int64_t metric, double expiration);
 
 	int64_t erase(KeyRef key);
 	void erase(KeyRangeRef keys);
@@ -73,8 +73,10 @@ struct TransientStorageMetricSample : StorageMetricSample {
 	void poll();
 
 private:
-	bool roll(KeyRef key, int64_t metric) const;
-	int64_t add(KeyRef key, int64_t metric);
+	bool roll(int64_t metric) const;
+
+	// return the sampled metric delta
+	int64_t add(const Key& key, int64_t metric);
 };
 
 struct StorageServerMetrics {
@@ -92,14 +94,14 @@ struct StorageServerMetrics {
 
 	StorageMetrics getMetrics(KeyRangeRef const& keys) const;
 
-	void notify(KeyRef key, StorageMetrics& metrics);
+	void notify(const Key& key, StorageMetrics& metrics);
 
-	void notifyBytesReadPerKSecond(KeyRef key, int64_t in);
+	void notifyBytesReadPerKSecond(const Key& key, int64_t in);
 
 	void notifyBytes(RangeMap<Key, std::vector<PromiseStream<StorageMetrics>>, KeyRangeRef>::iterator shard,
 	                 int64_t bytes);
 
-	void notifyBytes(KeyRef key, int64_t bytes);
+	void notifyBytes(const KeyRef& key, int64_t bytes);
 
 	void notifyNotReadable(KeyRangeRef keys);
 

--- a/flow/include/flow/IndexedSet.h
+++ b/flow/include/flow/IndexedSet.h
@@ -193,9 +193,9 @@ public:
 	int insert(const std::vector<std::pair<T, Metric>>& data, bool replaceExisting = true);
 
 	// Increase the metric for the given item by the given amount.  Inserts data into the set if it
-	//   doesn't exist. Returns the new sum.
+	//   doesn't exist. Returns the pair of new sum and inserted iterator.
 	template <class T_, class Metric_>
-	Metric addMetric(T_&& data, Metric_&& metric);
+	std::pair<Metric, iterator> addMetric(T_&& data, Metric_&& metric);
 
 	// Remove the data item, if any, which is equal to key
 	template <class Key>
@@ -820,15 +820,16 @@ typename IndexedSet<T, Metric>::template Impl<isConst>::IteratorT IndexedSet<T, 
 
 template <class T, class Metric>
 template <class T_, class Metric_>
-Metric IndexedSet<T, Metric>::addMetric(T_&& data, Metric_&& metric) {
+std::pair<Metric, typename IndexedSet<T, Metric>::iterator> IndexedSet<T, Metric>::addMetric(T_&& data,
+                                                                                             Metric_&& metric) {
 	auto i = find(data);
 	if (i == end()) {
-		insert(std::forward<T_>(data), std::forward<Metric_>(metric));
-		return metric;
+		auto it = insert(std::forward<T_>(data), std::forward<Metric_>(metric));
+		return { metric, it };
 	} else {
 		Metric m = metric + getMetric(i);
-		insert(std::forward<T_>(data), m);
-		return m;
+		auto it = insert(std::forward<T_>(data), m);
+		return { m, it };
 	}
 }
 

--- a/flow/include/flow/MetricSample.h
+++ b/flow/include/flow/MetricSample.h
@@ -127,14 +127,14 @@ struct TransientThresholdMetricSample : MetricSample<T> {
 			int64_t delta = std::get<2>(queue.front());
 			ASSERT(delta != 0);
 
-			int64_t val = this->sample.addMetric(T(key), delta);
+			auto [val, it] = this->sample.addMetric(T(key), delta);
 			if (val < thresholdLimit && (val + std::abs(delta)) >= thresholdLimit) {
 				auto iter = thresholdCrossedSet.find(key);
 				ASSERT(iter != thresholdCrossedSet.end());
 				thresholdCrossedSet.erase(iter);
 			}
 			if (val == 0)
-				this->sample.erase(key);
+				this->sample.erase(it);
 
 			queue.pop_front();
 		}
@@ -159,7 +159,7 @@ private:
 			metric = metric < 0 ? -this->metricUnitsPerSample : this->metricUnitsPerSample;
 		}
 
-		int64_t val = this->sample.addMetric(T(key), metric);
+		auto [val, it] = this->sample.addMetric(T(key), metric);
 		if (val >= thresholdLimit) {
 			ASSERT((val - metric) < thresholdLimit ? thresholdCrossedSet.find(key) == thresholdCrossedSet.end()
 			                                       : thresholdCrossedSet.find(key) != thresholdCrossedSet.end());
@@ -167,7 +167,7 @@ private:
 		}
 
 		if (val == 0)
-			this->sample.erase(key);
+			this->sample.erase(it);
 
 		return metric;
 	}


### PR DESCRIPTION
Cherry-Pick of #9571

Original Description:

1. change parameter type from KeyRef to Key to avoid extra copy in sampler
2. avoid second search in IndexSet

Pass 100k correctness test. And it eliminates extra `memcpy` comparing the former code.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
