### PR TITLE
Fix ConsistencyCheck_DataInconsistent failure in simulation

### DIFF
--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -3651,9 +3651,6 @@ ACTOR Future<Void> commitProxyServerCore(CommitProxyInterface proxy,
 	state PromiseStream<Future<Void>> addActor;
 	state Future<Void> onError = transformError(actorCollection(addActor.getFuture()), broken_promise(), tlog_failed());
 
-	state GetHealthMetricsReply healthMetricsReply;
-	state GetHealthMetricsReply detailedHealthMetricsReply;
-
 	TraceEvent("CPEncryptionAtRestMode", proxy.id()).detail("Mode", commitData.encryptMode);
 
 	addActor.send(waitFailureServer(proxy.waitFailure.getFuture()));

--- a/fdbserver/ConsistencyScan.actor.cpp
+++ b/fdbserver/ConsistencyScan.actor.cpp
@@ -326,14 +326,13 @@ ACTOR Future<int> consistencyCheckReadData(Database cx,
 					// response from a different region returned with a lower version (because
 					// of the rollback of the forced recovery). In this case, we should not fail
 					// the test. So we double check both process are live.
-					bool isFailed = g_network->isSimulated() &&
-										    (g_simulator->getProcessByAddress((*storageServerInterfaces)[j].address())
-										         ->failed ||
-										    g_simulator
-										         ->getProcessByAddress(
-										             (*storageServerInterfaces)[firstValidServer->get()].address())
-										         ->failed);
-					TraceEvent(isExpectedTSSMismatch || isFailed ? SevWarn : SevError, "ConsistencyCheck_DataInconsistent")
+					bool isFailed =
+					    g_network->isSimulated() &&
+					    (g_simulator->getProcessByAddress((*storageServerInterfaces)[j].address())->failed ||
+					     g_simulator->getProcessByAddress((*storageServerInterfaces)[firstValidServer->get()].address())
+					         ->failed);
+					TraceEvent(isExpectedTSSMismatch || isFailed ? SevWarn : SevError,
+					           "ConsistencyCheck_DataInconsistent")
 					    .detail(format("StorageServer%d", j).c_str(), (*storageServerInterfaces)[j].id())
 					    .detail(format("StorageServer%d", firstValidServer->get()).c_str(),
 					            (*storageServerInterfaces)[firstValidServer->get()].id())
@@ -852,8 +851,6 @@ ACTOR Future<Void> disableConsistencyScanInSim(Database db, ConsistencyScanMemor
 	state Reference<ReadYourWritesTransaction> tr = makeReference<ReadYourWritesTransaction>(db);
 	state ConsistencyScanState cs;
 	TraceEvent("ConsistencyScan_SimDisableWaiting", memState->csId).log();
-	// Also wait until we've scanned at least one round by checking stats
-	state bool waitForRoundComplete = true;
 	// FIXME: also wait until we've done the canary failure
 	ASSERT(g_network->isSimulated());
 	loop {

--- a/fdbserver/ConsistencyScan.actor.cpp
+++ b/fdbserver/ConsistencyScan.actor.cpp
@@ -330,7 +330,10 @@ ACTOR Future<int> consistencyCheckReadData(Database cx,
 					    g_network->isSimulated() &&
 					    (g_simulator->getProcessByAddress((*storageServerInterfaces)[j].address())->failed ||
 					     g_simulator->getProcessByAddress((*storageServerInterfaces)[firstValidServer->get()].address())
-					         ->failed);
+					         ->failed) &&
+					    (g_simulator->getProcessByAddress((*storageServerInterfaces)[j].address())->locality.dcId() !=
+					     g_simulator->getProcessByAddress((*storageServerInterfaces)[firstValidServer->get()].address())
+					         ->locality.dcId());
 					TraceEvent(isExpectedTSSMismatch || isFailed ? SevWarn : SevError,
 					           "ConsistencyCheck_DataInconsistent")
 					    .detail(format("StorageServer%d", j).c_str(), (*storageServerInterfaces)[j].id())


### PR DESCRIPTION
In the KillRegion workload, a force recovery can intentionally kill a region and recover from another region with data loss. It's possible that when the ConsistencyScan (CS) role is checking a shard from two storage servers, the one from the failed region returned first for a higher version, then the SS was killed. Later, CS got data from the second SS from a different region, where forced recovery rollback happened and a lower version value was returned. In this case, even though the data is inconsistent, we shouldn't fail the test.

Reproduction:
  commit: 8e0c9eab8 on release-7.3 branch
  seed: -f ./tests/fast/KillRegionCycle.toml -s 2713020850 -b on
  build: gcc

```
128.285111 KillMachineProcess ID=0000000000000000 KillType=0 Process=name: Server address: 2.0.1.0:1 zone: b0b936fdeb06677996b4d08ea4cee0ac datahall: 0 class: storage excluded: 0 cleared: 0 StartingClass=storage Failed=0 Excluded=0 Cleared=0 Rebooting=0 TS
128.285111 FailMachine ID=0000000000000000 Name=Server Address=2.0.1.0:1 ZoneId=b0b936fdeb06677996b4d08ea4cee0ac Process=name: Server address: 2.0.1.0:1 zone: b0b936fdeb06677996b4d08ea4cee0ac datahall: 0 class: storage excluded: 0 cleared: 0 Rebooting=0 Protected=0 Backtrace=addr2line -e fdbserver.debug -p -C -f -i 0x4d9285c 0x4c09baf 0x4c1deae 0x4c20410 0x34273a4 0x342bada 0x4c2e580 0xff2f33 0x7f88c9301555 TS

ConsistencyCheck get data back:
136.110275 ConsistencyCheck_GetKeyValuesStream ID=0000000000000000 DataSize=1250 StorageServer0=59b6f434e126a7f6cee2d49bb9a46d08 136.110275 ConsistencyCheck_FirstValidServer ID=0000000000000000 Iter=0 CC,CD,CP,CS,DD,GP,MS,RK,RV,SS,TL
136.110275 ConsistencyCheck_GetKeyValuesStream ID=0000000000000000 DataSize=1250 StorageServer1=f0ab44b4c48c0ddc92c4764a6e024336 

Got reply from SS0 before the crash:
127.778843 ConsistencyCheck_StoringGetFutures ID=0000000000000000 SSISize=2
```

20230518-060217-jzhou-8706da73ce630d29
20230518-220312-jzhou-a0bccaf350004b87

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
