### PR TITLE
Reduce running time for ClogTlog

### DIFF
--- a/tests/rare/ClogTlog.toml
+++ b/tests/rare/ClogTlog.toml
@@ -17,9 +17,9 @@ testTitle = 'ClogTlog'
     testName = 'Cycle'
     nodeCount = 30000
     transactionsPerSecond = 2500.0
-    testDuration = 120.0
+    testDuration = 60.0
     expectedRate = 0
 
     [[test.workload]]
     testName = 'ClogTlog'
-    testDuration = 3000.0
+    testDuration = 150.0


### PR DESCRIPTION
When the ClogTlog is running, we may already pass the 450s, i.e., SIM_SPEEDUP_AFTER_SECONDS, and clogging is no longer effective. If that's the case, we want to finish the test quickly.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
