### PR TITLE
Consistency scan test improvements

### DIFF
--- a/fdbcli/ConsistencyScanCommand.actor.cpp
+++ b/fdbcli/ConsistencyScanCommand.actor.cpp
@@ -62,6 +62,8 @@ ACTOR Future<bool> consistencyScanCommandActor(Database db, std::vector<StringRe
 					config.enabled = false;
 				} else if (next == "restart") {
 					config.minStartVersion = tr->getReadVersion().get();
+				} else if (next == "clearstats") {
+					wait(cs.clearStats(tr));
 				} else if (next == "maxRate") {
 					error = args.empty();
 					if (!error) {
@@ -100,7 +102,7 @@ CommandFactory consistencyScanFactory(
     "consistencyscan",
     CommandHelp(
         // TODO:  Expose/document additional configuration options
-        "consistencyscan [on|off] [restart] [maxRate <BYTES_PER_SECOND>] [targetInterval <SECONDS>]",
+        "consistencyscan [on|off] [restart] [clearstats] [maxRate <BYTES_PER_SECOND>] [targetInterval <SECONDS>]",
         "Enables, disables, or sets options for the Consistency Scan role which repeatedly scans "
         "shard replicas for consistency.",
         "`on' enables the scan.\n\n"
@@ -110,6 +112,8 @@ CommandFactory consistencyScanFactory(
         "`maxRate <BYTES_PER_SECOND>' sets the maximum scan read speed rate to BYTES_PER_SECOND, post-replication.\n\n"
         "`targetInterval <SECONDS>' sets the target interval for the scan to SECONDS.  The scan will adjust speed "
         "to attempt to complete in that amount of time but it will not exceed BYTES_PER_SECOND\n\n"
+        "`clearstats` will clear all of the stats for the consistency scan but otherwise leave the configuration as "
+        "is. This can be used to clear errors or reset stat counts, for example."
         "The consistency scan role publishes its configuration and metrics in Status JSON under the path "
         "`.cluster.consistency_scan'\n"
         // TODO:  Syntax hint generator

--- a/fdbrpc/include/fdbrpc/simulator.h
+++ b/fdbrpc/include/fdbrpc/simulator.h
@@ -363,8 +363,40 @@ public:
 	double injectTargetedBMRestartTime = std::numeric_limits<double>::max();
 	double injectTargetedBWRestartTime = std::numeric_limits<double>::max();
 
-	enum SimConsistencyScanState { DisabledStart = 0, Enabling = 1, Enabled = 2, Complete = 3, DisabledEnd = 4 };
+	enum SimConsistencyScanState {
+		DisabledStart = 0,
+		Enabling = 1,
+		Enabled = 2,
+		Enabled_InjectCorruption = 3,
+		Enabled_FoundCorruption = 4,
+		Complete = 5,
+		DisabledEnd = 6
+	};
 	SimConsistencyScanState consistencyScanState = SimConsistencyScanState::DisabledStart;
+
+	// check that validates that the state transition is valid
+	bool updateConsistencyScanState(SimConsistencyScanState expectedCurrent, SimConsistencyScanState desired) {
+		if (consistencyScanState == expectedCurrent && desired > consistencyScanState) {
+			consistencyScanState = desired;
+
+			if (desired == SimConsistencyScanState::Enabled_FoundCorruption) {
+				// reset other metadata
+				consistencyScanInjectedCorruptionType = {};
+				consistencyScanCorruptRequestKey = {};
+				consistencyScanCorruptor = {};
+			}
+
+			return true;
+		}
+		return false;
+	}
+
+	// Inject corruption only in consistency scan reads to ensure scan finds it.
+	enum SimConsistencyScanCorruptionType { FlipMoreFlag = 0, AddToEmpty = 1, RemoveLastRow = 2, ChangeFirstValue = 3 };
+	Optional<SimConsistencyScanCorruptionType> consistencyScanInjectedCorruptionType;
+	Optional<bool> doInjectConsistencyScanCorruption;
+	Optional<Standalone<StringRef>> consistencyScanCorruptRequestKey;
+	Optional<UID> consistencyScanCorruptor;
 
 	std::unordered_map<Standalone<StringRef>, PrivateKey> authKeys;
 

--- a/fdbserver/ConsistencyScan.actor.cpp
+++ b/fdbserver/ConsistencyScan.actor.cpp
@@ -147,7 +147,8 @@ ACTOR Future<std::vector<StorageServerInterface>> loadShardInterfaces(Reference<
 }
 
 // returns error count
-ACTOR Future<int> consistencyCheckReadData(Database cx,
+ACTOR Future<int> consistencyCheckReadData(UID myId,
+                                           Database cx,
                                            KeyRange range,
                                            Version version,
                                            std::vector<StorageServerInterface>* storageServerInterfaces,
@@ -184,7 +185,10 @@ ACTOR Future<int> consistencyCheckReadData(Database cx,
 
 	req.options = readOptions;
 
-	DisabledTraceEvent("ConsistencyCheck_ReadDataStart").detail("Range", range).detail("Version", version);
+	DisabledTraceEvent("ConsistencyCheck_ReadDataStart")
+	    .detail("Range", range)
+	    .detail("Version", version)
+	    .detail("Servers", storageServerInterfaces->size());
 
 	// Try getting the entries in the specified range
 
@@ -199,7 +203,25 @@ ACTOR Future<int> consistencyCheckReadData(Database cx,
 
 	wait(waitForAll(*keyValueFutures));
 
+	bool expectInjected =
+	    storageServerInterfaces->size() > 1 && g_network->isSimulated() && consistencyCheckStartVersion.present() &&
+	    g_simulator->consistencyScanState == ISimulator::SimConsistencyScanState::Enabled_InjectCorruption &&
+	    g_simulator->consistencyScanCorruptRequestKey.present() && g_simulator->consistencyScanCorruptor.present() &&
+	    g_simulator->consistencyScanCorruptor.get() == myId &&
+	    range.contains(g_simulator->consistencyScanCorruptRequestKey.get());
+	if (expectInjected) {
+		TraceEvent(SevWarnAlways, "ConsistencyScanExpectingInjectedCorruption")
+		    .detail("StorageServers", storageServerInterfaces->size())
+		    .detail("ScanState", g_simulator->consistencyScanState)
+		    .detail("CorruptKey", g_simulator->consistencyScanCorruptRequestKey.get())
+		    .detail("ReqRange", range)
+		    .detail("CCStartVersion",
+		            consistencyCheckStartVersion.present() ? consistencyCheckStartVersion.get() : invalidVersion);
+	}
+
 	// Read the resulting entries
+	bool allSucceeded = true;
+	bool foundInjected = false;
 	for (j = 0; j < storageServerInterfaces->size(); j++) {
 		ErrorOr<GetKeyValuesReply> rangeResult = (*keyValueFutures)[j].get();
 
@@ -334,7 +356,59 @@ ACTOR Future<int> consistencyCheckReadData(Database cx,
 					    (g_simulator->getProcessByAddress((*storageServerInterfaces)[j].address())->locality.dcId() !=
 					     g_simulator->getProcessByAddress((*storageServerInterfaces)[firstValidServer->get()].address())
 					         ->locality.dcId());
-					TraceEvent(isExpectedTSSMismatch || isFailed ? SevWarn : SevError,
+
+					if (!isTss && !isFailed && expectInjected) {
+						// Ensure the only corruption we see is the one that was expected to be injected
+						ASSERT(g_simulator->consistencyScanInjectedCorruptionType.present());
+						if (g_simulator->consistencyScanInjectedCorruptionType.get() ==
+						    ISimulator::SimConsistencyScanCorruptionType::FlipMoreFlag) {
+							// only more flag should be different
+							expectInjected = (current.more != reference.more && currentUniques == 0 &&
+							                  referenceUniques == 0 && valueMismatches == 0);
+						} else if (g_simulator->consistencyScanInjectedCorruptionType.get() ==
+						           ISimulator::SimConsistencyScanCorruptionType::AddToEmpty) {
+							expectInjected =
+							    (current.more == reference.more && current.data.size() + reference.data.size() == 1);
+							if (expectInjected) {
+								KeyValueRef& kv = current.data.empty() ? reference.data[0] : current.data[0];
+								expectInjected = kv.key == g_simulator->consistencyScanCorruptRequestKey.get() &&
+								                 kv.value == "consistencyCheckCorruptValue"_sr;
+							}
+						} else if (g_simulator->consistencyScanInjectedCorruptionType.get() ==
+						           ISimulator::SimConsistencyScanCorruptionType::RemoveLastRow) {
+							expectInjected = (current.more == reference.more && valueMismatches == 0 &&
+							                  currentUniques + referenceUniques == 1 &&
+							                  std::abs(current.data.size() - reference.data.size()) == 1);
+							if (expectInjected) {
+								// make sure the unique was the last key
+								for (int i = 0; i < current.data.size() && i < reference.data.size(); i++) {
+									if (current.data[i] != reference.data[i]) {
+										expectInjected = false;
+										break;
+									}
+								}
+							}
+						} else if (g_simulator->consistencyScanInjectedCorruptionType.get() ==
+						           ISimulator::SimConsistencyScanCorruptionType::ChangeFirstValue) {
+							expectInjected =
+							    (current.more == reference.more && valueMismatches == 1 && currentUniques == 0 &&
+							     referenceUniques == 0 && valueMismatchKey == current.data[0].key &&
+							     std::abs(current.data[0].value.size() - reference.data[0].value.size()) == 1);
+							if (expectInjected) {
+								// make sure the value difference was just truncating the last byte
+								Value shorter = current.data[0].value < reference.data[0].value
+								                    ? current.data[0].value
+								                    : reference.data[0].value;
+								Value longer = current.data[0].value < reference.data[0].value ? reference.data[0].value
+								                                                               : current.data[0].value;
+								expectInjected = (shorter == longer.substr(0, shorter.size()));
+							}
+						} else {
+							ASSERT(false);
+						}
+					}
+
+					TraceEvent(isExpectedTSSMismatch || isFailed || expectInjected ? SevWarn : SevError,
 					           "ConsistencyCheck_DataInconsistent")
 					    .detail(format("StorageServer%d", j).c_str(), (*storageServerInterfaces)[j].id())
 					    .detail(format("StorageServer%d", firstValidServer->get()).c_str(),
@@ -349,18 +423,51 @@ ACTOR Future<int> consistencyCheckReadData(Database cx,
 					    .detail("ValueMismatches", valueMismatches)
 					    .detail("ValueMismatchKey", valueMismatchKey)
 					    .detail("MatchingKVPairs", matchingKVPairs)
-					    .detail("IsTSS", isTss);
+					    .detail(format("Server%dHasMore", j).c_str(), current.more)
+					    .detail(format("Server%dHasMore", firstValidServer->get()).c_str(), reference.more)
+					    .detail("IsTSS", isTss)
+					    .detail("IsInjected", expectInjected);
+
+					if (expectInjected) {
+						foundInjected = true;
+						CODE_PROBE(true, "consistency check detected injected corruption");
+						// we found the injected corruption, clear the state
+						TraceEvent(SevWarnAlways, "ConsistencyScanFoundInjectedCorruption")
+						    .detail("CorruptionType", g_simulator->consistencyScanInjectedCorruptionType.get())
+						    .detail("Version", req.version);
+						g_simulator->updateConsistencyScanState(
+						    ISimulator::SimConsistencyScanState::Enabled_InjectCorruption,
+						    ISimulator::SimConsistencyScanState::Enabled_FoundCorruption);
+					}
 
 					if (!isExpectedTSSMismatch) {
-						int issues = currentUniques + referenceUniques + valueMismatches;
+						int issues = currentUniques + referenceUniques + valueMismatches +
+						             ((current.more == reference.more) ? 0 : 1);
 						ASSERT(issues > 0);
 						return issues;
 					}
+
 					if (isFailed) {
 						throw wrong_shard_server();
 					}
 				}
 			}
+		} else {
+			allSucceeded = false;
+		}
+	}
+
+	if (expectInjected && !foundInjected) {
+		if (allSucceeded) {
+			// should for sure have found it
+			TraceEvent(SevError, "ConsistencyCheck_ShouldHaveFoundInjectedCorruption");
+		} else {
+			CODE_PROBE(true,
+			           "consistency check potentially missed injected corruption due to failures",
+			           probe::decoration::rare);
+			TraceEvent(SevInfo, "ConsistencyCheck_MissedCorruptionDueToFailures");
+			g_simulator->updateConsistencyScanState(ISimulator::SimConsistencyScanState::Enabled_InjectCorruption,
+			                                        ISimulator::SimConsistencyScanState::Enabled_FoundCorruption);
 		}
 	}
 
@@ -635,10 +742,48 @@ ACTOR Future<Void> consistencyScanCore(Database db,
 					state Optional<Error> failedRequest;
 
 					if (scanRange) {
+						// inject corruption if desired in simulation
+						if (g_network->isSimulated() &&
+						    g_simulator->consistencyScanState == ISimulator::SimConsistencyScanState::Enabled &&
+						    g_simulator->doInjectConsistencyScanCorruption.present() &&
+						    g_simulator->doInjectConsistencyScanCorruption.get() &&
+						    (deterministicRandom()->random01() < 0.1 || targetRange.end == allKeys.end)) {
+							if (storageServerInterfaces.size() > 1) {
+								// sometimes do the first key in the range, sometimes try to do a later key in the range
+								Key corruptKey = targetRange.begin;
+								if (deterministicRandom()->coinflip() && targetRange.end.size() > 0) {
+									Key corruptKey2 = targetRange.end.substr(0, targetRange.end.size() - 1);
+									if (corruptKey2 > corruptKey) {
+										corruptKey = corruptKey2;
+									}
+								}
+								g_simulator->consistencyScanCorruptRequestKey = corruptKey;
+								g_simulator->consistencyScanCorruptor = memState->csId;
+								g_simulator->updateConsistencyScanState(
+								    ISimulator::SimConsistencyScanState::Enabled,
+								    ISimulator::SimConsistencyScanState::Enabled_InjectCorruption);
+								TraceEvent(
+								    SevWarnAlways, "ConsistencyScanProgressScanRangeInjectCorruption", memState->csId)
+								    .detail("StartKey", targetRange.begin)
+								    .detail("CorruptKey", corruptKey)
+								    .detail("Storages", storageServerInterfaces.size());
+							} else {
+								// since we can't notice the corruption with only 1 server, just skip it
+								CODE_PROBE(true, "skipping consistency scan corruption check because only 1 replica");
+								g_simulator->updateConsistencyScanState(
+								    ISimulator::SimConsistencyScanState::Enabled,
+								    ISimulator::SimConsistencyScanState::Enabled_FoundCorruption);
+								TraceEvent(SevWarnAlways,
+								           "ConsistencyScanProgressScanRangeSkipInjectCorruption",
+								           memState->csId)
+								    .detail("StartKey", targetRange.begin);
+							}
+						}
 						if (DEBUG_SCAN_PROGRESS) {
 							TraceEvent(SevDebug, "ConsistencyScanProgressScanRangeStart", memState->csId)
 							    .detail("StartKey", targetRange.begin);
 						}
+
 						// Stats for *this unit of durable progress only*, which will be committed atomically with the
 						// endKey update. Total bytes from all replicas read
 						state int64_t replicatedBytesRead = 0;
@@ -662,7 +807,8 @@ ACTOR Future<Void> consistencyScanCore(Database db,
 						loop {
 							state std::vector<Future<ErrorOr<GetKeyValuesReply>>> keyValueFutures;
 							state Optional<int> firstValidServer;
-							int newErrors = wait(consistencyCheckReadData(db,
+							int newErrors = wait(consistencyCheckReadData(memState->csId,
+							                                              db,
 							                                              targetRange,
 							                                              tr->getReadVersion().get(),
 							                                              &storageServerInterfaces,
@@ -684,7 +830,7 @@ ACTOR Future<Void> consistencyScanCore(Database db,
 								}
 							}
 
-							if (!failedRequest.present()) {
+							if (!failedRequest.present() && !newErrors) {
 								ASSERT(firstValidServer.present());
 								GetKeyValuesReply rangeResult = keyValueFutures[firstValidServer.get()].get().get();
 								logicalBytesRead += rangeResult.data.expectedSize();
@@ -696,11 +842,35 @@ ACTOR Future<Void> consistencyScanCore(Database db,
 									VectorRef<KeyValueRef> result =
 									    keyValueFutures[firstValidServer.get()].get().get().data;
 									ASSERT(result.size() > 0);
-									statsCurrentRound.lastEndKey = keyAfter(result[result.size() - 1].key);
+									statsCurrentRound.lastEndKey = keyAfter(result.back().key);
 									targetRange = KeyRangeRef(statsCurrentRound.lastEndKey, targetRange.end);
 									if (targetRange.empty()) {
+										noMoreRecords = targetRange.end == allKeys.end;
 										break;
 									}
+								}
+							} else if (!failedRequest.present() && newErrors) {
+								// responses will disagree on the next key, just take the max of the possible ones to
+								// ensure we can make progress past this corruption
+								Key nextKey = statsCurrentRound.lastEndKey;
+								for (int i = 0; i < storageServerInterfaces.size(); i++) {
+									GetKeyValuesReply rangeResult = keyValueFutures[i].get().get();
+									if (i == firstValidServer.get()) {
+										logicalBytesRead += rangeResult.data.expectedSize();
+									}
+									Key storageNextKey = (rangeResult.more && rangeResult.data.size() > 0)
+									                         ? keyAfter(rangeResult.data.back().key)
+									                         : targetRange.end;
+									if (storageNextKey > nextKey) {
+										nextKey = storageNextKey;
+									}
+								}
+								statsCurrentRound.lastEndKey = nextKey;
+								if (nextKey == targetRange.end) {
+									noMoreRecords = nextKey == allKeys.end;
+									break;
+								} else {
+									targetRange = KeyRangeRef(nextKey, targetRange.end);
 								}
 							} else {
 								// transaction too old expected here for large shards
@@ -852,6 +1022,11 @@ ACTOR Future<Void> enableConsistencyScanInSim(Database db, UID csId) {
 	state ConsistencyScanState cs;
 	ASSERT(g_network->isSimulated());
 	TraceEvent("ConsistencyScan_SimEnable", csId).log();
+	if (g_simulator->willRestart) {
+		// FIXME: better handling for checking for consistency scan in restarting tests
+		TraceEvent("ConsistencyScan_SimEnableSkipBeforeRestart", csId).log();
+		return Void();
+	}
 	loop {
 		try {
 			SystemDBWriteLockedNow(db.getReference())->setOptions(tr);
@@ -866,7 +1041,14 @@ ACTOR Future<Void> enableConsistencyScanInSim(Database db, UID csId) {
 				return Void();
 			}
 			if (!config.enabled && g_simulator->consistencyScanState < ISimulator::SimConsistencyScanState::Enabled) {
-				g_simulator->consistencyScanState = ISimulator::SimConsistencyScanState::Enabling;
+				if (!g_simulator->doInjectConsistencyScanCorruption.present()) {
+					g_simulator->doInjectConsistencyScanCorruption = BUGGIFY_WITH_PROB(0.1);
+					TraceEvent("ConsistencyScan_DoInjectCorruption")
+					    .detail("Val", g_simulator->doInjectConsistencyScanCorruption.get());
+				}
+
+				g_simulator->updateConsistencyScanState(ISimulator::SimConsistencyScanState::DisabledStart,
+				                                        ISimulator::SimConsistencyScanState::Enabling);
 				config.enabled = true;
 			} else if (BUGGIFY_WITH_PROB(0.5)) {
 				config.minStartVersion = tr->getReadVersion().get();
@@ -882,7 +1064,8 @@ ACTOR Future<Void> enableConsistencyScanInSim(Database db, UID csId) {
 				cs.config().set(tr, config);
 				wait(tr->commit());
 
-				g_simulator->consistencyScanState = ISimulator::SimConsistencyScanState::Enabled;
+				g_simulator->updateConsistencyScanState(ISimulator::SimConsistencyScanState::Enabling,
+				                                        ISimulator::SimConsistencyScanState::Enabled);
 				TraceEvent("ConsistencyScan_SimEnabled")
 				    .detail("MaxReadByteRate", config.maxReadByteRate)
 				    .detail("TargetRoundTimeSeconds", config.targetRoundTimeSeconds)
@@ -938,8 +1121,13 @@ ACTOR Future<Void> disableConsistencyScanInSim(Database db,
 	// FIXME: sometimes maybe don't wait for scan to stop, just disable it anyway?
 	ASSERT(g_network->isSimulated());
 	loop {
+		bool waitForCorruption = g_simulator->doInjectConsistencyScanCorruption.present() &&
+		                         g_simulator->doInjectConsistencyScanCorruption.get();
 		if (g_simulator->speedUpSimulation &&
-		    g_simulator->consistencyScanState >= ISimulator::SimConsistencyScanState::Enabled) {
+		    ((waitForCorruption &&
+		      g_simulator->consistencyScanState >= ISimulator::SimConsistencyScanState::Enabled_FoundCorruption) ||
+		     (!waitForCorruption &&
+		      g_simulator->consistencyScanState >= ISimulator::SimConsistencyScanState::Enabled))) {
 			break;
 		}
 		double delayTime = std::max(1.0, FLOW_KNOBS->SIM_SPEEDUP_AFTER_SECONDS - now());
@@ -962,7 +1150,11 @@ ACTOR Future<Void> disableConsistencyScanInSim(Database db,
 
 			// Enable if disable, else set the scan min version to restart it
 			if (config.enabled) {
-				g_simulator->consistencyScanState = ISimulator::SimConsistencyScanState::Complete;
+				// state was either enabled or enabled_foundcorruption
+				g_simulator->updateConsistencyScanState(ISimulator::SimConsistencyScanState::Enabled,
+				                                        ISimulator::SimConsistencyScanState::Complete);
+				g_simulator->updateConsistencyScanState(ISimulator::SimConsistencyScanState::Enabled_FoundCorruption,
+				                                        ISimulator::SimConsistencyScanState::Complete);
 				config.enabled = false;
 			} else {
 				TraceEvent("ConsistencyScan_SimDisableAlreadyDisabled", memState->csId).log();
@@ -982,10 +1174,25 @@ ACTOR Future<Void> disableConsistencyScanInSim(Database db,
 		}
 	}
 
-	g_simulator->consistencyScanState = ISimulator::SimConsistencyScanState::DisabledEnd;
+	g_simulator->updateConsistencyScanState(ISimulator::SimConsistencyScanState::Complete,
+	                                        ISimulator::SimConsistencyScanState::DisabledEnd);
 	CODE_PROBE(true, "Consistency Scan disabled in simulation");
 	TraceEvent("ConsistencyScan_SimDisabled", memState->csId).log();
 	return Void();
+}
+
+void resetSimCorruptionCheckOnDeath(Reference<ConsistencyScanMemoryState> memState) {
+	if (!g_network->isSimulated()) {
+		return;
+	}
+	if (g_simulator->consistencyScanCorruptor.present() &&
+	    g_simulator->consistencyScanCorruptor.get() == memState->csId) {
+		TraceEvent("ConsistencyScan_ResetCorruptionOnDeath");
+		CODE_PROBE(
+		    true, "Consistency Scan skipped corruption check because scan died in the middle", probe::decoration::rare);
+		g_simulator->updateConsistencyScanState(ISimulator::SimConsistencyScanState::Enabled_InjectCorruption,
+		                                        ISimulator::SimConsistencyScanState::Enabled_FoundCorruption);
+	}
 }
 
 ACTOR Future<Void> consistencyScan(ConsistencyScanInterface csInterf, Reference<AsyncVar<ServerDBInfo> const> dbInfo) {
@@ -1017,6 +1224,7 @@ ACTOR Future<Void> consistencyScan(ConsistencyScanInterface csInterf, Reference<
 					ASSERT(false);
 				}
 				when(HaltConsistencyScanRequest req = waitNext(csInterf.haltConsistencyScan.getFuture())) {
+					resetSimCorruptionCheckOnDeath(memState);
 					req.reply.send(Void());
 					core = Void();
 					TraceEvent("ConsistencyScan_Halted", csInterf.id()).detail("ReqID", req.requesterID);
@@ -1028,6 +1236,7 @@ ACTOR Future<Void> consistencyScan(ConsistencyScanInterface csInterf, Reference<
 				}
 			}
 		} catch (Error& err) {
+			resetSimCorruptionCheckOnDeath(memState);
 			TraceEvent("ConsistencyScan_Error", csInterf.id()).errorUnsuppressed(err);
 			throw;
 		}
@@ -1627,7 +1836,8 @@ ACTOR Future<Void> checkDataConsistency(Database cx,
 					state Optional<int> firstValidServer;
 
 					totalReadAmount = 0;
-					int failures = wait(consistencyCheckReadData(cx,
+					int failures = wait(consistencyCheckReadData(UID(),
+					                                             cx,
 					                                             readRange,
 					                                             version,
 					                                             &storageServerInterfaces,

--- a/fdbserver/ConsistencyScan.actor.cpp
+++ b/fdbserver/ConsistencyScan.actor.cpp
@@ -1243,20 +1243,6 @@ ACTOR Future<Void> consistencyScan(ConsistencyScanInterface csInterf, Reference<
 	}
 }
 
-/*ACTOR Future<Void> consistencyScanStateClearStats(ConsistencyScanState* cs, Reference<ReadYourWritesTransaction> tr) {
-    // read the keyspaces so the transaction conflicts on write (key-backed properties don't expose conflict ranges, and
-the extra work here is negligible because this is a rare manual command so performance is not a huge concern)
-    wait(success(cs->currentRoundStats().getD(tr)) && success(cs->lifetimeStats().getD(tr)) &&
-success(cs->roundStatsHistory().getRange(tr, {}, {}, 1, Snapshot::False, Reverse::False)));
-
-    // update each of the stats keyspaces to empty
-    cs->currentRoundStats().set(tr, ConsistencyScanState::RoundStats());
-    cs->lifetimeStats().set(tr, ConsistencyScanState::LifetimeStats());
-    cs->roundStatsHistory().erase(tr, 0, MAX_VERSION);
-
-    return Void();
-}*/
-
 ///////////////////////////////////////////////////////
 // Everything below this line is not relevant to the ConsistencyScan Role anymore.
 // It is only used by workloads/ConsistencyCheck

--- a/fdbserver/ConsistencyScan.actor.cpp
+++ b/fdbserver/ConsistencyScan.actor.cpp
@@ -899,11 +899,43 @@ ACTOR Future<Void> enableConsistencyScanInSim(Database db, UID csId) {
 	return Void();
 }
 
-ACTOR Future<Void> disableConsistencyScanInSim(Database db, Reference<ConsistencyScanMemoryState> memState) {
+ACTOR Future<Void> sometimesRandomlyClearStatsInSim(Database db, Reference<ConsistencyScanMemoryState> memState) {
+	ASSERT(g_network->isSimulated());
+
+	state Reference<ReadYourWritesTransaction> tr = makeReference<ReadYourWritesTransaction>(db);
+	state ConsistencyScanState cs;
+
+	if (BUGGIFY_WITH_PROB(0.1) && !g_simulator->speedUpSimulation) {
+		TraceEvent("ConsistencyScan_RandomStatClearWaiting", memState->csId).log();
+		wait(delay(deterministicRandom()->randomInt(1, 60)));
+
+		TraceEvent("ConsistencyScan_RandomStatClearing", memState->csId).log();
+		loop {
+			try {
+				SystemDBWriteLockedNow(db.getReference())->setOptions(tr);
+				wait(cs.clearStats(tr));
+				wait(tr->commit());
+				break;
+			} catch (Error& e) {
+				wait(tr->onError(e));
+			}
+		}
+
+		TraceEvent("ConsistencyScan_RandomStatCleared", memState->csId).log();
+	}
+
+	return Void();
+}
+
+ACTOR Future<Void> disableConsistencyScanInSim(Database db,
+                                               Reference<ConsistencyScanMemoryState> memState,
+                                               Future<Void> waitBeforeDisable) {
 	state Reference<ReadYourWritesTransaction> tr = makeReference<ReadYourWritesTransaction>(db);
 	state ConsistencyScanState cs;
 	TraceEvent("ConsistencyScan_SimDisableWaiting", memState->csId).log();
+	wait(waitBeforeDisable);
 	// FIXME: also wait until we've done the canary failure
+	// FIXME: sometimes maybe don't wait for scan to stop, just disable it anyway?
 	ASSERT(g_network->isSimulated());
 	loop {
 		if (g_simulator->speedUpSimulation &&
@@ -968,11 +1000,13 @@ ACTOR Future<Void> consistencyScan(ConsistencyScanInterface csInterf, Reference<
 	state Future<Void> core = consistencyScanCore(db, memState, ConsistencyScanState());
 
 	// Enable consistencyScan in simulation
-	// TODO:  Move this to a BehaviorInjection workload once that concept exists.
+	// TODO: Move this to a BehaviorInjection workload once that concept exists.
 	if (g_network->isSimulated()) {
 		wait(enableConsistencyScanInSim(db, csInterf.id()));
 		// even if we don't enable it, if a previous incarnation did, we still need to disable it
-		actors.add(disableConsistencyScanInSim(db, memState));
+		Future<Void> chaosStatsClear = sometimesRandomlyClearStatsInSim(db, memState);
+		actors.add(chaosStatsClear);
+		actors.add(disableConsistencyScanInSim(db, memState, chaosStatsClear));
 	}
 
 	loop {
@@ -999,6 +1033,20 @@ ACTOR Future<Void> consistencyScan(ConsistencyScanInterface csInterf, Reference<
 		}
 	}
 }
+
+/*ACTOR Future<Void> consistencyScanStateClearStats(ConsistencyScanState* cs, Reference<ReadYourWritesTransaction> tr) {
+    // read the keyspaces so the transaction conflicts on write (key-backed properties don't expose conflict ranges, and
+the extra work here is negligible because this is a rare manual command so performance is not a huge concern)
+    wait(success(cs->currentRoundStats().getD(tr)) && success(cs->lifetimeStats().getD(tr)) &&
+success(cs->roundStatsHistory().getRange(tr, {}, {}, 1, Snapshot::False, Reverse::False)));
+
+    // update each of the stats keyspaces to empty
+    cs->currentRoundStats().set(tr, ConsistencyScanState::RoundStats());
+    cs->lifetimeStats().set(tr, ConsistencyScanState::LifetimeStats());
+    cs->roundStatsHistory().erase(tr, 0, MAX_VERSION);
+
+    return Void();
+}*/
 
 ///////////////////////////////////////////////////////
 // Everything below this line is not relevant to the ConsistencyScan Role anymore.

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -4481,12 +4481,14 @@ void maybeInjectConsistencyScanCorruption(UID thisServerID, GetKeyValuesRequest 
 	CODE_PROBE(true, "consistency check injecting corruption");
 
 	// FIXME: code probe for each type?
-	// FIXME: weird memory issues when messing with actual response data, enable and figure out later
+
 	if (true /*deterministicRandom()->random01() < 0.3*/) {
 		// flip more flag
 		reply.more = !reply.more;
 		g_simulator->consistencyScanInjectedCorruptionType = ISimulator::SimConsistencyScanCorruptionType::FlipMoreFlag;
 	} else {
+		// FIXME: weird memory issues when messing with actual response data, enable and figure out later
+		ASSERT(false);
 		// make deep copy of request, since some of the underlying memory can reference storage engine data directly
 		GetKeyValuesReply copy = reply;
 		reply = GetKeyValuesReply();

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -4470,6 +4470,58 @@ KeyRange getShardKeyRange(StorageServer* data, const KeySelectorRef& sel)
 	return KeyRangeRef(begin, end);
 }
 
+void maybeInjectConsistencyScanCorruption(UID thisServerID, GetKeyValuesRequest const& req, GetKeyValuesReply& reply) {
+	if (g_simulator->consistencyScanState != ISimulator::SimConsistencyScanState::Enabled_InjectCorruption ||
+	    !req.options.present() || !req.options.get().consistencyCheckStartVersion.present() ||
+	    g_simulator->consistencyScanInjectedCorruptionType.present() ||
+	    !g_simulator->consistencyScanCorruptRequestKey.present()) {
+		return;
+	}
+
+	CODE_PROBE(true, "consistency check injecting corruption");
+
+	// FIXME: code probe for each type?
+	// FIXME: weird memory issues when messing with actual response data, enable and figure out later
+	if (true /*deterministicRandom()->random01() < 0.3*/) {
+		// flip more flag
+		reply.more = !reply.more;
+		g_simulator->consistencyScanInjectedCorruptionType = ISimulator::SimConsistencyScanCorruptionType::FlipMoreFlag;
+	} else {
+		// make deep copy of request, since some of the underlying memory can reference storage engine data directly
+		GetKeyValuesReply copy = reply;
+		reply = GetKeyValuesReply();
+		reply.more = copy.more;
+		reply.cached = copy.cached;
+		reply.version = copy.version;
+		reply.data.append_deep(reply.arena, copy.data.begin(), copy.data.size());
+
+		if (reply.data.empty()) {
+			// add row to empty response
+			g_simulator->consistencyScanInjectedCorruptionType =
+			    ISimulator::SimConsistencyScanCorruptionType::AddToEmpty;
+			reply.data.push_back_deep(
+			    reply.arena,
+			    KeyValueRef(g_simulator->consistencyScanCorruptRequestKey.get(), "consistencyCheckCorruptValue"_sr));
+		} else if (deterministicRandom()->coinflip() || reply.data.back().value.empty()) {
+			// change value in non-empty response
+			g_simulator->consistencyScanInjectedCorruptionType =
+			    ISimulator::SimConsistencyScanCorruptionType::RemoveLastRow;
+			reply.data.pop_back();
+		} else {
+			// chop off last byte of first value
+			g_simulator->consistencyScanInjectedCorruptionType =
+			    ISimulator::SimConsistencyScanCorruptionType::ChangeFirstValue;
+
+			reply.data[0].value = reply.data[0].value.substr(0, reply.data[0].value.size() - 1);
+		}
+	}
+
+	TraceEvent(SevWarnAlways, "InjectedConsistencyScanCorruption", thisServerID)
+	    .detail("CorruptionType", g_simulator->consistencyScanInjectedCorruptionType.get())
+	    .detail("Version", req.version)
+	    .detail("Count", reply.data.size());
+}
+
 ACTOR Future<Void> getKeyValuesQ(StorageServer* data, GetKeyValuesRequest req)
 // Throws a wrong_shard_server if the keys in the request or result depend on data outside this server OR if a large
 // selector offset prevents all data from being read in one range read
@@ -4587,6 +4639,10 @@ ACTOR Future<Void> getKeyValuesQ(StorageServer* data, GetKeyValuesRequest req)
 			data->checkChangeCounter(changeCounter,
 			                         KeyRangeRef(std::min<KeyRef>(req.begin.getKey(), req.end.getKey()),
 			                                     std::max<KeyRef>(req.begin.getKey(), req.end.getKey())));
+
+			if (g_network->isSimulated()) {
+				maybeInjectConsistencyScanCorruption(data->thisServerID, req, none);
+			}
 			req.reply.send(none);
 		} else {
 			state int remainingLimitBytes = req.limitBytes;
@@ -4639,6 +4695,9 @@ ACTOR Future<Void> getKeyValuesQ(StorageServer* data, GetKeyValuesRequest req)
 			}
 
 			r.penalty = data->getPenalty();
+			if (g_network->isSimulated()) {
+				maybeInjectConsistencyScanCorruption(data->thisServerID, req, r);
+			}
 			req.reply.send(r);
 
 			resultSize = req.limitBytes - remainingLimitBytes;


### PR DESCRIPTION
Changes
- add fdbcli command to clear stats
- add test to inject corruption and ensure the scan finds it
- added more of a proper state machine of consistency scan state

With corruption injection buggify rate increased to 80% instead of 10%
 - Passed 100k correctness 
 - Passed 10k asan

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
