### PR TITLE
fixing consistency scan loop and completion check

### DIFF
--- a/fdbserver/ConsistencyScan.actor.cpp
+++ b/fdbserver/ConsistencyScan.actor.cpp
@@ -745,8 +745,7 @@ ACTOR Future<Void> consistencyScanCore(Database db,
 
 						if (DEBUG_SCAN_PROGRESS) {
 							TraceEvent(SevDebug, "ConsistencyScanProgressRoundComplete", memState->csId)
-							    .detail("BytesRead", logicalBytesRead)
-							    .detail("ProgressKey", statsCurrentRound.lastEndKey);
+							    .detail("BytesRead", statsCurrentRound.logicalBytesScanned);
 						}
 
 						// Return to main loop after this commit, but delay first for the difference between the time

--- a/fdbserver/ConsistencyScan.actor.cpp
+++ b/fdbserver/ConsistencyScan.actor.cpp
@@ -636,7 +636,8 @@ ACTOR Future<Void> consistencyScanCore(Database db,
 
 					if (scanRange) {
 						if (DEBUG_SCAN_PROGRESS) {
-							TraceEvent(SevDebug, "ConsistencyScanProgressScanRangeStart", memState->csId);
+							TraceEvent(SevDebug, "ConsistencyScanProgressScanRangeStart", memState->csId)
+							    .detail("StartKey", targetRange.begin);
 						}
 						// Stats for *this unit of durable progress only*, which will be committed atomically with the
 						// endKey update. Total bytes from all replicas read
@@ -702,9 +703,14 @@ ACTOR Future<Void> consistencyScanCore(Database db,
 									}
 								}
 							} else {
-								TraceEvent("ConsistencyScan_FailedRequest", memState->csId)
-								    .errorUnsuppressed(failedRequest.get())
-								    .suppressFor(5.0);
+								// transaction too old expected here for large shards
+								CODE_PROBE(failedRequest.get().code() == error_code_transaction_too_old,
+								           "consistency scan loop shard too large for one transaction");
+								if (failedRequest.get().code() != error_code_transaction_too_old) {
+									TraceEvent("ConsistencyScan_FailedRequest", memState->csId)
+									    .errorUnsuppressed(failedRequest.get())
+									    .suppressFor(5.0);
+								}
 								// FIXME: increment failed request count if error present
 								ASSERT(failedRequest.get().code() != error_code_operation_cancelled);
 								break;
@@ -737,6 +743,12 @@ ACTOR Future<Void> consistencyScanCore(Database db,
 						statsCurrentRound.lastEndKey = Key();
 						statsCurrentRound.complete = true;
 
+						if (DEBUG_SCAN_PROGRESS) {
+							TraceEvent(SevDebug, "ConsistencyScanProgressRoundComplete", memState->csId)
+							    .detail("BytesRead", logicalBytesRead)
+							    .detail("ProgressKey", statsCurrentRound.lastEndKey);
+						}
+
 						// Return to main loop after this commit, but delay first for the difference between the time
 						// the round took and minRoundTimeSeconds
 						restartMainLoop = true;
@@ -745,16 +757,6 @@ ACTOR Future<Void> consistencyScanCore(Database db,
 						    0.0));
 					}
 
-					// Save updated stats.
-					cs.currentRoundStats().set(tr, statsCurrentRound);
-					cs.lifetimeStats().set(tr, statsLifetime);
-
-					wait(tr->commit());
-					if (DEBUG_SCAN_PROGRESS) {
-						TraceEvent(SevDebug, "ConsistencyScanProgress_RoundComplete", memState->csId)
-						    .detail("BytesRead", statsCurrentRound.logicalBytesScanned)
-						    .detail("ProgressKey", statsCurrentRound.lastEndKey);
-					}
 					// fmt::print("CONSISTENCY SCAN PROGRESS: {}\n",
 					//            json_spirit::write_string(json_spirit::mValue(statsCurrentRound.toJSON())));
 					break;
@@ -764,7 +766,7 @@ ACTOR Future<Void> consistencyScanCore(Database db,
 					    e.code() == error_code_all_alternatives_failed || e.code() == error_code_process_behind) {
 						// sleep for a bit extra
 						totalReadBytesFromStorageServers += 100000;
-						tr->reset();
+						break;
 					} else {
 						try {
 							wait(tr->onError(e));
@@ -774,10 +776,56 @@ ACTOR Future<Void> consistencyScanCore(Database db,
 						}
 					}
 				}
-			} // Transaction retry loop for making one increment of durable progress
+			} // Transaction retry loop for making one increment of progress
 
-			if (DEBUG_SCAN_PROGRESS) {
-				TraceEvent(SevDebug, "ConsistencyScanProgressScanLoopDurable", memState->csId);
+			// Save updated stats if we made progress. Do in new transaction because we could have read data until the
+			// old one expired
+			tr->reset();
+			if (statsCurrentRound.lastEndKey != savedCurrentRoundState.lastEndKey || statsCurrentRound.complete) {
+				if (DEBUG_SCAN_PROGRESS) {
+					TraceEvent(SevDebug, "ConsistencyScanProgressScanLoopSaving", memState->csId)
+					    .detail("ProgressKey", statsCurrentRound.lastEndKey);
+				}
+				loop {
+					if (DEBUG_SCAN_PROGRESS) {
+						TraceEvent(SevDebug, "ConsistencyScanProgressScanLoopSaveStart", memState->csId)
+						    .detail("ProgressKey", statsCurrentRound.lastEndKey);
+					}
+					try {
+						systemDB->setOptions(tr);
+						Optional<Versionstamp> csVersion2 = wait(cs.trigger.get(tr));
+						if (csVersion2 != configVersion) {
+							if (DEBUG_SCAN_PROGRESS) {
+								TraceEvent(SevDebug, "ConsistencyScanProgressScanLoopVersionMismatch2", memState->csId);
+							}
+							restartMainLoop = true;
+							break;
+						}
+						cs.currentRoundStats().set(tr, statsCurrentRound);
+						cs.lifetimeStats().set(tr, statsLifetime);
+
+						wait(tr->commit());
+						if (DEBUG_SCAN_PROGRESS) {
+							TraceEvent(SevDebug, "ConsistencyScanProgressScanLoopDurable", memState->csId)
+							    .detail("BytesRead", statsCurrentRound.logicalBytesScanned)
+							    .detail("ProgressKey", statsCurrentRound.lastEndKey);
+						}
+						break;
+					} catch (Error& e) {
+						if (DEBUG_SCAN_PROGRESS) {
+							TraceEvent(SevDebug, "ConsistencyScanProgressScanLoopSaveError", memState->csId)
+							    .errorUnsuppressed(e)
+							    .detail("ProgressKey", statsCurrentRound.lastEndKey);
+						}
+						wait(tr->onError(e));
+					}
+				}
+			} else {
+				CODE_PROBE(true, "consistency scan loop no progress");
+				if (DEBUG_SCAN_PROGRESS) {
+					TraceEvent(SevDebug, "ConsistencyScanProgressScanLoopNoProgress", memState->csId)
+					    .detail("ProgressKey", statsCurrentRound.lastEndKey);
+				}
 			}
 
 			// Wait for the rate control to generate enough budget to match what we read.
@@ -873,9 +921,10 @@ ACTOR Future<Void> disableConsistencyScanInSim(Database db, Reference<Consistenc
 			state ConsistencyScanState::Config config = wait(cs.config().getD(tr));
 			state bool skipDisable = false;
 			// see if any rounds have completed
-			ConsistencyScanState::StatsHistoryMap::RangeResultType olderStats =
+			state ConsistencyScanState::RoundStats statsCurrentRound = wait(cs.currentRoundStats().getD(tr));
+			state ConsistencyScanState::StatsHistoryMap::RangeResultType olderStats =
 			    wait(cs.roundStatsHistory().getRange(tr, {}, {}, 1, Snapshot::False, Reverse::False));
-			if (olderStats.results.empty()) {
+			if (olderStats.results.empty() && !statsCurrentRound.complete) {
 				TraceEvent("ConsistencyScan_SimDisable_NoRoundsCompleted", memState->csId).log();
 				skipDisable = true;
 			}


### PR DESCRIPTION
Had an issue that it would stall on too large of a shard because it used the same transaction to read and then commit.
Also fixed a couple other little things

Running 50k correctness

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
