### PR TITLE
Remove some unnecessary ref-counting in the PTree

### DIFF
--- a/fdbclient/include/fdbclient/VersionedMap.h
+++ b/fdbclient/include/fdbclient/VersionedMap.h
@@ -533,17 +533,15 @@ void split(Reference<PTree<T>> p, const X& x, Reference<PTree<T>>& left, Referen
 }
 
 template <class T>
-void rotate(Reference<PTree<T>>& p, Version at, bool right) {
-	auto r = p->child(!right, at);
-
-	auto n1 = r->child(!right, at);
-	auto n2 = r->child(right, at);
-	auto n3 = p->child(right, at);
-
-	auto newC = update(p, !right, n2, at);
-	newC = update(newC, right, n3, at);
-	p = update(r, !right, n1, at);
-	p = update(p, right, newC, at);
+void rotate(Reference<PTree<T>>& n, Version at, bool right) {
+	auto l = n->child(!right, at);
+	n = update(l, right, update(n, !right, l->child(right, at), at), at);
+	// Diagram for right = true
+	//   n      l
+	//  /        \
+	// l    ->    n
+	//  \        /
+	//   x      x
 }
 
 template <class T>

--- a/fdbclient/include/fdbclient/VersionedMap.h
+++ b/fdbclient/include/fdbclient/VersionedMap.h
@@ -51,14 +51,14 @@ struct PTree : public ReferenceCounted<PTree<T>>, FastAllocated<PTree<T>>, NonCo
 	bool replacedPointer;
 	T data;
 
-	Reference<PTree> child(bool which, Version at) const {
+	const Reference<PTree>& child(bool which, Version at) const {
 		if (updated && lastUpdateVersion <= at && which == replacedPointer)
 			return pointer[2];
 		else
 			return pointer[which];
 	}
-	Reference<PTree> left(Version at) const { return child(false, at); }
-	Reference<PTree> right(Version at) const { return child(true, at); }
+	const Reference<PTree>& left(Version at) const { return child(false, at); }
+	const Reference<PTree>& right(Version at) const { return child(true, at); }
 
 	PTree(const T& data, Version ver) : lastUpdateVersion(ver), updated(false), data(data) {
 		priority = deterministicRandom()->randomUInt32();


### PR DESCRIPTION
- Return const references in PTree accessors
- Remove unnecessary refcounting for rotating ptree

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
