### PR TITLE
[Release-7.1] Fix tester stale interface issue at CC

### DIFF
--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -917,10 +917,9 @@ ACTOR Future<Void> rebootAndCheck(ClusterControllerData* cluster, Optional<Stand
 ACTOR Future<Void> workerAvailabilityWatch(WorkerInterface worker,
                                            ProcessClass startingClass,
                                            ClusterControllerData* cluster) {
-	state Future<Void> failed =
-	    (worker.address() == g_network->getLocalAddress() || startingClass.classType() == ProcessClass::TesterClass)
-	        ? Never()
-	        : waitFailureClient(worker.waitFailure, SERVER_KNOBS->WORKER_FAILURE_TIME);
+	state Future<Void> failed = (worker.address() == g_network->getLocalAddress())
+	                                ? Never()
+	                                : waitFailureClient(worker.waitFailure, SERVER_KNOBS->WORKER_FAILURE_TIME);
 	cluster->updateWorkerList.set(worker.locality.processId(),
 	                              ProcessData(worker.locality, startingClass, worker.stableAddress()));
 	// This switching avoids a race where the worker can be added to id_worker map after the workerAvailabilityWatch


### PR DESCRIPTION
workerAvailabilityWatch is an actor spawned when a new worker is registered to CC. However, the tester (ProcessClass::TesterClass) is ignored in workerAvailabilityWatch. For the removed tester, the corresponding worker has registered to CC but no workerAvailabilityWatch is monitoring the availability of the tester. Therefore, CC does not get notified when the tester has been physically removed and CC still keeps the worker interface. In clusterGetStatus(), [CC still contacts to the removed tester but failed](https://github.com/kakaiu/foundationdb/blob/2a2adf3b9564a4e5349dd41f7e749c6affc140f9/fdbserver/Status.actor.cpp#L2912). Then, [the removed worker interface is added to mergeUnreachable.](https://github.com/kakaiu/foundationdb/blob/2a2adf3b9564a4e5349dd41f7e749c6affc140f9/fdbserver/Status.actor.cpp#L2923) Finally, ["unreachable_processes" message is produced in the status json](https://github.com/kakaiu/foundationdb/blob/2a2adf3b9564a4e5349dd41f7e749c6affc140f9/fdbserver/Status.actor.cpp#L2935).

500K Correctness test:
  20240126-235133-zhewang-f5c68b34cb706909           compressed=True data_size=24309527 duration=21796697 ended=500000 fail=1 fail_fast=10 max_runs=500000 pass=499999 priority=100 remaining=0 runtime=2:05:59 sanity=False started=500000 stopped=20240127-015732 submitted=20240126-235133 timeout=5400 username=zhewang


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
