### PR TITLE
Set readThrough for empty response as a workaround

### DIFF
--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -6646,6 +6646,7 @@ ACTOR Future<Void> tryGetRangeFromBlob(PromiseStream<RangeResult> results,
 
 		if (chunks.size() == 0) {
 			RangeResult rows;
+			rows.readThrough = KeyRef(rows.arena(), keys.end);
 			results.send(rows);
 		}
 


### PR DESCRIPTION
It's a workround for the release branch 71.3 without #10002. It set the `readThrough` when the response is empty.
After #10002, it is not needed, as there's no `more` data after this.
It fixes a bug in 71.3 release that `fetchKeys()` may fail when the response from `GetRangeFromBlob` is empty.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
