### PR TITLE
Add DD Security Mode

### DIFF
--- a/fdbclient/AuditUtils.actor.cpp
+++ b/fdbclient/AuditUtils.actor.cpp
@@ -761,9 +761,9 @@ ACTOR Future<std::vector<AuditStorageState>> loadAndUpdateAuditMetadataWithNewDD
 	loop {
 		try {
 			auditStates.clear();
-			tr.setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
-			tr.setOption(FDBTransactionOptions::READ_LOCK_AWARE);
 			tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
+			tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+			tr.setOption(FDBTransactionOptions::LOCK_AWARE);
 			wait(checkMoveKeysLock(&tr, lock, ddEnabled, true));
 			RangeResult result = wait(tr.getRange(auditKeys, CLIENT_KNOBS->TOO_MANY));
 			if (result.more || result.size() >= CLIENT_KNOBS->TOO_MANY) {

--- a/fdbclient/AuditUtils.actor.cpp
+++ b/fdbclient/AuditUtils.actor.cpp
@@ -815,6 +815,7 @@ ACTOR Future<std::vector<AuditStorageState>> initAuditMetadata(Database cx,
 				wait(tr.onError(e));
 			} catch (Error& e) {
 				retryCount++;
+				tr.reset();
 			}
 		}
 	}

--- a/fdbclient/AuditUtils.actor.cpp
+++ b/fdbclient/AuditUtils.actor.cpp
@@ -808,13 +808,14 @@ ACTOR Future<std::vector<AuditStorageState>> initAuditMetadata(Database cx,
 				throw e;
 			}
 			if (retryCount > 50) {
-				TraceEvent(
-				    g_network->isSimulated() ? SevError : SevWarnAlways, "InitAuditMetadataFailed", dataDistributorId)
-				    .errorUnsuppressed(e);
+				TraceEvent(SevWarnAlways, "InitAuditMetadataExceedRetryMax", dataDistributorId).errorUnsuppressed(e);
 				break;
 			}
-			wait(tr.onError(e));
-			retryCount++;
+			try {
+				wait(tr.onError(e));
+			} catch (Error& e) {
+				retryCount++;
+			}
 		}
 	}
 	return auditStatesToResume;

--- a/fdbclient/AuditUtils.actor.cpp
+++ b/fdbclient/AuditUtils.actor.cpp
@@ -351,7 +351,11 @@ ACTOR static Future<Void> checkMoveKeysLock(Transaction* tr,
 		return Void();
 	} else {
 		CODE_PROBE(true, "checkMoveKeysLock: Conflict with new owner");
-		TraceEvent(SevDebug, "AuditUtilConflictWithNewOwner");
+		TraceEvent(SevDebug, "AuditUtilConflictWithNewOwner")
+		    .detail("CurrentOwner", currentOwner.toString())
+		    .detail("PrevOwner", lock.prevOwner.toString())
+		    .detail("PrevWrite", lock.prevWrite.toString())
+		    .detail("MyOwner", lock.myOwner.toString());
 		throw movekeys_conflict(); // need a new name
 	}
 }

--- a/fdbclient/AuditUtils.actor.cpp
+++ b/fdbclient/AuditUtils.actor.cpp
@@ -848,7 +848,7 @@ ACTOR Future<std::vector<AuditStorageState>> initAuditMetadata(Database cx,
 				throw e;
 			}
 			if (retryCount > 50) {
-				TraceEvent(SevWarnAlways, "initAuditMetadataFailed", dataDistributorId).errorUnsuppressed(e);
+				TraceEvent(SevWarnAlways, "InitAuditMetadataFailed", dataDistributorId).errorUnsuppressed(e);
 				break;
 			}
 			wait(tr.onError(e));

--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -2234,6 +2234,8 @@ ACTOR Future<int> setDDMode(Database cx, int mode) {
 			tr.set(dataDistributionModeKey, wr.toValue());
 			if (mode) {
 				// set DDMode to 1 will enable all disabled parts, for instance the SS failure monitors.
+				// set DDMode to 2 is a security mode which disables data moves but allows auditStorage part
+				// DDMode=2 is set when shard location metadata inconsistency is detected
 				Optional<Value> currentHealthyZoneValue = wait(tr.get(healthyZoneKey));
 				if (currentHealthyZoneValue.present() &&
 				    decodeHealthyZoneValue(currentHealthyZoneValue.get()).first == ignoreSSFailuresZoneString) {

--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -2626,7 +2626,7 @@ Future<Optional<std::string>> DataDistributionImpl::commit(ReadYourWritesTransac
 				try {
 					int mode = boost::lexical_cast<int>(iter->value().second.get().toString());
 					Value modeVal = BinaryWriter::toValue(mode, Unversioned());
-					if (mode == 0 || mode == 1) {
+					if (mode == 0 || mode == 1 || mode == 2) {
 						// Whenever configuration changes or DD related system keyspace is changed,
 						// actor must grab the moveKeysLockOwnerKey and update moveKeysLockWriteKey.
 						// This prevents concurrent write to the same system keyspace.

--- a/fdbclient/include/fdbclient/AuditUtils.actor.h
+++ b/fdbclient/include/fdbclient/AuditUtils.actor.h
@@ -67,8 +67,11 @@ ACTOR Future<Void> clearAuditMetadataForType(Database cx,
                                              UID maxAuditIdToClear,
                                              int numFinishAuditToKeep);
 ACTOR Future<bool> checkStorageServerRemoved(Database cx, UID ssid);
-ACTOR Future<Void> updateAuditState(Database cx, AuditStorageState auditState, MoveKeyLockInfo lock, bool ddEnabled);
 AuditPhase stringToAuditPhase(std::string auditPhaseStr);
 ACTOR Future<bool> checkAuditProgressComplete(Database cx, AuditType auditType, UID auditId, KeyRange auditRange);
+ACTOR Future<std::vector<AuditStorageState>> loadAndUpdateAuditMetadataWithNewDDId(Database cx,
+                                                                                   MoveKeyLockInfo lock,
+                                                                                   bool ddEnabled,
+                                                                                   UID dataDistributorId);
 #include "flow/unactorcompiler.h"
 #endif

--- a/fdbclient/include/fdbclient/AuditUtils.actor.h
+++ b/fdbclient/include/fdbclient/AuditUtils.actor.h
@@ -36,7 +36,6 @@ struct MoveKeyLockInfo {
 	UID prevOwner, myOwner, prevWrite;
 };
 
-ACTOR Future<Void> clearAuditMetadata(Database cx, AuditType auditType, UID auditId, bool clearProgressMetadata);
 ACTOR Future<Void> cancelAuditMetadata(Database cx, AuditType auditType, UID auditId);
 ACTOR Future<UID> persistNewAuditState(Database cx, AuditStorageState auditState, MoveKeyLockInfo lock, bool ddEnabled);
 ACTOR Future<Void> persistAuditState(Database cx,

--- a/fdbclient/include/fdbclient/AuditUtils.actor.h
+++ b/fdbclient/include/fdbclient/AuditUtils.actor.h
@@ -69,9 +69,10 @@ ACTOR Future<Void> clearAuditMetadataForType(Database cx,
 ACTOR Future<bool> checkStorageServerRemoved(Database cx, UID ssid);
 AuditPhase stringToAuditPhase(std::string auditPhaseStr);
 ACTOR Future<bool> checkAuditProgressComplete(Database cx, AuditType auditType, UID auditId, KeyRange auditRange);
-ACTOR Future<std::vector<AuditStorageState>> loadAndUpdateAuditMetadataWithNewDDId(Database cx,
-                                                                                   MoveKeyLockInfo lock,
-                                                                                   bool ddEnabled,
-                                                                                   UID dataDistributorId);
+ACTOR Future<std::vector<AuditStorageState>> initAuditMetadata(Database cx,
+                                                               MoveKeyLockInfo lock,
+                                                               bool ddEnabled,
+                                                               UID dataDistributorId,
+                                                               int persistFinishAuditCount);
 #include "flow/unactorcompiler.h"
 #endif

--- a/fdbserver/DDTxnProcessor.actor.cpp
+++ b/fdbserver/DDTxnProcessor.actor.cpp
@@ -517,7 +517,7 @@ class DDTxnProcessorImpl {
 					TraceEvent(SevDebug, "WaitForDDEnabled")
 					    .detail("Mode", m)
 					    .detail("IsDDEnabled", ddEnabledState->isEnabled());
-					if (m != 0 && ddEnabledState->isEnabled()) {
+					if (m && ddEnabledState->isEnabled()) {
 						TraceEvent("WaitForDDEnabledSucceeded").log();
 						return Void();
 					}
@@ -545,7 +545,7 @@ class DDTxnProcessorImpl {
 					BinaryReader rd(mode.get(), Unversioned());
 					int m;
 					rd >> m;
-					if (m != 0 && ddEnabledState->isEnabled()) {
+					if (m && ddEnabledState->isEnabled()) {
 						TraceEvent(SevDebug, "IsDDEnabledSucceeded")
 						    .detail("Mode", m)
 						    .detail("IsDDEnabled", ddEnabledState->isEnabled());
@@ -577,7 +577,6 @@ class DDTxnProcessorImpl {
 	ACTOR static Future<Void> pollMoveKeysLock(Database cx, MoveKeysLock lock, const DDEnabledState* ddEnabledState) {
 		loop {
 			wait(delay(SERVER_KNOBS->MOVEKEYS_LOCK_POLLING_DELAY));
-			TraceEvent("PollMoveKeysLock");
 			state Transaction tr(cx);
 			loop {
 				tr.setOption(FDBTransactionOptions::READ_LOCK_AWARE);
@@ -587,7 +586,6 @@ class DDTxnProcessorImpl {
 					wait(checkMoveKeysLockReadOnly(&tr, lock, ddEnabledState));
 					break;
 				} catch (Error& e) {
-					TraceEvent("PollMoveKeysLockError").errorUnsuppressed(e);
 					wait(tr.onError(e));
 				}
 			}

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -596,11 +596,11 @@ public:
 			// So, we need to check MoveKeyLock when waitUntilDataDistributorExitSecurityMode
 			wait(waitUntilDataDistributorExitSecurityMode(self)); // Trap DDMode == 2
 			// It is possible DDMode begins with 2 and passes
-			// waitDataDistributorEnabledOrSecurityMode and then set to 0 before
+			// waitDataDistributorEnabled and then set to 0 before
 			// waitUntilDataDistributorExitSecurityMode. For this case,
 			// after waitUntilDataDistributorExitSecurityMode, DDMode is 0.
 			// The init loop does not break and the loop will stuct at
-			// waitDataDistributorEnabledOrSecurityMode in the next iteration.
+			// waitDataDistributorEnabled in the next iteration.
 			TraceEvent("DataDistributorExitSecurityMode").log();
 
 			wait(self->loadDatabaseConfiguration());

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -1799,16 +1799,6 @@ ACTOR Future<Void> auditStorageCore(Reference<DataDistributor> self,
 	lockInfo.prevWrite = self->lock.prevWrite;
 
 	try {
-		if (!self->auditStorageInitialized.getFuture().isReady()) {
-			TraceEvent(g_network->isSimulated() ? SevError : SevWarnAlways, "DDAuditStorageCoreRunError", self->ddId)
-			    .detail("Context", audit->getDDAuditContext())
-			    .detail("AuditID", auditID)
-			    .detail("AuditStorageCoreGeneration", currentRetryCount)
-			    .detail("RetryCount", audit->retryCount)
-			    .detail("AuditType", auditType)
-			    .detail("Range", audit->coreState.range);
-			throw audit_storage_cancelled();
-		}
 		ASSERT(audit != nullptr);
 		ASSERT(audit->coreState.ddId == self->ddId);
 		loadAndDispatchAudit(self, audit, audit->coreState.range);

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -307,6 +307,34 @@ static std::set<int> const& normalDDQueueErrors() {
 	return s;
 }
 
+struct DataDistributor;
+void runAuditStorage(Reference<DataDistributor> self,
+                     AuditStorageState auditStates,
+                     int retryCount,
+                     std::string context);
+ACTOR Future<Void> auditStorageCore(Reference<DataDistributor> self,
+                                    UID auditID,
+                                    AuditType auditType,
+                                    std::string context,
+                                    int currentRetryCount);
+ACTOR Future<UID> launchAudit(Reference<DataDistributor> self, KeyRange auditRange, AuditType auditType);
+ACTOR Future<Void> auditStorage(Reference<DataDistributor> self, TriggerAuditRequest req);
+void loadAndDispatchAudit(Reference<DataDistributor> self, std::shared_ptr<DDAudit> audit, KeyRange range);
+ACTOR Future<Void> dispatchAuditStorageServerShard(Reference<DataDistributor> self, std::shared_ptr<DDAudit> audit);
+ACTOR Future<Void> scheduleAuditStorageShardOnServer(Reference<DataDistributor> self,
+                                                     std::shared_ptr<DDAudit> audit,
+                                                     StorageServerInterface ssi);
+ACTOR Future<Void> dispatchAuditStorage(Reference<DataDistributor> self,
+                                        std::shared_ptr<DDAudit> audit,
+                                        KeyRange range);
+ACTOR Future<Void> scheduleAuditOnRange(Reference<DataDistributor> self,
+                                        std::shared_ptr<DDAudit> audit,
+                                        KeyRange range);
+ACTOR Future<Void> doAuditOnStorageServer(Reference<DataDistributor> self,
+                                          std::shared_ptr<DDAudit> audit,
+                                          StorageServerInterface ssi,
+                                          AuditStorageRequest req);
+
 struct DataDistributor : NonCopyable, ReferenceCounted<DataDistributor> {
 public:
 	Reference<AsyncVar<ServerDBInfo> const> dbInfo;
@@ -396,6 +424,198 @@ public:
 		return txnProcessor->waitForDataDistributionEnabled(context->ddEnabledState.get());
 	}
 
+	ACTOR static Future<Void> initAuditStorage(Reference<DataDistributor> self) {
+		if (self->auditInitialized.getFuture().isReady()) {
+			return Void();
+		}
+		// Load persist metadata
+		state std::vector<AuditStorageState> auditStates;
+		state Transaction tr(self->txnProcessor->context());
+		loop {
+			try {
+				tr.setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
+				tr.setOption(FDBTransactionOptions::READ_LOCK_AWARE);
+				tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
+				auditStates.clear();
+				RangeResult ads = wait(tr.getRange(auditKeys, CLIENT_KNOBS->TOO_MANY));
+				ASSERT(!ads.more && ads.size() < CLIENT_KNOBS->TOO_MANY);
+				for (int i = 0; i < ads.size(); ++i) {
+					auto auditState = decodeAuditStorageState(ads[i].value);
+					TraceEvent(SevVerbose, "AuditStorageResumeLoad", self->ddId)
+					    .detail("AuditDDID", auditState.ddId)
+					    .detail("AuditType", auditState.getType())
+					    .detail("AuditID", auditState.id)
+					    .detail("AuditPhase", auditState.getPhase());
+					auditStates.push_back(auditState);
+				}
+				break;
+			} catch (Error& e) {
+				wait(tr.onError(e));
+			}
+		}
+		if (auditStates.empty()) {
+			self->auditInitialized.send(Void());
+			TraceEvent(SevVerbose, "AuditStorageResumeEmptyDone", self->ddId);
+			return Void();
+		}
+		TraceEvent(SevInfo, "AuditStorageResumeLoadDone", self->ddId);
+
+		// Update metadata with current ddId
+		state int retryCount = 0;
+		state MoveKeyLockInfo lockInfo;
+		loop {
+			try {
+				std::vector<Future<Void>> fs;
+				lockInfo.myOwner = self->lock.myOwner;
+				lockInfo.prevOwner = self->lock.prevOwner;
+				lockInfo.prevWrite = self->lock.prevWrite;
+				for (const auto auditState : auditStates) {
+					// Only running audit will be resumed
+					if (auditState.getPhase() == AuditPhase::Running) {
+						AuditStorageState toUpdate = auditState;
+						toUpdate.ddId = self->ddId;
+						fs.push_back(updateAuditState(
+						    self->txnProcessor->context(), toUpdate, lockInfo, self->context->isDDEnabled()));
+						TraceEvent(SevDebug, "AuditStorageResumeUpdateMetadata", self->ddId)
+						    .detail("AuditType", toUpdate.getType())
+						    .detail("AuditID", toUpdate.id)
+						    .detail("AuditRange", toUpdate.range)
+						    .detail("AuditPhase", toUpdate.getPhase())
+						    .detail("NewDDID", toUpdate.ddId);
+					}
+				}
+				wait(waitForAll(fs));
+				break;
+			} catch (Error& e) {
+				if (e.code() == error_code_actor_cancelled || e.code() == error_code_movekeys_conflict) {
+					throw e;
+				}
+				if (retryCount > 50) {
+					TraceEvent(SevWarnAlways, "AuditStorageResumeUnableUpdateMetadata", self->ddId)
+					    .errorUnsuppressed(e);
+					self->auditInitialized.send(Void());
+					return Void();
+				}
+				retryCount++;
+			}
+		}
+		TraceEvent(SevInfo, "AuditStorageResumeUpdateMetadataDone", self->ddId);
+
+		// Following is atomic
+		// Cancel existing audits
+		for (auto& [auditType, auditMap] : self->audits) {
+			for (auto& [auditID, audit] : auditMap) {
+				// Any existing audit should stop running when the context switches out
+				audit->cancel();
+			}
+		}
+		self->audits.clear();
+		// Clear persist audit metadata
+		std::unordered_map<AuditType, std::vector<AuditStorageState>> restoredAudits;
+		for (const auto& auditState : auditStates) {
+			restoredAudits[auditState.getType()].push_back(auditState);
+		}
+		// We clear finish audit and resume running audit for each auditType separately
+		for (const auto& [auditType, _] : restoredAudits) {
+			int numFinishAudit = 0; // "finish" audits include Complete/Failed audits
+			for (const auto& auditState : restoredAudits[auditType]) {
+				if (auditState.getPhase() == AuditPhase::Complete || auditState.getPhase() == AuditPhase::Failed) {
+					numFinishAudit++;
+				}
+			}
+			const int numFinishAuditsToClear = numFinishAudit - SERVER_KNOBS->PERSIST_FINISH_AUDIT_COUNT;
+			int numFinishAuditsCleared = 0;
+			std::sort(restoredAudits[auditType].begin(),
+			          restoredAudits[auditType].end(),
+			          [](AuditStorageState a, AuditStorageState b) {
+				          return a.id < b.id; // Inplacement sort in ascending order
+			          });
+			// Cleanup audit metadata for Failed/Complete audits
+			// Resume RUNNING audits
+			// Keep Error audits persistent
+			for (const auto& auditState : restoredAudits[auditType]) {
+				TraceEvent(SevVerbose, "AuditStorageResumeCheck", self->ddId)
+				    .detail("AuditID", auditState.id)
+				    .detail("AuditType", auditState.getType())
+				    .detail("AuditRange", auditState.range);
+				if (auditState.getPhase() == AuditPhase::Error) {
+					continue;
+				} else if (auditState.getPhase() == AuditPhase::Failed) {
+					if (numFinishAuditsCleared < numFinishAuditsToClear) {
+						// Clear both audit metadata and corresponding progress metadata
+						self->addActor.send(clearAuditMetadata(self->txnProcessor->context(),
+						                                       auditState.getType(),
+						                                       auditState.id,
+						                                       /*clearProgressMetadata=*/true));
+						numFinishAuditsCleared++;
+					}
+					continue;
+				} else if (auditState.getPhase() == AuditPhase::Complete) {
+					if (numFinishAuditsCleared < numFinishAuditsToClear) {
+						// Clear audit metadata only
+						// No need to clear the corresponding progress metadata
+						// since it has been cleared for Complete audits
+						self->addActor.send(clearAuditMetadata(self->txnProcessor->context(),
+						                                       auditState.getType(),
+						                                       auditState.id,
+						                                       /*clearProgressMetadata=*/false));
+						numFinishAuditsCleared++;
+					}
+					continue;
+				}
+				ASSERT(auditState.getPhase() == AuditPhase::Running);
+				if (self->audits.contains(auditState.getType()) &&
+				    self->audits[auditState.getType()].contains(auditState.id)) {
+					// It is possible that the current DD is running this audit
+					// Suppose DDinit re-runs right after a new audit is persisted
+					// For this case, auditResume sees the new audit and resumes it
+					// At this point, the new audit is in the audit map
+					// Meanwhile, existing DDAuditStorage retries (since DD does not restart)
+					// Then, existing DDAuditStorageStart is conflict with auditResume
+					// auditResume cannot see the new audit in the map
+					continue;
+				}
+				TraceEvent(SevDebug, "AuditStorageResume", self->ddId)
+				    .detail("AuditID", auditState.id)
+				    .detail("AuditType", auditState.getType())
+				    .detail("AuditState", auditState.toString())
+				    .detail("NumFinishAuditsCleared", numFinishAuditsCleared)
+				    .detail("IsReady", self->auditInitialized.getFuture().isReady());
+				runAuditStorage(self, auditState, 0, "ResumeAudit");
+			}
+		}
+
+		self->auditInitialized.send(Void());
+		TraceEvent(SevDebug, "AuditStorageResumeDone", self->ddId);
+		return Void();
+	}
+
+	ACTOR static Future<Void> waitUntilDataDistributorExitSecurityMode(Reference<DataDistributor> self) {
+		state Transaction tr(self->txnProcessor->context());
+		loop {
+			wait(delay(SERVER_KNOBS->DD_ENABLED_CHECK_DELAY, TaskPriority::DataDistribution));
+			tr.setOption(FDBTransactionOptions::READ_LOCK_AWARE);
+			tr.setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
+			tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
+			try {
+				Optional<Value> mode = wait(tr.get(dataDistributionModeKey));
+				if (!mode.present()) {
+					return Void();
+				}
+				BinaryReader rd(mode.get(), Unversioned());
+				int ddMode = 1;
+				rd >> ddMode;
+				if (ddMode != 2) {
+					return Void();
+				}
+				wait(checkMoveKeysLockReadOnly(&tr, self->context->lock, self->context->ddEnabledState.get()));
+				tr.reset();
+			} catch (Error& e) {
+				wait(tr.onError(e));
+			}
+		}
+	}
+
 	// Initialize the required internal states of DataDistributor from system metadata. It's necessary before
 	// DataDistributor start working. Doesn't include initialization of optional components, like TenantCache, DDQueue,
 	// Tracker, TeamCollection. The components should call its own ::init methods.
@@ -407,6 +627,23 @@ public:
 			TraceEvent("DDInitTakingMoveKeysLock", self->ddId).log();
 			wait(self->takeMoveKeysLock());
 			TraceEvent("DDInitTookMoveKeysLock", self->ddId).log();
+
+			// AuditStorage does not rely on DatabaseConfiguration
+			// AuditStorage read neccessary info purely from system key space
+			wait(self->initAuditStorage(self));
+			TraceEvent("DDAuditStorageInitialized", self->ddId).log();
+			// It is possible that an audit request arrives and then DDMode
+			// is set to 2 at this point
+			// No polling MoveKeyLock is running
+			// So, we need to check MoveKeyLock when waitUntilDataDistributorExitSecurityMode
+			wait(waitUntilDataDistributorExitSecurityMode(self)); // Trap DDMode == 2
+			// It is possible DDMode begins with 2 and passes
+			// waitDataDistributorEnabledOrSecurityMode and then set to 0 before
+			// waitUntilDataDistributorExitSecurityMode. For this case,
+			// after waitUntilDataDistributorExitSecurityMode, DDMode is 0.
+			// The init loop does not break and the loop will stuct at
+			// waitDataDistributorEnabledOrSecurityMode in the next iteration.
+			TraceEvent("DataDistributorExitSecurityMode").log();
 
 			wait(self->loadDatabaseConfiguration());
 			self->initDcInfo();
@@ -442,7 +679,7 @@ public:
 				    .trackLatest(self->initialDDEventHolder->trackingKey);
 			}
 
-			if (self->initData->mode && self->context->isDDEnabled()) {
+			if (self->initData->mode == 1 && self->context->isDDEnabled()) {
 				// mode may be set true by system operator using fdbcli and isEnabled() set to true
 				break;
 			}
@@ -780,155 +1017,6 @@ inline std::unordered_map<UID, std::shared_ptr<DDAudit>> getAuditsForType(Refere
 	return self->audits[auditType];
 }
 
-void runAuditStorage(Reference<DataDistributor> self,
-                     AuditStorageState auditStates,
-                     int retryCount,
-                     std::string context);
-ACTOR Future<Void> auditStorageCore(Reference<DataDistributor> self,
-                                    UID auditID,
-                                    AuditType auditType,
-                                    std::string context,
-                                    int currentRetryCount);
-ACTOR Future<UID> launchAudit(Reference<DataDistributor> self, KeyRange auditRange, AuditType auditType);
-ACTOR Future<Void> auditStorage(Reference<DataDistributor> self, TriggerAuditRequest req);
-void loadAndDispatchAudit(Reference<DataDistributor> self, std::shared_ptr<DDAudit> audit, KeyRange range);
-ACTOR Future<Void> dispatchAuditStorageServerShard(Reference<DataDistributor> self, std::shared_ptr<DDAudit> audit);
-ACTOR Future<Void> scheduleAuditStorageShardOnServer(Reference<DataDistributor> self,
-                                                     std::shared_ptr<DDAudit> audit,
-                                                     StorageServerInterface ssi);
-ACTOR Future<Void> dispatchAuditStorage(Reference<DataDistributor> self,
-                                        std::shared_ptr<DDAudit> audit,
-                                        KeyRange range);
-ACTOR Future<Void> scheduleAuditOnRange(Reference<DataDistributor> self,
-                                        std::shared_ptr<DDAudit> audit,
-                                        KeyRange range);
-ACTOR Future<Void> doAuditOnStorageServer(Reference<DataDistributor> self,
-                                          std::shared_ptr<DDAudit> audit,
-                                          StorageServerInterface ssi,
-                                          AuditStorageRequest req);
-
-void cancelAllAuditsInAuditMap(Reference<DataDistributor> self) {
-	TraceEvent(SevDebug, "AuditMapOps", self->ddId).detail("Ops", "cancelAllAuditsInAuditMap");
-	for (auto& [auditType, auditMap] : self->audits) {
-		for (auto& [auditID, audit] : auditMap) {
-			// Any existing audit should stop running when the context switches out
-			audit->cancel();
-		}
-	}
-	self->audits.clear();
-	return;
-}
-
-ACTOR Future<Void> resumeStorageAudits(Reference<DataDistributor> self) {
-	ASSERT(!self->auditInitialized.getFuture().isReady());
-	if (self->initData->auditStates.empty()) {
-		self->auditInitialized.send(Void());
-		TraceEvent(SevVerbose, "AuditStorageResumeEmptyDone", self->ddId);
-		return Void();
-	}
-
-	// Update metadata
-	state int retryCount = 0;
-	loop {
-		try {
-			std::vector<Future<Void>> fs;
-			state MoveKeyLockInfo lockInfo;
-			lockInfo.myOwner = self->lock.myOwner;
-			lockInfo.prevOwner = self->lock.prevOwner;
-			lockInfo.prevWrite = self->lock.prevWrite;
-			for (const auto& auditState : self->initData->auditStates) {
-				// Only running audit will be resumed
-				if (auditState.getPhase() == AuditPhase::Running) {
-					AuditStorageState toUpdate = auditState;
-					toUpdate.ddId = self->ddId;
-					fs.push_back(updateAuditState(
-					    self->txnProcessor->context(), toUpdate, lockInfo, self->context->isDDEnabled()));
-				}
-			}
-			wait(waitForAll(fs));
-			break;
-		} catch (Error& e) {
-			if (e.code() == error_code_actor_cancelled || e.code() == error_code_movekeys_conflict) {
-				throw e;
-			}
-			if (retryCount > 50) {
-				TraceEvent(SevWarnAlways, "AuditStorageResumeUnableUpdateMetadata", self->ddId).errorUnsuppressed(e);
-				return Void();
-			}
-			retryCount++;
-		}
-	}
-
-	// Following is atomic
-	// Cancel existing audits and restore
-	cancelAllAuditsInAuditMap(self);
-	std::unordered_map<AuditType, std::vector<AuditStorageState>> restoredAudits;
-	for (const auto& auditState : self->initData->auditStates) {
-		restoredAudits[auditState.getType()].push_back(auditState);
-	}
-	// We clear existing audit state for each auditType separately
-	for (const auto& [auditType, _] : restoredAudits) {
-		int numFinishAudit = 0; // "finish" audits include Complete/Failed audits
-		for (const auto& auditState : restoredAudits[auditType]) {
-			if (auditState.getPhase() == AuditPhase::Complete || auditState.getPhase() == AuditPhase::Failed) {
-				numFinishAudit++;
-			}
-		}
-		const int numFinishAuditsToClear = numFinishAudit - SERVER_KNOBS->PERSIST_FINISH_AUDIT_COUNT;
-		int numFinishAuditsCleared = 0;
-		std::sort(restoredAudits[auditType].begin(),
-		          restoredAudits[auditType].end(),
-		          [](AuditStorageState a, AuditStorageState b) {
-			          return a.id < b.id; // Inplacement sort in ascending order
-		          });
-		// Cleanup audit metadata for Failed/Complete audits
-		// Resume RUNNING audits
-		// Keep Error audits persistent
-		for (const auto& auditState : restoredAudits[auditType]) {
-			TraceEvent(SevVerbose, "AuditStorageResumeCheck", self->ddId)
-			    .detail("AuditID", auditState.id)
-			    .detail("AuditType", auditState.getType());
-			if (auditState.getPhase() == AuditPhase::Error) {
-				continue;
-			} else if (auditState.getPhase() == AuditPhase::Failed) {
-				if (numFinishAuditsCleared < numFinishAuditsToClear) {
-					// Clear both audit metadata and corresponding progress metadata
-					self->addActor.send(clearAuditMetadata(self->txnProcessor->context(),
-					                                       auditState.getType(),
-					                                       auditState.id,
-					                                       /*clearProgressMetadata=*/true));
-					numFinishAuditsCleared++;
-				}
-				continue;
-			} else if (auditState.getPhase() == AuditPhase::Complete) {
-				if (numFinishAuditsCleared < numFinishAuditsToClear) {
-					// Clear audit metadata only
-					// No need to clear the corresponding progress metadata
-					// since it has been cleared for Complete audits
-					self->addActor.send(clearAuditMetadata(self->txnProcessor->context(),
-					                                       auditState.getType(),
-					                                       auditState.id,
-					                                       /*clearProgressMetadata=*/false));
-					numFinishAuditsCleared++;
-				}
-				continue;
-			}
-			ASSERT(auditState.getPhase() == AuditPhase::Running);
-			TraceEvent(SevDebug, "AuditStorageResume", self->ddId)
-			    .detail("AuditID", auditState.id)
-			    .detail("AuditType", auditState.getType())
-			    .detail("AuditState", auditState.toString())
-			    .detail("NumFinishAuditsCleared", numFinishAuditsCleared)
-			    .detail("IsReady", self->auditInitialized.getFuture().isReady());
-			runAuditStorage(self, auditState, 0, "ResumeAudit");
-		}
-	}
-
-	self->auditInitialized.send(Void());
-	TraceEvent(SevDebug, "AuditStorageResumeDone", self->ddId);
-	return Void();
-}
-
 // Periodically check and log the physicalShard status; clean up empty physicalShard;
 ACTOR Future<Void> monitorPhysicalShardStatus(Reference<PhysicalShardCollection> self) {
 	ASSERT(SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA);
@@ -1072,8 +1160,6 @@ ACTOR Future<Void> dataDistribution(Reference<DataDistributor> self,
 			} else {
 				anyZeroHealthyTeams = zeroHealthyTeams[0];
 			}
-
-			actors.push_back(resumeStorageAudits(self));
 
 			actors.push_back(self->pollMoveKeysLock());
 
@@ -1944,7 +2030,7 @@ ACTOR Future<Void> auditStorageCore(Reference<DataDistributor> self,
 				                       "AuditStorageCoreError",
 				                       lockInfo,
 				                       self->context->isDDEnabled()));
-				TraceEvent(SevInfo, "DDAuditStorageCoreSetFailed", self->ddId)
+				TraceEvent(SevWarn, "DDAuditStorageCoreSetFailed", self->ddId)
 				    .detail("Context", context)
 				    .detail("AuditID", auditID)
 				    .detail("AuditType", auditType)
@@ -2025,13 +2111,10 @@ ACTOR Future<UID> launchAudit(Reference<DataDistributor> self, KeyRange auditRan
 		    .detail("AuditType", auditType)
 		    .detail("Range", auditRange)
 		    .detail("IsReady", self->auditInitialized.getFuture().isReady());
-		std::vector<Future<Void>> fs;
-		fs.push_back(self->auditInitialized.getFuture());
-		fs.push_back(self->initialized.getFuture());
-		wait(waitForAll(fs));
+		wait(self->auditInitialized.getFuture());
 
 		// Get audit, if not exist, triggers a new one
-		ASSERT(self->auditInitialized.getFuture().isReady() && self->initialized.getFuture().isReady());
+		ASSERT(self->auditInitialized.getFuture().isReady());
 		TraceEvent(SevVerbose, "DDAuditStorageLaunchStart", self->ddId)
 		    .detail("AuditType", auditType)
 		    .detail("Range", auditRange)
@@ -2104,6 +2187,13 @@ ACTOR Future<UID> launchAudit(Reference<DataDistributor> self, KeyRange auditRan
 			    .detail("Range", auditRange);
 			auditState.id = auditID_;
 			auditID = auditID_;
+			if (self->audits.contains(auditType) && self->audits[auditType].contains(auditID)) {
+				// It is possible that the current DD is running this audit
+				// Suppose DDinit re-runs right after a new audit is persisted
+				// For this case, auditResume sees the new audit and resumes it
+				// At this point, the new audit is already in the audit map
+				return auditID;
+			}
 			runAuditStorage(self, auditState, 0, "LaunchAudit");
 		}
 	} catch (Error& e) {
@@ -2393,8 +2483,7 @@ ACTOR Future<Void> scheduleAuditStorageShardOnServer(Reference<DataDistributor> 
 		    .detail("AuditType", auditType)
 		    .detail("IssuedDoAuditCount", issueDoAuditCount);
 
-		if (e.code() == error_code_not_implemented || e.code() == error_code_audit_storage_exceeded_request_limit ||
-		    e.code() == error_code_audit_storage_cancelled) {
+		if (e.code() == error_code_not_implemented || e.code() == error_code_audit_storage_cancelled) {
 			throw e;
 		} else if (e.code() == error_code_audit_storage_error) {
 			audit->foundError = true;

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -586,7 +586,7 @@ public:
 					    g_network->isSimulated() ? SevError : SevWarnAlways, "AuditStorageInitStateError", self->ddId);
 				}
 			} else {
-				TraceEvent(SevVerbose, "DDInitTookMoveKeysLock", self->ddId).log();
+				TraceEvent(SevVerbose, "DDInitAuditStorageStarted", self->ddId).log();
 			}
 			// It is possible that an audit request arrives and then DDMode
 			// is set to 2 at this point
@@ -1068,6 +1068,7 @@ ACTOR Future<Void> dataDistribution(Reference<DataDistributor> self,
 		// whether all initial shard are tracked
 		self->initialized = Promise<Void>();
 		self->auditInitialized = Promise<Void>();
+		self->auditStorageInitStarted = false;
 
 		// Stored outside of data distribution tracker to avoid slow tasks
 		// when tracker is cancelled

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -1885,7 +1885,7 @@ ACTOR Future<Void> auditStorageCore(Reference<DataDistributor> self,
 		if (e.code() == error_code_movekeys_conflict) {
 			removeAuditFromAuditMap(self, audit->coreState.getType(),
 			                        audit->coreState.id); // remove audit
-			throw e; // throw to DD and DD will restart
+			// Silently exit
 		} else if (e.code() == error_code_audit_storage_cancelled) {
 			// If this audit is cancelled, the place where cancelling
 			// this audit does removeAuditFromAuditMap

--- a/fdbserver/MoveKeys.actor.cpp
+++ b/fdbserver/MoveKeys.actor.cpp
@@ -306,7 +306,7 @@ ACTOR static Future<Void> checkPersistentMoveKeysLock(Transaction* tr, MoveKeysL
 	tr->setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
 
 	Optional<Value> readVal = wait(tr->get(moveKeysLockOwnerKey));
-	UID currentOwner = readVal.present() ? BinaryReader::fromStringRef<UID>(readVal.get(), Unversioned()) : UID();
+	state UID currentOwner = readVal.present() ? BinaryReader::fromStringRef<UID>(readVal.get(), Unversioned()) : UID();
 
 	if (currentOwner == lock.prevOwner) {
 		// Check that the previous owner hasn't touched the lock since we took it
@@ -314,6 +314,13 @@ ACTOR static Future<Void> checkPersistentMoveKeysLock(Transaction* tr, MoveKeysL
 		UID lastWrite = readVal.present() ? BinaryReader::fromStringRef<UID>(readVal.get(), Unversioned()) : UID();
 		if (lastWrite != lock.prevWrite) {
 			CODE_PROBE(true, "checkMoveKeysLock: Conflict with previous owner");
+			TraceEvent(SevDebug, "CheckPersistentMoveKeysWritterConflict")
+			    .errorUnsuppressed(movekeys_conflict())
+			    .detail("PrevOwner", lock.prevOwner.toString())
+			    .detail("PrevWrite", lock.prevWrite.toString())
+			    .detail("MyOwner", lock.myOwner.toString())
+			    .detail("CurrentOwner", currentOwner.toString())
+			    .detail("Writer", lastWrite.toString());
 			throw movekeys_conflict();
 		}
 
@@ -347,6 +354,12 @@ ACTOR static Future<Void> checkPersistentMoveKeysLock(Transaction* tr, MoveKeysL
 		return Void();
 	} else {
 		CODE_PROBE(true, "checkMoveKeysLock: Conflict with new owner");
+		TraceEvent(SevDebug, "CheckPersistentMoveKeysLockOwnerConflict")
+		    .errorUnsuppressed(movekeys_conflict())
+		    .detail("PrevOwner", lock.prevOwner.toString())
+		    .detail("PrevWrite", lock.prevWrite.toString())
+		    .detail("MyOwner", lock.myOwner.toString())
+		    .detail("CurrentOwner", currentOwner.toString());
 		throw movekeys_conflict();
 	}
 }
@@ -426,8 +439,10 @@ ACTOR Future<bool> validateRangeAssignment(Database occ,
 		}
 	}
 	if (!allCorrect) {
-		try { // If corruption detected, stop using DD
-			int _ = wait(setDDMode(occ, 0));
+		try {
+			// If corruption detected, enter security mode which
+			// stops using data moves and only allow auditStorage
+			int _ = wait(setDDMode(occ, 2));
 			TraceEvent(SevInfo, "ValidateRangeAssignmentCorruptionDetectedAndDDStopped")
 			    .detail("DataMoveID", dataMoveId)
 			    .detail("Range", range)
@@ -450,19 +465,17 @@ ACTOR Future<Void> auditLocationMetadataPreCheck(Database occ,
                                                  std::string context,
                                                  UID dataMoveId) {
 	if (range.empty()) {
-		TraceEvent(SevWarn, "AuditLocationMetadataEmptyInputRange")
-		    .detail("By", "PreCheck")
-		    .detail("AuditRange", range);
+		TraceEvent(SevWarn, "CheckLocationMetadataEmptyInputRange").detail("By", "PreCheck").detail("Range", range);
 		return Void();
 	}
 	state std::vector<Future<Void>> actors;
 	state std::unordered_map<UID, Optional<bool>> results;
-	TraceEvent(SevDebug, "AuditLocationMetadataStart")
+	TraceEvent(SevVerbose, "CheckLocationMetadataStart")
 	    .detail("By", "PreCheck")
 	    .detail("DataMoveID", dataMoveId)
 	    .detail("Servers", describe(servers))
 	    .detail("Context", context)
-	    .detail("AuditRange", range);
+	    .detail("Range", range);
 	try {
 		actors.clear();
 		results.clear();
@@ -473,40 +486,40 @@ ACTOR Future<Void> auditLocationMetadataPreCheck(Database occ,
 		for (const auto& [ssid, res] : results) {
 			ASSERT(res.present());
 			if (!res.get()) { // Stop check if corruption detected
-				TraceEvent(SevError, "AuditLocationMetadataCorruptionDetected")
+				TraceEvent(SevError, "CheckLocationMetadataCorruptionDetected")
 				    .detail("By", "PreCheck")
 				    .detail("DataMoveID", dataMoveId)
 				    .detail("Servers", describe(servers))
 				    .detail("Context", context)
-				    .detail("AuditRange", range);
+				    .detail("Range", range);
 				throw location_metadata_corruption();
 			}
 		}
-		TraceEvent(SevDebug, "AuditLocationMetadataComplete")
+		TraceEvent(SevVerbose, "CheckLocationMetadataComplete")
 		    .detail("By", "PreCheck")
 		    .detail("DataMoveID", dataMoveId)
 		    .detail("Servers", describe(servers))
 		    .detail("Context", context)
-		    .detail("AuditRange", range);
+		    .detail("Range", range);
 	} catch (Error& e) {
 		if (e.code() == error_code_actor_cancelled || e.code() == error_code_location_metadata_corruption) {
 			throw e;
 		} else {
-			TraceEvent(SevInfo, "AuditLocationMetadataFailed")
+			TraceEvent(SevInfo, "CheckLocationMetadataFailed")
 			    .errorUnsuppressed(e)
 			    .detail("By", "PreCheck")
 			    .detail("DataMoveID", dataMoveId)
 			    .detail("Context", context)
-			    .detail("AuditRange", range);
+			    .detail("Range", range);
 			// Check any existing result when failure presents
 			for (const auto& [ssid, res] : results) {
 				if (res.present() && !res.get()) {
-					TraceEvent(SevError, "AuditLocationMetadataCorruptionDetectedWhenFailed")
+					TraceEvent(SevError, "CheckLocationMetadataCorruptionDetectedWhenFailed")
 					    .detail("By", "PreCheck")
 					    .detail("DataMoveID", dataMoveId)
 					    .detail("Servers", describe(servers))
 					    .detail("Context", context)
-					    .detail("AuditRange", range);
+					    .detail("Range", range);
 					throw location_metadata_corruption();
 				}
 			}
@@ -518,9 +531,7 @@ ACTOR Future<Void> auditLocationMetadataPreCheck(Database occ,
 
 ACTOR Future<Void> auditLocationMetadataPostCheck(Database occ, KeyRange range, std::string context, UID dataMoveId) {
 	if (range.empty()) {
-		TraceEvent(SevWarn, "AuditLocationMetadataEmptyInputRange")
-		    .detail("By", "PostCheck")
-		    .detail("AuditRange", range);
+		TraceEvent(SevWarn, "CheckLocationMetadataEmptyInputRange").detail("By", "PostCheck").detail("Range", range);
 		return Void();
 	}
 	state std::vector<Future<Void>> actors;
@@ -530,10 +541,10 @@ ACTOR Future<Void> auditLocationMetadataPostCheck(Database occ, KeyRange range, 
 	state RangeResult UIDtoTagMap;
 	state Transaction tr(occ);
 	state int retryCount = 0;
-	TraceEvent(SevDebug, "AuditLocationMetadataStart")
+	TraceEvent(SevVerbose, "CheckLocationMetadataStart")
 	    .detail("By", "PostCheck")
 	    .detail("Context", context)
-	    .detail("AuditRange", range);
+	    .detail("Range", range);
 	loop {
 		try {
 			loop {
@@ -554,7 +565,7 @@ ACTOR Future<Void> auditLocationMetadataPostCheck(Database occ, KeyRange range, 
 					actors.push_back(store(UIDtoTagMap, tr.getRange(serverTagKeys, CLIENT_KNOBS->TOO_MANY)));
 					wait(waitForAll(actors));
 					ASSERT(!UIDtoTagMap.more && UIDtoTagMap.size() < CLIENT_KNOBS->TOO_MANY);
-					TraceEvent(SevVerbose, "AuditLocationMetadataReadDone")
+					TraceEvent(SevVerbose, "CheckLocationMetadataReadDone")
 					    .detail("By", "PostCheck")
 					    .detail("ResultSize", readResultKS.size());
 					// Read serverKeys
@@ -591,11 +602,11 @@ ACTOR Future<Void> auditLocationMetadataPostCheck(Database occ, KeyRange range, 
 						rangeToReadBegin = readResultKS.back().key;
 						continue;
 					} else {
-						TraceEvent(SevDebug, "AuditLocationMetadataComplete")
+						TraceEvent(SevVerbose, "CheckLocationMetadataComplete")
 						    .detail("By", "PostCheck")
 						    .detail("DataMoveID", dataMoveId)
 						    .detail("Context", context)
-						    .detail("AuditRange", range);
+						    .detail("Range", range);
 						break;
 					}
 				} catch (Error& e) {
@@ -611,21 +622,21 @@ ACTOR Future<Void> auditLocationMetadataPostCheck(Database occ, KeyRange range, 
 				// Check corruptions for the current (failed) round
 				for (const auto& [idx, res] : results) {
 					if (res.present() && !res.get()) {
-						TraceEvent(SevError, "AuditLocationMetadataCorruptionDetectedWhenFailed")
+						TraceEvent(SevError, "CheckLocationMetadataCorruptionDetectedWhenFailed")
 						    .detail("By", "PostCheck")
 						    .detail("DataMoveID", dataMoveId)
 						    .detail("Context", context)
-						    .detail("AuditRange", range);
+						    .detail("Range", range);
 						throw location_metadata_corruption();
 					}
 				}
 				if (retryCount > SERVER_KNOBS->AUDIT_DATAMOVE_POST_CHECK_RETRY_COUNT_MAX) {
-					TraceEvent(SevInfo, "AuditLocationMetadataFailed")
+					TraceEvent(SevInfo, "CheckLocationMetadataFailed")
 					    .errorUnsuppressed(e)
 					    .detail("By", "PostCheck")
 					    .detail("DataMoveID", dataMoveId)
 					    .detail("Context", context)
-					    .detail("AuditRange", range);
+					    .detail("Range", range);
 					// If no corruption detected, exit silently
 				} else {
 					wait(delay(0.5));

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -5684,6 +5684,10 @@ ACTOR Future<Void> auditStorageServerShardQ(StorageServer* data, AuditStorageReq
 	    .detail("NumValidatedLocalShards", cumulatedValidatedLocalShardsNum)
 	    .detail("NumValidatedServerKeys", cumulatedValidatedServerKeysNum);
 
+	// Make sure the history collection is not open due to this audit
+	data->stopTrackShardAssignment();
+	TraceEvent(SevVerbose, "SSShardAssignmentHistoryRecordStopWhenExit", data->thisServerID).detail("AuditID", req.id);
+
 	return Void();
 }
 

--- a/fdbserver/workloads/ValidateStorage.actor.cpp
+++ b/fdbserver/workloads/ValidateStorage.actor.cpp
@@ -23,6 +23,7 @@
 #include "fdbclient/ManagementAPI.actor.h"
 #include "fdbclient/NativeAPI.actor.h"
 #include "fdbserver/Knobs.h"
+#include "fdbserver/QuietDatabase.h"
 #include "fdbrpc/simulator.h"
 #include "fdbserver/workloads/workloads.actor.h"
 #include "flow/Error.h"


### PR DESCRIPTION
This PR introduces a new DDMode called "SecurityMode". In the security mode, data moves are not allowed but auditStorage is enabled. DD security model is used when inconsistency shard location metadata is detected. At this time, the data distributor can have some serious bugs and the functionality of the data distributor cannot be trusted, and we want to enable auditStorage to do a consistency check and investigate the issue.

With this PR, we have three DDModes: (1) 0, DD is disabled; (2) 1, DD is enabled; (3) 2, DD is enabled but is in Security Mode.
MoveKeyLock is grabbed in the DD security mode.

Note that this PR does not break existing contract of blob restore and snapshot. When blob restore/snapshot starts, movekeys_conflicts is thrown (e.g. by polling MoveKeyLock) to trigger the restart of data distribution (not the distributor role). DD init will run and get stuck at waitDataDistributorEnabled. When blob restore/snapshot ends, DD exits waitDataDistributorEnabled. This mechanism works in DD Security Mode.


from: https://github.com/apple/foundationdb/pull/10559

Correctness test with 8 irrelevant failures (external timeout without running Audit module):
20230721-224313-zhewang-5194e2f46e7d91d4           compressed=True data_size=34537730 duration=8092143 ended=100000 fail=8 fail_fast=10 max_runs=100000 pass=99992 priority=100 remaining=0 runtime=1:06:33 sanity=False started=100000 stopped=20230721-234946 submitted=20230721-224313 timeout=5400 username=zhewang

AuditStorage test:
20230721-224938-zhewang-88e1068b948372d7           compressed=True data_size=34565733 duration=9078055 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:02:03 sanity=False started=100000 stopped=20230721-235141 submitted=20230721-224938 timeout=5400 username=zhewang

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
