### PR TITLE
[cluster-controller] Remove unused DBInfo::logGenerations

### DIFF
--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -1023,11 +1023,7 @@ void clusterRegisterMaster(ClusterControllerData* self, RegisterMasterRequest co
 
 	if (req.recoveryState == RecoveryState::FULLY_RECOVERED) {
 		self->db.unfinishedRecoveries = 0;
-		self->db.logGenerations = 0;
 		ASSERT(!req.logSystemConfig.oldTLogs.size());
-	} else {
-		// TODO(zhewu): Remove logGenerations. It is not used anywhere.
-		self->db.logGenerations = req.logSystemConfig.oldTLogs.size();
 	}
 
 	db->masterRegistrationCount = req.registrationCount;

--- a/fdbserver/include/fdbserver/ClusterController.actor.h
+++ b/fdbserver/include/fdbserver/ClusterController.actor.h
@@ -141,7 +141,6 @@ public:
 		DatabaseConfiguration fullyRecoveredConfig;
 		Database db;
 		int unfinishedRecoveries;
-		int logGenerations;
 		bool cachePopulated;
 		std::map<NetworkAddress, std::pair<double, OpenDatabaseRequest>> clientStatus;
 		Future<Void> clientCounter;
@@ -163,7 +162,7 @@ public:
 		                               EnableLocalityLoadBalance::True,
 		                               TaskPriority::DefaultEndpoint,
 		                               LockAware::True)), // SOMEDAY: Locality!
-		    unfinishedRecoveries(0), logGenerations(0), cachePopulated(false), clientCount(0),
+		    unfinishedRecoveries(0), cachePopulated(false), clientCount(0),
 		    blobGranulesEnabled(config.blobGranulesEnabled), blobRestoreEnabled(false) {
 			clientCounter = countClients(this);
 		}


### PR DESCRIPTION
# Description

`DBInfo::logGenerations` in ClusterController looks like dead code so deleting it.

# Testing

- Ran `ctest`, all tests passed.
- Ran `fdbserver -r unittests -f noSim`, all tests passed.
- Ran `fdbserver -r simulation -f tests/fast/RandomUnitTests.toml`, all tests passed.
- Ran 100K Joshua test (`20240712-185721-praza-94ed9d61cb4505d3`). 99999 tests passed, 1 failed (`fast/BlobRestoreTenantMode.toml`). Can reproduce the failing test but don't think it's related to my change -- will discuss with @jzhou77. 

---

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
