### PR TITLE
EKP Should not Throw Transient Errors

### DIFF
--- a/fdbserver/EncryptKeyProxy.actor.cpp
+++ b/fdbserver/EncryptKeyProxy.actor.cpp
@@ -67,11 +67,6 @@ bool canReplyWith(Error e) {
 	switch (e.code()) {
 	case error_code_encrypt_key_not_found:
 	case error_code_encrypt_keys_fetch_failed:
-	// FDB <-> KMS connection may be observing transient issues
-	// Caller processes should consider reusing 'non-revocable' CipherKeys iff ONLY below error codes lead to CipherKey
-	// refresh failure
-	case error_code_timed_out:
-	case error_code_connection_failed:
 		return true;
 	default:
 		return false;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -202,7 +202,7 @@ if(WITH_PYTHON)
   add_fdb_test(TEST_FILES fast/RandomUnitTests.toml)
   add_fdb_test(TEST_FILES fast/ReadHotDetectionCorrectness.toml IGNORE) # TODO re-enable once read hot detection is enabled.
   add_fdb_test(TEST_FILES fast/ReportConflictingKeys.toml)
-  add_fdb_test(TEST_FILES fast/RESTKmsConnectorUnit.toml IGNORE)
+  add_fdb_test(TEST_FILES fast/RESTKmsConnectorUnit.toml)
   add_fdb_test(TEST_FILES fast/RESTUtilsUnit.toml IGNORE)
   add_fdb_test(TEST_FILES fast/SelectorCorrectness.toml)
   add_fdb_test(TEST_FILES fast/Sideband.toml)


### PR DESCRIPTION
Previously the EKP would throw `timed_out` or `connection_failed` errors which were propagated to clients. This PR prevents these types of errors from reaching the client by retrying 

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
