### PR TITLE
Log the relocation decision at the time of launching relocations

### DIFF
--- a/fdbserver/DDRelocationQueue.actor.cpp
+++ b/fdbserver/DDRelocationQueue.actor.cpp
@@ -1226,27 +1226,24 @@ static std::string destServersString(std::vector<std::pair<Reference<IDataDistri
 	return std::move(ss).str();
 }
 
-void traceRelocateDecision(TraceEvent& ev,
-                           const RelocateData& rd,
-                           const UID& pairId,
-                           const std::vector<UID>& destIds,
-                           const std::vector<UID>& extraIds,
-                           const StorageMetrics& metrics) {
+void traceRelocateDecision(TraceEvent& ev, const UID& pairId, const RelocateDecision& decision) {
 	ev.detail("PairId", pairId)
-	    .detail("Priority", rd.priority)
-	    .detail("KeyBegin", rd.keys.begin)
-	    .detail("KeyEnd", rd.keys.end)
-	    .detail("Reason", rd.reason.toString())
-	    .detail("SourceServers", describe(rd.src))
-	    .detail("DestinationTeam", describe(destIds))
-	    .detail("ExtraIds", describe(extraIds));
+	    .detail("Priority", decision.rd.priority)
+	    .detail("KeyBegin", decision.rd.keys.begin)
+	    .detail("KeyEnd", decision.rd.keys.end)
+	    .detail("Reason", decision.rd.reason.toString())
+	    .detail("SourceServers", describe(decision.rd.src))
+	    .detail("DestinationTeam", describe(decision.destIds))
+	    .detail("ExtraIds", describe(decision.extraIds));
 	if (SERVER_KNOBS->DD_ENABLE_VERBOSE_TRACING) {
 		// StorageMetrics is the rd shard's metrics, e.g., bytes and write bandwidth
-		ev.detail("StorageMetrics", metrics.toString());
+		ev.detail("StorageMetrics", decision.metrics.toString());
 	}
 	// tell if the splitter acted as expected for write bandwidth splitting
-	if (rd.reason == RelocateReason::WRITE_SPLIT) {
-		ev.detail("ShardWriteBytes", metrics.bytesWrittenPerKSecond);
+	if (decision.rd.reason == RelocateReason::WRITE_SPLIT) {
+		// SOMEDAY: trace the source team write bytes if necessary
+		ev.detail("ShardWriteBytes", decision.metrics.bytesWrittenPerKSecond)
+		    .detail("ParentShardWriteBytes", decision.parentMetrics.get().bytesWrittenPerKSecond);
 	}
 }
 // This actor relocates the specified keys to a good place.
@@ -1707,7 +1704,8 @@ ACTOR Future<Void> dataDistributionRelocator(DDQueue* self,
 			launchDest(rd, bestTeams, self->destBusymap);
 
 			TraceEvent ev(relocateShardInterval.severity, "RelocateShardHasDestination", distributorId);
-			traceRelocateDecision(ev, rd, relocateShardInterval.pairID, destIds, extraIds, metrics);
+			RelocateDecision decision{ rd, destIds, extraIds, metrics, parentMetrics };
+			traceRelocateDecision(ev, relocateShardInterval.pairID, decision);
 
 			self->serverCounter.increaseForTeam(rd.src, rd.reason, DDQueue::ServerCounter::LaunchedSource);
 			self->serverCounter.increaseForTeam(destIds, rd.reason, DDQueue::ServerCounter::LaunchedDest);

--- a/fdbserver/DDShardTracker.actor.cpp
+++ b/fdbserver/DDShardTracker.actor.cpp
@@ -460,14 +460,18 @@ void executeShardSplit(DataDistributionTracker* self,
 		KeyRangeRef r(splitKeys[i], splitKeys[i + 1]);
 		self->shardsAffectedByTeamFailure->defineShard(r);
 		if (relocate) {
-			self->output.send(RelocateShard(r, DataMovementReason::SPLIT_SHARD, reason));
+			RelocateShard rs(r, DataMovementReason::SPLIT_SHARD, reason);
+			rs.setParentRange(keys);
+			self->output.send(rs);
 		}
 	}
 	for (int i = numShards - 1; i > skipRange; i--) {
 		KeyRangeRef r(splitKeys[i], splitKeys[i + 1]);
 		self->shardsAffectedByTeamFailure->defineShard(r);
 		if (relocate) {
-			self->output.send(RelocateShard(r, DataMovementReason::SPLIT_SHARD, reason));
+			RelocateShard rs(r, DataMovementReason::SPLIT_SHARD, reason);
+			rs.setParentRange(keys);
+			self->output.send(rs);
 		}
 	}
 
@@ -1112,7 +1116,7 @@ ACTOR Future<Void> shardEvaluator(DataDistributionTracker* self,
 		onChange = onChange || shardMerger(self, keys, shardSize);
 	}
 	if (shouldSplit) {
-		RelocateReason reason = writeSplit ? RelocateReason::WRITE_SPLIT : RelocateReason::SIZE_SPLIT;
+		RelocateReason reason = sizeSplit ? RelocateReason::SIZE_SPLIT : RelocateReason::WRITE_SPLIT;
 		onChange = onChange || shardSplitter(self, keys, shardSize, shardBounds, reason);
 	}
 

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -54,6 +54,14 @@
 #include "flow/genericactors.actor.h"
 #include "flow/serialize.h"
 
+void RelocateShard::setParentRange(KeyRange const& parent) {
+	parent_range = parent;
+}
+
+Optional<KeyRange> RelocateShard::getParentRange() const {
+	return parent_range;
+}
+
 ShardSizeBounds ShardSizeBounds::shardSizeBoundsBeforeTrack() {
 	return ShardSizeBounds{ .max = StorageMetrics{ .bytes = -1,
 		                                           .bytesWrittenPerKSecond = StorageMetrics::infinity,

--- a/fdbserver/include/fdbserver/DDRelocationQueue.h
+++ b/fdbserver/include/fdbserver/DDRelocationQueue.h
@@ -85,6 +85,14 @@ public:
 	bool operator!=(const RelocateData& rhs) const;
 };
 
+struct RelocateDecision {
+	const RelocateData& rd;
+	const std::vector<UID>& destIds;
+	const std::vector<UID>& extraIds;
+	const StorageMetrics& metrics;
+	const Optional<StorageMetrics>& parentMetrics;
+};
+
 // DDQueue uses Busyness to throttle too many movement to/from a same server
 struct Busyness {
 	std::vector<int> ledger;

--- a/fdbserver/include/fdbserver/DDRelocationQueue.h
+++ b/fdbserver/include/fdbserver/DDRelocationQueue.h
@@ -39,6 +39,9 @@ public:
 
 // DDQueue use RelocateData to track proposed movements
 class RelocateData {
+	// If this rs comes from a splitting, parent range is the original range.
+	Optional<KeyRange> parent_range;
+
 public:
 	KeyRange keys;
 	int priority;
@@ -75,6 +78,7 @@ public:
 	}
 
 	bool isRestore() const;
+	Optional<KeyRange> getParentRange() const;
 
 	bool operator>(const RelocateData& rhs) const;
 	bool operator==(const RelocateData& rhs) const;

--- a/fdbserver/include/fdbserver/DataDistribution.actor.h
+++ b/fdbserver/include/fdbserver/DataDistribution.actor.h
@@ -163,7 +163,13 @@ struct RelocateShard {
 
 	bool isRestore() const { return this->dataMove != nullptr; }
 
+	void setParentRange(KeyRange const& parent);
+	Optional<KeyRange> getParentRange() const;
+
 private:
+	// If this rs comes from a splitting, parent range is the original range.
+	Optional<KeyRange> parent_range;
+
 	RelocateShard()
 	  : priority(0), cancelled(false), dataMoveId(anonymousShardId), reason(RelocateReason::OTHER),
 	    moveReason(DataMovementReason::INVALID) {}

--- a/flow/include/flow/genericactors.actor.h
+++ b/flow/include/flow/genericactors.actor.h
@@ -328,8 +328,8 @@ Future<Void> holdWhileVoid(X object, Future<T> what) {
 }
 
 // Assign the future value of what to out
-template <class T>
-Future<Void> store(T& out, Future<T> what) {
+template <class T, class X>
+Future<Void> store(X& out, Future<T> what) {
 	return map(what, [&out](T const& v) {
 		out = v;
 		return Void();


### PR DESCRIPTION
For write-bandwidth-based splits, we want to know whether the split decision is good by looking at the storage metrics of parent shard and splitted shard. Otherwise, it is hard to tell if the splitter acted as expected.

The next step might be use the ongoing shard re-evaluation project to prevent unnecessary splitting.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
