### PR TITLE
fixing logical merge conflict that dropped tenant modes (Cherry-Pick #10190 to snowflake/release-71.3)

### DIFF
--- a/tests/rare/BlobGranuleRangesChangeLog.toml
+++ b/tests/rare/BlobGranuleRangesChangeLog.toml
@@ -4,6 +4,7 @@ blobGranulesEnabled = true
 allowDefaultTenant = false
 injectTargetedSSRestart = true
 injectSSDelay = true
+tenantModes = ['optional', 'required']
 
 [[knobs]]
 bg_use_blob_range_change_log = true


### PR DESCRIPTION
Cherry-Pick of #10190

Original Description:

Logical merge conflict between #10174 and #10183 that causes BlobGranuleRangesChangeLog test to fail

Now passes 10k BlobGranuleRanges* tests

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
