### PR TITLE
Fix duplicated requests from DDDoAudit

### DIFF
--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -3011,8 +3011,7 @@ ACTOR Future<Void> doAuditOnStorageServer(Reference<DataDistributor> self,
 	try {
 		audit->overallIssuedDoAuditCount++;
 		ASSERT(req.ddId.isValid());
-		ErrorOr<AuditStorageState> vResult = wait(ssi.auditStorage.getReplyUnlessFailedFor(
-		    req, /*sustainedFailureDuration=*/2.0, /*sustainedFailureSlope=*/0));
+		ErrorOr<AuditStorageState> vResult = wait(ssi.auditStorage.tryGetReply(req));
 		if (vResult.isError()) {
 			throw vResult.getError();
 		}


### PR DESCRIPTION
100K correctness test with 4 irrelevant failures:
  20230914-053527-zhewang-7915c27f65a8d5f8           compressed=True data_size=34728639 duration=6631017 ended=100000 fail=4 fail_fast=10 max_runs=100000 pass=99996 priority=100 remaining=0 runtime=1:25:01 sanity=False started=100000 stopped=20230914-070028 submitted=20230914-053527 timeout=5400 username=zhewang

100K ValidateStorage test:
  20230914-053545-zhewang-7d0e16d28e001394           compressed=True data_size=34757861 duration=9504942 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:28:05 sanity=False started=100000 stopped=20230914-070350 submitted=20230914-053545 timeout=5400 username=zhewang

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
