### PR TITLE
fdbkubernetesmonitor: Update the pod annotation if the cluster file changes

### DIFF
--- a/fdbkubernetesmonitor/kubernetes.go
+++ b/fdbkubernetesmonitor/kubernetes.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"path"
 	"strconv"
+	"time"
 
 	"github.com/apple/foundationdb/fdbkubernetesmonitor/api"
 	"github.com/go-logr/logr"
@@ -55,6 +56,9 @@ const (
 	// The FDB Kubernetes monitor will always shutdown all fdbserver processes, independent of this setting.
 	// The value of this annotation must be a duration like "60s".
 	DelayShutdownAnnotation = "foundationdb.org/delay-shutdown"
+
+	// ClusterFileChangeDetectedAnnotation is the annotation that will be updated if the fdb.cluster file is updated.
+	ClusterFileChangeDetectedAnnotation = "foundationdb.org/cluster-file-change"
 )
 
 // PodClient is a wrapper around the pod API.
@@ -191,12 +195,31 @@ func (podClient *PodClient) UpdateAnnotations(monitor *Monitor) error {
 		return err
 	}
 
+	return podClient.updateAnnotationsOnPod(map[string]string{
+		CurrentConfigurationAnnotation: string(monitor.ActiveConfigurationBytes),
+		EnvironmentAnnotation:          string(jsonEnvironment),
+	})
+}
+
+// updateFdbClusterTimestampAnnotation updates the ClusterFileChangeDetectedAnnotation annotation on the pod
+// after a change to the fdb.cluster file was detected, e.g. because the coordinators were changed.
+func (podClient *PodClient) updateFdbClusterTimestampAnnotation() error {
+	return podClient.updateAnnotationsOnPod(map[string]string{
+		ClusterFileChangeDetectedAnnotation: strconv.FormatInt(time.Now().Unix(), 10),
+	})
+}
+
+// updateAnnotationsOnPod will update the annotations with the provided annotationChanges. If an annotation exists, it
+// will be updated if the annotation is absent it will be added.
+func (podClient *PodClient) updateAnnotationsOnPod(annotationChanges map[string]string) error {
 	annotations := podClient.metadata.Annotations
-	if len(annotations) > 0 {
+	if len(annotations) == 0 {
 		annotations = map[string]string{}
 	}
-	annotations[CurrentConfigurationAnnotation] = string(monitor.ActiveConfigurationBytes)
-	annotations[EnvironmentAnnotation] = string(jsonEnvironment)
+
+	for key, val := range annotationChanges {
+		annotations[key] = val
+	}
 
 	return podClient.Patch(context.Background(), &corev1.Pod{
 		TypeMeta: metav1.TypeMeta{

--- a/fdbkubernetesmonitor/main.go
+++ b/fdbkubernetesmonitor/main.go
@@ -22,9 +22,9 @@ package main
 import (
 	"bufio"
 	"context"
-	"fmt"
 	"io"
 	"os"
+	"path"
 	"regexp"
 	"strings"
 
@@ -124,7 +124,7 @@ func main() {
 			logger.Error(err, "Error loading additional environment")
 			os.Exit(1)
 		}
-		StartMonitor(context.Background(), logger, fmt.Sprintf("%s/%s", inputDir, monitorConfFile), customEnvironment, processCount, listenAddress, enablePprof, currentContainerVersion)
+		StartMonitor(context.Background(), logger, path.Join(inputDir, monitorConfFile), customEnvironment, processCount, listenAddress, enablePprof, currentContainerVersion)
 	case executionModeInit:
 		err = CopyFiles(logger, outputDir, copyDetails, requiredCopies)
 		if err != nil {


### PR DESCRIPTION
In cases where multiple operator instances are managing the same FDB cluster, like in the multi-dc setup, there can be a delay between a change in the coordinators and the operator instance updating the ConfigMap and all related resources. Especially in cases where only pods in a single dc are failing and the other operator instances are not receiving any events.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
