### PR TITLE
Avoid multiple-DD issue of audit storage

### DIFF
--- a/fdbclient/include/fdbclient/Audit.h
+++ b/fdbclient/include/fdbclient/Audit.h
@@ -45,17 +45,17 @@ enum class AuditType : uint8_t {
 struct AuditStorageState {
 	constexpr static FileIdentifier file_identifier = 13804340;
 
-	AuditStorageState() : type(0), auditServerId(UID()), phase(0) {}
+	AuditStorageState() : type(0), auditServerId(UID()), phase(0), ddAuditId(UID()) {}
 	AuditStorageState(UID id, UID auditServerId, AuditType type)
-	  : id(id), auditServerId(auditServerId), type(static_cast<uint8_t>(type)), phase(0) {}
+	  : id(id), auditServerId(auditServerId), type(static_cast<uint8_t>(type)), phase(0), ddAuditId(UID()) {}
 	AuditStorageState(UID id, KeyRange range, AuditType type)
-	  : id(id), auditServerId(UID()), range(range), type(static_cast<uint8_t>(type)), phase(0) {}
+	  : id(id), auditServerId(UID()), range(range), type(static_cast<uint8_t>(type)), phase(0), ddAuditId(UID()) {}
 	AuditStorageState(UID id, AuditType type)
-	  : id(id), auditServerId(UID()), type(static_cast<uint8_t>(type)), phase(0) {}
+	  : id(id), auditServerId(UID()), type(static_cast<uint8_t>(type)), phase(0), ddAuditId(UID()) {}
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, id, auditServerId, range, type, phase, error);
+		serializer(ar, id, auditServerId, range, type, phase, error, ddAuditId);
 	}
 
 	void setType(AuditType type) { this->type = static_cast<uint8_t>(type); }
@@ -90,6 +90,7 @@ struct AuditStorageState {
 	}
 
 	UID id;
+	UID ddAuditId;
 	UID auditServerId;
 	KeyRange range;
 	uint8_t type;
@@ -110,10 +111,11 @@ struct AuditStorageRequest {
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, id, range, type, targetServers, reply);
+		serializer(ar, id, range, type, targetServers, reply, ddAuditId);
 	}
 
 	UID id;
+	UID ddAuditId; // UID of DD who claims the audit
 	KeyRange range;
 	uint8_t type;
 	std::vector<UID> targetServers;

--- a/fdbclient/include/fdbclient/AuditUtils.actor.h
+++ b/fdbclient/include/fdbclient/AuditUtils.actor.h
@@ -65,5 +65,6 @@ ACTOR Future<Void> clearAuditMetadataForType(Database cx,
                                              AuditType auditType,
                                              UID maxAuditIdToClear,
                                              int numFinishAuditToKeep);
+ACTOR Future<Void> updateAuditState(Database cx, AuditStorageState auditState, MoveKeyLockInfo lock, bool ddEnabled);
 #include "flow/unactorcompiler.h"
 #endif


### PR DESCRIPTION
DD issues audit requests to SSes. In the middle of a SS is processing an audit request, another DD starts. However, the SS does not know the change of DD. As a result, the audit task keeps proceeding while another audit request will be delivered to the SS from the new DD. This new audit request is duplicated with the old request.

We want the old request stops proceeding when a new request is issued. To achieve this, we write current ddId to auditState metadata (`auditKey`) when a new auditState is persisted or an audit is resumed by a new DD. Further, DD sends its ID to SS when sending the audit request.  When a SS persists the progress (`auditRangeBasedProgressPrefixFor`/`auditServerBasedProgressPrefixFor`), it checks whether the ddId in the audit request is same as the ddId persisted in the auditState metadata (`auditKey`). If yes, the progress is persisted and proceeds. If not, this audit actor stops immediately.


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
