### PR TITLE
Do not opt into sse4.2 for arm64 CPUs in crc32 library

### DIFF
--- a/contrib/crc32/crc32c.cpp
+++ b/contrib/crc32/crc32c.cpp
@@ -178,7 +178,7 @@ static inline uint32_t shift_crc(uint32_t shift_table[][256], uint32_t crc) {
 }
 
 /* Compute CRC-32C using the hardware instruction. */
-#if (defined(__clang__) || defined(__GNUG__) && !defined(__aarch64__) && !defined(__powerpc64__))
+#if ((defined(__clang__) || defined(__GNUG__)) && !defined(__aarch64__) && !defined(__powerpc64__))
 /* Enable SSE CEC instructions on Intel processor */
 __attribute__((target("sse4.2")))
 #endif


### PR DESCRIPTION
The fork of the `crc32` library in `contrib` makes use of streaming SIMD instructions where possible. This is achieved via a preprocessor directive, but short-circuiting of the evaluation previously meant that any use of clang or GCC opted into SSE regardless.

This commit adds additional parentheses to ensure a warning-free build of the CRC32 library using clang on ARM64 machines.

On macOS on Apple Silicon:

```
$ uname -m
arm64
```

Before:

```
$ ninja crc32
[0/2] Re-checking globbed directories...
[3/4] Building CXX object contrib/crc32/CMakeFiles/crc32.dir/crc32c.cpp.o
'+sse4.2' is not a recognized feature for this target (ignoring feature)
'+sse4.2' is not a recognized feature for this target (ignoring feature)
[4/4] Linking CXX static library lib/libcrc32.a
```

After:

```
$ ninja -t clean
Cleaning... 5 files.

$ ninja crc32
[0/2] Re-checking globbed directories...
[4/4] Linking CXX static library lib/libcrc32.a
```

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
