### PR TITLE
Fix bindingTestScript.sh shebang and use /usr/bin/env to find bash

### DIFF
--- a/contrib/Joshua/scripts/bindingTestScript.sh
+++ b/contrib/Joshua/scripts/bindingTestScript.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/usr/bin/env bash
 SCRIPTDIR=$( cd "${BASH_SOURCE[0]%\/*}" && pwd )
 cwd="$(pwd)"
 BINDIR="${BINDIR:-${SCRIPTDIR}}"

--- a/contrib/Joshua/scripts/localClusterStart.sh
+++ b/contrib/Joshua/scripts/localClusterStart.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 SCRIPTDIR="${SCRIPTDIR:-$( cd "${BASH_SOURCE[0]%\/*}" && pwd )}"
 DEBUGLEVEL="${DEBUGLEVEL:-1}"
 WORKDIR="${WORKDIR:-${SCRIPTDIR}/tmp/fdb.work}"


### PR DESCRIPTION
This change allows people to run this script on macOS, which has quite an old version of bash at /bin/bash. Without it, I see the following error:

```
build/bindingtester/localClusterStart.sh: line 209: syntax error near unexpected token `>'
build/bindingtester/localClusterStart.sh: line 209: `  elif "${BINDIR}/fdbcli" -C "${FDBCONF}" --exec "kill; kill ${FDBCLUSTERTEXT}; sleep 3" --timeout 120 &>> "${LOGDIR}/fdbcli-kill.log"'
```

Also, note that the old shebang in bindingTestScript.sh was also missing the ! character.

localClusterStart.sh didn't need to be changed since it is directly sourced by bindingTestScript.sh, but there's no harm to correct it, and it could perhaps become useful if one tries to use it directly.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
