### PR TITLE
fixing bugs with tenant_mode required on external clients and changin… (Cherry-Pick #10183 to snowflake/release-71.3)

### DIFF
--- a/fdbcli/ChangeFeedCommand.actor.cpp
+++ b/fdbcli/ChangeFeedCommand.actor.cpp
@@ -41,11 +41,12 @@ ACTOR Future<Void> changeFeedList(Database db) {
 		try {
 			tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 			tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
+			tr.setOption(FDBTransactionOptions::RAW_ACCESS);
 
 			RangeResult result = wait(tr.getRange(changeFeedKeys, CLIENT_KNOBS->TOO_MANY));
 			// shouldn't have many quarantined TSSes
 			ASSERT(!result.more);
-			printf("Found %d range feeds%s\n", result.size(), result.size() == 0 ? "." : ":");
+			printf("Found %d change feeds%s\n", result.size(), result.size() == 0 ? "." : ":");
 			for (auto& it : result) {
 				auto range = std::get<0>(decodeChangeFeedValue(it.value));
 				printf("  %s: `%s' - `%s'\n",
@@ -68,6 +69,7 @@ ACTOR Future<Void> requestVersionUpdate(Database localDb, Reference<ChangeFeedDa
 	loop {
 		wait(delay(5.0));
 		Transaction tr(localDb);
+		tr.setOption(FDBTransactionOptions::RAW_ACCESS);
 		state Version ver = wait(tr.getReadVersion());
 		fmt::print("Requesting version {}\n", ver);
 		wait(feedData->whenAtLeast(ver));

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -8507,8 +8507,11 @@ ACTOR Future<Version> setPerpetualStorageWiggle(Database cx, bool enable, LockAw
 	return version;
 }
 
-ACTOR Future<Version> checkBlobSubrange(Database db, KeyRange keyRange, Optional<Version> version) {
-	state Transaction tr(db);
+ACTOR Future<Version> checkBlobSubrange(Database db,
+                                        Optional<Reference<Tenant>> tenant,
+                                        KeyRange keyRange,
+                                        Optional<Version> version) {
+	state Transaction tr(db, tenant);
 	state Optional<Version> summaryVersion;
 	if (version.present()) {
 		summaryVersion = version.get();
@@ -8535,7 +8538,7 @@ ACTOR Future<Version> verifyBlobRangeActor(Reference<DatabaseContext> cx,
                                            Optional<Version> version,
                                            Optional<Reference<Tenant>> tenant) {
 	state Database db(cx);
-	state Transaction tr(db);
+	state Transaction tr(db, tenant);
 	state Standalone<VectorRef<KeyRangeRef>> allRanges;
 	state KeyRange curRegion = KeyRangeRef(range.begin, range.begin);
 	state Version readVersionOut = invalidVersion;
@@ -8562,8 +8565,6 @@ ACTOR Future<Version> verifyBlobRangeActor(Reference<DatabaseContext> cx,
 
 	if (tenant.present()) {
 		wait(tenant.get()->ready());
-		range = range.withPrefix(tenant.get()->prefix());
-		curRegion = KeyRangeRef(range.begin, range.begin);
 	}
 
 	loop {
@@ -8598,13 +8599,13 @@ ACTOR Future<Version> verifyBlobRangeActor(Reference<DatabaseContext> cx,
 			batchCount++;
 
 			if (batchCount == batchSize) {
-				checkParts.push_back(checkBlobSubrange(db, curRegion, version));
+				checkParts.push_back(checkBlobSubrange(db, tenant, curRegion, version));
 				batchCount = 0;
 				curRegion = KeyRangeRef(curRegion.end, curRegion.end);
 			}
 		}
 		if (!curRegion.empty()) {
-			checkParts.push_back(checkBlobSubrange(db, curRegion, version));
+			checkParts.push_back(checkBlobSubrange(db, tenant, curRegion, version));
 		}
 
 		try {

--- a/fdbclient/include/fdbclient/BlobGranuleRequest.actor.h
+++ b/fdbclient/include/fdbclient/BlobGranuleRequest.actor.h
@@ -170,6 +170,8 @@ Future<Standalone<VectorRef<REPLY_TYPE(Request)>>> doBlobGranuleRequests(
 			tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 			tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
 			tr.setOption(FDBTransactionOptions::LOCK_AWARE);
+			// raw access for avoiding tenant check in required mode
+			tr.setOption(FDBTransactionOptions::RAW_ACCESS);
 			Standalone<VectorRef<REPLY_TYPE(Request)>> partialResults =
 			    wait(txnDoBlobGranuleRequests(&tr, &beginKey, endKey, request, channel));
 			if (!partialResults.empty()) {

--- a/fdbserver/workloads/BlobGranuleRangesWorkload.actor.cpp
+++ b/fdbserver/workloads/BlobGranuleRangesWorkload.actor.cpp
@@ -88,9 +88,7 @@ struct BlobGranuleRangesWorkload : TestWorkload {
 		nextKey = 10000000 * clientId;
 
 		stopUnitClient = false;
-		if (deterministicRandom()->coinflip()) {
-			tenantName = StringRef("bgrwTenant" + std::to_string(clientId));
-		}
+		tenantName = StringRef("bgrwTenant" + std::to_string(clientId));
 
 		TraceEvent("BlobGranuleRangesWorkloadInit").detail("TargetRanges", targetRanges);
 	}
@@ -189,8 +187,11 @@ struct BlobGranuleRangesWorkload : TestWorkload {
 		// set up blob granules
 		wait(success(ManagementAPI::changeConfig(cx.getReference(), "blob_granules_enabled=1", true)));
 
+		if (cx->clientInfo->get().tenantMode != TenantMode::REQUIRED && deterministicRandom()->coinflip()) {
+			self->tenantName.reset();
+		}
+
 		if (self->tenantName.present()) {
-			wait(success(ManagementAPI::changeConfig(cx.getReference(), "tenant_mode=optional_experimental", true)));
 			wait(success(self->setupTenant(cx, self->tenantName.get())));
 
 			self->tenant = makeReference<Tenant>(cx, self->tenantName.get());
@@ -300,6 +301,9 @@ struct BlobGranuleRangesWorkload : TestWorkload {
 	}
 
 	ACTOR Future<bool> _check(Database cx, BlobGranuleRangesWorkload* self) {
+		if (deterministicRandom()->coinflip()) {
+			cx->internal = IsInternal::False;
+		}
 		TraceEvent("BlobGranuleRangesCheck")
 		    .detail("ActiveRanges", self->activeRanges.size())
 		    .detail("InactiveRanges", self->inactiveRanges.size())
@@ -328,6 +332,9 @@ struct BlobGranuleRangesWorkload : TestWorkload {
 	void getMetrics(std::vector<PerfMetric>& m) override {}
 
 	ACTOR Future<Void> blobGranuleRangesClient(Database cx, BlobGranuleRangesWorkload* self) {
+		if (deterministicRandom()->coinflip()) {
+			cx->internal = IsInternal::False;
+		}
 		state double last = now();
 		loop {
 			state Future<Void> waitNextOp = poisson(&last, 1.0 / self->operationsPerSecond);
@@ -729,6 +736,9 @@ struct BlobGranuleRangesWorkload : TestWorkload {
 	};
 
 	ACTOR Future<Void> blobGranuleRangesUnitTests(Database cx, BlobGranuleRangesWorkload* self) {
+		if (deterministicRandom()->coinflip()) {
+			cx->internal = IsInternal::False;
+		}
 		loop {
 			if (self->stopUnitClient) {
 				return Void();

--- a/tests/rare/BlobGranuleRanges.toml
+++ b/tests/rare/BlobGranuleRanges.toml
@@ -3,6 +3,7 @@ blobGranulesEnabled = true
 allowDefaultTenant = false
 injectTargetedSSRestart = true
 injectSSDelay = true
+tenantModes = ['optional', 'required']
 
 [[test]]
 testTitle = 'BlobGranuleRanges'


### PR DESCRIPTION
Cherry-Pick of #10183

Original Description:

…g test to find them

- changed BlobGranuleRanges workload to use tenant_mode=required and buggify non-internal clients to reproduce issues
- fixed blob management apis to properly use tenant where provided to fix errors

Passes 50k BlobGranuleRanges correctness and 50k BlobGranule* correctness with 1 unrelated error.
Also tested manually with fdbcli on a cluster with tenant_mode=required

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
