### PR TITLE
Implement Event using std::latch from c++20

### DIFF
--- a/flow/include/flow/ThreadPrimitives.h
+++ b/flow/include/flow/ThreadPrimitives.h
@@ -24,6 +24,7 @@
 
 #include <atomic>
 #include <array>
+#include <latch>
 
 #include "flow/Error.h"
 #include "flow/Trace.h"
@@ -134,16 +135,7 @@ public:
 	void block();
 
 private:
-#ifdef _WIN32
-	void* ev;
-#elif defined(__linux__) || defined(__FreeBSD__)
-	sem_t sem;
-#elif defined(__APPLE__)
-	mach_port_t self;
-	semaphore_t sem;
-#else
-#error Port me!
-#endif
+	std::latch latch{ 1 };
 };
 
 class Mutex {


### PR DESCRIPTION
I have a benchmark using [nanobench](https://nanobench.ankerl.com/reference.html) that measures the time it takes to round-trip reading from the ryw cache from libfdb_c. It looks like the following:


```
  fdb_transaction_clear_range(tr, (const uint8_t*)"", 0, (const uint8_t*)"\xff", 1);

  bench.run("ryw read", [&]() {
    FDBFuture* f = fdb_transaction_get(tr, (const uint8_t*)"", 0, 0);
    checkError(fdb_future_block_until_ready(f));
    fdb_future_destroy(f);
  });
```

Before this change:
|               ns/op |                op/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|           32,281.52 |           30,977.47 |    0.5% |      0.39 | `ryw read`

After this change:
|               ns/op |                op/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|           27,115.25 |           36,879.61 |    0.6% |      0.33 | `ryw read`

Using a 2020 m1 mac mini

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
