### PR TITLE
Avoid potential access of empty optionals when printing errors in the api tester

### DIFF
--- a/bindings/c/test/apitester/TesterCancelTransactionWorkload.cpp
+++ b/bindings/c/test/apitester/TesterCancelTransactionWorkload.cpp
@@ -69,8 +69,8 @@ private:
 					    auto val = f.get<fdb::future_var::ValueRef>();
 					    if (expectedVal != val) {
 						    error(fmt::format("cancelAfterFirstResTx mismatch. expected: {:.80} actual: {:.80}",
-						                      fdb::toCharsRef(expectedVal.value()),
-						                      fdb::toCharsRef(val.value())));
+						                      fdb::toCharsRef(expectedVal),
+						                      fdb::toCharsRef(val)));
 					    }
 					    ctx->done();
 				    });

--- a/bindings/c/test/apitester/TesterCorrectnessWorkload.cpp
+++ b/bindings/c/test/apitester/TesterCorrectnessWorkload.cpp
@@ -88,8 +88,8 @@ private:
 						        error(
 						            fmt::format("randomCommitReadOp mismatch. key: {} expected: {:.80} actual: {:.80}",
 						                        fdb::toCharsRef((*kvPairs)[i].key),
-						                        fdb::toCharsRef(expected.value()),
-						                        fdb::toCharsRef(actual.value())));
+						                        fdb::toCharsRef(expected),
+						                        fdb::toCharsRef(actual)));
 						        ASSERT(false);
 					        }
 				        }
@@ -129,8 +129,8 @@ private:
 				    if ((*results)[i] != expected) {
 					    error(fmt::format("randomGetOp mismatch. key: {} expected: {:.80} actual: {:.80}",
 					                      fdb::toCharsRef((*keys)[i]),
-					                      fdb::toCharsRef(expected.value()),
-					                      fdb::toCharsRef((*results)[i].value())));
+					                      fdb::toCharsRef(expected),
+					                      fdb::toCharsRef((*results)[i])));
 				    }
 			    }
 			    schedule(cont);

--- a/bindings/c/test/apitester/TesterExampleWorkload.cpp
+++ b/bindings/c/test/apitester/TesterExampleWorkload.cpp
@@ -50,7 +50,7 @@ public:
 					        std::optional<fdb::Value> res = copyValueRef(future.get());
 					        if (res != value) {
 						        error(fmt::format(
-						            "expected: {} actual: {}", fdb::toCharsRef(value), fdb::toCharsRef(res.value())));
+						            "expected: {} actual: {}", fdb::toCharsRef(value), fdb::toCharsRef(res)));
 					        }
 					        ctx->done();
 				        });

--- a/bindings/c/test/fdb_api.hpp
+++ b/bindings/c/test/fdb_api.hpp
@@ -162,6 +162,17 @@ CharsRef toCharsRef(const StringLike<Char>& s) noexcept {
 	return CharsRef(reinterpret_cast<char const*>(s.data()), s.size());
 }
 
+// get charstring view from optional bytestring: e.g. std::optional<std::basic_string{_view}<uint8_t>>
+template <template <class...> class StringLike, class Char>
+CharsRef toCharsRef(const std::optional<StringLike<Char>>& s) noexcept {
+	static_assert(sizeof(Char) == 1);
+	if (s) {
+		return CharsRef(reinterpret_cast<char const*>(s.value().data()), s.value().size());
+	} else {
+		return CharsRef("[not set]");
+	}
+}
+
 [[maybe_unused]] constexpr const bool OverflowCheck = false;
 
 inline int intSize(BytesRef b) {


### PR DESCRIPTION
Add a toCharsRef function that allows converting an optional byte string to a chars ref.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
