### PR TITLE
Revert error masking in #9913

### DIFF
--- a/fdbserver/include/fdbserver/WorkerInterface.actor.h
+++ b/fdbserver/include/fdbserver/WorkerInterface.actor.h
@@ -1330,10 +1330,10 @@ Future<T> ioTimeoutError(Future<T> what, double time, const char* context = null
 		}
 		when(wait(end)) {
 			Error err = io_timeout();
-			if (g_network->isSimulated()) {
+			if (!isSimulatorProcessReliable()) {
 				err = err.asInjectedFault();
 			}
-			TraceEvent e(g_network->isSimulated() ? SevWarn : SevError, "IoTimeoutError");
+			TraceEvent e(SevError, "IoTimeoutError");
 			e.error(err);
 			if (context != nullptr) {
 				e.detail("Context", context);


### PR DESCRIPTION
So that it wouldn't hide bugs where something in the disk queue or storage engine gets stuck but works after a reboot as the test wouldn't fail so the hang would not be exposed as an issue.

The issue for #9913 is solved by increasing TLOG_MAX_CREATE_DURATION in simulation, which is already done in commit 0aa096dc1.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
