### PR TITLE
Fix uninitialized bulkLoadMode

### DIFF
--- a/fdbserver/include/fdbserver/DataDistribution.actor.h
+++ b/fdbserver/include/fdbserver/DataDistribution.actor.h
@@ -496,7 +496,7 @@ struct InitialDataDistribution : ReferenceCounted<InitialDataDistribution> {
 	// Read from dataDistributionModeKey. Whether DD is disabled. DD can be disabled persistently (mode = 0). Set mode
 	// to 1 will enable all disabled parts
 	int mode;
-	int bulkLoadMode;
+	int bulkLoadMode = 0;
 	std::vector<std::pair<StorageServerInterface, ProcessClass>> allServers;
 	std::set<std::vector<UID>> primaryTeams;
 	std::set<std::vector<UID>> remoteTeams;


### PR DESCRIPTION
100K Correctness with 1 external timeout:
  20240809-181227-zhewang-d1ca44ea98a1392f           compressed=True data_size=37152430 duration=5869844 ended=100000 fail=1 fail_fast=10 max_runs=100000 pass=99999 priority=100 remaining=0 runtime=0:56:22 sanity=False started=100000 stopped=20240809-190849 submitted=20240809-181227 timeout=5400 username=zhewang

100K BulkLoading:  
  20240809-191033-zhewang-a6d9be6480a32fa6           compressed=True data_size=37185806 duration=10528867 ended=37929 fail=1 fail_fast=10 max_runs=100000 pass=37928 priority=100 remaining=1:51:30 runtime=1:08:08 sanity=False started=44063 submitted=20240809-191033 timeout=5400 username=zhewang
  
  
# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
