### PR TITLE
Fix valgrind error [release-7.3]

### DIFF
--- a/fdbclient/include/fdbclient/StorageServerInterface.h
+++ b/fdbclient/include/fdbclient/StorageServerInterface.h
@@ -1163,12 +1163,12 @@ struct GetStorageMetricsReply {
 	StorageMetrics load; // sum of key-value metrics (logical bytes)
 	StorageMetrics available; // physical bytes
 	StorageMetrics capacity; // physical bytes
-	double bytesInputRate;
-	int64_t versionLag;
-	double lastUpdate;
-	int64_t bytesDurable, bytesInput;
+	double bytesInputRate = 0;
+	int64_t versionLag = 0;
+	double lastUpdate = 0;
+	int64_t bytesDurable = 0, bytesInput = 0;
 
-	GetStorageMetricsReply() : bytesInputRate(0) {}
+	GetStorageMetricsReply() = default;
 
 	template <class Ar>
 	void serialize(Ar& ar) {


### PR DESCRIPTION
cherrypick #11201

bytesDurable and bytesInput are not initilized here: https://github.com/apple/foundationdb/blob/09b593c328e0dbd3d98c3e54a10c5b4fb22d3a77/fdbserver/BlobMigrator.actor.cpp#L505

Found by Valgrind nightly:
```
-f ./tests/fast/BlobRestoreBasic.toml -s 4063154784 -b on
-f ./tests/fast/BlobRestoreLarge.toml -s 4249568466 -b on
```

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
