### PR TITLE
Add code probes for tenant and metacluster code

### DIFF
--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -1394,7 +1394,10 @@ struct SingleSpecialKeyImpl : SpecialKeyRangeReadImpl {
 	                     bool supportsTenants = false)
 	  : SpecialKeyRangeReadImpl(singleKeyRange(k)), k(k), f(f), tenantSupport(supportsTenants) {}
 
-	bool supportsTenants() const override { return tenantSupport; };
+	bool supportsTenants() const override {
+		CODE_PROBE(tenantSupport, "Single special key in tenant");
+		return tenantSupport;
+	};
 
 private:
 	Key k;
@@ -1919,6 +1922,7 @@ Optional<KeyRangeLocationInfo> DatabaseContext::getCachedLocation(const TenantIn
 	KeyRef resolvedKey = key;
 
 	if (tenant.hasTenant()) {
+		CODE_PROBE(true, "Database context get cached location with tenant");
 		resolvedKey = resolvedKey.withPrefix(tenant.prefix.get(), arena);
 	}
 
@@ -1942,6 +1946,7 @@ bool DatabaseContext::getCachedLocations(const TenantInfo& tenant,
 	KeyRangeRef resolvedRange = range;
 
 	if (tenant.hasTenant()) {
+		CODE_PROBE(true, "Database context get cached locations with tenant");
 		resolvedRange = resolvedRange.withPrefix(tenant.prefix.get(), arena);
 	}
 
@@ -1994,6 +1999,7 @@ void DatabaseContext::invalidateCache(const Optional<KeyRef>& tenantPrefix, cons
 	Arena arena;
 	KeyRef resolvedKey = key;
 	if (tenantPrefix.present() && !tenantPrefix.get().empty()) {
+		CODE_PROBE(true, "Database context invalidate cache for tenant key");
 		resolvedKey = resolvedKey.withPrefix(tenantPrefix.get(), arena);
 	}
 
@@ -2008,6 +2014,7 @@ void DatabaseContext::invalidateCache(const Optional<KeyRef>& tenantPrefix, cons
 	Arena arena;
 	KeyRangeRef resolvedKeys = keys;
 	if (tenantPrefix.present() && !tenantPrefix.get().empty()) {
+		CODE_PROBE(true, "Database context invalidate cache for tenant range");
 		resolvedKeys = resolvedKeys.withPrefix(tenantPrefix.get(), arena);
 	}
 
@@ -3105,6 +3112,7 @@ Future<KeyRangeLocationInfo> getKeyLocation(Reference<TransactionState> trState,
                                             F StorageServerInterface::*member,
                                             Reverse isBackward,
                                             UseTenant useTenant) {
+	CODE_PROBE(!useTenant, "Get key location ignoring tenant");
 	return getKeyLocation(trState->cx,
 	                      useTenant ? trState->getTenantInfo() : TenantInfo(),
 	                      key,
@@ -3262,6 +3270,7 @@ Future<std::vector<KeyRangeLocationInfo>> getKeyRangeLocations(Reference<Transac
                                                                Reverse reverse,
                                                                F StorageServerInterface::*member,
                                                                UseTenant useTenant) {
+	CODE_PROBE(!useTenant, "Get key range locations ignoring tenant");
 	return getKeyRangeLocations(trState->cx,
 	                            useTenant ? trState->getTenantInfo(AllowInvalidTenantID::True) : TenantInfo(),
 	                            keys,
@@ -3291,6 +3300,8 @@ ACTOR Future<std::vector<std::pair<KeyRange, UID>>> getBlobGranuleLocations_inte
 	state Span span("NAPI:getBlobGranuleLocations"_loc, spanContext);
 	if (debugID.present())
 		g_traceBatch.addEvent("TransactionDebug", debugID.get().first(), "NativeAPI.getBlobGranuleLocations.Before");
+
+	CODE_PROBE(tenant.hasTenant(), "NativeAPI getBlobGranuleLocations has tenant");
 
 	loop {
 		++cx->transactionBlobGranuleLocationRequests;
@@ -3460,6 +3471,7 @@ ACTOR Future<int64_t> lookupTenantImpl(DatabaseContext* cx, TenantName tenant) {
 			}
 		} catch (Error& e) {
 			if (e.code() == error_code_commit_proxy_memory_limit_exceeded) {
+				CODE_PROBE(true, "Lookup tenant memory limit exceeded");
 				TraceEvent(SevWarnAlways, "CommitProxyOverloadedForTenant").suppressFor(5);
 				// Eats commit_proxy_memory_limit_exceeded error from commit proxies
 				cx->updateBackoff(e);
@@ -3509,20 +3521,26 @@ TenantInfo TransactionState::getTenantInfo(AllowInvalidTenantID allowInvalidTena
 	Optional<Reference<Tenant>> const& t = tenant();
 
 	if (options.rawAccess) {
+		CODE_PROBE(true, "Get tenant info raw access transaction");
 		return TenantInfo();
 	} else if (!cx->internal && cx->clientInfo->get().clusterType == ClusterType::METACLUSTER_MANAGEMENT) {
+		CODE_PROBE(true, "Get tenant info invalid management cluster access", probe::decoration::rare);
 		throw management_cluster_invalid_access();
 	} else if (!cx->internal && cx->clientInfo->get().tenantMode == TenantMode::REQUIRED && !t.present()) {
+		CODE_PROBE(true, "Get tenant info tenant name required", probe::decoration::rare);
 		throw tenant_name_required();
 	} else if (!t.present()) {
+		CODE_PROBE(true, "Get tenant info without tenant");
 		return TenantInfo();
 	} else if (cx->clientInfo->get().tenantMode == TenantMode::DISABLED && t.present()) {
 		// If we are running provisional proxies, we allow a tenant request to go through since we don't know the tenant
 		// mode. Such a transaction would not be allowed to commit without enabling provisional commits because either
 		// the commit proxies will be provisional or the read version will be too old.
 		if (!cx->clientInfo->get().grvProxies.empty() && !cx->clientInfo->get().grvProxies[0].provisional) {
+			CODE_PROBE(true, "Get tenant info use tenant in disabled tenant mode", probe::decoration::rare);
 			throw tenants_disabled();
 		} else {
+			CODE_PROBE(true, "Get tenant info provisional proxies");
 			ASSERT(!useProvisionalProxies);
 		}
 	}
@@ -3559,7 +3577,7 @@ bool TransactionState::hasTenant(ResolveDefaultTenant resolveDefaultTenant) {
 
 ACTOR Future<Void> startTransaction(Reference<TransactionState> trState) {
 	wait(success(trState->readVersionFuture));
-	if (trState->tenant().present()) {
+	if (trState->hasTenant()) {
 		wait(trState->tenant().get()->ready());
 	}
 
@@ -3571,7 +3589,7 @@ Future<Void> TransactionState::startTransaction(uint32_t readVersionFlags) {
 		if (!readVersionFuture.isValid()) {
 			readVersionFuture = getReadVersion(readVersionFlags);
 		}
-		if (readVersionFuture.isReady() && (!tenant().present() || tenant().get()->ready().isReady())) {
+		if (readVersionFuture.isReady() && (!hasTenant() || tenant().get()->ready().isReady())) {
 			startFuture = Void();
 		} else {
 			startFuture = ::startTransaction(Reference<TransactionState>::addRef(this));
@@ -3591,8 +3609,10 @@ ACTOR Future<Optional<Value>> getValue(Reference<TransactionState> trState,
                                        TransactionRecordLogInfo recordLogInfo) {
 	wait(trState->startTransaction());
 
+	CODE_PROBE(trState->hasTenant(), "NativeAPI getValue has tenant");
+
 	state Span span("NAPI:getValue"_loc, trState->spanContext);
-	if (useTenant && trState->tenant().present()) {
+	if (useTenant && trState->hasTenant()) {
 		span.addAttribute("tenant"_sr,
 		                  trState->tenant().get()->name.castTo<TenantNameRef>().orDefault("<unspecified>"_sr));
 	}
@@ -3725,7 +3745,10 @@ ACTOR Future<Optional<Value>> getValue(Reference<TransactionState> trState,
 }
 
 ACTOR Future<Key> getKey(Reference<TransactionState> trState, KeySelector k, UseTenant useTenant = UseTenant::True) {
+	CODE_PROBE(!useTenant, "Get key ignoring tenant");
 	wait(trState->startTransaction());
+
+	CODE_PROBE(trState->hasTenant(), "NativeAPI getKey has tenant");
 
 	state Optional<UID> getKeyID;
 	state Optional<ReadOptions> readOptions = trState->readOptions;
@@ -3905,6 +3928,8 @@ ACTOR Future<Version> watchValue(Database cx, Reference<const WatchParameters> p
 	state Version ver = parameters->version;
 	cx->validateVersion(parameters->version);
 	ASSERT(parameters->version != latestVersion);
+
+	CODE_PROBE(parameters->tenant.hasTenant(), "NativeAPI watchValue has tenant");
 
 	loop {
 		state KeyRangeLocationInfo locationInfo = wait(getKeyLocation(cx,
@@ -4233,7 +4258,10 @@ Future<RangeResultFamily> getExactRange(Reference<TransactionState> trState,
 	// TODO - ljoswiak parent or link?
 	state Span span("NAPI:getExactRange"_loc, trState->spanContext);
 
-	if (useTenant && trState->tenant().present()) {
+	CODE_PROBE(trState->hasTenant() && useTenant, "NativeAPI getExactRange has tenant");
+	CODE_PROBE(!useTenant, "NativeAPI getExactRange ignoring tenant");
+
+	if (useTenant && trState->hasTenant()) {
 		span.addAttribute("tenant"_sr,
 		                  trState->tenant().get()->name.castTo<TenantNameRef>().orDefault("<unspecified>"_sr));
 	}
@@ -4433,6 +4461,9 @@ Future<RangeResultFamily> getRangeFallback(Reference<TransactionState> trState,
                                            GetRangeLimits limits,
                                            Reverse reverse,
                                            UseTenant useTenant) {
+	CODE_PROBE(trState->hasTenant() && useTenant, "NativeAPI getRangeFallback has tenant");
+	CODE_PROBE(!useTenant, "NativeAPI getRangeFallback ignoring tenant");
+
 	Future<Key> fb = resolveKey(trState, begin, useTenant);
 	state Future<Key> fe = resolveKey(trState, end, useTenant);
 
@@ -4580,7 +4611,11 @@ Future<RangeResultFamily> getRange(Reference<TransactionState> trState,
 	state RangeResultFamily output;
 	state Span span("NAPI:getRange"_loc, trState->spanContext);
 	state Optional<UID> getRangeID = Optional<UID>();
-	if (useTenant && trState->tenant().present()) {
+
+	CODE_PROBE(trState->hasTenant() && useTenant, "NativeAPI getExactRange has tenant");
+	CODE_PROBE(!useTenant, "Get range ignoring tenant");
+
+	if (useTenant && trState->hasTenant()) {
 		span.addAttribute("tenant"_sr,
 		                  trState->tenant().get()->name.castTo<TenantNameRef>().orDefault("<unspecified>"_sr));
 	}
@@ -5337,6 +5372,8 @@ ACTOR Future<Void> getRangeStream(Reference<TransactionState> trState,
 	state Span span("NAPI:getRangeStream"_loc, trState->spanContext);
 
 	wait(trState->startTransaction());
+
+	CODE_PROBE(trState->hasTenant(), "NativeAPI getRangeStream has tenant");
 	trState->cx->validateVersion(trState->readVersion());
 
 	Future<Key> fb = resolveKey(trState, begin, UseTenant::True);
@@ -5682,6 +5719,7 @@ ACTOR Future<Standalone<VectorRef<const char*>>> getAddressesForKeyActor(Referen
 
 	state Key resolvedKey = key;
 	if (trState->hasTenant()) {
+		CODE_PROBE(true, "NativeAPI getAddressesForKey has tenant");
 		resolvedKey = key.withPrefix(trState->tenant().get()->prefix());
 	}
 
@@ -6505,7 +6543,10 @@ void applyTenantPrefix(CommitTransactionRequest& req, Key tenantPrefix) {
 				uint8_t* key = mutateString(param1);
 				int* offset = reinterpret_cast<int*>(&key[param1.size() - 4]);
 				*offset += tenantPrefix.size();
+				CODE_PROBE(true, "Set versionstamped key in tenant");
 			}
+		} else {
+			CODE_PROBE(true, "Set metadata version key in tenant");
 		}
 		updatedMutations.push_back(req.arena, MutationRef(MutationRef::Type(m.type), param1, param2));
 	}
@@ -6543,6 +6584,8 @@ ACTOR static Future<Void> tryCommit(Reference<TransactionState> trState, CommitT
 	if (debugID.present()) {
 		TraceEvent(interval.begin()).detail("Parent", debugID.get());
 	}
+
+	CODE_PROBE(trState->hasTenant(), "NativeAPI commit has tenant");
 
 	// If the read version hasn't already been fetched, then we had no reads and don't need (expensive) full causal
 	// consistency.
@@ -7800,6 +7843,8 @@ ACTOR Future<StorageMetrics> getStorageMetricsLargeKeyRange(Database cx,
 	}
 	state TenantInfo tenantInfo =
 	    wait(trState.present() ? populateAndGetTenant(trState.get(), keys.begin) : TenantInfo());
+
+	CODE_PROBE(tenantInfo.hasTenant(), "NativeAPI doGetStorageMetricsLargeKeyRange has tenant");
 	state Version version = trState.present() ? trState.get()->readVersion() : latestVersion;
 	std::vector<KeyRangeLocationInfo> locations = wait(getKeyRangeLocations(cx,
 	                                                                        tenantInfo,
@@ -7835,6 +7880,7 @@ ACTOR Future<Void> trackBoundedStorageMetrics(TenantInfo tenantInfo,
                                               StorageMetrics x,
                                               StorageMetrics halfError,
                                               PromiseStream<StorageMetrics> deltaStream) {
+
 	try {
 		loop {
 			WaitMetricsRequest req(tenantInfo, version, keys, x - halfError, x + halfError);
@@ -8007,6 +8053,8 @@ ACTOR Future<std::pair<Optional<StorageMetrics>, int>> waitStorageMetrics(
 		}
 		state TenantInfo tenantInfo =
 		    wait(trState.present() ? populateAndGetTenant(trState.get(), keys.begin) : TenantInfo());
+
+		CODE_PROBE(tenantInfo.hasTenant(), "NativeAPI waitStorageMetrics has tenant", probe::decoration::rare);
 		state Version version = trState.present() ? trState.get()->readVersion() : latestVersion;
 		state std::vector<KeyRangeLocationInfo> locations =
 		    wait(getKeyRangeLocations(cx,
@@ -8127,6 +8175,7 @@ ACTOR Future<Standalone<VectorRef<KeyRef>>> getRangeSplitPoints(Reference<Transa
 	state Span span("NAPI:GetRangeSplitPoints"_loc, trState->spanContext);
 
 	if (trState->hasTenant()) {
+		CODE_PROBE(trState->hasTenant(), "NativeAPI getRangeSplitPoints has tenant");
 		wait(trState->startTransaction());
 	}
 
@@ -8502,6 +8551,8 @@ ACTOR Future<Standalone<VectorRef<BlobGranuleSummaryRef>>> summarizeBlobGranules
                                                                                       KeyRange range,
                                                                                       Optional<Version> summaryVersion,
                                                                                       int rangeLimit) {
+	CODE_PROBE(self->trState->hasTenant(), "NativeAPI summarizeBlobGranules has tenant");
+
 	state Version readVersionOut;
 	Standalone<VectorRef<BlobGranuleChunkRef>> chunks =
 	    wait(readBlobGranulesActor(self, range, 0, summaryVersion, &readVersionOut, rangeLimit, true));
@@ -8609,6 +8660,7 @@ ACTOR Future<Version> verifyBlobRangeActor(Reference<DatabaseContext> cx,
 	}
 
 	if (tenant.present()) {
+		CODE_PROBE(true, "NativeAPI verifyBlobRange has tenant");
 		wait(tenant.get()->ready());
 	}
 
@@ -8679,6 +8731,7 @@ ACTOR Future<bool> flushBlobRangeActor(Reference<DatabaseContext> cx,
                                        Optional<Version> version,
                                        Optional<Reference<Tenant>> tenant) {
 	if (tenant.present()) {
+		CODE_PROBE(true, "NativeAPI flushBlobRange has tenant");
 		wait(tenant.get()->ready());
 		range = range.withPrefix(tenant.get()->prefix());
 	}
@@ -10980,6 +11033,7 @@ ACTOR Future<Key> purgeBlobGranulesActor(Reference<DatabaseContext> db,
 	}
 
 	if (tenant.present()) {
+		CODE_PROBE(true, "NativeAPI purgeBlobGranules has tenant");
 		wait(tenant.get()->ready());
 		purgeRange = purgeRange.withPrefix(tenant.get()->prefix());
 	}
@@ -11149,6 +11203,9 @@ ACTOR Future<bool> blobbifyRangeActor(Reference<DatabaseContext> cx,
 	if (BG_REQUEST_DEBUG) {
 		fmt::print("BlobbifyRange [{0} - {1}) ({2})\n", range.begin.printable(), range.end.printable(), doWait);
 	}
+
+	CODE_PROBE(tenant.present(), "NativeAPI blobbifyRange has tenant");
+
 	state bool result = wait(setBlobRangeActor(cx, range, true, tenant));
 	if (!doWait || !result) {
 		return result;
@@ -11192,6 +11249,7 @@ ACTOR Future<Standalone<VectorRef<KeyRangeRef>>> listBlobbifiedRangesActor(Refer
 	state Standalone<VectorRef<KeyRangeRef>> blobRanges;
 
 	if (tenant.present()) {
+		CODE_PROBE(true, "NativeAPI listBlobbifiedRanges has tenant");
 		wait(tenant.get()->ready());
 		tenantPrefix = tenant.get()->prefix();
 		range = range.withPrefix(tenantPrefix);

--- a/fdbclient/Tenant.cpp
+++ b/fdbclient/Tenant.cpp
@@ -48,6 +48,7 @@ int64_t prefixToId(KeyRef prefix, EnforceValidTenantId enforceValidTenantId) {
 	if (enforceValidTenantId) {
 		ASSERT(id >= 0);
 	} else if (id < 0) {
+		CODE_PROBE(true, "Attempt to convert invalid tenant prefix");
 		return TenantInfo::INVALID_TENANT;
 	}
 	return id;
@@ -151,8 +152,10 @@ bool TenantMapEntry::matchesConfiguration(TenantMapEntry const& other) const {
 
 void TenantMapEntry::configure(Standalone<StringRef> parameter, Optional<Value> value) {
 	if (parameter == "tenant_group"_sr) {
+		CODE_PROBE(true, "Configure tenant's group");
 		tenantGroup = value;
 	} else {
+		CODE_PROBE(true, "Invalid tenant configuration parameter");
 		TraceEvent(SevWarnAlways, "UnknownTenantConfigurationParameter").detail("Parameter", parameter);
 		throw invalid_tenant_configuration();
 	}

--- a/fdbclient/TenantManagement.actor.cpp
+++ b/fdbclient/TenantManagement.actor.cpp
@@ -83,6 +83,7 @@ int64_t computeNextTenantId(int64_t baseId, int64_t delta) {
 		TraceEvent(g_network->isSimulated() ? SevWarnAlways : SevError, "NoMoreTenantIds")
 		    .detail("LastTenantId", baseId)
 		    .detail("TenantIdPrefix", getTenantIdPrefix(baseId));
+		CODE_PROBE(true, "Tenant IDs exhausted");
 		throw cluster_no_capacity();
 	}
 

--- a/fdbclient/include/fdbclient/DatabaseContext.h
+++ b/fdbclient/include/fdbclient/DatabaseContext.h
@@ -720,7 +720,12 @@ public:
 	                            Version readVersion,
 	                            VersionVector& latestCommitVersion);
 
-	TenantMode getTenantMode() const { return clientInfo->get().tenantMode; }
+	TenantMode getTenantMode() const {
+		CODE_PROBE(clientInfo->get().grvProxies.empty() || clientInfo->get().grvProxies[0].provisional,
+		           "Accessing tenant mode in provisional ClientDBInfo",
+		           probe::decoration::rare);
+		return clientInfo->get().tenantMode;
+	}
 
 	// used in template functions to create a transaction
 	using TransactionT = ReadYourWritesTransaction;

--- a/fdbclient/include/fdbclient/GenericManagementAPI.actor.h
+++ b/fdbclient/include/fdbclient/GenericManagementAPI.actor.h
@@ -499,6 +499,7 @@ Future<ConfigurationResult> changeConfig(Reference<DB> db, std::map<std::string,
 						Optional<MetaclusterRegistrationEntry> metaclusterRegistration =
 						    wait(metacluster::metadata::metaclusterRegistration().get(tr));
 						if (metaclusterRegistration.present()) {
+							CODE_PROBE(true, "Attempt to change tenant mode in a metacluster", probe::decoration::rare);
 							return ConfigurationResult::DATABASE_IS_REGISTERED;
 						}
 					}

--- a/fdbclient/include/fdbclient/KeyBackedTypes.actor.h
+++ b/fdbclient/include/fdbclient/KeyBackedTypes.actor.h
@@ -213,7 +213,7 @@ public:
 	void update(Transaction tr, AddConflictRange conflict = AddConflictRange::False) {
 		std::array<uint8_t, 14> value;
 		value.fill(0);
-		tr->atomicOp(key, StringRef(value.begin(), value.size()), MutationRef::SetVersionstampedValue);
+		tr->atomicOp(key, StringRef(value.data(), value.size()), MutationRef::SetVersionstampedValue);
 		if (conflict) {
 			tr->addReadConflictRange(singleKeyRange(key));
 		}

--- a/fdbclient/include/fdbclient/MetaclusterRegistration.h
+++ b/fdbclient/include/fdbclient/MetaclusterRegistration.h
@@ -148,6 +148,7 @@ struct MetaclusterRegistrationEntryImpl {
 		serializer(ar, clusterType, metaclusterName, name, metaclusterId, id, version);
 		if constexpr (Ar::isDeserializing && Versioned) {
 			if (version < MetaclusterVersion::MIN_SUPPORTED || version > MetaclusterVersion::MAX_SUPPORTED) {
+				CODE_PROBE(true, "Load unsupported metacluster registration");
 				throw unsupported_metacluster_version();
 			}
 		}

--- a/fdbclient/include/fdbclient/SpecialKeySpace.actor.h
+++ b/fdbclient/include/fdbclient/SpecialKeySpace.actor.h
@@ -303,7 +303,10 @@ public:
 	Future<RangeResult> getRange(ReadYourWritesTransaction* ryw,
 	                             KeyRangeRef kr,
 	                             GetRangeLimits limitsHint) const override;
-	bool supportsTenants() const override { return true; };
+	bool supportsTenants() const override { 
+		CODE_PROBE(true, "Accessing conflicting keys in tenant");
+		return true; 
+	};
 };
 
 class ReadConflictRangeImpl : public SpecialKeyRangeReadImpl {
@@ -312,7 +315,10 @@ public:
 	Future<RangeResult> getRange(ReadYourWritesTransaction* ryw,
 	                             KeyRangeRef kr,
 	                             GetRangeLimits limitsHint) const override;
-	bool supportsTenants() const override { return true; };
+	bool supportsTenants() const override { 
+		CODE_PROBE(true, "Accessing read conflict ranges in tenant");
+		return true; 
+	};
 };
 
 class WriteConflictRangeImpl : public SpecialKeyRangeReadImpl {
@@ -321,7 +327,10 @@ public:
 	Future<RangeResult> getRange(ReadYourWritesTransaction* ryw,
 	                             KeyRangeRef kr,
 	                             GetRangeLimits limitsHint) const override;
-	bool supportsTenants() const override { return true; };
+	bool supportsTenants() const override { 
+		CODE_PROBE(true, "Accessing write conflict ranges in tenant");
+		return true; 
+	};
 };
 
 class DDStatsRangeImpl : public SpecialKeyRangeAsyncImpl {

--- a/fdbclient/include/fdbclient/SpecialKeySpace.actor.h
+++ b/fdbclient/include/fdbclient/SpecialKeySpace.actor.h
@@ -303,9 +303,9 @@ public:
 	Future<RangeResult> getRange(ReadYourWritesTransaction* ryw,
 	                             KeyRangeRef kr,
 	                             GetRangeLimits limitsHint) const override;
-	bool supportsTenants() const override { 
+	bool supportsTenants() const override {
 		CODE_PROBE(true, "Accessing conflicting keys in tenant");
-		return true; 
+		return true;
 	};
 };
 
@@ -315,9 +315,9 @@ public:
 	Future<RangeResult> getRange(ReadYourWritesTransaction* ryw,
 	                             KeyRangeRef kr,
 	                             GetRangeLimits limitsHint) const override;
-	bool supportsTenants() const override { 
+	bool supportsTenants() const override {
 		CODE_PROBE(true, "Accessing read conflict ranges in tenant");
-		return true; 
+		return true;
 	};
 };
 
@@ -327,9 +327,9 @@ public:
 	Future<RangeResult> getRange(ReadYourWritesTransaction* ryw,
 	                             KeyRangeRef kr,
 	                             GetRangeLimits limitsHint) const override;
-	bool supportsTenants() const override { 
+	bool supportsTenants() const override {
 		CODE_PROBE(true, "Accessing write conflict ranges in tenant");
-		return true; 
+		return true;
 	};
 };
 

--- a/fdbclient/include/fdbclient/TenantManagement.actor.h
+++ b/fdbclient/include/fdbclient/TenantManagement.actor.h
@@ -115,8 +115,10 @@ Future<Void> checkTenantMode(Transaction tr, ClusterType expectedClusterType) {
 
 	TenantMode tenantMode = TenantMode::fromValue(tenantModeValue.castTo<ValueRef>());
 	if (actualClusterType != expectedClusterType) {
+		CODE_PROBE(true, "Attempting tenant operation on wrong cluster type");
 		throw invalid_metacluster_operation();
 	} else if (actualClusterType == ClusterType::STANDALONE && tenantMode == TenantMode::DISABLED) {
+		CODE_PROBE(true, "Attempting tenant operation on cluster with tenants disabled", probe::decoration::rare);
 		throw tenants_disabled();
 	}
 
@@ -141,10 +143,12 @@ Future<bool> checkTombstone(Transaction tr, int64_t id) {
 	// with an error.
 	Optional<TenantTombstoneCleanupData> tombstoneCleanupData = wait(TenantMetadata::tombstoneCleanupData().get(tr));
 	if (tombstoneCleanupData.present() && tombstoneCleanupData.get().tombstonesErasedThrough >= id) {
+		CODE_PROBE(true, "Tenant creation permanently failed");
 		throw tenant_creation_permanently_failed();
 	}
 
 	state bool hasTombstone = wait(tombstoneFuture);
+
 	return hasTombstone;
 }
 
@@ -157,9 +161,11 @@ createTenantTransaction(Transaction tr, TenantMapEntry tenantEntry, ClusterType 
 	ASSERT(tenantEntry.id >= 0);
 
 	if (tenantEntry.tenantName.startsWith("\xff"_sr)) {
+		CODE_PROBE(true, "Invalid tenant name");
 		throw invalid_tenant_name();
 	}
 	if (tenantEntry.tenantGroup.present() && tenantEntry.tenantGroup.get().startsWith("\xff"_sr)) {
+		CODE_PROBE(true, "Invalid tenant group name");
 		throw invalid_tenant_group_name();
 	}
 
@@ -177,11 +183,13 @@ createTenantTransaction(Transaction tr, TenantMapEntry tenantEntry, ClusterType 
 	wait(tenantModeCheck);
 	Optional<TenantMapEntry> existingEntry = wait(existingEntryFuture);
 	if (existingEntry.present()) {
+		CODE_PROBE(true, "Create tenant already exists");
 		return std::make_pair(existingEntry.get(), false);
 	}
 
 	state bool hasTombstone = wait(tombstoneFuture);
 	if (hasTombstone) {
+		CODE_PROBE(hasTombstone, "Tenant creation blocked by tombstone");
 		return std::make_pair(Optional<TenantMapEntry>(), false);
 	}
 
@@ -190,6 +198,7 @@ createTenantTransaction(Transaction tr, TenantMapEntry tenantEntry, ClusterType 
 
 	RangeResult contents = wait(safeThreadFutureToFuture(prefixRangeFuture));
 	if (!contents.empty()) {
+		CODE_PROBE(hasTombstone, "Tenant creation conflict with existing data", probe::decoration::rare);
 		throw tenant_prefix_allocator_conflict();
 	}
 
@@ -215,6 +224,7 @@ createTenantTransaction(Transaction tr, TenantMapEntry tenantEntry, ClusterType 
 	// tenants in the same transaction are properly reflected.
 	int64_t tenantCount = wait(TenantMetadata::tenantCount().getD(tr, Snapshot::False, 0));
 	if (tenantCount > CLIENT_KNOBS->MAX_TENANTS_PER_CLUSTER) {
+		CODE_PROBE(true, "Tenant creation would exceed cluster capacity");
 		throw cluster_no_capacity();
 	}
 
@@ -248,6 +258,8 @@ Future<Optional<TenantMapEntry>> createTenant(Reference<DB> db,
 
 	state bool checkExistence = clusterType != ClusterType::METACLUSTER_DATA;
 	state bool generateTenantId = tenantEntry.id < 0;
+
+	CODE_PROBE(generateTenantId, "Create tenant with generated ID");
 
 	ASSERT(clusterType == ClusterType::STANDALONE || !generateTenantId);
 
@@ -295,6 +307,7 @@ Future<Optional<TenantMapEntry>> createTenant(Reference<DB> db,
 
 			return newTenant.first;
 		} catch (Error& e) {
+			CODE_PROBE(e.code() == error_code_commit_unknown_result, "Create tenant maybe committed");
 			wait(safeThreadFutureToFuture(tr->onError(e)));
 		}
 	}
@@ -313,6 +326,7 @@ Future<Void> markTenantTombstones(Transaction tr, int64_t tenantId) {
 		state int64_t deleteThroughId = cleanupData.present() ? cleanupData.get().nextTombstoneEraseId : -1;
 		// Delete all tombstones up through the one currently marked in the cleanup data
 		if (deleteThroughId >= 0) {
+			CODE_PROBE(true, "Deleting tenant tombstones");
 			TenantMetadata::tenantTombstones().erase(tr, 0, deleteThroughId + 1);
 		}
 
@@ -366,6 +380,7 @@ Future<Void> deleteTenantTransaction(Transaction tr,
 
 		RangeResult contents = wait(safeThreadFutureToFuture(prefixRangeFuture));
 		if (!contents.empty()) {
+			CODE_PROBE(true, "Attempt deletion of non-empty tenant");
 			throw tenant_not_empty();
 		}
 
@@ -386,9 +401,12 @@ Future<Void> deleteTenantTransaction(Transaction tr,
 			        2));
 			if (tenantsInGroup.results.empty() ||
 			    (tenantsInGroup.results.size() == 1 && tenantsInGroup.results[0].getInt(2) == tenantId)) {
+				CODE_PROBE(true, "Deleting tenant results in empty group");
 				TenantMetadata::tenantGroupMap().erase(tr, tenantEntry.get().tenantGroup.get());
 			}
 		}
+	} else {
+		CODE_PROBE(true, "Delete non-existent tenant");
 	}
 
 	if (clusterType == ClusterType::METACLUSTER_DATA) {
@@ -416,6 +434,8 @@ Future<Void> deleteTenant(Reference<DB> db,
 			if (checkExistence) {
 				Optional<int64_t> actualId = wait(TenantMetadata::tenantNameIndex().get(tr, name));
 				if (!actualId.present() || (tenantId.present() && tenantId != actualId)) {
+					CODE_PROBE(!actualId.present(), "Delete non-existing tenant");
+					CODE_PROBE(actualId.present(), "Delete tenant with incorrect ID", probe::decoration::rare);
 					throw tenant_not_found();
 				}
 
@@ -432,6 +452,7 @@ Future<Void> deleteTenant(Reference<DB> db,
 			    .detail("Version", tr->getCommittedVersion());
 			return Void();
 		} catch (Error& e) {
+			CODE_PROBE(e.code() == error_code_commit_unknown_result, "Delete tenant maybe committed");
 			wait(safeThreadFutureToFuture(tr->onError(e)));
 		}
 	}
@@ -453,9 +474,11 @@ Future<Void> configureTenantTransaction(Transaction tr,
 	// If the tenant group was changed, we need to update the tenant group metadata structures
 	if (originalEntry.tenantGroup != updatedTenantEntry.tenantGroup) {
 		if (updatedTenantEntry.tenantGroup.present() && updatedTenantEntry.tenantGroup.get().startsWith("\xff"_sr)) {
+			CODE_PROBE(true, "Configure with invalid group name");
 			throw invalid_tenant_group_name();
 		}
 		if (originalEntry.tenantGroup.present()) {
+			CODE_PROBE(true, "Change tenant group of tenant already in group");
 			// Remove this tenant from the original tenant group index
 			TenantMetadata::tenantGroupTenantIndex().erase(
 			    tr, Tuple::makeTuple(originalEntry.tenantGroup.get(), originalEntry.tenantName, updatedTenantEntry.id));
@@ -469,6 +492,7 @@ Future<Void> configureTenantTransaction(Transaction tr,
 
 			if (tenants.results.empty() ||
 			    (tenants.results.size() == 1 && tenants.results[0].getInt(2) == updatedTenantEntry.id)) {
+				CODE_PROBE(true, "Changing tenant group results in empty group");
 				TenantMetadata::tenantGroupMap().erase(tr, originalEntry.tenantGroup.get());
 			}
 		}
@@ -477,7 +501,10 @@ Future<Void> configureTenantTransaction(Transaction tr,
 			Optional<TenantGroupEntry> entry =
 			    wait(TenantMetadata::tenantGroupMap().get(tr, updatedTenantEntry.tenantGroup.get()));
 			if (!entry.present()) {
+				CODE_PROBE(true, "Change tenant group to a new group");
 				TenantMetadata::tenantGroupMap().set(tr, updatedTenantEntry.tenantGroup.get(), TenantGroupEntry());
+			} else {
+				CODE_PROBE(true, "Change tenant group to an existing group");
 			}
 
 			// Insert this tenant in the tenant group index
@@ -497,10 +524,12 @@ Future<Void> configureTenantTransaction(Transaction tr,
 template <class TenantMapEntryT>
 bool checkLockState(TenantMapEntryT entry, TenantLockState desiredLockState, UID lockId) {
 	if (entry.tenantLockId == lockId && entry.tenantLockState == desiredLockState) {
+		CODE_PROBE(true, "Attempting lock change to same state");
 		return true;
 	}
 
 	if (entry.tenantLockId.present() && entry.tenantLockId.get() != lockId) {
+		CODE_PROBE(true, "Attempting invalid lock change");
 		throw tenant_locked();
 	}
 
@@ -634,6 +663,7 @@ Future<Void> renameTenantTransaction(Transaction tr,
 	if (!tenantId.present()) {
 		wait(store(tenantId, oldNameIdFuture));
 		if (!tenantId.present()) {
+			CODE_PROBE(true, "Tenant rename transaction tenant not found");
 			throw tenant_not_found();
 		}
 	}
@@ -641,14 +671,17 @@ Future<Void> renameTenantTransaction(Transaction tr,
 	state TenantMapEntry entry = wait(getTenantTransaction(tr, tenantId.get()));
 	Optional<int64_t> newNameId = wait(newNameIdFuture);
 	if (entry.tenantName != oldName) {
+		CODE_PROBE(true, "Tenant rename transaction ID/name mismatch");
 		throw tenant_not_found();
 	}
 	if (newNameId.present()) {
+		CODE_PROBE(true, "Tenant rename transaction new name already exists");
 		throw tenant_already_exists();
 	}
 
 	if (configureSequenceNum.present()) {
 		if (entry.configurationSequenceNum > configureSequenceNum.get()) {
+			CODE_PROBE(true, "Tenant rename transaction already applied", probe::decoration::rare);
 			return Void();
 		}
 		entry.configurationSequenceNum = configureSequenceNum.get();
@@ -661,6 +694,7 @@ Future<Void> renameTenantTransaction(Transaction tr,
 	TenantMetadata::tenantNameIndex().erase(tr, oldName);
 
 	if (entry.tenantGroup.present()) {
+		CODE_PROBE(true, "Tenant rename transaction inside group");
 		TenantMetadata::tenantGroupTenantIndex().erase(
 		    tr, Tuple::makeTuple(entry.tenantGroup.get(), oldName, tenantId.get()));
 		TenantMetadata::tenantGroupTenantIndex().insert(
@@ -692,6 +726,7 @@ Future<Void> renameTenant(Reference<DB> db,
 			if (!tenantId.present()) {
 				wait(store(tenantId, TenantMetadata::tenantNameIndex().get(tr, oldName)));
 				if (!tenantId.present()) {
+					CODE_PROBE(true, "Tenant rename tenant not found");
 					throw tenant_not_found();
 				}
 			}
@@ -702,10 +737,13 @@ Future<Void> renameTenant(Reference<DB> db,
 
 			if (!firstTry && entry.tenantName == newName) {
 				// On a retry, the rename may have already occurred
+				CODE_PROBE(true, "Tenant rename retried and already succeeded");
 				return Void();
 			} else if (entry.tenantName != oldName) {
+				CODE_PROBE(true, "Tenant rename ID/name mismatch");
 				throw tenant_not_found();
 			} else if (newNameId.present() && newNameId.get() != tenantId.get()) {
+				CODE_PROBE(true, "Tenant rename new name already exists");
 				throw tenant_already_exists();
 			}
 

--- a/fdbclient/include/fdbclient/TenantSpecialKeys.actor.h
+++ b/fdbclient/include/fdbclient/TenantSpecialKeys.actor.h
@@ -44,6 +44,7 @@ private:
 		if (range.end.startsWith(prefix)) {
 			end = range.end.removePrefix(prefix);
 		} else {
+			CODE_PROBE(true, "Tenant special keys remove prefix clamped to end", probe::decoration::rare);
 			end = defaultEnd;
 		}
 
@@ -113,6 +114,7 @@ private:
 		state TenantMapEntry tenantEntry(tenantId, tenantName);
 
 		for (auto const& [name, value] : configMutations) {
+			CODE_PROBE(true, "Special keys create tenant with configuration parameters");
 			tenantEntry.configure(name, value);
 		}
 
@@ -155,9 +157,13 @@ private:
 			}
 		}
 
+		CODE_PROBE(numCreatedTenants > 1, "Special keys create multiple tenants simultaneously");
+		CODE_PROBE(numCreatedTenants < createFutures.size(), "Special keys some tenants not created");
+
 		// Check the tenant count here rather than rely on the createTenantTransaction check because we don't have RYW
 		int64_t tenantCount = wait(tenantCountFuture);
 		if (tenantCount + numCreatedTenants > CLIENT_KNOBS->MAX_TENANTS_PER_CLUSTER) {
+			CODE_PROBE(true, "Special keys create tenants no capacity");
 			throw cluster_no_capacity();
 		}
 
@@ -172,6 +178,7 @@ private:
 		TenantMapEntry originalEntry = wait(TenantAPI::getTenantTransaction(&ryw->getTransaction(), tenantName));
 		TenantMapEntry updatedEntry = originalEntry;
 		for (auto const& [name, value] : configEntries) {
+			CODE_PROBE(true, "Special keys change tenant config");
 			updatedEntry.configure(name, value);
 		}
 
@@ -191,6 +198,8 @@ private:
 	ACTOR static Future<Void> deleteSingleTenant(ReadYourWritesTransaction* ryw,
 	                                             TenantName tenantName,
 	                                             std::map<TenantGroupName, int>* tenantGroupNetTenantDelta) {
+		CODE_PROBE(true, "Special keys delete tenant");
+
 		state Optional<TenantMapEntry> tenantEntry =
 		    wait(TenantAPI::tryGetTenantTransaction(&ryw->getTransaction(), tenantName));
 		if (tenantEntry.present()) {
@@ -224,6 +233,8 @@ private:
 			deleteFutures.push_back(deleteSingleTenant(ryw, tenant.first, tenantGroupNetTenantDelta));
 		}
 
+		CODE_PROBE(deleteFutures.size() > 1, "Special keys delete multiple tenants simultaneously");
+
 		wait(waitForAll(deleteFutures));
 		return Void();
 	}
@@ -243,6 +254,7 @@ private:
 
 		ASSERT(tenantsInGroup.results.size() >= removedTenants);
 		if (tenantsInGroup.results.size() == removedTenants) {
+			CODE_PROBE(true, "Special keys tenant modifications removed tenant");
 			TenantMetadata::tenantGroupMap().erase(&ryw->getTransaction(), tenantGroup);
 		}
 
@@ -308,6 +320,7 @@ public:
 					configMutations[tuple.getString(0)].push_back(
 					    std::make_pair(tuple.getString(1), range.value().second));
 				} catch (Error& e) {
+					CODE_PROBE(true, "Special keys invalid tenant configuration key");
 					TraceEvent(SevWarn, "InvalidTenantConfigurationKey").error(e).detail("Key", adjustedRange.begin);
 					ryw->setSpecialKeySpaceErrorMsg(ManagementAPIError::toJsonString(
 					    false, "configure tenant", "invalid tenant configuration key"));
@@ -319,6 +332,7 @@ public:
 				// Do not allow overlapping renames in the same commit
 				// e.g. A->B + B->C, D->D
 				if (renameSet.count(oldName) || renameSet.count(newName) || oldName == newName) {
+					CODE_PROBE(true, "Special keys tenant rename conflict");
 					ryw->setSpecialKeySpaceErrorMsg(
 					    ManagementAPIError::toJsonString(false, "rename tenant", "tenant rename conflict"));
 					throw special_keys_api_failure();
@@ -334,6 +348,9 @@ public:
 			TenantNameRef tenantName = mapMutation.first.begin;
 			auto set_iter = renameSet.lower_bound(tenantName);
 			if (set_iter != renameSet.end() && mapMutation.first.contains(*set_iter)) {
+				CODE_PROBE(true,
+				           "Special keys tenant rename conflicts with tenant creation/deletion",
+				           probe::decoration::rare);
 				ryw->setSpecialKeySpaceErrorMsg(
 				    ManagementAPIError::toJsonString(false, "rename tenant", "tenant rename conflict"));
 				throw special_keys_api_failure();
@@ -349,6 +366,7 @@ public:
 			} else {
 				// For a single key clear, just issue the delete
 				if (mapMutation.first.singleKeyRange()) {
+					CODE_PROBE(true, "Special keys single key tenant deletion");
 					tenantManagementFutures.push_back(deleteSingleTenant(ryw, tenantName, &tenantGroupNetTenantDelta));
 
 					// Configuration changes made to a deleted tenant are discarded
@@ -364,11 +382,18 @@ public:
 			}
 		}
 
+		CODE_PROBE(!mapMutations.empty() && !configMutations.empty(),
+		           "Special keys simultaneous tenant create/delete and config changes",
+		           probe::decoration::rare);
+
 		if (!tenantsToCreate.empty()) {
 			tenantManagementFutures.push_back(createTenants(ryw, tenantsToCreate, &tenantGroupNetTenantDelta));
 		}
 		for (auto configMutation : configMutations) {
 			if (renameSet.count(configMutation.first)) {
+				CODE_PROBE(true,
+				           "Special keys tenant rename conflicts with tenant configuration change",
+				           probe::decoration::rare);
 				ryw->setSpecialKeySpaceErrorMsg(
 				    ManagementAPIError::toJsonString(false, "rename tenant", "tenant rename conflict"));
 				throw special_keys_api_failure();

--- a/fdbserver/ApplyMetadataMutation.cpp
+++ b/fdbserver/ApplyMetadataMutation.cpp
@@ -694,6 +694,7 @@ private:
 		if (m.param1.startsWith(prefix)) {
 			TenantMapEntry tenantEntry;
 			if (initialCommit) {
+				CODE_PROBE(true, "Recovering tenant from txn state store");
 				TenantMapEntryTxnStateStore txnStateStoreEntry = TenantMapEntryTxnStateStore::decode(m.param2);
 				tenantEntry.setId(txnStateStoreEntry.id);
 				tenantEntry.tenantName = txnStateStoreEntry.tenantName;
@@ -717,8 +718,10 @@ private:
 			}
 			if (lockedTenants) {
 				if (tenantEntry.tenantLockState == TenantAPI::TenantLockState::UNLOCKED) {
+					CODE_PROBE(true, "ApplyMetadataMutation unlock tenant");
 					lockedTenants->erase(tenantEntry.id);
 				} else {
+					CODE_PROBE(true, "ApplyMetadataMutation lock tenant");
 					lockedTenants->insert(tenantEntry.id);
 				}
 			}
@@ -1174,6 +1177,7 @@ private:
 					auto endItr = endId.present()
 					                  ? std::lower_bound(lockedTenants->begin(), lockedTenants->end(), endId.get())
 					                  : lockedTenants->end();
+					CODE_PROBE(startItr != endItr, "Deleting locked tenant");
 					lockedTenants->erase(startItr, endItr);
 				}
 			}

--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -269,6 +269,7 @@ bool checkTenantNoWait(ProxyCommitData* commitData, int64_t tenant, const char* 
 				    .detail("Tenant", tenant)
 				    .detail("Context", context);
 			}
+			CODE_PROBE(true, "Commit proxy tenant not found");
 			return false;
 		}
 
@@ -286,6 +287,7 @@ ACTOR Future<bool> checkTenant(ProxyCommitData* commitData, int64_t tenant, Vers
 		} else if (currentVersion >= minVersion) {
 			return false;
 		} else {
+			CODE_PROBE(true, "Commit proxy tenant not found waiting for min version");
 			wait(commitData->version.whenAtLeast(currentVersion + 1));
 		}
 	}
@@ -301,6 +303,7 @@ bool verifyTenantPrefix(ProxyCommitData* const commitData, const CommitTransacti
 					    .detail("Tenant", req.tenantInfo.tenantId)
 					    .detail("Prefix", tenantPrefix)
 					    .detail("Key", m.param1);
+					CODE_PROBE(true, "Committed mutation tenant prefix mismatch", probe::decoration::rare);
 					return false;
 				}
 
@@ -310,6 +313,7 @@ bool verifyTenantPrefix(ProxyCommitData* const commitData, const CommitTransacti
 					    .detail("Tenant", req.tenantInfo.tenantId)
 					    .detail("Prefix", tenantPrefix)
 					    .detail("Key", m.param2);
+					CODE_PROBE(true, "Committed mutation clear range prefix mismatch", probe::decoration::rare);
 					return false;
 				} else if (m.type == MutationRef::SetVersionstampedKey) {
 					ASSERT(m.param1.size() >= 4);
@@ -322,9 +326,14 @@ bool verifyTenantPrefix(ProxyCommitData* const commitData, const CommitTransacti
 						    .detail("Prefix", tenantPrefix)
 						    .detail("Key", m.param1)
 						    .detail("Offset", *offset);
+						CODE_PROBE(true,
+						           "Committed mutation versionstamp offset inside tenant prefix",
+						           probe::decoration::rare);
 						return false;
 					}
 				}
+			} else {
+				CODE_PROBE(true, "Modifying metadata version key in tenant");
 			}
 		}
 
@@ -337,6 +346,7 @@ bool verifyTenantPrefix(ProxyCommitData* const commitData, const CommitTransacti
 				    .detail("Prefix", tenantPrefix)
 				    .detail("BeginKey", rc.begin)
 				    .detail("EndKey", rc.end);
+				CODE_PROBE(true, "Committed mutation read conflict prefix mismatch", probe::decoration::rare);
 				return false;
 			}
 		}
@@ -350,6 +360,7 @@ bool verifyTenantPrefix(ProxyCommitData* const commitData, const CommitTransacti
 				    .detail("Prefix", tenantPrefix)
 				    .detail("BeginKey", wc.begin)
 				    .detail("EndKey", wc.end);
+				CODE_PROBE(true, "Committed mutation write conflict prefix mismatch", probe::decoration::rare);
 				return false;
 			}
 		}
@@ -1066,7 +1077,9 @@ void assertResolutionStateMutationsSizeConsistent(const std::vector<ResolveTrans
 bool validTenantAccess(MutationRef m, std::map<int64_t, TenantName> const& tenantMap, Optional<int64_t>& tenantId) {
 	if (isSingleKeyMutation((MutationRef::Type)m.type)) {
 		tenantId = TenantAPI::extractTenantIdFromMutation(m);
-		return tenantMap.count(tenantId.get()) > 0;
+		bool isLegalTenant = tenantMap.count(tenantId.get()) > 0;
+		CODE_PROBE(!isLegalTenant, "Commit proxy access invalid tenant");
+		return isLegalTenant;
 	}
 	return true;
 }
@@ -1420,6 +1433,7 @@ Error validateAndProcessTenantAccess(Arena& arena,
 			TraceEvent(SevWarn, "IllegalTenantAccess", pProxyCommitData->dbgid)
 			    .suppressFor(10.0)
 			    .detail("Reason", "Tenant change and normal key write in same transaction");
+			CODE_PROBE(true, "Writing normal keys while changing the tenant map");
 			return illegal_tenant_access();
 		}
 		if (tenantId.present()) {
@@ -1442,6 +1456,7 @@ Error validateAndProcessTenantAccess(CommitTransactionRequest& tr,
 		return tenant_not_found();
 	}
 	if (!tr.isLockAware() && pProxyCommitData->lockedTenants.count(tr.tenantInfo.tenantId) > 0) {
+		CODE_PROBE(true, "Attempt access to locked tenant without lock awareness");
 		return tenant_locked();
 	}
 
@@ -1605,6 +1620,7 @@ ACTOR Future<Void> applyMetadataToCommittedTransactions(CommitBatchContext* self
 		if (e.code() != error_code_success) {
 			trs[t].reply.sendError(e);
 			self->committed[t] = ConflictBatch::TransactionTenantFailure;
+			CODE_PROBE(true, "Commit proxy transaction tenant failure");
 		} else if (self->committed[t] == ConflictBatch::TransactionCommitted &&
 		           (!self->locked || trs[t].isLockAware())) {
 			self->commitCount++;
@@ -2586,6 +2602,10 @@ ACTOR static Future<Void> doTenantIdRequest(GetTenantIdRequest req, ProxyCommitD
 	wait(commitData->validState.getFuture());
 	wait(delay(0, TaskPriority::DefaultEndpoint));
 
+	CODE_PROBE(
+	    req.minTenantVersion != latestVersion, "Tenant ID request with specific version", probe::decoration::rare);
+	CODE_PROBE(req.minTenantVersion == latestVersion, "Tenant ID request at latest version");
+
 	state ErrorOr<int64_t> tenantId;
 	state Version minTenantVersion =
 	    req.minTenantVersion == latestVersion ? commitData->stats.lastCommitVersionAssigned + 1 : req.minTenantVersion;
@@ -2596,6 +2616,7 @@ ACTOR static Future<Void> doTenantIdRequest(GetTenantIdRequest req, ProxyCommitD
 	                                            : Never();
 
 	if (minTenantVersion > commitData->version.get()) {
+		CODE_PROBE(true, "Tenant ID request trigger commit");
 		commitData->triggerCommit.set(true);
 	}
 
@@ -2603,8 +2624,11 @@ ACTOR static Future<Void> doTenantIdRequest(GetTenantIdRequest req, ProxyCommitD
 		// Wait until we are sure that we've received metadata updates through minTenantVersion
 		// If latestVersion is specified, this will wait until we have definitely received
 		// updates through the version at the time we received the request
-		when(wait(commitData->version.whenAtLeast(minTenantVersion))) {}
+		when(wait(commitData->version.whenAtLeast(minTenantVersion))) {
+			CODE_PROBE(true, "Tenant ID request wait for min version");
+		}
 		when(wait(futureVersionDelay)) {
+			CODE_PROBE(true, "Tenant ID request future version", probe::decoration::rare);
 			req.reply.sendError(future_version());
 			++commitData->stats.tenantIdRequestOut;
 			++commitData->stats.tenantIdRequestErrors;
@@ -2649,6 +2673,9 @@ ACTOR static Future<Void> doKeyServerLocationRequest(GetKeyServerLocationsReques
 	getCurrentLineage()->modify(&TransactionLineage::operation) = TransactionLineage::Operation::GetKeyServersLocations;
 	getCurrentLineage()->modify(&TransactionLineage::txID) = req.spanContext.traceID;
 
+	CODE_PROBE(req.minTenantVersion != latestVersion, "Key server location request with specific version");
+	CODE_PROBE(req.minTenantVersion == latestVersion, "Key server location request at latest version");
+
 	wait(commitData->validState.getFuture());
 
 	state Version minVersion =
@@ -2659,6 +2686,7 @@ ACTOR static Future<Void> doKeyServerLocationRequest(GetKeyServerLocationsReques
 	bool validTenant = wait(checkTenant(commitData, req.tenant.tenantId, minVersion, "GetKeyServerLocation"));
 
 	if (!validTenant) {
+		CODE_PROBE(true, "Key server location request with invalid tenant");
 		++commitData->stats.keyServerLocationOut;
 		req.reply.sendError(tenant_not_found());
 		return Void();

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -1317,10 +1317,12 @@ ACTOR Future<Void> restartSimulatedSystem(std::vector<Future<Void>>* systemActor
 		auto tssModeStr = ini.GetValue("META", "tssMode");
 		auto tenantMode = ini.GetValue("META", "tenantMode");
 		if (tenantMode != nullptr) {
+			CODE_PROBE(true, "Restarting test with tenant mode set");
 			testConfig->tenantModes.push_back(tenantMode);
 		}
 		std::string defaultTenant = ini.GetValue("META", "defaultTenant", "");
 		if (!defaultTenant.empty()) {
+			CODE_PROBE(true, "Restarting test with default tenant set");
 			testConfig->defaultTenant = defaultTenant;
 		}
 		if (tssModeStr != nullptr) {

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -3395,6 +3395,7 @@ ACTOR Future<StatusReply> clusterGetStatus(
 					tenants["tenant_group_capacity"] = metaclusterMetrics.tenantGroupCapacity;
 					tenants["tenant_groups_allocated"] = metaclusterMetrics.tenantGroupsAllocated;
 				} else {
+					CODE_PROBE(true, "Failed to fetch metacluster metrics", probe::decoration::rare);
 					messages.push_back(JsonString::makeMessage(
 					    "metacluster_metrics_missing",
 					    fmt::format("Failed to fetch metacluster metrics: {}.", metaclusterMetrics.error.get())

--- a/fdbserver/include/fdbserver/ProxyCommitData.actor.h
+++ b/fdbserver/include/fdbserver/ProxyCommitData.actor.h
@@ -285,7 +285,11 @@ struct ProxyCommitData {
 		return false;
 	}
 
-	TenantMode getTenantMode() const { return db->get().client.tenantMode; }
+	TenantMode getTenantMode() const {
+		CODE_PROBE(db->get().client.grvProxies.empty() || db->get().client.grvProxies[0].provisional,
+		           "Accessing tenant mode in provisional ClientDBInfo");
+		return db->get().client.tenantMode;
+	}
 
 	void updateLatencyBandConfig(Optional<LatencyBandConfig> newLatencyBandConfig) {
 		if (newLatencyBandConfig.present() != latencyBandConfig.present() ||

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -2156,8 +2156,10 @@ void StorageServer::checkTenantEntry(Version version, TenantInfo tenantInfo, boo
 			TraceEvent(SevWarn, "StorageTenantNotFound", thisServerID)
 			    .detail("Tenant", tenantInfo.tenantId)
 			    .backtrace();
+			CODE_PROBE(true, "Storage server tenant not found");
 			throw tenant_not_found();
 		} else if (!lockAware && itr->lockState == TenantAPI::TenantLockState::LOCKED) {
+			CODE_PROBE(true, "Storage server access locked tenant without lock awareness");
 			throw tenant_locked();
 		}
 	}
@@ -2343,6 +2345,7 @@ ACTOR Future<Version> watchWaitForValueChange(StorageServer* data, SpanContext p
 			if (tenantId != TenantInfo::INVALID_TENANT) {
 				auto view = data->tenantMap.at(latestVersion);
 				if (view.find(tenantId) == view.end()) {
+					CODE_PROBE(true, "Watched tenant removed");
 					throw tenant_removed();
 				}
 			}

--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -918,6 +918,8 @@ ACTOR Future<Void> clearData(Database cx, Optional<TenantName> defaultTenant) {
 				}
 			}
 
+			CODE_PROBE(deleteFutures.size() > 0, "Clearing tenants after test");
+
 			wait(waitForAll(deleteFutures));
 			wait(tr.commit());
 

--- a/fdbserver/workloads/MetaclusterManagementConcurrencyWorkload.actor.cpp
+++ b/fdbserver/workloads/MetaclusterManagementConcurrencyWorkload.actor.cpp
@@ -105,6 +105,8 @@ struct MetaclusterManagementConcurrencyWorkload : TestWorkload {
 					    .detail("NumTenantGroups", entry.capacity.numTenantGroups);
 					break;
 				}
+
+				CODE_PROBE(true, "Register cluster timed out");
 			}
 		} catch (Error& e) {
 			TraceEvent(SevDebug, "MetaclusterManagementConcurrencyRegisterClusterError", debugId)
@@ -152,6 +154,8 @@ struct MetaclusterManagementConcurrencyWorkload : TestWorkload {
 					    .detail("ClusterName", clusterName);
 					break;
 				}
+
+				CODE_PROBE(true, "Remove cluster timed out");
 			}
 		} catch (Error& e) {
 			TraceEvent(SevDebug, "MetaclusterManagementConcurrencyRemoveClusterError", debugId)
@@ -302,9 +306,11 @@ struct MetaclusterManagementConcurrencyWorkload : TestWorkload {
 				    .detail("NewNumTenantGroups", newNumTenantGroups.orDefault(-1))
 				    .detail("NewConnectionString",
 				            connectionString.map(&ClusterConnectionString::toString).orDefault(""));
+
 				Optional<Optional<metacluster::DataClusterEntry>> result = wait(timeout(
 				    configureImpl(self, clusterName, newNumTenantGroups, connectionString, autoTenantAssignment),
 				    deterministicRandom()->randomInt(1, 30)));
+
 				if (result.present()) {
 					TraceEvent(SevDebug, "MetaclusterManagementConcurrencyConfiguredCluster", debugId)
 					    .detail("ClusterName", clusterName)
@@ -313,6 +319,8 @@ struct MetaclusterManagementConcurrencyWorkload : TestWorkload {
 					            connectionString.map(&ClusterConnectionString::toString).orDefault(""));
 					break;
 				}
+
+				CODE_PROBE(true, "Configure cluster timed out");
 			}
 		} catch (Error& e) {
 			TraceEvent(SevDebug, "MetaclusterManagementConcurrencyConfigureClusterError", debugId)
@@ -343,59 +351,68 @@ struct MetaclusterManagementConcurrencyWorkload : TestWorkload {
 		state UID debugId = deterministicRandom()->randomUniqueID();
 
 		try {
-			TraceEvent(SevDebug, "MetaclusterManagementConcurrencyRestore", debugId)
-			    .detail("ClusterName", clusterName)
-			    .detail("ApplyManagementClusterUpdates", applyManagementClusterUpdates);
-
-			if (removeFirst) {
-				TraceEvent(SevDebug, "MetaclusterManagementConcurrencyRestoreRemoveDataCluster", debugId)
+			loop {
+				TraceEvent(SevDebug, "MetaclusterManagementConcurrencyRestore", debugId)
 				    .detail("ClusterName", clusterName)
 				    .detail("ApplyManagementClusterUpdates", applyManagementClusterUpdates);
 
-				wait(success(metacluster::removeCluster(self->simMetacluster.managementDb,
-				                                        clusterName,
-				                                        ClusterType::METACLUSTER_MANAGEMENT,
-				                                        metacluster::ForceRemove::True)));
+				if (removeFirst) {
+					TraceEvent(SevDebug, "MetaclusterManagementConcurrencyRestoreRemoveDataCluster", debugId)
+					    .detail("ClusterName", clusterName)
+					    .detail("ApplyManagementClusterUpdates", applyManagementClusterUpdates);
 
-				TraceEvent(SevDebug, "MetaclusterManagementConcurrencyRestoreRemovedDataCluster", debugId)
-				    .detail("ClusterName", clusterName)
-				    .detail("ApplyManagementClusterUpdates", applyManagementClusterUpdates);
+					wait(success(errorOr(metacluster::removeCluster(self->simMetacluster.managementDb,
+					                                                clusterName,
+					                                                ClusterType::METACLUSTER_MANAGEMENT,
+					                                                metacluster::ForceRemove::True))));
+
+					TraceEvent(SevDebug, "MetaclusterManagementConcurrencyRestoreRemovedDataCluster", debugId)
+					    .detail("ClusterName", clusterName)
+					    .detail("ApplyManagementClusterUpdates", applyManagementClusterUpdates);
+				}
+
+				state std::vector<std::string> messages;
+				if (deterministicRandom()->coinflip()) {
+					TraceEvent(SevDebug, "MetaclusterManagementConcurrencyRestoreDryRun", debugId)
+					    .detail("ClusterName", clusterName)
+					    .detail("ApplyManagementClusterUpdates", applyManagementClusterUpdates);
+
+					wait(metacluster::restoreCluster(self->simMetacluster.managementDb,
+					                                 clusterName,
+					                                 db->getConnectionRecord()->getConnectionString(),
+					                                 applyManagementClusterUpdates,
+					                                 metacluster::RestoreDryRun::True,
+					                                 forceJoin,
+					                                 metacluster::ForceReuseTenantIdPrefix::True,
+					                                 &messages));
+
+					TraceEvent(SevDebug, "MetaclusterManagementConcurrencyRestoreDryRunDone", debugId)
+					    .detail("ClusterName", clusterName)
+					    .detail("ApplyManagementClusterUpdates", applyManagementClusterUpdates);
+
+					messages.clear();
+				}
+
+				Optional<Void> result =
+				    wait(timeout(metacluster::restoreCluster(self->simMetacluster.managementDb,
+				                                             clusterName,
+				                                             db->getConnectionRecord()->getConnectionString(),
+				                                             applyManagementClusterUpdates,
+				                                             metacluster::RestoreDryRun::False,
+				                                             forceJoin,
+				                                             metacluster::ForceReuseTenantIdPrefix::True,
+				                                             &messages),
+				                 30.0));
+
+				if (result.present()) {
+					TraceEvent(SevDebug, "MetaclusterManagementConcurrencyRestoreComplete", debugId)
+					    .detail("ClusterName", clusterName)
+					    .detail("ApplyManagementClusterUpdates", applyManagementClusterUpdates);
+					break;
+				}
+
+				CODE_PROBE(true, "Restore cluster timed out");
 			}
-
-			state std::vector<std::string> messages;
-			if (deterministicRandom()->coinflip()) {
-				TraceEvent(SevDebug, "MetaclusterManagementConcurrencyRestoreDryRun", debugId)
-				    .detail("ClusterName", clusterName)
-				    .detail("ApplyManagementClusterUpdates", applyManagementClusterUpdates);
-
-				wait(metacluster::restoreCluster(self->simMetacluster.managementDb,
-				                                 clusterName,
-				                                 db->getConnectionRecord()->getConnectionString(),
-				                                 applyManagementClusterUpdates,
-				                                 metacluster::RestoreDryRun::True,
-				                                 forceJoin,
-				                                 metacluster::ForceReuseTenantIdPrefix::True,
-				                                 &messages));
-
-				TraceEvent(SevDebug, "MetaclusterManagementConcurrencyRestoreDryRunDone", debugId)
-				    .detail("ClusterName", clusterName)
-				    .detail("ApplyManagementClusterUpdates", applyManagementClusterUpdates);
-
-				messages.clear();
-			}
-
-			wait(metacluster::restoreCluster(self->simMetacluster.managementDb,
-			                                 clusterName,
-			                                 db->getConnectionRecord()->getConnectionString(),
-			                                 applyManagementClusterUpdates,
-			                                 metacluster::RestoreDryRun::False,
-			                                 forceJoin,
-			                                 metacluster::ForceReuseTenantIdPrefix::True,
-			                                 &messages));
-
-			TraceEvent(SevDebug, "MetaclusterManagementConcurrencyRestoreComplete", debugId)
-			    .detail("ClusterName", clusterName)
-			    .detail("ApplyManagementClusterUpdates", applyManagementClusterUpdates);
 		} catch (Error& e) {
 			TraceEvent(SevDebug, "MetaclusterManagementConcurrencyRestoreError", debugId)
 			    .error(e)

--- a/fdbserver/workloads/MetaclusterManagementWorkload.actor.cpp
+++ b/fdbserver/workloads/MetaclusterManagementWorkload.actor.cpp
@@ -115,6 +115,7 @@ struct MetaclusterManagementWorkload : TestWorkload {
 			int64_t newPrefix = deterministicRandom()->randomInt(TenantAPI::TENANT_ID_PREFIX_MIN_VALUE,
 			                                                     TenantAPI::TENANT_ID_PREFIX_MAX_VALUE + 1);
 			if (allowTenantIdPrefixReuse || !usedPrefixes.count(newPrefix)) {
+				CODE_PROBE(usedPrefixes.count(newPrefix), "Reusing tenant ID prefix", probe::decoration::rare);
 				return newPrefix;
 			}
 		}
@@ -189,6 +190,8 @@ struct MetaclusterManagementWorkload : TestWorkload {
 		bool dataValid = !dataDb.present() || (dataDb.get()->version >= MetaclusterVersion::MIN_SUPPORTED &&
 		                                       dataDb.get()->version <= MetaclusterVersion::MAX_SUPPORTED);
 
+		CODE_PROBE(!managementValid, "Management cluster invalid version");
+		CODE_PROBE(!dataValid, "Data cluster invalid version");
 		return managementValid && dataValid;
 	}
 
@@ -573,6 +576,8 @@ struct MetaclusterManagementWorkload : TestWorkload {
 			}
 		}
 
+		CODE_PROBE(foundTenantCollision, "Resolved tenant collision for restore", probe::decoration::rare);
+		CODE_PROBE(foundGroupCollision, "Resolved group collision for restore");
 		return foundTenantCollision || foundGroupCollision;
 	}
 
@@ -643,7 +648,9 @@ struct MetaclusterManagementWorkload : TestWorkload {
 				if (error.code() == error_code_conflicting_restore ||
 				    error.code() == error_code_cluster_already_exists) {
 					ASSERT(retried);
-					CODE_PROBE(true, "MetaclusterManagementWorkload: timed out restore conflicts with retried restore");
+					CODE_PROBE(true,
+					           "MetaclusterManagementWorkload: timed out restore conflicts with retried restore",
+					           probe::decoration::rare);
 					continue;
 				} else if (error.code() == error_code_cluster_not_found) {
 					ASSERT(!dataDb->registered);
@@ -662,6 +669,7 @@ struct MetaclusterManagementWorkload : TestWorkload {
 						ASSERT(self->allowTenantIdPrefixReuse);
 						ASSERT(!messages.empty());
 						ASSERT(messages[0].find("has the same ID"));
+						CODE_PROBE(true, "Reused tenant ID", probe::decoration::rare);
 						return Void();
 					}
 				} else if (error.code() == error_code_invalid_metacluster_configuration) {

--- a/fdbserver/workloads/MetaclusterRestoreWorkload.actor.cpp
+++ b/fdbserver/workloads/MetaclusterRestoreWorkload.actor.cpp
@@ -279,6 +279,7 @@ struct MetaclusterRestoreWorkload : TestWorkload {
 
 				// A dry-run shouldn't change anything
 				if (simultaneousRestoreCount == 1) {
+					CODE_PROBE(true, "Checking data cluster dry-run with no simultaneous restores");
 					preDryRunMetaclusterData.assertEquals(postDryRunMetaclusterData);
 				} else {
 					preDryRunMetaclusterData.dataClusterMetadata[clusterName].assertEquals(
@@ -317,6 +318,7 @@ struct MetaclusterRestoreWorkload : TestWorkload {
 					}
 				}
 
+				CODE_PROBE(!successfulRestore, "Simultaneous restores all failed");
 				ASSERT(successfulRestore || restoreFutures.size() > 1);
 				numRestores = 1;
 			}
@@ -366,11 +368,13 @@ struct MetaclusterRestoreWorkload : TestWorkload {
 			// If the data cluster tenant is expected, then remove the management tenant
 			// Note that the management tenant may also have been expected
 			if (self->createdTenants.count(t.second.first)) {
+				CODE_PROBE(true, "Remove management tenant in restore collision");
 				removeTrackedTenant(t.second.second);
 				deleteFutures.push_back(metacluster::deleteTenant(self->managementDb, t.second.second));
 			}
 			// We don't expect the data cluster tenant, so delete it
 			else {
+				CODE_PROBE(true, "Remove data cluster tenant in restore collision");
 				removeTrackedTenant(t.second.first);
 				deleteFutures.push_back(TenantAPI::deleteTenant(dataDb.getReference(), t.first, t.second.first));
 			}
@@ -413,6 +417,7 @@ struct MetaclusterRestoreWorkload : TestWorkload {
 			// Note that the management tenant group may also have been expected
 			auto itr = self->tenantGroups.find(*collisionItr);
 			if (itr->second.cluster == clusterName) {
+				CODE_PROBE(true, "Remove management tenant group in restore collision");
 				TraceEvent(SevDebug, "MetaclusterRestoreWorkloadDeleteTenantGroupCollision")
 				    .detail("From", "ManagementCluster")
 				    .detail("TenantGroup", *collisionItr);
@@ -426,10 +431,10 @@ struct MetaclusterRestoreWorkload : TestWorkload {
 					self->removeTrackedTenant(t);
 					deleteFutures.push_back(metacluster::deleteTenant(self->managementDb, t));
 				}
-
 			}
 			// The tenant group from the management cluster is what we expect
 			else {
+				CODE_PROBE(true, "Remove data cluster tenant group in restore collision");
 				TraceEvent(SevDebug, "MetaclusterRestoreWorkloadDeleteTenantGroupCollision")
 				    .detail("From", "DataCluster")
 				    .detail("TenantGroup", *collisionItr);
@@ -636,9 +641,6 @@ struct MetaclusterRestoreWorkload : TestWorkload {
 						Optional<Error> nonConflictError;
 						for (int i = 0; i < restoreFutures.size(); ++i) {
 							ErrorOr<Void> result = restoreFutures[i].get();
-							fmt::print("Restore result for {}: {}\n",
-							           printable(clusterItr->first),
-							           result.isError() ? result.getError().what() : "success");
 							if (!result.isError()) {
 								ASSERT(!successfulRestore);
 								successfulRestore = true;
@@ -659,6 +661,9 @@ struct MetaclusterRestoreWorkload : TestWorkload {
 							break;
 						}
 
+						CODE_PROBE(true,
+						           "Management cluster restore conflict for all simultaneous attempts",
+						           probe::decoration::rare);
 						ASSERT_GT(restoreFutures.size(), 1);
 
 						numRestores = 1;
@@ -711,7 +716,6 @@ struct MetaclusterRestoreWorkload : TestWorkload {
 				    wait(getDataClusterTenants(clusterItr->second.db));
 
 				// Restoring a management cluster from data clusters should not change the data clusters at all
-				fmt::print("Checking data clusters: {}\n", completed);
 				ASSERT_EQ(dataTenantsBeforeRestore.size(), dataTenantsAfterRestore.size());
 				for (int i = 0; i < dataTenantsBeforeRestore.size(); ++i) {
 					ASSERT_EQ(dataTenantsBeforeRestore[i].first, dataTenantsAfterRestore[i].first);
@@ -1130,6 +1134,7 @@ struct MetaclusterRestoreWorkload : TestWorkload {
 				}
 			}
 
+			CODE_PROBE(unexpectedTenants > 0, "Deleted tenants reappeared during metacluster restore");
 			ASSERT_EQ(tenantMap.size() - unexpectedTenants, expectedTenantCount);
 		}
 
@@ -1176,6 +1181,7 @@ struct MetaclusterRestoreWorkload : TestWorkload {
 				// lost data in the process of recovering both the management and some data clusters
 				ASSERT_NE(tenantData.createTime, RestoreTenantData::AccessTime::BEFORE_BACKUP);
 				ASSERT(self->dataDbs[tenantData.cluster].restored && self->recoverManagementCluster);
+				CODE_PROBE(true, "Tenant lost when recovering management and data cluster");
 			} else {
 				if (tenantData.createTime != RestoreTenantData::AccessTime::BEFORE_BACKUP &&
 				    self->dataDbs[tenantData.cluster].restored) {
@@ -1184,6 +1190,7 @@ struct MetaclusterRestoreWorkload : TestWorkload {
 					        tenantData.createTime == RestoreTenantData::AccessTime::DURING_BACKUP));
 					if (tenantItr->second.tenantState == metacluster::TenantState::ERROR) {
 						ASSERT(self->dataDbs[tenantData.cluster].restoreHasMessages);
+						CODE_PROBE(true, "Tenant lost when recovering data cluster");
 					}
 				} else {
 					ASSERT_EQ(tenantItr->second.tenantState, metacluster::TenantState::READY);

--- a/fdbserver/workloads/TenantManagementWorkload.actor.cpp
+++ b/fdbserver/workloads/TenantManagementWorkload.actor.cpp
@@ -191,7 +191,7 @@ struct TenantManagementWorkload : TestWorkload {
 		});
 	}
 
-	// load test parameters from meta-cluster
+	// load test parameters from metacluster
 	ACTOR static Future<Void> loadTestParameters(Database cx, TenantManagementWorkload* self) {
 		state Transaction tr(cx);
 		// Read the parameters chosen and saved by client 0
@@ -1072,6 +1072,7 @@ struct TenantManagementWorkload : TestWorkload {
 				// A non-empty tenant should have our single key. The value of that key should be the name of the
 				// tenant.
 				else {
+					CODE_PROBE(true, "Check tenant contents with data");
 					ASSERT(result.size() == 1);
 					ASSERT(result[0].key == self->keyName);
 					ASSERT(result[0].value == tenantName);
@@ -1269,6 +1270,8 @@ struct TenantManagementWorkload : TestWorkload {
 		// "tenants" exhausted to end. If tenantGroup was specified,
 		// continue iterating localItr until end to verify there are no matches
 		if (tenantGroup.present() && tenants.size() < limit) {
+			CODE_PROBE(localItr != self->createdTenants.end() && localItr->first < endTenant,
+			           "Listed range contained extra tenants not in group");
 			while (localItr != self->createdTenants.end() && localItr->first < endTenant) {
 				ASSERT(localItr->second.tenantGroup != tenantGroup);
 				++localItr;
@@ -1468,6 +1471,8 @@ struct TenantManagementWorkload : TestWorkload {
 				tenantExists = true;
 			}
 		}
+
+		CODE_PROBE(tenantOverlap, "Attempting overlapping tenant renames");
 
 		state Version originalReadVersion = wait(self->getLatestReadVersion(self, operationType));
 		loop {
@@ -1912,8 +1917,10 @@ struct TenantManagementWorkload : TestWorkload {
 				if (readKey) {
 					Optional<Value> val = wait(tr->get(self->keyName));
 					if (val.present()) {
+						CODE_PROBE(true, "Read tenant key has value");
 						ASSERT((keyPresent && val.get() == tName) || (maybeCommitted && writeKey && !clearKey));
 					} else {
+						CODE_PROBE(true, "Read tenant key is empty");
 						ASSERT((tenantPresent && tData.empty) || (maybeCommitted && writeKey && clearKey));
 					}
 
@@ -1927,6 +1934,8 @@ struct TenantManagementWorkload : TestWorkload {
 					}
 
 					wait(tr->commit());
+					CODE_PROBE(clearKey, "Clear tenant key");
+					CODE_PROBE(!clearKey, "Set tenant key");
 
 					ASSERT(lockAware || lockState == TenantAPI::TenantLockState::UNLOCKED);
 					self->createdTenants[tName].empty = clearKey;
@@ -1952,6 +1961,7 @@ struct TenantManagementWorkload : TestWorkload {
 
 				try {
 					maybeCommitted = maybeCommitted || err.code() == error_code_commit_unknown_result;
+					CODE_PROBE(maybeCommitted, "Modify tenant key maybe committed");
 					wait(tr->onError(err));
 				} catch (Error& error) {
 					TraceEvent(SevError, "ReadKeyFailure").errorUnsuppressed(error).detail("TenantName", tenant);
@@ -2218,9 +2228,11 @@ struct TenantManagementWorkload : TestWorkload {
 				    wait(TenantMetadata::tombstoneCleanupData().get(tr));
 
 				if (self->oldestDeletionVersion != 0) {
+					CODE_PROBE(true, "Tenant tombstone oldest deletion version non-zero");
 					ASSERT(tombstoneCleanupData.present());
 					if (self->newestDeletionVersion - self->oldestDeletionVersion >
 					    CLIENT_KNOBS->TENANT_TOMBSTONE_CLEANUP_INTERVAL * CLIENT_KNOBS->VERSIONS_PER_SECOND) {
+						CODE_PROBE(tombstoneCleanupData.get().tombstonesErasedThrough > 0, "Tenant tombstones erased");
 						ASSERT(tombstoneCleanupData.get().tombstonesErasedThrough >= 0);
 					}
 				}

--- a/metacluster/MetaclusterMetrics.actor.cpp
+++ b/metacluster/MetaclusterMetrics.actor.cpp
@@ -54,6 +54,8 @@ ACTOR Future<MetaclusterMetrics> getMetaclusterMetricsImpl(Database db) {
 			    .detail("TenantGroupCapacity", metrics.tenantGroupCapacity)
 			    .detail("TenantGroupsAllocated", metrics.tenantGroupsAllocated);
 
+			CODE_PROBE(true, "Got metacluster metrics");
+
 			return metrics;
 		} catch (Error& e) {
 			TraceEvent("MetaclusterUpdaterError").error(e);

--- a/metacluster/include/metacluster/ConfigureCluster.h
+++ b/metacluster/include/metacluster/ConfigureCluster.h
@@ -41,17 +41,22 @@ void updateClusterMetadata(Transaction tr,
                            Optional<ClusterConnectionString> const& updatedConnectionString,
                            Optional<DataClusterEntry> const& updatedEntry,
                            IsRestoring isRestoring = IsRestoring::False) {
+	CODE_PROBE(updatedEntry.present() && updatedConnectionString.present(),
+	           "Update configuration and connection string simultaneously");
 
 	if (updatedEntry.present()) {
 		if (previousMetadata.entry.clusterState == DataClusterState::REGISTERING &&
 		    updatedEntry.get().clusterState != DataClusterState::READY &&
 		    updatedEntry.get().clusterState != DataClusterState::REMOVING) {
+			CODE_PROBE(true, "Updating cluster state from registering to unexpected state");
 			throw cluster_not_found();
 		} else if (previousMetadata.entry.clusterState == DataClusterState::REMOVING) {
+			CODE_PROBE(true, "Attempting to configure cluster that is being removed");
 			throw cluster_removed();
 		} else if (!isRestoring && previousMetadata.entry.clusterState == DataClusterState::RESTORING &&
 		           (updatedEntry.get().clusterState != DataClusterState::READY &&
 		            updatedEntry.get().clusterState != DataClusterState::REMOVING)) {
+			CODE_PROBE(true, "Attempting to configure cluster that is being restored");
 			throw cluster_restoring();
 		} else if (isRestoring) {
 			ASSERT(previousMetadata.entry.clusterState == DataClusterState::RESTORING &&
@@ -61,6 +66,7 @@ void updateClusterMetadata(Transaction tr,
 		internal::updateClusterCapacityIndex(tr, name, previousMetadata.entry, updatedEntry.get());
 	}
 	if (updatedConnectionString.present()) {
+		CODE_PROBE(true, "Updating data cluster connection string");
 		metadata::management::dataClusterConnectionRecords().set(tr, name, updatedConnectionString.get());
 	}
 }

--- a/metacluster/include/metacluster/CreateMetacluster.actor.h
+++ b/metacluster/include/metacluster/CreateMetacluster.actor.h
@@ -60,6 +60,7 @@ Future<Optional<std::string>> createMetacluster(Reference<DB> db,
 	       tenantIdPrefix <= TenantAPI::TENANT_ID_PREFIX_MAX_VALUE);
 
 	if (name.startsWith("\xff"_sr)) {
+		CODE_PROBE(true, "Create metacluster with invalid name");
 		throw invalid_cluster_name();
 	}
 
@@ -78,8 +79,10 @@ Future<Optional<std::string>> createMetacluster(Reference<DB> db,
 			Optional<MetaclusterRegistrationEntry> existingRegistration = wait(metaclusterRegistrationFuture);
 			if (existingRegistration.present()) {
 				if (metaclusterUid.present() && metaclusterUid.get() == existingRegistration.get().metaclusterId) {
+					CODE_PROBE(true, "Create metacluster already succeeded");
 					return Optional<std::string>();
 				} else {
+					CODE_PROBE(true, "Metacluster already registered");
 					return fmt::format("cluster is already registered as a {} named `{}'",
 					                   existingRegistration.get().clusterType == ClusterType::METACLUSTER_DATA
 					                       ? "data cluster"
@@ -91,6 +94,7 @@ Future<Optional<std::string>> createMetacluster(Reference<DB> db,
 			wait(metaclusterEmptinessCheck);
 			TenantMode tenantMode = wait(tenantModeFuture);
 			if (tenantMode != TenantMode::DISABLED) {
+				CODE_PROBE(true, "Create metacluster with invalid tenant mode", probe::decoration::rare);
 				return fmt::format("cluster is configured with tenant mode `{}' when tenants should be disabled",
 				                   tenantMode.toString());
 			}
@@ -107,6 +111,9 @@ Future<Optional<std::string>> createMetacluster(Reference<DB> db,
 			wait(buggifiedCommit(tr, BUGGIFY_WITH_PROB(0.1)));
 			break;
 		} catch (Error& e) {
+			CODE_PROBE(e.code() == error_code_cluster_not_empty,
+			           "Create metacluster on non-empty cluster",
+			           probe::decoration::rare);
 			wait(safeThreadFutureToFuture(tr->onError(e)));
 		}
 	}

--- a/metacluster/include/metacluster/CreateTenant.actor.h
+++ b/metacluster/include/metacluster/CreateTenant.actor.h
@@ -89,17 +89,20 @@ struct CreateTenantImpl {
 			    existingEntry.get().tenantState != TenantState::REGISTERING) {
 				// The tenant already exists and is either completely created or has a different
 				// configuration
+				CODE_PROBE(true, "Create tenant that already exists");
 				throw tenant_already_exists();
 			} else if (!self->replaceExistingTenantId.present() ||
 			           self->replaceExistingTenantId.get() != existingEntry.get().id) {
 				// The tenant creation has already started, so resume where we left off
 				if (!self->assignClusterAutomatically &&
 				    existingEntry.get().assignedCluster != self->tenantEntry.assignedCluster) {
+					CODE_PROBE(true, "Resume tenant creation failed due to assigned cluster change");
 					TraceEvent("MetaclusterCreateTenantClusterMismatch")
 					    .detail("Preferred", self->tenantEntry.assignedCluster)
 					    .detail("Actual", existingEntry.get().assignedCluster);
 					throw invalid_tenant_configuration();
 				}
+				CODE_PROBE(true, "Resume tenant creation");
 				self->tenantEntry = existingEntry.get();
 				wait(self->ctx.setCluster(tr, existingEntry.get().assignedCluster));
 				return true;
@@ -107,6 +110,7 @@ struct CreateTenantImpl {
 				// The previous creation is permanently failed, so cleanup the tenant and create it again from
 				// scratch. We don't need to remove it from the tenant name index because we will overwrite the
 				// existing entry later in this transaction.
+				CODE_PROBE(true, "Recreate tenant after permanent failure of previous ID", probe::decoration::rare);
 				metadata::management::tenantMetadata().tenantMap.erase(tr, existingEntry.get().id);
 				metadata::management::tenantMetadata().tenantCount.atomicOp(tr, -1, MutationRef::AddValue);
 				metadata::management::clusterTenantCount().atomicOp(
@@ -124,6 +128,7 @@ struct CreateTenantImpl {
 				    tr, existingEntry.get(), &previousAssignedClusterMetadata));
 			}
 		} else if (self->replaceExistingTenantId.present()) {
+			CODE_PROBE(true, "Tenant removed during creation", probe::decoration::rare);
 			throw tenant_removed();
 		}
 
@@ -143,11 +148,15 @@ struct CreateTenantImpl {
 			if (groupEntry.present()) {
 				if (!self->assignClusterAutomatically &&
 				    groupEntry.get().assignedCluster != self->tenantEntry.assignedCluster) {
+					CODE_PROBE(true, "Attempt to create tenant in group on a different cluster");
 					TraceEvent("MetaclusterCreateTenantGroupClusterMismatch")
 					    .detail("TenantGroupCluster", groupEntry.get().assignedCluster)
 					    .detail("SpecifiedCluster", self->tenantEntry.assignedCluster);
 					throw invalid_tenant_configuration();
 				}
+				CODE_PROBE(self->assignClusterAutomatically, "Create tenant in an existing group with auto-assignment");
+				CODE_PROBE(!self->assignClusterAutomatically,
+				           "Create tenant in an existing group with assigned cluster");
 				return std::make_pair(groupEntry.get().assignedCluster, true);
 			}
 		}
@@ -161,6 +170,7 @@ struct CreateTenantImpl {
 			DataClusterMetadata dataClusterMetadata =
 			    wait(getClusterTransaction(tr, self->tenantEntry.assignedCluster));
 			if (!dataClusterMetadata.entry.hasCapacity() && !self->ignoreCapacityLimit) {
+				CODE_PROBE(true, "Selected cluster has no capacity");
 				throw cluster_no_capacity();
 			}
 			dataClusterNames.push_back(self->tenantEntry.assignedCluster);
@@ -174,6 +184,7 @@ struct CreateTenantImpl {
 			        Snapshot::False,
 			        Reverse::True));
 			if (availableClusters.results.empty()) {
+				CODE_PROBE(true, "Metacluster has no capacity");
 				throw metacluster_no_capacity();
 			}
 			for (auto const& clusterTuple : availableClusters.results) {
@@ -197,9 +208,13 @@ struct CreateTenantImpl {
 		    CLIENT_KNOBS->METACLUSTER_ASSIGNMENT_AVAILABILITY_TIMEOUT));
 
 		if (!clusterAvailabilityCheck.present()) {
+			CODE_PROBE(true, "Data cluster availability check timed out");
 			// If no clusters were available for long enough, then we throw an error and try again
 			throw transaction_too_old();
 		}
+
+		CODE_PROBE(clusterAvailabilityChecks[0].isReady(), "Preferred cluster available");
+		CODE_PROBE(!clusterAvailabilityChecks[0].isReady(), "Preferred cluster not available");
 
 		// Get the first cluster that was available
 		state Optional<ClusterName> chosenCluster;
@@ -208,6 +223,8 @@ struct CreateTenantImpl {
 				chosenCluster = f.get();
 				break;
 			}
+
+			CODE_PROBE(true, "Preferred cluster not available");
 		}
 
 		ASSERT(chosenCluster.present());
@@ -234,6 +251,7 @@ struct CreateTenantImpl {
 		// If the last tenant id is not present fetch the prefix from system keys and make it the prefix for the
 		// next allocated tenant id
 		if (!lastId.present()) {
+			CODE_PROBE(true, "Generating first tenant ID");
 			Optional<int64_t> tenantIdPrefix = wait(TenantMetadata::tenantIdPrefix().get(tr));
 			ASSERT(tenantIdPrefix.present());
 			lastId = tenantIdPrefix.get() << 48;
@@ -255,6 +273,7 @@ struct CreateTenantImpl {
 		    metadata::management::clusterTenantCount().getD(tr, self->tenantEntry.assignedCluster, Snapshot::False, 0));
 
 		if (clusterTenantCount > CLIENT_KNOBS->MAX_TENANTS_PER_CLUSTER) {
+			CODE_PROBE(true, "Cluster tenant capacity exceeded");
 			throw cluster_no_capacity();
 		}
 
@@ -268,8 +287,10 @@ struct CreateTenantImpl {
 		// If we are part of a tenant group that is assigned to a cluster being removed from the metacluster,
 		// then we fail with an error.
 		if (self->ctx.dataClusterMetadata.get().entry.clusterState == DataClusterState::REMOVING) {
+			CODE_PROBE(true, "Tenant created in cluster being removed", probe::decoration::rare);
 			throw cluster_removed();
 		} else if (self->ctx.dataClusterMetadata.get().entry.clusterState == DataClusterState::RESTORING) {
+			CODE_PROBE(true, "Tenant created in cluster being restored", probe::decoration::rare);
 			throw cluster_restoring();
 		}
 
@@ -297,6 +318,7 @@ struct CreateTenantImpl {
 		// If the tenant map entry is empty, then we encountered a tombstone indicating that the tenant was
 		// simultaneously removed.
 		if (!dataClusterTenant.first.present()) {
+			CODE_PROBE(true, "Tenant creation encountered tombstone");
 			throw tenant_removed();
 		}
 
@@ -307,6 +329,7 @@ struct CreateTenantImpl {
 		state Optional<MetaclusterTenantMapEntry> managementEntry =
 		    wait(tryGetTenantTransaction(tr, self->tenantEntry.id));
 		if (!managementEntry.present()) {
+			CODE_PROBE(true, "Tenant removed during creation");
 			throw tenant_removed();
 		}
 
@@ -315,6 +338,8 @@ struct CreateTenantImpl {
 			updatedEntry.tenantState = TenantState::READY;
 			metadata::management::tenantMetadata().tenantMap.set(tr, updatedEntry.id, updatedEntry);
 			metadata::management::tenantMetadata().lastTenantModification.setVersionstamp(tr, Versionstamp(), 0);
+		} else {
+			CODE_PROBE(true, "Tenant creation already completed");
 		}
 
 		return Void();
@@ -322,13 +347,16 @@ struct CreateTenantImpl {
 
 	ACTOR static Future<Void> run(CreateTenantImpl* self) {
 		if (!self->tenantEntry.assignedCluster.empty() && self->assignClusterAutomatically) {
+			CODE_PROBE(true, "Tenant creation invalid assigned cluster configuration", probe::decoration::rare);
 			throw invalid_tenant_configuration();
 		}
 		if (self->assignClusterAutomatically && self->ignoreCapacityLimit) {
 			TraceEvent("MetaclusterCreateTenantIgnoreCapacityAutoAssign").log();
+			CODE_PROBE(true, "Tenant creation ignoring capacity limit with auto-assignment on");
 			throw invalid_tenant_configuration();
 		}
 		if (self->tenantEntry.tenantName.startsWith("\xff"_sr)) {
+			CODE_PROBE(true, "Tenant creation with invalid name");
 			throw invalid_tenant_name();
 		}
 

--- a/metacluster/include/metacluster/DecommissionMetacluster.actor.h
+++ b/metacluster/include/metacluster/DecommissionMetacluster.actor.h
@@ -48,8 +48,10 @@ Future<Void> decommissionMetacluster(Reference<DB> db) {
 			ClusterType clusterType = wait(TenantAPI::getClusterType(tr));
 			if (clusterType != ClusterType::METACLUSTER_MANAGEMENT) {
 				if (firstTry) {
+					CODE_PROBE(true, "Decommission non-metacluster");
 					throw invalid_metacluster_operation();
 				} else {
+					CODE_PROBE(true, "Decommission retrying after success");
 					return Void();
 				}
 			}
@@ -69,6 +71,7 @@ Future<Void> decommissionMetacluster(Reference<DB> db) {
 			wait(buggifiedCommit(tr, BUGGIFY_WITH_PROB(0.1)));
 			break;
 		} catch (Error& e) {
+			CODE_PROBE(e.code() == error_code_cluster_not_empty, "Decommission non-empty metacluster");
 			wait(safeThreadFutureToFuture(tr->onError(e)));
 		}
 	}

--- a/metacluster/include/metacluster/GetCluster.actor.h
+++ b/metacluster/include/metacluster/GetCluster.actor.h
@@ -37,6 +37,7 @@ namespace metacluster {
 
 ACTOR template <class Transaction>
 Future<Optional<DataClusterMetadata>> tryGetClusterTransaction(Transaction tr, ClusterName name) {
+	CODE_PROBE(true, "Try get cluster");
 	tr->setOption(FDBTransactionOptions::RAW_ACCESS);
 
 	state Future<Void> metaclusterRegistrationCheck =

--- a/metacluster/include/metacluster/GetTenant.actor.h
+++ b/metacluster/include/metacluster/GetTenant.actor.h
@@ -37,12 +37,14 @@ namespace metacluster {
 
 template <class Transaction>
 Future<Optional<MetaclusterTenantMapEntry>> tryGetTenantTransaction(Transaction tr, int64_t tenantId) {
+	CODE_PROBE(true, "Try get tenant by ID");
 	tr->setOption(FDBTransactionOptions::RAW_ACCESS);
 	return metadata::management::tenantMetadata().tenantMap.get(tr, tenantId);
 }
 
 ACTOR template <class Transaction>
 Future<Optional<MetaclusterTenantMapEntry>> tryGetTenantTransaction(Transaction tr, TenantName name) {
+	CODE_PROBE(true, "Try get tenant by name");
 	tr->setOption(FDBTransactionOptions::RAW_ACCESS);
 	Optional<int64_t> tenantId = wait(metadata::management::tenantMetadata().tenantNameIndex.get(tr, name));
 	if (tenantId.present()) {

--- a/metacluster/include/metacluster/GetTenantGroup.actor.h
+++ b/metacluster/include/metacluster/GetTenantGroup.actor.h
@@ -37,6 +37,7 @@ namespace metacluster {
 
 template <class Transaction>
 Future<Optional<MetaclusterTenantGroupEntry>> tryGetTenantGroupTransaction(Transaction tr, TenantGroupName name) {
+	CODE_PROBE(true, "Try get tenant group");
 	tr->setOption(FDBTransactionOptions::RAW_ACCESS);
 	return metadata::management::tenantMetadata().tenantGroupMap.get(tr, name);
 }

--- a/metacluster/include/metacluster/ListClusters.actor.h
+++ b/metacluster/include/metacluster/ListClusters.actor.h
@@ -40,6 +40,7 @@ Future<std::map<ClusterName, DataClusterMetadata>> listClustersTransaction(Trans
                                                                            ClusterNameRef begin,
                                                                            ClusterNameRef end,
                                                                            int limit) {
+	CODE_PROBE(true, "List clusters");
 	tr->setOption(FDBTransactionOptions::RAW_ACCESS);
 
 	state Future<Void> tenantModeCheck = TenantAPI::checkTenantMode(tr, ClusterType::METACLUSTER_MANAGEMENT);

--- a/metacluster/include/metacluster/ListTenantGroups.actor.h
+++ b/metacluster/include/metacluster/ListTenantGroups.actor.h
@@ -38,6 +38,7 @@ namespace metacluster {
 ACTOR template <class Transaction>
 Future<std::vector<std::pair<TenantGroupName, MetaclusterTenantGroupEntry>>>
 listTenantGroupsTransaction(Transaction tr, TenantGroupName begin, TenantGroupName end, int limit) {
+	CODE_PROBE(true, "List tenant groups");
 	tr->setOption(FDBTransactionOptions::RAW_ACCESS);
 
 	KeyBackedRangeResult<std::pair<TenantGroupName, MetaclusterTenantGroupEntry>> results =

--- a/metacluster/include/metacluster/ListTenants.actor.h
+++ b/metacluster/include/metacluster/ListTenants.actor.h
@@ -41,6 +41,7 @@ Future<std::vector<std::pair<TenantName, int64_t>>> listTenantsTransaction(Trans
                                                                            TenantName end,
                                                                            int limit,
                                                                            int offset = 0) {
+	CODE_PROBE(true, "List tenants");
 	tr->setOption(FDBTransactionOptions::RAW_ACCESS);
 	auto future = metadata::management::tenantMetadata().tenantNameIndex.getRange(tr, begin, end, limit + offset);
 	return fmap(
@@ -58,6 +59,7 @@ Future<std::vector<std::pair<TenantName, int64_t>>> listTenantGroupTenantsTransa
                                                                                       TenantName begin,
                                                                                       TenantName end,
                                                                                       int limit) {
+	CODE_PROBE(true, "List tenant group tenants");
 	tr->setOption(FDBTransactionOptions::RAW_ACCESS);
 	state KeyBackedSet<Tuple>::RangeResultType result =
 	    wait(metadata::management::tenantMetadata().tenantGroupTenantIndex.getRange(
@@ -91,6 +93,7 @@ Future<std::vector<std::pair<TenantName, MetaclusterTenantMapEntry>>> listTenant
     Transaction tr,
     std::vector<std::pair<TenantName, int64_t>> tenantIds) {
 
+	CODE_PROBE(true, "List tenant metadata");
 	state int idIdx = 0;
 	state std::vector<Future<Optional<MetaclusterTenantMapEntry>>> futures;
 	for (; idIdx < tenantIds.size(); ++idIdx) {
@@ -181,6 +184,7 @@ Future<std::vector<std::pair<TenantName, MetaclusterTenantMapEntry>>> listTenant
 					}
 				}
 
+				CODE_PROBE(true, "List tenant multiple batches");
 				begin = keyAfter(tenantBatch.back().first);
 			}
 		} catch (Error& e) {

--- a/metacluster/include/metacluster/MetaclusterData.actor.h
+++ b/metacluster/include/metacluster/MetaclusterData.actor.h
@@ -174,6 +174,7 @@ private:
 			}
 			MetaclusterTenantMapEntry const& entry = self->managementMetadata.tenantData.tenantMap[tenantId];
 			if (renaming) {
+				CODE_PROBE(true, "Loading metacluster data with renaming tenant");
 				ASSERT(entry.tenantState == TenantState::RENAMING || entry.tenantState == TenantState::REMOVING);
 				ASSERT(entry.renameDestination == tenantName);
 			} else {

--- a/metacluster/include/metacluster/MetaclusterOperationContext.actor.h
+++ b/metacluster/include/metacluster/MetaclusterOperationContext.actor.h
@@ -71,10 +71,13 @@ struct MetaclusterOperationContext {
 		    dataClusterMetadata.present() ? dataClusterMetadata.get().entry.clusterState : DataClusterState::READY;
 		if (clusterState != DataClusterState::READY && extraSupportedDataClusterStates.count(clusterState) == 0) {
 			if (clusterState == DataClusterState::REGISTERING) {
+				CODE_PROBE(true, "Run metacluster transaction on registering cluster");
 				throw cluster_not_found();
 			} else if (clusterState == DataClusterState::REMOVING) {
+				CODE_PROBE(true, "Run metacluster transaction on removing cluster");
 				throw cluster_removed();
 			} else if (clusterState == DataClusterState::RESTORING) {
+				CODE_PROBE(true, "Run metacluster transaction on restoring cluster");
 				throw cluster_restoring();
 			}
 
@@ -96,6 +99,7 @@ struct MetaclusterOperationContext {
 				// If this transaction is retrying and didn't have the cluster name set at the beginning, clear it
 				// out to be set again in the next iteration.
 				if (!clusterPresentAtStart) {
+					CODE_PROBE(true, "Retry management transaction with unconfigured cluster");
 					self->clearCluster();
 				}
 
@@ -119,9 +123,11 @@ struct MetaclusterOperationContext {
 				// transactions have run on.
 				if (!currentMetaclusterRegistration.present() ||
 				    currentMetaclusterRegistration.get().clusterType != ClusterType::METACLUSTER_MANAGEMENT) {
+					CODE_PROBE(true, "Run management transaction on non-management cluster");
 					throw invalid_metacluster_operation();
 				} else if (self->metaclusterRegistration.present() &&
 				           !self->metaclusterRegistration.get().matches(currentMetaclusterRegistration.get())) {
+					CODE_PROBE(true, "Run management transaction on wrong management cluster", probe::decoration::rare);
 					throw metacluster_mismatch();
 				}
 
@@ -130,6 +136,7 @@ struct MetaclusterOperationContext {
 				// registration entry.
 				if (self->clusterName.present()) {
 					if (!currentDataClusterMetadata.present()) {
+						CODE_PROBE(true, "Run management transaction using deleted data cluster");
 						throw cluster_removed();
 					} else {
 						currentMetaclusterRegistration = currentMetaclusterRegistration.get().toDataClusterRegistration(
@@ -146,6 +153,7 @@ struct MetaclusterOperationContext {
 				// updated cluster metadata in the context and open a connection to the data DB.
 				if (self->dataClusterMetadata.present() &&
 				    self->dataClusterMetadata.get().entry.id != currentDataClusterMetadata.get().entry.id) {
+					CODE_PROBE(true, "Run management transaction using wrong data cluster");
 					throw cluster_removed();
 				} else if (self->clusterName.present()) {
 					self->dataClusterMetadata = currentDataClusterMetadata;
@@ -208,12 +216,15 @@ struct MetaclusterOperationContext {
 				// Check that this is the expected data cluster and is part of the right metacluster
 				if (!currentMetaclusterRegistration.present()) {
 					if (!runOnDisconnectedCluster) {
+						CODE_PROBE(true, "Run data cluster transaction on non-data cluster");
 						throw cluster_removed();
 					}
 				} else if (currentMetaclusterRegistration.get().clusterType != ClusterType::METACLUSTER_DATA) {
+					CODE_PROBE(true, "Run data cluster transaction on non-data cluster", probe::decoration::rare);
 					throw cluster_removed();
 				} else if (!self->metaclusterRegistration.get().matches(currentMetaclusterRegistration.get())) {
 					if (!runOnMismatchedCluster) {
+						CODE_PROBE(true, "Run data cluster transaction on wrong data cluster");
 						throw cluster_removed();
 					}
 				}
@@ -221,6 +232,7 @@ struct MetaclusterOperationContext {
 				if (checkRestoring) {
 					KeyBackedRangeResult<std::pair<ClusterName, UID>> activeRestoreId = wait(activeRestoreIdFuture);
 					if (!activeRestoreId.results.empty()) {
+						CODE_PROBE(true, "Run data cluster transaction on restoring data cluster");
 						throw cluster_restoring();
 					}
 				}

--- a/metacluster/include/metacluster/RegisterCluster.actor.h
+++ b/metacluster/include/metacluster/RegisterCluster.actor.h
@@ -59,6 +59,7 @@ struct RegisterClusterImpl {
 	                                                      Reference<typename DB::TransactionT> tr) {
 		state Optional<DataClusterMetadata> dataClusterMetadata = wait(tryGetClusterTransaction(tr, self->clusterName));
 		if (!dataClusterMetadata.present()) {
+			CODE_PROBE(true, "Register new cluster");
 			self->clusterEntry.clusterState = DataClusterState::REGISTERING;
 			self->clusterEntry.allocated = ClusterUsage();
 			self->clusterEntry.id = deterministicRandom()->randomUniqueID();
@@ -70,12 +71,15 @@ struct RegisterClusterImpl {
 			metadata::management::dataClusters().set(tr, self->clusterName, self->clusterEntry);
 			metadata::management::dataClusterConnectionRecords().set(tr, self->clusterName, self->connectionString);
 		} else if (dataClusterMetadata.get().entry.clusterState == DataClusterState::REMOVING) {
+			CODE_PROBE(true, "Registering cluster being removed");
 			throw cluster_removed();
 		} else if (!dataClusterMetadata.get().matchesConfiguration(
 		               DataClusterMetadata(self->clusterEntry, self->connectionString)) ||
 		           dataClusterMetadata.get().entry.clusterState != DataClusterState::REGISTERING) {
+			CODE_PROBE(true, "Cluster already exists");
 			throw cluster_already_exists();
 		} else {
+			CODE_PROBE(true, "Retrying cluster registration");
 			self->clusterEntry = dataClusterMetadata.get().entry;
 		}
 
@@ -111,10 +115,12 @@ struct RegisterClusterImpl {
 					    existingRegistration.get().name != self->clusterName ||
 					    !existingRegistration.get().matches(self->ctx.metaclusterRegistration.get()) ||
 					    existingRegistration.get().id != self->clusterEntry.id) {
+						CODE_PROBE(true, "Cluster already registered during data cluster configuration");
 						throw cluster_already_registered();
 					} else {
 						// We already successfully registered the cluster with these details, so there's nothing to
 						// do
+						CODE_PROBE(true, "Cluster registration already done on data cluster");
 						return Void();
 					}
 				}
@@ -122,6 +128,7 @@ struct RegisterClusterImpl {
 				// Check if the cluster was removed concurrently
 				bool tombstone = wait(tombstoneFuture);
 				if (tombstone) {
+					CODE_PROBE(true, "Registering cluster removed");
 					throw cluster_removed();
 				}
 
@@ -129,12 +136,14 @@ struct RegisterClusterImpl {
 				std::vector<std::pair<TenantName, int64_t>> existingTenants =
 				    wait(safeThreadFutureToFuture(existingTenantsFuture));
 				if (!existingTenants.empty()) {
+					CODE_PROBE(true, "Registering cluster with tenants");
 					TraceEvent(SevWarn, "CannotRegisterClusterWithTenants").detail("ClusterName", self->clusterName);
 					throw cluster_not_empty();
 				}
 
 				RangeResult existingData = wait(safeThreadFutureToFuture(existingDataFuture));
 				if (!existingData.empty()) {
+					CODE_PROBE(true, "Registering cluster with data", probe::decoration::rare);
 					TraceEvent(SevWarn, "CannotRegisterClusterWithData").detail("ClusterName", self->clusterName);
 					throw cluster_not_empty();
 				}
@@ -173,12 +182,16 @@ struct RegisterClusterImpl {
 		state Optional<DataClusterMetadata> dataClusterMetadata = wait(tryGetClusterTransaction(tr, self->clusterName));
 		if (!dataClusterMetadata.present() ||
 		    dataClusterMetadata.get().entry.clusterState == DataClusterState::REMOVING) {
+			CODE_PROBE(true, "Registering cluster removed");
 			throw cluster_removed();
 		} else if (dataClusterMetadata.get().entry.id != self->clusterEntry.id) {
+			CODE_PROBE(true, "Registering cluster exists with different ID");
 			throw cluster_already_exists();
 		} else if (dataClusterMetadata.get().entry.clusterState == DataClusterState::READY) {
+			CODE_PROBE(true, "Registering cluster already ready");
 			return Void();
 		} else if (dataClusterMetadata.get().entry.clusterState == DataClusterState::RESTORING) {
+			CODE_PROBE(true, "Registering cluster restoring");
 			throw cluster_restoring();
 		} else {
 			ASSERT(dataClusterMetadata.get().entry.clusterState == DataClusterState::REGISTERING);
@@ -213,6 +226,7 @@ struct RegisterClusterImpl {
 		                                                    5.0);
 
 		if (self->clusterName.startsWith("\xff"_sr)) {
+			CODE_PROBE(true, "Registering cluster with invalid name");
 			throw invalid_cluster_name();
 		}
 
@@ -229,6 +243,7 @@ struct RegisterClusterImpl {
 				// Attempt to unregister the cluster if we could not configure the data cluster. We should only do this
 				// if the data cluster state matches our ID and is in the REGISTERING in case somebody else has
 				// attempted to complete the registration or start a new one.
+				CODE_PROBE(true, "Rollback cluster registration");
 				removeCluster.clusterId = self->clusterEntry.id;
 				removeCluster.legalClusterStates.insert(DataClusterState::REGISTERING);
 				wait(removeCluster.run());

--- a/metacluster/include/metacluster/RenameTenant.actor.h
+++ b/metacluster/include/metacluster/RenameTenant.actor.h
@@ -107,6 +107,7 @@ struct RenameTenantImpl {
 		    wait(metadata::management::clusterTenantCount().getD(tr, tenantEntry.assignedCluster, Snapshot::False, 0));
 
 		if (clusterTenantCount + 1 > CLIENT_KNOBS->MAX_TENANTS_PER_CLUSTER) {
+			CODE_PROBE(true, "Rename failed due to cluster capacity limit");
 			throw cluster_no_capacity();
 		}
 
@@ -154,6 +155,7 @@ struct RenameTenantImpl {
 			return Void();
 		}
 		if (tenantEntry.get().tenantState == TenantState::REMOVING) {
+			CODE_PROBE(true, "Tenant removed during rename");
 			throw tenant_removed();
 		}
 

--- a/metacluster/include/metacluster/UpdateTenantGroups.actor.h
+++ b/metacluster/include/metacluster/UpdateTenantGroups.actor.h
@@ -55,6 +55,7 @@ void managementClusterAddTenantToGroup(Transaction tr,
                                        IsRestoring isRestoring = IsRestoring::False) {
 	if (tenantEntry.tenantGroup.present()) {
 		if (tenantEntry.tenantGroup.get().startsWith("\xff"_sr)) {
+			CODE_PROBE(true, "Invalid tenant group name");
 			throw invalid_tenant_group_name();
 		}
 
@@ -109,6 +110,7 @@ Future<Void> managementClusterRemoveTenantFromGroup(Transaction tr,
 	// Update the tenant group count information for the assigned cluster if this tenant group was erased so we
 	// can use the freed capacity.
 	if (updateClusterCapacity) {
+		CODE_PROBE(true, "Remove tenant from group deleted group");
 		DataClusterEntry updatedEntry = clusterMetadata->entry;
 		--updatedEntry.allocated.numTenantGroups;
 		updateClusterMetadata(


### PR DESCRIPTION
Add various code probes for tenant and metacluster code. 

Fix one bug in the tenant management concurrency workload where a particular test operation wasn't being run, and make another test change that allows restore operations to timeout and be retried in the metacluster management workload.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
