### PR TITLE
backporting blob granule restarting tests

### DIFF
--- a/fdbserver/BlobWorker.actor.cpp
+++ b/fdbserver/BlobWorker.actor.cpp
@@ -550,8 +550,7 @@ ACTOR Future<Void> updateGranuleSplitState(Transaction* tr,
 	state RangeResult totalState = wait(tr->getRange(currentRange, SERVER_KNOBS->BG_MAX_SPLIT_FANOUT + 1));
 	// FIXME: remove above conflict range?
 	tr->addWriteConflictRange(currentRange);
-	ASSERT_WE_THINK(!totalState.more && totalState.size() <= SERVER_KNOBS->BG_MAX_SPLIT_FANOUT);
-	// maybe someone decreased the knob, we should gracefully handle it not in simulation
+	// maybe someone decreased the knob, we should gracefully handle it
 	if (totalState.more || totalState.size() > SERVER_KNOBS->BG_MAX_SPLIT_FANOUT) {
 		RangeResult tryAgain = wait(tr->getRange(currentRange, 10000));
 		ASSERT(!tryAgain.more);

--- a/fdbserver/workloads/BlobGranuleVerifier.actor.cpp
+++ b/fdbserver/workloads/BlobGranuleVerifier.actor.cpp
@@ -108,8 +108,11 @@ struct BlobGranuleVerifierWorkload : TestWorkload {
 		sharedRandomNumber /= 3;
 
 		// randomly some tests write data first and then turn on blob granules later, to test conversion of existing DB
-		initAtEnd = !enablePurging && sharedRandomNumber % 10 == 0;
+		initAtEnd = getOption(options, "initAtEnd"_sr, sharedRandomNumber % 10 == 0);
 		sharedRandomNumber /= 10;
+		if (enablePurging) {
+			initAtEnd = false;
+		}
 		// FIXME: enable and fix bugs!
 		// granuleSizeCheck = initAtEnd;
 		granuleSizeCheck = false;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -301,7 +301,12 @@ if(WITH_PYTHON)
   add_fdb_test(
     TEST_FILES restarting/from_7.2.0/DrUpgradeRestart-1.txt
                restarting/from_7.2.0/DrUpgradeRestart-2.txt)
-
+  add_fdb_test(
+    TEST_FILES restarting/from_71.2.8/BlobGranuleRestartCycle-1.toml
+    restarting/from_71.2.8/BlobGranuleRestartCycle-2.toml)
+  add_fdb_test(
+    TEST_FILES restarting/from_71.2.8/BlobGranuleRestartLarge-1.toml
+    restarting/from_71.2.8/BlobGranuleRestartLarge-2.toml)
 
   add_fdb_test(TEST_FILES slow/ApiCorrectness.toml)
   add_fdb_test(TEST_FILES slow/ApiCorrectnessAtomicRestore.toml)

--- a/tests/restarting/from_71.2.8/BlobGranuleRestartCycle-1.toml
+++ b/tests/restarting/from_71.2.8/BlobGranuleRestartCycle-1.toml
@@ -1,0 +1,56 @@
+# Blob Granules are only upgrade-able as of snowflake/release-71.2.3 and tests were only added as of 71.2.8
+
+[configuration]
+blobGranulesEnabled = true
+allowDefaultTenant = false
+injectTargetedSSRestart = true
+injectSSDelay = true
+# FIXME: re-enable rocks at some point
+storageEngineExcludeTypes = [4, 5]
+
+[[test]]
+testTitle = 'BlobGranuleRestartCycle'
+clearAfterTest=false
+
+    [[test.workload]]
+    testName = 'Cycle'
+    transactionsPerSecond = 500.0
+    nodeCount = 2500
+    testDuration = 30.0
+    expectedRate = 0
+
+    [[test.workload]]
+    testName = 'BlobGranuleVerifier'
+    testDuration = 30.0
+    # don't delete state after test
+    clearAndMergeCheck = false
+    doForcePurge = false
+    initAtEnd = false
+
+    [[test.workload]]
+    testName = 'RandomClogging'
+    testDuration = 30.0
+
+    [[test.workload]]
+    testName = 'Rollback'
+    meanDelay = 30.0
+    testDuration = 30.0
+
+    [[test.workload]]
+    testName = 'Attrition'
+    machinesToKill = 10
+    machinesToLeave = 3
+    reboot = true
+    testDuration = 30.0
+
+    [[test.workload]]
+    testName = 'Attrition'
+    machinesToKill = 10
+    machinesToLeave = 3
+    reboot = true
+    testDuration = 30.0
+
+    [[test.workload]]
+    testName='SaveAndKill'
+    restartInfoLocation='simfdb/restartInfo.ini'
+    testDuration=30.0

--- a/tests/restarting/from_71.2.8/BlobGranuleRestartCycle-2.toml
+++ b/tests/restarting/from_71.2.8/BlobGranuleRestartCycle-2.toml
@@ -1,0 +1,50 @@
+# Blob Granules are only upgrade-able as of snowflake/release-71.2.3 and release-7.2
+
+[configuration]
+blobGranulesEnabled = true
+allowDefaultTenant = false
+injectTargetedSSRestart = true
+injectSSDelay = true
+# FIXME: re-enable rocks at some point
+storageEngineExcludeTypes = [4, 5]
+
+[[test]]
+testTitle = 'BlobGranuleRestartCycle'
+clearAfterTest=false
+runSetup=false
+
+    [[test.workload]]
+    testName = 'Cycle'
+    transactionsPerSecond = 2500.0
+    nodeCount = 2500
+    testDuration = 30.0
+    expectedRate = 0
+
+    [[test.workload]]
+    testName = 'RandomClogging'
+    testDuration = 30.0
+
+    [[test.workload]]
+    testName = 'Rollback'
+    meanDelay = 30.0
+    testDuration = 30.0
+
+    [[test.workload]]
+    testName = 'Attrition'
+    machinesToKill = 10
+    machinesToLeave = 3
+    reboot = true
+    testDuration = 30.0
+
+    [[test.workload]]
+    testName = 'Attrition'
+    machinesToKill = 10
+    machinesToLeave = 3
+    reboot = true
+    testDuration = 30.0
+
+    [[test.workload]]
+    testName = 'BlobGranuleVerifier'
+    testDuration = 30.0
+    # cycle does its own workload checking, don't want clear racing with its checking
+    clearAndMergeCheck = false

--- a/tests/restarting/from_71.2.8/BlobGranuleRestartLarge-1.toml
+++ b/tests/restarting/from_71.2.8/BlobGranuleRestartLarge-1.toml
@@ -1,0 +1,64 @@
+# Blob Granules are only upgrade-able as of snowflake/release-71.2.3 and tests were only added as of 71.2.8
+
+[configuration]
+blobGranulesEnabled = true
+allowDefaultTenant = false
+injectTargetedSSRestart = true
+injectSSDelay = true
+# FIXME: re-enable rocks at some point
+storageEngineExcludeTypes = [4, 5]
+
+[[test]]
+testTitle = 'BlobGranuleRestartLarge'
+clearAfterTest=false
+
+    [[test.workload]]
+    testName = 'ReadWrite'
+    testDuration = 60.0
+    transactionsPerSecond = 200
+    writesPerTransactionA = 5
+    readsPerTransactionA = 1
+    writesPerTransactionB = 10
+    readsPerTransactionB = 1
+    alpha = 0.5
+    nodeCount = 2000000
+    valueBytes = 128
+    discardEdgeMeasurements = false
+    warmingDelay = 10.0
+    setup = false
+
+    [[test.workload]]
+    testName = 'BlobGranuleVerifier'
+    testDuration = 60.0
+    # don't delete state after test
+    clearAndMergeCheck = false
+    doForcePurge = false
+    initAtEnd = false
+
+    [[test.workload]]
+    testName = 'RandomClogging'
+    testDuration = 60.0
+
+    [[test.workload]]
+    testName = 'Rollback'
+    meanDelay = 60.0
+    testDuration = 60.0
+
+    [[test.workload]]
+    testName = 'Attrition'
+    machinesToKill = 10
+    machinesToLeave = 3
+    reboot = true
+    testDuration = 60.0
+
+    [[test.workload]]
+    testName = 'Attrition'
+    machinesToKill = 10
+    machinesToLeave = 3
+    reboot = true
+    testDuration = 60.0
+
+    [[test.workload]]
+    testName='SaveAndKill'
+    restartInfoLocation='simfdb/restartInfo.ini'
+    testDuration=60.0

--- a/tests/restarting/from_71.2.8/BlobGranuleRestartLarge-2.toml
+++ b/tests/restarting/from_71.2.8/BlobGranuleRestartLarge-2.toml
@@ -1,0 +1,56 @@
+# Blob Granules are only upgrade-able as of snowflake/release-71.2.3 and tests were only added as of 71.2.8
+
+[configuration]
+blobGranulesEnabled = true
+allowDefaultTenant = false
+injectTargetedSSRestart = true
+injectSSDelay = true
+# FIXME: re-enable rocks at some point
+storageEngineExcludeTypes = [4, 5]
+
+[[test]]
+testTitle = 'BlobGranuleRestartLarge'
+clearAfterTest=false
+runSetup=false
+
+    [[test.workload]]
+    testName = 'ReadWrite'
+    testDuration = 60.0
+    transactionsPerSecond = 200
+    writesPerTransactionA = 5
+    readsPerTransactionA = 1
+    writesPerTransactionB = 10
+    readsPerTransactionB = 1
+    alpha = 0.5
+    nodeCount = 2000000
+    valueBytes = 128
+    discardEdgeMeasurements = false
+    warmingDelay = 10.0
+    setup = false
+
+    [[test.workload]]
+    testName = 'RandomClogging'
+    testDuration = 60.0
+
+    [[test.workload]]
+    testName = 'Rollback'
+    meanDelay = 60.0
+    testDuration = 60.0
+
+    [[test.workload]]
+    testName = 'Attrition'
+    machinesToKill = 10
+    machinesToLeave = 3
+    reboot = true
+    testDuration = 60.0
+
+    [[test.workload]]
+    testName = 'Attrition'
+    machinesToKill = 10
+    machinesToLeave = 3
+    reboot = true
+    testDuration = 60.0
+
+    [[test.workload]]
+    testName = 'BlobGranuleVerifier'
+    testDuration = 60.0


### PR DESCRIPTION
Cherry-picking blob granule restarting tests to 71.2 so we can test BG upgrades and downgrades with 71.3:
#9259 
#9313 

Passes 10k BlobGranuleRestart* correctness

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
