### PR TITLE
Add Tenant support for Go bindings

### DIFF
--- a/bindings/go/CMakeLists.txt
+++ b/bindings/go/CMakeLists.txt
@@ -1,3 +1,4 @@
+
 set(SRCS
   src/_stacktester/directory.go
   src/fdb/directory/allocator.go
@@ -19,6 +20,7 @@ set(SRCS
   src/fdb/tuple/tuple_test.go
   src/fdb/database.go
   src/fdb/directory/directorySubspace.go
+  src/fdb/tenant.go
   src/fdb/fdb_test.go
   src/fdb/snapshot.go)
 

--- a/bindings/go/src/fdb/database.go
+++ b/bindings/go/src/fdb/database.go
@@ -153,6 +153,22 @@ func retryable(wrapped func() (interface{}, error), onError func(Error) FutureNi
 	}
 }
 
+func transact(tr Transaction, f func(Transaction) (interface{}, error)) (interface{}, error) {
+	wrapped := func() (ret interface{}, e error) {
+		defer panicToError(&e)
+
+		ret, e = f(tr)
+
+		if e == nil {
+			e = tr.Commit().Get()
+		}
+
+		return
+	}
+
+	return retryable(wrapped, tr.OnError)
+}
+
 // Transact runs a caller-provided function inside a retry loop, providing it
 // with a newly created Transaction. After the function returns, the Transaction
 // will be committed automatically. Any error during execution of the function
@@ -182,6 +198,11 @@ func (d Database) Transact(f func(Transaction) (interface{}, error)) (interface{
 		return nil, e
 	}
 
+	return transact(tr, f)
+}
+
+
+func readTransact(tr Transaction, f func(ReadTransaction) (interface{}, error)) (interface{}, error) {
 	wrapped := func() (ret interface{}, e error) {
 		defer panicToError(&e)
 
@@ -225,19 +246,7 @@ func (d Database) ReadTransact(f func(ReadTransaction) (interface{}, error)) (in
 		return nil, e
 	}
 
-	wrapped := func() (ret interface{}, e error) {
-		defer panicToError(&e)
-
-		ret, e = f(tr)
-
-		if e == nil {
-			e = tr.Commit().Get()
-		}
-
-		return
-	}
-
-	return retryable(wrapped, tr.OnError)
+	return readTransact(tr, f)
 }
 
 // Options returns a DatabaseOptions instance suitable for setting options

--- a/bindings/go/src/fdb/errors.go
+++ b/bindings/go/src/fdb/errors.go
@@ -54,4 +54,8 @@ var (
 	errAPIVersionUnset        = Error{2200}
 	errAPIVersionAlreadySet   = Error{2201}
 	errAPIVersionNotSupported = Error{2203}
+
+	errTenantNotFound    = Error{2131}
+	errTenantExists      = Error{2132}
+	errTenantNameInvalid = Error{2134}
 )

--- a/bindings/go/src/fdb/fdb_test.go
+++ b/bindings/go/src/fdb/fdb_test.go
@@ -23,6 +23,7 @@
 package fdb_test
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"testing"
@@ -350,14 +351,14 @@ func ExampleOpenWithConnectionString() {
 
 	clusterFileContent, err := os.ReadFile(os.Getenv("FDB_CLUSTER_FILE"))
 	if err != nil {
-		fmt.Errorf("Unable to read cluster file: %v\n", err)
+		fmt.Printf("Unable to read cluster file: %v\n", err)
 		return
 	}
 
 	// OpenWithConnectionString opens the database described by the connection string
 	db, err := fdb.OpenWithConnectionString(string(clusterFileContent))
 	if err != nil {
-		fmt.Errorf("Unable to open database: %v\n", err)
+		fmt.Printf("Unable to open database: %v\n", err)
 		return
 	}
 
@@ -367,4 +368,186 @@ func ExampleOpenWithConnectionString() {
 	// Do work here
 
 	// Output:
+}
+
+// Copied from errors.go so that these types aren't public
+var (
+	errTenantNotFound    = fdb.Error{2131}
+	errTenantExists      = fdb.Error{2132}
+	errTenantNameInvalid = fdb.Error{2134}
+)
+
+func TestCreateTenant(t *testing.T) {
+	err := fdb.APIVersion(API_VERSION)
+	if err != nil {
+		t.Fatalf("Unable to set API version: %v\n", err)
+	}
+
+	// OpenDefault opens the database described by the platform-specific default
+	// cluster file
+	db, err := fdb.OpenDefault()
+	if err != nil {
+		t.Fatalf("Unable to set API version: %v\n", err)
+	}
+
+	var testTenantName = fdb.Key("test-create-tenant")
+
+	err = db.CreateTenant(testTenantName)
+	if err != nil {
+		t.Fatalf("Unable to create tenant: %v\n", err)
+	}
+
+	_, err = db.OpenTenant(testTenantName)
+	if err != nil {
+		t.Fatalf("Unable to open tenant: %v\n", err)
+	}
+}
+
+func TestCreateExistTenant(t *testing.T) {
+	err := fdb.APIVersion(API_VERSION)
+	if err != nil {
+		t.Fatalf("Unable to set API version: %v\n", err)
+	}
+
+	// OpenDefault opens the database described by the platform-specific default
+	// cluster file
+	db, err := fdb.OpenDefault()
+	if err != nil {
+		t.Fatalf("Unable to set API version: %v\n", err)
+	}
+
+	var testTenantName = fdb.Key("test-exist-tenant")
+
+	err = db.CreateTenant(testTenantName)
+	if err != nil {
+		t.Fatalf("Unable to create tenant: %v\n", err)
+	}
+
+	// This should fail
+	err = db.CreateTenant(testTenantName)
+	assertErrorCodeEqual(t, err, errTenantExists)
+}
+
+func TestOpenNotExistTenant(t *testing.T) {
+	err := fdb.APIVersion(API_VERSION)
+	if err != nil {
+		t.Fatalf("Unable to set API version: %v\n", err)
+	}
+
+	// OpenDefault opens the database described by the platform-specific default
+	// cluster file
+	db, err := fdb.OpenDefault()
+	if err != nil {
+		t.Fatalf("Unable to set API version: %v\n", err)
+	}
+
+	var testTenantName = fdb.Key("test-not-exist-tenant")
+
+	// this should fail
+	_, err = db.OpenTenant(testTenantName)
+	assertErrorCodeEqual(t, err, errTenantNotFound)
+}
+
+func TestDeleteNotExistTenant(t *testing.T) {
+	err := fdb.APIVersion(API_VERSION)
+	if err != nil {
+		t.Fatalf("Unable to set API version: %v\n", err)
+	}
+
+	// OpenDefault opens the database described by the platform-specific default
+	// cluster file
+	db, err := fdb.OpenDefault()
+	if err != nil {
+		t.Fatalf("Unable to set API version: %v\n", err)
+	}
+
+	var testTenantName = fdb.Key("test-not-exist-tenant")
+
+	// this should fail
+	err = db.DeleteTenant(testTenantName)
+	assertErrorCodeEqual(t, err, errTenantNotFound)
+}
+
+func inSlice(sl []fdb.Key, t fdb.Key) bool {
+	for _, s := range sl {
+		if bytes.Equal(s, t) {
+			return true
+		}
+	}
+	return false
+}
+
+func assertErrorCodeEqual(t *testing.T, actual error, expected fdb.Error) {
+	if actual == nil {
+		t.Fatalf("Error is nil when it should be: %v\n", expected.Code)
+	}
+
+	castErr, ok := actual.(fdb.Error)
+	if !ok {
+		t.Fatalf("Error is wrong type %v, expected %v\n", actual, expected)
+	}
+
+	if castErr.Code != expected.Code {
+		t.Fatalf("Error is wrong code, expected %v, actual %v\n", expected.Code, castErr.Code)
+	}
+}
+
+func TestListTenant(t *testing.T) {
+	err := fdb.APIVersion(API_VERSION)
+	if err != nil {
+		t.Fatalf("Unable to set API version: %v\n", err)
+	}
+
+	// OpenDefault opens the database described by the platform-specific default
+	// cluster file
+	db, err := fdb.OpenDefault()
+	if err != nil {
+		t.Fatalf("Unable to set API version: %v\n", err)
+	}
+
+	var testTenantName1 = fdb.Key("1-test-list-1-tenant-1")
+	var testTenantName2 = fdb.Key("2-test-list-2-tenant-2")
+
+	err = db.CreateTenant(testTenantName1)
+	if err != nil {
+		t.Fatalf("Unable to create tenant 1: %v\n", err)
+	}
+
+	err = db.CreateTenant(testTenantName2)
+	if err != nil {
+		t.Fatalf("Unable to create tenant 2: %v\n", err)
+	}
+
+	ls, err := db.ListTenants()
+	if err != nil {
+		t.Fatalf("Unable to list tenants: %v\n", err)
+	}
+
+	if !inSlice(ls, testTenantName1) {
+		t.Fatalf("tenant 1 not in slice %#v", ls)
+	}
+
+	if !inSlice(ls, testTenantName2) {
+		t.Fatalf("tenant 2 not in slice, %#v", ls)
+	}
+}
+
+func TestInvalidPrefixTenant(t *testing.T) {
+	err := fdb.APIVersion(API_VERSION)
+	if err != nil {
+		t.Fatalf("Unable to set API version: %v\n", err)
+	}
+
+	// OpenDefault opens the database described by the platform-specific default
+	// cluster file
+	db, err := fdb.OpenDefault()
+	if err != nil {
+		t.Fatalf("Unable to set API version: %v\n", err)
+	}
+
+	var testTenantName = fdb.Key("\xFFtest-invalid-prefix-tenant")
+
+	// this should fail
+	err = db.CreateTenant(testTenantName)
+	assertErrorCodeEqual(t, err, errTenantNameInvalid)
 }

--- a/bindings/go/src/fdb/tenant.go
+++ b/bindings/go/src/fdb/tenant.go
@@ -1,0 +1,256 @@
+/*
+ * tenant.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// FoundationDB Go API
+
+package fdb
+
+// #define FDB_API_VERSION 720
+// #include <foundationdb/fdb_c.h>
+// #include <stdlib.h>
+import "C"
+
+import (
+	"runtime"
+)
+
+// CreateTenant creates a new tenant in the cluster. The tenant name cannot
+// start with the \xff byte.
+func (t Transaction) CreateTenant(name KeyConvertible) error {
+	tenantName := name.FDBKey()
+	if len(tenantName) > 0 && tenantName[0] == '\xFF' {
+		return errTenantNameInvalid
+	}
+
+	if err := t.Options().SetSpecialKeySpaceEnableWrites(); err != nil {
+		return err
+	}
+
+	key := append(Key("\xFF\xFF/management/tenant/map/"), tenantName...)
+
+	exist, err := t.checkTenantExist(key)
+	if err != nil {
+		return err
+	}
+	if exist {
+		return errTenantExists
+	}
+
+	t.Set(key, nil)
+
+	return nil
+}
+
+// CreateTenant creates a new tenant in the cluster. The tenant name cannot
+// start with the \xff byte.
+func (d Database) CreateTenant(name KeyConvertible) error {
+	_, err := d.Transact(func(t Transaction) (interface{}, error) {
+		return nil, t.CreateTenant(name)
+	})
+	return err
+}
+
+// DeleteTenant deletes an existing tenant in the cluster.
+func (t Transaction) DeleteTenant(name KeyConvertible) error {
+	if err := t.Options().SetSpecialKeySpaceEnableWrites(); err != nil {
+		return err
+	}
+
+	key := append(Key("\xFF\xFF/management/tenant/map/"), name.FDBKey()...)
+
+	exist, err := t.checkTenantExist(key)
+	if err != nil {
+		return err
+	}
+	if !exist {
+		return errTenantNotFound
+	}
+
+	t.Clear(key)
+
+	return nil
+}
+
+// DeleteTenant creates a new tenant in the cluster. The tenant name cannot
+// start with the \xff byte.
+func (d Database) DeleteTenant(name KeyConvertible) error {
+	_, err := d.Transact(func(t Transaction) (interface{}, error) {
+		return nil, t.DeleteTenant(name)
+	})
+	return err
+}
+
+// ListTenants lists all existings tenants in the cluster.
+func (t Transaction) ListTenants() ([]Key, error) {
+	if err := t.Options().SetSpecialKeySpaceEnableWrites(); err != nil {
+		return nil, err
+	}
+
+	kr, err := PrefixRange(Key("\xFF\xFF/management/tenant/map/"))
+	if err != nil {
+		return nil, err
+	}
+
+	rawTenants, err := t.GetRange(kr, RangeOptions{}).GetSliceWithError()
+	if err != nil {
+		return nil, err
+	}
+
+	// trim tenant prefix
+	tenants := make([]Key, len(rawTenants))
+	for i, rt := range rawTenants {
+		tenants[i] = rt.Key[25:] // len of tenant prefix
+	}
+
+	return tenants, nil
+}
+
+// CreateTenant creates a new tenant in the cluster. The tenant name cannot
+// start with the \xff byte.
+func (d Database) ListTenants() ([]Key, error) {
+	tenants, err := d.Transact(func(t Transaction) (interface{}, error) {
+		return t.ListTenants()
+	})
+	return tenants.([]Key), err
+}
+
+func (t Transaction) checkTenantExist(tenantPath Key) (bool, error) {
+	buf, err := t.Get(tenantPath).Get()
+	if err != nil {
+		return true, err
+	}
+
+	return buf != nil, nil
+}
+
+// Tenant is a handle to a FoundationDB tenant. Tenant is a lightweight
+// object that may be efficiently copied, and is safe for concurrent use by
+// multiple goroutines.
+type Tenant struct {
+	*tenant
+
+	db Database
+}
+
+type tenant struct {
+	ptr *C.FDBTenant
+}
+
+// OpenTenant returns a tenant handle identified by the given name. All transactions
+// created by this tenant will operate on the tenant’s key-space.
+func (d Database) OpenTenant(name KeyConvertible) (Tenant, error) {
+	var outt *C.FDBTenant
+	if err := C.fdb_database_open_tenant(d.database.ptr, byteSliceToPtr(name.FDBKey()), C.int(len(name.FDBKey())), &outt); err != 0 {
+		return Tenant{}, Error{int(err)}
+	}
+
+	tnt := &tenant{outt}
+	runtime.SetFinalizer(tnt, (*tenant).destroy)
+
+	return Tenant{tnt, d}, nil
+}
+
+func (t *tenant) destroy() {
+	if t.ptr == nil {
+		return
+	}
+
+	C.fdb_tenant_destroy(t.ptr)
+}
+
+// CreateTransaction returns a new FoundationDB transaction. It is generally
+// preferable to use the (Tenant).Transact method, which handles
+// automatically creating and committing a transaction with appropriate retry
+// behavior.
+func (t Tenant) CreateTransaction() (Transaction, error) {
+	var outt *C.FDBTransaction
+
+	if err := C.fdb_tenant_create_transaction(t.ptr, &outt); err != 0 {
+		return Transaction{}, Error{int(err)}
+	}
+
+	trx := &transaction{outt, t.db}
+	runtime.SetFinalizer(trx, (*transaction).destroy)
+
+	return Transaction{trx}, nil
+}
+
+// Transact runs a caller-provided function inside a retry loop, providing it
+// with a newly created Transaction. After the function returns, the Transaction
+// will be committed automatically. Any error during execution of the function
+// (by panic or return) or the commit will cause the function and commit to be
+// retried or, if fatal, return the error to the caller.
+//
+// When working with Future objects in a transactional function, you may either
+// explicitly check and return error values using Get, or call MustGet. Transact
+// will recover a panicked Error and either retry the transaction or return the
+// error.
+//
+// The transaction is retried if the error is or wraps a retryable Error.
+// The error is unwrapped.
+//
+// Do not return Future objects from the function provided to Transact. The
+// Transaction created by Transact may be finalized at any point after Transact
+// returns, resulting in the cancellation of any outstanding
+// reads. Additionally, any errors returned or panicked by the Future will no
+// longer be able to trigger a retry of the caller-provided function.
+//
+// See the Transactor interface for an example of using Transact with
+// Transaction and Database objects.
+func (t Tenant) Transact(f func(Transaction) (interface{}, error)) (interface{}, error) {
+	tr, e := t.CreateTransaction()
+	// Any error here is non-retryable
+	if e != nil {
+		return nil, e
+	}
+
+	return transact(tr, f)
+}
+
+// ReadTransact runs a caller-provided function inside a retry loop, providing
+// it with a newly created Transaction (as a ReadTransaction). Any error during
+// execution of the function (by panic or return) will cause the function to be
+// retried or, if fatal, return the error to the caller.
+//
+// When working with Future objects in a read-only transactional function, you
+// may either explicitly check and return error values using Get, or call
+// MustGet. ReadTransact will recover a panicked Error and either retry the
+// transaction or return the error.
+//
+// The transaction is retried if the error is or wraps a retryable Error.
+// The error is unwrapped.
+//
+// Do not return Future objects from the function provided to ReadTransact. The
+// Transaction created by ReadTransact may be finalized at any point after
+// ReadTransact returns, resulting in the cancellation of any outstanding
+// reads. Additionally, any errors returned or panicked by the Future will no
+// longer be able to trigger a retry of the caller-provided function.
+//
+// See the ReadTransactor interface for an example of using ReadTransact with
+// Transaction, Snapshot and Database objects.
+func (t Tenant) ReadTransact(f func(ReadTransaction) (interface{}, error)) (interface{}, error) {
+	tr, e := t.CreateTransaction()
+	// Any error here is non-retryable
+	if e != nil {
+		return nil, e
+	}
+
+	return readTransact(tr, f)
+}


### PR DESCRIPTION
Add [Tenant](https://apple.github.io/foundationdb/tenants.html) support for Go bindings. I've attempted to follow the same logic as the [Python implementation](https://github.com/apple/foundationdb/blob/main/bindings/python/fdb/tenant_management.py).

A couple questions for the reviewer:
* Should I check for the /xFF [prefix restriction 2](https://apple.github.io/foundationdb/tenants.html?highlight=tenant#:~:text=Tenants%20can%20be%20created%20with%20any%20byte%2Dstring%20name%20that%20does%20not%20begin%20with%20the%20%5Cxff%20character.%20Once%20created%2C%20a%20tenant%20will%20be%20assigned%20an%20ID%20and%20a%20prefix%20where%20its%20data%20will%20reside.) in the bindings, I don’t see such a check in the Python bindings, but I’ve added such a check for Go
* I seem to be able to open a tenant even if it doesn’t exist.

Supersedes: https://github.com/apple/foundationdb/pull/10703

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
