### PR TITLE
Fix Compatibility Issue of DataMoveId with BulkLoad type

### DIFF
--- a/fdbserver/DDRelocationQueue.actor.cpp
+++ b/fdbserver/DDRelocationQueue.actor.cpp
@@ -116,14 +116,6 @@ std::pair<const DmReasonPriorityMapping*, const PriorityDmReasonMapping*> buildP
 	return std::make_pair(&reasonPriority, &priorityReason);
 }
 
-DataMoveType getDataMoveType(const UID& dataMoveId) {
-	bool assigned, emptyRange;
-	DataMoveType dataMoveType;
-	DataMovementReason dataMoveReason;
-	decodeDataMoveId(dataMoveId, assigned, emptyRange, dataMoveType, dataMoveReason);
-	return dataMoveType;
-}
-
 // Return negative priority for invalid or dummy reasons
 int dataMovementPriority(DataMovementReason reason) {
 	auto [reasonPriority, _] = buildPriorityMappings();
@@ -2112,7 +2104,7 @@ ACTOR Future<Void> dataDistributionRelocator(DDQueue* self,
 					    .detail("Reason", rd.reason.toString())
 					    .detail("DataMoveReason", static_cast<int>(rd.dmReason))
 					    .detail("DataMoveID", rd.dataMoveId)
-					    .detail("DataMoveType", getDataMoveType(rd.dataMoveId));
+					    .detail("DataMoveType", getDataMoveTypeFromDataMoveId(rd.dataMoveId));
 					if (now() - startTime > 600) {
 						TraceEvent(SevWarnAlways, "RelocateShardTooLong")
 						    .detail("Duration", now() - startTime)

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -822,7 +822,9 @@ public:
 				rs.dataMoveId = meta.id;
 				rs.cancelled = true;
 				self->relocationProducer.send(rs); // Cancal data move
-				TraceEvent("DDInitScheduledCancelDataMove", self->ddId).detail("DataMove", meta.toString());
+				TraceEvent("DDInitScheduledCancelDataMoveForWrongType", self->ddId)
+				    .detail("DataMove", meta.toString())
+				    .detail("DataMoveType", dataMoveType);
 			} else if (it.value()->isCancelled() ||
 			           (it.value()->valid && !SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA)) {
 				RelocateShard rs(meta.ranges.front(), DataMovementReason::RECOVER_MOVE, RelocateReason::OTHER);

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -57,6 +57,14 @@
 #include "flow/serialize.h"
 #include "flow/actorcompiler.h" // This must be the last #include.
 
+DataMoveType getDataMoveTypeFromDataMoveId(const UID& dataMoveId) {
+	bool assigned, emptyRange;
+	DataMoveType dataMoveType;
+	DataMovementReason dataMoveReason;
+	decodeDataMoveId(dataMoveId, assigned, emptyRange, dataMoveType, dataMoveReason);
+	return dataMoveType;
+}
+
 void RelocateShard::setParentRange(KeyRange const& parent) {
 	ASSERT(reason == RelocateReason::WRITE_SPLIT || reason == RelocateReason::SIZE_SPLIT);
 	parent_range = parent;
@@ -794,6 +802,7 @@ public:
 
 		for (; it != self->initData->dataMoveMap.ranges().end(); ++it) {
 			const DataMoveMetaData& meta = it.value()->meta;
+			DataMoveType dataMoveType = getDataMoveTypeFromDataMoveId(meta.id);
 			if (meta.ranges.empty()) {
 				TraceEvent(SevInfo, "EmptyDataMoveRange", self->ddId).detail("DataMoveMetaData", meta.toString());
 				continue;
@@ -806,6 +815,14 @@ public:
 				// Cancel data move for old bulk loading
 				// Do not assign bulk load to rs so that this is a normal data move cancellation signal
 				TraceEvent("DDInitScheduledCancelOldBulkLoadDataMove", self->ddId).detail("DataMove", meta.toString());
+			} else if (dataMoveType == DataMoveType::LOGICAL_BULKLOAD ||
+			           dataMoveType == DataMoveType::PHYSICAL_BULKLOAD) {
+				// The metadata is from the old system
+				RelocateShard rs(meta.ranges.front(), DataMovementReason::RECOVER_MOVE, RelocateReason::OTHER);
+				rs.dataMoveId = meta.id;
+				rs.cancelled = true;
+				self->relocationProducer.send(rs); // Cancal data move
+				TraceEvent("DDInitScheduledCancelDataMove", self->ddId).detail("DataMove", meta.toString());
 			} else if (it.value()->isCancelled() ||
 			           (it.value()->valid && !SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA)) {
 				RelocateShard rs(meta.ranges.front(), DataMovementReason::RECOVER_MOVE, RelocateReason::OTHER);

--- a/fdbserver/include/fdbserver/DataDistribution.actor.h
+++ b/fdbserver/include/fdbserver/DataDistribution.actor.h
@@ -98,6 +98,8 @@ private:
 extern int dataMovementPriority(DataMovementReason moveReason);
 extern DataMovementReason priorityToDataMovementReason(int priority);
 
+DataMoveType getDataMoveTypeFromDataMoveId(const UID& dataMoveId);
+
 struct DDShardInfo;
 
 // Represents a data move in DD.


### PR DESCRIPTION
In early minor versions of release-7.3, DD does not encode DataMoveType in DataMoveID when persisting DataMoveID to the system metadata. Thus, when upgrading to the current version from the old system, DD can load a data move metadata but decoding the metadata in a wrong way. In particular, the data move type can be decoded as a bulkLoading type while no bulkLoadState is in the data move metadata. In this case, SS DD cancels such data move to keep the correctness.

100K correctness tests:
  20240727-061611-zhewang-06d38ad830126b01           compressed=True data_size=37149430 duration=7053009 ended=100000 fail=1 fail_fast=10 max_runs=100000 pass=99999 priority=100 remaining=0 runtime=0:58:01 sanity=False started=100000 stopped=20240727-071412 submitted=20240727-061611 timeout=5400 username=zhewang
        
100K bulkloading test:
20240727-021632-zhewang-e09deaf1797db8fc           compressed=True data_size=37183722 duration=30699272 ended=100000 fail=3 fail_fast=10 max_runs=100000 pass=99997 priority=100 remaining=0 runtime=2:19:40 sanity=False started=100000 stopped=20240727-043612 submitted=20240727-021632 timeout=5400 username=zhewang
  
In BulkLoading test, the 3 failures are because the DD is hard to find a team which has available remaining disk bytes, therefore, blocking the bulk loading.
  
# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
