### PR TITLE
Fix deadlock in Java bindings on future cancellation

### DIFF
--- a/bindings/java/CMakeLists.txt
+++ b/bindings/java/CMakeLists.txt
@@ -429,5 +429,14 @@ if(NOT OPEN_FOR_IDE)
       org.junit.platform.console.ConsoleLauncher "--details=summary" "--class-path=${integration_jar_path}" "--scan-classpath" "--disable-banner" "-t MultiClient"
       )
 
+    add_fdbclient_test(NAME java-integration-external-client
+      API_TEST_BLOB_GRANULES_ENABLED
+      COMMAND ${Java_JAVA_EXECUTABLE}
+      -classpath "${target_jar}:${integration_jar_path}:${JUNIT_CLASSPATH}"
+      -Djava.library.path=${CMAKE_BINARY_DIR}/lib
+      org.junit.platform.console.ConsoleLauncher "--details=summary" "--class-path=${integration_jar_path}" "--scan-classpath" 
+          "--disable-banner" "-t SupportsExternalClient" "--config=external_client_library=${CMAKE_BINARY_DIR}/bindings/c/libfdb_c_external.so"
+      )
+
   endif()
 endif()

--- a/bindings/java/src/integration/com/apple/foundationdb/FutureIntegrationTest.java
+++ b/bindings/java/src/integration/com/apple/foundationdb/FutureIntegrationTest.java
@@ -38,7 +38,6 @@ class FutureIntegrationTest {
   static class DirectExecutor implements Executor {
     @Override
     public void execute(Runnable command) {
-      System.out.println("Executing callback");
       command.run();
     }
   }
@@ -47,10 +46,8 @@ class FutureIntegrationTest {
   @Tag("SupportsExternalClient")
   public void testCancelFutureOnThreadPool() throws Exception {
     try (Database db = fdb.open()) {
-      System.out.println("Executing transaction");
       Transaction tr = db.createTransaction();
       CompletableFuture<byte[]> result = tr.get("hello".getBytes("US-ASCII"));
-      System.out.println("Cancelling future");
       result.cancel(true);
     }
   }
@@ -59,10 +56,8 @@ class FutureIntegrationTest {
   @Tag("SupportsExternalClient")
   public void testCancelFutureOnSameThread() throws Exception {
     try (Database db = fdb.open(null, new DirectExecutor())) {
-      System.out.println("Executing transaction");
       Transaction tr = db.createTransaction();
       CompletableFuture<Void> result = tr.watch("hello".getBytes("US-ASCII"));
-      System.out.println("Cancelling future");
       result.cancel(true);
     }
   }

--- a/bindings/java/src/integration/com/apple/foundationdb/FutureIntegrationTest.java
+++ b/bindings/java/src/integration/com/apple/foundationdb/FutureIntegrationTest.java
@@ -1,0 +1,70 @@
+/*
+ * FutureIntegrationTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2023 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.apple.foundationdb;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Tests for working with FDB futures
+ */
+@ExtendWith(RequiresDatabase.class)
+class FutureIntegrationTest {
+  private static final FDB fdb = FDB.selectAPIVersion(ApiVersion.LATEST);
+
+  static class DirectExecutor implements Executor {
+    @Override
+    public void execute(Runnable command) {
+      System.out.println("Executing callback");
+      command.run();
+    }
+  }
+
+  @Test
+  @Tag("SupportsExternalClient")
+  public void testCancelFutureOnThreadPool() throws Exception {
+    try (Database db = fdb.open()) {
+      System.out.println("Executing transaction");
+      Transaction tr = db.createTransaction();
+      CompletableFuture<byte[]> result = tr.get("hello".getBytes("US-ASCII"));
+      System.out.println("Cancelling future");
+      result.cancel(true);
+    }
+  }
+
+  @Test
+  @Tag("SupportsExternalClient")
+  public void testCancelFutureOnSameThread() throws Exception {
+    try (Database db = fdb.open(null, new DirectExecutor())) {
+      System.out.println("Executing transaction");
+      Transaction tr = db.createTransaction();
+      CompletableFuture<Void> result = tr.watch("hello".getBytes("US-ASCII"));
+      System.out.println("Cancelling future");
+      result.cancel(true);
+    }
+  }
+
+}

--- a/bindings/java/src/main/com/apple/foundationdb/NativeFuture.java
+++ b/bindings/java/src/main/com/apple/foundationdb/NativeFuture.java
@@ -110,14 +110,14 @@ abstract class NativeFuture<T> extends CompletableFuture<T> implements AutoClose
 	public boolean cancel(boolean mayInterruptIfRunning) {
 		boolean result = super.cancel(mayInterruptIfRunning);
 		try {
-			rwl.readLock().lock();
+			rwl.writeLock().lock();
 			if(cPtr != 0) {
 				Future_cancel(cPtr);
 			}
 			return result;
 		}
 		finally {
-			rwl.readLock().unlock();
+			rwl.writeLock().unlock();
 		}
 	}
 

--- a/bindings/java/src/tests.cmake
+++ b/bindings/java/src/tests.cmake
@@ -56,6 +56,7 @@ set(JAVA_INTEGRATION_TESTS
   src/integration/com/apple/foundationdb/BlobGranuleIntegrationTest.java
   src/integration/com/apple/foundationdb/GetClientStatusIntegrationTest.java
   src/integration/com/apple/foundationdb/TransactionIntegrationTest.java
+  src/integration/com/apple/foundationdb/FutureIntegrationTest.java
 )
 
 # Resources that are used in integration testing, but are not explicitly test files (JUnit rules,


### PR DESCRIPTION
`NativeFuture.cancel` may run into a deadlock when recursively calling `NativeFuture.close`. This can happen in a configuration with an external client and when the executor decides to execute the callback in the caller thread.

These methods use a reentrant lock, but `ReentrantReadWriteLock` deadlocks on an attempt to upgrade from read lock to  write lock. 

We fix it by acquiring the write lock already in the `NativeFuture.cancel`.

The PR also a capability to execute the Java integration tests with an external client, as well as a test reproducing the issue.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
