### PR TITLE
[swift] Remove deprecated Swift attr spelling: `import_as_ref`

### DIFF
--- a/SWIFT_GUIDE.md
+++ b/SWIFT_GUIDE.md
@@ -182,7 +182,7 @@ You can use the `SWIFT_CXX_REF` annotation for that. Right now `SWIFT_CXX_REF` d
 
 ```cpp
 #define SWIFT_CXX_REF_MASTERDATA   \
-    __attribute__((swift_attr("import_as_ref")))   \
+    __attribute__((swift_attr("import_reference")))   \
     __attribute__((swift_attr("retain:addrefMasterData")))   \
     __attribute__((swift_attr("release:delrefMasterData")))
 

--- a/fdbserver/include/fdbserver/MasterData.actor.h
+++ b/fdbserver/include/fdbserver/MasterData.actor.h
@@ -54,7 +54,7 @@ struct MasterData;
 
 // FIXME(swift): Remove once https://github.com/apple/swift/issues/61620 is fixed.
 #define SWIFT_CXX_REF_MASTERDATA                                                                                       \
-	__attribute__((swift_attr("import_as_ref"))) __attribute__((swift_attr("retain:addrefMasterData")))                \
+	__attribute__((swift_attr("import_reference"))) __attribute__((swift_attr("retain:addrefMasterData")))             \
 	__attribute__((swift_attr("release:delrefMasterData")))
 
 // A type with Swift value semantics for working with `Counter` types.

--- a/flow/include/flow/DeterministicRandom.h
+++ b/flow/include/flow/DeterministicRandom.h
@@ -32,7 +32,7 @@
 
 // FIXME: Remove once https://github.com/apple/swift/issues/61620 is fixed.
 #define SWIFT_CXX_REF_DETERMINISTICRANDOM                                                                              \
-	__attribute__((swift_attr("import_as_ref"))) __attribute__((swift_attr("retain:addref_DeterministicRandom")))      \
+	__attribute__((swift_attr("import_reference"))) __attribute__((swift_attr("retain:addref_DeterministicRandom")))   \
 	__attribute__((swift_attr("release:delref_DeterministicRandom")))
 
 class SWIFT_CXX_REF_DETERMINISTICRANDOM DeterministicRandom final : public IRandom,

--- a/flow/include/flow/genericactors.actor.h
+++ b/flow/include/flow/genericactors.actor.h
@@ -752,7 +752,7 @@ private:
 
 // FIXME(swift): Remove once https://github.com/apple/swift/issues/61620 is fixed.
 #define SWIFT_CXX_REF_ASYNCVAR                                                                                         \
-	__attribute__((swift_attr("import_as_ref"))) __attribute__((swift_attr("retain:immortal")))                        \
+	__attribute__((swift_attr("import_reference"))) __attribute__((swift_attr("retain:immortal")))                     \
 	__attribute__((swift_attr("release:immortal")))
 // // TODO(swift): https://github.com/apple/swift/issues/62456 can't support retain/release funcs that are templates
 // themselfes

--- a/flow/include/flow/swift_support.h
+++ b/flow/include/flow/swift_support.h
@@ -33,11 +33,11 @@
 /// This annotation bridges immortal C++ singleton types
 /// that are always accessed via a pointer or a reference in C++ as immortal class types in Swift.
 #define SWIFT_CXX_IMMORTAL_SINGLETON_TYPE                                                                              \
-	__attribute__((swift_attr("import_as_ref"))) __attribute__((swift_attr("retain:immortal")))                        \
+	__attribute__((swift_attr("import_reference"))) __attribute__((swift_attr("retain:immortal")))                     \
 	__attribute__((swift_attr("release:immortal")))
 
 #define SWIFT_CXX_REF                                                                                                  \
-	__attribute__((swift_attr("import_as_ref"))) __attribute__((swift_attr("retain:addref")))                          \
+	__attribute__((swift_attr("import_reference"))) __attribute__((swift_attr("retain:addref")))                       \
 	__attribute__((swift_attr("release:delref")))
 
 /// Ignore that a type seems to be an unsafe projection, and import it regardless.

--- a/flow/include/flow/unsafe_swift_compat.h
+++ b/flow/include/flow/unsafe_swift_compat.h
@@ -26,7 +26,7 @@
 /// Please take extreme care when applying this annotation to C++ types, as this annotation
 /// can lead to use-after-frees or memory leaks very easily.
 #define UNSAFE_SWIFT_CXX_IMMORTAL_REF                                                                                  \
-	__attribute__((swift_attr("import_as_ref"))) __attribute__((swift_attr("retain:immortal")))                        \
+	__attribute__((swift_attr("import_reference"))) __attribute__((swift_attr("retain:immortal")))                     \
 	__attribute__((swift_attr("release:immortal")))
 
 #endif // FLOW_UNSAFE_SWIFT_COMPAT_H


### PR DESCRIPTION
This spelling is deprecated and will be removed in the future version of Swift:
```
__attribute__((swift_attr("import_as_ref")))
```

The new correct spelling is:
```
__attribute__((swift_attr("import_reference")))
```

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
