### PR TITLE
Wait file deleted in blob manifest cleanup

### DIFF
--- a/fdbserver/BlobManifest.actor.cpp
+++ b/fdbserver/BlobManifest.actor.cpp
@@ -193,17 +193,16 @@ public:
 	// Delete all files of oldest manifest
 	ACTOR static Future<Void> deleteOldest(std::vector<BlobManifestFile> allFiles,
 	                                       Reference<BackupContainerFileSystem> container) {
-		if (allFiles.empty()) {
-			return Void();
-		}
+		ASSERT(!allFiles.empty());
 		state int64_t epoch = allFiles.back().epoch;
 		state int64_t seqNo = allFiles.back().seqNo;
+		std::vector<Future<Void>> futures;
 		for (auto& f : allFiles) {
 			if (f.epoch == epoch && f.seqNo == seqNo) {
-				wait(container->deleteFile(f.fileName));
+				futures.push_back(container->deleteFile(f.fileName));
 			}
 		}
-		TraceEvent("BlobManfiestDelete").detail("Epoch", epoch).detail("SeqNo", seqNo);
+		wait(waitForAll(futures));
 		return Void();
 	}
 


### PR DESCRIPTION
Need to wait container->deleteFile() to be completed before proceeding.

100K correctness test passed. 20230817-202759-huliu-a1c814164369f5ee 
100K blobrestore test passed. 20230817-195321-huliu-fd962e2aa1a6bab0
# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
