### PR TITLE
Properly handle proxy_memory_limit_exceeded error for GetKeyServerLocationsRequest

### DIFF
--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -2998,10 +2998,7 @@ ACTOR Future<KeyRangeLocationInfo> getKeyLocation_internal(Database cx,
 
 	loop {
 		try {
-			double backoff = cx->getBackoff();
-			if (backoff > 0.0) {
-				wait(delay(backoff));
-			}
+			wait(cx->getBackoff());
 			++cx->transactionKeyServerLocationRequests;
 			choose {
 				when(wait(cx->onProxiesChanged())) {}
@@ -3162,10 +3159,7 @@ ACTOR Future<std::vector<KeyRangeLocationInfo>> getKeyRangeLocations_internal(
 
 	loop {
 		try {
-			double backoff = cx->getBackoff();
-			if (backoff > 0.0) {
-				wait(delay(backoff));
-			}
+			wait(cx->getBackoff());
 			++cx->transactionKeyServerLocationRequests;
 			choose {
 				when(wait(cx->onProxiesChanged())) {}
@@ -3451,10 +3445,7 @@ SpanContext generateSpanID(bool transactionTracingSample, SpanContext parentCont
 ACTOR Future<int64_t> lookupTenantImpl(DatabaseContext* cx, TenantName tenant) {
 	loop {
 		try {
-			double backoff = cx->getBackoff();
-			if (backoff > 0.0) {
-				wait(delay(backoff));
-			}
+			wait(cx->getBackoff());
 
 			++cx->transactionTenantLookupRequests;
 			choose {

--- a/fdbclient/include/fdbclient/DatabaseContext.h
+++ b/fdbclient/include/fdbclient/DatabaseContext.h
@@ -763,8 +763,8 @@ public:
 	// { "InitializationError" : <error code> }
 	Standalone<StringRef> getClientStatus();
 
-	// Gets a database level backoff delay time in seconds.
-	double getBackoff() { return backoffDelay; }
+	// Gets a database level backoff delay future, time in seconds.
+	Future<Void> getBackoff() const { return backoffDelay > 0.0 ? delay(backoffDelay) : Future<Void>(Void()); }
 
 	// Updates internal Backoff state when a request fails or succeeds.
 	// E.g., commit_proxy_memory_limit_exceeded error means the database is overloaded

--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -2632,7 +2632,8 @@ ACTOR static Future<Void> tenantIdServer(CommitProxyInterface proxy,
 		GetTenantIdRequest req = waitNext(proxy.getTenantId.getFuture());
 		// WARNING: this code is run at a high priority, so it needs to do as little work as possible
 		if (commitData->stats.tenantIdRequestIn.getValue() - commitData->stats.tenantIdRequestOut.getValue() >
-		    SERVER_KNOBS->TENANT_ID_REQUEST_MAX_QUEUE_SIZE) {
+		        SERVER_KNOBS->TENANT_ID_REQUEST_MAX_QUEUE_SIZE ||
+		    (g_network->isSimulated() && !g_simulator->speedUpSimulation && BUGGIFY_WITH_PROB(0.0001))) {
 			++commitData->stats.tenantIdRequestErrors;
 			req.reply.sendError(commit_proxy_memory_limit_exceeded());
 			TraceEvent(SevWarnAlways, "ProxyGetTenantRequestThresholdExceeded").suppressFor(60);

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -7383,6 +7383,23 @@ ACTOR Future<std::unordered_map<Key, Version>> dispatchChangeFeeds(StorageServer
 	}
 }
 
+bool fetchKeyCanRetry(const Error& e) {
+	switch (e.code()) {
+	case error_code_end_of_stream:
+	case error_code_connection_failed:
+	case error_code_transaction_too_old:
+	case error_code_future_version:
+	case error_code_process_behind:
+	case error_code_server_overloaded:
+	case error_code_blob_granule_request_failed:
+	case error_code_blob_granule_transaction_too_old:
+	case error_code_commit_proxy_memory_limit_exceeded:
+		return true;
+	default:
+		return false;
+	}
+}
+
 ACTOR Future<Void> fetchKeys(StorageServer* data, AddingShard* shard) {
 	state const UID fetchKeysID = deterministicRandom()->randomUniqueID();
 	state TraceInterval interval("FetchKeys");
@@ -7624,11 +7641,7 @@ ACTOR Future<Void> fetchKeys(StorageServer* data, AddingShard* shard) {
 					data->fetchKeysBudgetUsed.set(data->fetchKeysBytesBudget <= 0);
 				}
 			} catch (Error& e) {
-				if (e.code() != error_code_end_of_stream && e.code() != error_code_connection_failed &&
-				    e.code() != error_code_transaction_too_old && e.code() != error_code_future_version &&
-				    e.code() != error_code_process_behind && e.code() != error_code_server_overloaded &&
-				    e.code() != error_code_blob_granule_request_failed &&
-				    e.code() != error_code_blob_granule_transaction_too_old) {
+				if (!fetchKeyCanRetry(e)) {
 					throw;
 				}
 				lastError = e;

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -7393,6 +7393,7 @@ bool fetchKeyCanRetry(const Error& e) {
 	case error_code_server_overloaded:
 	case error_code_blob_granule_request_failed:
 	case error_code_blob_granule_transaction_too_old:
+	case error_code_grv_proxy_memory_limit_exceeded:
 	case error_code_commit_proxy_memory_limit_exceeded:
 		return true;
 	default:


### PR DESCRIPTION
When a commit proxy becomes overloaded, it will send back `commit_proxy_memory_limit_exceeded` error. This error is often not caught, e.g., in storage server's fetch key operation. We've seen `StorageServerFailed` in live clusters due to this problem. The proposed solution is to catch this error and automatically retry the request with backoffs, which is a per database backoff, instead of the normal per transaction backoff. The current thinking is that once the database is overloaded, we should avoid sending too many `GetKeyServerLocationsRequest` to commit proxies.

Also added buggify to inject the error in simulation for `GetTenantIdRequest` as well and fixed some issues found.

The backoff logic is at the database level: for each error, double the backoff time (starting at 0.01s); for each success, half the backoff time (when less than 0.01s, set to 0).

20230419-171234-jzhou-26ff208cd554c752

20230419-210237-jzhou-1c2d569def93bf45

20230419-214039-jzhou-8a553ad4e6a6c3b2

20230420-000516-jzhou-25c3ebf1e8ac5255

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
