### PR TITLE
Fixes a typo in the output from the restore command.

### DIFF
--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -2411,7 +2411,7 @@ ACTOR Future<Void> runRestore(Database db,
 			}
 
 			if (verbose) {
-				fmt::print("Ussing target restore version {}\n", targetVersion);
+				fmt::print("Using target restore version {}\n", targetVersion);
 			}
 		}
 


### PR DESCRIPTION
This fixes a typo I noticed when I was testing the restore command.

I did not perform any testing, since this should be a straightforward text-only change.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
