### PR TITLE
Support restoring a cluster with a tenant in the error state

### DIFF
--- a/fdbcli/TenantCommands.actor.cpp
+++ b/fdbcli/TenantCommands.actor.cpp
@@ -59,7 +59,7 @@ parseTenantConfiguration(std::vector<StringRef> const& tokens, int startIndex, i
 			}
 			param = tokens[tokenNum];
 		} else {
-			bool foundEquals;
+			bool foundEquals = false;
 			param = token.eat("=", &foundEquals);
 			if (!foundEquals) {
 				fmt::print(stderr,
@@ -79,6 +79,15 @@ parseTenantConfiguration(std::vector<StringRef> const& tokens, int startIndex, i
 		if (tokencmp(param, "tenant_group")) {
 			configParams[param] = value;
 		} else if (tokencmp(param, "assigned_cluster")) {
+			configParams[param] = value;
+		} else if (tokencmp(param, "tenant_state")) {
+			if (!value.present() ||
+			    value.compare(metacluster::tenantStateToString(metacluster::TenantState::READY)) != 0) {
+				fmt::print(stderr,
+				           "ERROR: only support setting tenant state back to `ready', but `{}' given.\n",
+				           value.present() ? value.get().toString().c_str() : "null");
+				return {};
+			}
 			configParams[param] = value;
 		} else {
 			fmt::print(stderr, "ERROR: unrecognized configuration parameter `{}'.\n", param.toString().c_str());

--- a/fdbserver/workloads/MetaclusterRestoreWorkload.actor.cpp
+++ b/fdbserver/workloads/MetaclusterRestoreWorkload.actor.cpp
@@ -1156,6 +1156,7 @@ struct MetaclusterRestoreWorkload : TestWorkload {
 		// restore should be present after the restore. All tenants in the management cluster should be unchanged except
 		// for those tenants that were created after the backup and lost during the restore, which will be marked in an
 		// error state.
+		state std::set<TenantName> tenantsInErrorState;
 		for (auto const& [tenantId, tenantEntry] : self->managementTenantsBeforeRestore) {
 			auto itr = tenantMap.find(tenantId);
 			ASSERT(itr != tenantMap.end());
@@ -1165,6 +1166,7 @@ struct MetaclusterRestoreWorkload : TestWorkload {
 				ASSERT(self->dataDbs[itr->second.assignedCluster].restored);
 				postRecoveryEntry.tenantState = tenantEntry.tenantState;
 				postRecoveryEntry.error.clear();
+				tenantsInErrorState.emplace(itr->second.tenantName);
 			}
 
 			ASSERT(tenantEntry == postRecoveryEntry);
@@ -1205,6 +1207,27 @@ struct MetaclusterRestoreWorkload : TestWorkload {
 				ASSERT(self->deletedTenants.count(tenantId));
 				ASSERT(self->recoverManagementCluster);
 				ASSERT(self->recoverDataClusters);
+			}
+		}
+
+		if (!tenantsInErrorState.empty()) {
+			CODE_PROBE(true, "One or more tenants in ERROR state");
+			std::vector<Future<Void>> resetErrorFutures;
+			for (const auto& tenantName : tenantsInErrorState) {
+				resetErrorFutures.emplace_back(metacluster::resetTenantStateToReady(self->managementDb, tenantName));
+			}
+			wait(waitForAll(resetErrorFutures));
+			KeyBackedRangeResult<std::pair<int64_t, metacluster::MetaclusterTenantMapEntry>> _tenants =
+			    wait(runTransaction(self->managementDb, [](Reference<ITransaction> tr) {
+				    tr->setOption(FDBTransactionOptions::RAW_ACCESS);
+				    return metacluster::metadata::management::tenantMetadata().tenantMap.getRange(
+				        tr, {}, {}, CLIENT_KNOBS->MAX_TENANTS_PER_CLUSTER + 1);
+			    }));
+			for (const auto& [tenantId, tenantEntry] : _tenants.results) {
+				ASSERT(tenantEntry.tenantState != metacluster::TenantState::ERROR);
+				if (tenantsInErrorState.contains(tenantEntry.tenantName)) {
+					ASSERT_EQ(metacluster::TenantState::READY, tenantEntry.tenantState);
+				}
 			}
 		}
 

--- a/metacluster/include/metacluster/ConfigureTenant.actor.h
+++ b/metacluster/include/metacluster/ConfigureTenant.actor.h
@@ -233,6 +233,11 @@ struct ConfigureTenantImpl {
 			return Void();
 		}
 
+		if (self->updatedEntry.toTenantMapEntry() == tenantEntry) {
+			// No update to write to data cluster, just return.
+			return Void();
+		}
+
 		wait(TenantAPI::configureTenantTransaction(tr, tenantEntry.get(), self->updatedEntry.toTenantMapEntry()));
 		return Void();
 	}
@@ -243,7 +248,7 @@ struct ConfigureTenantImpl {
 		state Optional<MetaclusterTenantMapEntry> tenantEntry =
 		    wait(tryGetTenantTransaction(tr, self->updatedEntry.id));
 
-		if (!tenantEntry.present() || tenantEntry.get().tenantState != TenantState::UPDATING_CONFIGURATION ||
+		if (!tenantEntry.present() || (tenantEntry.get().tenantState != TenantState::UPDATING_CONFIGURATION) ||
 		    tenantEntry.get().configurationSequenceNum > self->updatedEntry.configurationSequenceNum) {
 			CODE_PROBE(!tenantEntry.present(), "Tenant removed while configuring on management cluster");
 			CODE_PROBE(tenantEntry.present(), "Tenant configuration already applied on management cluster");
@@ -256,7 +261,52 @@ struct ConfigureTenantImpl {
 		return Void();
 	}
 
+	ACTOR static Future<Void> forceMarkManagementTenantAsReady(ConfigureTenantImpl* self,
+	                                                           Reference<typename DB::TransactionT> tr) {
+		state Optional<MetaclusterTenantMapEntry> tenantEntry = wait(tryGetTenantTransaction(tr, self->tenantName));
+
+		if (!tenantEntry.present()) {
+			CODE_PROBE(true, "Configure tenant state for non-existent tenant");
+			throw tenant_not_found();
+		}
+
+		if (tenantEntry.get().tenantState == metacluster::TenantState::READY) {
+			// We may reach here due to retry after getting `commit_unknown_result`.
+			// No work to do, just return
+			return Void();
+		} else if (tenantEntry.get().tenantState != metacluster::TenantState::ERROR) {
+			TraceEvent(SevError, "TenantStateNotError")
+			    .detail("Tenant", self->tenantName)
+			    .detail("State", tenantEntry.get().tenantState);
+			throw invalid_tenant_state();
+		}
+		self->updatedEntry = tenantEntry.get();
+		self->updatedEntry.tenantState = metacluster::TenantState::READY;
+		metadata::management::tenantMetadata().tenantMap.set(tr, self->updatedEntry.id, self->updatedEntry);
+		metadata::management::tenantMetadata().lastTenantModification.setVersionstamp(tr, Versionstamp(), 0);
+
+		return Void();
+	}
+
 	ACTOR static Future<Void> run(ConfigureTenantImpl* self) {
+		// Check whether we are setting tenant state and other properties together.
+		// If so, throw
+		state std::map<Standalone<StringRef>, Optional<Value>> parameters = self->configurationParameters;
+		for (const auto& [configKey, configValue] : parameters) {
+			if (configKey == "tenant_state"_sr) {
+				if (self->configurationParameters.size() > 1) {
+					CODE_PROBE(true, "SettingTenantStateWithOtherConfigs", probe::decoration::rare);
+					TraceEvent(SevError, "ConfigureTenantStateWithOtherProperties").detail("Tenant", self->tenantName);
+					throw invalid_tenant_configuration();
+				} else {
+					wait(self->ctx.runManagementTransaction([self = self](Reference<typename DB::TransactionT> tr) {
+						return forceMarkManagementTenantAsReady(self, tr);
+					}));
+					return Void();
+				}
+			}
+		}
+
 		bool configUpdated = wait(self->ctx.runManagementTransaction(
 		    [self = self](Reference<typename DB::TransactionT> tr) { return updateManagementCluster(self, tr); }));
 
@@ -290,6 +340,18 @@ Future<Void> changeTenantLockState(Reference<DB> db,
                                    TenantAPI::TenantLockState lockState,
                                    UID lockId) {
 	state internal::ConfigureTenantImpl<DB> impl(db, name, lockState, lockId);
+	wait(impl.run());
+	return Void();
+}
+
+ACTOR template <class DB>
+Future<Void> resetTenantStateToReady(Reference<DB> db, TenantName name) {
+	state internal::ConfigureTenantImpl<DB> impl(
+	    db,
+	    name,
+	    std::map<Standalone<StringRef>, Optional<Value>>{
+	        { "tenant_state"_sr, metacluster::tenantStateToString(metacluster::TenantState::READY) } },
+	    IgnoreCapacityLimit::False);
 	wait(impl.run());
 	return Void();
 }

--- a/metacluster/include/metacluster/RestoreCluster.actor.h
+++ b/metacluster/include/metacluster/RestoreCluster.actor.h
@@ -386,7 +386,6 @@ struct RestoreClusterImpl {
 		state KeyBackedRangeResult<std::pair<int64_t, MetaclusterTenantMapEntry>> tenants =
 		    wait(metadata::management::tenantMetadata().tenantMap.getRange(
 		        tr, initialTenantId, {}, CLIENT_KNOBS->MAX_TENANTS_PER_CLUSTER));
-
 		for (auto const& t : tenants.results) {
 			self->mgmtClusterTenantMap.emplace(t.first, t.second);
 			if (self->clusterName == t.second.assignedCluster) {
@@ -1023,7 +1022,9 @@ struct RestoreClusterImpl {
 			// set restored cluster to ready state
 			wait(self->ctx.runManagementTransaction(
 			    [self = self](Reference<typename DB::TransactionT> tr) { return self->markClusterAsReady(tr); }));
-			TraceEvent("MetaclusterRepopulatedFromDataCluster").detail("Name", self->clusterName);
+			TraceEvent("MetaclusterRepopulatedFromDataCluster")
+			    .detail("Name", self->clusterName)
+			    .detail("RestoreId", self->restoreId);
 		}
 
 		return Void();


### PR DESCRIPTION
If we restore a cluster and a previously created tenant was not included in the backup, then the tenant will be marked in an error state on the management cluster. It is then up to the operator to resolve the error, generally by deleting the tenant and recreating it if needed.

There is, however, the possibility that we restored a backup that was older than we wanted, and a newer backup would have the tenant. If we tried to restore the newer backup, it would not leave the previously missing tenant in a fully usable state.

We need to have a way to deal with this case. One option is to allow us to clear the error state of a tenant, and that can be performed before (or maybe even after) the second restore.

Test plan:
Joshua test
100K ensemble: 20230616-053206-yajin-c88e5c9fabb9b272 fail=2, but the errors are not related.

Replace this text with your description here...

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
