### PR TITLE
Remove an assertion for UB (Cherry-Pick #9865 to snowflake/release-71.3)

### DIFF
--- a/flow/Arena.cpp
+++ b/flow/Arena.cpp
@@ -996,6 +996,10 @@ TEST_CASE("/flow/Arena/OptionalMap") {
 	return Void();
 }
 
+// TODO: remove the following `#if 0 ... #endif` once we come up with a way of reliably, temporarily swapping
+// Arena alloc/free implementation for the duration of a test run.
+// See https://github.com/apple/foundationdb/pull/9865/files#r1155735635.
+#if 0
 TEST_CASE("/flow/Arena/Secure") {
 #if !defined(USE_SANITIZER) && !defined(VALGRIND)
 	// Note: Assumptions underlying this unit test are speculative.
@@ -1053,3 +1057,4 @@ TEST_CASE("/flow/Arena/Secure") {
 #endif // !defined(USE_SANITIZER) && !defined(VALGRIND)
 	return Void();
 }
+#endif // 0


### PR DESCRIPTION
Cherry-Pick of #9865

Original Description:

Original code comment says
"there's no hard guarantee about the above equality and the result could vary by platform, malloc implementation, and tooling instrumentation (e.g. ASAN, valgrind)"

Therefore, we should remove the assertion on UB.

Furthermore, we have a case in which, even without ASAN or other instrumentation, e.g. Valgrind, etc, the equality does not hold.

Profile: team
Commit hash: 3164cadc6f7bf6ed00e8d22ce8dcd51820a152a7
Command: devRetryCorrectnessTest bin/fdbserver -r simulation -f tests/fast/RandomUnitTests.toml -s 3939330597 -b on  --crash --trace_format json

Replace this text with your description here...

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
