### PR TITLE
Fixing double-completing of destination servers in busy map (Cherry-Pick #9629 to snowflake/release-71.3)

### DIFF
--- a/fdbserver/DDRelocationQueue.actor.cpp
+++ b/fdbserver/DDRelocationQueue.actor.cpp
@@ -2044,7 +2044,11 @@ ACTOR Future<Void> dataDistributionRelocator(DDQueue* self,
 				    trigger([destinationRef, readLoad]() mutable { destinationRef.addReadInFlightToTeam(-readLoad); },
 				            delay(SERVER_KNOBS->STORAGE_METRICS_AVERAGE_INTERVAL)));
 
-				completeDest(rd, self->destBusymap);
+				if (!signalledTransferComplete) {
+					// signalling transferComplete calls completeDest() in complete(), so doing so here would
+					// double-complete the work
+					completeDest(rd, self->destBusymap);
+				}
 				rd.completeDests.clear();
 
 				wait(delay(SERVER_KNOBS->RETRY_RELOCATESHARD_DELAY, TaskPriority::DataDistributionLaunch));


### PR DESCRIPTION
Cherry-Pick of #9629

Original Description:

Found by 71.2.7 release correctness tests, and appears to be a rare latent bug

Correctness in progress

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
