### PR TITLE
Check if var is None before comparing with int

### DIFF
--- a/contrib/TestHarness2/test_harness/run.py
+++ b/contrib/TestHarness2/test_harness/run.py
@@ -599,7 +599,11 @@ class TestRunner:
             result = result and run.success
             test_picker.add_time(test_files[0], run.run_time, run.summary.out)
             decorate_summary(run.summary.out, file, seed + count, run.buggify_enabled)
-            if unseed_check and run.summary.unseed >= 0:
+            if (
+                unseed_check
+                and run.summary.unseed is not None
+                and run.summary.unseed >= 0
+            ):
                 run.summary.out.append(run.summary.list_simfdb())
             run.summary.out.dump(sys.stdout)
             if not result:


### PR DESCRIPTION
We should check a variable is not None before comparing with integer in python.

100k ensemble: 20230607-173503-yajin-a01d9450252da05e

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
