### PR TITLE
Adding blob ranges to backup keys

### DIFF
--- a/fdbclient/BackupAgentBase.actor.cpp
+++ b/fdbclient/BackupAgentBase.actor.cpp
@@ -1377,6 +1377,7 @@ VectorRef<KeyRangeRef> const& getSystemBackupRanges() {
 		systemBackupRanges.push_back_deep(systemBackupRanges.arena(),
 		                                  singleKeyRange(metacluster::metadata::metaclusterRegistration().key));
 		systemBackupRanges.push_back_deep(systemBackupRanges.arena(), tagQuotaKeys);
+		systemBackupRanges.push_back_deep(systemBackupRanges.arena(), blobRangeKeys);
 	}
 
 	return systemBackupRanges;


### PR DESCRIPTION
Cherry pick #10059 

Adds blob key ranges to system mutation logs.

100K correctness test passed 20230628-150329-huliu-ba898fe4a0c7942f

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
