### PR TITLE
Storage-Queue-Aware GetTeam

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -289,7 +289,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( DD_STORAGE_WIGGLE_PAUSE_THRESHOLD,                      10 ); if( randomize && BUGGIFY ) DD_STORAGE_WIGGLE_PAUSE_THRESHOLD = 1000;
 	init( DD_STORAGE_WIGGLE_STUCK_THRESHOLD,                      20 );
 	init( DD_BUILD_EXTRA_TEAMS_OVERRIDE,                          10 ); if( randomize && BUGGIFY ) DD_BUILD_EXTRA_TEAMS_OVERRIDE = 2;
-	init( ENABLE_STORAGE_QUEUE_AWARE_TEAM_SELECTION,            true );
+	init( ENABLE_STORAGE_QUEUE_AWARE_TEAM_SELECTION,           false );
 	init( DD_TARGET_STORAGE_QUEUE_SIZE,                         TARGET_BYTES_PER_STORAGE_SERVER/3 );
 
 	// TeamRemover

--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -135,6 +135,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( DD_QUEUE_LOGGING_INTERVAL,                             5.0 );
 	init( RELOCATION_PARALLELISM_PER_SOURCE_SERVER,                2 ); if( randomize && BUGGIFY ) RELOCATION_PARALLELISM_PER_SOURCE_SERVER = 1;
 	init( RELOCATION_PARALLELISM_PER_DEST_SERVER,                 10 ); if( randomize && BUGGIFY ) RELOCATION_PARALLELISM_PER_DEST_SERVER = 1; // Note: if this is smaller than FETCH_KEYS_PARALLELISM, this will artificially reduce performance. The current default of 10 is probably too high but is set conservatively for now.
+	init( RELOCATION_PARALLELISM_FACTOR_HOT_SHARD,               0.2 );
 	init( DD_QUEUE_MAX_KEY_SERVERS,                              100 ); if( randomize && BUGGIFY ) DD_QUEUE_MAX_KEY_SERVERS = 1;
 	init( DD_REBALANCE_PARALLELISM,                               50 );
 	init( DD_REBALANCE_RESET_AMOUNT,                              30 );
@@ -290,7 +291,6 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( DD_STORAGE_WIGGLE_PAUSE_THRESHOLD,                      10 ); if( randomize && BUGGIFY ) DD_STORAGE_WIGGLE_PAUSE_THRESHOLD = 1000;
 	init( DD_STORAGE_WIGGLE_STUCK_THRESHOLD,                      20 );
 	init( DD_BUILD_EXTRA_TEAMS_OVERRIDE,                          10 ); if( randomize && BUGGIFY ) DD_BUILD_EXTRA_TEAMS_OVERRIDE = 2;
-	init( DD_DECREMENT_STORAGE_QUEUE_AWARE_SHARD_DELAY_TIME,   300.0 );
 
 	// TeamRemover
 	init( TR_FLAG_DISABLE_MACHINE_TEAM_REMOVER,                false ); if( randomize && BUGGIFY ) TR_FLAG_DISABLE_MACHINE_TEAM_REMOVER = deterministicRandom()->random01() < 0.1 ? true : false; // false by default. disable the consistency check when it's true

--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -162,6 +162,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( PRIORITY_TEAM_1_LEFT,                                  800 );
 	init( PRIORITY_TEAM_FAILED,                                  805 );
 	init( PRIORITY_TEAM_0_LEFT,                                  809 );
+	init( PRIORITY_STORAGE_QUEUE_AWARE_REDISTRIBUTE,             940 );
 	init( PRIORITY_SPLIT_SHARD,                                  950 ); if( randomize && BUGGIFY ) PRIORITY_SPLIT_SHARD = 350;
 
 	// Data distribution

--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -289,8 +289,8 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( DD_STORAGE_WIGGLE_PAUSE_THRESHOLD,                      10 ); if( randomize && BUGGIFY ) DD_STORAGE_WIGGLE_PAUSE_THRESHOLD = 1000;
 	init( DD_STORAGE_WIGGLE_STUCK_THRESHOLD,                      20 );
 	init( DD_BUILD_EXTRA_TEAMS_OVERRIDE,                          10 ); if( randomize && BUGGIFY ) DD_BUILD_EXTRA_TEAMS_OVERRIDE = 2;
-	init( ENABLE_STORAGE_QUEUE_AWARE_TEAM_SELECTION,           false );
-	init( DD_TARGET_STORAGE_QUEUE_SIZE,                         TARGET_BYTES_PER_STORAGE_SERVER/3 );
+	init( ENABLE_STORAGE_QUEUE_AWARE_TEAM_SELECTION,           false ); if( randomize && BUGGIFY ) ENABLE_STORAGE_QUEUE_AWARE_TEAM_SELECTION = true;
+	init( DD_TARGET_STORAGE_QUEUE_SIZE, TARGET_BYTES_PER_STORAGE_SERVER/3 ); if( randomize && BUGGIFY ) DD_TARGET_STORAGE_QUEUE_SIZE = TARGET_BYTES_PER_STORAGE_SERVER/10;
 
 	// TeamRemover
 	init( TR_FLAG_DISABLE_MACHINE_TEAM_REMOVER,                false ); if( randomize && BUGGIFY ) TR_FLAG_DISABLE_MACHINE_TEAM_REMOVER = deterministicRandom()->random01() < 0.1 ? true : false; // false by default. disable the consistency check when it's true

--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -135,7 +135,6 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( DD_QUEUE_LOGGING_INTERVAL,                             5.0 );
 	init( RELOCATION_PARALLELISM_PER_SOURCE_SERVER,                2 ); if( randomize && BUGGIFY ) RELOCATION_PARALLELISM_PER_SOURCE_SERVER = 1;
 	init( RELOCATION_PARALLELISM_PER_DEST_SERVER,                 10 ); if( randomize && BUGGIFY ) RELOCATION_PARALLELISM_PER_DEST_SERVER = 1; // Note: if this is smaller than FETCH_KEYS_PARALLELISM, this will artificially reduce performance. The current default of 10 is probably too high but is set conservatively for now.
-	init( RELOCATION_PARALLELISM_FACTOR_HOT_SHARD,               0.2 );
 	init( DD_QUEUE_MAX_KEY_SERVERS,                              100 ); if( randomize && BUGGIFY ) DD_QUEUE_MAX_KEY_SERVERS = 1;
 	init( DD_REBALANCE_PARALLELISM,                               50 );
 	init( DD_REBALANCE_RESET_AMOUNT,                              30 );
@@ -163,7 +162,6 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( PRIORITY_TEAM_1_LEFT,                                  800 );
 	init( PRIORITY_TEAM_FAILED,                                  805 );
 	init( PRIORITY_TEAM_0_LEFT,                                  809 );
-	init( PRIORITY_STORAGE_QUEUE_AWARE_REDISTRIBUTE,             940 );
 	init( PRIORITY_SPLIT_SHARD,                                  950 ); if( randomize && BUGGIFY ) PRIORITY_SPLIT_SHARD = 350;
 
 	// Data distribution
@@ -291,6 +289,8 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( DD_STORAGE_WIGGLE_PAUSE_THRESHOLD,                      10 ); if( randomize && BUGGIFY ) DD_STORAGE_WIGGLE_PAUSE_THRESHOLD = 1000;
 	init( DD_STORAGE_WIGGLE_STUCK_THRESHOLD,                      20 );
 	init( DD_BUILD_EXTRA_TEAMS_OVERRIDE,                          10 ); if( randomize && BUGGIFY ) DD_BUILD_EXTRA_TEAMS_OVERRIDE = 2;
+	init( ENABLE_STORAGE_QUEUE_AWARE_TEAM_SELECTION,            true );
+	init( DD_TARGET_STORAGE_QUEUE_SIZE,                         TARGET_BYTES_PER_STORAGE_SERVER/3 );
 
 	// TeamRemover
 	init( TR_FLAG_DISABLE_MACHINE_TEAM_REMOVER,                false ); if( randomize && BUGGIFY ) TR_FLAG_DISABLE_MACHINE_TEAM_REMOVER = deterministicRandom()->random01() < 0.1 ? true : false; // false by default. disable the consistency check when it's true

--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -290,6 +290,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( DD_STORAGE_WIGGLE_PAUSE_THRESHOLD,                      10 ); if( randomize && BUGGIFY ) DD_STORAGE_WIGGLE_PAUSE_THRESHOLD = 1000;
 	init( DD_STORAGE_WIGGLE_STUCK_THRESHOLD,                      20 );
 	init( DD_BUILD_EXTRA_TEAMS_OVERRIDE,                          10 ); if( randomize && BUGGIFY ) DD_BUILD_EXTRA_TEAMS_OVERRIDE = 2;
+	init( DD_DECREMENT_STORAGE_QUEUE_AWARE_SHARD_DELAY_TIME,   300.0 );
 
 	// TeamRemover
 	init( TR_FLAG_DISABLE_MACHINE_TEAM_REMOVER,                false ); if( randomize && BUGGIFY ) TR_FLAG_DISABLE_MACHINE_TEAM_REMOVER = deterministicRandom()->random01() < 0.1 ? true : false; // false by default. disable the consistency check when it's true

--- a/fdbclient/ServerKnobs.h
+++ b/fdbclient/ServerKnobs.h
@@ -128,6 +128,7 @@ public:
 	double DD_QUEUE_LOGGING_INTERVAL;
 	double RELOCATION_PARALLELISM_PER_SOURCE_SERVER;
 	double RELOCATION_PARALLELISM_PER_DEST_SERVER;
+	double RELOCATION_PARALLELISM_FACTOR_HOT_SHARD;
 	int DD_QUEUE_MAX_KEY_SERVERS;
 	int DD_REBALANCE_PARALLELISM;
 	int DD_REBALANCE_RESET_AMOUNT;
@@ -232,7 +233,6 @@ public:
 	int DD_TEAM_ZERO_SERVER_LEFT_LOG_DELAY;
 	int DD_STORAGE_WIGGLE_PAUSE_THRESHOLD; // How many unhealthy relocations are ongoing will pause storage wiggle
 	int DD_STORAGE_WIGGLE_STUCK_THRESHOLD; // How many times bestTeamStuck accumulate will pause storage wiggle
-	double DD_DECREMENT_STORAGE_QUEUE_AWARE_SHARD_DELAY_TIME;
 
 	// TeamRemover to remove redundant teams
 	bool TR_FLAG_DISABLE_MACHINE_TEAM_REMOVER; // disable the machineTeamRemover actor

--- a/fdbclient/ServerKnobs.h
+++ b/fdbclient/ServerKnobs.h
@@ -128,7 +128,6 @@ public:
 	double DD_QUEUE_LOGGING_INTERVAL;
 	double RELOCATION_PARALLELISM_PER_SOURCE_SERVER;
 	double RELOCATION_PARALLELISM_PER_DEST_SERVER;
-	double RELOCATION_PARALLELISM_FACTOR_HOT_SHARD;
 	int DD_QUEUE_MAX_KEY_SERVERS;
 	int DD_REBALANCE_PARALLELISM;
 	int DD_REBALANCE_RESET_AMOUNT;
@@ -163,7 +162,6 @@ public:
 	int PRIORITY_TEAM_FAILED; // Priority when a server in the team is excluded as failed
 	int PRIORITY_TEAM_0_LEFT;
 	int PRIORITY_SPLIT_SHARD;
-	int PRIORITY_STORAGE_QUEUE_AWARE_REDISTRIBUTE;
 
 	// Data distribution
 	double RETRY_RELOCATESHARD_DELAY;
@@ -233,6 +231,8 @@ public:
 	int DD_TEAM_ZERO_SERVER_LEFT_LOG_DELAY;
 	int DD_STORAGE_WIGGLE_PAUSE_THRESHOLD; // How many unhealthy relocations are ongoing will pause storage wiggle
 	int DD_STORAGE_WIGGLE_STUCK_THRESHOLD; // How many times bestTeamStuck accumulate will pause storage wiggle
+	bool ENABLE_STORAGE_QUEUE_AWARE_TEAM_SELECTION; // experimental!
+	int64_t DD_TARGET_STORAGE_QUEUE_SIZE;
 
 	// TeamRemover to remove redundant teams
 	bool TR_FLAG_DISABLE_MACHINE_TEAM_REMOVER; // disable the machineTeamRemover actor

--- a/fdbclient/ServerKnobs.h
+++ b/fdbclient/ServerKnobs.h
@@ -162,6 +162,7 @@ public:
 	int PRIORITY_TEAM_FAILED; // Priority when a server in the team is excluded as failed
 	int PRIORITY_TEAM_0_LEFT;
 	int PRIORITY_SPLIT_SHARD;
+	int PRIORITY_STORAGE_QUEUE_AWARE_REDISTRIBUTE;
 
 	// Data distribution
 	double RETRY_RELOCATESHARD_DELAY;

--- a/fdbclient/ServerKnobs.h
+++ b/fdbclient/ServerKnobs.h
@@ -232,6 +232,7 @@ public:
 	int DD_TEAM_ZERO_SERVER_LEFT_LOG_DELAY;
 	int DD_STORAGE_WIGGLE_PAUSE_THRESHOLD; // How many unhealthy relocations are ongoing will pause storage wiggle
 	int DD_STORAGE_WIGGLE_STUCK_THRESHOLD; // How many times bestTeamStuck accumulate will pause storage wiggle
+	double DD_DECREMENT_STORAGE_QUEUE_AWARE_SHARD_DELAY_TIME;
 
 	// TeamRemover to remove redundant teams
 	bool TR_FLAG_DISABLE_MACHINE_TEAM_REMOVER; // disable the machineTeamRemover actor

--- a/fdbclient/StorageServerInterface.h
+++ b/fdbclient/StorageServerInterface.h
@@ -1007,12 +1007,13 @@ struct GetStorageMetricsReply {
 	double bytesInputRate;
 	int64_t versionLag;
 	double lastUpdate;
+	int64_t bytesDurable, bytesInput;
 
 	GetStorageMetricsReply() : bytesInputRate(0) {}
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, load, available, capacity, bytesInputRate, versionLag, lastUpdate);
+		serializer(ar, load, available, capacity, bytesInputRate, versionLag, lastUpdate, bytesDurable, bytesInput);
 	}
 };
 

--- a/fdbserver/DDTeamCollection.actor.cpp
+++ b/fdbserver/DDTeamCollection.actor.cpp
@@ -265,6 +265,14 @@ public:
 					    (!req.preferLowerUtilization ||
 					     self->teams[currentIndex]->hasHealthyAvailableSpace(self->medianAvailableSpace))) {
 						int64_t loadBytes = self->teams[currentIndex]->getLoadBytes(true, req.inflightPenalty);
+						if (req.storageQueueAware) {
+							int64_t storageQueueSize = self->teams[currentIndex]->getLongestStorageQueueSize();
+							if (storageQueueSize == -1) {
+								continue; // this SS may not healthy, skip
+							} else if (storageQueueSize > SERVER_KNOBS->DD_TARGET_STORAGE_QUEUE_SIZE) {
+								continue; // this SS storage queue is too long, skip
+							}
+						}
 						if ((!bestOption.present() || (req.preferLowerUtilization && loadBytes < bestLoadBytes) ||
 						     (!req.preferLowerUtilization && loadBytes > bestLoadBytes)) &&
 						    (!req.teamMustHaveShards ||
@@ -308,6 +316,15 @@ public:
 					            self->shardsAffectedByTeamFailure->hasShards(
 					                ShardsAffectedByTeamFailure::Team(dest->getServerIDs(), self->primary)));
 
+					if (req.storageQueueAware) {
+						int64_t storageQueueSize = dest->getLongestStorageQueueSize();
+						if (storageQueueSize == -1) {
+							ok = false; // this SS may not healthy, skip
+						} else if (storageQueueSize > SERVER_KNOBS->DD_TARGET_STORAGE_QUEUE_SIZE) {
+							ok = false; // this SS storage queue is too long, skip
+						}
+					}
+
 					if (ok)
 						randomTeams.push_back(dest);
 					else
@@ -326,6 +343,14 @@ public:
 
 				for (int i = 0; i < randomTeams.size(); i++) {
 					int64_t loadBytes = randomTeams[i]->getLoadBytes(true, req.inflightPenalty);
+					if (req.storageQueueAware) {
+						int64_t storageQueueSize = randomTeams[i]->getLongestStorageQueueSize();
+						if (storageQueueSize == -1) {
+							continue; // this SS may not healthy, skip
+						} else if (storageQueueSize > SERVER_KNOBS->DD_TARGET_STORAGE_QUEUE_SIZE) {
+							continue; // this SS storage queue is too long, skip
+						}
+					}
 					if (!bestOption.present() || (req.preferLowerUtilization && loadBytes < bestLoadBytes) ||
 					    (!req.preferLowerUtilization && loadBytes > bestLoadBytes)) {
 
@@ -374,11 +399,16 @@ public:
 			// 	self->traceAllInfo(true);
 			// }
 
-			req.reply.send(std::make_pair(bestOption, foundSrc));
+			if (req.storageQueueAware && !bestOption.present()) {
+				req.storageQueueAware = false;
+				wait(getTeam(self, req)); // re-run getTeam without storageQueueAware
+			} else {
+				req.reply.send(std::make_pair(bestOption, foundSrc));
+			}
 
 			return Void();
 		} catch (Error& e) {
-			if (e.code() != error_code_actor_cancelled)
+			if (e.code() != error_code_actor_cancelled && req.reply.canBeSet())
 				req.reply.sendError(e);
 			throw;
 		}

--- a/fdbserver/DDTeamCollection.actor.cpp
+++ b/fdbserver/DDTeamCollection.actor.cpp
@@ -343,14 +343,6 @@ public:
 
 				for (int i = 0; i < randomTeams.size(); i++) {
 					int64_t loadBytes = randomTeams[i]->getLoadBytes(true, req.inflightPenalty);
-					if (req.storageQueueAware) {
-						int64_t storageQueueSize = randomTeams[i]->getLongestStorageQueueSize();
-						if (storageQueueSize == -1) {
-							continue; // this SS may not healthy, skip
-						} else if (storageQueueSize > SERVER_KNOBS->DD_TARGET_STORAGE_QUEUE_SIZE) {
-							continue; // this SS storage queue is too long, skip
-						}
-					}
 					if (!bestOption.present() || (req.preferLowerUtilization && loadBytes < bestLoadBytes) ||
 					    (!req.preferLowerUtilization && loadBytes > bestLoadBytes)) {
 

--- a/fdbserver/DDTeamCollection.actor.cpp
+++ b/fdbserver/DDTeamCollection.actor.cpp
@@ -1020,6 +1020,8 @@ public:
 		state ServerStatus status(false, false, false, server->getLastKnownInterface().locality);
 		state bool lastIsUnhealthy = false;
 		state Future<Void> metricsTracker = server->serverMetricsPolling();
+		state Future<Void> decrementMovingInStorageQueueAwareShardHandler =
+		    server->decrementMovingInStorageQueueAwareShardHandler();
 
 		state Future<std::pair<StorageServerInterface, ProcessClass>> interfaceChanged = server->onInterfaceChanged;
 

--- a/fdbserver/DDTeamCollection.actor.cpp
+++ b/fdbserver/DDTeamCollection.actor.cpp
@@ -266,10 +266,11 @@ public:
 					     self->teams[currentIndex]->hasHealthyAvailableSpace(self->medianAvailableSpace))) {
 						int64_t loadBytes = self->teams[currentIndex]->getLoadBytes(true, req.inflightPenalty);
 						if (req.storageQueueAware) {
-							int64_t storageQueueSize = self->teams[currentIndex]->getLongestStorageQueueSize();
-							if (storageQueueSize == -1) {
+							Optional<int64_t> storageQueueSize =
+							    self->teams[currentIndex]->getLongestStorageQueueSize();
+							if (!storageQueueSize.present()) {
 								continue; // this SS may not healthy, skip
-							} else if (storageQueueSize > SERVER_KNOBS->DD_TARGET_STORAGE_QUEUE_SIZE) {
+							} else if (storageQueueSize.get() > SERVER_KNOBS->DD_TARGET_STORAGE_QUEUE_SIZE) {
 								continue; // this SS storage queue is too long, skip
 							}
 						}
@@ -317,10 +318,10 @@ public:
 					                ShardsAffectedByTeamFailure::Team(dest->getServerIDs(), self->primary)));
 
 					if (req.storageQueueAware) {
-						int64_t storageQueueSize = dest->getLongestStorageQueueSize();
-						if (storageQueueSize == -1) {
+						Optional<int64_t> storageQueueSize = dest->getLongestStorageQueueSize();
+						if (!storageQueueSize.present()) {
 							ok = false; // this SS may not healthy, skip
-						} else if (storageQueueSize > SERVER_KNOBS->DD_TARGET_STORAGE_QUEUE_SIZE) {
+						} else if (storageQueueSize.get() > SERVER_KNOBS->DD_TARGET_STORAGE_QUEUE_SIZE) {
 							ok = false; // this SS storage queue is too long, skip
 						}
 					}

--- a/fdbserver/DDTeamCollection.actor.cpp
+++ b/fdbserver/DDTeamCollection.actor.cpp
@@ -1020,8 +1020,6 @@ public:
 		state ServerStatus status(false, false, false, server->getLastKnownInterface().locality);
 		state bool lastIsUnhealthy = false;
 		state Future<Void> metricsTracker = server->serverMetricsPolling();
-		state Future<Void> decrementMovingInStorageQueueAwareShardHandler =
-		    server->decrementMovingInStorageQueueAwareShardHandler();
 
 		state Future<std::pair<StorageServerInterface, ProcessClass>> interfaceChanged = server->onInterfaceChanged;
 

--- a/fdbserver/DataDistribution.actor.h
+++ b/fdbserver/DataDistribution.actor.h
@@ -46,9 +46,6 @@ struct IDataDistributionTeam {
 	virtual std::vector<UID> const& getServerIDs() const = 0;
 	virtual void addDataInFlightToTeam(int64_t delta) = 0;
 	virtual int64_t getDataInFlightToTeam() const = 0;
-	virtual void incrementMovingStorageQueueAwareShardToTeam() = 0;
-	virtual void decrementMovingStorageQueueAwareShardToTeam() = 0;
-	virtual int64_t getMovingInStorageQueueAwareShardCounterMax() const = 0;
 	virtual int64_t getLongestStorageQueueSize() const = 0;
 	virtual int64_t getLoadBytes(bool includeInFlight = true, double inflightPenalty = 1.0) const = 0;
 	virtual int64_t getMinAvailableSpace(bool includeInFlight = true) const = 0;

--- a/fdbserver/DataDistribution.actor.h
+++ b/fdbserver/DataDistribution.actor.h
@@ -80,6 +80,7 @@ struct IDataDistributionTeam {
 struct GetTeamRequest {
 	bool wantsNewServers;
 	bool wantsTrueBest;
+	bool storageQueueAware;
 	bool preferLowerUtilization;
 	bool teamMustHaveShards;
 	double inflightPenalty;
@@ -93,15 +94,16 @@ struct GetTeamRequest {
 	               bool preferLowerUtilization,
 	               bool teamMustHaveShards,
 	               double inflightPenalty = 1.0)
-	  : wantsNewServers(wantsNewServers), wantsTrueBest(wantsTrueBest), preferLowerUtilization(preferLowerUtilization),
-	    teamMustHaveShards(teamMustHaveShards), inflightPenalty(inflightPenalty) {}
+	  : wantsNewServers(wantsNewServers), wantsTrueBest(wantsTrueBest), storageQueueAware(false),
+	    preferLowerUtilization(preferLowerUtilization), teamMustHaveShards(teamMustHaveShards),
+	    inflightPenalty(inflightPenalty) {}
 
 	std::string getDesc() const {
 		std::stringstream ss;
 
-		ss << "WantsNewServers:" << wantsNewServers << " WantsTrueBest:" << wantsTrueBest
-		   << " PreferLowerUtilization:" << preferLowerUtilization << " teamMustHaveShards:" << teamMustHaveShards
-		   << " inflightPenalty:" << inflightPenalty << ";";
+		ss << "WantsNewServers:" << wantsNewServers << " WantsTrueBest:" << wantsTrueBest << "StorageQueueAware"
+		   << storageQueueAware << " PreferLowerUtilization:" << preferLowerUtilization
+		   << " teamMustHaveShards:" << teamMustHaveShards << " inflightPenalty:" << inflightPenalty << ";";
 		ss << "CompleteSources:";
 		for (const auto& cs : completeSources) {
 			ss << cs.toString() << ",";

--- a/fdbserver/DataDistribution.actor.h
+++ b/fdbserver/DataDistribution.actor.h
@@ -101,8 +101,8 @@ struct GetTeamRequest {
 	std::string getDesc() const {
 		std::stringstream ss;
 
-		ss << "WantsNewServers:" << wantsNewServers << " WantsTrueBest:" << wantsTrueBest << "StorageQueueAware"
-		   << storageQueueAware << " PreferLowerUtilization:" << preferLowerUtilization
+		ss << "WantsNewServers:" << wantsNewServers << " WantsTrueBest:" << wantsTrueBest
+		   << " StorageQueueAware:" << storageQueueAware << " PreferLowerUtilization:" << preferLowerUtilization
 		   << " teamMustHaveShards:" << teamMustHaveShards << " inflightPenalty:" << inflightPenalty << ";";
 		ss << "CompleteSources:";
 		for (const auto& cs : completeSources) {

--- a/fdbserver/DataDistribution.actor.h
+++ b/fdbserver/DataDistribution.actor.h
@@ -46,7 +46,8 @@ struct IDataDistributionTeam {
 	virtual std::vector<UID> const& getServerIDs() const = 0;
 	virtual void addDataInFlightToTeam(int64_t delta) = 0;
 	virtual int64_t getDataInFlightToTeam() const = 0;
-	virtual void incrementStorageQueueAwareShardToTeam(int64_t delta) = 0;
+	virtual void incrementMovingStorageQueueAwareShardToTeam() = 0;
+	virtual void decrementMovingStorageQueueAwareShardToTeam() = 0;
 	virtual int64_t getStorageQueueAwareShardPerServerNumMax() const = 0;
 	virtual int64_t getLongestStorageQueueSize() const = 0;
 	virtual int64_t getLoadBytes(bool includeInFlight = true, double inflightPenalty = 1.0) const = 0;

--- a/fdbserver/DataDistribution.actor.h
+++ b/fdbserver/DataDistribution.actor.h
@@ -46,7 +46,7 @@ struct IDataDistributionTeam {
 	virtual std::vector<UID> const& getServerIDs() const = 0;
 	virtual void addDataInFlightToTeam(int64_t delta) = 0;
 	virtual int64_t getDataInFlightToTeam() const = 0;
-	virtual int64_t getLongestStorageQueueSize() const = 0;
+	virtual Optional<int64_t> getLongestStorageQueueSize() const = 0;
 	virtual int64_t getLoadBytes(bool includeInFlight = true, double inflightPenalty = 1.0) const = 0;
 	virtual int64_t getMinAvailableSpace(bool includeInFlight = true) const = 0;
 	virtual double getMinAvailableSpaceRatio(bool includeInFlight = true) const = 0;

--- a/fdbserver/DataDistribution.actor.h
+++ b/fdbserver/DataDistribution.actor.h
@@ -48,7 +48,7 @@ struct IDataDistributionTeam {
 	virtual int64_t getDataInFlightToTeam() const = 0;
 	virtual void incrementMovingStorageQueueAwareShardToTeam() = 0;
 	virtual void decrementMovingStorageQueueAwareShardToTeam() = 0;
-	virtual int64_t getStorageQueueAwareShardPerServerNumMax() const = 0;
+	virtual int64_t getMovingInStorageQueueAwareShardCounterMax() const = 0;
 	virtual int64_t getLongestStorageQueueSize() const = 0;
 	virtual int64_t getLoadBytes(bool includeInFlight = true, double inflightPenalty = 1.0) const = 0;
 	virtual int64_t getMinAvailableSpace(bool includeInFlight = true) const = 0;

--- a/fdbserver/DataDistribution.actor.h
+++ b/fdbserver/DataDistribution.actor.h
@@ -46,6 +46,9 @@ struct IDataDistributionTeam {
 	virtual std::vector<UID> const& getServerIDs() const = 0;
 	virtual void addDataInFlightToTeam(int64_t delta) = 0;
 	virtual int64_t getDataInFlightToTeam() const = 0;
+	virtual void incrementStorageQueueAwareShardToTeam(int64_t delta) = 0;
+	virtual int64_t getStorageQueueAwareShardPerServerNumMax() const = 0;
+	virtual int64_t getLongestStorageQueueSize() const = 0;
 	virtual int64_t getLoadBytes(bool includeInFlight = true, double inflightPenalty = 1.0) const = 0;
 	virtual int64_t getMinAvailableSpace(bool includeInFlight = true) const = 0;
 	virtual double getMinAvailableSpaceRatio(bool includeInFlight = true) const = 0;

--- a/fdbserver/DataDistributionQueue.actor.cpp
+++ b/fdbserver/DataDistributionQueue.actor.cpp
@@ -187,11 +187,15 @@ public:
 	}
 
 	int64_t getLongestStorageQueueSize() const override {
-		int64_t queueSize = 0;
+		int64_t maxQueueSize = 0;
 		for (const auto& team : teams) {
-			queueSize = std::max(queueSize, team->getLongestStorageQueueSize());
+			int64_t queueSize = team->getLongestStorageQueueSize();
+			if (queueSize == -1) {
+				return -1;
+			}
+			maxQueueSize = std::max(maxQueueSize, queueSize);
 		}
-		return queueSize;
+		return maxQueueSize;
 	}
 
 	int64_t getStorageQueueAwareShardPerServerNumMax() const override {

--- a/fdbserver/DataDistributionQueue.actor.cpp
+++ b/fdbserver/DataDistributionQueue.actor.cpp
@@ -1140,9 +1140,7 @@ ACTOR Future<Void> dataDistributionRelocator(DDQueueData* self, RelocateData rd,
 					                          inflightPenalty);
 					req.src = rd.src;
 					req.completeSources = rd.completeSources;
-					if (SERVER_KNOBS->ENABLE_STORAGE_QUEUE_AWARE_TEAM_SELECTION) {
-						req.storageQueueAware = true;
-					}
+					req.storageQueueAware = SERVER_KNOBS->ENABLE_STORAGE_QUEUE_AWARE_TEAM_SELECTION;
 					// bestTeam.second = false if the bestTeam in the teamCollection (in the DC) does not have any
 					// server that hosts the relocateData. This is possible, for example, in a fearless configuration
 					// when the remote DC is just brought up.

--- a/fdbserver/DataDistributionQueue.actor.cpp
+++ b/fdbserver/DataDistributionQueue.actor.cpp
@@ -204,10 +204,10 @@ public:
 		return maxQueueSize;
 	}
 
-	int64_t getStorageQueueAwareShardPerServerNumMax() const override {
+	int64_t getMovingInStorageQueueAwareShardCounterMax() const override {
 		int64_t shardNumMax = 0;
 		for (const auto& team : teams) {
-			shardNumMax = std::max(shardNumMax, team->getStorageQueueAwareShardPerServerNumMax());
+			shardNumMax = std::max(shardNumMax, team->getMovingInStorageQueueAwareShardCounterMax());
 		}
 		return shardNumMax;
 	}

--- a/fdbserver/DataDistributionQueue.actor.cpp
+++ b/fdbserver/DataDistributionQueue.actor.cpp
@@ -176,14 +176,14 @@ public:
 		});
 	}
 
-	int64_t getLongestStorageQueueSize() const override {
+	Optional<int64_t> getLongestStorageQueueSize() const override {
 		int64_t maxQueueSize = 0;
 		for (const auto& team : teams) {
-			int64_t queueSize = team->getLongestStorageQueueSize();
-			if (queueSize == -1) {
-				return -1;
+			Optional<int64_t> queueSize = team->getLongestStorageQueueSize();
+			if (!queueSize.present()) {
+				return Optional<int64_t>();
 			}
-			maxQueueSize = std::max(maxQueueSize, queueSize);
+			maxQueueSize = std::max(maxQueueSize, queueSize.get());
 		}
 		return maxQueueSize;
 	}

--- a/fdbserver/StorageMetrics.actor.h
+++ b/fdbserver/StorageMetrics.actor.h
@@ -435,7 +435,9 @@ struct StorageServerMetrics {
 	                       StorageBytes sb,
 	                       double bytesInputRate,
 	                       int64_t versionLag,
-	                       double lastUpdate) const {
+	                       double lastUpdate,
+	                       int64_t bytesDurable,
+	                       int64_t bytesInput) const {
 		GetStorageMetricsReply rep;
 
 		// SOMEDAY: make bytes dynamic with hard disk space
@@ -464,6 +466,8 @@ struct StorageServerMetrics {
 
 		rep.versionLag = versionLag;
 		rep.lastUpdate = lastUpdate;
+		rep.bytesDurable = bytesDurable;
+		rep.bytesInput = bytesInput;
 
 		req.reply.send(rep);
 	}

--- a/fdbserver/TCInfo.actor.cpp
+++ b/fdbserver/TCInfo.actor.cpp
@@ -364,10 +364,7 @@ int64_t TCTeamInfo::getLongestStorageQueueSize() const {
 	int64_t longestQueueSize = 0;
 	for (const auto& server : servers) {
 		if (server->metricsPresent()) {
-			int64_t storageQueueSize = server->getStorageQueueSize();
-			if (storageQueueSize > longestQueueSize) {
-				longestQueueSize = storageQueueSize;
-			}
+			longestQueueSize = std::max(longestQueueSize, server->getStorageQueueSize());
 		} else if (server->ssVersionTooFarBehind.get() == true) {
 			return -1;
 		}

--- a/fdbserver/TCInfo.actor.cpp
+++ b/fdbserver/TCInfo.actor.cpp
@@ -384,6 +384,8 @@ int64_t TCTeamInfo::getLongestStorageQueueSize() const {
 			if (storageQueueSize > longestQueueSize) {
 				longestQueueSize = storageQueueSize;
 			}
+		} else if (server->ssVersionTooFarBehind.get() == true) {
+			return -1;
 		}
 	}
 	return longestQueueSize;

--- a/fdbserver/TCInfo.actor.cpp
+++ b/fdbserver/TCInfo.actor.cpp
@@ -360,13 +360,13 @@ int64_t TCTeamInfo::getDataInFlightToTeam() const {
 	return dataInFlight;
 }
 
-int64_t TCTeamInfo::getLongestStorageQueueSize() const {
+Optional<int64_t> TCTeamInfo::getLongestStorageQueueSize() const {
 	int64_t longestQueueSize = 0;
 	for (const auto& server : servers) {
 		if (server->metricsPresent()) {
 			longestQueueSize = std::max(longestQueueSize, server->getStorageQueueSize());
-		} else if (server->ssVersionTooFarBehind.get() == true) {
-			return -1;
+		} else {
+			return Optional<int64_t>();
 		}
 	}
 	return longestQueueSize;

--- a/fdbserver/TCInfo.actor.cpp
+++ b/fdbserver/TCInfo.actor.cpp
@@ -117,7 +117,7 @@ public:
 				when(waitNext(server->decrementMovingInStorageQueueAwareShard.getFuture())) {
 					wait(delay(SERVER_KNOBS->DD_DECREMENT_STORAGE_QUEUE_AWARE_SHARD_DELAY_TIME));
 					wait(updateServerMetrics(server)); // Keep metrics updated before decrement the counter
-					server->storageQueueAwareShardNum--;
+					server->movingInStorageQueueAwareShardCounter--;
 				}
 			}
 		}
@@ -386,10 +386,10 @@ void TCTeamInfo::decrementMovingStorageQueueAwareShardToTeam() {
 		servers[i]->decrementMovingStorageQueueAwareShardToServer();
 }
 
-int64_t TCTeamInfo::getStorageQueueAwareShardPerServerNumMax() const {
+int64_t TCTeamInfo::getMovingInStorageQueueAwareShardCounterMax() const {
 	int64_t storageQueueAwareShardNumMax = 0;
 	for (auto const& server : servers) {
-		int64_t shardNum = server->getStorageQueueAwareShardNum();
+		int64_t shardNum = server->getMovingInStorageQueueAwareShardCounter();
 		if (shardNum > storageQueueAwareShardNumMax) {
 			storageQueueAwareShardNumMax = shardNum;
 		}

--- a/fdbserver/TCInfo.h
+++ b/fdbserver/TCInfo.h
@@ -45,7 +45,6 @@ class TCServerInfo : public ReferenceCounted<TCServerInfo> {
 	KeyValueStoreType storeType; // Storage engine type
 
 	int64_t dataInFlightToServer;
-	int64_t movingInStorageQueueAwareShardCounter;
 	std::vector<Reference<TCTeamInfo>> teams;
 	ErrorOr<GetStorageMetricsReply> metrics;
 
@@ -67,7 +66,6 @@ public:
 	Promise<Void> updated;
 	AsyncVar<bool> wrongStoreTypeToRemove;
 	AsyncVar<bool> ssVersionTooFarBehind;
-	PromiseStream<Void> decrementMovingInStorageQueueAwareShard;
 
 	TCServerInfo(StorageServerInterface ssi,
 	             DDTeamCollection* collection,
@@ -86,9 +84,6 @@ public:
 	Future<Void> updateStoreType();
 	KeyValueStoreType getStoreType() const { return storeType; }
 	int64_t getDataInFlightToServer() const { return dataInFlightToServer; }
-	void incrementMovingStorageQueueAwareShardToServer() { movingInStorageQueueAwareShardCounter++; }
-	void decrementMovingStorageQueueAwareShardToServer() { decrementMovingInStorageQueueAwareShard.send(Void()); }
-	int64_t getMovingInStorageQueueAwareShardCounter() const { return movingInStorageQueueAwareShardCounter; }
 	int64_t getStorageQueueSize() const;
 	void incrementDataInFlightToServer(int64_t bytes) { dataInFlightToServer += bytes; }
 	void cancel();
@@ -112,7 +107,6 @@ public:
 	Future<Void> updateServerMetrics();
 	static Future<Void> updateServerMetrics(Reference<TCServerInfo> server);
 	Future<Void> serverMetricsPolling();
-	Future<Void> decrementMovingInStorageQueueAwareShardHandler();
 
 	~TCServerInfo();
 };
@@ -199,12 +193,6 @@ public:
 	void addDataInFlightToTeam(int64_t delta) override;
 
 	int64_t getDataInFlightToTeam() const override;
-
-	void incrementMovingStorageQueueAwareShardToTeam() override;
-
-	void decrementMovingStorageQueueAwareShardToTeam() override;
-
-	int64_t getMovingInStorageQueueAwareShardCounterMax() const override;
 
 	int64_t getLongestStorageQueueSize() const override;
 

--- a/fdbserver/TCInfo.h
+++ b/fdbserver/TCInfo.h
@@ -45,6 +45,7 @@ class TCServerInfo : public ReferenceCounted<TCServerInfo> {
 	KeyValueStoreType storeType; // Storage engine type
 
 	int64_t dataInFlightToServer;
+	int64_t storageQueueAwareShardNum;
 	std::vector<Reference<TCTeamInfo>> teams;
 	ErrorOr<GetStorageMetricsReply> metrics;
 
@@ -84,6 +85,9 @@ public:
 	Future<Void> updateStoreType();
 	KeyValueStoreType getStoreType() const { return storeType; }
 	int64_t getDataInFlightToServer() const { return dataInFlightToServer; }
+	void incrementStorageQueueAwareShardToServer(int64_t bytes) { storageQueueAwareShardNum += bytes; }
+	int64_t getStorageQueueAwareShardNum() const { return storageQueueAwareShardNum; }
+	int64_t getStorageQueueSize() const;
 	void incrementDataInFlightToServer(int64_t bytes) { dataInFlightToServer += bytes; }
 	void cancel();
 	std::vector<Reference<TCTeamInfo>> const& getTeams() const { return teams; }
@@ -192,6 +196,12 @@ public:
 	void addDataInFlightToTeam(int64_t delta) override;
 
 	int64_t getDataInFlightToTeam() const override;
+
+	void incrementStorageQueueAwareShardToTeam(int64_t delta) override;
+
+	int64_t getStorageQueueAwareShardPerServerNumMax() const override;
+
+	int64_t getLongestStorageQueueSize() const override;
 
 	int64_t getLoadBytes(bool includeInFlight = true, double inflightPenalty = 1.0) const override;
 

--- a/fdbserver/TCInfo.h
+++ b/fdbserver/TCInfo.h
@@ -194,7 +194,7 @@ public:
 
 	int64_t getDataInFlightToTeam() const override;
 
-	int64_t getLongestStorageQueueSize() const override;
+	Optional<int64_t> getLongestStorageQueueSize() const override;
 
 	int64_t getLoadBytes(bool includeInFlight = true, double inflightPenalty = 1.0) const override;
 

--- a/fdbserver/TCInfo.h
+++ b/fdbserver/TCInfo.h
@@ -45,7 +45,7 @@ class TCServerInfo : public ReferenceCounted<TCServerInfo> {
 	KeyValueStoreType storeType; // Storage engine type
 
 	int64_t dataInFlightToServer;
-	int64_t storageQueueAwareShardNum;
+	int64_t movingInStorageQueueAwareShardCounter;
 	std::vector<Reference<TCTeamInfo>> teams;
 	ErrorOr<GetStorageMetricsReply> metrics;
 
@@ -86,9 +86,9 @@ public:
 	Future<Void> updateStoreType();
 	KeyValueStoreType getStoreType() const { return storeType; }
 	int64_t getDataInFlightToServer() const { return dataInFlightToServer; }
-	void incrementMovingStorageQueueAwareShardToServer() { storageQueueAwareShardNum++; }
+	void incrementMovingStorageQueueAwareShardToServer() { movingInStorageQueueAwareShardCounter++; }
 	void decrementMovingStorageQueueAwareShardToServer() { decrementMovingInStorageQueueAwareShard.send(Void()); }
-	int64_t getStorageQueueAwareShardNum() const { return storageQueueAwareShardNum; }
+	int64_t getMovingInStorageQueueAwareShardCounter() const { return movingInStorageQueueAwareShardCounter; }
 	int64_t getStorageQueueSize() const;
 	void incrementDataInFlightToServer(int64_t bytes) { dataInFlightToServer += bytes; }
 	void cancel();
@@ -204,7 +204,7 @@ public:
 
 	void decrementMovingStorageQueueAwareShardToTeam() override;
 
-	int64_t getStorageQueueAwareShardPerServerNumMax() const override;
+	int64_t getMovingInStorageQueueAwareShardCounterMax() const override;
 
 	int64_t getLongestStorageQueueSize() const override;
 

--- a/fdbserver/TCInfo.h
+++ b/fdbserver/TCInfo.h
@@ -67,6 +67,7 @@ public:
 	Promise<Void> updated;
 	AsyncVar<bool> wrongStoreTypeToRemove;
 	AsyncVar<bool> ssVersionTooFarBehind;
+	PromiseStream<Void> decrementMovingInStorageQueueAwareShard;
 
 	TCServerInfo(StorageServerInterface ssi,
 	             DDTeamCollection* collection,
@@ -85,7 +86,8 @@ public:
 	Future<Void> updateStoreType();
 	KeyValueStoreType getStoreType() const { return storeType; }
 	int64_t getDataInFlightToServer() const { return dataInFlightToServer; }
-	void incrementStorageQueueAwareShardToServer(int64_t bytes) { storageQueueAwareShardNum += bytes; }
+	void incrementMovingStorageQueueAwareShardToServer() { storageQueueAwareShardNum++; }
+	void decrementMovingStorageQueueAwareShardToServer() { decrementMovingInStorageQueueAwareShard.send(Void()); }
 	int64_t getStorageQueueAwareShardNum() const { return storageQueueAwareShardNum; }
 	int64_t getStorageQueueSize() const;
 	void incrementDataInFlightToServer(int64_t bytes) { dataInFlightToServer += bytes; }
@@ -110,6 +112,7 @@ public:
 	Future<Void> updateServerMetrics();
 	static Future<Void> updateServerMetrics(Reference<TCServerInfo> server);
 	Future<Void> serverMetricsPolling();
+	Future<Void> decrementMovingInStorageQueueAwareShardHandler();
 
 	~TCServerInfo();
 };
@@ -197,7 +200,9 @@ public:
 
 	int64_t getDataInFlightToTeam() const override;
 
-	void incrementStorageQueueAwareShardToTeam(int64_t delta) override;
+	void incrementMovingStorageQueueAwareShardToTeam() override;
+
+	void decrementMovingStorageQueueAwareShardToTeam() override;
 
 	int64_t getStorageQueueAwareShardPerServerNumMax() const override;
 

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -8669,8 +8669,13 @@ ACTOR Future<Void> metricsCore(StorageServer* self, StorageServerInterface ssi) 
 			}
 			when(GetStorageMetricsRequest req = waitNext(ssi.getStorageMetrics.getFuture())) {
 				StorageBytes sb = self->storage.getStorageBytes();
-				self->metrics.getStorageMetrics(
-				    req, sb, self->counters.bytesInput.getRate(), self->versionLag, self->lastUpdate);
+				self->metrics.getStorageMetrics(req,
+				                                sb,
+				                                self->counters.bytesInput.getRate(),
+				                                self->versionLag,
+				                                self->lastUpdate,
+				                                self->counters.bytesDurable.getValue(),
+				                                self->counters.bytesInput.getValue());
 			}
 			when(ReadHotSubRangeRequest req = waitNext(ssi.getReadHotRanges.getFuture())) {
 				if (!self->isReadable(req.keys)) {


### PR DESCRIPTION
When get a dest team, we want to choose a team which does not have too long storage queue. In this PR, we set a threshold for the storage queue when getTeam(). If the longest storage queue of a team is over **1/3** of the `TARGET_BYTES_PER_STORAGE_SERVER`, this team will not be selected as the destination for any split/rebalancing data move. We should note that it is possible that getTeam may not be able to select any team when worrying the storage queue length. To address this issue, we simply retry getTeam without storage-queue-aware. 

Concerns:
1. When wantsNewServers==false, we do not check the queue size. Do we want to check this case as well?
2. Do we want to count potential increase of storage queue by inflight data moves when checking the storage queue length of the team candidate?
3. Do we want to change TARGET_BYTES_PER_STORAGE_SERVER to the hard limit of SSQueue for RateKeeping?

100K correctness test with feature off:
  20230919-201949-zhewang-a68ecb6a730a89cc           compressed=True data_size=24072497 duration=4834855 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:10:35 sanity=False started=100000 stopped=20230919-213024 submitted=20230919-201949 timeout=5400 username=zhewang

100K correctness test with feature on:
 20230919-201816-zhewang-a10e5909327ce756           compressed=True data_size=24072495 duration=4847303 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:09:10 sanity=False started=100000 stopped=20230919-212726 submitted=20230919-201816 timeout=5400 username=zhewang

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
