### PR TITLE
Remove an assertion for a condition that can happen

### DIFF
--- a/fdbserver/MoveKeys.actor.cpp
+++ b/fdbserver/MoveKeys.actor.cpp
@@ -707,14 +707,9 @@ ACTOR static Future<Void> startMoveKeys(Database occ,
 					state std::vector<Optional<Value>> serverListValues = wait(getAll(serverListEntries));
 
 					for (int s = 0; s < serverListValues.size(); s++) {
-						// We don't think this condition should be triggered, but we're not sure if there are conditions
-						// that might cause it to trigger. Adding this assertion to find any such cases via testing.
-						ASSERT_WE_THINK(serverListValues[s].present());
+						// This can happen if a SS is removed after a shard move. See comments on PR #10110.
 						if (!serverListValues[s].present()) {
-							// Attempt to move onto a server that isn't in serverList (removed or never added to the
-							// database) This can happen (why?) and is handled by the data distribution algorithm
-							// FIXME: Answer why this can happen?
-							// CODE_PROBE(true, "start move keys moving to a removed server", probe::decoration::rare);
+							CODE_PROBE(true, "start move keys moving to a removed server", probe::decoration::rare);
 							throw move_to_removed_server();
 						}
 					}


### PR DESCRIPTION
Revert part of logic introduced in #10110

Reproduction on commit https://github.com/apple/foundationdb/commit/c423a60e506b69373fe1b1cadf1f268219b5e0a3:
./fdbserver-7.1.27 -r simulation -f ./tests/restarting/from_7.1.0_until_7.2.0/ConfigureTestRestart-1.toml -s 1969136453 -b on ./fdbserver -r simulation -f ./tests/restarting/from_7.1.0_until_7.2.0/ConfigureTestRestart-2.toml --restarting -s 1969136454 -b on


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
