### PR TITLE
Add yields to backup agents to avoid slow tasks

### DIFF
--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -1752,12 +1752,14 @@ ACTOR Future<json_spirit::mObject> getLayerStatus(Database src, std::string root
 			tr.setOption(FDBTransactionOptions::LOCK_AWARE);
 			state RangeResult kvPairs =
 			    wait(tr.getRange(KeyRangeRef(rootKey, strinc(rootKey)), GetRangeLimits::ROW_LIMIT_UNLIMITED));
-			json_spirit::mObject statusDoc;
-			JSONDoc modifier(statusDoc);
+			state json_spirit::mObject statusDoc;
+			state JSONDoc modifier(statusDoc);
 			for (auto& kv : kvPairs) {
-				json_spirit::mValue docValue;
+				state json_spirit::mValue docValue;
 				json_spirit::read_string(kv.value.toString(), docValue);
+				wait(yield());
 				modifier.absorb(docValue);
+				wait(yield());
 			}
 			JSONDoc::expires_reference_version = (uint64_t)tr.getReadVersion().get();
 			modifier.cleanOps();


### PR DESCRIPTION
If there are many (> 100) backup agents running, then when each backup agent reads the layer status doc for all other backup agents and computes the final backup layer JSON doc (which is done for agent coordination reasons) the JSON manipulations could take long enough to trigger a SlowTask event.  

This PR adds yields both after parsing and after merging the per-agent JSON documents to avoid a SlowTask.  This is similar to what the Cluster Controller does when computing layer status.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
