### PR TITLE
Fix a segfault when tlog encounters platform_error

### DIFF
--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -2548,6 +2548,10 @@ ACTOR Future<Void> rejoinClusterController(TLogData* self,
 			stoppedPromise.send(Void());
 		}
 
+		if (self->terminated.isSet()) {
+			return Void();
+		}
+
 		if (registerWithCC.isReady()) {
 			if (!lastMasterLifetime.isEqual(self->dbInfo->get().masterLifetime)) {
 				// The TLogRejoinRequest is needed to establish communications with a new master, which doesn't have our


### PR DESCRIPTION
During destruction, rejoinClusterController actor should be cancelled to avoid accessing TLogData object.

20240517-212153-jzhou-362ae64fb4cc186e

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
