### PR TITLE
Fix detection of private mutations in version vector

### DIFF
--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -2323,6 +2323,8 @@ ACTOR Future<Void> postResolution(CommitBatchContext* self) {
 	bool firstMessage = true;
 	for (auto m : self->msg.messages) {
 		if (firstMessage) {
+			ASSERT(!SERVER_KNOBS->ENABLE_VERSION_VECTOR ||
+			       pProxyCommitData->db->get().logSystemConfig.numLogs() == self->tpcvMap.size());
 			self->toCommit.addTxsTag();
 		}
 		self->toCommit.writeMessage(StringRef(m.begin(), m.size()), !firstMessage);

--- a/fdbserver/Resolver.actor.cpp
+++ b/fdbserver/Resolver.actor.cpp
@@ -482,7 +482,7 @@ ACTOR Future<Void> resolveBatch(Reference<Resolver> self,
 				reply.tpcvMap.clear();
 			} else {
 				std::set<uint16_t> writtenTLogs;
-				if (shardChanged || reply.privateMutationCount) {
+				if (shardChanged || reply.privateMutations.size()) {
 					for (int i = 0; i < self->numLogs; i++) {
 						writtenTLogs.insert(i);
 					}

--- a/fdbserver/Resolver.actor.cpp
+++ b/fdbserver/Resolver.actor.cpp
@@ -76,23 +76,24 @@ public:
 
 	// Adds state transactions between two versions to the reply message.
 	// "initialShardChanged" indicates if commitVersion has shard changes.
-	// Returns if shardChanged has ever happened for these versions.
+	// Returns if shardChanged or a state transaction has ever happened for these versions.
 	[[nodiscard]] bool applyStateTxnsToBatchReply(ResolveTransactionBatchReply* reply,
 	                                              Version firstUnseenVersion,
 	                                              Version commitVersion,
 	                                              bool initialShardChanged) {
-		bool shardChanged = initialShardChanged;
+		bool shardChangedOrStateTxn = initialShardChanged;
 		auto stateTransactionItr = recentStateTransactions.lower_bound(firstUnseenVersion);
 		auto endItr = recentStateTransactions.lower_bound(commitVersion);
 		// Resolver only sends back prior state txns back, because the proxy
 		// sends this request has them and will apply them via applyMetadataToCommittedTransactions();
 		// and other proxies will get this version's state txns as a prior version.
 		for (; stateTransactionItr != endItr; ++stateTransactionItr) {
-			shardChanged = shardChanged || stateTransactionItr->value.first;
+			shardChangedOrStateTxn =
+			    shardChangedOrStateTxn || stateTransactionItr->value.first || stateTransactionItr->value.second.size();
 			reply->stateMutations.push_back(reply->arena, stateTransactionItr->value.second);
 			reply->arena.dependsOn(stateTransactionItr->value.second.arena());
 		}
-		return shardChanged;
+		return shardChangedOrStateTxn;
 	}
 
 	bool empty() const { return recentStateTransactionSizes.empty(); }
@@ -430,7 +431,7 @@ ACTOR Future<Void> resolveBatch(Reference<Resolver> self,
 		// If shardChanged at or before this commit version, the proxy may have computed
 		// the wrong set of groups. Then we need to broadcast to all groups below.
 		stateTransactionsPair.first = toCommit && toCommit->isShardChanged();
-		bool shardChanged = self->recentStateTransactionsInfo.applyStateTxnsToBatchReply(
+		bool shardChangedOrStateTxn = self->recentStateTransactionsInfo.applyStateTxnsToBatchReply(
 		    &reply, firstUnseenVersion, req.version, toCommit && toCommit->isShardChanged());
 
 		// Adds private mutation messages to the reply message.
@@ -482,7 +483,7 @@ ACTOR Future<Void> resolveBatch(Reference<Resolver> self,
 				reply.tpcvMap.clear();
 			} else {
 				std::set<uint16_t> writtenTLogs;
-				if (shardChanged || reply.privateMutations.size()) {
+				if (shardChangedOrStateTxn || req.txnStateTransactions.size()) {
 					for (int i = 0; i < self->numLogs; i++) {
 						writtenTLogs.insert(i);
 					}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -337,10 +337,10 @@ if(WITH_PYTHON)
     restarting/from_7.1.0_until_7.2.0/UpgradeAndBackupRestore-2.toml)
   add_fdb_test(
     TEST_FILES restarting/from_7.1.0_until_7.2.0/VersionVectorDisableRestart-1.toml
-    restarting/from_7.1.0_until_7.2.0/VersionVectorDisableRestart-2.toml IGNORE)
+    restarting/from_7.1.0_until_7.2.0/VersionVectorDisableRestart-2.toml )
   add_fdb_test(
     TEST_FILES restarting/from_7.1.0_until_7.2.0/VersionVectorEnableRestart-1.toml
-    restarting/from_7.1.0_until_7.2.0/VersionVectorEnableRestart-2.toml IGNORE)
+    restarting/from_7.1.0_until_7.2.0/VersionVectorEnableRestart-2.toml )
   add_fdb_test(
     TEST_FILES restarting/from_7.2.0_until_7.3.0/ConfigureTestRestart-1.toml
     restarting/from_7.2.0_until_7.3.0/ConfigureTestRestart-2.toml)
@@ -352,10 +352,10 @@ if(WITH_PYTHON)
       restarting/from_7.2.0_until_7.3.0/DrUpgradeRestart-2.toml)
   add_fdb_test(
     TEST_FILES restarting/from_7.2.0_until_7.3.0/VersionVectorDisableRestart-1.toml
-    restarting/from_7.2.0_until_7.3.0/VersionVectorDisableRestart-2.toml IGNORE)
+    restarting/from_7.2.0_until_7.3.0/VersionVectorDisableRestart-2.toml )
   add_fdb_test(
     TEST_FILES restarting/from_7.2.0_until_7.3.0/VersionVectorEnableRestart-1.toml
-    restarting/from_7.2.0_until_7.3.0/VersionVectorEnableRestart-2.toml IGNORE)
+    restarting/from_7.2.0_until_7.3.0/VersionVectorEnableRestart-2.toml )
   add_fdb_test(
     TEST_FILES restarting/from_7.2.4_until_7.3.0/UpgradeAndBackupRestore-1.toml
     restarting/from_7.2.4_until_7.3.0/UpgradeAndBackupRestore-2.toml)
@@ -373,10 +373,10 @@ if(WITH_PYTHON)
     restarting/from_7.3.0/UpgradeAndBackupRestore-2.toml)
   add_fdb_test(
     TEST_FILES restarting/from_7.3.0/VersionVectorDisableRestart-1.toml
-    restarting/from_7.3.0/VersionVectorDisableRestart-2.toml IGNORE)
+    restarting/from_7.3.0/VersionVectorDisableRestart-2.toml )
   add_fdb_test(
     TEST_FILES restarting/from_7.3.0/VersionVectorEnableRestart-1.toml
-    restarting/from_7.3.0/VersionVectorEnableRestart-2.toml IGNORE)
+    restarting/from_7.3.0/VersionVectorEnableRestart-2.toml )
   add_fdb_test(
     TEST_FILES restarting/from_7.3.0/BlobGranuleRestartCycle-1.toml
     restarting/from_7.3.0/BlobGranuleRestartCycle-2.toml)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -337,10 +337,10 @@ if(WITH_PYTHON)
     restarting/from_7.1.0_until_7.2.0/UpgradeAndBackupRestore-2.toml)
   add_fdb_test(
     TEST_FILES restarting/from_7.1.0_until_7.2.0/VersionVectorDisableRestart-1.toml
-    restarting/from_7.1.0_until_7.2.0/VersionVectorDisableRestart-2.toml )
+    restarting/from_7.1.0_until_7.2.0/VersionVectorDisableRestart-2.toml IGNORE)
   add_fdb_test(
     TEST_FILES restarting/from_7.1.0_until_7.2.0/VersionVectorEnableRestart-1.toml
-    restarting/from_7.1.0_until_7.2.0/VersionVectorEnableRestart-2.toml )
+    restarting/from_7.1.0_until_7.2.0/VersionVectorEnableRestart-2.toml IGNORE)
   add_fdb_test(
     TEST_FILES restarting/from_7.2.0_until_7.3.0/ConfigureTestRestart-1.toml
     restarting/from_7.2.0_until_7.3.0/ConfigureTestRestart-2.toml)
@@ -352,10 +352,10 @@ if(WITH_PYTHON)
       restarting/from_7.2.0_until_7.3.0/DrUpgradeRestart-2.toml)
   add_fdb_test(
     TEST_FILES restarting/from_7.2.0_until_7.3.0/VersionVectorDisableRestart-1.toml
-    restarting/from_7.2.0_until_7.3.0/VersionVectorDisableRestart-2.toml )
+    restarting/from_7.2.0_until_7.3.0/VersionVectorDisableRestart-2.toml IGNORE)
   add_fdb_test(
     TEST_FILES restarting/from_7.2.0_until_7.3.0/VersionVectorEnableRestart-1.toml
-    restarting/from_7.2.0_until_7.3.0/VersionVectorEnableRestart-2.toml )
+    restarting/from_7.2.0_until_7.3.0/VersionVectorEnableRestart-2.toml IGNORE)
   add_fdb_test(
     TEST_FILES restarting/from_7.2.4_until_7.3.0/UpgradeAndBackupRestore-1.toml
     restarting/from_7.2.4_until_7.3.0/UpgradeAndBackupRestore-2.toml)
@@ -373,10 +373,10 @@ if(WITH_PYTHON)
     restarting/from_7.3.0/UpgradeAndBackupRestore-2.toml)
   add_fdb_test(
     TEST_FILES restarting/from_7.3.0/VersionVectorDisableRestart-1.toml
-    restarting/from_7.3.0/VersionVectorDisableRestart-2.toml )
+    restarting/from_7.3.0/VersionVectorDisableRestart-2.toml IGNORE)
   add_fdb_test(
     TEST_FILES restarting/from_7.3.0/VersionVectorEnableRestart-1.toml
-    restarting/from_7.3.0/VersionVectorEnableRestart-2.toml )
+    restarting/from_7.3.0/VersionVectorEnableRestart-2.toml IGNORE)
   add_fdb_test(
     TEST_FILES restarting/from_7.3.0/BlobGranuleRestartCycle-1.toml
     restarting/from_7.3.0/BlobGranuleRestartCycle-2.toml)


### PR DESCRIPTION
Version vector checks for the existence of private mutations in a transaction on the resolver. 
* A private mutation is sent in `req.txnStateTransactions` 
* Or, a private mutation is found in the version history of changes from another resolver. 

Add an assertion testing the invariant: "transactions with primate mutations are sent to all logs in version vector mode."

The version vector upgrade tests do not yet pass because other recovery bugs still exist. Their fixes belong in separate PRs.

`20240327-182929-henrylambright-18e4bdff29dd3c6c`