### PR TITLE
add fdb_c_apiversion.g.h to osx package

### DIFF
--- a/packaging/osx/buildpkg.sh
+++ b/packaging/osx/buildpkg.sh
@@ -38,7 +38,7 @@ mkdir -p -m 0775 $CLIENTSDIR/usr/local/etc/foundationdb
 mkdir -p -m 0755 $CLIENTSDIR/usr/local/foundationdb/backup_agent
 
 install -m 0755 "$BUILDDIR"/bin/fdbcli $CLIENTSDIR/usr/local/bin
-install -m 0644 "$SRCDIR"/bindings/c/foundationdb/fdb_c.h "$BUILDDIR"/bindings/c/foundationdb/fdb_c_options.g.h "$SRCDIR"/bindings/c/foundationdb/fdb_c_types.h "$SRCDIR"/bindings/c/foundationdb/fdb_c_internal.h "$SRCDIR"/fdbclient/vexillographer/fdb.options $CLIENTSDIR/usr/local/include/foundationdb
+install -m 0644 "$SRCDIR"/bindings/c/foundationdb/fdb_c.h "$BUILDDIR"/bindings/c/foundationdb/fdb_c_options.g.h "$BUILDDIR"/bindings/c/foundationdb/fdb_c_apiversion.g.h "$SRCDIR"/bindings/c/foundationdb/fdb_c_types.h "$SRCDIR"/bindings/c/foundationdb/fdb_c_internal.h "$SRCDIR"/fdbclient/vexillographer/fdb.options $CLIENTSDIR/usr/local/include/foundationdb
 install -m 0755 "$BUILDDIR"/lib/libfdb_c.dylib $CLIENTSDIR/usr/local/lib
 install -m 0644 "$BUILDDIR"/bindings/python/fdb/*.py $CLIENTSDIR/Library/Python/2.7/site-packages/fdb
 install -m 0755 "$BUILDDIR"/bin/fdbbackup $CLIENTSDIR/usr/local/foundationdb/backup_agent/backup_agent


### PR DESCRIPTION
fdb_c.h depends on this header, and it is not currently included. This results in build failures as described in #11036 . This change adds this header to the osx package.

Re testing: I successfully built and installed the new package on my own osx system, and the minimal case described in the issue now builds fine. Also confirmed that `/usr/local/include/foundationdb/fdb_c_apiversion.g.h` now exists.
I can add this file to other packaging scripts as part of this PR, but I am not able to test them eg for debian linux.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.
