### PR TITLE
Simplify `GlobalTagThrottler` limiting TPS calculation

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -846,6 +846,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( GLOBAL_TAG_THROTTLING_TRACE_INTERVAL,                  5.0 );
 	init( GLOBAL_TAG_THROTTLING_REPORT_ONLY,                   false );
 	init( GLOBAL_TAG_THROTTLING_FORGET_SS_THRESHOLD,            4096 );
+	init( GLOBAL_TAG_THROTTLING_LIMITING_THRESHOLD,         409600.0 );
 
 	init( GLOBAL_TAG_THROTTLING_TARGET_RATE_FOLDING_TIME,        10.0 );
 	init( GLOBAL_TAG_THROTTLING_TRANSACTION_COUNT_FOLDING_TIME,   2.0 );

--- a/fdbclient/include/fdbclient/ServerKnobs.h
+++ b/fdbclient/include/fdbclient/ServerKnobs.h
@@ -790,6 +790,10 @@ public:
 	// Below this throughput threshold (in bytes/second), ratekeeper will forget about the
 	// throughput of a particular tag on a particular storage server
 	int64_t GLOBAL_TAG_THROTTLING_FORGET_SS_THRESHOLD;
+	// If a tag's throughput on a particular storage server exceeds this threshold,
+	// this storage server's throttling ratio will contribute the calculation of the
+	// throttlingId's limiting transaction rate
+	double GLOBAL_TAG_THROTTLING_LIMITING_THRESHOLD;
 
 	double GLOBAL_TAG_THROTTLING_TARGET_RATE_FOLDING_TIME;
 	double GLOBAL_TAG_THROTTLING_TRANSACTION_COUNT_FOLDING_TIME;

--- a/fdbserver/GlobalTagThrottler.actor.cpp
+++ b/fdbserver/GlobalTagThrottler.actor.cpp
@@ -177,33 +177,13 @@ class GlobalTagThrottlerImpl {
 	Database db;
 	UID id;
 	int maxFallingBehind{ 0 };
+	double limitingThreshold{ 0.0 };
 	uint64_t throttledTagChangeId{ 0 };
 	uint32_t lastBusyTagCount{ 0 };
 
 	std::unordered_map<UID, StorageServerInfo> ssInfos;
 	std::unordered_map<TransactionTag, PerTagStatistics> tagStatistics;
 	ServerThroughputTracker throughputTracker;
-
-	// For transactions with the provided tag, returns the average cost that gets associated with the provided storage
-	// server
-	Optional<double> getAverageTransactionCost(TransactionTag tag, UID storageServerId) const {
-		auto const cost = throughputTracker.getThroughput(storageServerId, tag);
-		if (!cost.present()) {
-			return {};
-		}
-		auto const stats = tryGet(tagStatistics, tag);
-		if (!stats.present()) {
-			return {};
-		}
-		auto const transactionRate = stats.get().getTransactionRate();
-		// If there is less than GLOBAL_TAG_THROTTLING_MIN_RATE transactions per second, we do not have enough data
-		// to accurately compute an average transaction cost.
-		if (transactionRate < SERVER_KNOBS->GLOBAL_TAG_THROTTLING_MIN_RATE) {
-			return {};
-		} else {
-			return std::max(static_cast<double>(CLIENT_KNOBS->TAG_THROTTLING_PAGE_SIZE), cost.get() / transactionRate);
-		}
-	}
 
 	// For transactions with the provided tag, returns the average cost of all transactions
 	// accross the cluster. The minimum cost is one page. If the transaction rate is too low,
@@ -240,49 +220,39 @@ class GlobalTagThrottlerImpl {
 		}
 	}
 
-	// Of all tags meaningfully performing workload on the given storage server,
-	// returns the ratio of total quota allocated to the specified tag
-	double getQuotaRatio(TransactionTagRef tag, UID storageServerId) const {
-		double sumQuota{ 0.0 };
-		double tagQuota{ 0.0 };
-		auto const tagsAffectingStorageServer = throughputTracker.getTagsAffectingStorageServer(storageServerId);
-		for (const auto& t : tagsAffectingStorageServer) {
-			auto const tQuota = getQuota(t, LimitType::TOTAL);
-			sumQuota += tQuota.orDefault(0);
-			if (t.compare(tag) == 0) {
-				tagQuota = tQuota.orDefault(0);
+	Optional<double> getLimitingThrottlingRatio(TransactionTag tag) const {
+		std::unordered_map<Optional<Standalone<StringRef>>, double> zoneThrottlingRatios;
+		for (auto const& [id, ssInfo] : ssInfos) {
+			// Ignore storage servers where throttlingId is not significantly contributing
+			auto const throughput = throughputTracker.getThroughput(id, tag);
+			if (!throughput.present() || throughput.get() < limitingThreshold) {
+				continue;
+			}
+
+			if (ssInfo.throttlingRatio.present()) {
+				auto const [it, inserted] =
+				    zoneThrottlingRatios.try_emplace(ssInfo.zoneId, ssInfo.throttlingRatio.get());
+				if (!inserted) {
+					auto& zoneThrottlingRatio = it->second;
+					zoneThrottlingRatio = std::min<double>(zoneThrottlingRatio, ssInfo.throttlingRatio.get());
+				}
 			}
 		}
-		if (tagQuota == 0.0) {
-			return 0;
-		}
-		ASSERT_GT(sumQuota, 0.0);
-		return tagQuota / sumQuota;
-	}
-
-	// Returns the desired cost for a storage server, based on its current
-	// cost and throttling ratio
-	Optional<double> getLimitingCost(UID storageServerId) const {
-		auto const ssInfo = tryGet(ssInfos, storageServerId);
-		Optional<double> const throttlingRatio = ssInfo.present() ? ssInfo.get().throttlingRatio : Optional<double>{};
-		Optional<double> const currentCost = throughputTracker.getThroughput(storageServerId);
-		if (!throttlingRatio.present() || !currentCost.present()) {
+		if (zoneThrottlingRatios.size() <= maxFallingBehind) {
 			return {};
+		} else {
+			std::priority_queue<double, std::vector<double>> maxHeap;
+			ASSERT_GE(maxFallingBehind, 0);
+			for (auto const& [_, throttlingRatio] : zoneThrottlingRatios) {
+				if (maxHeap.size() < maxFallingBehind + 1) {
+					maxHeap.push(throttlingRatio);
+				} else if (maxHeap.top() > throttlingRatio) {
+					maxHeap.pop();
+					maxHeap.push(throttlingRatio);
+				}
+			}
+			return maxHeap.top();
 		}
-		return throttlingRatio.get() * currentCost.get();
-	}
-
-	// For a given storage server and tag combination, return the limiting transaction rate.
-	Optional<double> getLimitingTps(UID storageServerId, TransactionTag tag) const {
-		auto const quotaRatio = getQuotaRatio(tag, storageServerId);
-		Optional<double> const limitingCost = getLimitingCost(storageServerId);
-		Optional<double> const averageTransactionCost = getAverageTransactionCost(tag, storageServerId);
-		if (!limitingCost.present() || !averageTransactionCost.present()) {
-			return {};
-		}
-
-		auto const limitingCostForTag = limitingCost.get() * quotaRatio;
-		return limitingCostForTag / averageTransactionCost.get();
 	}
 
 	// Return the limiting transaction rate, aggregated across all storage servers.
@@ -291,30 +261,15 @@ class GlobalTagThrottlerImpl {
 	// to affect tag throttling. If more than maxFallingBehind zones are at
 	// or near saturation, this indicates that throttling should take place.
 	Optional<double> getLimitingTps(TransactionTag tag) const {
-		// TODO: The algorithm for ignoring the worst zones can be made more efficient
-		std::unordered_map<Optional<Standalone<StringRef>>, double> zoneIdToLimitingTps;
-		for (const auto& [id, ssInfo] : ssInfos) {
-			auto const limitingTpsForSS = getLimitingTps(id, tag);
-			if (limitingTpsForSS.present()) {
-				auto it = zoneIdToLimitingTps.find(ssInfo.zoneId);
-				if (it != zoneIdToLimitingTps.end()) {
-					auto& limitingTpsForZone = it->second;
-					limitingTpsForZone = std::min<double>(limitingTpsForZone, limitingTpsForSS.get());
-				} else {
-					zoneIdToLimitingTps[ssInfo.zoneId] = limitingTpsForSS.get();
-				}
-			}
-		}
-		if (zoneIdToLimitingTps.size() <= maxFallingBehind) {
+		auto const stats = tryGet(tagStatistics, tag);
+		if (!stats.present()) {
 			return {};
-		} else {
-			std::vector<double> zoneLimits;
-			for (const auto& [_, limit] : zoneIdToLimitingTps) {
-				zoneLimits.push_back(limit);
-			}
-			std::nth_element(zoneLimits.begin(), zoneLimits.begin() + maxFallingBehind, zoneLimits.end());
-			return zoneLimits[maxFallingBehind];
 		}
+		auto const limitingThrottlingRatio = getLimitingThrottlingRatio(tag);
+		if (!limitingThrottlingRatio.present()) {
+			return {};
+		}
+		return stats.get().getTransactionRate() * limitingThrottlingRatio.get();
 	}
 
 	void removeUnseenQuotas(std::unordered_set<TransactionTag> const& tagsWithQuota) {
@@ -385,8 +340,8 @@ class GlobalTagThrottlerImpl {
 	}
 
 public:
-	GlobalTagThrottlerImpl(Database db, UID id, int maxFallingBehind)
-	  : db(db), id(id), maxFallingBehind(maxFallingBehind) {}
+	GlobalTagThrottlerImpl(Database db, UID id, int maxFallingBehind, double limitingThreshold)
+	  : db(db), id(id), maxFallingBehind(maxFallingBehind), limitingThreshold(limitingThreshold) {}
 	Future<Void> monitorThrottlingChanges() { return monitorThrottlingChanges(this); }
 	void addRequests(TransactionTag tag, int count) {
 		auto it = tagStatistics.find(tag);
@@ -517,8 +472,8 @@ public:
 	uint32_t tagsTracked() const { return tagStatistics.size(); }
 };
 
-GlobalTagThrottler::GlobalTagThrottler(Database db, UID id, int maxFallingBehind)
-  : impl(PImpl<GlobalTagThrottlerImpl>::create(db, id, maxFallingBehind)) {}
+GlobalTagThrottler::GlobalTagThrottler(Database db, UID id, int maxFallingBehind, double limitingThreshold)
+  : impl(PImpl<GlobalTagThrottlerImpl>::create(db, id, maxFallingBehind, limitingThreshold)) {}
 
 GlobalTagThrottler::~GlobalTagThrottler() = default;
 
@@ -777,6 +732,11 @@ ACTOR Future<Void> updateGlobalTagThrottler(GlobalTagThrottler* globalTagThrottl
 	}
 }
 
+GlobalTagThrottler getTestGlobalTagThrottler(int maxFallingBehind = 0) {
+	return GlobalTagThrottler(
+	    Database{}, UID{}, maxFallingBehind, /*limitingThreshold=*/CLIENT_KNOBS->TAG_THROTTLING_PAGE_SIZE);
+}
+
 } // namespace
 
 // 10 storage servers can handle 100 pages/second each.
@@ -784,7 +744,7 @@ ACTOR Future<Void> updateGlobalTagThrottler(GlobalTagThrottler* globalTagThrottl
 // Client attempts 5 6-byte read transactions per second.
 // Limit should adjust to allow 100/6 transactions per second.
 TEST_CASE("/GlobalTagThrottler/Simple") {
-	state GlobalTagThrottler globalTagThrottler(Database{}, UID{}, 0);
+	state GlobalTagThrottler globalTagThrottler = getTestGlobalTagThrottler();
 	state StorageServerCollection storageServers(10, 100);
 	ThrottleApi::TagQuotaValue tagQuotaValue;
 	TransactionTag testTag = "sampleTag1"_sr;
@@ -803,7 +763,7 @@ TEST_CASE("/GlobalTagThrottler/Simple") {
 // Client attempts 5 6-byte write transactions per second.
 // Limit should adjust to allow 100/(6*<fungibility_ratio>) transactions per second.
 TEST_CASE("/GlobalTagThrottler/WriteThrottling") {
-	state GlobalTagThrottler globalTagThrottler(Database{}, UID{}, 0);
+	state GlobalTagThrottler globalTagThrottler = getTestGlobalTagThrottler();
 	state StorageServerCollection storageServers(10, 100);
 	ThrottleApi::TagQuotaValue tagQuotaValue;
 	TransactionTag testTag = "sampleTag1"_sr;
@@ -824,7 +784,7 @@ TEST_CASE("/GlobalTagThrottler/WriteThrottling") {
 // 2 clients each attempt 5 6-byte read transactions per second.
 // Both limits should adjust to allow 100/6 transactions per second.
 TEST_CASE("/GlobalTagThrottler/MultiTagThrottling") {
-	state GlobalTagThrottler globalTagThrottler(Database{}, UID{}, 0);
+	state GlobalTagThrottler globalTagThrottler = getTestGlobalTagThrottler();
 	state StorageServerCollection storageServers(10, 100);
 	ThrottleApi::TagQuotaValue tagQuotaValue;
 	TransactionTag testTag1 = "sampleTag1"_sr;
@@ -849,7 +809,7 @@ TEST_CASE("/GlobalTagThrottler/MultiTagThrottling") {
 // Client attempts 20 10-byte read transactions per second.
 // Limit should adjust to allow 100/10 transactions per second.
 TEST_CASE("/GlobalTagThrottler/AttemptWorkloadAboveQuota") {
-	state GlobalTagThrottler globalTagThrottler(Database{}, UID{}, 0);
+	state GlobalTagThrottler globalTagThrottler = getTestGlobalTagThrottler();
 	state StorageServerCollection storageServers(10, 100);
 	ThrottleApi::TagQuotaValue tagQuotaValue;
 	TransactionTag testTag = "sampleTag1"_sr;
@@ -868,7 +828,7 @@ TEST_CASE("/GlobalTagThrottler/AttemptWorkloadAboveQuota") {
 // 2 clients each attempt 5 6-byte transactions per second.
 // Limit should adjust to allow 100/6 transactions per second.
 TEST_CASE("/GlobalTagThrottler/MultiClientThrottling") {
-	state GlobalTagThrottler globalTagThrottler(Database{}, UID{}, 0);
+	state GlobalTagThrottler globalTagThrottler = getTestGlobalTagThrottler();
 	state StorageServerCollection storageServers(10, 100);
 	ThrottleApi::TagQuotaValue tagQuotaValue;
 	TransactionTag testTag = "sampleTag1"_sr;
@@ -890,7 +850,7 @@ TEST_CASE("/GlobalTagThrottler/MultiClientThrottling") {
 // Target rate should adjust to allow 100/10 transactions per second.
 // Each client is throttled to only perform (100/10)/2 transactions per second.
 TEST_CASE("/GlobalTagThrottler/MultiClientThrottling2") {
-	state GlobalTagThrottler globalTagThrottler(Database{}, UID{}, 0);
+	state GlobalTagThrottler globalTagThrottler = getTestGlobalTagThrottler();
 	state StorageServerCollection storageServers(10, 100);
 	ThrottleApi::TagQuotaValue tagQuotaValue;
 	TransactionTag testTag = "sampleTag1"_sr;
@@ -913,7 +873,7 @@ TEST_CASE("/GlobalTagThrottler/MultiClientThrottling2") {
 // Target rate should adjust to allow 100/5 transactions per second.
 // This 20 transactions/second limit is split with a distribution of (5, 15) between the 2 clients.
 TEST_CASE("/GlobalTagThrottler/SkewedMultiClientThrottling") {
-	state GlobalTagThrottler globalTagThrottler(Database{}, UID{}, 0);
+	state GlobalTagThrottler globalTagThrottler = getTestGlobalTagThrottler();
 	state StorageServerCollection storageServers(10, 100);
 	ThrottleApi::TagQuotaValue tagQuotaValue;
 	TransactionTag testTag = "sampleTag1"_sr;
@@ -937,7 +897,7 @@ TEST_CASE("/GlobalTagThrottler/SkewedMultiClientThrottling") {
 // Total quota is modified to 50 pages/second.
 // Target rate should adjust to allow 50/6 transactions per second.
 TEST_CASE("/GlobalTagThrottler/UpdateQuota") {
-	state GlobalTagThrottler globalTagThrottler(Database{}, UID{}, 0);
+	state GlobalTagThrottler globalTagThrottler = getTestGlobalTagThrottler();
 	state StorageServerCollection storageServers(10, 100);
 	state ThrottleApi::TagQuotaValue tagQuotaValue;
 	state TransactionTag testTag = "sampleTag1"_sr;
@@ -963,7 +923,7 @@ TEST_CASE("/GlobalTagThrottler/UpdateQuota") {
 // Then Quota is removed.
 // Target limit is removed as a result.
 TEST_CASE("/GlobalTagThrottler/RemoveQuota") {
-	state GlobalTagThrottler globalTagThrottler(Database{}, UID{}, 0);
+	state GlobalTagThrottler globalTagThrottler = getTestGlobalTagThrottler();
 	state StorageServerCollection storageServers(10, 100);
 	state ThrottleApi::TagQuotaValue tagQuotaValue;
 	state TransactionTag testTag = "sampleTag1"_sr;
@@ -985,7 +945,7 @@ TEST_CASE("/GlobalTagThrottler/RemoveQuota") {
 // Client attempts 10 6-page transactions per second
 // Target is adjusted to 50/6 transactions per second, to match the total capacity all storage servers.
 TEST_CASE("/GlobalTagThrottler/ActiveThrottling") {
-	state GlobalTagThrottler globalTagThrottler(Database{}, UID{}, 0);
+	state GlobalTagThrottler globalTagThrottler = getTestGlobalTagThrottler();
 	state StorageServerCollection storageServers(10, 5);
 	state ThrottleApi::TagQuotaValue tagQuotaValue;
 	TransactionTag testTag = "sampleTag1"_sr;
@@ -1007,7 +967,7 @@ TEST_CASE("/GlobalTagThrottler/ActiveThrottling") {
 //   add storage servers. The two tags receive this capacity with a 2:1 ratio,
 //   matching the ratio of their total quotas.
 TEST_CASE("/GlobalTagThrottler/MultiTagActiveThrottling") {
-	state GlobalTagThrottler globalTagThrottler(Database{}, UID{}, 0);
+	state GlobalTagThrottler globalTagThrottler = getTestGlobalTagThrottler();
 	state StorageServerCollection storageServers(10, 5);
 	state ThrottleApi::TagQuotaValue tagQuotaValue1;
 	state ThrottleApi::TagQuotaValue tagQuotaValue2;
@@ -1036,7 +996,7 @@ TEST_CASE("/GlobalTagThrottler/MultiTagActiveThrottling") {
 // Target rates for both tags are adjusted to 50/6 transactions per second to match the throughput
 //   that the busiest server can handle.
 TEST_CASE("/GlobalTagThrottler/MultiTagActiveThrottling2") {
-	state GlobalTagThrottler globalTagThrottler(Database{}, UID{}, 0);
+	state GlobalTagThrottler globalTagThrottler = getTestGlobalTagThrottler();
 	state StorageServerCollection storageServers(3, 50);
 	state ThrottleApi::TagQuotaValue tagQuotaValue1;
 	state ThrottleApi::TagQuotaValue tagQuotaValue2;
@@ -1066,7 +1026,7 @@ TEST_CASE("/GlobalTagThrottler/MultiTagActiveThrottling2") {
 // of the
 //   storage servers being accessed.
 TEST_CASE("/GlobalTagThrottler/MultiTagActiveThrottling3") {
-	state GlobalTagThrottler globalTagThrottler(Database{}, UID{}, 0);
+	state GlobalTagThrottler globalTagThrottler = getTestGlobalTagThrottler();
 	state StorageServerCollection storageServers(3, 50);
 	state ThrottleApi::TagQuotaValue tagQuotaValue1;
 	state ThrottleApi::TagQuotaValue tagQuotaValue2;
@@ -1095,7 +1055,7 @@ TEST_CASE("/GlobalTagThrottler/MultiTagActiveThrottling3") {
 // Despite the storage server only having capacity to serve 50/6 transactions per second,
 //   the reserved quota will ensure the target rate adjusts to 70/6 transactions per second.
 TEST_CASE("/GlobalTagThrottler/ReservedQuota") {
-	state GlobalTagThrottler globalTagThrottler(Database{}, UID{}, 0);
+	state GlobalTagThrottler globalTagThrottler = getTestGlobalTagThrottler();
 	state StorageServerCollection storageServers(10, 5);
 	state ThrottleApi::TagQuotaValue tagQuotaValue;
 	TransactionTag testTag = "sampleTag1"_sr;
@@ -1113,7 +1073,7 @@ TEST_CASE("/GlobalTagThrottler/ReservedQuota") {
 // Test that tags are expired iff a sufficient amount of time has passed since the
 // last transaction with that tag
 TEST_CASE("/GlobalTagThrottler/ExpireTags") {
-	state GlobalTagThrottler globalTagThrottler(Database{}, UID{}, 0);
+	state GlobalTagThrottler globalTagThrottler = getTestGlobalTagThrottler();
 	state StorageServerCollection storageServers(10, 5);
 	TransactionTag testTag = "sampleTag1"_sr;
 
@@ -1135,7 +1095,7 @@ TEST_CASE("/GlobalTagThrottler/ExpireTags") {
 
 // Test that the number of tags tracked does not grow beyond SERVER_KNOBS->GLOBAL_TAG_THROTTLING_MAX_TAGS_TRACKED
 TEST_CASE("/GlobalTagThrottler/TagLimit") {
-	state GlobalTagThrottler globalTagThrottler(Database{}, UID{}, 0);
+	state GlobalTagThrottler globalTagThrottler = getTestGlobalTagThrottler();
 	state StorageServerCollection storageServers(10, 5);
 	std::vector<Future<Void>> futures;
 	for (int i = 0; i < 2 * SERVER_KNOBS->GLOBAL_TAG_THROTTLING_MAX_TAGS_TRACKED; ++i) {
@@ -1157,7 +1117,7 @@ TEST_CASE("/GlobalTagThrottler/TagLimit") {
 // Then, a second storage server becomes unhealthy and can only handle 1 page/second.
 // Target rate adjusts down to 10/6 transactions per second, because only one bad zone can be ignored.
 TEST_CASE("/GlobalTagThrottler/IgnoreWorstZone") {
-	state GlobalTagThrottler globalTagThrottler(Database{}, UID{}, 1);
+	state GlobalTagThrottler globalTagThrottler = getTestGlobalTagThrottler(/*maxFallingBehind=*/1);
 	state StorageServerCollection storageServers(10, 100);
 	state TransactionTag testTag = "sampleTag1"_sr;
 	storageServers.setCapacity(0, 1);

--- a/fdbserver/Ratekeeper.actor.cpp
+++ b/fdbserver/Ratekeeper.actor.cpp
@@ -663,7 +663,8 @@ Ratekeeper::Ratekeeper(UID id, Database db)
                 SERVER_KNOBS->TARGET_BW_LAG_BATCH),
     maxVersion(0), blobWorkerTime(now()), unblockedAssignmentTime(now()), anyBlobRanges(false) {
 	if (SERVER_KNOBS->GLOBAL_TAG_THROTTLING) {
-		tagThrottler = std::make_unique<GlobalTagThrottler>(db, id, SERVER_KNOBS->MAX_MACHINES_FALLING_BEHIND);
+		tagThrottler = std::make_unique<GlobalTagThrottler>(
+		    db, id, SERVER_KNOBS->MAX_MACHINES_FALLING_BEHIND, SERVER_KNOBS->GLOBAL_TAG_THROTTLING_LIMITING_THRESHOLD);
 	} else {
 		tagThrottler = std::make_unique<TagThrottler>(db, id);
 	}

--- a/fdbserver/include/fdbserver/TagThrottler.h
+++ b/fdbserver/include/fdbserver/TagThrottler.h
@@ -83,7 +83,7 @@ class GlobalTagThrottler : public ITagThrottler {
 	PImpl<class GlobalTagThrottlerImpl> impl;
 
 public:
-	GlobalTagThrottler(Database db, UID id, int maxFallingBehind);
+	GlobalTagThrottler(Database db, UID id, int maxFallingBehind, double limitingThreshold);
 	~GlobalTagThrottler();
 
 	Future<Void> monitorThrottlingChanges() override;


### PR DESCRIPTION
Previously, when calculating the limiting TPS for a throttlingId, the quota throttler would take into account total quotas. With this PR, quotas are ignored when computing limiting TPS. The formula is simply: `limitingThrottlingRatio * currentTps`. This has two advantages:

- It is easier to reason about
- It allows setting extremely large quotas for workloads that we only want to throttle in the saturating case. (Previously these workloads would receive an unfairly large throughput in the saturating case)

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
