### PR TITLE
Tenant watch fix

### DIFF
--- a/fdbserver/BlobManager.actor.cpp
+++ b/fdbserver/BlobManager.actor.cpp
@@ -1327,7 +1327,7 @@ ACTOR Future<Void> monitorTenants(Reference<BlobManagerData> bmData) {
 				tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 				wait(loadTenantMap(tr, bmData));
 
-				state Future<Void> watchChange = tr->watch(TenantMetadata::lastTenantId().key);
+				state Future<Void> watchChange = TenantMetadata::lastTenantModification().watch(tr);
 				wait(tr->commit());
 				wait(watchChange);
 				tr->reset();

--- a/fdbserver/BlobManifest.actor.cpp
+++ b/fdbserver/BlobManifest.actor.cpp
@@ -847,7 +847,8 @@ private:
 					// A special key to be loaded at the end:
 					// Blob worker monitors lastTenantId to refresh tenant map. If we load it before
 					// rest of other part of tenant metadata, Blob worker may get partial tenant map. So delay it.
-					if (rows[i].key == TenantMetadata::lastTenantId().key) {
+					if (rows[i].key == TenantMetadata::lastTenantId().key ||
+					    rows[i].key == TenantMetadata::lastTenantModification().key) {
 						self->delayedRows_.push_back_deep(self->delayedRows_.arena(), rows[i]);
 					} else {
 						tr.set(rows[i].key, rows[i].value);

--- a/fdbserver/BlobWorker.actor.cpp
+++ b/fdbserver/BlobWorker.actor.cpp
@@ -5075,7 +5075,7 @@ ACTOR Future<Void> monitorTenants(Reference<BlobWorkerData> bwData) {
 				}
 				bwData->tenantData.addTenants(tenants);
 
-				state Future<Void> watchChange = tr->watch(TenantMetadata::lastTenantId().key);
+				state Future<Void> watchChange = TenantMetadata::lastTenantModification().watch(tr);
 				wait(tr->commit());
 				bwData->addGRVHistory(tr->getReadVersion().get());
 				wait(watchChange);


### PR DESCRIPTION
Potential bug fix stuck blob manager, and just correct anyway even if it's not the cause of the fix.

after blob restore fix:
50k BlobRestoreTenant* test - 20230807-175903-jslocum-c097c3b0452c579e  
100k normal correctness - 20230807-180154-jslocum-c097c3b0452c579e

previous tests:

100k BlobGranuleCorrectness* with additional testing - 20230807-163755-jslocum-38ac1be71766caa0
100k normal correctness -  20230807-170707-jslocum-3330220ee725f5c0  - found issue with blob restore

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
