### PR TITLE
Configure make_public.py to ignore comments in the cluster file

### DIFF
--- a/packaging/make_public.py
+++ b/packaging/make_public.py
@@ -66,6 +66,8 @@ def makePublic(clusterFile, newAddress, makeTLS):
     for line in f:
         line = line.strip()
         if len(line) > 0:
+            if line[0] == '#':
+                continue
             if clusterStr is not None:
                 invalidClusterFile(clusterFile)
                 return


### PR DESCRIPTION
Fixes #10700. (See that issue for a more detailed description of the problem.) `make_public.py` will fail if the cluster file contains comments, which is permitted per the [format](https://apple.github.io/foundationdb/administration.html#cluster-file-format).

Since this is a change to a Python file in the `packaging/` directory, and not the core FoundationDB application itself, I performed manual testing on the updated version of the file on a cluster I had running locally.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
