### PR TITLE
Call debugTransaction() before retry (Cherry-Pick #10033 to snowflake/release-71.3)

### DIFF
--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -881,11 +881,11 @@ ACTOR Future<Void> testerServerCore(TesterInterface interf,
 
 ACTOR Future<Void> clearData(Database cx, Optional<TenantName> defaultTenant) {
 	state Transaction tr(cx);
-	tr.debugTransaction(debugRandom()->randomUniqueID());
-	ASSERT(tr.trState->readOptions.present() && tr.trState->readOptions.get().debugID.present());
 
 	loop {
 		try {
+			tr.debugTransaction(debugRandom()->randomUniqueID());
+			ASSERT(tr.trState->readOptions.present() && tr.trState->readOptions.get().debugID.present());
 			TraceEvent("TesterClearingDatabaseStart", tr.trState->readOptions.get().debugID.get()).log();
 			// This transaction needs to be self-conflicting, but not conflict consistently with
 			// any other transactions
@@ -900,16 +900,14 @@ ACTOR Future<Void> clearData(Database cx, Optional<TenantName> defaultTenant) {
 		} catch (Error& e) {
 			TraceEvent(SevWarn, "TesterClearingDatabaseError", tr.trState->readOptions.get().debugID.get()).error(e);
 			wait(tr.onError(e));
-			tr.debugTransaction(debugRandom()->randomUniqueID());
 		}
 	}
 
 	tr = Transaction(cx);
-	tr.debugTransaction(debugRandom()->randomUniqueID());
-	ASSERT(tr.trState->readOptions.present() && tr.trState->readOptions.get().debugID.present());
-
 	loop {
 		try {
+			tr.debugTransaction(debugRandom()->randomUniqueID());
+			ASSERT(tr.trState->readOptions.present() && tr.trState->readOptions.get().debugID.present());
 			TraceEvent("TesterClearingTenantsStart", tr.trState->readOptions.get().debugID.get());
 			state KeyBackedRangeResult<std::pair<int64_t, TenantMapEntry>> tenants =
 			    wait(TenantMetadata::tenantMap().getRange(&tr, {}, {}, 1000));
@@ -941,15 +939,13 @@ ACTOR Future<Void> clearData(Database cx, Optional<TenantName> defaultTenant) {
 		} catch (Error& e) {
 			TraceEvent(SevWarn, "TesterClearingTenantsError", tr.trState->readOptions.get().debugID.get()).error(e);
 			wait(tr.onError(e));
-			tr.debugTransaction(debugRandom()->randomUniqueID());
 		}
 	}
 
 	tr = Transaction(cx);
-	tr.debugTransaction(debugRandom()->randomUniqueID());
-	ASSERT(tr.trState->readOptions.present() && tr.trState->readOptions.get().debugID.present());
 	loop {
 		try {
+			tr.debugTransaction(debugRandom()->randomUniqueID());
 			tr.setOption(FDBTransactionOptions::RAW_ACCESS);
 			state RangeResult rangeResult = wait(tr.getRange(normalKeys, 1));
 			state Optional<Key> tenantPrefix;
@@ -975,13 +971,13 @@ ACTOR Future<Void> clearData(Database cx, Optional<TenantName> defaultTenant) {
 
 				ASSERT(false);
 			}
+			ASSERT(tr.trState->readOptions.present() && tr.trState->readOptions.get().debugID.present());
 			TraceEvent("TesterCheckDatabaseClearedDone", tr.trState->readOptions.get().debugID.get());
 			break;
 		} catch (Error& e) {
 			TraceEvent(SevWarn, "TesterCheckDatabaseClearedError", tr.trState->readOptions.get().debugID.get())
 			    .error(e);
 			wait(tr.onError(e));
-			tr.debugTransaction(debugRandom()->randomUniqueID());
 		}
 	}
 	return Void();


### PR DESCRIPTION
Cherry-Pick of #10033

Original Description:

In `clearData()`, the second transaction may retry on the no-exception path. We need to
call `debugTransaction()` to reset the debugID there as well.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
