### PR TITLE
Add consistency check for rocksdb only

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -802,6 +802,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( PEER_DEGRADATION_CONNECTION_FAILURE_COUNT,               5 );
 	init( WORKER_HEALTH_REPORT_RECENT_DESTROYED_PEER,           true );
 	init( STORAGE_SERVER_REBOOT_ON_IO_TIMEOUT,                 false ); if ( randomize && BUGGIFY ) STORAGE_SERVER_REBOOT_ON_IO_TIMEOUT = true;
+	init( CONSISTENCY_CHECK_SPECIFIC_ENGINE,                       0 ); // disable by default
 
 	// Test harness
 	init( WORKER_POLL_DELAY,                                     1.0 );

--- a/fdbclient/ServerKnobs.h
+++ b/fdbclient/ServerKnobs.h
@@ -740,6 +740,9 @@ public:
 	                                          // Enabling this can reduce toil of manually restarting the SS.
 	                                          // Enable with caution: If io_timeout is caused by disk failure, we won't
 	                                          // want to restart the SS, which increases risk of data corruption.
+	int CONSISTENCY_CHECK_SPECIFIC_ENGINE; // When set, consistency check only check data corruption for a
+	                                       // shard which is in at least one SS with the given storage engine.
+	                                       // 1: rocksdb; 2: sqlite; Other values: disable specific check;
 
 	// Test harness
 	double WORKER_POLL_DELAY;

--- a/fdbclient/ServerKnobs.h
+++ b/fdbclient/ServerKnobs.h
@@ -744,6 +744,9 @@ public:
 	                                       // shard which is in at least one SS with the rocksdb engine.
 	bool CONSISTENCY_CHECK_SQLITE_ENGINE; // When set, consistency check only check data corruption for a
 	                                      // shard which is in at least one SS with the sqlite engine.
+	                                      // When both CONSISTENCY_CHECK_ROCKSDB_ENGINE and
+	                                      // CONSISTENCY_CHECK_SQLITE_ENGINE are set, consistency check only checks for
+	                                      // the rocksdb engine.
 
 	// Test harness
 	double WORKER_POLL_DELAY;


### PR DESCRIPTION
Introduce two new server knobs: 
CONSISTENCY_CHECK_ROCKSDB_ENGINE and CONSISTENCY_CHECK_SQLITE_ENGINE
Both knobs are off by default.
When both knobs are off, consistency check checks all data shards.
When any knob is on, consistency check only check data corruption for a shard which is in at least one SS with the specified storage engine.
When both knobs are on, consistency check does check for rocksdb.

Note that when enabling the new knobs, we may want to shorten CONSISTENCY_CHECK_ONE_ROUND_TARGET_COMPLETION_TIME to shorten the check period.

**Correctness tests**

100K correctness test with feature off
  20230809-013840-zhewang-9d6d891996d26264           compressed=True data_size=23137221 duration=4920346 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:35:50 sanity=False started=100000 stopped=20230809-031430 submitted=20230809-013840 timeout=5400 username=zhewang

100K correctness test with CONSISTENCY_CHECK_ROCKSDB_ENGINE is on only
  20230809-014016-zhewang-95d3264e98092a36           compressed=True data_size=23137020 duration=4914649 ended=100000 fail=1 fail_fast=10 max_runs=100000 pass=99999 priority=100 remaining=0 runtime=1:41:52 sanity=False started=100000 stopped=20230809-032208 submitted=20230809-014016 timeout=5400 username=zhewang

100K correctness test with CONSISTENCY_CHECK_SQLITE_ENGINE is on only
  20230809-014122-zhewang-b45e71ca82bddbdb           compressed=True data_size=23137020 duration=4913020 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:32:20 sanity=False started=100000 stopped=20230809-031342 submitted=20230809-014122 timeout=5400 username=zhewang

100K correctness test with both knobs are on:
  20230809-014242-zhewang-2d3b64e8c028d03f           compressed=True data_size=23136992 duration=4906306 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:32:11 sanity=False started=100000 stopped=20230809-031453 submitted=20230809-014242 timeout=5400 username=zhewang

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
