### PR TITLE
EaR: Implement Key Check Value semantics

### DIFF
--- a/bindings/c/fdb_c.cpp
+++ b/bindings/c/fdb_c.cpp
@@ -355,6 +355,7 @@ void parseGetTenant(Optional<KeyRef>& dest, FDBBGTenantPrefix const* source) {
 void parseGetEncryptionKey(BlobGranuleCipherKey& dest, FDBBGEncryptionKey const* source) {
 	dest.encryptDomainId = source->domain_id;
 	dest.baseCipherId = source->base_key_id;
+	dest.baseCipherKCV = source->base_kcv;
 	dest.salt = source->random_salt;
 	dest.baseCipher = StringRef(source->base_key.key, source->base_key.key_length);
 }
@@ -371,6 +372,7 @@ void parseGetEncryptionKeyCtx(Optional<BlobGranuleCipherKeysCtx>& dest, FDBBGEnc
 void setEncryptionKey(FDBBGEncryptionKey* dest, const BlobGranuleCipherKey& source) {
 	dest->domain_id = source.encryptDomainId;
 	dest->base_key_id = source.baseCipherId;
+	dest->base_kcv = source.baseCipherKCV;
 	dest->random_salt = source.salt;
 	dest->base_key.key = source.baseCipher.begin();
 	dest->base_key.key_length = source.baseCipher.size();
@@ -379,7 +381,9 @@ void setEncryptionKey(FDBBGEncryptionKey* dest, const BlobGranuleCipherKey& sour
 void setEncryptionKeyCtx(FDBBGEncryptionCtx* dest, const BlobGranuleCipherKeysCtx& source) {
 	dest->present = true;
 	setEncryptionKey(&dest->textKey, source.textCipherKey);
+	dest->textKCV = source.textCipherKey.baseCipherKCV;
 	setEncryptionKey(&dest->headerKey, source.headerCipherKey);
+	dest->headerKCV = source.headerCipherKey.baseCipherKCV;
 	dest->iv.key = source.ivRef.begin();
 	dest->iv.key_length = source.ivRef.size();
 }

--- a/bindings/c/foundationdb/fdb_c.h
+++ b/bindings/c/foundationdb/fdb_c.h
@@ -234,6 +234,7 @@ typedef struct bgtenantprefix {
 typedef struct bgencryptionkey {
 	int64_t domain_id;
 	uint64_t base_key_id;
+	uint32_t base_kcv;
 	uint64_t random_salt;
 	FDBKey base_key;
 } FDBBGEncryptionKey;
@@ -241,7 +242,9 @@ typedef struct bgencryptionkey {
 typedef struct bgencryptionctx {
 	fdb_bool_t present;
 	FDBBGEncryptionKey textKey;
+	uint32_t textKCV;
 	FDBBGEncryptionKey headerKey;
+	uint32_t headerKCV;
 	FDBKey iv;
 } FDBBGEncryptionCtx;
 

--- a/fdbclient/BlobCipher.cpp
+++ b/fdbclient/BlobCipher.cpp
@@ -2045,6 +2045,7 @@ void testMaxBaseCipherLen() {
 		                                                               baseCipherKCV,
 		                                                               std::numeric_limits<int64_t>::max(),
 		                                                               std::numeric_limits<int64_t>::max());
+		ASSERT(false); // error expected
 	} catch (Error& e) {
 		ASSERT_EQ(e.code(), error_code_encrypt_max_base_cipher_len);
 	}

--- a/fdbclient/BlobGranuleFiles.cpp
+++ b/fdbclient/BlobGranuleFiles.cpp
@@ -201,6 +201,7 @@ BlobGranuleFileEncryptionKeys getEncryptBlobCipherKey(const BlobGranuleCipherKey
 	                                                   cipherKeysCtx.textCipherKey.baseCipherId,
 	                                                   cipherKeysCtx.textCipherKey.baseCipher.begin(),
 	                                                   cipherKeysCtx.textCipherKey.baseCipher.size(),
+	                                                   cipherKeysCtx.textCipherKey.baseCipherKCV,
 	                                                   cipherKeysCtx.textCipherKey.salt,
 	                                                   std::numeric_limits<int64_t>::max(),
 	                                                   std::numeric_limits<int64_t>::max());
@@ -208,6 +209,7 @@ BlobGranuleFileEncryptionKeys getEncryptBlobCipherKey(const BlobGranuleCipherKey
 	                                                     cipherKeysCtx.headerCipherKey.baseCipherId,
 	                                                     cipherKeysCtx.headerCipherKey.baseCipher.begin(),
 	                                                     cipherKeysCtx.headerCipherKey.baseCipher.size(),
+	                                                     cipherKeysCtx.headerCipherKey.baseCipherKCV,
 	                                                     cipherKeysCtx.headerCipherKey.salt,
 	                                                     std::numeric_limits<int64_t>::max(),
 	                                                     std::numeric_limits<int64_t>::max());
@@ -253,9 +255,16 @@ void validateEncryptionHeaderDetails(const BlobGranuleFileEncryptionKeys& eKeys,
                                      const BlobCipherEncryptHeaderRef& headerRef,
                                      const StringRef& ivRef) {
 	ASSERT(eKeys.textCipherKey.isValid());
+	EncryptHeaderCipherKCVs kcvs;
+
+	kcvs.textKCV = eKeys.textCipherKey->getBaseCipherKCV();
+	if (eKeys.headerCipherKey.isValid()) {
+		kcvs.headerKCV = eKeys.headerCipherKey->getBaseCipherKCV();
+	}
 	headerRef.validateEncryptionHeaderDetails(eKeys.textCipherKey->details(),
 	                                          eKeys.headerCipherKey.isValid() ? eKeys.headerCipherKey->details()
 	                                                                          : BlobCipherDetails(),
+	                                          kcvs,
 	                                          ivRef);
 }
 
@@ -1877,23 +1886,27 @@ const EncryptCipherBaseKeyId encryptBaseCipherId = deterministicRandom()->random
 const EncryptCipherRandomSalt encryptSalt = deterministicRandom()->randomUInt64();
 
 Standalone<StringRef> getBaseCipher() {
-	Standalone<StringRef> baseCipher = makeString(deterministicRandom()->randomInt(4, 256));
+	Standalone<StringRef> baseCipher = makeString(deterministicRandom()->randomInt(4, MAX_BASE_CIPHER_LEN + 1));
 	deterministicRandom()->randomBytes(mutateString(baseCipher), baseCipher.size());
 	return baseCipher;
 }
 
-Standalone<StringRef> encryptBaseCipher = getBaseCipher();
+const Standalone<StringRef> encryptBaseCipher = getBaseCipher();
 
 BlobGranuleCipherKeysCtx getCipherKeysCtx(Arena& arena) {
 	BlobGranuleCipherKeysCtx cipherKeysCtx;
+	const EncryptCipherKeyCheckValue cipherKCV =
+	    Sha256KCV().computeKCV(encryptBaseCipher.begin(), encryptBaseCipher.size());
 
 	cipherKeysCtx.textCipherKey.encryptDomainId = encryptDomainId;
 	cipherKeysCtx.textCipherKey.baseCipherId = encryptBaseCipherId;
+	cipherKeysCtx.textCipherKey.baseCipherKCV = cipherKCV;
 	cipherKeysCtx.textCipherKey.salt = encryptSalt;
 	cipherKeysCtx.textCipherKey.baseCipher = StringRef(arena, encryptBaseCipher);
 
 	cipherKeysCtx.headerCipherKey.encryptDomainId = SYSTEM_KEYSPACE_ENCRYPT_DOMAIN_ID;
 	cipherKeysCtx.headerCipherKey.baseCipherId = encryptBaseCipherId;
+	cipherKeysCtx.headerCipherKey.baseCipherKCV = cipherKCV;
 	cipherKeysCtx.headerCipherKey.salt = encryptSalt;
 	cipherKeysCtx.headerCipherKey.baseCipher = StringRef(arena, encryptBaseCipher);
 

--- a/fdbclient/include/fdbclient/BlobCipher.h
+++ b/fdbclient/include/fdbclient/BlobCipher.h
@@ -1007,6 +1007,13 @@ private:
 	Optional<Reference<BlobCipherKey>> headerCipherKeyOpt;
 	bool authTokensValidationDone;
 
+	// API is resposible to validate persisted EncryptionHeader sanity, it does following checks
+	// 1. Parse and validate EncryptionHeaderFlags (version compliant checks)
+	// 2. Parse and validate KCVs
+	// 3. Parse and validate auth-tokens if applicable.
+	//
+	// Routine is invoked for every decryption buffer request and is done transparently to the caller
+
 	void validateEncryptHeader(const uint8_t*,
 	                           const int,
 	                           const BlobCipherEncryptHeaderRef&,

--- a/fdbclient/include/fdbclient/BlobCipher.h
+++ b/fdbclient/include/fdbclient/BlobCipher.h
@@ -521,6 +521,13 @@ struct BlobCipherEncryptHeaderRef {
 	EncryptCipherDomainId getDomainId() const;
 	EncryptHeaderCipherKCVs getKCVs() const;
 
+	// API supports following validation:
+	// 1. Ensure input BlobCipherDetails (textDetails and/or headerDetails) matches with the input
+	// 2. Ensure persited KCV matches with the input values
+	// 3. Ensure input IV buffer matches with the persisted ones.
+	//
+	// Currently API is used by BlobGranule encryption where encryption key lookup based on persisted
+	// BlobGranuleCipherKeyCtx
 	void validateEncryptionHeaderDetails(const BlobCipherDetails& textCipherDetails,
 	                                     const BlobCipherDetails& headerCipherDetails,
 	                                     const EncryptHeaderCipherKCVs& kcvs,

--- a/fdbclient/include/fdbclient/BlobGranuleCommon.h
+++ b/fdbclient/include/fdbclient/BlobGranuleCommon.h
@@ -90,26 +90,40 @@ struct GranuleMaterializeStats {
 struct BlobGranuleCipherKeysMeta {
 	EncryptCipherDomainId textDomainId;
 	EncryptCipherBaseKeyId textBaseCipherId;
+	EncryptCipherKeyCheckValue textBaseCipherKCV;
 	EncryptCipherRandomSalt textSalt;
 	EncryptCipherDomainId headerDomainId;
 	EncryptCipherBaseKeyId headerBaseCipherId;
+	EncryptCipherKeyCheckValue headerBaseCipherKCV;
 	EncryptCipherRandomSalt headerSalt;
 	std::string ivStr;
 
 	BlobGranuleCipherKeysMeta() {}
 	BlobGranuleCipherKeysMeta(const EncryptCipherDomainId tDomainId,
 	                          const EncryptCipherBaseKeyId tBaseCipherId,
+	                          const EncryptCipherKeyCheckValue tBaseCipherKCV,
 	                          const EncryptCipherRandomSalt tSalt,
 	                          const EncryptCipherDomainId hDomainId,
 	                          const EncryptCipherBaseKeyId hBaseCipherId,
+	                          const EncryptCipherKeyCheckValue hBaseCipherKCV,
 	                          const EncryptCipherRandomSalt hSalt,
 	                          const std::string& iv)
-	  : textDomainId(tDomainId), textBaseCipherId(tBaseCipherId), textSalt(tSalt), headerDomainId(hDomainId),
-	    headerBaseCipherId(hBaseCipherId), headerSalt(hSalt), ivStr(iv) {}
+	  : textDomainId(tDomainId), textBaseCipherId(tBaseCipherId), textBaseCipherKCV(tBaseCipherKCV), textSalt(tSalt),
+	    headerDomainId(hDomainId), headerBaseCipherId(hBaseCipherId), headerBaseCipherKCV(hBaseCipherKCV),
+	    headerSalt(hSalt), ivStr(iv) {}
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, textDomainId, textBaseCipherId, textSalt, headerDomainId, headerBaseCipherId, headerSalt, ivStr);
+		serializer(ar,
+		           textDomainId,
+		           textBaseCipherId,
+		           textBaseCipherKCV,
+		           textSalt,
+		           headerDomainId,
+		           headerBaseCipherId,
+		           headerBaseCipherKCV,
+		           headerSalt,
+		           ivStr);
 	}
 };
 
@@ -119,6 +133,7 @@ struct BlobGranuleCipherKey {
 	constexpr static FileIdentifier file_identifier = 7274734;
 	EncryptCipherDomainId encryptDomainId;
 	EncryptCipherBaseKeyId baseCipherId;
+	EncryptCipherKeyCheckValue baseCipherKCV;
 	EncryptCipherRandomSalt salt;
 	StringRef baseCipher;
 
@@ -126,6 +141,7 @@ struct BlobGranuleCipherKey {
 		BlobGranuleCipherKey cipherKey;
 		cipherKey.encryptDomainId = keyRef->getDomainId();
 		cipherKey.baseCipherId = keyRef->getBaseCipherId();
+		cipherKey.baseCipherKCV = keyRef->getBaseCipherKCV();
 		cipherKey.salt = keyRef->getSalt();
 		cipherKey.baseCipher = makeString(keyRef->getBaseCipherLen(), arena);
 		memcpy(mutateString(cipherKey.baseCipher), keyRef->rawBaseCipher(), keyRef->getBaseCipherLen());
@@ -135,7 +151,7 @@ struct BlobGranuleCipherKey {
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, encryptDomainId, baseCipherId, salt, baseCipher);
+		serializer(ar, encryptDomainId, baseCipherId, baseCipherKCV, salt, baseCipher);
 	}
 };
 
@@ -150,9 +166,11 @@ struct BlobGranuleCipherKeysCtx {
 	static BlobGranuleCipherKeysMeta toCipherKeysMeta(const BlobGranuleCipherKeysCtx& ctx) {
 		return BlobGranuleCipherKeysMeta(ctx.textCipherKey.encryptDomainId,
 		                                 ctx.textCipherKey.baseCipherId,
+		                                 ctx.textCipherKey.baseCipherKCV,
 		                                 ctx.textCipherKey.salt,
 		                                 ctx.headerCipherKey.encryptDomainId,
 		                                 ctx.headerCipherKey.baseCipherId,
+		                                 ctx.headerCipherKey.baseCipherKCV,
 		                                 ctx.headerCipherKey.salt,
 		                                 ctx.ivRef.toString());
 	}

--- a/fdbclient/include/fdbclient/EncryptKeyProxyInterface.h
+++ b/fdbclient/include/fdbclient/EncryptKeyProxyInterface.h
@@ -103,20 +103,31 @@ struct EKPBaseCipherDetails {
 	int64_t encryptDomainId;
 	uint64_t baseCipherId;
 	Standalone<StringRef> baseCipherKey;
+	EncryptCipherKeyCheckValue baseCipherKCV;
 	int64_t refreshAt;
 	int64_t expireAt;
 
 	EKPBaseCipherDetails()
-	  : encryptDomainId(0), baseCipherId(0), baseCipherKey(Standalone<StringRef>()), refreshAt(0), expireAt(-1) {}
-	explicit EKPBaseCipherDetails(int64_t dId, uint64_t id, Standalone<StringRef> key)
-	  : encryptDomainId(dId), baseCipherId(id), baseCipherKey(key), refreshAt(std::numeric_limits<int64_t>::max()),
-	    expireAt(std::numeric_limits<int64_t>::max()) {}
-	explicit EKPBaseCipherDetails(int64_t dId, uint64_t id, Standalone<StringRef> key, int64_t refAt, int64_t expAt)
-	  : encryptDomainId(dId), baseCipherId(id), baseCipherKey(key), refreshAt(refAt), expireAt(expAt) {}
+	  : encryptDomainId(0), baseCipherId(0), baseCipherKey(Standalone<StringRef>()), baseCipherKCV(0), refreshAt(0),
+	    expireAt(-1) {}
+	explicit EKPBaseCipherDetails(int64_t dId,
+	                              uint64_t id,
+	                              Standalone<StringRef> key,
+	                              EncryptCipherKeyCheckValue cipherKCV)
+	  : encryptDomainId(dId), baseCipherId(id), baseCipherKey(key), baseCipherKCV(cipherKCV),
+	    refreshAt(std::numeric_limits<int64_t>::max()), expireAt(std::numeric_limits<int64_t>::max()) {}
+	explicit EKPBaseCipherDetails(int64_t dId,
+	                              uint64_t id,
+	                              Standalone<StringRef> key,
+	                              EncryptCipherKeyCheckValue cipherKCV,
+	                              int64_t refAt,
+	                              int64_t expAt)
+	  : encryptDomainId(dId), baseCipherId(id), baseCipherKey(key), baseCipherKCV(cipherKCV), refreshAt(refAt),
+	    expireAt(expAt) {}
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, encryptDomainId, baseCipherId, baseCipherKey, refreshAt, expireAt);
+		serializer(ar, encryptDomainId, baseCipherId, baseCipherKey, baseCipherKCV, refreshAt, expireAt);
 	}
 };
 

--- a/fdbclient/include/fdbclient/GetEncryptCipherKeys_impl.actor.h
+++ b/fdbclient/include/fdbclient/GetEncryptCipherKeys_impl.actor.h
@@ -135,6 +135,7 @@ Future<std::unordered_map<EncryptCipherDomainId, Reference<BlobCipherKey>>> _get
 					                                                                     details.baseCipherId,
 					                                                                     details.baseCipherKey.begin(),
 					                                                                     details.baseCipherKey.size(),
+					                                                                     details.baseCipherKCV,
 					                                                                     details.refreshAt,
 					                                                                     details.expireAt);
 					ASSERT(cipherKey.isValid());
@@ -270,6 +271,7 @@ Future<std::unordered_map<BlobCipherDetails, Reference<BlobCipherKey>>> _getEncr
 				                                                                     details.baseCipherId,
 				                                                                     itr->second.baseCipherKey.begin(),
 				                                                                     itr->second.baseCipherKey.size(),
+				                                                                     itr->second.baseCipherKCV,
 				                                                                     details.salt,
 				                                                                     itr->second.refreshAt,
 				                                                                     itr->second.expireAt);

--- a/fdbserver/EncryptKeyProxy.actor.cpp
+++ b/fdbserver/EncryptKeyProxy.actor.cpp
@@ -145,6 +145,8 @@ struct EncryptBaseCipherKey {
 	EncryptCipherDomainId domainId;
 	EncryptCipherBaseKeyId baseCipherId;
 	Standalone<StringRef> baseCipherKey;
+	// Key check value for the 'baseCipher'
+	EncryptCipherKeyCheckValue baseCipherKCV;
 	// Timestamp after which the cached CipherKey is eligible for KMS refresh
 	int64_t refreshAt;
 	// Timestamp after which the cached CipherKey 'should' be considered as 'expired'
@@ -158,13 +160,16 @@ struct EncryptBaseCipherKey {
 	// CipherKeys with the latest CipherKeys sometime soon in the future.
 	int64_t expireAt;
 
-	EncryptBaseCipherKey() : domainId(0), baseCipherId(0), baseCipherKey(StringRef()), refreshAt(0), expireAt(0) {}
+	EncryptBaseCipherKey()
+	  : domainId(0), baseCipherId(0), baseCipherKey(StringRef()), baseCipherKCV(0), refreshAt(0), expireAt(0) {}
 	explicit EncryptBaseCipherKey(EncryptCipherDomainId dId,
 	                              EncryptCipherBaseKeyId cipherId,
 	                              Standalone<StringRef> cipherKey,
+	                              EncryptCipherKeyCheckValue cipherKCV,
 	                              int64_t refAtTS,
 	                              int64_t expAtTS)
-	  : domainId(dId), baseCipherId(cipherId), baseCipherKey(cipherKey), refreshAt(refAtTS), expireAt(expAtTS) {}
+	  : domainId(dId), baseCipherId(cipherId), baseCipherKey(cipherKey), baseCipherKCV(cipherKCV), refreshAt(refAtTS),
+	    expireAt(expAtTS) {}
 
 	bool isValid() const {
 		int64_t currTS = (int64_t)now();
@@ -261,36 +266,48 @@ public:
 	void insertIntoBaseDomainIdCache(const EncryptCipherDomainId domainId,
 	                                 const EncryptCipherBaseKeyId baseCipherId,
 	                                 Standalone<StringRef> baseCipherKey,
+	                                 const EncryptCipherKeyCheckValue baseCipherKCV,
 	                                 int64_t refreshAtTS,
 	                                 int64_t expireAtTS) {
 		// Entries in domainId cache are eligible for periodic refreshes to support 'limiting lifetime of encryption
 		// key' support if enabled on external KMS solutions.
 
 		baseCipherDomainIdCache[domainId] =
-		    EncryptBaseCipherKey(domainId, baseCipherId, baseCipherKey, refreshAtTS, expireAtTS);
+		    EncryptBaseCipherKey(domainId, baseCipherId, baseCipherKey, baseCipherKCV, refreshAtTS, expireAtTS);
 
 		// Update cached the information indexed using baseCipherId
 		// Cache indexed by 'baseCipherId' need not refresh cipher, however, it still needs to abide by KMS governed
 		// CipherKey lifetime rules
 		insertIntoBaseCipherIdCache(
-		    domainId, baseCipherId, baseCipherKey, std::numeric_limits<int64_t>::max(), expireAtTS);
+		    domainId, baseCipherId, baseCipherKey, baseCipherKCV, std::numeric_limits<int64_t>::max(), expireAtTS);
 	}
 
 	void insertIntoBaseCipherIdCache(const EncryptCipherDomainId domainId,
 	                                 const EncryptCipherBaseKeyId baseCipherId,
 	                                 const Standalone<StringRef> baseCipherKey,
+	                                 const EncryptCipherKeyCheckValue baseCipherKCV,
 	                                 int64_t refreshAtTS,
 	                                 int64_t expireAtTS) {
 		// Given an cipherKey is immutable, it is OK to NOT expire cached information.
 		// TODO: Update cache to support LRU eviction policy to limit the total cache size.
-
+		const EncryptCipherKeyCheckValue computedKCV =
+		    Sha256KCV().computeKCV(baseCipherKey.begin(), baseCipherKey.size());
+		if (computedKCV != baseCipherKCV) {
+			TraceEvent(SevWarnAlways, "BlobCipherKeyInitBaseCipherKCVMismatch")
+			    .detail("DomId", domainId)
+			    .detail("BaseCipherId", baseCipherId)
+			    .detail("Computed", computedKCV)
+			    .detail("BaseCipherKCV", baseCipherKCV);
+			throw encrypt_key_check_value_mismatch();
+		}
 		EncryptBaseCipherDomainIdKeyIdCacheKey cacheKey = getBaseCipherDomainIdKeyIdCacheKey(domainId, baseCipherId);
 		baseCipherDomainIdKeyIdCache[cacheKey] =
-		    EncryptBaseCipherKey(domainId, baseCipherId, baseCipherKey, refreshAtTS, expireAtTS);
+		    EncryptBaseCipherKey(domainId, baseCipherId, baseCipherKey, baseCipherKCV, refreshAtTS, expireAtTS);
 		TraceEvent("InsertIntoBaseCipherIdCache")
 		    .detail("DomId", domainId)
 		    .detail("BaseCipherId", baseCipherId)
-		    .detail("BaseCipherLen", baseCipherKey.size());
+		    .detail("BaseCipherLen", baseCipherKey.size())
+		    .detail("BaseCipherKCV", baseCipherKCV);
 	}
 
 	void insertIntoBlobMetadataCache(const BlobMetadataDomainId domainId,
@@ -364,7 +381,7 @@ ACTOR Future<Void> getCipherKeysByBaseCipherKeyIds(Reference<EncryptKeyProxyData
 		const auto itr = ekpProxyData->baseCipherDomainIdKeyIdCache.find(cacheKey);
 		if (itr != ekpProxyData->baseCipherDomainIdKeyIdCache.end() && itr->second.isValid()) {
 			keyIdsReply.baseCipherDetails.emplace_back(
-			    itr->second.domainId, itr->second.baseCipherId, itr->second.baseCipherKey);
+			    itr->second.domainId, itr->second.baseCipherId, itr->second.baseCipherKey, itr->second.baseCipherKCV);
 			numHits++;
 
 			if (dbgTrace.present()) {
@@ -396,7 +413,8 @@ ACTOR Future<Void> getCipherKeysByBaseCipherKeyIds(Reference<EncryptKeyProxyData
 			ekpProxyData->kmsLookupByIdsReqLatency.addMeasurement(now() - startTime);
 
 			for (const auto& item : keysByIdsRep.cipherKeyDetails) {
-				keyIdsReply.baseCipherDetails.emplace_back(item.encryptDomainId, item.encryptKeyId, item.encryptKey);
+				keyIdsReply.baseCipherDetails.emplace_back(
+				    item.encryptDomainId, item.encryptKeyId, item.encryptKey, item.encryptKCV);
 			}
 
 			// Record the fetched cipher details to the local cache for the future references
@@ -418,6 +436,7 @@ ACTOR Future<Void> getCipherKeysByBaseCipherKeyIds(Reference<EncryptKeyProxyData
 				ekpProxyData->insertIntoBaseCipherIdCache(item.encryptDomainId,
 				                                          item.encryptKeyId,
 				                                          item.encryptKey,
+				                                          item.encryptKCV,
 				                                          validityTS.refreshAtTS,
 				                                          validityTS.expAtTS);
 
@@ -491,6 +510,7 @@ ACTOR Future<Void> getLatestCipherKeys(Reference<EncryptKeyProxyData> ekpProxyDa
 			latestCipherReply.baseCipherDetails.emplace_back(domainId,
 			                                                 itr->second.baseCipherId,
 			                                                 itr->second.baseCipherKey,
+			                                                 itr->second.baseCipherKCV,
 			                                                 itr->second.refreshAt,
 			                                                 itr->second.expireAt);
 			numHits++;
@@ -533,6 +553,7 @@ ACTOR Future<Void> getLatestCipherKeys(Reference<EncryptKeyProxyData> ekpProxyDa
 				latestCipherReply.baseCipherDetails.emplace_back(item.encryptDomainId,
 				                                                 item.encryptKeyId,
 				                                                 item.encryptKey,
+				                                                 item.encryptKCV,
 				                                                 validityTS.refreshAtTS,
 				                                                 validityTS.expAtTS);
 
@@ -546,6 +567,7 @@ ACTOR Future<Void> getLatestCipherKeys(Reference<EncryptKeyProxyData> ekpProxyDa
 				ekpProxyData->insertIntoBaseDomainIdCache(item.encryptDomainId,
 				                                          item.encryptKeyId,
 				                                          item.encryptKey,
+				                                          item.encryptKCV,
 				                                          validityTS.refreshAtTS,
 				                                          validityTS.expAtTS);
 
@@ -646,8 +668,12 @@ ACTOR Future<Void> refreshEncryptionKeysImpl(Reference<EncryptKeyProxyData> ekpP
 			}
 
 			CipherKeyValidityTS validityTS = getCipherKeyValidityTS(item.refreshAfterSec, item.expireAfterSec);
-			ekpProxyData->insertIntoBaseDomainIdCache(
-			    item.encryptDomainId, item.encryptKeyId, item.encryptKey, validityTS.refreshAtTS, validityTS.expAtTS);
+			ekpProxyData->insertIntoBaseDomainIdCache(item.encryptDomainId,
+			                                          item.encryptKeyId,
+			                                          item.encryptKey,
+			                                          item.encryptKCV,
+			                                          validityTS.refreshAtTS,
+			                                          validityTS.expAtTS);
 			// {encryptDomainId, baseCipherId} forms a unique tuple across encryption domains
 			t.detail(getEncryptDbgTraceKeyWithTS(ENCRYPT_DBG_TRACE_INSERT_PREFIX,
 			                                     item.encryptDomainId,

--- a/fdbserver/RESTKmsConnector.actor.cpp
+++ b/fdbserver/RESTKmsConnector.actor.cpp
@@ -460,6 +460,14 @@ Standalone<VectorRef<EncryptCipherKeyDetailsRef>> parseEncryptCipherResponse(Ref
 		//
 		// Approach compute KCV after reading it from the network buffer, HTTP checksum protects against potential
 		// on-wire corruption
+		if (cipher.size() > MAX_BASE_CIPHER_LEN) {
+			// HMAC_SHA digest generation accepts upto MAX_BASE_CIPHER_LEN key-buffer, longer keys are truncated and
+			// weakens the security guarantees.
+			TraceEvent(SevWarnAlways, "RESTKmsConnectorMaxBaseCipherKeyLimit")
+			    .detail("MaxAllowed", MAX_BASE_CIPHER_LEN)
+			    .detail("BaseCipherLen", cipher.size());
+			throw rest_max_base_cipher_len();
+		}
 
 		EncryptCipherKeyCheckValue cipherKCV = Sha256KCV().computeKCV(cipher.begin(), cipher.size());
 

--- a/fdbserver/RESTKmsConnector.actor.cpp
+++ b/fdbserver/RESTKmsConnector.actor.cpp
@@ -452,11 +452,23 @@ Standalone<VectorRef<EncryptCipherKeyDetailsRef>> parseEncryptCipherResponse(Ref
 		EncryptCipherBaseKeyId baseCipherId = cipherDetail[BASE_CIPHER_ID_TAG].GetUint64();
 		StringRef cipher = StringRef(cipherKey.get(), cipherKeyLen);
 
+		// https://en.wikipedia.org/wiki/Key_checksum_value
+		// Key Check Value (KCV) is the checksum of a cryptographic key, it is used to validate integrity of the
+		// 'baseCipher' key supplied by the external KMS. The checksum computed is eventually persisted as part of
+		// EncryptionHeader and assists in following scenarios: a) 'baseCipher' corruption happen external to FDB b)
+		// 'baseCipher' corruption within FDB processes
+		//
+		// Approach compute KCV after reading it from the network buffer, HTTP checksum protects against potential
+		// on-wire corruption
+
+		EncryptCipherKeyCheckValue cipherKCV = Sha256KCV().computeKCV(cipher.begin(), cipher.size());
+
 		if (FLOW_KNOBS->REST_LOG_LEVEL >= RESTLogSeverity::DEBUG) {
 			TraceEvent event("RESTParseEncryptCipherResponse", ctx->uid);
 			event.detail("DomainId", domainId);
 			event.detail("BaseCipherId", baseCipherId);
 			event.detail("BaseCipherLen", cipher.size());
+			event.detail("BaseCipherKCV", cipherKCV);
 			if (refreshAfterSec.present()) {
 				event.detail("RefreshAt", refreshAfterSec.get());
 			}
@@ -465,7 +477,8 @@ Standalone<VectorRef<EncryptCipherKeyDetailsRef>> parseEncryptCipherResponse(Ref
 			}
 		}
 
-		result.emplace_back_deep(result.arena(), domainId, baseCipherId, cipher, refreshAfterSec, expireAfterSec);
+		result.emplace_back_deep(
+		    result.arena(), domainId, baseCipherId, cipher, cipherKCV, refreshAfterSec, expireAfterSec);
 	}
 
 	checkDocForNewKmsUrls(ctx, resp, doc);

--- a/fdbserver/SimKmsConnector.actor.cpp
+++ b/fdbserver/SimKmsConnector.actor.cpp
@@ -61,11 +61,16 @@ struct SimEncryptKeyCtx {
 	EncryptCipherBaseKeyId id;
 	SimEncryptKey key;
 	int keyLen;
+	EncryptCipherKeyCheckValue kcv;
 
 	explicit SimEncryptKeyCtx(EncryptCipherBaseKeyId kId, const char* data, const int dataLen)
 	  : id(kId), key(data, dataLen), keyLen(dataLen) {
+		kcv = Sha256KCV().computeKCV((const uint8_t*)data, dataLen);
 		if (DEBUG_SIM_KEY_CIPHER) {
-			TraceEvent(SevDebug, "SimKmsKeyCtxInit").detail("BaseCipherId", kId).detail("BaseCipherLen", dataLen);
+			TraceEvent(SevDebug, "SimKmsKeyCtxInit")
+			    .detail("BaseCipherId", kId)
+			    .detail("BaseCipherLen", dataLen)
+			    .detail("KCV", kcv);
 		}
 	}
 
@@ -74,7 +79,7 @@ struct SimEncryptKeyCtx {
 
 		int ret = AES_256_KEY_LENGTH;
 		if ((id % 2) == 0) {
-			ret += (id % AES_256_KEY_LENGTH);
+			ret += (id % (MAX_BASE_CIPHER_LEN - AES_256_KEY_LENGTH));
 		}
 		CODE_PROBE(ret == AES_256_KEY_LENGTH, "BaseCipherKeyLen AES_256_KEY_LENGTH");
 		CODE_PROBE(ret != AES_256_KEY_LENGTH, "BaseCipherKeyLen variable length");
@@ -164,8 +169,13 @@ ACTOR Future<Void> ekLookupByIds(Reference<SimKmsConnectorContext> ctx,
 		if (itr != ctx->simEncryptKeyStore.end()) {
 			// TODO: Relax assert if EKP APIs are updated to make 'domain_id' optional for encryption keys point lookups
 			ASSERT(item.domainId.present());
-			rep.cipherKeyDetails.emplace_back_deep(
-			    rep.arena, item.domainId.get(), itr->first, StringRef(itr->second.get()->key), refAtTS, expAtTS);
+			rep.cipherKeyDetails.emplace_back_deep(rep.arena,
+			                                       item.domainId.get(),
+			                                       itr->first,
+			                                       StringRef(itr->second.get()->key),
+			                                       itr->second->kcv,
+			                                       refAtTS,
+			                                       expAtTS);
 
 			if (dbgKIdTrace.present()) {
 				// {encryptDomainId, baseCipherId} forms a unique tuple across encryption domains
@@ -178,7 +188,8 @@ ACTOR Future<Void> ekLookupByIds(Reference<SimKmsConnectorContext> ctx,
 				    .detail("DomId", item.domainId.get())
 				    .detail("BaseCipherId", item.baseCipherId)
 				    .detail("BaseCipherLen", itr->second->keyLen)
-				    .detail("BaseCipherKeyLen", itr->second->keyLen);
+				    .detail("BaseCipherKeyLen", itr->second->keyLen)
+				    .detail("BaseCipherKCV", itr->second->kcv);
 			}
 		} else {
 			TraceEvent("SimKmsEKLookupByIdsKeyNotFound")
@@ -226,7 +237,7 @@ ACTOR Future<Void> ekLookupByDomainIds(Reference<SimKmsConnectorContext> ctx,
 		const auto& itr = ctx->simEncryptKeyStore.find(keyId);
 		if (itr != ctx->simEncryptKeyStore.end()) {
 			rep.cipherKeyDetails.emplace_back_deep(
-			    req.arena, domainId, keyId, StringRef(itr->second.get()->key), refAtTS, expAtTS);
+			    req.arena, domainId, keyId, StringRef(itr->second.get()->key), itr->second->kcv, refAtTS, expAtTS);
 			if (dbgDIdTrace.present()) {
 				// {encryptId, baseCipherId} forms a unique tuple across encryption domains
 				dbgDIdTrace.get().detail(getEncryptDbgTraceKey(ENCRYPT_DBG_TRACE_RESULT_PREFIX, domainId, keyId), "");
@@ -236,7 +247,8 @@ ACTOR Future<Void> ekLookupByDomainIds(Reference<SimKmsConnectorContext> ctx,
 				    .detail("DomId", domainId)
 				    .detail("BaseCipherId", itr->second->id)
 				    .detail("BaseCipherLen", itr->second->keyLen)
-				    .detail("BaseCipherKeyLen", itr->second->keyLen);
+				    .detail("BaseCipherKeyLen", itr->second->keyLen)
+				    .detail("BaseCipherKCV", itr->second->kcv);
 			}
 
 		} else {

--- a/fdbserver/include/fdbserver/IPageEncryptionKeyProvider.actor.h
+++ b/fdbserver/include/fdbserver/IPageEncryptionKeyProvider.actor.h
@@ -270,10 +270,12 @@ private:
 		    EncryptAuthTokenAlgo::ENCRYPT_HEADER_AUTH_TOKEN_ALGO_HMAC_SHA,
 		    AUTH_TOKEN_HMAC_SHA_SIZE);
 		ASSERT_EQ(AUTH_TOKEN_HMAC_SHA_SIZE, AES_256_KEY_LENGTH);
+		const EncryptCipherKeyCheckValue kcv = Sha256KCV().computeKCV(&digest[0], AES_256_KEY_LENGTH);
 		return makeReference<BlobCipherKey>(cipherDetails.encryptDomainId,
 		                                    cipherDetails.baseCipherId,
 		                                    &digest[0],
 		                                    AES_256_KEY_LENGTH,
+		                                    kcv,
 		                                    cipherDetails.salt,
 		                                    std::numeric_limits<int64_t>::max() /* refreshAt */,
 		                                    std::numeric_limits<int64_t>::max() /* expireAt */);
@@ -294,6 +296,7 @@ private:
 		                                    cipherId,
 		                                    cipherKeys[cipherId - 1]->rawBaseCipher(),
 		                                    AES_256_KEY_LENGTH,
+		                                    cipherKeys[cipherId - 1]->getBaseCipherKCV(),
 		                                    cipherKeys[cipherId - 1]->getSalt(),
 		                                    std::numeric_limits<int64_t>::max() /* refreshAt */,
 		                                    std::numeric_limits<int64_t>::max() /* expireAt */);

--- a/fdbserver/include/fdbserver/KmsConnectorInterface.h
+++ b/fdbserver/include/fdbserver/KmsConnectorInterface.h
@@ -72,6 +72,7 @@ struct EncryptCipherKeyDetailsRef {
 	EncryptCipherDomainId encryptDomainId;
 	EncryptCipherBaseKeyId encryptKeyId;
 	StringRef encryptKey;
+	EncryptCipherKeyCheckValue encryptKCV;
 	Optional<int64_t> refreshAfterSec;
 	Optional<int64_t> expireAfterSec;
 
@@ -81,26 +82,28 @@ struct EncryptCipherKeyDetailsRef {
 	explicit EncryptCipherKeyDetailsRef(Arena& arena,
 	                                    EncryptCipherDomainId dId,
 	                                    EncryptCipherBaseKeyId keyId,
-	                                    StringRef key)
-	  : encryptDomainId(dId), encryptKeyId(keyId), encryptKey(StringRef(arena, key)),
+	                                    StringRef key,
+	                                    EncryptCipherKeyCheckValue keyKCV)
+	  : encryptDomainId(dId), encryptKeyId(keyId), encryptKey(StringRef(arena, key)), encryptKCV(keyKCV),
 	    refreshAfterSec(Optional<int64_t>()), expireAfterSec(Optional<int64_t>()) {}
 	explicit EncryptCipherKeyDetailsRef(Arena& arena,
 	                                    EncryptCipherDomainId dId,
 	                                    EncryptCipherBaseKeyId keyId,
 	                                    StringRef key,
+	                                    EncryptCipherKeyCheckValue keyKCV,
 	                                    Optional<int64_t> refAfterSec,
 	                                    Optional<int64_t> expAfterSec)
-	  : encryptDomainId(dId), encryptKeyId(keyId), encryptKey(StringRef(arena, key)), refreshAfterSec(refAfterSec),
-	    expireAfterSec(expAfterSec) {}
+	  : encryptDomainId(dId), encryptKeyId(keyId), encryptKey(StringRef(arena, key)), encryptKCV(keyKCV),
+	    refreshAfterSec(refAfterSec), expireAfterSec(expAfterSec) {}
 
 	bool operator==(const EncryptCipherKeyDetailsRef& toCompare) {
 		return encryptDomainId == toCompare.encryptDomainId && encryptKeyId == toCompare.encryptKeyId &&
-		       encryptKey.compare(toCompare.encryptKey) == 0;
+		       encryptKey.compare(toCompare.encryptKey) == 0 && encryptKCV == toCompare.encryptKCV;
 	}
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, encryptDomainId, encryptKeyId, encryptKey, refreshAfterSec, expireAfterSec);
+		serializer(ar, encryptDomainId, encryptKeyId, encryptKey, encryptKCV, refreshAfterSec, expireAfterSec);
 	}
 };
 

--- a/flow/include/flow/EncryptUtils.h
+++ b/flow/include/flow/EncryptUtils.h
@@ -27,6 +27,7 @@
 
 #include <cstdint>
 #include <limits>
+#include <openssl/evp.h>
 #include <string>
 #include <string_view>
 #include <unordered_set>
@@ -40,6 +41,9 @@ constexpr const int AUTH_TOKEN_MAX_SIZE = AUTH_TOKEN_HMAC_SHA_SIZE;
 using EncryptCipherDomainId = int64_t;
 using EncryptCipherBaseKeyId = uint64_t;
 using EncryptCipherRandomSalt = uint64_t;
+using EncryptCipherKeyCheckValue = uint32_t;
+
+constexpr const int MAX_BASE_CIPHER_LEN = EVP_MAX_KEY_LENGTH - sizeof(EncryptCipherRandomSalt);
 
 constexpr const EncryptCipherDomainId INVALID_ENCRYPT_DOMAIN_ID = -1;
 constexpr const EncryptCipherDomainId SYSTEM_KEYSPACE_ENCRYPT_DOMAIN_ID = -2;

--- a/flow/include/flow/error_definitions.h
+++ b/flow/include/flow/error_definitions.h
@@ -171,6 +171,7 @@ ERROR( rest_connectpool_key_not_found, 1528, "ConnectKey not found in connection
 ERROR( lock_file_failure, 1529, "Unable to lock the file")
 ERROR( rest_unsupported_protocol, 1530, "Unsupported REST protocol")
 ERROR( rest_malformed_response, 1531, "Malformed REST response")
+ERROR( rest_max_base_cipher_len, 1532, "Max BaseCipher length violation")
 
 
 // 2xxx Attempt (presumably by a _client_) to do something illegal.  If an error is known to
@@ -375,6 +376,7 @@ ERROR( encrypt_invalid_kms_config, 2708, "Invalid encryption/kms configuration: 
 ERROR( encrypt_unsupported, 2709, "Encryption not supported" )
 ERROR( encrypt_mode_mismatch, 2710, "Encryption mode mismatch with configuration")
 ERROR( encrypt_key_check_value_mismatch, 2711, "Encryption key-check-value mismatch")
+ERROR( encrypt_max_base_cipher_len, 2712, "Max Base Cipher buffer length violation")
 
 // 4xxx Internal errors (those that should be generated only by bugs) are decimal 4xxx
 ERROR( unknown_error, 4000, "An unknown error occurred" )  // C++ exception not of type Error

--- a/flow/include/flow/error_definitions.h
+++ b/flow/include/flow/error_definitions.h
@@ -374,6 +374,7 @@ ERROR( encrypt_keys_fetch_failed, 2707, "Encryption keys fetch from external KMS
 ERROR( encrypt_invalid_kms_config, 2708, "Invalid encryption/kms configuration: discovery-url, validation-token, endpoint etc." )
 ERROR( encrypt_unsupported, 2709, "Encryption not supported" )
 ERROR( encrypt_mode_mismatch, 2710, "Encryption mode mismatch with configuration")
+ERROR( encrypt_key_check_value_mismatch, 2711, "Encryption key-check-value mismatch")
 
 // 4xxx Internal errors (those that should be generated only by bugs) are decimal 4xxx
 ERROR( unknown_error, 4000, "An unknown error occurred" )  // C++ exception not of type Error

--- a/flow/include/flow/error_definitions.h
+++ b/flow/include/flow/error_definitions.h
@@ -376,7 +376,7 @@ ERROR( encrypt_invalid_kms_config, 2708, "Invalid encryption/kms configuration: 
 ERROR( encrypt_unsupported, 2709, "Encryption not supported" )
 ERROR( encrypt_mode_mismatch, 2710, "Encryption mode mismatch with configuration")
 ERROR( encrypt_key_check_value_mismatch, 2711, "Encryption key-check-value mismatch")
-ERROR( encrypt_max_base_cipher_len, 2712, "Max Base Cipher buffer length violation")
+ERROR( encrypt_max_base_cipher_len, 2712, "Max BaseCipher buffer length violation")
 
 // 4xxx Internal errors (those that should be generated only by bugs) are decimal 4xxx
 ERROR( unknown_error, 4000, "An unknown error occurred" )  // C++ exception not of type Error

--- a/flowbench/BenchEncrypt.cpp
+++ b/flowbench/BenchEncrypt.cpp
@@ -99,7 +99,7 @@ public:
 	           const EncryptCipherBaseKeyId& kId,
 	           const int64_t rAt,
 	           const int64_t eAt)
-	  : domainId(dId), len(deterministicRandom()->randomInt(4, MAX_BASE_CIPHER_LEN)), keyId(kId),
+	  : domainId(dId), len(deterministicRandom()->randomInt(4, MAX_BASE_CIPHER_LEN + 1)), keyId(kId),
 	    key(std::make_unique<uint8_t[]>(len)), refreshAt(rAt), expireAt(eAt) {
 		deterministicRandom()->randomBytes(key.get(), len);
 		kcv = Sha256KCV().computeKCV(key.get(), len);

--- a/flowbench/BenchEncrypt.cpp
+++ b/flowbench/BenchEncrypt.cpp
@@ -21,6 +21,7 @@
 #include "benchmark/benchmark.h"
 
 #include "fdbclient/BlobCipher.h"
+#include "flow/EncryptUtils.h"
 #include "flow/StreamCipher.h"
 #include "flowbench/GlobalData.h"
 
@@ -79,6 +80,8 @@ static void bench_decrypt(benchmark::State& state) {
 BENCHMARK(bench_encrypt)->Ranges({ { 1 << 12, 1 << 20 }, { 1, 1 << 12 } });
 BENCHMARK(bench_decrypt)->Ranges({ { 1 << 12, 1 << 20 }, { 1, 1 << 12 } });
 
+// DEPRECATED -- Use EncryptionOps for benchmarking purposes.
+
 // blob_chipher* benchmarks are following the encrypt and decrypt unittests from BlobCipher.cpp
 // Construct a dummy External Key Manager representation and populate with some keys
 class BaseCipher : public ReferenceCounted<BaseCipher>, NonCopyable {
@@ -86,6 +89,7 @@ public:
 	EncryptCipherDomainId domainId;
 	int len;
 	EncryptCipherBaseKeyId keyId;
+	EncryptCipherKeyCheckValue kcv;
 	std::unique_ptr<uint8_t[]> key;
 	int64_t refreshAt;
 	int64_t expireAt;
@@ -95,9 +99,10 @@ public:
 	           const EncryptCipherBaseKeyId& kId,
 	           const int64_t rAt,
 	           const int64_t eAt)
-	  : domainId(dId), len(deterministicRandom()->randomInt(AES_256_KEY_LENGTH / 2, AES_256_KEY_LENGTH + 1)),
-	    keyId(kId), key(std::make_unique<uint8_t[]>(len)), refreshAt(rAt), expireAt(eAt) {
+	  : domainId(dId), len(deterministicRandom()->randomInt(4, MAX_BASE_CIPHER_LEN)), keyId(kId),
+	    key(std::make_unique<uint8_t[]>(len)), refreshAt(rAt), expireAt(eAt) {
 		deterministicRandom()->randomBytes(key.get(), len);
+		kcv = Sha256KCV().computeKCV(key.get(), len);
 	}
 };
 
@@ -131,6 +136,7 @@ void static SetupEncryptCipher() {
 			                                baseCipher->keyId,
 			                                baseCipher->key.get(),
 			                                baseCipher->len,
+			                                baseCipher->kcv,
 			                                baseCipher->refreshAt,
 			                                baseCipher->expireAt);
 			Reference<BlobCipherKey> fetchedKey = cipherKeyCache->getLatestCipherKey(baseCipher->domainId);


### PR DESCRIPTION
Description

Key Check Value (KCV) is a checksum of cryptographic encryption key used to validate encryption keys's integrity. FDB Encryption at-rest relies on external KMS to supply encryption keys.

Patch proposes following major changes:
1. Implement Sha256 based KCV implementation to protect against 'baseCipher' corruption in two possible scenarios:
 a) potential corruption external to FDB
 b) potential corruption within FDB processes.
2. Scheme persists computed KCV token in block encryption header, which then gets validated as part of header validation during decryption.
3. FDB Encryption key derivation uses HMAC_SHA256 digest generation scheme, which allows max 64 bytes of 'cipher buffer', patch add required check to ensure 'baseCipher' length are within bounds. OpenSSL HMAC underlying call ignores extra length if supplied, however, it weakens the security guarantees, hence, disallowed.

Testing

devRunCorrectness - multiple 500K runs
Valgrind & Asan - BlobCipherUnit, RESTKMSUnit, BlobGranuleCorrectness*, EncryptionOps, EncryptKeyProxyTest

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
