### PR TITLE
Added perpetualStorageWiggleSpeed check to pick perpetualStoreType

### DIFF
--- a/fdbserver/DDTeamCollection.actor.cpp
+++ b/fdbserver/DDTeamCollection.actor.cpp
@@ -2561,7 +2561,8 @@ public:
 			// Check if perpetual storage wiggle is enabled and perpetualStoreType is set. If so, we use
 			// perpetualStoreType for all new SSes that match perpetualStorageWiggleLocality.
 			// Note that this only applies to regular storage servers, not TSS.
-			if (!recruitTss && self->configuration.storageMigrationType == StorageMigrationType::GRADUAL &&
+			if (!recruitTss && self->configuration.perpetualStorageWiggleSpeed == 1 &&
+			    self->configuration.storageMigrationType == StorageMigrationType::GRADUAL &&
 			    self->configuration.perpetualStoreType.isValid()) {
 				if (self->configuration.perpetualStorageWiggleLocality == "0") {
 					isr.storeType = self->configuration.perpetualStoreType;


### PR DESCRIPTION
Added perpetualStorageWiggleSpeed check to pick perpetualStoreType
cherry-pick of #11272

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
