### PR TITLE
Documentation fix: datacenter_id does not need to be hexadecimal

### DIFF
--- a/bindings/go/src/fdb/generated.go
+++ b/bindings/go/src/fdb/generated.go
@@ -357,7 +357,7 @@ func (o DatabaseOptions) SetMachineId(param string) error {
 
 // Specify the datacenter ID that was passed to fdbserver processes running in the same datacenter as this client, for better location-aware load balancing.
 //
-// Parameter: Hexadecimal ID
+// Parameter: A string identifier for the datacenter
 func (o DatabaseOptions) SetDatacenterId(param string) error {
 	return o.setOpt(22, []byte(param))
 }

--- a/fdbclient/vexillographer/fdb.options
+++ b/fdbclient/vexillographer/fdb.options
@@ -178,7 +178,7 @@ description is not currently required but encouraged.
             paramType="String" paramDescription="Hexadecimal ID"
             description="Specify the machine ID that was passed to fdbserver processes running on the same machine as this client, for better location-aware load balancing." />
     <Option name="datacenter_id" code="22"
-            paramType="String" paramDescription="Hexadecimal ID"
+            paramType="String" paramDescription="A string identifier for the datacenter"
             description="Specify the datacenter ID that was passed to fdbserver processes running in the same datacenter as this client, for better location-aware load balancing." />
     <!-- The snapshot RYW options act like defaults for the equivalent transaction options, but database defaults cannot have cumulative effects from multiple calls.
          Thus, we don't use the defaultFor annotation on these options. -->


### PR DESCRIPTION
Documentation currently mentions that the `datacenter_id` needs to be hexadecimal, however that is not the case.

# Code-Reviewer Section

- [x] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.
