### PR TITLE
Blob kms connector ids (Cherry-Pick #10121 to snowflake/release-71.3)

### DIFF
--- a/fdbclient/include/fdbclient/BlobConnectionProvider.h
+++ b/fdbclient/include/fdbclient/BlobConnectionProvider.h
@@ -41,6 +41,7 @@ struct BlobConnectionProvider : NonCopyable, ReferenceCounted<BlobConnectionProv
 
 	static Reference<BlobConnectionProvider> newBlobConnectionProvider(std::string blobUrl);
 
+	// FIXME: make this function dedupe location connections/providers across location ids
 	static Reference<BlobConnectionProvider> newBlobConnectionProvider(Standalone<BlobMetadataDetailsRef> blobMetadata);
 };
 

--- a/fdbclient/include/fdbclient/BlobMetadataUtils.h
+++ b/fdbclient/include/fdbclient/BlobMetadataUtils.h
@@ -25,21 +25,41 @@
 #include "flow/FileIdentifier.h"
 
 using BlobMetadataDomainId = int64_t;
+using BlobMetadataLocationId = int64_t;
 
 /*
- * There are 3 cases for blob metadata.
- *  1. A non-partitioned blob store. baseUrl is set, and partitions is empty. Files will be written with this prefix.
- *  2. A sub-path partitioned blob store. baseUrl is set, and partitions contains 2 or more sub-paths. Files will be
- * written with a prefix of the base url and then one of the sub-paths.
- *  3. A separate-storage-location partitioned blob store. baseUrl is NOT set, and partitions contains 2 or more full
- * fdb blob urls. Files will be written with one of the partition prefixes.
+ * There are 2 cases for blob metadata. These are all represented fundamentally in the same input schema.
+ *  1. A non-partitioned blob store. Files will be written with the specified location.
+ *  2. A partitioned blob store. Files will be written with one of the partition's locationId prefixes.
  * Partitioning is desired in blob stores such as s3 that can run into metadata hotspotting issues.
  */
+
+// FIXME: do internal deduping of locations based on location id
+struct BlobMetadataLocationRef {
+	BlobMetadataLocationId locationId;
+	StringRef path;
+
+	BlobMetadataLocationRef() {}
+	BlobMetadataLocationRef(Arena& arena, const BlobMetadataLocationRef& from)
+	  : locationId(from.locationId), path(arena, from.path) {}
+
+	explicit BlobMetadataLocationRef(Arena& ar, BlobMetadataLocationId locationId, StringRef path)
+	  : locationId(locationId), path(ar, path) {}
+	explicit BlobMetadataLocationRef(BlobMetadataLocationId locationId, StringRef path)
+	  : locationId(locationId), path(path) {}
+
+	int expectedSize() const { return sizeof(BlobMetadataLocationRef) + path.size(); }
+
+	template <class Ar>
+	void serialize(Ar& ar) {
+		serializer(ar, locationId, path);
+	}
+};
+
 struct BlobMetadataDetailsRef {
 	constexpr static FileIdentifier file_identifier = 6685526;
 	BlobMetadataDomainId domainId;
-	Optional<StringRef> base;
-	VectorRef<StringRef> partitions;
+	VectorRef<BlobMetadataLocationRef> locations;
 
 	// cache options
 	double refreshAt;
@@ -47,39 +67,30 @@ struct BlobMetadataDetailsRef {
 
 	BlobMetadataDetailsRef() {}
 	BlobMetadataDetailsRef(Arena& arena, const BlobMetadataDetailsRef& from)
-	  : domainId(from.domainId), partitions(arena, from.partitions), refreshAt(from.refreshAt),
-	    expireAt(from.expireAt) {
-		if (from.base.present()) {
-			base = StringRef(arena, from.base.get());
-		}
-	}
+	  : domainId(from.domainId), locations(arena, from.locations), refreshAt(from.refreshAt), expireAt(from.expireAt) {}
 
 	explicit BlobMetadataDetailsRef(Arena& ar,
 	                                BlobMetadataDomainId domainId,
-	                                Optional<StringRef> baseLocation,
-	                                VectorRef<StringRef> partitions,
+	                                VectorRef<BlobMetadataLocationRef> locations,
 	                                double refreshAt,
 	                                double expireAt)
-	  : domainId(domainId), partitions(ar, partitions), refreshAt(refreshAt), expireAt(expireAt) {
-		if (baseLocation.present()) {
-			base = StringRef(ar, baseLocation.get());
-		}
+	  : domainId(domainId), locations(ar, locations), refreshAt(refreshAt), expireAt(expireAt) {
+		ASSERT(!locations.empty());
 	}
 
 	explicit BlobMetadataDetailsRef(BlobMetadataDomainId domainId,
-	                                Optional<StringRef> base,
-	                                VectorRef<StringRef> partitions,
+	                                VectorRef<BlobMetadataLocationRef> locations,
 	                                double refreshAt,
 	                                double expireAt)
-	  : domainId(domainId), base(base), partitions(partitions), refreshAt(refreshAt), expireAt(expireAt) {}
-
-	int expectedSize() const {
-		return sizeof(BlobMetadataDetailsRef) + (base.present() ? base.get().size() : 0) + partitions.expectedSize();
+	  : domainId(domainId), locations(locations), refreshAt(refreshAt), expireAt(expireAt) {
+		ASSERT(!locations.empty());
 	}
+
+	int expectedSize() const { return sizeof(BlobMetadataDetailsRef) + locations.expectedSize(); }
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, domainId, base, partitions, refreshAt, expireAt);
+		serializer(ar, domainId, locations, refreshAt, expireAt);
 	}
 };
 

--- a/fdbserver/RESTKmsConnector.actor.cpp
+++ b/fdbserver/RESTKmsConnector.actor.cpp
@@ -82,8 +82,9 @@ const char DISCOVER_URL_FILE_URL_SEP = '\n';
 
 const char* BLOB_METADATA_DETAILS_TAG = "blob_metadata_details";
 const char* BLOB_METADATA_DOMAIN_ID_TAG = "domain_id";
-const char* BLOB_METADATA_BASE_LOCATION_TAG = "base_location";
-const char* BLOB_METADATA_PARTITIONS_TAG = "partitions";
+const char* BLOB_METADATA_LOCATIONS_TAG = "locations";
+const char* BLOB_METADATA_LOCATION_ID_TAG = "id";
+const char* BLOB_METADATA_LOCATION_PATH_TAG = "path";
 
 constexpr int INVALID_REQUEST_VERSION = 0;
 
@@ -509,11 +510,9 @@ Standalone<VectorRef<BlobMetadataDetailsRef>> parseBlobMetadataResponse(Referenc
 	//   "blob_metadata_details" : [
 	//     {
 	//        "domain_id" : <domainId>,
-	//        "domain_name" : <baseCipher>,
-	//        "baseLocation" : <baseLocation>, (Optional if partitions is present)
-	//        "partitions" : [
-	//			  "partition1", "partition2", ...
-	//		  ], (Optional if baseLocation is present)
+	//        "locations" : [
+	//			  { id: 1, path: "fdbblob://partition1"} , {id: 2, path: "fdbblob://partition2"}, ...
+	//		  ],
 	//        "refresh_after_sec"   : <refreshTimeInterval>, (Optional)
 	//        "expire_after_sec"    : <expireTimeInterval>  (Optional)
 	//     },
@@ -545,7 +544,7 @@ Standalone<VectorRef<BlobMetadataDetailsRef>> parseBlobMetadataResponse(Referenc
 	// Extract CipherKeyDetails
 	if (!doc.HasMember(BLOB_METADATA_DETAILS_TAG) || !doc[BLOB_METADATA_DETAILS_TAG].IsArray()) {
 		TraceEvent(SevWarn, "ParseBlobMetadataResponseFailureMissingDetails", ctx->uid).log();
-		CODE_PROBE(true, "REST BlobMedata details missing or not-array");
+		CODE_PROBE(true, "REST BlobMetadata details missing or not-array");
 		throw rest_malformed_response();
 	}
 
@@ -553,45 +552,47 @@ Standalone<VectorRef<BlobMetadataDetailsRef>> parseBlobMetadataResponse(Referenc
 		if (!detail.IsObject()) {
 			TraceEvent(SevWarn, "ParseBlobMetadataResponseFailureDetailsNotObject", ctx->uid)
 			    .detail("CipherDetailType", detail.GetType());
-			CODE_PROBE(true, "REST BlobMedata detail not-object");
+			CODE_PROBE(true, "REST BlobMetadata detail not-object");
 			throw rest_malformed_response();
 		}
 
 		const bool isDomainIdPresent = detail.HasMember(BLOB_METADATA_DOMAIN_ID_TAG);
-		const bool isBasePresent = detail.HasMember(BLOB_METADATA_BASE_LOCATION_TAG);
-		const bool isPartitionsPresent = detail.HasMember(BLOB_METADATA_PARTITIONS_TAG);
-		if (!isDomainIdPresent || (!isBasePresent && !isPartitionsPresent)) {
+		const bool isLocationsPresent =
+		    detail.HasMember(BLOB_METADATA_LOCATIONS_TAG) && detail[BLOB_METADATA_LOCATIONS_TAG].IsArray();
+		if (!isDomainIdPresent || !isLocationsPresent) {
 			TraceEvent(SevWarn, "ParseBlobMetadataResponseMalformedDetail", ctx->uid)
 			    .detail("DomainIdPresent", isDomainIdPresent)
-			    .detail("BaseLocationPresent", isBasePresent)
-			    .detail("PartitionsPresent", isPartitionsPresent);
-			CODE_PROBE(true, "REST BlobMedata detail malformed");
+			    .detail("LocationsPresent", isLocationsPresent);
+			CODE_PROBE(true, "REST BlobMetadata detail malformed");
 			throw rest_malformed_response();
 		}
 
-		std::unique_ptr<uint8_t[]> baseStr;
-		Optional<StringRef> base;
-		if (isBasePresent) {
-			const int baseLen = detail[BLOB_METADATA_BASE_LOCATION_TAG].GetStringLength();
-			baseStr = std::make_unique<uint8_t[]>(baseLen);
-			memcpy(baseStr.get(), detail[BLOB_METADATA_BASE_LOCATION_TAG].GetString(), baseLen);
-			base = StringRef(baseStr.get(), baseLen);
-		}
+		BlobMetadataDomainId domainId = detail[BLOB_METADATA_DOMAIN_ID_TAG].GetInt64();
 
 		// just do extra memory copy for simplicity here
-		Standalone<VectorRef<StringRef>> partitions;
-		if (isPartitionsPresent) {
-			for (const auto& partition : detail[BLOB_METADATA_PARTITIONS_TAG].GetArray()) {
-				if (!partition.IsString()) {
-					TraceEvent("ParseBlobMetadataResponseFailurePartitionNotString", ctx->uid)
-					    .detail("PartitionType", partition.GetType());
-					throw operation_failed();
-				}
-				const int partitionLen = partition.GetStringLength();
-				std::unique_ptr<uint8_t[]> partitionStr = std::make_unique<uint8_t[]>(partitionLen);
-				memcpy(partitionStr.get(), partition.GetString(), partitionLen);
-				partitions.push_back_deep(partitions.arena(), StringRef(partitionStr.get(), partitionLen));
+		Standalone<VectorRef<BlobMetadataLocationRef>> locations;
+		for (const auto& location : detail[BLOB_METADATA_LOCATIONS_TAG].GetArray()) {
+			if (!location.IsObject()) {
+				TraceEvent("ParseBlobMetadataResponseFailureLocationNotObject", ctx->uid)
+				    .detail("LocationType", location.GetType());
+				throw rest_malformed_response();
 			}
+			const bool isLocationIdPresent = location.HasMember(BLOB_METADATA_LOCATION_ID_TAG);
+			const bool isPathPresent = location.HasMember(BLOB_METADATA_LOCATION_PATH_TAG);
+			if (!isLocationIdPresent || !isPathPresent) {
+				TraceEvent(SevWarn, "ParseBlobMetadataResponseMalformedLocation", ctx->uid)
+				    .detail("LocationIdPresent", isLocationIdPresent)
+				    .detail("PathPresent", isPathPresent);
+				CODE_PROBE(true, "REST BlobMetadata location malformed");
+				throw rest_malformed_response();
+			}
+
+			BlobMetadataLocationId locationId = location[BLOB_METADATA_LOCATION_ID_TAG].GetInt64();
+
+			const int pathLen = location[BLOB_METADATA_LOCATION_PATH_TAG].GetStringLength();
+			std::unique_ptr<uint8_t[]> pathStr = std::make_unique<uint8_t[]>(pathLen);
+			memcpy(pathStr.get(), location[BLOB_METADATA_LOCATION_PATH_TAG].GetString(), pathLen);
+			locations.emplace_back_deep(locations.arena(), locationId, StringRef(pathStr.get(), pathLen));
 		}
 
 		// Extract refresh and/or expiry interval if supplied
@@ -600,8 +601,7 @@ Standalone<VectorRef<BlobMetadataDetailsRef>> parseBlobMetadataResponse(Referenc
 		                       : std::numeric_limits<double>::max();
 		double expireAt = detail.HasMember(EXPIRE_AFTER_SEC) ? now() + detail[EXPIRE_AFTER_SEC].GetInt64()
 		                                                     : std::numeric_limits<double>::max();
-		result.emplace_back_deep(
-		    result.arena(), detail[BLOB_METADATA_DOMAIN_ID_TAG].GetInt64(), base, partitions, refreshAt, expireAt);
+		result.emplace_back_deep(result.arena(), domainId, locations, refreshAt, expireAt);
 	}
 
 	checkDocForNewKmsUrls(ctx, resp, doc);
@@ -1189,7 +1189,6 @@ void forceLinkRESTKmsConnectorTest() {}
 namespace {
 std::string_view KMS_URL_NAME_TEST = "http://foo/bar";
 std::string_view BLOB_METADATA_BASE_LOCATION_TEST = "file://local";
-std::string_view BLOB_METADATA_PARTITION_TEST = "part";
 uint8_t BASE_CIPHER_KEY_TEST[32];
 
 std::shared_ptr<platform::TmpFile> prepareTokenFile(const uint8_t* buff, const int len) {
@@ -1467,25 +1466,26 @@ void getFakeBlobMetadataResponse(StringRef jsonReqRef,
 		domainId.SetInt64(detail[BLOB_METADATA_DOMAIN_ID_TAG].GetInt64());
 		keyDetail.AddMember(key, domainId, resDoc.GetAllocator());
 
-		int type = deterministicRandom()->randomInt(0, 3);
-		if (type == 0 || type == 1) {
-			key.SetString(BLOB_METADATA_BASE_LOCATION_TAG, resDoc.GetAllocator());
-			rapidjson::Value baseLocation;
-			baseLocation.SetString(BLOB_METADATA_BASE_LOCATION_TEST.data(), resDoc.GetAllocator());
-			keyDetail.AddMember(key, baseLocation, resDoc.GetAllocator());
+		int locationCount = deterministicRandom()->randomInt(1, 6);
+		rapidjson::Value locations(rapidjson::kArrayType);
+		for (int i = 0; i < locationCount; i++) {
+			rapidjson::Value location(rapidjson::kObjectType);
+
+			rapidjson::Value locId;
+			key.SetString(BLOB_METADATA_LOCATION_ID_TAG, resDoc.GetAllocator());
+			locId.SetInt64(i);
+			location.AddMember(key, locId, resDoc.GetAllocator());
+
+			rapidjson::Value path;
+			key.SetString(BLOB_METADATA_LOCATION_PATH_TAG, resDoc.GetAllocator());
+			path.SetString(BLOB_METADATA_BASE_LOCATION_TEST.data(), resDoc.GetAllocator());
+			location.AddMember(key, path, resDoc.GetAllocator());
+
+			locations.PushBack(location, resDoc.GetAllocator());
 		}
-		if (type == 1 || type == 2) {
-			int partitionCount = deterministicRandom()->randomInt(2, 6);
-			rapidjson::Value partitions(rapidjson::kArrayType);
-			for (int i = 0; i < partitionCount; i++) {
-				rapidjson::Value p;
-				p.SetString(((type == 1) ? BLOB_METADATA_PARTITION_TEST : BLOB_METADATA_BASE_LOCATION_TEST).data(),
-				            resDoc.GetAllocator());
-				partitions.PushBack(p, resDoc.GetAllocator());
-			}
-			key.SetString(BLOB_METADATA_PARTITIONS_TAG, resDoc.GetAllocator());
-			keyDetail.AddMember(key, partitions, resDoc.GetAllocator());
-		}
+
+		key.SetString(BLOB_METADATA_LOCATIONS_TAG, resDoc.GetAllocator());
+		keyDetail.AddMember(key, locations, resDoc.GetAllocator());
 
 		addFakeRefreshExpire(resDoc, keyDetail, key);
 
@@ -1604,7 +1604,7 @@ void testGetBlobMetadataRequestBody(Reference<RESTKmsConnectorCtx> ctx) {
 	for (const auto& detail : details) {
 		auto it = domainIds.find(detail.domainId);
 		ASSERT(it != domainIds.end());
-		ASSERT(detail.base.present() || !detail.partitions.empty());
+		ASSERT(!detail.locations.empty());
 	}
 	if (refreshKmsUrls) {
 		validateKmsUrls(ctx);


### PR DESCRIPTION
Cherry-Pick of #10121

Passes 10k BlobGranuleCorrectness, which is currently the only full simulation workload that exercises this logic - 20230516-171059-jslocum-7d89f35144ceb754

100k correctness passed with 1 unrelated failure - 20230516-173533-jslocum-7d89f35144ceb754 

Original Description:

Refactor the interface of the rest kms connector for blob metadata to be simpler and also to pass ids with each storage location.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
