### PR TITLE
Fix picking of IPv4 addresses

### DIFF
--- a/flow/include/flow/IConnection.h
+++ b/flow/include/flow/IConnection.h
@@ -192,7 +192,7 @@ public:
 			}
 		}
 		if (ipV4Addresses.size() > 0 && FLOW_KNOBS->RESOLVE_PREFER_IPV4_ADDR) {
-			return addresses[deterministicRandom()->randomInt(0, ipV4Addresses.size())];
+			return ipV4Addresses[deterministicRandom()->randomInt(0, ipV4Addresses.size())];
 		}
 		if (ipV6Addresses.size() > 0) {
 			return ipV6Addresses[deterministicRandom()->randomInt(0, ipV6Addresses.size())];


### PR DESCRIPTION
Could return ipv6 addresses due to the bug in #10822

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
