### PR TITLE
Cherry-pick PR #11617 (Address an assertion failure)

### DIFF
--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -2067,6 +2067,7 @@ void getTLogLocIds(std::vector<Reference<LogSet>>& tLogs,
 			if (it->logServers[i]->get().present()) {
 				interfLocMap[it->logServers[i]->get().interf().id()] = location++;
 			}
+			maxTLogLocId++;
 		}
 	}
 
@@ -2076,7 +2077,6 @@ void getTLogLocIds(std::vector<Reference<LogSet>>& tLogs,
 		for (auto& tLogResult : std::get<1>(logGroupResult)) {
 			ASSERT(interfLocMap.find(tLogResult.logId) != interfLocMap.end());
 			tLogLocIds[logGroupId].push_back(interfLocMap[tLogResult.logId]);
-			maxTLogLocId = std::max(maxTLogLocId, interfLocMap[tLogResult.logId]);
 		}
 		logGroupId++;
 	}
@@ -2084,6 +2084,7 @@ void getTLogLocIds(std::vector<Reference<LogSet>>& tLogs,
 
 void populateBitset(boost::dynamic_bitset<>& bs, std::vector<uint16_t>& ids) {
 	for (auto& id : ids) {
+		ASSERT(id < bs.size());
 		bs.set(id);
 	}
 }
@@ -2097,7 +2098,7 @@ Version getRecoverVersionUnicast(std::vector<Reference<LogSet>>& logServers,
                                  Version minDVEnd,
                                  Version minKCVEnd) {
 	std::vector<std::vector<uint16_t>> tLogLocIds;
-	uint16_t maxTLogLocId;
+	uint16_t maxTLogLocId; // maximum possible id, not maximum of id's of available log servers
 	getTLogLocIds(logServers, logGroupResults, tLogLocIds, maxTLogLocId);
 	uint16_t bsSize = maxTLogLocId + 1; // bitset size, used below
 


### PR DESCRIPTION
Cherry-pick PR https://github.com/apple/foundationdb/pull/11617.

Testing:

Joshua job: 20240829-190837-sre-bac092f07172c0c4 (shows a failure in "BlobGranuleRangesChangeLog.toml" test, likely not related to this change)

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
