### PR TITLE
Avoid double escaping for SSValidateRangeKeyOutOfRange events

### DIFF
--- a/fdbserver/BackupWorker.actor.cpp
+++ b/fdbserver/BackupWorker.actor.cpp
@@ -806,7 +806,7 @@ ACTOR Future<Void> saveMutationsToFile(BackupData* self,
 		if (!message.isCandidateBackupMessage(&m, cipherKeys))
 			continue;
 
-		DEBUG_MUTATION("addMutation", message.version.version, m)
+		DEBUG_MUTATION("addMutation", message.version.version, m, self->myId)
 		    .detail("KCV", self->minKnownCommittedVersion)
 		    .detail("SavedVersion", self->savedVersion);
 

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -4738,9 +4738,9 @@ ACTOR Future<Void> validateRangeAgainstServer(StorageServer* data,
 				if (!range.contains(remoteKV.key) || !range.contains(localKV.key)) {
 					TraceEvent(SevWarn, "SSValidateRangeKeyOutOfRange", data->thisServerID)
 					    .detail("Range", range)
-					    .detail("RemoteServer", remoteServer.toString().c_str())
-					    .detail("LocalKey", Traceable<StringRef>::toString(localKV.key).c_str())
-					    .detail("RemoteKey", Traceable<StringRef>::toString(remoteKV.key).c_str());
+					    .detail("RemoteServer", remoteServer.toString())
+					    .detail("LocalKey", localKV.key)
+					    .detail("RemoteKey", remoteKV.key);
 					throw wrong_shard_server();
 				}
 


### PR DESCRIPTION
So that `\x00\x01` won't be logged as `\\x00\\x01`.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
