### PR TITLE
Account for 'tenant_locked' error in MetaclusterManagementWorkload

### DIFF
--- a/fdbserver/workloads/MetaclusterManagementWorkload.actor.cpp
+++ b/fdbserver/workloads/MetaclusterManagementWorkload.actor.cpp
@@ -1404,6 +1404,9 @@ struct MetaclusterManagementWorkload : TestWorkload {
 			} else if (e.code() == error_code_invalid_metacluster_operation) {
 				ASSERT(!self->metaclusterCreated);
 				return Void();
+			} else if (e.code() == error_code_tenant_locked) {
+			   ASSERT(exists);
+			   return Void();
 			}
 
 			TraceEvent(SevError, "LockTenantFailure")

--- a/fdbserver/workloads/MetaclusterManagementWorkload.actor.cpp
+++ b/fdbserver/workloads/MetaclusterManagementWorkload.actor.cpp
@@ -1378,6 +1378,8 @@ struct MetaclusterManagementWorkload : TestWorkload {
 			auto tenantData = self->createdTenants.find(tenant);
 			ASSERT(tenantData != self->createdTenants.end());
 
+			ASSERT(!tenantData->second->lockId.present() || lockId == tenantData->second->lockId.get());
+
 			auto& dataDb = self->dataDbs[tenantData->second->cluster];
 			ASSERT(dataDb->registered);
 
@@ -1398,15 +1400,15 @@ struct MetaclusterManagementWorkload : TestWorkload {
 			if (e.code() == error_code_tenant_not_found) {
 				ASSERT(!exists);
 				return Void();
-			} else if (e.code() == error_code_invalid_tenant_configuration) {
-				ASSERT(exists);
-				return Void();
 			} else if (e.code() == error_code_invalid_metacluster_operation) {
 				ASSERT(!self->metaclusterCreated);
 				return Void();
 			} else if (e.code() == error_code_tenant_locked) {
-			   ASSERT(exists);
-			   return Void();
+				ASSERT(exists);
+				auto tenantData = self->createdTenants.find(tenant);
+				ASSERT(tenantData != self->createdTenants.end());
+				ASSERT(tenantData->second->lockId.present() && lockId != tenantData->second->lockId.get());
+				return Void();
 			}
 
 			TraceEvent(SevError, "LockTenantFailure")


### PR DESCRIPTION
In MetaclusterManagementWorkload, if we lock a tenant that has already been locked with a different lockId, it's possible that a tenant_locked error is thrown. We need to account for this instead of terminating the test.

Test plan:
Regular simulation and a deterministic reproduction

Branch: https://github.com/sfc-gh-yajin/foundationdb/tree/snow-791039
Commit hash: 7356504723d3c77de501b5683b0a159676c56840
Profile: team
Command: devRetryCorrectnessTest bin/fdbserver -r simulation -f tests/slow/MetaclusterManagement.toml -s 3475230174 -b off --crash --trace_format json

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
