### PR TITLE
Fix acknowledgeBulkLoadTask stuck

### DIFF
--- a/fdbserver/workloads/BulkLoading.actor.cpp
+++ b/fdbserver/workloads/BulkLoading.actor.cpp
@@ -73,14 +73,14 @@ struct BulkLoading : TestWorkload {
 					TraceEvent("BulkLoadingSubmitBulkLoadTask")
 					    .setMaxEventLength(-1)
 					    .setMaxFieldLength(-1)
-					    .detail("BulkLoadStates", describe(tasks));
+					    .detail("BulkLoadState", tasks[i].toString());
 					break;
 				} catch (Error& e) {
 					TraceEvent("BulkLoadingSubmitBulkLoadTaskError")
 					    .setMaxEventLength(-1)
 					    .setMaxFieldLength(-1)
 					    .errorUnsuppressed(e)
-					    .detail("BulkLoadStates", describe(tasks));
+					    .detail("BulkLoadState", tasks[i].toString());
 					wait(delay(0.1));
 				}
 			}
@@ -97,14 +97,17 @@ struct BulkLoading : TestWorkload {
 					TraceEvent("BulkLoadingAcknowledgeBulkLoadTask")
 					    .setMaxEventLength(-1)
 					    .setMaxFieldLength(-1)
-					    .detail("BulkLoadStates", describe(tasks[i]));
+					    .detail("BulkLoadState", tasks[i].toString());
 					break;
 				} catch (Error& e) {
 					TraceEvent("BulkLoadingAcknowledgeBulkLoadTaskError")
 					    .setMaxEventLength(-1)
 					    .setMaxFieldLength(-1)
 					    .errorUnsuppressed(e)
-					    .detail("BulkLoadStates", describe(tasks));
+					    .detail("BulkLoadState", tasks[i].toString());
+					if (e.code() == error_code_bulkload_task_outdated) {
+						break; // has been erased or overwritten by other tasks
+					}
 					wait(delay(0.1));
 				}
 			}


### PR DESCRIPTION
When a complete task's metadata has been erased, acknowledgeBulkLoadTask should not retry, since this task has been acknowledged.

100K bulkLoad tests with 1 failure which is getTeamForBulkLoad stuck:
  20240729-170524-zhewang-94893831862647e8           compressed=True data_size=37184050 duration=30443390 ended=100000 fail=1 fail_fast=10 max_runs=100000 pass=99999 priority=100 remaining=0 runtime=3:50:49 sanity=False started=100000 stopped=20240729-205613 submitted=20240729-170524 timeout=5400 username=zhewang
  
100K correctness test with 3 irrelevant failures:
  20240729-173441-zhewang-17db2fe2631bfdfe           compressed=True data_size=37151002 duration=6648073 ended=100000 fail=3 fail_fast=10 max_runs=100000 pass=99997 priority=100 remaining=0 runtime=0:56:30 sanity=False started=100000 stopped=20240729-183111 submitted=20240729-173441 timeout=5400 username=zhewang

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
