### PR TITLE
Make Redwood unit test run shorter amounts of time.

### DIFF
--- a/fdbserver/VersionedBTree.actor.cpp
+++ b/fdbserver/VersionedBTree.actor.cpp
@@ -10228,7 +10228,7 @@ TEST_CASE("Lredwood/correctness/btree") {
 	// Check test op limits
 	state std::function<bool()> testFinished = [=]() {
 		return !(totalPageOps < maxPageOps && written.size() < maxVerificationMapEntries &&
-		         totalRecordsRead < maxRecordsRead);
+		         totalRecordsRead < maxRecordsRead && coldStarts < maxColdStarts);
 	};
 
 	while (!testFinished()) {
@@ -10405,8 +10405,7 @@ TEST_CASE("Lredwood/correctness/btree") {
 			mutationBytesTargetThisCommit = randomSize(maxCommitSize);
 
 			// Recover from disk at random
-			if (!pagerMemoryOnly && coldStarts < maxColdStarts &&
-			    deterministicRandom()->random01() < coldStartProbability) {
+			if (!pagerMemoryOnly && deterministicRandom()->random01() < coldStartProbability) {
 				++coldStarts;
 				printf("Recovering from disk after next commit.\n");
 


### PR DESCRIPTION
- After maxColdStarts is hit, stop the test instead of stopping cold starts.

With this change, running 100k of just the BTree unit test does not result in any timeouts and the longest execution time is  1700 seconds.  This would probably still time out for test with ASAN.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
