### PR TITLE
Bg tenant lock (Cherry-Pick #10746 to snowflake/release-71.3)

### DIFF
--- a/fdbclient/ClientKnobs.cpp
+++ b/fdbclient/ClientKnobs.cpp
@@ -295,6 +295,7 @@ void ClientKnobs::initialize(Randomize randomize) {
 	init( BLOB_METADATA_REFRESH_INTERVAL,          3600 ); if ( randomize && BUGGIFY ) { BLOB_METADATA_REFRESH_INTERVAL = deterministicRandom()->randomInt(5, 120); }
 	init( DETERMINISTIC_BLOB_METADATA,            false ); if( randomize && BUGGIFY_WITH_PROB(0.01) ) DETERMINISTIC_BLOB_METADATA = true;
 	init( ENABLE_BLOB_GRANULE_FILE_LOGICAL_SIZE,  false ); if ( randomize && BUGGIFY ) { ENABLE_BLOB_GRANULE_FILE_LOGICAL_SIZE = true; }
+	init( HYBRID_MANAGEMENT_BYPASS_TENANT_LOCK,   false );
 
 	init( CHANGE_QUORUM_BAD_STATE_RETRY_TIMES,        3 );
 	init( CHANGE_QUORUM_BAD_STATE_RETRY_DELAY,      2.0 );

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -11245,6 +11245,9 @@ ACTOR Future<TenantMode> getOrWaitForTenantMode(Database cx) {
 }
 
 ACTOR Future<Void> checkTenantLock(Transaction* tr, Optional<Reference<Tenant>> tenant, KeyRange keyRange) {
+	if (CLIENT_KNOBS->HYBRID_MANAGEMENT_BYPASS_TENANT_LOCK) {
+		return Void();
+	}
 	state int64_t tenantId;
 	if (tenant.present()) {
 		// if tenant present, explicitly get id

--- a/fdbclient/include/fdbclient/ClientKnobs.h
+++ b/fdbclient/include/fdbclient/ClientKnobs.h
@@ -286,6 +286,7 @@ public:
 	int64_t BLOB_METADATA_REFRESH_INTERVAL;
 	bool DETERMINISTIC_BLOB_METADATA;
 	bool ENABLE_BLOB_GRANULE_FILE_LOGICAL_SIZE;
+	bool HYBRID_MANAGEMENT_BYPASS_TENANT_LOCK;
 
 	// The coordinator key/value in storage server might be inconsistent to the value stored in the cluster file.
 	// This might happen when a recovery is happening together with a cluster controller coordinator key change.

--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -2757,6 +2757,8 @@ ACTOR static Future<Void> doBlobGranuleLocationRequest(GetBlobGranuleLocationsRe
 
 	wait(delay(0, TaskPriority::DefaultEndpoint));
 
+	// FIXME: wait for hybrid read version as part of this - need to specify in request  - then check CP state to see if
+	// tenant locked as of version and reject if so
 	bool validTenant = wait(checkTenant(commitData, req.tenant.tenantId, minVersion, "GetBlobGranuleLocation"));
 
 	if (!validTenant) {

--- a/fdbserver/workloads/BlobGranuleRangesWorkload.actor.cpp
+++ b/fdbserver/workloads/BlobGranuleRangesWorkload.actor.cpp
@@ -57,6 +57,9 @@ struct BlobGranuleRangesWorkload : TestWorkload {
 	Optional<TenantName> tenantName;
 	Optional<Reference<Tenant>> tenant;
 
+	Optional<TenantName> lockTenantName;
+	Optional<Reference<Tenant>> lockTenant;
+
 	int32_t nextKey;
 
 	std::vector<KeyRange> inactiveRanges;
@@ -89,6 +92,10 @@ struct BlobGranuleRangesWorkload : TestWorkload {
 
 		stopUnitClient = false;
 		tenantName = StringRef("bgrwTenant" + std::to_string(clientId));
+
+		if (clientId == 0) {
+			lockTenantName = StringRef("bgrwLockTenant" + std::to_string(clientId));
+		}
 
 		TraceEvent("BlobGranuleRangesWorkloadInit").detail("TargetRanges", targetRanges);
 	}
@@ -189,6 +196,7 @@ struct BlobGranuleRangesWorkload : TestWorkload {
 
 		if (cx->clientInfo->get().tenantMode != TenantMode::REQUIRED && deterministicRandom()->coinflip()) {
 			self->tenantName.reset();
+			self->lockTenantName.reset();
 		}
 
 		if (self->tenantName.present()) {
@@ -206,6 +214,11 @@ struct BlobGranuleRangesWorkload : TestWorkload {
 			}
 		}
 
+		if (self->lockTenantName.present()) {
+			wait(success(self->setupTenant(cx, self->lockTenantName.get())));
+			self->lockTenant = makeReference<Tenant>(cx, self->lockTenantName.get());
+		}
+
 		state int i;
 		std::vector<Future<Void>> createInitialRanges;
 		for (i = 0; i < self->targetRanges; i++) {
@@ -219,6 +232,7 @@ struct BlobGranuleRangesWorkload : TestWorkload {
 		client = blobGranuleRangesClient(cx->clone(), this);
 		if (clientId == 0) {
 			unitClient = blobGranuleRangesUnitTests(cx->clone(), this);
+			unitClient = unitClient && lockUnitTests(cx->clone(), this);
 		} else {
 			unitClient = Future<Void>(Void());
 		}
@@ -865,6 +879,114 @@ struct BlobGranuleRangesWorkload : TestWorkload {
 			}
 
 			wait(delay(1.0));
+		}
+	}
+
+	ACTOR Future<Void> doLockTest(Database cx,
+	                              BlobGranuleRangesWorkload* self,
+	                              KeyRange range,
+	                              std::function<Future<Void>(KeyRange, Optional<Reference<Tenant>>)> testFunction) {
+		wait(self->lockTenant.get()->ready());
+
+		state Optional<Reference<Tenant>> tenant;
+		// randomly choose to use tenant or to use raw equivalent
+		if (deterministicRandom()->coinflip()) {
+			tenant = self->lockTenant;
+
+		} else {
+			range = range.withPrefix(self->lockTenant.get()->prefix());
+		}
+		// ensure the function works before locking and after unlocking, but not during
+		state KeyRange beforeRange = singleKeyRange(range.begin.withSuffix("/before/"_sr));
+		state KeyRange duringRange = singleKeyRange(range.begin.withSuffix("/during/"_sr));
+		state KeyRange afterRange = singleKeyRange(range.begin.withSuffix("/after/"_sr));
+
+		state UID lockId = deterministicRandom()->randomUniqueID();
+
+		wait(testFunction(beforeRange, tenant));
+
+		// lock tenant
+		state Reference<ReadYourWritesTransaction> tr = makeReference<ReadYourWritesTransaction>(cx);
+		loop {
+			try {
+				tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+				wait(TenantAPI::changeLockState(
+				    tr, self->lockTenant.get()->id(), TenantAPI::TenantLockState::LOCKED, lockId));
+				wait(tr->commit());
+				break;
+			} catch (Error& e) {
+				wait(tr->onError(e));
+			}
+		}
+
+		try {
+			wait(testFunction(duringRange, tenant));
+			ASSERT(false);
+		} catch (Error& e) {
+			ASSERT(e.code() == error_code_tenant_locked);
+		}
+
+		// unlock tenant
+		tr->reset();
+		loop {
+			try {
+				tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+				wait(TenantAPI::changeLockState(
+				    tr, self->lockTenant.get()->id(), TenantAPI::TenantLockState::UNLOCKED, lockId));
+				wait(tr->commit());
+				break;
+			} catch (Error& e) {
+				wait(tr->onError(e));
+			}
+		}
+
+		wait(testFunction(afterRange, tenant));
+
+		// FIXME: could clean up, but only necessary for blobbify
+
+		return Void();
+	}
+
+	// FIXME: extend test support to reads and read lock as well
+	// Should metadata operations like getting the set of blobbified ranges for a tenant also respect the tenant read
+	// lock?
+	using LockTestFunc = std::function<Future<Void>(const KeyRange&, Optional<Reference<Tenant>> tenant)>;
+
+	ACTOR Future<Void> lockUnitTests(Database cx, BlobGranuleRangesWorkload* self) {
+		if (!self->lockTenant.present()) {
+			return Void();
+		}
+		if (deterministicRandom()->coinflip()) {
+			cx->internal = IsInternal::False;
+		}
+		state std::vector<LockTestFunc> testFunctions;
+
+		LockTestFunc blobbifyFunc = [this](const KeyRange& keyRange,
+		                                   Optional<Reference<Tenant>> tenant) -> Future<Void> {
+			return success(cx->blobbifyRange(keyRange, tenant));
+		};
+		testFunctions.push_back(blobbifyFunc);
+
+		LockTestFunc unblobbifyFunc = [this](const KeyRange& keyRange,
+		                                     Optional<Reference<Tenant>> tenant) -> Future<Void> {
+			return success(cx->unblobbifyRange(keyRange, tenant));
+		};
+		testFunctions.push_back(unblobbifyFunc);
+
+		LockTestFunc purgeFunc = [this](const KeyRange& keyRange, Optional<Reference<Tenant>> tenant) -> Future<Void> {
+			return success(cx->purgeBlobGranules(keyRange, 1, tenant, false));
+		};
+		testFunctions.push_back(purgeFunc);
+
+		loop {
+			if (self->stopUnitClient) {
+				return Void();
+			}
+			std::string nextRangeKey = "L_" + self->newKey();
+			state KeyRange range(KeyRangeRef(StringRef(nextRangeKey), strinc(StringRef(nextRangeKey))));
+			int idx = deterministicRandom()->randomInt(0, testFunctions.size());
+			wait(self->doLockTest(cx, self, range, testFunctions[idx]));
+			wait(delayJittered(1.0));
 		}
 	}
 };

--- a/fdbserver/workloads/BlobGranuleRangesWorkload.actor.cpp
+++ b/fdbserver/workloads/BlobGranuleRangesWorkload.actor.cpp
@@ -921,8 +921,13 @@ struct BlobGranuleRangesWorkload : TestWorkload {
 
 		try {
 			wait(testFunction(duringRange, tenant));
-			ASSERT(false);
+			if (!CLIENT_KNOBS->HYBRID_MANAGEMENT_BYPASS_TENANT_LOCK) {
+				ASSERT(false);
+			}
 		} catch (Error& e) {
+			if (CLIENT_KNOBS->HYBRID_MANAGEMENT_BYPASS_TENANT_LOCK) {
+				ASSERT(false);
+			}
 			ASSERT(e.code() == error_code_tenant_locked);
 		}
 

--- a/fdbserver/workloads/BlobGranuleRangesWorkload.actor.cpp
+++ b/fdbserver/workloads/BlobGranuleRangesWorkload.actor.cpp
@@ -921,13 +921,9 @@ struct BlobGranuleRangesWorkload : TestWorkload {
 
 		try {
 			wait(testFunction(duringRange, tenant));
-			if (!CLIENT_KNOBS->HYBRID_MANAGEMENT_BYPASS_TENANT_LOCK) {
-				ASSERT(false);
-			}
+			ASSERT(CLIENT_KNOBS->HYBRID_MANAGEMENT_BYPASS_TENANT_LOCK);
 		} catch (Error& e) {
-			if (CLIENT_KNOBS->HYBRID_MANAGEMENT_BYPASS_TENANT_LOCK) {
-				ASSERT(false);
-			}
+			ASSERT(!CLIENT_KNOBS->HYBRID_MANAGEMENT_BYPASS_TENANT_LOCK);
 			ASSERT(e.code() == error_code_tenant_locked);
 		}
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -254,6 +254,7 @@ if(WITH_PYTHON)
 
   add_fdb_test(TEST_FILES rare/BlobGranuleRanges.toml)
   add_fdb_test(TEST_FILES rare/BlobGranuleRangesChangeLog.toml)
+  add_fdb_test(TEST_FILES rare/BlobGranuleRangesBypassLock.toml)
   add_fdb_test(TEST_FILES rare/BlobGranuleMergeBoundaries.toml)
   add_fdb_test(TEST_FILES rare/CheckRelocation.toml)
   add_fdb_test(TEST_FILES rare/ClogTlog.toml)

--- a/tests/rare/BlobGranuleRangesBypassLock.toml
+++ b/tests/rare/BlobGranuleRangesBypassLock.toml
@@ -1,0 +1,49 @@
+# this test is lower value than the BlobGranuleRanges test, the delta is just tests that if the knob is set we don't bypass the lock
+testPriority = '10'
+
+# FIXME: remove this test once we have tenant + db options for this and can bypass lock or not on a per-operation basis
+
+[configuration]
+blobGranulesEnabled = true 
+allowDefaultTenant = false
+injectTargetedSSRestart = true
+injectSSDelay = true
+tenantModes = ['optional', 'required']
+
+[[knobs]]
+hybrid_management_bypass_tenant_lock = true
+
+[[test]]
+testTitle = 'BlobGranuleRanges'
+
+    [[test.workload]]
+    testName = 'BlobGranuleRanges'
+    testDuration = 30.0
+
+    [[test.workload]]
+    testName = 'RandomClogging'
+    testDuration = 30.0
+
+    [[test.workload]]
+    testName = 'Rollback'
+    meanDelay = 20.0
+    testDuration = 30.0
+
+    [[test.workload]]
+    testName = 'Attrition'
+    machinesToKill = 10
+    machinesToLeave = 3
+    reboot = true
+    testDuration = 30.0
+
+    [[test.workload]]
+    testName = 'Attrition'
+    machinesToKill = 10
+    machinesToLeave = 3
+    reboot = true
+    testDuration = 30.0
+
+    [[test.workload]]
+    testName = 'BlobFailureInjection'
+    testDuration = 30.0
+


### PR DESCRIPTION
Cherry-Pick of #10746

Avoids races in tenant moves with blob management 

100k correctness -   20230814-140810-jslocum-f2c605d286836a09 - no failures
100k blob granule correctness -  20230814-135112-jslocum-f2c605d286836a09 - 2 failures - likely exisitng healthyZoneIssue and did not use tenants so this change wouldn't have an impact

Original Description:



# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
