### PR TITLE
Bump up the number of keys that "fdbcli checkall" can fetch per GetKeyValueRequest call

### DIFF
--- a/fdbcli/DebugCommands.actor.cpp
+++ b/fdbcli/DebugCommands.actor.cpp
@@ -201,10 +201,18 @@ bool checkResults(Version version,
 		size_t currentI = 0, referenceI = 0;
 		while (currentI < current.data.size() || referenceI < reference.data.size()) {
 			if (currentI >= current.data.size()) {
-				printf(" #%d Unique key: %s\n", firstValidServer, printable(reference.data[referenceI].key).c_str());
+				printf(" #%d CurrentI: %lu ReferenceI: %lu Unique key: %s\n",
+				       firstValidServer,
+				       currentI,
+				       referenceI,
+				       printable(reference.data[referenceI].key).c_str());
 				referenceI++;
 			} else if (referenceI >= reference.data.size()) {
-				printf(" #%d Unique key: %s\n", j, printable(current.data[currentI].key).c_str());
+				printf(" #%d CurrentI: %lu ReferenceI: %lu Unique key: %s\n",
+				       j,
+				       currentI,
+				       referenceI,
+				       printable(current.data[currentI].key).c_str());
 				currentI++;
 			} else {
 				KeyValueRef currentKV = current.data[currentI];
@@ -212,15 +220,26 @@ bool checkResults(Version version,
 
 				if (currentKV.key == referenceKV.key) {
 					if (currentKV.value != referenceKV.value) {
-						printf(" Value mismatch key: %s\n", printable(currentKV.key).c_str());
+						printf(" CurrentI: %lu ReferenceI: %lu Value mismatch key: %s\n",
+						       currentI,
+						       referenceI,
+						       printable(currentKV.key).c_str());
 					}
 					currentI++;
 					referenceI++;
 				} else if (currentKV.key < referenceKV.key) {
-					printf(" #%d Unique key: %s\n", j, printable(currentKV.key).c_str());
+					printf(" #%d CurrentI: %lu ReferenceI: %lu Unique key: %s\n",
+					       j,
+					       currentI,
+					       referenceI,
+					       printable(currentKV.key).c_str());
 					currentI++;
 				} else {
-					printf(" #%d Unique key: %s\n", firstValidServer, printable(referenceKV.key).c_str());
+					printf(" #%d CurrentI: %lu ReferenceI: %lu Unique key: %s\n",
+					       firstValidServer,
+					       currentI,
+					       referenceI,
+					       printable(referenceKV.key).c_str());
 					referenceI++;
 				}
 			}
@@ -232,6 +251,9 @@ bool checkResults(Version version,
 
 	if (firstValidServer >= 0 && replies[firstValidServer].get().get().more) {
 		const VectorRef<KeyValueRef>& result = replies[firstValidServer].get().get().data;
+		printf("Warning: Consistency check was incomplete, last key of server %d that was checked: %s\n",
+		       firstValidServer,
+		       printable(result[result.size() - 1].key).c_str());
 		begin = firstGreaterThan(result[result.size() - 1].key);
 	} else {
 		printf("Same at version %ld\n", version);

--- a/fdbcli/DebugCommands.actor.cpp
+++ b/fdbcli/DebugCommands.actor.cpp
@@ -186,11 +186,18 @@ bool checkResults(Version version,
 		}
 
 		allSame = false;
-		printf("#%d  server: %s  key count: %lu\n",
+		printf("#%d  server: %s  key count: %lu, cached: %d, more: %d\n",
 		       firstValidServer,
 		       servers[firstValidServer].address().toString().c_str(),
-		       reference.data.size());
-		printf("#%d  server: %s  key count: %lu\n", j, servers[j].address().toString().c_str(), current.data.size());
+		       reference.data.size(),
+		       reference.cached,
+		       +reference.more);
+		printf("#%d  server: %s  key count: %lu, cached: %d, more: %dn",
+		       j,
+		       servers[j].address().toString().c_str(),
+		       current.data.size(),
+		       current.cached,
+		       current.more);
 		size_t currentI = 0, referenceI = 0;
 		while (currentI < current.data.size() || referenceI < reference.data.size()) {
 			if (currentI >= current.data.size()) {

--- a/fdbcli/DebugCommands.actor.cpp
+++ b/fdbcli/DebugCommands.actor.cpp
@@ -293,8 +293,8 @@ ACTOR Future<bool> checkallCommandActor(Database cx, std::vector<StringRef> toke
 					GetKeyValuesRequest req;
 					req.begin = begin;
 					req.end = end;
-					req.limit = 1e4;
-					req.limitBytes = CLIENT_KNOBS->REPLY_BYTE_LIMIT;
+					req.limit = CLIENT_KNOBS->KRM_GET_RANGE_LIMIT;
+					req.limitBytes = CLIENT_KNOBS->KRM_GET_RANGE_LIMIT_BYTES;
 					req.version = version;
 					req.tags = TagSet();
 

--- a/fdbcli/DebugCommands.actor.cpp
+++ b/fdbcli/DebugCommands.actor.cpp
@@ -246,9 +246,6 @@ bool checkResults(Version version,
 		}
 	}
 
-	if (!allSame)
-		return false;
-
 	if (firstValidServer >= 0 && replies[firstValidServer].get().get().more) {
 		const VectorRef<KeyValueRef>& result = replies[firstValidServer].get().get().data;
 		printf("Warning: Consistency check was incomplete, last key of server %d that was checked: %s\n",
@@ -259,7 +256,8 @@ bool checkResults(Version version,
 		printf("Same at version %ld\n", version);
 		begin = end; // signal that we're done
 	}
-	return true;
+
+	return allSame;
 }
 
 // The command is used to check the inconsistency in a keyspace, default is \xff\x02/blog/ keyspace.


### PR DESCRIPTION
This will make "fdbcli checkall" results reliable until the number of keys in the requested range exceed CLIENT_KNOBS->KRM_GET_RANGE_LIMIT/CLIENT_KNOBS->KRM_GET_RANGE_LIMIT_BYTES.

Testing:

Joshua job: 20231211-201217-sre-0bc522bf3dc28038 (started)

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
