### PR TITLE
Speed up DR upgrade tests (snowflake/release-71.3)

### DIFF
--- a/fdbclient/BackupAgentBase.actor.cpp
+++ b/fdbclient/BackupAgentBase.actor.cpp
@@ -628,8 +628,8 @@ ACTOR Future<Void> readCommitted(Database cx,
 				}
 				rangevalue = copy;
 				rangevalue.more = true;
-				// Half of the time wait for this tr to expire so that the next read is at a different version
-				if (deterministicRandom()->random01() < 0.5)
+				// Some of the time wait for this tr to expire so that the next read is at a different version
+				if (deterministicRandom()->random01() < 0.01)
 					wait(delay(6.0));
 			}
 

--- a/tests/restarting/from_5.1.7_until_6.3.0/DrUpgradeRestart-1.txt
+++ b/tests/restarting/from_5.1.7_until_6.3.0/DrUpgradeRestart-1.txt
@@ -6,7 +6,7 @@ simBackupAgents=BackupToDB
 
     testName=Cycle
     nodeCount=30000
-    transactionsPerSecond=2500.0
+    transactionsPerSecond=1000.0
     testDuration=30.0
     expectedRate=0
 

--- a/tests/restarting/from_5.1.7_until_6.3.0/DrUpgradeRestart-2.txt
+++ b/tests/restarting/from_5.1.7_until_6.3.0/DrUpgradeRestart-2.txt
@@ -8,7 +8,7 @@ waitForQuiescenceBegin=false
 
     testName=Cycle
     nodeCount=30000
-    transactionsPerSecond=2500.0
+    transactionsPerSecond=1000.0
     testDuration=30.0
     expectedRate=0
 

--- a/tests/restarting/from_6.3.13_until_71.2.0/DrUpgradeRestart-1.txt
+++ b/tests/restarting/from_6.3.13_until_71.2.0/DrUpgradeRestart-1.txt
@@ -7,7 +7,7 @@ simBackupAgents=BackupToDB
 
     testName=Cycle
     nodeCount=30000
-    transactionsPerSecond=2500.0
+    transactionsPerSecond=1000.0
     testDuration=30.0
     expectedRate=0
 

--- a/tests/restarting/from_6.3.13_until_71.2.0/DrUpgradeRestart-2.txt
+++ b/tests/restarting/from_6.3.13_until_71.2.0/DrUpgradeRestart-2.txt
@@ -8,7 +8,7 @@ waitForQuiescenceBegin=false
 
     testName=Cycle
     nodeCount=30000
-    transactionsPerSecond=2500.0
+    transactionsPerSecond=1000.0
     testDuration=30.0
     expectedRate=0
 

--- a/tests/restarting/from_71.2.0_until_71.3.0/DrUpgradeRestart-1.toml
+++ b/tests/restarting/from_71.2.0_until_71.3.0/DrUpgradeRestart-1.toml
@@ -12,7 +12,7 @@ simBackupAgents = "BackupToDB"
     [[test.workload]]
     testName = "Cycle"
     nodeCount = 30000
-    transactionsPerSecond = 2500.0
+    transactionsPerSecond = 1000.0
     testDuration = 30.0
     expectedRate = 0
 

--- a/tests/restarting/from_71.2.0_until_71.3.0/DrUpgradeRestart-2.toml
+++ b/tests/restarting/from_71.2.0_until_71.3.0/DrUpgradeRestart-2.toml
@@ -11,7 +11,7 @@ waitForQuiescenceBegin = false
     [[test.workload]]
     testName = "Cycle"
     nodeCount = 30000
-    transactionsPerSecond = 2500.0
+    transactionsPerSecond = 1000.0
     testDuration = 30.0
     expectedRate = 0
 

--- a/tests/restarting/from_71.3.0/DrUpgradeRestart-1.toml
+++ b/tests/restarting/from_71.3.0/DrUpgradeRestart-1.toml
@@ -12,7 +12,7 @@ simBackupAgents = "BackupToDB"
     [[test.workload]]
     testName = "Cycle"
     nodeCount = 30000
-    transactionsPerSecond = 2500.0
+    transactionsPerSecond = 1000.0
     testDuration = 30.0
     expectedRate = 0
 

--- a/tests/restarting/from_71.3.0/DrUpgradeRestart-2.toml
+++ b/tests/restarting/from_71.3.0/DrUpgradeRestart-2.toml
@@ -11,7 +11,7 @@ waitForQuiescenceBegin = false
     [[test.workload]]
     testName = "Cycle"
     nodeCount = 30000
-    transactionsPerSecond = 2500.0
+    transactionsPerSecond = 1000.0
     testDuration = 30.0
     expectedRate = 0
 


### PR DESCRIPTION
This modifies a buggify to less frequently insert a delay and decreases the TPS rate of the cycle test being run during the DR in order to decrease the runtime of the DR upgrade tests.

Passed 100K correctness: 20230623-161027-abeamon-5a2087cd8a10ca13

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
