### PR TITLE
Fix data move trigger for rebalancing SS queue

### DIFF
--- a/fdbserver/DDShardTracker.actor.cpp
+++ b/fdbserver/DDShardTracker.actor.cpp
@@ -1469,6 +1469,44 @@ ACTOR Future<Void> fetchShardMetricsList(DataDistributionTracker* self, GetMetri
 	return Void();
 }
 
+void triggerStorageQueueRebalance(DataDistributionTracker* self, RebalanceStorageQueueRequest req) {
+	TraceEvent e("TriggerDataMoveStorageQueueRebalance", self->distributorId);
+	e.detail("Server", req.serverId);
+	e.detail("Teams", req.teams.size());
+	int64_t maxShardWriteTraffic = 0;
+	KeyRange shardToMove;
+	ShardsAffectedByTeamFailure::Team selectedTeam;
+	for (const auto& team : req.teams) {
+		for (auto const& shard : self->shardsAffectedByTeamFailure->getShardsFor(team)) {
+			for (auto it : self->shards->intersectingRanges(shard)) {
+				if (it->value().stats->get().present()) {
+					int64_t shardWriteTraffic = it->value().stats->get().get().metrics.bytesWrittenPerKSecond;
+					if (shardWriteTraffic > maxShardWriteTraffic &&
+					    (SERVER_KNOBS->DD_ENABLE_REBALANCE_STORAGE_QUEUE_WITH_LIGHT_WRITE_SHARD ||
+					     shardWriteTraffic > SERVER_KNOBS->REBALANCE_STORAGE_QUEUE_SHARD_PER_KSEC_MIN)) {
+						shardToMove = it->range();
+						maxShardWriteTraffic = shardWriteTraffic;
+					}
+				}
+			}
+		}
+	}
+	if (!shardToMove.empty()) {
+		e.detail("TeamSelected", selectedTeam.servers);
+		e.detail("ShardSelected", shardToMove);
+		e.detail("ShardWriteBytesPerKSec", maxShardWriteTraffic);
+		RelocateShard rs(shardToMove, DataMovementReason::REBALANCE_STORAGE_QUEUE, RelocateReason::REBALANCE_WRITE);
+		self->output.send(rs);
+		TraceEvent("SendRelocateToDDQueue", self->distributorId)
+		    .detail("ServerPrimary", req.primary)
+		    .detail("ServerTeam", selectedTeam.servers)
+		    .detail("KeyBegin", rs.keys.begin)
+		    .detail("KeyEnd", rs.keys.end)
+		    .detail("Priority", rs.priority);
+	}
+	return;
+}
+
 DataDistributionTracker::DataDistributionTracker(DataDistributionTrackerInitParams const& params)
   : IDDShardTracker(), db(params.db), distributorId(params.distributorId), shards(params.shards), actors(false),
     systemSizeEstimate(0), dbSizeEstimate(new AsyncVar<int64_t>()), maxShardSize(new AsyncVar<Optional<int64_t>>()),
@@ -1523,45 +1561,8 @@ struct DataDistributionTrackerImpl {
 				when(GetMetricsListRequest req = waitNext(self->getShardMetricsList)) {
 					self->actors.add(fetchShardMetricsList(self, req));
 				}
-				when(ServerTeamInfo req = waitNext(self->triggerStorageQueueRebalance)) {
-					TraceEvent e("TriggerDataMoveStorageQueueRebalance", self->distributorId);
-					e.detail("Server", req.serverId);
-					e.detail("Teams", req.teams.size());
-					int64_t maxShardWriteTraffic = 0;
-					KeyRange shardToMove;
-					ShardsAffectedByTeamFailure::Team selectedTeam;
-					for (const auto& team : req.teams) {
-						for (auto const& shard : self->shardsAffectedByTeamFailure->getShardsFor(team)) {
-							for (auto it : self->shards->intersectingRanges(shard)) {
-								if (it->value().stats->get().present()) {
-									int64_t shardWriteTraffic =
-									    it->value().stats->get().get().metrics.bytesWrittenPerKSecond;
-									if (shardWriteTraffic > maxShardWriteTraffic &&
-									    (SERVER_KNOBS->DD_ENABLE_REBALANCE_STORAGE_QUEUE_WITH_LIGHT_WRITE_SHARD ||
-									     shardWriteTraffic >
-									         SERVER_KNOBS->REBALANCE_STORAGE_QUEUE_SHARD_PER_KSEC_MIN)) {
-										shardToMove = it->range();
-										maxShardWriteTraffic = shardWriteTraffic;
-									}
-								}
-							}
-						}
-					}
-					if (!shardToMove.empty()) {
-						e.detail("TeamSelected", selectedTeam.servers);
-						e.detail("ShardSelected", shardToMove);
-						e.detail("ShardWriteBytesPerKSec", maxShardWriteTraffic);
-						RelocateShard rs(shardToMove,
-						                 SERVER_KNOBS->PRIORITY_REBALANCE_STORAGE_QUEUE,
-						                 RelocateReason::REBALANCE_WRITE);
-						self->output.send(rs);
-						TraceEvent("SendRelocateToDDQueue", self->distributorId)
-						    .detail("ServerPrimary", req.primary)
-						    .detail("ServerTeam", selectedTeam.servers)
-						    .detail("KeyBegin", rs.keys.begin)
-						    .detail("KeyEnd", rs.keys.end)
-						    .detail("Priority", rs.priority);
-					}
+				when(RebalanceStorageQueueRequest req = waitNext(self->triggerStorageQueueRebalance)) {
+					triggerStorageQueueRebalance(self, req);
 				}
 				when(wait(self->actors.getResult())) {}
 				when(TenantCacheTenantCreated newTenant = waitNext(tenantCreationSignal.getFuture())) {
@@ -1578,13 +1579,14 @@ struct DataDistributionTrackerImpl {
 	}
 };
 
-Future<Void> DataDistributionTracker::run(Reference<DataDistributionTracker> self,
-                                          const Reference<InitialDataDistribution>& initData,
-                                          const FutureStream<GetMetricsRequest>& getShardMetrics,
-                                          const FutureStream<GetTopKMetricsRequest>& getTopKMetrics,
-                                          const FutureStream<GetMetricsListRequest>& getShardMetricsList,
-                                          const FutureStream<Promise<int64_t>>& getAverageShardBytes,
-                                          const FutureStream<ServerTeamInfo>& triggerStorageQueueRebalance) {
+Future<Void> DataDistributionTracker::run(
+    Reference<DataDistributionTracker> self,
+    const Reference<InitialDataDistribution>& initData,
+    const FutureStream<GetMetricsRequest>& getShardMetrics,
+    const FutureStream<GetTopKMetricsRequest>& getTopKMetrics,
+    const FutureStream<GetMetricsListRequest>& getShardMetricsList,
+    const FutureStream<Promise<int64_t>>& getAverageShardBytes,
+    const FutureStream<RebalanceStorageQueueRequest>& triggerStorageQueueRebalance) {
 	self->getShardMetrics = getShardMetrics;
 	self->getTopKMetrics = getTopKMetrics;
 	self->getShardMetricsList = getShardMetricsList;

--- a/fdbserver/DDTeamCollection.actor.cpp
+++ b/fdbserver/DDTeamCollection.actor.cpp
@@ -1598,7 +1598,7 @@ public:
 								teams.push_back(ShardsAffectedByTeamFailure::Team(servers, self->primary));
 							}
 							self->triggerStorageQueueRebalance.send(
-							    ServerTeamInfo(server->getId(), teams, self->primary));
+							    RebalanceStorageQueueRequest(server->getId(), teams, self->primary));
 						}
 					}
 				}
@@ -6009,7 +6009,7 @@ public:
 		                                                     Promise<UID>(),
 		                                                     PromiseStream<Promise<int>>(),
 		                                                     PromiseStream<Promise<int64_t>>(),
-		                                                     PromiseStream<ServerTeamInfo>() }));
+		                                                     PromiseStream<RebalanceStorageQueueRequest>() }));
 
 		for (int id = 1; id <= processCount; ++id) {
 			UID uid(id, 0);
@@ -6063,7 +6063,7 @@ public:
 		                                                     Promise<UID>(),
 		                                                     PromiseStream<Promise<int>>(),
 		                                                     PromiseStream<Promise<int64_t>>(),
-		                                                     PromiseStream<ServerTeamInfo>() }));
+		                                                     PromiseStream<RebalanceStorageQueueRequest>() }));
 
 		for (int id = 1; id <= processCount; id++) {
 			UID uid(id, 0);

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -1033,7 +1033,7 @@ ACTOR Future<Void> dataDistribution(Reference<DataDistributor> self,
 			ASSERT(self->configuration.storageTeamSize > 0);
 
 			state PromiseStream<Promise<int64_t>> getAverageShardBytes;
-			state PromiseStream<ServerTeamInfo> triggerStorageQueueRebalance;
+			state PromiseStream<RebalanceStorageQueueRequest> triggerStorageQueueRebalance;
 			state PromiseStream<Promise<int>> getUnhealthyRelocationCount;
 			state PromiseStream<GetMetricsRequest> getShardMetrics;
 			state PromiseStream<GetTopKMetricsRequest> getTopKShardMetrics;

--- a/fdbserver/include/fdbserver/DDShardTracker.h
+++ b/fdbserver/include/fdbserver/DDShardTracker.h
@@ -30,7 +30,7 @@ public:
 	FutureStream<GetTopKMetricsRequest> getTopKMetrics;
 	FutureStream<GetMetricsListRequest> getShardMetricsList;
 	FutureStream<Promise<int64_t>> averageShardBytes;
-	FutureStream<ServerTeamInfo> triggerStorageQueueRebalance;
+	FutureStream<RebalanceStorageQueueRequest> triggerStorageQueueRebalance;
 
 	virtual double getAverageShardBytes() = 0;
 	virtual ~IDDShardTracker() = default;
@@ -123,7 +123,7 @@ public:
 	                        FutureStream<GetTopKMetricsRequest> const& getTopKMetrics,
 	                        FutureStream<GetMetricsListRequest> const& getShardMetricsList,
 	                        FutureStream<Promise<int64_t>> const& getAverageShardBytes,
-	                        FutureStream<ServerTeamInfo> const& triggerStorageQueueRebalance);
+	                        FutureStream<RebalanceStorageQueueRequest> const& triggerStorageQueueRebalance);
 
 	explicit DataDistributionTracker(DataDistributionTrackerInitParams const& params);
 };

--- a/fdbserver/include/fdbserver/DDTeamCollection.h
+++ b/fdbserver/include/fdbserver/DDTeamCollection.h
@@ -199,7 +199,7 @@ struct DDTeamCollectionInitParams {
 	Promise<UID> removeFailedServer;
 	PromiseStream<Promise<int>> getUnhealthyRelocationCount;
 	PromiseStream<Promise<int64_t>> getAverageShardBytes;
-	PromiseStream<ServerTeamInfo> triggerStorageQueueRebalance;
+	PromiseStream<RebalanceStorageQueueRequest> triggerStorageQueueRebalance;
 };
 
 class DDTeamCollection : public ReferenceCounted<DDTeamCollection> {
@@ -238,7 +238,7 @@ protected:
 	Reference<AsyncVar<bool>> processingWiggle; // track whether wiggling relocation is being processed
 	PromiseStream<StorageWiggleValue> nextWiggleInfo;
 	PromiseStream<Promise<int64_t>> getAverageShardBytes;
-	PromiseStream<ServerTeamInfo> triggerStorageQueueRebalance;
+	PromiseStream<RebalanceStorageQueueRequest> triggerStorageQueueRebalance;
 
 	std::vector<Reference<TCTeamInfo>> badTeams;
 	std::vector<Reference<TCTeamInfo>> largeTeams;

--- a/fdbserver/include/fdbserver/DataDistribution.actor.h
+++ b/fdbserver/include/fdbserver/DataDistribution.actor.h
@@ -449,13 +449,15 @@ private:
 	double lastTransitionStartTime;
 };
 
-struct ServerTeamInfo {
+struct RebalanceStorageQueueRequest {
 	UID serverId;
 	std::vector<ShardsAffectedByTeamFailure::Team> teams;
 	bool primary;
 
-	ServerTeamInfo() {}
-	ServerTeamInfo(UID serverId, const std::vector<ShardsAffectedByTeamFailure::Team>& teams, bool primary)
+	RebalanceStorageQueueRequest() {}
+	RebalanceStorageQueueRequest(UID serverId,
+	                             const std::vector<ShardsAffectedByTeamFailure::Team>& teams,
+	                             bool primary)
 	  : serverId(serverId), teams(teams), primary(primary) {}
 };
 

--- a/fdbserver/workloads/MockDDTrackerShardEvaluator.actor.cpp
+++ b/fdbserver/workloads/MockDDTrackerShardEvaluator.actor.cpp
@@ -32,7 +32,7 @@ public:
 	PromiseStream<GetTopKMetricsRequest> getTopKMetrics;
 	PromiseStream<GetMetricsListRequest> getShardMetricsList;
 	PromiseStream<Promise<int64_t>> getAverageShardBytes;
-	PromiseStream<ServerTeamInfo> triggerStorageQueueRebalance;
+	PromiseStream<RebalanceStorageQueueRequest> triggerStorageQueueRebalance;
 
 	KeyRangeMap<ShardTrackedData> shards;
 

--- a/fdbserver/workloads/PerpetualWiggleStatsWorkload.actor.cpp
+++ b/fdbserver/workloads/PerpetualWiggleStatsWorkload.actor.cpp
@@ -214,7 +214,7 @@ struct PerpetualWiggleStatsWorkload : public TestWorkload {
 		                                      Promise<UID>(),
 		                                      PromiseStream<Promise<int>>(),
 		                                      PromiseStream<Promise<int64_t>>(),
-		                                      PromiseStream<ServerTeamInfo>() });
+		                                      PromiseStream<RebalanceStorageQueueRequest>() });
 		tester.configuration.storageTeamSize = 3;
 		tester.configuration.perpetualStorageWiggleSpeed = 1;
 


### PR DESCRIPTION
Fix data move trigger for rebalancing SS queue
Cleanup code

Passed 100K correctness test:
  20240508-002131-zhewang-8aafdf9e0f16b9a5           compressed=True data_size=36912057 duration=8304145 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:08:10 sanity=False started=100000 stopped=20240508-012941 submitted=20240508-002131 timeout=5400 username=zhewang



# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
