### PR TITLE
Avoid divide-by-zero in isKeyValueInSample.

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -839,9 +839,26 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( STORAGE_DURABILITY_LAG_REJECT_THRESHOLD,              0.25 );
 	init( STORAGE_DURABILITY_LAG_MIN_RATE,                       0.1 );
 	init( STORAGE_COMMIT_INTERVAL,                               0.5 ); if( randomize && BUGGIFY ) STORAGE_COMMIT_INTERVAL = 2.0;
+
+
+	// Constants which affect the fraction of data which is sampled
+	// by storage severs to estimate key-range sizes and splits.
+	//
+	// The rough goal is for the sample size to be a fixed fraction of the total
+	// size of all keys and values, 1/BYTE_SAMPLING_FACTOR, which defaults to 1/250.
+	// This includes an estimated overhead per entry of BYTE_SAMPLING_OVERHEAD,
+	// which defaults to 100 bytes.
+	//
+	// NOTE: This BYTE_SAMPLING_FACTOR and BYTE_SAMPLING_OVERHEAD knobs can't be
+	// changed after a database has been created. Data which has been already
+	// sampled can't be resampled, and the estimates of the size of key ranges
+	// implicitly includes these constants.
 	init( BYTE_SAMPLING_FACTOR,                                  250 ); //cannot buggify because of differences in restarting tests
 	init( BYTE_SAMPLING_OVERHEAD,                                100 );
-	init( MIN_BYTE_SAMPLING_PROBABILITY,                           0 ); // Adjustable only for test of PhysicalShardMove. should be always zero for other cases
+
+	// Adjustable only for test of PhysicalShardMove. Should always be 0 for other cases.
+	init( MIN_BYTE_SAMPLING_PROBABILITY,                           0 );
+
 	init( MAX_STORAGE_SERVER_WATCH_BYTES,                      100e6 ); if( randomize && BUGGIFY ) MAX_STORAGE_SERVER_WATCH_BYTES = 10e3;
 	init( MAX_BYTE_SAMPLE_CLEAR_MAP_SIZE,                        1e9 ); if( randomize && BUGGIFY ) MAX_BYTE_SAMPLE_CLEAR_MAP_SIZE = 1e3;
 	init( LONG_BYTE_SAMPLE_RECOVERY_DELAY,                      60.0 );

--- a/fdbserver/ConsistencyScan.actor.cpp
+++ b/fdbserver/ConsistencyScan.actor.cpp
@@ -831,9 +831,15 @@ ACTOR Future<Void> checkDataConsistency(Database cx,
 						for (int k = 0; k < data.size(); k++) {
 							ByteSampleInfo sampleInfo = isKeyValueInSample(data[k]);
 							shardBytes += sampleInfo.size;
-							if (sampleInfo.probability > 0 && sampleInfo.probability < 1)
-								shardVariance += sampleInfo.probability * (1 - sampleInfo.probability) *
-								                 pow((double)sampleInfo.sampledSize, 2);
+
+							// Sanity check before putting probability into variance formula.
+							ASSERT_GE(sampleInfo.probability, 0);
+							ASSERT_LE(sampleInfo.probability, 1);
+
+							// Variance of a single Bernoulli trial, for which X=n with probability p,
+							// is p * (1-p) * n^2.
+							shardVariance += sampleInfo.probability * (1 - sampleInfo.probability) *
+							                 pow((double)sampleInfo.sampledSize, 2);
 
 							if (sampleInfo.inSample) {
 								sampledBytes += sampleInfo.sampledSize;
@@ -857,7 +863,13 @@ ACTOR Future<Void> checkDataConsistency(Database cx,
 									firstKeySampledBytes += sampleInfo.sampledSize;
 
 								sampledKeys++;
-								if (sampleInfo.probability > 0 && sampleInfo.probability < 1) {
+
+								// Track sampled items with non-trivial variance,
+								// i.e. not those withprobability 0 or 1.
+								// Probability shouldn't be 0 here because we're
+								// decided to sample this key.
+								ASSERT_GT(sampleInfo.probability, 0);
+								if (sampleInfo.probability < 1) {
 									sampledKeysWithProb++;
 								}
 							}

--- a/fdbserver/include/fdbserver/StorageMetrics.actor.h
+++ b/fdbserver/include/fdbserver/StorageMetrics.actor.h
@@ -165,7 +165,8 @@ struct ByteSampleInfo {
 
 	// Probability that the key-value pair will be sampled.
 	// This is a function of key and value sizes.
-	// The goal is to sample ~1/250th of the key-value space.
+	// The goal is to sample ~1/BYTE_SAMPLING_FACTOR of the key-value space,
+	// which by default is 1/250th.
 	double probability;
 
 	// The recorded size of the sample (max of bytesPerSample, size).

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -10822,11 +10822,16 @@ Future<bool> StorageServerDisk::restoreDurableState() {
 // are used to estimate the size of key ranges and determine split points.
 //
 // It's assumed that there's some overhead involved in the sample,
-// BYTE_SAMPLING_OVERHEAD, which defaults to 100 bytes.
+// BYTE_SAMPLING_OVERHEAD, which defaults to 100 bytes per entry.
 //
 // The rough goal is for the sample size to be a fixed fraction of the total
 // size of all keys and values, 1/BYTE_SAMPLING_FACTOR, which defaults to 1/250.
 // This includes the overhead, mentioned above.
+//
+// NOTE: This BYTE_SAMPLING_FACTOR and BYTE_SAMPLING_OVERHEAD knobs can't be
+// changed after a database has been created. Data which has been already
+// sampled can't be resampled, and the estimates of the size of key ranges
+// implicitly includes these constants.
 //
 // This functions returns a struct containing
 //   * inSample: true if we've selected this key-value pair for sampling.


### PR DESCRIPTION
In the pathological case that both key size and value size are 0,
the probability of choosing that key-value pair is 0, and we divide
by zero when computing the sampledSize.

This change adds documentation to that function, which was quite
difficult to understand. In addition, we add `probability` to the
returned values, since one of the callers was backing it out from
sampledSize and itself in danger of dividing by zero.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
