### PR TITLE
Fix Asan reporting heap overflow

### DIFF
--- a/fdbclient/BlobCipher.cpp
+++ b/fdbclient/BlobCipher.cpp
@@ -1910,10 +1910,9 @@ void testKeyCacheEssentials(DomainKeyMap& domainKeyMap,
 		Reference<BaseCipher> baseCipher = domainKeyMap[minDomainId][minBaseCipherKeyId];
 		uint8_t rawCipher[baseCipher->len];
 		memcpy(rawCipher, baseCipher->key.get(), baseCipher->len);
-		// modify few bytes in the cipherKey
-		for (int i = 2; i < 5; i++) {
-			rawCipher[i]++;
-		}
+		// modify cipherKey by flipping a bit
+		const int idx = deterministicRandom()->randomInt(0, baseCipher->len + 1);
+		rawCipher[idx]++;
 		cipherKeyCache->insertCipherKey(baseCipher->domainId,
 		                                baseCipher->keyId,
 		                                &rawCipher[0],

--- a/fdbclient/BlobCipher.cpp
+++ b/fdbclient/BlobCipher.cpp
@@ -1911,7 +1911,7 @@ void testKeyCacheEssentials(DomainKeyMap& domainKeyMap,
 		uint8_t rawCipher[baseCipher->len];
 		memcpy(rawCipher, baseCipher->key.get(), baseCipher->len);
 		// modify cipherKey by flipping a bit
-		const int idx = deterministicRandom()->randomInt(0, baseCipher->len + 1);
+		const int idx = deterministicRandom()->randomInt(0, baseCipher->len);
 		rawCipher[idx]++;
 		cipherKeyCache->insertCipherKey(baseCipher->domainId,
 		                                baseCipher->keyId,


### PR DESCRIPTION
Description

Fix Asan reporting heap overflow

Testing

BlobCipherUnitTest with failing seed

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
