### PR TITLE
Move lastFlushTs to BlobGranuleBackupConfig (Cherry-Pick #10505 to snowflake/release-71.3)

### DIFF
--- a/fdbclient/FileBackupAgent.actor.cpp
+++ b/fdbclient/FileBackupAgent.actor.cpp
@@ -5391,9 +5391,11 @@ public:
 				bgBackupConfig.manifestUrl().set(tr, blobManifestUrl.get());
 				bgBackupConfig.mutationLogsUrl().set(tr, bc->getURL());
 				bgBackupConfig.enabled().set(tr, true);
+				bgBackupConfig.lastFlushTs().set(tr, 0);
 			}
 			// Allow only incremental backup
 			incrementalBackupOnly = IncrementalBackupOnly::True;
+			stopWhenDone = StopWhenDone::False;
 		}
 
 		KeyRangeMap<int> backupRangeSet;
@@ -5719,6 +5721,7 @@ public:
 		if (bgBackupEnabled) {
 			BlobGranuleBackupConfig bgbackupConfig;
 			bgbackupConfig.enabled().set(tr, false);
+			bgbackupConfig.lastFlushTs().set(tr, 0);
 		}
 
 		// Cancel backup task through tag

--- a/fdbclient/SystemData.cpp
+++ b/fdbclient/SystemData.cpp
@@ -1772,7 +1772,6 @@ UID decodeBlobWorkerAffinityValue(ValueRef const& value) {
 }
 
 const Key blobManifestVersionKey = "\xff\x02/blobManifestVersion"_sr;
-const Key blobGranulesLastFlushKey = "\xff\x02/blobGranulesLastFlushTs"_sr;
 
 const KeyRangeRef idempotencyIdKeys("\xff\x02/idmp/"_sr, "\xff\x02/idmp0"_sr);
 const KeyRef idempotencyIdsExpiredVersion("\xff\x02/idmpExpiredVersion"_sr);

--- a/fdbclient/include/fdbclient/BlobRestoreCommon.h
+++ b/fdbclient/include/fdbclient/BlobRestoreCommon.h
@@ -30,9 +30,12 @@
 struct BlobGranuleBackupConfig : public KeyBackedClass {
 	BlobGranuleBackupConfig(KeyRef prefix = SystemKey("\xff\x02/bgbackup/"_sr)) : KeyBackedClass(prefix) {}
 
-	KeyBackedProperty<bool> enabled() { return subspace.pack(__FUNCTION__sr); }
+	KeyBackedProperty<bool> enabled() { return { subspace.pack(__FUNCTION__sr), trigger, TupleCodec<bool>() }; }
 	KeyBackedProperty<std::string> manifestUrl() { return subspace.pack(__FUNCTION__sr); }
 	KeyBackedProperty<std::string> mutationLogsUrl() { return subspace.pack(__FUNCTION__sr); }
+
+	KeyBackedProperty<int64_t> lastFlushTs() { return subspace.pack(__FUNCTION__sr); }
+	KeyBackedProperty<Version> lastFlushVersion() { return subspace.pack(__FUNCTION__sr); }
 };
 
 // Defines blob restore state

--- a/fdbclient/include/fdbclient/SystemData.h
+++ b/fdbclient/include/fdbclient/SystemData.h
@@ -744,7 +744,6 @@ const Value blobWorkerAffinityValue(UID const& id);
 UID decodeBlobWorkerAffinityValue(ValueRef const& value);
 
 extern const Key blobManifestVersionKey;
-extern const Key blobGranulesLastFlushKey;
 
 extern const KeyRangeRef idempotencyIdKeys;
 extern const KeyRef idempotencyIdsExpiredVersion;

--- a/fdbserver/BlobManager.actor.cpp
+++ b/fdbserver/BlobManager.actor.cpp
@@ -28,6 +28,7 @@
 
 #include "fdbclient/BackupContainer.h"
 #include "fdbclient/ClientBooleanParams.h"
+#include "fdbclient/FDBTypes.h"
 #include "fdbclient/KeyBackedTypes.actor.h"
 #include "fdbclient/ServerKnobs.h"
 #include "fdbrpc/simulator.h"
@@ -422,6 +423,7 @@ struct BlobManagerData : NonCopyable, ReferenceCounted<BlobManagerData> {
 	int64_t seqNo = 1;
 	int64_t manifestDumperSeqNo = 1;
 	bool enableManifestEncryption = false;
+	AsyncTrigger backupTrigger;
 	AsyncTrigger manifestCompletitionTrigger;
 
 	Promise<Void> iAmReplaced;
@@ -5569,84 +5571,37 @@ ACTOR Future<Void> bgConsistencyCheck(Reference<BlobManagerData> bmData) {
 	}
 }
 
-ACTOR Future<Void> updateLastFlushTs(Database db) {
-	state Transaction tr(db);
-	loop {
-		try {
-			tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
-			tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
-			tr.setOption(FDBTransactionOptions::LOCK_AWARE);
-			KeyBackedProperty<int64_t> lastFlushTs(blobGranulesLastFlushKey);
-			int64_t epochs = (int64_t)now();
-			lastFlushTs.set(&tr, epochs);
-			wait(tr.commit());
-			return Void();
-		} catch (Error& e) {
-			wait(tr.onError(e));
-		}
-	}
-}
+ACTOR Future<Void> updateLastFlushVersion(Database db, Version flushVersion) {
+	wait(runRYWTransaction(db, [=](Reference<ReadYourWritesTransaction> tr) -> Future<Void> {
+		tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+		tr->setOption(FDBTransactionOptions::LOCK_AWARE);
+		tr->setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
 
-ACTOR Future<int64_t> getLastFlushTs(Database db) {
-	state Transaction tr(db);
-	loop {
-		try {
-			tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
-			tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
-			tr.setOption(FDBTransactionOptions::LOCK_AWARE);
-			KeyBackedProperty<int64_t> lastFlushTs(blobGranulesLastFlushKey);
-			state int64_t ret;
-			wait(store(ret, lastFlushTs.getD(&tr, Snapshot::False, 0)));
-			return ret;
-		} catch (Error& e) {
-			wait(tr.onError(e));
-		}
-	}
-}
-
-ACTOR Future<bool> shouldBackupManifest(Reference<BlobManagerData> bmData) {
-	bool enabled = wait(BlobGranuleBackupConfig().enabled().getD(SystemDBWriteLockedNow(bmData->db.getReference())));
-	if (!enabled) {
-		TraceEvent("BackupManifestNotEnabled").log();
-		return false;
-	}
-
-	if (bmData->isFullRestoreMode) {
-		return false;
-	}
-
-	auto knownRanges = bmData->knownBlobRanges.intersectingRanges(normalKeys);
-	for (auto& it : knownRanges) {
-		if (it.cvalue()) {
-			return true; // there is at least one active blob range
-		}
-	}
-	TraceEvent("SkipManifestBackup")
-	    .detail("KnownRanges", knownRanges.empty())
-	    .detail("Total", bmData->knownBlobRanges.size());
-	return false;
-}
-
-ACTOR Future<Void> truncateMutationLogs(Reference<BlobManagerData> bmData) {
-	bool shouldBackup = wait(shouldBackupManifest(bmData));
-	if (!shouldBackup) {
+		BlobGranuleBackupConfig config;
+		int64_t epochs = (int64_t)now();
+		config.lastFlushTs().set(tr, epochs);
+		config.lastFlushVersion().set(tr, flushVersion);
 		return Void();
-	}
-	int64_t lastFlushTs = wait(getLastFlushTs(bmData->db));
-	bool shouldFlush = (now() - lastFlushTs) > SERVER_KNOBS->BLOB_RESTORE_MLOGS_RETENTION_SECS;
+	}));
+	return Void();
+}
 
+// Try to flush blob granules. Return the flushed version if it's successful.
+ACTOR Future<Version> maybeFlushGranules(Reference<BlobManagerData> bmData) {
+	state BlobGranuleBackupConfig config;
+	int64_t lastFlushTs = wait(config.lastFlushTs().getD(SystemDBWriteLockedNow(bmData->db.getReference())));
+	bool shouldFlush = lastFlushTs == 0 || (now() - lastFlushTs) > SERVER_KNOBS->BLOB_RESTORE_MLOGS_RETENTION_SECS;
 	if (!shouldFlush) {
 		TraceEvent("SkipBlobGranulesFlush").detail("LastFlushTs", lastFlushTs);
-		return Void();
+		return invalidVersion;
 	}
 
-	state std::string mlogsUrl =
-	    wait(BlobGranuleBackupConfig().mutationLogsUrl().getD(SystemDBWriteLockedNow(bmData->db.getReference())));
+	state std::string mlogsUrl = wait(config.mutationLogsUrl().getD(SystemDBWriteLockedNow(bmData->db.getReference())));
 	state Reference<IBackupContainer> bc = IBackupContainer::openContainer(mlogsUrl, {}, {});
 	state BackupDescription desc = wait(bc->describeBackup());
 	if (!desc.contiguousLogEnd.present()) {
 		TraceEvent("SkipBlobGranulesFlush").detail("LogUrl", mlogsUrl);
-		return Void(); // skip truncation if no valid backup for mutation logs
+		return invalidVersion; // skip truncation if no valid backup for mutation logs
 	}
 	state Version logEndVersion = desc.contiguousLogEnd.get();
 	TraceEvent("DescribedMutationLogs").detail("LogEndVersion", logEndVersion);
@@ -5666,32 +5621,24 @@ ACTOR Future<Void> truncateMutationLogs(Reference<BlobManagerData> bmData) {
 		    success(doBlobGranuleRequests(bmData->db, range, req, &BlobWorkerInterface::flushGranuleRequest));
 		futures.push_back(future);
 		if (futures.size() > SERVER_KNOBS->BLOB_GRANULES_FLUSH_BATCH_SIZE) {
-			waitForAll(futures);
+			wait(waitForAll(futures));
 			futures.clear();
 			TraceEvent("FlushedBlobGranules").detail("Completed", SERVER_KNOBS->BLOB_GRANULES_FLUSH_BATCH_SIZE);
 		}
 	}
-	waitForAll(futures);
-	wait(updateLastFlushTs(bmData->db));
+	wait(waitForAll(futures));
+	wait(updateLastFlushVersion(bmData->db, logEndVersion));
 	bmData->stats.lastFlushVersion = logEndVersion;
 	TraceEvent("FlushedBlobGranules").detail("FlushVersion", logEndVersion);
+	return logEndVersion;
+}
 
-	// Wait for next manifest dumped
-	state int64_t seqNo = bmData->manifestDumperSeqNo;
-	loop {
-		TraceEvent("WaitingBlobManifest").detail("Seq", seqNo);
-		wait(bmData->manifestCompletitionTrigger.onTrigger());
-		if (bmData->manifestDumperSeqNo > seqNo) {
-			TraceEvent("BlobManifestDumped").detail("Seq", bmData->manifestDumperSeqNo);
-			break;
-		}
-	}
-
-	// Truncate mutation logs to max retention period
+// Truncate mutation logs up to (last flush version - max retention period)
+ACTOR Future<Void> truncateMutations(Reference<BlobManagerData> bmData, Version flushVersion) {
 	Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(bmData->db));
-	Optional<int64_t> logEndEpochs = wait(timeKeeperEpochsFromVersion(logEndVersion, tr));
+	Optional<int64_t> logEndEpochs = wait(timeKeeperEpochsFromVersion(flushVersion, tr));
 	if (!logEndEpochs.present()) {
-		TraceEvent("SkipMutationLogTruncation").detail("LogEndVersion", logEndVersion);
+		TraceEvent("SkipMutationLogTruncation").detail("LogEndVersion", flushVersion);
 		return Void(); // skip truncation if no timestamp about log end
 	}
 
@@ -5704,28 +5651,40 @@ ACTOR Future<Void> truncateMutationLogs(Reference<BlobManagerData> bmData) {
 	state std::string timestamp = BackupAgentBase::formatTime(epochs);
 	state Version truncVersion = wait(timeKeeperVersionFromDatetime(timestamp, bmData->db));
 
-	wait(bc->expireData(truncVersion, true));
-	bmData->stats.lastMLogTruncationVersion = truncVersion;
-	TraceEvent("TruncateMutationLogs").detail("Version", truncVersion).detail("Timestamp", timestamp);
-	CODE_PROBE(true, "Flush blob granules and truncate mutation logs");
+	if (truncVersion > 0) {
+		state std::string mlogsUrl =
+		    wait(BlobGranuleBackupConfig().mutationLogsUrl().getD(SystemDBWriteLockedNow(bmData->db.getReference())));
+		state Reference<IBackupContainer> bc = IBackupContainer::openContainer(mlogsUrl, {}, {});
+		wait(bc->expireData(truncVersion, true));
+		bmData->stats.lastMLogTruncationVersion = truncVersion;
+		TraceEvent("TruncateMutationLogs").detail("Version", truncVersion).detail("Timestamp", timestamp);
+		CODE_PROBE(true, "Flush blob granules and truncate mutation logs");
+	}
 	return Void();
 }
 
-ACTOR Future<Void> truncateMutationLogsLoop(Reference<BlobManagerData> bmData) {
-	loop {
-		try {
-			wait(truncateMutationLogs(bmData));
-		} catch (Error& e) {
-			if (e.code() == error_code_operation_cancelled) {
-				throw;
-			}
-			TraceEvent("TruncateMutationLogsError").error(e); // skip and retry next time
-		}
-		wait(delay(SERVER_KNOBS->BLOB_MANIFEST_BACKUP_INTERVAL));
-	}
+// Dump manifest to external blob storage
+ACTOR Future<Void> backupManifest(Reference<BlobManagerData> bmData) {
+	TraceEvent("BackupManifest").log();
+	auto db = SystemDBWriteLockedNow(bmData->db.getReference());
+	std::string url = wait(BlobGranuleBackupConfig().manifestUrl().getD(db));
+	Reference<BlobConnectionProvider> manifestStore = BlobConnectionProvider::newBlobConnectionProvider(url);
+	int64_t bytes = wait(dumpManifest(bmData->db,
+	                                  bmData->dbInfo,
+	                                  manifestStore,
+	                                  bmData->epoch,
+	                                  bmData->manifestDumperSeqNo,
+	                                  bmData->enableManifestEncryption));
+	bmData->stats.lastManifestSeqNo = bmData->manifestDumperSeqNo;
+	bmData->stats.manifestSizeInBytes += bytes;
+	bmData->stats.lastManifestDumpTs = now();
+	bmData->manifestDumperSeqNo++;
+	bmData->manifestCompletitionTrigger.trigger();
+	return Void();
 }
 
-ACTOR Future<Void> backupManifest(Reference<BlobManagerData> bmData) {
+// Periodically backup manifest
+ACTOR Future<Void> backupManifestLoop(Reference<BlobManagerData> bmData) {
 	bmData->initBStore();
 
 	DatabaseConfiguration config = wait(getDatabaseConfiguration(bmData->db, true));
@@ -5733,30 +5692,105 @@ ACTOR Future<Void> backupManifest(Reference<BlobManagerData> bmData) {
 
 	loop {
 		try {
-			// Skip backup if no active blob ranges
-			bool shouldBackup = wait(shouldBackupManifest(bmData));
-			if (shouldBackup) {
-				TraceEvent("BackupManifest").log();
-				auto db = SystemDBWriteLockedNow(bmData->db.getReference());
-				std::string url = wait(BlobGranuleBackupConfig().manifestUrl().getD(db));
-				Reference<BlobConnectionProvider> manifestStore =
-				    BlobConnectionProvider::newBlobConnectionProvider(url);
-				int64_t bytes = wait(dumpManifest(bmData->db,
-				                                  bmData->dbInfo,
-				                                  manifestStore,
-				                                  bmData->epoch,
-				                                  bmData->manifestDumperSeqNo,
-				                                  bmData->enableManifestEncryption));
-				bmData->stats.lastManifestSeqNo = bmData->manifestDumperSeqNo;
-				bmData->stats.manifestSizeInBytes += bytes;
-				bmData->stats.lastManifestDumpTs = now();
-				bmData->manifestDumperSeqNo++;
-				bmData->manifestCompletitionTrigger.trigger();
+			bool enabled =
+			    wait(BlobGranuleBackupConfig().enabled().getD(SystemDBWriteLockedNow(bmData->db.getReference())));
+			if (!enabled) {
+				TraceEvent("BackupManifestLoopExit").log();
+				bmData->stats.lastFlushVersion = 0;
+				bmData->stats.lastManifestDumpTs = 0;
+				return Void();
 			}
+			wait(backupManifest(bmData));
 		} catch (Error& e) {
+			if (e.code() == error_code_operation_cancelled) {
+				throw;
+			}
 			TraceEvent("BackupManifestError").error(e);
 		}
-		wait(delay(SERVER_KNOBS->BLOB_MANIFEST_BACKUP_INTERVAL));
+		wait(delay(SERVER_KNOBS->BLOB_MANIFEST_BACKUP_INTERVAL) || bmData->backupTrigger.onTrigger());
+	}
+}
+
+// Periodically flush granules and truncate mutation logs
+ACTOR Future<Void> truncateMutationsLoop(Reference<BlobManagerData> bmData) {
+	loop {
+		try {
+			bool enabled =
+			    wait(BlobGranuleBackupConfig().enabled().getD(SystemDBWriteLockedNow(bmData->db.getReference())));
+			if (!enabled) {
+				TraceEvent("TruncateMutationLogsLoopExit").log();
+				return Void();
+			}
+
+			// Try flush blob granules
+			state Version lastFlushVersion = wait(maybeFlushGranules(bmData));
+			if (lastFlushVersion != invalidVersion) {
+				// Wait for next manifest dumped
+				state int64_t seqNo = bmData->manifestDumperSeqNo;
+				bmData->backupTrigger.trigger();
+				loop {
+					TraceEvent("WaitingBlobManifest").detail("Seq", seqNo);
+					if (bmData->manifestDumperSeqNo > seqNo) {
+						TraceEvent("BlobManifestDumped").detail("Seq", bmData->manifestDumperSeqNo);
+						break;
+					}
+					wait(bmData->manifestCompletitionTrigger.onTrigger());
+				}
+				// Truncate mutations up to lastFlushVersion -
+				wait(truncateMutations(bmData, lastFlushVersion));
+			}
+		} catch (Error& e) {
+			if (e.code() == error_code_operation_cancelled) {
+				throw;
+			}
+			TraceEvent("TruncateMutationsError").error(e); // skip and retry next time
+		}
+		wait(delay(SERVER_KNOBS->BLOB_MANIFEST_BACKUP_INTERVAL) || bmData->backupTrigger.onTrigger());
+	}
+}
+
+// Watch BlobGranuleBackupConfig to start or stop manifest backup actors.
+ACTOR Future<Void> watchBackupEnabled(Reference<BlobManagerData> bmData) {
+	state Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(bmData->db));
+	state bool prevState = false; // save the last state so we don't have to initialize twice
+	loop {
+		try {
+			tr->setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
+			tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+			tr->setOption(FDBTransactionOptions::LOCK_AWARE);
+
+			state bool enabled = wait(BlobGranuleBackupConfig().enabled().getD(tr));
+			TraceEvent("WatchBackupEnabled").detail("Enabled", enabled);
+			if (enabled && !prevState) { // only initialize once
+				int64_t lastFlushTs = wait(BlobGranuleBackupConfig().lastFlushTs().getD(tr));
+				if (lastFlushTs == 0) {
+					TraceEvent("StartInitialFlush").log();
+					loop {
+						Version lastFlushVersion = wait(maybeFlushGranules(bmData));
+						if (lastFlushVersion != invalidVersion) {
+							TraceEvent("CompleteInitialFlush").detail("Version", lastFlushVersion);
+							break;
+						}
+						wait(delay(5));
+					}
+				}
+				bmData->addActor.send(backupManifestLoop(bmData));
+				bmData->addActor.send(truncateMutationsLoop(bmData));
+			} else {
+				bmData->backupTrigger.trigger(); // notify backup loops to exit
+			}
+			prevState = enabled;
+
+			state Future<Void> watch = BlobGranuleBackupConfig().trigger.watch(tr);
+			wait(tr->commit());
+			wait(watch);
+			tr->reset();
+		} catch (Error& e) {
+			if (e.code() == error_code_operation_cancelled) {
+				throw;
+			}
+			wait(tr->onError(e));
+		}
 	}
 }
 
@@ -5850,12 +5884,12 @@ ACTOR Future<Void> blobManager(BlobManagerInterface bmInterf,
 		if (SERVER_KNOBS->BG_ENABLE_MERGING) {
 			self->addActor.send(granuleMergeChecker(self));
 		}
-		self->addActor.send(backupManifest(self));
-		self->addActor.send(truncateMutationLogsLoop(self));
 
 		if (BUGGIFY && !self->isFullRestoreMode) {
 			self->addActor.send(chaosRangeMover(self));
 		}
+
+		self->addActor.send(watchBackupEnabled(self));
 
 		loop choose {
 			when(wait(self->iAmReplaced.getFuture())) {

--- a/fdbserver/BlobManifest.actor.cpp
+++ b/fdbserver/BlobManifest.actor.cpp
@@ -175,6 +175,9 @@ public:
 			// return the manifest if it's valid
 			BlobManifest manifest(result);
 			if (manifest.isValid()) {
+				TraceEvent("BlobRestoreManifest")
+				    .detail("FileName", firstFile.fileName)
+				    .detail("Count", manifest.totalSegments());
 				return manifest;
 			} else {
 				dprint("Skip corrupted manifest {} {}\n", firstFile.epoch, firstFile.seqNo);
@@ -449,12 +452,13 @@ private:
 
 				// last flush for in-memory data
 				wait(BlobManifestFileSplitter::close(splitter));
-				TraceEvent("BlobManfiestDump")
+				TraceEvent("BlobManifestDump")
 				    .detail("Size", splitter->totalBytes())
-				    .detail("Encrypted", self->encryptionEnabled_);
+				    .detail("Encrypted", self->encryptionEnabled_)
+				    .detail("Version", readVersion);
 				return splitter->totalBytes();
 			} catch (Error& e) {
-				TraceEvent("BlobManfiestDumpError").error(e).log();
+				TraceEvent("BlobManifestDumpError").error(e).log();
 				dprint("Manifest dumping error {}\n", e.what());
 				wait(BlobManifestFileSplitter::reset(splitter));
 				// wait to avoid spinning
@@ -472,6 +476,14 @@ private:
 			tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 			tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
 			tr.setOption(FDBTransactionOptions::LOCK_AWARE);
+
+			state Version readVersion = wait(tr.getReadVersion());
+			int64_t lastFlushVersion = wait(BlobGranuleBackupConfig().lastFlushVersion().getD(&tr));
+			if (readVersion < lastFlushVersion) {
+				wait(delay(FLOW_KNOBS->PREVENT_FAST_SPIN_DELAY));
+				throw blob_granule_transaction_too_old();
+			}
+
 			for (auto range : ranges) {
 				try {
 					state PromiseStream<RangeResult> rows;
@@ -487,7 +499,7 @@ private:
 					throw;
 				}
 			}
-			Version readVersion = wait(tr.getReadVersion());
+
 			Value versionEncoded = BinaryWriter::toValue(readVersion, Unversioned());
 			splitter->append(KeyValueRef(blobManifestVersionKey, versionEncoded));
 			return readVersion;

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -2409,7 +2409,6 @@ ACTOR Future<Void> watchBlobRestoreCommand(ClusterControllerData* self) {
 					}
 				} else {
 					TraceEvent("SkipBlobRestoreInitCommand", self->id).log();
-					wait(BlobRestoreController::setError(restoreController, "Blob granules should be enabled first"));
 				}
 			}
 			self->db.blobRestoreEnabled.set(phase > BlobRestorePhase::UNINIT && phase < BlobRestorePhase::DONE);

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -2460,10 +2460,15 @@ ACTOR static Future<JsonBuilderObject> blobGranulesStatusFetcher(
 			Optional<TraceEventFields> fields = wait(timeoutError(
 			    latestEventOnWorker(addressWorkersMap[managerIntf.get().address()], "BlobManagerMetrics"), 2.0));
 			if (fields.present()) {
-				statusObj["last_manifest_dump_ts"] = fields.get().getUint64("LastManifestDumpTs");
-				statusObj["last_manifest_seq_no"] = fields.get().getUint64("LastManifestSeqNo");
-				statusObj["last_manifest_epoch"] = fields.get().getUint64("Epoch");
-				statusObj["last_manifest_size_in_bytes"] = fields.get().getUint64("ManifestSizeInBytes");
+				int64_t lastFlushVersion = fields.get().getUint64("LastFlushVersion");
+				if (lastFlushVersion > 0) {
+					statusObj["last_flush_version"] = fields.get().getUint64("LastFlushVersion");
+					statusObj["last_manifest_dump_ts"] = fields.get().getUint64("LastManifestDumpTs");
+					statusObj["last_manifest_seq_no"] = fields.get().getUint64("LastManifestSeqNo");
+					statusObj["last_manifest_epoch"] = fields.get().getUint64("Epoch");
+					statusObj["last_manifest_size_in_bytes"] = fields.get().getUint64("ManifestSizeInBytes");
+					statusObj["last_truncation_version"] = fields.get().getUint64("LastMLogTruncationVersion");
+				}
 			}
 		}
 

--- a/fdbserver/workloads/BlobRestoreWorkload.actor.cpp
+++ b/fdbserver/workloads/BlobRestoreWorkload.actor.cpp
@@ -206,7 +206,7 @@ struct BlobRestoreWorkload : TestWorkload {
 			}
 			// TODO need to define more specific error handling
 			if (phase == BlobRestorePhase::ERROR) {
-				auto db = SystemDBWriteLockedNow(cx.getReference());
+				auto db = SystemDBWriteLockedNow(self->extraDb_.getReference());
 				std::string error = wait(BlobGranuleRestoreConfig().error().getD(db));
 				fmt::print("Unexpected restore error code = {}\n", error);
 				return Void();


### PR DESCRIPTION
Cherry-Pick of #10505

Original Description:

This PR includes the following changes:
1. Remove blobGranulesLastFlushKey and add lastFlushTs and lastFlushVersion to BlobGranuleBackupConfig.
2. Make BlobGranuleBackupConfig::enabled() as a trigger to trigger backups. watchBackupEnabled() is added to watch this flag and start/stop backup loops
3. refactor backupManifest loop and truncationMutations loop.

100k correctness 20230616-025543-huliu-f1ed2d71d896a3af

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
