### PR TITLE
Fix TraceTooManyLines in BulkLoading Simulation Test

### DIFF
--- a/fdbserver/DDTeamCollection.actor.cpp
+++ b/fdbserver/DDTeamCollection.actor.cpp
@@ -239,7 +239,9 @@ public:
 					unhealthyTeamCount++;
 					continue;
 				}
-				if (dest->getEligibilityCount(data_distribution::EligibilityCounter::LOW_DISK_UTIL) <= 0) {
+				bool allDestServerHaveLowDiskUtil =
+				    dest->getEligibilityCount(data_distribution::EligibilityCounter::LOW_DISK_UTIL) > 0;
+				if (!allDestServerHaveLowDiskUtil) {
 					notEligibileTeamCount++;
 					continue;
 				}

--- a/fdbserver/DDTeamCollection.actor.cpp
+++ b/fdbserver/DDTeamCollection.actor.cpp
@@ -232,10 +232,15 @@ public:
 
 			std::vector<Reference<TCTeamInfo>> candidateTeams;
 			int unhealthyTeamCount = 0;
+			int notEligibileTeamCount = 0;
 			int duplicatedCount = 0;
 			for (const auto& dest : self->teams) {
 				if (!dest->isHealthy()) {
 					unhealthyTeamCount++;
+					continue;
+				}
+				if (dest->getEligibilityCount(data_distribution::EligibilityCounter::LOW_DISK_UTIL) <= 0) {
+					notEligibileTeamCount++;
 					continue;
 				}
 				bool ok = true;
@@ -268,6 +273,7 @@ public:
 				    .detail("CandidateSize", candidateTeams.size())
 				    .detail("UnhealthyTeamCount", unhealthyTeamCount)
 				    .detail("DuplicatedCount", duplicatedCount)
+				    .detail("NotEligibileTeamCount", notEligibileTeamCount)
 				    .detail("DestIds", describe(res.get()->getServerIDs()))
 				    .detail("DestTeam", res.get()->getTeamID());
 			} else {
@@ -278,7 +284,8 @@ public:
 				    .detail("TeamSize", self->teams.size())
 				    .detail("CandidateSize", candidateTeams.size())
 				    .detail("UnhealthyTeamCount", unhealthyTeamCount)
-				    .detail("DuplicatedCount", duplicatedCount);
+				    .detail("DuplicatedCount", duplicatedCount)
+				    .detail("NotEligibileTeamCount", notEligibileTeamCount);
 			}
 			req.reply.send(std::make_pair(res, false));
 			return Void();
@@ -3672,7 +3679,7 @@ public:
 
 			for (i = 0; i < machineTeams.size(); i++) {
 				const auto& team = machineTeams[i];
-				TraceEvent("MachineTeamInfo", self->getDistributorId())
+				TraceEvent(g_network->isSimulated() ? SevVerbose : SevInfo, "MachineTeamInfo", self->getDistributorId())
 				    .detail("TeamIndex", i)
 				    .detail("MachineIDs", team->getMachineIDsStr())
 				    .detail("ServerTeams", team->getServerTeams().size())

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -12265,7 +12265,7 @@ ACTOR Future<Void> updateStorage(StorageServer* data) {
 		}
 
 		// Handle MoveInShard::MoveInUpdates.
-		TraceEvent(SevDebug, "MoveInUpdatesPrePersist", data->thisServerID)
+		TraceEvent(g_network->isSimulated() ? SevVerbose : SevInfo, "MoveInUpdatesPrePersist", data->thisServerID)
 		    .detail("NewOldestVersion", newOldestVersion)
 		    .detail("StartOldestVersion", startOldestVersion);
 		for (const auto& [_, moveInShard] : data->moveInShards) {

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -12265,7 +12265,7 @@ ACTOR Future<Void> updateStorage(StorageServer* data) {
 		}
 
 		// Handle MoveInShard::MoveInUpdates.
-		TraceEvent(g_network->isSimulated() ? SevVerbose : SevInfo, "MoveInUpdatesPrePersist", data->thisServerID)
+		TraceEvent(SevVerbose, "MoveInUpdatesPrePersist", data->thisServerID)
 		    .detail("NewOldestVersion", newOldestVersion)
 		    .detail("StartOldestVersion", startOldestVersion);
 		for (const auto& [_, moveInShard] : data->moveInShards) {

--- a/fdbserver/worker.actor.cpp
+++ b/fdbserver/worker.actor.cpp
@@ -1178,6 +1178,7 @@ UpdateWorkerHealthRequest doPeerHealthCheck(const WorkerInterface& interf,
 		double lastLoggedTime = peer->lastLoggedTime <= 0.0 ? peer->lastConnectTime : peer->lastLoggedTime;
 
 		TraceEvent(SevDebug, "PeerHealthMonitor")
+		    .suppressFor(5.0)
 		    .detail("Peer", address)
 		    .detail("PeerAddress", address)
 		    .detail("Force", enablePrimaryTxnSystemHealthCheck->get())


### PR DESCRIPTION
During simulation tests, mute `MachineTeamInfo` and `MoveInUpdatesPrePersist` and `PeerHealthMonitor`, as they account for 20% ~ 50% of the total trace events when TraceTooManyLines occurs.

Avoid selecting destination team with high disk util to bulkload the data. If we select dest team to do bulkloading without considering the leftover machine bytes, it can result in MachineTeamInfo is intensively generated by printSnapshotTeamsInfo() when the leftover machine bytes is too small.

100K correctness test:
  20240726-220113-zhewang-9ab0a468cd9a92ab           compressed=True data_size=37147684 duration=5159112 ended=100000 fail=2 fail_fast=10 max_runs=100000 pass=99998 priority=100 remaining=0 runtime=1:12:23 sanity=False started=100000 stopped=20240726-231336 submitted=20240726-220113 timeout=5400 username=zhewang

There is a failure in the upgrade test, where SS decodes an unexpected dataMoveType. This will be fixed in a separate PR.
          
100K BulkLoading tests:
  20240726-220138-zhewang-3bddf42642cf7d73           compressed=True data_size=37181509 duration=31033266 ended=100000 fail=4 fail_fast=10 max_runs=100000 pass=99996 priority=100 remaining=0 runtime=2:32:22 sanity=False started=100000 stopped=20240727-003400 submitted=20240726-220138 timeout=5400 username=zhewang
  
There is two failures: (1) bulkLoading workload gets stuck since getTeamForBulkLoad keeps failing since it considers the disk remaining bytes; (2) bulkLoading workload gets stuck since `acknowledgeBulkLoadTask` keeps failing since it cannot find the task metadata to erase which has been erased. These will be fixed in two separate PRs.
      
# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
