### PR TITLE
Fix fdbbackup crashes [release-7.1]

### DIFF
--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -4103,10 +4103,12 @@ int main(int argc, char* argv[]) {
 				// where the fdbbackup command hangs infinitely. 60 seconds should be more than
 				// enough for all cases to finish and 5 retries should also be good enough for
 				// most cases.
+				int64_t timeout = 60000;
 				db->setOption(FDBDatabaseOptions::TRANSACTION_TIMEOUT,
-				              Optional<StringRef>(StringRef((const uint8_t*)60000, 8)));
+				              Optional<StringRef>(StringRef((const uint8_t*)&timeout, sizeof(timeout))));
+				int64_t retryLimit = 5;
 				db->setOption(FDBDatabaseOptions::TRANSACTION_RETRY_LIMIT,
-				              Optional<StringRef>(StringRef((const uint8_t*)5, 8)));
+				              Optional<StringRef>(StringRef((const uint8_t*)&retryLimit, sizeof(retryLimit))));
 			}
 
 			return result.present();
@@ -4127,10 +4129,12 @@ int main(int argc, char* argv[]) {
 				// where the fdbbackup command hangs infinitely. 60 seconds should be more than
 				// enough for all cases to finish and 5 retries should also be good enough for
 				// most cases.
-				sourceDb->setOption(FDBDatabaseOptions::TRANSACTION_TIMEOUT,
-				                    Optional<StringRef>(StringRef((const uint8_t*)60000, 8)));
-				sourceDb->setOption(FDBDatabaseOptions::TRANSACTION_RETRY_LIMIT,
-				                    Optional<StringRef>(StringRef((const uint8_t*)5, 8)));
+				int64_t timeout = 60000;
+				db->setOption(FDBDatabaseOptions::TRANSACTION_TIMEOUT,
+				              Optional<StringRef>(StringRef((const uint8_t*)&timeout, sizeof(timeout))));
+				int64_t retryLimit = 5;
+				db->setOption(FDBDatabaseOptions::TRANSACTION_RETRY_LIMIT,
+				              Optional<StringRef>(StringRef((const uint8_t*)&retryLimit, sizeof(retryLimit))));
 			}
 
 			return result.present();

--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -4130,11 +4130,11 @@ int main(int argc, char* argv[]) {
 				// enough for all cases to finish and 5 retries should also be good enough for
 				// most cases.
 				int64_t timeout = 60000;
-				db->setOption(FDBDatabaseOptions::TRANSACTION_TIMEOUT,
-				              Optional<StringRef>(StringRef((const uint8_t*)&timeout, sizeof(timeout))));
+				sourceDb->setOption(FDBDatabaseOptions::TRANSACTION_TIMEOUT,
+				                    Optional<StringRef>(StringRef((const uint8_t*)&timeout, sizeof(timeout))));
 				int64_t retryLimit = 5;
-				db->setOption(FDBDatabaseOptions::TRANSACTION_RETRY_LIMIT,
-				              Optional<StringRef>(StringRef((const uint8_t*)&retryLimit, sizeof(retryLimit))));
+				sourceDb->setOption(FDBDatabaseOptions::TRANSACTION_RETRY_LIMIT,
+				                    Optional<StringRef>(StringRef((const uint8_t*)&retryLimit, sizeof(retryLimit))));
 			}
 
 			return result.present();

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -2043,6 +2043,9 @@ void DatabaseContext::setOption(FDBDatabaseOptions::Option option, Optional<Stri
 	if (defaultFor >= 0) {
 		ASSERT(FDBTransactionOptions::optionInfo.find((FDBTransactionOptions::Option)defaultFor) !=
 		       FDBTransactionOptions::optionInfo.end());
+		TraceEvent(SevDebug, "DatabaseContextSetPersistentOption")
+			.detail("option", option)
+			.detail("value", value);
 		transactionDefaults.addOption((FDBTransactionOptions::Option)defaultFor, value.castTo<Standalone<StringRef>>());
 	} else {
 		switch (option) {

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -2043,7 +2043,7 @@ void DatabaseContext::setOption(FDBDatabaseOptions::Option option, Optional<Stri
 	if (defaultFor >= 0) {
 		ASSERT(FDBTransactionOptions::optionInfo.find((FDBTransactionOptions::Option)defaultFor) !=
 		       FDBTransactionOptions::optionInfo.end());
-		TraceEvent(SevDebug, "DatabaseContextSetPersistentOption").detail("option", option).detail("value", value);
+		TraceEvent(SevDebug, "DatabaseContextSetPersistentOption").detail("Option", option).detail("Value", value);
 		transactionDefaults.addOption((FDBTransactionOptions::Option)defaultFor, value.castTo<Standalone<StringRef>>());
 	} else {
 		switch (option) {

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -2043,9 +2043,7 @@ void DatabaseContext::setOption(FDBDatabaseOptions::Option option, Optional<Stri
 	if (defaultFor >= 0) {
 		ASSERT(FDBTransactionOptions::optionInfo.find((FDBTransactionOptions::Option)defaultFor) !=
 		       FDBTransactionOptions::optionInfo.end());
-		TraceEvent(SevDebug, "DatabaseContextSetPersistentOption")
-			.detail("option", option)
-			.detail("value", value);
+		TraceEvent(SevDebug, "DatabaseContextSetPersistentOption").detail("option", option).detail("value", value);
 		transactionDefaults.addOption((FDBTransactionOptions::Option)defaultFor, value.castTo<Standalone<StringRef>>());
 	} else {
 		switch (option) {

--- a/fdbclient/ReadYourWrites.actor.cpp
+++ b/fdbclient/ReadYourWrites.actor.cpp
@@ -2417,9 +2417,7 @@ void ReadYourWritesTransaction::setOption(FDBTransactionOptions::Option option, 
 }
 
 void ReadYourWritesTransaction::setOptionImpl(FDBTransactionOptions::Option option, Optional<StringRef> value) {
-	TraceEvent(SevDebug, "TransactionSetOption")
-		.detail("option", option)
-		.detail("value", value);
+	TraceEvent(SevDebug, "TransactionSetOption").detail("option", option).detail("value", value);
 	switch (option) {
 	case FDBTransactionOptions::READ_YOUR_WRITES_DISABLE:
 		validateOptionValueNotPresent(value);
@@ -2457,15 +2455,13 @@ void ReadYourWritesTransaction::setOptionImpl(FDBTransactionOptions::Option opti
 
 	case FDBTransactionOptions::TIMEOUT:
 		options.timeoutInSeconds = extractIntOption(value, 0, std::numeric_limits<int>::max()) / 1000.0;
-		TraceEvent(SevDebug, "TransactionTimeout")
-			.detail("timeoutInSeconds", options.timeoutInSeconds);
+		TraceEvent(SevDebug, "TransactionTimeout").detail("timeoutInSeconds", options.timeoutInSeconds);
 		resetTimeout();
 		break;
 
 	case FDBTransactionOptions::RETRY_LIMIT:
 		options.maxRetries = (int)extractIntOption(value, -1, std::numeric_limits<int>::max());
-		TraceEvent(SevDebug, "TransactionRetryLimit")
-			.detail("maxRetries", options.maxRetries);
+		TraceEvent(SevDebug, "TransactionRetryLimit").detail("maxRetries", options.maxRetries);
 		break;
 
 	case FDBTransactionOptions::DEBUG_RETRY_LOGGING:

--- a/fdbclient/ReadYourWrites.actor.cpp
+++ b/fdbclient/ReadYourWrites.actor.cpp
@@ -2417,7 +2417,7 @@ void ReadYourWritesTransaction::setOption(FDBTransactionOptions::Option option, 
 }
 
 void ReadYourWritesTransaction::setOptionImpl(FDBTransactionOptions::Option option, Optional<StringRef> value) {
-	TraceEvent(SevDebug, "TransactionSetOption").detail("option", option).detail("value", value);
+	TraceEvent(SevDebug, "TransactionSetOption").detail("Option", option).detail("Value", value);
 	switch (option) {
 	case FDBTransactionOptions::READ_YOUR_WRITES_DISABLE:
 		validateOptionValueNotPresent(value);
@@ -2455,13 +2455,13 @@ void ReadYourWritesTransaction::setOptionImpl(FDBTransactionOptions::Option opti
 
 	case FDBTransactionOptions::TIMEOUT:
 		options.timeoutInSeconds = extractIntOption(value, 0, std::numeric_limits<int>::max()) / 1000.0;
-		TraceEvent(SevDebug, "TransactionTimeout").detail("timeoutInSeconds", options.timeoutInSeconds);
+		TraceEvent(SevDebug, "TransactionTimeout").detail("TimeoutInSeconds", options.timeoutInSeconds);
 		resetTimeout();
 		break;
 
 	case FDBTransactionOptions::RETRY_LIMIT:
 		options.maxRetries = (int)extractIntOption(value, -1, std::numeric_limits<int>::max());
-		TraceEvent(SevDebug, "TransactionRetryLimit").detail("maxRetries", options.maxRetries);
+		TraceEvent(SevDebug, "TransactionRetryLimit").detail("MaxRetries", options.maxRetries);
 		break;
 
 	case FDBTransactionOptions::DEBUG_RETRY_LOGGING:

--- a/fdbclient/ReadYourWrites.actor.cpp
+++ b/fdbclient/ReadYourWrites.actor.cpp
@@ -2417,6 +2417,9 @@ void ReadYourWritesTransaction::setOption(FDBTransactionOptions::Option option, 
 }
 
 void ReadYourWritesTransaction::setOptionImpl(FDBTransactionOptions::Option option, Optional<StringRef> value) {
+	TraceEvent(SevDebug, "TransactionSetOption")
+		.detail("option", option)
+		.detail("value", value);
 	switch (option) {
 	case FDBTransactionOptions::READ_YOUR_WRITES_DISABLE:
 		validateOptionValueNotPresent(value);
@@ -2454,11 +2457,15 @@ void ReadYourWritesTransaction::setOptionImpl(FDBTransactionOptions::Option opti
 
 	case FDBTransactionOptions::TIMEOUT:
 		options.timeoutInSeconds = extractIntOption(value, 0, std::numeric_limits<int>::max()) / 1000.0;
+		TraceEvent(SevDebug, "TransactionTimeout")
+			.detail("timeoutInSeconds", options.timeoutInSeconds);
 		resetTimeout();
 		break;
 
 	case FDBTransactionOptions::RETRY_LIMIT:
 		options.maxRetries = (int)extractIntOption(value, -1, std::numeric_limits<int>::max());
+		TraceEvent(SevDebug, "TransactionRetryLimit")
+			.detail("maxRetries", options.maxRetries);
 		break;
 
 	case FDBTransactionOptions::DEBUG_RETRY_LOGGING:


### PR DESCRIPTION
the bug was introduced in #11403 and affects 7.1.60 and 7.1.61

cherrypick #11575 #11588


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
