### PR TITLE
AsyncFileWriteChecker false-positive bug fix and sim-only Redwood shutdown improvements found along the way. (Cherry-Pick #10109 to snowflake/release-71.3)

### DIFF
--- a/fdbrpc/include/fdbrpc/AsyncFileWriteChecker.h
+++ b/fdbrpc/include/fdbrpc/AsyncFileWriteChecker.h
@@ -35,7 +35,12 @@ public:
 		// Lambda must hold a reference to this to keep it alive until after the read
 		auto self = Reference<AsyncFileWriteChecker>::addRef(this);
 		return map(m_f->read(data, length, offset), [self, data, offset](int r) {
-			self->updateChecksumHistory(false, offset, r, (uint8_t*)data);
+			// Do not check the checksum if self is the sole owner of the reference because the end user has dropped the
+			// file handle and may already have re-opened the file and written to it before this read completed so our
+			// stored checksum can be wrong.
+			if (!self->isSoleOwner()) {
+				self->updateChecksumHistory(false, offset, r, (uint8_t*)data);
+			}
 			return r;
 		});
 	}
@@ -43,7 +48,12 @@ public:
 		// Lambda must hold a reference to this to keep it alive until after the read
 		auto self = Reference<AsyncFileWriteChecker>::addRef(this);
 		return map(m_f->readZeroCopy(data, length, offset), [self, data, length, offset](Void r) {
-			self->updateChecksumHistory(false, offset, *length, (uint8_t*)data);
+			// Do not check the checksum if self is the sole owner of the reference because the end user has dropped the
+			// file handle and may already have re-opened the file and written to it before this read completed so our
+			// stored checksum can be wrong.
+			if (!self->isSoleOwner()) {
+				self->updateChecksumHistory(false, offset, *length, (uint8_t*)data);
+			}
 			return r;
 		});
 	}

--- a/fdbserver/include/fdbserver/VersionedBTreeDebug.h
+++ b/fdbserver/include/fdbserver/VersionedBTreeDebug.h
@@ -32,10 +32,13 @@ extern FILE* g_debugStream;
 // Knob to disable XOR encryption for unit tests that aren't compatible with XOR encryption.
 extern bool g_allowXOREncryptionInSimulation;
 
+// Applies filters for when debug lines should be printed, defined in
+// .cpp so it avoids a rebuild.
 bool enableRedwoodDebug();
 
+// debug_printf_always() always outputs the line regardless of REDWOOD_DEBUG or enableRedwoodDebug() filters
 #define debug_printf_always(...)                                                                                       \
-	if (enableRedwoodDebug()) {                                                                                        \
+	{                                                                                                                  \
 		std::string prefix = format("%s %f %04d ", g_network->getLocalAddress().toString().c_str(), now(), __LINE__);  \
 		std::string msg = format(__VA_ARGS__);                                                                         \
 		fputs(addPrefix(prefix, msg).c_str(), g_debugStream);                                                          \
@@ -48,8 +51,15 @@ bool enableRedwoodDebug();
 
 #if defined(NO_INTELLISENSE)
 #if REDWOOD_DEBUG
-#define debug_printf debug_printf_always
+
+// debug_print() only outputs the line if the enableRedwoodDebug() pass.
+#define debug_printf(...)                                                                                              \
+	if (enableRedwoodDebug()) {                                                                                        \
+		debug_printf_always(__VA_ARGS__);                                                                              \
+	}
 #else
+
+// Completely compile out debug statements if REDWOOD_DEBUG is off.
 #define debug_printf debug_printf_noop
 #endif
 #else


### PR DESCRIPTION
Cherry-Pick of #10109

Original Description:

- Move AsyncFileWriteChecker to right above SimpleFile in the file stack in simulation, which is analogous to where it is created in production and prevents false positive errors caused by stacking it on top of AsyncFileNonDurable multiple times for different users of the same file.
- Explicitly cancel background actors in ~VersionedBTree() as a precaution in case they were to have references elsewhere when the tree is destroyed.
- Make ICloseable()::close() implementations in Redwood delete the object *before* triggering the onClosed() future, just in case a future use case would try to immediately reopen the instance in the callback that handles the closed signal.
- Fix divide by zero in RedwoodMetrics if no time has passed at all in the logging period (not possible outside of simulation).
- Restore original functionality of `debug_printf_always()` in Redwood.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
