### PR TITLE
Update macos cgo 6.3

### DIFF
--- a/bindings/go/src/fdb/fdb_darwin.go
+++ b/bindings/go/src/fdb/fdb_darwin.go
@@ -1,5 +1,5 @@
 package fdb
 
 //#cgo CFLAGS: -I/usr/local/include/
-//#cgo LDFLAGS: -Wl,-rpath,/usr/local/lib
+//#cgo LDFLAGS: -L/usr/local/lib/ -Wl,-rpath,/usr/local/lib
 import "C"

--- a/bindings/go/src/fdb/fdb_darwin.go
+++ b/bindings/go/src/fdb/fdb_darwin.go
@@ -1,5 +1,5 @@
 package fdb
 
 //#cgo CFLAGS: -I/usr/local/include/
-//#cgo LDFLAGS: -L/usr/local/lib/
+//#cgo LDFLAGS: -Wl,-rpath,/usr/local/lib
 import "C"


### PR DESCRIPTION
Fix the usage of the go bindings for 6.3 on newer macOS versions. This doesn't require a release and users of the go bindings just have to update the reference.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [x] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [x] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
