### PR TITLE
Update the tenant group index to include the tenant name

### DIFF
--- a/fdbclient/include/fdbclient/TenantData.actor.h
+++ b/fdbclient/include/fdbclient/TenantData.actor.h
@@ -110,11 +110,14 @@ private:
 
 		self->tenantGroupIndex.clear();
 		for (auto t : tenantGroupTenantTuples.results) {
-			ASSERT_EQ(t.size(), 2);
+			ASSERT_EQ(t.size(), 3);
 			TenantGroupName tenantGroupName = t.getString(0);
-			int64_t tenantId = t.getInt(1);
+			TenantName tenantName = t.getString(1);
+			int64_t tenantId = t.getInt(2);
 			ASSERT(self->tenantGroupMap.count(tenantGroupName));
-			ASSERT(self->tenantMap.count(tenantId));
+			auto tenantItr = self->tenantMap.find(tenantId);
+			ASSERT(tenantItr != self->tenantMap.end());
+			ASSERT_EQ(tenantItr->second.tenantName, tenantName);
 			self->tenantGroupIndex[tenantGroupName].insert(tenantId);
 		}
 		ASSERT_EQ(self->tenantGroupIndex.size(), self->tenantGroupMap.size());

--- a/fdbclient/include/fdbclient/TenantManagement.actor.h
+++ b/fdbclient/include/fdbclient/TenantManagement.actor.h
@@ -199,7 +199,7 @@ createTenantTransaction(Transaction tr, TenantMapEntry tenantEntry, ClusterType 
 
 	if (tenantEntry.tenantGroup.present()) {
 		TenantMetadata::tenantGroupTenantIndex().insert(
-		    tr, Tuple::makeTuple(tenantEntry.tenantGroup.get(), tenantEntry.id));
+		    tr, Tuple::makeTuple(tenantEntry.tenantGroup.get(), tenantEntry.tenantName, tenantEntry.id));
 
 		// Create the tenant group associated with this tenant if it doesn't already exist
 		Optional<TenantGroupEntry> existingTenantGroup = wait(existingTenantGroupEntryFuture);
@@ -377,7 +377,7 @@ Future<Void> deleteTenantTransaction(Transaction tr,
 
 		if (tenantEntry.get().tenantGroup.present()) {
 			TenantMetadata::tenantGroupTenantIndex().erase(
-			    tr, Tuple::makeTuple(tenantEntry.get().tenantGroup.get(), tenantId));
+			    tr, Tuple::makeTuple(tenantEntry.get().tenantGroup.get(), tenantEntry.get().tenantName, tenantId));
 			KeyBackedSet<Tuple>::RangeResultType tenantsInGroup =
 			    wait(TenantMetadata::tenantGroupTenantIndex().getRange(
 			        tr,
@@ -385,7 +385,7 @@ Future<Void> deleteTenantTransaction(Transaction tr,
 			        Tuple::makeTuple(keyAfter(tenantEntry.get().tenantGroup.get())),
 			        2));
 			if (tenantsInGroup.results.empty() ||
-			    (tenantsInGroup.results.size() == 1 && tenantsInGroup.results[0].getInt(1) == tenantId)) {
+			    (tenantsInGroup.results.size() == 1 && tenantsInGroup.results[0].getInt(2) == tenantId)) {
 				TenantMetadata::tenantGroupMap().erase(tr, tenantEntry.get().tenantGroup.get());
 			}
 		}
@@ -457,8 +457,10 @@ Future<Void> configureTenantTransaction(Transaction tr,
 		}
 		if (originalEntry.tenantGroup.present()) {
 			// Remove this tenant from the original tenant group index
-			TenantMetadata::tenantGroupTenantIndex().erase(
-			    tr, Tuple::makeTuple(originalEntry.tenantGroup.get(), updatedTenantEntry.id));
+			TenantMetadata::tenantGroupTenantIndex().erase(tr,
+			                                               Tuple::makeTuple(originalEntry.tenantGroup.get(),
+			                                                                updatedTenantEntry.tenantName,
+			                                                                updatedTenantEntry.id));
 
 			// Check if the original tenant group is now empty. If so, remove the tenant group.
 			KeyBackedSet<Tuple>::RangeResultType tenants = wait(TenantMetadata::tenantGroupTenantIndex().getRange(
@@ -468,7 +470,7 @@ Future<Void> configureTenantTransaction(Transaction tr,
 			    2));
 
 			if (tenants.results.empty() ||
-			    (tenants.results.size() == 1 && tenants.results[0].getInt(1) == updatedTenantEntry.id)) {
+			    (tenants.results.size() == 1 && tenants.results[0].getInt(2) == updatedTenantEntry.id)) {
 				TenantMetadata::tenantGroupMap().erase(tr, originalEntry.tenantGroup.get());
 			}
 		}
@@ -481,8 +483,10 @@ Future<Void> configureTenantTransaction(Transaction tr,
 			}
 
 			// Insert this tenant in the tenant group index
-			TenantMetadata::tenantGroupTenantIndex().insert(
-			    tr, Tuple::makeTuple(updatedTenantEntry.tenantGroup.get(), updatedTenantEntry.id));
+			TenantMetadata::tenantGroupTenantIndex().insert(tr,
+			                                                Tuple::makeTuple(updatedTenantEntry.tenantGroup.get(),
+			                                                                 updatedTenantEntry.tenantName,
+			                                                                 updatedTenantEntry.id));
 		}
 	}
 
@@ -625,6 +629,14 @@ Future<Void> renameTenantTransaction(Transaction tr,
 	TenantMetadata::tenantMap().set(tr, tenantId.get(), entry);
 	TenantMetadata::tenantNameIndex().set(tr, newName, tenantId.get());
 	TenantMetadata::tenantNameIndex().erase(tr, oldName);
+
+	if (entry.tenantGroup.present()) {
+		TenantMetadata::tenantGroupTenantIndex().erase(
+		    tr, Tuple::makeTuple(entry.tenantGroup.get(), oldName, tenantId.get()));
+		TenantMetadata::tenantGroupTenantIndex().insert(
+		    tr, Tuple::makeTuple(entry.tenantGroup.get(), newName, tenantId.get()));
+	}
+
 	TenantMetadata::lastTenantModification().setVersionstamp(tr, Versionstamp(), 0);
 
 	if (clusterType == ClusterType::METACLUSTER_DATA) {

--- a/fdbclient/include/fdbclient/TenantManagement.actor.h
+++ b/fdbclient/include/fdbclient/TenantManagement.actor.h
@@ -457,10 +457,8 @@ Future<Void> configureTenantTransaction(Transaction tr,
 		}
 		if (originalEntry.tenantGroup.present()) {
 			// Remove this tenant from the original tenant group index
-			TenantMetadata::tenantGroupTenantIndex().erase(tr,
-			                                               Tuple::makeTuple(originalEntry.tenantGroup.get(),
-			                                                                originalEntry.tenantName,
-			                                                                updatedTenantEntry.id));
+			TenantMetadata::tenantGroupTenantIndex().erase(
+			    tr, Tuple::makeTuple(originalEntry.tenantGroup.get(), originalEntry.tenantName, updatedTenantEntry.id));
 
 			// Check if the original tenant group is now empty. If so, remove the tenant group.
 			KeyBackedSet<Tuple>::RangeResultType tenants = wait(TenantMetadata::tenantGroupTenantIndex().getRange(

--- a/fdbclient/include/fdbclient/TenantManagement.actor.h
+++ b/fdbclient/include/fdbclient/TenantManagement.actor.h
@@ -459,7 +459,7 @@ Future<Void> configureTenantTransaction(Transaction tr,
 			// Remove this tenant from the original tenant group index
 			TenantMetadata::tenantGroupTenantIndex().erase(tr,
 			                                               Tuple::makeTuple(originalEntry.tenantGroup.get(),
-			                                                                updatedTenantEntry.tenantName,
+			                                                                originalEntry.tenantName,
 			                                                                updatedTenantEntry.id));
 
 			// Check if the original tenant group is now empty. If so, remove the tenant group.

--- a/fdbserver/workloads/MetaclusterRestoreWorkload.actor.cpp
+++ b/fdbserver/workloads/MetaclusterRestoreWorkload.actor.cpp
@@ -404,7 +404,7 @@ struct MetaclusterRestoreWorkload : TestWorkload {
 		                                                        CLIENT_KNOBS->MAX_TENANTS_PER_CLUSTER + 1));
 		std::unordered_set<int64_t> tenants;
 		for (auto const& tuple : groupTenants.results) {
-			tenants.insert(tuple.getInt(1));
+			tenants.insert(tuple.getInt(2));
 		}
 
 		return tenants;

--- a/fdbserver/workloads/TenantManagementWorkload.actor.cpp
+++ b/fdbserver/workloads/TenantManagementWorkload.actor.cpp
@@ -2177,6 +2177,8 @@ struct TenantManagementWorkload : TestWorkload {
 		}
 
 		ASSERT(localItr == self->createdTenantGroups.end());
+		wait(waitForAll(checkTenantGroups));
+
 		return Void();
 	}
 

--- a/metacluster/include/metacluster/RenameTenant.actor.h
+++ b/metacluster/include/metacluster/RenameTenant.actor.h
@@ -169,7 +169,15 @@ struct RenameTenantImpl {
 
 			metadata::management::tenantMetadata().tenantNameIndex.erase(tr, self->oldName);
 
-			// Remove the tenant from the cluster -> tenant index
+			// Update the tenant in the tenant group -> tenant index
+			if (updatedEntry.tenantGroup.present()) {
+				metadata::management::tenantMetadata().tenantGroupTenantIndex.erase(
+				    tr, Tuple::makeTuple(updatedEntry.tenantGroup.get(), self->oldName, self->tenantId));
+				metadata::management::tenantMetadata().tenantGroupTenantIndex.insert(
+				    tr, Tuple::makeTuple(updatedEntry.tenantGroup.get(), self->newName, self->tenantId));
+			}
+
+			// Update the tenant in the cluster -> tenant index
 			metadata::management::clusterTenantIndex().erase(
 			    tr, Tuple::makeTuple(updatedEntry.assignedCluster, self->oldName, self->tenantId));
 			metadata::management::clusterTenantIndex().erase(

--- a/metacluster/include/metacluster/UpdateTenantGroups.actor.h
+++ b/metacluster/include/metacluster/UpdateTenantGroups.actor.h
@@ -65,7 +65,7 @@ void managementClusterAddTenantToGroup(Transaction tr,
 			    tr, Tuple::makeTuple(tenantEntry.assignedCluster, tenantEntry.tenantGroup.get()));
 		}
 		metadata::management::tenantMetadata().tenantGroupTenantIndex.insert(
-		    tr, Tuple::makeTuple(tenantEntry.tenantGroup.get(), tenantEntry.id));
+		    tr, Tuple::makeTuple(tenantEntry.tenantGroup.get(), tenantEntry.tenantName, tenantEntry.id));
 	}
 
 	if (!groupAlreadyExists && !isRestoring) {
@@ -88,7 +88,7 @@ Future<Void> managementClusterRemoveTenantFromGroup(Transaction tr,
 	state bool updateClusterCapacity = !tenantEntry.tenantGroup.present();
 	if (tenantEntry.tenantGroup.present()) {
 		metadata::management::tenantMetadata().tenantGroupTenantIndex.erase(
-		    tr, Tuple::makeTuple(tenantEntry.tenantGroup.get(), tenantEntry.id));
+		    tr, Tuple::makeTuple(tenantEntry.tenantGroup.get(), tenantEntry.tenantName, tenantEntry.id));
 
 		state KeyBackedSet<Tuple>::RangeResultType result =
 		    wait(metadata::management::tenantMetadata().tenantGroupTenantIndex.getRange(


### PR DESCRIPTION
The tenant group index is now a tuple of the form (tenant group name, tenant name, tenant ID). This allows us to read the index paged by the tenant name and to get both the name and ID in one read.

Replace this text with your description here...

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
