### PR TITLE
Go binding: do not commit read-only transactions

### DIFF
--- a/bindings/go/src/fdb/database.go
+++ b/bindings/go/src/fdb/database.go
@@ -61,7 +61,7 @@ type DatabaseOptions struct {
 }
 
 // Close will close the Database and clean up all resources.
-// You have to ensure that you're not resuing this database.
+// You have to ensure that you're not reusing this database.
 func (d Database) Close() {
 	// Remove database object from the cached databases
 	if d.isCached {


### PR DESCRIPTION
Do not commit read-only transactions following the [C API documentation](https://apple.github.io/foundationdb/api-c.html#c.fdb_transaction_commit):
> It is not necessary to commit a read-only transaction – you can simply call fdb_transaction_destroy().

No forms of testing were done as I cannot locate a test suite for the Go bindings; would be happy to contribute some in a separate PR.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
