### PR TITLE
[fdbmonitor] Environment variable support

### DIFF
--- a/documentation/sphinx/source/configuration.rst
+++ b/documentation/sphinx/source/configuration.rst
@@ -218,6 +218,7 @@ Contains basic configuration parameters of the ``fdbmonitor`` process. ``user`` 
     # initial-restart-delay = 0
     # restart-backoff = 60.0
     # restart-delay-reset-interval = 60
+    # envvars = FOO=BAR BAZ=FOO
     # delete-envvars =
     # kill-on-configuration-change = true
     # disable-lifecycle-logging = false
@@ -225,7 +226,8 @@ Contains basic configuration parameters of the ``fdbmonitor`` process. ``user`` 
 Contains settings applicable to all processes (e.g. fdbserver, backup_agent).
 
 * ``cluster-file``: Specifies the location of the cluster file. This file and the directory that contains it must be writable by all processes (i.e. by the user or group set in the ``[fdbmonitor]`` section).
-* ``delete-envvars``: A space separated list of environment variables to remove from the environments of child processes. This can be used if the ``fdbmonitor`` process needs to be run with environment variables that are undesired in its children.
+* ``envvars``: A space separated list of environment variables to be added to child processes' environment variables. Every environment variable in the list must be of the form ``A=B`` where ``A`` and ``B`` are key and value names respectively.
+* ``delete-envvars``: A space separated list of environment variables to remove from the environments of child processes. This can be used if the ``fdbmonitor`` process needs to be run with environment variables that are undesired in its children. This takes precedence over envvars field.
 * ``kill-on-configuration-change``: If ``true``, affected processes will be restarted whenever the configuration file changes. Defaults to ``true``.
 * ``disable-lifecycle-logging``: If ``true``, ``fdbmonitor`` will not write log events when processes start or terminate. Defaults to ``false``.
 


### PR DESCRIPTION
# Description

Add environment variable support to fdbmonitor. Users can now provide a space separated environment variable list in their fdbmonitor conf file via `envvars` field. 

This PR required quite a lot of iteration as I was learning the nuances of [putenv](https://man7.org/linux/man-pages/man3/putenv.3.html) around memory management (read the history section to understand the complexity involved), what's allowed in the string and what's not, etc. 

Eventually I ended up these design and implementation decisions:
- Overall, the idea is to follow delete-envvars and optimize for feature consistency. 
- I do not use `putenv`, [this resource](https://wiki.sei.cmu.edu/confluence/display/c/POS34-C.+Do+not+call+putenv%28%29+with+a+pointer+to+an+automatic+variable+as+the+argument) provides some good reasons on why. I settled on `setenv` because that way I don't have to worry about when to deallocate the environment variable string since `setenv` makes its own copy.
- In terms of what's valid, I delegate most of that to `setenv`. I do some basic checks though in terms of having an equal sign, empty key-value pair, etc. See fdbmonitor_tests.cpp. Also, the decision to use space as the delimiter was based on how delete-envvars does it. 
- delete-envvars takes precedence over envvars. Documented this along with general documentation.
- Finally, the user can provide the envvars list at any section (general, fdbserver, fdbserver.1, fdbserver.2, etc.). Same overriding behavior is followed as other properties. 


# Testing

- Ran `ctest`, all tests passed.
- Added new unit test

---

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
