### PR TITLE
misc operational and documentation improvements (Cherry-Pick #10465 to snowflake/release-71.3)

### DIFF
--- a/documentation/sphinx/source/command-line-interface.rst
+++ b/documentation/sphinx/source/command-line-interface.rst
@@ -138,7 +138,7 @@ This command controls a native data consistency scan role that is automatically 
 
 The syntax is
 
-``consistencyscan [on|off] [restart] [maxRate <BYTES_PER_SECOND>] [targetInterval <SECONDS>]``
+``consistencyscan [on|off] [restart] [stats] [clearstats] [maxRate <BYTES_PER_SECOND>] [targetInterval <SECONDS>]``
 
 * ``on`` enables the scan.
 
@@ -146,11 +146,17 @@ The syntax is
 
 * ``restart`` will end the current scan cycle.  A new cycle will start if the scan is enabled, or later when it is re-enabled.
 
+* ``stats`` dumps the current round and lifetime stats of the consistency scan. It is a convenience method to expose the stats which are also in status json.
+
+* ``clearstats`` will clear all of the stats for the consistency scan but otherwise leave the configuration as is. This can be used to clear errors or reset stat counts, for example.
+
 * ``maxRate <BYTES_PER_SECOND>`` sets the maximum scan read speed rate to BYTES_PER_SECOND, post-replication.
 
 * ``targetInterval <SECONDS>`` sets the target interval for the scan to SECONDS.  The scan will adjust speed to attempt to complete in that amount of time but it will not exceed BYTES_PER_SECOND.
 
 The consistency scan role publishes its configuration and metrics in Status JSON under the path ``.cluster.consistency_scan``.
+
+For more details, see :ref:`consistency-scan`.
 
 consistencycheck
 ----------------

--- a/documentation/sphinx/source/consistency-scan.rst
+++ b/documentation/sphinx/source/consistency-scan.rst
@@ -1,0 +1,39 @@
+.. _consistency-scan:
+
+############################
+Consistency Scan
+############################
+
+.. include:: guide-common.rst.inc
+
+This document covers the concept and usage of the consistency scan feature.
+
+.. _consistency-scan-introduction:
+
+Summary
+============
+ The consistency scan reads all replicas of each shard to verify data consistency at a configured rate.  It is useful for finding corrupt cold data by ensuring that all data is read periodically.  Any errors found will be logged as TraceEvents with Severity = 40.
+
+Configuration
+=============
+
+You can configure the Consistency Scan via the FDB :ref:`command line interface <command-line-interface>` using the ``consistencyscan`` command.
+
+
+Example commands
+----------------
+
+Enable consistency scan to scan the cluster once every 28 days with a maximum speed of 5MB/s: ``consistencyscan on maxRate 5000000 targetInterval 2419200``.
+
+Disable consistency scan on the cluster: ``consistencyscan off``.
+
+View the current stats for the consistency scan: ``consistencyscan stats``.
+
+Monitor
+=======
+
+The consistency scan role publishes its configuration and metrics in Status JSON under the path ``.cluster.consistency_scan``.
+
+Trace Events
+----------------------
+``ConsistencyScanMetrics`` show the over-time stats of the consistency scan's behavior, including bytes scanned, error counts, inconsistencies found, etc...

--- a/documentation/sphinx/source/operations.rst
+++ b/documentation/sphinx/source/operations.rst
@@ -30,6 +30,8 @@ Ready to operate an externally accessible FoundationDB cluster? You'll find what
 
 * :doc:`perpetual-storage-wiggle` gives an overview of Perpetual Storage Wiggle feature about how to use it.
 
+* :doc:`consistency-scan` gives an overview of the ConsistencyScan feature and how to use it.
+
 .. toctree::
  :maxdepth: 2
  :titlesonly:
@@ -47,3 +49,4 @@ Ready to operate an externally accessible FoundationDB cluster? You'll find what
  transaction-tagging
  tss
  perpetual-storage-wiggle
+ consistency-scan

--- a/fdbclient/include/fdbclient/ConsistencyScanInterface.actor.h
+++ b/fdbclient/include/fdbclient/ConsistencyScanInterface.actor.h
@@ -241,6 +241,8 @@ struct ConsistencyScanState : public KeyBackedClass {
 			           startTime,
 			           endVersion,
 			           endTime,
+			           lastProgressVersion,
+			           lastProgressTime,
 			           complete,
 			           logicalBytesScanned,
 			           replicatedBytesRead,

--- a/fdbserver/ConsistencyScan.actor.cpp
+++ b/fdbserver/ConsistencyScan.actor.cpp
@@ -928,8 +928,9 @@ ACTOR Future<Void> consistencyScanCore(Database db,
 							// we also don't want to alternate bursting for 5 seconds and then sleeping for many seconds
 							// As a compromise, only sleep for some tunable percentage of the target here, and sleep the
 							// rest at the end
-							int sleepBytes = (int)(totalReadBytesFromStorageServers *
-							                       SERVER_KNOBS->CONSISTENCY_SCAN_ACTIVE_THROTTLE_RATIO);
+							double ratio = SERVER_KNOBS->CONSISTENCY_SCAN_ACTIVE_THROTTLE_RATIO;
+							ratio = std::max(0.0, std::min(1.0, ratio));
+							int sleepBytes = (int)(totalReadBytesFromStorageServers * ratio);
 							totalReadBytesFromStorageServers -= sleepBytes;
 							wait(readRateControl->getAllowance(sleepBytes));
 						}


### PR DESCRIPTION
Cherry-Pick of #10465

Original Description:

- document consistency scan feature
- add "consistencyscan stats" command
- provide validation and clamping on user-specified knob value
- fix bug of not serializing last progress version/timestamp, causing them to be missing from status json + stats

100k correctness: 20230612-203911-jslocum-485d65b48e5efaf8: 2 failures, which look to be issues solved by #10496

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
