### PR TITLE
Fixed compiling foundationdb with the clang 17 compiler

### DIFF
--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -913,7 +913,7 @@ ACTOR Future<Void> clearData(Database cx, Optional<TenantName> defaultTenant) {
 
 			std::vector<Future<Void>> deleteFutures;
 			for (auto const& [id, entry] : tenants.results) {
-				if (entry.tenantName != defaultTenant) {
+				if (!defaultTenant.present() || entry.tenantName != defaultTenant.get()) {
 					deleteFutures.push_back(TenantAPI::deleteTenantTransaction(&tr, id));
 				}
 			}

--- a/fdbserver/workloads/DcLag.actor.cpp
+++ b/fdbserver/workloads/DcLag.actor.cpp
@@ -75,8 +75,8 @@ struct DcLagWorkload : TestWorkload {
 		std::vector<IPAddress> ips; // all remote process IPs
 		for (const auto& process : g_simulator->getAllProcesses()) {
 			const auto& ip = process->address.ip;
-			if (process->locality.dcId().present() && g_simulator->remoteDcId.present() &&
-			    process->locality.dcId().get() == g_simulator->remoteDcId.get()) {
+			if (process->locality.dcId().present() && 
+			    process->locality.dcId() == g_simulator->remoteDcId) {
 				ips.push_back(ip);
 			}
 		}

--- a/fdbserver/workloads/DcLag.actor.cpp
+++ b/fdbserver/workloads/DcLag.actor.cpp
@@ -75,7 +75,8 @@ struct DcLagWorkload : TestWorkload {
 		std::vector<IPAddress> ips; // all remote process IPs
 		for (const auto& process : g_simulator->getAllProcesses()) {
 			const auto& ip = process->address.ip;
-			if (process->locality.dcId().present() && process->locality.dcId().get() == g_simulator->remoteDcId) {
+			if (process->locality.dcId().present() && g_simulator->remoteDcId.present() &&
+			    process->locality.dcId().get() == g_simulator->remoteDcId.get()) {
 				ips.push_back(ip);
 			}
 		}

--- a/fdbserver/workloads/DcLag.actor.cpp
+++ b/fdbserver/workloads/DcLag.actor.cpp
@@ -75,8 +75,7 @@ struct DcLagWorkload : TestWorkload {
 		std::vector<IPAddress> ips; // all remote process IPs
 		for (const auto& process : g_simulator->getAllProcesses()) {
 			const auto& ip = process->address.ip;
-			if (process->locality.dcId().present() && 
-			    process->locality.dcId() == g_simulator->remoteDcId) {
+			if (process->locality.dcId().present() && process->locality.dcId() == g_simulator->remoteDcId) {
 				ips.push_back(ip);
 			}
 		}

--- a/fdbserver/workloads/GcGenerations.actor.cpp
+++ b/fdbserver/workloads/GcGenerations.actor.cpp
@@ -97,8 +97,8 @@ struct GcGenerationsWorkload : TestWorkload {
 		std::vector<IPAddress> remoteIps; // all remote process IPs
 		for (const auto& process : g_simulator->getAllProcesses()) {
 			const auto& ip = process->address.ip;
-			if (process->locality.dcId().present() && 
-			    process->locality.dcId() == g_simulator->remoteDcId && !isCoordinator(coordinators, ip)) {
+			if (process->locality.dcId().present() && process->locality.dcId() == g_simulator->remoteDcId &&
+			    !isCoordinator(coordinators, ip)) {
 				remoteIps.push_back(ip);
 			} else {
 				ips.push_back(ip);

--- a/fdbserver/workloads/GcGenerations.actor.cpp
+++ b/fdbserver/workloads/GcGenerations.actor.cpp
@@ -97,8 +97,8 @@ struct GcGenerationsWorkload : TestWorkload {
 		std::vector<IPAddress> remoteIps; // all remote process IPs
 		for (const auto& process : g_simulator->getAllProcesses()) {
 			const auto& ip = process->address.ip;
-			if (process->locality.dcId().present() && process->locality.dcId().get() == g_simulator->remoteDcId &&
-			    !isCoordinator(coordinators, ip)) {
+			if (process->locality.dcId().present() && g_simulator->remoteDcId.present() &&
+			    process->locality.dcId().get() == g_simulator->remoteDcId.get() && !isCoordinator(coordinators, ip)) {
 				remoteIps.push_back(ip);
 			} else {
 				ips.push_back(ip);

--- a/fdbserver/workloads/GcGenerations.actor.cpp
+++ b/fdbserver/workloads/GcGenerations.actor.cpp
@@ -97,8 +97,8 @@ struct GcGenerationsWorkload : TestWorkload {
 		std::vector<IPAddress> remoteIps; // all remote process IPs
 		for (const auto& process : g_simulator->getAllProcesses()) {
 			const auto& ip = process->address.ip;
-			if (process->locality.dcId().present() && g_simulator->remoteDcId.present() &&
-			    process->locality.dcId().get() == g_simulator->remoteDcId.get() && !isCoordinator(coordinators, ip)) {
+			if (process->locality.dcId().present() && 
+			    process->locality.dcId() == g_simulator->remoteDcId && !isCoordinator(coordinators, ip)) {
 				remoteIps.push_back(ip);
 			} else {
 				ips.push_back(ip);

--- a/metacluster/include/metacluster/ConfigureTenant.actor.h
+++ b/metacluster/include/metacluster/ConfigureTenant.actor.h
@@ -233,7 +233,7 @@ struct ConfigureTenantImpl {
 			return Void();
 		}
 
-		if (tenantEntry.present() && self->updatedEntry.toTenantMapEntry() == tenantEntry.get()) {
+		if (self->updatedEntry.toTenantMapEntry() == tenantEntry.get()) {
 			// No update to write to data cluster, just return.
 			return Void();
 		}

--- a/metacluster/include/metacluster/ConfigureTenant.actor.h
+++ b/metacluster/include/metacluster/ConfigureTenant.actor.h
@@ -233,7 +233,7 @@ struct ConfigureTenantImpl {
 			return Void();
 		}
 
-		if (self->updatedEntry.toTenantMapEntry() == tenantEntry) {
+		if (tenantEntry.present() && self->updatedEntry.toTenantMapEntry() == tenantEntry.get()) {
 			// No update to write to data cluster, just return.
 			return Void();
 		}

--- a/metacluster/include/metacluster/MetaclusterConsistency.actor.h
+++ b/metacluster/include/metacluster/MetaclusterConsistency.actor.h
@@ -213,12 +213,13 @@ private:
 			ASSERT_EQ(data.metaclusterRegistration.get().version, managementData.metaclusterRegistration.get().version);
 
 			if (data.tenantData.lastTenantId >= 0) {
-				ASSERT_EQ(TenantAPI::getTenantIdPrefix(data.tenantData.lastTenantId), managementData.tenantIdPrefix);
+				ASSERT_EQ(TenantAPI::getTenantIdPrefix(data.tenantData.lastTenantId),
+				          managementData.tenantIdPrefix.get());
 				ASSERT_LE(data.tenantData.lastTenantId, managementData.tenantData.lastTenantId);
 			} else {
 				CODE_PROBE(true, "Data cluster has no tenants with current tenant ID prefix");
 				for (auto const& [id, tenant] : data.tenantData.tenantMap) {
-					ASSERT_NE(TenantAPI::getTenantIdPrefix(id), managementData.tenantIdPrefix);
+					ASSERT_NE(TenantAPI::getTenantIdPrefix(id), managementData.tenantIdPrefix.get());
 				}
 			}
 
@@ -258,7 +259,7 @@ private:
 					ASSERT_EQ(metaclusterEntry.tenantState, TenantState::READY);
 					ASSERT(entry.tenantName == metaclusterEntry.tenantName);
 				} else if (entry.tenantName != metaclusterEntry.tenantName) {
-					ASSERT(entry.tenantName == metaclusterEntry.renameDestination);
+					ASSERT(entry.tenantName == metaclusterEntry.renameDestination.get());
 				}
 				if (metaclusterEntry.tenantState != TenantState::UPDATING_CONFIGURATION &&
 				    metaclusterEntry.tenantState != TenantState::REMOVING) {

--- a/metacluster/include/metacluster/MetaclusterConsistency.actor.h
+++ b/metacluster/include/metacluster/MetaclusterConsistency.actor.h
@@ -259,7 +259,8 @@ private:
 					ASSERT_EQ(metaclusterEntry.tenantState, TenantState::READY);
 					ASSERT(entry.tenantName == metaclusterEntry.tenantName);
 				} else if (entry.tenantName != metaclusterEntry.tenantName) {
-					ASSERT(metaclusterEntry.renameDestination.present() && entry.tenantName == metaclusterEntry.renameDestination.get());
+					ASSERT(metaclusterEntry.renameDestination.present() &&
+					       entry.tenantName == metaclusterEntry.renameDestination.get());
 				}
 				if (metaclusterEntry.tenantState != TenantState::UPDATING_CONFIGURATION &&
 				    metaclusterEntry.tenantState != TenantState::REMOVING) {

--- a/metacluster/include/metacluster/MetaclusterConsistency.actor.h
+++ b/metacluster/include/metacluster/MetaclusterConsistency.actor.h
@@ -259,7 +259,7 @@ private:
 					ASSERT_EQ(metaclusterEntry.tenantState, TenantState::READY);
 					ASSERT(entry.tenantName == metaclusterEntry.tenantName);
 				} else if (entry.tenantName != metaclusterEntry.tenantName) {
-					ASSERT(entry.tenantName == metaclusterEntry.renameDestination.get());
+					ASSERT(metaclusterEntry.renameDestination.present() && entry.tenantName == metaclusterEntry.renameDestination.get());
 				}
 				if (metaclusterEntry.tenantState != TenantState::UPDATING_CONFIGURATION &&
 				    metaclusterEntry.tenantState != TenantState::REMOVING) {


### PR DESCRIPTION
When I'm trying to compile FoundationDb with the clang-17 compiler, I receive some compilation errors.

All of them relate to miscapability of comparing objects of `T` and `Optional<T>` types.

This PR fixed the compilation errors. It adds excplicit calls `Optional::present()` and `Optional::get()` to such comparing.