### PR TITLE
Fix MoveKeysClean.toml failure (Cherry-Pick #10470 to snowflake/release-71.3)

### DIFF
--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -2155,6 +2155,7 @@ ACTOR Future<int> setDDMode(Database cx, int mode) {
 		try {
 			tr.setOption(FDBTransactionOptions::LOCK_AWARE);
 			tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+			tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
 			Optional<Value> old = wait(tr.get(dataDistributionModeKey));
 			if (oldMode < 0) {
 				oldMode = 1;

--- a/fdbserver/ConsistencyScan.actor.cpp
+++ b/fdbserver/ConsistencyScan.actor.cpp
@@ -136,7 +136,7 @@ ACTOR Future<Void> pollDatabaseSize(Reference<ConsistencyScanMemoryState> memSta
 			++memState->stats.databasePollErrors;
 		}
 
-		wait(delay(1.0));
+		wait(delay(5.0));
 	}
 }
 


### PR DESCRIPTION
Cherry-Pick of #10470

100K correctness tests: 20230612-203427-huliu-5b0dfdb52c1ddeee

Original Description:

RandomMoveKeys is stuck at ManagementAPI::setDDMode() when db is throttled. So set PRIORITY_SYSTEM_IMMEDIATE option for the transaction.

Another change in ConsistencyScanner. Let it delay longer. Otherwise it creates more problems when DD is not started yet because of the above DD mode issue

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
