### PR TITLE
remove knobs to make granule small

### DIFF
--- a/tests/TestRunner/local_cluster.py
+++ b/tests/TestRunner/local_cluster.py
@@ -263,10 +263,7 @@ knob_min_trace_severity=5
             if self.blob_granules_enabled:
                 bg_config = "\n".join(
                     [
-                        "knob_bg_url=file://" + str(self.data) + "/fdbblob/",
-                        "knob_bg_snapshot_file_target_bytes=200000",
-                        "knob_bg_delta_file_target_bytes=10000",
-                        "knob_bg_delta_bytes_before_compact=100000",
+                        "knob_bg_url=file://" + str(self.data) + "/fdbblob/"
                     ]
                 )
             if self.enable_encryption_at_rest:


### PR DESCRIPTION
Temporarily fixes flakiness of blob granule ctests until I can fix the real bug

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
