### PR TITLE
fdbkubernetesmonitor: Retry update pod annotations in case of an error

### DIFF
--- a/fdbkubernetesmonitor/monitor.go
+++ b/fdbkubernetesmonitor/monitor.go
@@ -537,7 +537,7 @@ func (monitor *Monitor) Run() {
 	go func() { monitor.WatchConfiguration(watcher) }()
 
 	// The cluster file will be created and managed by the fdbserver processes, so we have to wait until the fdbserver
-	// processes have been started. Except for the initial cluster creation his file should be present as soon as the
+	// processes have been started. Except for the initial cluster creation this file should be present as soon as the
 	// monitor starts the processes.
 	for {
 		_, err = os.Stat(fdbClusterFilePath)


### PR DESCRIPTION
Follow up of: https://github.com/apple/foundationdb/pull/11455#pullrequestreview-2113278192

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
