### PR TITLE
Fix commit location accounting in DiskQueue.

### DIFF
--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -2296,6 +2296,12 @@ ACTOR Future<Void> commitQueue(TLogData* self) {
 		}
 
 		loop {
+			// Insert enough of a delay to allow this tlog to be stopped and a new one registered
+			// before the commit is issued. These are the conditions which trigger a missingFinalCommit.
+			if (g_network->isSimulated() && !g_simulator->speedUpSimulation && BUGGIFY) {
+				wait(delay(1.0));
+			}
+
 			if (logData->stopped() && logData->version.get() == std::max(logData->queueCommittingVersion,
 			                                                             logData->queueCommittedVersion.get())) {
 				wait(logData->queueCommittedVersion.whenAtLeast(logData->version.get()));

--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -2298,7 +2298,7 @@ ACTOR Future<Void> commitQueue(TLogData* self) {
 		loop {
 			// Insert enough of a delay to allow this tlog to be stopped and a new one registered
 			// before the commit is issued. These are the conditions which trigger a missingFinalCommit.
-			if (g_network->isSimulated() && !g_simulator->speedUpSimulation && BUGGIFY) {
+			if (BUGGIFY_WITH_PROB(0.0001) && !g_simulator->speedUpSimulation) {
 				wait(delay(1.0));
 			}
 

--- a/fdbserver/include/fdbserver/IDiskQueue.h
+++ b/fdbserver/include/fdbserver/IDiskQueue.h
@@ -76,8 +76,6 @@ public:
 	virtual location getNextReadLocation()
 	    const = 0; // Returns a location >= the location of all bytes previously returned by readNext(), and <= the
 	               // location of all bytes subsequently returned
-	virtual location getNextCommitLocation()
-	    const = 0; // If commit() were to be called, all buffered writes would be written starting at `location`.
 	virtual location getNextPushLocation()
 	    const = 0; // If push() were to be called, the pushed data would be written starting at `location`.
 

--- a/fdbserver/include/fdbserver/LogSystemDiskQueueAdapter.h
+++ b/fdbserver/include/fdbserver/LogSystemDiskQueueAdapter.h
@@ -97,10 +97,6 @@ public:
 	Future<bool> initializeRecovery(location recoverAt) override { return false; }
 	Future<Standalone<StringRef>> readNext(int bytes) override;
 	IDiskQueue::location getNextReadLocation() const override;
-	IDiskQueue::location getNextCommitLocation() const override {
-		ASSERT(false);
-		throw internal_error();
-	}
 	IDiskQueue::location getNextPushLocation() const override {
 		ASSERT(false);
 		throw internal_error();


### PR DESCRIPTION
We encountered a situation in simulation where the disk queue was in the following state

    +------------+------------+
    | page 1     | page 2     |
    +------------+------------+
    |rec |.......|rec |.......|
    +------------+------------+
    0..85        4096..4181
    ^.   ^__             ^
    popped. committed    pushed

and we attempted to pop up to 4096, i.e. everything before page 2. This triggered one of the assertions in the disk queue code which was meant to catch tlog logic bugs where we pop too much.

The issue, though, is the accounting of the commit location in the disk queue. While we only pushed records through posiiton 85, we committed the entire page. Attempts to pop everything before page 2 should have succeeded since we're not attempting to pop any uncommitted data.

The solution is to fix the commit location accounting in the disk queue to round up to the next page, to reflect the reality that we only commit entire pages.

This bug was discovered in the first place by introducing a delay into the commit queue loop during simulation testing. That delay is included in this change.

We also noticed that getNextCommitLocation() was incorrect. Since there are no users of that function, we've removed it entirely.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
