### PR TITLE
Cherry pick:  Stash correct id for tlog idenfication in recovery (#11604)

### DIFF
--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -3384,7 +3384,7 @@ ACTOR Future<TLogLockResult> TagPartitionedLogSystem::lockTLog(
 			                               : Never())) {
 				TraceEvent("TLogLocked", myID).detail("TLog", tlog->get().id()).detail("End", data.end);
 				if (lockInterf.present()) {
-					lockInterf.get()->lockInterf[tlog->get().id()] = tlog->get().interf();
+					lockInterf.get()->lockInterf[data.id] = tlog->get().interf();
 				}
 				return data;
 			}


### PR DESCRIPTION
Cherry pick:  Stash correct id for tlog idenfication in recovery (#11604)

Joshua:
`20240826-220057-dlambrig-0c4f65e71f1c3e33`

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [x] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [x] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
