### PR TITLE
Fix Implib.so imports when 'amd64' architecture is using

### DIFF
--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -439,17 +439,24 @@ elseif(NOT WIN32 AND NOT APPLE) # Linux Only
     ${SHIM_LIB_OUTPUT_DIR}/libfdb_c.so.tramp.S)
 
   set(IMPLIBSO_SRC_DIR ${CMAKE_SOURCE_DIR}/contrib/Implib.so)
+
+  if(CMAKE_SYSTEM_PROCESSOR STREQUAL "amd64")
+    set(IMPLIBSO_ARCH "x86_64")
+  else()
+    set(IMPLIBSO_ARCH ${CMAKE_SYSTEM_PROCESSOR})
+  endif()
+
   set(IMPLIBSO_SRC
     ${IMPLIBSO_SRC_DIR}/implib-gen.py
     ${IMPLIBSO_SRC_DIR}/arch/common/init.cpp.tpl
-    ${IMPLIBSO_SRC_DIR}/arch/${CMAKE_SYSTEM_PROCESSOR}/config.ini
-    ${IMPLIBSO_SRC_DIR}/arch/${CMAKE_SYSTEM_PROCESSOR}/table.S.tpl
-    ${IMPLIBSO_SRC_DIR}/arch/${CMAKE_SYSTEM_PROCESSOR}/trampoline.S.tpl
+    ${IMPLIBSO_SRC_DIR}/arch/${IMPLIBSO_ARCH}/config.ini
+    ${IMPLIBSO_SRC_DIR}/arch/${IMPLIBSO_ARCH}/table.S.tpl
+    ${IMPLIBSO_SRC_DIR}/arch/${IMPLIBSO_ARCH}/trampoline.S.tpl
     )
 
   add_custom_command(OUTPUT ${SHIM_LIB_GEN_SRC}
     COMMAND $<TARGET_FILE:Python3::Interpreter> ${IMPLIBSO_SRC_DIR}/implib-gen.py
-    --target ${CMAKE_SYSTEM_PROCESSOR}
+    --target ${IMPLIBSO_ARCH}
     --outdir ${SHIM_LIB_OUTPUT_DIR}
     --dlopen-callback=fdb_shim_dlopen_callback
     --symbol-filter='^fdb_.*$$'


### PR DESCRIPTION
Fix from @santana705736 

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
