### PR TITLE
Fix for correctness failures when issuing duplicate snapshot requests

### DIFF
--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -1794,18 +1794,21 @@ ACTOR Future<Void> dataDistributor(DataDistributorInterface di, Reference<AsyncV
 					CODE_PROBE(true, "Data distributor received a duplicate ongoing snapshot request");
 					TraceEvent("RetryOngoingDistributorSnapRequest").detail("SnapUID", snapUID);
 					ASSERT(snapReq.snapPayload == ddSnapReqMap[snapUID].snapPayload);
+					// Discard the old request if a duplicate new request is received
+					ddSnapReqMap[snapUID].reply.sendError(duplicate_snapshot_request());
 					ddSnapReqMap[snapUID] = snapReq;
 				} else {
 					ddSnapReqMap[snapUID] = snapReq;
-					actors.add(ddSnapCreate(
-					    snapReq, db, self->context->ddEnabledState.get(), &ddSnapReqMap, &ddSnapReqResultMap));
 					auto* ddSnapReqResultMapPtr = &ddSnapReqResultMap;
 					actors.add(fmap(
 					    [ddSnapReqResultMapPtr, snapUID](Void _) {
 						    ddSnapReqResultMapPtr->erase(snapUID);
 						    return Void();
 					    },
-					    delay(SERVER_KNOBS->SNAP_MINIMUM_TIME_GAP)));
+					    delayed(
+					        ddSnapCreate(
+					            snapReq, db, self->context->ddEnabledState.get(), &ddSnapReqMap, &ddSnapReqResultMap),
+					        SERVER_KNOBS->SNAP_MINIMUM_TIME_GAP)));
 				}
 			}
 			when(DistributorExclusionSafetyCheckRequest exclCheckReq =

--- a/fdbserver/worker.actor.cpp
+++ b/fdbserver/worker.actor.cpp
@@ -3146,30 +3146,35 @@ ACTOR Future<Void> workerServer(Reference<IClusterConnectionRecord> connRecord,
 					    .detail("Role", snapReq.role);
 					ASSERT(snapReq.role == snapReqMap[snapReqKey].role);
 					ASSERT(snapReq.snapPayload == snapReqMap[snapReqKey].snapPayload);
+					// Discard the old request if a duplicate new request is received
+					// In theory, the old request should be discarded when we send this error since DD won't resend a
+					// request unless for a network error, where the old request is discarded before sending the
+					// duplicate request.
+					snapReqMap[snapReqKey].reply.sendError(duplicate_snapshot_request());
 					snapReqMap[snapReqKey] = snapReq;
 				} else {
 					snapReqMap[snapReqKey] = snapReq; // set map point to the request
 					if (g_network->isSimulated() && (now() - lastSnapTime) < SERVER_KNOBS->SNAP_MINIMUM_TIME_GAP) {
-						// only allow duplicate snapshots on same process in a short time for different roles
-						auto okay = (lastSnapReq.snapUID == snapReq.snapUID) && lastSnapReq.role != snapReq.role;
+						// duplicate snapshots on the same process for the same role is not allowed
+						auto okay = lastSnapReq.snapUID != snapReq.snapUID || lastSnapReq.role != snapReq.role;
 						TraceEvent(okay ? SevInfo : SevError, "RapidSnapRequestsOnSameProcess")
-						    .detail("CurrSnapUID", snapReqKey)
+						    .detail("CurrSnapUID", snapReq.snapUID)
 						    .detail("PrevSnapUID", lastSnapReq.snapUID)
 						    .detail("CurrRole", snapReq.role)
 						    .detail("PrevRole", lastSnapReq.role)
 						    .detail("GapTime", now() - lastSnapTime);
 					}
-					errorForwarders.add(workerSnapCreate(snapReq,
-					                                     snapReq.role.toString() == "coord" ? coordFolder : folder,
-					                                     &snapReqMap,
-					                                     &snapReqResultMap));
 					auto* snapReqResultMapPtr = &snapReqResultMap;
 					errorForwarders.add(fmap(
 					    [snapReqResultMapPtr, snapReqKey](Void _) {
 						    snapReqResultMapPtr->erase(snapReqKey);
 						    return Void();
 					    },
-					    delay(SERVER_KNOBS->SNAP_MINIMUM_TIME_GAP)));
+					    delayed(workerSnapCreate(snapReq,
+					                             snapReq.role.toString() == "coord" ? coordFolder : folder,
+					                             &snapReqMap,
+					                             &snapReqResultMap),
+					            SERVER_KNOBS->SNAP_MINIMUM_TIME_GAP)));
 					if (g_network->isSimulated()) {
 						lastSnapReq = snapReq;
 						lastSnapTime = now();

--- a/fdbserver/workloads/SnapTest.actor.cpp
+++ b/fdbserver/workloads/SnapTest.actor.cpp
@@ -96,9 +96,7 @@ public: // workload functions
 
 	void getMetrics(std::vector<PerfMetric>& m) override { TraceEvent("SnapTestWorkloadGetMetrics"); }
 
-	void disableFailureInjectionWorkloads(std::set<std::string>& out) const override {
-		out.insert("all");
-	}
+	void disableFailureInjectionWorkloads(std::set<std::string>& out) const override { out.insert("all"); }
 
 	ACTOR Future<Void> _create_keys(Database cx, std::string prefix, bool even = true) {
 		state Transaction tr(cx);

--- a/fdbserver/workloads/SnapTest.actor.cpp
+++ b/fdbserver/workloads/SnapTest.actor.cpp
@@ -24,6 +24,7 @@
 #include "fdbclient/ReadYourWrites.h"
 #include "fdbclient/SystemData.h"
 #include "fdbclient/SimpleIni.h"
+#include "fdbserver/Knobs.h"
 #include "fdbserver/Status.actor.h"
 #include "fdbserver/TesterInterface.actor.h"
 #include "fdbserver/WorkerInterface.actor.h"
@@ -58,7 +59,8 @@ public: // ctor & dtor
 		maxSnapDelay = getOption(options, "maxSnapDelay"_sr, 25.0);
 		testID = getOption(options, "testID"_sr, 0);
 		restartInfoLocation = getOption(options, "restartInfoLocation"_sr, "simfdb/restartInfo.ini"_sr).toString();
-		retryLimit = getOption(options, "retryLimit"_sr, 5);
+		// default behavior is to retry until success
+		retryLimit = getOption(options, "retryLimit"_sr, -1);
 		g_simulator->allowLogSetKills = false;
 		{
 			double duplicateSnapshotProbability = getOption(options, "duplicateSnapshotProbability"_sr, 0.1);
@@ -93,6 +95,10 @@ public: // workload functions
 	}
 
 	void getMetrics(std::vector<PerfMetric>& m) override { TraceEvent("SnapTestWorkloadGetMetrics"); }
+
+	void disableFailureInjectionWorkloads(std::set<std::string>& out) const override {
+		out.insert("all");
+	}
 
 	ACTOR Future<Void> _create_keys(Database cx, std::string prefix, bool even = true) {
 		state Transaction tr(cx);
@@ -157,17 +163,29 @@ public: // workload functions
 						wait(delay(deterministicRandom()->random01()));
 						duplicateSnapStatus = snapCreate(cx, snapCmdRef, self->snapUID);
 					}
-					wait(status);
+					ErrorOr<Void> statusErr = wait(errorOr(status));
+					if (statusErr.isError() && statusErr.getError().code() != error_code_duplicate_snapshot_request) {
+						// First request is expected to fail with duplicate_snapshot_request error
+						// Any other errors should be thrown
+						throw statusErr.getError();
+					}
+					if (self->attemptDuplicateSnapshot) {
+						// If duplicate, the first request is discarded, wait for the latest one
+						wait(duplicateSnapStatus);
+					}
 					break;
 				} catch (Error& e) {
-					TraceEvent("SnapCreateError").error(e);
+					TraceEvent("SnapTestCreateError")
+					    .error(e)
+					    .detail("SnapUID", self->snapUID)
+					    .detail("Duplicate", self->attemptDuplicateSnapshot);
 					++retry;
-					// snap v2 can fail for many reasons, so retry for 5 times and then fail it
+					// snap v2 can fail for many reasons, so retry until specified times and then fail it
 					if (self->retryLimit != -1 && retry > self->retryLimit) {
 						snapFailed = true;
 						break;
 					}
-					wait(delay(5.0));
+					wait(delay(SERVER_KNOBS->SNAP_MINIMUM_TIME_GAP));
 				}
 			}
 			CSimpleIni ini;

--- a/flow/include/flow/error_definitions.h
+++ b/flow/include/flow/error_definitions.h
@@ -104,6 +104,7 @@ ERROR( blob_granule_request_failed, 1079, "BlobGranule request failed" )
 ERROR( storage_too_many_feed_streams, 1080, "Too many feed streams to a single storage server" )
 ERROR( storage_engine_not_initialized, 1081, "Storage engine was never successfully initialized." )
 ERROR( unknown_storage_engine, 1082, "Storage engine type is not recognized." )
+ERROR( duplicate_snapshot_request, 1083, "A duplicate snapshot request has been sent, the old request is discarded.")
 
 ERROR( broken_promise, 1100, "Broken promise" )
 ERROR( operation_cancelled, 1101, "Asynchronous operation cancelled" )


### PR DESCRIPTION
This is the fix when you run snapshot restarting tests and issue duplicate snapshot requests.
Details are commented on the change of the code.

The fix basically contains the following:
- Commit proxy sends the newly added `duplicate_snapshot_request` error back when the old request is discarded.
- SnapTest retry and error handling for the error

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
