### PR TITLE
handling multiple in-flight rollbacks for tss change feed stream comparison

### DIFF
--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -9464,7 +9464,6 @@ struct ChangeFeedTSSValidationData {
 				}
 				rollbacks.push_back({ rollbackVersion, m.version });
 			}
-
 			return true;
 		} else {
 			return false;
@@ -9476,7 +9475,18 @@ struct ChangeFeedTSSValidationData {
 	}
 
 	bool isRolledBack(Version v) {
-		return !rollbacks.empty() && rollbacks.front().first < v && rollbacks.front().second > v;
+		if (rollbacks.empty()) {
+			return false;
+		}
+		for (int i = 0; i < rollbacks.size(); i++) {
+			if (v <= rollbacks[i].first) {
+				return false;
+			}
+			if (v < rollbacks[i].second) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	void send(const ChangeFeedStreamReply& ssReply) {


### PR DESCRIPTION
Handling case where ss or tss is multiple rollbacks ahead of its pair (infrequent).

Passes 50k BlobGranule* correctness

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
