### PR TITLE
Audit storage statistic

### DIFF
--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -4684,6 +4684,7 @@ ACTOR Future<Void> validateRangeAgainstServer(StorageServer* data,
 	state Key originBegin = range.begin;
 	state int validatedKeys = 0;
 	state std::string error;
+	state int64_t cumulatedValidatedKeysNum = 0;
 	loop {
 		try {
 			std::vector<Future<ErrorOr<GetKeyValuesReply>>> fs;
@@ -4733,6 +4734,7 @@ ACTOR Future<Void> validateRangeAgainstServer(StorageServer* data,
 			auditState.range = range;
 
 			const int end = std::min(local.data.size(), remote.data.size());
+			cumulatedValidatedKeysNum = cumulatedValidatedKeysNum + end;
 			int i = 0;
 			for (; i < end; ++i) {
 				KeyValueRef remoteKV = remote.data[i];
@@ -4766,6 +4768,15 @@ ACTOR Future<Void> validateRangeAgainstServer(StorageServer* data,
 
 				lastKey = localKV.key;
 			}
+
+			TraceEvent(SevInfo, "AuditStorageStatistic", data->thisServerID)
+			    .detail("AuditType", auditState.getType())
+			    .detail("AuditId", auditState.id)
+			    .detail("AuditRange", auditState.range)
+			    .detail("CurrentValidatedKeysNum", end)
+			    .detail("CurrentValidatedInclusiveRange", KeyRangeRef(range.begin, lastKey))
+			    .detail("CumulatedValidatedKeysNum", cumulatedValidatedKeysNum)
+			    .detail("CumulatedValidatedInclusiveRange", KeyRangeRef(auditState.range.begin, lastKey));
 
 			if (!error.empty()) {
 				break;
@@ -5267,6 +5278,8 @@ ACTOR Future<Void> auditStorageStorageServerShardQ(StorageServer* data, AuditSto
 	state int storageAutoProceedCount = 0;
 	// storageAutoProceedCount is guard to make sure that audit at SS does not run too long
 	// by itself without being notified by DD
+	state int64_t cumulatedValidatedLocalShardsNum = 0;
+	state int64_t cumulatedValidatedServerKeysNum = 0;
 
 	try {
 		while (true) {
@@ -5357,6 +5370,20 @@ ACTOR Future<Void> auditStorageStorageServerShardQ(StorageServer* data, AuditSto
 			    .detail("ClaimRange", claimRange)
 			    .detail("ServerKeyAtVersion", serverKeyReadAtVersion)
 			    .detail("ShardInfoAtVersion", data->version.get());
+
+			// Log statistic
+			cumulatedValidatedLocalShardsNum = cumulatedValidatedLocalShardsNum + ownRangesLocalView.size();
+			cumulatedValidatedServerKeysNum = cumulatedValidatedServerKeysNum + ownRangesSeenByServerKey.size();
+			TraceEvent(SevInfo, "AuditStorageStatistic", data->thisServerID)
+			    .detail("AuditType", req.getType())
+			    .detail("AuditId", req.id)
+			    .detail("AuditRange", req.range)
+			    .detail("CurrentValidatedLocalShardsNum", ownRangesLocalView.size())
+			    .detail("CurrentValidatedServerKeysNum", ownRangesSeenByServerKey.size())
+			    .detail("CurrentValidatedInclusiveRange", claimRange)
+			    .detail("CumulatedValidatedLocalShardsNum", cumulatedValidatedLocalShardsNum)
+			    .detail("CumulatedValidatedServerKeysNum", cumulatedValidatedServerKeysNum)
+			    .detail("CumulatedValidatedInclusiveRange", KeyRangeRef(req.range.begin, claimRange.end));
 
 			// Compare
 			Optional<std::pair<KeyRange, KeyRange>> anyMismatch =
@@ -5466,6 +5493,8 @@ ACTOR Future<Void> auditStorageLocationMetadataQ(StorageServer* data, AuditStora
 	state int storageAutoProceedCount = 0;
 	// storageAutoProceedCount is guard to make sure that audit at SS does not run too long
 	// by itself without being notified by DD
+	state int64_t cumulatedValidatedServerKeysNum = 0;
+	state int64_t cumulatedValidatedKeyServersNum = 0;
 
 	try {
 		while (true) {
@@ -5505,6 +5534,7 @@ ACTOR Future<Void> auditStorageLocationMetadataQ(StorageServer* data, AuditStora
 				ASSERT(readAtVersion == serverKeyRes.readAtVersion);
 			}
 			// Use claimRange to get mapFromServerKeys and mapFromKeyServers to compare
+			int64_t numValidatedServerKeys = 0;
 			for (auto& [ssid, serverKeyRes] : serverKeyResMap) {
 				for (auto& range : serverKeyRes.ownRanges) {
 					KeyRange overlappingRange = range & claimRange;
@@ -5517,8 +5547,12 @@ ACTOR Future<Void> auditStorageLocationMetadataQ(StorageServer* data, AuditStora
 					    .detail("Range", overlappingRange)
 					    .detail("SSID", ssid);
 					mapFromServerKeys[ssid].push_back(overlappingRange);
+					numValidatedServerKeys++;
 				}
 			}
+			cumulatedValidatedServerKeysNum = cumulatedValidatedServerKeysNum + numValidatedServerKeys;
+
+			int64_t numValidatedKeyServers = 0;
 			for (auto& [ssid, ranges] : mapFromKeyServersRaw) {
 				std::vector mergedRanges = coalesceRangeList(ranges);
 				for (auto& range : mergedRanges) {
@@ -5532,8 +5566,10 @@ ACTOR Future<Void> auditStorageLocationMetadataQ(StorageServer* data, AuditStora
 					    .detail("Range", overlappingRange)
 					    .detail("SSID", ssid);
 					mapFromKeyServers[ssid].push_back(overlappingRange);
+					numValidatedKeyServers++;
 				}
 			}
+			cumulatedValidatedKeyServersNum = cumulatedValidatedKeyServersNum + numValidatedKeyServers;
 
 			// Compare: check if mapFromKeyServers === mapFromServerKeys
 			// 1. check mapFromKeyServers => mapFromServerKeys
@@ -5590,6 +5626,18 @@ ACTOR Future<Void> auditStorageLocationMetadataQ(StorageServer* data, AuditStora
 					    .detail("AuditServerID", data->thisServerID);
 				}
 			}
+
+			// Log statistic
+			TraceEvent(SevInfo, "AuditStorageStatistic", data->thisServerID)
+			    .detail("AuditType", req.getType())
+			    .detail("AuditId", req.id)
+			    .detail("AuditRange", req.range)
+			    .detail("CurrentValidatedServerKeysNum", numValidatedServerKeys)
+			    .detail("CurrentValidatedKeyServersNum", numValidatedServerKeys)
+			    .detail("CurrentValidatedInclusiveRange", claimRange)
+			    .detail("CumulatedValidatedServerKeysNum", cumulatedValidatedServerKeysNum)
+			    .detail("CumulatedValidatedKeyServersNum", cumulatedValidatedKeyServersNum)
+			    .detail("CumulatedValidatedInclusiveRange", KeyRangeRef(req.range.begin, claimRange.end));
 
 			// Return result
 			if (!errors.empty()) {


### PR DESCRIPTION
This PR introduces AuditStorageStatistic trace event to:
(1) Understand the progress of audit storage;
(2) Understand the fragment of serverKeys introduced by encode_shard_location_metadata.

100K correctness test with 2 irrelevant failures
20230504-223330-zhewang-b9c720dd6272566a           compressed=True data_size=33126674 duration=6473460 ended=100000 fail=2 fail_fast=10 max_runs=100000 pass=99998 priority=100 remaining=0 runtime=1:12:45 sanity=False started=100000 stopped=20230504-234615 submitted=20230504-223330 timeout=5400 username=zhewang

100K ValidateStorage test
20230504-223406-zhewang-eaa2bcbcd54aaef1           compressed=True data_size=33155985 duration=3378096 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:52:40 sanity=False started=100000 stopped=20230504-232646 submitted=20230504-223406 timeout=5400 username=zhewang

This PR is based on https://github.com/apple/foundationdb/pull/9628

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
