### PR TITLE
Don't downgrade RebootProcessAndSwitch to Reboot (snowflake/release-71.3)

### DIFF
--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -1973,8 +1973,10 @@ public:
 		KillType originalKt = kt;
 		// Reboot if any of the processes are protected and count the number of processes not rebooting
 		for (auto& process : machines[machineId].processes) {
-			if (protectedAddresses.count(process->address))
+			if (protectedAddresses.count(process->address) && kt != KillType::RebootProcessAndSwitch) {
 				kt = KillType::Reboot;
+			}
+
 			if (!process->rebooting)
 				processesOnMachine++;
 			if (process->drProcess) {


### PR DESCRIPTION
Cherry pick #9941 

RebootProcessAndSwitch is meant to be used across an entire cluster, but it was not being applied on protected processes. When not all processes were switched to the new cluster, it was possible for a CC to log a SevError event if it connected to a coordinator that had changed clusters.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
