### PR TITLE
fix for bw read driven compaction rare race (Cherry-Pick #9784 to snowflake/release-71.3)

### DIFF
--- a/fdbserver/BlobWorker.actor.cpp
+++ b/fdbserver/BlobWorker.actor.cpp
@@ -96,7 +96,7 @@ double GranuleMetadata::weightRDC() {
 bool GranuleMetadata::isEligibleRDC() const {
 	// granule should be reasonably read-hot to be eligible
 	int64_t bytesWritten = bufferedDeltaBytes + bytesInNewDeltaFiles;
-	return bytesWritten * SERVER_KNOBS->BG_RDC_READ_FACTOR < readStats.deltaBytesRead;
+	return bytesWritten > 0 && bytesWritten * SERVER_KNOBS->BG_RDC_READ_FACTOR < readStats.deltaBytesRead;
 }
 
 bool GranuleMetadata::updateReadStats(Version readVersion, const BlobGranuleChunkRef& chunk) {
@@ -110,9 +110,15 @@ bool GranuleMetadata::updateReadStats(Version readVersion, const BlobGranuleChun
 		return false;
 	}
 
+	// any memory deltas must be newer than snapshot
 	readStats.deltaBytesRead += chunk.newDeltas.expectedSize();
 	for (auto& it : chunk.deltaFiles) {
-		readStats.deltaBytesRead += it.length;
+		// some races where you get previous snapshot + deltas instead of new snapshot for read, don't count those
+		// as we already re-snapshotted after them
+		if (it.fileVersion > pendingSnapshotVersion) {
+			// TODO: should this be logical size instead?
+			readStats.deltaBytesRead += it.length;
+		}
 	}
 
 	if (rdcCandidate) {


### PR DESCRIPTION
Cherry-Pick of #9784

Original Description:

A bug in attributing reads incorrectly in read-driven compaction meant that we would try to resnapshot twice at the same snapshot version, causing an issue.

Passes 20k BlobGranule* correctness

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
