### PR TITLE
RestoreConfig - use restoreRangeSet to replace restoreRanges

### DIFF
--- a/fdbclient/ClientKnobs.cpp
+++ b/fdbclient/ClientKnobs.cpp
@@ -190,6 +190,7 @@ void ClientKnobs::initialize(Randomize randomize) {
 	init( BACKUP_STATUS_JITTER,                   0.05 );
 	init( MIN_CLEANUP_SECONDS,                  3600.0 );
 	init( FASTRESTORE_ATOMICOP_WEIGHT,               1 ); if( randomize && BUGGIFY ) { FASTRESTORE_ATOMICOP_WEIGHT = deterministicRandom()->random01() * 200 + 1; }
+	init( RESTORE_RANGES_READ_BATCH,             10000 );
 
 	// Configuration
 	init( DEFAULT_AUTO_COMMIT_PROXIES,               3 );

--- a/fdbclient/FileBackupAgent.actor.cpp
+++ b/fdbclient/FileBackupAgent.actor.cpp
@@ -25,6 +25,7 @@
 #include "fdbrpc/simulator.h"
 #include "flow/EncryptUtils.h"
 #include "flow/FastRef.h"
+#include "flow/flow.h"
 #include "fmt/format.h"
 #include "fdbclient/BackupAgent.actor.h"
 #include "fdbclient/BackupContainer.h"
@@ -170,7 +171,9 @@ public:
 	KeyBackedProperty<bool> unlockDBAfterRestore() { return configSpace.pack(__FUNCTION__sr); }
 	// XXX: Remove restoreRange() once it is safe to remove. It has been changed to restoreRanges
 	KeyBackedProperty<KeyRange> restoreRange() { return configSpace.pack(__FUNCTION__sr); }
+	// XXX: Changed to restoreRangeSet. It can be removed.
 	KeyBackedProperty<std::vector<KeyRange>> restoreRanges() { return configSpace.pack(__FUNCTION__sr); }
+	KeyBackedSet<KeyRange> restoreRangeSet() { return configSpace.pack(__FUNCTION__sr); }
 	KeyBackedProperty<Key> batchFuture() { return configSpace.pack(__FUNCTION__sr); }
 	KeyBackedProperty<Version> beginVersion() { return configSpace.pack(__FUNCTION__sr); }
 	KeyBackedProperty<Version> restoreVersion() { return configSpace.pack(__FUNCTION__sr); }
@@ -197,10 +200,29 @@ public:
 
 	ACTOR static Future<std::vector<KeyRange>> getRestoreRangesOrDefault_impl(RestoreConfig* self,
 	                                                                          Reference<ReadYourWritesTransaction> tr) {
-		state std::vector<KeyRange> ranges = wait(self->restoreRanges().getD(tr));
+		state std::vector<KeyRange> ranges;
+		state int batchSize = BUGGIFY ? 1 : CLIENT_KNOBS->RESTORE_RANGES_READ_BATCH;
+		state Optional<KeyRange> begin;
+		state Arena arena;
+		loop {
+			KeyBackedSet<KeyRange>::RangeResultType rangeResult =
+			    wait(self->restoreRangeSet().getRange(tr, begin, {}, batchSize));
+			ranges.insert(ranges.end(), rangeResult.results.begin(), rangeResult.results.end());
+			if (!rangeResult.more) {
+				break;
+			}
+			ASSERT(!rangeResult.results.empty());
+			begin = KeyRangeRef(KeyRef(arena, ranges.back().begin), keyAfter(ranges.back().end, arena));
+		}
+
+		// fall back to original fields if the new field is empty
 		if (ranges.empty()) {
-			state KeyRange range = wait(self->restoreRange().getD(tr));
-			ranges.push_back(range);
+			std::vector<KeyRange> _ranges = wait(self->restoreRanges().getD(tr));
+			ranges = _ranges;
+			if (ranges.empty()) {
+				KeyRange range = wait(self->restoreRange().getD(tr));
+				ranges.push_back(range);
+			}
 		}
 		return ranges;
 	}
@@ -5481,7 +5503,9 @@ public:
 		if (BUGGIFY && restoreRanges.size() == 1) {
 			restore.restoreRange().set(tr, restoreRanges[0]);
 		} else {
-			restore.restoreRanges().set(tr, restoreRanges);
+			for (auto& range : restoreRanges) {
+				restore.restoreRangeSet().insert(tr, range);
+			}
 		}
 
 		// this also sets restore.add/removePrefix.

--- a/fdbclient/include/fdbclient/ClientKnobs.h
+++ b/fdbclient/include/fdbclient/ClientKnobs.h
@@ -190,6 +190,7 @@ public:
 	double BACKUP_STATUS_JITTER;
 	double MIN_CLEANUP_SECONDS;
 	int64_t FASTRESTORE_ATOMICOP_WEIGHT; // workload amplication factor for atomic op
+	int RESTORE_RANGES_READ_BATCH;
 
 	// Configuration
 	int32_t DEFAULT_AUTO_COMMIT_PROXIES;


### PR DESCRIPTION
Use KeyBackedSet to replace KeyBackedProperty<std::vector<KeyRange>>. If there are lot of ranges to restore, it may throw value_too_large errors when writing this property. 

100k correctness test passed

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
