### PR TITLE
Check write traffic when bypass shard split

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -265,7 +265,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 		If this value is too small relative to SHARD_MIN_BYTES_PER_KSEC immediate merging work will be generated.
 		*/
 
-	init( CHECK_WRITE_TRAFFIC_WHEN_EXIT_SPLIT,                 false ); if( randomize && BUGGIFY ) CHECK_WRITE_TRAFFIC_WHEN_EXIT_SPLIT = true;
+	init( ENABLE_WRITE_BASED_SHARD_SPLIT,                      false ); if( randomize && BUGGIFY ) ENABLE_WRITE_BASED_SHARD_SPLIT = true;
 	init( STORAGE_METRIC_TIMEOUT,         isSimulated ? 60.0 : 600.0 ); if( randomize && BUGGIFY ) STORAGE_METRIC_TIMEOUT = deterministicRandom()->coinflip() ? 10.0 : 30.0;
 	init( METRIC_DELAY,                                          0.1 ); if( randomize && BUGGIFY ) METRIC_DELAY = 1.0;
 	init( ALL_DATA_REMOVED_DELAY,                                1.0 );

--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -265,6 +265,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 		If this value is too small relative to SHARD_MIN_BYTES_PER_KSEC immediate merging work will be generated.
 		*/
 
+	init( CHECK_WRITE_TRAFFIC_WHEN_EXIT_SPLIT,                 false ); if( randomize && BUGGIFY ) CHECK_WRITE_TRAFFIC_WHEN_EXIT_SPLIT = true;
 	init( STORAGE_METRIC_TIMEOUT,         isSimulated ? 60.0 : 600.0 ); if( randomize && BUGGIFY ) STORAGE_METRIC_TIMEOUT = deterministicRandom()->coinflip() ? 10.0 : 30.0;
 	init( METRIC_DELAY,                                          0.1 ); if( randomize && BUGGIFY ) METRIC_DELAY = 1.0;
 	init( ALL_DATA_REMOVED_DELAY,                                1.0 );

--- a/fdbclient/include/fdbclient/ServerKnobs.h
+++ b/fdbclient/include/fdbclient/ServerKnobs.h
@@ -236,7 +236,7 @@ public:
 	// When the sampled read operations changes more than this threshold, the
 	// shard metrics will update immediately
 	int64_t SHARD_READ_OPS_CHANGE_THRESHOLD;
-	bool CHECK_WRITE_TRAFFIC_WHEN_EXIT_SPLIT; // experimental
+	bool ENABLE_WRITE_BASED_SHARD_SPLIT; // experimental
 
 	double SHARD_MAX_READ_DENSITY_RATIO;
 	int64_t SHARD_READ_HOT_BANDWIDTH_MIN_PER_KSECONDS;

--- a/fdbclient/include/fdbclient/ServerKnobs.h
+++ b/fdbclient/include/fdbclient/ServerKnobs.h
@@ -236,6 +236,7 @@ public:
 	// When the sampled read operations changes more than this threshold, the
 	// shard metrics will update immediately
 	int64_t SHARD_READ_OPS_CHANGE_THRESHOLD;
+	bool CHECK_WRITE_TRAFFIC_WHEN_EXIT_SPLIT; // experimental
 
 	double SHARD_MAX_READ_DENSITY_RATIO;
 	int64_t SHARD_READ_HOT_BANDWIDTH_MIN_PER_KSECONDS;

--- a/fdbserver/StorageMetrics.actor.cpp
+++ b/fdbserver/StorageMetrics.actor.cpp
@@ -284,6 +284,7 @@ KeyRef StorageServerMetrics::getSplitKey(int64_t remaining,
 
 void StorageServerMetrics::splitMetrics(SplitMetricsRequest req) const {
 	int minSplitBytes = req.minSplitBytes.present() ? req.minSplitBytes.get() : SERVER_KNOBS->MIN_SHARD_BYTES;
+	int minSplitWriteTraffic = SERVER_KNOBS->SHARD_SPLIT_BYTES_PER_KSEC;
 	try {
 		SplitMetricsReply reply;
 		KeyRef lastKey = req.keys.begin;
@@ -294,7 +295,8 @@ void StorageServerMetrics::splitMetrics(SplitMetricsRequest req) const {
 		//TraceEvent("SplitMetrics").detail("Begin", req.keys.begin).detail("End", req.keys.end).detail("Remaining", remaining.bytes).detail("Used", used.bytes).detail("MinSplitBytes", minSplitBytes);
 
 		while (true) {
-			if (remaining.bytes < 2 * minSplitBytes)
+			if (remaining.bytes < 2 * minSplitBytes && (!SERVER_KNOBS->CHECK_WRITE_TRAFFIC_WHEN_EXIT_SPLIT ||
+			                                            remaining.bytesWrittenPerKSecond < minSplitWriteTraffic))
 				break;
 			KeyRef key = req.keys.end;
 			bool hasUsed = used.bytes != 0 || used.bytesWrittenPerKSecond != 0 || used.iosPerKSecond != 0;
@@ -309,7 +311,8 @@ void StorageServerMetrics::splitMetrics(SplitMetricsRequest req) const {
 			                  lastKey,
 			                  key,
 			                  hasUsed);
-			if (used.bytes < minSplitBytes)
+			if (used.bytes < minSplitBytes && (!SERVER_KNOBS->CHECK_WRITE_TRAFFIC_WHEN_EXIT_SPLIT ||
+			                                   remaining.bytesWrittenPerKSecond < minSplitWriteTraffic))
 				key = std::max(
 				    key, byteSample.splitEstimate(KeyRangeRef(lastKey, req.keys.end), minSplitBytes - used.bytes));
 			key = getSplitKey(remaining.iosPerKSecond,

--- a/fdbserver/StorageMetrics.actor.cpp
+++ b/fdbserver/StorageMetrics.actor.cpp
@@ -295,7 +295,7 @@ void StorageServerMetrics::splitMetrics(SplitMetricsRequest req) const {
 		//TraceEvent("SplitMetrics").detail("Begin", req.keys.begin).detail("End", req.keys.end).detail("Remaining", remaining.bytes).detail("Used", used.bytes).detail("MinSplitBytes", minSplitBytes);
 
 		while (true) {
-			if (remaining.bytes < 2 * minSplitBytes && (!SERVER_KNOBS->CHECK_WRITE_TRAFFIC_WHEN_EXIT_SPLIT ||
+			if (remaining.bytes < 2 * minSplitBytes && (!SERVER_KNOBS->ENABLE_WRITE_BASED_SHARD_SPLIT ||
 			                                            remaining.bytesWrittenPerKSecond < minSplitWriteTraffic))
 				break;
 			KeyRef key = req.keys.end;
@@ -311,7 +311,7 @@ void StorageServerMetrics::splitMetrics(SplitMetricsRequest req) const {
 			                  lastKey,
 			                  key,
 			                  hasUsed);
-			if (used.bytes < minSplitBytes && (!SERVER_KNOBS->CHECK_WRITE_TRAFFIC_WHEN_EXIT_SPLIT ||
+			if (used.bytes < minSplitBytes && (!SERVER_KNOBS->ENABLE_WRITE_BASED_SHARD_SPLIT ||
 			                                   remaining.bytesWrittenPerKSecond < minSplitWriteTraffic))
 				key = std::max(
 				    key, byteSample.splitEstimate(KeyRangeRef(lastKey, req.keys.end), minSplitBytes - used.bytes));


### PR DESCRIPTION
Problem: when calculating split points of a shard, DD skips splitting if the size of the remaining shard size is reasonably small. However, it is possible that a shard size is small but the write traffic is high, resulting in rate keeping due to a storage queue. 

Solution: we want to continue splitting the remaining shard even when the size is small but the write traffic is high. This may lead to more shards and more data movements. We need to test this solution in a real cluster before merge it.

Usage: set ENABLE_WRITE_BASED_SHARD_SPLIT to enable this feature.

Passed 100K tests with 3 external timeout failures:
  20231011-210230-zhewang-4fbc5fa5e9cb65e1           compressed=True data_size=35910250 duration=6595407 ended=100000 fail=3 fail_fast=10 max_runs=100000 pass=99997 priority=100 remaining=0 runtime=0:50:16 sanity=False started=100000 stopped=20231011-215246 submitted=20231011-210230 timeout=5400 username=zhewang

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
