### PR TITLE
Fix the misuse of BIO_get_mem_data

### DIFF
--- a/flow/TLSConfig.actor.cpp
+++ b/flow/TLSConfig.actor.cpp
@@ -741,9 +741,9 @@ std::string getX509Name(const X509_NAME* name) {
 	}
 	X509_NAME_print_ex(out.get(), name, /* indent= */ 0, /* flags */ XN_FLAG_ONELINE);
 	unsigned char* rawName = nullptr;
-	int length = BIO_get_mem_data(out.get(), &rawName);
-	std::string result = (char*)rawName;
-	ASSERT_EQ(result.size(), size_t(length));
+	long length = BIO_get_mem_data(out.get(), &rawName);
+	ASSERT(length > 0);
+	std::string result((const char*)rawName, length);
 	return result;
 }
 


### PR DESCRIPTION
BIO_get_mem_data will return the length of the string, however, the string is not zero-terminated. The length value determines where the string terminates.

Replace this text with your description here...

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
