### PR TITLE
[release 7.3] Revert the latest "Refactor healthMonitor in worker.actor.cpp"

### DIFF
--- a/fdbserver/worker.actor.cpp
+++ b/fdbserver/worker.actor.cpp
@@ -1097,12 +1097,44 @@ TEST_CASE("/fdbserver/worker/addressIsRemoteLogRouter") {
 
 } // namespace
 
-// Check if the current worker is a transaction worker, and is experiencing degraded or disconnected peers. If so,
-// report degraded and disconnected peers to the cluster controller.
-void doPeerHealthCheck(Reference<AsyncVar<Optional<ClusterControllerFullInterface>> const> ccInterface,
-                       const WorkerInterface& interf,
-                       const LocalityData& locality,
-                       Reference<AsyncVar<ServerDBInfo> const> dbInfo) {
+// Returns true if the `peer` has enough measurement samples that should be checked by the health monitor.
+bool shouldCheckPeer(Reference<Peer> peer) {
+	if (peer->connectFailedCount != 0) {
+		return true;
+	}
+
+	if (peer->pingLatencies.getPopulationSize() >= SERVER_KNOBS->PEER_LATENCY_CHECK_MIN_POPULATION) {
+		// Ignore peers that don't have enough samples.
+		// TODO(zhewu): Currently, FlowTransport latency monitor clears ping latency samples on a
+		// regular basis, which may affect the measurement count. Currently,
+		// WORKER_HEALTH_MONITOR_INTERVAL is much smaller than the ping clearance interval, so it may be
+		// ok. If this ends to be a problem, we need to consider keep track of last ping latencies
+		// logged.
+		return true;
+	}
+
+	return false;
+}
+
+// Returns true if `address` is a degraded/disconnected peer in `lastReq` sent to CC.
+bool isDegradedPeer(const UpdateWorkerHealthRequest& lastReq, const NetworkAddress& address) {
+	if (std::find(lastReq.degradedPeers.begin(), lastReq.degradedPeers.end(), address) != lastReq.degradedPeers.end()) {
+		return true;
+	}
+
+	if (std::find(lastReq.disconnectedPeers.begin(), lastReq.disconnectedPeers.end(), address) !=
+	    lastReq.disconnectedPeers.end()) {
+		return true;
+	}
+
+	return false;
+}
+
+// Check if the current worker is a transaction worker, and is experiencing degraded or disconnected peers.
+UpdateWorkerHealthRequest doPeerHealthCheck(const WorkerInterface& interf,
+                                            const LocalityData& locality,
+                                            Reference<AsyncVar<ServerDBInfo> const> dbInfo,
+                                            const UpdateWorkerHealthRequest& lastReq) {
 	const auto& allPeers = FlowTransport::transport().getAllPeers();
 
 	// Check remote log router connectivity only when remote TLogs are recruited and in use.
@@ -1122,18 +1154,11 @@ void doPeerHealthCheck(Reference<AsyncVar<Optional<ClusterControllerFullInterfac
 
 	if (workerLocation == None) {
 		// This worker doesn't need to monitor anything if it is in remote satellite.
-		return;
+		return req;
 	}
 
 	for (const auto& [address, peer] : allPeers) {
-		if (peer->connectFailedCount == 0 &&
-		    peer->pingLatencies.getPopulationSize() < SERVER_KNOBS->PEER_LATENCY_CHECK_MIN_POPULATION) {
-			// Ignore peers that don't have enough samples.
-			// TODO(zhewu): Currently, FlowTransport latency monitor clears ping latency samples on a
-			// regular basis, which may affect the measurement count. Currently,
-			// WORKER_HEALTH_MONITOR_INTERVAL is much smaller than the ping clearance interval, so it may be
-			// ok. If this ends to be a problem, we need to consider keep track of last ping latencies
-			// logged.
+		if (!shouldCheckPeer(peer)) {
 			continue;
 		}
 
@@ -1228,6 +1253,9 @@ void doPeerHealthCheck(Reference<AsyncVar<Optional<ClusterControllerFullInterfac
 			req.disconnectedPeers.push_back(address);
 		} else if (degradedPeer) {
 			req.degradedPeers.push_back(address);
+		} else if (isDegradedPeer(lastReq, address)) {
+			TraceEvent("HealthMonitorDetectRecoveredPeer").detail("Peer", address);
+			req.recoveredPeers.push_back(address);
 		}
 	}
 
@@ -1237,6 +1265,8 @@ void doPeerHealthCheck(Reference<AsyncVar<Optional<ClusterControllerFullInterfac
 		// transport's health monitor. Note that all the closed peers stored here are caused by connection
 		// failure, but not normal connection close. Therefore, we report all such peers if they are also
 		// part of the transaction sub system.
+		// Note that we don't need to calculate recovered peer in this case since all the recently closed peers are
+		// considered permanently closed peers.
 		for (const auto& address : FlowTransport::transport().healthMonitor()->getRecentClosedPeers()) {
 			if (allPeers.find(address) != allPeers.end()) {
 				// We have checked this peer in the above for loop.
@@ -1254,11 +1284,25 @@ void doPeerHealthCheck(Reference<AsyncVar<Optional<ClusterControllerFullInterfac
 		}
 	}
 
-	if (!req.disconnectedPeers.empty() || !req.degradedPeers.empty()) {
-		// Disconnected or degraded peers are reported to the cluster controller.
-		req.address = FlowTransport::transport().getLocalAddress();
-		ccInterface->get().get().updateWorkerHealth.send(req);
+	if (g_network->isSimulated()) {
+		// Invariant check in simulation: for any peers that shouldn't be checked, we won't include it in the
+		// UpdateWorkerHealthRequest sent to CC.
+		for (const auto& [address, peer] : allPeers) {
+			if (!shouldCheckPeer(peer)) {
+				for (const auto& disconnectedPeer : req.disconnectedPeers) {
+					ASSERT(address != disconnectedPeer);
+				}
+				for (const auto& degradedPeer : req.degradedPeers) {
+					ASSERT(address != degradedPeer);
+				}
+				for (const auto& recoveredPeer : req.recoveredPeers) {
+					ASSERT(address != recoveredPeer);
+				}
+			}
+		}
 	}
+
+	return req;
 }
 
 // The actor that actively monitors the health of local and peer servers, and reports anomaly to the cluster controller.
@@ -1271,7 +1315,26 @@ ACTOR Future<Void> healthMonitor(Reference<AsyncVar<Optional<ClusterControllerFu
 		Future<Void> nextHealthCheckDelay = Never();
 		if (dbInfo->get().recoveryState >= RecoveryState::ACCEPTING_COMMITS && ccInterface->get().present()) {
 			nextHealthCheckDelay = delay(SERVER_KNOBS->WORKER_HEALTH_MONITOR_INTERVAL);
-			doPeerHealthCheck(ccInterface, interf, locality, dbInfo);
+			req = doPeerHealthCheck(interf, locality, dbInfo, req);
+
+			if (!req.disconnectedPeers.empty() || !req.degradedPeers.empty() || !req.recoveredPeers.empty()) {
+				if (g_network->isSimulated()) {
+					// Do invarant check only in simulation.
+					// Any recovered peer shouldn't appear as disconnected or degraded peer.
+					for (const auto& recoveredPeer : req.recoveredPeers) {
+						for (const auto& disconnectedPeer : req.disconnectedPeers) {
+							ASSERT(recoveredPeer != disconnectedPeer);
+						}
+						for (const auto& degradedPeer : req.degradedPeers) {
+							ASSERT(recoveredPeer != degradedPeer);
+						}
+					}
+				}
+
+				// Disconnected or degraded peers are reported to the cluster controller.
+				req.address = FlowTransport::transport().getLocalAddress();
+				ccInterface->get().get().updateWorkerHealth.send(req);
+			}
 		}
 		choose {
 			when(wait(nextHealthCheckDelay)) {}


### PR DESCRIPTION
Particularly, we want to revert commit 47ad10a3af2afd65320202bbaec1027f46f3cf66 from #10391 . This commit has been applied to release-7.3 branch in #10541 . Applied it twice reverted some of the changes in #10541 

Gray failure is currently broken in release-7.3

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
