### PR TITLE
[Release-7.3] Cherry-pick audit storage checksum interface

### DIFF
--- a/fdbclient/include/fdbclient/StorageServerInterface.h
+++ b/fdbclient/include/fdbclient/StorageServerInterface.h
@@ -123,6 +123,8 @@ struct StorageServerInterface {
 	RequestStream<struct FetchCheckpointKeyValuesRequest> fetchCheckpointKeyValues;
 	RequestStream<struct UpdateCommitCostRequest> updateCommitCostRequest;
 	RequestStream<struct AuditStorageRequest> auditStorage;
+	RequestStream<struct GetHotShardsRequest> getHotShards;
+	RequestStream<struct GetStorageCheckSumRequest> getCheckSum;
 
 private:
 	bool acceptingRequests;
@@ -198,6 +200,10 @@ public:
 				    RequestStream<struct UpdateCommitCostRequest>(getValue.getEndpoint().getAdjustedEndpoint(22));
 				auditStorage =
 				    RequestStream<struct AuditStorageRequest>(getValue.getEndpoint().getAdjustedEndpoint(23));
+				getHotShards =
+				    RequestStream<struct GetHotShardsRequest>(getValue.getEndpoint().getAdjustedEndpoint(24));
+				getCheckSum =
+				    RequestStream<struct GetStorageCheckSumRequest>(getValue.getEndpoint().getAdjustedEndpoint(25));
 			}
 		} else {
 			ASSERT(Ar::isDeserializing);
@@ -250,6 +256,8 @@ public:
 		streams.push_back(fetchCheckpointKeyValues.getReceiver());
 		streams.push_back(updateCommitCostRequest.getReceiver());
 		streams.push_back(auditStorage.getReceiver());
+		streams.push_back(getHotShards.getReceiver());
+		streams.push_back(getCheckSum.getReceiver());
 		FlowTransport::transport().addEndpoints(streams);
 	}
 };
@@ -1231,6 +1239,85 @@ struct StorageQueuingMetricsRequest {
 	template <class Ar>
 	void serialize(Ar& ar) {
 		serializer(ar, reply);
+	}
+};
+
+struct GetHotShardsReply {
+	constexpr static FileIdentifier file_identifier = 3828140;
+	std::vector<KeyRange> hotShards;
+
+	GetHotShardsReply() {}
+	explicit GetHotShardsReply(std::vector<KeyRange> hotShards) : hotShards(hotShards) {}
+
+	template <class Ar>
+	void serialize(Ar& ar) {
+		serializer(ar, hotShards);
+	}
+};
+
+struct GetHotShardsRequest {
+	constexpr static FileIdentifier file_identifier = 3828141;
+	ReplyPromise<GetHotShardsReply> reply;
+
+	GetHotShardsRequest() {}
+
+	template <class Ar>
+	void serialize(Ar& ar) {
+		serializer(ar, reply);
+	}
+};
+
+enum class CheckSumMethod : uint8_t {
+	Invalid = 0,
+};
+
+struct CheckSumMetaData {
+	constexpr static FileIdentifier file_identifier = 3828142;
+	KeyRange range;
+	Version version;
+	StringRef checkSumValue;
+
+	CheckSumMetaData() {}
+	CheckSumMetaData(KeyRange range, Version version, StringRef checkSumValue)
+	  : range(range), version(version), checkSumValue(checkSumValue) {}
+
+	template <class Ar>
+	void serialize(Ar& ar) {
+		serializer(ar, range, version, checkSumValue);
+	}
+};
+
+struct GetStorageCheckSumReply {
+	constexpr static FileIdentifier file_identifier = 3828143;
+	std::vector<CheckSumMetaData> checkSums;
+	uint8_t checkSumMethod;
+
+	GetStorageCheckSumReply() {}
+	GetStorageCheckSumReply(const std::vector<CheckSumMetaData>& checkSums, CheckSumMethod checkSumMethod)
+	  : checkSums(checkSums), checkSumMethod(static_cast<uint8_t>(checkSumMethod)) {}
+
+	template <class Ar>
+	void serialize(Ar& ar) {
+		serializer(ar, checkSums, checkSumMethod);
+	}
+};
+
+struct GetStorageCheckSumRequest {
+	constexpr static FileIdentifier file_identifier = 3828144;
+	std::vector<std::pair<KeyRange, Optional<Version>>> ranges;
+	Optional<UID> actionId;
+	uint8_t checkSumMethod;
+	ReplyPromise<GetStorageCheckSumReply> reply;
+
+	GetStorageCheckSumRequest() {}
+	GetStorageCheckSumRequest(const std::vector<std::pair<KeyRange, Optional<Version>>>& ranges,
+	                          Optional<UID> actionId,
+	                          CheckSumMethod checkSumMethod)
+	  : ranges(ranges), actionId(actionId), checkSumMethod(static_cast<uint8_t>(checkSumMethod)) {}
+
+	template <class Ar>
+	void serialize(Ar& ar) {
+		serializer(ar, ranges, actionId, checkSumMethod, reply);
 	}
 };
 

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -13533,6 +13533,14 @@ ACTOR Future<Void> storageServerCore(StorageServer* self, StorageServerInterface
 				updateProcessStats(self);
 				updateProcessStatsTimer = delay(SERVER_KNOBS->FASTRESTORE_UPDATE_PROCESS_STATS_INTERVAL);
 			}
+			when(GetHotShardsRequest req = waitNext(ssi.getHotShards.getFuture())) {
+				TraceEvent(SevError, "GetHotShardsHasNotImplemented", ssi.id());
+				req.reply.sendError(not_implemented());
+			}
+			when(GetStorageCheckSumRequest req = waitNext(ssi.getCheckSum.getFuture())) {
+				TraceEvent(SevError, "GetStorageCheckSumHasNotImplemented", ssi.id());
+				req.reply.sendError(not_implemented());
+			}
 			when(wait(self->actors.getResult())) {}
 		}
 	}


### PR DESCRIPTION
To cherry-pick audit storage checksum interface, we have to cherry-pick GetHotShardsRequest interface as well.

100K correctness test
20240125-194457-zhewang-22a35a6e3a4f69b4           compressed=True data_size=34701652 duration=6353071 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:15:39 sanity=False started=100000 stopped=20240125-210036 submitted=20240125-194457 timeout=5400 username=zhewang

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
