### PR TITLE
Block unblobbify

### DIFF
--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -11111,20 +11111,22 @@ ACTOR Future<bool> setBlobRangeActor(Reference<DatabaseContext> cx,
 				if (startBlobRanges.empty()) {
 					// already unblobbified
 					return true;
-				} else if (startBlobRanges.front().begin != range.begin) {
-					// If there is a blob at the beginning of the range and it isn't aligned
+				} else if (startBlobRanges.front().begin < range.begin) {
+					// If there is a blob at the beginning of the range that overlaps the start
 					return false;
 				}
 				// if blob range does start at the specified, key, we need to make sure the end of also a boundary of a
 				// blob range
-				Optional<Value> endPresent = wait(tr->get(range.end.withPrefix(blobRangeKeys.begin)));
-				if (!endPresent.present()) {
+				Standalone<VectorRef<KeyRangeRef>> endBlobRanges =
+				    wait(getBlobRanges(&tr->getTransaction(), singleKeyRange(range.end), 1));
+				if (!endBlobRanges.empty() && endBlobRanges.front().begin < range.end) {
 					return false;
 				}
 			}
 
 			tr->set(blobRangeChangeKey, deterministicRandom()->randomUniqueID().toString());
 			// This is not coalescing because we want to keep each range logically separate.
+			// FIXME: if not active, do coalescing - had issues
 			wait(krmSetRange(tr, blobRangeKeys.begin, range, value));
 			wait(tr->commit());
 			return true;


### PR DESCRIPTION
Allowed unblobbify to work with a superset of ranges, eg unblobbifying [A - Z) would work if your blob ranges were [B - C), [C - D),  [F - G).
Also strengthened testing to add extra checks that blob granules would not be merged across consecutive but explicitly different blobbified ranges.

Passes 50k BlobGranuleRange* correctness and 50k BlobGranule* correctness with 1 unrelated error.


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
