### PR TITLE
[Release 7.3] Cherry-pick Add audit storage cancellation (#10386)

### DIFF
--- a/fdbcli/GetAuditStatusCommand.actor.cpp
+++ b/fdbcli/GetAuditStatusCommand.actor.cpp
@@ -31,7 +31,7 @@
 namespace fdb_cli {
 
 ACTOR Future<bool> getAuditStatusCommandActor(Database cx, std::vector<StringRef> tokens) {
-	if (tokens.size() < 2 || tokens.size() > 4) {
+	if (tokens.size() < 2 || tokens.size() > 5) {
 		printUsage(tokens[0]);
 		return false;
 	}
@@ -73,6 +73,20 @@ ACTOR Future<bool> getAuditStatusCommandActor(Database cx, std::vector<StringRef
 		for (const auto& it : res) {
 			printf("Audit result is:\n%s\n", it.toString().c_str());
 		}
+	} else if (tokencmp(tokens[2], "phase")) {
+		AuditPhase phase = stringToAuditPhase(tokens[3].toString());
+		if (phase == AuditPhase::Invalid) {
+			printUsage(tokens[0]);
+			return false;
+		}
+		int count = CLIENT_KNOBS->TOO_MANY;
+		if (tokens.size() == 5) {
+			count = std::stoi(tokens[4].toString());
+		}
+		std::vector<AuditStorageState> res = wait(getAuditStates(cx, type, /*newFirst=*/true, count, phase));
+		for (const auto& it : res) {
+			printf("Audit result is:\n%s\n", it.toString().c_str());
+		}
 	} else {
 		printUsage(tokens[0]);
 		return false;
@@ -83,12 +97,16 @@ ACTOR Future<bool> getAuditStatusCommandActor(Database cx, std::vector<StringRef
 
 CommandFactory getAuditStatusFactory(
     "get_audit_status",
-    CommandHelp("get_audit_status [ha|replica|locationmetadata|ssshard|checkmigration] [id|recent] [ARGs]",
+    CommandHelp("get_audit_status [ha|replica|locationmetadata|ssshard|checkmigration] [id|recent|phase] [ARGs]",
                 "Retrieve audit storage status",
                 "To fetch audit status via ID: `get_audit_status [Type] id [ID]'\n"
                 "To fetch status of most recent audit: `get_audit_status [Type] recent [Count]'\n"
                 "Supported types include: 'ha', `replica`, `locationmetadata`, "
                 "`ssshard` and `checkmigration`. If specified, `Count' is how many\n"
+                "To fetch status of audits in a specific phase: `get_audit_status [Type] phase "
+                "[running|complete|failed|error] count'\n"
+                "Supported types include: 'ha', `replica`, `locationmetadata`, `ssshard`, \n"
+                "and `checkmigration`. If specified, `Count' is how many\n"
                 "rows to audit. If not specified, check all rows in audit.\n"
                 "get_audit_status checkmigration prints out the number of data shards and physical shards."
                 "Results have the following format: if not `checkmigration`\n"

--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -1668,7 +1668,9 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise, Reference<ClusterCo
 					if (!auditId.isValid()) {
 						is_error = true;
 					} else {
-						printf("Started audit: %s\n", auditId.toString().c_str());
+						printf("%s audit: %s\n",
+						       tokencmp(tokens[1], "cancel") ? "Cancelled" : "Started",
+						       auditId.toString().c_str());
 					}
 					continue;
 				}

--- a/fdbclient/AuditUtils.actor.cpp
+++ b/fdbclient/AuditUtils.actor.cpp
@@ -60,6 +60,7 @@ ACTOR Future<bool> checkStorageServerRemoved(Database cx, UID ssid) {
 		try {
 			tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
 			tr.setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
+			tr.setOption(FDBTransactionOptions::LOCK_AWARE);
 			Optional<Value> serverListValue = wait(tr.get(serverListKeyFor(ssid)));
 			if (!serverListValue.present()) {
 				res = true; // SS is removed
@@ -78,17 +79,25 @@ ACTOR Future<bool> checkStorageServerRemoved(Database cx, UID ssid) {
 }
 
 ACTOR Future<Void> clearAuditMetadata(Database cx, AuditType auditType, UID auditId, bool clearProgressMetadata) {
-	state Transaction tr(cx);
-	TraceEvent(SevDebug, "AuditUtilClearAuditMetadataStart", auditId).detail("AuditKey", auditKey(auditType, auditId));
-
 	try {
+		state Transaction tr(cx);
+		TraceEvent(SevDebug, "AuditUtilClearAuditMetadataStart", auditId)
+		    .detail("AuditKey", auditKey(auditType, auditId));
 		loop {
 			try {
 				tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
 				tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+				tr.setOption(FDBTransactionOptions::LOCK_AWARE);
+				Optional<Value> res_ = wait(tr.get(auditKey(auditType, auditId)));
+				if (!res_.present()) { // has been cleared
+					break; // Nothing to clear
+				}
+				state AuditStorageState toClearState = decodeAuditStorageState(res_.get());
+				ASSERT(toClearState.id == auditId && toClearState.getType() == auditType);
+				// For a zombie audit, it is in running state
 				// Clear audit metadata
 				tr.clear(auditKey(auditType, auditId));
-				// Clear progress metadata
+				// clear progress metadata
 				if (clearProgressMetadata) {
 					clearAuditProgressMetadata(&tr, auditType, auditId);
 				}
@@ -97,24 +106,76 @@ ACTOR Future<Void> clearAuditMetadata(Database cx, AuditType auditType, UID audi
 				    .detail("AuditKey", auditKey(auditType, auditId));
 				break;
 			} catch (Error& e) {
+				TraceEvent(SevDebug, "AuditUtilClearAuditMetadataError", auditId)
+				    .detail("AuditKey", auditKey(auditType, auditId));
 				wait(tr.onError(e));
 			}
 		}
 	} catch (Error& e) {
-		TraceEvent(SevInfo, "AuditUtilClearAuditMetadataError", auditId)
-		    .errorUnsuppressed(e)
-		    .detail("AuditKey", auditKey(auditType, auditId));
 		// We do not want audit cleanup effects DD
+		// pass
 	}
-
 	return Void();
+}
+
+ACTOR Future<Void> cancelAuditMetadata(Database cx, AuditType auditType, UID auditId) {
+	try {
+		state Transaction tr(cx);
+		TraceEvent(SevDebug, "AuditUtilCancelAuditMetadataStart", auditId)
+		    .detail("AuditKey", auditKey(auditType, auditId));
+		loop {
+			try {
+				tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
+				tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+				tr.setOption(FDBTransactionOptions::LOCK_AWARE);
+				Optional<Value> res_ = wait(tr.get(auditKey(auditType, auditId)));
+				if (!res_.present()) { // has been cancelled
+					break; // Nothing to cancel
+				}
+				state AuditStorageState toCancelState = decodeAuditStorageState(res_.get());
+				ASSERT(toCancelState.id == auditId && toCancelState.getType() == auditType);
+				toCancelState.setPhase(AuditPhase::Failed);
+				tr.set(auditKey(toCancelState.getType(), toCancelState.id), auditStorageStateValue(toCancelState));
+				wait(tr.commit());
+				TraceEvent(SevDebug, "AuditUtilCancelAuditMetadataEnd", auditId)
+				    .detail("AuditKey", auditKey(auditType, auditId));
+				break;
+			} catch (Error& e) {
+				TraceEvent(SevDebug, "AuditUtilCancelAuditMetadataError", auditId)
+				    .detail("AuditKey", auditKey(auditType, auditId));
+				wait(tr.onError(e));
+			}
+		}
+	} catch (Error& e) {
+		throw cancel_audit_storage_failed();
+	}
+	return Void();
+}
+
+AuditPhase stringToAuditPhase(std::string auditPhaseStr) {
+	// Convert chars of auditPhaseStr to lower case
+	std::transform(auditPhaseStr.begin(), auditPhaseStr.end(), auditPhaseStr.begin(), [](unsigned char c) {
+		return std::tolower(c);
+	});
+	if (auditPhaseStr == "running") {
+		return AuditPhase::Running;
+	} else if (auditPhaseStr == "complete") {
+		return AuditPhase::Complete;
+	} else if (auditPhaseStr == "failed") {
+		return AuditPhase::Failed;
+	} else if (auditPhaseStr == "error") {
+		return AuditPhase::Error;
+	} else {
+		return AuditPhase::Invalid;
+	}
 }
 
 // This is not transactional
 ACTOR Future<std::vector<AuditStorageState>> getAuditStates(Database cx,
                                                             AuditType auditType,
                                                             bool newFirst,
-                                                            Optional<int> num = Optional<int>()) {
+                                                            Optional<int> num,
+                                                            Optional<AuditPhase> phase) {
 	state Transaction tr(cx);
 	state std::vector<AuditStorageState> auditStates;
 	state Key readBegin;
@@ -131,13 +192,18 @@ ACTOR Future<std::vector<AuditStorageState>> getAuditStates(Database cx,
 			while (true) {
 				tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
 				tr.setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
+				tr.setOption(FDBTransactionOptions::LOCK_AWARE);
 				KeyRangeRef rangeToRead(readBegin, readEnd);
 				state RangeResult res = wait(tr.getRange(rangeToRead,
 				                                         num.present() ? GetRangeLimits(num.get()) : GetRangeLimits(),
 				                                         Snapshot::False,
 				                                         reverse));
 				for (int i = 0; i < res.size(); ++i) {
-					auditStates.push_back(decodeAuditStorageState(res[i].value));
+					const AuditStorageState auditState = decodeAuditStorageState(res[i].value);
+					if (phase.present() && auditState.getPhase() != phase.get()) {
+						continue;
+					}
+					auditStates.push_back(auditState);
 					if (num.present() && auditStates.size() == num.get()) {
 						return auditStates; // since res.more is not reliable when GetRangeLimits is set to 1
 					}
@@ -191,6 +257,7 @@ ACTOR Future<Void> clearAuditMetadataForType(Database cx,
 				numFinishAuditCleaned = 0;
 				tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
 				tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+				tr.setOption(FDBTransactionOptions::LOCK_AWARE);
 				for (const auto& auditState : auditStates) {
 					if (auditState.id.first() > maxAuditIdToClear.first()) {
 						continue; // ignore any audit with a larger auditId than the input threshold
@@ -288,20 +355,30 @@ ACTOR static Future<Void> checkMoveKeysLock(Transaction* tr,
 
 ACTOR Future<Void> updateAuditState(Database cx, AuditStorageState auditState, MoveKeyLockInfo lock, bool ddEnabled) {
 	state Transaction tr(cx);
+	state bool hasCancelled = false;
 
 	loop {
 		try {
 			tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
 			tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+			tr.setOption(FDBTransactionOptions::LOCK_AWARE);
 			wait(checkMoveKeysLock(&tr, lock, ddEnabled, true));
+			// Check existing state
+			Optional<Value> res_ = wait(tr.get(auditKey(auditState.getType(), auditState.id)));
+			if (!res_.present()) { // has been cancelled
+				hasCancelled = true;
+				break; // exit
+			} else {
+				const AuditStorageState currentState = decodeAuditStorageState(res_.get());
+				ASSERT(currentState.id == auditState.id && currentState.getType() == auditState.getType());
+				if (currentState.getPhase() == AuditPhase::Failed) {
+					hasCancelled = true;
+					break; // exit
+				}
+			}
 			// Persist audit result
 			tr.set(auditKey(auditState.getType(), auditState.id), auditStorageStateValue(auditState));
 			wait(tr.commit());
-			TraceEvent(SevDebug, "AuditUtilUpdateAuditState", auditState.id)
-			    .detail("AuditID", auditState.id)
-			    .detail("AuditType", auditState.getType())
-			    .detail("AuditPhase", auditState.getPhase())
-			    .detail("AuditKey", auditKey(auditState.getType(), auditState.id));
 			break;
 		} catch (Error& e) {
 			TraceEvent(SevDebug, "AuditUtilUpdateAuditStateError", auditState.id)
@@ -313,6 +390,13 @@ ACTOR Future<Void> updateAuditState(Database cx, AuditStorageState auditState, M
 			wait(tr.onError(e));
 		}
 	}
+
+	TraceEvent(SevDebug, "AuditUtilUpdateAuditStateEnd", auditState.id)
+	    .detail("Cancelled", hasCancelled)
+	    .detail("AuditID", auditState.id)
+	    .detail("AuditType", auditState.getType())
+	    .detail("AuditPhase", auditState.getPhase())
+	    .detail("AuditKey", auditKey(auditState.getType(), auditState.id));
 
 	return Void();
 }
@@ -331,6 +415,7 @@ ACTOR Future<UID> persistNewAuditState(Database cx,
 			try {
 				tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
 				tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+				tr.setOption(FDBTransactionOptions::LOCK_AWARE);
 				wait(checkMoveKeysLock(&tr, lock, ddEnabled, true));
 				RangeResult res =
 				    wait(tr.getRange(auditKeyRange(auditState.getType()), 1, Snapshot::False, Reverse::True));
@@ -398,11 +483,23 @@ ACTOR Future<Void> persistAuditState(Database cx,
 		try {
 			tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
 			tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+			tr.setOption(FDBTransactionOptions::LOCK_AWARE);
 			wait(checkMoveKeysLock(&tr, lock, ddEnabled, true));
 			// Clear persistent progress data of the new audit if complete
 			if (auditPhase == AuditPhase::Complete) {
 				clearAuditProgressMetadata(&tr, auditState.getType(), auditState.id);
 			} // We keep the progess metadata of Failed and Error audits for further investigations
+			// Check existing state
+			Optional<Value> res_ = wait(tr.get(auditKey(auditState.getType(), auditState.id)));
+			if (!res_.present()) { // has been cancelled
+				throw audit_storage_cancelled();
+			} else {
+				const AuditStorageState currentState = decodeAuditStorageState(res_.get());
+				ASSERT(currentState.id == auditState.id && currentState.getType() == auditState.getType());
+				if (currentState.getPhase() == AuditPhase::Failed) {
+					throw audit_storage_cancelled();
+				}
+			}
 			// Persist audit result
 			tr.set(auditKey(auditState.getType(), auditState.id), auditStorageStateValue(auditState));
 			wait(tr.commit());
@@ -436,6 +533,7 @@ ACTOR Future<AuditStorageState> getAuditState(Database cx, AuditType type, UID i
 		try {
 			tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
 			tr.setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
+			tr.setOption(FDBTransactionOptions::LOCK_AWARE);
 			Optional<Value> res_ = wait(tr.get(auditKey(type, id)));
 			res = res_;
 			TraceEvent(SevDebug, "AuditUtilReadAuditState", id)
@@ -467,18 +565,30 @@ ACTOR Future<Void> persistAuditStateByRange(Database cx, AuditStorageState audit
 		try {
 			tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
 			tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+			tr.setOption(FDBTransactionOptions::LOCK_AWARE);
 			Optional<Value> ddAuditState_ = wait(tr.get(auditKey(auditState.getType(), auditState.id)));
 			if (!ddAuditState_.present()) {
-				throw audit_storage_failed();
+				throw audit_storage_cancelled();
 			}
 			AuditStorageState ddAuditState = decodeAuditStorageState(ddAuditState_.get());
-			ASSERT(ddAuditState.getPhase() != AuditPhase::Invalid);
-			if (ddAuditState.getPhase() != AuditPhase::Running) {
-				throw audit_storage_failed();
-			}
 			ASSERT(ddAuditState.ddId.isValid());
 			if (ddAuditState.ddId != auditState.ddId) {
 				throw audit_storage_failed(); // a new dd starts and this audit task is outdated
+			}
+			// It is possible ddAuditState is complete while some progress is about to persist
+			// Since doAuditOnStorageServer may repeatedly issue multiple requests (see getReplyUnlessFailedFor)
+			// For this case, no need to proceed. Sliently exit
+			if (ddAuditState.getPhase() == AuditPhase::Complete) {
+				break;
+			}
+			// If this is the same dd, the phase must be following
+			TraceEvent("PersistAuditStateByRange")
+			    .detail("AuditID", auditState.id)
+			    .detail("AuditType", auditState.getType())
+			    .detail("AuditPhase", auditState.getPhase());
+			ASSERT(ddAuditState.getPhase() == AuditPhase::Running || ddAuditState.getPhase() == AuditPhase::Failed);
+			if (ddAuditState.getPhase() == AuditPhase::Failed) {
+				throw audit_storage_cancelled();
 			}
 			wait(krmSetRange(&tr,
 			                 auditRangeBasedProgressPrefixFor(auditState.getType(), auditState.id),
@@ -486,6 +596,11 @@ ACTOR Future<Void> persistAuditStateByRange(Database cx, AuditStorageState audit
 			                 auditStorageStateValue(auditState)));
 			break;
 		} catch (Error& e) {
+			TraceEvent("PersistAuditStateByRangeError")
+			    .errorUnsuppressed(e)
+			    .detail("AuditID", auditState.id)
+			    .detail("AuditType", auditState.getPhase())
+			    .detail("AuditPhase", auditState.getPhase());
 			wait(tr.onError(e));
 		}
 	}
@@ -504,6 +619,7 @@ ACTOR Future<std::vector<AuditStorageState>> getAuditStateByRange(Database cx,
 		try {
 			tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
 			tr.setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
+			tr.setOption(FDBTransactionOptions::LOCK_AWARE);
 			RangeResult res_ = wait(krmGetRanges(&tr,
 			                                     auditRangeBasedProgressPrefixFor(type, auditId),
 			                                     range,
@@ -543,18 +659,26 @@ ACTOR Future<Void> persistAuditStateByServer(Database cx, AuditStorageState audi
 		try {
 			tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
 			tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+			tr.setOption(FDBTransactionOptions::LOCK_AWARE);
 			Optional<Value> ddAuditState_ = wait(tr.get(auditKey(auditState.getType(), auditState.id)));
 			if (!ddAuditState_.present()) {
-				throw audit_storage_failed();
+				throw audit_storage_cancelled();
 			}
 			AuditStorageState ddAuditState = decodeAuditStorageState(ddAuditState_.get());
-			ASSERT(ddAuditState.getPhase() != AuditPhase::Invalid);
-			if (ddAuditState.getPhase() != AuditPhase::Running) {
-				throw audit_storage_failed();
-			}
 			ASSERT(ddAuditState.ddId.isValid());
 			if (ddAuditState.ddId != auditState.ddId) {
 				throw audit_storage_failed(); // a new dd starts and this audit task is outdated
+			}
+			// It is possible ddAuditState is complete while some progress is about to persist
+			// Since doAuditOnStorageServer may repeatedly issue multiple requests (see getReplyUnlessFailedFor)
+			// For this case, no need to proceed. Sliently exit
+			if (ddAuditState.getPhase() == AuditPhase::Complete) {
+				break;
+			}
+			// If this is the same dd, the phase must be following
+			ASSERT(ddAuditState.getPhase() == AuditPhase::Running || ddAuditState.getPhase() == AuditPhase::Failed);
+			if (ddAuditState.getPhase() == AuditPhase::Failed) {
+				throw audit_storage_cancelled();
 			}
 			wait(krmSetRange(
 			    &tr,
@@ -582,6 +706,7 @@ ACTOR Future<std::vector<AuditStorageState>> getAuditStateByServer(Database cx,
 		try {
 			tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
 			tr.setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
+			tr.setOption(FDBTransactionOptions::LOCK_AWARE);
 			RangeResult res_ = wait(krmGetRanges(&tr,
 			                                     auditServerBasedProgressPrefixFor(type, auditId, auditServerId),
 			                                     range,

--- a/fdbclient/AuditUtils.actor.cpp
+++ b/fdbclient/AuditUtils.actor.cpp
@@ -133,6 +133,7 @@ ACTOR Future<Void> cancelAuditMetadata(Database cx, AuditType auditType, UID aud
 					break; // Nothing to cancel
 				}
 				state AuditStorageState toCancelState = decodeAuditStorageState(res_.get());
+				// For a zombie audit, it is in running state
 				ASSERT(toCancelState.id == auditId && toCancelState.getType() == auditType);
 				toCancelState.setPhase(AuditPhase::Failed);
 				tr.set(auditKey(toCancelState.getType(), toCancelState.id), auditStorageStateValue(toCancelState));
@@ -278,6 +279,7 @@ ACTOR Future<Void> clearAuditMetadataForType(Database cx,
 						clearAuditProgressMetadata(&tr, auditType, auditState.id);
 						numFinishAuditCleaned++;
 					}
+					// For a zombie audit, it is in running state
 				}
 				wait(tr.commit());
 				TraceEvent(SevDebug, "AuditUtilClearAuditMetadataForTypeEnd")

--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -2681,6 +2681,39 @@ ACTOR Future<UID> auditStorage(Reference<IClusterConnectionRecord> clusterFile,
 	return auditId;
 }
 
+ACTOR Future<UID> cancelAuditStorage(Reference<IClusterConnectionRecord> clusterFile,
+                                     AuditType type,
+                                     UID auditId,
+                                     double timeoutSeconds) {
+	state Reference<AsyncVar<Optional<ClusterInterface>>> clusterInterface(new AsyncVar<Optional<ClusterInterface>>);
+	state Future<Void> leaderMon = monitorLeader<ClusterInterface>(clusterFile, clusterInterface);
+	TraceEvent(SevVerbose, "ManagementAPICancelAuditStorageTrigger")
+	    .detail("AuditType", type)
+	    .detail("AuditId", auditId);
+	try {
+		while (!clusterInterface->get().present()) {
+			wait(clusterInterface->onChange());
+		}
+		TraceEvent(SevVerbose, "ManagementAPICancelAuditStorageBegin")
+		    .detail("AuditType", type)
+		    .detail("AuditId", auditId);
+		TriggerAuditRequest req(type, auditId);
+		UID auditId_ = wait(timeoutError(clusterInterface->get().get().triggerAudit.getReply(req), timeoutSeconds));
+		ASSERT(auditId_ == auditId);
+		TraceEvent(SevVerbose, "ManagementAPICancelAuditStorageEnd")
+		    .detail("AuditType", type)
+		    .detail("AuditID", auditId);
+	} catch (Error& e) {
+		TraceEvent(SevInfo, "ManagementAPICancelAuditStorageError")
+		    .errorUnsuppressed(e)
+		    .detail("AuditType", type)
+		    .detail("AuditID", auditId);
+		throw e;
+	}
+
+	return auditId;
+}
+
 ACTOR Future<Void> waitForPrimaryDC(Database cx, StringRef dcId) {
 	state ReadYourWritesTransaction tr(cx);
 

--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -875,7 +875,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( SERVE_FETCH_CHECKPOINT_PARALLELISM,                      4 );
 	init( SERVE_AUDIT_STORAGE_PARALLELISM,                         1 );
 	init( PERSIST_FINISH_AUDIT_COUNT,                             10 ); if ( isSimulated ) PERSIST_FINISH_AUDIT_COUNT = 1;
-	init( AUDIT_RETRY_COUNT_MAX,                                 100 ); if ( isSimulated ) AUDIT_RETRY_COUNT_MAX = 10;
+	init( AUDIT_RETRY_COUNT_MAX,                                1000 ); if ( isSimulated ) AUDIT_RETRY_COUNT_MAX = 10;
 	init( CONCURRENT_AUDIT_TASK_COUNT_MAX,                        10 ); if ( isSimulated ) CONCURRENT_AUDIT_TASK_COUNT_MAX = deterministicRandom()->randomInt(1, CONCURRENT_AUDIT_TASK_COUNT_MAX+1);
 	init( BUGGIFY_BLOCK_BYTES,                                 10000 );
 	init( STORAGE_RECOVERY_VERSION_LAG_LIMIT,				2 * MAX_READ_TRANSACTION_LIFE_VERSIONS );

--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -874,7 +874,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( FETCH_KEYS_LOWER_PRIORITY,                               0 );
 	init( SERVE_FETCH_CHECKPOINT_PARALLELISM,                      4 );
 	init( SERVE_AUDIT_STORAGE_PARALLELISM,                         1 );
-	init( PERSIST_FINISH_AUDIT_COUNT,                             10 ); if ( isSimulated ) PERSIST_FINISH_AUDIT_COUNT = 1;
+	init( PERSIST_FINISH_AUDIT_COUNT,                             10 ); if ( isSimulated ) PERSIST_FINISH_AUDIT_COUNT = deterministicRandom()->randomInt(1, PERSIST_FINISH_AUDIT_COUNT+1);
 	init( AUDIT_RETRY_COUNT_MAX,                                1000 ); if ( isSimulated ) AUDIT_RETRY_COUNT_MAX = 10;
 	init( CONCURRENT_AUDIT_TASK_COUNT_MAX,                        10 ); if ( isSimulated ) CONCURRENT_AUDIT_TASK_COUNT_MAX = deterministicRandom()->randomInt(1, CONCURRENT_AUDIT_TASK_COUNT_MAX+1);
 	init( BUGGIFY_BLOCK_BYTES,                                 10000 );

--- a/fdbclient/include/fdbclient/Audit.h
+++ b/fdbclient/include/fdbclient/Audit.h
@@ -116,25 +116,28 @@ struct AuditStorageRequest {
 
 // Triggers an audit of the specific type, an audit id is returned if an audit is scheduled successfully.
 // If there is an running audit, the corresponding id will be returned, unless force is true;
-// When force is set, the ongoing audit will be cancelled, and a new audit will be scheduled.
+// When cancel is set, the ongoing audit will be cancelled.
 struct TriggerAuditRequest {
 	constexpr static FileIdentifier file_identifier = 1384445;
 
 	TriggerAuditRequest() = default;
 	TriggerAuditRequest(AuditType type, KeyRange range)
-	  : type(static_cast<uint8_t>(type)), range(range), force(false) {}
+	  : type(static_cast<uint8_t>(type)), range(range), cancel(false) {}
+
+	TriggerAuditRequest(AuditType type, UID id) : type(static_cast<uint8_t>(type)), id(id), cancel(true) {}
 
 	void setType(AuditType type) { this->type = static_cast<uint8_t>(this->type); }
 	AuditType getType() const { return static_cast<AuditType>(this->type); }
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, type, range, force, reply);
+		serializer(ar, type, range, id, cancel, reply);
 	}
 
+	UID id;
 	uint8_t type;
 	KeyRange range;
-	bool force;
+	bool cancel;
 	ReplyPromise<UID> reply;
 };
 

--- a/fdbclient/include/fdbclient/AuditUtils.actor.h
+++ b/fdbclient/include/fdbclient/AuditUtils.actor.h
@@ -37,6 +37,7 @@ struct MoveKeyLockInfo {
 };
 
 ACTOR Future<Void> clearAuditMetadata(Database cx, AuditType auditType, UID auditId, bool clearProgressMetadata);
+ACTOR Future<Void> cancelAuditMetadata(Database cx, AuditType auditType, UID auditId);
 ACTOR Future<UID> persistNewAuditState(Database cx, AuditStorageState auditState, MoveKeyLockInfo lock, bool ddEnabled);
 ACTOR Future<Void> persistAuditState(Database cx,
                                      AuditStorageState auditState,
@@ -47,7 +48,8 @@ ACTOR Future<AuditStorageState> getAuditState(Database cx, AuditType type, UID i
 ACTOR Future<std::vector<AuditStorageState>> getAuditStates(Database cx,
                                                             AuditType auditType,
                                                             bool newFirst,
-                                                            Optional<int> num);
+                                                            Optional<int> num = Optional<int>(),
+                                                            Optional<AuditPhase> phase = Optional<AuditPhase>());
 ACTOR Future<Void> persistAuditStateByRange(Database cx, AuditStorageState auditState);
 ACTOR Future<std::vector<AuditStorageState>> getAuditStateByRange(Database cx,
                                                                   AuditType type,
@@ -66,5 +68,6 @@ ACTOR Future<Void> clearAuditMetadataForType(Database cx,
                                              int numFinishAuditToKeep);
 ACTOR Future<bool> checkStorageServerRemoved(Database cx, UID ssid);
 ACTOR Future<Void> updateAuditState(Database cx, AuditStorageState auditState, MoveKeyLockInfo lock, bool ddEnabled);
+AuditPhase stringToAuditPhase(std::string auditPhaseStr);
 #include "flow/unactorcompiler.h"
 #endif

--- a/fdbclient/include/fdbclient/ManagementAPI.actor.h
+++ b/fdbclient/include/fdbclient/ManagementAPI.actor.h
@@ -155,6 +155,11 @@ ACTOR Future<UID> auditStorage(Reference<IClusterConnectionRecord> clusterFile,
                                KeyRange range,
                                AuditType type,
                                double timeoutSeconds);
+// Cancel an audit given type and id
+ACTOR Future<UID> cancelAuditStorage(Reference<IClusterConnectionRecord> clusterFile,
+                                     AuditType type,
+                                     UID auditId,
+                                     double timeoutSeconds);
 
 ACTOR Future<Void> printHealthyZone(Database cx);
 ACTOR Future<bool> clearHealthyZone(Database cx, bool printWarning = false, bool clearSSFailureZoneString = false);

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -1919,7 +1919,7 @@ ACTOR Future<Void> handleForcedRecoveries(ClusterControllerData* self, ClusterCo
 
 ACTOR Future<Void> triggerAuditStorage(ClusterControllerData* self, TriggerAuditRequest req) {
 	state UID auditId;
-
+	ASSERT(!req.cancel);
 	try {
 		while (self->db.serverInfo->get().recoveryState < RecoveryState::ACCEPTING_COMMITS ||
 		       !self->db.serverInfo->get().distributor.present()) {
@@ -1949,14 +1949,49 @@ ACTOR Future<Void> triggerAuditStorage(ClusterControllerData* self, TriggerAudit
 	return Void();
 }
 
+ACTOR Future<Void> cancelAuditStorage(ClusterControllerData* self, TriggerAuditRequest req) {
+	ASSERT(req.cancel);
+	try {
+		while (self->db.serverInfo->get().recoveryState < RecoveryState::ACCEPTING_COMMITS ||
+		       !self->db.serverInfo->get().distributor.present()) {
+			wait(self->db.serverInfo->onChange());
+		}
+		TraceEvent(SevVerbose, "CCCancelAuditStorageBegin", self->id)
+		    .detail("AuditID", req.id)
+		    .detail("AuditType", req.getType())
+		    .detail("DDId", self->db.serverInfo->get().distributor.get().id());
+		TriggerAuditRequest fReq(req.getType(), req.id);
+		UID auditId = wait(self->db.serverInfo->get().distributor.get().triggerAudit.getReply(fReq));
+		TraceEvent(SevVerbose, "CCCancelAuditStorageEnd", self->id)
+		    .detail("ReturnedAuditID", auditId)
+		    .detail("AuditID", auditId)
+		    .detail("AuditType", req.getType());
+		ASSERT(auditId == req.id);
+		req.reply.send(auditId);
+	} catch (Error& e) {
+		TraceEvent(SevInfo, "CCCancelAuditStorageFailed", self->id)
+		    .errorUnsuppressed(e)
+		    .detail("AuditID", req.id)
+		    .detail("AuditType", req.getType());
+		req.reply.sendError(cancel_audit_storage_failed());
+	}
+
+	return Void();
+}
+
 ACTOR Future<Void> handleTriggerAuditStorage(ClusterControllerData* self, ClusterControllerFullInterface interf) {
 	loop {
 		TriggerAuditRequest req = waitNext(interf.clientInterface.triggerAudit.getFuture());
 		TraceEvent(SevVerbose, "CCTriggerAuditStorageReceived", self->id)
 		    .detail("ClusterControllerDcId", self->clusterControllerDcId)
 		    .detail("Range", req.range)
-		    .detail("AuditType", req.type);
-		self->addActor.send(triggerAuditStorage(self, req));
+		    .detail("AuditType", req.getType());
+		if (req.cancel) {
+			ASSERT(req.id.isValid());
+			self->addActor.send(cancelAuditStorage(self, req));
+		} else {
+			self->addActor.send(triggerAuditStorage(self, req));
+		}
 	}
 }
 

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -328,7 +328,10 @@ public:
 
 	std::unordered_map<AuditType, std::unordered_map<UID, std::shared_ptr<DDAudit>>> audits;
 	Promise<Void> auditInitialized;
-	std::unordered_map<AuditType, bool> anyAuditStorageLaunching;
+	FlowLock auditStorageHaLaunchingLock;
+	FlowLock auditStorageReplicaLaunchingLock;
+	FlowLock auditStorageLocationMetadataLaunchingLock;
+	FlowLock auditStorageSsShardLaunchingLock;
 	std::unordered_map<AuditType, AsyncVar<int>> remainingBudgetForAuditTasks;
 
 	Optional<Reference<TenantCache>> ddTenantCache;
@@ -339,7 +342,8 @@ public:
 	    movingDataEventHolder(makeReference<EventCacheHolder>("MovingData")),
 	    totalDataInFlightEventHolder(makeReference<EventCacheHolder>("TotalDataInFlight")),
 	    totalDataInFlightRemoteEventHolder(makeReference<EventCacheHolder>("TotalDataInFlightRemote")),
-	    teamCollection(nullptr) {}
+	    teamCollection(nullptr), auditStorageHaLaunchingLock(1), auditStorageReplicaLaunchingLock(1),
+	    auditStorageLocationMetadataLaunchingLock(1), auditStorageSsShardLaunchingLock(1) {}
 
 	// bootstrap steps
 
@@ -794,7 +798,7 @@ ACTOR Future<Void> resumeStorageAudits(Reference<DataDistributor> self) {
 				throw e;
 			}
 			if (retryCount > 50) {
-				TraceEvent(SevWarnAlways, "ResumeAuditStorageUnableUpdateMetadata", self->ddId).errorUnsuppressed(e);
+				TraceEvent(SevWarnAlways, "AuditStorageResumeUnableUpdateMetadata", self->ddId).errorUnsuppressed(e);
 				return Void();
 			}
 			retryCount++;
@@ -1772,6 +1776,9 @@ ACTOR Future<Void> auditStorageCore(Reference<DataDistributor> self,
 		    .detail("RetryCount", currentRetryCount)
 		    .detail("IsReady", self->auditInitialized.getFuture().isReady());
 	} catch (Error& e) {
+		if (e.code() == error_code_actor_cancelled) {
+			throw e;
+		}
 		TraceEvent(SevDebug, "DDAuditStorageCoreError", self->ddId)
 		    .errorUnsuppressed(e)
 		    .detail("Context", context)
@@ -1780,7 +1787,7 @@ ACTOR Future<Void> auditStorageCore(Reference<DataDistributor> self,
 		    .detail("AuditType", auditType)
 		    .detail("Range", audit->coreState.range)
 		    .detail("IsReady", self->auditInitialized.getFuture().isReady());
-		if (e.code() == error_code_actor_cancelled || e.code() == error_code_movekeys_conflict) {
+		if (e.code() == error_code_movekeys_conflict) {
 			throw e; // throw to DD and DD will restart
 		} else if (e.code() == error_code_audit_storage_cancelled) {
 			// do nothing, silently quit
@@ -1952,7 +1959,7 @@ ACTOR Future<UID> launchAudit(Reference<DataDistributor> self, KeyRange auditRan
 				    .detail("AuditID", auditID_)
 				    .detail("AuditType", auditType)
 				    .detail("Range", auditRange);
-				throw operation_cancelled(); // Trigger DD restart and check if resume audit is correct
+				throw operation_failed(); // Trigger DD restart and check if resume audit is correct
 			}
 			TraceEvent(SevInfo, "DDAuditStorageLaunchPersistNewAuditID", self->ddId)
 			    .detail("AuditID", auditID_)
@@ -1963,6 +1970,9 @@ ACTOR Future<UID> launchAudit(Reference<DataDistributor> self, KeyRange auditRan
 			runAuditStorage(self, auditState, 0, "LaunchAudit");
 		}
 	} catch (Error& e) {
+		if (e.code() == error_code_actor_cancelled) {
+			throw e;
+		}
 		TraceEvent(SevInfo, "DDAuditStorageLaunchError", self->ddId)
 		    .errorUnsuppressed(e)
 		    .detail("AuditType", auditType)
@@ -1973,9 +1983,20 @@ ACTOR Future<UID> launchAudit(Reference<DataDistributor> self, KeyRange auditRan
 }
 
 ACTOR Future<Void> cancelAuditStorage(Reference<DataDistributor> self, TriggerAuditRequest req) {
-	if (req.getType() != AuditType::ValidateHA && req.getType() != AuditType::ValidateReplica &&
-	    req.getType() != AuditType::ValidateLocationMetadata &&
-	    req.getType() != AuditType::ValidateStorageServerShard) {
+	state FlowLock::Releaser holder;
+	if (req.getType() == AuditType::ValidateHA) {
+		wait(self->auditStorageHaLaunchingLock.take(TaskPriority::DefaultYield));
+		holder = FlowLock::Releaser(self->auditStorageHaLaunchingLock);
+	} else if (req.getType() == AuditType::ValidateReplica) {
+		wait(self->auditStorageReplicaLaunchingLock.take(TaskPriority::DefaultYield));
+		holder = FlowLock::Releaser(self->auditStorageReplicaLaunchingLock);
+	} else if (req.getType() == AuditType::ValidateLocationMetadata) {
+		wait(self->auditStorageLocationMetadataLaunchingLock.take(TaskPriority::DefaultYield));
+		holder = FlowLock::Releaser(self->auditStorageLocationMetadataLaunchingLock);
+	} else if (req.getType() == AuditType::ValidateStorageServerShard) {
+		wait(self->auditStorageSsShardLaunchingLock.take(TaskPriority::DefaultYield));
+		holder = FlowLock::Releaser(self->auditStorageSsShardLaunchingLock);
+	} else {
 		req.reply.sendError(not_implemented());
 		return Void();
 	}
@@ -1997,14 +2018,14 @@ ACTOR Future<Void> cancelAuditStorage(Reference<DataDistributor> self, TriggerAu
 		    .detail("AuditID", req.id);
 		req.reply.send(req.id);
 	} catch (Error& e) {
+		if (e.code() == error_code_actor_cancelled) {
+			throw e;
+		}
 		TraceEvent(SevWarn, "DDCancelAuditStorageError", self->ddId)
 		    .errorUnsuppressed(e)
 		    .detail("AuditID", req.id)
 		    .detail("AuditType", req.getType());
 		req.reply.sendError(cancel_audit_storage_failed());
-		if (e.code() == error_code_actor_cancelled) {
-			throw e;
-		}
 	}
 	return Void();
 }
@@ -2019,14 +2040,24 @@ ACTOR Future<Void> cancelAuditStorage(Reference<DataDistributor> self, TriggerAu
 // For 1 and 2, we believe no new audit is persisted; For 3, we do not know whether a new
 // audit is persisted, but DD will restart and the new audit will be resume if created.
 ACTOR Future<Void> auditStorage(Reference<DataDistributor> self, TriggerAuditRequest req) {
-	if (req.getType() != AuditType::ValidateHA && req.getType() != AuditType::ValidateReplica &&
-	    req.getType() != AuditType::ValidateLocationMetadata &&
-	    req.getType() != AuditType::ValidateStorageServerShard) {
+	state FlowLock::Releaser holder;
+	if (req.getType() == AuditType::ValidateHA) {
+		wait(self->auditStorageHaLaunchingLock.take(TaskPriority::DefaultYield));
+		holder = FlowLock::Releaser(self->auditStorageHaLaunchingLock);
+	} else if (req.getType() == AuditType::ValidateReplica) {
+		wait(self->auditStorageReplicaLaunchingLock.take(TaskPriority::DefaultYield));
+		holder = FlowLock::Releaser(self->auditStorageReplicaLaunchingLock);
+	} else if (req.getType() == AuditType::ValidateLocationMetadata) {
+		wait(self->auditStorageLocationMetadataLaunchingLock.take(TaskPriority::DefaultYield));
+		holder = FlowLock::Releaser(self->auditStorageLocationMetadataLaunchingLock);
+	} else if (req.getType() == AuditType::ValidateStorageServerShard) {
+		wait(self->auditStorageSsShardLaunchingLock.take(TaskPriority::DefaultYield));
+		holder = FlowLock::Releaser(self->auditStorageSsShardLaunchingLock);
+	} else {
 		req.reply.sendError(not_implemented());
 		return Void();
 	}
-	ASSERT(!self->anyAuditStorageLaunching.contains(req.getType()) || !self->anyAuditStorageLaunching[req.getType()]);
-	self->anyAuditStorageLaunching[req.getType()] = true;
+
 	state int retryCount = 0;
 	loop {
 		try {
@@ -2043,15 +2074,16 @@ ACTOR Future<Void> auditStorage(Reference<DataDistributor> self, TriggerAuditReq
 			    .detail("Range", req.range)
 			    .detail("AuditID", auditID);
 		} catch (Error& e) {
+			if (e.code() == error_code_actor_cancelled) {
+				throw e;
+			}
 			TraceEvent(SevInfo, "DDAuditStorageError", self->ddId)
 			    .errorUnsuppressed(e)
 			    .detail("RetryCount", retryCount)
 			    .detail("AuditType", req.getType())
 			    .detail("Range", req.range);
-			if (e.code() == error_code_actor_cancelled) {
-				req.reply.sendError(audit_storage_failed());
-				self->anyAuditStorageLaunching[req.getType()] = false;
-				throw audit_storage_failed();
+			if (e.code() == error_code_operation_failed && g_network->isSimulated()) {
+				throw audit_storage_failed(); // to trigger dd restart
 			} else if (e.code() == error_code_audit_storage_exceeded_request_limit) {
 				req.reply.sendError(audit_storage_exceeded_request_limit());
 			} else if (e.code() == error_code_persist_new_audit_metadata_error) {
@@ -2066,7 +2098,6 @@ ACTOR Future<Void> auditStorage(Reference<DataDistributor> self, TriggerAuditReq
 		}
 		break;
 	}
-	self->anyAuditStorageLaunching[req.getType()] = false;
 	return Void();
 }
 
@@ -2124,15 +2155,14 @@ ACTOR Future<Void> dispatchAuditStorageServerShard(Reference<DataDistributor> se
 		    .detail("AuditType", auditType);
 
 	} catch (Error& e) {
+		if (e.code() == error_code_actor_cancelled) {
+			throw e;
+		}
 		TraceEvent(SevWarn, "DDDispatchAuditStorageServerShardError", self->ddId)
 		    .errorUnsuppressed(e)
 		    .detail("AuditID", audit->coreState.id)
 		    .detail("AuditType", auditType);
-		if (e.code() == error_code_actor_cancelled) {
-			throw e;
-		} else {
-			audit->auditStorageAnyChildFailed = true;
-		}
+		audit->auditStorageAnyChildFailed = true;
 	}
 
 	return Void();
@@ -2214,16 +2244,15 @@ ACTOR Future<Void> scheduleAuditStorageShardOnServer(Reference<DataDistributor> 
 		    .detail("IssuedDoAuditCount", issueDoAuditCount);
 
 	} catch (Error& e) {
+		if (e.code() == error_code_actor_cancelled) {
+			throw e;
+		}
 		TraceEvent(SevInfo, "DDScheduleAuditStorageShardOnServerError", self->ddId)
 		    .errorUnsuppressed(e)
 		    .detail("AuditID", audit->coreState.id)
 		    .detail("AuditType", auditType)
 		    .detail("IssuedDoAuditCount", issueDoAuditCount);
-		if (e.code() == error_code_actor_cancelled) {
-			throw e;
-		} else {
-			audit->auditStorageAnyChildFailed = true;
-		}
+		audit->auditStorageAnyChildFailed = true;
 	}
 
 	return Void();
@@ -2291,15 +2320,14 @@ ACTOR Future<Void> dispatchAuditStorage(Reference<DataDistributor> self,
 		    .detail("CompleteRatio", completedCount * 1.0 / totalCount);
 
 	} catch (Error& e) {
+		if (e.code() == error_code_actor_cancelled) {
+			throw e;
+		}
 		TraceEvent(SevWarn, "DDDispatchAuditStorageError", self->ddId)
 		    .errorUnsuppressed(e)
 		    .detail("AuditID", audit->coreState.id)
 		    .detail("AuditType", auditType);
-		if (e.code() == error_code_actor_cancelled) {
-			throw e;
-		} else {
-			audit->auditStorageAnyChildFailed = true;
-		}
+		audit->auditStorageAnyChildFailed = true;
 	}
 
 	return Void();
@@ -2440,17 +2468,16 @@ ACTOR Future<Void> scheduleAuditOnRange(Reference<DataDistributor> self,
 		    .detail("IssuedDoAuditCountInThisSchedule", issueDoAuditCount);
 
 	} catch (Error& e) {
+		if (e.code() == error_code_actor_cancelled) {
+			throw e;
+		}
 		TraceEvent(SevInfo, "DDScheduleAuditOnRangeError", self->ddId)
 		    .errorUnsuppressed(e)
 		    .detail("AuditID", audit->coreState.id)
 		    .detail("Range", range)
 		    .detail("AuditType", auditType)
 		    .detail("IssuedDoAuditCount", issueDoAuditCount);
-		if (e.code() == error_code_actor_cancelled) {
-			throw e;
-		} else {
-			audit->auditStorageAnyChildFailed = true;
-		}
+		audit->auditStorageAnyChildFailed = true;
 	}
 
 	return Void();
@@ -2494,6 +2521,9 @@ ACTOR Future<Void> doAuditOnStorageServer(Reference<DataDistributor> self,
 		ASSERT(self->remainingBudgetForAuditTasks[auditType].get() <= SERVER_KNOBS->CONCURRENT_AUDIT_TASK_COUNT_MAX);
 
 	} catch (Error& e) {
+		if (e.code() == error_code_actor_cancelled) {
+			throw e;
+		}
 		TraceEvent(SevInfo, "DDDoAuditOnStorageServerError", self->ddId)
 		    .errorUnsuppressed(e)
 		    .detail("AuditID", req.id)
@@ -2507,8 +2537,7 @@ ACTOR Future<Void> doAuditOnStorageServer(Reference<DataDistributor> self,
 		self->remainingBudgetForAuditTasks[auditType].set(self->remainingBudgetForAuditTasks[auditType].get() + 1);
 		ASSERT(self->remainingBudgetForAuditTasks[auditType].get() <= SERVER_KNOBS->CONCURRENT_AUDIT_TASK_COUNT_MAX);
 
-		if (e.code() == error_code_actor_cancelled || e.code() == error_code_not_implemented ||
-		    e.code() == error_code_audit_storage_exceeded_request_limit ||
+		if (e.code() == error_code_not_implemented || e.code() == error_code_audit_storage_exceeded_request_limit ||
 		    e.code() == error_code_audit_storage_cancelled) {
 			throw e;
 		} else if (e.code() == error_code_audit_storage_error) {
@@ -2616,12 +2645,7 @@ ACTOR Future<Void> dataDistributor(DataDistributorInterface di, Reference<AsyncV
 					actors.add(cancelAuditStorage(self, req));
 					continue;
 				}
-				if (!self->anyAuditStorageLaunching.contains(req.getType()) ||
-				    !self->anyAuditStorageLaunching[req.getType()]) {
-					actors.add(auditStorage(self, req));
-				} else { // Only one audit storage is allowed at any time
-					req.reply.sendError(audit_storage_exceeded_request_limit());
-				}
+				actors.add(auditStorage(self, req));
 			}
 			when(TenantsOverStorageQuotaRequest req = waitNext(di.tenantsOverStorageQuota.getFuture())) {
 				req.reply.send(getTenantsOverStorageQuota(self));

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -4915,6 +4915,7 @@ ACTOR Future<Void> validateRangeAgainstServer(StorageServer* data,
                                               StorageServerInterface remoteServer,
                                               UID ddId) {
 	TraceEvent(SevInfo, "ValidateRangeAgainstServerBegin", data->thisServerID)
+	    .detail("AuditType", auditState.getType())
 	    .detail("AuditID", auditState.id)
 	    .detail("Range", auditState.range)
 	    .detail("Version", version)
@@ -5058,6 +5059,8 @@ ACTOR Future<Void> validateRangeAgainstServer(StorageServer* data,
 		} catch (Error& e) {
 			TraceEvent(SevWarn, "ValidateRangeAgainstServerFailed", data->thisServerID)
 			    .errorUnsuppressed(e)
+			    .detail("AuditType", auditState.getType())
+			    .detail("AuditId", auditState.id)
 			    .detail("RemoteServer", remoteServer.toString())
 			    .detail("Range", range)
 			    .detail("Version", version);
@@ -5067,6 +5070,8 @@ ACTOR Future<Void> validateRangeAgainstServer(StorageServer* data,
 
 	if (!error.empty()) {
 		TraceEvent(SevError, "ValidateRangeAgainstServerError", data->thisServerID)
+		    .detail("AuditType", auditState.getType())
+		    .detail("AuditId", auditState.id)
 		    .detail("Range", range)
 		    .detail("Version", version)
 		    .detail("ErrorMessage", error)
@@ -5079,6 +5084,8 @@ ACTOR Future<Void> validateRangeAgainstServer(StorageServer* data,
 	}
 
 	TraceEvent(SevInfo, "ValidateRangeAgainstServerEnd", data->thisServerID)
+	    .detail("AuditType", auditState.getType())
+	    .detail("AuditId", auditState.id)
 	    .detail("Range", range)
 	    .detail("Version", version)
 	    .detail("ValidatedKeys", validatedKeys)
@@ -5733,7 +5740,11 @@ ACTOR Future<Void> auditStorageStorageServerShardQ(StorageServer* data, AuditSto
 		TraceEvent(SevVerbose, "ShardAssignmentHistoryRecordStopWhenError", data->thisServerID)
 		    .detail("AuditID", req.id);
 
-		req.reply.sendError(audit_storage_failed());
+		if (e.code() == error_code_audit_storage_cancelled) {
+			req.reply.sendError(audit_storage_cancelled());
+		} else {
+			req.reply.sendError(audit_storage_failed());
+		}
 		if (e.code() == error_code_actor_cancelled) {
 			throw e;
 		}
@@ -5968,7 +5979,11 @@ ACTOR Future<Void> auditStorageLocationMetadataQ(StorageServer* data, AuditStora
 		    .detail("AuditId", req.id)
 		    .detail("AuditRange", req.range)
 		    .detail("AuditServer", data->thisServerID);
-		req.reply.sendError(audit_storage_failed());
+		if (e.code() == error_code_audit_storage_cancelled) {
+			req.reply.sendError(audit_storage_cancelled());
+		} else {
+			req.reply.sendError(audit_storage_failed());
+		}
 		if (e.code() == error_code_actor_cancelled) {
 			throw e;
 		}
@@ -6038,10 +6053,12 @@ ACTOR Future<Void> auditStorageQ(StorageServer* data, AuditStorageRequest req) {
 		    .detail("Range", req.range)
 		    .detail("AuditType", req.type)
 		    .detail("TargetServers", describe(req.targetServers));
-		if (e.code() != error_code_audit_storage_error) {
-			req.reply.sendError(audit_storage_failed());
-		} else {
+		if (e.code() == error_code_audit_storage_cancelled) {
+			req.reply.sendError(audit_storage_cancelled());
+		} else if (e.code() == error_code_audit_storage_error) {
 			req.reply.sendError(audit_storage_error());
+		} else {
+			req.reply.sendError(audit_storage_failed());
 		}
 		if (e.code() == error_code_actor_cancelled) {
 			throw e;

--- a/fdbserver/workloads/ValidateStorage.actor.cpp
+++ b/fdbserver/workloads/ValidateStorage.actor.cpp
@@ -100,7 +100,11 @@ struct ValidateStorage : TestWorkload {
 		return auditId;
 	}
 
-	ACTOR Future<Void> waitAuditStorageUntilComplete(Database cx, AuditType type, UID auditId, std::string context) {
+	ACTOR Future<Void> waitAuditStorageUntilComplete(Database cx,
+	                                                 AuditType type,
+	                                                 UID auditId,
+	                                                 std::string context,
+	                                                 bool stopWaitWhenCleared) {
 		state AuditStorageState auditState;
 		loop {
 			try {
@@ -123,6 +127,9 @@ struct ValidateStorage : TestWorkload {
 					UNREACHABLE();
 				}
 			} catch (Error& e) {
+				if (stopWaitWhenCleared && e.code() == error_code_key_not_found) {
+					break; // this audit has been cleared
+				}
 				TraceEvent("TestAuditStorageWaitError")
 				    .errorUnsuppressed(e)
 				    .detail("Context", context)
@@ -398,11 +405,15 @@ struct ValidateStorage : TestWorkload {
 		return Void();
 	}
 
-	ACTOR Future<UID> auditStorageForType(ValidateStorage* self, Database cx, AuditType type, std::string context) {
+	ACTOR Future<UID> auditStorageForType(ValidateStorage* self,
+	                                      Database cx,
+	                                      AuditType type,
+	                                      std::string context,
+	                                      bool stopWaitWhenCleared = false) {
 		// Send audit request until the server accepts the request
 		state UID auditId = wait(self->triggerAuditStorageForType(cx, type, context));
 		// Wait until the request completes
-		wait(self->waitAuditStorageUntilComplete(cx, type, auditId, context));
+		wait(self->waitAuditStorageUntilComplete(cx, type, auditId, context, stopWaitWhenCleared));
 		// Check internal persist state
 		wait(self->checkAuditStorageInternalState(cx, type, auditId, context));
 		return auditId;
@@ -533,18 +544,22 @@ struct ValidateStorage : TestWorkload {
 		TraceEvent("TestAuditStorageConcurrentRunForSameTypeBegin");
 		state std::vector<Future<Void>> fs;
 		state std::vector<UID> auditIds = { UID(), UID(), UID(), UID() };
-		fs.push_back(
-		    store(auditIds[0],
-		          self->auditStorageForType(self, cx, AuditType::ValidateReplica, "TestConcurrentRunForSameType")));
-		fs.push_back(
-		    store(auditIds[1],
-		          self->auditStorageForType(self, cx, AuditType::ValidateReplica, "TestConcurrentRunForSameType")));
-		fs.push_back(
-		    store(auditIds[2],
-		          self->auditStorageForType(self, cx, AuditType::ValidateReplica, "TestConcurrentRunForSameType")));
-		fs.push_back(
-		    store(auditIds[3],
-		          self->auditStorageForType(self, cx, AuditType::ValidateReplica, "TestConcurrentRunForSameType")));
+		fs.push_back(store(
+		    auditIds[0],
+		    self->auditStorageForType(
+		        self, cx, AuditType::ValidateReplica, "TestConcurrentRunForSameType", /*stopWaitWhenCleared=*/true)));
+		fs.push_back(store(
+		    auditIds[1],
+		    self->auditStorageForType(
+		        self, cx, AuditType::ValidateReplica, "TestConcurrentRunForSameType", /*stopWaitWhenCleared=*/true)));
+		fs.push_back(store(
+		    auditIds[2],
+		    self->auditStorageForType(
+		        self, cx, AuditType::ValidateReplica, "TestConcurrentRunForSameType", /*stopWaitWhenCleared=*/true)));
+		fs.push_back(store(
+		    auditIds[3],
+		    self->auditStorageForType(
+		        self, cx, AuditType::ValidateReplica, "TestConcurrentRunForSameType", /*stopWaitWhenCleared=*/true)));
 		wait(waitForAll(fs));
 		TraceEvent("TestAuditStorageConcurrentRunForSameTypeEnd");
 		return Void();

--- a/fdbserver/workloads/ValidateStorage.actor.cpp
+++ b/fdbserver/workloads/ValidateStorage.actor.cpp
@@ -164,6 +164,7 @@ struct ValidateStorage : TestWorkload {
 				}
 				if (res.size() > SERVER_KNOBS->PERSIST_FINISH_AUDIT_COUNT + 1) {
 					TraceEvent("TestAuditStorageCheckPersistStateWaitClean")
+					    .detail("ExistCount", res.size())
 					    .detail("Context", context)
 					    .detail("AuditID", auditId)
 					    .detail("AuditType", type);
@@ -262,6 +263,9 @@ struct ValidateStorage : TestWorkload {
 
 		wait(self->testAuditStorageConcurrentRunForDifferentType(self, cx));
 		TraceEvent("TestAuditStorageConcurrentRunForDifferentTypeDone");
+
+		wait(self->testAuditStorageConcurrentRunForSameType(self, cx));
+		TraceEvent("TestAuditStorageConcurrentRunForSameTypeDone");
 
 		wait(self->testAuditStorageCancellation(self, cx));
 		TraceEvent("TestAuditStorageCancellationDone");

--- a/fdbserver/workloads/ValidateStorage.actor.cpp
+++ b/fdbserver/workloads/ValidateStorage.actor.cpp
@@ -74,9 +74,8 @@ struct ValidateStorage : TestWorkload {
 		return _start(this, cx);
 	}
 
-	ACTOR Future<UID> auditStorageForType(Database cx, AuditType type, std::string context) {
-		// Check client API
-		// Send audit request until the server accepts the request
+	ACTOR Future<UID> triggerAuditStorageForType(Database cx, AuditType type, std::string context) {
+		// Send audit request until the cluster accepts the request
 		state UID auditId;
 		loop {
 			try {
@@ -98,7 +97,10 @@ struct ValidateStorage : TestWorkload {
 				wait(delay(1));
 			}
 		}
-		// Wait until the request completes
+		return auditId;
+	}
+
+	ACTOR Future<Void> waitAuditStorageUntilComplete(Database cx, AuditType type, UID auditId, std::string context) {
 		state AuditStorageState auditState;
 		loop {
 			try {
@@ -130,7 +132,15 @@ struct ValidateStorage : TestWorkload {
 				wait(delay(1));
 			}
 		}
-		// Check internal persist state
+		TraceEvent("TestAuditStorageEnd")
+		    .detail("Context", context)
+		    .detail("AuditID", auditId)
+		    .detail("AuditType", type)
+		    .detail("AuditState", auditState.toString());
+		return Void();
+	}
+
+	ACTOR Future<Void> checkAuditStorageInternalState(Database cx, AuditType type, UID auditId, std::string context) {
 		// Check no audit is in Running or Error phase
 		// Check the number of existing persisted audits is no more than PERSIST_FINISH_AUDIT_COUNT
 		state Transaction tr(cx);
@@ -149,7 +159,8 @@ struct ValidateStorage : TestWorkload {
 					    .detail("AuditID", auditId)
 					    .detail("AuditType", type);
 					ASSERT(existingAuditState.getPhase() == AuditPhase::Complete ||
-					       existingAuditState.getPhase() == AuditPhase::Failed);
+					       existingAuditState.getPhase() == AuditPhase::Failed ||
+					       existingAuditState.getPhase() == AuditPhase::Running);
 				}
 				if (res.size() > SERVER_KNOBS->PERSIST_FINISH_AUDIT_COUNT + 1) {
 					TraceEvent("TestAuditStorageCheckPersistStateWaitClean")
@@ -190,26 +201,28 @@ struct ValidateStorage : TestWorkload {
 				wait(tr.onError(e));
 			}
 		}
-		TraceEvent("TestAuditStorageEnd")
-		    .detail("Context", context)
-		    .detail("AuditID", auditId)
-		    .detail("AuditType", type)
-		    .detail("AuditState", auditState.toString());
-		return auditId;
+		return Void();
 	}
 
-	ACTOR Future<Void> testAuditStorageForType(ValidateStorage* self, Database cx, AuditType type) {
-		state UID auditIdA = wait(self->auditStorageForType(cx, type, "FirstRun"));
-		state UID auditIdB = wait(self->auditStorageForType(cx, type, "SecondRun"));
-		if (auditIdA == auditIdB) {
-			TraceEvent(SevError, "TestAuditStorageAuditIdError")
-			    .detail("AuditType", type)
-			    .detail("AuditIDA", auditIdA)
-			    .detail("AuditIDB", auditIdB);
-		}
-		std::vector<AuditStorageState> res = wait(getAuditStates(cx, type, /*newFirst=*/true, 1));
-		if (res.size() != 1) {
-			TraceEvent(SevError, "TestGetAuditStatesError").detail("ActualResSize", res.size());
+	ACTOR Future<Void> waitCancelAuditStorageUntilComplete(Database cx, AuditType type, UID auditId) {
+		loop {
+			try {
+				state UID auditId_ = wait(cancelAuditStorage(cx->getConnectionRecord(),
+				                                             type,
+				                                             auditId,
+				                                             /*timeoutSecond=*/300));
+				ASSERT(auditId == auditId_);
+				TraceEvent("TestAuditStorageWaitCancelAuditStorageUntilComplete")
+				    .detail("AuditID", auditId)
+				    .detail("AuditType", type);
+				break;
+			} catch (Error& e) {
+				TraceEvent(SevWarn, "TestAuditStorageWaitCancelAuditStorageUntilCompleteError")
+				    .errorUnsuppressed(e)
+				    .detail("AuditID", auditId)
+				    .detail("AuditType", type);
+				wait(delay(1));
+			}
 		}
 		return Void();
 	}
@@ -232,28 +245,26 @@ struct ValidateStorage : TestWorkload {
 			disableConnectionFailures("AuditStorage");
 		}
 
-		wait(self->validateData(self, cx, KeyRangeRef("TestKeyA"_sr, "TestKeyF"_sr)));
-		TraceEvent("TestValidateValueVerified");
+		self->testStringToAuditPhaseFunctionality();
+		TraceEvent("TestAuditStorageStringToAuditPhaseFuncionalityDone");
 
-		wait(self->testAuditStorageForType(self, cx, AuditType::ValidateHA));
-		TraceEvent("TestValidateHADone");
+		wait(self->testSSUserDataValidation(self, cx, KeyRangeRef("TestKeyA"_sr, "TestKeyF"_sr)));
+		TraceEvent("TestAuditStorageValidateValueDone");
 
-		wait(self->testAuditStorageForType(self, cx, AuditType::ValidateReplica));
-		TraceEvent("TestValidateReplicaDone");
+		wait(self->testAuditStorageFunctionality(self, cx));
+		TraceEvent("TestAuditStorageFunctionalityDone");
 
-		wait(self->testAuditStorageForType(self, cx, AuditType::ValidateLocationMetadata));
-		TraceEvent("TestValidateShardKeyServersDone");
+		wait(self->testAuditStorageIDGenerator(self, cx));
+		TraceEvent("TestAuditStorageIDGeneratorDone");
 
-		wait(self->testAuditStorageForType(self, cx, AuditType::ValidateStorageServerShard));
-		TraceEvent("TestValidateShardSSShardInfoDone");
+		wait(self->testGetAuditStateWhenNoOngingAudit(self, cx));
+		TraceEvent("TestGetAuditStateDone");
 
-		std::vector<Future<Void>> fs;
-		fs.push_back(self->testAuditStorageForType(self, cx, AuditType::ValidateHA));
-		fs.push_back(self->testAuditStorageForType(self, cx, AuditType::ValidateReplica));
-		fs.push_back(self->testAuditStorageForType(self, cx, AuditType::ValidateLocationMetadata));
-		fs.push_back(self->testAuditStorageForType(self, cx, AuditType::ValidateStorageServerShard));
-		wait(waitForAll(fs));
-		TraceEvent("TestValidatesConcurrentRunDone");
+		wait(self->testAuditStorageConcurrentRunForDifferentType(self, cx));
+		TraceEvent("TestAuditStorageConcurrentRunForDifferentTypeDone");
+
+		wait(self->testAuditStorageCancellation(self, cx));
+		TraceEvent("TestAuditStorageCancellationDone");
 
 		return Void();
 	}
@@ -286,8 +297,43 @@ struct ValidateStorage : TestWorkload {
 		return version;
 	}
 
-	ACTOR Future<Void> validateData(ValidateStorage* self, Database cx, KeyRange range) {
-		TraceEvent("TestValidateStorageBegin").detail("Range", range);
+	void testStringToAuditPhaseFunctionality() {
+		AuditPhase phase = AuditPhase::Invalid;
+		std::string inputStr = "RUNNING";
+		phase = stringToAuditPhase(inputStr);
+		if (phase != AuditPhase::Running) {
+			TraceEvent(SevError, "TestStringToAuditPhaseError").detail("Input", inputStr);
+		}
+		inputStr = "RUnnING";
+		phase = stringToAuditPhase(inputStr);
+		if (phase != AuditPhase::Running) {
+			TraceEvent(SevError, "TestStringToAuditPhaseError").detail("Input", inputStr);
+		}
+		inputStr = "error";
+		phase = stringToAuditPhase(inputStr);
+		if (phase != AuditPhase::Error) {
+			TraceEvent(SevError, "TestStringToAuditPhaseError").detail("Input", inputStr);
+		}
+		inputStr = "error123";
+		phase = stringToAuditPhase(inputStr);
+		if (phase != AuditPhase::Invalid) {
+			TraceEvent(SevError, "TestStringToAuditPhaseError").detail("Input", inputStr);
+		}
+		inputStr = "123";
+		phase = stringToAuditPhase(inputStr);
+		if (phase != AuditPhase::Invalid) {
+			TraceEvent(SevError, "TestStringToAuditPhaseError").detail("Input", inputStr);
+		}
+		inputStr = "12Failed";
+		phase = stringToAuditPhase(inputStr);
+		if (phase != AuditPhase::Invalid) {
+			TraceEvent(SevError, "TestStringToAuditPhaseError").detail("Input", inputStr);
+		}
+		return;
+	}
+
+	ACTOR Future<Void> testSSUserDataValidation(ValidateStorage* self, Database cx, KeyRange range) {
+		TraceEvent("TestSSUserDataValidationBegin").detail("Range", range);
 		state Transaction tr(cx);
 		tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
 		tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
@@ -312,7 +358,7 @@ struct ValidateStorage : TestWorkload {
 					Optional<Value> serverListValue = wait(tr.get(serverListKeyFor(src[idx])));
 					ASSERT(serverListValue.present());
 					const StorageServerInterface ssi = decodeServerListValue(serverListValue.get());
-					TraceEvent("TestValidateStorageSendingRequest")
+					TraceEvent("TestSSUserDataValidationSendingRequest")
 					    .detail("Range", range)
 					    .detail("StorageServer", ssi.toString());
 					AuditStorageRequest req(deterministicRandom()->randomUniqueID(),
@@ -327,10 +373,12 @@ struct ValidateStorage : TestWorkload {
 				break;
 			} catch (Error& e) {
 				if (retryCount > 5) {
-					TraceEvent(SevWarnAlways, "TestValidateStorageFailed").errorUnsuppressed(e).detail("Range", range);
+					TraceEvent(SevWarnAlways, "TestSSUserDataValidationFailed")
+					    .errorUnsuppressed(e)
+					    .detail("Range", range);
 					break;
 				} else {
-					TraceEvent(SevWarn, "TestValidateStorageFailedRetry")
+					TraceEvent(SevWarn, "TestSSUserDataValidationFailedRetry")
 					    .errorUnsuppressed(e)
 					    .detail("Range", range)
 					    .detail("RetryCount", retryCount);
@@ -341,8 +389,200 @@ struct ValidateStorage : TestWorkload {
 			}
 		}
 
-		TraceEvent("TestValidateStorageDone").detail("Range", range);
+		TraceEvent("TestSSUserDataValidationDone").detail("Range", range);
 
+		return Void();
+	}
+
+	ACTOR Future<UID> auditStorageForType(ValidateStorage* self, Database cx, AuditType type, std::string context) {
+		// Send audit request until the server accepts the request
+		state UID auditId = wait(self->triggerAuditStorageForType(cx, type, context));
+		// Wait until the request completes
+		wait(self->waitAuditStorageUntilComplete(cx, type, auditId, context));
+		// Check internal persist state
+		wait(self->checkAuditStorageInternalState(cx, type, auditId, context));
+		return auditId;
+	}
+
+	ACTOR Future<Void> testAuditStorageFunctionality(ValidateStorage* self, Database cx) {
+		UID auditIdA =
+		    wait(self->auditStorageForType(self, cx, AuditType::ValidateHA, "TestAuditStorageFunctionality"));
+		TraceEvent("TestFunctionalityHADone");
+		UID auditIdB =
+		    wait(self->auditStorageForType(self, cx, AuditType::ValidateReplica, "TestAuditStorageFunctionality"));
+		TraceEvent("TestFunctionalityReplicaDone");
+		UID auditIdC = wait(
+		    self->auditStorageForType(self, cx, AuditType::ValidateLocationMetadata, "TestAuditStorageFunctionality"));
+		TraceEvent("TestFunctionalityShardLocationMetadataDone");
+		UID auditIdD = wait(self->auditStorageForType(
+		    self, cx, AuditType::ValidateStorageServerShard, "TestAuditStorageFunctionality"));
+		TraceEvent("TestFunctionalitySSShardInfoDone");
+		return Void();
+	}
+
+	ACTOR Future<Void> testAuditStorageIDGenerator(ValidateStorage* self, Database cx) {
+		state AuditType type = AuditType::ValidateReplica;
+		TraceEvent("TestAuditStorageIDGeneratorBegin").detail("AuditType", type);
+		state UID auditIdA = wait(self->auditStorageForType(self, cx, type, "FirstRunInTestIDGenerator"));
+		state UID auditIdB = wait(self->auditStorageForType(self, cx, type, "SecondRunInTestIDGenerator"));
+		if (auditIdA == auditIdB) {
+			TraceEvent(SevError, "TestAuditStorageIDGeneratorError")
+			    .detail("AuditType", type)
+			    .detail("AuditIDA", auditIdA)
+			    .detail("AuditIDB", auditIdB);
+		}
+		TraceEvent("TestAuditStorageIDGeneratorEnd").detail("AuditType", type);
+		;
+		return Void();
+	}
+
+	ACTOR Future<Void> testGetAuditStateWhenNoOngingAuditForType(ValidateStorage* self, Database cx, AuditType type) {
+		TraceEvent("TestGetAuditStateBegin").detail("AuditType", type);
+		;
+		std::vector<AuditStorageState> res1 = wait(getAuditStates(cx, type, /*newFirst=*/true, 1));
+		if (res1.size() != 1) {
+			TraceEvent(SevError, "TestGetAuditStatesError").detail("ActualResSize", res1.size());
+		}
+		std::vector<AuditStorageState> res2 =
+		    wait(getAuditStates(cx, type, /*newFirst=*/true, CLIENT_KNOBS->TOO_MANY, AuditPhase::Invalid));
+		if (res2.size() != 0) {
+			TraceEvent(SevError, "TestExistingInvalidAudit")
+			    .detail("ActualResSize", res2.size())
+			    .detail("InputPhase", AuditPhase::Invalid);
+		}
+		std::vector<AuditStorageState> res3 =
+		    wait(getAuditStates(cx, type, /*newFirst=*/true, CLIENT_KNOBS->TOO_MANY, AuditPhase::Running));
+		if (res3.size() != 0) {
+			TraceEvent(SevError, "TestExistingRunningAudit")
+			    .detail("ActualResSize", res3.size())
+			    .detail("InputPhase", AuditPhase::Running);
+		}
+		std::vector<AuditStorageState> res4 =
+		    wait(getAuditStates(cx, type, /*newFirst=*/true, CLIENT_KNOBS->TOO_MANY, AuditPhase::Complete));
+		for (const auto& auditState : res4) {
+			if (auditState.getPhase() != AuditPhase::Complete) {
+				TraceEvent(SevError, "TestGetAuditStatesByPhaseError")
+				    .detail("ActualPhase", auditState.getPhase())
+				    .detail("InputPhase", AuditPhase::Complete);
+			}
+		}
+		std::vector<AuditStorageState> res5 =
+		    wait(getAuditStates(cx, type, /*newFirst=*/true, CLIENT_KNOBS->TOO_MANY, AuditPhase::Failed));
+		for (const auto& auditState : res5) {
+			if (auditState.getPhase() != AuditPhase::Failed) {
+				TraceEvent(SevError, "TestGetAuditStatesByPhaseError")
+				    .detail("ActualPhase", auditState.getPhase())
+				    .detail("InputPhase", AuditPhase::Failed);
+			}
+		}
+		std::vector<AuditStorageState> res6 =
+		    wait(getAuditStates(cx, type, /*newFirst=*/true, CLIENT_KNOBS->TOO_MANY, AuditPhase::Error));
+		for (const auto& auditState : res6) {
+			if (auditState.getPhase() != AuditPhase::Error) {
+				TraceEvent(SevError, "TestGetAuditStatesByPhaseError")
+				    .detail("ActualPhase", auditState.getPhase())
+				    .detail("InputPhase", AuditPhase::Error);
+			}
+		}
+		TraceEvent("TestGetAuditStateEnd").detail("AuditType", type);
+		return Void();
+	}
+
+	ACTOR Future<Void> testGetAuditStateWhenNoOngingAudit(ValidateStorage* self, Database cx) {
+		wait(self->testGetAuditStateWhenNoOngingAuditForType(self, cx, AuditType::ValidateHA));
+		TraceEvent("TestGetAuditStateHADone");
+
+		wait(self->testGetAuditStateWhenNoOngingAuditForType(self, cx, AuditType::ValidateReplica));
+		TraceEvent("TestGetAuditStateReplicaDone");
+
+		wait(self->testGetAuditStateWhenNoOngingAuditForType(self, cx, AuditType::ValidateLocationMetadata));
+		TraceEvent("TestGetAuditStateShardLocationMetadataDone");
+
+		wait(self->testGetAuditStateWhenNoOngingAuditForType(self, cx, AuditType::ValidateStorageServerShard));
+		TraceEvent("TestGetAuditStateSSShardInfoDone");
+		return Void();
+	}
+
+	ACTOR Future<Void> testAuditStorageConcurrentRunForDifferentType(ValidateStorage* self, Database cx) {
+		TraceEvent("TestAuditStorageConcurrentRunForDifferentTypeBegin");
+		state std::vector<Future<Void>> fs;
+		state std::vector<UID> auditIds = { UID(), UID(), UID(), UID() };
+		fs.push_back(
+		    store(auditIds[0],
+		          self->auditStorageForType(self, cx, AuditType::ValidateHA, "TestConcurrentRunForDifferentType")));
+		fs.push_back(store(
+		    auditIds[1],
+		    self->auditStorageForType(self, cx, AuditType::ValidateReplica, "TestConcurrentRunForDifferentType")));
+		fs.push_back(store(auditIds[2],
+		                   self->auditStorageForType(
+		                       self, cx, AuditType::ValidateLocationMetadata, "TestConcurrentRunForDifferentType")));
+		fs.push_back(store(auditIds[3],
+		                   self->auditStorageForType(
+		                       self, cx, AuditType::ValidateStorageServerShard, "TestConcurrentRunForDifferentType")));
+		wait(waitForAll(fs));
+		fs.clear();
+		TraceEvent("TestAuditStorageConcurrentRunForDifferentTypeEnd");
+		return Void();
+	}
+
+	ACTOR Future<Void> testAuditStorageConcurrentRunForSameType(ValidateStorage* self, Database cx) {
+		TraceEvent("TestAuditStorageConcurrentRunForSameTypeBegin");
+		state std::vector<Future<Void>> fs;
+		state std::vector<UID> auditIds = { UID(), UID(), UID(), UID() };
+		fs.push_back(
+		    store(auditIds[0],
+		          self->auditStorageForType(self, cx, AuditType::ValidateReplica, "TestConcurrentRunForSameType")));
+		fs.push_back(
+		    store(auditIds[1],
+		          self->auditStorageForType(self, cx, AuditType::ValidateReplica, "TestConcurrentRunForSameType")));
+		fs.push_back(
+		    store(auditIds[2],
+		          self->auditStorageForType(self, cx, AuditType::ValidateReplica, "TestConcurrentRunForSameType")));
+		fs.push_back(
+		    store(auditIds[3],
+		          self->auditStorageForType(self, cx, AuditType::ValidateReplica, "TestConcurrentRunForSameType")));
+		wait(waitForAll(fs));
+		TraceEvent("TestAuditStorageConcurrentRunForSameTypeEnd");
+		return Void();
+	}
+
+	ACTOR Future<Void> testAuditStorageCancellation(ValidateStorage* self, Database cx) {
+		TraceEvent("TestAuditStorageCancellationBegin");
+		state UID auditId = wait(self->triggerAuditStorageForType(cx, AuditType::ValidateHA, "TestAuditCancellation"));
+		state std::vector<Future<Void>> fs;
+		fs.push_back(self->waitCancelAuditStorageUntilComplete(cx, AuditType::ValidateHA, auditId));
+		fs.push_back(self->waitCancelAuditStorageUntilComplete(cx, AuditType::ValidateHA, auditId));
+		fs.push_back(self->waitCancelAuditStorageUntilComplete(cx, AuditType::ValidateReplica, auditId));
+		fs.push_back(self->checkAuditStorageInternalState(cx, AuditType::ValidateHA, auditId, "TestAuditCancellation"));
+		fs.push_back(
+		    self->checkAuditStorageInternalState(cx, AuditType::ValidateReplica, auditId, "TestAuditCancellation"));
+		wait(waitForAll(fs));
+		fs.clear();
+		fs.push_back(self->checkAuditStorageInternalState(cx, AuditType::ValidateHA, auditId, "TestAuditCancellation"));
+		fs.push_back(
+		    self->checkAuditStorageInternalState(cx, AuditType::ValidateReplica, auditId, "TestAuditCancellation"));
+		wait(waitForAll(fs));
+		state std::vector<AuditStorageState> currentAuditStates1 =
+		    wait(getAuditStates(cx, AuditType::ValidateHA, /*newFirst=*/true, CLIENT_KNOBS->TOO_MANY));
+		for (const auto& auditState : currentAuditStates1) {
+			if (auditState.id == auditId && auditState.getPhase() != AuditPhase::Failed) {
+				TraceEvent(SevError, "TestAuditStorageCancellation1Error")
+				    .detail("AuditType", auditState.getType())
+				    .detail("AuditID", auditId)
+				    .detail("AuditPhase", auditState.getPhase());
+			}
+		}
+		state std::vector<AuditStorageState> currentAuditStates2 =
+		    wait(getAuditStates(cx, AuditType::ValidateReplica, /*newFirst=*/true, CLIENT_KNOBS->TOO_MANY));
+		for (const auto& auditState : currentAuditStates2) {
+			if (auditState.id == auditId && auditState.getPhase() != AuditPhase::Failed) {
+				TraceEvent(SevError, "TestAuditStorageCancellation2Error")
+				    .detail("AuditType", auditState.getType())
+				    .detail("AuditID", auditId)
+				    .detail("AuditPhase", auditState.getPhase());
+			}
+		}
+		TraceEvent("TestAuditStorageCancellationEnd");
 		return Void();
 	}
 

--- a/flow/include/flow/error_definitions.h
+++ b/flow/include/flow/error_definitions.h
@@ -145,6 +145,8 @@ ERROR( master_failed, 1227, "Cluster recovery terminating because master has fai
 ERROR( test_failed, 1228, "Test failed" )
 ERROR( retry_clean_up_datamove_tombstone_added, 1229, "Need background datamove cleanup" )
 ERROR( persist_new_audit_metadata_error, 1230, "Persist new audit metadata error" )
+ERROR( cancel_audit_storage_failed, 1231, "Failed to cancel an audit" )
+ERROR( audit_storage_cancelled, 1232, "Audit has been cancelled" )
 
 // 15xx Platform errors
 ERROR( platform_error, 1500, "Platform error" )


### PR DESCRIPTION
100K correctness test with 2 irrelevant failures:
  20230609-013805-zhewang-46607244d14a05cd           compressed=True data_size=33350015 duration=5726197 ended=100000 fail=2 fail_fast=10 max_runs=100000 pass=99998 priority=100 remaining=0 runtime=1:16:54 sanity=False started=100000 stopped=20230609-025459 submitted=20230609-013805 timeout=5400 username=zhewang

100K ValidateStorage test:
  20230609-013851-zhewang-a25d10e6250f5119           compressed=True data_size=33380737 duration=7934388 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:21:12 sanity=False started=100000 stopped=20230609-030003 submitted=20230609-013851 timeout=5400 username=zhewang

tested by test_frm.run

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
