### PR TITLE
Speed up BackupCorrectnessClean (snowflake/release-71.3)

### DIFF
--- a/tests/fast/BackupCorrectnessClean.toml
+++ b/tests/fast/BackupCorrectnessClean.toml
@@ -7,21 +7,21 @@ simBackupAgents = 'BackupToFile'
 
     [[test.workload]]
     testName = 'Cycle'
-    transactionsPerSecond = 500.0
+    transactionsPerSecond = 250.0
     testDuration = 20.0
     expectedRate = 0
     keyPrefix = 'a'
 
     [[test.workload]]
     testName = 'Cycle'
-    transactionsPerSecond = 500.0
+    transactionsPerSecond = 250.0
     testDuration = 30.0
     expectedRate = 0
     keyPrefix = 'A'
 
     [[test.workload]]
     testName = 'Cycle'
-    transactionsPerSecond = 500.0
+    transactionsPerSecond = 250.0
     testDuration = 40.0
     expectedRate = 0
     keyPrefix = 'm'


### PR DESCRIPTION
Decrease the transaction rate to speed up the backup correctness clean test

Passed 100K correctness: 20230623-232535-abeamon-5ca566c2043b08a7

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
