### PR TITLE
Encode data move priority into DataMoveId

### DIFF
--- a/fdbclient/SystemData.cpp
+++ b/fdbclient/SystemData.cpp
@@ -519,7 +519,8 @@ const ValueRef serverKeysTrue = "1"_sr, // compatible with what was serverKeysTr
 const UID newDataMoveId(const uint64_t physicalShardId,
                         AssignEmptyRange assignEmptyRange,
                         EnablePhysicalShardMove enablePSM,
-                        UnassignShard unassignShard) {
+                        UnassignShard unassignShard,
+                        Optional<uint64_t> dmReasonBitMask) {
 	uint64_t split = 0;
 	if (assignEmptyRange) {
 		split = emptyShardId;
@@ -528,6 +529,11 @@ const UID newDataMoveId(const uint64_t physicalShardId,
 	} else {
 		do {
 			split = deterministicRandom()->randomUInt64();
+			split &= 64U; // clear last 6 bits
+			if (dmReasonBitMask.present()) {
+				// the last 1 bit is reserved for enablePSM
+				split |= (dmReasonBitMask.get() << 1);
+			}
 			if (enablePSM) {
 				split |= 1U;
 			} else {

--- a/fdbclient/include/fdbclient/SystemData.h
+++ b/fdbclient/include/fdbclient/SystemData.h
@@ -164,7 +164,8 @@ extern const ValueRef serverKeysTrue, serverKeysTrueEmptyRange, serverKeysFalse;
 const UID newDataMoveId(const uint64_t physicalShardId,
                         AssignEmptyRange assignEmptyRange,
                         EnablePhysicalShardMove enablePSM = EnablePhysicalShardMove::False,
-                        UnassignShard unassignShard = UnassignShard::False);
+                        UnassignShard unassignShard = UnassignShard::False,
+                        Optional<uint64_t> dmReasonBitMask = Optional<uint64_t>());
 const Key serverKeysKey(UID serverID, const KeyRef& keys);
 const Key serverKeysPrefixFor(UID serverID);
 UID serverKeysDecodeServer(const KeyRef& key);

--- a/fdbserver/MoveKeys.actor.cpp
+++ b/fdbserver/MoveKeys.actor.cpp
@@ -2759,6 +2759,7 @@ ACTOR Future<Void> removeKeysFromFailedServer(Database cx,
 
 						const UID shardId =
 						    newDataMoveId(deterministicRandom()->randomUInt64(), AssignEmptyRange::True);
+						// no data move is triggered, so, we do not encode dmReason into shardId
 
 						// Assign the shard to teamForDroppedRange in keyServer space.
 						if (SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA) {


### PR DESCRIPTION
This PR encodes the data move reason into the dataMoveId. 
DataMoveId is an UID, which contains two parts and each part is an uint64 value.
First part is a random id, as physical shard id.
Second part is embedded with data move information:
    The last one bit: enable physical shard move
    The last two ~ six bits: data move reason

As a result, this PR enables SS to check the data move reason when fetchKeys/fetchShards.

Correctness test with 2 irrelevant failures:
  20231012-002649-zhewang-b53c14a4e772f501           compressed=True data_size=35922445 duration=7533954 ended=100000 fail=2 fail_fast=10 max_runs=100000 pass=99998 priority=100 remaining=0 runtime=1:01:24 sanity=False started=100000 stopped=20231012-012813 submitted=20231012-002649 timeout=5400 username=zhewang

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
