### PR TITLE
Add preinstalled libfmt support

### DIFF
--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -1,13 +1,17 @@
 add_library(rapidjson INTERFACE)
 target_include_directories(rapidjson INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/rapidjson)
 
+find_package(fmt 8.1.1 GLOBAL)
+if(NOT fmt_FOUND)
+  add_subdirectory(fmt-8.1.1)
+endif()
+
 add_subdirectory(crc32)
 add_subdirectory(stacktrace)
 add_subdirectory(folly_memcpy)
 add_subdirectory(rapidxml)
 add_subdirectory(sqlite)
 add_subdirectory(SimpleOpt)
-add_subdirectory(fmt-8.1.1)
 add_subdirectory(md5)
 add_subdirectory(libb64)
 if(NOT WIN32)


### PR DESCRIPTION
The proposed change adds support of preinstalled libfmt.
Ex., there's a building problem on a FreeBSD platform with preinstalled devel/libfmt.

It's good to cherry-pick into 7.3
