### PR TITLE
Stash correct id for tlog identification in recovery

### DIFF
--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -3423,7 +3423,7 @@ ACTOR Future<TLogLockResult> TagPartitionedLogSystem::lockTLog(
 			                               : Never())) {
 				TraceEvent("TLogLocked", myID).detail("TLog", tlog->get().id()).detail("End", data.end);
 				if (lockInterf.present()) {
-					lockInterf.get()->lockInterf[tlog->get().id()] = tlog->get().interf();
+					lockInterf.get()->lockInterf[data.id] = tlog->get().interf();
 				}
 				return data;
 			}


### PR DESCRIPTION
Stash correct id for tlog identification in recovery

(prior, the one associated with the interface did not match the dbgid returned on the lock call, resulting in a failed lookup [here](https://github.com/apple/foundationdb/blob/8475ad87bb68eb2bca99dfc8db462115ac4acf15/fdbserver/TagPartitionedLogSystem.actor.cpp#L2538))

Joshua
`20240826-181851-dlambrig-4ff8b42f5a49e024`

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
