### PR TITLE
lower the sample rate of client metric in simulation

### DIFF
--- a/fdbserver/workloads/ClientMetric.actor.cpp
+++ b/fdbserver/workloads/ClientMetric.actor.cpp
@@ -212,8 +212,8 @@ struct ClientMetricWorkload : TestWorkload {
 	//      vs2 should be strictly larger than vs1, to verify new latency metrics are added
 	ACTOR Future<Void> runner(Database cx, ClientMetricWorkload* self) {
 		try {
-			state int initialWrites = deterministicRandom()->randomInt(1, 5);
-			state int secondWrites = deterministicRandom()->randomInt(1, 5);
+			state int initialWrites = deterministicRandom()->randomInt(100, 200);
+			state int secondWrites = deterministicRandom()->randomInt(100, 200);
 
 			state uint64_t zeroVS = 0;
 			state uint64_t vs1 = wait(self->writeKeysAndGetLatencyVersion(cx, self, initialWrites, zeroVS));

--- a/tests/restarting/from_7.1.63_until_7.2.0/ClientMetricRestart-1.toml
+++ b/tests/restarting/from_7.1.63_until_7.2.0/ClientMetricRestart-1.toml
@@ -4,16 +4,13 @@ tenantModes = ['disabled']
 [[test]]
 testTitle='ClientMetricRestartTest'
 clearAfterTest=false
+waitForQuiescenceEnd=false
 
     [[test.workload]]
     testName='ClientMetric'
     toSet=true
-    samplingProbability=1.0
+    samplingProbability=0.01
     testDuration=500.0
-
-    [[test.workload]]
-    testName='RandomClogging'
-    testDuration=30.0
 
     [[test.workload]]
     testName='SaveAndKill'

--- a/tests/restarting/from_7.1.63_until_7.2.0/ClientMetricRestart-2.toml
+++ b/tests/restarting/from_7.1.63_until_7.2.0/ClientMetricRestart-2.toml
@@ -1,12 +1,10 @@
 [[test]]
 testTitle='ClientMetricRestartTest'
 clearAfterTest=false
+waitForQuiescenceEnd=false
+runConsistencyCheck=false
 
     [[test.workload]]
     testName='ClientMetric'
     toSet=false
-    testDuration=500.0
-
-    [[test.workload]]
-    testName='RandomClogging'
     testDuration=500.0

--- a/tests/restarting/from_7.3.49/ClientMetricRestart-1.toml
+++ b/tests/restarting/from_7.3.49/ClientMetricRestart-1.toml
@@ -4,16 +4,13 @@ tenantModes = ['disabled']
 [[test]]
 testTitle='ClientMetricRestartTest'
 clearAfterTest=false
+waitForQuiescenceEnd=false
 
     [[test.workload]]
     testName='ClientMetric'
     toSet=true
-    samplingProbability=1.0
+    samplingProbability=0.01
     testDuration=500.0
-
-    [[test.workload]]
-    testName='RandomClogging'
-    testDuration=30.0
 
     [[test.workload]]
     testName='SaveAndKill'

--- a/tests/restarting/from_7.3.49/ClientMetricRestart-2.toml
+++ b/tests/restarting/from_7.3.49/ClientMetricRestart-2.toml
@@ -1,12 +1,10 @@
 [[test]]
 testTitle='ClientMetricRestartTest'
 clearAfterTest=false
+waitForQuiescenceEnd=false
+runConsistencyCheck=false
 
     [[test.workload]]
     testName='ClientMetric'
     toSet=false
-    testDuration=500.0
-
-    [[test.workload]]
-    testName='RandomClogging'
     testDuration=500.0


### PR DESCRIPTION
This change also disable waitForQuiescenceEnd in clientmetric test. There are other transactions happening, so there will be lots of conflicts in fdbClientInfo/client_latency prefix.

This change lower the sample rate of client metric to avoid such conflicts. It also increases the keys to write correspondingly to make sure client latency are being written.

Replace this text with your description here...

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
