### PR TITLE
Cherry pick Add dynamic knob to disable gray failure recoveries. (#11509)

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -755,6 +755,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( COORDINATOR_REGISTER_INTERVAL,                         5.0 );
 	init( CLIENT_REGISTER_INTERVAL,                            600.0 );
 	init( CC_ENABLE_WORKER_HEALTH_MONITOR,                     false );
+	init( CC_PAUSE_HEALTH_MONITOR,                             false, Atomic::NO );
 	init( CC_WORKER_HEALTH_CHECKING_INTERVAL,                   60.0 );
 	init( CC_DEGRADED_LINK_EXPIRATION_INTERVAL,                300.0 );
 	init( CC_MIN_DEGRADATION_INTERVAL,                         120.0 );

--- a/fdbclient/include/fdbclient/ServerKnobs.h
+++ b/fdbclient/include/fdbclient/ServerKnobs.h
@@ -705,6 +705,7 @@ public:
 	double REPLACE_INTERFACE_CHECK_DELAY;
 	double COORDINATOR_REGISTER_INTERVAL;
 	double CLIENT_REGISTER_INTERVAL;
+	bool CC_PAUSE_HEALTH_MONITOR;
 	bool CC_ENABLE_WORKER_HEALTH_MONITOR;
 	double CC_WORKER_HEALTH_CHECKING_INTERVAL; // The interval of refreshing the degraded server list.
 	double CC_DEGRADED_LINK_EXPIRATION_INTERVAL; // The time period from the last degradation report after which a

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -2924,7 +2924,6 @@ ACTOR Future<Void> workerHealthMonitor(ClusterControllerData* self) {
 			while (!self->goodRecruitmentTime.isReady()) {
 				wait(lowPriorityDelay(SERVER_KNOBS->CC_WORKER_HEALTH_CHECKING_INTERVAL));
 			}
-
 			self->degradationInfo = self->getDegradationInfo();
 
 			// Compare `self->degradationInfo` with `self->excludedDegradedServers` and remove those that have
@@ -2958,7 +2957,9 @@ ACTOR Future<Void> workerHealthMonitor(ClusterControllerData* self) {
 
 				// Check if the cluster controller should trigger a recovery to exclude any degraded servers from
 				// the transaction system.
-				if (self->shouldTriggerRecoveryDueToDegradedServers()) {
+				if (SERVER_KNOBS->CC_PAUSE_HEALTH_MONITOR) {
+					TraceEvent(SevWarnAlways, "HealthMonitorPaused");
+				} else if (self->shouldTriggerRecoveryDueToDegradedServers()) {
 					if (SERVER_KNOBS->CC_HEALTH_TRIGGER_RECOVERY) {
 						if (self->recentRecoveryCountDueToHealth() < SERVER_KNOBS->CC_MAX_HEALTH_RECOVERY_COUNT) {
 							self->recentHealthTriggeredRecoveryTime.push(now());
@@ -3144,7 +3145,6 @@ ACTOR Future<Void> clusterControllerCore(ClusterControllerFullInterface interf,
 	                                                               self.id.toString() + "/ClusterControllerMetrics"));
 	self.addActor.send(traceRole(Role::CLUSTER_CONTROLLER, interf.id()));
 	// printf("%s: I am the cluster controller\n", g_network->getLocalAddress().toString().c_str());
-
 	if (SERVER_KNOBS->CC_ENABLE_WORKER_HEALTH_MONITOR) {
 		self.addActor.send(workerHealthMonitor(&self));
 		self.addActor.send(updateRemoteDCHealth(&self));


### PR DESCRIPTION
Add a knob to pause gray failure recoveries. While paused, the health checks will still be done and the ClusterControllerHealthMonitor messages logged. However, no action will be taken.

The knob is defined with Atomic set to false, meaning the system does not need to be rebooted when the knob is set. The dynamic knob feature does not use the transaction system. The knob is intended for use during production incidents where running a heavy duty temporal script is difficult.

To pause health monitoring, run the command below from fdbcli:
`fdb> setknob cc_pause_health_monitor true`

Joshua `20240722-163317-dlambrig-2fec58a027c97688`

Tests confirmed the fdbcli command modified the value of the knob in a running system without causing a reboot, to show gray failure stopped taking any action. A reboot was manually done to check persistency.