### PR TITLE
Excluding some sharded rocksdb tests in simulation

### DIFF
--- a/tests/fast/BackupCorrectnessClean.toml
+++ b/tests/fast/BackupCorrectnessClean.toml
@@ -1,5 +1,8 @@
 testClass = "Backup"
 
+[configuration]
+storageEngineExcludeTypes = [5]
+
 [[test]]
 testTitle = 'BackupAndRestore'
 clearAfterTest = false

--- a/tests/fast/BackupToDBCorrectness.toml
+++ b/tests/fast/BackupToDBCorrectness.toml
@@ -4,6 +4,7 @@ testClass = "Backup"
 extraDatabaseMode = 'LocalOrSingle'
 # DR is not currently supported in required tenant mode
 tenantModes = ['disabled', 'optional']
+storageEngineExcludeTypes = [5]
 
 [[test]]
 testTitle = 'BackupAndRestore'


### PR DESCRIPTION
Excluding some sharded rocksdb tests in simulation.
These tests are timing out in simulation, so excluding them temporarily from simulation.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
