### PR TITLE
Fix warnings for long long or int64_t format specifiers by switching to fmt::print*

### DIFF
--- a/fdbcli/BulkLoadCommand.actor.cpp
+++ b/fdbcli/BulkLoadCommand.actor.cpp
@@ -18,6 +18,8 @@
  * limitations under the License.
  */
 
+#include <fmt/core.h>
+
 #include "fdbcli/fdbcli.actor.h"
 
 #include "fdbclient/IClientApi.h"
@@ -42,28 +44,28 @@ ACTOR Future<Void> getBulkLoadStateByRange(Database cx,
 		int64_t unfinishedCount = 0;
 		for (const auto& bulkLoadState : res) {
 			if (bulkLoadState.phase == BulkLoadPhase::Complete) {
-				printf("[Complete]: %s\n", bulkLoadState.toString().c_str());
+				fmt::println("[Complete]: {}", bulkLoadState.toString());
 				++finishCount;
 			} else if (bulkLoadState.phase == BulkLoadPhase::Running) {
-				printf("[Running]: %s\n", bulkLoadState.toString().c_str());
+				fmt::println("[Running]: {}", bulkLoadState.toString());
 				++unfinishedCount;
 			} else if (bulkLoadState.phase == BulkLoadPhase::Triggered) {
-				printf("[Triggered]: %s\n", bulkLoadState.toString().c_str());
+				fmt::println("[Triggered]: {}", bulkLoadState.toString());
 				++unfinishedCount;
 			} else if (bulkLoadState.phase == BulkLoadPhase::Submitted) {
-				printf("[Submitted] %s\n", bulkLoadState.toString().c_str());
+				fmt::println("[Submitted] {}", bulkLoadState.toString());
 				++unfinishedCount;
 			} else if (bulkLoadState.phase == BulkLoadPhase::Acknowledged) {
-				printf("[Acknowledge] %s\n", bulkLoadState.toString().c_str());
+				fmt::println("[Acknowledge] {}", bulkLoadState.toString());
 				++finishCount;
 			} else {
 				UNREACHABLE();
 			}
 		}
-		printf("Finished task count %ld of total %ld tasks\n", finishCount, finishCount + unfinishedCount);
+		fmt::println("Finished task count {} of total {} tasks", finishCount, finishCount + unfinishedCount);
 	} catch (Error& e) {
 		if (e.code() == error_code_timed_out) {
-			printf("timed out\n");
+			fmt::println("timed out");
 		}
 	}
 	return Void();


### PR DESCRIPTION
Probably not a big issue and not sure if anyone is running FDB on 32 bit, but this still helps to suppress perhaps unnecessary warnings.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
