### PR TITLE
set version vector cluster recovery version to RV+1

### DIFF
--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -2536,9 +2536,10 @@ ACTOR Future<Void> TagPartitionedLogSystem::epochEnd(Reference<AsyncVar<Referenc
 					state std::vector<TLogLockResult> tLogResults = std::get<1>(logGroupResult);
 					for (auto& tLogResult : tLogResults) {
 						wait(transformErrors(
+						    // TODO: why + 1
 						    throwErrorOr(lockResultsInterf->lockInterf[tLogResult.id]
 						                     .setClusterRecoveryVersion.getReplyUnlessFailedFor(
-						                         setClusterRecoveryVersionRequest(logSystem->recoverAt.get()),
+						                         setClusterRecoveryVersionRequest(logSystem->recoverAt.get() + 1),
 						                         SERVER_KNOBS->TLOG_TIMEOUT,
 						                         SERVER_KNOBS->MASTER_FAILURE_SLOPE_DURING_RECOVERY)),
 						    cluster_recovery_failed()));


### PR DESCRIPTION
draft - not ready for review

On recovery, the remote TL [peeks](https://github.com/apple/foundationdb/blob/4e96c3cab228eb73c2bbc7b9cc98141041ba04b5/fdbserver/TLogServer.actor.cpp#L3120) up to RV+1. When version vector is enabled, we must set the clusterRV to RV+1, rather than RV, or the remote TL will hang waiting for that version and recovery will never complete.

This change has no effect on recovery logic. On recoveries, the TL will still peek until RV, and the remote TL until RV+1. 

Without this change, many simulation tests fail with version vector enabled. Its not clear why the remote TL peeks until RV+1. We will monitor this version vector only change. 

Joshua
`20240903-171420-dlambrig-0235cdbcfb11abca `

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
