### PR TITLE
[Release-7.1] ConsistencyCheckerUrgent should tolerate busy restart loop of the checker

### DIFF
--- a/fdbclient/ConsistencyCheckUtil.actor.cpp
+++ b/fdbclient/ConsistencyCheckUtil.actor.cpp
@@ -310,7 +310,7 @@ Key getKeyFromString(const std::string& str) {
 		return emptyKey;
 	}
 	if (str.size() % 4 != 0) {
-		TraceEvent(SevWarnAlways, "ConsistencyCheck_GetKeyFromStringError")
+		TraceEvent(SevWarnAlways, "ConsistencyCheckUrgent_GetKeyFromStringError")
 		    .setMaxEventLength(-1)
 		    .setMaxFieldLength(-1)
 		    .detail("Reason", "WrongLength")
@@ -320,7 +320,7 @@ Key getKeyFromString(const std::string& str) {
 	std::vector<uint8_t> byteList;
 	for (int i = 0; i < str.size(); i += 4) {
 		if (str.at(i + 0) != '\\' || str.at(i + 1) != 'x') {
-			TraceEvent(SevWarnAlways, "ConsistencyCheck_GetKeyFromStringError")
+			TraceEvent(SevWarnAlways, "ConsistencyCheckUrgent_GetKeyFromStringError")
 			    .setMaxEventLength(-1)
 			    .setMaxFieldLength(-1)
 			    .detail("Reason", "WrongBytePrefix")
@@ -330,7 +330,7 @@ Key getKeyFromString(const std::string& str) {
 		const char first = str.at(i + 2);
 		const char second = str.at(i + 3);
 		if (parseCharMap.count(first) == 0 || parseCharMap.count(second) == 0) {
-			TraceEvent(SevWarnAlways, "ConsistencyCheck_GetKeyFromStringError")
+			TraceEvent(SevWarnAlways, "ConsistencyCheckUrgent_GetKeyFromStringError")
 			    .setMaxEventLength(-1)
 			    .setMaxFieldLength(-1)
 			    .detail("Reason", "WrongByteContent")
@@ -403,7 +403,7 @@ std::vector<KeyRange> loadRangesToCheckFromKnob() {
 			rangeBegin = allKeys.end;
 		}
 		if (rangeEnd > allKeys.end) {
-			TraceEvent("ConsistencyCheck_ReverseInputRange")
+			TraceEvent("ConsistencyCheckUrgent_ReverseInputRange")
 			    .setMaxEventLength(-1)
 			    .setMaxFieldLength(-1)
 			    .detail("Index", i)
@@ -418,7 +418,7 @@ std::vector<KeyRange> loadRangesToCheckFromKnob() {
 		} else if (rangeBegin > rangeEnd) {
 			rangeToCheck = Standalone(KeyRangeRef(rangeEnd, rangeBegin));
 		} else {
-			TraceEvent("ConsistencyCheck_EmptyInputRange")
+			TraceEvent("ConsistencyCheckUrgent_EmptyInputRange")
 			    .setMaxEventLength(-1)
 			    .setMaxFieldLength(-1)
 			    .detail("Index", i)
@@ -437,7 +437,7 @@ std::vector<KeyRange> loadRangesToCheckFromKnob() {
 			res.push_back(rangeToCheck.range());
 		}
 	}
-	TraceEvent e("ConsistencyCheck_LoadedInputRange");
+	TraceEvent e("ConsistencyCheckUrgent_LoadedInputRange");
 	e.setMaxEventLength(-1);
 	e.setMaxFieldLength(-1);
 	for (int i = 0; i < res.size(); i++) {


### PR DESCRIPTION
This PR aims at preventing testers from being overloaded when there are multiple checkers. 
If there are multiple tasks issued by different checkers on a tester at a time, the tester replaces the existing task with the new task.
This guarantees following invariants: 
- Any tester executes workload from at most one checker at a time.
- If there are two checkers: 1 is a transient checker and 1 is a stable checker, the stable checker wins (by tries).
- If two checkers are stable checker: neither checker makes progress and a s40 trace event is logged. Removing anyone of the checker will bring the system back to the single checker state.

This PR also adds trace events to record bytes and keys that are compared at each time.

500K correctness test with 1 irrelevant failure:
  20240116-221538-zhewang-527281ccb0088491           compressed=True data_size=24309711 duration=20324562 ended=500000 fail=1 fail_fast=10 max_runs=500000 pass=499999 priority=100 remaining=0 runtime=2:06:20 sanity=False started=500000 stopped=20240117-002158 submitted=20240116-221538 timeout=5400 username=zhewang

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
