### PR TITLE
[snowflake/release-71.3] Fix two bugs in checkExclusion() and add a trace event for better observability (cherry-pick #10330)

### DIFF
--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -1024,6 +1024,9 @@ ACTOR Future<bool> checkExclusion(Database db,
 			for (StatusObjectReader role : rolesArray) {
 				if (role["role"].get_str() == "storage") {
 					ssTotalCount++;
+					if (excluded) {
+						ssExcludedCount++;
+					}
 
 					int64_t used_bytes;
 					if (!role.get("kvstore_used_bytes", used_bytes)) {
@@ -1060,10 +1063,6 @@ ACTOR Future<bool> checkExclusion(Database db,
 							}
 						}
 					}
-				}
-
-				if (excluded) {
-					ssExcludedCount++;
 				}
 			}
 		}

--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -999,7 +999,7 @@ ACTOR Future<bool> checkExclusion(Database db,
 	state int64_t totalKvStoreFreeBytes = 0;
 	state int64_t totalKvStoreFreeBytesNotExcluded = 0;
 	state int64_t totalKvStoreUsedBytes = 0;
-	state int64_t totalKvStoreUsedBytesNonExcluded = 0;
+	state int64_t totalKvStoreUsedBytesNotExcluded = 0;
 	state int64_t totalKvStoreAvailableBytes = 0;
 
 	try {
@@ -1051,7 +1051,7 @@ ACTOR Future<bool> checkExclusion(Database db,
 					totalKvStoreAvailableBytes += available_bytes;
 
 					if (!excluded) {
-						totalKvStoreUsedBytesNonExcluded += used_bytes;
+						totalKvStoreUsedBytesNotExcluded += used_bytes;
 
 						if (disk_id.empty() || diskLocalities.find(disk_id) == diskLocalities.end()) {
 							totalKvStoreFreeBytesNotExcluded += free_bytes;
@@ -1075,10 +1075,20 @@ ACTOR Future<bool> checkExclusion(Database db,
 
 	// The numerator is the total space in use by FDB that is not immediately reusable.
 	// This is calculated as: used + free - available = used + free - (free - reusable) = used - reusable.
-	// The denominator is the total capacity usable by FDB (either used or unused currently).
+	// The denominator is the total capacity usable by FDB (either used or unused currently) on non-excluded servers.
 	double finalUnavailableRatio =
-	    (totalKvStoreUsedBytes + totalKvStoreFreeBytes - totalKvStoreAvailableBytes) /
-	    std::max((totalKvStoreUsedBytesNonExcluded + totalKvStoreFreeBytesNotExcluded), (int64_t)1);
+	    (double)(totalKvStoreUsedBytes + totalKvStoreFreeBytes - totalKvStoreAvailableBytes) /
+	    std::max((double)(totalKvStoreUsedBytesNotExcluded + totalKvStoreFreeBytesNotExcluded), (double)1);
+
+	TraceEvent(SevInfo, "CheckExclusionDetails")
+	    .detail("SsTotalCount", ssTotalCount)
+	    .detail("SsExcludedCount", ssExcludedCount)
+	    .detail("FinalUnavailableRatio", finalUnavailableRatio)
+	    .detail("TotalKvStoreUsedBytes", totalKvStoreUsedBytes)
+	    .detail("TotalKvStoreFreeBytes", totalKvStoreFreeBytes)
+	    .detail("TotalKvStoreAvailableBytes", totalKvStoreAvailableBytes)
+	    .detail("TotalKvStoreUsedBytesNotExcluded", totalKvStoreUsedBytesNotExcluded)
+	    .detail("TotalKvStoreFreeBytesNotExcluded", totalKvStoreFreeBytesNotExcluded);
 
 	if (ssExcludedCount == ssTotalCount || finalUnavailableRatio > 0.9) {
 		std::string temp = "ERROR: This exclude may cause the total available space in the cluster to drop below 10%.\n"


### PR DESCRIPTION
Cherrypick https://github.com/apple/foundationdb/pull/10330.

This is being included in 71.3.0 since this is a client side change that fixes a bugs in a command that has been causing issues during cluster wiggles.
100K run ensemble: `20230523-233454-akejriwal-94ed3ee54ac2e64a`: all tests pass

Original description:
This PR fixes two bugs in checkExclusion():

Increment ssExcludedCount only if the role is storage. (It was previously incrementing this number regardless of the role, and then comparing it to ssTotalCount which is only updated when the role is storage.)
Fix the computation of finalUnavailableRatio to use a double division. (It was previously using a integer division which truncates the result.)
Also add a trace event which exposes the aggregate metrics used in checkExclusion() which can be used if the the function shows unexpected behavior.

This has been tested on an FDB cluster. Previously, the exclude command had been failing on this cluster (when it shouldn't have been), but after this fix, the command succeeded. This trace event (as well as more detailed temporary trace events) showed the expected numbers.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
