### PR TITLE
Add trace details about over-replicated shard and range count (snowflake/release-71.3)

### DIFF
--- a/fdbserver/DDTeamCollection.actor.cpp
+++ b/fdbserver/DDTeamCollection.actor.cpp
@@ -4182,6 +4182,7 @@ Reference<TCTeamInfo> DDTeamCollection::buildLargeTeam(int teamSize) {
 	}
 
 	int totalShardCount = 0;
+	largeTeamSizeShards.clear();
 	for (auto& team : largeTeams) {
 		const auto servers = team->getServerIDs();
 		const int shardCount =

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -852,7 +852,8 @@ ACTOR Future<Void> dataDistribution(Reference<DataDistributor> self,
 			                                       .anyZeroHealthyTeams = anyZeroHealthyTeams,
 			                                       .shards = &shards,
 			                                       .trackerCancelled = &self->context->trackerCancelled,
-			                                       .ddTenantCache = self->ddTenantCache });
+			                                       .ddTenantCache = self->ddTenantCache,
+			                                       .teamSize = self->configuration.storageTeamSize });
 			actors.push_back(reportErrorsExcept(DataDistributionTracker::run(self->context->tracker,
 			                                                                 self->initData,
 			                                                                 getShardMetrics.getFuture(),

--- a/fdbserver/include/fdbserver/DDShardTracker.h
+++ b/fdbserver/include/fdbserver/DDShardTracker.h
@@ -46,6 +46,7 @@ struct DataDistributionTrackerInitParams {
 	KeyRangeMap<ShardTrackedData>* shards = nullptr;
 	bool* trackerCancelled = nullptr;
 	Optional<Reference<TenantCache>> ddTenantCache;
+	int teamSize = 0;
 };
 
 // track the status of shards
@@ -109,6 +110,9 @@ public:
 	Optional<Reference<TenantCache>> ddTenantCache;
 
 	Reference<DDConfiguration::RangeConfigMapSnapshot> userRangeConfig;
+	int teamSize;
+	// logical range configured to be over-replicated. key: replica, value: range count
+	std::map<int, int> largeTeamSizeRanges;
 
 	DataDistributionTracker() = default;
 

--- a/fdbserver/include/fdbserver/DDTeamCollection.h
+++ b/fdbserver/include/fdbserver/DDTeamCollection.h
@@ -240,6 +240,9 @@ protected:
 
 	std::vector<Reference<TCTeamInfo>> badTeams;
 	std::vector<Reference<TCTeamInfo>> largeTeams;
+	// shards have been over-replicated
+	std::map<int, int> largeTeamSizeShards;
+
 	Reference<ShardsAffectedByTeamFailure> shardsAffectedByTeamFailure;
 	PromiseStream<UID> removedServers;
 	PromiseStream<UID> removedTSS;


### PR DESCRIPTION
correctness (100k passed) : `20230824-224139-xwang-9f2350745c7e5808`

Output example when the simulation test is configured as `double`:
```
<Event Severity="10" Time="331.886378" DateTime="2023-08-24T22:57:37Z" Type="DDTrackerStats" Machine="[abcd::2:0:2:1]:2" ID="b83966aaebdac68f" Shards="11" TotalSizeBytes="32250" SystemSizeBytes="32250" RangeCountLargeTeam3="3" RangeCountLargeTeam4="1" RangeCountLargeTeam6="2" ThreadID="3898103688851930672" LogGroup="default" Roles="DD,SS" TrackLatestType="Original" />

<Event Severity="10" Time="331.880267" DateTime="2023-08-24T22:57:37Z" Type="TotalDataInFlight" Machine="[abcd::2:0:2:1]:2" ID="b83966aaebdac68f" Primary="1" TotalBytes="0" UnhealthyServers="0" ServerCount="28" StorageTeamSize="2" ZeroHealthy="0" HighestPriority="140" ShardCountLargeTeam3="10" ShardCountLargeTeam4="2" ShardCountLargeTeam6="3" ThreadID="3898103688851930672" LogGroup="default" Roles="DD,SS" TrackLatestType="Original" />
```

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
