### PR TITLE
Fix a cluster controller crash in status server

### DIFF
--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -874,9 +874,8 @@ ACTOR static Future<JsonBuilderObject> processStatusFetcher(
 	}
 
 	state std::vector<OldTLogConf>::const_iterator oldTLogIter;
-	for (oldTLogIter = db->get().logSystemConfig.oldTLogs.begin();
-	     oldTLogIter != db->get().logSystemConfig.oldTLogs.end();
-	     ++oldTLogIter) {
+	state std::vector<OldTLogConf> oldTLogs = db->get().logSystemConfig.oldTLogs;
+	for (oldTLogIter = oldTLogs.begin(); oldTLogIter != oldTLogs.end(); ++oldTLogIter) {
 		for (auto& tLogSet : oldTLogIter->tLogs) {
 			for (auto& it : tLogSet.tLogs) {
 				if (it.present()) {


### PR DESCRIPTION
The logSystemConfig could be changed after the yield(), thus the iterator can points to invalid memory.

To reproduce with gcc build at commit 3e90644779:
   -f tests/slow/DDBalanceAndRemoveStatus.toml -s 3134372275 -b off

20240814-041243-jzhou-19b95ae325eb46fb

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
