### PR TITLE
Let coordination server crash on file_not_found error.

### DIFF
--- a/fdbserver/worker.actor.cpp
+++ b/fdbserver/worker.actor.cpp
@@ -3145,19 +3145,6 @@ static std::set<int> const& normalWorkerErrors() {
 	return s;
 }
 
-ACTOR Future<Void> fileNotFoundToNever(Future<Void> f) {
-	try {
-		wait(f);
-		return Void();
-	} catch (Error& e) {
-		if (e.code() == error_code_file_not_found) {
-			TraceEvent(SevWarn, "ClusterCoordinatorFailed").error(e);
-			return Never();
-		}
-		throw;
-	}
-}
-
 ACTOR Future<Void> printTimeout() {
 	wait(delay(5));
 	if (!g_network->isSimulated()) {
@@ -3831,10 +3818,7 @@ ACTOR Future<Void> fdbd(Reference<IClusterConnectionRecord> connRecord,
 		// Endpoints should be registered first before any process trying to connect to it.
 		// So coordinationServer actor should be the first one executed before any other.
 		if (coordFolder.size()) {
-			// SOMEDAY: remove the fileNotFound wrapper and make DiskQueue construction safe from errors setting up
-			// their files
-			actors.push_back(
-			    fileNotFoundToNever(coordinationServer(coordFolder, connRecord, configNode, configBroadcastInterface)));
+			actors.push_back(coordinationServer(coordFolder, connRecord, configNode, configBroadcastInterface));
 		}
 
 		state UID processIDUid = wait(createAndLockProcessIdFile(dataFolder));


### PR DESCRIPTION
(Cherry-Pick #10363 to snowflake/release-71.3)

The only case when a coordination server should fail with file_not_found is when the DiskQueue only finds 1 out of its 2 queue files. This either means data has been lost, or the initial creation of the two files failed partway through. In either case, it's sensible to crash the process and refuse to start.

The existing code was catching the file_not_found error and letting the FDBD process continue after the coordination server failed. This resulted in clients attempting to contact the coordination server on a well-known endpoint and never getting a response, because Flow transport silently dropped the request when there was no receiver for it. By terminating the process instead, we effectively notify waiting clients that they won't get a response from this coordinator.

100k correctness tests passed:
20230605-175012-dadkins-ed2e43c962358496

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
