### PR TITLE
[release 7.1] Update 7.1 minInvalidProtocolVersion to 7.4 to make downgrading from 7.3 to 7.1 work

### DIFF
--- a/flow/ProtocolVersion.h
+++ b/flow/ProtocolVersion.h
@@ -35,7 +35,7 @@ constexpr uint64_t currentProtocolVersionValue = 0x0FDB00B071010000LL;
 
 // The first protocol version that cannot be downgraded from. Ordinarily, this will be two release versions larger
 // than the current version, meaning that we only support downgrades between consecutive release versions.
-constexpr uint64_t minInvalidProtocolVersionValue = 0x0FDB00B073000000LL;
+constexpr uint64_t minInvalidProtocolVersionValue = 0x0FDB00B074000000LL;
 
 #define PROTOCOL_VERSION_FEATURE(v, x)                                                                                 \
 	static_assert((v & 0xF0FFFFLL) == 0 || v < 0x0FDB00B071000000LL, "Unexpected feature protocol version");           \


### PR DESCRIPTION
Downgrading from 7.3 to 7.2 is broken due to missing blobbify related functions in 7.2 branch (a testing branch). To make downgrade test work, we need to allow downgrading from 7.3 to 7.1.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
