### PR TITLE
Add getlocation and getall fdbcli commands [release-7.1]

### DIFF
--- a/fdbcli/CMakeLists.txt
+++ b/fdbcli/CMakeLists.txt
@@ -8,6 +8,7 @@ set(FDBCLI_SRCS
   ConsistencyCheckCommand.actor.cpp
   CoordinatorsCommand.actor.cpp
   DataDistributionCommand.actor.cpp
+  DebugCommands.actor.cpp
   ExcludeCommand.actor.cpp
   ExpensiveDataCheckCommand.actor.cpp
   FileConfigureCommand.actor.cpp

--- a/fdbcli/DebugCommands.actor.cpp
+++ b/fdbcli/DebugCommands.actor.cpp
@@ -1,0 +1,95 @@
+/*
+ * DebugCommands.actor.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2023 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "fdbcli/fdbcli.actor.h"
+
+#include "fdbclient/NativeAPI.actor.h"
+
+#include "flow/actorcompiler.h" // This must be the last #include.
+
+namespace fdb_cli {
+
+// The command is used to get all storage server addresses for a given key.
+ACTOR Future<bool> getLocationCommandActor(Database cx, std::vector<StringRef> tokens, Version version) {
+	if (tokens.size() != 2) {
+		printf("getlocation <KEY>\n"
+		       "fetch the storage server address for a given key.\n"
+		       "Displays the addresses of storage servers, or `not found' if location is not found.");
+		return false;
+	}
+
+	KeyRangeLocationInfo loc = wait(getKeyLocation_internal(
+	    cx, {}, tokens[1], SpanID(), Optional<UID>(), UseProvisionalProxies::False, Reverse::False, version));
+
+	if (loc.locations) {
+		printf("version is %ld\n", version);
+		printf("`%s' is at:\n", printable(tokens[1]).c_str());
+		auto locations = loc.locations->locations();
+		for (int i = 0; locations && i < locations->size(); i++) {
+			printf("  %s\n", locations->getInterface(i).address().toString().c_str());
+		}
+	} else {
+		printf("`%s': location not found\n", printable(tokens[1]).c_str());
+	}
+	return true;
+}
+// hidden commands, no help text for now
+CommandFactory getLocationCommandFactory("getlocation");
+
+// The command is used to get values from all storage servers that have the given key.
+ACTOR Future<bool> getallCommandActor(Database cx, std::vector<StringRef> tokens, Version version) {
+	if (tokens.size() != 2) {
+		printf("getall <KEY>\n"
+		       "fetch values from all storage servers that have the given key.\n"
+		       "Displays the value and the addresses of storage servers, or `not found' if key is not found.");
+		return false;
+	}
+
+	KeyRangeLocationInfo loc = wait(getKeyLocation_internal(
+	    cx, {}, tokens[1], SpanID(), Optional<UID>(), UseProvisionalProxies::False, Reverse::False, version));
+
+	if (loc.locations) {
+		printf("version is %ld\n", version);
+		printf("`%s' is at:\n", printable(tokens[1]).c_str());
+		state Reference<LocationInfo::Locations> locations = loc.locations->locations();
+		state std::vector<Future<GetValueReply>> replies;
+		for (int i = 0; locations && i < locations->size(); i++) {
+			GetValueRequest req({}, {}, tokens[1], version, {}, {}, {});
+			replies.push_back(locations->get(i, &StorageServerInterface::getValue).getReply(req));
+		}
+		wait(waitForAll(replies));
+		for (int i = 0; i < replies.size(); i++) {
+			std::string ssi = locations->getInterface(i).address().toString();
+			if (replies[i].isError()) {
+				fprintf(stderr, "ERROR: %s %s\n", ssi.c_str(), replies[i].getError().what());
+			} else {
+				Optional<Value> v = replies[i].get().value;
+				printf(" %s %s\n", ssi.c_str(), v.present() ? printable(v.get()).c_str() : "(not found)");
+			}
+		}
+	} else {
+		printf("`%s': location not found\n", printable(tokens[1]).c_str());
+	}
+	return true;
+}
+// hidden commands, no help text for now
+CommandFactory getallCommandFactory("getall");
+
+} // namespace fdb_cli

--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -1297,7 +1297,6 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise) {
 	}
 
 	state bool is_error = false;
-
 	state Future<Void> warn;
 	loop {
 		if (warn.isValid())
@@ -1661,6 +1660,24 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise) {
 						else
 							printf("`%s': not found\n", printable(tokens[1]).c_str());
 					}
+					continue;
+				}
+
+				if (tokencmp(tokens[0], "getlocation")) {
+					Version _v = wait(makeInterruptable(
+					    safeThreadFutureToFuture(getTransaction(db, tenant, tr, options, intrans)->getReadVersion())));
+					bool _result = wait(makeInterruptable(getLocationCommandActor(localDb, tokens, _v)));
+					if (!_result)
+						is_error = true;
+					continue;
+				}
+
+				if (tokencmp(tokens[0], "getall")) {
+					Version _v = wait(makeInterruptable(
+					    safeThreadFutureToFuture(getTransaction(db, tenant, tr, options, intrans)->getReadVersion())));
+					bool _result = wait(makeInterruptable(getallCommandActor(localDb, tokens, _v)));
+					if (!_result)
+						is_error = true;
 					continue;
 				}
 

--- a/fdbcli/fdbcli.actor.h
+++ b/fdbcli/fdbcli.actor.h
@@ -215,6 +215,10 @@ ACTOR Future<bool> versionEpochCommandActor(Reference<IDatabase> db, Database cx
 // targetversion command
 ACTOR Future<bool> targetVersionCommandActor(Reference<IDatabase> db, std::vector<StringRef> tokens);
 
+// debug commands: getlocation, getall
+ACTOR Future<bool> getLocationCommandActor(Database cx, std::vector<StringRef> tokens, Version version);
+ACTOR Future<bool> getallCommandActor(Database cx, std::vector<StringRef> tokens, Version version);
+
 } // namespace fdb_cli
 
 #include "flow/unactorcompiler.h"

--- a/fdbclient/NativeAPI.actor.h
+++ b/fdbclient/NativeAPI.actor.h
@@ -19,8 +19,6 @@
  */
 
 #pragma once
-#include "flow/IRandom.h"
-#include "flow/Tracing.h"
 #if defined(NO_INTELLISENSE) && !defined(FDBCLIENT_NATIVEAPI_ACTOR_G_H)
 #define FDBCLIENT_NATIVEAPI_ACTOR_G_H
 #include "fdbclient/NativeAPI.actor.g.h"
@@ -30,6 +28,8 @@
 #include "flow/BooleanParam.h"
 #include "flow/flow.h"
 #include "flow/TDMetric.actor.h"
+#include "flow/IRandom.h"
+#include "flow/Tracing.h"
 #include "fdbclient/FDBTypes.h"
 #include "fdbclient/CommitProxyInterface.h"
 #include "fdbclient/ClientBooleanParams.h"
@@ -552,6 +552,16 @@ int64_t getMaxWriteKeySize(KeyRef const& key, bool hasRawAccess);
 
 // Returns the maximum legal size of a key that can be cleared. Keys larger than this will be assumed not to exist.
 int64_t getMaxClearKeySize(KeyRef const& key);
+
+struct KeyRangeLocationInfo;
+ACTOR Future<KeyRangeLocationInfo> getKeyLocation_internal(Database cx,
+                                                           Optional<TenantName> tenant,
+                                                           Key key,
+                                                           SpanID spanID,
+                                                           Optional<UID> debugID,
+                                                           UseProvisionalProxies useProvisionalProxies,
+                                                           Reverse isBackward,
+                                                           Version version);
 
 #include "flow/unactorcompiler.h"
 #endif


### PR DESCRIPTION
cherrypick #10436

getlocation: returns the SS list for a key
getall: returns both the SS list and values on the SS for a key

Manually tested in clusters.


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
