### PR TITLE
[Release 7.1] Do not update exclude/failed system metadata in excludeServers if the input list is already excluded/failed

### DIFF
--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -1347,6 +1347,7 @@ ACTOR Future<Void> excludeServers(Database cx, std::vector<AddressExclusion> ser
 }
 
 // excludes localities by setting the keys in api version below 7.0
+// TODO(zhewu): update this function that if the locality is already excluded, don't need to update the system metadata.
 void excludeLocalities(Transaction& tr, std::unordered_set<std::string> localities, bool failed) {
 	tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 	tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);

--- a/fdbclient/ManagementAPI.actor.h
+++ b/fdbclient/ManagementAPI.actor.h
@@ -86,12 +86,15 @@ ACTOR Future<Void> includeLocalities(Database cx,
 // the given IP.
 ACTOR Future<Void> setClass(Database cx, AddressExclusion server, ProcessClass processClass);
 
-// Get the current list of excluded servers
+// Get the current list of excluded servers including both "exclude" and "failed".
 ACTOR Future<std::vector<AddressExclusion>> getAllExcludedServers(Database cx);
-
-ACTOR Future<std::vector<AddressExclusion>> getExcludedServerList(Transaction* tr);
-ACTOR Future<std::vector<AddressExclusion>> getExcludedFailedServerList(Transaction* tr);
 ACTOR Future<std::vector<AddressExclusion>> getAllExcludedServers(Transaction* tr);
+
+// Get the current list of excluded servers.
+ACTOR Future<std::vector<AddressExclusion>> getExcludedServerList(Transaction* tr);
+
+// Get the current list of failed servers.
+ACTOR Future<std::vector<AddressExclusion>> getExcludedFailedServerList(Transaction* tr);
 
 // Get the current list of excluded localities
 ACTOR Future<std::vector<std::string>> getExcludedLocalities(Database cx);

--- a/fdbclient/ManagementAPI.actor.h
+++ b/fdbclient/ManagementAPI.actor.h
@@ -65,7 +65,7 @@ Reference<IQuorumChange> nameQuorumChange(std::string const& name, Reference<IQu
 // necessarily waiting for the servers to be evacuated.  A NetworkAddress with a port of 0 means all servers on the
 // given IP.
 ACTOR Future<Void> excludeServers(Database cx, std::vector<AddressExclusion> servers, bool failed = false);
-void excludeServers(Transaction& tr, std::vector<AddressExclusion>& servers, bool failed = false);
+ACTOR Future<Void> excludeServers(Transaction* tr, std::vector<AddressExclusion> servers, bool failed = false);
 
 // Exclude the servers matching the given set of localities from use as state servers.  Returns as soon as the change
 // is durable, without necessarily waiting for the servers to be evacuated.
@@ -87,8 +87,11 @@ ACTOR Future<Void> includeLocalities(Database cx,
 ACTOR Future<Void> setClass(Database cx, AddressExclusion server, ProcessClass processClass);
 
 // Get the current list of excluded servers
-ACTOR Future<std::vector<AddressExclusion>> getExcludedServers(Database cx);
-ACTOR Future<std::vector<AddressExclusion>> getExcludedServers(Transaction* tr);
+ACTOR Future<std::vector<AddressExclusion>> getAllExcludedServers(Database cx);
+
+ACTOR Future<std::vector<AddressExclusion>> getExcludedServerList(Transaction* tr);
+ACTOR Future<std::vector<AddressExclusion>> getExcludedFailedServerList(Transaction* tr);
+ACTOR Future<std::vector<AddressExclusion>> getAllExcludedServers(Transaction* tr);
 
 // Get the current list of excluded localities
 ACTOR Future<std::vector<std::string>> getExcludedLocalities(Database cx);

--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -1122,7 +1122,7 @@ ACTOR Future<Optional<std::string>> excludeCommitActor(ReadYourWritesTransaction
 		if (!safe)
 			return result;
 	}
-	excludeServers(ryw->getTransaction(), addresses, failed);
+	wait(excludeServers(&(ryw->getTransaction()), addresses, failed));
 	includeServers(ryw);
 
 	return result;
@@ -1167,7 +1167,7 @@ ACTOR Future<RangeResult> ExclusionInProgressActor(ReadYourWritesTransaction* ry
 	tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE); // necessary?
 	tr.setOption(FDBTransactionOptions::LOCK_AWARE);
 
-	state std::vector<AddressExclusion> excl = wait((getExcludedServers(&tr)));
+	state std::vector<AddressExclusion> excl = wait((getAllExcludedServers(&tr)));
 	state std::set<AddressExclusion> exclusions(excl.begin(), excl.end());
 	state std::set<NetworkAddress> inProgressExclusion;
 	// Just getting a consistent read version proves that a set of tlogs satisfying the exclusions has completed

--- a/fdbserver/workloads/DataLossRecovery.actor.cpp
+++ b/fdbserver/workloads/DataLossRecovery.actor.cpp
@@ -152,7 +152,7 @@ struct DataLossRecoveryWorkload : TestWorkload {
 		servers.push_back(AddressExclusion(addr.ip, addr.port));
 		loop {
 			try {
-				excludeServers(tr, servers, true);
+				wait(excludeServers(&tr, servers, true));
 				wait(tr.commit());
 				break;
 			} catch (Error& e) {


### PR DESCRIPTION
Cherry-pick #9803 

Didn't add SpecialKeySpaceRobustness.actor.cpp since it doesn't exist in 7.1

20230327-170002-zhewu_exclude_7.1-950d1a741aa7ffea compressed=True data_size=37914275 duration=3328832 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:31:48 sanity=False started=100000 stopped=20230327-173150 submitted=20230327-170002 timeout=5400 username=zhewu_exclude_7.1

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
