### PR TITLE
Fixing path for non-backup (blob granule) blob url use cases to not p… (Cherry-Pick #10011 to snowflake/release-71.3)

### DIFF
--- a/fdbclient/BackupContainer.actor.cpp
+++ b/fdbclient/BackupContainer.actor.cpp
@@ -283,7 +283,7 @@ Reference<IBackupContainer> IBackupContainer::openContainer(const std::string& u
 			for (auto c : resource)
 				if (!isalnum(c) && c != '_' && c != '-' && c != '.' && c != '/')
 					throw backup_invalid_url();
-			r = makeReference<BackupContainerS3BlobStore>(bstore, resource, backupParams, encryptionKeyFileName);
+			r = makeReference<BackupContainerS3BlobStore>(bstore, resource, backupParams, encryptionKeyFileName, true);
 		}
 #ifdef BUILD_AZURE_BACKUP
 		else if (u.startsWith("azure://"_sr)) {
@@ -376,7 +376,7 @@ ACTOR Future<std::vector<std::string>> listContainers_impl(std::string baseURL, 
 			}
 
 			// Create a dummy container to parse the backup-specific parameters from the URL and get a final bucket name
-			BackupContainerS3BlobStore dummy(bstore, "dummy", backupParams, {});
+			BackupContainerS3BlobStore dummy(bstore, "dummy", backupParams, {}, true);
 
 			std::vector<std::string> results = wait(BackupContainerS3BlobStore::listURLs(bstore, dummy.getBucket()));
 			return results;

--- a/fdbclient/BackupContainerFileSystem.actor.cpp
+++ b/fdbclient/BackupContainerFileSystem.actor.cpp
@@ -1503,7 +1503,8 @@ Future<Void> BackupContainerFileSystem::createTestEncryptionKeyFile(std::string 
 Reference<BackupContainerFileSystem> BackupContainerFileSystem::openContainerFS(
     const std::string& url,
     const Optional<std::string>& proxy,
-    const Optional<std::string>& encryptionKeyFileName) {
+    const Optional<std::string>& encryptionKeyFileName,
+    bool isBackup) {
 	static std::map<std::string, Reference<BackupContainerFileSystem>> m_cache;
 
 	Reference<BackupContainerFileSystem>& r = m_cache[url];
@@ -1527,7 +1528,8 @@ Reference<BackupContainerFileSystem> BackupContainerFileSystem::openContainerFS(
 			for (auto c : resource)
 				if (!isalnum(c) && c != '_' && c != '-' && c != '.' && c != '/')
 					throw backup_invalid_url();
-			r = makeReference<BackupContainerS3BlobStore>(bstore, resource, backupParams, encryptionKeyFileName);
+			r = makeReference<BackupContainerS3BlobStore>(
+			    bstore, resource, backupParams, encryptionKeyFileName, isBackup);
 		}
 #ifdef BUILD_AZURE_BACKUP
 		else if (u.startsWith("azure://"_sr)) {

--- a/fdbclient/include/fdbclient/BackupContainerFileSystem.h
+++ b/fdbclient/include/fdbclient/BackupContainerFileSystem.h
@@ -81,7 +81,8 @@ public:
 	// TODO: refactor this to separate out the "deal with blob store" stuff from the backup business logic
 	static Reference<BackupContainerFileSystem> openContainerFS(const std::string& url,
 	                                                            const Optional<std::string>& proxy,
-	                                                            const Optional<std::string>& encryptionKeyFileName);
+	                                                            const Optional<std::string>& encryptionKeyFileName,
+	                                                            bool isBackup = true);
 
 	// Get a list of fileNames and their sizes in the container under the given path
 	// Although not required, an implementation can avoid traversing unwanted subfolders

--- a/fdbclient/include/fdbclient/BackupContainerS3BlobStore.h
+++ b/fdbclient/include/fdbclient/BackupContainerS3BlobStore.h
@@ -33,6 +33,9 @@ class BackupContainerS3BlobStore final : public BackupContainerFileSystem,
 	// All backup data goes into a single bucket
 	std::string m_bucket;
 
+	// if not used for backup, don't prefix paths with fdbbackup-specific logic
+	bool isBackup;
+
 	std::string dataPath(const std::string& path);
 
 	// Get the path of the backups's index entry
@@ -44,7 +47,8 @@ public:
 	BackupContainerS3BlobStore(Reference<S3BlobStoreEndpoint> bstore,
 	                           const std::string& name,
 	                           const S3BlobStoreEndpoint::ParametersT& params,
-	                           const Optional<std::string>& encryptionKeyFileName);
+	                           const Optional<std::string>& encryptionKeyFileName,
+	                           bool isBackup);
 
 	void addref() override;
 	void delref() override;


### PR DESCRIPTION
Cherry-Pick of #10011

Original Description:

…repend "/data/" to path and to not double-slash the resource if the user-provided one ends in a slash.
Also handles backwards compatibility to 71.2 such that existing clusters that configure a url instead of using BlobMetadata continue to use the old path and logic.

Passes:
10k correctness
20k BlobGranule* correctness
10k Backup* correctness
Non-simulation - passed /fdbserver/blob/connectionprovider unit test on s3

Validated manually that path worked with and without trailing slash in resource

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
