### PR TITLE
Fix ACS mutation bug and improve accumulative checksum

### DIFF
--- a/fdbclient/ClientKnobs.cpp
+++ b/fdbclient/ClientKnobs.cpp
@@ -337,8 +337,8 @@ void ClientKnobs::initialize(Randomize randomize) {
 	init( REST_KMS_ALLOW_NOT_SECURE_CONNECTION,     false ); if ( randomize && BUGGIFY ) REST_KMS_ALLOW_NOT_SECURE_CONNECTION = !REST_KMS_ALLOW_NOT_SECURE_CONNECTION;
 	init( SIM_KMS_VAULT_MAX_KEYS,                    4096 );
 
-	init( ENABLE_MUTATION_CHECKSUM,                  true ); if ( randomize && BUGGIFY ) ENABLE_MUTATION_CHECKSUM = deterministicRandom()->coinflip();; // Enable this after deserialiser is ported to 7.3.
-	init( ENABLE_ACCUMULATIVE_CHECKSUM,              true ); if ( randomize && BUGGIFY ) ENABLE_ACCUMULATIVE_CHECKSUM = deterministicRandom()->coinflip();; // Enable this after deserialiser is ported to 7.3.
+	init( ENABLE_MUTATION_CHECKSUM,                  true ); if ( randomize && BUGGIFY ) ENABLE_MUTATION_CHECKSUM = deterministicRandom()->coinflip(); // Enable this after deserialiser is ported to 7.3.
+	init( ENABLE_ACCUMULATIVE_CHECKSUM,              true ); if ( randomize && BUGGIFY ) ENABLE_ACCUMULATIVE_CHECKSUM = deterministicRandom()->coinflip(); // Enable this after deserialiser is ported to 7.3.
 	init( ENABLE_ACCUMULATIVE_CHECKSUM_LOGGING,     false );
 	// clang-format on
 }

--- a/fdbclient/ClientKnobs.cpp
+++ b/fdbclient/ClientKnobs.cpp
@@ -337,8 +337,8 @@ void ClientKnobs::initialize(Randomize randomize) {
 	init( REST_KMS_ALLOW_NOT_SECURE_CONNECTION,     false ); if ( randomize && BUGGIFY ) REST_KMS_ALLOW_NOT_SECURE_CONNECTION = !REST_KMS_ALLOW_NOT_SECURE_CONNECTION;
 	init( SIM_KMS_VAULT_MAX_KEYS,                    4096 );
 
-	init( ENABLE_MUTATION_CHECKSUM,                 false ); if ( randomize && BUGGIFY ) ENABLE_MUTATION_CHECKSUM = deterministicRandom()->coinflip();; // Enable this after deserialiser is ported to 7.3.
-	init( ENABLE_ACCUMULATIVE_CHECKSUM,             false ); if ( randomize && BUGGIFY ) ENABLE_ACCUMULATIVE_CHECKSUM = deterministicRandom()->coinflip();; // Enable this after deserialiser is ported to 7.3.
+	init( ENABLE_MUTATION_CHECKSUM,                  true ); if ( randomize && BUGGIFY ) ENABLE_MUTATION_CHECKSUM = deterministicRandom()->coinflip();; // Enable this after deserialiser is ported to 7.3.
+	init( ENABLE_ACCUMULATIVE_CHECKSUM,              true ); if ( randomize && BUGGIFY ) ENABLE_ACCUMULATIVE_CHECKSUM = deterministicRandom()->coinflip();; // Enable this after deserialiser is ported to 7.3.
 	init( ENABLE_ACCUMULATIVE_CHECKSUM_LOGGING,     false );
 	// clang-format on
 }

--- a/fdbserver/AccumulativeChecksumUtil.cpp
+++ b/fdbserver/AccumulativeChecksumUtil.cpp
@@ -251,8 +251,8 @@ void AccumulativeChecksumValidator::restore(const AccumulativeChecksumState& acs
 	ASSERT(CLIENT_KNOBS->ENABLE_MUTATION_CHECKSUM && CLIENT_KNOBS->ENABLE_ACCUMULATIVE_CHECKSUM);
 	const uint16_t& acsIndex = acsState.acsIndex;
 	if (acsState.version > ssVersion) {
-		TraceEvent(SevError, "AcsValidatorAcsMutationVersionMismatch", ssid)
-		    .detail("Context", "Restore")
+		TraceEvent(SevError, "AcsValidatorCorruptionDetected", ssid)
+		    .detail("Reason", "Restored ACS version is larger than storage server version")
 		    .detail("AcsTag", tag)
 		    .detail("AcsIndex", acsIndex)
 		    .detail("SSVersion", ssVersion)

--- a/fdbserver/AccumulativeChecksumUtil.cpp
+++ b/fdbserver/AccumulativeChecksumUtil.cpp
@@ -132,8 +132,8 @@ void AccumulativeChecksumValidator::addMutation(const MutationRef& mutation,
 	if (!mutationBuffer.empty()) {
 		ASSERT(mutationBuffer[0].second.accumulativeChecksumIndex.present());
 		if (mutationBuffer[0].first != mutationVersion) {
-			TraceEvent(SevError, "AcsValidatorAcsMutationVersionMismatch", ssid)
-			    .detail("Context", "AddMutation")
+			TraceEvent(SevError, "AcsValidatorCorruptionDetected", ssid)
+			    .detail("Reason", "Mutation version changed when AddMutation")
 			    .detail("AcsTag", tag)
 			    .detail("AcsIndex", acsIndex)
 			    .detail("MissingVersion", mutationBuffer[0].first)
@@ -142,7 +142,8 @@ void AccumulativeChecksumValidator::addMutation(const MutationRef& mutation,
 			    .detail("MutationVersion", mutationVersion);
 			throw please_reboot();
 		} else if (mutationBuffer[0].second.accumulativeChecksumIndex.get() != acsIndex) {
-			TraceEvent(SevError, "AcsValidatorMissingAcs", ssid)
+			TraceEvent(SevError, "AcsValidatorCorruptionDetected", ssid)
+			    .detail("Reason", "Mutation ACSIndex changed when AddMutation")
 			    .detail("AcsTag", tag)
 			    .detail("AcsIndex", acsIndex)
 			    .detail("MissingAcsIndex", mutationBuffer[0].second.accumulativeChecksumIndex.get())
@@ -170,53 +171,33 @@ Optional<AccumulativeChecksumState> AccumulativeChecksumValidator::processAccumu
     Tag tag,
     Version ssVersion) {
 	ASSERT(CLIENT_KNOBS->ENABLE_MUTATION_CHECKSUM && CLIENT_KNOBS->ENABLE_ACCUMULATIVE_CHECKSUM);
-	const LogEpoch& epoch = acsMutationState.epoch;
 	const uint16_t& acsIndex = acsMutationState.acsIndex;
 	auto it = acsTable.find(acsIndex);
+	bool newEpoch = false;
 	if (it == acsTable.end()) {
-		// Unexpected. Since we assign acs mutation in commit batch
-		// So, there must be acs entry set up when adding the mutations of the batch
-		acsTable[acsIndex] = acsMutationState;
-		mutationBuffer.clear();
-		if (CLIENT_KNOBS->ENABLE_ACCUMULATIVE_CHECKSUM_LOGGING) {
-			TraceEvent(SevError, "AcsValidatorAcsMutationSkip", ssid)
-			    .detail("Reason", "No Entry")
-			    .detail("AcsTag", tag)
-			    .detail("AcsIndex", acsIndex)
-			    .detail("SSVersion", ssVersion)
-			    .detail("Epoch", epoch);
-		}
-		return acsMutationState;
+		newEpoch = true;
+	} else if (acsMutationState.epoch > it->second.epoch) {
+		acsTable.erase(it); // Clear the old acs state if new epoch comes
+		newEpoch = true;
 	}
-	if ((acsMutationState.version < it->second.version || acsMutationState.epoch < it->second.epoch)) {
-		mutationBuffer.clear();
-		if (CLIENT_KNOBS->ENABLE_ACCUMULATIVE_CHECKSUM_LOGGING) {
-			TraceEvent(SevError, "AcsValidatorAcsMutationSkip", ssid)
-			    .detail("Reason", "Acs Mutation Too Old")
-			    .detail("AcsTag", tag)
-			    .detail("AcsIndex", acsIndex)
-			    .detail("SSVersion", ssVersion)
-			    .detail("AcsMutation", acsMutationState.toString())
-			    .detail("Epoch", epoch);
-		}
-		return Optional<AccumulativeChecksumState>();
+	// Calculate acs value by mutation buffer and compare it with acs value in acs mutation
+	if (mutationBuffer.size() == 0) {
+		TraceEvent(SevError, "AcsValidatorCorruptionDetected", ssid)
+		    .detail("Reason", "Mutation buffer is empty when processAccumulativeChecksum")
+		    .detail("AcsTag", tag)
+		    .detail("AcsIndex", acsIndex)
+		    .detail("SSVersion", ssVersion);
+		throw please_reboot();
 	}
-	// Clear the old acs state if new epoch comes
-	bool cleared = false;
-	if (acsMutationState.epoch > it->second.epoch) {
-		acsTable.erase(it);
-		cleared = true;
-	}
-	// Apply mutations in cache to acs
-	ASSERT(mutationBuffer.size() >= 1);
-	uint32_t oldAcs = !cleared ? it->second.acs : initialAccumulativeChecksum;
-	Version oldVersion = !cleared ? it->second.version : 0;
+	uint32_t oldAcs = newEpoch ? initialAccumulativeChecksum : it->second.acs;
+	Version oldVersion = newEpoch ? 0 : it->second.version; // used for logging only, simply set it 0 if newEpoch
 	uint32_t newAcs = aggregateAcs(oldAcs, mutationBuffer);
 	checkedMutations = checkedMutations + mutationBuffer.size();
 	checkedVersions = checkedVersions + 1;
 	Version newVersion = acsMutationState.version;
 	if (newAcs != acsMutationState.acs) {
-		TraceEvent(SevError, "AcsValidatorAcsMutationMismatch", ssid)
+		TraceEvent(SevError, "AcsValidatorCorruptionDetected", ssid)
+		    .detail("Reason", "ACS value mismatch when processAccumulativeChecksum")
 		    .detail("AcsTag", tag)
 		    .detail("AcsIndex", acsIndex)
 		    .detail("SSVersion", ssVersion)
@@ -226,11 +207,13 @@ Optional<AccumulativeChecksumState> AccumulativeChecksumValidator::processAccumu
 		    .detail("ToVersion", newVersion)
 		    .detail("AcsToValidate", acsMutationState.acs)
 		    .detail("Epoch", acsMutationState.epoch)
-		    .detail("Cleared", cleared);
+		    .detail("NewEpoch", newEpoch);
 		throw please_reboot();
 	} else if (newVersion != mutationBuffer.back().first) {
-		TraceEvent(SevError, "AcsValidatorAcsMutationVersionMismatch", ssid)
-		    .detail("Context", "ValidateAcs")
+		TraceEvent(SevError, "AcsValidatorCorruptionDetected", ssid)
+		    .detail(
+		        "Reason",
+		        "ACS mutation version is different from mutation version in buffer when processAccumulativeChecksum")
 		    .detail("AcsTag", tag)
 		    .detail("AcsIndex", acsIndex)
 		    .detail("LastMutationVersion", mutationBuffer.back().first)
@@ -249,10 +232,14 @@ Optional<AccumulativeChecksumState> AccumulativeChecksumValidator::processAccumu
 			    .detail("ToAcs", newAcs)
 			    .detail("ToVersion", newVersion)
 			    .detail("Epoch", acsMutationState.epoch)
-			    .detail("Cleared", cleared);
+			    .detail("NewEpoch", newEpoch);
 		}
 	}
-	it->second = acsMutationState;
+	if (newEpoch) {
+		acsTable[acsIndex] = acsMutationState;
+	} else {
+		it->second = acsMutationState;
+	}
 	mutationBuffer.clear();
 	return acsMutationState;
 }

--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -1963,8 +1963,9 @@ void addAccumulativeChecksumMutations(CommitBatchContext* self) {
 		MutationRef acsMutation;
 		acsMutation.type = MutationRef::SetValue;
 		acsMutation.param1 = accumulativeChecksumKey; // private mutation
-		acsMutation.param2 = accumulativeChecksumValue(
+		Value acsValue = accumulativeChecksumValue(
 		    AccumulativeChecksumState(acsIndex, acsState.acs, self->commitVersion, self->pProxyCommitData->epoch));
+		acsMutation.param2 = acsValue;
 		acsMutation.setAccumulativeChecksumIndex(acsIndex);
 		if (CLIENT_KNOBS->ENABLE_ACCUMULATIVE_CHECKSUM_LOGGING) {
 			TraceEvent(SevInfo, "AcsBuilderIssueAccumulativeChecksumMutation", self->pProxyCommitData->dbgid)


### PR DESCRIPTION
Improve ACS implementation in following aspects:
- Refactor processAccumulativeChecksum
- Refactor ACS corruption event
- Open ACS by default
- Fix memory corruption of ACS mutation

Passed 100K correctness test:
  20240420-000939-zhewang-b8e8fae4b2b6179c           compressed=True data_size=36684040 duration=6349222 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:34:19 sanity=False started=100000 stopped=20240420-004358 submitted=20240420-000939 timeout=5400 username=zhewang






# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
