### PR TITLE
updates to add fdb-kubernetes-monitor to the standard build flow

### DIFF
--- a/cmake/InstallLayout.cmake
+++ b/cmake/InstallLayout.cmake
@@ -181,6 +181,7 @@ install(DIRECTORY "${script_dir}/clients/usr/lib/cmake"
 ################################################################################
 
 file(COPY "${PROJECT_SOURCE_DIR}/packaging/docker" DESTINATION "${PROJECT_BINARY_DIR}/packages/")
+file(COPY "${PROJECT_SOURCE_DIR}/fdbkubernetesmonitor" DESTINATION "${PROJECT_BINARY_DIR}/packages/docker/")
 
 ################################################################################
 # General CPack configuration

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -59,7 +59,7 @@ RUN curl -Ls https://github.com/krallin/tini/releases/download/v0.19.0/tini-amd6
 
 WORKDIR /
 
-FROM golang:1.20.12-bullseye AS go-build
+FROM golang:1.22.2-bullseye AS go-build
 
 COPY fdbkubernetesmonitor/ /fdbkubernetesmonitor
 WORKDIR /fdbkubernetesmonitor

--- a/packaging/docker/Dockerfile.eks
+++ b/packaging/docker/Dockerfile.eks
@@ -67,7 +67,7 @@ RUN NO_PROXY="" no_proxy="" curl -Ls https://s3.us-west-2.amazonaws.com/amazon-e
 
 WORKDIR /
 
-FROM golang:1.17.11-bullseye AS go-build
+FROM golang:1.22.2-bullseye AS go-build
 
 COPY fdbkubernetesmonitor/ /fdbkubernetesmonitor
 WORKDIR /fdbkubernetesmonitor

--- a/packaging/docker/build-images.sh
+++ b/packaging/docker/build-images.sh
@@ -247,14 +247,14 @@ build_output_directory="${script_dir}/../../"
 source_code_diretory=$(awk -F= '/foundationdb_SOURCE_DIR:STATIC/{print $2}' "${build_output_directory}/CMakeCache.txt")
 commit_sha=$(cd "${source_code_diretory}" && git rev-parse --verify HEAD --short=10)
 fdb_version=$(cat "${build_output_directory}/version.txt")
-fdb_library_versions=( '5.1.7' '6.1.13' '6.2.30' '6.3.18' "${fdb_version}" )
+fdb_library_versions=( '6.3.25' '7.1.57' '7.3.37' "${fdb_version}" )
 fdb_website="https://github.com/apple/foundationdb/releases/download"
 image_list=(
     'base'
-    # 'go-build'
+    'go-build'
     'foundationdb-base'
     'foundationdb'
-    # 'foundationdb-kubernetes-monitor'
+    'fdb-kubernetes-monitor'
     'foundationdb-kubernetes-sidecar'
     'ycsb'
 )


### PR DESCRIPTION
minor updates to include `fdbkubernetesmonitor` in the developer workflow and docker build.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
