### PR TITLE
Compute known committed version correctly when version vector unicast is enabled

### DIFF
--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -2582,12 +2582,6 @@ ACTOR Future<Void> reply(CommitBatchContext* self) {
 		                                     self->prevVersion,
 		                                     writtenTags),
 		    TaskPriority::ProxyMasterVersionReply));
-		if (SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST) {
-			ASSERT(self->loggingComplete.isReady());
-			ASSERT_WE_THINK(self->loggingComplete.get() >= self->commitVersion); // @todo remove later
-			pProxyCommitData->minKnownCommittedVersion =
-			    std::max(pProxyCommitData->minKnownCommittedVersion, self->loggingComplete.get());
-		}
 	}
 
 	if (debugID.present()) {
@@ -2599,6 +2593,11 @@ ACTOR Future<Void> reply(CommitBatchContext* self) {
 		pProxyCommitData->locked = self->lockedAfter;
 		pProxyCommitData->metadataVersion = self->metadataVersionAfter;
 		pProxyCommitData->committedVersion.set(self->commitVersion);
+		if (SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST) {
+			ASSERT(self->loggingComplete.isReady());
+			pProxyCommitData->minKnownCommittedVersion =
+			    std::max(pProxyCommitData->minKnownCommittedVersion, self->loggingComplete.get());
+		}
 	}
 
 	if (self->forceRecovery) {


### PR DESCRIPTION
Make commit proxies update known committed version after receiving a reply (for the commit version request) from the sequencer, instead of after making the committed transactions persistent on tLogs.

Testing:

With version vector disabled (and no knobs explicitly set):
Job id: 20240718-101540-sre-c8a4b8fcac91c90d (no failures).

By setting "ProxyCommitData::minKnownCommittedVersion" in "reply()" actor in "CommitProxyServer.actor.cpp" in all cases:
Job id: 20240718-131047-sre-8b5549fd2f3d236e (no failures).

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
