### PR TITLE
Revert "Added perpetualStorageWiggleSpeed check to pick perpetualStoreType"

### DIFF
--- a/fdbserver/DDTeamCollection.actor.cpp
+++ b/fdbserver/DDTeamCollection.actor.cpp
@@ -2539,8 +2539,7 @@ public:
 			// Check if perpetual storage wiggle is enabled and perpetualStoreType is set. If so, we use
 			// perpetualStoreType for all new SSes that match perpetualStorageWiggleLocality.
 			// Note that this only applies to regular storage servers, not TSS.
-			if (!recruitTss && self->configuration.perpetualStorageWiggleSpeed == 1 &&
-			    self->configuration.storageMigrationType == StorageMigrationType::GRADUAL &&
+			if (!recruitTss && self->configuration.storageMigrationType == StorageMigrationType::GRADUAL &&
 			    self->configuration.perpetualStoreType.isValid()) {
 				if (self->configuration.perpetualStorageWiggleLocality == "0") {
 					isr.storeType = self->configuration.perpetualStoreType;


### PR DESCRIPTION
Reverts apple/foundationdb#11272
#11272diff is necessary to avoid unintended changes in prod. But, with this the simulation changes is broken. So reverting the change temporarily.