### PR TITLE
Cherry-pick to 7.3: Added location_metadata fdbcli to query shard locations, assignements…

### DIFF
--- a/fdbcli/GetAuditStatusCommand.actor.cpp
+++ b/fdbcli/GetAuditStatusCommand.actor.cpp
@@ -45,18 +45,12 @@ ACTOR Future<bool> getAuditStatusCommandActor(Database cx, std::vector<StringRef
 		type = AuditType::ValidateLocationMetadata;
 	} else if (tokencmp(tokens[1], "ssshard")) {
 		type = AuditType::ValidateStorageServerShard;
-	} else if (tokencmp(tokens[1], "checkmigration")) {
-		type = AuditType::CheckMigrationStatus;
 	} else {
 		printUsage(tokens[0]);
 		return false;
 	}
 
-	if (tokens.size() == 2) {
-		ASSERT(type == AuditType::CheckMigrationStatus);
-		std::string res = wait(checkMigrationProgress(cx));
-		printf("\n%s", res.c_str());
-	} else if (tokencmp(tokens[2], "id")) {
+	if (tokencmp(tokens[2], "id")) {
 		if (tokens.size() != 4) {
 			printUsage(tokens[0]);
 			return false;

--- a/fdbcli/LocationMetadataCommand.actor.cpp
+++ b/fdbcli/LocationMetadataCommand.actor.cpp
@@ -1,0 +1,278 @@
+/*
+ * LocationMetadataCommand.actor.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2023 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "fdbcli/fdbcli.actor.h"
+#include "fdbclient/Audit.h"
+#include "fdbclient/AuditUtils.actor.h"
+#include "fdbclient/IClientApi.h"
+#include "flow/Arena.h"
+#include "flow/FastRef.h"
+#include "flow/ThreadHelper.actor.h"
+
+#include "flow/actorcompiler.h" // This must be the last #include.
+
+namespace {
+std::string describeUIDs(const std::vector<UID>& ids) {
+	std::string res;
+	for (const UID& id : ids) {
+		if (!res.empty()) {
+			res += ", ";
+		}
+		res += id.toString();
+	}
+
+	return res;
+}
+
+ACTOR Future<Void> printRandomShards(Database cx, int n, bool physicalShard) {
+	state Key begin = allKeys.begin;
+	state int numShards = 0;
+
+	while (begin < allKeys.end && numShards < n) {
+		// RYW to optimize re-reading the same key ranges
+		state Reference<ReadYourWritesTransaction> tr = makeReference<ReadYourWritesTransaction>(cx);
+
+		loop {
+			try {
+				tr->setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
+				tr->setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
+
+				state RangeResult UIDtoTagMap = wait(tr->getRange(serverTagKeys, CLIENT_KNOBS->TOO_MANY));
+				ASSERT(!UIDtoTagMap.more && UIDtoTagMap.size() < CLIENT_KNOBS->TOO_MANY);
+
+				KeyRangeRef currentKeys(begin, allKeys.end);
+				RangeResult shards = wait(krmGetRanges(tr, keyServersPrefix, currentKeys, n, CLIENT_KNOBS->TOO_MANY));
+
+				for (int i = 0; i < shards.size() - 1 && numShards < n; ++i) {
+					const KeyRangeRef currentRange(shards[i].key, shards[i + 1].key);
+					std::vector<UID> src;
+					std::vector<UID> dest;
+					UID srcId;
+					UID destId;
+					decodeKeyServersValue(UIDtoTagMap, shards[i].value, src, dest, srcId, destId);
+					if (physicalShard == (srcId != anonymousShardId)) {
+						printf("Range: %s, IsPhysicalShard: %s, ShardID: %s, Src Servers: %s, Dest Servers: %s\n",
+						       Traceable<KeyRangeRef>::toString(currentRange).c_str(),
+						       physicalShard ? "Yes" : "No",
+						       srcId.toString().c_str(),
+						       describeUIDs(src).c_str(),
+						       describeUIDs(dest).c_str());
+						++numShards;
+					}
+				}
+
+				begin = shards.back().key;
+				break;
+			} catch (Error& e) {
+				wait(tr->onError(e));
+			}
+		}
+	}
+
+	printf("Found %d %s shards\n", numShards, physicalShard ? "Physical" : "Non-physical");
+
+	return Void();
+}
+
+ACTOR Future<Void> printPhysicalShardCount(Database cx) {
+	state Key begin = allKeys.begin;
+	state int numShards = 0;
+	state int numPhysicalShards = 0;
+
+	while (begin < allKeys.end) {
+		// RYW to optimize re-reading the same key ranges
+		state Reference<ReadYourWritesTransaction> tr = makeReference<ReadYourWritesTransaction>(cx);
+
+		loop {
+			try {
+				tr->setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
+				tr->setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
+
+				state RangeResult UIDtoTagMap = wait(tr->getRange(serverTagKeys, CLIENT_KNOBS->TOO_MANY));
+				ASSERT(!UIDtoTagMap.more && UIDtoTagMap.size() < CLIENT_KNOBS->TOO_MANY);
+
+				KeyRangeRef currentKeys(begin, allKeys.end);
+				RangeResult shards = wait(
+				    krmGetRanges(tr, keyServersPrefix, currentKeys, CLIENT_KNOBS->TOO_MANY, CLIENT_KNOBS->TOO_MANY));
+
+				for (int i = 0; i < shards.size() - 1; ++i) {
+					std::vector<UID> src;
+					std::vector<UID> dest;
+					UID srcId;
+					UID destId;
+					decodeKeyServersValue(UIDtoTagMap, shards[i].value, src, dest, srcId, destId);
+					if (srcId != anonymousShardId) {
+						++numPhysicalShards;
+					}
+				}
+
+				begin = shards.back().key;
+				numShards += shards.size() - 1;
+				break;
+			} catch (Error& e) {
+				wait(tr->onError(e));
+			}
+		}
+	}
+
+	printf("Total number of shards: %d, number of physical shards: %d\n", numShards, numPhysicalShards);
+
+	return Void();
+}
+
+ACTOR Future<Void> printServerShards(Database cx, UID serverId) {
+	state Key begin = allKeys.begin;
+	state int numShards = 0;
+
+	while (begin < allKeys.end) {
+		// RYW to optimize re-reading the same key ranges
+		state Reference<ReadYourWritesTransaction> tr = makeReference<ReadYourWritesTransaction>(cx);
+
+		loop {
+			try {
+				tr->setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
+				tr->setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
+
+				RangeResult serverShards =
+				    wait(krmGetRanges(tr, serverKeysPrefixFor(serverId), KeyRangeRef(begin, allKeys.end)));
+
+				for (int i = 0; i < serverShards.size() - 1; ++i) {
+					KeyRangeRef currentRange(serverShards[i].key, serverShards[i + 1].key);
+					UID shardId;
+					bool assigned, emptyRange;
+					EnablePhysicalShardMove enablePSM = EnablePhysicalShardMove::False;
+					decodeServerKeysValue(serverShards[i].value, assigned, emptyRange, enablePSM, shardId);
+					printf("Range: %s, ShardID: %s, Assigned: %s\n",
+					       Traceable<KeyRangeRef>::toString(currentRange).c_str(),
+					       shardId.toString().c_str(),
+					       assigned ? "true" : "false");
+				}
+
+				begin = serverShards.back().key;
+				numShards += serverShards.size() - 1;
+				break;
+			} catch (Error& e) {
+				wait(tr->onError(e));
+			}
+		}
+	}
+
+	return Void();
+}
+
+ACTOR Future<Void> resolveRange(Database cx, KeyRange range) {
+	state Key begin = range.begin;
+
+	while (begin < range.end) {
+		// RYW to optimize re-reading the same key ranges
+		state Reference<ReadYourWritesTransaction> tr = makeReference<ReadYourWritesTransaction>(cx);
+
+		loop {
+			try {
+				tr->setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
+				tr->setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
+
+				state RangeResult UIDtoTagMap = wait(tr->getRange(serverTagKeys, CLIENT_KNOBS->TOO_MANY));
+				ASSERT(!UIDtoTagMap.more && UIDtoTagMap.size() < CLIENT_KNOBS->TOO_MANY);
+
+				KeyRangeRef currentKeys(begin, range.end);
+				RangeResult shards = wait(
+				    krmGetRanges(tr, keyServersPrefix, currentKeys, CLIENT_KNOBS->TOO_MANY, CLIENT_KNOBS->TOO_MANY));
+
+				for (int i = 0; i < shards.size() - 1; ++i) {
+					const KeyRangeRef currentRange(shards[i].key, shards[i + 1].key);
+					std::vector<UID> src;
+					std::vector<UID> dest;
+					UID srcId;
+					UID destId;
+					decodeKeyServersValue(UIDtoTagMap, shards[i].value, src, dest, srcId, destId);
+					printf("Range: %s, ShardID: %s, Src Servers: %s, Dest Servers: %s\n",
+					       Traceable<KeyRangeRef>::toString(currentRange).c_str(),
+					       srcId.toString().c_str(),
+					       describeUIDs(src).c_str(),
+					       describeUIDs(dest).c_str());
+				}
+
+				begin = shards.back().key;
+				break;
+			} catch (Error& e) {
+				wait(tr->onError(e));
+			}
+		}
+	}
+
+	return Void();
+}
+
+} // namespace
+
+namespace fdb_cli {
+
+ACTOR Future<bool> locationMetadataCommandActor(Database cx, std::vector<StringRef> tokens) {
+	if (tokens.size() < 2 || tokens.size() > 4) {
+		printUsage(tokens[0]);
+		return false;
+	}
+
+	if (tokens.size() == 2) {
+		if (!tokencmp(tokens[1], "physicalshards")) {
+			printUsage(tokens[0]);
+			return false;
+		}
+		wait(printPhysicalShardCount(cx));
+	} else if (tokencmp(tokens[1], "resolve")) {
+		if (tokens.size() == 3) {
+			wait(resolveRange(cx, singleKeyRange(tokens[2])));
+		} else {
+			wait(resolveRange(cx, KeyRangeRef(tokens[2], tokens[3])));
+		}
+	} else if (tokencmp(tokens[1], "servershards")) {
+		if (tokens.size() != 3) {
+			printUsage(tokens[0]);
+			return false;
+		}
+		wait(printServerShards(cx, UID::fromString(tokens[2].toString())));
+	} else if (tokencmp(tokens[1], "listshards")) {
+		if (tokens.size() == 4 && !tokencmp(tokens[3], "physical")) {
+			printUsage(tokens[0]);
+			return false;
+		}
+		const bool physical = tokens.size() == 4;
+		wait(printRandomShards(cx, std::stoi(tokens[2].toString()), physical));
+	} else {
+		printUsage(tokens[0]);
+		return false;
+	}
+
+	return true;
+}
+
+CommandFactory locationMetadataFactory(
+    "location_metadata",
+    CommandHelp(
+        "location_metadata [physicalshards|resolve|servershards|listshards] [<id>|<begin>|<n>] [<end>|physical]",
+        "Check location metadata",
+        "To check number of physical shards: `location_metadata physicalshards'\n"
+        "To check the location of a key: `location_metadata resolve <key>'\n"
+        "To check the location of a keyrange: `location_metadata resolve <begin> <end>'\n"
+        "To check shard assignments of a storage server: `location_metadata servershards <ssID>'\n"
+        "To list <n> random physical shards: `location_metadata listshards <n> physical'\n"
+        "To list <n> random non-physical shards: `location_metadata listshards <n>'\n"));
+} // namespace fdb_cli

--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -1681,6 +1681,14 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise, Reference<ClusterCo
 					continue;
 				}
 
+				if (tokencmp(tokens[0], "location_metadata")) {
+					bool _result = wait(makeInterruptable(locationMetadataCommandActor(localDb, tokens)));
+					if (!_result) {
+						is_error = true;
+					}
+					continue;
+				}
+
 				if (tokencmp(tokens[0], "force_recovery_with_data_loss")) {
 					bool _result = wait(makeInterruptable(forceRecoveryWithDataLossCommandActor(db, tokens)));
 					if (!_result)

--- a/fdbcli/include/fdbcli/fdbcli.actor.h
+++ b/fdbcli/include/fdbcli/fdbcli.actor.h
@@ -203,6 +203,7 @@ ACTOR Future<UID> auditStorageCommandActor(Reference<IClusterConnectionRecord> c
                                            std::vector<StringRef> tokens);
 // Retrieve audit storage status
 ACTOR Future<bool> getAuditStatusCommandActor(Database cx, std::vector<StringRef> tokens);
+ACTOR Future<bool> locationMetadataCommandActor(Database cx, std::vector<StringRef> tokens);
 // force_recovery_with_data_loss command
 ACTOR Future<bool> forceRecoveryWithDataLossCommandActor(Reference<IDatabase> db, std::vector<StringRef> tokens);
 // include command

--- a/fdbclient/include/fdbclient/Audit.h
+++ b/fdbclient/include/fdbclient/Audit.h
@@ -39,7 +39,6 @@ enum class AuditType : uint8_t {
 	ValidateReplica = 2,
 	ValidateLocationMetadata = 3,
 	ValidateStorageServerShard = 4,
-	CheckMigrationStatus = 5,
 };
 
 struct AuditStorageState {


### PR DESCRIPTION
main branch PR: #10395

* Added location_metadata fdbcli to query shard locations, assignements, numbers etc.

* Added `listshards` to get some random physical/non-physical shards.

* Resolved comments.

Replace this text with your description here...

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
