### PR TITLE
Fix an assertion failure in tests [release-7.1]

### DIFF
--- a/tests/rare/ClogTlog.toml
+++ b/tests/rare/ClogTlog.toml
@@ -13,6 +13,7 @@ cc_worker_health_checking_interval = 15
 cc_min_degradation_interval = 30
 cc_health_trigger_recovery = true
 peer_latency_degradation_threshold = 1
+peek_tracker_expiration_time = 600
 
 [[test]]
 testTitle = 'ClogTlog'


### PR DESCRIPTION
cherrypick #10894

The buggified value 120 triggers assertion failure, so restore it to the default.

Reproduction seed: -f ./tests/rare/ClogTlog.toml -s 537536800 -b on
commit: 163774cfd at release-7.1


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
