### PR TITLE
[flow] Refactor BaseTraceEvent::detail

### DIFF
--- a/flow/include/flow/Trace.h
+++ b/flow/include/flow/Trace.h
@@ -278,12 +278,7 @@ struct SWIFT_CXX_IMPORT_OWNED BaseTraceEvent {
 	template <class T>
 	typename std::enable_if<Traceable<T>::value && !std::is_enum_v<T>, BaseTraceEvent&>::type detail(std::string&& key,
 	                                                                                                 const T& value) {
-		if (enabled && init()) {
-			auto s = Traceable<T>::toString(value);
-			addMetric(key.c_str(), value, s);
-			return detailImpl(std::move(key), std::move(s), false);
-		}
-		return *this;
+		return detail(key.c_str(), value);
 	}
 
 	template <class T>


### PR DESCRIPTION
# Description

`BaseTraceEvent::detail(std::string&& key, const T& value)`'s implementation was exactly the same as `BaseTraceEvent::detail(const char* key, const T& value)`. This PR refactors `BaseTraceEvent::detail(std::string&& key, const T& value)` such that it simply calls `BaseTraceEvent::detail(const char* key, const T& value)` -- implementation uses `string.c_str()` to pass the `const char*`. 

# Testing

- Ran `ctest`, all tests pass.
- Ran `fdbserver -r unittests -f noSim`, all tests pass.
- Ran 100K Joshua test (`20240711-200017-praza-43a18d557f79f714`). This passed 99999 tests and only one failed (`tests/slow/VersionStampSwitchover.toml`) because of a timeout issue. Ran it again manually and it passed.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
