### PR TITLE
Adding cleanup of audit progress metadata when audit complete

### DIFF
--- a/fdbclient/AuditUtils.actor.cpp
+++ b/fdbclient/AuditUtils.actor.cpp
@@ -147,13 +147,12 @@ ACTOR Future<Void> persistAuditState(Database cx,
                                      bool ddEnabled) {
 	state Transaction tr(cx);
 	state AuditPhase auditPhase = auditState.getPhase();
+	ASSERT(auditPhase == AuditPhase::Complete || auditPhase == AuditPhase::Failed || auditPhase == AuditPhase::Error);
 
 	loop {
 		try {
 			tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
 			tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
-			ASSERT(auditPhase == AuditPhase::Complete || auditPhase == AuditPhase::Failed ||
-			       auditPhase == AuditPhase::Error);
 			wait(checkMoveKeysLock(&tr, lock, ddEnabled, true));
 			// Clear persistent progress data of the new audit if complete
 			if (auditPhase == AuditPhase::Complete) {

--- a/fdbclient/SystemData.cpp
+++ b/fdbclient/SystemData.cpp
@@ -327,26 +327,46 @@ const KeyRange auditKeyRange(const AuditType type) {
 	return prefixRange(wr.toValue());
 }
 
-const Key auditRangePrefixFor(const AuditType type, const UID& auditId) {
+const Key auditRangeBasedProgressPrefixFor(const AuditType type, const UID& auditId) {
 	BinaryWriter wr(Unversioned());
 	wr.serializeBytes(auditRangePrefix);
 	wr << static_cast<uint8_t>(type);
 	wr.serializeBytes("/"_sr);
-	wr << auditId;
+	wr << bigEndian64(auditId.first());
 	wr.serializeBytes("/"_sr);
 	return wr.toValue();
 }
 
-const Key auditServerPrefixFor(const AuditType type, const UID& auditId, const UID& serverId) {
+const KeyRange auditRangeBasedProgressRangeFor(const AuditType type, const UID& auditId) {
+	BinaryWriter wr(Unversioned());
+	wr.serializeBytes(auditRangePrefix);
+	wr << static_cast<uint8_t>(type);
+	wr.serializeBytes("/"_sr);
+	wr << bigEndian64(auditId.first());
+	wr.serializeBytes("/"_sr);
+	return prefixRange(wr.toValue());
+}
+
+const Key auditServerBasedProgressPrefixFor(const AuditType type, const UID& auditId, const UID& serverId) {
 	BinaryWriter wr(Unversioned());
 	wr.serializeBytes(auditServerPrefix);
 	wr << static_cast<uint8_t>(type);
 	wr.serializeBytes("/"_sr);
-	wr << auditId;
+	wr << bigEndian64(auditId.first());
 	wr.serializeBytes("/"_sr);
-	wr << serverId;
+	wr << bigEndian64(serverId.first());
 	wr.serializeBytes("/"_sr);
 	return wr.toValue();
+}
+
+const KeyRange auditServerBasedProgressRangeFor(const AuditType type, const UID& auditId) {
+	BinaryWriter wr(Unversioned());
+	wr.serializeBytes(auditServerPrefix);
+	wr << static_cast<uint8_t>(type);
+	wr.serializeBytes("/"_sr);
+	wr << bigEndian64(auditId.first());
+	wr.serializeBytes("/"_sr);
+	return prefixRange(wr.toValue());
 }
 
 const Value auditStorageStateValue(const AuditStorageState& auditStorageState) {

--- a/fdbclient/include/fdbclient/SystemData.h
+++ b/fdbclient/include/fdbclient/SystemData.h
@@ -110,9 +110,13 @@ const Key auditKey(const AuditType type, const UID& auditId);
 // KeyRange for whole audit
 const KeyRange auditKeyRange(const AuditType type);
 // Prefix for audit work progress by range
-const Key auditRangePrefixFor(const AuditType type, const UID& auditId);
+const Key auditRangeBasedProgressPrefixFor(const AuditType type, const UID& auditId);
+// Range for audit work progress by range
+const KeyRange auditRangeBasedProgressRangeFor(const AuditType type, const UID& auditId);
 // Prefix for audit work progress by audit server id
-const Key auditServerPrefixFor(const AuditType type, const UID& auditId, const UID& serverId);
+const Key auditServerBasedProgressPrefixFor(const AuditType type, const UID& auditId, const UID& serverId);
+// Range for audit work progress by audit server id
+const KeyRange auditServerBasedProgressRangeFor(const AuditType type, const UID& auditId);
 
 const Value auditStorageStateValue(const AuditStorageState& auditStorageState);
 AuditStorageState decodeAuditStorageState(const ValueRef& value);

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -1954,10 +1954,11 @@ ACTOR Future<UID> launchAudit(Reference<DataDistributor> self, KeyRange auditRan
 			// Since the resumed audit has already taken over the launchAudit job,
 			// we simply retry this launchAudit, then return the audit id to client
 			if (g_network->isSimulated() && deterministicRandom()->coinflip()) {
-				TraceEvent(SevVerbose, "DDAuditStorageLaunchInjectActorCancelWhenPersist", self->ddId)
+				TraceEvent(SevDebug, "DDAuditStorageLaunchInjectActorCancelWhenPersist", self->ddId)
+				    .detail("AuditID", auditID_)
 				    .detail("AuditType", auditType)
 				    .detail("Range", auditRange);
-				throw operation_failed(); // Simulate restarting
+				throw operation_failed(); // Simulate failure
 			}
 			TraceEvent(SevInfo, "DDAuditStorageLaunchPersistNewAuditID", self->ddId)
 			    .detail("AuditID", auditID_)
@@ -1994,17 +1995,19 @@ ACTOR Future<Void> auditStorage(Reference<DataDistributor> self, TriggerAuditReq
 	loop {
 		try {
 			TraceEvent(SevDebug, "DDAuditStorageStart", self->ddId)
+			    .detail("RetryCount", retryCount)
 			    .detail("AuditType", req.getType())
 			    .detail("Range", req.range)
 			    .detail("IsReady", self->auditInitialized.getFuture().isReady());
 			UID auditID = wait(launchAudit(self, req.range, req.getType()));
 			req.reply.send(auditID);
 			TraceEvent(SevVerbose, "DDAuditStorageReply", self->ddId)
+			    .detail("RetryCount", retryCount)
 			    .detail("AuditType", req.getType())
 			    .detail("Range", req.range)
 			    .detail("AuditID", auditID);
 		} catch (Error& e) {
-			TraceEvent(SevDebug, "DDAuditStorageError", self->ddId)
+			TraceEvent(SevInfo, "DDAuditStorageError", self->ddId)
 			    .errorUnsuppressed(e)
 			    .detail("RetryCount", retryCount)
 			    .detail("AuditType", req.getType())

--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -1172,8 +1172,7 @@ ACTOR Future<Void> auditStorageCorrectness(Reference<AsyncVar<ServerDBInfo>> dbI
 	loop {
 		try {
 			TriggerAuditRequest req(auditType, allKeys);
-			UID auditId_ =
-			    wait(timeoutError(dbInfo->get().clusterInterface.clientInterface.triggerAudit.getReply(req), 300));
+			UID auditId_ = wait(timeoutError(dbInfo->get().distributor.get().triggerAudit.getReply(req), 300));
 			auditId = auditId_;
 			TraceEvent(SevDebug, "AuditStorageCorrectnessTriggered")
 			    .detail("AuditID", auditId)


### PR DESCRIPTION
This PR includes:
1. Cleanup audit progress metadata when audit complete;
2. Changing audit metadata name, highlighting the functionality of recording progress;
3. Tester issues audit requests directly to DD instead of CC.

100K Correctness test with 3 irrelevant failures:
20230503-195643-zhewang-9f3f469e1cacebd0           compressed=True data_size=33111807 duration=4589053 ended=100000 fail=3 fail_fast=10 max_runs=100000 pass=99997 priority=100 remaining=0 runtime=1:28:14 sanity=False started=100000 stopped=20230503-212457 submitted=20230503-195643 timeout=5400 username=zhewang

100K AduitStorageTest:
20230503-195709-zhewang-bd26ae660974c954           compressed=True data_size=33143943 duration=3145881 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:12:21 sanity=False started=100000 stopped=20230503-210930 submitted=20230503-195709 timeout=5400 username=zhewang

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
