### PR TITLE
Increase MAX_STORAGE_COMMIT_TIME to be inline with LOW_PRIORITY_DURABILITY_LAG

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -896,7 +896,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( REPORT_DD_METRICS,                                    true );
 	init( DD_METRICS_REPORT_INTERVAL,                           30.0 );
 	init( FETCH_KEYS_TOO_LONG_TIME_CRITERIA,                   300.0 );
-	init( MAX_STORAGE_COMMIT_TIME,                             120.0 ); //The max fsync stall time on the storage server and tlog before marking a disk as failed
+	init( MAX_STORAGE_COMMIT_TIME,                             200.0 ); //The max fsync stall time on the storage server and tlog before marking a disk as failed
 	init( RANGESTREAM_LIMIT_BYTES,                               2e6 ); if( randomize && BUGGIFY ) RANGESTREAM_LIMIT_BYTES = 1;
 	init( CHANGEFEEDSTREAM_LIMIT_BYTES,                          1e6 ); if( randomize && BUGGIFY ) CHANGEFEEDSTREAM_LIMIT_BYTES = 1;
 	init( BLOBWORKERSTATUSSTREAM_LIMIT_BYTES,                    1e4 ); if( randomize && BUGGIFY ) BLOBWORKERSTATUSSTREAM_LIMIT_BYTES = 1;


### PR DESCRIPTION
When a storage server is overloaded by queries, writing to disk is stalled. LOW_PRIORITY_DURABILITY_LAG is supposed to make sure that when durability lag is high, we convert queries to low priority queries so that commit has a chance to write to disk.

Currently LOW_PRIORITY_DURABILITY_LAG is 200M versions (roughly 3 minutes of commits) where as MAX_STORAGE_COMMIT_TIME is 120 seconds. Therefore, we need to make MAX_STORAGE_COMMIT_TIME is inline with LOW_PRIORITY_DURABILITY_LAG.

We could also reduce LOW_PRIORITY_DURABILITY_LAG, but when SS is overloaded with queries, writes probably has lower priority.

20230502-182449-zhewu_ss_timeout-6ed691eb06976904

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
