### PR TITLE
Clean up data move tombstone when DD init

### DIFF
--- a/fdbserver/DDRelocationQueue.actor.cpp
+++ b/fdbserver/DDRelocationQueue.actor.cpp
@@ -1111,8 +1111,13 @@ void DDQueue::enqueueCancelledDataMove(UID dataMoveId, KeyRange range, const DDE
 	}
 
 	DDQueue::DDDataMove dataMove(dataMoveId);
-	dataMove.cancel =
-	    cleanUpDataMove(this->cx, dataMoveId, this->lock, &this->cleanUpDataMoveParallelismLock, range, ddEnabledState);
+	dataMove.cancel = cleanUpDataMove(this->cx,
+	                                  dataMoveId,
+	                                  this->lock,
+	                                  &this->cleanUpDataMoveParallelismLock,
+	                                  range,
+	                                  ddEnabledState,
+	                                  this->addBackgroundCleanUpDataMoveActor);
 	this->dataMoves.insert(range, dataMove);
 	TraceEvent(SevInfo, "DDEnqueuedCancelledDataMove", this->distributorId)
 	    .detail("DataMoveID", dataMoveId)

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -438,10 +438,10 @@ public:
 	}
 
 	ACTOR static Future<Void> removeDataMoveTombstone(Reference<DataDistributor> self) {
+		state UID currentID;
 		try {
 			state Database cx = openDBOnServer(self->dbInfo, TaskPriority::DefaultEndpoint, LockAware::True);
 			state Transaction tr(cx);
-			state UID currentID;
 			loop {
 				try {
 					tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);

--- a/fdbserver/include/fdbserver/DataDistribution.actor.h
+++ b/fdbserver/include/fdbserver/DataDistribution.actor.h
@@ -488,6 +488,7 @@ struct InitialDataDistribution : ReferenceCounted<InitialDataDistribution> {
 	std::set<std::vector<UID>> primaryTeams;
 	std::set<std::vector<UID>> remoteTeams;
 	std::vector<DDShardInfo> shards;
+	std::vector<UID> toCleanDataMoveTombstone;
 	Optional<Key> initHealthyZoneValue; // set for maintenance mode
 	KeyRangeMap<std::shared_ptr<DataMove>> dataMoveMap;
 	std::vector<AuditStorageState> auditStates;


### PR DESCRIPTION
Persisted data move keeps following invariant:
A persisted data move has an empty range if and only if the persisted data move is a tombstone of a data move.
This persisted data move is generated by a background cleanup. See PR #9421.
Any tombstone of data move should be cleanup later. 
There are two cases of cleaning tombstone: (1) the tombstone is cleaned by a background data move, as it does in PR #9421; (2) before the background data move is triggered, DD restarts. For the second case, we want the tombstone is cleaned when DD is inited.
In this PR, we clean the tombstone for the second case.

Pass 100K with 2 irrelevant failure:
  20230406-015534-zhewang-12a0792761b37748           compressed=True data_size=32691062 duration=4981917 ended=100000 fail=2 fail_fast=10 max_runs=100000 pass=99998 priority=100 remaining=0 runtime=0:52:35 sanity=False started=100000 stopped=20230406-024809 submitted=20230406-015534 timeout=5400 username=zhewang

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
