### PR TITLE
Make `perpetual_storage_wiggle_locality` database option to take a list of localities

### DIFF
--- a/fdbclient/FDBTypes.cpp
+++ b/fdbclient/FDBTypes.cpp
@@ -253,7 +253,6 @@ KeyValueStoreType KeyValueStoreType::fromString(const std::string& str) {
 	return it->second;
 }
 
-
 TEST_CASE("/PerpetualStorageWiggleLocality/Validation") {
 	ASSERT(isValidPerpetualStorageWiggleLocality("aaa:bbb"));
 	ASSERT(isValidPerpetualStorageWiggleLocality("aaa:bbb;ccc:ddd"));

--- a/fdbclient/FDBTypes.cpp
+++ b/fdbclient/FDBTypes.cpp
@@ -252,3 +252,15 @@ KeyValueStoreType KeyValueStoreType::fromString(const std::string& str) {
 	}
 	return it->second;
 }
+
+
+TEST_CASE("/PerpetualStorageWiggleLocality/Validation") {
+	ASSERT(isValidPerpetualStorageWiggleLocality("aaa:bbb"));
+	ASSERT(isValidPerpetualStorageWiggleLocality("aaa:bbb;ccc:ddd"));
+	ASSERT(isValidPerpetualStorageWiggleLocality("0"));
+
+	ASSERT(!isValidPerpetualStorageWiggleLocality("aaa:bbb;"));
+	ASSERT(!isValidPerpetualStorageWiggleLocality("aaa:bbb;ccc"));
+
+	return Void();
+}

--- a/fdbclient/FDBTypes.cpp
+++ b/fdbclient/FDBTypes.cpp
@@ -261,13 +261,14 @@ TEST_CASE("/PerpetualStorageWiggleLocality/Validation") {
 
 	ASSERT(!isValidPerpetualStorageWiggleLocality("aaa:bbb;"));
 	ASSERT(!isValidPerpetualStorageWiggleLocality("aaa:bbb;ccc"));
+	ASSERT(!isValidPerpetualStorageWiggleLocality(""));
 
 	return Void();
 }
 
 std::vector<std::pair<Optional<Value>, Optional<Value>>> ParsePerpetualStorageWiggleLocality(
     const std::string& localityKeyValues) {
-	// parsing format is like "datahall:0"
+	// parsing format is like "datahall:0<;locality:filter>"
 	ASSERT(isValidPerpetualStorageWiggleLocality(localityKeyValues));
 
 	std::vector<std::pair<Optional<Value>, Optional<Value>>> parsedLocalities;

--- a/fdbclient/FDBTypes.cpp
+++ b/fdbclient/FDBTypes.cpp
@@ -21,6 +21,7 @@
 #include "fdbclient/FDBTypes.h"
 #include "fdbclient/Knobs.h"
 #include "fdbclient/NativeAPI.actor.h"
+#include <boost/algorithm/string.hpp>
 
 KeyRangeRef toPrefixRelativeRange(KeyRangeRef range, Optional<KeyRef> prefix) {
 	if (!prefix.present() || prefix.get().empty()) {
@@ -261,5 +262,132 @@ TEST_CASE("/PerpetualStorageWiggleLocality/Validation") {
 	ASSERT(!isValidPerpetualStorageWiggleLocality("aaa:bbb;"));
 	ASSERT(!isValidPerpetualStorageWiggleLocality("aaa:bbb;ccc"));
 
+	return Void();
+}
+
+std::vector<std::pair<Optional<Value>, Optional<Value>>> ParsePerpetualStorageWiggleLocality(
+    const std::string& localityKeyValues) {
+	// parsing format is like "datahall:0"
+	ASSERT(isValidPerpetualStorageWiggleLocality(localityKeyValues));
+
+	std::vector<std::pair<Optional<Value>, Optional<Value>>> parsedLocalities;
+
+	if (localityKeyValues == "0") {
+		return parsedLocalities;
+	}
+
+	std::vector<std::string> splitLocalityKeyValues;
+	boost::split(splitLocalityKeyValues, localityKeyValues, [](char c) { return c == ';'; });
+
+	for (const auto& localityKeyValue : splitLocalityKeyValues) {
+		ASSERT(!localityKeyValue.empty());
+
+		// get key and value from perpetual_storage_wiggle_locality.
+		int split = localityKeyValue.find(':');
+		auto key = Optional<Value>(ValueRef((uint8_t*)localityKeyValue.c_str(), split));
+		auto value = Optional<Value>(
+		    ValueRef((uint8_t*)localityKeyValue.c_str() + split + 1, localityKeyValue.size() - split - 1));
+		parsedLocalities.push_back(std::make_pair(key, value));
+	}
+
+	return parsedLocalities;
+}
+
+bool localityMatchInList(const std::vector<std::pair<Optional<Value>, Optional<Value>>>& localityKeyValues,
+                         const LocalityData& locality) {
+	for (const auto& [localityKey, localityValue] : localityKeyValues) {
+		if (locality.get(localityKey.get()) == localityValue) {
+			return true;
+		}
+	}
+	return false;
+}
+
+TEST_CASE("/PerpetualStorageWiggleLocality/ParsePerpetualStorageWiggleLocality") {
+	{
+		auto localityKeyValues = ParsePerpetualStorageWiggleLocality("aaa:bbb");
+		ASSERT(localityKeyValues.size() == 1);
+		ASSERT(localityKeyValues[0].first.get() == "aaa");
+		ASSERT(localityKeyValues[0].second.get() == "bbb");
+
+		{
+			LocalityData locality;
+			locality.set("aaa"_sr, "bbb"_sr);
+			ASSERT(localityMatchInList(localityKeyValues, locality));
+		}
+
+		{
+			LocalityData locality;
+			locality.set("aaa"_sr, "ccc"_sr);
+			ASSERT(!localityMatchInList(localityKeyValues, locality));
+		}
+	}
+
+	{
+		auto localityKeyValues = ParsePerpetualStorageWiggleLocality("aaa:bbb;ccc:ddd");
+		ASSERT(localityKeyValues.size() == 2);
+		ASSERT(localityKeyValues[0].first.get() == "aaa");
+		ASSERT(localityKeyValues[0].second.get() == "bbb");
+		ASSERT(localityKeyValues[1].first.get() == "ccc");
+		ASSERT(localityKeyValues[1].second.get() == "ddd");
+
+		{
+			LocalityData locality;
+			locality.set("aaa"_sr, "bbb"_sr);
+			ASSERT(localityMatchInList(localityKeyValues, locality));
+		}
+
+		{
+			LocalityData locality;
+			locality.set("ccc"_sr, "ddd"_sr);
+			ASSERT(localityMatchInList(localityKeyValues, locality));
+		}
+
+		{
+			LocalityData locality;
+			locality.set("aaa"_sr, "ddd"_sr);
+			ASSERT(!localityMatchInList(localityKeyValues, locality));
+		}
+	}
+
+	{
+		auto localityKeyValues = ParsePerpetualStorageWiggleLocality("aaa:111;bbb:222;ccc:3dd");
+		ASSERT(localityKeyValues.size() == 3);
+		ASSERT(localityKeyValues[0].first.get() == "aaa");
+		ASSERT(localityKeyValues[0].second.get() == "111");
+		ASSERT(localityKeyValues[1].first.get() == "bbb");
+		ASSERT(localityKeyValues[1].second.get() == "222");
+		ASSERT(localityKeyValues[2].first.get() == "ccc");
+		ASSERT(localityKeyValues[2].second.get() == "3dd");
+
+		{
+			LocalityData locality;
+			locality.set("aaa"_sr, "111"_sr);
+			ASSERT(localityMatchInList(localityKeyValues, locality));
+		}
+
+		{
+			LocalityData locality;
+			locality.set("bbb"_sr, "222"_sr);
+			ASSERT(localityMatchInList(localityKeyValues, locality));
+		}
+
+		{
+			LocalityData locality;
+			locality.set("ccc"_sr, "222"_sr);
+			ASSERT(!localityMatchInList(localityKeyValues, locality));
+		}
+	}
+
+	{
+		auto localityKeyValues = ParsePerpetualStorageWiggleLocality("0");
+		ASSERT(localityKeyValues.empty());
+
+		{
+			LocalityData locality;
+			locality.set("aaa"_sr, "111"_sr);
+			ASSERT(!localityMatchInList(localityKeyValues, locality));
+		}
+	}
 	return Void();
 }

--- a/fdbclient/include/fdbclient/FDBTypes.h
+++ b/fdbclient/include/fdbclient/FDBTypes.h
@@ -36,6 +36,7 @@
 #include "flow/ProtocolVersion.h"
 #include "flow/flow.h"
 #include "fdbclient/Status.h"
+#include "fdbrpc/Locality.h"
 
 typedef int64_t Version;
 typedef uint64_t LogEpoch;
@@ -1615,11 +1616,17 @@ struct DatabaseSharedState {
 
 const static std::regex wiggleLocalityValidation("(\\w+:\\w+)(;\\w+:\\w+)*");
 inline bool isValidPerpetualStorageWiggleLocality(std::string locality) {
-	if (locality == "0") { 
+	if (locality == "0") {
 		return true;
 	}
 	return std::regex_match(locality, wiggleLocalityValidation);
 }
+
+std::vector<std::pair<Optional<Value>, Optional<Value>>> ParsePerpetualStorageWiggleLocality(
+    const std::string& localityKeyValues);
+
+bool localityMatchInList(const std::vector<std::pair<Optional<Value>, Optional<Value>>>& localityKeyValues,
+                         const LocalityData& locality);
 
 // matches what's in fdb_c.h
 struct ReadBlobGranuleContext {

--- a/fdbclient/include/fdbclient/FDBTypes.h
+++ b/fdbclient/include/fdbclient/FDBTypes.h
@@ -1622,9 +1622,12 @@ inline bool isValidPerpetualStorageWiggleLocality(std::string locality) {
 	return std::regex_match(locality, wiggleLocalityValidation);
 }
 
+// Parses `perpetual_storage_wiggle_locality` database option.
 std::vector<std::pair<Optional<Value>, Optional<Value>>> ParsePerpetualStorageWiggleLocality(
     const std::string& localityKeyValues);
 
+// Whether the locality matches any locality filter in `localityKeyValues` (which is supposed to be parsed from
+// ParsePerpetualStorageWiggleLocality).
 bool localityMatchInList(const std::vector<std::pair<Optional<Value>, Optional<Value>>>& localityKeyValues,
                          const LocalityData& locality);
 

--- a/fdbclient/include/fdbclient/FDBTypes.h
+++ b/fdbclient/include/fdbclient/FDBTypes.h
@@ -1613,7 +1613,7 @@ struct DatabaseSharedState {
 	  : protocolVersion(currentProtocolVersion()), mutexLock(Mutex()), grvCacheSpace(GRVCacheSpace()), refCount(0) {}
 };
 
-const static std::regex wiggleLocalityValidation("\\w+:\\w+(;\\w:\\w)*");
+const static std::regex wiggleLocalityValidation("(\\w+:\\w+)(;\\w+:\\w+)*");
 inline bool isValidPerpetualStorageWiggleLocality(std::string locality) {
 	if (locality == "0") { 
 		return true;

--- a/fdbclient/include/fdbclient/FDBTypes.h
+++ b/fdbclient/include/fdbclient/FDBTypes.h
@@ -24,6 +24,7 @@
 #include <algorithm>
 #include <array>
 #include <cinttypes>
+#include <regex>
 #include <set>
 #include <string>
 #include <variant>
@@ -1612,10 +1613,12 @@ struct DatabaseSharedState {
 	  : protocolVersion(currentProtocolVersion()), mutexLock(Mutex()), grvCacheSpace(GRVCacheSpace()), refCount(0) {}
 };
 
+const static std::regex wiggleLocalityValidation("\\w+:\\w+(;\\w:\\w)*");
 inline bool isValidPerpetualStorageWiggleLocality(std::string locality) {
-	int pos = locality.find(':');
-	// locality should be either 0 or in the format '<non_empty_string>:<non_empty_string>'
-	return ((pos > 0 && pos < locality.size() - 1) || locality == "0");
+	if (locality == "0") { 
+		return true;
+	}
+	return std::regex_match(locality, wiggleLocalityValidation);
 }
 
 // matches what's in fdb_c.h

--- a/fdbserver/DDTeamCollection.actor.cpp
+++ b/fdbserver/DDTeamCollection.actor.cpp
@@ -27,7 +27,6 @@
 #include "flow/actorcompiler.h" // This must be the last #include.
 #include "flow/network.h"
 #include <climits>
-#include <boost/algorithm/string.hpp>
 
 namespace {
 
@@ -37,60 +36,6 @@ auto get(MapContainer& m, K const& k) -> decltype(m.at(k)) {
 	auto it = m.find(k);
 	ASSERT(it != m.end());
 	return it->second;
-}
-
-std::vector<std::pair<Optional<Value>, Optional<Value>>> ParsePerpetualStorageWiggleLocality(
-    const std::string& localityKeyValues) {
-	// parsing format is like "datahall:0"
-	ASSERT(isValidPerpetualStorageWiggleLocality(localityKeyValues));
-
-	std::vector<std::pair<Optional<Value>, Optional<Value>>> parsedLocalities;
-
-	std::vector<std::string> splitLocalityKeyValues;
-	boost::split(splitLocalityKeyValues, localityKeyValues, [](char c) { return c == ';'; });
-
-	for (const auto& localityKeyValue : splitLocalityKeyValues) {
-		ASSERT(!localityKeyValue.empty());
-
-		// get key and value from perpetual_storage_wiggle_locality.
-		int split = localityKeyValue.find(':');
-		auto key = Optional<Value>(ValueRef((uint8_t*)localityKeyValue.c_str(), split));
-		auto value = Optional<Value>(
-		    ValueRef((uint8_t*)localityKeyValue.c_str() + split + 1, localityKeyValue.size() - split - 1));
-		parsedLocalities.push_back(std::make_pair(key, value));
-	}
-
-	return parsedLocalities;
-}
-
-TEST_CASE("/DataDistribution/StorageWiggler/ParsePerpetualStorageWiggleLocality") {
-	{
-		auto localityKeyValues = ParsePerpetualStorageWiggleLocality("aaa:bbb");
-		ASSERT(localityKeyValues.size() == 1);
-		ASSERT(localityKeyValues[0].first.get() == "aaa");
-		ASSERT(localityKeyValues[0].second.get() == "bbb");
-	}
-
-	{
-		auto localityKeyValues = ParsePerpetualStorageWiggleLocality("aaa:bbb;ccc:ddd");
-		ASSERT(localityKeyValues.size() == 2);
-		ASSERT(localityKeyValues[0].first.get() == "aaa");
-		ASSERT(localityKeyValues[0].second.get() == "bbb");
-		ASSERT(localityKeyValues[1].first.get() == "ccc");
-		ASSERT(localityKeyValues[1].second.get() == "ddd");
-	}
-
-	{
-		auto localityKeyValues = ParsePerpetualStorageWiggleLocality("aaa:111;bbb:222;ccc:3dd");
-		ASSERT(localityKeyValues.size() == 3);
-		ASSERT(localityKeyValues[0].first.get() == "aaa");
-		ASSERT(localityKeyValues[0].second.get() == "111");
-		ASSERT(localityKeyValues[1].first.get() == "bbb");
-		ASSERT(localityKeyValues[1].second.get() == "222");
-		ASSERT(localityKeyValues[2].first.get() == "ccc");
-		ASSERT(localityKeyValues[2].second.get() == "3dd");
-	}
-	return Void();
 }
 
 } // namespace

--- a/fdbserver/DDTeamCollection.actor.cpp
+++ b/fdbserver/DDTeamCollection.actor.cpp
@@ -27,6 +27,7 @@
 #include "flow/actorcompiler.h" // This must be the last #include.
 #include "flow/network.h"
 #include <climits>
+#include <boost/algorithm/string.hpp>
 
 namespace {
 
@@ -38,17 +39,57 @@ auto get(MapContainer& m, K const& k) -> decltype(m.at(k)) {
 	return it->second;
 }
 
-void ParsePerpetualStorageWiggleLocality(const std::string& localityKeyValue,
-                                         Optional<Value>* localityKey,
-                                         Optional<Value>* localityValue) {
+std::vector<std::pair<Optional<Value>, Optional<Value>>> ParsePerpetualStorageWiggleLocality(const std::string& localityKeyValues) {
 	// parsing format is like "datahall:0"
-	ASSERT(isValidPerpetualStorageWiggleLocality(localityKeyValue));
+	ASSERT(isValidPerpetualStorageWiggleLocality(localityKeyValues));
 
-	// get key and value from perpetual_storage_wiggle_locality.
-	int split = localityKeyValue.find(':');
-	*localityKey = Optional<Value>(ValueRef((uint8_t*)localityKeyValue.c_str(), split));
-	*localityValue =
-	    Optional<Value>(ValueRef((uint8_t*)localityKeyValue.c_str() + split + 1, localityKeyValue.size() - split - 1));
+	std::vector<std::pair<Optional<Value>, Optional<Value>>> parsedLocalities;
+
+	std::vector<std::string> splitLocalityKeyValues;
+	boost::split(splitLocalityKeyValues, localityKeyValues, [](char c){ return c == ';';});
+
+	for (const auto& localityKeyValue : splitLocalityKeyValues) {
+		ASSERT(!localityKeyValue.empty());
+
+		// get key and value from perpetual_storage_wiggle_locality.
+		int split = localityKeyValue.find(':');
+		auto key = Optional<Value>(ValueRef((uint8_t*)localityKeyValue.c_str(), split));
+		auto value =
+		    Optional<Value>(ValueRef((uint8_t*)localityKeyValue.c_str() + split + 1, localityKeyValue.size() - split - 1));
+		parsedLocalities.push_back(std::make_pair(key, value));
+	}
+
+	return parsedLocalities;
+}
+
+TEST_CASE("/DataDistribution/StorageWiggler/ParsePerpetualStorageWiggleLocality") {
+	{
+		auto localityKeyValues = ParsePerpetualStorageWiggleLocality("aaa:bbb");
+		ASSERT(localityKeyValues.size() == 1);
+		ASSERT(localityKeyValues[0].first.get() == "aaa");
+		ASSERT(localityKeyValues[0].second.get() == "bbb");
+	}
+
+	{
+		auto localityKeyValues = ParsePerpetualStorageWiggleLocality("aaa:bbb;ccc:ddd");
+		ASSERT(localityKeyValues.size() == 2);
+		ASSERT(localityKeyValues[0].first.get() == "aaa");
+		ASSERT(localityKeyValues[0].second.get() == "bbb");
+		ASSERT(localityKeyValues[1].first.get() == "ccc");
+		ASSERT(localityKeyValues[1].second.get() == "ddd");
+	}
+	
+	{
+		auto localityKeyValues = ParsePerpetualStorageWiggleLocality("aaa:111;bbb:222;ccc:3dd");
+		ASSERT(localityKeyValues.size() == 3);
+		ASSERT(localityKeyValues[0].first.get() == "aaa");
+		ASSERT(localityKeyValues[0].second.get() == "111");
+		ASSERT(localityKeyValues[1].first.get() == "bbb");
+		ASSERT(localityKeyValues[1].second.get() == "222");
+		ASSERT(localityKeyValues[2].first.get() == "ccc");
+		ASSERT(localityKeyValues[2].second.get() == "3dd");
+	}
+	return Void();
 }
 
 } // namespace
@@ -2417,11 +2458,10 @@ public:
 				if (self->configuration.perpetualStorageWiggleLocality == "0") {
 					isr.storeType = self->configuration.perpetualStoreType;
 				} else {
-					Optional<Value> localityKey;
-					Optional<Value> localityValue;
-					ParsePerpetualStorageWiggleLocality(
-					    self->configuration.perpetualStorageWiggleLocality, &localityKey, &localityValue);
-					if (candidateWorker.worker.locality.get(localityKey.get()) == localityValue) {
+					std::vector<std::pair<Optional<Value>, Optional<Value>>> localityKeyValues = ParsePerpetualStorageWiggleLocality(
+					    self->configuration.perpetualStorageWiggleLocality);
+					ASSERT(localityKeyValues.size() == 1);
+					if (candidateWorker.worker.locality.get(localityKeyValues[0].first.get()) == localityKeyValues[0].second) {
 						isr.storeType = self->configuration.perpetualStoreType;
 					}
 				}
@@ -3951,16 +3991,17 @@ Future<Void> DDTeamCollection::monitorHealthyTeams() {
 }
 
 Future<UID> DDTeamCollection::getNextWigglingServerID() {
-	Optional<Value> localityKey;
-	Optional<Value> localityValue;
+	std::vector<std::pair<Optional<Value>, Optional<Value>>> localityFilter;
 
 	// NOTE: because normal \xff/conf change through `changeConfig` now will cause DD throw `movekeys_conflict()`
 	// then recruit a new DD, we only need to read current configuration once
 	if (configuration.perpetualStorageWiggleLocality != "0") {
-		ParsePerpetualStorageWiggleLocality(configuration.perpetualStorageWiggleLocality, &localityKey, &localityValue);
+		localityFilter = ParsePerpetualStorageWiggleLocality(configuration.perpetualStorageWiggleLocality);
+		ASSERT(localityFilter.size() == 1);
+		return DDTeamCollectionImpl::getNextWigglingServerID(storageWiggler, localityFilter[0].first, localityFilter[0].second, this);
 	}
 
-	return DDTeamCollectionImpl::getNextWigglingServerID(storageWiggler, localityKey, localityValue, this);
+	return DDTeamCollectionImpl::getNextWigglingServerID(storageWiggler, Optional<Value>(), Optional<Value>(), this);
 }
 
 Future<Void> DDTeamCollection::readStorageWiggleMap() {

--- a/fdbserver/DDTeamCollection.actor.cpp
+++ b/fdbserver/DDTeamCollection.actor.cpp
@@ -2406,11 +2406,8 @@ public:
 				} else {
 					std::vector<std::pair<Optional<Value>, Optional<Value>>> localityKeyValues =
 					    ParsePerpetualStorageWiggleLocality(self->configuration.perpetualStorageWiggleLocality);
-					for (const auto& [localityKey, localityValue] : localityKeyValues) {
-						if (candidateWorker.worker.locality.get(localityKey.get()) == localityValue) {
-							isr.storeType = self->configuration.perpetualStoreType;
-							break;
-						}
+					if (localityMatchInList(localityKeyValues, candidateWorker.worker.locality)) {
+						isr.storeType = self->configuration.perpetualStoreType;
 					}
 				}
 			}
@@ -2976,12 +2973,9 @@ public:
 			if (!localityKeyValues.empty()) {
 				// Whether the selected server matches the locality
 				auto server = teamCollection->server_info.at(id.get());
-
-				for (const auto& [localityKey, localityValue] : localityKeyValues) {
-					// TraceEvent("PerpetualLocality").detail("Server", server->getLastKnownInterface().locality.get(localityKey)).detail("Desire", localityValue);
-					if (server->getLastKnownInterface().locality.get(localityKey.get()) == localityValue) {
-						return id.get();
-					}
+				// TraceEvent("PerpetualLocality").detail("Server", server->getLastKnownInterface().locality.get(localityKey)).detail("Desire", localityValue);
+				if (localityMatchInList(localityKeyValues, server->getLastKnownInterface().locality)) {
+					return id.get();
 				}
 
 				if (wiggler->empty()) {

--- a/fdbserver/DDTeamCollection.actor.cpp
+++ b/fdbserver/DDTeamCollection.actor.cpp
@@ -39,14 +39,15 @@ auto get(MapContainer& m, K const& k) -> decltype(m.at(k)) {
 	return it->second;
 }
 
-std::vector<std::pair<Optional<Value>, Optional<Value>>> ParsePerpetualStorageWiggleLocality(const std::string& localityKeyValues) {
+std::vector<std::pair<Optional<Value>, Optional<Value>>> ParsePerpetualStorageWiggleLocality(
+    const std::string& localityKeyValues) {
 	// parsing format is like "datahall:0"
 	ASSERT(isValidPerpetualStorageWiggleLocality(localityKeyValues));
 
 	std::vector<std::pair<Optional<Value>, Optional<Value>>> parsedLocalities;
 
 	std::vector<std::string> splitLocalityKeyValues;
-	boost::split(splitLocalityKeyValues, localityKeyValues, [](char c){ return c == ';';});
+	boost::split(splitLocalityKeyValues, localityKeyValues, [](char c) { return c == ';'; });
 
 	for (const auto& localityKeyValue : splitLocalityKeyValues) {
 		ASSERT(!localityKeyValue.empty());
@@ -54,8 +55,8 @@ std::vector<std::pair<Optional<Value>, Optional<Value>>> ParsePerpetualStorageWi
 		// get key and value from perpetual_storage_wiggle_locality.
 		int split = localityKeyValue.find(':');
 		auto key = Optional<Value>(ValueRef((uint8_t*)localityKeyValue.c_str(), split));
-		auto value =
-		    Optional<Value>(ValueRef((uint8_t*)localityKeyValue.c_str() + split + 1, localityKeyValue.size() - split - 1));
+		auto value = Optional<Value>(
+		    ValueRef((uint8_t*)localityKeyValue.c_str() + split + 1, localityKeyValue.size() - split - 1));
 		parsedLocalities.push_back(std::make_pair(key, value));
 	}
 
@@ -78,7 +79,7 @@ TEST_CASE("/DataDistribution/StorageWiggler/ParsePerpetualStorageWiggleLocality"
 		ASSERT(localityKeyValues[1].first.get() == "ccc");
 		ASSERT(localityKeyValues[1].second.get() == "ddd");
 	}
-	
+
 	{
 		auto localityKeyValues = ParsePerpetualStorageWiggleLocality("aaa:111;bbb:222;ccc:3dd");
 		ASSERT(localityKeyValues.size() == 3);
@@ -2458,8 +2459,8 @@ public:
 				if (self->configuration.perpetualStorageWiggleLocality == "0") {
 					isr.storeType = self->configuration.perpetualStoreType;
 				} else {
-					std::vector<std::pair<Optional<Value>, Optional<Value>>> localityKeyValues = ParsePerpetualStorageWiggleLocality(
-					    self->configuration.perpetualStorageWiggleLocality);
+					std::vector<std::pair<Optional<Value>, Optional<Value>>> localityKeyValues =
+					    ParsePerpetualStorageWiggleLocality(self->configuration.perpetualStorageWiggleLocality);
 					for (const auto& [localityKey, localityValue] : localityKeyValues) {
 						if (candidateWorker.worker.locality.get(localityKey.get()) == localityValue) {
 							isr.storeType = self->configuration.perpetualStoreType;
@@ -3011,9 +3012,11 @@ public:
 		}
 	}
 
-	ACTOR static Future<UID> getNextWigglingServerID(Reference<StorageWiggler> wiggler,
-													 std::vector<std::pair<Optional<Value>, Optional<Value>>> localityKeyValues = std::vector<std::pair<Optional<Value>, Optional<Value>>>(),
-	                                                 DDTeamCollection* teamCollection = nullptr) {
+	ACTOR static Future<UID> getNextWigglingServerID(
+	    Reference<StorageWiggler> wiggler,
+	    std::vector<std::pair<Optional<Value>, Optional<Value>>> localityKeyValues =
+	        std::vector<std::pair<Optional<Value>, Optional<Value>>>(),
+	    DDTeamCollection* teamCollection = nullptr) {
 		ASSERT(wiggler->teamCollection == teamCollection);
 		loop {
 			// when the DC need more
@@ -3029,7 +3032,7 @@ public:
 				// Whether the selected server matches the locality
 				auto server = teamCollection->server_info.at(id.get());
 
-				for (const auto& [localityKey, localityValue] : localityKeyValues){
+				for (const auto& [localityKey, localityValue] : localityKeyValues) {
 					// TraceEvent("PerpetualLocality").detail("Server", server->getLastKnownInterface().locality.get(localityKey)).detail("Desire", localityValue);
 					if (server->getLastKnownInterface().locality.get(localityKey.get()) == localityValue) {
 						return id.get();
@@ -6776,8 +6779,7 @@ TEST_CASE("/DataDistribution/StorageWiggler/NextIdWithTSS") {
 	                                       KeyValueStoreType::SSD_BTREE_V2));
 	ASSERT(!wiggler->getNextServerId(true).present());
 	ASSERT(wiggler->getNextServerId(collection->reachTSSPairTarget()) == UID(1, 0));
-	UID id = wait(
-	    DDTeamCollectionImpl::getNextWigglingServerID(wiggler, {}, collection.get()));
+	UID id = wait(DDTeamCollectionImpl::getNextWigglingServerID(wiggler, {}, collection.get()));
 	ASSERT(now() - startTime < SERVER_KNOBS->DD_STORAGE_WIGGLE_MIN_SS_AGE_SEC + 150.0);
 	ASSERT(id == UID(2, 0));
 	return Void();

--- a/fdbserver/DDTeamCollection.actor.cpp
+++ b/fdbserver/DDTeamCollection.actor.cpp
@@ -3005,21 +3005,22 @@ public:
 			// SOMEDAY: support wiggle multiple SS at once
 			ASSERT(!self->wigglingId.present()); // only single process wiggle is allowed
 
-			Optional<Value> localityKey;
-			Optional<Value> localityValue;
+			std::vector<std::pair<Optional<Value>, Optional<Value>>> localityKeyValues;
 			if (self->configuration.perpetualStorageWiggleLocality != "0") {
-				ParsePerpetualStorageWiggleLocality(
-				    self->configuration.perpetualStorageWiggleLocality, &localityKey, &localityValue);
+				localityKeyValues =
+				    ParsePerpetualStorageWiggleLocality(self->configuration.perpetualStorageWiggleLocality);
 			}
 
 			// if perpetual_storage_wiggle_locality has value and not 0(disabled).
-			if (localityKey.present()) {
-				if (self->server_info.count(res.begin()->first)) {
-					auto server = self->server_info.at(res.begin()->first);
+			if (!localityKeyValues.empty()) {
+				for (const auto& [localityKey, localityValue] : localityKeyValues) {
+					if (self->server_info.count(res.begin()->first)) {
+						auto server = self->server_info.at(res.begin()->first);
 
-					// Update the wigglingId only if it matches the locality.
-					if (server->getLastKnownInterface().locality.get(localityKey.get()) == localityValue) {
-						self->wigglingId = res.begin()->first;
+						// Update the wigglingId only if it matches the locality.
+						if (server->getLastKnownInterface().locality.get(localityKey.get()) == localityValue) {
+							self->wigglingId = res.begin()->first;
+						}
 					}
 				}
 			} else {

--- a/fdbserver/DDTeamCollection.actor.cpp
+++ b/fdbserver/DDTeamCollection.actor.cpp
@@ -3007,10 +3007,9 @@ public:
 
 			// if perpetual_storage_wiggle_locality has value and not 0(disabled).
 			if (!localityKeyValues.empty()) {
-				for (const auto& [localityKey, localityValue] : localityKeyValues) {
-					if (self->server_info.count(res.begin()->first)) {
-						auto server = self->server_info.at(res.begin()->first);
-
+				if (self->server_info.count(res.begin()->first)) {
+					auto server = self->server_info.at(res.begin()->first);
+					for (const auto& [localityKey, localityValue] : localityKeyValues) {
 						// Update the wigglingId only if it matches the locality.
 						if (server->getLastKnownInterface().locality.get(localityKey.get()) == localityValue) {
 							self->wigglingId = res.begin()->first;

--- a/fdbserver/workloads/ConfigureDatabase.actor.cpp
+++ b/fdbserver/workloads/ConfigureDatabase.actor.cpp
@@ -18,6 +18,8 @@
  * limitations under the License.
  */
 
+#include <algorithm>
+
 #include "fdbclient/FDBTypes.h"
 #include "fdbclient/NativeAPI.actor.h"
 #include "fdbserver/TesterInterface.actor.h"
@@ -305,14 +307,9 @@ struct ConfigureDatabaseWorkload : TestWorkload {
 				state DatabaseConfiguration conf = wait(getDatabaseConfiguration(cx));
 
 				state std::string wiggleLocalityKeyValue = conf.perpetualStorageWiggleLocality;
-				state std::string wiggleLocalityKey;
-				state std::string wiggleLocalityValue;
+				state std::vector<std::pair<Optional<Value>, Optional<Value>>> wiggleLocalityKeyValues =
+				    ParsePerpetualStorageWiggleLocality(wiggleLocalityKeyValue);
 				state int i;
-				if (wiggleLocalityKeyValue != "0") {
-					int split = wiggleLocalityKeyValue.find(':');
-					wiggleLocalityKey = wiggleLocalityKeyValue.substr(0, split);
-					wiggleLocalityValue = wiggleLocalityKeyValue.substr(split + 1);
-				}
 
 				state bool pass = true;
 				state std::vector<StorageServerInterface> storageServers = wait(getStorageServers(cx));
@@ -321,8 +318,7 @@ struct ConfigureDatabaseWorkload : TestWorkload {
 					// Check that each storage server has the correct key value store type
 					if (!storageServers[i].isTss() &&
 					    (wiggleLocalityKeyValue == "0" ||
-					     (storageServers[i].locality.get(wiggleLocalityKey).present() &&
-					      storageServers[i].locality.get(wiggleLocalityKey).get().toString() == wiggleLocalityValue))) {
+					     localityMatchInList(wiggleLocalityKeyValues, storageServers[i].locality))) {
 						ReplyPromise<KeyValueStoreType> typeReply;
 						ErrorOr<KeyValueStoreType> keyValueStoreType =
 						    wait(storageServers[i].getKeyValueStoreType.getReplyUnlessFailedFor(typeReply, 2, 0));
@@ -478,19 +474,31 @@ struct ConfigureDatabaseWorkload : TestWorkload {
 					state std::string randomPerpetualWiggleLocality;
 					if (deterministicRandom()->random01() < 0.25) {
 						state std::vector<StorageServerInterface> storageServers = wait(getStorageServers(cx));
-						StorageServerInterface randomSS =
-						    storageServers[deterministicRandom()->randomInt(0, storageServers.size())];
+						std::string localityFilter;
+						int selectSSCount =
+						    deterministicRandom()->randomInt(1, std::min(4, (int)(storageServers.size())));
 						std::vector<StringRef> localityKeys = { LocalityData::keyDcId,
 							                                    LocalityData::keyDataHallId,
 							                                    LocalityData::keyZoneId,
 							                                    LocalityData::keyMachineId,
 							                                    LocalityData::keyProcessId };
-						StringRef randomLocalityKey =
-						    localityKeys[deterministicRandom()->randomInt(0, localityKeys.size())];
-						if (randomSS.locality.isPresent(randomLocalityKey)) {
-							randomPerpetualWiggleLocality =
-							    " perpetual_storage_wiggle_locality=" + randomLocalityKey.toString() + ":" +
-							    randomSS.locality.get(randomLocalityKey).get().toString();
+						for (int i = 0; i < selectSSCount; ++i) {
+							StorageServerInterface randomSS =
+							    storageServers[deterministicRandom()->randomInt(0, storageServers.size())];
+							StringRef randomLocalityKey =
+							    localityKeys[deterministicRandom()->randomInt(0, localityKeys.size())];
+							if (randomSS.locality.isPresent(randomLocalityKey)) {
+								if (localityFilter.size() > 0) {
+									localityFilter += ";";
+								}
+								localityFilter += randomLocalityKey.toString() + ":" +
+								                  randomSS.locality.get(randomLocalityKey).get().toString();
+							}
+						}
+
+						if (localityFilter.size() > 0) {
+							TraceEvent("ConfigureTestSettingWiggleLocality").detail("LocalityFilter", localityFilter);
+							randomPerpetualWiggleLocality = " perpetual_storage_wiggle_locality=" + localityFilter;
 						}
 					}
 

--- a/fdbserver/workloads/ConsistencyCheck.actor.cpp
+++ b/fdbserver/workloads/ConsistencyCheck.actor.cpp
@@ -931,13 +931,8 @@ struct ConsistencyCheckWorkload : TestWorkload {
 		state int j;
 		state std::vector<StorageServerInterface> storageServers = wait(getStorageServers(cx));
 		state std::string wiggleLocalityKeyValue = configuration.perpetualStorageWiggleLocality;
-		state std::string wiggleLocalityKey;
-		state std::string wiggleLocalityValue;
-		if (wiggleLocalityKeyValue != "0") {
-			int split = wiggleLocalityKeyValue.find(':');
-			wiggleLocalityKey = wiggleLocalityKeyValue.substr(0, split);
-			wiggleLocalityValue = wiggleLocalityKeyValue.substr(split + 1);
-		}
+		state std::vector<std::pair<Optional<Value>, Optional<Value>>> wiggleLocalityKeyValues =
+		    ParsePerpetualStorageWiggleLocality(configuration.perpetualStorageWiggleLocality);
 
 		// Check each pair of storage servers for an address match
 		for (i = 0; i < storageServers.size(); i++) {
@@ -953,8 +948,7 @@ struct ConsistencyCheckWorkload : TestWorkload {
 				// Perpetual storage wiggle is used to migrate storage. Check that the matched storage servers are
 				// correctly migrated.
 				if (wiggleLocalityKeyValue == "0" ||
-				    (storageServers[i].locality.get(wiggleLocalityKey).present() &&
-				     storageServers[i].locality.get(wiggleLocalityKey).get().toString() == wiggleLocalityValue)) {
+				    localityMatchInList(wiggleLocalityKeyValues, storageServers[i].locality)) {
 					if (keyValueStoreType.get() != configuration.perpetualStoreType) {
 						TraceEvent("ConsistencyCheck_WrongKeyValueStoreType")
 						    .detail("ServerID", storageServers[i].id())
@@ -981,8 +975,7 @@ struct ConsistencyCheckWorkload : TestWorkload {
 			            (storageServers[i].isTss() &&
 			             keyValueStoreType.get() != configuration.testingStorageServerStoreType)) &&
 			           (wiggleLocalityKeyValue == "0" ||
-			            (storageServers[i].locality.get(wiggleLocalityKey).present() &&
-			             storageServers[i].locality.get(wiggleLocalityKey).get().toString() == wiggleLocalityValue))) {
+			            localityMatchInList(wiggleLocalityKeyValues, storageServers[i].locality))) {
 				TraceEvent("ConsistencyCheck_WrongKeyValueStoreType")
 				    .detail("ServerID", storageServers[i].id())
 				    .detail("StoreType", keyValueStoreType.get().toString())

--- a/tests/SpecificUnitTest.txt
+++ b/tests/SpecificUnitTest.txt
@@ -5,4 +5,5 @@ runSetup=false
 
     testName=UnitTests
     maxTestCases=0
-    testsMatching=/status/json/builder
+    testsMatching=/DataDistribution/StorageWiggler/ParsePerpetualStorageWiggleLocality
+    # testsMatching=/PerpetualStorageWiggleLocality/Validation

--- a/tests/SpecificUnitTest.txt
+++ b/tests/SpecificUnitTest.txt
@@ -5,5 +5,4 @@ runSetup=false
 
     testName=UnitTests
     maxTestCases=0
-    testsMatching=/DataDistribution/StorageWiggler/ParsePerpetualStorageWiggleLocality
-    # testsMatching=/PerpetualStorageWiggleLocality/Validation
+    testsMatching=/status/json/builder


### PR DESCRIPTION
The format of the option will be a `";"` seperated locality list, such as `"processid:123;dcid:456"`

20230913-214228-zhewu_wiggle_list-273c7d29666ffd1c compressed=True data_size=34726723 duration=6745515 ended=100000 fail=5 fail_fast=10 max_runs=100000 pass=99995 priority=100 remaining=0 runtime=1:38:57 sanity=False started=100000 stopped=20230913-232125 submitted=20230913-214228 timeout=5400 username=zhewu_wiggle_list

all failures are related to ShardedRocksDBNonDeterminism

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
