### PR TITLE
fix unit test failure because of implicit uint16_t conversion to int

### DIFF
--- a/fdbserver/TenantCache.actor.cpp
+++ b/fdbserver/TenantCache.actor.cpp
@@ -385,8 +385,9 @@ public:
 		uint16_t tenantNumber = deterministicRandom()->randomInt(0, std::numeric_limits<uint16_t>::max());
 
 		for (uint16_t i = 0; i < tenantCount; i++) {
-			TenantName tenantName(format("%s_%08d", "ddtc_test_tenant", tenantNumber + i));
-			TenantMapEntry tenant(tenantNumber + i, tenantName);
+			uint16_t tenantOrdinal = tenantNumber + i;
+			TenantName tenantName(format("%s_%08d", "ddtc_test_tenant", tenantOrdinal));
+			TenantMapEntry tenant(tenantOrdinal, tenantName);
 
 			tenantCache.insert(tenant);
 		}


### PR DESCRIPTION
Then the tenant number when insert (implicitly converted to int 65536) and updated (overflow to 1) doesn't match.


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
