### PR TITLE
Add tenant getId api to fdbcli (Cherry-Pick #9658 to snowflake/release-71.3)

### DIFF
--- a/fdbcli/TenantCommands.actor.cpp
+++ b/fdbcli/TenantCommands.actor.cpp
@@ -415,6 +415,65 @@ ACTOR Future<bool> tenantListCommand(Reference<IDatabase> db, std::vector<String
 	}
 }
 
+void tenantGetCmdOutput(json_spirit::mValue jsonObject, bool useJson) {
+	if (useJson) {
+		json_spirit::mObject resultObj;
+		resultObj["tenant"] = jsonObject;
+		resultObj["type"] = "success";
+		fmt::print("{}\n",
+		           json_spirit::write_string(json_spirit::mValue(resultObj), json_spirit::pretty_print).c_str());
+	} else {
+		JSONDoc doc(jsonObject);
+
+		int64_t id;
+		std::string name;
+		std::string prefix;
+		std::string tenantState;
+		std::string tenantLockState;
+		std::string lockId;
+		std::string tenantGroup;
+		std::string assignedCluster;
+		std::string error;
+
+		doc.get("id", id);
+		doc.get("prefix.printable", prefix);
+		doc.get("lock_state", tenantLockState);
+
+		bool hasName = doc.tryGet("name.printable", name);
+		bool hasTenantState = doc.tryGet("tenant_state", tenantState);
+		bool hasLockId = doc.tryGet("lock_id", lockId);
+		bool hasTenantGroup = doc.tryGet("tenant_group.printable", tenantGroup);
+		bool hasAssignedCluster = doc.tryGet("assigned_cluster.printable", assignedCluster);
+		bool hasError = doc.tryGet("error", error);
+
+		fmt::print("  id: {}\n", id);
+		fmt::print("  prefix: {}\n", printable(prefix));
+
+		if (hasName) {
+			fmt::print("  name: {}\n", name);
+		}
+
+		if (hasTenantState) {
+			fmt::print("  tenant state: {}\n", printable(tenantState));
+		}
+
+		fmt::print("  lock state: {}\n", tenantLockState);
+		if (hasLockId) {
+			fmt::print("  lock id: {}\n", lockId);
+		}
+
+		if (hasTenantGroup) {
+			fmt::print("  tenant group: {}\n", tenantGroup);
+		}
+		if (hasAssignedCluster) {
+			fmt::print("  assigned cluster: {}\n", printable(assignedCluster));
+		}
+		if (hasError) {
+			fmt::print("  error: {}\n", error);
+		}
+	}
+}
+
 // tenant get command
 ACTOR Future<bool> tenantGetCommand(Reference<IDatabase> db, std::vector<StringRef> tokens) {
 	if (tokens.size() < 3 || tokens.size() > 4 || (tokens.size() == 4 && tokens[3] != "JSON"_sr)) {
@@ -445,60 +504,76 @@ ACTOR Future<bool> tenantGetCommand(Reference<IDatabase> db, std::vector<StringR
 				}
 				tenantJson = tenant.get().toString();
 			}
+			json_spirit::mValue jsonObject;
+			json_spirit::read_string(tenantJson, jsonObject);
+			tenantGetCmdOutput(jsonObject, useJson);
+			return true;
+		} catch (Error& e) {
+			try {
+				wait(safeThreadFutureToFuture(tr->onError(e)));
+			} catch (Error& finalErr) {
+				state std::string errorStr;
+				if (finalErr.code() == error_code_special_keys_api_failure) {
+					std::string str = wait(getSpecialKeysFailureErrorMessage(tr));
+					errorStr = str;
+				} else if (useJson) {
+					errorStr = finalErr.what();
+				} else {
+					throw finalErr;
+				}
+
+				if (useJson) {
+					json_spirit::mObject resultObj;
+					resultObj["type"] = "error";
+					resultObj["error"] = errorStr;
+					fmt::print(
+					    "{}\n",
+					    json_spirit::write_string(json_spirit::mValue(resultObj), json_spirit::pretty_print).c_str());
+				} else {
+					fmt::print(stderr, "ERROR: {}\n", errorStr.c_str());
+				}
+
+				return false;
+			}
+		}
+	}
+}
+
+// tenant getId command
+ACTOR Future<bool> tenantGetIdCommand(Reference<IDatabase> db, std::vector<StringRef> tokens) {
+	if (tokens.size() < 3 || tokens.size() > 4 || (tokens.size() == 4 && tokens[3] != "JSON"_sr)) {
+		fmt::print("Usage: tenant getId <ID> [JSON]\n\n");
+		fmt::print("Prints metadata associated with the given tenant ID.\n");
+		fmt::print("If JSON is specified, then the output will be in JSON format.\n");
+		return false;
+	}
+
+	state bool useJson = tokens.size() == 4;
+	state int64_t tenantId;
+	int n = 0;
+	if (sscanf(tokens[2].toString().c_str(), "%" PRId64 "%n", &tenantId, &n) != 1 || n != tokens[2].size() ||
+	    tenantId < 0) {
+		fmt::print(stderr, "ERROR: invalid ID `{}'\n", tokens[2].toString().c_str());
+		return false;
+	}
+	state Reference<ITransaction> tr = db->createTransaction();
+
+	loop {
+		try {
+			tr->setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
+			state ClusterType clusterType = wait(TenantAPI::getClusterType(tr));
+			state std::string tenantJson;
+			if (clusterType != ClusterType::METACLUSTER_MANAGEMENT) {
+				TenantMapEntry entry = wait(TenantAPI::getTenantTransaction(tr, tenantId));
+				tenantJson = entry.toJson();
+			} else {
+				MetaclusterTenantMapEntry mEntry = wait(MetaclusterAPI::getTenantTransaction(tr, tenantId));
+				tenantJson = mEntry.toJson();
+			}
 
 			json_spirit::mValue jsonObject;
 			json_spirit::read_string(tenantJson, jsonObject);
-
-			if (useJson) {
-				json_spirit::mObject resultObj;
-				resultObj["tenant"] = jsonObject;
-				resultObj["type"] = "success";
-				fmt::print(
-				    "{}\n",
-				    json_spirit::write_string(json_spirit::mValue(resultObj), json_spirit::pretty_print).c_str());
-			} else {
-				JSONDoc doc(jsonObject);
-
-				int64_t id;
-				std::string prefix;
-				std::string tenantState;
-				std::string tenantLockState;
-				std::string lockId;
-				std::string tenantGroup;
-				std::string assignedCluster;
-				std::string error;
-
-				doc.get("id", id);
-				doc.get("prefix.printable", prefix);
-				doc.get("lock_state", tenantLockState);
-
-				bool hasTenantState = doc.tryGet("tenant_state", tenantState);
-				bool hasLockId = doc.tryGet("lock_id", lockId);
-				bool hasTenantGroup = doc.tryGet("tenant_group.printable", tenantGroup);
-				bool hasAssignedCluster = doc.tryGet("assigned_cluster.printable", assignedCluster);
-				bool hasError = doc.tryGet("error", error);
-
-				fmt::print("  id: {}\n", id);
-				fmt::print("  prefix: {}\n", printable(prefix));
-				if (hasTenantState) {
-					fmt::print("  tenant state: {}\n", printable(tenantState));
-				}
-
-				fmt::print("  lock state: {}\n", tenantLockState);
-				if (hasLockId) {
-					fmt::print("  lock id: {}\n", lockId);
-				}
-
-				if (hasTenantGroup) {
-					fmt::print("  tenant group: {}\n", tenantGroup);
-				}
-				if (hasAssignedCluster) {
-					fmt::print("  assigned cluster: {}\n", printable(assignedCluster));
-				}
-				if (hasError) {
-					fmt::print("  error: {}\n", error);
-				}
-			}
+			tenantGetCmdOutput(jsonObject, useJson);
 			return true;
 		} catch (Error& e) {
 			try {
@@ -785,6 +860,8 @@ Future<bool> tenantCommand(Reference<IDatabase> db, std::vector<StringRef> token
 		return tenantListCommand(db, tokens);
 	} else if (tokencmp(tokens[1], "get")) {
 		return tenantGetCommand(db, tokens);
+	} else if (tokencmp(tokens[1], "getId")) {
+		return tenantGetIdCommand(db, tokens);
 	} else if (tokencmp(tokens[1], "configure")) {
 		return tenantConfigureCommand(db, tokens);
 	} else if (tokencmp(tokens[1], "rename")) {
@@ -825,6 +902,9 @@ void tenantGenerator(const char* text,
 	} else if (tokens.size() == 3 && tokencmp(tokens[1], "get")) {
 		const char* opts[] = { "JSON", nullptr };
 		arrayGenerator(text, line, opts, lc);
+	} else if (tokens.size() == 3 && tokencmp(tokens[1], "getId")) {
+		const char* opts[] = { "JSON", nullptr };
+		arrayGenerator(text, line, opts, lc);
 	} else if (tokencmp(tokens[1], "configure")) {
 		if (tokens.size() == 3) {
 			const char* opts[] = { "tenant_group=", "unset", nullptr };
@@ -846,7 +926,7 @@ void tenantGenerator(const char* text,
 
 std::vector<const char*> tenantHintGenerator(std::vector<StringRef> const& tokens, bool inArgument) {
 	if (tokens.size() == 1) {
-		return { "<create|delete|deleteId|list|get|configure|rename>", "[ARGS]" };
+		return { "<create|delete|deleteId|list|get|getId|configure|rename>", "[ARGS]" };
 	} else if (tokencmp(tokens[1], "create") && tokens.size() < 5) {
 		static std::vector<const char*> opts = { "<NAME>",
 			                                     "[tenant_group=<TENANT_GROUP>]",
@@ -865,6 +945,9 @@ std::vector<const char*> tenantHintGenerator(std::vector<StringRef> const& token
 		return std::vector<const char*>(opts.begin() + tokens.size() - 2, opts.end());
 	} else if (tokencmp(tokens[1], "get") && tokens.size() < 4) {
 		static std::vector<const char*> opts = { "<NAME>", "[JSON]" };
+		return std::vector<const char*>(opts.begin() + tokens.size() - 2, opts.end());
+	} else if (tokencmp(tokens[1], "getId") && tokens.size() < 4) {
+		static std::vector<const char*> opts = { "<ID>", "[JSON]" };
 		return std::vector<const char*>(opts.begin() + tokens.size() - 2, opts.end());
 	} else if (tokencmp(tokens[1], "configure")) {
 		if (tokens.size() < 4) {
@@ -897,7 +980,7 @@ std::vector<const char*> tenantHintGenerator(std::vector<StringRef> const& token
 }
 
 CommandFactory tenantRegisterFactory("tenant",
-                                     CommandHelp("tenant <create|delete|list|get|configure|rename|lock|unlock> [ARGS]",
+                                     CommandHelp("tenant <create|delete|list|get|getId|configure|rename|lock|unlock> [ARGS]",
                                                  "view and manage tenants in a cluster or metacluster",
                                                  "`create' and `delete' add and remove tenants from the cluster.\n"
                                                  "`list' prints a list of tenants in the cluster.\n"

--- a/fdbcli/TenantCommands.actor.cpp
+++ b/fdbcli/TenantCommands.actor.cpp
@@ -979,18 +979,19 @@ std::vector<const char*> tenantHintGenerator(std::vector<StringRef> const& token
 	}
 }
 
-CommandFactory tenantRegisterFactory("tenant",
-                                     CommandHelp("tenant <create|delete|list|get|getId|configure|rename|lock|unlock> [ARGS]",
-                                                 "view and manage tenants in a cluster or metacluster",
-                                                 "`create' and `delete' add and remove tenants from the cluster.\n"
-                                                 "`list' prints a list of tenants in the cluster.\n"
-                                                 "`get' prints the metadata for a particular tenant.\n"
-                                                 "`configure' modifies the configuration for a tenant.\n"
-                                                 "`rename' changes the name of a tenant.\n"
-                                                 "`lock` locks a tenant.\n"
-                                                 "`unlock` unlocks a tenant.\n"),
-                                     &tenantGenerator,
-                                     &tenantHintGenerator);
+CommandFactory tenantRegisterFactory(
+    "tenant",
+    CommandHelp("tenant <create|delete|list|get|getId|configure|rename|lock|unlock> [ARGS]",
+                "view and manage tenants in a cluster or metacluster",
+                "`create' and `delete' add and remove tenants from the cluster.\n"
+                "`list' prints a list of tenants in the cluster.\n"
+                "`get' prints the metadata for a particular tenant.\n"
+                "`configure' modifies the configuration for a tenant.\n"
+                "`rename' changes the name of a tenant.\n"
+                "`lock` locks a tenant.\n"
+                "`unlock` unlocks a tenant.\n"),
+    &tenantGenerator,
+    &tenantHintGenerator);
 
 // Generate hidden commands for the old versions of the tenant commands
 CommandFactory createTenantFactory("createtenant");

--- a/fdbcli/tests/fdbcli_tests.py
+++ b/fdbcli/tests/fdbcli_tests.py
@@ -50,9 +50,7 @@ def run_fdbcli_command(*args):
         string: Console output from fdbcli
     """
     commands = command_template + ["{}".format(" ".join(args))]
-    process = subprocess.run(
-        commands, stdout=subprocess.PIPE, env=fdbcli_env
-    )
+    process = subprocess.run(commands, stdout=subprocess.PIPE, env=fdbcli_env)
     return process.stdout.decode("utf-8").strip()
 
 
@@ -1069,10 +1067,17 @@ def tenant_get(logger):
 
     output = run_fdbcli_command("tenant get tenant")
     lines = output.split("\n")
-    assert len(lines) == 3
+    assert len(lines) == 4
     assert lines[0].strip().startswith("id: ")
     assert lines[1].strip().startswith("prefix: ")
-    assert lines[2].strip() == "lock state: unlocked"
+    assert lines[2].strip().startswith("name: ")
+    assert lines[3].strip() == "lock state: unlocked"
+    # id = lines[0].strip().removeprefix("id: ")
+    # Workaround until Python 3.9+ for removeprefix
+    id = lines[0].strip()[len("id: ") :]
+
+    id_output = run_fdbcli_command("tenant getId {}".format(id))
+    assert id_output == output
 
     output = run_fdbcli_command("tenant get tenant JSON")
     json_output = json.loads(output, strict=False)
@@ -1092,13 +1097,23 @@ def tenant_get(logger):
     assert "lock_state" in json_output["tenant"]
     assert json_output["tenant"]["lock_state"] == "unlocked"
 
+    id_output = run_fdbcli_command("tenant getId {} JSON".format(id))
+    assert id_output == output
+
     output = run_fdbcli_command("tenant get tenant2")
     lines = output.split("\n")
-    assert len(lines) == 4
+    assert len(lines) == 5
     assert lines[0].strip().startswith("id: ")
     assert lines[1].strip().startswith("prefix: ")
-    assert lines[2].strip() == "lock state: unlocked"
-    assert lines[3].strip() == "tenant group: tenant_group2"
+    assert lines[2].strip().startswith("name: ")
+    assert lines[3].strip() == "lock state: unlocked"
+    assert lines[4].strip() == "tenant group: tenant_group2"
+    # id2 = lines[0].strip().removeprefix("id: ")
+    # Workaround until Python 3.9+ for removeprefix
+    id2 = lines[0].strip()[len("id: ") :]
+
+    id_output = run_fdbcli_command("tenant getId {}".format(id2))
+    assert id_output == output
 
     output = run_fdbcli_command("tenant get tenant2 JSON")
     json_output = json.loads(output, strict=False)
@@ -1119,6 +1134,9 @@ def tenant_get(logger):
     assert "base64" in json_output["tenant"]["tenant_group"]
     assert json_output["tenant"]["tenant_group"]["printable"] == "tenant_group2"
 
+    id_output = run_fdbcli_command("tenant getId {} JSON".format(id2))
+    assert id_output == output
+
 
 @enable_logging()
 def tenant_configure(logger):
@@ -1134,8 +1152,8 @@ def tenant_configure(logger):
 
     output = run_fdbcli_command("tenant get tenant")
     lines = output.split("\n")
-    assert len(lines) == 4
-    assert lines[3].strip() == "tenant group: tenant_group1"
+    assert len(lines) == 5
+    assert lines[4].strip() == "tenant group: tenant_group1"
 
     output = run_fdbcli_command("tenant configure tenant unset tenant_group")
     assert output == "The configuration for tenant `tenant' has been updated"
@@ -1147,7 +1165,7 @@ def tenant_configure(logger):
 
     output = run_fdbcli_command("tenant get tenant")
     lines = output.split("\n")
-    assert len(lines) == 3
+    assert len(lines) == 4
 
     output = run_fdbcli_command_and_get_error(
         "tenant configure tenant tenant_group=tenant_group1 tenant_group=tenant_group2"


### PR DESCRIPTION
Cherry-Pick of #9658

Original Description:

Similar to `delete` and `deleteId`, provide the ability to use either the name of the tenant or its ID to get the metadata.
# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
