### PR TITLE
[RELEASE-7.1] Abort process when abnormal shutdown is initiated to allow coredumps to be generated

### DIFF
--- a/flow/Knobs.cpp
+++ b/flow/Knobs.cpp
@@ -71,6 +71,7 @@ void FlowKnobs::initialize(Randomize randomize, IsSimulated isSimulated) {
 	init( FAST_ALLOC_LOGGING_BYTES,                           10e6 );
 	init( HUGE_ARENA_LOGGING_BYTES,                          100e6 );
 	init( HUGE_ARENA_LOGGING_INTERVAL,                         5.0 );
+	init( ABORT_ON_FAILURE,                                  false );
 
 	init( MEMORY_USAGE_CHECK_INTERVAL,                         1.0 );
 

--- a/flow/Knobs.h
+++ b/flow/Knobs.h
@@ -133,6 +133,9 @@ public:
 	double FAST_ALLOC_LOGGING_BYTES;
 	double HUGE_ARENA_LOGGING_BYTES;
 	double HUGE_ARENA_LOGGING_INTERVAL;
+	// This setting allows to let the fdbserver abort instead of exit to generate coredumps
+	// in case of a failure.
+	bool ABORT_ON_FAILURE;
 
 	double MEMORY_USAGE_CHECK_INTERVAL;
 

--- a/flow/Platform.actor.cpp
+++ b/flow/Platform.actor.cpp
@@ -3250,7 +3250,7 @@ extern "C" void flushAndExit(int exitCode) {
 	// Send a signal to allow the Kernel to generate a coredump for this process.
 	// See: https://man7.org/linux/man-pages/man5/core.5.html
 	// The abort method will send a SIGABRT, which causes the kernel to collect a coredump.
-	// See: https://pubs.opengroup.org/onlinepubs/9699919799/functions/abort.html.
+	// See: https://man7.org/linux/man-pages/man3/abort.3.html.
 	if (exitCode != FDB_EXIT_SUCCESS)
 		abort();
 	// In the success case exit the process gracefully.

--- a/flow/Platform.actor.cpp
+++ b/flow/Platform.actor.cpp
@@ -3251,7 +3251,7 @@ extern "C" void flushAndExit(int exitCode) {
 	// See: https://man7.org/linux/man-pages/man5/core.5.html
 	// The abort method will send a SIGABRT, which causes the kernel to collect a coredump.
 	// See: https://man7.org/linux/man-pages/man3/abort.3.html.
-	if (exitCode != FDB_EXIT_SUCCESS)
+	if (exitCode != FDB_EXIT_SUCCESS && FLOW_KNOBS->ABORT_ON_FAILURE)
 		abort();
 	// In the success case exit the process gracefully.
 	_exit(exitCode);

--- a/flow/Platform.actor.cpp
+++ b/flow/Platform.actor.cpp
@@ -3247,6 +3247,13 @@ extern "C" void flushAndExit(int exitCode) {
 	// to the crashAndDie call below.
 	TerminateProcess(GetCurrentProcess(), exitCode);
 #else
+	// Send a signal to allow the Kernel to generate a coredump for this process.
+	// See: https://man7.org/linux/man-pages/man5/core.5.html
+	// The abort method will send a SIGABRT, which causes the kernel to collect a coredump.
+	// See: https://pubs.opengroup.org/onlinepubs/9699919799/functions/abort.html.
+	if (exitCode != FDB_EXIT_SUCCESS)
+		abort();
+	// In the success case exit the process gracefully.
 	_exit(exitCode);
 #endif
 	// should never reach here, but you never know


### PR DESCRIPTION
If the processes are exiting with the `_exit` method, that is considered a graceful shutdown and will not cause the kernel to generate a core dump.

I'm still doing some testing, once we validated that this setup works and the change looks good, we can merge it and I can create the PRs to add this change to 7.3 and main.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
