### PR TITLE
fix two misspelled words

### DIFF
--- a/contrib/mockkms/mock_kms.go
+++ b/contrib/mockkms/mock_kms.go
@@ -26,7 +26,7 @@ package main
 
 // Importing module enable .note.gnu.build-id insertion in the ELF executable.
 // Few drawbacks of the scheme are:
-// 1. Potentialy slower builds
+// 1. Potentially slower builds
 // 2. No cross-compilation support
 // 3. Limited `go tools` availability.
 // TODO: Replace with a better scheme if possible.

--- a/contrib/mockkms/mockkms_test.go
+++ b/contrib/mockkms/mockkms_test.go
@@ -20,7 +20,7 @@
 
 // MockKMS unit tests, the coverage includes:
 // 1. Mock HttpRequest creation and HttpResponse writer.
-// 2. Construct fake request to validate the following scenarions:
+// 2. Construct fake request to validate the following scenarios:
 //  2.1. Request with "unsupported query mode"
 //  2.2. Get encryption keys by KeyIds; with and without 'RefreshKmsUrls' flag.
 //  2.2. Get encryption keys by DomainIds; with and without 'RefreshKmsUrls' flag.


### PR DESCRIPTION
This PR fixes two minor typos in the comments. 
It does not change any functionality.