### PR TITLE
Add fdb_c_apiversion.g.h to osx package [release-7.3]

### DIFF
--- a/packaging/osx/buildpkg.sh
+++ b/packaging/osx/buildpkg.sh
@@ -38,7 +38,7 @@ mkdir -p -m 0775 $CLIENTSDIR/usr/local/etc/foundationdb
 mkdir -p -m 0755 $CLIENTSDIR/usr/local/foundationdb/backup_agent
 
 install -m 0755 "$BUILDDIR"/bin/fdbcli $CLIENTSDIR/usr/local/bin
-install -m 0644 "$SRCDIR"/bindings/c/foundationdb/fdb_c.h "$BUILDDIR"/bindings/c/foundationdb/fdb_c_options.g.h "$SRCDIR"/bindings/c/foundationdb/fdb_c_types.h "$SRCDIR"/bindings/c/foundationdb/fdb_c_internal.h "$SRCDIR"/fdbclient/vexillographer/fdb.options $CLIENTSDIR/usr/local/include/foundationdb
+install -m 0644 "$SRCDIR"/bindings/c/foundationdb/fdb_c.h "$BUILDDIR"/bindings/c/foundationdb/fdb_c_options.g.h "$BUILDDIR"/bindings/c/foundationdb/fdb_c_apiversion.g.h "$SRCDIR"/bindings/c/foundationdb/fdb_c_types.h "$SRCDIR"/bindings/c/foundationdb/fdb_c_internal.h "$SRCDIR"/fdbclient/vexillographer/fdb.options $CLIENTSDIR/usr/local/include/foundationdb
 install -m 0755 "$BUILDDIR"/lib/libfdb_c.dylib $CLIENTSDIR/usr/local/lib
 install -m 0644 "$BUILDDIR"/bindings/python/fdb/*.py $CLIENTSDIR/Library/Python/2.7/site-packages/fdb
 install -m 0755 "$BUILDDIR"/bin/fdbbackup $CLIENTSDIR/usr/local/foundationdb/backup_agent/backup_agent


### PR DESCRIPTION
cherrypick #11037 

fdb_c.h depends on this header, and it is not currently included. This results in build failures as described in #11036 . This change adds this header to the osx package.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
