### PR TITLE
Downgrade "inaccurate shard estimate" consistency check to warning, not test failure.

### DIFF
--- a/fdbserver/ConsistencyScan.actor.cpp
+++ b/fdbserver/ConsistencyScan.actor.cpp
@@ -992,10 +992,12 @@ ACTOR Future<Void> checkDataConsistency(Database cx,
 				    .detail("NumSampledKeys", sampledKeys)
 				    .detail("NumSampledKeysWithProb", sampledKeysWithProb);
 
+				// NOTE: Shard sampling is known to be biased.
+				// Downgrade this to a warning until we have a proper solution.
 				testFailure(format("Shard size is more than %f std dev from estimate", failErrorNumStdDev),
 				            performQuiescentChecks,
 				            success,
-				            failureIsError);
+				            /*failureIsError*/ false);
 			}
 
 			// In a quiescent database, check that the (estimated) size of the shard is within permitted bounds

--- a/fdbserver/ConsistencyScan.actor.cpp
+++ b/fdbserver/ConsistencyScan.actor.cpp
@@ -978,7 +978,7 @@ ACTOR Future<Void> checkDataConsistency(Database cx,
 			// normal distribution
 			if (sampledKeysWithProb > 30 && estimateError > failErrorNumStdDev * stdDev) {
 				double numStdDev = estimateError / sqrt(shardVariance);
-				TraceEvent("ConsistencyCheck_InaccurateShardEstimate")
+				TraceEvent(SevWarn, "ConsistencyCheck_InaccurateShardEstimate")
 				    .detail("Min", shardBounds.min.bytes)
 				    .detail("Max", shardBounds.max.bytes)
 				    .detail("Estimate", sampledBytes)
@@ -993,11 +993,12 @@ ACTOR Future<Void> checkDataConsistency(Database cx,
 				    .detail("NumSampledKeysWithProb", sampledKeysWithProb);
 
 				// NOTE: Shard sampling is known to be biased.
-				// Downgrade this to a warning until we have a proper solution.
-				testFailure(format("Shard size is more than %f std dev from estimate", failErrorNumStdDev),
-				            performQuiescentChecks,
-				            success,
-				            /*failureIsError*/ false);
+				// Disable this test failure until we have a proper solution.
+				//
+				// testFailure(format("Shard size is more than %f std dev from estimate", failErrorNumStdDev),
+				//             performQuiescentChecks,
+				//             success,
+				//             false);
 			}
 
 			// In a quiescent database, check that the (estimated) size of the shard is within permitted bounds


### PR DESCRIPTION
We know that the hash function used for sampling keys is biased and oversamples.
The fix is non-trivial, since we can't straightforwardly change the sampling function
for existing FDB databases. Thus, we downgrade this particular test failure to a warning.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
