### PR TITLE
Fix panic when connecting to database from multiple threads in Go bindings

### DIFF
--- a/bindings/go/src/fdb/database.go
+++ b/bindings/go/src/fdb/database.go
@@ -65,7 +65,7 @@ type DatabaseOptions struct {
 func (d *Database) Close() {
 	// Remove database object from the cached databases
 	if d.isCached {
-		delete(openDatabases, d.clusterFile)
+		openDatabases.Delete(d.clusterFile)
 	}
 
 	// Destroy the database


### PR DESCRIPTION
Fix panic when connecting to database from multiple threads in Go bindings

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
