### PR TITLE
Fix GlobalConfig_RetryableMigrationError when the database is locked

### DIFF
--- a/fdbclient/GlobalConfig.actor.cpp
+++ b/fdbclient/GlobalConfig.actor.cpp
@@ -176,6 +176,7 @@ ACTOR Future<Void> GlobalConfig::migrate(GlobalConfig* self) {
 		loop {
 			tr = makeReference<ReadYourWritesTransaction>(Database(Reference<DatabaseContext>::addRef(self->cx)));
 			tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+			tr->setOption(FDBTransactionOptions::LOCK_AWARE); // dr_agent
 
 			try {
 				state Optional<Value> migrated = wait(tr->get(migratedKey));
@@ -239,6 +240,7 @@ ACTOR Future<Void> GlobalConfig::refresh(GlobalConfig* self) {
 		try {
 			tr = makeReference<ReadYourWritesTransaction>(Database(Reference<DatabaseContext>::addRef(self->cx)));
 			tr->setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
+			tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 			RangeResult result = wait(tr->getRange(globalConfigDataKeys, CLIENT_KNOBS->TOO_MANY));
 			for (const auto& kv : result) {
 				KeyRef systemKey = kv.key.removePrefix(globalConfigKeysPrefix);

--- a/fdbclient/GlobalConfig.actor.cpp
+++ b/fdbclient/GlobalConfig.actor.cpp
@@ -176,7 +176,7 @@ ACTOR Future<Void> GlobalConfig::migrate(GlobalConfig* self) {
 		loop {
 			tr = makeReference<ReadYourWritesTransaction>(Database(Reference<DatabaseContext>::addRef(self->cx)));
 			tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
-			tr->setOption(FDBTransactionOptions::LOCK_AWARE); // dr_agent
+			tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 
 			try {
 				state Optional<Value> migrated = wait(tr->get(migratedKey));


### PR DESCRIPTION
Original bug report: https://forums.foundationdb.org/t/100-cpu-usage-on-an-idle-cluster/3928

In FoundationDB 7.1, if a database is locked (e.g. on DR destination clusters), the following error is reported periodically in fdbserver log. This seems to cause some tasks to leak, and the `Transaction started` metric keeps increasing until useless GRVs saturate the cluster and make it no longer responsive.

```
<Event Severity="10" Time="1682418199.889216" DateTime="2023-04-25T10:23:19Z" Type="GlobalConfig_RetryableMigrationError" ID="0000000000000000" Error="database_locked" ErrorDescription="Database is locked" ErrorCode="1038" SuppressedEventCount="32350" ThreadID="14882012433472669136" Machine="10.220.11.2:4500" LogGroup="default" Roles="CC,CD,CP,DD,GP,MS,RK,RV,SS,TL" />
```

This patch sets the `LOCK_AWARE` option on GlobalConfig refresh/migrate transactions to fix that issue.

`GlobalConfig::refresh` mechanisms seem to have changed on `main`, so this PR is made directly to the `release-7.1` branch.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [x] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
