### PR TITLE
Fix Valgrind Issue of BulkLoading

### DIFF
--- a/fdbclient/include/fdbclient/BulkLoading.h
+++ b/fdbclient/include/fdbclient/BulkLoading.h
@@ -186,7 +186,7 @@ struct BulkLoadState {
 	}
 
 	// Updated by DD
-	BulkLoadPhase phase;
+	BulkLoadPhase phase = BulkLoadPhase::Invalid;
 	double submitTime = 0;
 	double triggerTime = 0;
 	double startTime = 0;
@@ -198,9 +198,9 @@ private:
 	UID taskId; // Unique ID of the task
 	KeyRange range; // Load the key-value within this range "[begin, end)" from data file
 	// File inject config
-	BulkLoadType loadType;
-	BulkLoadTransportMethod transportMethod;
-	BulkLoadInjectMethod injectMethod;
+	BulkLoadType loadType = BulkLoadType::Invalid;
+	BulkLoadTransportMethod transportMethod = BulkLoadTransportMethod::Invalid;
+	BulkLoadInjectMethod injectMethod = BulkLoadInjectMethod::Invalid;
 	// Folder includes all files to be injected
 	std::string folder;
 	// Files to inject

--- a/fdbserver/include/fdbserver/DataDistribution.actor.h
+++ b/fdbserver/include/fdbserver/DataDistribution.actor.h
@@ -532,7 +532,7 @@ struct TeamCollectionInterface {
 
 struct DDBulkLoadTask {
 	BulkLoadState coreState;
-	Version commitVersion;
+	Version commitVersion = invalidVersion;
 	Promise<Void> completeAck; // satisfied when a data move for this task completes for the first time, where the task
 	                           // metadata phase has been complete
 

--- a/fdbserver/include/fdbserver/RocksDBCheckpointUtils.actor.h
+++ b/fdbserver/include/fdbserver/RocksDBCheckpointUtils.actor.h
@@ -66,7 +66,7 @@ struct CheckpointFile {
 	constexpr static FileIdentifier file_identifier = 13804348;
 	std::string path;
 	KeyRange range;
-	int64_t size; // Logical bytes of the checkpoint.
+	int64_t size = 0; // Logical bytes of the checkpoint.
 
 	CheckpointFile() = default;
 	CheckpointFile(std::string path, KeyRange range, int64_t size) : path(path), range(range), size(size) {}

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -9201,8 +9201,6 @@ ACTOR Future<Void> fetchShardFetchBulkLoadSSTFiles(StorageServer* data,
 	localRecord.ranges = moveInShard->ranges();
 	RocksDBCheckpointKeyValues rcp({ bulkLoadState.getRange() });
 	for (const auto& filePath : fileSetToLoad.dataFileList) {
-		CheckpointFile cpFile;
-		cpFile.path = abspath(filePath);
 		std::vector<KeyRange> coalesceRanges = coalesceRangeList(moveInShard->ranges());
 		if (coalesceRanges.size() != 1) {
 			TraceEvent(SevError, "SSBulkLoadTaskFetchSSTFileError", data->thisServerID)
@@ -9212,8 +9210,7 @@ ACTOR Future<Void> fetchShardFetchBulkLoadSSTFiles(StorageServer* data,
 			    .detail("FileSetToLoad", fileSetToLoad.toString());
 		}
 		// TODO(BulkLoad): set loading file size --- logging purpose
-		cpFile.range = coalesceRanges[0];
-		rcp.fetchedFiles.push_back(cpFile);
+		rcp.fetchedFiles.emplace_back(abspath(filePath), coalesceRanges[0], 0);
 	}
 	localRecord.serializedCheckpoint = ObjectWriter::toValue(rcp, IncludeVersion());
 	localRecord.version = 0;


### PR DESCRIPTION
100K correctness test with 1 irrelevant failure:
  20240725-010922-zhewang-49e2a943ab51bb85           compressed=True data_size=37148235 duration=6949335 ended=100000 fail=1 fail_fast=10 max_runs=100000 pass=99999 priority=100 remaining=0 runtime=1:03:58 sanity=False started=100000 stopped=20240725-021320 submitted=20240725-010922 timeout=5400 username=zhewang
  
# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
