### PR TITLE
Fix ctest errors after 7.2.5 release

### DIFF
--- a/tests/TestRunner/binary_download.py
+++ b/tests/TestRunner/binary_download.py
@@ -10,7 +10,7 @@ import hashlib
 
 from local_cluster import random_secret_string
 
-CURRENT_VERSION = "7.2.4"
+CURRENT_VERSION = "7.2.6"
 FUTURE_VERSION = "7.3.0"
 
 SUPPORTED_PLATFORMS = ["x86_64", "aarch64"]


### PR DESCRIPTION
By setting the latest version to 7.2.6



# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
