### PR TITLE
Fixed stuck data movement when a server is removed [release-7.1]

### DIFF
--- a/documentation/sphinx/source/release-notes/release-notes-710.rst
+++ b/documentation/sphinx/source/release-notes/release-notes-710.rst
@@ -19,6 +19,7 @@ Release Notes
 * Upgraded RocksDB to version 7.10.2. `(PR #9829) <https://github.com/apple/foundationdb/pull/9829>`_
 * Fixed an issue where ExclusionSafetyCheckRequest could be blocked forever. `(PR #9871) <https://github.com/apple/foundationdb/pull/9871>`_
 * Fixed fdbserver not able to join the cluster if the majority of coordinators in its connection string have failed. `(PR #9883) <https://github.com/apple/foundationdb/pull/9883>`_
+* Fixed stuck data movement when moving to removed a storage server. `(PR #9904) <https://github.com/apple/foundationdb/pull/9904>`_
 
 7.1.29
 ======


### PR DESCRIPTION
When a server is removed, `dataDistributionRelocator` doesn't remove the work for the destination storage workers. As a result, it can no long move shard into any of the healthy workers in the destination team.

seed: `-r simulation -f ./tests/slow/ConfigureTest.toml -s 688316276 -b on`
commit: d4ffd358d676869e144aff38565406291138021d

cherrypick #9629 and previous changes

20230405-153518-jzhou-ee5ac1a8d0fc66a3

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
