### PR TITLE
[Release-7.3] Cherry-pick Check write traffic when bypass shard split

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -265,6 +265,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 		If this value is too small relative to SHARD_MIN_BYTES_PER_KSEC immediate merging work will be generated.
 		*/
 
+	init( ENABLE_WRITE_BASED_SHARD_SPLIT,                      false ); if( randomize && BUGGIFY ) ENABLE_WRITE_BASED_SHARD_SPLIT = true;
 	init( STORAGE_METRIC_TIMEOUT,         isSimulated ? 60.0 : 600.0 ); if( randomize && BUGGIFY ) STORAGE_METRIC_TIMEOUT = deterministicRandom()->coinflip() ? 10.0 : 30.0;
 	init( METRIC_DELAY,                                          0.1 ); if( randomize && BUGGIFY ) METRIC_DELAY = 1.0;
 	init( ALL_DATA_REMOVED_DELAY,                                1.0 );

--- a/fdbclient/include/fdbclient/ServerKnobs.h
+++ b/fdbclient/include/fdbclient/ServerKnobs.h
@@ -235,6 +235,7 @@ public:
 	// When the sampled read operations changes more than this threshold, the
 	// shard metrics will update immediately
 	int64_t SHARD_READ_OPS_CHANGE_THRESHOLD;
+	bool ENABLE_WRITE_BASED_SHARD_SPLIT; // experimental
 
 	double SHARD_MAX_READ_DENSITY_RATIO;
 	int64_t SHARD_READ_HOT_BANDWIDTH_MIN_PER_KSECONDS;

--- a/fdbserver/StorageMetrics.actor.cpp
+++ b/fdbserver/StorageMetrics.actor.cpp
@@ -259,6 +259,7 @@ KeyRef StorageServerMetrics::getSplitKey(int64_t remaining,
 
 void StorageServerMetrics::splitMetrics(SplitMetricsRequest req) const {
 	int minSplitBytes = req.minSplitBytes.present() ? req.minSplitBytes.get() : SERVER_KNOBS->MIN_SHARD_BYTES;
+	int minSplitWriteTraffic = SERVER_KNOBS->SHARD_SPLIT_BYTES_PER_KSEC;
 	try {
 		SplitMetricsReply reply;
 		KeyRef lastKey = req.keys.begin;
@@ -269,7 +270,8 @@ void StorageServerMetrics::splitMetrics(SplitMetricsRequest req) const {
 		//TraceEvent("SplitMetrics").detail("Begin", req.keys.begin).detail("End", req.keys.end).detail("Remaining", remaining.bytes).detail("Used", used.bytes).detail("MinSplitBytes", minSplitBytes);
 
 		while (true) {
-			if (remaining.bytes < 2 * minSplitBytes)
+			if (remaining.bytes < 2 * minSplitBytes && (!SERVER_KNOBS->ENABLE_WRITE_BASED_SHARD_SPLIT ||
+			                                            remaining.bytesWrittenPerKSecond < minSplitWriteTraffic))
 				break;
 			KeyRef key = req.keys.end;
 			bool hasUsed = used.bytes != 0 || used.bytesWrittenPerKSecond != 0 || used.iosPerKSecond != 0;
@@ -284,7 +286,8 @@ void StorageServerMetrics::splitMetrics(SplitMetricsRequest req) const {
 			                  lastKey,
 			                  key,
 			                  hasUsed);
-			if (used.bytes < minSplitBytes)
+			if (used.bytes < minSplitBytes && (!SERVER_KNOBS->ENABLE_WRITE_BASED_SHARD_SPLIT ||
+			                                   remaining.bytesWrittenPerKSecond < minSplitWriteTraffic))
 				key = std::max(
 				    key, byteSample.splitEstimate(KeyRangeRef(lastKey, req.keys.end), minSplitBytes - used.bytes));
 			key = getSplitKey(remaining.iosPerKSecond,


### PR DESCRIPTION
This PR cherry-picks PR https://github.com/apple/foundationdb/pull/10974

**100K correctness test with 4 failures:**
  20231020-191640-zhewang-cd645ce644e60f7f           compressed=True data_size=34493556 duration=6529908 ended=100000 fail=4 fail_fast=10 max_runs=100000 pass=99996 priority=100 remaining=0 runtime=1:38:17 sanity=False started=100000 stopped=20231020-205457 submitted=20231020-191640 timeout=5400 username=zhewang

- rare/WriteTagThrottling.toml:
```
<HealthMetricsStoppedUpdating Severity="40" ErrorKind="Unset" Time="208.018929" DateTime="2023-10-20T19:50:44Z" Type="HealthMetricsStoppedUpdating" Machine="[abcd::3:4:3:5]:1" ID="0000000000000000" ThreadID="13065669644775959922" Backtrace="cd /root/build_output/bin; addr2line -e fdbserver -p -C -f -i 0x54020ed 0x54023b3 0x3a3fbd6 0x33e3014 0x33e2d06 0x33fcf81 0x33fb519 0x1efb7d6 0x51d439d 0x51d3c73 0x1b769e8 0x52c8b91 0x52c86aa 0x32037cc 0x7f8e64289555" LogGroup="default" Roles="TS"/>
```

- slow/DDBalanceAndRemove.toml:
```
<RemoveServersSafelyError Severity="40" ErrorKind="Unset" Time="6163.136197" DateTime="2023-10-20T20:28:47Z" Type="RemoveServersSafelyError" Machine="3.4.3.2:1" ID="0000000000000000" Error="timed_out" ErrorDescription="Operation timed out" ErrorCode="1004" ThreadID="14981950275450971598" Backtrace="cd /root/build_output/bin; addr2line -e fdbserver -p -C -f -i 0x54020ed 0x54023b3 0x53fc5b4 0x223f81d 0x223fa87 0x1b61039 0x22cf794 0x1b769e8 0x52c8b91 0x52c86aa 0x32037cc 0x7fab40543555" LogGroup="default" Roles="TS"/>
<TestFailure Severity="40" ErrorKind="Unset" Time="6163.136197" DateTime="2023-10-20T20:28:47Z" Type="TestFailure" Machine="3.4.3.2:1" ID="2a08f9ed1c39e0ff" Error="timed_out" ErrorDescription="Operation timed out" ErrorCode="1004" Reason="Error starting workload" Workload="DDBalance;BackgroundSelector;RandomClogging;Rollback;Attrition;Attrition;Attrition;RemoveServersSafely" ThreadID="14981950275450971598" Backtrace="cd /root/build_output/bin; addr2line -e fdbserver -p -C -f -i 0x54020ed 0x54023b3 0x53fc5b4 0x33fe2f7 0x33ffa4f 0x1b61039 0x1c77c8d 0x1b61039 0x1b61039 0x33f3826 0x1b61039 0x3e7776a 0x1b61039 0x223f847 0x223fa87 0x1b61039 0x22cf794 0x1b769e8 0x52c8b91 0x52c86aa 0x32037cc 0x7fab40543555" LogGroup="default" Roles="TS"/>
```

- 2 External timeout with rocksdb


**100K correctness test with feature always on:**
  20231020-191841-zhewang-18baa3c61d7ed495           compressed=True data_size=34493574 duration=5874964 ended=100000 fail=2 fail_fast=10 max_runs=100000 pass=99998 priority=100 remaining=0 runtime=1:23:02 sanity=False started=100000 stopped=20231020-204143 submitted=20231020-191841 timeout=5400 username=zhewang

- rare/PerpetualWiggleStorageMigration.toml: TracedTooManyLines. This error can be reproduce. Once I set `--knob_max_trace_lines 100000000`, the test can successfully complete.

- 1 External timeout with sharded-rocksdb

Tested by Kubernetes test:
The number of shards when test completes with feature on and off is the same.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
