### PR TITLE
[Relase 7.2] Don't block the exclusion of stateless processes by the free capacity check

### DIFF
--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -1028,13 +1028,9 @@ ACTOR Future<bool> checkExclusion(Database db,
 					// Check if we are excluding a process that serves the storage role. If this check was true once, we don't have to check any further
 					// since we don't case in this variable about the count of excluded storage servers but only about if we exclude any storage server with the
 					// provided addresses.
-					if (!excludedAddressesContainsStorageRole) {
-						for (auto exclusion : addresses) {
-							if (exclusion.excludes(addr)) {
-								excludedAddressesContainsStorageRole = true;
-								break;
-							}
-						}
+					if (!excludedAddressesContainsStorageRole && excluded) {
+						excludedAddressesContainsStorageRole = true;
+						break;
 					}
 
 					int64_t used_bytes;

--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -1025,9 +1025,9 @@ ACTOR Future<bool> checkExclusion(Database db,
 				if (role["role"].get_str() == "storage") {
 					ssTotalCount++;
 
-					// Check if we are excluding a process that serves the storage role. If this check was true once, we don't have to check any further
-					// since we don't case in this variable about the count of excluded storage servers but only about if we exclude any storage server with the
-					// provided addresses.
+					// Check if we are excluding a process that serves the storage role. If this check was true once, we
+					// don't have to check any further since we don't case in this variable about the count of excluded
+					// storage servers but only about if we exclude any storage server with the provided addresses.
 					if (!excludedAddressesContainsStorageRole && excluded) {
 						excludedAddressesContainsStorageRole = true;
 						break;
@@ -1072,8 +1072,8 @@ ACTOR Future<bool> checkExclusion(Database db,
 		return false;
 	}
 
-	// If the exclusion command only contains processes that serve a non storage role we can skip the free capacity check in order to not
-	// block those exclusions.
+	// If the exclusion command only contains processes that serve a non storage role we can skip the free capacity
+	// check in order to not block those exclusions.
 	if (!excludedAddressesContainsStorageRole) {
 		return true;
 	}

--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -1011,8 +1011,9 @@ ACTOR Future<bool> checkExclusion(Database db,
 				return false;
 			}
 			NetworkAddress addr = NetworkAddress::parse(addrStr);
+			bool includedInExclusion =  addressExcluded(*exclusions, addr);
 			bool excluded =
-			    (process.has("excluded") && process.last().get_bool()) || addressExcluded(*exclusions, addr);
+			    (process.has("excluded") && process.last().get_bool()) || includedInExclusion;
 
 			StatusObjectReader localityObj;
 			std::string disk_id;
@@ -1028,7 +1029,7 @@ ACTOR Future<bool> checkExclusion(Database db,
 					// Check if we are excluding a process that serves the storage role. If this check was true once, we
 					// don't have to check any further since we don't case in this variable about the count of excluded
 					// storage servers but only about if we exclude any storage server with the provided addresses.
-					if (!excludedAddressesContainsStorageRole && excluded) {
+					if (!excludedAddressesContainsStorageRole && includedInExclusion) {
 						excludedAddressesContainsStorageRole = true;
 						break;
 					}

--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -1029,7 +1029,6 @@ ACTOR Future<bool> checkExclusion(Database db,
 					// capacity if we are excluding at least one process that serves the storage role.
 					if (!excludedAddressesContainsStorageRole && includedInExclusion) {
 						excludedAddressesContainsStorageRole = true;
-						break;
 					}
 
 					int64_t used_bytes;

--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -1011,9 +1011,8 @@ ACTOR Future<bool> checkExclusion(Database db,
 				return false;
 			}
 			NetworkAddress addr = NetworkAddress::parse(addrStr);
-			bool includedInExclusion =  addressExcluded(*exclusions, addr);
-			bool excluded =
-			    (process.has("excluded") && process.last().get_bool()) || includedInExclusion;
+			bool includedInExclusion = addressExcluded(*exclusions, addr);
+			bool excluded = (process.has("excluded") && process.last().get_bool()) || includedInExclusion;
 
 			StatusObjectReader localityObj;
 			std::string disk_id;
@@ -1026,9 +1025,8 @@ ACTOR Future<bool> checkExclusion(Database db,
 				if (role["role"].get_str() == "storage") {
 					ssTotalCount++;
 
-					// Check if we are excluding a process that serves the storage role. If this check was true once, we
-					// don't have to check any further since we don't case in this variable about the count of excluded
-					// storage servers but only about if we exclude any storage server with the provided addresses.
+					// Check if we are excluding a process that serves the storage role. We only have to check the free
+					// capacity if we are excluding at least one process that serves the storage role.
 					if (!excludedAddressesContainsStorageRole && includedInExclusion) {
 						excludedAddressesContainsStorageRole = true;
 						break;

--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -1028,7 +1028,7 @@ ACTOR Future<bool> checkExclusion(Database db,
 					// Check if we are excluding a process that serves the storage role. If this check was true once, we don't have to check any further
 					// since we don't case in this variable about the count of excluded storage servers but only about if we exclude any storage server with the
 					// provided addresses.
-					if !excludedAddressesContainsStorageRole {
+					if (!excludedAddressesContainsStorageRole) {
 						for (auto exclusion : addresses) {
 							if (exclusion.excludes(addr)) {
 								excludedAddressesContainsStorageRole = true;
@@ -1078,7 +1078,7 @@ ACTOR Future<bool> checkExclusion(Database db,
 
 	// If the exclusion command only contains processes that serve a non storage role we can skip the free capacity check in order to not
 	// block those exclusions.
-	if ! excludedAddressesContainsStorageRole {
+	if (!excludedAddressesContainsStorageRole) {
 		return true;
 	}
 


### PR DESCRIPTION
This PR back ports changes from https://github.com/apple/foundationdb/pull/9468 + https://github.com/apple/foundationdb/pull/9846 to the 7.2 release (we already did this for the 7.1 release.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [x] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [x] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
