### PR TITLE
Don't use RandomMoveKeys in clusters with multiple regions

### DIFF
--- a/fdbserver/workloads/RandomMoveKeys.actor.cpp
+++ b/fdbserver/workloads/RandomMoveKeys.actor.cpp
@@ -224,7 +224,8 @@ struct MoveKeysWorkload : FailureInjectionWorkload {
 
 		ASSERT(self->configuration.storageTeamSize > 0);
 
-		if (self->configuration.usableRegions > 1) { // FIXME: add support for generating random teams across DCs
+		// FIXME: add support for generating random teams across DCs
+		if (self->configuration.usableRegions > 1 || self->configuration.regions.size() > 1) {
 			return Void();
 		}
 


### PR DESCRIPTION
RandomMoveKeys doesn't understand how to generate teams in multiple regions. It has already been disabled if usableRegions > 1, but it can still run into trouble if there are multiple regions and usableRegions == 1. This disables RandomMoveKeys if there is more than one region.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
