### PR TITLE
Fix RemoveServersSafely workload timeout error [release-7.1]

### DIFF
--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -1782,15 +1782,15 @@ std::pair<std::string, std::string> decodeLocality(const std::string& locality) 
 }
 
 // Returns the list of IPAddresses of the workers that match the given locality.
-// Example: locality="dcid:primary" returns all the ip addresses of the workers in the primary dc.
+// Example: locality="locality_dcid:primary" returns all the ip addresses of the workers in the primary dc.
 std::set<AddressExclusion> getAddressesByLocality(const std::vector<ProcessData>& workers,
                                                   const std::string& locality) {
 	std::pair<std::string, std::string> localityKeyValue = decodeLocality(locality);
 
 	std::set<AddressExclusion> localityAddresses;
 	for (int i = 0; i < workers.size(); i++) {
-		if (workers[i].locality.isPresent(localityKeyValue.first) &&
-		    workers[i].locality.get(localityKeyValue.first) == localityKeyValue.second) {
+		auto localityValue = workers[i].locality.get(localityKeyValue.first);
+		if (localityValue.present() && localityValue.get() == localityKeyValue.second) {
 			localityAddresses.insert(AddressExclusion(workers[i].address.ip, workers[i].address.port));
 		}
 	}

--- a/fdbserver/workloads/RemoveServersSafely.actor.cpp
+++ b/fdbserver/workloads/RemoveServersSafely.actor.cpp
@@ -530,7 +530,8 @@ struct RemoveServersSafelyWorkload : TestWorkload {
 			    .detail("Step", "localities changed")
 			    .detail("OrigKillLocalities", describe(origKillLocalities))
 			    .detail("KillLocalities", describe(killLocalities))
-			    .detail("ToKillLocalities", describe(toKillLocalities));
+			    .detail("ToKillLocalities", describe(toKillLocalities))
+			    .detail("Failed", markExcludeAsFailed);
 			killLocalities = toKillLocalities;
 
 			// Include back the localities that are no longer in the kill list
@@ -722,7 +723,11 @@ struct RemoveServersSafelyWorkload : TestWorkload {
 			    .detail("ClusterAvailable", g_simulator.isAvailable());
 			if (excludeLocalitiesInsteadOfServers) {
 				wait(success(checkForExcludingServers(cx, toKillArray, true /* wait for exclusion */)) ||
-				     checkLocalityChange(self, cx, toKillArray, toKillLocalities, markExcludeAsFailed));
+				     checkLocalityChange(self,
+				                         cx,
+				                         toKillArray,
+				                         toKillLocalities,
+				                         markExcludeAsFailed && toKillLocalitiesFailed.size() > 0));
 			} else {
 				wait(success(checkForExcludingServers(cx, toKillArray, true /* wait for exclusion */)));
 			}

--- a/fdbserver/workloads/RemoveServersSafely.actor.cpp
+++ b/fdbserver/workloads/RemoveServersSafely.actor.cpp
@@ -508,6 +508,44 @@ struct RemoveServersSafelyWorkload : TestWorkload {
 		return killProcArray;
 	}
 
+	// If a process is rebooted, it's processid will change. So we need to monitor
+	// such changes and re-issue the locality-based exclusion again.
+	ACTOR static Future<Void> checkLocalityChange(RemoveServersSafelyWorkload* self,
+	                                              Database cx,
+	                                              std::vector<AddressExclusion> toKillArray,
+	                                              std::unordered_set<std::string> origKillLocalities,
+	                                              bool markExcludeAsFailed) {
+		state std::unordered_set<std::string> killLocalities = origKillLocalities;
+
+		loop {
+			wait(delay(10.0));
+			wait(self->updateProcessIds(cx));
+			std::unordered_set<std::string> toKillLocalities = self->getLocalitiesFromAddresses(toKillArray);
+			if (toKillLocalities == killLocalities) {
+				continue;
+			}
+
+			// The kill localities have changed.
+			TraceEvent("RemoveAndKill")
+			    .detail("Step", "localities changed")
+			    .detail("OrigKillLocalities", describe(origKillLocalities))
+			    .detail("KillLocalities", describe(killLocalities))
+			    .detail("ToKillLocalities", describe(toKillLocalities));
+			killLocalities = toKillLocalities;
+
+			// Include back the localities that are no longer in the kill list
+			state bool failed = true;
+			wait(includeLocalities(cx, std::vector<std::string>(), failed, true));
+			wait(includeLocalities(cx, std::vector<std::string>(), !failed, true));
+
+			// Exclude the localities that are now in the kill list
+			wait(excludeLocalities(cx, killLocalities, markExcludeAsFailed));
+			TraceEvent("RemoveAndKill")
+			    .detail("Step", "new localities excluded")
+			    .detail("Localities", describe(killLocalities));
+		}
+	}
+
 	// Attempts to exclude a set of processes, and once the exclusion is successful it kills them.
 	// If markExcludeAsFailed is true, then it is an error if we cannot complete the exclusion.
 	ACTOR static Future<Void> removeAndKill(RemoveServersSafelyWorkload* self,
@@ -682,7 +720,12 @@ struct RemoveServersSafelyWorkload : TestWorkload {
 			    .detail("Step", "Wait For Server Exclusion")
 			    .detail("Addresses", describe(toKill))
 			    .detail("ClusterAvailable", g_simulator.isAvailable());
-			wait(success(checkForExcludingServers(cx, toKillArray, true /* wait for exclusion */)));
+			if (excludeLocalitiesInsteadOfServers) {
+				wait(success(checkForExcludingServers(cx, toKillArray, true /* wait for exclusion */)) ||
+				     checkLocalityChange(self, cx, toKillArray, toKillLocalities, markExcludeAsFailed));
+			} else {
+				wait(success(checkForExcludingServers(cx, toKillArray, true /* wait for exclusion */)));
+			}
 
 			TraceEvent("RemoveAndKill", functionId)
 			    .detail("Step", "coordinators auto")

--- a/tests/slow/MoveKeysSideband.toml
+++ b/tests/slow/MoveKeysSideband.toml
@@ -1,3 +1,6 @@
+[[knobs]]
+peek_tracker_expiration_time = 600
+
 [[test]]
 testTitle = 'MoveKeysNew'
 


### PR DESCRIPTION
cherrypick #11001 

This workload can have timeout error when using locality-based exclusion. The
sequence is:

1. RemoveServerSafely workload exclude locality by processid
2. Attrition reboots the target process, thus changing the processid, because
    processid is generated for each worker process at fdbd()
3. RemoveServerSafely waits for the process exclusion, which never succeed
4. Timeout

The fix monitors processid locality changes and reissue the exclusion with the
correct locality.

To reproduce:
    seed: -f ./tests/fast/SwizzledRollbackSideband.toml -s 879108103 -b on
    commit: a3dbd4baf release-7.1

500k 20231020-040336-jzhou-42bd5d69b66f383a

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
