### PR TITLE
fix consistency scan ubsan issue and replication factor calculation (Cherry-Pick #10492 to snowflake/release-71.3)

### DIFF
--- a/fdbserver/ConsistencyScan.actor.cpp
+++ b/fdbserver/ConsistencyScan.actor.cpp
@@ -652,10 +652,11 @@ ACTOR Future<Void> consistencyScanCore(Database db,
 				    (statsCurrentRound.logicalBytesScanned == 0)
 				        ? 3
 				        : ((double)statsCurrentRound.replicatedBytesRead / statsCurrentRound.logicalBytesScanned);
-				configuredRate =
-				    std::min<int>(config.maxReadByteRate,
-				                  memState->databaseSize.get() * replicationFactor /
-				                      (config.targetRoundTimeSeconds > 0 ? config.targetRoundTimeSeconds : 1));
+				double bytesPerSecTarget = memState->databaseSize.get() * replicationFactor /
+				                           (config.targetRoundTimeSeconds > 0 ? config.targetRoundTimeSeconds : 1);
+				// avoid ubsan int conversion issue if misconfigured, also max of 100MB/s is reasonable anyway
+				bytesPerSecTarget = std::min(bytesPerSecTarget, 1e8);
+				configuredRate = std::min<int>(config.maxReadByteRate, bytesPerSecTarget);
 			}
 
 			configuredRate = std::max<int>(100e3, configuredRate);
@@ -842,6 +843,7 @@ ACTOR Future<Void> consistencyScanCore(Database db,
 							state std::vector<Future<ErrorOr<GetKeyValuesReply>>> keyValueFutures;
 							state Optional<int> firstValidServer;
 							memState->stats.requests += storageServerInterfaces.size();
+							state int64_t replicatedBytesReadThisLoop = 0;
 							int newErrors = wait(consistencyCheckReadData(memState->csId,
 							                                              db,
 							                                              targetRange,
@@ -849,7 +851,7 @@ ACTOR Future<Void> consistencyScanCore(Database db,
 							                                              &storageServerInterfaces,
 							                                              &keyValueFutures,
 							                                              &firstValidServer,
-							                                              &replicatedBytesRead,
+							                                              &replicatedBytesReadThisLoop,
 							                                              statsCurrentRound.startVersion));
 							errors += newErrors;
 							memState->stats.inconsistencies += newErrors;
@@ -870,6 +872,7 @@ ACTOR Future<Void> consistencyScanCore(Database db,
 								ASSERT(firstValidServer.present());
 								GetKeyValuesReply rangeResult = keyValueFutures[firstValidServer.get()].get().get();
 								logicalBytesRead += rangeResult.data.expectedSize();
+								replicatedBytesRead += replicatedBytesReadThisLoop;
 								if (!rangeResult.more) {
 									statsCurrentRound.lastEndKey = targetRange.end;
 									noMoreRecords = statsCurrentRound.lastEndKey == allKeys.end;
@@ -901,6 +904,7 @@ ACTOR Future<Void> consistencyScanCore(Database db,
 										nextKey = storageNextKey;
 									}
 								}
+								replicatedBytesRead += replicatedBytesReadThisLoop;
 								statsCurrentRound.lastEndKey = nextKey;
 								if (nextKey == targetRange.end) {
 									noMoreRecords = nextKey == allKeys.end;
@@ -920,7 +924,9 @@ ACTOR Future<Void> consistencyScanCore(Database db,
 								}
 								// FIXME: increment failed request count if error present
 								ASSERT(failedRequest.get().code() != error_code_operation_cancelled);
-								totalReadBytesFromStorageServers += 100000;
+								// don't include replicated bytes this loop in metrics to avoid getting replication
+								// factor wrong, but make sure we stil throttle based on it
+								totalReadBytesFromStorageServers += replicatedBytesReadThisLoop + 100000;
 								break;
 							}
 


### PR DESCRIPTION
Cherry-Pick of #10492

Original Description:

UBSAN triggered because db size * replication factor > INT_MAX.
This was due to a bug of replication factor being higher than it should be when encountering errors, but is an actual issue when DB size > INT_MAX as well.

100k correctness: 20230614-135304-jslocum-bb8beb1830a43c52: 0 failures

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
