### PR TITLE
cherry pick pr 11268 - Fix detection of private mutations in version vector

### DIFF
--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -2209,6 +2209,8 @@ ACTOR Future<Void> postResolution(CommitBatchContext* self) {
 	bool firstMessage = true;
 	for (auto m : self->msg.messages) {
 		if (firstMessage) {
+			ASSERT(!SERVER_KNOBS->ENABLE_VERSION_VECTOR ||
+			       pProxyCommitData->db->get().logSystemConfig.numLogs() == self->tpcvMap.size());
 			self->toCommit.addTxsTag();
 		}
 		self->toCommit.writeMessage(StringRef(m.begin(), m.size()), !firstMessage);


### PR DESCRIPTION
Version vector checks for the existence of private mutations in a transaction on the resolver.

* A private mutation is sent in req.txnStateTransactions
* Or, a private mutation is found in the version history of changes from another resolver.

Add an assertion testing the invariant: "transactions with primate mutations are sent to all logs in version vector mode."

The version vector upgrade tests do not yet pass because other recovery bugs still exist. Their fixes belong in separate PRs.