### PR TITLE
Fix a dynamic knobs bug where fulfilling a promise could cause it to get deleted (snowflake/release-71.3)

### DIFF
--- a/fdbclient/PaxosConfigTransaction.actor.cpp
+++ b/fdbclient/PaxosConfigTransaction.actor.cpp
@@ -42,7 +42,9 @@ class CommitQuorum {
 
 	void updateResult() {
 		if (successful >= ctis.size() / 2 + 1 && result.canBeSet()) {
-			result.send(Void());
+			// Calling send could delete this
+			auto local = this->result;
+			local.send(Void());
 		} else if (failed >= ctis.size() / 2 + 1 && result.canBeSet()) {
 			// Rollforwards could cause a version that didn't have quorum to
 			// commit, so send commit_unknown_result instead of commit_failed.


### PR DESCRIPTION
Cherry pick of #10420 to `snowflake/release-71.3`.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
