### PR TITLE
[Release-7.3] Cherry-pick Add write traffic metrics to ddMetricsGetRange

### DIFF
--- a/fdbclient/Schemas.cpp
+++ b/fdbclient/Schemas.cpp
@@ -1156,7 +1156,8 @@ const KeyRef JSONSchemas::latencyBandConfigurationSchema = R"configSchema(
 
 const KeyRef JSONSchemas::dataDistributionStatsSchema = R"""(
 {
-  "shard_bytes": 1947000
+  "shard_bytes": 1947000,
+  "shard_bytes_per_ksecond": 1000000
 }
 )"""_sr;
 

--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -741,6 +741,7 @@ ACTOR Future<RangeResult> ddMetricsGetRangeActor(ReadYourWritesTransaction* ryw,
 				// Use json string encoded in utf-8 to encode the values, easy for adding more fields in the future
 				json_spirit::mObject statsObj;
 				statsObj["shard_bytes"] = ddMetricsRef.shardBytes;
+				statsObj["shard_bytes_per_ksecond"] = ddMetricsRef.shardBytesPerKSecond;
 				std::string statsString =
 				    json_spirit::write_string(json_spirit::mValue(statsObj), json_spirit::Output_options::raw_utf8);
 				ValueRef bytes(result.arena(), statsString);

--- a/fdbclient/include/fdbclient/FDBTypes.h
+++ b/fdbclient/include/fdbclient/FDBTypes.h
@@ -1331,16 +1331,19 @@ struct HealthMetrics {
 
 struct DDMetricsRef {
 	int64_t shardBytes;
+	int64_t shardBytesPerKSecond;
 	KeyRef beginKey;
 
-	DDMetricsRef() : shardBytes(0) {}
-	DDMetricsRef(int64_t bytes, KeyRef begin) : shardBytes(bytes), beginKey(begin) {}
+	DDMetricsRef() : shardBytes(0), shardBytesPerKSecond(0) {}
+	DDMetricsRef(int64_t bytes, int64_t bytesPerKSecond, KeyRef begin)
+	  : shardBytes(bytes), shardBytesPerKSecond(bytesPerKSecond), beginKey(begin) {}
 	DDMetricsRef(Arena& a, const DDMetricsRef& copyFrom)
-	  : shardBytes(copyFrom.shardBytes), beginKey(a, copyFrom.beginKey) {}
+	  : shardBytes(copyFrom.shardBytes), shardBytesPerKSecond(copyFrom.shardBytesPerKSecond),
+	    beginKey(a, copyFrom.beginKey) {}
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, shardBytes, beginKey);
+		serializer(ar, shardBytes, beginKey, shardBytesPerKSecond);
 	}
 };
 

--- a/fdbserver/DDShardTracker.actor.cpp
+++ b/fdbserver/DDShardTracker.actor.cpp
@@ -1434,7 +1434,9 @@ ACTOR Future<Void> fetchShardMetricsList_impl(DataDistributionTracker* self, Get
 					break;
 				}
 				result.push_back_deep(result.arena(),
-				                      DDMetricsRef(stats->get().get().metrics.bytes, KeyRef(t.begin().toString())));
+				                      DDMetricsRef(stats->get().get().metrics.bytes,
+				                                   stats->get().get().metrics.bytesWrittenPerKSecond,
+				                                   KeyRef(t.begin().toString())));
 				++shardNum;
 				if (shardNum >= req.shardLimit) {
 					break;


### PR DESCRIPTION
This PR cherry-picks https://github.com/apple/foundationdb/pull/10987.

100K correctness test:
  20231019-182456-zhewang-0cfefafa39a1fe2a           compressed=True data_size=34493324 duration=8175372 ended=100000 fail=2 fail_fast=10 max_runs=100000 pass=99998 priority=100 remaining=0 runtime=1:07:20 sanity=False started=100000 stopped=20231019-193216 submitted=20231019-182456 timeout=5400 username=zhewang

1 failure is external timeout with rocksdb storage engine in a restart test.
1 failure is a shared tLog failure in `tests/rare/DcLag.toml:`
`<SharedTLogFailed Severity="40" ErrorKind="DiskIssue" Time="315.123440" DateTime="2023-10-19T19:13:15Z" Type="SharedTLogFailed" Machine="2.2.1.1:1" ID="a77c36aeb3b94777" Error="io_error" ErrorDescription="Disk i/o operation failed" ErrorCode="1510" Reason="Error" ThreadID="14335352005369276283" Backtrace="cd /root/build_output/bin; addr2line -e fdbserver -p -C -f -i 0x5401c0d 0x5401ed3 0x53fc0d4 0x34a432d 0x34d4756 0x34d435e 0x34d2422 0x34d2766 0x1b61039 0x34d353d 0x34d2909 0x209c4a8 0x209c916 0x1b61039 0x34d353d 0x34d2909 0x209c4a8 0x209c916 0x1b61039 0x3054d10 0x30548c9 0x1b61039 0x530e4f4 0x530d9a1 0x530dd67 0x1b61039 0x2ac9293 0x2ac9589 0x1b61039 0x305396a 0x1b61039 0x3045811 0x3045bb7 0x1b61039 0x530e4f4 0x530d9a1 0x530dd67 0x1b61039 0x3041d6a 0x1b61039 0x1f3e0f9 0x2718aa0 0x1f3e0f9 0x2717454 0x2717f48 0x27..." LogGroup="default"/>
`

To the best of my knowledge, the two failures should not be relevant to this PR @dlambrig @jzhou77 

Tested in Kubernetes cluster.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
