### PR TITLE
Go binding: do not use pointer receiver for Close()

### DIFF
--- a/bindings/go/src/fdb/database.go
+++ b/bindings/go/src/fdb/database.go
@@ -62,7 +62,7 @@ type DatabaseOptions struct {
 
 // Close will close the Database and clean up all resources.
 // You have to ensure that you're not resuing this database.
-func (d *Database) Close() {
+func (d Database) Close() {
 	// Remove database object from the cached databases
 	if d.isCached {
 		openDatabases.Delete(d.clusterFile)

--- a/bindings/go/src/fdb/fdb.go
+++ b/bindings/go/src/fdb/fdb.go
@@ -345,7 +345,7 @@ func createDatabase(clusterFile string) (Database, error) {
 	db := &database{outdb}
 	runtime.SetFinalizer(db, (*database).destroy)
 
-	return Database{clusterFile, true, db}, nil
+	return Database{clusterFile: clusterFile, isCached: true, database: db}, nil
 }
 
 // OpenWithConnectionString returns a database handle to the FoundationDB cluster identified


### PR DESCRIPTION
A mix of pointer/non-pointer receivers makes it impossible to use interfaces for the `fdb.Database` type; I propose to change the `Close()` method for consistency.

See https://go.dev/play/p/PQ_FDXajpnB for an example of the problem (needs to be run locally):
```
# command-line-arguments
./main.go:18:22: cannot use fdb.Database{} (value of type fdb.Database) as FoundationDB value in variable declaration: fdb.Database does not implement FoundationDB (method Close has pointer receiver)
```

Custom interfaces can still be used by using a pointer instead of directly the `fdb.Database` type:
```go
var _ FoundationDB = &fdb.Database{}
```

But that's less efficient.

NOTE: no test was updated

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
