### PR TITLE
[test only] Fix backup workers stability issues

### DIFF
--- a/fdbclient/FileBackupAgent.actor.cpp
+++ b/fdbclient/FileBackupAgent.actor.cpp
@@ -3408,6 +3408,7 @@ struct StartFullBackupTaskFunc : BackupTaskFuncBase {
 				state Future<Optional<Value>> taskStarted = tr->get(config.allWorkerStarted().key);
 				partitionedLog = config.partitionedLogEnabled().get(tr);
 				wait(success(started) && success(taskStarted) && success(partitionedLog));
+				// comment
 
 				if (!partitionedLog.get().present() || !partitionedLog.get().get()) {
 					return Void(); // Skip if not using partitioned logs


### PR DESCRIPTION
This PR includes a few stability fixes for Backup Worker

* Fixed memory bookkeeping issue in Backup Worker. Previously it didn't release flow lock correctly when erasing messages.

* Added TLogServer fix to return 0 from poppedVersion() for unrecognized log router tags.

Replace this text with your description here...

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
