### PR TITLE
refactor to use struct rather than tuple for "uncommitedVersions"

### DIFF
--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -2165,17 +2165,17 @@ Version getRecoverVersionUnicast(std::vector<Reference<LogSet>>& logServers,
 			availableTLogs.set(tLogLocId);
 			bool logGroupCandidate = false;
 			for (auto& unknownCommittedVersion : tLogResult.unknownCommittedVersions) {
-				Version k = std::get<0>(unknownCommittedVersion);
+				Version k = unknownCommittedVersion.version;
 				if (k > minEnd) {
 					if (versionAvailableTLogs[k].empty()) {
 						versionAvailableTLogs[k].resize(bsSize);
 					}
 					versionAvailableTLogs[k].set(tLogLocId);
-					prevVersionMap[k] = std::get<1>(unknownCommittedVersion);
+					prevVersionMap[k] = unknownCommittedVersion.prev;
 					if (versionAllTLogs[k].empty()) {
 						versionAllTLogs[k].resize(bsSize);
 					}
-					populateBitset(versionAllTLogs[k], std::get<2>(unknownCommittedVersion));
+					populateBitset(versionAllTLogs[k], unknownCommittedVersion.tLogLocIds);
 					logGroupCandidate = true;
 				}
 			}

--- a/fdbserver/include/fdbserver/TLogInterface.h
+++ b/fdbserver/include/fdbserver/TLogInterface.h
@@ -137,11 +137,25 @@ struct TLogRecoveryFinishedRequest {
 	}
 };
 
+struct UnknownCommittedVersions {
+	constexpr static FileIdentifier file_identifier = 11822137;
+	Version version;
+	Version prev;
+	std::vector<uint16_t> tLogLocIds;
+	UnknownCommittedVersions() {}
+	UnknownCommittedVersions(Version version, Version prev, std::vector<uint16_t> tLogLocIds)
+	  : version(version), prev(prev), tLogLocIds(tLogLocIds) {}
+	template <class Ar>
+	void serialize(Ar& ar) {
+		serializer(ar, version, prev, tLogLocIds);
+	}
+};
+
 struct TLogLockResult {
 	constexpr static FileIdentifier file_identifier = 11822027;
 	Version end;
 	Version knownCommittedVersion;
-	std::deque<std::tuple<Version, Version, std::vector<uint16_t>>> unknownCommittedVersions;
+	std::deque<UnknownCommittedVersions> unknownCommittedVersions;
 	UID id; // captures TLogData::dbgid
 	UID logId; // captures LogData::logId
 

--- a/fdbserver/include/fdbserver/TLogInterface.h
+++ b/fdbserver/include/fdbserver/TLogInterface.h
@@ -139,9 +139,9 @@ struct TLogRecoveryFinishedRequest {
 
 struct UnknownCommittedVersions {
 	constexpr static FileIdentifier file_identifier = 11822137;
-	Version version;
-	Version prev;
-	std::vector<uint16_t> tLogLocIds;
+	Version version; // version made durable on recovering tLog
+	Version prev; // previous to version; to ensure no gaps in chain
+	std::vector<uint16_t> tLogLocIds; // locations version was sent to
 	UnknownCommittedVersions() {}
 	UnknownCommittedVersions(Version version, Version prev, std::vector<uint16_t> tLogLocIds)
 	  : version(version), prev(prev), tLogLocIds(tLogLocIds) {}


### PR DESCRIPTION
Refactor `uncommitedVersions` to use struct rather than tuple. The struct is more readable and concise.

We saw serialization problems when using tuples (e.g. `tests/fast/Watches.toml` with seed 814493817). The tuple was embedded in a deque. The size element of the vector in the third position of the tuple (tLogLocIds) was corrupted. Using a struct in serialization is a common pattern in the code. The serialization problems do not manifest in testing with version vector enabled: `20240829-154514-dlambrig-4f44b1d4e56b905b`.

This should be loaded on top of [PR 11617](https://github.com/apple/foundationdb/pull/11617)

Joshua 
`20240829-175112-dlambrig-fdae5c124340f01d `

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
