### PR TITLE
Fix audit storage actor cancel issue

### DIFF
--- a/fdbclient/AuditUtils.actor.cpp
+++ b/fdbclient/AuditUtils.actor.cpp
@@ -133,6 +133,7 @@ ACTOR Future<Void> cancelAuditMetadata(Database cx, AuditType auditType, UID aud
 					break; // Nothing to cancel
 				}
 				state AuditStorageState toCancelState = decodeAuditStorageState(res_.get());
+				// For a zombie audit, it is in running state
 				ASSERT(toCancelState.id == auditId && toCancelState.getType() == auditType);
 				toCancelState.setPhase(AuditPhase::Failed);
 				tr.set(auditKey(toCancelState.getType(), toCancelState.id), auditStorageStateValue(toCancelState));
@@ -278,6 +279,7 @@ ACTOR Future<Void> clearAuditMetadataForType(Database cx,
 						clearAuditProgressMetadata(&tr, auditType, auditState.id);
 						numFinishAuditCleaned++;
 					}
+					// For a zombie audit, it is in running state
 				}
 				wait(tr.commit());
 				TraceEvent(SevDebug, "AuditUtilClearAuditMetadataForTypeEnd")

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -337,7 +337,10 @@ public:
 
 	std::unordered_map<AuditType, std::unordered_map<UID, std::shared_ptr<DDAudit>>> audits;
 	Promise<Void> auditInitialized;
-	std::unordered_map<AuditType, bool> anyAuditStorageLaunching;
+	FlowLock auditStorageHaLaunchingLock;
+	FlowLock auditStorageReplicaLaunchingLock;
+	FlowLock auditStorageLocationMetadataLaunchingLock;
+	FlowLock auditStorageSsShardLaunchingLock;
 	std::unordered_map<AuditType, AsyncVar<int>> remainingBudgetForAuditTasks;
 
 	Optional<Reference<TenantCache>> ddTenantCache;
@@ -348,7 +351,8 @@ public:
 	    movingDataEventHolder(makeReference<EventCacheHolder>("MovingData")),
 	    totalDataInFlightEventHolder(makeReference<EventCacheHolder>("TotalDataInFlight")),
 	    totalDataInFlightRemoteEventHolder(makeReference<EventCacheHolder>("TotalDataInFlightRemote")),
-	    teamCollection(nullptr) {}
+	    teamCollection(nullptr), auditStorageHaLaunchingLock(1), auditStorageReplicaLaunchingLock(1),
+	    auditStorageLocationMetadataLaunchingLock(1), auditStorageSsShardLaunchingLock(1) {}
 
 	// bootstrap steps
 
@@ -805,7 +809,7 @@ ACTOR Future<Void> resumeStorageAudits(Reference<DataDistributor> self) {
 				throw e;
 			}
 			if (retryCount > 50) {
-				TraceEvent(SevWarnAlways, "ResumeAuditStorageUnableUpdateMetadata", self->ddId).errorUnsuppressed(e);
+				TraceEvent(SevWarnAlways, "AuditStorageResumeUnableUpdateMetadata", self->ddId).errorUnsuppressed(e);
 				return Void();
 			}
 			retryCount++;
@@ -1843,6 +1847,9 @@ ACTOR Future<Void> auditStorageCore(Reference<DataDistributor> self,
 		    .detail("RetryCount", currentRetryCount)
 		    .detail("IsReady", self->auditInitialized.getFuture().isReady());
 	} catch (Error& e) {
+		if (e.code() == error_code_actor_cancelled) {
+			throw e;
+		}
 		TraceEvent(SevDebug, "DDAuditStorageCoreError", self->ddId)
 		    .errorUnsuppressed(e)
 		    .detail("Context", context)
@@ -1851,7 +1858,7 @@ ACTOR Future<Void> auditStorageCore(Reference<DataDistributor> self,
 		    .detail("AuditType", auditType)
 		    .detail("Range", audit->coreState.range)
 		    .detail("IsReady", self->auditInitialized.getFuture().isReady());
-		if (e.code() == error_code_actor_cancelled || e.code() == error_code_movekeys_conflict) {
+		if (e.code() == error_code_movekeys_conflict) {
 			throw e; // throw to DD and DD will restart
 		} else if (e.code() == error_code_audit_storage_cancelled) {
 			// do nothing, silently quit
@@ -2023,7 +2030,7 @@ ACTOR Future<UID> launchAudit(Reference<DataDistributor> self, KeyRange auditRan
 				    .detail("AuditID", auditID_)
 				    .detail("AuditType", auditType)
 				    .detail("Range", auditRange);
-				throw operation_cancelled(); // Trigger DD restart and check if resume audit is correct
+				throw operation_failed(); // Trigger DD restart and check if resume audit is correct
 			}
 			TraceEvent(SevInfo, "DDAuditStorageLaunchPersistNewAuditID", self->ddId)
 			    .detail("AuditID", auditID_)
@@ -2034,6 +2041,9 @@ ACTOR Future<UID> launchAudit(Reference<DataDistributor> self, KeyRange auditRan
 			runAuditStorage(self, auditState, 0, "LaunchAudit");
 		}
 	} catch (Error& e) {
+		if (e.code() == error_code_actor_cancelled) {
+			throw e;
+		}
 		TraceEvent(SevInfo, "DDAuditStorageLaunchError", self->ddId)
 		    .errorUnsuppressed(e)
 		    .detail("AuditType", auditType)
@@ -2044,9 +2054,20 @@ ACTOR Future<UID> launchAudit(Reference<DataDistributor> self, KeyRange auditRan
 }
 
 ACTOR Future<Void> cancelAuditStorage(Reference<DataDistributor> self, TriggerAuditRequest req) {
-	if (req.getType() != AuditType::ValidateHA && req.getType() != AuditType::ValidateReplica &&
-	    req.getType() != AuditType::ValidateLocationMetadata &&
-	    req.getType() != AuditType::ValidateStorageServerShard) {
+	state FlowLock::Releaser holder;
+	if (req.getType() == AuditType::ValidateHA) {
+		wait(self->auditStorageHaLaunchingLock.take(TaskPriority::DefaultYield));
+		holder = FlowLock::Releaser(self->auditStorageHaLaunchingLock);
+	} else if (req.getType() == AuditType::ValidateReplica) {
+		wait(self->auditStorageReplicaLaunchingLock.take(TaskPriority::DefaultYield));
+		holder = FlowLock::Releaser(self->auditStorageReplicaLaunchingLock);
+	} else if (req.getType() == AuditType::ValidateLocationMetadata) {
+		wait(self->auditStorageLocationMetadataLaunchingLock.take(TaskPriority::DefaultYield));
+		holder = FlowLock::Releaser(self->auditStorageLocationMetadataLaunchingLock);
+	} else if (req.getType() == AuditType::ValidateStorageServerShard) {
+		wait(self->auditStorageSsShardLaunchingLock.take(TaskPriority::DefaultYield));
+		holder = FlowLock::Releaser(self->auditStorageSsShardLaunchingLock);
+	} else {
 		req.reply.sendError(not_implemented());
 		return Void();
 	}
@@ -2068,14 +2089,14 @@ ACTOR Future<Void> cancelAuditStorage(Reference<DataDistributor> self, TriggerAu
 		    .detail("AuditID", req.id);
 		req.reply.send(req.id);
 	} catch (Error& e) {
+		if (e.code() == error_code_actor_cancelled) {
+			throw e;
+		}
 		TraceEvent(SevWarn, "DDCancelAuditStorageError", self->ddId)
 		    .errorUnsuppressed(e)
 		    .detail("AuditID", req.id)
 		    .detail("AuditType", req.getType());
 		req.reply.sendError(cancel_audit_storage_failed());
-		if (e.code() == error_code_actor_cancelled) {
-			throw e;
-		}
 	}
 	return Void();
 }
@@ -2090,14 +2111,24 @@ ACTOR Future<Void> cancelAuditStorage(Reference<DataDistributor> self, TriggerAu
 // For 1 and 2, we believe no new audit is persisted; For 3, we do not know whether a new
 // audit is persisted, but DD will restart and the new audit will be resume if created.
 ACTOR Future<Void> auditStorage(Reference<DataDistributor> self, TriggerAuditRequest req) {
-	if (req.getType() != AuditType::ValidateHA && req.getType() != AuditType::ValidateReplica &&
-	    req.getType() != AuditType::ValidateLocationMetadata &&
-	    req.getType() != AuditType::ValidateStorageServerShard) {
+	state FlowLock::Releaser holder;
+	if (req.getType() == AuditType::ValidateHA) {
+		wait(self->auditStorageHaLaunchingLock.take(TaskPriority::DefaultYield));
+		holder = FlowLock::Releaser(self->auditStorageHaLaunchingLock);
+	} else if (req.getType() == AuditType::ValidateReplica) {
+		wait(self->auditStorageReplicaLaunchingLock.take(TaskPriority::DefaultYield));
+		holder = FlowLock::Releaser(self->auditStorageReplicaLaunchingLock);
+	} else if (req.getType() == AuditType::ValidateLocationMetadata) {
+		wait(self->auditStorageLocationMetadataLaunchingLock.take(TaskPriority::DefaultYield));
+		holder = FlowLock::Releaser(self->auditStorageLocationMetadataLaunchingLock);
+	} else if (req.getType() == AuditType::ValidateStorageServerShard) {
+		wait(self->auditStorageSsShardLaunchingLock.take(TaskPriority::DefaultYield));
+		holder = FlowLock::Releaser(self->auditStorageSsShardLaunchingLock);
+	} else {
 		req.reply.sendError(not_implemented());
 		return Void();
 	}
-	ASSERT(!self->anyAuditStorageLaunching.contains(req.getType()) || !self->anyAuditStorageLaunching[req.getType()]);
-	self->anyAuditStorageLaunching[req.getType()] = true;
+
 	state int retryCount = 0;
 	loop {
 		try {
@@ -2114,15 +2145,16 @@ ACTOR Future<Void> auditStorage(Reference<DataDistributor> self, TriggerAuditReq
 			    .detail("Range", req.range)
 			    .detail("AuditID", auditID);
 		} catch (Error& e) {
+			if (e.code() == error_code_actor_cancelled) {
+				throw e;
+			}
 			TraceEvent(SevInfo, "DDAuditStorageError", self->ddId)
 			    .errorUnsuppressed(e)
 			    .detail("RetryCount", retryCount)
 			    .detail("AuditType", req.getType())
 			    .detail("Range", req.range);
-			if (e.code() == error_code_actor_cancelled) {
-				req.reply.sendError(audit_storage_failed());
-				self->anyAuditStorageLaunching[req.getType()] = false;
-				throw audit_storage_failed();
+			if (e.code() == error_code_operation_failed && g_network->isSimulated()) {
+				throw audit_storage_failed(); // to trigger dd restart
 			} else if (e.code() == error_code_audit_storage_exceeded_request_limit) {
 				req.reply.sendError(audit_storage_exceeded_request_limit());
 			} else if (e.code() == error_code_persist_new_audit_metadata_error) {
@@ -2137,7 +2169,6 @@ ACTOR Future<Void> auditStorage(Reference<DataDistributor> self, TriggerAuditReq
 		}
 		break;
 	}
-	self->anyAuditStorageLaunching[req.getType()] = false;
 	return Void();
 }
 
@@ -2195,15 +2226,14 @@ ACTOR Future<Void> dispatchAuditStorageServerShard(Reference<DataDistributor> se
 		    .detail("AuditType", auditType);
 
 	} catch (Error& e) {
+		if (e.code() == error_code_actor_cancelled) {
+			throw e;
+		}
 		TraceEvent(SevWarn, "DDDispatchAuditStorageServerShardError", self->ddId)
 		    .errorUnsuppressed(e)
 		    .detail("AuditID", audit->coreState.id)
 		    .detail("AuditType", auditType);
-		if (e.code() == error_code_actor_cancelled) {
-			throw e;
-		} else {
-			audit->auditStorageAnyChildFailed = true;
-		}
+		audit->auditStorageAnyChildFailed = true;
 	}
 
 	return Void();
@@ -2285,16 +2315,15 @@ ACTOR Future<Void> scheduleAuditStorageShardOnServer(Reference<DataDistributor> 
 		    .detail("IssuedDoAuditCount", issueDoAuditCount);
 
 	} catch (Error& e) {
+		if (e.code() == error_code_actor_cancelled) {
+			throw e;
+		}
 		TraceEvent(SevInfo, "DDScheduleAuditStorageShardOnServerError", self->ddId)
 		    .errorUnsuppressed(e)
 		    .detail("AuditID", audit->coreState.id)
 		    .detail("AuditType", auditType)
 		    .detail("IssuedDoAuditCount", issueDoAuditCount);
-		if (e.code() == error_code_actor_cancelled) {
-			throw e;
-		} else {
-			audit->auditStorageAnyChildFailed = true;
-		}
+		audit->auditStorageAnyChildFailed = true;
 	}
 
 	return Void();
@@ -2362,15 +2391,14 @@ ACTOR Future<Void> dispatchAuditStorage(Reference<DataDistributor> self,
 		    .detail("CompleteRatio", completedCount * 1.0 / totalCount);
 
 	} catch (Error& e) {
+		if (e.code() == error_code_actor_cancelled) {
+			throw e;
+		}
 		TraceEvent(SevWarn, "DDDispatchAuditStorageError", self->ddId)
 		    .errorUnsuppressed(e)
 		    .detail("AuditID", audit->coreState.id)
 		    .detail("AuditType", auditType);
-		if (e.code() == error_code_actor_cancelled) {
-			throw e;
-		} else {
-			audit->auditStorageAnyChildFailed = true;
-		}
+		audit->auditStorageAnyChildFailed = true;
 	}
 
 	return Void();
@@ -2511,17 +2539,16 @@ ACTOR Future<Void> scheduleAuditOnRange(Reference<DataDistributor> self,
 		    .detail("IssuedDoAuditCountInThisSchedule", issueDoAuditCount);
 
 	} catch (Error& e) {
+		if (e.code() == error_code_actor_cancelled) {
+			throw e;
+		}
 		TraceEvent(SevInfo, "DDScheduleAuditOnRangeError", self->ddId)
 		    .errorUnsuppressed(e)
 		    .detail("AuditID", audit->coreState.id)
 		    .detail("Range", range)
 		    .detail("AuditType", auditType)
 		    .detail("IssuedDoAuditCount", issueDoAuditCount);
-		if (e.code() == error_code_actor_cancelled) {
-			throw e;
-		} else {
-			audit->auditStorageAnyChildFailed = true;
-		}
+		audit->auditStorageAnyChildFailed = true;
 	}
 
 	return Void();
@@ -2565,6 +2592,9 @@ ACTOR Future<Void> doAuditOnStorageServer(Reference<DataDistributor> self,
 		ASSERT(self->remainingBudgetForAuditTasks[auditType].get() <= SERVER_KNOBS->CONCURRENT_AUDIT_TASK_COUNT_MAX);
 
 	} catch (Error& e) {
+		if (e.code() == error_code_actor_cancelled) {
+			throw e;
+		}
 		TraceEvent(SevInfo, "DDDoAuditOnStorageServerError", self->ddId)
 		    .errorUnsuppressed(e)
 		    .detail("AuditID", req.id)
@@ -2578,8 +2608,7 @@ ACTOR Future<Void> doAuditOnStorageServer(Reference<DataDistributor> self,
 		self->remainingBudgetForAuditTasks[auditType].set(self->remainingBudgetForAuditTasks[auditType].get() + 1);
 		ASSERT(self->remainingBudgetForAuditTasks[auditType].get() <= SERVER_KNOBS->CONCURRENT_AUDIT_TASK_COUNT_MAX);
 
-		if (e.code() == error_code_actor_cancelled || e.code() == error_code_not_implemented ||
-		    e.code() == error_code_audit_storage_exceeded_request_limit ||
+		if (e.code() == error_code_not_implemented || e.code() == error_code_audit_storage_exceeded_request_limit ||
 		    e.code() == error_code_audit_storage_cancelled) {
 			throw e;
 		} else if (e.code() == error_code_audit_storage_error) {
@@ -2687,12 +2716,7 @@ ACTOR Future<Void> dataDistributor(DataDistributorInterface di, Reference<AsyncV
 					actors.add(cancelAuditStorage(self, req));
 					continue;
 				}
-				if (!self->anyAuditStorageLaunching.contains(req.getType()) ||
-				    !self->anyAuditStorageLaunching[req.getType()]) {
-					actors.add(auditStorage(self, req));
-				} else { // Only one audit storage is allowed at any time
-					req.reply.sendError(audit_storage_exceeded_request_limit());
-				}
+				actors.add(auditStorage(self, req));
 			}
 			when(TenantsOverStorageQuotaRequest req = waitNext(di.tenantsOverStorageQuota.getFuture())) {
 				req.reply.send(getTenantsOverStorageQuota(self));

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -5781,8 +5781,7 @@ ACTOR Future<Void> auditStorageStorageServerShardQ(StorageServer* data, AuditSto
 		}
 	} catch (Error& e) {
 		if (e.code() == error_code_actor_cancelled) {
-			req.reply.sendError(audit_storage_failed());
-			throw e;
+			return Void(); // sliently exit
 		}
 		TraceEvent(SevInfo, "AuditStorageSsShardFailed", data->thisServerID)
 		    .errorUnsuppressed(e)
@@ -6027,8 +6026,7 @@ ACTOR Future<Void> auditStorageLocationMetadataQ(StorageServer* data, AuditStora
 
 	} catch (Error& e) {
 		if (e.code() == error_code_actor_cancelled) {
-			req.reply.sendError(audit_storage_failed());
-			throw e;
+			return Void(); // sliently exit
 		}
 		TraceEvent(SevInfo, "AuditStorageShardLocMetadataFailed", data->thisServerID)
 		    .errorUnsuppressed(e)
@@ -6101,8 +6099,7 @@ ACTOR Future<Void> auditStorageQ(StorageServer* data, AuditStorageRequest req) {
 		req.reply.send(res);
 	} catch (Error& e) {
 		if (e.code() == error_code_actor_cancelled) {
-			req.reply.sendError(audit_storage_failed());
-			throw e;
+			return Void(); // sliently exit
 		}
 		TraceEvent(SevInfo, "SSAuditStorageError", data->thisServerID)
 		    .errorUnsuppressed(e)
@@ -13650,7 +13647,7 @@ ACTOR Future<Void> storageServerCore(StorageServer* self, StorageServerInterface
 						TraceEvent(SevWarn, "ExistSSAuditForServerShardWithSameId")
 						    .detail("AuditId", req.id)
 						    .detail("AuditType", req.getType());
-						// Make sure the history collection is not open due to this old audit
+						// Make sure the history collection is not open for the old audit
 						self->stopTrackShardAssignment();
 						self->auditTasks[req.getType()].second.clear(true);
 					}

--- a/fdbserver/workloads/ValidateStorage.actor.cpp
+++ b/fdbserver/workloads/ValidateStorage.actor.cpp
@@ -164,6 +164,7 @@ struct ValidateStorage : TestWorkload {
 				}
 				if (res.size() > SERVER_KNOBS->PERSIST_FINISH_AUDIT_COUNT + 1) {
 					TraceEvent("TestAuditStorageCheckPersistStateWaitClean")
+					    .detail("ExistCount", res.size())
 					    .detail("Context", context)
 					    .detail("AuditID", auditId)
 					    .detail("AuditType", type);

--- a/fdbserver/workloads/ValidateStorage.actor.cpp
+++ b/fdbserver/workloads/ValidateStorage.actor.cpp
@@ -264,6 +264,9 @@ struct ValidateStorage : TestWorkload {
 		wait(self->testAuditStorageConcurrentRunForDifferentType(self, cx));
 		TraceEvent("TestAuditStorageConcurrentRunForDifferentTypeDone");
 
+		wait(self->testAuditStorageConcurrentRunForSameType(self, cx));
+		TraceEvent("TestAuditStorageConcurrentRunForSameTypeDone");
+
 		wait(self->testAuditStorageCancellation(self, cx));
 		TraceEvent("TestAuditStorageCancellationDone");
 


### PR DESCRIPTION
Follow up https://github.com/apple/foundationdb/pull/10430

100K correctness with 5 irrelevant failures:
  20230608-055159-zhewang-8dbb00516f90e982           compressed=True data_size=34178803 duration=6016445 ended=100000 fail=5 fail_fast=10 max_runs=100000 pass=99995 priority=100 remaining=0 runtime=1:07:33 sanity=False started=100000 stopped=20230608-065932 submitted=20230608-055159 timeout=5400 username=zhewang

100K ValidateStorage with 2 irrelevant failures:
  20230608-055305-zhewang-3c5cc9a579dc30a6           compressed=True data_size=34208377 duration=8755966 ended=100000 fail=2 fail_fast=10 max_runs=100000 pass=99998 priority=100 remaining=0 runtime=1:08:30 sanity=False started=100000 stopped=20230608-070135 submitted=20230608-055305 timeout=5400 username=zhewang

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
