### PR TITLE
Fix an unitialized variable

### DIFF
--- a/fdbserver/KeyValueStoreShardedRocksDB.actor.cpp
+++ b/fdbserver/KeyValueStoreShardedRocksDB.actor.cpp
@@ -137,7 +137,7 @@ int getWriteStallState(const rocksdb::WriteStallCondition& condition) {
 
 class RocksDBEventListener : public rocksdb::EventListener {
 public:
-	RocksDBEventListener(UID id) : logId(id) {}
+	RocksDBEventListener(UID id) : logId(id), lastResetTime(now()) {}
 	void OnStallConditionsChanged(const rocksdb::WriteStallInfo& info) override {
 		auto curState = getWriteStallState(info.condition.cur);
 		auto prevState = getWriteStallState(info.condition.prev);

--- a/tests/rare/ClogTlog.toml
+++ b/tests/rare/ClogTlog.toml
@@ -5,6 +5,7 @@ machineCount = 20
 commitProxyCount = 4
 config = 'triple'
 desiredTLogCount = 6
+storageEngineExcludeTypes = [5]
 
 [[knobs]]
 enable_worker_health_monitor = true

--- a/tests/rare/SwizzledLargeApiCorrectness.toml
+++ b/tests/rare/SwizzledLargeApiCorrectness.toml
@@ -1,3 +1,6 @@
+[configuration]
+storageEngineExcludeTypes = [5]
+
 [[test]]
 testTitle = 'ApiCorrectnessTest'
 clearAfterTest = true

--- a/tests/slow/GcGenerations.toml
+++ b/tests/slow/GcGenerations.toml
@@ -5,6 +5,7 @@ machineCount = 20
 minimumRegions = 2
 coordinators = 1
 remoteConfig = 'remote_double'
+storageEngineExcludeTypes = [5]
 
 [[knobs]]
 max_write_transaction_life_versions = 5000000

--- a/tests/slow/ParallelRestoreNewBackupCorrectnessAtomicOp.toml
+++ b/tests/slow/ParallelRestoreNewBackupCorrectnessAtomicOp.toml
@@ -1,5 +1,6 @@
 [configuration]
 allowDefaultTenant = false
+storageEngineExcludeTypes = [5]
 
 [[test]]
 testTitle = 'BackupAndParallelRestoreWithAtomicOp'

--- a/tests/slow/VersionStampBackupToDB.toml
+++ b/tests/slow/VersionStampBackupToDB.toml
@@ -2,6 +2,7 @@
 extraDatabaseMode = 'Single'
 # required tenant mode is not supported for Disaster Recovery yet
 tenantModes = ['disabled', 'optional']
+storageEngineExcludeTypes = [5]
 
 [[test]]
 testTitle = 'VersionStampBackupToDB'


### PR DESCRIPTION
Valgrind complains this for RecentRocksDBBackgroundWorkStats event.

Disable more sharded rocks for simulation tests.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
