### PR TITLE
checkSafeExclusion should always create new ExclusionSafetyCheckRequest

### DIFF
--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -9169,7 +9169,6 @@ ACTOR Future<bool> checkSafeExclusions(Database cx, std::vector<AddressExclusion
 	TraceEvent("ExclusionSafetyCheckBegin")
 	    .detail("NumExclusion", exclusions.size())
 	    .detail("Exclusions", describe(exclusions));
-	state ExclusionSafetyCheckRequest req(exclusions);
 	state bool ddCheck;
 	try {
 		loop {
@@ -9178,7 +9177,7 @@ ACTOR Future<bool> checkSafeExclusions(Database cx, std::vector<AddressExclusion
 				when(ExclusionSafetyCheckReply _ddCheck =
 				         wait(basicLoadBalance(cx->getCommitProxies(UseProvisionalProxies::False),
 				                               &CommitProxyInterface::exclusionSafetyCheckReq,
-				                               req,
+				                               ExclusionSafetyCheckRequest(exclusions),
 				                               cx->taskID))) {
 					ddCheck = _ddCheck.safe;
 					break;


### PR DESCRIPTION
We recently added a test to test `exclude failed` command which exposed this bug in the existing code.

When a client is issuing an ExclusionSafetyCheckRequest to check safe exclusion, if during this time, there is a proxy change, this will cancel the current basicLoadBalance() function along with the future created for the ExclusionSafetyCheckReply. However, when we re-issue the ExclusionSafetyCheckRequest again, we will use the same req object, whose reply future has already being cancelled. This causes the request to throw broken promise immediately, and then the host will mistakenly think the remote endpoint is failed.

This leads to the ExclusionSafetyCheckRequest to be blocked forever.

The fix is to re-create the ExclusionSafetyCheckRequest every time when issuing a new ExclusionSafetyCheckRequest.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
