### PR TITLE
Address a bug related to computing the ids of log servers

### DIFF
--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -2104,11 +2104,14 @@ void getTLogLocIds(std::vector<Reference<LogSet>>& tLogs,
 		}
 		for (uint16_t i = 0; i < it->logServers.size(); i++) {
 			if (it->logServers[i]->get().present()) {
-				interfLocMap[it->logServers[i]->get().interf().id()] = location++;
+				interfLocMap[it->logServers[i]->get().interf().id()] = location;
 			}
-			maxTLogLocId++;
+			location++;
 		}
 	}
+
+	// Set maxTLogLocId.
+	maxTLogLocId = location;
 
 	// Find the locations of tLogs in "logGroupResults".
 	uint8_t logGroupId = 0;


### PR DESCRIPTION
Entries in LogSet::logServers shouldn't be skipped while computing the ids of log servers (as it would cause a mismatch in the ids computed by the commit proxy and the cluster controller).

Testing:

- Test "/root/src/foundationdb/tests/fast/Unreadable.toml -b on -s 3902225582" fails on an assertion without this change, succeeds with it.
- Joshua job (with version vector disabled): 20240830-223342-sre-8b2b901fe1957f98

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
