### PR TITLE
Fix heap use-after-free in validateRangeAgainstServer (Cherry-Pick #10132 to snowflake/release-71.3)

### DIFF
--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -4649,6 +4649,7 @@ ACTOR Future<Void> validateRangeAgainstServer(StorageServer* data,
 			GetKeyValuesRequest req;
 			req.begin = firstGreaterOrEqual(range.begin);
 			req.end = firstGreaterOrEqual(range.end);
+			req.arena.dependsOn(range.arena());
 			req.limit = limit;
 			req.limitBytes = limitBytes;
 			req.version = version;
@@ -4658,6 +4659,7 @@ ACTOR Future<Void> validateRangeAgainstServer(StorageServer* data,
 			GetKeyValuesRequest localReq;
 			localReq.begin = firstGreaterOrEqual(range.begin);
 			localReq.end = firstGreaterOrEqual(range.end);
+			localReq.arena.dependsOn(range.arena());
 			localReq.limit = limit;
 			localReq.limitBytes = limitBytes;
 			localReq.version = version;


### PR DESCRIPTION
Cherry-Pick of #10132

Original Description:

GetKeyValuesRequest keeps a reference to begin and end keys, so we must ensure the range doesn't go out of scope while the request is still being used. 

This was detected by ASAN:

```
=================================================================
==47==ERROR: AddressSanitizer: heap-use-after-free on address 0x6060068bbf48 at pc 0x000002db55f6 bp 0x7ffc2380ff60 sp 0x7ffc2380f710
READ of size 2 at 0x6060068bbf48 thread T0
    #0 0x2db55f5 in MemcmpInterceptorCommon(void*, int (*)(void const*, void const*, unsigned long), void const*, void const*, unsigned long) /tmp/llvm-project/compiler-rt/lib/asan/../sanitizer_common/sanitizer_common_interceptors.inc:932:7
    #1 0x2db5ae9 in memcmp /tmp/llvm-project/compiler-rt/lib/asan/../sanitizer_common/sanitizer_common_interceptors.inc:964:10
    #2 0x85080c6 in operator<(StringRef const&, StringRef const&) /mnt/ephemeral/mdvorsky/foundationdb/flow/include/flow/Arena.h:766:11
    #3 0x85080c6 in std::__1::__less<StringRef, StringRef>::operator()[abi:v15006](StringRef const&, StringRef const&) const /usr/local/bin/../include/c++/v1/__algorithm/comp.h:73:71
    #4 0x85080c6 in StringRef const& std::__1::min[abi:v15006]<StringRef, std::__1::__less<StringRef, StringRef>>(StringRef const&, StringRef const&, std::__1::__less<StringRef, StringRef>) /usr/local/bin/../include/c++/v1/__algorithm/min.h:33:12
    #5 0x85080c6 in StringRef const& std::__1::min[abi:v15006]<StringRef>(StringRef const&, StringRef const&) /usr/local/bin/../include/c++/v1/__algorithm/min.h:42:12
    #6 0x85080c6 in (anonymous namespace)::GetKeyValuesQActorState<(anonymous namespace)::GetKeyValuesQActor>::a_body1cont11cont6(GetKeyValuesReply const&, int) /mnt/ephemeral/mdvorsky/foundationdb/fdbserver/storageserver.actor.cpp:4386:80
    
...

0x6060068bbf48 is located 40 bytes inside of 64-byte region [0x6060068bbf20,0x6060068bbf60)
freed by thread T0 here:
    #0 0x2e1e722 in free /tmp/llvm-project/compiler-rt/lib/asan/asan_malloc_linux.cpp:52:3
    #1 0xed18d24 in ArenaBlock::destroy() /mnt/ephemeral/mdvorsky/foundationdb/flow/Arena.cpp:485:6
    #2 0x8523a5d in void delref<ArenaBlock>(ArenaBlock*) /mnt/ephemeral/mdvorsky/foundationdb/flow/include/flow/FastRef.h:95:7
    #3 0x8523a5d in Reference<ArenaBlock>::~Reference() /mnt/ephemeral/mdvorsky/foundationdb/flow/include/flow/FastRef.h:126:4
    #4 0x8523a5d in Arena::~Arena() /mnt/ephemeral/mdvorsky/foundationdb/flow/include/flow/Arena.h:106:7
    #5 0x8523a5d in (anonymous namespace)::ValidateRangeAgainstServerActorState<(anonymous namespace)::ValidateRangeAgainstServerActor>::~ValidateRangeAgainstServerActorState() /mnt/ephemeral/mdvorsky/build/foundationdb.linux.clang.asan.x86_64/fdbserver/storageserver.actor.g.cpp:15702:2
    #6 0x8511d0d in (anonymous namespace)::ValidateRangeAgainstServerActorState<(anonymous namespace)::ValidateRangeAgainstServerActor>::a_body1Catch1(Error, int) /mnt/ephemeral/mdvorsky/build/foundationdb.linux.clang.asan.x86_64/fdbserver/storageserver.actor.g.cpp:15731:10
    #7 0x8511d0d in (anonymous namespace)::ValidateRangeAgainstServerActorState<(anonymous namespace)::ValidateRangeAgainstServerActor>::a_body1loopBody1Catch1(Error const&, int) /mnt/ephemeral/mdvorsky/foundationdb/fdbserver/storageserver.actor.cpp:4800:11
   
````

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
