### PR TITLE
Replace 10-second delay with explicit wait for cluster recovery in checkExtraDataStores (Cherry-Pick #9691 to snowflake/release-71.2)

### DIFF
--- a/fdbserver/workloads/ConsistencyCheck.actor.cpp
+++ b/fdbserver/workloads/ConsistencyCheck.actor.cpp
@@ -1851,6 +1851,23 @@ struct ConsistencyCheckWorkload : TestWorkload {
 		return true;
 	}
 
+	// Run an empty commit through the system.
+	ACTOR static Future<Void> doEmptyCommit(Database cx) {
+		state Transaction tr(cx);
+		loop {
+			try {
+				wait(::success(tr.getReadVersion()));
+				tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
+				tr.setOption(FDBTransactionOptions::LOCK_AWARE);
+				tr.makeSelfConflicting();
+				wait(tr.commit());
+				return Void();
+			} catch (Error& e) {
+				wait(tr.onError(e));
+			}
+		}
+	}
+
 	ACTOR Future<bool> checkForExtraDataStores(Database cx, ConsistencyCheckWorkload* self) {
 		state std::vector<WorkerDetails> workers = wait(getWorkers(self->dbInfo));
 		state std::vector<StorageServerInterface> storageServers = wait(getStorageServers(cx));
@@ -1953,6 +1970,14 @@ struct ConsistencyCheckWorkload : TestWorkload {
 		}
 
 		if (foundExtraDataStore) {
+			// Let the cluster fully recover after rebooting/killing storage servers with extra stores.
+			//
+			// This requires an end-to-end comitting transaction to ensure recovery has started in case
+			// any stateless processes, like the commit proxy, were killed.
+			wait(::success(doEmptyCommit(cx)));
+			while (self->dbInfo->get().recoveryState != RecoveryState::FULLY_RECOVERED) {
+				wait(self->dbInfo->onChange());
+			}
 			self->testFailure("Extra data stores present on workers");
 			return false;
 		}


### PR DESCRIPTION
Cherry-Pick of #9691

Original Description:

CheckExtraDataStores reboots or kills storage servers with extra data stores. Since this occurs during a consistency check, the expectation is that the database is quiet and not in the midst of recovery. This was done with a 10-second delay, but it's possible during simulation tests that it takes longer than 10 seconds to recruit a new master, so this assumption is invalid and can cause a test failure when the consistency checks proceed.

Instead of a delay, we run an empty transaction through the system and explicitly wait for the cluster to return to a fully-recovered state.

Testing: 250,000 correctness tests.
7 failed due to jemalloc assertion
2 failed stuck in accepting_commits, with usable_regions=2
Both are known issues.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
