### PR TITLE
Fix auditStorage: Audit task should not retry if the task is issued by an outdated DD

### DIFF
--- a/fdbclient/AuditUtils.actor.cpp
+++ b/fdbclient/AuditUtils.actor.cpp
@@ -490,7 +490,7 @@ ACTOR Future<Void> persistAuditStateByRange(Database cx, AuditStorageState audit
 			AuditStorageState ddAuditState = decodeAuditStorageState(ddAuditState_.get());
 			ASSERT(ddAuditState.ddId.isValid());
 			if (ddAuditState.ddId != auditState.ddId) {
-				throw audit_storage_failed(); // a new dd starts and this audit task is outdated
+				throw audit_storage_task_outdated(); // a new dd starts and this audit task is outdated
 			}
 			// It is possible ddAuditState is complete while some progress is about to persist
 			// Since doAuditOnStorageServer may repeatedly issue multiple requests (see getReplyUnlessFailedFor)
@@ -581,7 +581,7 @@ ACTOR Future<Void> persistAuditStateByServer(Database cx, AuditStorageState audi
 			AuditStorageState ddAuditState = decodeAuditStorageState(ddAuditState_.get());
 			ASSERT(ddAuditState.ddId.isValid());
 			if (ddAuditState.ddId != auditState.ddId) {
-				throw audit_storage_failed(); // a new dd starts and this audit task is outdated
+				throw audit_storage_task_outdated(); // a new dd starts and this audit task is outdated
 			}
 			// It is possible ddAuditState is complete while some progress is about to persist
 			// Since doAuditOnStorageServer may repeatedly issue multiple requests (see getReplyUnlessFailedFor)

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -1983,6 +1983,8 @@ ACTOR Future<Void> auditStorageCore(Reference<DataDistributor> self,
 			removeAuditFromAuditMap(self, audit->coreState.getType(),
 			                        audit->coreState.id); // remove audit
 			// Silently exit
+		} else if (e.code() == error_code_audit_storage_task_outdated) {
+			// Silently exit
 		} else if (e.code() == error_code_audit_storage_cancelled) {
 			// If this audit is cancelled, the place where cancelling
 			// this audit does removeAuditFromAuditMap
@@ -2956,7 +2958,7 @@ ACTOR Future<Void> skipAuditOnRange(Reference<DataDistributor> self,
 		    .detail("Ops", "Increase")
 		    .detail("Val", audit->remainingBudgetForAuditTasks.get())
 		    .detail("AuditType", auditType);
-		if (e.code() == error_code_audit_storage_cancelled) {
+		if (e.code() == error_code_audit_storage_cancelled || e.code() == error_code_audit_storage_task_outdated) {
 			throw e;
 		} else if (audit->retryCount >= SERVER_KNOBS->AUDIT_RETRY_COUNT_MAX) {
 			throw audit_storage_failed();
@@ -3040,7 +3042,7 @@ ACTOR Future<Void> doAuditOnStorageServer(Reference<DataDistributor> self,
 			throw e; // handled by scheduleAuditStorageShardOnServer
 		}
 		if (e.code() == error_code_not_implemented || e.code() == error_code_audit_storage_exceeded_request_limit ||
-		    e.code() == error_code_audit_storage_cancelled) {
+		    e.code() == error_code_audit_storage_cancelled || e.code() == error_code_audit_storage_task_outdated) {
 			throw e;
 		} else if (e.code() == error_code_audit_storage_error) {
 			audit->foundError = true;
@@ -3314,10 +3316,9 @@ ACTOR Future<Void> doAuditLocationMetadata(Reference<DataDistributor> self,
 		    .detail("Ops", "Increase")
 		    .detail("Val", audit->remainingBudgetForAuditTasks.get())
 		    .detail("AuditType", audit->coreState.getType());
-		if (e.code() == error_code_audit_storage_error) {
-			throw audit_storage_error();
-		} else if (e.code() == error_code_audit_storage_cancelled) {
-			throw audit_storage_cancelled();
+		if (e.code() == error_code_audit_storage_error || e.code() == error_code_audit_storage_cancelled ||
+		    e.code() == error_code_audit_storage_task_outdated) {
+			throw e;
 		} else if (audit->retryCount >= SERVER_KNOBS->AUDIT_RETRY_COUNT_MAX) {
 			throw audit_storage_failed();
 		} else {

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -5415,6 +5415,8 @@ ACTOR Future<Void> auditStorageServerShardQ(StorageServer* data, AuditStorageReq
 
 		if (e.code() == error_code_audit_storage_cancelled) {
 			req.reply.sendError(audit_storage_cancelled());
+		} else if (e.code() == error_code_audit_storage_task_outdated) {
+			req.reply.sendError(audit_storage_task_outdated());
 		} else {
 			req.reply.sendError(audit_storage_failed());
 		}
@@ -5781,6 +5783,8 @@ ACTOR Future<Void> auditStorageShardReplicaQ(StorageServer* data, AuditStorageRe
 		    .detail("AuditServer", data->thisServerID);
 		if (e.code() == error_code_audit_storage_cancelled) {
 			req.reply.sendError(audit_storage_cancelled());
+		} else if (e.code() == error_code_audit_storage_task_outdated) {
+			req.reply.sendError(audit_storage_task_outdated());
 		} else {
 			req.reply.sendError(audit_storage_failed());
 		}

--- a/flow/include/flow/error_definitions.h
+++ b/flow/include/flow/error_definitions.h
@@ -148,6 +148,7 @@ ERROR( persist_new_audit_metadata_error, 1230, "Persist new audit metadata error
 ERROR( cancel_audit_storage_failed, 1231, "Failed to cancel an audit" )
 ERROR( audit_storage_cancelled, 1232, "Audit has been cancelled" )
 ERROR( location_metadata_corruption, 1233, "Found location metadata corruption" )
+ERROR( audit_storage_task_outdated, 1234, "Audit task is scheduled by an outdated DD" )
 
 // 15xx Platform errors
 ERROR( platform_error, 1500, "Platform error" )


### PR DESCRIPTION
Audit task should not retry if the task is issued by an outdated DD.

Correctness test with 3 irrelevant failures:
  20230829-000319-zhewang-3e73fb9db4e80ff1           compressed=True data_size=34690653 duration=6589019 ended=100000 fail=3 fail_fast=10 max_runs=100000 pass=99997 priority=100 remaining=0 runtime=1:42:34 sanity=False started=100000 stopped=20230829-014553 submitted=20230829-000319 timeout=5400 username=zhewang

ValidateStorage test:
  20230829-000354-zhewang-7530c26eb05148a6           compressed=True data_size=34721874 duration=9419629 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:23:34 sanity=False started=100000 stopped=20230829-012728 submitted=20230829-000354 timeout=5400 username=zhewang

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
