### PR TITLE
Add BitFlip fault injection workload

### DIFF
--- a/fdbrpc/include/fdbrpc/simulator.h
+++ b/fdbrpc/include/fdbrpc/simulator.h
@@ -58,6 +58,11 @@ struct MachineInfo;
 
 constexpr double DISABLE_CONNECTION_FAILURE_FOREVER = 1e6;
 
+// Flip a random bit in the data for error injection ONLY in simulation.
+void flip_bit(StringRef data, const char* file, int line);
+
+#define INJECT_BIT_FLIP(data) flip_bit(data, __FILE__, __LINE__)
+
 class ISimulator : public INetwork {
 
 public:
@@ -433,6 +438,14 @@ public:
 
 	ISimulator();
 	virtual ~ISimulator();
+
+	bool allowBitFlipInjection = false;
+	std::map<std::string, int> bitFlipInjections;
+	void enableBitFlipInjection() { allowBitFlipInjection = true; }
+	bool isBitFlipInjectionEnabled() { return allowBitFlipInjection && !speedUpSimulation; }
+	void disableBitFlipInjection() { allowBitFlipInjection = false; }
+	void maybeInjectBitFlip(char* data, int size);
+	void addBitFlipInjectionStats(const char* file, int line);
 
 protected:
 	Mutex mutex;

--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -2110,6 +2110,10 @@ Future<Void> tLogPeekMessages(PromiseType replyPromise,
 	reply.end = endVersion;
 	reply.onlySpilled = onlySpilled;
 
+	if (g_network->isSimulated() && g_simulator->isBitFlipInjectionEnabled() && BUGGIFY_WITH_PROB(0.001)) {
+		INJECT_BIT_FLIP(reply.messages);
+	}
+
 	DebugLogTraceEvent("TLogPeekMessages4", self->dbgid)
 	    .detail("LogId", logData->logId)
 	    .detail("Tag", reqTag.toString())

--- a/fdbserver/workloads/BitFlip.actor.cpp
+++ b/fdbserver/workloads/BitFlip.actor.cpp
@@ -1,0 +1,87 @@
+/*
+ * BitFlip.actor.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2024 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "fdbrpc/simulator.h"
+#include "fdbserver/TesterInterface.actor.h"
+#include "fdbserver/QuietDatabase.h"
+#include "fdbserver/ServerDBInfo.h"
+#include "fdbserver/workloads/workloads.actor.h"
+#include "flow/DeterministicRandom.h"
+
+#include "flow/actorcompiler.h" // This must be the last #include.
+
+// A simulation workload that flips random memory bit of the data in the system.
+struct BitFlipWorkload : FailureInjectionWorkload {
+	static constexpr auto NAME = "BitFlip";
+	bool enabled;
+	bool success = true;
+
+	// How long to run the workload before starting
+	double initialDelay = 0.0;
+
+	// How long the workload should be run; if <= 0 then it will run until the workload's check function is called
+	double duration = 10.0;
+
+	BitFlipWorkload(WorkloadContext const& wcx, NoOptions) : FailureInjectionWorkload(wcx) {
+		enabled = !clientId && g_network->isSimulated();
+	}
+
+	BitFlipWorkload(WorkloadContext const& wcx) : FailureInjectionWorkload(wcx) {
+		// only do this on the "first" client in simulation
+		enabled = !clientId && g_network->isSimulated();
+		initialDelay = getOption(options, "initialDelay"_sr, 0.0);
+		duration = getOption(options, "testDuration"_sr, 20.0);
+	}
+
+	bool shouldInject(DeterministicRandom& random,
+	                  const WorkloadRequest& work,
+	                  const unsigned alreadyAdded) const override {
+		return alreadyAdded < 1 && work.useDatabase && 0.1 / (1 + alreadyAdded) > random.random01();
+	}
+	Future<Void> setup(Database const& cx) override { return Void(); }
+
+	Future<Void> start(Database const& cx) override { return _start(cx, this); }
+
+	ACTOR Future<Void> _start(Database cx, BitFlipWorkload* self) {
+		if (!self->enabled) {
+			return Void();
+		}
+
+		wait(delay(self->initialDelay));
+		TraceEvent("BitFlipOn").log();
+		g_simulator->enableBitFlipInjection();
+
+		// If a duration was given, let the duration elapse and then shut the profiler off
+		if (self->duration > 0) {
+			wait(delay(self->duration));
+		}
+		g_simulator->disableBitFlipInjection();
+		TraceEvent("BitFlipOff").log();
+
+		return Void();
+	}
+
+	Future<bool> check(Database const& cx) override { return success; }
+
+	void getMetrics(std::vector<PerfMetric>& m) override {}
+};
+
+WorkloadFactory<BitFlipWorkload> BitFlipWorkloadFactory;
+FailureInjectorFactory<BitFlipWorkload> BitFlipFailureInjectorFactory;

--- a/fdbserver/workloads/Rollback.actor.cpp
+++ b/fdbserver/workloads/Rollback.actor.cpp
@@ -28,10 +28,6 @@
 #include "fdbserver/ServerDBInfo.h"
 #include "flow/actorcompiler.h" // This must be the last #include.
 
-// Choose a random proxy and a random tLog, represented as unclogTlog.
-// The workload first clogs network link between the chosen proxy and all tLogs but the unclogTlog;
-// While the network is still clogged, the workload kills the proxy and clogs the unclogged tlog's interface.
-// Note: The clogged network link's latency will become "clogDuration".
 struct RollbackWorkload : FailureInjectionWorkload {
 	static constexpr auto NAME = "Rollback";
 


### PR DESCRIPTION
Add a bit flip for messages from TLog to SS. This either causes SS crash due to serialization error or inconsistent data on the SS.

Once #11255 is landed, this types of error should be detected, hopefully resolved by restarting processes.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
