### PR TITLE
Fix bug: isEnabled() to !isEnabled()

### DIFF
--- a/fdbserver/MoveKeys.actor.cpp
+++ b/fdbserver/MoveKeys.actor.cpp
@@ -201,7 +201,7 @@ bool DDEnabledState::isBlobRestorePreparing() const {
 bool DDEnabledState::trySetSnapshot(UID requesterId) {
 	ASSERT(requesterId != UID());
 	// disabling DD
-	if (isEnabled()) {
+	if (!isEnabled()) {
 		// only allow state modification to snapshot when DD is enabled.
 		return false;
 	}


### PR DESCRIPTION
Replace this text with your description here...

A bug caused by typo in #10067 

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
