### PR TITLE
Fix ConsistencyCheck_InvalidShardSize due to unfair split

### DIFF
--- a/fdbserver/ConsistencyScan.actor.cpp
+++ b/fdbserver/ConsistencyScan.actor.cpp
@@ -274,9 +274,11 @@ ACTOR Future<bool> getKeyLocations(Database cx,
 // Retrieves a vector of the storage servers' estimates for the size of a particular shard
 // If a storage server can't be reached, its estimate will be -1
 // If there is an error, then the returned vector will have 0 size
-ACTOR Future<std::vector<int64_t>> getStorageSizeEstimate(std::vector<StorageServerInterface> storageServers,
-                                                          KeyRangeRef shard) {
+ACTOR Future<std::pair<std::vector<int64_t>, StorageMetrics>> getStorageSizeEstimate(
+    std::vector<StorageServerInterface> storageServers,
+    KeyRangeRef shard) {
 	state std::vector<int64_t> estimatedBytes;
+	state StorageMetrics metrics;
 
 	state WaitMetricsRequest req;
 	req.keys = shard;
@@ -316,9 +318,10 @@ ACTOR Future<std::vector<int64_t>> getStorageSizeEstimate(std::vector<StorageSer
 			else if (reply.present()) {
 				int64_t numBytes = reply.get().bytes;
 				estimatedBytes.push_back(numBytes);
-				if (firstValidStorageServer < 0)
+				if (firstValidStorageServer < 0) {
 					firstValidStorageServer = i;
-				else if (estimatedBytes[firstValidStorageServer] != numBytes) {
+					metrics = reply.get();
+				} else if (estimatedBytes[firstValidStorageServer] != numBytes) {
 					TraceEvent("ConsistencyCheck_InconsistentStorageMetrics")
 					    .detail("ByteEstimate1", estimatedBytes[firstValidStorageServer])
 					    .detail("ByteEstimate2", numBytes)
@@ -340,7 +343,7 @@ ACTOR Future<std::vector<int64_t>> getStorageSizeEstimate(std::vector<StorageSer
 		estimatedBytes.clear();
 	}
 
-	return estimatedBytes;
+	return std::make_pair(estimatedBytes, metrics);
 }
 
 ACTOR Future<int64_t> getDatabaseSize(Database cx) {
@@ -562,7 +565,10 @@ ACTOR Future<Void> checkDataConsistency(Database cx,
 			}
 		}
 
-		state std::vector<int64_t> estimatedBytes = wait(getStorageSizeEstimate(storageServerInterfaces, range));
+		std::pair<std::vector<int64_t>, StorageMetrics> estimatedBytesAndMetrics =
+		    wait(getStorageSizeEstimate(storageServerInterfaces, range));
+		state std::vector<int64_t> estimatedBytes = estimatedBytesAndMetrics.first;
+		state StorageMetrics estimated = estimatedBytesAndMetrics.second;
 
 		// Gets permitted size range of shard
 		int64_t maxShardSize = getMaxShardSize(dbSize);
@@ -998,6 +1004,26 @@ ACTOR Future<Void> checkDataConsistency(Database cx,
 				            failureIsError);
 			}
 
+			// Check if the storage server returns split point for the shard. There are cases where
+			// the split point returned by storage server is discarded because it's an unfair split.
+			// See splitStorageMetrics() in NativeAPI.actor.cpp.
+			if (canSplit && sampledKeys > 5 && performQuiescentChecks) {
+				StorageMetrics splitMetrics;
+				splitMetrics.bytes = shardBounds.max.bytes / 2;
+				splitMetrics.bytesWrittenPerKSecond = range.begin >= keyServersKeys.begin
+				                                          ? splitMetrics.infinity
+				                                          : SERVER_KNOBS->SHARD_SPLIT_BYTES_PER_KSEC;
+				splitMetrics.iosPerKSecond = splitMetrics.infinity;
+				splitMetrics.bytesReadPerKSecond = splitMetrics.infinity; // Don't split by readBandwidth
+
+				Standalone<VectorRef<KeyRef>> splits = wait(cx->splitStorageMetrics(range, splitMetrics, estimated));
+				if (splits.size() <= 2) {
+					// Because the range's begin and end is included in splits, so this is the case
+					// the returned split is unfair and is discarded.
+					TraceEvent("ConsistencyCheck_DiscardSplits").detail("Range", range);
+					canSplit = false;
+				}
+			}
 			// In a quiescent database, check that the (estimated) size of the shard is within permitted bounds
 			// Min and max shard sizes have a 3 * shardBounds.permittedError.bytes cushion for error since shard
 			// sizes are not precise Shard splits ignore the first key in a shard, so its size shouldn't be


### PR DESCRIPTION
ConsistencyCheck thinks the shard is too large and should be split. However, it is possible that the split point returned by the Storage Server is discarded due to "unfair" sizes after the split. Fix this problem by checking if this is the case in ConsistencyCheck.

 20230427-215044-jzhou-a3e4bb4d97f3bd02

Reproduction:
- `-f ./tests/fast/FuzzApiCorrectness.toml -s 749622535 -b on`
- 7.1 Commit ID: d4ffd358d676869e144aff38565406291138021d
- gcc


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
