### PR TITLE
Fix gcc build warning (Cherry-Pick #9948 to snowflake/release-71.3)

### DIFF
--- a/fdbserver/include/fdbserver/DataDistributionTeam.h
+++ b/fdbserver/include/fdbserver/DataDistributionTeam.h
@@ -87,6 +87,7 @@ public:
 		case ANY:
 			return "Any";
 		}
+		return "";
 	}
 
 	bool operator==(const TeamSelect& tmpTeamSelect) { return value == tmpTeamSelect.value; }


### PR DESCRIPTION
Cherry-Pick of #9948

Original Description:

```
src237931343/src/github.com/apple/foundationdb/build_output/fdbserver/DDTeamCollection.actor.g.cpp
distcc[9528] ERROR: compile /codebuild/output/src237931343/src/github.com/apple/foundationdb/build_output/fdbserver/DDTeamCollection.actor.g.cpp on distcc-4ef89001724141db.elb.us-west-2.amazonaws.com/96 failed
In file included from /codebuild/output/src237931343/src/github.com/apple/foundationdb/fdbserver/include/fdbserver/TCInfo.h:26,
                 from /codebuild/output/src237931343/src/github.com/apple/foundationdb/fdbserver/include/fdbserver/TenantCache.h:26,
                 from /codebuild/output/src237931343/src/github.com/apple/foundationdb/fdbserver/include/fdbserver/DataDistribution.actor.h:29,
                 from /codebuild/output/src237931343/src/github.com/apple/foundationdb/fdbserver/include/fdbserver/DataDistribution.actor.h:23,
                 from /codebuild/output/src237931343/src/github.com/apple/foundationdb/fdbserver/include/fdbserver/DDTeamCollection.h:35,
                 from /codebuild/output/src237931343/src/github.com/apple/foundationdb/fdbserver/DDTeamCollection.actor.cpp:21:
/codebuild/output/src237931343/src/github.com/apple/foundationdb/fdbserver/include/fdbserver/DataDistributionTeam.h: In member function 'std::string TeamSelect::toString() const':
/codebuild/output/src237931343/src/github.com/apple/foundationdb/fdbserver/include/fdbserver/DataDistributionTeam.h:122:2: error: control reaches end of non-void function [-Werror=return-type]
cc1plus: all warnings being treated as errors
```
# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
