### PR TITLE
Blob kms connector ids

### DIFF
--- a/fdbclient/BlobConnectionProvider.cpp
+++ b/fdbclient/BlobConnectionProvider.cpp
@@ -45,91 +45,61 @@ private:
 	Reference<BackupContainerFileSystem> conn;
 };
 
-struct PartitionedBlobConnectionProvider : BlobConnectionProvider {
-	std::pair<Reference<BackupContainerFileSystem>, std::string> createForWrite(std::string newFileName) {
-		// choose a partition randomly, to distribute load
-		int writePartition = deterministicRandom()->randomInt(0, metadata.partitions.size());
-		return std::pair(conn, metadata.partitions[writePartition].toString() + newFileName);
-	}
-
-	Reference<BackupContainerFileSystem> getForRead(std::string filePath) {
-		CODE_PROBE(isExpired(), "partitioned blob connection using expired blob metadata for read!");
-		return conn;
-	}
-
-	void updateMetadata(const Standalone<BlobMetadataDetailsRef>& newMetadata, bool checkPrevious) {
-		ASSERT(newMetadata.base.present());
-		ASSERT(newMetadata.partitions.size() >= 2);
-		for (auto& it : newMetadata.partitions) {
-			// these should be suffixes, not whole blob urls
-			ASSERT(it.toString().find("://") == std::string::npos);
-		}
-		if (checkPrevious) {
-			if (newMetadata.expireAt <= metadata.expireAt) {
-				return;
-			}
-			// FIXME: validate only the credentials changed and the location is the same
-			ASSERT(newMetadata.partitions.size() == metadata.partitions.size());
-			for (int i = 0; i < newMetadata.partitions.size(); i++) {
-				ASSERT(newMetadata.partitions[i] == metadata.partitions[i]);
-			}
-		}
-		metadata = newMetadata;
-		conn = BackupContainerFileSystem::openContainerFS(metadata.base.get().toString(), {}, {}, false);
-	}
-
-	PartitionedBlobConnectionProvider(const Standalone<BlobMetadataDetailsRef> metadata) {
-		updateMetadata(metadata, false);
-	}
-
-	bool needsRefresh() const { return now() >= metadata.refreshAt; }
-
-	bool isExpired() const { return now() >= metadata.expireAt; }
-
-	void update(Standalone<BlobMetadataDetailsRef> newBlobMetadata) { updateMetadata(newBlobMetadata, true); }
-
-private:
-	Standalone<BlobMetadataDetailsRef> metadata;
-	Reference<BackupContainerFileSystem> conn;
-};
-
 // Could always include number of partitions as validation in sanity check or something?
 // Ex: partition_numPartitions/filename instead of partition/filename
 struct StorageLocationBlobConnectionProvider : BlobConnectionProvider {
 	std::pair<Reference<BackupContainerFileSystem>, std::string> createForWrite(std::string newFileName) {
 		// choose a partition randomly, to distribute load
-		int writePartition = deterministicRandom()->randomInt(0, partitions.size());
-		// include partition information in the filename
-		return std::pair(partitions[writePartition], std::to_string(writePartition) + "/" + newFileName);
+		int writePartition = deterministicRandom()->randomInt(0, connections.size());
+		// include location id in the filename
+		BlobMetadataLocationId locationId = metadata.locations[writePartition].locationId;
+		return std::pair(connections[writePartition], std::to_string(locationId) + "/" + newFileName);
 	}
 
 	Reference<BackupContainerFileSystem> getForRead(std::string filePath) {
 		CODE_PROBE(isExpired(), "storage location blob connection using expired blob metadata for read!");
 		size_t slash = filePath.find("/");
 		ASSERT(slash != std::string::npos);
-		int partition = stoi(filePath.substr(0, slash));
-		ASSERT(partition >= 0);
-		ASSERT(partition < partitions.size());
-		return partitions[partition];
+
+		BlobMetadataLocationId locationId = stoll(filePath.substr(0, slash));
+		ASSERT(locationId >= 0);
+
+		auto conn = locationToConnectionIndex.find(locationId);
+		ASSERT(conn != locationToConnectionIndex.end());
+
+		int connectionIdx = conn->second;
+		ASSERT(connectionIdx >= 0);
+		ASSERT(connectionIdx < connections.size());
+		return connections[connectionIdx];
 	}
 
 	void updateMetadata(const Standalone<BlobMetadataDetailsRef>& newMetadata, bool checkPrevious) {
-		ASSERT(!newMetadata.base.present());
-		ASSERT(newMetadata.partitions.size() >= 2);
+		ASSERT(newMetadata.locations.size() >= 1);
 		if (checkPrevious) {
-			// FIXME: validate only the credentials changed and the locations are the same
-			ASSERT(newMetadata.partitions.size() == partitions.size());
+			// FIXME: validate only the credentials changed and the locations are the same. They don't necessarily need
+			// to be provided in the same order though.
+			ASSERT(newMetadata.locations.size() == metadata.locations.size());
+			ASSERT(newMetadata.locations.size() == locationToConnectionIndex.size());
+			for (int i = 0; i < newMetadata.locations.size(); i++) {
+				ASSERT(locationToConnectionIndex.count(newMetadata.locations[i].locationId));
+			}
 			if (newMetadata.expireAt <= metadata.expireAt) {
 				return;
 			}
 		}
 		metadata = newMetadata;
-		partitions.clear();
-		for (auto& it : metadata.partitions) {
+		connections.clear();
+		locationToConnectionIndex.clear();
+		for (int i = 0; i < metadata.locations.size(); i++) {
 			// these should be whole blob urls
-			ASSERT(it.toString().find("://") != std::string::npos);
-			partitions.push_back(BackupContainerFileSystem::openContainerFS(it.toString(), {}, {}, false));
+			auto& it = metadata.locations[i];
+			ASSERT(it.path.toString().find("://") != std::string::npos);
+			connections.push_back(BackupContainerFileSystem::openContainerFS(it.path.toString(), {}, {}, false));
+			locationToConnectionIndex[it.locationId] = i;
 		}
+
+		ASSERT(connections.size() == metadata.locations.size());
+		ASSERT(connections.size() == locationToConnectionIndex.size());
 	}
 
 	StorageLocationBlobConnectionProvider(const Standalone<BlobMetadataDetailsRef> metadata) {
@@ -144,7 +114,8 @@ struct StorageLocationBlobConnectionProvider : BlobConnectionProvider {
 
 private:
 	Standalone<BlobMetadataDetailsRef> metadata;
-	std::vector<Reference<BackupContainerFileSystem>> partitions;
+	std::vector<Reference<BackupContainerFileSystem>> connections;
+	std::unordered_map<BlobMetadataLocationId, int> locationToConnectionIndex;
 };
 
 Reference<BlobConnectionProvider> BlobConnectionProvider::newBlobConnectionProvider(std::string blobUrl) {
@@ -154,14 +125,5 @@ Reference<BlobConnectionProvider> BlobConnectionProvider::newBlobConnectionProvi
 
 Reference<BlobConnectionProvider> BlobConnectionProvider::newBlobConnectionProvider(
     Standalone<BlobMetadataDetailsRef> blobMetadata) {
-	if (blobMetadata.partitions.empty()) {
-		return makeReference<SingleBlobConnectionProvider>(blobMetadata.base.get().toString(), false);
-	} else {
-		ASSERT(blobMetadata.partitions.size() >= 2);
-		if (blobMetadata.base.present()) {
-			return makeReference<PartitionedBlobConnectionProvider>(blobMetadata);
-		} else {
-			return makeReference<StorageLocationBlobConnectionProvider>(blobMetadata);
-		}
-	}
+	return makeReference<StorageLocationBlobConnectionProvider>(blobMetadata);
 }

--- a/fdbclient/BlobConnectionProvider.cpp
+++ b/fdbclient/BlobConnectionProvider.cpp
@@ -76,6 +76,7 @@ struct StorageLocationBlobConnectionProvider : BlobConnectionProvider {
 	void updateMetadata(const Standalone<BlobMetadataDetailsRef>& newMetadata, bool checkPrevious) {
 		ASSERT(newMetadata.locations.size() >= 1);
 		if (checkPrevious) {
+			CODE_PROBE(true, "Updating blob metadata details with new credentials");
 			// FIXME: validate only the credentials changed and the locations are the same. They don't necessarily need
 			// to be provided in the same order though.
 			ASSERT(newMetadata.locations.size() == metadata.locations.size());

--- a/fdbclient/include/fdbclient/BlobConnectionProvider.h
+++ b/fdbclient/include/fdbclient/BlobConnectionProvider.h
@@ -41,6 +41,7 @@ struct BlobConnectionProvider : NonCopyable, ReferenceCounted<BlobConnectionProv
 
 	static Reference<BlobConnectionProvider> newBlobConnectionProvider(std::string blobUrl);
 
+	// FIXME: make this function dedupe location connections/providers across location ids
 	static Reference<BlobConnectionProvider> newBlobConnectionProvider(Standalone<BlobMetadataDetailsRef> blobMetadata);
 };
 

--- a/fdbclient/include/fdbclient/BlobMetadataUtils.h
+++ b/fdbclient/include/fdbclient/BlobMetadataUtils.h
@@ -25,21 +25,41 @@
 #include "flow/FileIdentifier.h"
 
 using BlobMetadataDomainId = int64_t;
+using BlobMetadataLocationId = int64_t;
 
 /*
- * There are 3 cases for blob metadata.
- *  1. A non-partitioned blob store. baseUrl is set, and partitions is empty. Files will be written with this prefix.
- *  2. A sub-path partitioned blob store. baseUrl is set, and partitions contains 2 or more sub-paths. Files will be
- * written with a prefix of the base url and then one of the sub-paths.
- *  3. A separate-storage-location partitioned blob store. baseUrl is NOT set, and partitions contains 2 or more full
- * fdb blob urls. Files will be written with one of the partition prefixes.
+ * There are 2 cases for blob metadata. These are all represented fundamentally in the same input schema.
+ *  1. A non-partitioned blob store. Files will be written with the specified location.
+ *  2. A partitioned blob store. Files will be written with one of the partition's locationId prefixes.
  * Partitioning is desired in blob stores such as s3 that can run into metadata hotspotting issues.
  */
+
+// FIXME: do internal deduping of locations based on location id
+struct BlobMetadataLocationRef {
+	BlobMetadataLocationId locationId;
+	StringRef path;
+
+	BlobMetadataLocationRef() {}
+	BlobMetadataLocationRef(Arena& arena, const BlobMetadataLocationRef& from)
+	  : locationId(from.locationId), path(arena, from.path) {}
+
+	explicit BlobMetadataLocationRef(Arena& ar, BlobMetadataLocationId locationId, StringRef path)
+	  : locationId(locationId), path(ar, path) {}
+	explicit BlobMetadataLocationRef(BlobMetadataLocationId locationId, StringRef path)
+	  : locationId(locationId), path(path) {}
+
+	int expectedSize() const { return sizeof(BlobMetadataLocationRef) + path.size(); }
+
+	template <class Ar>
+	void serialize(Ar& ar) {
+		serializer(ar, locationId, path);
+	}
+};
+
 struct BlobMetadataDetailsRef {
 	constexpr static FileIdentifier file_identifier = 6685526;
 	BlobMetadataDomainId domainId;
-	Optional<StringRef> base;
-	VectorRef<StringRef> partitions;
+	VectorRef<BlobMetadataLocationRef> locations;
 
 	// cache options
 	double refreshAt;
@@ -47,39 +67,30 @@ struct BlobMetadataDetailsRef {
 
 	BlobMetadataDetailsRef() {}
 	BlobMetadataDetailsRef(Arena& arena, const BlobMetadataDetailsRef& from)
-	  : domainId(from.domainId), partitions(arena, from.partitions), refreshAt(from.refreshAt),
-	    expireAt(from.expireAt) {
-		if (from.base.present()) {
-			base = StringRef(arena, from.base.get());
-		}
-	}
+	  : domainId(from.domainId), locations(arena, from.locations), refreshAt(from.refreshAt), expireAt(from.expireAt) {}
 
 	explicit BlobMetadataDetailsRef(Arena& ar,
 	                                BlobMetadataDomainId domainId,
-	                                Optional<StringRef> baseLocation,
-	                                VectorRef<StringRef> partitions,
+	                                VectorRef<BlobMetadataLocationRef> locations,
 	                                double refreshAt,
 	                                double expireAt)
-	  : domainId(domainId), partitions(ar, partitions), refreshAt(refreshAt), expireAt(expireAt) {
-		if (baseLocation.present()) {
-			base = StringRef(ar, baseLocation.get());
-		}
+	  : domainId(domainId), locations(ar, locations), refreshAt(refreshAt), expireAt(expireAt) {
+		ASSERT(!locations.empty());
 	}
 
 	explicit BlobMetadataDetailsRef(BlobMetadataDomainId domainId,
-	                                Optional<StringRef> base,
-	                                VectorRef<StringRef> partitions,
+	                                VectorRef<BlobMetadataLocationRef> locations,
 	                                double refreshAt,
 	                                double expireAt)
-	  : domainId(domainId), base(base), partitions(partitions), refreshAt(refreshAt), expireAt(expireAt) {}
-
-	int expectedSize() const {
-		return sizeof(BlobMetadataDetailsRef) + (base.present() ? base.get().size() : 0) + partitions.expectedSize();
+	  : domainId(domainId), locations(locations), refreshAt(refreshAt), expireAt(expireAt) {
+		ASSERT(!locations.empty());
 	}
+
+	int expectedSize() const { return sizeof(BlobMetadataDetailsRef) + locations.expectedSize(); }
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, domainId, base, partitions, refreshAt, expireAt);
+		serializer(ar, domainId, locations, refreshAt, expireAt);
 	}
 };
 

--- a/fdbserver/RESTKmsConnector.actor.cpp
+++ b/fdbserver/RESTKmsConnector.actor.cpp
@@ -82,8 +82,9 @@ const char DISCOVER_URL_FILE_URL_SEP = '\n';
 
 const char* BLOB_METADATA_DETAILS_TAG = "blob_metadata_details";
 const char* BLOB_METADATA_DOMAIN_ID_TAG = "domain_id";
-const char* BLOB_METADATA_BASE_LOCATION_TAG = "base_location";
-const char* BLOB_METADATA_PARTITIONS_TAG = "partitions";
+const char* BLOB_METADATA_LOCATIONS_TAG = "locations";
+const char* BLOB_METADATA_LOCATION_ID_TAG = "id";
+const char* BLOB_METADATA_LOCATION_PATH_TAG = "path";
 
 constexpr int INVALID_REQUEST_VERSION = 0;
 
@@ -509,11 +510,9 @@ Standalone<VectorRef<BlobMetadataDetailsRef>> parseBlobMetadataResponse(Referenc
 	//   "blob_metadata_details" : [
 	//     {
 	//        "domain_id" : <domainId>,
-	//        "domain_name" : <baseCipher>,
-	//        "baseLocation" : <baseLocation>, (Optional if partitions is present)
-	//        "partitions" : [
-	//			  "partition1", "partition2", ...
-	//		  ], (Optional if baseLocation is present)
+	//        "locations" : [
+	//			  { id: 1, path: "fdbblob://partition1"} , {id: 2, path: "fdbblob://partition2"}, ...
+	//		  ],
 	//        "refresh_after_sec"   : <refreshTimeInterval>, (Optional)
 	//        "expire_after_sec"    : <expireTimeInterval>  (Optional)
 	//     },
@@ -545,7 +544,7 @@ Standalone<VectorRef<BlobMetadataDetailsRef>> parseBlobMetadataResponse(Referenc
 	// Extract CipherKeyDetails
 	if (!doc.HasMember(BLOB_METADATA_DETAILS_TAG) || !doc[BLOB_METADATA_DETAILS_TAG].IsArray()) {
 		TraceEvent(SevWarn, "ParseBlobMetadataResponseFailureMissingDetails", ctx->uid).log();
-		CODE_PROBE(true, "REST BlobMedata details missing or not-array");
+		CODE_PROBE(true, "REST BlobMetadata details missing or not-array");
 		throw rest_malformed_response();
 	}
 
@@ -553,45 +552,47 @@ Standalone<VectorRef<BlobMetadataDetailsRef>> parseBlobMetadataResponse(Referenc
 		if (!detail.IsObject()) {
 			TraceEvent(SevWarn, "ParseBlobMetadataResponseFailureDetailsNotObject", ctx->uid)
 			    .detail("CipherDetailType", detail.GetType());
-			CODE_PROBE(true, "REST BlobMedata detail not-object");
+			CODE_PROBE(true, "REST BlobMetadata detail not-object");
 			throw rest_malformed_response();
 		}
 
 		const bool isDomainIdPresent = detail.HasMember(BLOB_METADATA_DOMAIN_ID_TAG);
-		const bool isBasePresent = detail.HasMember(BLOB_METADATA_BASE_LOCATION_TAG);
-		const bool isPartitionsPresent = detail.HasMember(BLOB_METADATA_PARTITIONS_TAG);
-		if (!isDomainIdPresent || (!isBasePresent && !isPartitionsPresent)) {
+		const bool isLocationsPresent =
+		    detail.HasMember(BLOB_METADATA_LOCATIONS_TAG) && detail[BLOB_METADATA_LOCATIONS_TAG].IsArray();
+		if (!isDomainIdPresent || !isLocationsPresent) {
 			TraceEvent(SevWarn, "ParseBlobMetadataResponseMalformedDetail", ctx->uid)
 			    .detail("DomainIdPresent", isDomainIdPresent)
-			    .detail("BaseLocationPresent", isBasePresent)
-			    .detail("PartitionsPresent", isPartitionsPresent);
-			CODE_PROBE(true, "REST BlobMedata detail malformed");
+			    .detail("LocationsPresent", isLocationsPresent);
+			CODE_PROBE(true, "REST BlobMetadata detail malformed");
 			throw rest_malformed_response();
 		}
 
-		std::unique_ptr<uint8_t[]> baseStr;
-		Optional<StringRef> base;
-		if (isBasePresent) {
-			const int baseLen = detail[BLOB_METADATA_BASE_LOCATION_TAG].GetStringLength();
-			baseStr = std::make_unique<uint8_t[]>(baseLen);
-			memcpy(baseStr.get(), detail[BLOB_METADATA_BASE_LOCATION_TAG].GetString(), baseLen);
-			base = StringRef(baseStr.get(), baseLen);
-		}
+		BlobMetadataDomainId domainId = detail[BLOB_METADATA_DOMAIN_ID_TAG].GetInt64();
 
 		// just do extra memory copy for simplicity here
-		Standalone<VectorRef<StringRef>> partitions;
-		if (isPartitionsPresent) {
-			for (const auto& partition : detail[BLOB_METADATA_PARTITIONS_TAG].GetArray()) {
-				if (!partition.IsString()) {
-					TraceEvent("ParseBlobMetadataResponseFailurePartitionNotString", ctx->uid)
-					    .detail("PartitionType", partition.GetType());
-					throw operation_failed();
-				}
-				const int partitionLen = partition.GetStringLength();
-				std::unique_ptr<uint8_t[]> partitionStr = std::make_unique<uint8_t[]>(partitionLen);
-				memcpy(partitionStr.get(), partition.GetString(), partitionLen);
-				partitions.push_back_deep(partitions.arena(), StringRef(partitionStr.get(), partitionLen));
+		Standalone<VectorRef<BlobMetadataLocationRef>> locations;
+		for (const auto& location : detail[BLOB_METADATA_LOCATIONS_TAG].GetArray()) {
+			if (!location.IsObject()) {
+				TraceEvent("ParseBlobMetadataResponseFailureLocationNotObject", ctx->uid)
+				    .detail("LocationType", location.GetType());
+				throw rest_malformed_response();
 			}
+			const bool isLocationIdPresent = location.HasMember(BLOB_METADATA_LOCATION_ID_TAG);
+			const bool isPathPresent = location.HasMember(BLOB_METADATA_LOCATION_PATH_TAG);
+			if (!isLocationIdPresent || !isPathPresent) {
+				TraceEvent(SevWarn, "ParseBlobMetadataResponseMalformedLocation", ctx->uid)
+				    .detail("LocationIdPresent", isLocationIdPresent)
+				    .detail("PathPresent", isPathPresent);
+				CODE_PROBE(true, "REST BlobMetadata location malformed");
+				throw rest_malformed_response();
+			}
+
+			BlobMetadataLocationId locationId = location[BLOB_METADATA_LOCATION_ID_TAG].GetInt64();
+
+			const int pathLen = location[BLOB_METADATA_LOCATION_PATH_TAG].GetStringLength();
+			std::unique_ptr<uint8_t[]> pathStr = std::make_unique<uint8_t[]>(pathLen);
+			memcpy(pathStr.get(), location[BLOB_METADATA_LOCATION_PATH_TAG].GetString(), pathLen);
+			locations.emplace_back_deep(locations.arena(), locationId, StringRef(pathStr.get(), pathLen));
 		}
 
 		// Extract refresh and/or expiry interval if supplied
@@ -600,8 +601,7 @@ Standalone<VectorRef<BlobMetadataDetailsRef>> parseBlobMetadataResponse(Referenc
 		                       : std::numeric_limits<double>::max();
 		double expireAt = detail.HasMember(EXPIRE_AFTER_SEC) ? now() + detail[EXPIRE_AFTER_SEC].GetInt64()
 		                                                     : std::numeric_limits<double>::max();
-		result.emplace_back_deep(
-		    result.arena(), detail[BLOB_METADATA_DOMAIN_ID_TAG].GetInt64(), base, partitions, refreshAt, expireAt);
+		result.emplace_back_deep(result.arena(), domainId, locations, refreshAt, expireAt);
 	}
 
 	checkDocForNewKmsUrls(ctx, resp, doc);
@@ -1188,7 +1188,6 @@ void forceLinkRESTKmsConnectorTest() {}
 namespace {
 std::string_view KMS_URL_NAME_TEST = "http://foo/bar";
 std::string_view BLOB_METADATA_BASE_LOCATION_TEST = "file://local";
-std::string_view BLOB_METADATA_PARTITION_TEST = "part";
 uint8_t BASE_CIPHER_KEY_TEST[32];
 
 std::shared_ptr<platform::TmpFile> prepareTokenFile(const uint8_t* buff, const int len) {
@@ -1466,25 +1465,26 @@ void getFakeBlobMetadataResponse(StringRef jsonReqRef,
 		domainId.SetInt64(detail[BLOB_METADATA_DOMAIN_ID_TAG].GetInt64());
 		keyDetail.AddMember(key, domainId, resDoc.GetAllocator());
 
-		int type = deterministicRandom()->randomInt(0, 3);
-		if (type == 0 || type == 1) {
-			key.SetString(BLOB_METADATA_BASE_LOCATION_TAG, resDoc.GetAllocator());
-			rapidjson::Value baseLocation;
-			baseLocation.SetString(BLOB_METADATA_BASE_LOCATION_TEST.data(), resDoc.GetAllocator());
-			keyDetail.AddMember(key, baseLocation, resDoc.GetAllocator());
+		int locationCount = deterministicRandom()->randomInt(1, 6);
+		rapidjson::Value locations(rapidjson::kArrayType);
+		for (int i = 0; i < locationCount; i++) {
+			rapidjson::Value location(rapidjson::kObjectType);
+
+			rapidjson::Value locId;
+			key.SetString(BLOB_METADATA_LOCATION_ID_TAG, resDoc.GetAllocator());
+			locId.SetInt64(i);
+			location.AddMember(key, locId, resDoc.GetAllocator());
+
+			rapidjson::Value path;
+			key.SetString(BLOB_METADATA_LOCATION_PATH_TAG, resDoc.GetAllocator());
+			path.SetString(BLOB_METADATA_BASE_LOCATION_TEST.data(), resDoc.GetAllocator());
+			location.AddMember(key, path, resDoc.GetAllocator());
+
+			locations.PushBack(location, resDoc.GetAllocator());
 		}
-		if (type == 1 || type == 2) {
-			int partitionCount = deterministicRandom()->randomInt(2, 6);
-			rapidjson::Value partitions(rapidjson::kArrayType);
-			for (int i = 0; i < partitionCount; i++) {
-				rapidjson::Value p;
-				p.SetString(((type == 1) ? BLOB_METADATA_PARTITION_TEST : BLOB_METADATA_BASE_LOCATION_TEST).data(),
-				            resDoc.GetAllocator());
-				partitions.PushBack(p, resDoc.GetAllocator());
-			}
-			key.SetString(BLOB_METADATA_PARTITIONS_TAG, resDoc.GetAllocator());
-			keyDetail.AddMember(key, partitions, resDoc.GetAllocator());
-		}
+
+		key.SetString(BLOB_METADATA_LOCATIONS_TAG, resDoc.GetAllocator());
+		keyDetail.AddMember(key, locations, resDoc.GetAllocator());
 
 		addFakeRefreshExpire(resDoc, keyDetail, key);
 
@@ -1603,7 +1603,7 @@ void testGetBlobMetadataRequestBody(Reference<RESTKmsConnectorCtx> ctx) {
 	for (const auto& detail : details) {
 		auto it = domainIds.find(detail.domainId);
 		ASSERT(it != domainIds.end());
-		ASSERT(detail.base.present() || !detail.partitions.empty());
+		ASSERT(!detail.locations.empty());
 	}
 	if (refreshKmsUrls) {
 		validateKmsUrls(ctx);

--- a/fdbserver/SimKmsConnector.actor.cpp
+++ b/fdbserver/SimKmsConnector.actor.cpp
@@ -288,17 +288,33 @@ ACTOR Future<Void> blobMetadataLookup(KmsConnectorInterface interf, KmsConnBlobM
 
 	wait(delay(deterministicRandom()->random01())); // simulate network delay
 
-	// buggify errors or omitted tenants in response
+	// buggify omitted tenants, errors, or unexpectedly ordered locations in response
 	if (g_network->isSimulated() && !g_simulator->speedUpSimulation && BUGGIFY_WITH_PROB(0.01)) {
-		if (deterministicRandom()->coinflip()) {
+		int bug = deterministicRandom()->randomInt(0, 3);
+		if (bug == 0) {
 			// remove some number of tenants from the response
 			int targetSize = deterministicRandom()->randomInt(0, rep.metadataDetails.size());
 			while (rep.metadataDetails.size() > targetSize) {
 				swapAndPop(&rep.metadataDetails, deterministicRandom()->randomInt(0, rep.metadataDetails.size()));
 			}
-		} else {
+		} else if (bug == 1) {
+			// send error
 			req.reply.sendError(connection_failed());
 			return Void();
+		} else if (bug == 2) {
+			int targetDetail = deterministicRandom()->randomInt(0, rep.metadataDetails.size());
+			auto& locs = rep.metadataDetails[targetDetail].locations;
+			if (locs.size() > 1) {
+				int targetIdx1 = deterministicRandom()->randomInt(0, locs.size());
+				int targetIdx2 = targetIdx1;
+				while (targetIdx2 == targetIdx1) {
+					targetIdx2 = deterministicRandom()->randomInt(0, locs.size());
+				}
+				std::swap(locs[targetIdx1], locs[targetIdx2]);
+			}
+		} else {
+			// developer forgot to update cases
+			ASSERT(false);
 		}
 	}
 


### PR DESCRIPTION
Refactor the interface of the rest kms connector for blob metadata to be simpler and also to pass ids with each storage location.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
