### PR TITLE
The isHostname function could cause an unknown_error if regex parsing failed (snowflake/release-71.3)

### DIFF
--- a/flow/Hostname.actor.cpp
+++ b/flow/Hostname.actor.cpp
@@ -35,7 +35,12 @@ const static std::regex ipv4Validation("^([\\d]{1,3}\\.?){4,}:([\\d]+){1,}(:tls)
 } // anonymous namespace
 
 bool Hostname::isHostname(const std::string& str) {
-	return !std::regex_match(str, ipv4Validation) && std::regex_match(str, validation);
+	try {
+		return !std::regex_match(str, ipv4Validation) && std::regex_match(str, validation);
+	} catch (std::exception e) {
+		TraceEvent(SevWarn, "AddressParseError").detail("StdException", e.what()).detail("String", str);
+		throw address_parse_error();
+	}
 }
 
 Hostname Hostname::parse(const std::string& s) {

--- a/flow/include/flow/error_definitions.h
+++ b/flow/include/flow/error_definitions.h
@@ -220,6 +220,7 @@ ERROR( invalid_checkpoint_format, 2044, "Invalid checkpoint format" )
 ERROR( invalid_throttle_quota_value, 2045, "Invalid quota value. Note that reserved_throughput cannot exceed total_throughput" )
 ERROR( failed_to_create_checkpoint, 2046, "Failed to create a checkpoint" )
 ERROR( failed_to_restore_checkpoint, 2047, "Failed to restore a checkpoint" )
+ERROR( address_parse_error, 2049, "Failed to parse address" )
 
 ERROR( incompatible_protocol_version, 2100, "Incompatible protocol version" )
 ERROR( transaction_too_large, 2101, "Transaction exceeds byte limit" )


### PR DESCRIPTION
This is a cherry pick of #9676 

This catches the std::exception, logs a trace event, and converts it to an FDB exception

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
