### PR TITLE
Disable sharded rocks for more simulation tests

### DIFF
--- a/tests/fast/BackupToDBCorrectnessClean.toml
+++ b/tests/fast/BackupToDBCorrectnessClean.toml
@@ -4,6 +4,7 @@ testClass = "Backup"
 extraDatabaseMode = 'LocalOrSingle'
 # DR is not currently supported in required tenant mode
 tenantModes = ['disabled', 'optional']
+storageEngineExcludeTypes = [5]
 
 [[test]]
 testTitle = 'BackupAndRestore'

--- a/tests/fast/KillRegionCycle.toml
+++ b/tests/fast/KillRegionCycle.toml
@@ -1,5 +1,6 @@
 [configuration]
 minimumRegions = 2
+storageEngineExcludeTypes = [5]
 
 [[test]]
 testTitle = 'KillRegionCycle'

--- a/tests/rare/Throttling.toml
+++ b/tests/rare/Throttling.toml
@@ -1,3 +1,6 @@
+[configuration]
+storageEngineExcludeTypes = [5]
+
 [[test]]
 testTitle='ThrottlingTest'
     [[test.workload]]

--- a/tests/slow/ApiCorrectness.toml
+++ b/tests/slow/ApiCorrectness.toml
@@ -1,3 +1,6 @@
+[configuration]
+storageEngineExcludeTypes = [5]
+
 [[test]]
 testTitle = 'ApiCorrectnessTest'
 clearAfterTest = true

--- a/tests/slow/ApiCorrectnessSwitchover.toml
+++ b/tests/slow/ApiCorrectnessSwitchover.toml
@@ -2,6 +2,7 @@
 extraDatabaseMode = 'Single'
 # required tenant mode is not supported for Disaster Recovery yet
 tenantModes = ['disabled', 'optional']
+storageEngineExcludeTypes = [5]
 
 [[test]]
 testTitle = 'ApiCorrectnessTest'

--- a/tests/slow/ClogWithRollbacks.toml
+++ b/tests/slow/ClogWithRollbacks.toml
@@ -1,3 +1,6 @@
+[configuration]
+storageEngineExcludeTypes = [5]
+
 [[test]]
 testTitle = 'CloggedCycleTest'
 


### PR DESCRIPTION
Found in nightly and can't reproduce the ExternalTimeout error.



# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
