### PR TITLE
[Release-7.1] Avoid duplicated split points input to manual shard split

### DIFF
--- a/fdbserver/DataDistribution.actor.h
+++ b/fdbserver/DataDistribution.actor.h
@@ -245,8 +245,8 @@ struct ShardTrackedData {
 	Future<Void> trackShard;
 	Future<Void> trackBytes;
 	Reference<AsyncVar<Optional<ShardMetrics>>> stats;
-	Reference<AsyncVar<bool>> shouldManualSplit;
-	std::shared_ptr<std::vector<Key>> manualSplitPoints;
+	Reference<AsyncVar<Void>> manualSplitTrigger;
+	std::shared_ptr<std::set<Key>> manualSplitPoints;
 };
 
 ACTOR Future<Void> dataDistributionTracker(Reference<InitialDataDistribution> initData,


### PR DESCRIPTION
This PR uses std::set to store the split points to remove duplicated split points.

This PR makes the logic of handling split points more clear. When DD tracker receives a manual split request, it checks the current shards and uses shard->manualSplitTrigger.trigger() to trigger the corresponding shard to check the shard->manualSplitPoints. If there is any split point in the shard->manualSplitPoints, the shard evaluator will call shardSplitter to consume the split point. After the shardSplitter has split the shard, shard->manualSplitPoints will be cleared.

Add more complicated simulation tests.

100K correctness:
  20230927-031129-zhewang-cf1af847da936422           compressed=True data_size=24117230 duration=4858229 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:59:40 sanity=False started=100000 stopped=20230927-041109 submitted=20230927-031129 timeout=5400 username=zhewang

ManualShardSplit test, the 1 failure is where the init of simulation is stuck and no manualShardSplit test runs:
  20230927-031206-zhewang-badca6a019b0ab8b           compressed=True data_size=24148496 duration=1409588 ended=100000 fail=1 fail_fast=10 max_runs=100000 pass=99999 priority=100 remaining=0 runtime=0:36:51 sanity=False started=100000 stopped=20230927-034857 submitted=20230927-031206 timeout=5400 username=zhewang

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
