### PR TITLE
[snowflake/release-71.3] adding blob granule restarting tests to use tenants, encryption, and …

### DIFF
--- a/fdbclient/ClientKnobs.cpp
+++ b/fdbclient/ClientKnobs.cpp
@@ -289,6 +289,7 @@ void ClientKnobs::initialize(Randomize randomize) {
 	init( BG_MAX_GRANULE_PARALLELISM,                10 );
 	init( BG_TOO_MANY_GRANULES,                   20000 );
 	init( BLOB_METADATA_REFRESH_INTERVAL,          3600 ); if ( randomize && BUGGIFY ) { BLOB_METADATA_REFRESH_INTERVAL = deterministicRandom()->randomInt(5, 120); }
+	init( DETERMINISTIC_BLOB_METADATA,            false ); if( randomize && BUGGIFY_WITH_PROB(0.01) ) DETERMINISTIC_BLOB_METADATA = true;
 	init( ENABLE_BLOB_GRANULE_FILE_LOGICAL_SIZE,  false ); if ( randomize && BUGGIFY ) { ENABLE_BLOB_GRANULE_FILE_LOGICAL_SIZE = true; }
 
 	init( CHANGE_QUORUM_BAD_STATE_RETRY_TIMES,        3 );

--- a/fdbclient/include/fdbclient/ClientKnobs.h
+++ b/fdbclient/include/fdbclient/ClientKnobs.h
@@ -280,6 +280,7 @@ public:
 	int BG_MAX_GRANULE_PARALLELISM;
 	int BG_TOO_MANY_GRANULES;
 	int64_t BLOB_METADATA_REFRESH_INTERVAL;
+	bool DETERMINISTIC_BLOB_METADATA;
 	bool ENABLE_BLOB_GRANULE_FILE_LOGICAL_SIZE;
 
 	// The coordinator key/value in storage server might be inconsistent to the value stored in the cluster file.

--- a/fdbserver/include/fdbserver/StorageMetrics.actor.h
+++ b/fdbserver/include/fdbserver/StorageMetrics.actor.h
@@ -254,7 +254,9 @@ Future<Void> serveStorageMetricsRequests(ServiceType* self, StorageServerInterfa
 				self->metrics.getReadHotRanges(req);
 			}
 			when(SplitRangeRequest req = waitNext(ssi.getRangeSplitPoints.getFuture())) {
-				if (!self->isReadable(req.keys)) {
+				if ((!req.tenantInfo.hasTenant() && !self->isReadable(req.keys)) ||
+				    (req.tenantInfo.hasTenant() &&
+				     !self->isReadable(req.keys.withPrefix(req.tenantInfo.prefix.get())))) {
 					CODE_PROBE(true, "getSplitPoints immediate wrong_shard_server()");
 					self->sendErrorWithPenalty(req.reply, wrong_shard_server(), self->getPenalty());
 				} else {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -384,6 +384,9 @@ if(WITH_PYTHON)
     TEST_FILES restarting/from_71.3.0/StorefrontTestRestart-1.txt
     restarting/from_71.3.0/StorefrontTestRestart-2.txt)
   add_fdb_test(
+    TEST_FILES restarting/from_71.3.0/BlobGranuleRestartCorrectness-1.toml
+    restarting/from_71.3.0/BlobGranuleRestartCorrectness-2.toml)
+  add_fdb_test(
     TEST_FILES restarting/to_7.1.0_until_71.2.0/ConfigureStorageMigrationTestRestart-1.toml
     restarting/to_7.1.0_until_71.2.0/ConfigureStorageMigrationTestRestart-2.toml)
   add_fdb_test(
@@ -407,9 +410,12 @@ if(WITH_PYTHON)
   add_fdb_test(
     TEST_FILES restarting/to_71.3.0/CycleTestRestart-1.toml
     restarting/to_71.3.0/CycleTestRestart-2.toml)
-   add_fdb_test(
+  add_fdb_test(
     TEST_FILES restarting/to_71.3.0/BlobGranuleRestartCycle-1.toml
     restarting/to_71.3.0/BlobGranuleRestartCycle-2.toml)
+  add_fdb_test(
+    TEST_FILES restarting/to_71.3.1/BlobGranuleRestartCorrectness-1.toml
+    restarting/to_71.3.1/BlobGranuleRestartCorrectness-2.toml)
   add_fdb_test(
     TEST_FILES restarting/to_71.3.0/BlobGranuleRestartLarge-1.toml
     restarting/to_71.3.0/BlobGranuleRestartLarge-2.toml)

--- a/tests/restarting/from_71.3.0/BlobGranuleRestartCorrectness-1.toml
+++ b/tests/restarting/from_71.3.0/BlobGranuleRestartCorrectness-1.toml
@@ -1,0 +1,54 @@
+# FIXME: also add downgrade
+[configuration]
+blobGranulesEnabled = true 
+allowDefaultTenant = false
+tenantModes = ['optional', 'required']
+injectTargetedSSRestart = true
+injectSSDelay = true
+
+[[knobs]]
+bg_metadata_source = "tenant"
+bg_key_tuple_truncate_offset = 1
+enable_configurable_encryption = true
+enable_rest_kms_communication = true
+deterministic_blob_metadata = true
+
+[[test]]
+testTitle = 'BlobGranuleCorrectness'
+clearAfterTest=false
+
+    [[test.workload]]
+    testName = 'BlobGranuleCorrectnessWorkload'
+    testDuration = 60.0
+
+    [[test.workload]]
+    testName = 'RandomClogging'
+    testDuration = 60.0
+
+    [[test.workload]]
+    testName = 'Rollback'
+    meanDelay = 30.0
+    testDuration = 60.0
+
+    [[test.workload]]
+    testName = 'Attrition'
+    machinesToKill = 10
+    machinesToLeave = 3
+    reboot = true
+    testDuration = 60.0
+
+    [[test.workload]]
+    testName = 'Attrition'
+    machinesToKill = 10
+    machinesToLeave = 3
+    reboot = true
+    testDuration = 60.0
+
+    [[test.workload]]
+    testName = 'BlobFailureInjection'
+    testDuration = 60.0
+
+    [[test.workload]]
+    testName='SaveAndKill'
+    restartInfoLocation='simfdb/restartInfo.ini'
+    testDuration=30.0

--- a/tests/restarting/from_71.3.0/BlobGranuleRestartCorrectness-2.toml
+++ b/tests/restarting/from_71.3.0/BlobGranuleRestartCorrectness-2.toml
@@ -1,0 +1,49 @@
+# FIXME: also add downgrade
+[configuration]
+blobGranulesEnabled = true 
+allowDefaultTenant = false
+tenantModes = ['optional', 'required']
+injectTargetedSSRestart = true
+injectSSDelay = true
+
+[[knobs]]
+bg_metadata_source = "tenant"
+bg_key_tuple_truncate_offset = 1
+enable_configurable_encryption = true
+enable_rest_kms_communication = true
+deterministic_blob_metadata = true
+
+[[test]]
+testTitle = 'BlobGranuleCorrectness'
+clearAfterTest=false
+
+    [[test.workload]]
+    testName = 'BlobGranuleCorrectnessWorkload'
+    testDuration = 120.0
+
+    [[test.workload]]
+    testName = 'RandomClogging'
+    testDuration = 60.0
+
+    [[test.workload]]
+    testName = 'Rollback'
+    meanDelay = 30.0
+    testDuration = 60.0
+
+    [[test.workload]]
+    testName = 'Attrition'
+    machinesToKill = 10
+    machinesToLeave = 3
+    reboot = true
+    testDuration = 60.0
+
+    [[test.workload]]
+    testName = 'Attrition'
+    machinesToKill = 10
+    machinesToLeave = 3
+    reboot = true
+    testDuration = 60.0
+
+    [[test.workload]]
+    testName = 'BlobFailureInjection'
+    testDuration = 60.0

--- a/tests/restarting/to_71.3.1/BlobGranuleRestartCorrectness-1.toml
+++ b/tests/restarting/to_71.3.1/BlobGranuleRestartCorrectness-1.toml
@@ -1,0 +1,54 @@
+# FIXME: also add downgrade
+[configuration]
+blobGranulesEnabled = true 
+allowDefaultTenant = false
+tenantModes = ['optional', 'required']
+injectTargetedSSRestart = true
+injectSSDelay = true
+
+[[knobs]]
+bg_metadata_source = "tenant"
+bg_key_tuple_truncate_offset = 1
+enable_configurable_encryption = true
+enable_rest_kms_communication = true
+deterministic_blob_metadata = true
+
+[[test]]
+testTitle = 'BlobGranuleCorrectness'
+clearAfterTest=false
+
+    [[test.workload]]
+    testName = 'BlobGranuleCorrectnessWorkload'
+    testDuration = 60.0
+
+    [[test.workload]]
+    testName = 'RandomClogging'
+    testDuration = 60.0
+
+    [[test.workload]]
+    testName = 'Rollback'
+    meanDelay = 30.0
+    testDuration = 60.0
+
+    [[test.workload]]
+    testName = 'Attrition'
+    machinesToKill = 10
+    machinesToLeave = 3
+    reboot = true
+    testDuration = 60.0
+
+    [[test.workload]]
+    testName = 'Attrition'
+    machinesToKill = 10
+    machinesToLeave = 3
+    reboot = true
+    testDuration = 60.0
+
+    [[test.workload]]
+    testName = 'BlobFailureInjection'
+    testDuration = 60.0
+
+    [[test.workload]]
+    testName='SaveAndKill'
+    restartInfoLocation='simfdb/restartInfo.ini'
+    testDuration=30.0

--- a/tests/restarting/to_71.3.1/BlobGranuleRestartCorrectness-2.toml
+++ b/tests/restarting/to_71.3.1/BlobGranuleRestartCorrectness-2.toml
@@ -1,0 +1,49 @@
+# FIXME: also add downgrade
+[configuration]
+blobGranulesEnabled = true 
+allowDefaultTenant = false
+tenantModes = ['optional', 'required']
+injectTargetedSSRestart = true
+injectSSDelay = true
+
+[[knobs]]
+bg_metadata_source = "tenant"
+bg_key_tuple_truncate_offset = 1
+enable_configurable_encryption = true
+enable_rest_kms_communication = true
+deterministic_blob_metadata = true
+
+[[test]]
+testTitle = 'BlobGranuleCorrectness'
+clearAfterTest=false
+
+    [[test.workload]]
+    testName = 'BlobGranuleCorrectnessWorkload'
+    testDuration = 120.0
+
+    [[test.workload]]
+    testName = 'RandomClogging'
+    testDuration = 60.0
+
+    [[test.workload]]
+    testName = 'Rollback'
+    meanDelay = 30.0
+    testDuration = 60.0
+
+    [[test.workload]]
+    testName = 'Attrition'
+    machinesToKill = 10
+    machinesToLeave = 3
+    reboot = true
+    testDuration = 60.0
+
+    [[test.workload]]
+    testName = 'Attrition'
+    machinesToKill = 10
+    machinesToLeave = 3
+    reboot = true
+    testDuration = 60.0
+
+    [[test.workload]]
+    testName = 'BlobFailureInjection'
+    testDuration = 60.0


### PR DESCRIPTION
Cherry-pick #10235

The bug fixed in StorageMetrics means the second phase will fail without the bug fix. So, they upgrade from 71.3.0 to current, but only downgrade from current to 71.3.1 because 71.3.0 does not have this bug fix.

100k normal correctness: 20230606-141356-jslocum-ec4bde50a9a02264: 1 failure
  (1 ExternalTimeout failure in blob granule tests that should be fixed by #10318)

50k of the new BlobGranuleRestartCorrectness* tests: 20230606-141254-jslocum-ec4bde50a9a0226: no failures

50k BlobGranule* correctness: 20230606-141327-jslocum-ec4bde50a9a02264: 3 failures
 (all ExternalTimeout failure in blob granule tests that should be fixed by #10318)



# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
