### PR TITLE
Add more tests in `tests/restarting/from_71.3.0`

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -361,6 +361,15 @@ if(WITH_PYTHON)
     TEST_FILES restarting/from_71.3.0/BlobGranuleRestartLarge-1.toml
     restarting/from_71.3.0/BlobGranuleRestartLarge-2.toml)
   add_fdb_test(
+    TEST_FILES restarting/from_71.3.0/ClientTransactionProfilingCorrectness-1.txt
+    restarting/from_71.3.0/ClientTransactionProfilingCorrectness-2.txt)
+  add_fdb_test(
+    TEST_FILES restarting/from_71.3.0/CycleTestRestart-1.txt
+    restarting/from_71.3.0/CycleTestRestart-2.txt)
+  add_fdb_test(
+    TEST_FILES restarting/from_71.3.0/StorefrontTestRestart-1.txt
+    restarting/from_71.3.0/StorefrontTestRestart-2.txt)
+  add_fdb_test(
     TEST_FILES restarting/to_7.1.0_until_71.2.0/ConfigureStorageMigrationTestRestart-1.toml
     restarting/to_7.1.0_until_71.2.0/ConfigureStorageMigrationTestRestart-2.toml)
   add_fdb_test(

--- a/tests/restarting/from_71.3.0/ClientTransactionProfilingCorrectness-1.txt
+++ b/tests/restarting/from_71.3.0/ClientTransactionProfilingCorrectness-1.txt
@@ -1,0 +1,31 @@
+storageEngineExcludeTypes=3
+
+testTitle=ClientTransactionProfilingCorrectness
+clearAfterTest=false
+runSetup=true
+timeout=2100
+
+    testName=ApiCorrectness
+    numKeys=5000
+    onlyLowerCase=true
+    shortKeysRatio=0.5
+    minShortKeyLength=1
+    maxShortKeyLength=3
+    minLongKeyLength=1
+    maxLongKeyLength=128
+    minValueLength=1
+    maxValueLength=1000
+    numGets=1000
+    numGetRanges=100
+    numGetRangeSelectors=100
+    numGetKeys=100
+    numClears=100
+    numClearRanges=10
+    maxTransactionBytes=500000
+    randomTestDuration=30
+
+    testName=ClientTransactionProfileCorrectness
+
+    testName=SaveAndKill
+    restartInfoLocation=simfdb/restartInfo.ini
+    testDuration=60

--- a/tests/restarting/from_71.3.0/ClientTransactionProfilingCorrectness-2.txt
+++ b/tests/restarting/from_71.3.0/ClientTransactionProfilingCorrectness-2.txt
@@ -1,0 +1,26 @@
+testTitle=ClientTransactionProfilingCorrectness
+clearAfterTest=true
+timeout=2100
+runSetup=true
+
+    testName=ApiCorrectness
+    numKeys=5000
+    onlyLowerCase=true
+    shortKeysRatio=0.5
+    minShortKeyLength=1
+    maxShortKeyLength=3
+    minLongKeyLength=1
+    maxLongKeyLength=128
+    minValueLength=1
+    maxValueLength=1000
+    numGets=1000
+    numGetRanges=100
+    numGetRangeSelectors=100
+    numGetKeys=100
+    numClears=100
+    numClearRanges=10
+    maxTransactionBytes=500000
+    randomTestDuration=60
+
+    testName=ClientTransactionProfileCorrectness
+

--- a/tests/restarting/from_71.3.0/CycleTestRestart-1.txt
+++ b/tests/restarting/from_71.3.0/CycleTestRestart-1.txt
@@ -1,0 +1,32 @@
+storageEngineExcludeTypes=3
+testTitle=Clogged
+clearAfterTest=false 
+
+    testName=Cycle
+    transactionsPerSecond=500.0
+    nodeCount=2500
+    testDuration=10.0
+    expectedRate=0
+
+    testName=RandomClogging
+    testDuration=10.0
+
+    testName=Rollback
+    meanDelay=10.0
+    testDuration=10.0
+
+    testName=Attrition
+    machinesToKill=10
+    machinesToLeave=3
+    reboot=true
+    testDuration=10.0
+	
+    testName=Attrition
+    machinesToKill=10
+    machinesToLeave=3
+    reboot=true
+    testDuration=10.0
+    
+    testName=SaveAndKill
+    restartInfoLocation=simfdb/restartInfo.ini
+    testDuration=10.0

--- a/tests/restarting/from_71.3.0/CycleTestRestart-2.txt
+++ b/tests/restarting/from_71.3.0/CycleTestRestart-2.txt
@@ -1,0 +1,27 @@
+testTitle=Clogged
+runSetup=false
+
+    testName=Cycle
+    transactionsPerSecond=2500.0
+    nodeCount=2500
+    testDuration=10.0
+    expectedRate=0
+
+    testName=RandomClogging
+    testDuration=10.0
+
+    testName=Rollback
+    meanDelay=10.0
+    testDuration=10.0
+
+    testName=Attrition
+    machinesToKill=10
+    machinesToLeave=3
+    reboot=true
+    testDuration=10.0
+
+    testName=Attrition
+    machinesToKill=10
+    machinesToLeave=3
+    reboot=true
+    testDuration=10.0

--- a/tests/restarting/from_71.3.0/StorefrontTestRestart-1.txt
+++ b/tests/restarting/from_71.3.0/StorefrontTestRestart-1.txt
@@ -1,0 +1,10 @@
+storageEngineExcludeTypes=3
+testTitle=StorefrontTest
+clearAfterTest=false 
+testName=Storefront
+actorsPerClient=50
+itemCount=100000
+maxOrderSize=4
+testName=SaveAndKill
+restartInfoLocation=simfdb/restartInfo.ini
+testDuration=10.0

--- a/tests/restarting/from_71.3.0/StorefrontTestRestart-2.txt
+++ b/tests/restarting/from_71.3.0/StorefrontTestRestart-2.txt
@@ -1,0 +1,6 @@
+testTitle=StorefrontTest
+runSetup=false
+testName=Storefront
+actorsPerClient=50
+itemCount=100000
+maxOrderSize=4


### PR DESCRIPTION
These are tests that were originally in `from_6.3.13`. In a previous PR they were moved to `from_6.3.13_until_71.2.0` and `from_71.2.0_until_71.3.0`. This commit adds coverage for upto the current version by adding a third copy in `from_71.3.0`.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
