### PR TITLE
made blob metadata load lazily from EKP (Cherry-Pick #10463 to snowflake/release-71.3)

### DIFF
--- a/fdbserver/BlobWorker.actor.cpp
+++ b/fdbserver/BlobWorker.actor.cpp
@@ -4182,6 +4182,11 @@ ACTOR Future<GranuleStartState> openGranule(Reference<BlobWorkerData> bwData, As
 		           req.managerSeqno);
 	}
 
+	TraceEvent("GranuleOpenStart", bwData->id)
+	    .detail("Granule", req.keyRange)
+	    .detail("Epoch", req.managerEpoch)
+	    .detail("Seqno", req.managerSeqno);
+
 	loop {
 		try {
 			tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);

--- a/fdbserver/include/fdbserver/BlobGranuleServerCommon.actor.h
+++ b/fdbserver/include/fdbserver/BlobGranuleServerCommon.actor.h
@@ -108,12 +108,14 @@ ACTOR Future<ForcedPurgeState> getForcePurgedState(Transaction* tr, KeyRange key
 struct GranuleTenantData : NonCopyable, ReferenceCounted<GranuleTenantData> {
 	TenantMapEntry entry;
 	Reference<BlobConnectionProvider> bstore;
+	bool startedLoadingBStore = false;
 	Promise<Void> bstoreLoaded;
 
 	GranuleTenantData() {}
 	GranuleTenantData(TenantMapEntry entry) : entry(entry) {}
 
 	void updateBStore(const BlobMetadataDetailsRef& metadata) {
+		ASSERT(startedLoadingBStore);
 		if (bstoreLoaded.canBeSet()) {
 			// new
 			bstore = BlobConnectionProvider::newBlobConnectionProvider(metadata);


### PR DESCRIPTION
Cherry-Pick of #10463

100k normal correctness: 20230612-133549-jslocum-58ddfb4c1c3b3368: 0 failures
50k blobgranule correctness: 20230612-133515-jslocum-58ddfb4c1c3b3368: 0 failures

Original Description:

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
