### PR TITLE
Update `GlobalTagThrottlerImpl::tryUpdateAutoThrottling`

### DIFF
--- a/fdbserver/GlobalTagThrottler.actor.cpp
+++ b/fdbserver/GlobalTagThrottler.actor.cpp
@@ -686,7 +686,7 @@ public:
 		}
 		result.lastReply.bytesInput = ((totalReadCost.smoothRate() + totalWriteCost.smoothRate()) /
 		                               (capacity * CLIENT_KNOBS->TAG_THROTTLING_PAGE_SIZE)) *
-		                              SERVER_KNOBS->TARGET_BYTES_PER_STORAGE_SERVER;
+		                              SERVER_KNOBS->AUTO_TAG_THROTTLE_STORAGE_QUEUE_BYTES;
 		return result;
 	}
 };

--- a/fdbserver/GlobalTagThrottler.actor.cpp
+++ b/fdbserver/GlobalTagThrottler.actor.cpp
@@ -521,14 +521,15 @@ public:
 		                                                  SERVER_KNOBS->SPRING_BYTES_STORAGE_SERVER);
 		ssInfo.zoneId = ss.locality.zoneId();
 
+		auto& tagToThroughputCounters = throughput[ss.id];
 		for (const auto& busyReadTag : ss.busiestReadTags) {
 			if (tagStatistics.find(busyReadTag.tag) != tagStatistics.end()) {
-				throughput[ss.id][busyReadTag.tag].updateCost(busyReadTag.rate, OpType::READ);
+				tagToThroughputCounters[busyReadTag.tag].updateCost(busyReadTag.rate, OpType::READ);
 			}
 		}
 		for (const auto& busyWriteTag : ss.busiestWriteTags) {
 			if (tagStatistics.find(busyWriteTag.tag) != tagStatistics.end()) {
-				throughput[ss.id][busyWriteTag.tag].updateCost(busyWriteTag.rate, OpType::WRITE);
+				tagToThroughputCounters[busyWriteTag.tag].updateCost(busyWriteTag.rate, OpType::WRITE);
 			}
 		}
 		return Void();

--- a/fdbserver/GlobalTagThrottler.actor.cpp
+++ b/fdbserver/GlobalTagThrottler.actor.cpp
@@ -522,14 +522,26 @@ public:
 		ssInfo.zoneId = ss.locality.zoneId();
 
 		auto& tagToThroughputCounters = throughput[ss.id];
+		std::unordered_set<TransactionTag> busyReadTags, busyWriteTags;
 		for (const auto& busyReadTag : ss.busiestReadTags) {
+			busyReadTags.insert(busyReadTag.tag);
 			if (tagStatistics.find(busyReadTag.tag) != tagStatistics.end()) {
 				tagToThroughputCounters[busyReadTag.tag].updateCost(busyReadTag.rate, OpType::READ);
 			}
 		}
 		for (const auto& busyWriteTag : ss.busiestWriteTags) {
+			busyWriteTags.insert(busyWriteTag.tag);
 			if (tagStatistics.find(busyWriteTag.tag) != tagStatistics.end()) {
 				tagToThroughputCounters[busyWriteTag.tag].updateCost(busyWriteTag.rate, OpType::WRITE);
+			}
+		}
+
+		for (auto& [tag, throughputCounters] : tagToThroughputCounters) {
+			if (!busyReadTags.count(tag)) {
+				throughputCounters.updateCost(0.0, OpType::READ);
+			}
+			if (!busyWriteTags.count(tag)) {
+				throughputCounters.updateCost(0.0, OpType::WRITE);
 			}
 		}
 		return Void();

--- a/fdbserver/GlobalTagThrottler.actor.cpp
+++ b/fdbserver/GlobalTagThrottler.actor.cpp
@@ -517,7 +517,7 @@ public:
 
 	Future<Void> tryUpdateAutoThrottling(StorageQueueInfo const& ss) {
 		auto& ssInfo = ssInfos[ss.id];
-		ssInfo.throttlingRatio = ss.getTagThrottlingRatio(SERVER_KNOBS->TARGET_BYTES_PER_STORAGE_SERVER,
+		ssInfo.throttlingRatio = ss.getTagThrottlingRatio(SERVER_KNOBS->AUTO_TAG_THROTTLE_STORAGE_QUEUE_BYTES,
 		                                                  SERVER_KNOBS->SPRING_BYTES_STORAGE_SERVER);
 		ssInfo.zoneId = ss.locality.zoneId();
 


### PR DESCRIPTION
For tags that don't have an associated read or write cost for a storage server, assume that the cost is 0 and update the ThroughputCounters accordingly.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
