### PR TITLE
EaR: Add test case to validate decryption with invalid key

### DIFF
--- a/fdbclient/BlobCipher.cpp
+++ b/fdbclient/BlobCipher.cpp
@@ -3107,6 +3107,142 @@ void testEncryptInplaceSingleAuthMode(const int minDomainId) {
 	TraceEvent("BlobCipherTestEncryptInplaceSingleAuthEnd").detail("Mode", authAlgoStr);
 }
 
+void testConfigurableEncryptionInvalidEncryptionKeyNoAuth(const int minDomainId) {
+	ASSERT(CLIENT_KNOBS->ENABLE_CONFIGURABLE_ENCRYPTION);
+
+	TraceEvent("TestConfigurableEncryptionInvalidEncryptKeyNoAuthStart");
+
+	Reference<BlobCipherKeyCache> cipherKeyCache = BlobCipherKeyCache::getInstance();
+
+	// Validate Encryption ops
+	Reference<BlobCipherKey> cipherKey = cipherKeyCache->getLatestCipherKey(minDomainId);
+	Reference<BlobCipherKey> headerCipherKey = cipherKeyCache->getLatestCipherKey(ENCRYPT_HEADER_DOMAIN_ID);
+	const int bufLen = deterministicRandom()->randomInt(786, 2127) + 512;
+	uint8_t orgData[bufLen];
+	deterministicRandom()->randomBytes(&orgData[0], bufLen);
+
+	Arena arena;
+	uint8_t iv[AES_256_IV_LENGTH];
+	deterministicRandom()->randomBytes(&iv[0], AES_256_IV_LENGTH);
+
+	EncryptBlobCipherAes265Ctr encryptor(cipherKey,
+	                                     headerCipherKey,
+	                                     iv,
+	                                     AES_256_IV_LENGTH,
+	                                     EncryptAuthTokenMode::ENCRYPT_HEADER_AUTH_TOKEN_MODE_NONE,
+	                                     BlobCipherMetrics::TEST);
+
+	BlobCipherEncryptHeaderRef headerRef;
+	StringRef encryptedBuf = encryptor.encrypt(&orgData[0], bufLen, &headerRef, arena);
+
+	// Test scenario where 'encryption key' with which the data was encrypted is 'different' from the one decryption
+	// gets attempted
+	AesCtrNoAuth noAuth = std::get<AesCtrNoAuth>(headerRef.algoHeader);
+	Reference<BlobCipherKey> tCipherKey = makeReference<BlobCipherKey>(cipherKey->getDomainId(),
+	                                                                   cipherKey->getBaseCipherId(),
+	                                                                   cipherKey->rawBaseCipher(),
+	                                                                   cipherKey->getBaseCipherLen(),
+	                                                                   cipherKey->getBaseCipherKCV(),
+	                                                                   cipherKey->getRefreshAtTS(),
+	                                                                   cipherKey->getExpireAtTS());
+	ASSERT(!tCipherKey->isEqual(cipherKey));
+	DecryptBlobCipherAes256Ctr decryptor(
+	    tCipherKey, Reference<BlobCipherKey>(), &noAuth.v1.iv[0], BlobCipherMetrics::TEST);
+
+	try {
+		StringRef decryptedBuf = decryptor.decrypt(encryptedBuf.begin(), encryptedBuf.size(), headerRef, arena);
+		ASSERT_EQ(decryptedBuf.size(), bufLen);
+		ASSERT_NE(memcmp(decryptedBuf.begin(), &orgData[0], bufLen), 0);
+	} catch (Error& e) {
+		// underlying layer 'may' throw exception
+		TraceEvent("InvalidEncryptKeyError").error(e);
+	}
+
+	TraceEvent("TestConfigurableEncryptionInvalidEncryptKeyNoAuthEnd");
+}
+
+template <class Params>
+void testConfigurableEncryptionInvalidEncryptKeySingleAuthMode(const int minDomainId) {
+	constexpr bool isHmac = std::is_same_v<Params, AesCtrWithHmacParams>;
+	const std::string authAlgoStr = isHmac ? "HMAC-SHA" : "AES-CMAC";
+	const EncryptAuthTokenAlgo authAlgo = isHmac ? EncryptAuthTokenAlgo::ENCRYPT_HEADER_AUTH_TOKEN_ALGO_HMAC_SHA
+	                                             : EncryptAuthTokenAlgo::ENCRYPT_HEADER_AUTH_TOKEN_ALGO_AES_CMAC;
+	const int algoHeaderVersion = isHmac ? CLIENT_KNOBS->ENCRYPT_HEADER_AES_CTR_HMAC_SHA_AUTH_VERSION
+	                                     : CLIENT_KNOBS->ENCRYPT_HEADER_AES_CTR_AES_CMAC_AUTH_VERSION;
+
+	ASSERT(CLIENT_KNOBS->ENABLE_CONFIGURABLE_ENCRYPTION);
+
+	TraceEvent("TestConfigurableEncryptionSingleAuthStart").detail("Mode", authAlgoStr);
+
+	Reference<BlobCipherKeyCache> cipherKeyCache = BlobCipherKeyCache::getInstance();
+
+	// Validate Encryption ops
+	Reference<BlobCipherKey> cipherKey = cipherKeyCache->getLatestCipherKey(minDomainId);
+	Reference<BlobCipherKey> headerCipherKey = cipherKeyCache->getLatestCipherKey(ENCRYPT_HEADER_DOMAIN_ID);
+	const int bufLen = deterministicRandom()->randomInt(786, 2127) + 512;
+	Arena arena;
+	uint8_t iv[AES_256_IV_LENGTH];
+	deterministicRandom()->randomBytes(&iv[0], AES_256_IV_LENGTH);
+	uint8_t orgData[bufLen];
+	deterministicRandom()->randomBytes(&orgData[0], bufLen);
+
+	EncryptBlobCipherAes265Ctr encryptor(cipherKey,
+	                                     headerCipherKey,
+	                                     iv,
+	                                     AES_256_IV_LENGTH,
+	                                     EncryptAuthTokenMode::ENCRYPT_HEADER_AUTH_TOKEN_MODE_SINGLE,
+	                                     authAlgo,
+	                                     BlobCipherMetrics::TEST);
+	BlobCipherEncryptHeaderRef headerRef;
+	StringRef encryptedBuf = encryptor.encrypt(&orgData[0], bufLen, &headerRef, arena);
+
+	ASSERT_EQ(encryptedBuf.size(), bufLen);
+	ASSERT_NE(memcmp(&orgData[0], encryptedBuf.begin(), bufLen), 0);
+	ASSERT_EQ(headerRef.flagsVersion(), CLIENT_KNOBS->ENCRYPT_HEADER_FLAGS_VERSION);
+	ASSERT_EQ(headerRef.algoHeaderVersion(), algoHeaderVersion);
+
+	// validate flags
+	BlobCipherEncryptHeaderFlagsV1 flags = std::get<BlobCipherEncryptHeaderFlagsV1>(headerRef.flags);
+	ASSERT_EQ(flags.encryptMode, EncryptCipherMode::ENCRYPT_CIPHER_MODE_AES_256_CTR);
+	ASSERT_EQ(flags.authTokenMode, EncryptAuthTokenMode::ENCRYPT_HEADER_AUTH_TOKEN_MODE_SINGLE);
+	ASSERT_EQ(flags.authTokenAlgo, authAlgo);
+
+	// validate IV
+	AesCtrWithAuth<Params> withAuth = std::get<AesCtrWithAuth<Params>>(headerRef.algoHeader);
+	ASSERT_EQ(memcmp(&iv[0], &withAuth.v1.iv[0], AES_256_IV_LENGTH), 0);
+	ASSERT_NE(memcmp(&orgData[0], encryptedBuf.begin(), bufLen), 0);
+	// validate cipherKey details
+	ASSERT_EQ(withAuth.v1.cipherTextDetails.encryptDomainId, cipherKey->getDomainId());
+	ASSERT_EQ(withAuth.v1.cipherTextDetails.baseCipherId, cipherKey->getBaseCipherId());
+	ASSERT_EQ(withAuth.v1.cipherTextDetails.salt, cipherKey->getSalt());
+	ASSERT_EQ(withAuth.v1.cipherHeaderDetails.encryptDomainId, headerCipherKey->getDomainId());
+	ASSERT_EQ(withAuth.v1.cipherHeaderDetails.baseCipherId, headerCipherKey->getBaseCipherId());
+	ASSERT_EQ(withAuth.v1.cipherHeaderDetails.salt, headerCipherKey->getSalt());
+
+	Reference<BlobCipherKey> tCipherKey = cipherKeyCache->getCipherKey(withAuth.v1.cipherTextDetails.encryptDomainId,
+	                                                                   withAuth.v1.cipherTextDetails.baseCipherId,
+	                                                                   withAuth.v1.cipherTextDetails.salt);
+	Reference<BlobCipherKey> hCipherKey = cipherKeyCache->getCipherKey(withAuth.v1.cipherHeaderDetails.encryptDomainId,
+	                                                                   withAuth.v1.cipherHeaderDetails.baseCipherId,
+	                                                                   withAuth.v1.cipherHeaderDetails.salt);
+	ASSERT(tCipherKey->isEqual(cipherKey));
+	ASSERT(hCipherKey->isEqual(headerCipherKey));
+	try {
+
+		// Switch text & header cipher keys to simulate decryption using invalid encryption keys
+		DecryptBlobCipherAes256Ctr decryptor(hCipherKey, tCipherKey, &withAuth.v1.iv[0], BlobCipherMetrics::TEST);
+		StringRef decryptedBuf = decryptor.decrypt(encryptedBuf.begin(), bufLen, headerRef, arena);
+
+		ASSERT_EQ(decryptedBuf.size(), bufLen);
+		ASSERT_EQ(memcmp(decryptedBuf.begin(), &orgData[0], bufLen), 0);
+	} catch (Error& e) {
+		// underlying layer 'may' throw exception
+		TraceEvent("InvalidEncryptKeyError").error(e);
+	}
+
+	TraceEvent("TestConfigurableEncryptionInvalidEncryptKeySingleAuthTokenEnd").detail("Mode", authAlgoStr);
+}
+
 TEST_CASE("/blobCipher") {
 	DomainKeyMap domainKeyMap;
 	auto& g_knobs = IKnobCollection::getMutableGlobalKnobCollection();
@@ -3148,6 +3284,10 @@ TEST_CASE("/blobCipher") {
 	testConfigurableEncryptionNoAuthMode(minDomainId);
 	testConfigurableEncryptionSingleAuthMode<AesCtrWithHmacParams>(minDomainId);
 	testConfigurableEncryptionSingleAuthMode<AesCtrWithCmacParams>(minDomainId);
+
+	testConfigurableEncryptionInvalidEncryptionKeyNoAuth(minDomainId);
+	testConfigurableEncryptionInvalidEncryptKeySingleAuthMode<AesCtrWithHmacParams>(minDomainId);
+	testConfigurableEncryptionInvalidEncryptKeySingleAuthMode<AesCtrWithCmacParams>(minDomainId);
 
 	testEncryptInplaceNoAuthMode(minDomainId);
 	testEncryptInplaceSingleAuthMode<AesCtrWithHmacParams>(minDomainId);

--- a/fdbclient/BlobCipher.cpp
+++ b/fdbclient/BlobCipher.cpp
@@ -3145,6 +3145,7 @@ void testConfigurableEncryptionInvalidEncryptionKeyNoAuth(const int minDomainId)
 	                                                                   cipherKey->getBaseCipherKCV(),
 	                                                                   cipherKey->getRefreshAtTS(),
 	                                                                   cipherKey->getExpireAtTS());
+	// BlobCipherKey uses unique random salt to ensure generated encryption-keys are different
 	ASSERT(!tCipherKey->isEqual(cipherKey));
 	DecryptBlobCipherAes256Ctr decryptor(
 	    tCipherKey, Reference<BlobCipherKey>(), &noAuth.v1.iv[0], BlobCipherMetrics::TEST);
@@ -3234,7 +3235,7 @@ void testConfigurableEncryptionInvalidEncryptKeySingleAuthMode(const int minDoma
 		StringRef decryptedBuf = decryptor.decrypt(encryptedBuf.begin(), bufLen, headerRef, arena);
 
 		ASSERT_EQ(decryptedBuf.size(), bufLen);
-		ASSERT_EQ(memcmp(decryptedBuf.begin(), &orgData[0], bufLen), 0);
+		ASSERT_NE(memcmp(decryptedBuf.begin(), &orgData[0], bufLen), 0);
 	} catch (Error& e) {
 		// underlying layer 'may' throw exception
 		TraceEvent("InvalidEncryptKeyError").error(e);


### PR DESCRIPTION
Description

Extend BlobCipher unit test to provide coverage for the scenario where buffer got encrypted with a EncryptionKey K, however, decryption for some reason got attempted with K'.

Testing

EncryptionUnit.toml - 100K

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
