### PR TITLE
Fix a simulation DR stuck issue

### DIFF
--- a/fdbclient/DatabaseBackupAgent.actor.cpp
+++ b/fdbclient/DatabaseBackupAgent.actor.cpp
@@ -26,7 +26,9 @@
 #include "fdbclient/NativeAPI.actor.h"
 #include <ctime>
 #include <climits>
+#include "fdbrpc/simulator.h"
 #include "flow/IAsyncFile.h"
+#include "flow/flow.h"
 #include "flow/genericactors.actor.h"
 #include "flow/Hash3.h"
 #include <numeric>
@@ -361,8 +363,10 @@ struct BackupRangeTaskFunc : TaskFuncBase {
 
 					if ((!prevAdjacent || !nextAdjacent) &&
 					    rangeCount > ((prevAdjacent || nextAdjacent) ? CLIENT_KNOBS->BACKUP_MAP_KEY_UPPER_LIMIT
-					                                                 : CLIENT_KNOBS->BACKUP_MAP_KEY_LOWER_LIMIT)) {
-						CODE_PROBE(true, "range insert delayed because too versionMap is too large");
+					                                                 : CLIENT_KNOBS->BACKUP_MAP_KEY_LOWER_LIMIT) &&
+					    (!g_network->isSimulated() ||
+					     (isBuggifyEnabled(BuggifyType::General) && g_simulator->speedUpSimulation))) {
+						CODE_PROBE(true, "range insert delayed because versionMap is too large");
 
 						if (rangeCount > CLIENT_KNOBS->BACKUP_MAP_KEY_UPPER_LIMIT)
 							TraceEvent(SevWarnAlways, "DBA_KeyRangeMapTooLarge").log();

--- a/fdbclient/DatabaseBackupAgent.actor.cpp
+++ b/fdbclient/DatabaseBackupAgent.actor.cpp
@@ -365,7 +365,7 @@ struct BackupRangeTaskFunc : TaskFuncBase {
 					    rangeCount > ((prevAdjacent || nextAdjacent) ? CLIENT_KNOBS->BACKUP_MAP_KEY_UPPER_LIMIT
 					                                                 : CLIENT_KNOBS->BACKUP_MAP_KEY_LOWER_LIMIT) &&
 					    (!g_network->isSimulated() ||
-					     (isBuggifyEnabled(BuggifyType::General) && g_simulator->speedUpSimulation))) {
+					     (isBuggifyEnabled(BuggifyType::General) && !g_simulator->speedUpSimulation))) {
 						CODE_PROBE(true, "range insert delayed because versionMap is too large");
 
 						if (rangeCount > CLIENT_KNOBS->BACKUP_MAP_KEY_UPPER_LIMIT)


### PR DESCRIPTION
When buggify is enabled, it's possible the version map has 5 entries, which is larger than `BACKUP_MAP_KEY_LOWER_LIMIT=4`, causing the range task to be delayed infinitely: the `BackupRangeTaskFunc::_execute()` skips the execution and schedules the task to be added back in `BackupRangeTaskFunc::_finish()`.

Fix by ignore the buggified value when in simulation, buggy is on, and `speedUpSimulation` is true.

Reproduction:
  Seed: `-f ./tests/slow/SharedDefaultBackupCorrectness.toml -s 3202874095 -b on`
       `-f ./tests/slow/VersionStampBackupToDB.toml -s 1190111003 -b on`
  Commit: 6e5773dd5 at release-7.3
  Build: clang


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
