### PR TITLE
Serve no-op configuration database interface when disabled

### DIFF
--- a/design/dynamic-knobs.md
+++ b/design/dynamic-knobs.md
@@ -176,13 +176,13 @@ The only client change from the configuration database is as part of the change
 coordinators command. The change coordinators command is not considered
 successful until the configuration database is readable on the new
 coordinators. If the configuration database has been disabled server-side via
-the ``-no-config-db`` command line option, the coordinators will continue to
+the ``--no-config-db`` command line option, the coordinators will continue to
 serve the configuration interface, but will reply to each request with an empty
 response. Client-side changes are no longer necessary when disabling the
 configuration database.
 
 Optionally, the client liveness check of the configuration database can be
-prevented by specifying the ``-no-config-db`` flag when changing the
+prevented by specifying the ``--no-config-db`` flag when changing the
 coordinators. For example:
 
 ```

--- a/design/dynamic-knobs.md
+++ b/design/dynamic-knobs.md
@@ -175,10 +175,15 @@ for *every* ``fdbserver`` process.
 The only client change from the configuration database is as part of the change
 coordinators command. The change coordinators command is not considered
 successful until the configuration database is readable on the new
-coordinators. This will cause the change coordinators command to hang if run
-against a database with dynamic knobs disabled. To disable the client side
-configuration database liveness check, specify the ``--no-config-db`` flag when
-changing coordinators. For example:
+coordinators. If the configuration database has been disabled server-side via
+the ``-no-config-db`` command line option, the coordinators will continue to
+serve the configuration interface, but will reply to each request with an empty
+response. Client-side changes are no longer necessary when disabling the
+configuration database.
+
+Optionally, the client liveness check of the configuration database can be
+prevented by specifying the ``-no-config-db`` flag when changing the
+coordinators. For example:
 
 ```
 fdbcli> coordinators auto --no-config-db

--- a/fdbserver/include/fdbserver/ConfigNode.h
+++ b/fdbserver/include/fdbserver/ConfigNode.h
@@ -37,6 +37,9 @@ public:
 	Future<Void> serve(ConfigBroadcastInterface const&,
 	                   ConfigTransactionInterface const&,
 	                   ConfigFollowerInterface const&);
+	// Serves some interfaces even when the configuration database is disabled,
+	// to prevent client requests from hanging.
+	Future<Void> serveDisabled(ConfigTransactionInterface const&, ConfigFollowerInterface const&);
 
 public: // Testing
 	Future<Void> serve(ConfigBroadcastInterface const&);


### PR DESCRIPTION
By continuing to serve the configuration database interface used by clients even when disabled, clients no longer need to specify a special `--no-config-db` option when running commands which talk to the configuration database.

Replace this text with your description here...

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
