### PR TITLE
EaR: Fix heap-over-flow in BlobCipherTest (#9877)

### DIFF
--- a/fdbclient/BlobCipher.cpp
+++ b/fdbclient/BlobCipher.cpp
@@ -1674,7 +1674,8 @@ void testKeyCacheEssentials(DomainKeyMap& domainKeyMap,
 			// ensure that baseCipher matches with the cached information
 			ASSERT_EQ(std::memcmp(cipherKey->rawBaseCipher(), baseCipher->key.get(), cipherKey->getBaseCipherLen()), 0);
 			// validate the encryption derivation
-			ASSERT_NE(std::memcmp(cipherKey->rawCipher(), baseCipher->key.get(), cipherKey->getBaseCipherLen()), 0);
+			const int len = std::min(AES_256_KEY_LENGTH, cipherKey->getBaseCipherLen());
+			ASSERT_NE(std::memcmp(cipherKey->rawCipher(), baseCipher->key.get(), len), 0);
 		}
 	}
 	TraceEvent("BlobCipherTestLooksupDone").log();


### PR DESCRIPTION
Description

Heap overflow was due to recent upgrade in BlobCipherTest to use variable size 'baseCipher' buffer.

Testing

BlobCipherUnit test

(cherry picked from commit 769226e5c0f97ece66150fa6bb9efa267d8b6c7d)
(https://github.com/apple/foundationdb/pull/9877)

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
