### PR TITLE
AsyncFileWriteChecker false-positive bug fix and sim-only Redwood shutdown improvements found along the way.

### DIFF
--- a/fdbrpc/include/fdbrpc/AsyncFileWriteChecker.h
+++ b/fdbrpc/include/fdbrpc/AsyncFileWriteChecker.h
@@ -35,12 +35,7 @@ public:
 		// Lambda must hold a reference to this to keep it alive until after the read
 		auto self = Reference<AsyncFileWriteChecker>::addRef(this);
 		return map(m_f->read(data, length, offset), [self, data, offset](int r) {
-			// Do not check the checksum if self is the sole owner of the reference because the end user has dropped the
-			// file handle and may already have re-opened the file and written to it before this read completed so our
-			// stored checksum can be wrong.
-			if (!self->isSoleOwner()) {
-				self->updateChecksumHistory(false, offset, r, (uint8_t*)data);
-			}
+			self->updateChecksumHistory(false, offset, r, (uint8_t*)data);
 			return r;
 		});
 	}
@@ -48,12 +43,7 @@ public:
 		// Lambda must hold a reference to this to keep it alive until after the read
 		auto self = Reference<AsyncFileWriteChecker>::addRef(this);
 		return map(m_f->readZeroCopy(data, length, offset), [self, data, length, offset](Void r) {
-			// Do not check the checksum if self is the sole owner of the reference because the end user has dropped the
-			// file handle and may already have re-opened the file and written to it before this read completed so our
-			// stored checksum can be wrong.
-			if (!self->isSoleOwner()) {
-				self->updateChecksumHistory(false, offset, *length, (uint8_t*)data);
-			}
+			self->updateChecksumHistory(false, offset, *length, (uint8_t*)data);
 			return r;
 		});
 	}

--- a/fdbrpc/include/fdbrpc/AsyncFileWriteChecker.h
+++ b/fdbrpc/include/fdbrpc/AsyncFileWriteChecker.h
@@ -35,7 +35,12 @@ public:
 		// Lambda must hold a reference to this to keep it alive until after the read
 		auto self = Reference<AsyncFileWriteChecker>::addRef(this);
 		return map(m_f->read(data, length, offset), [self, data, offset](int r) {
-			self->updateChecksumHistory(false, offset, r, (uint8_t*)data);
+			// Do not check the checksum if self is the sole owner of the reference because the end user has dropped the
+			// file handle and may already have re-opened the file and written to it before this read completed so our
+			// stored checksum can be wrong.
+			if (!self->isSoleOwner()) {
+				self->updateChecksumHistory(false, offset, r, (uint8_t*)data);
+			}
 			return r;
 		});
 	}
@@ -43,7 +48,12 @@ public:
 		// Lambda must hold a reference to this to keep it alive until after the read
 		auto self = Reference<AsyncFileWriteChecker>::addRef(this);
 		return map(m_f->readZeroCopy(data, length, offset), [self, data, length, offset](Void r) {
-			self->updateChecksumHistory(false, offset, *length, (uint8_t*)data);
+			// Do not check the checksum if self is the sole owner of the reference because the end user has dropped the
+			// file handle and may already have re-opened the file and written to it before this read completed so our
+			// stored checksum can be wrong.
+			if (!self->isSoleOwner()) {
+				self->updateChecksumHistory(false, offset, *length, (uint8_t*)data);
+			}
 			return r;
 		});
 	}

--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -2882,10 +2882,6 @@ Future<Reference<class IAsyncFile>> Sim2FileSystem::open(const std::string& file
 			auto partFile = machineCache.find(actualFilename);
 			if (partFile != machineCache.end()) {
 				Future<Reference<IAsyncFile>> f = AsyncFileDetachable::open(partFile->second.get());
-				if (FLOW_KNOBS->PAGE_WRITE_CHECKSUM_HISTORY > 0)
-					f = map(f, [=](Reference<IAsyncFile> r) {
-						return Reference<IAsyncFile>(new AsyncFileWriteChecker(r));
-					});
 				return f;
 			}
 		}
@@ -2897,11 +2893,15 @@ Future<Reference<class IAsyncFile>> Sim2FileSystem::open(const std::string& file
 			// This way, they can both keep up with the time to start the next operation
 			auto diskParameters =
 			    makeReference<DiskParameters>(FLOW_KNOBS->SIM_DISK_IOPS, FLOW_KNOBS->SIM_DISK_BANDWIDTH);
-			f = AsyncFileNonDurable::open(filename,
-			                              actualFilename,
-			                              SimpleFile::open(filename, flags, mode, diskParameters, false),
-			                              diskParameters,
-			                              (flags & IAsyncFile::OPEN_NO_AIO) == 0);
+
+			f = SimpleFile::open(filename, flags, mode, diskParameters, false);
+			if (FLOW_KNOBS->PAGE_WRITE_CHECKSUM_HISTORY > 0) {
+				f = map(f,
+				        [=](Reference<IAsyncFile> r) { return Reference<IAsyncFile>(new AsyncFileWriteChecker(r)); });
+			}
+
+			f = AsyncFileNonDurable::open(
+			    filename, actualFilename, f, diskParameters, (flags & IAsyncFile::OPEN_NO_AIO) == 0);
 
 			machineCache[actualFilename] = UnsafeWeakFutureReference<IAsyncFile>(f);
 		} else {
@@ -2909,8 +2909,6 @@ Future<Reference<class IAsyncFile>> Sim2FileSystem::open(const std::string& file
 		}
 
 		f = AsyncFileDetachable::open(f);
-		if (FLOW_KNOBS->PAGE_WRITE_CHECKSUM_HISTORY > 0)
-			f = map(f, [=](Reference<IAsyncFile> r) { return Reference<IAsyncFile>(new AsyncFileWriteChecker(r)); });
 		if (FLOW_KNOBS->ENABLE_CHAOS_FEATURES)
 			f = map(f, [=](Reference<IAsyncFile> r) { return Reference<IAsyncFile>(new AsyncFileChaos(r)); });
 		if (flags & IAsyncFile::OPEN_ENCRYPTED)

--- a/fdbserver/VersionedBTree.actor.cpp
+++ b/fdbserver/VersionedBTree.actor.cpp
@@ -8846,6 +8846,9 @@ void RedwoodMetrics::getFields(TraceEvent* e, std::string* s, bool skipZeroes) {
 		                                               { "", 0 } };
 
 	double elapsed = now() - startTime;
+	if (elapsed == 0) {
+		return;
+	}
 
 	if (e != nullptr) {
 		for (auto& m : metrics) {

--- a/fdbserver/VersionedBTree.actor.cpp
+++ b/fdbserver/VersionedBTree.actor.cpp
@@ -5363,6 +5363,7 @@ public:
 		// uncommitted writes so it should not be committed.
 		m_init.cancel();
 		m_latestCommit.cancel();
+		m_lazyClearActor.cancel();
 	}
 
 	Future<Void> commit(Version v) {

--- a/fdbserver/VersionedBTree.actor.cpp
+++ b/fdbserver/VersionedBTree.actor.cpp
@@ -3672,8 +3672,9 @@ public:
 			}
 		}
 
-		self->closedPromise.send(Void());
+		Promise<Void> closedPromise = self->closedPromise;
 		delete self;
+		closedPromise.send(Void());
 	}
 
 	void dispose() override { shutdown(this, true); }
@@ -5361,9 +5362,9 @@ public:
 		// This probably shouldn't be called directly (meaning deleting an instance directly) but it should be safe,
 		// it will cancel init and commit and leave the pager alive but with potentially an incomplete set of
 		// uncommitted writes so it should not be committed.
-		m_init.cancel();
 		m_latestCommit.cancel();
 		m_lazyClearActor.cancel();
+		m_init.cancel();
 	}
 
 	Future<Void> commit(Version v) {
@@ -8076,9 +8077,11 @@ public:
 		else
 			self->m_tree->close();
 		wait(closedFuture);
-		self->m_closed.send(Void());
+
+		Promise<Void> closedPromise = self->m_closed;
 		TraceEvent(SevInfo, "RedwoodShutdownComplete").detail("Filename", self->m_filename).detail("Dispose", dispose);
 		delete self;
+		closedPromise.send(Void());
 	}
 
 	void close() override { shutdown(this, false); }

--- a/fdbserver/include/fdbserver/VersionedBTreeDebug.h
+++ b/fdbserver/include/fdbserver/VersionedBTreeDebug.h
@@ -32,10 +32,13 @@ extern FILE* g_debugStream;
 // Knob to disable XOR encryption for unit tests that aren't compatible with XOR encryption.
 extern bool g_allowXOREncryptionInSimulation;
 
+// Applies filters for when debug lines should be printed, defined in
+// .cpp so it avoids a rebuild.
 bool enableRedwoodDebug();
 
+// debug_printf_always() always outputs the line regardless of REDWOOD_DEBUG or enableRedwoodDebug() filters
 #define debug_printf_always(...)                                                                                       \
-	if (enableRedwoodDebug()) {                                                                                        \
+	{                                                                                                                  \
 		std::string prefix = format("%s %f %04d ", g_network->getLocalAddress().toString().c_str(), now(), __LINE__);  \
 		std::string msg = format(__VA_ARGS__);                                                                         \
 		fputs(addPrefix(prefix, msg).c_str(), g_debugStream);                                                          \
@@ -48,8 +51,15 @@ bool enableRedwoodDebug();
 
 #if defined(NO_INTELLISENSE)
 #if REDWOOD_DEBUG
-#define debug_printf debug_printf_always
+
+// debug_print() only outputs the line if the enableRedwoodDebug() pass.
+#define debug_printf(...)                                                                                              \
+	if (enableRedwoodDebug()) {                                                                                        \
+		debug_printf_always(__VA_ARGS__);                                                                              \
+	}
 #else
+
+// Completely compile out debug statements if REDWOOD_DEBUG is off.
 #define debug_printf debug_printf_noop
 #endif
 #else


### PR DESCRIPTION
- Move AsyncFileWriteChecker to right above SimpleFile in the file stack in simulation, which is analogous to where it is created in production and prevents false positive errors caused by stacking it on top of AsyncFileNonDurable multiple times for different users of the same file.
- Explicitly cancel background actors in ~VersionedBTree() as a precaution in case they were to have references elsewhere when the tree is destroyed.
- Make ICloseable()::close() implementations in Redwood delete the object *before* triggering the onClosed() future, just in case a future use case would try to immediately reopen the instance in the callback that handles the closed signal.
- Fix divide by zero in RedwoodMetrics if no time has passed at all in the logging period (not possible outside of simulation).
- Restore original functionality of `debug_printf_always()` in Redwood.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
