### PR TITLE
Disables another instance of usable_regions=2

### DIFF
--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -1401,32 +1401,6 @@ ACTOR Future<Void> restartSimulatedSystem(std::vector<Future<Void>>* systemActor
 		g_simulator->processesPerMachine = processesPerMachine;
 
 		uniquify(dcIds);
-		if (!BUGGIFY && dcIds.size() == 2 && dcIds[0] != "" && dcIds[1] != "") {
-			StatusObject primaryObj;
-			StatusObject primaryDcObj;
-			primaryDcObj["id"] = dcIds[0];
-			primaryDcObj["priority"] = 2;
-			StatusArray primaryDcArr;
-			primaryDcArr.push_back(primaryDcObj);
-
-			StatusObject remoteObj;
-			StatusObject remoteDcObj;
-			remoteDcObj["id"] = dcIds[1];
-			remoteDcObj["priority"] = 1;
-			StatusArray remoteDcArr;
-			remoteDcArr.push_back(remoteDcObj);
-
-			primaryObj["datacenters"] = primaryDcArr;
-			remoteObj["datacenters"] = remoteDcArr;
-
-			StatusArray regionArr;
-			regionArr.push_back(primaryObj);
-			regionArr.push_back(remoteObj);
-
-			*pStartingConfiguration =
-			    "single usable_regions=2 regions=" +
-			    json_spirit::write_string(json_spirit::mValue(regionArr), json_spirit::Output_options::none);
-		}
 
 		g_simulator->restarted = true;
 


### PR DESCRIPTION
Passes 10k correctness.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
