### PR TITLE
Encode DoBulkLoading option in DataMoveId

### DIFF
--- a/fdbcli/LocationMetadataCommand.actor.cpp
+++ b/fdbcli/LocationMetadataCommand.actor.cpp
@@ -182,9 +182,15 @@ ACTOR Future<Void> printServerShards(Database cx, UID serverId) {
 					UID shardId;
 					bool assigned, emptyRange;
 					DataMoveType dataMoveType = DataMoveType::LOGICAL;
+					DoBulkLoading doBulkLoading(false);
 					DataMovementReason dataMoveReason = DataMovementReason::INVALID;
-					decodeServerKeysValue(
-					    serverShards[i].value, assigned, emptyRange, dataMoveType, shardId, dataMoveReason);
+					decodeServerKeysValue(serverShards[i].value,
+					                      assigned,
+					                      emptyRange,
+					                      dataMoveType,
+					                      doBulkLoading,
+					                      shardId,
+					                      dataMoveReason);
 					printf("Range: %s, ShardID: %s, Assigned: %s\n",
 					       Traceable<KeyRangeRef>::toString(currentRange).c_str(),
 					       shardId.toString().c_str(),

--- a/fdbclient/include/fdbclient/SystemData.h
+++ b/fdbclient/include/fdbclient/SystemData.h
@@ -38,14 +38,13 @@
 FDB_BOOLEAN_PARAM(AssignEmptyRange);
 FDB_BOOLEAN_PARAM(UnassignShard);
 FDB_BOOLEAN_PARAM(EnablePhysicalShardMove);
+FDB_BOOLEAN_PARAM(DoBulkLoading);
 
 enum class DataMoveType : uint8_t {
 	LOGICAL = 0,
 	PHYSICAL = 1,
 	PHYSICAL_EXP = 2,
-	LOGICAL_BULKLOAD = 3,
-	PHYSICAL_BULKLOAD = 4,
-	NUMBER_OF_TYPES = 5,
+	NUMBER_OF_TYPES = 3,
 };
 
 // One-to-one relationship to the priority knobs
@@ -206,6 +205,7 @@ extern const ValueRef serverKeysTrue, serverKeysTrueEmptyRange, serverKeysFalse;
 const UID newDataMoveId(const uint64_t physicalShardId,
                         AssignEmptyRange assignEmptyRange,
                         const DataMoveType type,
+                        DoBulkLoading doBulkLoading,
                         const DataMovementReason reason,
                         UnassignShard unassignShard = UnassignShard::False);
 const Key serverKeysKey(UID serverID, const KeyRef& keys);
@@ -218,11 +218,13 @@ void decodeDataMoveId(const UID& id,
                       bool& assigned,
                       bool& emptyRange,
                       DataMoveType& dataMoveType,
+                      DoBulkLoading& doBulkLoading,
                       DataMovementReason& dataMoveReason);
 void decodeServerKeysValue(const ValueRef& value,
                            bool& assigned,
                            bool& emptyRange,
                            DataMoveType& dataMoveType,
+                           DoBulkLoading& doBulkLoading,
                            UID& id,
                            DataMovementReason& dataMoveReason);
 

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -10814,8 +10814,10 @@ private:
 			// keys
 			startKey = m.param1;
 			DataMoveType dataMoveType = DataMoveType::LOGICAL;
+			DoBulkLoading doBulkLoading(false);
 			dataMoveReason = DataMovementReason::INVALID;
-			decodeServerKeysValue(m.param2, nowAssigned, emptyRange, dataMoveType, dataMoveId, dataMoveReason);
+			decodeServerKeysValue(
+			    m.param2, nowAssigned, emptyRange, dataMoveType, doBulkLoading, dataMoveId, dataMoveReason);
 			if (dataMoveType != DataMoveType::LOGICAL &&
 			    data->storage.getKeyValueStoreType() != KeyValueStoreType::SSD_SHARDED_ROCKSDB) {
 				TraceEvent(SevWarnAlways, "KVStoreNotSupportDataMoveType", data->thisServerID)
@@ -10825,10 +10827,8 @@ private:
 				dataMoveType = DataMoveType::LOGICAL;
 			}
 			enablePSM = EnablePhysicalShardMove(dataMoveType == DataMoveType::PHYSICAL ||
-			                                    (dataMoveType == DataMoveType::PHYSICAL_EXP && data->isTss()) ||
-			                                    dataMoveType == DataMoveType::PHYSICAL_BULKLOAD);
-			conductBulkLoad =
-			    dataMoveType == DataMoveType::LOGICAL_BULKLOAD || dataMoveType == DataMoveType::PHYSICAL_BULKLOAD;
+			                                    (dataMoveType == DataMoveType::PHYSICAL_EXP && data->isTss()));
+			conductBulkLoad = (doBulkLoading == DoBulkLoading::True);
 			// TODO(BulkLoad): remove after logical move based bulk loading has been implmented
 			ASSERT(enablePSM || !conductBulkLoad);
 			processedStartKey = true;

--- a/fdbserver/workloads/DataLossRecovery.actor.cpp
+++ b/fdbserver/workloads/DataLossRecovery.actor.cpp
@@ -23,6 +23,7 @@
 #include "fdbclient/FDBOptions.g.h"
 #include "fdbclient/NativeAPI.actor.h"
 #include "fdbclient/ManagementAPI.actor.h"
+#include "fdbclient/SystemData.h"
 #include "fdbserver/MoveKeys.actor.h"
 #include "fdbserver/QuietDatabase.h"
 #include "fdbserver/Knobs.h"
@@ -237,6 +238,7 @@ struct DataLossRecoveryWorkload : TestWorkload {
 					UID dataMoveId = newDataMoveId(deterministicRandom()->randomUInt64(),
 					                               AssignEmptyRange(false),
 					                               DataMoveType::PHYSICAL,
+					                               DoBulkLoading(false),
 					                               DataMovementReason::TEAM_HEALTHY,
 					                               UnassignShard(false));
 					params = std::make_unique<MoveKeysParams>(dataMoveId,
@@ -256,6 +258,7 @@ struct DataLossRecoveryWorkload : TestWorkload {
 					UID dataMoveId = newDataMoveId(deterministicRandom()->randomUInt64(),
 					                               AssignEmptyRange(false),
 					                               DataMoveType::LOGICAL,
+					                               DoBulkLoading(false),
 					                               DataMovementReason::TEAM_HEALTHY,
 					                               UnassignShard(false));
 					params = std::make_unique<MoveKeysParams>(dataMoveId,

--- a/fdbserver/workloads/IDDTxnProcessorApiCorrectness.actor.cpp
+++ b/fdbserver/workloads/IDDTxnProcessorApiCorrectness.actor.cpp
@@ -353,6 +353,7 @@ struct IDDTxnProcessorApiWorkload : TestWorkload {
 		const UID dataMoveId = newDataMoveId(deterministicRandom()->randomUInt64(),
 		                                     AssignEmptyRange(false),
 		                                     DataMoveType::LOGICAL,
+		                                     DoBulkLoading(false),
 		                                     DataMovementReason::INVALID,
 		                                     UnassignShard(false));
 		if (SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA) {

--- a/fdbserver/workloads/PhysicalShardMove.actor.cpp
+++ b/fdbserver/workloads/PhysicalShardMove.actor.cpp
@@ -104,6 +104,7 @@ struct PhysicalShardMoveWorkLoad : TestWorkload {
 		                           newDataMoveId(deterministicRandom()->randomUInt64(),
 		                                         AssignEmptyRange::False,
 		                                         DataMoveType::PHYSICAL,
+		                                         DoBulkLoading::False,
 		                                         dataMoveReason),
 		                           currentRange,
 		                           teamSize,
@@ -120,13 +121,15 @@ struct PhysicalShardMoveWorkLoad : TestWorkload {
 		// Move range [TestKeyA, TestKeyB) to sh0.
 		currentRange = KeyRangeRef("TestKeyA"_sr, "TestKeyB"_sr);
 		wait(store(teamA,
-		           self->moveShard(self,
-		                           cx,
-		                           newDataMoveId(sh0, AssignEmptyRange::False, DataMoveType::PHYSICAL, dataMoveReason),
-		                           currentRange,
-		                           teamSize,
-		                           includes,
-		                           excludes)));
+		           self->moveShard(
+		               self,
+		               cx,
+		               newDataMoveId(
+		                   sh0, AssignEmptyRange::False, DataMoveType::PHYSICAL, DoBulkLoading::False, dataMoveReason),
+		               currentRange,
+		               teamSize,
+		               includes,
+		               excludes)));
 		TraceEvent(SevDebug, "TestMovedRange2").detail("Range", currentRange).detail("Team", describe(teamA));
 
 		state std::vector<KeyRange> checkpointRanges;
@@ -137,14 +140,14 @@ struct PhysicalShardMoveWorkLoad : TestWorkload {
 		// Move range [TestKeyD, TestKeyF) to sh0;
 		includes.insert(teamA.begin(), teamA.end());
 		currentRange = KeyRangeRef("TestKeyD"_sr, "TestKeyF"_sr);
-		state std::vector<UID> teamE =
-		    wait(self->moveShard(self,
-		                         cx,
-		                         newDataMoveId(sh0, AssignEmptyRange::False, DataMoveType::PHYSICAL, dataMoveReason),
-		                         currentRange,
-		                         teamSize,
-		                         includes,
-		                         excludes));
+		state std::vector<UID> teamE = wait(self->moveShard(
+		    self,
+		    cx,
+		    newDataMoveId(sh0, AssignEmptyRange::False, DataMoveType::PHYSICAL, DoBulkLoading::False, dataMoveReason),
+		    currentRange,
+		    teamSize,
+		    includes,
+		    excludes));
 		TraceEvent(SevDebug, "TestMovedRange3").detail("Range", currentRange).detail("Team", describe(teamE));
 		ASSERT(std::equal(teamA.begin(), teamA.end(), teamE.begin()));
 
@@ -169,14 +172,14 @@ struct PhysicalShardMoveWorkLoad : TestWorkload {
 		// Move range [TestKeyB, TestKeyC) to sh1, on the same server.
 		currentRange = KeyRangeRef("TestKeyB"_sr, "TestKeyC"_sr);
 		includes.insert(teamA.begin(), teamA.end());
-		state std::vector<UID> teamB =
-		    wait(self->moveShard(self,
-		                         cx,
-		                         newDataMoveId(sh1, AssignEmptyRange::False, DataMoveType::PHYSICAL, dataMoveReason),
-		                         currentRange,
-		                         teamSize,
-		                         includes,
-		                         excludes));
+		state std::vector<UID> teamB = wait(self->moveShard(
+		    self,
+		    cx,
+		    newDataMoveId(sh1, AssignEmptyRange::False, DataMoveType::PHYSICAL, DoBulkLoading::False, dataMoveReason),
+		    currentRange,
+		    teamSize,
+		    includes,
+		    excludes));
 		TraceEvent(SevDebug, "TestMovedRange4").detail("Range", currentRange).detail("Team", describe(teamB));
 		ASSERT(std::equal(teamA.begin(), teamA.end(), teamB.begin()));
 
@@ -200,14 +203,14 @@ struct PhysicalShardMoveWorkLoad : TestWorkload {
 		TraceEvent(SevDebug, "TestCheckpointRestored3");
 
 		currentRange = KeyRangeRef("TestKeyB"_sr, "TestKeyC"_sr);
-		state std::vector<UID> teamC =
-		    wait(self->moveShard(self,
-		                         cx,
-		                         newDataMoveId(sh2, AssignEmptyRange::False, DataMoveType::PHYSICAL, dataMoveReason),
-		                         currentRange,
-		                         teamSize,
-		                         includes,
-		                         excludes));
+		state std::vector<UID> teamC = wait(self->moveShard(
+		    self,
+		    cx,
+		    newDataMoveId(sh2, AssignEmptyRange::False, DataMoveType::PHYSICAL, DoBulkLoading::False, dataMoveReason),
+		    currentRange,
+		    teamSize,
+		    includes,
+		    excludes));
 		TraceEvent(SevDebug, "TestMovedRange5").detail("Range", currentRange).detail("Team", describe(teamC));
 		ASSERT(std::equal(teamA.begin(), teamA.end(), teamC.begin()));
 

--- a/fdbserver/workloads/RandomMoveKeys.actor.cpp
+++ b/fdbserver/workloads/RandomMoveKeys.actor.cpp
@@ -161,6 +161,7 @@ struct MoveKeysWorkload : FailureInjectionWorkload {
 				UID dataMoveId = newDataMoveId(deterministicRandom()->randomUInt64(),
 				                               AssignEmptyRange(false),
 				                               DataMoveType::PHYSICAL,
+				                               DoBulkLoading::False,
 				                               DataMovementReason::TEAM_HEALTHY,
 				                               UnassignShard(false));
 				params = std::make_unique<MoveKeysParams>(dataMoveId,
@@ -180,6 +181,7 @@ struct MoveKeysWorkload : FailureInjectionWorkload {
 				UID dataMoveId = newDataMoveId(deterministicRandom()->randomUInt64(),
 				                               AssignEmptyRange(false),
 				                               DataMoveType::LOGICAL,
+				                               DoBulkLoading(false),
 				                               DataMovementReason::TEAM_HEALTHY,
 				                               UnassignShard(false));
 				params = std::make_unique<MoveKeysParams>(dataMoveId,

--- a/fdbserver/workloads/StorageServerCheckpointRestoreTest.actor.cpp
+++ b/fdbserver/workloads/StorageServerCheckpointRestoreTest.actor.cpp
@@ -89,6 +89,7 @@ struct SSCheckpointRestoreWorkload : TestWorkload {
 		state UID dataMoveId = newDataMoveId(deterministicRandom()->randomUInt64(),
 		                                     AssignEmptyRange(false),
 		                                     DataMoveType::PHYSICAL,
+		                                     DoBulkLoading(false),
 		                                     DataMovementReason::TEAM_HEALTHY,
 		                                     UnassignShard(false));
 		loop {


### PR DESCRIPTION
When a data move is a bulkLoad data move, we want to notify the storage server to conductBulkLoad that injecting data files. To encode this option to dataMoveId. Now, the lower [16, 20) bits in the dataMoveId indicating whether to conduct bulkLoading. 

TODO: storage server should tolerate any compatibility issue since release-7.3 which does not encode DoBulkLoading option to  DataMoveId. (Fallback to normal data move).

100K correctness test:
  20240727-011944-zhewang-8692e623a76636d1           compressed=True data_size=37149797 fail_fast=10 max_runs=100000 priority=100 sanity=False submitted=20240727-011944 timeout=5400 username=zhewang

100K BulkLoading test:
  20240727-012159-zhewang-25af1c1a6b26fc1a           compressed=True data_size=37182817 fail_fast=10 max_runs=100000 priority=100 sanity=False submitted=20240727-012159 timeout=5400 username=zhewang

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
