### PR TITLE
Go binding: fix bug with R/O transaction destroyed before futures, add GC references for db/tx

### DIFF
--- a/bindings/go/src/fdb/database.go
+++ b/bindings/go/src/fdb/database.go
@@ -89,15 +89,6 @@ func (opt DatabaseOptions) setOpt(code int, param []byte) error {
 // automatically creating and committing a transaction with appropriate retry
 // behavior.
 func (d Database) CreateTransaction() (Transaction, error) {
-	tr, err := d.createTransaction(true)
-	if err != nil {
-		return Transaction{}, err
-	}
-
-	return tr, nil
-}
-
-func (d Database) createTransaction(setFinalizer bool) (Transaction, error) {
 	var outt *C.FDBTransaction
 
 	if err := C.fdb_database_create_transaction(d.ptr, &outt); err != 0 {
@@ -105,9 +96,10 @@ func (d Database) createTransaction(setFinalizer bool) (Transaction, error) {
 	}
 
 	t := &transaction{outt, d}
-	if setFinalizer {
-		runtime.SetFinalizer(t, (*transaction).destroy)
-	}
+	// transactions cannot be destroyed explicitly if any future is still potentially used
+	// thus the GC is used to figure out when all Go wrapper objects for futures have gone out of scope,
+	// making the transaction ready to be garbage-collected.
+	runtime.SetFinalizer(t, (*transaction).destroy)
 
 	return Transaction{t}, nil
 }
@@ -119,13 +111,16 @@ func (d Database) createTransaction(setFinalizer bool) (Transaction, error) {
 // process address is the form of IP:Port pair.
 func (d Database) RebootWorker(address string, checkFile bool, suspendDuration int) error {
 	t := &futureInt64{
-		future: newFuture(C.fdb_database_reboot_worker(
-			d.ptr,
-			byteSliceToPtr([]byte(address)),
-			C.int(len(address)),
-			C.fdb_bool_t(boolToInt(checkFile)),
-			C.int(suspendDuration),
-		),
+		future: newFutureWithDb(
+			d.database,
+			nil,
+			C.fdb_database_reboot_worker(
+				d.ptr,
+				byteSliceToPtr([]byte(address)),
+				C.int(len(address)),
+				C.fdb_bool_t(boolToInt(checkFile)),
+				C.int(suspendDuration),
+			),
 		),
 	}
 
@@ -229,19 +224,19 @@ func (d Database) Transact(f func(Transaction) (interface{}, error)) (interface{
 // See the ReadTransactor interface for an example of using ReadTransact with
 // Transaction, Snapshot and Database objects.
 func (d Database) ReadTransact(f func(ReadTransaction) (interface{}, error)) (interface{}, error) {
-	tr, e := d.createTransaction(false)
-	// Any error here is non-retryable
+	tr, e := d.CreateTransaction()
 	if e != nil {
+		// Any error here is non-retryable
 		return nil, e
 	}
-	defer tr.transaction.destroy()
 
 	wrapped := func() (ret interface{}, e error) {
 		defer panicToError(&e)
 
 		ret, e = f(tr)
 
-		// read-only transactions are not committed and destroyed automatically on exit
+		// read-only transactions are not committed and will be destroyed automatically via GC,
+		// once all the futures go out of scope
 
 		return
 	}

--- a/bindings/go/src/fdb/fdb_test.go
+++ b/bindings/go/src/fdb/fdb_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 
 	"github.com/apple/foundationdb/bindings/go/src/fdb"
+	"github.com/apple/foundationdb/bindings/go/src/fdb/subspace"
 )
 
 const API_VERSION int = 740
@@ -101,6 +102,26 @@ func TestVersionstamp(t *testing.T) {
 	}
 	t.Log(k)
 	t.Logf("setOne returned %s", k)
+}
+
+func TestEstimatedRangeSize(t *testing.T) {
+	fdb.MustAPIVersion(API_VERSION)
+	db := fdb.MustOpenDefault()
+
+	var f fdb.FutureInt64
+	_, e := db.ReadTransact(func(rtr fdb.ReadTransaction) (interface{}, error) {
+		f = rtr.GetEstimatedRangeSizeBytes(subspace.AllKeys())
+
+		return nil, nil
+	})
+	if e != nil {
+		t.Error(e)
+	}
+
+	_, e = f.Get()
+	if e != nil {
+		t.Error(e)
+	}
 }
 
 func TestReadTransactionOptions(t *testing.T) {

--- a/bindings/go/src/fdb/transaction.go
+++ b/bindings/go/src/fdb/transaction.go
@@ -191,7 +191,7 @@ func (t Transaction) Snapshot() Snapshot {
 // OnError internally to implement a correct retry loop.
 func (t Transaction) OnError(e Error) FutureNil {
 	return &futureNil{
-		future: newFuture(C.fdb_transaction_on_error(t.ptr, C.fdb_error_t(e.Code))),
+		future: newFuture(t.transaction, C.fdb_transaction_on_error(t.ptr, C.fdb_error_t(e.Code))),
 	}
 }
 
@@ -207,7 +207,7 @@ func (t Transaction) OnError(e Error) FutureNil {
 // https://apple.github.io/foundationdb/developer-guide.html#transactions-with-unknown-results.
 func (t Transaction) Commit() FutureNil {
 	return &futureNil{
-		future: newFuture(C.fdb_transaction_commit(t.ptr)),
+		future: newFuture(t.transaction, C.fdb_transaction_commit(t.ptr)),
 	}
 }
 
@@ -243,13 +243,13 @@ func (t Transaction) Commit() FutureNil {
 func (t Transaction) Watch(key KeyConvertible) FutureNil {
 	kb := key.FDBKey()
 	return &futureNil{
-		future: newFuture(C.fdb_transaction_watch(t.ptr, byteSliceToPtr(kb), C.int(len(kb)))),
+		future: newFuture(t.transaction, C.fdb_transaction_watch(t.ptr, byteSliceToPtr(kb), C.int(len(kb)))),
 	}
 }
 
 func (t *transaction) get(key []byte, snapshot int) FutureByteSlice {
 	return &futureByteSlice{
-		future: newFuture(C.fdb_transaction_get(
+		future: newFuture(t, C.fdb_transaction_get(
 			t.ptr,
 			byteSliceToPtr(key),
 			C.int(len(key)),
@@ -273,7 +273,7 @@ func (t *transaction) doGetRange(r Range, options RangeOptions, snapshot bool, i
 	ekey := esel.Key.FDBKey()
 
 	return futureKeyValueArray{
-		future: newFuture(C.fdb_transaction_get_range(
+		future: newFuture(t, C.fdb_transaction_get_range(
 			t.ptr,
 			byteSliceToPtr(bkey),
 			C.int(len(bkey)),
@@ -315,7 +315,7 @@ func (t Transaction) GetRange(r Range, options RangeOptions) RangeResult {
 
 func (t *transaction) getEstimatedRangeSizeBytes(beginKey Key, endKey Key) FutureInt64 {
 	return &futureInt64{
-		future: newFuture(C.fdb_transaction_get_estimated_range_size_bytes(
+		future: newFuture(t, C.fdb_transaction_get_estimated_range_size_bytes(
 			t.ptr,
 			byteSliceToPtr(beginKey),
 			C.int(len(beginKey)),
@@ -343,7 +343,7 @@ func (t Transaction) GetEstimatedRangeSizeBytes(r ExactRange) FutureInt64 {
 
 func (t *transaction) getRangeSplitPoints(beginKey Key, endKey Key, chunkSize int64) FutureKeyArray {
 	return &futureKeyArray{
-		future: newFuture(C.fdb_transaction_get_range_split_points(
+		future: newFuture(t, C.fdb_transaction_get_range_split_points(
 			t.ptr,
 			byteSliceToPtr(beginKey),
 			C.int(len(beginKey)),
@@ -368,7 +368,7 @@ func (t Transaction) GetRangeSplitPoints(r ExactRange, chunkSize int64) FutureKe
 
 func (t *transaction) getReadVersion() FutureInt64 {
 	return &futureInt64{
-		future: newFuture(C.fdb_transaction_get_read_version(t.ptr)),
+		future: newFuture(t, C.fdb_transaction_get_read_version(t.ptr)),
 	}
 }
 
@@ -435,12 +435,12 @@ func (t Transaction) GetCommittedVersion() (int64, error) {
 // mind that a transaction which reads keys and then sets them to their current
 // values may be optimized to a read-only transaction.
 func (t Transaction) GetVersionstamp() FutureKey {
-	return &futureKey{future: newFuture(C.fdb_transaction_get_versionstamp(t.ptr))}
+	return &futureKey{future: newFuture(t.transaction, C.fdb_transaction_get_versionstamp(t.ptr))}
 }
 
 func (t *transaction) getApproximateSize() FutureInt64 {
 	return &futureInt64{
-		future: newFuture(C.fdb_transaction_get_approximate_size(t.ptr)),
+		future: newFuture(t, C.fdb_transaction_get_approximate_size(t.ptr)),
 	}
 }
 
@@ -468,7 +468,7 @@ func boolToInt(b bool) int {
 func (t *transaction) getKey(sel KeySelector, snapshot int) FutureKey {
 	key := sel.Key.FDBKey()
 	return &futureKey{
-		future: newFuture(C.fdb_transaction_get_key(
+		future: newFuture(t, C.fdb_transaction_get_key(
 			t.ptr,
 			byteSliceToPtr(key),
 			C.int(len(key)),
@@ -587,7 +587,7 @@ func (t Transaction) Options() TransactionOptions {
 func localityGetAddressesForKey(t *transaction, key KeyConvertible) FutureStringSlice {
 	kb := key.FDBKey()
 	return &futureStringSlice{
-		future: newFuture(C.fdb_transaction_get_addresses_for_key(
+		future: newFuture(t, C.fdb_transaction_get_addresses_for_key(
 			t.ptr,
 			byteSliceToPtr(kb),
 			C.int(len(kb)),


### PR DESCRIPTION
Fix bug with R/O transaction destroyed before futures, add GC references for db/tx

In a [previous PR](https://github.com/apple/foundationdb/pull/11366) the R/O transaction was optimized and the finalizer was removed; however this prevents using any future, since transaction is already destroyed by the time future is attempted evaluation.

Additionally, a new issue is uncovered and addressed: the Go Database, Transaction and Future objects are all garbage-collected independently, which is incorrect because Database and Transaction must not be garbage-collected if any future has not yet been garbage-collected.

A test has been added to verify that futures work right after their creation within a `ReadTransact` call.

# Code-Reviewer Section

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
