### PR TITLE
(snowflake/release-71.3) Fix `get*OperationCost` functions for empty mutations/results

### DIFF
--- a/fdbclient/include/fdbclient/NativeAPI.actor.h
+++ b/fdbclient/include/fdbclient/NativeAPI.actor.h
@@ -619,13 +619,21 @@ ACTOR Future<bool> checkSafeExclusions(Database cx, std::vector<AddressExclusion
 // Measured in bytes, rounded up to the nearest page size. Multiply by fungibility ratio
 // because writes are more expensive than reads.
 inline uint64_t getWriteOperationCost(uint64_t bytes) {
-	return CLIENT_KNOBS->GLOBAL_TAG_THROTTLING_RW_FUNGIBILITY_RATIO * CLIENT_KNOBS->TAG_THROTTLING_PAGE_SIZE *
-	       ((bytes - 1) / CLIENT_KNOBS->TAG_THROTTLING_PAGE_SIZE + 1);
+	if (bytes == 0) {
+		return CLIENT_KNOBS->GLOBAL_TAG_THROTTLING_RW_FUNGIBILITY_RATIO * CLIENT_KNOBS->TAG_THROTTLING_PAGE_SIZE;
+	} else {
+		return CLIENT_KNOBS->GLOBAL_TAG_THROTTLING_RW_FUNGIBILITY_RATIO * CLIENT_KNOBS->TAG_THROTTLING_PAGE_SIZE *
+		       ((bytes - 1) / CLIENT_KNOBS->TAG_THROTTLING_PAGE_SIZE + 1);
+	}
 }
 
 // Measured in bytes, rounded up to the nearest page size.
 inline uint64_t getReadOperationCost(uint64_t bytes) {
-	return ((bytes - 1) / CLIENT_KNOBS->TAG_THROTTLING_PAGE_SIZE + 1) * CLIENT_KNOBS->TAG_THROTTLING_PAGE_SIZE;
+	if (bytes == 0) {
+		return CLIENT_KNOBS->TAG_THROTTLING_PAGE_SIZE;
+	} else {
+		return ((bytes - 1) / CLIENT_KNOBS->TAG_THROTTLING_PAGE_SIZE + 1) * CLIENT_KNOBS->TAG_THROTTLING_PAGE_SIZE;
+	}
 }
 
 // Create a transaction to set the value of system key \xff/conf/perpetual_storage_wiggle. If enable == true, the value

--- a/fdbserver/RkTagThrottleCollection.cpp
+++ b/fdbserver/RkTagThrottleCollection.cpp
@@ -70,8 +70,8 @@ RkTagThrottleCollection& RkTagThrottleCollection::RkTagThrottleCollection::opera
 double RkTagThrottleCollection::computeTargetTpsRate(double currentBusyness,
                                                      double targetBusyness,
                                                      double requestRate) {
-	ASSERT_GT(currentBusyness, 0);
-
+	ASSERT_GT(currentBusyness, 0.0);
+	ASSERT_LE(currentBusyness, 1.0);
 	if (targetBusyness < 1) {
 		double targetFraction = targetBusyness * (1 - currentBusyness) / ((1 - targetBusyness) * currentBusyness);
 		return requestRate * targetFraction;
@@ -135,7 +135,8 @@ Optional<double> RkTagThrottleCollection::autoThrottleTag(UID id,
 		expiration = now() + SERVER_KNOBS->AUTO_TAG_THROTTLE_DURATION;
 	}
 
-	ASSERT(tpsRate.present() && tpsRate.get() >= 0);
+	ASSERT(tpsRate.present());
+	ASSERT_GE(tpsRate.get(), 0);
 
 	throttle.limits.tpsRate = tpsRate.get();
 	throttle.limits.expiration = expiration.get();


### PR DESCRIPTION
This is a backport of https://github.com/apple/foundationdb/pull/10367.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
