### PR TITLE
use unique pointer to ensure memory recovery 

### DIFF
--- a/fdbserver/GrvProxyServer.actor.cpp
+++ b/fdbserver/GrvProxyServer.actor.cpp
@@ -199,7 +199,7 @@ struct GrvProxyData {
 	Optional<LatencyBandConfig> latencyBandConfig;
 	double lastStartCommit;
 	double lastCommitLatency;
-	LatencySample* versionVectorSizeOnGRVReply = nullptr;
+	std::unique_ptr<LatencySample> versionVectorSizeOnGRVReply;
 	int updateCommitRequests;
 	NotifiedDouble lastCommitTime;
 
@@ -238,10 +238,11 @@ struct GrvProxyData {
 	    version(0), minKnownCommittedVersion(invalidVersion),
 	    tagThrottler(CLIENT_KNOBS->PROXY_MAX_TAG_THROTTLE_DURATION) {
 		if (SERVER_KNOBS->ENABLE_VERSION_VECTOR) {
-			versionVectorSizeOnGRVReply = new LatencySample("VersionVectorSizeOnGRVReply",
-			                                                dbgid,
-			                                                SERVER_KNOBS->LATENCY_METRICS_LOGGING_INTERVAL,
-			                                                SERVER_KNOBS->LATENCY_SKETCH_ACCURACY);
+			versionVectorSizeOnGRVReply =
+			    std::make_unique<LatencySample>("VersionVectorSizeOnGRVReply",
+			                                    dbgid,
+			                                    SERVER_KNOBS->LATENCY_METRICS_LOGGING_INTERVAL,
+			                                    SERVER_KNOBS->LATENCY_SKETCH_ACCURACY);
 		}
 	}
 };

--- a/fdbserver/include/fdbserver/MasterData.actor.h
+++ b/fdbserver/include/fdbserver/MasterData.actor.h
@@ -127,11 +127,11 @@ struct SWIFT_CXX_REF_MASTERDATA MasterData : NonCopyable, ReferenceCounted<Maste
 	CounterValue reportLiveCommittedVersionRequests;
 	// This counter gives an estimate of the number of non-empty peeks that storage servers
 	// should do from tlogs (in the worst case, ignoring blocking peek timeouts).
-	LatencySample* versionVectorTagUpdates = nullptr;
+	std::unique_ptr<LatencySample> versionVectorTagUpdates;
 	CounterValue waitForPrevCommitRequests;
 	CounterValue nonWaitForPrevCommitRequests;
-	LatencySample* versionVectorSizeOnCVReply = nullptr;
-	LatencySample* waitForPrevLatencies = nullptr;
+	std::unique_ptr<LatencySample> versionVectorSizeOnCVReply;
+	std::unique_ptr<LatencySample> waitForPrevLatencies;
 
 	PromiseStream<Future<Void>> addActor;
 

--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -273,18 +273,18 @@ MasterData::MasterData(Reference<AsyncVar<ServerDBInfo> const> const& dbInfo,
 	locality = tagLocalityInvalid;
 
 	if (SERVER_KNOBS->ENABLE_VERSION_VECTOR) {
-		versionVectorTagUpdates = new LatencySample("VersionVectorTagUpdates",
-		                                            dbgid,
-		                                            SERVER_KNOBS->LATENCY_METRICS_LOGGING_INTERVAL,
-		                                            SERVER_KNOBS->LATENCY_SKETCH_ACCURACY);
-		versionVectorSizeOnCVReply = new LatencySample("VersionVectorSizeOnCVReply",
-		                                               dbgid,
-		                                               SERVER_KNOBS->LATENCY_METRICS_LOGGING_INTERVAL,
-		                                               SERVER_KNOBS->LATENCY_SKETCH_ACCURACY);
-		waitForPrevLatencies = new LatencySample("WaitForPrevLatencies",
-		                                         dbgid,
-		                                         SERVER_KNOBS->LATENCY_METRICS_LOGGING_INTERVAL,
-		                                         SERVER_KNOBS->LATENCY_SKETCH_ACCURACY);
+		versionVectorTagUpdates = std::make_unique<LatencySample>("VersionVectorTagUpdates",
+		                                                          dbgid,
+		                                                          SERVER_KNOBS->LATENCY_METRICS_LOGGING_INTERVAL,
+		                                                          SERVER_KNOBS->LATENCY_SKETCH_ACCURACY);
+		versionVectorSizeOnCVReply = std::make_unique<LatencySample>("VersionVectorSizeOnCVReply",
+		                                                             dbgid,
+		                                                             SERVER_KNOBS->LATENCY_METRICS_LOGGING_INTERVAL,
+		                                                             SERVER_KNOBS->LATENCY_SKETCH_ACCURACY);
+		waitForPrevLatencies = std::make_unique<LatencySample>("WaitForPrevLatencies",
+		                                                       dbgid,
+		                                                       SERVER_KNOBS->LATENCY_METRICS_LOGGING_INTERVAL,
+		                                                       SERVER_KNOBS->LATENCY_SKETCH_ACCURACY);
 	}
 
 #ifdef WITH_SWIFT


### PR DESCRIPTION
use unique point to ensure memory recovery for dynamically allocated LatencyMetrics

`20240520-191358-dlambrig-373d0b73dd02e6c5`
