### PR TITLE
Fix issue where the versions on seed storage servers decreased [release-7.1]

### DIFF
--- a/documentation/sphinx/source/release-notes/release-notes-710.rst
+++ b/documentation/sphinx/source/release-notes/release-notes-710.rst
@@ -4,6 +4,20 @@
 Release Notes
 #############
 
+7.1.29
+======
+* Same as 7.1.28 release with AVX enabled.
+
+7.1.28
+======
+* Released with AVX disabled.
+* Changed log router to detect slow peeks and to automatically switch DC for peeking. `(PR #9640) <https://github.com/apple/foundationdb/pull/9640>`_
+* Added multiple prefix filter support for fdbdecode. `(PR #9483) <https://github.com/apple/foundationdb/pull/9483>`_, `(PR #9489) <https://github.com/apple/foundationdb/pull/9489>`_, `(PR #9511) <https://github.com/apple/foundationdb/pull/9511>`_, and `(PR #9560) <https://github.com/apple/foundationdb/pull/9560>`_
+* Enhanced fdbbackup query command to estimate data processing from a specific snapshot to a target version. `(PR #9506) <https://github.com/apple/foundationdb/pull/9506>`_
+* Improved PTree insertion and erase performance for storage servers. `(PR #9508) <https://github.com/apple/foundationdb/pull/9508>`_
+* Added exclude to fdbcli's configure command to prevent faulty TLogs from affecting recovery. `(PR #9404) <https://github.com/apple/foundationdb/pull/9404>`_
+* Fixed getMappedRange metrics. `(PR #9331) <https://github.com/apple/foundationdb/pull/9331>`_
+
 7.1.27
 ======
 * Same as 7.1.26 release with AVX enabled.

--- a/fdbclient/VersionedMap.h
+++ b/fdbclient/VersionedMap.h
@@ -724,7 +724,7 @@ public:
 	}
 
 	Future<Void> forgetVersionsBeforeAsync(Version newOldestVersion, TaskPriority taskID = TaskPriority::DefaultYield) {
-		ASSERT(newOldestVersion <= latestVersion);
+		ASSERT_LE(newOldestVersion, latestVersion);
 		auto r = upper_bound(roots.begin(), roots.end(), newOldestVersion, rootsComparator());
 		auto upper = r;
 		--r;

--- a/fdbserver/ClusterRecovery.actor.cpp
+++ b/fdbserver/ClusterRecovery.actor.cpp
@@ -1093,10 +1093,14 @@ ACTOR Future<Void> readTransactionSystemState(Reference<ClusterRecoveryData> sel
 
 		if (self->recoveryTransactionVersion < minRequiredCommitVersion)
 			self->recoveryTransactionVersion = minRequiredCommitVersion;
-	}
 
-	if (BUGGIFY) {
-		self->recoveryTransactionVersion += deterministicRandom()->randomInt64(0, 10000000);
+		// Test randomly increasing the recovery version by a large number.
+		// When the version epoch is enabled, versions stay in sync with time.
+		// An offline cluster could see a large version jump when it comes back
+		// online, so test this behavior in simulation.
+		if (BUGGIFY) {
+			self->recoveryTransactionVersion += deterministicRandom()->randomInt64(0, 10000000);
+		}
 	}
 
 	TraceEvent(getRecoveryEventName(ClusterRecoveryEventType::CLUSTER_RECOVERY_RECOVERING_EVENT_NAME).c_str(),

--- a/tests/rare/ClogTlog.toml
+++ b/tests/rare/ClogTlog.toml
@@ -17,9 +17,9 @@ testTitle = 'ClogTlog'
     testName = 'Cycle'
     nodeCount = 30000
     transactionsPerSecond = 2500.0
-    testDuration = 120.0
+    testDuration = 60.0
     expectedRate = 0
 
     [[test.workload]]
     testName = 'ClogTlog'
-    testDuration = 3000.0
+    testDuration = 150.0


### PR DESCRIPTION
cherrypick #8972 #9671  #9623

Seed storage servers are recruited as the intial set of storage servers when a database is first created. They function a little bit differently than normal, and do not set an initial version like storages normally do when they get recruited (typically equal to the recovery version).

Version correction is a feature where versions advance in sync with the clock, and are equal across FDB clusters. To allow different FDB clusters to have matching versions, they must share the same base version. This defaults to the Unix epoch, and clusters with the version epoch enabled will have a current version equal to the number of microseconds since the Unix epoch.

When the version epoch is enabled on a cluster, it causes a one time jump from the clusters current version to the version based on the epoch. After a recovery, the recovery version sent to storages should have advanced by a significant amount.

The recovery path contained a `BUGGIFY` to randomly advance the recovery version in simulation, testing the version epoch being enabled. However, it was also advancing the version during an initial recovery, when the seed storage servers are recruited. If a set of storage servers were recruited as seed servers, but another recovery occurred before the bootstrap process was complete, the randomly selected version increase could be smaller during the second recovery than during the first. This could cause the initial set of seed servers to think they should be at a version larger than what the cluuster was actually at.

The fix contained in this commit is to only cause a random version jump when the recovery is occuring on an existing database, and not when it is recruiting seed storages.

This commit fixes an issue found in simulation, reproducible with:

Commit: 93dc4bfeb97a700bafa4b34bc18d38a248e47b35
Test: fast/DataLossRecovery.toml
Seed: 3101495991
Buggify: on
Compiler: clang

20230313-040650-jzhou-fe0cb3bcf6b214b9


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
