### PR TITLE
Verify server tag key existence when handling checkpoint metadata mutation

### DIFF
--- a/fdbserver/ApplyMetadataMutation.cpp
+++ b/fdbserver/ApplyMetadataMutation.cpp
@@ -621,19 +621,22 @@ private:
 		if (toCommit) {
 			CheckpointMetaData checkpoint = decodeCheckpointValue(m.param2);
 			for (const auto& ssID : checkpoint.src) {
-				Tag tag = decodeServerTagValue(txnStateStore->readValue(serverTagKeyFor(ssID)).get().get());
-				MutationRef privatized = m;
-				privatized.param1 = m.param1.withPrefix(systemKeys.begin, arena);
-				TraceEvent("SendingPrivateMutationCheckpoint", dbgid)
-				    .detail("Original", m)
-				    .detail("Privatized", privatized)
-				    .detail("Server", ssID)
-				    .detail("TagKey", serverTagKeyFor(ssID))
-				    .detail("Tag", tag.toString())
-				    .detail("Checkpoint", checkpoint.toString());
+				Optional<Value> tagV = txnStateStore->readValue(serverTagKeyFor(ssID)).get();
+				if (tagV.present()) {
+					Tag tag = decodeServerTagValue(tagV.get());
+					MutationRef privatized = m;
+					privatized.param1 = m.param1.withPrefix(systemKeys.begin, arena);
+					TraceEvent("SendingPrivateMutationCheckpoint", dbgid)
+					    .detail("Original", m)
+					    .detail("Privatized", privatized)
+					    .detail("Server", ssID)
+					    .detail("TagKey", serverTagKeyFor(ssID))
+					    .detail("Tag", tag.toString())
+					    .detail("Checkpoint", checkpoint.toString());
 
-				toCommit->addTag(tag);
-				writeMutation(privatized);
+					toCommit->addTag(tag);
+					writeMutation(privatized);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Cherry pick #9963 

If the server tag key doesn't exist, don't send a privatized mutation to the SS.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
