### PR TITLE
Disable more RocksDB simulation tests due to timeout issue

### DIFF
--- a/tests/rare/TransactionTagSwizzledApiCorrectness.toml
+++ b/tests/rare/TransactionTagSwizzledApiCorrectness.toml
@@ -1,3 +1,6 @@
+[configuration]
+storageEngineExcludeTypes = [5]
+
 [[test]]
 testTitle = 'TransactionTagWithSwizzledApiCorrectnessTest'
 clearAfterTest = true

--- a/tests/restarting/from_7.3.0/DrUpgradeRestart-1.toml
+++ b/tests/restarting/from_7.3.0/DrUpgradeRestart-1.toml
@@ -3,7 +3,7 @@ extraDatabaseMode = "Local"
 # In 7.2, DR is not supported in required tenant mode
 allowDefaultTenant = false
 encryptModes = ['disabled']
-storageEngineExcludeTypes = [5]
+storageEngineExcludeTypes = [4,5]
 
 [[test]]
 testTitle = "DrUpgrade"

--- a/tests/slow/SwizzledDdBalance.toml
+++ b/tests/slow/SwizzledDdBalance.toml
@@ -1,3 +1,6 @@
+[configuration]
+storageEngineExcludeTypes = [5]
+
 [[test]]
 testTitle = 'DDBalance_Test'
 

--- a/tests/slow/ddbalance.toml
+++ b/tests/slow/ddbalance.toml
@@ -1,3 +1,6 @@
+[configuration]
+storageEngineExcludeTypes = [5]
+
 [[test]]
 testTitle = 'DDBalance_Test'
 


### PR DESCRIPTION
clang nightly failed for these tests.


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
