### PR TITLE
Fix GRV queue leak

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -562,7 +562,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( TAG_THROTTLE_RATE_WINDOW,                              2.0 );
 	init( START_TRANSACTION_MAX_EMPTY_QUEUE_BUDGET,             10.0 );
 	init( TAG_THROTTLE_MAX_EMPTY_QUEUE_BUDGET,                1000.0 );
-	init( START_TRANSACTION_MAX_QUEUE_SIZE,                      1e6 );
+	init( START_TRANSACTION_MAX_QUEUE_SIZE,                      1e6 ); if ( randomize && BUGGIFY ) START_TRANSACTION_MAX_QUEUE_SIZE = 1000;
 	init( KEY_LOCATION_MAX_QUEUE_SIZE,                           1e6 );
 	init( TENANT_ID_REQUEST_MAX_QUEUE_SIZE,                      1e6 );
 	init( BLOB_GRANULE_LOCATION_MAX_QUEUE_SIZE,                  1e5 ); if ( randomize && BUGGIFY ) BLOB_GRANULE_LOCATION_MAX_QUEUE_SIZE = 100;

--- a/fdbserver/GrvProxyServer.actor.cpp
+++ b/fdbserver/GrvProxyServer.actor.cpp
@@ -920,7 +920,7 @@ ACTOR static Future<Void> transactionStarter(GrvProxyInterface proxy,
 			elapsed = 1e-15;
 		}
 
-		grvProxyData->stats.update(grvProxyData->tagThrottler.releaseTransactions(elapsed, defaultQueue, batchQueue));
+		grvProxyData->stats.update(grvProxyData->tagThrottler.releaseTransactions(elapsed, batchQueue, defaultQueue));
 
 		normalRateInfo.startReleaseWindow();
 		batchRateInfo.startReleaseWindow();

--- a/fdbserver/include/fdbserver/GrvProxyTagThrottler.h
+++ b/fdbserver/include/fdbserver/GrvProxyTagThrottler.h
@@ -79,12 +79,20 @@ public:
 	// Called with rates received from ratekeeper
 	void updateRates(TransactionTagMap<double> const& newRates);
 
+	struct ReleaseTransactionsResult {
+		uint64_t batchPriorityTransactionsReleased{ 0 };
+		uint64_t batchPriorityRequestsReleased{ 0 };
+		uint64_t defaultPriorityTransactionsReleased{ 0 };
+		uint64_t defaultPriorityRequestsReleased{ 0 };
+		uint64_t rejectedRequests{ 0 };
+	};
+
 	// elapsed indicates the amount of time since the last epoch was run.
 	// If a request is ready to be executed, it is sent to the deque
 	// corresponding to its priority. If not, the request remains queued.
-	void releaseTransactions(double elapsed,
-	                         Deque<GetReadVersionRequest>& outBatchPriority,
-	                         Deque<GetReadVersionRequest>& outDefaultPriority);
+	ReleaseTransactionsResult releaseTransactions(double elapsed,
+	                                              Deque<GetReadVersionRequest>& outBatchPriority,
+	                                              Deque<GetReadVersionRequest>& outDefaultPriority);
 
 	void addRequest(GetReadVersionRequest const&);
 


### PR DESCRIPTION
This PR makes the following changes:

- Fixes a bug where rejected transactions were reported to ratekeeper as having started, causing average transaction cost under-estimation, and thus overly lax throttling.
- Fixes a bug where `GrvProxyStats::txnStartIn` (but not `GrvProxyStats::txnStartOut`) is incremented for rejected transactions. This caused the measured queue of pending GRV requests to grow indefinitely, leading to `grv_proxy_memory_limit_exceeded` errors.
- Buggifies `START_TRANSACTION_MAX_QUEUE_SIZE` to cause the above bug to fail simulation tests without the fix
- Adds tag throttler queue stats to `GrvProxyStats`

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
