### PR TITLE
Disable all parallel restore tests (snowflake/release-71.3)

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ if(WITH_PYTHON)
   find_program(OLD_FDBSERVER_BINARY
     fdbserver-7.1.23 fdbserver fdbserver.exe
     HINTS /opt/foundationdb/old/7.1.23/bin/ /opt/foundationdb/old /usr/sbin /usr/libexec /usr/local/sbin /usr/local/libexec)
+
   if(OLD_FDBSERVER_BINARY)
     message(STATUS "Use old fdb at ${OLD_FDBSERVER_BINARY}")
   else()
@@ -167,6 +168,7 @@ if(WITH_PYTHON)
   add_fdb_test(TEST_FILES fast/ChangeFeedOperationsMove.toml)
   add_fdb_test(TEST_FILES fast/DataLossRecovery.toml)
   add_fdb_test(TEST_FILES fast/EncryptionOps.toml)
+
   # EncryptionUnitTests is only a convenience file to run the different types of encryption tests at once. Do not enable in general ensembles
   add_fdb_test(TEST_FILES fast/EncryptionUnitTests.toml IGNORE)
   add_fdb_test(TEST_FILES fast/EncryptKeyProxyTest.toml)
@@ -228,7 +230,7 @@ if(WITH_PYTHON)
   add_fdb_test(TEST_FILES fast/WriteDuringReadClean.toml)
   add_fdb_test(TEST_FILES noSim/RandomUnitTests.toml UNIT)
 
-#  if(WITH_ROCKSDB_EXPERIMENTAL)
+  # if(WITH_ROCKSDB_EXPERIMENTAL)
   if(0)
     add_fdb_test(TEST_FILES fast/ValidateStorage.toml)
     add_fdb_test(TEST_FILES noSim/KeyValueStoreRocksDBTest.toml UNIT)
@@ -331,9 +333,9 @@ if(WITH_PYTHON)
   add_fdb_test(
     TEST_FILES restarting/from_71.2.0_until_71.3.0/ConfigureStorageMigrationTestRestart-1.toml
     restarting/from_71.2.0_until_71.3.0/ConfigureStorageMigrationTestRestart-2.toml)
-    add_fdb_test(
-      TEST_FILES restarting/from_71.2.0_until_71.3.0/DrUpgradeRestart-1.toml
-      restarting/from_71.2.0_until_71.3.0/DrUpgradeRestart-2.toml)
+  add_fdb_test(
+    TEST_FILES restarting/from_71.2.0_until_71.3.0/DrUpgradeRestart-1.toml
+    restarting/from_71.2.0_until_71.3.0/DrUpgradeRestart-2.toml)
   add_fdb_test(
     TEST_FILES restarting/from_71.2.0_until_71.3.0/ClientTransactionProfilingCorrectness-1.txt
     restarting/from_71.2.0_until_71.3.0/ClientTransactionProfilingCorrectness-2.txt)
@@ -355,7 +357,7 @@ if(WITH_PYTHON)
   add_fdb_test(
     TEST_FILES restarting/from_71.3.0/ConfigureStorageMigrationTestRestart-1.toml
     restarting/from_71.3.0/ConfigureStorageMigrationTestRestart-2.toml)
-    add_fdb_test(
+  add_fdb_test(
     TEST_FILES restarting/from_71.3.0/DrUpgradeRestart-1.toml
     restarting/from_71.3.0/DrUpgradeRestart-2.toml)
   add_fdb_test(
@@ -476,13 +478,13 @@ if(WITH_PYTHON)
   add_fdb_test(TEST_FILES slow/WriteDuringReadSwitchover.toml)
   add_fdb_test(TEST_FILES slow/ddbalance.toml)
   add_fdb_test(TEST_FILES slow/ParallelRestoreNewBackupCorrectnessAtomicOp.toml IGNORE)
-  add_fdb_test(TEST_FILES slow/ParallelRestoreNewBackupCorrectnessCycle.toml)
-  add_fdb_test(TEST_FILES slow/ParallelRestoreNewBackupCorrectnessMultiCycles.toml)
+  add_fdb_test(TEST_FILES slow/ParallelRestoreNewBackupCorrectnessCycle.toml IGNORE)
+  add_fdb_test(TEST_FILES slow/ParallelRestoreNewBackupCorrectnessMultiCycles.toml IGNORE)
   add_fdb_test(TEST_FILES slow/ParallelRestoreNewBackupWriteDuringReadAtomicRestore.toml IGNORE)
-  add_fdb_test(TEST_FILES slow/ParallelRestoreOldBackupCorrectnessAtomicOp.toml)
-  add_fdb_test(TEST_FILES slow/ParallelRestoreOldBackupCorrectnessCycle.toml)
-  add_fdb_test(TEST_FILES slow/ParallelRestoreOldBackupCorrectnessMultiCycles.toml)
-  add_fdb_test(TEST_FILES slow/ParallelRestoreOldBackupWriteDuringReadAtomicRestore.toml)
+  add_fdb_test(TEST_FILES slow/ParallelRestoreOldBackupCorrectnessAtomicOp.toml IGNORE)
+  add_fdb_test(TEST_FILES slow/ParallelRestoreOldBackupCorrectnessCycle.toml IGNORE)
+  add_fdb_test(TEST_FILES slow/ParallelRestoreOldBackupCorrectnessMultiCycles.toml IGNORE)
+  add_fdb_test(TEST_FILES slow/ParallelRestoreOldBackupWriteDuringReadAtomicRestore.toml IGNORE)
   add_fdb_test(TEST_FILES ParallelRestoreOldBackupApiCorrectnessAtomicRestore.toml IGNORE)
 
   # Note that status tests are not deterministic.


### PR DESCRIPTION
This disables all parallel restore tests in simulation.

Passes 100K correctness: 20230621-172656-abeamon-d1fe2a42b15a32e9

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
