### PR TITLE
Disable failure injection in ValidateStorage test

### DIFF
--- a/fdbserver/workloads/ValidateStorage.actor.cpp
+++ b/fdbserver/workloads/ValidateStorage.actor.cpp
@@ -51,9 +51,9 @@ struct ValidateStorage : TestWorkload {
 	bool pass;
 
 	// We disable failure injection because there is an irrelevant issue:
- 	// Remote tLog is failed to rejoin to CC
- 	// Once this issue is fixed, we should be able to enable the failure injection
- 	void disableFailureInjectionWorkloads(std::set<std::string>& out) const override { out.emplace("Attrition"); }
+	// Remote tLog is failed to rejoin to CC
+	// Once this issue is fixed, we should be able to enable the failure injection
+	void disableFailureInjectionWorkloads(std::set<std::string>& out) const override { out.emplace("Attrition"); }
 
 	void validationFailed(ErrorOr<Optional<Value>> expectedValue, ErrorOr<Optional<Value>> actualValue) {
 		TraceEvent(SevError, "TestFailed")
@@ -88,9 +88,9 @@ struct ValidateStorage : TestWorkload {
 		TraceEvent("TestValueWritten");
 
 		if (g_network->isSimulated()) {
- 			// NOTE: the value will be reset after consistency check
- 			disableConnectionFailures("AuditStorage");
- 		}
+			// NOTE: the value will be reset after consistency check
+			disableConnectionFailures("AuditStorage");
+		}
 
 		wait(self->validateData(self, cx, KeyRangeRef("TestKeyA"_sr, "TestKeyF"_sr)));
 		TraceEvent("TestValueVerified");

--- a/fdbserver/workloads/ValidateStorage.actor.cpp
+++ b/fdbserver/workloads/ValidateStorage.actor.cpp
@@ -50,6 +50,11 @@ struct ValidateStorage : TestWorkload {
 	const bool enabled;
 	bool pass;
 
+	// We disable failure injection because there is an irrelevant issue:
+ 	// Remote tLog is failed to rejoin to CC
+ 	// Once this issue is fixed, we should be able to enable the failure injection
+ 	void disableFailureInjectionWorkloads(std::set<std::string>& out) const override { out.emplace("Attrition"); }
+
 	void validationFailed(ErrorOr<Optional<Value>> expectedValue, ErrorOr<Optional<Value>> actualValue) {
 		TraceEvent(SevError, "TestFailed")
 		    .detail("ExpectedValue", printValue(expectedValue))
@@ -81,6 +86,11 @@ struct ValidateStorage : TestWorkload {
 		Version _ = wait(self->populateData(self, cx, &kvs));
 
 		TraceEvent("TestValueWritten");
+
+		if (g_network->isSimulated()) {
+ 			// NOTE: the value will be reset after consistency check
+ 			disableConnectionFailures("AuditStorage");
+ 		}
 
 		wait(self->validateData(self, cx, KeyRangeRef("TestKeyA"_sr, "TestKeyF"_sr)));
 		TraceEvent("TestValueVerified");


### PR DESCRIPTION
100K ValidateStorage:
20230329-220011-zhewang-73a042385b2f8e1f           compressed=True data_size=32642311 duration=1312360 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:26:32 sanity=False started=100000 stopped=20230329-222643 submitted=20230329-220011 timeout=5400 username=zhewang

100K Correctness test with 4 irrelevant failures:
20230329-221003-zhewang-24676354dee72c79           compressed=True data_size=32613329 duration=3661856 ended=100000 fail=4 fail_fast=10 max_runs=100000 pass=99996 priority=100 remaining=0 runtime=0:47:52 sanity=False started=100000 stopped=20230329-225755 submitted=20230329-221003 timeout=5400 username=zhewang

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
