### PR TITLE
ClusterController watches changes to storage metadata

### DIFF
--- a/fdbclient/SystemData.cpp
+++ b/fdbclient/SystemData.cpp
@@ -693,6 +693,18 @@ const KeyRangeRef tssMismatchKeys("\xff/tssMismatch/"_sr, "\xff/tssMismatch0"_sr
 const KeyRef serverMetadataChangeKey = "\xff\x02/serverMetadataChanges"_sr;
 const KeyRangeRef serverMetadataKeys("\xff/serverMetadata/"_sr, "\xff/serverMetadata0"_sr);
 
+UID decodeServerMetadataKey(const KeyRef& key) {
+	// Key is packed by KeyBackedObjectMap::packKey
+	return TupleCodec<UID>::unpack(key.removePrefix(serverMetadataKeys.begin));
+}
+
+StorageMetadataType decodeServerMetadataValue(const KeyRef& value) {
+	StorageMetadataType type;
+	ObjectReader rd(value.begin(), IncludeVersion());
+	rd.deserialize(type);
+	return type;
+}
+
 const KeyRangeRef serverTagKeys("\xff/serverTag/"_sr, "\xff/serverTag0"_sr);
 
 const KeyRef serverTagPrefix = serverTagKeys.begin;

--- a/fdbclient/SystemData.cpp
+++ b/fdbclient/SystemData.cpp
@@ -690,6 +690,7 @@ UID decodeTssQuarantineKey(KeyRef const& key) {
 
 const KeyRangeRef tssMismatchKeys("\xff/tssMismatch/"_sr, "\xff/tssMismatch0"_sr);
 
+const KeyRef serverMetadataChangeKey = "\xff\x02/serverMetadataChanges"_sr;
 const KeyRangeRef serverMetadataKeys("\xff/serverMetadata/"_sr, "\xff/serverMetadata0"_sr);
 
 const KeyRangeRef serverTagKeys("\xff/serverTag/"_sr, "\xff/serverTag0"_sr);

--- a/fdbclient/include/fdbclient/StorageServerInterface.h
+++ b/fdbclient/include/fdbclient/StorageServerInterface.h
@@ -260,6 +260,14 @@ struct StorageInfo : NonCopyable, public ReferenceCounted<StorageInfo> {
 	StorageInfo() : tag(invalidTag) {}
 };
 
+struct StorageServerMetaInfo : public StorageServerInterface {
+	Optional<StorageMetadataType> metadata;
+
+	StorageServerMetaInfo(const StorageServerInterface& interface,
+	                      Optional<StorageMetadataType> metadata = Optional<StorageMetadataType>())
+	  : StorageServerInterface(interface), metadata(metadata) {}
+};
+
 struct ServerCacheInfo {
 	std::vector<Tag> tags; // all tags in both primary and remote DC for the key-range
 	std::vector<Reference<StorageInfo>> src_info;

--- a/fdbclient/include/fdbclient/SystemData.h
+++ b/fdbclient/include/fdbclient/SystemData.h
@@ -218,6 +218,9 @@ extern const KeyRangeRef serverMetadataKeys;
 // Any update to serverMetadataKeys will update this key to a random UID.
 extern const KeyRef serverMetadataChangeKey;
 
+UID decodeServerMetadataKey(const KeyRef&);
+StorageMetadataType decodeServerMetadataValue(const KeyRef&);
+
 // "\xff/serverTag/[[serverID]]" = "[[Tag]]"
 //	Provides the Tag for the given serverID. Used to access a
 //	storage server's corresponding TLog in order to apply mutations.

--- a/fdbclient/include/fdbclient/SystemData.h
+++ b/fdbclient/include/fdbclient/SystemData.h
@@ -215,6 +215,9 @@ extern const KeyRangeRef tssMismatchKeys;
 // Note: storageInterfaceUID is the one stated in the file name
 extern const KeyRangeRef serverMetadataKeys;
 
+// Any update to serverMetadataKeys will update this key to a random UID.
+extern const KeyRef serverMetadataChangeKey;
+
 // "\xff/serverTag/[[serverID]]" = "[[Tag]]"
 //	Provides the Tag for the given serverID. Used to access a
 //	storage server's corresponding TLog in order to apply mutations.

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -1514,6 +1514,7 @@ ACTOR Future<Void> statusServer(FutureStream<StatusRequest> requests,
 			                                                                  self->cx,
 			                                                                  workers,
 			                                                                  workerIssues,
+			                                                                  self->storageStatusInfos,
 			                                                                  &self->db.clientStatus,
 			                                                                  coordinators,
 			                                                                  incompatibleConnections,
@@ -1665,6 +1666,45 @@ ACTOR Future<Void> monitorServerInfoConfig(ClusterControllerData::DBInfo* db) {
 			} catch (Error& e) {
 				wait(tr.onError(e));
 			}
+		}
+	}
+}
+
+// Monitors storage metadata changes and updates to storage servers.
+ACTOR Future<Void> monitorStorageMetadata(ClusterControllerData* self) {
+	state KeyBackedObjectMap<UID, StorageMetadataType, decltype(IncludeVersion())> metadataMap(serverMetadataKeys.begin,
+	                                                                                           IncludeVersion());
+	state Reference<ReadYourWritesTransaction> tr = makeReference<ReadYourWritesTransaction>(self->cx);
+	state std::vector<StorageServerMetaInfo> servers;
+	loop {
+		try {
+			servers.clear();
+			tr->setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
+			tr->setOption(FDBTransactionOptions::LOCK_AWARE);
+			tr->setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
+			state RangeResult serverList = wait(tr->getRange(serverListKeys, CLIENT_KNOBS->TOO_MANY));
+			ASSERT(!serverList.more && serverList.size() < CLIENT_KNOBS->TOO_MANY);
+
+			servers.reserve(serverList.size());
+			// TODO: this can issue many point reads if the serverList is large.
+			// A better approach is to use getRange() for the metadata.
+			for (const auto ss : serverList) {
+				servers.push_back(StorageServerMetaInfo(decodeServerListValue(ss.value)));
+			}
+			state std::vector<Future<Void>> futures(servers.size());
+			for (int i = 0; i < servers.size(); ++i) {
+				futures[i] = store(servers[i].metadata, metadataMap.get(tr, servers[i].id()));
+				// TraceEvent(SevDebug, "MetadataAppear", servers[i].id()).detail("Present", metadata.present());
+			}
+			state Future<Void> watchFuture = tr->watch(serverMetadataChangeKey);
+			wait(waitForAll(futures));
+			wait(tr->commit());
+
+			self->storageStatusInfos = std::move(servers);
+			wait(watchFuture);
+			tr->reset();
+		} catch (Error& e) {
+			wait(tr->onError(e));
 		}
 	}
 }
@@ -3074,6 +3114,7 @@ ACTOR Future<Void> clusterControllerCore(ClusterControllerFullInterface interf,
 	self.addActor.send(timeKeeper(&self));
 	self.addActor.send(monitorProcessClasses(&self));
 	self.addActor.send(monitorServerInfoConfig(&self.db));
+	self.addActor.send(monitorStorageMetadata(&self));
 	self.addActor.send(monitorGlobalConfig(&self.db));
 	self.addActor.send(updatedChangingDatacenters(&self));
 	self.addActor.send(updatedChangedDatacenters(&self));

--- a/fdbserver/DDTeamCollection.actor.cpp
+++ b/fdbserver/DDTeamCollection.actor.cpp
@@ -18,15 +18,19 @@
  * limitations under the License.
  */
 
-#include "fdbserver/DDTeamCollection.h"
+#include <climits>
+
+#include "fdbclient/SystemData.h"
 #include "fdbrpc/simulator.h"
+#include "fdbserver/BlobMigratorInterface.h"
+#include "fdbserver/DDTeamCollection.h"
 #include "fdbserver/ExclusionTracker.actor.h"
 #include "fdbserver/DataDistributionTeam.h"
-#include "fdbserver/BlobMigratorInterface.h"
+#include "flow/IRandom.h"
 #include "flow/Trace.h"
-#include "flow/actorcompiler.h" // This must be the last #include.
 #include "flow/network.h"
-#include <climits>
+
+#include "flow/actorcompiler.h" // This must be the last #include.
 
 namespace {
 
@@ -3078,6 +3082,7 @@ public:
 					data.createdTime = metadata.get().createdTime;
 				}
 				metadataMap.set(tr, server->getId(), data);
+				tr->set(serverMetadataChangeKey, deterministicRandom()->randomUniqueID().toString());
 				wait(tr->commit());
 				break;
 			} catch (Error& e) {

--- a/fdbserver/include/fdbserver/ClusterController.actor.h
+++ b/fdbserver/include/fdbserver/ClusterController.actor.h
@@ -18,24 +18,23 @@
  * limitations under the License.
  */
 
-#pragma once
-
 // When actually compiled (NO_INTELLISENSE), include the generated version of this file.  In intellisense use the source
 // version.
-#include "fdbclient/StorageServerInterface.h"
-#include "fdbserver/BlobMigratorInterface.h"
-#include <utility>
-
 #if defined(NO_INTELLISENSE) && !defined(FDBSERVER_CLUSTERCONTROLLER_ACTOR_G_H)
 #define FDBSERVER_CLUSTERCONTROLLER_ACTOR_G_H
 #include "fdbserver/ClusterController.actor.g.h"
 #elif !defined(FDBSERVER_CLUSTERCONTROLLER_ACTOR_H)
 #define FDBSERVER_CLUSTERCONTROLLER_ACTOR_H
+#pragma once
+
+#include <utility>
 
 #include "fdbclient/DatabaseContext.h"
 #include "fdbclient/MetaclusterRegistration.h"
+#include "fdbclient/StorageServerInterface.h"
 #include "fdbrpc/Replication.h"
 #include "fdbrpc/ReplicationUtils.h"
+#include "fdbserver/BlobMigratorInterface.h"
 #include "fdbserver/Knobs.h"
 #include "fdbserver/WorkerInterface.actor.h"
 #include "flow/SystemMonitor.h"
@@ -3339,6 +3338,7 @@ public:
 	AsyncTrigger updateDBInfo;
 	std::set<Endpoint> updateDBInfoEndpoints;
 	std::set<Endpoint> removedDBInfoEndpoints;
+	std::vector<StorageServerMetaInfo> storageStatusInfos;
 
 	DBInfo db;
 	Database cx;

--- a/fdbserver/include/fdbserver/Status.actor.h
+++ b/fdbserver/include/fdbserver/Status.actor.h
@@ -48,6 +48,7 @@ Future<StatusReply> clusterGetStatus(
     Database const& cx,
     std::vector<WorkerDetails> const& workers,
     std::vector<ProcessIssues> const& workerIssues,
+    std::vector<StorageServerMetaInfo> const& storageMetadatas,
     std::map<NetworkAddress, std::pair<double, OpenDatabaseRequest>>* const& clientStatus,
     ServerCoordinators const& coordinators,
     std::vector<NetworkAddress> const& incompatibleConnections,

--- a/fdbserver/worker.actor.cpp
+++ b/fdbserver/worker.actor.cpp
@@ -3801,7 +3801,7 @@ TEST_CASE("/fdbserver/worker/swversion/runNewer") {
 namespace {
 KeyValueStoreType randomStoreType() {
 	int type = deterministicRandom()->randomInt(0, (int)KeyValueStoreType::END);
-	if (type == KeyValueStoreType::NONE) {
+	if (type == KeyValueStoreType::NONE || type == KeyValueStoreType::SSD_REDWOOD_V1) {
 		type = KeyValueStoreType::SSD_BTREE_V2;
 	}
 #ifndef WITH_ROCKSDB


### PR DESCRIPTION
To retrieve storage metadata for every status json request is very expensive for clusters with a large number of storage servers. So I change the logic so that ClusterController actively monitors changes to storage metadata, and only retrieves them when there is a change.

20230915-213205-jzhou-0679d18f63c68424
20230918-204319-jzhou-cd2418370504940b

For the status json part, i.e.,
```
                        "storage_metadata" : {
                            "created_time_datetime" : "2023-09-18 20:27:54.526 +0000",
                            "created_time_timestamp" : 1695068874.5260661,
                            "storage_engine" : "ssd-2"
                        },
```
it is manually verified with a loop back cluster.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
