### PR TITLE
BlobGranuleRestore - skip muations applying if restore target version (Cherry-Pick #10442 to snowflake/release-71.3)

### DIFF
--- a/fdbclient/FileBackupAgent.actor.cpp
+++ b/fdbclient/FileBackupAgent.actor.cpp
@@ -4861,7 +4861,17 @@ struct StartFullRestoreTaskFunc : RestoreTaskFuncBase {
 				if (phase != BlobRestorePhase::APPLYING_MLOGS) {
 					wait(delay(CLIENT_KNOBS->BLOB_GRANULE_RESTORE_CHECK_INTERVAL));
 				} else {
-					TraceEvent("BlobGranuleRestoreResume").log();
+					Version version = wait(BlobGranuleRestoreConfig().beginVersion().getOrThrow(tr));
+					beginVersion = version;
+					restore.beginVersion().set(tr, beginVersion);
+					TraceEvent("BlobGranuleRestoreResume").detail("BeginVersion", beginVersion);
+					wait(tr->commit());
+					if (restoreVersion <= beginVersion) {
+						TraceEvent("BlobGranuleRestoreDone")
+						    .detail("BeginVersion", beginVersion)
+						    .detail("Target", restoreVersion);
+						return Void();
+					}
 					break;
 				}
 			} catch (Error& e) {
@@ -5006,6 +5016,23 @@ struct StartFullRestoreTaskFunc : RestoreTaskFuncBase {
 
 		state Version firstVersion = Params.firstVersion().getOrDefault(task, invalidVersion);
 		if (firstVersion == invalidVersion) {
+			// For blob granule restore, we can complete the restore job if no mutation log is needed
+			state bool isBlobGranuleRestore;
+			wait(store(isBlobGranuleRestore, restore.isBlobGranuleRestore().getD(tr, Snapshot::False, false)));
+			if (isBlobGranuleRestore) {
+				state Version beginVersion;
+				state Version restoreVersion;
+				wait(store(beginVersion, restore.beginVersion().getD(tr, Snapshot::False, ::invalidVersion)));
+				wait(store(restoreVersion, restore.restoreVersion().getOrThrow(tr)));
+				// no need to apply mutations if target version is less than begin version
+				if (restoreVersion <= beginVersion) {
+					wait(
+					    success(RestoreCompleteTaskFunc::addTask(tr, taskBucket, task, TaskCompletionKey::noSignal())));
+					wait(taskBucket->finish(tr, task));
+					return Void();
+				}
+			}
+
 			wait(restore.logError(
 			    tr->getDatabase(), restore_missing_data(), "StartFullRestore: The backup had no data.", THIS));
 			std::string tag = wait(restore.tag().getD(tr));
@@ -6180,7 +6207,8 @@ public:
 		Optional<RestorableFileSet> restoreSet =
 		    wait(bc->getRestoreSet(targetVersion, ranges, onlyApplyMutationLogs, beginVersion));
 
-		if (!restoreSet.present()) {
+		// for blob granule restore, we don't have the begin version yet, so no need to check restore data set
+		if (!restoreSet.present() && !blobManifestUrl.present()) {
 			TraceEvent(SevWarn, "FileBackupAgentRestoreNotPossible")
 			    .detail("BackupContainer", bc->getURL())
 			    .detail("BeginVersion", beginVersion)

--- a/fdbclient/include/fdbclient/BlobRestoreCommon.h
+++ b/fdbclient/include/fdbclient/BlobRestoreCommon.h
@@ -64,6 +64,8 @@ struct BlobGranuleRestoreConfig : public KeyBackedClass {
 	KeyBackedProperty<std::string> error() { return subspace.pack(__FUNCTION__sr); }
 	KeyBackedMap<BlobRestorePhase, int64_t> phaseStartTs() { return subspace.pack(__FUNCTION__sr); };
 	KeyBackedProperty<UID> lock() { return subspace.pack(__FUNCTION__sr); }
+	// Begin version to apply mutation logs
+	KeyBackedProperty<Version> beginVersion() { return subspace.pack(__FUNCTION__sr); }
 };
 
 #endif

--- a/fdbserver/BlobMigrator.actor.cpp
+++ b/fdbserver/BlobMigrator.actor.cpp
@@ -473,10 +473,11 @@ private:
 					beginVersion = *std::min_element(self->mlogRestoreBeginVersions_.begin(),
 					                                 self->mlogRestoreBeginVersions_.end());
 				}
+				BlobGranuleRestoreConfig().beginVersion().set(tr, beginVersion);
+
 				Value versionEncoded = BinaryWriter::toValue(beginVersion, Unversioned());
 				Key prefix = uidPrefixKey(applyMutationsKeyVersionMapRange.begin, uid);
 				wait(krmSetRange(tr, prefix, allKeys, versionEncoded));
-
 				wait(tr->commit());
 				break;
 			} catch (Error& e) {


### PR DESCRIPTION
Cherry-Pick of #10442

100K BlobRestore test passed. 20230608-161155-huliu-d3d2893e6ef4315d
100k correctness test passed. 20230608-162712-huliu-9fec608613fba7dc

Original Description:

This PR fixes two bugs for blob granules restore when restoring to a previous version

we can complete the restore job sooner if no mutation log need to be applied.
Set the correct beginVersion for the restore job so that it only loads mutation log files needed to be applied
50K BlobRestore test passed. 100k correctness test passed

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
