### PR TITLE
Update the config for golangci-lint and remove unused variables

### DIFF
--- a/fdbkubernetesmonitor/.golangci.yml
+++ b/fdbkubernetesmonitor/.golangci.yml
@@ -1,54 +1,89 @@
 issues:
+  exclude-files:
+    - "zz_generated.*\\.go$"
   # don't skip warning about doc comments
   # don't exclude the default set of lint
   exclude-use-default: false
+  exclude:
+    - "ST1000: at least one file in a package should have a package comment"
   exclude-rules:
-  # exclude deprecation warning otherwise we get an error for our own deprecations
-  - linters: [staticcheck]
-    text: "SA1019:"
-  - linters: [ govet ]
-    text: 'declaration of "(err|ctx)" shadows declaration at'
+    - path: _test\.go
+      linters:
+        - revive
+      text: "dot-imports: should not use dot imports"
+    # exclude deprecation warning otherwise we get an error for our own deprecations
+    - linters:
+        - staticcheck
+      text: "SA1019:"
+    - linters:
+        - govet
+      text: 'declaration of "(err|ctx)" shadows declaration at'
+    - linters:
+        - revive
+      text: "package-comments: should have a package comment"
 
 linters:
   disable-all: true
-  # TODO(johscheuer): activate linters again and fix issues
   enable:
-    - deadcode
-    #- dupl
+    - asciicheck
+    - bodyclose
+    - depguard
+    - dogsled
     - errcheck
-    #- goconst
-    #- gocyclo
+    - errorlint
+    - exportloopref
+    #    - goconst
+    #    - gocritic
+    #    - gocyclo
     - gofmt
-    - goimports
-    - revive
-    #- gosec
+    #- goimports
+    - goprintffuncname
+    #    - gosec
     - gosimple
     - govet
+    - importas
     - ineffassign
-    #- interfacer
-    #- lll
-    #- maligned
     - misspell
     - nakedret
+    - nilerr
+    #    - nolintlint
     - prealloc
-    - exportloopref
+    - revive
+    - rowserrcheck
     - staticcheck
-    - structcheck
+    - stylecheck
     - typecheck
     - unconvert
     - unparam
     - unused
-    - varcheck
+    - whitespace
 
 linters-settings:
   errcheck:
-    # path to a file containing a list of functions to exclude from checking
-    # see https://github.com/kisielk/errcheck#excluding-functions for details
-    exclude: errcheck_excludes.txt
+    exclude-functions:
+      - (io.Closer).Close
+      - (*os.File).Close
   govet:
     enable:
       - shadow
+  depguard:
+    rules:
+      main:
+        allow:
+          - $gostd
+          - github.com/apple/foundationdb
+          - sigs.k8s.io/controller-runtime
+          - k8s.io/apimachinery
+          - k8s.io/client-go
+          - k8s.io/api
+          - k8s.io/utils
+          - github.com/onsi/gomega
+          - github.com/onsi/ginkgo
+          - github.com/spf13/pflag
+          - github.com/prometheus
+          - github.com/go-logr
+          - github.com/fsnotify/fsnotify
+
 run:
-  deadline: 5m
-  skip-files:
-    - ".*_generated.*.go$"
+  timeout: 10m
+  allow-parallel-runners: true

--- a/fdbkubernetesmonitor/errcheck_excludes.txt
+++ b/fdbkubernetesmonitor/errcheck_excludes.txt
@@ -1,2 +1,0 @@
-(io.Closer).Close
-(*os.File).Close

--- a/fdbkubernetesmonitor/go.mod
+++ b/fdbkubernetesmonitor/go.mod
@@ -19,7 +19,7 @@
 
 module github.com/apple/foundationdb/fdbkubernetesmonitor
 
-go 1.20
+go 1.22
 
 require (
 	github.com/fsnotify/fsnotify v1.6.0

--- a/fdbkubernetesmonitor/main.go
+++ b/fdbkubernetesmonitor/main.go
@@ -37,26 +37,18 @@ import (
 )
 
 var (
-	inputDir                string
-	fdbserverPath           string
-	versionFilePath         string
-	sharedBinaryDir         string
-	monitorConfFile         string
-	logPath                 string
-	executionModeString     string
-	outputDir               string
-	mainContainerVersion    string
-	currentContainerVersion string
-	additionalEnvFile       string
-	binaryOutputDirectory   string
-	listenAddress           string
-	copyPrimaryLibrary      string
-	requiredCopyFiles       []string
-	copyFiles               []string
-	copyBinaries            []string
-	copyLibraries           []string
-	processCount            int
-	enablePprof             bool
+	fdbserverPath        string
+	versionFilePath      string
+	sharedBinaryDir      string
+	monitorConfFile      string
+	logPath              string
+	executionModeString  string
+	outputDir            string
+	mainContainerVersion string
+	additionalEnvFile    string
+	listenAddress        string
+	processCount         int
+	enablePprof          bool
 )
 
 type executionMode string


### PR DESCRIPTION
Updates the golangci-lint config for go 1.22 and remove unused variables.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
