### PR TITLE
Disable Python unit tests in sanitizer builds

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -83,9 +83,13 @@ add_custom_target(python_package DEPENDS ${package_file})
 add_dependencies(python_package python_binding)
 add_dependencies(packages python_package)
 
-add_fdbclient_test(
-  NAME python_unit_tests
-  COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/tests/unit_tests.py
-          --cluster-file @CLUSTER_FILE@ --verbose
-  DISABLE_LOG_DUMP
-)
+if(NOT OPEN_FOR_IDE AND NOT USE_SANITIZER)
+
+  add_fdbclient_test(
+    NAME python_unit_tests
+    COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/tests/unit_tests.py
+            --cluster-file @CLUSTER_FILE@ --verbose
+    DISABLE_LOG_DUMP
+  )
+
+endif() # NOT OPEN_FOR_IDE AND NOT USE_SANITIZER


### PR DESCRIPTION
Loading the client library over python FDB API in sanitizer builds leads to crashes. Therefore disabling python unit tests in sanitizer builds.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
