### PR TITLE
Trace shardedrocks manifest size

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -441,7 +441,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( ROCKSDB_BLOOM_WHOLE_KEY_FILTERING,                   false );
 	init( ROCKSDB_MAX_AUTO_READAHEAD_SIZE,                     65536 );
 	// If rocksdb block cache size is 0, the default 8MB is used.
-	int64_t blockCacheSize = isSimulated ? 16 * 1024 * 1024 : 2147483648 /* 2GB */;
+	int64_t blockCacheSize = isSimulated ? 16 * 1024 : 2147483648 /* 2GB */;
 	init( ROCKSDB_BLOCK_CACHE_SIZE,                   blockCacheSize );
 	init( ROCKSDB_METRICS_DELAY,                                60.0 );
 	// ROCKSDB_READ_VALUE_TIMEOUT, ROCKSDB_READ_VALUE_PREFIX_TIMEOUT, ROCKSDB_READ_RANGE_TIMEOUT knobs:

--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -538,7 +538,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init (ROCKSDB_SKIP_FILE_SIZE_CHECK_ON_OPEN,                 false ); if (isSimulated) ROCKSDB_SKIP_FILE_SIZE_CHECK_ON_OPEN = deterministicRandom()->coinflip();
 	init (SHARDED_ROCKSDB_VALIDATE_MAPPING_RATIO,                 0.01 ); if (isSimulated) SHARDED_ROCKSDB_VALIDATE_MAPPING_RATIO = deterministicRandom()->random01(); 
 	init (SHARD_METADATA_SCAN_BYTES_LIMIT,                    10485760 ); // 10MB
-	init (ROCKSDB_MAX_MANIFEST_FILE_SIZE,                    100 << 20 ); // 100MB
+	init (ROCKSDB_MAX_MANIFEST_FILE_SIZE,                    500 << 20 ); // 500MB
 	init (ROCKSDB_MAX_WRITE_BUFFER_NUMBER,                           6 ); // RocksDB default.
 
 	// Leader election

--- a/fdbserver/KeyValueStoreShardedRocksDB.actor.cpp
+++ b/fdbserver/KeyValueStoreShardedRocksDB.actor.cpp
@@ -2284,11 +2284,13 @@ void RocksDBMetrics::logStats(rocksdb::DB* db, std::string manifestDirectory) {
 
 	int64_t manifestSizeTotal = 0;
 	auto manifests = getManifestBytes(manifestDirectory);
+	int idx = 0;
 	for (const auto& [fileName, fileBytes] : manifests) {
-		e.detail("FileName-" + fileName, fileBytes);
+		e.detail(format("Manifest-%d", idx), format("%s-%lld", fileName.c_str(), fileBytes));
 		manifestSizeTotal += fileBytes;
+		idx++;
 	}
-	e.detail("ManifestSizeTotal", manifestSizeTotal);
+	e.detail("ManifestSize", manifestSizeTotal);
 
 	std::string propValue = "";
 	ASSERT(db->GetProperty(rocksdb::DB::Properties::kDBWriteStallStats, &propValue));

--- a/fdbserver/KeyValueStoreShardedRocksDB.actor.cpp
+++ b/fdbserver/KeyValueStoreShardedRocksDB.actor.cpp
@@ -2282,15 +2282,15 @@ void RocksDBMetrics::logStats(rocksdb::DB* db, std::string manifestDirectory) {
 		e.detail(name, stat);
 	}
 
-	int64_t manifestSizeTotal = 0;
+	int64_t manifestBytesTotal = 0;
 	auto manifests = getManifestBytes(manifestDirectory);
 	int idx = 0;
 	for (const auto& [fileName, fileBytes] : manifests) {
 		e.detail(format("Manifest-%d", idx), format("%s-%lld", fileName.c_str(), fileBytes));
-		manifestSizeTotal += fileBytes;
+		manifestBytesTotal += fileBytes;
 		idx++;
 	}
-	e.detail("ManifestSize", manifestSizeTotal);
+	e.detail("ManifestBytes", manifestBytesTotal);
 
 	std::string propValue = "";
 	ASSERT(db->GetProperty(rocksdb::DB::Properties::kDBWriteStallStats, &propValue));

--- a/fdbserver/KeyValueStoreShardedRocksDB.actor.cpp
+++ b/fdbserver/KeyValueStoreShardedRocksDB.actor.cpp
@@ -56,6 +56,7 @@ static_assert((ROCKSDB_MAJOR == FDB_ROCKSDB_MAJOR && ROCKSDB_MINOR == FDB_ROCKSD
 const std::string rocksDataFolderSuffix = "-data";
 const std::string METADATA_SHARD_ID = "kvs-metadata";
 const std::string DEFAULT_CF_NAME = "default"; // `specialKeys` is stored in this culoumn family.
+const std::string manifestFilePrefix = "MANIFEST-";
 const KeyRef shardMappingPrefix("\xff\xff/ShardMapping/"_sr);
 // TODO: move constants to a header file.
 const KeyRef persistVersion = "\xff\xffVersion"_sr;
@@ -1955,7 +1956,7 @@ private:
 class RocksDBMetrics {
 public:
 	RocksDBMetrics(UID debugID, std::shared_ptr<rocksdb::Statistics> stats);
-	void logStats(rocksdb::DB* db);
+	void logStats(rocksdb::DB* db, std::string manifestDirectory);
 	// PerfContext
 	void resetPerfContext();
 	void collectPerfContext(int index);
@@ -1981,6 +1982,7 @@ public:
 	Reference<Histogram> getDeleteCompactRangeHistogram();
 	// Stat for Memory Usage
 	void logMemUsage(rocksdb::DB* db);
+	std::vector<std::pair<std::string, int64_t>> getManifestBytes(std::string manifestDirectory);
 
 private:
 	const UID debugID;
@@ -2015,6 +2017,18 @@ private:
 
 	uint64_t getRocksdbPerfcontextMetric(int metric);
 };
+
+std::vector<std::pair<std::string, int64_t>> RocksDBMetrics::getManifestBytes(std::string manifestDirectory) {
+	std::vector<std::pair<std::string, int64_t>> res;
+	std::vector<std::string> returnFiles = platform::listFiles(manifestDirectory, "");
+	for (const auto& fileEntry : returnFiles) {
+		if (fileEntry.find(manifestFilePrefix) != std::string::npos) {
+			int64_t manifestSize = fileSize(manifestDirectory + "/" + fileEntry);
+			res.push_back(std::make_pair(fileEntry, manifestSize));
+		}
+	}
+	return res;
+}
 
 // We have 4 readers and 1 writer. Following input index denotes the
 // id assigned to the reader thread when creating it
@@ -2254,7 +2268,7 @@ RocksDBMetrics::RocksDBMetrics(UID debugID, std::shared_ptr<rocksdb::Statistics>
 	    ROCKSDBSTORAGE_HISTOGRAM_GROUP, ROCKSDB_DELETE_COMPACTRANGE_HISTOGRAM, Histogram::Unit::milliseconds);
 }
 
-void RocksDBMetrics::logStats(rocksdb::DB* db) {
+void RocksDBMetrics::logStats(rocksdb::DB* db, std::string manifestDirectory) {
 	TraceEvent e(SevInfo, "ShardedRocksDBMetrics", debugID);
 	uint64_t stat;
 	for (auto& [name, ticker, cumulation] : tickerStats) {
@@ -2267,6 +2281,14 @@ void RocksDBMetrics::logStats(rocksdb::DB* db) {
 		ASSERT(db->GetAggregatedIntProperty(property, &stat));
 		e.detail(name, stat);
 	}
+
+	int64_t manifestSizeTotal = 0;
+	auto manifests = getManifestBytes(manifestDirectory);
+	for (const auto& [fileName, fileBytes] : manifests) {
+		e.detail("FileName-" + fileName, fileBytes);
+		manifestSizeTotal += fileBytes;
+	}
+	e.detail("ManifestSizeTotal", manifestSizeTotal);
 
 	std::string propValue = "";
 	ASSERT(db->GetProperty(rocksdb::DB::Properties::kDBWriteStallStats, &propValue));
@@ -2459,7 +2481,8 @@ uint64_t RocksDBMetrics::getRocksdbPerfcontextMetric(int metric) {
 ACTOR Future<Void> rocksDBAggregatedMetricsLogger(std::shared_ptr<ShardedRocksDBState> rState,
                                                   Future<Void> openFuture,
                                                   std::shared_ptr<RocksDBMetrics> rocksDBMetrics,
-                                                  ShardManager* shardManager) {
+                                                  ShardManager* shardManager,
+                                                  std::string manifestDirectory) {
 	try {
 		wait(openFuture);
 		state rocksdb::DB* db = shardManager->getDb();
@@ -2468,7 +2491,7 @@ ACTOR Future<Void> rocksDBAggregatedMetricsLogger(std::shared_ptr<ShardedRocksDB
 			if (rState->closing) {
 				break;
 			}
-			rocksDBMetrics->logStats(db);
+			rocksDBMetrics->logStats(db, manifestDirectory);
 			rocksDBMetrics->logMemUsage(db);
 			if (SERVER_KNOBS->ROCKSDB_PERFCONTEXT_SAMPLE_RATE != 0) {
 				rocksDBMetrics->logPerfContext(true);
@@ -3648,8 +3671,9 @@ struct ShardedRocksDBKeyValueStore : IKeyValueStore {
 		} else {
 			auto a = std::make_unique<Writer::OpenAction>(&shardManager, metrics, &readSemaphore, &fetchSemaphore);
 			openFuture = a->done.getFuture();
-			this->metrics = ShardManager::shardMetricsLogger(this->rState, openFuture, &shardManager) &&
-			                rocksDBAggregatedMetricsLogger(this->rState, openFuture, rocksDBMetrics, &shardManager);
+			this->metrics =
+			    ShardManager::shardMetricsLogger(this->rState, openFuture, &shardManager) &&
+			    rocksDBAggregatedMetricsLogger(this->rState, openFuture, rocksDBMetrics, &shardManager, this->path);
 			this->refreshHolder = refreshReadIteratorPools(this->rState, openFuture, shardManager.getAllShards());
 			this->refreshRocksDBBackgroundWorkHolder = refreshRocksDBBackgroundEventCounter(this->eventListener);
 			this->cleanUpJob = emptyShardCleaner(this->rState, openFuture, &shardManager, writeThread);


### PR DESCRIPTION
1. Trace shardedrocks manifest size (in the unit of byte).
2. Try to reduce the chance of external timeout in simulation by reducing ROCKSDB_BLOCK_CACHE_SIZE.
3. Try to reduce the chance of external timeout in simulation by increasing ROCKSDB_MAX_MANIFEST_FILE_SIZE.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
