### PR TITLE
Fix calculation of EmptyMessageRatio when version vector was enabled.

### DIFF
--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -594,6 +594,8 @@ Future<Version> TagPartitionedLogSystem::push(Version prevVersion,
 			}
 			std::vector<Future<Void>> tLogCommitResults;
 			for (int loc = 0; loc < it->logServers.size(); loc++) {
+				Standalone<StringRef> msg = data.getMessages(location);
+				data.recordEmptyMessage(location, msg);
 				if (SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST) {
 					if (tpcvMap.get().find(location) != tpcvMap.get().end()) {
 						prevVersion = tpcvMap.get()[location];
@@ -602,8 +604,7 @@ Future<Version> TagPartitionedLogSystem::push(Version prevVersion,
 						continue;
 					}
 				}
-				Standalone<StringRef> msg = data.getMessages(location);
-				data.recordEmptyMessage(location, msg);
+
 				allReplies.push_back(recordPushMetrics(
 				    it->connectionResetTrackers[loc],
 				    it->tlogPushDistTrackers[loc],


### PR DESCRIPTION
The EmptyMessageRatio LatencySample was not calculated when version vector was enabled.