### PR TITLE
Avoid a thread race trying to initialize the chained signal handler

### DIFF
--- a/flow/Platform.actor.cpp
+++ b/flow/Platform.actor.cpp
@@ -3801,7 +3801,7 @@ int64_t getNumProfilesCaptured() {
 void profileHandler(int sig) {
 #ifdef __linux__
 	if (chainedAction.sa_handler != SIG_DFL && chainedAction.sa_handler != SIG_IGN &&
-	    chainedAction.sa_handler != NULL) {
+	    chainedAction.sa_handler != nullptr) {
 		chainedAction.sa_handler(sig);
 	}
 
@@ -3997,6 +3997,8 @@ std::string getExecPath() {
 void setupRunLoopProfiler() {
 #ifdef __linux__
 	if (profileThreadId == -1 && FLOW_KNOBS->RUN_LOOP_PROFILING_INTERVAL > 0) {
+		chainedAction.sa_handler = SIG_DFL;
+
 		TraceEvent("StartingRunLoopProfilingThread").detail("Interval", FLOW_KNOBS->RUN_LOOP_PROFILING_INTERVAL);
 
 		profileThread = true;

--- a/flow/Platform.actor.cpp
+++ b/flow/Platform.actor.cpp
@@ -3766,7 +3766,7 @@ thread_local bool profileThread = false;
 // to see if we are on the profiled thread. Can be used in the signal handler.
 volatile int64_t profileThreadId = -1;
 
-void (*chainedSignalHandler)(int) = nullptr;
+struct sigaction chainedAction;
 volatile bool profilingEnabled = 1;
 volatile thread_local bool flowProfilingEnabled = 1;
 
@@ -3800,8 +3800,9 @@ int64_t getNumProfilesCaptured() {
 
 void profileHandler(int sig) {
 #ifdef __linux__
-	if (chainedSignalHandler) {
-		chainedSignalHandler(sig);
+	if (chainedAction.sa_handler != SIG_DFL && chainedAction.sa_handler != SIG_IGN &&
+	    chainedAction.sa_handler != NULL) {
+		chainedAction.sa_handler(sig);
 	}
 
 	// This is not documented in the POSIX list of signal-safe functions, but numbered syscalls are reported to be
@@ -4009,22 +4010,15 @@ void setupRunLoopProfiler() {
 
 		initProfiling();
 
-		struct sigaction oldAction;
 		struct sigaction action;
 		action.sa_handler = profileHandler;
 		sigfillset(&action.sa_mask);
 		action.sa_flags = 0;
-		if (sigaction(SIGPROF, &action, &oldAction)) {
+		if (sigaction(SIGPROF, &action, &chainedAction)) {
 			TraceEvent(SevWarnAlways, "RunLoopProfilingSetupFailed")
 			    .detail("Reason", "Error configuring signal handler")
 			    .GetLastError();
 			return;
-		}
-
-		if (oldAction.sa_handler != SIG_DFL && oldAction.sa_handler != SIG_IGN && oldAction.sa_handler != NULL) {
-			chainedSignalHandler = oldAction.sa_handler;
-		} else {
-			chainedSignalHandler = nullptr;
 		}
 
 		// Start a thread which will use signals to log stacks on long events


### PR DESCRIPTION
The signal handler for the run loop profiler accesses a variable called `chainedSignalHandler` that is configured after the signal handler is set. This introduces a brief period where there could be a race between getting the signal and accessing `chainedSignalHandler` and the variable being set.

Instead, this change updates the logic so that we use the `struct sigaction` returned from the `sigaction` call directly and avoid modifying it after setting the signal handler.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
