### PR TITLE
Fix the ConfigureCompiler.cmake 

### DIFF
--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -252,10 +252,6 @@ else()
     list(APPEND SANITIZER_LINK_OPTIONS $<${is_cxx_link}:-fsanitize=thread>)
   endif()
 
-  if(USE_VALGRIND)
-    list(APPEND SANITIZER_COMPILE_OPTIONS $<${is_cxx_compile}:-DBOOST_USE_VALGRIND})
-  endif()
-
   if(SANITIZER_COMPILE_OPTIONS)
     add_compile_options(${SANITIZER_COMPILE_OPTIONS})
   endif()


### PR DESCRIPTION
    1. The original lines are problematic -- <> are not paired.
    2. Fixing the original line by pairing <> would cause build failure if
       valgrind is turned on.
    3. git grep BOOST_USE_VALGRIND returned only one single usage, which is
       in the cmake file.
    4. Removing the lines caused build success.
    
# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
