### PR TITLE
Disable more RocksDB tests due to timeout issue

### DIFF
--- a/tests/rare/CheckRelocation.toml
+++ b/tests/rare/CheckRelocation.toml
@@ -1,3 +1,6 @@
+[configuration]
+storageEngineExcludeTypes = [5]
+
 [[test]]
 testTitle = 'RandomReadWriteTest'
 simCheckRelocationDuration = true

--- a/tests/rare/LargeApiCorrectness.toml
+++ b/tests/rare/LargeApiCorrectness.toml
@@ -1,3 +1,6 @@
+[configuration]
+storageEngineExcludeTypes = [5]
+
 [[test]]
 testTitle = 'ApiCorrectnessTest'
 clearAfterTest = true

--- a/tests/rare/LargeApiCorrectnessStatus.toml
+++ b/tests/rare/LargeApiCorrectnessStatus.toml
@@ -1,3 +1,6 @@
+[configuration]
+storageEngineExcludeTypes = [5]
+
 [[test]]
 testTitle = 'ApiCorrectnessTest'
 clearAfterTest = true

--- a/tests/slow/ApiCorrectnessAtomicRestore.toml
+++ b/tests/slow/ApiCorrectnessAtomicRestore.toml
@@ -1,6 +1,7 @@
 [configuration]
 # Tenant lookups fail during the atomic restore because they aren't affected by locking
 allowDefaultTenant = false
+storageEngineExcludeTypes = [5]
 
 [[knobs]]
 rocksdb_read_value_timeout=300.0

--- a/tests/slow/DDBalanceAndRemove.toml
+++ b/tests/slow/DDBalanceAndRemove.toml
@@ -1,3 +1,6 @@
+[configuration]
+storageEngineExcludeTypes = [5]
+
 [[test]]
 testTitle = 'DDBalance_Test'
 

--- a/tests/slow/SharedDefaultBackupCorrectness.toml
+++ b/tests/slow/SharedDefaultBackupCorrectness.toml
@@ -2,6 +2,7 @@
 extraDatabaseMode = 'Single'
 # required tenant mode is not supported for Disaster Recovery yet
 tenantModes = ['disabled', 'optional']
+storageEngineExcludeTypes = [5]
 
 [[test]]
 testTitle = 'SharedDefaultBackupToFileThenDB'


### PR DESCRIPTION
Found from gcc nightly

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
