### PR TITLE
Fix blob restore stuck issue (Cherry-Pick #10574 to snowflake/release-71.3)

### DIFF
--- a/fdbserver/BlobManifest.actor.cpp
+++ b/fdbserver/BlobManifest.actor.cpp
@@ -706,8 +706,8 @@ public:
 							TraceEvent("BlobRestoreMissingData").detail("KeyRange", granuleRange.toString());
 						} else {
 							TraceEvent("BlobManifestError").error(e).detail("KeyRange", granuleRange.toString());
+							throw;
 						}
-						throw;
 					}
 				}
 				return results;

--- a/fdbserver/workloads/BlobRestoreWorkload.actor.cpp
+++ b/fdbserver/workloads/BlobRestoreWorkload.actor.cpp
@@ -200,7 +200,13 @@ struct BlobRestoreWorkload : TestWorkload {
 				wait(verify(cx, self));
 
 				// Check if we can flush ranges after restore
-				wait(killBlobWorkers(self->extraDb_));
+				state ISimulator::KillType kt = ISimulator::KillType::RebootProcessAndSwitch;
+				g_simulator->killAll(kt, true);
+				g_simulator->toggleGlobalSwitchCluster();
+				wait(delay(2));
+				g_simulator->killAll(kt, true);
+				g_simulator->toggleGlobalSwitchCluster();
+
 				wait(flushBlobRanges(self->extraDb_, self, {}));
 				return Void();
 			}


### PR DESCRIPTION
Cherry-Pick of #10574

100K test passed
20230628-161600-huliu-77ff5a59e54e921a

Original Description:

This PR is to fix a few correctness failures
1.  blob restore is stuck.
2. Assertion finalSplit.keys.size() > 2 failed

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
