### PR TITLE
Disable sharded rocks for more sim tests

### DIFF
--- a/tests/rare/TransactionCost.toml
+++ b/tests/rare/TransactionCost.toml
@@ -1,3 +1,6 @@
+[configuration]
+storageEngineExcludeTypes=[5]
+
 [[test]]
 testTitle = 'TransactionCostTest'
 

--- a/tests/restarting/from_7.3.0/UpgradeAndBackupRestore-1.toml
+++ b/tests/restarting/from_7.3.0/UpgradeAndBackupRestore-1.toml
@@ -1,5 +1,5 @@
 [configuration]
-storageEngineExcludeTypes=[3]
+storageEngineExcludeTypes=[3,5]
 
 [[test]]
 testTitle = 'SubmitBackup'

--- a/tests/slow/DDBalanceAndRemoveStatus.toml
+++ b/tests/slow/DDBalanceAndRemoveStatus.toml
@@ -1,3 +1,6 @@
+[configuration]
+storageEngineExcludeTypes=[5]
+
 [[test]]
 testTitle = 'DDBalance_Test'
 

--- a/tests/slow/SwizzledApiCorrectness.toml
+++ b/tests/slow/SwizzledApiCorrectness.toml
@@ -1,3 +1,6 @@
+[configuration]
+storageEngineExcludeTypes = [5]
+
 [[test]]
 testTitle = 'ApiCorrectnessTest'
 clearAfterTest = true


### PR DESCRIPTION
Saw ExternalTimeout test failures for these.


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
