### PR TITLE
Change compiler options order to avoid -gdwarf overriding -g1 [snowflake/release-71.3]

### DIFF
--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -168,6 +168,13 @@ else()
 
   add_compile_options(-fno-omit-frame-pointer)
 
+  if(CLANG)
+    # The default DWARF 5 format does not play nicely with GNU Binutils 2.39 and earlier, resulting
+    # in tools like addr2line omitting line numbers. We can consider removing this once we are able 
+    # to use a version that has a fix.
+    add_compile_options(-gdwarf-4)
+  endif()
+
   if(FULL_DEBUG_SYMBOLS OR CMAKE_BUILD_TYPE STREQUAL "Debug")
     # Configure with FULL_DEBUG_SYMBOLS=ON to generate all symbols for debugging with gdb
     # Also generating full debug symbols in release builds. CPack will strip them out
@@ -176,13 +183,6 @@ else()
   else()
     # Generating minimal debug symbols by default. They are sufficient for testing purposes
     add_compile_options(-ggdb1)
-  endif()
-
-  if(CLANG)
-    # The default DWARF 5 format does not play nicely with GNU Binutils 2.39 and earlier, resulting
-    # in tools like addr2line omitting line numbers. We can consider removing this once we are able 
-    # to use a version that has a fix.
-    add_compile_options(-gdwarf-4)
   endif()
 
   if(NOT FDB_RELEASE)


### PR DESCRIPTION
Reorder the compiler options so that -g1 is added after -gdwarf, because otherwise -gdwarf resets it to -g2. It is important for reducing the size of our release binaries.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
