### PR TITLE
Log reason for QuietDatabase check failure.

### DIFF
--- a/fdbserver/QuietDatabase.actor.cpp
+++ b/fdbserver/QuietDatabase.actor.cpp
@@ -344,7 +344,7 @@ getStorageWorkers(Database cx, Reference<AsyncVar<ServerDBInfo> const> dbInfo, b
 		if (!localOnly || (usableRegions == 1 || server.locality.dcId() == masterDcId)) {
 			auto itr = workersMap.find(server.address());
 			if (itr == workersMap.end()) {
-				TraceEvent(SevWarn, "GetstStorageWorkers")
+				TraceEvent(SevWarn, "GetStorageWorkers")
 				    .detail("Reason", "Could not find worker for storage server")
 				    .detail("SS", server.id());
 				++failures;

--- a/fdbserver/QuietDatabase.actor.cpp
+++ b/fdbserver/QuietDatabase.actor.cpp
@@ -407,7 +407,7 @@ ACTOR Future<TraceEventFields> getStorageMetricsTimeout(UID storage, WorkerInter
 					TraceEvent("QuietDatabaseFailure")
 					    .error(e)
 					    .detail("Reason", "Failed to extract DurableVersion from StorageMetrics")
-					    .detail("SSID", StringRef(storage.toString()))
+					    .detail("SSID", storage)
 					    .detail("StorageMetrics", res.toString());
 					throw;
 				}

--- a/fdbserver/QuietDatabase.actor.cpp
+++ b/fdbserver/QuietDatabase.actor.cpp
@@ -403,7 +403,7 @@ ACTOR Future<TraceEventFields> getStorageMetricsTimeout(UID storage, WorkerInter
 				try {
 					if (version == invalidVersion ||
 					    getDurableVersion(storageMetrics) >= static_cast<int64_t>(version)) {
-						return;
+						return storageMetrics;
 					}
 				} catch (Error& e) {
 					TraceEvent("QuietDatabaseFailure")


### PR DESCRIPTION
An 'attribute_not_found' error was slipping through the cracks when attempting to get the max storage queue size for a storage server which has been removed. This change explicitly logs the error where it occurs, making it easier to debug.

Replace this text with your description here...

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
