### PR TITLE
Fix errors when linking fdbserver on macOS due to boost::filesystem

### DIFF
--- a/fdbmonitor/fdbmonitor.h
+++ b/fdbmonitor/fdbmonitor.h
@@ -31,6 +31,7 @@
 #include <string>
 #include <sstream>
 #include <random>
+#include <unordered_map>
 #include <unordered_set>
 
 #ifdef __linux__

--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -18,12 +18,8 @@
  * limitations under the License.
  */
 
-#include <boost/algorithm/string/predicate.hpp>
-#include <boost/filesystem.hpp>
-#include <boost/filesystem/directory.hpp>
-#include <boost/filesystem/path.hpp>
-#include <boost/range/iterator_range_core.hpp>
 #include <cinttypes>
+#include <filesystem>
 #include <fstream>
 #include <functional>
 #include <istream>
@@ -2558,7 +2554,7 @@ void encryptionAtRestPlaintextMarkerCheck() {
 		return;
 	}
 
-	namespace fs = boost::filesystem;
+	namespace fs = std::filesystem;
 
 	printf("EncryptionAtRestPlaintextMarkerCheckStart\n");
 	TraceEvent("EncryptionAtRestPlaintextMarkerCheckStart");
@@ -2568,8 +2564,8 @@ void encryptionAtRestPlaintextMarkerCheck() {
 	bool success = true;
 	// Enumerate all files in the "simfdb/" folder and look for "marker" string
 	for (fs::recursive_directory_iterator itr(p); itr != end; ++itr) {
-		if (boost::filesystem::is_regular_file(itr->path())) {
-			std::ifstream f(itr->path().string().c_str());
+		if (fs::is_regular_file(itr->path())) {
+			std::ifstream f(itr->path());
 			if (f) {
 				std::string buf;
 				int count = 0;
@@ -3048,9 +3044,9 @@ ACTOR Future<Void> runTests(Reference<IClusterConnectionRecord> connRecord,
 			return Void();
 		}
 		enableClientInfoLogging(); // Enable Client Info logging by default for tester
-		if (boost::algorithm::ends_with(fileName, ".txt")) {
+		if (fileName.ends_with(".txt")) {
 			testSet.testSpecs = readTests(ifs);
-		} else if (boost::algorithm::ends_with(fileName, ".toml")) {
+		} else if (fileName.ends_with(".toml")) {
 			// TOML is weird about opening the file as binary on windows, so we
 			// just let TOML re-open the file instead of using ifs.
 			testSet = readTOMLTests(fileName);


### PR DESCRIPTION
Hi there,

This was one of the issues when compiling on macOS. See here: https://forums.foundationdb.org/t/building-on-macos/4491/3

This replaces `boost::filesystem` with `std::filesystem`.`std::filesystem::recursive_directory_iterator` is supported since C++17  and `std::string::ends_with` is since C++20. FoundationDB is configured to C++20.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
