### PR TITLE
 Fix finishedQueries metric, add metrics reporting in GetMappedRange test [release-7.1]

### DIFF
--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -4173,6 +4173,7 @@ ACTOR Future<Void> getMappedKeyValuesQ(StorageServer* data, GetMappedKeyValuesRe
 	}
 
 	data->transactionTagCounter.addRequest(req.tags, resultSize);
+	++data->counters.finishedQueries;
 	++data->counters.finishedGetMappedRangeQueries;
 	--data->readQueueSizeMetric;
 

--- a/tests/fast/GetMappedRange.toml
+++ b/tests/fast/GetMappedRange.toml
@@ -4,4 +4,4 @@ useDB = true
 
     [[test.workload]]
     testName = 'GetMappedRange'
-    checkStorageQueueSeconds=20
+    checkStorageQueueSeconds=60

--- a/tests/fast/GetMappedRange.toml
+++ b/tests/fast/GetMappedRange.toml
@@ -4,3 +4,4 @@ useDB = true
 
     [[test.workload]]
     testName = 'GetMappedRange'
+    checkStorageQueueSeconds=20


### PR DESCRIPTION
20230323-183541-haofu-31f88aa7fae092f4

before the fix
```
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="0"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="0"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="0"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="0"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="9"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="25"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="0"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="0"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="0"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="6"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="0"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="0"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="0"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="6"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="0"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="0"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="1"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="6"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="0"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="0"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="0"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="6"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="0"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="0"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="1"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="6"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="0"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="0"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="3"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="7"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="0"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="0"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="1"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="8"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="1"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="0"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="0"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="6"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="0"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="0"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="2"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="8"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="0"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="0"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="3"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="6"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="1"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="2"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="1"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="6"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="1"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="0"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="28"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="32"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="12"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="12"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="88"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="81"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="43"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="55"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="137"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="134"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="95"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="102"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="193"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="170"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="148"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="154"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="245"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="216"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="197"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="203"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="297"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="266"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="248"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="248"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="325"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="313"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="289"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="289"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="325"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="313"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="289"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="289"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="326"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="313"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="290"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="290"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="325"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="313"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="289"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="289"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="327"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="313"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="290"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="289"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="325"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="313"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="289"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="289"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="325"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="313"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="289"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="289"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="0"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="313"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="289"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="289"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="325"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="313"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="0"
trace.0.0.0.0.0.1679585524.NeL00s.0.1.xml:QueryQueueMax="0"
```


after the fix

```
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="0"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="0"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="0"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="19"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="0"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="0"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="6"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="0"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="0"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="6"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="0"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="0"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="6"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="0"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="0"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="6"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="0"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="0"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="6"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="0"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="6"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="0"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="6"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="0"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="6"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="1"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="6"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="1"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="12"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="12"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="8"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="2"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="8"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="2"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="8"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="2"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="9"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="2"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="8"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="2"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="9"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="2"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="6"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="1"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="6"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="2"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="6"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="2"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="6"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="1"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="6"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="1"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="6"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="2"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="6"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="2"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="6"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="1"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="6"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="1"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="11"
trace.0.0.0.0.0.1679585858.L4NmOs.0.1.xml:QueryQueueMax="2"

```