### PR TITLE
Cherry-pick commit to implement IStorageMetricsService inteface for BlobMigrator (Cherry-Pick #10336 to snowflake/release-71.3)

### DIFF
--- a/fdbserver/MockGlobalState.actor.cpp
+++ b/fdbserver/MockGlobalState.actor.cpp
@@ -337,6 +337,14 @@ Future<Void> MockStorageServer::waitMetricsTenantAware(const WaitMetricsRequest&
 
 void MockStorageServer::getStorageMetrics(const GetStorageMetricsRequest& req) {}
 
+void MockStorageServer::getSplitMetrics(const SplitMetricsRequest& req) {
+	this->metrics.splitMetrics(req);
+}
+
+void MockStorageServer::getHotRangeMetrics(const ReadHotSubRangeRequest& req) {
+	this->metrics.getReadHotRanges(req);
+}
+
 Future<Void> MockStorageServer::run() {
 	ssi.initEndpoints();
 	ssi.startAcceptingRequests();

--- a/fdbserver/include/fdbserver/MockGlobalState.h
+++ b/fdbserver/include/fdbserver/MockGlobalState.h
@@ -148,6 +148,10 @@ public:
 
 	void getStorageMetrics(const GetStorageMetricsRequest& req) override;
 
+	void getSplitMetrics(const SplitMetricsRequest& req) override;
+
+	void getHotRangeMetrics(const ReadHotSubRangeRequest& req) override;
+
 	template <class Reply>
 	static constexpr bool isLoadBalancedReply = std::is_base_of_v<LoadBalancedReply, Reply>;
 

--- a/fdbserver/include/fdbserver/StorageMetrics.actor.h
+++ b/fdbserver/include/fdbserver/StorageMetrics.actor.h
@@ -221,6 +221,10 @@ public:
 
 	virtual void getStorageMetrics(const GetStorageMetricsRequest& req) = 0;
 
+	virtual void getSplitMetrics(const SplitMetricsRequest& req) = 0;
+
+	virtual void getHotRangeMetrics(const ReadHotSubRangeRequest& req) = 0;
+
 	// NOTE: also need to have this function but template can't be a virtual so...
 	// template <class Reply>
 	// void sendErrorWithPenalty(const ReplyPromise<Reply>& promise, const Error& err, double penalty);
@@ -244,14 +248,14 @@ Future<Void> serveStorageMetricsRequests(ServiceType* self, StorageServerInterfa
 					CODE_PROBE(true, "splitMetrics immediate wrong_shard_server()");
 					self->sendErrorWithPenalty(req.reply, wrong_shard_server(), self->getPenalty());
 				} else {
-					self->metrics.splitMetrics(req);
+					self->getSplitMetrics(req);
 				}
 			}
 			when(GetStorageMetricsRequest req = waitNext(ssi.getStorageMetrics.getFuture())) {
 				self->getStorageMetrics(req);
 			}
 			when(ReadHotSubRangeRequest req = waitNext(ssi.getReadHotRanges.getFuture())) {
-				self->metrics.getReadHotRanges(req);
+				self->getHotRangeMetrics(req);
 			}
 			when(SplitRangeRequest req = waitNext(ssi.getRangeSplitPoints.getFuture())) {
 				if (!self->isReadable(req.keys)) {


### PR DESCRIPTION
Cherry-Pick of #10336
- This commit is helpful for branch 71.3 release because it refactors code and reduces complexity.

Original Description:

- Xiaoxi did some refactoring for StorageServerInterface and we are changing BlobMigrator accordingly. We refactor `BlobMigrator` implement the `IStorageMetricsService` interface.

Test
- 100K correctness tests, all passed
  - Ensemble ID `20230525-234524-jzhong-ef392574e762191e`

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
