### PR TITLE
Stop pulling if a backup worker is displaced [release-7.3]

### DIFF
--- a/fdbclient/BackupContainerFileSystem.actor.cpp
+++ b/fdbclient/BackupContainerFileSystem.actor.cpp
@@ -364,7 +364,8 @@ public:
 		    .detail("ScanBegin", scanBegin)
 		    .detail("ScanEnd", scanEnd)
 		    .detail("Begin", begin)
-		    .detail("ContiguousLogEnd", desc->contiguousLogEnd.get());
+		    .detail("ContiguousLogEnd", desc->contiguousLogEnd.get())
+		    .detail("SnapshotBeginVersion", snapshotBeginVersion);
 		for (const auto& file : logs) {
 			if (file.beginVersion > begin) {
 				if (scanBegin > 0)

--- a/fdbserver/BackupWorker.actor.cpp
+++ b/fdbserver/BackupWorker.actor.cpp
@@ -349,6 +349,7 @@ struct BackupData {
 
 	void stop() {
 		stopped = true;
+		pulling = false;
 		for (auto& [uid, info] : backups) {
 			// Cancel the actor. Because container is valid, CANNOT set the
 			// "stop" flag that will block writing mutation files in


### PR DESCRIPTION
If the backup worker is displaced, we want to stop pulling mutations and let the next epoch's new worker does it. Otherwise, we may end up with scenarios that mutations are missing for the new workers in the new epoch.

Reproduction:
```
clang build
commit 971ac19fc
-f tests/slow/ParallelRestoreNewBackupCorrectnessAtomicOp.toml -s 2754302304 -b on
```

Symptom:
```
Assertion failed @ /root/src/foundationdb/fdbclient/BackupContainerFileSystem.actor.cpp 307:
  expression:
              logs[indices.back()].fileSize <= logs[i].fileSize
  expands to:
              42333 <= 0

total 176
-rw-r--r-- 1 root root 132140 Sep 25 22:26 log,422704158,539670950,2e404580f5f32fb643e2c8dd94d73105,1-of-3,1048576 -rw-r--r-- 1 root root  42333 Sep 25 22:26 log,539197377,539670950,890543b9738ba33d2a367186aea5fe79,0-of-3,1048576
-rw-r--r-- 1 root root      0 Sep 25 22:26 log,539197377,545972518,7c36526721a253963f210c904908669e,0-of-3,1048576
```

100k ParallelRestore tests: 20231002-232016-jzhou-81bd8316ec5dd947

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
