### PR TITLE
Support blob manifest backup for fdbbackup cmdline

### DIFF
--- a/fdbclient/FileBackupAgent.actor.cpp
+++ b/fdbclient/FileBackupAgent.actor.cpp
@@ -18,10 +18,12 @@
  * limitations under the License.
  */
 
+#include "fdbclient/BlobGranuleCommon.h"
 #include "fdbclient/CommitProxyInterface.h"
 #include "fdbclient/DatabaseConfiguration.h"
 #include "fdbclient/TenantEntryCache.actor.h"
 #include "fdbclient/TenantManagement.actor.h"
+#include "fdbclient/BlobRestoreCommon.h"
 #include "fdbrpc/TenantInfo.h"
 #include "fdbrpc/simulator.h"
 #include "flow/EncryptUtils.h"
@@ -5291,7 +5293,8 @@ public:
 	                                       StopWhenDone stopWhenDone,
 	                                       UsePartitionedLog partitionedLog,
 	                                       IncrementalBackupOnly incrementalBackupOnly,
-	                                       Optional<std::string> encryptionKeyFileName) {
+	                                       Optional<std::string> encryptionKeyFileName,
+	                                       Optional<std::string> blobManifestUrl) {
 		tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 		tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 		tr->setOption(FDBTransactionOptions::COMMIT_ON_FIRST_PROXY);
@@ -5347,6 +5350,21 @@ public:
 			        "ERROR: The last backup `%s' happened in the future.\n",
 			        printable(lastBackupTimestamp.get()).c_str());
 			throw backup_error();
+		}
+
+		if (blobManifestUrl.present()) {
+			state BlobGranuleBackupConfig bgBackupConfig;
+			bool enabled = wait(bgBackupConfig.enabled().getD(tr));
+			if (enabled) {
+				fprintf(stderr, "ERROR: Abort existing blob manifest backup first before creating new one.\n");
+				throw backup_error();
+			} else {
+				bgBackupConfig.manifestUrl().set(tr, blobManifestUrl.get());
+				bgBackupConfig.mutationLogsUrl().set(tr, bc->getURL());
+				bgBackupConfig.enabled().set(tr, true);
+			}
+			// Allow only incremental backup
+			incrementalBackupOnly = IncrementalBackupOnly::True;
 		}
 
 		KeyRangeMap<int> backupRangeSet;
@@ -5411,6 +5429,7 @@ public:
 		config.partitionedLogEnabled().set(tr, partitionedLog);
 		config.incrementalBackupOnly().set(tr, incrementalBackupOnly);
 		config.enableSnapshotBackupEncryption().set(tr, encryptionEnabled);
+		config.blobBackupEnabled().set(tr, blobManifestUrl.present());
 
 		Key taskKey = wait(fileBackup::StartFullBackupTaskFunc::addTask(
 		    tr, backupAgent->taskBucket, uid, TaskCompletionKey::noSignal()));
@@ -5515,6 +5534,8 @@ public:
 
 		// this also sets restore.add/removePrefix.
 		restore.initApplyMutations(tr, addPrefix, removePrefix, onlyApplyMutationLogs);
+
+		//
 
 		Key taskKey = wait(fileBackup::StartFullRestoreTaskFunc::addTask(
 		    tr, backupAgent->taskBucket, uid, TaskCompletionKey::noSignal()));
@@ -5648,6 +5669,12 @@ public:
 		TraceEvent(SevInfo, "FBA_AbortBackup")
 		    .detail("TagName", tagName.c_str())
 		    .detail("Status", BackupAgentBase::getStateText(status));
+
+		bool bgBackupEnabled = wait(config.blobBackupEnabled().getD(tr));
+		if (bgBackupEnabled) {
+			BlobGranuleBackupConfig bgbackupConfig;
+			bgbackupConfig.enabled().set(tr, false);
+		}
 
 		// Cancel backup task through tag
 		wait(tag.cancel(tr));
@@ -6171,6 +6198,7 @@ public:
 				                   inconsistentSnapshotOnly,
 				                   beginVersion,
 				                   randomUid));
+
 				wait(tr->commit());
 				break;
 			} catch (Error& e) {
@@ -6687,7 +6715,8 @@ Future<Void> FileBackupAgent::submitBackup(Reference<ReadYourWritesTransaction> 
                                            StopWhenDone stopWhenDone,
                                            UsePartitionedLog partitionedLog,
                                            IncrementalBackupOnly incrementalBackupOnly,
-                                           Optional<std::string> const& encryptionKeyFileName) {
+                                           Optional<std::string> const& encryptionKeyFileName,
+                                           Optional<std::string> const& blobManifestUrl) {
 	return FileBackupAgentImpl::submitBackup(this,
 	                                         tr,
 	                                         outContainer,
@@ -6700,7 +6729,8 @@ Future<Void> FileBackupAgent::submitBackup(Reference<ReadYourWritesTransaction> 
 	                                         stopWhenDone,
 	                                         partitionedLog,
 	                                         incrementalBackupOnly,
-	                                         encryptionKeyFileName);
+	                                         encryptionKeyFileName,
+	                                         blobManifestUrl);
 }
 
 Future<Void> FileBackupAgent::discontinueBackup(Reference<ReadYourWritesTransaction> tr, Key tagName) {

--- a/fdbclient/include/fdbclient/BackupAgent.actor.h
+++ b/fdbclient/include/fdbclient/BackupAgent.actor.h
@@ -276,7 +276,8 @@ public:
 	                          StopWhenDone = StopWhenDone::True,
 	                          UsePartitionedLog = UsePartitionedLog::False,
 	                          IncrementalBackupOnly = IncrementalBackupOnly::False,
-	                          Optional<std::string> const& encryptionKeyFileName = {});
+	                          Optional<std::string> const& encryptionKeyFileName = {},
+	                          Optional<std::string> const& blobManifestUrl = {});
 	Future<Void> submitBackup(Database cx,
 	                          Key outContainer,
 	                          Optional<std::string> proxy,
@@ -288,7 +289,8 @@ public:
 	                          StopWhenDone stopWhenDone = StopWhenDone::True,
 	                          UsePartitionedLog partitionedLog = UsePartitionedLog::False,
 	                          IncrementalBackupOnly incrementalBackupOnly = IncrementalBackupOnly::False,
-	                          Optional<std::string> const& encryptionKeyFileName = {}) {
+	                          Optional<std::string> const& encryptionKeyFileName = {},
+	                          Optional<std::string> const& blobManifestUrl = {}) {
 		return runRYWTransactionFailIfLocked(cx, [=](Reference<ReadYourWritesTransaction> tr) {
 			return submitBackup(tr,
 			                    outContainer,
@@ -301,7 +303,8 @@ public:
 			                    stopWhenDone,
 			                    partitionedLog,
 			                    incrementalBackupOnly,
-			                    encryptionKeyFileName);
+			                    encryptionKeyFileName,
+			                    blobManifestUrl);
 		});
 	}
 
@@ -960,6 +963,8 @@ public:
 
 		return updateErrorInfo(cx, e, details);
 	}
+
+	KeyBackedProperty<bool> blobBackupEnabled() { return configSpace.pack(__FUNCTION__sr); }
 };
 
 // Helper class for reading restore data from a buffer and throwing the right errors.

--- a/fdbclient/include/fdbclient/BlobGranuleCommon.h
+++ b/fdbclient/include/fdbclient/BlobGranuleCommon.h
@@ -25,7 +25,7 @@
 #include "fdbclient/BlobCipher.h"
 #include "fdbclient/CommitTransaction.h"
 #include "fdbclient/FDBTypes.h"
-
+#include "fdbclient/KeyBackedTypes.actor.h"
 #include "flow/EncryptUtils.h"
 #include "flow/IRandom.h"
 #include "flow/serialize.h"

--- a/fdbclient/include/fdbclient/BlobRestoreCommon.h
+++ b/fdbclient/include/fdbclient/BlobRestoreCommon.h
@@ -1,0 +1,38 @@
+
+/*
+ * BlobRestoreCommon.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FDBCLIENT_BLOBRESTORECOMMON_H
+#define FDBCLIENT_BLOBRESTORECOMMON_H
+#pragma once
+
+#include "fdbclient/FDBTypes.h"
+#include "fdbclient/SystemData.h"
+#include "fdbclient/KeyBackedTypes.actor.h"
+
+struct BlobGranuleBackupConfig : public KeyBackedClass {
+	BlobGranuleBackupConfig(KeyRef prefix = SystemKey("\xff\x02/bgbackup/"_sr)) : KeyBackedClass(prefix) {}
+
+	KeyBackedProperty<bool> enabled() { return subspace.pack(__FUNCTION__sr); }
+	KeyBackedProperty<std::string> manifestUrl() { return subspace.pack(__FUNCTION__sr); }
+	KeyBackedProperty<std::string> mutationLogsUrl() { return subspace.pack(__FUNCTION__sr); }
+};
+
+#endif

--- a/fdbserver/BlobManifest.actor.cpp
+++ b/fdbserver/BlobManifest.actor.cpp
@@ -144,7 +144,6 @@ public:
 			ASSERT(iter->seqNo == seqNo);
 			if (iter->segmentNo != nextSegmentNo) {
 				TraceEvent("BlobRestoreMissingSegment")
-				    .detail("Url", SERVER_KNOBS->BLOB_RESTORE_MANIFEST_URL)
 				    .detail("Epoch", epoch)
 				    .detail("SeqNo", epoch)
 				    .detail("Expected", nextSegmentNo)
@@ -183,7 +182,7 @@ public:
 		}
 
 		dprint("No valid blob manifest files\n");
-		TraceEvent("BlobRestoreMissingManifest").detail("Url", SERVER_KNOBS->BLOB_RESTORE_MANIFEST_URL);
+		TraceEvent("BlobRestoreMissingManifest").log();
 		throw blob_restore_missing_manifest();
 	}
 
@@ -644,7 +643,7 @@ private:
 	                                                               Reference<BackupContainerFileSystem> container,
 	                                                               BlobManifestFile tailerFile) {
 		if (tailerFile.segmentNo != 0) {
-			TraceEvent("BlobRestoreMissingTailer").detail("Url", SERVER_KNOBS->BLOB_RESTORE_MANIFEST_URL);
+			TraceEvent("BlobRestoreMissingTailer").log();
 			throw blob_restore_corrupted_manifest();
 		}
 

--- a/tests/fast/BlobRestoreBasic.toml
+++ b/tests/fast/BlobRestoreBasic.toml
@@ -8,7 +8,6 @@ storageEngineExcludeTypes = [4, 5]
 
 [[knobs]]
 bg_consistency_check_enabled = 0
-blob_manifest_backup = true
 shard_encode_location_metadata = false
 bw_throttling_enabled = false
 
@@ -22,7 +21,7 @@ waitForQuiescence = false
     [[test.workload]]
     testName = 'BlobRestoreWorkload'
     setupBlob = true
-    
+
 [[test]] 
 testTitle = 'BackupMutationLogs'
 simBackupAgents = 'BackupToFile'
@@ -32,9 +31,10 @@ waitForQuiescence = false
     [[test.workload]]
     testName = 'IncrementalBackup'
     tag = 'default'
+    blobManifestUrl = 'file://simfdb/fdbblob/manifest'
     submitOnly = true
     waitForBackup = true
-
+    
 [[test]]
 testTitle = 'CycleTest'
 simBackupAgents = 'BackupToFile'

--- a/tests/fast/BlobRestoreLarge.toml
+++ b/tests/fast/BlobRestoreLarge.toml
@@ -22,7 +22,7 @@ waitForQuiescence = false
     [[test.workload]]
     testName = 'BlobRestoreWorkload'
     setupBlob = true
-    
+
 [[test]] 
 testTitle = 'BackupMutationLogs'
 simBackupAgents = 'BackupToFile'
@@ -32,9 +32,10 @@ waitForQuiescence = false
     [[test.workload]]
     testName = 'IncrementalBackup'
     tag = 'default'
+    blobManifestUrl = 'file://simfdb/fdbblob/manifest'
     submitOnly = true
     waitForBackup = true
-
+    
 [[test]]
 testTitle = 'WriteTest'
 simBackupAgents = 'BackupToFile'

--- a/tests/fast/BlobRestoreTenantMode.toml
+++ b/tests/fast/BlobRestoreTenantMode.toml
@@ -27,6 +27,7 @@ waitForQuiescence = false
     [[test.workload]]
     testName = 'IncrementalBackup'
     tag = 'default'
+    blobManifestUrl = 'file://simfdb/fdbblob/manifest'
     submitOnly = true
     waitForBackup = true
 

--- a/tests/fast/BlobRestoreToVersion.toml
+++ b/tests/fast/BlobRestoreToVersion.toml
@@ -22,7 +22,7 @@ waitForQuiescence = false
     [[test.workload]]
     testName = 'BlobRestoreWorkload'
     setupBlob = true
-    
+
 [[test]] 
 testTitle = 'BackupMutationLogs'
 simBackupAgents = 'BackupToFile'
@@ -32,9 +32,10 @@ waitForQuiescence = false
     [[test.workload]]
     testName = 'IncrementalBackup'
     tag = 'default'
+    blobManifestUrl = 'file://simfdb/fdbblob/manifest'
     submitOnly = true
     waitForBackup = true
-
+        
 [[test]]
 testTitle = 'WriteTest'
 simBackupAgents = 'BackupToFile'


### PR DESCRIPTION
Add command line option "--blob-manifest-url" to fdbbackup. To enable blob granules backup:
"fdbbackup start --blob-manifest-url file:///path/to/manifest --destcontainer file:///path/to/mlogs/ -z -t sometag"
- if tag is not specified, we'll use 'default' as the default tag name
- there is only one blob granules backup allowed at a time. Error message will show up if you try to submit more than one 

To disable blob granules backup
"fdbbackup abort -t sometag"

100K correctness test passed

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
