### PR TITLE
Improvements on RocksDB and ShardedRocksDB checksum

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -548,20 +548,21 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( ROCKSDB_USE_POINT_DELETE_FOR_SYSTEM_KEYS,            false ); 
 	init( ROCKSDB_CF_RANGE_DELETION_LIMIT,                         0 );
 	init( ROCKSDB_MEMTABLE_MAX_RANGE_DELETIONS,                  100 );
-	init (ROCKSDB_WAIT_ON_CF_FLUSH,                            false );
-	init (ROCKSDB_ALLOW_WRITE_STALL_ON_FLUSH,                  false );
-	init (ROCKSDB_CF_METRICS_DELAY,                            900.0 );
-	init (ROCKSDB_MAX_LOG_FILE_SIZE,                         10485760 ); // 10MB.
-	init (ROCKSDB_KEEP_LOG_FILE_NUM,                             100 ); // Keeps 1GB log per storage server.
-	init (ROCKSDB_SKIP_STATS_UPDATE_ON_OPEN,                     true ); 
-	init (ROCKSDB_SKIP_FILE_SIZE_CHECK_ON_OPEN,                  true );
-	init (SHARDED_ROCKSDB_VALIDATE_MAPPING_RATIO,                 0.01 ); if (isSimulated) SHARDED_ROCKSDB_VALIDATE_MAPPING_RATIO = deterministicRandom()->random01(); 
-	init (SHARD_METADATA_SCAN_BYTES_LIMIT,                    10485760 ); // 10MB
-	init (ROCKSDB_MAX_MANIFEST_FILE_SIZE,                    100 << 20 ); if (isSimulated) ROCKSDB_MAX_MANIFEST_FILE_SIZE = 500 << 20; // 500MB in simulation
-	init (SHARDED_ROCKSDB_AVERAGE_FILE_SIZE,                    8 << 20 ); // 8MB
-	init (SHARDED_ROCKSDB_COMPACTION_PERIOD,                   isSimulated? 3600 : 2592000 ); // 30d
-	init (SHARDED_ROCKSDB_COMPACTION_ACTOR_DELAY,                  3600 ); // 1h
-	init (SHARDED_ROCKSDB_COMPACTION_SHARD_LIMIT,                    -1 );
+	init( ROCKSDB_WAIT_ON_CF_FLUSH,                            false );
+	init( ROCKSDB_ALLOW_WRITE_STALL_ON_FLUSH,                  false );
+	init( ROCKSDB_CF_METRICS_DELAY,                            900.0 );
+	init( ROCKSDB_MAX_LOG_FILE_SIZE,                        10485760 ); // 10MB.
+	init( ROCKSDB_KEEP_LOG_FILE_NUM,                             100 ); // Keeps 1GB log per storage server.
+	init( ROCKSDB_SKIP_STATS_UPDATE_ON_OPEN,                      true ); 
+	init( ROCKSDB_SKIP_FILE_SIZE_CHECK_ON_OPEN,                   true );
+	init( ROCKSDB_FULLFILE_CHECKSUM,                             false ); if ( randomize && BUGGIFY ) ROCKSDB_FULLFILE_CHECKSUM = true;
+	init( SHARDED_ROCKSDB_VALIDATE_MAPPING_RATIO,                 0.01 ); if (isSimulated) SHARDED_ROCKSDB_VALIDATE_MAPPING_RATIO = deterministicRandom()->random01(); 
+	init( SHARD_METADATA_SCAN_BYTES_LIMIT,                    10485760 ); // 10MB
+	init( ROCKSDB_MAX_MANIFEST_FILE_SIZE,                    100 << 20 ); if (isSimulated) ROCKSDB_MAX_MANIFEST_FILE_SIZE = 500 << 20; // 500MB in simulation
+	init( SHARDED_ROCKSDB_AVERAGE_FILE_SIZE,                    8 << 20 ); // 8MB
+	init( SHARDED_ROCKSDB_COMPACTION_PERIOD,                   isSimulated? 3600 : 2592000 ); // 30d
+	init( SHARDED_ROCKSDB_COMPACTION_ACTOR_DELAY,                  3600 ); // 1h
+	init( SHARDED_ROCKSDB_COMPACTION_SHARD_LIMIT,                    -1 );
 	init( SHARDED_ROCKSDB_WRITE_BUFFER_SIZE,                   16 << 20 ); // 16MB
 	init( SHARDED_ROCKSDB_TOTAL_WRITE_BUFFER_SIZE,              1 << 30 ); // 1GB
 	init( SHARDED_ROCKSDB_MEMTABLE_BUDGET,                      64 << 20); // 64MB

--- a/fdbclient/include/fdbclient/ServerKnobs.h
+++ b/fdbclient/include/fdbclient/ServerKnobs.h
@@ -493,7 +493,7 @@ public:
 	bool ROCKSDB_ATOMIC_FLUSH;
 	bool ROCKSDB_IMPORT_MOVE_FILES;
 	bool ROCKSDB_CHECKPOINT_REPLAY_MARKER;
-	bool ROCKSDB_VERIFY_CHECKSUM_BEFORE_RESTORE;
+	bool ROCKSDB_VERIFY_CHECKSUM_BEFORE_RESTORE; // Conduct block-level checksum when rocksdb injecting data
 	bool ROCKSDB_ENABLE_CHECKPOINT_VALIDATION;
 	bool ROCKSDB_RETURN_OVERLOADED_ON_TIMEOUT;
 	int ROCKSDB_COMPACTION_PRI;
@@ -511,6 +511,11 @@ public:
 	int ROCKSDB_KEEP_LOG_FILE_NUM;
 	bool ROCKSDB_SKIP_STATS_UPDATE_ON_OPEN;
 	bool ROCKSDB_SKIP_FILE_SIZE_CHECK_ON_OPEN;
+	bool ROCKSDB_FULLFILE_CHECKSUM; // For validate sst files when compaction and producing backup files. TODO: set
+	                                // verify_file_checksum when ingesting (for physical shard move).
+	                                // This is different from ROCKSDB_VERIFY_CHECKSUM_BEFORE_RESTORE (block-level
+	                                // checksum). The block-level checksum does not cover the corruption such as wrong
+	                                // sst file or file move/copy.
 	double SHARDED_ROCKSDB_VALIDATE_MAPPING_RATIO;
 	int SHARD_METADATA_SCAN_BYTES_LIMIT;
 	int ROCKSDB_MAX_MANIFEST_FILE_SIZE;

--- a/fdbserver/KeyValueStoreShardedRocksDB.actor.cpp
+++ b/fdbserver/KeyValueStoreShardedRocksDB.actor.cpp
@@ -806,6 +806,12 @@ rocksdb::DBOptions getOptions() {
 	options.skip_stats_update_on_db_open = SERVER_KNOBS->ROCKSDB_SKIP_STATS_UPDATE_ON_OPEN;
 	options.skip_checking_sst_file_sizes_on_db_open = SERVER_KNOBS->ROCKSDB_SKIP_FILE_SIZE_CHECK_ON_OPEN;
 	options.max_manifest_file_size = SERVER_KNOBS->ROCKSDB_MAX_MANIFEST_FILE_SIZE;
+
+	if (SERVER_KNOBS->ROCKSDB_FULLFILE_CHECKSUM) {
+		// We want this sst level checksum for many scenarios, such as compaction, backup, and physicalshardmove
+		// https://github.com/facebook/rocksdb/wiki/Full-File-Checksum-and-Checksum-Handoff
+		options.file_checksum_gen_factory = rocksdb::GetFileChecksumGenCrc32cFactory();
+	}
 	return options;
 }
 


### PR DESCRIPTION
This PR evaluates the current RocksDB checksum mechanism:
- Block checksum is written to disk when generating SST files. When reading the data from a SST file, the block checksum is checked. This covers any corruption that happens to data block of SST file after the block has been persisted. Ref: https://github.com/facebook/rocksdb/wiki/Full-File-Checksum-and-Checksum-Handoff
- paranoid_file_checks: Right after generating a SST file on disk, RocksDB reads the data of the SST file and compare it with the data before the SST file generation. This covers cases where the file system says that the data has been persisted but it is actually not. Ref: https://rocksdb.org/blog/2021/05/26/online-validation.html
- SST file checksum: When generating a SST file, a checksum of the file is attached and persisted on disk. When using the SST file, RocksDB is able to check the integrity and identity of the file. This covers cases where a SST file is corrupted during the transmission or when it is stored in the storage. Ref: https://github.com/facebook/rocksdb/wiki/Full-File-Checksum-and-Checksum-Handoff

Leftover part: We are not be able to tolerate lost write corruption in WAL. When RocksDB restarts, any corrupted data in WAL can silently propagate to SST. We are not easily to capture this corruption.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
