### PR TITLE
Automatic idempotency test flagged improper cleanup

### DIFF
--- a/fdbserver/workloads/AutomaticIdempotencyWorkload.actor.cpp
+++ b/fdbserver/workloads/AutomaticIdempotencyWorkload.actor.cpp
@@ -260,7 +260,7 @@ struct AutomaticIdempotencyWorkload : TestWorkload {
 			Version commitVersion;
 			int64_t timestamp;
 			std::vector<Key> decodedKeys = self->idempotencyKeyValueToTestKeys(kv, &commitVersion, &timestamp);
-			for (auto key : decodedKeys) {
+			for (auto const& key : decodedKeys) {
 				timestamps.push_back(timestamp);
 				keys.push_back(key);
 			}


### PR DESCRIPTION
The automatic idempotency test checks whether it has cleaned up too many idempotency keys and fails if so. This check uses timestamps generated prior to commit to make sure that we haven't deleted keys that are too new, but this runs into a subtle issue.

When trying to figure out what timestamps have been deleted, it looks at the oldest remaining timestamp and then sees what timestamps were created before that. Any timestamp created before that is assumed deleted, and the largest of those is treated as the timestamp that we deleted through. However, the timestamps used for deletion and the timestamps used in the test are not exactly the same, and if there is a difference then this can cause us to think that the most recently deleted timestamp is much newer than it actually was.

To correct this, this change computes the largest difference between the test timestamp and idempotency key timestamp and considers any timestamp in that many preceding seconds from the oldest timestamp to be undeleted.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
