### PR TITLE
Fix early unknown_error crash when tracing too many lines

### DIFF
--- a/flow/Trace.cpp
+++ b/flow/Trace.cpp
@@ -1362,7 +1362,7 @@ BaseTraceEvent::~BaseTraceEvent() {
 	if (failedLineOverflow == 1) {
 		failedLineOverflow = 2;
 		auto msg = fmt::format("Traced {} lines", tracedLines);
-		ProcessEvents::trigger("TracedTooManyLines"_sr, StringRef(msg), unknown_error());
+		ProcessEvents::trigger("TracedTooManyLines"_sr, StringRef(msg), test_failed());
 		TraceEvent(SevError, "TracedTooManyLines").log();
 		crashAndDie();
 	}

--- a/flow/include/flow/error_definitions.h
+++ b/flow/include/flow/error_definitions.h
@@ -140,6 +140,7 @@ ERROR( key_value_store_deadline_exceeded, 1224, "Exceeded maximum time allowed t
 ERROR( storage_quota_exceeded, 1225, "Exceeded the maximum storage quota allocated to the tenant.")
 ERROR( audit_storage_error, 1226, "Found data corruption" )
 ERROR( master_failed, 1227, "Cluster recovery terminating because master has failed")
+ERROR( test_failed, 1228, "Test failed" )
 
 // 15xx Platform errors
 ERROR( platform_error, 1500, "Platform error" )


### PR DESCRIPTION
The error handling for tracing too many lines was creating an `unknown_error`, which immediately terminates a test when `--crash` is used. To allow us to collect and log all of the relevant details for this scenario, use a new, different error that doesn't immediately fail.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
