### PR TITLE
Add more trace events for exclude command [release-7.1]

### DIFF
--- a/fdbcli/Util.actor.cpp
+++ b/fdbcli/Util.actor.cpp
@@ -155,6 +155,7 @@ ACTOR Future<bool> getWorkers(Reference<IDatabase> db, std::vector<ProcessData>*
 
 			return true;
 		} catch (Error& e) {
+			TraceEvent(SevWarn, "GetWorkersError").error(e);
 			wait(safeThreadFutureToFuture(tr->onError(e)));
 		}
 	}
@@ -181,6 +182,7 @@ ACTOR Future<Void> getStorageServerInterfaces(Reference<IDatabase> db,
 			}
 			return Void();
 		} catch (Error& e) {
+			TraceEvent(SevWarn, "GetStorageServerInterfacesError").error(e);
 			wait(safeThreadFutureToFuture(tr->onError(e)));
 		}
 	}

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -835,9 +835,8 @@ ACTOR static Future<JsonBuilderObject> processStatusFetcher(
 	}
 
 	state std::vector<OldTLogConf>::const_iterator oldTLogIter;
-	for (oldTLogIter = db->get().logSystemConfig.oldTLogs.begin();
-	     oldTLogIter != db->get().logSystemConfig.oldTLogs.end();
-	     ++oldTLogIter) {
+	state std::vector<OldTLogConf> oldTLogs = db->get().logSystemConfig.oldTLogs;
+	for (oldTLogIter = oldTLogs.begin(); oldTLogIter != oldTLogs.end(); ++oldTLogIter) {
 		for (auto& tLogSet : oldTLogIter->tLogs) {
 			for (auto& it : tLogSet.tLogs) {
 				if (it.present()) {


### PR DESCRIPTION
Use PRIORITY_SYSTEM_IMMEDIATE for excludeServersAndLocalities() call.

Fixed a cluster controller crash bug in status server

cherrypick #11571 #11573

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
