### PR TITLE
Add a metacluster version to the MetaclusterRegistrationEntry and validate it when loading the entry (snowflake/release-71.3)

### DIFF
--- a/documentation/sphinx/source/mr-status-json-schemas.rst.inc
+++ b/documentation/sphinx/source/mr-status-json-schemas.rst.inc
@@ -529,7 +529,8 @@
                   "primary_dc_missing",
                   "fetch_primary_dc_timeout",
                   "fetch_storage_wiggler_stats_timeout",
-                  "fetch_consistency_scan_info_timeout"
+                  "fetch_consistency_scan_info_timeout",
+                  "metacluster_metrics_missing"
                ]
             },
             "issues":[

--- a/fdbclient/MetaclusterRegistration.cpp
+++ b/fdbclient/MetaclusterRegistration.cpp
@@ -32,9 +32,17 @@ std::string clusterTypeToString(const ClusterType& clusterType) {
 		return "unknown";
 	}
 }
+
 KeyBackedObjectProperty<MetaclusterRegistrationEntry, decltype(IncludeVersion())>&
 metacluster::metadata::metaclusterRegistration() {
 	static KeyBackedObjectProperty<MetaclusterRegistrationEntry, decltype(IncludeVersion())> instance(
+	    "\xff/metacluster/clusterRegistration"_sr, IncludeVersion());
+	return instance;
+}
+
+KeyBackedObjectProperty<UnversionedMetaclusterRegistrationEntry, decltype(IncludeVersion())>&
+metacluster::metadata::unversionedMetaclusterRegistration() {
+	static KeyBackedObjectProperty<UnversionedMetaclusterRegistrationEntry, decltype(IncludeVersion())> instance(
 	    "\xff/metacluster/clusterRegistration"_sr, IncludeVersion());
 	return instance;
 }

--- a/fdbclient/Schemas.cpp
+++ b/fdbclient/Schemas.cpp
@@ -583,7 +583,8 @@ const KeyRef JSONSchemas::statusSchema = R"statusSchema(
                   "primary_dc_missing",
                   "fetch_primary_dc_timeout",
                   "fetch_storage_wiggler_stats_timeout",
-                  "fetch_consistency_scan_info_timeout"
+                  "fetch_consistency_scan_info_timeout",
+                  "metacluster_metrics_missing"
                ]
             },
             "issues":[

--- a/fdbclient/include/fdbclient/MetaclusterRegistration.h
+++ b/fdbclient/include/fdbclient/MetaclusterRegistration.h
@@ -28,8 +28,32 @@
 
 std::string clusterTypeToString(const ClusterType& clusterType);
 
-struct MetaclusterRegistrationEntry {
+enum class MetaclusterVersion {
+	// Smaller than any legal version; used for testing
+	BEGIN = 0,
+
+	// This is the smallest version of metacluster metadata understood by this version of FDB. It should be updated any
+	// time support for older versions is dropped. Our contract is that we will support at least one older version, but
+	// likely we will stop supporting versions older than that.
+	MIN_SUPPORTED = 1,
+
+	// The initial version used for metacluster metadata
+	V1 = 1,
+
+	// This is the largest version of metacluster metadata understood by this version of FDB. It should be increased any
+	// time an FDB version adds a new metacluster version.
+	MAX_SUPPORTED = 1,
+
+	// Larger than any legal version; used for testing
+	END
+};
+
+template <bool Versioned>
+struct MetaclusterRegistrationEntryImpl {
 	constexpr static FileIdentifier file_identifier = 13448589;
+
+	// Set to true to allow tests to write metacluster registrations that are invalid
+	static inline bool allowUnsupportedRegistrationWrites = false;
 
 	ClusterType clusterType;
 
@@ -38,20 +62,31 @@ struct MetaclusterRegistrationEntry {
 	UID metaclusterId;
 	UID id;
 
-	MetaclusterRegistrationEntry() = default;
-	MetaclusterRegistrationEntry(ClusterName metaclusterName, UID metaclusterId)
+	MetaclusterVersion version;
+
+	MetaclusterRegistrationEntryImpl() = default;
+	MetaclusterRegistrationEntryImpl(ClusterName metaclusterName, UID metaclusterId, MetaclusterVersion version)
 	  : clusterType(ClusterType::METACLUSTER_MANAGEMENT), metaclusterName(metaclusterName), name(metaclusterName),
-	    metaclusterId(metaclusterId), id(metaclusterId) {}
-	MetaclusterRegistrationEntry(ClusterName metaclusterName, ClusterName name, UID metaclusterId, UID id)
+	    metaclusterId(metaclusterId), id(metaclusterId), version(version) {}
+	MetaclusterRegistrationEntryImpl(ClusterName metaclusterName,
+	                                 ClusterName name,
+	                                 UID metaclusterId,
+	                                 UID id,
+	                                 MetaclusterVersion version)
 	  : clusterType(ClusterType::METACLUSTER_DATA), metaclusterName(metaclusterName), name(name),
-	    metaclusterId(metaclusterId), id(id) {
+	    metaclusterId(metaclusterId), id(id), version(version) {
 		ASSERT(metaclusterName != name && metaclusterId != id);
 	}
+
+	template <bool V>
+	MetaclusterRegistrationEntryImpl(MetaclusterRegistrationEntryImpl<V> other)
+	  : clusterType(other.clusterType), metaclusterName(other.metaclusterName), name(other.name),
+	    metaclusterId(other.metaclusterId), id(other.id), version(other.version) {}
 
 	// Returns true if this entry is associated with the same cluster as the passed in entry. If one entry is from the
 	// management cluster and the other is from a data cluster, this checks whether they are part of the same
 	// metacluster.
-	bool matches(MetaclusterRegistrationEntry const& other) const {
+	bool matches(MetaclusterRegistrationEntryImpl const& other) const {
 		if (metaclusterName != other.metaclusterName || metaclusterId != other.metaclusterId) {
 			return false;
 		} else if (clusterType == ClusterType::METACLUSTER_DATA && other.clusterType == ClusterType::METACLUSTER_DATA &&
@@ -62,58 +97,81 @@ struct MetaclusterRegistrationEntry {
 		return true;
 	}
 
-	MetaclusterRegistrationEntry toManagementClusterRegistration() const {
+	MetaclusterRegistrationEntryImpl toManagementClusterRegistration() const {
 		ASSERT(clusterType == ClusterType::METACLUSTER_DATA);
-		return MetaclusterRegistrationEntry(metaclusterName, metaclusterId);
+		return MetaclusterRegistrationEntryImpl(metaclusterName, metaclusterId, version);
 	}
 
-	MetaclusterRegistrationEntry toDataClusterRegistration(ClusterName name, UID id) const {
+	MetaclusterRegistrationEntryImpl toDataClusterRegistration(ClusterName name, UID id) const {
 		ASSERT(clusterType == ClusterType::METACLUSTER_MANAGEMENT);
-		return MetaclusterRegistrationEntry(metaclusterName, name, metaclusterId, id);
+		return MetaclusterRegistrationEntryImpl(metaclusterName, name, metaclusterId, id, version);
 	}
 
 	Value encode() const { return ObjectWriter::toValue(*this, IncludeVersion()); }
-	static MetaclusterRegistrationEntry decode(ValueRef const& value) {
-		return ObjectReader::fromStringRef<MetaclusterRegistrationEntry>(value, IncludeVersion());
+	static MetaclusterRegistrationEntryImpl decode(ValueRef const& value) {
+		return ObjectReader::fromStringRef<MetaclusterRegistrationEntryImpl>(value, IncludeVersion());
 	}
-	static Optional<MetaclusterRegistrationEntry> decode(Optional<Value> value) {
-		return value.map([](ValueRef const& v) { return MetaclusterRegistrationEntry::decode(v); });
+	static Optional<MetaclusterRegistrationEntryImpl> decode(Optional<Value> value) {
+		return value.map([](ValueRef const& v) { return MetaclusterRegistrationEntryImpl::decode(v); });
 	}
 
 	std::string toString() const {
 		if (clusterType == ClusterType::METACLUSTER_MANAGEMENT) {
-			return fmt::format(
-			    "metacluster name: {}, metacluster id: {}", printable(metaclusterName), metaclusterId.shortString());
-		} else {
-			return fmt::format("metacluster name: {}, metacluster id: {}, data cluster name: {}, data cluster id: {}",
+			return fmt::format("metacluster name: {}, metacluster id: {}, version: {}",
 			                   printable(metaclusterName),
 			                   metaclusterId.shortString(),
-			                   printable(name),
-			                   id.shortString());
+			                   (int)version);
+		} else {
+			return fmt::format(
+			    "metacluster name: {}, metacluster id: {}, data cluster name: {}, data cluster id: {}, version: {}",
+			    printable(metaclusterName),
+			    metaclusterId.shortString(),
+			    printable(name),
+			    id.shortString(),
+			    (int)version);
 		}
 	}
 
-	bool operator==(MetaclusterRegistrationEntry const& other) const {
+	template <bool V>
+	bool operator==(MetaclusterRegistrationEntryImpl<V> const& other) const {
 		return clusterType == other.clusterType && metaclusterName == other.metaclusterName && name == other.name &&
-		       metaclusterId == other.metaclusterId && id == other.id;
+		       metaclusterId == other.metaclusterId && id == other.id && version == other.version;
 	}
 
-	bool operator!=(MetaclusterRegistrationEntry const& other) const { return !(*this == other); }
+	template <bool V>
+	bool operator!=(MetaclusterRegistrationEntryImpl<V> const& other) const {
+		return !(*this == other);
+	}
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, clusterType, metaclusterName, name, metaclusterId, id);
+		serializer(ar, clusterType, metaclusterName, name, metaclusterId, id, version);
+		if constexpr (Ar::isDeserializing && Versioned) {
+			if (version < MetaclusterVersion::MIN_SUPPORTED || version > MetaclusterVersion::MAX_SUPPORTED) {
+				throw unsupported_metacluster_version();
+			}
+		}
 	}
 };
 
-template <>
-struct Traceable<MetaclusterRegistrationEntry> : std::true_type {
-	static std::string toString(MetaclusterRegistrationEntry const& entry) { return entry.toString(); }
+template <bool Versioned>
+struct Traceable<MetaclusterRegistrationEntryImpl<Versioned>> : std::true_type {
+	static std::string toString(MetaclusterRegistrationEntryImpl<Versioned> const& entry) { return entry.toString(); }
 };
+
+using MetaclusterRegistrationEntry = MetaclusterRegistrationEntryImpl<true>;
+using UnversionedMetaclusterRegistrationEntry = MetaclusterRegistrationEntryImpl<false>;
 
 // Registration information for a metacluster, stored on both management and data clusters
 namespace metacluster::metadata {
+// Use of this metacluster registration property will verify that the metacluster registration has a compatible version
+// before using it. This should be the default choice for accessing the metacluster registration.
 KeyBackedObjectProperty<MetaclusterRegistrationEntry, decltype(IncludeVersion())>& metaclusterRegistration();
+
+// Use of this metacluster registration property will not verify that the metacluster registration has a compatible
+// version. It should only be used in limited circumstances.
+KeyBackedObjectProperty<UnversionedMetaclusterRegistrationEntry, decltype(IncludeVersion())>&
+unversionedMetaclusterRegistration();
 }; // namespace metacluster::metadata
 
 #endif

--- a/fdbserver/ApplyMetadataMutation.cpp
+++ b/fdbserver/ApplyMetadataMutation.cpp
@@ -747,19 +747,30 @@ private:
 		}
 	}
 
+	template <bool Versioned>
+	void reportMetaclusterRegistration(ValueRef value) {
+		MetaclusterRegistrationEntryImpl<Versioned> entry = MetaclusterRegistrationEntryImpl<Versioned>::decode(value);
+
+		TraceEvent("SetMetaclusterRegistration", dbgid)
+		    .detail("ClusterType", entry.clusterType)
+		    .detail("MetaclusterID", entry.metaclusterId)
+		    .detail("MetaclusterName", entry.metaclusterName)
+		    .detail("ClusterID", entry.id)
+		    .detail("ClusterName", entry.name)
+		    .detail("MetaclusterVersion", entry.version);
+	}
+
 	void checkSetMetaclusterRegistration(MutationRef m) {
 		if (m.param1 == metacluster::metadata::metaclusterRegistration().key) {
-			MetaclusterRegistrationEntry entry = MetaclusterRegistrationEntry::decode(m.param2);
-
-			TraceEvent("SetMetaclusterRegistration", dbgid)
-			    .detail("ClusterType", entry.clusterType)
-			    .detail("MetaclusterID", entry.metaclusterId)
-			    .detail("MetaclusterName", entry.metaclusterName)
-			    .detail("ClusterID", entry.id)
-			    .detail("ClusterName", entry.name);
+			if (MetaclusterRegistrationEntry::allowUnsupportedRegistrationWrites) {
+				reportMetaclusterRegistration<false>(m.param2);
+			} else {
+				CODE_PROBE(true, "Writing metacluster registration with version validation");
+				reportMetaclusterRegistration<true>(m.param2);
+			}
 
 			Optional<Value> value =
-			    txnStateStore->readValue(metacluster::metadata::metaclusterRegistration().key).get();
+			    txnStateStore->readValue(metacluster::metadata::unversionedMetaclusterRegistration().key).get();
 			if (!initialCommit) {
 				txnStateStore->set(KeyValueRef(m.param1, m.param2));
 			}

--- a/fdbserver/ClusterRecovery.actor.cpp
+++ b/fdbserver/ClusterRecovery.actor.cpp
@@ -1199,8 +1199,8 @@ ACTOR Future<Void> readTransactionSystemState(Reference<ClusterRecoveryData> sel
 
 	Optional<Value> metaclusterRegistrationVal =
 	    wait(self->txnStateStore->readValue(metacluster::metadata::metaclusterRegistration().key));
-	Optional<MetaclusterRegistrationEntry> metaclusterRegistration =
-	    MetaclusterRegistrationEntry::decode(metaclusterRegistrationVal);
+	Optional<UnversionedMetaclusterRegistrationEntry> metaclusterRegistration =
+	    UnversionedMetaclusterRegistrationEntry::decode(metaclusterRegistrationVal);
 	Optional<ClusterName> metaclusterName;
 	Optional<UID> metaclusterId;
 	Optional<ClusterName> clusterName;

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -3042,7 +3042,7 @@ ACTOR Future<StatusReply> clusterGetStatus(
     std::vector<NetworkAddress> incompatibleConnections,
     Version datacenterVersionDifference,
     ConfigBroadcaster const* configBroadcaster,
-    Optional<MetaclusterRegistrationEntry> metaclusterRegistration,
+    Optional<UnversionedMetaclusterRegistrationEntry> metaclusterRegistration,
     metacluster::MetaclusterMetrics metaclusterMetrics) {
 	state double tStart = timer();
 
@@ -3389,12 +3389,18 @@ ACTOR Future<StatusReply> clusterGetStatus(
 				if (metaclusterRegistration.get().clusterType == ClusterType::METACLUSTER_DATA) {
 					metacluster["data_cluster_name"] = metaclusterRegistration.get().name;
 					metacluster["data_cluster_id"] = metaclusterRegistration.get().id.toString();
-				} else { // clusterType == ClusterType::METACLUSTER_MANAGEMENT
+				} else if (!metaclusterMetrics.error.present()) { // clusterType == ClusterType::METACLUSTER_MANAGEMENT
 					metacluster["num_data_clusters"] = metaclusterMetrics.numDataClusters;
 					tenants["num_tenants"] = metaclusterMetrics.numTenants;
 					tenants["tenant_group_capacity"] = metaclusterMetrics.tenantGroupCapacity;
 					tenants["tenant_groups_allocated"] = metaclusterMetrics.tenantGroupsAllocated;
+				} else {
+					messages.push_back(JsonString::makeMessage(
+					    "metacluster_metrics_missing",
+					    fmt::format("Failed to fetch metacluster metrics: {}.", metaclusterMetrics.error.get())
+					        .c_str()));
 				}
+
 			} else {
 				metacluster["cluster_type"] = clusterTypeToString(ClusterType::STANDALONE);
 			}

--- a/fdbserver/include/fdbserver/ClusterController.actor.h
+++ b/fdbserver/include/fdbserver/ClusterController.actor.h
@@ -149,7 +149,7 @@ public:
 		AsyncVar<bool> blobRestoreEnabled;
 		ClusterType clusterType = ClusterType::STANDALONE;
 		Optional<ClusterName> metaclusterName;
-		Optional<MetaclusterRegistrationEntry> metaclusterRegistration;
+		Optional<UnversionedMetaclusterRegistrationEntry> metaclusterRegistration;
 		metacluster::MetaclusterMetrics metaclusterMetrics;
 
 		DBInfo()

--- a/fdbserver/include/fdbserver/Status.actor.h
+++ b/fdbserver/include/fdbserver/Status.actor.h
@@ -53,7 +53,7 @@ Future<StatusReply> clusterGetStatus(
     std::vector<NetworkAddress> const& incompatibleConnections,
     Version const& datacenterVersionDifference,
     ConfigBroadcaster const* const& conifgBroadcaster,
-    Optional<MetaclusterRegistrationEntry> const& metaclusterRegistration,
+    Optional<UnversionedMetaclusterRegistrationEntry> const& metaclusterRegistration,
     metacluster::MetaclusterMetrics const& metaclusterMetrics);
 
 struct WorkerEvents : std::map<NetworkAddress, TraceEventFields> {};

--- a/fdbserver/workloads/TenantManagementWorkload.actor.cpp
+++ b/fdbserver/workloads/TenantManagementWorkload.actor.cpp
@@ -260,8 +260,8 @@ struct TenantManagementWorkload : TestWorkload {
 		self->mvDb = simMetacluster.managementDb;
 
 		if (self->useMetacluster) {
-			self->dataClusterName = simMetacluster.dataDbs.begin()->first;
 			ASSERT_EQ(simMetacluster.dataDbs.size(), 1);
+			self->dataClusterName = simMetacluster.dataDbs.begin()->first;
 			self->dataDb = simMetacluster.dataDbs.begin()->second;
 		} else {
 			self->dataDb = cx;

--- a/flow/include/flow/error_definitions.h
+++ b/flow/include/flow/error_definitions.h
@@ -282,6 +282,7 @@ ERROR( invalid_data_cluster, 2171, "The data cluster being restored has no recor
 ERROR( metacluster_mismatch, 2172, "The cluster does not have the expected name or is associated with a different metacluster" )
 ERROR( conflicting_restore, 2173, "Another restore is running for the same data cluster" )
 ERROR( invalid_metacluster_configuration, 2174, "Metacluster configuration is invalid" )
+ERROR( unsupported_metacluster_version, 2175, "Client is not compatible with the metacluster" )
 
 // 2200 - errors from bindings and official APIs
 ERROR( api_version_unset, 2200, "API version is not set" )

--- a/metacluster/MetaclusterMetrics.actor.cpp
+++ b/metacluster/MetaclusterMetrics.actor.cpp
@@ -57,6 +57,13 @@ ACTOR Future<MetaclusterMetrics> getMetaclusterMetricsImpl(Database db) {
 			return metrics;
 		} catch (Error& e) {
 			TraceEvent("MetaclusterUpdaterError").error(e);
+			if (e.code() == error_code_unsupported_metacluster_version) {
+				TraceEvent(SevWarnAlways, "MetaclusterMetricsFailure").error(e);
+				MetaclusterMetrics metrics;
+				metrics.error = e.what();
+				return metrics;
+			}
+
 			wait(tr->onError(e));
 		}
 	}

--- a/metacluster/include/metacluster/CreateMetacluster.actor.h
+++ b/metacluster/include/metacluster/CreateMetacluster.actor.h
@@ -99,7 +99,8 @@ Future<Optional<std::string>> createMetacluster(Reference<DB> db,
 				metaclusterUid = deterministicRandom()->randomUniqueID();
 			}
 
-			metadata::metaclusterRegistration().set(tr, MetaclusterRegistrationEntry(name, metaclusterUid.get()));
+			metadata::metaclusterRegistration().set(
+			    tr, MetaclusterRegistrationEntry(name, metaclusterUid.get(), MetaclusterVersion::V1));
 
 			TenantMetadata::tenantIdPrefix().set(tr, tenantIdPrefix);
 

--- a/metacluster/include/metacluster/MetaclusterConsistency.actor.h
+++ b/metacluster/include/metacluster/MetaclusterConsistency.actor.h
@@ -80,6 +80,9 @@ private:
 		ASSERT_EQ(data.metaclusterRegistration.get().clusterType, ClusterType::METACLUSTER_MANAGEMENT);
 		ASSERT(data.metaclusterRegistration.get().id == data.metaclusterRegistration.get().metaclusterId &&
 		       data.metaclusterRegistration.get().name == data.metaclusterRegistration.get().metaclusterName);
+		ASSERT_GE(data.metaclusterRegistration.get().version, MetaclusterVersion::MIN_SUPPORTED);
+		ASSERT_LE(data.metaclusterRegistration.get().version, MetaclusterVersion::MAX_SUPPORTED);
+
 		ASSERT_LE(data.dataClusters.size(), CLIENT_KNOBS->MAX_DATA_CLUSTERS);
 		ASSERT_LE(data.tenantData.tenantCount, metaclusterMaxTenants);
 		ASSERT(data.clusterTenantCounts.results.size() <= data.dataClusters.size() && !data.clusterTenantCounts.more);
@@ -198,6 +201,9 @@ private:
 			ASSERT(data.metaclusterRegistration.get().matches(managementData.metaclusterRegistration.get()));
 			ASSERT(data.metaclusterRegistration.get().name == clusterName);
 			ASSERT(data.metaclusterRegistration.get().id == clusterMetadata.entry.id);
+			ASSERT_GE(data.metaclusterRegistration.get().version, MetaclusterVersion::MIN_SUPPORTED);
+			ASSERT_LE(data.metaclusterRegistration.get().version, MetaclusterVersion::MAX_SUPPORTED);
+			ASSERT_EQ(data.metaclusterRegistration.get().version, managementData.metaclusterRegistration.get().version);
 
 			if (data.tenantData.lastTenantId >= 0) {
 				ASSERT_EQ(TenantAPI::getTenantIdPrefix(data.tenantData.lastTenantId), managementData.tenantIdPrefix);

--- a/metacluster/include/metacluster/MetaclusterMetrics.h
+++ b/metacluster/include/metacluster/MetaclusterMetrics.h
@@ -32,6 +32,8 @@ struct MetaclusterMetrics {
 	int tenantGroupCapacity = 0;
 	int tenantGroupsAllocated = 0;
 
+	Optional<std::string> error;
+
 	MetaclusterMetrics() = default;
 
 	static Future<MetaclusterMetrics> getMetaclusterMetrics(Database db);


### PR DESCRIPTION
Cherry picks #10047 

This add a version field to MetaclusterRegistrationEntry and enforces that the version be a legal version when performing metacluster operations. This will help to prevent an old version of an FDB client from modifying metacluster state if the metadata format has changed.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
