### PR TITLE
Add a utility function for creating a simulated metacluster (snowflake/release-71.3)

### DIFF
--- a/fdbserver/workloads/MetaclusterRestoreWorkload.actor.cpp
+++ b/fdbserver/workloads/MetaclusterRestoreWorkload.actor.cpp
@@ -181,30 +181,17 @@ struct MetaclusterRestoreWorkload : TestWorkload {
 		}
 	}
 	ACTOR static Future<Void> _setup(Database cx, MetaclusterRestoreWorkload* self) {
-		Reference<IDatabase> threadSafeHandle =
-		    wait(unsafeThreadFutureToFuture(ThreadSafeDatabase::createFromExistingDatabase(cx)));
+		metacluster::DataClusterEntry clusterEntry;
+		clusterEntry.capacity.numTenantGroups = self->tenantGroupCapacity;
 
-		MultiVersionApi::api->selectApiVersion(cx->apiVersion.version());
-		self->managementDb = MultiVersionDatabase::debugCreateFromExistingDatabase(threadSafeHandle);
-		wait(success(metacluster::createMetacluster(
-		    self->managementDb, "management_cluster"_sr, self->initialTenantIdPrefix, false)));
+		metacluster::util::SimulatedMetacluster simMetacluster =
+		    wait(metacluster::util::createSimulatedMetacluster(cx, self->initialTenantIdPrefix, clusterEntry));
 
-		ASSERT(g_simulator->extraDatabases.size() > 0);
-		state std::vector<std::string>::iterator extraDatabasesItr;
-		for (extraDatabasesItr = g_simulator->extraDatabases.begin();
-		     extraDatabasesItr != g_simulator->extraDatabases.end();
-		     ++extraDatabasesItr) {
-			ClusterConnectionString ccs(*extraDatabasesItr);
-			auto extraFile = makeReference<ClusterConnectionMemoryRecord>(ccs);
-			state ClusterName clusterName = ClusterName(format("cluster_%08d", self->dataDbs.size()));
-			Database db = Database::createDatabase(extraFile, ApiVersion::LATEST_VERSION);
-			self->dataDbIndex.push_back(clusterName);
-			self->dataDbs[clusterName] = DataClusterData(db);
-
-			metacluster::DataClusterEntry clusterEntry;
-			clusterEntry.capacity.numTenantGroups = self->tenantGroupCapacity;
-
-			wait(metacluster::registerCluster(self->managementDb, clusterName, ccs, clusterEntry));
+		self->managementDb = simMetacluster.managementDb;
+		ASSERT(!simMetacluster.dataDbs.empty());
+		for (auto const& [name, db] : simMetacluster.dataDbs) {
+			self->dataDbs[name] = DataClusterData(db);
+			self->dataDbIndex.push_back(name);
 		}
 
 		TraceEvent(SevDebug, "MetaclusterRestoreWorkloadCreateTenants").detail("NumTenants", self->initialTenants);
@@ -555,6 +542,7 @@ struct MetaclusterRestoreWorkload : TestWorkload {
 
 		wait(success(
 		    metacluster::createMetacluster(self->managementDb, "management_cluster"_sr, newTenantIdPrefix, false)));
+
 		state std::map<ClusterName, DataClusterData>::iterator clusterItr;
 		for (clusterItr = self->dataDbs.begin(); clusterItr != self->dataDbs.end(); ++clusterItr) {
 			TraceEvent("MetaclusterRestoreWorkloadProcessDataCluster").detail("FromCluster", clusterItr->first);

--- a/fdbserver/workloads/TenantCapacityLimits.actor.cpp
+++ b/fdbserver/workloads/TenantCapacityLimits.actor.cpp
@@ -76,36 +76,20 @@ struct TenantCapacityLimits : TestWorkload {
 	}
 	ACTOR static Future<Void> _setup(Database cx, TenantCapacityLimits* self) {
 		if (self->useMetacluster) {
-			Reference<IDatabase> threadSafeHandle =
-			    wait(unsafeThreadFutureToFuture(ThreadSafeDatabase::createFromExistingDatabase(cx)));
-
-			MultiVersionApi::api->selectApiVersion(cx->apiVersion.version());
-			self->managementDb = MultiVersionDatabase::debugCreateFromExistingDatabase(threadSafeHandle);
-
-			wait(success(metacluster::createMetacluster(
-			    cx.getReference(), "management_cluster"_sr, self->tenantIdPrefix, false)));
-
 			metacluster::DataClusterEntry entry;
 			entry.capacity.numTenantGroups = 1e9;
-			wait(metacluster::registerCluster(
-			    self->managementDb, "test_data_cluster"_sr, g_simulator->extraDatabases[0], entry));
 
-			ASSERT(g_simulator->extraDatabases.size() == 1);
-			self->dataDb = Database::createSimulatedExtraDatabase(g_simulator->extraDatabases[0], cx->defaultTenant);
-			// wait for tenant mode change on dataDB
-			wait(success(self->waitDataDbTenantModeChange()));
+			metacluster::util::SimulatedMetacluster simMetacluster =
+			    wait(metacluster::util::createSimulatedMetacluster(cx, self->tenantIdPrefix, entry));
+
+			self->managementDb = simMetacluster.managementDb;
+			ASSERT_EQ(simMetacluster.dataDbs.size(), 1);
+			self->dataDb = simMetacluster.dataDbs.begin()->second;
 		} else {
 			self->dataDb = cx;
 		}
 
 		return Void();
-	}
-
-	Future<Optional<Key>> waitDataDbTenantModeChange() const {
-		return runRYWTransaction(dataDb, [](Reference<ReadYourWritesTransaction> tr) {
-			tr->setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
-			return tr->get("\xff"_sr); // just a meaningless read
-		});
 	}
 
 	Future<Void> start(Database const& cx) override {

--- a/fdbserver/workloads/TenantManagementWorkload.actor.cpp
+++ b/fdbserver/workloads/TenantManagementWorkload.actor.cpp
@@ -82,7 +82,7 @@ struct TenantManagementWorkload : TestWorkload {
 	const Key testParametersKey = nonMetadataSystemKeys.begin.withSuffix("/tenant_test/test_parameters"_sr);
 	const Value noTenantValue = "no_tenant"_sr;
 	const TenantName tenantNamePrefix = "tenant_management_workload_"_sr;
-	const ClusterName dataClusterName = "cluster1"_sr;
+	ClusterName dataClusterName;
 	TenantName localTenantNamePrefix;
 	TenantName localTenantGroupNamePrefix;
 
@@ -182,13 +182,6 @@ struct TenantManagementWorkload : TestWorkload {
 		}
 	}
 
-	Future<Optional<Key>> waitDataDbTenantModeChange() const {
-		return runRYWTransaction(dataDb, [](Reference<ReadYourWritesTransaction> tr) {
-			tr->setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
-			return tr->get("\xff"_sr); // just a meaningless read
-		});
-	}
-
 	// Set a key outside of all tenants to make sure that our tenants aren't writing to the regular key-space
 	Future<Void> writeNonTenantKey() const {
 		return runRYWTransaction(dataDb, [this](Reference<ReadYourWritesTransaction> tr) {
@@ -239,24 +232,6 @@ struct TenantManagementWorkload : TestWorkload {
 
 	// only the first client will do this setup
 	ACTOR static Future<Void> firstClientSetup(Database cx, TenantManagementWorkload* self) {
-		if (self->useMetacluster) {
-			fmt::print("Create metacluster and register data cluster ... \n");
-			// Configure the metacluster (this changes the tenant mode)
-			wait(success(metacluster::createMetacluster(
-			    cx.getReference(), "management_cluster"_sr, self->tenantIdPrefix, false)));
-
-			metacluster::DataClusterEntry entry;
-			entry.capacity.numTenantGroups = 1e9;
-			wait(
-			    metacluster::registerCluster(self->mvDb, self->dataClusterName, g_simulator->extraDatabases[0], entry));
-
-			ASSERT(g_simulator->extraDatabases.size() == 1);
-			self->dataDb = Database::createSimulatedExtraDatabase(g_simulator->extraDatabases[0], cx->defaultTenant);
-			// wait for tenant mode change on dataDB
-			wait(success(self->waitDataDbTenantModeChange()));
-		} else {
-			self->dataDb = cx;
-		}
 		wait(sendTestParameters(cx, self));
 
 		if (self->dataDb->getTenantMode() != TenantMode::REQUIRED) {
@@ -267,23 +242,33 @@ struct TenantManagementWorkload : TestWorkload {
 	}
 
 	ACTOR static Future<Void> _setup(Database cx, TenantManagementWorkload* self) {
-		Reference<IDatabase> threadSafeHandle =
-		    wait(unsafeThreadFutureToFuture(ThreadSafeDatabase::createFromExistingDatabase(cx)));
+		if (self->clientId != 0) {
+			wait(loadTestParameters(cx, self));
+		}
 
-		MultiVersionApi::api->selectApiVersion(cx->apiVersion.version());
-		self->mvDb = MultiVersionDatabase::debugCreateFromExistingDatabase(threadSafeHandle);
+		metacluster::util::SkipMetaclusterCreation skipMetaclusterCreation(!self->useMetacluster ||
+		                                                                   self->clientId != 0);
+		Optional<metacluster::DataClusterEntry> entry;
+		if (!skipMetaclusterCreation) {
+			entry = metacluster::DataClusterEntry();
+			entry.get().capacity.numTenantGroups = 1e9;
+		}
+
+		state metacluster::util::SimulatedMetacluster simMetacluster = wait(
+		    metacluster::util::createSimulatedMetacluster(cx, self->tenantIdPrefix, entry, skipMetaclusterCreation));
+
+		self->mvDb = simMetacluster.managementDb;
+
+		if (self->useMetacluster) {
+			self->dataClusterName = simMetacluster.dataDbs.begin()->first;
+			ASSERT_EQ(simMetacluster.dataDbs.size(), 1);
+			self->dataDb = simMetacluster.dataDbs.begin()->second;
+		} else {
+			self->dataDb = cx;
+		}
 
 		if (self->clientId == 0) {
 			wait(firstClientSetup(cx, self));
-		} else {
-			wait(loadTestParameters(cx, self));
-			if (self->useMetacluster) {
-				ASSERT(g_simulator->extraDatabases.size() == 1);
-				self->dataDb =
-				    Database::createSimulatedExtraDatabase(g_simulator->extraDatabases[0], cx->defaultTenant);
-			} else {
-				self->dataDb = cx;
-			}
 		}
 
 		return Void();

--- a/metacluster/include/metacluster/MetaclusterConsistency.actor.h
+++ b/metacluster/include/metacluster/MetaclusterConsistency.actor.h
@@ -182,106 +182,113 @@ private:
 	ACTOR static Future<Void> validateDataCluster(MetaclusterConsistencyCheck* self,
 	                                              ClusterName clusterName,
 	                                              DataClusterMetadata clusterMetadata) {
-		state Reference<IDatabase> dataDb = wait(openDatabase(clusterMetadata.connectionString));
-		state TenantConsistencyCheck<IDatabase, StandardTenantTypes> tenantConsistencyCheck(
-		    dataDb, &TenantMetadata::instance());
-		wait(tenantConsistencyCheck.run());
+		try {
+			state Reference<IDatabase> dataDb = wait(openDatabase(clusterMetadata.connectionString));
+			state TenantConsistencyCheck<IDatabase, StandardTenantTypes> tenantConsistencyCheck(
+			    dataDb, &TenantMetadata::instance());
+			wait(tenantConsistencyCheck.run());
 
-		auto dataClusterItr = self->metaclusterData.dataClusterMetadata.find(clusterName);
-		ASSERT(dataClusterItr != self->metaclusterData.dataClusterMetadata.end());
-		auto const& data = dataClusterItr->second;
-		auto const& managementData = self->metaclusterData.managementMetadata;
+			auto dataClusterItr = self->metaclusterData.dataClusterMetadata.find(clusterName);
+			ASSERT(dataClusterItr != self->metaclusterData.dataClusterMetadata.end());
+			auto const& data = dataClusterItr->second;
+			auto const& managementData = self->metaclusterData.managementMetadata;
 
-		ASSERT(data.metaclusterRegistration.present());
-		ASSERT_EQ(data.metaclusterRegistration.get().clusterType, ClusterType::METACLUSTER_DATA);
-		ASSERT(data.metaclusterRegistration.get().matches(managementData.metaclusterRegistration.get()));
-		ASSERT(data.metaclusterRegistration.get().name == clusterName);
-		ASSERT(data.metaclusterRegistration.get().id == clusterMetadata.entry.id);
+			ASSERT(data.metaclusterRegistration.present());
+			ASSERT_EQ(data.metaclusterRegistration.get().clusterType, ClusterType::METACLUSTER_DATA);
+			ASSERT(data.metaclusterRegistration.get().matches(managementData.metaclusterRegistration.get()));
+			ASSERT(data.metaclusterRegistration.get().name == clusterName);
+			ASSERT(data.metaclusterRegistration.get().id == clusterMetadata.entry.id);
 
-		if (data.tenantData.lastTenantId >= 0) {
-			ASSERT_EQ(TenantAPI::getTenantIdPrefix(data.tenantData.lastTenantId), managementData.tenantIdPrefix);
-			ASSERT_LE(data.tenantData.lastTenantId, managementData.tenantData.lastTenantId);
-		} else {
-			for (auto const& [id, tenant] : data.tenantData.tenantMap) {
-				ASSERT_NE(TenantAPI::getTenantIdPrefix(id), managementData.tenantIdPrefix);
+			if (data.tenantData.lastTenantId >= 0) {
+				ASSERT_EQ(TenantAPI::getTenantIdPrefix(data.tenantData.lastTenantId), managementData.tenantIdPrefix);
+				ASSERT_LE(data.tenantData.lastTenantId, managementData.tenantData.lastTenantId);
+			} else {
+				for (auto const& [id, tenant] : data.tenantData.tenantMap) {
+					ASSERT_NE(TenantAPI::getTenantIdPrefix(id), managementData.tenantIdPrefix);
+				}
 			}
-		}
 
-		std::set<int64_t> expectedTenants;
-		auto clusterTenantMapItr = managementData.clusterTenantMap.find(clusterName);
-		if (clusterTenantMapItr != managementData.clusterTenantMap.end()) {
-			expectedTenants = clusterTenantMapItr->second;
-		}
+			std::set<int64_t> expectedTenants;
+			auto clusterTenantMapItr = managementData.clusterTenantMap.find(clusterName);
+			if (clusterTenantMapItr != managementData.clusterTenantMap.end()) {
+				expectedTenants = clusterTenantMapItr->second;
+			}
 
-		std::set<TenantGroupName> tenantGroupsWithCompletedTenants;
-		if (!self->allowPartialMetaclusterOperations) {
-			ASSERT_EQ(data.tenantData.tenantMap.size(), expectedTenants.size());
-		} else {
-			ASSERT_LE(data.tenantData.tenantMap.size(), expectedTenants.size());
-			for (auto const& tenantId : expectedTenants) {
+			std::set<TenantGroupName> tenantGroupsWithCompletedTenants;
+			if (!self->allowPartialMetaclusterOperations) {
+				ASSERT_EQ(data.tenantData.tenantMap.size(), expectedTenants.size());
+			} else {
+				ASSERT_LE(data.tenantData.tenantMap.size(), expectedTenants.size());
+				for (auto const& tenantId : expectedTenants) {
+					auto tenantMapItr = managementData.tenantData.tenantMap.find(tenantId);
+					ASSERT(tenantMapItr != managementData.tenantData.tenantMap.end());
+					MetaclusterTenantMapEntry const& metaclusterEntry = tenantMapItr->second;
+					if (!data.tenantData.tenantMap.count(tenantId)) {
+						ASSERT(metaclusterEntry.tenantState == TenantState::REGISTERING ||
+						       metaclusterEntry.tenantState == TenantState::REMOVING ||
+						       metaclusterEntry.tenantState == TenantState::ERROR);
+					} else if (metaclusterEntry.tenantGroup.present()) {
+						tenantGroupsWithCompletedTenants.insert(metaclusterEntry.tenantGroup.get());
+					}
+				}
+			}
+
+			for (auto const& [tenantId, entry] : data.tenantData.tenantMap) {
+				ASSERT(expectedTenants.count(tenantId));
 				auto tenantMapItr = managementData.tenantData.tenantMap.find(tenantId);
 				ASSERT(tenantMapItr != managementData.tenantData.tenantMap.end());
 				MetaclusterTenantMapEntry const& metaclusterEntry = tenantMapItr->second;
-				if (!data.tenantData.tenantMap.count(tenantId)) {
-					ASSERT(metaclusterEntry.tenantState == TenantState::REGISTERING ||
-					       metaclusterEntry.tenantState == TenantState::REMOVING ||
-					       metaclusterEntry.tenantState == TenantState::ERROR);
-				} else if (metaclusterEntry.tenantGroup.present()) {
-					tenantGroupsWithCompletedTenants.insert(metaclusterEntry.tenantGroup.get());
+				ASSERT_EQ(entry.id, metaclusterEntry.id);
+
+				if (!self->allowPartialMetaclusterOperations) {
+					ASSERT_EQ(metaclusterEntry.tenantState, TenantState::READY);
+					ASSERT(entry.tenantName == metaclusterEntry.tenantName);
+				} else if (entry.tenantName != metaclusterEntry.tenantName) {
+					ASSERT(entry.tenantName == metaclusterEntry.renameDestination);
+				}
+				if (metaclusterEntry.tenantState != TenantState::UPDATING_CONFIGURATION &&
+				    metaclusterEntry.tenantState != TenantState::REMOVING) {
+					ASSERT_EQ(entry.configurationSequenceNum, metaclusterEntry.configurationSequenceNum);
+				} else {
+					ASSERT_LE(entry.configurationSequenceNum, metaclusterEntry.configurationSequenceNum);
+				}
+
+				if (entry.configurationSequenceNum == metaclusterEntry.configurationSequenceNum) {
+					ASSERT(entry.tenantGroup == metaclusterEntry.tenantGroup);
+					ASSERT_EQ(entry.tenantLockState, metaclusterEntry.tenantLockState);
+					ASSERT(entry.tenantLockId == metaclusterEntry.tenantLockId);
 				}
 			}
-		}
 
-		for (auto const& [tenantId, entry] : data.tenantData.tenantMap) {
-			ASSERT(expectedTenants.count(tenantId));
-			auto tenantMapItr = managementData.tenantData.tenantMap.find(tenantId);
-			ASSERT(tenantMapItr != managementData.tenantData.tenantMap.end());
-			MetaclusterTenantMapEntry const& metaclusterEntry = tenantMapItr->second;
-			ASSERT_EQ(entry.id, metaclusterEntry.id);
-
+			std::set<TenantGroupName> expectedTenantGroups;
+			auto clusterTenantGroupItr = managementData.clusterTenantGroupMap.find(clusterName);
+			if (clusterTenantGroupItr != managementData.clusterTenantGroupMap.end()) {
+				expectedTenantGroups = clusterTenantGroupItr->second;
+			}
 			if (!self->allowPartialMetaclusterOperations) {
-				ASSERT_EQ(metaclusterEntry.tenantState, TenantState::READY);
-				ASSERT(entry.tenantName == metaclusterEntry.tenantName);
-			} else if (entry.tenantName != metaclusterEntry.tenantName) {
-				ASSERT(entry.tenantName == metaclusterEntry.renameDestination);
-			}
-			if (metaclusterEntry.tenantState != TenantState::UPDATING_CONFIGURATION &&
-			    metaclusterEntry.tenantState != TenantState::REMOVING) {
-				ASSERT_EQ(entry.configurationSequenceNum, metaclusterEntry.configurationSequenceNum);
+				ASSERT_EQ(data.tenantData.tenantGroupMap.size(), expectedTenantGroups.size());
 			} else {
-				ASSERT_LE(entry.configurationSequenceNum, metaclusterEntry.configurationSequenceNum);
-			}
-
-			if (entry.configurationSequenceNum == metaclusterEntry.configurationSequenceNum) {
-				ASSERT(entry.tenantGroup == metaclusterEntry.tenantGroup);
-				ASSERT_EQ(entry.tenantLockState, metaclusterEntry.tenantLockState);
-				ASSERT(entry.tenantLockId == metaclusterEntry.tenantLockId);
-			}
-		}
-
-		std::set<TenantGroupName> expectedTenantGroups;
-		auto clusterTenantGroupItr = managementData.clusterTenantGroupMap.find(clusterName);
-		if (clusterTenantGroupItr != managementData.clusterTenantGroupMap.end()) {
-			expectedTenantGroups = clusterTenantGroupItr->second;
-		}
-		if (!self->allowPartialMetaclusterOperations) {
-			ASSERT_EQ(data.tenantData.tenantGroupMap.size(), expectedTenantGroups.size());
-		} else {
-			ASSERT_LE(data.tenantData.tenantGroupMap.size(), expectedTenantGroups.size());
-			for (auto const& name : expectedTenantGroups) {
-				if (!data.tenantData.tenantGroupMap.count(name)) {
-					auto itr = tenantGroupsWithCompletedTenants.find(name);
-					ASSERT(itr == tenantGroupsWithCompletedTenants.end());
+				ASSERT_LE(data.tenantData.tenantGroupMap.size(), expectedTenantGroups.size());
+				for (auto const& name : expectedTenantGroups) {
+					if (!data.tenantData.tenantGroupMap.count(name)) {
+						auto itr = tenantGroupsWithCompletedTenants.find(name);
+						ASSERT(itr == tenantGroupsWithCompletedTenants.end());
+					}
 				}
 			}
-		}
-		for (auto const& [name, entry] : data.tenantData.tenantGroupMap) {
-			ASSERT(expectedTenantGroups.count(name));
-			expectedTenantGroups.erase(name);
-		}
+			for (auto const& [name, entry] : data.tenantData.tenantGroupMap) {
+				ASSERT(expectedTenantGroups.count(name));
+				expectedTenantGroups.erase(name);
+			}
 
-		for (auto const& name : expectedTenantGroups) {
-			ASSERT(tenantGroupsWithCompletedTenants.count(name) == 0);
+			for (auto const& name : expectedTenantGroups) {
+				ASSERT(tenantGroupsWithCompletedTenants.count(name) == 0);
+			}
+		} catch (Error& e) {
+			TraceEvent(SevError, "MetaclusterConsistencyDataClusterValidationFailed")
+			    .error(e)
+			    .detail("ClusterName", clusterName);
+			ASSERT(false);
 		}
 
 		return Void();
@@ -291,7 +298,13 @@ private:
 		state TenantConsistencyCheck<DB, MetaclusterTenantTypes> managementTenantConsistencyCheck(
 		    self->managementDb, &metadata::management::tenantMetadata());
 
-		wait(managementTenantConsistencyCheck.run() && self->metaclusterData.load() && checkManagementSystemKeys(self));
+		try {
+			wait(managementTenantConsistencyCheck.run() && self->metaclusterData.load() &&
+			     checkManagementSystemKeys(self));
+		} catch (Error& e) {
+			TraceEvent(SevError, "MetaclusterConsistencyManagementClusterValidationFailed").error(e);
+			ASSERT(false);
+		}
 
 		self->validateManagementCluster();
 

--- a/metacluster/include/metacluster/MetaclusterData.actor.h
+++ b/metacluster/include/metacluster/MetaclusterData.actor.h
@@ -195,27 +195,32 @@ private:
 	ACTOR static Future<Void> loadDataClusterMetadata(MetaclusterData* self,
 	                                                  ClusterName clusterName,
 	                                                  ClusterConnectionString connectionString) {
-		state std::pair<typename std::map<ClusterName, DataClusterData>::iterator, bool> clusterItr =
-		    self->dataClusterMetadata.try_emplace(clusterName);
+		try {
+			state std::pair<typename std::map<ClusterName, DataClusterData>::iterator, bool> clusterItr =
+			    self->dataClusterMetadata.try_emplace(clusterName);
 
-		if (clusterItr.second) {
-			state Reference<IDatabase> dataDb = wait(openDatabase(connectionString));
-			state Reference<ITransaction> tr = dataDb->createTransaction();
+			if (clusterItr.second) {
+				state Reference<IDatabase> dataDb = wait(openDatabase(connectionString));
+				state Reference<ITransaction> tr = dataDb->createTransaction();
 
-			clusterItr.first->second.tenantData =
-			    TenantData<IDatabase, StandardTenantTypes>(dataDb, &TenantMetadata::instance());
-			loop {
-				try {
-					tr->setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
-					wait(store(clusterItr.first->second.metaclusterRegistration,
-					           metadata::metaclusterRegistration().get(tr)) &&
-					     clusterItr.first->second.tenantData.load(tr));
+				clusterItr.first->second.tenantData =
+				    TenantData<IDatabase, StandardTenantTypes>(dataDb, &TenantMetadata::instance());
+				loop {
+					try {
+						tr->setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
+						wait(store(clusterItr.first->second.metaclusterRegistration,
+						           metadata::metaclusterRegistration().get(tr)) &&
+						     clusterItr.first->second.tenantData.load(tr));
 
-					break;
-				} catch (Error& e) {
-					wait(safeThreadFutureToFuture(tr->onError(e)));
+						break;
+					} catch (Error& e) {
+						wait(safeThreadFutureToFuture(tr->onError(e)));
+					}
 				}
 			}
+		} catch (Error& e) {
+			TraceEvent(SevError, "LoadDataClusterError").error(e).detail("ClusterName", clusterName);
+			ASSERT(false);
 		}
 
 		return Void();

--- a/metacluster/include/metacluster/MetaclusterUtil.actor.h
+++ b/metacluster/include/metacluster/MetaclusterUtil.actor.h
@@ -27,6 +27,8 @@
 
 #include "fdbclient/CoordinationInterface.h"
 #include "fdbclient/FDBTypes.h"
+#include "fdbclient/IClientApi.h"
+#include "fdbclient/NativeAPI.actor.h"
 #include "flow/FastRef.h"
 #include "flow/IRandom.h"
 #include "flow/Platform.h"
@@ -37,6 +39,8 @@
 
 // This provide metacluster utility functions that may be used both internally and externally to the metacluster project
 namespace metacluster::util {
+
+FDB_BOOLEAN_PARAM(SkipMetaclusterCreation);
 
 // Helper function to compute metacluster capacity by passing the result of metacluster::listClusters
 std::pair<ClusterUsage, ClusterUsage> metaclusterCapacity(std::map<ClusterName, DataClusterMetadata> const& clusters);
@@ -49,6 +53,17 @@ Future<Reference<IDatabase>> getAndOpenDatabase(Transaction managementTr, Cluste
 	Reference<IDatabase> db = wait(openDatabase(clusterMetadata.connectionString));
 	return db;
 }
+
+struct SimulatedMetacluster {
+	Reference<IDatabase> managementDb;
+	std::map<ClusterName, Database> dataDbs;
+};
+
+ACTOR Future<SimulatedMetacluster> createSimulatedMetacluster(
+    Database db,
+    Optional<int64_t> tenantIdPrefix = Optional<int64_t>(),
+    Optional<DataClusterEntry> dataClusterConfig = DataClusterEntry(),
+    SkipMetaclusterCreation skipMetaclusterCreation = SkipMetaclusterCreation::False);
 
 } // namespace metacluster::util
 

--- a/metacluster/include/metacluster/TenantConsistency.actor.h
+++ b/metacluster/include/metacluster/TenantConsistency.actor.h
@@ -91,7 +91,7 @@ private:
 
 	// Specialization for MetaclusterTenantMapEntry, used on management clusters
 	void validateTenantMetadata(TenantData<DB, MetaclusterTenantTypes> tenantData) {
-		ASSERT(tenantData.clusterType == ClusterType::METACLUSTER_MANAGEMENT);
+		ASSERT_EQ(tenantData.clusterType, ClusterType::METACLUSTER_MANAGEMENT);
 		ASSERT_LE(tenantData.tenantMap.size(), metaclusterMaxTenants);
 
 		// Check metacluster specific properties


### PR DESCRIPTION
Cherry-pick #10057 

There are several workloads that need to create a metacluster, and this adds a function that can be called to help do that. This function is used in all workloads that create metaclusters except for the metacluster management workload, which will be changed in a subsequent PR.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
