### PR TITLE
Flag error if log router is not learning its primary peek location

### DIFF
--- a/fdbserver/LogRouter.actor.cpp
+++ b/fdbserver/LogRouter.actor.cpp
@@ -348,7 +348,8 @@ ACTOR Future<Reference<ILogSystem::IPeekCursor>> getPeekCursorData(LogRouterData
 				    .trackLatest(self->eventCacheHolder->trackingKey);
 				// If no primary peek location after many tries, flag an error for manual intervention.
 				// The LR may become a bottleneck on the system and need to be excluded.
-				if (!self->primaryPeekLocation.present() && !(++noPrimaryPeekLocation % 4)) {
+				noPrimaryPeekLocation = self->primaryPeekLocation.present() ? 0 : ++noPrimaryPeekLocation;
+				if (!(noPrimaryPeekLocation % 4)) {
 					TraceEvent(SevError, "NoPrimaryPeekLocationForLR", self->dbgid);
 				}
 			}

--- a/fdbserver/LogRouter.actor.cpp
+++ b/fdbserver/LogRouter.actor.cpp
@@ -302,6 +302,8 @@ ACTOR Future<Reference<ILogSystem::IPeekCursor>> getPeekCursorData(LogRouterData
                                                                    Version startVersion) {
 	state Reference<ILogSystem::IPeekCursor> result = r;
 	state bool useSatellite = SERVER_KNOBS->LOG_ROUTER_PEEK_FROM_SATELLITES_PREFERRED;
+	state uint32_t noPrimaryPeekLocation = 0;
+
 	loop {
 		Future<Void> getMoreF = Never();
 		if (result) {
@@ -344,6 +346,11 @@ ACTOR Future<Reference<ILogSystem::IPeekCursor>> getPeekCursorData(LogRouterData
 				TraceEvent("LogRouterPeekLocation", self->dbgid)
 				    .detail("LogID", result->getPrimaryPeekLocation())
 				    .trackLatest(self->eventCacheHolder->trackingKey);
+				// If no primary peek location after many tries, flag an error for manual intervention.
+				// The LR may become a bottleneck on the system and need to be excluded.
+				if (!self->primaryPeekLocation.present() && !(++noPrimaryPeekLocation % 4)) {
+					TraceEvent(SevError, "NoPrimaryPeekLocationForLR", self->dbgid);
+				}
 			}
 		}
 	}

--- a/fdbserver/LogRouter.actor.cpp
+++ b/fdbserver/LogRouter.actor.cpp
@@ -350,7 +350,7 @@ ACTOR Future<Reference<ILogSystem::IPeekCursor>> getPeekCursorData(LogRouterData
 				// The LR may become a bottleneck on the system and need to be excluded.
 				noPrimaryPeekLocation = self->primaryPeekLocation.present() ? 0 : ++noPrimaryPeekLocation;
 				if (!(noPrimaryPeekLocation % 4)) {
-					TraceEvent(SevError, "NoPrimaryPeekLocationForLR", self->dbgid);
+					TraceEvent(SevWarnAlways, "NoPrimaryPeekLocationForLR", self->dbgid);
 				}
 			}
 		}


### PR DESCRIPTION
In production there have been occurrences where a recruited LR never received the log system within dbInfo. Flag a `SevWarnAlways` for manual intervention in these circumstances, as the LR may become a bottleneck on the system and need to be excluded. 