### PR TITLE
Block unblobbify (Cherry-Pick #10182 to snowflake/release-71.3)

### DIFF
--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -11062,20 +11062,22 @@ ACTOR Future<bool> setBlobRangeActor(Reference<DatabaseContext> cx,
 				if (startBlobRanges.empty()) {
 					// already unblobbified
 					return true;
-				} else if (startBlobRanges.front().begin != range.begin) {
-					// If there is a blob at the beginning of the range and it isn't aligned
+				} else if (startBlobRanges.front().begin < range.begin) {
+					// If there is a blob at the beginning of the range that overlaps the start
 					return false;
 				}
 				// if blob range does start at the specified, key, we need to make sure the end of also a boundary of a
 				// blob range
-				Optional<Value> endPresent = wait(tr->get(range.end.withPrefix(blobRangeKeys.begin)));
-				if (!endPresent.present()) {
+				Standalone<VectorRef<KeyRangeRef>> endBlobRanges =
+				    wait(getBlobRanges(&tr->getTransaction(), singleKeyRange(range.end), 1));
+				if (!endBlobRanges.empty() && endBlobRanges.front().begin < range.end) {
 					return false;
 				}
 			}
 
 			tr->set(blobRangeChangeKey, deterministicRandom()->randomUniqueID().toString());
 			// This is not coalescing because we want to keep each range logically separate.
+			// FIXME: if not active, do coalescing - had issues
 			wait(krmSetRange(tr, blobRangeKeys.begin, range, value));
 			wait(tr->commit());
 			return true;

--- a/fdbserver/workloads/BlobGranuleRangesWorkload.actor.cpp
+++ b/fdbserver/workloads/BlobGranuleRangesWorkload.actor.cpp
@@ -239,7 +239,11 @@ struct BlobGranuleRangesWorkload : TestWorkload {
 		return v != invalidVersion;
 	}
 
-	ACTOR Future<Void> checkRange(Database cx, BlobGranuleRangesWorkload* self, KeyRange range, bool isActive) {
+	ACTOR Future<Void> checkRange(Database cx,
+	                              BlobGranuleRangesWorkload* self,
+	                              KeyRange range,
+	                              bool isActive,
+	                              bool strict) {
 		// Check that a read completes for the range. If not loop around and try again
 		loop {
 			bool completed = wait(self->isRangeActive(cx, range, self->tenant));
@@ -261,8 +265,13 @@ struct BlobGranuleRangesWorkload : TestWorkload {
 		Standalone<VectorRef<KeyRangeRef>> blobRanges = wait(cx->listBlobbifiedRanges(range, 1000000, self->tenant));
 		if (isActive) {
 			ASSERT(blobRanges.size() == 1);
-			ASSERT(blobRanges[0].begin <= range.begin);
-			ASSERT(blobRanges[0].end >= range.end);
+			if (strict) {
+				ASSERT_EQ(blobRanges[0].begin, range.begin);
+				ASSERT_EQ(blobRanges[0].end, range.end);
+			} else {
+				ASSERT_LE(blobRanges[0].begin, range.begin);
+				ASSERT_GE(blobRanges[0].end, range.end);
+			}
 		} else {
 			ASSERT(blobRanges.empty());
 		}
@@ -273,8 +282,13 @@ struct BlobGranuleRangesWorkload : TestWorkload {
 				Standalone<VectorRef<KeyRangeRef>> granules = wait(tr.getBlobGranuleRanges(range, 1000000));
 				if (isActive) {
 					ASSERT(granules.size() >= 1);
-					ASSERT(granules.front().begin <= range.begin);
-					ASSERT(granules.back().end >= range.end);
+					if (strict) {
+						ASSERT_EQ(granules.front().begin, range.begin);
+						ASSERT_EQ(granules.back().end, range.end);
+					} else {
+						ASSERT_LE(granules.front().begin, range.begin);
+						ASSERT_GE(granules.back().end, range.end);
+					}
 					for (int i = 0; i < granules.size() - 1; i++) {
 						ASSERT(granules[i].end == granules[i + 1].begin);
 					}
@@ -311,13 +325,13 @@ struct BlobGranuleRangesWorkload : TestWorkload {
 		}
 		state std::vector<Future<Void>> checks;
 		for (int i = 0; i < self->activeRanges.size(); i++) {
-			checks.push_back(self->checkRange(cx, self, self->activeRanges[i], true));
+			checks.push_back(self->checkRange(cx, self, self->activeRanges[i], true, true));
 		}
 
 		// FIXME: re-enable! if we don't force purge there are weird races that cause granules to technically still
 		// exist
 		/*for (int i = 0; i < self->inactiveRanges.size(); i++) {
-		    checks.push_back(self->checkRange(cx, self, self->inactiveRanges[i], false));
+		    checks.push_back(self->checkRange(cx, self, self->inactiveRanges[i], false, false));
 		}*/
 		wait(waitForAll(checks));
 		wait(self->unitClient);
@@ -369,7 +383,7 @@ struct BlobGranuleRangesWorkload : TestWorkload {
 		}
 		bool setSuccess = wait(cx->blobbifyRange(activeRange, self->tenant));
 		ASSERT(setSuccess);
-		wait(self->checkRange(cx, self, activeRange, true));
+		wait(self->checkRange(cx, self, activeRange, true, true));
 
 		bool success1 = wait(self->isRangeActive(cx, KeyRangeRef(activeRange.begin, middleKey), self->tenant));
 		ASSERT(success1);
@@ -422,9 +436,9 @@ struct BlobGranuleRangesWorkload : TestWorkload {
 			if (i != rangeToNotBlobbify) {
 				bool setSuccess = wait(cx->blobbifyRange(subRange, self->tenant));
 				ASSERT(setSuccess);
-				wait(self->checkRange(cx, self, subRange, true));
+				wait(self->checkRange(cx, self, subRange, true, true));
 			} else {
-				wait(self->checkRange(cx, self, subRange, false));
+				wait(self->checkRange(cx, self, subRange, false, false));
 			}
 		}
 
@@ -472,11 +486,11 @@ struct BlobGranuleRangesWorkload : TestWorkload {
 		state KeyRange subRange(KeyRangeRef(range.begin.withSuffix("A"_sr), range.begin.withSuffix("B"_sr)));
 
 		// validate range set up correctly
-		wait(self->checkRange(cx, self, range, true));
+		wait(self->checkRange(cx, self, range, true, true));
 		wait(self->checkRangesMisaligned(cx, self, range, range));
 
 		// getBlobGranules and getBlobRanges on sub ranges- should return actual granule/range instead of clipped
-		wait(self->checkRange(cx, self, subRange, true));
+		wait(self->checkRange(cx, self, subRange, true, false));
 		wait(self->checkRangesMisaligned(cx, self, range, subRange));
 		wait(self->checkRangesMisaligned(cx, self, range, KeyRangeRef(range.begin, subRange.end)));
 		wait(self->checkRangesMisaligned(cx, self, range, KeyRangeRef(subRange.begin, range.end)));
@@ -502,7 +516,7 @@ struct BlobGranuleRangesWorkload : TestWorkload {
 		}
 
 		// ensure range still there after unaligned purges
-		wait(self->checkRange(cx, self, range, true));
+		wait(self->checkRange(cx, self, range, true, true));
 		wait(self->checkRangesMisaligned(cx, self, range, range));
 
 		wait(self->tearDownRangeAfterUnit(cx, self, range));
@@ -526,12 +540,12 @@ struct BlobGranuleRangesWorkload : TestWorkload {
 
 		bool success = wait(cx->blobbifyRange(activeRange, self->tenant));
 		ASSERT(success);
-		wait(self->checkRange(cx, self, activeRange, true));
+		wait(self->checkRange(cx, self, activeRange, true, true));
 
 		// check that re-blobbifying same range is successful
 		bool retrySuccess = wait(cx->blobbifyRange(activeRange, self->tenant));
 		ASSERT(retrySuccess);
-		wait(self->checkRange(cx, self, activeRange, true));
+		wait(self->checkRange(cx, self, activeRange, true, true));
 
 		// check that blobbifying range that overlaps but does not match existing blob range fails
 		bool fail1 = wait(cx->blobbifyRange(range, self->tenant));
@@ -595,33 +609,43 @@ struct BlobGranuleRangesWorkload : TestWorkload {
 			ASSERT(blobRanges.size() == 1);
 			ASSERT(blobRanges[0] == activeRange);
 
-			bool unblobbifyFail1 = wait(cx->unblobbifyRange(range, self->tenant));
+			// range that overlaps but does not completely include activeRange should fail to unblobbify
+			bool unblobbifyFail1 = wait(cx->unblobbifyRange(KeyRangeRef(activeRange.begin, middleKey), self->tenant));
 			ASSERT(!unblobbifyFail1);
 
-			bool unblobbifyFail2 = wait(cx->unblobbifyRange(KeyRangeRef(range.begin, activeRange.end), self->tenant));
+			bool unblobbifyFail2 = wait(cx->unblobbifyRange(KeyRangeRef(middleKey, activeRange.end), self->tenant));
 			ASSERT(!unblobbifyFail2);
 
-			bool unblobbifyFail3 = wait(cx->unblobbifyRange(KeyRangeRef(activeRange.begin, range.end), self->tenant));
+			bool unblobbifyFail3 = wait(cx->unblobbifyRange(KeyRangeRef(activeRange.begin, middleKey), self->tenant));
 			ASSERT(!unblobbifyFail3);
 
-			bool unblobbifyFail4 = wait(cx->unblobbifyRange(KeyRangeRef(activeRange.begin, middleKey), self->tenant));
+			bool unblobbifyFail4 = wait(cx->unblobbifyRange(KeyRangeRef(middleKey, activeRange.end), self->tenant));
 			ASSERT(!unblobbifyFail4);
 
-			bool unblobbifyFail5 = wait(cx->unblobbifyRange(KeyRangeRef(middleKey, activeRange.end), self->tenant));
+			bool unblobbifyFail5 = wait(cx->unblobbifyRange(KeyRangeRef(middleKey, middleKey2), self->tenant));
 			ASSERT(!unblobbifyFail5);
 
-			bool unblobbifyFail6 = wait(cx->unblobbifyRange(KeyRangeRef(activeRange.begin, middleKey), self->tenant));
-			ASSERT(!unblobbifyFail6);
+			// several combinations of unblobbifying should work here, any that completely contain activeRange
+			state int unblobbifyMethod = deterministicRandom()->randomInt(0, 4);
+			if (unblobbifyMethod == 0) {
+				bool unblobbifySuccess0 = wait(cx->unblobbifyRange(range, self->tenant));
+				ASSERT(unblobbifySuccess0);
+			} else if (unblobbifyMethod == 1) {
+				bool unblobbifySuccess1 =
+				    wait(cx->unblobbifyRange(KeyRangeRef(range.begin, activeRange.end), self->tenant));
+				ASSERT(unblobbifySuccess1);
+			} else if (unblobbifyMethod == 2) {
+				bool unblobbifySuccess2 =
+				    wait(cx->unblobbifyRange(KeyRangeRef(activeRange.begin, range.end), self->tenant));
+				ASSERT(unblobbifySuccess2);
+			} else if (unblobbifyMethod == 3) {
+				bool unblobbifySuccess3 = wait(cx->unblobbifyRange(activeRange, self->tenant));
+				ASSERT(unblobbifySuccess3);
+			} else {
+				ASSERT(false);
+			}
 
-			bool unblobbifyFail7 = wait(cx->unblobbifyRange(KeyRangeRef(middleKey, activeRange.end), self->tenant));
-			ASSERT(!unblobbifyFail7);
-
-			bool unblobbifyFail8 = wait(cx->unblobbifyRange(KeyRangeRef(middleKey, middleKey2), self->tenant));
-			ASSERT(!unblobbifyFail8);
-
-			bool unblobbifySuccess = wait(cx->unblobbifyRange(activeRange, self->tenant));
-			ASSERT(unblobbifySuccess);
-
+			// unblobbify should be idempotent
 			bool unblobbifySuccessAgain = wait(cx->unblobbifyRange(activeRange, self->tenant));
 			ASSERT(unblobbifySuccessAgain);
 		}
@@ -632,20 +656,20 @@ struct BlobGranuleRangesWorkload : TestWorkload {
 	ACTOR Future<Void> reBlobbifyUnit(Database cx, BlobGranuleRangesWorkload* self, KeyRange range) {
 		bool setSuccess = wait(cx->blobbifyRange(range, self->tenant));
 		ASSERT(setSuccess);
-		wait(self->checkRange(cx, self, range, true));
+		wait(self->checkRange(cx, self, range, true, true));
 
 		// force purge range
 		Key purgeKey = wait(self->versionedForcePurge(cx, range, self->tenant));
 		wait(cx->waitPurgeGranulesComplete(purgeKey));
-		wait(self->checkRange(cx, self, range, false));
+		wait(self->checkRange(cx, self, range, false, false));
 
 		bool unsetSuccess = wait(cx->unblobbifyRange(range, self->tenant));
 		ASSERT(unsetSuccess);
-		wait(self->checkRange(cx, self, range, false));
+		wait(self->checkRange(cx, self, range, false, false));
 
 		bool reSetSuccess = wait(cx->blobbifyRange(range, self->tenant));
 		ASSERT(reSetSuccess);
-		wait(self->checkRange(cx, self, range, true));
+		wait(self->checkRange(cx, self, range, true, true));
 
 		wait(self->tearDownRangeAfterUnit(cx, self, range));
 
@@ -661,10 +685,10 @@ struct BlobGranuleRangesWorkload : TestWorkload {
 		state bool setSuccess = false;
 		wait(store(setSuccess, cx->blobbifyRange(range1, self->tenant)));
 		ASSERT(setSuccess);
-		wait(self->checkRange(cx, self, range1, true));
+		wait(self->checkRange(cx, self, range1, true, true));
 		wait(store(setSuccess, cx->blobbifyRange(range2, self->tenant)));
 		ASSERT(setSuccess);
-		wait(self->checkRange(cx, self, range2, true));
+		wait(self->checkRange(cx, self, range2, true, true));
 
 		// force purge range
 		state Key purgeKey;
@@ -716,6 +740,56 @@ struct BlobGranuleRangesWorkload : TestWorkload {
 		return Void();
 	}
 
+	// Simulate having many consecutive ranges within one subrange registered, and unblobbifying some prefix of them
+	// (potentially the whole range)
+	ACTOR Future<Void> unblobbifyManyUnit(Database cx, BlobGranuleRangesWorkload* self, KeyRange range) {
+		// Create 2 adjacent blobbified regions.
+		state int ranges = deterministicRandom()->randomInt(2, 10);
+		state int prefixToUnblobbify = deterministicRandom()->randomInt(1, ranges + 1);
+
+		state int i;
+		for (i = 0; i < ranges; i++) {
+			state KeyRange subRange(KeyRangeRef(range.begin.withSuffix("_" + std::to_string(i)),
+			                                    range.begin.withSuffix("_" + std::to_string(i + 1))));
+			bool success = wait(cx->blobbifyRange(subRange, self->tenant));
+			ASSERT(success);
+			wait(self->checkRange(cx, self, subRange, true, true));
+		}
+
+		// sometimes start purge and unblobbify at logical range start, other times at first subrange start
+		Key startKey = range.begin;
+		if (deterministicRandom()->coinflip()) {
+			startKey = startKey.withSuffix("_0"_sr);
+		}
+
+		// if purge is full range, sometimes end it at logical range end, other times at subrange boundary
+		state Key endKey = range.end;
+		if (prefixToUnblobbify < ranges || deterministicRandom()->coinflip()) {
+			endKey = range.begin.withSuffix("_" + std::to_string(prefixToUnblobbify));
+		}
+
+		state KeyRange unblobbifyRange(KeyRangeRef(startKey, endKey));
+
+		state Key purgeKey;
+		wait(store(purgeKey, self->versionedForcePurge(cx, unblobbifyRange, self->tenant)));
+		wait(cx->waitPurgeGranulesComplete(purgeKey));
+
+		bool unsetSuccess = wait(cx->unblobbifyRange(unblobbifyRange, self->tenant));
+		ASSERT(unsetSuccess);
+
+		// check that all ranges after the unblobbified boundary are still valid
+		for (i = prefixToUnblobbify; i < ranges; i++) {
+			KeyRange checkRange(KeyRangeRef(range.begin.withSuffix("_" + std::to_string(i)),
+			                                range.begin.withSuffix("_" + std::to_string(i + 1))));
+			wait(self->checkRange(cx, self, checkRange, true, true));
+		}
+
+		// tear down the part of the test that we didn't already do
+		wait(self->tearDownRangeAfterUnit(cx, self, KeyRangeRef(endKey, range.end)));
+
+		return Void();
+	}
+
 	enum UnitTestTypes {
 		VERIFY_RANGE_UNIT,
 		VERIFY_RANGE_GAP_UNIT,
@@ -725,7 +799,8 @@ struct BlobGranuleRangesWorkload : TestWorkload {
 		ADJACENT_PURGE,
 		BLOBBIFY_BLOCKING_UNIT,
 		DELETE_TENANT_UNIT,
-		OP_COUNT = 8 /* keep this last */
+		UNBLOBBIFY_MANY_UNIT,
+		OP_COUNT = 9 /* keep this last */
 	};
 
 	ACTOR Future<Void> blobGranuleRangesUnitTests(Database cx, BlobGranuleRangesWorkload* self) {
@@ -773,6 +848,8 @@ struct BlobGranuleRangesWorkload : TestWorkload {
 				wait(self->blobbifyBlockingUnit(cx, self, range));
 			} else if (op == DELETE_TENANT_UNIT) {
 				wait(self->deleteTenantUnit(cx, self, range));
+			} else if (op == UNBLOBBIFY_MANY_UNIT) {
+				wait(self->unblobbifyManyUnit(cx, self, range));
 			} else {
 				ASSERT(false);
 			}


### PR DESCRIPTION
Cherry-Pick of #10182

Original Description:

Allowed unblobbify to work with a superset of ranges, eg unblobbifying [A - Z) would work if your blob ranges were [B - C), [C - D),  [F - G).
Also strengthened testing to add extra checks that blob granules would not be merged across consecutive but explicitly different blobbified ranges.

Passes 50k BlobGranuleRange* correctness and 50k BlobGranule* correctness with 1 unrelated error.


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
