### PR TITLE
Nits for blobcipher test

### DIFF
--- a/fdbclient/BlobCipher.cpp
+++ b/fdbclient/BlobCipher.cpp
@@ -2241,7 +2241,7 @@ void testNoAuthMode(const int minDomainId) {
 	Reference<EncryptBuf> encrypted = encryptor.encrypt(&orgData[0], bufLen, &header, arena);
 
 	ASSERT_EQ(encrypted->getLogicalSize(), bufLen);
-	if (ENABLE_MUTATION_TRACKING_WITH_BLOB_CIPHER)
+	if (g_network->isSimulated() && ENABLE_MUTATION_TRACKING_WITH_BLOB_CIPHER)
 		ASSERT_EQ(memcmp(&orgData[0], encrypted->begin(), bufLen), 0);
 	else
 		ASSERT_NE(memcmp(&orgData[0], encrypted->begin(), bufLen), 0);
@@ -2604,7 +2604,7 @@ void testSingleAuthMode(const int minDomainId) {
 	Reference<EncryptBuf> encrypted = encryptor.encrypt(&orgData[0], bufLen, &header, arena);
 
 	ASSERT_EQ(encrypted->getLogicalSize(), bufLen);
-	if (ENABLE_MUTATION_TRACKING_WITH_BLOB_CIPHER)
+	if (g_network->isSimulated() && ENABLE_MUTATION_TRACKING_WITH_BLOB_CIPHER)
 		ASSERT_EQ(memcmp(&orgData[0], encrypted->begin(), bufLen), 0);
 	else
 		ASSERT_NE(memcmp(&orgData[0], encrypted->begin(), bufLen), 0);
@@ -2829,7 +2829,7 @@ void testConfigurableEncryptionSingleAuthMode(const int minDomainId) {
 	StringRef encryptedBuf = encryptor.encrypt(&orgData[0], bufLen, &headerRef, arena);
 
 	ASSERT_EQ(encryptedBuf.size(), bufLen);
-	if (ENABLE_MUTATION_TRACKING_WITH_BLOB_CIPHER)
+	if (g_network->isSimulated() && ENABLE_MUTATION_TRACKING_WITH_BLOB_CIPHER)
 		ASSERT_EQ(memcmp(&orgData[0], encryptedBuf.begin(), bufLen), 0);
 	else
 		ASSERT_NE(memcmp(&orgData[0], encryptedBuf.begin(), bufLen), 0);
@@ -2845,7 +2845,7 @@ void testConfigurableEncryptionSingleAuthMode(const int minDomainId) {
 	// validate IV
 	AesCtrWithAuth<Params> withAuth = std::get<AesCtrWithAuth<Params>>(headerRef.algoHeader);
 	ASSERT_EQ(memcmp(&iv[0], &withAuth.v1.iv[0], AES_256_IV_LENGTH), 0);
-	if (ENABLE_MUTATION_TRACKING_WITH_BLOB_CIPHER)
+	if (g_network->isSimulated() && ENABLE_MUTATION_TRACKING_WITH_BLOB_CIPHER)
 		ASSERT_EQ(memcmp(&orgData[0], encryptedBuf.begin(), bufLen), 0);
 	else
 		ASSERT_NE(memcmp(&orgData[0], encryptedBuf.begin(), bufLen), 0);
@@ -3099,7 +3099,7 @@ void testConfigurableEncryptionInvalidEncryptionKeyNoAuth(const int minDomainId)
 	try {
 		StringRef decryptedBuf = decryptor.decrypt(encryptedBuf.begin(), encryptedBuf.size(), headerRef, arena);
 		ASSERT_EQ(decryptedBuf.size(), bufLen);
-		if (ENABLE_MUTATION_TRACKING_WITH_BLOB_CIPHER)
+		if (g_network->isSimulated() && ENABLE_MUTATION_TRACKING_WITH_BLOB_CIPHER)
 			ASSERT_EQ(memcmp(decryptedBuf.begin(), &orgData[0], bufLen), 0);
 		else
 			ASSERT_NE(memcmp(decryptedBuf.begin(), &orgData[0], bufLen), 0);
@@ -3145,7 +3145,7 @@ void testConfigurableEncryptionInvalidEncryptKeySingleAuthMode(const int minDoma
 	StringRef encryptedBuf = encryptor.encrypt(&orgData[0], bufLen, &headerRef, arena);
 
 	ASSERT_EQ(encryptedBuf.size(), bufLen);
-	if (ENABLE_MUTATION_TRACKING_WITH_BLOB_CIPHER)
+	if (g_network->isSimulated() && ENABLE_MUTATION_TRACKING_WITH_BLOB_CIPHER)
 		ASSERT_EQ(memcmp(&orgData[0], encryptedBuf.begin(), bufLen), 0);
 	else
 		ASSERT_NE(memcmp(&orgData[0], encryptedBuf.begin(), bufLen), 0);
@@ -3161,7 +3161,7 @@ void testConfigurableEncryptionInvalidEncryptKeySingleAuthMode(const int minDoma
 	// validate IV
 	AesCtrWithAuth<Params> withAuth = std::get<AesCtrWithAuth<Params>>(headerRef.algoHeader);
 	ASSERT_EQ(memcmp(&iv[0], &withAuth.v1.iv[0], AES_256_IV_LENGTH), 0);
-	if (ENABLE_MUTATION_TRACKING_WITH_BLOB_CIPHER)
+	if (g_network->isSimulated() && ENABLE_MUTATION_TRACKING_WITH_BLOB_CIPHER)
 		ASSERT_EQ(memcmp(&orgData[0], encryptedBuf.begin(), bufLen), 0);
 	else
 		ASSERT_NE(memcmp(&orgData[0], encryptedBuf.begin(), bufLen), 0);

--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -1947,7 +1947,7 @@ void encryptionAtRestPlaintextMarkerCheck() {
 				while (std::getline(f, buf)) {
 					// SOMEDAY: using 'std::boyer_moore_horspool_searcher' would significantly improve search
 					// time
-					if (!ENABLE_MUTATION_TRACKING_WITH_BLOB_CIPHER) {
+					if (!g_network->isSimulated() || !ENABLE_MUTATION_TRACKING_WITH_BLOB_CIPHER) {
 						if (buf.find(g_simulator->dataAtRestPlaintextMarker.get()) != std::string::npos) {
 							TraceEvent(SevError, "EncryptionAtRestPlaintextMarkerCheckPanic")
 							    .detail("Filename", itr->path().string())

--- a/fdbserver/workloads/EncryptionOps.actor.cpp
+++ b/fdbserver/workloads/EncryptionOps.actor.cpp
@@ -308,7 +308,7 @@ struct EncryptionOpsWorkload : TestWorkload {
 
 		// validate encrypted buffer size and contents (not matching with plaintext)
 		ASSERT_EQ(encrypted->getLogicalSize(), len);
-		if (ENABLE_MUTATION_TRACKING_WITH_BLOB_CIPHER)
+		if (g_network->isSimulated() && ENABLE_MUTATION_TRACKING_WITH_BLOB_CIPHER)
 			ASSERT_EQ(memcmp(encrypted->begin(), payload, len), 0);
 		else
 			ASSERT_NE(memcmp(encrypted->begin(), payload, len), 0);
@@ -356,7 +356,7 @@ struct EncryptionOpsWorkload : TestWorkload {
 
 		ASSERT_EQ(encrypted.size(), len);
 		ASSERT_EQ(headerRef->flagsVersion(), CLIENT_KNOBS->ENCRYPT_HEADER_FLAGS_VERSION);
-		if (ENABLE_MUTATION_TRACKING_WITH_BLOB_CIPHER)
+		if (g_network->isSimulated() && ENABLE_MUTATION_TRACKING_WITH_BLOB_CIPHER)
 			ASSERT_EQ(memcmp(encrypted.begin(), payload, len), 0);
 		else
 			ASSERT_NE(memcmp(encrypted.begin(), payload, len), 0);


### PR DESCRIPTION
ENABLE_MUTATION_TRACKING_WITH_BLOB_CIPHER on
  20231117-075715-zhewang-f3e5dc62fbf7f5c6           compressed=True data_size=36158746 duration=6945914 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:02:04 sanity=False started=100000 stopped=20231117-085919 submitted=20231117-075715 timeout=5400 username=zhewang

ENABLE_MUTATION_TRACKING_WITH_BLOB_CIPHER off
  20231117-061006-zhewang-157a37d233e487de           compressed=True data_size=36158992 duration=6060409 ended=100000 fail=1 fail_fast=10 max_runs=100000 pass=99999 priority=100 remaining=0 runtime=1:21:32 sanity=False started=100000 stopped=20231117-073138 submitted=20231117-061006 timeout=5400 username=zhewang

1 irrelevant failure

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
