### PR TITLE
Use actual versions in tlog tests

### DIFF
--- a/fdbserver/include/fdbserver/TestTLogServer.actor.h
+++ b/fdbserver/include/fdbserver/TestTLogServer.actor.h
@@ -44,6 +44,7 @@ struct TestTLogOptions {
 	std::string kvStoreFilename;
 	std::string dataFolder;
 	std::string kvStoreExtension;
+	std::vector<Version> versions;
 	int64_t kvMemoryLimit;
 	int numTagsPerServer;
 	int numLogServers;


### PR DESCRIPTION
The TLog test should better simulate actual versions.

`20240725-231728-dlambrig-6db4a7c650dbb1d6 `
