### PR TITLE
Add API version protection to Java's used during commit option

### DIFF
--- a/bindings/java/src/main/com/apple/foundationdb/FDBDatabase.java
+++ b/bindings/java/src/main/com/apple/foundationdb/FDBDatabase.java
@@ -45,7 +45,9 @@ class FDBDatabase extends NativeObjectWrapper implements Database, OptionConsume
 		// Automatically set the UsedDuringCommitProtectionDisable option
 		// This is because the Java bindings disallow use of Transaction objects after
 		// Transaction#onError is called.
-		this.options.setTransactionUsedDuringCommitProtectionDisable();
+		if (FDB.instance().getAPIVersion() >= 730) {
+			this.options.setTransactionUsedDuringCommitProtectionDisable();
+		}
 		this.eventKeeper = eventKeeper;
 	}
 
@@ -170,6 +172,10 @@ class FDBDatabase extends NativeObjectWrapper implements Database, OptionConsume
 		Transaction tr = null;
 		try {
 			tr = new FDBTransaction(Database_createTransaction(getPtr()), this, e, eventKeeper);
+			// In newer versions, this option is set as a default option on the database
+			if (FDB.instance().getAPIVersion() < 730) {
+				tr.options().setUsedDuringCommitProtectionDisable();
+			}
 			return tr;
 		} catch (RuntimeException err) {
 			if (tr != null) {

--- a/bindings/java/src/main/com/apple/foundationdb/FDBTenant.java
+++ b/bindings/java/src/main/com/apple/foundationdb/FDBTenant.java
@@ -127,6 +127,10 @@ class FDBTenant extends NativeObjectWrapper implements Tenant {
 		Transaction tr = null;
 		try {
 			tr = new FDBTransaction(Tenant_createTransaction(getPtr()), database, e, eventKeeper);
+			// In newer versions, this option is set as a default option on the database
+			if (FDB.instance().getAPIVersion() < 730) {
+				tr.options().setUsedDuringCommitProtectionDisable();
+			}
 			return tr;
 		} catch (RuntimeException err) {
 			if (tr != null) {

--- a/bindings/java/src/main/com/apple/foundationdb/FDBTransaction.java
+++ b/bindings/java/src/main/com/apple/foundationdb/FDBTransaction.java
@@ -766,6 +766,10 @@ class FDBTransaction extends NativeObjectWrapper implements Transaction, OptionC
 		FDBTransaction tr = null;
 		try {
 			tr = new FDBTransaction(getPtr(), database, executor);
+			// In newer versions, this option is set as a default option on the database
+			if (FDB.instance().getAPIVersion() < 730) {
+				tr.options().setUsedDuringCommitProtectionDisable();
+			}
 			transactionOwner = false;
 			return tr;
 		}


### PR DESCRIPTION
7.3 changed the way that the used during commit option was set from a transaction option to a database default option. This option is not supported in older clients, so we cannot use it unless we specify an API version that is new enough.

This adds API version guards to use of this option and falls back to the transaction option for older versions.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
