### PR TITLE
Go binding: allow cancelling snapshots and R/O transactions

### DIFF
--- a/bindings/go/src/fdb/snapshot.go
+++ b/bindings/go/src/fdb/snapshot.go
@@ -53,6 +53,12 @@ func (s Snapshot) ReadTransact(f func(ReadTransaction) (interface{}, error)) (r 
 	return
 }
 
+// Cancel cancels the underlying transaction of the snapshot.
+// See Transaction.Cancel() for more information.
+func (s Snapshot) Cancel() {
+	s.transaction.cancel()
+}
+
 // Snapshot returns the receiver and allows Snapshot to satisfy the
 // ReadTransaction interface.
 func (s Snapshot) Snapshot() Snapshot {

--- a/bindings/go/src/fdb/transaction.go
+++ b/bindings/go/src/fdb/transaction.go
@@ -42,6 +42,7 @@ type ReadTransaction interface {
 	GetEstimatedRangeSizeBytes(r ExactRange) FutureInt64
 	GetRangeSplitPoints(r ExactRange, chunkSize int64) FutureKeyArray
 	Options() TransactionOptions
+	Cancel()
 
 	ReadTransactor
 }
@@ -89,6 +90,10 @@ func (opt TransactionOptions) setOpt(code int, param []byte) error {
 
 func (t *transaction) destroy() {
 	C.fdb_transaction_destroy(t.ptr)
+}
+
+func (t *transaction) cancel() {
+	C.fdb_transaction_cancel(t.ptr)
 }
 
 // GetDatabase returns a handle to the database with which this transaction is
@@ -155,7 +160,7 @@ func (t Transaction) ReadTransact(f func(ReadTransaction) (interface{}, error)) 
 // error, the commit may have occurred or may occur in the future. This can make
 // it more difficult to reason about the order in which transactions occur.
 func (t Transaction) Cancel() {
-	C.fdb_transaction_cancel(t.ptr)
+	t.transaction.cancel()
 }
 
 // (Infrequently used) SetReadVersion sets the database version that the transaction will read from


### PR DESCRIPTION
Allow cancelling snapshots and R/O transactions.

It is beneficial to cancel a transaction, even if not performing any changes, so that futures and other associated resources can be released early.

# Code-Reviewer Section

- [x] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
