### PR TITLE
Test use of the metacluster after a restore

### DIFF
--- a/fdbclient/TupleVersionstamp.cpp
+++ b/fdbclient/TupleVersionstamp.cpp
@@ -7,6 +7,14 @@ TupleVersionstamp::TupleVersionstamp(StringRef str) {
 	data = str;
 }
 
+TupleVersionstamp::TupleVersionstamp(int64_t version, uint16_t batchNumber, uint16_t userVersion) {
+	data = makeString(VERSIONSTAMP_TUPLE_SIZE);
+	uint8_t* buf = mutateString(data);
+	*reinterpret_cast<int64_t*>(buf) = bigEndian64(version);
+	*reinterpret_cast<uint16_t*>(buf + sizeof(int64_t)) = bigEndian16(batchNumber);
+	*reinterpret_cast<uint16_t*>(buf + sizeof(int64_t) + sizeof(uint16_t)) = bigEndian16(userVersion);
+}
+
 int16_t TupleVersionstamp::getBatchNumber() const {
 	const uint8_t* begin = data.begin();
 	begin += 8;

--- a/fdbclient/include/fdbclient/KeyBackedTypes.actor.h
+++ b/fdbclient/include/fdbclient/KeyBackedTypes.actor.h
@@ -37,6 +37,7 @@
 #include "fdbclient/FDBTypes.h"
 #include "fdbclient/GenericTransactionHelper.h"
 #include "fdbclient/Subspace.h"
+#include "fdbclient/TupleVersionstamp.h"
 #include "flow/ObjectSerializer.h"
 #include "flow/Platform.h"
 #include "flow/genericactors.actor.h"
@@ -121,6 +122,26 @@ inline Standalone<StringRef> TupleCodec<UID>::pack(UID const& val) {
 template <>
 inline UID TupleCodec<UID>::unpack(Standalone<StringRef> const& val) {
 	return BinaryReader::fromStringRef<UID>(TupleCodec<Standalone<StringRef>>::unpack(val), Unversioned());
+}
+
+template <>
+inline Standalone<StringRef> TupleCodec<TupleVersionstamp>::pack(TupleVersionstamp const& val) {
+	return Tuple::makeTuple(val).pack();
+}
+template <>
+inline TupleVersionstamp TupleCodec<TupleVersionstamp>::unpack(Standalone<StringRef> const& val) {
+	return Tuple::unpack(val).getVersionstamp(0);
+}
+
+template <>
+inline Standalone<StringRef> TupleCodec<Versionstamp>::pack(Versionstamp const& val) {
+	return TupleCodec<TupleVersionstamp>::pack(TupleVersionstamp(val.version, val.batchNumber));
+}
+template <>
+inline Versionstamp TupleCodec<Versionstamp>::unpack(Standalone<StringRef> const& val) {
+	TupleVersionstamp vs = TupleCodec<TupleVersionstamp>::unpack(val);
+	ASSERT(vs.getUserVersion() == 0);
+	return Versionstamp(vs.getVersion(), vs.getBatchNumber());
 }
 
 // This is backward compatible with TupleCodec<Standalone<StringRef>>
@@ -769,6 +790,16 @@ public:
 		Key k = packKey(key);
 		Value v = packValue(val);
 		tr->atomicOp(k, v, type);
+		if (trigger.present()) {
+			trigger->update(tr);
+		}
+	}
+
+	template <class Transaction>
+	void setVersionstamp(Transaction tr, KeyType const& key, ValueType const& val, int offset = 0) {
+		Key k = packKey(key);
+		Value v = packValue(val).withSuffix(StringRef(reinterpret_cast<uint8_t*>(&offset), 4));
+		tr->atomicOp(k, v, MutationRef::SetVersionstampedValue);
 		if (trigger.present()) {
 			trigger->update(tr);
 		}

--- a/fdbclient/include/fdbclient/TenantManagement.actor.h
+++ b/fdbclient/include/fdbclient/TenantManagement.actor.h
@@ -318,8 +318,17 @@ Future<Void> markTenantTombstones(Transaction tr, int64_t tenantId) {
 	// In data clusters, we store a tombstone
 	state Future<KeyBackedRangeResult<int64_t>> latestTombstoneFuture =
 	    TenantMetadata::tenantTombstones().getRange(tr, {}, {}, 1, Snapshot::False, Reverse::True);
+	state Future<int64_t> tenantIdPrefixFuture = TenantMetadata::tenantIdPrefix().getD(tr, Snapshot::False, 0);
 	state Optional<TenantTombstoneCleanupData> cleanupData = wait(TenantMetadata::tombstoneCleanupData().get(tr));
 	state Version transactionReadVersion = wait(safeThreadFutureToFuture(tr->getReadVersion()));
+
+	// If the tenant being deleted has a different tenant ID prefix than the current cluster, then it won't conflict
+	// with any tenant creations. In that case, we do not need to create a tombstone.
+	int64_t tenantIdPrefix = wait(tenantIdPrefixFuture);
+	if (tenantIdPrefix != TenantAPI::getTenantIdPrefix(tenantId)) {
+		CODE_PROBE(true, "Skipping tenant tombstone for tenant with different prefix");
+		return Void();
+	}
 
 	// If it has been long enough since we last cleaned up the tenant tombstones, we do that first
 	if (!cleanupData.present() || cleanupData.get().nextTombstoneEraseVersion <= transactionReadVersion) {

--- a/fdbclient/include/fdbclient/TupleVersionstamp.h
+++ b/fdbclient/include/fdbclient/TupleVersionstamp.h
@@ -28,7 +28,13 @@
 const size_t VERSIONSTAMP_TUPLE_SIZE = 12;
 
 struct TupleVersionstamp {
+	// Version = invalid version, batch/user version = 0
+	static inline const Standalone<StringRef> DEFAULT_VERSIONSTAMP =
+	    "\xff\xff\xff\xff\xff\xff\xff\xff\x00\x00\x00\x00"_sr;
+
+	TupleVersionstamp() : data(DEFAULT_VERSIONSTAMP) {}
 	TupleVersionstamp(StringRef);
+	TupleVersionstamp(int64_t version, uint16_t batchNumber, uint16_t userVersion = 0);
 
 	int64_t getVersion() const;
 	int16_t getBatchNumber() const;

--- a/fdbserver/workloads/MetaclusterManagementConcurrencyWorkload.actor.cpp
+++ b/fdbserver/workloads/MetaclusterManagementConcurrencyWorkload.actor.cpp
@@ -50,9 +50,11 @@ struct MetaclusterManagementConcurrencyWorkload : TestWorkload {
 	std::vector<ClusterName> dataDbIndex;
 
 	double testDuration;
+	bool createMetacluster;
 
 	MetaclusterManagementConcurrencyWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
 		testDuration = getOption(options, "testDuration"_sr, 90.0);
+		createMetacluster = getOption(options, "createMetacluster"_sr, true);
 	}
 
 	Future<Void> setup(Database const& cx) override { return _setup(cx, this); }
@@ -64,7 +66,7 @@ struct MetaclusterManagementConcurrencyWorkload : TestWorkload {
 		               deterministicRandom()->randomInt(TenantAPI::TENANT_ID_PREFIX_MIN_VALUE,
 		                                                TenantAPI::TENANT_ID_PREFIX_MAX_VALUE + 1),
 		               {},
-		               metacluster::util::SkipMetaclusterCreation(self->clientId != 0))));
+		               metacluster::util::SkipMetaclusterCreation(self->clientId != 0 || !self->createMetacluster))));
 
 		ASSERT_GT(self->simMetacluster.dataDbs.size(), 0);
 		for (auto const& [name, db] : self->simMetacluster.dataDbs) {

--- a/fdbserver/workloads/MetaclusterManagementWorkload.actor.cpp
+++ b/fdbserver/workloads/MetaclusterManagementWorkload.actor.cpp
@@ -36,6 +36,7 @@
 #include "flow/IRandom.h"
 #include "flow/ThreadHelper.actor.h"
 #include "flow/flow.h"
+#include "fdbserver/ServerDBInfo.actor.h"
 
 #include "metacluster/Metacluster.h"
 #include "metacluster/MetaclusterConsistency.actor.h"
@@ -100,12 +101,14 @@ struct MetaclusterManagementWorkload : TestWorkload {
 	int64_t tenantIdPrefix = -1;
 	std::set<int64_t> usedPrefixes;
 	double testDuration;
+	bool useExistingMetacluster;
 
 	MetaclusterManagementWorkload(WorkloadContext const& wcx)
 	  : TestWorkload(wcx), metaclusterCreated(deterministicRandom()->coinflip()) {
 		maxTenants = std::min<int>(1e8 - 1, getOption(options, "maxTenants"_sr, 1000));
 		maxTenantGroups = std::min<int>(2 * maxTenants, getOption(options, "maxTenantGroups"_sr, 20));
 		testDuration = getOption(options, "testDuration"_sr, 120.0);
+		useExistingMetacluster = getOption(options, "useExistingMetacluster"_sr, false);
 		allowTenantIdPrefixReuse = deterministicRandom()->coinflip();
 		MetaclusterRegistrationEntry::allowUnsupportedRegistrationWrites = true;
 	}
@@ -127,7 +130,7 @@ struct MetaclusterManagementWorkload : TestWorkload {
 
 	Future<Void> setup(Database const& cx) override {
 		if (clientId == 0) {
-			if (g_network->isSimulated() && BUGGIFY) {
+			if (!useExistingMetacluster && g_network->isSimulated() && BUGGIFY) {
 				IKnobCollection::getMutableGlobalKnobCollection().setKnob(
 				    "max_tenants_per_cluster", KnobValueRef::create(int{ deterministicRandom()->randomInt(20, 100) }));
 			}
@@ -139,28 +142,94 @@ struct MetaclusterManagementWorkload : TestWorkload {
 	ACTOR static Future<Void> _setup(Database cx, MetaclusterManagementWorkload* self) {
 		ASSERT(g_simulator->extraDatabases.size() > 0);
 
-		if (self->metaclusterCreated) {
-			self->tenantIdPrefix = self->generateTenantIdPrefix().get();
-			self->usedPrefixes.insert(self->tenantIdPrefix);
+		if (!self->useExistingMetacluster) {
+			if (self->metaclusterCreated) {
+				self->tenantIdPrefix = self->generateTenantIdPrefix().get();
+				self->usedPrefixes.insert(self->tenantIdPrefix);
+			}
+
+			metacluster::util::SimulatedMetacluster simMetacluster = wait(metacluster::util::createSimulatedMetacluster(
+			    cx,
+			    self->tenantIdPrefix,
+			    Optional<metacluster::DataClusterEntry>(),
+			    metacluster::util::SkipMetaclusterCreation(!self->metaclusterCreated)));
+
+			self->managementDb = simMetacluster.managementDb;
+			for (auto const& [name, db] : simMetacluster.dataDbs) {
+				self->dataDbIndex.push_back(name);
+				self->dataDbs[name] = makeReference<DataClusterData>(db);
+			}
+
+			if (self->metaclusterCreated) {
+				Optional<MetaclusterRegistrationEntry> registration =
+				    wait(metacluster::metadata::metaclusterRegistration().get(self->managementDb));
+				ASSERT(registration.present());
+				self->managementVersion = registration.get().version;
+			}
+		} else {
+			metacluster::util::SimulatedMetacluster simMetacluster = wait(metacluster::util::createSimulatedMetacluster(
+			    cx, {}, {}, metacluster::util::SkipMetaclusterCreation::True));
+			self->managementDb = simMetacluster.managementDb;
+			wait(loadExistingMetacluster(self));
 		}
 
-		metacluster::util::SimulatedMetacluster simMetacluster = wait(metacluster::util::createSimulatedMetacluster(
-		    cx,
-		    self->tenantIdPrefix,
-		    Optional<metacluster::DataClusterEntry>(),
-		    metacluster::util::SkipMetaclusterCreation(!self->metaclusterCreated)));
+		return Void();
+	}
 
-		self->managementDb = simMetacluster.managementDb;
-		for (auto const& [name, db] : simMetacluster.dataDbs) {
+	ACTOR static Future<Void> loadExistingMetacluster(MetaclusterManagementWorkload* self) {
+		state metacluster::util::MetaclusterData<IDatabase> metaclusterData(self->managementDb);
+		wait(metaclusterData.load());
+
+		self->metaclusterCreated = true;
+		self->managementVersion = metaclusterData.managementMetadata.metaclusterRegistration.get().version;
+		self->tenantIdPrefix = metaclusterData.managementMetadata.tenantIdPrefix.get();
+		self->usedPrefixes.insert(self->tenantIdPrefix);
+
+		for (auto const& [name, metadata] : metaclusterData.managementMetadata.dataClusters) {
+			metacluster::util::MetaclusterData<IDatabase>::DataClusterData dataClusterMetadata =
+			    metaclusterData.dataClusterMetadata[name];
+
 			self->dataDbIndex.push_back(name);
-			self->dataDbs[name] = makeReference<DataClusterData>(db);
+			Reference<DataClusterData> dataDb = makeReference<DataClusterData>(
+			    Database::createSimulatedExtraDatabase(metadata.connectionString.toString()));
+			self->dataDbs[name] = dataDb;
+
+			dataDb->registered = true;
+			dataDb->detached = false;
+			dataDb->tenantGroupCapacity = metadata.entry.capacity.numTenantGroups;
+			dataDb->version = dataClusterMetadata.metaclusterRegistration.get().version;
+			dataDb->autoTenantAssignment = metadata.entry.autoTenantAssignment;
+
+			self->totalTenantGroupCapacity +=
+			    std::max(metadata.entry.capacity.numTenantGroups, metadata.entry.allocated.numTenantGroups);
 		}
 
-		if (self->metaclusterCreated) {
-			Optional<MetaclusterRegistrationEntry> registration =
-			    wait(metacluster::metadata::metaclusterRegistration().get(self->managementDb));
-			ASSERT(registration.present());
-			self->managementVersion = registration.get().version;
+		for (auto const& [id, entry] : metaclusterData.managementMetadata.tenantData.tenantMap) {
+			Reference<TenantTestData> tenantData =
+			    makeReference<TenantTestData>(entry.assignedCluster, entry.tenantGroup);
+			self->createdTenants[entry.tenantName] = tenantData;
+
+			Reference<DataClusterData> dataDb = self->dataDbs[entry.assignedCluster];
+			dataDb->tenants[entry.tenantName] = tenantData;
+
+			tenantData->lockId = entry.tenantLockId;
+			tenantData->lockState = entry.tenantLockState;
+
+			if (!entry.tenantGroup.present()) {
+				self->ungroupedTenants.insert(entry.tenantName);
+				dataDb->ungroupedTenants.insert(entry.tenantName);
+			} else {
+				auto itr = self->tenantGroups.find(entry.tenantGroup.get());
+				if (itr == self->tenantGroups.end()) {
+					itr =
+					    self->tenantGroups
+					        .try_emplace(entry.tenantGroup.get(), makeReference<TenantGroupData>(entry.assignedCluster))
+					        .first;
+				}
+				auto tenantGroup = itr->second;
+				tenantGroup->tenants.insert(entry.tenantName);
+				dataDb->tenantGroups[entry.tenantGroup.get()] = tenantGroup;
+			}
 		}
 
 		return Void();
@@ -193,6 +262,14 @@ struct MetaclusterManagementWorkload : TestWorkload {
 		CODE_PROBE(!managementValid, "Management cluster invalid version");
 		CODE_PROBE(!dataValid, "Data cluster invalid version");
 		return managementValid && dataValid;
+	}
+
+	ACTOR static Future<Void> waitForFullyRecovered(MetaclusterManagementWorkload* self) {
+		while (self->dbInfo->get().recoveryState != RecoveryState::FULLY_RECOVERED) {
+			wait(self->dbInfo->onChange());
+		}
+
+		return Void();
 	}
 
 	ACTOR template <class DB>
@@ -262,6 +339,7 @@ struct MetaclusterManagementWorkload : TestWorkload {
 				ASSERT(registrationEntry.present());
 
 				self->managementVersion = registrationEntry.get().version;
+				wait(waitForFullyRecovered(self));
 			} else {
 				ASSERT(self->metaclusterCreated);
 			}
@@ -1571,6 +1649,7 @@ struct MetaclusterManagementWorkload : TestWorkload {
 			if (self->metaclusterCreated) {
 				self->managementVersion = newVersion;
 				wait(self->setMetaclusterVersion(self->managementDb, self->managementVersion));
+				wait(waitForFullyRecovered(self));
 			}
 		} else {
 			ClusterName clusterName = self->chooseClusterName();

--- a/fdbserver/workloads/MetaclusterRestoreWorkload.actor.cpp
+++ b/fdbserver/workloads/MetaclusterRestoreWorkload.actor.cpp
@@ -175,6 +175,7 @@ struct MetaclusterRestoreWorkload : TestWorkload {
 
 	Future<Void> setup(Database const& cx) override {
 		if (clientId == 0) {
+			metacluster::metadata::RestoreId::simAllowUidRestoreId = false;
 			return _setup(cx, this);
 		} else {
 			return Void();
@@ -1229,6 +1230,14 @@ struct MetaclusterRestoreWorkload : TestWorkload {
 					ASSERT_EQ(metacluster::TenantState::READY, tenantEntry.tenantState);
 				}
 			}
+
+			// Delete the former ERROR tenants so that the cluster is in a consistent state for subsequent testing
+			std::vector<Future<Void>> deleteFutures;
+			for (TenantName const& tenantName : tenantsInErrorState) {
+				deleteFutures.push_back(metacluster::deleteTenant(self->managementDb, tenantName));
+			}
+
+			wait(waitForAll(deleteFutures));
 		}
 
 		return Void();
@@ -1254,6 +1263,7 @@ struct MetaclusterRestoreWorkload : TestWorkload {
 		}
 		wait(waitForAll(dataClusterChecks));
 		wait(checkTenants(self));
+
 		return true;
 	}
 

--- a/fdbserver/workloads/TenantManagementConcurrencyWorkload.actor.cpp
+++ b/fdbserver/workloads/TenantManagementConcurrencyWorkload.actor.cpp
@@ -52,6 +52,7 @@ struct TenantManagementConcurrencyWorkload : TestWorkload {
 	double testDuration;
 	bool useMetacluster;
 	bool createMetacluster;
+	bool allowTenantLimitChanges;
 
 	Reference<IDatabase> managementDb;
 	Database standaloneDb;
@@ -61,6 +62,7 @@ struct TenantManagementConcurrencyWorkload : TestWorkload {
 		maxTenantGroups = std::min<int>(2 * maxTenants, getOption(options, "maxTenantGroups"_sr, 20));
 		testDuration = getOption(options, "testDuration"_sr, 120.0);
 		createMetacluster = getOption(options, "createMetacluster"_sr, true);
+		allowTenantLimitChanges = getOption(options, "allowTenantLimitChanges"_sr, true);
 
 		if (hasOption(options, "useMetacluster"_sr)) {
 			useMetacluster = getOption(options, "useMetacluster"_sr, false);
@@ -94,7 +96,7 @@ struct TenantManagementConcurrencyWorkload : TestWorkload {
 	};
 
 	Future<Void> setup(Database const& cx) override {
-		if (clientId == 0 && g_network->isSimulated() && BUGGIFY) {
+		if (allowTenantLimitChanges && clientId == 0 && g_network->isSimulated() && BUGGIFY) {
 			IKnobCollection::getMutableGlobalKnobCollection().setKnob(
 			    "max_tenants_per_cluster", KnobValueRef::create(int{ deterministicRandom()->randomInt(20, 100) }));
 		}

--- a/metacluster/include/metacluster/MetaclusterConsistency.actor.h
+++ b/metacluster/include/metacluster/MetaclusterConsistency.actor.h
@@ -82,6 +82,7 @@ private:
 		       data.metaclusterRegistration.get().name == data.metaclusterRegistration.get().metaclusterName);
 		ASSERT_GE(data.metaclusterRegistration.get().version, MetaclusterVersion::MIN_SUPPORTED);
 		ASSERT_LE(data.metaclusterRegistration.get().version, MetaclusterVersion::MAX_SUPPORTED);
+		ASSERT(!data.maxRestoreId.present());
 
 		ASSERT_LE(data.dataClusters.size(), CLIENT_KNOBS->MAX_DATA_CLUSTERS);
 		ASSERT_LE(data.tenantData.tenantCount, metaclusterMaxTenants);

--- a/metacluster/include/metacluster/MetaclusterOperationContext.actor.h
+++ b/metacluster/include/metacluster/MetaclusterOperationContext.actor.h
@@ -37,6 +37,7 @@
 #include "flow/ThreadHelper.actor.h"
 
 #include "metacluster/GetCluster.actor.h"
+#include "metacluster/MetaclusterMetadata.h"
 #include "metacluster/MetaclusterTypes.h"
 #include "metacluster/MetaclusterUtil.actor.h"
 
@@ -205,7 +206,7 @@ struct MetaclusterOperationContext {
 				tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 
 				state bool checkRestoring = !self->extraSupportedDataClusterStates.count(DataClusterState::RESTORING);
-				state Future<KeyBackedRangeResult<std::pair<ClusterName, UID>>> activeRestoreIdFuture;
+				state Future<KeyBackedRangeResult<std::pair<ClusterName, metadata::RestoreId>>> activeRestoreIdFuture;
 				if (checkRestoring && self->clusterName.present()) {
 					activeRestoreIdFuture = metadata::activeRestoreIds().getRange(tr, {}, {}, 1);
 				}
@@ -230,7 +231,8 @@ struct MetaclusterOperationContext {
 				}
 
 				if (checkRestoring) {
-					KeyBackedRangeResult<std::pair<ClusterName, UID>> activeRestoreId = wait(activeRestoreIdFuture);
+					KeyBackedRangeResult<std::pair<ClusterName, metadata::RestoreId>> activeRestoreId =
+					    wait(activeRestoreIdFuture);
 					if (!activeRestoreId.results.empty()) {
 						CODE_PROBE(true, "Run data cluster transaction on restoring data cluster");
 						throw cluster_restoring();

--- a/metacluster/include/metacluster/RestoreCluster.actor.h
+++ b/metacluster/include/metacluster/RestoreCluster.actor.h
@@ -69,9 +69,10 @@ struct RestoreClusterImpl {
 	std::vector<std::string>& messages;
 
 	// Unique ID generated for this restore. Used to avoid concurrent restores
-	UID restoreId = deterministicRandom()->randomUniqueID();
+	metadata::RestoreId restoreId;
 
 	// Loaded from the management cluster
+	int64_t tenantIdPrefix;
 	Optional<int64_t> lastManagementClusterTenantId;
 
 	// Loaded from the data cluster
@@ -101,7 +102,8 @@ struct RestoreClusterImpl {
 	ACTOR template <class Transaction>
 	static Future<Void> checkRestoreId(RestoreClusterImpl* self, Transaction tr) {
 		if (!self->restoreDryRun) {
-			Optional<UID> activeRestoreId = wait(metadata::activeRestoreIds().get(tr, self->clusterName));
+			Optional<metadata::RestoreId> activeRestoreId =
+			    wait(metadata::activeRestoreIds().get(tr, self->clusterName));
 			if (!activeRestoreId.present() || activeRestoreId.get() != self->restoreId) {
 				CODE_PROBE(true, "Conflicting restore detected");
 				throw conflicting_restore();
@@ -114,7 +116,7 @@ struct RestoreClusterImpl {
 	// Returns true if the restore ID was erased
 	ACTOR template <class Transaction>
 	static Future<bool> eraseRestoreId(RestoreClusterImpl* self, Transaction tr) {
-		Optional<UID> transactionId = wait(metadata::activeRestoreIds().get(tr, self->clusterName));
+		Optional<metadata::RestoreId> transactionId = wait(metadata::activeRestoreIds().get(tr, self->clusterName));
 		if (!transactionId.present()) {
 			CODE_PROBE(true, "Erasing non-existent restore ID");
 			return false;
@@ -202,9 +204,24 @@ struct RestoreClusterImpl {
 		}
 	}
 
+	ACTOR static Future<Void> loadTenantIdData(RestoreClusterImpl* self, Reference<typename DB::TransactionT> tr) {
+		wait(store(self->lastManagementClusterTenantId, metadata::management::tenantMetadata().lastTenantId.get(tr)));
+
+		if (!self->lastManagementClusterTenantId.present()) {
+			Optional<int64_t> prefix = wait(TenantMetadata::tenantIdPrefix().get(tr));
+			ASSERT(prefix.present());
+			self->tenantIdPrefix = prefix.get();
+		} else {
+			self->tenantIdPrefix = TenantAPI::getTenantIdPrefix(self->lastManagementClusterTenantId.get());
+		}
+
+		return Void();
+	}
+
 	// Store the cluster entry for the restored cluster
-	ACTOR static Future<Void> registerRestoringClusterInManagementCluster(RestoreClusterImpl* self,
-	                                                                      Reference<typename DB::TransactionT> tr) {
+	ACTOR static Future<metadata::RestoreId> registerRestoringClusterInManagementCluster(
+	    RestoreClusterImpl* self,
+	    Reference<typename DB::TransactionT> tr) {
 		state Optional<DataClusterMetadata> dataClusterMetadata = wait(tryGetClusterTransaction(tr, self->clusterName));
 		if (dataClusterMetadata.present() &&
 		    (dataClusterMetadata.get().entry.clusterState != DataClusterState::RESTORING ||
@@ -214,7 +231,8 @@ struct RestoreClusterImpl {
 			throw cluster_already_exists();
 		} else if (!self->restoreDryRun) {
 			metadata::activeRestoreIds().addReadConflictKey(tr, self->clusterName);
-			metadata::activeRestoreIds().set(tr, self->clusterName, self->restoreId);
+			metadata::RestoreId restoreId =
+			    metadata::RestoreId::createRestoreId(tr, metadata::activeRestoreIds(), self->clusterName);
 
 			if (!dataClusterMetadata.present()) {
 				self->dataClusterId = deterministicRandom()->randomUniqueID();
@@ -233,9 +251,11 @@ struct RestoreClusterImpl {
 			    .detail("Capacity", clusterEntry.capacity)
 			    .detail("Version", tr->getCommittedVersion())
 			    .detail("ConnectionString", self->connectionString.toString());
+
+			return restoreId;
 		}
 
-		return Void();
+		return metadata::RestoreId();
 	}
 
 	// If adding a data cluster to a restored management cluster, write a metacluster registration entry
@@ -264,7 +284,7 @@ struct RestoreClusterImpl {
 
 				wait(lastTenantIdFuture);
 
-				MetaclusterRegistrationEntry dataClusterEntry =
+				state MetaclusterRegistrationEntry dataClusterEntry =
 				    self->ctx.metaclusterRegistration.get().toDataClusterRegistration(self->clusterName,
 				                                                                      self->dataClusterId);
 
@@ -281,9 +301,16 @@ struct RestoreClusterImpl {
 				}
 
 				if (!self->restoreDryRun) {
+					Versionstamp maxRestoreId =
+					    wait(metadata::maxRestoreId().getD(tr, Snapshot::False, Versionstamp()));
+					if (!self->restoreId.replaces(maxRestoreId)) {
+						throw conflicting_restore();
+					}
+
 					metadata::metaclusterRegistration().set(tr, dataClusterEntry);
 					metadata::activeRestoreIds().addReadConflictKey(tr, self->clusterName);
 					metadata::activeRestoreIds().set(tr, self->clusterName, self->restoreId);
+					metadata::maxRestoreId().set(tr, self->restoreId.versionstamp);
 					wait(buggifiedCommit(tr, BUGGIFY_WITH_PROB(0.1)));
 				}
 
@@ -296,9 +323,11 @@ struct RestoreClusterImpl {
 		return Void();
 	}
 
-	ACTOR static Future<Void> markClusterRestoring(RestoreClusterImpl* self, Reference<typename DB::TransactionT> tr) {
+	ACTOR static Future<metadata::RestoreId> markClusterRestoring(RestoreClusterImpl* self,
+	                                                              Reference<typename DB::TransactionT> tr) {
 		metadata::activeRestoreIds().addReadConflictKey(tr, self->clusterName);
-		metadata::activeRestoreIds().set(tr, self->clusterName, self->restoreId);
+		state metadata::RestoreId restoreId =
+		    metadata::RestoreId::createRestoreId(tr, metadata::activeRestoreIds(), self->clusterName);
 		if (self->ctx.dataClusterMetadata.get().entry.clusterState != DataClusterState::RESTORING) {
 			DataClusterEntry updatedEntry = self->ctx.dataClusterMetadata.get().entry;
 			updatedEntry.clusterState = DataClusterState::RESTORING;
@@ -315,10 +344,10 @@ struct RestoreClusterImpl {
 			CODE_PROBE(true, "Mark cluster restoring already complete");
 		}
 
-		wait(store(self->lastManagementClusterTenantId, metadata::management::tenantMetadata().lastTenantId.get(tr)));
+		wait(loadTenantIdData(self, tr));
 
 		TraceEvent("MarkedDataClusterRestoring").detail("Name", self->clusterName);
-		return Void();
+		return restoreId;
 	}
 
 	Future<Void> markClusterAsReady(Reference<typename DB::TransactionT> tr) {
@@ -800,12 +829,11 @@ struct RestoreClusterImpl {
 
 	ACTOR static Future<Void> addTenantBatchToManagementCluster(RestoreClusterImpl* self,
 	                                                            Reference<typename DB::TransactionT> tr,
-	                                                            std::vector<TenantMapEntry> tenants,
-	                                                            int64_t tenantIdPrefix) {
+	                                                            std::vector<TenantMapEntry> tenants) {
 		state std::vector<Future<bool>> futures;
 		state int64_t maxId = -1;
 		for (auto const& t : tenants) {
-			if (TenantAPI::getTenantIdPrefix(t.id) == tenantIdPrefix) {
+			if (TenantAPI::getTenantIdPrefix(t.id) == self->tenantIdPrefix) {
 				maxId = std::max(maxId, t.id);
 				self->newLastDataClusterTenantId = std::max(t.id, self->newLastDataClusterTenantId.orDefault(0));
 			}
@@ -857,26 +885,19 @@ struct RestoreClusterImpl {
 		return Void();
 	}
 
-	ACTOR static Future<int64_t> updateLastTenantId(RestoreClusterImpl* self, Reference<typename DB::TransactionT> tr) {
-		state Optional<int64_t> lastTenantId = wait(metadata::management::tenantMetadata().lastTenantId.get(tr));
-		state int64_t tenantIdPrefix;
-		if (!lastTenantId.present()) {
-			Optional<int64_t> prefix = wait(TenantMetadata::tenantIdPrefix().get(tr));
-			ASSERT(prefix.present());
-			tenantIdPrefix = prefix.get();
-		} else {
-			tenantIdPrefix = TenantAPI::getTenantIdPrefix(lastTenantId.get());
-		}
+	ACTOR static Future<Void> updateLastTenantId(RestoreClusterImpl* self, Reference<typename DB::TransactionT> tr) {
+		wait(loadTenantIdData(self, tr));
 
 		if (self->lastDataClusterTenantId.present() &&
-		    tenantIdPrefix == TenantAPI::getTenantIdPrefix(self->lastDataClusterTenantId.get())) {
+		    self->tenantIdPrefix == TenantAPI::getTenantIdPrefix(self->lastDataClusterTenantId.get())) {
 			if (!self->forceReuseTenantIdPrefix) {
 				self->messages.push_back(fmt::format(
 				    "The data cluster being added is using the same tenant ID prefix {} as the management cluster.",
-				    tenantIdPrefix));
+				    self->tenantIdPrefix));
 				CODE_PROBE(true, "Reusing tenant ID without force reuse option");
 				throw invalid_metacluster_configuration();
-			} else if (!self->restoreDryRun && self->lastDataClusterTenantId.get() > lastTenantId.orDefault(-1)) {
+			} else if (!self->restoreDryRun &&
+			           self->lastDataClusterTenantId.get() > self->lastManagementClusterTenantId.orDefault(-1)) {
 				CODE_PROBE(true, "Reusing tenant ID prefix and increase existing ID");
 				metadata::management::tenantMetadata().lastTenantId.set(tr, self->lastDataClusterTenantId.get());
 			}
@@ -885,7 +906,7 @@ struct RestoreClusterImpl {
 			self->newLastDataClusterTenantId = self->lastDataClusterTenantId;
 		}
 
-		return tenantIdPrefix;
+		return Void();
 	}
 
 	ACTOR static Future<Void> addTenantsToManagementCluster(RestoreClusterImpl* self) {
@@ -893,7 +914,7 @@ struct RestoreClusterImpl {
 		state std::vector<TenantMapEntry> tenantBatch;
 		state int64_t tenantsToAdd = 0;
 
-		state int64_t tenantIdPrefix = wait(self->runRestoreManagementTransaction(
+		wait(self->runRestoreManagementTransaction(
 		    [self = self](Reference<typename DB::TransactionT> tr) { return updateLastTenantId(self, tr); }));
 
 		for (itr = self->dataClusterTenantMap.begin(); itr != self->dataClusterTenantMap.end(); ++itr) {
@@ -917,10 +938,9 @@ struct RestoreClusterImpl {
 
 			if (tenantBatch.size() == CLIENT_KNOBS->METACLUSTER_RESTORE_BATCH_SIZE) {
 				wait(self->runRestoreManagementTransaction(
-				    [self = self, tenantBatch = tenantBatch, tenantIdPrefix = tenantIdPrefix](
-				        Reference<typename DB::TransactionT> tr) {
+				    [self = self, tenantBatch = tenantBatch](Reference<typename DB::TransactionT> tr) {
 					    tr->setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
-					    return addTenantBatchToManagementCluster(self, tr, tenantBatch, tenantIdPrefix);
+					    return addTenantBatchToManagementCluster(self, tr, tenantBatch);
 				    }));
 				tenantBatch.clear();
 			}
@@ -928,10 +948,9 @@ struct RestoreClusterImpl {
 
 		if (!tenantBatch.empty()) {
 			wait(self->runRestoreManagementTransaction(
-			    [self = self, tenantBatch = tenantBatch, tenantIdPrefix = tenantIdPrefix](
-			        Reference<typename DB::TransactionT> tr) {
+			    [self = self, tenantBatch = tenantBatch](Reference<typename DB::TransactionT> tr) {
 				    tr->setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
-				    return addTenantBatchToManagementCluster(self, tr, tenantBatch, tenantIdPrefix);
+				    return addTenantBatchToManagementCluster(self, tr, tenantBatch);
 			    }));
 		}
 
@@ -948,11 +967,53 @@ struct RestoreClusterImpl {
 	ACTOR static Future<Void> finalizeDataClusterAfterRepopulate(RestoreClusterImpl* self, Reference<ITransaction> tr) {
 		bool erased = wait(eraseRestoreId(self, tr));
 		if (erased) {
+			TenantMetadata::tenantIdPrefix().set(tr, self->tenantIdPrefix);
 			if (self->newLastDataClusterTenantId.present()) {
 				TenantMetadata::lastTenantId().set(tr, self->newLastDataClusterTenantId.get());
 			} else {
 				TenantMetadata::lastTenantId().clear(tr);
 			}
+
+			Optional<TenantTombstoneCleanupData> tombstoneCleanupData =
+			    wait(TenantMetadata::tombstoneCleanupData().get(tr));
+
+			// If our tombstones are for a different tenant prefix, we need to erase them
+			if (!tombstoneCleanupData.present() ||
+			    TenantAPI::getTenantIdPrefix(tombstoneCleanupData.get().nextTombstoneEraseId) != self->tenantIdPrefix) {
+				CODE_PROBE(true, "Remove tombstone cleanup data during management cluster repopulate");
+				TenantMetadata::tenantTombstones().clear(tr);
+				TenantMetadata::tombstoneCleanupData().clear(tr);
+			}
+		}
+
+		return Void();
+	}
+
+	ACTOR static Future<Void> updateDataClusterMetadata(RestoreClusterImpl* self, Reference<ITransaction> tr) {
+		Versionstamp maxRestoreId = wait(metadata::maxRestoreId().getD(tr, Snapshot::False, Versionstamp()));
+		if (!self->restoreId.replaces(maxRestoreId)) {
+			throw conflicting_restore();
+		}
+
+		metadata::activeRestoreIds().addReadConflictKey(tr, self->clusterName);
+		metadata::activeRestoreIds().set(tr, self->clusterName, self->restoreId);
+		metadata::maxRestoreId().set(tr, self->restoreId.versionstamp);
+		TenantMetadata::tenantIdPrefix().set(tr, self->tenantIdPrefix);
+		if (self->lastManagementClusterTenantId.present()) {
+			TenantMetadata::lastTenantId().set(tr, self->lastManagementClusterTenantId.get());
+		} else {
+			TenantMetadata::lastTenantId().clear(tr);
+		}
+
+		Optional<TenantTombstoneCleanupData> tombstoneCleanupData =
+		    wait(TenantMetadata::tombstoneCleanupData().get(tr));
+
+		// If our tombstones are for a different tenant prefix, we need to erase them
+		if (!tombstoneCleanupData.present() ||
+		    TenantAPI::getTenantIdPrefix(tombstoneCleanupData.get().nextTombstoneEraseId) != self->tenantIdPrefix) {
+			CODE_PROBE(true, "Remove tombstone cleanup data during data cluster restore");
+			TenantMetadata::tenantTombstones().clear(tr);
+			TenantMetadata::tombstoneCleanupData().clear(tr);
 		}
 
 		return Void();
@@ -973,30 +1034,18 @@ struct RestoreClusterImpl {
 
 		// set state to restoring
 		if (!self->restoreDryRun) {
-			try {
-				wait(self->ctx.runManagementTransaction(
-				    [self = self](Reference<typename DB::TransactionT> tr) { return markClusterRestoring(self, tr); }));
-			} catch (Error& e) {
-				// If the transaction retries after success or if we are trying a second time to restore the cluster, it
-				// will throw an error indicating that the restore has already started
-				if (e.code() != error_code_cluster_restoring) {
-					throw;
-				}
-			}
+			wait(store(self->restoreId,
+			           self->ctx.runManagementTransaction([self = self](Reference<typename DB::TransactionT> tr) {
+				           return markClusterRestoring(self, tr);
+			           })));
+
+			wait(self->restoreId.onSet());
 		}
 
 		// Set the restore ID in the data cluster and update the last tenant ID to match the management cluster
 		if (!self->restoreDryRun) {
-			wait(self->ctx.runDataClusterTransaction([self = self](Reference<ITransaction> tr) {
-				metadata::activeRestoreIds().addReadConflictKey(tr, self->clusterName);
-				metadata::activeRestoreIds().set(tr, self->clusterName, self->restoreId);
-				if (self->lastManagementClusterTenantId.present()) {
-					TenantMetadata::lastTenantId().set(tr, self->lastManagementClusterTenantId.get());
-				} else {
-					TenantMetadata::lastTenantId().clear(tr);
-				}
-				return Future<Void>(Void());
-			}));
+			wait(self->ctx.runDataClusterTransaction(
+			    [self = self](Reference<ITransaction> tr) { return updateDataClusterMetadata(self, tr); }));
 		}
 
 		// get all the tenants in the metacluster
@@ -1035,9 +1084,15 @@ struct RestoreClusterImpl {
 		CODE_PROBE(self->forceReuseTenantIdPrefix, "Management cluster restore force reuse tenant ID prefix");
 
 		// Record the data cluster in the management cluster
-		wait(self->ctx.runManagementTransaction([self = self](Reference<typename DB::TransactionT> tr) {
-			return registerRestoringClusterInManagementCluster(self, tr);
-		}));
+		state metadata::RestoreId restoreId =
+		    wait(self->ctx.runManagementTransaction([self = self](Reference<typename DB::TransactionT> tr) {
+			    return registerRestoringClusterInManagementCluster(self, tr);
+		    }));
+
+		if (!self->restoreDryRun) {
+			wait(restoreId.onSet());
+			self->restoreId = restoreId;
+		}
 
 		// Write a metacluster registration entry in the data cluster
 		wait(writeDataClusterRegistration(self));

--- a/tests/slow/MetaclusterRecovery.toml
+++ b/tests/slow/MetaclusterRecovery.toml
@@ -12,7 +12,7 @@ machineCount = 5
 
 [[test]]
 testTitle = 'MetaclusterRestoreTest'
-clearAfterTest = true
+clearAfterTest = false
 timeout = 2100
 runSetup = true
 simBackupAgents = 'BackupToFile'
@@ -21,3 +21,16 @@ simBackupAgents = 'BackupToFile'
     testName = 'MetaclusterRestore'
 	maxTenants = 500
 	maxTenantGroups = 10
+
+[[test]]
+testTitle = 'MetaclusterManagementTest'
+clearAfterTest = true
+timeout = 2100
+runSetup = true
+
+    [[test.workload]]
+    testName = 'MetaclusterManagement'
+	maxTenants = 100
+	maxTenantGroups = 20
+	testDuration = 60
+	useExistingMetacluster = true


### PR DESCRIPTION
Previously, the metacluster restore test did not use the metacluster to validate that it was functional after restoring. This updates the test to run the metacluster management workload on a restored metacluster.

This also addresses two bugs that were caught by this test:

1. Concurrent restores could interleave in a way that caused the data cluster to be left in a permanently restoring state, thus preventing normal metacluster operations on that cluster.
2. The data clusters would keep tenant tombstone data for the old tenant ID prefix when restored to a metacluster with a different tenant ID prefix. This ended up causing problems for tenant creation.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
