### PR TITLE
[Release-7.3] Cherry-pick Enable Accumulative Checksum in MutationRef (#11225)

### DIFF
--- a/fdbclient/ClientKnobs.cpp
+++ b/fdbclient/ClientKnobs.cpp
@@ -335,6 +335,7 @@ void ClientKnobs::initialize(Randomize randomize) {
 	init( SIM_KMS_VAULT_MAX_KEYS,                    4096 );
 
 	init( ENABLE_MUTATION_CHECKSUM,                 false ); // if ( randomize && BUGGIFY )  ENABLE_MUTATION_CHECKSUM = true; Enable this after deserialiser is ported to 7.3.
+	init( ENABLE_ACCUMULATIVE_CHECKSUM,             false ); // if ( randomize && BUGGIFY )  ENABLE_ACCUMULATIVE_CHECKSUM = true; Enable this after deserialiser is ported to 7.3.
 	// clang-format on
 }
 

--- a/fdbclient/include/fdbclient/Atomic.h
+++ b/fdbclient/include/fdbclient/Atomic.h
@@ -301,7 +301,7 @@ inline void transformVersionstampMutation(MutationRef& mutation,
                                           StringRef MutationRef::*param,
                                           Version version,
                                           uint16_t transactionNumber) {
-	mutation.removeChecksum();
+	mutation.clearChecksumAndAccumulativeIndex();
 	if ((mutation.*param).size() >= 4) {
 		int32_t pos = parseVersionstampOffset(mutation.*param);
 		mutation.*param = (mutation.*param).substr(0, (mutation.*param).size() - 4);

--- a/fdbclient/include/fdbclient/ClientKnobs.h
+++ b/fdbclient/include/fdbclient/ClientKnobs.h
@@ -334,6 +334,7 @@ public:
 	int SIM_KMS_VAULT_MAX_KEYS;
 
 	bool ENABLE_MUTATION_CHECKSUM;
+	bool ENABLE_ACCUMULATIVE_CHECKSUM;
 
 	ClientKnobs(Randomize randomize);
 	void initialize(Randomize randomize);

--- a/fdbserver/AccumulativeChecksumUtil.cpp
+++ b/fdbserver/AccumulativeChecksumUtil.cpp
@@ -27,20 +27,6 @@ uint16_t getCommitProxyAccumulativeChecksumIndex(uint16_t commitProxyIndex) {
 	return commitProxyIndex * 10 + 1;
 }
 
-bool validateAccumulativeChecksumIndexAtStorageServer(MutationRef m) {
-	if (m.checksum.present() && CLIENT_KNOBS->ENABLE_ACCUMULATIVE_CHECKSUM &&
-	    (!m.accumulativeChecksumIndex.present())) {
-		TraceEvent(SevError, "ACSIndexNotPresent").detail("Mutation", m);
-		return false;
-	} else if (m.checksum.present() && CLIENT_KNOBS->ENABLE_ACCUMULATIVE_CHECKSUM &&
-	           m.accumulativeChecksumIndex.present() &&
-	           m.accumulativeChecksumIndex.get() == invalidAccumulativeChecksumIndex) {
-		TraceEvent(SevError, "ACSIndexNotSet").detail("Mutation", m);
-		return false;
-	}
-	return true;
-}
-
 TEST_CASE("noSim/AccumulativeChecksum/MutationRef") {
 	printf("testing MutationRef encoding/decoding\n");
 	MutationRef m(MutationRef::SetValue, "TestKey"_sr, "TestValue"_sr);

--- a/fdbserver/AccumulativeChecksumUtil.cpp
+++ b/fdbserver/AccumulativeChecksumUtil.cpp
@@ -1,0 +1,78 @@
+/*
+ * AccumulativeChecksumUtil.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "fdbserver/AccumulativeChecksumUtil.h"
+#include "fdbserver/Knobs.h"
+
+uint16_t getCommitProxyAccumulativeChecksumIndex(uint16_t commitProxyIndex) {
+	// We leave flexibility in acs index generated from different components
+	// Acs index ends with 1 indicates the mutation is from a commit proxy
+	return commitProxyIndex * 10 + 1;
+}
+
+bool validateAccumulativeChecksumIndexAtStorageServer(MutationRef m) {
+	if (m.checksum.present() && CLIENT_KNOBS->ENABLE_ACCUMULATIVE_CHECKSUM &&
+	    (!m.accumulativeChecksumIndex.present())) {
+		TraceEvent(SevError, "ACSIndexNotPresent").detail("Mutation", m);
+		return false;
+	} else if (m.checksum.present() && CLIENT_KNOBS->ENABLE_ACCUMULATIVE_CHECKSUM &&
+	           m.accumulativeChecksumIndex.present() &&
+	           m.accumulativeChecksumIndex.get() == invalidAccumulativeChecksumIndex) {
+		TraceEvent(SevError, "ACSIndexNotSet").detail("Mutation", m);
+		return false;
+	}
+	return true;
+}
+
+TEST_CASE("noSim/AccumulativeChecksum/MutationRef") {
+	printf("testing MutationRef encoding/decoding\n");
+	MutationRef m(MutationRef::SetValue, "TestKey"_sr, "TestValue"_sr);
+	if (CLIENT_KNOBS->ENABLE_ACCUMULATIVE_CHECKSUM) {
+		m.setAccumulativeChecksumIndex(512);
+	}
+	BinaryWriter wr(AssumeVersion(ProtocolVersion::withMutationChecksum()));
+
+	wr << m;
+
+	Standalone<StringRef> value = wr.toValue();
+	TraceEvent("EncodedMutation").detail("RawBytes", value);
+
+	BinaryReader rd(value, AssumeVersion(ProtocolVersion::withMutationChecksum()));
+	Standalone<MutationRef> de;
+
+	rd >> de;
+
+	printf("Deserialized mutation: %s\n", de.toString().c_str());
+
+	if (de.type != m.type || de.param1 != m.param1 || de.param2 != m.param2) {
+		TraceEvent(SevError, "MutationMismatch")
+		    .detail("OldType", m.type)
+		    .detail("NewType", de.type)
+		    .detail("OldParam1", m.param1)
+		    .detail("NewParam1", de.param1)
+		    .detail("OldParam2", m.param2)
+		    .detail("NewParam2", de.param2);
+		ASSERT(false);
+	}
+
+	ASSERT(de.validateChecksum());
+
+	return Void();
+}

--- a/fdbserver/ApplyMetadataMutation.cpp
+++ b/fdbserver/ApplyMetadataMutation.cpp
@@ -25,6 +25,7 @@
 #include "fdbclient/Notified.h"
 #include "fdbclient/SystemData.h"
 #include "fdbclient/Tenant.h"
+#include "fdbserver/AccumulativeChecksumUtil.h"
 #include "fdbserver/ApplyMetadataMutation.h"
 #include "fdbclient/IKeyValueStore.h"
 #include "fdbserver/Knobs.h"
@@ -87,7 +88,8 @@ public:
 	    storageCache(&proxyCommitData_.storageCache), tag_popped(&proxyCommitData_.tag_popped),
 	    tssMapping(&proxyCommitData_.tssMapping), tenantMap(&proxyCommitData_.tenantMap),
 	    tenantNameIndex(&proxyCommitData_.tenantNameIndex), lockedTenants(&proxyCommitData_.lockedTenants),
-	    initialCommit(initialCommit_), provisionalCommitProxy(provisionalCommitProxy_) {
+	    initialCommit(initialCommit_), provisionalCommitProxy(provisionalCommitProxy_),
+	    accumulativeChecksumIndex(getCommitProxyAccumulativeChecksumIndex(proxyCommitData_.commitProxyIndex)) {
 		if (encryptMode.isEncryptionEnabled()) {
 			ASSERT(cipherKeys != nullptr);
 			ASSERT(cipherKeys->count(SYSTEM_KEYSPACE_ENCRYPT_DOMAIN_ID) > 0);
@@ -106,7 +108,8 @@ public:
 	    cipherKeys(cipherKeys_), encryptMode(encryptMode), txnStateStore(resolverData_.txnStateStore),
 	    toCommit(resolverData_.toCommit), confChange(resolverData_.confChanges), logSystem(resolverData_.logSystem),
 	    popVersion(resolverData_.popVersion), keyInfo(resolverData_.keyInfo), storageCache(resolverData_.storageCache),
-	    initialCommit(resolverData_.initialCommit), forResolver(true) {
+	    initialCommit(resolverData_.initialCommit), forResolver(true),
+	    accumulativeChecksumIndex(resolverAccumulativeChecksumIndex) {
 		if (encryptMode.isEncryptionEnabled()) {
 			ASSERT(cipherKeys != nullptr);
 			ASSERT(cipherKeys->count(SYSTEM_KEYSPACE_ENCRYPT_DOMAIN_ID) > 0);
@@ -166,6 +169,9 @@ private:
 
 	// true if called from a provisional commit proxy
 	bool provisionalCommitProxy = false;
+
+	// indicate which commit proxy / resolver applies mutations
+	uint16_t accumulativeChecksumIndex = invalidAccumulativeChecksumIndex;
 
 private:
 	// The following variables are used internally
@@ -258,7 +264,8 @@ private:
 			Tag tag = decodeServerTagValue(
 			    txnStateStore->readValue(serverTagKeyFor(serverKeysDecodeServer(m.param1))).get().get());
 			MutationRef privatized = m;
-			privatized.removeChecksum();
+			privatized.clearChecksumAndAccumulativeIndex();
+			privatized.setAccumulativeChecksumIndex(accumulativeChecksumIndex);
 			privatized.param1 = m.param1.withPrefix(systemKeys.begin, arena);
 			TraceEvent(SevDebug, "SendingPrivateMutation", dbgid)
 			    .detail("Original", m)
@@ -282,7 +289,8 @@ private:
 
 		if (toCommit) {
 			MutationRef privatized = m;
-			privatized.removeChecksum();
+			privatized.clearChecksumAndAccumulativeIndex();
+			privatized.setAccumulativeChecksumIndex(accumulativeChecksumIndex);
 			privatized.param1 = m.param1.withPrefix(systemKeys.begin, arena);
 			TraceEvent("ServerTag", dbgid).detail("Server", id).detail("Tag", tag.toString());
 
@@ -326,7 +334,8 @@ private:
 			// This is done to make the storage servers aware of the cached key-ranges
 			if (toCommit) {
 				MutationRef privatized = m;
-				privatized.removeChecksum();
+				privatized.clearChecksumAndAccumulativeIndex();
+				privatized.setAccumulativeChecksumIndex(accumulativeChecksumIndex);
 				privatized.param1 = m.param1.withPrefix(systemKeys.begin, arena);
 				//TraceEvent(SevDebug, "SendingPrivateMutation", dbgid).detail("Original", m.toString()).detail("Privatized", privatized.toString());
 				cachedRangeInfo[k] = privatized;
@@ -349,7 +358,8 @@ private:
 		// Create a private mutation for cache servers
 		// This is done to make the cache servers aware of the cached key-ranges
 		MutationRef privatized = m;
-		privatized.removeChecksum();
+		privatized.clearChecksumAndAccumulativeIndex();
+		privatized.setAccumulativeChecksumIndex(accumulativeChecksumIndex);
 		privatized.param1 = m.param1.withPrefix(systemKeys.begin, arena);
 		TraceEvent(SevDebug, "SendingPrivatized_CacheTag", dbgid).detail("M", privatized);
 		toCommit->addTag(cacheTag);
@@ -390,7 +400,8 @@ private:
 		if (toCommit && keyInfo) {
 			KeyRange r = std::get<0>(decodeChangeFeedValue(m.param2));
 			MutationRef privatized = m;
-			privatized.removeChecksum();
+			privatized.clearChecksumAndAccumulativeIndex();
+			privatized.setAccumulativeChecksumIndex(accumulativeChecksumIndex);
 			privatized.param1 = m.param1.withPrefix(systemKeys.begin, arena);
 			auto ranges = keyInfo->intersectingRanges(r);
 			auto firstRange = ranges.begin();
@@ -455,7 +466,8 @@ private:
 		if (toCommit) {
 			// send private mutation to SS that it now has a TSS pair
 			MutationRef privatized = m;
-			privatized.removeChecksum();
+			privatized.clearChecksumAndAccumulativeIndex();
+			privatized.setAccumulativeChecksumIndex(accumulativeChecksumIndex);
 			privatized.param1 = m.param1.withPrefix(systemKeys.begin, arena);
 
 			Optional<Value> tagV = txnStateStore->readValue(serverTagKeyFor(ssId)).get();
@@ -488,7 +500,8 @@ private:
 		Optional<Value> tagV = txnStateStore->readValue(serverTagKeyFor(ssi.tssPairID.get())).get();
 		if (tagV.present()) {
 			MutationRef privatized = m;
-			privatized.removeChecksum();
+			privatized.clearChecksumAndAccumulativeIndex();
+			privatized.setAccumulativeChecksumIndex(accumulativeChecksumIndex);
 			privatized.param1 = m.param1.withPrefix(systemKeys.begin, arena);
 			TraceEvent(SevDebug, "SendingPrivatized_TSSQuarantine", dbgid).detail("M", privatized);
 			toCommit->addTag(decodeServerTagValue(tagV.get()));
@@ -654,7 +667,8 @@ private:
 		}
 
 		MutationRef privatized = m;
-		privatized.removeChecksum();
+		privatized.clearChecksumAndAccumulativeIndex();
+		privatized.setAccumulativeChecksumIndex(accumulativeChecksumIndex);
 		privatized.param1 = m.param1.withPrefix(systemKeys.begin, arena);
 		TraceEvent(SevDebug, "SendingPrivatized_GlobalKeys", dbgid).detail("M", privatized);
 		toCommit->addTags(allTags);
@@ -689,7 +703,8 @@ private:
 				}
 				const Tag tag = decodeServerTagValue(tagValue.get());
 				MutationRef privatized = m;
-				privatized.removeChecksum();
+				privatized.clearChecksumAndAccumulativeIndex();
+				privatized.setAccumulativeChecksumIndex(accumulativeChecksumIndex);
 				privatized.param1 = m.param1.withPrefix(systemKeys.begin, arena);
 				TraceEvent("SendingPrivateMutationCheckpoint", dbgid)
 				    .detail("Original", m)
@@ -803,7 +818,8 @@ private:
 				toCommit->addTags(allTags);
 
 				MutationRef privatized = m;
-				privatized.removeChecksum();
+				privatized.clearChecksumAndAccumulativeIndex();
+				privatized.setAccumulativeChecksumIndex(accumulativeChecksumIndex);
 				privatized.param1 = m.param1.withPrefix(systemKeys.begin, arena);
 				writeMutation(privatized);
 			}
@@ -922,7 +938,8 @@ private:
 
 				if (toCommit) {
 					MutationRef privatized = m;
-					privatized.removeChecksum();
+					privatized.clearChecksumAndAccumulativeIndex();
+					privatized.setAccumulativeChecksumIndex(accumulativeChecksumIndex);
 					privatized.param1 = kv.key.withPrefix(systemKeys.begin, arena);
 					privatized.param2 = keyAfter(privatized.param1, arena);
 
@@ -946,7 +963,8 @@ private:
 							Optional<Value> tagV = txnStateStore->readValue(serverTagKeyFor(ssi.tssPairID.get())).get();
 							if (tagV.present()) {
 								MutationRef privatized = m;
-								privatized.removeChecksum();
+								privatized.clearChecksumAndAccumulativeIndex();
+								privatized.setAccumulativeChecksumIndex(accumulativeChecksumIndex);
 								privatized.param1 = maybeTssRange.begin.withPrefix(systemKeys.begin, arena);
 								privatized.param2 =
 								    keyAfter(maybeTssRange.begin, arena).withPrefix(systemKeys.begin, arena);
@@ -1144,7 +1162,8 @@ private:
 		// send private mutation to SS to notify that it no longer has a tss pair
 		if (Optional<Value> tagV = txnStateStore->readValue(serverTagKeyFor(ssId)).get(); tagV.present()) {
 			MutationRef privatized = m;
-			privatized.removeChecksum();
+			privatized.clearChecksumAndAccumulativeIndex();
+			privatized.setAccumulativeChecksumIndex(accumulativeChecksumIndex);
 			privatized.param1 = m.param1.withPrefix(systemKeys.begin, arena);
 			privatized.param2 = m.param2.withPrefix(systemKeys.begin, arena);
 			TraceEvent(SevDebug, "SendingPrivatized_ClearTSSMapping", dbgid).detail("M", privatized);
@@ -1172,7 +1191,8 @@ private:
 				    tagV.present()) {
 
 					MutationRef privatized = m;
-					privatized.removeChecksum();
+					privatized.clearChecksumAndAccumulativeIndex();
+					privatized.setAccumulativeChecksumIndex(accumulativeChecksumIndex);
 					privatized.param1 = m.param1.withPrefix(systemKeys.begin, arena);
 					privatized.param2 = m.param2.withPrefix(systemKeys.begin, arena);
 					TraceEvent(SevDebug, "SendingPrivatized_ClearTSSQuarantine", dbgid).detail("M", privatized);
@@ -1252,7 +1272,8 @@ private:
 				toCommit->addTags(allTags);
 
 				MutationRef privatized;
-				privatized.removeChecksum();
+				privatized.clearChecksumAndAccumulativeIndex();
+				privatized.setAccumulativeChecksumIndex(accumulativeChecksumIndex);
 				privatized.type = MutationRef::ClearRange;
 				privatized.param1 = systemKeys.begin.withSuffix(std::max(range.begin, subspace.begin), arena);
 				if (range.end < subspace.end) {

--- a/fdbserver/ClusterRecovery.actor.cpp
+++ b/fdbserver/ClusterRecovery.actor.cpp
@@ -200,11 +200,13 @@ ACTOR Future<Void> newCommitProxies(Reference<ClusterRecoveryData> self, Recruit
 		req.recoveryTransactionVersion = self->recoveryTransactionVersion;
 		req.firstProxy = i == 0;
 		req.encryptMode = getEncryptionAtRest(self->configuration);
+		req.commitProxyIndex = i;
 		TraceEvent("CommitProxyReplies", self->dbgid)
 		    .detail("WorkerID", recr.commitProxies[i].id())
 		    .detail("RecoveryTxnVersion", self->recoveryTransactionVersion)
 		    .detail("EncryptMode", req.encryptMode.toString())
-		    .detail("FirstProxy", req.firstProxy ? "True" : "False");
+		    .detail("FirstProxy", req.firstProxy ? "True" : "False")
+		    .detail("CommitProxyIndex", req.commitProxyIndex);
 		initializationReplies.push_back(
 		    transformErrors(throwErrorOr(recr.commitProxies[i].commitProxy.getReplyUnlessFailedFor(
 		                        req, SERVER_KNOBS->TLOG_TIMEOUT, SERVER_KNOBS->MASTER_FAILURE_SLOPE_DURING_RECOVERY)),

--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -40,6 +40,7 @@
 #include "fdbclient/TransactionLineage.h"
 #include "fdbrpc/TenantInfo.h"
 #include "fdbrpc/sim_validation.h"
+#include "fdbserver/AccumulativeChecksumUtil.h"
 #include "fdbserver/ApplyMetadataMutation.h"
 #include "fdbserver/ConflictSet.h"
 #include "fdbserver/DataDistributorInterface.h"
@@ -550,6 +551,10 @@ ACTOR Future<Void> addBackupMutations(ProxyCommitData* self,
 			backupMutation.param2 = val.substr(
 			    part * CLIENT_KNOBS->MUTATION_BLOCK_SIZE,
 			    std::min(val.size() - part * CLIENT_KNOBS->MUTATION_BLOCK_SIZE, CLIENT_KNOBS->MUTATION_BLOCK_SIZE));
+			if (CLIENT_KNOBS->ENABLE_ACCUMULATIVE_CHECKSUM) {
+				backupMutation.setAccumulativeChecksumIndex(
+				    getCommitProxyAccumulativeChecksumIndex(self->commitProxyIndex));
+			}
 
 			// Write the last part of the mutation to the serialization, if the buffer is not defined
 			if (!partBuffer) {
@@ -1898,6 +1903,10 @@ ACTOR Future<Void> assignMutationsToStorageServers(CommitBatchContext* self) {
 			}
 
 			state MutationRef m = (*pMutations)[mutationNum];
+			if (CLIENT_KNOBS->ENABLE_ACCUMULATIVE_CHECKSUM) {
+				m.setAccumulativeChecksumIndex(
+				    getCommitProxyAccumulativeChecksumIndex(self->pProxyCommitData->commitProxyIndex));
+			}
 			state Optional<MutationRef> encryptedMutation =
 			    encryptedMutations->size() > 0 ? (*encryptedMutations)[mutationNum] : Optional<MutationRef>();
 			state Arena arena;
@@ -2114,37 +2123,46 @@ ACTOR Future<Void> postResolution(CommitBatchContext* self) {
 		                        &self->computeStart));
 	}
 
-	buildIdempotencyIdMutations(self->trs,
-	                            self->idempotencyKVBuilder,
-	                            self->commitVersion,
-	                            self->committed,
-	                            ConflictBatch::TransactionCommitted,
-	                            self->locked,
-	                            [&](const KeyValue& kv) {
-		                            MutationRef idempotencyIdSet;
-		                            idempotencyIdSet.type = MutationRef::Type::SetValue;
-		                            idempotencyIdSet.param1 = kv.key;
-		                            idempotencyIdSet.param2 = kv.value;
-		                            auto& tags = pProxyCommitData->tagsForKey(kv.key);
-		                            self->toCommit.addTags(tags);
-		                            if (self->pProxyCommitData->encryptMode.isEncryptionEnabled()) {
-			                            CODE_PROBE(true, "encrypting idempotency mutation");
-			                            EncryptCipherDomainId domainId =
-			                                getEncryptDetailsFromMutationRef(self->pProxyCommitData, idempotencyIdSet);
-			                            MutationRef encryptedMutation = idempotencyIdSet.encrypt(
-			                                self->cipherKeys, domainId, self->arena, BlobCipherMetrics::TLOG);
-			                            ASSERT(encryptedMutation.isEncrypted());
-			                            self->toCommit.writeTypedMessage(encryptedMutation);
-		                            } else {
-			                            self->toCommit.writeTypedMessage(idempotencyIdSet);
-		                            }
-	                            });
+	buildIdempotencyIdMutations(
+	    self->trs,
+	    self->idempotencyKVBuilder,
+	    self->commitVersion,
+	    self->committed,
+	    ConflictBatch::TransactionCommitted,
+	    self->locked,
+	    [&](const KeyValue& kv) {
+		    MutationRef idempotencyIdSet;
+		    idempotencyIdSet.type = MutationRef::Type::SetValue;
+		    idempotencyIdSet.param1 = kv.key;
+		    idempotencyIdSet.param2 = kv.value;
+		    if (CLIENT_KNOBS->ENABLE_ACCUMULATIVE_CHECKSUM) {
+			    idempotencyIdSet.setAccumulativeChecksumIndex(
+			        getCommitProxyAccumulativeChecksumIndex(self->pProxyCommitData->commitProxyIndex));
+		    }
+		    auto& tags = pProxyCommitData->tagsForKey(kv.key);
+		    self->toCommit.addTags(tags);
+		    if (self->pProxyCommitData->encryptMode.isEncryptionEnabled()) {
+			    CODE_PROBE(true, "encrypting idempotency mutation");
+			    EncryptCipherDomainId domainId =
+			        getEncryptDetailsFromMutationRef(self->pProxyCommitData, idempotencyIdSet);
+			    MutationRef encryptedMutation =
+			        idempotencyIdSet.encrypt(self->cipherKeys, domainId, self->arena, BlobCipherMetrics::TLOG);
+			    ASSERT(encryptedMutation.isEncrypted());
+			    self->toCommit.writeTypedMessage(encryptedMutation);
+		    } else {
+			    self->toCommit.writeTypedMessage(idempotencyIdSet);
+		    }
+	    });
 	state int i = 0;
 	for (i = 0; i < pProxyCommitData->idempotencyClears.size(); i++) {
 		auto& tags = pProxyCommitData->tagsForKey(pProxyCommitData->idempotencyClears[i].param1);
 		self->toCommit.addTags(tags);
 		// We already have an arena with an appropriate lifetime handy
 		Arena& arena = pProxyCommitData->idempotencyClears.arena();
+		if (CLIENT_KNOBS->ENABLE_ACCUMULATIVE_CHECKSUM) {
+			pProxyCommitData->idempotencyClears[i].setAccumulativeChecksumIndex(
+			    getCommitProxyAccumulativeChecksumIndex(self->pProxyCommitData->commitProxyIndex));
+		}
 		WriteMutationRefVar var = wait(writeMutation(
 		    self, SYSTEM_KEYSPACE_ENCRYPT_DOMAIN_ID, &pProxyCommitData->idempotencyClears[i], nullptr, &arena));
 		ASSERT(std::holds_alternative<MutationRef>(var));
@@ -3601,7 +3619,8 @@ ACTOR Future<Void> commitProxyServerCore(CommitProxyInterface proxy,
                                          bool firstProxy,
                                          std::string whitelistBinPaths,
                                          EncryptionAtRestMode encryptMode,
-                                         bool provisional) {
+                                         bool provisional,
+                                         uint16_t commitProxyIndex) {
 	state ProxyCommitData commitData(proxy.id(),
 	                                 master,
 	                                 proxy.getConsistentReadVersion,
@@ -3610,7 +3629,8 @@ ACTOR Future<Void> commitProxyServerCore(CommitProxyInterface proxy,
 	                                 db,
 	                                 firstProxy,
 	                                 encryptMode,
-	                                 provisional);
+	                                 provisional,
+	                                 commitProxyIndex);
 
 	state Future<Sequence> sequenceFuture = (Sequence)0;
 	state PromiseStream<std::pair<std::vector<CommitTransactionRequest>, int>> batchedCommits;
@@ -3819,7 +3839,8 @@ ACTOR Future<Void> commitProxyServer(CommitProxyInterface proxy,
 		                                                req.firstProxy,
 		                                                whitelistBinPaths,
 		                                                req.encryptMode,
-		                                                proxy.provisional);
+		                                                proxy.provisional,
+		                                                req.commitProxyIndex);
 		wait(core || updateLocalDbInfo(db, localDb, req.recoveryCount, proxy));
 	} catch (Error& e) {
 		TraceEvent("CommitProxyTerminated", proxy.id()).errorUnsuppressed(e);

--- a/fdbserver/include/fdbserver/AccumulativeChecksumUtil.h
+++ b/fdbserver/include/fdbserver/AccumulativeChecksumUtil.h
@@ -1,0 +1,34 @@
+/*
+ * AccumulativeChecksumUtil.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ACCUMULATIVECHECKSUMUTIL_H
+#define ACCUMULATIVECHECKSUMUTIL_H
+#pragma once
+
+#include "fdbclient/CommitTransaction.h"
+
+static const uint16_t invalidAccumulativeChecksumIndex = 0;
+static const uint16_t resolverAccumulativeChecksumIndex = 2;
+
+uint16_t getCommitProxyAccumulativeChecksumIndex(uint16_t commitProxyIndex);
+
+bool validateAccumulativeChecksumIndexAtStorageServer(MutationRef m);
+
+#endif

--- a/fdbserver/include/fdbserver/AccumulativeChecksumUtil.h
+++ b/fdbserver/include/fdbserver/AccumulativeChecksumUtil.h
@@ -29,6 +29,4 @@ static const uint16_t resolverAccumulativeChecksumIndex = 2;
 
 uint16_t getCommitProxyAccumulativeChecksumIndex(uint16_t commitProxyIndex);
 
-bool validateAccumulativeChecksumIndexAtStorageServer(MutationRef m);
-
 #endif

--- a/fdbserver/include/fdbserver/ProxyCommitData.actor.h
+++ b/fdbserver/include/fdbserver/ProxyCommitData.actor.h
@@ -218,6 +218,7 @@ struct ProxyCommitData {
 	KeyRangeMap<bool> cacheInfo;
 	std::map<Key, ApplyMutationsData> uid_applyMutationsData;
 	bool firstProxy;
+	uint16_t commitProxyIndex; // decided when the cluster controller recruits commit proxies
 	double lastCoalesceTime;
 	bool locked;
 	Optional<Value> metadataVersion;
@@ -323,7 +324,8 @@ struct ProxyCommitData {
 	                Reference<AsyncVar<ServerDBInfo> const> db,
 	                bool firstProxy,
 	                EncryptionAtRestMode encryptMode,
-	                bool provisional)
+	                bool provisional,
+	                uint16_t commitProxyIndex)
 	  : dbgid(dbgid), commitBatchesMemBytesCount(0),
 	    stats(dbgid, &version, &committedVersion, &commitBatchesMemBytesCount, &tenantMap), master(master),
 	    logAdapter(nullptr), txnStateStore(nullptr), committedVersion(recoveryTransactionVersion),
@@ -334,7 +336,7 @@ struct ProxyCommitData {
 	    cx(openDBOnServer(db, TaskPriority::DefaultEndpoint, LockAware::True)), db(db),
 	    singleKeyMutationEvent("SingleKeyMutation"_sr), lastTxsPop(0), popRemoteTxs(false), lastStartCommit(0),
 	    lastCommitLatency(SERVER_KNOBS->REQUIRED_MIN_RECOVERY_DURATION), lastCommitTime(0), lastMasterReset(now()),
-	    lastResolverReset(now()) {
+	    lastResolverReset(now()), commitProxyIndex(commitProxyIndex) {
 		commitComputePerOperation.resize(SERVER_KNOBS->PROXY_COMPUTE_BUCKETS, 0.0);
 	}
 };

--- a/fdbserver/include/fdbserver/WorkerInterface.actor.h
+++ b/fdbserver/include/fdbserver/WorkerInterface.actor.h
@@ -737,11 +737,19 @@ struct InitializeCommitProxyRequest {
 	bool firstProxy;
 	ReplyPromise<CommitProxyInterface> reply;
 	EncryptionAtRestMode encryptMode;
+	uint16_t commitProxyIndex;
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(
-		    ar, master, masterLifetime, recoveryCount, recoveryTransactionVersion, firstProxy, reply, encryptMode);
+		serializer(ar,
+		           master,
+		           masterLifetime,
+		           recoveryCount,
+		           recoveryTransactionVersion,
+		           firstProxy,
+		           reply,
+		           encryptMode,
+		           commitProxyIndex);
 	}
 };
 

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -11023,13 +11023,7 @@ ACTOR Future<Void> update(StorageServer* data, bool* pReceivedUpdate) {
 							msg = msg.decrypt(cipherKeys.get(), eager.arena, BlobCipherMetrics::TLOG);
 						}
 					} else {
-						if (!msg.validateChecksum() || !validateAccumulativeChecksumIndexAtStorageServer(msg)) {
-							TraceEvent(SevError, "ValidateChecksumOrAcsIndexError", data->thisServerID)
-							    .detail("Mutation", msg)
-							    .detail("ResolverGeneratePrivateMutation",
-							            SERVER_KNOBS->PROXY_USE_RESOLVER_PRIVATE_MUTATIONS);
-							ASSERT(false);
-						}
+						ASSERT(msg.validateChecksum());
 					}
 					// TraceEvent(SevDebug, "SSReadingLog", data->thisServerID).detail("Mutation", msg);
 

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -70,8 +70,6 @@
 #include "fdbrpc/sim_validation.h"
 #include "fdbrpc/Smoother.h"
 #include "fdbrpc/Stats.h"
-#include "fdbserver/AccumulativeChecksumUtil.h"
-#include "fdbserver/DataDistribution.actor.h"
 #include "fdbserver/FDBExecHelper.actor.h"
 #include "fdbclient/GetEncryptCipherKeys.h"
 #include "fdbclient/IKeyValueStore.h"

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -70,6 +70,8 @@
 #include "fdbrpc/sim_validation.h"
 #include "fdbrpc/Smoother.h"
 #include "fdbrpc/Stats.h"
+#include "fdbserver/AccumulativeChecksumUtil.h"
+#include "fdbserver/DataDistribution.actor.h"
 #include "fdbserver/FDBExecHelper.actor.h"
 #include "fdbclient/GetEncryptCipherKeys.h"
 #include "fdbclient/IKeyValueStore.h"
@@ -11021,7 +11023,13 @@ ACTOR Future<Void> update(StorageServer* data, bool* pReceivedUpdate) {
 							msg = msg.decrypt(cipherKeys.get(), eager.arena, BlobCipherMetrics::TLOG);
 						}
 					} else {
-						ASSERT(msg.validateChecksum());
+						if (!msg.validateChecksum() || !validateAccumulativeChecksumIndexAtStorageServer(msg)) {
+							TraceEvent(SevError, "ValidateChecksumOrAcsIndexError", data->thisServerID)
+							    .detail("Mutation", msg)
+							    .detail("ResolverGeneratePrivateMutation",
+							            SERVER_KNOBS->PROXY_USE_RESOLVER_PRIVATE_MUTATIONS);
+							ASSERT(false);
+						}
 					}
 					// TraceEvent(SevDebug, "SSReadingLog", data->thisServerID).detail("Mutation", msg);
 


### PR DESCRIPTION
Cherry-pick ACS Index (PR https://github.com/apple/foundationdb/pull/11225) to release-7.3 to guarantee the downgrade compatibility from 7.4, similar to MutationChecksum feature.

Feature on:
  20240405-003157-zhewang-23b09646a07dc913           compressed=True data_size=34888425 duration=4969776 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:29:34 sanity=False started=100000 stopped=20240405-020131 submitted=20240405-003157 timeout=5400 username=zhewang


Feature off:
  20240405-003006-zhewang-ada6b9ade0623502           compressed=True data_size=34888438 duration=5580015 ended=100000 fail=2 fail_fast=10 max_runs=100000 pass=99998 priority=100 remaining=0 runtime=1:34:46 sanity=False started=100000 stopped=20240405-020452 submitted=20240405-003006 timeout=5400 username=zhewang






# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
