### PR TITLE
Fix queued relocations missing

### DIFF
--- a/fdbserver/DDRelocationQueue.actor.cpp
+++ b/fdbserver/DDRelocationQueue.actor.cpp
@@ -147,9 +147,17 @@ bool RelocateData::isRestore() const {
 }
 
 bool RelocateData::operator>(const RelocateData& rhs) const {
-	return priority != rhs.priority
-	           ? priority > rhs.priority
-	           : (startTime != rhs.startTime ? startTime < rhs.startTime : randomId > rhs.randomId);
+	if (priority != rhs.priority) {
+		return priority > rhs.priority;
+	} else if (startTime != rhs.startTime) {
+		return startTime < rhs.startTime;
+	} else if (randomId != rhs.randomId) {
+		return randomId > rhs.randomId;
+	} else if (keys.begin != rhs.keys.begin) {
+		return keys.begin < rhs.keys.begin;
+	} else {
+		return keys.end < rhs.keys.end;
+	}
 }
 
 bool RelocateData::operator==(const RelocateData& rhs) const {
@@ -802,11 +810,18 @@ void DDQueue::queueRelocation(RelocateShard rs, std::set<UID>& serversToLaunchFr
 	// update fetchingSourcesQueue and the per-server queue based on truncated ranges after insertion, (re-)launch
 	// getSourceServers
 	auto queueMapItr = queueMap.rangeContaining(affectedQueuedItems[0].begin);
+
+	// Put off erasing elements from fetchingSourcesQueue
+	std::set<RelocateData, std::greater<RelocateData>> delayDelete;
 	for (int r = 0; r < affectedQueuedItems.size(); ++r, ++queueMapItr) {
 		// ASSERT(queueMapItr->value() == queueMap.rangeContaining(affectedQueuedItems[r].begin)->value());
 		RelocateData& rrs = queueMapItr->value();
 
-		if (rrs.src.size() == 0 && (rrs.keys == rd.keys || fetchingSourcesQueue.erase(rrs) > 0)) {
+		if (rrs.src.size() == 0 && (rrs.keys == rd.keys || fetchingSourcesQueue.count(rrs) > 0)) {
+			if (fetchingSourcesQueue.count(rrs) > 0) {
+				delayDelete.insert(rrs);
+			}
+
 			rrs.keys = affectedQueuedItems[r];
 			rrs.interval = TraceInterval("QueuedRelocation", rrs.randomId); // inherit the old randomId
 
@@ -865,6 +880,9 @@ void DDQueue::queueRelocation(RelocateShard rs, std::set<UID>& serversToLaunchFr
 		}
 	}
 
+	for (auto it : delayDelete) {
+		fetchingSourcesQueue.erase(it);
+	}
 	DebugRelocationTraceEvent("ReceivedRelocateShard", distributorId)
 	    .detail("KeyBegin", rd.keys.begin)
 	    .detail("KeyEnd", rd.keys.end)

--- a/fdbserver/DDRelocationQueue.actor.cpp
+++ b/fdbserver/DDRelocationQueue.actor.cpp
@@ -820,7 +820,7 @@ void DDQueue::queueRelocation(RelocateShard rs, std::set<UID>& serversToLaunchFr
 		RelocateData& rrs = queueMapItr->value();
 
 		if (rrs.src.size() == 0 && (rrs.keys == rd.keys || fetchingSourcesQueue.count(rrs) > 0)) {
-			if (fetchingSourcesQueue.count(rrs) > 0) {
+			if (rrs.keys != rd.keys) {
 				delayDelete.insert(rrs);
 			}
 

--- a/fdbserver/DDRelocationQueue.actor.cpp
+++ b/fdbserver/DDRelocationQueue.actor.cpp
@@ -146,6 +146,8 @@ bool RelocateData::isRestore() const {
 	return this->dataMove != nullptr;
 }
 
+// Note: C++ standard library uses the Compare operator, uniqueness is determined by !comp(a, b) && !comp(b, a).
+// So operator == and != is not used by std::set<RelocateData, std::greater<RelocateData>>
 bool RelocateData::operator>(const RelocateData& rhs) const {
 	if (priority != rhs.priority) {
 		return priority > rhs.priority;


### PR DESCRIPTION
In a corner case, one pending DD request might be split into two requests, and fetchingSourcesQueue would take those two as single one.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
