### PR TITLE
Avoid run loop profiler deadlocking in sanitizer builds

### DIFF
--- a/flow/Platform.actor.cpp
+++ b/flow/Platform.actor.cpp
@@ -3833,8 +3833,14 @@ void profileHandler(int sig) {
 	// We can't get the time from a timer() call because it's not signal safe.
 	ps->timestamp = checkThreadTime.is_lock_free() ? checkThreadTime.load() : 0;
 
+#if defined(USE_SANITIZER)
+	// In sanitizer builds the workaround implemented in SignalSafeUnwind.cpp is disabled
+	// so calling backtrace may cause a deadlock
+	size_t size = 0;
+#else
 	// SOMEDAY: should we limit the maximum number of frames from backtrace beyond just available space?
 	size_t size = backtrace(ps->frames, net2backtraces_max - net2backtraces_offset - 2);
+#endif
 
 	ps->length = size;
 

--- a/flow/SignalSafeUnwind.cpp
+++ b/flow/SignalSafeUnwind.cpp
@@ -22,6 +22,9 @@
 
 int64_t dl_iterate_phdr_calls = 0;
 
+// Disabling the workaround in santizer builds, because dl_iterate_phdr used in the initialization of
+// the sanitizer state, so calling any sanitizer-instrumented code in the context of this function
+// causes uninitialized memory access
 #if defined(__linux__) && !defined(USE_SANITIZER)
 
 #include <link.h>


### PR DESCRIPTION
The test `fdb_c_api_test_CApiRunLoopProfiler` was failing relatively frequently in sanitizer builds, running in a deadlock when the profiler signal hander is triggered in a context of code doing stack unwind and calls backtrace, which tries to acquire the same lock. 

This deadlock is avoided in normal builds by overloading `dl_iterate_phdr` and disabling the profiler in its context. This workaround is disabled in sanitizer builds, because sanitizers use this function during initialization of their state. 

This fix avoids the deadlock by disabling `backtrace` call from profiler handler in sanitizer builds.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
