### PR TITLE
Enable zstd on 71.3

### DIFF
--- a/cmake/CompileZstd.cmake
+++ b/cmake/CompileZstd.cmake
@@ -17,9 +17,9 @@ function(compile_zstd)
     add_subdirectory(${zstd_SOURCE_DIR}/build/cmake ${zstd_BINARY_DIR})
 
     if (CLANG)
-      target_compile_options(zstd PRIVATE -Wno-array-bounds -Wno-tautological-compare)
-      target_compile_options(libzstd_static PRIVATE -Wno-array-bounds -Wno-tautological-compare)
-      target_compile_options(zstd-frugal PRIVATE -Wno-array-bounds -Wno-tautological-compare)
+      target_compile_options(zstd PRIVATE -Wno-array-bounds -Wno-tautological-compare -Wno-strict-prototypes)
+      target_compile_options(libzstd_static PRIVATE -Wno-array-bounds -Wno-tautological-compare -Wno-strict-prototypes)
+      target_compile_options(zstd-frugal PRIVATE -Wno-array-bounds -Wno-tautological-compare -Wno-strict-prototypes)
     endif()
   endif()
 

--- a/flow/CMakeLists.txt
+++ b/flow/CMakeLists.txt
@@ -1,6 +1,6 @@
 find_package(Threads REQUIRED)
 
-option(FLOW_USE_ZSTD "Enable zstd compression in flow" OFF)
+option(FLOW_USE_ZSTD "Enable zstd compression in flow" ON)
 
 fdb_find_sources(FLOW_SRCS)
 


### PR DESCRIPTION
So that blob granules can use it in the 71.3 release

Passed 1k correctness and 1k blobgranule* correctness

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
