### PR TITLE
fix: encodeTuple int32 panic

### DIFF
--- a/bindings/go/src/fdb/tuple/tuple.go
+++ b/bindings/go/src/fdb/tuple/tuple.go
@@ -376,6 +376,8 @@ func (p *packer) encodeTuple(t Tuple, nested bool, versionstamps bool) {
 			}
 		case int:
 			p.encodeInt(int64(e))
+		case int32:
+			p.encodeInt(int64(e))
 		case int64:
 			p.encodeInt(e)
 		case uint:
@@ -433,7 +435,6 @@ func (p *packer) encodeTuple(t Tuple, nested bool, versionstamps bool) {
 //
 // This method will panic if it contains an incomplete Versionstamp. Use
 // PackWithVersionstamp instead.
-//
 func (t Tuple) Pack() []byte {
 	p := newPacker()
 	p.encodeTuple(t, false, false)


### PR DESCRIPTION
When using int32 type in tuple and Pack, error will occur:

`panic: unencodable element at index 0 (1, type int32)`

The following example can be reproduced:

```go
package main

import (
	"github.com/apple/foundationdb/bindings/go/src/fdb"
	"github.com/apple/foundationdb/bindings/go/src/fdb/tuple"
)

func main() {
	fdb.MustAPIVersion(730)
	var i int32 = 1
	tuple.Tuple{i}.Pack()
}
```

This is because encodeTuple does not handle int32.

In the Go language, int and int32 are not the same type.

Fixed by adding support for int32.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
