### PR TITLE
Update fdbcli tenant list function to take tenant group filter, support JSON, and report tenant IDs (Cherry-Pick #9967 to snowflake/release-71.3)

### DIFF
--- a/fdbcli/TenantCommands.actor.cpp
+++ b/fdbcli/TenantCommands.actor.cpp
@@ -93,16 +93,18 @@ bool parseTenantListOptions(std::vector<StringRef> const& tokens,
                             int startIndex,
                             int& limit,
                             int& offset,
-                            std::vector<metacluster::TenantState>& filters) {
+                            std::vector<metacluster::TenantState>& filters,
+                            Optional<TenantGroupName>& tenantGroup,
+                            bool& useJson) {
 	for (int tokenNum = startIndex; tokenNum < tokens.size(); ++tokenNum) {
 		Optional<Value> value;
 		StringRef token = tokens[tokenNum];
 		StringRef param;
 		bool foundEquals;
 		param = token.eat("=", &foundEquals);
-		if (!foundEquals) {
+		if (!foundEquals && !tokencmp(param, "JSON")) {
 			fmt::print(stderr,
-			           "ERROR: invalid option string `{}'. String must specify a value using `='.\n",
+			           "ERROR: invalid option string `{}'. String must specify a value using `=' or be `JSON'.\n",
 			           param.toString().c_str());
 			return false;
 		}
@@ -131,6 +133,10 @@ bool parseTenantListOptions(std::vector<StringRef> const& tokens,
 				fmt::print(stderr, "ERROR: unrecognized tenant state(s) `{}'.\n", value.get().toString());
 				return false;
 			}
+		} else if (tokencmp(param, "tenant_group")) {
+			tenantGroup = TenantGroupName(value.get().toString());
+		} else if (tokencmp(param, "JSON")) {
+			useJson = true;
 		} else {
 			fmt::print(stderr, "ERROR: unrecognized parameter `{}'.\n", param.toString().c_str());
 			return false;
@@ -324,16 +330,36 @@ ACTOR Future<bool> tenantDeleteIdCommand(Reference<IDatabase> db, std::vector<St
 	return true;
 }
 
+void tenantListOutputJson(std::map<TenantName, int64_t> tenants) {
+	json_spirit::mArray tenantsArr;
+	for (auto const& [tenantName, tenantId] : tenants) {
+		json_spirit::mObject tenantObj;
+		tenantObj["name"] = binaryToJson(tenantName);
+		tenantObj["id"] = tenantId;
+		tenantsArr.push_back(tenantObj);
+	}
+
+	json_spirit::mObject resultObj;
+	resultObj["tenants"] = tenantsArr;
+	resultObj["type"] = "success";
+
+	fmt::print("{}\n", json_spirit::write_string(json_spirit::mValue(resultObj), json_spirit::pretty_print).c_str());
+}
+
 // tenant list command
 ACTOR Future<bool> tenantListCommand(Reference<IDatabase> db, std::vector<StringRef> tokens) {
-	if (tokens.size() > 7) {
+	if (tokens.size() > 9) {
 		fmt::print(
-		    "Usage: tenant list [BEGIN] [END] [limit=<LIMIT>|offset=<OFFSET>|state=<STATE1>,<STATE2>,...] ...\n\n");
+		    "Usage: tenant list [BEGIN] [END] "
+		    "[limit=<LIMIT>|offset=<OFFSET>|state=<STATE1>,<STATE2>,...|tenant_group=<TENANT_GROUP>] [JSON] ...\n\n");
 		fmt::print("Lists the tenants in a cluster.\n");
 		fmt::print("Only tenants in the range BEGIN - END will be printed.\n");
 		fmt::print("An optional LIMIT can be specified to limit the number of results (default 100).\n");
 		fmt::print("Optionally skip over the first OFFSET results (default 0).\n");
 		fmt::print("Optional comma-separated tenant state(s) can be provided to filter the list.\n");
+		fmt::print("Optional tenant group can be provided to filter the list.\n");
+		fmt::print("If JSON is specified, then the output will be in JSON format.\n");
+		fmt::print("Specifying [offset] and [state] is only supported in a metacluster.\n");
 		return false;
 	}
 
@@ -342,6 +368,8 @@ ACTOR Future<bool> tenantListCommand(Reference<IDatabase> db, std::vector<String
 	state int limit = 100;
 	state int offset = 0;
 	state std::vector<metacluster::TenantState> filters;
+	state Optional<TenantGroupName> tenantGroup;
+	state bool useJson = false;
 
 	if (tokens.size() >= 3) {
 		beginTenant = tokens[2];
@@ -354,7 +382,7 @@ ACTOR Future<bool> tenantListCommand(Reference<IDatabase> db, std::vector<String
 		}
 	}
 	if (tokens.size() >= 5) {
-		if (!parseTenantListOptions(tokens, 4, limit, offset, filters)) {
+		if (!parseTenantListOptions(tokens, 4, limit, offset, filters, tenantGroup, useJson)) {
 			return false;
 		}
 	}
@@ -367,53 +395,87 @@ ACTOR Future<bool> tenantListCommand(Reference<IDatabase> db, std::vector<String
 		try {
 			tr->setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
 			state ClusterType clusterType = wait(TenantAPI::getClusterType(tr));
-			state std::vector<TenantName> tenantNames;
+			state std::map<TenantName, int64_t> tenantInfo;
+			// State filters only apply to calls from the management cluster
+			// Tenant group filters can apply to management, data, and standalone clusters
 			if (clusterType == ClusterType::METACLUSTER_MANAGEMENT) {
-				if (filters.empty()) {
-					std::vector<std::pair<TenantName, int64_t>> tenants =
-					    wait(metacluster::listTenants(db, beginTenant, endTenant, limit, offset));
-					for (auto tenant : tenants) {
-						tenantNames.push_back(tenant.first);
-					}
-				} else {
-					std::vector<std::pair<TenantName, metacluster::MetaclusterTenantMapEntry>> tenants =
-					    wait(metacluster::listTenantMetadata(db, beginTenant, endTenant, limit, offset, filters));
-					for (auto tenant : tenants) {
-						tenantNames.push_back(tenant.first);
-					}
+				std::vector<std::pair<TenantName, metacluster::MetaclusterTenantMapEntry>> tenants = wait(
+				    metacluster::listTenantMetadata(db, beginTenant, endTenant, limit, offset, filters, tenantGroup));
+				for (const auto& [tenantName, entry] : tenants) {
+					tenantInfo[tenantName] = entry.id;
 				}
 			} else {
-				// Hold the reference to the standalone's memory
-				state ThreadFuture<RangeResult> kvsFuture =
-				    tr->getRange(firstGreaterOrEqual(beginTenantKey), firstGreaterOrEqual(endTenantKey), limit);
-				RangeResult tenants = wait(safeThreadFutureToFuture(kvsFuture));
-				for (auto tenant : tenants) {
-					tenantNames.push_back(tenant.key.removePrefix(tenantMapSpecialKeyRange.begin));
-				}
-			}
-
-			if (tenantNames.empty()) {
-				if (tokens.size() == 2) {
-					fmt::print("The cluster has no tenants\n");
+				if (tenantGroup.present()) {
+					// For expediency: does not use special key space
+					// TODO: add special key support
+					std::vector<std::pair<TenantName, int64_t>> tenants =
+					    wait(TenantAPI::listTenantGroupTenants(db, tenantGroup.get(), beginTenant, endTenant, limit));
+					for (const auto& [tenantName, tenantId] : tenants) {
+						tenantInfo[tenantName] = tenantId;
+					}
 				} else {
-					fmt::print("The cluster has no tenants in the specified range\n");
+					// Hold the reference to the standalone's memory
+					state ThreadFuture<RangeResult> kvsFuture =
+					    tr->getRange(firstGreaterOrEqual(beginTenantKey), firstGreaterOrEqual(endTenantKey), limit);
+					RangeResult tenants = wait(safeThreadFutureToFuture(kvsFuture));
+					for (auto tenant : tenants) {
+						TenantName tName = tenant.key.removePrefix(tenantMapSpecialKeyRange.begin);
+						json_spirit::mValue jsonObject;
+						json_spirit::read_string(tenant.value.toString(), jsonObject);
+						JSONDoc jsonDoc(jsonObject);
+
+						int64_t tId;
+						jsonDoc.get("id", tId);
+						tenantInfo[tName] = tId;
+					}
 				}
 			}
 
-			int index = 0;
-			for (auto tenantName : tenantNames) {
-				fmt::print("  {}. {}\n", ++index, printable(tenantName).c_str());
+			if (useJson) {
+				tenantListOutputJson(tenantInfo);
+			} else {
+				if (tenantInfo.empty()) {
+					if (tokens.size() == 2) {
+						fmt::print("The cluster has no tenants\n");
+					} else {
+						fmt::print("The cluster has no tenants in the specified range\n");
+					}
+				}
+
+				int index = 0;
+				for (const auto& [tenantName, tenantId] : tenantInfo) {
+					fmt::print("  {}. {}\n", ++index, printable(tenantName).c_str());
+				}
 			}
 
 			return true;
 		} catch (Error& e) {
-			state Error err(e);
-			if (e.code() == error_code_special_keys_api_failure) {
-				std::string errorMsgStr = wait(getSpecialKeysFailureErrorMessage(tr));
-				fmt::print(stderr, "ERROR: {}\n", errorMsgStr.c_str());
+			try {
+				wait(safeThreadFutureToFuture(tr->onError(e)));
+			} catch (Error& finalErr) {
+				state std::string errorStr;
+				if (finalErr.code() == error_code_special_keys_api_failure) {
+					std::string str = wait(getSpecialKeysFailureErrorMessage(tr));
+					errorStr = str;
+				} else if (useJson) {
+					errorStr = finalErr.what();
+				} else {
+					throw finalErr;
+				}
+
+				if (useJson) {
+					json_spirit::mObject resultObj;
+					resultObj["type"] = "error";
+					resultObj["error"] = errorStr;
+					fmt::print(
+					    "{}\n",
+					    json_spirit::write_string(json_spirit::mValue(resultObj), json_spirit::pretty_print).c_str());
+				} else {
+					fmt::print(stderr, "ERROR: {}\n", errorStr.c_str());
+				}
+
 				return false;
 			}
-			wait(safeThreadFutureToFuture(tr->onError(err)));
 		}
 	}
 }
@@ -908,6 +970,9 @@ void tenantGenerator(const char* text,
 	} else if (tokens.size() == 3 && tokencmp(tokens[1], "getId")) {
 		const char* opts[] = { "JSON", nullptr };
 		arrayGenerator(text, line, opts, lc);
+	} else if (tokens.size() >= 4 && tokencmp(tokens[1], "list")) {
+		const char* opts[] = { "limit=", "offset=", "state=", "tenant_group=", "JSON", nullptr };
+		arrayGenerator(text, line, opts, lc);
 	} else if (tokencmp(tokens[1], "configure")) {
 		if (tokens.size() == 3) {
 			const char* opts[] = { "tenant_group=", "unset", nullptr };
@@ -942,9 +1007,13 @@ std::vector<const char*> tenantHintGenerator(std::vector<StringRef> const& token
 		static std::vector<const char*> opts = { "<ID>" };
 		return std::vector<const char*>(opts.begin() + tokens.size() - 2, opts.end());
 	} else if (tokencmp(tokens[1], "list") && tokens.size() < 7) {
-		static std::vector<const char*> opts = {
-			"[BEGIN]", "[END]", "[limit=LIMIT]", "[offset=OFFSET]", "[state=<STATE1>,<STATE2>,...]"
-		};
+		static std::vector<const char*> opts = { "[BEGIN]",
+			                                     "[END]",
+			                                     "[limit=LIMIT]",
+			                                     "[offset=OFFSET]",
+			                                     "[state=<STATE1>,<STATE2>,...]",
+			                                     "[tenant_group=TENANT_GROUP]",
+			                                     "[JSON]" };
 		return std::vector<const char*>(opts.begin() + tokens.size() - 2, opts.end());
 	} else if (tokencmp(tokens[1], "get") && tokens.size() < 4) {
 		static std::vector<const char*> opts = { "<NAME>", "[JSON]" };


### PR DESCRIPTION
Cherry-Pick of #9967

Original Description:

This provides the client a simpler way to filter tenants by their tenant groups, as well as adding some useful additional info (tenant IDs) that can be retrieved in bulk. 
Some sample output on a metacluster with the following tenant locations:

| Tenant | Cluster | Tenant Group |
|--------|---------|--------------|
| t1     | d1      | tg1          |
| t2     | d2      | tg2          |
| t3     | d1      | tg1          |
| t4     | d1      | tg1          |
| t5     | d2      | tg2          |
| t6     | d1      | tg3          |

On the management cluster:
```
fdb> tenant list a z
  1. t1
  2. t2
  3. t3
  4. t4
  5. t5
  6. t6
fdb> tenant list a z tenant_group=tg1
  1. t1
  2. t2
  3. t4
fdb> tenant list a z tenant_group=tg2
  1. t3
  2. t5
fdb> tenant list a z tenant_group=tg3
  1. t6
fdb> tenant list a z tenant_group=tg1 JSON
{
    "tenants" : [
        {
            "id" : 2251799813685249,
            "name" : {
                "base64" : "dDE=",
                "printable" : "t1"
            }
        },
        {
            "id" : 2251799813685250,
            "name" : {
                "base64" : "dDI=",
                "printable" : "t2"
            }
        },
        {
            "id" : 2251799813685252,
            "name" : {
                "base64" : "dDQ=",
                "printable" : "t4"
            }
        }
    ],
    "type" : "success"
}
```
On data cluster d1:
```
fdb> tenant list a z
  1. t1
  2. t2
  3. t4
  4. t6
fdb> tenant list a z tenant_group=tg1
  1. t1
  2. t2
  3. t4
fdb> tenant list a z tenant_group=tg2
The cluster has no tenants in the specified range
fdb> tenant list a z tenant_group=tg3
  1. t6
fdb> tenant list a z tenant_group=tg3 JSON
{
    "tenants" : [
        {
            "id" : 2251799813685254,
            "name" : {
                "base64" : "dDY=",
                "printable" : "t6"
            }
        }
    ],
    "type" : "success"
}
```

On data cluster d2:
```
fdb> tenant list a z
  1. t3
  2. t5
fdb> tenant list a z tenant_group=tg1
The cluster has no tenants in the specified range
fdb> tenant list a z tenant_group=tg2
  1. t3
  2. t5
fdb> tenant list a z tenant_group=tg3
The cluster has no tenants in the specified range
fdb> tenant list a z tenant_group=tg2 JSON
{
    "tenants" : [
        {
            "id" : 2251799813685251,
            "name" : {
                "base64" : "dDM=",
                "printable" : "t3"
            }
        },
        {
            "id" : 2251799813685253,
            "name" : {
                "base64" : "dDU=",
                "printable" : "t5"
            }
        }
    ],
    "type" : "success"
}
```
# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
