### PR TITLE
[Release-7.3] Cherry pick trace ss init progress

### DIFF
--- a/fdbserver/DDTeamCollection.actor.cpp
+++ b/fdbserver/DDTeamCollection.actor.cpp
@@ -2420,34 +2420,38 @@ public:
 			state bool doRecruit = true;
 			if (recruitTss) {
 				TraceEvent("TSS_Recruit", self->distributorId)
+				    .detail("ReqID", isr.reqId)
 				    .detail("TSSID", interfaceId)
 				    .detail("Stage", "TSSWaitingPair")
-				    .detail("Addr", candidateWorker.worker.address())
-				    .detail("Locality", candidateWorker.worker.locality.toString());
+				    .detail("TSSAddr", candidateWorker.worker.address())
+				    .detail("TSSLocality", candidateWorker.worker.locality.toString());
 
 				Optional<std::pair<UID, Version>> ssPairInfoResult = wait(tssState->waitOnSS());
 				if (ssPairInfoResult.present()) {
 					isr.tssPairIDAndVersion = ssPairInfoResult.get();
 
 					TraceEvent("TSS_Recruit", self->distributorId)
+					    .detail("ReqID", isr.reqId)
 					    .detail("SSID", ssPairInfoResult.get().first)
 					    .detail("TSSID", interfaceId)
-					    .detail("Stage", "TSSWaitingPair")
-					    .detail("Addr", candidateWorker.worker.address())
-					    .detail("Version", ssPairInfoResult.get().second)
-					    .detail("Locality", candidateWorker.worker.locality.toString());
+					    .detail("Stage", "TSSGotPair")
+					    .detail("TSSAddr", candidateWorker.worker.address())
+					    .detail("SSVersion", ssPairInfoResult.get().second)
+					    .detail("TSSLocality", candidateWorker.worker.locality.toString());
 				} else {
 					doRecruit = false;
 
 					TraceEvent(SevWarnAlways, "TSS_RecruitError", self->distributorId)
+					    .detail("ReqID", isr.reqId)
 					    .detail("TSSID", interfaceId)
-					    .detail("Reason", "SS recruitment failed for some reason")
-					    .detail("Addr", candidateWorker.worker.address())
-					    .detail("Locality", candidateWorker.worker.locality.toString());
+					    .detail("Reason", "TSS failed to get SS pair for some reason")
+					    .detail("TSSAddr", candidateWorker.worker.address())
+					    .detail("TSSLocality", candidateWorker.worker.locality.toString());
 				}
 			}
 
 			TraceEvent("DDRecruiting")
+			    .detail("ReqID", isr.reqId)
 			    .detail("Primary", self->primary)
 			    .detail("State", "Sending request to worker")
 			    .detail("WorkerID", candidateWorker.worker.id())
@@ -2455,7 +2459,8 @@ public:
 			    .detail("Interf", interfaceId)
 			    .detail("Addr", candidateWorker.worker.address())
 			    .detail("TSS", recruitTss ? "true" : "false")
-			    .detail("RecruitingStream", self->recruitingStream.get());
+			    .detail("RecruitingStream", self->recruitingStream.get())
+			    .detail("StoreType", isr.storeType);
 
 			Future<ErrorOr<InitializeStorageReply>> fRecruit =
 			    doRecruit
@@ -2479,10 +2484,11 @@ public:
 				// SS has a tss pair. send it this id, but try to wait for add server until tss is recruited
 
 				TraceEvent("TSS_Recruit", self->distributorId)
+				    .detail("ReqID", isr.reqId)
 				    .detail("SSID", interfaceId)
 				    .detail("Stage", "SSSignaling")
-				    .detail("Addr", candidateWorker.worker.address())
-				    .detail("Locality", candidateWorker.worker.locality.toString());
+				    .detail("SSAddr", candidateWorker.worker.address())
+				    .detail("SSLocality", candidateWorker.worker.locality.toString());
 
 				// wait for timeout, but eventually move on if no TSS pair recruited
 				Optional<bool> tssSuccessful =
@@ -2490,18 +2496,20 @@ public:
 
 				if (tssSuccessful.present() && tssSuccessful.get()) {
 					TraceEvent("TSS_Recruit", self->distributorId)
+					    .detail("ReqID", isr.reqId)
 					    .detail("SSID", interfaceId)
 					    .detail("Stage", "SSGotPair")
-					    .detail("Addr", candidateWorker.worker.address())
-					    .detail("Locality", candidateWorker.worker.locality.toString());
+					    .detail("SSAddr", candidateWorker.worker.address())
+					    .detail("SSLocality", candidateWorker.worker.locality.toString());
 				} else {
 					TraceEvent(SevWarn, "TSS_RecruitError", self->distributorId)
+					    .detail("ReqID", isr.reqId)
 					    .detail("SSID", interfaceId)
 					    .detail("Reason",
 					            tssSuccessful.present() ? "TSS recruitment failed for some reason"
 					                                    : "TSS recruitment timed out")
-					    .detail("Addr", candidateWorker.worker.address())
-					    .detail("Locality", candidateWorker.worker.locality.toString());
+					    .detail("SSAddr", candidateWorker.worker.address())
+					    .detail("SSLocality", candidateWorker.worker.locality.toString());
 				}
 			}
 
@@ -2509,13 +2517,16 @@ public:
 			self->recruitingLocalities.erase(candidateWorker.worker.stableAddress());
 
 			TraceEvent("DDRecruiting")
+			    .detail("ReqID", isr.reqId)
 			    .detail("Primary", self->primary)
 			    .detail("State", "Finished request")
 			    .detail("WorkerID", candidateWorker.worker.id())
 			    .detail("WorkerLocality", candidateWorker.worker.locality.toString())
 			    .detail("Interf", interfaceId)
 			    .detail("Addr", candidateWorker.worker.address())
-			    .detail("RecruitingStream", self->recruitingStream.get());
+			    .detail("RecruitingStream", self->recruitingStream.get())
+			    .detail("TSS", recruitTss ? "true" : "false")
+			    .detail("StoreType", isr.storeType);
 
 			if (newServer.present()) {
 				UID id = newServer.get().interf.id();
@@ -2526,12 +2537,24 @@ public:
 						                self->serverTrackerErrorOut,
 						                newServer.get().addedVersion,
 						                *ddEnabledState);
+						TraceEvent("DDRecruiting")
+						    .detail("ReqID", isr.reqId)
+						    .detail("Primary", self->primary)
+						    .detail("State", "Add new SS to DD")
+						    .detail("WorkerID", candidateWorker.worker.id())
+						    .detail("WorkerLocality", candidateWorker.worker.locality.toString())
+						    .detail("Interf", interfaceId)
+						    .detail("Addr", candidateWorker.worker.address())
+						    .detail("RecruitingStream", self->recruitingStream.get())
+						    .detail("TSS", recruitTss ? "true" : "false")
+						    .detail("StoreType", isr.storeType);
 						self->waitUntilRecruited.set(false);
 						// signal all done after adding tss to tracking info
 						tssState->markComplete();
 					}
 				} else {
 					TraceEvent(SevWarn, "DDRecruitmentError")
+					    .detail("ReqID", isr.reqId)
 					    .detail("Reason", "Server ID already recruited")
 					    .detail("ServerID", id);
 				}

--- a/fdbserver/worker.actor.cpp
+++ b/fdbserver/worker.actor.cpp
@@ -1518,6 +1518,7 @@ struct TrackRunningStorage {
 	                    std::unordered_map<UID, StorageDiskCleaner>* storageCleaners)
 	  : self(self), storeType(storeType), locality(locality), filename(filename), runningStorages(runningStorages),
 	    storageCleaners(storageCleaners) {
+		TraceEvent("StorageServerInitProgress", self).detail("Step", "4.AddedItselfToRunningStorageOnSameWorker");
 		runningStorages->emplace(self, storeType);
 	}
 	~TrackRunningStorage() {
@@ -2868,6 +2869,22 @@ ACTOR Future<Void> workerServer(Reference<IClusterConnectionRecord> connRecord,
 				activeSharedTLog->set(logData.back().uid);
 			}
 			when(InitializeStorageRequest req = waitNext(interf.storage.getFuture())) {
+				TraceEvent e("StorageServerInitProgress", req.interfaceId);
+				e.detail("Step", "1.RequestReceived");
+				e.detail("ReqID", req.reqId);
+				e.detail("WorkerID", interf.id());
+				e.detail("StorageType", req.storeType.toString());
+				e.detail("SeedTag", req.seedTag.toString());
+				e.detail("IsTssPair", req.tssPairIDAndVersion.present());
+				if (req.tssPairIDAndVersion.present()) {
+					e.detail("TssPairID", req.tssPairIDAndVersion.get().first);
+				}
+				int j = 0;
+				for (const auto& runningStorage : runningStorages) {
+					e.detail("RunningStorageIDOnSameWorker" + std::to_string(j), runningStorage.first);
+					e.detail("RunningStorageEngineOnSameWorker" + std::to_string(j), runningStorage.second);
+					j++;
+				}
 				// We want to prevent double recruiting on a worker unless we try to recruit something
 				// with a different storage engine (otherwise storage migration won't work for certain
 				// configuration). Additionally we also need to allow double recruitment for seed servers.
@@ -2900,6 +2917,11 @@ ACTOR Future<Void> workerServer(Reference<IClusterConnectionRecord> connRecord,
 					details["IsTSS"] = std::to_string(isTss);
 					Role ssRole = isTss ? Role::TESTING_STORAGE_SERVER : Role::STORAGE_SERVER;
 					startRole(ssRole, recruited.id(), interf.id(), details);
+					TraceEvent("StorageServerInitProgress", recruited.id())
+					    .detail("ReqID", req.reqId)
+					    .detail("StorageType", req.storeType.toString())
+					    .detail("Step", "2.RoleStarted")
+					    .detail("WorkerID", interf.id());
 
 					DUMPTOKEN(recruited.getValue);
 					DUMPTOKEN(recruited.getKey);
@@ -2940,6 +2962,11 @@ ACTOR Future<Void> workerServer(Reference<IClusterConnectionRecord> connRecord,
 					             : true),
 					    dbInfo,
 					    req.encryptMode);
+					TraceEvent("StorageServerInitProgress", recruited.id())
+					    .detail("ReqID", req.reqId)
+					    .detail("StorageType", req.storeType.toString())
+					    .detail("Step", "3.KVStoreOpened")
+					    .detail("WorkerID", interf.id());
 
 					Future<Void> kvClosed =
 					    data->onClosed() ||


### PR DESCRIPTION
Correctness test:
  20230819-021415-zhewang-c4b9bc7db403682c           compressed=True data_size=33511438 duration=6492321 ended=100000 fail=2 fail_fast=10 max_runs=100000 pass=99998 priority=100 remaining=0 runtime=1:06:12 sanity=False started=100000 stopped=20230819-032027 submitted=20230819-021415 timeout=5400 username=zhewang

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
