### PR TITLE
Speed up the runtime of the metacluster recovery tests

### DIFF
--- a/fdbserver/workloads/MetaclusterRestoreWorkload.actor.cpp
+++ b/fdbserver/workloads/MetaclusterRestoreWorkload.actor.cpp
@@ -97,12 +97,14 @@ struct MetaclusterRestoreWorkload : TestWorkload {
 
 	int initialTenantIdPrefix;
 	bool backupComplete = false;
+	double postBackupDuration;
 	double endTime = std::numeric_limits<double>::max();
 
 	MetaclusterRestoreWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
 		maxTenants = std::min<int>(1e8 - 1, getOption(options, "maxTenants"_sr, 1000));
 		initialTenants = std::min<int>(maxTenants, getOption(options, "initialTenants"_sr, 40));
 		maxTenantGroups = std::min<int>(2 * maxTenants, getOption(options, "maxTenantGroups"_sr, 20));
+		postBackupDuration = getOption(options, "postBackupDuration"_sr, 30);
 
 		tenantGroupCapacity = (initialTenants / 2 + maxTenantGroups - 1) / g_simulator->extraDatabases.size();
 		int mode = deterministicRandom()->randomInt(0, 3);
@@ -1011,7 +1013,7 @@ struct MetaclusterRestoreWorkload : TestWorkload {
 		}
 
 		self->backupComplete = true;
-		self->endTime = now() + 30.0;
+		self->endTime = now() + self->postBackupDuration;
 
 		wait(opsFuture);
 		TraceEvent("MetaclusterRestoreWorkloadOperationsComplete");

--- a/tests/slow/MetaclusterRecovery.toml
+++ b/tests/slow/MetaclusterRecovery.toml
@@ -2,9 +2,13 @@
 allowDefaultTenant = false
 allowCreatingTenants = false
 extraDatabaseMode = 'Multiple'
-extraDatabaseCount = 4
+extraDatabaseCount = 3
 extraDatabaseBackupAgents = true
 tenantModes = ['optional', 'required']
+config = 'triple'
+generateFearless = false
+processesPerMachine = 1
+machineCount = 5
 
 [[test]]
 testTitle = 'MetaclusterRestoreTest'


### PR DESCRIPTION
The metacluster recovery workload has a particular long runtime when run in ASan. This uses a simplified configuration for the metacluster recovery workload to speed up its runtime.

Here is a distribution of ~10K ASan runs before and after the change:

```
Num tests:    10479                10499
Median   :   428.93       192.50 (0.45x)
p90      :   863.39       351.60 (0.41x)
p99      :  1478.09       570.22 (0.39x)
p99.9    :  2097.96       923.79 (0.44x)
Max      :  2861.45      1098.96 (0.38x)
```

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
