### PR TITLE
AuthZ test: add a wait-reply loop to tenant id getter

### DIFF
--- a/tests/TestRunner/local_cluster.py
+++ b/tests/TestRunner/local_cluster.py
@@ -732,7 +732,6 @@ knob_min_trace_severity=5
         for file in glob.glob(glob_pattern):
             if filename_substr and file.find(filename_substr) == -1:
                 continue
-            print(f"### considering file {file}")
             for line in open(file):
                 try:
                     entry = ET.fromstring(line)

--- a/tests/authorization/conftest.py
+++ b/tests/authorization/conftest.py
@@ -304,8 +304,13 @@ def tenant_tr_gen(db, use_grv_cache):
 @pytest.fixture
 def tenant_id_from_name(db):
     def fn(tenant_name):
-        tenant = db.open_tenant(to_bytes(tenant_name))
-        return tenant.get_id().wait()  # returns int
+        while True:
+            try:
+                tenant = db.open_tenant(to_bytes(tenant_name))
+                return tenant.get_id().wait()  # returns int
+            except fdb.FDBError as e:
+                print("retrying tenant id fetch after 0.5 second backoff due to {}".format(e))
+                time.sleep(0.5)
 
     return fn
 


### PR DESCRIPTION
`cluster_version_changed` error can be hit even with `tenant.get_id()`

Make this operation properly retried with 0.5s backoff

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
