### PR TITLE
Improve visibility of consistency checker

### DIFF
--- a/fdbserver/ConsistencyScan.actor.cpp
+++ b/fdbserver/ConsistencyScan.actor.cpp
@@ -1514,11 +1514,17 @@ ACTOR Future<Void> checkDataConsistency(Database cx,
 	    *bytesReadInPrevRound == 0
 	        ? maxRate
 	        : std::min(maxRate, static_cast<int64_t>(ceil(*bytesReadInPrevRound / (float)targetInterval)));
+	TraceEvent("ConsistencyCheck_RateLimitForThisRound")
+	    .detail("RateLimit", rateLimitForThisRound)
+	    .detail("BytesReadInPrevRound", *bytesReadInPrevRound)
+	    .detail("TargetInterval", targetInterval)
+	    .detail("MaxRate", maxRate);
 	ASSERT(rateLimitForThisRound >= 0 && rateLimitForThisRound <= maxRate);
-	TraceEvent("ConsistencyCheck_RateLimitForThisRound").detail("RateLimit", rateLimitForThisRound);
 	state Reference<IRateControl> rateLimiter = Reference<IRateControl>(new SpeedLimit(rateLimitForThisRound, 1));
 	state double rateLimiterStartTime = now();
 	state int64_t bytesReadInthisRound = 0;
+	state double rateLimiterCumulatedWaitTime = 0;
+	state bool decideToRunAtMaxRate = false;
 
 	state double dbSize = 100e12;
 	state int ssCount = 1e6;
@@ -1556,6 +1562,8 @@ ACTOR Future<Void> checkDataConsistency(Database cx,
 	        SystemDBWriteLockedNow(cx.getReference()), allKeys.begin, allKeys.end));
 	state int customReplicatedShards = 0;
 	state int underReplicatedShards = 0;
+	state int64_t numCheckedShard = 0;
+	state int64_t numCheckedReadShard = 0;
 
 	for (; i < ranges.size(); i++) {
 		state int shard = shardOrder[i];
@@ -1573,6 +1581,9 @@ ACTOR Future<Void> checkDataConsistency(Database cx,
 
 		// If the destStorageServers is non-empty, then this shard is being relocated
 		state bool isRelocating = destStorageServers.size() > 0;
+
+		state double shardCheckStartTime = now();
+		state double rateLimiterWaitTimeForThisShard = 0;
 
 		int desiredReplicas = configuration.storageTeamSize;
 		if (ddLargeTeamEnabled()) {
@@ -1742,6 +1753,7 @@ ACTOR Future<Void> checkDataConsistency(Database cx,
 			state int64_t totalReadAmount = 0;
 			state KeyRange readRange = range;
 			state Transaction onErrorTr(cx); // This transaction exists only to access onError and its backoff behavior
+			state double dataConsistencyCheckTime = 0;
 
 			// Read a limited number of entries at a time, repeating until all keys in the shard have been read
 			loop {
@@ -1753,6 +1765,7 @@ ACTOR Future<Void> checkDataConsistency(Database cx,
 
 					state std::vector<Future<ErrorOr<GetKeyValuesReply>>> keyValueFutures;
 					state Optional<int> firstValidServer;
+					state double dataConsistencyCheckBeginTime = now();
 
 					totalReadAmount = 0;
 					int failures = wait(consistencyCheckReadData(UID(),
@@ -1767,6 +1780,7 @@ ACTOR Future<Void> checkDataConsistency(Database cx,
 					if (failures > 0) {
 						testFailure("Data inconsistent", performQuiescentChecks, success, true);
 					}
+					dataConsistencyCheckTime += (now() - dataConsistencyCheckBeginTime);
 
 					// If the data is not available and we aren't relocating this shard
 					for (int i = 0; i < storageServerInterfaces.size(); i++) {
@@ -1863,8 +1877,12 @@ ACTOR Future<Void> checkDataConsistency(Database cx,
 						TraceEvent("ConsistencyCheck_RateLimit")
 						    .detail("RateLimitForThisRound", rateLimitForThisRound)
 						    .detail("TotalAmountRead", totalReadAmount);
+						state double rateLimiterBeforeWaitTime = now();
 						wait(rateLimiter->getAllowance(totalReadAmount));
-						TraceEvent("ConsistencyCheck_AmountRead1").detail("TotalAmountRead", totalReadAmount);
+						double rateLimiterCurrentWaitTime = now() - rateLimiterBeforeWaitTime;
+						rateLimiterWaitTimeForThisShard += rateLimiterCurrentWaitTime;
+						rateLimiterCumulatedWaitTime += rateLimiterCurrentWaitTime;
+						TraceEvent("ConsistencyCheck_AmountRead").detail("TotalAmountRead", totalReadAmount);
 						// Set ratelimit to max allowed if current round has been going on for a while
 						if (now() - rateLimiterStartTime > 1.1 * targetInterval && rateLimitForThisRound != maxRate) {
 							rateLimitForThisRound = maxRate;
@@ -1872,6 +1890,7 @@ ACTOR Future<Void> checkDataConsistency(Database cx,
 							rateLimiterStartTime = now();
 							TraceEvent(SevInfo, "ConsistencyCheck_RateLimitSetMaxForThisRound")
 							    .detail("RateLimit", rateLimitForThisRound);
+							decideToRunAtMaxRate = true;
 						}
 					}
 					bytesReadInRange += totalReadAmount;
@@ -2019,11 +2038,34 @@ ACTOR Future<Void> checkDataConsistency(Database cx,
 		}
 
 		if (bytesReadInRange > 0) {
+			numCheckedReadShard++;
 			TraceEvent("ConsistencyCheck_ReadRange")
 			    .suppressFor(1.0)
 			    .detail("Range", range)
 			    .detail("BytesRead", bytesReadInRange);
 		}
+		numCheckedShard++;
+
+		TraceEvent("ConsistencyCheck_ShardComplete")
+		    .suppressFor(1.0)
+		    .detail("Index", i)
+		    .detail("BytesReadInthisRound", bytesReadInthisRound)
+		    .detail("NumCheckedReadShard", numCheckedReadShard)
+		    .detail("NumCheckedShard", numCheckedShard)
+		    .detail("Range", range)
+		    .detail("BytesRead", bytesReadInRange)
+		    .detail("ShardCheckTime", now() - shardCheckStartTime)
+		    .detail("DataConsistencyCheckTime", dataConsistencyCheckTime)
+		    .detail("RateLimitTime", rateLimiterWaitTimeForThisShard)
+		    .detail("CumulatedRateLimitTime", rateLimiterCumulatedWaitTime)
+		    .detail("DecideToRunAtMaxRate", decideToRunAtMaxRate)
+		    .detail("ClientId", clientId)
+		    .detail("ClientCount", clientCount)
+		    .detail("FirstClient", firstClient)
+		    .detail("Distributed", distributed)
+		    .detail("PerformTSSCheck", performTSSCheck)
+		    .detail("ShardSampleFactor", shardSampleFactor)
+		    .detail("EffectiveClientCount", effectiveClientCount);
 	}
 
 	if (customReplicatedShards > SERVER_KNOBS->DD_MAX_SHARDS_ON_LARGE_TEAMS) {

--- a/fdbserver/workloads/ConsistencyCheck.actor.cpp
+++ b/fdbserver/workloads/ConsistencyCheck.actor.cpp
@@ -232,6 +232,7 @@ struct ConsistencyCheckWorkload : TestWorkload {
 	ACTOR Future<Void> runCheck(Database cx, ConsistencyCheckWorkload* self) {
 		CODE_PROBE(self->performQuiescentChecks, "Quiescent consistency check");
 		CODE_PROBE(!self->performQuiescentChecks, "Non-quiescent consistency check");
+		state double consistenyCheckerBeginTime = now();
 
 		if (self->firstClient || self->distributed) {
 			try {
@@ -412,7 +413,9 @@ struct ConsistencyCheckWorkload : TestWorkload {
 			}
 		}
 
-		TraceEvent("ConsistencyCheck_FinishedCheck").detail("Repetitions", self->repetitions);
+		TraceEvent("ConsistencyCheck_FinishedCheck")
+		    .detail("Repetitions", self->repetitions)
+		    .detail("TimeSpan", now() - consistenyCheckerBeginTime);
 
 		return Void();
 	}


### PR DESCRIPTION
This PR adds trace events to expose performance of consistency checker. With this PR, we want to understand whether consistency check can run as fast as we expected and whether the rate limiter actually takes effects.

For collecting performance numbers to compare AuditStorage and ConsistencyChecker.

100K correctness test with 2 external timeout failures with rocksdb and sharded rocksdb
  20231023-225000-zhewang-baac37bdaf31b6ff           compressed=True data_size=35938644 duration=6460390 ended=100000 fail=2 fail_fast=10 max_runs=100000 pass=99998 priority=100 remaining=0 runtime=1:13:38 sanity=False started=100000 stopped=20231024-000338 submitted=20231023-225000 timeout=5400 username=zhewang

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
