### PR TITLE
Deflake test FastTriggeredWatches (Cherry-Pick #9627 to snowflake/release-71.3)

### DIFF
--- a/fdbserver/workloads/FastTriggeredWatches.actor.cpp
+++ b/fdbserver/workloads/FastTriggeredWatches.actor.cpp
@@ -106,7 +106,7 @@ struct FastTriggeredWatchesWorkload : TestWorkload {
 			loop {
 				state double getDuration = 0;
 				state double watchEnd = 0;
-				state bool first = true;
+				state bool watchCommitted = false;
 				state Key setKey = self->keyForIndex(deterministicRandom()->randomInt(0, self->nodes));
 				state Optional<Value> setValue;
 				if (deterministicRandom()->random01() > 0.5)
@@ -114,12 +114,13 @@ struct FastTriggeredWatchesWorkload : TestWorkload {
 				// Set the value at setKey to something random
 				state Future<Version> setFuture = self->setter(cx, setKey, setValue);
 				wait(delay(deterministicRandom()->random01()));
+				state Version watchCommitVersion = 0;
 				loop {
 					state ReadYourWritesTransaction tr(cx);
 
 					try {
 						Optional<Value> val = wait(tr.get(setKey));
-						if (!first) {
+						if (watchCommitted) {
 							getDuration = now() - watchEnd;
 						}
 						lastReadVersion = tr.getReadVersion().get();
@@ -128,25 +129,28 @@ struct FastTriggeredWatchesWorkload : TestWorkload {
 						// loop
 						if (val == setValue)
 							break;
-						ASSERT(first);
+						ASSERT(!watchCommitted);
+						tr.addWriteConflictRange(singleKeyRange(""_sr));
 						// set a watch and wait for it to be triggered (i.e for self->setter to set the value)
 						state Future<Void> watchFuture = tr.watch(setKey);
 						wait(tr.commit());
+						watchCommitVersion = tr.getCommittedVersion();
+
 						//TraceEvent("FTWStartWatch").detail("Key", printable(setKey));
 						wait(watchFuture);
 						watchEnd = now();
-						first = false;
+						watchCommitted = true;
 					} catch (Error& e) {
 						//TraceEvent("FTWWatchError").error(e).detail("Key", printable(setKey));
 						wait(tr.onError(e));
 					}
 				}
-				Version ver = wait(setFuture);
+				Version keySetVersion = wait(setFuture);
+				int64_t versionDelta = lastReadVersion - std::max(keySetVersion, watchCommitVersion);
 				//TraceEvent("FTWWatchDone").detail("Key", printable(setKey));
 				// Assert that the time from setting the key to triggering the watch is no greater than 25s
-				// TODO: This assertion can cause flaky behaviour since sometimes a watch can take longer to fire
-				ASSERT(lastReadVersion - ver >= SERVER_KNOBS->MAX_VERSIONS_IN_FLIGHT ||
-				       lastReadVersion - ver < SERVER_KNOBS->VERSIONS_PER_SECOND * (25 + getDuration));
+				ASSERT(!watchCommitted || versionDelta >= SERVER_KNOBS->MAX_VERSIONS_IN_FLIGHT ||
+				       versionDelta < SERVER_KNOBS->VERSIONS_PER_SECOND * (25 + getDuration));
 
 				if (now() - testStart > self->testDuration)
 					break;


### PR DESCRIPTION
Cherry-Pick of #9627

Original Description:

In FastTriggeredWatchesWorkload, if the randomized new value for the given `setKey` happens to be the same as the current value, the following will hold

- `first` is true, and
- `getDuration` is 0, and
- assertion `lastReadVersion - ver >= SERVER_KNOBS->MAX_VERSIONS_IN_FLIGHT || lastReadVersion - ver < SERVER_KNOBS->VERSIONS_PER_SECOND * (25 + getDuration)` will fail

To fix this, change the assertion to
```
assert(first || lastReadVersion - ver >= SERVER_KNOBS->MAX_VERSIONS_IN_FLIGHT ||
	lastReadVersion - ver < SERVER_KNOBS->VERSIONS_PER_SECOND * (25 + getDuration));

```

Test plan:
On c27cdcd2df0aecc5973829c0542858d4f380850f:
- Apply to the fix on top of the commit reported by Joshua test. Rerun the command to make sure it passes.
- devRunCorrectnessFiltered  +FastTriggeredWatches* --max-runs 10000

Replace this text with your description here...

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
