### PR TITLE
Catch initial flush error and avoid crashing blob manager

### DIFF
--- a/fdbserver/BlobManager.actor.cpp
+++ b/fdbserver/BlobManager.actor.cpp
@@ -5683,6 +5683,45 @@ ACTOR Future<Void> updateLastFlushVersion(Database db, Version flushVersion) {
 	return Void();
 }
 
+// Flush a blob range and retry for non-fatal errors
+ACTOR Future<Void> tryFlushRange(Reference<BlobManagerData> bmData, KeyRange range, Version logEndVersion) {
+	state int retryCount = 0;
+	loop {
+		try {
+			FlushGranuleRequest req(bmData->epoch, range, logEndVersion, false);
+			wait(success(doBlobGranuleRequests(bmData->db, range, req, &BlobWorkerInterface::flushGranuleRequest)));
+			return Void();
+		} catch (Error& e) {
+			if (e.code() != error_code_blob_granule_transaction_too_old) {
+				throw; // terminate for unretryable error
+			}
+
+			// check if the range is blobified and then decide retry or skip.
+			// it may take long time to flush the whole key range and some ranges may have been unblobified or purged.
+			// so we try to check that first when seeing non-fatal errors
+			bool knownRange = false;
+			for (auto& r : bmData->knownBlobRanges.intersectingRanges(range)) {
+				if (r.value()) {
+					knownRange = true;
+					break;
+				}
+			}
+			if (knownRange) {
+				TraceEvent(retryCount > 100 ? SevError : SevInfo, "BlobGranulesFlushRetry")
+				    .detail("Range", range)
+				    .detail("Version", logEndVersion);
+				CODE_PROBE(true, "Retry blob granule flush", probe::decoration::rare);
+				wait(delayJittered(1));
+				++retryCount;
+			} else {
+				TraceEvent("BlobGranulesFlushSkip").detail("Range", range).detail("Version", logEndVersion);
+				CODE_PROBE(true, "Skip blob granule flush", probe::decoration::rare);
+				return Void();
+			}
+		}
+	}
+}
+
 // Try to flush blob granules. Return the flushed version if it's successful.
 ACTOR Future<Version> maybeFlushGranules(Reference<BlobManagerData> bmData) {
 	state BlobGranuleBackupConfig config;
@@ -5716,9 +5755,7 @@ ACTOR Future<Version> maybeFlushGranules(Reference<BlobManagerData> bmData) {
 	TraceEvent("FlushingBlobGranules").detail("Ranges", flushRanges.size());
 	state std::vector<Future<Void>> futures;
 	for (auto& range : flushRanges) {
-		FlushGranuleRequest req(bmData->epoch, range, logEndVersion, false);
-		Future<Void> future =
-		    success(doBlobGranuleRequests(bmData->db, range, req, &BlobWorkerInterface::flushGranuleRequest));
+		Future<Void> future = tryFlushRange(bmData, range, logEndVersion);
 		futures.push_back(future);
 		if (futures.size() > SERVER_KNOBS->BLOB_GRANULES_FLUSH_BATCH_SIZE) {
 			wait(waitForAll(futures));


### PR DESCRIPTION
Flushing may throw errors in some race conditions. we can catch the error and retry after. No need to crash blob manager

100k correctness test passed - 20230825-000758-huliu-52be0338639e10bb

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
