### PR TITLE
[tutorial] Simplify connect() logic

### DIFF
--- a/documentation/tutorial/tutorial.actor.cpp
+++ b/documentation/tutorial/tutorial.actor.cpp
@@ -342,9 +342,8 @@ ACTOR Future<Void> kvStoreServer() {
 
 ACTOR Future<SimpleKeyValueStoreInterface> connect() {
 	std::cout << format("%llu: Connect...\n", uint64_t(g_network->now()));
-	SimpleKeyValueStoreInterface c;
-	c.connect = RequestStream<GetKVInterface>(Endpoint::wellKnown({ serverAddress }, WLTOKEN_SIMPLE_KV_SERVER));
-	SimpleKeyValueStoreInterface result = wait(c.connect.getReply(GetKVInterface()));
+	auto reqStream = RequestStream<GetKVInterface>(Endpoint::wellKnown({ serverAddress }, WLTOKEN_SIMPLE_KV_SERVER));
+	SimpleKeyValueStoreInterface result = wait(reqStream.getReply(GetKVInterface()));
 	std::cout << format("%llu: done..\n", uint64_t(g_network->now()));
 	return result;
 }


### PR DESCRIPTION
# Description

The client calls `connect` as part of bootstrapping the connection with the server and getting the `SimpleKeyValueStoreInterface` back. Right now, to make this call, we first create a temporary  `SimpleKeyValueStoreInterface` just to hold an inner `RequestStream`. As far as I can tell, this is not needed and was confusing me because to get a `SimpleKeyValueStoreInterface` from server, the client is itself creating a temporary `SimpleKeyValueStoreInterface` first. We can instead just create a `RequestStream` object directly without going through `SimpleKeyValueStoreInterface`. 


# Testing

Ran `kvSimpleClient` and `multipleClients` against `kvStoreServer`, ensured clients got expected responses. 

---

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
