### PR TITLE
Use separated actors to dump manifest and truncate mutation logs

### DIFF
--- a/fdbserver/BlobManager.actor.cpp
+++ b/fdbserver/BlobManager.actor.cpp
@@ -5494,73 +5494,91 @@ ACTOR Future<int64_t> getLastFlushTs(Database db) {
 	}
 }
 
-ACTOR Future<Void> maybeFlushAndTruncateMutationLogs(Reference<BlobManagerData> bmData) {
-	try {
-		int64_t lastFlushTs = wait(getLastFlushTs(bmData->db));
-		bool shouldFlush = (now() - lastFlushTs) > SERVER_KNOBS->BLOB_RESTORE_MLOGS_RETENTION_SECS;
-		if (!shouldFlush) {
-			TraceEvent("SkipBlobGranulesFlush").detail("LastFlushTs", lastFlushTs);
-			return Void();
-		}
-
-		state std::string mlogsUrl = wait(getMutationLogUrl());
-		state Reference<IBackupContainer> bc = IBackupContainer::openContainer(mlogsUrl, {}, {});
-		state BackupDescription desc = wait(bc->describeBackup(true));
-		if (!desc.contiguousLogEnd.present()) {
-			TraceEvent("SkipBlobGranulesFlush").detail("LogUrl", mlogsUrl);
-			return Void(); // skip truncation if no valid backup for mutation logs
-		}
-
-		state Version logEndVersion = desc.contiguousLogEnd.get();
-		// Force flush in-memory data of all blob workers until end of log
-		FlushGranuleRequest req(bmData->epoch, normalKeys, logEndVersion, false);
-		wait(success(doBlobGranuleRequests(bmData->db, normalKeys, req, &BlobWorkerInterface::flushGranuleRequest)));
-		wait(updateLastFlushTs(bmData->db));
-		bmData->stats.lastFlushVersion = logEndVersion;
-
-		// Truncate mutation logs to max retention period
-		Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(bmData->db));
-		Optional<int64_t> logEndEpochs = wait(timeKeeperEpochsFromVersion(logEndVersion, tr));
-		if (!logEndEpochs.present()) {
-			TraceEvent("SkipMutationLogTruncation").detail("LogEndVersion", logEndVersion);
-			return Void(); // skip truncation if no timestamp about log end
-		}
-
-		// Find timestamp and version to truncate
-		int64_t epochs = logEndEpochs.get() - SERVER_KNOBS->BLOB_RESTORE_MLOGS_RETENTION_SECS;
-		if (epochs <= 0) {
-			TraceEvent("SkipMutationLogTruncation").detail("Epochs", epochs);
-			return Void();
-		}
-		state std::string timestamp = BackupAgentBase::formatTime(epochs);
-		state Version truncVersion = wait(timeKeeperVersionFromDatetime(timestamp, bmData->db));
-
-		wait(bc->expireData(truncVersion, true));
-		bmData->stats.lastMLogTruncationVersion = truncVersion;
-		TraceEvent("TruncateMutationLogs").detail("Version", truncVersion).detail("Timestamp", timestamp);
-		CODE_PROBE(true, "Flush blob granules and truncate mutation logs");
-	} catch (Error& e) {
-		TraceEvent("TruncateMutationLogsError").error(e); // skip and retry next time
+bool shouldBackupManifest(Reference<BlobManagerData> bmData) {
+	if (!SERVER_KNOBS->BLOB_MANIFEST_BACKUP) {
+		return false;
 	}
-	return Void();
+
+	if (bmData->isFullRestoreMode) {
+		return false;
+	}
+
+	auto knownRanges = bmData->knownBlobRanges.intersectingRanges(normalKeys);
+	for (auto& it : knownRanges) {
+		if (it.cvalue()) {
+			return true; // there is at least one active blob range
+		}
+	}
+	return false;
+}
+
+ACTOR Future<Void> truncateMutationLogs(Reference<BlobManagerData> bmData) {
+	loop {
+		wait(delay(SERVER_KNOBS->BLOB_MANIFEST_BACKUP_INTERVAL));
+
+		if (!shouldBackupManifest(bmData)) {
+			continue;
+		}
+
+		try {
+			int64_t lastFlushTs = wait(getLastFlushTs(bmData->db));
+			bool shouldFlush = (now() - lastFlushTs) > SERVER_KNOBS->BLOB_RESTORE_MLOGS_RETENTION_SECS;
+			if (!shouldFlush) {
+				TraceEvent("SkipBlobGranulesFlush").detail("LastFlushTs", lastFlushTs);
+				return Void();
+			}
+
+			state std::string mlogsUrl = wait(getMutationLogUrl());
+			state Reference<IBackupContainer> bc = IBackupContainer::openContainer(mlogsUrl, {}, {});
+			state BackupDescription desc = wait(bc->describeBackup());
+			if (!desc.contiguousLogEnd.present()) {
+				TraceEvent("SkipBlobGranulesFlush").detail("LogUrl", mlogsUrl);
+				return Void(); // skip truncation if no valid backup for mutation logs
+			}
+			state Version logEndVersion = desc.contiguousLogEnd.get();
+			TraceEvent("DescribedMutationLogs").detail("LogEndVersion", logEndVersion);
+
+			// Force flush in-memory data of all blob workers until end of log
+			FlushGranuleRequest req(bmData->epoch, normalKeys, logEndVersion, false);
+			wait(
+			    success(doBlobGranuleRequests(bmData->db, normalKeys, req, &BlobWorkerInterface::flushGranuleRequest)));
+			wait(updateLastFlushTs(bmData->db));
+			bmData->stats.lastFlushVersion = logEndVersion;
+			TraceEvent("FlushedBlobGranules").detail("FlushVersion", logEndVersion);
+
+			// Truncate mutation logs to max retention period
+			Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(bmData->db));
+			Optional<int64_t> logEndEpochs = wait(timeKeeperEpochsFromVersion(logEndVersion, tr));
+			if (!logEndEpochs.present()) {
+				TraceEvent("SkipMutationLogTruncation").detail("LogEndVersion", logEndVersion);
+				return Void(); // skip truncation if no timestamp about log end
+			}
+
+			// Find timestamp and version to truncate
+			int64_t epochs = logEndEpochs.get() - SERVER_KNOBS->BLOB_RESTORE_MLOGS_RETENTION_SECS;
+			if (epochs <= 0) {
+				TraceEvent("SkipMutationLogTruncation").detail("Epochs", epochs);
+				return Void();
+			}
+			state std::string timestamp = BackupAgentBase::formatTime(epochs);
+			state Version truncVersion = wait(timeKeeperVersionFromDatetime(timestamp, bmData->db));
+
+			wait(bc->expireData(truncVersion, true));
+			bmData->stats.lastMLogTruncationVersion = truncVersion;
+			TraceEvent("TruncateMutationLogs").detail("Version", truncVersion).detail("Timestamp", timestamp);
+			CODE_PROBE(true, "Flush blob granules and truncate mutation logs");
+		} catch (Error& e) {
+			TraceEvent("TruncateMutationLogsError").error(e); // skip and retry next time
+		}
+	}
 }
 
 ACTOR Future<Void> backupManifest(Reference<BlobManagerData> bmData) {
 	bmData->initBStore();
-
 	loop {
 		// Skip backup if no active blob ranges
-		bool activeRanges = false;
-		auto knownRanges = bmData->knownBlobRanges.intersectingRanges(normalKeys);
-		for (auto& it : knownRanges) {
-			if (it.cvalue()) {
-				activeRanges = true;
-				break;
-			}
-		}
-		if (activeRanges && SERVER_KNOBS->BLOB_MANIFEST_BACKUP) {
+		if (shouldBackupManifest(bmData)) {
 			if (bmData->manifestStore.isValid()) {
-				wait(maybeFlushAndTruncateMutationLogs(bmData));
 				int64_t bytes =
 				    wait(dumpManifest(bmData->db, bmData->manifestStore, bmData->epoch, bmData->manifestDumperSeqNo));
 				bmData->stats.lastManifestSeqNo = bmData->manifestDumperSeqNo;
@@ -5661,8 +5679,9 @@ ACTOR Future<Void> blobManager(BlobManagerInterface bmInterf,
 		if (SERVER_KNOBS->BG_ENABLE_MERGING) {
 			self->addActor.send(granuleMergeChecker(self));
 		}
-		if (SERVER_KNOBS->BLOB_MANIFEST_BACKUP && !self->isFullRestoreMode) {
+		if (SERVER_KNOBS->BLOB_MANIFEST_BACKUP) {
 			self->addActor.send(backupManifest(self));
+			self->addActor.send(truncateMutationLogs(self));
 		}
 
 		if (BUGGIFY && !self->isFullRestoreMode) {


### PR DESCRIPTION
This PR is to split manifest backup into 2 actors: one is to dump manifest, and the other is to truncate mutation logs. Sometimes mutation log backup takes long time because of flushing granules and it blocks manifest backup. So it's better to  split them and make sure we can always dump manifests. 

The other fix is in manifest cleanup. we should wait on the deletion future before return. 

100K correctness tests passed

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
