### PR TITLE
Disable tenant in downgrade test to 7.3

### DIFF
--- a/tests/restarting/to_7.3.0_until_7.3.39/BlobGranuleRestartCorrectness-1.toml
+++ b/tests/restarting/to_7.3.0_until_7.3.39/BlobGranuleRestartCorrectness-1.toml
@@ -1,7 +1,7 @@
 [configuration]
 blobGranulesEnabled = true 
 allowDefaultTenant = false
-tenantModes = ['optional', 'required']
+tenantModes = ['disabled']
 injectTargetedSSRestart = true
 injectSSDelay = true
 

--- a/tests/restarting/to_7.3.0_until_7.3.39/BlobGranuleRestartCorrectness-2.toml
+++ b/tests/restarting/to_7.3.0_until_7.3.39/BlobGranuleRestartCorrectness-2.toml
@@ -2,7 +2,7 @@
 [configuration]
 blobGranulesEnabled = true 
 allowDefaultTenant = false
-tenantModes = ['optional', 'required']
+tenantModes = ['disabled']
 injectTargetedSSRestart = true
 injectSSDelay = true
 

--- a/tests/restarting/to_7.3.0_until_7.3.39/ConfigureStorageMigrationTestRestart-1.toml
+++ b/tests/restarting/to_7.3.0_until_7.3.39/ConfigureStorageMigrationTestRestart-1.toml
@@ -3,7 +3,7 @@ extraMachineCountDC = 2
 maxTLogVersion=6
 disableHostname=true
 storageEngineExcludeTypes=[4]
-tenantModes=['disabled']
+tenantModes = ['disabled']
 
 [[knobs]]
 # Mutation checksum and accumulative checksum is not compatible with release-7.3.(<41)

--- a/tests/restarting/to_7.3.0_until_7.3.39/ConfigureStorageMigrationTestRestart-2.toml
+++ b/tests/restarting/to_7.3.0_until_7.3.39/ConfigureStorageMigrationTestRestart-2.toml
@@ -1,6 +1,7 @@
 [configuration]
 extraMachineCountDC = 2
 allowDefaultTenant = false
+tenantModes = ['disabled']
 
 [[test]]
 testTitle = 'CloggedConfigureDatabaseTest'

--- a/tests/restarting/to_7.3.0_until_7.3.39/CycleTestRestart-1.toml
+++ b/tests/restarting/to_7.3.0_until_7.3.39/CycleTestRestart-1.toml
@@ -2,6 +2,7 @@
 maxTLogVersion = 6
 disableTss = true
 disableHostname = true
+tenantModes = ['disabled']
 
 [[knobs]]
 # Mutation checksum and accumulative checksum is not compatible with release-7.3.(<41)

--- a/tests/restarting/to_7.3.0_until_7.3.39/CycleTestRestart-2.toml
+++ b/tests/restarting/to_7.3.0_until_7.3.39/CycleTestRestart-2.toml
@@ -1,6 +1,7 @@
 [configuration]
 maxTLogVersion = 6
 disableTss = true
+tenantModes = ['disabled']
 
 [[knobs]]
 # testing that restart with writing recover at version to CSTATE.

--- a/tests/restarting/to_7.3.39_until_7.4.0/BlobGranuleRestartCorrectness-1.toml
+++ b/tests/restarting/to_7.3.39_until_7.4.0/BlobGranuleRestartCorrectness-1.toml
@@ -1,7 +1,7 @@
 [configuration]
 blobGranulesEnabled = true 
 allowDefaultTenant = false
-tenantModes = ['optional', 'required']
+tenantModes = ['disabled']
 injectTargetedSSRestart = true
 injectSSDelay = true
 

--- a/tests/restarting/to_7.3.39_until_7.4.0/BlobGranuleRestartCorrectness-2.toml
+++ b/tests/restarting/to_7.3.39_until_7.4.0/BlobGranuleRestartCorrectness-2.toml
@@ -2,7 +2,7 @@
 [configuration]
 blobGranulesEnabled = true 
 allowDefaultTenant = false
-tenantModes = ['optional', 'required']
+tenantModes = ['disabled']
 injectTargetedSSRestart = true
 injectSSDelay = true
 

--- a/tests/restarting/to_7.3.39_until_7.4.0/ConfigureStorageMigrationTestRestart-1.toml
+++ b/tests/restarting/to_7.3.39_until_7.4.0/ConfigureStorageMigrationTestRestart-1.toml
@@ -3,7 +3,7 @@ extraMachineCountDC = 2
 maxTLogVersion=6
 disableHostname=true
 storageEngineExcludeTypes=[4]
-tenantModes=['disabled']
+tenantModes = ['disabled']
 
 [[test]]
 testTitle = 'CloggedConfigureDatabaseTest'

--- a/tests/restarting/to_7.3.39_until_7.4.0/ConfigureStorageMigrationTestRestart-2.toml
+++ b/tests/restarting/to_7.3.39_until_7.4.0/ConfigureStorageMigrationTestRestart-2.toml
@@ -1,6 +1,7 @@
 [configuration]
 extraMachineCountDC = 2
 allowDefaultTenant = false
+tenantModes = ['disabled']
 
 [[test]]
 testTitle = 'CloggedConfigureDatabaseTest'

--- a/tests/restarting/to_7.3.39_until_7.4.0/CycleTestRestart-1.toml
+++ b/tests/restarting/to_7.3.39_until_7.4.0/CycleTestRestart-1.toml
@@ -2,6 +2,7 @@
 maxTLogVersion = 6
 disableTss = true
 disableHostname = true
+tenantModes = ['disabled']
 
 [[test]]
 testTitle = 'Clogged'

--- a/tests/restarting/to_7.3.39_until_7.4.0/CycleTestRestart-2.toml
+++ b/tests/restarting/to_7.3.39_until_7.4.0/CycleTestRestart-2.toml
@@ -1,6 +1,7 @@
 [configuration]
 maxTLogVersion = 6
 disableTss = true
+tenantModes = ['disabled']
 
 [[knobs]]
 # testing that restart with writing recover at version to CSTATE.


### PR DESCRIPTION
When downgrading to release-7.3 from a higher version, the tenant group is not compatible. So, we disable tenant in all downgrade tests to release-7.3.

100K test:
  20240524-180057-zhewang-4ffef132b258f6e1           compressed=True data_size=36919045 fail_fast=10 max_runs=100000 priority=100 sanity=False submitted=20240524-180057 timeout=5400 username=zhewang

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
