### PR TITLE
Validate Mutation Version in Accumulative Checksum Framework

### DIFF
--- a/fdbclient/ClientKnobs.cpp
+++ b/fdbclient/ClientKnobs.cpp
@@ -336,8 +336,8 @@ void ClientKnobs::initialize(Randomize randomize) {
 	init( REST_KMS_ALLOW_NOT_SECURE_CONNECTION,     false ); if ( randomize && BUGGIFY ) REST_KMS_ALLOW_NOT_SECURE_CONNECTION = !REST_KMS_ALLOW_NOT_SECURE_CONNECTION;
 	init( SIM_KMS_VAULT_MAX_KEYS,                    4096 );
 
-	init( ENABLE_MUTATION_CHECKSUM,                 false ); if ( randomize && BUGGIFY ) ENABLE_MUTATION_CHECKSUM = true; // Enable this after deserialiser is ported to 7.3.
-	init( ENABLE_ACCUMULATIVE_CHECKSUM,             false ); if ( randomize && BUGGIFY ) ENABLE_ACCUMULATIVE_CHECKSUM = true; // Enable this after deserialiser is ported to 7.3.
+	init( ENABLE_MUTATION_CHECKSUM,                 true ); if ( randomize && BUGGIFY ) ENABLE_MUTATION_CHECKSUM = true; // Enable this after deserialiser is ported to 7.3.
+	init( ENABLE_ACCUMULATIVE_CHECKSUM,             true ); if ( randomize && BUGGIFY ) ENABLE_ACCUMULATIVE_CHECKSUM = true; // Enable this after deserialiser is ported to 7.3.
 	init( ENABLE_ACCUMULATIVE_CHECKSUM_LOGGING,     false );
 	// clang-format on
 }

--- a/fdbclient/ClientKnobs.cpp
+++ b/fdbclient/ClientKnobs.cpp
@@ -336,8 +336,8 @@ void ClientKnobs::initialize(Randomize randomize) {
 	init( REST_KMS_ALLOW_NOT_SECURE_CONNECTION,     false ); if ( randomize && BUGGIFY ) REST_KMS_ALLOW_NOT_SECURE_CONNECTION = !REST_KMS_ALLOW_NOT_SECURE_CONNECTION;
 	init( SIM_KMS_VAULT_MAX_KEYS,                    4096 );
 
-	init( ENABLE_MUTATION_CHECKSUM,                 true ); if ( randomize && BUGGIFY ) ENABLE_MUTATION_CHECKSUM = true; // Enable this after deserialiser is ported to 7.3.
-	init( ENABLE_ACCUMULATIVE_CHECKSUM,             true ); if ( randomize && BUGGIFY ) ENABLE_ACCUMULATIVE_CHECKSUM = true; // Enable this after deserialiser is ported to 7.3.
+	init( ENABLE_MUTATION_CHECKSUM,                 false ); if ( randomize && BUGGIFY ) ENABLE_MUTATION_CHECKSUM = true; // Enable this after deserialiser is ported to 7.3.
+	init( ENABLE_ACCUMULATIVE_CHECKSUM,             false ); if ( randomize && BUGGIFY ) ENABLE_ACCUMULATIVE_CHECKSUM = true; // Enable this after deserialiser is ported to 7.3.
 	init( ENABLE_ACCUMULATIVE_CHECKSUM_LOGGING,     false );
 	// clang-format on
 }

--- a/fdbclient/ClientKnobs.cpp
+++ b/fdbclient/ClientKnobs.cpp
@@ -336,8 +336,8 @@ void ClientKnobs::initialize(Randomize randomize) {
 	init( REST_KMS_ALLOW_NOT_SECURE_CONNECTION,     false ); if ( randomize && BUGGIFY ) REST_KMS_ALLOW_NOT_SECURE_CONNECTION = !REST_KMS_ALLOW_NOT_SECURE_CONNECTION;
 	init( SIM_KMS_VAULT_MAX_KEYS,                    4096 );
 
-	init( ENABLE_MUTATION_CHECKSUM,                 false ); if ( randomize && BUGGIFY ) ENABLE_MUTATION_CHECKSUM = true; // Enable this after deserialiser is ported to 7.3.
-	init( ENABLE_ACCUMULATIVE_CHECKSUM,             false ); if ( randomize && BUGGIFY ) ENABLE_ACCUMULATIVE_CHECKSUM = true; // Enable this after deserialiser is ported to 7.3.
+	init( ENABLE_MUTATION_CHECKSUM,                 false ); if ( randomize && BUGGIFY ) ENABLE_MUTATION_CHECKSUM = deterministicRandom()->coinflip();; // Enable this after deserialiser is ported to 7.3.
+	init( ENABLE_ACCUMULATIVE_CHECKSUM,             false ); if ( randomize && BUGGIFY ) ENABLE_ACCUMULATIVE_CHECKSUM = deterministicRandom()->coinflip();; // Enable this after deserialiser is ported to 7.3.
 	init( ENABLE_ACCUMULATIVE_CHECKSUM_LOGGING,     false );
 	// clang-format on
 }

--- a/fdbserver/include/fdbserver/AccumulativeChecksumUtil.h
+++ b/fdbserver/include/fdbserver/AccumulativeChecksumUtil.h
@@ -49,9 +49,9 @@ inline bool tagSupportAccumulativeChecksum(Tag tag) {
 }
 
 // Define how to aggregate ACS values of a vector of mutations from a starting ACS
-inline uint32_t aggregateAcs(uint32_t startAcs, Standalone<VectorRef<MutationRef>> mutations) {
+inline uint32_t aggregateAcs(uint32_t startAcs, Standalone<VectorRef<std::pair<Version, MutationRef>>> mutations) {
 	uint32_t newAcs = startAcs;
-	for (const auto& mutation : mutations) {
+	for (const auto& [version, mutation] : mutations) {
 		ASSERT(mutation.checksum.present());
 		newAcs = calculateAccumulativeChecksum(newAcs, mutation.checksum.get());
 	}
@@ -121,7 +121,7 @@ public:
 
 	// Called when SS pulls a non-ACS mutation
 	// Add the mutation to the mutation buffer
-	void addMutation(const MutationRef& mutation, UID ssid, Tag tag, Version ssVersion);
+	void addMutation(const MutationRef& mutation, UID ssid, Tag tag, Version ssVersion, Version mutationVersion);
 
 	// Called when SS receives an ACS mutation
 	// Consume the current mutation buffer to generate ACS
@@ -175,7 +175,7 @@ private:
 	// Any mutation is added to mutationBuffer at first. Those mutations
 	// will be consumed to generate ACS value until SS receives the first
 	// following ACS mutation.
-	Standalone<VectorRef<MutationRef>> mutationBuffer;
+	Standalone<VectorRef<std::pair<Version, MutationRef>>> mutationBuffer;
 	uint64_t checkedMutations = 0; // the number of mutations checked by ACS
 	uint64_t checkedVersions = 0; // the number of versions checked by ACS
 	uint64_t totalMutations = 0; // the number of mutations received by SS

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -11426,7 +11426,8 @@ ACTOR Future<Void> update(StorageServer* data, bool* pReceivedUpdate) {
 				           msg.accumulativeChecksumIndex.present() && !isAccumulativeChecksumMutation(msg)) {
 					// We have to check accumulative checksum when iterating through cloneCursor2,
 					// where ss removal by tag assignment takes effect immediately
-					data->acsValidator->addMutation(msg, data->thisServerID, data->tag, data->version.get());
+					data->acsValidator->addMutation(
+					    msg, data->thisServerID, data->tag, data->version.get(), cloneCursor2->version().version);
 				}
 
 				Span span("SS:update"_loc, spanContext);


### PR DESCRIPTION
This PR validates the key invariant kept by the transaction system:
Given a mutation sent by a commit proxy at a commit version, a storage server sees this mutation at the same version provided by tLog cursor.

  20240411-201533-zhewang-1565e777065b17fe           compressed=True data_size=36595364 duration=4889247 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:21:30 sanity=False started=100000 stopped=20240411-213703 submitted=20240411-201533 timeout=5400 username=zhewang


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
