### PR TITLE
[Release-7.1] Check user inputs to manual shard split

### DIFF
--- a/fdbcli/RedistributeCommand.actor.cpp
+++ b/fdbcli/RedistributeCommand.actor.cpp
@@ -30,7 +30,10 @@ ACTOR Future<bool> redistributeCommandActor(Reference<IClusterConnectionRecord> 
 	if (tokens.size() == 3) {
 		Key begin = tokens[1];
 		Key end = tokens[2];
-		if (begin == end) {
+		if (begin >= end) {
+			printUsage(tokens[0]);
+			result = false;
+		} else if (begin >= systemKeys.begin || end > systemKeys.begin) {
 			printUsage(tokens[0]);
 			result = false;
 		}
@@ -45,9 +48,10 @@ ACTOR Future<bool> redistributeCommandActor(Reference<IClusterConnectionRecord> 
 CommandFactory RedistributeFactory(
     "redistribute",
     CommandHelp("redistribute [Begin] [End]",
-                "Redistribute data of the range<Begin, End> among the cluster, where [Begin]!=[End]\n",
-                "Given an input range, say <b, d>, where b!=d and we suppose the current FDB"
-                "internal shard boundary is [a, c), [c, d), [d, e),"
+                "Redistribute data of the range<Begin, End> among the cluster,"
+                "where [Begin] < [End] and keys are not in system key space\n",
+                "Given an input range, say <b, d>, where b<d and b,d are not in system key space"
+                "We suppose the current FDB internal shard boundary is [a, c), [c, d), [d, e),"
                 "our splitting algorithm splits the input range into [b, c) and [c, d)."
                 "Then the two ranges will be redistributed among the cluster.\n"));
 } // namespace fdb_cli


### PR DESCRIPTION
100K correctness test:
  20231003-181922-zhewang-291be11d968235b4           compressed=True data_size=24124620 duration=4784384 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:14:30 sanity=False started=100000 stopped=20231003-193352 submitted=20231003-181922 timeout=5400 username=zhewang

100K manualShardSplit test:
  20231003-183052-zhewang-a82a21adcc8f2e69           compressed=True data_size=24155689 duration=8453303 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:12:30 sanity=False started=100000 stopped=20231003-194322 submitted=20231003-183052 timeout=5400 username=zhewang

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
