### PR TITLE
Update a test to check data cluster's version only when registered

### DIFF
--- a/fdbserver/workloads/MetaclusterManagementWorkload.actor.cpp
+++ b/fdbserver/workloads/MetaclusterManagementWorkload.actor.cpp
@@ -402,7 +402,12 @@ struct MetaclusterManagementWorkload : TestWorkload {
 				ASSERT(clusterName.startsWith("\xff"_sr));
 				return Void();
 			} else if (e.code() == error_code_unsupported_metacluster_version) {
-				ASSERT(!self->isValidVersion(dataDb));
+				// If we reach here, it is either because
+				// 1) the management cluster version is invalid and the registration failed, thus the version is
+				//    meaningless, or
+				// 2) the data cluster is already registered and invalid.
+				// If the data cluster is not registered, we shouldn't check its version.
+				ASSERT(!self->isValidVersion(dataDb->registered ? dataDb : Optional<Reference<DataClusterData>>()));
 				return Void();
 			} else if (e.code() == error_code_invalid_metacluster_operation) {
 				ASSERT(!self->metaclusterCreated);


### PR DESCRIPTION
This PR fixes an unitialized-value error reported by valgrind.

Steps to reproduce:
Ensemble: 20230516-050214-nightly_valgrind_main_x86_64_apple-b77b4ac44a15911e
Profile: team valgrind
Commit hash: 0ce1ab3162006a1ff40b652f1ccc21c7b9d7d837 on apple/main
Command: devRetryCorrectnessTest valgrind bin/fdbserver -r simulation -f tests/slow/MetaclusterManagement.toml -s 1695330198 -b off --crash --trace_format json


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
