### PR TITLE
Fix a compilation issue in TestTLogServer.actor.cpp

### DIFF
--- a/fdbserver/TestTLogServer.actor.cpp
+++ b/fdbserver/TestTLogServer.actor.cpp
@@ -360,8 +360,8 @@ ACTOR Future<Void> startTestsTLogRecoveryActors(TestTLogOptions params) {
 		wait(pTLogTestContextEpochOne->peekCommitMessages(0, 0));
 	} else {
 		// Done with old generation. Lock the old generation of tLogs.
-		TLogLockResult data = wait(
-		    pTLogTestContextEpochOne->pTLogContextList[tLogIdx]->TestTLogInterface.lock.getReply<TLogLockResult>());
+		TLogLockResult data = wait(pTLogTestContextEpochOne->pTLogContextList[tLogIdx]
+		                               ->TestTLogInterface.lock.template getReply<TLogLockResult>());
 		TraceEvent("TestTLogServerLockResult").detail("KCV", data.knownCommittedVersion);
 
 		state Reference<TLogTestContext> pTLogTestContextEpochTwo =


### PR DESCRIPTION
Without this change, `cmake --build` fails with (on macOS with Apple clang 15.0.0):

fdbserver/TestTLogServer.actor.cpp:363:125: error: use 'template' keyword to treat 'getReply' as a dependent template name

Full error:

```
FAILED: fdbserver/CMakeFiles/fdbserver.dir/TestTLogServer.actor.g.cpp.o
/opt/homebrew/bin/ccache /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -DBOOST_ERROR_CODE_HEADER_ONLY -DBOOST_SYSTEM_NO_DEPRECATED -DFMT_SHARED -DNO_INTELLISENSE -D_LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION -DCOMPILATION_UNIT=/Users/sepeth/Code/foundationdb/build/fdbserver/TestTLogServer.actor.g.cpp -I/Users/sepeth/Code/foundationdb/bindings/c -I/Users/sepeth/Code/foundationdb/build/bindings/c -I/Users/sepeth/Code/foundationdb/fdbserver/include -I/Users/sepeth/Code/foundationdb/build/fdbserver/include -I/Users/sepeth/Code/foundationdb/fdbclient/include -I/Users/sepeth/Code/foundationdb/build/fdbclient/include -I/Users/sepeth/Code/foundationdb/fdbrpc/include -I/Users/sepeth/Code/foundationdb/build/fdbrpc/include -I/Users/sepeth/Code/foundationdb/flow/include -I/Users/sepeth/Code/foundationdb/build/flow/include -I/Users/sepeth/Code/foundationdb/contrib/libb64/include -I/Users/sepeth/Code/foundationdb/contrib/SimpleOpt/include -I/Users/sepeth/Code/foundationdb/contrib/crc32/include -I/Users/sepeth/Code/foundationdb/contrib/md5/include -I/Users/sepeth/Code/foundationdb/metacluster/include -I/Users/sepeth/Code/foundationdb/build/metacluster/include -I/Users/sepeth/Code/foundationdb/contrib/sqlite -I/Users/sepeth/Code/foundationdb/contrib/rapidjson -isystem /opt/homebrew/include -isystem /opt/homebrew/Cellar/openssl@3/3.3.1/include -isystem /Users/sepeth/Code/foundationdb/build/boost_install/include -isystem /Users/sepeth/Code/foundationdb/build/msgpackProject-prefix/src/msgpackProject/include -isystem /Users/sepeth/Code/foundationdb/build/toml11/include -Wl,-ld_classic -stdlib=libc++ -O3 -DNDEBUG -std=gnu++20 -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk -DCMAKE_BUILD -fno-omit-frame-pointer -gdwarf-4 -ggdb1 -gz -Wall -Wextra -Wredundant-move -Wpessimizing-move -Woverloaded-virtual -Wshift-sign-overflow -Wno-sign-compare -Wno-undefined-var-template -Wno-unknown-warning-option -Wno-unused-parameter -Wno-constant-logical-operand -Wno-deprecated-copy -Wno-delete-non-abstract-non-virtual-dtor -Wno-range-loop-construct -Wno-reorder-ctor -Wno-unused-command-line-argument -Wno-ambiguous-reversed-operator -Wno-unused-function -Wno-unused-private-field -Wno-nullability-completeness -Wno-macro-redefined -Wno-register -Wno-error=format -Wunused-variable -Wno-deprecated -fvisibility=hidden -Wreturn-type -fPIC -DHAVE_OPENSSL -MD -MT fdbserver/CMakeFiles/fdbserver.dir/TestTLogServer.actor.g.cpp.o -MF fdbserver/CMakeFiles/fdbserver.dir/TestTLogServer.actor.g.cpp.o.d -o fdbserver/CMakeFiles/fdbserver.dir/TestTLogServer.actor.g.cpp.o -c /Users/sepeth/Code/foundationdb/build/fdbserver/TestTLogServer.actor.g.cpp
/Users/sepeth/Code/foundationdb/fdbserver/TestTLogServer.actor.cpp:363:125: error: use 'template' keyword to treat 'getReply' as a dependent template name
                        StrictFuture<TLogLockResult> __when_expr_3 = pTLogTestContextEpochOne->pTLogContextList[tLogIdx]->TestTLogInterface.lock.getReply<TLogLockResult>();
                                                                                                                                                 ^
                                                                                                                                                 template
/Users/sepeth/Code/foundationdb/fdbserver/TestTLogServer.actor.cpp:363:125: error: use 'template' keyword to treat 'getReply' as a dependent template name
                        StrictFuture<TLogLockResult> __when_expr_3 = pTLogTestContextEpochOne->pTLogContextList[tLogIdx]->TestTLogInterface.lock.getReply<TLogLockResult>();
                                                                                                                                                 ^
                                                                                                                                                 template
2 errors generated.

```

Not sure why it got reported as 2 errors, but the error makes sense according to the ISO C++ 14.2/4:

> When the name of a member template specialization appears after . or -> in a postfix-expression or after a
nested-name-specifier in a qualified-id, and the object expression of the postfix-expression is type-dependent
or the nested-name-specifier in the qualified-id refers to a dependent type, but the name is not a member of
the current instantiation (14.6.2.1), the member template name must be prefixed by the keyword template.
Otherwise the name is assumed to name a non-template. Example:
>
> ```
> struct X {
>   template<std::size_t> X* alloc();
>   template<std::size_t> static X* adjust();
> };
>
> template<class T> void f(T* p) {
>   T* p1 = p->alloc<200>();           // ill-formed: < means less than
>   T* p2 = p->template alloc<200>();  // OK: < starts template argument list
>   T::adjust<100>();                  // ill-formed: < means less than
>   T::template adjust<100>();         // OK: < starts template argument list
> } ```


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
