### PR TITLE
Add configuration option `auto_tenant_assignment` to data clusters (Cherry-Pick #10058 to snowflake/release-71.3)

### DIFF
--- a/fdbcli/tests/metacluster_fdbcli_tests.py
+++ b/fdbcli/tests/metacluster_fdbcli_tests.py
@@ -98,7 +98,11 @@ def metacluster_create(logger, cluster_file, name, tenant_id_prefix):
 
 
 def metacluster_register(
-    management_cluster_file, data_cluster_file, name, max_tenant_groups
+    management_cluster_file,
+    data_cluster_file,
+    name,
+    max_tenant_groups,
+    auto_tenant_assignment,
 ):
     conn_str = get_cluster_connection_str(data_cluster_file)
     rc, out, err = run_fdbcli_command(
@@ -107,6 +111,7 @@ def metacluster_register(
         name,
         "connection_string={}".format(conn_str),
         "max_tenant_groups={}".format(max_tenant_groups),
+        "auto_tenant_assignment={}".format(auto_tenant_assignment),
     )
     if rc != 0:
         raise Exception(err)
@@ -120,17 +125,18 @@ def setup_metacluster(
     management_cluster_name = management_cluster[1]
     tenant_id_prefix = random.randint(0, 32767)
     logger.debug("management cluster: {}".format(management_cluster_name))
-    logger.debug("data clusters: {}".format([name for (_, name) in data_clusters]))
+    logger.debug("data clusters: {}".format([name for (_, name, _) in data_clusters]))
     metacluster_create(
         management_cluster_file, management_cluster_name, tenant_id_prefix
     )
     cluster_names_to_files[management_cluster_name] = management_cluster_file
-    for (cf, name) in data_clusters:
+    for (cf, name, auto_assignment) in data_clusters:
         metacluster_register(
             management_cluster_file,
             cf,
             name,
             max_tenant_groups=max_tenant_groups_per_cluster,
+            auto_tenant_assignment=auto_assignment,
         )
         cluster_names_to_files[name] = cf
     assert len(cluster_names_to_files) == len(data_clusters) + 1
@@ -319,6 +325,93 @@ def clear_kv_range_with_tenant(
 
 
 @enable_logging()
+def register_and_configure_data_clusters_test(logger, cluster_files):
+    logger.debug("Setting up a metacluster")
+    management_cluster_file = cluster_files[0]
+    tenant_id_prefix = random.randint(0, 32767)
+    logger.debug("management cluster: {}".format(management_cluster_name))
+    metacluster_create(
+        management_cluster_file, management_cluster_name, tenant_id_prefix
+    )
+    cluster_names_to_files[management_cluster_name] = management_cluster_file
+    conn_str = get_cluster_connection_str(cluster_files[1])
+
+    # Register a data cluster
+    rc, _, err = run_fdbcli_command(
+        management_cluster_file,
+        "metacluster register",
+        data_cluster_names[0],
+        "connection_string={}".format(conn_str),
+        "max_tenant_groups={}".format(5),
+        "auto_tenant_assignment=disable",
+    )
+    assert rc != 0
+    assert err == "ERROR: invalid configuration `disable' for `auto_tenant_assignment'."
+    # Second attempt
+    rc, _, err = run_fdbcli_command(
+        management_cluster_file,
+        "metacluster register",
+        data_cluster_names[0],
+        "connection_string={}".format(conn_str),
+        "max_tenant_groups={}".format(5),
+        "auto_tenant_assignment=enable",
+    )
+    assert rc != 0
+    assert err == "ERROR: invalid configuration `enable' for `auto_tenant_assignment'."
+    # Third attempt
+    rc, out, err = run_fdbcli_command(
+        management_cluster_file,
+        "metacluster register",
+        data_cluster_names[0],
+        "connection_string={}".format(conn_str),
+        "max_tenant_groups=5",
+        "auto_tenant_assignment=disabled",
+    )
+    assert 0 == rc
+    rc, out, err = run_fdbcli_command(
+        management_cluster_file,
+        "metacluster get",
+        data_cluster_names[0],
+    )
+    assert rc == 0
+
+    # Try creating a tenant without specifying data cluster
+    out, err = create_tenant(management_cluster_file, "tenant1")
+    assert (
+        err == "ERROR: Metacluster does not have capacity to create new tenants (2166)"
+    )
+    out, err = create_tenant(
+        management_cluster_file, "tenant1", assigned_cluster=data_cluster_names[0]
+    )
+    assert out == "The tenant `tenant1' has been created"
+    assert len(err) == 0
+
+    rc, out, err = run_fdbcli_command(
+        management_cluster_file,
+        "metacluster configure",
+        data_cluster_names[0],
+        "auto_tenant_assignment=enabled",
+    )
+    assert 0 == rc
+
+    out, err = create_tenant(management_cluster_file, "tenant2")
+    assert out == "The tenant `tenant2' has been created"
+    assert len(err) == 0
+
+    # clean up
+    out, err = delete_tenant(management_cluster_file, "tenant1")
+    assert len(err) == 0
+    out, err = delete_tenant(management_cluster_file, "tenant2")
+    assert len(err) == 0
+    rc, out, err = remove_data_cluster(management_cluster_file, data_cluster_names[0])
+    assert 0 == rc
+    rc, out, err = run_fdbcli_command(
+        management_cluster_file, "metacluster decommission"
+    )
+    assert 0 == rc
+
+
+@enable_logging()
 def clusters_status_test(logger, cluster_files, max_tenant_groups_per_cluster):
     logger.debug("Verifying no cluster is part of a metacluster")
     for cf in cluster_files:
@@ -328,9 +421,10 @@ def clusters_status_test(logger, cluster_files, max_tenant_groups_per_cluster):
     logger.debug("Verified")
     num_clusters = len(cluster_files)
     logger.debug("Setting up a metacluster")
+    auto_assignment = ["enabled"] * (num_clusters - 1)
     setup_metacluster(
         [cluster_files[0], management_cluster_name],
-        list(zip(cluster_files[1:], data_cluster_names)),
+        list(zip(cluster_files[1:], data_cluster_names, auto_assignment)),
         max_tenant_groups_per_cluster=max_tenant_groups_per_cluster,
     )
 
@@ -483,9 +577,8 @@ def configure_tenants_test_disableClusterAssignment(logger, cluster_files):
 @enable_logging()
 def test_main(logger):
     logger.debug("Tests start")
-    # This must be the first test to run, since it sets up the metacluster that
-    # will be used throughout the test. The cluster names to files mapping is also
-    # set up for testing purpose.
+    register_and_configure_data_clusters_test(cluster_files)
+
     clusters_status_test(cluster_files, max_tenant_groups_per_cluster=5)
 
     configure_tenants_test_disableClusterAssignment(cluster_files)
@@ -517,7 +610,7 @@ if __name__ == "__main__":
     # keep current environment variables
     fdbcli_env = os.environ.copy()
     cluster_files = fdbcli_env.get("FDB_CLUSTERS").split(";")
-    assert len(cluster_files) > 1
+    assert len(cluster_files) > 2
 
     fdbcli_bin = args.build_dir + "/bin/fdbcli"
 

--- a/metacluster/Metacluster.cpp
+++ b/metacluster/Metacluster.cpp
@@ -93,12 +93,24 @@ DataClusterState DataClusterEntry::stringToClusterState(std::string stateStr) {
 	UNREACHABLE();
 }
 
+std::string DataClusterEntry::autoTenantAssignmentToString(AutoTenantAssignment autoTenantAssignment) {
+	switch (autoTenantAssignment) {
+	case AutoTenantAssignment::DISABLED:
+		return "disabled";
+	case AutoTenantAssignment::ENABLED:
+		return "enabled";
+	default:
+		UNREACHABLE();
+	}
+}
+
 json_spirit::mObject DataClusterEntry::toJson() const {
 	json_spirit::mObject obj;
 	obj["id"] = id.toString();
 	obj["capacity"] = capacity.toJson();
 	obj["allocated"] = allocated.toJson();
 	obj["cluster_state"] = DataClusterEntry::clusterStateToString(clusterState);
+	obj["auto_tenant_assignment"] = autoTenantAssignmentToString(autoTenantAssignment);
 	return obj;
 }
 

--- a/metacluster/include/metacluster/MetaclusterConsistency.actor.h
+++ b/metacluster/include/metacluster/MetaclusterConsistency.actor.h
@@ -100,12 +100,15 @@ private:
 		int numFoundInTenantGroupMap = 0;
 		for (auto const& [clusterName, clusterMetadata] : data.dataClusters) {
 			// If the cluster has capacity, it should be in the capacity index and have the correct count of
-			// allocated tenants stored there
+			// allocated tenants stored there.
+			// If the cluster has disabled auto tenant assignment, then it mustn't exist in the capacity index.
 			auto allocatedItr = data.clusterAllocatedMap.find(clusterName);
-			if (!clusterMetadata.entry.hasCapacity()) {
+			if (!clusterMetadata.entry.hasCapacity() ||
+			    clusterMetadata.entry.autoTenantAssignment == AutoTenantAssignment::DISABLED) {
 				ASSERT(allocatedItr == data.clusterAllocatedMap.end());
 			} else if (allocatedItr != data.clusterAllocatedMap.end()) {
 				ASSERT_EQ(allocatedItr->second, clusterMetadata.entry.allocated.numTenantGroups);
+				ASSERT_EQ(AutoTenantAssignment::ENABLED, clusterMetadata.entry.autoTenantAssignment);
 				++numFoundInAllocatedMap;
 			} else {
 				ASSERT_NE(clusterMetadata.entry.clusterState, DataClusterState::READY);

--- a/metacluster/include/metacluster/MetaclusterInternal.actor.h
+++ b/metacluster/include/metacluster/MetaclusterInternal.actor.h
@@ -69,11 +69,11 @@ void updateClusterCapacityIndex(Transaction tr,
                                 DataClusterEntry const& previousEntry,
                                 DataClusterEntry const& updatedEntry) {
 	// Entries are put in the cluster capacity index ordered by how many items are already allocated to them
-	if (previousEntry.hasCapacity()) {
+	if (previousEntry.hasCapacity() || updatedEntry.autoTenantAssignment == AutoTenantAssignment::DISABLED) {
 		metadata::management::clusterCapacityIndex().erase(
 		    tr, Tuple::makeTuple(previousEntry.allocated.numTenantGroups, name));
 	}
-	if (updatedEntry.hasCapacity()) {
+	if (updatedEntry.hasCapacity() && updatedEntry.autoTenantAssignment == AutoTenantAssignment::ENABLED) {
 		metadata::management::clusterCapacityIndex().insert(
 		    tr, Tuple::makeTuple(updatedEntry.allocated.numTenantGroups, name));
 	}

--- a/metacluster/include/metacluster/MetaclusterTypes.h
+++ b/metacluster/include/metacluster/MetaclusterTypes.h
@@ -85,17 +85,22 @@ struct ClusterUsage {
 //             created/updated/deleted.
 enum class DataClusterState { REGISTERING, READY, REMOVING, RESTORING };
 
+enum class AutoTenantAssignment { ENABLED, DISABLED };
+
 struct DataClusterEntry {
 	constexpr static FileIdentifier file_identifier = 929511;
 
 	static std::string clusterStateToString(DataClusterState clusterState);
 	static DataClusterState stringToClusterState(std::string stateStr);
+	static std::string autoTenantAssignmentToString(AutoTenantAssignment autoTenantAssignment);
 
 	UID id;
 	ClusterUsage capacity;
 	ClusterUsage allocated;
 
 	DataClusterState clusterState = DataClusterState::READY;
+
+	AutoTenantAssignment autoTenantAssignment = AutoTenantAssignment::ENABLED;
 
 	DataClusterEntry() = default;
 	DataClusterEntry(ClusterUsage capacity) : capacity(capacity) {}
@@ -123,7 +128,7 @@ struct DataClusterEntry {
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, id, capacity, allocated, clusterState);
+		serializer(ar, id, capacity, allocated, clusterState, autoTenantAssignment);
 	}
 };
 

--- a/metacluster/include/metacluster/RegisterCluster.actor.h
+++ b/metacluster/include/metacluster/RegisterCluster.actor.h
@@ -83,7 +83,9 @@ struct RegisterClusterImpl {
 		    .detail("ClusterName", self->clusterName)
 		    .detail("ClusterID", self->clusterEntry.id)
 		    .detail("Capacity", self->clusterEntry.capacity)
-		    .detail("ConnectionString", self->connectionString.toString());
+		    .detail("ConnectionString", self->connectionString.toString())
+		    .detail("AutoTenantAssignment",
+		            DataClusterEntry::autoTenantAssignmentToString(self->clusterEntry.autoTenantAssignment));
 
 		return Void();
 	}
@@ -182,7 +184,8 @@ struct RegisterClusterImpl {
 			ASSERT(dataClusterMetadata.get().entry.clusterState == DataClusterState::REGISTERING);
 			dataClusterMetadata.get().entry.clusterState = DataClusterState::READY;
 
-			if (dataClusterMetadata.get().entry.hasCapacity()) {
+			if (dataClusterMetadata.get().entry.hasCapacity() &&
+			    dataClusterMetadata.get().entry.autoTenantAssignment == AutoTenantAssignment::ENABLED) {
 				metadata::management::clusterCapacityIndex().insert(
 				    tr, Tuple::makeTuple(dataClusterMetadata.get().entry.allocated.numTenantGroups, self->clusterName));
 			}
@@ -194,7 +197,9 @@ struct RegisterClusterImpl {
 		    .detail("ClusterName", self->clusterName)
 		    .detail("ClusterID", self->clusterEntry.id)
 		    .detail("Capacity", dataClusterMetadata.get().entry.capacity)
-		    .detail("ConnectionString", self->connectionString.toString());
+		    .detail("ConnectionString", self->connectionString.toString())
+		    .detail("AutoTenantAssignment",
+		            DataClusterEntry::autoTenantAssignmentToString(self->clusterEntry.autoTenantAssignment));
 
 		return Void();
 	}


### PR DESCRIPTION
Cherry-Pick of #10058

Original Description:

This PR adds `auto_tenant_assignment` option to register/configure data clusters.
Setting `auto_tenant_assignment` to `disabled` means the data cluster is a dedicated one and won't be
used for auto tenant assignment. This option is enabled by default (allowing auto tenant assignment).

Test plan:
simulation tests and metacluster_fdbcli_tests.py

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
