### PR TITLE
Fix bug in which private mutations were detected incorrectly

### DIFF
--- a/fdbserver/include/fdbserver/LogSystem.h
+++ b/fdbserver/include/fdbserver/LogSystem.h
@@ -806,8 +806,8 @@ struct LogPushData : NonCopyable {
 	// MUST be called after getMessages() and recordEmptyMessage().
 	float getEmptyMessageRatio() const;
 
-	// Returns the total number of mutations.
-	uint32_t getMutationCount() const { return subsequence; }
+	// Returns the total number of mutations. Subsequence is initialized to 1, so subtract 1 to get count.
+	uint32_t getMutationCount() const { return subsequence - 1; }
 
 	// Sets mutations for all internal writers. "mutations" is the output from
 	// getAllMessages() and is used before writing any other mutations.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -328,10 +328,10 @@ if(WITH_PYTHON)
     restarting/from_7.1.0_until_7.2.0/UpgradeAndBackupRestore-2.toml)
   add_fdb_test(
     TEST_FILES restarting/from_7.1.0_until_7.2.0/VersionVectorDisableRestart-1.toml
-    restarting/from_7.1.0_until_7.2.0/VersionVectorDisableRestart-2.toml)
+    restarting/from_7.1.0_until_7.2.0/VersionVectorDisableRestart-2.toml IGNORE)
   add_fdb_test(
     TEST_FILES restarting/from_7.1.0_until_7.2.0/VersionVectorEnableRestart-1.toml
-    restarting/from_7.1.0_until_7.2.0/VersionVectorEnableRestart-2.toml)
+    restarting/from_7.1.0_until_7.2.0/VersionVectorEnableRestart-2.toml IGNORE)
   add_fdb_test(
     TEST_FILES restarting/from_7.2.0_until_7.3.0/ConfigureTestRestart-1.toml
     restarting/from_7.2.0_until_7.3.0/ConfigureTestRestart-2.toml)
@@ -343,10 +343,10 @@ if(WITH_PYTHON)
       restarting/from_7.2.0_until_7.3.0/DrUpgradeRestart-2.toml)
   add_fdb_test(
     TEST_FILES restarting/from_7.2.0_until_7.3.0/VersionVectorDisableRestart-1.toml
-    restarting/from_7.2.0_until_7.3.0/VersionVectorDisableRestart-2.toml)
+    restarting/from_7.2.0_until_7.3.0/VersionVectorDisableRestart-2.toml IGNORE)
   add_fdb_test(
     TEST_FILES restarting/from_7.2.0_until_7.3.0/VersionVectorEnableRestart-1.toml
-    restarting/from_7.2.0_until_7.3.0/VersionVectorEnableRestart-2.toml)
+    restarting/from_7.2.0_until_7.3.0/VersionVectorEnableRestart-2.toml IGNORE)
   add_fdb_test(
     TEST_FILES restarting/from_7.2.4_until_7.3.0/UpgradeAndBackupRestore-1.toml
     restarting/from_7.2.4_until_7.3.0/UpgradeAndBackupRestore-2.toml)
@@ -364,10 +364,10 @@ if(WITH_PYTHON)
     restarting/from_7.3.0/UpgradeAndBackupRestore-2.toml)
   add_fdb_test(
     TEST_FILES restarting/from_7.3.0/VersionVectorDisableRestart-1.toml
-    restarting/from_7.3.0/VersionVectorDisableRestart-2.toml)
+    restarting/from_7.3.0/VersionVectorDisableRestart-2.toml IGNORE)
   add_fdb_test(
     TEST_FILES restarting/from_7.3.0/VersionVectorEnableRestart-1.toml
-    restarting/from_7.3.0/VersionVectorEnableRestart-2.toml)
+    restarting/from_7.3.0/VersionVectorEnableRestart-2.toml IGNORE)
   add_fdb_test(
     TEST_FILES restarting/from_7.3.0/BlobGranuleRestartCycle-1.toml
     restarting/from_7.3.0/BlobGranuleRestartCycle-2.toml)


### PR DESCRIPTION
cherry pick 11236

The resolver logic under PROXY_USE_RESOLVER_PRIVATE_MUTATIONS miscounted the number of private mutations. This led us to write to all TLs when version vector was enabled. The number of mutations can be found by looking at a count in LogPushMutations (subsequence). The bug was this value is initialized to 1, not 0. So to find the count of mutations, 1 must be subtracted.

Verified by enabling version vector, and observing a subset of TLs were selected for the CP to send messages to, rather than all TLs.

Removed version vector upgrade tests pending fix to recovery.