### PR TITLE
[release-7.1] Fix compile issue for ALLOC_INSTRUMENTATION

### DIFF
--- a/flow/Platform.actor.cpp
+++ b/flow/Platform.actor.cpp
@@ -3109,10 +3109,10 @@ void outOfMemory() {
 	    .detail("BackTraces", traceCounts.size());
 
 	for (auto i = traceCounts.begin(); i != traceCounts.end(); ++i) {
-		char buf[1024];
 		std::vector<void*>* frames = i->second.backTrace;
 		std::string backTraceStr;
 #if defined(_WIN32)
+		char buf[1024];
 		for (int j = 1; j < frames->size(); j++) {
 			_snprintf(buf, 1024, "%p ", frames->at(j));
 			backTraceStr += buf;

--- a/flow/SystemMonitor.cpp
+++ b/flow/SystemMonitor.cpp
@@ -355,10 +355,10 @@ SystemStatistics customSystemMonitor(std::string const& eventName, StatisticsSta
 			uint64_t totalSize = 0;
 			uint64_t totalCount = 0;
 			for (auto i = traceCounts.begin(); i != traceCounts.end(); ++i) {
-				char buf[1024];
 				std::vector<void*>* frames = i->second.backTrace;
 				std::string backTraceStr;
 #if defined(_WIN32)
+				char buf[1024];
 				for (int j = 1; j < frames->size(); j++) {
 					_snprintf(buf, 1024, "%p ", frames->at(j));
 					backTraceStr += buf;


### PR DESCRIPTION
Failure without this patch:

```text
[STARTED 150, FINISHED 67 OF 609 IN 37.177 SEC]Building CXX object flow/CMakeFiles/flow.dir/SystemMonitor.cpp.o
FAILED: flow/CMakeFiles/flow.dir/SystemMonitor.cpp.o
ccache /opt/rh/devtoolset-11/root/usr/bin/g++ -DBOOST_CONTEXT_NO_LIB -DBOOST_ERROR_CODE_HEADER_ONLY -DBOOST_SYSTEM_NO_DEPRECATED -DNO_INTELLISENSE -I/root/src/foundationdb -I/root/build_output -I/root/src/foundationdb/contrib/fmt-8.1.1/include -isystem /opt/boost_1_78_0/include -O3 -DNDEBUG -std=gnu++17 -DCMAKE_BUILD -ggdb -fno-omit-frame-pointer -mavx -Werror -Wno-pragmas -Wno-attributes -Wno-error=format -Wunused-variable -Wno-deprecated -fvisibility=hidden -Wreturn-type -fPIC -Wclass-memaccess -DHAVE_OPENSSL -pthread -MD -MT flow/CMakeFiles/flow.dir/SystemMonitor.cpp.o -MF flow/CMakeFiles/flow.dir/SystemMonitor.cpp.o.d -o flow/CMakeFiles/flow.dir/SystemMonitor.cpp.o -c /root/src/foundationdb/flow/SystemMonitor.cpp
distcc[337968] ERROR: compile /root/src/foundationdb/flow/SystemMonitor.cpp on distcc.default.svc.cluster.local/84 failed
distcc[337968] (dcc_build_somewhere) Warning: remote compilation of '/root/src/foundationdb/flow/SystemMonitor.cpp' failed, retrying locally
distcc[337968] (dcc_build_somewhere) ERROR: failed to distribute and fallbacks are disabled
/root/src/foundationdb/flow/SystemMonitor.cpp: In function 'SystemStatistics customSystemMonitor(const string&, StatisticsState*, bool)':
/root/src/foundationdb/flow/SystemMonitor.cpp:358:10: error: unused variable 'buf' [-Werror=unused-variable]
cc1plus: all warnings being treated as errors
[STARTED 150, FINISHED 75 OF 609 IN 39.152 SEC]Building CXX object flow/CMakeFiles/flow.dir/Platform.actor.g.cpp.o
FAILED: flow/CMakeFiles/flow.dir/Platform.actor.g.cpp.o
ccache /opt/rh/devtoolset-11/root/usr/bin/g++ -DBOOST_CONTEXT_NO_LIB -DBOOST_ERROR_CODE_HEADER_ONLY -DBOOST_SYSTEM_NO_DEPRECATED -DNO_INTELLISENSE -I/root/src/foundationdb -I/root/build_output -I/root/src/foundationdb/contrib/fmt-8.1.1/include -isystem /opt/boost_1_78_0/include -O3 -DNDEBUG -std=gnu++17 -DCMAKE_BUILD -ggdb -fno-omit-frame-pointer -mavx -Werror -Wno-pragmas -Wno-attributes -Wno-error=format -Wunused-variable -Wno-deprecated -fvisibility=hidden -Wreturn-type -fPIC -Wclass-memaccess -DHAVE_OPENSSL -pthread -MD -MT flow/CMakeFiles/flow.dir/Platform.actor.g.cpp.o -MF flow/CMakeFiles/flow.dir/Platform.actor.g.cpp.o.d -o flow/CMakeFiles/flow.dir/Platform.actor.g.cpp.o -c /root/build_output/flow/Platform.actor.g.cpp
distcc[337973] ERROR: compile /root/build_output/flow/Platform.actor.g.cpp on distcc.default.svc.cluster.local/84 failed
distcc[337973] (dcc_build_somewhere) Warning: remote compilation of '/root/build_output/flow/Platform.actor.g.cpp' failed, retrying locally
distcc[337973] (dcc_build_somewhere) ERROR: failed to distribute and fallbacks are disabled
/root/src/foundationdb/flow/Platform.actor.cpp: In function 'void platform::outOfMemory()':
/root/src/foundationdb/flow/Platform.actor.cpp:3112:8: error: unused variable 'buf' [-Werror=unused-variable]
cc1plus: all warnings being treated as errors
[STARTED 150, FINISHED 76 OF 609 IN 39.183 SEC]Building CXX object flow/CMakeFiles/flow_sampling.dir/StreamCipher.cpp.o
FAILED: flow/CMakeFiles/flow_sampling.dir/StreamCipher.cpp.o
ccache /opt/rh/devtoolset-11/root/usr/bin/g++ -DBOOST_CONTEXT_NO_LIB -DBOOST_ERROR_CODE_HEADER_ONLY -DBOOST_SYSTEM_NO_DEPRECATED -DENABLE_SAMPLING -DNO_INTELLISENSE -I/root/src/foundationdb -I/root/build_output -isystem /opt/boost_1_78_0/include -O3 -DNDEBUG -std=gnu++17 -DCMAKE_BUILD -ggdb -fno-omit-frame-pointer -mavx -Werror -Wno-pragmas -Wno-attributes -Wno-error=format -Wunused-variable -Wno-deprecated -fvisibility=hidden -Wreturn-type -fPIC -Wclass-memaccess -DHAVE_OPENSSL -pthread -MD -MT flow/CMakeFiles/flow_sampling.dir/StreamCipher.cpp.o -MF flow/CMakeFiles/flow_sampling.dir/StreamCipher.cpp.o.d -o flow/CMakeFiles/flow_sampling.dir/StreamCipher.cpp.o -c /root/src/foundationdb/flow/StreamCipher.cpp
distcc[338257] (dcc_build_somewhere) ERROR: failed to distribute and fallbacks are disabled
[STARTED 150, FINISHED 88 OF 609 IN 42.078 SEC]Building CXX object flow/CMakeFiles/flow_sampling.dir/SystemMonitor.cpp.o
FAILED: flow/CMakeFiles/flow_sampling.dir/SystemMonitor.cpp.o
ccache /opt/rh/devtoolset-11/root/usr/bin/g++ -DBOOST_CONTEXT_NO_LIB -DBOOST_ERROR_CODE_HEADER_ONLY -DBOOST_SYSTEM_NO_DEPRECATED -DENABLE_SAMPLING -DNO_INTELLISENSE -I/root/src/foundationdb -I/root/build_output -isystem /opt/boost_1_78_0/include -O3 -DNDEBUG -std=gnu++17 -DCMAKE_BUILD -ggdb -fno-omit-frame-pointer -mavx -Werror -Wno-pragmas -Wno-attributes -Wno-error=format -Wunused-variable -Wno-deprecated -fvisibility=hidden -Wreturn-type -fPIC -Wclass-memaccess -DHAVE_OPENSSL -pthread -MD -MT flow/CMakeFiles/flow_sampling.dir/SystemMonitor.cpp.o -MF flow/CMakeFiles/flow_sampling.dir/SystemMonitor.cpp.o.d -o flow/CMakeFiles/flow_sampling.dir/SystemMonitor.cpp.o -c /root/src/foundationdb/flow/SystemMonitor.cpp
distcc[338065] ERROR: compile /root/src/foundationdb/flow/SystemMonitor.cpp on distcc.default.svc.cluster.local/84 failed
distcc[338065] (dcc_build_somewhere) Warning: remote compilation of '/root/src/foundationdb/flow/SystemMonitor.cpp' failed, retrying locally
distcc[338065] (dcc_build_somewhere) ERROR: failed to distribute and fallbacks are disabled
/root/src/foundationdb/flow/SystemMonitor.cpp: In function 'SystemStatistics customSystemMonitor(const string&, StatisticsState*, bool)':
/root/src/foundationdb/flow/SystemMonitor.cpp:358:10: error: unused variable 'buf' [-Werror=unused-variable]
cc1plus: all warnings being treated as errors
[STARTED 150, FINISHED 142 OF 609 IN 53.775 SEC]Building CXX object flow/CMakeFiles/flow_sampling.dir/Platform.actor.g.cpp.o
FAILED: flow/CMakeFiles/flow_sampling.dir/Platform.actor.g.cpp.o
ccache /opt/rh/devtoolset-11/root/usr/bin/g++ -DBOOST_CONTEXT_NO_LIB -DBOOST_ERROR_CODE_HEADER_ONLY -DBOOST_SYSTEM_NO_DEPRECATED -DENABLE_SAMPLING -DNO_INTELLISENSE -I/root/src/foundationdb -I/root/build_output -isystem /opt/boost_1_78_0/include -O3 -DNDEBUG -std=gnu++17 -DCMAKE_BUILD -ggdb -fno-omit-frame-pointer -mavx -Werror -Wno-pragmas -Wno-attributes -Wno-error=format -Wunused-variable -Wno-deprecated -fvisibility=hidden -Wreturn-type -fPIC -Wclass-memaccess -DHAVE_OPENSSL -pthread -MD -MT flow/CMakeFiles/flow_sampling.dir/Platform.actor.g.cpp.o -MF flow/CMakeFiles/flow_sampling.dir/Platform.actor.g.cpp.o.d -o flow/CMakeFiles/flow_sampling.dir/Platform.actor.g.cpp.o -c /root/build_output/flow/Platform.actor.g.cpp
distcc[338056] ERROR: compile /root/build_output/flow/Platform.actor.g.cpp on distcc.default.svc.cluster.local/84 failed
distcc[338056] (dcc_build_somewhere) Warning: remote compilation of '/root/build_output/flow/Platform.actor.g.cpp' failed, retrying locally
distcc[338056] (dcc_build_somewhere) ERROR: failed to distribute and fallbacks are disabled
/root/src/foundationdb/flow/Platform.actor.cpp: In function 'void platform::outOfMemory()':
/root/src/foundationdb/flow/Platform.actor.cpp:3112:8: error: unused variable 'buf' [-Werror=unused-variable]
cc1plus: all warnings being treated as errors
[STARTED 150, FINISHED 150 OF 609 IN 65.500 SEC]Building CXX object fdbrpc/CMakeFiles/fdbrpc_sampling.dir/Net2FileSystem.cpp.o
```

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [x] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
