### PR TITLE
[fdbmonitor] Bug fixes

### DIFF
--- a/fdbmonitor/fdbmonitor.h
+++ b/fdbmonitor/fdbmonitor.h
@@ -146,8 +146,8 @@ public:
 	double last_start;
 	double fork_retry_time;
 	bool quiet;
-	const char* envvars;
-	const char* delete_envvars;
+	std::string envvars;
+	std::string delete_envvars;
 	bool deconfigured;
 	bool kill_on_configuration_change;
 	uint64_t memory_rss;
@@ -156,8 +156,8 @@ public:
 	int pipes[2][2];
 
 	Command(const CSimpleIni& ini, std::string _section, ProcessID id, fdb_fd_set fds, int* maxfd)
-	  : fds(fds), argv(nullptr), section(_section), fork_retry_time(-1), quiet(false), envvars(nullptr),
-	    delete_envvars(nullptr), deconfigured(false), kill_on_configuration_change(true), memory_rss(0) {
+	  : fds(fds), argv(nullptr), section(_section), fork_retry_time(-1), quiet(false), envvars(), delete_envvars(),
+	    deconfigured(false), kill_on_configuration_change(true), memory_rss(0) {
 		char _ssection[strlen(section.c_str()) + 22];
 		snprintf(_ssection, strlen(section.c_str()) + 22, "%s", id.c_str());
 		ssection = _ssection;
@@ -249,11 +249,15 @@ public:
 			quiet = true;
 
 		const char* env = get_value_multi(ini, "envvars", ssection.c_str(), section.c_str(), "general", nullptr);
-		envvars = env;
+		if (env) {
+			envvars = env;
+		}
 
 		const char* del_env =
 		    get_value_multi(ini, "delete-envvars", ssection.c_str(), section.c_str(), "general", nullptr);
-		delete_envvars = del_env;
+		if (del_env) {
+			delete_envvars = del_env;
+		}
 
 		const char* kocc =
 		    get_value_multi(ini, "kill-on-configuration-change", ssection.c_str(), section.c_str(), "general", nullptr);


### PR DESCRIPTION
# Description  

Grouping fixes for some bugs I found in fdbmonitor:

1. When a child process fails, it exits and is retried by parent after a `restart-delay`. This delay did not account for setting/unsetting environment variables, but now it does. Fix was simply to move the delay a bit up in code. 

2. Some string processing bugs when unsetting environment variables due to `delete-envvars` configuration. These are related to not handling `std::string::npos` properly, which means previously we could have been reading outside the string buffer which is [undefined behavior](https://en.cppreference.com/w/cpp/string/basic_string/operator_at). 

3. The trickiest one was reading invalid memory issue that I found as part of `delete-envvars` use-case but can happen for other fdbmonitor use-cases. It happens because [`load_conf`\(https://github.com/spraza/foundationdb/blob/fdf5057ec53c956dde59386dd2437e6e48940cb4/fdbmonitor/fdbmonitor_lib.cpp#L632) allocates memory for `CSimpleIniA`, then creates a `Command` object, and within the `Command` object we have pointers back to `CSimpleIniA`'s internal state (e.g. const char* to the list of `delete-envvars`). The lifetime of this `Command` object is more than the `load_conf` function, meaning that we rely on those pointers later (e.g. when we restart the process because unsetting env variables failed). The most non-intrusive fix I could find was to increase the lifetime of `CSimpleIniA` by allocating it once in `main()` and then passing it to `load_conf`. Based on `load_conf` callsities, I don't think every `load_conf` needs to create a new `CSimpleIniA` object but correct me if I am wrong. 

# Testing

- Ran `ctest`, all tests passed except 3 which I don't think are related to my change. Will confirm via CI. 

# Changelog 

- (07/06/2024): `fdb_c_wiggle_only` is failing with this change. Hold on to reviewing. I will also change this PR to draft for now.

- (07/06/2024): In description #3, I mentioned that every `load_conf` may not need a new `CSimpleIniA`, so I made one `CSimpleIniA` for all `load_conf` calls. However, this results in failure of `fdb_c_wiggle_only`. The alternative fix for the original issue is to not have pointers in `Command` object pointing to internal state of `CSimpleIniA`. Instead, I simply make a string copy and store it within the `Command` object. 

---

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
