### PR TITLE
EaR: Update KMS URL refresh policy and fix bugs (#10382)

### DIFF
--- a/fdbclient/RESTUtils.actor.cpp
+++ b/fdbclient/RESTUtils.actor.cpp
@@ -263,6 +263,10 @@ void RESTUrl::parseUrl(const std::string& fullUrl) {
 	}
 }
 
+double continuousTimeDecay(double initialValue, double decayRate, double time) {
+	return initialValue * exp(-decayRate * time);
+}
+
 // Only used to link unit tests
 void forceLinkRESTUtilsTests() {}
 

--- a/fdbclient/include/fdbclient/RESTUtils.h
+++ b/fdbclient/include/fdbclient/RESTUtils.h
@@ -136,4 +136,6 @@ private:
 	void parseUrl(const std::string& fullUrl);
 };
 
+double continuousTimeDecay(double initialValue, double decayRate, double time);
+
 #endif

--- a/fdbserver/RESTKmsConnector.actor.cpp
+++ b/fdbserver/RESTKmsConnector.actor.cpp
@@ -18,6 +18,7 @@
  * limitations under the License.
  */
 
+#include "fdbclient/RESTUtils.h"
 #include "fdbserver/RESTKmsConnector.h"
 
 #include "fdbclient/BlobCipher.h"
@@ -39,10 +40,12 @@
 #include "flow/IAsyncFile.h"
 #include "flow/IConnection.h"
 #include "flow/IRandom.h"
+#include "flow/Knobs.h"
 #include "flow/Platform.h"
 #include "flow/Trace.h"
 #include "flow/UnitTest.h"
 
+#include <algorithm>
 #include <limits>
 #include <boost/algorithm/string.hpp>
 #include <cstring>
@@ -89,40 +92,140 @@ void removeTrailingChar(std::string& str, char c) {
 
 } // namespace
 
+template <class Params>
 struct KmsUrlCtx {
+	enum class PenaltyType { TIMEOUT = 1, MALFORMED_RESPONSE = 2 };
+
 	std::string url;
 	uint64_t nRequests;
 	uint64_t nFailedResponses;
 	uint64_t nResponseParseFailures;
+	double unresponsivenessPenalty;
+	double unresponsivenessPenaltyTS;
 
-	KmsUrlCtx() : url(""), nRequests(0), nFailedResponses(0), nResponseParseFailures(0) {}
-	explicit KmsUrlCtx(const std::string& u) : url(u), nRequests(0), nFailedResponses(0), nResponseParseFailures(0) {}
+	KmsUrlCtx()
+	  : url(""), nRequests(0), nFailedResponses(0), nResponseParseFailures(0), unresponsivenessPenalty(0.0),
+	    unresponsivenessPenaltyTS(0) {}
+	explicit KmsUrlCtx(const std::string& u)
+	  : url(u), nRequests(0), nFailedResponses(0), nResponseParseFailures(0), unresponsivenessPenalty(0.0),
+	    unresponsivenessPenaltyTS(0) {}
 
-	bool operator<(const KmsUrlCtx& toCompare) const {
-		if (nFailedResponses != toCompare.nFailedResponses) {
-			return nFailedResponses > toCompare.nFailedResponses;
+	bool operator==(const KmsUrlCtx& toCompare) const { return url.compare(toCompare.url) == 0; }
+
+	void refreshUnresponsivenessPenalty() {
+		if (unresponsivenessPenaltyTS == 0) {
+			return;
 		}
-		return nResponseParseFailures > toCompare.nResponseParseFailures;
+		int64_t timeSinceLastPenalty = now() - unresponsivenessPenaltyTS;
+		unresponsivenessPenalty = Params::penalty(timeSinceLastPenalty);
+	}
+
+	void penalize(const PenaltyType type) {
+		if (type == PenaltyType::TIMEOUT) {
+			nFailedResponses++;
+			unresponsivenessPenaltyTS = now();
+		} else {
+			ASSERT_EQ(type, PenaltyType::MALFORMED_RESPONSE);
+			nResponseParseFailures++;
+		}
+	}
+
+	std::string toString() const {
+		return fmt::format(
+		    "{} {} {} {} {}", url, nRequests, nFailedResponses, nResponseParseFailures, unresponsivenessPenalty);
 	}
 };
 
-using KmsUrlMinHeap = std::priority_queue<std::shared_ptr<KmsUrlCtx>,
-                                          std::vector<std::shared_ptr<KmsUrlCtx>>,
-                                          std::less<std::vector<std::shared_ptr<KmsUrlCtx>>::value_type>>;
+// Current implementation is designed to favor the most-preferable KMS for all outbound requests allowing leveraging KMS
+// implemented caching if supported
+//
+// TODO: Implement load-balancing requests to available KMS servers maintaining prioritized KMS server list based on
+// observed errors/connection failures/timeouts etc.
+
+template <class Params>
+struct KmsUrlStore {
+	void sort() {
+		std::sort(kmsUrls.begin(), kmsUrls.end(), [](const KmsUrlCtx<Params>& l, const KmsUrlCtx<Params>& r) {
+			// Sort the available URLs based on following rules:
+			// 1. URL with higher unresponsiveness-penalty are least preferred
+			// 2. Among URLs with same unresponsiveness-penalty weight, URLs with more number of failed-respones are
+			// less preferrred
+			// 3. Lastly, URLs with more malformed response messages are less preferred
+
+			if (l.unresponsivenessPenalty != r.unresponsivenessPenalty) {
+				return l.unresponsivenessPenalty < r.unresponsivenessPenalty;
+			}
+			if (l.nFailedResponses != r.nFailedResponses) {
+				return l.nFailedResponses < r.nFailedResponses;
+			}
+			return l.nResponseParseFailures < r.nResponseParseFailures;
+		});
+	}
+
+	void penalize(const KmsUrlCtx<Params>& toPenalize, const typename KmsUrlCtx<Params>::PenaltyType type) {
+		bool found = false;
+		for (KmsUrlCtx<Params>& urlCtx : kmsUrls) {
+			if (urlCtx == toPenalize) {
+				urlCtx.penalize(type);
+				found = true;
+				break;
+			}
+		}
+		ASSERT(found);
+
+		// update the penalties
+		for (auto& url : kmsUrls) {
+			url.refreshUnresponsivenessPenalty();
+		}
+
+		if (FLOW_KNOBS->REST_LOG_LEVEL >= RESTLogSeverity::DEBUG) {
+			std::string details;
+			for (const auto& url : kmsUrls) {
+				details.append(fmt::format("[ {} ], ", url.toString()));
+			}
+			TraceEvent("RESTKmsUrlStoreBeforeSort")
+			    .detail("Details", details)
+			    .detail("Penalize", toPenalize.toString());
+		}
+
+		// Reshuffle the URLs
+		sort();
+
+		if (FLOW_KNOBS->REST_LOG_LEVEL >= RESTLogSeverity::DEBUG) {
+			std::string details;
+			for (const auto& url : kmsUrls) {
+				details.append(fmt::format("[ {} ], ", url.toString()));
+			}
+			TraceEvent("RESTKmsUrlStoreAfterSort").detail("Details", details);
+		}
+	}
+
+	std::vector<KmsUrlCtx<Params>> kmsUrls;
+};
 
 FDB_BOOLEAN_PARAM(RefreshPersistedUrls);
 FDB_BOOLEAN_PARAM(IsCipherType);
 
+// Routine to determine penalty for cached KMSUrl based on unresponsive KMS behavior observed in recent past. The
+// routine is desgined to assign a maximum penalty if KMS responses are unacceptable in very recent past, with time the
+// the penalty weight deteorates (matches real world outage OR server overload scenario)
+
+struct KmsUrlPenaltyParams {
+	static double penalty(int64_t timeSinceLastPenalty) { return continuousTimeDecay(1.0, 0.1, timeSinceLastPenalty); }
+};
+
 struct RESTKmsConnectorCtx : public ReferenceCounted<RESTKmsConnectorCtx> {
 	UID uid;
-	KmsUrlMinHeap kmsUrlHeap;
+	KmsUrlStore<KmsUrlPenaltyParams> kmsUrlStore;
 	double lastKmsUrlsRefreshTs;
+	double lastKmsUrlDiscoverTS;
 	RESTClient restClient;
 	ValidationTokenMap validationTokenMap;
 	PromiseStream<Future<Void>> addActor;
 
-	RESTKmsConnectorCtx() : uid(deterministicRandom()->randomUniqueID()), lastKmsUrlsRefreshTs(0) {}
-	explicit RESTKmsConnectorCtx(const UID& id) : uid(id), lastKmsUrlsRefreshTs(0) {}
+	RESTKmsConnectorCtx()
+	  : uid(deterministicRandom()->randomUniqueID()), lastKmsUrlsRefreshTs(0), lastKmsUrlDiscoverTS(0.0) {}
+	explicit RESTKmsConnectorCtx(const UID& id) : uid(id), lastKmsUrlsRefreshTs(0), lastKmsUrlDiscoverTS(0.0) {}
 };
 
 std::string getFullRequestUrl(Reference<RESTKmsConnectorCtx> ctx, const std::string& url, const std::string& suffix) {
@@ -134,18 +237,19 @@ std::string getFullRequestUrl(Reference<RESTKmsConnectorCtx> ctx, const std::str
 	return (suffix[0] == '/') ? fullUrl.append(suffix) : fullUrl.append("/").append(suffix);
 }
 
-void dropCachedKmsUrls(Reference<RESTKmsConnectorCtx> ctx) {
-	while (!ctx->kmsUrlHeap.empty()) {
-		std::shared_ptr<KmsUrlCtx> curUrl = ctx->kmsUrlHeap.top();
-
-		TraceEvent("RESTDropCachedKmsUrls", ctx->uid)
-		    .detail("Url", curUrl->url)
-		    .detail("NumRequests", curUrl->nRequests)
-		    .detail("NumFailedResponses", curUrl->nFailedResponses)
-		    .detail("NumRespParseFailures", curUrl->nResponseParseFailures);
-
-		ctx->kmsUrlHeap.pop();
+void dropCachedKmsUrls(Reference<RESTKmsConnectorCtx> ctx,
+                       std::unordered_map<std::string, KmsUrlCtx<KmsUrlPenaltyParams>>* urlMap) {
+	for (const auto& url : ctx->kmsUrlStore.kmsUrls) {
+		if (FLOW_KNOBS->REST_LOG_LEVEL >= RESTLogSeverity::VERBOSE) {
+			TraceEvent("RESTDropCachedKmsUrls", ctx->uid)
+			    .detail("Url", url.url)
+			    .detail("NumRequests", url.nRequests)
+			    .detail("NumFailedResponses", url.nFailedResponses)
+			    .detail("NumRespParseFailures", url.nResponseParseFailures);
+		}
+		urlMap->insert(std::make_pair(url.url, url));
 	}
+	ctx->kmsUrlStore.kmsUrls.clear();
 }
 
 bool shouldRefreshKmsUrls(Reference<RESTKmsConnectorCtx> ctx) {
@@ -160,8 +264,9 @@ void extractKmsUrls(Reference<RESTKmsConnectorCtx> ctx,
                     const rapidjson::Document& doc,
                     Reference<HTTP::IncomingResponse> httpResp) {
 	// Refresh KmsUrls cache
-	dropCachedKmsUrls(ctx);
-	ASSERT(ctx->kmsUrlHeap.empty());
+	std::unordered_map<std::string, KmsUrlCtx<KmsUrlPenaltyParams>> urlMap;
+	dropCachedKmsUrls(ctx, &urlMap);
+	ASSERT_EQ(ctx->kmsUrlStore.kmsUrls.size(), 0);
 
 	for (const auto& url : doc[KMS_URLS_TAG].GetArray()) {
 		if (!url.IsString()) {
@@ -174,12 +279,26 @@ void extractKmsUrls(Reference<RESTKmsConnectorCtx> ctx,
 		urlStr.resize(url.GetStringLength());
 		memcpy(urlStr.data(), url.GetString(), url.GetStringLength());
 
-		if (FLOW_KNOBS->REST_LOG_LEVEL >= RESTLogSeverity::INFO) {
-			TraceEvent("RESTExtractDiscoverKmsUrlsAddUrl", ctx->uid).detail("Url", urlStr);
-		}
+		// preserve the KmsUrl stats while (re)discovering KMS URLs, preferable to select the servers with lesser count
+		// of unexpected events in the past
 
-		ctx->kmsUrlHeap.emplace(std::make_shared<KmsUrlCtx>(urlStr));
+		auto itr = urlMap.find(urlStr);
+		if (itr != urlMap.end()) {
+			if (FLOW_KNOBS->REST_LOG_LEVEL >= RESTLogSeverity::INFO) {
+				TraceEvent("RESTDiscoverExistingKmsUrl", ctx->uid).detail("UrlCtx", itr->second.toString());
+			}
+			ctx->kmsUrlStore.kmsUrls.emplace_back(itr->second);
+		} else {
+			auto urlCtx = KmsUrlCtx<KmsUrlPenaltyParams>(urlStr);
+			if (FLOW_KNOBS->REST_LOG_LEVEL >= RESTLogSeverity::INFO) {
+				TraceEvent("RESTDiscoverNewKmsUrl", ctx->uid).detail("UrlCtx", urlCtx.toString());
+			}
+			ctx->kmsUrlStore.kmsUrls.emplace_back(urlCtx);
+		}
 	}
+
+	// Reshuffle URLs to re-arrange them in appropriate priority
+	ctx->kmsUrlStore.sort();
 
 	// Update Kms URLs refresh timestamp
 	ctx->lastKmsUrlsRefreshTs = now();
@@ -208,6 +327,10 @@ ACTOR Future<Void> parseDiscoverKmsUrlFile(Reference<RESTKmsConnectorCtx> ctx, s
 	// <url1>\n
 	// <url2>\n
 
+	std::unordered_map<std::string, KmsUrlCtx<KmsUrlPenaltyParams>> urlMap;
+	dropCachedKmsUrls(ctx, &urlMap);
+	ASSERT_EQ(ctx->kmsUrlStore.kmsUrls.size(), 0);
+
 	std::stringstream ss(buff.toString());
 	std::string url;
 	while (std::getline(ss, url, DISCOVER_URL_FILE_URL_SEP)) {
@@ -220,9 +343,23 @@ ACTOR Future<Void> parseDiscoverKmsUrlFile(Reference<RESTKmsConnectorCtx> ctx, s
 			// Empty URL, ignore and continue
 			continue;
 		}
-		TraceEvent("RESTParseDiscoverKmsUrlsAddUrl", ctx->uid).detail("OrgUrl", url).detail("TrimUrl", trimedUrl);
-		ctx->kmsUrlHeap.emplace(std::make_shared<KmsUrlCtx>(trimedUrl));
+		auto itr = urlMap.find(trimedUrl);
+		if (itr != urlMap.end()) {
+			if (FLOW_KNOBS->REST_LOG_LEVEL >= RESTLogSeverity::INFO) {
+				TraceEvent("RESTParseDiscoverKmsUrlsExistingUrl", ctx->uid).detail("UrlCtx", itr->second.toString());
+			}
+			ctx->kmsUrlStore.kmsUrls.emplace_back(itr->second);
+		} else {
+			auto urlCtx = KmsUrlCtx<KmsUrlPenaltyParams>(trimedUrl);
+			if (FLOW_KNOBS->REST_LOG_LEVEL >= RESTLogSeverity::INFO) {
+				TraceEvent("RESTParseDiscoverKmsUrlsAddUrl", ctx->uid).detail("UrlCtx", urlCtx.toString());
+			}
+			ctx->kmsUrlStore.kmsUrls.emplace_back(urlCtx);
+		}
 	}
+
+	// Reshuffle URLs to re-arrange them in appropriate priority
+	ctx->kmsUrlStore.sort();
 
 	return Void();
 }
@@ -234,11 +371,11 @@ ACTOR Future<Void> discoverKmsUrls(Reference<RESTKmsConnectorCtx> ctx, RefreshPe
 	//
 	// Following steps are followed as part of KMS discovery:
 	// 1) Based on the configured KMS URL discovery mode, the KMS URLs are extracted and persited in a DynamicKnob
-	// enabled configuration knob. Approach allows relying on the parsing configuration supplied discovery URL mode only
-	// during afte the initial boot, from then on, the URLs can periodically refreshed along with encryption key fetch
-	// requests (SERVER_KNOBS->REST_KMS_CONNECTOR_REFRESH_KMS_URLS needs to be enabled).
-	// 2) Cluster will continue using cached KMS URLs (and refreshing them if needed); however, if for some reason, all
-	// cached URLs aren't working, then code re-discovers the URL following step#1 and refresh persisted state as well.
+	// enabled configuration knob. Approach allows relying on the parsing configuration supplied discovery URL mode
+	// only during afte the initial boot, from then on, the URLs can periodically refreshed along with encryption
+	// key fetch requests (SERVER_KNOBS->REST_KMS_CONNECTOR_REFRESH_KMS_URLS needs to be enabled). 2) Cluster will
+	// continue using cached KMS URLs (and refreshing them if needed); however, if for some reason, all cached URLs
+	// aren't working, then code re-discovers the URL following step#1 and refresh persisted state as well.
 
 	if (!refreshPersistedUrls) {
 		// TODO: request must be satisfied accessing KMS URLs persited using DynamicKnobs. Will be implemented once
@@ -252,6 +389,8 @@ ACTOR Future<Void> discoverKmsUrls(Reference<RESTKmsConnectorCtx> ctx, RefreshPe
 	} else {
 		throw not_implemented();
 	}
+
+	ctx->lastKmsUrlDiscoverTS = now();
 
 	return Void();
 }
@@ -611,78 +750,73 @@ Future<T> kmsRequestImpl(
     std::function<T(Reference<RESTKmsConnectorCtx>, Reference<HTTP::IncomingResponse>)> parseFunc) {
 	state UID requestID = deterministicRandom()->randomUniqueID();
 
-	// Follow 2-phase scheme:
-	// Phase-1: Attempt to do request reaching out to cached KmsUrls in the order of
-	//          past success requests success counts.
-	// Phase-2: For some reason if none of the cached KmsUrls worked, re-discover the KmsUrls and
-	//          repeat phase-1.
+	// Follow multi-phase approach:
+	// Step-1: Enumerate KmsUrlStore cached URLs in the defined order of preference, if URL fails with an acceptable
+	// error (time-out or connection-failed), then continue enumeration. Otherwise, bubble up the error.
+	// Step-2: Refresh KmsUlrStore cached URLs by re-discovering KMS URLs and loop Step-1
 
-	state int pass = 1;
-	for (; pass <= 2; pass++) {
-		state std::stack<std::shared_ptr<KmsUrlCtx>> tempStack;
+	state int pass = 0;
+	state KmsUrlCtx<KmsUrlPenaltyParams>* urlCtx;
+	loop {
+		state int idx = 0;
+		state double start = now();
 
-		// Iterate over Kms URLs
-		while (!ctx->kmsUrlHeap.empty()) {
-			state std::shared_ptr<KmsUrlCtx> curUrl = ctx->kmsUrlHeap.top();
-			ctx->kmsUrlHeap.pop();
-			tempStack.push(curUrl);
-
+		pass++;
+		while (idx < ctx->kmsUrlStore.kmsUrls.size()) {
+			urlCtx = &ctx->kmsUrlStore.kmsUrls[idx++];
 			try {
-				std::string kmsEncryptionFullUrl = getFullRequestUrl(ctx, curUrl->url, urlSuffix);
+				std::string kmsEncryptionFullUrl = getFullRequestUrl(ctx, urlCtx->url, urlSuffix);
 
 				if (FLOW_KNOBS->REST_LOG_LEVEL >= RESTLogSeverity::DEBUG) {
 					TraceEvent("RESTKmsRequestImpl", ctx->uid)
 					    .detail("Pass", pass)
 					    .detail("RequestID", requestID)
-					    .detail("FullUrl", kmsEncryptionFullUrl);
+					    .detail("FullUrl", kmsEncryptionFullUrl)
+					    .detail("StartIdx", start)
+					    .detail("CurIdx", idx)
+					    .detail("LastKmsUrlDiscoverTS", ctx->lastKmsUrlDiscoverTS);
 				}
 
 				Reference<HTTP::IncomingResponse> resp = wait(ctx->restClient.doPost(
 				    kmsEncryptionFullUrl, requestBodyRef.toString(), RESTKmsConnectorUtils::getHTTPHeaders()));
-				curUrl->nRequests++;
+				urlCtx->nRequests++;
 
 				try {
 					T parsedResp = parseFunc(ctx, resp);
-
-					// Push urlCtx back on the ctx->urlHeap
-					while (!tempStack.empty()) {
-						ctx->kmsUrlHeap.emplace(tempStack.top());
-						tempStack.pop();
-					}
-
 					return parsedResp;
 				} catch (Error& e) {
 					TraceEvent(SevWarn, "KmsRequestRespParseFailure").error(e).detail("RequestID", requestID);
-					curUrl->nResponseParseFailures++;
+					ctx->kmsUrlStore.penalize(*urlCtx, KmsUrlCtx<KmsUrlPenaltyParams>::PenaltyType::MALFORMED_RESPONSE);
 					// attempt to do request from next KmsUrl
 				}
 			} catch (Error& e) {
-				curUrl->nFailedResponses++;
-				if (pass > 1 && isKmsNotReachable(e.code())) {
-					TraceEvent(SevWarn, "KmsRequestFailedUnreachable", ctx->uid)
-					    .error(e)
-					    .detail("RequestID", requestID);
+				ctx->kmsUrlStore.penalize(*urlCtx, KmsUrlCtx<KmsUrlPenaltyParams>::PenaltyType::TIMEOUT);
+				// Keep re-trying if KMS request time-out OR is server unreachable; otherwise, bubble up the error
+				if (!isKmsNotReachable(e.code())) {
+					if (FLOW_KNOBS->REST_LOG_LEVEL >= RESTLogSeverity::DEBUG) {
+						TraceEvent("KmsRequestFailedUnreachable", ctx->uid).error(e).detail("RequestID", requestID);
+					}
 					throw e;
-				} else {
-					TraceEvent(SevWarn, "KmsRequestError", ctx->uid).error(e).detail("RequestID", requestID);
-					// attempt to do request from next KmsUrl
 				}
+				TraceEvent(SevDebug, "KmsRequestError", ctx->uid).error(e).detail("RequestID", requestID);
+				// attempt to do request from next KmsUrl
+			}
+
+			// Possible scenarios:
+			// 1. URLs got reshuffled since the start of the enumeration.
+			// 2. All cached URLs aren't working, KMS URLs got re-discovered since start of enumeration.
+			// For #1, let the code continue enumerating cached URLs, an attempt to reset enumeration order could
+			// cause deadlock when: all cached URLs aren't working and multiple requests keep updating penalities
+			// and reshuffling the order. For #2, reset the enumeration order to re-attempt operation after
+			// re-discovery for KMS URL is done (stale cached KMS URLs)
+
+			if (start < ctx->lastKmsUrlDiscoverTS) {
+				idx = 0;
 			}
 		}
-
-		if (pass == 1) {
-			// Re-discover KMS urls and re-attempt request using newer KMS URLs
-			wait(discoverKmsUrls(ctx, RefreshPersistedUrls::True));
-		}
+		// Re-discover KMS urls and re-attempt request using newer KMS URLs
+		wait(discoverKmsUrls(ctx, RefreshPersistedUrls::True));
 	}
-
-	if (FLOW_KNOBS->REST_LOG_LEVEL >= RESTLogSeverity::VERBOSE) {
-		TraceEvent("RESTKmsRequestFailed", ctx->uid).detail("RequestID", requestID);
-	}
-
-	// Failed to do request from the remote KMS
-	// TODO: generic KMS error types
-	throw encrypt_keys_fetch_failed();
 }
 
 ACTOR Future<Void> fetchEncryptionKeysByKeyIds(Reference<RESTKmsConnectorCtx> ctx, KmsConnLookupEKsByKeyIdsReq req) {
@@ -1337,9 +1471,8 @@ void getFakeBlobMetadataResponse(StringRef jsonReqRef,
 }
 
 void validateKmsUrls(Reference<RESTKmsConnectorCtx> ctx) {
-	ASSERT_EQ(ctx->kmsUrlHeap.size(), 3);
-	std::shared_ptr<KmsUrlCtx> urlCtx = ctx->kmsUrlHeap.top();
-	ASSERT_EQ(urlCtx->url.compare(KMS_URL_NAME_TEST), 0);
+	ASSERT_EQ(ctx->kmsUrlStore.kmsUrls.size(), 3);
+	ASSERT_EQ(ctx->kmsUrlStore.kmsUrls[0].url.compare(KMS_URL_NAME_TEST), 0);
 }
 
 void testGetEncryptKeysByKeyIdsRequestBody(Reference<RESTKmsConnectorCtx> ctx, Arena& arena) {
@@ -1723,15 +1856,63 @@ ACTOR Future<Void> testParseDiscoverKmsUrlFile(Reference<RESTKmsConnectorCtx> ct
 	tmpFile->write((const uint8_t*)content.data(), content.size());
 	wait(parseDiscoverKmsUrlFile(ctx, tmpFile->getFileName()));
 
-	ASSERT_EQ(ctx->kmsUrlHeap.size(), urls.size());
-	while (!ctx->kmsUrlHeap.empty()) {
-		std::shared_ptr<KmsUrlCtx> urlCtx = ctx->kmsUrlHeap.top();
-		ctx->kmsUrlHeap.pop();
+	ASSERT_EQ(ctx->kmsUrlStore.kmsUrls.size(), urls.size());
+	for (const auto& url : ctx->kmsUrlStore.kmsUrls) {
+		ASSERT(compareUrls.find(url.url) != compareUrls.end());
+		ASSERT_EQ(url.nFailedResponses, 0);
+		ASSERT_EQ(url.nRequests, 0);
+		ASSERT_EQ(url.nResponseParseFailures, 0);
+	}
 
-		ASSERT(compareUrls.find(urlCtx->url) != compareUrls.end());
-		ASSERT_EQ(urlCtx->nFailedResponses, 0);
-		ASSERT_EQ(urlCtx->nRequests, 0);
-		ASSERT_EQ(urlCtx->nResponseParseFailures, 0);
+	return Void();
+}
+
+ACTOR Future<Void> testParseDiscoverKmsUrlFileAlreadyExisting(Reference<RESTKmsConnectorCtx> ctx) {
+	std::unordered_map<std::string, KmsUrlCtx<KmsUrlPenaltyParams>> urlMap;
+	dropCachedKmsUrls(ctx, &urlMap);
+	ASSERT_EQ(ctx->kmsUrlStore.kmsUrls.size(), 0);
+
+	auto urlCtx = KmsUrlCtx<KmsUrlPenaltyParams>("https://127.0.0.1/foo2");
+	urlCtx.nFailedResponses = 1;
+	urlCtx.nRequests = 2;
+	urlCtx.nResponseParseFailures = 3;
+	ctx->kmsUrlStore.kmsUrls.push_back(KmsUrlCtx<KmsUrlPenaltyParams>("https://127.0.0.1/foo4"));
+	ctx->kmsUrlStore.kmsUrls.push_back(KmsUrlCtx<KmsUrlPenaltyParams>("https://127.0.0.1/foo5"));
+	ctx->kmsUrlStore.kmsUrls.push_back(KmsUrlCtx<KmsUrlPenaltyParams>(urlCtx));
+
+	state std::shared_ptr<platform::TmpFile> tmpFile = std::make_shared<platform::TmpFile>("/tmp");
+	ASSERT(fileExists(tmpFile->getFileName()));
+
+	state std::unordered_set<std::string> urls;
+	urls.emplace("https://127.0.0.1/foo  ");
+	urls.emplace("  https://127.0.0.1/foo1");
+	urls.emplace("  https://127.0.0.1/foo2  ");
+
+	state std::unordered_set<std::string> compareUrls;
+	compareUrls.emplace("https://127.0.0.1/foo");
+	compareUrls.emplace("https://127.0.0.1/foo1");
+	compareUrls.emplace("https://127.0.0.1/foo2");
+
+	std::string content;
+	for (auto& url : urls) {
+		content.append(url);
+		content.push_back(DISCOVER_URL_FILE_URL_SEP);
+	}
+	tmpFile->write((const uint8_t*)content.data(), content.size());
+	wait(parseDiscoverKmsUrlFile(ctx, tmpFile->getFileName()));
+
+	ASSERT_EQ(ctx->kmsUrlStore.kmsUrls.size(), urls.size());
+	for (const auto& url : ctx->kmsUrlStore.kmsUrls) {
+		ASSERT(compareUrls.find(url.url) != compareUrls.end());
+		if (url.url == "https://127.0.0.1/foo2") {
+			ASSERT_EQ(url.nFailedResponses, 1);
+			ASSERT_EQ(url.nRequests, 2);
+			ASSERT_EQ(url.nResponseParseFailures, 3);
+		} else {
+			ASSERT_EQ(url.nFailedResponses, 0);
+			ASSERT_EQ(url.nRequests, 0);
+			ASSERT_EQ(url.nResponseParseFailures, 0);
+		}
 	}
 
 	return Void();
@@ -1758,6 +1939,7 @@ TEST_CASE("/KmsConnector/REST/ParseKmsDiscoveryUrls") {
 
 	wait(testParseDiscoverKmsUrlFileNotFound(ctx));
 	wait(testParseDiscoverKmsUrlFile(ctx));
+	wait(testParseDiscoverKmsUrlFileAlreadyExisting(ctx));
 
 	return Void();
 }
@@ -1832,6 +2014,59 @@ TEST_CASE("/KmsConnector/REST/GetEncryptionKeyOps") {
 		testGetEncryptKeysByKeyIdsRequestBody(ctx, arena);
 		testGetEncryptKeysByDomainIdsRequestBody(ctx, arena);
 		testGetBlobMetadataRequestBody(ctx);
+	}
+	return Void();
+}
+
+namespace {
+struct TestUrlPenaltyParam {
+	static double penalty(int64_t ignored) {
+		int elapsed = deterministicRandom()->randomInt(1, 120);
+		return KmsUrlPenaltyParams::penalty(elapsed);
+	}
+};
+} // namespace
+
+TEST_CASE("/KmsConnector/KmsUrlStore") {
+	KmsUrlStore<TestUrlPenaltyParam> store;
+	const int nUrls = deterministicRandom()->randomInt(2, 10);
+	for (int i = 0; i < nUrls; i++) {
+		store.kmsUrls.emplace_back("foo" + std::to_string(i));
+	}
+	ASSERT_EQ(store.kmsUrls.size(), nUrls);
+	for (const auto& url : store.kmsUrls) {
+		ASSERT_EQ(url.unresponsivenessPenalty, 0.0);
+		ASSERT_EQ(url.unresponsivenessPenaltyTS, 0);
+		ASSERT_EQ(url.nFailedResponses, 0);
+		ASSERT_EQ(url.nResponseParseFailures, 0);
+		ASSERT_EQ(url.nRequests, 0);
+	}
+
+	const int nIterations = deterministicRandom()->randomInt(100, 500);
+	for (int i = 0; i < nIterations; i++) {
+		const int idx = deterministicRandom()->randomInt(0, nUrls);
+
+		if (deterministicRandom()->coinflip()) {
+			if (deterministicRandom()->coinflip()) {
+				store.penalize(store.kmsUrls[idx], KmsUrlCtx<TestUrlPenaltyParam>::PenaltyType::TIMEOUT);
+			} else {
+				store.penalize(store.kmsUrls[idx], KmsUrlCtx<TestUrlPenaltyParam>::PenaltyType::MALFORMED_RESPONSE);
+			}
+		} else {
+			// perfect world!
+		}
+
+		for (int j = 0; j < store.kmsUrls.size() - 1; j++) {
+			if (store.kmsUrls[j].unresponsivenessPenalty != store.kmsUrls[j + 1].unresponsivenessPenalty) {
+				ASSERT_LE(store.kmsUrls[j].unresponsivenessPenalty, store.kmsUrls[j + 1].unresponsivenessPenalty);
+			} else {
+				if (store.kmsUrls[j].nFailedResponses != store.kmsUrls[j + 1].nFailedResponses) {
+					ASSERT_LE(store.kmsUrls[j].nFailedResponses, store.kmsUrls[j + 1].nFailedResponses);
+				} else {
+					ASSERT_LE(store.kmsUrls[j].nResponseParseFailures, store.kmsUrls[j + 1].nResponseParseFailures);
+				}
+			}
+		}
 	}
 	return Void();
 }

--- a/tests/fast/RESTUnit.toml
+++ b/tests/fast/RESTUnit.toml
@@ -26,4 +26,4 @@ startDelay = 0
 
     [[test.workload]]
     testName = 'UnitTests'
-    testsMatching = '/KmsConnector/REST/'    
+    testsMatching = '/KmsConnector/'


### PR DESCRIPTION
* EaR: Update KMS URL refresh policy and fix bugs

Description

RESTKmsConnector implements discovery and refresh semantics i.e. on bootstrap it discovers KMS Urls and periodically refresh the URLs (handle server upgrade scenario). The current implementation caches the URLs in a min-heap, as part of serving a request, actor pops out elements from min-heap and attempts connecting to the server, on failure, the URL is temporarily stored in a stack, at the end of the request processing, the stack is merged back into the heap. The code doesn't work as expected if there are multiple requests consumes the heap causing following issues:
1. Min-heap would retain old URLs replaced by latest refresh (stack merge)
2. URL discovery file is read more than expected as multiple requests can empty heap, causing the code to read URLs from the file.

Patch proposes following policy to cache and maintain URLs priority:
1. Unresponsiveness penalty: KMS flaky connection or overload can cause requests to timeout or fail; each such instance updates unresponsiveness penalty of associated URL context. Further, the penalty is time bound and deteriorate with time.
2. Cached URLs are sorted once a failure is encountered, priority followed is:
2.1. Unresponsiveness penalty server(s) least preferred 2.2. Server(s) with high total-failures less preferred 2.3. Server(s) with high total-malformed response less preferred.
3. Updates RESTClient to throw 'retryable' error up to the client such as: 'connection_failed' and/or 'timeout'
4. Extend RESTUrl to support IPv6 format.

Testing

RESTUnit - 100K (new test added for coverage)
devRunCorrectness

(cherry picked from commit bfbf8cd0530a13ad180fc1864254a2c70a0b8f47)

Replace this text with your description here...

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
