### PR TITLE
Fix backup worker stability issues

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -662,7 +662,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( BACKUP_TIMEOUT,                                        0.4 );
 	init( BACKUP_NOOP_POP_DELAY,                                 5.0 );
 	init( BACKUP_FILE_BLOCK_BYTES,                       1024 * 1024 );
-	init( BACKUP_LOCK_BYTES,                                     3e9 ); if(randomize && BUGGIFY) BACKUP_LOCK_BYTES = deterministicRandom()->randomInt(1024, 4096) * 256 * 1024;
+	init( BACKUP_LOCK_BYTES,                                     3e9 ); if(randomize && BUGGIFY) BACKUP_LOCK_BYTES = deterministicRandom()->randomInt(1024, 4096) * 4096;
 	init( BACKUP_UPLOAD_DELAY,                                  10.0 ); if(randomize && BUGGIFY) BACKUP_UPLOAD_DELAY = deterministicRandom()->random01() * 60;
 
 	//Cluster Controller

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -1627,10 +1627,6 @@ void SimulationConfig::setRandomConfig() {
 		// TraceEvent("SimulatedConfigRandom").detail("PerpetualWiggle", 1);
 		set_config("perpetual_storage_wiggle=1");
 	}
-
-	if (deterministicRandom()->random01() < 0.5) {
-		set_config("backup_worker_enabled:=1");
-	}
 }
 
 // Overwrite DB with simple options, used when simpleConfig is true in the TestConfig

--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -1622,7 +1622,7 @@ void commitMessages(TLogData* self, Reference<LogData> logData, Version version,
 Version poppedVersion(Reference<LogData> self, Tag tag) {
 	auto tagData = self->getTagData(tag);
 	if (!tagData) {
-		if (tag == txsTag || tag.locality == tagLocalityTxs) {
+		if (tag == txsTag || tag.locality == tagLocalityTxs || tag.locality == tagLocalityLogRouter) {
 			return 0;
 		}
 		return std::max(self->recoveredAt + 1, self->recoveryTxnVersion);

--- a/fdbserver/workloads/ConfigureDatabase.actor.cpp
+++ b/fdbserver/workloads/ConfigureDatabase.actor.cpp
@@ -48,7 +48,6 @@ static const char* logTypes[] = { "log_engine:=1",
 	                              // downgrade incompatible log version
 	                              "log_version:=7" };
 static const char* redundancies[] = { "single", "double", "triple" };
-static const char* backupTypes[] = { "backup_worker_enabled:=0", "backup_worker_enabled:=1" };
 
 std::string generateRegions() {
 	std::string result;
@@ -357,12 +356,12 @@ struct ConfigureDatabaseWorkload : TestWorkload {
 			state int randomChoice;
 			if (self->allowTestStorageMigration) {
 				randomChoice = (deterministicRandom()->random01() < 0.375) ? deterministicRandom()->randomInt(0, 3)
-				                                                           : deterministicRandom()->randomInt(4, 9);
+				                                                           : deterministicRandom()->randomInt(4, 7);
 			} else if (self->storageMigrationCompatibleConf) {
 				randomChoice = (deterministicRandom()->random01() < 3.0 / 7) ? deterministicRandom()->randomInt(0, 3)
-				                                                             : deterministicRandom()->randomInt(4, 8);
+				                                                             : deterministicRandom()->randomInt(4, 7);
 			} else {
-				randomChoice = deterministicRandom()->randomInt(0, 8);
+				randomChoice = deterministicRandom()->randomInt(0, 7);
 			}
 			if (randomChoice == 0) {
 				wait(success(
@@ -462,11 +461,6 @@ struct ConfigureDatabaseWorkload : TestWorkload {
 				wait(success(
 				    IssueConfigurationChange(cx, logTypes[deterministicRandom()->randomInt(0, length)], false)));
 			} else if (randomChoice == 7) {
-				wait(success(IssueConfigurationChange(
-				    cx,
-				    backupTypes[deterministicRandom()->randomInt(0, sizeof(backupTypes) / sizeof(backupTypes[0]))],
-				    false)));
-			} else if (randomChoice == 8) {
 				if (self->allowTestStorageMigration) {
 					CODE_PROBE(true, "storage migration type change");
 


### PR DESCRIPTION
This PR includes a few stability fixes for Backup Worker

1) Fixed memory bookkeeping issue in Backup Worker. Previously it didn't release flow lock correctly when erasing messages. 
2) Got rid of Backup Worker noop mode. Noop mode may over-pop when starting backups. Since we don't have noop mode now, we need to disable Backup Worker globally when no backup is running.
3) Added a check for popped() API after peeking mutations from tlog. A non-zero value indicates mutation loss
3) Added TLogServer fix to return 0 from poppedVersion() for unrecognized log router tags.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
