### PR TITLE
make network address returned by SimExternalConnection's dns resoluti… (Cherry-Pick #10396 to snowflake/release-71.3)

### DIFF
--- a/fdbrpc/SimExternalConnection.actor.cpp
+++ b/fdbrpc/SimExternalConnection.actor.cpp
@@ -151,10 +151,12 @@ std::vector<NetworkAddress> SimExternalConnection::resolveTCPEndpointBlocking(co
 		while (iter != end) {
 			auto endpoint = iter->endpoint();
 			auto addr = endpoint.address();
+			// register the endpoint as public so that if it does happen to be an fdb process, we can connect to it
+			// successfully
 			if (addr.is_v6()) {
-				addrs.emplace_back(IPAddress(addr.to_v6().to_bytes()), endpoint.port());
+				addrs.emplace_back(IPAddress(addr.to_v6().to_bytes()), endpoint.port(), true, false);
 			} else {
-				addrs.emplace_back(addr.to_v4().to_ulong(), endpoint.port());
+				addrs.emplace_back(addr.to_v4().to_ulong(), endpoint.port(), true, false);
 			}
 			++iter;
 		}


### PR DESCRIPTION
Cherry-Pick of #10396

Required for 71.3.1 for simulated http server testing

Original Description:

…on public to fix resolving an fdb process' ip in simulation

100k HTTP* correctness and 100k standard correctness passed (1 unrelated error) on main

On 71.3:
100k HTTP* correctness: 20230606-143116-jslocum-3f3a0f4a9fe5dcd1: no failures

100k standard correctness: 20230606-143051-jslocum-3f3a0f4a9fe5dcd1: no faliures

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
