### PR TITLE
fixing stable feeds check by allowing more time post speedup sim, and… (Cherry-Pick #10327 to snowflake/release-71.3)

### DIFF
--- a/fdbserver/BlobGranuleValidation.actor.cpp
+++ b/fdbserver/BlobGranuleValidation.actor.cpp
@@ -528,7 +528,7 @@ ACTOR Future<Void> checkFeedCleanup(Database cx, bool debug) {
 	}
 	// big extra timeout just because simulation can take a while to quiesce
 
-	state double checkTimeoutSpeedupSim = 50.0 + 2 * SERVER_KNOBS->BLOB_WORKER_FORCE_FLUSH_CLEANUP_DELAY;
+	state double checkTimeoutSpeedupSim = 100.0 + 2 * SERVER_KNOBS->BLOB_WORKER_FORCE_FLUSH_CLEANUP_DELAY;
 	state double checkTimeoutOnceStable = 250.0 + checkTimeoutSpeedupSim;
 	state Optional<double> stableTimestamp;
 	state Optional<double> speedUpSimTimestamp;
@@ -543,19 +543,25 @@ ACTOR Future<Void> checkFeedCleanup(Database cx, bool debug) {
 
 			// TODO REMOVE
 			if (debug) {
-				fmt::print("{0} granules and {1} active feeds found\n", granules.size(), activeFeeds.size());
+				fmt::print("{0} granules and {1} active feeds found @ {2}\n",
+				           granules.size(),
+				           activeFeeds.size(),
+				           tr.getReadVersion().get());
 			}
 
 			bool allPresent = granules.size() == activeFeeds.size();
 			/*if (!allPresent) {
-			    fmt::print("Granules:\n");
+			    fmt::print("Got feeds and granules @ {0}\n", tr.getReadVersion().get());
+			    fmt::print("Granules ({0}):\n", granules.size());
 			    for (auto& it : granules) {
 			        fmt::print("  [{0} - {1})\n", it.begin.printable(), it.end.printable());
 			    }
-			    fmt::print("Feeds:\n");
+			    fmt::print("Feeds ({0}):\n", activeFeeds.size());
 			    for (auto& it : activeFeeds) {
-			        fmt::print("  {0}: [{1} - {2})\n", it.first.printable(), it.second.begin.printable(),
-			it.second.end.printable());
+			        fmt::print("  {0}: [{1} - {2})\n",
+			                   it.first.printable(),
+			                   it.second.begin.printable(),
+			                   it.second.end.printable());
 			    }
 			}*/
 			for (int i = 0; allPresent && i < granules.size(); i++) {
@@ -598,6 +604,8 @@ ACTOR Future<Void> checkFeedCleanup(Database cx, bool debug) {
 			}
 
 			wait(delay(2.0));
+			// reset transaction to get higher read version
+			tr.reset();
 		} catch (Error& e) {
 			wait(tr.onError(e));
 		}


### PR DESCRIPTION
Cherry-Pick of #10327

Original Description:

… ensuring retry uses higher read version for the check

100k normal correctness: 20230606-164430-jslocum-af37a6dd43570cb6: 0 failures

50k BlobGranule* correctness: 20230606-164347-jslocum-af37a6dd43570cb6 - 0 failures

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
