### PR TITLE
Restore original function names for old blob granule API [release-71.3]

### DIFF
--- a/bindings/c/fdb_c.cpp
+++ b/bindings/c/fdb_c.cpp
@@ -414,9 +414,9 @@ extern "C" DLLEXPORT fdb_error_t fdb_future_readbg_get_descriptions_v2(FDBFuture
 	return 0;
 }
 
-extern "C" DLLEXPORT fdb_error_t fdb_future_readbg_get_descriptions_v1(FDBFuture* f,
-                                                                       FDBBGFileDescriptionV1** out_descs,
-                                                                       int* out_count) {
+extern "C" DLLEXPORT fdb_error_t fdb_future_readbg_get_descriptions(FDBFuture* f,
+                                                                    FDBBGFileDescriptionV1** out_descs,
+                                                                    int* out_count) {
 	CATCH_AND_RETURN(ReadBGDescriptionsApiResultV1 res = TSAV(ReadBGDescriptionsApiResultV1, f)->get();
 	                 *out_descs = res.desc_arr;
 	                 *out_count = res.desc_count;);
@@ -431,10 +431,10 @@ extern "C" DLLEXPORT FDBResult* fdb_readbg_parse_snapshot_file_v2(const uint8_t*
 	        .extractPtr(););
 }
 
-extern "C" DLLEXPORT FDBResult* fdb_readbg_parse_snapshot_file_v1(const uint8_t* file_data,
-                                                                  int file_len,
-                                                                  FDBBGTenantPrefix const* tenant_prefix,
-                                                                  FDBBGEncryptionCtxV1 const* encryption_ctx) {
+extern "C" DLLEXPORT FDBResult* fdb_readbg_parse_snapshot_file(const uint8_t* file_data,
+                                                               int file_len,
+                                                               FDBBGTenantPrefix const* tenant_prefix,
+                                                               FDBBGEncryptionCtxV1 const* encryption_ctx) {
 	RETURN_RESULT_ON_ERROR(
 	    return parseBlobGranulesSnapshotFileV1(StringRef(file_data, file_len), tenant_prefix, encryption_ctx)
 	        .extractPtr(););
@@ -449,10 +449,10 @@ extern "C" DLLEXPORT FDBResult* fdb_readbg_parse_delta_file_v2(const uint8_t* fi
 	        .extractPtr(););
 }
 
-extern "C" DLLEXPORT FDBResult* fdb_readbg_parse_delta_file_v1(const uint8_t* file_data,
-                                                               int file_len,
-                                                               FDBBGTenantPrefix const* tenant_prefix,
-                                                               FDBBGEncryptionCtxV1 const* encryption_ctx) {
+extern "C" DLLEXPORT FDBResult* fdb_readbg_parse_delta_file(const uint8_t* file_data,
+                                                            int file_len,
+                                                            FDBBGTenantPrefix const* tenant_prefix,
+                                                            FDBBGEncryptionCtxV1 const* encryption_ctx) {
 	RETURN_RESULT_ON_ERROR(
 	    return parseBlobGranulesDeltaFileV1(StringRef(file_data, file_len), tenant_prefix, encryption_ctx)
 	        .extractPtr(););
@@ -1265,14 +1265,14 @@ extern "C" DLLEXPORT FDBFuture* fdb_transaction_read_blob_granules_description_v
 	return future;
 }
 
-extern "C" DLLEXPORT FDBFuture* fdb_transaction_read_blob_granules_description_v1(FDBTransaction* tr,
-                                                                                  uint8_t const* begin_key_name,
-                                                                                  int begin_key_name_length,
-                                                                                  uint8_t const* end_key_name,
-                                                                                  int end_key_name_length,
-                                                                                  int64_t begin_version,
-                                                                                  int64_t read_version,
-                                                                                  int64_t* read_version_out) {
+extern "C" DLLEXPORT FDBFuture* fdb_transaction_read_blob_granules_description(FDBTransaction* tr,
+                                                                               uint8_t const* begin_key_name,
+                                                                               int begin_key_name_length,
+                                                                               uint8_t const* end_key_name,
+                                                                               int end_key_name_length,
+                                                                               int64_t begin_version,
+                                                                               int64_t read_version,
+                                                                               int64_t* read_version_out) {
 	FDBFuture* f = fdb_transaction_read_blob_granules_description_v2(
 	    tr, begin_key_name, begin_key_name_length, end_key_name, end_key_name_length, begin_version, read_version);
 	return (FDBFuture*)mapThreadFuture<ApiResult, ReadBGDescriptionsApiResultV1>(

--- a/bindings/c/foundationdb/fdb_c.h
+++ b/bindings/c/foundationdb/fdb_c.h
@@ -57,22 +57,9 @@
 #include "fdb_c_options.g.h"
 #include "fdb_c_types.h"
 
-/**
- * Assuming Blob Granule API V1 by default for compatibility with the current release
- * The application code using Blob Granule API, should be upgraded to V2, because V1
- * will be deprecated in the next major release
- */
-#if !defined(FDB_BLOB_GRANULE_API_VERSION)
-#define FDB_BLOB_GRANULE_API_VERSION 1
-#endif
-
-#define BUILD_BLOB_GRANULE_IDENTIFIER(symbolname, version) symbolname##version
-#define BLOB_GRANULE_IDENTIFIER_(symbolname, version) BUILD_BLOB_GRANULE_IDENTIFIER(symbolname, version)
-#define BLOB_GRANULE_IDENTIFIER(symbolname) BLOB_GRANULE_IDENTIFIER_(symbolname, FDB_BLOB_GRANULE_API_VERSION)
-
-typedef BLOB_GRANULE_IDENTIFIER(FDBBGEncryptionCtxV) FDBBGEncryptionCtx;
-typedef BLOB_GRANULE_IDENTIFIER(FDBBGFilePointerV) FDBBGFilePointer;
-typedef BLOB_GRANULE_IDENTIFIER(FDBBGFileDescriptionV) FDBBGFileDescription;
+typedef FDBBGEncryptionCtxV1 FDBBGEncryptionCtx;
+typedef FDBBGFilePointerV1 FDBBGFilePointer;
+typedef FDBBGFileDescriptionV1 FDBBGFileDescription;
 
 #ifdef __cplusplus
 extern "C" {
@@ -226,39 +213,33 @@ DLLEXPORT WARN_UNUSED_RESULT fdb_error_t fdb_future_get_granule_summary_array(FD
                                                                               int* out_count);
 
 /* all for using future result from read_blob_granules_description */
-DLLEXPORT WARN_UNUSED_RESULT fdb_error_t fdb_future_readbg_get_descriptions_v1(FDBFuture* f,
-                                                                               FDBBGFileDescriptionV1** out_descs,
-                                                                               int* out_count);
+DLLEXPORT WARN_UNUSED_RESULT fdb_error_t fdb_future_readbg_get_descriptions(FDBFuture* f,
+                                                                            FDBBGFileDescriptionV1** out_descs,
+                                                                            int* out_count);
 
 DLLEXPORT WARN_UNUSED_RESULT fdb_error_t fdb_future_readbg_get_descriptions_v2(FDBFuture* f,
                                                                                FDBBGFileDescriptionV2*** out_descs,
                                                                                int* out_count);
 
-#define fdb_future_readbg_get_descriptions BLOB_GRANULE_IDENTIFIER(fdb_future_readbg_get_descriptions_v)
-
-DLLEXPORT WARN_UNUSED_RESULT FDBResult* fdb_readbg_parse_snapshot_file_v1(const uint8_t* file_data,
-                                                                          int file_len,
-                                                                          FDBBGTenantPrefix const* tenant_prefix,
-                                                                          FDBBGEncryptionCtxV1 const* encryption_ctx);
+DLLEXPORT WARN_UNUSED_RESULT FDBResult* fdb_readbg_parse_snapshot_file(const uint8_t* file_data,
+                                                                       int file_len,
+                                                                       FDBBGTenantPrefix const* tenant_prefix,
+                                                                       FDBBGEncryptionCtxV1 const* encryption_ctx);
 
 DLLEXPORT WARN_UNUSED_RESULT FDBResult* fdb_readbg_parse_snapshot_file_v2(const uint8_t* file_data,
                                                                           int file_len,
                                                                           FDBBGTenantPrefix const* tenant_prefix,
                                                                           FDBBGEncryptionCtxV2 const* encryption_ctx);
 
-#define fdb_readbg_parse_snapshot_file BLOB_GRANULE_IDENTIFIER(fdb_readbg_parse_snapshot_file_v)
-
-DLLEXPORT WARN_UNUSED_RESULT FDBResult* fdb_readbg_parse_delta_file_v1(const uint8_t* file_data,
-                                                                       int file_len,
-                                                                       FDBBGTenantPrefix const* tenant_prefix,
-                                                                       FDBBGEncryptionCtxV1 const* encryption_ctx);
+DLLEXPORT WARN_UNUSED_RESULT FDBResult* fdb_readbg_parse_delta_file(const uint8_t* file_data,
+                                                                    int file_len,
+                                                                    FDBBGTenantPrefix const* tenant_prefix,
+                                                                    FDBBGEncryptionCtxV1 const* encryption_ctx);
 
 DLLEXPORT WARN_UNUSED_RESULT FDBResult* fdb_readbg_parse_delta_file_v2(const uint8_t* file_data,
                                                                        int file_len,
                                                                        FDBBGTenantPrefix const* tenant_prefix,
                                                                        FDBBGEncryptionCtxV2 const* encryption_ctx);
-
-#define fdb_readbg_parse_delta_file BLOB_GRANULE_IDENTIFIER(fdb_readbg_parse_delta_file_v)
 
 /* FDBResult is a synchronous computation result, as opposed to a future that is asynchronous. */
 DLLEXPORT void fdb_result_destroy(FDBResult* r);
@@ -601,14 +582,14 @@ DLLEXPORT WARN_UNUSED_RESULT FDBFuture* fdb_transaction_summarize_blob_granules(
                                                                                 int64_t summaryVersion,
                                                                                 int rangeLimit);
 
-DLLEXPORT WARN_UNUSED_RESULT FDBFuture* fdb_transaction_read_blob_granules_description_v1(FDBTransaction* tr,
-                                                                                          uint8_t const* begin_key_name,
-                                                                                          int begin_key_name_length,
-                                                                                          uint8_t const* end_key_name,
-                                                                                          int end_key_name_length,
-                                                                                          int64_t begin_version,
-                                                                                          int64_t read_version,
-                                                                                          int64_t* read_version_out);
+DLLEXPORT WARN_UNUSED_RESULT FDBFuture* fdb_transaction_read_blob_granules_description(FDBTransaction* tr,
+                                                                                       uint8_t const* begin_key_name,
+                                                                                       int begin_key_name_length,
+                                                                                       uint8_t const* end_key_name,
+                                                                                       int end_key_name_length,
+                                                                                       int64_t begin_version,
+                                                                                       int64_t read_version,
+                                                                                       int64_t* read_version_out);
 
 DLLEXPORT WARN_UNUSED_RESULT FDBFuture* fdb_transaction_read_blob_granules_description_v2(FDBTransaction* tr,
                                                                                           uint8_t const* begin_key_name,
@@ -617,9 +598,6 @@ DLLEXPORT WARN_UNUSED_RESULT FDBFuture* fdb_transaction_read_blob_granules_descr
                                                                                           int end_key_name_length,
                                                                                           int64_t begin_version,
                                                                                           int64_t read_version);
-
-#define fdb_transaction_read_blob_granules_description                                                                 \
-	BLOB_GRANULE_IDENTIFIER(fdb_transaction_read_blob_granules_description_v)
 
 #define FDB_KEYSEL_LAST_LESS_THAN(k, l) k, l, 0, 0
 #define FDB_KEYSEL_LAST_LESS_OR_EQUAL(k, l) k, l, 1, 0

--- a/bindings/c/test/fdb_api.hpp
+++ b/bindings/c/test/fdb_api.hpp
@@ -463,7 +463,7 @@ struct ReadBlobGranulesDescriptionResultV1 {
 	static Error extract(native::FDBFuture* f, Type& out) noexcept {
 		native::FDBBGFileDescriptionV1* descs;
 		int desc_cnt;
-		auto err = native::fdb_future_readbg_get_descriptions_v1(f, &descs, &desc_cnt);
+		auto err = native::fdb_future_readbg_get_descriptions(f, &descs, &desc_cnt);
 		out = Type((GranuleDescriptionRefV1*)descs, desc_cnt);
 		return Error(err);
 	}
@@ -857,14 +857,14 @@ public:
 	    int64_t beginVersion,
 	    int64_t readVersion,
 	    int64_t* readVersionOut) {
-		return native::fdb_transaction_read_blob_granules_description_v1(tr.get(),
-		                                                                 begin.data(),
-		                                                                 intSize(begin),
-		                                                                 end.data(),
-		                                                                 intSize(end),
-		                                                                 beginVersion,
-		                                                                 readVersion,
-		                                                                 readVersionOut);
+		return native::fdb_transaction_read_blob_granules_description(tr.get(),
+		                                                              begin.data(),
+		                                                              intSize(begin),
+		                                                              end.data(),
+		                                                              intSize(end),
+		                                                              beginVersion,
+		                                                              readVersion,
+		                                                              readVersionOut);
 	}
 
 	ReadRangeResult parseSnapshotFile(BytesRef fileData,
@@ -877,7 +877,7 @@ public:
 	ReadRangeResult parseSnapshotFileV1(BytesRef fileData,
 	                                    native::FDBBGTenantPrefix const* tenantPrefix,
 	                                    native::FDBBGEncryptionCtxV1 const* encryptionCtx) {
-		return ReadRangeResult::create((native::FDBReadRangeResult*)native::fdb_readbg_parse_snapshot_file_v1(
+		return ReadRangeResult::create((native::FDBReadRangeResult*)native::fdb_readbg_parse_snapshot_file(
 		    fileData.data(), intSize(fileData), tenantPrefix, encryptionCtx));
 	}
 
@@ -891,7 +891,7 @@ public:
 	ReadBGMutationsResult parseDeltaFileV1(BytesRef fileData,
 	                                       native::FDBBGTenantPrefix const* tenantPrefix,
 	                                       native::FDBBGEncryptionCtxV1 const* encryptionCtx) {
-		return ReadBGMutationsResult::create((native::FDBReadBGMutationsResult*)native::fdb_readbg_parse_delta_file_v1(
+		return ReadBGMutationsResult::create((native::FDBReadBGMutationsResult*)native::fdb_readbg_parse_delta_file(
 		    fileData.data(), intSize(fileData), tenantPrefix, encryptionCtx));
 	}
 


### PR DESCRIPTION
Restoring original function names for old blob granule API for backwards compatibility with previous 71.3 patches. 

The change does not need to merged to main, because is based on API refactoring performed only on that release branch

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
