### PR TITLE
Fix asan error caused by StringRef parameter of updateRestoreState

### DIFF
--- a/fdbserver/BlobManager.actor.cpp
+++ b/fdbserver/BlobManager.actor.cpp
@@ -3545,7 +3545,7 @@ ACTOR Future<Void> recoverBlobManager(Reference<BlobManagerData> bmData) {
 				// terminate blob restore for non-retryable errors
 				TraceEvent("ManifestLoadError", bmData->id).error(e).detail("Phase", phase);
 				std::string errorMessage = fmt::format("Manifest loading error '{}'", e.what());
-				wait(BlobRestoreController::updateError(restoreController, errorMessage));
+				wait(BlobRestoreController::updateError(restoreController, StringRef(errorMessage)));
 			}
 		}
 	}

--- a/fdbserver/BlobMigrator.actor.cpp
+++ b/fdbserver/BlobMigrator.actor.cpp
@@ -657,7 +657,7 @@ ACTOR Future<Void> blobMigrator(BlobMigratorInterface interf, Reference<AsyncVar
 		TraceEvent("BlobMigratorError", interf.id()).error(e);
 		std::string errorMessage = fmt::format("Migrator failure '{}' on {}", e.what(), interf.address().toString());
 		Reference<BlobRestoreController> restoreController = makeReference<BlobRestoreController>(db, normalKeys);
-		wait(BlobRestoreController::updateError(restoreController, errorMessage));
+		wait(BlobRestoreController::updateError(restoreController, StringRef(errorMessage)));
 	}
 	return Void();
 }

--- a/fdbserver/BlobRestoreController.actor.cpp
+++ b/fdbserver/BlobRestoreController.actor.cpp
@@ -120,7 +120,8 @@ ACTOR Future<Void> BlobRestoreController::updateState(Reference<BlobRestoreContr
 	return Void();
 }
 
-ACTOR Future<Void> BlobRestoreController::updateError(Reference<BlobRestoreController> self, StringRef errorMessage) {
+ACTOR Future<Void> BlobRestoreController::updateError(Reference<BlobRestoreController> self,
+                                                      Standalone<StringRef> errorMessage) {
 	Standalone<BlobRestoreState> newState;
 	newState.error = StringRef(newState.arena(), errorMessage);
 	newState.phase = BlobRestorePhase::ERROR;

--- a/fdbserver/include/fdbserver/BlobGranuleServerCommon.actor.h
+++ b/fdbserver/include/fdbserver/BlobGranuleServerCommon.actor.h
@@ -183,7 +183,7 @@ public:
 	ACTOR static Future<Void> updateState(Reference<BlobRestoreController> self,
 	                                      BlobRestorePhase newPhase,
 	                                      Optional<BlobRestorePhase> expectedPhase);
-	ACTOR static Future<Void> updateError(Reference<BlobRestoreController> self, StringRef errorMessage);
+	ACTOR static Future<Void> updateError(Reference<BlobRestoreController> self, Standalone<StringRef> errorMessage);
 
 private:
 	Database db_;


### PR DESCRIPTION
cherrypick #9645

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
