### PR TITLE
Add processID, networkAddress, and locality to layer status JSON for Backup Agents. (Cherry-Pick #9736 to snowflake/release-71.3)

### DIFF
--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -1534,6 +1534,19 @@ ACTOR Future<std::string> getLayerStatus(Reference<ReadYourWritesTransaction> tr
 	o.create("main_thread_cpu_seconds") = getProcessorTimeThread();
 	o.create("process_cpu_seconds") = getProcessorTimeProcess();
 	o.create("configured_workers") = CLIENT_KNOBS->BACKUP_TASKS_PER_AGENT;
+	o.create("processID") = ::getpid();
+	o.create("locality") = tr->getDatabase()->clientLocality.toJSON<json_spirit::mObject>();
+
+	// Try to determine the public address used to talk to the cluster
+	state IPAddress ip;
+	try {
+		ip = determinePublicIPAutomatically(tr->getDatabase()->getConnectionRecord()->getConnectionString());
+	} catch (Error& e) {
+		// Output an error into the doc and fall back to localAddress()
+		o.create("networkAddressError") = e.what();
+		ip = g_network->getLocalAddress().ip;
+	}
+	o.create("networkAddress") = ip.toString();
 
 	if (exe == ProgramExe::AGENT) {
 		static S3BlobStoreEndpoint::Stats last_stats;

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -2223,8 +2223,6 @@ void DatabaseContext::expireThrottles() {
 	}
 }
 
-extern IPAddress determinePublicIPAutomatically(ClusterConnectionString& ccs);
-
 // Initialize tracing for FDB client
 //
 // connRecord is necessary for determining the local IP, which is then included in the trace

--- a/fdbclient/include/fdbclient/CoordinationInterface.h
+++ b/fdbclient/include/fdbclient/CoordinationInterface.h
@@ -350,4 +350,6 @@ struct CheckDescriptorMutableRequest {
 	}
 };
 
+IPAddress determinePublicIPAutomatically(ClusterConnectionString& ccs);
+
 #endif

--- a/fdbclient/include/fdbclient/JsonBuilder.h
+++ b/fdbclient/include/fdbclient/JsonBuilder.h
@@ -14,8 +14,10 @@ typedef JsonBuilder JsonString;
 template <typename T>
 class JsonBuilderObjectSetter;
 
-// Class for building JSON string values.
-// Default value is null, as in the JSON type
+// Class for building JSON strings linearly.
+// JSON data structure is only appendable.  No key deduplication is done in JSON Objects, and the output is not readable
+// other than obtaining a complete JSON string of what has been written to the builder. Default value is null, as in the
+// JSON type
 class JsonBuilder {
 protected:
 	enum EType { NULLVALUE, OBJECT, ARRAY };

--- a/fdbrpc/include/fdbrpc/Locality.h
+++ b/fdbrpc/include/fdbrpc/Locality.h
@@ -322,6 +322,23 @@ public:
 		return infoString;
 	}
 
+	// Convert locality fields to a JSON object.  This is a template because it works with JSONBuilder, StatusObject,
+	// and json_spirit::mObject, but none of these types are in the fdbrpc/ project.
+	template <typename JSONType>
+	JSONType toJSON() const {
+		JSONType obj;
+
+		for (auto it = _data.begin(); it != _data.end(); it++) {
+			if (it->second.present()) {
+				obj[it->first.toString()] = it->second.get().toString();
+			} else {
+				obj[it->first.toString()] = nullptr;
+			}
+		}
+
+		return obj;
+	}
+
 	template <class Ar>
 	void serialize(Ar& ar) {
 		// Locality is persisted in the database inside StorageServerInterface, so changes here have to be

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -240,20 +240,6 @@ protected:
 	int64_t counter;
 };
 
-static JsonBuilderObject getLocalityInfo(const LocalityData& locality) {
-	JsonBuilderObject localityObj;
-
-	for (auto it = locality._data.begin(); it != locality._data.end(); it++) {
-		if (it->second.present()) {
-			localityObj[it->first] = it->second.get();
-		} else {
-			localityObj[it->first] = JsonBuilder();
-		}
-	}
-
-	return localityObj;
-}
-
 static JsonBuilderObject getError(const TraceEventFields& errorFields) {
 	JsonBuilderObject statusObj;
 	try {
@@ -352,7 +338,7 @@ JsonBuilderObject machineStatusFetcher(WorkerEvents mMetrics,
 				}
 
 				if (locality.count(it->first)) {
-					statusObj["locality"] = getLocalityInfo(locality[it->first]);
+					statusObj["locality"] = locality[it->first].toJSON<JsonBuilderObject>();
 				}
 
 				statusObj["address"] = address;
@@ -949,7 +935,7 @@ ACTOR static Future<JsonBuilderObject> processStatusFetcher(
 				std::string MachineID = processMetrics.getValue("MachineID");
 				statusObj["machine_id"] = MachineID;
 
-				statusObj["locality"] = getLocalityInfo(workerItr->interf.locality);
+				statusObj["locality"] = workerItr->interf.locality.toJSON<JsonBuilderObject>();
 
 				statusObj.setKeyRawNumber("uptime_seconds", processMetrics.getValue("UptimeSeconds"));
 

--- a/fdbserver/fdbserver.actor.cpp
+++ b/fdbserver/fdbserver.actor.cpp
@@ -234,8 +234,6 @@ extern void pingtest();
 extern void copyTest();
 extern void versionedMapTest();
 extern void createTemplateDatabase();
-// FIXME: this really belongs in a header somewhere since it is actually used.
-extern IPAddress determinePublicIPAutomatically(ClusterConnectionString& ccs);
 
 extern const char* getSourceVersion();
 


### PR DESCRIPTION
Cherry-Pick of #9736

Original Description:

In order to keep `locality` JSON objects the same between server roles and the Backup and DR agents, `LocalityData::toJSON()` was added.  

It may be best to move the JSON types into the `flow/` project but this PR will be cherry-picked to release branches so I'm deferring that for now to keep the change set smaller.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
