### PR TITLE
LogCursor timeout check should take when connection failure is enabled into account

### DIFF
--- a/fdbrpc/include/fdbrpc/simulator.h
+++ b/fdbrpc/include/fdbrpc/simulator.h
@@ -325,6 +325,7 @@ public:
 	double lastConnectionFailure;
 	double connectionFailuresDisableDuration;
 	bool speedUpSimulation;
+	double connectionFailureEnableTime; // Last time connection failure is enabled.
 	BackupAgentType backupAgents;
 	BackupAgentType drAgents;
 	bool restarted = false;

--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -73,8 +73,8 @@ ISimulator::ISimulator()
   : desiredCoordinators(1), physicalDatacenters(1), processesPerMachine(0), listenersPerProcess(1), usableRegions(1),
     allowLogSetKills(true), tssMode(TSSMode::Disabled), configDBType(ConfigDBType::DISABLED), isStopped(false),
     lastConnectionFailure(0), connectionFailuresDisableDuration(0), speedUpSimulation(false),
-    backupAgents(BackupAgentType::WaitForType), drAgents(BackupAgentType::WaitForType), allSwapsDisabled(false),
-    blobGranulesEnabled(false) {}
+    connectionFailureEnableTime(0), backupAgents(BackupAgentType::WaitForType), drAgents(BackupAgentType::WaitForType),
+    allSwapsDisabled(false), blobGranulesEnabled(false) {}
 ISimulator::~ISimulator() = default;
 
 bool simulator_should_inject_fault(const char* context, const char* file, int line, int error_code) {
@@ -2785,6 +2785,7 @@ void enableConnectionFailures(std::string const& context) {
 	if (g_network->isSimulated()) {
 		g_simulator->connectionFailuresDisableDuration = 0;
 		g_simulator->speedUpSimulation = false;
+		g_simulator->connectionFailureEnableTime = now();
 		TraceEvent(SevWarnAlways, ("EnableConnectionFailures_" + context).c_str());
 	}
 }

--- a/fdbserver/LogSystemPeekCursor.actor.cpp
+++ b/fdbserver/LogSystemPeekCursor.actor.cpp
@@ -343,7 +343,9 @@ ACTOR Future<Void> serverPeekParallelGetMore(ILogSystem::ServerPeekCursor* self,
 				// A cursor for a log router can be delayed indefinitely during a network partition, so only fail
 				// simulation tests sufficiently far after we finish simulating network partitions.
 				CODE_PROBE(e.code() == error_code_timed_out, "peek cursor timed out");
-				if (now() >= FLOW_KNOBS->SIM_SPEEDUP_AFTER_SECONDS + SERVER_KNOBS->PEEK_TRACKER_EXPIRATION_TIME) {
+				if (g_network->isSimulated() && now() >= g_simulator->connectionFailureEnableTime +
+				                                             FLOW_KNOBS->SIM_SPEEDUP_AFTER_SECONDS +
+				                                             SERVER_KNOBS->PEEK_TRACKER_EXPIRATION_TIME) {
 					ASSERT_WE_THINK(e.code() == error_code_operation_obsolete ||
 					                SERVER_KNOBS->PEEK_TRACKER_EXPIRATION_TIME < 10);
 				}


### PR DESCRIPTION
This is an issue discovered in simulation where connection failure is enabled around 150s, and disabled around 150+450 = 600s. But the log cursor check is exercised at 450+120 = 570, which violate that Log cursor shouldn't return timeout. However, since the connection failure is still enabled, it is a valid log cursor timeout.

Therefore, the log cursor timeout check should take when connection failure is enabled into account.

20230322-051028-zhewu_cursor_check-a145f9a47e01b302

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
