### PR TITLE
Don't retry consistency scan if expected TSS faults [release-7.3]

### DIFF
--- a/fdbclient/RandomKeyValueUtils.cpp
+++ b/fdbclient/RandomKeyValueUtils.cpp
@@ -55,13 +55,13 @@ TEST_CASE("/randomKeyValueUtils/generate") {
 
 	printNextN(RandomKeyTupleSetGenerator(
 	               RandomIntGenerator(10),
-	               RandomKeyTupleGenerator(
-	                   { RandomKeySetGenerator(
-	                         RandomIntGenerator(5),
-	                         RandomStringGenerator(RandomIntGenerator(5), RandomIntGenerator('a', 'c', false))),
-	                     RandomKeySetGenerator(RandomIntGenerator(5),
-	                                           RandomStringGenerator(RandomIntGenerator(3, 10, true),
-	                                                                 RandomIntGenerator('d', 'f', false))) })),
+	               RandomKeyTupleGenerator(std::vector<RandomKeySetGenerator>{
+	                   RandomKeySetGenerator(
+	                       RandomIntGenerator(5),
+	                       RandomStringGenerator(RandomIntGenerator(5), RandomIntGenerator('a', 'c', false))),
+	                   RandomKeySetGenerator(RandomIntGenerator(5),
+	                                         RandomStringGenerator(RandomIntGenerator(3, 10, true),
+	                                                               RandomIntGenerator('d', 'f', false))) })),
 	           10);
 
 	// Same as above in string form

--- a/fdbserver/ConsistencyScan.actor.cpp
+++ b/fdbserver/ConsistencyScan.actor.cpp
@@ -836,7 +836,7 @@ ACTOR Future<Void> checkDataConsistency(Database cx,
 
 									if (!isExpectedTSSMismatch && !isFailed) {
 										testFailure("Data inconsistent", performQuiescentChecks, success, true);
-									} else {
+									} else if (isFailed) {
 										// If the storage servers are not live, we should retry.
 										TraceEvent("ConsistencyCheck_StorageServerUnavailable")
 										    .detail("StorageServer0", storageServerInterfaces[firstValidServer].id())

--- a/tests/rare/SpecificUnitTests.toml
+++ b/tests/rare/SpecificUnitTests.toml
@@ -11,4 +11,4 @@ runSetup=false
     [[test.workload]]
     testName = 'UnitTests'
     maxTestCases = 1
-    testsMatching = 'noSim/'
+    testsMatching = '/'


### PR DESCRIPTION
Fix the issue introduced in #10276

Also fix a GCC compiling error and cherrypick #10288

500k 20230522-161148-jzhou-be0d09cd728e5bc5

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
