### PR TITLE
fix: golang docker compose example

### DIFF
--- a/packaging/docker/samples/golang/app/fdb.cluster
+++ b/packaging/docker/samples/golang/app/fdb.cluster
@@ -1,1 +1,1 @@
-docker:docker@127.0.0.1:4500
+docker:docker@fdb-coordinator:4500

--- a/packaging/docker/samples/golang/docker-compose.yml
+++ b/packaging/docker/samples/golang/docker-compose.yml
@@ -57,7 +57,8 @@ services:
       context: app
       args:
         FDB_VERSION: ${FDB_VERSION}
-    network_mode: host
+    ports:
+      - 8080:8080/tcp
     environment:
       FDB_COORDINATOR: ${FDB_COORDINATOR}
       FDB_API_VERSION: ${FDB_API_VERSION}


### PR DESCRIPTION
When I run `docker-compose up -d`, I can't use http://localhost:8080/counter to test golang app.

This is because docker-compose.yaml does not expose the port, and fdb.cluster needs to replace the address with the container name.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
