### PR TITLE
[release-7.3] Cherry-pick Improve throughput of audit storage (#10245)

### DIFF
--- a/fdbclient/AuditUtils.actor.cpp
+++ b/fdbclient/AuditUtils.actor.cpp
@@ -51,6 +51,32 @@ void clearAuditProgressMetadata(Transaction* tr, AuditType auditType, UID auditI
 	return;
 }
 
+ACTOR Future<bool> checkStorageServerRemoved(Database cx, UID ssid) {
+	state bool res = false;
+	state Transaction tr(cx);
+	TraceEvent(SevDebug, "AuditUtilStorageServerRemovedStart").detail("StorageServer", ssid);
+
+	loop {
+		try {
+			tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
+			tr.setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
+			Optional<Value> serverListValue = wait(tr.get(serverListKeyFor(ssid)));
+			if (!serverListValue.present()) {
+				res = true; // SS is removed
+			}
+			break;
+		} catch (Error& e) {
+			TraceEvent(SevDebug, "AuditUtilStorageServerRemovedError")
+			    .errorUnsuppressed(e)
+			    .detail("StorageServer", ssid);
+			wait(tr.onError(e));
+		}
+	}
+
+	TraceEvent(SevDebug, "AuditUtilStorageServerRemovedEnd").detail("StorageServer", ssid).detail("Removed", res);
+	return res;
+}
+
 ACTOR Future<Void> clearAuditMetadata(Database cx, AuditType auditType, UID auditId, bool clearProgressMetadata) {
 	state Transaction tr(cx);
 	TraceEvent(SevDebug, "AuditUtilClearAuditMetadataStart", auditId).detail("AuditKey", auditKey(auditType, auditId));
@@ -414,6 +440,15 @@ ACTOR Future<Void> persistAuditStateByRange(Database cx, AuditStorageState audit
 		try {
 			tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
 			tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+			Optional<Value> ddAuditState_ = wait(tr.get(auditKey(auditState.getType(), auditState.id)));
+			if (!ddAuditState_.present()) {
+				throw audit_storage_failed();
+			}
+			AuditStorageState ddAuditState = decodeAuditStorageState(ddAuditState_.get());
+			ASSERT(ddAuditState.getPhase() != AuditPhase::Invalid);
+			if (ddAuditState.getPhase() != AuditPhase::Running) {
+				throw audit_storage_failed();
+			}
 			wait(krmSetRange(&tr,
 			                 auditRangeBasedProgressPrefixFor(auditState.getType(), auditState.id),
 			                 auditState.range,
@@ -479,6 +514,15 @@ ACTOR Future<Void> persistAuditStateByServer(Database cx, AuditStorageState audi
 		try {
 			tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
 			tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+			Optional<Value> ddAuditState_ = wait(tr.get(auditKey(auditState.getType(), auditState.id)));
+			if (!ddAuditState_.present()) {
+				throw audit_storage_failed();
+			}
+			AuditStorageState ddAuditState = decodeAuditStorageState(ddAuditState_.get());
+			ASSERT(ddAuditState.getPhase() != AuditPhase::Invalid);
+			if (ddAuditState.getPhase() != AuditPhase::Running) {
+				throw audit_storage_failed();
+			}
 			wait(krmSetRange(
 			    &tr,
 			    auditServerBasedProgressPrefixFor(auditState.getType(), auditState.id, auditState.auditServerId),

--- a/fdbclient/include/fdbclient/AuditUtils.actor.h
+++ b/fdbclient/include/fdbclient/AuditUtils.actor.h
@@ -64,5 +64,6 @@ ACTOR Future<Void> clearAuditMetadataForType(Database cx,
                                              AuditType auditType,
                                              UID maxAuditIdToClear,
                                              int numFinishAuditToKeep);
+ACTOR Future<bool> checkStorageServerRemoved(Database cx, UID ssid);
 #include "flow/unactorcompiler.h"
 #endif

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -74,18 +74,18 @@ ShardSizeBounds ShardSizeBounds::shardSizeBoundsBeforeTrack() {
 
 struct DDAudit {
 	DDAudit(AuditStorageState coreState)
-	  : coreState(coreState), actors(true), foundError(false), anyChildAuditFailed(false), retryCount(0),
-	    cancelled(false), issueDoAuditCount(0), completeDoAuditCount(0) {}
+	  : coreState(coreState), actors(true), foundError(false), auditStorageAnyChildFailed(false), retryCount(0),
+	    cancelled(false), overallCompleteDoAuditCount(0), overallIssuedDoAuditCount(0) {}
 
 	AuditStorageState coreState;
 	ActorCollection actors;
 	Future<Void> auditActor;
 	bool foundError;
 	int retryCount;
-	bool anyChildAuditFailed;
+	bool auditStorageAnyChildFailed;
 	bool cancelled; // use to cancel any actor beyond auditActor
-	int64_t issueDoAuditCount;
-	int64_t completeDoAuditCount;
+	int64_t overallIssuedDoAuditCount;
+	int64_t overallCompleteDoAuditCount;
 
 	void setAuditRunActor(Future<Void> actor) { auditActor = actor; }
 	Future<Void> getAuditRunActor() { return auditActor; }
@@ -1696,23 +1696,16 @@ ACTOR Future<Void> auditStorageCore(Reference<DataDistributor> self,
 		    .detail("Range", audit->coreState.range)
 		    .detail("AuditType", audit->coreState.getType())
 		    .detail("RetryCount", currentRetryCount)
-		    .detail("DDDoAuditTasksIssued", audit->issueDoAuditCount)
-		    .detail("DDDoAuditTasksComplete", audit->completeDoAuditCount);
-		ASSERT(audit->issueDoAuditCount >= audit->completeDoAuditCount);
-		ASSERT(audit->issueDoAuditCount == audit->completeDoAuditCount || audit->anyChildAuditFailed);
-		// reset issueDoAuditCount and completeDoAuditCount for future use
-		audit->issueDoAuditCount = 0;
-		audit->completeDoAuditCount = 0;
+		    .detail("DDDoAuditTasksIssued", audit->overallIssuedDoAuditCount)
+		    .detail("DDDoAuditTasksComplete", audit->overallCompleteDoAuditCount);
+		// reset for the usage for future retry
+		audit->overallCompleteDoAuditCount = 0;
+		audit->overallIssuedDoAuditCount = 0;
+
 		if (audit->foundError) {
 			audit->coreState.setPhase(AuditPhase::Error);
-		} else if (audit->anyChildAuditFailed) {
-			// We do not want an Audit blindly retry for failure of any child,
-			// which can overwhelm both DD and SSes.
-			// So, any failure in audit->actors will silently exits with
-			// setting audit->anyChildAuditFailed = true
-			// As a result, any failure of an audit child does stop
-			// other children of the audit
-			audit->anyChildAuditFailed = false;
+		} else if (audit->auditStorageAnyChildFailed) {
+			audit->auditStorageAnyChildFailed = false;
 			throw retry();
 		} else {
 			audit->coreState.setPhase(AuditPhase::Complete);
@@ -1752,7 +1745,7 @@ ACTOR Future<Void> auditStorageCore(Reference<DataDistributor> self,
 		    .detail("Range", audit->coreState.range)
 		    .detail("IsReady", self->auditInitialized.getFuture().isReady());
 		if (e.code() == error_code_actor_cancelled || e.code() == error_code_movekeys_conflict) {
-			throw e;
+			throw e; // throw to DD and DD will restart
 		} else if (audit->retryCount < SERVER_KNOBS->AUDIT_RETRY_COUNT_MAX && e.code() != error_code_not_implemented) {
 			audit->retryCount++;
 			audit->actors.clear(true);
@@ -2039,13 +2032,15 @@ void loadAndDispatchAudit(Reference<DataDistributor> self, std::shared_ptr<DDAud
 	TraceEvent(SevInfo, "DDLoadAndDispatchAudit", self->ddId)
 	    .detail("AuditID", audit->coreState.id)
 	    .detail("AuditType", audit->coreState.getType());
-	if (audit->coreState.getType() == AuditType::ValidateStorageServerShard) {
-		audit->actors.add(dispatchAuditStorageServerShard(self, audit));
+
+	if (audit->coreState.getType() == AuditType::ValidateHA) {
+		audit->actors.add(dispatchAuditStorage(self, audit, range));
+	} else if (audit->coreState.getType() == AuditType::ValidateReplica) {
+		audit->actors.add(dispatchAuditStorage(self, audit, range));
 	} else if (audit->coreState.getType() == AuditType::ValidateLocationMetadata) {
 		audit->actors.add(dispatchAuditStorage(self, audit, allKeys));
-	} else if (audit->coreState.getType() == AuditType::ValidateHA ||
-	           audit->coreState.getType() == AuditType::ValidateReplica) {
-		audit->actors.add(dispatchAuditStorage(self, audit, range));
+	} else if (audit->coreState.getType() == AuditType::ValidateStorageServerShard) {
+		audit->actors.add(dispatchAuditStorageServerShard(self, audit));
 	} else {
 		UNREACHABLE();
 	}
@@ -2089,7 +2084,11 @@ ACTOR Future<Void> dispatchAuditStorageServerShard(Reference<DataDistributor> se
 		    .errorUnsuppressed(e)
 		    .detail("AuditID", audit->coreState.id)
 		    .detail("AuditType", auditType);
-		audit->anyChildAuditFailed = true;
+		if (e.code() == error_code_actor_cancelled) {
+			throw e;
+		} else {
+			audit->auditStorageAnyChildFailed = true;
+		}
 	}
 
 	return Void();
@@ -2097,6 +2096,7 @@ ACTOR Future<Void> dispatchAuditStorageServerShard(Reference<DataDistributor> se
 
 // Schedule audit ssshard task on the input storage server (ssi)
 // Do audit on allKeys
+// Automatically retry until complete or timed out
 ACTOR Future<Void> scheduleAuditStorageShardOnServer(Reference<DataDistributor> self,
                                                      std::shared_ptr<DDAudit> audit,
                                                      StorageServerInterface ssi) {
@@ -2109,9 +2109,9 @@ ACTOR Future<Void> scheduleAuditStorageShardOnServer(Reference<DataDistributor> 
 	    .detail("AuditType", auditType);
 	state Key begin = allKeys.begin;
 	state KeyRange currentRange = allKeys;
-	state int64_t completedCount = 0;
-	state int64_t totalCount = 0;
 	state std::vector<AuditStorageState> auditStates;
+	state int64_t issueDoAuditCount = 0;
+
 	try {
 		while (begin < allKeys.end) {
 			currentRange = KeyRangeRef(begin, allKeys.end);
@@ -2131,11 +2131,9 @@ ACTOR Future<Void> scheduleAuditStorageShardOnServer(Reference<DataDistributor> 
 			for (; i < auditStates.size(); i++) {
 				state AuditPhase phase = auditStates[i].getPhase();
 				ASSERT(phase != AuditPhase::Running && phase != AuditPhase::Failed);
-				totalCount++;
 				if (phase == AuditPhase::Complete) {
-					completedCount++;
+					continue; // pass
 				} else if (phase == AuditPhase::Error) {
-					completedCount++;
 					audit->foundError = true;
 				} else {
 					ASSERT(phase == AuditPhase::Invalid);
@@ -2154,25 +2152,33 @@ ACTOR Future<Void> scheduleAuditStorageShardOnServer(Reference<DataDistributor> 
 						    SERVER_KNOBS->CONCURRENT_AUDIT_TASK_COUNT_MAX - 1);
 					}
 					AuditStorageRequest req(audit->coreState.id, auditStates[i].range, auditType);
+					// Since remaining part is always successcive
+					// We always issue exactly one audit task (for the remaining part) when schedule
+					ASSERT(issueDoAuditCount == 0);
+					issueDoAuditCount++;
 					audit->actors.add(doAuditOnStorageServer(self, audit, ssi, req));
 				}
 			}
 			wait(delay(0.1));
 		}
+
 		TraceEvent(SevInfo, "DDScheduleAuditStorageShardOnServerEnd", self->ddId)
 		    .detail("ServerID", serverId)
 		    .detail("AuditID", audit->coreState.id)
 		    .detail("AuditType", auditType)
-		    .detail("TotalRanges", totalCount)
-		    .detail("TotalComplete", completedCount)
-		    .detail("CompleteRatio", completedCount * 1.0 / totalCount);
+		    .detail("IssuedDoAuditCount", issueDoAuditCount);
 
 	} catch (Error& e) {
-		TraceEvent(SevWarn, "DDScheduleAuditStorageShardOnServerError", self->ddId)
+		TraceEvent(SevInfo, "DDScheduleAuditStorageShardOnServerError", self->ddId)
 		    .errorUnsuppressed(e)
 		    .detail("AuditID", audit->coreState.id)
-		    .detail("AuditType", auditType);
-		audit->anyChildAuditFailed = true;
+		    .detail("AuditType", auditType)
+		    .detail("IssuedDoAuditCount", issueDoAuditCount);
+		if (e.code() == error_code_actor_cancelled) {
+			throw e;
+		} else {
+			audit->auditStorageAnyChildFailed = true;
+		}
 	}
 
 	return Void();
@@ -2244,7 +2250,11 @@ ACTOR Future<Void> dispatchAuditStorage(Reference<DataDistributor> self,
 		    .errorUnsuppressed(e)
 		    .detail("AuditID", audit->coreState.id)
 		    .detail("AuditType", auditType);
-		audit->anyChildAuditFailed = true;
+		if (e.code() == error_code_actor_cancelled) {
+			throw e;
+		} else {
+			audit->auditStorageAnyChildFailed = true;
+		}
 	}
 
 	return Void();
@@ -2252,6 +2262,7 @@ ACTOR Future<Void> dispatchAuditStorage(Reference<DataDistributor> self,
 
 // Partition the input range into multiple subranges according to the range ownership, and
 // schedule ha/replica/locationmetadata audit tasks of each subrange on the server which owns the subrange
+// Automatically retry until complete or timed out
 ACTOR Future<Void> scheduleAuditOnRange(Reference<DataDistributor> self,
                                         std::shared_ptr<DDAudit> audit,
                                         KeyRange range) {
@@ -2262,6 +2273,7 @@ ACTOR Future<Void> scheduleAuditOnRange(Reference<DataDistributor> self,
 	    .detail("AuditType", auditType);
 	state Key begin = range.begin;
 	state KeyRange currentRange;
+	state int64_t issueDoAuditCount = 0;
 
 	try {
 		while (begin < range.end) {
@@ -2272,93 +2284,127 @@ ACTOR Future<Void> scheduleAuditOnRange(Reference<DataDistributor> self,
 			    .detail("AuditType", auditType);
 			state std::vector<IDDTxnProcessor::DDRangeLocations> rangeLocations =
 			    wait(self->txnProcessor->getSourceServerInterfacesForRange(currentRange));
-
+			// Divide the audit job in to tasks according to KeyServers system mapping
 			state int i = 0;
 			for (i = 0; i < rangeLocations.size(); ++i) {
-				state AuditStorageRequest req(audit->coreState.id, rangeLocations[i].range, auditType);
-				state StorageServerInterface targetServer;
-				// Set req.targetServers and targetServer, which will be
-				// used to doAuditOnStorageServer
-				// Different audit types have different settings
-				if (auditType == AuditType::ValidateHA) {
-					if (rangeLocations[i].servers.size() < 2) {
-						TraceEvent(SevInfo, "DDScheduleAuditOnRangeEnd", self->ddId)
-						    .detail("Reason", "Single replica, ignore")
-						    .detail("AuditID", audit->coreState.id)
-						    .detail("Range", range)
-						    .detail("AuditType", auditType);
-						return Void();
-					}
-					// pick a server from primary DC
-					auto it = rangeLocations[i].servers.begin();
-					const int idx = deterministicRandom()->randomInt(0, it->second.size());
-					targetServer = it->second[idx];
-					++it;
-					// pick a server from each remote DC
-					for (; it != rangeLocations[i].servers.end(); ++it) {
-						const int idx = deterministicRandom()->randomInt(0, it->second.size());
-						req.targetServers.push_back(it->second[idx].id());
-					}
-				} else if (auditType == AuditType::ValidateReplica) {
-					auto it = rangeLocations[i].servers.begin(); // always compare primary DC
-					if (it->second.size() == 1) {
-						TraceEvent(SevInfo, "DDScheduleAuditOnRangeEnd", self->ddId)
-						    .detail("Reason", "Single replica, ignore")
-						    .detail("AuditID", audit->coreState.id)
-						    .detail("Range", range)
-						    .detail("AuditType", auditType);
-						return Void();
-					}
-					ASSERT(it->second.size() >= 2);
-					const int idx = deterministicRandom()->randomInt(0, it->second.size());
-					targetServer = it->second[idx];
-					for (int i = 0; i < it->second.size(); ++i) {
-						if (i == idx) {
+				// For each task, check the progress, and create task request for the unfinished range
+				state KeyRange taskRange = rangeLocations[i].range;
+				state Key taskRangeBegin = taskRange.begin;
+				while (taskRangeBegin < taskRange.end) {
+					state std::vector<AuditStorageState> auditStates =
+					    wait(getAuditStateByRange(self->txnProcessor->context(),
+					                              auditType,
+					                              audit->coreState.id,
+					                              KeyRangeRef(taskRangeBegin, taskRange.end)));
+					ASSERT(!auditStates.empty());
+					taskRangeBegin = auditStates.back().range.end;
+					state int j = 0;
+					for (j = 0; j < auditStates.size(); ++j) {
+						state AuditPhase phase = auditStates[j].getPhase();
+						ASSERT(phase != AuditPhase::Running && phase != AuditPhase::Failed);
+						if (phase == AuditPhase::Complete) {
+							continue;
+						} else if (phase == AuditPhase::Error) {
+							audit->foundError = true;
 							continue;
 						}
-						req.targetServers.push_back(it->second[i].id());
+						// Create audit task for the range where the phase is Invalid which indicates
+						// this range has not been audited
+						ASSERT(phase == AuditPhase::Invalid);
+						state AuditStorageRequest req(audit->coreState.id, auditStates[j].range, auditType);
+						state StorageServerInterface targetServer;
+						// Set req.targetServers and targetServer, which will be
+						// used to doAuditOnStorageServer
+						// Different audit types have different settings
+						if (auditType == AuditType::ValidateHA) {
+							if (rangeLocations[i].servers.size() < 2) {
+								TraceEvent(SevInfo, "DDScheduleAuditOnRangeEnd", self->ddId)
+								    .detail("Reason", "Single replica, ignore")
+								    .detail("AuditID", audit->coreState.id)
+								    .detail("Range", range)
+								    .detail("AuditType", auditType);
+								return Void();
+							}
+							// pick a server from primary DC
+							auto it = rangeLocations[i].servers.begin();
+							const int idx = deterministicRandom()->randomInt(0, it->second.size());
+							targetServer = it->second[idx];
+							++it;
+							// pick a server from each remote DC
+							for (; it != rangeLocations[i].servers.end(); ++it) {
+								const int idx = deterministicRandom()->randomInt(0, it->second.size());
+								req.targetServers.push_back(it->second[idx].id());
+							}
+						} else if (auditType == AuditType::ValidateReplica) {
+							auto it = rangeLocations[i].servers.begin(); // always compare primary DC
+							if (it->second.size() == 1) {
+								TraceEvent(SevInfo, "DDScheduleAuditOnRangeEnd", self->ddId)
+								    .detail("Reason", "Single replica, ignore")
+								    .detail("AuditID", audit->coreState.id)
+								    .detail("Range", range)
+								    .detail("AuditType", auditType);
+								return Void();
+							}
+							ASSERT(it->second.size() >= 2);
+							const int idx = deterministicRandom()->randomInt(0, it->second.size());
+							targetServer = it->second[idx];
+							for (int i = 0; i < it->second.size(); ++i) {
+								if (i == idx) {
+									continue;
+								}
+								req.targetServers.push_back(it->second[i].id());
+							}
+						} else if (audit->coreState.getType() == AuditType::ValidateLocationMetadata) {
+							auto it = rangeLocations[i].servers.begin(); // always do in primary DC
+							const int idx = deterministicRandom()->randomInt(0, it->second.size());
+							targetServer = it->second[idx];
+						} else {
+							UNREACHABLE();
+						}
+						// Set doAuditOnStorageServer
+						if (self->remainingBudgetForAuditTasks.contains(auditType)) {
+							ASSERT(self->remainingBudgetForAuditTasks[auditType].get() >= 0);
+							while (self->remainingBudgetForAuditTasks[auditType].get() == 0) {
+								wait(self->remainingBudgetForAuditTasks[auditType].onChange());
+								ASSERT(self->remainingBudgetForAuditTasks[auditType].get() >= 0);
+							}
+							self->remainingBudgetForAuditTasks[auditType].set(
+							    self->remainingBudgetForAuditTasks[auditType].get() - 1);
+							ASSERT(self->remainingBudgetForAuditTasks[auditType].get() >= 0);
+						} else {
+							self->remainingBudgetForAuditTasks[auditType].set(
+							    SERVER_KNOBS->CONCURRENT_AUDIT_TASK_COUNT_MAX - 1);
+						}
+						issueDoAuditCount++;
+						audit->actors.add(doAuditOnStorageServer(self, audit, targetServer, req));
 					}
-				} else if (audit->coreState.getType() == AuditType::ValidateLocationMetadata) {
-					auto it = rangeLocations[i].servers.begin(); // always do in primary DC
-					const int idx = deterministicRandom()->randomInt(0, it->second.size());
-					targetServer = it->second[idx];
-				} else {
-					UNREACHABLE();
 				}
-				// Set doAuditOnStorageServer
-				if (self->remainingBudgetForAuditTasks.contains(auditType)) {
-					ASSERT(self->remainingBudgetForAuditTasks[auditType].get() >= 0);
-					while (self->remainingBudgetForAuditTasks[auditType].get() == 0) {
-						wait(self->remainingBudgetForAuditTasks[auditType].onChange());
-						ASSERT(self->remainingBudgetForAuditTasks[auditType].get() >= 0);
-					}
-					self->remainingBudgetForAuditTasks[auditType].set(
-					    self->remainingBudgetForAuditTasks[auditType].get() - 1);
-					ASSERT(self->remainingBudgetForAuditTasks[auditType].get() >= 0);
-				} else {
-					self->remainingBudgetForAuditTasks[auditType].set(SERVER_KNOBS->CONCURRENT_AUDIT_TASK_COUNT_MAX -
-					                                                  1);
-				}
-				audit->actors.add(doAuditOnStorageServer(self, audit, targetServer, req));
+
 				// Proceed to the next range if getSourceServerInterfacesForRange is partially read
 				begin = rangeLocations[i].range.end;
 				wait(delay(0.1));
 			}
 		}
+
 		TraceEvent(SevDebug, "DDScheduleAuditOnRangeEnd", self->ddId)
 		    .detail("Reason", "End")
 		    .detail("AuditID", audit->coreState.id)
 		    .detail("Range", range)
 		    .detail("AuditType", auditType)
-		    .detail("IssuedDoAuditCount", audit->issueDoAuditCount);
+		    .detail("IssuedDoAuditCountInThisSchedule", issueDoAuditCount);
 
 	} catch (Error& e) {
-		TraceEvent(SevWarn, "DDScheduleAuditOnRangeError", self->ddId)
+		TraceEvent(SevInfo, "DDScheduleAuditOnRangeError", self->ddId)
 		    .errorUnsuppressed(e)
 		    .detail("AuditID", audit->coreState.id)
 		    .detail("Range", range)
-		    .detail("AuditType", auditType);
-		audit->anyChildAuditFailed = true;
+		    .detail("AuditType", auditType)
+		    .detail("IssuedDoAuditCount", issueDoAuditCount);
+		if (e.code() == error_code_actor_cancelled) {
+			throw e;
+		} else {
+			audit->auditStorageAnyChildFailed = true;
+		}
 	}
 
 	return Void();
@@ -2371,57 +2417,77 @@ ACTOR Future<Void> doAuditOnStorageServer(Reference<DataDistributor> self,
                                           std::shared_ptr<DDAudit> audit,
                                           StorageServerInterface ssi,
                                           AuditStorageRequest req) {
+	state AuditType auditType = req.getType();
 	TraceEvent(SevDebug, "DDDoAuditOnStorageServerBegin", self->ddId)
 	    .detail("AuditID", req.id)
 	    .detail("Range", req.range)
-	    .detail("AuditType", req.getType())
+	    .detail("AuditType", auditType)
 	    .detail("StorageServer", ssi.toString())
-	    .detail("TargetServers", describe(req.targetServers));
+	    .detail("TargetServers", describe(req.targetServers))
+	    .detail("DDDoAuditTaskIssue", audit->overallIssuedDoAuditCount)
+	    .detail("DDDoAuditTaskComplete", audit->overallCompleteDoAuditCount);
 
 	try {
-		audit->issueDoAuditCount++;
+		audit->overallIssuedDoAuditCount++;
 		ErrorOr<AuditStorageState> vResult = wait(ssi.auditStorage.getReplyUnlessFailedFor(
 		    req, /*sustainedFailureDuration=*/2.0, /*sustainedFailureSlope=*/0));
 		if (vResult.isError()) {
 			throw vResult.getError();
 		}
-		audit->completeDoAuditCount++;
+		audit->overallCompleteDoAuditCount++;
 		TraceEvent(SevInfo, "DDDoAuditOnStorageServerResult", self->ddId)
 		    .detail("AuditID", req.id)
 		    .detail("Range", req.range)
-		    .detail("AuditType", req.getType())
+		    .detail("AuditType", auditType)
 		    .detail("StorageServer", ssi.toString())
 		    .detail("TargetServers", describe(req.targetServers))
-		    .detail("DDDoAuditTaskIssue", audit->issueDoAuditCount)
-		    .detail("DDDoAuditTaskComplete", audit->completeDoAuditCount);
+		    .detail("DDDoAuditTaskIssue", audit->overallIssuedDoAuditCount)
+		    .detail("DDDoAuditTaskComplete", audit->overallCompleteDoAuditCount);
+		ASSERT(self->remainingBudgetForAuditTasks.contains(auditType));
+		self->remainingBudgetForAuditTasks[auditType].set(self->remainingBudgetForAuditTasks[auditType].get() + 1);
+		ASSERT(self->remainingBudgetForAuditTasks[auditType].get() <= SERVER_KNOBS->CONCURRENT_AUDIT_TASK_COUNT_MAX);
 
 	} catch (Error& e) {
 		TraceEvent(SevInfo, "DDDoAuditOnStorageServerError", req.id)
 		    .errorUnsuppressed(e)
 		    .detail("AuditID", req.id)
 		    .detail("Range", req.range)
-		    .detail("AuditType", req.getType())
+		    .detail("AuditType", auditType)
 		    .detail("StorageServer", ssi.toString())
-		    .detail("TargetServers", describe(req.targetServers));
+		    .detail("TargetServers", describe(req.targetServers))
+		    .detail("DDDoAuditTaskIssue", audit->overallIssuedDoAuditCount)
+		    .detail("DDDoAuditTaskComplete", audit->overallCompleteDoAuditCount);
+		ASSERT(self->remainingBudgetForAuditTasks.contains(auditType));
+		self->remainingBudgetForAuditTasks[auditType].set(self->remainingBudgetForAuditTasks[auditType].get() + 1);
+		ASSERT(self->remainingBudgetForAuditTasks[auditType].get() <= SERVER_KNOBS->CONCURRENT_AUDIT_TASK_COUNT_MAX);
+
 		if (e.code() == error_code_actor_cancelled) {
-			ASSERT(self->remainingBudgetForAuditTasks.contains(req.getType()));
-			self->remainingBudgetForAuditTasks[req.getType()].set(
-			    self->remainingBudgetForAuditTasks[req.getType()].get() + 1);
-			ASSERT(self->remainingBudgetForAuditTasks[req.getType()].get() <=
-			       SERVER_KNOBS->CONCURRENT_AUDIT_TASK_COUNT_MAX);
 			throw e;
 		} else if (e.code() == error_code_audit_storage_error) {
 			audit->foundError = true;
+		} else if (audit->retryCount >= SERVER_KNOBS->AUDIT_RETRY_COUNT_MAX) {
+			throw audit_storage_failed();
 		} else {
-			// Since doAuditOnStorageServers is stateful
-			// Any doAuditOnStorageServer failure should not stop other doAuditOnStorageServers
-			// We want to retry when other doAuditOnStorageServers complete
-			audit->anyChildAuditFailed = true;
+			if (req.getType() == AuditType::ValidateStorageServerShard) {
+				if (e.code() != error_code_audit_storage_failed) {
+					try {
+						bool ssRemoved = wait(checkStorageServerRemoved(self->txnProcessor->context(), ssi.uniqueID));
+						if (ssRemoved) {
+							// It is possible that the input ss has been removed, then silently exit
+							return Void();
+						}
+					} catch (Error& e) {
+						// retry
+					}
+				}
+				audit->retryCount++;
+				audit->actors.add(scheduleAuditStorageShardOnServer(self, audit, ssi));
+			} else {
+				audit->retryCount++;
+				audit->actors.add(scheduleAuditOnRange(self, audit, req.range));
+			}
 		}
 	}
-	ASSERT(self->remainingBudgetForAuditTasks.contains(req.getType()));
-	self->remainingBudgetForAuditTasks[req.getType()].set(self->remainingBudgetForAuditTasks[req.getType()].get() + 1);
-	ASSERT(self->remainingBudgetForAuditTasks[req.getType()].get() <= SERVER_KNOBS->CONCURRENT_AUDIT_TASK_COUNT_MAX);
 	return Void();
 }
 

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -5285,7 +5285,7 @@ ACTOR Future<Void> auditStorageStorageServerShardQ(StorageServer* data, AuditSto
 	ASSERT(req.getType() == AuditType::ValidateStorageServerShard);
 	wait(data->serveAuditStorageParallelismLock.take(TaskPriority::DefaultYield));
 	state FlowLock::Releaser holder(data->serveAuditStorageParallelismLock);
-	TraceEvent(SevInfo, "AuditStorageShardStorageServerShardBegin", data->thisServerID)
+	TraceEvent(SevInfo, "AuditStorageSsShardBegin", data->thisServerID)
 	    .detail("AuditId", req.id)
 	    .detail("AuditRange", req.range);
 	state AuditStorageState res(req.id, data->thisServerID, req.getType());
@@ -5361,7 +5361,15 @@ ACTOR Future<Void> auditStorageStorageServerShardQ(StorageServer* data, AuditSto
 				ownRangesSeenByServerKey = serverKeyRes.ownRanges;
 			} // retry until serverKeyReadAtVersion is as larger as localShardInfoReadAtVersion
 			ASSERT(serverKeyReadAtVersion >= localShardInfoReadAtVersion);
-			wait(data->version.whenAtLeast(serverKeyReadAtVersion));
+			try {
+				wait(timeoutError(data->version.whenAtLeast(serverKeyReadAtVersion), 30));
+			} catch (Error& e) {
+				TraceEvent(SevWarn, "AuditStorageSsShardWaitSSVersionTooLong", data->thisServerID)
+				    .detail("ServerKeyReadAtVersion", serverKeyReadAtVersion)
+				    .detail("SSVersion", data->version.get());
+				failureReason = "SS version takes long time to catch up with serverKeyReadAtVersion";
+				throw audit_storage_failed();
+			}
 			// At this point, shard assignment history guarantees to contain assignments
 			// upto serverKeyReadAtVersion
 
@@ -5372,7 +5380,7 @@ ACTOR Future<Void> auditStorageStorageServerShardQ(StorageServer* data, AuditSto
 			// check any serverKey update between localShardInfoReadAtVersion and serverKeyReadAtVersion
 			std::vector<std::pair<Version, KeyRangeRef>> shardAssignments =
 			    data->getShardAssignmentHistory(localShardInfoReadAtVersion, serverKeyReadAtVersion);
-			TraceEvent(SevInfo, "AuditStorageShardStorageServerShardGetHistory", data->thisServerID)
+			TraceEvent(SevInfo, "AuditStorageSsShardGetHistory", data->thisServerID)
 			    .detail("AuditId", req.id)
 			    .detail("AuditRange", req.range)
 			    .detail("ServerKeyAtVersion", serverKeyReadAtVersion)
@@ -5398,7 +5406,7 @@ ACTOR Future<Void> auditStorageStorageServerShardQ(StorageServer* data, AuditSto
 				}
 				ownRangesLocalView.push_back(overlappingRange);
 			}
-			TraceEvent(SevInfo, "AuditStorageShardStorageServerShardReadDone", data->thisServerID)
+			TraceEvent(SevInfo, "AuditStorageSsShardReadDone", data->thisServerID)
 			    .detail("AuditId", req.id)
 			    .detail("AuditRange", req.range)
 			    .detail("ClaimRange", claimRange)
@@ -5431,7 +5439,7 @@ ACTOR Future<Void> auditStorageStorageServerShardQ(StorageServer* data, AuditSto
 				           data->thisServerID.toString().c_str(),
 				           mismatchedRangeByServerKey.toString().c_str(),
 				           mismatchedRangeByLocalView.toString().c_str());
-				TraceEvent(SevError, "AuditStorageShardStorageServerShardError", data->thisServerID)
+				TraceEvent(SevError, "AuditStorageSsShardError", data->thisServerID)
 				    .detail("AuditId", req.id)
 				    .detail("AuditRange", req.range)
 				    .detail("ClaimRange", claimRange)
@@ -5444,7 +5452,7 @@ ACTOR Future<Void> auditStorageStorageServerShardQ(StorageServer* data, AuditSto
 
 			// Return result
 			if (!errors.empty()) {
-				TraceEvent(SevVerbose, "AuditStorageShardStorageServerShardErrorEnd", data->thisServerID)
+				TraceEvent(SevVerbose, "AuditStorageSsShardErrorEnd", data->thisServerID)
 				    .detail("AuditId", req.id)
 				    .detail("AuditRange", req.range)
 				    .detail("AuditServer", data->thisServerID);
@@ -5458,7 +5466,7 @@ ACTOR Future<Void> auditStorageStorageServerShardQ(StorageServer* data, AuditSto
 				res.range = Standalone(KeyRangeRef(req.range.begin, claimRange.end));
 				res.setPhase(AuditPhase::Complete);
 				wait(persistAuditStateByServer(data->cx, res));
-				TraceEvent(SevInfo, "AuditStorageShardStorageServerShardDone", data->thisServerID)
+				TraceEvent(SevInfo, "AuditStorageSsShardDone", data->thisServerID)
 				    .detail("AuditId", req.id)
 				    .detail("AuditRange", req.range)
 				    .detail("AuditServer", data->thisServerID)
@@ -5476,7 +5484,7 @@ ACTOR Future<Void> auditStorageStorageServerShardQ(StorageServer* data, AuditSto
 			}
 		}
 	} catch (Error& e) {
-		TraceEvent(SevInfo, "AuditStorageShardStorageServerShardFailed", data->thisServerID)
+		TraceEvent(SevInfo, "AuditStorageSsShardFailed", data->thisServerID)
 		    .errorUnsuppressed(e)
 		    .detail("AuditId", req.id)
 		    .detail("AuditRange", req.range)
@@ -5714,7 +5722,7 @@ ACTOR Future<Void> auditStorageLocationMetadataQ(StorageServer* data, AuditStora
 		}
 
 	} catch (Error& e) {
-		TraceEvent(SevInfo, "AuditStorageShardStorageServerShardFailed", data->thisServerID)
+		TraceEvent(SevInfo, "AuditStorageShardLocMetadataFailed", data->thisServerID)
 		    .errorUnsuppressed(e)
 		    .detail("AuditId", req.id)
 		    .detail("AuditRange", req.range)

--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -1373,8 +1373,8 @@ ACTOR Future<bool> runTest(Database cx,
 				ok = false;
 			}
 
-			// Run auditStorage
-			if (quiescent) {
+			// Run auditStorage at the end of simulation
+			if (quiescent && g_network->isSimulated()) {
 				try {
 					TraceEvent("AuditStorageStart");
 					wait(timeoutError(auditStorageCorrectness(dbInfo, AuditType::ValidateHA), 1000.0));


### PR DESCRIPTION
Cherry-pick https://github.com/apple/foundationdb/pull/10245

100K Correctness Test with 3 irrelevant failures:
  20230522-194814-zhewang-7c1f81f8d6f51e34           compressed=True data_size=33221184 duration=4942087 ended=100000 fail=3 fail_fast=10 max_runs=100000 pass=99997 priority=100 remaining=0 runtime=1:18:30 sanity=False started=100000 stopped=20230522-210644 submitted=20230522-194814 timeout=5400 username=zhewang

100K ValidateStorage Test:
  20230522-194906-zhewang-b5abc3bf0a145e3e           compressed=True data_size=33255889 duration=3991974 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:00:04 sanity=False started=100000 stopped=20230522-204910 submitted=20230522-194906 timeout=5400 username=zhewang

Tested by test_shardedrocksdb_audit.run

Replace this text with your description here...

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
