### PR TITLE
Cherry-pick commit to implement IStorageMetricsService interface

### DIFF
--- a/fdbserver/BlobMigrator.actor.cpp
+++ b/fdbserver/BlobMigrator.actor.cpp
@@ -19,12 +19,15 @@
  */
 #include <algorithm>
 #include <cmath>
+#include <cstddef>
 #include <string>
 #include "fdbclient/ClientBooleanParams.h"
 #include "fdbclient/Knobs.h"
 #include "fdbserver/RestoreCommon.actor.h"
 #include "fdbserver/RestoreUtil.h"
+#include "fdbserver/StorageMetrics.actor.h"
 #include "flow/CodeProbe.h"
+#include "flow/Error.h"
 #include "flow/network.h"
 #include "flow/flow.h"
 #include "flow/ActorCollection.h"
@@ -50,6 +53,8 @@
 #include "fdbserver/BlobMigratorInterface.h"
 #include "fdbserver/Knobs.h"
 #include "flow/genericactors.actor.h"
+#include "fmt/core.h"
+
 #include "flow/actorcompiler.h" // has to be last include
 #include "fmt/core.h"
 
@@ -63,7 +68,7 @@ static inline void dprint(fmt::format_string<T...> fmt, T&&... args) {
 
 // BlobMigrator offers APIs to migrate data from blob storage to storage server. It implements a minimal set of
 // StorageServerInterface APIs which are needed for DataDistributor to start data migration.
-class BlobMigrator : public NonCopyable, public ReferenceCounted<BlobMigrator> {
+class BlobMigrator : public NonCopyable, public ReferenceCounted<BlobMigrator>, public IStorageMetricsService {
 public:
 	BlobMigrator(BlobMigratorInterface interf, Reference<AsyncVar<ServerDBInfo> const> dbInfo)
 	  : interf_(interf), actors_(false), dbInfo_(dbInfo) {
@@ -525,6 +530,7 @@ private:
 		self->actors_.add(waitFailureServer(self->interf_.waitFailure.getFuture()));
 		self->actors_.add(handleRequest(self));
 		self->actors_.add(handleUnsupportedRequest(self));
+		self->addActor(serveStorageMetricsRequests(self.getPtr(), self->interf_.ssi));
 		loop {
 			try {
 				choose {
@@ -558,26 +564,6 @@ private:
 						GetShardStateReply rep(version, version);
 						req.reply.send(rep); // return empty shards
 					}
-					when(WaitMetricsRequest req = waitNext(ssi.waitMetrics.getFuture())) {
-						// dprint("Handle WaitMetricsRequest\n");
-						self->actors_.add(processWaitMetricsRequest(self, req));
-					}
-					when(SplitMetricsRequest req = waitNext(ssi.splitMetrics.getFuture())) {
-						// dprint("Handle SplitMetrics {} limit {} bytes\n", req.keys.toString(), req.limits.bytes);
-						processSplitMetricsRequest(self, req);
-					}
-					when(GetStorageMetricsRequest req = waitNext(ssi.getStorageMetrics.getFuture())) {
-						StorageMetrics metrics;
-						metrics.bytes = sizeInBytes(self);
-						GetStorageMetricsReply resp;
-						resp.load = metrics;
-						resp.available = StorageMetrics();
-						resp.capacity = StorageMetrics();
-						resp.bytesInputRate = 0;
-						resp.versionLag = 0;
-						resp.lastUpdate = now();
-						req.reply.send(resp);
-					}
 					when(ReplyPromise<KeyValueStoreType> reply = waitNext(ssi.getKeyValueStoreType.getFuture())) {
 						dprint("Handle KeyValueStoreType\n");
 						reply.send(KeyValueStoreType::MEMORY);
@@ -596,16 +582,8 @@ private:
 		loop {
 			try {
 				choose {
-					when(SplitRangeRequest req = waitNext(ssi.getRangeSplitPoints.getFuture())) {
-						dprint("Unsupported SplitRangeRequest\n");
-						req.reply.sendError(broken_promise());
-					}
 					when(StorageQueuingMetricsRequest req = waitNext(ssi.getQueuingMetrics.getFuture())) {
-						self->actors_.add(processStorageQueuingMetricsRequest(req));
-					}
-					when(ReadHotSubRangeRequest req = waitNext(ssi.getReadHotRanges.getFuture())) {
-						dprint("Unsupported ReadHotSubRange\n");
-						req.reply.sendError(unsupported_operation());
+						self->addActor(processStorageQueuingMetricsRequest(req));
 					}
 					when(GetKeyValuesStreamRequest req = waitNext(ssi.getKeyValuesStream.getFuture())) {
 						dprint("Unsupported GetKeyValuesStreamRequest\n");
@@ -653,41 +631,13 @@ private:
 		}
 	}
 
-	// This API is used by DD to figure out split points for data movement.
-	static void processSplitMetricsRequest(Reference<BlobMigrator> self, SplitMetricsRequest req) {
-		SplitMetricsReply rep;
-		int64_t bytes = 0; // number of bytes accumulated for current split
-		for (auto& granule : self->blobGranules_) {
-			if (!req.keys.contains(granule.keyRange)) {
-				continue;
-			}
-			bytes += granule.sizeInBytes;
-			if (bytes < req.limits.bytes) {
-				continue;
-			}
-			// Add a split point if the key range exceeds expected minimal size in bytes
-			rep.splits.push_back_deep(rep.splits.arena(), granule.keyRange.end);
-			bytes = 0;
-			// Limit number of splits in single response for fast RPC processing
-			if (rep.splits.size() > SERVER_KNOBS->SPLIT_METRICS_MAX_ROWS) {
-				CODE_PROBE(true, "Blob Migrator SplitMetrics API has more");
-				TraceEvent("BlobMigratorSplitMetricsContinued", self->interf_.id())
-				    .detail("Range", req.keys)
-				    .detail("Splits", rep.splits.size());
-				rep.more = true;
-				break;
-			}
-		}
-		req.reply.send(rep);
-	}
-
-	ACTOR static Future<Void> processWaitMetricsRequest(Reference<BlobMigrator> self, WaitMetricsRequest req) {
+	ACTOR static Future<Void> waitMetricsTenantAwareImpl(Reference<BlobMigrator> self, WaitMetricsRequest req) {
 		state WaitMetricsRequest waitMetricsRequest = req;
-		// FIXME get rid of this delay. it's a temp solution to avoid starvaion scheduling of DD
-		// processes
-		wait(delay(1));
-		StorageMetrics metrics;
+		state StorageMetrics metrics;
 		metrics.bytes = sizeInBytes(self, waitMetricsRequest.keys);
+		if (waitMetricsRequest.min.allLessOrEqual(metrics) && metrics.allLessOrEqual(waitMetricsRequest.max)) {
+			wait(delay(SERVER_KNOBS->STORAGE_METRIC_TIMEOUT));
+		}
 		waitMetricsRequest.reply.send(metrics);
 		return Void();
 	}
@@ -721,6 +671,72 @@ private:
 			max = std::max(granule.version, max);
 		}
 		return max;
+	}
+
+public: // Methods for IStorageMetricsService
+	void addActor(Future<Void> future) override { actors_.add(future); }
+
+	void getSplitPoints(SplitRangeRequest const& req) override {
+		dprint("Unsupported SplitRangeRequest\n");
+		req.reply.sendError(broken_promise());
+	}
+
+	Future<Void> waitMetricsTenantAware(const WaitMetricsRequest& req) override {
+		Reference<BlobMigrator> self = Reference<BlobMigrator>::addRef(this);
+		return waitMetricsTenantAwareImpl(self, req);
+	}
+
+	void getStorageMetrics(const GetStorageMetricsRequest& req) override {
+		StorageMetrics metrics;
+		Reference<BlobMigrator> self = Reference<BlobMigrator>::addRef(this);
+		metrics.bytes = sizeInBytes(self);
+		GetStorageMetricsReply resp;
+		resp.load = metrics;
+		resp.available = StorageMetrics();
+		resp.capacity = StorageMetrics();
+		resp.bytesInputRate = 0;
+		resp.versionLag = 0;
+		resp.lastUpdate = now();
+		req.reply.send(resp);
+	}
+
+	// This API is used by DD to figure out split points for data movement.
+	void getSplitMetrics(const SplitMetricsRequest& req) override {
+		Reference<BlobMigrator> self = Reference<BlobMigrator>::addRef(this);
+		SplitMetricsReply rep;
+		int64_t bytes = 0; // number of bytes accumulated for current split
+		for (auto& granule : self->blobGranules_) {
+			if (!req.keys.contains(granule.keyRange)) {
+				continue;
+			}
+			bytes += granule.sizeInBytes;
+			if (bytes < req.limits.bytes) {
+				continue;
+			}
+			// Add a split point if the key range exceeds expected minimal size in bytes
+			rep.splits.push_back_deep(rep.splits.arena(), granule.keyRange.end);
+			bytes = 0;
+			// Limit number of splits in single response for fast RPC processing
+			if (rep.splits.size() > SERVER_KNOBS->SPLIT_METRICS_MAX_ROWS) {
+				CODE_PROBE(true, "Blob Migrator SplitMetrics API has more");
+				TraceEvent("BlobMigratorSplitMetricsContinued", self->interf_.id())
+				    .detail("Range", req.keys)
+				    .detail("Splits", rep.splits.size());
+				rep.more = true;
+				break;
+			}
+		}
+		req.reply.send(rep);
+	}
+
+	void getHotRangeMetrics(const ReadHotSubRangeRequest& req) override {
+		ReadHotSubRangeReply emptyReply;
+		req.reply.send(emptyReply);
+	}
+
+	template <class Reply>
+	void sendErrorWithPenalty(const ReplyPromise<Reply>& promise, const Error& err, double) {
+		promise.sendError(err);
 	}
 
 private:

--- a/fdbserver/MockGlobalState.actor.cpp
+++ b/fdbserver/MockGlobalState.actor.cpp
@@ -337,6 +337,14 @@ Future<Void> MockStorageServer::waitMetricsTenantAware(const WaitMetricsRequest&
 
 void MockStorageServer::getStorageMetrics(const GetStorageMetricsRequest& req) {}
 
+void MockStorageServer::getSplitMetrics(const SplitMetricsRequest& req) {
+	this->metrics.splitMetrics(req);
+}
+
+void MockStorageServer::getHotRangeMetrics(const ReadHotSubRangeRequest& req) {
+	this->metrics.getReadHotRanges(req);
+}
+
 Future<Void> MockStorageServer::run() {
 	ssi.initEndpoints();
 	ssi.startAcceptingRequests();

--- a/fdbserver/include/fdbserver/MockGlobalState.h
+++ b/fdbserver/include/fdbserver/MockGlobalState.h
@@ -148,6 +148,10 @@ public:
 
 	void getStorageMetrics(const GetStorageMetricsRequest& req) override;
 
+	void getSplitMetrics(const SplitMetricsRequest& req) override;
+
+	void getHotRangeMetrics(const ReadHotSubRangeRequest& req) override;
+
 	template <class Reply>
 	static constexpr bool isLoadBalancedReply = std::is_base_of_v<LoadBalancedReply, Reply>;
 

--- a/fdbserver/include/fdbserver/StorageMetrics.actor.h
+++ b/fdbserver/include/fdbserver/StorageMetrics.actor.h
@@ -221,6 +221,10 @@ public:
 
 	virtual void getStorageMetrics(const GetStorageMetricsRequest& req) = 0;
 
+	virtual void getSplitMetrics(const SplitMetricsRequest& req) = 0;
+
+	virtual void getHotRangeMetrics(const ReadHotSubRangeRequest& req) = 0;
+
 	// NOTE: also need to have this function but template can't be a virtual so...
 	// template <class Reply>
 	// void sendErrorWithPenalty(const ReplyPromise<Reply>& promise, const Error& err, double penalty);
@@ -244,14 +248,14 @@ Future<Void> serveStorageMetricsRequests(ServiceType* self, StorageServerInterfa
 					CODE_PROBE(true, "splitMetrics immediate wrong_shard_server()");
 					self->sendErrorWithPenalty(req.reply, wrong_shard_server(), self->getPenalty());
 				} else {
-					self->metrics.splitMetrics(req);
+					self->getSplitMetrics(req);
 				}
 			}
 			when(GetStorageMetricsRequest req = waitNext(ssi.getStorageMetrics.getFuture())) {
 				self->getStorageMetrics(req);
 			}
 			when(ReadHotSubRangeRequest req = waitNext(ssi.getReadHotRanges.getFuture())) {
-				self->metrics.getReadHotRanges(req);
+				self->getHotRangeMetrics(req);
 			}
 			when(SplitRangeRequest req = waitNext(ssi.getRangeSplitPoints.getFuture())) {
 				if (!self->isReadable(req.keys)) {

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -1728,6 +1728,10 @@ public:
 		StorageBytes sb = storage.getStorageBytes();
 		metrics.getStorageMetrics(req, sb, counters.bytesInput.getRate(), versionLag, lastUpdate);
 	}
+
+	void getSplitMetrics(const SplitMetricsRequest& req) override { this->metrics.splitMetrics(req); }
+
+	void getHotRangeMetrics(const ReadHotSubRangeRequest& req) override { this->metrics.getReadHotRanges(req); }
 };
 
 const StringRef StorageServer::CurrentRunningFetchKeys::emptyString = ""_sr;


### PR DESCRIPTION
Cherry-Pick of #10336
- This commit is helpful for branch 71.3 release because it refactors code and reduces complexity.

Original Description:

- Xiaoxi did some refactoring for StorageServerInterface and we are changing BlobMigrator accordingly. We refactor `BlobMigrator` implement the `IStorageMetricsService` interface.

Test
- 100K correctness tests, all passed
  - Ensemble ID `20230606-194526-jzhong-11a06ade9611209c`

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
