### PR TITLE
Fix audit storage testAuditStorageConcurrentRunForSameType test

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -874,7 +874,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( FETCH_KEYS_LOWER_PRIORITY,                               0 );
 	init( SERVE_FETCH_CHECKPOINT_PARALLELISM,                      4 );
 	init( SERVE_AUDIT_STORAGE_PARALLELISM,                         1 );
-	init( PERSIST_FINISH_AUDIT_COUNT,                             10 ); if ( isSimulated ) PERSIST_FINISH_AUDIT_COUNT = 1;
+	init( PERSIST_FINISH_AUDIT_COUNT,                             10 ); if ( isSimulated ) PERSIST_FINISH_AUDIT_COUNT = deterministicRandom()->randomInt(1, PERSIST_FINISH_AUDIT_COUNT+1);
 	init( AUDIT_RETRY_COUNT_MAX,                                1000 ); if ( isSimulated ) AUDIT_RETRY_COUNT_MAX = 10;
 	init( CONCURRENT_AUDIT_TASK_COUNT_MAX,                        10 ); if ( isSimulated ) CONCURRENT_AUDIT_TASK_COUNT_MAX = deterministicRandom()->randomInt(1, CONCURRENT_AUDIT_TASK_COUNT_MAX+1);
 	init( BUGGIFY_BLOCK_BYTES,                                 10000 );

--- a/fdbserver/workloads/ValidateStorage.actor.cpp
+++ b/fdbserver/workloads/ValidateStorage.actor.cpp
@@ -100,7 +100,11 @@ struct ValidateStorage : TestWorkload {
 		return auditId;
 	}
 
-	ACTOR Future<Void> waitAuditStorageUntilComplete(Database cx, AuditType type, UID auditId, std::string context) {
+	ACTOR Future<Void> waitAuditStorageUntilComplete(Database cx,
+	                                                 AuditType type,
+	                                                 UID auditId,
+	                                                 std::string context,
+	                                                 bool stopWaitWhenCleared) {
 		state AuditStorageState auditState;
 		loop {
 			try {
@@ -123,6 +127,9 @@ struct ValidateStorage : TestWorkload {
 					UNREACHABLE();
 				}
 			} catch (Error& e) {
+				if (stopWaitWhenCleared && e.code() == error_code_key_not_found) {
+					break; // this audit has been cleared
+				}
 				TraceEvent("TestAuditStorageWaitError")
 				    .errorUnsuppressed(e)
 				    .detail("Context", context)
@@ -398,11 +405,15 @@ struct ValidateStorage : TestWorkload {
 		return Void();
 	}
 
-	ACTOR Future<UID> auditStorageForType(ValidateStorage* self, Database cx, AuditType type, std::string context) {
+	ACTOR Future<UID> auditStorageForType(ValidateStorage* self,
+	                                      Database cx,
+	                                      AuditType type,
+	                                      std::string context,
+	                                      bool stopWaitWhenCleared = false) {
 		// Send audit request until the server accepts the request
 		state UID auditId = wait(self->triggerAuditStorageForType(cx, type, context));
 		// Wait until the request completes
-		wait(self->waitAuditStorageUntilComplete(cx, type, auditId, context));
+		wait(self->waitAuditStorageUntilComplete(cx, type, auditId, context, stopWaitWhenCleared));
 		// Check internal persist state
 		wait(self->checkAuditStorageInternalState(cx, type, auditId, context));
 		return auditId;
@@ -533,18 +544,22 @@ struct ValidateStorage : TestWorkload {
 		TraceEvent("TestAuditStorageConcurrentRunForSameTypeBegin");
 		state std::vector<Future<Void>> fs;
 		state std::vector<UID> auditIds = { UID(), UID(), UID(), UID() };
-		fs.push_back(
-		    store(auditIds[0],
-		          self->auditStorageForType(self, cx, AuditType::ValidateReplica, "TestConcurrentRunForSameType")));
-		fs.push_back(
-		    store(auditIds[1],
-		          self->auditStorageForType(self, cx, AuditType::ValidateReplica, "TestConcurrentRunForSameType")));
-		fs.push_back(
-		    store(auditIds[2],
-		          self->auditStorageForType(self, cx, AuditType::ValidateReplica, "TestConcurrentRunForSameType")));
-		fs.push_back(
-		    store(auditIds[3],
-		          self->auditStorageForType(self, cx, AuditType::ValidateReplica, "TestConcurrentRunForSameType")));
+		fs.push_back(store(
+		    auditIds[0],
+		    self->auditStorageForType(
+		        self, cx, AuditType::ValidateReplica, "TestConcurrentRunForSameType", /*stopWaitWhenCleared=*/true)));
+		fs.push_back(store(
+		    auditIds[1],
+		    self->auditStorageForType(
+		        self, cx, AuditType::ValidateReplica, "TestConcurrentRunForSameType", /*stopWaitWhenCleared=*/true)));
+		fs.push_back(store(
+		    auditIds[2],
+		    self->auditStorageForType(
+		        self, cx, AuditType::ValidateReplica, "TestConcurrentRunForSameType", /*stopWaitWhenCleared=*/true)));
+		fs.push_back(store(
+		    auditIds[3],
+		    self->auditStorageForType(
+		        self, cx, AuditType::ValidateReplica, "TestConcurrentRunForSameType", /*stopWaitWhenCleared=*/true)));
 		wait(waitForAll(fs));
 		TraceEvent("TestAuditStorageConcurrentRunForSameTypeEnd");
 		return Void();


### PR DESCRIPTION
100K correctness test with 8 irrelevant failures: 
  20230608-214221-zhewang-456ba581e3507201           compressed=True data_size=34205445 duration=6155064 ended=100000 fail=8 fail_fast=10 max_runs=100000 pass=99992 priority=100 remaining=0 runtime=1:24:26 sanity=False started=100000 stopped=20230608-230647 submitted=20230608-214221 timeout=5400 username=zhewang

100K ValidateStorage test:
  20230608-214326-zhewang-863278d79b92a9a5           compressed=True data_size=34235131 duration=8320042 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:23:56 sanity=False started=100000 stopped=20230608-230722 submitted=20230608-214326 timeout=5400 username=zhewang

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
