### PR TITLE
[snowflake/release-71.3] EaR: REST kms misc fixes (#9664)

### DIFF
--- a/fdbclient/RESTUtils.actor.cpp
+++ b/fdbclient/RESTUtils.actor.cpp
@@ -113,6 +113,15 @@ ACTOR Future<RESTConnectionPool::ReusableConnection> connect_impl(Reference<REST
                                                                   RESTConnectionPoolKey connectKey,
                                                                   bool isSecure,
                                                                   int maxConnLife) {
+
+	if (FLOW_KNOBS->REST_LOG_LEVEL >= RESTLogSeverity::VERBOSE) {
+		TraceEvent("RESTUtilConnectStart")
+		    .detail("Host", connectKey.first)
+		    .detail("Service", connectKey.second)
+		    .detail("IsSecure", isSecure)
+		    .detail("ConnectPoolNumKeys", connectionPool->connectionPoolMap.size());
+	}
+
 	auto poolItr = connectionPool->connectionPoolMap.find(connectKey);
 	while (poolItr != connectionPool->connectionPoolMap.end() && !poolItr->second.empty()) {
 		RESTConnectionPool::ReusableConnection rconn = poolItr->second.front();
@@ -120,32 +129,32 @@ ACTOR Future<RESTConnectionPool::ReusableConnection> connect_impl(Reference<REST
 
 		if (rconn.expirationTime > now()) {
 			if (FLOW_KNOBS->REST_LOG_LEVEL >= RESTLogSeverity::DEBUG) {
-				TraceEvent("RESTClientReuseConn")
+				TraceEvent("RESTUtilReuseConn")
 				    .detail("Host", connectKey.first)
 				    .detail("Service", connectKey.second)
 				    .detail("RemoteEndpoint", rconn.conn->getPeerAddress())
-				    .detail("ExpireIn", rconn.expirationTime - now());
+				    .detail("ExpireIn", rconn.expirationTime - now())
+				    .detail("NumConnsInPool", poolItr->second.size());
 			}
 			return rconn;
 		}
 	}
+
+	ASSERT(poolItr == connectionPool->connectionPoolMap.end() || poolItr->second.empty());
 
 	// No valid connection exists, create a new one
 	state Reference<IConnection> conn =
 	    wait(INetworkConnections::net()->connect(connectKey.first, connectKey.second, isSecure));
 	wait(conn->connectHandshake());
 
-	RESTConnectionPool::ReusableConnection reusableConn =
-	    RESTConnectionPool::ReusableConnection({ conn, now() + maxConnLife });
-	connectionPool->connectionPoolMap.insert(
-	    { connectKey, std::queue<RESTConnectionPool::ReusableConnection>({ reusableConn }) });
-
-	TraceEvent("RESTClientCreateNewConn")
+	TraceEvent("RESTTUilCreateNewConn")
 	    .suppressFor(60)
 	    .detail("Host", connectKey.first)
 	    .detail("Service", connectKey.second)
-	    .detail("RemoteEndpoint", conn->getPeerAddress());
-	return reusableConn;
+	    .detail("RemoteEndpoint", conn->getPeerAddress())
+	    .detail("ConnPoolSize", connectionPool->connectionPoolMap.size());
+
+	return RESTConnectionPool::ReusableConnection({ conn, now() + maxConnLife });
 }
 
 Future<RESTConnectionPool::ReusableConnection> RESTConnectionPool::connect(RESTConnectionPoolKey connectKey,
@@ -157,18 +166,35 @@ Future<RESTConnectionPool::ReusableConnection> RESTConnectionPool::connect(RESTC
 void RESTConnectionPool::returnConnection(RESTConnectionPoolKey connectKey,
                                           ReusableConnection& rconn,
                                           const int maxConnections) {
+	if (FLOW_KNOBS->REST_LOG_LEVEL >= RESTLogSeverity::VERBOSE) {
+		TraceEvent("RESTUtilReturnConnStart")
+		    .detail("Host", connectKey.first)
+		    .detail("Service", connectKey.second)
+		    .detail("ConnectPoolNumKeys", connectionPoolMap.size());
+	}
+
 	auto poolItr = connectionPoolMap.find(connectKey);
-	if (poolItr == connectionPoolMap.end()) {
-		throw rest_connectpool_key_not_found();
-	}
-
-	if (FLOW_KNOBS->REST_LOG_LEVEL >= RESTLogSeverity::DEBUG) {
-		TraceEvent("RESTClientReturnConn").detail("Host", connectKey.first).detail("Service", connectKey.second);
-	}
-
 	// If it expires in the future then add it to the pool in the front iff connection pool size is not maxed
-	if (rconn.expirationTime > now() && poolItr->second.size() < maxConnections) {
-		poolItr->second.push(rconn);
+	if (rconn.expirationTime > now()) {
+		bool returned = true;
+		if (poolItr == connectionPoolMap.end()) {
+			connectionPoolMap.insert({ connectKey, std::queue<RESTConnectionPool::ReusableConnection>({ rconn }) });
+		} else if (poolItr->second.size() < maxConnections) {
+			poolItr->second.push(rconn);
+		} else {
+			// Connection pool at its capacity; do nothing
+			returned = false;
+		}
+
+		if (FLOW_KNOBS->REST_LOG_LEVEL >= RESTLogSeverity::DEBUG && returned) {
+			poolItr = connectionPoolMap.find(connectKey);
+			TraceEvent("RESTUtilReturnConnToPool")
+			    .detail("Host", connectKey.first)
+			    .detail("Service", connectKey.second)
+			    .detail("ConnPoolSize", connectionPoolMap.size())
+			    .detail("CachedConns", poolItr->second.size())
+			    .detail("TimeToExpire", rconn.expirationTime - now());
+		}
 	}
 	rconn.conn = Reference<IConnection>();
 }
@@ -206,8 +232,9 @@ void RESTUrl::parseUrl(const std::string& fullUrl) {
 		// extract 'resource' and optional 'parameter list' if supplied in the URL
 		uint8_t foundSeparator = 0;
 		StringRef hostPort = t.eatAny("/?", &foundSeparator);
+		this->resource = "/";
 		if (foundSeparator == '/') {
-			this->resource = t.eat("?").toString();
+			this->resource += t.eat("?").toString();
 			this->reqParameters = t.eat().toString();
 		}
 
@@ -222,7 +249,7 @@ void RESTUrl::parseUrl(const std::string& fullUrl) {
 		this->service = hRef.eat().toString();
 
 		if (FLOW_KNOBS->REST_LOG_LEVEL >= RESTLogSeverity::DEBUG) {
-			TraceEvent("RESTClientParseURI")
+			TraceEvent("RESTUtilParseURI")
 			    .detail("URI", fullUrl)
 			    .detail("Host", this->host)
 			    .detail("Service", this->service)
@@ -231,7 +258,7 @@ void RESTUrl::parseUrl(const std::string& fullUrl) {
 			    .detail("ConnectionType", this->connType.toString());
 		}
 	} catch (std::string& err) {
-		TraceEvent(SevWarnAlways, "RESTClientParseError").detail("URI", fullUrl).detail("Error", err);
+		TraceEvent(SevWarnAlways, "RESTUtilParseError").detail("URI", fullUrl).detail("Error", err);
 		throw rest_invalid_uri();
 	}
 }
@@ -271,7 +298,7 @@ TEST_CASE("/RESTUtils/ValidURIWithService") {
 	ASSERT_EQ(r.connType.secure, RESTConnectionType::SECURE_CONNECTION);
 	ASSERT_EQ(r.host.compare("host"), 0);
 	ASSERT_EQ(r.service.compare("80"), 0);
-	ASSERT_EQ(r.resource.compare("foo/bar"), 0);
+	ASSERT_EQ(r.resource.compare("/foo/bar"), 0);
 	return Void();
 }
 
@@ -281,7 +308,17 @@ TEST_CASE("/RESTUtils/ValidURIWithoutService") {
 	ASSERT_EQ(r.connType.secure, RESTConnectionType::SECURE_CONNECTION);
 	ASSERT_EQ(r.host.compare("host"), 0);
 	ASSERT(r.service.empty());
-	ASSERT_EQ(r.resource.compare("foo/bar"), 0);
+	ASSERT_EQ(r.resource.compare("/foo/bar"), 0);
+	return Void();
+}
+
+TEST_CASE("/RESTUtils/ValidURIWithExtraForwardSlash") {
+	std::string uri("https://host//foo/bar");
+	RESTUrl r(uri);
+	ASSERT_EQ(r.connType.secure, RESTConnectionType::SECURE_CONNECTION);
+	ASSERT_EQ(r.host.compare("host"), 0);
+	ASSERT(r.service.empty());
+	ASSERT_EQ(r.resource.compare("//foo/bar"), 0);
 	return Void();
 }
 
@@ -291,7 +328,7 @@ TEST_CASE("/RESTUtils/ValidURIWithParamsSecure") {
 	ASSERT_EQ(r.connType.secure, RESTConnectionType::SECURE_CONNECTION);
 	ASSERT_EQ(r.host.compare("host"), 0);
 	ASSERT(r.service.empty());
-	ASSERT_EQ(r.resource.compare("foo/bar"), 0);
+	ASSERT_EQ(r.resource.compare("/foo/bar"), 0);
 	ASSERT_EQ(r.reqParameters.compare("param1,param2"), 0);
 	return Void();
 }
@@ -317,7 +354,7 @@ TEST_CASE("/RESTUtils/ValidURIWithParams") {
 	ASSERT_EQ(r.connType.secure, RESTConnectionType::NOT_SECURE_CONNECTION);
 	ASSERT_EQ(r.host.compare("host"), 0);
 	ASSERT(r.service.empty());
-	ASSERT_EQ(r.resource.compare("foo/bar"), 0);
+	ASSERT_EQ(r.resource.compare("/foo/bar"), 0);
 	ASSERT_EQ(r.reqParameters.compare("param1,param2"), 0);
 	return Void();
 }

--- a/fdbclient/include/fdbclient/RESTUtils.h
+++ b/fdbclient/include/fdbclient/RESTUtils.h
@@ -27,6 +27,7 @@
 #include "flow/FastRef.h"
 #include "flow/Net2Packet.h"
 
+#include <boost/functional/hash.hpp>
 #include <fmt/format.h>
 #include <unordered_map>
 #include <utility>
@@ -52,7 +53,8 @@ public:
 
 	// Maximum number of connections cached in the connection-pool.
 	int maxConnPerConnectKey;
-	std::map<RESTConnectionPoolKey, std::queue<ReusableConnection>> connectionPoolMap;
+	std::unordered_map<RESTConnectionPoolKey, std::queue<ReusableConnection>, boost::hash<RESTConnectionPoolKey>>
+	    connectionPoolMap;
 
 	RESTConnectionPool(const int maxConnsPerKey) : maxConnPerConnectKey(maxConnsPerKey) {}
 

--- a/fdbserver/RESTKmsConnector.actor.cpp
+++ b/fdbserver/RESTKmsConnector.actor.cpp
@@ -172,7 +172,7 @@ std::string getFullRequestUrl(Reference<RESTKmsConnectorCtx> ctx, const std::str
 		throw encrypt_invalid_kms_config();
 	}
 	std::string fullUrl(url);
-	return fullUrl.append("/").append(suffix);
+	return (suffix[0] == '/') ? fullUrl.append(suffix) : fullUrl.append("/").append(suffix);
 }
 
 void dropCachedKmsUrls(Reference<RESTKmsConnectorCtx> ctx) {

--- a/flow/Net2.actor.cpp
+++ b/flow/Net2.actor.cpp
@@ -1826,7 +1826,10 @@ ACTOR static Future<std::vector<NetworkAddress>> resolveTCPEndpoint_impl(Net2* s
 			    auto endpoint = iter->endpoint();
 			    auto addr = endpoint.address();
 			    if (addr.is_v6()) {
-				    addrs.emplace_back(IPAddress(addr.to_v6().to_bytes()), endpoint.port());
+				    // IPV6 loopback might not be supported, only return IPV6 address
+				    if (!addr.is_loopback()) {
+					    addrs.emplace_back(IPAddress(addr.to_v6().to_bytes()), endpoint.port());
+				    }
 			    } else {
 				    addrs.emplace_back(addr.to_v4().to_ulong(), endpoint.port());
 			    }


### PR DESCRIPTION
* EaR: REST kms misc fixes

Description

Patch addresses following issues:
1. Fix "return connection" routine, it fixes a regression introduced by an earlier fix.
2. Update RESTConnectionPool::connectionPoolMap to an "unordered_map" for O(1) lookups
3. Improve logging
4. Make RESTUrl parsing handle extra '/' for 'resource'

Testing

Standalone fdbserver connecting to external KMS and database create

(cherry picked from commit ea796eb3ecb5fb3e7cc128f9579d0e61b839856b)

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
