### PR TITLE
Fix overflow

### DIFF
--- a/fdbserver/workloads/ClientMetric.actor.cpp
+++ b/fdbserver/workloads/ClientMetric.actor.cpp
@@ -174,7 +174,7 @@ struct ClientMetricWorkload : TestWorkload {
 	ACTOR Future<uint64_t> writeKeysAndGetLatencyVersion(Database cx,
 	                                                     ClientMetricWorkload* self,
 	                                                     int numKeys,
-	                                                     int previousVS) {
+	                                                     uint64_t previousVS) {
 		state int retry = 0;
 		state int max_retry = 10;
 		state int keysLimit = 1;


### PR DESCRIPTION
uint64_t should be used instead of int

```
Read from globalconfig: rate=0.010000 size=3621340
VersionStamp is 2181719979
vs1=2181719979
writeRandomKeys finish, written=136
Read from globalconfig: rate=0.010000 size=3621340
VersionStamp is 2284603078
Assertion vs >= previousVS failed @ /root/src/foundationdb/fdbserver/workloads/ClientMetric.actor.cpp 199:
```
reproduced the issue, and 2181719979 is overflow

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
