### PR TITLE
Update SimKmsVault unit test assert checking max encryption keys

### DIFF
--- a/fdbclient/include/fdbclient/SimKmsVault.cpp
+++ b/fdbclient/include/fdbclient/SimKmsVault.cpp
@@ -154,10 +154,8 @@ uint32_t maxSimKeys() {
 void forceLinkSimKmsVaultTests() {}
 
 TEST_CASE("/simKmsVault") {
-	auto& g_knobs = IKnobCollection::getMutableGlobalKnobCollection();
-	g_knobs.setKnob("sim_kms_vault_max_keys", KnobValueRef::create(int{ 20 }));
-
 	Reference<SimKmsVaultCtx> vaultCtx = SimKmsVaultCtx::getInstance();
+	ASSERT_GT(vaultCtx->maxKeys(), 0);
 	ASSERT_EQ(vaultCtx->maxKeys(), CLIENT_KNOBS->SIM_KMS_VAULT_MAX_KEYS);
 
 	// Test non-existing baseCiphers


### PR DESCRIPTION
SimKmsVault unit test when run as part of simulation Random test, based on the test order, SimKmsVaultKeyCtx can be initialized as part of some other test (FlowSingleton). Update the test to handle the scenario.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
