### PR TITLE
Add exponential backoff mechanism for restarting fdbserver processes in the monitor

### DIFF
--- a/fdbkubernetesmonitor/monitor_test.go
+++ b/fdbkubernetesmonitor/monitor_test.go
@@ -1,0 +1,54 @@
+// monitor_test.go
+//
+// This source file is part of the FoundationDB open source project
+//
+// Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package main
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Testing FDB Kubernetes Monitor", func() {
+	DescribeTable("when getting the backoff time", func(errorCount int, expected time.Duration) {
+		Expect(getBackoffDuration(errorCount)).To(Equal(expected))
+	},
+		Entry("no errors have occurred",
+			0,
+			time.Duration(0),
+		),
+		Entry("one error have occurred",
+			1,
+			1*time.Second,
+		),
+		Entry("two errors have occurred",
+			2,
+			4*time.Second,
+		),
+		Entry("three errors have occurred",
+			3,
+			9*time.Second,
+		),
+		Entry("ten errors have occurred, should return the max backoff seconds",
+			100,
+			60*time.Second,
+		),
+	)
+})


### PR DESCRIPTION
Before the monitor used a hardcoded value of 60 seconds. The exponential backoff, might help to recover the cluster faster.

Once those changes are merged I can open the PR's for 7.1 and 7.3.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
