### PR TITLE
fixing healthy zone issue with restarting tests

### DIFF
--- a/fdbrpc/include/fdbrpc/simulator.h
+++ b/fdbrpc/include/fdbrpc/simulator.h
@@ -328,6 +328,7 @@ public:
 	double connectionFailureEnableTime; // Last time connection failure is enabled.
 	BackupAgentType backupAgents;
 	BackupAgentType drAgents;
+	bool willRestart = false;
 	bool restarted = false;
 	ValidationData validationData;
 

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -2585,6 +2585,7 @@ void setupSimulatedSystem(std::vector<Future<Void>>* systemActors,
 	g_simulator->connectionString = conn.toString();
 	g_simulator->testerCount = testerCount;
 	g_simulator->allowStorageMigrationTypeChange = gradualMigrationPossible;
+	g_simulator->willRestart = testConfig.isFirstTestInRestart;
 
 	TraceEvent("SimulatedClusterStarted")
 	    .detail("DataCenters", dataCenters)

--- a/fdbserver/workloads/MachineAttrition.actor.cpp
+++ b/fdbserver/workloads/MachineAttrition.actor.cpp
@@ -410,7 +410,8 @@ struct MachineAttritionWorkload : FailureInjectionWorkload {
 						wait(success(
 						    setHealthyZone(cx, targetMachine.zoneId().get(), deterministicRandom()->random01() * 20)));
 					} else if (!g_simulator->willRestart && BUGGIFY_WITH_PROB(0.005)) {
-						// don't do this in restarting test, since test could exit before it is unset, and restarted test would never unset it
+						// don't do this in restarting test, since test could exit before it is unset, and restarted
+						// test would never unset it
 						CODE_PROBE(true, "Disable DD for all storage server failures");
 						self->ignoreSSFailures =
 						    uncancellable(ignoreSSFailuresForDuration(cx, deterministicRandom()->random01() * 5));

--- a/fdbserver/workloads/MachineAttrition.actor.cpp
+++ b/fdbserver/workloads/MachineAttrition.actor.cpp
@@ -409,7 +409,8 @@ struct MachineAttritionWorkload : FailureInjectionWorkload {
 						CODE_PROBE(true, "Marked a zone for maintenance before killing it");
 						wait(success(
 						    setHealthyZone(cx, targetMachine.zoneId().get(), deterministicRandom()->random01() * 20)));
-					} else if (BUGGIFY_WITH_PROB(0.005)) {
+					} else if (!g_simulator->willRestart && BUGGIFY_WITH_PROB(0.005)) {
+						// don't do this in restarting test, since test could exit before it is unset, and restarted test would never unset it
 						CODE_PROBE(true, "Disable DD for all storage server failures");
 						self->ignoreSSFailures =
 						    uncancellable(ignoreSSFailuresForDuration(cx, deterministicRandom()->random01() * 5));


### PR DESCRIPTION
Occasionally a restarting test would hit an issue where the first phase of the test would set the healthy zone key to ignore ss failures. If the first test was stopped before the healthy zone key could be cleared, the second test would ignore any ss failures permanently.
This would cause DD to never remove the storage servers, which would cause the quiet database check to continually reach out to these dead storage servers asking for their storage metrics, resulting in attribute_not_found and the test timing out.

Passes 10k correctness.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
