### PR TITLE
EaR: Remove unused CODE_PROBE handling encryption header flag version (#10020)

### DIFF
--- a/fdbclient/BlobCipher.cpp
+++ b/fdbclient/BlobCipher.cpp
@@ -1466,19 +1466,8 @@ void DecryptBlobCipherAes256Ctr::validateEncryptHeader(const uint8_t* ciphertext
                                                        const BlobCipherEncryptHeaderRef& headerRef,
                                                        EncryptAuthTokenMode* authTokenMode,
                                                        EncryptAuthTokenAlgo* authTokenAlgo) {
-	if (headerRef.flagsVersion() != 1) {
-		TraceEvent(SevWarn, "BlobCipherVerifyEncryptBlobHeader")
-		    .detail("HeaderVersion", headerRef.flagsVersion())
-		    .detail("MaxSupportedVersion", CLIENT_KNOBS->ENCRYPT_HEADER_FLAGS_VERSION);
-
-		CODE_PROBE(true, "ConfigurableEncryption: Encryption header version unsupported");
-
-		throw encrypt_header_metadata_mismatch();
-	}
-
-	if (headerRef.flagsVersion() != 1) {
-		throw not_implemented();
-	}
+	// FlagsVersion is computed based on std::variant available index
+	ASSERT_EQ(headerRef.flagsVersion(), 1);
 
 	BlobCipherEncryptHeaderFlagsV1 flags = std::get<BlobCipherEncryptHeaderFlagsV1>(headerRef.flags);
 	validateEncryptHeaderFlagsV1(headerRef.flagsVersion(), flags);


### PR DESCRIPTION
Description

Patch removes an unused CODE_PROBE checking the encryption header being read flag version is valid, given the flag-version is determined by peeking into std::variant index and we only have version-1 supported, for now converted the check to an ASSERT

Testing

EncryptionUnitTests.toml
EncryptionOps.toml
BlobGranuleCorrectness/Clean.toml

(cherry picked from commit a099d377fa212d23d420cf5a05d987d8e468c1e2)
Cherrypick PR #10020

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
