### PR TITLE
Fix possible off-by-one in the simulation upper bound check for page corruption

### DIFF
--- a/fdbserver/KeyValueStoreSQLite.actor.cpp
+++ b/fdbserver/KeyValueStoreSQLite.actor.cpp
@@ -153,8 +153,9 @@ struct PageChecksumCodec {
 		if (!silent) {
 			auto severity = SevError;
 			if (g_network->isSimulated()) {
-				auto firstBlock = pageNumber == 1 ? 0 : ((pageNumber - 1) * pageLen) / 4096,
-				     lastBlock = (pageNumber * pageLen) / 4096;
+				auto firstBlock = pageNumber == 1 ? 0 : ((pageNumber - 1) * pageLen) / 4096;
+				auto lastBlock = (pageNumber * pageLen + 4095) / 4096;
+
 				auto iter = g_simulator->corruptedBlocks.lower_bound(std::make_pair(filename, firstBlock));
 				if (iter != g_simulator->corruptedBlocks.end() && iter->first == filename && iter->second < lastBlock) {
 					severity = SevWarnAlways;


### PR DESCRIPTION
When detecting failed checksums in KeyValueStoreSQLite, we were computing the start and end affected pages and comparing that to the set of known corrupted pages to see if the failed checksum was expected. In the case that the page being checked didn't align with a 4096-sized block boundary, the end page was one too small and could result in us not detecting that a corruption was expected.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
