### PR TITLE
Bug fix, check is supposed to be for overlap, not lack of overlap. (Cherry-Pick #10157 to snowflake/release-71.3)

### DIFF
--- a/fdbclient/SystemData.cpp
+++ b/fdbclient/SystemData.cpp
@@ -43,7 +43,7 @@ SystemKey::SystemKey(Key const& k) : Key(k) {
 
 		if (!knownKeys.contains(k)) {
 			for (auto& known : knownKeys) {
-				if (!k.startsWith(known)) {
+				if (k.startsWith(known) || known.startsWith(k)) {
 					TraceEvent(SevError, "SystemKeyPrefixConflict").detail("NewKey", k).detail("ExistingKey", known);
 					UNSTOPPABLE_ASSERT(false);
 				}


### PR DESCRIPTION
Cherry-Pick of #10157

Original Description:

Bug fix, check is supposed to be for overlap, not lack of overlap.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
