### PR TITLE
Fix releasing watches on future cancellation [snowflake/release-71.3]

### DIFF
--- a/bindings/java/src/integration/com/apple/foundationdb/BlobGranuleIntegrationTest.java
+++ b/bindings/java/src/integration/com/apple/foundationdb/BlobGranuleIntegrationTest.java
@@ -43,7 +43,7 @@ class BlobGranuleIntegrationTest {
          */
         try (Database db = fdb.open()) {
             db.run(tr -> {
-                tr.clear(Range.startsWith(new byte[] { (byte)0x00 }));
+                tr.clear(new Range(new byte[] { (byte)0x00 }, new byte[] { (byte)0xff }));
                 return null;
             });
         }

--- a/bindings/java/src/integration/com/apple/foundationdb/BlobGranuleIntegrationTest.java
+++ b/bindings/java/src/integration/com/apple/foundationdb/BlobGranuleIntegrationTest.java
@@ -43,7 +43,7 @@ class BlobGranuleIntegrationTest {
          */
         try (Database db = fdb.open()) {
             db.run(tr -> {
-                tr.clear(new Range(new byte[] { (byte)0x00 }, new byte[] { (byte)0xff }));
+                tr.clear(new byte[0], new byte[] { (byte) 0xff });
                 return null;
             });
         }

--- a/bindings/java/src/integration/com/apple/foundationdb/MappedRangeQueryIntegrationTest.java
+++ b/bindings/java/src/integration/com/apple/foundationdb/MappedRangeQueryIntegrationTest.java
@@ -53,7 +53,7 @@ class MappedRangeQueryIntegrationTest {
 		 */
 		try (Database db = openFDB()) {
 			db.run(tr -> {
-				tr.clear(new Range(new byte[] { (byte)0x00 }, new byte[] { (byte)0xff }));
+				tr.clear(new byte[0], new byte[] { (byte) 0xff });
 				return null;
 			});
 		}

--- a/bindings/java/src/integration/com/apple/foundationdb/MappedRangeQueryIntegrationTest.java
+++ b/bindings/java/src/integration/com/apple/foundationdb/MappedRangeQueryIntegrationTest.java
@@ -53,7 +53,7 @@ class MappedRangeQueryIntegrationTest {
 		 */
 		try (Database db = openFDB()) {
 			db.run(tr -> {
-				tr.clear(Range.startsWith(new byte[] { (byte)0x00 }));
+				tr.clear(new Range(new byte[] { (byte)0x00 }, new byte[] { (byte)0xff }));
 				return null;
 			});
 		}

--- a/bindings/java/src/integration/com/apple/foundationdb/RangeQueryIntegrationTest.java
+++ b/bindings/java/src/integration/com/apple/foundationdb/RangeQueryIntegrationTest.java
@@ -51,7 +51,7 @@ class RangeQueryIntegrationTest {
 		 */
 		try (Database db = fdb.open()) {
 			db.run(tr -> {
-				tr.clear(new Range(new byte[] { (byte)0x00 }, new byte[] { (byte)0xff }));
+				tr.clear(new byte[0], new byte[] { (byte) 0xff });
 				return null;
 			});
 		}

--- a/bindings/java/src/integration/com/apple/foundationdb/RangeQueryIntegrationTest.java
+++ b/bindings/java/src/integration/com/apple/foundationdb/RangeQueryIntegrationTest.java
@@ -51,7 +51,7 @@ class RangeQueryIntegrationTest {
 		 */
 		try (Database db = fdb.open()) {
 			db.run(tr -> {
-				tr.clear(Range.startsWith(new byte[] { (byte)0x00 }));
+				tr.clear(new Range(new byte[] { (byte)0x00 }, new byte[] { (byte)0xff }));
 				return null;
 			});
 		}

--- a/bindings/java/src/integration/com/apple/foundationdb/WatchesIntegrationTest.java
+++ b/bindings/java/src/integration/com/apple/foundationdb/WatchesIntegrationTest.java
@@ -1,0 +1,223 @@
+/*
+ * WatchesIntegrationTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2023 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Tests for working with FDB futures
+ */
+@ExtendWith(RequiresDatabase.class)
+class WatchesIntegrationTest {
+  private static final FDB fdb = FDB.selectAPIVersion(ApiVersion.LATEST);
+
+  private static final int WATCH_TIMEOUT_SEC = 10;
+
+  static class DirectExecutor implements Executor {
+    @Override
+    public void execute(Runnable command) {
+      command.run();
+    }
+  }
+
+  @Test
+  @Tag("SupportsExternalClient")
+  public void testWatchesWithinLimit() throws Exception {
+    final String prefix = "eee";
+    final int numKeys = 10;
+    final int watchLimit = 10;
+    try (Database db = fdb.open()) {
+      db.options().setMaxWatches(watchLimit);
+      ensureConnected(db);
+      setTestKeys(db, prefix, numKeys, "oldVal");
+      List<CompletableFuture<Void>> futureList = new ArrayList<CompletableFuture<Void>>();
+      for (int i = 0; i < numKeys; i++) {
+        final int idx = i;
+        db.run(tr -> {
+          futureList.add(createTestWatch(tr, prefix, idx));
+          return null;
+        });
+      }
+      setTestKeys(db, prefix, numKeys, "newVal");
+      for (CompletableFuture<Void> future : futureList) {
+        future.orTimeout(WATCH_TIMEOUT_SEC, TimeUnit.SECONDS).join();
+      }
+    }
+  }
+
+  @Test
+  @Tag("SupportsExternalClient")
+  public void testWatchesWithinLimitInSingleTx() throws Exception {
+    final String prefix = "aaa";
+    final int numKeys = 10;
+    final int watchLimit = 10;
+    try (Database db = fdb.open()) {
+      db.options().setMaxWatches(watchLimit);
+      ensureConnected(db);
+      setTestKeys(db, prefix, numKeys, "oldVal");
+      List<CompletableFuture<Void>> futureList = new ArrayList<CompletableFuture<Void>>();
+      db.run(tr -> {
+        for (int i = 0; i < numKeys; i++) {
+          futureList.add(createTestWatch(tr, prefix, i));
+        }
+        return null;
+      });
+      setTestKeys(db, prefix, numKeys, "newVal");
+      for (CompletableFuture<Void> future : futureList) {
+        future.orTimeout(WATCH_TIMEOUT_SEC, TimeUnit.SECONDS).join();
+      }
+    }
+  }
+
+  @Test
+  @Tag("SupportsExternalClient")
+  public void testWatchesOverTheLimit() throws Exception {
+    final String prefix = "bbb";
+    final int numKeys = 11;
+    final int watchLimit = 10;
+    try (Database db = fdb.open()) {
+      db.options().setMaxWatches(watchLimit);
+      ensureConnected(db);
+      setTestKeys(db, prefix, numKeys, "oldVal");
+      List<CompletableFuture<Void>> futureList = new ArrayList<CompletableFuture<Void>>();
+      for (int i = 0; i < numKeys; i++) {
+        final int idx = i;
+        db.run(tr -> {
+          futureList.add(createTestWatch(tr, prefix, idx));
+          return null;
+        });
+      }
+      setTestKeys(db, prefix, numKeys, "newVal");
+      try {
+        for (CompletableFuture<Void> future : futureList) {
+          future.orTimeout(1, TimeUnit.SECONDS).join();
+        }
+        Assertions.fail("Watch limit not imposed");
+      } catch (CompletionException e) {
+        Assertions.assertTrue(e.getCause() instanceof FDBException);
+        Assertions.assertEquals(1032, ((FDBException) e.getCause()).getCode());
+      }
+    }
+  }
+
+  @Test
+  @Tag("SupportsExternalClient")
+  public void testWatchesOverTheLimitInSingleTx() throws Exception {
+    final String prefix = "ccc";
+    final int numKeys = 11;
+    final int watchLimit = 10;
+    try (Database db = fdb.open()) {
+      db.options().setMaxWatches(watchLimit);
+      ensureConnected(db);
+      List<CompletableFuture<Void>> futureList = new ArrayList<CompletableFuture<Void>>();
+      setTestKeys(db, prefix, numKeys, "oldVal");
+      db.run(tr -> {
+        for (int i = 0; i < numKeys; i++) {
+          futureList.add(createTestWatch(tr, prefix, i));
+        }
+        return null;
+      });
+      setTestKeys(db, prefix, numKeys, "newVal");
+      try {
+        for (CompletableFuture<Void> future : futureList) {
+          future.orTimeout(1, TimeUnit.SECONDS).join();
+        }
+        Assertions.fail("Watch limit not imposed");
+      } catch (CompletionException e) {
+        Assertions.assertTrue(e.getCause() instanceof FDBException);
+        Assertions.assertEquals(1032, ((FDBException) e.getCause()).getCode());
+      }
+    }
+  }
+
+  @Test
+  @Tag("SupportsExternalClient")
+  public void testWatchCleanupOnCancel() throws Exception {
+    final String prefix = "ddd";
+    final int numKeys = 100;
+    final int watchesToCancel = 90;
+    final int watchLimit = 10;
+    try (Database db = fdb.open()) {
+      db.options().setMaxWatches(watchLimit);
+      ensureConnected(db);
+      setTestKeys(db, prefix, numKeys, "oldVal");
+      List<CompletableFuture<Void>> futureList = new ArrayList<CompletableFuture<Void>>();
+      for (int i = 0; i < numKeys; i++) {
+        final int idx = i;
+        db.run(tr -> {
+          CompletableFuture<Void> result = createTestWatch(tr, prefix, idx);
+          futureList.add(result);
+          if (idx < watchesToCancel) {
+            result.cancel(true);
+          }
+          return null;
+        });
+      }
+      setTestKeys(db, prefix, numKeys, "newVal");
+      int idx = 0;
+      for (CompletableFuture<Void> future : futureList) {
+        if (idx < watchesToCancel) {
+          try {
+            future.orTimeout(1, TimeUnit.SECONDS).join();
+            Assertions.fail("Expecting cancellation exception");
+          } catch (CancellationException e) {
+          }
+        } else {
+          future.orTimeout(WATCH_TIMEOUT_SEC, TimeUnit.SECONDS).join();
+        }
+        idx++;
+      }
+    }
+  }
+
+  private void ensureConnected(Database db) throws Exception {
+      // Run one transaction succesfully to ensure we established connection
+      db.run(tr -> {
+        tr.getReadVersion().join();
+        return null;
+      });
+  }
+
+  private void setTestKeys(Database db, String prefix, int numberOfKeys, String value) throws Exception {
+    db.run(tr -> {
+      for (int i = 0; i < numberOfKeys; i++) {
+        tr.set(String.format("%s%d", prefix, i).getBytes(), value.getBytes());
+      }
+      return null;
+    });
+  }
+
+  private CompletableFuture<Void> createTestWatch(Transaction tr, String prefix, int idx) {
+    return tr.watch(String.format("%s%d", prefix, idx).getBytes());
+  }
+
+}

--- a/bindings/java/src/tests.cmake
+++ b/bindings/java/src/tests.cmake
@@ -57,6 +57,7 @@ set(JAVA_INTEGRATION_TESTS
   src/integration/com/apple/foundationdb/GetClientStatusIntegrationTest.java
   src/integration/com/apple/foundationdb/TransactionIntegrationTest.java
   src/integration/com/apple/foundationdb/FutureIntegrationTest.java
+  src/integration/com/apple/foundationdb/WatchesIntegrationTest.java
 )
 
 # Resources that are used in integration testing, but are not explicitly test files (JUnit rules,

--- a/fdbclient/include/fdbclient/MultiVersionAssignmentVars.h
+++ b/fdbclient/include/fdbclient/MultiVersionAssignmentVars.h
@@ -118,10 +118,12 @@ private:
 				ThreadSingleAssignmentVar<T>::delref();
 			} else {
 				notificationRequired = false;
-				future.getPtr()->addref(); // Cancel will delref our future, but we don't want to destroy it until this
-				                           // callback gets destroyed
-				future.getPtr()->cancel();
 			}
+
+			// Cancel will delref our future, but we don't want to destroy it until this
+			// callback gets destroyed
+			future.getPtr()->addref();
+			future.getPtr()->cancel();
 
 			if (abortSignal.clearCallback(this)) {
 				ThreadSingleAssignmentVar<T>::delref();


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/foundationdb/pull/10304

The PR needs to be included to 71.3, because it fixes a critical issue of watches not being released on cancellation of futures, which is a regression from 71.2.

100000 correctness tests passed, 20230523-092118-vgasiunas-1aff94d0c696b1f0

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
