### PR TITLE
fixing incorrect uses of ThreadSafeAsyncVar (Cherry-Pick #10086 to snowflake/release-71.3)

### DIFF
--- a/fdbclient/MultiVersionTransaction.actor.cpp
+++ b/fdbclient/MultiVersionTransaction.actor.cpp
@@ -2147,10 +2147,10 @@ ThreadFuture<int64_t> MultiVersionDatabase::rebootWorker(const StringRef& addres
 
 template <class T, class... Args>
 ThreadFuture<T> MultiVersionDatabase::executeOperation(ThreadFuture<T> (IDatabase::*func)(Args...), Args&&... args) {
-	auto db = dbState->db;
-	if (db) {
-		auto f = (db.getPtr()->*func)(std::forward<Args>(args)...);
-		return abortableFuture(f, dbState->dbVar->get().onChange);
+	auto db = dbState->dbVar->get();
+	if (db.value) {
+		auto f = (db.value.getPtr()->*func)(std::forward<Args>(args)...);
+		return abortableFuture(f, db.onChange);
 	}
 
 	// If database initialization failed, return the initialization error
@@ -2160,7 +2160,7 @@ ThreadFuture<T> MultiVersionDatabase::executeOperation(ThreadFuture<T> (IDatabas
 	}
 
 	// Wait for the database to be initialized
-	return abortableFuture(ThreadFuture<T>(Never()), dbState->dbVar->get().onChange);
+	return abortableFuture(ThreadFuture<T>(Never()), db.onChange);
 }
 
 ThreadFuture<Void> MultiVersionDatabase::forceRecoveryWithDataLoss(const StringRef& dcid) {
@@ -2243,16 +2243,16 @@ ThreadFuture<ProtocolVersion> MultiVersionDatabase::getServerProtocol(Optional<P
 
 ThreadFuture<Standalone<StringRef>> MultiVersionDatabase::getClientStatus() {
 	auto stateRef = dbState;
-	auto db = stateRef->db;
-	if (!db.isValid()) {
-		db = stateRef->versionMonitorDb;
+	auto db = stateRef->dbVar->get();
+	if (!db.value.isValid()) {
+		db.value = stateRef->versionMonitorDb;
 	}
-	if (!db.isValid()) {
+	if (!db.value.isValid()) {
 		return onMainThread([stateRef] { return Future<Standalone<StringRef>>(stateRef->getClientStatus(""_sr)); });
 	} else {
 		// If a database is created first retrieve its status
-		auto f = db->getClientStatus();
-		auto statusFuture = abortableFuture(f, dbState->dbVar->get().onChange);
+		auto f = db.value->getClientStatus();
+		auto statusFuture = abortableFuture(f, db.onChange);
 		return flatMapThreadFuture<Standalone<StringRef>, Standalone<StringRef>>(
 		    statusFuture, [stateRef](ErrorOr<Standalone<StringRef>> dbContextStatus) {
 			    return onMainThread([stateRef, dbContextStatus] {


### PR DESCRIPTION
Cherry-Pick of #10086 - fixed a deadlock in Multi-Version Client

Original Description:

Fixed several cases where a user of threadsafe async var would use the value directly and then separately call onChange instead of using get() and using the returned value and onChange from get.

Passes ctest.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
