### PR TITLE
Remove SS entries from RateKeeper once it is down [release-7.1]

### DIFF
--- a/fdbserver/Ratekeeper.actor.cpp
+++ b/fdbserver/Ratekeeper.actor.cpp
@@ -175,6 +175,7 @@ public:
 		} catch (...) {
 			// including cancellation
 			self->storageQueueInfo.erase(myQueueInfo);
+			self->healthMetrics.storageStats.erase(ssi.id());
 			throw;
 		}
 	}
@@ -221,8 +222,10 @@ public:
 						a = Future<Void>();
 						a = splitError(trackStorageServerQueueInfo(self, change.second.get()), err);
 					}
-				} else
+				} else {
 					actors.erase(change.first);
+					self->healthMetrics.storageStats.erase(change.first);
+				}
 			}
 			when(wait(err.getFuture())) {}
 		}


### PR DESCRIPTION
backport https://github.com/apple/foundationdb/pull/10627

Dropped the test, because there is a gap between 7.1 and main, which could take significant more amount of time.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
