### PR TITLE
Add a utility function for creating a simulated metacluster

### DIFF
--- a/fdbserver/workloads/MetaclusterManagementConcurrencyWorkload.actor.cpp
+++ b/fdbserver/workloads/MetaclusterManagementConcurrencyWorkload.actor.cpp
@@ -66,7 +66,6 @@ struct MetaclusterManagementConcurrencyWorkload : TestWorkload {
 		               {},
 		               metacluster::util::SkipMetaclusterCreation(self->clientId != 0))));
 
-		ASSERT_EQ(self->simMetacluster.dataDbs.size(), g_simulator->extraDatabases.size());
 		ASSERT_GT(self->simMetacluster.dataDbs.size(), 0);
 		for (auto const& [name, db] : self->simMetacluster.dataDbs) {
 			self->dataDbIndex.push_back(name);

--- a/fdbserver/workloads/MetaclusterManagementConcurrencyWorkload.actor.cpp
+++ b/fdbserver/workloads/MetaclusterManagementConcurrencyWorkload.actor.cpp
@@ -46,8 +46,7 @@
 struct MetaclusterManagementConcurrencyWorkload : TestWorkload {
 	static constexpr auto NAME = "MetaclusterManagementConcurrency";
 
-	Reference<IDatabase> managementDb;
-	std::map<ClusterName, Database> dataDbs;
+	metacluster::util::SimulatedMetacluster simMetacluster;
 	std::vector<ClusterName> dataDbIndex;
 
 	double testDuration;
@@ -59,28 +58,20 @@ struct MetaclusterManagementConcurrencyWorkload : TestWorkload {
 	Future<Void> setup(Database const& cx) override { return _setup(cx, this); }
 
 	ACTOR static Future<Void> _setup(Database cx, MetaclusterManagementConcurrencyWorkload* self) {
-		Reference<IDatabase> threadSafeHandle =
-		    wait(unsafeThreadFutureToFuture(ThreadSafeDatabase::createFromExistingDatabase(cx)));
+		wait(store(self->simMetacluster,
+		           metacluster::util::createSimulatedMetacluster(
+		               cx,
+		               deterministicRandom()->randomInt(TenantAPI::TENANT_ID_PREFIX_MIN_VALUE,
+		                                                TenantAPI::TENANT_ID_PREFIX_MAX_VALUE + 1),
+		               {},
+		               metacluster::util::SkipMetaclusterCreation(self->clientId != 0))));
 
-		MultiVersionApi::api->selectApiVersion(cx->apiVersion.version());
-		self->managementDb = MultiVersionDatabase::debugCreateFromExistingDatabase(threadSafeHandle);
-
-		ASSERT(g_simulator->extraDatabases.size() > 0);
-		for (auto connectionString : g_simulator->extraDatabases) {
-			ClusterConnectionString ccs(connectionString);
-			self->dataDbIndex.push_back(ClusterName(format("cluster_%08d", self->dataDbs.size())));
-			self->dataDbs[self->dataDbIndex.back()] =
-			    Database::createSimulatedExtraDatabase(connectionString, cx->defaultTenant);
+		ASSERT_EQ(self->simMetacluster.dataDbs.size(), g_simulator->extraDatabases.size());
+		ASSERT_GT(self->simMetacluster.dataDbs.size(), 0);
+		for (auto const& [name, db] : self->simMetacluster.dataDbs) {
+			self->dataDbIndex.push_back(name);
 		}
 
-		if (self->clientId == 0) {
-			wait(success(metacluster::createMetacluster(
-			    cx.getReference(),
-			    "management_cluster"_sr,
-			    deterministicRandom()->randomInt(TenantAPI::TENANT_ID_PREFIX_MIN_VALUE,
-			                                     TenantAPI::TENANT_ID_PREFIX_MAX_VALUE + 1),
-			    false)));
-		}
 		return Void();
 	}
 
@@ -88,7 +79,7 @@ struct MetaclusterManagementConcurrencyWorkload : TestWorkload {
 
 	ACTOR static Future<Void> registerCluster(MetaclusterManagementConcurrencyWorkload* self) {
 		state ClusterName clusterName = self->chooseClusterName();
-		state Database dataDb = self->dataDbs[clusterName];
+		state Database dataDb = self->simMetacluster.dataDbs[clusterName];
 
 		state UID debugId = deterministicRandom()->randomUniqueID();
 
@@ -100,7 +91,7 @@ struct MetaclusterManagementConcurrencyWorkload : TestWorkload {
 				    .detail("ClusterName", clusterName)
 				    .detail("NumTenantGroups", entry.capacity.numTenantGroups);
 				Future<Void> registerFuture =
-				    metacluster::registerCluster(self->managementDb,
+				    metacluster::registerCluster(self->simMetacluster.managementDb,
 				                                 clusterName,
 				                                 dataDb.getReference()->getConnectionRecord()->getConnectionString(),
 				                                 entry);
@@ -126,7 +117,7 @@ struct MetaclusterManagementConcurrencyWorkload : TestWorkload {
 				ASSERT(false);
 			}
 
-			wait(success(errorOr(metacluster::removeCluster(self->managementDb,
+			wait(success(errorOr(metacluster::removeCluster(self->simMetacluster.managementDb,
 			                                                clusterName,
 			                                                ClusterType::METACLUSTER_MANAGEMENT,
 			                                                metacluster::ForceRemove::True))));
@@ -139,7 +130,7 @@ struct MetaclusterManagementConcurrencyWorkload : TestWorkload {
 
 	ACTOR static Future<Void> removeCluster(MetaclusterManagementConcurrencyWorkload* self) {
 		state ClusterName clusterName = self->chooseClusterName();
-		state Database dataDb = self->dataDbs[clusterName];
+		state Database dataDb = self->simMetacluster.dataDbs[clusterName];
 		state metacluster::ForceRemove forceRemove(deterministicRandom()->coinflip());
 
 		state UID debugId = deterministicRandom()->randomUniqueID();
@@ -148,7 +139,7 @@ struct MetaclusterManagementConcurrencyWorkload : TestWorkload {
 			loop {
 				TraceEvent(SevDebug, "MetaclusterManagementConcurrencyRemovingCluster", debugId)
 				    .detail("ClusterName", clusterName);
-				Future<bool> removeFuture = metacluster::removeCluster(self->managementDb,
+				Future<bool> removeFuture = metacluster::removeCluster(self->simMetacluster.managementDb,
 				                                                       clusterName,
 				                                                       ClusterType::METACLUSTER_MANAGEMENT,
 				                                                       metacluster::ForceRemove::False);
@@ -179,7 +170,7 @@ struct MetaclusterManagementConcurrencyWorkload : TestWorkload {
 	ACTOR static Future<Void> listClusters(MetaclusterManagementConcurrencyWorkload* self) {
 		state ClusterName clusterName1 = self->chooseClusterName();
 		state ClusterName clusterName2 = self->chooseClusterName();
-		state int limit = deterministicRandom()->randomInt(1, self->dataDbs.size() + 1);
+		state int limit = deterministicRandom()->randomInt(1, self->simMetacluster.dataDbs.size() + 1);
 		try {
 			TraceEvent(SevDebug, "MetaclusterManagementConcurrencyListClusters")
 			    .detail("StartClusterName", clusterName1)
@@ -187,7 +178,7 @@ struct MetaclusterManagementConcurrencyWorkload : TestWorkload {
 			    .detail("Limit", limit);
 
 			std::map<ClusterName, metacluster::DataClusterMetadata> clusterList =
-			    wait(metacluster::listClusters(self->managementDb, clusterName1, clusterName2, limit));
+			    wait(metacluster::listClusters(self->simMetacluster.managementDb, clusterName1, clusterName2, limit));
 
 			TraceEvent(SevDebug, "MetaclusterManagementConcurrencyListedClusters")
 			    .detail("StartClusterName", clusterName1)
@@ -217,12 +208,12 @@ struct MetaclusterManagementConcurrencyWorkload : TestWorkload {
 
 	ACTOR static Future<Void> getCluster(MetaclusterManagementConcurrencyWorkload* self) {
 		state ClusterName clusterName = self->chooseClusterName();
-		state Database dataDb = self->dataDbs[clusterName];
+		state Database dataDb = self->simMetacluster.dataDbs[clusterName];
 
 		try {
 			TraceEvent(SevDebug, "MetaclusterManagementConcurrencyGetCluster").detail("ClusterName", clusterName);
 			metacluster::DataClusterMetadata clusterMetadata =
-			    wait(metacluster::getCluster(self->managementDb, clusterName));
+			    wait(metacluster::getCluster(self->simMetacluster.managementDb, clusterName));
 			TraceEvent(SevDebug, "MetaclusterManagementConcurrencyGotCluster").detail("ClusterName", clusterName);
 
 			ASSERT(dataDb.getReference()->getConnectionRecord()->getConnectionString() ==
@@ -248,7 +239,7 @@ struct MetaclusterManagementConcurrencyWorkload : TestWorkload {
 	    ClusterName clusterName,
 	    Optional<int64_t> numTenantGroups,
 	    Optional<ClusterConnectionString> connectionString) {
-		state Reference<ITransaction> tr = self->managementDb->createTransaction();
+		state Reference<ITransaction> tr = self->simMetacluster.managementDb->createTransaction();
 		loop {
 			try {
 				tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
@@ -275,7 +266,7 @@ struct MetaclusterManagementConcurrencyWorkload : TestWorkload {
 
 	ACTOR static Future<Void> configureCluster(MetaclusterManagementConcurrencyWorkload* self) {
 		state ClusterName clusterName = self->chooseClusterName();
-		state Database dataDb = self->dataDbs[clusterName];
+		state Database dataDb = self->simMetacluster.dataDbs[clusterName];
 
 		state UID debugId = deterministicRandom()->randomUniqueID();
 
@@ -327,7 +318,7 @@ struct MetaclusterManagementConcurrencyWorkload : TestWorkload {
 
 	ACTOR static Future<Void> restoreCluster(MetaclusterManagementConcurrencyWorkload* self) {
 		state ClusterName clusterName = self->chooseClusterName();
-		state Database db = self->dataDbs[clusterName];
+		state Database db = self->simMetacluster.dataDbs[clusterName];
 		state metacluster::ApplyManagementClusterUpdates applyManagementClusterUpdates(
 		    deterministicRandom()->coinflip());
 		state metacluster::ForceJoin forceJoin(deterministicRandom()->coinflip());
@@ -345,7 +336,7 @@ struct MetaclusterManagementConcurrencyWorkload : TestWorkload {
 				    .detail("ClusterName", clusterName)
 				    .detail("ApplyManagementClusterUpdates", applyManagementClusterUpdates);
 
-				wait(success(metacluster::removeCluster(self->managementDb,
+				wait(success(metacluster::removeCluster(self->simMetacluster.managementDb,
 				                                        clusterName,
 				                                        ClusterType::METACLUSTER_MANAGEMENT,
 				                                        metacluster::ForceRemove::True)));
@@ -361,7 +352,7 @@ struct MetaclusterManagementConcurrencyWorkload : TestWorkload {
 				    .detail("ClusterName", clusterName)
 				    .detail("ApplyManagementClusterUpdates", applyManagementClusterUpdates);
 
-				wait(metacluster::restoreCluster(self->managementDb,
+				wait(metacluster::restoreCluster(self->simMetacluster.managementDb,
 				                                 clusterName,
 				                                 db->getConnectionRecord()->getConnectionString(),
 				                                 applyManagementClusterUpdates,
@@ -377,7 +368,7 @@ struct MetaclusterManagementConcurrencyWorkload : TestWorkload {
 				messages.clear();
 			}
 
-			wait(metacluster::restoreCluster(self->managementDb,
+			wait(metacluster::restoreCluster(self->simMetacluster.managementDb,
 			                                 clusterName,
 			                                 db->getConnectionRecord()->getConnectionString(),
 			                                 applyManagementClusterUpdates,
@@ -413,7 +404,7 @@ struct MetaclusterManagementConcurrencyWorkload : TestWorkload {
 				ASSERT(false);
 			}
 
-			wait(success(errorOr(metacluster::removeCluster(self->managementDb,
+			wait(success(errorOr(metacluster::removeCluster(self->simMetacluster.managementDb,
 			                                                clusterName,
 			                                                ClusterType::METACLUSTER_MANAGEMENT,
 			                                                metacluster::ForceRemove::True))));
@@ -457,7 +448,7 @@ struct MetaclusterManagementConcurrencyWorkload : TestWorkload {
 	ACTOR static Future<bool> _check(Database cx, MetaclusterManagementConcurrencyWorkload* self) {
 		// The metacluster consistency check runs the tenant consistency check for each cluster
 		state metacluster::util::MetaclusterConsistencyCheck<IDatabase> metaclusterConsistencyCheck(
-		    self->managementDb, metacluster::util::AllowPartialMetaclusterOperations::True);
+		    self->simMetacluster.managementDb, metacluster::util::AllowPartialMetaclusterOperations::True);
 		wait(metaclusterConsistencyCheck.run());
 
 		return true;

--- a/fdbserver/workloads/MetaclusterRestoreWorkload.actor.cpp
+++ b/fdbserver/workloads/MetaclusterRestoreWorkload.actor.cpp
@@ -181,8 +181,6 @@ struct MetaclusterRestoreWorkload : TestWorkload {
 		}
 	}
 	ACTOR static Future<Void> _setup(Database cx, MetaclusterRestoreWorkload* self) {
-		ASSERT(g_simulator->extraDatabases.size() > 0);
-
 		metacluster::DataClusterEntry clusterEntry;
 		clusterEntry.capacity.numTenantGroups = self->tenantGroupCapacity;
 
@@ -190,6 +188,7 @@ struct MetaclusterRestoreWorkload : TestWorkload {
 		    wait(metacluster::util::createSimulatedMetacluster(cx, self->initialTenantIdPrefix, clusterEntry));
 
 		self->managementDb = simMetacluster.managementDb;
+		ASSERT(!simMetacluster.dataDbs.empty());
 		for (auto const& [name, db] : simMetacluster.dataDbs) {
 			self->dataDbs[name] = DataClusterData(db);
 			self->dataDbIndex.push_back(name);

--- a/fdbserver/workloads/TenantCapacityLimits.actor.cpp
+++ b/fdbserver/workloads/TenantCapacityLimits.actor.cpp
@@ -76,8 +76,6 @@ struct TenantCapacityLimits : TestWorkload {
 	}
 	ACTOR static Future<Void> _setup(Database cx, TenantCapacityLimits* self) {
 		if (self->useMetacluster) {
-			ASSERT(g_simulator->extraDatabases.size() == 1);
-
 			metacluster::DataClusterEntry entry;
 			entry.capacity.numTenantGroups = 1e9;
 
@@ -85,6 +83,7 @@ struct TenantCapacityLimits : TestWorkload {
 			    wait(metacluster::util::createSimulatedMetacluster(cx, self->tenantIdPrefix, entry));
 
 			self->managementDb = simMetacluster.managementDb;
+			ASSERT_EQ(simMetacluster.dataDbs.size(), 1);
 			self->dataDb = simMetacluster.dataDbs.begin()->second;
 		} else {
 			self->dataDb = cx;

--- a/fdbserver/workloads/TenantManagementConcurrencyWorkload.actor.cpp
+++ b/fdbserver/workloads/TenantManagementConcurrencyWorkload.actor.cpp
@@ -53,8 +53,8 @@ struct TenantManagementConcurrencyWorkload : TestWorkload {
 	bool useMetacluster;
 	bool createMetacluster;
 
-	Reference<IDatabase> mvDb;
-	Database dataDb;
+	Reference<IDatabase> managementDb;
+	Database standaloneDb;
 
 	TenantManagementConcurrencyWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
 		maxTenants = std::min<int>(1e8 - 1, getOption(options, "maxTenants"_sr, 100));
@@ -102,31 +102,6 @@ struct TenantManagementConcurrencyWorkload : TestWorkload {
 		return _setup(cx, this);
 	}
 	ACTOR static Future<Void> _setup(Database cx, TenantManagementConcurrencyWorkload* self) {
-		Reference<IDatabase> threadSafeHandle =
-		    wait(unsafeThreadFutureToFuture(ThreadSafeDatabase::createFromExistingDatabase(cx)));
-
-		MultiVersionApi::api->selectApiVersion(cx->apiVersion.version());
-		self->mvDb = MultiVersionDatabase::debugCreateFromExistingDatabase(threadSafeHandle);
-
-		if (self->useMetacluster && self->createMetacluster && self->clientId == 0) {
-			wait(success(metacluster::createMetacluster(
-			    cx.getReference(),
-			    "management_cluster"_sr,
-			    deterministicRandom()->randomInt(TenantAPI::TENANT_ID_PREFIX_MIN_VALUE,
-			                                     TenantAPI::TENANT_ID_PREFIX_MAX_VALUE + 1),
-			    false)));
-
-			state int extraDatabaseIdx;
-			for (extraDatabaseIdx = 0; extraDatabaseIdx < g_simulator->extraDatabases.size(); ++extraDatabaseIdx) {
-				metacluster::DataClusterEntry entry;
-				entry.capacity.numTenantGroups = 1e9;
-				wait(metacluster::registerCluster(self->mvDb,
-				                                  ClusterName(fmt::format("cluster{}", extraDatabaseIdx)),
-				                                  g_simulator->extraDatabases[extraDatabaseIdx],
-				                                  entry));
-			}
-		}
-
 		state Transaction tr(cx);
 		if (self->clientId == 0) {
 			// Send test parameters to the other clients
@@ -160,8 +135,22 @@ struct TenantManagementConcurrencyWorkload : TestWorkload {
 			}
 		}
 
-		if (!self->useMetacluster) {
-			self->dataDb = cx;
+		if (self->useMetacluster) {
+			metacluster::util::SkipMetaclusterCreation skipMetaclusterCreation(!self->createMetacluster ||
+			                                                                   self->clientId != 0);
+
+			Optional<metacluster::DataClusterEntry> entry;
+			if (!skipMetaclusterCreation) {
+				entry = metacluster::DataClusterEntry();
+				entry.get().capacity.numTenantGroups = 1e9;
+			}
+
+			metacluster::util::SimulatedMetacluster simMetacluster =
+			    wait(metacluster::util::createSimulatedMetacluster(cx, {}, entry, skipMetaclusterCreation));
+
+			self->managementDb = simMetacluster.managementDb;
+		} else {
+			self->standaloneDb = cx;
 		}
 
 		return Void();
@@ -199,10 +188,10 @@ struct TenantManagementConcurrencyWorkload : TestWorkload {
 				    .detail("TenantName", entry.tenantName)
 				    .detail("TenantGroup", entry.tenantGroup);
 				Future<Void> createFuture =
-				    self->useMetacluster
-				        ? metacluster::createTenant(self->mvDb, entry, metacluster::AssignClusterAutomatically::True)
-				        : success(
-				              TenantAPI::createTenant(self->dataDb.getReference(), tenant, entry.toTenantMapEntry()));
+				    self->useMetacluster ? metacluster::createTenant(
+				                               self->managementDb, entry, metacluster::AssignClusterAutomatically::True)
+				                         : success(TenantAPI::createTenant(
+				                               self->standaloneDb.getReference(), tenant, entry.toTenantMapEntry()));
 				Optional<Void> result = wait(timeout(createFuture, 30));
 				if (result.present()) {
 					TraceEvent(SevDebug, "TenantManagementConcurrencyCreatedTenant", debugId)
@@ -243,8 +232,8 @@ struct TenantManagementConcurrencyWorkload : TestWorkload {
 			loop {
 				TraceEvent(SevDebug, "TenantManagementConcurrencyDeletingTenant", debugId).detail("TenantName", tenant);
 				Future<Void> deleteFuture = self->useMetacluster
-				                                ? metacluster::deleteTenant(self->mvDb, tenant)
-				                                : TenantAPI::deleteTenant(self->dataDb.getReference(), tenant);
+				                                ? metacluster::deleteTenant(self->managementDb, tenant)
+				                                : TenantAPI::deleteTenant(self->standaloneDb.getReference(), tenant);
 				Optional<Void> result = wait(timeout(deleteFuture, 30));
 
 				if (result.present()) {
@@ -277,9 +266,9 @@ struct TenantManagementConcurrencyWorkload : TestWorkload {
 	                                        std::map<Standalone<StringRef>, Optional<Value>> configParams,
 	                                        metacluster::IgnoreCapacityLimit ignoreCapacityLimit) {
 		if (self->useMetacluster) {
-			wait(metacluster::configureTenant(self->mvDb, tenant, configParams, ignoreCapacityLimit));
+			wait(metacluster::configureTenant(self->managementDb, tenant, configParams, ignoreCapacityLimit));
 		} else {
-			state Reference<ReadYourWritesTransaction> tr = self->dataDb->createTransaction();
+			state Reference<ReadYourWritesTransaction> tr = self->standaloneDb->createTransaction();
 			loop {
 				try {
 					tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
@@ -358,8 +347,9 @@ struct TenantManagementConcurrencyWorkload : TestWorkload {
 				    .detail("OldTenantName", oldTenant)
 				    .detail("NewTenantName", newTenant);
 				Future<Void> renameFuture =
-				    self->useMetacluster ? metacluster::renameTenant(self->mvDb, oldTenant, newTenant)
-				                         : TenantAPI::renameTenant(self->dataDb.getReference(), oldTenant, newTenant);
+				    self->useMetacluster
+				        ? metacluster::renameTenant(self->managementDb, oldTenant, newTenant)
+				        : TenantAPI::renameTenant(self->standaloneDb.getReference(), oldTenant, newTenant);
 				Optional<Void> result = wait(timeout(renameFuture, 30));
 
 				if (result.present()) {
@@ -398,16 +388,16 @@ struct TenantManagementConcurrencyWorkload : TestWorkload {
 	                                              bool useExistingId) {
 		state UID lockId;
 		if (self->useMetacluster) {
-			metacluster::MetaclusterTenantMapEntry entry = wait(metacluster::getTenant(self->mvDb, tenant));
+			metacluster::MetaclusterTenantMapEntry entry = wait(metacluster::getTenant(self->managementDb, tenant));
 			if (useExistingId && entry.tenantLockId.present()) {
 				lockId = entry.tenantLockId.get();
 			} else {
 				lockId = deterministicRandom()->randomUniqueID();
 			}
 
-			wait(metacluster::changeTenantLockState(self->mvDb, tenant, lockState, lockId));
+			wait(metacluster::changeTenantLockState(self->managementDb, tenant, lockState, lockId));
 		} else {
-			state Reference<ReadYourWritesTransaction> tr = self->dataDb->createTransaction();
+			state Reference<ReadYourWritesTransaction> tr = self->standaloneDb->createTransaction();
 			loop {
 				try {
 					tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
@@ -503,11 +493,11 @@ struct TenantManagementConcurrencyWorkload : TestWorkload {
 		if (self->useMetacluster) {
 			// The metacluster consistency check runs the tenant consistency check for each cluster
 			state metacluster::util::MetaclusterConsistencyCheck<IDatabase> metaclusterConsistencyCheck(
-			    self->mvDb, metacluster::util::AllowPartialMetaclusterOperations::True);
+			    self->managementDb, metacluster::util::AllowPartialMetaclusterOperations::True);
 			wait(metaclusterConsistencyCheck.run());
 		} else {
 			state metacluster::util::TenantConsistencyCheck<DatabaseContext, StandardTenantTypes>
-			    tenantConsistencyCheck(self->dataDb.getReference(), &TenantMetadata::instance());
+			    tenantConsistencyCheck(self->standaloneDb.getReference(), &TenantMetadata::instance());
 			wait(tenantConsistencyCheck.run());
 		}
 

--- a/fdbserver/workloads/TenantManagementConcurrencyWorkload.actor.cpp
+++ b/fdbserver/workloads/TenantManagementConcurrencyWorkload.actor.cpp
@@ -149,6 +149,7 @@ struct TenantManagementConcurrencyWorkload : TestWorkload {
 			    wait(metacluster::util::createSimulatedMetacluster(cx, {}, entry, skipMetaclusterCreation));
 
 			self->managementDb = simMetacluster.managementDb;
+			ASSERT(!simMetacluster.dataDbs.empty());
 		} else {
 			self->standaloneDb = cx;
 		}

--- a/fdbserver/workloads/TenantManagementWorkload.actor.cpp
+++ b/fdbserver/workloads/TenantManagementWorkload.actor.cpp
@@ -260,8 +260,8 @@ struct TenantManagementWorkload : TestWorkload {
 		self->mvDb = simMetacluster.managementDb;
 
 		if (self->useMetacluster) {
-			ASSERT(g_simulator->extraDatabases.size() == 1);
 			self->dataClusterName = simMetacluster.dataDbs.begin()->first;
+			ASSERT_EQ(simMetacluster.dataDbs.size(), 1);
 			self->dataDb = simMetacluster.dataDbs.begin()->second;
 		} else {
 			self->dataDb = cx;

--- a/fdbserver/workloads/TenantManagementWorkload.actor.cpp
+++ b/fdbserver/workloads/TenantManagementWorkload.actor.cpp
@@ -82,7 +82,7 @@ struct TenantManagementWorkload : TestWorkload {
 	const Key testParametersKey = nonMetadataSystemKeys.begin.withSuffix("/tenant_test/test_parameters"_sr);
 	const Value noTenantValue = "no_tenant"_sr;
 	const TenantName tenantNamePrefix = "tenant_management_workload_"_sr;
-	const ClusterName dataClusterName = "cluster1"_sr;
+	ClusterName dataClusterName;
 	TenantName localTenantNamePrefix;
 	TenantName localTenantGroupNamePrefix;
 
@@ -182,13 +182,6 @@ struct TenantManagementWorkload : TestWorkload {
 		}
 	}
 
-	Future<Optional<Key>> waitDataDbTenantModeChange() const {
-		return runRYWTransaction(dataDb, [](Reference<ReadYourWritesTransaction> tr) {
-			tr->setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
-			return tr->get("\xff"_sr); // just a meaningless read
-		});
-	}
-
 	// Set a key outside of all tenants to make sure that our tenants aren't writing to the regular key-space
 	Future<Void> writeNonTenantKey() const {
 		return runRYWTransaction(dataDb, [this](Reference<ReadYourWritesTransaction> tr) {
@@ -239,24 +232,6 @@ struct TenantManagementWorkload : TestWorkload {
 
 	// only the first client will do this setup
 	ACTOR static Future<Void> firstClientSetup(Database cx, TenantManagementWorkload* self) {
-		if (self->useMetacluster) {
-			fmt::print("Create metacluster and register data cluster ... \n");
-			// Configure the metacluster (this changes the tenant mode)
-			wait(success(metacluster::createMetacluster(
-			    cx.getReference(), "management_cluster"_sr, self->tenantIdPrefix, false)));
-
-			metacluster::DataClusterEntry entry;
-			entry.capacity.numTenantGroups = 1e9;
-			wait(
-			    metacluster::registerCluster(self->mvDb, self->dataClusterName, g_simulator->extraDatabases[0], entry));
-
-			ASSERT(g_simulator->extraDatabases.size() == 1);
-			self->dataDb = Database::createSimulatedExtraDatabase(g_simulator->extraDatabases[0], cx->defaultTenant);
-			// wait for tenant mode change on dataDB
-			wait(success(self->waitDataDbTenantModeChange()));
-		} else {
-			self->dataDb = cx;
-		}
 		wait(sendTestParameters(cx, self));
 
 		if (self->dataDb->getTenantMode() != TenantMode::REQUIRED) {
@@ -267,23 +242,33 @@ struct TenantManagementWorkload : TestWorkload {
 	}
 
 	ACTOR static Future<Void> _setup(Database cx, TenantManagementWorkload* self) {
-		Reference<IDatabase> threadSafeHandle =
-		    wait(unsafeThreadFutureToFuture(ThreadSafeDatabase::createFromExistingDatabase(cx)));
+		if (self->clientId != 0) {
+			wait(loadTestParameters(cx, self));
+		}
 
-		MultiVersionApi::api->selectApiVersion(cx->apiVersion.version());
-		self->mvDb = MultiVersionDatabase::debugCreateFromExistingDatabase(threadSafeHandle);
+		metacluster::util::SkipMetaclusterCreation skipMetaclusterCreation(!self->useMetacluster ||
+		                                                                   self->clientId != 0);
+		Optional<metacluster::DataClusterEntry> entry;
+		if (!skipMetaclusterCreation) {
+			entry = metacluster::DataClusterEntry();
+			entry.get().capacity.numTenantGroups = 1e9;
+		}
+
+		state metacluster::util::SimulatedMetacluster simMetacluster = wait(
+		    metacluster::util::createSimulatedMetacluster(cx, self->tenantIdPrefix, entry, skipMetaclusterCreation));
+
+		self->mvDb = simMetacluster.managementDb;
+
+		if (self->useMetacluster) {
+			ASSERT(g_simulator->extraDatabases.size() == 1);
+			self->dataClusterName = simMetacluster.dataDbs.begin()->first;
+			self->dataDb = simMetacluster.dataDbs.begin()->second;
+		} else {
+			self->dataDb = cx;
+		}
 
 		if (self->clientId == 0) {
 			wait(firstClientSetup(cx, self));
-		} else {
-			wait(loadTestParameters(cx, self));
-			if (self->useMetacluster) {
-				ASSERT(g_simulator->extraDatabases.size() == 1);
-				self->dataDb =
-				    Database::createSimulatedExtraDatabase(g_simulator->extraDatabases[0], cx->defaultTenant);
-			} else {
-				self->dataDb = cx;
-			}
 		}
 
 		return Void();

--- a/metacluster/include/metacluster/MetaclusterConsistency.actor.h
+++ b/metacluster/include/metacluster/MetaclusterConsistency.actor.h
@@ -182,106 +182,113 @@ private:
 	ACTOR static Future<Void> validateDataCluster(MetaclusterConsistencyCheck* self,
 	                                              ClusterName clusterName,
 	                                              DataClusterMetadata clusterMetadata) {
-		state Reference<IDatabase> dataDb = wait(openDatabase(clusterMetadata.connectionString));
-		state TenantConsistencyCheck<IDatabase, StandardTenantTypes> tenantConsistencyCheck(
-		    dataDb, &TenantMetadata::instance());
-		wait(tenantConsistencyCheck.run());
+		try {
+			state Reference<IDatabase> dataDb = wait(openDatabase(clusterMetadata.connectionString));
+			state TenantConsistencyCheck<IDatabase, StandardTenantTypes> tenantConsistencyCheck(
+			    dataDb, &TenantMetadata::instance());
+			wait(tenantConsistencyCheck.run());
 
-		auto dataClusterItr = self->metaclusterData.dataClusterMetadata.find(clusterName);
-		ASSERT(dataClusterItr != self->metaclusterData.dataClusterMetadata.end());
-		auto const& data = dataClusterItr->second;
-		auto const& managementData = self->metaclusterData.managementMetadata;
+			auto dataClusterItr = self->metaclusterData.dataClusterMetadata.find(clusterName);
+			ASSERT(dataClusterItr != self->metaclusterData.dataClusterMetadata.end());
+			auto const& data = dataClusterItr->second;
+			auto const& managementData = self->metaclusterData.managementMetadata;
 
-		ASSERT(data.metaclusterRegistration.present());
-		ASSERT_EQ(data.metaclusterRegistration.get().clusterType, ClusterType::METACLUSTER_DATA);
-		ASSERT(data.metaclusterRegistration.get().matches(managementData.metaclusterRegistration.get()));
-		ASSERT(data.metaclusterRegistration.get().name == clusterName);
-		ASSERT(data.metaclusterRegistration.get().id == clusterMetadata.entry.id);
+			ASSERT(data.metaclusterRegistration.present());
+			ASSERT_EQ(data.metaclusterRegistration.get().clusterType, ClusterType::METACLUSTER_DATA);
+			ASSERT(data.metaclusterRegistration.get().matches(managementData.metaclusterRegistration.get()));
+			ASSERT(data.metaclusterRegistration.get().name == clusterName);
+			ASSERT(data.metaclusterRegistration.get().id == clusterMetadata.entry.id);
 
-		if (data.tenantData.lastTenantId >= 0) {
-			ASSERT_EQ(TenantAPI::getTenantIdPrefix(data.tenantData.lastTenantId), managementData.tenantIdPrefix);
-			ASSERT_LE(data.tenantData.lastTenantId, managementData.tenantData.lastTenantId);
-		} else {
-			for (auto const& [id, tenant] : data.tenantData.tenantMap) {
-				ASSERT_NE(TenantAPI::getTenantIdPrefix(id), managementData.tenantIdPrefix);
+			if (data.tenantData.lastTenantId >= 0) {
+				ASSERT_EQ(TenantAPI::getTenantIdPrefix(data.tenantData.lastTenantId), managementData.tenantIdPrefix);
+				ASSERT_LE(data.tenantData.lastTenantId, managementData.tenantData.lastTenantId);
+			} else {
+				for (auto const& [id, tenant] : data.tenantData.tenantMap) {
+					ASSERT_NE(TenantAPI::getTenantIdPrefix(id), managementData.tenantIdPrefix);
+				}
 			}
-		}
 
-		std::set<int64_t> expectedTenants;
-		auto clusterTenantMapItr = managementData.clusterTenantMap.find(clusterName);
-		if (clusterTenantMapItr != managementData.clusterTenantMap.end()) {
-			expectedTenants = clusterTenantMapItr->second;
-		}
+			std::set<int64_t> expectedTenants;
+			auto clusterTenantMapItr = managementData.clusterTenantMap.find(clusterName);
+			if (clusterTenantMapItr != managementData.clusterTenantMap.end()) {
+				expectedTenants = clusterTenantMapItr->second;
+			}
 
-		std::set<TenantGroupName> tenantGroupsWithCompletedTenants;
-		if (!self->allowPartialMetaclusterOperations) {
-			ASSERT_EQ(data.tenantData.tenantMap.size(), expectedTenants.size());
-		} else {
-			ASSERT_LE(data.tenantData.tenantMap.size(), expectedTenants.size());
-			for (auto const& tenantId : expectedTenants) {
+			std::set<TenantGroupName> tenantGroupsWithCompletedTenants;
+			if (!self->allowPartialMetaclusterOperations) {
+				ASSERT_EQ(data.tenantData.tenantMap.size(), expectedTenants.size());
+			} else {
+				ASSERT_LE(data.tenantData.tenantMap.size(), expectedTenants.size());
+				for (auto const& tenantId : expectedTenants) {
+					auto tenantMapItr = managementData.tenantData.tenantMap.find(tenantId);
+					ASSERT(tenantMapItr != managementData.tenantData.tenantMap.end());
+					MetaclusterTenantMapEntry const& metaclusterEntry = tenantMapItr->second;
+					if (!data.tenantData.tenantMap.count(tenantId)) {
+						ASSERT(metaclusterEntry.tenantState == TenantState::REGISTERING ||
+						       metaclusterEntry.tenantState == TenantState::REMOVING ||
+						       metaclusterEntry.tenantState == TenantState::ERROR);
+					} else if (metaclusterEntry.tenantGroup.present()) {
+						tenantGroupsWithCompletedTenants.insert(metaclusterEntry.tenantGroup.get());
+					}
+				}
+			}
+
+			for (auto const& [tenantId, entry] : data.tenantData.tenantMap) {
+				ASSERT(expectedTenants.count(tenantId));
 				auto tenantMapItr = managementData.tenantData.tenantMap.find(tenantId);
 				ASSERT(tenantMapItr != managementData.tenantData.tenantMap.end());
 				MetaclusterTenantMapEntry const& metaclusterEntry = tenantMapItr->second;
-				if (!data.tenantData.tenantMap.count(tenantId)) {
-					ASSERT(metaclusterEntry.tenantState == TenantState::REGISTERING ||
-					       metaclusterEntry.tenantState == TenantState::REMOVING ||
-					       metaclusterEntry.tenantState == TenantState::ERROR);
-				} else if (metaclusterEntry.tenantGroup.present()) {
-					tenantGroupsWithCompletedTenants.insert(metaclusterEntry.tenantGroup.get());
+				ASSERT_EQ(entry.id, metaclusterEntry.id);
+
+				if (!self->allowPartialMetaclusterOperations) {
+					ASSERT_EQ(metaclusterEntry.tenantState, TenantState::READY);
+					ASSERT(entry.tenantName == metaclusterEntry.tenantName);
+				} else if (entry.tenantName != metaclusterEntry.tenantName) {
+					ASSERT(entry.tenantName == metaclusterEntry.renameDestination);
+				}
+				if (metaclusterEntry.tenantState != TenantState::UPDATING_CONFIGURATION &&
+				    metaclusterEntry.tenantState != TenantState::REMOVING) {
+					ASSERT_EQ(entry.configurationSequenceNum, metaclusterEntry.configurationSequenceNum);
+				} else {
+					ASSERT_LE(entry.configurationSequenceNum, metaclusterEntry.configurationSequenceNum);
+				}
+
+				if (entry.configurationSequenceNum == metaclusterEntry.configurationSequenceNum) {
+					ASSERT(entry.tenantGroup == metaclusterEntry.tenantGroup);
+					ASSERT_EQ(entry.tenantLockState, metaclusterEntry.tenantLockState);
+					ASSERT(entry.tenantLockId == metaclusterEntry.tenantLockId);
 				}
 			}
-		}
 
-		for (auto const& [tenantId, entry] : data.tenantData.tenantMap) {
-			ASSERT(expectedTenants.count(tenantId));
-			auto tenantMapItr = managementData.tenantData.tenantMap.find(tenantId);
-			ASSERT(tenantMapItr != managementData.tenantData.tenantMap.end());
-			MetaclusterTenantMapEntry const& metaclusterEntry = tenantMapItr->second;
-			ASSERT_EQ(entry.id, metaclusterEntry.id);
-
+			std::set<TenantGroupName> expectedTenantGroups;
+			auto clusterTenantGroupItr = managementData.clusterTenantGroupMap.find(clusterName);
+			if (clusterTenantGroupItr != managementData.clusterTenantGroupMap.end()) {
+				expectedTenantGroups = clusterTenantGroupItr->second;
+			}
 			if (!self->allowPartialMetaclusterOperations) {
-				ASSERT_EQ(metaclusterEntry.tenantState, TenantState::READY);
-				ASSERT(entry.tenantName == metaclusterEntry.tenantName);
-			} else if (entry.tenantName != metaclusterEntry.tenantName) {
-				ASSERT(entry.tenantName == metaclusterEntry.renameDestination);
-			}
-			if (metaclusterEntry.tenantState != TenantState::UPDATING_CONFIGURATION &&
-			    metaclusterEntry.tenantState != TenantState::REMOVING) {
-				ASSERT_EQ(entry.configurationSequenceNum, metaclusterEntry.configurationSequenceNum);
+				ASSERT_EQ(data.tenantData.tenantGroupMap.size(), expectedTenantGroups.size());
 			} else {
-				ASSERT_LE(entry.configurationSequenceNum, metaclusterEntry.configurationSequenceNum);
-			}
-
-			if (entry.configurationSequenceNum == metaclusterEntry.configurationSequenceNum) {
-				ASSERT(entry.tenantGroup == metaclusterEntry.tenantGroup);
-				ASSERT_EQ(entry.tenantLockState, metaclusterEntry.tenantLockState);
-				ASSERT(entry.tenantLockId == metaclusterEntry.tenantLockId);
-			}
-		}
-
-		std::set<TenantGroupName> expectedTenantGroups;
-		auto clusterTenantGroupItr = managementData.clusterTenantGroupMap.find(clusterName);
-		if (clusterTenantGroupItr != managementData.clusterTenantGroupMap.end()) {
-			expectedTenantGroups = clusterTenantGroupItr->second;
-		}
-		if (!self->allowPartialMetaclusterOperations) {
-			ASSERT_EQ(data.tenantData.tenantGroupMap.size(), expectedTenantGroups.size());
-		} else {
-			ASSERT_LE(data.tenantData.tenantGroupMap.size(), expectedTenantGroups.size());
-			for (auto const& name : expectedTenantGroups) {
-				if (!data.tenantData.tenantGroupMap.count(name)) {
-					auto itr = tenantGroupsWithCompletedTenants.find(name);
-					ASSERT(itr == tenantGroupsWithCompletedTenants.end());
+				ASSERT_LE(data.tenantData.tenantGroupMap.size(), expectedTenantGroups.size());
+				for (auto const& name : expectedTenantGroups) {
+					if (!data.tenantData.tenantGroupMap.count(name)) {
+						auto itr = tenantGroupsWithCompletedTenants.find(name);
+						ASSERT(itr == tenantGroupsWithCompletedTenants.end());
+					}
 				}
 			}
-		}
-		for (auto const& [name, entry] : data.tenantData.tenantGroupMap) {
-			ASSERT(expectedTenantGroups.count(name));
-			expectedTenantGroups.erase(name);
-		}
+			for (auto const& [name, entry] : data.tenantData.tenantGroupMap) {
+				ASSERT(expectedTenantGroups.count(name));
+				expectedTenantGroups.erase(name);
+			}
 
-		for (auto const& name : expectedTenantGroups) {
-			ASSERT(tenantGroupsWithCompletedTenants.count(name) == 0);
+			for (auto const& name : expectedTenantGroups) {
+				ASSERT(tenantGroupsWithCompletedTenants.count(name) == 0);
+			}
+		} catch (Error& e) {
+			TraceEvent(SevError, "MetaclusterConsistencyDataClusterValidationFailed")
+			    .error(e)
+			    .detail("ClusterName", clusterName);
+			ASSERT(false);
 		}
 
 		return Void();
@@ -291,7 +298,13 @@ private:
 		state TenantConsistencyCheck<DB, MetaclusterTenantTypes> managementTenantConsistencyCheck(
 		    self->managementDb, &metadata::management::tenantMetadata());
 
-		wait(managementTenantConsistencyCheck.run() && self->metaclusterData.load() && checkManagementSystemKeys(self));
+		try {
+			wait(managementTenantConsistencyCheck.run() && self->metaclusterData.load() &&
+			     checkManagementSystemKeys(self));
+		} catch (Error& e) {
+			TraceEvent(SevError, "MetaclusterConsistencyManagementClusterValidationFailed").error(e);
+			ASSERT(false);
+		}
 
 		self->validateManagementCluster();
 

--- a/metacluster/include/metacluster/MetaclusterData.actor.h
+++ b/metacluster/include/metacluster/MetaclusterData.actor.h
@@ -195,27 +195,32 @@ private:
 	ACTOR static Future<Void> loadDataClusterMetadata(MetaclusterData* self,
 	                                                  ClusterName clusterName,
 	                                                  ClusterConnectionString connectionString) {
-		state std::pair<typename std::map<ClusterName, DataClusterData>::iterator, bool> clusterItr =
-		    self->dataClusterMetadata.try_emplace(clusterName);
+		try {
+			state std::pair<typename std::map<ClusterName, DataClusterData>::iterator, bool> clusterItr =
+			    self->dataClusterMetadata.try_emplace(clusterName);
 
-		if (clusterItr.second) {
-			state Reference<IDatabase> dataDb = wait(openDatabase(connectionString));
-			state Reference<ITransaction> tr = dataDb->createTransaction();
+			if (clusterItr.second) {
+				state Reference<IDatabase> dataDb = wait(openDatabase(connectionString));
+				state Reference<ITransaction> tr = dataDb->createTransaction();
 
-			clusterItr.first->second.tenantData =
-			    TenantData<IDatabase, StandardTenantTypes>(dataDb, &TenantMetadata::instance());
-			loop {
-				try {
-					tr->setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
-					wait(store(clusterItr.first->second.metaclusterRegistration,
-					           metadata::metaclusterRegistration().get(tr)) &&
-					     clusterItr.first->second.tenantData.load(tr));
+				clusterItr.first->second.tenantData =
+				    TenantData<IDatabase, StandardTenantTypes>(dataDb, &TenantMetadata::instance());
+				loop {
+					try {
+						tr->setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
+						wait(store(clusterItr.first->second.metaclusterRegistration,
+						           metadata::metaclusterRegistration().get(tr)) &&
+						     clusterItr.first->second.tenantData.load(tr));
 
-					break;
-				} catch (Error& e) {
-					wait(safeThreadFutureToFuture(tr->onError(e)));
+						break;
+					} catch (Error& e) {
+						wait(safeThreadFutureToFuture(tr->onError(e)));
+					}
 				}
 			}
+		} catch (Error& e) {
+			TraceEvent(SevError, "LoadDataClusterError").error(e).detail("ClusterName", clusterName);
+			ASSERT(false);
 		}
 
 		return Void();

--- a/metacluster/include/metacluster/MetaclusterUtil.actor.h
+++ b/metacluster/include/metacluster/MetaclusterUtil.actor.h
@@ -27,6 +27,8 @@
 
 #include "fdbclient/CoordinationInterface.h"
 #include "fdbclient/FDBTypes.h"
+#include "fdbclient/IClientApi.h"
+#include "fdbclient/NativeAPI.actor.h"
 #include "flow/FastRef.h"
 #include "flow/IRandom.h"
 #include "flow/Platform.h"
@@ -37,6 +39,8 @@
 
 // This provide metacluster utility functions that may be used both internally and externally to the metacluster project
 namespace metacluster::util {
+
+FDB_BOOLEAN_PARAM(SkipMetaclusterCreation);
 
 // Helper function to compute metacluster capacity by passing the result of metacluster::listClusters
 std::pair<ClusterUsage, ClusterUsage> metaclusterCapacity(std::map<ClusterName, DataClusterMetadata> const& clusters);
@@ -49,6 +53,17 @@ Future<Reference<IDatabase>> getAndOpenDatabase(Transaction managementTr, Cluste
 	Reference<IDatabase> db = wait(openDatabase(clusterMetadata.connectionString));
 	return db;
 }
+
+struct SimulatedMetacluster {
+	Reference<IDatabase> managementDb;
+	std::map<ClusterName, Database> dataDbs;
+};
+
+ACTOR Future<SimulatedMetacluster> createSimulatedMetacluster(
+    Database db,
+    Optional<int64_t> tenantIdPrefix = Optional<int64_t>(),
+    Optional<DataClusterEntry> dataClusterConfig = DataClusterEntry(),
+    SkipMetaclusterCreation skipMetaclusterCreation = SkipMetaclusterCreation::False);
 
 } // namespace metacluster::util
 

--- a/metacluster/include/metacluster/TenantConsistency.actor.h
+++ b/metacluster/include/metacluster/TenantConsistency.actor.h
@@ -91,7 +91,7 @@ private:
 
 	// Specialization for MetaclusterTenantMapEntry, used on management clusters
 	void validateTenantMetadata(TenantData<DB, MetaclusterTenantTypes> tenantData) {
-		ASSERT(tenantData.clusterType == ClusterType::METACLUSTER_MANAGEMENT);
+		ASSERT_EQ(tenantData.clusterType, ClusterType::METACLUSTER_MANAGEMENT);
 		ASSERT_LE(tenantData.tenantMap.size(), metaclusterMaxTenants);
 
 		// Check metacluster specific properties


### PR DESCRIPTION
There are several workloads that need to create a metacluster, and this adds a function that can be called to help do that. This function is used in all workloads that create metaclusters except for the metacluster management workload, which will be changed in a subsequent PR.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
