### PR TITLE
Add proxy to backup agent via global var(release-7.1)

### DIFF
--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -222,6 +222,7 @@ CSimpleOpt::SOption g_rgAgentOptions[] = {
 	{ OPT_HELP, "--help", SO_NONE },
 	{ OPT_DEVHELP, "--dev-help", SO_NONE },
 	{ OPT_BLOB_CREDENTIALS, "--blob-credentials", SO_REQ_SEP },
+	{ OPT_PROXY, "--proxy", SO_REQ_SEP },
 #ifndef TLS_DISABLED
 	TLS_OPTION_FLAGS
 #endif

--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -4121,6 +4121,7 @@ int main(int argc, char* argv[]) {
 		case ProgramExe::AGENT:
 			if (!initCluster())
 				return FDB_EXIT_ERROR;
+			fileBackupAgentProxy = proxy;
 			f = stopAfter(runAgent(db));
 			break;
 		case ProgramExe::BACKUP:

--- a/fdbclient/BackupAgent.actor.h
+++ b/fdbclient/BackupAgent.actor.h
@@ -56,6 +56,8 @@ FDB_DECLARE_BOOLEAN_PARAM(DeleteData);
 FDB_DECLARE_BOOLEAN_PARAM(SetValidation);
 FDB_DECLARE_BOOLEAN_PARAM(PartialBackup);
 
+extern Optional<std::string> fileBackupAgentProxy;
+
 class BackupAgentBase : NonCopyable {
 public:
 	// Time formatter for anything backup or restore related

--- a/fdbclient/FileBackupAgent.actor.cpp
+++ b/fdbclient/FileBackupAgent.actor.cpp
@@ -5007,13 +5007,12 @@ public:
 
 					if (backupState != EBackupState::STATE_NEVERRAN) {
 						state Reference<IBackupContainer> bc;
-						state Reference<IBackupContainer> _bc;
 						state TimestampedVersion latestRestorable;
 
 						wait(
 						    store(latestRestorable, getTimestampedVersion(tr, config.getLatestRestorableVersion(tr))) &&
-						    store(_bc, config.backupContainer().getOrThrow(tr)));
-						bc = fileBackup::getBackupContainerWithProxy(_bc);
+						    store(bc, config.backupContainer().getOrThrow(tr)));
+						bc = fileBackup::getBackupContainerWithProxy(bc);
 
 						doc.setKey("Restorable", latestRestorable.present());
 
@@ -5151,14 +5150,13 @@ public:
 				} else {
 					state std::string backupStatus(BackupAgentBase::getStateText(backupState));
 					state Reference<IBackupContainer> bc;
-					state Reference<IBackupContainer> _bc;
 					state Optional<Version> latestRestorableVersion;
 					state Version recentReadVersion;
 
 					wait(store(latestRestorableVersion, config.getLatestRestorableVersion(tr)) &&
-					     store(_bc, config.backupContainer().getOrThrow(tr)) &&
+					     store(bc, config.backupContainer().getOrThrow(tr)) &&
 					     store(recentReadVersion, tr->getReadVersion()));
-					bc = fileBackup::getBackupContainerWithProxy(_bc);
+					bc = fileBackup::getBackupContainerWithProxy(bc);
 
 					bool snapshotProgress = false;
 

--- a/fdbclient/FileBackupAgent.actor.cpp
+++ b/fdbclient/FileBackupAgent.actor.cpp
@@ -5007,10 +5007,12 @@ public:
 
 					if (backupState != EBackupState::STATE_NEVERRAN) {
 						state Reference<IBackupContainer> bc;
+						state Reference<IBackupContainer> _bc;
 						state TimestampedVersion latestRestorable;
 
-						wait(store(latestRestorable, getTimestampedVersion(tr, config.getLatestRestorableVersion(tr))));
-						Reference<IBackupContainer> _bc = wait(config.backupContainer().getOrThrow(tr));
+						wait(
+						    store(latestRestorable, getTimestampedVersion(tr, config.getLatestRestorableVersion(tr))) &&
+						    store(_bc, config.backupContainer().getOrThrow(tr)));
 						bc = fileBackup::getBackupContainerWithProxy(_bc);
 
 						doc.setKey("Restorable", latestRestorable.present());
@@ -5149,13 +5151,14 @@ public:
 				} else {
 					state std::string backupStatus(BackupAgentBase::getStateText(backupState));
 					state Reference<IBackupContainer> bc;
+					state Reference<IBackupContainer> _bc;
 					state Optional<Version> latestRestorableVersion;
 					state Version recentReadVersion;
 
-					wait(store(latestRestorableVersion, config.getLatestRestorableVersion(tr)));
-					Reference<IBackupContainer> _bc = wait(config.backupContainer().getOrThrow(tr));
+					wait(store(latestRestorableVersion, config.getLatestRestorableVersion(tr)) &&
+					     store(_bc, config.backupContainer().getOrThrow(tr)) &&
+					     store(recentReadVersion, tr->getReadVersion()));
 					bc = fileBackup::getBackupContainerWithProxy(_bc);
-					wait(store(recentReadVersion, tr->getReadVersion()));
 
 					bool snapshotProgress = false;
 


### PR DESCRIPTION
  
  backup agent itself does not have proxy info.
  This changes adds the proxy via a global var.


proxy is already passed in from cmd [here](https://github.com/apple/foundationdb/blob/d47e0eaaaa2e985f0ff14cb8cca889d3751d7d83/fdbbackup/backup.actor.cpp#L3784) or from env var [here](https://github.com/apple/foundationdb/blob/d47e0eaaaa2e985f0ff14cb8cca889d3751d7d83/fdbbackup/backup.actor.cpp#L3493)

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
