### PR TITLE
[Release-7.3] Cherry-pick multiple fixes to AuditStorage

### DIFF
--- a/fdbcli/GetAuditStatusCommand.actor.cpp
+++ b/fdbcli/GetAuditStatusCommand.actor.cpp
@@ -144,7 +144,12 @@ ACTOR Future<Void> getAuditProgress(Database cx, AuditType auditType, UID auditI
 		state int numCompleteServers = 0;
 		state int numOngoingServers = 0;
 		state int numErrorServers = 0;
+		state int numTSSes = 0;
 		for (; i < interfs.size(); i++) {
+			if (interfs[i].isTss()) {
+				numTSSes++;
+				continue; // SSShard audit does not test TSS
+			}
 			AuditPhase serverPhase = wait(getAuditProgressByServer(cx, auditType, auditId, allKeys, interfs[i].id()));
 			if (serverPhase == AuditPhase::Running) {
 				numOngoingServers++;
@@ -159,6 +164,7 @@ ACTOR Future<Void> getAuditProgress(Database cx, AuditType auditType, UID auditI
 		printf("CompleteServers: %d\n", numCompleteServers);
 		printf("OngoingServers: %d\n", numOngoingServers);
 		printf("ErrorServers: %d\n", numErrorServers);
+		printf("IgnoredTSSes: %d\n", numTSSes);
 	} else {
 		printf("AuditType not implemented\n");
 	}

--- a/fdbclient/include/fdbclient/Audit.h
+++ b/fdbclient/include/fdbclient/Audit.h
@@ -54,7 +54,7 @@ struct AuditStorageState {
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, id, auditServerId, range, type, phase, error, ddId);
+		serializer(ar, id, auditServerId, range, type, phase, error, ddId, engineType);
 	}
 
 	inline void setType(AuditType type) { this->type = static_cast<uint8_t>(type); }

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -95,8 +95,13 @@ struct DDAudit {
 	int64_t overallCompleteDoAuditCount;
 	int64_t overallSkippedDoAuditCount;
 	AsyncVar<int> remainingBudgetForAuditTasks;
+<<<<<<< HEAD
 	uint8_t context;
 	std::unordered_map<UID, bool> serverProgressFinishMap; // dedicated to ssshard
+=======
+	DDAuditContext context;
+	std::unordered_set<UID> serversFinishedSSShardAudit; // dedicated to ssshard
+>>>>>>> 29a2f63f8 (Fix SSShard Audit (#10896))
 
 	inline void setAuditRunActor(Future<Void> actor) { auditActor = actor; }
 	inline Future<Void> getAuditRunActor() { return auditActor; }
@@ -310,10 +315,12 @@ static std::set<int> const& normalDDQueueErrors() {
 }
 
 struct DataDistributor;
-void runAuditStorage(Reference<DataDistributor> self,
-                     AuditStorageState auditStates,
-                     int retryCount,
-                     DDAuditContext context);
+void runAuditStorage(
+    Reference<DataDistributor> self,
+    AuditStorageState auditStates,
+    int retryCount,
+    DDAuditContext context,
+    Optional<std::unordered_set<UID>> serversFinishedSSShardAudit = Optional<std::unordered_set<UID>>());
 ACTOR Future<Void> auditStorageCore(Reference<DataDistributor> self,
                                     UID auditID,
                                     AuditType auditType,
@@ -1710,9 +1717,12 @@ ACTOR Future<bool> checkAuditProgressCompleteForSSShard(Database cx, std::shared
 	    .detail("InitBudget", remainingBudget->get());
 	for (; i < interfs.size(); i++) {
 		serverId = interfs[i].uniqueID;
-		if (audit->serverProgressFinishMap.contains(serverId) && audit->serverProgressFinishMap[serverId]) {
+		if (audit->serversFinishedSSShardAudit.contains(serverId)) {
 			TraceEvent(SevDebug, "CheckAuditProgressCompleteForSSShardSkipCheck").detail("ServerId", serverId);
-			continue; // skip if already complete
+			continue; // Skip if already complete
+		}
+		if (interfs[i].isTss()) {
+			continue; // SSShard audit does not test TSS
 		}
 		ASSERT(remainingBudget->get() >= 0);
 		while (remainingBudget->get() == 0) {
@@ -1733,12 +1743,13 @@ ACTOR Future<bool> checkAuditProgressCompleteForSSShard(Database cx, std::shared
 	}
 	wait(actors.getResult());
 	for (const auto& [serverId, finish] : res) {
-		audit->serverProgressFinishMap[serverId] = finish;
 		TraceEvent(SevDebug, "CheckAuditProgressCompleteForSSShardRes")
 		    .detail("AuditState", audit->coreState.toString())
 		    .detail("ServerId", serverId)
 		    .detail("Finish", finish);
-		if (!finish) {
+		if (finish) {
+			audit->serversFinishedSSShardAudit.insert(serverId);
+		} else {
 			allFinish = false;
 		}
 	}
@@ -1900,7 +1911,15 @@ ACTOR Future<Void> auditStorageCore(Reference<DataDistributor> self,
 			// Erase the old audit from map and spawn a new audit inherit from the old audit
 			removeAuditFromAuditMap(self, audit->coreState.getType(),
 			                        audit->coreState.id); // remove audit
-			runAuditStorage(self, audit->coreState, audit->retryCount, DDAuditContext::Retry);
+			if (audit->coreState.getType() == AuditType::ValidateStorageServerShard) {
+				runAuditStorage(self,
+				                audit->coreState,
+				                audit->retryCount,
+				                DDAuditContext::Retry,
+				                audit->serversFinishedSSShardAudit);
+			} else {
+				runAuditStorage(self, audit->coreState, audit->retryCount, DDAuditContext::Retry);
+			}
 		} else {
 			try {
 				audit->coreState.setPhase(AuditPhase::Failed);
@@ -1954,7 +1973,8 @@ ACTOR Future<Void> auditStorageCore(Reference<DataDistributor> self,
 void runAuditStorage(Reference<DataDistributor> self,
                      AuditStorageState auditState,
                      int retryCount,
-                     DDAuditContext context) {
+                     DDAuditContext context,
+                     Optional<std::unordered_set<UID>> serversFinishedSSShardAudit) {
 	// Validate input auditState
 	if (auditState.getType() != AuditType::ValidateHA && auditState.getType() != AuditType::ValidateReplica &&
 	    auditState.getType() != AuditType::ValidateLocationMetadata &&
@@ -1971,6 +1991,9 @@ void runAuditStorage(Reference<DataDistributor> self,
 	std::shared_ptr<DDAudit> audit = std::make_shared<DDAudit>(auditState);
 	audit->retryCount = retryCount;
 	audit->setDDAuditContext(context);
+	if (serversFinishedSSShardAudit.present()) {
+		audit->serversFinishedSSShardAudit = serversFinishedSSShardAudit.get();
+	}
 	addAuditToAuditMap(self, audit);
 	audit->setAuditRunActor(auditStorageCore(self, audit->coreState.id, audit->coreState.getType(), audit->retryCount));
 	return;

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -3131,7 +3131,7 @@ ACTOR Future<Void> doAuditLocationMetadata(Reference<DataDistributor> self,
 				}
 
 				// Log statistic
-				TraceEvent(SevInfo, "DDDoAuditLocationMetadataMetadata", self->ddId)
+				TraceEvent(SevInfo, "DDDoAuditLocationMetadataStatistic", self->ddId)
 				    .suppressFor(30.0)
 				    .detail("AuditType", audit->coreState.getType())
 				    .detail("AuditId", audit->coreState.id)

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -2909,8 +2909,7 @@ ACTOR Future<Void> doAuditOnStorageServer(Reference<DataDistributor> self,
 	try {
 		audit->overallIssuedDoAuditCount++;
 		ASSERT(req.ddId.isValid());
-		ErrorOr<AuditStorageState> vResult = wait(ssi.auditStorage.getReplyUnlessFailedFor(
-		    req, /*sustainedFailureDuration=*/2.0, /*sustainedFailureSlope=*/0));
+		ErrorOr<AuditStorageState> vResult = wait(ssi.auditStorage.tryGetReply(req));
 		if (vResult.isError()) {
 			throw vResult.getError();
 		}

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -95,13 +95,8 @@ struct DDAudit {
 	int64_t overallCompleteDoAuditCount;
 	int64_t overallSkippedDoAuditCount;
 	AsyncVar<int> remainingBudgetForAuditTasks;
-<<<<<<< HEAD
 	uint8_t context;
-	std::unordered_map<UID, bool> serverProgressFinishMap; // dedicated to ssshard
-=======
-	DDAuditContext context;
 	std::unordered_set<UID> serversFinishedSSShardAudit; // dedicated to ssshard
->>>>>>> 29a2f63f8 (Fix SSShard Audit (#10896))
 
 	inline void setAuditRunActor(Future<Void> actor) { auditActor = actor; }
 	inline Future<Void> getAuditRunActor() { return auditActor; }

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -5587,7 +5587,11 @@ ACTOR Future<Void> auditStorageShardReplicaQ(StorageServer* data, AuditStorageRe
 						errors.push_back(error);
 						continue; // check next remote server
 					} else if (i >= remote.data.size() && !remote.more && i < local.data.size()) {
-						ASSERT(missingKey);
+						if (!missingKey) {
+							TraceEvent(g_network->isSimulated() ? SevError : SevWarnAlways,
+							           "SSAuditStorageShardReplicaMissingKeyUnexpected",
+							           data->thisServerID);
+						}
 						std::string error =
 						    format("Missing key(s) form remote server (%lld), next local server(%016llx) key: %s",
 						           remoteServer.uniqueID.first(),


### PR DESCRIPTION
100K correctness:
  20230914-183045-zhewang-10f2a796f72500ab           compressed=True data_size=33605057 duration=6796592 ended=100000 fail=3 fail_fast=10 max_runs=100000 pass=99997 priority=100 remaining=0 runtime=1:36:35 sanity=False started=100000 stopped=20230914-200720 submitted=20230914-183045 timeout=5400 username=zhewang

100K AuditStorage:
  20230914-183135-zhewang-19a88159b6352b18           compressed=True data_size=33635669 duration=11088227 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:45:58 sanity=False started=100000 stopped=20230914-201733 submitted=20230914-183135 timeout=5400 username=zhewang

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
