### PR TITLE
Modify tlog unit tests to work with multiple tags

### DIFF
--- a/fdbserver/include/fdbserver/TestTLogServer.actor.h
+++ b/fdbserver/include/fdbserver/TestTLogServer.actor.h
@@ -46,7 +46,7 @@ struct TestTLogOptions {
 	std::string kvStoreExtension;
 	std::vector<Version> versions;
 	int64_t kvMemoryLimit;
-	int numTagsPerServer;
+	int numTags;
 	int numLogServers;
 	int numCommits;
 	int initVersion;
@@ -59,9 +59,9 @@ struct TestTLogOptions {
 		kvStoreFilename = params.get("kvStoreFilename").orDefault("kvstore");
 		dataFolder = params.get("dataFolder").orDefault("simfdb");
 		kvMemoryLimit = params.getDouble("kvMemoryLimit").orDefault(0x500e6);
-		numTagsPerServer = params.getInt("numTagsPerServer").orDefault(1);
+		numTags = params.getInt("numTags").orDefault(1);
 		numLogServers = params.getInt("numLogServers").orDefault(2);
-		numCommits = params.getInt("numCommits").orDefault(3);
+		numCommits = params.getInt("numCommits").orDefault(10);
 		initVersion = params.getInt("initVersion").orDefault(1);
 		recover = params.getInt("recover").orDefault(1);
 	}
@@ -107,7 +107,7 @@ struct TLogTestContext : NonCopyable, public ReferenceCounted<TLogTestContext> {
 	// paramaters
 	std::string diskQueueBasename;
 	int numCommits;
-	int numTagsPerServer;
+	int numTags;
 	int numLogServers;
 	int initVersion;
 	int recover;


### PR DESCRIPTION
Add support for multiple tags, to enable differentiating the number of commits per tLog.

20240813-205527-dlambrig-77d878858b487400

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
