### PR TITLE
Fix for `No module named 'jinja2'` on Sonoma

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,9 @@ include(CompileCoverageTool)
 # with the actor compiler, we can now make the flow commands available
 include(FlowCommands)
 
+# needed for the jinga2 dependency in protocol_version.py
+find_package(Jinja2 REQUIRED)
+
 ################################################################################
 # Vexilographer
 ################################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,9 +143,6 @@ include(CompileCoverageTool)
 # with the actor compiler, we can now make the flow commands available
 include(FlowCommands)
 
-# needed for the jinga2 dependency in protocol_version.py
-find_package(Jinja2 REQUIRED)
-
 ################################################################################
 # Vexilographer
 ################################################################################

--- a/cmake/FindJinja2.cmake
+++ b/cmake/FindJinja2.cmake
@@ -1,0 +1,46 @@
+# Distributed under the OSI-approved Apache 2.0. See the LICENSE file in
+# FoundationDB source code
+
+#[=======================================================================[.rst:
+FindJinja2
+-------
+
+Find Jinja2, the Python templating engine
+
+Jinja2_ROOT variable can be used for HINTS for different version of Jinja2.
+
+Result variables
+^^^^^^^^^^^^^^^^
+
+This module will set the following variables in your project:
+
+``Jinja2_VERSION``
+  The version of Jinja2
+``Jinja2_FOUND``
+  If false, Jinja2 is not available
+#]=======================================================================]
+
+include(FindPackageHandleStandardArgs)
+find_package(Python3 COMPONENTS Interpreter REQUIRED)
+
+if(NOT Jinja2_ROOT)
+  set(Jinja2_ROOT $ENV{Jinja2_ROOT})
+endif()
+
+# Check for Jinja2 using Python
+execute_process(
+  COMMAND ${Python3_EXECUTABLE} -c "import jinja2; print(jinja2.__version__)"
+  RESULT_VARIABLE _Jinja2_NOT_FOUND
+  OUTPUT_VARIABLE _Jinja2_VERSION_STRING
+  OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+if(NOT _Jinja2_NOT_FOUND)
+  set(Jinja2_VERSION ${_Jinja2_VERSION_STRING})
+endif()
+
+find_package_handle_standard_args(
+  Jinja2
+  FOUND_VAR Jinja2_FOUND
+  REQUIRED_VARS Jinja2_VERSION)
+
+mark_as_advanced(Jinja2_FOUND Jinja2_VERSION)

--- a/documentation/CMakeLists.txt
+++ b/documentation/CMakeLists.txt
@@ -15,11 +15,9 @@ if(NOT Sphinx_FOUND)
     PATHS ${SPHINX_VENV_DIR}/Scripts ${SPHINX_VENV_DIR}/bin REQUIRED
     NO_DEFAULT_PATH NO_CACHE
     DOC "Checking Python3 executable in virtual environment")
-  execute_process(
-    COMMAND "${VENV_Python3_EXECUTABLE}" -m ensurepip
-    COMMAND "${VENV_Python3_EXECUTABLE}" -m pip install --upgrade pip
-    COMMAND "${VENV_Python3_EXECUTABLE}" -m pip install -r
-            "${SPHINX_DOCUMENT_DIR}/requirements.txt")
+  execute_process(COMMAND "${VENV_Python3_EXECUTABLE}" -m ensurepip COMMAND_ERROR_IS_FATAL ANY)
+  execute_process(COMMAND "${VENV_Python3_EXECUTABLE}" -m pip install --upgrade pip COMMAND_ERROR_IS_FATAL ANY)
+  execute_process(COMMAND "${VENV_Python3_EXECUTABLE}" -m pip install -r "${SPHINX_DOCUMENT_DIR}/requirements.txt" COMMAND_ERROR_IS_FATAL ANY)
   set(Sphinx_ROOT "${SPHINX_VENV_DIR}")
   unset(Sphinx_FOUND)
   find_package(Sphinx REQUIRED)

--- a/flow/CMakeLists.txt
+++ b/flow/CMakeLists.txt
@@ -30,15 +30,35 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/ApiVersion.h.cmake ${CMAKE_CURRENT_BI
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/SourceVersion.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/include/flow/SourceVersion.h)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/include/flow/config.h)
 
+set(PROTOCOL_VERSION_PYTHON_EXECUTABLE "${Python3_EXECUTABLE}")
+
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
+find_package(Jinja2)
+if(NOT Jinja2_FOUND)
+  message(STATUS "Jinja2 not found, setting up virtual environment for protocol_version.py")
+  set(PROTOCOL_VERSION_VENV_DIR "${CMAKE_BINARY_DIR}/protocol_version-venv")
+  execute_process(COMMAND "${Python3_EXECUTABLE}" -m venv ${PROTOCOL_VERSION_VENV_DIR})
+  find_program(
+    VENV_Python3_EXECUTABLE
+    NAMES python3 python3.exe
+    PATHS ${PROTOCOL_VERSION_VENV_DIR}/Scripts ${PROTOCOL_VERSION_VENV_DIR}/bin REQUIRED
+    NO_DEFAULT_PATH NO_CACHE
+    DOC "Checking Python3 executable in virtual environment")
+  execute_process(COMMAND "${VENV_Python3_EXECUTABLE}" -m ensurepip COMMAND_ERROR_IS_FATAL ANY)
+  execute_process(COMMAND "${VENV_Python3_EXECUTABLE}" -m pip install --upgrade pip COMMAND_ERROR_IS_FATAL ANY)
+  execute_process(COMMAND "${VENV_Python3_EXECUTABLE}" -m pip install -r "${CMAKE_CURRENT_SOURCE_DIR}/protocolversion/requirements.txt" COMMAND_ERROR_IS_FATAL ANY)
+  set(PROTOCOL_VERSION_PYTHON_EXECUTABLE "${VENV_Python3_EXECUTABLE}")
+endif()
+
 set(FDB_PROTOCOL_VERSION_FILE "${CMAKE_CURRENT_SOURCE_DIR}/ProtocolVersions.cmake" CACHE STRING "Protocol version cmake file." FORCE)
 set(FDB_PROTOCOL_VERSION_HEADER_FILE "${CMAKE_CURRENT_BINARY_DIR}/include/flow/ProtocolVersion.h")
 set(FDB_PROTOCOL_VERSION_JAVA_FILE "${CMAKE_CURRENT_BINARY_DIR}/include/flow/ProtocolVersion.java")
 set(FDB_PROTOCOL_VERSION_PYTHON_FILE "${CMAKE_CURRENT_BINARY_DIR}/include/flow/protocol_version.py")
 add_custom_command(
 	OUTPUT ${FDB_PROTOCOL_VERSION_HEADER_FILE}
-	COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/protocolversion/protocol_version.py --source ${FDB_PROTOCOL_VERSION_FILE} --generator cpp --output ${FDB_PROTOCOL_VERSION_HEADER_FILE}
-	COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/protocolversion/protocol_version.py --source ${FDB_PROTOCOL_VERSION_FILE} --generator java --output ${FDB_PROTOCOL_VERSION_JAVA_FILE}
-	COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/protocolversion/protocol_version.py --source ${FDB_PROTOCOL_VERSION_FILE} --generator python --output ${FDB_PROTOCOL_VERSION_PYTHON_FILE}
+	COMMAND ${PROTOCOL_VERSION_PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/protocolversion/protocol_version.py --source ${FDB_PROTOCOL_VERSION_FILE} --generator cpp --output ${FDB_PROTOCOL_VERSION_HEADER_FILE}
+	COMMAND ${PROTOCOL_VERSION_PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/protocolversion/protocol_version.py --source ${FDB_PROTOCOL_VERSION_FILE} --generator java --output ${FDB_PROTOCOL_VERSION_JAVA_FILE}
+	COMMAND ${PROTOCOL_VERSION_PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/protocolversion/protocol_version.py --source ${FDB_PROTOCOL_VERSION_FILE} --generator python --output ${FDB_PROTOCOL_VERSION_PYTHON_FILE}
 	DEPENDS
 		${CMAKE_CURRENT_SOURCE_DIR}/protocolversion/protocol_version.py
 		${CMAKE_CURRENT_SOURCE_DIR}/protocolversion/ProtocolVersion.h.template

--- a/flow/protocolversion/requirements.txt
+++ b/flow/protocolversion/requirements.txt
@@ -1,0 +1,2 @@
+Jinja2==3.1.2
+MarkupSafe==2.1.3


### PR DESCRIPTION
I was recently trying to build foundationdb on a fresh install of Sonoma, and I ran into the following issue when running `ninja`:

```
FAILED: flow/include/flow/ProtocolVersion.h /Users/eccolnu/fdb/flow/include/flow/ProtocolVersion.h
...
Traceback (most recent call last):
  File "/Users/home/foundationdb/flow/protocolversion/protocol_version.py", line 18, in <module>
    import jinja2
ModuleNotFoundError: No module named 'jinja2'
```

The problem is that `protocol_version.py` implictly expects `jinga2` to be installed in the system python environment.

So, this PR has patches that do three things:

1. `8fea64db80bb89fb7325164380c199153163e87e` makes the build fail correctly during the configure step, instead of failing once we are actually compiling.
2. `2bfff79fd36dbd4ee4482e4083f158acfeeb34c6` makes the build run `protocol_version` in a virtual env if `jinga2` isn't available, similar to what is done for the Sphinx scripts
3. `0d8b941b7f2556a909783a0be8eeae1c71983ae3` is somewhat unrelated, but it fixes an issue with build output I noticed when working on this.

One other thing to note is that for both `protocol_version.py` as well as well as the Spinx script is that the build only uses a virtual env if the Python library isn't found. It might be beneficial to switch them to always use a virtual env instead.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
