### PR TITLE
Make it so can run the ycsb container standalone without need of a k8s

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -170,7 +170,7 @@ ENV FDB_CLUSTER_FILE_CONTENTS ""
 ENV FDB_PROCESS_CLASS unset
 ENTRYPOINT ["/usr/bin/tini", "-g", "--", "/var/fdb/scripts/fdb.bash"]
 
-FROM base as ycsb
+FROM foundationdb-base as ycsb
 
 RUN yum -y install \
     java-11-openjdk-11.0.13.0.8-1.el7_9 && \
@@ -192,9 +192,11 @@ RUN NO_PROXY="" no_proxy="" curl -Ls https://s3.us-west-2.amazonaws.com/amazon-e
 
 # TODO: Log4J complains that it's eating the HTracer logs.  Even without it, we get per-operation
 # time series graphs of throughput, median, 90, 99, 99.9 and 99.99 (in usec).
-ADD run_ycsb.sh /usr/local/bin/run_ycsb.sh
+ADD run_ycsb.sh run_ycsb_standalone.sh /usr/local/bin
 RUN mkdir -p /var/log/fdb-trace-logs && \
-    chmod +x /usr/local/bin/run_ycsb.sh
+    chmod +x /usr/local/bin/run_ycsb.sh && \
+    chmod +x /usr/local/bin/run_ycsb_standalone.sh
+
 
 ADD YCSB /YCSB
 WORKDIR /YCSB
@@ -202,4 +204,4 @@ ENV FDB_NETWORK_OPTION_EXTERNAL_CLIENT_DIRECTORY=/var/dynamic-conf/lib/multivers
 ENV FDB_NETWORK_OPTION_TRACE_ENABLE=/var/log/fdb-trace-logs
 ENV LD_LIBRARY_PATH=/var/dynamic-conf/lib/
 ENV BUCKET=""
-CMD ["run_ycsb.sh"]
+ENTRYPOINT ["run_ycsb.sh"]

--- a/packaging/docker/Dockerfile.eks
+++ b/packaging/docker/Dockerfile.eks
@@ -178,7 +178,7 @@ ENV FDB_CLUSTER_FILE_CONTENTS ""
 ENV FDB_PROCESS_CLASS unset
 ENTRYPOINT ["/usr/bin/tini", "-g", "--", "/var/fdb/scripts/fdb.bash"]
 
-FROM base as ycsb
+FROM foundationdb-base as ycsb
 
 RUN yum -y install \
     java-11-amazon-corretto-11.0.13+8-1.amzn2 && \
@@ -187,9 +187,10 @@ RUN yum -y install \
 
 # TODO: Log4J complains that it's eating the HTracer logs.  Even without it, we get per-operation
 # time series graphs of throughput, median, 90, 99, 99.9 and 99.99 (in usec).
-ADD run_ycsb.sh /usr/local/bin/run_ycsb.sh
+ADD run_ycsb.sh run_ycsb_standalone.sh /usr/local/bin
 RUN mkdir -p /var/log/fdb-trace-logs && \
-    chmod +x /usr/local/bin/run_ycsb.sh
+    chmod +x /usr/local/bin/run_ycsb.sh && \
+    chmod +x /usr/local/bin/run_ycsb_standalone.sh
 
 ADD YCSB /YCSB
 WORKDIR /YCSB
@@ -197,4 +198,4 @@ ENV FDB_NETWORK_OPTION_EXTERNAL_CLIENT_DIRECTORY=/var/dynamic-conf/lib/multivers
 ENV FDB_NETWORK_OPTION_TRACE_ENABLE=/var/log/fdb-trace-logs
 ENV LD_LIBRARY_PATH=/var/dynamic-conf/lib/
 ENV BUCKET=""
-CMD ["run_ycsb.sh"]
+ENTRYPOINT ["run_ycsb.sh"]

--- a/packaging/docker/run_ycsb_standalone.sh
+++ b/packaging/docker/run_ycsb_standalone.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# This script is like the run_ycsb.sh script only there is no presumption of
+# a k8s context. It also takes a method from the adjacent fdb.bash script for
+# writing out an fdb.cluster file based off environment variables.
+set -Eeuo pipefail
+
+function logg () {
+    printf "##### $(date +'%Y-%m-%dT%H:%M:%SZ') #  %-56.55s #####\n" "${1}"
+}
+
+function error_exit () {
+    echo "################################################################################"
+    logg "${0} FAILED"
+    logg "RUN_ID: ${RUN_ID}"
+    logg "WORKLOAD: ${WORKLOAD}"
+    logg "ENVIRONMENT IS:"
+    env
+    echo "################################################################################"
+}
+
+function create_cluster_file() {
+    FDB_CLUSTER_FILE=${FDB_CLUSTER_FILE:-/etc/foundationdb/fdb.cluster}
+    mkdir -p "$(dirname $FDB_CLUSTER_FILE)"
+
+    if [[ -n "$FDB_CLUSTER_FILE_CONTENTS" ]]; then
+        echo "$FDB_CLUSTER_FILE_CONTENTS" > "$FDB_CLUSTER_FILE"
+    elif [[ -n $FDB_COORDINATOR ]]; then
+        coordinator_ip=$(dig +short "$FDB_COORDINATOR")
+        if [[ -z "$coordinator_ip" ]]; then
+            echo "Failed to look up coordinator address for $FDB_COORDINATOR" 1>&2
+            exit 1
+        fi
+        coordinator_port=${FDB_COORDINATOR_PORT:-4500}
+        echo "docker:docker@$coordinator_ip:$coordinator_port" > "$FDB_CLUSTER_FILE"
+    else
+        echo "FDB_COORDINATOR environment variable not defined" 1>&2
+        exit 1
+    fi
+}
+
+trap error_exit ERR
+
+logg "RUNNING YCSB ${WORKLOAD}"
+set -x
+create_cluster_file
+./bin/ycsb.sh "${MODE}" foundationdb -s -P "workloads/${WORKLOAD}" "${YCSB_ARGS}"
+set +x
+logg "YCSB ${WORKLOAD} FINISHED"
+
+echo "################################################################################"
+logg "COMPLETED ${0}"
+logg "RUN_ID: ${RUN_ID}"
+logg "WORKLOAD: ${WORKLOAD}"
+echo "################################################################################"


### PR DESCRIPTION
context (useful for running ycsb against bare metal cluster).

* packaging/docker/Dockerfile
* packaging/docker/Dockerfile.eks Make the ycsb target inherit from foundationdb-base so we pick up libfdb_c.so. Add in a version of run_ycsb.sh that doesn't presume k8s. Use 'entrypoint' rather than 'cmd' so can override on 'docker run'.

* packaging/docker/run_ycsb_standalone.sh Version of run_ycsb.sh w/o the presumption of k8s.

Replace this text with your description here...

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
