### PR TITLE
Add manifest encryption (Cherry-Pick #10081 to snowflake/release-71.3)

### DIFF
--- a/fdbclient/include/fdbclient/BlobGranuleCommon.h
+++ b/fdbclient/include/fdbclient/BlobGranuleCommon.h
@@ -358,10 +358,14 @@ struct BlobManifestTailer {
 	int64_t totalRows;
 	int64_t totalSegments;
 	int64_t totalBytes;
+	// All manifest files are currently encrypted using default_domain
+	// and with a single encryption key.
+	// TODO: Extend domain_aware encryption semantics to manifest file(s)
+	Optional<BlobGranuleCipherKeysMeta> cipherKeysMeta;
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, totalRows, totalSegments, totalBytes);
+		serializer(ar, totalRows, totalSegments, totalBytes, cipherKeysMeta);
 	}
 };
 

--- a/fdbserver/BlobManifest.actor.cpp
+++ b/fdbserver/BlobManifest.actor.cpp
@@ -26,7 +26,6 @@
 #include "fdbclient/BackupContainer.h"
 #include "fdbclient/BlobGranuleCommon.h"
 #include "fdbclient/BlobGranuleFiles.h"
-#include "fdbserver/Knobs.h"
 #include "flow/Arena.h"
 #include "flow/FastRef.h"
 #include "flow/Trace.h"
@@ -38,6 +37,8 @@
 #include "fdbclient/SystemData.h"
 #include "fdbclient/BackupContainerFileSystem.h"
 #include "fdbclient/BlobGranuleReader.actor.h"
+#include "fdbclient/ManagementAPI.actor.h"
+#include "fdbserver/Knobs.h"
 #include "fdbserver/BlobGranuleServerCommon.actor.h"
 
 #include "flow/actorcompiler.h" // has to be last include
@@ -226,9 +227,12 @@ private:
 // Splitter could write manifest content into a collection of files with bounded # rows
 class BlobManifestFileSplitter : public ReferenceCounted<BlobManifestFileSplitter> {
 public:
-	BlobManifestFileSplitter(Reference<BlobConnectionProvider> blobConn, int64_t epoch, int64_t seqNo)
+	BlobManifestFileSplitter(Reference<BlobConnectionProvider> blobConn,
+	                         int64_t epoch,
+	                         int64_t seqNo,
+	                         Optional<BlobGranuleCipherKeysCtx> cipherKeysCtx)
 	  : segmentNo_(1), blobConn_(blobConn), epoch_(epoch), seqNo_(seqNo), closed_(false), totalRows_(0),
-	    logicalSize_(0), totalBytes_(0) {}
+	    logicalSize_(0), totalBytes_(0), cipherKeysCtx_(cipherKeysCtx) {}
 
 	// Append a new row to the splitter
 	void append(KeyValueRef row) {
@@ -275,12 +279,11 @@ private:
 	void flushNext() {
 		std::string fname = fileName(segmentNo_);
 		Optional<CompressionFilter> compressionFilter;
-		Optional<BlobGranuleCipherKeysCtx> cipherKeysCtx;
 		Value bytes = serializeChunkedSnapshot(StringRef(fname),
 		                                       rows_,
 		                                       SERVER_KNOBS->BG_SNAPSHOT_FILE_TARGET_CHUNK_BYTES,
 		                                       compressionFilter,
-		                                       cipherKeysCtx,
+		                                       cipherKeysCtx_,
 		                                       false);
 		pendingFutures_.push_back(writeToFile(this, bytes, fname));
 		TraceEvent("BlobManifestFile").detail("Rows", rows_.size()).detail("SegNo", segmentNo_);
@@ -297,6 +300,10 @@ private:
 		tailer.totalRows = totalRows_;
 		tailer.totalSegments = segmentNo_ - 1;
 		tailer.totalBytes = totalBytes_;
+		if (cipherKeysCtx_.present()) {
+			tailer.cipherKeysMeta = BlobGranuleCipherKeysCtx::toCipherKeysMeta(cipherKeysCtx_.get());
+		}
+
 		Value bytes = BinaryWriter::toValue(tailer, IncludeVersion(ProtocolVersion::withBlobGranuleFile()));
 		std::string fname = fileName(0);
 		pendingFutures_.push_back(writeToFile(this, bytes, fname));
@@ -341,15 +348,42 @@ private:
 	int64_t totalBytes_;
 	std::vector<Future<Void>> pendingFutures_;
 	bool closed_;
+	Optional<BlobGranuleCipherKeysCtx> cipherKeysCtx_;
 };
+
+ACTOR Future<BlobGranuleCipherKeysCtx> getLatestManifestCipherKeys(Reference<AsyncVar<ServerDBInfo> const> dbInfo,
+                                                                   Arena* arena) {
+	state BlobGranuleCipherKeysCtx cipherKeysCtx;
+	std::unordered_map<EncryptCipherDomainId, Reference<BlobCipherKey>> domainKeyMap =
+	    wait(GetEncryptCipherKeys<ServerDBInfo>::getLatestEncryptCipherKeys(
+	        dbInfo, { FDB_DEFAULT_ENCRYPT_DOMAIN_ID }, BlobCipherMetrics::BLOB_GRANULE));
+
+	auto domainKeyItr = domainKeyMap.find(FDB_DEFAULT_ENCRYPT_DOMAIN_ID);
+	ASSERT(domainKeyItr != domainKeyMap.end());
+	cipherKeysCtx.textCipherKey = BlobGranuleCipherKey::fromBlobCipherKey(domainKeyItr->second, *arena);
+
+	TextAndHeaderCipherKeys cipherKeys = wait(
+	    GetEncryptCipherKeys<ServerDBInfo>::getLatestSystemEncryptCipherKeys(dbInfo, BlobCipherMetrics::BLOB_GRANULE));
+	ASSERT(cipherKeys.cipherHeaderKey.isValid());
+	cipherKeysCtx.headerCipherKey = BlobGranuleCipherKey::fromBlobCipherKey(cipherKeys.cipherHeaderKey, *arena);
+
+	cipherKeysCtx.ivRef = makeString(AES_256_IV_LENGTH, *arena);
+	deterministicRandom()->randomBytes(mutateString(cipherKeysCtx.ivRef), AES_256_IV_LENGTH);
+
+	return cipherKeysCtx;
+}
 
 // This class dumps blob manifest to external blob storage.
 class BlobManifestDumper : public ReferenceCounted<BlobManifestDumper> {
 public:
-	BlobManifestDumper(Database& db, Reference<BlobConnectionProvider> blobConn, int64_t epoch, int64_t seqNo)
-	  : db_(db), blobConn_(blobConn) {
-		fileSplitter_ = makeReference<BlobManifestFileSplitter>(blobConn, epoch, seqNo);
-	}
+	BlobManifestDumper(Database& db,
+	                   Reference<AsyncVar<ServerDBInfo> const> dbInfo,
+	                   Reference<BlobConnectionProvider> blobConn,
+	                   int64_t epoch,
+	                   int64_t seqNo,
+	                   bool encryptionEnabled)
+	  : db_(db), blobConn_(blobConn), epoch_(epoch), seqNo_(seqNo), dbInfo_(dbInfo),
+	    encryptionEnabled_(encryptionEnabled) {}
 	virtual ~BlobManifestDumper() {}
 
 	// Execute the dumper
@@ -367,7 +401,15 @@ public:
 private:
 	// Read system keys and write to manifest files
 	ACTOR static Future<int64_t> dump(Reference<BlobManifestDumper> self) {
-		state Reference<BlobManifestFileSplitter> splitter = self->fileSplitter_;
+		state Arena arena;
+		state Optional<BlobGranuleCipherKeysCtx> cipherKeysCtx;
+		if (self->encryptionEnabled_) {
+			BlobGranuleCipherKeysCtx ctx = wait(getLatestManifestCipherKeys(self->dbInfo_, &arena));
+			cipherKeysCtx = ctx;
+		}
+
+		state Reference<BlobManifestFileSplitter> splitter =
+		    makeReference<BlobManifestFileSplitter>(self->blobConn_, self->epoch_, self->seqNo_, cipherKeysCtx);
 		state Transaction tr(self->db_);
 		loop {
 			tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
@@ -415,6 +457,9 @@ private:
 
 				// last flush for in-memory data
 				wait(BlobManifestFileSplitter::close(splitter));
+				TraceEvent("BlobManfiestDump")
+				    .detail("Size", splitter->totalBytes())
+				    .detail("Encrypted", self->encryptionEnabled_);
 				return splitter->totalBytes();
 			} catch (Error& e) {
 				TraceEvent("BlobManfiestDumpError").error(e).log();
@@ -443,7 +488,10 @@ private:
 
 	Database db_;
 	Reference<BlobConnectionProvider> blobConn_;
-	Reference<BlobManifestFileSplitter> fileSplitter_;
+	int64_t epoch_;
+	int64_t seqNo_;
+	Reference<AsyncVar<ServerDBInfo> const> dbInfo_;
+	bool encryptionEnabled_;
 };
 
 // Defines filename, version, size for each granule file that interests full restore
@@ -457,7 +505,10 @@ struct GranuleFileVersion {
 // This class is to load blob manifest into system key space, which is part of for bare metal restore
 class BlobManifestLoader : public ReferenceCounted<BlobManifestLoader> {
 public:
-	BlobManifestLoader(Database& db, Reference<BlobConnectionProvider> blobConn) : db_(db), blobConn_(blobConn) {}
+	BlobManifestLoader(Database& db,
+	                   Reference<AsyncVar<ServerDBInfo> const> dbInfo,
+	                   Reference<BlobConnectionProvider> blobConn)
+	  : db_(db), blobConn_(blobConn), dbInfo_(dbInfo) {}
 	virtual ~BlobManifestLoader() {}
 
 	// Execute the loader
@@ -561,13 +612,20 @@ private:
 		// Load tailer
 		state BlobManifest manifest = BlobManifest::latest(files);
 		state Standalone<BlobManifestTailer> tailer = wait(loadTailer(self, container, manifest.tailer()));
+		state Arena arena;
+		state Optional<BlobGranuleCipherKeysCtx> cipherKeysCtx;
+		if (tailer.cipherKeysMeta.present()) {
+			BlobGranuleCipherKeysCtx ctx =
+			    wait(getGranuleCipherKeysFromKeysMeta(self->dbInfo_, tailer.cipherKeysMeta.get(), &arena));
+			cipherKeysCtx = ctx;
+		}
 
 		// Load segments
 		state int64_t totalRows = 0;
 		state int64_t totalBytes = 0;
 		state std::vector<BlobManifestFile>::iterator iter;
 		for (iter = manifest.segmentsBegin(); iter != manifest.segmentsEnd(); ++iter) {
-			wait(loadSegment(self, container, *iter, &totalRows, &totalBytes));
+			wait(loadSegment(self, container, *iter, cipherKeysCtx, &totalRows, &totalBytes));
 		}
 		wait(writeDelayedRows(self));
 
@@ -605,13 +663,13 @@ private:
 	ACTOR static Future<Void> loadSegment(Reference<BlobManifestLoader> self,
 	                                      Reference<BackupContainerFileSystem> container,
 	                                      BlobManifestFile segmentFile,
+	                                      Optional<BlobGranuleCipherKeysCtx> cipherKeysCtx,
 	                                      int64_t* totalRows,
 	                                      int64_t* totalBytes) {
-		Value data = wait(readFromFile(self, container, segmentFile.fileName));
+		state Value data = wait(readFromFile(self, container, segmentFile.fileName));
 		*totalBytes += data.size();
 
-		Standalone<StringRef> fileName;
-		state RangeResult rows = bgReadSnapshotFile(data, {}, {}, allKeys);
+		state RangeResult rows = bgReadSnapshotFile(data, {}, cipherKeysCtx, allKeys);
 		wait(writeSystemKeys(self, rows));
 		*totalRows += rows.size();
 		return Void();
@@ -855,43 +913,55 @@ private:
 	Database db_;
 	Reference<BlobConnectionProvider> blobConn_;
 	RangeResult delayedRows_; // special rows that we would write at the end of restore
+	Reference<AsyncVar<ServerDBInfo> const> dbInfo_;
+	Optional<BlobGranuleCipherKeysCtx> cipherKeysCtx_;
 };
 
 // API to dump a manifest copy to external storage
 ACTOR Future<int64_t> dumpManifest(Database db,
+                                   Reference<AsyncVar<ServerDBInfo> const> dbInfo,
                                    Reference<BlobConnectionProvider> blobConn,
                                    int64_t epoch,
-                                   int64_t seqNo) {
-	Reference<BlobManifestDumper> dumper = makeReference<BlobManifestDumper>(db, blobConn, epoch, seqNo);
+                                   int64_t seqNo,
+                                   bool encryptionEnabled) {
+	Reference<BlobManifestDumper> dumper =
+	    makeReference<BlobManifestDumper>(db, dbInfo, blobConn, epoch, seqNo, encryptionEnabled);
 	int64_t bytes = wait(BlobManifestDumper::execute(dumper));
 	return bytes;
 }
 
 // API to load manifest from external blob storage
-ACTOR Future<Void> loadManifest(Database db, Reference<BlobConnectionProvider> blobConn) {
-	Reference<BlobManifestLoader> loader = makeReference<BlobManifestLoader>(db, blobConn);
+ACTOR Future<Void> loadManifest(Database db,
+                                Reference<AsyncVar<ServerDBInfo> const> dbInfo,
+                                Reference<BlobConnectionProvider> blobConn) {
+	Reference<BlobManifestLoader> loader = makeReference<BlobManifestLoader>(db, dbInfo, blobConn);
 	wait(BlobManifestLoader::execute(loader));
 	return Void();
 }
 
 // API to print summary for restorable granules
-ACTOR Future<Void> printRestoreSummary(Database db, Reference<BlobConnectionProvider> blobConn) {
-	Reference<BlobManifestLoader> loader = makeReference<BlobManifestLoader>(db, blobConn);
+ACTOR Future<Void> printRestoreSummary(Database db,
+                                       Reference<AsyncVar<ServerDBInfo> const> dbInfo,
+                                       Reference<BlobConnectionProvider> blobConn) {
+	Reference<BlobManifestLoader> loader = makeReference<BlobManifestLoader>(db, dbInfo, blobConn);
 	wait(BlobManifestLoader::print(loader));
 	return Void();
 }
 
 // API to list blob granules
 ACTOR Future<BlobGranuleRestoreVersionVector> listBlobGranules(Database db,
+                                                               Reference<AsyncVar<ServerDBInfo> const> dbInfo,
                                                                Reference<BlobConnectionProvider> blobConn) {
-	Reference<BlobManifestLoader> loader = makeReference<BlobManifestLoader>(db, blobConn);
+	Reference<BlobManifestLoader> loader = makeReference<BlobManifestLoader>(db, dbInfo, blobConn);
 	BlobGranuleRestoreVersionVector result = wait(BlobManifestLoader::listGranules(loader));
 	return result;
 }
 
 // API to get max blob manager epoc from manifest files
-ACTOR Future<int64_t> lastBlobEpoc(Database db, Reference<BlobConnectionProvider> blobConn) {
-	Reference<BlobManifestLoader> loader = makeReference<BlobManifestLoader>(db, blobConn);
+ACTOR Future<int64_t> lastBlobEpoc(Database db,
+                                   Reference<AsyncVar<ServerDBInfo> const> dbInfo,
+                                   Reference<BlobConnectionProvider> blobConn) {
+	Reference<BlobManifestLoader> loader = makeReference<BlobManifestLoader>(db, dbInfo, blobConn);
 	int64_t epoc = wait(BlobManifestLoader::lastBlobEpoc(loader));
 	return epoc;
 }

--- a/fdbserver/BlobWorker.actor.cpp
+++ b/fdbserver/BlobWorker.actor.cpp
@@ -369,14 +369,14 @@ ACTOR Future<BlobGranuleCipherKeysCtx> getLatestGranuleCipherKeys(Reference<Blob
 	return cipherKeysCtx;
 }
 
-ACTOR Future<BlobGranuleCipherKey> lookupCipherKey(Reference<BlobWorkerData> bwData,
+ACTOR Future<BlobGranuleCipherKey> lookupCipherKey(Reference<AsyncVar<ServerDBInfo> const> dbInfo,
                                                    BlobCipherDetails cipherDetails,
                                                    Arena* arena) {
 	std::unordered_set<BlobCipherDetails> cipherDetailsSet;
 	cipherDetailsSet.emplace(cipherDetails);
 	state std::unordered_map<BlobCipherDetails, Reference<BlobCipherKey>> cipherKeyMap =
 	    wait(GetEncryptCipherKeys<ServerDBInfo>::getEncryptCipherKeys(
-	        bwData->dbInfo, cipherDetailsSet, BlobCipherMetrics::BLOB_GRANULE));
+	        dbInfo, cipherDetailsSet, BlobCipherMetrics::BLOB_GRANULE));
 
 	ASSERT(cipherKeyMap.size() == 1);
 
@@ -392,7 +392,7 @@ ACTOR Future<BlobGranuleCipherKey> lookupCipherKey(Reference<BlobWorkerData> bwD
 	return BlobGranuleCipherKey::fromBlobCipherKey(cipherKeyMapItr->second, *arena);
 }
 
-ACTOR Future<BlobGranuleCipherKeysCtx> getGranuleCipherKeysImpl(Reference<BlobWorkerData> bwData,
+ACTOR Future<BlobGranuleCipherKeysCtx> getGranuleCipherKeysImpl(Reference<AsyncVar<ServerDBInfo> const> dbInfo,
                                                                 BlobCipherDetails textCipherDetails,
                                                                 BlobCipherDetails headerCipherDetails,
                                                                 StringRef ivRef,
@@ -400,11 +400,11 @@ ACTOR Future<BlobGranuleCipherKeysCtx> getGranuleCipherKeysImpl(Reference<BlobWo
 	state BlobGranuleCipherKeysCtx cipherKeysCtx;
 
 	// Fetch 'textCipher' key
-	BlobGranuleCipherKey textCipherKey = wait(lookupCipherKey(bwData, textCipherDetails, arena));
+	BlobGranuleCipherKey textCipherKey = wait(lookupCipherKey(dbInfo, textCipherDetails, arena));
 	cipherKeysCtx.textCipherKey = textCipherKey;
 
 	// Fetch 'headerCipher' key
-	BlobGranuleCipherKey headerCipherKey = wait(lookupCipherKey(bwData, headerCipherDetails, arena));
+	BlobGranuleCipherKey headerCipherKey = wait(lookupCipherKey(dbInfo, headerCipherDetails, arena));
 	cipherKeysCtx.headerCipherKey = headerCipherKey;
 
 	// Populate 'Intialization Vector'
@@ -425,7 +425,7 @@ ACTOR Future<BlobGranuleCipherKeysCtx> getGranuleCipherKeysImpl(Reference<BlobWo
 	return cipherKeysCtx;
 }
 
-Future<BlobGranuleCipherKeysCtx> getGranuleCipherKeysFromKeysMeta(Reference<BlobWorkerData> bwData,
+Future<BlobGranuleCipherKeysCtx> getGranuleCipherKeysFromKeysMeta(Reference<AsyncVar<ServerDBInfo> const> dbInfo,
                                                                   BlobGranuleCipherKeysMeta cipherKeysMeta,
                                                                   Arena* arena) {
 	BlobCipherDetails textCipherDetails(
@@ -436,10 +436,10 @@ Future<BlobGranuleCipherKeysCtx> getGranuleCipherKeysFromKeysMeta(Reference<Blob
 
 	StringRef ivRef = StringRef(*arena, cipherKeysMeta.ivStr);
 
-	return getGranuleCipherKeysImpl(bwData, textCipherDetails, headerCipherDetails, ivRef, arena);
+	return getGranuleCipherKeysImpl(dbInfo, textCipherDetails, headerCipherDetails, ivRef, arena);
 }
 
-Future<BlobGranuleCipherKeysCtx> getGranuleCipherKeysFromKeysMetaRef(Reference<BlobWorkerData> bwData,
+Future<BlobGranuleCipherKeysCtx> getGranuleCipherKeysFromKeysMetaRef(Reference<AsyncVar<ServerDBInfo> const> dbInfo,
                                                                      BlobGranuleCipherKeysMetaRef cipherKeysMetaRef,
                                                                      Arena* arena) {
 	BlobCipherDetails textCipherDetails(
@@ -448,7 +448,7 @@ Future<BlobGranuleCipherKeysCtx> getGranuleCipherKeysFromKeysMetaRef(Reference<B
 	BlobCipherDetails headerCipherDetails(
 	    cipherKeysMetaRef.headerDomainId, cipherKeysMetaRef.headerBaseCipherId, cipherKeysMetaRef.headerSalt);
 
-	return getGranuleCipherKeysImpl(bwData, textCipherDetails, headerCipherDetails, cipherKeysMetaRef.ivRef, arena);
+	return getGranuleCipherKeysImpl(dbInfo, textCipherDetails, headerCipherDetails, cipherKeysMetaRef.ivRef, arena);
 }
 
 ACTOR Future<Void> readAndCheckGranuleLock(Reference<ReadYourWritesTransaction> tr,
@@ -1290,7 +1290,7 @@ ACTOR Future<BlobFileIndex> compactFromBlob(Reference<BlobWorkerData> bwData,
 			ASSERT(bwData->encryptMode.isEncryptionEnabled());
 			CODE_PROBE(true, "fetching cipher keys for blob snapshot file");
 			BlobGranuleCipherKeysCtx keysCtx =
-			    wait(getGranuleCipherKeysFromKeysMeta(bwData, snapshotF.cipherKeysMeta.get(), &filenameArena));
+			    wait(getGranuleCipherKeysFromKeysMeta(bwData->dbInfo, snapshotF.cipherKeysMeta.get(), &filenameArena));
 			snapCipherKeysCtx = std::move(keysCtx);
 		}
 
@@ -1321,7 +1321,7 @@ ACTOR Future<BlobFileIndex> compactFromBlob(Reference<BlobWorkerData> bwData,
 				ASSERT(bwData->encryptMode.isEncryptionEnabled());
 				CODE_PROBE(true, "fetching cipher keys for delta file");
 				BlobGranuleCipherKeysCtx keysCtx =
-				    wait(getGranuleCipherKeysFromKeysMeta(bwData, deltaF.cipherKeysMeta.get(), &filenameArena));
+				    wait(getGranuleCipherKeysFromKeysMeta(bwData->dbInfo, deltaF.cipherKeysMeta.get(), &filenameArena));
 				deltaCipherKeysCtx = std::move(keysCtx);
 			}
 
@@ -3973,7 +3973,7 @@ ACTOR Future<Void> doBlobGranuleFileRequest(Reference<BlobWorkerData> bwData, Bl
 							ASSERT(!chunk.snapshotFile.get().cipherKeysCtx.present());
 							CODE_PROBE(true, "fetching cipher keys from meta ref for snapshot file");
 							snapCipherKeysCtx = getGranuleCipherKeysFromKeysMetaRef(
-							    bwData, chunk.snapshotFile.get().cipherKeysMetaRef.get(), &rep.arena);
+							    bwData->dbInfo, chunk.snapshotFile.get().cipherKeysMetaRef.get(), &rep.arena);
 						}
 					}
 					state std::unordered_map<int, Future<BlobGranuleCipherKeysCtx>> deltaCipherKeysCtxs;
@@ -3994,7 +3994,7 @@ ACTOR Future<Void> doBlobGranuleFileRequest(Reference<BlobWorkerData> bwData, Bl
 							deltaCipherKeysCtxs.emplace(
 							    deltaIdx,
 							    getGranuleCipherKeysFromKeysMetaRef(
-							        bwData, chunk.deltaFiles[deltaIdx].cipherKeysMetaRef.get(), &rep.arena));
+							        bwData->dbInfo, chunk.deltaFiles[deltaIdx].cipherKeysMetaRef.get(), &rep.arena));
 						}
 					}
 

--- a/fdbserver/include/fdbserver/BlobGranuleServerCommon.actor.h
+++ b/fdbserver/include/fdbserver/BlobGranuleServerCommon.actor.h
@@ -168,13 +168,23 @@ struct BlobGranuleRestoreVersion {
 typedef Standalone<VectorRef<BlobGranuleRestoreVersion>> BlobGranuleRestoreVersionVector;
 
 ACTOR Future<int64_t> dumpManifest(Database db,
+                                   Reference<AsyncVar<ServerDBInfo> const> dbInfo,
                                    Reference<BlobConnectionProvider> blobConn,
                                    int64_t epoch,
-                                   int64_t seqNo);
-ACTOR Future<Void> loadManifest(Database db, Reference<BlobConnectionProvider> blobConn);
-ACTOR Future<Void> printRestoreSummary(Database db, Reference<BlobConnectionProvider> blobConn);
-ACTOR Future<BlobGranuleRestoreVersionVector> listBlobGranules(Database db, Reference<BlobConnectionProvider> blobConn);
-ACTOR Future<int64_t> lastBlobEpoc(Database db, Reference<BlobConnectionProvider> blobConn);
+                                   int64_t seqNo,
+                                   bool encryptionEnabled);
+ACTOR Future<Void> loadManifest(Database db,
+                                Reference<AsyncVar<ServerDBInfo> const> dbInfo,
+                                Reference<BlobConnectionProvider> blobConn);
+ACTOR Future<Void> printRestoreSummary(Database db,
+                                       Reference<AsyncVar<ServerDBInfo> const> dbInfo,
+                                       Reference<BlobConnectionProvider> blobConn);
+ACTOR Future<BlobGranuleRestoreVersionVector> listBlobGranules(Database db,
+                                                               Reference<AsyncVar<ServerDBInfo> const> dbInfo,
+                                                               Reference<BlobConnectionProvider> blobConn);
+ACTOR Future<int64_t> lastBlobEpoc(Database db,
+                                   Reference<AsyncVar<ServerDBInfo> const> dbInfo,
+                                   Reference<BlobConnectionProvider> blobConn);
 ACTOR Future<std::string> getMutationLogUrl();
 
 using BlobRestoreRangeState = std::pair<KeyRange, BlobRestoreState>;
@@ -200,6 +210,10 @@ private:
 	Database db_;
 	Standalone<KeyRangeRef> range_;
 };
+
+Future<BlobGranuleCipherKeysCtx> getGranuleCipherKeysFromKeysMeta(Reference<AsyncVar<ServerDBInfo> const> dbInfo,
+                                                                  BlobGranuleCipherKeysMeta cipherKeysMeta,
+                                                                  Arena* arena);
 #include "flow/unactorcompiler.h"
 
 #endif

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -6656,6 +6656,12 @@ ACTOR Future<Void> tryGetRangeFromBlob(PromiseStream<RangeResult> results,
 			}
 			results.send(rows);
 		}
+
+		if (chunks.size() == 0) {
+			RangeResult rows;
+			results.send(rows);
+		}
+
 		results.sendError(end_of_stream()); // end of range read
 	} catch (Error& e) {
 		TraceEvent(SevWarn, "ReadBlobDataFailure")

--- a/fdbserver/workloads/BlobRestoreWorkload.actor.cpp
+++ b/fdbserver/workloads/BlobRestoreWorkload.actor.cpp
@@ -81,6 +81,10 @@ struct BlobRestoreWorkload : TestWorkload {
 			IKnobCollection::getMutableGlobalKnobCollection().setKnob("blob_manifest_backup", knobFalse);
 
 			wait(store(self->restoreTargetVersion_, getRestoreVersion(cx, self)));
+			if (self->restoreTargetVersion_ == invalidVersion) {
+				CODE_PROBE(true, "Skip blob restore test because of missing mutation logs");
+				return Void();
+			}
 			fmt::print("Restore target version {}\n", self->restoreTargetVersion_);
 
 			// Only need to pass the version if we are trying to restore to a previous version
@@ -104,13 +108,15 @@ struct BlobRestoreWorkload : TestWorkload {
 		state std::vector<std::string> containers = wait(IBackupContainer::listContainers(baseUrl, {}));
 		if (containers.size() == 0) {
 			fmt::print("missing mutation logs {}\n", baseUrl);
-			throw restore_missing_data();
+			CODE_PROBE(true, "Skip blob restore test because of missing log backups");
+			return invalidVersion;
 		}
 		state Reference<IBackupContainer> bc = IBackupContainer::openContainer(containers.front(), {}, {});
 		BackupDescription desc = wait(bc->describeBackup(true));
 		if (!desc.contiguousLogEnd.present()) {
 			fmt::print("missing mutation logs {}\n", baseUrl);
-			throw restore_missing_data();
+			CODE_PROBE(true, "Skip blob restore test because of invalid log backup");
+			return invalidVersion;
 		}
 		targetVersion = desc.contiguousLogEnd.get() - 1;
 		if (self->restoreToVersion_) {


### PR DESCRIPTION
Cherry-Pick of #10081

Original Description:

Add encryption support for blob manifest files. Passed 100K Blob test

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
