### PR TITLE
Show manifest dump info in status json even when no flushing (Cherry-Pick #10584 to snowflake/release-71.3)

### DIFF
--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -2460,15 +2460,12 @@ ACTOR static Future<JsonBuilderObject> blobGranulesStatusFetcher(
 			Optional<TraceEventFields> fields = wait(timeoutError(
 			    latestEventOnWorker(addressWorkersMap[managerIntf.get().address()], "BlobManagerMetrics"), 2.0));
 			if (fields.present()) {
-				int64_t lastFlushVersion = fields.get().getUint64("LastFlushVersion");
-				if (lastFlushVersion > 0) {
-					statusObj["last_flush_version"] = fields.get().getUint64("LastFlushVersion");
-					statusObj["last_manifest_dump_ts"] = fields.get().getUint64("LastManifestDumpTs");
-					statusObj["last_manifest_seq_no"] = fields.get().getUint64("LastManifestSeqNo");
-					statusObj["last_manifest_epoch"] = fields.get().getUint64("Epoch");
-					statusObj["last_manifest_size_in_bytes"] = fields.get().getUint64("ManifestSizeInBytes");
-					statusObj["last_truncation_version"] = fields.get().getUint64("LastMLogTruncationVersion");
-				}
+				statusObj["last_flush_version"] = fields.get().getUint64("LastFlushVersion");
+				statusObj["last_manifest_dump_ts"] = fields.get().getUint64("LastManifestDumpTs");
+				statusObj["last_manifest_seq_no"] = fields.get().getUint64("LastManifestSeqNo");
+				statusObj["last_manifest_epoch"] = fields.get().getUint64("Epoch");
+				statusObj["last_manifest_size_in_bytes"] = fields.get().getUint64("ManifestSizeInBytes");
+				statusObj["last_truncation_version"] = fields.get().getUint64("LastMLogTruncationVersion");
 			}
 		}
 


### PR DESCRIPTION
Cherry-Pick of #10584

100K correctness 20230630-023510-huliu-9a12d3919540030c(with 1 unrelated failure VersionStampSwitchover.toml)

Original Description:

This PR fixed a problem in status json. Without this PR, manifest backup fields in status json doesn't show up after blob manager restart

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
