### PR TITLE
make status json report desired role count (log, resolver, proxies...… 

### DIFF
--- a/fdbclient/DatabaseConfiguration.cpp
+++ b/fdbclient/DatabaseConfiguration.cpp
@@ -255,6 +255,9 @@ bool DatabaseConfiguration::isValid() const {
 	return true;
 }
 
+// The database configuration is what we desired state of the cluster, which may be different from ongoing cluster
+// states. For example, the real count of roles, which is reported in each process, can differ from the desired role
+// count.
 StatusObject DatabaseConfiguration::toJSON(bool noPolicies) const {
 	StatusObject result;
 

--- a/fdbclient/DatabaseConfiguration.cpp
+++ b/fdbclient/DatabaseConfiguration.cpp
@@ -336,20 +336,12 @@ StatusObject DatabaseConfiguration::toJSON(bool noPolicies) const {
 
 	auto cpCount = getDesiredCommitProxies();
 	result["commit_proxies"] = cpCount;
-	// Add to the `proxies` count for backwards compatibility with tools built before 7.0.
-	int32_t proxyCount = cpCount;
 
 	auto grvCount = getDesiredGrvProxies();
 	result["grv_proxies"] = grvCount;
-	if (proxyCount != -1) {
-		proxyCount += grvCount;
-	} else {
-		proxyCount = grvCount;
-	}
 
-	if (proxyCount != -1) {
-		result["proxies"] = proxyCount;
-	}
+	// Add to the `proxies` count for backwards compatibility with tools built before 7.0.
+	result["proxies"] = cpCount + grvCount;
 
 	result["resolvers"] = getDesiredResolvers();
 

--- a/fdbclient/include/fdbclient/DatabaseConfiguration.h
+++ b/fdbclient/include/fdbclient/DatabaseConfiguration.h
@@ -269,6 +269,7 @@ struct DatabaseConfiguration {
 	std::set<AddressExclusion> getExcludedServers() const;
 	std::set<std::string> getExcludedLocalities() const;
 
+	// report auto value or configured value
 	int32_t getDesiredCommitProxies() const {
 		if (commitProxyCount == -1)
 			return autoCommitProxyCount;


### PR DESCRIPTION
…) regardless of whether the user sets it explicitly. If the existing process count is not enough for the default configuration, we can detect that.
Note: The change is not in Apple branch in case the cluster monitor tool use different semantic meaning.

Configured values for

- grv_proxies
- commit_proxies
- resolvers
- logs

are reported in status json in the cluster.configuration section.

Default values are not reported if they have never been changed manually and are defaulting to a value determined by fdb.

This should be changed to report default values in the status json, so efdb can properly import the current state of the role counts. This can be especially problematic if the default on fdb side where to change since we have no way of learning about it.

Manually fdbcli test:
```
"configuration" : { 
             "backup_worker_enabled" : 0,
             "blob_granules_enabled" : 0,
             "commit_proxies" : 3,
             "coordinators_count" : 1,
             "encryption_at_rest_mode" : "disabled",
             "excluded_servers" : [ 
             ],  
             "grv_proxies" : 1,
             "log_engine" : "ssd-2",
             "log_spill" : 2,
             "logs" : 3,
             "perpetual_storage_wiggle" : 0,
             "perpetual_storage_wiggle_locality" : "0",
             "proxies" : 4,
             "redundancy_mode" : "single",
             "resolvers" : 1,
             "storage_engine" : "ssd-2",
             "storage_migration_type" : "disabled",
             "tenant_mode" : "disabled",
             "usable_regions" : 1 
         },  
```
# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
