### PR TITLE
Do not update exclude/failed system metadata in excludeServers if the input list is already excluded/failed.

### DIFF
--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -1678,6 +1678,7 @@ ACTOR Future<Void> excludeServers(Database cx, std::vector<AddressExclusion> ser
 }
 
 // excludes localities by setting the keys in api version below 7.0
+// TODO(zhewu): update this function that if the locality is already excluded, don't need to update the system metadata.
 void excludeLocalities(Transaction& tr, std::unordered_set<std::string> localities, bool failed) {
 	tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 	tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);

--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -1457,7 +1457,7 @@ struct AutoQuorumChange final : IQuorumChange {
 			desiredCount = redundancy * 2 - 1;
 		}
 
-		std::vector<AddressExclusion> excl = wait(getExcludedServers(tr));
+		std::vector<AddressExclusion> excl = wait(getAllExcludedServers(tr));
 		state std::set<AddressExclusion> excluded(excl.begin(), excl.end());
 
 		std::vector<ProcessData> _workers = wait(getWorkers(tr));
@@ -1603,23 +1603,37 @@ Reference<IQuorumChange> autoQuorumChange(int desired) {
 	return Reference<IQuorumChange>(new AutoQuorumChange(desired));
 }
 
-void excludeServers(Transaction& tr, std::vector<AddressExclusion>& servers, bool failed) {
-	tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
-	tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
-	tr.setOption(FDBTransactionOptions::LOCK_AWARE);
-	tr.setOption(FDBTransactionOptions::USE_PROVISIONAL_PROXIES);
-	std::string excludeVersionKey = deterministicRandom()->randomUniqueID().toString();
-	auto serversVersionKey = failed ? failedServersVersionKey : excludedServersVersionKey;
-	tr.addReadConflictRange(singleKeyRange(serversVersionKey)); // To conflict with parallel includeServers
-	tr.set(serversVersionKey, excludeVersionKey);
+ACTOR Future<Void> excludeServers(Transaction* tr, std::vector<AddressExclusion> servers, bool failed) {
+	tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+	tr->setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
+	tr->setOption(FDBTransactionOptions::LOCK_AWARE);
+	tr->setOption(FDBTransactionOptions::USE_PROVISIONAL_PROXIES);
+	std::vector<AddressExclusion> excl = wait(failed ? getExcludedFailedServerList(tr) : getExcludedServerList(tr));
+	std::set<AddressExclusion> exclusions(excl.begin(), excl.end());
+	bool containNewExclusion = false;
 	for (auto& s : servers) {
+		if (exclusions.find(s) != exclusions.end()) {
+			continue;
+		}
+		containNewExclusion = true;
 		if (failed) {
-			tr.set(encodeFailedServersKey(s), StringRef());
+			tr->set(encodeFailedServersKey(s), StringRef());
 		} else {
-			tr.set(encodeExcludedServersKey(s), StringRef());
+			tr->set(encodeExcludedServersKey(s), StringRef());
 		}
 	}
-	TraceEvent("ExcludeServersCommit").detail("Servers", describe(servers)).detail("ExcludeFailed", failed);
+
+	if (containNewExclusion) {
+		std::string excludeVersionKey = deterministicRandom()->randomUniqueID().toString();
+		auto serversVersionKey = failed ? failedServersVersionKey : excludedServersVersionKey;
+		tr->addReadConflictRange(singleKeyRange(serversVersionKey)); // To conflict with parallel includeServers
+		tr->set(serversVersionKey, excludeVersionKey);
+	}
+	TraceEvent("ExcludeServersCommit")
+	    .detail("Servers", describe(servers))
+	    .detail("ExcludeFailed", failed)
+	    .detail("ExclusionUpdated", containNewExclusion);
+	return Void();
 }
 
 ACTOR Future<Void> excludeServers(Database cx, std::vector<AddressExclusion> servers, bool failed) {
@@ -1652,7 +1666,7 @@ ACTOR Future<Void> excludeServers(Database cx, std::vector<AddressExclusion> ser
 		state Transaction tr(cx);
 		loop {
 			try {
-				excludeServers(tr, servers, failed);
+				wait(excludeServers(&tr, servers, failed));
 				wait(tr.commit());
 				return Void();
 			} catch (Error& e) {
@@ -1950,11 +1964,9 @@ ACTOR Future<Void> setClass(Database cx, AddressExclusion server, ProcessClass p
 	}
 }
 
-ACTOR Future<std::vector<AddressExclusion>> getExcludedServers(Transaction* tr) {
+ACTOR Future<std::vector<AddressExclusion>> getExcludedServerList(Transaction* tr) {
 	state RangeResult r = wait(tr->getRange(excludedServersKeys, CLIENT_KNOBS->TOO_MANY));
 	ASSERT(!r.more && r.size() < CLIENT_KNOBS->TOO_MANY);
-	state RangeResult r2 = wait(tr->getRange(failedServersKeys, CLIENT_KNOBS->TOO_MANY));
-	ASSERT(!r2.more && r2.size() < CLIENT_KNOBS->TOO_MANY);
 
 	std::vector<AddressExclusion> exclusions;
 	for (auto i = r.begin(); i != r.end(); ++i) {
@@ -1962,7 +1974,16 @@ ACTOR Future<std::vector<AddressExclusion>> getExcludedServers(Transaction* tr) 
 		if (a.isValid())
 			exclusions.push_back(a);
 	}
-	for (auto i = r2.begin(); i != r2.end(); ++i) {
+	uniquify(exclusions);
+	return exclusions;
+}
+
+ACTOR Future<std::vector<AddressExclusion>> getExcludedFailedServerList(Transaction* tr) {
+	state RangeResult r = wait(tr->getRange(failedServersKeys, CLIENT_KNOBS->TOO_MANY));
+	ASSERT(!r.more && r.size() < CLIENT_KNOBS->TOO_MANY);
+
+	std::vector<AddressExclusion> exclusions;
+	for (auto i = r.begin(); i != r.end(); ++i) {
 		auto a = decodeFailedServersKey(i->key);
 		if (a.isValid())
 			exclusions.push_back(a);
@@ -1971,14 +1992,24 @@ ACTOR Future<std::vector<AddressExclusion>> getExcludedServers(Transaction* tr) 
 	return exclusions;
 }
 
-ACTOR Future<std::vector<AddressExclusion>> getExcludedServers(Database cx) {
+ACTOR Future<std::vector<AddressExclusion>> getAllExcludedServers(Transaction* tr) {
+	state std::vector<AddressExclusion> exclusions;
+	std::vector<AddressExclusion> excludedServers = wait(getExcludedServerList(tr));
+	exclusions.insert(exclusions.end(), excludedServers.begin(), excludedServers.end());
+	std::vector<AddressExclusion> excludedFailed = wait(getExcludedFailedServerList(tr));
+	exclusions.insert(exclusions.end(), excludedFailed.begin(), excludedFailed.end());
+	uniquify(exclusions);
+	return exclusions;
+}
+
+ACTOR Future<std::vector<AddressExclusion>> getAllExcludedServers(Database cx) {
 	state Transaction tr(cx);
 	loop {
 		try {
 			tr.setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
 			tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE); // necessary?
 			tr.setOption(FDBTransactionOptions::LOCK_AWARE);
-			std::vector<AddressExclusion> exclusions = wait(getExcludedServers(&tr));
+			std::vector<AddressExclusion> exclusions = wait(getAllExcludedServers(&tr));
 			return exclusions;
 		} catch (Error& e) {
 			wait(tr.onError(e));

--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -1159,7 +1159,7 @@ ACTOR Future<Optional<std::string>> excludeCommitActor(ReadYourWritesTransaction
 		if (!safe)
 			return result;
 	}
-	excludeServers(ryw->getTransaction(), addresses, failed);
+	wait(excludeServers(&(ryw->getTransaction()), addresses, failed));
 	includeServers(ryw);
 
 	return result;
@@ -1204,7 +1204,7 @@ ACTOR Future<RangeResult> ExclusionInProgressActor(ReadYourWritesTransaction* ry
 	tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE); // necessary?
 	tr.setOption(FDBTransactionOptions::LOCK_AWARE);
 
-	state std::vector<AddressExclusion> excl = wait((getExcludedServers(&tr)));
+	state std::vector<AddressExclusion> excl = wait((getAllExcludedServers(&tr)));
 	state std::set<AddressExclusion> exclusions(excl.begin(), excl.end());
 	state std::set<NetworkAddress> inProgressExclusion;
 	// Just getting a consistent read version proves that a set of tlogs satisfying the exclusions has completed

--- a/fdbclient/include/fdbclient/ManagementAPI.actor.h
+++ b/fdbclient/include/fdbclient/ManagementAPI.actor.h
@@ -67,7 +67,7 @@ Reference<IQuorumChange> nameQuorumChange(std::string const& name, Reference<IQu
 // necessarily waiting for the servers to be evacuated.  A NetworkAddress with a port of 0 means all servers on the
 // given IP.
 ACTOR Future<Void> excludeServers(Database cx, std::vector<AddressExclusion> servers, bool failed = false);
-void excludeServers(Transaction& tr, std::vector<AddressExclusion>& servers, bool failed = false);
+ACTOR Future<Void> excludeServers(Transaction* tr, std::vector<AddressExclusion> servers, bool failed = false);
 
 // Exclude the servers matching the given set of localities from use as state servers.  Returns as soon as the change
 // is durable, without necessarily waiting for the servers to be evacuated.
@@ -89,8 +89,11 @@ ACTOR Future<Void> includeLocalities(Database cx,
 ACTOR Future<Void> setClass(Database cx, AddressExclusion server, ProcessClass processClass);
 
 // Get the current list of excluded servers
-ACTOR Future<std::vector<AddressExclusion>> getExcludedServers(Database cx);
-ACTOR Future<std::vector<AddressExclusion>> getExcludedServers(Transaction* tr);
+ACTOR Future<std::vector<AddressExclusion>> getAllExcludedServers(Database cx);
+
+ACTOR Future<std::vector<AddressExclusion>> getExcludedServerList(Transaction* tr);
+ACTOR Future<std::vector<AddressExclusion>> getExcludedFailedServerList(Transaction* tr);
+ACTOR Future<std::vector<AddressExclusion>> getAllExcludedServers(Transaction* tr);
 
 // Get the current list of excluded localities
 ACTOR Future<std::vector<std::string>> getExcludedLocalities(Database cx);

--- a/fdbclient/include/fdbclient/ManagementAPI.actor.h
+++ b/fdbclient/include/fdbclient/ManagementAPI.actor.h
@@ -88,12 +88,15 @@ ACTOR Future<Void> includeLocalities(Database cx,
 // the given IP.
 ACTOR Future<Void> setClass(Database cx, AddressExclusion server, ProcessClass processClass);
 
-// Get the current list of excluded servers
+// Get the current list of excluded servers including both "exclude" and "failed".
 ACTOR Future<std::vector<AddressExclusion>> getAllExcludedServers(Database cx);
-
-ACTOR Future<std::vector<AddressExclusion>> getExcludedServerList(Transaction* tr);
-ACTOR Future<std::vector<AddressExclusion>> getExcludedFailedServerList(Transaction* tr);
 ACTOR Future<std::vector<AddressExclusion>> getAllExcludedServers(Transaction* tr);
+
+// Get the current list of excluded servers.
+ACTOR Future<std::vector<AddressExclusion>> getExcludedServerList(Transaction* tr);
+
+// Get the current list of failed servers.
+ACTOR Future<std::vector<AddressExclusion>> getExcludedFailedServerList(Transaction* tr);
 
 // Get the current list of excluded localities
 ACTOR Future<std::vector<std::string>> getExcludedLocalities(Database cx);

--- a/fdbserver/workloads/DataLossRecovery.actor.cpp
+++ b/fdbserver/workloads/DataLossRecovery.actor.cpp
@@ -164,7 +164,7 @@ struct DataLossRecoveryWorkload : TestWorkload {
 		servers.push_back(AddressExclusion(addr.ip, addr.port));
 		loop {
 			try {
-				excludeServers(tr, servers, true);
+				wait(excludeServers(&tr, servers, true));
 				wait(tr.commit());
 				break;
 			} catch (Error& e) {

--- a/fdbserver/workloads/SpecialKeySpaceRobustness.actor.cpp
+++ b/fdbserver/workloads/SpecialKeySpaceRobustness.actor.cpp
@@ -132,8 +132,7 @@ struct SpecialKeySpaceRobustnessWorkload : TestWorkload {
 		{
 			try {
 				std::vector<ProcessData> workers = wait(getWorkers(&tx->getTransaction()));
-				ProcessData excludeWorker = deterministicRandom()->randomChoice(workers);
-				state std::string workerAddress = formatIpPort(excludeWorker.address.ip, excludeWorker.address.port);
+				state std::string workerAddress = "123.4.56.7:9876"; // Use a random address to not impact the cluster.
 
 				tx->setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
 				state Optional<Value> versionKey0 = wait(tx->get(excludedServersVersionKey));

--- a/fdbserver/workloads/SpecialKeySpaceRobustness.actor.cpp
+++ b/fdbserver/workloads/SpecialKeySpaceRobustness.actor.cpp
@@ -154,23 +154,23 @@ struct SpecialKeySpaceRobustnessWorkload : TestWorkload {
 			} catch (Error& e) {
 				if (e.code() == error_code_actor_cancelled)
 					throw;
-			if (e.code() == error_code_special_keys_api_failure) {
-				Optional<Value> errorMsg =
-				    wait(tx->get(SpecialKeySpace::getModuleRange(SpecialKeySpace::MODULE::ERRORMSG).begin));
-				ASSERT(errorMsg.present());
-				std::string errorStr;
-				auto valueObj = readJSONStrictly(errorMsg.get().toString()).get_obj();
-				auto schema = readJSONStrictly(JSONSchemas::managementApiErrorSchema.toString()).get_obj();
-				// special_key_space_management_api_error_msg schema validation
-				ASSERT(schemaMatch(schema, valueObj, errorStr, SevError, true));
-				ASSERT(valueObj["command"].get_str() == "exclude" && !valueObj["retriable"].get_bool());
-			} else {
-				TraceEvent(SevDebug, "UnexpectedError")
-				    .error(e)
-				    .detail("Command", "Exclude")
-				    .detail("Test", "Repeated exclusions");
-				wait(tx->onError(e));
-			}
+				if (e.code() == error_code_special_keys_api_failure) {
+					Optional<Value> errorMsg =
+					    wait(tx->get(SpecialKeySpace::getModuleRange(SpecialKeySpace::MODULE::ERRORMSG).begin));
+					ASSERT(errorMsg.present());
+					std::string errorStr;
+					auto valueObj = readJSONStrictly(errorMsg.get().toString()).get_obj();
+					auto schema = readJSONStrictly(JSONSchemas::managementApiErrorSchema.toString()).get_obj();
+					// special_key_space_management_api_error_msg schema validation
+					ASSERT(schemaMatch(schema, valueObj, errorStr, SevError, true));
+					ASSERT(valueObj["command"].get_str() == "exclude" && !valueObj["retriable"].get_bool());
+				} else {
+					TraceEvent(SevDebug, "UnexpectedError")
+					    .error(e)
+					    .detail("Command", "Exclude")
+					    .detail("Test", "Repeated exclusions");
+					wait(tx->onError(e));
+				}
 				tx->reset();
 			}
 		}

--- a/fdbserver/workloads/SpecialKeySpaceRobustness.actor.cpp
+++ b/fdbserver/workloads/SpecialKeySpaceRobustness.actor.cpp
@@ -61,18 +61,19 @@ struct SpecialKeySpaceRobustnessWorkload : TestWorkload {
 		return true;
 	}
 
-	ACTOR static Future<Optional<Value>> runExcludeAndGetVersionKey(Reference<ReadYourWritesTransaction> tx, std::string workerAddress, std::string command, KeyRef versionKey) {
-		tx->reset();		
+	ACTOR static Future<Optional<Value>> runExcludeAndGetVersionKey(Reference<ReadYourWritesTransaction> tx,
+	                                                                std::string workerAddress,
+	                                                                std::string command,
+	                                                                KeyRef versionKey) {
+		tx->reset();
 		tx->setOption(FDBTransactionOptions::RAW_ACCESS);
 		tx->setOption(FDBTransactionOptions::SPECIAL_KEY_SPACE_ENABLE_WRITES);
-		tx->set(Key(workerAddress)
-				            .withPrefix(SpecialKeySpace::getManagementApiCommandPrefix(command)),
-				        ValueRef());
+		tx->set(Key(workerAddress).withPrefix(SpecialKeySpace::getManagementApiCommandPrefix(command)), ValueRef());
 		wait(tx->commit());
 		tx->reset();
 
 		tx->setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
-				Optional<Value> versionKeyValue = wait(tx->get(versionKey));
+		Optional<Value> versionKeyValue = wait(tx->get(versionKey));
 		tx->reset();
 		return versionKeyValue;
 	}
@@ -131,17 +132,21 @@ struct SpecialKeySpaceRobustnessWorkload : TestWorkload {
 			try {
 				std::vector<ProcessData> workers = wait(getWorkers(&tx->getTransaction()));
 				ProcessData excludeWorker = deterministicRandom()->randomChoice(workers);
-				state std::string workerAddress = formatIpPort(excludeWorker.address.ip, excludeWorker.address.port); 
+				state std::string workerAddress = formatIpPort(excludeWorker.address.ip, excludeWorker.address.port);
 
-				state Optional<Value> versionKey1 = wait(runExcludeAndGetVersionKey(tx, workerAddress, "exclude", excludedServersVersionKey));
+				state Optional<Value> versionKey1 =
+				    wait(runExcludeAndGetVersionKey(tx, workerAddress, "exclude", excludedServersVersionKey));
 				ASSERT(versionKey1.present());
-				Optional<Value> versionKey2 = wait(runExcludeAndGetVersionKey(tx, workerAddress, "exclude", excludedServersVersionKey));
+				Optional<Value> versionKey2 =
+				    wait(runExcludeAndGetVersionKey(tx, workerAddress, "exclude", excludedServersVersionKey));
 				ASSERT(versionKey2.present());
 				ASSERT(versionKey1 == versionKey2);
 
-				state Optional<Value> versionKey3 = wait(runExcludeAndGetVersionKey(tx, workerAddress, "failed", failedServersVersionKey));
+				state Optional<Value> versionKey3 =
+				    wait(runExcludeAndGetVersionKey(tx, workerAddress, "failed", failedServersVersionKey));
 				ASSERT(versionKey3.present());
-				Optional<Value> versionKey4 = wait(runExcludeAndGetVersionKey(tx, workerAddress, "failed", failedServersVersionKey));
+				Optional<Value> versionKey4 =
+				    wait(runExcludeAndGetVersionKey(tx, workerAddress, "failed", failedServersVersionKey));
 				ASSERT(versionKey4.present());
 				ASSERT(versionKey3 == versionKey4);
 

--- a/tests/fast/SpecialKeySpaceRobustness.toml
+++ b/tests/fast/SpecialKeySpaceRobustness.toml
@@ -1,5 +1,6 @@
 [configuration]
 tenantModes = ['optional', 'required']
+extraMachineCountDC = 2
 
 [[test]]
 testTitle = 'SpecialKeySpaceRobustnessTest'


### PR DESCRIPTION
The motivation is that exclude command triggers recovery if the system is not in `fully_recovered` state. This causes trouble during unstable states.

20230325-031637-zhewu_exclude-a96cf27b7a08a2db     compressed=True data_size=32586002 duration=4731216 ended=100000 fail=4 fail_fast=10 max_runs=100000 pass=99996 priority=100 remaining=0 runtime=1:02:28 sanity=False started=100000 stopped=20230325-041905 submitted=20230325-031637 timeout=5400 username=zhewu_exclude

All unrealted failures.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
