### PR TITLE
Cherry pick cluster level RV when tLogs advance at different rates (#11557)

### DIFF
--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -336,7 +336,7 @@ struct TLogData : NonCopyable {
 	int64_t overheadBytesInput;
 	int64_t overheadBytesDurable;
 	int activePeekStreams = 0;
-
+	Optional<Version> clusterRecoveryVersion;
 	WorkerCache<TLogInterface> tlogCache;
 	FlowLock peekMemoryLimiter;
 
@@ -1799,7 +1799,16 @@ Future<Void> tLogPeekMessages(PromiseType replyPromise,
 
 	state double blockStart = now();
 
-	if (reqReturnIfBlocked && logData->version.get() < reqBegin) {
+	// if tLog locked for recovery, return an empty message at the cluster recovery version
+	// if requested version is greater than any received.
+	state Optional<Version> clusterRecoveryVersion = Optional<Version>();
+	ASSERT(!clusterRecoveryVersion.present() || reqBegin <= clusterRecoveryVersion.get());
+	if (logData->stopped() && logData->version.get() < reqBegin && self->clusterRecoveryVersion.present()) {
+		clusterRecoveryVersion = self->clusterRecoveryVersion.get();
+		TraceEvent("TLogPeekMessagesClusterRecoveryVersion").detail("Version", clusterRecoveryVersion.get());
+	}
+
+	if (!clusterRecoveryVersion.present() && reqReturnIfBlocked && logData->version.get() < reqBegin) {
 		replyPromise.sendError(end_of_stream());
 		if (reqSequence.present()) {
 			auto& trackerData = logData->peekTracker[peekId];
@@ -1819,7 +1828,7 @@ Future<Void> tLogPeekMessages(PromiseType replyPromise,
 	    .detail("Version", logData->version.get())
 	    .detail("RecoveredAt", logData->recoveredAt);
 	// Wait until we have something to return that the caller doesn't already have
-	if (logData->version.get() < reqBegin) {
+	if (!clusterRecoveryVersion.present() && logData->version.get() < reqBegin) {
 		wait(logData->version.whenAtLeast(reqBegin));
 		wait(delay(SERVER_KNOBS->TLOG_PEEK_DELAY, g_network->getCurrentTask()));
 	}
@@ -2096,7 +2105,7 @@ Future<Void> tLogPeekMessages(PromiseType replyPromise,
 	auto messagesValue = messages.toValue();
 	reply.arena.dependsOn(messagesValue.arena());
 	reply.messages = messagesValue;
-	reply.end = endVersion;
+	reply.end = clusterRecoveryVersion.present() ? clusterRecoveryVersion.get() : endVersion;
 	reply.onlySpilled = onlySpilled;
 
 	DebugLogTraceEvent("TLogPeekMessages4", self->dbgid)
@@ -2344,7 +2353,6 @@ ACTOR Future<Void> tLogCommit(TLogData* self,
 	logData->minKnownCommittedVersion = std::max(logData->minKnownCommittedVersion, req.minKnownCommittedVersion);
 
 	wait(logData->version.whenAtLeast(req.prevVersion));
-
 	// Time until now has been spent waiting in the queue to do actual work.
 	state double queueWaitEndTime = g_network->timer();
 	self->queueWaitLatencyDist->sampleSeconds(queueWaitEndTime - req.requestTime());
@@ -2846,6 +2854,11 @@ ACTOR Future<Void> serveTLogInterface(TLogData* self,
 		}
 		when(TLogEnablePopRequest enablePopReq = waitNext(tli.enablePopRequest.getFuture())) {
 			logData->addActor.send(tLogEnablePopReq(enablePopReq, self, logData));
+		}
+		when(setClusterRecoveryVersionRequest req = waitNext(tli.setClusterRecoveryVersion.getFuture())) {
+			ASSERT(logData->stopped());
+			self->clusterRecoveryVersion = req.recoveryVersion;
+			req.reply.send(Void());
 		}
 	}
 }

--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -317,7 +317,10 @@ struct TLogData : NonCopyable {
 	                                // interface should work without directly accessing rawPersistentQueue
 	TLogQueue* persistentQueue; // Logical queue the log operates on and persist its data.
 
-	std::deque<std::tuple<Version, int>> unknownCommittedVersions;
+	// For each version above knownCommittedVersion, track:
+	// <Version, PrevVersion (that the sequencer provided), TLogs that the version has been sent to (the tLogs
+	//  are represented by their corresponding positions in "TagPartitionedLogSystem::tLogs")>
+	std::deque<std::tuple<Version, Version, std::vector<uint16_t>>> unknownCommittedVersions;
 
 	int64_t diskQueueCommitBytes;
 	AsyncVar<bool>
@@ -851,6 +854,7 @@ ACTOR Future<Void> tLogLock(TLogData* self, ReplyPromise<TLogLockResult> reply, 
 	result.knownCommittedVersion = logData->knownCommittedVersion;
 	result.unknownCommittedVersions = self->unknownCommittedVersions;
 	result.id = self->dbgid;
+	result.logId = logData->logId;
 
 	TraceEvent("TLogStop2", self->dbgid)
 	    .detail("LogId", logData->logId)
@@ -2405,11 +2409,13 @@ ACTOR Future<Void> tLogCommit(TLogData* self,
 		// Notifies the commitQueue actor to commit persistentQueue, and also unblocks tLogPeekMessages actors
 		logData->version.set(req.version);
 		if (SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST) {
-			self->unknownCommittedVersions.push_front(std::make_tuple(req.version, req.tLogCount));
+			self->unknownCommittedVersions.push_front(std::make_tuple(req.version, req.seqPrevVersion, req.tLogLocIds));
 			while (!self->unknownCommittedVersions.empty() &&
 			       std::get<0>(self->unknownCommittedVersions.back()) <= req.knownCommittedVersion) {
 				self->unknownCommittedVersions.pop_back();
 			}
+		} else {
+			ASSERT(req.prevVersion == req.seqPrevVersion); // @todo remove this assert later
 		}
 
 		if (req.debugID.present())

--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "fdbserver/TagPartitionedLogSystem.actor.h"
+#include <boost/dynamic_bitset.hpp>
 
 #include "flow/actorcompiler.h" // This must be the last #include.
 
@@ -557,9 +558,11 @@ Future<Version> TagPartitionedLogSystem::push(Version prevVersion,
 	std::vector<Future<Void>> quorumResults;
 	std::vector<Future<TLogCommitReply>> allReplies;
 	int location = 0;
+	Version seqPrevVersion = prevVersion; // prevVersion provided by the sequencer
 	Span span("TPLS:push"_loc, spanContext);
 
-	std::unordered_map<int, int> tLogCount;
+	std::unordered_map<uint8_t, uint16_t> tLogCount;
+	std::unordered_map<uint8_t, std::vector<uint16_t>> tLogLocIds;
 	if (SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST) {
 		int location = 0;
 		int logGroupLocal = 0;
@@ -570,6 +573,7 @@ Future<Version> TagPartitionedLogSystem::push(Version prevVersion,
 			for (int loc = 0; loc < it->logServers.size(); loc++) {
 				if (tpcvMap.get().find(location) != tpcvMap.get().end()) {
 					tLogCount[logGroupLocal]++;
+					tLogLocIds[logGroupLocal].push_back(location);
 				}
 				location++;
 			}
@@ -615,8 +619,10 @@ Future<Version> TagPartitionedLogSystem::push(Version prevVersion,
 				                                                                          version,
 				                                                                          knownCommittedVersion,
 				                                                                          minKnownCommittedVersion,
+				                                                                          seqPrevVersion,
 				                                                                          msg,
 				                                                                          tLogCount[logGroupLocal],
+				                                                                          tLogLocIds[logGroupLocal],
 				                                                                          debugID),
 				                                                        TaskPriority::ProxyTLogCommitReply)));
 				Future<Void> commitSuccess = success(allReplies.back());
@@ -2041,41 +2047,139 @@ ACTOR Future<Void> TagPartitionedLogSystem::getDurableVersionChanged(LogLockInfo
 	return Void();
 }
 
+<<<<<<< HEAD
 // If ENABLE_VERSION_VECTOR_TLOG_UNICAST is set, one tLog's DV may advance beyond the min(DV) over all tLogs.
+=======
+void getTLogLocIds(std::vector<Reference<LogSet>>& tLogs,
+                   std::vector<std::tuple<int, std::vector<TLogLockResult>>>& logGroupResults,
+                   std::vector<std::vector<uint16_t>>& tLogLocIds,
+                   uint16_t& maxTLogLocId) {
+	// Initialization.
+	tLogLocIds.clear();
+	tLogLocIds.resize(logGroupResults.size());
+	maxTLogLocId = 0;
+
+	// Map the interfaces of all (local) tLogs to their corresponding locations in LogSets.
+	std::map<UID, uint16_t> interfLocMap;
+	uint16_t location = 0;
+	for (auto& it : tLogs) {
+		if (!it->isLocal) {
+			continue;
+		}
+		for (uint16_t i = 0; i < it->logServers.size(); i++) {
+			interfLocMap[it->logServers[i]->get().interf().id()] = location++;
+		}
+	}
+
+	// Find the locations of tLogs in "logGroupResults".
+	uint8_t logGroupId = 0;
+	for (auto& logGroupResult : logGroupResults) {
+		for (auto& tLogResult : std::get<1>(logGroupResult)) {
+			ASSERT(interfLocMap.find(tLogResult.logId) != interfLocMap.end());
+			tLogLocIds[logGroupId].push_back(interfLocMap[tLogResult.logId]);
+			maxTLogLocId = std::max(maxTLogLocId, interfLocMap[tLogResult.logId]);
+		}
+		logGroupId++;
+	}
+}
+
+void populateBitset(boost::dynamic_bitset<>& bs, std::vector<uint16_t>& ids) {
+	for (auto& id : ids) {
+		bs.set(id);
+	}
+}
+
+// If VERSION_VECTOR_UNICAST is enabled, one tLog's DV may advance beyond the min(DV) over all tLogs.
+>>>>>>> 8803455e3 (Cherry-pick PR #11565 (Recovery version computation when version vector unicast is enabled) (#11590))
 // This function finds the highest recoverable version for each tLog group over all log groups.
 // All prior versions to the chosen RV must also be recoverable.
 // TODO: unit tests to stress UNICAST
-Version getRecoverVersionUnicast(std::vector<std::tuple<int, std::vector<TLogLockResult>>>& logGroupResults,
-                                 Version minEnd) {
+Version getRecoverVersionUnicast(std::vector<Reference<LogSet>>& logServers,
+                                 std::vector<std::tuple<int, std::vector<TLogLockResult>>>& logGroupResults,
+                                 Version minDVEnd,
+                                 Version minKCVEnd) {
+	std::vector<std::vector<uint16_t>> tLogLocIds;
+	uint16_t maxTLogLocId;
+	getTLogLocIds(logServers, logGroupResults, tLogLocIds, maxTLogLocId);
+	uint16_t bsSize = maxTLogLocId + 1; // bitset size, used below
+
+	// NOTE: We think the unicast recovery version is always greater than or equal to
+	// "min(DV)" (= "minDVEnd"). To be conservative we use "min(KCV)" (= "minKCVEnd")
+	// as the default (starting) recovery version and later verify that the computed
+	// recovery version is greater than or equal to "minDVEnd".
+	// @todo modify code to use "minDVEnd" as the default (starting) recovery version
+	Version minEnd = minKCVEnd;
+	std::vector<Version> RVs(maxTLogLocId + 1, minEnd); // recovery versions of various tLogs
+
+	uint8_t tLogGroupIdx = 0;
 	Version minLogGroup = std::numeric_limits<Version>::max();
 	for (auto& logGroupResult : logGroupResults) {
-		std::unordered_map<Version, int> versionRepCount;
-		std::map<Version, int> versionTLogCount;
+		uint16_t tLogIdx = 0;
+		boost::dynamic_bitset<> availableTLogs(bsSize);
+		// version -> tLogs (that are avaiable) that have received the version
+		std::unordered_map<Version, boost::dynamic_bitset<>> versionAvailableTLogs;
+		// version -> all tLogs that the version was sent to (by the commit proxy)
+		std::map<Version, boost::dynamic_bitset<>> versionAllTLogs;
+		// version -> prevVersion (that was given out by the sequencer) map
+		std::map<Version, Version> prevVersionMap;
 		int replicationFactor = std::get<0>(logGroupResult);
 		for (auto& tLogResult : std::get<1>(logGroupResult)) {
+			uint16_t tLogLocId = tLogLocIds[tLogGroupIdx][tLogIdx];
+			availableTLogs.set(tLogLocId);
 			bool logGroupCandidate = false;
 			for (auto& unknownCommittedVersion : tLogResult.unknownCommittedVersions) {
 				Version k = std::get<0>(unknownCommittedVersion);
 				if (k > minEnd) {
-					versionRepCount[k]++;
-					versionTLogCount[k] = std::get<1>(unknownCommittedVersion);
+					if (versionAvailableTLogs[k].empty()) {
+						versionAvailableTLogs[k].resize(bsSize);
+					}
+					versionAvailableTLogs[k].set(tLogLocId);
+					prevVersionMap[k] = std::get<1>(unknownCommittedVersion);
+					if (versionAllTLogs[k].empty()) {
+						versionAllTLogs[k].resize(bsSize);
+					}
+					populateBitset(versionAllTLogs[k], std::get<2>(unknownCommittedVersion));
 					logGroupCandidate = true;
 				}
 			}
 			if (!logGroupCandidate) {
 				return minEnd;
 			}
+			tLogIdx++;
 		}
 		Version minTLogs = minEnd;
-		for (auto const& [version, tLogCount] : versionTLogCount) {
-			if (versionRepCount[version] >= tLogCount - replicationFactor + 1) {
-				minTLogs = version;
-			} else {
+		Version prevVersion = minEnd;
+		for (auto const& [version, tLogs] : versionAllTLogs) {
+			if (!(prevVersion == minEnd || prevVersion == prevVersionMap[version])) {
 				break;
 			}
+			// This version is not recoverable if there is a log server (LS) such that:
+			// - the commit proxy sent this version to LS (i.e., LS is present in "versionAllTLogs[version]")
+			// - LS is available (i.e., LS is present in "availableTLogs")
+			// - LS didn't receive this version (i.e., LS is not present in "versionAvailableTLogs[version]")
+			if (((tLogs & availableTLogs) & ~versionAvailableTLogs[version]).any()) {
+				break;
+			}
+			// If the commit proxy sent this version to "N" log servers then at least
+			// (N - replicationFactor + 1) log servers must be available.
+			if (!(versionAvailableTLogs[version].size() >= tLogs.size() - replicationFactor + 1)) {
+				break;
+			}
+			// Update RV.
+			minTLogs = version;
+			// Update recovery version vector.
+			for (boost::dynamic_bitset<>::size_type id = 0; id < versionAvailableTLogs[version].size(); id++) {
+				if (versionAvailableTLogs[version][id]) {
+					RVs[id] = version;
+				}
+			}
+			// Update prevVersion.
+			prevVersion = version;
 		}
 		minLogGroup = std::min(minLogGroup, minTLogs);
+		tLogGroupIdx++;
 	}
+	ASSERT_WE_THINK(minLogGroup >= minDVEnd && minLogGroup != std::numeric_limits<Version>::max());
 	return minLogGroup;
 }
 
@@ -2340,6 +2444,7 @@ ACTOR Future<Void> TagPartitionedLogSystem::epochEnd(Reference<AsyncVar<Referenc
 	state Version knownCommittedVersion = 0;
 	loop {
 		Version minEnd = std::numeric_limits<Version>::max();
+		Version minKCVEnd = std::numeric_limits<Version>::max();
 		Version maxEnd = 0;
 		state std::vector<Future<Void>> changes;
 		state std::vector<std::tuple<int, std::vector<TLogLockResult>>> logGroupResults;
@@ -2354,6 +2459,7 @@ ACTOR Future<Void> TagPartitionedLogSystem::epochEnd(Reference<AsyncVar<Referenc
 				logGroupResults.emplace_back(logServers[log]->tLogReplicationFactor, std::get<2>(versions.get()));
 				maxEnd = std::max(maxEnd, std::get<1>(versions.get()));
 				minEnd = std::min(minEnd, std::get<1>(versions.get()));
+				minKCVEnd = std::min(minKCVEnd, std::get<0>(versions.get()));
 			}
 			changes.push_back(TagPartitionedLogSystem::getDurableVersionChanged(lockResults[log], logFailed[log]));
 		}

--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -2089,8 +2089,12 @@ void populateBitset(boost::dynamic_bitset<>& bs, std::vector<uint16_t>& ids) {
 	}
 }
 
+<<<<<<< HEAD
 // If VERSION_VECTOR_UNICAST is enabled, one tLog's DV may advance beyond the min(DV) over all tLogs.
 >>>>>>> 8803455e3 (Cherry-pick PR #11565 (Recovery version computation when version vector unicast is enabled) (#11590))
+=======
+// If ENABLE_VERSION_VECTOR_TLOG_UNICAST is set, one tLog's DV may advance beyond the min(DV) over all tLogs.
+>>>>>>> 2329628e5 (cluster level RV when tLogs advance at different rates (#11557))
 // This function finds the highest recoverable version for each tLog group over all log groups.
 // All prior versions to the chosen RV must also be recoverable.
 // TODO: unit tests to stress UNICAST
@@ -2470,7 +2474,6 @@ ACTOR Future<Void> TagPartitionedLogSystem::epochEnd(Reference<AsyncVar<Referenc
 			    makeReference<TagPartitionedLogSystem>(dbgid, locality, prevState.recoveryCount);
 
 			logSystem->recoverAt = minEnd;
-
 			lastEnd = minEnd;
 			logSystem->tLogs = logServers;
 			logSystem->logRouterTags = prevState.logRouterTags;

--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -2041,7 +2041,7 @@ ACTOR Future<Void> TagPartitionedLogSystem::getDurableVersionChanged(LogLockInfo
 	return Void();
 }
 
-// If VERSION_VECTOR_UNICAST is enabled, one tLog's DV may advance beyond the min(DV) over all tLogs.
+// If ENABLE_VERSION_VECTOR_TLOG_UNICAST is set, one tLog's DV may advance beyond the min(DV) over all tLogs.
 // This function finds the highest recoverable version for each tLog group over all log groups.
 // All prior versions to the chosen RV must also be recoverable.
 // TODO: unit tests to stress UNICAST
@@ -2214,6 +2214,7 @@ ACTOR Future<Void> TagPartitionedLogSystem::epochEnd(Reference<AsyncVar<Referenc
 	// trackRejoins listens for rejoin requests from the tLogs that we are recovering from, to learn their
 	// TLogInterfaces
 	state std::vector<LogLockInfo> lockResults;
+	state Reference<IdToInterf> lockResultsInterf = makeReference<IdToInterf>();
 	state std::vector<std::pair<Reference<AsyncVar<OptionalInterface<TLogInterface>>>, Reference<IReplicationPolicy>>>
 	    allLogServers;
 	state std::vector<Reference<LogSet>> logServers;
@@ -2255,7 +2256,8 @@ ACTOR Future<Void> TagPartitionedLogSystem::epochEnd(Reference<AsyncVar<Referenc
 		lockResults[i].isCurrent = true;
 		lockResults[i].logSet = logServers[i];
 		for (int t = 0; t < logServers[i]->logServers.size(); t++) {
-			lockResults[i].replies.push_back(TagPartitionedLogSystem::lockTLog(dbgid, logServers[i]->logServers[t]));
+			lockResults[i].replies.push_back(
+			    TagPartitionedLogSystem::lockTLog(dbgid, logServers[i]->logServers[t], lockResultsInterf));
 		}
 	}
 
@@ -2276,7 +2278,8 @@ ACTOR Future<Void> TagPartitionedLogSystem::epochEnd(Reference<AsyncVar<Referenc
 				lockResult.epochEnd = old.epochEnd;
 				lockResult.logSet = log;
 				for (int t = 0; t < log->logServers.size(); t++) {
-					lockResult.replies.push_back(TagPartitionedLogSystem::lockTLog(dbgid, log->logServers[t]));
+					lockResult.replies.push_back(
+					    TagPartitionedLogSystem::lockTLog(dbgid, log->logServers[t], lockResultsInterf));
 				}
 				lockResults.push_back(lockResult);
 			}
@@ -2292,7 +2295,8 @@ ACTOR Future<Void> TagPartitionedLogSystem::epochEnd(Reference<AsyncVar<Referenc
 			lockResult.epochEnd = old.epochEnd;
 			lockResult.logSet = old.tLogs[0];
 			for (int t = 0; t < old.tLogs[0]->logServers.size(); t++) {
-				lockResult.replies.push_back(TagPartitionedLogSystem::lockTLog(dbgid, old.tLogs[0]->logServers[t]));
+				lockResult.replies.push_back(
+				    TagPartitionedLogSystem::lockTLog(dbgid, old.tLogs[0]->logServers[t], lockResultsInterf));
 			}
 			allLockResults.push_back(lockResult);
 		}
@@ -2337,8 +2341,8 @@ ACTOR Future<Void> TagPartitionedLogSystem::epochEnd(Reference<AsyncVar<Referenc
 	loop {
 		Version minEnd = std::numeric_limits<Version>::max();
 		Version maxEnd = 0;
-		std::vector<Future<Void>> changes;
-		std::vector<std::tuple<int, std::vector<TLogLockResult>>> logGroupResults;
+		state std::vector<Future<Void>> changes;
+		state std::vector<std::tuple<int, std::vector<TLogLockResult>>> logGroupResults;
 		for (int log = 0; log < logServers.size(); log++) {
 			if (!logServers[log]->isLocal) {
 				continue;
@@ -2356,16 +2360,12 @@ ACTOR Future<Void> TagPartitionedLogSystem::epochEnd(Reference<AsyncVar<Referenc
 		if (maxEnd > 0 && (!lastEnd.present() || maxEnd < lastEnd.get())) {
 			CODE_PROBE(lastEnd.present(), "Restarting recovery at an earlier point");
 
-			auto logSystem = makeReference<TagPartitionedLogSystem>(dbgid, locality, prevState.recoveryCount);
+			state Reference<TagPartitionedLogSystem> logSystem =
+			    makeReference<TagPartitionedLogSystem>(dbgid, locality, prevState.recoveryCount);
 
 			logSystem->recoverAt = minEnd;
-			if (SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST) {
-				logSystem->recoverAt = getRecoverVersionUnicast(logGroupResults, minEnd);
-				TraceEvent("RecoveryVersionInfo").detail("RecoverAt", logSystem->recoverAt);
-			}
 
 			lastEnd = minEnd;
-
 			logSystem->tLogs = logServers;
 			logSystem->logRouterTags = prevState.logRouterTags;
 			logSystem->txsTags = prevState.txsTags;
@@ -2383,6 +2383,25 @@ ACTOR Future<Void> TagPartitionedLogSystem::epochEnd(Reference<AsyncVar<Referenc
 			logSystem->remoteLogsWrittenToCoreState = true;
 			logSystem->stopped = true;
 			logSystem->pseudoLocalities = prevState.pseudoLocalities;
+
+			if (SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST) {
+				logSystem->recoverAt = getRecoverVersionUnicast(logServers, logGroupResults, minEnd, minKCVEnd);
+				TraceEvent("RecoveryVersionInfo").detail("RecoverAt", logSystem->recoverAt);
+				// When a new log system is created, inform the surviving tLogs of the RV.
+				// SOMEDAY: Assert surviving tLogs use the RV from the latest log system.
+				for (auto logGroupResult : logGroupResults) {
+					state std::vector<TLogLockResult> tLogResults = std::get<1>(logGroupResult);
+					for (auto& tLogResult : tLogResults) {
+						wait(transformErrors(
+						    throwErrorOr(lockResultsInterf->lockInterf[tLogResult.id]
+						                     .setClusterRecoveryVersion.getReplyUnlessFailedFor(
+						                         setClusterRecoveryVersionRequest(logSystem->recoverAt.get()),
+						                         SERVER_KNOBS->TLOG_TIMEOUT,
+						                         SERVER_KNOBS->MASTER_FAILURE_SLOPE_DURING_RECOVERY)),
+						    cluster_recovery_failed()));
+					}
+				}
+			}
 
 			outLogSystem->set(logSystem);
 		}
@@ -3252,8 +3271,8 @@ ACTOR Future<Void> TagPartitionedLogSystem::trackRejoins(
 
 ACTOR Future<TLogLockResult> TagPartitionedLogSystem::lockTLog(
     UID myID,
-    Reference<AsyncVar<OptionalInterface<TLogInterface>>> tlog) {
-
+    Reference<AsyncVar<OptionalInterface<TLogInterface>>> tlog,
+    Optional<Reference<IdToInterf>> lockInterf) {
 	TraceEvent("TLogLockStarted", myID).detail("TLog", tlog->get().id()).detail("InfPresent", tlog->get().present());
 	loop {
 		choose {
@@ -3261,6 +3280,9 @@ ACTOR Future<TLogLockResult> TagPartitionedLogSystem::lockTLog(
 			         tlog->get().present() ? brokenPromiseToNever(tlog->get().interf().lock.getReply<TLogLockResult>())
 			                               : Never())) {
 				TraceEvent("TLogLocked", myID).detail("TLog", tlog->get().id()).detail("End", data.end);
+				if (lockInterf.present()) {
+					lockInterf.get()->lockInterf[tlog->get().id()] = tlog->get().interf();
+				}
 				return data;
 			}
 			when(wait(tlog->onChange())) {}

--- a/fdbserver/include/fdbserver/TLogInterface.h
+++ b/fdbserver/include/fdbserver/TLogInterface.h
@@ -141,12 +141,13 @@ struct TLogLockResult {
 	constexpr static FileIdentifier file_identifier = 11822027;
 	Version end;
 	Version knownCommittedVersion;
-	std::deque<std::tuple<Version, int>> unknownCommittedVersions;
-	UID id;
+	std::deque<std::tuple<Version, Version, std::vector<uint16_t>>> unknownCommittedVersions;
+	UID id; // captures TLogData::dbgid
+	UID logId; // captures LogData::logId
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, end, knownCommittedVersion, unknownCommittedVersions, id);
+		serializer(ar, end, knownCommittedVersion, unknownCommittedVersions, id, logId);
 	}
 };
 
@@ -307,12 +308,13 @@ struct TLogCommitRequest : TimedRequest {
 	constexpr static FileIdentifier file_identifier = 4022206;
 	SpanContext spanContext;
 	Arena arena;
-	Version prevVersion, version, knownCommittedVersion, minKnownCommittedVersion;
+	Version prevVersion, version, knownCommittedVersion, minKnownCommittedVersion, seqPrevVersion;
 
 	StringRef messages; // Each message prefixed by a 4-byte length
 
 	ReplyPromise<TLogCommitReply> reply;
-	int tLogCount;
+	uint16_t tLogCount;
+	std::vector<uint16_t> tLogLocIds;
 	Optional<UID> debugID;
 
 	TLogCommitRequest() {}
@@ -322,12 +324,15 @@ struct TLogCommitRequest : TimedRequest {
 	                  Version version,
 	                  Version knownCommittedVersion,
 	                  Version minKnownCommittedVersion,
+	                  Version seqPrevVersion,
 	                  StringRef messages,
-	                  int tLogCount,
+	                  uint16_t tLogCount,
+	                  std::vector<uint16_t>& tLogLocIds,
 	                  Optional<UID> debugID)
 	  : spanContext(context), arena(a), prevVersion(prevVersion), version(version),
 	    knownCommittedVersion(knownCommittedVersion), minKnownCommittedVersion(minKnownCommittedVersion),
-	    messages(messages), tLogCount(tLogCount), debugID(debugID) {}
+	    seqPrevVersion(seqPrevVersion), messages(messages), tLogCount(tLogCount), tLogLocIds(tLogLocIds),
+	    debugID(debugID) {}
 	template <class Ar>
 	void serialize(Ar& ar) {
 		serializer(ar,
@@ -335,10 +340,12 @@ struct TLogCommitRequest : TimedRequest {
 		           version,
 		           knownCommittedVersion,
 		           minKnownCommittedVersion,
+		           seqPrevVersion,
 		           messages,
 		           reply,
 		           debugID,
 		           tLogCount,
+		           tLogLocIds,
 		           spanContext,
 		           arena);
 	}

--- a/fdbserver/include/fdbserver/TLogInterface.h
+++ b/fdbserver/include/fdbserver/TLogInterface.h
@@ -53,6 +53,7 @@ struct TLogInterface {
 	RequestStream<struct TLogEnablePopRequest> enablePopRequest;
 	RequestStream<struct TLogSnapRequest> snapRequest;
 	RequestStream<struct TrackTLogRecoveryRequest> trackRecovery;
+	RequestStream<struct setClusterRecoveryVersionRequest> setClusterRecoveryVersion;
 
 	TLogInterface() {}
 	explicit TLogInterface(const LocalityData& locality)
@@ -87,6 +88,7 @@ struct TLogInterface {
 		streams.push_back(snapRequest.getReceiver());
 		streams.push_back(peekStreamMessages.getReceiver(TaskPriority::TLogPeek));
 		streams.push_back(trackRecovery.getReceiver());
+		streams.push_back(setClusterRecoveryVersion.getReceiver());
 		FlowTransport::transport().addEndpoints(streams);
 	}
 
@@ -117,6 +119,8 @@ struct TLogInterface {
 			    RequestStream<struct TLogPeekStreamRequest>(peekMessages.getEndpoint().getAdjustedEndpoint(11));
 			trackRecovery =
 			    RequestStream<struct TrackTLogRecoveryRequest>(peekMessages.getEndpoint().getAdjustedEndpoint(12));
+			setClusterRecoveryVersion = RequestStream<struct setClusterRecoveryVersionRequest>(
+			    peekMessages.getEndpoint().getAdjustedEndpoint(13));
 		}
 	}
 };
@@ -442,6 +446,21 @@ struct TrackTLogRecoveryRequest {
 	template <class Ar>
 	void serialize(Ar& ar) {
 		serializer(ar, oldestGenRecoverAtVersion, reply);
+	}
+};
+
+struct setClusterRecoveryVersionRequest {
+	constexpr static FileIdentifier file_identifier = 6876464;
+
+	Version recoveryVersion;
+	ReplyPromise<Void> reply;
+
+	setClusterRecoveryVersionRequest() = default;
+	setClusterRecoveryVersionRequest(Version recoveryVersion) : recoveryVersion(recoveryVersion) {}
+
+	template <class Ar>
+	void serialize(Ar& ar) {
+		serializer(ar, recoveryVersion, reply);
 	}
 };
 

--- a/fdbserver/include/fdbserver/TagPartitionedLogSystem.actor.h
+++ b/fdbserver/include/fdbserver/TagPartitionedLogSystem.actor.h
@@ -65,6 +65,10 @@ struct OldLogData {
 	}
 };
 
+struct IdToInterf : ReferenceCounted<IdToInterf> {
+	std::map<UID, TLogInterface> lockInterf;
+};
+
 struct LogLockInfo {
 	Version epochEnd;
 	bool isCurrent;
@@ -389,8 +393,10 @@ struct TagPartitionedLogSystem final : ILogSystem, ReferenceCounted<TagPartition
 	    std::vector<Reference<AsyncVar<OptionalInterface<TLogInterface>>>> tlogs,
 	    Reference<AsyncVar<Version>> recoveredVersion);
 
-	ACTOR static Future<TLogLockResult> lockTLog(UID myID, Reference<AsyncVar<OptionalInterface<TLogInterface>>> tlog);
-
+	ACTOR static Future<TLogLockResult> lockTLog(
+	    UID myID,
+	    Reference<AsyncVar<OptionalInterface<TLogInterface>>> tlog,
+	    Optional<Reference<IdToInterf>> lockInterf = Optional<Reference<IdToInterf>>());
 	template <class T>
 	static std::vector<T> getReadyNonError(std::vector<Future<T>> const& futures);
 };


### PR DESCRIPTION
cluster level RV when tLogs advance at different rates (#11557)

Joshua
20240823-183013-dlambrig-5f211de7fcaede76

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
