### PR TITLE
fixing bg downgrade to also disable http servers

### DIFF
--- a/tests/restarting/to_71.2.8_until_71.3.0/BlobGranuleRestartCycle-1.toml
+++ b/tests/restarting/to_71.2.8_until_71.3.0/BlobGranuleRestartCycle-1.toml
@@ -10,6 +10,7 @@ storageEngineExcludeTypes = [4, 5]
 # encryption and tenants are not compatible between 71.2 and 71.3
 encryptModes = ['disabled']
 tenantModes=['disabled']
+simHTTPServerEnabled=false
 
 [[ knobs ]]
 # url was updated to correct default location under simfdb after 71.2, use old location

--- a/tests/restarting/to_71.2.8_until_71.3.0/BlobGranuleRestartLarge-1.toml
+++ b/tests/restarting/to_71.2.8_until_71.3.0/BlobGranuleRestartLarge-1.toml
@@ -10,6 +10,7 @@ storageEngineExcludeTypes = [4, 5]
 # encryption and tenants are not compatible between 71.2 and 71.3
 encryptModes = ['disabled']
 tenantModes=['disabled']
+simHTTPServerEnabled=false
 
 [[ knobs ]]
 # url was updated to correct default location under simfdb after 71.2, use old location


### PR DESCRIPTION
Logical merge conflict between #10217 and #10220.
One disabled http servers in downgrade tests from 71.3, the other added new 71.3 downgrade tests that missed this change.
Passes 10k BlobGranuleRestart* - 20230516-181246-jslocum-86601ed4ebe4fdb1

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
