### PR TITLE
fix retransmits in corruption check

### DIFF
--- a/fdbrpc/include/fdbrpc/simulator.h
+++ b/fdbrpc/include/fdbrpc/simulator.h
@@ -395,6 +395,7 @@ public:
 	// Inject corruption only in consistency scan reads to ensure scan finds it.
 	enum SimConsistencyScanCorruptionType { FlipMoreFlag = 0, AddToEmpty = 1, RemoveLastRow = 2, ChangeFirstValue = 3 };
 	Optional<SimConsistencyScanCorruptionType> consistencyScanInjectedCorruptionType;
+	Optional<UID> consistencyScanInjectedCorruptionDestination;
 	Optional<bool> doInjectConsistencyScanCorruption;
 	Optional<Standalone<StringRef>> consistencyScanCorruptRequestKey;
 	Optional<UID> consistencyScanCorruptor;


### PR DESCRIPTION
Fixes case in corruption check where original request would be corrupted, get a network error, and the retransmit would then not be corrupted, causing the scan to think it missed a corruption.

Passed 100k correctness

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
