### PR TITLE
C workload bindings

### DIFF
--- a/bindings/c/foundationdb/CWorkload.h
+++ b/bindings/c/foundationdb/CWorkload.h
@@ -1,0 +1,91 @@
+/*
+ * CWorkload.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#ifndef C_WORKLOAD_H
+#define C_WORKLOAD_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+typedef struct FDB_future FDBFuture;
+typedef struct FDB_result FDBResult;
+typedef struct FDB_database FDBDatabase;
+typedef struct FDB_transaction FDBTransaction;
+
+typedef struct FDB_promise FDBPromise;
+typedef struct FDB_workload FDBWorkload;
+typedef struct FDB_workloadContext FDBWorkloadContext;
+
+typedef enum FDBSeverity {
+	FDBSeverity_Debug,
+	FDBSeverity_Info,
+	FDBSeverity_Warn,
+	FDBSeverity_WarnAlways,
+	FDBSeverity_Error,
+} FDBSeverity;
+
+typedef struct CVector {
+    int n;
+    void* elements;
+} CVector;
+
+typedef struct CStringPair {
+	const char* key;
+	const char* val;
+} CStringPair;
+
+typedef struct CMetric {
+	const char* name;
+	const char* format_code;
+	double value;
+	bool averaged;
+} CMetric;
+
+typedef struct BridgeToClient {
+    FDBWorkload* workload;
+    void (*setup)(FDBWorkload*, FDBDatabase*, FDBPromise*);
+    void (*start)(FDBWorkload*, FDBDatabase*, FDBPromise*);
+    void (*check)(FDBWorkload*, FDBDatabase*, FDBPromise*);
+    CVector (*getMetrics)(FDBWorkload*);
+    double (*getCheckTimeout)(FDBWorkload*);
+    void (*free)(FDBWorkload*);
+} BridgeToClient;
+
+typedef struct BridgeToServer {
+	struct ContextImpl {
+		void (*trace)(FDBWorkloadContext* context, FDBSeverity severity, const char* name, CVector vec);
+		uint64_t (*getProcessID)(FDBWorkloadContext* context);
+		void (*setProcessID)(FDBWorkloadContext* context, uint64_t processID);
+		double (*now)(FDBWorkloadContext* context);
+		uint32_t (*rnd)(FDBWorkloadContext* context);
+		char* (*getOption)(FDBWorkloadContext* context, const char* name, const char* defaultValue);
+		int (*clientId)(FDBWorkloadContext* context);
+		int (*clientCount)(FDBWorkloadContext* context);
+		int64_t (*sharedRandomNumber)(FDBWorkloadContext* context);
+	} context;
+
+	struct PromiseImpl {
+		void (*send)(FDBPromise* promise, bool value);
+		void (*free)(FDBPromise* promise);
+	} promise;
+} BridgeToServer;
+
+#endif

--- a/bindings/c/foundationdb/CWorkload.h
+++ b/bindings/c/foundationdb/CWorkload.h
@@ -43,8 +43,8 @@ typedef enum FDBSeverity {
 } FDBSeverity;
 
 typedef struct CVector {
-    int n;
-    void* elements;
+	int n;
+	void* elements;
 } CVector;
 
 typedef struct CStringPair {
@@ -60,13 +60,13 @@ typedef struct CMetric {
 } CMetric;
 
 typedef struct BridgeToClient {
-    FDBWorkload* workload;
-    void (*setup)(FDBWorkload*, FDBDatabase*, FDBPromise*);
-    void (*start)(FDBWorkload*, FDBDatabase*, FDBPromise*);
-    void (*check)(FDBWorkload*, FDBDatabase*, FDBPromise*);
-    CVector (*getMetrics)(FDBWorkload*);
-    double (*getCheckTimeout)(FDBWorkload*);
-    void (*free)(FDBWorkload*);
+	FDBWorkload* workload;
+	void (*setup)(FDBWorkload*, FDBDatabase*, FDBPromise*);
+	void (*start)(FDBWorkload*, FDBDatabase*, FDBPromise*);
+	void (*check)(FDBWorkload*, FDBDatabase*, FDBPromise*);
+	CVector (*getMetrics)(FDBWorkload*);
+	double (*getCheckTimeout)(FDBWorkload*);
+	void (*free)(FDBWorkload*);
 } BridgeToClient;
 
 typedef struct BridgeToServer {

--- a/bindings/c/foundationdb/CWorkload.h
+++ b/bindings/c/foundationdb/CWorkload.h
@@ -25,14 +25,11 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-typedef struct FDB_future FDBFuture;
-typedef struct FDB_result FDBResult;
 typedef struct FDB_database FDBDatabase;
-typedef struct FDB_transaction FDBTransaction;
-
-typedef struct FDB_promise FDBPromise;
-typedef struct FDB_workload FDBWorkload;
-typedef struct FDB_workloadContext FDBWorkloadContext;
+typedef struct Opaque_promise OpaquePromise;
+typedef struct Opaque_workload OpaqueWorkload;
+typedef struct Opaque_workloadContext OpaqueWorkloadContext;
+typedef struct Opaque_metrics OpaqueMetrics;
 
 typedef enum FDBSeverity {
 	FDBSeverity_Debug,
@@ -42,84 +39,56 @@ typedef enum FDBSeverity {
 	FDBSeverity_Error,
 } FDBSeverity;
 
-typedef struct CVector {
-	int n;
-	void* elements;
-} CVector;
-
-typedef struct CStringPair {
+typedef struct FDBStringPair {
 	const char* key;
 	const char* val;
-} CStringPair;
+} FDBStringPair;
 
-typedef struct CMetric {
-	const char* name;
-	const char* format_code;
-	double value;
-	bool averaged;
-} CMetric;
+typedef struct FDBMetric {
+	const char* key;
+	const char* fmt;
+	double val;
+	bool avg;
+} FDBMetric;
 
-/**
- * BridgeToClient - A structure the client has to pass to the fdbserver so it
- * can interact with the workload it defines.
- *
- * This structure includes:
- * - An opaque pointer to the client-defined workload.
- * - A set of function pointers that operate on the workload, with the workload
- *   itself as the first parameter (emulating C++ method calls).
- *
- * All methods, except `free`, directly map to corresponding C++ methods in
- * `CppWorkload.h`, documented here: https://apple.github.io/foundationdb/client-testing.html.
- *
- * Notes:
- * - `FDBWorkload::init` is not defined in this struct, initialization should be
- *   done during workload creation.
- * - The `FDBWorkload` pointer passed in each method corresponds to the pointer
- *   the client sets in `BridgeToClient::workload`, allowing it to be safely cast
- *   back to its original type.
- */
-typedef struct BridgeToClient {
-	FDBWorkload* workload;
-	void (*setup)(FDBWorkload*, FDBDatabase*, FDBPromise*);
-	void (*start)(FDBWorkload*, FDBDatabase*, FDBPromise*);
-	void (*check)(FDBWorkload*, FDBDatabase*, FDBPromise*);
-	CVector (*getMetrics)(FDBWorkload*);
-	double (*getCheckTimeout)(FDBWorkload*);
-	void (*free)(FDBWorkload*);
-} BridgeToClient;
+typedef struct FDBString {
+	const char* inner;
+	void (*free)(const char* inner);
+} FDBString;
 
-/**
- * BridgeToServer - A structure the client will receive at initialisation
- * to interact with the FDBContext and FDBPromise.
- *
- * Each C workload must define the following entry point:
- * extern BridgeToClient workloadInstantiate(char* name, FDBWorkloadContext* ctx, BridgeToServer bridge);
- * This allows the fdbserver to pass to the workload's name, context and bridge.
- * A workload instance must be created, initialized and returned as a pointer
- * in the BridgeToClient structure. The context and bridge should be stored, as
- * they cannot be accessed otherwise
- *
- * The ContextImpl and PromiseImpl sub-structures store the function pointers
- * corresponding to the C++ methods of FDBContext and FDBPromise respectively,
- * defined in CppWorkload.h
- */
-typedef struct BridgeToServer {
-	struct ContextImpl {
-		void (*trace)(FDBWorkloadContext* context, FDBSeverity severity, const char* name, CVector vec);
-		uint64_t (*getProcessID)(FDBWorkloadContext* context);
-		void (*setProcessID)(FDBWorkloadContext* context, uint64_t processID);
-		double (*now)(FDBWorkloadContext* context);
-		uint32_t (*rnd)(FDBWorkloadContext* context);
-		char* (*getOption)(FDBWorkloadContext* context, const char* name, const char* defaultValue);
-		int (*clientId)(FDBWorkloadContext* context);
-		int (*clientCount)(FDBWorkloadContext* context);
-		int64_t (*sharedRandomNumber)(FDBWorkloadContext* context);
-	} context;
+typedef struct FDBMetrics {
+	OpaqueMetrics* inner;
+	void (*reserve)(OpaqueMetrics* inner, int n);
+	void (*push)(OpaqueMetrics* inner, FDBMetric val);
+} FDBMetrics;
 
-	struct PromiseImpl {
-		void (*send)(FDBPromise* promise, bool value);
-		void (*free)(FDBPromise* promise);
-	} promise;
-} BridgeToServer;
+typedef struct FDBPromise {
+	OpaquePromise* inner;
+	void (*send)(OpaquePromise* inner, bool val);
+	void (*free)(OpaquePromise* inner);
+} FDBPromise;
+
+typedef struct FDBWorkloadContext {
+	OpaqueWorkloadContext* inner;
+	void (*trace)(OpaqueWorkloadContext* inner, FDBSeverity sev, const char* name, const FDBStringPair* details, int n);
+	uint64_t (*getProcessID)(OpaqueWorkloadContext* inner);
+	void (*setProcessID)(OpaqueWorkloadContext* inner, uint64_t processID);
+	double (*now)(OpaqueWorkloadContext* inner);
+	uint32_t (*rnd)(OpaqueWorkloadContext* inner);
+	FDBString (*getOption)(OpaqueWorkloadContext* inner, const char* name, const char* defaultValue);
+	int (*clientId)(OpaqueWorkloadContext* inner);
+	int (*clientCount)(OpaqueWorkloadContext* inner);
+	int64_t (*sharedRandomNumber)(OpaqueWorkloadContext* inner);
+} FDBWorkloadContext;
+
+typedef struct FDBWorkload {
+	OpaqueWorkload* inner;
+	void (*setup)(OpaqueWorkload* inner, FDBDatabase* db, FDBPromise done);
+	void (*start)(OpaqueWorkload* inner, FDBDatabase* db, FDBPromise done);
+	void (*check)(OpaqueWorkload* inner, FDBDatabase* db, FDBPromise done);
+	void (*getMetrics)(OpaqueWorkload* inner, FDBMetrics out);
+	double (*getCheckTimeout)(OpaqueWorkload* inner);
+	void (*free)(OpaqueWorkload* inner);
+} FDBWorkload;
 
 #endif

--- a/bindings/c/foundationdb/CWorkload.h
+++ b/bindings/c/foundationdb/CWorkload.h
@@ -31,6 +31,8 @@ typedef struct Opaque_workload OpaqueWorkload;
 typedef struct Opaque_workloadContext OpaqueWorkloadContext;
 typedef struct Opaque_metrics OpaqueMetrics;
 
+// Log severity levels.
+// FDBSeverity_Error automatically stops the simulation.
 typedef enum FDBSeverity {
 	FDBSeverity_Debug,
 	FDBSeverity_Info,
@@ -39,11 +41,15 @@ typedef enum FDBSeverity {
 	FDBSeverity_Error,
 } FDBSeverity;
 
+// Key-value pair for logging additional details.
 typedef struct FDBStringPair {
 	const char* key;
 	const char* val;
 } FDBStringPair;
 
+// Metric entry for simulation statistics.
+// Values are either averaged or summed across clients based on the `avg` flag.
+// `fmt` is used to format the value, defaults to "%.3g" if null.
 typedef struct FDBMetric {
 	const char* key;
 	const char* fmt;
@@ -51,42 +57,74 @@ typedef struct FDBMetric {
 	bool avg;
 } FDBMetric;
 
+// Wrapper around an owned C++ string.
+// The `free` function must be called on `inner` before releasing the string.
 typedef struct FDBString {
 	const char* inner;
 	void (*free)(const char* inner);
 } FDBString;
 
+// Wrapper around a borrowed C++ vector<FDBMetric>.
 typedef struct FDBMetrics {
 	OpaqueMetrics* inner;
 	void (*reserve)(OpaqueMetrics* inner, int n);
 	void (*push)(OpaqueMetrics* inner, FDBMetric val);
 } FDBMetrics;
 
+// Wrapper around an owned C++ GenericPromise<bool>
+// Calling `send` resolves the promise (the value is meaningless).
+// Calling `free` before resolving the promise triggers a "broken promise" error.
 typedef struct FDBPromise {
 	OpaquePromise* inner;
 	void (*send)(OpaquePromise* inner, bool val);
 	void (*free)(OpaquePromise* inner);
 } FDBPromise;
 
+// Wrapper around a borrowed ExternalWorkload's context
+// All pointer-based arguments are borrowed and managed by the workload.
 typedef struct FDBWorkloadContext {
 	OpaqueWorkloadContext* inner;
+	// Log a message with severity and optional details.
+	// `details` is an array of key-value pairs, and `n` specifies the array size.
 	void (*trace)(OpaqueWorkloadContext* inner, FDBSeverity sev, const char* name, const FDBStringPair* details, int n);
 	uint64_t (*getProcessID)(OpaqueWorkloadContext* inner);
 	void (*setProcessID)(OpaqueWorkloadContext* inner, uint64_t processID);
+	// Return the current simulated time in seconds (starts at zero)
 	double (*now)(OpaqueWorkloadContext* inner);
 	uint32_t (*rnd)(OpaqueWorkloadContext* inner);
+	// Get an option by name, returning `defaultValue` if the option is not found.
+	// Getting an option consumes it, querying it again returns the empty string.
 	FDBString (*getOption)(OpaqueWorkloadContext* inner, const char* name, const char* defaultValue);
 	int (*clientId)(OpaqueWorkloadContext* inner);
 	int (*clientCount)(OpaqueWorkloadContext* inner);
 	int64_t (*sharedRandomNumber)(OpaqueWorkloadContext* inner);
 } FDBWorkloadContext;
 
+// Interface for a workload implementation in C.
+// Workloads must expose an entry point named `workloadCFactory`:
+// extern FDBWorkload workloadCFactory(const char* name, FDBWorkloadContext context);
+// This function must return a valid instance of the FDBWorkload structure.
+// A specific implementation can be chosen based on the name passed.
+// The client C workload must be allocated, initialized and passed as pointer
+// in `inner`. It is advised to store the context alongside the workload as
+// it can't be retrieved it later. No function pointer can be left null.
+//
+// All methods directly map to a corresponding C++ methods in `CppWorkload.h`
+// documented here: https://apple.github.io/foundationdb/client-testing.html.
+//
+// Simulation stages (setup, start, and check) are executed sequentially.
+// A stage finishes when its associated promise is resolved. If a promise
+// is not resolved or freed, the simulation hangs.
+//
+// Workload functions should not block. If an operation must wait for database interaction,
+// it should initiate the action, register a callback, and return.
 typedef struct FDBWorkload {
 	OpaqueWorkload* inner;
 	void (*setup)(OpaqueWorkload* inner, FDBDatabase* db, FDBPromise done);
 	void (*start)(OpaqueWorkload* inner, FDBDatabase* db, FDBPromise done);
 	void (*check)(OpaqueWorkload* inner, FDBDatabase* db, FDBPromise done);
 	void (*getMetrics)(OpaqueWorkload* inner, FDBMetrics out);
+	// The timeout in simulated seconds for the check stage
 	double (*getCheckTimeout)(OpaqueWorkload* inner);
 	void (*free)(OpaqueWorkload* inner);
 } FDBWorkload;

--- a/bindings/c/foundationdb/CppWorkload.h
+++ b/bindings/c/foundationdb/CppWorkload.h
@@ -1,5 +1,5 @@
 /*
- * ClientWorkload.h
+ * CppWorkload.h
  *
  * This source file is part of the FoundationDB open source project
  *
@@ -19,8 +19,8 @@
  */
 
 #pragma once
-#ifndef CLIENT_WORKLOAD_H
-#define CLIENT_WORKLOAD_H
+#ifndef CPP_WORKLOAD_H
+#define CPP_WORKLOAD_H
 #include <string>
 #include <vector>
 #include <functional>
@@ -90,7 +90,7 @@ struct FDBPerfMetric {
 
 class DLLEXPORT FDBWorkload {
 public:
-	virtual std::string description() const = 0;
+	// virtual std::string description() const = 0;
 	virtual bool init(FDBWorkloadContext* context) = 0;
 	virtual void setup(FDBDatabase* db, GenericPromise<bool> done) = 0;
 	virtual void start(FDBDatabase* db, GenericPromise<bool> done) = 0;

--- a/bindings/c/foundationdb/CppWorkload.h
+++ b/bindings/c/foundationdb/CppWorkload.h
@@ -26,10 +26,6 @@
 #include <functional>
 #include <memory>
 
-namespace capi {
-#include "foundationdb/CWorkload.h"
-}
-
 #ifndef DLLEXPORT
 #if defined(_MSC_VER)
 #define DLLEXPORT __declspec(dllexport)
@@ -45,13 +41,7 @@ typedef struct FDB_result FDBResult;
 typedef struct FDB_database FDBDatabase;
 typedef struct FDB_transaction FDBTransaction;
 
-enum class FDBSeverity {
-	Debug = capi::FDBSeverity_Debug,
-	Info = capi::FDBSeverity_Info,
-	Warn = capi::FDBSeverity_Warn,
-	WarnAlways = capi::FDBSeverity_WarnAlways,
-	Error = capi::FDBSeverity_Error,
-};
+enum class FDBSeverity { Debug, Info, Warn, WarnAlways, Error };
 
 class FDBLogger {
 public:

--- a/bindings/c/foundationdb/CppWorkload.h
+++ b/bindings/c/foundationdb/CppWorkload.h
@@ -26,6 +26,10 @@
 #include <functional>
 #include <memory>
 
+namespace capi {
+#include "foundationdb/CWorkload.h"
+}
+
 #ifndef DLLEXPORT
 #if defined(_MSC_VER)
 #define DLLEXPORT __declspec(dllexport)
@@ -41,7 +45,13 @@ typedef struct FDB_result FDBResult;
 typedef struct FDB_database FDBDatabase;
 typedef struct FDB_transaction FDBTransaction;
 
-enum class FDBSeverity { Debug, Info, Warn, WarnAlways, Error };
+enum class FDBSeverity {
+	Debug = capi::FDBSeverity_Debug,
+	Info = capi::FDBSeverity_Info,
+	Warn = capi::FDBSeverity_Warn,
+	WarnAlways = capi::FDBSeverity_WarnAlways,
+	Error = capi::FDBSeverity_Error,
+};
 
 class FDBLogger {
 public:

--- a/bindings/c/test/workloads/CWorkload.c
+++ b/bindings/c/test/workloads/CWorkload.c
@@ -1,0 +1,92 @@
+/*
+ * CWorkload.c
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define FDB_USE_LATEST_API_VERSION
+#include <stdlib.h>
+#include "foundationdb/fdb_c.h"
+#include "foundationdb/ClienWorkload.h"
+
+typedef struct CWorkload {
+    BridgeToServer cpp;
+    FDBWorkloadContext* context;
+} CWorkload;
+
+void workload_setup(CWorkload* workload, FDBDatabase* db, FDBPromise* done) {
+    CStringPair pairs[2] = {
+        {.key = "Layer", .val = "C"},
+        {.key = "Stage", .val = "setup"},
+    };
+    CVector details = { .n = 2, .elements = pairs };
+    workload->cpp.context.trace(workload->context, FDBSeverity_Debug, "Test", details);
+    workload->cpp.promise.send(done, true);
+    workload->cpp.promise.free(done);
+}
+void workload_start(CWorkload* workload, FDBDatabase* db, FDBPromise* done) {
+    CStringPair pairs[2] = {
+        {.key = "Layer", .val = "C"},
+        {.key = "Stage", .val = "start"},
+    };
+    CVector details = { .n = 2, .elements = pairs };
+    workload->cpp.context.trace(workload->context, FDBSeverity_Debug, "Test", details);
+    workload->cpp.promise.send(done, true);
+    workload->cpp.promise.free(done);
+}
+void workload_check(CWorkload* workload, FDBDatabase* db, FDBPromise* done) {
+    CStringPair pairs[2] = {
+        {.key = "Layer", .val = "C"},
+        {.key = "Stage", .val = "check"},
+    };
+    CVector details = { .n = 2, .elements = pairs };
+    workload->cpp.context.trace(workload->context, FDBSeverity_Debug, "Test", details);
+    workload->cpp.promise.send(done, true);
+    workload->cpp.promise.free(done);
+}
+CVector workload_getMetrics(CWorkload* workload) {
+    CVector metrics = { 0 };
+    return metrics;
+}
+double workload_getCheckTimeout(CWorkload* workload) {
+    return 3000.;
+};
+void workload_free(CWorkload* workload) {
+    free(workload);
+}
+
+BridgeToClient workloadInstantiate(const char* name, FDBWorkloadContext* context, BridgeToServer bridgeToServer) {
+    int status = fdb_select_api_version(FDB_API_VERSION);
+    // if (status != 0) {
+    //     fdb_get_error(status);
+    // }
+
+    CWorkload* workload = (CWorkload*)malloc(sizeof(CWorkload));
+    workload->cpp = bridgeToServer;
+    workload->context = context;
+
+    BridgeToClient bridgeToClient = {
+        .workload = workload,
+        .setup = workload_setup,
+        .start = workload_start,
+        .check = workload_check,
+        .getMetrics = workload_getMetrics,
+        .getCheckTimeout = workload_getCheckTimeout,
+        .free = workload_free,
+    };
+    return bridgeToClient;
+}

--- a/bindings/c/test/workloads/CWorkload.c
+++ b/bindings/c/test/workloads/CWorkload.c
@@ -25,96 +25,96 @@
 #include "foundationdb/CWorkload.h"
 
 typedef struct CWorkload {
-    char* name;
-    int cliendId;
-    BridgeToServer cpp;
-    FDBWorkloadContext* context;
+	char* name;
+	int cliendId;
+	BridgeToServer cpp;
+	FDBWorkloadContext* context;
 } CWorkload;
 
 #define GET_CWORKLOAD(NAME, W) CWorkload* NAME = (CWorkload*)W
 
 static void workload_setup(FDBWorkload* raw_workload, FDBDatabase* db, FDBPromise* done) {
-    GET_CWORKLOAD(workload, raw_workload);
-    printf("workload_setup(%s_%d)\n", workload->name, workload->cliendId);
-    CStringPair pairs[2] = {
-        {.key = "Layer", .val = "C"},
-        {.key = "Stage", .val = "setup"},
-    };
-    CVector details = { .n = 2, .elements = pairs };
-    workload->cpp.context.trace(workload->context, FDBSeverity_Debug, "Test", details);
-    workload->cpp.promise.send(done, true);
-    workload->cpp.promise.free(done);
+	GET_CWORKLOAD(workload, raw_workload);
+	printf("workload_setup(%s_%d)\n", workload->name, workload->cliendId);
+	CStringPair pairs[2] = {
+		{ .key = "Layer", .val = "C" },
+		{ .key = "Stage", .val = "setup" },
+	};
+	CVector details = { .n = 2, .elements = pairs };
+	workload->cpp.context.trace(workload->context, FDBSeverity_Debug, "Test", details);
+	workload->cpp.promise.send(done, true);
+	workload->cpp.promise.free(done);
 }
 static void workload_start(FDBWorkload* raw_workload, FDBDatabase* db, FDBPromise* done) {
-    GET_CWORKLOAD(workload, raw_workload);
-    printf("workload_start(%s_%d)\n", workload->name, workload->cliendId);
-    CStringPair pairs[2] = {
-        {.key = "Layer", .val = "C"},
-        {.key = "Stage", .val = "start"},
-    };
-    CVector details = { .n = 2, .elements = pairs };
-    workload->cpp.context.trace(workload->context, FDBSeverity_Debug, "Test", details);
-    workload->cpp.promise.send(done, true);
-    workload->cpp.promise.free(done);
+	GET_CWORKLOAD(workload, raw_workload);
+	printf("workload_start(%s_%d)\n", workload->name, workload->cliendId);
+	CStringPair pairs[2] = {
+		{ .key = "Layer", .val = "C" },
+		{ .key = "Stage", .val = "start" },
+	};
+	CVector details = { .n = 2, .elements = pairs };
+	workload->cpp.context.trace(workload->context, FDBSeverity_Debug, "Test", details);
+	workload->cpp.promise.send(done, true);
+	workload->cpp.promise.free(done);
 }
 static void workload_check(FDBWorkload* raw_workload, FDBDatabase* db, FDBPromise* done) {
-    GET_CWORKLOAD(workload, raw_workload);
-    printf("workload_check(%s_%d)\n", workload->name, workload->cliendId);
-    CStringPair pairs[2] = {
-        {.key = "Layer", .val = "C"},
-        {.key = "Stage", .val = "check"},
-    };
-    CVector details = { .n = 2, .elements = pairs };
-    workload->cpp.context.trace(workload->context, FDBSeverity_Debug, "Test", details);
-    workload->cpp.promise.send(done, true);
-    workload->cpp.promise.free(done);
+	GET_CWORKLOAD(workload, raw_workload);
+	printf("workload_check(%s_%d)\n", workload->name, workload->cliendId);
+	CStringPair pairs[2] = {
+		{ .key = "Layer", .val = "C" },
+		{ .key = "Stage", .val = "check" },
+	};
+	CVector details = { .n = 2, .elements = pairs };
+	workload->cpp.context.trace(workload->context, FDBSeverity_Debug, "Test", details);
+	workload->cpp.promise.send(done, true);
+	workload->cpp.promise.free(done);
 }
 static CVector workload_getMetrics(FDBWorkload* raw_workload) {
-    GET_CWORKLOAD(workload, raw_workload);
-    printf("workload_getMetrics(%s_%d)\n", workload->name, workload->cliendId);
-    CVector metrics = { 0 };
-    return metrics;
+	GET_CWORKLOAD(workload, raw_workload);
+	printf("workload_getMetrics(%s_%d)\n", workload->name, workload->cliendId);
+	CVector metrics = { 0 };
+	return metrics;
 }
 static double workload_getCheckTimeout(FDBWorkload* raw_workload) {
-    GET_CWORKLOAD(workload, raw_workload);
-    printf("workload_getCheckTimeout(%s_%d)\n", workload->name, workload->cliendId);
-    return 3000.;
+	GET_CWORKLOAD(workload, raw_workload);
+	printf("workload_getCheckTimeout(%s_%d)\n", workload->name, workload->cliendId);
+	return 3000.;
 };
 static void workload_free(FDBWorkload* raw_workload) {
-    GET_CWORKLOAD(workload, raw_workload);
-    printf("workload_free(%s_%d)\n", workload->name, workload->cliendId);
-    free(workload->name);
-    free(workload);
+	GET_CWORKLOAD(workload, raw_workload);
+	printf("workload_free(%s_%d)\n", workload->name, workload->cliendId);
+	free(workload->name);
+	free(workload);
 }
 
 extern BridgeToClient workloadInstantiate(char* name, FDBWorkloadContext* context, BridgeToServer bridgeToServer) {
-    // int status = fdb_select_api_version(FDB_API_VERSION);
-    // if (status != 0) {
-    //     fdb_get_error(status);
-    // }
+	// int status = fdb_select_api_version(FDB_API_VERSION);
+	// if (status != 0) {
+	//     fdb_get_error(status);
+	// }
 
-    char* configValue = bridgeToServer.context.getOption(context, "my_c_option", "null");
-    int clientId = bridgeToServer.context.clientId(context);
-    int clientCount = bridgeToServer.context.clientCount(context);
+	char* configValue = bridgeToServer.context.getOption(context, "my_c_option", "null");
+	int clientId = bridgeToServer.context.clientId(context);
+	int clientCount = bridgeToServer.context.clientCount(context);
 
-    printf("workloadInstantiate(%s, %p)[%d/%d]\n", name, context, client_id, clientCount);
-    printf("my_c_option: %s\n", configValue);
-    free(configValue);
+	printf("workloadInstantiate(%s, %p)[%d/%d]\n", name, context, client_id, clientCount);
+	printf("my_c_option: %s\n", configValue);
+	free(configValue);
 
-    CWorkload* workload = (CWorkload*)malloc(sizeof(CWorkload));
-    workload->name = name;
-    workload->cliendId = clientId;
-    workload->cpp = bridgeToServer;
-    workload->context = context;
+	CWorkload* workload = (CWorkload*)malloc(sizeof(CWorkload));
+	workload->name = name;
+	workload->cliendId = clientId;
+	workload->cpp = bridgeToServer;
+	workload->context = context;
 
-    BridgeToClient bridgeToClient = {
-        .workload = (FDBWorkload*)workload,
-        .setup = workload_setup,
-        .start = workload_start,
-        .check = workload_check,
-        .getMetrics = workload_getMetrics,
-        .getCheckTimeout = workload_getCheckTimeout,
-        .free = workload_free,
-    };
-    return bridgeToClient;
+	BridgeToClient bridgeToClient = {
+		.workload = (FDBWorkload*)workload,
+		.setup = workload_setup,
+		.start = workload_start,
+		.check = workload_check,
+		.getMetrics = workload_getMetrics,
+		.getCheckTimeout = workload_getCheckTimeout,
+		.free = workload_free,
+	};
+	return bridgeToClient;
 }

--- a/bindings/c/test/workloads/CWorkload.c
+++ b/bindings/c/test/workloads/CWorkload.c
@@ -34,7 +34,7 @@ typedef struct CWorkload {
 
 static void workload_setup(OpaqueWorkload* raw_workload, FDBDatabase* db, FDBPromise done) {
 	BIND(raw_workload);
-	printf("workload_setup(%s_%d)\n", this->name, this->cliend_id);
+	printf("c_setup(%s_%d)\n", this->name, this->cliend_id);
 	FDBStringPair details[2] = {
 		{ .key = "Layer", .val = "C" },
 		{ .key = "Stage", .val = "setup" },
@@ -45,7 +45,7 @@ static void workload_setup(OpaqueWorkload* raw_workload, FDBDatabase* db, FDBPro
 }
 static void workload_start(OpaqueWorkload* raw_workload, FDBDatabase* db, FDBPromise done) {
 	BIND(raw_workload);
-	printf("workload_start(%s_%d)\n", this->name, this->cliend_id);
+	printf("c_start(%s_%d)\n", this->name, this->cliend_id);
 	FDBStringPair details[2] = {
 		{ .key = "Layer", .val = "C" },
 		{ .key = "Stage", .val = "start" },
@@ -56,7 +56,7 @@ static void workload_start(OpaqueWorkload* raw_workload, FDBDatabase* db, FDBPro
 }
 static void workload_check(OpaqueWorkload* raw_workload, FDBDatabase* db, FDBPromise done) {
 	BIND(raw_workload);
-	printf("workload_check(%s_%d)\n", this->name, this->cliend_id);
+	printf("c_check(%s_%d)\n", this->name, this->cliend_id);
 	FDBStringPair details[2] = {
 		{ .key = "Layer", .val = "C" },
 		{ .key = "Stage", .val = "check" },
@@ -67,18 +67,18 @@ static void workload_check(OpaqueWorkload* raw_workload, FDBDatabase* db, FDBPro
 }
 static void workload_getMetrics(OpaqueWorkload* raw_workload, FDBMetrics out) {
 	BIND(raw_workload);
-	printf("workload_getMetrics(%s_%d)\n", this->name, this->cliend_id);
+	printf("c_getMetrics(%s_%d)\n", this->name, this->cliend_id);
 	WITH(out, reserve, 8);
 	WITH(out, push, (FDBMetric){ .key = "test", .val = 42., .avg = false });
 }
 static double workload_getCheckTimeout(OpaqueWorkload* raw_workload) {
 	BIND(raw_workload);
-	printf("workload_getCheckTimeout(%s_%d)\n", this->name, this->cliend_id);
+	printf("c_getCheckTimeout(%s_%d)\n", this->name, this->cliend_id);
 	return 3000.;
 };
 static void workload_free(OpaqueWorkload* raw_workload) {
 	BIND(raw_workload);
-	printf("workload_free(%s_%d)\n", this->name, this->cliend_id);
+	printf("c_free(%s_%d)\n", this->name, this->cliend_id);
 	free(this->name);
 	free(this);
 }

--- a/bindings/c/test/workloads/CWorkload.c
+++ b/bindings/c/test/workloads/CWorkload.c
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2013-2022 Apple Inc. and the FoundationDB project authors
+ * Copyright 2013-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -88,11 +88,6 @@ static void workload_free(FDBWorkload* raw_workload) {
 }
 
 extern BridgeToClient workloadInstantiate(char* name, FDBWorkloadContext* context, BridgeToServer bridgeToServer) {
-	// int status = fdb_select_api_version(FDB_API_VERSION);
-	// if (status != 0) {
-	//     fdb_get_error(status);
-	// }
-
 	char* configValue = bridgeToServer.context.getOption(context, "my_c_option", "null");
 	int clientId = bridgeToServer.context.clientId(context);
 	int clientCount = bridgeToServer.context.clientCount(context);

--- a/bindings/c/test/workloads/RustWorkload/Cargo.toml
+++ b/bindings/c/test/workloads/RustWorkload/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "rust-workload"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[build-dependencies]
+bindgen = "0.70.1"

--- a/bindings/c/test/workloads/RustWorkload/build.rs
+++ b/bindings/c/test/workloads/RustWorkload/build.rs
@@ -1,0 +1,16 @@
+use std::{env, path::PathBuf};
+
+fn main() {
+    let c_workload_h = "../../../foundationdb/CWorkload.h";
+    println!("cargo:rerun-if-changed={c_workload_h}");
+
+    let bindings = bindgen::Builder::default()
+        .header(c_workload_h)
+        .generate()
+        .expect("generate bindings");
+
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    bindings
+        .write_to_file(out_path.join("bindings.rs"))
+        .expect(" write bindings");
+}

--- a/bindings/c/test/workloads/RustWorkload/src/bindings.rs
+++ b/bindings/c/test/workloads/RustWorkload/src/bindings.rs
@@ -1,0 +1,221 @@
+mod raw_bindings {
+    #![allow(non_camel_case_types)]
+    #![allow(non_upper_case_globals)]
+    #![allow(non_snake_case)]
+    #![allow(dead_code)]
+    include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+}
+use raw_bindings::*;
+pub use raw_bindings::{
+    BridgeToClient, BridgeToServer, BridgeToServer_ContextImpl, BridgeToServer_PromiseImpl,
+    CVector, FDBDatabase, FDBPromise, FDBWorkload, FDBWorkloadContext,
+};
+
+use std::{
+    ffi::{CStr, CString},
+    os::raw::c_char,
+    str::FromStr,
+};
+
+// -----------------------------------------------------------------------------
+// String conversions
+
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+pub(crate) fn str_from_c(c_buf: *const c_char) -> String {
+    let c_str = unsafe { CStr::from_ptr(c_buf) };
+    c_str.to_str().unwrap().to_string()
+}
+pub(crate) fn str_for_c<T>(buf: T) -> CString
+where
+    T: Into<Vec<u8>>,
+{
+    CString::new(buf).unwrap()
+}
+
+// -----------------------------------------------------------------------------
+// Rust Types
+
+/// A wrapper around a FoundationDB context
+pub struct WorkloadContext {
+    inner: *mut FDBWorkloadContext,
+    bridge: BridgeToServer_ContextImpl,
+}
+
+/// A wrapper around a FoundationDB promise
+pub struct Promise {
+    inner: *mut FDBPromise,
+    bridge: BridgeToServer_PromiseImpl,
+}
+
+/// A single metric entry
+pub struct Metric {
+    /// The name of the metric
+    pub name: String,
+    /// The value of the metric
+    pub value: f64,
+    /// Indicates if the value represents an average or not
+    pub averaged: bool,
+    /// C++ string formatter of the metric
+    pub format_code: Option<String>,
+}
+
+/// Indicates the severity of a FoundationDB log entry
+#[derive(Clone, Copy)]
+#[repr(u32)]
+pub enum Severity {
+    /// debug
+    Debug = FDBSeverity_FDBSeverity_Debug,
+    /// info
+    Info = FDBSeverity_FDBSeverity_Info,
+    /// warn
+    Warn = FDBSeverity_FDBSeverity_Warn,
+    /// warn always
+    WarnAlways = FDBSeverity_FDBSeverity_WarnAlways,
+    /// error, this severity automatically breaks execution
+    Error = FDBSeverity_FDBSeverity_Error,
+}
+
+// -----------------------------------------------------------------------------
+
+impl WorkloadContext {
+    pub(crate) fn new(inner: *mut FDBWorkloadContext, bridge: BridgeToServer_ContextImpl) -> Self {
+        Self { inner, bridge }
+    }
+    /// Add a log entry in the FoundationDB logs
+    pub fn trace<S>(&self, severity: Severity, name: S, details: &[(&str, &str)])
+    where
+        S: Into<Vec<u8>>,
+    {
+        let name = str_for_c(name);
+        let details_storage = details
+            .iter()
+            .map(|(key, val)| {
+                let key = str_for_c(*key);
+                let val = str_for_c(*val);
+                (key, val)
+            })
+            .collect::<Vec<_>>();
+        let details = details_storage
+            .iter()
+            .map(|(key, val)| CStringPair {
+                key: key.as_ptr(),
+                val: val.as_ptr(),
+            })
+            .collect::<Vec<_>>();
+        unsafe {
+            self.bridge.trace.unwrap_unchecked()(
+                self.inner,
+                severity as FDBSeverity,
+                name.as_ptr(),
+                CVector {
+                    elements: details.as_ptr() as *mut _,
+                    n: details.len() as i32,
+                },
+            )
+        }
+    }
+    /// Get the process id of the workload
+    pub fn get_process_id(&self) -> u64 {
+        unsafe { self.bridge.getProcessID.unwrap_unchecked()(self.inner) }
+    }
+    /// Set the process id of the workload
+    pub fn set_process_id(&self, id: u64) {
+        unsafe { self.bridge.setProcessID.unwrap_unchecked()(self.inner, id) }
+    }
+    /// Get the current time
+    pub fn now(&self) -> f64 {
+        unsafe { self.bridge.now.unwrap_unchecked()(self.inner) }
+    }
+    /// Get a determinist 32-bit random number
+    pub fn rnd(&self) -> u32 {
+        unsafe { self.bridge.rnd.unwrap_unchecked()(self.inner) }
+    }
+    /// Get the value of a parameter from the simulation config file
+    ///
+    /// /!\ getting an option consumes it, following call on that option will return `None`
+    pub fn get_option<T>(&self, name: &str) -> Option<T>
+    where
+        T: FromStr,
+    {
+        self.get_option_raw(name)
+            .and_then(|value| value.parse::<T>().ok())
+    }
+    fn get_option_raw(&self, name: &str) -> Option<String> {
+        let null = "null";
+        let name = str_for_c(name);
+        let default_value = str_for_c(null);
+        let value_ptr = unsafe {
+            self.bridge.getOption.unwrap_unchecked()(
+                self.inner,
+                name.as_ptr(),
+                default_value.as_ptr(),
+            )
+        };
+        let value = str_from_c(value_ptr);
+        // FIXME: value leak
+        if value == null {
+            None
+        } else {
+            Some(value)
+        }
+    }
+    /// Get the client id of the workload
+    pub fn client_id(&self) -> i32 {
+        unsafe { self.bridge.clientId.unwrap_unchecked()(self.inner) }
+    }
+    /// Get the client id of the workload
+    pub fn client_count(&self) -> i32 {
+        unsafe { self.bridge.clientCount.unwrap_unchecked()(self.inner) }
+    }
+    /// Get a determinist 64-bit random number
+    pub fn shared_random_number(&self) -> i64 {
+        unsafe { self.bridge.sharedRandomNumber.unwrap_unchecked()(self.inner) }
+    }
+}
+
+impl Promise {
+    pub(crate) fn new(inner: *mut FDBPromise, bridge: BridgeToServer_PromiseImpl) -> Self {
+        Self { inner, bridge }
+    }
+    /// Resolve a FoundationDB promise by setting its value to a boolean.
+    /// You can resolve a Promise only once.
+    ///
+    /// note: FoundationDB disregards the value sent, so sending `true` or `false` is equivalent
+    pub fn send(self, value: bool) {
+        unsafe { self.bridge.send.unwrap_unchecked()(self.inner, value) };
+    }
+}
+impl Drop for Promise {
+    fn drop(&mut self) {
+        unsafe { self.bridge.free.unwrap_unchecked()(self.inner) };
+    }
+}
+
+impl Metric {
+    /// Create a metric value entry
+    pub fn val<S, V>(name: S, value: V) -> Self
+    where
+        S: Into<String>,
+        f64: From<V>,
+    {
+        Self {
+            name: name.into(),
+            value: value.into(),
+            averaged: false,
+            format_code: None,
+        }
+    }
+    /// Create a metric average entry
+    pub fn avg<S, V>(name: S, value: V) -> Self
+    where
+        S: Into<String>,
+        V: TryInto<f64>,
+    {
+        Self {
+            name: name.into(),
+            value: value.try_into().ok().expect("convertion failed"),
+            averaged: true,
+            format_code: None,
+        }
+    }
+}

--- a/bindings/c/test/workloads/RustWorkload/src/bindings.rs
+++ b/bindings/c/test/workloads/RustWorkload/src/bindings.rs
@@ -1,4 +1,4 @@
-use std::{ffi, os::raw::c_char, str::FromStr};
+use std::{ffi, str::FromStr};
 
 mod raw_bindings {
     #![allow(non_camel_case_types)]
@@ -20,7 +20,7 @@ use raw_bindings::{
 // String conversions
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
-pub fn str_from_c(c_buf: *const c_char) -> String {
+pub fn str_from_c(c_buf: *const i8) -> String {
     let c_str = unsafe { ffi::CStr::from_ptr(c_buf) };
     c_str.to_str().unwrap().to_string()
 }
@@ -132,7 +132,7 @@ impl WorkloadContext {
             .and_then(|value| value.parse::<T>().ok())
     }
     fn get_option_raw(&self, name: &str) -> Option<String> {
-        let null = "null";
+        let null = "";
         let name = str_for_c(name);
         let default_value = str_for_c(null);
         let raw_value = unsafe {
@@ -187,7 +187,7 @@ impl Metrics {
     }
     pub fn push(&mut self, metric: Metric) {
         let key_storage = str_for_c(metric.key);
-        let fmt_storage = str_for_c(metric.fmt.as_deref().unwrap_or("0.3g"));
+        let fmt_storage = str_for_c(metric.fmt.as_deref().unwrap_or("%.3g"));
         unsafe {
             self.0.push.unwrap_unchecked()(
                 self.0.inner,

--- a/bindings/c/test/workloads/RustWorkload/src/lib.rs
+++ b/bindings/c/test/workloads/RustWorkload/src/lib.rs
@@ -1,0 +1,145 @@
+use std::{os::raw::c_char, ptr::NonNull};
+
+mod bindings;
+mod mock;
+
+use bindings::{
+    str_from_c, BridgeToClient, BridgeToServer, BridgeToServer_PromiseImpl, CVector, FDBDatabase,
+    FDBPromise, FDBWorkload, FDBWorkloadContext, Metric, Promise, Severity, WorkloadContext,
+};
+
+/// RustWorkload trait provides a one to one equivalent to the C++ abstract class `FDBWorkload`
+pub trait RustWorkload {
+    fn new(name: String, context: WorkloadContext) -> Self;
+
+    /// This method is called by the tester during the setup phase.
+    /// It should be used to populate the database.
+    ///
+    /// # Arguments
+    ///
+    /// * `db` - The simulated database.
+    /// * `done` - A promise that should be resolved to indicate completion
+    fn setup(&'static mut self, db: MockDatabase, done: Promise);
+
+    /// This method should run the actual test.
+    ///
+    /// # Arguments
+    ///
+    /// * `db` - The simulated database.
+    /// * `done` - A promise that should be resolved to indicate completion
+    fn start(&'static mut self, db: MockDatabase, done: Promise);
+
+    /// This method is called when the tester completes.
+    /// A workload should run any consistency/correctness tests during this phase.
+    ///
+    /// # Arguments
+    ///
+    /// * `db` - The simulated database.
+    /// * `done` - A promise that should be resolved to indicate completion
+    fn check(&'static mut self, db: MockDatabase, done: Promise);
+
+    /// If a workload collects metrics (like latencies or throughput numbers), these should be reported back here.
+    /// The multitester (or test orchestrator) will collect all metrics from all test clients and it will aggregate them.
+    fn get_metrics(&self) -> Vec<Metric>;
+
+    /// Set the check timeout for this workload.
+    fn get_check_timeout(&self) -> f64;
+}
+
+// Should be replaced by a Rust wrapper over the FDBDatabase bindings, like the one provided by
+// foundationdb-rs
+type MockDatabase = NonNull<FDBDatabase>;
+
+struct Bridge<W: RustWorkload> {
+    workload: W,
+    promise: BridgeToServer_PromiseImpl,
+}
+
+unsafe extern "C" fn workload_setup<W: RustWorkload + 'static>(
+    raw_bridge: *mut FDBWorkload,
+    raw_database: *mut FDBDatabase,
+    raw_promise: *mut FDBPromise,
+) {
+    let bridge = &mut *(raw_bridge as *mut Bridge<W>);
+    let database = NonNull::new_unchecked(raw_database);
+    let done = Promise::new(raw_promise, bridge.promise);
+    bridge.workload.setup(database, done)
+}
+unsafe extern "C" fn workload_start<W: RustWorkload + 'static>(
+    raw_bridge: *mut FDBWorkload,
+    raw_database: *mut FDBDatabase,
+    raw_promise: *mut FDBPromise,
+) {
+    let bridge = &mut *(raw_bridge as *mut Bridge<W>);
+    let database = NonNull::new_unchecked(raw_database);
+    let done = Promise::new(raw_promise, bridge.promise);
+    bridge.workload.start(database, done)
+}
+unsafe extern "C" fn workload_check<W: RustWorkload + 'static>(
+    raw_bridge: *mut FDBWorkload,
+    raw_database: *mut FDBDatabase,
+    raw_promise: *mut FDBPromise,
+) {
+    let bridge: &mut Bridge<W> = &mut *(raw_bridge as *mut Bridge<W>);
+    let database = NonNull::new_unchecked(raw_database);
+    let done = Promise::new(raw_promise, bridge.promise);
+    bridge.workload.check(database, done)
+}
+unsafe extern "C" fn workload_get_metrics<W: RustWorkload>(
+    raw_bridge: *mut FDBWorkload,
+) -> CVector {
+    let bridge = &*(raw_bridge as *mut Bridge<W>);
+    let mut metrics = bridge.workload.get_metrics();
+    // TODO: Metric to CMetric
+    // FIXME: dangling pointers
+    CVector {
+        elements: metrics.as_mut_ptr() as *mut _,
+        n: metrics.len() as i32,
+    }
+}
+unsafe extern "C" fn workload_get_check_timeout<W: RustWorkload>(
+    raw_bridge: *mut FDBWorkload,
+) -> f64 {
+    let bridge = &*(raw_bridge as *mut Bridge<W>);
+    bridge.workload.get_check_timeout()
+}
+unsafe extern "C" fn workload_drop<W: RustWorkload>(raw_bridge: *mut FDBWorkload) {
+    unsafe { drop(Box::from_raw(raw_bridge as *mut Bridge<W>)) };
+}
+
+extern "C" fn workload_instantiate<W: RustWorkload + 'static>(
+    raw_name: *const c_char,
+    raw_context: *mut FDBWorkloadContext,
+    bridge_to_server: BridgeToServer,
+) -> BridgeToClient {
+    let name = str_from_c(raw_name);
+    let context = WorkloadContext::new(raw_context, bridge_to_server.context);
+    let workload = Box::into_raw(Box::new(Bridge {
+        workload: W::new(name, context),
+        promise: bridge_to_server.promise,
+    }));
+    BridgeToClient {
+        workload: workload as *mut _,
+        setup: Some(workload_setup::<W>),
+        start: Some(workload_start::<W>),
+        check: Some(workload_check::<W>),
+        getMetrics: Some(workload_get_metrics::<W>),
+        getCheckTimeout: Some(workload_get_check_timeout::<W>),
+        free: Some(workload_drop::<W>),
+    }
+}
+
+// FIXME: workloadFactory
+#[macro_export]
+macro_rules! register_workload {
+    ($name:ident) => {
+        #[no_mangle]
+        extern "C" fn workloadInstantiate(
+            raw_name: *const $crate::c_char,
+            raw_context: *mut $crate::FDBWorkloadContext,
+            bridge_to_server: $crate::BridgeToServer,
+        ) -> $crate::BridgeToClient {
+            $crate::workload_instantiate::<$name>(raw_name, raw_context, bridge_to_server)
+        }
+    };
+}

--- a/bindings/c/test/workloads/RustWorkload/src/lib.rs
+++ b/bindings/c/test/workloads/RustWorkload/src/lib.rs
@@ -1,12 +1,12 @@
-use std::{os::raw::c_char, ptr::NonNull};
+use std::ptr::NonNull;
 
 mod bindings;
 mod mock;
 
 use bindings::{
-    str_from_c, FDBMetrics, FDBPromise, FDBWorkload, FDBWorkloadContext, OpaqueWorkload,
+    str_from_c, FDBMetrics, FDBPromise, FDBWorkloadContext, OpaqueWorkload,
 };
-pub use bindings::{FDBDatabase, Metric, Metrics, Promise, Severity, WorkloadContext};
+pub use bindings::{FDBDatabase, FDBWorkload, Metric, Metrics, Promise, Severity, WorkloadContext};
 
 // Should be replaced by a Rust wrapper over the FDBDatabase bindings, like the one provided by
 // foundationdb-rs
@@ -126,12 +126,12 @@ macro_rules! register_factory {
     ($name:ident) => {
         #[no_mangle]
         extern "C" fn workloadCFactory(
-            raw_name: *const $crate::c_char,
+            raw_name: *const i8,
             raw_context: $crate::FDBWorkloadContext,
         ) -> $crate::FDBWorkload {
             let name = $crate::str_from_c(raw_name);
             let context = $crate::WorkloadContext::new(raw_context);
-            $name::create(name, context)
+            <$name as $crate::RustWorkloadFactory>::create(name, context)
         }
     };
 }

--- a/bindings/c/test/workloads/RustWorkload/src/mock.rs
+++ b/bindings/c/test/workloads/RustWorkload/src/mock.rs
@@ -1,5 +1,6 @@
 use crate::{
-    register_workload, Metric, MockDatabase, Promise, RustWorkload, Severity, WorkloadContext,
+    register_factory, wrap, FDBWorkload, Metric, Metrics, MockDatabase, Promise, RustWorkload,
+    RustWorkloadFactory, Severity, WorkloadContext,
 };
 
 struct MockWorkload {
@@ -9,14 +10,6 @@ struct MockWorkload {
 }
 
 impl RustWorkload for MockWorkload {
-    fn new(name: String, context: WorkloadContext) -> Self {
-        let client_id = context.client_id();
-        Self {
-            name,
-            client_id,
-            context,
-        }
-    }
     fn setup(&'static mut self, _db: MockDatabase, done: Promise) {
         println!("workload_setup({}_{})", self.name, self.client_id);
         self.context.trace(
@@ -44,12 +37,48 @@ impl RustWorkload for MockWorkload {
         );
         done.send(true);
     }
-    fn get_metrics(&self) -> Vec<Metric> {
-        Vec::new()
+    fn get_metrics(&self, mut out: Metrics) {
+        out.reserve(8);
+        out.push(Metric::val("test", 42));
     }
     fn get_check_timeout(&self) -> f64 {
         3000.
     }
 }
+impl MockWorkload {
+    fn new(name: String, client_id: i32, context: WorkloadContext) -> Self {
+        Self {
+            name,
+            client_id,
+            context,
+        }
+    }
+}
+impl Drop for MockWorkload {
+    fn drop(&mut self) {
+        println!("workload_free({}_{})", self.name, self.client_id);
+    }
+}
 
-register_workload!(MockWorkload);
+struct MockFactory;
+impl RustWorkloadFactory for MockFactory {
+    fn create(name: String, context: WorkloadContext) -> FDBWorkload {
+        let client_id = context.client_id();
+        let client_count = context.client_count();
+        println!("RustWorkloadFactory::create({name})[{client_id}/{client_count}]");
+        println!(
+            "my_c_option: {:?}",
+            context.get_option::<String>("my_c_option")
+        );
+        println!(
+            "my_c_option: {:?}",
+            context.get_option::<String>("my_c_option")
+        );
+        match name.as_str() {
+            "MockWorkload" => wrap(MockWorkload::new(name, client_id, context)),
+            _ => panic!("Unknown workload name: {name}"),
+        }
+    }
+}
+
+register_factory!(MockFactory);

--- a/bindings/c/test/workloads/RustWorkload/src/mock.rs
+++ b/bindings/c/test/workloads/RustWorkload/src/mock.rs
@@ -1,0 +1,55 @@
+use crate::{
+    register_workload, Metric, MockDatabase, Promise, RustWorkload, Severity, WorkloadContext,
+};
+
+struct MockWorkload {
+    name: String,
+    client_id: i32,
+    context: WorkloadContext,
+}
+
+impl RustWorkload for MockWorkload {
+    fn new(name: String, context: WorkloadContext) -> Self {
+        let client_id = context.client_id();
+        Self {
+            name,
+            client_id,
+            context,
+        }
+    }
+    fn setup(&'static mut self, _db: MockDatabase, done: Promise) {
+        println!("workload_setup({}_{})", self.name, self.client_id);
+        self.context.trace(
+            Severity::Debug,
+            "Test",
+            &[("Layer", "Rust"), ("Stage", "Setup")],
+        );
+        done.send(true);
+    }
+    fn start(&'static mut self, _db: MockDatabase, done: Promise) {
+        println!("workload_start({}_{})", self.name, self.client_id);
+        self.context.trace(
+            Severity::Debug,
+            "Test",
+            &[("Layer", "Rust"), ("Stage", "Start")],
+        );
+        done.send(true);
+    }
+    fn check(&'static mut self, _db: MockDatabase, done: Promise) {
+        println!("workload_check({}_{})", self.name, self.client_id);
+        self.context.trace(
+            Severity::Debug,
+            "Test",
+            &[("Layer", "Rust"), ("Stage", "Check")],
+        );
+        done.send(true);
+    }
+    fn get_metrics(&self) -> Vec<Metric> {
+        Vec::new()
+    }
+    fn get_check_timeout(&self) -> f64 {
+        3000.
+    }
+}
+
+register_workload!(MockWorkload);

--- a/bindings/c/test/workloads/RustWorkload/src/mock.rs
+++ b/bindings/c/test/workloads/RustWorkload/src/mock.rs
@@ -11,7 +11,7 @@ struct MockWorkload {
 
 impl RustWorkload for MockWorkload {
     fn setup(&'static mut self, _db: MockDatabase, done: Promise) {
-        println!("workload_setup({}_{})", self.name, self.client_id);
+        println!("rust_setup({}_{})", self.name, self.client_id);
         self.context.trace(
             Severity::Debug,
             "Test",
@@ -20,7 +20,7 @@ impl RustWorkload for MockWorkload {
         done.send(true);
     }
     fn start(&'static mut self, _db: MockDatabase, done: Promise) {
-        println!("workload_start({}_{})", self.name, self.client_id);
+        println!("rust_start({}_{})", self.name, self.client_id);
         self.context.trace(
             Severity::Debug,
             "Test",
@@ -29,7 +29,7 @@ impl RustWorkload for MockWorkload {
         done.send(true);
     }
     fn check(&'static mut self, _db: MockDatabase, done: Promise) {
-        println!("workload_check({}_{})", self.name, self.client_id);
+        println!("rust_check({}_{})", self.name, self.client_id);
         self.context.trace(
             Severity::Debug,
             "Test",
@@ -38,10 +38,12 @@ impl RustWorkload for MockWorkload {
         done.send(true);
     }
     fn get_metrics(&self, mut out: Metrics) {
+        println!("rust_getMetrics({}_{})", self.name, self.client_id);
         out.reserve(8);
         out.push(Metric::val("test", 42));
     }
     fn get_check_timeout(&self) -> f64 {
+        println!("rust_getCheckTimeout({}_{})", self.name, self.client_id);
         3000.
     }
 }
@@ -56,7 +58,7 @@ impl MockWorkload {
 }
 impl Drop for MockWorkload {
     fn drop(&mut self) {
-        println!("workload_free({}_{})", self.name, self.client_id);
+        println!("rust_free({}_{})", self.name, self.client_id);
     }
 }
 

--- a/bindings/c/test/workloads/SimpleWorkload.cpp
+++ b/bindings/c/test/workloads/SimpleWorkload.cpp
@@ -256,7 +256,7 @@ struct SimpleWorkload final : FDBWorkload {
 		}
 	};
 
-	std::string description() const override { return name; }
+	// std::string description() const override { return name; }
 	bool init(FDBWorkloadContext* context) override {
 		this->context = context;
 		context->trace(FDBSeverity::Info, "SimpleWorkloadInit", {});

--- a/bindings/c/test/workloads/workloads.h
+++ b/bindings/c/test/workloads/workloads.h
@@ -19,7 +19,7 @@
  */
 
 #pragma once
-#include "foundationdb/ClientWorkload.h"
+#include "foundationdb/CppWorkload.h"
 
 #include <map>
 

--- a/bindings/java/JavaWorkload.cpp
+++ b/bindings/java/JavaWorkload.cpp
@@ -18,7 +18,7 @@
  * limitations under the License.
  */
 
-#include <foundationdb/ClientWorkload.h>
+#include <foundationdb/CppWorkload.h>
 #define FDB_USE_LATEST_BINDINGS_API_VERSION
 #include <foundationdb/fdb_c.h>
 

--- a/bindings/java/JavaWorkload.cpp
+++ b/bindings/java/JavaWorkload.cpp
@@ -539,7 +539,7 @@ struct JavaWorkload final : FDBWorkload {
 		}
 	}
 
-	std::string description() const override { return name; }
+	// std::string description() const override { return name; }
 	bool init(FDBWorkloadContext* context) override {
 		this->context = context;
 		try {

--- a/fdbserver/workloads/ExternalWorkload.actor.cpp
+++ b/fdbserver/workloads/ExternalWorkload.actor.cpp
@@ -100,91 +100,101 @@ struct FDBLoggerImpl : FDBLogger {
 	}
 };
 
+namespace capi {
+	#include "foundationdb/CWorkload.h"
+}
 namespace translator {
-	template<typename T>
+	template <typename T>
 	struct Wrapper {
 		T inner;
 	};
 
 	namespace context {
-		void trace(FDBWorkloadContext* context, FDBSeverity severity, const char* name, CVector vec) {
+		void trace(capi::FDBWorkloadContext* c_context, capi::FDBSeverity c_severity, const char* name, capi::CVector vec) {
+			auto context = (FDBWorkloadContext*)c_context;
+			auto severity = (FDBSeverity)c_severity;
 			std::vector<std::pair<std::string, std::string>> details;
-			CStringPair* pairs = (CStringPair*)vec.elements;
-			for (int i = 0 ; i < vec.n ; i++) {
-				details.push_back(std::pair<std::string, std::string>(pairs[i].key, pairs[i].value));
+			auto pairs = (capi::CStringPair*)vec.elements;
+			for (int i = 0; i < vec.n; i++) {
+				details.push_back(std::pair<std::string, std::string>(pairs[i].key, pairs[i].val));
 			}
 			return context->trace(severity, name, details);
 		}
-		uint64_t getProcessID(FDBWorkloadContext* context) {
+		uint64_t getProcessID(capi::FDBWorkloadContext* c_context) {
+			auto context = (FDBWorkloadContext*)c_context;
 			return context->getProcessID();
 		}
-		void setProcessID(FDBWorkloadContext* context, uint64_t processID) {
+		void setProcessID(capi::FDBWorkloadContext* c_context, uint64_t processID) {
+			auto context = (FDBWorkloadContext*)c_context;
 			return context->setProcessID(processID);
 		}
-		double now(FDBWorkloadContext* context) {
+		double now(capi::FDBWorkloadContext* c_context) {
+			auto context = (FDBWorkloadContext*)c_context;
 			return context->now();
 		}
-		uint32_t rnd(FDBWorkloadContext* context) {
+		uint32_t rnd(capi::FDBWorkloadContext* c_context) {
+			auto context = (FDBWorkloadContext*)c_context;
 			return context->rnd();
 		}
-		char* getOption(FDBWorkloadContext* context, const char* name, const char* defaultValue) {
+		char* getOption(capi::FDBWorkloadContext* c_context, const char* name, const char* defaultValue) {
+			auto context = (FDBWorkloadContext*)c_context;
 			std::string str = context->getOption(name, std::string(defaultValue));
-			size_t len = str.length();
-			char* c_str = (char*)malloc(len + 1);
+			size_t len = str.length() + 1;
+			char* c_str = (char*)malloc(len);
 			memcpy(c_str, str.c_str(), len);
-			c_str[len] = '\0';
 			return c_str;
 		}
-		int clientId(FDBWorkloadContext* context) {
+		int clientId(capi::FDBWorkloadContext* c_context) {
+			auto context = (FDBWorkloadContext*)c_context;
 			return context->clientId();
 		}
-		int clientCount(FDBWorkloadContext* context) {
+		int clientCount(capi::FDBWorkloadContext* c_context) {
+			auto context = (FDBWorkloadContext*)c_context;
 			return context->clientCount();
 		}
-		int64_t sharedRandomNumber(FDBWorkloadContext* context) {
+		int64_t sharedRandomNumber(capi::FDBWorkloadContext* c_context) {
+			auto context = (FDBWorkloadContext*)c_context;
 			return context->sharedRandomNumber();
 		}
-	}
+	} // namespace context
 
 	namespace promise {
-		void send(Wrapper<GenericPromise<bool>>* promise, bool value) {
+		void send(capi::FDBPromise* c_promise, bool value) {
+			auto promise = (Wrapper<GenericPromise<bool>>*)c_promise;
 			promise->inner.send(value);
 		}
-		void free(Wrapper<GenericPromise<bool>>* promise) {
+		void free(capi::FDBPromise* c_promise) {
+			auto promise = (Wrapper<GenericPromise<bool>>*)c_promise;
 			delete promise;
 		}
-	}
+	} // namespace promise
 
-	class Workload: public FDBWorkload {
+	class Workload : public FDBWorkload {
 	private:
-		BridgeToClient c;
+		capi::BridgeToClient c;
 
 	public:
-		Workload(BridgeToClient bridgeToClient): c(bridgeToClient) {}
-		~Workload() {
-			this->c.free(this->c.workload);
-		}
+		Workload(capi::BridgeToClient bridgeToClient) : c(bridgeToClient) {}
+		~Workload() { this->c.free(this->c.workload); }
 
-		virtual bool init(FDBWorkloadContext* context) override {
-			return true;
-		}
+		virtual bool init(FDBWorkloadContext* context) override { return true; }
 		virtual void setup(FDBDatabase* db, GenericPromise<bool> done) override {
-			auto wrapped = new Wrapper<GenericPromise<bool>> { done };
+			auto wrapped = (capi::FDBPromise*)new Wrapper<GenericPromise<bool>>{ done };
 			return this->c.setup(this->c.workload, db, wrapped);
 		}
 		virtual void start(FDBDatabase* db, GenericPromise<bool> done) override {
-			auto wrapped = new Wrapper<GenericPromise<bool>> { done };
+			auto wrapped = (capi::FDBPromise*)new Wrapper<GenericPromise<bool>>{ done };
 			return this->c.start(this->c.workload, db, wrapped);
 		}
 		virtual void check(FDBDatabase* db, GenericPromise<bool> done) override {
-			auto wrapped = new Wrapper<GenericPromise<bool>> { done };
+			auto wrapped = (capi::FDBPromise*)new Wrapper<GenericPromise<bool>>{ done };
 			return this->c.check(this->c.workload, db, wrapped);
 		}
 		virtual void getMetrics(std::vector<FDBPerfMetric>& out) const override {
-			CVector vec = this->c.getMetrics(this->c.workload);
-			CMetric* metrics = (CMetric*)vec.elements;
-			for (int i = 0 ; i < vec.n ; i++) {
-				out->emplace_back(FDBPerfMetric {
+			auto vec = this->c.getMetrics(this->c.workload);
+			auto metrics = (capi::CMetric*)vec.elements;
+			for (int i = 0; i < vec.n; i++) {
+				out.emplace_back(FDBPerfMetric{
 					std::string(metrics[i].name),
 					metrics[i].value,
 					metrics[i].averaged,
@@ -192,17 +202,14 @@ namespace translator {
 				});
 			}
 		}
-		virtual double getCheckTimeout() override {
-			return this->c.getCheckTimeout(this->c.workload);
-		}
+		virtual double getCheckTimeout() override { return this->c.getCheckTimeout(this->c.workload); }
 	};
-}
+} // namespace translator
 
 struct ExternalWorkload : TestWorkload, FDBWorkloadContext {
 	std::string libraryName, libraryPath;
 	bool success = true;
 	void* library = nullptr;
-	FDBWorkloadFactory* (*workloadFactory)(FDBLogger*);
 	std::shared_ptr<FDBWorkload> workloadImpl;
 
 	constexpr static auto NAME = "External";
@@ -231,6 +238,7 @@ struct ExternalWorkload : TestWorkload, FDBWorkloadContext {
 		libraryPath = ::getOption(options, "libraryPath"_sr, Value(getDefaultLibraryPath())).toString();
 		auto wName = ::getOption(options, "workloadName"_sr, ""_sr);
 		auto fullPath = joinPath(libraryPath, toLibName(libraryName));
+		// std::cout << "ExternalWorkload::useCAPI: " << useCAPI << "\n";
 		TraceEvent("ExternalWorkloadLoad")
 		    .detail("LibraryName", libraryName)
 		    .detail("LibraryPath", fullPath)
@@ -243,14 +251,15 @@ struct ExternalWorkload : TestWorkload, FDBWorkloadContext {
 		}
 
 		if (useCAPI) {
-			BridgeToClient (*workloadInstantiate)(const char*, FDBWorkloadContext*, BridgeToServer);
-			workloadInstantiate = reinterpret_cast<decltype(workloadInstantiate)>(loadFunction(library, "workloadInstantiate"));
-			if (workloadFactory == nullptr) {
-				TraceEvent(SevError, "ExternalFactoryNotFound").log();
+			capi::BridgeToClient (*workloadInstantiate)(char*, FDBWorkloadContext*, capi::BridgeToServer);
+			workloadInstantiate =
+			    reinterpret_cast<decltype(workloadInstantiate)>(loadFunction(library, "workloadInstantiate"));
+			if (workloadInstantiate == nullptr) {
+				TraceEvent(SevError, "ExternalInstantiateNotFound").log();
 				success = false;
 				return;
 			}
-			BridgeToServer bridgeToServer = {
+			capi::BridgeToServer bridgeToServer = {
 				.context = {
 					.trace = translator::context::trace,
 					.getProcessID = translator::context::getProcessID,
@@ -267,14 +276,14 @@ struct ExternalWorkload : TestWorkload, FDBWorkloadContext {
 					.free = translator::promise::free,
 				},
 			};
-			BridgeToClient bridgeToClient = (*workloadInstantiate)(wName.toString().c_str(), this, bridgeToServer);
-			if (!bridgeToClient) {
-				TraceEvent(SevError, "WorkloadNotFound").log();
-				success = false;
-				return;
-			}
+			auto name = wName.toString();
+			size_t len = name.length() + 1;
+			char* c_str = (char*)malloc(len);
+			memcpy(c_str, name.c_str(), len);
+			capi::BridgeToClient bridgeToClient = (*workloadInstantiate)(c_str, this, bridgeToServer);
 			workloadImpl = std::make_shared<translator::Workload>(bridgeToClient);
 		} else {
+			FDBWorkloadFactory* (*workloadFactory)(FDBLogger*);
 			workloadFactory = reinterpret_cast<decltype(workloadFactory)>(loadFunction(library, "workloadFactory"));
 			if (workloadFactory == nullptr) {
 				TraceEvent(SevError, "ExternalFactoryNotFound").log();


### PR DESCRIPTION
I'm utilizing the `ExternalWorkload` to test custom layers within the FoundationDB simulation. The layers under test are authored in Rust and are based on the [foundationdb-rs project](https://github.com/foundationdb-rs/foundationdb-rs). The workload API is defined by the C++ header file `ClientWorkload.h`. Interoperability between Rust and C++ presents challenges, although creating a C++ to C shim was relatively straightforward. My main concern is the unstable ABI of the C++ API, as it relies on the compiler, linker, and system libraries. This proved to be an issue when transitioning from version 7.1 to 7.3, where the workload I was using suddenly broke due to a change in the representation of the `std::string` class as the fdbserver switched from gcc to clang, as detailed in [this forum thread](https://forums.foundationdb.org/t/externalworkload-segmentation-fault-in-7-3/4375) and issue #11298.

To address this, I propose that alongside the existing C++ API (utilized by `JavaWorkload`), pure C bindings should be made available to ease integration with other languages and mitigate the impact of changes in compilation environments. This aligns well with the location of `ClientWorkload.h` in the `bindings/c` folder.

Given my limited familiarity with the FoundationDB codebase, I resorted to various wrappers to minimize code changes. However, a more efficient approach might involve rewriting the `ExternalWorkload` or creating a dedicated C version.

In this PR, I've divided `ClientWorkload.h` into `CWorkload.h` and `CppWorkload.h`. Importing `CppWorkload.h` should mirror the behavior of the original `ClientWorkload.h`, ensuring compatibility with existing workloads utilizing this API. The C bindings introduce `BridgeToClient` and `BridgeToServer` structs that encapsulate collections of function pointers. If the "useCAPI" option is enabled in the `ExternalWorkload` configuration file, it will load the `workloadInstantiate` symbol (instead of `workloadFactory`) and invoke it with the server-bridge (allowing the C workload to interact with the C++ `FDBWorkloadContext` and `GenericPromise<bool>` classes). The returned client-bridge is then encapsulated within a C++ "translator" workload and assigned as the `workloadImpl` of the `ExternalWorkload`.