### PR TITLE
Correctly throttling consistency check on error case

### DIFF
--- a/fdbserver/ConsistencyScan.actor.cpp
+++ b/fdbserver/ConsistencyScan.actor.cpp
@@ -713,6 +713,7 @@ ACTOR Future<Void> consistencyScanCore(Database db,
 								}
 								// FIXME: increment failed request count if error present
 								ASSERT(failedRequest.get().code() != error_code_operation_cancelled);
+								totalReadBytesFromStorageServers += 100000;
 								break;
 							}
 						}


### PR DESCRIPTION
In simulation, the consistency check was not properly throttling itself in error cases.
Normally this would still allow for test progress as reads take some time, but in the error case, when the CC and SS were on the same process, there was little to no latency for the read request, so it would essentially spin loop, causing joshua to time out.

100k correctness passed with 1 likely unrelated TracedTooManyLines failure

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
