### PR TITLE
Fix hashCode() and equals() for MappedKeyValue

### DIFF
--- a/bindings/java/src/main/com/apple/foundationdb/MappedKeyValue.java
+++ b/bindings/java/src/main/com/apple/foundationdb/MappedKeyValue.java
@@ -115,7 +115,9 @@ public class MappedKeyValue extends KeyValue {
 	@Override
 	public String toString() {
 		final StringBuilder sb = new StringBuilder("MappedKeyValue{");
-		sb.append("rangeBegin=").append(ByteArrayUtil.printable(rangeBegin));
+		sb.append("key=").append(ByteArrayUtil.printable(getKey()));
+		sb.append(", value=").append(ByteArrayUtil.printable(getValue()));
+		sb.append(", rangeBegin=").append(ByteArrayUtil.printable(rangeBegin));
 		sb.append(", rangeEnd=").append(ByteArrayUtil.printable(rangeEnd));
 		sb.append(", rangeResult=").append(rangeResult);
 		sb.append('}');

--- a/bindings/java/src/main/com/apple/foundationdb/MappedKeyValue.java
+++ b/bindings/java/src/main/com/apple/foundationdb/MappedKeyValue.java
@@ -22,8 +22,6 @@ package com.apple.foundationdb;
 
 import com.apple.foundationdb.tuple.ByteArrayUtil;
 
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -102,14 +100,16 @@ public class MappedKeyValue extends KeyValue {
 			return false;
 
 		MappedKeyValue rhs = (MappedKeyValue) obj;
-		return Arrays.equals(rangeBegin, rhs.rangeBegin) && Arrays.equals(rangeEnd, rhs.rangeEnd) &&
-		    Objects.equals(rangeResult, rhs.rangeResult);
+		return Arrays.equals(getKey(), rhs.getKey()) && Arrays.equals(getValue(), rhs.getValue())
+			&& Arrays.equals(rangeBegin, rhs.rangeBegin) && Arrays.equals(rangeEnd, rhs.rangeEnd)
+			&& Objects.equals(rangeResult, rhs.rangeResult);
 	}
 
 	@Override
 	public int hashCode() {
 		int hashForResult = rangeResult == null ? 0 : rangeResult.hashCode();
-		return 17 + (29 * hashForResult + 37 * Arrays.hashCode(rangeBegin) + Arrays.hashCode(rangeEnd));
+		return 17 + (13 * Arrays.hashCode(getKey()) + 11 * Arrays.hashCode(getValue())
+			+ 29 * hashForResult + 37 * Arrays.hashCode(rangeBegin) + Arrays.hashCode(rangeEnd));
 	}
 
 	@Override


### PR DESCRIPTION
The key and value fields are compared in C++ struct, but not in Java. This changes fixed it.

C++ part is correct, ref: https://github.com/apple/foundationdb/blob/main/fdbclient/include/fdbclient/FDBTypes.h#L910

Replace this text with your description here...

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
