### PR TITLE
add generic interface for transact/read transact.

### DIFF
--- a/bindings/go/go.mod
+++ b/bindings/go/go.mod
@@ -1,4 +1,6 @@
 module github.com/apple/foundationdb/bindings/go
 
+go 1.18
+
 // The FoundationDB go bindings currently have no external golang dependencies outside of
 // the go standard library.

--- a/bindings/go/src/fdb/transact.go
+++ b/bindings/go/src/fdb/transact.go
@@ -1,0 +1,116 @@
+/*
+ * database.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2024 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// FoundationDB Go API
+package fdb
+
+func Transact(db Database, f func(t Transaction) error) error {
+	_, err := db.Transact(func(t Transaction) (interface{}, error) {
+		return nil, f(t)
+	})
+	return err
+}
+
+func Transact1[T any](db Database, f func(t Transaction) (T, error)) (T, error) {
+	v, err := db.Transact(func(t Transaction) (interface{}, error) {
+		return f(t)
+	})
+	if v == nil {
+		var empty T
+		return empty, err
+	}
+	return v.(T), nil
+}
+
+func Transact2[T1 any, T2 any](db Database, f func(t Transaction) (T1, T2, error)) (T1, T2, error) {
+	v, err := db.Transact(func(t Transaction) (interface{}, error) {
+		t1, t2, err := f(t)
+		return []any{t1, t2}, err
+	})
+	if v == nil {
+		var t1 T1
+		var t2 T2
+		return t1, t2, err
+	}
+	a := v.([]interface{})
+	return a[0].(T1), a[1].(T2), err
+}
+
+func Transact3[T1 any, T2 any, T3 any](db Database, f func(t Transaction) (T1, T2, T3, error)) (T1, T2, T3, error) {
+	v, err := db.Transact(func(t Transaction) (interface{}, error) {
+		t1, t2, t3, err := f(t)
+		return []any{t1, t2, t3}, err
+	})
+	if v == nil {
+		var t1 T1
+		var t2 T2
+		var t3 T3
+		return t1, t2, t3, err
+	}
+	a := v.([]interface{})
+	return a[0].(T1), a[1].(T2), a[2].(T3), err
+}
+
+func ReadTransact(db Database, f func(t ReadTransaction) error) error {
+	_, err := db.ReadTransact(func(t ReadTransaction) (interface{}, error) {
+		return nil, f(t)
+	})
+	return err
+}
+
+func ReadTransact1[T any](db Database, f func(t ReadTransaction) (T, error)) (T, error) {
+	v, err := db.ReadTransact(func(t ReadTransaction) (interface{}, error) {
+		return f(t)
+	})
+	if v == nil {
+		var empty T
+		return empty, err
+	}
+	return v.(T), nil
+}
+
+func ReadTransact2[T1 any, T2 any](db Database, f func(t ReadTransaction) (T1, T2, error)) (T1, T2, error) {
+	v, err := db.ReadTransact(func(t ReadTransaction) (interface{}, error) {
+		t1, t2, err := f(t)
+		return []any{t1, t2}, err
+	})
+	if v == nil {
+		var t1 T1
+		var t2 T2
+		return t1, t2, err
+	}
+	a := v.([]interface{})
+	return a[0].(T1), a[1].(T2), err
+}
+
+func ReadTransact3[T1 any, T2 any, T3 any](db Database, f func(t ReadTransaction) (T1, T2, T3, error)) (T1, T2, T3, error) {
+	v, err := db.ReadTransact(func(t ReadTransaction) (interface{}, error) {
+		t1, t2, t3, err := f(t)
+		return []any{t1, t2, t3}, err
+	})
+	if v == nil {
+		var t1 T1
+		var t2 T2
+		var t3 T3
+		return t1, t2, t3, err
+	}
+	a := v.([]interface{})
+	return a[0].(T1), a[1].(T2), a[2].(T3), err
+}


### PR DESCRIPTION
The current `db.Transact` and `db.ReadTransact` relies on `interface{}` and is error prone. This PR provides a new API based around generics for `Transact` and `ReadTransact`.

It is intended to be used like:

```
err = fdb.Transact(db, func(t fdb.Transaction) error {
    ...
})

val, err = fdb.Transact1(db, func(t fdb.Transaction) (string, error) {
    ...
})
```

Any feedback, please let me know. If there is alignment on a solution, then I can add tests, and such.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
