### PR TITLE
Properly handle proxy_memory_limit_exceeded error for GetKeyServerLocationsRequest [release-7.1]

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,4 @@
+# clang-format the entire codebase
+df90cc89de67ea4748c8cadd18e6fc4ce7fda12e
+2c788c233db56ccec4ed90d7da31887487b9f3b7
+69508b980f3cc5aabea6322f292e53b07bb27544

--- a/fdbclient/DatabaseContext.h
+++ b/fdbclient/DatabaseContext.h
@@ -656,8 +656,8 @@ public:
 	std::unique_ptr<GlobalConfig> globalConfig;
 	EventCacheHolder connectToDatabaseEventCacheHolder;
 
-	// Gets a database level backoff delay time in seconds.
-	double getBackoff() { return backoffDelay; }
+	// Gets a database level backoff delay future, time in seconds.
+	Future<Void> getBackoff() const { return backoffDelay > 0.0 ? delay(backoffDelay) : Future<Void>(Void()); }
 
 	// Updates internal Backoff state when a request fails or succeeds.
 	// E.g., commit_proxy_memory_limit_exceeded error means the database is overloaded

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -3024,56 +3024,66 @@ ACTOR Future<std::vector<KeyRangeLocationInfo>> getKeyRangeLocations_internal(
 	if (debugID.present())
 		g_traceBatch.addEvent("TransactionDebug", debugID.get().first(), "NativeAPI.getKeyLocations.Before");
 
-	try {
-		loop {
-			++cx->transactionKeyServerLocationRequests;
-			choose {
-				when(wait(cx->onProxiesChanged())) {}
-				when(GetKeyServerLocationsReply _rep =
-				         wait(basicLoadBalance(cx->getCommitProxies(useProvisionalProxies),
-				                               &CommitProxyInterface::getKeyServersLocations,
-				                               GetKeyServerLocationsRequest(span.context,
-				                                                            tenant.castTo<TenantNameRef>(),
-				                                                            keys.begin,
-				                                                            keys.end,
-				                                                            limit,
-				                                                            reverse,
-				                                                            version,
-				                                                            keys.arena()),
-				                               TaskPriority::DefaultPromiseEndpoint))) {
-					++cx->transactionKeyServerLocationRequestsCompleted;
-					state GetKeyServerLocationsReply rep = _rep;
-					if (debugID.present())
-						g_traceBatch.addEvent(
-						    "TransactionDebug", debugID.get().first(), "NativeAPI.getKeyLocations.After");
-					ASSERT(rep.results.size());
-
-					state std::vector<KeyRangeLocationInfo> results;
-					state int shard = 0;
-					for (; shard < rep.results.size(); shard++) {
-						// FIXME: these shards are being inserted into the map sequentially, it would be much more CPU
-						// efficient to save the map pairs and insert them all at once.
-						results.emplace_back(
-						    rep.tenantEntry,
-						    (toRelativeRange(rep.results[shard].first, rep.tenantEntry.prefix) & keys),
-						    cx->setCachedLocation(
-						        tenant, rep.tenantEntry, rep.results[shard].first, rep.results[shard].second));
-						wait(yield());
+	state Transaction tr(cx); // Only used for exponential backoff
+	loop {
+		try {
+			loop {
+				++cx->transactionKeyServerLocationRequests;
+				choose {
+					when(wait(cx->onProxiesChanged())) {
+						tr.reset();
 					}
-					updateTssMappings(cx, rep);
-					updateTagMappings(cx, rep);
+					when(GetKeyServerLocationsReply _rep =
+					         wait(basicLoadBalance(cx->getCommitProxies(useProvisionalProxies),
+					                               &CommitProxyInterface::getKeyServersLocations,
+					                               GetKeyServerLocationsRequest(span.context,
+					                                                            tenant.castTo<TenantNameRef>(),
+					                                                            keys.begin,
+					                                                            keys.end,
+					                                                            limit,
+					                                                            reverse,
+					                                                            version,
+					                                                            keys.arena()),
+					                               TaskPriority::DefaultPromiseEndpoint))) {
+						++cx->transactionKeyServerLocationRequestsCompleted;
+						state GetKeyServerLocationsReply rep = _rep;
+						if (debugID.present())
+							g_traceBatch.addEvent(
+							    "TransactionDebug", debugID.get().first(), "NativeAPI.getKeyLocations.After");
+						ASSERT(rep.results.size());
 
-					return results;
+						state std::vector<KeyRangeLocationInfo> results;
+						state int shard = 0;
+						for (; shard < rep.results.size(); shard++) {
+							// FIXME: these shards are being inserted into the map sequentially, it would be much more
+							// CPU efficient to save the map pairs and insert them all at once.
+							results.emplace_back(
+							    rep.tenantEntry,
+							    (toRelativeRange(rep.results[shard].first, rep.tenantEntry.prefix) & keys),
+							    cx->setCachedLocation(
+							        tenant, rep.tenantEntry, rep.results[shard].first, rep.results[shard].second));
+							wait(yield());
+						}
+						updateTssMappings(cx, rep);
+						updateTagMappings(cx, rep);
+
+						return results;
+					}
 				}
 			}
-		}
-	} catch (Error& e) {
-		if (e.code() == error_code_tenant_not_found) {
-			ASSERT(tenant.present());
-			cx->invalidateCachedTenant(tenant.get());
-		}
+		} catch (Error& e) {
+			if (e.code() == error_code_proxy_memory_limit_exceeded) {
+				// Eats proxy_memory_limit_exceeded error from commit proxies
+				delay(tr.getBackoff(e.code()));
+				continue;
+			}
+			if (e.code() == error_code_tenant_not_found) {
+				ASSERT(tenant.present());
+				cx->invalidateCachedTenant(tenant.get());
+			}
 
-		throw;
+			throw;
+		}
 	}
 }
 

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -3063,24 +3063,24 @@ ACTOR Future<std::vector<KeyRangeLocationInfo>> getKeyRangeLocations_internal(
 			wait(cx->getBackoff());
 			++cx->transactionKeyServerLocationRequests;
 			choose {
-				when(wait(cx->onProxiesChanged())) { }
+				when(wait(cx->onProxiesChanged())) {}
 				when(GetKeyServerLocationsReply _rep =
-							wait(basicLoadBalance(cx->getCommitProxies(useProvisionalProxies),
-												&CommitProxyInterface::getKeyServersLocations,
-												GetKeyServerLocationsRequest(span.context,
-																			tenant.castTo<TenantNameRef>(),
-																			keys.begin,
-																			keys.end,
-																			limit,
-																			reverse,
-																			version,
-																			keys.arena()),
-												TaskPriority::DefaultPromiseEndpoint))) {
+				         wait(basicLoadBalance(cx->getCommitProxies(useProvisionalProxies),
+				                               &CommitProxyInterface::getKeyServersLocations,
+				                               GetKeyServerLocationsRequest(span.context,
+				                                                            tenant.castTo<TenantNameRef>(),
+				                                                            keys.begin,
+				                                                            keys.end,
+				                                                            limit,
+				                                                            reverse,
+				                                                            version,
+				                                                            keys.arena()),
+				                               TaskPriority::DefaultPromiseEndpoint))) {
 					++cx->transactionKeyServerLocationRequestsCompleted;
 					state GetKeyServerLocationsReply rep = _rep;
 					if (debugID.present())
 						g_traceBatch.addEvent(
-							"TransactionDebug", debugID.get().first(), "NativeAPI.getKeyLocations.After");
+						    "TransactionDebug", debugID.get().first(), "NativeAPI.getKeyLocations.After");
 					ASSERT(rep.results.size());
 
 					state std::vector<KeyRangeLocationInfo> results;
@@ -3089,10 +3089,10 @@ ACTOR Future<std::vector<KeyRangeLocationInfo>> getKeyRangeLocations_internal(
 						// FIXME: these shards are being inserted into the map sequentially, it would be much more
 						// CPU efficient to save the map pairs and insert them all at once.
 						results.emplace_back(
-							rep.tenantEntry,
-							(toRelativeRange(rep.results[shard].first, rep.tenantEntry.prefix) & keys),
-							cx->setCachedLocation(
-								tenant, rep.tenantEntry, rep.results[shard].first, rep.results[shard].second));
+						    rep.tenantEntry,
+						    (toRelativeRange(rep.results[shard].first, rep.tenantEntry.prefix) & keys),
+						    cx->setCachedLocation(
+						        tenant, rep.tenantEntry, rep.results[shard].first, rep.results[shard].second));
 						wait(yield());
 					}
 					updateTssMappings(cx, rep);

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -47,6 +47,7 @@
 #include "fdbclient/DatabaseContext.h"
 #include "fdbclient/GlobalConfig.actor.h"
 #include "fdbclient/IKnobCollection.h"
+#include "fdbclient/Knobs.h"
 #include "fdbclient/JsonBuilder.h"
 #include "fdbclient/KeyBackedTypes.h"
 #include "fdbclient/KeyRangeMap.h"
@@ -1998,7 +1999,8 @@ void DatabaseContext::clearFailedEndpointOnHealthyServer(const Endpoint& endpoin
 	failedEndpointsOnHealthyServersInfo.erase(endpoint);
 }
 
-Future<Void> DatabaseContext::onProxiesChanged() const {
+Future<Void> DatabaseContext::onProxiesChanged() {
+	backoffDelay = 0.0;
 	return this->proxiesChangeTrigger.onTrigger();
 }
 
@@ -3010,6 +3012,26 @@ Future<KeyRangeLocationInfo> getKeyLocation(Reference<TransactionState> trState,
 	}
 }
 
+void DatabaseContext::updateBackoff(const Error& err) {
+	switch (err.code()) {
+	case error_code_success:
+		backoffDelay = 0.0;
+		break;
+
+	case error_code_commit_proxy_memory_limit_exceeded:
+		if (backoffDelay == 0.0) {
+			backoffDelay = CLIENT_KNOBS->DEFAULT_BACKOFF;
+		} else {
+			backoffDelay = std::min(backoffDelay * CLIENT_KNOBS->BACKOFF_GROWTH_RATE,
+			                        CLIENT_KNOBS->RESOURCE_CONSTRAINED_MAX_BACKOFF);
+		}
+		break;
+
+	default:
+		ASSERT_WE_THINK(false);
+	}
+}
+
 ACTOR Future<std::vector<KeyRangeLocationInfo>> getKeyRangeLocations_internal(
     Database cx,
     Optional<TenantName> tenant,
@@ -3024,57 +3046,57 @@ ACTOR Future<std::vector<KeyRangeLocationInfo>> getKeyRangeLocations_internal(
 	if (debugID.present())
 		g_traceBatch.addEvent("TransactionDebug", debugID.get().first(), "NativeAPI.getKeyLocations.Before");
 
-	state Transaction tr(cx); // Only used for exponential backoff
 	loop {
 		try {
-			loop {
-				++cx->transactionKeyServerLocationRequests;
-				choose {
-					when(wait(cx->onProxiesChanged())) {
-						tr.reset();
-					}
-					when(GetKeyServerLocationsReply _rep =
-					         wait(basicLoadBalance(cx->getCommitProxies(useProvisionalProxies),
-					                               &CommitProxyInterface::getKeyServersLocations,
-					                               GetKeyServerLocationsRequest(span.context,
-					                                                            tenant.castTo<TenantNameRef>(),
-					                                                            keys.begin,
-					                                                            keys.end,
-					                                                            limit,
-					                                                            reverse,
-					                                                            version,
-					                                                            keys.arena()),
-					                               TaskPriority::DefaultPromiseEndpoint))) {
-						++cx->transactionKeyServerLocationRequestsCompleted;
-						state GetKeyServerLocationsReply rep = _rep;
-						if (debugID.present())
-							g_traceBatch.addEvent(
-							    "TransactionDebug", debugID.get().first(), "NativeAPI.getKeyLocations.After");
-						ASSERT(rep.results.size());
+			double backoff = cx->getBackoff();
+			if (backoff > 0.0) {
+				wait(delay(backoff));
+			}
+			++cx->transactionKeyServerLocationRequests;
+			choose {
+				when(wait(cx->onProxiesChanged())) { }
+				when(GetKeyServerLocationsReply _rep =
+							wait(basicLoadBalance(cx->getCommitProxies(useProvisionalProxies),
+												&CommitProxyInterface::getKeyServersLocations,
+												GetKeyServerLocationsRequest(span.context,
+																			tenant.castTo<TenantNameRef>(),
+																			keys.begin,
+																			keys.end,
+																			limit,
+																			reverse,
+																			version,
+																			keys.arena()),
+												TaskPriority::DefaultPromiseEndpoint))) {
+					++cx->transactionKeyServerLocationRequestsCompleted;
+					state GetKeyServerLocationsReply rep = _rep;
+					if (debugID.present())
+						g_traceBatch.addEvent(
+							"TransactionDebug", debugID.get().first(), "NativeAPI.getKeyLocations.After");
+					ASSERT(rep.results.size());
 
-						state std::vector<KeyRangeLocationInfo> results;
-						state int shard = 0;
-						for (; shard < rep.results.size(); shard++) {
-							// FIXME: these shards are being inserted into the map sequentially, it would be much more
-							// CPU efficient to save the map pairs and insert them all at once.
-							results.emplace_back(
-							    rep.tenantEntry,
-							    (toRelativeRange(rep.results[shard].first, rep.tenantEntry.prefix) & keys),
-							    cx->setCachedLocation(
-							        tenant, rep.tenantEntry, rep.results[shard].first, rep.results[shard].second));
-							wait(yield());
-						}
-						updateTssMappings(cx, rep);
-						updateTagMappings(cx, rep);
-
-						return results;
+					state std::vector<KeyRangeLocationInfo> results;
+					state int shard = 0;
+					for (; shard < rep.results.size(); shard++) {
+						// FIXME: these shards are being inserted into the map sequentially, it would be much more
+						// CPU efficient to save the map pairs and insert them all at once.
+						results.emplace_back(
+							rep.tenantEntry,
+							(toRelativeRange(rep.results[shard].first, rep.tenantEntry.prefix) & keys),
+							cx->setCachedLocation(
+								tenant, rep.tenantEntry, rep.results[shard].first, rep.results[shard].second));
+						wait(yield());
 					}
+					updateTssMappings(cx, rep);
+					updateTagMappings(cx, rep);
+
+					cx->updateBackoff(success());
+					return results;
 				}
 			}
 		} catch (Error& e) {
 			if (e.code() == error_code_proxy_memory_limit_exceeded) {
 				// Eats proxy_memory_limit_exceeded error from commit proxies
-				delay(tr.getBackoff(e.code()));
+				cx->updateBackoff(e);
 				continue;
 			}
 			if (e.code() == error_code_tenant_not_found) {

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -2880,10 +2880,7 @@ ACTOR Future<KeyRangeLocationInfo> getKeyLocation_internal(Database cx,
 
 	loop {
 		try {
-			double backoff = cx->getBackoff();
-			if (backoff > 0.0) {
-				wait(delay(backoff));
-			}
+			wait(cx->getBackoff());
 			++cx->transactionKeyServerLocationRequests;
 			choose {
 				when(wait(cx->onProxiesChanged())) {}
@@ -3063,10 +3060,7 @@ ACTOR Future<std::vector<KeyRangeLocationInfo>> getKeyRangeLocations_internal(
 
 	loop {
 		try {
-			double backoff = cx->getBackoff();
-			if (backoff > 0.0) {
-				wait(delay(backoff));
-			}
+			wait(cx->getBackoff());
 			++cx->transactionKeyServerLocationRequests;
 			choose {
 				when(wait(cx->onProxiesChanged())) { }

--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -1805,8 +1805,9 @@ ACTOR static Future<Void> readRequestServer(CommitProxyInterface proxy,
 		GetKeyServerLocationsRequest req = waitNext(proxy.getKeyServersLocations.getFuture());
 		// WARNING: this code is run at a high priority, so it needs to do as little work as possible
 		if (req.limit != CLIENT_KNOBS->STORAGE_METRICS_SHARD_LIMIT && // Always do data distribution requests
-		    commitData->stats.keyServerLocationIn.getValue() - commitData->stats.keyServerLocationOut.getValue() >
-		        SERVER_KNOBS->KEY_LOCATION_MAX_QUEUE_SIZE) {
+		    (commitData->stats.keyServerLocationIn.getValue() - commitData->stats.keyServerLocationOut.getValue() >
+		         SERVER_KNOBS->KEY_LOCATION_MAX_QUEUE_SIZE ||
+		     (g_network->isSimulated() && BUGGIFY_WITH_PROB(0.001)))) {
 			++commitData->stats.keyServerLocationErrors;
 			req.reply.sendError(proxy_memory_limit_exceeded());
 			TraceEvent(SevWarnAlways, "ProxyLocationRequestThresholdExceeded").suppressFor(60);

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -5787,6 +5787,21 @@ ACTOR Future<std::unordered_map<Key, Version>> dispatchChangeFeeds(StorageServer
 	}
 }
 
+bool fetchKeyCanRetry(const Error& e) {
+	switch (e.code()) {
+	case error_code_end_of_stream:
+	case error_code_connection_failed:
+	case error_code_transaction_too_old:
+	case error_code_future_version:
+	case error_code_process_behind:
+	case error_code_server_overloaded:
+	case error_code_proxy_memory_limit_exceeded:
+		return true;
+	default:
+		return false;
+	}
+}
+
 ACTOR Future<Void> fetchKeys(StorageServer* data, AddingShard* shard) {
 	state const UID fetchKeysID = deterministicRandom()->randomUniqueID();
 	state TraceInterval interval("FetchKeys");
@@ -5995,10 +6010,7 @@ ACTOR Future<Void> fetchKeys(StorageServer* data, AddingShard* shard) {
 					}
 				}
 			} catch (Error& e) {
-				if (e.code() != error_code_end_of_stream && e.code() != error_code_connection_failed &&
-				    e.code() != error_code_transaction_too_old && e.code() != error_code_future_version &&
-				    e.code() != error_code_process_behind && e.code() != error_code_server_overloaded &&
-				    e.code() != error_code_proxy_memory_limit_exceeded) {
+				if (!fetchKeyCanRetry(e)) {
 					throw;
 				}
 				lastError = e;

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -5997,7 +5997,8 @@ ACTOR Future<Void> fetchKeys(StorageServer* data, AddingShard* shard) {
 			} catch (Error& e) {
 				if (e.code() != error_code_end_of_stream && e.code() != error_code_connection_failed &&
 				    e.code() != error_code_transaction_too_old && e.code() != error_code_future_version &&
-				    e.code() != error_code_process_behind && e.code() != error_code_server_overloaded) {
+				    e.code() != error_code_process_behind && e.code() != error_code_server_overloaded &&
+				    e.code() != error_code_proxy_memory_limit_exceeded) {
 					throw;
 				}
 				lastError = e;


### PR DESCRIPTION
cherrypick #10010

When a commit proxy becomes overloaded, it will send back commit_proxy_memory_limit_exceeded error. This error is often not caught, e.g., in storage server's fetch key operation. We've seen StorageServerFailed in live clusters due to this problem. The proposed solution is to catch this error and automatically retry the request with backoffs, which is a per database backoff, instead of the normal per transaction backoff. The current thinking is that once the database is overloaded, we should avoid sending too many GetKeyServerLocationsRequest to commit proxies.

Also added buggify to inject the error in simulation.

The backoff logic is at the database level: for each error, double the backoff time (starting at 0.01s); for each success, half the backoff time (when less than 0.01s, set to 0).

20230424-222653-jzhou-4a8d6c9bccde6070

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
