### PR TITLE
EaR: turn down the probability of enabling encryption in simulation

### DIFF
--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -1706,7 +1706,10 @@ void SimulationConfig::setEncryptionAtRestMode(const TestConfig& testConfig) {
 		// If encryptModes are not specified, give encryption higher chance to be enabled.
 		// The good thing is testing with encryption on doesn't loss test coverage for most of the other features.
 		available = std::vector<bool>(EncryptionAtRestMode::END, true);
-		probability = { 0.25, 0.5, 0.25 };
+		// Enabling encryption require the use of Redwood storage engine, but we don't want to test with Redwood with
+		// high probability in simulation. Setting total probability of encryption being enabled to be close to 1/6,
+		// since we have 6 storage engine type currently.
+		probability = { 0.85, 0.1, 0.05 };
 		// Only Redwood support encryption. Disable encryption if Redwood is not available.
 		if ((testConfig.storageEngineType.present() &&
 		     testConfig.storageEngineType != SimulationStorageEngine::REDWOOD) ||
@@ -1821,11 +1824,7 @@ SimulationStorageEngine chooseSimulationStorageEngine(const TestConfig& testConf
 	StringRef reason;
 	SimulationStorageEngine result = SimulationStorageEngine::SIMULATION_STORAGE_ENGINE_INVALID_VALUE;
 
-	if (isEncryptionEnabled) {
-		// Only storage engine supporting encryption is Redwood.
-		reason = "EncryptionEnabled"_sr;
-		result = SimulationStorageEngine::REDWOOD;
-	} else if (testConfig.storageEngineType.present()) {
+	if (testConfig.storageEngineType.present()) {
 		reason = "ConfigureSpecified"_sr;
 		result = testConfig.storageEngineType.get();
 	} else {
@@ -1840,6 +1839,12 @@ SimulationStorageEngine chooseSimulationStorageEngine(const TestConfig& testConf
 		if (result == SimulationStorageEngine::SIMULATION_STORAGE_ENGINE_INVALID_VALUE) {
 			UNREACHABLE();
 		}
+	}
+
+	if (isEncryptionEnabled) {
+		// Only storage engine supporting encryption is Redwood.
+		reason = "EncryptionEnabled"_sr;
+		result = SimulationStorageEngine::REDWOOD;
 	}
 
 	TraceEvent(SevInfo, "SimulationStorageEngine")


### PR DESCRIPTION
Enabling encryption in simulation forces the use of Redwood, which is the only storage engine type supporting encryption currently. We want to turn down the probability of testing Redwood in simulation, and so we need to turn the probability for encryption as well.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
