### PR TITLE
Fix fdbmonitor build issues on macOS

### DIFF
--- a/fdbmonitor/fdbmonitor.cpp
+++ b/fdbmonitor/fdbmonitor.cpp
@@ -18,11 +18,16 @@
  * limitations under the License.
  */
 
+#include <csignal>
 #include <memory>
 #include <sys/wait.h>
 #include <cinttypes>
 #include <sys/stat.h>
 #include <fcntl.h>
+
+#if defined(__APPLE__) || defined(__FreeBSD__)
+#include <sys/event.h>
+#endif
 
 #include "fdbmonitor.h"
 #include "SimpleOpt/SimpleOpt.h"

--- a/fdbmonitor/fdbmonitor.h
+++ b/fdbmonitor/fdbmonitor.h
@@ -92,6 +92,11 @@ struct Command;
 void read_child_output(Command* cmd, int pipe_idx, fdb_fd_set fds);
 void start_process(Command* cmd, ProcessID id, uid_t uid, gid_t gid, int delay, sigset_t* mask);
 
+#if defined(__APPLE__) || defined(__FreeBSD__)
+void watch_conf_dir(int kq, int* confd_fd, std::string confdir);
+void watch_conf_file(int kq, int* conff_fd, const char* confpath);
+#endif
+
 struct EnvVarUtils {
 	// This utility assumes key and value are separated by one equal sign
 	static std::pair<std::string, std::string> extractKeyAndValue(const std::string& keyValue) {

--- a/fdbmonitor/fdbmonitor_lib.cpp
+++ b/fdbmonitor/fdbmonitor_lib.cpp
@@ -18,7 +18,9 @@
  * limitations under the License.
  */
 
+#include <csignal>
 #include <limits>
+#include <sys/time.h>
 #ifndef _WIN32
 #include <unistd.h>
 #endif


### PR DESCRIPTION
This is potentially happening on FreeBSD as well.

Without this change, the build fails with multiple identifiers not found, such as `gettimeofday`, `sigprocmask`, `kqueue` and some more related ones. `watch_conf_dir` and  `watch_conf_file` were also missing in the `fdbmonitor.h`.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
