### PR TITLE
Remove unnecessary usage of `printable`

### DIFF
--- a/fdbserver/GlobalTagThrottler.actor.cpp
+++ b/fdbserver/GlobalTagThrottler.actor.cpp
@@ -214,7 +214,7 @@ class GlobalTagThrottlerImpl {
 			result += getCurrentCost(id, tag).orDefault(0);
 		}
 		// FIXME: Disabled due to noisy trace events. Fix the noise and reenabled
-		//TraceEvent("GlobalTagThrottler_GetCurrentCost").detail("Tag", printable(tag)).detail("Cost", result);
+		//TraceEvent("GlobalTagThrottler_GetCurrentCost").detail("Tag", tag).detail("Cost", result);
 
 		return result;
 	}
@@ -421,7 +421,7 @@ class GlobalTagThrottlerImpl {
 
 		isBusy = limitingTps.present() && limitingTps.get() < desiredTps;
 
-		te.detail("Tag", printable(tag))
+		te.detail("Tag", tag)
 		    .detail("TargetTps", targetTps)
 		    .detail("AverageTransactionCost", averageTransactionCost)
 		    .detail("LimitingTps", limitingTps)
@@ -447,7 +447,7 @@ public:
 				           "been reached");
 				TraceEvent("GlobalTagThrottler_IgnoringRequests")
 				    .suppressFor(60.0)
-				    .detail("Tag", printable(tag))
+				    .detail("Tag", tag)
 				    .detail("Count", count);
 			} else {
 				tagStatistics[tag].addTransactions(static_cast<double>(count));

--- a/fdbserver/GrvProxyTagThrottler.actor.cpp
+++ b/fdbserver/GrvProxyTagThrottler.actor.cpp
@@ -112,7 +112,7 @@ void GrvProxyTagThrottler::addRequest(GetReadVersionRequest const& req) {
 		TraceEvent(SevWarnAlways, "GrvProxyTagThrottler_MultipleTags")
 		    .suppressFor(60.0)
 		    .detail("NumTags", req.tags.size())
-		    .detail("UsingTag", printable(tag));
+		    .detail("UsingTag", tag);
 	}
 	queues[tag].requests.emplace_back(req);
 }

--- a/fdbserver/TransactionTagCounter.cpp
+++ b/fdbserver/TransactionTagCounter.cpp
@@ -128,14 +128,14 @@ public:
 					}
 				}
 				TraceEvent("BusiestReadTag", thisServerID)
-				    .detail("Tag", printable(busiestTagInfo.tag))
+				    .detail("Tag", busiestTagInfo.tag)
 				    .detail("TagCost", busiestTagInfo.rate)
 				    .detail("FractionalBusyness", busiestTagInfo.fractionalBusyness);
 			}
 
 			for (const auto& tagInfo : previousBusiestTags) {
 				TraceEvent("BusyReadTag", thisServerID)
-				    .detail("Tag", printable(tagInfo.tag))
+				    .detail("Tag", tagInfo.tag)
 				    .detail("TagCost", tagInfo.rate)
 				    .detail("FractionalBusyness", tagInfo.fractionalBusyness);
 			}

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -13493,7 +13493,7 @@ ACTOR Future<Void> storageServerCore(StorageServer* self, StorageServerInterface
 				self->busiestWriteTagContext.lastUpdateTime = req.postTime;
 				TraceEvent("BusiestWriteTag", self->thisServerID)
 				    .detail("Elapsed", req.elapsed)
-				    .detail("Tag", printable(req.busiestTag))
+				    .detail("Tag", req.busiestTag)
 				    .detail("TagOps", req.opsSum)
 				    .detail("TagCost", req.costSum)
 				    .detail("TotalCost", req.totalWriteCosts)


### PR DESCRIPTION
In trace event details, escaping is already applied, so it shouldn't be applied twice.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
