### PR TITLE
use 32 bits to track locations in unicast recovery

### DIFF
--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -320,7 +320,7 @@ struct TLogData : NonCopyable {
 	// For each version above knownCommittedVersion, track:
 	// <Version, PrevVersion (that the sequencer provided), TLogs that the version has been sent to (the tLogs
 	//  are represented by their corresponding positions in "TagPartitionedLogSystem::tLogs")>
-	std::deque<std::tuple<Version, Version, std::vector<uint16_t>>> unknownCommittedVersions;
+	std::deque<std::tuple<Version, Version, std::vector<uint32_t>>> unknownCommittedVersions;
 
 	int64_t diskQueueCommitBytes;
 	AsyncVar<bool>

--- a/fdbserver/include/fdbserver/TLogInterface.h
+++ b/fdbserver/include/fdbserver/TLogInterface.h
@@ -141,7 +141,7 @@ struct TLogLockResult {
 	constexpr static FileIdentifier file_identifier = 11822027;
 	Version end;
 	Version knownCommittedVersion;
-	std::deque<std::tuple<Version, Version, std::vector<uint16_t>>> unknownCommittedVersions;
+	std::deque<std::tuple<Version, Version, std::vector<uint32_t>>> unknownCommittedVersions;
 	UID id; // captures TLogData::dbgid
 	UID logId; // captures LogData::logId
 
@@ -314,7 +314,7 @@ struct TLogCommitRequest : TimedRequest {
 
 	ReplyPromise<TLogCommitReply> reply;
 	uint16_t tLogCount;
-	std::vector<uint16_t> tLogLocIds;
+	std::vector<uint32_t> tLogLocIds;
 	Optional<UID> debugID;
 
 	TLogCommitRequest() {}
@@ -327,7 +327,7 @@ struct TLogCommitRequest : TimedRequest {
 	                  Version seqPrevVersion,
 	                  StringRef messages,
 	                  uint16_t tLogCount,
-	                  std::vector<uint16_t>& tLogLocIds,
+	                  std::vector<uint32_t>& tLogLocIds,
 	                  Optional<UID> debugID)
 	  : spanContext(context), arena(a), prevVersion(prevVersion), version(version),
 	    knownCommittedVersion(knownCommittedVersion), minKnownCommittedVersion(minKnownCommittedVersion),


### PR DESCRIPTION
use 32 bits to track locations in unicast recovery.

Joshua
20240828-122820-dlambrig-3d79d34cfe382cb3

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
