### PR TITLE
Expose list_blobbified_ranges for tenants in python API (Cherry-Pick #9940 to snowflake/release-71.3)

### DIFF
--- a/bindings/python/fdb/impl.py
+++ b/bindings/python/fdb/impl.py
@@ -1345,6 +1345,17 @@ class Tenant(_TransactionCreator):
     def get_id(self):
         return FutureInt64(self.capi.fdb_tenant_get_id(self.tpointer))
 
+    def list_blobbified_ranges(self, begin, end, limit):
+        return FutureKeyValueArray(
+            self.capi.fdb_tenant_list_blobbified_ranges(
+                self.tpointer,
+                begin,
+                len(begin),
+                end,
+                len(end),
+                limit
+            )
+        )
 
 fill_operations()
 
@@ -1721,6 +1732,16 @@ def init_c_api():
 
     _capi.fdb_tenant_get_id.argtypes = [ctypes.c_void_p]
     _capi.fdb_tenant_get_id.restype = ctypes.c_void_p
+
+    _capi.fdb_tenant_list_blobbified_ranges.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_int,
+        ctypes.c_void_p,
+        ctypes.c_int,
+        ctypes.c_int,
+    ]
+    _capi.fdb_tenant_list_blobbified_ranges.restype = ctypes.c_void_p
 
     _capi.fdb_tenant_create_transaction.argtypes = [
         ctypes.c_void_p,


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/foundationdb/pull/9940

Original Description:

This exposes a C binding needed to facilitate tenant movement, but was only present in the C and Java bindings.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
