### PR TITLE
Replica comparison error message cleanup

### DIFF
--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -5058,7 +5058,7 @@ static Future<Void> tssStreamComparison(Request request,
 				mismatchEvent.detail("TSSID", tssData.tssId);
 
 				if (tssData.metrics->shouldRecordDetailedMismatch()) {
-					TSS_traceMismatch(mismatchEvent, request, ssReply.get(), tssReply.get());
+					TSS_traceMismatch(mismatchEvent, request, ssReply.get(), tssReply.get(), TSS_COMPARISON);
 
 					CODE_PROBE(FLOW_KNOBS->LOAD_BALANCE_TSS_MISMATCH_TRACE_FULL,
 					           "Tracing Full TSS Mismatch in stream comparison",

--- a/fdbrpc/include/fdbrpc/LoadBalance.actor.h
+++ b/fdbrpc/include/fdbrpc/LoadBalance.actor.h
@@ -199,7 +199,7 @@ Future<Void> tssComparison(Req req,
 					    .detail("TeamCheckMatchNeither", numMatchNeither);
 				}
 				if (tssData.metrics->shouldRecordDetailedMismatch()) {
-					TSS_traceMismatch(mismatchEvent, req, src.get(), tss.get().get());
+					TSS_traceMismatch(mismatchEvent, req, src.get(), tss.get().get(), TSS_COMPARISON);
 
 					CODE_PROBE(FLOW_KNOBS->LOAD_BALANCE_TSS_MISMATCH_TRACE_FULL, "Tracing Full TSS Mismatch");
 					CODE_PROBE(!FLOW_KNOBS->LOAD_BALANCE_TSS_MISMATCH_TRACE_FULL,
@@ -381,7 +381,8 @@ Future<Void> replicaComparison(Req req,
 								mismatchEvent.detail("ReplicaFetchErrors", numError)
 								    .detail("ReplicaFetchTimeouts", numFetchReplicaTimeout);
 								// Re-use TSS trace mechanism to log replica mismatch information.
-								TSS_traceMismatch(mismatchEvent, req, src.get(), f.get().get().get());
+								TSS_traceMismatch(
+								    mismatchEvent, req, src.get(), f.get().get().get(), REPLICA_COMPARISON);
 							}
 							if (++successfulReplies == requiredReplicas) {
 								break;

--- a/fdbrpc/include/fdbrpc/TSSComparison.h
+++ b/fdbrpc/include/fdbrpc/TSSComparison.h
@@ -117,7 +117,7 @@ bool TSS_doCompare(const Rep& src, const Rep& tss);
 template <class Req, class Type>
 const char* LB_mismatchTraceName(const Req& req, const Type& type);
 
-template <class Req, class Rep>
-void TSS_traceMismatch(TraceEvent& event, const Req& req, const Rep& src, const Rep& tss);
+template <class Req, class Rep, class Type>
+void TSS_traceMismatch(TraceEvent& event, const Req& req, const Rep& src, const Rep& tss, const Type& type);
 
 #endif


### PR DESCRIPTION
Do not refer to TSS when logging error/trace messages in the context of replica comparison.

Testing:

Joshua job: 

20240618-164125-sre-1bd7af425d6bb76b (shows test failures but it is unlikely they were caused by this change set).

20240618-182439-sre-1bd7af425d6bb76b (shows a "cacheTest.toml" failing, again it is unlikely that was caused by this change set).

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
