### PR TITLE
Add flag for custom jemalloc build

### DIFF
--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -40,6 +40,7 @@ if(USE_SANITIZER OR WIN32 OR (CMAKE_SYSTEM_NAME STREQUAL "FreeBSD") OR APPLE)
   set(jemalloc_default OFF)
 endif()
 env_set(USE_JEMALLOC ${jemalloc_default} BOOL "Link with jemalloc")
+env_set(USE_CUSTOM_JEMALLOC OFF BOOL "Manually download and build jemalloc")
 
 if(USE_LIBCXX AND STATIC_LINK_LIBCXX AND NOT USE_LD STREQUAL "LLD")
   message(FATAL_ERROR "Unsupported configuration: STATIC_LINK_LIBCXX with libc++ only works if USE_LD=LLD")

--- a/cmake/FDBComponents.cmake
+++ b/cmake/FDBComponents.cmake
@@ -5,7 +5,11 @@ set(FORCE_ALL_COMPONENTS OFF CACHE BOOL "Fails cmake if not all dependencies are
 ################################################################################
 
 if(USE_JEMALLOC)
-  find_package(jemalloc 5.3.0 REQUIRED)
+  if(NOT USE_CUSTOM_JEMALLOC)
+    find_package(jemalloc 5.3.0 REQUIRED)
+  else()
+    include(Jemalloc)
+  endif()
 endif()
 
 ################################################################################

--- a/cmake/Jemalloc.cmake
+++ b/cmake/Jemalloc.cmake
@@ -4,28 +4,25 @@ if(NOT USE_JEMALLOC)
   return()
 endif()
 
-add_library(im_jemalloc_pic STATIC IMPORTED)
-add_library(im_jemalloc STATIC IMPORTED)
-if(EXISTS /opt/jemalloc_5.3.0)
-  set(JEMALLOC_DIR /opt/jemalloc_5.3.0)
-else()
-  include(ExternalProject)
-  set(JEMALLOC_DIR "${CMAKE_BINARY_DIR}/jemalloc")
-  ExternalProject_add(Jemalloc_project
-    URL "https://github.com/jemalloc/jemalloc/releases/download/5.3.0/jemalloc-5.3.0.tar.bz2"
-    URL_HASH SHA256=2db82d1e7119df3e71b7640219b6dfe84789bc0537983c3b7ac4f7189aecfeaa
-    BUILD_BYPRODUCTS "${JEMALLOC_DIR}/include/jemalloc/jemalloc.h"
-    "${JEMALLOC_DIR}/lib/libjemalloc.a"
-    "${JEMALLOC_DIR}/lib/libjemalloc_pic.a"
-    CONFIGURE_COMMAND CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER} ./configure --prefix=${JEMALLOC_DIR} --enable-static --disable-cxx --enable-prof
-    BUILD_IN_SOURCE ON
-    BUILD_COMMAND make
-    INSTALL_DIR "${JEMALLOC_DIR}"
-    INSTALL_COMMAND make install)
-endif()
-add_dependencies(im_jemalloc Jemalloc_project)
-add_dependencies(im_jemalloc_pic Jemalloc_project)
-set_target_properties(im_jemalloc_pic PROPERTIES IMPORTED_LOCATION "${JEMALLOC_DIR}/lib/libjemalloc_pic.a")
-set_target_properties(im_jemalloc PROPERTIES IMPORTED_LOCATION "${JEMALLOC_DIR}/lib/libjemalloc.a")
-target_include_directories(jemalloc INTERFACE "${JEMALLOC_DIR}/include")
-target_link_libraries(jemalloc INTERFACE im_jemalloc_pic im_jemalloc)
+add_library(jemalloc::jemalloc STATIC IMPORTED)
+add_library(jemalloc_pic::jemalloc_pic STATIC IMPORTED)
+
+include(ExternalProject)
+set(JEMALLOC_DIR "${CMAKE_BINARY_DIR}/jemalloc")
+ExternalProject_add(Jemalloc_project
+  URL "https://github.com/jemalloc/jemalloc/releases/download/5.3.0/jemalloc-5.3.0.tar.bz2"
+  URL_HASH SHA256=2db82d1e7119df3e71b7640219b6dfe84789bc0537983c3b7ac4f7189aecfeaa
+  BUILD_BYPRODUCTS "${JEMALLOC_DIR}/include/jemalloc/jemalloc.h"
+  "${JEMALLOC_DIR}/lib/libjemalloc.a"
+  "${JEMALLOC_DIR}/lib/libjemalloc_pic.a"
+  CONFIGURE_COMMAND CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER} ./configure --prefix=${JEMALLOC_DIR} --enable-static --disable-cxx --enable-prof
+  BUILD_IN_SOURCE ON
+  BUILD_COMMAND make
+  INSTALL_DIR "${JEMALLOC_DIR}"
+  INSTALL_COMMAND make install)
+
+add_dependencies(jemalloc::jemalloc Jemalloc_project)
+add_dependencies(jemalloc_pic::jemalloc_pic Jemalloc_project)
+
+set_target_properties(jemalloc::jemalloc PROPERTIES IMPORTED_LOCATION "${JEMALLOC_DIR}/lib/libjemalloc_pic.a")
+set_target_properties(jemalloc_pic::jemalloc_pic PROPERTIES IMPORTED_LOCATION "${JEMALLOC_DIR}/lib/libjemalloc_pic.a")

--- a/cmake/Jemalloc.cmake
+++ b/cmake/Jemalloc.cmake
@@ -24,5 +24,5 @@ ExternalProject_add(Jemalloc_project
 add_dependencies(jemalloc::jemalloc Jemalloc_project)
 add_dependencies(jemalloc_pic::jemalloc_pic Jemalloc_project)
 
-set_target_properties(jemalloc::jemalloc PROPERTIES IMPORTED_LOCATION "${JEMALLOC_DIR}/lib/libjemalloc_pic.a")
+set_target_properties(jemalloc::jemalloc PROPERTIES IMPORTED_LOCATION "${JEMALLOC_DIR}/lib/libjemalloc.a")
 set_target_properties(jemalloc_pic::jemalloc_pic PROPERTIES IMPORTED_LOCATION "${JEMALLOC_DIR}/lib/libjemalloc_pic.a")


### PR DESCRIPTION
A new flag, USE_CUSTOM_JEMALLOC, is added. If it is turned on, e.g. `cmake $HOME/src/foundationdb/ -GNinja -DUSE_CUSTOM_JEMALLOC`, the builder will download Jemalloc and ignore local version.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
