### PR TITLE
Fix a couple thread-safety issues

### DIFF
--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -2305,8 +2305,6 @@ void initializeClientTracing(Reference<IClusterConnectionRecord> connRecord, Opt
 		                              FDB_VT_VERSION,
 		                              deterministicRandom()->randomUInt64()));
 
-		initTraceEventMetrics();
-
 		std::string identifier = networkOptions.traceFileIdentifier;
 		openTraceFile(localAddress,
 		              networkOptions.traceRollSize,
@@ -2315,7 +2313,8 @@ void initializeClientTracing(Reference<IClusterConnectionRecord> connRecord, Opt
 		              "trace",
 		              networkOptions.traceLogGroup,
 		              identifier,
-		              networkOptions.tracePartialFileSuffix);
+		              networkOptions.tracePartialFileSuffix,
+		              InitializeTraceMetrics::True);
 
 		TraceEvent("ClientStart")
 		    .detail("SourceVersion", getSourceVersion())

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -2305,6 +2305,8 @@ void initializeClientTracing(Reference<IClusterConnectionRecord> connRecord, Opt
 		                              FDB_VT_VERSION,
 		                              deterministicRandom()->randomUInt64()));
 
+		initTraceEventMetrics();
+
 		std::string identifier = networkOptions.traceFileIdentifier;
 		openTraceFile(localAddress,
 		              networkOptions.traceRollSize,
@@ -2328,7 +2330,6 @@ void initializeClientTracing(Reference<IClusterConnectionRecord> connRecord, Opt
 
 		g_network->initMetrics();
 		FlowTransport::transport().initMetrics();
-		initTraceEventMetrics();
 	}
 
 	// Initialize system monitoring once the local IP is available

--- a/fdbserver/fdbserver.actor.cpp
+++ b/fdbserver/fdbserver.actor.cpp
@@ -2044,10 +2044,16 @@ int main(int argc, char* argv[]) {
 				}
 			}
 
-			initTraceEventMetrics();
+			openTraceFile(opts.publicAddresses.address,
+			              opts.rollsize,
+			              opts.maxLogsSize,
+			              opts.logFolder,
+			              "trace",
+			              opts.logGroup,
+			              /* identifier = */ "",
+			              /* tracePartialFileSuffix = */ "",
+			              InitializeTraceMetrics::True);
 
-			openTraceFile(
-			    opts.publicAddresses.address, opts.rollsize, opts.maxLogsSize, opts.logFolder, "trace", opts.logGroup);
 			g_network->initTLS();
 			if (!opts.authzPublicKeyFile.empty()) {
 				try {

--- a/fdbserver/fdbserver.actor.cpp
+++ b/fdbserver/fdbserver.actor.cpp
@@ -2044,6 +2044,8 @@ int main(int argc, char* argv[]) {
 				}
 			}
 
+			initTraceEventMetrics();
+
 			openTraceFile(
 			    opts.publicAddresses.address, opts.rollsize, opts.maxLogsSize, opts.logFolder, "trace", opts.logGroup);
 			g_network->initTLS();
@@ -2089,7 +2091,6 @@ int main(int argc, char* argv[]) {
 			                              opts.fileSystemPath);
 			g_network->initMetrics();
 			FlowTransport::transport().initMetrics();
-			initTraceEventMetrics();
 		}
 
 		double start = timer(), startNow = now();

--- a/flow/Trace.cpp
+++ b/flow/Trace.cpp
@@ -170,6 +170,7 @@ public:
 	bool logTraceEventMetrics;
 
 	void initMetrics() {
+		ASSERT(!isOpen());
 		SevErrorNames.init("TraceEvents.SevError"_sr);
 		SevWarnAlwaysNames.init("TraceEvents.SevWarnAlways"_sr);
 		SevWarnNames.init("TraceEvents.SevWarn"_sr);
@@ -431,8 +432,7 @@ public:
 	}
 
 	void log(int severity, const char* name, UID id, uint64_t event_ts) {
-		if (!logTraceEventMetrics)
-			return;
+		ASSERT(TraceEvent::isNetworkThread() && !logTraceEventMetrics);
 
 		EventMetricHandle<TraceEventNameID>* m = nullptr;
 		switch (severity) {
@@ -1340,7 +1340,7 @@ void BaseTraceEvent::log() {
 
 				if (g_traceLog.isOpen()) {
 					// Log Metrics
-					if (g_traceLog.logTraceEventMetrics && isNetworkThread()) {
+					if (isNetworkThread() && g_traceLog.logTraceEventMetrics) {
 						// Get the persistent Event Metric representing this trace event and push the fields (details)
 						// accumulated in *this to it and then log() it. Note that if the event metric is disabled it
 						// won't actually be logged BUT any new fields added to it will be registered. If the event IS

--- a/flow/Trace.cpp
+++ b/flow/Trace.cpp
@@ -431,8 +431,8 @@ public:
 		}
 	}
 
-	void log(int severity, const char* name, UID id, uint64_t event_ts) {
-		ASSERT(TraceEvent::isNetworkThread() && !logTraceEventMetrics);
+	void logMetrics(int severity, const char* name, UID id, uint64_t event_ts) {
+		ASSERT(TraceEvent::isNetworkThread() && logTraceEventMetrics);
 
 		EventMetricHandle<TraceEventNameID>* m = nullptr;
 		switch (severity) {

--- a/flow/Trace.cpp
+++ b/flow/Trace.cpp
@@ -781,7 +781,8 @@ void openTraceFile(const Optional<NetworkAddress>& na,
                    std::string baseOfBase,
                    std::string logGroup,
                    std::string identifier,
-                   std::string tracePartialFileSuffix) {
+                   std::string tracePartialFileSuffix,
+                   InitializeTraceMetrics initializeTraceMetrics) {
 	if (g_traceLog.isOpen())
 		return;
 
@@ -808,6 +809,10 @@ void openTraceFile(const Optional<NetworkAddress>& na,
 		baseName = format("%s.0.0.0.0.%d", baseOfBase.c_str(), ::getpid());
 	}
 
+	if (initializeTraceMetrics) {
+		g_traceLog.initMetrics();
+	}
+
 	g_traceLog.open(directory,
 	                baseName,
 	                logGroup,
@@ -819,10 +824,6 @@ void openTraceFile(const Optional<NetworkAddress>& na,
 
 	uncancellable(recurring(&flushTraceFile, FLOW_KNOBS->TRACE_FLUSH_INTERVAL, TaskPriority::FlushTrace));
 	g_traceBatch.dump();
-}
-
-void initTraceEventMetrics() {
-	g_traceLog.initMetrics();
 }
 
 void closeTraceFile() {
@@ -1342,15 +1343,15 @@ void BaseTraceEvent::log() {
 					// Log Metrics
 					if (isNetworkThread() && g_traceLog.logTraceEventMetrics) {
 						// Get the persistent Event Metric representing this trace event and push the fields (details)
-						// accumulated in *this to it and then log() it. Note that if the event metric is disabled it
-						// won't actually be logged BUT any new fields added to it will be registered. If the event IS
-						// logged, a timestamp will be returned, if not then 0.  Either way, pass it through to be used
-						// if possible in the Sev* event metrics.
+						// accumulated in *this to it and then logMetrics() it. Note that if the event metric is
+						// disabled it won't actually be logged BUT any new fields added to it will be registered. If
+						// the event IS logged, a timestamp will be returned, if not then 0.  Either way, pass it
+						// through to be used if possible in the Sev* event metrics.
 
 						uint64_t event_ts =
 						    DynamicEventMetric::getOrCreateInstance(format("TraceEvent.%s", type), StringRef(), true)
 						        ->setFieldsAndLogFrom(tmpEventMetric.get());
-						g_traceLog.log(severity, type, id, event_ts);
+						g_traceLog.logMetrics(severity, type, id, event_ts);
 					}
 				}
 			}

--- a/flow/include/flow/BooleanParam.h
+++ b/flow/include/flow/BooleanParam.h
@@ -20,8 +20,6 @@
 
 #pragma once
 
-#include "flow/Trace.h"
-
 class BooleanParam {
 	bool value;
 
@@ -29,11 +27,6 @@ public:
 	explicit constexpr BooleanParam(bool value) : value(value) {}
 	constexpr operator bool() const { return value; }
 	constexpr void set(bool value) { this->value = value; }
-};
-
-template <class BooleanParamSub>
-struct Traceable<BooleanParamSub, std::enable_if_t<std::is_base_of_v<BooleanParam, BooleanParamSub>>> : std::true_type {
-	static std::string toString(BooleanParamSub const& value) { return Traceable<bool>::toString(value); }
 };
 
 // Declares a boolean parametr with the desired name. This declaration can be nested inside of a namespace or another

--- a/flow/include/flow/CodeProbe.h
+++ b/flow/include/flow/CodeProbe.h
@@ -281,7 +281,7 @@ struct CodeProbeImpl : ICodeProbe {
 private:
 	CodeProbeImpl() { registerProbe(*this); }
 	inline static CodeProbeImpl _instance;
-	unsigned _hitCount = 0;
+	std::atomic<unsigned> _hitCount = 0;
 	Annotations annotations;
 };
 

--- a/flow/include/flow/Trace.h
+++ b/flow/include/flow/Trace.h
@@ -31,6 +31,7 @@
 #include <map>
 #include <set>
 #include <type_traits>
+#include "flow/BooleanParam.h"
 #include "flow/IRandom.h"
 #include "flow/Error.h"
 #include "flow/ITrace.h"
@@ -38,6 +39,8 @@
 
 #define TRACE_DEFAULT_ROLL_SIZE (10 << 20)
 #define TRACE_DEFAULT_MAX_LOGS_SIZE (10 * TRACE_DEFAULT_ROLL_SIZE)
+
+FDB_BOOLEAN_PARAM(InitializeTraceMetrics);
 
 inline int fastrand() {
 	static int g_seed = 0;
@@ -539,8 +542,8 @@ void openTraceFile(const Optional<NetworkAddress>& na,
                    std::string baseOfBase = "trace",
                    std::string logGroup = "default",
                    std::string identifier = "",
-                   std::string tracePartialFileSuffix = "");
-void initTraceEventMetrics();
+                   std::string tracePartialFileSuffix = "",
+                   InitializeTraceMetrics initializeTraceMetrics = InitializeTraceMetrics::False);
 void closeTraceFile();
 bool traceFileIsOpen();
 void flushTraceFileVoid();

--- a/flow/include/flow/Traceable.h
+++ b/flow/include/flow/Traceable.h
@@ -29,6 +29,8 @@
 #include <type_traits>
 #include <fmt/format.h>
 
+#include "flow/BooleanParam.h"
+
 #define PRINTABLE_COMPRESS_NULLS 0
 
 template <class IntType>
@@ -243,6 +245,11 @@ struct Traceable<std::string_view> : TraceableStringImpl<std::string_view> {};
 template <class T>
 struct Traceable<std::atomic<T>> : std::true_type {
 	static std::string toString(const std::atomic<T>& value) { return Traceable<T>::toString(value.load()); }
+};
+
+template <class BooleanParamSub>
+struct Traceable<BooleanParamSub, std::enable_if_t<std::is_base_of_v<BooleanParam, BooleanParamSub>>> : std::true_type {
+	static std::string toString(BooleanParamSub const& value) { return Traceable<bool>::toString(value); }
 };
 
 // Adapter to redirect fmt::formatter calls to Traceable for a supported type


### PR DESCRIPTION
This fixes two thread safety issues:

Convert CodeProbeImpl::_hitCount to an atomic so that it can be incremented from multiple threads simultaneously.
Update accesses of logTraceEventMetrics so that it is written before a trace log is opened and read after it is opened and only from the network thread.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
