### PR TITLE
Prevent Status actor from bubbling up timeout error

### DIFF
--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -3393,9 +3393,14 @@ ACTOR Future<StatusReply> clusterGetStatus(
 			state std::vector<JsonBuilderObject> workerStatuses = wait(getAll(futures2));
 			wait(success(primaryDCFO));
 
-			std::vector<NetworkAddress> addresses =
-			    wait(timeoutError(coordinators.ccr->getConnectionString().tryResolveHostnames(), 5.0));
-			coordinatorAddresses = std::move(addresses);
+			ErrorOr<std::vector<NetworkAddress>> addresses =
+			    wait(errorOr(timeoutError(coordinators.ccr->getConnectionString().tryResolveHostnames(), 5.0)));
+			if (addresses.present()) {
+				coordinatorAddresses = std::move(addresses.get());
+			} else {
+				messages.push_back(
+				    JsonString::makeMessage("fetch_coordinator_addresses", "Fetching coordinator addresses timed out"));
+			}
 
 			int logFaultTolerance = 100;
 			if (db->get().recoveryState >= RecoveryState::ACCEPTING_COMMITS) {
@@ -3573,14 +3578,25 @@ ACTOR Future<StatusReply> clusterGetStatus(
 		statusObj["clients"] = clientStatusFetcher(clientStatus);
 
 		if (configuration.present() && configuration.get().blobGranulesEnabled) {
-			JsonBuilderObject blobGranuelsStatus = wait(
+			ErrorOr<JsonBuilderObject> blobGranulesStatus = wait(errorOr(
 			    timeoutError(blobGranulesStatusFetcher(
 			                     cx, db->get().blobManager, blobWorkers, address_workers, &status_incomplete_reasons),
-			                 2.0));
-			statusObj["blob_granules"] = blobGranuelsStatus;
-			JsonBuilderObject blobRestoreStatus =
-			    wait(timeoutError(blobRestoreStatusFetcher(cx, &status_incomplete_reasons), 2.0));
-			statusObj["blob_restore"] = blobRestoreStatus;
+			                 2.0)));
+			if (blobGranulesStatus.present()) {
+				statusObj["blob_granules"] = blobGranulesStatus.get();
+			} else {
+				messages.push_back(JsonString::makeMessage("fetch_blob_granule_status_timed_out",
+				                                           "Fetch BlobGranule status timed out."));
+			}
+
+			ErrorOr<JsonBuilderObject> blobRestoreStatus =
+			    wait(errorOr(timeoutError(blobRestoreStatusFetcher(cx, &status_incomplete_reasons), 2.0)));
+			if (blobRestoreStatus.present()) {
+				statusObj["blob_restore"] = blobRestoreStatus.get();
+			} else {
+				messages.push_back(JsonString::makeMessage("fetch_blob_restore_status_timed_out",
+				                                           "Fetch BlobRestore status timed out."));
+			}
 		}
 
 		JsonBuilderArray incompatibleConnectionsArray;


### PR DESCRIPTION
Description

Patch addresses occurrences where Status.actor ends up bubbling timeout error up to the ClusterController causing recovery to be triggered when ClusterGetStatus timeout for some reason.

Testing

Replace this text with your description here...

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
