### PR TITLE
Slow down wiggler when in ConsistencyCheck [release-7.3]

### DIFF
--- a/fdbrpc/include/fdbrpc/simulator.h
+++ b/fdbrpc/include/fdbrpc/simulator.h
@@ -340,6 +340,7 @@ public:
 	BackupAgentType drAgents;
 	bool willRestart = false;
 	bool restarted = false;
+	bool isConsistencyChecked = false;
 	ValidationData validationData;
 
 	bool hasDiffProtocolProcess; // true if simulator is testing a process with a different version

--- a/fdbserver/DDTeamCollection.actor.cpp
+++ b/fdbserver/DDTeamCollection.actor.cpp
@@ -1959,7 +1959,7 @@ public:
 	}
 
 	ACTOR static Future<Void> waitPerpetualWiggleDelay(DDTeamCollection* self) {
-		if (g_network->isSimulated() && g_simulator->speedUpSimulation) {
+		if (g_network->isSimulated() && g_simulator->isConsistencyChecked) {
 			// Wiggle can cause consistency check to repeatedly restart. So we want to
 			// slow it down to avoid consistency check timeout.
 			wait(delay(300));

--- a/fdbserver/DDTeamCollection.actor.cpp
+++ b/fdbserver/DDTeamCollection.actor.cpp
@@ -19,10 +19,12 @@
  */
 
 #include "fdbserver/DDTeamCollection.h"
+#include "fdbrpc/simulator.h"
 #include "fdbserver/ExclusionTracker.actor.h"
 #include "fdbserver/DataDistributionTeam.h"
 #include "flow/Trace.h"
 #include "flow/actorcompiler.h" // This must be the last #include.
+#include "flow/network.h"
 #include <climits>
 
 namespace {
@@ -1957,7 +1959,12 @@ public:
 	}
 
 	ACTOR static Future<Void> waitPerpetualWiggleDelay(DDTeamCollection* self) {
-		if (SERVER_KNOBS->PERPETUAL_WIGGLE_DELAY <= 60.0) {
+		if (g_network->isSimulated() && g_simulator->speedUpSimulation) {
+			// Wiggle can cause consistency check to repeatedly restart. So we want to
+			// slow it down to avoid consistency check timeout.
+			wait(delay(300));
+			return Void();
+		} else if (SERVER_KNOBS->PERPETUAL_WIGGLE_DELAY <= 60.0) {
 			wait(delay(SERVER_KNOBS->PERPETUAL_WIGGLE_DELAY));
 			return Void();
 		}

--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -1253,6 +1253,7 @@ ACTOR Future<Void> checkConsistency(Database cx,
 		// NOTE: the value will be reset after consistency check
 		connectionFailures = g_simulator->connectionFailuresDisableDuration;
 		disableConnectionFailures("ConsistencyCheck");
+		g_simulator->isConsistencyChecked = true;
 	}
 
 	Standalone<VectorRef<KeyValueRef>> options;
@@ -1290,6 +1291,7 @@ ACTOR Future<Void> checkConsistency(Database cx,
 		if (testResults.ok() || lastRun) {
 			if (g_network->isSimulated()) {
 				g_simulator->connectionFailuresDisableDuration = connectionFailures;
+				g_simulator->isConsistencyChecked = false;
 			}
 			return Void();
 		}


### PR DESCRIPTION
cherrypick #10320

Storage wiggle can cause consistency check to restart due to wrong_shard_server error. This can sometimes repeatedly happen and cause consistency check timeout.

Reproduction:
  seed: -f ./tests/fast/MutationLogReaderCorrectness.toml -s 575471711 -b on
  commit: 2e62b577f at release-7.1
  build: clang

20230523-192435-jzhou-2440f73df4b213f6
20230524-212519-jzhou-a42df3d2ae471197

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
