### PR TITLE
GetMsgpack: add 4+ versions of upstream

### DIFF
--- a/cmake/GetMsgpack.cmake
+++ b/cmake/GetMsgpack.cmake
@@ -1,9 +1,13 @@
 find_package(msgpack 3.3.0 EXACT QUIET CONFIG)
+find_package(msgpackc-cxx 4.0.0...<6 QUIET CONFIG)
+find_package(msgpack-cxx 6 QUIET CONFIG)
 
 add_library(msgpack INTERFACE)
 
-if(msgpack_FOUND)
+if(msgpack_FOUND OR msgpackc-cxx_FOUND)
   target_link_libraries(msgpack INTERFACE msgpackc-cxx)
+elseif(msgpack-cxx_FOUND)
+  target_link_libraries(msgpack INTERFACE msgpack-cxx)
 else()
   include(ExternalProject)
   ExternalProject_add(msgpackProject


### PR DESCRIPTION
The proposed change adds support msgpack v.4+.

It's good to cherry-pick into 7.1 and 7.3.