### PR TITLE
Disable fdb_c_client_config_tests in snowflake/release-71.3

### DIFF
--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -327,12 +327,12 @@ if(NOT WIN32)
       )
 
     if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64" AND NOT USE_SANITIZER)
-      add_python_venv_test(NAME fdb_c_client_config_tests
-        COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/test/fdb_c_client_config_tests.py
-        --build-dir ${CMAKE_BINARY_DIR}
-        --client-config-tester-bin $<TARGET_FILE:fdb_c_client_config_tester>
-        )
-
+#      add_python_venv_test(NAME fdb_c_client_config_tests
+#        COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/test/fdb_c_client_config_tests.py
+#        --build-dir ${CMAKE_BINARY_DIR}
+#        --client-config-tester-bin $<TARGET_FILE:fdb_c_client_config_tester>
+#        )
+#
 #      add_python_venv_test(NAME fdb_c_upgrade_from_prev3_gradual
 #        COMMAND python ${CMAKE_SOURCE_DIR}/tests/TestRunner/upgrade_test.py
 #        --build-dir ${CMAKE_BINARY_DIR}


### PR DESCRIPTION
Disable fdb_c_client_config_tests in snowflake/release-71.3.

These tests were added on main after the 71.2 release and are currently failing on the 71.3 branch. Disable them for now to unblock CI while we figure out a solution.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
