### PR TITLE
BlobMetadata: Move SimBlobMetada store to SimKmsVault

### DIFF
--- a/fdbclient/include/fdbclient/SimKmsVault.h
+++ b/fdbclient/include/fdbclient/SimKmsVault.h
@@ -22,6 +22,7 @@
 #define FDBCLIENT_SIM_KMS_VAULT_H
 #pragma once
 
+#include "fdbclient/BlobMetadataUtils.h"
 #include "flow/EncryptUtils.h"
 
 #define DEBUG_SIM_KEY_CIPHER DEBUG_ENCRYPT_KEY_CIPHER
@@ -45,6 +46,8 @@ namespace SimKmsVault {
 Reference<SimKmsVaultKeyCtx> getByBaseCipherId(const EncryptCipherBaseKeyId baseCipherId);
 Reference<SimKmsVaultKeyCtx> getByDomainId(const EncryptCipherDomainId domainId);
 uint32_t maxSimKeys();
+
+Standalone<BlobMetadataDetailsRef> getBlobMetadata(const BlobMetadataDomainId domainId, const std::string& bgUrl);
 } // namespace SimKmsVault
 
 #endif

--- a/fdbserver/RESTSimKmsVault.actor.cpp
+++ b/fdbserver/RESTSimKmsVault.actor.cpp
@@ -18,6 +18,7 @@
  * limitations under the License.
  */
 
+#include "fdbclient/BlobMetadataUtils.h"
 #include "fdbserver/RESTSimKmsVault.h"
 #include "fdbclient/SimKmsVault.h"
 #include "fdbrpc/HTTP.h"
@@ -35,6 +36,7 @@
 #include "flow/FastRef.h"
 #include "flow/IRandom.h"
 #include "flow/Knobs.h"
+#include "flow/Trace.h"
 #include "flow/actorcompiler.h" // This must be the last #include.
 
 using DomIdVec = std::vector<EncryptCipherDomainId>;
@@ -49,6 +51,8 @@ const std::string invalidVersionMsg = "Invalid version";
 const std::string invalidVersionCode = "5678";
 const std::string missingTokensMsg = "Missing validation tokens";
 const std::string missingTokenCode = "0123";
+
+const std::string bgUrl = "file://simfdb/fdbblob/";
 
 struct VaultResponse {
 	bool failed;
@@ -129,7 +133,6 @@ void prepareErrorResponse(VaultResponse* response,
 bool extractVersion(const rapidjson::Document& doc, VaultResponse* response, int* version) {
 	// check version tag sanityrest_malformed_response
 	if (!doc.HasMember(REQUEST_VERSION_TAG) || !doc[REQUEST_VERSION_TAG].IsInt()) {
-		TraceEvent("What").detail("One", doc.HasMember(REQUEST_VERSION_TAG));
 		prepareErrorResponse(response, ErrorDetail(missingVersionCode, missingVersionMsg));
 		CODE_PROBE(true, "RESTSimKmsVault missing version");
 		return false;
@@ -203,6 +206,39 @@ void addCipherDetailToRespDoc(rapidjson::Document& doc,
 	cipherDetails.PushBack(cipherDetail, doc.GetAllocator());
 }
 
+void addBlobMetadaToResDoc(rapidjson::Document& doc, rapidjson::Value& blobDetails, const EncryptCipherDomainId domId) {
+	Standalone<BlobMetadataDetailsRef> detailsRef = SimKmsVault::getBlobMetadata(domId, bgUrl);
+	rapidjson::Value blobDetail(rapidjson::kObjectType);
+
+	rapidjson::Value key(BLOB_METADATA_DOMAIN_ID_TAG, doc.GetAllocator());
+	rapidjson::Value domainId;
+	domainId.SetInt64(domId);
+	blobDetail.AddMember(key, domainId, doc.GetAllocator());
+
+	rapidjson::Value locations(rapidjson::kArrayType);
+	for (const auto& loc : detailsRef.locations) {
+		rapidjson::Value location(rapidjson::kObjectType);
+
+		// set location-id
+		key.SetString(BLOB_METADATA_LOCATION_ID_TAG, doc.GetAllocator());
+		rapidjson::Value id;
+		id.SetInt64(loc.locationId);
+		location.AddMember(key, id, doc.GetAllocator());
+
+		// set location-path
+		key.SetString(BLOB_METADATA_LOCATION_PATH_TAG, doc.GetAllocator());
+		rapidjson::Value path;
+		path.SetString(reinterpret_cast<const char*>(loc.path.begin()), loc.path.size(), doc.GetAllocator());
+		location.AddMember(key, path, doc.GetAllocator());
+
+		locations.PushBack(location, doc.GetAllocator());
+	}
+	key.SetString(BLOB_METADATA_LOCATIONS_TAG, doc.GetAllocator());
+	blobDetail.AddMember(key, locations, doc.GetAllocator());
+
+	blobDetails.PushBack(blobDetail, doc.GetAllocator());
+}
+
 void addKmsUrlsToDoc(rapidjson::Document& doc) {
 	rapidjson::Value kmsUrls(rapidjson::kArrayType);
 	// FIXME: fetch latest KMS URLs && append to the doc
@@ -260,7 +296,7 @@ VaultResponse handleFetchKeysByDomainIds(const std::string& content) {
 
 	ASSERT(!response.failed);
 	response.buff = std::string(sb.GetString(), sb.GetSize());
-	//TraceEvent("ResponeStr").detail("Str", response->buff);
+	//TraceEvent(SevDebug, "FetchByDomainIdsResponseStr").detail("Str", response->buff);
 	return response;
 }
 
@@ -318,7 +354,59 @@ VaultResponse handleFetchKeysByKeyIds(const std::string& content) {
 
 	ASSERT(!response.failed);
 	response.buff = std::string(sb.GetString(), sb.GetSize());
-	TraceEvent("ResponeStr").detail("Str", response.buff);
+	//TraceEvent(SevDebug, "FetchByKeyIdsResponseStr").detail("Str", response.buff);
+	return response;
+}
+
+VaultResponse handleFetchBlobMetada(const std::string& content) {
+	VaultResponse response;
+	rapidjson::Document doc;
+
+	doc.Parse(content.data());
+
+	int version;
+
+	if (!extractVersion(doc, &response, &version)) {
+		// Return HTTP::HTTP_STATUS_CODE_OK with appropriate 'error' details
+		ASSERT(response.failed);
+		return response;
+	}
+	ASSERT(!response.failed);
+
+	if (!checkValidationTokens(doc, version, &response)) {
+		// Return HTTP::HTTP_STATUS_CODE_OK with appropriate 'error' details
+		ASSERT(response.failed);
+		return response;
+	}
+	ASSERT(!response.failed);
+
+	rapidjson::Document result;
+	result.SetObject();
+
+	// Append 'request version'
+	addVersionToDoc(result, version);
+
+	// Append 'blob_metadata_details' as json array
+	rapidjson::Value blobDetails(rapidjson::kArrayType);
+	for (const auto& blobDetail : doc[BLOB_METADATA_DETAILS_TAG].GetArray()) {
+		EncryptCipherDomainId domainId = blobDetail[BLOB_METADATA_DOMAIN_ID_TAG].GetInt64();
+		addBlobMetadaToResDoc(doc, blobDetails, domainId);
+	}
+	rapidjson::Value memberKey(BLOB_METADATA_DETAILS_TAG, result.GetAllocator());
+	result.AddMember(memberKey, blobDetails, result.GetAllocator());
+
+	if (doc.HasMember(KMS_URLS_TAG) && doc[KMS_URLS_TAG].GetBool()) {
+		addKmsUrlsToDoc(result);
+	}
+
+	// Serialize json to string
+	rapidjson::StringBuffer sb;
+	rapidjson::Writer<rapidjson::StringBuffer> writer(sb);
+	result.Accept(writer);
+
+	ASSERT(!response.failed);
+	response.buff = std::string(sb.GetString(), sb.GetSize());
+	//TraceEvent(SevDebug, "FetchBlobMetadataResponeStr").detail("Str", response.buff);
 	return response;
 }
 
@@ -330,10 +418,12 @@ ACTOR Future<Void> simKmsVaultRequestHandler(Reference<HTTP::IncomingRequest> re
 	validateHeaders(request->data.headers);
 
 	state VaultResponse vaultResponse;
-	if (request->resource.compare("/get-encryption-keys-by-key-ids") == 0) {
+	if (request->resource.compare(REST_SIM_KMS_VAULT_GET_ENCRYPTION_KEYS_BY_KEY_IDS_RESOURCE) == 0) {
 		vaultResponse = handleFetchKeysByKeyIds(request->data.content);
-	} else if (request->resource.compare("/get-encryption-keys-by-domain-ids") == 0) {
+	} else if (request->resource.compare(REST_SIM_KMS_VAULT_GET_ENCRYPTION_KEYS_BY_DOMAIN_IDS_RESOURCE) == 0) {
 		vaultResponse = handleFetchKeysByDomainIds(request->data.content);
+	} else if (request->resource.compare(REST_SIM_KMS_VAULT_GET_BLOB_METADATA_RESOURCE) == 0) {
+		vaultResponse = handleFetchBlobMetada(request->data.content);
 	} else {
 		TraceEvent("UnexpectedResource").detail("Resource", request->resource);
 		throw http_bad_response();
@@ -379,7 +469,10 @@ void constructDomainIds(EncryptCipherDomainIdVec& domIds) {
 	}
 }
 
-std::string getFakeDomainIdsRequestContent(EncryptCipherDomainIdVec& domIds, FaultType fault = FaultType::NONE) {
+std::string getFakeDomainIdsRequestContent(EncryptCipherDomainIdVec& domIds,
+                                           const char* rootTag,
+                                           const char* elementTag,
+                                           FaultType fault = FaultType::NONE) {
 	rapidjson::Document doc;
 	doc.SetObject();
 
@@ -396,7 +489,7 @@ std::string getFakeDomainIdsRequestContent(EncryptCipherDomainIdVec& domIds, Fau
 	}
 
 	constructDomainIds(domIds);
-	addLatestDomainDetailsToDoc(doc, CIPHER_KEY_DETAILS_TAG, ENCRYPT_DOMAIN_ID_TAG, domIds);
+	addLatestDomainDetailsToDoc(doc, rootTag, elementTag, domIds);
 
 	addRefreshKmsUrlsSectionToJsonDoc(doc, deterministicRandom()->coinflip());
 
@@ -410,8 +503,19 @@ std::string getFakeDomainIdsRequestContent(EncryptCipherDomainIdVec& domIds, Fau
 	doc.Accept(writer);
 
 	std::string resp(sb.GetString(), sb.GetSize());
-	TraceEvent("Request").detail("Str", resp);
+	/*TraceEvent(SevDebug, "FakeDomainIdsRequest")
+	    .detail("Str", resp)
+	    .detail("RootTag", rootTag)
+	    .detail("ElementTag", elementTag);*/
 	return resp;
+}
+
+std::string getFakeEncryptDomainIdsRequestContent(EncryptCipherDomainIdVec& domIds, FaultType fault = FaultType::NONE) {
+	return getFakeDomainIdsRequestContent(domIds, CIPHER_KEY_DETAILS_TAG, ENCRYPT_DOMAIN_ID_TAG, fault);
+}
+
+std::string getFakeBlobDomainIdsRequestContent(EncryptCipherDomainIdVec& domIds, FaultType fault = FaultType::NONE) {
+	return getFakeDomainIdsRequestContent(domIds, BLOB_METADATA_DETAILS_TAG, BLOB_METADATA_DOMAIN_ID_TAG, fault);
 }
 
 std::string getFakeBaseCipherIdsRequestContent(EncryptCipherDomainIdVec& domIds, FaultType fault = FaultType::NONE) {
@@ -451,7 +555,7 @@ std::string getFakeBaseCipherIdsRequestContent(EncryptCipherDomainIdVec& domIds,
 	doc.Accept(writer);
 
 	std::string resp(sb.GetString(), sb.GetSize());
-	TraceEvent("Request").detail("Str", resp);
+	//TraceEvent(SevDebug, "FakeKeyIdsRequest").detail("Str", resp);
 	return resp;
 }
 
@@ -461,10 +565,10 @@ Optional<ErrorDetail> getErrorDetail(const std::string& buff) {
 	return RESTKmsConnectorUtils::getError(doc);
 }
 
-void validateLookup(const VaultResponse& response, const EncryptCipherDomainIdVec& domIds) {
+void validateEncryptLookup(const VaultResponse& response, const EncryptCipherDomainIdVec& domIds) {
 	ASSERT(!response.failed);
 
-	TraceEvent("VaultResponse").detail("Str", response.buff);
+	//TraceEvent(SevDebug, "VaultEncryptResponse").detail("Str", response.buff);
 
 	rapidjson::Document doc;
 	doc.Parse(response.buff.data());
@@ -487,6 +591,44 @@ void validateLookup(const VaultResponse& response, const EncryptCipherDomainIdVe
 		ASSERT_EQ(keyCtx->key.compare(cipherKeyRef), 0);
 		const int64_t refreshAfterSec = cipherDetail[REFRESH_AFTER_SEC].GetInt64();
 		const int64_t expireAfterSec = cipherDetail[EXPIRE_AFTER_SEC].GetInt64();
+		ASSERT(refreshAfterSec <= expireAfterSec || expireAfterSec == -1);
+		count++;
+	}
+	ASSERT_EQ(count, domIds.size());
+}
+
+void validateBlobLookup(const VaultResponse& response, const EncryptCipherDomainIdVec& domIds) {
+	ASSERT(!response.failed);
+
+	//TraceEvent(SevDebug, "VaultBlobResponse").detail("Str", response.buff);
+
+	rapidjson::Document doc;
+	doc.Parse(response.buff.data());
+
+	ASSERT(doc.HasMember(BLOB_METADATA_DETAILS_TAG) && doc[BLOB_METADATA_DETAILS_TAG].IsArray());
+
+	std::unordered_set<EncryptCipherDomainId> domIdSet(domIds.begin(), domIds.end());
+	int count = 0;
+	for (const auto& blobDetail : doc[BLOB_METADATA_DETAILS_TAG].GetArray()) {
+		EncryptCipherDomainId domainId = blobDetail[BLOB_METADATA_DOMAIN_ID_TAG].GetInt64();
+		Standalone<BlobMetadataDetailsRef> details = SimKmsVault::getBlobMetadata(domainId, bgUrl);
+
+		std::unordered_map<BlobMetadataLocationId, Standalone<StringRef>> locMap;
+		for (const auto& loc : details.locations) {
+			locMap[loc.locationId] = loc.path;
+		}
+		for (const auto& location : blobDetail[BLOB_METADATA_LOCATIONS_TAG].GetArray()) {
+			BlobMetadataLocationId locationId = location[BLOB_METADATA_LOCATION_ID_TAG].GetInt64();
+			Standalone<StringRef> path = makeString(location[BLOB_METADATA_LOCATION_PATH_TAG].GetStringLength());
+			memcpy(mutateString(path),
+			       location[BLOB_METADATA_LOCATION_PATH_TAG].GetString(),
+			       location[BLOB_METADATA_LOCATION_PATH_TAG].GetStringLength());
+			auto it = locMap.find(locationId);
+			ASSERT(it != locMap.end());
+			ASSERT_EQ(it->second.compare(path), 0);
+		}
+		const int64_t refreshAfterSec = blobDetail[REFRESH_AFTER_SEC].GetInt64();
+		const int64_t expireAfterSec = blobDetail[EXPIRE_AFTER_SEC].GetInt64();
 		ASSERT(refreshAfterSec <= expireAfterSec || expireAfterSec == -1);
 		count++;
 	}
@@ -530,7 +672,7 @@ TEST_CASE("/restSimKmsVault/invalidHeader") {
 
 TEST_CASE("/restSimKmsVault/GetByDomainIds/missingVersion") {
 	EncryptCipherDomainIdVec domIds;
-	std::string requestContent = getFakeDomainIdsRequestContent(domIds, FaultType::MISSING_VERSION);
+	std::string requestContent = getFakeEncryptDomainIdsRequestContent(domIds, FaultType::MISSING_VERSION);
 	VaultResponse response = handleFetchKeysByDomainIds(requestContent);
 	ASSERT(response.failed);
 	Optional<ErrorDetail> detail = getErrorDetail(response.buff);
@@ -542,7 +684,7 @@ TEST_CASE("/restSimKmsVault/GetByDomainIds/missingVersion") {
 
 TEST_CASE("/restSimKmsVault/GetByDomainIds/invalidVersion") {
 	EncryptCipherDomainIdVec domIds;
-	std::string requestContent = getFakeDomainIdsRequestContent(domIds, FaultType::INVALID_VERSION);
+	std::string requestContent = getFakeEncryptDomainIdsRequestContent(domIds, FaultType::INVALID_VERSION);
 	VaultResponse response = handleFetchKeysByDomainIds(requestContent);
 	ASSERT(response.failed);
 	Optional<ErrorDetail> detail = getErrorDetail(response.buff);
@@ -554,7 +696,7 @@ TEST_CASE("/restSimKmsVault/GetByDomainIds/invalidVersion") {
 
 TEST_CASE("/restSimKmsVault/GetByDomainIds/missingValidationTokens") {
 	EncryptCipherDomainIdVec domIds;
-	std::string requestContent = getFakeDomainIdsRequestContent(domIds, FaultType::MISSING_VALIDATION_TOKEN);
+	std::string requestContent = getFakeEncryptDomainIdsRequestContent(domIds, FaultType::MISSING_VALIDATION_TOKEN);
 
 	VaultResponse response = handleFetchKeysByDomainIds(requestContent);
 	ASSERT(response.failed);
@@ -567,10 +709,10 @@ TEST_CASE("/restSimKmsVault/GetByDomainIds/missingValidationTokens") {
 
 TEST_CASE("/restSimKmsVault/GetByDomainIds") {
 	EncryptCipherDomainIdVec domIds;
-	std::string requestContent = getFakeDomainIdsRequestContent(domIds);
+	std::string requestContent = getFakeEncryptDomainIdsRequestContent(domIds);
 
 	VaultResponse response = handleFetchKeysByDomainIds(requestContent);
-	validateLookup(response, domIds);
+	validateEncryptLookup(response, domIds);
 	return Void();
 }
 
@@ -618,6 +760,54 @@ TEST_CASE("/restSimKmsVault/GetByKeyIds") {
 	std::string requestContent = getFakeBaseCipherIdsRequestContent(domIds);
 
 	VaultResponse response = handleFetchKeysByKeyIds(requestContent);
-	validateLookup(response, domIds);
+	validateEncryptLookup(response, domIds);
+	return Void();
+}
+
+TEST_CASE("/restSimKmsVault/GetBlobMetadata/missingVersion") {
+	EncryptCipherDomainIdVec domIds;
+	std::string requestContent = getFakeBlobDomainIdsRequestContent(domIds, FaultType::MISSING_VERSION);
+
+	VaultResponse response = handleFetchBlobMetada(requestContent);
+	ASSERT(response.failed);
+	Optional<ErrorDetail> detail = getErrorDetail(response.buff);
+	ASSERT(detail.present());
+	ASSERT(detail->isEqual(ErrorDetail(missingVersionCode, missingVersionMsg)));
+
+	return Void();
+}
+
+TEST_CASE("/restSimKmsVault/GetBlobMetadata/invalidVersion") {
+	EncryptCipherDomainIdVec domIds;
+	std::string requestContent = getFakeBlobDomainIdsRequestContent(domIds, FaultType::INVALID_VERSION);
+
+	VaultResponse response = handleFetchBlobMetada(requestContent);
+	ASSERT(response.failed);
+	Optional<ErrorDetail> detail = getErrorDetail(response.buff);
+	ASSERT(detail.present());
+	ASSERT(detail->isEqual(ErrorDetail(invalidVersionCode, invalidVersionMsg)));
+
+	return Void();
+}
+
+TEST_CASE("/restSimKmsVault/GetByKeyIds/missingValidationTokens") {
+	EncryptCipherDomainIdVec domIds;
+	std::string requestContent = getFakeBlobDomainIdsRequestContent(domIds, FaultType::MISSING_VALIDATION_TOKEN);
+
+	VaultResponse response = handleFetchBlobMetada(requestContent);
+	ASSERT(response.failed);
+	Optional<ErrorDetail> detail = getErrorDetail(response.buff);
+	ASSERT(detail.present());
+	ASSERT(detail->isEqual(ErrorDetail(missingTokenCode, missingTokensMsg)));
+
+	return Void();
+}
+
+TEST_CASE("/restSimKmsVault/GetBlobMetadata/foo") {
+	EncryptCipherDomainIdVec domIds;
+	std::string requestContent = getFakeBlobDomainIdsRequestContent(domIds);
+
+	VaultResponse response = handleFetchBlobMetada(requestContent);
+	validateBlobLookup(response, domIds);
 	return Void();
 }

--- a/fdbserver/SimKmsConnector.actor.cpp
+++ b/fdbserver/SimKmsConnector.actor.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "fdbclient/BlobCipher.h"
+#include "fdbclient/BlobMetadataUtils.h"
 #include "fdbclient/SimKmsVault.h"
 
 #include "fdbrpc/sim_validation.h"
@@ -53,10 +54,6 @@
 #include "flow/actorcompiler.h" // This must be the last #include.
 
 #define DEBUG_SIM_KEY_CIPHER DEBUG_ENCRYPT_KEY_CIPHER
-
-// The credentials may be allowed to change, but the storage locations and partitioning cannot change, even across
-// restarts. Keep it as global static state in simulation.
-static std::unordered_map<BlobMetadataDomainId, Standalone<BlobMetadataDetailsRef>> simBlobMetadataStore;
 
 namespace {
 Optional<int64_t> getRefreshInterval(const int64_t now, const int64_t defaultTtl) {
@@ -192,18 +189,9 @@ ACTOR Future<Void> blobMetadataLookup(KmsConnectorInterface interf, KmsConnBlobM
 	}
 
 	for (auto const domainId : req.domainIds) {
-		auto it = simBlobMetadataStore.find(domainId);
-		if (it == simBlobMetadataStore.end()) {
-			// construct new blob metadata
-			it = simBlobMetadataStore.insert({ domainId, createRandomTestBlobMetadata(SERVER_KNOBS->BG_URL, domainId) })
-			         .first;
-		} else if (now() >= it->second.expireAt) {
-			// update random refresh and expire time
-			it->second.refreshAt = now() + deterministicRandom()->random01() * 30;
-			it->second.expireAt = it->second.refreshAt + deterministicRandom()->random01() * 10;
-		}
-		rep.metadataDetails.arena().dependsOn(it->second.arena());
-		rep.metadataDetails.push_back(rep.metadataDetails.arena(), it->second);
+		Standalone<BlobMetadataDetailsRef> metadataRef = SimKmsVault::getBlobMetadata(domainId, SERVER_KNOBS->BG_URL);
+		rep.metadataDetails.arena().dependsOn(metadataRef.arena());
+		rep.metadataDetails.push_back(rep.metadataDetails.arena(), metadataRef);
 	}
 
 	wait(delay(deterministicRandom()->random01())); // simulate network delay

--- a/fdbserver/include/fdbserver/RESTSimKmsVault.h
+++ b/fdbserver/include/fdbserver/RESTSimKmsVault.h
@@ -25,6 +25,10 @@
 #include "fdbrpc/HTTP.h"
 #include "fdbrpc/simulator.h"
 
+const std::string REST_SIM_KMS_VAULT_GET_ENCRYPTION_KEYS_BY_KEY_IDS_RESOURCE = "/get-encryption-keys-by-key-ids";
+const std::string REST_SIM_KMS_VAULT_GET_ENCRYPTION_KEYS_BY_DOMAIN_IDS_RESOURCE = "/get-encryption-keys-by-domain-ids";
+const std::string REST_SIM_KMS_VAULT_GET_BLOB_METADATA_RESOURCE = "/get-blob-metadata";
+
 struct RESTSimKmsVaultRequestHandler : HTTP::IRequestHandler, ReferenceCounted<RESTSimKmsVaultRequestHandler> {
 	Future<Void> handleRequest(Reference<HTTP::IncomingRequest> req,
 	                           Reference<HTTP::OutgoingResponse> response) override;


### PR DESCRIPTION
Description

Patch refactor SimKmsConnector to move SimBlobMetadata store to SimKmsVault

Testing

BlobGranuleCorrectness - 100K
/fdbserver/blob/connectionprovider - 100K
devRunCorrectness - 100K

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
