### PR TITLE
Remove blobGranuleLockKeys after blob granule restore

### DIFF
--- a/fdbclient/FileBackupAgent.actor.cpp
+++ b/fdbclient/FileBackupAgent.actor.cpp
@@ -3633,6 +3633,7 @@ struct RestoreCompleteTaskFunc : RestoreTaskFuncBase {
 			tr->clear(blobGranuleHistoryKeys);
 			tr->clear(blobGranuleFileKeys);
 			tr->clear(blobGranuleMappingKeys);
+			tr->clear(blobGranuleLockKeys);
 			BlobGranuleRestoreConfig().phase().set(tr, BlobRestorePhase::DONE);
 			BlobGranuleRestoreConfig().phaseStartTs().set(tr, BlobRestorePhase::DONE, now());
 		}

--- a/fdbserver/BlobGranuleValidation.actor.cpp
+++ b/fdbserver/BlobGranuleValidation.actor.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "fdbserver/BlobGranuleValidation.actor.h"
+#include "fdbclient/FDBOptions.h"
 #include "fdbserver/Knobs.h"
 #include "fdbclient/BlobGranuleRequest.actor.h"
 #include "fdbclient/DatabaseContext.h"
@@ -606,6 +607,51 @@ ACTOR Future<Void> checkFeedCleanup(Database cx, bool debug) {
 			wait(delay(2.0));
 			// reset transaction to get higher read version
 			tr.reset();
+		} catch (Error& e) {
+			wait(tr.onError(e));
+		}
+	}
+}
+
+ACTOR Future<Void> killBlobWorkers(Database cx) {
+	state Transaction tr(cx);
+	state std::set<UID> knownWorkers;
+	state bool first = true;
+	loop {
+		tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
+		tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+		tr.setOption(FDBTransactionOptions::LOCK_AWARE);
+		tr.setOption(FDBTransactionOptions::RAW_ACCESS);
+		try {
+			RangeResult r = wait(tr.getRange(blobWorkerListKeys, CLIENT_KNOBS->TOO_MANY));
+
+			state std::vector<UID> haltIds;
+			state std::vector<Future<ErrorOr<Void>>> haltRequests;
+			for (auto& it : r) {
+				BlobWorkerInterface interf = decodeBlobWorkerListValue(it.value);
+				if (first) {
+					knownWorkers.insert(interf.id());
+				}
+				if (knownWorkers.count(interf.id())) {
+					haltIds.push_back(interf.id());
+					haltRequests.push_back(interf.haltBlobWorker.tryGetReply(HaltBlobWorkerRequest(1e6, UID())));
+				}
+			}
+			first = false;
+			wait(waitForAll(haltRequests));
+			bool allPresent = true;
+			for (int i = 0; i < haltRequests.size(); i++) {
+				if (haltRequests[i].get().present()) {
+					knownWorkers.erase(haltIds[i]);
+				} else {
+					allPresent = false;
+				}
+			}
+			if (allPresent) {
+				return Void();
+			} else {
+				wait(delay(1.0));
+			}
 		} catch (Error& e) {
 			wait(tr.onError(e));
 		}

--- a/fdbserver/include/fdbserver/BlobGranuleValidation.actor.h
+++ b/fdbserver/include/fdbserver/BlobGranuleValidation.actor.h
@@ -67,6 +67,7 @@ ACTOR Future<Void> validateForceFlushing(Database cx,
 
 ACTOR Future<Void> checkFeedCleanup(Database cx, bool debug);
 
+ACTOR Future<Void> killBlobWorkers(Database cx);
 #include "flow/unactorcompiler.h"
 
 #endif

--- a/fdbserver/workloads/BlobGranuleVerifier.actor.cpp
+++ b/fdbserver/workloads/BlobGranuleVerifier.actor.cpp
@@ -218,47 +218,6 @@ struct BlobGranuleVerifierWorkload : TestWorkload {
 		OldRead(KeyRange range, Version v, RangeResult oldResult) : range(range), v(v), oldResult(oldResult) {}
 	};
 
-	ACTOR Future<Void> killBlobWorkers(Database cx, BlobGranuleVerifierWorkload* self) {
-		state Transaction tr(cx);
-		state std::set<UID> knownWorkers;
-		state bool first = true;
-		loop {
-			try {
-				RangeResult r = wait(tr.getRange(blobWorkerListKeys, CLIENT_KNOBS->TOO_MANY));
-
-				state std::vector<UID> haltIds;
-				state std::vector<Future<ErrorOr<Void>>> haltRequests;
-				for (auto& it : r) {
-					BlobWorkerInterface interf = decodeBlobWorkerListValue(it.value);
-					if (first) {
-						knownWorkers.insert(interf.id());
-					}
-					if (knownWorkers.count(interf.id())) {
-						haltIds.push_back(interf.id());
-						haltRequests.push_back(interf.haltBlobWorker.tryGetReply(HaltBlobWorkerRequest(1e6, UID())));
-					}
-				}
-				first = false;
-				wait(waitForAll(haltRequests));
-				bool allPresent = true;
-				for (int i = 0; i < haltRequests.size(); i++) {
-					if (haltRequests[i].get().present()) {
-						knownWorkers.erase(haltIds[i]);
-					} else {
-						allPresent = false;
-					}
-				}
-				if (allPresent) {
-					return Void();
-				} else {
-					wait(delay(1.0));
-				}
-			} catch (Error& e) {
-				wait(tr.onError(e));
-			}
-		}
-	}
-
 	// TODO refactor more generally
 	ACTOR Future<Void> loadGranuleMetadataBeforeForcePurge(Database cx, BlobGranuleVerifierWorkload* self) {
 		// load all granule history entries that intersect purged range
@@ -417,7 +376,7 @@ struct BlobGranuleVerifierWorkload : TestWorkload {
 					// reading older than the purge version
 					if (doPurging) {
 						if (self->strictPurgeChecking) {
-							wait(self->killBlobWorkers(cx, self));
+							wait(killBlobWorkers(cx));
 							if (BGV_DEBUG) {
 								fmt::print("BGV Reading post-purge [{0} - {1}) @ {2}\n",
 								           oldRead.range.begin.printable(),

--- a/fdbserver/workloads/BlobRestoreWorkload.actor.cpp
+++ b/fdbserver/workloads/BlobRestoreWorkload.actor.cpp
@@ -29,6 +29,7 @@
 #include "fdbclient/SystemData.h"
 #include "fdbclient/BlobGranuleReader.actor.h"
 #include "fdbclient/BlobRestoreCommon.h"
+#include "fdbserver/BlobGranuleValidation.actor.h"
 #include "fdbserver/Knobs.h"
 #include "fdbserver/workloads/workloads.actor.h"
 #include "fdbserver/BlobGranuleServerCommon.actor.h"
@@ -195,7 +196,12 @@ struct BlobRestoreWorkload : TestWorkload {
 			auto controller = makeReference<BlobRestoreController>(self->extraDb_, normalKeys);
 			state BlobRestorePhase phase = wait(BlobRestoreController::currentPhase(controller));
 			if (phase == BlobRestorePhase::DONE) {
+				// Check if src and dest db are consistent
 				wait(verify(cx, self));
+
+				// Check if we can flush ranges after restore
+				wait(killBlobWorkers(self->extraDb_));
+				wait(flushBlobRanges(self->extraDb_, self, {}));
 				return Void();
 			}
 			// TODO need to define more specific error handling
@@ -323,26 +329,42 @@ struct BlobRestoreWorkload : TestWorkload {
 		return true;
 	}
 
-	ACTOR static Future<Void> flushSrcDbToBlob(Database cx, BlobRestoreWorkload* self) {
+	ACTOR static Future<Void> flushBlobRanges(Database cx, BlobRestoreWorkload* self, Optional<Version> version) {
 		state Standalone<VectorRef<KeyRangeRef>> ranges =
 		    wait(cx->listBlobbifiedRanges(normalKeys, CLIENT_KNOBS->TOO_MANY));
-		try {
-			for (auto& r : ranges) {
-				bool flush = wait(cx->flushBlobRange(r, false, self->restoreTargetVersion_));
-				if (!flush) {
-					fmt::print("Cannot flush to version {} \n", self->restoreTargetVersion_);
+		loop {
+			try {
+				for (auto& r : ranges) {
+					state KeyRange range = r;
+					loop {
+						Version v = wait(cx->verifyBlobRange(range, {}, {}));
+						if (v != invalidVersion) {
+							fmt::print("Validated blob range {} at {}\n", range.toString(), v);
+							break;
+						}
+						wait(delay(2.0));
+					}
+
+					bool flush = wait(cx->flushBlobRange(range, false, version));
+					if (!flush) {
+						fmt::print("Cannot flush to version {} \n", version.present() ? version.get() : -1);
+						throw internal_error();
+					}
+				}
+				return Void();
+			} catch (Error& e) {
+				if (e.code() != error_code_tag_throttled) {
+					fmt::print("Cannot flush blob ranges {}\n", e.what());
 					throw internal_error();
 				}
+				wait(delay(2));
 			}
-			return Void();
-		} catch (Error& e) {
-			throw internal_error();
 		}
 	}
 
 	ACTOR static Future<Void> verify(Database cx, BlobRestoreWorkload* self) {
 		// flush src db
-		wait(flushSrcDbToBlob(cx, self));
+		wait(flushBlobRanges(cx, self, self->restoreTargetVersion_));
 
 		// restore src. data before restore
 		state Standalone<VectorRef<KeyValueRef>> src = wait(readFromBlob(cx, self->restoreTargetVersion_, self));


### PR DESCRIPTION
Need to cleanup blobGranuleLockKeys after restore. Otherwise change feed couldn't be created successfully. Also add post-restore test for BlobRestoreWorkload.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
