### PR TITLE
Empty check before opening backup container for mutation logs

### DIFF
--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -2485,13 +2485,15 @@ ACTOR static Future<JsonBuilderObject> blobGranulesStatusFetcher(
 		// Mutation log backup
 		state std::string mlogsUrl = wait(getMutationLogUrl());
 		statusObj["mutation_log_location"] = mlogsUrl;
-		state Reference<IBackupContainer> bc = IBackupContainer::openContainer(mlogsUrl, {}, {});
-		BackupDescription desc = wait(timeoutError(bc->describeBackup(), 2.0));
-		if (desc.contiguousLogEnd.present()) {
-			statusObj["mutation_log_end_version"] = desc.contiguousLogEnd.get();
-		}
-		if (desc.minLogBegin.present()) {
-			statusObj["mutation_log_begin_version"] = desc.minLogBegin.get();
+		if (mlogsUrl != "") {
+			state Reference<IBackupContainer> bc = IBackupContainer::openContainer(mlogsUrl, {}, {});
+			BackupDescription desc = wait(timeoutError(bc->describeBackup(), 2.0));
+			if (desc.contiguousLogEnd.present()) {
+				statusObj["mutation_log_end_version"] = desc.contiguousLogEnd.get();
+			}
+			if (desc.minLogBegin.present()) {
+				statusObj["mutation_log_begin_version"] = desc.minLogBegin.get();
+			}
 		}
 	} catch (Error& e) {
 		if (e.code() == error_code_actor_cancelled)


### PR DESCRIPTION
Cherry-pick #10044

Validate if the url is not empty before calling openContainer

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
