### PR TITLE
Fix references to the wrong DB in the backup actor initialization.

### DIFF
--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -4187,10 +4187,10 @@ int main(int argc, char* argv[]) {
 				// enough for all cases to finish and 5 retries should also be good enough for
 				// most cases.
 				int64_t timeout = 60000;
-				sourceDB->setOption(FDBDatabaseOptions::TRANSACTION_TIMEOUT,
+				sourceDb->setOption(FDBDatabaseOptions::TRANSACTION_TIMEOUT,
 				              Optional<StringRef>(StringRef((const uint8_t*)&timeout, sizeof(timeout))));
 				int64_t retryLimit = 5;
-				sourceDB->setOption(FDBDatabaseOptions::TRANSACTION_RETRY_LIMIT,
+				sourceDb->setOption(FDBDatabaseOptions::TRANSACTION_RETRY_LIMIT,
 				              Optional<StringRef>(StringRef((const uint8_t*)&retryLimit, sizeof(retryLimit))));
 			}
 

--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -4187,10 +4187,10 @@ int main(int argc, char* argv[]) {
 				// enough for all cases to finish and 5 retries should also be good enough for
 				// most cases.
 				int64_t timeout = 60000;
-				db->setOption(FDBDatabaseOptions::TRANSACTION_TIMEOUT,
+				sourceDB->setOption(FDBDatabaseOptions::TRANSACTION_TIMEOUT,
 				              Optional<StringRef>(StringRef((const uint8_t*)&timeout, sizeof(timeout))));
 				int64_t retryLimit = 5;
-				db->setOption(FDBDatabaseOptions::TRANSACTION_RETRY_LIMIT,
+				sourceDB->setOption(FDBDatabaseOptions::TRANSACTION_RETRY_LIMIT,
 				              Optional<StringRef>(StringRef((const uint8_t*)&retryLimit, sizeof(retryLimit))));
 			}
 

--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -4188,10 +4188,10 @@ int main(int argc, char* argv[]) {
 				// most cases.
 				int64_t timeout = 60000;
 				sourceDb->setOption(FDBDatabaseOptions::TRANSACTION_TIMEOUT,
-				              Optional<StringRef>(StringRef((const uint8_t*)&timeout, sizeof(timeout))));
+				                    Optional<StringRef>(StringRef((const uint8_t*)&timeout, sizeof(timeout))));
 				int64_t retryLimit = 5;
 				sourceDb->setOption(FDBDatabaseOptions::TRANSACTION_RETRY_LIMIT,
-				              Optional<StringRef>(StringRef((const uint8_t*)&retryLimit, sizeof(retryLimit))));
+				                    Optional<StringRef>(StringRef((const uint8_t*)&retryLimit, sizeof(retryLimit))));
 			}
 
 			return result.present();


### PR DESCRIPTION
This fixes issues that were identified after #11575 was merged. The initialization section is meant to be setting up `sourceDb`, but it was updated in that PR to set up `db`.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
