### PR TITLE
Fix RangeResult.readThrough misuse

### DIFF
--- a/bindings/flow/FDBLoanerTypes.h
+++ b/bindings/flow/FDBLoanerTypes.h
@@ -156,19 +156,53 @@ struct KeyValueRef {
 typedef Standalone<KeyValueRef> KeyValue;
 
 struct RangeResultRef : VectorRef<KeyValueRef> {
-	bool more; // True if (but not necessarily only if) values remain in the *key* range requested (possibly beyond the
-	           // limits requested)
-	// False implies that no such values remain
-	Optional<KeyRef> readThrough; // Only present when 'more' is true. When present, this value represent the end (or
-	                              // beginning if reverse) of the range
+	// True if the range may have more keys in it (possibly beyond the specified limits).
+	// 'more' can be true even if there are no keys left in the range, e.g. if a shard boundary is hit, it may or may
+	// not have more keys left, but 'more' will be set to true in that case.
+	// Additionally, 'getRangeStream()' always sets 'more' to true and uses the 'end_of_stream' error to indicate that a
+	// range is exhausted.
+	// If 'more' is false, the range is guaranteed to have been exhausted.
+	bool more;
 
-	KeyRef getReadThrough(Arena& arena) const {
+	// Only present when 'more' is true, for example, when the read reaches the shard boundary, 'readThrough' is set to
+	// the shard boundary and the client's next range read should start with the 'readThrough'.
+	// But 'more' is true does not necessarily guarantee 'readThrough' is present, for example, when the read reaches
+	// size limit, 'readThrough' might not be set, the next read should just start from the keyAfter of the current
+	// query result's last key.
+	// In both cases, please use the getter function 'getReadThrough()' instead, which represents the end (or beginning
+	// if reverse) of the range which was read.
+	Optional<KeyRef> readThrough;
+
+	// return the value represents the end of the range which was read. If 'reverse' is true, returns the last key, as
+	// it should be used as the new "end" of the next query and the end key should be non-inclusive.
+	Key getReadThrough(bool reverse = false) const {
 		ASSERT(more);
 		if (readThrough.present()) {
 			return readThrough.get();
 		}
 		ASSERT(size() > 0);
-		return keyAfter(back().key, arena);
+		return reverse ? back().key : keyAfter(back().key);
+	}
+
+	// Helper function to get the next range scan's BeginKeySelector, use it when the range read is non-reverse,
+	// otherwise, please use nextEndKeySelector().
+	KeySelectorRef nextBeginKeySelector() const {
+		ASSERT(more);
+		if (readThrough.present()) {
+			return firstGreaterOrEqual(readThrough.get());
+		}
+		ASSERT(size() > 0);
+		return firstGreaterThan(back().key);
+	}
+
+	// Helper function to get the next range scan's EndKeySelector, use it when the range read is reverse.
+	KeySelectorRef nextEndKeySelector() const {
+		ASSERT(more);
+		if (readThrough.present()) {
+			return firstGreaterOrEqual(readThrough.get());
+		}
+		ASSERT(size() > 0);
+		return firstGreaterOrEqual(back().key);
 	}
 
 	void setReadThrough(KeyRef key) {

--- a/bindings/flow/FDBLoanerTypes.h
+++ b/bindings/flow/FDBLoanerTypes.h
@@ -161,6 +161,22 @@ struct RangeResultRef : VectorRef<KeyValueRef> {
 	// False implies that no such values remain
 	Optional<KeyRef> readThrough; // Only present when 'more' is true. When present, this value represent the end (or
 	                              // beginning if reverse) of the range
+
+	KeyRef getReadThrough(Arena& arena) const {
+		ASSERT(more);
+		if (readThrough.present()) {
+			return readThrough.get();
+		}
+		ASSERT(size() > 0);
+		return keyAfter(back().key, arena);
+	}
+
+	void setReadThrough(KeyRef key) {
+		ASSERT(more);
+		ASSERT(!readThrough.present());
+		readThrough = key;
+	}
+
 	// which was read to produce these results. This is guaranteed to be less than the requested range.
 	bool readToBegin;
 	bool readThroughEnd;

--- a/fdbclient/MutationLogReader.actor.cpp
+++ b/fdbclient/MutationLogReader.actor.cpp
@@ -103,7 +103,7 @@ ACTOR Future<Void> PipelinedReader::getNext_impl(PipelinedReader* self, Database
 					return Void();
 				}
 
-				begin = kvs.getReadThrough(begin.arena());
+				begin = kvs.getReadThrough();
 
 				break;
 			} catch (Error& e) {

--- a/fdbclient/MutationLogReader.actor.cpp
+++ b/fdbclient/MutationLogReader.actor.cpp
@@ -103,7 +103,7 @@ ACTOR Future<Void> PipelinedReader::getNext_impl(PipelinedReader* self, Database
 					return Void();
 				}
 
-				begin = kvs.readThrough.present() ? kvs.readThrough.get() : keyAfter(kvs.back().key);
+				begin = kvs.getReadThrough(begin.arena());
 
 				break;
 			} catch (Error& e) {

--- a/fdbclient/include/fdbclient/FDBTypes.h
+++ b/fdbclient/include/fdbclient/FDBTypes.h
@@ -750,11 +750,38 @@ struct GetRangeLimits {
 
 struct RangeResultRef : VectorRef<KeyValueRef> {
 	constexpr static FileIdentifier file_identifier = 3985192;
-	bool more; // True if (but not necessarily only if) values remain in the *key* range requested (possibly beyond the
-	           // limits requested) False implies that no such values remain
-	Optional<KeyRef> readThrough; // Only present when 'more' is true. When present, this value represent the end (or
-	                              // beginning if reverse) of the range which was read to produce these results. This is
-	                              // guaranteed to be less than the requested range.
+	bool more; // True if values remain in the *key* range requested (possibly beyond the
+	           // limits requested), but not necessarily only if, for example, in getRangeStream(), 'more' is always set
+	           // to true, as each stream fragment doesn't know if it's the last one. Instead, it uses
+	           // `error_code_end_of_stream` for the end.
+	           // False implies that no such values remain
+
+	// Only present when 'more' is true, for example, when the read reaches the shard boundary, 'readThrough' is set to
+	// the shard boundary and the client's next range read should start with the 'readThrough'.
+	// But 'more' is true does not necessarily guarantee 'readThrough' is present, for example, when the read reaches
+	// size limit, 'readThrough' might not be set, the next read should just start from the keyAfter of the current
+	// query result's last key.
+	// In both cases, please use the getter function 'getReadThrough()' instead, which represents the end (or beginning
+	// if reverse) of the range which was read.
+	Optional<KeyRef> readThrough;
+
+	// return the value represent the end (or beginning if reverse) of the range which was read
+	KeyRef getReadThrough(Arena& arena) const {
+		ASSERT(more);
+		if (readThrough.present()) {
+			return readThrough.get();
+		}
+		ASSERT(size() > 0);
+		// TODO: is this still right if reverse
+		return keyAfter(back().key, arena);
+	}
+
+	void setReadThrough(KeyRef key) {
+		ASSERT(more);
+		ASSERT(!readThrough.present());
+		readThrough = key;
+	}
+
 	bool readToBegin;
 	bool readThroughEnd;
 
@@ -874,6 +901,12 @@ struct MappedRangeResultRef : VectorRef<MappedKeyValueRef> {
 	Optional<KeyRef> readThrough;
 	bool readToBegin;
 	bool readThroughEnd;
+
+	void setReadThrough(KeyRef key) {
+		ASSERT(more);
+		ASSERT(!readThrough.present());
+		readThrough = key;
+	}
 
 	MappedRangeResultRef() : more(false), readToBegin(false), readThroughEnd(false) {}
 	MappedRangeResultRef(Arena& p, const MappedRangeResultRef& toCopy)

--- a/fdbclient/include/fdbclient/FDBTypes.h
+++ b/fdbclient/include/fdbclient/FDBTypes.h
@@ -776,6 +776,17 @@ struct RangeResultRef : VectorRef<KeyValueRef> {
 		return keyAfter(back().key, arena);
 	}
 
+	// Helper function to get the next range scan's BeginKeySelector, currently only for non-reverse range read.
+	// TODO: add another function for reverse range read
+	KeySelectorRef nextBeginKeySelector() const {
+		ASSERT(more);
+		if (readThrough.present()) {
+			return firstGreaterOrEqual(readThrough.get());
+		}
+		ASSERT(size() > 0);
+		return firstGreaterThan(back().key);
+	}
+
 	void setReadThrough(KeyRef key) {
 		ASSERT(more);
 		ASSERT(!readThrough.present());

--- a/fdbserver/BlobManifest.actor.cpp
+++ b/fdbserver/BlobManifest.actor.cpp
@@ -394,7 +394,6 @@ private:
 					limits.minRows = 0;
 					state KeySelectorRef begin = firstGreaterOrEqual(range.begin);
 					state KeySelectorRef end = firstGreaterOrEqual(range.end);
-					state Arena beginKeyArena;
 					loop {
 						state RangeResult result = wait(tr.getRange(begin, end, limits, Snapshot::True));
 						for (auto& row : result) {
@@ -403,7 +402,7 @@ private:
 						if (!result.more) {
 							break;
 						}
-						begin = firstGreaterOrEqual(result.getReadThrough(beginKeyArena));
+						begin = result.nextBeginKeySelector();
 					}
 				}
 
@@ -488,7 +487,6 @@ public:
 				// Read all granules
 				state GetRangeLimits limits(SERVER_KNOBS->BLOB_MANIFEST_RW_ROWS);
 				limits.minRows = 0;
-				state Arena arena;
 				state KeySelectorRef begin = firstGreaterOrEqual(blobGranuleMappingKeys.begin);
 				state KeySelectorRef end = firstGreaterOrEqual(blobGranuleMappingKeys.end);
 				loop {
@@ -499,7 +497,7 @@ public:
 					if (!rows.more) {
 						break;
 					}
-					begin = firstGreaterOrEqual(rows.getReadThrough(arena));
+					begin = rows.nextBeginKeySelector();
 				}
 
 				// check each granule range
@@ -755,7 +753,6 @@ private:
 		limits.minRows = 0;
 		state KeySelectorRef begin = firstGreaterOrEqual(fileKeyRange.begin);
 		state KeySelectorRef end = firstGreaterOrEqual(fileKeyRange.end);
-		state Arena beginKeyArena;
 		loop {
 			RangeResult results = wait(tr->getRange(begin, end, limits, Snapshot::True));
 			for (auto& row : results) {
@@ -778,7 +775,7 @@ private:
 			if (!results.more) {
 				break;
 			}
-			begin = firstGreaterOrEqual(results.getReadThrough(beginKeyArena));
+			begin = results.nextBeginKeySelector();
 		}
 		return files;
 	}

--- a/fdbserver/BlobRestoreController.actor.cpp
+++ b/fdbserver/BlobRestoreController.actor.cpp
@@ -45,7 +45,6 @@ ACTOR Future<BlobRestoreRangeState> BlobRestoreController::getRangeState(Referen
 			limits.minRows = 0;
 			state KeySelectorRef begin = firstGreaterOrEqual(blobRestoreCommandKeys.begin);
 			state KeySelectorRef end = firstGreaterOrEqual(blobRestoreCommandKeys.end);
-			state Arena beginKeyArena;
 			loop {
 				RangeResult ranges = wait(tr.getRange(begin, end, limits, Snapshot::True));
 				for (auto& r : ranges) {
@@ -60,7 +59,7 @@ ACTOR Future<BlobRestoreRangeState> BlobRestoreController::getRangeState(Referen
 				if (!ranges.more) {
 					break;
 				}
-				begin = firstGreaterOrEqual(ranges.getReadThrough(beginKeyArena));
+				begin = ranges.nextBeginKeySelector();
 			}
 			return std::make_pair(KeyRangeRef(), BlobRestoreState(BlobRestorePhase::DONE));
 		} catch (Error& e) {
@@ -149,7 +148,6 @@ ACTOR Future<Optional<BlobRestoreArg>> BlobRestoreController::getArgument(Refere
 				limits.minRows = 0;
 				state KeySelectorRef begin = firstGreaterOrEqual(blobRestoreArgKeys.begin);
 				state KeySelectorRef end = firstGreaterOrEqual(blobRestoreArgKeys.end);
-				state Arena beginKeyArena;
 				loop {
 					RangeResult ranges = wait(tr.getRange(begin, end, limits, Snapshot::True));
 					for (auto& r : ranges) {
@@ -163,7 +161,7 @@ ACTOR Future<Optional<BlobRestoreArg>> BlobRestoreController::getArgument(Refere
 					if (!ranges.more) {
 						break;
 					}
-					begin = firstGreaterOrEqual(ranges.getReadThrough(beginKeyArena));
+					begin = ranges.nextBeginKeySelector();
 				}
 				return result;
 			} catch (Error& e) {

--- a/fdbserver/KeyValueStoreMemory.actor.cpp
+++ b/fdbserver/KeyValueStoreMemory.actor.cpp
@@ -276,10 +276,6 @@ public:
 		}
 
 		result.more = rowLimit == 0 || byteLimit <= 0;
-		if (result.more) {
-			ASSERT(result.size() > 0);
-			result.readThrough = result[result.size() - 1].key;
-		}
 		return result;
 	}
 

--- a/fdbserver/KeyValueStoreRocksDB.actor.cpp
+++ b/fdbserver/KeyValueStoreRocksDB.actor.cpp
@@ -1779,9 +1779,6 @@ struct RocksDBKeyValueStore : IKeyValueStore {
 			}
 			result.more =
 			    (result.size() == a.rowLimit) || (result.size() == -a.rowLimit) || (accumulatedBytes >= a.byteLimit);
-			if (result.more) {
-				result.readThrough = result[result.size() - 1].key;
-			}
 			a.result.send(result);
 			// Temporarily not sampling to understand the pattern of readRange results.
 			if (metricPromiseStream) {

--- a/fdbserver/KeyValueStoreSQLite.actor.cpp
+++ b/fdbserver/KeyValueStoreSQLite.actor.cpp
@@ -1261,10 +1261,6 @@ struct RawCursor {
 			}
 		}
 		result.more = rowLimit == 0 || accumulatedBytes >= byteLimit;
-		if (result.more) {
-			ASSERT(result.size() > 0);
-			result.readThrough = result[result.size() - 1].key;
-		}
 		// AccumulatedBytes includes KeyValueRef overhead so subtract it
 		kvBytesRead += (accumulatedBytes - result.size() * sizeof(KeyValueRef));
 		return result;

--- a/fdbserver/KeyValueStoreShardedRocksDB.actor.cpp
+++ b/fdbserver/KeyValueStoreShardedRocksDB.actor.cpp
@@ -2788,9 +2788,6 @@ struct ShardedRocksDBKeyValueStore : IKeyValueStore {
 
 			result.more =
 			    (result.size() == a.rowLimit) || (result.size() == -a.rowLimit) || (accumulatedBytes >= a.byteLimit);
-			if (result.more) {
-				result.readThrough = result[result.size() - 1].key;
-			}
 			a.result.send(result);
 			if (a.getHistograms) {
 				double currTime = timer_monotonic();

--- a/fdbserver/StorageCache.actor.cpp
+++ b/fdbserver/StorageCache.actor.cpp
@@ -1241,8 +1241,9 @@ ACTOR Future<RangeResult> tryFetchRange(Database cx,
 			if (e.code() == error_code_transaction_too_old)
 				*isTooOld = true;
 			output.more = true;
-			if (begin.isFirstGreaterOrEqual())
-				output.readThrough = begin.getKey();
+			if (begin.isFirstGreaterOrEqual()) {
+				output.setReadThrough(begin.getKey());
+			}
 			return output;
 		}
 		throw;

--- a/fdbserver/VersionedBTree.actor.cpp
+++ b/fdbserver/VersionedBTree.actor.cpp
@@ -8257,10 +8257,6 @@ public:
 		}
 
 		result.more = rowLimit == 0 || accumulatedBytes >= byteLimit;
-		if (result.more) {
-			ASSERT(result.size() > 0);
-			result.readThrough = result[result.size() - 1].key;
-		}
 		g_redwoodMetrics.kvSizeReadByGetRange->sample(accumulatedBytes);
 		return result;
 	}

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -7617,7 +7617,7 @@ ACTOR Future<Void> fetchKeys(StorageServer* data, AddingShard* shard) {
 						data->byteSampleApplySet(*kvItr, invalidVersion);
 					}
 					if (this_block.more) {
-						blockBegin = this_block.getReadThrough(blockBegin.arena());
+						blockBegin = this_block.getReadThrough();
 					} else {
 						ASSERT(!this_block.readThrough.present());
 						blockBegin = rangeEnd;
@@ -9717,7 +9717,7 @@ ACTOR Future<bool> createSstFileForCheckpointShardBytesSample(StorageServer* dat
 							numSampledKeys++;
 						}
 						if (readResult.more) {
-							readBegin = readResult.getReadThrough(readBegin.arena());
+							readBegin = readResult.getReadThrough();
 							ASSERT(readBegin <= readEnd);
 						} else {
 							break; // finish for current metaDataRangesIter

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -6547,15 +6547,13 @@ ACTOR Future<Void> tryGetRange(PromiseStream<RangeResult> results, Transaction* 
 
 	state KeySelectorRef begin = firstGreaterOrEqual(keys.begin);
 	state KeySelectorRef end = firstGreaterOrEqual(keys.end);
+	state Arena beginKeyArena;
 
 	try {
 		loop {
 			GetRangeLimits limits(GetRangeLimits::ROW_LIMIT_UNLIMITED, SERVER_KNOBS->FETCH_BLOCK_BYTES);
 			limits.minRows = 0;
 			state RangeResult rep = wait(tr->getRange(begin, end, limits, Snapshot::True));
-			if (!rep.more) {
-				rep.readThrough = keys.end;
-			}
 			results.send(rep);
 
 			if (!rep.more) {
@@ -6563,11 +6561,7 @@ ACTOR Future<Void> tryGetRange(PromiseStream<RangeResult> results, Transaction* 
 				return Void();
 			}
 
-			if (rep.readThrough.present()) {
-				begin = firstGreaterOrEqual(rep.readThrough.get());
-			} else {
-				begin = firstGreaterThan(rep.end()[-1].key);
-			}
+			begin = firstGreaterOrEqual(rep.getReadThrough(beginKeyArena));
 		}
 	} catch (Error& e) {
 		if (e.code() == error_code_actor_cancelled) {
@@ -6628,12 +6622,16 @@ ACTOR Future<Void> tryGetRangeFromBlob(PromiseStream<RangeResult> results,
 			    .detail("Rows", rows.size())
 			    .detail("ChunkRange", chunkRange)
 			    .detail("FetchVersion", fetchVersion);
-			if (rows.size() == 0) {
-				rows.readThrough = KeyRef(rows.arena(), std::min(chunkRange.end, keys.end));
-			}
+			// It should read all the data from that chunk
+			ASSERT(!rows.more);
 			if (i == chunks.size() - 1) {
-				rows.readThrough = KeyRef(rows.arena(), keys.end);
+				// set more to false when it's the last chunk
+				rows.more = false;
+			} else {
+				rows.more = true;
+				// no need to set readThrough, as the next read key range has to be the next chunkRange
 			}
+			ASSERT(!rows.readThrough.present());
 			results.send(rows);
 		}
 		results.sendError(end_of_stream()); // end of range read
@@ -7555,6 +7553,7 @@ ACTOR Future<Void> fetchKeys(StorageServer* data, AddingShard* shard) {
 
 			state PromiseStream<RangeResult> results;
 			state Future<Void> hold;
+			state KeyRef rangeEnd;
 			if (isFullRestore) {
 				state BlobRestoreRangeState rangeStatus = wait(BlobRestoreController::getRangeState(restoreController));
 				// Read from blob only when it's copying data for full restore. Otherwise it may cause data corruptions
@@ -7563,11 +7562,14 @@ ACTOR Future<Void> fetchKeys(StorageServer* data, AddingShard* shard) {
 				    rangeStatus.second.phase == BlobRestorePhase::ERROR) {
 					Version version = wait(BlobRestoreController::getTargetVersion(restoreController, fetchVersion));
 					hold = tryGetRangeFromBlob(results, &tr, rangeStatus.first, version, data->blobConn);
+					rangeEnd = rangeStatus.first.end;
 				} else {
 					hold = tryGetRange(results, &tr, keys);
+					rangeEnd = keys.end;
 				}
 			} else {
 				hold = tryGetRange(results, &tr, keys);
+				rangeEnd = keys.end;
 			}
 
 			state Key blockBegin = keys.begin;
@@ -7615,9 +7617,12 @@ ACTOR Future<Void> fetchKeys(StorageServer* data, AddingShard* shard) {
 					for (; kvItr != this_block.end(); ++kvItr) {
 						data->byteSampleApplySet(*kvItr, invalidVersion);
 					}
-					ASSERT(this_block.readThrough.present() || this_block.size());
-					blockBegin = this_block.readThrough.present() ? this_block.readThrough.get()
-					                                              : keyAfter(this_block.end()[-1].key);
+					if (this_block.more) {
+						blockBegin = this_block.getReadThrough(blockBegin.arena());
+					} else {
+						ASSERT(!this_block.readThrough.present());
+						blockBegin = rangeEnd;
+					}
 					this_block = RangeResult();
 
 					data->fetchKeysBytesBudget -= expectedBlockSize;
@@ -9713,8 +9718,7 @@ ACTOR Future<bool> createSstFileForCheckpointShardBytesSample(StorageServer* dat
 							numSampledKeys++;
 						}
 						if (readResult.more) {
-							ASSERT(readResult.readThrough.present());
-							readBegin = keyAfter(readResult.readThrough.get());
+							readBegin = readResult.getReadThrough(readBegin.arena());
 							ASSERT(readBegin <= readEnd);
 						} else {
 							break; // finish for current metaDataRangesIter

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -6547,7 +6547,6 @@ ACTOR Future<Void> tryGetRange(PromiseStream<RangeResult> results, Transaction* 
 
 	state KeySelectorRef begin = firstGreaterOrEqual(keys.begin);
 	state KeySelectorRef end = firstGreaterOrEqual(keys.end);
-	state Arena beginKeyArena;
 
 	try {
 		loop {
@@ -6561,7 +6560,7 @@ ACTOR Future<Void> tryGetRange(PromiseStream<RangeResult> results, Transaction* 
 				return Void();
 			}
 
-			begin = firstGreaterOrEqual(rep.getReadThrough(beginKeyArena));
+			begin = rep.nextBeginKeySelector();
 		}
 	} catch (Error& e) {
 		if (e.code() == error_code_actor_cancelled) {

--- a/fdbserver/workloads/BlobRestoreWorkload.actor.cpp
+++ b/fdbserver/workloads/BlobRestoreWorkload.actor.cpp
@@ -158,13 +158,12 @@ struct BlobRestoreWorkload : TestWorkload {
 		state Standalone<VectorRef<KeyValueRef>> data;
 		state Transaction tr(cx);
 		state KeySelectorRef end = firstGreaterOrEqual(normalKeys.end);
-		state Arena arena;
 
 		loop {
 			try {
 				GetRangeLimits limits(self->readBatchSize_ - data.size());
 				limits.minRows = 0;
-				RangeResult result = wait(tr.getRange(begin, end, limits, Snapshot::True));
+				state RangeResult result = wait(tr.getRange(begin, end, limits, Snapshot::True));
 				for (auto& row : result) {
 					data.push_back_deep(data.arena(), KeyValueRef(row.key, row.value));
 				}
@@ -174,7 +173,7 @@ struct BlobRestoreWorkload : TestWorkload {
 				if (data.size() == self->readBatchSize_) {
 					break;
 				}
-				begin = firstGreaterOrEqual(result.getReadThrough(arena));
+				begin = result.nextBeginKeySelector();
 			} catch (Error& e) {
 				wait(tr.onError(e));
 			}

--- a/fdbserver/workloads/BlobRestoreWorkload.actor.cpp
+++ b/fdbserver/workloads/BlobRestoreWorkload.actor.cpp
@@ -174,11 +174,7 @@ struct BlobRestoreWorkload : TestWorkload {
 				if (data.size() == self->readBatchSize_) {
 					break;
 				}
-				if (result.readThrough.present()) {
-					begin = firstGreaterOrEqual(KeyRef(arena, result.readThrough.get()));
-				} else {
-					begin = firstGreaterThan(KeyRef(arena, result.back().key));
-				}
+				begin = firstGreaterOrEqual(result.getReadThrough(arena));
 			} catch (Error& e) {
 				wait(tr.onError(e));
 			}

--- a/fdbserver/workloads/StreamingRangeRead.actor.cpp
+++ b/fdbserver/workloads/StreamingRangeRead.actor.cpp
@@ -35,7 +35,6 @@
 ACTOR Future<Void> streamUsingGetRange(PromiseStream<RangeResult> results, Transaction* tr, KeyRange keys) {
 	state KeySelectorRef begin = firstGreaterOrEqual(keys.begin);
 	state KeySelectorRef end = firstGreaterOrEqual(keys.end);
-	state Arena beginKeyArena;
 
 	try {
 		loop {
@@ -50,7 +49,7 @@ ACTOR Future<Void> streamUsingGetRange(PromiseStream<RangeResult> results, Trans
 				return Void();
 			}
 
-			begin = firstGreaterOrEqual(rep.getReadThrough(beginKeyArena));
+			begin = rep.nextBeginKeySelector();
 		}
 	} catch (Error& e) {
 		if (e.code() == error_code_actor_cancelled) {


### PR DESCRIPTION
Fix a few `RangeResult.readThrough` misuses:
1. `KeyValueStore`s do not need to set readThrough, as it will not be serialized and return. Also setting it to the last key of the result is not right, it should at least be the keyAfter of the last key;
2. Fix NativeAPI doesn't set `RangeResult.more` in a few places;
3. Avoid `tryGetRange()` setting `readThrough` when `more` is false, which was a workaround for the above item 2;
4. `tryGetRangeFromBlob()` doesn't set `more` but set `readThrough` to indicate it is end, which was following the same above workaround I think. Fixed that.
5. `getRangeStream()` is going to set `more` to true and then let the `readThrough` be it's boundary.

Also added readThrough getter/setter function to validate it's usage.

Replace this text with your description here...

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
