### PR TITLE
Trace SS init progress

### DIFF
--- a/fdbserver/DDTeamCollection.actor.cpp
+++ b/fdbserver/DDTeamCollection.actor.cpp
@@ -2425,34 +2425,38 @@ public:
 			state bool doRecruit = true;
 			if (recruitTss) {
 				TraceEvent("TSS_Recruit", self->distributorId)
+				    .detail("ReqID", isr.reqId)
 				    .detail("TSSID", interfaceId)
 				    .detail("Stage", "TSSWaitingPair")
-				    .detail("Addr", candidateWorker.worker.address())
-				    .detail("Locality", candidateWorker.worker.locality.toString());
+				    .detail("TSSAddr", candidateWorker.worker.address())
+				    .detail("TSSLocality", candidateWorker.worker.locality.toString());
 
 				Optional<std::pair<UID, Version>> ssPairInfoResult = wait(tssState->waitOnSS());
 				if (ssPairInfoResult.present()) {
 					isr.tssPairIDAndVersion = ssPairInfoResult.get();
 
 					TraceEvent("TSS_Recruit", self->distributorId)
+					    .detail("ReqID", isr.reqId)
 					    .detail("SSID", ssPairInfoResult.get().first)
 					    .detail("TSSID", interfaceId)
-					    .detail("Stage", "TSSWaitingPair")
-					    .detail("Addr", candidateWorker.worker.address())
-					    .detail("Version", ssPairInfoResult.get().second)
-					    .detail("Locality", candidateWorker.worker.locality.toString());
+					    .detail("Stage", "TSSGotPair")
+					    .detail("TSSAddr", candidateWorker.worker.address())
+					    .detail("SSVersion", ssPairInfoResult.get().second)
+					    .detail("TSSLocality", candidateWorker.worker.locality.toString());
 				} else {
 					doRecruit = false;
 
 					TraceEvent(SevWarnAlways, "TSS_RecruitError", self->distributorId)
+					    .detail("ReqID", isr.reqId)
 					    .detail("TSSID", interfaceId)
-					    .detail("Reason", "SS recruitment failed for some reason")
-					    .detail("Addr", candidateWorker.worker.address())
-					    .detail("Locality", candidateWorker.worker.locality.toString());
+					    .detail("Reason", "TSS failed to get SS pair for some reason")
+					    .detail("TSSAddr", candidateWorker.worker.address())
+					    .detail("TSSLocality", candidateWorker.worker.locality.toString());
 				}
 			}
 
 			TraceEvent("DDRecruiting")
+			    .detail("ReqID", isr.reqId)
 			    .detail("Primary", self->primary)
 			    .detail("State", "Sending request to worker")
 			    .detail("WorkerID", candidateWorker.worker.id())
@@ -2460,7 +2464,8 @@ public:
 			    .detail("Interf", interfaceId)
 			    .detail("Addr", candidateWorker.worker.address())
 			    .detail("TSS", recruitTss ? "true" : "false")
-			    .detail("RecruitingStream", self->recruitingStream.get());
+			    .detail("RecruitingStream", self->recruitingStream.get())
+			    .detail("StoreType", isr.storeType);
 
 			Future<ErrorOr<InitializeStorageReply>> fRecruit =
 			    doRecruit
@@ -2484,10 +2489,11 @@ public:
 				// SS has a tss pair. send it this id, but try to wait for add server until tss is recruited
 
 				TraceEvent("TSS_Recruit", self->distributorId)
+				    .detail("ReqID", isr.reqId)
 				    .detail("SSID", interfaceId)
 				    .detail("Stage", "SSSignaling")
-				    .detail("Addr", candidateWorker.worker.address())
-				    .detail("Locality", candidateWorker.worker.locality.toString());
+				    .detail("SSAddr", candidateWorker.worker.address())
+				    .detail("SSLocality", candidateWorker.worker.locality.toString());
 
 				// wait for timeout, but eventually move on if no TSS pair recruited
 				Optional<bool> tssSuccessful =
@@ -2495,18 +2501,20 @@ public:
 
 				if (tssSuccessful.present() && tssSuccessful.get()) {
 					TraceEvent("TSS_Recruit", self->distributorId)
+					    .detail("ReqID", isr.reqId)
 					    .detail("SSID", interfaceId)
 					    .detail("Stage", "SSGotPair")
-					    .detail("Addr", candidateWorker.worker.address())
-					    .detail("Locality", candidateWorker.worker.locality.toString());
+					    .detail("SSAddr", candidateWorker.worker.address())
+					    .detail("SSLocality", candidateWorker.worker.locality.toString());
 				} else {
 					TraceEvent(SevWarn, "TSS_RecruitError", self->distributorId)
+					    .detail("ReqID", isr.reqId)
 					    .detail("SSID", interfaceId)
 					    .detail("Reason",
 					            tssSuccessful.present() ? "TSS recruitment failed for some reason"
 					                                    : "TSS recruitment timed out")
-					    .detail("Addr", candidateWorker.worker.address())
-					    .detail("Locality", candidateWorker.worker.locality.toString());
+					    .detail("SSAddr", candidateWorker.worker.address())
+					    .detail("SSLocality", candidateWorker.worker.locality.toString());
 				}
 			}
 
@@ -2514,6 +2522,7 @@ public:
 			self->recruitingLocalities.erase(candidateWorker.worker.stableAddress());
 
 			TraceEvent("DDRecruiting")
+			    .detail("ReqID", isr.reqId)
 			    .detail("Primary", self->primary)
 			    .detail("State", "Finished request")
 			    .detail("WorkerID", candidateWorker.worker.id())
@@ -2521,6 +2530,7 @@ public:
 			    .detail("Interf", interfaceId)
 			    .detail("Addr", candidateWorker.worker.address())
 			    .detail("RecruitingStream", self->recruitingStream.get())
+			    .detail("TSS", recruitTss ? "true" : "false")
 			    .detail("StoreType", isr.storeType);
 
 			if (newServer.present()) {
@@ -2532,12 +2542,24 @@ public:
 						                self->serverTrackerErrorOut,
 						                newServer.get().addedVersion,
 						                *ddEnabledState);
+						TraceEvent("DDRecruiting")
+						    .detail("ReqID", isr.reqId)
+						    .detail("Primary", self->primary)
+						    .detail("State", "Add new SS to DD")
+						    .detail("WorkerID", candidateWorker.worker.id())
+						    .detail("WorkerLocality", candidateWorker.worker.locality.toString())
+						    .detail("Interf", interfaceId)
+						    .detail("Addr", candidateWorker.worker.address())
+						    .detail("RecruitingStream", self->recruitingStream.get())
+						    .detail("TSS", recruitTss ? "true" : "false")
+						    .detail("StoreType", isr.storeType);
 						self->waitUntilRecruited.set(false);
 						// signal all done after adding tss to tracking info
 						tssState->markComplete();
 					}
 				} else {
 					TraceEvent(SevWarn, "DDRecruitmentError")
+					    .detail("ReqID", isr.reqId)
 					    .detail("Reason", "Server ID already recruited")
 					    .detail("ServerID", id);
 				}

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -14332,6 +14332,9 @@ ACTOR Future<Void> storageServer(IKeyValueStore* persistentData,
 		self.setTssPair(ssi.tssPairID.get());
 		ASSERT(self.isTss());
 	}
+	TraceEvent("StorageServerInitProgress", ssi.id())
+	    .detail("EngineType", self.storage.getKeyValueStoreType().toString())
+	    .detail("Step", "Start");
 
 	self.sk = serverKeysPrefixFor(self.tssPairID.present() ? self.tssPairID.get() : self.thisServerID)
 	              .withPrefix(systemKeys.begin); // FFFF/serverKeys/[this server]/
@@ -14341,7 +14344,13 @@ ACTOR Future<Void> storageServer(IKeyValueStore* persistentData,
 
 	try {
 		wait(self.storage.init());
+		TraceEvent("StorageServerInitProgress", ssi.id())
+		    .detail("EngineType", self.storage.getKeyValueStoreType().toString())
+		    .detail("Step", "StorageInited");
 		wait(self.storage.commit());
+		TraceEvent("StorageServerInitProgress", ssi.id())
+		    .detail("EngineType", self.storage.getKeyValueStoreType().toString())
+		    .detail("Step", "StorageCommitted");
 		++self.counters.kvCommits;
 
 		platform::createDirectory(self.checkpointFolder);
@@ -14356,6 +14365,9 @@ ACTOR Future<Void> storageServer(IKeyValueStore* persistentData,
 
 			// Might throw recruitment_failed in case of simultaneous master failure
 			std::pair<Version, Tag> verAndTag = wait(addStorageServer(self.cx, ssi));
+			TraceEvent("StorageServerInitProgress", ssi.id())
+			    .detail("EngineType", self.storage.getKeyValueStoreType().toString())
+			    .detail("Step", "StorageServerAdded");
 
 			self.tag = verAndTag.second;
 			if (ssi.isTss()) {
@@ -14365,12 +14377,18 @@ ACTOR Future<Void> storageServer(IKeyValueStore* persistentData,
 			}
 
 			wait(initTenantMap(&self));
+			TraceEvent("StorageServerInitProgress", ssi.id())
+			    .detail("EngineType", self.storage.getKeyValueStoreType().toString())
+			    .detail("Step", "TenantMapInited");
 		} else {
 			self.tag = seedTag;
 		}
 
 		self.storage.makeNewStorageServerDurable(self.shardAware);
 		wait(self.storage.commit());
+		TraceEvent("StorageServerInitProgress", ssi.id())
+		    .detail("EngineType", self.storage.getKeyValueStoreType().toString())
+		    .detail("Step", "NewStorageServerDurable");
 		++self.counters.kvCommits;
 
 		self.interfaceRegistered =
@@ -14378,6 +14396,7 @@ ACTOR Future<Void> storageServer(IKeyValueStore* persistentData,
 		wait(delay(0));
 
 		TraceEvent("StorageServerInit", ssi.id())
+		    .detail("EngineType", self.storage.getKeyValueStoreType().toString())
 		    .detail("Version", self.version.get())
 		    .detail("SeedTag", seedTag.toString())
 		    .detail("TssPair", ssi.isTss() ? ssi.tssPairID.get().toString() : "");

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -14334,7 +14334,7 @@ ACTOR Future<Void> storageServer(IKeyValueStore* persistentData,
 	}
 	TraceEvent("StorageServerInitProgress", ssi.id())
 	    .detail("EngineType", self.storage.getKeyValueStoreType().toString())
-	    .detail("Step", "Start");
+	    .detail("Step", "5.StartInit");
 
 	self.sk = serverKeysPrefixFor(self.tssPairID.present() ? self.tssPairID.get() : self.thisServerID)
 	              .withPrefix(systemKeys.begin); // FFFF/serverKeys/[this server]/
@@ -14346,11 +14346,11 @@ ACTOR Future<Void> storageServer(IKeyValueStore* persistentData,
 		wait(self.storage.init());
 		TraceEvent("StorageServerInitProgress", ssi.id())
 		    .detail("EngineType", self.storage.getKeyValueStoreType().toString())
-		    .detail("Step", "StorageInited");
+		    .detail("Step", "6.StorageInited");
 		wait(self.storage.commit());
 		TraceEvent("StorageServerInitProgress", ssi.id())
 		    .detail("EngineType", self.storage.getKeyValueStoreType().toString())
-		    .detail("Step", "StorageCommitted");
+		    .detail("Step", "7.StorageCommitted");
 		++self.counters.kvCommits;
 
 		platform::createDirectory(self.checkpointFolder);
@@ -14367,7 +14367,7 @@ ACTOR Future<Void> storageServer(IKeyValueStore* persistentData,
 			std::pair<Version, Tag> verAndTag = wait(addStorageServer(self.cx, ssi));
 			TraceEvent("StorageServerInitProgress", ssi.id())
 			    .detail("EngineType", self.storage.getKeyValueStoreType().toString())
-			    .detail("Step", "StorageServerAdded");
+			    .detail("Step", "8.StorageServerAdded");
 
 			self.tag = verAndTag.second;
 			if (ssi.isTss()) {
@@ -14379,7 +14379,7 @@ ACTOR Future<Void> storageServer(IKeyValueStore* persistentData,
 			wait(initTenantMap(&self));
 			TraceEvent("StorageServerInitProgress", ssi.id())
 			    .detail("EngineType", self.storage.getKeyValueStoreType().toString())
-			    .detail("Step", "TenantMapInited");
+			    .detail("Step", "9.TenantMapInited");
 		} else {
 			self.tag = seedTag;
 		}
@@ -14388,7 +14388,7 @@ ACTOR Future<Void> storageServer(IKeyValueStore* persistentData,
 		wait(self.storage.commit());
 		TraceEvent("StorageServerInitProgress", ssi.id())
 		    .detail("EngineType", self.storage.getKeyValueStoreType().toString())
-		    .detail("Step", "NewStorageServerDurable");
+		    .detail("Step", "10.NewStorageServerDurable");
 		++self.counters.kvCommits;
 
 		self.interfaceRegistered =
@@ -14405,6 +14405,9 @@ ACTOR Future<Void> storageServer(IKeyValueStore* persistentData,
 		rep.addedVersion = self.version.get();
 		recruitReply.send(rep);
 		self.byteSampleRecovery = Void();
+		TraceEvent("StorageServerInitProgress", ssi.id())
+		    .detail("EngineType", self.storage.getKeyValueStoreType().toString())
+		    .detail("Step", "11.RecruitReplied");
 
 		ssCore = storageServerCore(&self, ssi);
 		wait(ssCore);

--- a/fdbserver/worker.actor.cpp
+++ b/fdbserver/worker.actor.cpp
@@ -1566,7 +1566,7 @@ struct TrackRunningStorage {
 	                    std::unordered_map<UID, StorageDiskCleaner>* storageCleaners)
 	  : self(self), storeType(storeType), locality(locality), filename(filename), runningStorages(runningStorages),
 	    storageCleaners(storageCleaners) {
-		TraceEvent("StorageServerInitProgress", self).detail("Step", "AddedItselfToRunningStorageOnSameWorker");
+		TraceEvent("StorageServerInitProgress", self).detail("Step", "4.AddedItselfToRunningStorageOnSameWorker");
 		runningStorages->emplace(self, storeType);
 	}
 	~TrackRunningStorage() {
@@ -2928,8 +2928,9 @@ ACTOR Future<Void> workerServer(Reference<IClusterConnectionRecord> connRecord,
 				activeSharedTLog->set(logData.back().uid);
 			}
 			when(InitializeStorageRequest req = waitNext(interf.storage.getFuture())) {
-				TraceEvent e("StorageServerInitProgress", req.reqId);
-				e.detail("Step", "RequestReceived");
+				TraceEvent e("StorageServerInitProgress", req.interfaceId);
+				e.detail("Step", "1.RequestReceived");
+				e.detail("ReqID", req.reqId);
 				e.detail("WorkerID", interf.id());
 				e.detail("StorageType", req.storeType.toString());
 				e.detail("SeedTag", req.seedTag.toString());
@@ -2976,8 +2977,9 @@ ACTOR Future<Void> workerServer(Reference<IClusterConnectionRecord> connRecord,
 					Role ssRole = isTss ? Role::TESTING_STORAGE_SERVER : Role::STORAGE_SERVER;
 					startRole(ssRole, recruited.id(), interf.id(), details);
 					TraceEvent("StorageServerInitProgress", recruited.id())
+					    .detail("ReqID", req.reqId)
 					    .detail("StorageType", req.storeType.toString())
-					    .detail("Step", "RoleStarted")
+					    .detail("Step", "2.RoleStarted")
 					    .detail("WorkerID", interf.id());
 
 					DUMPTOKEN(recruited.getValue);
@@ -3020,8 +3022,9 @@ ACTOR Future<Void> workerServer(Reference<IClusterConnectionRecord> connRecord,
 					    dbInfo,
 					    req.encryptMode);
 					TraceEvent("StorageServerInitProgress", recruited.id())
+					    .detail("ReqID", req.reqId)
 					    .detail("StorageType", req.storeType.toString())
-					    .detail("Step", "KVStoreOpened")
+					    .detail("Step", "3.KVStoreOpened")
 					    .detail("WorkerID", interf.id());
 
 					Future<Void> kvClosed =

--- a/fdbserver/worker.actor.cpp
+++ b/fdbserver/worker.actor.cpp
@@ -1566,6 +1566,7 @@ struct TrackRunningStorage {
 	                    std::unordered_map<UID, StorageDiskCleaner>* storageCleaners)
 	  : self(self), storeType(storeType), locality(locality), filename(filename), runningStorages(runningStorages),
 	    storageCleaners(storageCleaners) {
+		TraceEvent("StorageServerInitProgress", self).detail("Step", "AddedItselfToRunningStorageOnSameWorker");
 		runningStorages->emplace(self, storeType);
 	}
 	~TrackRunningStorage() {
@@ -2927,6 +2928,21 @@ ACTOR Future<Void> workerServer(Reference<IClusterConnectionRecord> connRecord,
 				activeSharedTLog->set(logData.back().uid);
 			}
 			when(InitializeStorageRequest req = waitNext(interf.storage.getFuture())) {
+				TraceEvent e("StorageServerInitProgress", req.reqId);
+				e.detail("Step", "RequestReceived");
+				e.detail("WorkerID", interf.id());
+				e.detail("StorageType", req.storeType.toString());
+				e.detail("SeedTag", req.seedTag.toString());
+				e.detail("IsTssPair", req.tssPairIDAndVersion.present());
+				if (req.tssPairIDAndVersion.present()) {
+					e.detail("TssPairID", req.tssPairIDAndVersion.get().first);
+				}
+				int j = 0;
+				for (const auto& runningStorage : runningStorages) {
+					e.detail("RunningStorageIDOnSameWorker" + std::to_string(j), runningStorage.first);
+					e.detail("RunningStorageEngineOnSameWorker" + std::to_string(j), runningStorage.second);
+					j++;
+				}
 				// We want to prevent double recruiting on a worker unless we try to recruit something
 				// with a different storage engine (otherwise storage migration won't work for certain
 				// configuration). Additionally we also need to allow double recruitment for seed servers.
@@ -2959,6 +2975,10 @@ ACTOR Future<Void> workerServer(Reference<IClusterConnectionRecord> connRecord,
 					details["IsTSS"] = std::to_string(isTss);
 					Role ssRole = isTss ? Role::TESTING_STORAGE_SERVER : Role::STORAGE_SERVER;
 					startRole(ssRole, recruited.id(), interf.id(), details);
+					TraceEvent("StorageServerInitProgress", recruited.id())
+					    .detail("StorageType", req.storeType.toString())
+					    .detail("Step", "RoleStarted")
+					    .detail("WorkerID", interf.id());
 
 					DUMPTOKEN(recruited.getValue);
 					DUMPTOKEN(recruited.getKey);
@@ -2999,6 +3019,10 @@ ACTOR Future<Void> workerServer(Reference<IClusterConnectionRecord> connRecord,
 					             : true),
 					    dbInfo,
 					    req.encryptMode);
+					TraceEvent("StorageServerInitProgress", recruited.id())
+					    .detail("StorageType", req.storeType.toString())
+					    .detail("Step", "KVStoreOpened")
+					    .detail("WorkerID", interf.id());
 
 					Future<Void> kvClosed =
 					    data->onClosed() ||


### PR DESCRIPTION
This PR adds `StorageServerInitProgress` to track the progress from a worker receiving a SS recruit request to the worker completes recruitment and the SS finishes init.

The new trace event is in particular useful when we want to see if there is an existing SS init getting stuck and the worker says "AttemptedDoubleRecruitment" for the new SS request.

  20230818-230804-zhewang-cfdf06dce88911c4           compressed=True data_size=34652725 duration=6742211 ended=100000 fail=6 fail_fast=10 max_runs=100000 pass=99994 priority=100 remaining=0 runtime=1:18:10 sanity=False started=100000 stopped=20230819-002614 submitted=20230818-230804 timeout=5400 username=zhewang

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
