### PR TITLE
Fix the key range affected by setting version stamped key

### DIFF
--- a/fdbclient/ReadYourWrites.actor.cpp
+++ b/fdbclient/ReadYourWrites.actor.cpp
@@ -2201,7 +2201,7 @@ RangeResult ReadYourWritesTransaction::getWriteConflictRangeIntersecting(KeyRang
 			// singleKeyRange, but share begin and end's memory
 			range = KeyRangeRef(key.substr(0, key.size() - 4), key.substr(0, key.size() - 3));
 		} else {
-			range = getVersionstampKeyRange(result.arena(), k, tr.getCachedReadVersion().orDefault(0), getMaxReadKey());
+			range = getVersionstampKeyRange(result.arena(), k, tr.getCachedReadVersion(), getMaxReadKey());
 		}
 		writeConflicts.insert(range.withPrefix(writeConflictRangeKeysRange.begin, result.arena()), "1"_sr);
 	}
@@ -2263,7 +2263,7 @@ void ReadYourWritesTransaction::atomicOp(const KeyRef& key, const ValueRef& oper
 	if (operationType == MutationRef::SetVersionstampedKey) {
 		CODE_PROBE(options.readYourWritesDisabled, "SetVersionstampedKey without ryw enabled");
 		// this does validation of the key and needs to be performed before the readYourWritesDisabled path
-		KeyRangeRef range = getVersionstampKeyRange(arena, k, tr.getCachedReadVersion().orDefault(0), getMaxReadKey());
+		KeyRangeRef range = getVersionstampKeyRange(arena, k, tr.getCachedReadVersion(), getMaxReadKey());
 		versionStampKeys.push_back(arena, k);
 		addWriteConflict = AddConflictRange::False;
 		if (!options.readYourWritesDisabled) {
@@ -2273,7 +2273,7 @@ void ReadYourWritesTransaction::atomicOp(const KeyRef& key, const ValueRef& oper
 		// k is the unversionstamped key provided by the user.  If we've filled in a minimum bound
 		// for the versionstamp, we need to make sure that's reflected when we insert it into the
 		// WriteMap below.
-		transformVersionstampKey(k, tr.getCachedReadVersion().orDefault(0), 0);
+		transformVersionstampKey(k, tr.getCachedReadVersion().map([](Version v) { return v + 1; }).orDefault(0), 0);
 	}
 
 	if (operationType == MutationRef::SetVersionstampedValue) {

--- a/fdbclient/include/fdbclient/Atomic.h
+++ b/fdbclient/include/fdbclient/Atomic.h
@@ -265,7 +265,10 @@ inline int32_t parseVersionstampOffset(StringRef& key) {
 /*
  * Returns the range corresponding to the specified versionstamp key.
  */
-inline KeyRangeRef getVersionstampKeyRange(Arena& arena, const KeyRef& key, Version minVersion, const KeyRef& maxKey) {
+inline KeyRangeRef getVersionstampKeyRange(Arena& arena,
+                                           const KeyRef& key,
+                                           Optional<Version> readVersion,
+                                           const KeyRef& maxKey) {
 	KeyRef begin(arena, key);
 	KeyRef end(arena, key);
 
@@ -280,7 +283,7 @@ inline KeyRangeRef getVersionstampKeyRange(Arena& arena, const KeyRef& key, Vers
 	if (pos < 0 || pos + 10 > begin.size())
 		throw client_invalid_operation();
 
-	placeVersionstamp(mutateString(begin) + pos, minVersion, 0);
+	placeVersionstamp(mutateString(begin) + pos, readVersion.map([](Version v) { return v + 1; }).orDefault(0), 0);
 	memset(mutateString(end) + pos, '\xff', 10);
 
 	return KeyRangeRef(begin, std::min(end, maxKey));

--- a/fdbserver/workloads/Unreadable.actor.cpp
+++ b/fdbserver/workloads/Unreadable.actor.cpp
@@ -351,7 +351,7 @@ struct UnreadableWorkload : TestWorkload {
 					key = RandomTestImpl::getRandomVersionstampKey(arena);
 					value = RandomTestImpl::getRandomValue(arena);
 					tr.atomicOp(key, value, MutationRef::SetVersionstampedKey);
-					range = getVersionstampKeyRange(arena, key, tr.getCachedReadVersion().orDefault(0), allKeys.end);
+					range = getVersionstampKeyRange(arena, key, tr.getCachedReadVersion(), allKeys.end);
 					unreadableMap.insert(range, true);
 					//TraceEvent("RYWT_SetVersionstampKey").detail("Range", printable(range));
 				} else if (r == 16) {

--- a/fdbserver/workloads/WriteDuringRead.actor.cpp
+++ b/fdbserver/workloads/WriteDuringRead.actor.cpp
@@ -968,7 +968,7 @@ struct WriteDuringReadWorkload : TestWorkload {
 									Value value = self->getRandomValue();
 									KeyRangeRef range = getVersionstampKeyRange(versionStampKey.arena(),
 									                                            versionStampKey,
-									                                            tr.getCachedReadVersion().orDefault(0),
+									                                            tr.getCachedReadVersion(),
 									                                            normalKeys.end);
 									self->changeCount.insert(range, changeNum++);
 									//TraceEvent("WDRVersionStamp").detail("VersionStampKey", versionStampKey).detail("Range", range);


### PR DESCRIPTION
As explained in [this](https://forums.foundationdb.org/t/why-is-read-or-wrote-unreadable-key-necessary/3753/11) forum post, the range that gets marked as unreadable should start from the next possible read version, not the current one. That's because the final version stamp can't possibly start with the current read version. The `+1` should be added to the read version if it's known.

The test script (JS):

```js
import { beforeEach, test } from 'node:test';
import * as fdb from 'foundationdb';
import assert from 'node:assert';

fdb.setAPIVersion(720);

const db = fdb.open();

beforeEach(() => db.clearRange(Buffer.from([]), Buffer.from([0xff])));

// currently works
test('read from the range of the previous read version', async () => {
	await db.doTn(async tn => {
		const readVersion = await tn.getReadVersion();
		const previousReadVersion = Buffer.from((BigInt(`0x${readVersion.toString('hex')}`) - 1n).toString(16).padStart(16, '0'), 'hex');

		tn.setVersionstampedKeyRaw(Buffer.from([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /**/ 0, 0, 0, 0]), '');

		await tn.get(Buffer.concat([previousReadVersion, Buffer.from([0, 0])]));
		await tn.get(Buffer.concat([previousReadVersion, Buffer.from([0xff, 0xff])]));
	});
});

// will work when 1 is added to the start of the range that's marked unreadable
test('read from the range of the current read version', async () => {
	await db.doTn(async tn => {
		const readVersion = await tn.getReadVersion();

		tn.setVersionstampedKeyRaw(Buffer.from([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /**/ 0, 0, 0, 0]), '');

		await tn.get(Buffer.concat([readVersion, Buffer.from([0, 0])]));
		await tn.get(Buffer.concat([readVersion, Buffer.from([0xff, 0xff])]));
	});
});

// currently works
test('read at the next read version', async () => {
	const result = db.doTn(async tn => {
		const readVersion = await tn.getReadVersion();
		const nextReadVersion = Buffer.from((BigInt(`0x${readVersion.toString('hex')}`) + 1n).toString(16).padStart(16, '0'), 'hex');

		tn.setVersionstampedKeyRaw(Buffer.from([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /**/ 0, 0, 0, 0]), '');

		await tn.get(Buffer.concat([nextReadVersion, Buffer.from([0, 0])]));
	});

	await assert.rejects(result, 'Error: Read or wrote an unreadable key');
});
```

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
