### PR TITLE
Disable sharded rocks for more sim tests

### DIFF
--- a/tests/fast/GetEstimatedRangeSize.toml
+++ b/tests/fast/GetEstimatedRangeSize.toml
@@ -1,6 +1,7 @@
 [configuration]
 allowDefaultTenant = false
 tenantModes = ['optional', 'required']
+storageEngineExcludeTypes = [5]
 
 [[test]]
 testTitle = 'TenantCreation'

--- a/tests/fast/MutationLogReaderCorrectness.toml
+++ b/tests/fast/MutationLogReaderCorrectness.toml
@@ -1,3 +1,6 @@
+[configuration]
+storageEngineExcludeTypes = [5]
+
 [[test]]
 testTitle = 'MutationLogReaderCorrectness'
 useDB = true

--- a/tests/rare/WriteTagThrottling.toml
+++ b/tests/rare/WriteTagThrottling.toml
@@ -1,3 +1,6 @@
+[configuration]
+storageEngineExcludeTypes = [5]
+
 [[test]]
 testTitle = 'withoutWriteThrottling'
 

--- a/tests/slow/SharedBackupCorrectness.toml
+++ b/tests/slow/SharedBackupCorrectness.toml
@@ -2,6 +2,7 @@
 extraDatabaseMode = 'LocalOrSingle'
 # DR is not currently supported in required tenant mode
 tenantModes = ['disabled', 'optional']
+storageEngineExcludeTypes = [5]
 
 [[test]]
 testTitle = 'BackupAndRestore'


### PR DESCRIPTION
Saw ExternalTimeout test failures for these.


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
