### PR TITLE
Parameterized queue length in GetMappedRange test(release-7.1)

### DIFF
--- a/tests/fast/GetMappedRange.toml
+++ b/tests/fast/GetMappedRange.toml
@@ -5,3 +5,4 @@ useDB = true
     [[test.workload]]
     testName = 'GetMappedRange'
     checkStorageQueueSeconds=60
+    queueMaxLength=200


### PR DESCRIPTION
Also retry when operation_cancelled happens

20230327-132924-haofu-327eacda35619bf1


part of https://github.com/apple/foundationdb/pull/9796

Replace this text with your description here...

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
