### PR TITLE
Add `ignore_capacity_limit` to `tenant create` (Cherry-Pick #10173 to snowflake/release-71.3)

### DIFF
--- a/fdbcli/TenantCommands.actor.cpp
+++ b/fdbcli/TenantCommands.actor.cpp
@@ -167,12 +167,15 @@ void applyConfigurationToSpecialKeys(Reference<ITransaction> tr,
 
 // tenant create command
 ACTOR Future<bool> tenantCreateCommand(Reference<IDatabase> db, std::vector<StringRef> tokens) {
-	if (tokens.size() < 3 || tokens.size() > 5) {
-		fmt::print("Usage: tenant create <NAME> [tenant_group=<TENANT_GROUP>] [assigned_cluster=<CLUSTER_NAME>]\n\n");
+	if (tokens.size() < 3 || tokens.size() > 6) {
+		fmt::print("Usage: tenant create <NAME> [tenant_group=<TENANT_GROUP>] [assigned_cluster=<CLUSTER_NAME>] "
+		           "[ignore_capacity_limit]\n\n");
 		fmt::print("Creates a new tenant in the cluster with the specified name.\n");
 		fmt::print("An optional group can be specified that will require this tenant\n");
 		fmt::print("to be placed on the same cluster as other tenants in the same group.\n");
 		fmt::print("An optional cluster name can be specified that this tenant will be placed in.\n");
+		fmt::print("Optionally, `ignore_capacity_limit' can be specified together with `assigned_cluster' to allow "
+		           "creation of a new tenant group on a cluster with no tenant group capacity remaining.\n");
 		return false;
 	}
 
@@ -180,10 +183,16 @@ ACTOR Future<bool> tenantCreateCommand(Reference<IDatabase> db, std::vector<Stri
 	state Reference<ITransaction> tr = db->createTransaction();
 	state bool doneExistenceCheck = false;
 
+	state bool ignoreCapacityLimit = tokens.back() == "ignore_capacity_limit";
+	int configurationEndIndex = tokens.size() - (ignoreCapacityLimit ? 1 : 0);
+
 	state Optional<std::map<Standalone<StringRef>, Optional<Value>>> configuration =
-	    parseTenantConfiguration(tokens, 3, tokens.size(), false);
+	    parseTenantConfiguration(tokens, 3, configurationEndIndex, false);
 
 	if (!configuration.present()) {
+		return false;
+	} else if (ignoreCapacityLimit && !configuration.get().contains("assigned_cluster"_sr)) {
+		fmt::print(stderr, "ERROR: `ignore_capacity_limit' can only be used if `assigned_cluster' is set.\n");
 		return false;
 	}
 
@@ -203,7 +212,10 @@ ACTOR Future<bool> tenantCreateCommand(Reference<IDatabase> db, std::vector<Stri
 					tenantEntry.configure(name, value);
 				}
 				tenantEntry.tenantName = tokens[2];
-				wait(metacluster::createTenant(db, tenantEntry, assignClusterAutomatically));
+				wait(metacluster::createTenant(db,
+				                               tenantEntry,
+				                               assignClusterAutomatically,
+				                               metacluster::IgnoreCapacityLimit(ignoreCapacityLimit)));
 			} else {
 				if (!doneExistenceCheck) {
 					// Hold the reference to the standalone's memory
@@ -961,8 +973,8 @@ void tenantGenerator(const char* text,
 		const char* opts[] = { "create",    "delete", "deleteId", "list",   "get",
 			                   "configure", "rename", "lock",     "unlock", nullptr };
 		arrayGenerator(text, line, opts, lc);
-	} else if (tokens.size() == 3 && tokencmp(tokens[1], "create")) {
-		const char* opts[] = { "tenant_group=", nullptr };
+	} else if (tokens.size() >= 3 && tokencmp(tokens[1], "create")) {
+		const char* opts[] = { "tenant_group=", "assigned_cluster=", "ignore_capacity_limit", nullptr };
 		arrayGenerator(text, line, opts, lc);
 	} else if (tokens.size() == 3 && tokencmp(tokens[1], "get")) {
 		const char* opts[] = { "JSON", nullptr };
@@ -996,9 +1008,9 @@ std::vector<const char*> tenantHintGenerator(std::vector<StringRef> const& token
 	if (tokens.size() == 1) {
 		return { "<create|delete|deleteId|list|get|getId|configure|rename>", "[ARGS]" };
 	} else if (tokencmp(tokens[1], "create") && tokens.size() < 5) {
-		static std::vector<const char*> opts = { "<NAME>",
-			                                     "[tenant_group=<TENANT_GROUP>]",
-			                                     "[assigned_cluster=<CLUSTER_NAME>]" };
+		static std::vector<const char*> opts = {
+			"<NAME>", "[tenant_group=<TENANT_GROUP>]", "[assigned_cluster=<CLUSTER_NAME>]", "[ignore_capacity_limit]"
+		};
 		return std::vector<const char*>(opts.begin() + tokens.size() - 2, opts.end());
 	} else if (tokencmp(tokens[1], "delete") && tokens.size() < 3) {
 		static std::vector<const char*> opts = { "<NAME>" };

--- a/fdbserver/workloads/MetaclusterRestoreWorkload.actor.cpp
+++ b/fdbserver/workloads/MetaclusterRestoreWorkload.actor.cpp
@@ -774,8 +774,10 @@ struct MetaclusterRestoreWorkload : TestWorkload {
 				metacluster::MetaclusterTenantMapEntry tenantEntry;
 				tenantEntry.tenantName = tenantName;
 				tenantEntry.tenantGroup = self->chooseTenantGroup();
-				wait(metacluster::createTenant(
-				    self->managementDb, tenantEntry, metacluster::AssignClusterAutomatically::True));
+				wait(metacluster::createTenant(self->managementDb,
+				                               tenantEntry,
+				                               metacluster::AssignClusterAutomatically::True,
+				                               metacluster::IgnoreCapacityLimit::False));
 				metacluster::MetaclusterTenantMapEntry createdEntry =
 				    wait(metacluster::getTenant(self->managementDb, tenantName));
 				TraceEvent(SevDebug, "MetaclusterRestoreWorkloadCreatedTenant")

--- a/fdbserver/workloads/TenantCapacityLimits.actor.cpp
+++ b/fdbserver/workloads/TenantCapacityLimits.actor.cpp
@@ -135,8 +135,10 @@ struct TenantCapacityLimits : TestWorkload {
 			try {
 				metacluster::MetaclusterTenantMapEntry entry;
 				entry.tenantName = "test_tenant_metacluster"_sr;
-				wait(metacluster::createTenant(
-				    self->managementDb, entry, metacluster::AssignClusterAutomatically::True));
+				wait(metacluster::createTenant(self->managementDb,
+				                               entry,
+				                               metacluster::AssignClusterAutomatically::True,
+				                               metacluster::IgnoreCapacityLimit::False));
 				ASSERT(false);
 			} catch (Error& e) {
 				ASSERT(e.code() == error_code_cluster_no_capacity);

--- a/fdbserver/workloads/TenantManagementConcurrencyWorkload.actor.cpp
+++ b/fdbserver/workloads/TenantManagementConcurrencyWorkload.actor.cpp
@@ -189,8 +189,10 @@ struct TenantManagementConcurrencyWorkload : TestWorkload {
 				    .detail("TenantName", entry.tenantName)
 				    .detail("TenantGroup", entry.tenantGroup);
 				Future<Void> createFuture =
-				    self->useMetacluster ? metacluster::createTenant(
-				                               self->managementDb, entry, metacluster::AssignClusterAutomatically::True)
+				    self->useMetacluster ? metacluster::createTenant(self->managementDb,
+				                                                     entry,
+				                                                     metacluster::AssignClusterAutomatically::True,
+				                                                     metacluster::IgnoreCapacityLimit::False)
 				                         : success(TenantAPI::createTenant(
 				                               self->standaloneDb.getReference(), tenant, entry.toTenantMapEntry()));
 				Optional<Void> result = wait(timeout(createFuture, 30));

--- a/metacluster/include/metacluster/CreateTenant.actor.h
+++ b/metacluster/include/metacluster/CreateTenant.actor.h
@@ -46,6 +46,7 @@ template <class DB>
 struct CreateTenantImpl {
 	MetaclusterOperationContext<DB> ctx;
 	AssignClusterAutomatically assignClusterAutomatically;
+	IgnoreCapacityLimit ignoreCapacityLimit;
 
 	// Initialization parameters
 	MetaclusterTenantMapEntry tenantEntry;
@@ -55,8 +56,10 @@ struct CreateTenantImpl {
 
 	CreateTenantImpl(Reference<DB> managementDb,
 	                 MetaclusterTenantMapEntry tenantEntry,
-	                 AssignClusterAutomatically assignClusterAutomatically)
-	  : ctx(managementDb), tenantEntry(tenantEntry), assignClusterAutomatically(assignClusterAutomatically) {}
+	                 AssignClusterAutomatically assignClusterAutomatically,
+	                 IgnoreCapacityLimit ignoreCapacityLimit)
+	  : ctx(managementDb), tenantEntry(tenantEntry), assignClusterAutomatically(assignClusterAutomatically),
+	    ignoreCapacityLimit(ignoreCapacityLimit) {}
 
 	ACTOR static Future<ClusterName> checkClusterAvailability(Reference<IDatabase> dataClusterDb,
 	                                                          ClusterName clusterName) {
@@ -157,7 +160,7 @@ struct CreateTenantImpl {
 		if (!self->assignClusterAutomatically) {
 			DataClusterMetadata dataClusterMetadata =
 			    wait(getClusterTransaction(tr, self->tenantEntry.assignedCluster));
-			if (!dataClusterMetadata.entry.hasCapacity()) {
+			if (!dataClusterMetadata.entry.hasCapacity() && !self->ignoreCapacityLimit) {
 				throw cluster_no_capacity();
 			}
 			dataClusterNames.push_back(self->tenantEntry.assignedCluster);
@@ -272,8 +275,11 @@ struct CreateTenantImpl {
 
 		ASSERT(self->ctx.dataClusterMetadata.get().entry.clusterState == DataClusterState::READY);
 
-		internal::managementClusterAddTenantToGroup(
-		    tr, self->tenantEntry, &self->ctx.dataClusterMetadata.get(), GroupAlreadyExists(assignment.second));
+		internal::managementClusterAddTenantToGroup(tr,
+		                                            self->tenantEntry,
+		                                            &self->ctx.dataClusterMetadata.get(),
+		                                            GroupAlreadyExists(assignment.second),
+		                                            self->ignoreCapacityLimit);
 
 		return Void();
 	}
@@ -315,6 +321,13 @@ struct CreateTenantImpl {
 	}
 
 	ACTOR static Future<Void> run(CreateTenantImpl* self) {
+		if (!self->tenantEntry.assignedCluster.empty() && self->assignClusterAutomatically) {
+			throw invalid_tenant_configuration();
+		}
+		if (self->assignClusterAutomatically && self->ignoreCapacityLimit) {
+			TraceEvent("MetaclusterCreateTenantIgnoreCapacityAutoAssign").log();
+			throw invalid_tenant_configuration();
+		}
 		if (self->tenantEntry.tenantName.startsWith("\xff"_sr)) {
 			throw invalid_tenant_name();
 		}
@@ -352,8 +365,9 @@ struct CreateTenantImpl {
 ACTOR template <class DB>
 Future<Void> createTenant(Reference<DB> db,
                           MetaclusterTenantMapEntry tenantEntry,
-                          AssignClusterAutomatically assignClusterAutomatically) {
-	state internal::CreateTenantImpl<DB> impl(db, tenantEntry, assignClusterAutomatically);
+                          AssignClusterAutomatically assignClusterAutomatically,
+                          IgnoreCapacityLimit ignoreCapacityLimit) {
+	state internal::CreateTenantImpl<DB> impl(db, tenantEntry, assignClusterAutomatically, ignoreCapacityLimit);
 	wait(impl.run());
 	return Void();
 }


### PR DESCRIPTION
Cherry-Pick of #10173

Original Description:

Similar to `tenant configure`, this PR adds `ignore_capacity_limit` as an optional argument to `tenant create`.
This allows the user of fdbcli to create a new tenant on an **assigned** cluster, ignoring the tenant group capacity
on that specific cluster.
When creating a tenant with `ignore_capacity_limit`.
- If the user specifies neither of `assigned_cluster` nor `tenant_group`, this is an error.
- If the user specifies `assigned_cluster` but not `tenant_group`, then the new tenant will be an ungrouped tenant on the `assigned_cluster` ignoring the capacity limit
- If the user specifies `tenant_group` but not `assigned_cluster`, and the tenant group already exists, then it means no new tenant group is being created, thus there will always be capacity, and `ignore_capacity_limit` is meaningless and unnecessary.
- If the user specifies both `assigned_cluster` and `tenant_group`, and the tenant group exists, then additional check is performed to make sure they match. If so, the new tenant will be created. Since no new tenant group is created, then similarly, `ignore_capacity_limit` is unnecessary.

Test plan:
Simulation and metacluster_fdbcli_tests.py


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
