### PR TITLE
[snowflake/release-71.3] fix per-scan-loop throttling to properly throttle in the loop

### DIFF
--- a/fdbserver/ConsistencyScan.actor.cpp
+++ b/fdbserver/ConsistencyScan.actor.cpp
@@ -868,6 +868,8 @@ ACTOR Future<Void> consistencyScanCore(Database db,
 								}
 							}
 
+							// throttle always includes replicated bytes read in total read bytes for throttling
+							totalReadBytesFromStorageServers += replicatedBytesReadThisLoop;
 							if (!failedRequest.present() && !newErrors) {
 								ASSERT(firstValidServer.present());
 								GetKeyValuesReply rangeResult = keyValueFutures[firstValidServer.get()].get().get();
@@ -926,7 +928,7 @@ ACTOR Future<Void> consistencyScanCore(Database db,
 								ASSERT(failedRequest.get().code() != error_code_operation_cancelled);
 								// don't include replicated bytes this loop in metrics to avoid getting replication
 								// factor wrong, but make sure we stil throttle based on it
-								totalReadBytesFromStorageServers += replicatedBytesReadThisLoop + 100000;
+								totalReadBytesFromStorageServers += 100000;
 								break;
 							}
 
@@ -953,7 +955,6 @@ ACTOR Future<Void> consistencyScanCore(Database db,
 						memState->stats.logicalBytesScanned += logicalBytesRead;
 						memState->stats.replicatedBytesRead += replicatedBytesRead;
 
-						totalReadBytesFromStorageServers += replicatedBytesRead;
 						if (DEBUG_SCAN_PROGRESS) {
 							TraceEvent(SevDebug, "ConsistencyScanProgressScanRangeEnd", memState->csId)
 							    .detail("BytesRead", logicalBytesRead)


### PR DESCRIPTION
Cherry-pick #10502 

100k correctness: 20230615-193302-jslocum-b0aa9db2f4402b8e: 0 failures

Did manual testing to confirm throttling worked as expected

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
