### PR TITLE
Fix two test failures [release-7.3]

### DIFF
--- a/fdbserver/QuietDatabase.actor.cpp
+++ b/fdbserver/QuietDatabase.actor.cpp
@@ -901,7 +901,7 @@ ACTOR Future<Void> waitForQuietDatabase(Database cx,
 	state Future<bool> storageServersRecruiting;
 	state Future<int64_t> versionOffset;
 	state Future<Version> dcLag;
-	state Version maxDcLag = 30e6;
+	state Version maxDcLag = 100e6;
 	state std::string traceMessage = "QuietDatabase" + phase + "Begin";
 	TraceEvent(traceMessage.c_str()).log();
 

--- a/tests/slow/ExcludeIncludeStorageServers.toml
+++ b/tests/slow/ExcludeIncludeStorageServers.toml
@@ -1,3 +1,6 @@
+[[knobs]]
+dd_max_shards_on_large_teams=0
+
 [[test]]
 testTitle = 'ExcludeIncludeStorageServers'
 


### PR DESCRIPTION
cherry-pick #10934

Found in release correctness tests:

```
-f ./tests/slow/ExcludeIncludeStorageServers.toml -s 3517392333 -b off
./fdbserver.6.3.16 -r simulation -f ./tests/restarting/from_6.3.13_until_7.2.0/DrUpgradeRestart-1.txt -s 3218805329 -b on --logsize 1GB
-f ./tests/restarting/from_6.3.13_until_7.2.0/DrUpgradeRestart-2.txt --restarting -s 3218805330 -b on
```

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
