### PR TITLE
Remove printable() from TSS trace events

### DIFF
--- a/fdbclient/StorageServerInterface.cpp
+++ b/fdbclient/StorageServerInterface.cpp
@@ -48,7 +48,7 @@ void TSS_traceMismatch(TraceEvent& event,
                        const GetValueRequest& req,
                        const GetValueReply& src,
                        const GetValueReply& tss) {
-	event.detail("Key", req.key.printable())
+	event.detail("Key", req.key)
 	    .detail("Tenant", req.tenantInfo.tenantId)
 	    .detail("Version", req.version)
 	    .detail("SSReply", src.value.present() ? traceChecksumValue(src.value.get()) : "missing")
@@ -167,10 +167,10 @@ static void traceKeyValuesDiff(TraceEvent& event,
 		if (i >= ssKV.size() || i >= tssKV.size() || ssKV[i] != tssKV[i]) {
 			event.detail("MismatchIndex", i);
 			if (i >= ssKV.size() || i >= tssKV.size() || ssKV[i].key != tssKV[i].key) {
-				event.detail("MismatchSSKey", i < ssKV.size() ? ssKV[i].key.printable() : "missing");
-				event.detail("MismatchTSSKey", i < tssKV.size() ? tssKV[i].key.printable() : "missing");
+				event.detail("MismatchSSKey", i < ssKV.size() ? ssKV[i].key : "missing"_sr);
+				event.detail("MismatchTSSKey", i < tssKV.size() ? tssKV[i].key : "missing"_sr);
 			} else {
-				event.detail("MismatchKey", ssKV[i].key.printable());
+				event.detail("MismatchKey", ssKV[i].key);
 				event.detail("MismatchSSValue", traceChecksumValue(ssKV[i].value));
 				event.detail("MismatchTSSValue", traceChecksumValue(tssKV[i].value));
 			}


### PR DESCRIPTION
To avoid having traces like `"MismatchSSKey"="\\\\x15(\\\\x19\\\\x02\\\\xa2...`

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
