### PR TITLE
fix API_VERSION.

### DIFF
--- a/bindings/go/src/fdb/tenant.go
+++ b/bindings/go/src/fdb/tenant.go
@@ -22,7 +22,7 @@
 
 package fdb
 
-// #define FDB_API_VERSION 710
+// #define FDB_API_VERSION 730
 // #include <foundationdb/fdb_c.h>
 // #include <stdlib.h>
 import "C"


### PR DESCRIPTION
Fix the FDB_API_VERSION define. 

When creating the main PR I noticed that the API VERSION at the top was not defined correctly. Not sure why that didn't cause an issue when I tested it, or in CI but nevertheless, here is a fix.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
