### PR TITLE
Reset connection idle time when restarting connection monitor (Cherry-Pick #10495 to snowflake/release-71.3)

### DIFF
--- a/fdbrpc/FlowTransport.actor.cpp
+++ b/fdbrpc/FlowTransport.actor.cpp
@@ -504,6 +504,8 @@ static ReliablePacket* sendPacket(TransportData* self,
 
 ACTOR Future<Void> connectionMonitor(Reference<Peer> peer) {
 	state Endpoint remotePingEndpoint({ peer->destination }, Endpoint::wellKnownToken(WLTOKEN_PING_PACKET));
+	// set this to not immediately close the connection as idle if the peer already existed
+	peer->lastDataPacketSentTime = now();
 	loop {
 		if (!FlowTransport::isClient() && !peer->destination.isPublic() && peer->compatible) {
 			// Don't send ping messages to clients unless necessary. Instead monitor incoming client pings.


### PR DESCRIPTION
Cherry-Pick of #10495

Original Description:

The problem:
Server A has a network connection to Server B.

The normal expected behavior is that:

1. On Server B, Server A's peer is destroyed by connectionKeeper with PeerDestroy on a network error.
2. Server A sends a new message re-establishing the connection, re-creating the peer, with lastDataPacketSentTime=now().

But, if in between these (before the client tries to reconnect), something else on Server B recreates the Peer to A, the Peer will already exist when the connection comes in with an old lastDataPacketSentTime.

If the time that has passed between when the peer was recreated and when the new connection came in exceeded CONNECTION_MONITOR_UNREFERENCED_CLOSE_DELAY, connectionMonitor would immediately close the connection, retriggering this loop.

The fix is to reset lastDataPacketSentTime when the new connection starts.
This is only used to track this idle time and close idle connections, so there is little risk to making this change.

This bug is very old, but the change that caused it to surface is the consistency scan now requests the worker interfaces for all workers in the cluster.
And doing this request has the side effect of deserializing all of the worker interfaces and creating Peer objects for each of them, which is valid behavior but is behavior that wasn't happening before.

The reason this continued to happen in this test was that the stuck request was a grv as part of setDDMode, and the consistency scan does the worker check to reach out to DD, so since DD was disabled the consistency scan was infinitely trying to contact DD, and thus repeatedly deserializing the worker interfaces, and since DD and the GRV proxy were on the same worker, the same peer kept hitting this issue.

Passed 250k correctness on main
100k correctness on 71.3: 20230614-190419-jslocum-526887d61fec5387: 1 unrelated failure, stuck recovery in accepting_commits that appeared due to io_errors

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
