### PR TITLE
Propagate data move reason from DD to SS

### DIFF
--- a/fdbcli/LocationMetadataCommand.actor.cpp
+++ b/fdbcli/LocationMetadataCommand.actor.cpp
@@ -183,7 +183,9 @@ ACTOR Future<Void> printServerShards(Database cx, UID serverId) {
 					UID shardId;
 					bool assigned, emptyRange;
 					DataMoveType dataMoveType = DataMoveType::LOGICAL;
-					decodeServerKeysValue(serverShards[i].value, assigned, emptyRange, dataMoveType, shardId);
+					DataMovementReason dataMoveReason = DataMovementReason::INVALID;
+					decodeServerKeysValue(
+					    serverShards[i].value, assigned, emptyRange, dataMoveType, shardId, dataMoveReason);
 					printf("Range: %s, ShardID: %s, Assigned: %s\n",
 					       Traceable<KeyRangeRef>::toString(currentRange).c_str(),
 					       shardId.toString().c_str(),

--- a/fdbclient/SystemData.cpp
+++ b/fdbclient/SystemData.cpp
@@ -2089,7 +2089,7 @@ TEST_CASE("noSim/SystemData/DataMoveId") {
 	const DataMoveType type =
 	    static_cast<DataMoveType>(deterministicRandom()->randomInt(0, static_cast<int>(DataMoveType::NUMBER_OF_TYPES)));
 	const DataMovementReason reason = static_cast<DataMovementReason>(
-	    deterministicRandom()->randomInt(0, static_cast<int>(DataMovementReason::NUMBER_OF_REASONS)));
+	    deterministicRandom()->randomInt(1, static_cast<int>(DataMovementReason::NUMBER_OF_REASONS)));
 	const UID dataMoveId = newDataMoveId(physicalShardId, AssignEmptyRange(false), type, reason, UnassignShard(false));
 
 	bool assigned, emptyRange;

--- a/fdbclient/SystemData.cpp
+++ b/fdbclient/SystemData.cpp
@@ -604,6 +604,13 @@ void decodeDataMoveId(const UID& id,
 	if (assigned && !emptyRange && id != anonymousShardId) {
 		dataMoveType = static_cast<DataMoveType>(0xFF & id.second());
 		dataMoveReason = static_cast<DataMovementReason>(0xFF & (id.second() >> 8));
+		ASSERT(dataMoveType < DataMoveType::NUMBER_OF_TYPES && dataMoveType >= DataMoveType::LOGICAL);
+		ASSERT(dataMoveReason < DataMovementReason::NUMBER_OF_REASONS && dataMoveReason > DataMovementReason::INVALID);
+		if (emptyRange || !assigned) {
+			ASSERT(dataMoveReason == DataMovementReason::INVALID);
+		} else {
+			ASSERT(dataMoveReason != DataMovementReason::INVALID);
+		}
 	}
 }
 
@@ -614,6 +621,7 @@ void decodeServerKeysValue(const ValueRef& value,
                            UID& id,
                            DataMovementReason& dataMoveReason) {
 	dataMoveType = DataMoveType::LOGICAL;
+	dataMoveReason = DataMovementReason::INVALID;
 	if (value.size() == 0) {
 		assigned = false;
 		emptyRange = false;
@@ -2094,7 +2102,7 @@ TEST_CASE("noSim/SystemData/DataMoveId") {
 
 	bool assigned, emptyRange;
 	DataMoveType decodeType;
-	DataMovementReason decodeReason;
+	DataMovementReason decodeReason = DataMovementReason::INVALID;
 	decodeDataMoveId(dataMoveId, assigned, emptyRange, decodeType, decodeReason);
 
 	ASSERT(type == decodeType && reason == decodeReason);

--- a/fdbclient/SystemData.cpp
+++ b/fdbclient/SystemData.cpp
@@ -519,6 +519,7 @@ const ValueRef serverKeysTrue = "1"_sr, // compatible with what was serverKeysTr
 const UID newDataMoveId(const uint64_t physicalShardId,
                         AssignEmptyRange assignEmptyRange,
                         const DataMoveType type,
+                        const DataMovementReason reason,
                         UnassignShard unassignShard) {
 	uint64_t split = 0;
 	if (assignEmptyRange) {
@@ -528,8 +529,12 @@ const UID newDataMoveId(const uint64_t physicalShardId,
 	} else {
 		do {
 			split = deterministicRandom()->randomUInt64();
-			// Set the lowest 8 bits
-			split = ((~0xFF) & split) | static_cast<uint64_t>(type);
+			// Clear the lower 16 bits
+			split = (~0xFFFF) & split;
+			// Set DataMoveType to the lower [0, 8) bits
+			split = split | static_cast<uint64_t>(type);
+			// Set DataMovementReason to the lower [8, 16) bits
+			split = split | (static_cast<uint64_t>(reason) << 8);
 		} while (split == anonymousShardId.second() || split == 0 || split == emptyShardId);
 	}
 	return UID(physicalShardId, split);
@@ -572,7 +577,8 @@ bool serverHasKey(ValueRef storedValue) {
 	UID shardId;
 	bool assigned, emptyRange;
 	DataMoveType dataMoveType = DataMoveType::LOGICAL;
-	decodeServerKeysValue(storedValue, assigned, emptyRange, dataMoveType, shardId);
+	DataMovementReason dataMoveReason = DataMovementReason::INVALID;
+	decodeServerKeysValue(storedValue, assigned, emptyRange, dataMoveType, shardId, dataMoveReason);
 	return assigned;
 }
 
@@ -586,12 +592,18 @@ const Value serverKeysValue(const UID& id) {
 	return wr.toValue();
 }
 
-void decodeDataMoveId(const UID& id, bool& assigned, bool& emptyRange, DataMoveType& dataMoveType) {
+void decodeDataMoveId(const UID& id,
+                      bool& assigned,
+                      bool& emptyRange,
+                      DataMoveType& dataMoveType,
+                      DataMovementReason& dataMoveReason) {
 	dataMoveType = DataMoveType::LOGICAL;
+	dataMoveReason = DataMovementReason::INVALID;
 	assigned = id.second() != 0LL;
 	emptyRange = id.second() == emptyShardId;
 	if (assigned && !emptyRange && id != anonymousShardId) {
 		dataMoveType = static_cast<DataMoveType>(0xFF & id.second());
+		dataMoveReason = static_cast<DataMovementReason>(0xFF & (id.second() >> 8));
 	}
 }
 
@@ -599,7 +611,8 @@ void decodeServerKeysValue(const ValueRef& value,
                            bool& assigned,
                            bool& emptyRange,
                            DataMoveType& dataMoveType,
-                           UID& id) {
+                           UID& id,
+                           DataMovementReason& dataMoveReason) {
 	dataMoveType = DataMoveType::LOGICAL;
 	if (value.size() == 0) {
 		assigned = false;
@@ -621,7 +634,7 @@ void decodeServerKeysValue(const ValueRef& value,
 		BinaryReader rd(value, IncludeVersion());
 		ASSERT(rd.protocolVersion().hasShardEncodeLocationMetaData());
 		rd >> id;
-		decodeDataMoveId(id, assigned, emptyRange, dataMoveType);
+		decodeDataMoveId(id, assigned, emptyRange, dataMoveType, dataMoveReason);
 	}
 }
 
@@ -2075,13 +2088,16 @@ TEST_CASE("noSim/SystemData/DataMoveId") {
 	const uint64_t physicalShardId = deterministicRandom()->randomUInt64();
 	const DataMoveType type =
 	    static_cast<DataMoveType>(deterministicRandom()->randomInt(0, static_cast<int>(DataMoveType::NUMBER_OF_TYPES)));
-	const UID dataMoveId = newDataMoveId(physicalShardId, AssignEmptyRange(false), type, UnassignShard(false));
+	const DataMovementReason reason = static_cast<DataMovementReason>(
+	    deterministicRandom()->randomInt(0, static_cast<int>(DataMovementReason::NUMBER_OF_REASONS)));
+	const UID dataMoveId = newDataMoveId(physicalShardId, AssignEmptyRange(false), type, reason, UnassignShard(false));
 
 	bool assigned, emptyRange;
 	DataMoveType decodeType;
-	decodeDataMoveId(dataMoveId, assigned, emptyRange, decodeType);
+	DataMovementReason decodeReason;
+	decodeDataMoveId(dataMoveId, assigned, emptyRange, decodeType, decodeReason);
 
-	ASSERT(type == decodeType);
+	ASSERT(type == decodeType && reason == decodeReason);
 
 	printf("testing data move ID encoding/decoding complete\n");
 

--- a/fdbclient/include/fdbclient/SystemData.h
+++ b/fdbclient/include/fdbclient/SystemData.h
@@ -44,6 +44,30 @@ enum class DataMoveType : uint8_t {
 	NUMBER_OF_TYPES = 3,
 };
 
+// One-to-one relationship to the priority knobs
+enum class DataMovementReason : uint8_t {
+	INVALID = 0,
+	RECOVER_MOVE = 1,
+	REBALANCE_UNDERUTILIZED_TEAM = 2,
+	REBALANCE_OVERUTILIZED_TEAM = 3,
+	REBALANCE_READ_OVERUTIL_TEAM = 4,
+	REBALANCE_READ_UNDERUTIL_TEAM = 5,
+	PERPETUAL_STORAGE_WIGGLE = 6,
+	TEAM_HEALTHY = 7,
+	TEAM_CONTAINS_UNDESIRED_SERVER = 8,
+	TEAM_REDUNDANT = 9,
+	MERGE_SHARD = 10,
+	POPULATE_REGION = 11,
+	TEAM_UNHEALTHY = 12,
+	TEAM_2_LEFT = 13,
+	TEAM_1_LEFT = 14,
+	TEAM_FAILED = 15,
+	TEAM_0_LEFT = 16,
+	SPLIT_SHARD = 17,
+	ENFORCE_MOVE_OUT_OF_PHYSICAL_SHARD = 18,
+	NUMBER_OF_REASONS = 19,
+};
+
 // SystemKey is just a Key but with a special type so that instances of it can be found easily throughput the code base
 // and in simulation constructions will verify that no SystemKey is a direct prefix of any other.
 struct SystemKey : Key {
@@ -171,6 +195,7 @@ extern const ValueRef serverKeysTrue, serverKeysTrueEmptyRange, serverKeysFalse;
 const UID newDataMoveId(const uint64_t physicalShardId,
                         AssignEmptyRange assignEmptyRange,
                         const DataMoveType type,
+                        const DataMovementReason reason = DataMovementReason::INVALID,
                         UnassignShard unassignShard = UnassignShard::False);
 const Key serverKeysKey(UID serverID, const KeyRef& keys);
 const Key serverKeysPrefixFor(UID serverID);
@@ -178,12 +203,17 @@ UID serverKeysDecodeServer(const KeyRef& key);
 std::pair<UID, Key> serverKeysDecodeServerBegin(const KeyRef& key);
 bool serverHasKey(ValueRef storedValue);
 const Value serverKeysValue(const UID& id);
-void decodeDataMoveId(const UID& id, bool& assigned, bool& emptyRange, DataMoveType& dataMoveType);
+void decodeDataMoveId(const UID& id,
+                      bool& assigned,
+                      bool& emptyRange,
+                      DataMoveType& dataMoveType,
+                      DataMovementReason& dataMoveReason);
 void decodeServerKeysValue(const ValueRef& value,
                            bool& assigned,
                            bool& emptyRange,
                            DataMoveType& dataMoveType,
-                           UID& id);
+                           UID& id,
+                           DataMovementReason& dataMoveReason);
 
 extern const KeyRangeRef conflictingKeysRange;
 extern const ValueRef conflictingKeysTrue, conflictingKeysFalse;

--- a/fdbclient/include/fdbclient/SystemData.h
+++ b/fdbclient/include/fdbclient/SystemData.h
@@ -65,7 +65,8 @@ enum class DataMovementReason : uint8_t {
 	TEAM_0_LEFT = 16,
 	SPLIT_SHARD = 17,
 	ENFORCE_MOVE_OUT_OF_PHYSICAL_SHARD = 18,
-	NUMBER_OF_REASONS = 19,
+	ASSIGN_EMPTY_RANGE = 19, // no corresponding data move priority
+	NUMBER_OF_REASONS = 20,
 };
 
 // SystemKey is just a Key but with a special type so that instances of it can be found easily throughput the code base
@@ -195,7 +196,7 @@ extern const ValueRef serverKeysTrue, serverKeysTrueEmptyRange, serverKeysFalse;
 const UID newDataMoveId(const uint64_t physicalShardId,
                         AssignEmptyRange assignEmptyRange,
                         const DataMoveType type,
-                        const DataMovementReason reason = DataMovementReason::INVALID,
+                        const DataMovementReason reason,
                         UnassignShard unassignShard = UnassignShard::False);
 const Key serverKeysKey(UID serverID, const KeyRef& keys);
 const Key serverKeysPrefixFor(UID serverID);

--- a/fdbclient/include/fdbclient/SystemData.h
+++ b/fdbclient/include/fdbclient/SystemData.h
@@ -65,8 +65,9 @@ enum class DataMovementReason : uint8_t {
 	TEAM_0_LEFT = 16,
 	SPLIT_SHARD = 17,
 	ENFORCE_MOVE_OUT_OF_PHYSICAL_SHARD = 18,
-	ASSIGN_EMPTY_RANGE = 19, // no corresponding data move priority
-	NUMBER_OF_REASONS = 20,
+	ASSIGN_EMPTY_RANGE = 19, // dummy reason, no corresponding data move priority
+	SEED_SHARD_SERVER = 20, // dummy reason, no corresponding data move priority
+	NUMBER_OF_REASONS = 21, // dummy reason, no corresponding data move priority
 };
 
 // SystemKey is just a Key but with a special type so that instances of it can be found easily throughput the code base

--- a/fdbserver/DDRelocationQueue.actor.cpp
+++ b/fdbserver/DDRelocationQueue.actor.cpp
@@ -94,7 +94,10 @@ std::pair<const DmReasonPriorityMapping*, const PriorityDmReasonMapping*> buildP
 		{ DataMovementReason::TEAM_0_LEFT, SERVER_KNOBS->PRIORITY_TEAM_0_LEFT },
 		{ DataMovementReason::SPLIT_SHARD, SERVER_KNOBS->PRIORITY_SPLIT_SHARD },
 		{ DataMovementReason::ENFORCE_MOVE_OUT_OF_PHYSICAL_SHARD,
-		  SERVER_KNOBS->PRIORITY_ENFORCE_MOVE_OUT_OF_PHYSICAL_SHARD }
+		  SERVER_KNOBS->PRIORITY_ENFORCE_MOVE_OUT_OF_PHYSICAL_SHARD },
+		{ DataMovementReason::ASSIGN_EMPTY_RANGE, -2 }, // dummy reason, no corresponding actual data move
+		{ DataMovementReason::SEED_SHARD_SERVER, -3 }, // dummy reason, no corresponding actual data move
+		{ DataMovementReason::NUMBER_OF_REASONS, -4 }, // dummy reason, no corresponding actual data move
 	};
 
 	static PriorityDmReasonMapping priorityReason;
@@ -120,6 +123,7 @@ DataMoveType getDataMoveType(const UID& dataMoveId) {
 	return dataMoveType;
 }
 
+// Return negative priority for invalid or dummy reasons
 int dataMovementPriority(DataMovementReason reason) {
 	auto [reasonPriority, _] = buildPriorityMappings();
 	return reasonPriority->at(reason);
@@ -2274,6 +2278,7 @@ ACTOR Future<Void> BgDDLoadRebalance(DDQueue* self, int teamCollectionIndex, Dat
 	state const bool readRebalance = isDataMovementForReadBalancing(reason);
 	state const char* eventName = isDataMovementForMountainChopper(reason) ? "BgDDMountainChopper" : "BgDDValleyFiller";
 	state int ddPriority = dataMovementPriority(reason);
+	ASSERT(ddPriority > 0);
 	state double rebalancePollingInterval = 0;
 
 	loop {

--- a/fdbserver/DDRelocationQueue.actor.cpp
+++ b/fdbserver/DDRelocationQueue.actor.cpp
@@ -115,7 +115,8 @@ std::pair<const DmReasonPriorityMapping*, const PriorityDmReasonMapping*> buildP
 DataMoveType getDataMoveType(const UID& dataMoveId) {
 	bool assigned, emptyRange;
 	DataMoveType dataMoveType;
-	decodeDataMoveId(dataMoveId, assigned, emptyRange, dataMoveType);
+	DataMovementReason dataMoveReason;
+	decodeDataMoveId(dataMoveId, assigned, emptyRange, dataMoveType, dataMoveReason);
 	return dataMoveType;
 }
 
@@ -1088,8 +1089,10 @@ void DDQueue::launchQueuedWork(std::set<RelocateData, std::greater<RelocateData>
 					if (SERVER_KNOBS->ENABLE_DD_PHYSICAL_SHARD) {
 						rrs.dataMoveId = UID();
 					} else {
-						rrs.dataMoveId = newDataMoveId(
-						    deterministicRandom()->randomUInt64(), AssignEmptyRange::False, newDataMoveType());
+						rrs.dataMoveId = newDataMoveId(deterministicRandom()->randomUInt64(),
+						                               AssignEmptyRange::False,
+						                               newDataMoveType(),
+						                               rrs.dmReason);
 						TraceEvent(SevInfo, "NewDataMoveWithRandomDestID")
 						    .detail("DataMoveID", rrs.dataMoveId.toString())
 						    .detail("Range", rrs.keys)
@@ -1674,7 +1677,8 @@ ACTOR Future<Void> dataDistributionRelocator(DDQueue* self,
 					} else {
 						self->moveCreateNewPhysicalShard++;
 					}
-					rd.dataMoveId = newDataMoveId(physicalShardIDCandidate, AssignEmptyRange::False, newDataMoveType());
+					rd.dataMoveId = newDataMoveId(
+					    physicalShardIDCandidate, AssignEmptyRange::False, newDataMoveType(), rd.dmReason);
 					TraceEvent(SevInfo, "NewDataMoveWithPhysicalShard")
 					    .detail("DataMoveID", rd.dataMoveId.toString())
 					    .detail("Reason", rd.reason.toString())

--- a/fdbserver/DDRelocationQueue.actor.cpp
+++ b/fdbserver/DDRelocationQueue.actor.cpp
@@ -2278,7 +2278,6 @@ ACTOR Future<Void> BgDDLoadRebalance(DDQueue* self, int teamCollectionIndex, Dat
 	state const bool readRebalance = isDataMovementForReadBalancing(reason);
 	state const char* eventName = isDataMovementForMountainChopper(reason) ? "BgDDMountainChopper" : "BgDDValleyFiller";
 	state int ddPriority = dataMovementPriority(reason);
-	ASSERT(ddPriority > 0);
 	state double rebalancePollingInterval = 0;
 
 	loop {

--- a/fdbserver/MoveKeys.actor.cpp
+++ b/fdbserver/MoveKeys.actor.cpp
@@ -3288,7 +3288,11 @@ void seedShardServers(Arena& arena, CommitTransactionRef& tr, std::vector<Storag
 	// to a specific
 	//   key (keyServersKeyServersKey)
 	if (SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA) {
-		const UID shardId = deterministicRandom()->randomUniqueID();
+		const UID shardId = newDataMoveId(deterministicRandom()->randomUInt64(),
+		                                  AssignEmptyRange(false),
+		                                  DataMoveType::PHYSICAL,
+		                                  DataMovementReason::SEED_SHARD_SERVER,
+		                                  UnassignShard(false));
 		ksValue = keyServersValue(serverSrcUID, /*dest=*/std::vector<UID>(), shardId, UID());
 		krmSetPreviouslyEmptyRange(tr, arena, keyServersPrefix, KeyRangeRef(KeyRef(), allKeys.end), ksValue, Value());
 

--- a/fdbserver/MoveKeys.actor.cpp
+++ b/fdbserver/MoveKeys.actor.cpp
@@ -2767,9 +2767,10 @@ ACTOR Future<Void> removeKeysFromFailedServer(Database cx,
 							}
 						}
 
-						const UID shardId = newDataMoveId(
-						    deterministicRandom()->randomUInt64(), AssignEmptyRange::True, DataMoveType::LOGICAL);
-						// no data move is triggered, so, we do not encode dmReason into shardId
+						const UID shardId = newDataMoveId(deterministicRandom()->randomUInt64(),
+						                                  AssignEmptyRange::True,
+						                                  DataMoveType::LOGICAL,
+						                                  DataMovementReason::ASSIGN_EMPTY_RANGE);
 
 						// Assign the shard to teamForDroppedRange in keyServer space.
 						if (SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA) {

--- a/fdbserver/include/fdbserver/DataDistribution.actor.h
+++ b/fdbserver/include/fdbserver/DataDistribution.actor.h
@@ -91,28 +91,6 @@ private:
 	Value value;
 };
 
-// One-to-one relationship to the priority knobs
-enum class DataMovementReason {
-	INVALID,
-	RECOVER_MOVE,
-	REBALANCE_UNDERUTILIZED_TEAM,
-	REBALANCE_OVERUTILIZED_TEAM,
-	REBALANCE_READ_OVERUTIL_TEAM,
-	REBALANCE_READ_UNDERUTIL_TEAM,
-	PERPETUAL_STORAGE_WIGGLE,
-	TEAM_HEALTHY,
-	TEAM_CONTAINS_UNDESIRED_SERVER,
-	TEAM_REDUNDANT,
-	MERGE_SHARD,
-	POPULATE_REGION,
-	TEAM_UNHEALTHY,
-	TEAM_2_LEFT,
-	TEAM_1_LEFT,
-	TEAM_FAILED,
-	TEAM_0_LEFT,
-	SPLIT_SHARD,
-	ENFORCE_MOVE_OUT_OF_PHYSICAL_SHARD
-};
 extern int dataMovementPriority(DataMovementReason moveReason);
 extern DataMovementReason priorityToDataMovementReason(int priority);
 

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -10510,13 +10510,15 @@ private:
 					// fetch the data for change.version-1 (changes from versions < change.version) If emptyRange,
 					// treat the shard as empty, see removeKeysFromFailedServer() for more details about this
 					// scenario.
+					ASSERT(dataMoveReason != DataMovementReason::NUMBER_OF_REASONS);
 					if (dataMoveId != anonymousShardId && dataMoveId.isValid()) {
-						ASSERT(dataMoveReason != DataMovementReason::NUMBER_OF_REASONS);
 						if (nowAssigned && !emptyRange) {
 							ASSERT(dataMoveReason != DataMovementReason::INVALID);
 						} else {
 							ASSERT(dataMoveReason == DataMovementReason::INVALID);
 						}
+					} else {
+						ASSERT(dataMoveReason == DataMovementReason::INVALID);
 					}
 					changeServerKeys(data, keys, nowAssigned, currentVersion - 1, context, dataMoveReason);
 				}

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -9902,7 +9902,6 @@ void changeServerKeys(StorageServer* data,
                       ChangeServerKeysContext context,
                       DataMovementReason dataMoveReason) {
 	ASSERT(!keys.empty());
-
 	// TraceEvent("ChangeServerKeys", data->thisServerID)
 	//     .detail("KeyBegin", keys.begin)
 	//     .detail("KeyEnd", keys.end)
@@ -10511,6 +10510,14 @@ private:
 					// fetch the data for change.version-1 (changes from versions < change.version) If emptyRange,
 					// treat the shard as empty, see removeKeysFromFailedServer() for more details about this
 					// scenario.
+					if (dataMoveId != anonymousShardId && dataMoveId.isValid()) {
+						ASSERT(dataMoveReason != DataMovementReason::NUMBER_OF_REASONS);
+						if (nowAssigned && !emptyRange) {
+							ASSERT(dataMoveReason != DataMovementReason::INVALID);
+						} else {
+							ASSERT(dataMoveReason == DataMovementReason::INVALID);
+						}
+					}
 					changeServerKeys(data, keys, nowAssigned, currentVersion - 1, context, dataMoveReason);
 				}
 			}

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -10510,16 +10510,6 @@ private:
 					// fetch the data for change.version-1 (changes from versions < change.version) If emptyRange,
 					// treat the shard as empty, see removeKeysFromFailedServer() for more details about this
 					// scenario.
-					ASSERT(dataMoveReason != DataMovementReason::NUMBER_OF_REASONS);
-					if (dataMoveId != anonymousShardId && dataMoveId.isValid()) {
-						if (nowAssigned && !emptyRange) {
-							ASSERT(dataMoveReason != DataMovementReason::INVALID);
-						} else {
-							ASSERT(dataMoveReason == DataMovementReason::INVALID);
-						}
-					} else {
-						ASSERT(dataMoveReason == DataMovementReason::INVALID);
-					}
 					changeServerKeys(data, keys, nowAssigned, currentVersion - 1, context, dataMoveReason);
 				}
 			}

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -9899,7 +9899,8 @@ void changeServerKeys(StorageServer* data,
                       const KeyRangeRef& keys,
                       bool nowAssigned,
                       Version version,
-                      ChangeServerKeysContext context) {
+                      ChangeServerKeysContext context,
+                      DataMovementReason dataMoveReason) {
 	ASSERT(!keys.empty());
 
 	// TraceEvent("ChangeServerKeys", data->thisServerID)
@@ -10474,6 +10475,7 @@ private:
 	bool nowAssigned;
 	bool emptyRange;
 	EnablePhysicalShardMove enablePSM = EnablePhysicalShardMove::False;
+	DataMovementReason dataMoveReason = DataMovementReason::INVALID;
 	UID dataMoveId;
 	bool processedStartKey;
 
@@ -10509,7 +10511,7 @@ private:
 					// fetch the data for change.version-1 (changes from versions < change.version) If emptyRange,
 					// treat the shard as empty, see removeKeysFromFailedServer() for more details about this
 					// scenario.
-					changeServerKeys(data, keys, nowAssigned, currentVersion - 1, context);
+					changeServerKeys(data, keys, nowAssigned, currentVersion - 1, context, dataMoveReason);
 				}
 			}
 
@@ -10520,7 +10522,8 @@ private:
 			// keys
 			startKey = m.param1;
 			DataMoveType dataMoveType = DataMoveType::LOGICAL;
-			decodeServerKeysValue(m.param2, nowAssigned, emptyRange, dataMoveType, dataMoveId);
+			dataMoveReason = DataMovementReason::INVALID;
+			decodeServerKeysValue(m.param2, nowAssigned, emptyRange, dataMoveType, dataMoveId, dataMoveReason);
 			enablePSM = EnablePhysicalShardMove(dataMoveType == DataMoveType::PHYSICAL ||
 			                                    (dataMoveType == DataMoveType::PHYSICAL_EXP && data->isTss()));
 			processedStartKey = true;
@@ -12658,7 +12661,7 @@ ACTOR Future<bool> restoreDurableState(StorageServer* data, IKeyValueStore* stor
 			bool nowAssigned = assigned[assignedLoc].value != "0"_sr;
 			/*if(nowAssigned)
 			TraceEvent("AssignedShard", data->thisServerID).detail("RangeBegin", keys.begin).detail("RangeEnd", keys.end);*/
-			changeServerKeys(data, keys, nowAssigned, version, CSK_RESTORE);
+			changeServerKeys(data, keys, nowAssigned, version, CSK_RESTORE, DataMovementReason::INVALID);
 
 			if (!nowAssigned)
 				ASSERT(data->newestAvailableVersion.allEqual(keys, invalidVersion));

--- a/fdbserver/workloads/DataLossRecovery.actor.cpp
+++ b/fdbserver/workloads/DataLossRecovery.actor.cpp
@@ -234,7 +234,12 @@ struct DataLossRecoveryWorkload : TestWorkload {
 				TraceEvent("DataLossRecovery").detail("Phase", "StartMoveKeys");
 				std::unique_ptr<MoveKeysParams> params;
 				if (SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA) {
-					params = std::make_unique<MoveKeysParams>(deterministicRandom()->randomUniqueID(),
+					UID dataMoveId = newDataMoveId(deterministicRandom()->randomUInt64(),
+					                               AssignEmptyRange(false),
+					                               DataMoveType::PHYSICAL,
+					                               DataMovementReason::TEAM_HEALTHY,
+					                               UnassignShard(false));
+					params = std::make_unique<MoveKeysParams>(dataMoveId,
 					                                          std::vector<KeyRange>{ keys },
 					                                          dest,
 					                                          dest,
@@ -247,7 +252,12 @@ struct DataLossRecoveryWorkload : TestWorkload {
 					                                          &ddEnabledState,
 					                                          CancelConflictingDataMoves::True);
 				} else {
-					params = std::make_unique<MoveKeysParams>(deterministicRandom()->randomUniqueID(),
+					UID dataMoveId = newDataMoveId(deterministicRandom()->randomUInt64(),
+					                               AssignEmptyRange(false),
+					                               DataMoveType::LOGICAL,
+					                               DataMovementReason::TEAM_HEALTHY,
+					                               UnassignShard(false));
+					params = std::make_unique<MoveKeysParams>(dataMoveId,
 					                                          keys,
 					                                          dest,
 					                                          dest,

--- a/fdbserver/workloads/PhysicalShardMove.actor.cpp
+++ b/fdbserver/workloads/PhysicalShardMove.actor.cpp
@@ -95,17 +95,20 @@ struct PhysicalShardMoveWorkLoad : TestWorkload {
 		state std::unordered_set<UID> excludes;
 		state std::unordered_set<UID> includes;
 		state int teamSize = 1;
+		state DataMovementReason dataMoveReason = static_cast<DataMovementReason>(
+		    deterministicRandom()->randomInt(1, static_cast<int>(DataMovementReason::NUMBER_OF_REASONS)));
 		state KeyRangeRef currentRange = KeyRangeRef("TestKeyA"_sr, "TestKeyF"_sr);
-		wait(store(
-		    teamA,
-		    self->moveShard(
-		        self,
-		        cx,
-		        newDataMoveId(deterministicRandom()->randomUInt64(), AssignEmptyRange::False, DataMoveType::PHYSICAL),
-		        currentRange,
-		        teamSize,
-		        includes,
-		        excludes)));
+		wait(store(teamA,
+		           self->moveShard(self,
+		                           cx,
+		                           newDataMoveId(deterministicRandom()->randomUInt64(),
+		                                         AssignEmptyRange::False,
+		                                         DataMoveType::PHYSICAL,
+		                                         dataMoveReason),
+		                           currentRange,
+		                           teamSize,
+		                           includes,
+		                           excludes)));
 		TraceEvent(SevDebug, "TestMovedRange1").detail("Range", currentRange).detail("Team", describe(teamA));
 
 		excludes.insert(teamA.begin(), teamA.end());
@@ -119,7 +122,7 @@ struct PhysicalShardMoveWorkLoad : TestWorkload {
 		wait(store(teamA,
 		           self->moveShard(self,
 		                           cx,
-		                           newDataMoveId(sh0, AssignEmptyRange::False, DataMoveType::PHYSICAL),
+		                           newDataMoveId(sh0, AssignEmptyRange::False, DataMoveType::PHYSICAL, dataMoveReason),
 		                           currentRange,
 		                           teamSize,
 		                           includes,

--- a/fdbserver/workloads/RandomMoveKeys.actor.cpp
+++ b/fdbserver/workloads/RandomMoveKeys.actor.cpp
@@ -158,7 +158,12 @@ struct MoveKeysWorkload : FailureInjectionWorkload {
 			state DDEnabledState ddEnabledState;
 			std::unique_ptr<MoveKeysParams> params;
 			if (SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA) {
-				params = std::make_unique<MoveKeysParams>(deterministicRandom()->randomUniqueID(),
+				UID dataMoveId = newDataMoveId(deterministicRandom()->randomUInt64(),
+				                               AssignEmptyRange(false),
+				                               DataMoveType::PHYSICAL,
+				                               DataMovementReason::TEAM_HEALTHY,
+				                               UnassignShard(false));
+				params = std::make_unique<MoveKeysParams>(dataMoveId,
 				                                          std::vector<KeyRange>{ keys },
 				                                          destinationTeamIDs,
 				                                          destinationTeamIDs,
@@ -171,7 +176,12 @@ struct MoveKeysWorkload : FailureInjectionWorkload {
 				                                          &ddEnabledState,
 				                                          CancelConflictingDataMoves::True);
 			} else {
-				params = std::make_unique<MoveKeysParams>(deterministicRandom()->randomUniqueID(),
+				UID dataMoveId = newDataMoveId(deterministicRandom()->randomUInt64(),
+				                               AssignEmptyRange(false),
+				                               DataMoveType::LOGICAL,
+				                               DataMovementReason::TEAM_HEALTHY,
+				                               UnassignShard(false));
+				params = std::make_unique<MoveKeysParams>(dataMoveId,
 				                                          keys,
 				                                          destinationTeamIDs,
 				                                          destinationTeamIDs,

--- a/fdbserver/workloads/StorageServerCheckpointRestoreTest.actor.cpp
+++ b/fdbserver/workloads/StorageServerCheckpointRestoreTest.actor.cpp
@@ -86,7 +86,11 @@ struct SSCheckpointRestoreWorkload : TestWorkload {
 		// Create checkpoint.
 		state Transaction tr(cx);
 		state CheckpointFormat format = DataMoveRocksCF;
-		state UID dataMoveId = deterministicRandom()->randomUniqueID();
+		state UID dataMoveId = newDataMoveId(deterministicRandom()->randomUInt64(),
+		                                     AssignEmptyRange(false),
+		                                     DataMoveType::PHYSICAL,
+		                                     DataMovementReason::TEAM_HEALTHY,
+		                                     UnassignShard(false));
 		loop {
 			try {
 				tr.setOption(FDBTransactionOptions::LOCK_AWARE);


### PR DESCRIPTION
This PR propagates data move reason from DD to SS by encoding data move reason to data move id.
The PR originates from PR https://github.com/apple/foundationdb/pull/10977 while following the datamoveId creation framework established by PR https://github.com/apple/foundationdb/pull/11057.
The PR is used for throttling fetch key: PR https://github.com/apple/foundationdb/pull/11060.

More:
Added validation of data move id decode.
Found and fixed a bug of shard id assignment when seedShardServers.

Tested by unit test for the correctness of encoding and decoding data move id:
`../build_output/packages/bin/fdbserver -r unittests -f noSim/SystemData/DataMoveId`

Tested by correctness test with 2 irrelevant failures:
  20231115-183721-zhewang-0a153d8925b6bb02           compressed=True data_size=36110906 duration=6669316 ended=100000 fail=2 fail_fast=10 max_runs=100000 pass=99998 priority=100 remaining=0 runtime=1:21:01 sanity=False started=100000 stopped=20231115-195822 submitted=20231115-183721 timeout=5400 username=zhewang

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
