### PR TITLE
Add extraStorageMachineCountPerDC config to simulation

### DIFF
--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -2643,7 +2643,7 @@ void setupSimulatedSystem(std::vector<Future<Void>>* systemActors,
 			if (machine >= machines) {
 				if (extraStorageMachineCount > 0) {
 					processClass = ProcessClass(ProcessClass::ClassType::StorageClass,
-					                            ProcessClass::CommandLineSource); // Unset or Storage
+					                            ProcessClass::CommandLineSource); // Storage
 					extraStorageMachineCount--;
 					possible_ss++;
 				} else if (storageCacheMachines > 0 && dc == 0) {

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -484,7 +484,7 @@ public:
 	// Refer to FDBTypes.h::TLogVersion. Defaults to the maximum supported version.
 	int maxTLogVersion = TLogVersion::MAX_SUPPORTED;
 	int extraMachineCountDC = 0;
-	int extraStorageMachineCountDC = 0;
+	int extraStorageMachineCountPerDC = 0;
 
 	Optional<bool> generateFearless, buggify;
 	Optional<std::string> config;
@@ -569,7 +569,7 @@ public:
 		    .add("coordinators", &coordinators)
 		    .add("configDB", &configDBType)
 		    .add("extraMachineCountDC", &extraMachineCountDC)
-		    .add("extraStorageMachineCountDC", &extraStorageMachineCountDC)
+		    .add("extraStorageMachineCountPerDC", &extraStorageMachineCountPerDC)
 		    .add("blobGranulesEnabled", &blobGranulesEnabled)
 		    .add("simHTTPServerEnabled", &simHTTPServerEnabled)
 		    .add("allowDefaultTenant", &allowDefaultTenant)
@@ -2191,7 +2191,7 @@ void SimulationConfig::setMachineCount(const TestConfig& testConfig) {
 			                             5, extraDatabaseMode == ISimulator::ExtraDatabaseMode::Disabled ? 10 : 6));
 		}
 	}
-	machine_count += datacenters * (testConfig.extraMachineCountDC + testConfig.extraStorageMachineCountDC);
+	machine_count += datacenters * (testConfig.extraMachineCountDC + testConfig.extraStorageMachineCountPerDC);
 }
 
 // Sets the coordinator count based on the testConfig. May be overwritten later
@@ -2602,7 +2602,7 @@ void setupSimulatedSystem(std::vector<Future<Void>>* systemActors,
 			simHTTPMachines = deterministicRandom()->randomInt(1, 4);
 			fmt::print("sim http machines = {0}\n", simHTTPMachines);
 		}
-		int extraStorageMachineCount = testConfig.extraStorageMachineCountDC;
+		int extraStorageMachineCount = testConfig.extraStorageMachineCountPerDC;
 
 		int totalMachines =
 		    machines + storageCacheMachines + blobWorkerMachines + simHTTPMachines + extraStorageMachineCount;

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -484,6 +484,7 @@ public:
 	// Refer to FDBTypes.h::TLogVersion. Defaults to the maximum supported version.
 	int maxTLogVersion = TLogVersion::MAX_SUPPORTED;
 	int extraMachineCountDC = 0;
+	int extraStorageMachineCountDC = 0;
 
 	Optional<bool> generateFearless, buggify;
 	Optional<std::string> config;
@@ -568,6 +569,7 @@ public:
 		    .add("coordinators", &coordinators)
 		    .add("configDB", &configDBType)
 		    .add("extraMachineCountDC", &extraMachineCountDC)
+		    .add("extraStorageMachineCountDC", &extraStorageMachineCountDC)
 		    .add("blobGranulesEnabled", &blobGranulesEnabled)
 		    .add("simHTTPServerEnabled", &simHTTPServerEnabled)
 		    .add("allowDefaultTenant", &allowDefaultTenant)
@@ -2189,7 +2191,7 @@ void SimulationConfig::setMachineCount(const TestConfig& testConfig) {
 			                             5, extraDatabaseMode == ISimulator::ExtraDatabaseMode::Disabled ? 10 : 6));
 		}
 	}
-	machine_count += datacenters * testConfig.extraMachineCountDC;
+	machine_count += datacenters * (testConfig.extraMachineCountDC + testConfig.extraStorageMachineCountDC);
 }
 
 // Sets the coordinator count based on the testConfig. May be overwritten later
@@ -2600,8 +2602,10 @@ void setupSimulatedSystem(std::vector<Future<Void>>* systemActors,
 			simHTTPMachines = deterministicRandom()->randomInt(1, 4);
 			fmt::print("sim http machines = {0}\n", simHTTPMachines);
 		}
+		int extraStorageMachineCount = testConfig.extraStorageMachineCountDC;
 
-		int totalMachines = machines + storageCacheMachines + blobWorkerMachines + simHTTPMachines;
+		int totalMachines =
+		    machines + storageCacheMachines + blobWorkerMachines + simHTTPMachines + extraStorageMachineCount;
 		int useSeedForMachine = deterministicRandom()->randomInt(0, totalMachines);
 		Standalone<StringRef> zoneId;
 		Standalone<StringRef> newZoneId;
@@ -2637,7 +2641,12 @@ void setupSimulatedSystem(std::vector<Future<Void>>* systemActors,
 			int processCount = processesPerMachine;
 			ProcessMode processMode = requiresExtraDBMachines ? BackupAgentOnly : FDBDAndBackupAgent;
 			if (machine >= machines) {
-				if (storageCacheMachines > 0 && dc == 0) {
+				if (extraStorageMachineCount > 0) {
+					processClass = ProcessClass(ProcessClass::ClassType::StorageClass,
+					                            ProcessClass::CommandLineSource); // Unset or Storage
+					extraStorageMachineCount--;
+					possible_ss++;
+				} else if (storageCacheMachines > 0 && dc == 0) {
 					processClass = ProcessClass(ProcessClass::StorageCacheClass, ProcessClass::CommandLineSource);
 					storageCacheMachines--;
 				} else if (blobWorkerMachines > 0) { // add blob workers to every DC

--- a/tests/fast/BulkLoading.toml
+++ b/tests/fast/BulkLoading.toml
@@ -3,7 +3,7 @@ config = 'triple'
 storageEngineType = 5
 processesPerMachine = 2
 machineCount = 15
-extraStorageMachineCountDC = 8
+extraStorageMachineCountPerDC = 8
 tenantModes = ['disabled'] # BulkLoading test injects SST files with raw bytes. Therefore, disable tenant
 
 [[knobs]]

--- a/tests/fast/BulkLoading.toml
+++ b/tests/fast/BulkLoading.toml
@@ -2,9 +2,8 @@
 config = 'triple'
 storageEngineType = 5
 processesPerMachine = 2
-coordinators = 3
-machineCount = 40
-generateFearless = false # disable remote DC. TODO(BulkLoad): remove this after SimulatedCluster has been fixed
+machineCount = 15
+extraStorageMachineCountDC = 8
 tenantModes = ['disabled'] # BulkLoading test injects SST files with raw bytes. Therefore, disable tenant
 
 [[knobs]]
@@ -16,7 +15,6 @@ tenantModes = ['disabled'] # BulkLoading test injects SST files with raw bytes. 
 # so for this BulkLoading test, the shard RocksDB storage engine is always turned on.
 shard_encode_location_metadata = true
 dd_physical_shard_move_probability = 1.0
-desired_teams_per_server = 10
 
 [[test]]
 testTitle = 'BulkLoadingWorkload'


### PR DESCRIPTION
When bulk loading selects destination team to inject a range, it always select teams that do not own the range. As a result, it is hard to select an available team when the available machine count per DC is small. The bulk loading test simulation can get stuck when HA mode is one since each DC only has 4 storage machine in the worst case. Previously, we worked around by disabling remote DC (disabling HA) in the bulk loading test. Now, by enforcing extra storage machines to each DC, bulk loading can easily find available team when HA is on.

In this PR, we add `extraStorageMachineCountPerDC` config to simulation. We enable HA in bulk loading test.

100K correctness tests:
20240725-233033-zhewang-d4de5e544b98a7d6           compressed=True data_size=37148289 duration=6329756 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:54:45 sanity=False started=100000 stopped=20240726-002518 submitted=20240725-233033 timeout=5400 username=zhewang
  
100K bulk loading tests for 1 external timeout with rocksdb and 8 traced_too_many_lines error:
20240725-210045-zhewang-d8b4639cca9a210e           compressed=True data_size=37182478 duration=31531021 ended=100000 fail=9 fail_fast=10 max_runs=100000 pass=99991 priority=100 remaining=0 runtime=2:29:03 sanity=False started=100000 stopped=20240725-232948 submitted=20240725-210045 timeout=5400 username=zhewang
  
In all simulations of the 8 traced_too_many_lines error, the `MachineTeamInfo` traced too many times. This is because MachineTeamInfo is intensively generated by printSnapshotTeamsInfo() when the leftover machine bytes is too small. The root cause has two aspects: (1) in the simulation, the disk leftover bytes is randomly selected. It is possible that the random bytes is initialized below `TARGET_AVAILABLE_SPACE_RATIO`; (2) the bulk load getTeam method does not avoid selecting machines with small available disk. We will create a separate PR to fix this issue.
  
# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
