### PR TITLE
Run client upgrade tests with latest root CAs

### DIFF
--- a/tests/TestRunner/binary_download.py
+++ b/tests/TestRunner/binary_download.py
@@ -10,6 +10,7 @@ import hashlib
 from fdb_version import CURRENT_VERSION, FUTURE_VERSION
 
 from test_util import random_alphanum_string
+import certifi
 
 SUPPORTED_PLATFORMS = ["x86_64", "aarch64"]
 FDB_DOWNLOAD_ROOT = "https://github.com/apple/foundationdb/releases/download/"
@@ -96,9 +97,9 @@ class FdbBinaryDownloader:
                 assert False, "Failed to download {} after {} attempts".format(local_file_tmp, MAX_DOWNLOAD_ATTEMPTS)
             try:
                 print("Downloading '{}' to '{}'...".format(remote_file, local_file_tmp))
-                request.urlretrieve(remote_file, local_file_tmp)
+                request.urlretrieve(remote_file, local_file_tmp, cafile=certifi.where())
                 print("Downloading '{}' to '{}'...".format(remote_sha256, local_sha256))
-                request.urlretrieve(remote_sha256, local_sha256)
+                request.urlretrieve(remote_sha256, local_sha256, cafile=certifi.where())
                 print("Download complete")
             except Exception as e:
                 print("Retrying on error:", e)

--- a/tests/TestRunner/requirements.txt
+++ b/tests/TestRunner/requirements.txt
@@ -3,3 +3,4 @@ cffi==1.15.1
 cryptography==39.0.1
 pycparser==2.21
 toml==0.10.2
+certifi


### PR DESCRIPTION
Add latest version of `certifi` to Python venv requirements to avoid `SSL: CERTIFICATE_VERIFY_FAILED` while fetching older FDB binaries.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
