### PR TITLE
Disable Change-Feed cache for 71.3 restarting tests

### DIFF
--- a/tests/restarting/to_71.3.0/BlobGranuleRestartCycle-1.toml
+++ b/tests/restarting/to_71.3.0/BlobGranuleRestartCycle-1.toml
@@ -9,6 +9,9 @@ injectSSDelay = true
 # FIXME: re-enable rocks at some point
 storageEngineExcludeTypes = [4, 5]
 
+[[knobs]]
+blob_worker_disk_enabled = false
+
 [[test]]
 testTitle = 'BlobGranuleRestartCycle'
 clearAfterTest=false

--- a/tests/restarting/to_71.3.0/BlobGranuleRestartLarge-1.toml
+++ b/tests/restarting/to_71.3.0/BlobGranuleRestartLarge-1.toml
@@ -9,6 +9,9 @@ injectSSDelay = true
 # FIXME: re-enable rocks at some point
 storageEngineExcludeTypes = [4, 5]
 
+[[knobs]]
+blob_worker_disk_enabled = false
+
 [[test]]
 testTitle = 'BlobGranuleRestartLarge'
 clearAfterTest=false

--- a/tests/restarting/to_71.3.1/BlobGranuleRestartCorrectness-1.toml
+++ b/tests/restarting/to_71.3.1/BlobGranuleRestartCorrectness-1.toml
@@ -5,12 +5,14 @@ allowDefaultTenant = false
 tenantModes = ['optional', 'required']
 injectTargetedSSRestart = true
 injectSSDelay = true
+simHTTPServerEnabled = false
 
 [[knobs]]
 bg_metadata_source = "tenant"
 bg_key_tuple_truncate_offset = 1
 enable_rest_kms_communication = true
 deterministic_blob_metadata = true
+blob_worker_disk_enabled = false
 
 [[test]]
 testTitle = 'BlobGranuleCorrectness'


### PR DESCRIPTION
Description

Given change-feed cache encryption support got added later to 71.3.0 release, using the features for those restarting test leads to tripping asserts due to mismtach detection for EaR state.

Testing

Replace this text with your description here...

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
