### PR TITLE
WIP: Use std::filesystem as standard

### DIFF
--- a/fdbmonitor/fdbmonitor.cpp
+++ b/fdbmonitor/fdbmonitor.cpp
@@ -24,6 +24,7 @@
 #include <cinttypes>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <filesystem>
 
 #if defined(__APPLE__) || defined(__FreeBSD__)
 #include <sys/event.h>

--- a/fdbrpc/Net2FileSystem.cpp
+++ b/fdbrpc/Net2FileSystem.cpp
@@ -96,7 +96,7 @@ Future<Reference<class IAsyncFile>> Net2FileSystem::open(const std::string& file
 
 // Deletes the given file.  If mustBeDurable, returns only when the file is guaranteed to be deleted even after a power
 // failure.
-Future<Void> Net2FileSystem::deleteFile(const std::string& filename, bool mustBeDurable) {
+Future<Void> Net2FileSystem::deleteFile(const std::filesystem::path& filename, bool mustBeDurable) {
 	return Net2AsyncFile::deleteFile(filename, mustBeDurable);
 }
 
@@ -144,7 +144,7 @@ Net2FileSystem::Net2FileSystem(double ioTimeout, const std::string& fileSystemPa
 #endif
 }
 
-Future<Void> Net2FileSystem::renameFile(const std::string& from, const std::string& to) {
+Future<Void> Net2FileSystem::renameFile(const std::filesystem::path& from, const std::filesystem::path& to) {
 	return Net2AsyncFile::renameFile(from, to);
 }
 

--- a/fdbrpc/include/fdbrpc/AsyncFileWinASIO.actor.h
+++ b/fdbrpc/include/fdbrpc/AsyncFileWinASIO.actor.h
@@ -150,7 +150,7 @@ public:
 		return result.getFuture();
 	}
 
-	static Future<Void> renameFile(std::string const& from, std::string const& to) {
+	static Future<Void> renameFile(std::filesystem::path const& from, std::filesystem::path const& to) {
 		::renameFile(from, to);
 		return Void();
 	}

--- a/flow/FileTraceLogWriter.cpp
+++ b/flow/FileTraceLogWriter.cpp
@@ -234,17 +234,17 @@ void FileTraceLogWriter::cleanupTraceFiles() {
 			// Rename/finalize any stray files ending in tracePartialFileSuffix for this process.
 			if (!tracePartialFileSuffix.empty()) {
 				for (const auto& f : platform::listFiles(directory, tracePartialFileSuffix)) {
-					if (f.substr(0, processName.length()) == processName) {
-						renameFile(f, f.substr(0, f.size() - tracePartialFileSuffix.size()));
+					if (f.parent_path() == processName) {
+						renameFile(f, f.stem());
 					}
 				}
 			}
 
-			std::vector<std::string> existingFiles = platform::listFiles(directory, extension);
-			std::vector<std::string> existingTraceFiles;
+			std::vector<std::filesystem::path> existingFiles = platform::listFiles(directory, extension);
+			std::vector<std::filesystem::path> existingTraceFiles;
 
 			for (auto f = existingFiles.begin(); f != existingFiles.end(); ++f) {
-				if (f->substr(0, processName.length()) == processName) {
+				if (f->parent_path() == processName) {
 					existingTraceFiles.push_back(*f);
 				}
 			}
@@ -253,15 +253,15 @@ void FileTraceLogWriter::cleanupTraceFiles() {
 			std::sort(existingTraceFiles.begin(), existingTraceFiles.end(), std::greater<std::string>());
 
 			uint64_t runningTotal = 0;
-			std::vector<std::string>::iterator fileListIterator = existingTraceFiles.begin();
+			std::vector<std::filesystem::path>::iterator fileListIterator = existingTraceFiles.begin();
 
 			while (runningTotal < maxLogsSize && fileListIterator != existingTraceFiles.end()) {
-				runningTotal += (fileSize(joinPath(directory, *fileListIterator)) + FLOW_KNOBS->ZERO_LENGTH_FILE_PAD);
+				runningTotal += (fileSize(directory / *fileListIterator) + FLOW_KNOBS->ZERO_LENGTH_FILE_PAD);
 				++fileListIterator;
 			}
 
 			while (fileListIterator != existingTraceFiles.end()) {
-				deleteFile(joinPath(directory, *fileListIterator));
+				deleteFile(directory / *fileListIterator);
 				++fileListIterator;
 			}
 		} catch (Error&) {

--- a/flow/IAsyncFile.actor.cpp
+++ b/flow/IAsyncFile.actor.cpp
@@ -133,8 +133,8 @@ TEST_CASE("/fileio/incrementalDelete") {
 TEST_CASE("/fileio/rename") {
 	// create a file
 	state int64_t fileSize = 100e6;
-	state std::string filename = "/tmp/__JUNK__." + deterministicRandom()->randomUniqueID().toString();
-	state std::string renamedFile = "/tmp/__RENAMED_JUNK__." + deterministicRandom()->randomUniqueID().toString();
+	state std::filesystem::path filename = std::filesystem::path("/tmp/__JUNK__." + deterministicRandom()->randomUniqueID().toString());
+	state std::filesystem::path renamedFile = std::filesystem::path("/tmp/__RENAMED_JUNK__." + deterministicRandom()->randomUniqueID().toString());
 	state std::unique_ptr<char[]> data(new char[4096]);
 	state std::unique_ptr<char[]> readData(new char[4096]);
 	state Reference<IAsyncFile> f = wait(IAsyncFileSystem::filesystem()->open(
@@ -161,7 +161,7 @@ TEST_CASE("/fileio/rename") {
 
 	// verify rename happened
 	bool renamedExists = false;
-	auto bName = basename(renamedFile);
+	auto bName = renamedFile.filename();
 	auto files = platform::listFiles("/tmp/");
 	for (const auto& file : files) {
 		if (file == bName) {

--- a/flow/IAsyncFile.actor.cpp
+++ b/flow/IAsyncFile.actor.cpp
@@ -133,8 +133,10 @@ TEST_CASE("/fileio/incrementalDelete") {
 TEST_CASE("/fileio/rename") {
 	// create a file
 	state int64_t fileSize = 100e6;
-	state std::filesystem::path filename = std::filesystem::path("/tmp/__JUNK__." + deterministicRandom()->randomUniqueID().toString());
-	state std::filesystem::path renamedFile = std::filesystem::path("/tmp/__RENAMED_JUNK__." + deterministicRandom()->randomUniqueID().toString());
+	state std::filesystem::path filename =
+	    std::filesystem::path("/tmp/__JUNK__." + deterministicRandom()->randomUniqueID().toString());
+	state std::filesystem::path renamedFile =
+	    std::filesystem::path("/tmp/__RENAMED_JUNK__." + deterministicRandom()->randomUniqueID().toString());
 	state std::unique_ptr<char[]> data(new char[4096]);
 	state std::unique_ptr<char[]> readData(new char[4096]);
 	state Reference<IAsyncFile> f = wait(IAsyncFileSystem::filesystem()->open(

--- a/flow/Platform.actor.cpp
+++ b/flow/Platform.actor.cpp
@@ -2294,8 +2294,8 @@ void renameFile(std::filesystem::path const& fromPath, std::filesystem::path con
 	}
 #elif (defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__))
 	rename(fromPath, toPath);
-		// FIXME: We cannot inject faults after renaming the file, because we could end up with two asyncFileNonDurable
-		// open for the same file renamedFile();
+	// FIXME: We cannot inject faults after renaming the file, because we could end up with two asyncFileNonDurable
+	// open for the same file renamedFile();
 	return;
 #else
 #error Port me!
@@ -2445,9 +2445,9 @@ std::filesystem::path cleanPath(std::filesystem::path const& path) {
 }
 
 std::filesystem::path popPath(std::filesystem::path const& path) {
-    std::filesystem::path parent = path.parent_path();
-    std::filesystem::path filename = parent.filename();
-    filename /= "";
+	std::filesystem::path parent = path.parent_path();
+	std::filesystem::path filename = parent.filename();
+	filename /= "";
 	return filename;
 }
 
@@ -2623,9 +2623,9 @@ bool acceptDirectory(FILE_ATTRIBUTE_DATA fileAttributes, std::string const& name
 }
 
 ACTOR Future<std::vector<std::filesystem::path>> findFiles(std::filesystem::path directory,
-                                                 std::string extension,
-                                                 bool directoryOnly,
-                                                 bool async) {
+                                                           std::string extension,
+                                                           bool directoryOnly,
+                                                           bool async) {
 	INJECT_FAULT(platform_error, "findFiles"); // findFiles failed
 	state std::vector<std::filesystem::path> result;
 	state int64_t tsc_begin = timestampCounter();
@@ -2840,7 +2840,7 @@ void setThreadPriority(int pri) {
 }
 
 bool fileExists(std::string const& filename) {
-	return std::filesystem::exists(filename); 
+	return std::filesystem::exists(filename);
 }
 
 bool directoryExists(std::filesystem::path const& p) {
@@ -4096,48 +4096,28 @@ void platformSpecificDirectoryOpsTests(const std::string& cwd, int& errors) {
 	ASSERT(symlink("one/two", "simfdb/backups/four") == 0);
 	ASSERT(symlink("../backups/four", "simfdb/backups/five") == 0);
 
-	errors += testPathFunction2(
-	    "abspath", abspath, "simfdb/backups/four/../two", true, true, cwd / "simfdb/backups/one/two");
-	errors += testPathFunction2(
-	    "abspath", abspath, "simfdb/backups/five/../two", true, true, cwd / "simfdb/backups/one/two");
+	errors +=
+	    testPathFunction2("abspath", abspath, "simfdb/backups/four/../two", true, true, cwd / "simfdb/backups/one/two");
+	errors +=
+	    testPathFunction2("abspath", abspath, "simfdb/backups/five/../two", true, true, cwd / "simfdb/backups/one/two");
 	errors += testPathFunction2(
 	    "abspath", abspath, "simfdb/backups/five/../two", true, false, cwd / "simfdb/backups/one/two");
 	errors += testPathFunction2("abspath", abspath, "simfdb/backups/five/../three", true, true, platform_error());
 	errors += testPathFunction2(
 	    "abspath", abspath, "simfdb/backups/five/../three", true, false, cwd / "simfdb/backups/one/three");
-	errors += testPathFunction2("abspath",
-	                            abspath,
-	                            "simfdb/backups/five/../three/../four",
-	                            true,
-	                            false,
-	                            cwd /"simfdb/backups/one/four");
+	errors += testPathFunction2(
+	    "abspath", abspath, "simfdb/backups/five/../three/../four", true, false, cwd / "simfdb/backups/one/four");
 
-	errors += testPathFunction2("parentDirectory",
-	                            parentDirectory,
-	                            "simfdb/backups/four/../two",
-	                            true,
-	                            true,
-	                            cwd / "simfdb/backups/one/");
-	errors += testPathFunction2("parentDirectory",
-	                            parentDirectory,
-	                            "simfdb/backups/five/../two",
-	                            true,
-	                            true,
-	                            cwd / "simfdb/backups/one/");
-	errors += testPathFunction2("parentDirectory",
-	                            parentDirectory,
-	                            "simfdb/backups/five/../two",
-	                            true,
-	                            false,
-	                            cwd, "simfdb/backups/one/");
+	errors += testPathFunction2(
+	    "parentDirectory", parentDirectory, "simfdb/backups/four/../two", true, true, cwd / "simfdb/backups/one/");
+	errors += testPathFunction2(
+	    "parentDirectory", parentDirectory, "simfdb/backups/five/../two", true, true, cwd / "simfdb/backups/one/");
+	errors += testPathFunction2(
+	    "parentDirectory", parentDirectory, "simfdb/backups/five/../two", true, false, cwd, "simfdb/backups/one/");
 	errors += testPathFunction2(
 	    "parentDirectory", parentDirectory, "simfdb/backups/five/../three", true, true, platform_error());
-	errors += testPathFunction2("parentDirectory",
-	                            parentDirectory,
-	                            "simfdb/backups/five/../three",
-	                            true,
-	                            false,
-	                            cwd / "simfdb/backups/one/");
+	errors += testPathFunction2(
+	    "parentDirectory", parentDirectory, "simfdb/backups/five/../three", true, false, cwd / "simfdb/backups/one/");
 	errors += testPathFunction2("parentDirectory",
 	                            parentDirectory,
 	                            "simfdb/backups/five/../three/../four",
@@ -4189,27 +4169,22 @@ TEST_CASE("/flow/Platform/directoryOps") {
 	errors += testPathFunction2("abspath", abspath, ".", true, false, cwd);
 	errors += testPathFunction2("abspath", abspath, "/a", true, false, "/a");
 	errors += testPathFunction2("abspath", abspath, "one/two/three/four", false, true, platform_error());
-	errors +=
-	    testPathFunction2("abspath", abspath, "one/two/three/four", false, false, cwd / "one/two/three/four");
-	errors += testPathFunction2(
-	    "abspath", abspath, "one/two/three/./four", false, false, cwd / "one/two/three/four");
-	errors += testPathFunction2(
-	    "abspath", abspath, "one/two/three/./four", false, false, cwd / "one/two/three/four");
-	errors +=
-	    testPathFunction2("abspath", abspath, "one/two/three/./four/..", false, false, cwd / "one/two/three");
-	errors += testPathFunction2(
-	    "abspath", abspath, "one/./two/../three/./four", false, false, cwd / "one/three/four");
+	errors += testPathFunction2("abspath", abspath, "one/two/three/four", false, false, cwd / "one/two/three/four");
+	errors += testPathFunction2("abspath", abspath, "one/two/three/./four", false, false, cwd / "one/two/three/four");
+	errors += testPathFunction2("abspath", abspath, "one/two/three/./four", false, false, cwd / "one/two/three/four");
+	errors += testPathFunction2("abspath", abspath, "one/two/three/./four/..", false, false, cwd / "one/two/three");
+	errors += testPathFunction2("abspath", abspath, "one/./two/../three/./four", false, false, cwd / "one/three/four");
 	errors += testPathFunction2("abspath", abspath, "one/./two/../three/./four", false, true, platform_error());
 	errors += testPathFunction2("abspath", abspath, "one/two/three/./four", false, true, platform_error());
 	errors += testPathFunction2(
 	    "abspath", abspath, "simfdb/backups/one/two/three", false, true, cwd / "simfdb/backups/one/two/three");
 	errors += testPathFunction2("abspath", abspath, "simfdb/backups/one/two/threefoo", false, true, platform_error());
-	errors += testPathFunction2(
-	    "abspath", abspath, "simfdb/backups/four/../two", false, false, cwd / "simfdb/backups/two");
+	errors +=
+	    testPathFunction2("abspath", abspath, "simfdb/backups/four/../two", false, false, cwd / "simfdb/backups/two");
 	errors += testPathFunction2("abspath", abspath, "simfdb/backups/four/../two", false, true, platform_error());
 	errors += testPathFunction2("abspath", abspath, "simfdb/backups/five/../two", false, true, platform_error());
-	errors += testPathFunction2(
-	    "abspath", abspath, "simfdb/backups/five/../two", false, false, cwd / "simfdb/backups/two");
+	errors +=
+	    testPathFunction2("abspath", abspath, "simfdb/backups/five/../two", false, false, cwd / "simfdb/backups/two");
 	errors += testPathFunction2("abspath", abspath, "foo/./../foo2/./bar//", false, false, cwd / "foo2/bar");
 	errors += testPathFunction2("abspath", abspath, "foo/./../foo2/./bar//", false, true, platform_error());
 	errors += testPathFunction2("abspath", abspath, "foo/./../foo2/./bar//", true, false, cwd / "foo2/bar");
@@ -4218,8 +4193,7 @@ TEST_CASE("/flow/Platform/directoryOps") {
 	errors += testPathFunction2("parentDirectory", parentDirectory, "", true, false, platform_error());
 	errors += testPathFunction2("parentDirectory", parentDirectory, "/", true, false, "/");
 	errors += testPathFunction2("parentDirectory", parentDirectory, "/a", true, false, "/");
-	errors +=
-	    testPathFunction2("parentDirectory", parentDirectory, ".", false, false, cleanPath(cwd / "..") + "/");
+	errors += testPathFunction2("parentDirectory", parentDirectory, ".", false, false, cleanPath(cwd / "..") + "/");
 	errors += testPathFunction2("parentDirectory", parentDirectory, "./foo", false, false, cleanPath(cwd) + "/");
 	errors +=
 	    testPathFunction2("parentDirectory", parentDirectory, "one/two/three/four", false, true, platform_error());
@@ -4243,28 +4217,20 @@ TEST_CASE("/flow/Platform/directoryOps") {
 	                            cwd / "simfdb/backups/one/two/");
 	errors += testPathFunction2(
 	    "parentDirectory", parentDirectory, "simfdb/backups/one/two/threefoo", false, true, platform_error());
-	errors += testPathFunction2("parentDirectory",
-	                            parentDirectory,
-	                            "simfdb/backups/four/../two",
-	                            false,
-	                            false,
-	                            cwd / "simfdb/backups/");
+	errors += testPathFunction2(
+	    "parentDirectory", parentDirectory, "simfdb/backups/four/../two", false, false, cwd / "simfdb/backups/");
 	errors += testPathFunction2(
 	    "parentDirectory", parentDirectory, "simfdb/backups/four/../two", false, true, platform_error());
 	errors += testPathFunction2(
 	    "parentDirectory", parentDirectory, "simfdb/backups/five/../two", false, true, platform_error());
-	errors += testPathFunction2("parentDirectory",
-	                            parentDirectory,
-	                            "simfdb/backups/five/../two",
-	                            false,
-	                            false,
-	                            cwd / "simfdb/backups/");
 	errors += testPathFunction2(
-	    "parentDirectory", parentDirectory, "foo/./../foo2/./bar//", false, false, cwd / "foo2/");
+	    "parentDirectory", parentDirectory, "simfdb/backups/five/../two", false, false, cwd / "simfdb/backups/");
+	errors +=
+	    testPathFunction2("parentDirectory", parentDirectory, "foo/./../foo2/./bar//", false, false, cwd / "foo2/");
 	errors +=
 	    testPathFunction2("parentDirectory", parentDirectory, "foo/./../foo2/./bar//", false, true, platform_error());
-	errors += testPathFunction2(
-	    "parentDirectory", parentDirectory, "foo/./../foo2/./bar//", true, false, cwd / "foo2/");
+	errors +=
+	    testPathFunction2("parentDirectory", parentDirectory, "foo/./../foo2/./bar//", true, false, cwd / "foo2/");
 	errors +=
 	    testPathFunction2("parentDirectory", parentDirectory, "foo/./../foo2/./bar//", true, true, platform_error());
 

--- a/flow/TLSConfig.actor.cpp
+++ b/flow/TLSConfig.actor.cpp
@@ -37,6 +37,7 @@ TLSPolicy::~TLSPolicy() {}
 #include <sstream>
 #include <utility>
 #include <vector>
+#include <filesystem>
 
 #include <boost/asio/ssl/context.hpp>
 #include <boost/lexical_cast.hpp>
@@ -192,8 +193,8 @@ std::string TLSConfig::getCertificatePathSync() const {
 	}
 
 	const char* defaultCertFileName = "cert.pem";
-	if (fileExists(joinPath(platform::getDefaultConfigPath(), defaultCertFileName))) {
-		return joinPath(platform::getDefaultConfigPath(), defaultCertFileName);
+	if (fileExists(platform::getDefaultConfigPath() / defaultCertFileName)) {
+		return platform::getDefaultConfigPath() / defaultCertFileName;
 	}
 
 	return std::string();
@@ -210,8 +211,8 @@ std::string TLSConfig::getKeyPathSync() const {
 	}
 
 	const char* defaultKeyFileName = "key.pem";
-	if (fileExists(joinPath(platform::getDefaultConfigPath(), defaultKeyFileName))) {
-		return joinPath(platform::getDefaultConfigPath(), defaultKeyFileName);
+	if (fileExists(platform::getDefaultConfigPath() / defaultKeyFileName)) {
+		return platform::getDefaultConfigPath() / defaultKeyFileName;
 	}
 
 	return std::string();

--- a/flow/include/flow/Platform.h
+++ b/flow/include/flow/Platform.h
@@ -31,6 +31,7 @@
 #define FLOW_THREAD_SAFE 0
 
 #include <stdlib.h>
+#include <filesystem>
 #if defined(__cplusplus)
 #include <ctime>
 #else
@@ -320,49 +321,49 @@ void threadSleep(double seconds);
 void threadYield(); // Attempt to yield to other processes or threads
 
 // Returns true iff the file exists
-bool fileExists(std::string const& filename);
+bool fileExists(std::filesystem::path const& filename);
 
 // Returns true iff the directory exists
-bool directoryExists(std::string const& path);
+bool directoryExists(std::filesystem::path const& path);
 
 // Returns size of file in bytes
-int64_t fileSize(std::string const& filename);
+int64_t fileSize(std::filesystem::path const& filename);
 
 // Returns last modified time of the file.
-time_t fileModifiedTime(const std::string& filename);
+time_t fileModifiedTime(const std::filesystem::path const& filename); // Maybe this should be const for extra protection?
 
 // Returns true if file is deleted, false if it was not found, throws platform_error() otherwise
 // Consider using IAsyncFileSystem::filesystem()->deleteFile() instead, especially if you need durability!
-bool deleteFile(std::string const& filename);
+bool deleteFile(std::filesystem::path const& path);
 
 // Renames the given file.  Does not fsync the directory.
-void renameFile(std::string const& fromPath, std::string const& toPath);
+void renameFile(std::filesystem::path const& fromPath, std::filesystem::path const& toPath);
 
 // Atomically replaces the contents of the specified file.
-void atomicReplace(std::string const& path, std::string const& content, bool textmode = true);
+void atomicReplace(std::filesystem::path const& path, std::string const& content, bool textmode = true); // Maybe the content should also be filesystem? Not sure if there's an alternative but there might be some security issues if we leave it as std::string. (Could be a victim of injection attacks)
 
 // Read a file into memory
 // This requires the file to be seekable
-std::string readFileBytes(std::string const& filename, size_t maxSize);
+std::string readFileBytes(std::filesystem::path const& filename, size_t maxSize);
 
 // Read a file into memory supplied by the caller
 // If 'len' is greater than file size, then read the filesize bytes.
-size_t readFileBytes(std::string const& filename, uint8_t* buff, size_t len);
+size_t readFileBytes(std::filesystem::path const& filename, uint8_t* buff, size_t len);
 
 // Write data buffer into file
-void writeFileBytes(std::string const& filename, const uint8_t* data, size_t count);
+void writeFileBytes(std::filesystem::path const& filename, const uint8_t* data, size_t count);
 
 // Write text into file
-void writeFile(std::string const& filename, std::string const& content);
+void writeFile(std::filesystem::path const& filename, std::string const& content);
 
-std::string joinPath(std::string const& directory, std::string const& filename);
+std::filesystem::path joinPath(std::filesystem::path const& directory, std::filesystem::path const& filename); // May not even exist tbh, because there's a function that prints out the filename canonical path 
 
 // cleanPath() does a 'logical' resolution of the given path string to a canonical form *without*
 // following symbolic links or verifying the existence of any path components.  It removes redundant
 // "." references and duplicate separators, and resolves any ".." references that can be resolved
 // using the preceding path components.
 // Relative paths remain relative and are NOT rebased on the current working directory.
-std::string cleanPath(std::string const& path);
+std::filesystem::path cleanPath(std::filesystem::path const& path);
 
 // Removes the last component from a path string (if possible) and returns the result with one trailing separator.
 // If there is only one path component, the result will be "" for relative paths and "/" for absolute paths.
@@ -376,7 +377,7 @@ std::string cleanPath(std::string const& path);
 //   /a/.
 //   /a/./
 //   /a//..//
-std::string popPath(const std::string& path);
+std::filesystem::path popPath(const std::filesystem::path& path);
 
 // abspath() resolves the given path to a canonical form.
 // If path is relative, the result will be based on the current working directory.
@@ -387,32 +388,32 @@ std::string popPath(const std::string& path);
 // User directory references such as '~' or '~user' are effectively treated as symbolic links which
 // are impossible to resolve, so resolveLinks=true results in failure and resolveLinks=false results
 // in the reference being left in-tact prior to resolving '..' references.
-std::string abspath(std::string const& path, bool resolveLinks = true, bool mustExist = false);
+std::filesystem::path abspath(std::filesystem::path const& path, bool resolveLinks = true, bool mustExist = false);
 
 // parentDirectory() returns the parent directory of the given file or directory in a canonical form,
 // with a single trailing path separator.
 // It uses absPath() with the same bool options to initially obtain a canonical form, and upon success
 // removes the final path component, if present.
-std::string parentDirectory(std::string const& path, bool resolveLinks = true, bool mustExist = false);
+//std::filesystem::path parentDirectory(std::filesystem::path const& path, bool resolveLinks = true, bool mustExist = false); // This doesn't need to exist. Will commit this out to track references.
 
 // Returns the portion of the path following the last path separator (e.g. the filename or directory name)
-std::string basename(std::string const& filename);
+//std::string basename(std::string const& filename); // This doesn't need to exist. Will commit this out to track references.
 
 // Returns the home directory of the current user
-std::string getUserHomeDirectory();
+std::string getUserHomeDirectory(); // Not sure if this needs to change.
 
 namespace platform {
 
 // Returns true if directory was created, false if it existed, throws platform_error() otherwise
-bool createDirectory(std::string const& directory);
+bool createDirectory(std::filesystem::path const& directory);
 
 // e.g. extension==".fdb", returns filenames relative to directory
-std::vector<std::string> listFiles(std::string const& directory, std::string const& extension = "");
+std::vector<std::filesystem::path> listFiles(std::filesystem::path const& directory, std::string const& extension = "");
 
 // returns directory names relative to directory
-std::vector<std::string> listDirectories(std::string const& directory);
+std::vector<std::filesystem::path> listDirectories(std::filesystem::path const& directory);
 
-void findFilesRecursively(std::string const& path, std::vector<std::string>& out);
+void findFilesRecursively(std::filesystem::path const& path, std::vector<std::filesystem::path>& out);
 
 // Tag the given file as "temporary", i.e. not really needing commits to disk
 void makeTemporary(const char* filename);
@@ -427,13 +428,13 @@ int getRandomSeed();
 bool getEnvironmentVar(const char* name, std::string& value);
 int setEnvironmentVar(const char* name, const char* value, int overwrite);
 
-std::string getWorkingDirectory();
+std::filesystem::path getWorkingDirectory();
 
 // Returns the absolute platform-dependant path for server-based files
-std::string getDefaultConfigPath();
+std::filesystem::path getDefaultConfigPath();
 
 // Returns the absolute platform-dependant path for the default fdb.cluster file
-std::string getDefaultClusterFilePath();
+std::filesystem::path getDefaultClusterFilePath();
 
 struct ImageInfo {
 	void* offset = nullptr;
@@ -463,10 +464,10 @@ public:
 	size_t read(uint8_t* buff, size_t len);
 	void write(const uint8_t* buff, size_t len);
 	bool destroyFile();
-	std::string getFileName() const { return filename; }
+	std::filesystem::path getFileName() const { return filename; }
 
 private:
-	std::string filename;
+	std::filesystem::path filename;
 	constexpr static std::string_view defaultPrefix = "fdbtmp";
 
 	void createTmpFile(const std::string_view dir, const std::string_view prefix);
@@ -753,10 +754,10 @@ void* loadLibrary(const char* lib_path);
 void closeLibrary(void* handle);
 void* loadFunction(void* lib, const char* func_name);
 
-std::string exePath();
+std::filesystem::path exePath();
 
 // get the absolute path
-std::string getExecPath();
+std::filesystem::path getExecPath();
 
 #ifdef _WIN32
 inline static int ctzll(uint64_t value) {

--- a/flow/include/flow/Platform.h
+++ b/flow/include/flow/Platform.h
@@ -330,7 +330,7 @@ bool directoryExists(std::filesystem::path const& path);
 int64_t fileSize(std::filesystem::path const& filename);
 
 // Returns last modified time of the file.
-time_t fileModifiedTime(const std::filesystem::path const& filename); // Maybe this should be const for extra protection?
+time_t fileModifiedTime(std::filesystem::path const& filename); // Maybe this should be const for extra protection?
 
 // Returns true if file is deleted, false if it was not found, throws platform_error() otherwise
 // Consider using IAsyncFileSystem::filesystem()->deleteFile() instead, especially if you need durability!
@@ -356,8 +356,6 @@ void writeFileBytes(std::filesystem::path const& filename, const uint8_t* data, 
 // Write text into file
 void writeFile(std::filesystem::path const& filename, std::string const& content);
 
-std::filesystem::path joinPath(std::filesystem::path const& directory, std::filesystem::path const& filename); 
-
 // cleanPath() does a 'logical' resolution of the given path string to a canonical form *without*
 // following symbolic links or verifying the existence of any path components.  It removes redundant
 // "." references and duplicate separators, and resolves any ".." references that can be resolved
@@ -377,7 +375,7 @@ std::filesystem::path cleanPath(std::filesystem::path const& path);
 //   /a/.
 //   /a/./
 //   /a//..//
-std::filesystem::path popPath(const std::filesystem::path& path);
+std::filesystem::path popPath(std::filesystem::path const& path);
 
 // abspath() resolves the given path to a canonical form.
 // If path is relative, the result will be based on the current working directory.

--- a/flow/include/flow/Platform.h
+++ b/flow/include/flow/Platform.h
@@ -340,7 +340,11 @@ bool deleteFile(std::filesystem::path const& path);
 void renameFile(std::filesystem::path const& fromPath, std::filesystem::path const& toPath);
 
 // Atomically replaces the contents of the specified file.
-void atomicReplace(std::filesystem::path const& path, std::string const& content, bool textmode = true); // Maybe the content should also be filesystem? Not sure if there's an alternative but there might be some security issues if we leave it as std::string. (Could be a victim of injection attacks)
+void atomicReplace(std::filesystem::path const& path,
+                   std::string const& content,
+                   bool textmode = true); // Maybe the content should also be filesystem? Not sure if there's an
+                                          // alternative but there might be some security issues if we leave it as
+                                          // std::string. (Could be a victim of injection attacks)
 
 // Read a file into memory
 // This requires the file to be seekable
@@ -392,10 +396,12 @@ std::filesystem::path abspath(std::filesystem::path const& path, bool resolveLin
 // with a single trailing path separator.
 // It uses absPath() with the same bool options to initially obtain a canonical form, and upon success
 // removes the final path component, if present.
-//std::filesystem::path parentDirectory(std::filesystem::path const& path, bool resolveLinks = true, bool mustExist = false); // This doesn't need to exist. Will commit this out to track references.
+// std::filesystem::path parentDirectory(std::filesystem::path const& path, bool resolveLinks = true, bool mustExist =
+// false); // This doesn't need to exist. Will commit this out to track references.
 
 // Returns the portion of the path following the last path separator (e.g. the filename or directory name)
-//std::string basename(std::string const& filename); // This doesn't need to exist. Will commit this out to track references.
+// std::string basename(std::string const& filename); // This doesn't need to exist. Will commit this out to track
+// references.
 
 // Returns the home directory of the current user
 std::string getUserHomeDirectory(); // Not sure if this needs to change.

--- a/flow/include/flow/Platform.h
+++ b/flow/include/flow/Platform.h
@@ -356,7 +356,7 @@ void writeFileBytes(std::filesystem::path const& filename, const uint8_t* data, 
 // Write text into file
 void writeFile(std::filesystem::path const& filename, std::string const& content);
 
-std::filesystem::path joinPath(std::filesystem::path const& directory, std::filesystem::path const& filename); // May not even exist tbh, because there's a function that prints out the filename canonical path 
+std::filesystem::path joinPath(std::filesystem::path const& directory, std::filesystem::path const& filename); 
 
 // cleanPath() does a 'logical' resolution of the given path string to a canonical form *without*
 // following symbolic links or verifying the existence of any path components.  It removes redundant

--- a/flow/include/flow/Traceable.h
+++ b/flow/include/flow/Traceable.h
@@ -83,7 +83,9 @@ struct Traceable : std::false_type {};
 #define FORMAT_TRACEABLE(type, fmt)                                                                                    \
 	template <>                                                                                                        \
 	struct Traceable<type> : std::true_type {                                                                          \
-		static std::string toString(type value) { return format(fmt, value); }                                         \
+		static std::string toString(type value) {                                                                      \
+			return format(fmt, value);                                                                                 \
+		}                                                                                                              \
 	}
 
 FORMAT_TRACEABLE(bool, "%d");
@@ -178,6 +180,11 @@ struct TraceableStringImpl : std::true_type {
 	static constexpr bool isPrintable(char c) { return 32 <= c && c <= 126; }
 
 	template <class Str>
+	static std::string toString(std::filesystem::path& value) {
+		return value.string();
+	}
+
+	template <class Str>
 	static std::string toString(Str&& value) {
 		// if all characters are printable ascii, we simply return the string
 		int nonPrintables = 0;
@@ -239,6 +246,8 @@ template <size_t S>
 struct Traceable<char[S]> : TraceableStringImpl<char[S]> {};
 template <>
 struct Traceable<std::string> : TraceableStringImpl<std::string> {};
+template <>
+struct Traceable<std::filesystem::path> : TraceableStringImpl<std::filesystem::path> {};
 template <>
 struct Traceable<std::string_view> : TraceableStringImpl<std::string_view> {};
 


### PR DESCRIPTION
Deprecate path manipulations and use `std::filesystem` as this is introduced in C++17

In reference: https://github.com/apple/foundationdb/issues/11443

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
