### PR TITLE
Add javadoc and fix the Java API link

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,6 +215,7 @@ if(WITH_PYTHON AND WITH_C_BINDING)
 endif()
 if(WITH_DOCUMENTATION)
   add_subdirectory(documentation)
+  add_dependencies(html CopyJavadoc)
 endif()
 
 if(WIN32)

--- a/bindings/java/CMakeLists.txt
+++ b/bindings/java/CMakeLists.txt
@@ -209,6 +209,17 @@ add_jar(fdb-java ${JAVA_BINDING_SRCS} ${GENERATED_JAVA_FILES} ${CMAKE_SOURCE_DIR
   OUTPUT_DIR ${PROJECT_BINARY_DIR}/lib VERSION ${FDB_VERSION} MANIFEST ${MANIFEST_FILE} GENERATE_NATIVE_HEADERS fdb_java_native)
 add_dependencies(fdb-java fdb_java_options)
 
+create_javadoc(fdb
+               FILES ${JAVA_BINDING_SRCS} ${GENERATED_JAVA_FILES} ${GENERATED_JAVA_DIR}/ApiVersion.java
+               VERSION ${FDB_VERSION}
+               )
+add_dependencies(fdb_javadoc fdb_java_options) 
+
+add_custom_target(CopyJavadoc
+    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_BINARY_DIR}/javadoc/fdb ${CMAKE_CURRENT_BINARY_DIR}/../../documentation/html/javadoc
+)
+add_dependencies(CopyJavadoc fdb_javadoc)
+
 if(NOT OPEN_FOR_IDE)
   set(FAT_JAR_BINARIES "NOTFOUND" CACHE STRING
     "Path of a directory structure with libraries to include in fat jar (a lib directory)")

--- a/bindings/java/src/main/com/apple/foundationdb/Database.java
+++ b/bindings/java/src/main/com/apple/foundationdb/Database.java
@@ -247,11 +247,10 @@ public interface Database extends AutoCloseable, TransactionContext {
 	CompletableFuture<Boolean> blobbifyRange(byte[] beginKey, byte[] endKey, Executor e);
 
 	/**
-	 * Runs {@link #blobbifyRange(byte[] beginKey, byte[] endKey, boolean wait)} on the default executor.
+	 * Runs {@link #blobbifyRange(byte[] beginKey, byte[] endKey, Executor e)} on the default executor.
 	 *
 	 * @param beginKey start of the key range
 	 * @param endKey end of the key range
-	 * @param wait wait for blobbification to complete
 
 	 * @return if the recording of the range was successful
 	 */
@@ -264,7 +263,6 @@ public interface Database extends AutoCloseable, TransactionContext {
 	 *
 	 * @param beginKey start of the key range
 	 * @param endKey end of the key range
-	 * @param wait wait for blobbification to complete
 	 * @param e the {@link Executor} to use for asynchronous callbacks
 
 	 * @return if the recording of the range was successful
@@ -357,7 +355,7 @@ public interface Database extends AutoCloseable, TransactionContext {
 	CompletableFuture<Long> verifyBlobRange(byte[] beginKey, byte[] endKey, long version, Executor e);
 
 	/**
-	 * Runs {@link #flushBlobRange(byte[] beginKey, byte[] endKey)} on the default executor.
+	 * Runs {@link #flushBlobRange(byte[] beginKey, byte[] endKey, boolean compact, long version, Executor e)} on the default executor.
 	 *
 	 * @param beginKey start of the key range
 	 * @param endKey end of the key range
@@ -370,7 +368,7 @@ public interface Database extends AutoCloseable, TransactionContext {
 	}
 
 	/**
-	 * Runs {@link #flushBlobRange(byte[] beginKey, byte[] endKey, long version)} on the default executor.
+	 * Runs {@link #flushBlobRange(byte[] beginKey, byte[] endKey, boolean compact, long version, Executor e)} on the default executor.
 	 *
 	 * @param beginKey start of the key range
 	 * @param endKey end of the key range

--- a/bindings/java/src/main/com/apple/foundationdb/FDB.java
+++ b/bindings/java/src/main/com/apple/foundationdb/FDB.java
@@ -37,7 +37,7 @@ import com.apple.foundationdb.tuple.ByteArrayUtil;
  *   This call is required before using any other part of the API. The call allows
  *   an error to be thrown at this point to prevent client code from accessing a later library
  *   with incorrect assumptions from the current version. The latest supported API version
- *   is defined as {@link ApiVersion.LATEST}.<br><br>
+ *   is defined as ApiVersion.LATEST.<br><br>
  *  FoundationDB encapsulates multiple versions of its interface by requiring
  *   the client to explicitly specify the version of the API it uses. The purpose
  *   of this design is to allow you to upgrade the server, client libraries, or

--- a/bindings/java/src/main/com/apple/foundationdb/Tenant.java
+++ b/bindings/java/src/main/com/apple/foundationdb/Tenant.java
@@ -334,11 +334,10 @@ public interface Tenant extends AutoCloseable, TransactionContext {
 	CompletableFuture<Boolean> blobbifyRange(byte[] beginKey, byte[] endKey, Executor e);
 
 	/**
-	 * Runs {@link #blobbifyRange(byte[] beginKey, byte[] endKey, boolean wait)} on the default executor.
+	 * Runs {@link #blobbifyRangeBlocking(byte[] beginKey, byte[] endKey, Executor e)} on the default executor.
 	 *
 	 * @param beginKey start of the key range
 	 * @param endKey end of the key range
-	 * @param wait wait for blobbification to complete
 
 	 * @return if the recording of the range was successful
 	 */
@@ -351,7 +350,6 @@ public interface Tenant extends AutoCloseable, TransactionContext {
 	 *
 	 * @param beginKey start of the key range
 	 * @param endKey end of the key range
-	 * @param wait wait for blobbification to complete
 	 * @param e the {@link Executor} to use for asynchronous callbacks
 
 	 * @return if the recording of the range was successful
@@ -444,7 +442,7 @@ public interface Tenant extends AutoCloseable, TransactionContext {
 	CompletableFuture<Long> verifyBlobRange(byte[] beginKey, byte[] endKey, long version, Executor e);
 
 	/**
-	 * Runs {@link #flushBlobRange(byte[] beginKey, byte[] endKey)} on the default executor.
+	 * Runs {@link #flushBlobRange(byte[] beginKey, byte[] endKey, boolean compact, long version, Executor e)} on the default executor.
 	 *
 	 * @param beginKey start of the key range
 	 * @param endKey end of the key range
@@ -457,7 +455,7 @@ public interface Tenant extends AutoCloseable, TransactionContext {
 	}
 
 	/**
-	 * Runs {@link #flushBlobRange(byte[] beginKey, byte[] endKey, long version)} on the default executor.
+	 * Runs {@link #flushBlobRange(byte[] beginKey, byte[] endKey, boolean compact, long version, Executor e)} on the default executor.
 	 *
 	 * @param beginKey start of the key range
 	 * @param endKey end of the key range

--- a/documentation/sphinx/extensions/relativelink.py
+++ b/documentation/sphinx/extensions/relativelink.py
@@ -29,10 +29,10 @@
 
 
 def setup(app):
-    import sphinx.environment
+    import sphinx.environment.adapters.toctree
     from docutils import nodes
 
-    old_resolve = sphinx.environment.BuildEnvironment.resolve_toctree
+    old_resolve = sphinx.environment.adapters.toctree.TocTree.resolve
 
     def resolve_toctree(
         self,
@@ -64,4 +64,4 @@ def setup(app):
                 node["refuri"] = node["refuri"][len("relative://") :]
         return result
 
-    sphinx.environment.BuildEnvironment.resolve_toctree = resolve_toctree
+    sphinx.environment.adapters.toctree.TocTree.resolve = resolve_toctree


### PR DESCRIPTION
Fixes https://github.com/apple/foundationdb/issues/9120. So the problem wasn't just that it needed a new link. The problem was that the javadoc docs weren't being generated at all, and in fact some of the existing javadoc comments actively broke a javadoc build.

This PR
* Adds a javadoc build
* Fixes the comments that broke said build
* Fixes the relative link support

# Code-Reviewer Section

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.