### PR TITLE
swallowing errors in redwood dispose (Cherry-Pick #9662 to snowflake/release-71.3)

### DIFF
--- a/fdbserver/VersionedBTree.actor.cpp
+++ b/fdbserver/VersionedBTree.actor.cpp
@@ -3666,7 +3666,10 @@ public:
 		if (dispose) {
 			if (!self->memoryOnly) {
 				debug_printf("DWALPager(%s) shutdown deleting file\n", self->filename.c_str());
-				wait(IAsyncFileSystem::filesystem()->incrementalDeleteFile(self->filename, true));
+				// We wrap this with ready() because we don't care if incrementalDeleteFile throws an error because:
+				// - if the file was unlinked, the file will be cleaned up by the filesystem after the process exits
+				// - if the file was not unlinked, the worker will restart and pick it up and it'll be removed later
+				wait(ready(IAsyncFileSystem::filesystem()->incrementalDeleteFile(self->filename, true)));
 			}
 		}
 


### PR DESCRIPTION
Cherry-Pick of #9662

Original Description:

Injected (or real) faults here cause shutdown to hang and a zombie worker that is still up but doesn't respond to requests.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
