### PR TITLE
Add `HoltLinearSmoother` class

### DIFF
--- a/design/global-tag-throttling.md
+++ b/design/global-tag-throttling.md
@@ -80,7 +80,7 @@ The ratekeeper must also track the rate of transactions performed with each tag.
 ### Average Cost Calculation
 Quotas are expressed in terms of cost, but because throttling is enforced at the beginning of transactions, budgets need to be calculated in terms of transactions per second. To make this conversion, it is necessary to track the average cost of transactions (per-tag, and per-tag on a particular storage server).
 
-Both cost and transaction counters are smoothed using the `Smoother` class to provide stability over time. The "smoothing interval" can be modified through `SERVER_KNOBS->GLOBAL_TAG_THROTTLING_FOLDING_TIME`.
+Both cost and transaction counters are exponentially smoothed over time, with knob-configurable smoothing intervals.
 
 ### Reserved Rate Calculation
 The global tag throttler periodically reads reserved quotas from the system keyspace. Using these reserved quotas and the average cost of transactions with the given tag, a reserved TPS rate is computed. Read and write rates are aggregated as follows:

--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -833,18 +833,16 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( GLOBAL_TAG_THROTTLING,                                true ); if(isSimulated) GLOBAL_TAG_THROTTLING = deterministicRandom()->coinflip();
 	init( ENFORCE_TAG_THROTTLING_ON_PROXIES,   GLOBAL_TAG_THROTTLING );
 	init( GLOBAL_TAG_THROTTLING_MIN_RATE,                        1.0 );
-	// 10 seconds was chosen as a default value to ensure that
-	// the global tag throttler does not react too drastically to
-	// changes in workload. To make the global tag throttler more reactive,
-	// lower this knob. To make global tag throttler more smooth, raise this knob.
-	// Setting this knob lower than TAG_MEASUREMENT_INTERVAL can cause erratic
-	// behaviour and is not recommended.
-	init( GLOBAL_TAG_THROTTLING_FOLDING_TIME,                   10.0 );
 	init( GLOBAL_TAG_THROTTLING_MAX_TAGS_TRACKED,                 10 );
 	init( GLOBAL_TAG_THROTTLING_TAG_EXPIRE_AFTER,              240.0 );
 	init( GLOBAL_TAG_THROTTLING_PROXY_LOGGING_INTERVAL,         60.0 );
 	init( GLOBAL_TAG_THROTTLING_TRACE_INTERVAL,                  5.0 );
 	init( GLOBAL_TAG_THROTTLING_REPORT_ONLY,                   false );
+
+	init( GLOBAL_TAG_THROTTLING_TARGET_RATE_FOLDING_TIME,        10.0 );
+	init( GLOBAL_TAG_THROTTLING_TRANSACTION_COUNT_FOLDING_TIME,   2.0 );
+	init( GLOBAL_TAG_THROTTLING_TRANSACTION_RATE_FOLDING_TIME,   10.0 );
+	init( GLOBAL_TAG_THROTTLING_COST_FOLDING_TIME,               10.0 );
 
 	//Storage Metrics
 	init( STORAGE_METRICS_AVERAGE_INTERVAL,                    120.0 );

--- a/fdbclient/include/fdbclient/ServerKnobs.h
+++ b/fdbclient/include/fdbclient/ServerKnobs.h
@@ -762,8 +762,6 @@ public:
 	// To protect against this, we do not compute the average cost when the
 	// measured tps drops below this threshold
 	double GLOBAL_TAG_THROTTLING_MIN_RATE;
-	// Used by global tag throttling counters
-	double GLOBAL_TAG_THROTTLING_FOLDING_TIME;
 	// Maximum number of tags tracked by global tag throttler. Additional tags will be ignored
 	// until some existing tags expire
 	int64_t GLOBAL_TAG_THROTTLING_MAX_TAGS_TRACKED;
@@ -778,6 +776,11 @@ public:
 	// compute rates, but these rates won't be sent to GRV proxies for
 	// enforcement.
 	bool GLOBAL_TAG_THROTTLING_REPORT_ONLY;
+
+	double GLOBAL_TAG_THROTTLING_TARGET_RATE_FOLDING_TIME;
+	double GLOBAL_TAG_THROTTLING_TRANSACTION_COUNT_FOLDING_TIME;
+	double GLOBAL_TAG_THROTTLING_TRANSACTION_RATE_FOLDING_TIME;
+	double GLOBAL_TAG_THROTTLING_COST_FOLDING_TIME;
 
 	double MAX_TRANSACTIONS_PER_BYTE;
 

--- a/fdbrpc/include/fdbrpc/Smoother.h
+++ b/fdbrpc/include/fdbrpc/Smoother.h
@@ -23,6 +23,8 @@
 #include "flow/flow.h"
 #include <cmath>
 
+// Implements a basic exponential smoothing algorithm
+// (see https://en.wikipedia.org/wiki/Exponential_smoothing#Basic_(simple)_exponential_smoothing)
 template <class T>
 class SmootherImpl {
 	// Times (t) are expected to be nondecreasing
@@ -76,4 +78,68 @@ class TimerSmoother : public SmootherImpl<TimerSmoother> {
 public:
 	static double now() { return timer(); }
 	explicit TimerSmoother(double eFoldingTime) : SmootherImpl<TimerSmoother>(eFoldingTime) {}
+};
+
+// Implements a Holt linear smoothing algorithm
+// (see https://en.wikipedia.org/wiki/Exponential_smoothing#Double_exponential_smoothing_(Holt_linear))
+// This is more accurate than Smoother for metrics that have a trend.
+template <class T>
+class HoltLinearSmootherImpl {
+	// Times (t) are expected to be nondecreasing
+	double eFoldingTime;
+	double total, lastEstimate, lastRateEstimate, lastTime;
+
+protected:
+	explicit HoltLinearSmootherImpl(double eFoldingTime) : eFoldingTime(eFoldingTime) { reset(0); }
+
+public:
+	void reset(double value) {
+		total = value;
+		lastEstimate = value;
+		lastRateEstimate = 0;
+		lastTime = 0;
+	}
+
+	void setTotal(double total, double t = T::now()) { addDelta(total - this->total, t); }
+
+	void addDelta(double delta, double t = T::now()) {
+		double const elapsed = t - lastTime;
+		if (elapsed) {
+			double const rateEstimate = smoothRate();
+			lastEstimate = smoothTotal();
+			lastRateEstimate = rateEstimate;
+			lastTime = t;
+		}
+		this->total += delta;
+	}
+
+	double smoothTotal(double t = T::now()) const {
+		double const elapsed = t - lastTime;
+		double const alpha = 1 - exp(-elapsed / eFoldingTime);
+		return alpha * total + (1 - alpha) * (lastEstimate + elapsed * lastRateEstimate);
+	}
+
+	double smoothRate(double t = T::now()) const {
+		double const elapsed = t - lastTime;
+		if (elapsed) {
+			double const recentRate = (smoothTotal() - lastEstimate) / elapsed;
+			double const alpha = 1 - exp(-elapsed / eFoldingTime);
+			return alpha * recentRate + (1 - alpha) * lastRateEstimate;
+		} else {
+			return lastRateEstimate;
+		}
+	}
+
+	double getTotal() const { return total; }
+};
+
+class HoltLinearSmoother : public HoltLinearSmootherImpl<HoltLinearSmoother> {
+public:
+	static double now() { return ::now(); }
+	explicit HoltLinearSmoother(double eFoldingTime) : HoltLinearSmootherImpl<HoltLinearSmoother>(eFoldingTime) {}
+};
+class HoltLinearTimerSmoother : public HoltLinearSmootherImpl<HoltLinearTimerSmoother> {
+	static double now() { return timer(); }
+	explicit HoltLinearTimerSmoother(double eFoldingTime)
+	  : HoltLinearSmootherImpl<HoltLinearTimerSmoother>(eFoldingTime) {}
 };

--- a/fdbserver/GlobalTagThrottler.actor.cpp
+++ b/fdbserver/GlobalTagThrottler.actor.cpp
@@ -117,7 +117,7 @@ class GlobalTagThrottlerImpl {
 	// Track various statistics per tag, aggregated across all storage servers
 	class PerTagStatistics {
 		Optional<ThrottleApi::TagQuotaValue> quota;
-		Smoother transactionCounter;
+		HoltLinearSmoother transactionCounter;
 		Smoother perClientRate;
 		Smoother targetRate;
 		double transactionsLastAdded;

--- a/fdbserver/GlobalTagThrottler.actor.cpp
+++ b/fdbserver/GlobalTagThrottler.actor.cpp
@@ -125,7 +125,8 @@ class GlobalTagThrottlerImpl {
 
 	public:
 		explicit PerTagStatistics()
-		  : transactionCounter(SERVER_KNOBS->GLOBAL_TAG_THROTTLING_FOLDING_TIME),
+		  : transactionCounter(SERVER_KNOBS->GLOBAL_TAG_THROTTLING_FOLDING_TIME,
+		                       SERVER_KNOBS->GLOBAL_TAG_THROTTLING_FOLDING_TIME),
 		    perClientRate(SERVER_KNOBS->GLOBAL_TAG_THROTTLING_FOLDING_TIME),
 		    targetRate(SERVER_KNOBS->GLOBAL_TAG_THROTTLING_FOLDING_TIME), transactionsLastAdded(now()), lastLogged(0) {}
 

--- a/fdbserver/GlobalTagThrottler.actor.cpp
+++ b/fdbserver/GlobalTagThrottler.actor.cpp
@@ -100,8 +100,8 @@ class GlobalTagThrottlerImpl {
 
 	public:
 		ThroughputCounters()
-		  : readCost(SERVER_KNOBS->GLOBAL_TAG_THROTTLING_FOLDING_TIME),
-		    writeCost(SERVER_KNOBS->GLOBAL_TAG_THROTTLING_FOLDING_TIME) {}
+		  : readCost(SERVER_KNOBS->GLOBAL_TAG_THROTTLING_COST_FOLDING_TIME),
+		    writeCost(SERVER_KNOBS->GLOBAL_TAG_THROTTLING_COST_FOLDING_TIME) {}
 
 		void updateCost(double newCost, OpType opType) {
 			if (opType == OpType::READ) {
@@ -125,10 +125,11 @@ class GlobalTagThrottlerImpl {
 
 	public:
 		explicit PerTagStatistics()
-		  : transactionCounter(SERVER_KNOBS->GLOBAL_TAG_THROTTLING_FOLDING_TIME,
-		                       SERVER_KNOBS->GLOBAL_TAG_THROTTLING_FOLDING_TIME),
-		    perClientRate(SERVER_KNOBS->GLOBAL_TAG_THROTTLING_FOLDING_TIME),
-		    targetRate(SERVER_KNOBS->GLOBAL_TAG_THROTTLING_FOLDING_TIME), transactionsLastAdded(now()), lastLogged(0) {}
+		  : transactionCounter(SERVER_KNOBS->GLOBAL_TAG_THROTTLING_TRANSACTION_COUNT_FOLDING_TIME,
+		                       SERVER_KNOBS->GLOBAL_TAG_THROTTLING_TRANSACTION_RATE_FOLDING_TIME),
+		    perClientRate(SERVER_KNOBS->GLOBAL_TAG_THROTTLING_TARGET_RATE_FOLDING_TIME),
+		    targetRate(SERVER_KNOBS->GLOBAL_TAG_THROTTLING_TARGET_RATE_FOLDING_TIME), transactionsLastAdded(now()),
+		    lastLogged(0) {}
 
 		Optional<ThrottleApi::TagQuotaValue> getQuota() const { return quota; }
 
@@ -667,7 +668,7 @@ class MockStorageServer {
 		Smoother smoother;
 
 	public:
-		Cost() : smoother(SERVER_KNOBS->GLOBAL_TAG_THROTTLING_FOLDING_TIME) {}
+		Cost() : smoother(SERVER_KNOBS->GLOBAL_TAG_THROTTLING_COST_FOLDING_TIME) {}
 		Cost& operator+=(double delta) {
 			smoother.addDelta(delta);
 			return *this;


### PR DESCRIPTION
This PR creates a `HoltLinearSmoother` class, which implements double exponential smoothing. This class is more accurate than `Smoother` for data with trends. This new class is used for the `GlobalTagThrottlerImpl::PerTagStatistics::transactionCounter` field. Furthermore, the `GLOBAL_TAG_THROTTLING_SMOOTHING_TIME` knob is split into several knobs, to give more fine-grained control over the various smoothers used in `GlobalTagThrottler`. The following knobs are introduced:

- `GLOBAL_TAG_THROTTLING_TARGET_RATE_SMOOTHING_INTERVAL`
- `GLOBAL_TAG_THROTTLING_TRANSACTION_COUNTER_SMOOTHING_INTERVAL` (defaults to 2.0, which is a behaviour change from the previous value of 10.0. This change was based on performance tests)
- `GLOBAL_TAG_THROTTLING_TRANSACTION_RATE_SMOOTHING_INTERVAL`
- `GLOBAL_TAG_THROTTLING_COST_SMOOTHING_INTERVAL`

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
