### PR TITLE
FDBCORE-6014: Update KMS Health Check timeouts

### DIFF
--- a/flow/Knobs.cpp
+++ b/flow/Knobs.cpp
@@ -310,9 +310,10 @@ void FlowKnobs::initialize(Randomize randomize, IsSimulated isSimulated) {
 	if ( randomize && BUGGIFY) { ENCRYPT_CIPHER_KEY_CACHE_TTL = deterministicRandom()->randomInt(2, 10) * 60; }
 	init( ENCRYPT_KEY_REFRESH_INTERVAL,   isSimulated ? 60 : 8 * 60 );
 	if ( randomize && BUGGIFY) { ENCRYPT_KEY_REFRESH_INTERVAL = deterministicRandom()->randomInt(2, 10); }
-	init( ENCRYPT_KEY_HEALTH_CHECK_INTERVAL,                    10 );
-	if ( randomize && BUGGIFY) { ENCRYPT_KEY_HEALTH_CHECK_INTERVAL = deterministicRandom()->randomInt(10, 60); }
-	init( EKP_HEALTH_CHECK_REQUEST_TIMEOUT,                    10.0);
+	init( ENCRYPT_KEY_HEALTH_CHECK_INTERVAL,                     3 );
+	if ( randomize && BUGGIFY) { ENCRYPT_KEY_HEALTH_CHECK_INTERVAL = deterministicRandom()->randomInt(3, 60); }
+	init( EKP_HEALTH_CHECK_REQUEST_TIMEOUT,                    2.0 );
+	if ( randomize && BUGGIFY) { ENCRYPT_KEY_HEALTH_CHECK_INTERVAL = deterministicRandom()->randomInt(2, 30); }
 	init( ENCRYPT_KEY_CACHE_ENABLE_DETAIL_LOGGING,           false ); if( randomize && BUGGIFY ) ENCRYPT_KEY_CACHE_ENABLE_DETAIL_LOGGING = true;
 	init( ENCRYPT_KEY_CACHE_LOGGING_INTERVAL,                  5.0 );
 	init( ENCRYPT_KEY_CACHE_LATENCY_LOGGING_INTERVAL,         60.0 );


### PR DESCRIPTION
Description

KMS health check monitor is instrumental in determing FDB <-> KMS connectivity issues (no connection or flakiness). Patch lower the check interval to be under FDB commit timeout to get assist diagnosing such issues.

The change do translate to increased request to KMS, however, the health-check asks for FDB system keyspace encryption key, it would be hitting cache on KMS server all the time (unless a KMS server got replaced and the first read is a miss)

Testing

devRunCorrectness - 100K - 20230824-161727-ahusain-95898cba71ad603b - one failure for `BackupToDBCorrectnessClean.toml` which is unrelated and due to Backup getting stuck causing test to fail

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
