### PR TITLE
A few test failure fixes

### DIFF
--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -92,14 +92,14 @@ std::set<int> const& normalDDQueueErrors() {
 	return s;
 }
 
+} // anonymous namespace
+
 enum class DDAuditContext : uint8_t {
 	INVALID = 0,
 	RESUME = 1,
 	LAUNCH = 2,
 	RETRY = 3,
 };
-
-} // anonymous namespace
 
 struct DDAudit {
 	DDAudit(AuditStorageState coreState)

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -106,6 +106,8 @@ enum class DDAuditContext : uint8_t {
 	RETRY = 3,
 };
 
+} // anonymous namespace
+
 struct DDAudit {
 	DDAudit(AuditStorageState coreState)
 	  : coreState(coreState), actors(true), foundError(false), auditStorageAnyChildFailed(false), retryCount(0),
@@ -140,8 +142,6 @@ struct DDAudit {
 
 	bool isCancelled() const { return cancelled; }
 };
-
-} // anonymous namespace
 
 void DataMove::validateShard(const DDShardInfo& shard, KeyRangeRef range, int priority) {
 	if (!valid) {

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -82,17 +82,35 @@ ShardSizeBounds ShardSizeBounds::shardSizeBoundsBeforeTrack() {
 		                                                      .opsReadPerKSecond = StorageMetrics::infinity } };
 }
 
+namespace {
+
+std::set<int> const& normalDDQueueErrors() {
+	static std::set<int> s{ error_code_movekeys_conflict,
+		                    error_code_broken_promise,
+		                    error_code_data_move_cancelled,
+		                    error_code_data_move_dest_team_not_found };
+	return s;
+}
+
+template <typename T>
+bool isDataDistributorTxnProcessorMocked(Reference<T> ref) {
+	ASSERT(ref.isValid());
+
+	return dynamic_cast<DDMockTxnProcessor*>(ref.getPtr()) != nullptr;
+}
+
 enum class DDAuditContext : uint8_t {
-	Invalid = 0,
-	Resume = 1,
-	Launch = 2,
-	Retry = 3,
+	INVALID = 0,
+	RESUME = 1,
+	LAUNCH = 2,
+	RETRY = 3,
 };
+
 struct DDAudit {
 	DDAudit(AuditStorageState coreState)
 	  : coreState(coreState), actors(true), foundError(false), auditStorageAnyChildFailed(false), retryCount(0),
 	    cancelled(false), overallCompleteDoAuditCount(0), overallIssuedDoAuditCount(0),
-	    remainingBudgetForAuditTasks(SERVER_KNOBS->CONCURRENT_AUDIT_TASK_COUNT_MAX), context(0) {}
+	    remainingBudgetForAuditTasks(SERVER_KNOBS->CONCURRENT_AUDIT_TASK_COUNT_MAX), context(DDAuditContext::INVALID) {}
 
 	AuditStorageState coreState;
 	ActorCollection actors;
@@ -104,14 +122,14 @@ struct DDAudit {
 	int64_t overallIssuedDoAuditCount;
 	int64_t overallCompleteDoAuditCount;
 	AsyncVar<int> remainingBudgetForAuditTasks;
-	uint8_t context;
+	DDAuditContext context;
 	std::unordered_map<UID, bool> serverProgressFinishMap; // dedicated to ssshard
 
 	inline void setAuditRunActor(Future<Void> actor) { auditActor = actor; }
 	inline Future<Void> getAuditRunActor() { return auditActor; }
 
-	inline void setDDAuditContext(DDAuditContext context) { this->context = static_cast<uint8_t>(context); }
-	inline DDAuditContext getDDAuditContext() const { return static_cast<DDAuditContext>(this->context); }
+	inline void setDDAuditContext(DDAuditContext context_) { this->context = context_; }
+	inline DDAuditContext getDDAuditContext() const { return context; }
 
 	// auditActor and actors are guaranteed to deliver a cancel signal
 	void cancel() {
@@ -122,6 +140,8 @@ struct DDAudit {
 
 	bool isCancelled() const { return cancelled; }
 };
+
+} // anonymous namespace
 
 void DataMove::validateShard(const DDShardInfo& shard, KeyRangeRef range, int priority) {
 	if (!valid) {
@@ -307,17 +327,6 @@ ACTOR Future<Void> debugCheckCoalescing(Database cx) {
 	}
 }
 
-static std::set<int> const& normalDDQueueErrors() {
-	static std::set<int> s;
-	if (s.empty()) {
-		s.insert(error_code_movekeys_conflict);
-		s.insert(error_code_broken_promise);
-		s.insert(error_code_data_move_cancelled);
-		s.insert(error_code_data_move_dest_team_not_found);
-	}
-	return s;
-}
-
 struct DataDistributor;
 void runAuditStorage(Reference<DataDistributor> self,
                      AuditStorageState auditStates,
@@ -453,7 +462,7 @@ public:
 				// instance in DD audits map
 				continue;
 			}
-			runAuditStorage(self, auditState, 0, DDAuditContext::Resume);
+			runAuditStorage(self, auditState, 0, DDAuditContext::RESUME);
 			TraceEvent(SevInfo, "AuditStorageResumed", self->ddId)
 			    .detail("AuditID", auditState.id)
 			    .detail("AuditType", auditState.getType())
@@ -520,14 +529,20 @@ public:
 			// AuditStorage does not rely on DatabaseConfiguration
 			// AuditStorage read neccessary info purely from system key space
 			if (!self->auditStorageInitStarted) {
-				// Avoid multiple initAuditStorages
-				self->addActor.send(self->initAuditStorage(self));
+				// AuditStorage currently does not support DDMockTxnProcessor
+				if (!isDataDistributorTxnProcessorMocked(self->txnProcessor)) {
+					// Avoid multiple initAuditStorages
+					self->addActor.send(self->initAuditStorage(self));
+				}
 			}
 			// It is possible that an audit request arrives and then DDMode
 			// is set to 2 at this point
 			// No polling MoveKeyLock is running
 			// So, we need to check MoveKeyLock when waitUntilDataDistributorExitSecurityMode
-			wait(waitUntilDataDistributorExitSecurityMode(self)); // Trap DDMode == 2
+			if (!isDataDistributorTxnProcessorMocked(self->txnProcessor)) {
+				// AuditStorage  currently does not suport DDMockTxnProcessor
+				wait(waitUntilDataDistributorExitSecurityMode(self)); // Trap DDMode == 2
+			}
 			// It is possible DDMode begins with 2 and passes
 			// waitDataDistributorEnabled and then set to 0 before
 			// waitUntilDataDistributorExitSecurityMode. For this case,
@@ -1971,7 +1986,7 @@ ACTOR Future<Void> auditStorageCore(Reference<DataDistributor> self,
 			// Erase the old audit from map and spawn a new audit inherit from the old audit
 			removeAuditFromAuditMap(self, audit->coreState.getType(),
 			                        audit->coreState.id); // remove audit
-			runAuditStorage(self, audit->coreState, audit->retryCount, DDAuditContext::Retry);
+			runAuditStorage(self, audit->coreState, audit->retryCount, DDAuditContext::RETRY);
 		} else {
 			try {
 				audit->coreState.setPhase(AuditPhase::Failed);
@@ -2134,7 +2149,7 @@ ACTOR Future<UID> launchAudit(Reference<DataDistributor> self, KeyRange auditRan
 				// At this point, the new audit is already in the audit map
 				return auditID;
 			}
-			runAuditStorage(self, auditState, 0, DDAuditContext::Launch);
+			runAuditStorage(self, auditState, 0, DDAuditContext::LAUNCH);
 		}
 	} catch (Error& e) {
 		if (e.code() == error_code_actor_cancelled) {

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -92,13 +92,6 @@ std::set<int> const& normalDDQueueErrors() {
 	return s;
 }
 
-template <typename T>
-bool isDataDistributorTxnProcessorMocked(Reference<T> ref) {
-	ASSERT(ref.isValid());
-
-	return dynamic_cast<DDMockTxnProcessor*>(ref.getPtr()) != nullptr;
-}
-
 enum class DDAuditContext : uint8_t {
 	INVALID = 0,
 	RESUME = 1,
@@ -532,7 +525,7 @@ public:
 			// AuditStorage read neccessary info purely from system key space
 			if (!self->auditStorageInitStarted) {
 				// AuditStorage currently does not support DDMockTxnProcessor
-				if (!isDataDistributorTxnProcessorMocked(self->txnProcessor)) {
+				if (!self->txnProcessor->isMocked()) {
 					// Avoid multiple initAuditStorages
 					self->addActor.send(self->initAuditStorage(self));
 				}
@@ -541,7 +534,7 @@ public:
 			// is set to 2 at this point
 			// No polling MoveKeyLock is running
 			// So, we need to check MoveKeyLock when waitUntilDataDistributorExitSecurityMode
-			if (!isDataDistributorTxnProcessorMocked(self->txnProcessor)) {
+			if (!self->txnProcessor->isMocked()) {
 				// AuditStorage  currently does not suport DDMockTxnProcessor
 				wait(waitUntilDataDistributorExitSecurityMode(self)); // Trap DDMode == 2
 			}

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -1828,6 +1828,13 @@ SimulationStorageEngine chooseSimulationStorageEngine(const TestConfig& testConf
 	if (testConfig.storageEngineType.present()) {
 		reason = "ConfigureSpecified"_sr;
 		result = testConfig.storageEngineType.get();
+		if (testConfig.excludedStorageEngineType(result) ||
+		    std::find(std::begin(SIMULATION_STORAGE_ENGINE), std::end(SIMULATION_STORAGE_ENGINE), result) ==
+		        std::end(SIMULATION_STORAGE_ENGINE)) {
+
+			TraceEvent(SevError, "StorageEngineNotSupported").detail("StorageEngineType", result);
+			ASSERT(false);
+		}
 	} else {
 		constexpr auto NUM_RETRIES = 1000;
 		for (auto _ = 0; _ < NUM_RETRIES; ++_) {


### PR DESCRIPTION
* Audit service will not be enabled when using Mock DD TxnProcessor
* PerpentualWiggleStorageMigrationWorkload will not run when RocksDB is disabled
* In simulation, if the test specified storage engine is not supported, an error is raised with proper description.

Passed simulation 100k without RocksDB enabled
# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
