### PR TITLE
Stop tracking a storage server after its removal (Cherry-Pick #10630 to snowflake/release-71.3)

### DIFF
--- a/fdbserver/DDTeamCollection.actor.cpp
+++ b/fdbserver/DDTeamCollection.actor.cpp
@@ -2893,7 +2893,7 @@ public:
 					    .detail("Server", server->getId())
 					    .detail("IsTss", isTss)
 					    .detail("Reason", "Absent server list item");
-					return Void();
+					return Never();
 				}
 				Optional<StorageMetadataType> metadata = wait(metadataMap.get(tr, server->getId()));
 				// NOTE: in upgrade testing, there may not be any metadata


### PR DESCRIPTION
Cherry-Pick of #10630

Original Description:

After a storageMetadataTracker detects that a storage server has been removed, the storageServerTracker should stop tracking this server. Without this fix, the
```
when(wait(storageMetadataTracker)) {}
```
will be triggered repeatedly, and the outer loop may busy looping printing trace lines ("UndesiredStorageServer"), which eventually hit `TracedTooManyLines` error.

Test plan:
This failure was captured on snowflake/release-71.3 branch, but I believe the bug is also present on main. To verify that it fixes the issue, do the following:
1. Checkout branch snowflake/release-71.3
2. Profile: team ubsan
3. Commit: 507bbc98e29236e4ac2c11ac602fc7b7b823e225
4. Command: devRetryCorrectnessTest bin/fdbserver -r simulation -f tests/fast/SwizzledRollbackSideband.toml -s 1845441210 -b on  --crash --trace_format json
5. Apply the simple fix, and rerun the test

In addition, we run a 100K Joshua ensemble.
20230717-221754-yajin-095b9d1364faca03, fail=0


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
