### PR TITLE
Decrease the number of records in MutationLogReaderCorrectness (snowflake/release-71.3)

### DIFF
--- a/fdbserver/workloads/MutationLogReaderCorrectness.actor.cpp
+++ b/fdbserver/workloads/MutationLogReaderCorrectness.actor.cpp
@@ -60,7 +60,7 @@ struct MutationLogReaderCorrectnessWorkload : TestWorkload {
 
 		beginVersion = deterministicRandom()->randomInt64(
 		    0, std::numeric_limits<int32_t>::max()); // intentionally not max of int64
-		records = deterministicRandom()->randomInt(0, 1e6);
+		records = deterministicRandom()->randomInt(0, 500e3);
 		versionRange = deterministicRandom()->randomInt64(records, std::numeric_limits<Version>::max());
 		versionIncrement = versionRange / (records + 1);
 


### PR DESCRIPTION
This decreases its overall duration and helps avoids timeouts.

Passed 100K correctness: 20230622-204338-abeamon-08d501a986ce66ef

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
