### PR TITLE
Add a flag for enabling/disabling RocksDB storage engine in simulations

### DIFF
--- a/cmake/FDBComponents.cmake
+++ b/cmake/FDBComponents.cmake
@@ -165,7 +165,7 @@ endif()
 # RocksDB
 ################################################################################
 
-set(SSD_ROCKSDB_EXPERIMENTAL ON CACHE BOOL "Build with experimental RocksDB support")
+set(WITH_ROCKSDB ON CACHE BOOL "Build with experimental RocksDB support")
 set(PORTABLE_ROCKSDB ON CACHE BOOL "Compile RocksDB in portable mode") # Set this to OFF to compile RocksDB with `-march=native`
 set(ROCKSDB_SSE42 OFF CACHE BOOL "Compile RocksDB with SSE42 enabled")
 set(ROCKSDB_AVX ${USE_AVX} CACHE BOOL "Compile RocksDB with AVX enabled")
@@ -245,7 +245,7 @@ function(print_components)
   message(STATUS "Build Documentation (make html):      ${WITH_DOCUMENTATION}")
   message(STATUS "Build Python sdist (make package):    ${WITH_PYTHON_BINDING}")
   message(STATUS "Configure CTest (depends on Python):  ${WITH_PYTHON}")
-  message(STATUS "Build with RocksDB:                   ${SSD_ROCKSDB_EXPERIMENTAL}")
+  message(STATUS "Build with RocksDB:                   ${WITH_ROCKSDB}")
   message(STATUS "Build with AWS SDK:                   ${WITH_AWS_BACKUP}")
   message(STATUS "=========================================")
 endfunction()

--- a/cmake/FDBComponents.cmake
+++ b/cmake/FDBComponents.cmake
@@ -172,13 +172,6 @@ set(ROCKSDB_AVX ${USE_AVX} CACHE BOOL "Compile RocksDB with AVX enabled")
 set(ROCKSDB_AVX2 OFF CACHE BOOL "Compile RocksDB with AVX2 enabled")
 set(ROCKSDB_TOOLS OFF CACHE BOOL "Compile RocksDB tools")
 set(WITH_LIBURING OFF CACHE BOOL "Build with liburing enabled") # Set this to ON to include liburing
-# RocksDB is currently enabled by default for GCC but does not build with the latest
-# Clang.
-if (SSD_ROCKSDB_EXPERIMENTAL AND NOT WIN32)
-  set(WITH_ROCKSDB_EXPERIMENTAL ON)
-else()
-  set(WITH_ROCKSDB_EXPERIMENTAL OFF)
-endif()
 
 ################################################################################
 # TOML11
@@ -252,7 +245,7 @@ function(print_components)
   message(STATUS "Build Documentation (make html):      ${WITH_DOCUMENTATION}")
   message(STATUS "Build Python sdist (make package):    ${WITH_PYTHON_BINDING}")
   message(STATUS "Configure CTest (depends on Python):  ${WITH_PYTHON}")
-  message(STATUS "Build with RocksDB:                   ${WITH_ROCKSDB_EXPERIMENTAL}")
+  message(STATUS "Build with RocksDB:                   ${SSD_ROCKSDB_EXPERIMENTAL}")
   message(STATUS "Build with AWS SDK:                   ${WITH_AWS_BACKUP}")
   message(STATUS "=========================================")
 endfunction()

--- a/fdbserver/CMakeLists.txt
+++ b/fdbserver/CMakeLists.txt
@@ -6,7 +6,9 @@ else()
   list(APPEND FDBSERVER_SRCS coroimpl/CoroFlow.actor.cpp)
 endif()
 
+
 if(WITH_ROCKSDB_EXPERIMENTAL)
+  set(ENABLE_ROCKSDB_IN_SIMULATION ON CACHE BOOL "Enable RocksDB engine in simulation tests")
   include(CompileRocksDB)
   # CompileRocksDB sets `lz4_LIBRARIES` to be the shared lib, we want to link
   # statically, so find the static library here.
@@ -15,6 +17,8 @@ if(WITH_ROCKSDB_EXPERIMENTAL)
   if(WITH_LIBURING)
     find_package(uring)
   endif()
+else()
+  set(ENABLE_ROCKSDB_IN_SIMULATION OFF CACHE BOOL "Enable RocksDB engine in simulation tests")
 endif()
 
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/workloads)
@@ -139,6 +143,9 @@ target_include_directories(fdbserver PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/include
   ${CMAKE_CURRENT_BINARY_DIR}/include)
 if (WITH_ROCKSDB_EXPERIMENTAL)
+  if (ENABLE_ROCKSDB_IN_SIMULATION)
+	  target_compile_definitions(fdbserver PRIVATE SIMULATION_ROCKSDB_ENABLED=1)
+  endif()
   add_dependencies(fdbserver rocksdb)
   if(WITH_LIBURING)
     target_include_directories(fdbserver PRIVATE ${ROCKSDB_INCLUDE_DIR} ${uring_INCLUDE_DIR})
@@ -147,9 +154,11 @@ if (WITH_ROCKSDB_EXPERIMENTAL)
   else()
     target_include_directories(fdbserver PRIVATE ${ROCKSDB_INCLUDE_DIR})
     target_link_libraries(fdbserver PRIVATE fdbclient metacluster sqlite ${ROCKSDB_LIBRARIES} ${lz4_STATIC_LIBRARIES})
-    target_compile_definitions(fdbserver PRIVATE)
   endif()
 else()
+  if (ENABLE_ROCKSDB_IN_SIMULATION)
+    message(FATAL_ERROR "ENABLE_ROCKSDB_IN_SIMULATION cannot be ON if WITH_ROCKSDB_EXPERIMENTAL is OFF")
+  endif()
   target_link_libraries(fdbserver PRIVATE fdbclient metacluster sqlite)
 endif()
 

--- a/fdbserver/CMakeLists.txt
+++ b/fdbserver/CMakeLists.txt
@@ -7,7 +7,7 @@ else()
 endif()
 
 
-if(SSD_ROCKSDB_EXPERIMENTAL)
+if(WITH_ROCKSDB)
   include(CompileRocksDB)
   # CompileRocksDB sets `lz4_LIBRARIES` to be the shared lib, we want to link
   # statically, so find the static library here.
@@ -139,7 +139,7 @@ target_include_directories(fdbserver PRIVATE
   ${CMAKE_BINARY_DIR}/bindings/c
   ${CMAKE_CURRENT_SOURCE_DIR}/include
   ${CMAKE_CURRENT_BINARY_DIR}/include)
-if (SSD_ROCKSDB_EXPERIMENTAL)
+if (WITH_ROCKSDB)
   add_dependencies(fdbserver rocksdb)
   if(WITH_LIBURING)
     target_include_directories(fdbserver PRIVATE ${ROCKSDB_INCLUDE_DIR} ${uring_INCLUDE_DIR})
@@ -159,8 +159,8 @@ if(USE_JEMALLOC)
 endif()
 
 target_link_libraries(fdbserver PRIVATE toml11_target rapidjson)
-if(SSD_ROCKSDB_EXPERIMENTAL)
-  target_compile_definitions(fdbserver PRIVATE SSD_ROCKSDB_EXPERIMENTAL)
+if(WITH_ROCKSDB)
+  target_compile_definitions(fdbserver PRIVATE WITH_ROCKSDB)
 endif()
 
 if (WITH_SWIFT)

--- a/fdbserver/CMakeLists.txt
+++ b/fdbserver/CMakeLists.txt
@@ -7,8 +7,7 @@ else()
 endif()
 
 
-if(WITH_ROCKSDB_EXPERIMENTAL)
-  set(ENABLE_ROCKSDB_IN_SIMULATION ON CACHE BOOL "Enable RocksDB engine in simulation tests")
+if(SSD_ROCKSDB_EXPERIMENTAL)
   include(CompileRocksDB)
   # CompileRocksDB sets `lz4_LIBRARIES` to be the shared lib, we want to link
   # statically, so find the static library here.
@@ -17,8 +16,6 @@ if(WITH_ROCKSDB_EXPERIMENTAL)
   if(WITH_LIBURING)
     find_package(uring)
   endif()
-else()
-  set(ENABLE_ROCKSDB_IN_SIMULATION OFF CACHE BOOL "Enable RocksDB engine in simulation tests")
 endif()
 
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/workloads)
@@ -142,10 +139,7 @@ target_include_directories(fdbserver PRIVATE
   ${CMAKE_BINARY_DIR}/bindings/c
   ${CMAKE_CURRENT_SOURCE_DIR}/include
   ${CMAKE_CURRENT_BINARY_DIR}/include)
-if (WITH_ROCKSDB_EXPERIMENTAL)
-  if (ENABLE_ROCKSDB_IN_SIMULATION)
-	  target_compile_definitions(fdbserver PRIVATE SIMULATION_ROCKSDB_ENABLED=1)
-  endif()
+if (SSD_ROCKSDB_EXPERIMENTAL)
   add_dependencies(fdbserver rocksdb)
   if(WITH_LIBURING)
     target_include_directories(fdbserver PRIVATE ${ROCKSDB_INCLUDE_DIR} ${uring_INCLUDE_DIR})
@@ -156,9 +150,6 @@ if (WITH_ROCKSDB_EXPERIMENTAL)
     target_link_libraries(fdbserver PRIVATE fdbclient metacluster sqlite ${ROCKSDB_LIBRARIES} ${lz4_STATIC_LIBRARIES})
   endif()
 else()
-  if (ENABLE_ROCKSDB_IN_SIMULATION)
-    message(FATAL_ERROR "ENABLE_ROCKSDB_IN_SIMULATION cannot be ON if WITH_ROCKSDB_EXPERIMENTAL is OFF")
-  endif()
   target_link_libraries(fdbserver PRIVATE fdbclient metacluster sqlite)
 endif()
 
@@ -168,7 +159,7 @@ if(USE_JEMALLOC)
 endif()
 
 target_link_libraries(fdbserver PRIVATE toml11_target rapidjson)
-if(WITH_ROCKSDB_EXPERIMENTAL)
+if(SSD_ROCKSDB_EXPERIMENTAL)
   target_compile_definitions(fdbserver PRIVATE SSD_ROCKSDB_EXPERIMENTAL)
 endif()
 

--- a/fdbserver/KeyValueStoreRocksDB.actor.cpp
+++ b/fdbserver/KeyValueStoreRocksDB.actor.cpp
@@ -19,7 +19,7 @@
  */
 
 #include "fdbclient/FDBTypes.h"
-#ifdef SSD_ROCKSDB_EXPERIMENTAL
+#ifdef WITH_ROCKSDB
 
 #include <rocksdb/c.h>
 #include <rocksdb/cache.h>
@@ -61,7 +61,7 @@
 #include <tuple>
 #include <vector>
 
-#endif // SSD_ROCKSDB_EXPERIMENTAL
+#endif // WITH_ROCKSDB
 
 #include "fdbserver/Knobs.h"
 #include "fdbserver/IKeyValueStore.h"
@@ -69,7 +69,7 @@
 
 #include "flow/actorcompiler.h" // has to be last include
 
-#ifdef SSD_ROCKSDB_EXPERIMENTAL
+#ifdef WITH_ROCKSDB
 
 // Enforcing rocksdb version.
 static_assert((ROCKSDB_MAJOR == FDB_ROCKSDB_MAJOR && ROCKSDB_MINOR == FDB_ROCKSDB_MINOR &&
@@ -2538,23 +2538,23 @@ void RocksDBKeyValueStore::Writer::action(RestoreAction& a) {
 
 } // namespace
 
-#endif // SSD_ROCKSDB_EXPERIMENTAL
+#endif // WITH_ROCKSDB
 
 IKeyValueStore* keyValueStoreRocksDB(std::string const& path,
                                      UID logID,
                                      KeyValueStoreType storeType,
                                      bool checkChecksums,
                                      bool checkIntegrity) {
-#ifdef SSD_ROCKSDB_EXPERIMENTAL
+#ifdef WITH_ROCKSDB
 	return new RocksDBKeyValueStore(path, logID);
 #else
 	TraceEvent(SevError, "RocksDBEngineInitFailure", logID).detail("Reason", "Built without RocksDB");
 	ASSERT(false);
 	return nullptr;
-#endif // SSD_ROCKSDB_EXPERIMENTAL
+#endif // WITH_ROCKSDB
 }
 
-#ifdef SSD_ROCKSDB_EXPERIMENTAL
+#ifdef WITH_ROCKSDB
 #include "flow/UnitTest.h"
 
 namespace {
@@ -2790,4 +2790,4 @@ TEST_CASE("noSim/RocksDB/RangeClear") {
 }
 } // namespace
 
-#endif // SSD_ROCKSDB_EXPERIMENTAL
+#endif // WITH_ROCKSDB

--- a/fdbserver/KeyValueStoreShardedRocksDB.actor.cpp
+++ b/fdbserver/KeyValueStoreShardedRocksDB.actor.cpp
@@ -1,5 +1,5 @@
 #include "fdbclient/FDBTypes.h"
-#ifdef SSD_ROCKSDB_EXPERIMENTAL
+#ifdef WITH_ROCKSDB
 
 #include "fdbclient/KeyRangeMap.h"
 #include "fdbclient/SystemData.h"
@@ -39,14 +39,14 @@
 #include <tuple>
 #include <vector>
 
-#endif // SSD_ROCKSDB_EXPERIMENTAL
+#endif // WITH_ROCKSDB
 
 #include "fdbserver/Knobs.h"
 #include "fdbserver/IKeyValueStore.h"
 #include "fdbserver/RocksDBCheckpointUtils.actor.h"
 #include "flow/actorcompiler.h" // has to be last include
 
-#ifdef SSD_ROCKSDB_EXPERIMENTAL
+#ifdef WITH_ROCKSDB
 
 // Enforcing rocksdb version.
 static_assert((ROCKSDB_MAJOR == FDB_ROCKSDB_MAJOR && ROCKSDB_MINOR == FDB_ROCKSDB_MINOR &&
@@ -3703,23 +3703,23 @@ ACTOR Future<Void> testCheckpointRestore(IKeyValueStore* kvStore, std::vector<Ke
 }
 } // namespace
 
-#endif // SSD_ROCKSDB_EXPERIMENTAL
+#endif // WITH_ROCKSDB
 
 IKeyValueStore* keyValueStoreShardedRocksDB(std::string const& path,
                                             UID logID,
                                             KeyValueStoreType storeType,
                                             bool checkChecksums,
                                             bool checkIntegrity) {
-#ifdef SSD_ROCKSDB_EXPERIMENTAL
+#ifdef WITH_ROCKSDB
 	return new ShardedRocksDBKeyValueStore(path, logID);
 #else
 	TraceEvent(SevError, "ShardedRocksDBEngineInitFailure").detail("Reason", "Built without RocksDB");
 	ASSERT(false);
 	return nullptr;
-#endif // SSD_ROCKSDB_EXPERIMENTAL
+#endif // WITH_ROCKSDB
 }
 
-#ifdef SSD_ROCKSDB_EXPERIMENTAL
+#ifdef WITH_ROCKSDB
 #include "flow/UnitTest.h"
 
 namespace {
@@ -4553,4 +4553,4 @@ TEST_CASE("perf/ShardedRocksDB/RangeClearUserKey") {
 }
 } // namespace
 
-#endif // SSD_ROCKSDB_EXPERIMENTAL
+#endif // WITH_ROCKSDB

--- a/fdbserver/RocksDBCheckpointUtils.actor.cpp
+++ b/fdbserver/RocksDBCheckpointUtils.actor.cpp
@@ -20,7 +20,7 @@
 
 #include "fdbserver/RocksDBCheckpointUtils.actor.h"
 
-#ifdef SSD_ROCKSDB_EXPERIMENTAL
+#ifdef WITH_ROCKSDB
 #include <rocksdb/db.h>
 #include <rocksdb/env.h>
 #include <rocksdb/options.h>
@@ -29,7 +29,7 @@
 #include <rocksdb/sst_file_reader.h>
 #include <rocksdb/types.h>
 #include <rocksdb/version.h>
-#endif // SSD_ROCKSDB_EXPERIMENTAL
+#endif // WITH_ROCKSDB
 
 #include "fdbclient/FDBTypes.h"
 #include "fdbclient/NativeAPI.actor.h"
@@ -45,7 +45,7 @@
 
 #include "flow/actorcompiler.h" // has to be last include
 
-#ifdef SSD_ROCKSDB_EXPERIMENTAL
+#ifdef WITH_ROCKSDB
 
 // Enforcing rocksdb version.
 static_assert((ROCKSDB_MAJOR == FDB_ROCKSDB_MAJOR && ROCKSDB_MINOR == FDB_ROCKSDB_MINOR &&
@@ -1239,7 +1239,7 @@ ACTOR Future<Void> deleteRocksCheckpoint(CheckpointMetaData checkpoint) {
 	wait(delay(0));
 	return Void();
 }
-#endif // SSD_ROCKSDB_EXPERIMENTAL
+#endif // WITH_ROCKSDB
 
 int64_t getTotalFetchedBytes(const std::vector<CheckpointMetaData>& checkpoints) {
 	int64_t totalBytes = 0;
@@ -1268,29 +1268,29 @@ int64_t getTotalFetchedBytes(const std::vector<CheckpointMetaData>& checkpoints)
 ICheckpointReader* newRocksDBCheckpointReader(const CheckpointMetaData& checkpoint,
                                               const CheckpointAsKeyValues checkpointAsKeyValues,
                                               UID logId) {
-#ifdef SSD_ROCKSDB_EXPERIMENTAL
+#ifdef WITH_ROCKSDB
 	const CheckpointFormat format = checkpoint.getFormat();
 	if (format == DataMoveRocksCF && !checkpointAsKeyValues) {
 		return new RocksDBCFCheckpointReader(checkpoint, logId);
 	} else {
 		return new RocksDBColumnFamilyReader(checkpoint, logId);
 	}
-#endif // SSD_ROCKSDB_EXPERIMENTAL
+#endif // WITH_ROCKSDB
 	return nullptr;
 }
 
 std::unique_ptr<IRocksDBSstFileWriter> newRocksDBSstFileWriter() {
-#ifdef SSD_ROCKSDB_EXPERIMENTAL
+#ifdef WITH_ROCKSDB
 	std::unique_ptr<IRocksDBSstFileWriter> sstWriter = std::make_unique<RocksDBSstFileWriter>();
 	return sstWriter;
-#endif // SSD_ROCKSDB_EXPERIMENTAL
+#endif // WITH_ROCKSDB
 	return nullptr;
 }
 
 std::unique_ptr<ICheckpointByteSampleReader> newCheckpointByteSampleReader(const CheckpointMetaData& checkpoint) {
-#ifdef SSD_ROCKSDB_EXPERIMENTAL
+#ifdef WITH_ROCKSDB
 	return std::make_unique<RocksDBCheckpointByteSampleReader>(checkpoint);
-#endif // SSD_ROCKSDB_EXPERIMENTAL
+#endif // WITH_ROCKSDB
 	return nullptr;
 }
 

--- a/fdbserver/RocksDBLogForwarder.actor.cpp
+++ b/fdbserver/RocksDBLogForwarder.actor.cpp
@@ -18,7 +18,7 @@
  * limitations under the License.
  */
 
-#ifdef SSD_ROCKSDB_EXPERIMENTAL
+#ifdef WITH_ROCKSDB
 #include "fdbserver/RocksDBLogForwarder.h"
 
 #include "flow/network.h"
@@ -146,4 +146,4 @@ void RocksDBLogForwarder::Logv(const InfoLogLevel log_level, const char* format,
 	}
 }
 
-#endif // SSD_ROCKSDB_EXPERIMENTAL
+#endif // WITH_ROCKSDB

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -1803,7 +1803,7 @@ SimulationStorageEngine chooseSimulationStorageEngine(const TestConfig& testConf
 	}
 	TraceEvent(SevInfo, "SimulationStorageEngine")
 	    .detail("StorageEngine", static_cast<uint8_t>(result))
-		.detail("Reason", reason)
+	    .detail("Reason", reason)
 #ifdef SIMULATION_ROCKSDB_ENABLED
 	    .detail("RocksDBEngineChoosable", true)
 #else

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -369,8 +369,7 @@ class TestConfig : public BasicTestConfig {
 			if (attrib == "storageEngineExcludeTypes") {
 				std::stringstream ss(value);
 				for (int i; ss >> i;) {
-					ASSERT(static_cast<uint8_t>(i) <
-					       static_cast<uint8_t>(SimulationStorageEngine::SIMULATION_STORAGE_ENGINE_INVALID_VALUE));
+					ASSERT(isValidSimulationStorageEngineValue(i));
 					storageEngineExcludeTypes.insert(static_cast<SimulationStorageEngine>(i));
 					if (ss.peek() == ',') {
 						ss.ignore();
@@ -1821,6 +1820,7 @@ std::string getExcludedStorageEngineTypesInString(const std::set<SimulationStora
 SimulationStorageEngine chooseSimulationStorageEngine(const TestConfig& testConfig, const bool isEncryptionEnabled) {
 	StringRef reason;
 	SimulationStorageEngine result = SimulationStorageEngine::SIMULATION_STORAGE_ENGINE_INVALID_VALUE;
+
 	if (isEncryptionEnabled) {
 		// Only storage engine supporting encryption is Redwood.
 		reason = "EncryptionEnabled"_sr;
@@ -1841,16 +1841,13 @@ SimulationStorageEngine chooseSimulationStorageEngine(const TestConfig& testConf
 			UNREACHABLE();
 		}
 	}
+
 	TraceEvent(SevInfo, "SimulationStorageEngine")
 	    .detail("StorageEngine", static_cast<uint8_t>(result))
 	    .detail("Reason", reason)
 	    .detail("Excluded", getExcludedStorageEngineTypesInString(testConfig.storageEngineExcludeTypes))
-#ifdef WITH_ROCKSDB
-	    .detail("RocksDBEngineChoosable", true)
-#else
-	    .detail("RocksDBEngineChoosable", false)
-#endif
-	    ;
+	    .detail("RocksDBEngineChoosable", hasRocksDB);
+
 	return result;
 }
 

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -78,7 +78,7 @@ bool isSimulatorProcessUnreliable() {
 namespace {
 
 constexpr bool hasRocksDB =
-#ifdef SSD_ROCKSDB_EXPERIMENTAL
+#ifdef WITH_ROCKSDB
     true
 #else
     false
@@ -1803,7 +1803,7 @@ const std::unordered_map<SimulationStorageEngine, StorageEngineConfigFunc> STORA
 const std::vector<SimulationStorageEngine> SIMULATION_STORAGE_ENGINE = {
 	SimulationStorageEngine::SSD,        SimulationStorageEngine::MEMORY,
 	SimulationStorageEngine::RADIX_TREE, SimulationStorageEngine::REDWOOD,
-#ifdef SSD_ROCKSDB_EXPERIMENTAL
+#ifdef WITH_ROCKSDB
 	SimulationStorageEngine::ROCKSDB,    SimulationStorageEngine::SHARDED_ROCKSDB,
 #endif
 };
@@ -1845,7 +1845,7 @@ SimulationStorageEngine chooseSimulationStorageEngine(const TestConfig& testConf
 	    .detail("StorageEngine", static_cast<uint8_t>(result))
 	    .detail("Reason", reason)
 	    .detail("Excluded", getExcludedStorageEngineTypesInString(testConfig.storageEngineExcludeTypes))
-#ifdef SSD_ROCKSDB_EXPERIMENTAL
+#ifdef WITH_ROCKSDB
 	    .detail("RocksDBEngineChoosable", true)
 #else
 	    .detail("RocksDBEngineChoosable", false)

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -1793,6 +1793,7 @@ SimulationStorageEngine chooseSimulationStorageEngine(const TestConfig& testConf
 		for (auto _ = 0; _ < NUM_RETRIES; ++_) {
 			result = deterministicRandom()->randomChoice(SIMULATION_STORAGE_ENGINE);
 			if (!testConfig.excludedStorageEngineType(static_cast<uint8_t>(result))) {
+				reason = "RandomlyChosen"_sr;
 				break;
 			}
 		}

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -1832,7 +1832,7 @@ SimulationStorageEngine chooseSimulationStorageEngine(const TestConfig& testConf
 		constexpr auto NUM_RETRIES = 1000;
 		for (auto _ = 0; _ < NUM_RETRIES; ++_) {
 			result = deterministicRandom()->randomChoice(SIMULATION_STORAGE_ENGINE);
-			if (!testConfig.excludedStorageEngineType(static_cast<uint8_t>(result))) {
+			if (!testConfig.excludedStorageEngineType(result)) {
 				reason = "RandomlyChosen"_sr;
 				break;
 			}

--- a/fdbserver/include/fdbserver/RocksDBLogForwarder.h
+++ b/fdbserver/include/fdbserver/RocksDBLogForwarder.h
@@ -24,7 +24,7 @@
 #include <cstdarg>
 #include <thread>
 
-#ifdef SSD_ROCKSDB_EXPERIMENTAL
+#ifdef WITH_ROCKSDB
 #include <rocksdb/env.h>
 
 #include "flow/genericactors.actor.h"
@@ -95,6 +95,6 @@ public:
 	virtual void Logv(const rocksdb::InfoLogLevel log_level, const char* format, va_list ap);
 };
 
-#endif // SSD_ROCKSDB_EXPERIMENTAL
+#endif // WITH_ROCKSDB
 
 #endif // __ROCKSDB_LOG_FORWARDER_H__

--- a/fdbserver/include/fdbserver/SimulatedCluster.h
+++ b/fdbserver/include/fdbserver/SimulatedCluster.h
@@ -29,6 +29,17 @@ void setupAndRun(std::string const& dataFolder,
                  bool const& restoring,
                  std::string const& whitelistBinPath);
 
+enum class SimulationStorageEngine : uint8_t {
+	SSD = 0,
+	MEMORY = 1,
+	RADIX_TREE = 2,
+	REDWOOD = 3,
+	ROCKSDB = 4,
+	SHARDED_ROCKSDB = 5,
+	SIMULATION_STORAGE_ENGINE_INVALID_VALUE
+};
+
+
 class BasicTestConfig {
 public:
 	int minimumReplication = 0;
@@ -37,8 +48,9 @@ public:
 	bool simpleConfig = false;
 	// set to true to force a single region config
 	bool singleRegion = false;
-	Optional<int> desiredTLogCount, commitProxyCount, grvProxyCount, resolverCount, storageEngineType, machineCount,
+	Optional<int> desiredTLogCount, commitProxyCount, grvProxyCount, resolverCount, machineCount,
 	    coordinators;
+	Optional<SimulationStorageEngine> storageEngineType;
 	// ASAN uses more memory, so adding too many machines can cause OOMs. Tests can set this if they need to lower
 	// machineCount specifically for ASAN. Only has an effect if `machineCount` is set and this is an ASAN build.
 	Optional<int> asanMachineCount;

--- a/fdbserver/include/fdbserver/SimulatedCluster.h
+++ b/fdbserver/include/fdbserver/SimulatedCluster.h
@@ -39,7 +39,6 @@ enum class SimulationStorageEngine : uint8_t {
 	SIMULATION_STORAGE_ENGINE_INVALID_VALUE
 };
 
-
 class BasicTestConfig {
 public:
 	int minimumReplication = 0;
@@ -48,8 +47,7 @@ public:
 	bool simpleConfig = false;
 	// set to true to force a single region config
 	bool singleRegion = false;
-	Optional<int> desiredTLogCount, commitProxyCount, grvProxyCount, resolverCount, machineCount,
-	    coordinators;
+	Optional<int> desiredTLogCount, commitProxyCount, grvProxyCount, resolverCount, machineCount, coordinators;
 	Optional<SimulationStorageEngine> storageEngineType;
 	// ASAN uses more memory, so adding too many machines can cause OOMs. Tests can set this if they need to lower
 	// machineCount specifically for ASAN. Only has an effect if `machineCount` is set and this is an ASAN build.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -227,7 +227,7 @@ if(WITH_PYTHON)
   add_fdb_test(TEST_FILES fast/WriteDuringReadClean.toml)
   add_fdb_test(TEST_FILES noSim/RandomUnitTests.toml UNIT)
 
-  if(WITH_ROCKSDB_EXPERIMENTAL)
+  if(SSD_ROCKSDB_EXPERIMENTAL)
     add_fdb_test(TEST_FILES fast/ValidateStorage.toml)
     add_fdb_test(TEST_FILES noSim/KeyValueStoreRocksDBTest.toml UNIT)
     add_fdb_test(TEST_FILES noSim/ShardedRocksDBTest.toml UNIT)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -227,7 +227,7 @@ if(WITH_PYTHON)
   add_fdb_test(TEST_FILES fast/WriteDuringReadClean.toml)
   add_fdb_test(TEST_FILES noSim/RandomUnitTests.toml UNIT)
 
-  if(SSD_ROCKSDB_EXPERIMENTAL)
+  if(WITH_ROCKSDB)
     add_fdb_test(TEST_FILES fast/ValidateStorage.toml)
     add_fdb_test(TEST_FILES noSim/KeyValueStoreRocksDBTest.toml UNIT)
     add_fdb_test(TEST_FILES noSim/ShardedRocksDBTest.toml UNIT)


### PR DESCRIPTION
Previously we have to modify SimulatedCluster source code to enable/disable RocksDB storage engine in simulations. Now it is doable by using cmake flags/ccmake gui by setting the OPTION

    WITH_ROCKSDB

ON/OFF.

Replace this text with your description here...

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
