### PR TITLE
Fix DD stuck due to too many rounds of FetchShardApplyingUpdates

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -1062,7 +1062,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( SPLIT_METRICS_MAX_ROWS,                              10000 ); if( randomize && BUGGIFY ) SPLIT_METRICS_MAX_ROWS = 10;
 	init( PHYSICAL_SHARD_MOVE_LOG_SEVERITY,                        1 );
 	init( FETCH_SHARD_BUFFER_BYTE_LIMIT,                        20e6 ); if( randomize && BUGGIFY ) FETCH_SHARD_BUFFER_BYTE_LIMIT = 1;
-	init( FETCH_SHARD_UPDATES_BYTE_LIMIT,                    2500000 ); if( randomize && BUGGIFY ) FETCH_SHARD_UPDATES_BYTE_LIMIT = 1;
+	init( FETCH_SHARD_UPDATES_BYTE_LIMIT,                    2500000 ); if( randomize && BUGGIFY ) FETCH_SHARD_UPDATES_BYTE_LIMIT = 100;
 
 	//Wait Failure
 	init( MAX_OUTSTANDING_WAIT_FAILURE_REQUESTS,                 250 ); if( randomize && BUGGIFY ) MAX_OUTSTANDING_WAIT_FAILURE_REQUESTS = 2;


### PR DESCRIPTION
When dest SS applying mutations accumulated for data moves, the fetchShard partitions the mutations into batches to apply. Each batch size is at most `fetch_shard_updates_byte_limit`. When `fetch_shard_updates_byte_limit` is set to 1, there can be tons of rounds of applying mutations when the number of mutations accumulated during the data move is large. As a result, a data move takes super long time to complete the data move, which triggers DDGotStuck.

100K correctness tests with 1 failure:
  20240730-002044-zhewang-3c99c31d6adfe116           compressed=True data_size=37152805 duration=7193275 ended=100000 fail=1 fail_fast=10 max_runs=100000 pass=99999 priority=100 remaining=0 runtime=1:01:49 sanity=False started=100000 stopped=20240730-012233 submitted=20240730-002044 timeout=5400 username=zhewang
  
The failure happens in a restarting test. In the first test, `usable_region=1`. In the second test, `usable_region=2`. The recovery of setting usable_region completes. However, the data move gets stuck. The data move is a restored data move and handled by `encode_shard_location_metadata`. This data move is failed to get the dest servers which are set in the first test, therefore the data move is cancelled. No following data moves on the range is triggered. As a result, the number of source servers of a shard keeps not matching the number of usable_region.
  
# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
