### PR TITLE
Add blob manifest and mutation log status to fdbcli

### DIFF
--- a/fdbserver/BlobManager.actor.cpp
+++ b/fdbserver/BlobManager.actor.cpp
@@ -291,7 +291,6 @@ struct BlobManagerStats {
 	Counter granulesFullyPurged;
 	Counter granulesPartiallyPurged;
 	Counter filesPurged;
-	Counter manifestSizeInBytes;
 	Future<Void> logger;
 	int64_t activeMerges;
 	int64_t blockedAssignments;
@@ -299,6 +298,8 @@ struct BlobManagerStats {
 	Version lastFlushVersion;
 	Version lastMLogTruncationVersion;
 	int64_t lastManifestSeqNo;
+	int64_t lastManifestDumpTs;
+	int64_t manifestSizeInBytes;
 
 	// Current stats maintained for a given blob worker process
 	explicit BlobManagerStats(UID id,
@@ -313,8 +314,8 @@ struct BlobManagerStats {
 	    ccBytesChecked("CCBytesChecked", cc), ccMismatches("CCMismatches", cc), ccTimeouts("CCTimeouts", cc),
 	    ccErrors("CCErrors", cc), purgesProcessed("PurgesProcessed", cc),
 	    granulesFullyPurged("GranulesFullyPurged", cc), granulesPartiallyPurged("GranulesPartiallyPurged", cc),
-	    filesPurged("FilesPurged", cc), manifestSizeInBytes("ManifestSizeInBytes", cc), activeMerges(0),
-	    blockedAssignments(0), lastFlushVersion(0), lastMLogTruncationVersion(0), lastManifestSeqNo(0) {
+	    filesPurged("FilesPurged", cc), activeMerges(0), blockedAssignments(0), lastFlushVersion(0),
+	    lastMLogTruncationVersion(0), lastManifestSeqNo(0), lastManifestDumpTs(0), manifestSizeInBytes(0) {
 		specialCounter(cc, "WorkerCount", [workers]() { return workers->size(); });
 		specialCounter(cc, "Epoch", [epoch]() { return epoch; });
 		specialCounter(cc, "ActiveMerges", [this]() { return this->activeMerges; });
@@ -324,6 +325,8 @@ struct BlobManagerStats {
 		specialCounter(cc, "LastFlushVersion", [this]() { return this->lastFlushVersion; });
 		specialCounter(cc, "LastMLogTruncationVersion", [this]() { return this->lastMLogTruncationVersion; });
 		specialCounter(cc, "LastManifestSeqNo", [this]() { return this->lastManifestSeqNo; });
+		specialCounter(cc, "LastManifestDumpTs", [this]() { return this->lastManifestDumpTs; });
+		specialCounter(cc, "ManifestSizeInBytes", [this]() { return this->manifestSizeInBytes; });
 		logger = cc.traceCounters("BlobManagerMetrics", id, interval, "BlobManagerMetrics");
 	}
 };
@@ -5562,7 +5565,7 @@ ACTOR Future<Void> backupManifest(Reference<BlobManagerData> bmData) {
 				    wait(dumpManifest(bmData->db, bmData->manifestStore, bmData->epoch, bmData->manifestDumperSeqNo));
 				bmData->stats.lastManifestSeqNo = bmData->manifestDumperSeqNo;
 				bmData->stats.manifestSizeInBytes += bytes;
-
+				bmData->stats.lastManifestDumpTs = now();
 				bmData->manifestDumperSeqNo++;
 			} else {
 				TraceEvent(SevError, "InvalidBlobManifestUrl").detail("Url", SERVER_KNOBS->BLOB_RESTORE_MANIFEST_URL);

--- a/fdbserver/BlobMigrator.actor.cpp
+++ b/fdbserver/BlobMigrator.actor.cpp
@@ -385,6 +385,12 @@ private:
 				    .detail("MinLogVersion", minLogVersion)
 				    .detail("MaxLogVersion", maxLogVersion)
 				    .detail("TargetVersion", targetVersion);
+				dprint("Granule {} version {} is out of the log range {} - {}. restore target version {}\n",
+				       granule.granuleID.toString(),
+				       granule.version,
+				       minLogVersion,
+				       maxLogVersion,
+				       targetVersion);
 				throw blob_restore_corrupted_logs();
 			}
 			// no need to apply mutation logs if granule is already on that version

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -21,6 +21,7 @@
 #include <cinttypes>
 #include "fdbclient/BlobGranuleCommon.h"
 #include "fdbserver/BlobGranuleServerCommon.actor.h"
+#include "fdbserver/BlobManagerInterface.h"
 #include "fmt/format.h"
 #include "fdbclient/BackupAgent.actor.h"
 #include "fdbclient/BlobWorkerInterface.h"
@@ -2428,23 +2429,36 @@ ACTOR static Future<JsonBuilderObject> clusterSummaryStatisticsFetcher(
 	return statusObj;
 }
 
-ACTOR static Future<JsonBuilderObject> blobWorkerStatusFetcher(
-    std::vector<BlobWorkerInterface> servers,
+ACTOR static Future<JsonBuilderObject> blobGranulesStatusFetcher(
+    Optional<BlobManagerInterface> managerIntf,
+    std::vector<BlobWorkerInterface> workers,
     std::unordered_map<NetworkAddress, WorkerInterface> addressWorkersMap,
     std::set<std::string>* incompleteReason) {
 
 	state JsonBuilderObject statusObj;
 	state std::vector<Future<Optional<TraceEventFields>>> futures;
 
-	statusObj["number_of_blob_workers"] = static_cast<int>(servers.size());
-
+	statusObj["number_of_blob_workers"] = static_cast<int>(workers.size());
 	try {
-		for (auto& intf : servers) {
+		// Blob manager status
+		if (managerIntf.present()) {
+			Optional<TraceEventFields> fields = wait(timeoutError(
+			    latestEventOnWorker(addressWorkersMap[managerIntf.get().address()], "BlobManagerMetrics"), 2.0));
+			if (fields.present()) {
+				statusObj["last_manifest_dump_ts"] = fields.get().getUint64("LastManifestDumpTs");
+				statusObj["last_manifest_seq_no"] = fields.get().getUint64("LastManifestSeqNo");
+				statusObj["last_manifest_epoch"] = fields.get().getUint64("Epoch");
+				statusObj["last_manifest_size_in_bytes"] = fields.get().getUint64("ManifestSizeInBytes");
+			}
+		}
+
+		// Blob workers status
+		for (auto& intf : workers) {
 			auto workerIntf = addressWorkersMap[intf.address()];
 			futures.push_back(latestEventOnWorker(workerIntf, "BlobWorkerMetrics"));
 		}
 
-		wait(waitForAll(futures));
+		wait(timeoutError(waitForAll(futures), 2.0));
 
 		state int totalRanges = 0;
 		for (auto future : futures) {
@@ -2467,6 +2481,18 @@ ACTOR static Future<JsonBuilderObject> blobWorkerStatusFetcher(
 			}
 		}
 		statusObj["number_of_key_ranges"] = totalRanges;
+
+		// Mutation log backup
+		state std::string mlogsUrl = wait(getMutationLogUrl());
+		statusObj["mutation_log_location"] = mlogsUrl;
+		state Reference<IBackupContainer> bc = IBackupContainer::openContainer(mlogsUrl, {}, {});
+		BackupDescription desc = wait(timeoutError(bc->describeBackup(), 2.0));
+		if (desc.contiguousLogEnd.present()) {
+			statusObj["mutation_log_end_version"] = desc.contiguousLogEnd.get();
+		}
+		if (desc.minLogBegin.present()) {
+			statusObj["mutation_log_begin_version"] = desc.minLogBegin.get();
+		}
 	} catch (Error& e) {
 		if (e.code() == error_code_actor_cancelled)
 			throw;
@@ -2476,12 +2502,11 @@ ACTOR static Future<JsonBuilderObject> blobWorkerStatusFetcher(
 }
 
 ACTOR static Future<JsonBuilderObject> blobRestoreStatusFetcher(Database db, std::set<std::string>* incompleteReason) {
-
 	state JsonBuilderObject statusObj;
-
 	try {
 		Reference<BlobRestoreController> restoreController = makeReference<BlobRestoreController>(db, normalKeys);
-		Optional<BlobRestoreState> restoreState = wait(BlobRestoreController::getState(restoreController));
+		Optional<BlobRestoreState> restoreState =
+		    wait(timeoutError(BlobRestoreController::getState(restoreController), 1.0));
 		if (restoreState.present()) {
 			statusObj["blob_full_restore_phase"] = restoreState.get().phase;
 			statusObj["blob_full_restore_phase_progress"] = restoreState.get().progress;
@@ -2490,6 +2515,7 @@ ACTOR static Future<JsonBuilderObject> blobRestoreStatusFetcher(Database db, std
 			Optional<StringRef> error = restoreState.get().error;
 			statusObj["blob_full_restore_error"] = error.present() ? error.get() : ""_sr;
 		}
+
 	} catch (Error& e) {
 		if (e.code() == error_code_actor_cancelled)
 			throw;
@@ -3166,6 +3192,7 @@ ACTOR Future<StatusReply> clusterGetStatus(
 		state std::vector<std::pair<CommitProxyInterface, EventMap>> commitProxies;
 		state std::vector<std::pair<GrvProxyInterface, EventMap>> grvProxies;
 		state std::vector<BlobWorkerInterface> blobWorkers;
+
 		state JsonBuilderObject qos;
 		state JsonBuilderObject dataOverlay;
 		state JsonBuilderObject tenants;
@@ -3479,9 +3506,12 @@ ACTOR Future<StatusReply> clusterGetStatus(
 
 		if (configuration.present() && configuration.get().blobGranulesEnabled) {
 			JsonBuilderObject blobGranuelsStatus =
-			    wait(blobWorkerStatusFetcher(blobWorkers, address_workers, &status_incomplete_reasons));
+			    wait(timeoutError(blobGranulesStatusFetcher(
+			                          db->get().blobManager, blobWorkers, address_workers, &status_incomplete_reasons),
+			                      2.0));
 			statusObj["blob_granules"] = blobGranuelsStatus;
-			JsonBuilderObject blobRestoreStatus = wait(blobRestoreStatusFetcher(cx, &status_incomplete_reasons));
+			JsonBuilderObject blobRestoreStatus =
+			    wait(timeoutError(blobRestoreStatusFetcher(cx, &status_incomplete_reasons), 2.0));
 			statusObj["blob_restore"] = blobRestoreStatus;
 		}
 


### PR DESCRIPTION
Fdbcli changes. New fields are added to reflect manifest and mutation log status.  some example output:

```
Blob Granules:
  Number of Workers      - 2
  Number of Key Ranges   - 12
  Last Manifest          - 1.3 dumped at 16:17. Total 41248 bytes.
  Restorable log version     - 13600359120 - 13680359120
```

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
