### PR TITLE
(snowflake/release-71.3) Add `GLOBAL_TAG_THROTTLING_REPORT_ONLY` knob

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -794,6 +794,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( GLOBAL_TAG_THROTTLING_PROXY_LOGGING_INTERVAL,         60.0 );
 	init( GLOBAL_TAG_THROTTLING_MIN_TPS,                         1.0 );
 	init( GLOBAL_TAG_THROTTLING_TRACE_INTERVAL,                  5.0 );
+	init( GLOBAL_TAG_THROTTLING_REPORT_ONLY,                   false );
 
 	//Storage Metrics
 	init( STORAGE_METRICS_AVERAGE_INTERVAL,                    120.0 );

--- a/fdbclient/include/fdbclient/ServerKnobs.h
+++ b/fdbclient/include/fdbclient/ServerKnobs.h
@@ -716,6 +716,10 @@ public:
 	double GLOBAL_TAG_THROTTLING_MIN_TPS;
 	// Interval at which ratekeeper logs statistics for each tag:
 	double GLOBAL_TAG_THROTTLING_TRACE_INTERVAL;
+	// If this knob is set to true, the global tag throttler will still
+	// compute rates, but these rates won't be sent to GRV proxies for
+	// enforcement.
+	bool GLOBAL_TAG_THROTTLING_REPORT_ONLY;
 
 	double MAX_TRANSACTIONS_PER_BYTE;
 

--- a/fdbserver/Ratekeeper.actor.cpp
+++ b/fdbserver/Ratekeeper.actor.cpp
@@ -520,13 +520,17 @@ public:
 
 						bool returningTagsToProxy{ false };
 						if (SERVER_KNOBS->ENFORCE_TAG_THROTTLING_ON_PROXIES) {
-							reply.proxyThrottledTags = self.tagThrottler->getProxyRates(self.grvProxyInfo.size());
-							returningTagsToProxy =
-							    reply.proxyThrottledTags.present() && reply.proxyThrottledTags.get().size() > 0;
+							auto proxyThrottledTags = self.tagThrottler->getProxyRates(self.grvProxyInfo.size());
+							if (!SERVER_KNOBS->GLOBAL_TAG_THROTTLING_REPORT_ONLY) {
+								returningTagsToProxy = proxyThrottledTags.size() > 0;
+								reply.proxyThrottledTags = std::move(proxyThrottledTags);
+							}
 						} else {
-							reply.clientThrottledTags = self.tagThrottler->getClientRates();
-							returningTagsToProxy =
-							    reply.clientThrottledTags.present() && reply.clientThrottledTags.get().size() > 0;
+							auto clientThrottledTags = self.tagThrottler->getClientRates();
+							if (!SERVER_KNOBS->GLOBAL_TAG_THROTTLING_REPORT_ONLY) {
+								returningTagsToProxy = clientThrottledTags.size() > 0;
+								reply.clientThrottledTags = std::move(clientThrottledTags);
+							}
 						}
 						CODE_PROBE(returningTagsToProxy, "Returning tag throttles to a proxy");
 					}


### PR DESCRIPTION
This is a backport of https://github.com/apple/foundationdb/pull/10005.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
