### PR TITLE
Bring Boost Valgrind flags back

### DIFF
--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -287,6 +287,12 @@ else()
     list(APPEND BOOST_LINK_OPTIONS -fsanitize=thread)
   endif()
 
+  if(USE_VALGRIND)
+    list(APPEND SANITIZER_COMPILE_OPTIONS $<${is_cxx_compile}:-DBOOST_USE_VALGRIND>)
+
+    list(APPEND BOOST_CXX_OPTIONS -DBOOST_USE_VALGRIND)
+  endif()
+
   if(SANITIZER_COMPILE_OPTIONS)
     add_compile_options(${SANITIZER_COMPILE_OPTIONS})
   endif()


### PR DESCRIPTION
The issue caused Boost build failure is found and fixed at #10733. Here the flag BOOST_USE_VALGRIND is reintroduced back.

Replace this text with your description here...

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
