### PR TITLE
Add support for the isolate process group annotation to shutdown fdbserver processes

### DIFF
--- a/fdbkubernetesmonitor/api/annotations.go
+++ b/fdbkubernetesmonitor/api/annotations.go
@@ -1,0 +1,47 @@
+// annotations.go
+//
+// This source file is part of the FoundationDB open source project
+//
+// Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api
+
+const (
+	// CurrentConfigurationAnnotation is the annotation we use to store the
+	// latest configuration.
+	CurrentConfigurationAnnotation = "foundationdb.org/launcher-current-configuration"
+
+	// EnvironmentAnnotation is the annotation we use to store the environment
+	// variables.
+	EnvironmentAnnotation = "foundationdb.org/launcher-environment"
+
+	// OutdatedConfigMapAnnotation is the annotation we read to get notified of
+	// outdated configuration.
+	OutdatedConfigMapAnnotation = "foundationdb.org/outdated-config-map-seen"
+
+	// DelayShutdownAnnotation defines how long the FDB Kubernetes monitor process should sleep before shutting itself down.
+	// The FDB Kubernetes monitor will always shutdown all fdbserver processes, independent of this setting.
+	// The value of this annotation must be a duration like "60s".
+	DelayShutdownAnnotation = "foundationdb.org/delay-shutdown"
+
+	// ClusterFileChangeDetectedAnnotation is the annotation that will be updated if the fdb.cluster file is updated.
+	ClusterFileChangeDetectedAnnotation = "foundationdb.org/cluster-file-change"
+
+	// IsolateProcessGroupAnnotation is the annotation that defines if the current Pod should be isolated. Isolated
+	// process groups will shutdown the fdbserver instance but keep the Pod and other Kubernetes resources running
+	// for debugging purpose.
+	IsolateProcessGroupAnnotation = "foundationdb.org/isolate-process-group"
+)

--- a/fdbkubernetesmonitor/api/config.go
+++ b/fdbkubernetesmonitor/api/config.go
@@ -33,12 +33,7 @@ import (
 // process.
 type ProcessConfiguration struct {
 	// Version provides the version of FoundationDB the process should run.
-	Version string `json:"version"`
-
-	// InitialStartVersion provides the version of FoundationDB the process should be initially started. In most cases
-	// this will be the same as Version. Only during Version incompatible upgrade those versions will be different to
-	// make sure the
-	InitialStartVersion string `json:"initialStartVersion"`
+	Version Version `json:"version"`
 
 	// RunServers defines whether we should run the server processes.
 	// This defaults to true, but you can set it to false to prevent starting

--- a/fdbkubernetesmonitor/api/config.go
+++ b/fdbkubernetesmonitor/api/config.go
@@ -25,6 +25,8 @@ import (
 	"os"
 	"strconv"
 	"strings"
+
+	"k8s.io/utils/pointer"
 )
 
 // ProcessConfiguration models the configuration for starting a FoundationDB
@@ -182,4 +184,13 @@ func (configuration *ProcessConfiguration) GenerateArguments(processNumber int, 
 		results = append(results, result)
 	}
 	return results, nil
+}
+
+// ShouldRunServers returns true if RunServers is unset or set to true.
+func (configuration *ProcessConfiguration) ShouldRunServers() bool {
+	if configuration == nil {
+		return false
+	}
+
+	return pointer.BoolDeref(configuration.RunServers, true)
 }

--- a/fdbkubernetesmonitor/api/config.go
+++ b/fdbkubernetesmonitor/api/config.go
@@ -33,7 +33,7 @@ import (
 // process.
 type ProcessConfiguration struct {
 	// Version provides the version of FoundationDB the process should run.
-	Version Version `json:"version"`
+	Version *Version `json:"version"`
 
 	// RunServers defines whether we should run the server processes.
 	// This defaults to true, but you can set it to false to prevent starting

--- a/fdbkubernetesmonitor/api/config.go
+++ b/fdbkubernetesmonitor/api/config.go
@@ -35,6 +35,11 @@ type ProcessConfiguration struct {
 	// Version provides the version of FoundationDB the process should run.
 	Version string `json:"version"`
 
+	// InitialStartVersion provides the version of FoundationDB the process should be initially started. In most cases
+	// this will be the same as Version. Only during Version incompatible upgrade those versions will be different to
+	// make sure the
+	InitialStartVersion string `json:"initialStartVersion"`
+
 	// RunServers defines whether we should run the server processes.
 	// This defaults to true, but you can set it to false to prevent starting
 	// new fdbserver processes.

--- a/fdbkubernetesmonitor/api/config_test.go
+++ b/fdbkubernetesmonitor/api/config_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Testing FDB Kubernetes Monitor API", func() {
 		BeforeEach(func() {
 			var err error
 			config := loadConfigFromFile(".testdata/default_config.json")
-			Expect(config.Version).To(Equal(Version{Major: 6, Minor: 3, Patch: 15}))
+			Expect(config.Version).To(Equal(&Version{Major: 6, Minor: 3, Patch: 15}))
 			arguments, err = config.GenerateArguments(1, map[string]string{
 				"FDB_PUBLIC_IP":   "10.0.0.1",
 				"FDB_POD_IP":      "192.168.0.1",
@@ -244,6 +244,28 @@ var _ = Describe("Testing FDB Kubernetes Monitor API", func() {
 				Expect(err.Error()).To(Equal("unsupported IP family 5"))
 				Expect(argument).To(BeEmpty())
 			})
+		})
+	})
+
+	When("marshalling a process configuration", func() {
+		var out string
+
+		BeforeEach(func() {
+			config := &ProcessConfiguration{
+				Version: &Version{
+					Major: 7,
+					Minor: 1,
+					Patch: 57,
+				},
+			}
+
+			data, err := json.Marshal(config)
+			Expect(err).NotTo(HaveOccurred())
+			out = string(data)
+		})
+
+		It("should parse it correct", func() {
+			Expect(out).To(Equal("{\"version\":\"7.1.57\"}"))
 		})
 	})
 })

--- a/fdbkubernetesmonitor/api/config_test.go
+++ b/fdbkubernetesmonitor/api/config_test.go
@@ -47,6 +47,7 @@ var _ = Describe("Testing FDB Kubernetes Monitor API", func() {
 		BeforeEach(func() {
 			var err error
 			config := loadConfigFromFile(".testdata/default_config.json")
+			Expect(config.Version).To(Equal(Version{Major: 6, Minor: 3, Patch: 15}))
 			arguments, err = config.GenerateArguments(1, map[string]string{
 				"FDB_PUBLIC_IP":   "10.0.0.1",
 				"FDB_POD_IP":      "192.168.0.1",

--- a/fdbkubernetesmonitor/api/suite_test.go
+++ b/fdbkubernetesmonitor/api/suite_test.go
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2023-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdbkubernetesmonitor/api/version.go
+++ b/fdbkubernetesmonitor/api/version.go
@@ -1,0 +1,197 @@
+/*
+ * version.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package api
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// Version represents a version of FoundationDB.
+//
+// This provides convenience methods for checking features available in
+// different versions.
+type Version struct {
+	// Major is the major version
+	Major int
+
+	// Minor is the minor version
+	Minor int
+
+	// Patch is the patch version
+	Patch int
+
+	// ReleaseCandidate is the number from the `-rc\d+` suffix version
+	// of the version if it exists
+	ReleaseCandidate int
+}
+
+// versionRegex describes the format of a FoundationDB version.
+var versionRegex = regexp.MustCompile(`(\d+)\.(\d+)\.(\d+)(-rc(\d+))?`)
+
+// MarshalJSON custom implementation of MarshalJSON
+func (version *Version) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf("\"%s\"", version.String())), nil
+}
+
+// UnmarshalJSON custom implementation of UnmarshalJSON
+func (version *Version) UnmarshalJSON(data []byte) error {
+	trimmed := strings.Trim(string(data), "\"")
+	currentVersion, err := ParseFdbVersion(trimmed)
+	if err != nil {
+		return err
+	}
+
+	version.Major = currentVersion.Major
+	version.Minor = currentVersion.Minor
+	version.Patch = currentVersion.Patch
+	version.ReleaseCandidate = currentVersion.ReleaseCandidate
+	return nil
+}
+
+// ParseFdbVersion parses a version from its string representation.
+func ParseFdbVersion(version string) (Version, error) {
+	matches := versionRegex.FindStringSubmatch(version)
+	if matches == nil {
+		return Version{}, fmt.Errorf("could not parse FDB version from %s", version)
+	}
+
+	major, err := strconv.Atoi(matches[1])
+	if err != nil {
+		return Version{}, err
+	}
+
+	minor, err := strconv.Atoi(matches[2])
+	if err != nil {
+		return Version{}, err
+	}
+
+	patch, err := strconv.Atoi(matches[3])
+	if err != nil {
+		return Version{}, err
+	}
+
+	rc, err := strconv.Atoi(matches[5])
+	if err != nil {
+		rc = 0
+	}
+
+	return Version{Major: major, Minor: minor, Patch: patch, ReleaseCandidate: rc}, nil
+}
+
+// String gets the string representation of an FDB version.
+func (version Version) String() string {
+	if version.ReleaseCandidate == 0 {
+		return fmt.Sprintf("%d.%d.%d", version.Major, version.Minor, version.Patch)
+	}
+	return fmt.Sprintf("%d.%d.%d-rc%d", version.Major, version.Minor, version.Patch, version.ReleaseCandidate)
+}
+
+// Compact prints the version in the major.minor format.
+func (version Version) Compact() string {
+	return fmt.Sprintf("%d.%d", version.Major, version.Minor)
+}
+
+// IsAtLeast determines if a version is greater than or equal to another version.
+func (version Version) IsAtLeast(other Version) bool {
+	if version.Major < other.Major {
+		return false
+	}
+	if version.Major > other.Major {
+		return true
+	}
+	if version.Minor < other.Minor {
+		return false
+	}
+	if version.Minor > other.Minor {
+		return true
+	}
+	if version.Patch < other.Patch {
+		return false
+	}
+	if version.Patch > other.Patch {
+		return true
+	}
+	if version.ReleaseCandidate == 0 {
+		return true
+	}
+	if other.ReleaseCandidate == 0 {
+		return false
+	}
+	if version.ReleaseCandidate < other.ReleaseCandidate {
+		return false
+	}
+	if version.ReleaseCandidate > other.ReleaseCandidate {
+		return true
+	}
+	return true
+}
+
+// GetBinaryVersion Returns a version string compatible with the log implemented in the sidecars
+func (version Version) GetBinaryVersion() string {
+	if version.ReleaseCandidate > 0 {
+		return version.String()
+	}
+	return version.Compact()
+}
+
+// IsProtocolCompatible determines whether two versions of FDB are protocol
+// compatible.
+func (version Version) IsProtocolCompatible(other Version) bool {
+	return version.Major == other.Major && version.Minor == other.Minor && version.ReleaseCandidate == other.ReleaseCandidate
+}
+
+// HasNonBlockingExcludes determines if a version has support for non-blocking
+// exclude commands.
+func (version Version) HasNonBlockingExcludes(useNonBlockingExcludes bool) bool {
+	return version.IsAtLeast(Version{Major: 6, Minor: 3, Patch: 5}) && useNonBlockingExcludes
+}
+
+// HasSeparatedProxies determines if a version has support for separate
+// grv/commit proxies
+func (version Version) HasSeparatedProxies() bool {
+	return version.IsAtLeast(Version{Major: 7, Minor: 0, Patch: 0})
+}
+
+// NextMajorVersion returns the next major version of FoundationDB.
+func (version Version) NextMajorVersion() Version {
+	return Version{Major: version.Major + 1, Minor: 0, Patch: 0}
+}
+
+// NextMinorVersion returns the next minor version of FoundationDB.
+func (version Version) NextMinorVersion() Version {
+	return Version{Major: version.Major, Minor: version.Minor + 1, Patch: 0}
+}
+
+// NextPatchVersion returns the next patch version of FoundationDB.
+func (version Version) NextPatchVersion() Version {
+	return Version{Major: version.Major, Minor: version.Minor, Patch: version.Patch + 1}
+}
+
+// Equal checks if two Version are the same.
+func (version Version) Equal(other Version) bool {
+	return version.Major == other.Major &&
+		version.Minor == other.Minor &&
+		version.Patch == other.Patch &&
+		version.ReleaseCandidate == other.ReleaseCandidate
+}

--- a/fdbkubernetesmonitor/api/version.go
+++ b/fdbkubernetesmonitor/api/version.go
@@ -161,18 +161,6 @@ func (version Version) IsProtocolCompatible(other Version) bool {
 	return version.Major == other.Major && version.Minor == other.Minor && version.ReleaseCandidate == other.ReleaseCandidate
 }
 
-// HasNonBlockingExcludes determines if a version has support for non-blocking
-// exclude commands.
-func (version Version) HasNonBlockingExcludes(useNonBlockingExcludes bool) bool {
-	return version.IsAtLeast(Version{Major: 6, Minor: 3, Patch: 5}) && useNonBlockingExcludes
-}
-
-// HasSeparatedProxies determines if a version has support for separate
-// grv/commit proxies
-func (version Version) HasSeparatedProxies() bool {
-	return version.IsAtLeast(Version{Major: 7, Minor: 0, Patch: 0})
-}
-
 // NextMajorVersion returns the next major version of FoundationDB.
 func (version Version) NextMajorVersion() Version {
 	return Version{Major: version.Major + 1, Minor: 0, Patch: 0}

--- a/fdbkubernetesmonitor/api/version_test.go
+++ b/fdbkubernetesmonitor/api/version_test.go
@@ -1,0 +1,163 @@
+/*
+ * version_test.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package api
+
+import (
+	//"encoding/json"
+	//"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("[api] FDBVersion", func() {
+	// TODO test a json marshal and unmarshl!
+
+	When("checking if the protocol and the version are compatible", func() {
+		It("should return the correct compatibility", func() {
+			version := Version{Major: 6, Minor: 2, Patch: 20}
+			Expect(version.IsProtocolCompatible(Version{Major: 6, Minor: 2, Patch: 20})).To(BeTrue())
+			Expect(version.IsProtocolCompatible(Version{Major: 6, Minor: 2, Patch: 22})).To(BeTrue())
+			Expect(version.IsProtocolCompatible(Version{Major: 6, Minor: 3, Patch: 0})).To(BeFalse())
+			Expect(version.IsProtocolCompatible(Version{Major: 6, Minor: 3, Patch: 20})).To(BeFalse())
+			Expect(version.IsProtocolCompatible(Version{Major: 7, Minor: 2, Patch: 20})).To(BeFalse())
+		})
+
+		When("release candidates differ", func() {
+			It("should be incompatible", func() {
+				version := Version{Major: 7, Minor: 0, Patch: 0, ReleaseCandidate: 1}
+				Expect(version.IsProtocolCompatible(Version{Major: 7, Minor: 0, Patch: 0, ReleaseCandidate: 2})).To(BeFalse())
+			})
+		})
+	})
+
+	Context("Using the fdb version", func() {
+		It("should return the fdb version struct", func() {
+			version, err := ParseFdbVersion("6.2.11")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(version).To(Equal(Version{Major: 6, Minor: 2, Patch: 11}))
+			Expect(version.HasSeparatedProxies()).To(BeFalse())
+
+			version, err = ParseFdbVersion("prerelease-6.2.11")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(version).To(Equal(Version{Major: 6, Minor: 2, Patch: 11}))
+
+			version, err = ParseFdbVersion("test-6.2.11-test")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(version).To(Equal(Version{Major: 6, Minor: 2, Patch: 11, ReleaseCandidate: 0}))
+
+			version, err = ParseFdbVersion("7.0.0")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(version).To(Equal(Version{Major: 7, Minor: 0, Patch: 0, ReleaseCandidate: 0}))
+			Expect(version.HasSeparatedProxies()).To(BeTrue())
+
+			version, err = ParseFdbVersion("7.0.0-rc1")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(version).To(Equal(Version{Major: 7, Minor: 0, Patch: 0, ReleaseCandidate: 1}))
+
+			version, err = ParseFdbVersion("7.1.0-rc39")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(version).To(Equal(Version{Major: 7, Minor: 1, Patch: 0, ReleaseCandidate: 39}))
+			Expect(version.HasSeparatedProxies()).To(BeTrue())
+
+			_, err = ParseFdbVersion("6.2")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("could not parse FDB version from 6.2"))
+		})
+
+		It("should format the version correctly", func() {
+			version := Version{Major: 6, Minor: 2, Patch: 11}
+			Expect(version.String()).To(Equal("6.2.11"))
+			version = Version{Major: 6, Minor: 2, Patch: 11, ReleaseCandidate: 0}
+			Expect(version.String()).To(Equal("6.2.11"))
+			version = Version{Major: 6, Minor: 2, Patch: 11, ReleaseCandidate: 1}
+			Expect(version.String()).To(Equal("6.2.11-rc1"))
+		})
+	})
+
+	When("getting the next version of the current FDBVersion", func() {
+		It("should return the correct next version", func() {
+			version := Version{Major: 6, Minor: 2, Patch: 20}
+			Expect(version.NextMajorVersion()).To(Equal(Version{Major: 7, Minor: 0, Patch: 0}))
+			Expect(version.NextMinorVersion()).To(Equal(Version{Major: version.Major, Minor: 3, Patch: 0}))
+			Expect(version.NextPatchVersion()).To(Equal(Version{Major: version.Major, Minor: version.Minor, Patch: 21}))
+		})
+	})
+
+	When("comparing two FDBVersions", func() {
+		It("should return if they are equal", func() {
+			version := Version{Major: 6, Minor: 2, Patch: 20}
+			Expect(version.Equal(version)).To(BeTrue())
+			Expect(version.Equal(Version{Major: 7, Minor: 0, Patch: 0})).To(BeFalse())
+			Expect(version.Equal(Version{Major: 7, Minor: 0, Patch: 0})).To(BeFalse())
+			Expect(version.Equal(Version{Major: 6, Minor: 3, Patch: 20})).To(BeFalse())
+			Expect(version.Equal(Version{Major: 6, Minor: 2, Patch: 21})).To(BeFalse())
+		})
+
+		It("should return correct result for IsAtleast", func() {
+			version := Version{Major: 7, Minor: 1, Patch: 0, ReleaseCandidate: 2}
+			Expect(version.IsAtLeast(Version{Major: 7, Minor: 1, Patch: 0})).To(BeFalse())
+			Expect(version.IsAtLeast(Version{Major: 7, Minor: 1, Patch: 0, ReleaseCandidate: 1})).To(BeTrue())
+			Expect(version.IsAtLeast(Version{Major: 7, Minor: 1, Patch: 0, ReleaseCandidate: 3})).To(BeFalse())
+
+			version = Version{Major: 7, Minor: 1, Patch: 0}
+			Expect(version.IsAtLeast(Version{Major: 7, Minor: 1, Patch: 0, ReleaseCandidate: 1})).To(BeTrue())
+		})
+	})
+
+	When("checking if the version has support for non-blocking exclude commands", func() {
+		type testCase struct {
+			version                Version
+			useNonBlockingExcludes bool
+			expectedResult         bool
+		}
+
+		DescribeTable("should return if non-blocking excludes are enabled",
+			func(tc testCase) {
+				Expect(tc.version.HasNonBlockingExcludes(tc.useNonBlockingExcludes)).To(Equal(tc.expectedResult))
+			},
+			Entry("When version is below 6.3.5 and useNonBlockingExcludes is false",
+				testCase{
+					version:                Version{Major: 6, Minor: 3, Patch: 0},
+					useNonBlockingExcludes: false,
+					expectedResult:         false,
+				}),
+			Entry("When version is below 6.3.5 and useNonBlockingExcludes is true",
+				testCase{
+					version:                Version{Major: 6, Minor: 3, Patch: 0},
+					useNonBlockingExcludes: false,
+					expectedResult:         false,
+				}),
+			Entry("When version is atleast 6.3.5 and useNonBlockingExcludes is false",
+				testCase{
+					version:                Version{Major: 6, Minor: 3, Patch: 5},
+					useNonBlockingExcludes: false,
+					expectedResult:         false,
+				}),
+			Entry("When version is atleast 6.3.5 and useNonBlockingExcludes is true",
+				testCase{
+					version:                Version{Major: 6, Minor: 3, Patch: 6},
+					useNonBlockingExcludes: true,
+					expectedResult:         true,
+				}),
+		)
+	})
+})

--- a/fdbkubernetesmonitor/api/version_test.go
+++ b/fdbkubernetesmonitor/api/version_test.go
@@ -54,7 +54,6 @@ var _ = Describe("[api] FDBVersion", func() {
 			version, err := ParseFdbVersion("6.2.11")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(version).To(Equal(Version{Major: 6, Minor: 2, Patch: 11}))
-			Expect(version.HasSeparatedProxies()).To(BeFalse())
 
 			version, err = ParseFdbVersion("prerelease-6.2.11")
 			Expect(err).NotTo(HaveOccurred())
@@ -67,7 +66,6 @@ var _ = Describe("[api] FDBVersion", func() {
 			version, err = ParseFdbVersion("7.0.0")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(version).To(Equal(Version{Major: 7, Minor: 0, Patch: 0, ReleaseCandidate: 0}))
-			Expect(version.HasSeparatedProxies()).To(BeTrue())
 
 			version, err = ParseFdbVersion("7.0.0-rc1")
 			Expect(err).NotTo(HaveOccurred())
@@ -76,7 +74,6 @@ var _ = Describe("[api] FDBVersion", func() {
 			version, err = ParseFdbVersion("7.1.0-rc39")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(version).To(Equal(Version{Major: 7, Minor: 1, Patch: 0, ReleaseCandidate: 39}))
-			Expect(version.HasSeparatedProxies()).To(BeTrue())
 
 			_, err = ParseFdbVersion("6.2")
 			Expect(err).To(HaveOccurred())
@@ -121,43 +118,5 @@ var _ = Describe("[api] FDBVersion", func() {
 			version = Version{Major: 7, Minor: 1, Patch: 0}
 			Expect(version.IsAtLeast(Version{Major: 7, Minor: 1, Patch: 0, ReleaseCandidate: 1})).To(BeTrue())
 		})
-	})
-
-	When("checking if the version has support for non-blocking exclude commands", func() {
-		type testCase struct {
-			version                Version
-			useNonBlockingExcludes bool
-			expectedResult         bool
-		}
-
-		DescribeTable("should return if non-blocking excludes are enabled",
-			func(tc testCase) {
-				Expect(tc.version.HasNonBlockingExcludes(tc.useNonBlockingExcludes)).To(Equal(tc.expectedResult))
-			},
-			Entry("When version is below 6.3.5 and useNonBlockingExcludes is false",
-				testCase{
-					version:                Version{Major: 6, Minor: 3, Patch: 0},
-					useNonBlockingExcludes: false,
-					expectedResult:         false,
-				}),
-			Entry("When version is below 6.3.5 and useNonBlockingExcludes is true",
-				testCase{
-					version:                Version{Major: 6, Minor: 3, Patch: 0},
-					useNonBlockingExcludes: false,
-					expectedResult:         false,
-				}),
-			Entry("When version is atleast 6.3.5 and useNonBlockingExcludes is false",
-				testCase{
-					version:                Version{Major: 6, Minor: 3, Patch: 5},
-					useNonBlockingExcludes: false,
-					expectedResult:         false,
-				}),
-			Entry("When version is atleast 6.3.5 and useNonBlockingExcludes is true",
-				testCase{
-					version:                Version{Major: 6, Minor: 3, Patch: 6},
-					useNonBlockingExcludes: true,
-					expectedResult:         true,
-				}),
-		)
 	})
 })

--- a/fdbkubernetesmonitor/copy.go
+++ b/fdbkubernetesmonitor/copy.go
@@ -81,7 +81,7 @@ func copyFile(logger logr.Logger, inputPath string, outputPath string, required 
 }
 
 // CopyFiles copies a list of files into the output directory.
-func CopyFiles(logger logr.Logger, outputDir string, copyDetails map[string]string, requiredCopies map[string]bool) error {
+func copyFiles(logger logr.Logger, outputDir string, copyDetails map[string]string, requiredCopies map[string]bool) error {
 	for inputPath, outputSubpath := range copyDetails {
 		if outputSubpath == "" {
 			outputSubpath = path.Base(inputPath)

--- a/fdbkubernetesmonitor/copy_test.go
+++ b/fdbkubernetesmonitor/copy_test.go
@@ -311,7 +311,7 @@ var _ = Describe("Testing the copy methods", func() {
 					copyDetails, _, err := getCopyDetails("", "", "", nil, binaries, nil, nil, "7.1.43", executionModeInit)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(copyDetails).To(HaveLen(3))
-					Expect(CopyFiles(GinkgoLogr, outputBinaryDir, copyDetails, map[string]bool{})).NotTo(HaveOccurred())
+					Expect(copyFiles(GinkgoLogr, outputBinaryDir, copyDetails, map[string]bool{})).NotTo(HaveOccurred())
 				})
 
 				It("should copy all the files", func() {
@@ -328,7 +328,7 @@ var _ = Describe("Testing the copy methods", func() {
 					copyDetails, _, err := getCopyDetails("", "", "", nil, binaries, nil, nil, "7.1.43", executionModeSidecar)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(copyDetails).To(HaveLen(3))
-					Expect(CopyFiles(GinkgoLogr, outputBinaryDir, copyDetails, map[string]bool{})).NotTo(HaveOccurred())
+					Expect(copyFiles(GinkgoLogr, outputBinaryDir, copyDetails, map[string]bool{})).NotTo(HaveOccurred())
 				})
 
 				It("should copy all the files", func() {
@@ -366,7 +366,7 @@ var _ = Describe("Testing the copy methods", func() {
 				copyDetails, _, err = getCopyDetails("", "", "", nil, nil, libraries, nil, "7.1.43", executionModeInit)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(copyDetails).To(HaveLen(3))
-				Expect(CopyFiles(GinkgoLogr, outputLibraryDir, copyDetails, map[string]bool{})).NotTo(HaveOccurred())
+				Expect(copyFiles(GinkgoLogr, outputLibraryDir, copyDetails, map[string]bool{})).NotTo(HaveOccurred())
 			})
 
 			It("should copy all the files", func() {
@@ -384,7 +384,7 @@ var _ = Describe("Testing the copy methods", func() {
 				copyDetails, _, err = getCopyDetails("", "7.1", "", nil, nil, libraries, nil, "7.1.43", executionModeInit)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(copyDetails).To(HaveLen(3))
-				Expect(CopyFiles(GinkgoLogr, outputLibraryDir, copyDetails, map[string]bool{})).NotTo(HaveOccurred())
+				Expect(copyFiles(GinkgoLogr, outputLibraryDir, copyDetails, map[string]bool{})).NotTo(HaveOccurred())
 			})
 
 			It("should copy all the files", func() {
@@ -413,7 +413,7 @@ var _ = Describe("Testing the copy methods", func() {
 					copyDetails, _, err = getCopyDetails(testInputDir, "", "", []string{"testfile"}, nil, nil, nil, "7.1.43", executionModeInit)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(copyDetails).To(HaveLen(1))
-					Expect(CopyFiles(GinkgoLogr, testOutputDir, copyDetails, map[string]bool{})).NotTo(HaveOccurred())
+					Expect(copyFiles(GinkgoLogr, testOutputDir, copyDetails, map[string]bool{})).NotTo(HaveOccurred())
 				})
 
 				It("should copy the file", func() {
@@ -434,7 +434,7 @@ var _ = Describe("Testing the copy methods", func() {
 
 				When("the file is empty", func() {
 					It("should not copy the file", func() {
-						Expect(CopyFiles(GinkgoLogr, testOutputDir, copyDetails, requiredFiles)).To(HaveOccurred())
+						Expect(copyFiles(GinkgoLogr, testOutputDir, copyDetails, requiredFiles)).To(HaveOccurred())
 						Expect(path.Join(testOutputDir, "testfile")).NotTo(BeAnExistingFile())
 					})
 				})
@@ -445,7 +445,7 @@ var _ = Describe("Testing the copy methods", func() {
 					})
 
 					It("should copy the file", func() {
-						Expect(CopyFiles(GinkgoLogr, testOutputDir, copyDetails, requiredFiles)).NotTo(HaveOccurred())
+						Expect(copyFiles(GinkgoLogr, testOutputDir, copyDetails, requiredFiles)).NotTo(HaveOccurred())
 						Expect(path.Join(testOutputDir, "testfile")).To(BeAnExistingFile())
 					})
 				})

--- a/fdbkubernetesmonitor/kubernetes.go
+++ b/fdbkubernetesmonitor/kubernetes.go
@@ -43,49 +43,23 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const (
-	// CurrentConfigurationAnnotation is the annotation we use to store the
-	// latest configuration.
-	CurrentConfigurationAnnotation = "foundationdb.org/launcher-current-configuration"
-
-	// EnvironmentAnnotation is the annotation we use to store the environment
-	// variables.
-	EnvironmentAnnotation = "foundationdb.org/launcher-environment"
-
-	// OutdatedConfigMapAnnotation is the annotation we read to get notified of
-	// outdated configuration.
-	OutdatedConfigMapAnnotation = "foundationdb.org/outdated-config-map-seen"
-
-	// DelayShutdownAnnotation defines how long the FDB Kubernetes monitor process should sleep before shutting itself down.
-	// The FDB Kubernetes monitor will always shutdown all fdbserver processes, independent of this setting.
-	// The value of this annotation must be a duration like "60s".
-	DelayShutdownAnnotation = "foundationdb.org/delay-shutdown"
-
-	// ClusterFileChangeDetectedAnnotation is the annotation that will be updated if the fdb.cluster file is updated.
-	ClusterFileChangeDetectedAnnotation = "foundationdb.org/cluster-file-change"
-
-	// IsolateProcessGroupAnnotation is the annotation that defines if the current Pod should be isolated. Isolated
-	// process groups will shutdown the fdbserver instance but keep the Pod and other Kubernetes resources running
-	// for debugging purpose.
-	IsolateProcessGroupAnnotation = "foundationdb.org/isolate-process-group"
-)
-
-// PodClient is a wrapper around the pod API.
-type PodClient struct {
+// kubernetesClient is a wrapper around the Kubernetes API.
+type kubernetesClient struct {
 	// podMetadata is the latest metadata that was seen by the fdb-kubernetes-monitor for the according Pod.
 	podMetadata *metav1.PartialObjectMetadata
 
 	// nodeMetadata is the latest metadata that was seen by the fdb-kubernetes-monitor for the according node that hosts the Pod.
 	nodeMetadata *metav1.PartialObjectMetadata
 
-	// TimestampFeed is a channel where the pod client will send updates with
-	// the values from OutdatedConfigMapAnnotation.
+	// TimestampFeed is a channel where the kubernetes client will send updates with
+	// the values from api.OutdatedConfigMapAnnotation. If the api.IsolateProcessGroupAnnotation is changed the current
+	// timestamp will be sent to the channel to force the monitor to change its configuration accordingly.
 	TimestampFeed chan int64
 
 	// Logger is the logger we use for this client.
 	Logger logr.Logger
 
-	// Adds the controller runtime client to the PodClient.
+	// Adds the controller runtime client to the kubernetesClient.
 	client.Client
 }
 
@@ -129,14 +103,14 @@ func setupCache(namespace string, podName string, nodeName string) (client.WithW
 	return internalClient, internalCache, nil
 }
 
-// CreatePodClient creates a new client for working with the pod object.
-func CreatePodClient(ctx context.Context, logger logr.Logger, enableNodeWatcher bool, setupCache func(string, string, string) (client.WithWatch, cache.Cache, error)) (*PodClient, error) {
+// createPodClient creates a new client for working with the pod object.
+func createPodClient(ctx context.Context, logger logr.Logger, enableNodeWatcher bool, setupCache func(string, string, string) (client.WithWatch, cache.Cache, error)) (*kubernetesClient, error) {
 	namespace := os.Getenv("FDB_POD_NAMESPACE")
 	podName := os.Getenv("FDB_POD_NAME")
 	nodeName := os.Getenv("FDB_NODE_NAME")
 
 	internalClient, internalCache, err := setupCache(namespace, podName, nodeName)
-	podClient := &PodClient{
+	podClient := &kubernetesClient{
 		podMetadata:   nil,
 		nodeMetadata:  nil,
 		TimestampFeed: make(chan int64, 10),
@@ -190,7 +164,7 @@ func CreatePodClient(ctx context.Context, logger logr.Logger, enableNodeWatcher 
 
 	podClient.Client = controllerClient
 
-	// Fetch the current metadata before returning the PodClient
+	// Fetch the current metadata before returning the kubernetesClient
 	currentPodMetadata := &metav1.PartialObjectMetadata{}
 	currentPodMetadata.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Pod"))
 	err = podClient.Client.Get(ctx, client.ObjectKey{Namespace: namespace, Name: podName}, currentPodMetadata)
@@ -218,9 +192,9 @@ func CreatePodClient(ctx context.Context, logger logr.Logger, enableNodeWatcher 
 
 // retrieveEnvironmentVariables extracts the environment variables we have for
 // an argument into a map.
-func retrieveEnvironmentVariables(monitor *Monitor, argument api.Argument, target map[string]string) {
+func retrieveEnvironmentVariables(monitor *monitor, argument api.Argument, target map[string]string) {
 	if argument.Source != "" {
-		value, err := argument.LookupEnv(monitor.CustomEnvironment)
+		value, err := argument.LookupEnv(monitor.customEnvironment)
 		if err == nil {
 			target[argument.Source] = value
 		}
@@ -232,38 +206,43 @@ func retrieveEnvironmentVariables(monitor *Monitor, argument api.Argument, targe
 	}
 }
 
-// UpdateAnnotations updates annotations on the pod after loading new
+// updateAnnotations updates annotations on the pod after loading new
 // configuration.
-func (podClient *PodClient) UpdateAnnotations(monitor *Monitor) error {
+func (podClient *kubernetesClient) updateAnnotations(monitor *monitor) error {
 	environment := make(map[string]string)
-	for _, argument := range monitor.ActiveConfiguration.Arguments {
+	for _, argument := range monitor.activeConfiguration.Arguments {
 		retrieveEnvironmentVariables(monitor, argument, environment)
 	}
-	environment["BINARY_DIR"] = path.Dir(monitor.ActiveConfiguration.BinaryPath)
+	environment["BINARY_DIR"] = path.Dir(monitor.activeConfiguration.BinaryPath)
 	jsonEnvironment, err := json.Marshal(environment)
 	if err != nil {
 		return err
 	}
 
 	return podClient.updateAnnotationsOnPod(map[string]string{
-		CurrentConfigurationAnnotation: string(monitor.ActiveConfigurationBytes),
-		EnvironmentAnnotation:          string(jsonEnvironment),
+		api.CurrentConfigurationAnnotation: string(monitor.activeConfigurationBytes),
+		api.EnvironmentAnnotation:          string(jsonEnvironment),
 	})
 }
 
 // updateFdbClusterTimestampAnnotation updates the ClusterFileChangeDetectedAnnotation annotation on the pod
 // after a change to the fdb.cluster file was detected, e.g. because the coordinators were changed.
-func (podClient *PodClient) updateFdbClusterTimestampAnnotation() error {
+func (podClient *kubernetesClient) updateFdbClusterTimestampAnnotation() error {
 	return podClient.updateAnnotationsOnPod(map[string]string{
-		ClusterFileChangeDetectedAnnotation: strconv.FormatInt(time.Now().Unix(), 10),
+		api.ClusterFileChangeDetectedAnnotation: strconv.FormatInt(time.Now().Unix(), 10),
 	})
 }
 
 // updateAnnotationsOnPod will update the annotations with the provided annotationChanges. If an annotation exists, it
 // will be updated if the annotation is absent it will be added.
-func (podClient *PodClient) updateAnnotationsOnPod(annotationChanges map[string]string) error {
+func (podClient *kubernetesClient) updateAnnotationsOnPod(annotationChanges map[string]string) error {
 	if podClient.podMetadata == nil {
 		return fmt.Errorf("pod client has no metadata present")
+	}
+	
+	annotations := podClient.podMetadata.Annotations
+	if len(annotations) == 0 {
+		annotations = map[string]string{}
 	}
 
 	if !podClient.podMetadata.DeletionTimestamp.IsZero() {
@@ -309,7 +288,7 @@ func (podClient *PodClient) updateAnnotationsOnPod(annotationChanges map[string]
 }
 
 // OnAdd is called when an object is added.
-func (podClient *PodClient) OnAdd(obj interface{}) {
+func (podClient *kubernetesClient) OnAdd(obj interface{}) {
 	switch castedObj := obj.(type) {
 	case *corev1.Pod:
 		podClient.Logger.Info("Got event for OnAdd for Pod resource", "name", castedObj.Name, "namespace", castedObj.Namespace)
@@ -329,7 +308,7 @@ func (podClient *PodClient) OnAdd(obj interface{}) {
 // OnUpdate is also called when a re-list happens, and it will
 // get called even if nothing changed. This is useful for periodically
 // evaluating or syncing something.
-func (podClient *PodClient) OnUpdate(_, newObj interface{}) {
+func (podClient *kubernetesClient) OnUpdate(_, newObj interface{}) {
 	switch castedObj := newObj.(type) {
 	case *corev1.Pod:
 		podClient.Logger.Info("Got event for OnUpdate for Pod resource", "name", castedObj.Name, "namespace", castedObj.Namespace, "generation", castedObj.Generation)
@@ -349,8 +328,8 @@ func (podClient *PodClient) OnUpdate(_, newObj interface{}) {
 
 		// If the IsolateProcessGroupAnnotation changes force a reload of the configuration to make sure the processes
 		// will be shutdown.
-		previousIsolateProcessGroupAnnotationValue := previousAnnotations[IsolateProcessGroupAnnotation]
-		newIsolateProcessGroupAnnotationValue := podClient.podMetadata.Annotations[IsolateProcessGroupAnnotation]
+		previousIsolateProcessGroupAnnotationValue := previousAnnotations[api.IsolateProcessGroupAnnotation]
+		newIsolateProcessGroupAnnotationValue := podClient.podMetadata.Annotations[api.IsolateProcessGroupAnnotation]
 		if previousIsolateProcessGroupAnnotationValue != newIsolateProcessGroupAnnotationValue {
 			podClient.Logger.Info("Got change in isolate process group annotation", "previous", previousIsolateProcessGroupAnnotationValue, "new", newIsolateProcessGroupAnnotationValue)
 			podClient.TimestampFeed <- time.Now().Unix()
@@ -358,14 +337,14 @@ func (podClient *PodClient) OnUpdate(_, newObj interface{}) {
 			return
 		}
 
-		annotation := podClient.podMetadata.Annotations[OutdatedConfigMapAnnotation]
+		annotation := podClient.podMetadata.Annotations[api.OutdatedConfigMapAnnotation]
 		if annotation == "" {
 			return
 		}
 
 		timestamp, err := strconv.ParseInt(annotation, 10, 64)
 		if err != nil {
-			podClient.Logger.Error(err, "Error parsing annotation", "key", OutdatedConfigMapAnnotation, "rawAnnotation", annotation)
+			podClient.Logger.Error(err, "Error parsing annotation", "key", api.OutdatedConfigMapAnnotation, "rawAnnotation", annotation)
 			return
 		}
 
@@ -383,7 +362,7 @@ func (podClient *PodClient) OnUpdate(_, newObj interface{}) {
 // it will get an object of type DeletedFinalStateUnknown. This can
 // happen if the watch is closed and misses the delete event and we don't
 // notice the deletion until the subsequent re-list.
-func (podClient *PodClient) OnDelete(obj interface{}) {
+func (podClient *kubernetesClient) OnDelete(obj interface{}) {
 	switch castedObj := obj.(type) {
 	case *corev1.Pod:
 		podClient.Logger.Info("Got event for OnDelete for Pod resource", "name", castedObj.Name, "namespace", castedObj.Namespace)

--- a/fdbkubernetesmonitor/main.go
+++ b/fdbkubernetesmonitor/main.go
@@ -28,6 +28,8 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/apple/foundationdb/fdbkubernetesmonitor/api"
+
 	"github.com/go-logr/logr"
 	"github.com/go-logr/zapr"
 	"github.com/spf13/pflag"
@@ -164,7 +166,13 @@ func main() {
 			certPath:   certPath,
 			keyPath:    keyPath,
 		}
-		startMonitor(context.Background(), logger, path.Join(inputDir, monitorConfFile), customEnvironment, processCount, promConfig, enablePprof, currentContainerVersion, enableNodeWatch)
+
+		parsedVersion, err := api.ParseFdbVersion(currentContainerVersion)
+		if err != nil {
+			logger.Error(err, "Error parsing container version", "currentContainerVersion", currentContainerVersion)
+			os.Exit(1)
+		}
+		startMonitor(context.Background(), logger, path.Join(inputDir, monitorConfFile), customEnvironment, processCount, promConfig, enablePprof, parsedVersion, enableNodeWatch)
 	case executionModeInit:
 		err = copyFiles(logger, outputDir, copyDetails, requiredCopies)
 		if err != nil {

--- a/fdbkubernetesmonitor/main.go
+++ b/fdbkubernetesmonitor/main.go
@@ -109,7 +109,7 @@ func parseFlagsAndSetEnvDefaults() error {
 }
 
 func main() {
-	var copyFiles, copyBinaries, copyLibraries, requiredCopyFiles []string
+	var filesToCopy, copyBinaries, copyLibraries, requiredCopyFiles []string
 	var inputDir, copyPrimaryLibrary, binaryOutputDirectory, certPath, keyPath string
 
 	pflag.StringVar(&executionModeString, "mode", "launcher", "Execution mode. Valid options are launcher, sidecar, and init")
@@ -118,7 +118,7 @@ func main() {
 	pflag.StringVar(&monitorConfFile, "input-monitor-conf", "config.json", "Name of the file in the input directory that contains the monitor configuration")
 	pflag.StringVar(&logPath, "log-path", "", "Name of a file to send logs to. Logs will be sent to stdout in addition the file you pass in this argument. If this is blank, logs will only by sent to stdout")
 	pflag.StringVar(&outputDir, "output-dir", ".", "Directory to copy files into")
-	pflag.StringArrayVar(&copyFiles, "copy-file", nil, "A list of files to copy")
+	pflag.StringArrayVar(&filesToCopy, "copy-file", nil, "A list of files to copy")
 	pflag.StringArrayVar(&copyBinaries, "copy-binary", nil, "A list of binaries to copy from /usr/bin")
 	pflag.StringVar(&versionFilePath, "version-file", "/var/fdb/version", "Path to a file containing the current FDB version")
 	pflag.StringVar(&sharedBinaryDir, "shared-binary-dir", "/var/fdb/shared-binaries/bin", "A directory containing binaries that are copied from a sidecar process")
@@ -146,7 +146,7 @@ func main() {
 	}
 	currentContainerVersion := strings.TrimSpace(string(versionBytes))
 	mode := executionMode(executionModeString)
-	copyDetails, requiredCopies, err := getCopyDetails(inputDir, copyPrimaryLibrary, binaryOutputDirectory, copyFiles, copyBinaries, copyLibraries, requiredCopyFiles, currentContainerVersion, mode)
+	copyDetails, requiredCopies, err := getCopyDetails(inputDir, copyPrimaryLibrary, binaryOutputDirectory, filesToCopy, copyBinaries, copyLibraries, requiredCopyFiles, currentContainerVersion, mode)
 	if err != nil {
 		logger.Error(err, "Error getting list of files to copy")
 		os.Exit(1)
@@ -164,16 +164,16 @@ func main() {
 			certPath:   certPath,
 			keyPath:    keyPath,
 		}
-		StartMonitor(context.Background(), logger, path.Join(inputDir, monitorConfFile), customEnvironment, processCount, promConfig, enablePprof, currentContainerVersion, enableNodeWatch)
+		startMonitor(context.Background(), logger, path.Join(inputDir, monitorConfFile), customEnvironment, processCount, promConfig, enablePprof, currentContainerVersion, enableNodeWatch)
 	case executionModeInit:
-		err = CopyFiles(logger, outputDir, copyDetails, requiredCopies)
+		err = copyFiles(logger, outputDir, copyDetails, requiredCopies)
 		if err != nil {
 			logger.Error(err, "Error copying files")
 			os.Exit(1)
 		}
 	case executionModeSidecar:
 		if mainContainerVersion != currentContainerVersion {
-			err = CopyFiles(logger, outputDir, copyDetails, requiredCopies)
+			err = copyFiles(logger, outputDir, copyDetails, requiredCopies)
 			if err != nil {
 				logger.Error(err, "Error copying files")
 				os.Exit(1)

--- a/fdbkubernetesmonitor/metrics.go
+++ b/fdbkubernetesmonitor/metrics.go
@@ -45,7 +45,7 @@ const (
 	desiredVersionMetricName = "desired_version"
 )
 
-// metrics represents the custom prometheus metrics for the Monitor.
+// metrics represents the custom prometheus metrics for the monitor.
 type metrics struct {
 	// restartCount represents the total number of fdbserver process restarts.
 	restartCount *prometheus.CounterVec

--- a/fdbkubernetesmonitor/metrics.go
+++ b/fdbkubernetesmonitor/metrics.go
@@ -30,7 +30,7 @@ const (
 	// processLabel represents the process label for the prometheus metrics.
 	processLabel = "process"
 	// namespace is the prometheus namespace for the metrics
-	namespace = "fdbkubernetesmonitor"
+	prometheusNamespace = "fdbkubernetesmonitor"
 	// restartCountMetricName represents the name of the restart metric.
 	restartCountMetricName = "restart_count"
 	// configurationChangeCountMetricName represents the configuration_change_count metric.
@@ -98,32 +98,32 @@ func registerMetrics(reg prometheus.Registerer) *metrics {
 	monitorMetrics := &metrics{
 		restartCount: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Namespace: namespace,
+				Namespace: prometheusNamespace,
 				Name:      restartCountMetricName,
 				Help:      "Number of fdbserver process restarts in total.",
 			}, []string{processLabel}),
 		configurationChangeCount: prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: namespace,
+			Namespace: prometheusNamespace,
 			Name:      configurationChangeCountMetricName,
 			Help:      "Number of observed configuration changes.",
 		}),
 		lastAppliedConfigurationTimestamp: prometheus.NewGauge(prometheus.GaugeOpts{
-			Namespace: namespace,
+			Namespace: prometheusNamespace,
 			Name:      lastAppliedConfigurationTimestampMetricName,
 			Help:      "Timestamp when the last time the configuration was applied.",
 		}),
 		startTimestamp: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Namespace: namespace,
+			Namespace: prometheusNamespace,
 			Name:      startTimestampMetricName,
 			Help:      "Timestamp when the last time the configuration was applied.",
 		}, []string{processLabel}),
 		runningVersion: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Namespace: namespace,
+			Namespace: prometheusNamespace,
 			Name:      runningVersionMetricName,
 			Help:      "The current running version of the fdbserver processes started by this monitor.",
 		}, []string{versionLabel}),
 		desiredVersion: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Namespace: namespace,
+			Namespace: prometheusNamespace,
 			Name:      desiredVersionMetricName,
 			Help:      "The desired running version of the fdbserver processes started by this monitor.",
 		}, []string{versionLabel}),

--- a/fdbkubernetesmonitor/metrics_test.go
+++ b/fdbkubernetesmonitor/metrics_test.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/utils/pointer"
 )
 
-var _ = Describe("Testing Monitor metrics", func() {
+var _ = Describe("Testing monitor metrics", func() {
 	When("getting the copy details", func() {
 		sevenOneVersion := "7.1.57"
 		sevenThreeVersion := "7.3.37"

--- a/fdbkubernetesmonitor/monitor.go
+++ b/fdbkubernetesmonitor/monitor.go
@@ -238,9 +238,14 @@ func (monitor *monitor) readConfiguration() (*api.ProcessConfiguration, []byte) 
 		return nil, nil
 	}
 
+	if configuration.Version == nil {
+		monitor.logger.Error(err, "Error could not parse configured version", "rawConfiguration", string(configurationBytes))
+		return nil, nil
+	}
+
 	// If the versions are protocol compatible don't try to point to another binary path. Otherwise, the processes will
 	// cannot restart when a process crashes during a patch upgrade.
-	if monitor.currentContainerVersion.IsProtocolCompatible(configuration.Version) {
+	if monitor.currentContainerVersion.IsProtocolCompatible(*configuration.Version) {
 		configuration.BinaryPath = fdbserverPath
 	} else {
 		configuration.BinaryPath = path.Join(sharedBinaryDir, configuration.Version.String(), "fdbserver")

--- a/fdbkubernetesmonitor/monitor_test.go
+++ b/fdbkubernetesmonitor/monitor_test.go
@@ -109,7 +109,7 @@ var _ = Describe("Testing FDB Kubernetes monitor", func() {
 		var configurationFilePath string
 		var configuration *api.ProcessConfiguration
 		var configurationBytes []byte
-		defaultVersion := "7.1.51"
+		defaultVersion := api.Version{Major: 7, Minor: 1, Patch: 51}
 
 		BeforeEach(func() {
 			tmpDir := GinkgoT().TempDir()

--- a/fdbkubernetesmonitor/monitor_test.go
+++ b/fdbkubernetesmonitor/monitor_test.go
@@ -146,7 +146,7 @@ var _ = Describe("Testing FDB Kubernetes monitor", func() {
 
 			BeforeEach(func() {
 				config := &api.ProcessConfiguration{
-					Version: defaultVersion,
+					Version: &defaultVersion,
 				}
 
 				var err error
@@ -157,7 +157,7 @@ var _ = Describe("Testing FDB Kubernetes monitor", func() {
 
 			It("should return the configuration", func() {
 				Expect(configuration).NotTo(BeNil())
-				Expect(configuration.Version).To(Equal(defaultVersion))
+				Expect(configuration.Version).To(Equal(&defaultVersion))
 				Expect(configuration.BinaryPath).To(Equal(fdbserverPath))
 				Expect(configuration.RunServers).To(BeNil())
 				Expect(configuration.Arguments).To(BeEmpty())
@@ -179,7 +179,7 @@ var _ = Describe("Testing FDB Kubernetes monitor", func() {
 
 				It("should return the configuration with runServers set to false", func() {
 					Expect(configuration).NotTo(BeNil())
-					Expect(configuration.Version).To(Equal(defaultVersion))
+					Expect(configuration.Version).To(Equal(&defaultVersion))
 					Expect(configuration.BinaryPath).To(Equal(fdbserverPath))
 					Expect(configuration.RunServers).NotTo(BeNil())
 					Expect(*configuration.RunServers).To(BeFalse())

--- a/fdbkubernetesmonitor/suite_test.go
+++ b/fdbkubernetesmonitor/suite_test.go
@@ -33,5 +33,5 @@ import (
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
 	SetDefaultEventuallyTimeout(10 * time.Second)
-	RunSpecs(t, "FDB Kubernetes Monitor")
+	RunSpecs(t, "FDB Kubernetes monitor")
 }


### PR DESCRIPTION
Implements the fdb-kubernetes-monitor support for: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1906

Replace this text with your description here...

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
