### PR TITLE
refactor GetTeamRequest (Cherry-Pick #9713 to snowflake/release-71.3)

### DIFF
--- a/fdbserver/DDRelocationQueue.actor.cpp
+++ b/fdbserver/DDRelocationQueue.actor.cpp
@@ -23,6 +23,7 @@
 #include <utility>
 #include <vector>
 
+#include "fdbserver/DataDistributionTeam.h"
 #include "flow/ActorCollection.h"
 #include "flow/FastRef.h"
 #include "flow/Trace.h"
@@ -1294,8 +1295,15 @@ ACTOR Future<Void> dataDistributionRelocator(DDQueue* self,
 						    rd.healthPriority == SERVER_KNOBS->PRIORITY_TEAM_0_LEFT)
 							inflightPenalty = SERVER_KNOBS->INFLIGHT_PENALTY_ONE_LEFT;
 
-						auto req = GetTeamRequest(WantNewServers(rd.wantsNewServers),
-						                          wantTrueBest,
+						TeamSelect destTeamSelect;
+						if (!rd.wantsNewServers) {
+							destTeamSelect = TeamSelect::WANT_COMPLETE_SRCS;
+						} else if (wantTrueBest) {
+							destTeamSelect = TeamSelect::WANT_TRUE_BEST;
+						} else {
+							destTeamSelect = TeamSelect::ANY;
+						}
+						auto req = GetTeamRequest(destTeamSelect,
 						                          PreferLowerDiskUtil::True,
 						                          TeamMustHaveShards::False,
 						                          ForReadBalance(rd.reason == RelocateReason::REBALANCE_READ),
@@ -2109,8 +2117,6 @@ ACTOR Future<Void> BgDDLoadRebalance(DDQueue* self, int teamCollectionIndex, Dat
 		state bool moved = false;
 		state Reference<IDataDistributionTeam> sourceTeam;
 		state Reference<IDataDistributionTeam> destTeam;
-		state GetTeamRequest srcReq;
-		state GetTeamRequest destReq;
 		state TraceEvent traceEvent(eventName, self->distributorId);
 		traceEvent.suppressFor(5.0)
 		    .detail("PollingInterval", rebalancePollingInterval)
@@ -2137,18 +2143,16 @@ ACTOR Future<Void> BgDDLoadRebalance(DDQueue* self, int teamCollectionIndex, Dat
 
 			if (self->priority_relocations[ddPriority] < SERVER_KNOBS->DD_REBALANCE_PARALLELISM) {
 				bool mcMove = isDataMovementForMountainChopper(reason);
-				srcReq = GetTeamRequest(WantNewServers::True,
-				                        WantTrueBest(mcMove),
-				                        PreferLowerDiskUtil::False,
-				                        TeamMustHaveShards::True,
-				                        ForReadBalance(readRebalance),
-				                        PreferLowerReadUtil::False);
-				destReq = GetTeamRequest(WantNewServers::True,
-				                         WantTrueBest(!mcMove),
-				                         PreferLowerDiskUtil::True,
-				                         TeamMustHaveShards::False,
-				                         ForReadBalance(readRebalance),
-				                         PreferLowerReadUtil::True);
+				GetTeamRequest srcReq = GetTeamRequest(mcMove ? TeamSelect::WANT_TRUE_BEST : TeamSelect::ANY,
+				                                       PreferLowerDiskUtil::False,
+				                                       TeamMustHaveShards::True,
+				                                       ForReadBalance(readRebalance),
+				                                       PreferLowerReadUtil::False);
+				GetTeamRequest destReq = GetTeamRequest(!mcMove ? TeamSelect::WANT_TRUE_BEST : TeamSelect::ANY,
+				                                        PreferLowerDiskUtil::True,
+				                                        TeamMustHaveShards::False,
+				                                        ForReadBalance(readRebalance),
+				                                        PreferLowerReadUtil::True);
 				state Future<SrcDestTeamPair> getTeamFuture =
 				    self->getSrcDestTeams(teamCollectionIndex, srcReq, destReq, ddPriority, &traceEvent);
 				wait(ready(getTeamFuture));

--- a/fdbserver/include/fdbserver/DataDistributionTeam.h
+++ b/fdbserver/include/fdbserver/DataDistributionTeam.h
@@ -69,9 +69,34 @@ FDB_BOOLEAN_PARAM(ForReadBalance);
 FDB_BOOLEAN_PARAM(PreferLowerReadUtil);
 FDB_BOOLEAN_PARAM(FindTeamByServers);
 
+class TeamSelect {
+public:
+	enum Value : int8_t {
+		ANY = 0, // Any other situations except for the next two
+		WANT_COMPLETE_SRCS, // Try best to select a healthy team consists of servers in completeSources
+		WANT_TRUE_BEST, // Ask for the most or least utilized team in the cluster
+	};
+	TeamSelect() : value(ANY) {}
+	TeamSelect(Value v) : value(v) {}
+	std::string toString() const {
+		switch (value) {
+		case WANT_COMPLETE_SRCS:
+			return "Want_Complete_Srcs";
+		case WANT_TRUE_BEST:
+			return "Want_True_Best";
+		case ANY:
+			return "Any";
+		}
+	}
+
+	bool operator==(const TeamSelect& tmpTeamSelect) { return value == tmpTeamSelect.value; }
+
+private:
+	Value value;
+};
+
 struct GetTeamRequest {
-	bool wantsNewServers; // In additional to servers in completeSources, try to find teams with new server
-	bool wantsTrueBest;
+	TeamSelect teamSelect;
 	bool preferLowerDiskUtil; // if true, lower utilized team has higher score
 	bool teamMustHaveShards;
 	bool forReadBalance;
@@ -79,29 +104,34 @@ struct GetTeamRequest {
 	double inflightPenalty;
 	bool findTeamByServers;
 	Optional<KeyRange> keys;
+
+	// completeSources have all shards in the key range being considered for movement, src have at least 1 shard in the
+	// key range for movement. From the point of set, completeSources is the Intersection set of several <server_lists>,
+	// while src is the Union set of them. E.g. keyRange = [Shard_1, Shard_2), and Shard_1 is located at {Server_1,
+	// Server_2, Server_3}, Shard_2 is located at {Server_2, Server_3, Server_4}. completeSources = {Server_2,
+	// Server_3}, src = {Server_1, Server_2, Server_3, Server_4}
 	std::vector<UID> completeSources;
 	std::vector<UID> src;
+
 	Promise<std::pair<Optional<Reference<IDataDistributionTeam>>, bool>> reply;
 
 	typedef Reference<IDataDistributionTeam> TeamRef;
 
 	GetTeamRequest() {}
-	GetTeamRequest(WantNewServers wantsNewServers,
-	               WantTrueBest wantsTrueBest,
+	GetTeamRequest(TeamSelect teamSelectRequest,
 	               PreferLowerDiskUtil preferLowerDiskUtil,
 	               TeamMustHaveShards teamMustHaveShards,
 	               ForReadBalance forReadBalance = ForReadBalance::False,
 	               PreferLowerReadUtil preferLowerReadUtil = PreferLowerReadUtil::False,
 	               double inflightPenalty = 1.0,
 	               Optional<KeyRange> keys = Optional<KeyRange>())
-	  : wantsNewServers(wantsNewServers), wantsTrueBest(wantsTrueBest), preferLowerDiskUtil(preferLowerDiskUtil),
-	    teamMustHaveShards(teamMustHaveShards), forReadBalance(forReadBalance),
-	    preferLowerReadUtil(preferLowerReadUtil), inflightPenalty(inflightPenalty),
+	  : teamSelect(teamSelectRequest), preferLowerDiskUtil(preferLowerDiskUtil), teamMustHaveShards(teamMustHaveShards),
+	    forReadBalance(forReadBalance), preferLowerReadUtil(preferLowerReadUtil), inflightPenalty(inflightPenalty),
 	    findTeamByServers(FindTeamByServers::False), keys(keys) {}
 	GetTeamRequest(std::vector<UID> servers)
-	  : wantsNewServers(WantNewServers::False), wantsTrueBest(WantTrueBest::False),
-	    preferLowerDiskUtil(PreferLowerDiskUtil::False), teamMustHaveShards(TeamMustHaveShards::False),
-	    forReadBalance(ForReadBalance::False), preferLowerReadUtil(PreferLowerReadUtil::False), inflightPenalty(1.0),
+	  : teamSelect(TeamSelect::WANT_COMPLETE_SRCS), preferLowerDiskUtil(PreferLowerDiskUtil::False),
+	    teamMustHaveShards(TeamMustHaveShards::False), forReadBalance(ForReadBalance::False),
+	    preferLowerReadUtil(PreferLowerReadUtil::False), inflightPenalty(1.0),
 	    findTeamByServers(FindTeamByServers::True), src(std::move(servers)) {}
 
 	// return true if a.score < b.score
@@ -116,10 +146,9 @@ struct GetTeamRequest {
 	std::string getDesc() const {
 		std::stringstream ss;
 
-		ss << "WantsNewServers:" << wantsNewServers << " WantsTrueBest:" << wantsTrueBest
-		   << " PreferLowerDiskUtil:" << preferLowerDiskUtil << " teamMustHaveShards:" << teamMustHaveShards
-		   << "forReadBalance" << forReadBalance << " inflightPenalty:" << inflightPenalty
-		   << " findTeamByServers:" << findTeamByServers << ";";
+		ss << "TeamSelect:" << teamSelect.toString() << " PreferLowerDiskUtil:" << preferLowerDiskUtil
+		   << " teamMustHaveShards:" << teamMustHaveShards << " forReadBalance:" << forReadBalance
+		   << " inflightPenalty:" << inflightPenalty << " findTeamByServers:" << findTeamByServers << ";";
 		ss << "CompleteSources:";
 		for (const auto& cs : completeSources) {
 			ss << cs.toString() << ",";


### PR DESCRIPTION
Cherry-Pick of #9713

Original Description:

`GetTeamRequest` has two boolean variables `wantsNewServers`, `wantsTrueBest`, which are not mutually exclusive. The `wantNewServers=false, wantsTrueBest=true` condition does not hold true semantically and theoretically. We want to use a single enum class TeamSelect to express the valid leftover 3 situations.
```
TeamSelect::WANT_TRUEBEST = wantsNewServers=True && wantsTrueBest=True
TeamSelect::ANY = wantsNewServers=True && wantsTrueBest=False
TeamSelect::WANT_SRCSERVERS = wantsNewServers=Fasle && wantsTrueBest=False
```

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
