### PR TITLE
Check if the locality is already excluded before issuing exclude locality transaction

### DIFF
--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -2766,7 +2766,7 @@ ACTOR Future<Optional<std::string>> excludeLocalityCommitActor(ReadYourWritesTra
 			return result;
 	}
 
-	excludeLocalities(ryw->getTransaction(), localities, failed);
+	wait(excludeLocalities(&ryw->getTransaction(), localities, failed));
 	includeLocalities(ryw);
 
 	return result;

--- a/fdbclient/include/fdbclient/ManagementAPI.actor.h
+++ b/fdbclient/include/fdbclient/ManagementAPI.actor.h
@@ -72,7 +72,7 @@ ACTOR Future<Void> excludeServers(Transaction* tr, std::vector<AddressExclusion>
 // Exclude the servers matching the given set of localities from use as state servers.  Returns as soon as the change
 // is durable, without necessarily waiting for the servers to be evacuated.
 ACTOR Future<Void> excludeLocalities(Database cx, std::unordered_set<std::string> localities, bool failed = false);
-void excludeLocalities(Transaction& tr, std::unordered_set<std::string> localities, bool failed = false);
+ACTOR Future<Void> excludeLocalities(Transaction* tr, std::unordered_set<std::string> localities, bool failed = false);
 
 // Remove the given servers from the exclusion list.  A NetworkAddress with a port of 0 means all servers on the given
 // IP.  A NetworkAddress() means all servers (don't exclude anything)
@@ -99,8 +99,14 @@ ACTOR Future<std::vector<AddressExclusion>> getExcludedServerList(Transaction* t
 ACTOR Future<std::vector<AddressExclusion>> getExcludedFailedServerList(Transaction* tr);
 
 // Get the current list of excluded localities
-ACTOR Future<std::vector<std::string>> getExcludedLocalities(Database cx);
-ACTOR Future<std::vector<std::string>> getExcludedLocalities(Transaction* tr);
+ACTOR Future<std::vector<std::string>> getAllExcludedLocalities(Database cx);
+ACTOR Future<std::vector<std::string>> getAllExcludedLocalities(Transaction* tr);
+
+// Get the current list of excluded localities.
+ACTOR Future<std::vector<std::string>> getExcludedLocalityList(Transaction* tr);
+
+// Get the current list of failed localities.
+ACTOR Future<std::vector<std::string>> getExcludedFailedLocalityList(Transaction* tr);
 
 std::set<AddressExclusion> getAddressesByLocality(const std::vector<ProcessData>& workers, const std::string& locality);
 

--- a/fdbserver/workloads/SpecialKeySpaceRobustness.actor.cpp
+++ b/fdbserver/workloads/SpecialKeySpaceRobustness.actor.cpp
@@ -136,6 +136,8 @@ struct SpecialKeySpaceRobustnessWorkload : TestWorkload {
 				state std::string failedCommand;
 				state KeyRef excludeVersionKey;
 				state KeyRef failedVersionKey;
+
+				// Test exclude servers and exclude localities randomly.
 				if (deterministicRandom()->coinflip()) {
 					excludeWorker = "123.4.56.7:9876"; // Use a random address to not impact the cluster.
 					excludeCommand = "exclude";

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,7 +8,7 @@ set(TEST_KEEP_LOGS "FAILED" CACHE STRING "Which logs to keep (NONE, FAILED, ALL)
 set(TEST_KEEP_SIMDIR "NONE" CACHE STRING "Which simfdb directories to keep (NONE, FAILED, ALL)")
 set(TEST_AGGREGATE_TRACES "NONE" CACHE STRING "Create aggregated trace files (NONE, FAILED, ALL)")
 set(TEST_LOG_FORMAT "xml" CACHE STRING "Format for test trace files (xml, json)")
-set(TEST_INCLUDE ".*SpecialKeySpaceRobustness.*" CACHE STRING "Include only tests that match the given regex")
+set(TEST_INCLUDE ".*" CACHE STRING "Include only tests that match the given regex")
 set(TEST_EXCLUDE ".^" CACHE STRING "Exclude all tests matching the given regex")
 set(SANITIZER_OPTIONS "UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1;TSAN_OPTIONS=suppressions=${CMAKE_SOURCE_DIR}/contrib/tsan.suppressions;LSAN_OPTIONS=suppressions=${CMAKE_SOURCE_DIR}/contrib/lsan.suppressions" CACHE STRING "Environment variables setting sanitizer options")
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,7 +8,7 @@ set(TEST_KEEP_LOGS "FAILED" CACHE STRING "Which logs to keep (NONE, FAILED, ALL)
 set(TEST_KEEP_SIMDIR "NONE" CACHE STRING "Which simfdb directories to keep (NONE, FAILED, ALL)")
 set(TEST_AGGREGATE_TRACES "NONE" CACHE STRING "Create aggregated trace files (NONE, FAILED, ALL)")
 set(TEST_LOG_FORMAT "xml" CACHE STRING "Format for test trace files (xml, json)")
-set(TEST_INCLUDE ".*" CACHE STRING "Include only tests that match the given regex")
+set(TEST_INCLUDE ".*SpecialKeySpaceRobustness.*" CACHE STRING "Include only tests that match the given regex")
 set(TEST_EXCLUDE ".^" CACHE STRING "Exclude all tests matching the given regex")
 set(SANITIZER_OPTIONS "UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1;TSAN_OPTIONS=suppressions=${CMAKE_SOURCE_DIR}/contrib/tsan.suppressions;LSAN_OPTIONS=suppressions=${CMAKE_SOURCE_DIR}/contrib/lsan.suppressions" CACHE STRING "Environment variables setting sanitizer options")
 


### PR DESCRIPTION
Similar to #9803 , we also don't want to update system metadata if exclude locality has already exist in the system metadata.

100K SpecialKeySpaceRobustness:

20230402-022130-zhewu_robustness_single-04a4fba40ca9d7d0 compressed=True data_size=32541672 duration=1720033 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:38:09 sanity=False started=100000 stopped=20230402-025939 submitted=20230402-022130 timeout=5400 username=zhewu_robustness_single

100K random simulation test:

20230402-023555-zhewu_exclude_locality_all-380d791038bcc78f compressed=True data_size=47768723 duration=5009879 ended=100000 fail=2 fail_fast=10 max_runs=100000 pass=99998 priority=100 remaining=0 runtime=0:49:57 sanity=False started=100000 stopped=20230402-032552 submitted=20230402-023555 timeout=5400 username=zhewu_exclude_locality_all

The two failures are unrelated to this PR.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
