### PR TITLE
[Release-7.1] Fix redistribute cli

### DIFF
--- a/fdbcli/RedistributeCommand.actor.cpp
+++ b/fdbcli/RedistributeCommand.actor.cpp
@@ -30,9 +30,9 @@ ACTOR Future<bool> redistributeCommandActor(Reference<IClusterConnectionRecord> 
 	if (tokens.size() == 3) {
 		Key begin = tokens[1];
 		Key end = tokens[2];
-		if (begin == end) {
+		if (begin >= end) {
 			printUsage(tokens[0]);
-			result = false;
+			return false;
 		}
 		wait(redistribute(clusterFile, KeyRangeRef(begin, end), /*timeoutSeconds=*/30));
 	} else {
@@ -45,8 +45,8 @@ ACTOR Future<bool> redistributeCommandActor(Reference<IClusterConnectionRecord> 
 CommandFactory RedistributeFactory(
     "redistribute",
     CommandHelp("redistribute [Begin] [End]",
-                "Redistribute data of the range<Begin, End> among the cluster, where [Begin]!=[End]\n",
-                "Given an input range, say <b, d>, where b!=d and we suppose the current FDB"
+                "Redistribute data of the range<Begin, End> among the cluster, where [Begin]<[End]\n",
+                "Given an input range, say <b, d>, where b<d and we suppose the current FDB"
                 "internal shard boundary is [a, c), [c, d), [d, e),"
                 "our splitting algorithm splits the input range into [b, c) and [c, d)."
                 "Then the two ranges will be redistributed among the cluster.\n"));


### PR DESCRIPTION
100K correctness with 1 irrelevant failure
20231003-223444-zhewang-917d61c0f4ece38b           compressed=True data_size=24124672 duration=4942302 ended=100000 fail=1 fail_fast=10 max_runs=100000 pass=99999 priority=100 remaining=0 runtime=1:07:35 sanity=False started=100000 stopped=20231003-234219 submitted=20231003-223444 timeout=5400 username=zhewang

Tested by kubernetes test

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
