### PR TITLE
Log the relocation decision at the time of launching relocations (Cherry-Pick #9991 to snowflake/release-71.3)

### DIFF
--- a/fdbserver/DDRelocationQueue.actor.cpp
+++ b/fdbserver/DDRelocationQueue.actor.cpp
@@ -129,7 +129,8 @@ RelocateData::RelocateData()
     interval("QueuedRelocation"){};
 
 RelocateData::RelocateData(RelocateShard const& rs)
-  : keys(rs.keys), priority(rs.priority), boundaryPriority(isBoundaryPriority(rs.priority) ? rs.priority : -1),
+  : parent_range(rs.getParentRange()), keys(rs.keys), priority(rs.priority),
+    boundaryPriority(isBoundaryPriority(rs.priority) ? rs.priority : -1),
     healthPriority(isHealthPriority(rs.priority) ? rs.priority : -1), reason(rs.reason), startTime(now()),
     randomId(rs.traceId.isValid() ? rs.traceId : deterministicRandom()->randomUniqueID()), dataMoveId(rs.dataMoveId),
     workFactor(0),
@@ -160,6 +161,9 @@ bool RelocateData::operator==(const RelocateData& rhs) const {
 }
 bool RelocateData::operator!=(const RelocateData& rhs) const {
 	return !(*this == rhs);
+}
+Optional<KeyRange> RelocateData::getParentRange() const {
+	return parent_range;
 }
 
 class ParallelTCInfo final : public ReferenceCounted<ParallelTCInfo>, public IDataDistributionTeam {
@@ -1163,6 +1167,29 @@ static std::string destServersString(std::vector<std::pair<Reference<IDataDistri
 	return std::move(ss).str();
 }
 
+void traceRelocateDecision(TraceEvent& ev,
+                           const RelocateData& rd,
+                           const UID& pairId,
+                           const std::vector<UID>& destIds,
+                           const std::vector<UID>& extraIds,
+                           const StorageMetrics& metrics) {
+	ev.detail("PairId", pairId)
+	    .detail("Priority", rd.priority)
+	    .detail("KeyBegin", rd.keys.begin)
+	    .detail("KeyEnd", rd.keys.end)
+	    .detail("Reason", rd.reason.toString())
+	    .detail("SourceServers", describe(rd.src))
+	    .detail("DestinationTeam", describe(destIds))
+	    .detail("ExtraIds", describe(extraIds));
+	if (SERVER_KNOBS->DD_ENABLE_VERBOSE_TRACING) {
+		// StorageMetrics is the rd shard's metrics, e.g., bytes and write bandwidth
+		ev.detail("StorageMetrics", metrics.toString());
+	}
+	// tell if the splitter acted as expected for write bandwidth splitting
+	if (rd.reason == RelocateReason::WRITE_SPLIT) {
+		ev.detail("ShardWriteBytes", metrics.bytesWrittenPerKSecond);
+	}
+}
 // This actor relocates the specified keys to a good place.
 // The inFlightActor key range map stores the actor for each RelocateData
 ACTOR Future<Void> dataDistributionRelocator(DDQueue* self,
@@ -1235,8 +1262,18 @@ ACTOR Future<Void> dataDistributionRelocator(DDQueue* self,
 			}
 		}
 
-		state StorageMetrics metrics =
-		    wait(brokenPromiseToNever(self->getShardMetrics.getReply(GetMetricsRequest(rd.keys))));
+		state Optional<StorageMetrics> parentMetrics;
+		state StorageMetrics metrics;
+
+		Future<StorageMetrics> metricsF =
+		    brokenPromiseToNever(self->getShardMetrics.getReply(GetMetricsRequest(rd.keys)));
+		if (rd.getParentRange().present()) {
+			Future<StorageMetrics> parentMetricsF =
+			    brokenPromiseToNever(self->getShardMetrics.getReply(GetMetricsRequest(rd.getParentRange().get())));
+			wait(store(metrics, metricsF) && store(parentMetrics, parentMetricsF));
+		} else {
+			wait(store(metrics, metricsF));
+		}
 
 		state std::unordered_set<uint64_t> excludedDstPhysicalShards;
 
@@ -1600,27 +1637,8 @@ ACTOR Future<Void> dataDistributionRelocator(DDQueue* self,
 
 			launchDest(rd, bestTeams, self->destBusymap);
 
-			if (SERVER_KNOBS->DD_ENABLE_VERBOSE_TRACING) {
-				// StorageMetrics is the rd shard's metrics, e.g., bytes and write bandwidth
-				TraceEvent(SevInfo, "RelocateShardDecision", distributorId)
-				    .detail("PairId", relocateShardInterval.pairID)
-				    .detail("Priority", rd.priority)
-				    .detail("KeyBegin", rd.keys.begin)
-				    .detail("KeyEnd", rd.keys.end)
-				    .detail("StorageMetrics", metrics.toString())
-				    .detail("SourceServers", describe(rd.src))
-				    .detail("DestinationTeam", describe(destIds))
-				    .detail("ExtraIds", describe(extraIds));
-			} else {
-				TraceEvent(relocateShardInterval.severity, "RelocateShardHasDestination", distributorId)
-				    .detail("PairId", relocateShardInterval.pairID)
-				    .detail("Priority", rd.priority)
-				    .detail("KeyBegin", rd.keys.begin)
-				    .detail("KeyEnd", rd.keys.end)
-				    .detail("SourceServers", describe(rd.src))
-				    .detail("DestinationTeam", describe(destIds))
-				    .detail("ExtraIds", describe(extraIds));
-			}
+			TraceEvent ev(relocateShardInterval.severity, "RelocateShardHasDestination", distributorId);
+			traceRelocateDecision(ev, rd, relocateShardInterval.pairID, destIds, extraIds, metrics);
 
 			self->serverCounter.increaseForTeam(rd.src, rd.reason, DDQueue::ServerCounter::LaunchedSource);
 			self->serverCounter.increaseForTeam(destIds, rd.reason, DDQueue::ServerCounter::LaunchedDest);

--- a/fdbserver/DDRelocationQueue.actor.cpp
+++ b/fdbserver/DDRelocationQueue.actor.cpp
@@ -1180,11 +1180,14 @@ void traceRelocateDecision(TraceEvent& ev, const UID& pairId, const RelocateDeci
 		// StorageMetrics is the rd shard's metrics, e.g., bytes and write bandwidth
 		ev.detail("StorageMetrics", decision.metrics.toString());
 	}
-	// tell if the splitter acted as expected for write bandwidth splitting
+
 	if (decision.rd.reason == RelocateReason::WRITE_SPLIT) {
+		// tell if the splitter acted as expected for write bandwidth splitting
 		// SOMEDAY: trace the source team write bytes if necessary
 		ev.detail("ShardWriteBytes", decision.metrics.bytesWrittenPerKSecond)
 		    .detail("ParentShardWriteBytes", decision.parentMetrics.get().bytesWrittenPerKSecond);
+	} else if (decision.rd.reason == RelocateReason::SIZE_SPLIT) {
+		ev.detail("ShardSize", decision.metrics.bytes).detail("ParentShardSize", decision.parentMetrics.get().bytes);
 	}
 }
 // This actor relocates the specified keys to a good place.

--- a/fdbserver/DDShardTracker.actor.cpp
+++ b/fdbserver/DDShardTracker.actor.cpp
@@ -457,14 +457,18 @@ void executeShardSplit(DataDistributionTracker* self,
 		KeyRangeRef r(splitKeys[i], splitKeys[i + 1]);
 		self->shardsAffectedByTeamFailure->defineShard(r);
 		if (relocate) {
-			self->output.send(RelocateShard(r, DataMovementReason::SPLIT_SHARD, reason));
+			RelocateShard rs(r, DataMovementReason::SPLIT_SHARD, reason);
+			rs.setParentRange(keys);
+			self->output.send(rs);
 		}
 	}
 	for (int i = numShards - 1; i > skipRange; i--) {
 		KeyRangeRef r(splitKeys[i], splitKeys[i + 1]);
 		self->shardsAffectedByTeamFailure->defineShard(r);
 		if (relocate) {
-			self->output.send(RelocateShard(r, DataMovementReason::SPLIT_SHARD, reason));
+			RelocateShard rs(r, DataMovementReason::SPLIT_SHARD, reason);
+			rs.setParentRange(keys);
+			self->output.send(rs);
 		}
 	}
 
@@ -1109,7 +1113,7 @@ ACTOR Future<Void> shardEvaluator(DataDistributionTracker* self,
 		onChange = onChange || shardMerger(self, keys, shardSize);
 	}
 	if (shouldSplit) {
-		RelocateReason reason = writeSplit ? RelocateReason::WRITE_SPLIT : RelocateReason::SIZE_SPLIT;
+		RelocateReason reason = sizeSplit ? RelocateReason::SIZE_SPLIT : RelocateReason::WRITE_SPLIT;
 		onChange = onChange || shardSplitter(self, keys, shardSize, shardBounds, reason);
 	}
 

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -55,6 +55,7 @@
 #include "flow/serialize.h"
 
 void RelocateShard::setParentRange(KeyRange const& parent) {
+	ASSERT(reason == RelocateReason::WRITE_SPLIT || reason == RelocateReason::SIZE_SPLIT);
 	parent_range = parent;
 }
 

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -54,6 +54,14 @@
 #include "flow/genericactors.actor.h"
 #include "flow/serialize.h"
 
+void RelocateShard::setParentRange(KeyRange const& parent) {
+	parent_range = parent;
+}
+
+Optional<KeyRange> RelocateShard::getParentRange() const {
+	return parent_range;
+}
+
 ShardSizeBounds ShardSizeBounds::shardSizeBoundsBeforeTrack() {
 	return ShardSizeBounds{
 		.max = StorageMetrics{ .bytes = -1,

--- a/fdbserver/include/fdbserver/DDRelocationQueue.h
+++ b/fdbserver/include/fdbserver/DDRelocationQueue.h
@@ -37,6 +37,9 @@ public:
 
 // DDQueue use RelocateData to track proposed movements
 class RelocateData {
+	// If this rs comes from a splitting, parent range is the original range.
+	Optional<KeyRange> parent_range;
+
 public:
 	KeyRange keys;
 	int priority;
@@ -73,6 +76,7 @@ public:
 	}
 
 	bool isRestore() const;
+	Optional<KeyRange> getParentRange() const;
 
 	bool operator>(const RelocateData& rhs) const;
 	bool operator==(const RelocateData& rhs) const;

--- a/fdbserver/include/fdbserver/DDRelocationQueue.h
+++ b/fdbserver/include/fdbserver/DDRelocationQueue.h
@@ -83,6 +83,14 @@ public:
 	bool operator!=(const RelocateData& rhs) const;
 };
 
+struct RelocateDecision {
+	const RelocateData& rd;
+	const std::vector<UID>& destIds;
+	const std::vector<UID>& extraIds;
+	const StorageMetrics& metrics;
+	const Optional<StorageMetrics>& parentMetrics;
+};
+
 // DDQueue uses Busyness to throttle too many movement to/from a same server
 struct Busyness {
 	std::vector<int> ledger;

--- a/fdbserver/include/fdbserver/DataDistribution.actor.h
+++ b/fdbserver/include/fdbserver/DataDistribution.actor.h
@@ -163,7 +163,13 @@ struct RelocateShard {
 
 	bool isRestore() const { return this->dataMove != nullptr; }
 
+	void setParentRange(KeyRange const& parent);
+	Optional<KeyRange> getParentRange() const;
+
 private:
+	// If this rs comes from a splitting, parent range is the original range.
+	Optional<KeyRange> parent_range;
+
 	RelocateShard()
 	  : priority(0), cancelled(false), dataMoveId(anonymousShardId), reason(RelocateReason::OTHER),
 	    moveReason(DataMovementReason::INVALID) {}

--- a/flow/include/flow/genericactors.actor.h
+++ b/flow/include/flow/genericactors.actor.h
@@ -328,8 +328,8 @@ Future<Void> holdWhileVoid(X object, Future<T> what) {
 }
 
 // Assign the future value of what to out
-template <class T>
-Future<Void> store(T& out, Future<T> what) {
+template <class T, class X>
+Future<Void> store(X& out, Future<T> what) {
 	return map(what, [&out](T const& v) {
 		out = v;
 		return Void();


### PR DESCRIPTION
Cherry-Pick of #9991

Original Description:

For write-bandwidth-based splits, we want to know whether the split decision is good by looking at the storage metrics of parent shard and splitted shard. Otherwise, it is hard to tell if the splitter acted as expected.

The next step might be to use the ongoing shard re-evaluation project to prevent unnecessary splitting movement.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
