### PR TITLE
disable mutation tracking

### DIFF
--- a/fdbserver/include/fdbserver/MutationTracking.h
+++ b/fdbserver/include/fdbserver/MutationTracking.h
@@ -25,7 +25,7 @@
 #include "fdbclient/FDBTypes.h"
 #include "fdbclient/CommitTransaction.h"
 
-#define MUTATION_TRACKING_ENABLED 1
+#define MUTATION_TRACKING_ENABLED 0
 // The keys to track are defined in the .cpp file to limit recompilation.
 
 #define DEBUG_MUTATION(...) MUTATION_TRACKING_ENABLED&& debugMutation(__VA_ARGS__)


### PR DESCRIPTION
#9817 enabled mutation tracking by default which is causing tracing issues, like trace buffer overflow or tests failing with TracedTooManyLines.
This is a setting that is intentionally very expensive and should only be enabled when actively debugging a simulation test.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
