### PR TITLE
Clear blobcipher test failures when enabling mutation tracking

### DIFF
--- a/fdbclient/BlobCipher.cpp
+++ b/fdbclient/BlobCipher.cpp
@@ -2241,7 +2241,10 @@ void testNoAuthMode(const int minDomainId) {
 	Reference<EncryptBuf> encrypted = encryptor.encrypt(&orgData[0], bufLen, &header, arena);
 
 	ASSERT_EQ(encrypted->getLogicalSize(), bufLen);
-	ASSERT_NE(memcmp(&orgData[0], encrypted->begin(), bufLen), 0);
+	if (ENABLE_MUTATION_TRACKING_WITH_BLOB_CIPHER)
+		ASSERT_EQ(memcmp(&orgData[0], encrypted->begin(), bufLen), 0);
+	else
+		ASSERT_NE(memcmp(&orgData[0], encrypted->begin(), bufLen), 0);
 	ASSERT_EQ(header.flags.headerVersion, EncryptBlobCipherAes265Ctr::ENCRYPT_HEADER_VERSION);
 	ASSERT_EQ(header.flags.encryptMode, EncryptCipherMode::ENCRYPT_CIPHER_MODE_AES_256_CTR);
 	ASSERT_EQ(header.flags.authTokenMode, EncryptAuthTokenMode::ENCRYPT_HEADER_AUTH_TOKEN_MODE_NONE);
@@ -2601,7 +2604,10 @@ void testSingleAuthMode(const int minDomainId) {
 	Reference<EncryptBuf> encrypted = encryptor.encrypt(&orgData[0], bufLen, &header, arena);
 
 	ASSERT_EQ(encrypted->getLogicalSize(), bufLen);
-	ASSERT_NE(memcmp(&orgData[0], encrypted->begin(), bufLen), 0);
+	if (ENABLE_MUTATION_TRACKING_WITH_BLOB_CIPHER)
+		ASSERT_EQ(memcmp(&orgData[0], encrypted->begin(), bufLen), 0);
+	else
+		ASSERT_NE(memcmp(&orgData[0], encrypted->begin(), bufLen), 0);
 	ASSERT_EQ(header.flags.headerVersion, EncryptBlobCipherAes265Ctr::ENCRYPT_HEADER_VERSION);
 	ASSERT_EQ(header.flags.encryptMode, ENCRYPT_CIPHER_MODE_AES_256_CTR);
 	ASSERT_EQ(header.flags.authTokenMode, EncryptAuthTokenMode::ENCRYPT_HEADER_AUTH_TOKEN_MODE_SINGLE);
@@ -2823,7 +2829,10 @@ void testConfigurableEncryptionSingleAuthMode(const int minDomainId) {
 	StringRef encryptedBuf = encryptor.encrypt(&orgData[0], bufLen, &headerRef, arena);
 
 	ASSERT_EQ(encryptedBuf.size(), bufLen);
-	ASSERT_NE(memcmp(&orgData[0], encryptedBuf.begin(), bufLen), 0);
+	if (ENABLE_MUTATION_TRACKING_WITH_BLOB_CIPHER)
+		ASSERT_EQ(memcmp(&orgData[0], encryptedBuf.begin(), bufLen), 0);
+	else
+		ASSERT_NE(memcmp(&orgData[0], encryptedBuf.begin(), bufLen), 0);
 	ASSERT_EQ(headerRef.flagsVersion(), CLIENT_KNOBS->ENCRYPT_HEADER_FLAGS_VERSION);
 	ASSERT_EQ(headerRef.algoHeaderVersion(), algoHeaderVersion);
 
@@ -2836,7 +2845,10 @@ void testConfigurableEncryptionSingleAuthMode(const int minDomainId) {
 	// validate IV
 	AesCtrWithAuth<Params> withAuth = std::get<AesCtrWithAuth<Params>>(headerRef.algoHeader);
 	ASSERT_EQ(memcmp(&iv[0], &withAuth.v1.iv[0], AES_256_IV_LENGTH), 0);
-	ASSERT_NE(memcmp(&orgData[0], encryptedBuf.begin(), bufLen), 0);
+	if (ENABLE_MUTATION_TRACKING_WITH_BLOB_CIPHER)
+		ASSERT_EQ(memcmp(&orgData[0], encryptedBuf.begin(), bufLen), 0);
+	else
+		ASSERT_NE(memcmp(&orgData[0], encryptedBuf.begin(), bufLen), 0);
 	// validate cipherKey details
 	ASSERT_EQ(withAuth.v1.cipherTextDetails.encryptDomainId, cipherKey->getDomainId());
 	ASSERT_EQ(withAuth.v1.cipherTextDetails.baseCipherId, cipherKey->getBaseCipherId());
@@ -3087,7 +3099,10 @@ void testConfigurableEncryptionInvalidEncryptionKeyNoAuth(const int minDomainId)
 	try {
 		StringRef decryptedBuf = decryptor.decrypt(encryptedBuf.begin(), encryptedBuf.size(), headerRef, arena);
 		ASSERT_EQ(decryptedBuf.size(), bufLen);
-		ASSERT_NE(memcmp(decryptedBuf.begin(), &orgData[0], bufLen), 0);
+		if (ENABLE_MUTATION_TRACKING_WITH_BLOB_CIPHER)
+			ASSERT_EQ(memcmp(decryptedBuf.begin(), &orgData[0], bufLen), 0);
+		else
+			ASSERT_NE(memcmp(decryptedBuf.begin(), &orgData[0], bufLen), 0);
 	} catch (Error& e) {
 		// underlying layer 'may' throw exception
 		TraceEvent("InvalidEncryptKeyError").error(e);
@@ -3130,7 +3145,10 @@ void testConfigurableEncryptionInvalidEncryptKeySingleAuthMode(const int minDoma
 	StringRef encryptedBuf = encryptor.encrypt(&orgData[0], bufLen, &headerRef, arena);
 
 	ASSERT_EQ(encryptedBuf.size(), bufLen);
-	ASSERT_NE(memcmp(&orgData[0], encryptedBuf.begin(), bufLen), 0);
+	if (ENABLE_MUTATION_TRACKING_WITH_BLOB_CIPHER)
+		ASSERT_EQ(memcmp(&orgData[0], encryptedBuf.begin(), bufLen), 0);
+	else
+		ASSERT_NE(memcmp(&orgData[0], encryptedBuf.begin(), bufLen), 0);
 	ASSERT_EQ(headerRef.flagsVersion(), CLIENT_KNOBS->ENCRYPT_HEADER_FLAGS_VERSION);
 	ASSERT_EQ(headerRef.algoHeaderVersion(), algoHeaderVersion);
 
@@ -3143,7 +3161,10 @@ void testConfigurableEncryptionInvalidEncryptKeySingleAuthMode(const int minDoma
 	// validate IV
 	AesCtrWithAuth<Params> withAuth = std::get<AesCtrWithAuth<Params>>(headerRef.algoHeader);
 	ASSERT_EQ(memcmp(&iv[0], &withAuth.v1.iv[0], AES_256_IV_LENGTH), 0);
-	ASSERT_NE(memcmp(&orgData[0], encryptedBuf.begin(), bufLen), 0);
+	if (ENABLE_MUTATION_TRACKING_WITH_BLOB_CIPHER)
+		ASSERT_EQ(memcmp(&orgData[0], encryptedBuf.begin(), bufLen), 0);
+	else
+		ASSERT_NE(memcmp(&orgData[0], encryptedBuf.begin(), bufLen), 0);
 	// validate cipherKey details
 	ASSERT_EQ(withAuth.v1.cipherTextDetails.encryptDomainId, cipherKey->getDomainId());
 	ASSERT_EQ(withAuth.v1.cipherTextDetails.baseCipherId, cipherKey->getBaseCipherId());


### PR DESCRIPTION
https://github.com/apple/foundationdb/pull/11068 triggers some test failures when ENABLE_MUTATION_TRACKING_WITH_BLOB_CIPHER is on.
This PR clear those failures.

100K test with feature on:
  20231116-233700-zhewang-c407a066b6c12931           compressed=True data_size=36157330 fail_fast=10 max_runs=100000 priority=100 remaining=not_started runtime=0:00:27 sanity=False submitted=20231116-233700 timeout=5400 username=zhewang

100K test with feature off:
  20231116-234529-zhewang-a3b9d3b87acbbfcf           compressed=True data_size=36157735 fail_fast=10 max_runs=100000 priority=100 sanity=False submitted=20231116-234529 timeout=5400 username=zhewang

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
