### PR TITLE
Update dynamic-knobs.md for Python 3

### DIFF
--- a/design/dynamic-knobs.md
+++ b/design/dynamic-knobs.md
@@ -111,21 +111,21 @@ fdb.api_version(730)
 
 @fdb.transactional
 def set_knob(tr, knob_name, knob_value, config_class, description):
-        tr['\xff\xff/description'] = description
+        tr[b'\xff\xff/description'] = description
         tr[fdb.tuple.pack((config_class, knob_name,))] = knob_value
 
 # This function performs two knob changes transactionally.
 @fdb.transactional
 def set_multiple_knobs(tr):
-        tr['\xff\xff/description'] = 'description'
-        tr[fdb.tuple.pack((None, 'min_trace_severity',))] = '10'
-        tr[fdb.tuple.pack(('az-1', 'min_trace_severity',))] = '20'
+        tr[b'\xff\xff/description'] = b'description'
+        tr[fdb.tuple.pack((None, b'min_trace_severity',))] = b'10'
+        tr[fdb.tuple.pack((b'az-1', b'min_trace_severity',))] = b'20'
 
 db = fdb.open()
 db.options.set_use_config_database()
 
-set_knob(db, 'min_trace_severity', '10', None, 'description')
-set_knob(db, 'min_trace_severity', '20', 'az-1', 'description')
+set_knob(db, b'min_trace_severity', b'10', None, b'description')
+set_knob(db, b'min_trace_severity', b'20', 'az-1', b'description')
 ```
 
 ### CLI Usage


### PR DESCRIPTION
fdb expects these to be bytes, not str.

It looks a bit uglier than `str`, but without `b` prefix, this example doesn't work, and throws `Key/Value must be a type of bytes`.

Alternatively, Python interface can be made to accept `str` and it can encode to `bytes` internally, but that may cause trouble in the future, or it requires a bit more careful thinking (e.g. it would be surprising to put `str`, and get `bytes`).

So for now, this is the simplest fix I think.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
