### PR TITLE
Improve audit replica

### DIFF
--- a/fdbclient/include/fdbclient/Audit.h
+++ b/fdbclient/include/fdbclient/Audit.h
@@ -95,14 +95,14 @@ struct AuditStorageRequest {
 
 	AuditStorageRequest() = default;
 	AuditStorageRequest(UID id, KeyRange range, AuditType type)
-	  : id(id), range(range), type(static_cast<uint8_t>(type)) {}
+	  : id(id), range(range), type(static_cast<uint8_t>(type)), engineType(KeyValueStoreType::END) {}
 
 	inline void setType(AuditType type) { this->type = static_cast<uint8_t>(this->type); }
 	inline AuditType getType() const { return static_cast<AuditType>(this->type); }
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, id, range, type, targetServers, reply, ddId);
+		serializer(ar, id, range, type, targetServers, reply, ddId, engineType);
 	}
 
 	UID id;
@@ -110,6 +110,7 @@ struct AuditStorageRequest {
 	KeyRange range;
 	uint8_t type;
 	std::vector<UID> targetServers;
+	KeyValueStoreType engineType;
 	ReplyPromise<AuditStorageState> reply;
 };
 


### PR DESCRIPTION
We want to audit replica by selecting the servers to audit at a version which is same as the version of reading the data.

Concern:
Do we still need HA type?

100K correctness test:
 20230918-212814-zhewang-15ba94080918abb9           compressed=True data_size=35590462 duration=7060752 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:39:58 sanity=False started=100000 stopped=20230918-230812 submitted=20230918-212814 timeout=5400 username=zhewang

100K ValidateStorage test:
  20230918-212824-zhewang-f0597a926a99a67b           compressed=True data_size=35619083 duration=9395351 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:41:44 sanity=False started=100000 stopped=20230918-231008 submitted=20230918-212824 timeout=5400 username=zhewang

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
