### PR TITLE
Rename PAGE_SIZE constant

### DIFF
--- a/fdbserver/IPager.cpp
+++ b/fdbserver/IPager.cpp
@@ -28,9 +28,9 @@
 TEST_CASE("/fdbserver/IPager/ArenaPage/PageContentChecksum") {
 	auto& g_knobs = IKnobCollection::getMutableGlobalKnobCollection();
 	for (uint8_t et = 0; et < EncodingType::MAX_ENCODING_TYPE; et++) {
-		constexpr int PAGE_SIZE = 8 * 1024;
+		constexpr int _PAGE_SIZE = 8 * 1024;
 		EncodingType encodingType = (EncodingType)et;
-		Reference<ArenaPage> page = makeReference<ArenaPage>(PAGE_SIZE, PAGE_SIZE);
+		Reference<ArenaPage> page = makeReference<ArenaPage>(_PAGE_SIZE, _PAGE_SIZE);
 		page->init(encodingType, PageType::BTreeNode, 1);
 		deterministicRandom()->randomBytes(page->mutateData(), page->dataSize());
 		PhysicalPageID pageID = deterministicRandom()->randomUInt32();


### PR DESCRIPTION
The `PAGE_SIZE` constant [is used](https://github.com/freebsd/freebsd-src/blob/e39e6bef6725bde54f94aac7f0cda47c2170dc48/sys/amd64/include/param.h#L98) in the FreeBSD's `param.h`. There's an error while building foundationdb on FreeBSD. It's proposed to rename the const to `_PAGE_SIZE`.

It's good to cherry-pick into 7.3.
