### PR TITLE
Add http_bad_request to indicate non-retryable client error

### DIFF
--- a/fdbclient/FileBackupAgent.actor.cpp
+++ b/fdbclient/FileBackupAgent.actor.cpp
@@ -6004,8 +6004,10 @@ ACTOR Future<Void> transformRestoredDatabase(Database cx,
 void simulateBlobFailure() {
 	if (BUGGIFY && deterministicRandom()->random01() < 0.01) { // Simulate blob failures
 		double i = deterministicRandom()->random01();
-		if (i < 0.5) {
+		if (i < 0.4) {
 			throw http_request_failed();
+		} else if (i < 0.5) {
+			throw http_bad_request();
 		} else if (i < 0.7) {
 			throw connection_failed();
 		} else if (i < 0.8) {

--- a/fdbclient/S3BlobStore.actor.cpp
+++ b/fdbclient/S3BlobStore.actor.cpp
@@ -1031,6 +1031,13 @@ ACTOR Future<Reference<HTTP::Response>> doRequest_impl(Reference<S3BlobStoreEndp
 			if (r && r->code == 401)
 				throw http_auth_failed();
 
+			// ref: https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html
+			// this error code indicates that an error from client side, such as expiredToken, empty header/body
+			// we have to throw a dedicated exception rather than a general http_failed because this is not retryable.
+			if (r && r->code == 400) {
+				throw http_bad_request();
+			}
+
 			// Recognize and throw specific errors
 			if (err.present()) {
 				int code = err.get().code();

--- a/flow/error_definitions.h
+++ b/flow/error_definitions.h
@@ -148,6 +148,7 @@ ERROR( file_corrupt, 1522, "A structurally corrupt data file was detected" )
 ERROR( http_request_failed, 1523, "HTTP response code not received or indicated failure" )
 ERROR( http_auth_failed, 1524, "HTTP request failed due to bad credentials" )
 ERROR( http_bad_request_id, 1525, "HTTP response contained an unexpected X-Request-ID header" )
+ERROR( http_bad_request, 1526, "HTTP bad request from client side" )
 
 // 2xxx Attempt (presumably by a _client_) to do something illegal.  If an error is known to
 // be internally caused, it should be 41xx


### PR DESCRIPTION
http_request_failed is considered retryable, thus we have to differentiate the non-retryable cases such as client-side error, and stop retrying them.

otherwise a general http_request_failed exception will be thrown [here](https://github.com/apple/foundationdb/blob/5c644f20e3c5b752c3dc11bcbf620536ba497419/fdbclient/S3BlobStore.actor.cpp#L902), and it will be considered retryable [here](https://github.com/apple/foundationdb/blob/5c644f20e3c5b752c3dc11bcbf620536ba497419/fdbserver/BlobWorker.actor.cpp#L1051)


Replace this text with your description here...

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
