### PR TITLE
Allow AsyncFileWriteChecker history.timestamp to have better precision(release-7.1)

### DIFF
--- a/fdbrpc/AsyncFileWriteChecker.h
+++ b/fdbrpc/AsyncFileWriteChecker.h
@@ -143,8 +143,9 @@ private:
 #endif
 
 			// For writes, just update the stored sum
+			double millisecondsPerSecond = 1000;
 			if (write) {
-				history.timestamp = (uint32_t)now();
+				history.timestamp = (uint32_t)(now() * millisecondsPerSecond);
 				history.checksum = checksum;
 			} else {
 				if (history.checksum != 0 && history.checksum != checksum) {
@@ -155,7 +156,7 @@ private:
 					    .detail("PageNumber", page)
 					    .detail("ChecksumOfPage", checksum)
 					    .detail("ChecksumHistory", history.checksum)
-					    .detail("LastWriteTime", history.timestamp);
+					    .detail("LastWriteTime", history.timestamp / millisecondsPerSecond);
 					history.checksum = 0;
 				}
 			}


### PR DESCRIPTION
backport https://github.com/apple/foundationdb/pull/11152

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
