### PR TITLE
Remove an assertion for UB

### DIFF
--- a/flow/Arena.cpp
+++ b/flow/Arena.cpp
@@ -1027,7 +1027,7 @@ TEST_CASE("/flow/Arena/Secure") {
 				} else {
 					newBuf = new (arena) uint8_t[len];
 				}
-				ASSERT(newBuf == buf);
+				// ASSERT(newBuf == buf);
 				// there's no hard guarantee about the above equality and the result could vary by platform,
 				// malloc implementation, and tooling instrumentation (e.g. ASAN, valgrind)
 				// but it is practically likely because of
@@ -1038,6 +1038,7 @@ TEST_CASE("/flow/Arena/Secure") {
 				// in the same vein, it is speculative but likely that if buf == newBuf,
 				// the memory backing the address is the same and remained untouched,
 				// because FDB servers are single-threaded
+				// Since there is no hard guarantee, it is an UB which should not be asserted.
 				samePtrCount++;
 				for (auto i = 0; i < len; i++) {
 					if (newBuf[i] != 0) {


### PR DESCRIPTION
Original code comment says
"there's no hard guarantee about the above equality and the result could vary by platform, malloc implementation, and tooling instrumentation (e.g. ASAN, valgrind)"

Therefore, we should remove the assertion on UB.

Furthermore, we have a case in which, even without ASAN or other instrumentation, e.g. Valgrind, etc, the equality does not hold.

Profile: team
Commit hash: 3164cadc6f7bf6ed00e8d22ce8dcd51820a152a7
Command: devRetryCorrectnessTest bin/fdbserver -r simulation -f tests/fast/RandomUnitTests.toml -s 3939330597 -b on  --crash --trace_format json

Replace this text with your description here...

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
