### PR TITLE
Fix ApplyMutationsError test failure due to hot shard throttling

### DIFF
--- a/fdbclient/BackupAgentBase.actor.cpp
+++ b/fdbclient/BackupAgentBase.actor.cpp
@@ -1016,8 +1016,11 @@ ACTOR Future<Void> applyMutations(Database cx,
 			}
 		}
 	} catch (Error& e) {
-		TraceEvent(e.code() == error_code_restore_missing_data ? SevWarnAlways : SevError, "ApplyMutationsError")
-		    .error(e);
+		Severity sev =
+		    (e.code() == error_code_restore_missing_data || e.code() == error_code_transaction_throttled_hot_shard)
+		        ? SevWarnAlways
+		        : SevError;
+		TraceEvent(sev, "ApplyMutationsError").error(e);
 		throw;
 	}
 }


### PR DESCRIPTION
In the restore test, there are hot ranges with writes to customized range with prefix "BeforeRestart" or "AfterRestart". As a result, FDB can return transaction_throttled_hot_shard errors and cause test failure.

This is usually happening UpgradeAndBackupRestore-2.toml tests (roughly 2 out 20k  20240801-195603-jzhou-c4fa6aff5d7d6b4c), e.g.,

```
fdbserver-7.3.43 -f ./tests/restarting/from_7.3.0/UpgradeAndBackupRestore-1.toml -s 2514831264 -b on
-f ./tests/restarting/from_7.3.0/UpgradeAndBackupRestore-2.toml --restarting -s 2514831265 -b on
```

100k 20240801-211333-jzhou-58d8e2565e953e7f

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
