### PR TITLE
The consistency check should retry if it couldn't find all the commit proxies when getting key server locations (snowflake/release-71.3)

### DIFF
--- a/fdbclient/include/fdbclient/ConsistencyScanInterface.actor.h
+++ b/fdbclient/include/fdbclient/ConsistencyScanInterface.actor.h
@@ -166,6 +166,7 @@ ACTOR Future<bool> getKeyServers(
     Promise<std::vector<std::pair<KeyRange, std::vector<StorageServerInterface>>>> keyServersPromise,
     KeyRangeRef kr,
     bool performQuiescentChecks,
+    bool failureIsError,
     bool* success);
 ACTOR Future<bool> getKeyLocations(Database cx,
                                    std::vector<std::pair<KeyRange, std::vector<StorageServerInterface>>> shards,

--- a/fdbserver/ConsistencyScan.actor.cpp
+++ b/fdbserver/ConsistencyScan.actor.cpp
@@ -97,6 +97,7 @@ ACTOR Future<bool> getKeyServers(
     Promise<std::vector<std::pair<KeyRange, std::vector<StorageServerInterface>>>> keyServersPromise,
     KeyRangeRef kr,
     bool performQuiescentChecks,
+    bool failureIsError,
     bool* success) {
 	state std::vector<std::pair<KeyRange, std::vector<StorageServerInterface>>> keyServers;
 
@@ -134,7 +135,7 @@ ACTOR Future<bool> getKeyServers(
 						TraceEvent("ConsistencyCheck_CommitProxyUnavailable")
 						    .error(shards.getError())
 						    .detail("CommitProxyID", commitProxyInfo->getId(i));
-						testFailure("Commit proxy unavailable", performQuiescentChecks, success, true);
+						testFailure("Commit proxy unavailable", performQuiescentChecks, success, failureIsError);
 						return false;
 					}
 
@@ -979,7 +980,8 @@ ACTOR Future<Void> runDataValidationCheck(ConsistencyScanData* self) {
 		// Get a list of key servers; verify that the TLogs and master all agree about who the key servers are
 		state Promise<std::vector<std::pair<KeyRange, std::vector<StorageServerInterface>>>> keyServerPromise;
 		state std::map<UID, StorageServerInterface> tssMapping;
-		bool keyServerResult = wait(getKeyServers(self->db, keyServerPromise, keyServersKeys, false, &self->success));
+		bool keyServerResult =
+		    wait(getKeyServers(self->db, keyServerPromise, keyServersKeys, false, false, &self->success));
 		if (keyServerResult) {
 			state std::vector<std::pair<KeyRange, std::vector<StorageServerInterface>>> keyServers =
 			    keyServerPromise.getFuture().get();

--- a/fdbserver/workloads/ConsistencyCheck.actor.cpp
+++ b/fdbserver/workloads/ConsistencyCheck.actor.cpp
@@ -329,8 +329,12 @@ struct ConsistencyCheckWorkload : TestWorkload {
 
 				// Get a list of key servers; verify that the TLogs and master all agree about who the key servers are
 				state Promise<std::vector<std::pair<KeyRange, std::vector<StorageServerInterface>>>> keyServerPromise;
-				bool keyServerResult = wait(
-				    getKeyServers(cx, keyServerPromise, keyServersKeys, self->performQuiescentChecks, &self->success));
+				bool keyServerResult = wait(getKeyServers(cx,
+				                                          keyServerPromise,
+				                                          keyServersKeys,
+				                                          self->performQuiescentChecks,
+				                                          self->failureIsError,
+				                                          &self->success));
 				if (keyServerResult) {
 					state std::vector<std::pair<KeyRange, std::vector<StorageServerInterface>>> keyServers =
 					    keyServerPromise.getFuture().get();
@@ -781,8 +785,8 @@ struct ConsistencyCheckWorkload : TestWorkload {
 	                                        bool removePrefix) {
 		// get shards paired with corresponding storage servers
 		state Promise<std::vector<std::pair<KeyRange, std::vector<StorageServerInterface>>>> keyServerPromise;
-		bool keyServerResult =
-		    wait(getKeyServers(cx, keyServerPromise, range, self->performQuiescentChecks, &self->success));
+		bool keyServerResult = wait(getKeyServers(
+		    cx, keyServerPromise, range, self->performQuiescentChecks, self->failureIsError, &self->success));
 		if (!keyServerResult)
 			return false;
 		state std::vector<std::pair<KeyRange, std::vector<StorageServerInterface>>> shards =
@@ -1127,7 +1131,6 @@ struct ConsistencyCheckWorkload : TestWorkload {
 		}
 
 		if (foundExtraDataStore) {
-			wait(delay(10)); // let the cluster get to fully_recovered after the reboot before retrying
 			self->testFailure("Extra data stores present on workers");
 			return false;
 		}


### PR DESCRIPTION
Cherry picks #9744 

Also as a result, we no longer need to verify that a recovery completed when killing/rebooting a machine during the consistency check

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
