### PR TITLE
Cherry-pick #10188 to 7.3

### DIFF
--- a/fdbcli/GetAuditStatusCommand.actor.cpp
+++ b/fdbcli/GetAuditStatusCommand.actor.cpp
@@ -31,7 +31,7 @@
 namespace fdb_cli {
 
 ACTOR Future<bool> getAuditStatusCommandActor(Database cx, std::vector<StringRef> tokens) {
-	if (tokens.size() < 3 || tokens.size() > 4) {
+	if (tokens.size() < 2 || tokens.size() > 4) {
 		printUsage(tokens[0]);
 		return false;
 	}
@@ -39,12 +39,18 @@ ACTOR Future<bool> getAuditStatusCommandActor(Database cx, std::vector<StringRef
 	AuditType type = AuditType::Invalid;
 	if (tokencmp(tokens[1], "ha")) {
 		type = AuditType::ValidateHA;
+	} else if (tokencmp(tokens[1], "checkmigration")) {
+		type = AuditType::CheckMigrationStatus;
 	} else {
 		printUsage(tokens[0]);
 		return false;
 	}
 
-	if (tokencmp(tokens[2], "id")) {
+	if (tokens.size() == 2) {
+		ASSERT(type == AuditType::CheckMigrationStatus);
+		std::string res = wait(checkMigrationProgress(cx));
+		printf("\n%s", res.c_str());
+	} else if (tokencmp(tokens[2], "id")) {
 		if (tokens.size() != 4) {
 			printUsage(tokens[0]);
 			return false;
@@ -61,19 +67,24 @@ ACTOR Future<bool> getAuditStatusCommandActor(Database cx, std::vector<StringRef
 		for (const auto& it : res) {
 			printf("Audit result is:\n%s\n", it.toString().c_str());
 		}
+	} else {
+		printUsage(tokens[0]);
+		return false;
 	}
+
 	return true;
 }
 
 CommandFactory getAuditStatusFactory(
     "get_audit_status",
-    CommandHelp("get_audit_status <Type> <id|recent> [ARGs]",
+    CommandHelp("get_audit_status [ha|replica|locationmetadata|ssshard|checkmigration] [id|recent] [ARGs]",
                 "Retrieve audit storage status",
                 "To fetch audit status via ID: `get_audit_status [Type] id [ID]'\n"
                 "To fetch status of most recent audit: `get_audit_status [Type] recent [Count]'\n"
-                "Only 'ha' `Type' is supported currently. If specified, `Count' is how many\n"
+                "Supported types include: 'ha', and `checkmigration`. If specified, `Count' is how many\n"
                 "rows to audit. If not specified, check all rows in audit.\n"
-                "Results have the following format:\n"
+                "get_audit_status checkmigration prints out the number of data shards and physical shards."
+                "Results have the following format: if not `checkmigration`\n"
                 "  `[ID]: 000000000001000000000000, [Range]:  - 0xff, [Type]: 1, [Phase]: 2'\n"
                 "where `Type' is `1' for `ha' and `Phase' is `2' for `Complete'.\n"
                 "Phase can be `Invalid=0', `Running=1', `Complete=2', `Error=3', or `Failed=4'.\n"

--- a/fdbclient/AuditUtils.actor.cpp
+++ b/fdbclient/AuditUtils.actor.cpp
@@ -23,7 +23,9 @@
 #include "fdbclient/Audit.h"
 #include "fdbclient/FDBTypes.h"
 #include "fdbclient/NativeAPI.actor.h"
+#include "fdbclient/ReadYourWrites.h"
 #include "fdbclient/ClientKnobs.h"
+#include <fmt/format.h>
 
 #include "flow/actorcompiler.h" // has to be last include
 
@@ -116,6 +118,50 @@ ACTOR Future<std::vector<AuditStorageState>> getLatestAuditStates(Database cx, A
 	return auditStates;
 }
 
+ACTOR Future<std::string> checkMigrationProgress(Database cx) {
+	state Key begin = allKeys.begin;
+	state int numShards = 0;
+	state int numPhysicalShards = 0;
+
+	while (begin < allKeys.end) {
+		// RYW to optimize re-reading the same key ranges
+		state Reference<ReadYourWritesTransaction> tr = makeReference<ReadYourWritesTransaction>(cx);
+
+		loop {
+			try {
+				tr->setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
+				tr->setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
+
+				state RangeResult UIDtoTagMap = wait(tr->getRange(serverTagKeys, CLIENT_KNOBS->TOO_MANY));
+				ASSERT(!UIDtoTagMap.more && UIDtoTagMap.size() < CLIENT_KNOBS->TOO_MANY);
+
+				KeyRangeRef currentKeys(begin, allKeys.end);
+				RangeResult shards = wait(
+				    krmGetRanges(tr, keyServersPrefix, currentKeys, CLIENT_KNOBS->TOO_MANY, CLIENT_KNOBS->TOO_MANY));
+
+				for (int i = 0; i < shards.size() - 1; ++i) {
+					std::vector<UID> src;
+					std::vector<UID> dest;
+					UID srcId;
+					UID destId;
+					decodeKeyServersValue(UIDtoTagMap, shards[i].value, src, dest, srcId, destId);
+					if (srcId != anonymousShardId) {
+						++numPhysicalShards;
+					}
+				}
+
+				begin = shards.back().key;
+				numShards += shards.size() - 1;
+				break;
+			} catch (Error& e) {
+				wait(tr->onError(e));
+			}
+		}
+	}
+
+	return fmt::format("Total number of shards: {}, number of physical shards: {}", numShards, numPhysicalShards);
+}
+
 ACTOR Future<Void> persistAuditStateMap(Database cx, AuditStorageState auditState) {
 	state Transaction tr(cx);
 
@@ -162,14 +208,4 @@ ACTOR Future<std::vector<AuditStorageState>> getAuditStateForRange(Database cx, 
 	}
 
 	return res;
-}
-
-StringRef auditTypeToString(const AuditType type) {
-	switch (type) {
-	case AuditType::Invalid:
-		return "Invalid"_sr;
-	case AuditType::ValidateHA:
-		return "ValidateHA"_sr;
-	}
-	return "Invalid"_sr;
 }

--- a/fdbclient/include/fdbclient/Audit.h
+++ b/fdbclient/include/fdbclient/Audit.h
@@ -36,6 +36,7 @@ enum class AuditPhase : uint8_t {
 enum class AuditType : uint8_t {
 	Invalid = 0,
 	ValidateHA = 1,
+	CheckMigrationStatus = 5,
 };
 
 struct AuditStorageState {

--- a/fdbclient/include/fdbclient/AuditUtils.actor.h
+++ b/fdbclient/include/fdbclient/AuditUtils.actor.h
@@ -40,7 +40,7 @@ ACTOR Future<std::vector<AuditStorageState>> getLatestAuditStates(Database cx, A
 ACTOR Future<Void> persistAuditStateMap(Database cx, AuditStorageState auditState);
 ACTOR Future<std::vector<AuditStorageState>> getAuditStateForRange(Database cx, UID id, KeyRange range);
 
-StringRef auditTypeToString(const AuditType type);
+ACTOR Future<std::string> checkMigrationProgress(Database cx);
 
 #include "flow/unactorcompiler.h"
 #endif


### PR DESCRIPTION
 Main branch PR: #10188
* Added `get_audit_status checkmigration` to print out the number of data shards and `physical shards`, so that we know the progress of migration to `shard_encode_location_metadata`

* Fixed print format.

* Addressed comments.

Replace this text with your description here...

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
