### PR TITLE
Disallow Unencrypted Blob Worker from Joining Encrypted Cluster

### DIFF
--- a/fdbserver/BlobWorker.actor.cpp
+++ b/fdbserver/BlobWorker.actor.cpp
@@ -5518,6 +5518,37 @@ bool blobWorkerTerminated(Reference<BlobWorkerData> self, IKeyValueStore* persis
 
 #define PERSIST_PREFIX "\xff\xff"
 static const KeyRef persistID = PERSIST_PREFIX "ID"_sr;
+static const KeyRef persistEncryptionAtRestModeKey = "encryptionAtRestMode"_sr;
+
+ACTOR Future<Void> checkUpdateEncryptionAtRestMode(Reference<BlobWorkerData> self,
+                                                   Future<DatabaseConfiguration> configF) {
+	DatabaseConfiguration config = wait(configF);
+	EncryptionAtRestMode encryptionAtRestMode = config.encryptionAtRestMode;
+	if (self->persistedEncryptMode.present()) {
+		// Ensure the BlobWorker encryptionAtRestMode status matches with the cluster config, if not, kill the TLog
+		// process. Approach prevents a fake TLog process joining the cluster.
+		if (self->persistedEncryptMode.get() != encryptionAtRestMode) {
+			TraceEvent(SevError, "BlobWorkerEncryptionAtRestMismatch", self->id)
+			    .detail("Expected", encryptionAtRestMode.toString())
+			    .detail("Present", self->persistedEncryptMode.get().toString());
+			ASSERT(false);
+		}
+		TraceEvent(SevDebug, "BlobWorkerPersistEncryptionAtRestModePresent", self->id)
+		    .detail("Mode", self->persistedEncryptMode.get().toString());
+	} else {
+		self->persistedEncryptMode = encryptionAtRestMode;
+		if (self->storage) {
+			self->storage->set(KeyValueRef(persistEncryptionAtRestModeKey, self->persistedEncryptMode.get().toValue()));
+			wait(self->storage->commit());
+			TraceEvent("BlobWorkerPersistEncryptionAtRestMode", self->id)
+			    .detail("Mode", self->persistedEncryptMode.get().toString());
+		}
+	}
+
+	ASSERT(self->persistedEncryptMode.present());
+	self->encryptMode = self->persistedEncryptMode.get();
+	return Void();
+}
 
 ACTOR Future<Void> blobWorker(BlobWorkerInterface bwInterf,
                               ReplyPromise<InitializeBlobWorkerReply> recruitReply,
@@ -5568,8 +5599,7 @@ ACTOR Future<Void> blobWorker(BlobWorkerInterface bwInterf,
 		rep.interf = bwInterf;
 		recruitReply.send(rep);
 
-		DatabaseConfiguration config = wait(configFuture);
-		self->encryptMode = config.encryptionAtRestMode;
+		wait(checkUpdateEncryptionAtRestMode(self, configFuture));
 		TraceEvent("BWEncryptionAtRestMode", self->id).detail("Mode", self->encryptMode.toString());
 
 		TraceEvent("BlobWorkerInit", self->id).log();
@@ -5593,8 +5623,9 @@ ACTOR Future<Void> blobWorker(BlobWorkerInterface bwInterf,
 
 ACTOR Future<UID> restorePersistentState(Reference<BlobWorkerData> self) {
 	state Future<Optional<Value>> fID = self->storage->readValue(persistID);
+	state Future<Optional<Value>> fEncryptionAtRestMode = self->storage->readValue(persistEncryptionAtRestModeKey);
 
-	wait(waitForAll(std::vector{ fID }));
+	wait(waitForAll(std::vector{ fID, fEncryptionAtRestMode }));
 
 	if (!SERVER_KNOBS->BLOB_WORKER_DISK_ENABLED || !fID.get().present()) {
 		CODE_PROBE(true, "Restored uninitialized blob worker");
@@ -5602,6 +5633,14 @@ ACTOR Future<UID> restorePersistentState(Reference<BlobWorkerData> self) {
 	}
 	UID recoveredID = BinaryReader::fromStringRef<UID>(fID.get().get(), Unversioned());
 	ASSERT(recoveredID != self->id);
+
+	if (fEncryptionAtRestMode.get().present()) {
+		CODE_PROBE(true, "Retrieved persisted encryption at rest mode");
+		self->persistedEncryptMode =
+		    Optional<EncryptionAtRestMode>(EncryptionAtRestMode::fromValue(fEncryptionAtRestMode.get()));
+		TraceEvent("BlobWorkerPersistEncryptionAtRestModeRead", self->id)
+		    .detail("Mode", self->persistedEncryptMode.get().toString());
+	}
 	return recoveredID;
 }
 
@@ -5659,9 +5698,8 @@ ACTOR Future<Void> blobWorker(BlobWorkerInterface bwInterf,
 		self->storage->set(KeyValueRef(persistID, BinaryWriter::toValue(self->id, Unversioned())));
 		wait(self->storage->commit());
 
-		DatabaseConfiguration config = wait(configFuture);
-		self->encryptMode = config.encryptionAtRestMode;
-		TraceEvent("BWEncryptionAtRestMode", self->id).detail("Mode", self->encryptMode.toString());
+		wait(checkUpdateEncryptionAtRestMode(self, configFuture));
+		TraceEvent("BWEncryptionAtRestModeRecover", self->id).detail("Mode", self->encryptMode.toString());
 
 		TraceEvent("BlobWorkerInit", self->id).log();
 		wait(blobWorkerCore(bwInterf, self));

--- a/fdbserver/include/fdbserver/BlobWorker.h
+++ b/fdbserver/include/fdbserver/BlobWorker.h
@@ -186,6 +186,7 @@ struct BlobWorkerData : NonCopyable, ReferenceCounted<BlobWorkerData> {
 	// FIXME: have cap on this independent of delta file size for larger granules
 	int changeFeedStreamReplyBufferSize = SERVER_KNOBS->BG_DELTA_FILE_TARGET_BYTES / 4;
 
+	Optional<EncryptionAtRestMode> persistedEncryptMode;
 	EncryptionAtRestMode encryptMode;
 	bool buggifyFull = false;
 


### PR DESCRIPTION
PR adds support for preventing an unencrypted blob worker to join an encrypted cluster or vise-versa (an encrypted blob worker joining an unencrypted cluster)

Passes 100k BlobGranule and 100k correctness

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
