### PR TITLE
fixup! joshua_logtool error should be reported as a XML element by te…

### DIFF
--- a/contrib/TestHarness2/test_harness/run.py
+++ b/contrib/TestHarness2/test_harness/run.py
@@ -393,7 +393,7 @@ class TestRun:
     def delete_simdir(self):
         shutil.rmtree(self.temp_path / Path("simfdb"))
 
-    def _run_rocksdb_logtool(self):
+    def _run_joshua_logtool(self):
         """Calls Joshua LogTool to upload the test logs if 1) test failed 2) test is RocksDB related"""
         if not os.path.exists("joshua_logtool.py"):
             raise RuntimeError("joshua_logtool.py missing")
@@ -407,7 +407,12 @@ class TestRun:
             str(self.temp_path),
             "--check-rocksdb",
         ]
-        subprocess.run(command, check=True)
+        result = subprocess.run(command, capture_output=True, text=True)
+        return {
+            "stdout": result.stdout,
+            "stderr": result.stderr,
+            "exit_code": result.returncode,
+        }
 
     def run(self):
         command: List[str] = []
@@ -498,10 +503,16 @@ class TestRun:
         self.summary.was_killed = did_kill
         self.summary.valgrind_out_file = valgrind_file
         self.summary.error_out = err_out
+        if not self.summary.is_negative_test and not self.summary.ok():
+            logtool_result = self._run_joshua_logtool()
+            if logtool_result["exit_code"] != 0:
+                child = SummaryTree("JoshuaLogTool")
+                child.attributes["ExitCode"] = str(logtool_result["exit_code"])
+                child.attributes["StdOut"] = logtool_result["stdout"]
+                child.attributes["StdErr"] = logtool_result["stderr"]
+                self.summary.out.append(child)
         self.summary.summarize(self.temp_path, " ".join(command))
 
-        if not self.summary.is_negative_test and not self.summary.ok():
-            self._run_rocksdb_logtool()
         return self.summary.ok()
 
 

--- a/contrib/joshua_logtool.py
+++ b/contrib/joshua_logtool.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python3
 
-"""rocksdb_logtool.py
+"""joshua_logtool.py
 
 Provides uploading/downloading FoundationDB log files to Joshua cluster.
 """
@@ -129,7 +129,7 @@ def list_commands(ensemble_id: str):
 
 
 def _setup_args():
-    parser = argparse.ArgumentParser(prog="rocksdb_logtool.py")
+    parser = argparse.ArgumentParser(prog="joshua_logtool.py")
 
     parser.add_argument(
         "--cluster-file", type=str, default=None, help="Joshua FDB cluster file"


### PR DESCRIPTION
…st_harness

Tested locally, by injecting an error in logtool the stdout/stderr is reported as XML element, which will not corrupt the output

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
