### PR TITLE
Debug all backup keys by inserting them into the DB [release-7.1]

### DIFF
--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -430,6 +430,18 @@ ACTOR Future<Void> addBackupMutations(ProxyCommitData* self,
 			// logRangeMutation.first) 					.detail("PartIndex", part).detail("PartIndexEndian",
 			// bigEndian32(part)).detail("PartData", backupMutation.param1);
 			//			}
+			if (SERVER_KNOBS->SS_BACKUP_KEYS_OP_LOGS) {
+				MutationRef m(backupMutation);
+				// replace \xff\x02/blog/... with \xff\x02/dlog/...
+				// replace value with commit version
+				auto param1 = backupMutation.param1.substr(4).withPrefix("\xff\x02/d"_sr);
+				m.param1 = param1;
+				// maybe add toCommit->getMutationCount(), i.e., subversion?
+				m.param2 = StringRef((uint8_t*)&commitVersion, sizeof(commitVersion));
+				auto& tags = self->tagsForKey(m.param1);
+				toCommit->addTags(tags);
+				toCommit->writeTypedMessage(m);
+			}
 		}
 	}
 	return Void();


### PR DESCRIPTION
Specifically, added `(key, commitVersion)` pairs to `\xff\x02\dlog` space.

Manually verified backup mutations are logged in the new space.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
