### PR TITLE
EaR: REST kms misc fixes

### DIFF
--- a/fdbclient/RESTUtils.actor.cpp
+++ b/fdbclient/RESTUtils.actor.cpp
@@ -30,8 +30,6 @@
 
 #include "flow/actorcompiler.h" // always the last include
 
-const std::string forwardSlash = "/";
-
 const std::unordered_map<std::string, RESTConnectionType> RESTConnectionType::supportedConnTypes = {
 	{ "http", RESTConnectionType("http", RESTConnectionType::NOT_SECURE_CONNECTION) },
 	{ "https", RESTConnectionType("https", RESTConnectionType::SECURE_CONNECTION) }
@@ -234,15 +232,9 @@ void RESTUrl::parseUrl(const std::string& fullUrl) {
 		// extract 'resource' and optional 'parameter list' if supplied in the URL
 		uint8_t foundSeparator = 0;
 		StringRef hostPort = t.eatAny("/?", &foundSeparator);
+		this->resource = "/";
 		if (foundSeparator == '/') {
-			StringRef resourceRef = t.eat("?");
-			if (!resourceRef.empty()) {
-				// Resource needs to starts with '/'
-				if (!resourceRef.startsWith(forwardSlash)) {
-					this->resource = forwardSlash;
-				}
-				this->resource.append(resourceRef.toString());
-			}
+			this->resource += t.eat("?").toString();
 			this->reqParameters = t.eat().toString();
 		}
 

--- a/fdbclient/include/fdbclient/RESTUtils.h
+++ b/fdbclient/include/fdbclient/RESTUtils.h
@@ -27,6 +27,7 @@
 #include "flow/FastRef.h"
 #include "flow/Net2Packet.h"
 
+#include <boost/functional/hash.hpp>
 #include <fmt/format.h>
 #include <unordered_map>
 #include <utility>
@@ -52,7 +53,8 @@ public:
 
 	// Maximum number of connections cached in the connection-pool.
 	int maxConnPerConnectKey;
-	std::map<RESTConnectionPoolKey, std::queue<ReusableConnection>> connectionPoolMap;
+	std::unordered_map<RESTConnectionPoolKey, std::queue<ReusableConnection>, boost::hash<RESTConnectionPoolKey>>
+	    connectionPoolMap;
 
 	RESTConnectionPool(const int maxConnsPerKey) : maxConnPerConnectKey(maxConnsPerKey) {}
 

--- a/fdbserver/RESTKmsConnector.actor.cpp
+++ b/fdbserver/RESTKmsConnector.actor.cpp
@@ -172,7 +172,7 @@ std::string getFullRequestUrl(Reference<RESTKmsConnectorCtx> ctx, const std::str
 		throw encrypt_invalid_kms_config();
 	}
 	std::string fullUrl(url);
-	return fullUrl.append("/").append(suffix);
+	return (suffix[0] == '/') ? fullUrl.append(suffix) : fullUrl.append("/").append(suffix);
 }
 
 void dropCachedKmsUrls(Reference<RESTKmsConnectorCtx> ctx) {

--- a/flow/Net2.actor.cpp
+++ b/flow/Net2.actor.cpp
@@ -1826,7 +1826,10 @@ ACTOR static Future<std::vector<NetworkAddress>> resolveTCPEndpoint_impl(Net2* s
 			    auto endpoint = iter->endpoint();
 			    auto addr = endpoint.address();
 			    if (addr.is_v6()) {
-				    addrs.emplace_back(IPAddress(addr.to_v6().to_bytes()), endpoint.port());
+				    // IPV6 loopback might not be supported, only return IPV6 address
+				    if (!addr.is_loopback()) {
+					    addrs.emplace_back(IPAddress(addr.to_v6().to_bytes()), endpoint.port());
+				    }
 			    } else {
 				    addrs.emplace_back(addr.to_v4().to_ulong(), endpoint.port());
 			    }


### PR DESCRIPTION
Description

Patch addresses following issues:
1. Fix "return connection" routine, it fixes a regression introduced by an earlier fix.
2. Update RESTConnectionPool::connectionPoolMap to an "unordered_map" for O(1) lookups
3. Improve logging
4. Make RESTUrl parsing handle extra '/' for 'resource'
5. Ensure localhost connections are batched properly.

Testing

Standalone fdbserver with external KMS; able to create database

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
