### PR TITLE
Update CGO LDflags for new MacOS linker

### DIFF
--- a/bindings/go/src/fdb/fdb_darwin.go
+++ b/bindings/go/src/fdb/fdb_darwin.go
@@ -1,5 +1,5 @@
 package fdb
 
 //#cgo CFLAGS: -I/usr/local/include/
-//#cgo LDFLAGS: -Wl,-rpath,/usr/local/lib
+//#cgo LDFLAGS: -L/usr/local/lib/ -Wl,-rpath,/usr/local/lib
 import "C"

--- a/bindings/go/src/fdb/fdb_darwin.go
+++ b/bindings/go/src/fdb/fdb_darwin.go
@@ -1,5 +1,5 @@
 package fdb
 
 //#cgo CFLAGS: -I/usr/local/include/
-//#cgo LDFLAGS: -L/usr/local/lib/
+//#cgo LDFLAGS: -Wl,-rpath,/usr/local/lib
 import "C"


### PR DESCRIPTION
The new MacOS linker from Xcode 15 has some changes that breaks things in our current setup (e.g. https://github.com/golang/go/issues/62598 + https://github.com/golang/go/issues/61229). I tested this change with go 1.20.8 and Xcode 15:

```text
$ xcodebuild -version
Xcode 15.0
Build version 15A240d
```

I haven't tested this with an older Xcode version.

Related forum post.: https://forums.foundationdb.org/t/golang-bindings-after-upgrading-to-xcode-15/4163/2

I opened the PR against 7.1 as my testing application uses 7.1 (and I have that library locally installed). I'm happy to open the PRs for 7.3/main once we agree that the fix is the right approach.

Before the change:

```bash
$ go test ./fdbclient/...
# github.com/FoundationDB/fdb-kubernetes-operator/fdbclient.test
ld: warning: '/private/var/folders/mh/mr__47051f18gpsd3x_synbc0000gn/T/go-link-2252000032/go.o' has malformed LC_DYSYMTAB, expected 127 undefined symbols to start at index 55097, found 133 undefined symbols starting at index 85
dyld[18768]: Symbol not found: _fdb_create_database
  Referenced from: <89D35BC1-1BFF-3E4C-A258-66C9061099C0> /private/var/folders/mh/mr__47051f18gpsd3x_synbc0000gn/T/go-build3984296838/b001/fdbclient.test
  Expected in:     <no uuid> unknown
FAIL    github.com/FoundationDB/fdb-kubernetes-operator/fdbclient       0.268s
FAIL
```

after the change:

```bash
$ go test -v ./fdbclient/...
# github.com/FoundationDB/fdb-kubernetes-operator/fdbclient.test
ld: warning: '/private/var/folders/mh/mr__47051f18gpsd3x_synbc0000gn/T/go-link-3824344522/go.o' has malformed LC_DYSYMTAB, expected 127 undefined symbols to start at index 55097, found 133 undefined symbols starting at index 85
=== RUN   TestCmd
Running Suite: FDB client - /Users/jscheuermann/go/src/github.com/FoundationDB/fdb-kubernetes-operator/fdbclient
================================================================================================================
Random Seed: 1695363764

Will run 59 of 59 specs
•••••••••••••••••••••••••••••••••••••••••••••••••••••••••••

Ran 59 of 59 Specs in 0.020 seconds
SUCCESS! -- 59 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestCmd (0.02s)
PASS
ok      github.com/FoundationDB/fdb-kubernetes-operator/fdbclient       0.293s
```

In addition I build the FDB operator with this change:

```bash
$  make manager
go build -ldflags="-s -w -X github.com/FoundationDB/fdb-kubernetes-operator/setup.operatorVersion=7e2735bc92e7557c1aa8ce5d9616fb6daa1ab8ea" -o bin/manager main.go
# command-line-arguments
ld: warning: '/private/var/folders/mh/mr__47051f18gpsd3x_synbc0000gn/T/go-link-4186637257/go.o' has malformed LC_DYSYMTAB, expected 125 undefined symbols to start at index 62489, found 178 undefined symbols starting at index 93

$ /bin/manager --help
Usage of ./bin/manager:
  -cache-database-status
        Defines the default value for caching the database status. (default true)
...
```

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [x] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [x] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
