### PR TITLE
Add an option to limit the number of shard per team

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -331,6 +331,8 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( CP_FETCH_TENANTS_OVER_STORAGE_QUOTA_INTERVAL,            5 ); if( randomize && BUGGIFY ) CP_FETCH_TENANTS_OVER_STORAGE_QUOTA_INTERVAL = deterministicRandom()->randomInt(1, 10);
 	init( DD_BUILD_EXTRA_TEAMS_OVERRIDE,                          10 ); if( randomize && BUGGIFY ) DD_BUILD_EXTRA_TEAMS_OVERRIDE = 2;
 	init( DD_SHARD_TRACKING_LOG_SEVERITY,                           1);
+	init( ENFORCE_SHARD_COUNT_PER_TEAM,                        false ); if( randomize && BUGGIFY ) ENFORCE_SHARD_COUNT_PER_TEAM = true;
+	init( DESIRED_MAX_SHARDS_PER_TEAM,                          1000 ); if( randomize && BUGGIFY ) DESIRED_MAX_SHARDS_PER_TEAM = 10;
 
 	// Large teams are disabled when SHARD_ENCODE_LOCATION_METADATA is enabled
 	init( DD_MAX_SHARDS_ON_LARGE_TEAMS,                          100 ); if( randomize && BUGGIFY ) DD_MAX_SHARDS_ON_LARGE_TEAMS = deterministicRandom()->randomInt(0, 3);

--- a/fdbclient/include/fdbclient/ServerKnobs.h
+++ b/fdbclient/include/fdbclient/ServerKnobs.h
@@ -323,6 +323,9 @@ public:
 	double DD_ZERO_HEALTHY_TEAM_DELAY;
 	int DD_BUILD_EXTRA_TEAMS_OVERRIDE; // build extra teams to allow data movement to progress. must be larger than 0
 	int DD_SHARD_TRACKING_LOG_SEVERITY;
+	bool ENFORCE_SHARD_COUNT_PER_TEAM;
+	int DESIRED_MAX_SHARDS_PER_TEAM;
+
 	int DD_MAX_SHARDS_ON_LARGE_TEAMS; // the maximum number of shards that can be assigned to large teams
 	int DD_MAXIMUM_LARGE_TEAM_CLEANUP; // the maximum number of large teams data distribution will attempt to cleanup
 	                                   // without yielding

--- a/fdbclient/include/fdbclient/ServerKnobs.h
+++ b/fdbclient/include/fdbclient/ServerKnobs.h
@@ -323,8 +323,10 @@ public:
 	double DD_ZERO_HEALTHY_TEAM_DELAY;
 	int DD_BUILD_EXTRA_TEAMS_OVERRIDE; // build extra teams to allow data movement to progress. must be larger than 0
 	int DD_SHARD_TRACKING_LOG_SEVERITY;
-	bool ENFORCE_SHARD_COUNT_PER_TEAM;
-	int DESIRED_MAX_SHARDS_PER_TEAM;
+	bool ENFORCE_SHARD_COUNT_PER_TEAM; // Whether data movement selects dst team not exceeding
+	                                   // DESIRED_MAX_SHARDS_PER_TEAM.
+	int DESIRED_MAX_SHARDS_PER_TEAM; // When ENFORCE_SHARD_COUNT_PER_TEAM is true, this is the desired, but not strictly
+	                                 // enforced, max shard count per team.
 
 	int DD_MAX_SHARDS_ON_LARGE_TEAMS; // the maximum number of shards that can be assigned to large teams
 	int DD_MAXIMUM_LARGE_TEAM_CLEANUP; // the maximum number of large teams data distribution will attempt to cleanup

--- a/fdbserver/DDRelocationQueue.actor.cpp
+++ b/fdbserver/DDRelocationQueue.actor.cpp
@@ -1425,7 +1425,7 @@ ACTOR Future<Void> dataDistributionRelocator(DDQueue* self,
 						                          PreferLowerDiskUtil::True,
 						                          TeamMustHaveShards::False,
 						                          PreferLowerReadUtil::True,
-						                          PreferWithinShardLimit::False,
+						                          PreferWithinShardLimit::True,
 						                          ForReadBalance(rd.reason == RelocateReason::REBALANCE_READ),
 						                          inflightPenalty,
 						                          rd.keys);

--- a/fdbserver/DDRelocationQueue.actor.cpp
+++ b/fdbserver/DDRelocationQueue.actor.cpp
@@ -1425,6 +1425,7 @@ ACTOR Future<Void> dataDistributionRelocator(DDQueue* self,
 						                          PreferLowerDiskUtil::True,
 						                          TeamMustHaveShards::False,
 						                          PreferLowerReadUtil::True,
+						                          PreferWithinShardLimit::False,
 						                          ForReadBalance(rd.reason == RelocateReason::REBALANCE_READ),
 						                          inflightPenalty,
 						                          rd.keys);
@@ -2266,11 +2267,13 @@ ACTOR Future<Void> BgDDLoadRebalance(DDQueue* self, int teamCollectionIndex, Dat
 				                                       PreferLowerDiskUtil::False,
 				                                       TeamMustHaveShards::True,
 				                                       PreferLowerReadUtil::False,
+				                                       PreferWithinShardLimit::False,
 				                                       ForReadBalance(readRebalance));
 				GetTeamRequest destReq = GetTeamRequest(!mcMove ? TeamSelect::WANT_TRUE_BEST : TeamSelect::ANY,
 				                                        PreferLowerDiskUtil::True,
 				                                        TeamMustHaveShards::False,
 				                                        PreferLowerReadUtil::True,
+				                                        PreferWithinShardLimit::False,
 				                                        ForReadBalance(readRebalance));
 				state Future<SrcDestTeamPair> getTeamFuture =
 				    self->getSrcDestTeams(teamCollectionIndex, srcReq, destReq, ddPriority, &traceEvent);

--- a/fdbserver/DDTeamCollection.actor.cpp
+++ b/fdbserver/DDTeamCollection.actor.cpp
@@ -191,6 +191,89 @@ public:
 		req.reply.send(std::make_pair(res, false));
 	}
 
+	static Optional<Reference<IDataDistributionTeam>> getBestTeam(DDTeamCollection* self,
+	                                                              const GetTeamRequest& req,
+	                                                              bool preferWithinShardLimit) {
+		auto& startIndex = req.preferLowerDiskUtil ? self->lowestUtilizationTeam : self->highestUtilizationTeam;
+		if (startIndex >= self->teams.size()) {
+			startIndex = 0;
+		}
+		Optional<Reference<IDataDistributionTeam>> bestOption;
+		int64_t bestLoadBytes = 0;
+		bool wigglingBestOption = false; // best option contains server in paused wiggle state
+		int bestIndex = startIndex;
+		for (int i = 0; i < self->teams.size(); i++) {
+			int currentIndex = (startIndex + i) % self->teams.size();
+			if (self->teams[currentIndex]->isHealthy()) {
+				int eligibilityType = data_distribution::EligibilityCounter::fromGetTeamRequest(req);
+				if (eligibilityType != data_distribution::EligibilityCounter::NONE &&
+				    self->teams[currentIndex]->getEligibilityCount(eligibilityType) <= 0) {
+					continue;
+				}
+
+				int64_t loadBytes = self->teams[currentIndex]->getLoadBytes(true, req.inflightPenalty);
+				auto team = ShardsAffectedByTeamFailure::Team(self->teams[currentIndex]->getServerIDs(), self->primary);
+				if ((!req.teamMustHaveShards || self->shardsAffectedByTeamFailure->hasShards(team)) &&
+				    // sort conditions
+				    (!bestOption.present() ||
+				     req.lessCompare(bestOption.get(), self->teams[currentIndex], bestLoadBytes, loadBytes))) {
+
+					// bestOption doesn't contain wiggling SS while current team does. Don't replace bestOption
+					// in this case
+					if (bestOption.present() && !wigglingBestOption &&
+					    self->teams[currentIndex]->hasWigglePausedServer()) {
+						continue;
+					}
+
+					if (SERVER_KNOBS->ENFORCE_SHARD_COUNT_PER_TEAM && preferWithinShardLimit &&
+					    self->shardsAffectedByTeamFailure->getNumberOfShards(team) >
+					        SERVER_KNOBS->DESIRED_MAX_SHARDS_PER_TEAM) {
+						continue;
+					}
+
+					bestLoadBytes = loadBytes;
+					bestOption = self->teams[currentIndex];
+					bestIndex = currentIndex;
+					wigglingBestOption = self->teams[bestIndex]->hasWigglePausedServer();
+				}
+			}
+		}
+		startIndex = bestIndex;
+		return bestOption;
+	}
+
+	static Optional<Reference<IDataDistributionTeam>> getBestTeamFromCandidates(
+	    DDTeamCollection* self,
+	    const GetTeamRequest& req,
+	    const std::vector<Reference<TCTeamInfo>>& candidates,
+	    bool preferWithinShardLimit) {
+		Optional<Reference<IDataDistributionTeam>> bestOption;
+		int64_t bestLoadBytes = 0;
+		bool wigglingBestOption = false; // best option contains server in paused wiggle state
+		for (int i = 0; i < candidates.size(); i++) {
+			int64_t loadBytes = candidates[i]->getLoadBytes(true, req.inflightPenalty);
+			if (!bestOption.present() || req.lessCompare(bestOption.get(), candidates[i], bestLoadBytes, loadBytes)) {
+
+				// bestOption doesn't contain wiggling SS while current team does. Don't replace bestOption
+				// in this case
+				if (bestOption.present() && !wigglingBestOption && candidates[i]->hasWigglePausedServer()) {
+					continue;
+				}
+
+				if (SERVER_KNOBS->ENFORCE_SHARD_COUNT_PER_TEAM && preferWithinShardLimit &&
+				    self->shardsAffectedByTeamFailure->getNumberOfShards(ShardsAffectedByTeamFailure::Team(
+				        candidates[i]->getServerIDs(), self->primary)) > SERVER_KNOBS->DESIRED_MAX_SHARDS_PER_TEAM) {
+					continue;
+				}
+
+				bestLoadBytes = loadBytes;
+				bestOption = candidates[i];
+				wigglingBestOption = candidates[i]->hasWigglePausedServer();
+			}
+		}
+		return bestOption;
+	}
+
 	// SOMEDAY: Make bestTeam better about deciding to leave a shard where it is (e.g. in PRIORITY_TEAM_HEALTHY case)
 	//		    use keys, src, dest, metrics, priority, system load, etc.. to decide...
 	ACTOR static Future<Void> getTeam(DDTeamCollection* self, GetTeamRequest req) {
@@ -235,10 +318,7 @@ public:
 				return Void();
 			}
 
-			int64_t bestLoadBytes = 0;
-			bool wigglingBestOption = false; // best option contains server in paused wiggle state
 			Optional<Reference<IDataDistributionTeam>> bestOption;
-			std::vector<Reference<TCTeamInfo>> randomTeams;
 
 			if (ddLargeTeamEnabled() && req.keys.present()) {
 				int customReplicas = self->configuration.storageTeamSize;
@@ -297,45 +377,18 @@ public:
 
 			if (req.teamSelect == TeamSelect::WANT_TRUE_BEST) {
 				ASSERT(!bestOption.present());
-				auto& startIndex = req.preferLowerDiskUtil ? self->lowestUtilizationTeam : self->highestUtilizationTeam;
-				if (startIndex >= self->teams.size()) {
-					startIndex = 0;
-				}
-
-				int bestIndex = startIndex;
-				for (int i = 0; i < self->teams.size(); i++) {
-					int currentIndex = (startIndex + i) % self->teams.size();
-					if (self->teams[currentIndex]->isHealthy()) {
-						int eligibilityType = data_distribution::EligibilityCounter::fromGetTeamRequest(req);
-						if (eligibilityType != data_distribution::EligibilityCounter::NONE &&
-						    self->teams[currentIndex]->getEligibilityCount(eligibilityType) <= 0) {
-							continue;
-						}
-
-						int64_t loadBytes = self->teams[currentIndex]->getLoadBytes(true, req.inflightPenalty);
-						if ((!req.teamMustHaveShards ||
-						     self->shardsAffectedByTeamFailure->hasShards(ShardsAffectedByTeamFailure::Team(
-						         self->teams[currentIndex]->getServerIDs(), self->primary))) &&
-						    // sort conditions
-						    (!bestOption.present() ||
-						     req.lessCompare(bestOption.get(), self->teams[currentIndex], bestLoadBytes, loadBytes))) {
-
-							// bestOption doesn't contain wiggling SS while current team does. Don't replace bestOption
-							// in this case
-							if (bestOption.present() && !wigglingBestOption &&
-							    self->teams[currentIndex]->hasWigglePausedServer()) {
-								continue;
-							}
-							bestLoadBytes = loadBytes;
-							bestOption = self->teams[currentIndex];
-							bestIndex = currentIndex;
-							wigglingBestOption = self->teams[bestIndex]->hasWigglePausedServer();
-						}
+				if (SERVER_KNOBS->ENFORCE_SHARD_COUNT_PER_TEAM && req.preferWithinShardLimit) {
+					bestOption = getBestTeam(self, req, /*preferWithinShardLimit=*/true);
+					if (!bestOption.present()) {
+						TraceEvent("GetBestTeamPreferWithinShardLimitFailed").log();
 					}
 				}
-
-				startIndex = bestIndex;
+				if (!bestOption.present()) {
+					bestOption = getBestTeam(self, req, /*preferWithinShardLimit=*/false);
+				}
 			} else {
+				ASSERT(!bestOption.present());
+				std::vector<Reference<TCTeamInfo>> randomTeams;
 				int nTries = 0;
 				while (randomTeams.size() < SERVER_KNOBS->BEST_TEAM_OPTION_COUNT &&
 				       nTries < SERVER_KNOBS->BEST_TEAM_MAX_TEAM_TRIES) {
@@ -351,6 +404,7 @@ public:
 
 					for (int i = 0; ok && i < randomTeams.size(); i++) {
 						if (randomTeams[i]->getServerIDs() == dest->getServerIDs()) {
+							// Found a duplicate team. Skip `dest`.
 							ok = false;
 							break;
 						}
@@ -373,20 +427,17 @@ public:
 					self->bestTeamKeepStuckCount = 0;
 				}
 
-				for (int i = 0; i < randomTeams.size(); i++) {
-					int64_t loadBytes = randomTeams[i]->getLoadBytes(true, req.inflightPenalty);
-					if (!bestOption.present() ||
-					    req.lessCompare(bestOption.get(), randomTeams[i], bestLoadBytes, loadBytes)) {
-
-						// bestOption doesn't contain wiggling SS while current team does. Don't replace bestOption
-						// in this case
-						if (bestOption.present() && !wigglingBestOption && randomTeams[i]->hasWigglePausedServer()) {
-							continue;
+				if (!randomTeams.empty()) {
+					if (SERVER_KNOBS->ENFORCE_SHARD_COUNT_PER_TEAM && req.preferWithinShardLimit) {
+						bestOption = getBestTeamFromCandidates(self, req, randomTeams, /*preferWithinShardLimit=*/true);
+						if (!bestOption.present()) {
+							TraceEvent("GetBestTeamFromCandidatesPreferWithinShardLimitFailed").log();
 						}
+					}
 
-						bestLoadBytes = loadBytes;
-						bestOption = randomTeams[i];
-						wigglingBestOption = randomTeams[i]->hasWigglePausedServer();
+					if (!bestOption.present()) {
+						bestOption =
+						    getBestTeamFromCandidates(self, req, randomTeams, /*preferWithinShardLimit=*/false);
 					}
 				}
 			}
@@ -5881,7 +5932,8 @@ public:
 		state GetTeamRequest req(TeamSelect::WANT_COMPLETE_SRCS,
 		                         PreferLowerDiskUtil::True,
 		                         TeamMustHaveShards::False,
-		                         PreferLowerReadUtil::False);
+		                         PreferLowerReadUtil::False,
+		                         PreferWithinShardLimit::False);
 		req.completeSources = completeSources;
 
 		wait(collection->getTeam(req));
@@ -5935,7 +5987,8 @@ public:
 		state GetTeamRequest req(TeamSelect::WANT_COMPLETE_SRCS,
 		                         PreferLowerDiskUtil::True,
 		                         TeamMustHaveShards::False,
-		                         PreferLowerReadUtil::False);
+		                         PreferLowerReadUtil::False,
+		                         PreferWithinShardLimit::False);
 		req.completeSources = completeSources;
 
 		wait(collection->getTeam(req));
@@ -5987,7 +6040,8 @@ public:
 		state GetTeamRequest req(TeamSelect::WANT_TRUE_BEST,
 		                         PreferLowerDiskUtil::True,
 		                         TeamMustHaveShards::False,
-		                         PreferLowerReadUtil::False);
+		                         PreferLowerReadUtil::False,
+		                         PreferWithinShardLimit::False);
 		req.completeSources = completeSources;
 
 		wait(collection->getTeam(req));
@@ -6038,7 +6092,8 @@ public:
 		state GetTeamRequest req(TeamSelect::WANT_TRUE_BEST,
 		                         PreferLowerDiskUtil::False,
 		                         TeamMustHaveShards::False,
-		                         PreferLowerReadUtil::False);
+		                         PreferLowerReadUtil::False,
+		                         PreferWithinShardLimit::False);
 		req.completeSources = completeSources;
 
 		wait(collection->getTeam(req));
@@ -6091,7 +6146,8 @@ public:
 		state GetTeamRequest req(TeamSelect::WANT_TRUE_BEST,
 		                         PreferLowerDiskUtil::True,
 		                         TeamMustHaveShards::False,
-		                         PreferLowerReadUtil::False);
+		                         PreferLowerReadUtil::False,
+		                         PreferWithinShardLimit::False);
 		req.completeSources = completeSources;
 
 		wait(collection->getTeam(req));
@@ -6149,7 +6205,8 @@ public:
 		state GetTeamRequest req(TeamSelect::WANT_TRUE_BEST,
 		                         PreferLowerDiskUtil::True,
 		                         TeamMustHaveShards::False,
-		                         PreferLowerReadUtil::False);
+		                         PreferLowerReadUtil::False,
+		                         PreferWithinShardLimit::False);
 		req.completeSources = completeSources;
 
 		wait(collection->getTeam(req));
@@ -6196,6 +6253,7 @@ public:
 		                         preferLowerDiskUtil,
 		                         teamMustHaveShards,
 		                         PreferLowerReadUtil::True,
+		                         PreferWithinShardLimit::False,
 		                         forReadBalance);
 		req.completeSources = completeSources;
 
@@ -6203,6 +6261,7 @@ public:
 		                             PreferLowerDiskUtil::False,
 		                             teamMustHaveShards,
 		                             PreferLowerReadUtil::False,
+		                             PreferWithinShardLimit::False,
 		                             forReadBalance);
 
 		wait(collection->getTeam(req) && collection->getTeam(reqHigh));
@@ -6267,7 +6326,8 @@ public:
 		state GetTeamRequest req(TeamSelect::WANT_TRUE_BEST,
 		                         PreferLowerDiskUtil::True,
 		                         TeamMustHaveShards::False,
-		                         PreferLowerReadUtil::False);
+		                         PreferLowerReadUtil::False,
+		                         PreferWithinShardLimit::False);
 		req.completeSources = completeSources;
 
 		wait(collection->getTeam(req));
@@ -6293,11 +6353,13 @@ public:
 		                             PreferLowerDiskUtil::True,
 		                             TeamMustHaveShards::False,
 		                             PreferLowerReadUtil::True,
+		                             PreferWithinShardLimit::False,
 		                             ForReadBalance::True);
 		state GetTeamRequest randomReq(TeamSelect::ANY,
 		                               PreferLowerDiskUtil::True,
 		                               TeamMustHaveShards::False,
 		                               PreferLowerReadUtil::True,
+		                               PreferWithinShardLimit::False,
 		                               ForReadBalance::True);
 		collection->teamPivots.lastPivotValuesUpdate = -100;
 

--- a/fdbserver/DDTeamCollection.actor.cpp
+++ b/fdbserver/DDTeamCollection.actor.cpp
@@ -5652,9 +5652,11 @@ Future<Void> DDTeamCollection::printSnapshotTeamsInfo(Reference<DDTeamCollection
 
 class DDTeamCollectionUnitTest {
 public:
-	static std::unique_ptr<DDTeamCollection> testTeamCollection(int teamSize,
-	                                                            Reference<IReplicationPolicy> policy,
-	                                                            int processCount) {
+	static std::unique_ptr<DDTeamCollection> testTeamCollection(
+	    int teamSize,
+	    Reference<IReplicationPolicy> policy,
+	    int processCount,
+	    Reference<ShardsAffectedByTeamFailure> shardsAffectedByTeamFailure) {
 		Database database = DatabaseContext::create(
 		    makeReference<AsyncVar<ClientDBInfo>>(), Never(), LocalityData(), EnableLocalityLoadBalance::False);
 		auto txnProcessor = Reference<IDDTxnProcessor>(new DDTxnProcessor(database));
@@ -5667,7 +5669,7 @@ public:
 		                                                     UID(0, 0),
 		                                                     MoveKeysLock(),
 		                                                     PromiseStream<RelocateShard>(),
-		                                                     makeReference<ShardsAffectedByTeamFailure>(),
+		                                                     shardsAffectedByTeamFailure,
 		                                                     conf,
 		                                                     {},
 		                                                     {},
@@ -5695,6 +5697,14 @@ public:
 		}
 
 		return collection;
+	}
+
+	static std::unique_ptr<DDTeamCollection> testTeamCollection(int teamSize,
+	                                                            Reference<IReplicationPolicy> policy,
+	                                                            int processCount) {
+		Reference<ShardsAffectedByTeamFailure> shardsAffectedByTeamFailure =
+		    makeReference<ShardsAffectedByTeamFailure>();
+		return testTeamCollection(teamSize, policy, processCount, shardsAffectedByTeamFailure);
 	}
 
 	static std::unique_ptr<DDTeamCollection> testMachineTeamCollection(int teamSize,
@@ -6432,6 +6442,51 @@ public:
 		}
 		return Void();
 	}
+
+	ACTOR static Future<Void> GetTeam_PreferShardsWithinLimit() {
+		ASSERT(SERVER_KNOBS->ENFORCE_SHARD_COUNT_PER_TEAM);
+		Reference<IReplicationPolicy> policy = makeReference<PolicyAcross>(3, "zoneid", makeReference<PolicyOne>());
+		state int processSize = 5;
+		state int teamSize = 3;
+		Reference<ShardsAffectedByTeamFailure> shardsAffectedByTeamFailure =
+		    makeReference<ShardsAffectedByTeamFailure>();
+		state std::unique_ptr<DDTeamCollection> collection =
+		    testTeamCollection(teamSize, policy, processSize, shardsAffectedByTeamFailure);
+
+		collection->addTeam(std::set<UID>({ UID(1, 0), UID(2, 0), UID(3, 0) }), IsInitialTeam::True);
+		collection->addTeam(std::set<UID>({ UID(2, 0), UID(3, 0), UID(4, 0) }), IsInitialTeam::True);
+		collection->disableBuildingTeams();
+		collection->setCheckTeamDelay();
+
+		std::vector<Key> randomKeys;
+		for (int i = 0; i < SERVER_KNOBS->DESIRED_MAX_SHARDS_PER_TEAM + 2; ++i) {
+			Key randomKey = Key(deterministicRandom()->randomAlphaNumeric(deterministicRandom()->randomInt(1, 1500)));
+		}
+		std::sort(randomKeys.begin(), randomKeys.end());
+		ShardsAffectedByTeamFailure::Team highShardTeam({ UID(1, 0), UID(2, 0), UID(3, 0) }, true);
+		for (int i = 0; i < randomKeys.size() - 1; ++i) {
+			shardsAffectedByTeamFailure->assignRangeToTeams(KeyRangeRef(randomKeys[i], randomKeys[i + 1]),
+			                                                { highShardTeam });
+		}
+
+		state GetTeamRequest req(deterministicRandom()->coinflip() ? TeamSelect::WANT_TRUE_BEST : TeamSelect::ANY,
+		                         PreferLowerDiskUtil::False,
+		                         TeamMustHaveShards::False,
+		                         PreferLowerReadUtil::False,
+		                         PreferWithinShardLimit::True);
+
+		wait(collection->getTeam(req));
+
+		const auto [resTeam, srcFound] = req.reply.getFuture().get();
+
+		std::set<UID> expectedServers{ UID(2, 0), UID(3, 0), UID(4, 0) };
+		ASSERT(resTeam.present());
+		auto servers = resTeam.get()->getServerIDs();
+		const std::set<UID> selectedServers(servers.begin(), servers.end());
+		ASSERT(expectedServers == selectedServers);
+
+		return Void();
+	}
 };
 
 TEST_CASE("DataDistribution/AddTeamsBestOf/UseMachineID") {
@@ -6581,5 +6636,13 @@ TEST_CASE("/DataDistribution/StorageWiggler/NextIdWithTSS") {
 
 TEST_CASE("/DataDistribution/GetTeam/CutOffByCpu") {
 	wait(DDTeamCollectionUnitTest::GetTeam_CutOffByCpu());
+	return Void();
+}
+
+TEST_CASE("/DataDistribution/GetTeam/PreferWithinShardRange") {
+	if (!SERVER_KNOBS->ENFORCE_SHARD_COUNT_PER_TEAM) {
+		return Void();
+	}
+	wait(DDTeamCollectionUnitTest::GetTeam_PreferShardsWithinLimit());
 	return Void();
 }

--- a/fdbserver/DDTeamCollection.actor.cpp
+++ b/fdbserver/DDTeamCollection.actor.cpp
@@ -6466,11 +6466,13 @@ public:
 
 		// Assign more than SERVER_KNOBS->DESIRED_MAX_SHARDS_PER_TEAM shards to the first team.
 		std::vector<Key> randomKeys;
-		for (int i = 0; i < SERVER_KNOBS->DESIRED_MAX_SHARDS_PER_TEAM + 2; ++i) {
+		for (int i = 0; i < SERVER_KNOBS->DESIRED_MAX_SHARDS_PER_TEAM + 10; ++i) {
 			Key randomKey = Key(deterministicRandom()->randomAlphaNumeric(deterministicRandom()->randomInt(1, 1500)));
+			randomKeys.push_back(randomKey);
 		}
 		std::sort(randomKeys.begin(), randomKeys.end());
 		ShardsAffectedByTeamFailure::Team highShardTeam({ UID(1, 0), UID(2, 0), UID(3, 0) }, true);
+		ASSERT(!randomKeys.empty());
 		for (int i = 0; i < randomKeys.size() - 1; ++i) {
 			shardsAffectedByTeamFailure->assignRangeToTeams(KeyRangeRef(randomKeys[i], randomKeys[i + 1]),
 			                                                { highShardTeam });

--- a/fdbserver/include/fdbserver/DataDistributionTeam.h
+++ b/fdbserver/include/fdbserver/DataDistributionTeam.h
@@ -102,6 +102,7 @@ FDB_BOOLEAN_PARAM(TeamMustHaveShards);
 FDB_BOOLEAN_PARAM(ForReadBalance);
 FDB_BOOLEAN_PARAM(PreferLowerReadUtil);
 FDB_BOOLEAN_PARAM(FindTeamByServers);
+FDB_BOOLEAN_PARAM(PreferWithinShardLimit);
 
 class TeamSelect {
 public:
@@ -138,6 +139,7 @@ struct GetTeamRequest {
 	bool teamMustHaveShards;
 	bool forReadBalance;
 	bool preferLowerReadUtil; // only make sense when forReadBalance is true
+	bool preferWithinShardLimit;
 	double inflightPenalty;
 	bool findTeamByServers;
 	Optional<KeyRange> keys;
@@ -159,17 +161,19 @@ struct GetTeamRequest {
 	               PreferLowerDiskUtil preferLowerDiskUtil,
 	               TeamMustHaveShards teamMustHaveShards,
 	               PreferLowerReadUtil preferLowerReadUtil,
+	               PreferWithinShardLimit preferWithinShardLimit,
 	               ForReadBalance forReadBalance = ForReadBalance::False,
 	               double inflightPenalty = 1.0,
 	               Optional<KeyRange> keys = Optional<KeyRange>())
 	  : teamSelect(teamSelectRequest), preferLowerDiskUtil(preferLowerDiskUtil), teamMustHaveShards(teamMustHaveShards),
-	    forReadBalance(forReadBalance), preferLowerReadUtil(preferLowerReadUtil), inflightPenalty(inflightPenalty),
+	    forReadBalance(forReadBalance), preferLowerReadUtil(preferLowerReadUtil),
+	    preferWithinShardLimit(preferWithinShardLimit), inflightPenalty(inflightPenalty),
 	    findTeamByServers(FindTeamByServers::False), keys(keys) {}
 	GetTeamRequest(std::vector<UID> servers)
 	  : teamSelect(TeamSelect::WANT_COMPLETE_SRCS), preferLowerDiskUtil(PreferLowerDiskUtil::False),
 	    teamMustHaveShards(TeamMustHaveShards::False), forReadBalance(ForReadBalance::False),
-	    preferLowerReadUtil(PreferLowerReadUtil::False), inflightPenalty(1.0),
-	    findTeamByServers(FindTeamByServers::True), src(std::move(servers)) {}
+	    preferLowerReadUtil(PreferLowerReadUtil::False), preferWithinShardLimit(PreferWithinShardLimit::False),
+	    inflightPenalty(1.0), findTeamByServers(FindTeamByServers::True), src(std::move(servers)) {}
 
 	// return true if a.score < b.score
 	[[nodiscard]] bool lessCompare(TeamRef a, TeamRef b, int64_t aLoadBytes, int64_t bLoadBytes) const {
@@ -184,6 +188,7 @@ struct GetTeamRequest {
 		std::stringstream ss;
 
 		ss << "TeamSelect:" << teamSelect.toString() << " PreferLowerDiskUtil:" << preferLowerDiskUtil
+		   << " PreferLowerReadUtil:" << preferLowerReadUtil << " PreferWithinShardLimit:" << preferWithinShardLimit
 		   << " teamMustHaveShards:" << teamMustHaveShards << " forReadBalance:" << forReadBalance
 		   << " inflightPenalty:" << inflightPenalty << " findTeamByServers:" << findTeamByServers << ";";
 		ss << "CompleteSources:";


### PR DESCRIPTION
In sharded Rocks, we don't want the number of shards to exceed certain value, which would make the number of on disk files too many. Therefore, in this PR, we added an option to select data move destination team that does not exceed `DESIRED_MAX_SHARDS_PER_TEAM`.

Ultimately, we want to control the number of shards per storage server. However, since we already have `DESIRED/MAX_TEAMS_PER_SERVER`. Adding a per team limit makes it easier to control.

Note that `DESIRED_MAX_SHARDS_PER_TEAM` is not a hard limit, and if no such team exists, `getTeam` will return the current best option ignoring `DESIRED_MAX_SHARDS_PER_TEAM`.

Later we will add a background balancer to rebalance shard counts to make it within the limit.

Added a unit test to test PreferWithinShardLimit logic.

20230608-051939-zhewu_shard_limit-969d52746780ddba

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
