### PR TITLE
Allow reading from system keyspace even with default tenant

### DIFF
--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -908,6 +908,7 @@ ACTOR Future<Void> clearData(Database cx, Optional<TenantName> defaultTenant) {
 	loop {
 		try {
 			tr.debugTransaction(debugRandom()->randomUniqueID());
+			tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 			ASSERT(tr.trState->readOptions.present() && tr.trState->readOptions.get().debugID.present());
 			TraceEvent("TesterClearingTenantsStart", tr.trState->readOptions.get().debugID.get());
 			state KeyBackedRangeResult<std::pair<int64_t, TenantMapEntry>> tenants =


### PR DESCRIPTION
As title.
With default tenant, not setting this ACCESS_SYSTEM_KEYS option can lead to the transaction reading
from somewhere else but not the tenant map, thus returning incorrect results.

100K Run:
- 20230711-175034-yajin-616c084995017695. All failures are in BlobGranule restarting tests

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
