### PR TITLE
Add getlocation and getall fdbcli debug commands

### DIFF
--- a/fdbcli/DebugCommands.actor.cpp
+++ b/fdbcli/DebugCommands.actor.cpp
@@ -22,6 +22,8 @@
 
 #include "fdbclient/NativeAPI.actor.h"
 
+#include "flow/actorcompiler.h" // This must be the last #include.
+
 namespace fdb_cli {
 
 // The command is used to get all storage server addresses for a given key.

--- a/fdbcli/DebugCommands.actor.cpp
+++ b/fdbcli/DebugCommands.actor.cpp
@@ -1,0 +1,93 @@
+/*
+ * DebugCommands.actor.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2023 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "fdbcli/fdbcli.actor.h"
+
+#include "fdbclient/NativeAPI.actor.h"
+
+namespace fdb_cli {
+
+// The command is used to get all storage server addresses for a given key.
+ACTOR Future<bool> getLocationCommandActor(Database cx, std::vector<StringRef> tokens, Version version) {
+	if (tokens.size() != 2) {
+		printf("getlocation <KEY>\n"
+		       "fetch the storage server address for a given key.\n"
+		       "Displays the addresses of storage servers, or `not found' if location is not found.");
+		return false;
+	}
+
+	KeyRangeLocationInfo loc = wait(getKeyLocation_internal(
+	    cx, {}, tokens[1], SpanID(), Optional<UID>(), UseProvisionalProxies::False, Reverse::False, version));
+
+	if (loc.locations) {
+		printf("version is %ld\n", version);
+		printf("`%s' is at:\n", printable(tokens[1]).c_str());
+		auto locations = loc.locations->locations();
+		for (int i = 0; locations && i < locations->size(); i++) {
+			printf("  %s\n", locations->getInterface(i).address().toString().c_str());
+		}
+	} else {
+		printf("`%s': location not found\n", printable(tokens[1]).c_str());
+	}
+	return true;
+}
+// hidden commands, no help text for now
+CommandFactory getLocationCommandFactory("getlocation");
+
+// The command is used to get values from all storage servers that have the given key.
+ACTOR Future<bool> getallCommandActor(Database cx, std::vector<StringRef> tokens, Version version) {
+	if (tokens.size() != 2) {
+		printf("getall <KEY>\n"
+		       "fetch values from all storage servers that have the given key.\n"
+		       "Displays the value and the addresses of storage servers, or `not found' if key is not found.");
+		return false;
+	}
+
+	KeyRangeLocationInfo loc = wait(getKeyLocation_internal(
+	    cx, {}, tokens[1], SpanID(), Optional<UID>(), UseProvisionalProxies::False, Reverse::False, version));
+
+	if (loc.locations) {
+		printf("version is %ld\n", version);
+		printf("`%s' is at:\n", printable(tokens[1]).c_str());
+		state Reference<LocationInfo::Locations> locations = loc.locations->locations();
+		state std::vector<Future<GetValueReply>> replies;
+		for (int i = 0; locations && i < locations->size(); i++) {
+			GetValueRequest req({}, {}, tokens[1], version, {}, {}, {});
+			replies.push_back(locations->get(i, &StorageServerInterface::getValue).getReply(req));
+		}
+		wait(waitForAll(replies));
+		for (int i = 0; i < replies.size(); i++) {
+			std::string ssi = locations->getInterface(i).address().toString();
+			if (replies[i].isError()) {
+				fprintf(stderr, "ERROR: %s %s\n", ssi.c_str(), replies[i].getError().what());
+			} else {
+				Optional<Value> v = replies[i].get().value;
+				printf(" %s %s\n", ssi.c_str(), v.present() ? printable(v.get()).c_str() : "(not found)");
+			}
+		}
+	} else {
+		printf("`%s': location not found\n", printable(tokens[1]).c_str());
+	}
+	return true;
+}
+// hidden commands, no help text for now
+CommandFactory getallCommandFactory("getall");
+
+} // namespace fdb_cli

--- a/fdbcli/DebugCommands.actor.cpp
+++ b/fdbcli/DebugCommands.actor.cpp
@@ -34,7 +34,7 @@ ACTOR Future<bool> getLocationCommandActor(Database cx, std::vector<StringRef> t
 	}
 
 	KeyRangeLocationInfo loc = wait(getKeyLocation_internal(
-	    cx, {}, tokens[1], SpanID(), Optional<UID>(), UseProvisionalProxies::False, Reverse::False, version));
+	    cx, {}, tokens[1], SpanContext(), Optional<UID>(), UseProvisionalProxies::False, Reverse::False, version));
 
 	if (loc.locations) {
 		printf("version is %ld\n", version);
@@ -61,7 +61,7 @@ ACTOR Future<bool> getallCommandActor(Database cx, std::vector<StringRef> tokens
 	}
 
 	KeyRangeLocationInfo loc = wait(getKeyLocation_internal(
-	    cx, {}, tokens[1], SpanID(), Optional<UID>(), UseProvisionalProxies::False, Reverse::False, version));
+	    cx, {}, tokens[1], SpanContext(), Optional<UID>(), UseProvisionalProxies::False, Reverse::False, version));
 
 	if (loc.locations) {
 		printf("version is %ld\n", version);

--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -1194,7 +1194,6 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise, Reference<ClusterCo
 	}
 
 	state bool is_error = false;
-
 	state Future<Void> warn;
 	loop {
 		if (warn.isValid())
@@ -1615,6 +1614,24 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise, Reference<ClusterCo
 						else
 							printf("`%s': not found\n", printable(tokens[1]).c_str());
 					}
+					continue;
+				}
+
+				if (tokencmp(tokens[0], "getlocation")) {
+					Version _v = wait(makeInterruptable(
+					    safeThreadFutureToFuture(getTransaction(db, tenant, tr, options, intrans)->getReadVersion())));
+					bool _result = wait(makeInterruptable(getLocationCommandActor(localDb, tokens, _v)));
+					if (!_result)
+						is_error = true;
+					continue;
+				}
+
+				if (tokencmp(tokens[0], "getall")) {
+					Version _v = wait(makeInterruptable(
+					    safeThreadFutureToFuture(getTransaction(db, tenant, tr, options, intrans)->getReadVersion())));
+					bool _result = wait(makeInterruptable(getallCommandActor(localDb, tokens, _v)));
+					if (!_result)
+						is_error = true;
 					continue;
 				}
 

--- a/fdbcli/include/fdbcli/fdbcli.actor.h
+++ b/fdbcli/include/fdbcli/fdbcli.actor.h
@@ -291,6 +291,10 @@ ACTOR Future<bool> idempotencyIdsCommandActor(Database cx, std::vector<StringRef
 // rangeconfig command
 ACTOR Future<bool> rangeConfigCommandActor(Database cx, std::vector<StringRef> tokens);
 
+// debug commands: getlocation, getall
+ACTOR Future<bool> getLocationCommandActor(Database cx, std::vector<StringRef> tokens, Version version);
+ACTOR Future<bool> getallCommandActor(Database cx, std::vector<StringRef> tokens, Version version);
+
 } // namespace fdb_cli
 
 #include "flow/unactorcompiler.h"

--- a/fdbclient/include/fdbclient/NativeAPI.actor.h
+++ b/fdbclient/include/fdbclient/NativeAPI.actor.h
@@ -19,8 +19,6 @@
  */
 
 #pragma once
-#include "flow/IRandom.h"
-#include "fdbclient/Tracing.h"
 #if defined(NO_INTELLISENSE) && !defined(FDBCLIENT_NATIVEAPI_ACTOR_G_H)
 #define FDBCLIENT_NATIVEAPI_ACTOR_G_H
 #include "fdbclient/NativeAPI.actor.g.h"
@@ -31,6 +29,7 @@
 #include "flow/flow.h"
 #include "flow/WipedString.h"
 #include "flow/TDMetric.actor.h"
+#include "flow/IRandom.h"
 #include "fdbclient/FDBTypes.h"
 #include "fdbclient/CommitProxyInterface.h"
 #include "fdbclient/ClientBooleanParams.h"
@@ -39,6 +38,7 @@
 #include "fdbclient/ClusterInterface.h"
 #include "fdbclient/ClientLogEvents.h"
 #include "fdbclient/KeyRangeMap.h"
+#include "fdbclient/Tracing.h"
 #include "flow/actorcompiler.h" // has to be last include
 
 // CLIENT_BUGGIFY should be used to randomly introduce failures at run time (like BUGGIFY but for client side testing)
@@ -683,5 +683,15 @@ namespace NativeAPI {
 ACTOR Future<std::vector<std::pair<StorageServerInterface, ProcessClass>>> getServerListAndProcessClasses(
     Transaction* tr);
 }
+
+ACTOR Future<KeyRangeLocationInfo> getKeyLocation_internal(Database cx,
+                                                           Optional<TenantName> tenant,
+                                                           Key key,
+                                                           SpanID spanID,
+                                                           Optional<UID> debugID,
+                                                           UseProvisionalProxies useProvisionalProxies,
+                                                           Reverse isBackward,
+                                                           Version version);
+
 #include "flow/unactorcompiler.h"
 #endif

--- a/fdbclient/include/fdbclient/NativeAPI.actor.h
+++ b/fdbclient/include/fdbclient/NativeAPI.actor.h
@@ -683,11 +683,10 @@ namespace NativeAPI {
 ACTOR Future<std::vector<std::pair<StorageServerInterface, ProcessClass>>> getServerListAndProcessClasses(
     Transaction* tr);
 }
-
 ACTOR Future<KeyRangeLocationInfo> getKeyLocation_internal(Database cx,
-                                                           Optional<TenantName> tenant,
+                                                           TenantInfo tenant,
                                                            Key key,
-                                                           SpanID spanID,
+                                                           SpanContext spanContext,
                                                            Optional<UID> debugID,
                                                            UseProvisionalProxies useProvisionalProxies,
                                                            Reverse isBackward,

--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -36,6 +36,7 @@
 #include "fdbclient/SystemData.h"
 #include "fdbclient/Tenant.h"
 #include "fdbclient/TenantManagement.actor.h"
+#include "fdbclient/Tracing.h"
 #include "fdbclient/TransactionLineage.h"
 #include "fdbrpc/TenantInfo.h"
 #include "fdbrpc/sim_validation.h"
@@ -64,10 +65,9 @@
 #include "flow/IRandom.h"
 #include "flow/Knobs.h"
 #include "flow/Trace.h"
-#include "fdbclient/Tracing.h"
+#include "flow/network.h"
 
 #include "flow/actorcompiler.h" // This must be the last #include.
-#include "flow/network.h"
 
 using WriteMutationRefVar = std::variant<MutationRef, VectorRef<MutationRef>>;
 


### PR DESCRIPTION
Can be useful for debugging. Manually tested in a loopback cluster.

getlocation: returns the SS list for a key
getall: returns both the SS list and values on the SS for a key


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
