### PR TITLE
Add wait at the end of the versionepoch fdbcli test which triggers recovery

### DIFF
--- a/fdbcli/tests/fdbcli_tests.py
+++ b/fdbcli/tests/fdbcli_tests.py
@@ -34,8 +34,11 @@ def enable_logging(level=logging.DEBUG):
             handler.setFormatter(handler_format)
             handler.setLevel(level)
             logger.addHandler(handler)
+            # log the start and the end of the function call
+            logger.debug("STARTED")
             # pass the logger to the decorated function
             result = func(logger, *args, **kwargs)
+            logger.debug("FINISHED")
             return result
 
         return wrapper
@@ -455,6 +458,8 @@ def versionepoch(logger):
     assert version10 == "Current version epoch is 0"
     version11 = run_fdbcli_command("versionepoch commit")
     assert version11.startswith("Current read version is ")
+    # the test can trigger recovery, thus we wait until the recovery is finished to move to the next test
+    wait_for_database_available(logger)
 
 
 def get_value_from_status_json(retry, *args):


### PR DESCRIPTION
Since `versionepoch` can trigger recovery, 
we need to wait until the database is available to move to the next test.
Otherwise, unexpected behavior can be seen as tests are added under the assumption that DB is healthy at the beginning of each test.

- Add wait at the end of the `versionepoch` fdbcli test, which triggers recovery
- Add start&end logging of each command test

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
