### PR TITLE
Shadow Cxx flags for Boost build

### DIFF
--- a/cmake/CompileBoost.cmake
+++ b/cmake/CompileBoost.cmake
@@ -52,6 +52,15 @@ function(compile_boost)
   foreach(flag IN LISTS BOOST_LINK_FLAGS COMPILE_BOOST_LDFLAGS)
     string(APPEND BOOST_ADDITIONAL_COMPILE_OPTIONS "<linkflags>${flag} ")
   endforeach()
+
+  # CMake can't expand generator expressions without a target to model against.
+  # Create a fake C++ target here and use `file(GENERATE ...)` to expand the
+  # flags appropriately for the boost build system and emit this file instead of
+  # configure_file.
+  # TODO: CMake runs into a memory corruption bug while trying to expand
+  #       generated files with the `file(GENERATE TARGET ...)` API. Once that is
+  #       fixed, we can drop the boost-options lists to reduce maintenance
+  #       burden.
   configure_file(${CMAKE_SOURCE_DIR}/cmake/user-config.jam.cmake ${CMAKE_BINARY_DIR}/user-config.jam)
   set(USER_CONFIG_FLAG --user-config=${CMAKE_BINARY_DIR}/user-config.jam)
 
@@ -114,10 +123,10 @@ if(USE_SANITIZER)
   message(STATUS "A sanitizer is enabled, need to build boost from source")
   if (USE_VALGRIND)
     compile_boost(TARGET boost_target BUILD_ARGS valgrind=on
-      CXXFLAGS ${SANITIZER_COMPILE_OPTIONS} LDFLAGS ${SANITIZER_LINK_OPTIONS})
+      CXXFLAGS ${BOOST_CXX_OPTIONS} LDFLAGS ${BOOST_LINK_OPTIONS})
   else()
     compile_boost(TARGET boost_target BUILD_ARGS context-impl=ucontext
-      CXXFLAGS ${SANITIZER_COMPILE_OPTIONS} LDFLAGS ${SANITIZER_LINK_OPTIONS})
+      CXXFLAGS ${BOOST_COMPILE_OPTIONS} LDFLAGS ${BOOST_LINK_OPTIONS})
   endif()
   return()
 endif()

--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -207,6 +207,8 @@ else()
   if(TRACE_PC_GUARD_INSTRUMENTATION_LIB)
       add_compile_options($<${is_cxx_compile}:-fsanitize-coverage=trace-pc-guard>)
       link_libraries("$<${is_cxx_link}:${TRACE_PC_GUARD_INSTRUMENTATION_LIB}>")
+      list(APPEND BOOST_CXX_OPTIONS -fsanitize-coverage=trace-pc-guard)
+      list(APPEND BOOST_LINK_OPTIONS ${TRACE_PC_GUARD_INSTRUMENTATION_LIB})
   endif()
   if(USE_ASAN)
     list(APPEND SANITIZER_COMPILE_OPTIONS
@@ -215,6 +217,14 @@ else()
       -DBOOST_USE_ASAN
       -DBOOST_USE_UCONTEXT)
     list(APPEND SANITIZER_LINK_OPTIONS -fsanitize=address)
+
+    list(APPEND BOOST_CXX_OPTIONS
+      -fsanitize=address
+      -DADDRESS_SANITIZER
+      -DBOOST_USE_ASAN
+      -DBOOST_USE_UCONTEXT
+    )
+    list(APPEND BOOST_LINK_OPTIONS -fsanitize=address)
   endif()
 
   if(USE_MSAN)
@@ -226,11 +236,20 @@ else()
       -fsanitize-memory-track-origins=2
       -DBOOST_USE_UCONTEXT)
     list(APPEND SANITIZER_LINK_OPTIONS -fsanitize=memory)
+    list(APPEND BOOST_CXX_OPTIONS
+      -fsanitize=memory
+      -fsanitize-memory-track-origins=2
+      -DBOOST_USE_UCONTEXT
+    )
+    list(APPEND BOOST_LINK_OPTIONS -fsanitize=memory)
   endif()
 
   if(USE_GCOV)
     add_compile_options($<${is_cxx_compile}:--coverage>)
     add_link_options($<${is_cxx_link}:--coverage>)
+
+    list(APPEND BOOST_CXX_OPTIONS --coverage)
+    list(APPEND BOOST_LINK_OPTIONS --coverage)
   endif()
 
   if(USE_UBSAN)
@@ -242,6 +261,16 @@ else()
       $<${is_cxx_compile}:-fno-sanitize=function>
       $<${is_cxx_compile}:-DBOOST_USE_UCONTEXT>)
     list(APPEND SANITIZER_LINK_OPTIONS $<${is_cxx_link}:-fsanitize=undefined>)
+
+    list(APPEND BOOST_COMPILER_FLAGS
+      -fsanitize=undefined
+      # TODO(atn34) Re-enable -fsanitize=alignment once https://github.com/apple/foundationdb/issues/1434 is resolved
+      -fno-sanitize=alignment
+      # https://github.com/apple/foundationdb/issues/7955
+      -fno-sanitize=function
+      -DBOOST_USE_UCONTEXT
+    )
+    list(APPEND BOOST_LINK_OPTIONS -fsanitize=undefined)
   endif()
 
   if(USE_TSAN)
@@ -250,6 +279,12 @@ else()
       $<${is_cxx_compile}:-DBOOST_USE_UCONTEXT>
     )
     list(APPEND SANITIZER_LINK_OPTIONS $<${is_cxx_link}:-fsanitize=thread>)
+
+    list(APPEND BOOST_CXX_OPTIONS
+      -fsanitize=thread
+      -DBOOST_USE_UCONTEXT
+    )
+    list(APPEND BOOST_LINK_OPTIONS -fsanitize=thread)
   endif()
 
   if(SANITIZER_COMPILE_OPTIONS)


### PR DESCRIPTION
Creating a shadow copy of the C++ and linker flags for the boost build because configure_file cannot expand generator expressions. `file(GENERATE...` can in theory, but CMake runs into memory corruption when it tries.

The generator expressions are used to filter out flags that are intended for the C/C++ compiler from going to the Swift compiler when building with Swift enabled, which doesn't understand them. The boost build system isn't integrated with CMake so flags are passed via a call to `configure_file` which generates are configuration, and CMake needs a target to expand target-generator-expressions agains, like `LINK_LANGUAGE`, for instance. Thus, generator expressions are not being expanded and the flags include the full generator expression, which b2 doesn't know how to deal with (`$<$<LINK_LANGUAGE:CXX>:-fsanitize=undefined>`).

We should be able to do something like this in the future, which will create a fake target (or we can point it at an existing C++ target instead of creating an empty C++ target) so that CMake can expand the generator expressions and give us a reasonable file;

```cmake
file(GENERATE CONTENT OUTPUT "${CMAKE_BINARY_DIR}/fake.cpp" "int foo() { return 0; }" )
add_target(fake_cpp_target "${CMAKE_BINARY_DIR}/fake.cpp")
file(GENERATE
     TARGET fake_cpp_target
     OUTPUT "${CMAKE_BINARY_DIR}/user-config.jam"
     CONTENT "using ${BOOST_TOOLSET} : : ${BOOST_CXX_COMPILER} : ${BOOST_ADDITIONAL_COMPILE_OPTIONS} ;
using zstd : 1.5.2 : <include>/${CMAKE_BINARY_DIR}/zstd/lib <search>/${CMAKE_BINARY_DIR}/lib ;"
)
```

Unfortunately, this is exposing a memory corruption bug in CMake, so that doesn't work.

Instead, I've gone with creating a shadow flag list that doesn't have the generator expressions, and then passing that into the boost compile. This has additional maintenance burden to keep the flags consistent across both lists, but should enable building boost with sanitizers enabled without breaking the Swift build.

To test, I ran CMake on FDB in the `foundationdb/devel:centos7-latest` container and checked that the contents of `user-config.jam` make sense;

```
using clang : : /usr/local/bin/clang++ : <cxxflags>-fvisibility=hidden <cxxflags>-fPIC <cxxflags>-std=c++17 <cxxflags>-w <cxxflags>-stdlib=libc++ <cxxflags>-nostdlib++ <linkflags>-lc++ <linkflags>-lc++abi <linkflags>-static-libgcc <linkflags>-fsanitize=undefined  ;
using zstd : 1.5.2 : <include>//source/build/zstd/lib <search>//source/build/lib ;
```

This case has UBSan enabled. Also looked at TSan. 

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
