### PR TITLE
Fix KeyRangeRef::isCovered() (#9675)

### DIFF
--- a/fdbclient/BlobGranuleReader.actor.cpp
+++ b/fdbclient/BlobGranuleReader.actor.cpp
@@ -193,5 +193,46 @@ TEST_CASE("/fdbserver/blobgranule/isRangeCoveredByBlob") {
 		testAddChunkRange("key_b1"_sr, "key_b9"_sr, continuedChunks);
 		ASSERT(isRangeFullyCovered(KeyRangeRef("key_a1"_sr, "key_b9"_sr), continuedChunks));
 	}
+
+	// check functionality of isCovered()
+	{
+		std::vector<KeyRangeRef> ranges;
+		ranges.push_back(KeyRangeRef("key_a"_sr, "key_b"_sr));
+		ranges.push_back(KeyRangeRef("key_x"_sr, "key_y"_sr));
+		ASSERT(KeyRangeRef("key_x"_sr, "key_y"_sr).isCovered(ranges));
+
+		ranges.clear();
+		ranges.push_back(KeyRangeRef("key_a"_sr, "key_b"_sr));
+		ranges.push_back(KeyRangeRef("key_v"_sr, "key_y"_sr));
+		ASSERT(KeyRangeRef("key_x"_sr, "key_y"_sr).isCovered(ranges));
+
+		ranges.clear();
+		ranges.push_back(KeyRangeRef("key_a"_sr, "key_b"_sr));
+		ranges.push_back(KeyRangeRef("key_x"_sr, "key_xa"_sr));
+		ranges.push_back(KeyRangeRef("key_xa"_sr, "key_ya"_sr));
+		ASSERT(KeyRangeRef("key_x"_sr, "key_y"_sr).isCovered(ranges));
+
+		ranges.clear();
+		ranges.push_back(KeyRangeRef("key_a"_sr, "key_b"_sr));
+		ranges.push_back(KeyRangeRef("key_x"_sr, "key_xa"_sr));
+		ranges.push_back(KeyRangeRef("key_xa"_sr, "key_xb"_sr));
+		ASSERT(!KeyRangeRef("key_x"_sr, "key_y"_sr).isCovered(ranges));
+
+		ranges.clear();
+		ranges.push_back(KeyRangeRef("key_a"_sr, "key_b"_sr));
+		ranges.push_back(KeyRangeRef("key_x"_sr, "key_xa"_sr));
+		ASSERT(!KeyRangeRef("key_x"_sr, "key_y"_sr).isCovered(ranges));
+
+		ranges.clear();
+		ranges.push_back(KeyRangeRef("key_a"_sr, "key_b"_sr));
+		ranges.push_back(KeyRangeRef("key_xa"_sr, "key_y"_sr));
+		ASSERT(!KeyRangeRef("key_x"_sr, "key_y"_sr).isCovered(ranges));
+
+		ranges.clear();
+		ranges.push_back(KeyRangeRef("key_a"_sr, "key_b"_sr));
+		ranges.push_back(KeyRangeRef("key_x"_sr, "key_y"_sr));
+		ASSERT(!KeyRangeRef("key_a"_sr, "key_y"_sr).isCovered(ranges));
+	}
+
 	return Void();
 }

--- a/fdbclient/include/fdbclient/FDBTypes.h
+++ b/fdbclient/include/fdbclient/FDBTypes.h
@@ -342,7 +342,11 @@ struct KeyRangeRef {
 				return false; // uncovered gap between clone.begin and r.begin
 			if (clone.end <= r.end)
 				return true; // range is fully covered
-			if (clone.end > r.begin)
+			// If a range of ranges is totally at the left of clone,
+			// clone needs not update
+			// If a range of ranges is partially at the left of clone,
+			// clone = clone - the overlap
+			if (clone.end > r.end && r.end > clone.begin)
 				// {clone.begin, r.end} is covered. need to check coverage for {r.end, clone.end}
 				clone = KeyRangeRef(r.end, clone.end);
 		}


### PR DESCRIPTION
This PR fixed a bug in KeyRangeRef:isCovered(), which is used by hybrid restore. 

cherry pick #9675

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
