### PR TITLE
Propagate Encryption Errors Properly

### DIFF
--- a/fdbclient/BackupAgentBase.actor.cpp
+++ b/fdbclient/BackupAgentBase.actor.cpp
@@ -387,7 +387,8 @@ ACTOR static Future<Void> decodeBackupLogValue(Arena* arena,
 					TraceEvent(SevWarnAlways, "MutationLogRestoreEncryptKeyFetchFailed")
 					    .detail("Version", version)
 					    .detail("TenantId", domainId);
-					if (e.code() == error_code_encrypt_keys_fetch_failed) {
+					if (e.code() == error_code_encrypt_keys_fetch_failed ||
+					    e.code() == error_code_encrypt_key_not_found) {
 						CODE_PROBE(true, "mutation log restore encrypt keys not found");
 						consumed += BackupAgentBase::logHeaderSize + len1 + len2;
 						continue;

--- a/fdbclient/FileBackupAgent.actor.cpp
+++ b/fdbclient/FileBackupAgent.actor.cpp
@@ -1296,7 +1296,7 @@ ACTOR Future<Standalone<VectorRef<KeyValueRef>>> decodeRangeFileBlock(Reference<
 		}
 		return results;
 	} catch (Error& e) {
-		if (e.code() == error_code_encrypt_keys_fetch_failed) {
+		if (e.code() == error_code_encrypt_keys_fetch_failed || e.code() == error_code_encrypt_key_not_found) {
 			ASSERT(!isReservedEncryptDomain(blockDomainId));
 			TraceEvent(SevWarnAlways, "SnapshotRestoreEncryptKeyFetchFailed").detail("TenantId", blockDomainId);
 			CODE_PROBE(true, "Snapshot restore encrypt keys not found");
@@ -3765,7 +3765,8 @@ struct RestoreRangeTaskFunc : RestoreFileTaskFuncBase {
 			blockData = data;
 		} catch (Error& e) {
 			// It's possible a tenant was deleted and the encrypt key fetch failed
-			if (e.code() == error_code_encrypt_keys_fetch_failed || e.code() == error_code_tenant_not_found) {
+			if (e.code() == error_code_encrypt_keys_fetch_failed || e.code() == error_code_tenant_not_found ||
+			    e.code() == error_code_encrypt_key_not_found) {
 				return Void();
 			}
 			throw;

--- a/fdbclient/include/fdbclient/GetEncryptCipherKeys_impl.actor.h
+++ b/fdbclient/include/fdbclient/GetEncryptCipherKeys_impl.actor.h
@@ -83,7 +83,7 @@ Future<EKPGetLatestBaseCipherKeysReply> _getUncachedLatestEncryptCipherKeys(Refe
 		EKPGetLatestBaseCipherKeysReply reply = wait(proxy.get().getLatestBaseCipherKeys.getReply(request));
 		if (reply.error.present()) {
 			TraceEvent(SevWarn, "GetLatestEncryptCipherKeysRequestFailed").error(reply.error.get());
-			throw encrypt_keys_fetch_failed();
+			throw reply.error.get();
 		}
 		return reply;
 	} catch (Error& e) {
@@ -186,8 +186,10 @@ Future<EKPGetBaseCipherKeysByIdsReply> _getUncachedEncryptCipherKeys(Reference<A
 		EKPGetBaseCipherKeysByIdsReply reply = wait(proxy.get().getBaseCipherKeysByIds.getReply(request));
 		if (reply.error.present()) {
 			TraceEvent(SevWarn, "GetEncryptCipherKeysRequestFailed").error(reply.error.get());
-			throw encrypt_keys_fetch_failed();
+			throw reply.error.get();
 		}
+		// The code below is used only during simulation to test backup/restore ability to handle encryption keys
+		// not being found for deleted tenants
 		if (g_network && g_network->isSimulated() && usageType == BlobCipherMetrics::RESTORE) {
 			std::unordered_set<int64_t> tenantIdsToDrop =
 			    parseStringToUnorderedSet<int64_t>(CLIENT_KNOBS->SIMULATION_EKP_TENANT_IDS_TO_DROP, ',');
@@ -195,7 +197,11 @@ Future<EKPGetBaseCipherKeysByIdsReply> _getUncachedEncryptCipherKeys(Reference<A
 				for (auto& baseCipherInfo : request.baseCipherInfos) {
 					if (tenantIdsToDrop.count(baseCipherInfo.domainId)) {
 						TraceEvent("GetEncryptCipherKeysSimulatedError").detail("DomainId", baseCipherInfo.domainId);
-						throw encrypt_keys_fetch_failed();
+						if (deterministicRandom()->coinflip()) {
+							throw encrypt_keys_fetch_failed();
+						} else {
+							throw encrypt_key_not_found();
+						}
 					}
 				}
 			}

--- a/fdbserver/workloads/EncryptKeyProxyTest.actor.cpp
+++ b/fdbserver/workloads/EncryptKeyProxyTest.actor.cpp
@@ -192,7 +192,7 @@ struct EncryptKeyProxyTestWorkload : TestWorkload {
 			// BlobCipherKeyCache is 'empty'; fetching invalid cipher from KMS must through 'encrypt_key_not_found'
 			ASSERT(false);
 		} catch (Error& e) {
-			ASSERT(e.code() == error_code_encrypt_keys_fetch_failed);
+			ASSERT(e.code() == error_code_encrypt_key_not_found);
 		}
 
 		TraceEvent("SimLookupInvalidKeyIdDone");


### PR DESCRIPTION
Currently any errors thrown by the EKP are converted to `encrypt_keys_fetch_failed`. This is incorrect and we should propagate the correct errors to the clients

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
