### PR TITLE
Audit storage for specific engine

### DIFF
--- a/fdbcli/AuditStorageCommand.actor.cpp
+++ b/fdbcli/AuditStorageCommand.actor.cpp
@@ -80,7 +80,7 @@ ACTOR Future<UID> auditStorageCommandActor(Reference<IClusterConnectionRecord> c
 		Key begin = allKeys.begin, end = allKeys.end;
 		if (tokens.size() == 3) {
 			begin = tokens[2];
-		} else if (tokens.size() == 4) {
+		} else if (tokens.size() == 4 || tokens.size() == 5) {
 			begin = tokens[2];
 			end = tokens[3];
 		} else {
@@ -96,7 +96,23 @@ ACTOR Future<UID> auditStorageCommandActor(Reference<IClusterConnectionRecord> c
 			return UID();
 		}
 
-		UID startedAuditId = wait(auditStorage(clusterFile, KeyRangeRef(begin, end), type, /*timeoutSeconds=*/60));
+		KeyValueStoreType engineType = KeyValueStoreType::END;
+		if (tokens.size() == 5 && (type == AuditType::ValidateHA || type == AuditType::ValidateReplica)) {
+			if (tokencmp(tokens[4], "sqlite")) {
+				engineType = KeyValueStoreType::SSD_BTREE_V2;
+			} else if (tokencmp(tokens[4], "rocksdb")) {
+				engineType = KeyValueStoreType::SSD_ROCKSDB_V1;
+			} else if (tokencmp(tokens[4], "shardedrocksdb")) {
+				engineType = KeyValueStoreType::SSD_SHARDED_ROCKSDB;
+			} else {
+				printUsage(tokens[0]);
+				return UID();
+			}
+		}
+		// For KeyValueStoreType::END: do not specify any storage engine
+		// Every storage engine will be audited
+		UID startedAuditId =
+		    wait(auditStorage(clusterFile, KeyRangeRef(begin, end), type, engineType, /*timeoutSeconds=*/60));
 		resAuditId = startedAuditId;
 	}
 	return resAuditId;
@@ -104,11 +120,13 @@ ACTOR Future<UID> auditStorageCommandActor(Reference<IClusterConnectionRecord> c
 
 CommandFactory auditStorageFactory(
     "audit_storage",
-    CommandHelp("audit_storage <Type> [BeginKey EndKey]",
+    CommandHelp("audit_storage <Type> [BeginKey EndKey] <EngineType>",
                 "Start an audit storage",
-                "Specify audit `Type' (only `ha' and `replica` and `locationmetadata` and "
-                "`ssshard` `Type' are supported currently), and\n"
+                "Specify audit `Type' (only `ha' and `replica' and `locationmetadata' and "
+                "`ssshard' `Type' are supported currently), and\n"
                 "optionally a sub-range with `BeginKey' and `EndKey'.\n"
+                "Specify audit `EngineType' when auditType is `ha' or `replica'\n"
+                "(only `rocksdb' and `shardedrocksdb' and `sqlite' are supported).\n"
                 "For example, to audit the full key range: `audit_storage ha'\n"
                 "To audit a sub-range only: `audit_storage ha \\xa \\xb'\n"
                 "Returns an audit `ID'. See also `get_audit_status' command.\n"

--- a/fdbcli/AuditStorageCommand.actor.cpp
+++ b/fdbcli/AuditStorageCommand.actor.cpp
@@ -98,13 +98,9 @@ ACTOR Future<UID> auditStorageCommandActor(Reference<IClusterConnectionRecord> c
 
 		KeyValueStoreType engineType = KeyValueStoreType::END;
 		if (tokens.size() == 5 && (type == AuditType::ValidateHA || type == AuditType::ValidateReplica)) {
-			if (tokencmp(tokens[4], "sqlite")) {
-				engineType = KeyValueStoreType::SSD_BTREE_V2;
-			} else if (tokencmp(tokens[4], "rocksdb")) {
-				engineType = KeyValueStoreType::SSD_ROCKSDB_V1;
-			} else if (tokencmp(tokens[4], "shardedrocksdb")) {
-				engineType = KeyValueStoreType::SSD_SHARDED_ROCKSDB;
-			} else {
+			engineType = KeyValueStoreType::fromString(tokens[4].toString());
+			if (engineType != KeyValueStoreType::SSD_BTREE_V2 && engineType != KeyValueStoreType::SSD_ROCKSDB_V1 &&
+			    engineType != KeyValueStoreType::SSD_SHARDED_ROCKSDB) {
 				printUsage(tokens[0]);
 				return UID();
 			}
@@ -126,7 +122,8 @@ CommandFactory auditStorageFactory(
                 "`ssshard' `Type' are supported currently), and\n"
                 "optionally a sub-range with `BeginKey' and `EndKey'.\n"
                 "Specify audit `EngineType' when auditType is `ha' or `replica'\n"
-                "(only `rocksdb' and `shardedrocksdb' and `sqlite' are supported).\n"
+                "(only `ssd-rocksdb-v1' and `ssd-sharded-rocksdb' and `ssd-2' are supported).\n"
+                "If no EngineType is specified, every storage engine will be audited.\n"
                 "For example, to audit the full key range: `audit_storage ha'\n"
                 "To audit a sub-range only: `audit_storage ha \\xa \\xb'\n"
                 "Returns an audit `ID'. See also `get_audit_status' command.\n"

--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -2658,6 +2658,7 @@ ACTOR Future<Void> forceRecovery(Reference<IClusterConnectionRecord> clusterFile
 ACTOR Future<UID> auditStorage(Reference<IClusterConnectionRecord> clusterFile,
                                KeyRange range,
                                AuditType type,
+                               KeyValueStoreType engineType,
                                double timeoutSeconds) {
 	state Reference<AsyncVar<Optional<ClusterInterface>>> clusterInterface(new AsyncVar<Optional<ClusterInterface>>);
 	state Future<Void> leaderMon = monitorLeader<ClusterInterface>(clusterFile, clusterInterface);
@@ -2668,7 +2669,7 @@ ACTOR Future<UID> auditStorage(Reference<IClusterConnectionRecord> clusterFile,
 			wait(clusterInterface->onChange());
 		}
 		TraceEvent(SevVerbose, "ManagementAPIAuditStorageBegin").detail("AuditType", type).detail("Range", range);
-		TriggerAuditRequest req(type, range);
+		TriggerAuditRequest req(type, range, engineType);
 		UID auditId_ = wait(timeoutError(clusterInterface->get().get().triggerAudit.getReply(req), timeoutSeconds));
 		auditId = auditId_;
 		TraceEvent(SevVerbose, "ManagementAPIAuditStorageEnd")

--- a/fdbclient/include/fdbclient/Audit.h
+++ b/fdbclient/include/fdbclient/Audit.h
@@ -86,6 +86,7 @@ struct AuditStorageState {
 	KeyRange range;
 	uint8_t type;
 	uint8_t phase;
+	KeyValueStoreType engineType;
 	std::string error;
 };
 
@@ -93,7 +94,6 @@ struct AuditStorageRequest {
 	constexpr static FileIdentifier file_identifier = 13804341;
 
 	AuditStorageRequest() = default;
-	// for audit user data
 	AuditStorageRequest(UID id, KeyRange range, AuditType type)
 	  : id(id), range(range), type(static_cast<uint8_t>(type)) {}
 
@@ -120,8 +120,8 @@ struct TriggerAuditRequest {
 	constexpr static FileIdentifier file_identifier = 1384445;
 
 	TriggerAuditRequest() = default;
-	TriggerAuditRequest(AuditType type, KeyRange range)
-	  : type(static_cast<uint8_t>(type)), range(range), cancel(false) {}
+	TriggerAuditRequest(AuditType type, KeyRange range, KeyValueStoreType engineType)
+	  : type(static_cast<uint8_t>(type)), range(range), cancel(false), engineType(engineType) {}
 
 	TriggerAuditRequest(AuditType type, UID id) : type(static_cast<uint8_t>(type)), id(id), cancel(true) {}
 
@@ -130,12 +130,13 @@ struct TriggerAuditRequest {
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, type, range, id, cancel, reply);
+		serializer(ar, type, range, id, cancel, reply, engineType);
 	}
 
 	UID id;
 	uint8_t type;
 	KeyRange range;
+	KeyValueStoreType engineType;
 	bool cancel;
 	ReplyPromise<UID> reply;
 };

--- a/fdbclient/include/fdbclient/ManagementAPI.actor.h
+++ b/fdbclient/include/fdbclient/ManagementAPI.actor.h
@@ -154,6 +154,7 @@ ACTOR Future<Void> forceRecovery(Reference<IClusterConnectionRecord> clusterFile
 ACTOR Future<UID> auditStorage(Reference<IClusterConnectionRecord> clusterFile,
                                KeyRange range,
                                AuditType type,
+                               KeyValueStoreType engineType,
                                double timeoutSeconds);
 // Cancel an audit given type and id
 ACTOR Future<UID> cancelAuditStorage(Reference<IClusterConnectionRecord> clusterFile,

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -2038,22 +2038,25 @@ ACTOR Future<Void> triggerAuditStorage(ClusterControllerData* self, TriggerAudit
 		}
 		TraceEvent(SevVerbose, "CCTriggerAuditStorageBegin", self->id)
 		    .detail("Range", req.range)
-		    .detail("AuditType", req.type)
+		    .detail("AuditType", req.getType())
+		    .detail("KeyValueStoreType", req.engineType.toString())
 		    .detail("DDId", self->db.serverInfo->get().distributor.get().id());
-		TriggerAuditRequest fReq(req.getType(), req.range);
+		TriggerAuditRequest fReq(req.getType(), req.range, req.engineType);
 		UID auditId_ = wait(self->db.serverInfo->get().distributor.get().triggerAudit.getReply(fReq));
 		auditId = auditId_;
 		TraceEvent(SevVerbose, "CCTriggerAuditStorageEnd", self->id)
 		    .detail("AuditID", auditId)
 		    .detail("Range", req.range)
-		    .detail("AuditType", req.type);
+		    .detail("AuditType", req.getType())
+		    .detail("KeyValueStoreType", req.engineType.toString());
 		req.reply.send(auditId);
 	} catch (Error& e) {
 		TraceEvent(SevInfo, "CCTriggerAuditStorageFailed", self->id)
 		    .errorUnsuppressed(e)
 		    .detail("AuditID", auditId)
 		    .detail("Range", req.range)
-		    .detail("AuditType", req.type);
+		    .detail("AuditType", req.getType())
+		    .detail("KeyValueStoreType", req.engineType.toString());
 		req.reply.sendError(audit_storage_failed());
 	}
 
@@ -2096,7 +2099,8 @@ ACTOR Future<Void> handleTriggerAuditStorage(ClusterControllerData* self, Cluste
 		TraceEvent(SevVerbose, "CCTriggerAuditStorageReceived", self->id)
 		    .detail("ClusterControllerDcId", self->clusterControllerDcId)
 		    .detail("Range", req.range)
-		    .detail("AuditType", req.getType());
+		    .detail("AuditType", req.getType())
+		    .detail("KeyValueStoreType", req.engineType.toString());
 		if (req.cancel) {
 			ASSERT(req.id.isValid());
 			self->addActor.send(cancelAuditStorage(self, req));

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -338,8 +338,7 @@ ACTOR Future<Void> scheduleAuditStorageShardOnServer(Reference<DataDistributor> 
 ACTOR Future<Void> scheduleAuditLocationMetadata(Reference<DataDistributor> self,
                                                  std::shared_ptr<DDAudit> audit,
                                                  KeyRange range);
-ACTOR Future<Void> dispatchAuditStorage(Reference<DataDistributor> self,
-                                        std::shared_ptr<DDAudit> audit);
+ACTOR Future<Void> dispatchAuditStorage(Reference<DataDistributor> self, std::shared_ptr<DDAudit> audit);
 ACTOR Future<Void> scheduleAuditOnRange(Reference<DataDistributor> self,
                                         std::shared_ptr<DDAudit> audit,
                                         KeyRange range);
@@ -2644,6 +2643,9 @@ ACTOR Future<std::unordered_map<UID, KeyValueStoreType>> getStorageType(
 			}
 		}
 	} catch (Error& e) {
+		if (e.code() == error_code_actor_cancelled) {
+			throw e;
+		}
 		TraceEvent("AuditStorageErrorGetStorageType").errorUnsuppressed(e);
 		res.clear();
 	}

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -91,7 +91,7 @@ enum class DDAuditContext : uint8_t {
 struct DDAudit {
 	DDAudit(AuditStorageState coreState)
 	  : coreState(coreState), actors(true), foundError(false), auditStorageAnyChildFailed(false), retryCount(0),
-	    cancelled(false), overallCompleteDoAuditCount(0), overallIssuedDoAuditCount(0),
+	    cancelled(false), overallCompleteDoAuditCount(0), overallIssuedDoAuditCount(0), overallSkippedDoAuditCount(0),
 	    remainingBudgetForAuditTasks(SERVER_KNOBS->CONCURRENT_AUDIT_TASK_COUNT_MAX), context(0) {}
 
 	AuditStorageState coreState;
@@ -103,6 +103,7 @@ struct DDAudit {
 	bool cancelled; // use to cancel any actor beyond auditActor
 	int64_t overallIssuedDoAuditCount;
 	int64_t overallCompleteDoAuditCount;
+	int64_t overallSkippedDoAuditCount;
 	AsyncVar<int> remainingBudgetForAuditTasks;
 	uint8_t context;
 	std::unordered_map<UID, bool> serverProgressFinishMap; // dedicated to ssshard
@@ -329,7 +330,7 @@ ACTOR Future<Void> auditStorageCore(Reference<DataDistributor> self,
                                     int currentRetryCount);
 ACTOR Future<UID> launchAudit(Reference<DataDistributor> self, KeyRange auditRange, AuditType auditType);
 ACTOR Future<Void> auditStorage(Reference<DataDistributor> self, TriggerAuditRequest req);
-void loadAndDispatchAudit(Reference<DataDistributor> self, std::shared_ptr<DDAudit> audit, KeyRange range);
+void loadAndDispatchAudit(Reference<DataDistributor> self, std::shared_ptr<DDAudit> audit);
 ACTOR Future<Void> dispatchAuditStorageServerShard(Reference<DataDistributor> self, std::shared_ptr<DDAudit> audit);
 ACTOR Future<Void> scheduleAuditStorageShardOnServer(Reference<DataDistributor> self,
                                                      std::shared_ptr<DDAudit> audit,
@@ -338,8 +339,7 @@ ACTOR Future<Void> scheduleAuditLocationMetadata(Reference<DataDistributor> self
                                                  std::shared_ptr<DDAudit> audit,
                                                  KeyRange range);
 ACTOR Future<Void> dispatchAuditStorage(Reference<DataDistributor> self,
-                                        std::shared_ptr<DDAudit> audit,
-                                        KeyRange range);
+                                        std::shared_ptr<DDAudit> audit);
 ACTOR Future<Void> scheduleAuditOnRange(Reference<DataDistributor> self,
                                         std::shared_ptr<DDAudit> audit,
                                         KeyRange range);
@@ -347,6 +347,9 @@ ACTOR Future<Void> doAuditOnStorageServer(Reference<DataDistributor> self,
                                           std::shared_ptr<DDAudit> audit,
                                           StorageServerInterface ssi,
                                           AuditStorageRequest req);
+ACTOR Future<Void> skipAuditOnRange(Reference<DataDistributor> self,
+                                    std::shared_ptr<DDAudit> audit,
+                                    KeyRange rangeToSkip);
 
 struct DataDistributor : NonCopyable, ReferenceCounted<DataDistributor> {
 public:
@@ -1855,7 +1858,7 @@ ACTOR Future<Void> auditStorageCore(Reference<DataDistributor> self,
 	try {
 		ASSERT(audit != nullptr);
 		ASSERT(audit->coreState.ddId == self->ddId);
-		loadAndDispatchAudit(self, audit, audit->coreState.range);
+		loadAndDispatchAudit(self, audit);
 		TraceEvent(SevInfo, "DDAuditStorageCoreScheduled", self->ddId)
 		    .detail("Context", audit->getDDAuditContext())
 		    .detail("AuditID", audit->coreState.id)
@@ -2048,7 +2051,10 @@ void runAuditStorage(Reference<DataDistributor> self,
 }
 
 // Get audit for auditRange and auditType, if not exist, launch a new one
-ACTOR Future<UID> launchAudit(Reference<DataDistributor> self, KeyRange auditRange, AuditType auditType) {
+ACTOR Future<UID> launchAudit(Reference<DataDistributor> self,
+                              KeyRange auditRange,
+                              AuditType auditType,
+                              KeyValueStoreType auditStorageEngineType) {
 	state MoveKeyLockInfo lockInfo;
 	lockInfo.myOwner = self->lock.myOwner;
 	lockInfo.prevOwner = self->lock.prevOwner;
@@ -2058,6 +2064,7 @@ ACTOR Future<UID> launchAudit(Reference<DataDistributor> self, KeyRange auditRan
 	try {
 		TraceEvent(SevInfo, "DDAuditStorageLaunchStarts", self->ddId)
 		    .detail("AuditType", auditType)
+		    .detail("KeyValueStoreType", auditStorageEngineType)
 		    .detail("RequestedRange", auditRange);
 		wait(self->auditStorageInitialized.getFuture());
 		// Start an audit if no audit exists
@@ -2070,6 +2077,7 @@ ACTOR Future<UID> launchAudit(Reference<DataDistributor> self, KeyRange auditRan
 				TraceEvent(SevInfo, "DDAuditStorageLaunchCheckExisting", self->ddId)
 				    .detail("AuditID", currentAudit->coreState.id)
 				    .detail("AuditType", currentAudit->coreState.getType())
+				    .detail("KeyValueStoreType", auditStorageEngineType)
 				    .detail("AuditPhase", currentAudit->coreState.getPhase())
 				    .detail("AuditRange", currentAudit->coreState.range)
 				    .detail("AuditRetryTime", currentAudit->retryCount);
@@ -2091,17 +2099,20 @@ ACTOR Future<UID> launchAudit(Reference<DataDistributor> self, KeyRange auditRan
 			}
 			TraceEvent(SevInfo, "DDAuditStorageLaunchExist", self->ddId)
 			    .detail("AuditType", auditType)
+			    .detail("KeyValueStoreType", auditStorageEngineType)
 			    .detail("AuditID", auditID)
 			    .detail("RequestedRange", auditRange)
 			    .detail("ExistingState", audit->coreState.toString());
 		} else {
 			state AuditStorageState auditState;
 			auditState.setType(auditType);
+			auditState.engineType = auditStorageEngineType;
 			auditState.range = auditRange;
 			auditState.setPhase(AuditPhase::Running);
 			auditState.ddId = self->ddId; // persist ddId to new ddAudit metadata
 			TraceEvent(SevVerbose, "DDAuditStorageLaunchPersistNewAuditIDBefore", self->ddId)
 			    .detail("AuditType", auditType)
+			    .detail("KeyValueStoreType", auditStorageEngineType)
 			    .detail("Range", auditRange);
 			UID auditID_ = wait(persistNewAuditState(
 			    self->txnProcessor->context(), auditState, lockInfo, self->context->isDDEnabled()));
@@ -2118,12 +2129,14 @@ ACTOR Future<UID> launchAudit(Reference<DataDistributor> self, KeyRange auditRan
 				TraceEvent(SevDebug, "DDAuditStorageLaunchInjectActorCancelWhenPersist", self->ddId)
 				    .detail("AuditID", auditID_)
 				    .detail("AuditType", auditType)
+				    .detail("KeyValueStoreType", auditStorageEngineType)
 				    .detail("Range", auditRange);
 				throw operation_failed(); // Trigger DD restart and check if resume audit is correct
 			}
 			TraceEvent(SevInfo, "DDAuditStorageLaunchPersistNewAuditID", self->ddId)
 			    .detail("AuditID", auditID_)
 			    .detail("AuditType", auditType)
+			    .detail("KeyValueStoreType", auditStorageEngineType)
 			    .detail("Range", auditRange);
 			auditState.id = auditID_;
 			auditID = auditID_;
@@ -2143,6 +2156,7 @@ ACTOR Future<UID> launchAudit(Reference<DataDistributor> self, KeyRange auditRan
 		TraceEvent(SevInfo, "DDAuditStorageLaunchError", self->ddId)
 		    .errorUnsuppressed(e)
 		    .detail("AuditType", auditType)
+		    .detail("KeyValueStoreType", auditStorageEngineType)
 		    .detail("Range", auditRange);
 		throw e;
 	}
@@ -2236,12 +2250,14 @@ ACTOR Future<Void> auditStorage(Reference<DataDistributor> self, TriggerAuditReq
 			TraceEvent(SevDebug, "DDAuditStorageStart", self->ddId)
 			    .detail("RetryCount", retryCount)
 			    .detail("AuditType", req.getType())
+			    .detail("KeyValueStoreType", req.engineType.toString())
 			    .detail("Range", req.range);
-			UID auditID = wait(launchAudit(self, req.range, req.getType()));
+			UID auditID = wait(launchAudit(self, req.range, req.getType(), req.engineType));
 			req.reply.send(auditID);
 			TraceEvent(SevVerbose, "DDAuditStorageReply", self->ddId)
 			    .detail("RetryCount", retryCount)
 			    .detail("AuditType", req.getType())
+			    .detail("KeyValueStoreType", req.engineType.toString())
 			    .detail("Range", req.range)
 			    .detail("AuditID", auditID);
 		} catch (Error& e) {
@@ -2252,6 +2268,7 @@ ACTOR Future<Void> auditStorage(Reference<DataDistributor> self, TriggerAuditReq
 			    .errorUnsuppressed(e)
 			    .detail("RetryCount", retryCount)
 			    .detail("AuditType", req.getType())
+			    .detail("KeyValueStoreType", req.engineType.toString())
 			    .detail("Range", req.range);
 			if (e.code() == error_code_operation_failed && g_network->isSimulated()) {
 				throw audit_storage_failed(); // to trigger dd restart
@@ -2274,16 +2291,16 @@ ACTOR Future<Void> auditStorage(Reference<DataDistributor> self, TriggerAuditReq
 
 // The entry of starting a series of audit workers
 // Decide which dispatch impl according to audit type
-void loadAndDispatchAudit(Reference<DataDistributor> self, std::shared_ptr<DDAudit> audit, KeyRange range) {
+void loadAndDispatchAudit(Reference<DataDistributor> self, std::shared_ptr<DDAudit> audit) {
 	TraceEvent(SevInfo, "DDLoadAndDispatchAudit", self->ddId)
 	    .detail("AuditID", audit->coreState.id)
 	    .detail("AuditType", audit->coreState.getType())
-	    .detail("AuditRange", range);
+	    .detail("AuditRange", audit->coreState.range);
 
 	if (audit->coreState.getType() == AuditType::ValidateHA) {
-		audit->actors.add(dispatchAuditStorage(self, audit, range));
+		audit->actors.add(dispatchAuditStorage(self, audit));
 	} else if (audit->coreState.getType() == AuditType::ValidateReplica) {
-		audit->actors.add(dispatchAuditStorage(self, audit, range));
+		audit->actors.add(dispatchAuditStorage(self, audit));
 	} else if (audit->coreState.getType() == AuditType::ValidateLocationMetadata) {
 		audit->actors.add(scheduleAuditLocationMetadata(self, audit, allKeys));
 	} else if (audit->coreState.getType() == AuditType::ValidateStorageServerShard) {
@@ -2530,12 +2547,11 @@ ACTOR Future<Void> scheduleAuditStorageShardOnServer(Reference<DataDistributor> 
 	return Void();
 }
 
-// This function is for ha/replica/locationmetadata audits
+// This function is for ha/replica audits
 // Schedule audit task on the input range
-ACTOR Future<Void> dispatchAuditStorage(Reference<DataDistributor> self,
-                                        std::shared_ptr<DDAudit> audit,
-                                        KeyRange range) {
+ACTOR Future<Void> dispatchAuditStorage(Reference<DataDistributor> self, std::shared_ptr<DDAudit> audit) {
 	state const AuditType auditType = audit->coreState.getType();
+	state const KeyRange range = audit->coreState.range;
 	ASSERT(auditType == AuditType::ValidateHA || auditType == AuditType::ValidateReplica);
 	TraceEvent(SevInfo, "DDDispatchAuditStorageBegin", self->ddId)
 	    .detail("AuditID", audit->coreState.id)
@@ -2603,8 +2619,40 @@ ACTOR Future<Void> dispatchAuditStorage(Reference<DataDistributor> self,
 	return Void();
 }
 
+ACTOR Future<std::unordered_map<UID, KeyValueStoreType>> getStorageType(
+    std::vector<StorageServerInterface> storageServers) {
+	state std::vector<Future<ErrorOr<KeyValueStoreType>>> storageTypeFutures;
+	state std::unordered_map<UID, KeyValueStoreType> res;
+
+	try {
+		for (int i = 0; i < storageServers.size(); i++) {
+			ReplyPromise<KeyValueStoreType> typeReply;
+			storageTypeFutures.push_back(
+			    storageServers[i].getKeyValueStoreType.getReplyUnlessFailedFor(typeReply, 2, 0));
+		}
+		wait(waitForAll(storageTypeFutures));
+
+		for (int i = 0; i < storageServers.size(); i++) {
+			ErrorOr<KeyValueStoreType> reply = storageTypeFutures[i].get();
+			if (!reply.present()) {
+				TraceEvent(SevWarn, "AuditStorageFailedToGetStorageType")
+				    .error(reply.getError())
+				    .detail("StorageServer", storageServers[i].id())
+				    .detail("IsTSS", storageServers[i].isTss() ? "True" : "False");
+			} else {
+				res[storageServers[i].id()] = reply.get();
+			}
+		}
+	} catch (Error& e) {
+		TraceEvent("AuditStorageErrorGetStorageType").errorUnsuppressed(e);
+		res.clear();
+	}
+
+	return res;
+}
+
 // Partition the input range into multiple subranges according to the range ownership, and
-// schedule ha/replica/locationmetadata audit tasks of each subrange on the server which owns the subrange
+// schedule ha/replica audit tasks of each subrange on the server which owns the subrange
 // Automatically retry until complete or timed out
 ACTOR Future<Void> scheduleAuditOnRange(Reference<DataDistributor> self,
                                         std::shared_ptr<DDAudit> audit,
@@ -2621,6 +2669,7 @@ ACTOR Future<Void> scheduleAuditOnRange(Reference<DataDistributor> self,
 	state Key currentRangeToScheduleBegin = rangeToSchedule.begin;
 	state KeyRange currentRangeToSchedule;
 	state int64_t issueDoAuditCount = 0;
+	state int64_t numSkippedShards = 0;
 
 	try {
 		while (currentRangeToScheduleBegin < rangeToSchedule.end) {
@@ -2683,6 +2732,7 @@ ACTOR Future<Void> scheduleAuditOnRange(Reference<DataDistributor> self,
 						state AuditStorageRequest req(
 						    audit->coreState.id, auditStates[auditStateIndex].range, auditType);
 						state StorageServerInterface targetServer;
+						state std::vector<StorageServerInterface> storageServersToCheck;
 						// Set req.targetServers and targetServer, which will be
 						// used to doAuditOnStorageServer
 						// Different audit types have different settings
@@ -2699,11 +2749,13 @@ ACTOR Future<Void> scheduleAuditOnRange(Reference<DataDistributor> self,
 							auto it = rangeLocations[rangeLocationIndex].servers.begin();
 							const int idx = deterministicRandom()->randomInt(0, it->second.size());
 							targetServer = it->second[idx];
+							storageServersToCheck.push_back(it->second[idx]);
 							++it;
 							// pick a server from each remote DC
 							for (; it != rangeLocations[rangeLocationIndex].servers.end(); ++it) {
 								const int idx = deterministicRandom()->randomInt(0, it->second.size());
 								req.targetServers.push_back(it->second[idx].id());
+								storageServersToCheck.push_back(it->second[idx]);
 							}
 						} else if (auditType == AuditType::ValidateReplica) {
 							auto it = rangeLocations[rangeLocationIndex].servers.begin(); // always compare primary DC
@@ -2718,11 +2770,13 @@ ACTOR Future<Void> scheduleAuditOnRange(Reference<DataDistributor> self,
 							ASSERT(it->second.size() >= 2);
 							const int idx = deterministicRandom()->randomInt(0, it->second.size());
 							targetServer = it->second[idx];
+							storageServersToCheck.push_back(it->second[idx]);
 							for (int i = 0; i < it->second.size(); ++i) {
 								if (i == idx) {
 									continue;
 								}
 								req.targetServers.push_back(it->second[i].id());
+								storageServersToCheck.push_back(it->second[idx]);
 							}
 						} else {
 							UNREACHABLE();
@@ -2741,9 +2795,34 @@ ACTOR Future<Void> scheduleAuditOnRange(Reference<DataDistributor> self,
 						    .detail("Val", audit->remainingBudgetForAuditTasks.get())
 						    .detail("AuditType", auditType);
 
-						issueDoAuditCount++;
 						req.ddId = self->ddId; // send this ddid to SS
-						audit->actors.add(doAuditOnStorageServer(self, audit, targetServer, req));
+						// Check if the shard is in any specified storage engine
+						// If yes, issue doAuditOnStorageServer
+						// Otherwise, persist progress complete
+						state bool anySpecifiedEngine = false;
+						if (audit->coreState.engineType == KeyValueStoreType::END) {
+							// Do not specify any storage engine, so check for all engine types
+							anySpecifiedEngine = true;
+						} else {
+							std::unordered_map<UID, KeyValueStoreType> storageTypeMapping =
+							    wait(getStorageType(storageServersToCheck));
+							for (int j = 0; j < storageServersToCheck.size(); j++) {
+								auto ssStorageType = storageTypeMapping.find(storageServersToCheck[j].id());
+								if (ssStorageType != storageTypeMapping.end()) {
+									if (ssStorageType->second == audit->coreState.engineType) {
+										anySpecifiedEngine = true;
+										break;
+									}
+								}
+							}
+						}
+						if (!anySpecifiedEngine) {
+							numSkippedShards++;
+							audit->actors.add(skipAuditOnRange(self, audit, auditStates[auditStateIndex].range));
+						} else {
+							issueDoAuditCount++;
+							audit->actors.add(doAuditOnStorageServer(self, audit, targetServer, req));
+						}
 					}
 
 					taskRangeBegin = auditStates.back().range.end;
@@ -2790,6 +2869,41 @@ ACTOR Future<Void> scheduleAuditOnRange(Reference<DataDistributor> self,
 	return Void();
 }
 
+ACTOR Future<Void> skipAuditOnRange(Reference<DataDistributor> self,
+                                    std::shared_ptr<DDAudit> audit,
+                                    KeyRange rangeToSkip) {
+	try {
+		AuditStorageState res(audit->coreState.id, rangeToSkip, audit->coreState.getType());
+		res.setPhase(AuditPhase::Complete);
+		res.ddId = self->ddId;
+		wait(persistAuditStateByRange(self->txnProcessor->context(), res));
+		audit->overallSkippedDoAuditCount++;
+		TraceEvent(SevInfo, "DDSkipAuditOnRangeComplete", self->ddId)
+		    .detail("AuditID", audit->coreState.id)
+		    .detail("AuditRange", audit->coreState.range)
+		    .detail("AuditType", audit->coreState.getType())
+		    .detail("KeyValueStoreType", audit->coreState.engineType.toString())
+		    .detail("DDDoAuditTaskIssue", audit->overallIssuedDoAuditCount)
+		    .detail("DDDoAuditTaskComplete", audit->overallCompleteDoAuditCount)
+		    .detail("DDDoAuditTaskSkip", audit->overallSkippedDoAuditCount);
+	} catch (Error& e) {
+		if (e.code() == error_code_actor_cancelled) {
+			throw e;
+		}
+		TraceEvent(SevInfo, "DDSkipAuditOnRangeError", self->ddId)
+		    .errorUnsuppressed(e)
+		    .detail("AuditID", audit->coreState.id)
+		    .detail("AuditRange", audit->coreState.range)
+		    .detail("AuditType", audit->coreState.getType())
+		    .detail("KeyValueStoreType", audit->coreState.engineType.toString())
+		    .detail("DDDoAuditTaskIssue", audit->overallIssuedDoAuditCount)
+		    .detail("DDDoAuditTaskComplete", audit->overallCompleteDoAuditCount)
+		    .detail("DDDoAuditTaskSkip", audit->overallSkippedDoAuditCount);
+		audit->auditStorageAnyChildFailed = true;
+	}
+	return Void();
+}
+
 // Request SS to do the audit
 // This actor is the only interface to SS to do the audit for
 // all audit types
@@ -2802,6 +2916,7 @@ ACTOR Future<Void> doAuditOnStorageServer(Reference<DataDistributor> self,
 	    .detail("AuditID", req.id)
 	    .detail("Range", req.range)
 	    .detail("AuditType", auditType)
+	    .detail("KeyValueStoreType", audit->coreState.engineType.toString())
 	    .detail("StorageServer", ssi.toString())
 	    .detail("TargetServers", describe(req.targetServers))
 	    .detail("DDDoAuditTaskIssue", audit->overallIssuedDoAuditCount)
@@ -2820,10 +2935,12 @@ ACTOR Future<Void> doAuditOnStorageServer(Reference<DataDistributor> self,
 		    .detail("AuditID", req.id)
 		    .detail("Range", req.range)
 		    .detail("AuditType", auditType)
+		    .detail("KeyValueStoreType", audit->coreState.engineType.toString())
 		    .detail("StorageServer", ssi.toString())
 		    .detail("TargetServers", describe(req.targetServers))
 		    .detail("DDDoAuditTaskIssue", audit->overallIssuedDoAuditCount)
-		    .detail("DDDoAuditTaskComplete", audit->overallCompleteDoAuditCount);
+		    .detail("DDDoAuditTaskComplete", audit->overallCompleteDoAuditCount)
+		    .detail("DDDoAuditTaskSkip", audit->overallSkippedDoAuditCount);
 		audit->remainingBudgetForAuditTasks.set(audit->remainingBudgetForAuditTasks.get() + 1);
 		ASSERT(audit->remainingBudgetForAuditTasks.get() <= SERVER_KNOBS->CONCURRENT_AUDIT_TASK_COUNT_MAX);
 		TraceEvent(SevDebug, "RemainingBudgetForAuditTasks")
@@ -2840,10 +2957,12 @@ ACTOR Future<Void> doAuditOnStorageServer(Reference<DataDistributor> self,
 		    .detail("AuditID", req.id)
 		    .detail("Range", req.range)
 		    .detail("AuditType", auditType)
+		    .detail("KeyValueStoreType", audit->coreState.engineType.toString())
 		    .detail("StorageServer", ssi.toString())
 		    .detail("TargetServers", describe(req.targetServers))
 		    .detail("DDDoAuditTaskIssue", audit->overallIssuedDoAuditCount)
-		    .detail("DDDoAuditTaskComplete", audit->overallCompleteDoAuditCount);
+		    .detail("DDDoAuditTaskComplete", audit->overallCompleteDoAuditCount)
+		    .detail("DDDoAuditTaskSkip", audit->overallSkippedDoAuditCount);
 		audit->remainingBudgetForAuditTasks.set(audit->remainingBudgetForAuditTasks.get() + 1);
 		ASSERT(audit->remainingBudgetForAuditTasks.get() <= SERVER_KNOBS->CONCURRENT_AUDIT_TASK_COUNT_MAX);
 		TraceEvent(SevDebug, "RemainingBudgetForAuditTasks")

--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -1202,7 +1202,7 @@ ACTOR Future<Void> auditStorageCorrectness(Reference<AsyncVar<ServerDBInfo>> dbI
 			       !dbInfo->get().distributor.present()) {
 				wait(dbInfo->onChange());
 			}
-			TriggerAuditRequest req(auditType, allKeys);
+			TriggerAuditRequest req(auditType, allKeys, KeyValueStoreType::END); // do not specify engine type to check
 			UID auditId_ = wait(timeoutError(dbInfo->get().distributor.get().triggerAudit.getReply(req), 300));
 			auditId = auditId_;
 			TraceEvent(SevDebug, "AuditStorageCorrectnessTriggered")

--- a/fdbserver/workloads/ValidateStorage.actor.cpp
+++ b/fdbserver/workloads/ValidateStorage.actor.cpp
@@ -113,6 +113,7 @@ struct ValidateStorage : TestWorkload {
 				UID auditId_ = wait(auditStorage(cx->getConnectionRecord(),
 				                                 auditRange,
 				                                 type,
+				                                 KeyValueStoreType::END, // do not specific any storage engine to check
 				                                 /*timeoutSecond=*/300));
 				auditId = auditId_;
 				TraceEvent("TestAuditStorageTriggered")

--- a/fdbserver/workloads/ValidateStorage.actor.cpp
+++ b/fdbserver/workloads/ValidateStorage.actor.cpp
@@ -108,18 +108,24 @@ struct ValidateStorage : TestWorkload {
 	                                             KeyRange auditRange = allKeys) {
 		// Send audit request until the cluster accepts the request
 		state UID auditId;
+		std::vector<KeyValueStoreType> storageEngineCollection = { KeyValueStoreType::SSD_ROCKSDB_V1,
+			                                                       KeyValueStoreType::SSD_SHARDED_ROCKSDB,
+			                                                       KeyValueStoreType::SSD_BTREE_V2,
+			                                                       KeyValueStoreType::END };
+		state KeyValueStoreType storageEngine = deterministicRandom()->randomChoice(storageEngineCollection);
 		loop {
 			try {
 				UID auditId_ = wait(auditStorage(cx->getConnectionRecord(),
 				                                 auditRange,
 				                                 type,
-				                                 KeyValueStoreType::END, // do not specific any storage engine to check
+				                                 storageEngine,
 				                                 /*timeoutSecond=*/300));
 				auditId = auditId_;
 				TraceEvent("TestAuditStorageTriggered")
 				    .detail("Context", context)
 				    .detail("AuditID", auditId)
 				    .detail("AuditType", type)
+				    .detail("AuditStorageEngine", storageEngine)
 				    .detail("AuditRange", auditRange);
 				break;
 			} catch (Error& e) {
@@ -127,6 +133,7 @@ struct ValidateStorage : TestWorkload {
 				    .errorUnsuppressed(e)
 				    .detail("Context", context)
 				    .detail("AuditType", type)
+				    .detail("AuditStorageEngine", storageEngine)
 				    .detail("AuditRange", auditRange);
 				if (auditRange.empty() && e.code() == error_code_audit_storage_failed) {
 					break;


### PR DESCRIPTION
Allow users to specify the storage engine type when triggering auditStorage for `ha` and `replica`. Given an engine type, the auditStorage checks a range if the range is owned by a server which is using the specified engine. If no engine type specified, the auditStorage checks all ranges. Currently, `sqlite`, `rocksdb`, and `shardedrocksdb` engine types are supported.

100K correctness test with 3 irrelevant failures
  20230823-030512-zhewang-1d52e021c28d5b2c           compressed=True data_size=34669011 duration=7414677 ended=100000 fail=3 fail_fast=10 max_runs=100000 pass=99997 priority=100 remaining=0 runtime=1:01:15 sanity=False started=100000 stopped=20230823-040627 submitted=20230823-030512 timeout=5400 username=zhewang

100K validateStorage test
  20230823-024949-zhewang-be54b671437f2ec0           compressed=True data_size=34698505 duration=9672187 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:59:19 sanity=False started=100000 stopped=20230823-034908 submitted=20230823-024949 timeout=5400 username=zhewang

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
