### PR TITLE
ConsistencyScan refactor to fix bugs and improve control and usability.

### DIFF
--- a/documentation/sphinx/source/command-line-interface.rst
+++ b/documentation/sphinx/source/command-line-interface.rst
@@ -138,7 +138,7 @@ This command controls a native data consistency scan role that is automatically 
 
 The syntax is
 
-``consistencyscan [on|off] [restart [0|1]] [maxRate <BYTES_PER_SECOND>] [targetInterval <SECONDS>]``
+``consistencyscan [on|off] [restart] [maxRate <BYTES_PER_SECOND>] [targetInterval <SECONDS>]``
 
 * ``on`` enables the scan.
 
@@ -150,7 +150,7 @@ The syntax is
 
 * ``targetInterval <SECONDS>`` sets the target interval for the scan to SECONDS.  The scan will adjust speed to attempt to complete in that amount of time but it will not exceed BYTES_PER_SECOND.
 
-The consistency scan role publishes its configuration and metrics in Status JSON under the path ``.cluster.consistency_scan_info``.
+The consistency scan role publishes its configuration and metrics in Status JSON under the path ``.cluster.consistency_scan``.
 
 consistencycheck
 ----------------

--- a/documentation/sphinx/source/command-line-interface.rst
+++ b/documentation/sphinx/source/command-line-interface.rst
@@ -138,24 +138,25 @@ This command controls a native data consistency scan role that is automatically 
 
 The syntax is
 
-``consistencyscan [ off | on [maxRate <RATE>] [targetInterval <INTERVAL>] [restart <RESTART>] ]``
+``consistencyscan [on|off] [restart [0|1]] [maxRate <BYTES_PER_SECOND>] [targetInterval <SECONDS>]``
 
-* ``off`` will disable the consistency scan
+* ``on`` enables the scan.
 
-* ``on`` will enable the scan and can be accompanied by additional options shown above
+* ``off`` disables the scan but keeps the current cycle's progress so it will resume later if enabled again.
 
-  * ``RATE`` - sets the maximum read speed of the scan in bytes/s.
+* ``restart`` will end the current scan cycle.  A new cycle will start if the scan is enabled, or later when it is re-enabled.
 
-  * ``INTERVAL`` - sets the target completion time, in seconds, for each full pass over all data in the cluster.  Scan speed will target this interval with a hard limit of RATE.
+* ``maxRate <BYTES_PER_SECOND>`` sets the maximum scan read speed rate to BYTES_PER_SECOND, post-replication.
 
-  * ``RESTART`` - a 1 or 0 and controls whether the process should restart from the beginning of userspace on startup or not.  This should normally be set to 0 which will resume progress from the last time the scan was running.
+* ``targetInterval <SECONDS>`` sets the target interval for the scan to SECONDS.  The scan will adjust speed to attempt to complete in that amount of time but it will not exceed BYTES_PER_SECOND.
 
 The consistency scan role publishes its configuration and metrics in Status JSON under the path ``.cluster.consistency_scan_info``.
 
 consistencycheck
 ----------------
 
-Note: This command exists for backward compatibility, it is suggested to use the ``consistencyscan`` command to control FDB's internal consistency scan role instead.
+.. note::
+   This command exists for backward compatibility, it is suggested to use the ``consistencyscan`` command above to control FDB's internal consistency scan role instead.
 
 This command controls a key which controls behavior of any externally configured consistency check roles.  You must be running an ``fdbserver`` process with the ``consistencycheck`` role to perform consistency checking.
 

--- a/documentation/sphinx/source/mr-status-json-schemas.rst.inc
+++ b/documentation/sphinx/source/mr-status-json-schemas.rst.inc
@@ -37,6 +37,51 @@
                "finished_wiggle": 1
             }
        },
+      "consistency_scan" : {
+         "configuration" : {
+            "enabled" : true,
+            "max_rate_bytes_per_second" : 50000000,
+            "min_interval_seconds" : 2592000,
+            "min_start_version" : 0,
+            "round_history_days" : 90,
+            "target_interval_seconds" : 2592000
+         },
+         "current_round" : {
+            "complete" : false,
+            "end_datetime" : "1970-01-01 00:00:00.000 +0000",
+            "end_timestamp" : 0,
+            "end_version" : 0,
+            "errors" : 0,
+            "last_end_key" : "",
+            "logical_bytes_scanned" : 0,
+            "replicated_bytes_scanned" : 0,
+            "skippedRanges" : 0,
+            "start_datetime" : "1970-01-01 00:00:00.000 +0000",
+            "start_timestamp" : 0,
+            "start_version" : 0
+         },
+         "lifetime_stats" : {
+            "errors" : 0,
+            "logical_bytes_scanned" : 0,
+            "replicated_bytes_scanned" : 0
+         },
+         "previous_rounds" : [
+            {
+               "complete" : false,
+               "end_datetime" : "1970-01-01 00:00:00.000 +0000",
+               "end_timestamp" : 0,
+               "end_version" : 0,
+               "errors" : 0,
+               "last_end_key" : "",
+               "logical_bytes_scanned" : 0,
+               "replicated_bytes_scanned" : 0,
+               "skippedRanges" : 0,
+               "start_datetime" : "1970-01-01 00:00:00.000 +0000",
+               "start_timestamp" : 0,
+               "start_version" : 0
+            }
+         ],
+      },
       "layers":{
          "_valid":true,
          "_error":"some error description"
@@ -548,7 +593,7 @@
                   "primary_dc_missing",
                   "fetch_primary_dc_timeout",
                   "fetch_storage_wiggler_stats_timeout",
-                  "fetch_consistency_scan_info_timeout",
+                  "fetch_consistency_scan_status_timeout",
                   "metacluster_metrics_missing"
                ]
             },

--- a/fdbcli/ConsistencyScanCommand.actor.cpp
+++ b/fdbcli/ConsistencyScanCommand.actor.cpp
@@ -51,6 +51,8 @@ ACTOR Future<bool> consistencyScanCommandActor(Database db, std::vector<StringRe
 				break;
 			}
 
+			// TODO:  Expose/document additional configuration options
+			// TODO:  Range configuration.
 			while (!error && !args.empty()) {
 				auto next = args.front();
 				args.pop_front();
@@ -59,15 +61,7 @@ ACTOR Future<bool> consistencyScanCommandActor(Database db, std::vector<StringRe
 				} else if (next == "off") {
 					config.enabled = false;
 				} else if (next == "restart") {
-					// For backward compatibility, support but do not require a next token of 0 or 1
-					bool restart = true;
-					if (!args.empty() && (args.front() == "0"_sr || args.front() == "1"_sr)) {
-						restart = (args.front() == "1");
-						args.pop_front();
-					}
-					if (restart) {
-						config.minStartVersion = tr->getReadVersion().get();
-					}
+					config.minStartVersion = tr->getReadVersion().get();
 				} else if (next == "maxRate") {
 					error = args.empty();
 					if (!error) {
@@ -104,6 +98,7 @@ ACTOR Future<bool> consistencyScanCommandActor(Database db, std::vector<StringRe
 CommandFactory consistencyScanFactory(
     "consistencyscan",
     CommandHelp(
+        // TODO:  Expose/document additional configuration options
         "consistencyscan [on|off] [restart] [maxRate <BYTES_PER_SECOND>] [targetInterval <SECONDS>]",
         "Enables, disables, or sets options for the Consistency Scan role which repeatedly scans\n"
         "shard replicas for consistency.",
@@ -113,6 +108,10 @@ CommandFactory consistencyScanFactory(
         "it is enabled.\n\n"
         "`maxRate <BYTES_PER_SECOND>' sets the maximum scan read speed rate to BYTES_PER_SECOND, post-replication.\n\n"
         "`targetInterval <SECONDS>' sets the target interval for the scan to SECONDS.  The scan will adjust speed\n"
-        "to attempt to complete in that amount of time but it will not exceed BYTES_PER_SECOND\n"));
+        "to attempt to complete in that amount of time but it will not exceed BYTES_PER_SECOND\n\n"
+        "The consistency scan role publishes its configuration and metrics in Status JSON under the path "
+        "`.cluster.consistency_scan'\n"
+        // TODO:  Syntax hint generator
+        ));
 
 } // namespace fdb_cli

--- a/fdbcli/ConsistencyScanCommand.actor.cpp
+++ b/fdbcli/ConsistencyScanCommand.actor.cpp
@@ -100,14 +100,14 @@ CommandFactory consistencyScanFactory(
     CommandHelp(
         // TODO:  Expose/document additional configuration options
         "consistencyscan [on|off] [restart] [maxRate <BYTES_PER_SECOND>] [targetInterval <SECONDS>]",
-        "Enables, disables, or sets options for the Consistency Scan role which repeatedly scans\n"
+        "Enables, disables, or sets options for the Consistency Scan role which repeatedly scans "
         "shard replicas for consistency.",
         "`on' enables the scan.\n\n"
         "`off' disables the scan but keeps the current cycle's progress so it will resume later if enabled again.\n\n"
-        "`restart' will end the current scan cycle.  A new cycle will start if the scan is enabled, or later when\n\n"
+        "`restart' will end the current scan cycle.  A new cycle will start if the scan is enabled, or later when "
         "it is enabled.\n\n"
         "`maxRate <BYTES_PER_SECOND>' sets the maximum scan read speed rate to BYTES_PER_SECOND, post-replication.\n\n"
-        "`targetInterval <SECONDS>' sets the target interval for the scan to SECONDS.  The scan will adjust speed\n"
+        "`targetInterval <SECONDS>' sets the target interval for the scan to SECONDS.  The scan will adjust speed "
         "to attempt to complete in that amount of time but it will not exceed BYTES_PER_SECOND\n\n"
         "The consistency scan role publishes its configuration and metrics in Status JSON under the path "
         "`.cluster.consistency_scan'\n"

--- a/fdbclient/Schemas.cpp
+++ b/fdbclient/Schemas.cpp
@@ -584,7 +584,7 @@ const KeyRef JSONSchemas::statusSchema = R"statusSchema(
                   "primary_dc_missing",
                   "fetch_primary_dc_timeout",
                   "fetch_storage_wiggler_stats_timeout",
-                  "fetch_consistency_scan_info_timeout",
+                  "fetch_consistency_scan_status_timeout",
                   "metacluster_metrics_missing"
                ]
             },
@@ -871,18 +871,50 @@ const KeyRef JSONSchemas::statusSchema = R"statusSchema(
              "cluster_aware"
          ]}
       },
-      "consistency_scan_info":{
-        "consistency_scan_enabled":false,
-        "restart":false,
-        "max_rate":0,
-        "target_interval":0,
-        "bytes_read_prev_round":0,
-        "last_round_start_datetime":"2022-04-20 00:05:05.123 +0000",
-        "last_round_finish_datetime":"1970-01-01 00:00:00.000 +0000",
-        "last_round_start_timestamp":1648857905.123,
-        "last_round_finish_timestamp":0,
-        "smoothed_round_seconds":1,
-        "finished_rounds":1
+      "consistency_scan" : {
+         "configuration" : {
+            "enabled" : true,
+            "max_rate_bytes_per_second" : 50000000,
+            "min_interval_seconds" : 2592000,
+            "min_start_version" : 0,
+            "round_history_days" : 90,
+            "target_interval_seconds" : 2592000
+         },
+         "current_round" : {
+            "complete" : false,
+            "end_datetime" : "1970-01-01 00:00:00.000 +0000",
+            "end_timestamp" : 0,
+            "end_version" : 0,
+            "errors" : 0,
+            "last_end_key" : "",
+            "logical_bytes_scanned" : 0,
+            "replicated_bytes_scanned" : 0,
+            "skippedRanges" : 0,
+            "start_datetime" : "1970-01-01 00:00:00.000 +0000",
+            "start_timestamp" : 0,
+            "start_version" : 0
+         },
+         "lifetime_stats" : {
+            "errors" : 0,
+            "logical_bytes_scanned" : 0,
+            "replicated_bytes_scanned" : 0
+         },
+         "previous_rounds" : [
+            {
+               "complete" : false,
+               "end_datetime" : "1970-01-01 00:00:00.000 +0000",
+               "end_timestamp" : 0,
+               "end_version" : 0,
+               "errors" : 0,
+               "last_end_key" : "",
+               "logical_bytes_scanned" : 0,
+               "replicated_bytes_scanned" : 0,
+               "skippedRanges" : 0,
+               "start_datetime" : "1970-01-01 00:00:00.000 +0000",
+               "start_timestamp" : 0,
+               "start_version" : 0
+            }
+         ],
       },
       "data":{
          "least_operating_space_bytes_log_server":0,

--- a/fdbclient/SystemData.cpp
+++ b/fdbclient/SystemData.cpp
@@ -954,8 +954,6 @@ const KeyRef perpetualStorageWigglePrefix("\xff/storageWiggle/"_sr);
 
 const KeyRef triggerDDTeamInfoPrintKey("\xff/triggerDDTeamInfoPrint"_sr);
 
-const KeyRef consistencyScanInfoKey = "\xff/consistencyScanInfo"_sr;
-
 const KeyRef encryptionAtRestModeConfKey("\xff/conf/encryption_at_rest_mode"_sr);
 const KeyRef tenantModeConfKey("\xff/conf/tenant_mode"_sr);
 

--- a/fdbclient/SystemData.cpp
+++ b/fdbclient/SystemData.cpp
@@ -43,7 +43,7 @@ SystemKey::SystemKey(Key const& k) : Key(k) {
 
 		if (!knownKeys.contains(k)) {
 			for (auto& known : knownKeys) {
-				if (!k.startsWith(known)) {
+				if (k.startsWith(known) || known.startsWith(k)) {
 					TraceEvent(SevError, "SystemKeyPrefixConflict").detail("NewKey", k).detail("ExistingKey", known);
 					UNSTOPPABLE_ASSERT(false);
 				}

--- a/fdbclient/include/fdbclient/ConsistencyScanInterface.actor.h
+++ b/fdbclient/include/fdbclient/ConsistencyScanInterface.actor.h
@@ -148,7 +148,6 @@ struct ConsistencyScanState : public KeyBackedClass {
 
 		// Whether the range should be currently even though it remains a scan target
 		// This should be set by operations on the cluster that would make shards temporarily inconsistent.
-		// TODO:  Track/update skipped shards in stats
 		Optional<bool> skip;
 
 		RangeConfig apply(RangeConfig const& rhs) const {

--- a/fdbclient/include/fdbclient/ConsistencyScanInterface.actor.h
+++ b/fdbclient/include/fdbclient/ConsistencyScanInterface.actor.h
@@ -82,7 +82,7 @@ struct HaltConsistencyScanRequest {
 //   RangeConfig - Tells the scan what ranges to operate on or ignore
 //
 //   CurrentRoundStats - Execution state and stats for the current round
-//   RoundHistory - History of RoundInfo's by start version (TODO)
+//   RoundHistory - History of RoundInfo's by start version
 // 	 LifetimeStats - Accumulated lifetime counts for the cluster
 //
 // The class trigger will only be fired by changes to Config or RangeConfig
@@ -287,7 +287,6 @@ struct ConsistencyScanState : public KeyBackedClass {
 	}
 
 	// History of scan round stats stored by their start version
-	// TODO:  This is not used yet so it is commented out.
 	StatsHistoryMap roundStatsHistory() { return { subspace.pack(__FUNCTION__sr), IncludeVersion() }; }
 };
 

--- a/fdbclient/include/fdbclient/ConsistencyScanInterface.actor.h
+++ b/fdbclient/include/fdbclient/ConsistencyScanInterface.actor.h
@@ -250,9 +250,17 @@ struct ConsistencyScanState : public KeyBackedClass {
 			json_spirit::mObject doc;
 			doc["complete"] = complete;
 			doc["start_version"] = startVersion;
-			doc["start_timestamp"] = startTime;
+			if (startTime != 0) {
+				doc["start_timestamp"] = startTime;
+				doc["start_datetime"] = epochsToGMTString(startTime);
+			}
+
 			doc["end_version"] = endVersion;
-			doc["end_timestamp"] = endTime;
+			if (endTime != 0) {
+				doc["end_timestamp"] = endTime;
+				doc["end_datetime"] = epochsToGMTString(endTime);
+			}
+
 			doc["logical_bytes_scanned"] = logicalBytesScanned;
 			doc["replicated_bytes_scanned"] = replicatedBytesRead;
 			doc["errors"] = errorCount;

--- a/fdbclient/include/fdbclient/ConsistencyScanInterface.actor.h
+++ b/fdbclient/include/fdbclient/ConsistencyScanInterface.actor.h
@@ -287,6 +287,9 @@ struct ConsistencyScanState : public KeyBackedClass {
 		return { subspace.pack(__FUNCTION__sr), IncludeVersion(), trigger };
 	}
 
+	// Updating the lifetime stats does not update the class trigger because the stats are constantly updated, but when
+	// resetting them the same transaction that sets the stats value must also call trigger.update(tr) so that the scan
+	// loop will restart and not overwrite the reset value with a stale copy.
 	KeyBackedObjectProperty<LifetimeStats, _IncludeVersion> lifetimeStats() {
 		return { subspace.pack(__FUNCTION__sr), IncludeVersion() };
 	}

--- a/fdbclient/include/fdbclient/ConsistencyScanInterface.actor.h
+++ b/fdbclient/include/fdbclient/ConsistencyScanInterface.actor.h
@@ -18,6 +18,10 @@
  * limitations under the License.
  */
 
+#include "fdbclient/SystemData.h"
+#include "fdbclient/json_spirit/json_spirit_value.h"
+#include "flow/serialize.h"
+#include "fmt/core.h"
 #if defined(NO_INTELLISENSE) && !defined(FDBCLIENT_CONSISTENCYSCANINTERFACE_ACTOR_G_H)
 #define FDBCLIENT_CONSISTENCYSCANINTERFACE_ACTOR_G_H
 #include "fdbclient/ConsistencyScanInterface.actor.g.h"
@@ -30,6 +34,8 @@
 #include "fdbclient/RunRYWTransaction.actor.h"
 #include "fdbrpc/fdbrpc.h"
 #include "fdbrpc/Locality.h"
+#include "fdbclient/KeyBackedTypes.actor.h"
+#include "fdbclient/KeyBackedRangeMap.actor.h"
 
 #include "flow/actorcompiler.h" // must be last include
 
@@ -69,96 +75,224 @@ struct HaltConsistencyScanRequest {
 	}
 };
 
-// consistency scan configuration and metrics
-struct ConsistencyScanInfo {
-	constexpr static FileIdentifier file_identifier = 732125;
-	bool consistency_scan_enabled = false;
-	bool restart = false;
-	int64_t max_rate = 0;
-	int64_t target_interval = CLIENT_KNOBS->CONSISTENCY_CHECK_ONE_ROUND_TARGET_COMPLETION_TIME;
-	int64_t bytes_read_prev_round = 0;
-	KeyRef progress_key = KeyRef();
+// Consistency Scan State
+// This class provides access to the Consistency Scan's state stored in the database.
+// The state is divided into these components
+//   Config - Tells the scan whether and how to run.  Written by user, read by scan.
+//   RangeConfig - Tells the scan what ranges to operate on or ignore
+//
+//   CurrentRoundStats - Execution state and stats for the current round
+//   RoundHistory - History of RoundInfo's by start version (TODO)
+// 	 LifetimeStats - Accumulated lifetime counts for the cluster
+//
+// The class trigger will only be fired by changes to Config or RangeConfig
+struct ConsistencyScanState : public KeyBackedClass {
+	ConsistencyScanState(Key prefix = SystemKey("\xff/consistencyScanState"_sr)) : KeyBackedClass(prefix) {}
 
-	// Round Metrics - one round of complete validation across all SSs
-	// Start and finish are in epoch seconds
-	double last_round_start = 0;
-	double last_round_finish = 0;
-	TimerSmoother smoothed_round_duration;
-	int finished_rounds = 0;
+	struct Config {
+		constexpr static FileIdentifier file_identifier = 23123;
 
-	ConsistencyScanInfo() : smoothed_round_duration(20.0 * 60) {}
-	ConsistencyScanInfo(bool enabled, bool r, uint64_t rate, uint64_t interval)
-	  : consistency_scan_enabled(enabled), restart(r), max_rate(rate), target_interval(interval),
-	    smoothed_round_duration(20.0 * 60) {}
+		bool enabled = false;
 
-	template <class Ar>
-	void serialize(Ar& ar) {
-		double round_total;
-		if (!ar.isDeserializing) {
-			round_total = smoothed_round_duration.getTotal();
+		// The values below are NOT being intialized from knobs because once the scan is enabled
+		// changing the knobs does nothing.  The consistency check knobs are for the consistency
+		// check workload, which is different from the Consistency Scan feature
+
+		// Max byte read bandwidth allowed, default 50 MB/s
+		int64_t maxReadByteRate = 50e6;
+		// Target time in seconds for completion of one full scan of the database, default 30 days.
+		int64_t targetRoundTimeSeconds = 60 * 60 * 24 * 30;
+		// Minimum time in seconds a round should take.
+
+		// If a round completes faster than this, the scanner will delay afterwards, though if the
+		// scan role is restarted it will start a new scan.
+		int64_t minRoundTimeSeconds = 60 * 60 * 24 * 30;
+
+		// The minimum start version allowed for the current round.  If the round started before this
+		// it will be ended without completion, moved to history, and a new round will begin.
+		Version minStartVersion = 0;
+
+		// Number of days of history to keep, this is enforced using CORE_VERSIONSPERSECOND
+		int64_t roundHistoryDays = 90;
+
+		json_spirit::mObject toJSON() const {
+			json_spirit::mObject doc;
+			doc["enabled"] = true;
+			doc["max_rate_bytes_per_second"] = maxReadByteRate;
+			doc["target_interval_seconds"] = targetRoundTimeSeconds;
+			doc["min_interval_seconds"] = minRoundTimeSeconds;
+			doc["min_start_version"] = minStartVersion;
+			doc["round_history_days"] = roundHistoryDays;
+			return doc;
 		}
-		serializer(ar,
-		           consistency_scan_enabled,
-		           restart,
-		           max_rate,
-		           target_interval,
-		           bytes_read_prev_round,
-		           last_round_start,
-		           last_round_finish,
-		           round_total,
-		           finished_rounds);
-		if (ar.isDeserializing) {
-			smoothed_round_duration.reset(round_total);
+
+		template <class Ar>
+		void serialize(Ar& ar) {
+			serializer(ar,
+			           enabled,
+			           maxReadByteRate,
+			           targetRoundTimeSeconds,
+			           minRoundTimeSeconds,
+			           minStartVersion,
+			           roundHistoryDays);
 		}
+	};
+
+	// Configuration value in a range map for a key range
+	struct RangeConfig {
+		constexpr static FileIdentifier file_identifier = 84636323;
+
+		// Whether the range is included as a configured target for the scan
+		// This should normally be set by the user
+		Optional<bool> included;
+
+		// Whether the range should be currently even though it remains a scan target
+		// This should be set by operations on the cluster that would make shards temporarily inconsistent.
+		Optional<bool> skip;
+
+		RangeConfig apply(RangeConfig const& rhs) const {
+			RangeConfig result = *this;
+			if (rhs.included.present()) {
+				result.included = rhs.included;
+			}
+			if (rhs.skip.present()) {
+				result.skip = rhs.skip;
+			}
+			return result;
+		}
+
+		template <class Ar>
+		void serialize(Ar& ar) {
+			serializer(ar, included, skip);
+		}
+
+		std::string toString() const { return fmt::format("included={} skip={}", included, skip); }
+		json_spirit::mObject toJSON() const {
+			json_spirit::mObject doc;
+			if (included.present()) {
+				doc["included"] = *included;
+			}
+			if (skip.present()) {
+				doc["skip"] = *skip;
+			}
+			return doc;
+		}
+	};
+
+	struct LifetimeStats {
+		constexpr static FileIdentifier file_identifier = 7897646;
+
+		// Amount of FDB keyspace read, regardless of replication
+		int64_t logicalBytesScanned = 0;
+		// Actual amount of data read from shard replicas
+		int64_t replicatedBytesRead = 0;
+		int64_t errorCount = 0;
+
+		template <class Ar>
+		void serialize(Ar& ar) {
+			serializer(ar, logicalBytesScanned, replicatedBytesRead, errorCount);
+		}
+
+		json_spirit::mObject toJSON() const {
+			json_spirit::mObject doc;
+			doc["logical_bytes_scanned"] = logicalBytesScanned;
+			doc["replicated_bytes_scanned"] = replicatedBytesRead;
+			doc["errors"] = errorCount;
+			return doc;
+		}
+	};
+
+	struct RoundStats {
+		constexpr static FileIdentifier file_identifier = 23126;
+
+		Version startVersion = 0;
+		double startTime = 0;
+		Version endVersion = 0;
+		double endTime = 0;
+
+		// Whether the scan finished, useful for history round stats.
+		bool complete = false;
+
+		// Amount of FDB keyspace read, regardless of replication
+		int64_t logicalBytesScanned = 0;
+		// Actual amount of data read from shard replicas
+		int64_t replicatedBytesRead = 0;
+		int64_t errorCount = 0;
+
+		Key lastEndKey = ""_sr;
+
+		/*
+		// TODO:  Ideas of more things to track:
+		int64_t shardsScanned = 0;
+		int64_t replicasScanned = 0;
+		// Shards or replicas can be skipped due to being offline or locked
+		int64_t shardsSkipped = 0;
+		int64_t replicasSkipped = 0;
+		*/
+
+		template <class Ar>
+		void serialize(Ar& ar) {
+			serializer(ar,
+			           startVersion,
+			           startTime,
+			           endVersion,
+			           endTime,
+			           complete,
+			           logicalBytesScanned,
+			           replicatedBytesRead,
+			           errorCount,
+			           lastEndKey);
+		}
+
+		json_spirit::mObject toJSON() const {
+			json_spirit::mObject doc;
+			doc["complete"] = complete;
+			doc["start_version"] = startVersion;
+			doc["start_timestamp"] = startTime;
+			doc["end_version"] = endVersion;
+			doc["end_timestamp"] = endTime;
+			doc["logical_bytes_scanned"] = logicalBytesScanned;
+			doc["replicated_bytes_scanned"] = replicatedBytesRead;
+			doc["errors"] = errorCount;
+			doc["last_end_key"] = lastEndKey.toString();
+			return doc;
+		}
+	};
+
+	// Range map for configuring key range options.  By default, all ranges are scanned.
+	typedef KeyBackedRangeMap<Key, RangeConfig, TupleCodec<Key>, ObjectCodec<RangeConfig, _IncludeVersion>>
+	    RangeConfigMap;
+
+	// Map of scan start version to its stats so a history can be maintained.
+	typedef KeyBackedObjectMap<Version, RoundStats, _IncludeVersion> StatsHistoryMap;
+
+	// TODO:  This is not used yet so it is commented out.
+	// rangeConfig() must be watched and obeyed by the actual data scan
+	// RangeConfigMap rangeConfig() {
+	// 	// Updating rangeConfig updates the class trigger
+	// 	return { subspace.pack(__FUNCTION__sr), trigger, IncludeVersion() };
+	// }
+
+	KeyBackedObjectProperty<Config, _IncludeVersion> config() {
+		// Updating rangeConfig updates the class trigger
+		return { subspace.pack(__FUNCTION__sr), IncludeVersion(), trigger };
 	}
 
-	static Future<Void> setInfo(Reference<ReadYourWritesTransaction> tr, ConsistencyScanInfo info) {
-		tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
-		tr->setOption(FDBTransactionOptions::LOCK_AWARE);
-		tr->set(consistencyScanInfoKey, ObjectWriter::toValue(info, IncludeVersion()));
-		return Void();
+	KeyBackedObjectProperty<LifetimeStats, _IncludeVersion> lifetimeStats() {
+		return { subspace.pack(__FUNCTION__sr), IncludeVersion() };
 	}
 
-	static Future<Void> setInfo(Database cx, ConsistencyScanInfo info) {
-		return runRYWTransaction(
-		    cx, [=](Reference<ReadYourWritesTransaction> tr) -> Future<Void> { return setInfo(tr, info); });
+	KeyBackedObjectProperty<RoundStats, _IncludeVersion> currentRoundStats() {
+		return { subspace.pack(__FUNCTION__sr), IncludeVersion() };
 	}
 
-	static Future<Optional<Value>> getInfo(Reference<ReadYourWritesTransaction> tr) {
-		tr->setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
-		tr->setOption(FDBTransactionOptions::READ_LOCK_AWARE);
-		return tr->get(consistencyScanInfoKey);
-	}
-
-	static Future<Optional<Value>> getInfo(Database cx) {
-		return runRYWTransaction(
-		    cx, [=](Reference<ReadYourWritesTransaction> tr) -> Future<Optional<Value>> { return getInfo(tr); });
-	}
-
-	StatusObject toJSON() const {
-		StatusObject result;
-		result["consistency_scan_enabled"] = consistency_scan_enabled;
-		result["restart"] = restart;
-		result["max_rate"] = max_rate;
-		result["target_interval"] = target_interval;
-		result["bytes_read_prev_round"] = bytes_read_prev_round;
-		result["last_round_start_datetime"] = epochsToGMTString(last_round_start);
-		result["last_round_finish_datetime"] = epochsToGMTString(last_round_finish);
-		result["last_round_start_timestamp"] = last_round_start;
-		result["last_round_finish_timestamp"] = last_round_finish;
-		result["smoothed_round_seconds"] = smoothed_round_duration.smoothTotal();
-		result["finished_rounds"] = finished_rounds;
-		return result;
-	}
-
-	std::string toString() const {
-		return format("consistency_scan_enabled = %d, restart =  %d, max_rate = %ld, target_interval = %ld",
-		              consistency_scan_enabled,
-		              restart,
-		              max_rate,
-		              target_interval);
-	}
+	// History of scan round stats stored by their start version
+	// TODO:  This is not used yet so it is commented out.
+	StatsHistoryMap roundStatsHistory() { return { subspace.pack(__FUNCTION__sr), IncludeVersion() }; }
 };
+
+/////////////////////
+// Code below this line is not used by the Consistency Scan Role, only the ConsistencyCheck Workload.
 
 ACTOR Future<Version> getVersion(Database cx);
 ACTOR Future<bool> getKeyServers(
@@ -192,7 +326,6 @@ ACTOR Future<Void> checkDataConsistency(Database cx,
                                         int restart,
                                         int64_t maxRate,
                                         int64_t targetInterval,
-                                        KeyRef progressKey,
                                         bool* success);
 
 #include "flow/unactorcompiler.h"

--- a/fdbclient/include/fdbclient/KeyBackedTypes.actor.h
+++ b/fdbclient/include/fdbclient/KeyBackedTypes.actor.h
@@ -518,20 +518,6 @@ public:
 	typedef KeyBackedProperty<ValueType, ValueCodec> SingleRecordProperty;
 	typedef TypedKeySelector<KeyType, KeyCodec> KeySelector;
 
-	template <class DB>
-	Future<RangeResultType> getRange(Optional<KeyType> const& begin,
-	                                 Optional<KeyType> const& end,
-	                                 int limit,
-	                                 Reference<DB> db,
-	                                 Snapshot snapshot = Snapshot::False,
-	                                 Reverse reverse = Reverse::False) const {
-		return runTransaction(db, [=, this](Reference<typename DB::TransactionT> tr) {
-			tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
-			tr->setOption(FDBTransactionOptions::LOCK_AWARE);
-			return this->getRange(tr, begin, end, limit, snapshot, reverse);
-		});
-	}
-
 	// If end is not present one key past the end of the map is used.
 	template <class Transaction>
 	Future<RangeResultType> getRange(Transaction tr,
@@ -540,25 +526,34 @@ public:
 	                                 int limit,
 	                                 Snapshot snapshot = Snapshot::False,
 	                                 Reverse reverse = Reverse::False) const {
-		Key beginKey = begin.present() ? packKey(begin.get()) : subspace.begin;
-		Key endKey = end.present() ? packKey(end.get()) : subspace.end;
 
-		typename transaction_future_type<Transaction, RangeResult>::type getRangeFuture =
-		    tr->getRange(KeyRangeRef(beginKey, endKey), GetRangeLimits(limit), snapshot, reverse);
+		if constexpr (is_transaction_creator<Transaction>) {
+			return runTransaction(tr, [=, self = *this](decltype(tr->createTransaction()) tr) {
+				tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+				tr->setOption(FDBTransactionOptions::LOCK_AWARE);
+				return self.getRange(tr, begin, end, limit, snapshot, reverse);
+			});
+		} else {
+			Key beginKey = begin.present() ? packKey(begin.get()) : subspace.begin;
+			Key endKey = end.present() ? packKey(end.get()) : subspace.end;
 
-		return holdWhile(
-		    getRangeFuture,
-		    map(safeThreadFutureToFuture(getRangeFuture),
-		        [prefix = subspace.begin, valueCodec = valueCodec](RangeResult const& kvs) -> RangeResultType {
-			        RangeResultType rangeResult;
-			        for (int i = 0; i < kvs.size(); ++i) {
-				        KeyType key = KeyCodec::unpack(kvs[i].key.removePrefix(prefix));
-				        ValueType val = valueCodec.unpack(kvs[i].value);
-				        rangeResult.results.push_back(PairType(key, val));
-			        }
-			        rangeResult.more = kvs.more;
-			        return rangeResult;
-		        }));
+			typename transaction_future_type<Transaction, RangeResult>::type getRangeFuture =
+			    tr->getRange(KeyRangeRef(beginKey, endKey), GetRangeLimits(limit), snapshot, reverse);
+
+			return holdWhile(
+			    getRangeFuture,
+			    map(safeThreadFutureToFuture(getRangeFuture),
+			        [prefix = subspace.begin, valueCodec = valueCodec](RangeResult const& kvs) -> RangeResultType {
+				        RangeResultType rangeResult;
+				        for (int i = 0; i < kvs.size(); ++i) {
+					        KeyType key = KeyCodec::unpack(kvs[i].key.removePrefix(prefix));
+					        ValueType val = valueCodec.unpack(kvs[i].value);
+					        rangeResult.results.push_back(PairType(key, val));
+				        }
+				        rangeResult.more = kvs.more;
+				        return rangeResult;
+			        }));
+		}
 	}
 
 	ACTOR template <class Transaction>

--- a/fdbclient/include/fdbclient/SystemData.h
+++ b/fdbclient/include/fdbclient/SystemData.h
@@ -195,9 +195,6 @@ extern const KeyRef cacheChangePrefix;
 const Key cacheChangeKeyFor(uint16_t idx);
 uint16_t cacheChangeKeyDecodeIndex(const KeyRef& key);
 
-// For persisting the consistency scan configuration and metrics
-extern const KeyRef consistencyScanInfoKey;
-
 // "\xff/tss/[[serverId]]" := "[[tssId]]"
 extern const KeyRangeRef tssMappingKeys;
 

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -3569,13 +3569,12 @@ ACTOR Future<StatusReply> clusterGetStatus(
 			}
 			csDoc["previous_rounds"] = olderRounds;
 
-			statusObj["consistency_scan"] = config.toJSON();
-			// TODO:  Update JSON schemas in code and documentation
+			statusObj["consistency_scan"] = csDoc;
 		} catch (Error& e) {
 			if (e.code() == error_code_actor_cancelled)
 				throw;
-			messages.push_back(JsonString::makeMessage("fetch_consistency_scan_info_timeout",
-			                                           "Fetching consistency scan information timed out."));
+			messages.push_back(JsonString::makeMessage("fetch_consistency_scan_status_timeout",
+			                                           "Fetching consistency scan state timed out."));
 		}
 
 		// Create the status_incomplete message if there were any reasons that the status is incomplete.

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -3561,8 +3561,8 @@ ACTOR Future<StatusReply> clusterGetStatus(
 			    2.0));
 			json_spirit::mObject csDoc;
 			csDoc["configuration"] = config.toJSON();
-			csDoc["current_round"] = currentRound.toJSON();
 			csDoc["lifetime_stats"] = lifetime.toJSON();
+			csDoc["current_round"] = currentRound.toJSON();
 			json_spirit::mArray olderRounds;
 			for (auto const& kv : olderStats.results) {
 				olderRounds.push_back(kv.second.toJSON());
@@ -3570,7 +3570,7 @@ ACTOR Future<StatusReply> clusterGetStatus(
 			csDoc["previous_rounds"] = olderRounds;
 
 			statusObj["consistency_scan"] = config.toJSON();
-			// TODO:  Update JSON schemas
+			// TODO:  Update JSON schemas in code and documentation
 		} catch (Error& e) {
 			if (e.code() == error_code_actor_cancelled)
 				throw;

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -20,6 +20,7 @@
 
 #include <cinttypes>
 #include "fdbclient/BlobGranuleCommon.h"
+#include "fdbclient/json_spirit/json_spirit_value.h"
 #include "fdbserver/BlobGranuleServerCommon.actor.h"
 #include "fdbserver/BlobManagerInterface.h"
 #include "fmt/format.h"
@@ -2999,25 +3000,6 @@ ACTOR Future<JsonBuilderObject> storageWigglerStatsFetcher(Optional<DataDistribu
 	return res;
 }
 
-// read consistencyScanInfo through Read-only tx
-ACTOR Future<Optional<Value>> consistencyScanInfoFetcher(Database cx) {
-	state Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
-	state Optional<Value> val;
-	loop {
-		try {
-			tr->setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
-			wait(store(val, ConsistencyScanInfo::getInfo(tr)));
-			wait(tr->commit());
-			break;
-		} catch (Error& e) {
-			wait(tr->onError(e));
-		}
-	}
-
-	TraceEvent("ConsistencyScanInfoFetcher").log();
-	return val;
-}
-
 // constructs the cluster section of the json status output
 ACTOR Future<StatusReply> clusterGetStatus(
     Reference<AsyncVar<ServerDBInfo>> db,
@@ -3563,13 +3545,32 @@ ACTOR Future<StatusReply> clusterGetStatus(
 
 		// Fetch Consistency Scan Information
 		try {
-			Optional<Value> val = wait(timeoutError(consistencyScanInfoFetcher(cx), 2.0));
-			if (val.present()) {
-				ConsistencyScanInfo consistencyScanInfo =
-				    ObjectReader::fromStringRef<ConsistencyScanInfo>(val.get(), IncludeVersion());
-				TraceEvent("StatusConsistencyScanGotVal").log();
-				statusObj["consistency_scan_info"] = consistencyScanInfo.toJSON();
+			state ConsistencyScanState cs;
+			state ConsistencyScanState::Config config;
+			state ConsistencyScanState::RoundStats currentRound;
+			state ConsistencyScanState::LifetimeStats lifetime;
+			state ConsistencyScanState::StatsHistoryMap::RangeResultType olderStats;
+			auto sysDB = SystemDBWriteLockedNow(cx.getReference());
+
+			// TODO: Use the same transaction.
+			wait(timeoutError(
+			    store(config, cs.config().getD(sysDB)) && store(currentRound, cs.currentRoundStats().getD(sysDB)) &&
+			        store(lifetime, cs.lifetimeStats().getD(sysDB)) &&
+			        store(olderStats,
+			              cs.roundStatsHistory().getRange(sysDB, {}, {}, 5, Snapshot::False, Reverse::True)),
+			    2.0));
+			json_spirit::mObject csDoc;
+			csDoc["configuration"] = config.toJSON();
+			csDoc["current_round"] = currentRound.toJSON();
+			csDoc["lifetime_stats"] = lifetime.toJSON();
+			json_spirit::mArray olderRounds;
+			for (auto const& kv : olderStats.results) {
+				olderRounds.push_back(kv.second.toJSON());
 			}
+			csDoc["previous_rounds"] = olderRounds;
+
+			statusObj["consistency_scan"] = config.toJSON();
+			// TODO:  Update JSON schemas
 		} catch (Error& e) {
 			if (e.code() == error_code_actor_cancelled)
 				throw;

--- a/fdbserver/include/fdbserver/SingletonRoles.h
+++ b/fdbserver/include/fdbserver/SingletonRoles.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include "fdbserver/ClusterController.actor.h"
 #include "fdbserver/RatekeeperInterface.h"
 #include "fdbserver/DataDistributorInterface.h"
 

--- a/fdbserver/workloads/ConsistencyCheck.actor.cpp
+++ b/fdbserver/workloads/ConsistencyCheck.actor.cpp
@@ -383,7 +383,6 @@ struct ConsistencyCheckWorkload : TestWorkload {
 						                          true,
 						                          self->rateLimitMax,
 						                          CLIENT_KNOBS->CONSISTENCY_CHECK_ONE_ROUND_TARGET_COMPLETION_TIME,
-						                          KeyRef(),
 						                          &self->success));
 
 						// Cache consistency check


### PR DESCRIPTION
`ConsistencyScanState` is introduced as a `KeyBackedClass` which provides access and watchability to the consistency scan configuration and access to (improved) stats and execution state which does not interfere with control state. 

The state is divided into sub-objects
- Config - Tells the scan whether and how to run.  Written by user, read by scan.  Connected to the class's `WatchableTrigger`.
- RangeConfig - `KeyBackedRangeMap` which tells the scan what ranges to operate on or ignore.  Connected to the class's `WatchableTrigger`.  This is defined but not used yet.
- RoundStats - Stats and progress state for the a Round.  
- RoundStatsHistory - the last 90 days (by default) of RoundStats
- LifetimeStats - a subset of Stats counts but for all time for the cluster

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
