### PR TITLE
Fix bug in FDB MultiVersionTransaction.actor.cpp (Cherry-Pick #10576 to snowflake/release-71.3) 

### DIFF
--- a/fdbclient/MultiVersionTransaction.actor.cpp
+++ b/fdbclient/MultiVersionTransaction.actor.cpp
@@ -2016,11 +2016,10 @@ void MultiVersionTenant::TenantState::updateTenant() {
 	}
 
 	tenantUpdater = mapThreadFuture<Void, Void>(currentDb.onChange, [self](ErrorOr<Void> result) {
-		if (result.isError()) {
-			throw result.getError();
+		if (!result.isError()) {
+			self->updateTenant();
 		}
-		self->updateTenant();
-		return Void();
+		return result;
 	});
 }
 

--- a/fdbclient/MultiVersionTransaction.actor.cpp
+++ b/fdbclient/MultiVersionTransaction.actor.cpp
@@ -2016,6 +2016,9 @@ void MultiVersionTenant::TenantState::updateTenant() {
 	}
 
 	tenantUpdater = mapThreadFuture<Void, Void>(currentDb.onChange, [self](ErrorOr<Void> result) {
+		if (result.isError()) {
+			throw result.getError();
+		}
 		self->updateTenant();
 		return Void();
 	});


### PR DESCRIPTION
Cherry-Pick of https://github.com/apple/foundationdb/pull/10576

Original Description:

Throw error in tenantUpdater if result is an error
Duplicate of https://github.com/apple/foundationdb/pull/10577 because changes can't be pushed to origin

100k correctness with 1 known unrelated failure on `20230628-225819-jfu-810910c7a465645c`

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
