### PR TITLE
fix a rare race condition in PerpetualWiggleStatsWorkload.actor.cpp (Cherry-Pick #9690 to snowflake/release-71.3)

### DIFF
--- a/fdbserver/workloads/PerpetualWiggleStatsWorkload.actor.cpp
+++ b/fdbserver/workloads/PerpetualWiggleStatsWorkload.actor.cpp
@@ -158,6 +158,7 @@ struct PerpetualWiggleStatsWorkload : public TestWorkload {
 		MoveKeysLock lock = wait(takeMoveKeysLock(cx, UID())); // force current DD to quit
 		bool success = wait(IssueConfigurationChange(cx, "storage_migration_type=disabled", true));
 		ASSERT(success);
+		wait(delay(30.0)); // make sure the DD has already quit before the test start
 		return Void();
 	}
 


### PR DESCRIPTION
Cherry-Pick of #9690. And re-ran *Perpetual* tests 100k pass.

Original Description:

PerpetualWiggleStatsWorkload assumes itself as the only writer to `PerpetualWiggleMetrics` in the database, so in the `setup` phase it disables DD.
However, there is a rare case that the DD hasn't finished the quit process before the workload enters the `start` phase, so the new `PerpetualWiggleMetrics` written by the workload may be overridden by DD before DD finishes the quit process, which causes the test failure.
The easy solution here is to wait for extra 30s in the setup phase which is 99.9% if not 100% enough for the DD completely quit before `start` phase. If DD hasn't quit after 30s since disabled, it also indicates other bugs.

Pass 100k Perpetual* workload.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
