### PR TITLE
EaR: Implement SimKmsVault interface, refactor SimKmsConnector (#10194)

### DIFF
--- a/fdbclient/ClientKnobs.cpp
+++ b/fdbclient/ClientKnobs.cpp
@@ -314,6 +314,7 @@ void ClientKnobs::initialize(Randomize randomize) {
 	init( ENCRYPT_HEADER_AES_CTR_HMAC_SHA_AUTH_VERSION, 1 );
 
 	init( REST_KMS_ALLOW_NOT_SECURE_CONNECTION,     false ); if ( randomize && BUGGIFY ) REST_KMS_ALLOW_NOT_SECURE_CONNECTION = !REST_KMS_ALLOW_NOT_SECURE_CONNECTION;
+	init( SIM_KMS_VAULT_MAX_KEYS,                    4096 );
 
 	// clang-format on
 }

--- a/fdbclient/include/fdbclient/ClientKnobs.h
+++ b/fdbclient/include/fdbclient/ClientKnobs.h
@@ -314,6 +314,7 @@ public:
 
 	// REST KMS configurations
 	bool REST_KMS_ALLOW_NOT_SECURE_CONNECTION;
+	int SIM_KMS_VAULT_MAX_KEYS;
 
 	ClientKnobs(Randomize randomize);
 	void initialize(Randomize randomize);

--- a/fdbclient/include/fdbclient/SimKmsVault.cpp
+++ b/fdbclient/include/fdbclient/SimKmsVault.cpp
@@ -1,0 +1,185 @@
+/*
+ * SimKmsVault.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2023 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "fdbclient/SimKmsVault.h"
+#include "fdbclient/BlobCipher.h"
+#include "fdbclient/ClientKnobs.h"
+
+#include "fdbclient/Knobs.h"
+#include "flow/Arena.h"
+#include "flow/EncryptUtils.h"
+#include "flow/FastRef.h"
+#include "flow/IRandom.h"
+#include "flow/network.h"
+
+SimKmsVaultKeyCtx::SimKmsVaultKeyCtx(EncryptCipherBaseKeyId kId, const uint8_t* data, const int dataLen)
+  : id(kId), keyLen(dataLen) {
+	key = makeString(keyLen);
+	memcpy(mutateString(key), data, keyLen);
+	kcv = Sha256KCV().computeKCV((const uint8_t*)data, dataLen);
+	if (DEBUG_SIM_KEY_CIPHER) {
+		TraceEvent(SevDebug, "SimKmsVaultKeyCtxInit")
+		    .detail("BaseCipherId", kId)
+		    .detail("BaseCipherLen", dataLen)
+		    .detail("KCV", kcv);
+	}
+}
+
+int SimKmsVaultKeyCtx::getKeyLen(const EncryptCipherBaseKeyId id) {
+	ASSERT_GT(id, INVALID_ENCRYPT_CIPHER_KEY_ID);
+
+	int ret = AES_256_KEY_LENGTH;
+	if ((id % 2) == 0) {
+		ret += (id % (MAX_BASE_CIPHER_LEN - AES_256_KEY_LENGTH));
+	}
+	CODE_PROBE(ret == AES_256_KEY_LENGTH, "SimKmsVault BaseCipherKeyLen AES_256_KEY_LENGTH");
+	CODE_PROBE(ret != AES_256_KEY_LENGTH, "SimKmsVault BaseCipherKeyLen variable length");
+
+	return ret;
+}
+
+class SimKmsVaultCtx : NonCopyable, public ReferenceCounted<SimKmsVaultCtx> {
+public:
+	// Public visibility constructior ONLY to assist FlowSingleton instance creation.
+	// API Note: Constructor is expected to be instantiated only in simulation mode.
+
+	explicit SimKmsVaultCtx(bool ignored) {
+		ASSERT(g_network->isSimulated());
+		init();
+	}
+
+	static Reference<SimKmsVaultCtx> getInstance() {
+		if (g_network->isSimulated()) {
+			return FlowSingleton<SimKmsVaultCtx>::getInstance(
+			    []() { return makeReference<SimKmsVaultCtx>(g_network->isSimulated()); });
+		} else {
+			static SimKmsVaultCtx instance;
+			return Reference<SimKmsVaultCtx>::addRef(&instance);
+		}
+	}
+
+	Reference<SimKmsVaultKeyCtx> getByBaseCipherId(const EncryptCipherBaseKeyId baseCipherId) {
+		auto itr = keyvault.find(baseCipherId);
+		if (itr == keyvault.end()) {
+			return Reference<SimKmsVaultKeyCtx>();
+		}
+		return itr->second;
+	}
+
+	EncryptCipherBaseKeyId getBaseCipherIdFromDomainId(const EncryptCipherDomainId domainId) const {
+		return 1 + abs(domainId) % maxEncryptionKeys;
+	}
+
+	uint32_t maxKeys() const { return maxEncryptionKeys; }
+
+private:
+	SimKmsVaultCtx() { init(); }
+
+	void init() {
+		maxEncryptionKeys = CLIENT_KNOBS->SIM_KMS_VAULT_MAX_KEYS;
+		// Vault needs to ensure 'stable encryption key semantics' across process restarts, the encryption keys are
+		// generated using following scheme:
+		// a. HMAC_SHA algorithm is used to generate the key (digest)
+		// b. HMAC_SHA uses an 'deterministic' seed (SHA_KEY) and 'data' buffer to generate a vault key
+		// c. To generate variable length vault-key, a known 'char' is used for padding
+		const unsigned char SHA_KEY[] = "0c39e7906db6d51ac0573d328ce1b6be";
+
+		// Construct encryption keyStore.
+		// Note the keys generated must be the same after restart.
+		for (int i = 1; i <= maxEncryptionKeys; i++) {
+			const int keyLen = SimKmsVaultKeyCtx::getKeyLen(i);
+			uint8_t key[keyLen];
+			uint8_t digest[AUTH_TOKEN_HMAC_SHA_SIZE];
+
+			// TODO: Allow baseCipherKeyLen < AES_256_KEY_LENGTH
+			ASSERT_EQ(AES_256_KEY_LENGTH, AUTH_TOKEN_HMAC_SHA_SIZE);
+			computeAuthToken({ { reinterpret_cast<const uint8_t*>(&i), sizeof(i) } },
+			                 SHA_KEY,
+			                 AES_256_KEY_LENGTH,
+			                 &digest[0],
+			                 EncryptAuthTokenAlgo::ENCRYPT_HEADER_AUTH_TOKEN_ALGO_HMAC_SHA,
+			                 AUTH_TOKEN_HMAC_SHA_SIZE);
+			memcpy(&key[0], &digest[0], std::min(keyLen, AUTH_TOKEN_HMAC_SHA_SIZE));
+			// Simulate variable length 'baseCipher' returned by external KMS
+			if (keyLen > AUTH_TOKEN_HMAC_SHA_SIZE) {
+				// pad it with known value
+				memset(&key[AUTH_TOKEN_HMAC_SHA_SIZE], 'b', (keyLen - AUTH_TOKEN_HMAC_SHA_SIZE));
+			}
+			keyvault[i] = makeReference<SimKmsVaultKeyCtx>(i, &key[0], keyLen);
+		}
+	}
+
+	uint32_t maxEncryptionKeys;
+	std::unordered_map<EncryptCipherBaseKeyId, Reference<SimKmsVaultKeyCtx>> keyvault;
+};
+
+namespace SimKmsVault {
+
+Reference<SimKmsVaultKeyCtx> getByBaseCipherId(const EncryptCipherBaseKeyId baseCipherId) {
+	Reference<SimKmsVaultCtx> ctx = SimKmsVaultCtx::getInstance();
+	return ctx->getByBaseCipherId(baseCipherId);
+}
+
+Reference<SimKmsVaultKeyCtx> getByDomainId(const EncryptCipherDomainId domainId) {
+	Reference<SimKmsVaultCtx> ctx = SimKmsVaultCtx::getInstance();
+	const EncryptCipherBaseKeyId baseCipherId = ctx->getBaseCipherIdFromDomainId(domainId);
+	return ctx->getByBaseCipherId(baseCipherId);
+}
+
+uint32_t maxSimKeys() {
+	Reference<SimKmsVaultCtx> vaultCtx = SimKmsVaultCtx::getInstance();
+	return vaultCtx->maxKeys();
+}
+
+} // namespace SimKmsVault
+
+// Only used to link unit tests
+void forceLinkSimKmsVaultTests() {}
+
+TEST_CASE("/simKmsVault") {
+	auto& g_knobs = IKnobCollection::getMutableGlobalKnobCollection();
+	g_knobs.setKnob("sim_kms_vault_max_keys", KnobValueRef::create(int{ 20 }));
+
+	Reference<SimKmsVaultCtx> vaultCtx = SimKmsVaultCtx::getInstance();
+	ASSERT_EQ(vaultCtx->maxKeys(), CLIENT_KNOBS->SIM_KMS_VAULT_MAX_KEYS);
+
+	// Test non-existing baseCiphers
+	Reference<SimKmsVaultKeyCtx> keyCtx = SimKmsVault::getByBaseCipherId(vaultCtx->maxKeys() + 1);
+	ASSERT(!keyCtx.isValid());
+
+	const int nIterations = deterministicRandom()->randomInt(512, 786);
+	for (int i = 0; i < nIterations; i++) {
+		Reference<SimKmsVaultKeyCtx> keyCtx;
+		if (deterministicRandom()->coinflip()) {
+			const EncryptCipherBaseKeyId baseCipherId = deterministicRandom()->randomInt(1, vaultCtx->maxKeys() + 1);
+			keyCtx = SimKmsVault::getByBaseCipherId(baseCipherId);
+			ASSERT(keyCtx.isValid());
+			ASSERT_EQ(keyCtx->id, baseCipherId);
+		} else {
+			const EncryptCipherDomainId domainId = deterministicRandom()->randomInt64(1, 100001);
+			keyCtx = SimKmsVault::getByDomainId(domainId);
+			ASSERT(keyCtx.isValid());
+			ASSERT_EQ(keyCtx->id, vaultCtx->getBaseCipherIdFromDomainId(domainId));
+		}
+		ASSERT_GT(keyCtx->kcv, 0);
+		ASSERT(!keyCtx->key.empty());
+	}
+	return Void();
+}

--- a/fdbclient/include/fdbclient/SimKmsVault.h
+++ b/fdbclient/include/fdbclient/SimKmsVault.h
@@ -1,0 +1,50 @@
+/*
+ * RESTKmsSimVault.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FDBCLIENT_SIM_KMS_VAULT_H
+#define FDBCLIENT_SIM_KMS_VAULT_H
+#pragma once
+
+#include "flow/EncryptUtils.h"
+
+#define DEBUG_SIM_KEY_CIPHER DEBUG_ENCRYPT_KEY_CIPHER
+
+struct SimKmsVaultKeyCtx : NonCopyable, public ReferenceCounted<SimKmsVaultKeyCtx> {
+	static const int minCipherLen = 4;
+	static const int maxCipherLen = 256;
+
+	EncryptCipherBaseKeyId id;
+	int keyLen;
+	Standalone<StringRef> key;
+	EncryptCipherKeyCheckValue kcv;
+
+	SimKmsVaultKeyCtx() : id(INVALID_ENCRYPT_CIPHER_KEY_ID), keyLen(-1), kcv(0) {}
+	explicit SimKmsVaultKeyCtx(EncryptCipherBaseKeyId kId, const uint8_t* data, const int dataLen);
+
+	static int getKeyLen(const EncryptCipherBaseKeyId id);
+};
+
+namespace SimKmsVault {
+Reference<SimKmsVaultKeyCtx> getByBaseCipherId(const EncryptCipherBaseKeyId baseCipherId);
+Reference<SimKmsVaultKeyCtx> getByDomainId(const EncryptCipherDomainId domainId);
+uint32_t maxSimKeys();
+} // namespace SimKmsVault
+
+#endif

--- a/fdbserver/workloads/UnitTests.actor.cpp
+++ b/fdbserver/workloads/UnitTests.actor.cpp
@@ -50,6 +50,7 @@ void forceLinkActorCollectionTests();
 void forceLinkDDSketchTests();
 void forceLinkCommitProxyTests();
 void forceLinkWipedStringTests();
+void forceLinkSimKmsVaultTests();
 
 struct UnitTestWorkload : TestWorkload {
 	static constexpr auto NAME = "UnitTests";
@@ -115,6 +116,7 @@ struct UnitTestWorkload : TestWorkload {
 		forceLinkActorCollectionTests();
 		forceLinkDDSketchTests();
 		forceLinkWipedStringTests();
+		forceLinkSimKmsVaultTests();
 	}
 
 	Future<Void> setup(Database const& cx) override {


### PR DESCRIPTION
Description

Patch implements a SimKmsVault interface allowing unittest/simulation to satisfy encryption lookup usecases. It also refactors existing SimKmsConnector to leverage SimKmsVault APIs

Testing

devRunCorrectness - 100K
/simKmsVault - asan & valgrind
EncryptionUnitTest

(cherry picked from commit 18fd2702c4369d5637d61da56fffef96694ddfeb)

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
