### PR TITLE
fixing BlobGranuleRequests to properly bump read version on retry

### DIFF
--- a/fdbclient/include/fdbclient/BlobGranuleRequest.actor.h
+++ b/fdbclient/include/fdbclient/BlobGranuleRequest.actor.h
@@ -92,7 +92,7 @@ Future<Standalone<VectorRef<REPLY_TYPE(Request)>>> txnDoBlobGranuleRequests(
 					           blobGranuleMapping[i + 1].key.printable());
 				}
 				// throw to force read version to increase and to retry reading mapping
-				throw transaction_too_old();
+				throw blob_granule_request_failed();
 			}
 		}
 
@@ -139,9 +139,9 @@ Future<Standalone<VectorRef<REPLY_TYPE(Request)>>> txnDoBlobGranuleRequests(
 		}
 	}
 	if (i < blobGranuleMapping.size() - 1) {
-		// a request failed, retry from there after a sleep
+		// a request failed, retry from that point next time
 		*beginKey = blobGranuleMapping[i].key;
-		wait(delay(FLOW_KNOBS->PREVENT_FAST_SPIN_DELAY));
+		throw blob_granule_request_failed();
 	} else if (blobGranuleMapping.more) {
 		*beginKey = blobGranuleMapping.back().key;
 		// no requests failed but there is more to read, continue reading


### PR DESCRIPTION
In case where some requests failed because the mapping was wrong, the retry loop would sleep instead of throwing an error, meaning the read version would not be reset on the following retry and it would read the same stale mapping.
This would cause the request to continue retrying until the read version got transaction_too_old, meaning the request could take 5 seconds extra (or some multiple of 5 seconds for a large range).

Passes 50k BlobGranule* correctness with no errors and manually verified flush performance and behavior in the error case with fdbcli.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
