### PR TITLE
Avoid killing too many machines if one region is being shared between the remote primary and a satellite

### DIFF
--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -1795,7 +1795,7 @@ ACTOR Future<Void> initializeSimConfig(Database db) {
 				if (!dcIds.insert(r.dcId).second) {
 					foundSharedDcId = true;
 				}
-				if (!r.satellites.empty()) {
+				if (!r.satellites.empty() && r.satelliteTLogReplicationFactor > 0 && r.satelliteTLogUsableDcs > 0) {
 					for (auto const& s : r.satellites) {
 						if (!dcIds.insert(s.dcId).second) {
 							foundSharedDcId = true;
@@ -1814,7 +1814,9 @@ ACTOR Future<Void> initializeSimConfig(Database db) {
 				    new PolicyAcross(totalRequired, "zoneid", Reference<IReplicationPolicy>(new PolicyOne())));
 				TraceEvent("ChangingSimTLogPolicyForSharedRemote")
 				    .detail("TotalRequired", totalRequired)
-				    .detail("MaxSatelliteReplication", maxSatelliteReplication);
+				    .detail("MaxSatelliteReplication", maxSatelliteReplication)
+				    .detail("ActualPolicy", dbConfig.getRemoteTLogPolicy()->info())
+				    .detail("SimulatorPolicy", g_simulator->remoteTLogPolicy->info());
 			} else {
 				g_simulator->remoteTLogPolicy = dbConfig.getRemoteTLogPolicy();
 			}


### PR DESCRIPTION
This modifies the simulated remote log policy to require more logs, preventing the simulator from killing machines that may be needed by other regions.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
