### PR TITLE
[snowflake/release-71.3 cherry-pick] EaR: Implement Key Check Value semantics (#9936)

### DIFF
--- a/bindings/c/fdb_c.cpp
+++ b/bindings/c/fdb_c.cpp
@@ -355,6 +355,7 @@ void parseGetTenant(Optional<KeyRef>& dest, FDBBGTenantPrefix const* source) {
 void parseGetEncryptionKey(BlobGranuleCipherKey& dest, FDBBGEncryptionKey const* source) {
 	dest.encryptDomainId = source->domain_id;
 	dest.baseCipherId = source->base_key_id;
+	dest.baseCipherKCV = source->base_kcv;
 	dest.salt = source->random_salt;
 	dest.baseCipher = StringRef(source->base_key.key, source->base_key.key_length);
 }
@@ -371,6 +372,7 @@ void parseGetEncryptionKeyCtx(Optional<BlobGranuleCipherKeysCtx>& dest, FDBBGEnc
 void setEncryptionKey(FDBBGEncryptionKey* dest, const BlobGranuleCipherKey& source) {
 	dest->domain_id = source.encryptDomainId;
 	dest->base_key_id = source.baseCipherId;
+	dest->base_kcv = source.baseCipherKCV;
 	dest->random_salt = source.salt;
 	dest->base_key.key = source.baseCipher.begin();
 	dest->base_key.key_length = source.baseCipher.size();
@@ -379,7 +381,9 @@ void setEncryptionKey(FDBBGEncryptionKey* dest, const BlobGranuleCipherKey& sour
 void setEncryptionKeyCtx(FDBBGEncryptionCtx* dest, const BlobGranuleCipherKeysCtx& source) {
 	dest->present = true;
 	setEncryptionKey(&dest->textKey, source.textCipherKey);
+	dest->textKCV = source.textCipherKey.baseCipherKCV;
 	setEncryptionKey(&dest->headerKey, source.headerCipherKey);
+	dest->headerKCV = source.headerCipherKey.baseCipherKCV;
 	dest->iv.key = source.ivRef.begin();
 	dest->iv.key_length = source.ivRef.size();
 }

--- a/bindings/c/foundationdb/fdb_c.h
+++ b/bindings/c/foundationdb/fdb_c.h
@@ -234,6 +234,7 @@ typedef struct bgtenantprefix {
 typedef struct bgencryptionkey {
 	int64_t domain_id;
 	uint64_t base_key_id;
+	uint32_t base_kcv;
 	uint64_t random_salt;
 	FDBKey base_key;
 } FDBBGEncryptionKey;
@@ -241,7 +242,9 @@ typedef struct bgencryptionkey {
 typedef struct bgencryptionctx {
 	fdb_bool_t present;
 	FDBBGEncryptionKey textKey;
+	uint32_t textKCV;
 	FDBBGEncryptionKey headerKey;
+	uint32_t headerKCV;
 	FDBKey iv;
 } FDBBGEncryptionCtx;
 

--- a/fdbclient/BlobCipher.cpp
+++ b/fdbclient/BlobCipher.cpp
@@ -27,6 +27,7 @@
 #include "flow/EncryptUtils.h"
 #include "flow/FileIdentifier.h"
 #include "flow/FastRef.h"
+#include "flow/IndexedSet.h"
 #include "flow/flow.h"
 #include "flow/Error.h"
 #include "flow/Knobs.h"
@@ -212,8 +213,38 @@ EncryptCipherDomainId BlobCipherEncryptHeaderRef::getDomainId() const {
 	return std::visit([](auto& h) { return h.v1.cipherTextDetails.encryptDomainId; }, algoHeader);
 }
 
+EncryptHeaderCipherKCVs BlobCipherEncryptHeaderRef::getKCVs() const {
+	ASSERT(CLIENT_KNOBS->ENABLE_CONFIGURABLE_ENCRYPTION);
+
+	validateEncryptHeaderFlagVersion(flagsVersion());
+	ASSERT_EQ(flagsVersion(), 1);
+
+	BlobCipherEncryptHeaderFlagsV1 flags = std::get<BlobCipherEncryptHeaderFlagsV1>(this->flags);
+
+	validateEncryptHeaderAlgoHeaderVersion((EncryptCipherMode)flags.encryptMode,
+	                                       (EncryptAuthTokenMode)flags.authTokenMode,
+	                                       (EncryptAuthTokenAlgo)flags.authTokenAlgo,
+	                                       algoHeaderVersion());
+	ASSERT_EQ(algoHeaderVersion(), 1);
+
+	// TODO: Replace with "Overload visitor pattern" someday.
+	return std::visit(
+	    [](auto&& h) {
+		    using T = std::decay_t<decltype(h)>;
+		    if constexpr (std::is_same_v<T, AesCtrNoAuth>) {
+			    return EncryptHeaderCipherKCVs(h.v1.textKCV);
+		    } else if constexpr (std::is_same_v<T, AesCtrWithHmac> || std::is_same_v<T, AesCtrWithCmac>) {
+			    return EncryptHeaderCipherKCVs(h.v1.textKCV, h.v1.headerKCV);
+		    } else {
+			    static_assert(always_false_v<T>, "Unknown encryption authentication");
+		    }
+	    },
+	    algoHeader);
+}
+
 void BlobCipherEncryptHeaderRef::validateEncryptionHeaderDetails(const BlobCipherDetails& textCipherDetails,
                                                                  const BlobCipherDetails& headerCipherDetails,
+                                                                 const EncryptHeaderCipherKCVs& kcvs,
                                                                  const StringRef& ivRef) const {
 	ASSERT(CLIENT_KNOBS->ENABLE_CONFIGURABLE_ENCRYPTION);
 
@@ -231,18 +262,27 @@ void BlobCipherEncryptHeaderRef::validateEncryptionHeaderDetails(const BlobCiphe
 	BlobCipherDetails persistedTextCipherDetails;
 	BlobCipherDetails persistedHeaderCipherDetails;
 	uint8_t* persistedIV = nullptr;
+	EncryptCipherKeyCheckValue persistedTextKCV;
+	Optional<EncryptCipherKeyCheckValue> persistedHeaderKCV;
 
 	// TODO: Replace with "Overload visitor pattern" someday.
 	return std::visit(
-	    [&persistedTextCipherDetails, &persistedHeaderCipherDetails, &persistedIV](auto&& h) {
+	    [&persistedTextCipherDetails,
+	     &persistedHeaderCipherDetails,
+	     &persistedIV,
+	     &persistedTextKCV,
+	     &persistedHeaderKCV](auto&& h) {
 		    using T = std::decay_t<decltype(h)>;
 		    if constexpr (std::is_same_v<T, AesCtrNoAuth>) {
 			    persistedTextCipherDetails = h.v1.cipherTextDetails;
 			    persistedIV = (uint8_t*)&h.v1.iv[0];
+			    persistedTextKCV = h.v1.textKCV;
 		    } else if constexpr (std::is_same_v<T, AesCtrWithHmac> || std::is_same_v<T, AesCtrWithCmac>) {
 			    persistedTextCipherDetails = h.v1.cipherTextDetails;
 			    persistedHeaderCipherDetails = h.v1.cipherHeaderDetails;
 			    persistedIV = (uint8_t*)&h.v1.iv[0];
+			    persistedTextKCV = h.v1.textKCV;
+			    persistedHeaderKCV = h.v1.headerKCV;
 		    } else {
 			    static_assert(always_false_v<T>, "Unknown encryption authentication");
 		    }
@@ -274,10 +314,30 @@ void BlobCipherEncryptHeaderRef::validateEncryptionHeaderDetails(const BlobCiphe
 	}
 	// Validate 'Initialization Vector' sanity
 	if (memcmp(ivRef.begin(), persistedIV, AES_256_IV_LENGTH) != 0) {
-		TraceEvent(SevError, "EncryptionHeader_IVMismatch")
+		TraceEvent(SevError, "EncryptionHeaderIVMismatch")
 		    .detail("IVChecksum", XXH3_64bits(ivRef.begin(), ivRef.size()))
 		    .detail("ExpectedIVChecksum", XXH3_64bits(persistedIV, AES_256_IV_LENGTH));
 		throw encrypt_header_metadata_mismatch();
+	}
+
+	// Validate baseCipher KCVs
+	if (persistedTextKCV != kcvs.textKCV) {
+		TraceEvent(SevError, "EncryptionHeadeTextKCVMismatch")
+		    .detail("Persisted", persistedTextKCV)
+		    .detail("Expected", kcvs.textKCV);
+		throw encrypt_key_check_value_mismatch();
+	}
+	if (persistedHeaderKCV.present()) {
+		if (!kcvs.headerKCV.present()) {
+			TraceEvent(SevError, "EncryptionHeadeMissingHeaderKCV");
+			throw encrypt_key_check_value_mismatch();
+		}
+		if (persistedHeaderKCV.get() != kcvs.headerKCV.get()) {
+			TraceEvent(SevError, "EncryptionHeadeTextKCVMismatch")
+			    .detail("Persisted", persistedTextKCV)
+			    .detail("Expected", kcvs.textKCV);
+			throw encrypt_key_check_value_mismatch();
+		}
 	}
 }
 
@@ -352,7 +412,8 @@ std::string toString(BlobCipherMetrics::UsageType type) {
 BlobCipherKey::BlobCipherKey(const EncryptCipherDomainId& domainId,
                              const EncryptCipherBaseKeyId& baseCiphId,
                              const uint8_t* baseCiph,
-                             int baseCiphLen,
+                             const int baseCiphLen,
+                             const EncryptCipherKeyCheckValue baseCiphKCV,
                              const int64_t refreshAt,
                              const int64_t expireAt) {
 	// Salt generated is used while applying HMAC Key derivation, hence, not using crypto-secure hash algorithm is
@@ -369,30 +430,53 @@ BlobCipherKey::BlobCipherKey(const EncryptCipherDomainId& domainId,
 	// timestamp.
 	ASSERT(refreshAt == std::numeric_limits<int64_t>::max() || (refreshAt <= expireAt));
 
-	initKey(domainId, baseCiph, baseCiphLen, baseCiphId, salt, refreshAt, expireAt);
+	initKey(domainId, baseCiphId, baseCiph, baseCiphLen, baseCiphKCV, salt, refreshAt, expireAt);
 }
 
 BlobCipherKey::BlobCipherKey(const EncryptCipherDomainId& domainId,
                              const EncryptCipherBaseKeyId& baseCiphId,
                              const uint8_t* baseCiph,
                              const int baseCiphLen,
+                             const EncryptCipherKeyCheckValue baseCiphKCV,
                              const EncryptCipherRandomSalt& salt,
                              const int64_t refreshAt,
                              const int64_t expireAt) {
-	initKey(domainId, baseCiph, baseCiphLen, baseCiphId, salt, refreshAt, expireAt);
+	initKey(domainId, baseCiphId, baseCiph, baseCiphLen, baseCiphKCV, salt, refreshAt, expireAt);
 }
 
 void BlobCipherKey::initKey(const EncryptCipherDomainId& domainId,
+                            const EncryptCipherBaseKeyId& baseCiphId,
                             const uint8_t* baseCiph,
                             const int baseCiphLen,
-                            const EncryptCipherBaseKeyId& baseCiphId,
+                            const EncryptCipherKeyCheckValue baseCiphKCV,
                             const EncryptCipherRandomSalt& salt,
                             const int64_t refreshAt,
                             const int64_t expireAt) {
+	if (baseCiphLen > MAX_BASE_CIPHER_LEN) {
+		// HMAC_SHA digest generation accepts upto MAX_BASE_CIPHER_LEN key-buffer, longer keys are truncated and weakens
+		// the security guarantees.
+		TraceEvent(SevWarnAlways, "MaxBaseCipherKeyLimit")
+		    .detail("MaxAllowed", MAX_BASE_CIPHER_LEN)
+		    .detail("BaseCipherLen", baseCiphLen);
+		CODE_PROBE(true, "Encryption max base cipher len violation");
+		throw encrypt_max_base_cipher_len();
+	}
+
+	const EncryptCipherKeyCheckValue computedKCV = Sha256KCV().computeKCV(baseCiph, baseCiphLen);
+	if (computedKCV != baseCiphKCV) {
+		TraceEvent(SevWarnAlways, "BlobCipherKeyInitBaseCipherKCVMismatch")
+		    .detail("DomId", domainId)
+		    .detail("BaseCipherId", baseCiphId)
+		    .detail("Computed", computedKCV)
+		    .detail("BaseCipherKCV", baseCipherKCV);
+		throw encrypt_ops_error();
+	}
+
 	// Set the base encryption key properties
 	baseCipher = std::make_unique<uint8_t[]>(baseCiphLen);
 	memcpy(baseCipher.get(), baseCiph, baseCiphLen);
 	baseCipherLen = baseCiphLen;
+	baseCipherKCV = baseCiphKCV;
 	baseCipherId = baseCiphId;
 	// Set the encryption domain for the base encryption key
 	encryptDomainId = domainId;
@@ -412,7 +496,8 @@ void BlobCipherKey::initKey(const EncryptCipherDomainId& domainId,
 	    .detail("BaseCipherLen", baseCipherLen)
 	    .detail("RandomSalt", randomSalt)
 	    .detail("RefreshAt", refreshAtTS)
-	    .detail("ExpireAtTS", expireAtTS);
+	    .detail("ExpireAtTS", expireAtTS)
+	    .detail("BaseCipherKCV", baseCipherKCV);
 #endif
 }
 
@@ -510,7 +595,8 @@ Reference<BlobCipherKey> BlobCipherKeyIdCache::getCipherByBaseCipherId(const Enc
 
 Reference<BlobCipherKey> BlobCipherKeyIdCache::insertBaseCipherKey(const EncryptCipherBaseKeyId& baseCipherId,
                                                                    const uint8_t* baseCipher,
-                                                                   int baseCipherLen,
+                                                                   const int baseCipherLen,
+                                                                   const EncryptCipherKeyCheckValue baseCipherKCV,
                                                                    const int64_t refreshAt,
                                                                    const int64_t expireAt) {
 	ASSERT_GT(baseCipherId, INVALID_ENCRYPT_CIPHER_KEY_ID);
@@ -524,7 +610,8 @@ Reference<BlobCipherKey> BlobCipherKeyIdCache::insertBaseCipherKey(const Encrypt
 #if BLOB_CIPHER_DEBUG
 			TraceEvent(SevDebug, "InsertBaseCipherKeyAlreadyPresent")
 			    .detail("BaseCipherKeyId", baseCipherId)
-			    .detail("DomainId", domainId);
+			    .detail("DomainId", domainId)
+			    .detail("BaseCipherKCV", baseCipherKCV);
 #endif
 
 			// Key is already present; nothing more to do.
@@ -548,11 +635,12 @@ Reference<BlobCipherKey> BlobCipherKeyIdCache::insertBaseCipherKey(const Encrypt
 	    .detail("DomainId", domainId)
 	    .detail("BaseCipherId", baseCipherId)
 	    .detail("BaseCipherLen", baseCipherLen)
+	    .detail("BaseCipherKCV", baseCipherKCV)
 	    .detail("RefreshAt", refreshAt)
 	    .detail("ExpireAt", expireAt);
 
-	Reference<BlobCipherKey> cipherKey =
-	    makeReference<BlobCipherKey>(domainId, baseCipherId, baseCipher, baseCipherLen, refreshAt, expireAt);
+	Reference<BlobCipherKey> cipherKey = makeReference<BlobCipherKey>(
+	    domainId, baseCipherId, baseCipher, baseCipherLen, baseCipherKCV, refreshAt, expireAt);
 	BlobCipherKeyIdCacheKey cacheKey = getCacheKey(cipherKey->getBaseCipherId(), cipherKey->getSalt());
 	auto result = keyIdCache.emplace(cacheKey, cipherKey);
 	ASSERT(result.second);
@@ -567,7 +655,8 @@ Reference<BlobCipherKey> BlobCipherKeyIdCache::insertBaseCipherKey(const Encrypt
 
 Reference<BlobCipherKey> BlobCipherKeyIdCache::insertBaseCipherKey(const EncryptCipherBaseKeyId& baseCipherId,
                                                                    const uint8_t* baseCipher,
-                                                                   int baseCipherLen,
+                                                                   const int baseCipherLen,
+                                                                   const EncryptCipherKeyCheckValue baseCipherKCV,
                                                                    const EncryptCipherRandomSalt& salt,
                                                                    const int64_t refreshAt,
                                                                    const int64_t expireAt) {
@@ -584,7 +673,8 @@ Reference<BlobCipherKey> BlobCipherKeyIdCache::insertBaseCipherKey(const Encrypt
 #if BLOB_CIPHER_DEBUG
 			TraceEvent(SevDebug, "InsertBaseCipherKeyAlreadyPresent")
 			    .detail("BaseCipherKeyId", baseCipherId)
-			    .detail("DomainId", domainId);
+			    .detail("DomainId", domainId)
+			    .detail("BaseCipherKCV", baseCipherKCV);
 #endif
 
 			// Key is already present; nothing more to do.
@@ -607,12 +697,13 @@ Reference<BlobCipherKey> BlobCipherKeyIdCache::insertBaseCipherKey(const Encrypt
 	    .detail("DomainId", domainId)
 	    .detail("BaseCipherId", baseCipherId)
 	    .detail("BaseCipherLen", baseCipherLen)
+	    .detail("BaseCipherKCV", baseCipherKCV)
 	    .detail("Salt", salt)
 	    .detail("RefreshAt", refreshAt)
 	    .detail("ExpireAt", expireAt);
 
-	Reference<BlobCipherKey> cipherKey =
-	    makeReference<BlobCipherKey>(domainId, baseCipherId, baseCipher, baseCipherLen, salt, refreshAt, expireAt);
+	Reference<BlobCipherKey> cipherKey = makeReference<BlobCipherKey>(
+	    domainId, baseCipherId, baseCipher, baseCipherLen, baseCipherKCV, salt, refreshAt, expireAt);
 	auto result = keyIdCache.emplace(cacheKey, cipherKey);
 	ASSERT(result.second);
 
@@ -641,7 +732,8 @@ std::vector<Reference<BlobCipherKey>> BlobCipherKeyIdCache::getAllCipherKeys() {
 Reference<BlobCipherKey> BlobCipherKeyCache::insertCipherKey(const EncryptCipherDomainId& domainId,
                                                              const EncryptCipherBaseKeyId& baseCipherId,
                                                              const uint8_t* baseCipher,
-                                                             int baseCipherLen,
+                                                             const int baseCipherLen,
+                                                             const EncryptCipherKeyCheckValue baseCipherKCV,
                                                              const int64_t refreshAt,
                                                              const int64_t expireAt) {
 	if (domainId == INVALID_ENCRYPT_DOMAIN_ID || baseCipherId == INVALID_ENCRYPT_CIPHER_KEY_ID) {
@@ -655,12 +747,14 @@ Reference<BlobCipherKey> BlobCipherKeyCache::insertCipherKey(const EncryptCipher
 		if (domainItr == domainCacheMap.end()) {
 			// Add mapping to track new encryption domain
 			Reference<BlobCipherKeyIdCache> keyIdCache = makeReference<BlobCipherKeyIdCache>(domainId, &size);
-			cipherKey = keyIdCache->insertBaseCipherKey(baseCipherId, baseCipher, baseCipherLen, refreshAt, expireAt);
+			cipherKey = keyIdCache->insertBaseCipherKey(
+			    baseCipherId, baseCipher, baseCipherLen, baseCipherKCV, refreshAt, expireAt);
 			domainCacheMap.emplace(domainId, keyIdCache);
 		} else {
 			// Track new baseCipher keys
 			Reference<BlobCipherKeyIdCache> keyIdCache = domainItr->second;
-			cipherKey = keyIdCache->insertBaseCipherKey(baseCipherId, baseCipher, baseCipherLen, refreshAt, expireAt);
+			cipherKey = keyIdCache->insertBaseCipherKey(
+			    baseCipherId, baseCipher, baseCipherLen, baseCipherKCV, refreshAt, expireAt);
 		}
 	} catch (Error& e) {
 		TraceEvent(SevWarn, "BlobCipherInsertCipherKeyFailed")
@@ -674,7 +768,8 @@ Reference<BlobCipherKey> BlobCipherKeyCache::insertCipherKey(const EncryptCipher
 Reference<BlobCipherKey> BlobCipherKeyCache::insertCipherKey(const EncryptCipherDomainId& domainId,
                                                              const EncryptCipherBaseKeyId& baseCipherId,
                                                              const uint8_t* baseCipher,
-                                                             int baseCipherLen,
+                                                             const int baseCipherLen,
+                                                             const EncryptCipherKeyCheckValue baseCipherKCV,
                                                              const EncryptCipherRandomSalt& salt,
                                                              const int64_t refreshAt,
                                                              const int64_t expireAt) {
@@ -689,17 +784,17 @@ Reference<BlobCipherKey> BlobCipherKeyCache::insertCipherKey(const EncryptCipher
 		if (domainItr == domainCacheMap.end()) {
 			// Add mapping to track new encryption domain
 			Reference<BlobCipherKeyIdCache> keyIdCache = makeReference<BlobCipherKeyIdCache>(domainId, &size);
-			cipherKey =
-			    keyIdCache->insertBaseCipherKey(baseCipherId, baseCipher, baseCipherLen, salt, refreshAt, expireAt);
+			cipherKey = keyIdCache->insertBaseCipherKey(
+			    baseCipherId, baseCipher, baseCipherLen, baseCipherKCV, salt, refreshAt, expireAt);
 			domainCacheMap.emplace(domainId, keyIdCache);
 		} else {
 			// Track new baseCipher keys
 			Reference<BlobCipherKeyIdCache> keyIdCache = domainItr->second;
-			cipherKey =
-			    keyIdCache->insertBaseCipherKey(baseCipherId, baseCipher, baseCipherLen, salt, refreshAt, expireAt);
+			cipherKey = keyIdCache->insertBaseCipherKey(
+			    baseCipherId, baseCipher, baseCipherLen, baseCipherKCV, salt, refreshAt, expireAt);
 		}
 	} catch (Error& e) {
-		TraceEvent(SevWarn, "BlobCipherInsertCipherKey_Failed")
+		TraceEvent(SevWarn, "BlobCipherInsertCipherKeyFailed")
 		    .detail("BaseCipherKeyId", baseCipherId)
 		    .detail("DomainId", domainId)
 		    .detail("Salt", salt);
@@ -897,9 +992,11 @@ void EncryptBlobCipherAes265Ctr::setCipherAlgoHeaderWithAuthV1(const uint8_t* ci
 	// authToken generation
 	AesCtrWithAuthV1<Params> algoHeader(
 	    BlobCipherDetails(textCipherKey->getDomainId(), textCipherKey->getBaseCipherId(), textCipherKey->getSalt()),
+	    textCipherKey->getBaseCipherKCV(),
 	    BlobCipherDetails(headerCipherKeyOpt.get()->getDomainId(),
 	                      headerCipherKeyOpt.get()->getBaseCipherId(),
 	                      headerCipherKeyOpt.get()->getSalt()),
+	    headerCipherKeyOpt.get()->getBaseCipherKCV(),
 	    iv,
 	    AES_256_IV_LENGTH);
 	headerRef->algoHeader = AesCtrWithAuth(algoHeader);
@@ -926,6 +1023,7 @@ void EncryptBlobCipherAes265Ctr::setCipherAlgoHeaderNoAuthV1(const BlobCipherEnc
 
 	AesCtrNoAuthV1 aesCtrNoAuth(
 	    BlobCipherDetails(textCipherKey->getDomainId(), textCipherKey->getBaseCipherId(), textCipherKey->getSalt()),
+	    textCipherKey->getBaseCipherKCV(),
 	    iv,
 	    AES_256_IV_LENGTH);
 	headerRef->algoHeader = AesCtrNoAuth(aesCtrNoAuth);
@@ -990,11 +1088,14 @@ void EncryptBlobCipherAes265Ctr::updateEncryptHeader(const uint8_t* ciphertext,
 
 	// Populate cipherText encryption-key details
 	header->cipherTextDetails = textCipherKey->details();
+	header->textKCV = textCipherKey->getBaseCipherKCV();
 	// Populate header encryption-key details
 	if (authTokenMode != ENCRYPT_HEADER_AUTH_TOKEN_MODE_NONE) {
 		header->cipherHeaderDetails = headerCipherKeyOpt.get()->details();
+		header->headerKCV = headerCipherKeyOpt.get()->getBaseCipherKCV();
 	} else {
 		header->cipherHeaderDetails = BlobCipherDetails();
+		header->headerKCV = 0;
 		ASSERT_EQ(INVALID_ENCRYPT_DOMAIN_ID, header->cipherHeaderDetails.encryptDomainId);
 		ASSERT_EQ(INVALID_ENCRYPT_CIPHER_KEY_ID, header->cipherHeaderDetails.baseCipherId);
 		ASSERT_EQ(INVALID_ENCRYPT_RANDOM_SALT, header->cipherHeaderDetails.salt);
@@ -1347,6 +1448,19 @@ void DecryptBlobCipherAes256Ctr::validateEncryptHeaderFlagsV1(const uint32_t hea
 	}
 }
 
+void DecryptBlobCipherAes256Ctr::vaidateEncryptHeaderCipherKCVs(const BlobCipherEncryptHeaderRef& headerRef,
+                                                                const BlobCipherEncryptHeaderFlagsV1& flags) {
+	const EncryptHeaderCipherKCVs kcvs = headerRef.getKCVs();
+	Sha256KCV::checkEqual(textCipherKey, kcvs.textKCV);
+	if (flags.authTokenMode != ENCRYPT_HEADER_AUTH_TOKEN_MODE_NONE) {
+		if (!kcvs.headerKCV.present()) {
+			TraceEvent(SevWarnAlways, "MissingHeaderKCV");
+			throw encrypt_key_check_value_mismatch();
+		}
+		Sha256KCV::checkEqual(headerCipherKeyOpt.get(), kcvs.headerKCV.get());
+	}
+}
+
 void DecryptBlobCipherAes256Ctr::validateEncryptHeader(const uint8_t* ciphertext,
                                                        const int ciphertextLen,
                                                        const BlobCipherEncryptHeaderRef& headerRef,
@@ -1368,6 +1482,7 @@ void DecryptBlobCipherAes256Ctr::validateEncryptHeader(const uint8_t* ciphertext
 
 	BlobCipherEncryptHeaderFlagsV1 flags = std::get<BlobCipherEncryptHeaderFlagsV1>(headerRef.flags);
 	validateEncryptHeaderFlagsV1(headerRef.flagsVersion(), flags);
+	vaidateEncryptHeaderCipherKCVs(headerRef, flags);
 	validateAuthTokensV1(ciphertext, ciphertextLen, flags, headerRef);
 
 	*authTokenMode = (EncryptAuthTokenMode)flags.authTokenMode;
@@ -1493,6 +1608,11 @@ void DecryptBlobCipherAes256Ctr::verifyEncryptHeaderMetadata(const BlobCipherEnc
 		CODE_PROBE(true, "Encryption header metadata mismatch");
 
 		throw encrypt_header_metadata_mismatch();
+	}
+
+	Sha256KCV::checkEqual(textCipherKey, header.textKCV);
+	if (header.flags.authTokenMode != ENCRYPT_HEADER_AUTH_TOKEN_MODE_NONE) {
+		Sha256KCV::checkEqual(headerCipherKeyOpt.get(), header.headerKCV);
 	}
 }
 
@@ -1784,6 +1904,73 @@ EncryptAuthTokenMode getEncryptAuthTokenMode(const EncryptAuthTokenMode mode) {
 	                                                     : EncryptAuthTokenMode::ENCRYPT_HEADER_AUTH_TOKEN_MODE_NONE;
 }
 
+Sha256KCV::Sha256KCV() : ctx(EVP_MD_CTX_new()) {
+	if (ctx == nullptr) {
+		TraceEvent(SevError, "ComputeSha256AllocFailed");
+		throw encrypt_ops_error();
+	}
+}
+
+Sha256KCV::~Sha256KCV() {
+	if (ctx != nullptr) {
+		EVP_MD_CTX_free(ctx);
+	}
+}
+
+EncryptCipherKeyCheckValue Sha256KCV::computeKCV(const uint8_t* cipher, const int len) {
+	if (!EVP_DigestInit_ex(ctx, EVP_sha256(), NULL)) {
+		TraceEvent(SevWarnAlways, "ComputeSha256DigestInitFailed");
+		throw encrypt_ops_error();
+	}
+
+	if (!EVP_DigestUpdate(ctx, cipher, len)) {
+		TraceEvent(SevWarnAlways, "ComputeSha256DigestUpdateFailed");
+		throw encrypt_ops_error();
+	}
+
+	unsigned char sha256[EVP_MAX_MD_SIZE];
+	unsigned int sha256Len;
+	if (!EVP_DigestFinal_ex(ctx, sha256, &sha256Len)) {
+		TraceEvent(SevWarnAlways, "ComputeSha256DigestFinalFailed");
+		throw encrypt_ops_error();
+	}
+
+	// KeyValueCheck token allows FDB code to sanitize 'baseCipher' buffer, an external input to FDB. Given the token is
+	// NOT meant to protect against any tampering attack, it is OK to truncate generated SHA256 KCV.
+
+	ASSERT_LE(sizeof(EncryptCipherKeyCheckValue), EVP_MAX_MD_SIZE);
+	EncryptCipherKeyCheckValue kcv;
+	std::memcpy((uint8_t*)&kcv, sha256, sizeof(EncryptCipherKeyCheckValue));
+
+#if BLOB_CIPHER_DEBUG
+	TraceEvent("ComputeSha256KCV").detail("KCV", kcv);
+#endif
+
+	CODE_PROBE(true, "Sha256 KCV generation done");
+	return kcv;
+}
+
+void Sha256KCV::checkEqual(const Reference<BlobCipherKey>& cipher, const EncryptCipherKeyCheckValue persisted) {
+	ASSERT(cipher.isValid());
+
+#if BLOB_CIPHER_DEBUG
+	TraceEvent(SevDebug, "Sha256KCVCheckEqual")
+	    .detail("CipherKCV", cipher->getBaseCipherKCV())
+	    .detail("Persisted", persisted);
+#endif
+
+	if (cipher->getBaseCipherKCV() != persisted) {
+		CODE_PROBE(true, "Sha256 Key Check Value mismatch");
+		TraceEvent(SevWarnAlways, "Sha256KCVMismatch")
+		    .detail("Computed", cipher->getBaseCipherKCV())
+		    .detail("Persited", persisted)
+		    .detail("DomainId", cipher->getDomainId())
+		    .detail("BaseCipherId", cipher->getBaseCipherId());
+		throw encrypt_key_check_value_mismatch();
+	}
+	CODE_PROBE(true, "Sha256 KCV validation done");
+}
+
 // Only used to link unit tests
 void forceLinkBlobCipherTests() {}
 
@@ -1807,6 +1994,7 @@ public:
 	int len;
 	EncryptCipherBaseKeyId keyId;
 	std::unique_ptr<uint8_t[]> key;
+	EncryptCipherKeyCheckValue kcv;
 	int64_t refreshAt;
 	int64_t expireAt;
 	EncryptCipherRandomSalt generatedSalt;
@@ -1815,22 +2003,60 @@ public:
 	           const EncryptCipherBaseKeyId& kId,
 	           const int64_t rAt,
 	           const int64_t eAt)
-	  : domainId(dId), len(deterministicRandom()->randomInt(4, 128)), keyId(kId), key(std::make_unique<uint8_t[]>(len)),
-	    refreshAt(rAt), expireAt(eAt) {
+	  : domainId(dId), len(deterministicRandom()->randomInt(4, MAX_BASE_CIPHER_LEN + 1)), keyId(kId),
+	    key(std::make_unique<uint8_t[]>(len)), refreshAt(rAt), expireAt(eAt) {
 		deterministicRandom()->randomBytes(key.get(), len);
+		kcv = Sha256KCV().computeKCV(key.get(), len);
 	}
 };
+
+Reference<BlobCipherKey> corruptCipherKey(const Reference<BlobCipherKey>& cipherKey) {
+	std::unique_ptr<uint8_t[]> corruptedBaseCipher = std::make_unique<uint8_t[]>(cipherKey->getBaseCipherLen());
+	memcpy(corruptedBaseCipher.get(), cipherKey->rawBaseCipher(), cipherKey->getBaseCipherLen());
+	const int idx = deterministicRandom()->randomInt(0, cipherKey->getBaseCipherLen());
+	corruptedBaseCipher.get()[idx]++;
+	const EncryptCipherKeyCheckValue baseCipherKCV =
+	    Sha256KCV().computeKCV(corruptedBaseCipher.get(), cipherKey->getBaseCipherLen());
+	return makeReference<BlobCipherKey>(cipherKey->getDomainId(),
+	                                    cipherKey->getBaseCipherId(),
+	                                    corruptedBaseCipher.get(),
+	                                    cipherKey->getBaseCipherLen(),
+	                                    baseCipherKCV,
+	                                    cipherKey->getRefreshAtTS(),
+	                                    cipherKey->getExpireAtTS());
+}
 
 using BaseKeyMap = std::unordered_map<EncryptCipherBaseKeyId, Reference<BaseCipher>>;
 using DomainKeyMap = std::unordered_map<EncryptCipherDomainId, BaseKeyMap>;
 
 } // namespace
 
+void testMaxBaseCipherLen() {
+	TraceEvent("TestMaxBaseCipherLenStart");
+	try {
+		const int baseCipherLen = deterministicRandom()->randomInt(MAX_BASE_CIPHER_LEN + 1, MAX_BASE_CIPHER_LEN + 10);
+		uint8_t baseCipher[baseCipherLen];
+		deterministicRandom()->randomBytes(&baseCipher[0], baseCipherLen);
+		const EncryptCipherKeyCheckValue baseCipherKCV = Sha256KCV().computeKCV(&baseCipher[0], baseCipherLen);
+		Reference<BlobCipherKey> cipher = makeReference<BlobCipherKey>(1,
+		                                                               1,
+		                                                               &baseCipher[0],
+		                                                               baseCipherLen,
+		                                                               baseCipherKCV,
+		                                                               std::numeric_limits<int64_t>::max(),
+		                                                               std::numeric_limits<int64_t>::max());
+		ASSERT(false); // error expected
+	} catch (Error& e) {
+		ASSERT_EQ(e.code(), error_code_encrypt_max_base_cipher_len);
+	}
+	TraceEvent("TestMaxBaseCipherLenDone");
+}
+
 void testKeyCacheEssentials(DomainKeyMap& domainKeyMap,
                             const int minDomainId,
                             const int maxDomainId,
                             const int minBaseCipherKeyId) {
-	TraceEvent("BlobCipherCacheEssentialsStart");
+	TraceEvent("TestCacheEssentialsStart");
 
 	Reference<BlobCipherKeyCache> cipherKeyCache = BlobCipherKeyCache::getInstance();
 
@@ -1844,7 +2070,7 @@ void testKeyCacheEssentials(DomainKeyMap& domainKeyMap,
 	}
 
 	// insert BlobCipher keys into BlobCipherKeyCache map and validate
-	TraceEvent("BlobCipherTestInsertKeys").log();
+	TraceEvent("TestInsertKeys").log();
 	for (auto& domainItr : domainKeyMap) {
 		for (auto& baseKeyItr : domainItr.second) {
 			Reference<BaseCipher> baseCipher = baseKeyItr.second;
@@ -1853,6 +2079,7 @@ void testKeyCacheEssentials(DomainKeyMap& domainKeyMap,
 			                                baseCipher->keyId,
 			                                baseCipher->key.get(),
 			                                baseCipher->len,
+			                                baseCipher->kcv,
 			                                baseCipher->refreshAt,
 			                                baseCipher->expireAt);
 			Reference<BlobCipherKey> fetchedKey = cipherKeyCache->getLatestCipherKey(baseCipher->domainId);
@@ -1866,10 +2093,11 @@ void testKeyCacheEssentials(DomainKeyMap& domainKeyMap,
 	                                headerBaseCipher->keyId,
 	                                headerBaseCipher->key.get(),
 	                                headerBaseCipher->len,
+	                                headerBaseCipher->kcv,
 	                                headerBaseCipher->refreshAt,
 	                                headerBaseCipher->expireAt);
 
-	TraceEvent("BlobCipherTestInsertKeysDone").log();
+	TraceEvent("TestInsertKeysDone").log();
 
 	// validate the cipherKey lookups work as desired
 	for (auto& domainItr : domainKeyMap) {
@@ -1889,7 +2117,7 @@ void testKeyCacheEssentials(DomainKeyMap& domainKeyMap,
 			ASSERT_NE(std::memcmp(cipherKey->rawCipher(), baseCipher->key.get(), len), 0);
 		}
 	}
-	TraceEvent("BlobCipherTestLooksupDone").log();
+	TraceEvent("TestLooksupDone").log();
 
 	// Ensure attemtping to insert existing cipherKey (identical) more than once is treated as a NOP
 	try {
@@ -1898,12 +2126,13 @@ void testKeyCacheEssentials(DomainKeyMap& domainKeyMap,
 		                                baseCipher->keyId,
 		                                baseCipher->key.get(),
 		                                baseCipher->len,
+		                                baseCipher->kcv,
 		                                std::numeric_limits<int64_t>::max(),
 		                                std::numeric_limits<int64_t>::max());
 	} catch (Error& e) {
 		throw;
 	}
-	TraceEvent("BlobCipherTestReinsertIdempotentKeyDone").log();
+	TraceEvent("TestReinsertIdempotentKeyDone").log();
 
 	// Ensure attemtping to insert an existing cipherKey (modified) fails with appropriate error
 	try {
@@ -1917,16 +2146,17 @@ void testKeyCacheEssentials(DomainKeyMap& domainKeyMap,
 		                                baseCipher->keyId,
 		                                &rawCipher[0],
 		                                baseCipher->len,
+		                                baseCipher->kcv,
 		                                std::numeric_limits<int64_t>::max(),
 		                                std::numeric_limits<int64_t>::max());
 	} catch (Error& e) {
 		if (e.code() != error_code_encrypt_update_cipher) {
 			throw;
 		}
+		TraceEvent("TestReinsertNonIdempotentKeyDone");
 	}
-	TraceEvent("BlobCipherTestReinsertNonIdempotentKeyDone");
 
-	TraceEvent("BlobCipherCacheEssentialsEnd");
+	TraceEvent("TestCacheEssentialsEnd");
 }
 
 void testKeyCacheRefreshExpireCipherKey(DomainKeyMap& domainKeyMap, const int maxDomainId) {
@@ -1939,6 +2169,7 @@ void testKeyCacheRefreshExpireCipherKey(DomainKeyMap& domainKeyMap, const int ma
 
 	Standalone<StringRef> baseCipher = makeString(4);
 	deterministicRandom()->randomBytes(mutateString(baseCipher), 4);
+	EncryptCipherKeyCheckValue baseCipherKCV = Sha256KCV().computeKCV(baseCipher.begin(), baseCipher.size());
 
 	Counter::Value expectedNeedRefreshCount =
 	    BlobCipherMetrics::getInstance()->latestCipherKeyCacheNeedsRefresh.getValue();
@@ -1950,8 +2181,8 @@ void testKeyCacheRefreshExpireCipherKey(DomainKeyMap& domainKeyMap, const int ma
 	// Insert key that needs refresh
 	int64_t refreshAt = now() - 1;
 	int64_t expireAt = std::numeric_limits<int64_t>::max();
-	Reference<BlobCipherKey> inserted =
-	    cipherKeyCache->insertCipherKey(domId, 1, baseCipher.begin(), baseCipher.size(), refreshAt, expireAt);
+	Reference<BlobCipherKey> inserted = cipherKeyCache->insertCipherKey(
+	    domId, 1, baseCipher.begin(), baseCipher.size(), baseCipherKCV, refreshAt, expireAt);
 	EncryptCipherRandomSalt salt = inserted->getSalt();
 
 	Reference<BlobCipherKey> cipher = cipherKeyCache->getLatestCipherKey(domId);
@@ -1986,8 +2217,8 @@ void testKeyCacheRefreshExpireCipherKey(DomainKeyMap& domainKeyMap, const int ma
 	// Re-insert same key with same 'baseCipherId' and cache should accept it
 	refreshAt = now() + 5;
 	expireAt = now() + 10; // limit the expiry of the cipher
-	Reference<BlobCipherKey> insertAgain =
-	    cipherKeyCache->insertCipherKey(domId, 1, baseCipher.begin(), baseCipher.size(), refreshAt, expireAt);
+	Reference<BlobCipherKey> insertAgain = cipherKeyCache->insertCipherKey(
+	    domId, 1, baseCipher.begin(), baseCipher.size(), baseCipherKCV, refreshAt, expireAt);
 	salt = insertAgain->getSalt();
 	cipher = cipherKeyCache->getLatestCipherKey(domId);
 	expectedLatestHitCount++;
@@ -2009,7 +2240,8 @@ void testKeyCacheRefreshExpireCipherKey(DomainKeyMap& domainKeyMap, const int ma
 	domId++;
 	expireAt = now() - 100;
 	refreshAt = expireAt - 10;
-	inserted = cipherKeyCache->insertCipherKey(domId, 1, baseCipher.begin(), baseCipher.size(), refreshAt, expireAt);
+	inserted = cipherKeyCache->insertCipherKey(
+	    domId, 1, baseCipher.begin(), baseCipher.size(), baseCipherKCV, refreshAt, expireAt);
 	salt = inserted->getSalt();
 
 	// Ensure getLatestCipher desired behavior
@@ -2026,7 +2258,8 @@ void testKeyCacheRefreshExpireCipherKey(DomainKeyMap& domainKeyMap, const int ma
 	ASSERT_EQ(BlobCipherMetrics::getInstance()->cipherKeyCacheExpired.getValue(), expectedExpiredKeys);
 
 	// Ensure getCipher desired behavior
-	inserted = cipherKeyCache->insertCipherKey(domId, 1, baseCipher.begin(), baseCipher.size(), refreshAt, expireAt);
+	inserted = cipherKeyCache->insertCipherKey(
+	    domId, 1, baseCipher.begin(), baseCipher.size(), baseCipherKCV, refreshAt, expireAt);
 	salt = inserted->getSalt();
 	cipher = cipherKeyCache->getCipherKey(domId, 1, salt);
 	ASSERT(!cipher.isValid());
@@ -2041,7 +2274,7 @@ void testKeyCacheRefreshExpireCipherKey(DomainKeyMap& domainKeyMap, const int ma
 }
 
 void testNoAuthMode(const int minDomainId) {
-	TraceEvent("BlobCipherTestInsertKeysDone").log();
+	TraceEvent("TestNoAuthModeStart");
 
 	Reference<BlobCipherKeyCache> cipherKeyCache = BlobCipherKeyCache::getInstance();
 
@@ -2071,7 +2304,7 @@ void testNoAuthMode(const int minDomainId) {
 	ASSERT_EQ(header.flags.encryptMode, EncryptCipherMode::ENCRYPT_CIPHER_MODE_AES_256_CTR);
 	ASSERT_EQ(header.flags.authTokenMode, EncryptAuthTokenMode::ENCRYPT_HEADER_AUTH_TOKEN_MODE_NONE);
 
-	TraceEvent("BlobCipherTestEncryptDone")
+	TraceEvent("TestNoAuthEncryptDone")
 	    .detail("HeaderVersion", header.flags.headerVersion)
 	    .detail("HeaderEncryptMode", header.flags.encryptMode)
 	    .detail("HeaderEncryptAuthTokenMode", header.flags.authTokenMode)
@@ -2079,17 +2312,17 @@ void testNoAuthMode(const int minDomainId) {
 	    .detail("DomainId", header.cipherTextDetails.encryptDomainId)
 	    .detail("BaseCipherId", header.cipherTextDetails.baseCipherId);
 
-	Reference<BlobCipherKey> tCipherKeyKey = cipherKeyCache->getCipherKey(
+	Reference<BlobCipherKey> tCipherKey = cipherKeyCache->getCipherKey(
 	    header.cipherTextDetails.encryptDomainId, header.cipherTextDetails.baseCipherId, header.cipherTextDetails.salt);
-	ASSERT(tCipherKeyKey->isEqual(cipherKey));
+	ASSERT(tCipherKey->isEqual(cipherKey));
 	DecryptBlobCipherAes256Ctr decryptor(
-	    tCipherKeyKey, Reference<BlobCipherKey>(), &header.iv[0], BlobCipherMetrics::TEST);
+	    tCipherKey, Reference<BlobCipherKey>(), &header.iv[0], BlobCipherMetrics::TEST);
 
 	Reference<EncryptBuf> decrypted = decryptor.decrypt(encrypted->begin(), bufLen, header, arena);
 	ASSERT_EQ(decrypted->getLogicalSize(), bufLen);
 	ASSERT_EQ(memcmp(decrypted->begin(), &orgData[0], bufLen), 0);
 
-	TraceEvent("BlobCipherTestDecryptDone");
+	TraceEvent("TestNoAuthDecryptDone");
 
 	// induce encryption header corruption - headerVersion corrupted
 	BlobCipherEncryptHeader headerCopy;
@@ -2100,13 +2333,14 @@ void testNoAuthMode(const int minDomainId) {
 	try {
 		encrypted = encryptor.encrypt(&orgData[0], bufLen, &header, arena);
 		DecryptBlobCipherAes256Ctr decryptor(
-		    tCipherKeyKey, Reference<BlobCipherKey>(), header.iv, BlobCipherMetrics::TEST);
+		    tCipherKey, Reference<BlobCipherKey>(), header.iv, BlobCipherMetrics::TEST);
 		decrypted = decryptor.decrypt(encrypted->begin(), bufLen, headerCopy, arena);
 		ASSERT(false); // error expected
 	} catch (Error& e) {
 		if (e.code() != error_code_encrypt_header_metadata_mismatch) {
 			throw;
 		}
+		TraceEvent("TestNoAuthHeaderVersionCorruptionDone");
 	}
 
 	// induce encryption header corruption - encryptionMode corrupted
@@ -2117,13 +2351,14 @@ void testNoAuthMode(const int minDomainId) {
 	try {
 		encrypted = encryptor.encrypt(&orgData[0], bufLen, &header, arena);
 		DecryptBlobCipherAes256Ctr decryptor(
-		    tCipherKeyKey, Reference<BlobCipherKey>(), header.iv, BlobCipherMetrics::TEST);
+		    tCipherKey, Reference<BlobCipherKey>(), header.iv, BlobCipherMetrics::TEST);
 		decrypted = decryptor.decrypt(encrypted->begin(), bufLen, headerCopy, arena);
 		ASSERT(false); // error expected
 	} catch (Error& e) {
 		if (e.code() != error_code_encrypt_header_metadata_mismatch) {
 			throw;
 		}
+		TraceEvent("TestNoAuthEncryptModeCorruptionDone");
 	}
 
 	// induce encrypted buffer payload corruption
@@ -2135,11 +2370,25 @@ void testNoAuthMode(const int minDomainId) {
 		int tIdx = deterministicRandom()->randomInt(0, bufLen - 1);
 		temp[tIdx] += 1;
 		DecryptBlobCipherAes256Ctr decryptor(
-		    tCipherKeyKey, Reference<BlobCipherKey>(), header.iv, BlobCipherMetrics::TEST);
+		    tCipherKey, Reference<BlobCipherKey>(), header.iv, BlobCipherMetrics::TEST);
 		decrypted = decryptor.decrypt(&temp[0], bufLen, header, arena);
+		TraceEvent("TestNoAuthEncryptPayloadCorruptionDone");
 	} catch (Error& e) {
 		// No authToken, hence, no corruption detection supported
 		ASSERT(false);
+	}
+
+	// induce baseCipher corruption
+	try {
+		encrypted = encryptor.encrypt(&orgData[0], bufLen, &header, arena);
+		Reference<BlobCipherKey> corruptedCipher = corruptCipherKey(tCipherKey);
+		DecryptBlobCipherAes256Ctr decryptor(
+		    corruptedCipher, Reference<BlobCipherKey>(), header.iv, BlobCipherMetrics::TEST);
+		decrypted = decryptor.decrypt(encrypted->begin(), bufLen, header, arena);
+		ASSERT(false); // error expected
+	} catch (Error& e) {
+		ASSERT_EQ(e.code(), error_code_encrypt_key_check_value_mismatch);
+		TraceEvent("TestNoAuthEncryptBaseCipherCorruptionDone");
 	}
 
 	TraceEvent("BlobCipherTestNoAuthModeDone");
@@ -2288,7 +2537,7 @@ void testConfigurableEncryptionHeaderNoAuthMode(const int minDomainId) {
 void testConfigurableEncryptionNoAuthMode(const int minDomainId) {
 	ASSERT(CLIENT_KNOBS->ENABLE_CONFIGURABLE_ENCRYPTION);
 
-	TraceEvent("BlobCipherTestConfigurableEncryptionNoAuthModeStart");
+	TraceEvent("TestConfigurableEncryptionNoAuthModeStart");
 
 	Reference<BlobCipherKeyCache> cipherKeyCache = BlobCipherKeyCache::getInstance();
 
@@ -2315,18 +2564,18 @@ void testConfigurableEncryptionNoAuthMode(const int minDomainId) {
 
 	// validate header version details
 	AesCtrNoAuth noAuth = std::get<AesCtrNoAuth>(headerRef.algoHeader);
-	Reference<BlobCipherKey> tCipherKeyKey = cipherKeyCache->getCipherKey(noAuth.v1.cipherTextDetails.encryptDomainId,
-	                                                                      noAuth.v1.cipherTextDetails.baseCipherId,
-	                                                                      noAuth.v1.cipherTextDetails.salt);
-	ASSERT(tCipherKeyKey->isEqual(cipherKey));
+	Reference<BlobCipherKey> tCipherKey = cipherKeyCache->getCipherKey(noAuth.v1.cipherTextDetails.encryptDomainId,
+	                                                                   noAuth.v1.cipherTextDetails.baseCipherId,
+	                                                                   noAuth.v1.cipherTextDetails.salt);
+	ASSERT(tCipherKey->isEqual(cipherKey));
 	DecryptBlobCipherAes256Ctr decryptor(
-	    tCipherKeyKey, Reference<BlobCipherKey>(), &noAuth.v1.iv[0], BlobCipherMetrics::TEST);
+	    tCipherKey, Reference<BlobCipherKey>(), &noAuth.v1.iv[0], BlobCipherMetrics::TEST);
 
 	StringRef decryptedBuf = decryptor.decrypt(encryptedBuf.begin(), encryptedBuf.size(), headerRef, arena);
 	ASSERT_EQ(decryptedBuf.size(), bufLen);
 	ASSERT_EQ(memcmp(decryptedBuf.begin(), &orgData[0], bufLen), 0);
 
-	TraceEvent("BlobCipherTestEncryptDecryptDone")
+	TraceEvent("TestConfigurableEncryptionNoAuthDecryptDone")
 	    .detail("HeaderFlagsVersion", headerRef.flagsVersion())
 	    .detail("AlgoHeaderVersion", headerRef.algoHeaderVersion())
 	    .detail("HeaderEncryptMode", ENCRYPT_CIPHER_MODE_AES_256_CTR)
@@ -2343,15 +2592,14 @@ void testConfigurableEncryptionNoAuthMode(const int minDomainId) {
 	corruptedHeaderRef.flags = corruptedFlags;
 	try {
 		encryptedBuf = encryptor.encrypt(&orgData[0], bufLen, &headerRef, arena);
-		DecryptBlobCipherAes256Ctr decryptor(
-		    tCipherKeyKey, Reference<BlobCipherKey>(), &iv[0], BlobCipherMetrics::TEST);
+		DecryptBlobCipherAes256Ctr decryptor(tCipherKey, Reference<BlobCipherKey>(), &iv[0], BlobCipherMetrics::TEST);
 		decryptedBuf = decryptor.decrypt(encryptedBuf.begin(), bufLen, corruptedHeaderRef, arena);
 		ASSERT(false); // error expected
 	} catch (Error& e) {
 		if (e.code() != error_code_encrypt_header_metadata_mismatch) {
 			throw;
 		}
-		TraceEvent("ConfigurableEncryptionNoAuthCorruptEncryptModeDone");
+		TraceEvent("TestConfigurableEncryptionNoAuthHeaderCorruptionDone");
 	}
 
 	// induce encrypted buffer payload corruption
@@ -2362,13 +2610,26 @@ void testConfigurableEncryptionNoAuthMode(const int minDomainId) {
 		memcpy((void*)encryptedBuf.begin(), &temp[0], bufLen);
 		int tIdx = deterministicRandom()->randomInt(0, bufLen - 1);
 		temp[tIdx] += 1;
-		DecryptBlobCipherAes256Ctr decryptor(
-		    tCipherKeyKey, Reference<BlobCipherKey>(), &iv[0], BlobCipherMetrics::TEST);
+		DecryptBlobCipherAes256Ctr decryptor(tCipherKey, Reference<BlobCipherKey>(), &iv[0], BlobCipherMetrics::TEST);
 		decryptedBuf = decryptor.decrypt(&temp[0], bufLen, headerRef, arena);
 		ASSERT_NE(memcmp(decryptedBuf.begin(), &orgData[0], bufLen), 0);
+		TraceEvent("TestConfigurableEncryptionNoAuthPayloadCorruptionDone");
 	} catch (Error& e) {
 		// No authToken, hence, no corruption detection supported
 		ASSERT(false);
+	}
+
+	// induce baseCipher corruption
+	try {
+		Reference<BlobCipherKey> corruptedTextCipher = corruptCipherKey(tCipherKey);
+		encryptedBuf = encryptor.encrypt(&orgData[0], bufLen, &headerRef, arena);
+		DecryptBlobCipherAes256Ctr decryptor(
+		    corruptedTextCipher, Reference<BlobCipherKey>(), &iv[0], BlobCipherMetrics::TEST);
+		decryptedBuf = decryptor.decrypt(encryptedBuf.begin(), bufLen, headerRef, arena);
+		ASSERT(false); // error expected
+	} catch (Error& e) {
+		ASSERT_EQ(e.code(), error_code_encrypt_key_check_value_mismatch);
+		TraceEvent("TestConfigurableEncryptionNoAuthBaseCipherCorruptionDone");
 	}
 
 	TraceEvent("ConfigurableEncryptionNoAuthDone");
@@ -2383,7 +2644,7 @@ void testSingleAuthMode(const int minDomainId) {
 	const EncryptAuthTokenAlgo authAlgo = isHmac ? EncryptAuthTokenAlgo::ENCRYPT_HEADER_AUTH_TOKEN_ALGO_HMAC_SHA
 	                                             : EncryptAuthTokenAlgo::ENCRYPT_HEADER_AUTH_TOKEN_ALGO_AES_CMAC;
 
-	TraceEvent("BlobCipherTestSingleAuthTokenStart").detail("Mode", authAlgoStr);
+	TraceEvent("TestSingleAuthTokenStart").detail("Mode", authAlgoStr);
 
 	Reference<BlobCipherKeyCache> cipherKeyCache = BlobCipherKeyCache::getInstance();
 
@@ -2414,7 +2675,7 @@ void testSingleAuthMode(const int minDomainId) {
 	ASSERT_EQ(header.flags.authTokenMode, EncryptAuthTokenMode::ENCRYPT_HEADER_AUTH_TOKEN_MODE_SINGLE);
 	ASSERT_EQ(header.flags.authTokenAlgo, authAlgo);
 
-	TraceEvent("BlobCipherTestEncryptDone")
+	TraceEvent("TestSingleAuthTokenEncryptDone")
 	    .detail("HeaderVersion", header.flags.headerVersion)
 	    .detail("HeaderEncryptMode", header.flags.encryptMode)
 	    .detail("HeaderEncryptAuthTokenMode", header.flags.authTokenMode)
@@ -2424,19 +2685,19 @@ void testSingleAuthMode(const int minDomainId) {
 	    .detail("HeaderAuthToken",
 	            StringRef(arena, &header.singleAuthToken.authToken[0], Params::authTokenSize).toString());
 
-	Reference<BlobCipherKey> tCipherKeyKey = cipherKeyCache->getCipherKey(
+	Reference<BlobCipherKey> tCipherKey = cipherKeyCache->getCipherKey(
 	    header.cipherTextDetails.encryptDomainId, header.cipherTextDetails.baseCipherId, header.cipherTextDetails.salt);
 	Reference<BlobCipherKey> hCipherKey = cipherKeyCache->getCipherKey(header.cipherHeaderDetails.encryptDomainId,
 	                                                                   header.cipherHeaderDetails.baseCipherId,
 	                                                                   header.cipherHeaderDetails.salt);
-	ASSERT(tCipherKeyKey->isEqual(cipherKey));
-	DecryptBlobCipherAes256Ctr decryptor(tCipherKeyKey, hCipherKey, header.iv, BlobCipherMetrics::TEST);
+	ASSERT(tCipherKey->isEqual(cipherKey));
+	DecryptBlobCipherAes256Ctr decryptor(tCipherKey, hCipherKey, header.iv, BlobCipherMetrics::TEST);
 	Reference<EncryptBuf> decrypted = decryptor.decrypt(encrypted->begin(), bufLen, header, arena);
 
 	ASSERT_EQ(decrypted->getLogicalSize(), bufLen);
 	ASSERT_EQ(memcmp(decrypted->begin(), &orgData[0], bufLen), 0);
 
-	TraceEvent("BlobCipherTestDecryptDone");
+	TraceEvent("TestSingleAuthTokenDecryptDone").detail("Mode", authAlgoStr);
 
 	// induce encryption header corruption - headerVersion corrupted
 	BlobCipherEncryptHeader headerCopy;
@@ -2446,13 +2707,14 @@ void testSingleAuthMode(const int minDomainId) {
 	       sizeof(BlobCipherEncryptHeader));
 	headerCopy.flags.headerVersion += 1;
 	try {
-		DecryptBlobCipherAes256Ctr decryptor(tCipherKeyKey, hCipherKey, header.iv, BlobCipherMetrics::TEST);
+		DecryptBlobCipherAes256Ctr decryptor(tCipherKey, hCipherKey, header.iv, BlobCipherMetrics::TEST);
 		decrypted = decryptor.decrypt(encrypted->begin(), bufLen, headerCopy, arena);
 		ASSERT(false); // error expected
 	} catch (Error& e) {
 		if (e.code() != error_code_encrypt_header_metadata_mismatch) {
 			throw;
 		}
+		TraceEvent("TestSingleAuthTokenHeaderVersionCorruptionDone").detail("Mode", authAlgoStr);
 	}
 
 	// induce encryption header corruption - encryptionMode corrupted
@@ -2462,13 +2724,14 @@ void testSingleAuthMode(const int minDomainId) {
 	       sizeof(BlobCipherEncryptHeader));
 	headerCopy.flags.encryptMode += 1;
 	try {
-		DecryptBlobCipherAes256Ctr decryptor(tCipherKeyKey, hCipherKey, header.iv, BlobCipherMetrics::TEST);
+		DecryptBlobCipherAes256Ctr decryptor(tCipherKey, hCipherKey, header.iv, BlobCipherMetrics::TEST);
 		decrypted = decryptor.decrypt(encrypted->begin(), bufLen, headerCopy, arena);
 		ASSERT(false); // error expected
 	} catch (Error& e) {
 		if (e.code() != error_code_encrypt_header_metadata_mismatch) {
 			throw;
 		}
+		TraceEvent("TestSingleAuthTokenEncryptModeCorruptionDone").detail("Mode", authAlgoStr);
 	}
 
 	// induce encryption header corruption - authToken mismatch
@@ -2479,13 +2742,14 @@ void testSingleAuthMode(const int minDomainId) {
 	int hIdx = deterministicRandom()->randomInt(0, Params::authTokenSize - 1);
 	headerCopy.singleAuthToken.authToken[hIdx] += 1;
 	try {
-		DecryptBlobCipherAes256Ctr decryptor(tCipherKeyKey, hCipherKey, header.iv, BlobCipherMetrics::TEST);
+		DecryptBlobCipherAes256Ctr decryptor(tCipherKey, hCipherKey, header.iv, BlobCipherMetrics::TEST);
 		decrypted = decryptor.decrypt(encrypted->begin(), bufLen, headerCopy, arena);
 		ASSERT(false); // error expected
 	} catch (Error& e) {
 		if (e.code() != error_code_encrypt_header_authtoken_mismatch) {
 			throw;
 		}
+		TraceEvent("TestSingleAuthTokenAuthTokenMismatchDone").detail("Mode", authAlgoStr);
 	}
 
 	// induce encrypted buffer payload corruption
@@ -2496,12 +2760,32 @@ void testSingleAuthMode(const int minDomainId) {
 		memcpy(encrypted->begin(), &temp[0], bufLen);
 		int tIdx = deterministicRandom()->randomInt(0, bufLen - 1);
 		temp[tIdx] += 1;
-		DecryptBlobCipherAes256Ctr decryptor(tCipherKeyKey, hCipherKey, header.iv, BlobCipherMetrics::TEST);
+		DecryptBlobCipherAes256Ctr decryptor(tCipherKey, hCipherKey, header.iv, BlobCipherMetrics::TEST);
 		decrypted = decryptor.decrypt(&temp[0], bufLen, header, arena);
 	} catch (Error& e) {
 		if (e.code() != error_code_encrypt_header_authtoken_mismatch) {
 			throw;
 		}
+		TraceEvent("TestSingleAuthTokenPayloadCorruptionDone").detail("Mode", authAlgoStr);
+	}
+
+	// induce baseCipher corruption
+	try {
+		const bool corruptTextCipher = deterministicRandom()->coinflip();
+		encrypted = encryptor.encrypt(&orgData[0], bufLen, &header, arena);
+		if (corruptTextCipher) {
+			Reference<BlobCipherKey> corruptedCipher = corruptCipherKey(tCipherKey);
+			DecryptBlobCipherAes256Ctr decryptor(corruptedCipher, hCipherKey, header.iv, BlobCipherMetrics::TEST);
+			decrypted = decryptor.decrypt(encrypted->begin(), bufLen, header, arena);
+		} else {
+			Reference<BlobCipherKey> corruptedCipher = corruptCipherKey(hCipherKey);
+			DecryptBlobCipherAes256Ctr decryptor(tCipherKey, corruptedCipher, header.iv, BlobCipherMetrics::TEST);
+			decrypted = decryptor.decrypt(encrypted->begin(), bufLen, header, arena);
+		}
+		ASSERT(false); // error expected
+	} catch (Error& e) {
+		ASSERT_EQ(e.code(), error_code_encrypt_key_check_value_mismatch);
+		TraceEvent("TestSingleAuthTokenBaseCipherCorruptionDone").detail("Mode", authAlgoStr);
 	}
 
 	TraceEvent("BlobCipherTestSingleAuthTokenEnd").detail("Mode", authAlgoStr);
@@ -2586,7 +2870,7 @@ void testConfigurableEncryptionSingleAuthMode(const int minDomainId) {
 
 	ASSERT(CLIENT_KNOBS->ENABLE_CONFIGURABLE_ENCRYPTION);
 
-	TraceEvent("BlobCipherTestEncryptionHeaderStart").detail("Mode", authAlgoStr);
+	TraceEvent("TestConfigurableEncryptionSingleAuthStart").detail("Mode", authAlgoStr);
 
 	Reference<BlobCipherKeyCache> cipherKeyCache = BlobCipherKeyCache::getInstance();
 
@@ -2633,21 +2917,21 @@ void testConfigurableEncryptionSingleAuthMode(const int minDomainId) {
 	ASSERT_EQ(withAuth.v1.cipherHeaderDetails.baseCipherId, headerCipherKey->getBaseCipherId());
 	ASSERT_EQ(withAuth.v1.cipherHeaderDetails.salt, headerCipherKey->getSalt());
 
-	Reference<BlobCipherKey> tCipherKeyKey = cipherKeyCache->getCipherKey(withAuth.v1.cipherTextDetails.encryptDomainId,
-	                                                                      withAuth.v1.cipherTextDetails.baseCipherId,
-	                                                                      withAuth.v1.cipherTextDetails.salt);
+	Reference<BlobCipherKey> tCipherKey = cipherKeyCache->getCipherKey(withAuth.v1.cipherTextDetails.encryptDomainId,
+	                                                                   withAuth.v1.cipherTextDetails.baseCipherId,
+	                                                                   withAuth.v1.cipherTextDetails.salt);
 	Reference<BlobCipherKey> hCipherKey = cipherKeyCache->getCipherKey(withAuth.v1.cipherHeaderDetails.encryptDomainId,
 	                                                                   withAuth.v1.cipherHeaderDetails.baseCipherId,
 	                                                                   withAuth.v1.cipherHeaderDetails.salt);
-	ASSERT(tCipherKeyKey->isEqual(cipherKey));
+	ASSERT(tCipherKey->isEqual(cipherKey));
 	ASSERT(hCipherKey->isEqual(headerCipherKey));
-	DecryptBlobCipherAes256Ctr decryptor(tCipherKeyKey, hCipherKey, &withAuth.v1.iv[0], BlobCipherMetrics::TEST);
+	DecryptBlobCipherAes256Ctr decryptor(tCipherKey, hCipherKey, &withAuth.v1.iv[0], BlobCipherMetrics::TEST);
 	StringRef decryptedBuf = decryptor.decrypt(encryptedBuf.begin(), bufLen, headerRef, arena);
 
 	ASSERT_EQ(decryptedBuf.size(), bufLen);
 	ASSERT_EQ(memcmp(decryptedBuf.begin(), &orgData[0], bufLen), 0);
 
-	TraceEvent("BlobCipherTestEncryptDecryptDone")
+	TraceEvent("TestConfigurableEncryptSingleAuthDecryptDone")
 	    .detail("HeaderFlagsVersion", headerRef.flagsVersion())
 	    .detail("AlgoHeaderVersion", headerRef.algoHeaderVersion())
 	    .detail("HeaderEncryptMode", flags.encryptMode)
@@ -2667,14 +2951,14 @@ void testConfigurableEncryptionSingleAuthMode(const int minDomainId) {
 	corruptedHeaderRef.flags = corruptedFlags;
 	try {
 		encryptedBuf = encryptor.encrypt(&orgData[0], bufLen, &headerRef, arena);
-		DecryptBlobCipherAes256Ctr decryptor(tCipherKeyKey, hCipherKey, &iv[0], BlobCipherMetrics::TEST);
+		DecryptBlobCipherAes256Ctr decryptor(tCipherKey, hCipherKey, &iv[0], BlobCipherMetrics::TEST);
 		decryptedBuf = decryptor.decrypt(encryptedBuf.begin(), bufLen, corruptedHeaderRef, arena);
 		ASSERT(false); // error expected
 	} catch (Error& e) {
 		if (e.code() != error_code_encrypt_header_metadata_mismatch) {
 			throw;
 		}
-		TraceEvent("ConfigurableEncryptionCorruptEncryptModeDone").detail("Mode", authAlgoStr);
+		TraceEvent("TestConfigurableEncryptionCorruptEncryptModeDone").detail("Mode", authAlgoStr);
 	}
 
 	// induce encrypted buffer payload corruption
@@ -2685,14 +2969,33 @@ void testConfigurableEncryptionSingleAuthMode(const int minDomainId) {
 		memcpy((void*)encryptedBuf.begin(), &temp[0], bufLen);
 		int tIdx = deterministicRandom()->randomInt(0, bufLen - 1);
 		temp[tIdx] += 1;
-		DecryptBlobCipherAes256Ctr decryptor(tCipherKeyKey, hCipherKey, &iv[0], BlobCipherMetrics::TEST);
+		DecryptBlobCipherAes256Ctr decryptor(tCipherKey, hCipherKey, &iv[0], BlobCipherMetrics::TEST);
 		decryptedBuf = decryptor.decrypt(&temp[0], bufLen, headerRef, arena);
 		ASSERT_NE(memcmp(decryptedBuf.begin(), &orgData[0], bufLen), 0);
 	} catch (Error& e) {
 		if (e.code() != error_code_encrypt_header_authtoken_mismatch) {
 			throw;
 		}
-		TraceEvent("ConfigurableEncryptionCorruptPayloadDone").detail("Mode", authAlgoStr);
+		TraceEvent("TestConfigurableEncryptionCorruptPayloadDone").detail("Mode", authAlgoStr);
+	}
+
+	// induce baseCipher payload corruption
+	try {
+		const bool corruptTextCipher = deterministicRandom()->coinflip();
+		encryptedBuf = encryptor.encrypt(&orgData[0], bufLen, &headerRef, arena);
+		if (corruptTextCipher) {
+			Reference<BlobCipherKey> corruptedCipher = corruptCipherKey(tCipherKey);
+			DecryptBlobCipherAes256Ctr decryptor(corruptedCipher, hCipherKey, &iv[0], BlobCipherMetrics::TEST);
+			decryptedBuf = decryptor.decrypt(encryptedBuf.begin(), bufLen, headerRef, arena);
+		} else {
+			Reference<BlobCipherKey> corruptedCipher = corruptCipherKey(hCipherKey);
+			DecryptBlobCipherAes256Ctr decryptor(tCipherKey, corruptedCipher, &iv[0], BlobCipherMetrics::TEST);
+			decryptedBuf = decryptor.decrypt(encryptedBuf.begin(), bufLen, headerRef, arena);
+		}
+		ASSERT(false); // error expected
+	} catch (Error& e) {
+		ASSERT_EQ(e.code(), error_code_encrypt_key_check_value_mismatch);
+		TraceEvent("TestConfigurableEncryptionBaseCipherCorruptionDone").detail("Mode", authAlgoStr);
 	}
 
 	TraceEvent("TestSingleAuthTokenConfigurableEncryptionEnd").detail("Mode", authAlgoStr);
@@ -2753,12 +3056,12 @@ void testEncryptInplaceNoAuthMode(const int minDomainId) {
 
 	// validate header version details
 	AesCtrNoAuth noAuth = std::get<AesCtrNoAuth>(headerRef.algoHeader);
-	Reference<BlobCipherKey> tCipherKeyKey = cipherKeyCache->getCipherKey(noAuth.v1.cipherTextDetails.encryptDomainId,
-	                                                                      noAuth.v1.cipherTextDetails.baseCipherId,
-	                                                                      noAuth.v1.cipherTextDetails.salt);
-	ASSERT(tCipherKeyKey->isEqual(cipherKey));
+	Reference<BlobCipherKey> tCipherKey = cipherKeyCache->getCipherKey(noAuth.v1.cipherTextDetails.encryptDomainId,
+	                                                                   noAuth.v1.cipherTextDetails.baseCipherId,
+	                                                                   noAuth.v1.cipherTextDetails.salt);
+	ASSERT(tCipherKey->isEqual(cipherKey));
 	DecryptBlobCipherAes256Ctr decryptor(
-	    tCipherKeyKey, Reference<BlobCipherKey>(), &noAuth.v1.iv[0], BlobCipherMetrics::TEST);
+	    tCipherKey, Reference<BlobCipherKey>(), &noAuth.v1.iv[0], BlobCipherMetrics::TEST);
 
 	decryptor.decryptInplace(plaintext, bufLen, headerRef);
 	ASSERT_EQ(memcmp(dataClone, plaintext, bufLen), 0);
@@ -2802,13 +3105,13 @@ void testEncryptInplaceSingleAuthMode(const int minDomainId) {
 	uint8_t empty_buff[100];
 	memset(empty_buff, 0, 100);
 
-	Reference<BlobCipherKey> tCipherKeyKey = cipherKeyCache->getCipherKey(
+	Reference<BlobCipherKey> tCipherKey = cipherKeyCache->getCipherKey(
 	    header.cipherTextDetails.encryptDomainId, header.cipherTextDetails.baseCipherId, header.cipherTextDetails.salt);
 	Reference<BlobCipherKey> hCipherKey = cipherKeyCache->getCipherKey(header.cipherHeaderDetails.encryptDomainId,
 	                                                                   header.cipherHeaderDetails.baseCipherId,
 	                                                                   header.cipherHeaderDetails.salt);
 
-	DecryptBlobCipherAes256Ctr decryptor(tCipherKeyKey, hCipherKey, header.iv, BlobCipherMetrics::TEST);
+	DecryptBlobCipherAes256Ctr decryptor(tCipherKey, hCipherKey, header.iv, BlobCipherMetrics::TEST);
 	decryptor.decryptInplace(&orgData[0], bufLen, header);
 	ASSERT_EQ(memcmp(dataClone, &orgData[0], bufLen), 0);
 
@@ -2834,6 +3137,8 @@ TEST_CASE("/blobCipher") {
 		}
 	}
 	ASSERT_EQ(domainKeyMap.size(), maxDomainId);
+
+	testMaxBaseCipherLen();
 
 	testKeyCacheEssentials(domainKeyMap, minDomainId, maxDomainId, minBaseCipherKeyId);
 	testKeyCacheRefreshExpireCipherKey(domainKeyMap, maxDomainId);

--- a/fdbclient/BlobGranuleFiles.cpp
+++ b/fdbclient/BlobGranuleFiles.cpp
@@ -201,6 +201,7 @@ BlobGranuleFileEncryptionKeys getEncryptBlobCipherKey(const BlobGranuleCipherKey
 	                                                   cipherKeysCtx.textCipherKey.baseCipherId,
 	                                                   cipherKeysCtx.textCipherKey.baseCipher.begin(),
 	                                                   cipherKeysCtx.textCipherKey.baseCipher.size(),
+	                                                   cipherKeysCtx.textCipherKey.baseCipherKCV,
 	                                                   cipherKeysCtx.textCipherKey.salt,
 	                                                   std::numeric_limits<int64_t>::max(),
 	                                                   std::numeric_limits<int64_t>::max());
@@ -208,6 +209,7 @@ BlobGranuleFileEncryptionKeys getEncryptBlobCipherKey(const BlobGranuleCipherKey
 	                                                     cipherKeysCtx.headerCipherKey.baseCipherId,
 	                                                     cipherKeysCtx.headerCipherKey.baseCipher.begin(),
 	                                                     cipherKeysCtx.headerCipherKey.baseCipher.size(),
+	                                                     cipherKeysCtx.headerCipherKey.baseCipherKCV,
 	                                                     cipherKeysCtx.headerCipherKey.salt,
 	                                                     std::numeric_limits<int64_t>::max(),
 	                                                     std::numeric_limits<int64_t>::max());
@@ -253,9 +255,16 @@ void validateEncryptionHeaderDetails(const BlobGranuleFileEncryptionKeys& eKeys,
                                      const BlobCipherEncryptHeaderRef& headerRef,
                                      const StringRef& ivRef) {
 	ASSERT(eKeys.textCipherKey.isValid());
+	EncryptHeaderCipherKCVs kcvs;
+
+	kcvs.textKCV = eKeys.textCipherKey->getBaseCipherKCV();
+	if (eKeys.headerCipherKey.isValid()) {
+		kcvs.headerKCV = eKeys.headerCipherKey->getBaseCipherKCV();
+	}
 	headerRef.validateEncryptionHeaderDetails(eKeys.textCipherKey->details(),
 	                                          eKeys.headerCipherKey.isValid() ? eKeys.headerCipherKey->details()
 	                                                                          : BlobCipherDetails(),
+	                                          kcvs,
 	                                          ivRef);
 }
 
@@ -1877,23 +1886,27 @@ const EncryptCipherBaseKeyId encryptBaseCipherId = deterministicRandom()->random
 const EncryptCipherRandomSalt encryptSalt = deterministicRandom()->randomUInt64();
 
 Standalone<StringRef> getBaseCipher() {
-	Standalone<StringRef> baseCipher = makeString(deterministicRandom()->randomInt(4, 256));
+	Standalone<StringRef> baseCipher = makeString(deterministicRandom()->randomInt(4, MAX_BASE_CIPHER_LEN + 1));
 	deterministicRandom()->randomBytes(mutateString(baseCipher), baseCipher.size());
 	return baseCipher;
 }
 
-Standalone<StringRef> encryptBaseCipher = getBaseCipher();
+const Standalone<StringRef> encryptBaseCipher = getBaseCipher();
 
 BlobGranuleCipherKeysCtx getCipherKeysCtx(Arena& arena) {
 	BlobGranuleCipherKeysCtx cipherKeysCtx;
+	const EncryptCipherKeyCheckValue cipherKCV =
+	    Sha256KCV().computeKCV(encryptBaseCipher.begin(), encryptBaseCipher.size());
 
 	cipherKeysCtx.textCipherKey.encryptDomainId = encryptDomainId;
 	cipherKeysCtx.textCipherKey.baseCipherId = encryptBaseCipherId;
+	cipherKeysCtx.textCipherKey.baseCipherKCV = cipherKCV;
 	cipherKeysCtx.textCipherKey.salt = encryptSalt;
 	cipherKeysCtx.textCipherKey.baseCipher = StringRef(arena, encryptBaseCipher);
 
 	cipherKeysCtx.headerCipherKey.encryptDomainId = SYSTEM_KEYSPACE_ENCRYPT_DOMAIN_ID;
 	cipherKeysCtx.headerCipherKey.baseCipherId = encryptBaseCipherId;
+	cipherKeysCtx.headerCipherKey.baseCipherKCV = cipherKCV;
 	cipherKeysCtx.headerCipherKey.salt = encryptSalt;
 	cipherKeysCtx.headerCipherKey.baseCipher = StringRef(arena, encryptBaseCipher);
 

--- a/fdbclient/include/fdbclient/BlobCipher.h
+++ b/fdbclient/include/fdbclient/BlobCipher.h
@@ -289,8 +289,12 @@ struct AesCtrWithAuthV1 {
 
 	// Text cipher encryption information
 	BlobCipherDetails cipherTextDetails;
+	// Text cipher Key Check Value
+	EncryptCipherKeyCheckValue textKCV;
 	// Header cipher encryption information
 	BlobCipherDetails cipherHeaderDetails;
+	// Header cipher Key Check Value
+	EncryptCipherKeyCheckValue headerKCV;
 	// Initialization vector
 	uint8_t iv[AES_256_IV_LENGTH];
 	// Authentication token
@@ -298,10 +302,12 @@ struct AesCtrWithAuthV1 {
 
 	AesCtrWithAuthV1() = default;
 	AesCtrWithAuthV1(const BlobCipherDetails& textDetails,
+	                 const EncryptCipherKeyCheckValue tKCV,
 	                 const BlobCipherDetails& headerDetails,
+	                 const EncryptCipherKeyCheckValue hKCV,
 	                 const uint8_t* ivBuf,
 	                 const int ivLen)
-	  : cipherTextDetails(textDetails), cipherHeaderDetails(headerDetails) {
+	  : cipherTextDetails(textDetails), textKCV(tKCV), cipherHeaderDetails(headerDetails), headerKCV(hKCV) {
 		ASSERT_EQ(ivLen, AES_256_IV_LENGTH);
 		memcpy(&iv[0], ivBuf, ivLen);
 		memset(&authToken[0], 0, Params::authTokenSize);
@@ -309,15 +315,18 @@ struct AesCtrWithAuthV1 {
 
 	bool operator==(const Self& o) const {
 		return cipherHeaderDetails == o.cipherHeaderDetails && cipherTextDetails == o.cipherTextDetails &&
-		       memcmp(&iv[0], &o.iv[0], AES_256_IV_LENGTH) == 0 &&
+		       textKCV == o.textKCV && headerKCV == o.headerKCV && memcmp(&iv[0], &o.iv[0], AES_256_IV_LENGTH) == 0 &&
 		       memcmp(&authToken[0], &o.authToken[0], Params::authTokenSize) == 0;
 	}
 
-	static uint32_t getSize() { return BlobCipherDetails::getSize() * 2 + AES_256_IV_LENGTH + Params::authTokenSize; }
+	static uint32_t getSize() {
+		return BlobCipherDetails::getSize() * 2 + sizeof(EncryptCipherKeyCheckValue) * 2 + AES_256_IV_LENGTH +
+		       Params::authTokenSize;
+	}
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, cipherTextDetails, cipherHeaderDetails);
+		serializer(ar, cipherTextDetails, textKCV, cipherHeaderDetails, headerKCV);
 		ar.serializeBytes(iv, AES_256_IV_LENGTH);
 		ar.serializeBytes(authToken, Params::authTokenSize);
 	}
@@ -389,25 +398,33 @@ struct AesCtrNoAuthV1 {
 
 	// Text cipher encryption information
 	BlobCipherDetails cipherTextDetails;
+	// Text cipher Key Check Value
+	EncryptCipherKeyCheckValue textKCV;
 	// Initialization vector
 	uint8_t iv[AES_256_IV_LENGTH];
 
 	AesCtrNoAuthV1() = default;
-	AesCtrNoAuthV1(const BlobCipherDetails& textDetails, const uint8_t* ivBuf, const int ivLen)
-	  : cipherTextDetails(textDetails) {
+	AesCtrNoAuthV1(const BlobCipherDetails& textDetails,
+	               const EncryptCipherKeyCheckValue tKCV,
+	               const uint8_t* ivBuf,
+	               const int ivLen)
+	  : cipherTextDetails(textDetails), textKCV(tKCV) {
 		ASSERT_EQ(ivLen, AES_256_IV_LENGTH);
 		memcpy(&iv[0], ivBuf, ivLen);
 	}
 
 	bool operator==(const AesCtrNoAuthV1& o) const {
-		return cipherTextDetails == o.cipherTextDetails && memcmp(&iv[0], &o.iv[0], AES_256_IV_LENGTH) == 0;
+		return cipherTextDetails == o.cipherTextDetails && textKCV == o.textKCV &&
+		       memcmp(&iv[0], &o.iv[0], AES_256_IV_LENGTH) == 0;
 	}
 
-	static uint32_t getSize() { return BlobCipherDetails::getSize() + AES_256_IV_LENGTH; }
+	static uint32_t getSize() {
+		return BlobCipherDetails::getSize() + sizeof(EncryptCipherKeyCheckValue) + AES_256_IV_LENGTH;
+	}
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, cipherTextDetails);
+		serializer(ar, cipherTextDetails, textKCV);
 		ar.serializeBytes(iv, AES_256_IV_LENGTH);
 	}
 };
@@ -456,6 +473,16 @@ struct AesCtrNoAuth {
 	}
 };
 
+struct EncryptHeaderCipherKCVs {
+	EncryptCipherKeyCheckValue textKCV;
+	Optional<EncryptCipherKeyCheckValue> headerKCV;
+
+	EncryptHeaderCipherKCVs() = default;
+	EncryptHeaderCipherKCVs(const EncryptCipherKeyCheckValue tKCV) : textKCV(tKCV) {}
+	EncryptHeaderCipherKCVs(const EncryptCipherKeyCheckValue tKCV, const EncryptCipherKeyCheckValue hKCV)
+	  : textKCV(tKCV), headerKCV(hKCV) {}
+};
+
 struct BlobCipherEncryptHeaderRef {
 	// Serializable fields
 	std::variant<BlobCipherEncryptHeaderFlagsV1> flags;
@@ -495,9 +522,18 @@ struct BlobCipherEncryptHeaderRef {
 	const EncryptHeaderCipherDetails getCipherDetails() const;
 	EncryptAuthTokenMode getAuthTokenMode() const;
 	EncryptCipherDomainId getDomainId() const;
+	EncryptHeaderCipherKCVs getKCVs() const;
 
+	// API supports following validation:
+	// 1. Ensure input BlobCipherDetails (textDetails and/or headerDetails) matches with the input
+	// 2. Ensure persited KCV matches with the input values
+	// 3. Ensure input IV buffer matches with the persisted ones.
+	//
+	// Currently API is used by BlobGranule encryption where encryption key lookup based on persisted
+	// BlobGranuleCipherKeyCtx
 	void validateEncryptionHeaderDetails(const BlobCipherDetails& textCipherDetails,
 	                                     const BlobCipherDetails& headerCipherDetails,
+	                                     const EncryptHeaderCipherKCVs& kcvs,
 	                                     const StringRef& ivRef) const;
 };
 
@@ -511,7 +547,7 @@ struct BlobCipherEncryptHeaderRef {
 
 #pragma pack(push, 1) // exact fit - no padding
 typedef struct BlobCipherEncryptHeader {
-	static constexpr int headerSize = 104;
+	static constexpr int headerSize = 112;
 	union {
 		struct {
 			uint8_t size; // reading first byte is sufficient to determine header
@@ -527,8 +563,12 @@ typedef struct BlobCipherEncryptHeader {
 
 	// Cipher text encryption information
 	BlobCipherDetails cipherTextDetails;
+	// Text Key Check Value
+	EncryptCipherKeyCheckValue textKCV;
 	// Cipher header encryption information
 	BlobCipherDetails cipherHeaderDetails;
+	// Header Key Check Value
+	EncryptCipherKeyCheckValue headerKCV;
 	// Initialization vector used to encrypt the payload.
 	uint8_t iv[AES_256_IV_LENGTH];
 
@@ -595,12 +635,14 @@ public:
 	              const EncryptCipherBaseKeyId& baseCiphId,
 	              const uint8_t* baseCiph,
 	              const int baseCiphLen,
+	              const EncryptCipherKeyCheckValue baseCipherKCV,
 	              const int64_t refreshAt,
 	              int64_t expireAt);
 	BlobCipherKey(const EncryptCipherDomainId& domainId,
 	              const EncryptCipherBaseKeyId& baseCiphId,
 	              const uint8_t* baseCiph,
-	              int baseCiphLen,
+	              const int baseCiphLen,
+	              const EncryptCipherKeyCheckValue baseCipherKCV,
 	              const EncryptCipherRandomSalt& salt,
 	              const int64_t refreshAt,
 	              const int64_t expireAt);
@@ -612,6 +654,7 @@ public:
 	EncryptCipherRandomSalt getSalt() const { return randomSalt; }
 	EncryptCipherBaseKeyId getBaseCipherId() const { return baseCipherId; }
 	int getBaseCipherLen() const { return baseCipherLen; }
+	EncryptCipherKeyCheckValue getBaseCipherKCV() const { return baseCipherKCV; }
 	uint8_t* rawCipher() const { return cipher.get(); }
 	uint8_t* rawBaseCipher() const { return baseCipher.get(); }
 	bool isEqual(const Reference<BlobCipherKey> toCompare) {
@@ -649,6 +692,7 @@ private:
 	EncryptCipherDomainId encryptDomainId;
 	// Base encryption cipher key properties
 	std::unique_ptr<uint8_t[]> baseCipher;
+	EncryptCipherKeyCheckValue baseCipherKCV;
 	int baseCipherLen;
 	EncryptCipherBaseKeyId baseCipherId;
 	// Random salt used for encryption cipher key derivation
@@ -661,9 +705,10 @@ private:
 	int64_t expireAtTS;
 
 	void initKey(const EncryptCipherDomainId& domainId,
+	             const EncryptCipherBaseKeyId& baseCiphId,
 	             const uint8_t* baseCiph,
 	             const int baseCiphLen,
-	             const EncryptCipherBaseKeyId& baseCiphId,
+	             const EncryptCipherKeyCheckValue baseCipherKCV,
 	             const EncryptCipherRandomSalt& salt,
 	             const int64_t refreshAt,
 	             const int64_t expireAt);
@@ -728,7 +773,8 @@ public:
 
 	Reference<BlobCipherKey> insertBaseCipherKey(const EncryptCipherBaseKeyId& baseCipherId,
 	                                             const uint8_t* baseCipher,
-	                                             int baseCipherLen,
+	                                             const int baseCipherLen,
+	                                             const EncryptCipherKeyCheckValue baseCipherKCV,
 	                                             const int64_t refreshAt,
 	                                             const int64_t expireAt);
 
@@ -744,7 +790,8 @@ public:
 
 	Reference<BlobCipherKey> insertBaseCipherKey(const EncryptCipherBaseKeyId& baseCipherId,
 	                                             const uint8_t* baseCipher,
-	                                             int baseCipherLen,
+	                                             const int baseCipherLen,
+	                                             const EncryptCipherKeyCheckValue baseCipherKCV,
 	                                             const EncryptCipherRandomSalt& salt,
 	                                             const int64_t refreshAt,
 	                                             const int64_t expireAt);
@@ -787,7 +834,8 @@ public:
 	Reference<BlobCipherKey> insertCipherKey(const EncryptCipherDomainId& domainId,
 	                                         const EncryptCipherBaseKeyId& baseCipherId,
 	                                         const uint8_t* baseCipher,
-	                                         int baseCipherLen,
+	                                         const int baseCipherLen,
+	                                         const EncryptCipherKeyCheckValue baseCipherKCV,
 	                                         const int64_t refreshAt,
 	                                         const int64_t expireAt);
 
@@ -805,7 +853,8 @@ public:
 	Reference<BlobCipherKey> insertCipherKey(const EncryptCipherDomainId& domainId,
 	                                         const EncryptCipherBaseKeyId& baseCipherId,
 	                                         const uint8_t* baseCipher,
-	                                         int baseCipherLen,
+	                                         const int baseCipherLen,
+	                                         const EncryptCipherKeyCheckValue baseCipherKCV,
 	                                         const EncryptCipherRandomSalt& salt,
 	                                         const int64_t refreshAt,
 	                                         const int64_t expireAt);
@@ -961,6 +1010,13 @@ private:
 	Optional<Reference<BlobCipherKey>> headerCipherKeyOpt;
 	bool authTokensValidationDone;
 
+	// API is resposible to validate persisted EncryptionHeader sanity, it does following checks
+	// 1. Parse and validate EncryptionHeaderFlags (version compliant checks)
+	// 2. Parse and validate KCVs
+	// 3. Parse and validate auth-tokens if applicable.
+	//
+	// Routine is invoked for every decryption buffer request and is done transparently to the caller
+
 	void validateEncryptHeader(const uint8_t*,
 	                           const int,
 	                           const BlobCipherEncryptHeaderRef&,
@@ -979,7 +1035,8 @@ private:
 	void validateAuthTokenV1(const uint8_t* ciphertext,
 	                         const int ciphertextLen,
 	                         const BlobCipherEncryptHeaderFlagsV1&,
-	                         const BlobCipherEncryptHeaderRef& header);
+	                         const BlobCipherEncryptHeaderRef&);
+	void vaidateEncryptHeaderCipherKCVs(const BlobCipherEncryptHeaderRef&, const BlobCipherEncryptHeaderFlagsV1&);
 
 	void verifyEncryptHeaderMetadata(const BlobCipherEncryptHeader& header);
 	void verifyAuthTokens(const uint8_t* ciphertext, const int ciphertextLen, const BlobCipherEncryptHeader& header);
@@ -1010,6 +1067,19 @@ public:
 
 private:
 	CMAC_CTX* ctx;
+};
+
+class Sha256KCV final : NonCopyable {
+public:
+	Sha256KCV();
+	~Sha256KCV();
+
+	EncryptCipherKeyCheckValue computeKCV(const uint8_t* cipher, const int len);
+
+	static void checkEqual(const Reference<BlobCipherKey>& cipher, const EncryptCipherKeyCheckValue persited);
+
+private:
+	EVP_MD_CTX* ctx;
 };
 
 void computeAuthToken(const std::vector<std::pair<const uint8_t*, size_t>>& payload,

--- a/fdbclient/include/fdbclient/BlobGranuleCommon.h
+++ b/fdbclient/include/fdbclient/BlobGranuleCommon.h
@@ -90,26 +90,40 @@ struct GranuleMaterializeStats {
 struct BlobGranuleCipherKeysMeta {
 	EncryptCipherDomainId textDomainId;
 	EncryptCipherBaseKeyId textBaseCipherId;
+	EncryptCipherKeyCheckValue textBaseCipherKCV;
 	EncryptCipherRandomSalt textSalt;
 	EncryptCipherDomainId headerDomainId;
 	EncryptCipherBaseKeyId headerBaseCipherId;
+	EncryptCipherKeyCheckValue headerBaseCipherKCV;
 	EncryptCipherRandomSalt headerSalt;
 	std::string ivStr;
 
 	BlobGranuleCipherKeysMeta() {}
 	BlobGranuleCipherKeysMeta(const EncryptCipherDomainId tDomainId,
 	                          const EncryptCipherBaseKeyId tBaseCipherId,
+	                          const EncryptCipherKeyCheckValue tBaseCipherKCV,
 	                          const EncryptCipherRandomSalt tSalt,
 	                          const EncryptCipherDomainId hDomainId,
 	                          const EncryptCipherBaseKeyId hBaseCipherId,
+	                          const EncryptCipherKeyCheckValue hBaseCipherKCV,
 	                          const EncryptCipherRandomSalt hSalt,
 	                          const std::string& iv)
-	  : textDomainId(tDomainId), textBaseCipherId(tBaseCipherId), textSalt(tSalt), headerDomainId(hDomainId),
-	    headerBaseCipherId(hBaseCipherId), headerSalt(hSalt), ivStr(iv) {}
+	  : textDomainId(tDomainId), textBaseCipherId(tBaseCipherId), textBaseCipherKCV(tBaseCipherKCV), textSalt(tSalt),
+	    headerDomainId(hDomainId), headerBaseCipherId(hBaseCipherId), headerBaseCipherKCV(hBaseCipherKCV),
+	    headerSalt(hSalt), ivStr(iv) {}
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, textDomainId, textBaseCipherId, textSalt, headerDomainId, headerBaseCipherId, headerSalt, ivStr);
+		serializer(ar,
+		           textDomainId,
+		           textBaseCipherId,
+		           textBaseCipherKCV,
+		           textSalt,
+		           headerDomainId,
+		           headerBaseCipherId,
+		           headerBaseCipherKCV,
+		           headerSalt,
+		           ivStr);
 	}
 };
 
@@ -119,6 +133,7 @@ struct BlobGranuleCipherKey {
 	constexpr static FileIdentifier file_identifier = 7274734;
 	EncryptCipherDomainId encryptDomainId;
 	EncryptCipherBaseKeyId baseCipherId;
+	EncryptCipherKeyCheckValue baseCipherKCV;
 	EncryptCipherRandomSalt salt;
 	StringRef baseCipher;
 
@@ -126,6 +141,7 @@ struct BlobGranuleCipherKey {
 		BlobGranuleCipherKey cipherKey;
 		cipherKey.encryptDomainId = keyRef->getDomainId();
 		cipherKey.baseCipherId = keyRef->getBaseCipherId();
+		cipherKey.baseCipherKCV = keyRef->getBaseCipherKCV();
 		cipherKey.salt = keyRef->getSalt();
 		cipherKey.baseCipher = makeString(keyRef->getBaseCipherLen(), arena);
 		memcpy(mutateString(cipherKey.baseCipher), keyRef->rawBaseCipher(), keyRef->getBaseCipherLen());
@@ -135,7 +151,7 @@ struct BlobGranuleCipherKey {
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, encryptDomainId, baseCipherId, salt, baseCipher);
+		serializer(ar, encryptDomainId, baseCipherId, baseCipherKCV, salt, baseCipher);
 	}
 };
 
@@ -150,9 +166,11 @@ struct BlobGranuleCipherKeysCtx {
 	static BlobGranuleCipherKeysMeta toCipherKeysMeta(const BlobGranuleCipherKeysCtx& ctx) {
 		return BlobGranuleCipherKeysMeta(ctx.textCipherKey.encryptDomainId,
 		                                 ctx.textCipherKey.baseCipherId,
+		                                 ctx.textCipherKey.baseCipherKCV,
 		                                 ctx.textCipherKey.salt,
 		                                 ctx.headerCipherKey.encryptDomainId,
 		                                 ctx.headerCipherKey.baseCipherId,
+		                                 ctx.headerCipherKey.baseCipherKCV,
 		                                 ctx.headerCipherKey.salt,
 		                                 ctx.ivRef.toString());
 	}

--- a/fdbclient/include/fdbclient/EncryptKeyProxyInterface.h
+++ b/fdbclient/include/fdbclient/EncryptKeyProxyInterface.h
@@ -103,20 +103,31 @@ struct EKPBaseCipherDetails {
 	int64_t encryptDomainId;
 	uint64_t baseCipherId;
 	Standalone<StringRef> baseCipherKey;
+	EncryptCipherKeyCheckValue baseCipherKCV;
 	int64_t refreshAt;
 	int64_t expireAt;
 
 	EKPBaseCipherDetails()
-	  : encryptDomainId(0), baseCipherId(0), baseCipherKey(Standalone<StringRef>()), refreshAt(0), expireAt(-1) {}
-	explicit EKPBaseCipherDetails(int64_t dId, uint64_t id, Standalone<StringRef> key)
-	  : encryptDomainId(dId), baseCipherId(id), baseCipherKey(key), refreshAt(std::numeric_limits<int64_t>::max()),
-	    expireAt(std::numeric_limits<int64_t>::max()) {}
-	explicit EKPBaseCipherDetails(int64_t dId, uint64_t id, Standalone<StringRef> key, int64_t refAt, int64_t expAt)
-	  : encryptDomainId(dId), baseCipherId(id), baseCipherKey(key), refreshAt(refAt), expireAt(expAt) {}
+	  : encryptDomainId(0), baseCipherId(0), baseCipherKey(Standalone<StringRef>()), baseCipherKCV(0), refreshAt(0),
+	    expireAt(-1) {}
+	explicit EKPBaseCipherDetails(int64_t dId,
+	                              uint64_t id,
+	                              Standalone<StringRef> key,
+	                              EncryptCipherKeyCheckValue cipherKCV)
+	  : encryptDomainId(dId), baseCipherId(id), baseCipherKey(key), baseCipherKCV(cipherKCV),
+	    refreshAt(std::numeric_limits<int64_t>::max()), expireAt(std::numeric_limits<int64_t>::max()) {}
+	explicit EKPBaseCipherDetails(int64_t dId,
+	                              uint64_t id,
+	                              Standalone<StringRef> key,
+	                              EncryptCipherKeyCheckValue cipherKCV,
+	                              int64_t refAt,
+	                              int64_t expAt)
+	  : encryptDomainId(dId), baseCipherId(id), baseCipherKey(key), baseCipherKCV(cipherKCV), refreshAt(refAt),
+	    expireAt(expAt) {}
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, encryptDomainId, baseCipherId, baseCipherKey, refreshAt, expireAt);
+		serializer(ar, encryptDomainId, baseCipherId, baseCipherKey, baseCipherKCV, refreshAt, expireAt);
 	}
 };
 

--- a/fdbclient/include/fdbclient/GetEncryptCipherKeys_impl.actor.h
+++ b/fdbclient/include/fdbclient/GetEncryptCipherKeys_impl.actor.h
@@ -135,6 +135,7 @@ Future<std::unordered_map<EncryptCipherDomainId, Reference<BlobCipherKey>>> _get
 					                                                                     details.baseCipherId,
 					                                                                     details.baseCipherKey.begin(),
 					                                                                     details.baseCipherKey.size(),
+					                                                                     details.baseCipherKCV,
 					                                                                     details.refreshAt,
 					                                                                     details.expireAt);
 					ASSERT(cipherKey.isValid());
@@ -270,6 +271,7 @@ Future<std::unordered_map<BlobCipherDetails, Reference<BlobCipherKey>>> _getEncr
 				                                                                     details.baseCipherId,
 				                                                                     itr->second.baseCipherKey.begin(),
 				                                                                     itr->second.baseCipherKey.size(),
+				                                                                     itr->second.baseCipherKCV,
 				                                                                     details.salt,
 				                                                                     itr->second.refreshAt,
 				                                                                     itr->second.expireAt);

--- a/fdbserver/EncryptKeyProxy.actor.cpp
+++ b/fdbserver/EncryptKeyProxy.actor.cpp
@@ -145,6 +145,8 @@ struct EncryptBaseCipherKey {
 	EncryptCipherDomainId domainId;
 	EncryptCipherBaseKeyId baseCipherId;
 	Standalone<StringRef> baseCipherKey;
+	// Key check value for the 'baseCipher'
+	EncryptCipherKeyCheckValue baseCipherKCV;
 	// Timestamp after which the cached CipherKey is eligible for KMS refresh
 	int64_t refreshAt;
 	// Timestamp after which the cached CipherKey 'should' be considered as 'expired'
@@ -158,13 +160,16 @@ struct EncryptBaseCipherKey {
 	// CipherKeys with the latest CipherKeys sometime soon in the future.
 	int64_t expireAt;
 
-	EncryptBaseCipherKey() : domainId(0), baseCipherId(0), baseCipherKey(StringRef()), refreshAt(0), expireAt(0) {}
+	EncryptBaseCipherKey()
+	  : domainId(0), baseCipherId(0), baseCipherKey(StringRef()), baseCipherKCV(0), refreshAt(0), expireAt(0) {}
 	explicit EncryptBaseCipherKey(EncryptCipherDomainId dId,
 	                              EncryptCipherBaseKeyId cipherId,
 	                              Standalone<StringRef> cipherKey,
+	                              EncryptCipherKeyCheckValue cipherKCV,
 	                              int64_t refAtTS,
 	                              int64_t expAtTS)
-	  : domainId(dId), baseCipherId(cipherId), baseCipherKey(cipherKey), refreshAt(refAtTS), expireAt(expAtTS) {}
+	  : domainId(dId), baseCipherId(cipherId), baseCipherKey(cipherKey), baseCipherKCV(cipherKCV), refreshAt(refAtTS),
+	    expireAt(expAtTS) {}
 
 	bool isValid() const {
 		int64_t currTS = (int64_t)now();
@@ -261,36 +266,48 @@ public:
 	void insertIntoBaseDomainIdCache(const EncryptCipherDomainId domainId,
 	                                 const EncryptCipherBaseKeyId baseCipherId,
 	                                 Standalone<StringRef> baseCipherKey,
+	                                 const EncryptCipherKeyCheckValue baseCipherKCV,
 	                                 int64_t refreshAtTS,
 	                                 int64_t expireAtTS) {
 		// Entries in domainId cache are eligible for periodic refreshes to support 'limiting lifetime of encryption
 		// key' support if enabled on external KMS solutions.
 
 		baseCipherDomainIdCache[domainId] =
-		    EncryptBaseCipherKey(domainId, baseCipherId, baseCipherKey, refreshAtTS, expireAtTS);
+		    EncryptBaseCipherKey(domainId, baseCipherId, baseCipherKey, baseCipherKCV, refreshAtTS, expireAtTS);
 
 		// Update cached the information indexed using baseCipherId
 		// Cache indexed by 'baseCipherId' need not refresh cipher, however, it still needs to abide by KMS governed
 		// CipherKey lifetime rules
 		insertIntoBaseCipherIdCache(
-		    domainId, baseCipherId, baseCipherKey, std::numeric_limits<int64_t>::max(), expireAtTS);
+		    domainId, baseCipherId, baseCipherKey, baseCipherKCV, std::numeric_limits<int64_t>::max(), expireAtTS);
 	}
 
 	void insertIntoBaseCipherIdCache(const EncryptCipherDomainId domainId,
 	                                 const EncryptCipherBaseKeyId baseCipherId,
 	                                 const Standalone<StringRef> baseCipherKey,
+	                                 const EncryptCipherKeyCheckValue baseCipherKCV,
 	                                 int64_t refreshAtTS,
 	                                 int64_t expireAtTS) {
 		// Given an cipherKey is immutable, it is OK to NOT expire cached information.
 		// TODO: Update cache to support LRU eviction policy to limit the total cache size.
-
+		const EncryptCipherKeyCheckValue computedKCV =
+		    Sha256KCV().computeKCV(baseCipherKey.begin(), baseCipherKey.size());
+		if (computedKCV != baseCipherKCV) {
+			TraceEvent(SevWarnAlways, "BlobCipherKeyInitBaseCipherKCVMismatch")
+			    .detail("DomId", domainId)
+			    .detail("BaseCipherId", baseCipherId)
+			    .detail("Computed", computedKCV)
+			    .detail("BaseCipherKCV", baseCipherKCV);
+			throw encrypt_key_check_value_mismatch();
+		}
 		EncryptBaseCipherDomainIdKeyIdCacheKey cacheKey = getBaseCipherDomainIdKeyIdCacheKey(domainId, baseCipherId);
 		baseCipherDomainIdKeyIdCache[cacheKey] =
-		    EncryptBaseCipherKey(domainId, baseCipherId, baseCipherKey, refreshAtTS, expireAtTS);
+		    EncryptBaseCipherKey(domainId, baseCipherId, baseCipherKey, baseCipherKCV, refreshAtTS, expireAtTS);
 		TraceEvent("InsertIntoBaseCipherIdCache")
 		    .detail("DomId", domainId)
 		    .detail("BaseCipherId", baseCipherId)
-		    .detail("BaseCipherLen", baseCipherKey.size());
+		    .detail("BaseCipherLen", baseCipherKey.size())
+		    .detail("BaseCipherKCV", baseCipherKCV);
 	}
 
 	void insertIntoBlobMetadataCache(const BlobMetadataDomainId domainId,
@@ -364,7 +381,7 @@ ACTOR Future<Void> getCipherKeysByBaseCipherKeyIds(Reference<EncryptKeyProxyData
 		const auto itr = ekpProxyData->baseCipherDomainIdKeyIdCache.find(cacheKey);
 		if (itr != ekpProxyData->baseCipherDomainIdKeyIdCache.end() && itr->second.isValid()) {
 			keyIdsReply.baseCipherDetails.emplace_back(
-			    itr->second.domainId, itr->second.baseCipherId, itr->second.baseCipherKey);
+			    itr->second.domainId, itr->second.baseCipherId, itr->second.baseCipherKey, itr->second.baseCipherKCV);
 			numHits++;
 
 			if (dbgTrace.present()) {
@@ -396,7 +413,8 @@ ACTOR Future<Void> getCipherKeysByBaseCipherKeyIds(Reference<EncryptKeyProxyData
 			ekpProxyData->kmsLookupByIdsReqLatency.addMeasurement(now() - startTime);
 
 			for (const auto& item : keysByIdsRep.cipherKeyDetails) {
-				keyIdsReply.baseCipherDetails.emplace_back(item.encryptDomainId, item.encryptKeyId, item.encryptKey);
+				keyIdsReply.baseCipherDetails.emplace_back(
+				    item.encryptDomainId, item.encryptKeyId, item.encryptKey, item.encryptKCV);
 			}
 
 			// Record the fetched cipher details to the local cache for the future references
@@ -418,6 +436,7 @@ ACTOR Future<Void> getCipherKeysByBaseCipherKeyIds(Reference<EncryptKeyProxyData
 				ekpProxyData->insertIntoBaseCipherIdCache(item.encryptDomainId,
 				                                          item.encryptKeyId,
 				                                          item.encryptKey,
+				                                          item.encryptKCV,
 				                                          validityTS.refreshAtTS,
 				                                          validityTS.expAtTS);
 
@@ -491,6 +510,7 @@ ACTOR Future<Void> getLatestCipherKeys(Reference<EncryptKeyProxyData> ekpProxyDa
 			latestCipherReply.baseCipherDetails.emplace_back(domainId,
 			                                                 itr->second.baseCipherId,
 			                                                 itr->second.baseCipherKey,
+			                                                 itr->second.baseCipherKCV,
 			                                                 itr->second.refreshAt,
 			                                                 itr->second.expireAt);
 			numHits++;
@@ -533,6 +553,7 @@ ACTOR Future<Void> getLatestCipherKeys(Reference<EncryptKeyProxyData> ekpProxyDa
 				latestCipherReply.baseCipherDetails.emplace_back(item.encryptDomainId,
 				                                                 item.encryptKeyId,
 				                                                 item.encryptKey,
+				                                                 item.encryptKCV,
 				                                                 validityTS.refreshAtTS,
 				                                                 validityTS.expAtTS);
 
@@ -546,6 +567,7 @@ ACTOR Future<Void> getLatestCipherKeys(Reference<EncryptKeyProxyData> ekpProxyDa
 				ekpProxyData->insertIntoBaseDomainIdCache(item.encryptDomainId,
 				                                          item.encryptKeyId,
 				                                          item.encryptKey,
+				                                          item.encryptKCV,
 				                                          validityTS.refreshAtTS,
 				                                          validityTS.expAtTS);
 
@@ -646,8 +668,12 @@ ACTOR Future<Void> refreshEncryptionKeysImpl(Reference<EncryptKeyProxyData> ekpP
 			}
 
 			CipherKeyValidityTS validityTS = getCipherKeyValidityTS(item.refreshAfterSec, item.expireAfterSec);
-			ekpProxyData->insertIntoBaseDomainIdCache(
-			    item.encryptDomainId, item.encryptKeyId, item.encryptKey, validityTS.refreshAtTS, validityTS.expAtTS);
+			ekpProxyData->insertIntoBaseDomainIdCache(item.encryptDomainId,
+			                                          item.encryptKeyId,
+			                                          item.encryptKey,
+			                                          item.encryptKCV,
+			                                          validityTS.refreshAtTS,
+			                                          validityTS.expAtTS);
 			// {encryptDomainId, baseCipherId} forms a unique tuple across encryption domains
 			t.detail(getEncryptDbgTraceKeyWithTS(ENCRYPT_DBG_TRACE_INSERT_PREFIX,
 			                                     item.encryptDomainId,

--- a/fdbserver/SimKmsConnector.actor.cpp
+++ b/fdbserver/SimKmsConnector.actor.cpp
@@ -61,11 +61,16 @@ struct SimEncryptKeyCtx {
 	EncryptCipherBaseKeyId id;
 	SimEncryptKey key;
 	int keyLen;
+	EncryptCipherKeyCheckValue kcv;
 
 	explicit SimEncryptKeyCtx(EncryptCipherBaseKeyId kId, const char* data, const int dataLen)
 	  : id(kId), key(data, dataLen), keyLen(dataLen) {
+		kcv = Sha256KCV().computeKCV((const uint8_t*)data, dataLen);
 		if (DEBUG_SIM_KEY_CIPHER) {
-			TraceEvent(SevDebug, "SimKmsKeyCtxInit").detail("BaseCipherId", kId).detail("BaseCipherLen", dataLen);
+			TraceEvent(SevDebug, "SimKmsKeyCtxInit")
+			    .detail("BaseCipherId", kId)
+			    .detail("BaseCipherLen", dataLen)
+			    .detail("KCV", kcv);
 		}
 	}
 
@@ -74,7 +79,7 @@ struct SimEncryptKeyCtx {
 
 		int ret = AES_256_KEY_LENGTH;
 		if ((id % 2) == 0) {
-			ret += (id % AES_256_KEY_LENGTH);
+			ret += (id % (MAX_BASE_CIPHER_LEN - AES_256_KEY_LENGTH));
 		}
 		CODE_PROBE(ret == AES_256_KEY_LENGTH, "BaseCipherKeyLen AES_256_KEY_LENGTH");
 		CODE_PROBE(ret != AES_256_KEY_LENGTH, "BaseCipherKeyLen variable length");
@@ -164,8 +169,13 @@ ACTOR Future<Void> ekLookupByIds(Reference<SimKmsConnectorContext> ctx,
 		if (itr != ctx->simEncryptKeyStore.end()) {
 			// TODO: Relax assert if EKP APIs are updated to make 'domain_id' optional for encryption keys point lookups
 			ASSERT(item.domainId.present());
-			rep.cipherKeyDetails.emplace_back_deep(
-			    rep.arena, item.domainId.get(), itr->first, StringRef(itr->second.get()->key), refAtTS, expAtTS);
+			rep.cipherKeyDetails.emplace_back_deep(rep.arena,
+			                                       item.domainId.get(),
+			                                       itr->first,
+			                                       StringRef(itr->second.get()->key),
+			                                       itr->second->kcv,
+			                                       refAtTS,
+			                                       expAtTS);
 
 			if (dbgKIdTrace.present()) {
 				// {encryptDomainId, baseCipherId} forms a unique tuple across encryption domains
@@ -178,7 +188,8 @@ ACTOR Future<Void> ekLookupByIds(Reference<SimKmsConnectorContext> ctx,
 				    .detail("DomId", item.domainId.get())
 				    .detail("BaseCipherId", item.baseCipherId)
 				    .detail("BaseCipherLen", itr->second->keyLen)
-				    .detail("BaseCipherKeyLen", itr->second->keyLen);
+				    .detail("BaseCipherKeyLen", itr->second->keyLen)
+				    .detail("BaseCipherKCV", itr->second->kcv);
 			}
 		} else {
 			TraceEvent("SimKmsEKLookupByIdsKeyNotFound")
@@ -226,7 +237,7 @@ ACTOR Future<Void> ekLookupByDomainIds(Reference<SimKmsConnectorContext> ctx,
 		const auto& itr = ctx->simEncryptKeyStore.find(keyId);
 		if (itr != ctx->simEncryptKeyStore.end()) {
 			rep.cipherKeyDetails.emplace_back_deep(
-			    req.arena, domainId, keyId, StringRef(itr->second.get()->key), refAtTS, expAtTS);
+			    req.arena, domainId, keyId, StringRef(itr->second.get()->key), itr->second->kcv, refAtTS, expAtTS);
 			if (dbgDIdTrace.present()) {
 				// {encryptId, baseCipherId} forms a unique tuple across encryption domains
 				dbgDIdTrace.get().detail(getEncryptDbgTraceKey(ENCRYPT_DBG_TRACE_RESULT_PREFIX, domainId, keyId), "");
@@ -236,7 +247,8 @@ ACTOR Future<Void> ekLookupByDomainIds(Reference<SimKmsConnectorContext> ctx,
 				    .detail("DomId", domainId)
 				    .detail("BaseCipherId", itr->second->id)
 				    .detail("BaseCipherLen", itr->second->keyLen)
-				    .detail("BaseCipherKeyLen", itr->second->keyLen);
+				    .detail("BaseCipherKeyLen", itr->second->keyLen)
+				    .detail("BaseCipherKCV", itr->second->kcv);
 			}
 
 		} else {

--- a/fdbserver/include/fdbserver/IPageEncryptionKeyProvider.actor.h
+++ b/fdbserver/include/fdbserver/IPageEncryptionKeyProvider.actor.h
@@ -270,10 +270,12 @@ private:
 		    EncryptAuthTokenAlgo::ENCRYPT_HEADER_AUTH_TOKEN_ALGO_HMAC_SHA,
 		    AUTH_TOKEN_HMAC_SHA_SIZE);
 		ASSERT_EQ(AUTH_TOKEN_HMAC_SHA_SIZE, AES_256_KEY_LENGTH);
+		const EncryptCipherKeyCheckValue kcv = Sha256KCV().computeKCV(&digest[0], AES_256_KEY_LENGTH);
 		return makeReference<BlobCipherKey>(cipherDetails.encryptDomainId,
 		                                    cipherDetails.baseCipherId,
 		                                    &digest[0],
 		                                    AES_256_KEY_LENGTH,
+		                                    kcv,
 		                                    cipherDetails.salt,
 		                                    std::numeric_limits<int64_t>::max() /* refreshAt */,
 		                                    std::numeric_limits<int64_t>::max() /* expireAt */);
@@ -294,6 +296,7 @@ private:
 		                                    cipherId,
 		                                    cipherKeys[cipherId - 1]->rawBaseCipher(),
 		                                    AES_256_KEY_LENGTH,
+		                                    cipherKeys[cipherId - 1]->getBaseCipherKCV(),
 		                                    cipherKeys[cipherId - 1]->getSalt(),
 		                                    std::numeric_limits<int64_t>::max() /* refreshAt */,
 		                                    std::numeric_limits<int64_t>::max() /* expireAt */);

--- a/fdbserver/include/fdbserver/KmsConnectorInterface.h
+++ b/fdbserver/include/fdbserver/KmsConnectorInterface.h
@@ -72,6 +72,7 @@ struct EncryptCipherKeyDetailsRef {
 	EncryptCipherDomainId encryptDomainId;
 	EncryptCipherBaseKeyId encryptKeyId;
 	StringRef encryptKey;
+	EncryptCipherKeyCheckValue encryptKCV;
 	Optional<int64_t> refreshAfterSec;
 	Optional<int64_t> expireAfterSec;
 
@@ -81,26 +82,28 @@ struct EncryptCipherKeyDetailsRef {
 	explicit EncryptCipherKeyDetailsRef(Arena& arena,
 	                                    EncryptCipherDomainId dId,
 	                                    EncryptCipherBaseKeyId keyId,
-	                                    StringRef key)
-	  : encryptDomainId(dId), encryptKeyId(keyId), encryptKey(StringRef(arena, key)),
+	                                    StringRef key,
+	                                    EncryptCipherKeyCheckValue keyKCV)
+	  : encryptDomainId(dId), encryptKeyId(keyId), encryptKey(StringRef(arena, key)), encryptKCV(keyKCV),
 	    refreshAfterSec(Optional<int64_t>()), expireAfterSec(Optional<int64_t>()) {}
 	explicit EncryptCipherKeyDetailsRef(Arena& arena,
 	                                    EncryptCipherDomainId dId,
 	                                    EncryptCipherBaseKeyId keyId,
 	                                    StringRef key,
+	                                    EncryptCipherKeyCheckValue keyKCV,
 	                                    Optional<int64_t> refAfterSec,
 	                                    Optional<int64_t> expAfterSec)
-	  : encryptDomainId(dId), encryptKeyId(keyId), encryptKey(StringRef(arena, key)), refreshAfterSec(refAfterSec),
-	    expireAfterSec(expAfterSec) {}
+	  : encryptDomainId(dId), encryptKeyId(keyId), encryptKey(StringRef(arena, key)), encryptKCV(keyKCV),
+	    refreshAfterSec(refAfterSec), expireAfterSec(expAfterSec) {}
 
 	bool operator==(const EncryptCipherKeyDetailsRef& toCompare) {
 		return encryptDomainId == toCompare.encryptDomainId && encryptKeyId == toCompare.encryptKeyId &&
-		       encryptKey.compare(toCompare.encryptKey) == 0;
+		       encryptKey.compare(toCompare.encryptKey) == 0 && encryptKCV == toCompare.encryptKCV;
 	}
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, encryptDomainId, encryptKeyId, encryptKey, refreshAfterSec, expireAfterSec);
+		serializer(ar, encryptDomainId, encryptKeyId, encryptKey, encryptKCV, refreshAfterSec, expireAfterSec);
 	}
 };
 

--- a/flow/include/flow/EncryptUtils.h
+++ b/flow/include/flow/EncryptUtils.h
@@ -27,6 +27,7 @@
 
 #include <cstdint>
 #include <limits>
+#include <openssl/evp.h>
 #include <string>
 #include <string_view>
 #include <unordered_set>
@@ -40,6 +41,9 @@ constexpr const int AUTH_TOKEN_MAX_SIZE = AUTH_TOKEN_HMAC_SHA_SIZE;
 using EncryptCipherDomainId = int64_t;
 using EncryptCipherBaseKeyId = uint64_t;
 using EncryptCipherRandomSalt = uint64_t;
+using EncryptCipherKeyCheckValue = uint32_t;
+
+constexpr const int MAX_BASE_CIPHER_LEN = EVP_MAX_KEY_LENGTH - sizeof(EncryptCipherRandomSalt);
 
 constexpr const EncryptCipherDomainId INVALID_ENCRYPT_DOMAIN_ID = -1;
 constexpr const EncryptCipherDomainId SYSTEM_KEYSPACE_ENCRYPT_DOMAIN_ID = -2;

--- a/flow/include/flow/error_definitions.h
+++ b/flow/include/flow/error_definitions.h
@@ -169,6 +169,7 @@ ERROR( rest_connectpool_key_not_found, 1528, "ConnectKey not found in connection
 ERROR( lock_file_failure, 1529, "Unable to lock the file")
 ERROR( rest_unsupported_protocol, 1530, "Unsupported REST protocol")
 ERROR( rest_malformed_response, 1531, "Malformed REST response")
+ERROR( rest_max_base_cipher_len, 1532, "Max BaseCipher length violation")
 
 
 // 2xxx Attempt (presumably by a _client_) to do something illegal.  If an error is known to
@@ -371,6 +372,8 @@ ERROR( encrypt_keys_fetch_failed, 2707, "Encryption keys fetch from external KMS
 ERROR( encrypt_invalid_kms_config, 2708, "Invalid encryption/kms configuration: discovery-url, validation-token, endpoint etc." )
 ERROR( encrypt_unsupported, 2709, "Encryption not supported" )
 ERROR( encrypt_mode_mismatch, 2710, "Encryption mode mismatch with configuration")
+ERROR( encrypt_key_check_value_mismatch, 2711, "Encryption key-check-value mismatch")
+ERROR( encrypt_max_base_cipher_len, 2712, "Max BaseCipher buffer length violation")
 
 // 4xxx Internal errors (those that should be generated only by bugs) are decimal 4xxx
 ERROR( unknown_error, 4000, "An unknown error occurred" )  // C++ exception not of type Error


### PR DESCRIPTION
* EaR: Implement Key Check Value semantics

Description

Key Check Value (KCV) is a checksum of cryptographic encryption key used to validate encryption keys's integrity. FDB Encryption at-rest relies on external KMS to supply encryption keys.

Patch proposes following major changes:
1. Implement Sha256 based KCV implementation to protect against 'baseCipher' corruption in two possible scenarios:
 a) potential corruption external to FDB
 b) potential corruption within FDB processes.
2. Scheme persists computed KCV token in block encryption header, which then gets validated as part of header validation during decryption.
3. FDB Encryption key derivation uses HMAC_SHA256 digest generation scheme, which allows max 64 bytes of 'cipher buffer', patch add required check to ensure 'baseCipher' length are within bounds. OpenSSL HMAC underlying call ignores extra length if supplied, however, it weakens the security guarantees, hence, disallowed.

Testing

devRunCorrectness - multiple 500K runs
Valgrind & Asan - BlobCipherUnit, RESTKMSUnit, BlobGranuleCorrectness*, EncryptionOps, EncryptKeyProxyTest

(cherry picked from commit fe0a4df06a90355f5c3b5f94e08c4a91bdf71bf8)
(https://github.com/apple/foundationdb/pull/9936)

Replace this text with your description here...

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
