### PR TITLE
fix: resolve missing CopyJavaDoc target

### DIFF
--- a/documentation/CMakeLists.txt
+++ b/documentation/CMakeLists.txt
@@ -67,6 +67,11 @@ endfunction()
 message(STATUS "Add html target")
 add_documentation_target(GENERATOR html)
 
+add_custom_target(CopyJavadoc
+  COMMAND ${CMAKE_COMMAND} -E copy_directory ${SPHINX_DOCUMENT_DIR}/javadoc ${CMAKE_BINARY_DIR}/docs/javadoc
+  COMMENT "Copying Javadoc to build directory"
+)
+
 set(DOCSERVER_PORT
     "-1"
     CACHE
@@ -116,3 +121,4 @@ add_custom_command(
 add_custom_target(package_html DEPENDS ${tar_file})
 add_dependencies(package_html html)
 add_dependencies(packages package_html)
+


### PR DESCRIPTION
This pull request addresses a build error encountered when enabling documentation generation for the FoundationDB project. The error is related to a missing CopyJavadoc target in the CMakeLists.txt file. The build error is as follows:

```bash
CMake Error at CMakeLists.txt:218 (add_dependencies):
  The dependency target "CopyJavadoc" of target "html" does not exist.
```

Solution: Added a custom target named CopyJavadoc that uses the cmake -E copy_directory command to copy Javadoc files from the sphinx directory to the build directory. This target is now correctly referenced as a dependency for the html target, ensuring that the build process completes successfully.


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
