### PR TITLE
Refactor LogRouter and Watch workload using coroutines

### DIFF
--- a/design/coroutines.md
+++ b/design/coroutines.md
@@ -100,7 +100,7 @@ co_await Choose()
     })
     .When(foo(), [](Foo const& f) {
         // do something else
-    }).Run();
+    }).run();
 ```
 
 While `Choose` and `choose` behave very similarly, there are some minor differences between

--- a/design/coroutines.md
+++ b/design/coroutines.md
@@ -589,16 +589,16 @@ Luckily, with coroutines, we can do one better: generalize the retry loop. The a
 
 ```c++
 co_await db.run([&](ReadYourWritesTransaction* tr) -> Future<Void> {
-    Value v = wait(tr.get(key));
-    tr.set(key2, val2);
-    wait(tr.commit());
+    Value v = wait(tr->get(key));
+    tr->set(key2, val2);
+    wait(tr->commit());
 });
 ```
 
 A possible implementation of `Database::run` would be:
 
 ```c++
-template <std:invocable<ReadYourWritesTransaction*> Fun>
+template <std::invocable<ReadYourWritesTransaction*> Fun>
 Future<Void> Database::run(Fun fun) {
     ReadYourWritesTransaction tr(*this);
     Future<Void> onError;
@@ -609,6 +609,7 @@ Future<Void> Database::run(Fun fun) {
         }
         try {
             co_await fun(&tr);
+            co_return;
         } catch (Error& e) {
             onError = tr.onError(e);
         }

--- a/fdbclient/include/fdbclient/NativeAPI.actor.h
+++ b/fdbclient/include/fdbclient/NativeAPI.actor.h
@@ -119,6 +119,9 @@ public:
 
 	const UniqueOrderedOptionList<FDBTransactionOptions>& getTransactionDefaults() const;
 
+	template <std::invocable<Transaction*> Fun>
+	Future<Void> run(Fun fun);
+
 private:
 	Reference<DatabaseContext> db;
 };
@@ -577,6 +580,24 @@ private:
 	Promise<Void> commitResult;
 	Future<Void> committing;
 };
+
+template <std::invocable<Transaction*> Fun>
+Future<Void> Database::run(Fun fun) {
+	Transaction tr(*this);
+	Future<Void> onError;
+	while (true) {
+		if (onError.isValid()) {
+			co_await onError;
+			onError = Future<Void>();
+		}
+		try {
+			co_await fun(&tr);
+			co_return;
+		} catch (Error& e) {
+			onError = tr.onError(e);
+		}
+	}
+}
 
 ACTOR Future<Version> waitForCommittedVersion(Database cx, Version version, SpanContext spanContext);
 ACTOR Future<Standalone<VectorRef<DDMetricsRef>>> waitDataDistributionMetricsList(Database cx,

--- a/fdbrpc/include/fdbrpc/fdbrpc.h
+++ b/fdbrpc/include/fdbrpc/fdbrpc.h
@@ -605,7 +605,7 @@ public:
 
 	// Must be called on the server before using a ReplyPromiseStream to limit the amount of outstanding bytes to the
 	// client
-	void setByteLimit(int64_t byteLimit) { queue->acknowledgements.bytesLimit = byteLimit; }
+	void setByteLimit(int64_t byteLimit) const { queue->acknowledgements.bytesLimit = byteLimit; }
 
 	void operator=(const ReplyPromiseStream& rhs) {
 		rhs.queue->addPromiseRef();

--- a/fdbserver/LogRouter.cpp
+++ b/fdbserver/LogRouter.cpp
@@ -226,7 +226,7 @@ struct LogRouterData {
 	                                   Optional<std::pair<UID, int>> reqSequence = Optional<std::pair<UID, int>>());
 
 	// Keeps pushing TLogPeekStreamReply until it's removed from the cluster or should recover
-	Future<Void> logRouterPeekStream(const TLogPeekStreamRequest& req);
+	Future<Void> logRouterPeekStream(TLogPeekStreamRequest req);
 
 	// Log router (LR) asynchronously pull data from satellite tLogs (preferred) or primary tLogs at tag
 	// (self->routerTag) for the version range from the LR's current version (exclusive) to its epoch's end version or
@@ -696,7 +696,7 @@ Future<Void> LogRouterData::logRouterPeekMessages(PromiseType replyPromise,
 	    .detail("PoppedVersion", poppedVersion);
 }
 
-Future<Void> LogRouterData::logRouterPeekStream(const TLogPeekStreamRequest& req) {
+Future<Void> LogRouterData::logRouterPeekStream(TLogPeekStreamRequest req) {
 	activePeekStreams++;
 
 	Version begin = req.begin;

--- a/fdbserver/include/fdbserver/WorkerInterface.actor.h
+++ b/fdbserver/include/fdbserver/WorkerInterface.actor.h
@@ -1274,9 +1274,9 @@ ACTOR Future<Void> tLog(IKeyValueStore* persistentData,
 ACTOR Future<Void> resolver(ResolverInterface resolver,
                             InitializeResolverRequest initReq,
                             Reference<AsyncVar<ServerDBInfo> const> db);
-ACTOR Future<Void> logRouter(TLogInterface interf,
-                             InitializeLogRouterRequest req,
-                             Reference<AsyncVar<ServerDBInfo> const> db);
+Future<Void> logRouter(TLogInterface interf,
+                       InitializeLogRouterRequest req,
+                       Reference<AsyncVar<ServerDBInfo> const> db);
 Future<Void> dataDistributor(DataDistributorInterface ddi, Reference<AsyncVar<ServerDBInfo> const> db);
 ACTOR Future<Void> ratekeeper(RatekeeperInterface rki, Reference<AsyncVar<ServerDBInfo> const> db);
 ACTOR Future<Void> consistencyScan(ConsistencyScanInterface csInterf, Reference<AsyncVar<ServerDBInfo> const> dbInfo);

--- a/fdbserver/workloads/Watches.actor.cpp
+++ b/fdbserver/workloads/Watches.actor.cpp
@@ -21,6 +21,8 @@
 #include "fdbrpc/DDSketch.h"
 #include "fdbclient/NativeAPI.actor.h"
 #include "fdbserver/TesterInterface.actor.h"
+#include "flow/CodeProbe.h"
+#include "flow/Coroutines.h"
 #include "flow/DeterministicRandom.h"
 #include "fdbserver/workloads/workloads.actor.h"
 #include "flow/actorcompiler.h" // This must be the last #include.
@@ -47,7 +49,22 @@ struct WatchesWorkload : TestWorkload {
 		tempRand.randomShuffle(nodeOrder);
 	}
 
-	Future<Void> setup(Database const& cx) override { return _setup(cx, this); }
+	Future<Void> setup(Database const& cx) override {
+		// return _setup(cx, this);
+		std::vector<Future<Void>> setupActors;
+		for (int i = 0; i < nodes; i++)
+			if (i % clientCount == clientId)
+				setupActors.push_back(
+				    watcherInit(cx, keyForIndex(nodeOrder[i]), keyForIndex(nodeOrder[i + 1]), extraPerNode));
+
+		co_await waitForAll(setupActors);
+
+		for (int i = 0; i < nodes; i++)
+			if (i % clientCount == clientId)
+				clients.push_back(watcher(cx, keyForIndex(nodeOrder[i]), keyForIndex(nodeOrder[i + 1]), extraPerNode));
+
+		co_return;
+	}
 
 	Future<Void> start(Database const& cx) override {
 		if (clientId == 0)
@@ -82,47 +99,22 @@ struct WatchesWorkload : TestWorkload {
 		return result;
 	}
 
-	ACTOR Future<Void> _setup(Database cx, WatchesWorkload* self) {
-		std::vector<Future<Void>> setupActors;
-		for (int i = 0; i < self->nodes; i++)
-			if (i % self->clientCount == self->clientId)
-				setupActors.push_back(self->watcherInit(cx,
-				                                        self->keyForIndex(self->nodeOrder[i]),
-				                                        self->keyForIndex(self->nodeOrder[i + 1]),
-				                                        self->extraPerNode));
-
-		wait(waitForAll(setupActors));
-
-		for (int i = 0; i < self->nodes; i++)
-			if (i % self->clientCount == self->clientId)
-				self->clients.push_back(self->watcher(cx,
-				                                      self->keyForIndex(self->nodeOrder[i]),
-				                                      self->keyForIndex(self->nodeOrder[i + 1]),
-				                                      self->extraPerNode));
-
-		return Void();
-	}
-
-	ACTOR static Future<Void> watcherInit(Database cx, Key watchKey, Key setKey, int extraNodes) {
-		state Transaction tr(cx);
-		state int extraLoc = 0;
+	Future<Void> watcherInit(Database cx, Key watchKey, Key setKey, int extraNodes) {
+		int extraLoc = 0;
 		while (extraLoc < extraNodes) {
-			try {
+			co_await cx.run([&](Transaction* tr) -> Future<Void> {
 				for (int i = 0; i < 1000 && extraLoc + i < extraNodes; i++) {
 					Key extraKey = KeyRef(watchKey.toString() + format("%d", extraLoc + i));
 					Value extraValue = ValueRef(std::string(100, '.'));
-					tr.set(extraKey, extraValue);
-					//TraceEvent("WatcherInitialSetupExtra").detail("Key", printable(extraKey)).detail("Value", printable(extraValue));
+					tr->set(extraKey, extraValue);
+					// TraceEvent("WatcherInitialSetupExtra").detail("Key", extraKey).detail("Value", extraValue);
 				}
-				wait(tr.commit());
+				co_await tr->commit();
 				extraLoc += 1000;
-				//TraceEvent("WatcherInitialSetup").detail("Watch", printable(watchKey)).detail("Ver", tr.getCommittedVersion());
-			} catch (Error& e) {
-				//TraceEvent("WatcherInitialSetupError").error(e).detail("ExtraLoc", extraLoc);
-				wait(tr.onError(e));
-			}
+				CODE_PROBE(true, "Watches workload initial setup");
+				// TraceEvent("WatcherInitialSetup").detail("Watch", watchKey).detail("Ver", tr->getCommittedVersion());
+			});
 		}
-		return Void();
 	}
 
 	ACTOR static Future<Void> watcher(Database cx, Key watchKey, Key setKey, int extraNodes) {
@@ -177,87 +169,76 @@ struct WatchesWorkload : TestWorkload {
 		}
 	}
 
-	ACTOR static Future<Void> watchesWorker(Database cx, WatchesWorkload* self) {
-		state Key startKey = self->keyForIndex(self->nodeOrder[0]);
-		state Key endKey = self->keyForIndex(self->nodeOrder[self->nodes]);
-		state Optional<Value> expectedValue;
-		state Optional<Value> startValue;
-		state double startTime = now();
-		state double chainStartTime;
+	Future<Void> watchesWorker(Database cx, WatchesWorkload* self) {
+		Key startKey = self->keyForIndex(self->nodeOrder[0]);
+		Key endKey = self->keyForIndex(self->nodeOrder[self->nodes]);
+		Optional<Value> expectedValue;
+		Optional<Value> startValue;
+		double startTime = now();
+		double chainStartTime;
 		loop {
-			state Transaction tr(cx);
-			state bool isValue = deterministicRandom()->random01() > 0.5;
-			state Value assignedValue = Value(deterministicRandom()->randomUniqueID().toString());
-			state bool firstAttempt = true;
-			loop {
-				try {
-					wait(success(tr.getReadVersion()));
-					Optional<Value> _startValue = wait(tr.get(startKey));
-					if (firstAttempt) {
-						startValue = _startValue;
-						firstAttempt = false;
-					}
-					expectedValue = Optional<Value>();
-					if (startValue.present()) {
-						if (isValue)
-							expectedValue = assignedValue;
-					} else
-						expectedValue = assignedValue;
-
-					if (expectedValue.present())
-						tr.set(startKey, expectedValue.get());
-					else
-						tr.clear(startKey);
-
-					wait(tr.commit());
-					break;
-				} catch (Error& e) {
-					wait(tr.onError(e));
+			bool isValue = deterministicRandom()->random01() > 0.5;
+			Value assignedValue = Value(deterministicRandom()->randomUniqueID().toString());
+			bool firstAttempt = true;
+			co_await cx.run([&](Transaction* tr) -> Future<Void> {
+				co_await tr->getReadVersion();
+				Optional<Value> _startValue = co_await tr->get(startKey);
+				if (firstAttempt) {
+					startValue = _startValue;
+					firstAttempt = false;
 				}
-			}
+				expectedValue = Optional<Value>();
+				if (startValue.present()) {
+					if (isValue)
+						expectedValue = assignedValue;
+				} else
+					expectedValue = assignedValue;
+
+				if (expectedValue.present())
+					tr->set(startKey, expectedValue.get());
+				else
+					tr->clear(startKey);
+
+				co_await tr->commit();
+				CODE_PROBE(expectedValue.present(), "watches workload set a key");
+				CODE_PROBE(!expectedValue.present(), "watches workload clear a key");
+				co_return;
+			});
 
 			chainStartTime = now();
 			firstAttempt = true;
-			loop {
-				state Transaction tr2(cx);
-				state bool finished = false;
-				loop {
-					try {
-						state Optional<Value> endValue = wait(tr2.get(endKey));
-						if (endValue == expectedValue) {
-							finished = true;
-							break;
-						}
-						if (!firstAttempt || endValue != startValue) {
-							TraceEvent(SevError, "WatcherError")
-							    .detail("FirstAttempt", firstAttempt)
-							    .detail("StartValue", printable(startValue))
-							    .detail("EndValue", printable(endValue))
-							    .detail("ExpectedValue", printable(expectedValue))
-							    .detail("EndVersion", tr2.getReadVersion().get());
-						}
-						state Future<Void> watchFuture = tr2.watch(makeReference<Watch>(endKey, startValue));
-						wait(tr2.commit());
-						wait(watchFuture);
-						firstAttempt = false;
-						break;
-					} catch (Error& e) {
-						wait(tr2.onError(e));
+			bool finished = false;
+			while (!finished) {
+				co_await cx.run([&](Transaction* tr2) -> Future<Void> {
+					Optional<Value> endValue = co_await tr2->get(endKey);
+					if (endValue == expectedValue) {
+						finished = true;
+						co_return;
 					}
-				}
-				if (finished)
-					break;
+					if (!firstAttempt || endValue != startValue) {
+						TraceEvent(SevError, "WatcherError")
+						    .detail("FirstAttempt", firstAttempt)
+						    .detail("StartValue", printable(startValue))
+						    .detail("EndValue", printable(endValue))
+						    .detail("ExpectedValue", printable(expectedValue))
+						    .detail("EndVersion", tr2->getReadVersion().get());
+					}
+					Future<Void> watchFuture = tr2->watch(makeReference<Watch>(endKey, startValue));
+					co_await tr2->commit();
+					co_await watchFuture;
+					CODE_PROBE(true, "watcher workload watch fired");
+					firstAttempt = false;
+				});
 			}
 			self->cycleLatencies.addSample(now() - chainStartTime);
 			++self->cycles;
 
 			if (g_network->isSimulated())
-				wait(delay(deterministicRandom()->random01() < 0.5 ? 0 : deterministicRandom()->random01() * 60));
+				co_await delay(deterministicRandom()->random01() < 0.5 ? 0 : deterministicRandom()->random01() * 60);
 
 			if (now() - startTime > self->testDuration)
 				break;
 		}
-		return Void();
 	}
 };
 


### PR DESCRIPTION
20240824-010621-jzhou-ab2df94b5f043c18

The watches workload has one actor left, which is not easy to do without introducing some ugly workaround. Specifically,
```
				} catch (Error& e) {
					if (tr != nullptr) {
						wait(tr->onError(e));
					}
				}
```
This piece of code is the one, not easy to be replaced with a `db.run()` call.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
