### PR TITLE
[Release-7.3] Cherry-pick Add DD Security Mode (#10646)

### DIFF
--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -2230,6 +2230,8 @@ ACTOR Future<int> setDDMode(Database cx, int mode) {
 			tr.set(dataDistributionModeKey, wr.toValue());
 			if (mode) {
 				// set DDMode to 1 will enable all disabled parts, for instance the SS failure monitors.
+				// set DDMode to 2 is a security mode which disables data moves but allows auditStorage part
+				// DDMode=2 is set when shard location metadata inconsistency is detected
 				Optional<Value> currentHealthyZoneValue = wait(tr.get(healthyZoneKey));
 				if (currentHealthyZoneValue.present() &&
 				    decodeHealthyZoneValue(currentHealthyZoneValue.get()).first == ignoreSSFailuresZoneString) {

--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -2611,7 +2611,7 @@ Future<Optional<std::string>> DataDistributionImpl::commit(ReadYourWritesTransac
 				try {
 					int mode = boost::lexical_cast<int>(iter->value().second.get().toString());
 					Value modeVal = BinaryWriter::toValue(mode, Unversioned());
-					if (mode == 0 || mode == 1) {
+					if (mode == 0 || mode == 1 || mode == 2) {
 						// Whenever configuration changes or DD related system keyspace is changed,
 						// actor must grab the moveKeysLockOwnerKey and update moveKeysLockWriteKey.
 						// This prevents concurrent write to the same system keyspace.

--- a/fdbclient/include/fdbclient/AuditUtils.actor.h
+++ b/fdbclient/include/fdbclient/AuditUtils.actor.h
@@ -36,7 +36,6 @@ struct MoveKeyLockInfo {
 	UID prevOwner, myOwner, prevWrite;
 };
 
-ACTOR Future<Void> clearAuditMetadata(Database cx, AuditType auditType, UID auditId, bool clearProgressMetadata);
 ACTOR Future<Void> cancelAuditMetadata(Database cx, AuditType auditType, UID auditId);
 ACTOR Future<UID> persistNewAuditState(Database cx, AuditStorageState auditState, MoveKeyLockInfo lock, bool ddEnabled);
 ACTOR Future<Void> persistAuditState(Database cx,
@@ -66,8 +65,12 @@ ACTOR Future<Void> clearAuditMetadataForType(Database cx,
                                              UID maxAuditIdToClear,
                                              int numFinishAuditToKeep);
 ACTOR Future<bool> checkStorageServerRemoved(Database cx, UID ssid);
-ACTOR Future<Void> updateAuditState(Database cx, AuditStorageState auditState, MoveKeyLockInfo lock, bool ddEnabled);
 AuditPhase stringToAuditPhase(std::string auditPhaseStr);
 ACTOR Future<bool> checkAuditProgressComplete(Database cx, AuditType auditType, UID auditId, KeyRange auditRange);
+ACTOR Future<std::vector<AuditStorageState>> initAuditMetadata(Database cx,
+                                                               MoveKeyLockInfo lock,
+                                                               bool ddEnabled,
+                                                               UID dataDistributorId,
+                                                               int persistFinishAuditCount);
 #include "flow/unactorcompiler.h"
 #endif

--- a/fdbserver/DDTxnProcessor.actor.cpp
+++ b/fdbserver/DDTxnProcessor.actor.cpp
@@ -358,13 +358,6 @@ class DDTxnProcessorImpl {
 					++numDataMoves;
 				}
 
-				RangeResult ads = wait(tr.getRange(auditKeys, CLIENT_KNOBS->TOO_MANY));
-				ASSERT(!ads.more && ads.size() < CLIENT_KNOBS->TOO_MANY);
-				for (int i = 0; i < ads.size(); ++i) {
-					auto auditState = decodeAuditStorageState(ads[i].value);
-					result->auditStates.push_back(auditState);
-				}
-
 				succeeded = true;
 
 				break;

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -479,7 +479,7 @@ public:
 				if (ddMode != 2) {
 					return Void();
 				}
-				wait(checkMoveKeysLockReadOnly(&tr, self->context->lock, self->context->ddEnabledState.get()));
+				wait(checkMoveKeysLockReadOnly(&tr, self->lock, self->context->ddEnabledState.get()));
 				tr.reset();
 			} catch (Error& e) {
 				wait(tr.onError(e));

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -2233,9 +2233,6 @@ ACTOR Future<Void> scheduleAuditStorageShardOnServer(Reference<DataDistributor> 
 					    .detail("Val", audit->remainingBudgetForAuditTasks.get())
 					    .detail("AuditType", auditType);
 					AuditStorageRequest req(audit->coreState.id, auditStates[i].range, auditType);
-					// Since remaining part is always successcive
-					// We always issue exactly one audit task (for the remaining part) when schedule
-					ASSERT(issueDoAuditCount == 0);
 					issueDoAuditCount++;
 					req.ddId = self->ddId; // send this ddid to SS
 					wait(doAuditOnStorageServer(self, audit, ssi, req)); // do audit one by one

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -72,11 +72,17 @@ ShardSizeBounds ShardSizeBounds::shardSizeBoundsBeforeTrack() {
 		                                                      .opsReadPerKSecond = StorageMetrics::infinity } };
 }
 
+enum class DDAuditContext : uint8_t {
+	Invalid = 0,
+	Resume = 1,
+	Launch = 2,
+	Retry = 3,
+};
 struct DDAudit {
 	DDAudit(AuditStorageState coreState)
 	  : coreState(coreState), actors(true), foundError(false), auditStorageAnyChildFailed(false), retryCount(0),
 	    cancelled(false), overallCompleteDoAuditCount(0), overallIssuedDoAuditCount(0),
-	    remainingBudgetForAuditTasks(SERVER_KNOBS->CONCURRENT_AUDIT_TASK_COUNT_MAX) {}
+	    remainingBudgetForAuditTasks(SERVER_KNOBS->CONCURRENT_AUDIT_TASK_COUNT_MAX), context(0) {}
 
 	AuditStorageState coreState;
 	ActorCollection actors;
@@ -88,9 +94,13 @@ struct DDAudit {
 	int64_t overallIssuedDoAuditCount;
 	int64_t overallCompleteDoAuditCount;
 	AsyncVar<int> remainingBudgetForAuditTasks;
+	uint8_t context;
 
 	inline void setAuditRunActor(Future<Void> actor) { auditActor = actor; }
 	inline Future<Void> getAuditRunActor() { return auditActor; }
+
+	inline void setDDAuditContext(DDAuditContext context) { this->context = static_cast<uint8_t>(context); }
+	inline DDAuditContext getDDAuditContext() const { return static_cast<DDAuditContext>(this->context); }
 
 	// auditActor and actors are guaranteed to deliver a cancel signal
 	void cancel() {
@@ -297,6 +307,33 @@ static std::set<int> const& normalDDQueueErrors() {
 	return s;
 }
 
+struct DataDistributor;
+void runAuditStorage(Reference<DataDistributor> self,
+                     AuditStorageState auditStates,
+                     int retryCount,
+                     DDAuditContext context);
+ACTOR Future<Void> auditStorageCore(Reference<DataDistributor> self,
+                                    UID auditID,
+                                    AuditType auditType,
+                                    int currentRetryCount);
+ACTOR Future<UID> launchAudit(Reference<DataDistributor> self, KeyRange auditRange, AuditType auditType);
+ACTOR Future<Void> auditStorage(Reference<DataDistributor> self, TriggerAuditRequest req);
+void loadAndDispatchAudit(Reference<DataDistributor> self, std::shared_ptr<DDAudit> audit, KeyRange range);
+ACTOR Future<Void> dispatchAuditStorageServerShard(Reference<DataDistributor> self, std::shared_ptr<DDAudit> audit);
+ACTOR Future<Void> scheduleAuditStorageShardOnServer(Reference<DataDistributor> self,
+                                                     std::shared_ptr<DDAudit> audit,
+                                                     StorageServerInterface ssi);
+ACTOR Future<Void> dispatchAuditStorage(Reference<DataDistributor> self,
+                                        std::shared_ptr<DDAudit> audit,
+                                        KeyRange range);
+ACTOR Future<Void> scheduleAuditOnRange(Reference<DataDistributor> self,
+                                        std::shared_ptr<DDAudit> audit,
+                                        KeyRange range);
+ACTOR Future<Void> doAuditOnStorageServer(Reference<DataDistributor> self,
+                                          std::shared_ptr<DDAudit> audit,
+                                          StorageServerInterface ssi,
+                                          AuditStorageRequest req);
+
 struct DataDistributor : NonCopyable, ReferenceCounted<DataDistributor> {
 public:
 	Reference<AsyncVar<ServerDBInfo> const> dbInfo;
@@ -329,11 +366,12 @@ public:
 	Promise<Void> initialized;
 
 	std::unordered_map<AuditType, std::unordered_map<UID, std::shared_ptr<DDAudit>>> audits;
-	Promise<Void> auditInitialized;
 	FlowLock auditStorageHaLaunchingLock;
 	FlowLock auditStorageReplicaLaunchingLock;
 	FlowLock auditStorageLocationMetadataLaunchingLock;
 	FlowLock auditStorageSsShardLaunchingLock;
+	Promise<Void> auditStorageInitialized;
+	bool auditStorageInitStarted;
 
 	Optional<Reference<TenantCache>> ddTenantCache;
 
@@ -344,7 +382,8 @@ public:
 	    totalDataInFlightEventHolder(makeReference<EventCacheHolder>("TotalDataInFlight")),
 	    totalDataInFlightRemoteEventHolder(makeReference<EventCacheHolder>("TotalDataInFlightRemote")),
 	    teamCollection(nullptr), auditStorageHaLaunchingLock(1), auditStorageReplicaLaunchingLock(1),
-	    auditStorageLocationMetadataLaunchingLock(1), auditStorageSsShardLaunchingLock(1) {}
+	    auditStorageLocationMetadataLaunchingLock(1), auditStorageSsShardLaunchingLock(1),
+	    auditStorageInitStarted(false) {}
 
 	// bootstrap steps
 
@@ -382,6 +421,72 @@ public:
 		return txnProcessor->waitForDataDistributionEnabled(context->ddEnabledState.get());
 	}
 
+	// Resume in-memory audit instances and issue background audit metadata cleanup
+	void resumeAuditStorage(Reference<DataDistributor> self, std::vector<AuditStorageState> auditStates) {
+		for (const auto& auditState : auditStates) {
+			if (auditState.getPhase() != AuditPhase::Running) {
+				TraceEvent(g_network->isSimulated() ? SevError : SevWarnAlways, "WrongAuditStateToResume")
+				    .detail("AuditState", auditState.toString());
+				return;
+			}
+			if (self->audits.contains(auditState.getType()) &&
+			    self->audits[auditState.getType()].contains(auditState.id)) {
+				// Ignore any RUNNING auditState with an alive audit
+				// instance in DD audits map
+				continue;
+			}
+			runAuditStorage(self, auditState, 0, DDAuditContext::Resume);
+			TraceEvent(SevInfo, "AuditStorageResumed", self->ddId)
+			    .detail("AuditID", auditState.id)
+			    .detail("AuditType", auditState.getType())
+			    .detail("AuditState", auditState.toString());
+		}
+		return;
+	}
+
+	ACTOR static Future<Void> initAuditStorage(Reference<DataDistributor> self) {
+		self->auditStorageInitStarted = true;
+		MoveKeyLockInfo lockInfo;
+		lockInfo.myOwner = self->lock.myOwner;
+		lockInfo.prevOwner = self->lock.prevOwner;
+		lockInfo.prevWrite = self->lock.prevWrite;
+		std::vector<AuditStorageState> auditStatesToResume =
+		    wait(initAuditMetadata(self->txnProcessor->context(),
+		                           lockInfo,
+		                           self->context->isDDEnabled(),
+		                           self->ddId,
+		                           SERVER_KNOBS->PERSIST_FINISH_AUDIT_COUNT));
+		self->resumeAuditStorage(self, auditStatesToResume);
+		self->auditStorageInitialized.send(Void());
+		return Void();
+	}
+
+	ACTOR static Future<Void> waitUntilDataDistributorExitSecurityMode(Reference<DataDistributor> self) {
+		state Transaction tr(self->txnProcessor->context());
+		loop {
+			wait(delay(SERVER_KNOBS->DD_ENABLED_CHECK_DELAY, TaskPriority::DataDistribution));
+			tr.setOption(FDBTransactionOptions::READ_LOCK_AWARE);
+			tr.setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
+			tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
+			try {
+				Optional<Value> mode = wait(tr.get(dataDistributionModeKey));
+				if (!mode.present()) {
+					return Void();
+				}
+				BinaryReader rd(mode.get(), Unversioned());
+				int ddMode = 1;
+				rd >> ddMode;
+				if (ddMode != 2) {
+					return Void();
+				}
+				wait(checkMoveKeysLockReadOnly(&tr, self->context->lock, self->context->ddEnabledState.get()));
+				tr.reset();
+			} catch (Error& e) {
+				wait(tr.onError(e));
+			}
+		}
+	}
+
 	// Initialize the required internal states of DataDistributor from system metadata. It's necessary before
 	// DataDistributor start working. Doesn't include initialization of optional components, like TenantCache, DDQueue,
 	// Tracker, TeamCollection. The components should call its own ::init methods.
@@ -390,6 +495,25 @@ public:
 			TraceEvent("DDInitTakingMoveKeysLock", self->ddId).log();
 			wait(self->takeMoveKeysLock());
 			TraceEvent("DDInitTookMoveKeysLock", self->ddId).log();
+
+			// AuditStorage does not rely on DatabaseConfiguration
+			// AuditStorage read neccessary info purely from system key space
+			if (!self->auditStorageInitStarted) {
+				// Avoid multiple initAuditStorages
+				self->addActor.send(self->initAuditStorage(self));
+			}
+			// It is possible that an audit request arrives and then DDMode
+			// is set to 2 at this point
+			// No polling MoveKeyLock is running
+			// So, we need to check MoveKeyLock when waitUntilDataDistributorExitSecurityMode
+			wait(waitUntilDataDistributorExitSecurityMode(self)); // Trap DDMode == 2
+			// It is possible DDMode begins with 2 and passes
+			// waitDataDistributorEnabled and then set to 0 before
+			// waitUntilDataDistributorExitSecurityMode. For this case,
+			// after waitUntilDataDistributorExitSecurityMode, DDMode is 0.
+			// The init loop does not break and the loop will stuct at
+			// waitDataDistributorEnabled in the next iteration.
+			TraceEvent("DataDistributorExitSecurityMode").log();
 
 			wait(self->loadDatabaseConfiguration());
 			self->initDcInfo();
@@ -425,8 +549,8 @@ public:
 				    .trackLatest(self->initialDDEventHolder->trackingKey);
 			}
 
-			if (self->initData->mode && self->context->isDDEnabled()) {
-				// mode may be set true by system operator using fdbcli and isDDEnabled() set to true
+			if (self->initData->mode == 1 && self->context->isDDEnabled()) {
+				// mode may be set true by system operator using fdbcli and isEnabled() set to true
 				break;
 			}
 
@@ -735,155 +859,6 @@ inline std::unordered_map<UID, std::shared_ptr<DDAudit>> getAuditsForType(Refere
 	return self->audits[auditType];
 }
 
-void runAuditStorage(Reference<DataDistributor> self,
-                     AuditStorageState auditStates,
-                     int retryCount,
-                     std::string context);
-ACTOR Future<Void> auditStorageCore(Reference<DataDistributor> self,
-                                    UID auditID,
-                                    AuditType auditType,
-                                    std::string context,
-                                    int currentRetryCount);
-ACTOR Future<UID> launchAudit(Reference<DataDistributor> self, KeyRange auditRange, AuditType auditType);
-ACTOR Future<Void> auditStorage(Reference<DataDistributor> self, TriggerAuditRequest req);
-void loadAndDispatchAudit(Reference<DataDistributor> self, std::shared_ptr<DDAudit> audit, KeyRange range);
-ACTOR Future<Void> dispatchAuditStorageServerShard(Reference<DataDistributor> self, std::shared_ptr<DDAudit> audit);
-ACTOR Future<Void> scheduleAuditStorageShardOnServer(Reference<DataDistributor> self,
-                                                     std::shared_ptr<DDAudit> audit,
-                                                     StorageServerInterface ssi);
-ACTOR Future<Void> dispatchAuditStorage(Reference<DataDistributor> self,
-                                        std::shared_ptr<DDAudit> audit,
-                                        KeyRange range);
-ACTOR Future<Void> scheduleAuditOnRange(Reference<DataDistributor> self,
-                                        std::shared_ptr<DDAudit> audit,
-                                        KeyRange range);
-ACTOR Future<Void> doAuditOnStorageServer(Reference<DataDistributor> self,
-                                          std::shared_ptr<DDAudit> audit,
-                                          StorageServerInterface ssi,
-                                          AuditStorageRequest req);
-
-void cancelAllAuditsInAuditMap(Reference<DataDistributor> self) {
-	TraceEvent(SevDebug, "AuditMapOps", self->ddId).detail("Ops", "cancelAllAuditsInAuditMap");
-	for (auto& [auditType, auditMap] : self->audits) {
-		for (auto& [auditID, audit] : auditMap) {
-			// Any existing audit should stop running when the context switches out
-			audit->cancel();
-		}
-	}
-	self->audits.clear();
-	return;
-}
-
-ACTOR Future<Void> resumeStorageAudits(Reference<DataDistributor> self) {
-	ASSERT(!self->auditInitialized.getFuture().isReady());
-	if (self->initData->auditStates.empty()) {
-		self->auditInitialized.send(Void());
-		TraceEvent(SevVerbose, "AuditStorageResumeEmptyDone", self->ddId);
-		return Void();
-	}
-
-	// Update metadata
-	state int retryCount = 0;
-	loop {
-		try {
-			std::vector<Future<Void>> fs;
-			state MoveKeyLockInfo lockInfo;
-			lockInfo.myOwner = self->lock.myOwner;
-			lockInfo.prevOwner = self->lock.prevOwner;
-			lockInfo.prevWrite = self->lock.prevWrite;
-			for (const auto& auditState : self->initData->auditStates) {
-				// Only running audit will be resumed
-				if (auditState.getPhase() == AuditPhase::Running) {
-					AuditStorageState toUpdate = auditState;
-					toUpdate.ddId = self->ddId;
-					fs.push_back(updateAuditState(
-					    self->txnProcessor->context(), toUpdate, lockInfo, self->context->isDDEnabled()));
-				}
-			}
-			wait(waitForAll(fs));
-			break;
-		} catch (Error& e) {
-			if (e.code() == error_code_actor_cancelled || e.code() == error_code_movekeys_conflict) {
-				throw e;
-			}
-			if (retryCount > 50) {
-				TraceEvent(SevWarnAlways, "AuditStorageResumeUnableUpdateMetadata", self->ddId).errorUnsuppressed(e);
-				return Void();
-			}
-			retryCount++;
-		}
-	}
-
-	// Following is atomic
-	// Cancel existing audits and restore
-	cancelAllAuditsInAuditMap(self);
-	std::unordered_map<AuditType, std::vector<AuditStorageState>> restoredAudits;
-	for (const auto& auditState : self->initData->auditStates) {
-		restoredAudits[auditState.getType()].push_back(auditState);
-	}
-	// We clear existing audit state for each auditType separately
-	for (const auto& [auditType, _] : restoredAudits) {
-		int numFinishAudit = 0; // "finish" audits include Complete/Failed audits
-		for (const auto& auditState : restoredAudits[auditType]) {
-			if (auditState.getPhase() == AuditPhase::Complete || auditState.getPhase() == AuditPhase::Failed) {
-				numFinishAudit++;
-			}
-		}
-		const int numFinishAuditsToClear = numFinishAudit - SERVER_KNOBS->PERSIST_FINISH_AUDIT_COUNT;
-		int numFinishAuditsCleared = 0;
-		std::sort(restoredAudits[auditType].begin(),
-		          restoredAudits[auditType].end(),
-		          [](AuditStorageState a, AuditStorageState b) {
-			          return a.id < b.id; // Inplacement sort in ascending order
-		          });
-		// Cleanup audit metadata for Failed/Complete audits
-		// Resume RUNNING audits
-		// Keep Error audits persistent
-		for (const auto& auditState : restoredAudits[auditType]) {
-			TraceEvent(SevVerbose, "AuditStorageResumeCheck", self->ddId)
-			    .detail("AuditID", auditState.id)
-			    .detail("AuditType", auditState.getType());
-			if (auditState.getPhase() == AuditPhase::Error) {
-				continue;
-			} else if (auditState.getPhase() == AuditPhase::Failed) {
-				if (numFinishAuditsCleared < numFinishAuditsToClear) {
-					// Clear both audit metadata and corresponding progress metadata
-					self->addActor.send(clearAuditMetadata(self->txnProcessor->context(),
-					                                       auditState.getType(),
-					                                       auditState.id,
-					                                       /*clearProgressMetadata=*/true));
-					numFinishAuditsCleared++;
-				}
-				continue;
-			} else if (auditState.getPhase() == AuditPhase::Complete) {
-				if (numFinishAuditsCleared < numFinishAuditsToClear) {
-					// Clear audit metadata only
-					// No need to clear the corresponding progress metadata
-					// since it has been cleared for Complete audits
-					self->addActor.send(clearAuditMetadata(self->txnProcessor->context(),
-					                                       auditState.getType(),
-					                                       auditState.id,
-					                                       /*clearProgressMetadata=*/false));
-					numFinishAuditsCleared++;
-				}
-				continue;
-			}
-			ASSERT(auditState.getPhase() == AuditPhase::Running);
-			TraceEvent(SevDebug, "AuditStorageResume", self->ddId)
-			    .detail("AuditID", auditState.id)
-			    .detail("AuditType", auditState.getType())
-			    .detail("AuditState", auditState.toString())
-			    .detail("NumFinishAuditsCleared", numFinishAuditsCleared)
-			    .detail("IsReady", self->auditInitialized.getFuture().isReady());
-			runAuditStorage(self, auditState, 0, "ResumeAudit");
-		}
-	}
-
-	self->auditInitialized.send(Void());
-	TraceEvent(SevDebug, "AuditStorageResumeDone", self->ddId);
-	return Void();
-}
-
 // Periodically check and log the physicalShard status; clean up empty physicalShard;
 ACTOR Future<Void> monitorPhysicalShardStatus(Reference<PhysicalShardCollection> self) {
 	ASSERT(SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA);
@@ -932,7 +907,6 @@ ACTOR Future<Void> dataDistribution(Reference<DataDistributor> self,
 		trackerCancelled = false;
 		// whether all initial shard are tracked
 		self->initialized = Promise<Void>();
-		self->auditInitialized = Promise<Void>();
 
 		// Stored outside of data distribution tracker to avoid slow tasks
 		// when tracker is cancelled
@@ -981,8 +955,6 @@ ACTOR Future<Void> dataDistribution(Reference<DataDistributor> self,
 			} else {
 				anyZeroHealthyTeams = zeroHealthyTeams[0];
 			}
-
-			actors.push_back(resumeStorageAudits(self));
 
 			actors.push_back(self->pollMoveKeysLock());
 
@@ -1718,9 +1690,7 @@ ACTOR Future<Void> ddGetMetrics(GetDataDistributorMetricsRequest req,
 ACTOR Future<Void> auditStorageCore(Reference<DataDistributor> self,
                                     UID auditID,
                                     AuditType auditType,
-                                    std::string context,
                                     int currentRetryCount) {
-	// At this point, audit must be launched
 	ASSERT(auditID.isValid());
 	state std::shared_ptr<DDAudit> audit = getAuditFromAuditMap(self, auditType, auditID);
 
@@ -1734,18 +1704,19 @@ ACTOR Future<Void> auditStorageCore(Reference<DataDistributor> self,
 		ASSERT(audit->coreState.ddId == self->ddId);
 		loadAndDispatchAudit(self, audit, audit->coreState.range);
 		TraceEvent(SevInfo, "DDAuditStorageCoreScheduled", self->ddId)
-		    .detail("Context", context)
+		    .detail("Context", audit->getDDAuditContext())
 		    .detail("AuditID", audit->coreState.id)
 		    .detail("Range", audit->coreState.range)
 		    .detail("AuditType", audit->coreState.getType())
-		    .detail("RetryCount", currentRetryCount)
-		    .detail("IsReady", self->auditInitialized.getFuture().isReady());
+		    .detail("AuditStorageCoreGeneration", currentRetryCount)
+		    .detail("RetryCount", audit->retryCount);
 		wait(audit->actors.getResult()); // goto exception handler if any actor is failed
 		TraceEvent(SevInfo, "DDAuditStorageCoreAllActorsComplete", self->ddId)
 		    .detail("AuditID", audit->coreState.id)
 		    .detail("Range", audit->coreState.range)
 		    .detail("AuditType", audit->coreState.getType())
-		    .detail("RetryCount", currentRetryCount)
+		    .detail("AuditStorageCoreGeneration", currentRetryCount)
+		    .detail("RetryCount", audit->retryCount)
 		    .detail("DDDoAuditTasksIssued", audit->overallIssuedDoAuditCount)
 		    .detail("DDDoAuditTasksComplete", audit->overallCompleteDoAuditCount);
 		// reset for the usage for future retry
@@ -1774,30 +1745,30 @@ ACTOR Future<Void> auditStorageCore(Reference<DataDistributor> self,
 			audit->coreState.setPhase(AuditPhase::Complete);
 		}
 		TraceEvent(SevVerbose, "DDAuditStorageCoreCompleteAudit", self->ddId)
-		    .detail("Context", context)
+		    .detail("Context", audit->getDDAuditContext())
 		    .detail("AuditState", audit->coreState.toString())
-		    .detail("RetryCount", currentRetryCount)
-		    .detail("IsReady", self->auditInitialized.getFuture().isReady());
+		    .detail("AuditStorageCoreGeneration", currentRetryCount)
+		    .detail("RetryCount", audit->retryCount);
 		wait(persistAuditState(self->txnProcessor->context(),
 		                       audit->coreState,
 		                       "AuditStorageCore",
 		                       lockInfo,
 		                       self->context->isDDEnabled()));
 		TraceEvent(SevVerbose, "DDAuditStorageCoreSetResult", self->ddId)
-		    .detail("Context", context)
+		    .detail("Context", audit->getDDAuditContext())
 		    .detail("AuditState", audit->coreState.toString())
-		    .detail("RetryCount", currentRetryCount)
-		    .detail("IsReady", self->auditInitialized.getFuture().isReady());
+		    .detail("AuditStorageCoreGeneration", currentRetryCount)
+		    .detail("RetryCount", audit->retryCount);
 		removeAuditFromAuditMap(self, audit->coreState.getType(),
 		                        audit->coreState.id); // remove audit
 
 		TraceEvent(SevInfo, "DDAuditStorageCoreEnd", self->ddId)
-		    .detail("Context", context)
+		    .detail("Context", audit->getDDAuditContext())
 		    .detail("AuditID", auditID)
 		    .detail("AuditType", auditType)
 		    .detail("Range", audit->coreState.range)
-		    .detail("RetryCount", currentRetryCount)
-		    .detail("IsReady", self->auditInitialized.getFuture().isReady());
+		    .detail("AuditStorageCoreGeneration", currentRetryCount)
+		    .detail("RetryCount", audit->retryCount);
 	} catch (Error& e) {
 		if (e.code() == error_code_actor_cancelled) {
 			// If this audit is cancelled, the place where cancelling
@@ -1806,16 +1777,16 @@ ACTOR Future<Void> auditStorageCore(Reference<DataDistributor> self,
 		}
 		TraceEvent(SevDebug, "DDAuditStorageCoreError", self->ddId)
 		    .errorUnsuppressed(e)
-		    .detail("Context", context)
+		    .detail("Context", audit->getDDAuditContext())
 		    .detail("AuditID", auditID)
-		    .detail("RetryCount", currentRetryCount)
+		    .detail("AuditStorageCoreGeneration", currentRetryCount)
+		    .detail("RetryCount", audit->retryCount)
 		    .detail("AuditType", auditType)
-		    .detail("Range", audit->coreState.range)
-		    .detail("IsReady", self->auditInitialized.getFuture().isReady());
+		    .detail("Range", audit->coreState.range);
 		if (e.code() == error_code_movekeys_conflict) {
 			removeAuditFromAuditMap(self, audit->coreState.getType(),
 			                        audit->coreState.id); // remove audit
-			throw e; // throw to DD and DD will restart
+			// Silently exit
 		} else if (e.code() == error_code_audit_storage_cancelled) {
 			// If this audit is cancelled, the place where cancelling
 			// this audit does removeAuditFromAuditMap
@@ -1825,18 +1796,20 @@ ACTOR Future<Void> auditStorageCore(Reference<DataDistributor> self,
 			TraceEvent(SevVerbose, "DDAuditStorageCoreRetry", self->ddId)
 			    .detail("AuditID", auditID)
 			    .detail("AuditType", auditType)
-			    .detail("RetryCount", currentRetryCount)
+			    .detail("AuditStorageCoreGeneration", currentRetryCount)
+			    .detail("RetryCount", audit->retryCount)
 			    .detail("Contains", self->audits.contains(auditType) && self->audits[auditType].contains(auditID));
 			wait(delay(0.1));
 			TraceEvent(SevVerbose, "DDAuditStorageCoreRetryAfterWait", self->ddId)
 			    .detail("AuditID", auditID)
 			    .detail("AuditType", auditType)
-			    .detail("RetryCount", currentRetryCount)
+			    .detail("AuditStorageCoreGeneration", currentRetryCount)
+			    .detail("RetryCount", audit->retryCount)
 			    .detail("Contains", self->audits.contains(auditType) && self->audits[auditType].contains(auditID));
 			// Erase the old audit from map and spawn a new audit inherit from the old audit
 			removeAuditFromAuditMap(self, audit->coreState.getType(),
 			                        audit->coreState.id); // remove audit
-			runAuditStorage(self, audit->coreState, audit->retryCount, "auditStorageCoreRetry");
+			runAuditStorage(self, audit->coreState, audit->retryCount, DDAuditContext::Retry);
 		} else {
 			try {
 				audit->coreState.setPhase(AuditPhase::Failed);
@@ -1845,22 +1818,22 @@ ACTOR Future<Void> auditStorageCore(Reference<DataDistributor> self,
 				                       "AuditStorageCoreError",
 				                       lockInfo,
 				                       self->context->isDDEnabled()));
-				TraceEvent(SevInfo, "DDAuditStorageCoreSetFailed", self->ddId)
-				    .detail("Context", context)
+				TraceEvent(SevWarn, "DDAuditStorageCoreSetAuditFailed", self->ddId)
+				    .detail("Context", audit->getDDAuditContext())
 				    .detail("AuditID", auditID)
 				    .detail("AuditType", auditType)
-				    .detail("RetryCount", currentRetryCount)
-				    .detail("AuditState", audit->coreState.toString())
-				    .detail("IsReady", self->auditInitialized.getFuture().isReady());
+				    .detail("AuditStorageCoreGeneration", currentRetryCount)
+				    .detail("RetryCount", audit->retryCount)
+				    .detail("AuditState", audit->coreState.toString());
 			} catch (Error& e) {
 				TraceEvent(SevWarn, "DDAuditStorageCoreErrorWhenSetAuditFailed", self->ddId)
 				    .errorUnsuppressed(e)
-				    .detail("Context", context)
+				    .detail("Context", audit->getDDAuditContext())
 				    .detail("AuditID", auditID)
 				    .detail("AuditType", auditType)
-				    .detail("RetryCount", currentRetryCount)
-				    .detail("AuditState", audit->coreState.toString())
-				    .detail("IsReady", self->auditInitialized.getFuture().isReady());
+				    .detail("AuditStorageCoreGeneration", currentRetryCount)
+				    .detail("RetryCount", audit->retryCount)
+				    .detail("AuditState", audit->coreState.toString());
 				// unexpected error when persistAuditState
 				// However, we do not want any audit error kills the DD
 				// So, we silently remove audit from auditMap
@@ -1890,7 +1863,7 @@ ACTOR Future<Void> auditStorageCore(Reference<DataDistributor> self,
 void runAuditStorage(Reference<DataDistributor> self,
                      AuditStorageState auditState,
                      int retryCount,
-                     std::string context) {
+                     DDAuditContext context) {
 	// Validate input auditState
 	if (auditState.getType() != AuditType::ValidateHA && auditState.getType() != AuditType::ValidateReplica &&
 	    auditState.getType() != AuditType::ValidateLocationMetadata &&
@@ -1906,14 +1879,13 @@ void runAuditStorage(Reference<DataDistributor> self,
 	auditState.ddId = self->ddId; // make sure any existing audit state claims the current DD
 	std::shared_ptr<DDAudit> audit = std::make_shared<DDAudit>(auditState);
 	audit->retryCount = retryCount;
+	audit->setDDAuditContext(context);
 	addAuditToAuditMap(self, audit);
-	audit->setAuditRunActor(
-	    auditStorageCore(self, audit->coreState.id, audit->coreState.getType(), context, audit->retryCount));
+	audit->setAuditRunActor(auditStorageCore(self, audit->coreState.id, audit->coreState.getType(), audit->retryCount));
 	return;
 }
 
-// Create/pick an audit for auditRange and auditType
-// Return audit ID if no error happens
+// Get audit for auditRange and auditType, if not exist, launch a new one
 ACTOR Future<UID> launchAudit(Reference<DataDistributor> self, KeyRange auditRange, AuditType auditType) {
 	state MoveKeyLockInfo lockInfo;
 	lockInfo.myOwner = self->lock.myOwner;
@@ -1922,21 +1894,10 @@ ACTOR Future<UID> launchAudit(Reference<DataDistributor> self, KeyRange auditRan
 
 	state UID auditID;
 	try {
-		TraceEvent(SevInfo, "DDAuditStorageLaunchTriggered", self->ddId)
+		TraceEvent(SevInfo, "DDAuditStorageLaunchStarts", self->ddId)
 		    .detail("AuditType", auditType)
-		    .detail("Range", auditRange)
-		    .detail("IsReady", self->auditInitialized.getFuture().isReady());
-		std::vector<Future<Void>> fs;
-		fs.push_back(self->auditInitialized.getFuture());
-		fs.push_back(self->initialized.getFuture());
-		wait(waitForAll(fs));
-
-		// Get audit, if not exist, triggers a new one
-		ASSERT(self->auditInitialized.getFuture().isReady() && self->initialized.getFuture().isReady());
-		TraceEvent(SevVerbose, "DDAuditStorageLaunchStart", self->ddId)
-		    .detail("AuditType", auditType)
-		    .detail("Range", auditRange)
-		    .detail("IsReady", self->auditInitialized.getFuture().isReady());
+		    .detail("RequestedRange", auditRange);
+		wait(self->auditStorageInitialized.getFuture());
 		// Start an audit if no audit exists
 		// If existing an audit for a different purpose, send error to client
 		// aka, we only allow one audit at a time for all purposes
@@ -1970,8 +1931,7 @@ ACTOR Future<UID> launchAudit(Reference<DataDistributor> self, KeyRange auditRan
 			    .detail("AuditType", auditType)
 			    .detail("AuditID", auditID)
 			    .detail("RequestedRange", auditRange)
-			    .detail("ExistingState", audit->coreState.toString())
-			    .detail("IsReady", self->auditInitialized.getFuture().isReady());
+			    .detail("ExistingState", audit->coreState.toString());
 		} else {
 			state AuditStorageState auditState;
 			auditState.setType(auditType);
@@ -2005,7 +1965,14 @@ ACTOR Future<UID> launchAudit(Reference<DataDistributor> self, KeyRange auditRan
 			    .detail("Range", auditRange);
 			auditState.id = auditID_;
 			auditID = auditID_;
-			runAuditStorage(self, auditState, 0, "LaunchAudit");
+			if (self->audits.contains(auditType) && self->audits[auditType].contains(auditID)) {
+				// It is possible that the current DD is running this audit
+				// Suppose DDinit re-runs right after a new audit is persisted
+				// For this case, auditResume sees the new audit and resumes it
+				// At this point, the new audit is already in the audit map
+				return auditID;
+			}
+			runAuditStorage(self, auditState, 0, DDAuditContext::Launch);
 		}
 	} catch (Error& e) {
 		if (e.code() == error_code_actor_cancelled) {
@@ -2107,8 +2074,7 @@ ACTOR Future<Void> auditStorage(Reference<DataDistributor> self, TriggerAuditReq
 			TraceEvent(SevDebug, "DDAuditStorageStart", self->ddId)
 			    .detail("RetryCount", retryCount)
 			    .detail("AuditType", req.getType())
-			    .detail("Range", req.range)
-			    .detail("IsReady", self->auditInitialized.getFuture().isReady());
+			    .detail("Range", req.range);
 			UID auditID = wait(launchAudit(self, req.range, req.getType()));
 			req.reply.send(auditID);
 			TraceEvent(SevVerbose, "DDAuditStorageReply", self->ddId)
@@ -2294,8 +2260,7 @@ ACTOR Future<Void> scheduleAuditStorageShardOnServer(Reference<DataDistributor> 
 		    .detail("AuditType", auditType)
 		    .detail("IssuedDoAuditCount", issueDoAuditCount);
 
-		if (e.code() == error_code_not_implemented || e.code() == error_code_audit_storage_exceeded_request_limit ||
-		    e.code() == error_code_audit_storage_cancelled) {
+		if (e.code() == error_code_not_implemented || e.code() == error_code_audit_storage_cancelled) {
 			throw e;
 		} else if (e.code() == error_code_audit_storage_error) {
 			audit->foundError = true;

--- a/fdbserver/MoveKeys.actor.cpp
+++ b/fdbserver/MoveKeys.actor.cpp
@@ -281,7 +281,7 @@ ACTOR static Future<Void> checkMoveKeysLock(Transaction* tr,
 		throw movekeys_conflict();
 	}
 	Optional<Value> readVal = wait(tr->get(moveKeysLockOwnerKey));
-	UID currentOwner = readVal.present() ? BinaryReader::fromStringRef<UID>(readVal.get(), Unversioned()) : UID();
+	state UID currentOwner = readVal.present() ? BinaryReader::fromStringRef<UID>(readVal.get(), Unversioned()) : UID();
 
 	if (currentOwner == lock.prevOwner) {
 		// Check that the previous owner hasn't touched the lock since we took it
@@ -289,6 +289,13 @@ ACTOR static Future<Void> checkMoveKeysLock(Transaction* tr,
 		UID lastWrite = readVal.present() ? BinaryReader::fromStringRef<UID>(readVal.get(), Unversioned()) : UID();
 		if (lastWrite != lock.prevWrite) {
 			CODE_PROBE(true, "checkMoveKeysLock: Conflict with previous owner");
+			TraceEvent(SevDebug, "CheckPersistentMoveKeysWritterConflict")
+			    .errorUnsuppressed(movekeys_conflict())
+			    .detail("PrevOwner", lock.prevOwner.toString())
+			    .detail("PrevWrite", lock.prevWrite.toString())
+			    .detail("MyOwner", lock.myOwner.toString())
+			    .detail("CurrentOwner", currentOwner.toString())
+			    .detail("Writer", lastWrite.toString());
 			throw movekeys_conflict();
 		}
 
@@ -322,6 +329,12 @@ ACTOR static Future<Void> checkMoveKeysLock(Transaction* tr,
 		return Void();
 	} else {
 		CODE_PROBE(true, "checkMoveKeysLock: Conflict with new owner");
+		TraceEvent(SevDebug, "CheckPersistentMoveKeysLockOwnerConflict")
+		    .errorUnsuppressed(movekeys_conflict())
+		    .detail("PrevOwner", lock.prevOwner.toString())
+		    .detail("PrevWrite", lock.prevWrite.toString())
+		    .detail("MyOwner", lock.myOwner.toString())
+		    .detail("CurrentOwner", currentOwner.toString());
 		throw movekeys_conflict();
 	}
 }
@@ -390,8 +403,10 @@ ACTOR Future<bool> validateRangeAssignment(Database occ,
 		}
 	}
 	if (!allCorrect) {
-		try { // If corruption detected, stop using DD
-			int _ = wait(setDDMode(occ, 0));
+		try {
+			// If corruption detected, enter security mode which
+			// stops using data moves and only allow auditStorage
+			int _ = wait(setDDMode(occ, 2));
 			TraceEvent(SevInfo, "ValidateRangeAssignmentCorruptionDetectedAndDDStopped")
 			    .detail("DataMoveID", dataMoveId)
 			    .detail("Range", range)
@@ -414,19 +429,17 @@ ACTOR Future<Void> auditLocationMetadataPreCheck(Database occ,
                                                  std::string context,
                                                  UID dataMoveId) {
 	if (range.empty()) {
-		TraceEvent(SevWarn, "AuditLocationMetadataEmptyInputRange")
-		    .detail("By", "PreCheck")
-		    .detail("AuditRange", range);
+		TraceEvent(SevWarn, "CheckLocationMetadataEmptyInputRange").detail("By", "PreCheck").detail("Range", range);
 		return Void();
 	}
 	state std::vector<Future<Void>> actors;
 	state std::unordered_map<UID, Optional<bool>> results;
-	TraceEvent(SevDebug, "AuditLocationMetadataStart")
+	TraceEvent(SevVerbose, "CheckLocationMetadataStart")
 	    .detail("By", "PreCheck")
 	    .detail("DataMoveID", dataMoveId)
 	    .detail("Servers", describe(servers))
 	    .detail("Context", context)
-	    .detail("AuditRange", range);
+	    .detail("Range", range);
 	try {
 		actors.clear();
 		results.clear();
@@ -437,40 +450,40 @@ ACTOR Future<Void> auditLocationMetadataPreCheck(Database occ,
 		for (const auto& [ssid, res] : results) {
 			ASSERT(res.present());
 			if (!res.get()) { // Stop check if corruption detected
-				TraceEvent(SevError, "AuditLocationMetadataCorruptionDetected")
+				TraceEvent(SevError, "CheckLocationMetadataCorruptionDetected")
 				    .detail("By", "PreCheck")
 				    .detail("DataMoveID", dataMoveId)
 				    .detail("Servers", describe(servers))
 				    .detail("Context", context)
-				    .detail("AuditRange", range);
+				    .detail("Range", range);
 				throw location_metadata_corruption();
 			}
 		}
-		TraceEvent(SevDebug, "AuditLocationMetadataComplete")
+		TraceEvent(SevVerbose, "CheckLocationMetadataComplete")
 		    .detail("By", "PreCheck")
 		    .detail("DataMoveID", dataMoveId)
 		    .detail("Servers", describe(servers))
 		    .detail("Context", context)
-		    .detail("AuditRange", range);
+		    .detail("Range", range);
 	} catch (Error& e) {
 		if (e.code() == error_code_actor_cancelled || e.code() == error_code_location_metadata_corruption) {
 			throw e;
 		} else {
-			TraceEvent(SevInfo, "AuditLocationMetadataFailed")
+			TraceEvent(SevInfo, "CheckLocationMetadataFailed")
 			    .errorUnsuppressed(e)
 			    .detail("By", "PreCheck")
 			    .detail("DataMoveID", dataMoveId)
 			    .detail("Context", context)
-			    .detail("AuditRange", range);
+			    .detail("Range", range);
 			// Check any existing result when failure presents
 			for (const auto& [ssid, res] : results) {
 				if (res.present() && !res.get()) {
-					TraceEvent(SevError, "AuditLocationMetadataCorruptionDetectedWhenFailed")
+					TraceEvent(SevError, "CheckLocationMetadataCorruptionDetectedWhenFailed")
 					    .detail("By", "PreCheck")
 					    .detail("DataMoveID", dataMoveId)
 					    .detail("Servers", describe(servers))
 					    .detail("Context", context)
-					    .detail("AuditRange", range);
+					    .detail("Range", range);
 					throw location_metadata_corruption();
 				}
 			}
@@ -482,9 +495,7 @@ ACTOR Future<Void> auditLocationMetadataPreCheck(Database occ,
 
 ACTOR Future<Void> auditLocationMetadataPostCheck(Database occ, KeyRange range, std::string context, UID dataMoveId) {
 	if (range.empty()) {
-		TraceEvent(SevWarn, "AuditLocationMetadataEmptyInputRange")
-		    .detail("By", "PostCheck")
-		    .detail("AuditRange", range);
+		TraceEvent(SevWarn, "CheckLocationMetadataEmptyInputRange").detail("By", "PostCheck").detail("Range", range);
 		return Void();
 	}
 	state std::vector<Future<Void>> actors;
@@ -494,10 +505,10 @@ ACTOR Future<Void> auditLocationMetadataPostCheck(Database occ, KeyRange range, 
 	state RangeResult UIDtoTagMap;
 	state Transaction tr(occ);
 	state int retryCount = 0;
-	TraceEvent(SevDebug, "AuditLocationMetadataStart")
+	TraceEvent(SevVerbose, "CheckLocationMetadataStart")
 	    .detail("By", "PostCheck")
 	    .detail("Context", context)
-	    .detail("AuditRange", range);
+	    .detail("Range", range);
 	loop {
 		try {
 			loop {
@@ -518,7 +529,7 @@ ACTOR Future<Void> auditLocationMetadataPostCheck(Database occ, KeyRange range, 
 					actors.push_back(store(UIDtoTagMap, tr.getRange(serverTagKeys, CLIENT_KNOBS->TOO_MANY)));
 					wait(waitForAll(actors));
 					ASSERT(!UIDtoTagMap.more && UIDtoTagMap.size() < CLIENT_KNOBS->TOO_MANY);
-					TraceEvent(SevVerbose, "AuditLocationMetadataReadDone")
+					TraceEvent(SevVerbose, "CheckLocationMetadataReadDone")
 					    .detail("By", "PostCheck")
 					    .detail("ResultSize", readResultKS.size());
 					// Read serverKeys
@@ -555,11 +566,11 @@ ACTOR Future<Void> auditLocationMetadataPostCheck(Database occ, KeyRange range, 
 						rangeToReadBegin = readResultKS.back().key;
 						continue;
 					} else {
-						TraceEvent(SevDebug, "AuditLocationMetadataComplete")
+						TraceEvent(SevVerbose, "CheckLocationMetadataComplete")
 						    .detail("By", "PostCheck")
 						    .detail("DataMoveID", dataMoveId)
 						    .detail("Context", context)
-						    .detail("AuditRange", range);
+						    .detail("Range", range);
 						break;
 					}
 				} catch (Error& e) {
@@ -575,21 +586,21 @@ ACTOR Future<Void> auditLocationMetadataPostCheck(Database occ, KeyRange range, 
 				// Check corruptions for the current (failed) round
 				for (const auto& [idx, res] : results) {
 					if (res.present() && !res.get()) {
-						TraceEvent(SevError, "AuditLocationMetadataCorruptionDetectedWhenFailed")
+						TraceEvent(SevError, "CheckLocationMetadataCorruptionDetectedWhenFailed")
 						    .detail("By", "PostCheck")
 						    .detail("DataMoveID", dataMoveId)
 						    .detail("Context", context)
-						    .detail("AuditRange", range);
+						    .detail("Range", range);
 						throw location_metadata_corruption();
 					}
 				}
 				if (retryCount > SERVER_KNOBS->AUDIT_DATAMOVE_POST_CHECK_RETRY_COUNT_MAX) {
-					TraceEvent(SevInfo, "AuditLocationMetadataFailed")
+					TraceEvent(SevInfo, "CheckLocationMetadataFailed")
 					    .errorUnsuppressed(e)
 					    .detail("By", "PostCheck")
 					    .detail("DataMoveID", dataMoveId)
 					    .detail("Context", context)
-					    .detail("AuditRange", range);
+					    .detail("Range", range);
 					// If no corruption detected, exit silently
 				} else {
 					wait(delay(0.5));

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -5613,6 +5613,10 @@ ACTOR Future<Void> auditStorageServerShardQ(StorageServer* data, AuditStorageReq
 	    .detail("NumValidatedLocalShards", cumulatedValidatedLocalShardsNum)
 	    .detail("NumValidatedServerKeys", cumulatedValidatedServerKeysNum);
 
+	// Make sure the history collection is not open due to this audit
+	data->stopTrackShardAssignment();
+	TraceEvent(SevVerbose, "SSShardAssignmentHistoryRecordStopWhenExit", data->thisServerID).detail("AuditID", req.id);
+
 	return Void();
 }
 


### PR DESCRIPTION
Commit: [fix lock used by waitUntilDataDistributorExitSecurityMode](https://github.com/apple/foundationdb/pull/10660/commits/f4f1e2aa7235022e3af783402abff04aca3adff6) fixes moveKeyLock used by waitUntilDataDistributorExitSecurityMode. In the main branch, DD->lock references to DD->context->lock. So, after DD takes the lock, DD->context->lock is set. In release 73,  DD->lock does not references to DD->context->lock. So, DD->context->lock is empty after DD takes the lock. This commit avoids using DD->context->lock.

Correctness test with three irrelevant failures (i.e. external timeout by rocksdb engine, no audit module runs in the test):
  20230723-212326-zhewang-bffe8ad438e44d6b           compressed=True data_size=33405135 duration=5150009 ended=100000 fail=3 fail_fast=10 max_runs=100000 pass=99997 priority=100 remaining=0 runtime=1:34:47 sanity=False started=100000 stopped=20230723-225813 submitted=20230723-212326 timeout=5400 username=zhewang

ValidateStorage test:
  20230723-212346-zhewang-70d9de4224982dda           compressed=True data_size=33438065 duration=9560131 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:43:53 sanity=False started=100000 stopped=20230723-230739 submitted=20230723-212346 timeout=5400 username=zhewang

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
