### PR TITLE
refactoring and adding future compatibility to blob range metadata

### DIFF
--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -11026,7 +11026,8 @@ ACTOR Future<bool> setBlobRangeActor(Reference<DatabaseContext> cx,
 
 	state Value value = active ? blobRangeActive : blobRangeInactive;
 	if (active && (!g_network->isSimulated() || !g_simulator->willRestart) && BUGGIFY_WITH_PROB(0.1)) {
-		// buggify to arbitrary if test isn't a restarting test that could downgrade to an earlier version that doesn't support this
+		// buggify to arbitrary if test isn't a restarting test that could downgrade to an earlier version that doesn't
+		// support this
 		int randLen = deterministicRandom()->randomInt(2, 20);
 		value = StringRef(deterministicRandom()->randomAlphaNumeric(randLen));
 	}

--- a/fdbclient/SystemData.cpp
+++ b/fdbclient/SystemData.cpp
@@ -1391,6 +1391,13 @@ int64_t decodeBlobManagerEpochValue(ValueRef const& value) {
 const KeyRef blobRangeActive = "1"_sr;
 const KeyRef blobRangeInactive = StringRef();
 
+ bool isBlobRangeActive(const ValueRef& blobRangeValue) {
+    // Empty or "0" is inactive
+    // "1" is active
+    // Support future change where serialized metadata struct is also active
+    return !blobRangeValue.empty() && blobRangeValue != blobRangeInactive;
+}
+
 const KeyRangeRef blobGranuleFileKeys("\xff\x02/bgf/"_sr, "\xff\x02/bgf0"_sr);
 const KeyRangeRef blobGranuleMappingKeys("\xff\x02/bgm/"_sr, "\xff\x02/bgm0"_sr);
 const KeyRangeRef blobGranuleLockKeys("\xff\x02/bgl/"_sr, "\xff\x02/bgl0"_sr);

--- a/fdbclient/SystemData.cpp
+++ b/fdbclient/SystemData.cpp
@@ -1391,11 +1391,11 @@ int64_t decodeBlobManagerEpochValue(ValueRef const& value) {
 const KeyRef blobRangeActive = "1"_sr;
 const KeyRef blobRangeInactive = StringRef();
 
- bool isBlobRangeActive(const ValueRef& blobRangeValue) {
-    // Empty or "0" is inactive
-    // "1" is active
-    // Support future change where serialized metadata struct is also active
-    return !blobRangeValue.empty() && blobRangeValue != blobRangeInactive;
+bool isBlobRangeActive(const ValueRef& blobRangeValue) {
+	// Empty or "0" is inactive
+	// "1" is active
+	// Support future change where serialized metadata struct is also active
+	return !blobRangeValue.empty() && blobRangeValue != blobRangeInactive;
 }
 
 const KeyRangeRef blobGranuleFileKeys("\xff\x02/bgf/"_sr, "\xff\x02/bgf0"_sr);

--- a/fdbclient/include/fdbclient/SystemData.h
+++ b/fdbclient/include/fdbclient/SystemData.h
@@ -638,6 +638,8 @@ int64_t decodeBlobManagerEpochValue(ValueRef const& value);
 extern const StringRef blobRangeActive;
 extern const StringRef blobRangeInactive;
 
+bool isBlobRangeActive(const ValueRef& blobRangeValue);
+
 extern const uint8_t BG_FILE_TYPE_DELTA;
 extern const uint8_t BG_FILE_TYPE_SNAPSHOT;
 

--- a/fdbserver/BlobManager.actor.cpp
+++ b/fdbserver/BlobManager.actor.cpp
@@ -145,7 +145,7 @@ void updateClientBlobRanges(int64_t epoch,
 				}
 				break;
 			}
-			bool active = dbBlobRanges[i].value == blobRangeActive;
+			bool active = isBlobRangeActive(dbBlobRanges[i].value);
 			if (active) {
 				if (BM_DEBUG) {
 					fmt::print("BM {0} sees client range [{1} - {2})\n",
@@ -1382,7 +1382,7 @@ ACTOR Future<Void> monitorClientRanges(Reference<BlobManagerData> bmData) {
 					needToCoalesce = false;
 
 					for (int i = 0; i < results.size() - 1; i++) {
-						bool active = results[i].value == blobRangeActive;
+						bool active = isBlobRangeActive(results[i].value);
 						bmData->knownBlobRanges.insert(KeyRangeRef(results[i].key, results[i + 1].key), active);
 					}
 				}


### PR DESCRIPTION
To support later attaching a metadata struct to each range after 71.3

Passes 20k BlobGranule* correctness

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
