### PR TITLE
build: disable swift prebuilt_for_ide target when Swift is disabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,7 +242,9 @@ if (CMAKE_EXPORT_COMPILE_COMMANDS AND WITH_PYTHON)
   add_custom_target(processed_compile_commands ALL DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/compile_commands.json ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json)
 
   # A prebuild target ensures that all actors, Swift-generated headers, and Swift modules are built.
-  add_custom_target(prebuild_for_ide ALL DEPENDS fdbserver_swift processed_compile_commands)
+  if (WITH_SWIFT)
+     add_custom_target(prebuild_for_ide ALL DEPENDS fdbserver_swift processed_compile_commands)
+  endif()
 endif()
 
 ################################################################################


### PR DESCRIPTION

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
