### PR TITLE
Fix calculateTeamStorageQueueThreshold

### DIFF
--- a/fdbserver/DDTeamCollection.actor.cpp
+++ b/fdbserver/DDTeamCollection.actor.cpp
@@ -199,6 +199,9 @@ public:
 	// portion of teams that have longer storage queues
 	// A team storage queue size is defined as the longest storage queue size among all SSes of the team
 	static int64_t calculateTeamStorageQueueThreshold(const std::vector<Reference<TCTeamInfo>>& teams) {
+		if (teams.size() == 0) {
+			return std::numeric_limits<int64_t>::max(); // disable this funcationality
+		}
 		std::vector<int64_t> queueLengthList;
 		for (const auto& team : teams) {
 			Optional<int64_t> storageQueueSize = team->getLongestStorageQueueSize();
@@ -210,7 +213,7 @@ public:
 			}
 		}
 		double percentile = std::max(0.0, std::min(SERVER_KNOBS->DD_LONG_STORAGE_QUEUE_TEAM_MAJORITY_PERCENTILE, 1.0));
-		int position = queueLengthList.size() * (1 - percentile);
+		int position = (queueLengthList.size() - 1) * (1 - percentile);
 		std::nth_element(queueLengthList.begin(), queueLengthList.begin() + position, queueLengthList.end());
 		int64_t threshold = queueLengthList[position];
 		TraceEvent(SevInfo, "StorageQueueAwareGotThreshold").suppressFor(5.0).detail("Threshold", threshold);


### PR DESCRIPTION
100K test:
  20240212-231957-zhewang-e4c7635a4885d056           compressed=True data_size=36692703 duration=6842483 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:58:50 sanity=False started=100000 stopped=20240213-001847 submitted=20240212-231957 timeout=5400 username=zhewang

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
