### PR TITLE
EaR: Add CODE_PROBEs to cover at-rest marker string file scan (#9990)

### DIFF
--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -1863,6 +1863,15 @@ void encryptionAtRestPlaintextMarkerCheck() {
 				    .detail("Filename", itr->path().string())
 				    .detail("NumLines", count);
 				scanned++;
+				if (itr->path().string().find("storage") != std::string::npos) {
+					CODE_PROBE(true, "EncryptionAtRestPlaintextMarkerCheckScanned storage file scanned");
+				} else if (itr->path().string().find("fdbblob") != std::string::npos) {
+					CODE_PROBE(true, "EncryptionAtRestPlaintextMarkerCheckScanned BlobGranule file scanned");
+				} else if (itr->path().string().find("logqueue") != std::string::npos) {
+					CODE_PROBE(true, "EncryptionAtRestPlaintextMarkerCheckScanned TLog file scanned");
+				} else if (itr->path().string().find("backup") != std::string::npos) {
+					CODE_PROBE(true, "EncryptionAtRestPlaintextMarkerCheckScanned KVBackup file scanned");
+				}
 			} else {
 				TraceEvent(SevError, "FileOpenError").detail("Filename", itr->path().string());
 			}


### PR DESCRIPTION
Description

Patch adds the required CODE_PROBEs to cover following cases where encryption at-rest scanner checks on-disk files for plaintext marker; the cases covered are:
1. Tlog files
2. BlobGranule files
3. Storage files
4. KVBackup files

Testing

Time=507.645390  Machine=AARDVARK(0.0.0.0:0)        Roles=                               Severity=10  Type=CodeCoverage                              ID=0,000,000,000,000,000  LogId=                At=             File=fdbserver/tester.actor.cpp                Comment=EncryptionAtRestPlaintextMarkerCheckScanned KVBackup file scanned  Condition=true                                      Covered=1  Line=1,874
Time=507.645390  Machine=AARDVARK(0.0.0.0:0)        Roles=                               Severity=10  Type=CodeCoverage                              ID=0,000,000,000,000,000  LogId=                At=             File=fdbserver/tester.actor.cpp                Comment=EncryptionAtRestPlaintextMarkerCheckScanned storage file scanned  Condition=true                                      Covered=1  Line=1,868
Time=507.645390  Machine=AARDVARK(0.0.0.0:0)        Roles=                               Severity=10  Type=CodeCoverage                              ID=0,000,000,000,000,000  LogId=                At=             File=fdbserver/tester.actor.cpp                Comment=EncryptionAtRestPlaintextMarkerCheckScanned BlobGranule file scanned  Condition=true                                      Covered=0  Line=1,870
Time=507.645390  Machine=AARDVARK(0.0.0.0:0)        Roles=                               Severity=10  Type=CodeCoverage                              ID=0,000,000,000,000,000  LogId=                At=             File=fdbserver/tester.actor.cpp                Comment=EncryptionAtRestPlaintextMarkerCheckScanned TLog file scanned  Condition=true                                      Covered=1  Line=1,872

(cherry picked from commit 5a80cb3898b2e4289bd5c6a89d80a3ea5a6af4b0)
(https://github.com/apple/foundationdb/pull/9990)

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
