### PR TITLE
Update TestMultiValidationTokeFile token generation with no trailing newline char

### DIFF
--- a/fdbserver/RESTKmsConnector.actor.cpp
+++ b/fdbserver/RESTKmsConnector.actor.cpp
@@ -1264,8 +1264,17 @@ ACTOR Future<Void> testMultiValidationFileTokenFiles(Reference<RESTKmsConnectorC
 	state std::string tokenDetailsStr;
 	state bool newLineAppended = BUGGIFY ? true : false;
 
-	deterministicRandom()->randomBytes(mutateString(buff), tokenLen);
-	std::string token((char*)buff.begin(), tokenLen);
+	std::string token;
+	// Construct token-value buffer ensuring it doesn't have trailing new-line character.
+	loop {
+		deterministicRandom()->randomBytes(mutateString(buff), tokenLen);
+		token = std::string((char*)buff.begin(), tokenLen);
+		removeTrailingChar(token, '\n');
+		if (token.size() > 0) {
+			break;
+		}
+	}
+	tokenLen = token.size();
 	std::string tokenWithNewLine(token);
 	tokenWithNewLine.push_back('\n');
 


### PR DESCRIPTION
Cherry-picks #9943 

Description

The test does the following:
1.Randomly appends new-line character to the token value buffer
2. If #1 is done, it generates temp token file with buffer containing new-line character.
3. Also, it remember the original token for future validation
4. The code parse and read token-validation files and removes the new-line character as desired.

Failure in this case due to random buffer used to populate token value contained newline character which was used for validation, however, the file parse/read code as expected removed the newline character, hence causing the mismatch.

Patch addresses the concern by ensuring test generated random token-value has no trailing newline chars.

Testing

tests/fast/RandomUnitTests.toml -s 1355028229

(cherry picked from commit 8e520824752203b4488a699465529809318bbfa8)

Replace this text with your description here...

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
