### PR TITLE
buggify blob granule compression per-file (Cherry-Pick #9670 to snowflake/release-71.3)

### DIFF
--- a/fdbserver/BlobWorker.actor.cpp
+++ b/fdbserver/BlobWorker.actor.cpp
@@ -425,6 +425,9 @@ Optional<CompressionFilter> getBlobFileCompressFilter() {
 	Optional<CompressionFilter> compFilter;
 	if (SERVER_KNOBS->ENABLE_BLOB_GRANULE_COMPRESSION) {
 		compFilter = CompressionUtils::fromFilterString(SERVER_KNOBS->BLOB_GRANULE_COMPRESSION_FILTER);
+		if (BUGGIFY_WITH_PROB(0.1)) {
+			compFilter = CompressionUtils::getRandomFilter();
+		}
 	}
 	return compFilter;
 }


### PR DESCRIPTION
Cherry-Pick of #9670

Original Description:

This effectively tests the ability to toggle compression on and off for new file writing dynamically.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
