### PR TITLE
Locality check on perpetualStorageWiggleIDPrefix when DD restarts

### DIFF
--- a/fdbserver/DDTeamCollection.actor.cpp
+++ b/fdbserver/DDTeamCollection.actor.cpp
@@ -2934,7 +2934,27 @@ public:
 		if (res.size() > 0) {
 			// SOMEDAY: support wiggle multiple SS at once
 			ASSERT(!self->wigglingId.present()); // only single process wiggle is allowed
-			self->wigglingId = res.begin()->first;
+
+			Optional<Value> localityKey;
+			Optional<Value> localityValue;
+			if (self->configuration.perpetualStorageWiggleLocality != "0") {
+				ParsePerpetualStorageWiggleLocality(
+				    self->configuration.perpetualStorageWiggleLocality, &localityKey, &localityValue);
+			}
+
+			// if perpetual_storage_wiggle_locality has value and not 0(disabled).
+			if (localityKey.present()) {
+				if (self->server_info.count(res.begin()->first)) {
+					auto server = self->server_info.at(res.begin()->first);
+
+					// Update the wigglingId only if it matches the locality.
+					if (server->getLastKnownInterface().locality.get(localityKey.get()) == localityValue) {
+						self->wigglingId = res.begin()->first;
+					}
+				}
+			} else {
+				self->wigglingId = res.begin()->first;
+			}
 		}
 		return Void();
 	}


### PR DESCRIPTION
Locality check on perpetualStorageWiggleIDPrefix when DD restarts
cherry-pick of #10877 

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
