### PR TITLE
Add a knob RESOLVE_PREFER_IPV4_ADDR to prefer IPv4 addresses

### DIFF
--- a/flow/Knobs.cpp
+++ b/flow/Knobs.cpp
@@ -222,6 +222,7 @@ void FlowKnobs::initialize(Randomize randomize, IsSimulated isSimulated) {
 	init( MIN_PACKET_BUFFER_FREE_BYTES,                        256 );
 	init( FLOW_TCP_NODELAY,                                      1 );
 	init( FLOW_TCP_QUICKACK,                                     0 );
+	init( RESOLVE_PREFER_IPV4_ADDR,                          false );  // Default to prefer IPv6 addresses. Set to true to prefer IPv4 addresses.
 
 	//Sim2
 	init( MIN_OPEN_TIME,                                    0.0002 );

--- a/flow/include/flow/IConnection.h
+++ b/flow/include/flow/IConnection.h
@@ -26,6 +26,7 @@
 
 #include <boost/asio/ip/tcp.hpp>
 
+#include "flow/Knobs.h"
 #include "flow/NetworkAddress.h"
 
 class Void;
@@ -179,12 +180,19 @@ public:
 	// If a DNS name can be resolved to both and IPv4 and IPv6 addresses, we want IPv6 addresses when running the
 	// clusters on IPv6.
 	// This function takes a vector of addresses and return a random one, preferring IPv6 over IPv4.
+	// To prefer IPv4 addresses instead, set knob RESOLVE_PREFER_IPV4_ADDR to true.
 	static NetworkAddress pickOneAddress(const std::vector<NetworkAddress>& addresses) {
 		std::vector<NetworkAddress> ipV6Addresses;
+		std::vector<NetworkAddress> ipV4Addresses;
 		for (const NetworkAddress& addr : addresses) {
 			if (addr.isV6()) {
 				ipV6Addresses.push_back(addr);
+			} else {
+				ipV4Addresses.push_back(addr);
 			}
+		}
+		if (ipV4Addresses.size() > 0 && FLOW_KNOBS->RESOLVE_PREFER_IPV4_ADDR) {
+			return addresses[deterministicRandom()->randomInt(0, ipV4Addresses.size())];
 		}
 		if (ipV6Addresses.size() > 0) {
 			return ipV6Addresses[deterministicRandom()->randomInt(0, ipV6Addresses.size())];

--- a/flow/include/flow/Knobs.h
+++ b/flow/include/flow/Knobs.h
@@ -286,6 +286,7 @@ public:
 	int MIN_PACKET_BUFFER_FREE_BYTES;
 	int FLOW_TCP_NODELAY;
 	int FLOW_TCP_QUICKACK;
+	bool RESOLVE_PREFER_IPV4_ADDR;
 
 	// Sim2
 	// FIMXE: more parameters could be factored out

--- a/flow/network.cpp
+++ b/flow/network.cpp
@@ -441,7 +441,8 @@ TEST_CASE("/flow/network/ipV6Preferred") {
 		addresses.push_back(NetworkAddress::parse(s));
 	}
 	// Confirm IPv6 is always preferred.
-	ASSERT(INetworkConnections::pickOneAddress(addresses).toString() == ipv6);
+	ASSERT((INetworkConnections::pickOneAddress(addresses).toString() == ipv6) ==
+	       !FLOW_KNOBS->RESOLVE_PREFER_IPV4_ADDR);
 
 	return Void();
 }


### PR DESCRIPTION
The default is to prefer IPv6 addresses.

This fixes #10816.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
