### PR TITLE
Cherry pick 11619: refactor to use struct rather than tuple for "uncommitedVersions"

### DIFF
--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -320,7 +320,7 @@ struct TLogData : NonCopyable {
 	// For each version above knownCommittedVersion, track:
 	// <Version, PrevVersion (that the sequencer provided), TLogs that the version has been sent to (the tLogs
 	//  are represented by their corresponding positions in "TagPartitionedLogSystem::tLogs")>
-	std::deque<std::tuple<Version, Version, std::vector<uint16_t>>> unknownCommittedVersions;
+	std::deque<UnknownCommittedVersions> unknownCommittedVersions;
 
 	int64_t diskQueueCommitBytes;
 	AsyncVar<bool>
@@ -852,9 +852,9 @@ ACTOR Future<Void> tLogLock(TLogData* self, ReplyPromise<TLogLockResult> reply, 
 	TLogLockResult result;
 	result.end = stopVersion;
 	result.knownCommittedVersion = logData->knownCommittedVersion;
-	result.unknownCommittedVersions = self->unknownCommittedVersions;
 	result.id = self->dbgid;
 	result.logId = logData->logId;
+	result.unknownCommittedVersions = self->unknownCommittedVersions;
 
 	TraceEvent("TLogStop2", self->dbgid)
 	    .detail("LogId", logData->logId)
@@ -2409,9 +2409,9 @@ ACTOR Future<Void> tLogCommit(TLogData* self,
 		// Notifies the commitQueue actor to commit persistentQueue, and also unblocks tLogPeekMessages actors
 		logData->version.set(req.version);
 		if (SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST) {
-			self->unknownCommittedVersions.push_front(std::make_tuple(req.version, req.seqPrevVersion, req.tLogLocIds));
+			self->unknownCommittedVersions.emplace_front(req.version, req.seqPrevVersion, req.tLogLocIds);
 			while (!self->unknownCommittedVersions.empty() &&
-			       std::get<0>(self->unknownCommittedVersions.back()) <= req.knownCommittedVersion) {
+			       self->unknownCommittedVersions.back().version <= req.knownCommittedVersion) {
 				self->unknownCommittedVersions.pop_back();
 			}
 		} else {

--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -2127,17 +2127,17 @@ Version getRecoverVersionUnicast(std::vector<Reference<LogSet>>& logServers,
 			availableTLogs.set(tLogLocId);
 			bool logGroupCandidate = false;
 			for (auto& unknownCommittedVersion : tLogResult.unknownCommittedVersions) {
-				Version k = std::get<0>(unknownCommittedVersion);
+				Version k = unknownCommittedVersion.version;
 				if (k > minEnd) {
 					if (versionAvailableTLogs[k].empty()) {
 						versionAvailableTLogs[k].resize(bsSize);
 					}
 					versionAvailableTLogs[k].set(tLogLocId);
-					prevVersionMap[k] = std::get<1>(unknownCommittedVersion);
+					prevVersionMap[k] = unknownCommittedVersion.prev;
 					if (versionAllTLogs[k].empty()) {
 						versionAllTLogs[k].resize(bsSize);
 					}
-					populateBitset(versionAllTLogs[k], std::get<2>(unknownCommittedVersion));
+					populateBitset(versionAllTLogs[k], unknownCommittedVersion.tLogLocIds);
 					logGroupCandidate = true;
 				}
 			}

--- a/fdbserver/include/fdbserver/TLogInterface.h
+++ b/fdbserver/include/fdbserver/TLogInterface.h
@@ -137,11 +137,25 @@ struct TLogRecoveryFinishedRequest {
 	}
 };
 
+struct UnknownCommittedVersions {
+	constexpr static FileIdentifier file_identifier = 11822137;
+	Version version; // version made durable on recovering tLog
+	Version prev; // previous to version; to ensure no gaps in chain
+	std::vector<uint16_t> tLogLocIds; // locations version was sent to
+	UnknownCommittedVersions() {}
+	UnknownCommittedVersions(Version version, Version prev, std::vector<uint16_t> tLogLocIds)
+	  : version(version), prev(prev), tLogLocIds(tLogLocIds) {}
+	template <class Ar>
+	void serialize(Ar& ar) {
+		serializer(ar, version, prev, tLogLocIds);
+	}
+};
+
 struct TLogLockResult {
 	constexpr static FileIdentifier file_identifier = 11822027;
 	Version end;
 	Version knownCommittedVersion;
-	std::deque<std::tuple<Version, Version, std::vector<uint16_t>>> unknownCommittedVersions;
+	std::deque<UnknownCommittedVersions> unknownCommittedVersions;
 	UID id; // captures TLogData::dbgid
 	UID logId; // captures LogData::logId
 


### PR DESCRIPTION
Cherry pick 11619: refactor to use struct rather than tuple for "uncommitedVersions"

* refactor to use struct rather than tuple for uncommitedVersions

* Document UnknownCommittedVersions struct

---------

Replace this text with your description here...

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
