### PR TITLE
Cherry pick cluster level RV when tLogs advance at different rates (#11557)

### DIFF
--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -2086,7 +2086,7 @@ void populateBitset(boost::dynamic_bitset<>& bs, std::vector<uint16_t>& ids) {
 	}
 }
 
-// If VERSION_VECTOR_UNICAST is enabled, one tLog's DV may advance beyond the min(DV) over all tLogs.
+// If ENABLE_VERSION_VECTOR_TLOG_UNICAST is set, one tLog's DV may advance beyond the min(DV) over all tLogs.
 // This function finds the highest recoverable version for each tLog group over all log groups.
 // All prior versions to the chosen RV must also be recoverable.
 // TODO: unit tests to stress UNICAST
@@ -2314,6 +2314,7 @@ ACTOR Future<Void> TagPartitionedLogSystem::epochEnd(Reference<AsyncVar<Referenc
 	// trackRejoins listens for rejoin requests from the tLogs that we are recovering from, to learn their
 	// TLogInterfaces
 	state std::vector<LogLockInfo> lockResults;
+	state Reference<IdToInterf> lockResultsInterf = makeReference<IdToInterf>();
 	state std::vector<std::pair<Reference<AsyncVar<OptionalInterface<TLogInterface>>>, Reference<IReplicationPolicy>>>
 	    allLogServers;
 	state std::vector<Reference<LogSet>> logServers;
@@ -2355,7 +2356,8 @@ ACTOR Future<Void> TagPartitionedLogSystem::epochEnd(Reference<AsyncVar<Referenc
 		lockResults[i].isCurrent = true;
 		lockResults[i].logSet = logServers[i];
 		for (int t = 0; t < logServers[i]->logServers.size(); t++) {
-			lockResults[i].replies.push_back(TagPartitionedLogSystem::lockTLog(dbgid, logServers[i]->logServers[t]));
+			lockResults[i].replies.push_back(
+			    TagPartitionedLogSystem::lockTLog(dbgid, logServers[i]->logServers[t], lockResultsInterf));
 		}
 	}
 
@@ -2376,7 +2378,8 @@ ACTOR Future<Void> TagPartitionedLogSystem::epochEnd(Reference<AsyncVar<Referenc
 				lockResult.epochEnd = old.epochEnd;
 				lockResult.logSet = log;
 				for (int t = 0; t < log->logServers.size(); t++) {
-					lockResult.replies.push_back(TagPartitionedLogSystem::lockTLog(dbgid, log->logServers[t]));
+					lockResult.replies.push_back(
+					    TagPartitionedLogSystem::lockTLog(dbgid, log->logServers[t], lockResultsInterf));
 				}
 				lockResults.push_back(lockResult);
 			}
@@ -2392,7 +2395,8 @@ ACTOR Future<Void> TagPartitionedLogSystem::epochEnd(Reference<AsyncVar<Referenc
 			lockResult.epochEnd = old.epochEnd;
 			lockResult.logSet = old.tLogs[0];
 			for (int t = 0; t < old.tLogs[0]->logServers.size(); t++) {
-				lockResult.replies.push_back(TagPartitionedLogSystem::lockTLog(dbgid, old.tLogs[0]->logServers[t]));
+				lockResult.replies.push_back(
+				    TagPartitionedLogSystem::lockTLog(dbgid, old.tLogs[0]->logServers[t], lockResultsInterf));
 			}
 			allLockResults.push_back(lockResult);
 		}
@@ -2438,8 +2442,8 @@ ACTOR Future<Void> TagPartitionedLogSystem::epochEnd(Reference<AsyncVar<Referenc
 		Version minEnd = std::numeric_limits<Version>::max();
 		Version minKCVEnd = std::numeric_limits<Version>::max();
 		Version maxEnd = 0;
-		std::vector<Future<Void>> changes;
-		std::vector<std::tuple<int, std::vector<TLogLockResult>>> logGroupResults;
+		state std::vector<Future<Void>> changes;
+		state std::vector<std::tuple<int, std::vector<TLogLockResult>>> logGroupResults;
 		for (int log = 0; log < logServers.size(); log++) {
 			if (!logServers[log]->isLocal) {
 				continue;
@@ -2458,16 +2462,11 @@ ACTOR Future<Void> TagPartitionedLogSystem::epochEnd(Reference<AsyncVar<Referenc
 		if (maxEnd > 0 && (!lastEnd.present() || maxEnd < lastEnd.get())) {
 			CODE_PROBE(lastEnd.present(), "Restarting recovery at an earlier point");
 
-			auto logSystem = makeReference<TagPartitionedLogSystem>(dbgid, locality, prevState.recoveryCount);
+			state Reference<TagPartitionedLogSystem> logSystem =
+			    makeReference<TagPartitionedLogSystem>(dbgid, locality, prevState.recoveryCount);
 
 			logSystem->recoverAt = minEnd;
-			if (SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST) {
-				logSystem->recoverAt = getRecoverVersionUnicast(logServers, logGroupResults, minEnd, minKCVEnd);
-				TraceEvent("RecoveryVersionInfo").detail("RecoverAt", logSystem->recoverAt);
-			}
-
 			lastEnd = minEnd;
-
 			logSystem->tLogs = logServers;
 			logSystem->logRouterTags = prevState.logRouterTags;
 			logSystem->txsTags = prevState.txsTags;
@@ -2485,6 +2484,25 @@ ACTOR Future<Void> TagPartitionedLogSystem::epochEnd(Reference<AsyncVar<Referenc
 			logSystem->remoteLogsWrittenToCoreState = true;
 			logSystem->stopped = true;
 			logSystem->pseudoLocalities = prevState.pseudoLocalities;
+
+			if (SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST) {
+				logSystem->recoverAt = getRecoverVersionUnicast(logServers, logGroupResults, minEnd, minKCVEnd);
+				TraceEvent("RecoveryVersionInfo").detail("RecoverAt", logSystem->recoverAt);
+				// When a new log system is created, inform the surviving tLogs of the RV.
+				// SOMEDAY: Assert surviving tLogs use the RV from the latest log system.
+				for (auto logGroupResult : logGroupResults) {
+					state std::vector<TLogLockResult> tLogResults = std::get<1>(logGroupResult);
+					for (auto& tLogResult : tLogResults) {
+						wait(transformErrors(
+						    throwErrorOr(lockResultsInterf->lockInterf[tLogResult.id]
+						                     .setClusterRecoveryVersion.getReplyUnlessFailedFor(
+						                         setClusterRecoveryVersionRequest(logSystem->recoverAt.get()),
+						                         SERVER_KNOBS->TLOG_TIMEOUT,
+						                         SERVER_KNOBS->MASTER_FAILURE_SLOPE_DURING_RECOVERY)),
+						    cluster_recovery_failed()));
+					}
+				}
+			}
 
 			outLogSystem->set(logSystem);
 		}
@@ -3354,8 +3372,8 @@ ACTOR Future<Void> TagPartitionedLogSystem::trackRejoins(
 
 ACTOR Future<TLogLockResult> TagPartitionedLogSystem::lockTLog(
     UID myID,
-    Reference<AsyncVar<OptionalInterface<TLogInterface>>> tlog) {
-
+    Reference<AsyncVar<OptionalInterface<TLogInterface>>> tlog,
+    Optional<Reference<IdToInterf>> lockInterf) {
 	TraceEvent("TLogLockStarted", myID).detail("TLog", tlog->get().id()).detail("InfPresent", tlog->get().present());
 	loop {
 		choose {
@@ -3363,6 +3381,9 @@ ACTOR Future<TLogLockResult> TagPartitionedLogSystem::lockTLog(
 			         tlog->get().present() ? brokenPromiseToNever(tlog->get().interf().lock.getReply<TLogLockResult>())
 			                               : Never())) {
 				TraceEvent("TLogLocked", myID).detail("TLog", tlog->get().id()).detail("End", data.end);
+				if (lockInterf.present()) {
+					lockInterf.get()->lockInterf[tlog->get().id()] = tlog->get().interf();
+				}
 				return data;
 			}
 			when(wait(tlog->onChange())) {}

--- a/fdbserver/include/fdbserver/TLogInterface.h
+++ b/fdbserver/include/fdbserver/TLogInterface.h
@@ -53,6 +53,7 @@ struct TLogInterface {
 	RequestStream<struct TLogEnablePopRequest> enablePopRequest;
 	RequestStream<struct TLogSnapRequest> snapRequest;
 	RequestStream<struct TrackTLogRecoveryRequest> trackRecovery;
+	RequestStream<struct setClusterRecoveryVersionRequest> setClusterRecoveryVersion;
 
 	TLogInterface() {}
 	explicit TLogInterface(const LocalityData& locality)
@@ -87,6 +88,7 @@ struct TLogInterface {
 		streams.push_back(snapRequest.getReceiver());
 		streams.push_back(peekStreamMessages.getReceiver(TaskPriority::TLogPeek));
 		streams.push_back(trackRecovery.getReceiver());
+		streams.push_back(setClusterRecoveryVersion.getReceiver());
 		FlowTransport::transport().addEndpoints(streams);
 	}
 
@@ -117,6 +119,8 @@ struct TLogInterface {
 			    RequestStream<struct TLogPeekStreamRequest>(peekMessages.getEndpoint().getAdjustedEndpoint(11));
 			trackRecovery =
 			    RequestStream<struct TrackTLogRecoveryRequest>(peekMessages.getEndpoint().getAdjustedEndpoint(12));
+			setClusterRecoveryVersion = RequestStream<struct setClusterRecoveryVersionRequest>(
+			    peekMessages.getEndpoint().getAdjustedEndpoint(13));
 		}
 	}
 };
@@ -449,6 +453,21 @@ struct TrackTLogRecoveryRequest {
 	template <class Ar>
 	void serialize(Ar& ar) {
 		serializer(ar, oldestGenRecoverAtVersion, reply);
+	}
+};
+
+struct setClusterRecoveryVersionRequest {
+	constexpr static FileIdentifier file_identifier = 6876464;
+
+	Version recoveryVersion;
+	ReplyPromise<Void> reply;
+
+	setClusterRecoveryVersionRequest() = default;
+	setClusterRecoveryVersionRequest(Version recoveryVersion) : recoveryVersion(recoveryVersion) {}
+
+	template <class Ar>
+	void serialize(Ar& ar) {
+		serializer(ar, recoveryVersion, reply);
 	}
 };
 

--- a/fdbserver/include/fdbserver/TagPartitionedLogSystem.actor.h
+++ b/fdbserver/include/fdbserver/TagPartitionedLogSystem.actor.h
@@ -65,6 +65,10 @@ struct OldLogData {
 	}
 };
 
+struct IdToInterf : ReferenceCounted<IdToInterf> {
+	std::map<UID, TLogInterface> lockInterf;
+};
+
 struct LogLockInfo {
 	Version epochEnd;
 	bool isCurrent;
@@ -389,8 +393,10 @@ struct TagPartitionedLogSystem final : ILogSystem, ReferenceCounted<TagPartition
 	    std::vector<Reference<AsyncVar<OptionalInterface<TLogInterface>>>> tlogs,
 	    Reference<AsyncVar<Version>> recoveredVersion);
 
-	ACTOR static Future<TLogLockResult> lockTLog(UID myID, Reference<AsyncVar<OptionalInterface<TLogInterface>>> tlog);
-
+	ACTOR static Future<TLogLockResult> lockTLog(
+	    UID myID,
+	    Reference<AsyncVar<OptionalInterface<TLogInterface>>> tlog,
+	    Optional<Reference<IdToInterf>> lockInterf = Optional<Reference<IdToInterf>>());
 	template <class T>
 	static std::vector<T> getReadyNonError(std::vector<Future<T>> const& futures);
 };


### PR DESCRIPTION
Part of version vector recovery.
Cherry pick cluster level RV when tLogs advance at different rates (#11557)

* simulate more than one tlog

* Draft use cluster RV for tlogs in version vector

* add TestTLogRecovery2

* Respond to review comments

* Add assert

* Send clusterRV to all locked tlogs

* Fix typo on rebase

* add memory managed IdToInterf structure

---------

Joshua
20240823-184245-dlambrig-f51e257379a9b2cf

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [x] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
