### PR TITLE
[swift] fix Swift specific build regressions

### DIFF
--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -538,6 +538,11 @@ if (WITH_SWIFT)
 
   set(SwiftOptions "${SwiftOptions} -Xcc -DWITH_SWIFT")
 
+  # Supress noisy C++ warnings from Swift.
+  set(SwiftOptions "${SwiftOptions} -Xcc -Wno-deprecated -Xcc -Wno-undefined-var-template")
+  # Supress rapidjson noisy GCC pragma diagnostics.
+  set(SwiftOptions "${SwiftOptions} -Xcc -Wno-unknown-warning-option")
+
   if (FOUNDATIONDB_CROSS_COMPILING)
     # Cross-compilation options.
     # For some reason we need to specify -sdk explictly to pass config-time

--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -176,7 +176,7 @@ else()
     # The default DWARF 5 format does not play nicely with GNU Binutils 2.39 and earlier, resulting
     # in tools like addr2line omitting line numbers. We can consider removing this once we are able 
     # to use a version that has a fix.
-    add_compile_options(-gdwarf-4)
+    add_compile_options("$<${is_cxx_compile}:-gdwarf-4>")
   endif()
 
   if(FDB_RELEASE OR FULL_DEBUG_SYMBOLS OR CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -536,6 +536,8 @@ if (WITH_SWIFT)
   # Enable Swift <-> C++ interoperability.
   set(SwiftOptions "${SwiftOptions} -cxx-interoperability-mode=swift-5.9")
 
+  set(SwiftOptions "${SwiftOptions} -Xcc -DWITH_SWIFT")
+
   if (FOUNDATIONDB_CROSS_COMPILING)
     # Cross-compilation options.
     # For some reason we need to specify -sdk explictly to pass config-time

--- a/fdbserver/CMakeLists.txt
+++ b/fdbserver/CMakeLists.txt
@@ -56,6 +56,7 @@ if (WITH_SWIFT)
       "${CMAKE_SOURCE_DIR}/contrib/sqlite"
       "${Boost_DIR}/../../../include"
       "${msgpack_DIR}/include"
+      "${CMAKE_SOURCE_DIR}/contrib/rapidjson"
   )
 
   # TODO: the TBD validation skip is because of swift_job_run_generic, though it seems weird why we need to do that?

--- a/flow/include/flow/Optional.h
+++ b/flow/include/flow/Optional.h
@@ -28,7 +28,9 @@
 #include "flow/FileIdentifier.h"
 #include "flow/Error.h"
 #include "flow/swift_support.h"
+#ifdef WITH_SWIFT
 #include <swift/bridging>
+#endif
 
 class Arena;
 

--- a/flow/include/flow/Optional.h
+++ b/flow/include/flow/Optional.h
@@ -45,7 +45,11 @@ class Arena;
 //    assertion failures are preferable. This is the main reason we
 //    don't intend to use std::optional directly.
 template <class T>
-class SWIFT_CONFORMS_TO_PROTOCOL(flow_swift.FlowOptionalProtocol) Optional : public ComposedIdentifier<T, 4> {
+class
+#ifdef WITH_SWIFT
+    SWIFT_CONFORMS_TO_PROTOCOL(flow_swift.FlowOptionalProtocol)
+#endif
+        Optional : public ComposedIdentifier<T, 4> {
 public:
 	using ValueType = T;
 	using Wrapped = T;

--- a/flow/include/flow/Optional.h
+++ b/flow/include/flow/Optional.h
@@ -28,6 +28,7 @@
 #include "flow/FileIdentifier.h"
 #include "flow/Error.h"
 #include "flow/swift_support.h"
+#include <swift/bridging>
 
 class Arena;
 
@@ -44,7 +45,7 @@ class Arena;
 //    assertion failures are preferable. This is the main reason we
 //    don't intend to use std::optional directly.
 template <class T>
-class SWIFT_CONFORMS_TO(flow_swift, FlowOptionalProtocol) Optional : public ComposedIdentifier<T, 4> {
+class SWIFT_CONFORMS_TO_PROTOCOL(flow_swift.FlowOptionalProtocol) Optional : public ComposedIdentifier<T, 4> {
 public:
 	using ValueType = T;
 	using Wrapped = T;

--- a/flow/include/flow/flow.h
+++ b/flow/include/flow/flow.h
@@ -942,7 +942,7 @@ using flow_swift::FlowCheckedContinuation;
 
 template<class T>
 class
-SWIFT_CONFORMS_TO(flow_swift, FlowCallbackForSwiftContinuationT)
+SWIFT_CONFORMS_TO_PROTOCOL(flow_swift.FlowCallbackForSwiftContinuationT)
 FlowCallbackForSwiftContinuation : Callback<T> {
 public:
 	using SwiftCC = flow_swift::FlowCheckedContinuation<T>;
@@ -995,7 +995,7 @@ template <class T>
 class
 SWIFT_SENDABLE
 #ifndef SWIFT_HIDE_CHECKED_CONTINUTATION
-SWIFT_CONFORMS_TO(flow_swift, FlowFutureOps)
+SWIFT_CONFORMS_TO_PROTOCOL(flow_swift.FlowFutureOps)
 #endif
 Future {
 public:

--- a/flow/include/flow/flow.h
+++ b/flow/include/flow/flow.h
@@ -60,6 +60,8 @@
 #include "SwiftModules/Flow_CheckedContinuation.h"
 #endif  /* SWIFT_HIDE_CHECKED_CONTINUATION */
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnullability-completeness"
 #endif /* WITH_SWIFT */
 
 #include "pthread.h"
@@ -97,7 +99,7 @@ bool validationIsEnabled(BuggifyType type);
 
 namespace SwiftBridging {
 
-inline bool buggify(const char *filename, int line) {
+inline bool buggify(const char * _Nonnull filename, int line) {
     // SEE: BUGGIFY_WITH_PROB and BUGGIFY macros above.
     return getSBVar(filename, line, BuggifyType::General) && deterministicRandom()->random01() < (P_BUGGIFIED_SECTION_FIRES[int(BuggifyType::General)]);
 }
@@ -1608,6 +1610,10 @@ inline bool check_yield(TaskPriority taskID = TaskPriority::DefaultYield) {
 }
 
 void bindDeterministicRandomToOpenssl();
+
+#ifdef WITH_SWIFT
+#pragma clang diagnostic pop
+#endif
 
 #include "flow/genericactors.actor.h"
 #endif

--- a/flow/include/flow/flow.h
+++ b/flow/include/flow/flow.h
@@ -944,7 +944,9 @@ using flow_swift::FlowCheckedContinuation;
 
 template<class T>
 class
+#ifdef WITH_SWIFT
 SWIFT_CONFORMS_TO_PROTOCOL(flow_swift.FlowCallbackForSwiftContinuationT)
+#endif
 FlowCallbackForSwiftContinuation : Callback<T> {
 public:
 	using SwiftCC = flow_swift::FlowCheckedContinuation<T>;
@@ -997,7 +999,9 @@ template <class T>
 class
 SWIFT_SENDABLE
 #ifndef SWIFT_HIDE_CHECKED_CONTINUTATION
+#ifdef WITH_SWIFT
 SWIFT_CONFORMS_TO_PROTOCOL(flow_swift.FlowFutureOps)
+#endif
 #endif
 Future {
 public:

--- a/flow/include/flow/swift_concurrency_hooks.h
+++ b/flow/include/flow/swift_concurrency_hooks.h
@@ -236,18 +236,18 @@
 // typedef struct _Job* JobRef;
 
 /// A hook to take over global enqueuing.
-typedef SWIFT_CC(swift) void (*swift_task_enqueueGlobal_original)(swift::Job* job);
+typedef SWIFT_CC(swift) void (*swift_task_enqueueGlobal_original)(swift::Job* _Nonnull job);
 SWIFT_EXPORT_FROM(swift_Concurrency)
 SWIFT_CC(swift)
-void (*_Nullable swift_task_enqueueGlobal_hook)(swift::Job* job, swift_task_enqueueGlobal_original _Nonnull original);
+void (*_Nullable swift_task_enqueueGlobal_hook)(swift::Job* _Nonnull job, swift_task_enqueueGlobal_original _Nonnull original);
 
 /// A hook to take over global enqueuing with delay.
-typedef SWIFT_CC(swift) void (*swift_task_enqueueGlobalWithDelay_original)(unsigned long long delay, swift::Job* job);
+typedef SWIFT_CC(swift) void (*swift_task_enqueueGlobalWithDelay_original)(unsigned long long delay, swift::Job* _Nonnull job);
 SWIFT_EXPORT_FROM(swift_Concurrency)
 SWIFT_CC(swift)
-void (*swift_task_enqueueGlobalWithDelay_hook)(unsigned long long delay,
+void (* _Nonnull swift_task_enqueueGlobalWithDelay_hook)(unsigned long long delay,
                                                swift::Job* _Nonnull job,
-                                               swift_task_enqueueGlobalWithDelay_original original);
+                                               swift_task_enqueueGlobalWithDelay_original _Nonnull original);
 
 typedef SWIFT_CC(swift) void (*swift_task_enqueueGlobalWithDeadline_original)(long long sec,
                                                                               long long nsec,
@@ -257,21 +257,21 @@ typedef SWIFT_CC(swift) void (*swift_task_enqueueGlobalWithDeadline_original)(lo
                                                                               swift::Job* _Nonnull job);
 SWIFT_EXPORT_FROM(swift_Concurrency)
 SWIFT_CC(swift)
-void (*swift_task_enqueueGlobalWithDeadline_hook)(long long sec,
+void (* _Nonnull swift_task_enqueueGlobalWithDeadline_hook)(long long sec,
                                                   long long nsec,
                                                   long long tsec,
                                                   long long tnsec,
                                                   int clock,
-                                                  swift::Job* job,
-                                                  swift_task_enqueueGlobalWithDeadline_original original);
+                                                  swift::Job* _Nonnull job,
+                                                  swift_task_enqueueGlobalWithDeadline_original _Nonnull original);
 
 /// A hook to take over main executor enqueueing.
-typedef SWIFT_CC(swift) void (*swift_task_enqueueMainExecutor_original)(swift::Job* job);
+typedef SWIFT_CC(swift) void (*swift_task_enqueueMainExecutor_original)(swift::Job* _Nonnull job);
 SWIFT_EXPORT_FROM(swift_Concurrency)
 SWIFT_CC(swift)
-void (*swift_task_enqueueMainExecutor_hook)(swift::Job* _Nonnull job, swift_task_enqueueMainExecutor_original original);
+void (* _Nonnull swift_task_enqueueMainExecutor_hook)(swift::Job* _Nonnull job, swift_task_enqueueMainExecutor_original _Nonnull original);
 
-SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift) void swift_job_run(swift::Job* job, ExecutorRef executor);
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift) void swift_job_run(swift::Job* _Nonnull job, ExecutorRef executor);
 
 // FIXME: why is adding this function causing TDB issues, even if it is not a Swift declared thing?
 //    <unknown>:0: error: symbol '_Z17s_job_run_genericP3Job' (_Z17s_job_run_genericP3Job) is in generated IR file, but
@@ -279,13 +279,13 @@ SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift) void swift_job_run(swift::J
 //    and include the project, and add '-Xfrontend -validate-tbd-against-ir=none' to squash the errors WORKAROUND:
 //    skipping TBD validation
 // This function exists so we can get the generic executor, and don't have to do that from Swift.
-void swift_job_run_generic(swift::Job* job);
+void swift_job_run_generic(swift::Job* _Nonnull job);
 
 SWIFT_CC(swift)
-void net2_enqueueGlobal_hook_impl(swift::Job* _Nonnull job, void (*_Nonnull)(swift::Job*) __attribute__((swiftcall)));
+void net2_enqueueGlobal_hook_impl(swift::Job* _Nonnull job, void (*_Nonnull)(swift::Job* _Nonnull) __attribute__((swiftcall)));
 
 SWIFT_CC(swift)
-void sim2_enqueueGlobal_hook_impl(swift::Job* _Nonnull job, void (*_Nonnull)(swift::Job*) __attribute__((swiftcall)));
+void sim2_enqueueGlobal_hook_impl(swift::Job* _Nonnull job, void (*_Nonnull)(swift::Job* _Nonnull) __attribute__((swiftcall)));
 
 inline void installSwiftConcurrencyHooks(bool isSimulator, INetwork* _Nonnull net) {
 #ifdef WITH_SWIFT

--- a/flow/include/flow/swift_concurrency_hooks.h
+++ b/flow/include/flow/swift_concurrency_hooks.h
@@ -239,15 +239,17 @@
 typedef SWIFT_CC(swift) void (*swift_task_enqueueGlobal_original)(swift::Job* _Nonnull job);
 SWIFT_EXPORT_FROM(swift_Concurrency)
 SWIFT_CC(swift)
-void (*_Nullable swift_task_enqueueGlobal_hook)(swift::Job* _Nonnull job, swift_task_enqueueGlobal_original _Nonnull original);
+void (*_Nullable swift_task_enqueueGlobal_hook)(swift::Job* _Nonnull job,
+                                                swift_task_enqueueGlobal_original _Nonnull original);
 
 /// A hook to take over global enqueuing with delay.
-typedef SWIFT_CC(swift) void (*swift_task_enqueueGlobalWithDelay_original)(unsigned long long delay, swift::Job* _Nonnull job);
+typedef SWIFT_CC(swift) void (*swift_task_enqueueGlobalWithDelay_original)(unsigned long long delay,
+                                                                           swift::Job* _Nonnull job);
 SWIFT_EXPORT_FROM(swift_Concurrency)
 SWIFT_CC(swift)
-void (* _Nonnull swift_task_enqueueGlobalWithDelay_hook)(unsigned long long delay,
-                                               swift::Job* _Nonnull job,
-                                               swift_task_enqueueGlobalWithDelay_original _Nonnull original);
+void (*_Nonnull swift_task_enqueueGlobalWithDelay_hook)(unsigned long long delay,
+                                                        swift::Job* _Nonnull job,
+                                                        swift_task_enqueueGlobalWithDelay_original _Nonnull original);
 
 typedef SWIFT_CC(swift) void (*swift_task_enqueueGlobalWithDeadline_original)(long long sec,
                                                                               long long nsec,
@@ -257,21 +259,24 @@ typedef SWIFT_CC(swift) void (*swift_task_enqueueGlobalWithDeadline_original)(lo
                                                                               swift::Job* _Nonnull job);
 SWIFT_EXPORT_FROM(swift_Concurrency)
 SWIFT_CC(swift)
-void (* _Nonnull swift_task_enqueueGlobalWithDeadline_hook)(long long sec,
-                                                  long long nsec,
-                                                  long long tsec,
-                                                  long long tnsec,
-                                                  int clock,
-                                                  swift::Job* _Nonnull job,
-                                                  swift_task_enqueueGlobalWithDeadline_original _Nonnull original);
+void (*_Nonnull swift_task_enqueueGlobalWithDeadline_hook)(
+    long long sec,
+    long long nsec,
+    long long tsec,
+    long long tnsec,
+    int clock,
+    swift::Job* _Nonnull job,
+    swift_task_enqueueGlobalWithDeadline_original _Nonnull original);
 
 /// A hook to take over main executor enqueueing.
 typedef SWIFT_CC(swift) void (*swift_task_enqueueMainExecutor_original)(swift::Job* _Nonnull job);
 SWIFT_EXPORT_FROM(swift_Concurrency)
 SWIFT_CC(swift)
-void (* _Nonnull swift_task_enqueueMainExecutor_hook)(swift::Job* _Nonnull job, swift_task_enqueueMainExecutor_original _Nonnull original);
+void (*_Nonnull swift_task_enqueueMainExecutor_hook)(swift::Job* _Nonnull job,
+                                                     swift_task_enqueueMainExecutor_original _Nonnull original);
 
-SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift) void swift_job_run(swift::Job* _Nonnull job, ExecutorRef executor);
+SWIFT_EXPORT_FROM(swift_Concurrency)
+SWIFT_CC(swift) void swift_job_run(swift::Job* _Nonnull job, ExecutorRef executor);
 
 // FIXME: why is adding this function causing TDB issues, even if it is not a Swift declared thing?
 //    <unknown>:0: error: symbol '_Z17s_job_run_genericP3Job' (_Z17s_job_run_genericP3Job) is in generated IR file, but
@@ -282,10 +287,12 @@ SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift) void swift_job_run(swift::J
 void swift_job_run_generic(swift::Job* _Nonnull job);
 
 SWIFT_CC(swift)
-void net2_enqueueGlobal_hook_impl(swift::Job* _Nonnull job, void (*_Nonnull)(swift::Job* _Nonnull) __attribute__((swiftcall)));
+void net2_enqueueGlobal_hook_impl(swift::Job* _Nonnull job,
+                                  void (*_Nonnull)(swift::Job* _Nonnull) __attribute__((swiftcall)));
 
 SWIFT_CC(swift)
-void sim2_enqueueGlobal_hook_impl(swift::Job* _Nonnull job, void (*_Nonnull)(swift::Job* _Nonnull) __attribute__((swiftcall)));
+void sim2_enqueueGlobal_hook_impl(swift::Job* _Nonnull job,
+                                  void (*_Nonnull)(swift::Job* _Nonnull) __attribute__((swiftcall)));
 
 inline void installSwiftConcurrencyHooks(bool isSimulator, INetwork* _Nonnull net) {
 #ifdef WITH_SWIFT

--- a/flow/include/flow/swift_stream_support.h
+++ b/flow/include/flow/swift_stream_support.h
@@ -102,7 +102,7 @@ private:
 	void (*_Nonnull resumeWithValue)(void* _Nonnull /*context*/, /*value*/ int);
 	void (*_Nonnull resumeWithError)(void* _Nonnull /*context*/, /*value*/ Error);
 
-	SwiftContinuationSingleCallbackCInt(void* continuationBox,
+	SwiftContinuationSingleCallbackCInt(void* _Nonnull continuationBox,
 	                                    void (*_Nonnull returning)(void* _Nonnull, int),
 	                                    void (*_Nonnull throwing)(void* _Nonnull, Error))
 	  : continuationBox(continuationBox), resumeWithValue(returning), resumeWithError(throwing) {}

--- a/flow/include/flow/swift_support.h
+++ b/flow/include/flow/swift_support.h
@@ -59,11 +59,6 @@
 
 #define SWIFT_STRINGIFY(x) #x
 
-/// Specify that the declared type conforms to the given Swift protocol when the type is
-/// imported into Swift.
-#define SWIFT_CONFORMS_TO(ModuleName, ProtocolName)                                                                    \
-	__attribute__((swift_attr(SWIFT_STRINGIFY(conforms_to : ModuleName.ProtocolName))))
-
 #define CONCAT2(id1, id2) id1##id2
 #define CONCAT3(id1, id2, id3) id1##id2##id3
 
@@ -106,7 +101,6 @@ TaskPriority swift_priority_to_net2(swift::JobPriority p);
 #define SWIFT_CXX_IMPORT_UNSAFE
 #define SWIFT_CXX_IMPORT_OWNED
 #define SWIFT_SENDABLE
-#define SWIFT_CONFORMS_TO(ModuleName, ProtocolName)
 #define SWIFT_NAME(x)
 #define CONCAT2(id1, id2) id1##id2
 #define CONCAT3(id1, id2, id3) id1##id2##id3


### PR DESCRIPTION
- We must pass `WITH_SWIFT` to clang importer.
- Migrate to `SWIFT_CONFORMS_TO_PROTOCOL` from `<swift/bridging>` correctly