### PR TITLE
Fix audit state serializer

### DIFF
--- a/fdbclient/include/fdbclient/Audit.h
+++ b/fdbclient/include/fdbclient/Audit.h
@@ -54,7 +54,7 @@ struct AuditStorageState {
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, id, auditServerId, range, type, phase, error, ddId);
+		serializer(ar, id, auditServerId, range, type, phase, error, ddId, engineType);
 	}
 
 	inline void setType(AuditType type) { this->type = static_cast<uint8_t>(type); }

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -3238,7 +3238,7 @@ ACTOR Future<Void> doAuditLocationMetadata(Reference<DataDistributor> self,
 				}
 
 				// Log statistic
-				TraceEvent(SevInfo, "DDDoAuditLocationMetadataMetadata", self->ddId)
+				TraceEvent(SevInfo, "DDDoAuditLocationMetadataStatistic", self->ddId)
 				    .suppressFor(30.0)
 				    .detail("AuditType", audit->coreState.getType())
 				    .detail("AuditId", audit->coreState.id)


### PR DESCRIPTION
100K correctness with irrelevant failures:
  20230911-211758-zhewang-e95db43052ad755e           compressed=True data_size=34719940 duration=6567216 ended=100000 fail=3 fail_fast=10 max_runs=100000 pass=99997 priority=100 remaining=0 runtime=1:43:22 sanity=False started=100000 stopped=20230911-230120 submitted=20230911-211758 timeout=5400 username=zhewang

100K AuditStorage test:
  20230911-211852-zhewang-d614cadb38411bd7           compressed=True data_size=34754018 duration=9331095 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:45:14 sanity=False started=100000 stopped=20230911-230406 submitted=20230911-211852 timeout=5400 username=zhewang

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
