### PR TITLE
Go binding: add GetClientStatus method to Database

### DIFF
--- a/bindings/go/src/fdb/database.go
+++ b/bindings/go/src/fdb/database.go
@@ -31,6 +31,10 @@ import (
 	"runtime"
 )
 
+// ErrMultiVersionClientUnavailable is returned when the multi-version client API is unavailable.
+// Client status information is available only when such API is enabled.
+var ErrMultiVersionClientUnavailable = errors.New("multi-version client API is unavailable")
+
 // Database is a handle to a FoundationDB database. Database is a lightweight
 // object that may be efficiently copied, and is safe for concurrent use by
 // multiple goroutines.
@@ -131,6 +135,29 @@ func (d Database) RebootWorker(address string, checkFile bool, suspendDuration i
 	}
 
 	return err
+}
+
+// GetClientStatus returns a JSON byte slice containing database client-side status information.
+// At the top level the report describes the status of the Multi-Version Client database - its initialization state, the protocol version, the available client versions; it also embeds the status of the actual version-specific database and within it the addresses of various FDB server roles the client is aware of and their connection status.
+// NOTE: ErrMultiVersionClientUnavailable will be returned if the Multi-Version client API was not enabled.
+func (d Database) GetClientStatus() ([]byte, error) {
+	if apiVersion == 0 {
+		return nil, errAPIVersionUnset
+	}
+
+	st := &futureByteSlice{
+		future: newFutureWithDb(d.database, nil, C.fdb_database_get_client_status(d.ptr)),
+	}
+
+	b, err := st.Get()
+	if err != nil {
+		return nil, err
+	}
+	if len(b) == 0 {
+		return nil, ErrMultiVersionClientUnavailable
+	}
+
+	return b, nil
 }
 
 func retryable(wrapped func() (interface{}, error), onError func(Error) FutureNil) (ret interface{}, err error) {

--- a/bindings/go/src/fdb/database.go
+++ b/bindings/go/src/fdb/database.go
@@ -219,7 +219,8 @@ func (d Database) Transact(f func(Transaction) (interface{}, error)) (interface{
 //
 // The transaction is retried if the error is or wraps a retryable Error.
 // The error is unwrapped.
-// Read transactions are never committed and destroyed before returning to caller.
+// Read transactions are never committed and destroyed automatically via GC,
+// once all their futures go out of scope.
 //
 // Do not return Future objects from the function provided to ReadTransact. The
 // Transaction created by ReadTransact may be finalized at any point after

--- a/bindings/go/src/fdb/fdb_test.go
+++ b/bindings/go/src/fdb/fdb_test.go
@@ -389,3 +389,45 @@ func ExampleOpenWithConnectionString() {
 
 	// Output:
 }
+
+func TestGetClientStatus(t *testing.T) {
+	// skip this test because multi-version client is currently not available in CI
+	t.Skip()
+
+	fdb.MustAPIVersion(API_VERSION)
+	db := fdb.MustOpenDefault()
+
+	st, e := db.GetClientStatus()
+	if e != nil {
+		t.Fatalf("GetClientStatus failed %v", e)
+	}
+	if len(st) == 0 {
+		t.Fatal("returned status is empty")
+	}
+}
+
+func ExampleGetClientStatus() {
+	fdb.MustAPIVersion(API_VERSION)
+	err := fdb.Options().SetDisableClientBypass()
+	if err != nil {
+		fmt.Errorf("Unable to disable client bypass: %v\n", err)
+		return
+	}
+
+	db := fdb.MustOpenDefault()
+
+	st, e := db.GetClientStatus()
+	if e != nil {
+		fmt.Errorf("Unable to get client status: %v\n", err)
+		return
+	}
+
+	fmt.Printf("client status: %s\n", string(st))
+
+	// Close the database after usage
+	defer db.Close()
+
+	// Do work here
+
+	// Output:
+}

--- a/documentation/sphinx/source/api-c.rst
+++ b/documentation/sphinx/source/api-c.rst
@@ -506,8 +506,8 @@ An |database-blurb1| Modifications to a database are performed via transactions.
 
 .. function:: FDBFuture* fdb_database_get_client_status(FDBDatabase* db)
 
-   Returns a JSON string containing database client-side status information. At the top level the report describes the status of the 
-   Multi-Version Client database - its initialization state, the protocol version, the available client versions. The report schema is:
+   Returns a JSON string containing database client-side status information. If the Multi-version client API is disabled an empty string will be returned.
+   At the top level the report describes the status of the Multi-Version Client database - its initialization state, the protocol version, the available client versions. The report schema is:
 
    .. code-block::
 


### PR DESCRIPTION
Add `GetClientStatus` method to `Database`.

Allow fetching client status JSON information for any database.
Added a test to make sure that it works with an open database.

By looking in `fdbclient/MultiVersionTransaction.actor.cpp` I found out that `fdb_database_get_client_status()` will return an empty string when the db is invalid; I will document this in this same PR.

Related: #11621

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
