### PR TITLE
Go binding: add StopNetwork()

### DIFF
--- a/bindings/go/src/fdb/errors.go
+++ b/bindings/go/src/fdb/errors.go
@@ -49,7 +49,9 @@ func (e Error) Error() string {
 // SOMEDAY: these (along with others) should be coming from fdb.options?
 
 var (
-	errNetworkNotSetup = Error{2008}
+	errNetworkNotSetup          = Error{2008}
+	errNetworkAlreadySetup      = Error{2009} // currently unused
+	errNetworkCannotBeRestarted = Error{2025} // currently unused
 
 	errAPIVersionUnset        = Error{2200}
 	errAPIVersionAlreadySet   = Error{2201}

--- a/bindings/go/src/fdb/fdb.go
+++ b/bindings/go/src/fdb/fdb.go
@@ -31,7 +31,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"log"
 	"sync"
 	"unsafe"
 )
@@ -197,9 +196,15 @@ var networkMutex sync.RWMutex
 
 var openDatabases sync.Map
 
-func startNetwork() error {
+// executeWithRunningNetworkThread starts the internal network event loop, if not already done,
+// then runs the provided function while network thread is running.
+func executeWithRunningNetworkThread(f func()) error {
 	networkMutex.RLock()
 	if networkStarted {
+
+		// network thread is guaranteed to be running while this user-provided function runs
+		f()
+
 		networkMutex.RUnlock()
 		return nil
 	}
@@ -207,35 +212,37 @@ func startNetwork() error {
 	networkMutex.RUnlock()
 	networkMutex.Lock()
 	defer networkMutex.Unlock()
-	if networkStarted {
-		return nil
-	}
 
-	if e := C.fdb_setup_network(); e != 0 {
-		return Error{int(e)}
-	}
-
-	go func() {
-		e := C.fdb_run_network()
-		if e != 0 {
-			log.Printf("Unhandled error in FoundationDB network thread: %v (%v)\n", C.GoString(C.fdb_get_error(e)), e)
+	// check if meanwhile another goroutine started the network thread
+	if !networkStarted {
+		if e := C.fdb_setup_network(); e != 0 {
+			return Error{int(e)}
 		}
-	}()
 
-	networkStarted = true
+		go func() {
+			e := C.fdb_run_network()
+			if e != 0 {
+				panic(fmt.Sprintf("Unhandled error in FoundationDB network thread: %v (%v)\n", C.GoString(C.fdb_get_error(e)), e))
+			}
+		}()
+
+		networkStarted = true
+	}
+
+	// network thread is guaranteed to be running while this user-provided function runs
+	f()
 
 	return nil
 }
 
 // Deprecated: the network is started automatically when a database is opened.
-// StartNetwork initializes the FoundationDB client networking engine. StartNetwork
-// must not be called more than once.
+// StartNetwork does nothing, but it will ensure that the API version is set and return an error otherwise.
 func StartNetwork() error {
 	if apiVersion == 0 {
 		return errAPIVersionUnset
 	}
 
-	return startNetwork()
+	return nil
 }
 
 // DefaultClusterFile should be passed to fdb.Open to allow the FoundationDB C
@@ -272,10 +279,6 @@ func MustOpenDefault() Database {
 // the multi-version client API must be used.
 // Caller must call Close() to release resources.
 func OpenDatabase(clusterFile string) (Database, error) {
-	if err := ensureNetworkIsStarted(); err != nil {
-		return Database{}, err
-	}
-
 	var db Database
 	var okDb bool
 	anyy, exist := openDatabases.Load(clusterFile)
@@ -289,15 +292,6 @@ func OpenDatabase(clusterFile string) (Database, error) {
 	}
 
 	return db, nil
-}
-
-// ensureNetworkIsStarted starts the network if not already done and ensures that the API version is set.
-func ensureNetworkIsStarted() error {
-	if apiVersion == 0 {
-		return errAPIVersionUnset
-	}
-
-	return startNetwork()
 }
 
 // MustOpenDatabase is like OpenDatabase but panics if the default database cannot
@@ -332,6 +326,10 @@ func MustOpen(clusterFile string, dbName []byte) Database {
 // createDatabase is the internal function used to create a database.
 // Caller must call Close() to release resources.
 func createDatabase(clusterFile string) (Database, error) {
+	if apiVersion == 0 {
+		return Database{}, errAPIVersionUnset
+	}
+
 	var cf *C.char
 
 	if len(clusterFile) != 0 {
@@ -340,8 +338,16 @@ func createDatabase(clusterFile string) (Database, error) {
 	}
 
 	var outdb *C.FDBDatabase
-	if err := C.fdb_create_database(cf, &outdb); err != 0 {
-		return Database{}, Error{int(err)}
+	var createErr error
+	if err := executeWithRunningNetworkThread(func() {
+		if err := C.fdb_create_database(cf, &outdb); err != 0 {
+			createErr = Error{int(err)}
+		}
+	}); err != nil {
+		return Database{}, err
+	}
+	if createErr != nil {
+		return Database{}, createErr
 	}
 
 	db := &database{outdb}
@@ -354,8 +360,8 @@ func createDatabase(clusterFile string) (Database, error) {
 // to the database only for a short time e.g. to test different connection strings.
 // Caller must call Close() to release resources.
 func OpenWithConnectionString(connectionString string) (Database, error) {
-	if err := ensureNetworkIsStarted(); err != nil {
-		return Database{}, err
+	if apiVersion == 0 {
+		return Database{}, errAPIVersionUnset
 	}
 
 	var cf *C.char
@@ -368,8 +374,16 @@ func OpenWithConnectionString(connectionString string) (Database, error) {
 	defer C.free(unsafe.Pointer(cf))
 
 	var outdb *C.FDBDatabase
-	if err := C.fdb_create_database_from_connection_string(cf, &outdb); err != 0 {
-		return Database{}, Error{int(err)}
+	var createErr error
+	if err := executeWithRunningNetworkThread(func() {
+		if err := C.fdb_create_database_from_connection_string(cf, &outdb); err != 0 {
+			createErr = Error{int(err)}
+		}
+	}); err != nil {
+		return Database{}, err
+	}
+	if createErr != nil {
+		return Database{}, createErr
 	}
 
 	db := &database{outdb}


### PR DESCRIPTION
This PR contains the following notable changes:
1. make sure that database creation is happening only while network thread is running
2. panic if the call to `fdb_run_network()` fails, instead of logging an error only
3. `StartNetwork()`, already deprecated, effectively becomes a no-op
4. expose a new `StopNetwork()` method which allows to follow spec for issues like https://github.com/apple/foundationdb/issues/2978 and https://github.com/apple/foundationdb/issues/3015

Any advice for test coverage?

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
