### PR TITLE
Ignore FileNotFoundError when tearing down a temp cluster

### DIFF
--- a/tests/TestRunner/fake_cluster.py
+++ b/tests/TestRunner/fake_cluster.py
@@ -25,10 +25,10 @@ class ClusterFileGenerator:
         return self
 
     def __exit__(self, xc_type, exc_value, traceback):
-        shutil.rmtree(self.tmp_dir)
+        shutil.rmtree(self.tmp_dir, ignore_errors=True)
 
     def close(self):
-        shutil.rmtree(self.tmp_dir)
+        shutil.rmtree(self.tmp_dir, ignore_errors=True)
 
 
 if __name__ == "__main__":

--- a/tests/TestRunner/tmp_cluster.py
+++ b/tests/TestRunner/tmp_cluster.py
@@ -63,12 +63,12 @@ class TempCluster(LocalCluster):
     def __exit__(self, xc_type, exc_value, traceback):
         super().__exit__(xc_type, exc_value, traceback)
         if self.remove_at_exit:
-            shutil.rmtree(self.tmp_dir)
+            shutil.rmtree(self.tmp_dir, ignore_errors=True)
 
     def close(self):
         super().__exit__(None, None, None)
         if self.remove_at_exit:
-            shutil.rmtree(self.tmp_dir)
+            shutil.rmtree(self.tmp_dir, ignore_errors=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
ctest can fail with errors like:

[2024-08-22 20:37:15,780] - fdbcli_tests.py:231 - DEBUG - killall - Old generation: 8, New generation: 10 log-dir: /codebuild/output/src3881629096/src/github.com/apple/foundationdb/build_output/tmp/ZIpl2Hm2zri6nlpu/log etc-dir: /codebuild/output/src3881629096/src/github.com/apple/foundationdb/build_output/tmp/ZIpl2Hm2zri6nlpu/etc data-dir: /codebuild/output/src3881629096/src/github.com/apple/foundationdb/build_output/tmp/ZIpl2Hm2zri6nlpu/data cluster-file: /codebuild/output/src3881629096/src/github.com/apple/foundationdb/build_output/tmp/ZIpl2Hm2zri6nlpu/etc/fdb.cluster Traceback (most recent call last):
  File "/codebuild/output/src3881629096/src/github.com/apple/foundationdb/tests/TestRunner/tmp_cluster.py", line 146, in <module>
    print(f.read())
  File "/codebuild/output/src3881629096/src/github.com/apple/foundationdb/tests/TestRunner/tmp_cluster.py", line 45, in __exit__
    shutil.rmtree(self.tmp_dir)
  File "/opt/rh/rh-python38/root/usr/lib64/python3.8/shutil.py", line 718, in rmtree
    _rmtree_safe_fd(fd, path, onerror)
  File "/opt/rh/rh-python38/root/usr/lib64/python3.8/shutil.py", line 655, in _rmtree_safe_fd
    _rmtree_safe_fd(dirfd, fullname, onerror)
  File "/opt/rh/rh-python38/root/usr/lib64/python3.8/shutil.py", line 675, in _rmtree_safe_fd
    onerror(os.unlink, fullname, sys.exc_info())
  File "/opt/rh/rh-python38/root/usr/lib64/python3.8/shutil.py", line 673, in _rmtree_safe_fd
    os.unlink(entry.name, dir_fd=topfd)
FileNotFoundError: [Errno 2] No such file or directory: 'fdbmonitor.lock'

Replace this text with your description here...

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
