### PR TITLE
EaR: Update KMS URL refresh policy and fix bugs

### DIFF
--- a/fdbclient/RESTClient.actor.cpp
+++ b/fdbclient/RESTClient.actor.cpp
@@ -180,10 +180,12 @@ ACTOR Future<Reference<HTTP::IncomingResponse>> doRequest_impl(Reference<RESTCli
 		// All errors in err are potentially (except 'timed_out' and/or 'connection_failed') retryable as well as
 		// certain HTTP response codes...
 		bool retryable =
-		    (err.present() && isErrorRetryable(err.get())) || r->code == HTTP::HTTP_STATUS_CODE_INTERNAL_SERVER_ERROR ||
-		    r->code == HTTP::HTTP_STATUS_CODE_BAD_GATEWAY || r->code == HTTP::HTTP_STATUS_CODE_BAD_GATEWAY ||
-		    r->code == HTTP::HTTP_STATUS_CODE_SERVICE_UNAVAILABLE ||
-		    r->code == HTTP::HTTP_STATUS_CODE_TOO_MANY_REQUESTS || r->code == HTTP::HTTP_STATUS_CODE_TIMEOUT;
+		    (err.present() && isErrorRetryable(err.get())) ||
+		    (r.isValid() &&
+		     (r->code == HTTP::HTTP_STATUS_CODE_INTERNAL_SERVER_ERROR ||
+		      r->code == HTTP::HTTP_STATUS_CODE_BAD_GATEWAY || r->code == HTTP::HTTP_STATUS_CODE_BAD_GATEWAY ||
+		      r->code == HTTP::HTTP_STATUS_CODE_SERVICE_UNAVAILABLE ||
+		      r->code == HTTP::HTTP_STATUS_CODE_TOO_MANY_REQUESTS || r->code == HTTP::HTTP_STATUS_CODE_TIMEOUT));
 
 		// But only if our previous attempt was not the last allowable try.
 		retryable = retryable && (thisTry < maxTries);

--- a/fdbclient/RESTClient.actor.cpp
+++ b/fdbclient/RESTClient.actor.cpp
@@ -87,6 +87,13 @@ std::unordered_map<std::string, int> RESTClient::getKnobs() const {
 	return knobs.get();
 }
 
+bool isErrorRetryable(const Error& e) {
+	// Server if unreachable or timing out requests, bubble the error to the caller to decide continue using the same
+	// server OR attempt connecting to a different server instance
+
+	return e.code() != error_code_timed_out && e.code() != error_code_connection_failed;
+}
+
 ACTOR Future<Reference<HTTP::IncomingResponse>> doRequest_impl(Reference<RESTClient> client,
                                                                std::string verb,
                                                                HTTP::Headers headers,
@@ -170,9 +177,10 @@ ACTOR Future<Reference<HTTP::IncomingResponse>> doRequest_impl(Reference<RESTCli
 		// Otherwise, this request is considered failed.  Update failure count.
 		statsPtr->requests_failed++;
 
-		// All errors in err are potentially retryable as well as certain HTTP response codes...
+		// All errors in err are potentially (except 'timed_out' and/or 'connection_failed') retryable as well as
+		// certain HTTP response codes...
 		bool retryable =
-		    err.present() || r->code == HTTP::HTTP_STATUS_CODE_INTERNAL_SERVER_ERROR ||
+		    (err.present() && isErrorRetryable(err.get())) || r->code == HTTP::HTTP_STATUS_CODE_INTERNAL_SERVER_ERROR ||
 		    r->code == HTTP::HTTP_STATUS_CODE_BAD_GATEWAY || r->code == HTTP::HTTP_STATUS_CODE_BAD_GATEWAY ||
 		    r->code == HTTP::HTTP_STATUS_CODE_SERVICE_UNAVAILABLE ||
 		    r->code == HTTP::HTTP_STATUS_CODE_TOO_MANY_REQUESTS || r->code == HTTP::HTTP_STATUS_CODE_TIMEOUT;

--- a/fdbclient/RESTUtils.actor.cpp
+++ b/fdbclient/RESTUtils.actor.cpp
@@ -263,6 +263,10 @@ void RESTUrl::parseUrl(const std::string& fullUrl) {
 	}
 }
 
+double continuousTimeDecay(double initialValue, double decayRate, double time) {
+	return initialValue * exp(-decayRate * time);
+}
+
 // Only used to link unit tests
 void forceLinkRESTUtilsTests() {}
 

--- a/fdbclient/include/fdbclient/RESTUtils.h
+++ b/fdbclient/include/fdbclient/RESTUtils.h
@@ -136,4 +136,6 @@ private:
 	void parseUrl(const std::string& fullUrl);
 };
 
+double continuousTimeDecay(double initialValue, double decayRate, double time);
+
 #endif

--- a/fdbserver/RESTKmsConnector.actor.cpp
+++ b/fdbserver/RESTKmsConnector.actor.cpp
@@ -90,12 +90,6 @@ void removeTrailingChar(std::string& str, char c) {
 	}
 }
 
-constexpr double LAST_5MIN_PENALTY_WEIGHT = 1.0;
-constexpr double LAST_15MIN_PENALTY_WEIGHT = 0.90;
-constexpr double LAST_30MIN_PENALTY_WEIGHT = 0.50;
-constexpr double LAST_HOUR_PENALTY_WEIGHT = 0.25;
-constexpr double MORE_THAN_HOUR_PENALTY = 0.05;
-
 } // namespace
 
 template <class Params>
@@ -777,7 +771,10 @@ Future<T> kmsRequestImpl(
 					TraceEvent("RESTKmsRequestImpl", ctx->uid)
 					    .detail("Pass", pass)
 					    .detail("RequestID", requestID)
-					    .detail("FullUrl", kmsEncryptionFullUrl);
+					    .detail("FullUrl", kmsEncryptionFullUrl)
+					    .detail("StartIdx", start)
+					    .detail("CurIdx", idx)
+					    .detail("LastKmsUrlDiscoverTS", ctx->lastKmsUrlDiscoverTS);
 				}
 
 				Reference<HTTP::IncomingResponse> resp = wait(ctx->restClient.doPost(

--- a/fdbserver/RESTKmsConnector.actor.cpp
+++ b/fdbserver/RESTKmsConnector.actor.cpp
@@ -96,25 +96,6 @@ constexpr double LAST_30MIN_PENALTY_WEIGHT = 0.50;
 constexpr double LAST_HOUR_PENALTY_WEIGHT = 0.25;
 constexpr double MORE_THAN_HOUR_PENALTY = 0.05;
 
-// Routine to determine penalty for cached KMSUrl based on unresponsive KMS behavior observed in recent past. The
-// routine is desgined to assign a maximum penalty if KMS responses are unacceptable in very recent past, with time the
-// the penalty weight deteorates (matches real world outage OR server overload scenario)
-
-struct KmsUrlPenaltyParams {
-	static double penalty(int64_t timeSinceLastPenalty) {
-		if (timeSinceLastPenalty <= 5) {
-			return LAST_5MIN_PENALTY_WEIGHT;
-		} else if (timeSinceLastPenalty > 5 && timeSinceLastPenalty <= 15) {
-			return LAST_15MIN_PENALTY_WEIGHT;
-		} else if (timeSinceLastPenalty > 15 && timeSinceLastPenalty <= 30) {
-			return LAST_30MIN_PENALTY_WEIGHT;
-		} else if (timeSinceLastPenalty > 30 && timeSinceLastPenalty <= 60) {
-			return LAST_HOUR_PENALTY_WEIGHT;
-		}
-		return MORE_THAN_HOUR_PENALTY;
-	}
-};
-
 } // namespace
 
 template <class Params>
@@ -220,6 +201,25 @@ struct KmsUrlStore {
 
 FDB_BOOLEAN_PARAM(RefreshPersistedUrls);
 FDB_BOOLEAN_PARAM(IsCipherType);
+
+// Routine to determine penalty for cached KMSUrl based on unresponsive KMS behavior observed in recent past. The
+// routine is desgined to assign a maximum penalty if KMS responses are unacceptable in very recent past, with time the
+// the penalty weight deteorates (matches real world outage OR server overload scenario)
+
+struct KmsUrlPenaltyParams {
+	static double penalty(int64_t timeSinceLastPenalty) {
+		if (timeSinceLastPenalty <= 5) {
+			return LAST_5MIN_PENALTY_WEIGHT;
+		} else if (timeSinceLastPenalty > 5 && timeSinceLastPenalty <= 15) {
+			return LAST_15MIN_PENALTY_WEIGHT;
+		} else if (timeSinceLastPenalty > 15 && timeSinceLastPenalty <= 30) {
+			return LAST_30MIN_PENALTY_WEIGHT;
+		} else if (timeSinceLastPenalty > 30 && timeSinceLastPenalty <= 60) {
+			return LAST_HOUR_PENALTY_WEIGHT;
+		}
+		return MORE_THAN_HOUR_PENALTY;
+	}
+};
 
 struct RESTKmsConnectorCtx : public ReferenceCounted<RESTKmsConnectorCtx> {
 	UID uid;

--- a/tests/fast/RESTUnit.toml
+++ b/tests/fast/RESTUnit.toml
@@ -26,4 +26,4 @@ startDelay = 0
 
     [[test.workload]]
     testName = 'UnitTests'
-    testsMatching = '/KmsConnector/REST/'    
+    testsMatching = '/KmsConnector/'


### PR DESCRIPTION
Description

RESTKmsConnector implements discovery and refresh semantics i.e. on bootstrap it discovers KMS Urls and periodically refresh the URLs (handle server upgrade scenario). The current implementation caches the URLs in a min-heap, as part of serving a request, actor pops out elements from min-heap and attempts connecting to the server, on failure, the URL is temporarily stored in a stack, at the end of the request processing, the stack is merged back into the heap. The code doesn't work as expected if there are multiple requests consumes the heap causing following issues:
1. Min-heap would retain old URLs replaced by latest refresh (stack merge)
2. URL discovery file is read more than expected as multiple requests can empty heap, causing the code to read URLs from the file.

Patch proposes following policy to cache and maintain URLs priority:
1. Unresponsiveness penalty: KMS flaky connection or overload can cause requests to timeout or fail; each such instance updates unresponsiveness penalty of associated URL context. Further, the penalty is timebound and deteriorate with time.
2. Cached URLs are sorted once a failure is encountered, priority followed is:
2.1. Unresponsiveness penalty server(s) least preferred 2.2. Server(s) with high total-failures less preferred 2.3. Server(s) with high total-malformed response less preferred.

Testing

Simulation
 - RESTUnit - 100K (new test added for coverage)
 - devRunCorrectness

Real Cluster
 - Bringup a FDB cluster with external KMS server(s)
 - Kill/restart KMS server(s) to ensure that FDB learned KMS URLs gets `connection_failure` or `timeout`, approach results in URL penalty; verified that KMS URLs sort-ordering matches desired behavior.
 - All FDB learned URLs goes stale, the code fall back to file-system `discover_url` file to refresh the URLs 

Replace this text with your description here...

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
