### PR TITLE
[fdbmonitor] Ctests for envvars key-value extraction

### DIFF
--- a/fdbmonitor/fdbmonitor_tests.cpp
+++ b/fdbmonitor/fdbmonitor_tests.cpp
@@ -128,7 +128,17 @@ void testPathOps() {
 }
 
 void testEnvVarUtils() {
-	// Ensure validation passes for good inputs
+	// Ensure key-value extraction works
+	std::pair<std::string, std::string> keyValuePair1 = std::make_pair("FOO", "BAR");
+	assert(keyValuePair1 == EnvVarUtils::extractKeyAndValue("FOO=BAR"));
+	std::pair<std::string, std::string> keyValuePair2 = std::make_pair("x", "y");
+	assert(keyValuePair2 == EnvVarUtils::extractKeyAndValue("x=y"));
+	std::pair<std::string, std::string> keyValuePair3 =
+	    std::make_pair("MALLOC_CONF", "prof:true,lg_prof_interval:30,prof_prefix:jeprof.out");
+	assert(keyValuePair3 ==
+	       EnvVarUtils::extractKeyAndValue("MALLOC_CONF=prof:true,lg_prof_interval:30,prof_prefix:jeprof.out"));
+
+	// Ensure key-value validation passes for good inputs
 	assert(EnvVarUtils::keyValueValid("FOO=BAR", "FOO=BAR"));
 	assert(EnvVarUtils::keyValueValid("x=y", "FOO=BAR x=y"));
 	assert(EnvVarUtils::keyValueValid("MALLOC_CONF=prof:true,lg_prof_interval:30,prof_prefix:jeprof.out",
@@ -136,7 +146,7 @@ void testEnvVarUtils() {
 	assert(EnvVarUtils::keyValueValid("MALLOC_CONF=prof:true,lg_prof_interval:30,prof_prefix:jeprof.out",
 	                                  "MALLOC_CONF=prof:true,lg_prof_interval:30,prof_prefix:jeprof.out FOO=BAR"));
 
-	// Ensure validation fails for bad inputs
+	// Ensure key-value validation fails for bad inputs
 	assert_msg(!EnvVarUtils::keyValueValid("", "FOO=BAR ="), "Key-Value can not be empty");
 	assert_msg(!EnvVarUtils::keyValueValid("FOO==BAR", "FOO==BAR"), "Only one equal sign allowed");
 	assert_msg(!EnvVarUtils::keyValueValid("BAZ=", "FOO=BAR BAZ="), "Value must be non-empty");

--- a/fdbmonitor/fdbmonitor_tests.cpp
+++ b/fdbmonitor/fdbmonitor_tests.cpp
@@ -129,12 +129,12 @@ void testPathOps() {
 
 void testEnvVarUtils() {
 	// Ensure key-value extraction works
-	std::pair<std::string, std::string> keyValuePair1 = std::make_pair("FOO", "BAR");
+	const std::pair<std::string, std::string> keyValuePair1{ "FOO", "BAR" };
 	assert(keyValuePair1 == EnvVarUtils::extractKeyAndValue("FOO=BAR"));
-	std::pair<std::string, std::string> keyValuePair2 = std::make_pair("x", "y");
+	const std::pair<std::string, std::string> keyValuePair2{ "x", "y" };
 	assert(keyValuePair2 == EnvVarUtils::extractKeyAndValue("x=y"));
-	std::pair<std::string, std::string> keyValuePair3 =
-	    std::make_pair("MALLOC_CONF", "prof:true,lg_prof_interval:30,prof_prefix:jeprof.out");
+	const std::pair<std::string, std::string> keyValuePair3{ "MALLOC_CONF",
+		                                                     "prof:true,lg_prof_interval:30,prof_prefix:jeprof.out" };
 	assert(keyValuePair3 ==
 	       EnvVarUtils::extractKeyAndValue("MALLOC_CONF=prof:true,lg_prof_interval:30,prof_prefix:jeprof.out"));
 


### PR DESCRIPTION
# Description

Simple tests to ensure we don't regress on logic that extracts key and value from a key-value pair. 

# Testing

- `ctest` on `fdbmonitor_tests` target passes

---
# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
