### PR TITLE
Disabling backup keys logging in simulation to avoid TracingTooManyLines error

### DIFF
--- a/fdbclient/ClientKnobs.cpp
+++ b/fdbclient/ClientKnobs.cpp
@@ -195,7 +195,7 @@ void ClientKnobs::initialize(Randomize randomize) {
 	init( BACKUP_STATUS_JITTER,                   0.05 );
 	init( MIN_CLEANUP_SECONDS,                  3600.0 );
 	init( FASTRESTORE_ATOMICOP_WEIGHT,               1 ); if( randomize && BUGGIFY ) { FASTRESTORE_ATOMICOP_WEIGHT = deterministicRandom()->random01() * 200 + 1; }
-	init( BACKUP_AGENT_VERBOSE_LOGGING, false ); if (randomize && BUGGIFY) { BACKUP_AGENT_VERBOSE_LOGGING = true; }
+	init( BACKUP_AGENT_VERBOSE_LOGGING,          false ); if (randomize && BUGGIFY) { BACKUP_AGENT_VERBOSE_LOGGING = true; }
 
 	// Configuration
 	init( DEFAULT_AUTO_COMMIT_PROXIES,               3 );

--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -446,7 +446,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( ROCKSDB_BLOCK_SIZE,                                  32768 ); // 32 KB, size of the block in rocksdb cache.
 	// Temporary knob to enable trace events which prints details about all the backup keys update(write/clear) operations.
 	// Caution: To be enabled only under supervision.
-	init( SS_BACKUP_KEYS_OP_LOGS,                              false ); if( randomize && BUGGIFY ) SS_BACKUP_KEYS_OP_LOGS = true;
+	init( SS_BACKUP_KEYS_OP_LOGS,                              false );
 
 	// Leader election
 	bool longLeaderElection = randomize && BUGGIFY;


### PR DESCRIPTION
Disabling backup keys logging in simulation to avoid TracingTooManyLines error

Replace this text with your description here...

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
