### PR TITLE
Add default timeout for fdbbackup

### DIFF
--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -4141,6 +4141,12 @@ int main(int argc, char* argv[]) {
 			Optional<Database> result = connectToCluster(clusterFile, localities, quiet);
 			if (result.present()) {
 				db = result.get();
+				// Make sure we are setting a transaction timeout and retry limit to prevent cases
+				// where the fdbbackup command hangs infinitely. 60 seconds should be more than
+				// enough for all cases to finish and 5 retries should also be good enough for
+				// most cases.
+				db->setOption(FDBDatabaseOptions::TRANSACTION_TIMEOUT, Optional<StringRef>(StringRef((const uint8_t*)60000, 8)));
+				db->setOption(FDBDatabaseOptions::TRANSACTION_RETRY_LIMIT, Optional<StringRef>(StringRef((const uint8_t*)5, 8)));
 			}
 
 			return result.present();
@@ -4157,6 +4163,12 @@ int main(int argc, char* argv[]) {
 			Optional<Database> result = connectToCluster(sourceClusterFile, localities, quiet);
 			if (result.present()) {
 				sourceDb = result.get();
+				// Make sure we are setting a transaction timeout and retry limit to prevent cases
+				// where the fdbbackup command hangs infinitely. 60 seconds should be more than
+				// enough for all cases to finish and 5 retries should also be good enough for
+				// most cases.
+				sourceDb->setOption(FDBDatabaseOptions::TRANSACTION_TIMEOUT, Optional<StringRef>(StringRef((const uint8_t*)60000, 8)));
+				sourceDb->setOption(FDBDatabaseOptions::TRANSACTION_RETRY_LIMIT, Optional<StringRef>(StringRef((const uint8_t*)5, 8)));
 			}
 
 			return result.present();

--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -4145,8 +4145,10 @@ int main(int argc, char* argv[]) {
 				// where the fdbbackup command hangs infinitely. 60 seconds should be more than
 				// enough for all cases to finish and 5 retries should also be good enough for
 				// most cases.
-				db->setOption(FDBDatabaseOptions::TRANSACTION_TIMEOUT, Optional<StringRef>(StringRef((const uint8_t*)60000, 8)));
-				db->setOption(FDBDatabaseOptions::TRANSACTION_RETRY_LIMIT, Optional<StringRef>(StringRef((const uint8_t*)5, 8)));
+				db->setOption(FDBDatabaseOptions::TRANSACTION_TIMEOUT,
+				              Optional<StringRef>(StringRef((const uint8_t*)60000, 8)));
+				db->setOption(FDBDatabaseOptions::TRANSACTION_RETRY_LIMIT,
+				              Optional<StringRef>(StringRef((const uint8_t*)5, 8)));
 			}
 
 			return result.present();
@@ -4167,8 +4169,10 @@ int main(int argc, char* argv[]) {
 				// where the fdbbackup command hangs infinitely. 60 seconds should be more than
 				// enough for all cases to finish and 5 retries should also be good enough for
 				// most cases.
-				sourceDb->setOption(FDBDatabaseOptions::TRANSACTION_TIMEOUT, Optional<StringRef>(StringRef((const uint8_t*)60000, 8)));
-				sourceDb->setOption(FDBDatabaseOptions::TRANSACTION_RETRY_LIMIT, Optional<StringRef>(StringRef((const uint8_t*)5, 8)));
+				sourceDb->setOption(FDBDatabaseOptions::TRANSACTION_TIMEOUT,
+				                    Optional<StringRef>(StringRef((const uint8_t*)60000, 8)));
+				sourceDb->setOption(FDBDatabaseOptions::TRANSACTION_RETRY_LIMIT,
+				                    Optional<StringRef>(StringRef((const uint8_t*)5, 8)));
 			}
 
 			return result.present();


### PR DESCRIPTION
Add default timeout for fdbbackup to prevent the fdbbackup to hang infinitely in some cases. In general I think having a default timeout is a good practice instead of waiting for an infinite amount of time. We have seen some cases in testing where the fdbbackup agent was able to connect to the cluster but was not able to perform a transaction, in this case the fdbbackup, e.g. describe, will hang forever. Another improvement, in a new PR, could be to add the `timeout` flag to the `fdbbackup` command.

I have to perform some additional testing, so far I verified that the build works and tests are passing.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
