### PR TITLE
Fix bug in which private mutations were detected incorrectly.

### DIFF
--- a/fdbserver/Resolver.actor.cpp
+++ b/fdbserver/Resolver.actor.cpp
@@ -482,7 +482,7 @@ ACTOR Future<Void> resolveBatch(Reference<Resolver> self,
 				reply.tpcvMap.clear();
 			} else {
 				std::set<uint16_t> writtenTLogs;
-				if (shardChanged || reply.privateMutationCount) {
+				if (shardChanged || toCommit->getEmptyMessageRatio() < 1.0) {
 					for (int i = 0; i < self->numLogs; i++) {
 						writtenTLogs.insert(i);
 					}


### PR DESCRIPTION
LogPushData creates an empty string for each tLog in its constructor. The resolver logic counted these empty strings ("empty messages") as actual data that represented private mutations. This led us to write to all tLogs when version vector was enabled. This PR ignores such empty messages when making that determination, so version vector will write to a subset of tLogs when there are no private mutations.