### PR TITLE
Simulate connection failure between specific pairs of machines

### DIFF
--- a/fdbrpc/include/fdbrpc/simulator.h
+++ b/fdbrpc/include/fdbrpc/simulator.h
@@ -286,6 +286,8 @@ public:
 	virtual void clogInterface(const IPAddress& ip, double seconds, ClogMode mode = ClogDefault) = 0;
 	virtual void clogPair(const IPAddress& from, const IPAddress& to, double seconds) = 0;
 	virtual void unclogPair(const IPAddress& from, const IPAddress& to) = 0;
+	virtual void disconnectPair(const IPAddress& from, const IPAddress& to, double seconds) = 0;
+	virtual void reconnectPair(const IPAddress& from, const IPAddress& to) = 0;
 	virtual std::vector<ProcessInfo*> getAllProcesses() const = 0;
 	virtual ProcessInfo* getProcessByAddress(NetworkAddress const& address) = 0;
 	virtual MachineInfo* getMachineByNetworkAddress(NetworkAddress const& address) = 0;

--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -254,6 +254,16 @@ struct SimClogging {
 		return t - tnow;
 	}
 
+	bool disconnected(const IPAddress& from, const IPAddress& to) {
+		auto pair = std::make_pair(from, to);
+		if (g_simulator->speedUpSimulation || disconnectPairUntil.find(pair) == disconnectPairUntil.end()) {
+			return false;
+		}
+
+		double disconnectUntil = disconnectPairUntil[pair];
+		return now() < disconnectUntil;
+	}
+
 	void clogPairFor(const IPAddress& from, const IPAddress& to, double t) {
 		auto& u = clogPairUntil[std::make_pair(from, to)];
 		u = std::max(u, now() + t);
@@ -287,11 +297,22 @@ struct SimClogging {
 		return i->second;
 	}
 
+	void disconnectPairFor(const IPAddress& from, const IPAddress& to, double t) {
+		auto& u = disconnectPairUntil[std::make_pair(from, to)];
+		u = std::max(u, now() + t);
+	}
+
+	void reconnectPair(const IPAddress& from, const IPAddress& to) {
+		disconnectPairUntil.erase(std::make_pair(from, to));
+	}
+
 private:
 	std::map<IPAddress, double> clogSendUntil, clogRecvUntil;
 	std::map<std::pair<IPAddress, IPAddress>, double> clogPairUntil;
 	std::map<std::pair<IPAddress, IPAddress>, double> clogPairLatency;
 	std::map<std::pair<NetworkAddress, NetworkAddress>, double> clogProcessPairUntil;
+	std::map<std::pair<IPAddress, IPAddress>, double> disconnectPairUntil;
+
 	double halfLatency() const {
 		double a = deterministicRandom()->random01();
 		const double pFast = 0.999;
@@ -338,6 +359,14 @@ struct Sim2Conn final : IConnection, ReferenceCounted<Sim2Conn> {
 		                   std::any_of(peerProcess->childs.begin(),
 		                               peerProcess->childs.end(),
 		                               [&](ISimulator::ProcessInfo* child) { return child && child == process; });
+
+		if (g_clogging.disconnected(process->address.ip, peerProcess->address.ip)) {
+			TraceEvent("SimulatedDisconnection")
+			    .detail("Phase", "Connect")
+			    .detail("Address", process->address)
+			    .detail("Peer", peerProcess->address);
+			throw connection_failed();
+		}
 
 		TraceEvent("Sim2Connection")
 		    .detail("SendBufSize", sendBufSize)
@@ -478,16 +507,26 @@ private:
 			while (self->sentBytes.get() == self->receivedBytes.get())
 				wait(self->sentBytes.onChange());
 			ASSERT(g_simulator->getCurrentProcess() == self->peerProcess);
+
+			// Simulated network disconnection. Make sure to only throw connection_failed() on the sender process.
+			if (g_clogging.disconnected(self->peerProcess->address.ip, self->process->address.ip)) {
+				TraceEvent("SimulatedDisconnection")
+				    .detail("Phase", "DataTransfer")
+				    .detail("Sender", self->peerProcess->address)
+				    .detail("Receiver", self->process->address);
+				throw connection_failed();
+			}
+
 			state int64_t pos =
 			    deterministicRandom()->random01() < .5
 			        ? self->sentBytes.get()
 			        : deterministicRandom()->randomInt64(self->receivedBytes.get(), self->sentBytes.get() + 1);
 			wait(delay(g_clogging.getSendDelay(
-			    self->process->address, self->peerProcess->address, self->isStableConnection())));
+			    self->peerProcess->address, self->process->address, self->isStableConnection())));
 			wait(g_simulator->onProcess(self->process));
 			ASSERT(g_simulator->getCurrentProcess() == self->process);
 			wait(delay(g_clogging.getRecvDelay(
-			    self->process->address, self->peerProcess->address, self->isStableConnection())));
+			    self->peerProcess->address, self->process->address, self->isStableConnection())));
 			ASSERT(g_simulator->getCurrentProcess() == self->process);
 			if (self->stopReceive.isReady()) {
 				wait(Future<Void>(Never()));
@@ -2388,6 +2427,16 @@ public:
 	void unclogPair(const IPAddress& from, const IPAddress& to) override {
 		TraceEvent("UncloggingPair").detail("From", from).detail("To", to);
 		g_clogging.unclogPair(from, to);
+	}
+
+	void disconnectPair(const IPAddress& from, const IPAddress& to, double seconds) override {
+		TraceEvent("DisconnectPair").detail("From", from).detail("To", to).detail("Seconds", seconds);
+		g_clogging.disconnectPairFor(from, to, seconds);
+	}
+
+	void reconnectPair(const IPAddress& from, const IPAddress& to) override {
+		TraceEvent("ReconnectPair").detail("From", from).detail("To", to);
+		g_clogging.reconnectPair(from, to);
 	}
 
 	void processInjectBlobFault(ProcessInfo* machine, double failureRate) override {


### PR DESCRIPTION
Current SimClogging only simulates high latency instead of disconnection. Adding a functionality to simulate connection failure between a specific pair of machines.

This is tested using the ClogTlog workload.

Simulated connection failure is logged like following
```
trace.0.0.0.0.13132.1688755404.7EuGiY.0.2.xml:<Event Severity="10" Time="207.158469" DateTime="2023-07-07T18:43:47Z" Type="SimulatedDisconnection" Machine="2.0.1.5:1" ID="0000000000000000" Phase="Connect" 
```

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
