### PR TITLE
Fix clean up of data moves when encode location metatdata [release-7.3]

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -178,7 +178,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( MAX_DEST_CPU_PERCENT, 		  					   100.0 );
 	init( DD_TEAM_PIVOT_UPDATE_DELAY,                            5.0 );
 
-	init( SHARD_ENCODE_LOCATION_METADATA,                       false ); if( randomize && BUGGIFY )  SHARD_ENCODE_LOCATION_METADATA = true;
+	init( SHARD_ENCODE_LOCATION_METADATA,                       true ); if( randomize && BUGGIFY )  SHARD_ENCODE_LOCATION_METADATA = true;
 	init( ENABLE_DD_PHYSICAL_SHARD,                             false ); // EXPERIMENTAL; If true, SHARD_ENCODE_LOCATION_METADATA must be true; When true, optimization of data move between DCs is disabled
 	init( ENABLE_DD_PHYSICAL_SHARD_MOVE,                        false );
 	init( MAX_PHYSICAL_SHARD_BYTES,                         10000000 ); // 10 MB; for ENABLE_DD_PHYSICAL_SHARD; smaller leads to larger number of physicalShard per storage server

--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -178,7 +178,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( MAX_DEST_CPU_PERCENT, 		  					   100.0 );
 	init( DD_TEAM_PIVOT_UPDATE_DELAY,                            5.0 );
 
-	init( SHARD_ENCODE_LOCATION_METADATA,                       true ); if( randomize && BUGGIFY )  SHARD_ENCODE_LOCATION_METADATA = true;
+	init( SHARD_ENCODE_LOCATION_METADATA,                       false ); if( randomize && BUGGIFY )  SHARD_ENCODE_LOCATION_METADATA = true;
 	init( ENABLE_DD_PHYSICAL_SHARD,                             false ); // EXPERIMENTAL; If true, SHARD_ENCODE_LOCATION_METADATA must be true; When true, optimization of data move between DCs is disabled
 	init( ENABLE_DD_PHYSICAL_SHARD_MOVE,                        false );
 	init( MAX_PHYSICAL_SHARD_BYTES,                         10000000 ); // 10 MB; for ENABLE_DD_PHYSICAL_SHARD; smaller leads to larger number of physicalShard per storage server

--- a/fdbserver/DDRelocationQueue.actor.cpp
+++ b/fdbserver/DDRelocationQueue.actor.cpp
@@ -1142,70 +1142,90 @@ int DDQueue::getUnhealthyRelocationCount() const {
 	return unhealthyRelocations;
 }
 
+// Cancel existing relocation if exists, and serialize all concurrent relocations
 ACTOR Future<Void> cancelDataMove(class DDQueue* self, KeyRange range, const DDEnabledState* ddEnabledState) {
+	state std::vector<Future<Void>> existingCleanup;
 	state std::vector<Future<Void>> cleanup;
 	state std::vector<std::pair<KeyRange, UID>> lastObservedDataMoves;
 
-	loop {
-		try {
-			cleanup.clear();
-			lastObservedDataMoves.clear();
+	try {
+		// Check if there exists any ongoing cancellation, if it exists, wait until no existence of cancellation
+		// As a result, any cancelDataMove called later must wait for the cancelDataMove called earlier on
+		// the same range. Since relocator as well as the update of self->dataMoves waits for the completion
+		// of cancelDataMove. Thus, any relocator called later must wait for the cancelDataMove called by an
+		// earlier relocator and the earlier relocator must update self->dataMoves which must reflect on the
+		// cancelDataMove of the later relocator, aka, serialize relocators and their cancelDataMoves
+		loop {
+			existingCleanup.clear();
 			auto f = self->dataMoves.intersectingRanges(range);
 			for (auto it = f.begin(); it != f.end(); ++it) {
 				if (!it->value().isValid()) {
 					continue;
 				}
-				KeyRange keys = KeyRangeRef(it->range().begin, it->range().end);
-				TraceEvent(SevInfo, "DDQueueCancelDataMove", self->distributorId)
-				    .detail("DataMoveID", it->value().id)
-				    .detail("DataMoveRange", keys)
-				    .detail("Range", range);
-				if (!it->value().cancel.isValid()) {
-					it->value().cancel = cleanUpDataMove(self->cx,
-					                                     it->value().id,
-					                                     self->lock,
-					                                     &self->cleanUpDataMoveParallelismLock,
-					                                     keys,
-					                                     ddEnabledState,
-					                                     self->addBackgroundCleanUpDataMoveActor);
-				}
-				lastObservedDataMoves.push_back(std::make_pair(keys, it->value().id));
-				cleanup.push_back(it->value().cancel);
-			}
-
-			wait(waitForAll(cleanup));
-
-			for (auto observedDataMove : lastObservedDataMoves) {
-				auto f = self->dataMoves.intersectingRanges(observedDataMove.first);
-				for (auto it = f.begin(); it != f.end(); ++it) {
-					if (it->value().id != observedDataMove.second) {
-						// Invariant: When two concurrent cleanups/relocations try to modify on the same range,
-						// the one who set ddQueue->dataMoves at first win the race
-						// the other one does backoff and retry cleanup later
-						// In this case, someone else of the overlapping range has changed the ddQueue->dataMoves
-						// Thus, the cleanup retries later
-						TraceEvent(SevInfo, "DataMoveWrittenByConcurrentDataMove", self->distributorId)
-						    .detail("Range", range)
-						    .detail("OldRange", observedDataMove.first)
-						    .detail("LastObservedDataMoveID", observedDataMove.second)
-						    .detail("CurrentDataMoveID", it->value().id);
-						throw retry();
-					}
+				if (it->value().cancel.isValid()) {
+					existingCleanup.push_back(it->value().cancel);
 				}
 			}
-			auto ranges = self->dataMoves.getAffectedRangesAfterInsertion(range);
-			if (!ranges.empty()) {
-				self->dataMoves.insert(KeyRangeRef(ranges.front().begin, ranges.back().end), DDQueue::DDDataMove());
+			Future<Void> waitAllCleanF = waitForAll(existingCleanup);
+			if (waitAllCleanF.isReady()) {
+				break;
 			}
-			break;
+			wait(waitAllCleanF);
+		}
 
-		} catch (Error& e) {
-			if (e.code() == error_code_retry) {
-				wait(delay(1));
-			} else {
-				throw e;
+		// At this point, no ongoing clean up, atomically takeover the range by
+		// Updating it->value().cancel at the range
+		// Later cancelDataMoves as well as relocators will wait
+		cleanup.clear();
+		lastObservedDataMoves.clear();
+		auto f = self->dataMoves.intersectingRanges(range);
+		for (auto it = f.begin(); it != f.end(); ++it) {
+			if (!it->value().isValid()) {
+				continue;
+			}
+			KeyRange keys = KeyRangeRef(it->range().begin, it->range().end);
+			TraceEvent(SevInfo, "DDQueueCancelDataMove", self->distributorId)
+			    .detail("DataMoveID", it->value().id)
+			    .detail("DataMoveRange", keys)
+			    .detail("Range", range);
+			if (!it->value().cancel.isValid()) {
+				it->value().cancel = cleanUpDataMove(self->cx,
+				                                     it->value().id,
+				                                     self->lock,
+				                                     &self->cleanUpDataMoveParallelismLock,
+				                                     keys,
+				                                     ddEnabledState,
+				                                     self->addBackgroundCleanUpDataMoveActor);
+			}
+			lastObservedDataMoves.push_back(std::make_pair(keys, it->value().id));
+			cleanup.push_back(it->value().cancel);
+		}
+
+		wait(waitForAll(cleanup));
+		// At this point, if there has any update to self->dataMoves by other relocators, cancel this relocator
+		for (auto observedDataMove : lastObservedDataMoves) {
+			auto f = self->dataMoves.intersectingRanges(observedDataMove.first);
+			for (auto it = f.begin(); it != f.end(); ++it) {
+				if (it->value().id != observedDataMove.second) {
+					TraceEvent(SevWarn, "DataMoveWrittenByConcurrentDataMove", self->distributorId)
+					    .detail("Range", range)
+					    .detail("OldRange", observedDataMove.first)
+					    .detail("LastObservedDataMoveID", observedDataMove.second)
+					    .detail("CurrentDataMoveID", it->value().id);
+					throw movekeys_conflict(); // make sure we have serialized all ongoing cleanups, as well as
+					                           // relocators
+				}
 			}
 		}
+		auto ranges = self->dataMoves.getAffectedRangesAfterInsertion(range);
+		if (!ranges.empty()) {
+			self->dataMoves.insert(KeyRangeRef(ranges.front().begin, ranges.back().end), DDQueue::DDDataMove());
+		}
+		// Since the start of relocator and update of self->dataMoves by the relocator is atomic with
+		// here, the relocator waiting on this cleanup must be visable to other cleanups
+
+	} catch (Error& e) {
+		throw e;
 	}
 
 	return Void();

--- a/fdbserver/DDRelocationQueue.actor.cpp
+++ b/fdbserver/DDRelocationQueue.actor.cpp
@@ -1054,7 +1054,7 @@ void DDQueue::launchQueuedWork(std::set<RelocateData, std::greater<RelocateData>
 			startRelocation(rrs.priority, rrs.healthPriority);
 			// Cleanup waited by a new relocator should only include the range that is moved by the relocator
 			Future<Void> fCleanup =
-                SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA ? cancelDataMove(this, rrs.keys, ddEnabledState) : Void();
+			    SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA ? cancelDataMove(this, rrs.keys, ddEnabledState) : Void();
 			// Start the actor that relocates data in the rrs.keys
 			inFlightActors.insert(rrs.keys, dataDistributionRelocator(this, rrs, fCleanup, ddEnabledState));
 		}

--- a/fdbserver/DDRelocationQueue.actor.cpp
+++ b/fdbserver/DDRelocationQueue.actor.cpp
@@ -1187,12 +1187,13 @@ ACTOR Future<Void> cancelDataMove(class DDQueue* self, KeyRange range, const DDE
 			auto f = self->dataMoves.intersectingRanges(observedDataMove.first);
 			for (auto it = f.begin(); it != f.end(); ++it) {
 				if (it->value().id != observedDataMove.second) {
-					TraceEvent(SevWarn, "DataMoveWrittenByConcurrentDataMove", self->distributorId)
+					TraceEvent(SevInfo, "DataMoveWrittenByConcurrentDataMove", self->distributorId)
 					    .detail("Range", range)
 					    .detail("OldRange", observedDataMove.first)
 					    .detail("LastObservedDataMoveID", observedDataMove.second)
 					    .detail("CurrentDataMoveID", it->value().id);
 				} else {
+					ASSERT(!it->value().isValid() || (it->value().cancel.isValid() && it->value().cancel.isReady()));
 					toResetRanges.push_back(Standalone(it->range()));
 				}
 			}

--- a/fdbserver/DDRelocationQueue.actor.cpp
+++ b/fdbserver/DDRelocationQueue.actor.cpp
@@ -1052,6 +1052,7 @@ void DDQueue::launchQueuedWork(std::set<RelocateData, std::greater<RelocateData>
 			    .detail("Launch", rrs.dataMoveId)
 			    .detail("Total", activeRelocations);
 			startRelocation(rrs.priority, rrs.healthPriority);
+			// Cleanup waited by a new relocator should only include the range that is moved by the relocator
 			Future<Void> fCleanup =
                 SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA ? cancelDataMove(this, rrs.keys, ddEnabledState) : Void();
 			// Start the actor that relocates data in the rrs.keys

--- a/fdbserver/DDRelocationQueue.actor.cpp
+++ b/fdbserver/DDRelocationQueue.actor.cpp
@@ -1015,8 +1015,6 @@ void DDQueue::launchQueuedWork(std::set<RelocateData, std::greater<RelocateData>
 		std::vector<KeyRange> ranges;
 		inFlightActors.getRangesAffectedByInsertion(rd.keys, ranges);
 		inFlightActors.cancel(KeyRangeRef(ranges.front().begin, ranges.back().end));
-		Future<Void> fCleanup =
-		    SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA ? cancelDataMove(this, rd.keys, ddEnabledState) : Void();
 
 		inFlight.insert(rd.keys, rd);
 		for (int r = 0; r < ranges.size(); r++) {
@@ -1054,6 +1052,8 @@ void DDQueue::launchQueuedWork(std::set<RelocateData, std::greater<RelocateData>
 			    .detail("Launch", rrs.dataMoveId)
 			    .detail("Total", activeRelocations);
 			startRelocation(rrs.priority, rrs.healthPriority);
+			Future<Void> fCleanup =
+                SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA ? cancelDataMove(this, rrs.keys, ddEnabledState) : Void();
 			// Start the actor that relocates data in the rrs.keys
 			inFlightActors.insert(rrs.keys, dataDistributionRelocator(this, rrs, fCleanup, ddEnabledState));
 		}


### PR DESCRIPTION
cherrypick #9986


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
