### PR TITLE
Fix the stateful ASSERTs and rewrite BUGGIFY

### DIFF
--- a/fdbclient/DatabaseBackupAgent.actor.cpp
+++ b/fdbclient/DatabaseBackupAgent.actor.cpp
@@ -364,8 +364,7 @@ struct BackupRangeTaskFunc : TaskFuncBase {
 					if ((!prevAdjacent || !nextAdjacent) &&
 					    rangeCount > ((prevAdjacent || nextAdjacent) ? CLIENT_KNOBS->BACKUP_MAP_KEY_UPPER_LIMIT
 					                                                 : CLIENT_KNOBS->BACKUP_MAP_KEY_LOWER_LIMIT) &&
-					    (!g_network->isSimulated() ||
-					     (isGeneralBuggifyEnabled() && !g_simulator->speedUpSimulation))) {
+					    (!g_network->isSimulated() || (isGeneralBuggifyEnabled() && !g_simulator->speedUpSimulation))) {
 						CODE_PROBE(true, "range insert delayed because versionMap is too large");
 
 						if (rangeCount > CLIENT_KNOBS->BACKUP_MAP_KEY_UPPER_LIMIT)

--- a/fdbclient/DatabaseBackupAgent.actor.cpp
+++ b/fdbclient/DatabaseBackupAgent.actor.cpp
@@ -365,7 +365,7 @@ struct BackupRangeTaskFunc : TaskFuncBase {
 					    rangeCount > ((prevAdjacent || nextAdjacent) ? CLIENT_KNOBS->BACKUP_MAP_KEY_UPPER_LIMIT
 					                                                 : CLIENT_KNOBS->BACKUP_MAP_KEY_LOWER_LIMIT) &&
 					    (!g_network->isSimulated() ||
-					     (isBuggifyEnabled(BuggifyType::General) && !g_simulator->speedUpSimulation))) {
+					     (isGeneralBuggifyEnabled() && !g_simulator->speedUpSimulation))) {
 						CODE_PROBE(true, "range insert delayed because versionMap is too large");
 
 						if (rangeCount > CLIENT_KNOBS->BACKUP_MAP_KEY_UPPER_LIMIT)

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -2579,19 +2579,19 @@ void setNetworkOption(FDBNetworkOptions::Option option, Optional<StringRef> valu
 		tlsConfig.setDisablePlainTextConnection(true);
 		break;
 	case FDBNetworkOptions::CLIENT_BUGGIFY_ENABLE:
-		enableBuggify(true, BuggifyType::Client);
+	 	enableClientBuggify();
 		break;
 	case FDBNetworkOptions::CLIENT_BUGGIFY_DISABLE:
-		enableBuggify(false, BuggifyType::Client);
+	 	disableClientBuggify();
 		break;
 	case FDBNetworkOptions::CLIENT_BUGGIFY_SECTION_ACTIVATED_PROBABILITY:
 		validateOptionValuePresent(value);
-		clearBuggifySections(BuggifyType::Client);
-		P_BUGGIFIED_SECTION_ACTIVATED[int(BuggifyType::Client)] = double(extractIntOption(value, 0, 100)) / 100.0;
+		clearClientBuggifySections();
+		P_CLIENT_BUGGIFIED_SECTION_ACTIVATED = double(extractIntOption(value, 0, 100)) / 100.0;
 		break;
 	case FDBNetworkOptions::CLIENT_BUGGIFY_SECTION_FIRED_PROBABILITY:
 		validateOptionValuePresent(value);
-		P_BUGGIFIED_SECTION_FIRES[int(BuggifyType::Client)] = double(extractIntOption(value, 0, 100)) / 100.0;
+		P_CLIENT_BUGGIFIED_SECTION_FIRES = double(extractIntOption(value, 0, 100)) / 100.0;
 		break;
 	case FDBNetworkOptions::DISABLE_CLIENT_STATISTICS_LOGGING:
 		validateOptionValueNotPresent(value);

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -2579,10 +2579,10 @@ void setNetworkOption(FDBNetworkOptions::Option option, Optional<StringRef> valu
 		tlsConfig.setDisablePlainTextConnection(true);
 		break;
 	case FDBNetworkOptions::CLIENT_BUGGIFY_ENABLE:
-	 	enableClientBuggify();
+		enableClientBuggify();
 		break;
 	case FDBNetworkOptions::CLIENT_BUGGIFY_DISABLE:
-	 	disableClientBuggify();
+		disableClientBuggify();
 		break;
 	case FDBNetworkOptions::CLIENT_BUGGIFY_SECTION_ACTIVATED_PROBABILITY:
 		validateOptionValuePresent(value);

--- a/fdbclient/include/fdbclient/NativeAPI.actor.h
+++ b/fdbclient/include/fdbclient/NativeAPI.actor.h
@@ -45,7 +45,7 @@
 // CLIENT_BUGGIFY should be used to randomly introduce failures at run time (like BUGGIFY but for client side testing)
 // Unlike BUGGIFY, CLIENT_BUGGIFY can be enabled and disabled at runtime.
 #define CLIENT_BUGGIFY_WITH_PROB(x)                                                                                    \
-	(getSBVar(__FILE__, __LINE__, BuggifyType::Client) && deterministicRandom()->random01() < (x))
+    (getSBVar(__FILE__, __LINE__, BuggifyType::Client) && deterministicRandom()->random01() < (x))
 #define CLIENT_BUGGIFY CLIENT_BUGGIFY_WITH_PROB(P_BUGGIFIED_SECTION_FIRES[int(BuggifyType::Client)])
 */
 

--- a/fdbclient/include/fdbclient/NativeAPI.actor.h
+++ b/fdbclient/include/fdbclient/NativeAPI.actor.h
@@ -41,11 +41,13 @@
 #include "fdbclient/Tracing.h"
 #include "flow/actorcompiler.h" // has to be last include
 
+/*
 // CLIENT_BUGGIFY should be used to randomly introduce failures at run time (like BUGGIFY but for client side testing)
 // Unlike BUGGIFY, CLIENT_BUGGIFY can be enabled and disabled at runtime.
 #define CLIENT_BUGGIFY_WITH_PROB(x)                                                                                    \
 	(getSBVar(__FILE__, __LINE__, BuggifyType::Client) && deterministicRandom()->random01() < (x))
 #define CLIENT_BUGGIFY CLIENT_BUGGIFY_WITH_PROB(P_BUGGIFIED_SECTION_FIRES[int(BuggifyType::Client)])
+*/
 
 FDB_BOOLEAN_PARAM(UseProvisionalProxies);
 

--- a/fdbserver/DDRelocationQueue.actor.cpp
+++ b/fdbserver/DDRelocationQueue.actor.cpp
@@ -1070,8 +1070,9 @@ void DDQueue::launchQueuedWork(std::set<RelocateData, std::greater<RelocateData>
 			finishRelocation(rd.priority, rd.healthPriority);
 
 			// now we are launching: remove this entry from the queue of all the src servers
-			for (int i = 0; i < rd.src.size(); i++) {
-				ASSERT(queue[rd.src[i]].erase(rd));
+			for (size_t i = 0; i < rd.src.size(); i++) {
+				const auto result = queue[rd.src[i]].erase(rd);
+				ASSERT(result);
 			}
 		}
 

--- a/fdbserver/QuietDatabase.actor.cpp
+++ b/fdbserver/QuietDatabase.actor.cpp
@@ -1024,7 +1024,7 @@ ACTOR Future<Void> waitForQuietDatabase(Database cx,
                                         int64_t maxDataDistributionQueueSize = 0,
                                         int64_t maxPoppedVersionLag = 30e6,
                                         int64_t maxVersionOffset = 1e6) {
-	state QuietDatabaseChecker checker(isBuggifyEnabled(BuggifyType::General) ? 4000.0 : 1000.0);
+	state QuietDatabaseChecker checker(isGeneralBuggifyEnabled() ? 4000.0 : 1000.0);
 	state Future<Void> reconfig =
 	    reconfigureAfter(cx, 100 + (deterministicRandom()->random01() * 100), dbInfo, "QuietDatabase");
 	state Future<int64_t> dataInFlight;

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -1591,7 +1591,8 @@ void SimulationConfig::set_config(std::string config) {
 	// The only mechanism we have for turning "single" into what single means
 	// is buildConfiguration()... :/
 	std::map<std::string, std::string> hack_map;
-	ASSERT(buildConfiguration(config, hack_map) != ConfigurationResult::NO_OPTIONS_PROVIDED);
+	const auto buildResult = buildConfiguration(config, hack_map);
+	ASSERT(buildResult != ConfigurationResult::NO_OPTIONS_PROVIDED);
 	for (auto kv : hack_map)
 		db.set(kv.first, kv.second);
 }

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -816,7 +816,7 @@ ACTOR Future<ISimulator::KillType> simulatedFDBDRebooter(Reference<IClusterConne
 			    .detail("ConnectionString", connRecord ? connRecord->getConnectionString().toString() : "")
 			    .detailf("ActualTime", "%lld", DEBUG_DETERMINISM ? 0 : time(nullptr))
 			    .detail("CommandLine", "fdbserver -r simulation")
-			    .detail("BuggifyEnabled", isBuggifyEnabled(BuggifyType::General))
+			    .detail("BuggifyEnabled", isGeneralBuggifyEnabled())
 			    .detail("Simulated", true)
 			    .trackLatest("ProgramStart");
 
@@ -2986,11 +2986,11 @@ ACTOR void simulationSetupAndRun(std::string dataFolder,
 		                                  rebooting);
 		wait(testConfig.longRunningTest ? runTestsF
 		                                : timeoutError(runTestsF,
-		                                               isBuggifyEnabled(BuggifyType::General)
+		                                              isGeneralBuggifyEnabled()
 		                                                   ? testConfig.simulationBuggifyRunTestsTimeoutSeconds
 		                                                   : testConfig.simulationNormalRunTestsTimeoutSeconds));
 	} catch (Error& e) {
-		auto timeoutVal = isBuggifyEnabled(BuggifyType::General) ? testConfig.simulationBuggifyRunTestsTimeoutSeconds
+		auto timeoutVal =isGeneralBuggifyEnabled() ? testConfig.simulationBuggifyRunTestsTimeoutSeconds
 		                                                         : testConfig.simulationNormalRunTestsTimeoutSeconds;
 		auto msg = fmt::format("Timeout after {} simulated seconds", timeoutVal);
 		ProcessEvents::trigger("Timeout"_sr, StringRef(msg), e);

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -2984,14 +2984,14 @@ ACTOR void simulationSetupAndRun(std::string dataFolder,
 		                                  defaultTenant,
 		                                  tenantsToCreate,
 		                                  rebooting);
-		wait(testConfig.longRunningTest ? runTestsF
-		                                : timeoutError(runTestsF,
-		                                              isGeneralBuggifyEnabled()
-		                                                   ? testConfig.simulationBuggifyRunTestsTimeoutSeconds
-		                                                   : testConfig.simulationNormalRunTestsTimeoutSeconds));
+		wait(testConfig.longRunningTest
+		         ? runTestsF
+		         : timeoutError(runTestsF,
+		                        isGeneralBuggifyEnabled() ? testConfig.simulationBuggifyRunTestsTimeoutSeconds
+		                                                  : testConfig.simulationNormalRunTestsTimeoutSeconds));
 	} catch (Error& e) {
-		auto timeoutVal =isGeneralBuggifyEnabled() ? testConfig.simulationBuggifyRunTestsTimeoutSeconds
-		                                                         : testConfig.simulationNormalRunTestsTimeoutSeconds;
+		auto timeoutVal = isGeneralBuggifyEnabled() ? testConfig.simulationBuggifyRunTestsTimeoutSeconds
+		                                            : testConfig.simulationNormalRunTestsTimeoutSeconds;
 		auto msg = fmt::format("Timeout after {} simulated seconds", timeoutVal);
 		ProcessEvents::trigger("Timeout"_sr, StringRef(msg), e);
 		TraceEvent(SevError, "SetupAndRunError").error(e);

--- a/fdbserver/fdbserver.actor.cpp
+++ b/fdbserver/fdbserver.actor.cpp
@@ -1986,7 +1986,11 @@ int main(int argc, char* argv[]) {
 
 		setThreadLocalDeterministicRandomSeed(opts.randomSeed);
 
-		enableBuggify(opts.buggifyEnabled, BuggifyType::General);
+		if (opts.buggifyEnabled) {
+			enableGeneralBuggify();
+		} else {
+			disableGeneralBuggify();
+		}
 		enableFaultInjection(opts.faultInjectionEnabled);
 
 		IKnobCollection::setGlobalKnobCollection(IKnobCollection::Type::SERVER,

--- a/fdbserver/workloads/FuzzApiCorrectness.actor.cpp
+++ b/fdbserver/workloads/FuzzApiCorrectness.actor.cpp
@@ -168,7 +168,7 @@ struct FuzzApiCorrectnessWorkload : TestWorkload {
 
 		// See https://github.com/apple/foundationdb/issues/2424
 		if (BUGGIFY) {
-			enableBuggify(true, BuggifyType::Client);
+			enableClientBuggify();
 		}
 
 		if (adjacentKeys) {

--- a/flow/flow.cpp
+++ b/flow/flow.cpp
@@ -341,50 +341,6 @@ Standalone<StringRef> addVersionStampAtEnd(StringRef const& str) {
 	return r;
 }
 
-namespace {
-
-std::vector<bool> buggifyActivated{ false, false };
-std::map<BuggifyType, std::map<std::pair<std::string, int>, int>> typedSBVars;
-
-} // namespace
-
-std::vector<double> P_BUGGIFIED_SECTION_ACTIVATED{ .25, .25 };
-std::vector<double> P_BUGGIFIED_SECTION_FIRES{ .25, .25 };
-
-double P_EXPENSIVE_VALIDATION = .05;
-
-int getSBVar(std::string const& file, int line, BuggifyType type) {
-	if (!buggifyActivated[int(type)])
-		return 0;
-
-	const auto& flPair = std::make_pair(file, line);
-	auto& SBVars = typedSBVars[type];
-	if (!SBVars.count(flPair)) {
-		SBVars[flPair] = deterministicRandom()->random01() < P_BUGGIFIED_SECTION_ACTIVATED[int(type)];
-		g_traceBatch.addBuggify(SBVars[flPair], line, file);
-		if (g_network)
-			g_traceBatch.dump();
-	}
-
-	return SBVars[flPair];
-}
-
-void clearBuggifySections(BuggifyType type) {
-	typedSBVars[type].clear();
-}
-
-bool validationIsEnabled(BuggifyType type) {
-	return buggifyActivated[int(type)];
-}
-
-bool isBuggifyEnabled(BuggifyType type) {
-	return buggifyActivated[int(type)];
-}
-
-void enableBuggify(bool enabled, BuggifyType type) {
-	buggifyActivated[int(type)] = enabled;
-}
-
 // Make OpenSSL use DeterministicRandom as RNG source such that simulation runs stay deterministic w/ e.g. signature ops
 void bindDeterministicRandomToOpenssl() {
 	// TODO: implement ifdef branch for 3.x using provider API

--- a/flow/include/flow/Buggify.h
+++ b/flow/include/flow/Buggify.h
@@ -39,18 +39,10 @@ inline double P_EXPENSIVE_VALIDATION{ 0.05 };
 	inline double P_##TYPE##_BUGGIFIED_SECTION_FIRES{ 0.25 };                                                          \
 	inline double P_##TYPE##_ENABLED{ false };                                                                         \
 	inline std::unordered_map<const char*, bool> Type##_SBVars;                                                        \
-	inline bool is##Type##BuggifyEnabled() noexcept {                                                                  \
-		return P_##TYPE##_ENABLED;                                                                                     \
-	}                                                                                                                  \
-	inline void enable##Type##Buggify() noexcept {                                                                     \
-		P_##TYPE##_ENABLED = true;                                                                                     \
-	}                                                                                                                  \
-	inline void disable##Type##Buggify() noexcept {                                                                    \
-		P_##TYPE##_ENABLED = false;                                                                                    \
-	}                                                                                                                  \
-	inline void clear##Type##BuggifySections() {                                                                       \
-		Type##_SBVars.clear();                                                                                         \
-	}                                                                                                                  \
+	inline bool is##Type##BuggifyEnabled() noexcept { return P_##TYPE##_ENABLED; }                                     \
+	inline void enable##Type##Buggify() noexcept { P_##TYPE##_ENABLED = true; }                                        \
+	inline void disable##Type##Buggify() noexcept { P_##TYPE##_ENABLED = false; }                                      \
+	inline void clear##Type##BuggifySections() { Type##_SBVars.clear(); }                                              \
 	inline bool get##Type##SBVar(const char* file, const int line, const char* combined) {                             \
 		if (Type##_SBVars.count(combined)) [[likely]] {                                                                \
 			return Type##_SBVars[combined];                                                                            \

--- a/flow/include/flow/Buggify.h
+++ b/flow/include/flow/Buggify.h
@@ -1,0 +1,119 @@
+/*
+ * Buggify.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2024 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FLOW_BUGGIFY_H
+#define FLOW_BUGGIFY_H
+
+#pragma once
+
+#include <map>
+#include <unordered_map>
+
+#include "flow/DeterministicRandom.h"
+#include "flow/Trace.h"
+
+extern class INetwork* g_network;
+extern TraceBatch g_traceBatch;
+
+inline double P_EXPENSIVE_VALIDATION{ 0.05 };
+
+#define __GENERATE_BUGGIFY_VARIABLES(TYPE, Type, type)                                                                 \
+	inline double P_##TYPE##_BUGGIFIED_SECTION_ACTIVATED{ 0.25 };                                                      \
+	inline double P_##TYPE##_BUGGIFIED_SECTION_FIRES{ 0.25 };                                                          \
+	inline double P_##TYPE##_ENABLED{ false };                                                                         \
+	inline std::unordered_map<const char*, bool> Type##_SBVars;                                                        \
+	inline bool is##Type##BuggifyEnabled() noexcept {                                                                  \
+		return P_##TYPE##_ENABLED;                                                                                     \
+	}                                                                                                                  \
+	inline void enable##Type##Buggify() noexcept {                                                                     \
+		P_##TYPE##_ENABLED = true;                                                                                     \
+	}                                                                                                                  \
+	inline void disable##Type##Buggify() noexcept {                                                                    \
+		P_##TYPE##_ENABLED = false;                                                                                    \
+	}                                                                                                                  \
+	inline void clear##Type##BuggifySections() {                                                                       \
+		Type##_SBVars.clear();                                                                                         \
+	}                                                                                                                  \
+	inline bool get##Type##SBVar(const char* file, const int line, const char* combined) {                             \
+		if (Type##_SBVars.count(combined)) [[likely]] {                                                                \
+			return Type##_SBVars[combined];                                                                            \
+		}                                                                                                              \
+                                                                                                                       \
+		const double rand = deterministicRandom()->random01();                                                         \
+		const bool activated = rand < P_##TYPE##_BUGGIFIED_SECTION_ACTIVATED;                                          \
+		Type##_SBVars[combined] = activated;                                                                           \
+		g_traceBatch.addBuggify(activated, line, file);                                                                \
+		if (g_network) [[likely]] {                                                                                    \
+			g_traceBatch.dump();                                                                                       \
+		}                                                                                                              \
+                                                                                                                       \
+		return activated;                                                                                              \
+	}
+
+__GENERATE_BUGGIFY_VARIABLES(GENERAL, General, general)
+
+__GENERATE_BUGGIFY_VARIABLES(CLIENT, Client, client)
+
+#undef __GENERATE_BUGGIFY_VARIABLES
+
+#define __BUGGIFY_TO_STRING_HELPER(param) #param
+#define __BUGGIFY_TO_STRING(param) __BUGGIFY_TO_STRING_HELPER(param)
+
+#define BUGGIFY_WITH_PROB(x)                                                                                           \
+	(isGeneralBuggifyEnabled() && getGeneralSBVar(__FILE__, __LINE__, __FILE__ __BUGGIFY_TO_STRING(__LINE__)) &&       \
+	 deterministicRandom()->random01() < (x))
+#define BUGGIFY BUGGIFY_WITH_PROB(P_GENERAL_BUGGIFIED_SECTION_FIRES)
+#define EXPENSIVE_VALIDATION (isGeneralBuggifyEnabled() && deterministicRandom()->random01() < P_EXPENSIVE_VALIDATION)
+
+#define CLIENT_BUGGIFY_WITH_PROB(x)                                                                                    \
+	(isClientBuggifyEnabled() && getClientSBVar(__FILE__, __LINE__, __FILE__ __BUGGIFY_TO_STRING(__LINE__)) &&         \
+	 deterministicRandom()->random01() < (x))
+#define CLIENT_BUGGIFY CLIENT_BUGGIFY_WITH_PROB(P_CLIENT_BUGGIFIED_SECTION_FIRES)
+
+namespace SwiftBridging {
+
+inline std::map<std::pair<std::string, int>, bool> SwiftGeneralSBVar;
+
+inline bool getGeneralSBVar(const char* file, const int line) {
+	const auto paired = std::make_pair(std::string(file), line);
+	if (SwiftGeneralSBVar.count(paired)) [[likely]] {
+		return SwiftGeneralSBVar[paired];
+	}
+
+	const double rand = deterministicRandom()->random01();
+	const bool activated = rand < P_GENERAL_BUGGIFIED_SECTION_ACTIVATED;
+	SwiftGeneralSBVar[paired] = activated;
+	g_traceBatch.addBuggify(activated, line, file);
+	if (g_network) [[likely]] {
+		g_traceBatch.dump();
+	}
+
+	return activated;
+}
+
+inline bool buggify(const char* _Nonnull filename, int line) {
+	// SEE: BUGGIFY_WITH_PROB and BUGGIFY macros above.
+	return isGeneralBuggifyEnabled() && getGeneralSBVar(filename, line) &&
+	       deterministicRandom()->random01() < P_GENERAL_BUGGIFIED_SECTION_FIRES;
+}
+
+} // namespace SwiftBridging
+
+#endif // FLOW_BUGGIFY_H

--- a/flow/include/flow/flow.h
+++ b/flow/include/flow/flow.h
@@ -33,6 +33,7 @@
 #endif
 
 #include <algorithm>
+#include <array>
 #include <iosfwd>
 #include <functional>
 #include <memory>
@@ -44,6 +45,7 @@
 #include <utility>
 #include <vector>
 
+#include "flow/Buggify.h"
 #include "flow/CodeProbe.h"
 #include "flow/Deque.h"
 #include "flow/Error.h"
@@ -78,38 +80,6 @@
 		static_assert(false, "TEST macros are deprecated, please use CODE_PROBE instead");                             \
 	} while (false)
 
-/*
-usage:
-if (BUGGIFY) (
-// code here is executed on some runs (with probability P_BUGGIFIED_SECTION_ACTIVATED),
-//  sometimes --
-)
-*/
-
-extern std::vector<double> P_BUGGIFIED_SECTION_ACTIVATED, P_BUGGIFIED_SECTION_FIRES;
-extern double P_EXPENSIVE_VALIDATION;
-enum class BuggifyType : uint8_t { General = 0, Client };
-bool isBuggifyEnabled(BuggifyType type);
-void clearBuggifySections(BuggifyType type);
-int getSBVar(std::string const& file, int line, BuggifyType);
-void enableBuggify(bool enabled,
-                   BuggifyType type); // Currently controls buggification and (randomized) expensive validation
-bool validationIsEnabled(BuggifyType type);
-
-#define BUGGIFY_WITH_PROB(x)                                                                                           \
-	(getSBVar(__FILE__, __LINE__, BuggifyType::General) && deterministicRandom()->random01() < (x))
-#define BUGGIFY BUGGIFY_WITH_PROB(P_BUGGIFIED_SECTION_FIRES[int(BuggifyType::General)])
-#define EXPENSIVE_VALIDATION                                                                                           \
-	(validationIsEnabled(BuggifyType::General) && deterministicRandom()->random01() < P_EXPENSIVE_VALIDATION)
-
-namespace SwiftBridging {
-
-inline bool buggify(const char * _Nonnull filename, int line) {
-    // SEE: BUGGIFY_WITH_PROB and BUGGIFY macros above.
-    return getSBVar(filename, line, BuggifyType::General) && deterministicRandom()->random01() < (P_BUGGIFIED_SECTION_FIRES[int(BuggifyType::General)]);
-}
-
-} // namespace SwiftBridging
 
 extern Optional<uint64_t> parse_with_suffix(std::string const& toparse, std::string const& default_unit = "");
 extern Optional<uint64_t> parseDuration(std::string const& str, std::string const& defaultUnit = "");


### PR DESCRIPTION
This patch fixes a stateful ASSERT statement by moving the internal function call out of the ASSERT context.

Also rewrite BUGGIFY and gained pretty good performance improvement during simulation

See #11422 and #6771


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
