### PR TITLE
Decorate TLS handshake errors with peerAddr

### DIFF
--- a/flow/Net2.actor.cpp
+++ b/flow/Net2.actor.cpp
@@ -28,6 +28,7 @@
 #include "flow/swift_concurrency_hooks.h"
 #include <algorithm>
 #include <memory>
+#include <string_view>
 #ifndef BOOST_SYSTEM_NO_LIB
 #define BOOST_SYSTEM_NO_LIB
 #endif
@@ -816,10 +817,7 @@ struct SSLHandshakerThread final : IThreadPoolReceiver {
 			std::ostringstream o;
 			boost::system::error_code ec;
 			auto addr = socket.lowest_layer().remote_endpoint(ec);
-			if (ec.failed()) {
-				o << "invalidEndpoint";
-			}
-			o << addr;
+			o << (!ec.failed() ? addr.address().to_string() : std::string_view("0.0.0.0"));
 			return std::move(o).str();
 		}
 

--- a/flow/Net2.actor.cpp
+++ b/flow/Net2.actor.cpp
@@ -922,7 +922,7 @@ public:
 				N2::g_net2->sslHandshakerPool->post(handshake);
 			} else {
 				// Otherwise use flow network thread
-				BindPromise p("N2_AcceptHandshakeError"_audit, UID());
+				BindPromise p("N2_AcceptHandshakeError"_audit, self->id);
 				onHandshook = p.getFuture();
 				self->ssl_sock.async_handshake(boost::asio::ssl::stream_base::server, std::move(p));
 			}

--- a/flow/Net2.actor.cpp
+++ b/flow/Net2.actor.cpp
@@ -354,14 +354,20 @@ class BindPromise {
 	Promise<Void> p;
 	std::variant<const char*, AuditedEvent> errContext;
 	UID errID;
+	NetworkAddress peerAddr;
 
 public:
 	BindPromise(const char* errContext, UID errID) : errContext(errContext), errID(errID) {}
 	BindPromise(AuditedEvent auditedEvent, UID errID) : errContext(auditedEvent), errID(errID) {}
-	BindPromise(BindPromise const& r) : p(r.p), errContext(r.errContext), errID(r.errID) {}
-	BindPromise(BindPromise&& r) noexcept : p(std::move(r.p)), errContext(r.errContext), errID(r.errID) {}
+	BindPromise(BindPromise const& r) : p(r.p), errContext(r.errContext), errID(r.errID), peerAddr(r.peerAddr) {}
+	BindPromise(BindPromise&& r) noexcept
+	  : p(std::move(r.p)), errContext(r.errContext), errID(r.errID), peerAddr(r.peerAddr) {}
 
 	Future<Void> getFuture() const { return p.getFuture(); }
+
+	NetworkAddress getPeerAddr() const { return peerAddr; }
+
+	void setPeerAddr(const NetworkAddress& addr) { peerAddr = addr; }
 
 	void operator()(const boost::system::error_code& error, size_t bytesWritten = 0) {
 		try {
@@ -380,6 +386,10 @@ public:
 					// error codes should never go that high.
 					if (error.value() >= (1 << 24L)) {
 						evt.detail("WhichMeans", TLSPolicy::ErrorString(error));
+					}
+
+					if (peerAddr.isValid()) {
+						evt.detail("PeerAddr", peerAddr);
 					}
 				}
 
@@ -802,6 +812,17 @@ struct SSLHandshakerThread final : IThreadPoolReceiver {
 		Handshake(ssl_socket& socket, ssl_socket::handshake_type type) : socket(socket), type(type) {}
 		double getTimeEstimate() const override { return 0.001; }
 
+		std::string getPeerAddress() const {
+			std::ostringstream o;
+			boost::system::error_code ec;
+			auto addr = socket.lowest_layer().remote_endpoint(ec);
+			if (ec.failed()) {
+				o << "invalidEndpoint";
+			}
+			o << addr;
+			return std::move(o).str();
+		}
+
 		ThreadReturnPromise<Void> done;
 		ssl_socket& socket;
 		ssl_socket::handshake_type type;
@@ -821,6 +842,7 @@ struct SSLHandshakerThread final : IThreadPoolReceiver {
 				TraceEvent(SevWarn,
 				           h.type == ssl_socket::handshake_type::client ? "N2_ConnectHandshakeError"_audit
 				                                                        : "N2_AcceptHandshakeError"_audit)
+				    .detail("PeerAddr", h.getPeerAddress())
 				    .detail("ErrorCode", h.err.value())
 				    .detail("ErrorMsg", h.err.message().c_str())
 				    .detail("BackgroundThread", true);
@@ -832,6 +854,7 @@ struct SSLHandshakerThread final : IThreadPoolReceiver {
 			TraceEvent(SevWarn,
 			           h.type == ssl_socket::handshake_type::client ? "N2_ConnectHandshakeUnknownError"_audit
 			                                                        : "N2_AcceptHandshakeUnknownError"_audit)
+			    .detail("PeerAddr", h.getPeerAddress())
 			    .detail("BackgroundThread", true);
 			h.done.sendError(connection_failed());
 		}
@@ -923,6 +946,7 @@ public:
 			} else {
 				// Otherwise use flow network thread
 				BindPromise p("N2_AcceptHandshakeError"_audit, self->id);
+				p.setPeerAddr(self->getPeerAddress());
 				onHandshook = p.getFuture();
 				self->ssl_sock.async_handshake(boost::asio::ssl::stream_base::server, std::move(p));
 			}
@@ -1005,6 +1029,7 @@ public:
 			} else {
 				// Otherwise use flow network thread
 				BindPromise p("N2_ConnectHandshakeError"_audit, self->id);
+				p.setPeerAddr(self->getPeerAddress());
 				onHandshook = p.getFuture();
 				self->ssl_sock.async_handshake(boost::asio::ssl::stream_base::client, std::move(p));
 			}


### PR DESCRIPTION
In order to improve auditing we've added a peerIP field to BindPromise in order to decorate `N2_(Connect|Accept)Handshake(Unknown)*Error` with the peerIP. 

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
