### PR TITLE
Fix a DR corruption bug

### DIFF
--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -1572,13 +1572,6 @@ ACTOR static Future<Void> logRangeWarningFetcher(Database cx,
 							break;
 						}
 						existingRanges.insert(rangePair);
-					} else {
-						// This cleanup is done during status, because it should only be required once after upgrading
-						// to 6.2.7 or later. There is no other good location to detect that the metadata is mismatched.
-						TraceEvent(SevWarnAlways, "CleaningDestUidLookup")
-						    .detail("K", it.key.printable())
-						    .detail("V", it.value.printable());
-						tr.clear(it.key);
 					}
 				}
 				wait(tr.commit() || timeoutFuture);

--- a/fdbserver/include/fdbserver/LogSystem.h
+++ b/fdbserver/include/fdbserver/LogSystem.h
@@ -774,12 +774,6 @@ struct LogPushData : NonCopyable {
 		writtenTLogs.insert(msg_locations.begin(), msg_locations.end());
 	}
 
-	void getLocations(const std::vector<Tag>& vtags, std::set<uint16_t>& writtenTLogs) {
-		std::vector<int> msg_locations;
-		logSystem->getPushLocations(vtags, msg_locations, false /*allLocations*/);
-		writtenTLogs.insert(msg_locations.begin(), msg_locations.end());
-	}
-
 	// store tlogs as represented by index
 	void saveLocations(std::set<uint16_t>& writtenTLogs) {
 		writtenTLogs.insert(msg_locations.begin(), msg_locations.end());

--- a/tests/slow/ApiCorrectnessSwitchover.toml
+++ b/tests/slow/ApiCorrectnessSwitchover.toml
@@ -33,3 +33,7 @@ runSetup = true
 
     [[test.workload]]
     testName = 'AtomicSwitchover'
+
+    [[test.workload]]
+    testName = 'Status'
+    testDuration = 30.0

--- a/tests/slow/WriteDuringReadSwitchover.toml
+++ b/tests/slow/WriteDuringReadSwitchover.toml
@@ -41,3 +41,7 @@ simBackupAgents = 'BackupToDB'
     machinesToLeave = 3
     reboot = true
     testDuration = 60.0
+
+    [[test.workload]]
+    testName = 'Status'
+    testDuration = 60.0


### PR DESCRIPTION
The clear in status call can cause corruptions.

To reproduce with clang build:
    seed: -f ./tests/slow/ApiCorrectnessSwitchover.toml -s 223736449 -b on
    commit: f8eca6a80
    Apply the ./tests/slow/ApiCorrectnessSwitchover.toml file in this commit.

Alternatively, existing binary can enable the knob `DISABLE_DUPLICATE_LOG_WARNING=true` to avoid the data corruptions.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
