### PR TITLE
[snowflake/release-71.3] Disable SSD_ROCKSDB_EXPERIMENTAL

### DIFF
--- a/cmake/FDBComponents.cmake
+++ b/cmake/FDBComponents.cmake
@@ -173,7 +173,7 @@ endif()
 # RocksDB
 ################################################################################
 
-set(SSD_ROCKSDB_EXPERIMENTAL ON CACHE BOOL "Build with experimental RocksDB support")
+set(SSD_ROCKSDB_EXPERIMENTAL OFF CACHE BOOL "Build with experimental RocksDB support")
 set(PORTABLE_ROCKSDB ON CACHE BOOL "Compile RocksDB in portable mode") # Set this to OFF to compile RocksDB with `-march=native`
 set(ROCKSDB_SSE42 OFF CACHE BOOL "Compile RocksDB with SSE42 enabled")
 set(ROCKSDB_AVX ${USE_AVX} CACHE BOOL "Compile RocksDB with AVX enabled")


### PR DESCRIPTION
This PR disables `SSD_ROCKSDB_EXPERIMENTAL` on snowflake/release-71.3 branch.

This is being done to fix the CI failures on the branch due to assertions in the RocksDB code. One option was to cherry-pick the RocksDB version upgrade. Trying that option led to a very large and complex cherry-pick since the version upgrade PR depended on another PR (from main), which depended on another PR, and so on. Second option was to disable the specific assertions that were failing in CI, however, that led to additional failures. Since Snowflake doesn't use RocksDB, disabling this knob is a simpler approach.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
