### PR TITLE
Fix coroutine generator test failure

### DIFF
--- a/fdbrpc/CoroTests.cpp
+++ b/fdbrpc/CoroTests.cpp
@@ -1695,8 +1695,10 @@ std::string rndFileName() {
 
 Future<Void> testReadLines() {
 	auto filename = rndFileName();
-	auto file = co_await IAsyncFileSystem::filesystem()->open(
-	    filename, IAsyncFile::OPEN_CREATE | IAsyncFile::OPEN_READWRITE, 0640);
+	auto file = co_await IAsyncFileSystem::filesystem()->open(filename,
+	                                                          IAsyncFile::OPEN_ATOMIC_WRITE_AND_CREATE |
+	                                                              IAsyncFile::OPEN_CREATE | IAsyncFile::OPEN_READWRITE,
+	                                                          0640);
 	auto expectedLines = co_await writeTestFile(file);
 	auto lines = readLines(file);
 	for (int i = 0; i < expectedLines.size(); ++i) {


### PR DESCRIPTION
Sim2FileSystem::open() seems to require this flag, otherwise assertion failed.

Found by nightly.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
