### PR TITLE
Remove unnecessary padding for encrypt/decrypt

### DIFF
--- a/fdbclient/BlobCipher.cpp
+++ b/fdbclient/BlobCipher.cpp
@@ -1028,8 +1028,7 @@ StringRef EncryptBlobCipherAes265Ctr::encrypt(const uint8_t* plaintext,
 		startTime = timer_monotonic();
 	}
 
-	const int allocSize = plaintextLen + AES_BLOCK_SIZE;
-	StringRef encryptBuf = makeString(allocSize, arena);
+	StringRef encryptBuf = makeString(plaintextLen, arena);
 	uint8_t* ciphertext = mutateString(encryptBuf);
 
 	int bytes{ 0 };
@@ -1040,17 +1039,17 @@ StringRef EncryptBlobCipherAes265Ctr::encrypt(const uint8_t* plaintext,
 		throw encrypt_ops_error();
 	}
 
-	int finalBytes{ 0 };
-	if (EVP_EncryptFinal_ex(ctx, ciphertext + bytes, &finalBytes) != 1) {
-		TraceEvent(SevWarn, "BlobCipherEncryptFinalFailed")
-		    .detail("BaseCipherId", textCipherKey->getBaseCipherId())
-		    .detail("EncryptDomainId", textCipherKey->getDomainId());
-		throw encrypt_ops_error();
-	}
-	if ((bytes + finalBytes) != plaintextLen) {
+	if (bytes != plaintextLen) {
 		TraceEvent(SevWarn, "BlobCipherEncryptUnexpectedCipherLen")
 		    .detail("PlaintextLen", plaintextLen)
-		    .detail("EncryptedBufLen", bytes + finalBytes);
+		    .detail("EncryptedBufLen", bytes);
+		throw encrypt_ops_error();
+	}
+
+	if (EVP_CIPHER_CTX_reset(ctx) != 1) {
+		TraceEvent(SevWarn, "BlobCipherInplaceEncryptCTXResetFailed")
+		    .detail("BaseCipherId", textCipherKey->getBaseCipherId())
+		    .detail("EncryptDomainId", textCipherKey->getDomainId());
 		throw encrypt_ops_error();
 	}
 
@@ -1068,7 +1067,6 @@ StringRef EncryptBlobCipherAes265Ctr::encrypt(const uint8_t* plaintext,
 	CODE_PROBE(authTokenAlgo == EncryptAuthTokenAlgo::ENCRYPT_HEADER_AUTH_TOKEN_ALGO_AES_CMAC,
 	           "ConfigurableEncryption: Encryption with AES_CMAC Auth token generation");
 
-	// discard the extra buffer allocated to account for AES_BLOCK_SIZE encryption assist
 	return encryptBuf.substr(0, plaintextLen);
 }
 
@@ -1131,9 +1129,7 @@ Reference<EncryptBuf> EncryptBlobCipherAes265Ctr::encrypt(const uint8_t* plainte
 
 	// Alloc buffer computation accounts for 'header authentication' generation scheme. If single-auth-token needs
 	// to be generated, allocate buffer sufficient to append header to the cipherText optimizing memcpy cost.
-
-	const int allocSize = plaintextLen + AES_BLOCK_SIZE;
-	Reference<EncryptBuf> encryptBuf = makeReference<EncryptBuf>(allocSize, arena);
+	Reference<EncryptBuf> encryptBuf = makeReference<EncryptBuf>(plaintextLen, arena);
 	uint8_t* ciphertext = encryptBuf->begin();
 
 	int bytes{ 0 };
@@ -1144,18 +1140,17 @@ Reference<EncryptBuf> EncryptBlobCipherAes265Ctr::encrypt(const uint8_t* plainte
 		throw encrypt_ops_error();
 	}
 
-	int finalBytes{ 0 };
-	if (EVP_EncryptFinal_ex(ctx, ciphertext + bytes, &finalBytes) != 1) {
-		TraceEvent(SevWarn, "BlobCipherEncryptFinalFailed")
-		    .detail("BaseCipherId", textCipherKey->getBaseCipherId())
-		    .detail("EncryptDomainId", textCipherKey->getDomainId());
+	if (bytes != plaintextLen) {
+		TraceEvent(SevWarn, "BlobCipherEncryptUnexpectedCipherLen")
+		    .detail("PlaintextLen", plaintextLen)
+		    .detail("EncryptedBufLen", bytes);
 		throw encrypt_ops_error();
 	}
 
-	if ((bytes + finalBytes) != plaintextLen) {
-		TraceEvent(SevWarn, "BlobCipherEncryptUnexpectedCipherLen")
-		    .detail("PlaintextLen", plaintextLen)
-		    .detail("EncryptedBufLen", bytes + finalBytes);
+	if (EVP_CIPHER_CTX_reset(ctx) != 1) {
+		TraceEvent(SevWarn, "BlobCipherEncryptResetFailed")
+		    .detail("BaseCipherId", textCipherKey->getBaseCipherId())
+		    .detail("EncryptDomainId", textCipherKey->getDomainId());
 		throw encrypt_ops_error();
 	}
 
@@ -1387,8 +1382,7 @@ StringRef DecryptBlobCipherAes256Ctr::decrypt(const uint8_t* ciphertext,
 	EncryptAuthTokenAlgo authTokenAlgo;
 	validateEncryptHeader(ciphertext, ciphertextLen, headerRef, &authTokenMode, &authTokenAlgo);
 
-	const int allocSize = ciphertextLen + AES_BLOCK_SIZE;
-	StringRef decrypted = makeString(allocSize, arena);
+	StringRef decrypted = makeString(ciphertextLen, arena);
 
 	uint8_t* plaintext = mutateString(decrypted);
 	int bytesDecrypted{ 0 };
@@ -1399,18 +1393,17 @@ StringRef DecryptBlobCipherAes256Ctr::decrypt(const uint8_t* ciphertext,
 		throw encrypt_ops_error();
 	}
 
-	int finalBlobBytes{ 0 };
-	if (EVP_DecryptFinal_ex(ctx, plaintext + bytesDecrypted, &finalBlobBytes) <= 0) {
-		TraceEvent(SevWarn, "BlobCipherDecryptFinalFailed")
-		    .detail("BaseCipherId", textCipherKey->getBaseCipherId())
-		    .detail("EncryptDomainId", textCipherKey->getDomainId());
+	if (bytesDecrypted != ciphertextLen) {
+		TraceEvent(SevWarn, "BlobCipherDecryptUnexpectedPlaintextLen")
+		    .detail("CiphertextLen", ciphertextLen)
+		    .detail("DecryptedBufLen", bytesDecrypted);
 		throw encrypt_ops_error();
 	}
 
-	if ((bytesDecrypted + finalBlobBytes) != ciphertextLen) {
-		TraceEvent(SevWarn, "BlobCipherEncryptUnexpectedPlaintextLen")
-		    .detail("CiphertextLen", ciphertextLen)
-		    .detail("DecryptedBufLen", bytesDecrypted + finalBlobBytes);
+	if (EVP_CIPHER_CTX_reset(ctx) != 1) {
+		TraceEvent(SevWarn, "BlobCipherDecryptCTXResetFailed")
+		    .detail("BaseCipherId", textCipherKey->getBaseCipherId())
+		    .detail("EncryptDomainId", textCipherKey->getDomainId());
 		throw encrypt_ops_error();
 	}
 
@@ -1425,7 +1418,6 @@ StringRef DecryptBlobCipherAes256Ctr::decrypt(const uint8_t* ciphertext,
 	CODE_PROBE(authTokenAlgo == EncryptAuthTokenAlgo::ENCRYPT_HEADER_AUTH_TOKEN_ALGO_AES_CMAC,
 	           "ConfigurableEncryption: Decryption with AES_CMAC Auth token generation");
 
-	// discard the extra buffer allocated to account AES_BLOCK_SIZE decryption assist
 	return decrypted.substr(0, ciphertextLen);
 }
 
@@ -1514,8 +1506,7 @@ Reference<EncryptBuf> DecryptBlobCipherAes256Ctr::decrypt(const uint8_t* ciphert
 		throw encrypt_ops_error();
 	}
 
-	const int allocSize = ciphertextLen + AES_BLOCK_SIZE;
-	Reference<EncryptBuf> decrypted = makeReference<EncryptBuf>(allocSize, arena);
+	Reference<EncryptBuf> decrypted = makeReference<EncryptBuf>(ciphertextLen, arena);
 
 	if (header.flags.authTokenMode != EncryptAuthTokenMode::ENCRYPT_HEADER_AUTH_TOKEN_MODE_NONE) {
 		verifyAuthTokens(ciphertext, ciphertextLen, header);
@@ -1531,18 +1522,17 @@ Reference<EncryptBuf> DecryptBlobCipherAes256Ctr::decrypt(const uint8_t* ciphert
 		throw encrypt_ops_error();
 	}
 
-	int finalBlobBytes{ 0 };
-	if (EVP_DecryptFinal_ex(ctx, plaintext + bytesDecrypted, &finalBlobBytes) <= 0) {
-		TraceEvent(SevWarn, "BlobCipherDecryptFinalFailed")
-		    .detail("BaseCipherId", header.cipherTextDetails.baseCipherId)
-		    .detail("EncryptDomainId", header.cipherTextDetails.encryptDomainId);
+	if (bytesDecrypted != ciphertextLen) {
+		TraceEvent(SevWarn, "BlobCipherDecryptUnexpectedPlaintextLen")
+		    .detail("CiphertextLen", ciphertextLen)
+		    .detail("DecryptedBufLen", bytesDecrypted);
 		throw encrypt_ops_error();
 	}
 
-	if ((bytesDecrypted + finalBlobBytes) != ciphertextLen) {
-		TraceEvent(SevWarn, "BlobCipherEncryptUnexpectedPlaintextLen")
-		    .detail("CiphertextLen", ciphertextLen)
-		    .detail("DecryptedBufLen", bytesDecrypted + finalBlobBytes);
+	if (EVP_CIPHER_CTX_reset(ctx) != 1) {
+		TraceEvent(SevWarn, "BlobCipherDecryptCTXResetFailed")
+		    .detail("BaseCipherId", textCipherKey->getBaseCipherId())
+		    .detail("EncryptDomainId", textCipherKey->getDomainId());
 		throw encrypt_ops_error();
 	}
 
@@ -1595,7 +1585,7 @@ void DecryptBlobCipherAes256Ctr::decryptInplace(uint8_t* ciphertext,
 
 	// Padding should be 0 for AES CTR mode, so DecryptUpdate() should decrypt all the data
 	if (bytesDecrypted != ciphertextLen) {
-		TraceEvent(SevWarn, "BlobCipherEncryptUnexpectedPlaintextLen")
+		TraceEvent(SevWarn, "BlobCipherDecryptUnexpectedPlaintextLen")
 		    .detail("CiphertextLen", ciphertextLen)
 		    .detail("DecryptedBufLen", bytesDecrypted);
 		throw encrypt_ops_error();
@@ -1643,7 +1633,7 @@ void DecryptBlobCipherAes256Ctr::decryptInplace(uint8_t* ciphertext,
 
 	// Padding should be 0 for AES CTR mode, so DecryptUpdate() should decrypt all the data
 	if (bytesDecrypted != ciphertextLen) {
-		TraceEvent(SevWarn, "BlobCipherEncryptUnexpectedPlaintextLen")
+		TraceEvent(SevWarn, "BlobCipherDecryptUnexpectedPlaintextLen")
 		    .detail("CiphertextLen", ciphertextLen)
 		    .detail("DecryptedBufLen", bytesDecrypted);
 		throw encrypt_ops_error();


### PR DESCRIPTION
AES CTR mode doesn't need padding: https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#Padding

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
