### PR TITLE
fixing 2 bugs related to high delta file waitCommitted latency

### DIFF
--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -9361,6 +9361,11 @@ void DatabaseContext::setSharedState(DatabaseSharedState* p) {
 	sharedStatePtr->refCount++;
 }
 
+// FIXME: this has undesired head-of-line-blocking behavior in the case of large version jumps.
+// For example, say that The current feed version is 100, and one waiter wants to wait for the feed version >= 1000.
+// This will send a request with minVersion=1000. Then say someone wants to wait for feed version >= 200. Because we've
+// already blocked this updater on version 1000, even if the feed would already be at version 200+, we won't get an
+// empty version response until version 1000.
 ACTOR Future<Void> storageFeedVersionUpdater(StorageServerInterface interf, ChangeFeedStorageData* self) {
 	loop {
 		if (self->version.get() < self->desired.get()) {

--- a/tests/TestRunner/local_cluster.py
+++ b/tests/TestRunner/local_cluster.py
@@ -120,6 +120,7 @@ logdir = {logdir}
 {custom_config}
 {use_future_protocol_version}
 knob_min_trace_severity=5
+trace_format=json
 # logsize = 10MiB
 # maxlogssize = 100MiB
 # machine-id =

--- a/tests/TestRunner/local_cluster.py
+++ b/tests/TestRunner/local_cluster.py
@@ -120,7 +120,6 @@ logdir = {logdir}
 {custom_config}
 {use_future_protocol_version}
 knob_min_trace_severity=5
-trace_format=json
 # logsize = 10MiB
 # maxlogssize = 100MiB
 # machine-id =


### PR DESCRIPTION
And also an assertion failure.

2 perf bugs
- head-of-line blocking in change feed empty version that would cause delta files writing at latest version to always block for 5 seconds
- not enough versions getting added to grv history to unblock delta files writing at non-latest versions

Fixes flaky BlobGranule* ctests that were timing out.

Passes 50k BlobGranule* correctness with no related failures

Supercedes #9694

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
