### PR TITLE
Add processID, networkAddress, and locality to layer status JSON for Backup Agents.

### DIFF
--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -1509,6 +1509,7 @@ DBType getDBType(std::string dbType) {
 }
 
 ACTOR Future<std::string> getLayerStatus(Reference<ReadYourWritesTransaction> tr,
+                                         IPAddress localIP,
                                          std::string name,
                                          std::string id,
                                          ProgramExe exe,
@@ -1546,17 +1547,7 @@ ACTOR Future<std::string> getLayerStatus(Reference<ReadYourWritesTransaction> tr
 	o.create("configured_workers") = CLIENT_KNOBS->BACKUP_TASKS_PER_AGENT;
 	o.create("processID") = ::getpid();
 	o.create("locality") = tr->getDatabase()->clientLocality.toJSON<json_spirit::mObject>();
-
-	// Try to determine the public address used to talk to the cluster
-	state IPAddress ip;
-	try {
-		ip = determinePublicIPAutomatically(tr->getDatabase()->getConnectionRecord()->getConnectionString());
-	} catch (Error& e) {
-		// Output an error into the doc and fall back to localAddress()
-		o.create("networkAddressError") = e.what();
-		ip = g_network->getLocalAddress().ip;
-	}
-	o.create("networkAddress") = ip.toString();
+	o.create("networkAddress") = localIP.toString();
 
 	if (exe == ProgramExe::AGENT) {
 		static S3BlobStoreEndpoint::Stats last_stats;
@@ -1802,6 +1793,21 @@ ACTOR Future<Void> statusUpdateActor(Database statusUpdateDest,
 	state Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(statusUpdateDest));
 	state Future<Void> pollRateUpdater;
 
+	// In order to report a useful networkAddress to the cluster's layer status JSON object, determine which local
+	// network interface IP will be used to talk to the cluster.  This is a blocking call, so it is only done once,
+	// and in a retry loop because if we can't connect to the cluster we can't do any work anyway.
+	state IPAddress localIP;
+
+	loop {
+		try {
+			localIP = statusUpdateDest->getConnectionRecord()->getConnectionString().determineLocalSourceIP();
+			break;
+		} catch (Error& e) {
+			TraceEvent(SevWarn, "AgentCouldNotDetermineLocalIP").error(e);
+			wait(delay(1.0));
+		}
+	}
+
 	// Register the existence of this layer in the meta key space
 	loop {
 		try {
@@ -1824,7 +1830,7 @@ ACTOR Future<Void> statusUpdateActor(Database statusUpdateDest,
 					tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 					tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 					state Future<std::string> futureStatusDoc =
-					    getLayerStatus(tr, name, id, exe, taskDest, Snapshot::True);
+					    getLayerStatus(tr, localIP, name, id, exe, taskDest, Snapshot::True);
 					wait(cleanupStatus(tr, rootKey, name, id));
 					std::string statusdoc = wait(futureStatusDoc);
 					tr->set(instanceKey, statusdoc);

--- a/fdbclient/CoordinationInterface.cpp
+++ b/fdbclient/CoordinationInterface.cpp
@@ -34,10 +34,8 @@
 
 #include "fdbclient/CoordinationInterface.h"
 
-// Determine public IP address by calling the first available coordinator.
-// If fail connecting all coordinators, throw bind_failed().
-IPAddress determinePublicIPAutomatically(ClusterConnectionString& ccs) {
-	int size = ccs.coords.size() + ccs.hostnames.size();
+IPAddress ClusterConnectionString::determineLocalSourceIP() const {
+	int size = coords.size() + hostnames.size();
 	int index = 0;
 	loop {
 		try {
@@ -48,10 +46,10 @@ IPAddress determinePublicIPAutomatically(ClusterConnectionString& ccs) {
 
 			NetworkAddress coordAddr;
 			// Try coords first, because they don't need to be resolved.
-			if (index < ccs.coords.size()) {
-				coordAddr = ccs.coords[index];
+			if (index < coords.size()) {
+				coordAddr = coords[index];
 			} else {
-				Hostname& h = ccs.hostnames[index - ccs.coords.size()];
+				const Hostname& h = hostnames[index - coords.size()];
 				Optional<NetworkAddress> resolvedAddr = h.resolveBlocking();
 				if (!resolvedAddr.present()) {
 					throw lookup_failed();

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -2223,8 +2223,6 @@ void DatabaseContext::expireThrottles() {
 	}
 }
 
-extern IPAddress determinePublicIPAutomatically(ClusterConnectionString& ccs);
-
 // Initialize tracing for FDB client
 //
 // connRecord is necessary for determining the local IP, which is then included in the trace

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -2254,7 +2254,7 @@ void initializeClientTracing(Reference<IClusterConnectionRecord> connRecord, Opt
 
 	Optional<NetworkAddress> localAddress;
 	if (connRecord) {
-		auto publicIP = determinePublicIPAutomatically(connRecord->getConnectionString());
+		auto publicIP = connRecord->getConnectionString().determineLocalSourceIP();
 		localAddress = NetworkAddress(publicIP, ::getpid());
 	}
 	platform::ImageInfo imageInfo = platform::getImageInfo();

--- a/fdbclient/include/fdbclient/CoordinationInterface.h
+++ b/fdbclient/include/fdbclient/CoordinationInterface.h
@@ -88,6 +88,11 @@ public:
 
 	size_t getNumberOfCoordinators() const { return coords.size() + hostnames.size(); }
 
+	// Determine the local source IP used to connect to the cluster by connecting to the first available coordinator.
+	// Throw bind_failed() if no connection attempts were successful.
+	// This function blocks on connection attempts.
+	IPAddress determineLocalSourceIP() const;
+
 	bool operator==(const ClusterConnectionString& other) const noexcept {
 		return key == other.key && keyDesc == other.keyDesc && coords == other.coords && hostnames == other.hostnames;
 	}
@@ -349,7 +354,5 @@ struct CheckDescriptorMutableRequest {
 		serializer(ar, reply);
 	}
 };
-
-IPAddress determinePublicIPAutomatically(ClusterConnectionString& ccs);
 
 #endif

--- a/fdbclient/include/fdbclient/CoordinationInterface.h
+++ b/fdbclient/include/fdbclient/CoordinationInterface.h
@@ -350,4 +350,6 @@ struct CheckDescriptorMutableRequest {
 	}
 };
 
+IPAddress determinePublicIPAutomatically(ClusterConnectionString& ccs);
+
 #endif

--- a/fdbclient/include/fdbclient/JsonBuilder.h
+++ b/fdbclient/include/fdbclient/JsonBuilder.h
@@ -14,8 +14,10 @@ typedef JsonBuilder JsonString;
 template <typename T>
 class JsonBuilderObjectSetter;
 
-// Class for building JSON string values.
-// Default value is null, as in the JSON type
+// Class for building JSON strings linearly.
+// JSON data structure is only appendable.  No key deduplication is done in JSON Objects, and the output is not readable
+// other than obtaining a complete JSON string of what has been written to the builder. Default value is null, as in the
+// JSON type
 class JsonBuilder {
 protected:
 	enum EType { NULLVALUE, OBJECT, ARRAY };

--- a/fdbrpc/include/fdbrpc/Locality.h
+++ b/fdbrpc/include/fdbrpc/Locality.h
@@ -322,6 +322,23 @@ public:
 		return infoString;
 	}
 
+	// Convert locality fields to a JSON object.  This is a template because it works with JSONBuilder, StatusObject,
+	// and json_spirit::mObject, but none of these types are in the fdbrpc/ project.
+	template <typename JSONType>
+	JSONType toJSON() const {
+		JSONType obj;
+
+		for (auto it = _data.begin(); it != _data.end(); it++) {
+			if (it->second.present()) {
+				obj[it->first.toString()] = it->second.get().toString();
+			} else {
+				obj[it->first.toString()] = nullptr;
+			}
+		}
+
+		return obj;
+	}
+
 	template <class Ar>
 	void serialize(Ar& ar) {
 		// Locality is persisted in the database inside StorageServerInterface, so changes here have to be

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -240,20 +240,6 @@ protected:
 	int64_t counter;
 };
 
-static JsonBuilderObject getLocalityInfo(const LocalityData& locality) {
-	JsonBuilderObject localityObj;
-
-	for (auto it = locality._data.begin(); it != locality._data.end(); it++) {
-		if (it->second.present()) {
-			localityObj[it->first] = it->second.get();
-		} else {
-			localityObj[it->first] = JsonBuilder();
-		}
-	}
-
-	return localityObj;
-}
-
 static JsonBuilderObject getError(const TraceEventFields& errorFields) {
 	JsonBuilderObject statusObj;
 	try {
@@ -352,7 +338,7 @@ JsonBuilderObject machineStatusFetcher(WorkerEvents mMetrics,
 				}
 
 				if (locality.count(it->first)) {
-					statusObj["locality"] = getLocalityInfo(locality[it->first]);
+					statusObj["locality"] = locality[it->first].toJSON<JsonBuilderObject>();
 				}
 
 				statusObj["address"] = address;
@@ -949,7 +935,7 @@ ACTOR static Future<JsonBuilderObject> processStatusFetcher(
 				std::string MachineID = processMetrics.getValue("MachineID");
 				statusObj["machine_id"] = MachineID;
 
-				statusObj["locality"] = getLocalityInfo(workerItr->interf.locality);
+				statusObj["locality"] = workerItr->interf.locality.toJSON<JsonBuilderObject>();
 
 				statusObj.setKeyRawNumber("uptime_seconds", processMetrics.getValue("UptimeSeconds"));
 

--- a/fdbserver/fdbserver.actor.cpp
+++ b/fdbserver/fdbserver.actor.cpp
@@ -895,7 +895,7 @@ std::pair<NetworkAddressList, NetworkAddressList> buildNetworkAddresses(
 		if (autoPublicAddress) {
 			try {
 				const NetworkAddress& parsedAddress = NetworkAddress::parse("0.0.0.0:" + publicAddressStr.substr(5));
-				const IPAddress publicIP = determinePublicIPAutomatically(connectionRecord.getConnectionString());
+				const IPAddress publicIP = connectionRecord.getConnectionString().determineLocalSourceIP();
 				currentPublicAddress = NetworkAddress(publicIP, parsedAddress.port, true, parsedAddress.isTLS());
 			} catch (Error& e) {
 				fprintf(stderr,
@@ -1112,7 +1112,7 @@ struct CLIOptions {
 				printHelpTeaser(name);
 				flushAndExit(FDB_EXIT_ERROR);
 			}
-			auto publicIP = determinePublicIPAutomatically(connectionFile->getConnectionString());
+			auto publicIP = connectionFile->getConnectionString().determineLocalSourceIP();
 			publicAddresses.address = NetworkAddress(publicIP, ::getpid());
 		}
 	}

--- a/fdbserver/fdbserver.actor.cpp
+++ b/fdbserver/fdbserver.actor.cpp
@@ -234,8 +234,6 @@ extern void pingtest();
 extern void copyTest();
 extern void versionedMapTest();
 extern void createTemplateDatabase();
-// FIXME: this really belongs in a header somewhere since it is actually used.
-extern IPAddress determinePublicIPAutomatically(ClusterConnectionString& ccs);
 
 extern const char* getSourceVersion();
 

--- a/flow/Hostname.actor.cpp
+++ b/flow/Hostname.actor.cpp
@@ -60,7 +60,7 @@ Hostname Hostname::parse(const std::string& s) {
 	return Hostname(f.substr(0, colonPos), f.substr(colonPos + 1), isTLS);
 }
 
-ACTOR Future<Optional<NetworkAddress>> resolveImpl(Hostname* self) {
+ACTOR Future<Optional<NetworkAddress>> resolveImpl(const Hostname* self) {
 	try {
 		std::vector<NetworkAddress> addresses =
 		    wait(INetworkConnections::net()->resolveTCPEndpointWithDNSCache(self->host, self->service));
@@ -76,7 +76,7 @@ ACTOR Future<Optional<NetworkAddress>> resolveImpl(Hostname* self) {
 	}
 }
 
-ACTOR Future<NetworkAddress> resolveWithRetryImpl(Hostname* self) {
+ACTOR Future<NetworkAddress> resolveWithRetryImpl(const Hostname* self) {
 	state double resolveInterval = FLOW_KNOBS->HOSTNAME_RESOLVE_INIT_INTERVAL;
 	loop {
 		try {
@@ -97,11 +97,11 @@ Future<Optional<NetworkAddress>> Hostname::resolve() {
 	return resolveImpl(this);
 }
 
-Future<NetworkAddress> Hostname::resolveWithRetry() {
+Future<NetworkAddress> Hostname::resolveWithRetry() const {
 	return resolveWithRetryImpl(this);
 }
 
-Optional<NetworkAddress> Hostname::resolveBlocking() {
+Optional<NetworkAddress> Hostname::resolveBlocking() const {
 	try {
 		std::vector<NetworkAddress> addresses =
 		    INetworkConnections::net()->resolveTCPEndpointBlockingWithDNSCache(host, service);

--- a/flow/include/flow/Hostname.h
+++ b/flow/include/flow/Hostname.h
@@ -60,9 +60,9 @@ struct Hostname {
 
 	// The resolve functions below use DNS cache.
 	Future<Optional<NetworkAddress>> resolve();
-	Future<NetworkAddress> resolveWithRetry();
-	Optional<NetworkAddress> resolveBlocking(); // This one should only be used when resolving asynchronously is
-	                                            // impossible. For all other cases, resolve() should be preferred.
+	Future<NetworkAddress> resolveWithRetry() const;
+	Optional<NetworkAddress> resolveBlocking() const; // This one should only be used when resolving asynchronously is
+	                                                  // impossible. For all other cases, resolve() should be preferred.
 
 	template <class Ar>
 	void serialize(Ar& ar) {


### PR DESCRIPTION
In order to keep `locality` JSON objects the same between server roles and the Backup and DR agents, `LocalityData::toJSON()` was added.  

It may be best to move the JSON types into the `flow/` project but this PR will be cherry-picked to release branches so I'm deferring that for now to keep the change set smaller.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
