### PR TITLE
Disable simulation recovery check (draft)

### DIFF
--- a/fdbserver/ClusterRecovery.actor.cpp
+++ b/fdbserver/ClusterRecovery.actor.cpp
@@ -1417,7 +1417,9 @@ ACTOR Future<Void> recoverFrom(Reference<ClusterRecoveryData> self,
 		updateConfigForForcedRecovery(self, initialConfChanges);
 	}
 
-	debug_checkMaxRestoredVersion(UID(), self->lastEpochEnd, "DBRecovery");
+	if (!SERVER_KNOBS->ENABLE_VERSION_VECTOR) {
+		debug_checkMaxRestoredVersion(UID(), self->lastEpochEnd, "DBRecovery");
+	}
 
 	// Ordinarily we pass through this loop once and recover.  We go around the loop if recovery stalls for more than a
 	// second, a provisional master is initialized, and an "emergency transaction" is submitted that might change the


### PR DESCRIPTION
When running in simulation mode, version vector recovery logic is such that the last epoch in the previous version is the minimum committed version of all TLogs. But the latest commit version recorded by the commit proxy, used in simulation tests, may be a higher number, if one TL is advancing faster than another. Either recovery or the test will need to change.

This is a draft placeholder PR for the problem.