### PR TITLE
Fix compilation errors complaint by GCC-13

### DIFF
--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -913,7 +913,7 @@ ACTOR Future<Void> clearData(Database cx, Optional<TenantName> defaultTenant) {
 
 			std::vector<Future<Void>> deleteFutures;
 			for (auto const& [id, entry] : tenants.results) {
-				if (entry.tenantName != defaultTenant.get()) {
+				if (!defaultTenant.present() || entry.tenantName != defaultTenant.get()) {
 					deleteFutures.push_back(TenantAPI::deleteTenantTransaction(&tr, id));
 				}
 			}

--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -913,7 +913,7 @@ ACTOR Future<Void> clearData(Database cx, Optional<TenantName> defaultTenant) {
 
 			std::vector<Future<Void>> deleteFutures;
 			for (auto const& [id, entry] : tenants.results) {
-				if (entry.tenantName != defaultTenant) {
+				if (entry.tenantName != defaultTenant.get()) {
 					deleteFutures.push_back(TenantAPI::deleteTenantTransaction(&tr, id));
 				}
 			}

--- a/fdbserver/workloads/DcLag.actor.cpp
+++ b/fdbserver/workloads/DcLag.actor.cpp
@@ -75,7 +75,7 @@ struct DcLagWorkload : TestWorkload {
 		std::vector<IPAddress> ips; // all remote process IPs
 		for (const auto& process : g_simulator->getAllProcesses()) {
 			const auto& ip = process->address.ip;
-			if (process->locality.dcId().present() && process->locality.dcId().get() == g_simulator->remoteDcId) {
+			if (process->locality.dcId().present() && process->locality.dcId().get() == g_simulator->remoteDcId.get()) {
 				ips.push_back(ip);
 			}
 		}

--- a/fdbserver/workloads/DcLag.actor.cpp
+++ b/fdbserver/workloads/DcLag.actor.cpp
@@ -75,7 +75,7 @@ struct DcLagWorkload : TestWorkload {
 		std::vector<IPAddress> ips; // all remote process IPs
 		for (const auto& process : g_simulator->getAllProcesses()) {
 			const auto& ip = process->address.ip;
-			if (process->locality.dcId().present() && process->locality.dcId().get() == g_simulator->remoteDcId.get()) {
+			if (process->locality.dcId().present() && process->locality.dcId() == g_simulator->remoteDcId) {
 				ips.push_back(ip);
 			}
 		}

--- a/fdbserver/workloads/GcGenerations.actor.cpp
+++ b/fdbserver/workloads/GcGenerations.actor.cpp
@@ -97,7 +97,7 @@ struct GcGenerationsWorkload : TestWorkload {
 		std::vector<IPAddress> remoteIps; // all remote process IPs
 		for (const auto& process : g_simulator->getAllProcesses()) {
 			const auto& ip = process->address.ip;
-			if (process->locality.dcId().present() && process->locality.dcId().get() == g_simulator->remoteDcId.get() &&
+			if (process->locality.dcId().present() && process->locality.dcId() == g_simulator->remoteDcId &&
 			    !isCoordinator(coordinators, ip)) {
 				remoteIps.push_back(ip);
 			} else {

--- a/fdbserver/workloads/GcGenerations.actor.cpp
+++ b/fdbserver/workloads/GcGenerations.actor.cpp
@@ -97,7 +97,7 @@ struct GcGenerationsWorkload : TestWorkload {
 		std::vector<IPAddress> remoteIps; // all remote process IPs
 		for (const auto& process : g_simulator->getAllProcesses()) {
 			const auto& ip = process->address.ip;
-			if (process->locality.dcId().present() && process->locality.dcId().get() == g_simulator->remoteDcId &&
+			if (process->locality.dcId().present() && process->locality.dcId().get() == g_simulator->remoteDcId.get() &&
 			    !isCoordinator(coordinators, ip)) {
 				remoteIps.push_back(ip);
 			} else {

--- a/metacluster/include/metacluster/ConfigureTenant.actor.h
+++ b/metacluster/include/metacluster/ConfigureTenant.actor.h
@@ -233,7 +233,7 @@ struct ConfigureTenantImpl {
 			return Void();
 		}
 
-		if (self->updatedEntry.toTenantMapEntry() == tenantEntry) {
+		if (self->updatedEntry.toTenantMapEntry() == tenantEntry.get()) {
 			// No update to write to data cluster, just return.
 			return Void();
 		}

--- a/metacluster/include/metacluster/MetaclusterConsistency.actor.h
+++ b/metacluster/include/metacluster/MetaclusterConsistency.actor.h
@@ -214,12 +214,13 @@ private:
 			ASSERT_EQ(data.metaclusterRegistration.get().version, managementData.metaclusterRegistration.get().version);
 
 			if (data.tenantData.lastTenantId >= 0) {
-				ASSERT_EQ(TenantAPI::getTenantIdPrefix(data.tenantData.lastTenantId), managementData.tenantIdPrefix);
+				ASSERT_EQ(TenantAPI::getTenantIdPrefix(data.tenantData.lastTenantId),
+				          managementData.tenantIdPrefix.get());
 				ASSERT_LE(data.tenantData.lastTenantId, managementData.tenantData.lastTenantId);
 			} else {
 				CODE_PROBE(true, "Data cluster has no tenants with current tenant ID prefix");
 				for (auto const& [id, tenant] : data.tenantData.tenantMap) {
-					ASSERT_NE(TenantAPI::getTenantIdPrefix(id), managementData.tenantIdPrefix);
+					ASSERT_NE(TenantAPI::getTenantIdPrefix(id), managementData.tenantIdPrefix.get());
 				}
 			}
 
@@ -259,7 +260,7 @@ private:
 					ASSERT_EQ(metaclusterEntry.tenantState, TenantState::READY);
 					ASSERT(entry.tenantName == metaclusterEntry.tenantName);
 				} else if (entry.tenantName != metaclusterEntry.tenantName) {
-					ASSERT(entry.tenantName == metaclusterEntry.renameDestination);
+					ASSERT(entry.tenantName == metaclusterEntry.renameDestination.get());
 				}
 				if (metaclusterEntry.tenantState != TenantState::UPDATING_CONFIGURATION &&
 				    metaclusterEntry.tenantState != TenantState::REMOVING) {

--- a/metacluster/include/metacluster/MetaclusterConsistency.actor.h
+++ b/metacluster/include/metacluster/MetaclusterConsistency.actor.h
@@ -260,7 +260,8 @@ private:
 					ASSERT_EQ(metaclusterEntry.tenantState, TenantState::READY);
 					ASSERT(entry.tenantName == metaclusterEntry.tenantName);
 				} else if (entry.tenantName != metaclusterEntry.tenantName) {
-					ASSERT(metaclusterEntry.renameDestination.present() && entry.tenantName == metaclusterEntry.renameDestination.get());
+					ASSERT(metaclusterEntry.renameDestination.present() &&
+					       entry.tenantName == metaclusterEntry.renameDestination.get());
 				}
 				if (metaclusterEntry.tenantState != TenantState::UPDATING_CONFIGURATION &&
 				    metaclusterEntry.tenantState != TenantState::REMOVING) {

--- a/metacluster/include/metacluster/MetaclusterConsistency.actor.h
+++ b/metacluster/include/metacluster/MetaclusterConsistency.actor.h
@@ -260,7 +260,7 @@ private:
 					ASSERT_EQ(metaclusterEntry.tenantState, TenantState::READY);
 					ASSERT(entry.tenantName == metaclusterEntry.tenantName);
 				} else if (entry.tenantName != metaclusterEntry.tenantName) {
-					ASSERT(entry.tenantName == metaclusterEntry.renameDestination.get());
+					ASSERT(metaclusterEntry.renameDestination.present() && entry.tenantName == metaclusterEntry.renameDestination.get());
 				}
 				if (metaclusterEntry.tenantState != TenantState::UPDATING_CONFIGURATION &&
 				    metaclusterEntry.tenantState != TenantState::REMOVING) {


### PR DESCRIPTION
## Issue

There are some inappropriate comparison statements between two objects with mismatched types.

For examples:
```
/Programs/foundationdb/metacluster/include/metacluster/ConfigureTenant.actor.h:236:59: error: no match for ‘operator==’ (operand types are ‘TenantMapEntry’ and ‘Optional<TenantMapEntry>’)
  236 |                 if (self->updatedEntry.toTenantMapEntry() == tenantEntry) {
      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^~ ~~~~~~~~~~~
      |                                                        |     |
      |                                                        |     Optional<TenantMapEntry>
      |                                                        TenantMapEntry
```

These errors are complaint by GCC-13.

## Solution

We should invoke the `get` method of `Optional<T>` first and compare these objects.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
