### PR TITLE
fix flushing empty range (Cherry-Pick #10508 to snowflake/release-71.3)

### DIFF
--- a/fdbserver/BlobGranuleValidation.actor.cpp
+++ b/fdbserver/BlobGranuleValidation.actor.cpp
@@ -383,16 +383,17 @@ ACTOR Future<Void> validateForceFlushing(Database cx,
 
 				// client req may not exactly align to granules - buggify this behavior
 				if (BUGGIFY_WITH_PROB(0.1)) {
-					if (deterministicRandom()->coinflip()) {
-						startKey = keyAfter(startKey);
-					}
 					// extend end (if there are granules in that space)
 					if (targetStart + targetRanges < granules.size() && deterministicRandom()->coinflip()) {
 						endKey = keyAfter(endKey);
 					}
+					if (deterministicRandom()->coinflip() && keyAfter(startKey) < endKey) {
+						startKey = keyAfter(startKey);
+					}
 				}
 
 				toFlush = KeyRangeRef(startKey, endKey);
+				ASSERT(!toFlush.empty());
 			}
 
 			break;


### PR DESCRIPTION
Cherry-Pick of #10508

100k correctness: 20230616-160242-jslocum-29ee66ea5c3d8951 : 1 failure
  (GetMappedRange which is not a feature we use and also cannot be caused by this change)
50k blob granule correctness: 0 failures

Original Description:

Buggified code could create an empty range if a test was using variable length null strings as keys.
Fixed it to check for this before flushing.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
