### PR TITLE
Fix RandomStringSetGenerator may not generate enough unique key

### DIFF
--- a/fdbclient/include/fdbclient/RandomKeyValueUtils.h
+++ b/fdbclient/include/fdbclient/RandomKeyValueUtils.h
@@ -221,10 +221,13 @@ struct RandomStringSetGeneratorBase : IKeyGenerator {
 		ASSERT(indexGenerator.max > 0);
 		std::set<Key> uniqueKeys;
 		int inserts = 0;
+		// for smaller indexGenerator.max, give it more insert try, as it may not find enough unique keys with 3 * max.
+		// It adds roughly log * 100. For example, even for max is 1, it will try at least 100 times.
+		const uint maxInsertTry = 3 * indexGenerator.max + (((sizeof(uint) * 8) - clz(indexGenerator.max)) * 100);
 		while (uniqueKeys.size() < indexGenerator.max) {
 			auto k = keyGen.next();
 			uniqueKeys.insert(k);
-			if (++inserts > 3 * indexGenerator.max) {
+			if (++inserts > maxInsertTry) {
 				// StringGenerator cardinality is too low, unable to find enough unique keys.
 				ASSERT(false);
 			}


### PR DESCRIPTION
For small key set, RandomStringSetGenerator may not try enough random key to generate unique key set.
Increase the retry for smaller key set number.

Test: passed 1000k `/randomKeyValueUtils/generate`

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
