### PR TITLE
Update the tenant group index to include the tenant name (snowflake/release-71.3)

### DIFF
--- a/fdbclient/include/fdbclient/TenantData.actor.h
+++ b/fdbclient/include/fdbclient/TenantData.actor.h
@@ -110,11 +110,14 @@ private:
 
 		self->tenantGroupIndex.clear();
 		for (auto t : tenantGroupTenantTuples.results) {
-			ASSERT_EQ(t.size(), 2);
+			ASSERT_EQ(t.size(), 3);
 			TenantGroupName tenantGroupName = t.getString(0);
-			int64_t tenantId = t.getInt(1);
+			TenantName tenantName = t.getString(1);
+			int64_t tenantId = t.getInt(2);
 			ASSERT(self->tenantGroupMap.count(tenantGroupName));
-			ASSERT(self->tenantMap.count(tenantId));
+			auto tenantItr = self->tenantMap.find(tenantId);
+			ASSERT(tenantItr != self->tenantMap.end());
+			ASSERT_EQ(tenantItr->second.tenantName, tenantName);
 			self->tenantGroupIndex[tenantGroupName].insert(tenantId);
 		}
 		ASSERT_EQ(self->tenantGroupIndex.size(), self->tenantGroupMap.size());

--- a/fdbserver/workloads/MetaclusterRestoreWorkload.actor.cpp
+++ b/fdbserver/workloads/MetaclusterRestoreWorkload.actor.cpp
@@ -404,7 +404,7 @@ struct MetaclusterRestoreWorkload : TestWorkload {
 		                                                        CLIENT_KNOBS->MAX_TENANTS_PER_CLUSTER + 1));
 		std::unordered_set<int64_t> tenants;
 		for (auto const& tuple : groupTenants.results) {
-			tenants.insert(tuple.getInt(1));
+			tenants.insert(tuple.getInt(2));
 		}
 
 		return tenants;

--- a/fdbserver/workloads/TenantManagementWorkload.actor.cpp
+++ b/fdbserver/workloads/TenantManagementWorkload.actor.cpp
@@ -2177,6 +2177,8 @@ struct TenantManagementWorkload : TestWorkload {
 		}
 
 		ASSERT(localItr == self->createdTenantGroups.end());
+		wait(waitForAll(checkTenantGroups));
+
 		return Void();
 	}
 

--- a/metacluster/include/metacluster/RenameTenant.actor.h
+++ b/metacluster/include/metacluster/RenameTenant.actor.h
@@ -169,7 +169,15 @@ struct RenameTenantImpl {
 
 			metadata::management::tenantMetadata().tenantNameIndex.erase(tr, self->oldName);
 
-			// Remove the tenant from the cluster -> tenant index
+			// Update the tenant in the tenant group -> tenant index
+			if (updatedEntry.tenantGroup.present()) {
+				metadata::management::tenantMetadata().tenantGroupTenantIndex.erase(
+				    tr, Tuple::makeTuple(updatedEntry.tenantGroup.get(), self->oldName, self->tenantId));
+				metadata::management::tenantMetadata().tenantGroupTenantIndex.insert(
+				    tr, Tuple::makeTuple(updatedEntry.tenantGroup.get(), self->newName, self->tenantId));
+			}
+
+			// Update the tenant in the cluster -> tenant index
 			metadata::management::clusterTenantIndex().erase(
 			    tr, Tuple::makeTuple(updatedEntry.assignedCluster, self->oldName, self->tenantId));
 			metadata::management::clusterTenantIndex().erase(

--- a/metacluster/include/metacluster/UpdateTenantGroups.actor.h
+++ b/metacluster/include/metacluster/UpdateTenantGroups.actor.h
@@ -65,7 +65,7 @@ void managementClusterAddTenantToGroup(Transaction tr,
 			    tr, Tuple::makeTuple(tenantEntry.assignedCluster, tenantEntry.tenantGroup.get()));
 		}
 		metadata::management::tenantMetadata().tenantGroupTenantIndex.insert(
-		    tr, Tuple::makeTuple(tenantEntry.tenantGroup.get(), tenantEntry.id));
+		    tr, Tuple::makeTuple(tenantEntry.tenantGroup.get(), tenantEntry.tenantName, tenantEntry.id));
 	}
 
 	if (!groupAlreadyExists && !isRestoring) {
@@ -88,7 +88,7 @@ Future<Void> managementClusterRemoveTenantFromGroup(Transaction tr,
 	state bool updateClusterCapacity = !tenantEntry.tenantGroup.present();
 	if (tenantEntry.tenantGroup.present()) {
 		metadata::management::tenantMetadata().tenantGroupTenantIndex.erase(
-		    tr, Tuple::makeTuple(tenantEntry.tenantGroup.get(), tenantEntry.id));
+		    tr, Tuple::makeTuple(tenantEntry.tenantGroup.get(), tenantEntry.tenantName, tenantEntry.id));
 
 		state KeyBackedSet<Tuple>::RangeResultType result =
 		    wait(metadata::management::tenantMetadata().tenantGroupTenantIndex.getRange(


### PR DESCRIPTION
Cherry pick #9899 

The tenant group index is now a tuple of the form (tenant group name, tenant name, tenant ID). This allows us to read the index paged by the tenant name and to get both the name and ID in one read.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
