### PR TITLE
fixing txn flags in new bw rk function

### DIFF
--- a/fdbserver/Ratekeeper.actor.cpp
+++ b/fdbserver/Ratekeeper.actor.cpp
@@ -251,6 +251,9 @@ public:
 		state Transaction tr(db);
 		loop {
 			try {
+				tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
+				tr.setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
+				tr.setOption(FDBTransactionOptions::LOCK_AWARE);
 				// FIXME: check if any active ranges. This still returns true if there are inactive ranges, but it
 				// mostly serves its purpose to allow setting blob_granules_enabled=1 on a cluster that has no blob
 				// workers currently.


### PR DESCRIPTION
If ratekeeper started throttling, this new transaction I added in #9425 didn't have the right flags. This would cause RK to get stuck computing the new blob worker transaction rate whenever RK was throttling based on blob workers being behind. This would basically deadlock until a cluster recovery happened and a new RK started.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
