### PR TITLE
Report to stdout if DTrace is enabled

### DIFF
--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -482,6 +482,7 @@ else()
       $<${is_cxx_compile}:-DNO_WARN_X86_INTRINSICS>
     )
   endif()
+
   # Check whether we can use dtrace probes
   include(CheckSymbolExists)
   check_symbol_exists(DTRACE_PROBE sys/sdt.h SUPPORT_DTRACE)
@@ -489,6 +490,7 @@ else()
   message(STATUS "Has aligned_alloc: ${HAS_ALIGNED_ALLOC}")
   if((SUPPORT_DTRACE) AND (USE_DTRACE))
     set(DTRACE_PROBES 1)
+	message(STATUS "DTrace probes installed")
   endif()
 
   set(USE_LTO OFF CACHE BOOL "Do link time optimization")


### PR DESCRIPTION
It seems that in the current Okteto docker environment, USE_DTRACE flag is set ON by default, yet the generated code is not using DTrace since the environment does not support DTRACE. Explicitly print out the final result will be helpful understanding why DTrace may not available in the final code.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
