### PR TITLE
Fix SSShard Audit

### DIFF
--- a/fdbcli/GetAuditStatusCommand.actor.cpp
+++ b/fdbcli/GetAuditStatusCommand.actor.cpp
@@ -144,7 +144,12 @@ ACTOR Future<Void> getAuditProgress(Database cx, AuditType auditType, UID auditI
 		state int numCompleteServers = 0;
 		state int numOngoingServers = 0;
 		state int numErrorServers = 0;
+		state int numTSSes = 0;
 		for (; i < interfs.size(); i++) {
+			if (interfs[i].isTss()) {
+				numTSSes++;
+				continue;
+			}
 			AuditPhase serverPhase = wait(getAuditProgressByServer(cx, auditType, auditId, allKeys, interfs[i].id()));
 			if (serverPhase == AuditPhase::Running) {
 				numOngoingServers++;
@@ -159,6 +164,7 @@ ACTOR Future<Void> getAuditProgress(Database cx, AuditType auditType, UID auditI
 		printf("CompleteServers: %d\n", numCompleteServers);
 		printf("OngoingServers: %d\n", numOngoingServers);
 		printf("ErrorServers: %d\n", numErrorServers);
+		printf("IgnoredTSSes: %d\n", numTSSes);
 	} else {
 		printf("AuditType not implemented\n");
 	}

--- a/fdbcli/GetAuditStatusCommand.actor.cpp
+++ b/fdbcli/GetAuditStatusCommand.actor.cpp
@@ -148,7 +148,7 @@ ACTOR Future<Void> getAuditProgress(Database cx, AuditType auditType, UID auditI
 		for (; i < interfs.size(); i++) {
 			if (interfs[i].isTss()) {
 				numTSSes++;
-				continue;
+				continue; // SSShard audit does not test TSS
 			}
 			AuditPhase serverPhase = wait(getAuditProgressByServer(cx, auditType, auditId, allKeys, interfs[i].id()));
 			if (serverPhase == AuditPhase::Running) {

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -322,11 +322,12 @@ ACTOR Future<Void> debugCheckCoalescing(Database cx) {
 }
 
 struct DataDistributor;
-void runAuditStorage(Reference<DataDistributor> self,
-                     AuditStorageState auditStates,
-                     int retryCount,
-                     DDAuditContext context,
-                     Optional<std::unordered_set<UID>> serversFinishedSSShardAudit = Optional<std::unordered_set<UID>>());
+void runAuditStorage(
+    Reference<DataDistributor> self,
+    AuditStorageState auditStates,
+    int retryCount,
+    DDAuditContext context,
+    Optional<std::unordered_set<UID>> serversFinishedSSShardAudit = Optional<std::unordered_set<UID>>());
 ACTOR Future<Void> auditStorageCore(Reference<DataDistributor> self,
                                     UID auditID,
                                     AuditType auditType,
@@ -2013,8 +2014,11 @@ ACTOR Future<Void> auditStorageCore(Reference<DataDistributor> self,
 			removeAuditFromAuditMap(self, audit->coreState.getType(),
 			                        audit->coreState.id); // remove audit
 			if (audit->coreState.getType() == AuditType::ValidateStorageServerShard) {
-				runAuditStorage(
-				    self, audit->coreState, audit->retryCount, DDAuditContext::RETRY, audit->serversFinishedSSShardAudit);
+				runAuditStorage(self,
+				                audit->coreState,
+				                audit->retryCount,
+				                DDAuditContext::RETRY,
+				                audit->serversFinishedSSShardAudit);
 			} else {
 				runAuditStorage(self, audit->coreState, audit->retryCount, DDAuditContext::RETRY);
 			}

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -119,7 +119,7 @@ struct DDAudit {
 	int64_t overallSkippedDoAuditCount;
 	AsyncVar<int> remainingBudgetForAuditTasks;
 	DDAuditContext context;
-	std::unordered_map<UID, bool> serverProgressFinishMap; // dedicated to ssshard
+	std::unordered_set<UID> serversFinishedSSShardAudit; // dedicated to ssshard
 
 	inline void setAuditRunActor(Future<Void> actor) { auditActor = actor; }
 	inline Future<Void> getAuditRunActor() { return auditActor; }
@@ -322,12 +322,11 @@ ACTOR Future<Void> debugCheckCoalescing(Database cx) {
 }
 
 struct DataDistributor;
-void runAuditStorage(
-    Reference<DataDistributor> self,
-    AuditStorageState auditStates,
-    int retryCount,
-    DDAuditContext context,
-    Optional<std::unordered_map<UID, bool>> serverProgressFinishMap = Optional<std::unordered_map<UID, bool>>());
+void runAuditStorage(Reference<DataDistributor> self,
+                     AuditStorageState auditStates,
+                     int retryCount,
+                     DDAuditContext context,
+                     Optional<std::unordered_set<UID>> serversFinishedSSShardAudit = Optional<std::unordered_set<UID>>());
 ACTOR Future<Void> auditStorageCore(Reference<DataDistributor> self,
                                     UID auditID,
                                     AuditType auditType,
@@ -1819,12 +1818,12 @@ ACTOR Future<bool> checkAuditProgressCompleteForSSShard(Database cx, std::shared
 	    .detail("InitBudget", remainingBudget->get());
 	for (; i < interfs.size(); i++) {
 		serverId = interfs[i].uniqueID;
-		if (audit->serverProgressFinishMap.contains(serverId) && audit->serverProgressFinishMap[serverId]) {
+		if (audit->serversFinishedSSShardAudit.contains(serverId)) {
 			TraceEvent(SevDebug, "CheckAuditProgressCompleteForSSShardSkipCheck").detail("ServerId", serverId);
-			continue; // skip if already complete
+			continue; // Skip if already complete
 		}
 		if (interfs[i].isTss()) {
-			continue; // we do not test TSS
+			continue; // SSShard audit does not test TSS
 		}
 		ASSERT(remainingBudget->get() >= 0);
 		while (remainingBudget->get() == 0) {
@@ -1845,12 +1844,13 @@ ACTOR Future<bool> checkAuditProgressCompleteForSSShard(Database cx, std::shared
 	}
 	wait(actors.getResult());
 	for (const auto& [serverId, finish] : res) {
-		audit->serverProgressFinishMap[serverId] = finish;
 		TraceEvent(SevDebug, "CheckAuditProgressCompleteForSSShardRes")
 		    .detail("AuditState", audit->coreState.toString())
 		    .detail("ServerId", serverId)
 		    .detail("Finish", finish);
-		if (!finish) {
+		if (finish) {
+			audit->serversFinishedSSShardAudit.insert(serverId);
+		} else {
 			allFinish = false;
 		}
 	}
@@ -2014,7 +2014,7 @@ ACTOR Future<Void> auditStorageCore(Reference<DataDistributor> self,
 			                        audit->coreState.id); // remove audit
 			if (audit->coreState.getType() == AuditType::ValidateStorageServerShard) {
 				runAuditStorage(
-				    self, audit->coreState, audit->retryCount, DDAuditContext::RETRY, audit->serverProgressFinishMap);
+				    self, audit->coreState, audit->retryCount, DDAuditContext::RETRY, audit->serversFinishedSSShardAudit);
 			} else {
 				runAuditStorage(self, audit->coreState, audit->retryCount, DDAuditContext::RETRY);
 			}
@@ -2072,7 +2072,7 @@ void runAuditStorage(Reference<DataDistributor> self,
                      AuditStorageState auditState,
                      int retryCount,
                      DDAuditContext context,
-                     Optional<std::unordered_map<UID, bool>> serverProgressFinishMap) {
+                     Optional<std::unordered_set<UID>> serversFinishedSSShardAudit) {
 	// Validate input auditState
 	if (auditState.getType() != AuditType::ValidateHA && auditState.getType() != AuditType::ValidateReplica &&
 	    auditState.getType() != AuditType::ValidateLocationMetadata &&
@@ -2089,8 +2089,8 @@ void runAuditStorage(Reference<DataDistributor> self,
 	std::shared_ptr<DDAudit> audit = std::make_shared<DDAudit>(auditState);
 	audit->retryCount = retryCount;
 	audit->setDDAuditContext(context);
-	if (serverProgressFinishMap.present()) {
-		audit->serverProgressFinishMap = serverProgressFinishMap.get();
+	if (serversFinishedSSShardAudit.present()) {
+		audit->serversFinishedSSShardAudit = serversFinishedSSShardAudit.get();
 	}
 	addAuditToAuditMap(self, audit);
 	audit->setAuditRunActor(auditStorageCore(self, audit->coreState.id, audit->coreState.getType(), audit->retryCount));

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -322,10 +322,12 @@ ACTOR Future<Void> debugCheckCoalescing(Database cx) {
 }
 
 struct DataDistributor;
-void runAuditStorage(Reference<DataDistributor> self,
-                     AuditStorageState auditStates,
-                     int retryCount,
-                     DDAuditContext context);
+void runAuditStorage(
+    Reference<DataDistributor> self,
+    AuditStorageState auditStates,
+    int retryCount,
+    DDAuditContext context,
+    Optional<std::unordered_map<UID, bool>> serverProgressFinishMap = Optional<std::unordered_map<UID, bool>>());
 ACTOR Future<Void> auditStorageCore(Reference<DataDistributor> self,
                                     UID auditID,
                                     AuditType auditType,
@@ -1821,6 +1823,9 @@ ACTOR Future<bool> checkAuditProgressCompleteForSSShard(Database cx, std::shared
 			TraceEvent(SevDebug, "CheckAuditProgressCompleteForSSShardSkipCheck").detail("ServerId", serverId);
 			continue; // skip if already complete
 		}
+		if (interfs[i].isTss()) {
+			continue; // we do not test TSS
+		}
 		ASSERT(remainingBudget->get() >= 0);
 		while (remainingBudget->get() == 0) {
 			wait(remainingBudget->onChange());
@@ -2007,7 +2012,12 @@ ACTOR Future<Void> auditStorageCore(Reference<DataDistributor> self,
 			// Erase the old audit from map and spawn a new audit inherit from the old audit
 			removeAuditFromAuditMap(self, audit->coreState.getType(),
 			                        audit->coreState.id); // remove audit
-			runAuditStorage(self, audit->coreState, audit->retryCount, DDAuditContext::RETRY);
+			if (audit->coreState.getType() == AuditType::ValidateStorageServerShard) {
+				runAuditStorage(
+				    self, audit->coreState, audit->retryCount, DDAuditContext::RETRY, audit->serverProgressFinishMap);
+			} else {
+				runAuditStorage(self, audit->coreState, audit->retryCount, DDAuditContext::RETRY);
+			}
 		} else {
 			try {
 				audit->coreState.setPhase(AuditPhase::Failed);
@@ -2061,7 +2071,8 @@ ACTOR Future<Void> auditStorageCore(Reference<DataDistributor> self,
 void runAuditStorage(Reference<DataDistributor> self,
                      AuditStorageState auditState,
                      int retryCount,
-                     DDAuditContext context) {
+                     DDAuditContext context,
+                     Optional<std::unordered_map<UID, bool>> serverProgressFinishMap) {
 	// Validate input auditState
 	if (auditState.getType() != AuditType::ValidateHA && auditState.getType() != AuditType::ValidateReplica &&
 	    auditState.getType() != AuditType::ValidateLocationMetadata &&
@@ -2078,6 +2089,9 @@ void runAuditStorage(Reference<DataDistributor> self,
 	std::shared_ptr<DDAudit> audit = std::make_shared<DDAudit>(auditState);
 	audit->retryCount = retryCount;
 	audit->setDDAuditContext(context);
+	if (serverProgressFinishMap.present()) {
+		audit->serverProgressFinishMap = serverProgressFinishMap.get();
+	}
 	addAuditToAuditMap(self, audit);
 	audit->setAuditRunActor(auditStorageCore(self, audit->coreState.id, audit->coreState.getType(), audit->retryCount));
 	return;

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -5674,7 +5674,11 @@ ACTOR Future<Void> auditStorageShardReplicaQ(StorageServer* data, AuditStorageRe
 						errors.push_back(error);
 						continue; // check next remote server
 					} else if (i >= remote.data.size() && !remote.more && i < local.data.size()) {
-						ASSERT(missingKey);
+						if (!missingKey) {
+							TraceEvent(g_network->isSimulated() ? SevError : SevWarnAlways,
+							           "SSAuditStorageShardReplicaMissingKeyUnexpected",
+							           data->thisServerID);
+						}
 						std::string error =
 						    format("Missing key(s) form remote server (%lld), next local server(%016llx) key: %s",
 						           remoteServer.uniqueID.first(),


### PR DESCRIPTION
SSShard dispatches audit tasks for any SS except for TSS.
However, when checking whether the SSShard completes, it checks all SSes.
So, SSShard audit cannot stop when there are TSSes.
This PR fixes this issue.

100K correctness with 2 irrelevant failures:
  20230913-182451-zhewang-93d6990f5d847e68           compressed=True data_size=34722150 duration=5538344 ended=100000 fail=2 fail_fast=10 max_runs=100000 pass=99998 priority=100 remaining=0 runtime=1:32:55 sanity=False started=100000 stopped=20230913-195746 submitted=20230913-182451 timeout=5400 username=zhewang

100K AuditStorage:
  20230913-182519-zhewang-c75e981c056ed633           compressed=True data_size=34754183 duration=8699036 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:18:38 sanity=False started=100000 stopped=20230913-194357 submitted=20230913-182519 timeout=5400 username=zhewang

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
