### PR TITLE
Choose log router tag prior to resolution in commit path for version vector

### DIFF
--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -836,6 +836,9 @@ std::set<Tag> CommitBatchContext::getWrittenTagsPreResolution() {
 		}
 	}
 
+	toCommit.storeRandomRouterTag();
+	transactionTags.insert(toCommit.savedRandomRouterTag.get());
+
 	return transactionTags;
 }
 

--- a/fdbserver/LogSystem.cpp
+++ b/fdbserver/LogSystem.cpp
@@ -299,7 +299,7 @@ void LogPushData::writeMessage(StringRef rawMessageWithoutLength, bool usePrevio
 	if (!usePreviousLocations) {
 		prev_tags.clear();
 		if (logSystem->hasRemoteLogs()) {
-			prev_tags.push_back(logSystem->getRandomRouterTag());
+			prev_tags.push_back(chooseRouterTag());
 		}
 		for (auto& tag : next_message_tags) {
 			prev_tags.push_back(tag);

--- a/fdbserver/include/fdbserver/LogSystem.h
+++ b/fdbserver/include/fdbserver/LogSystem.h
@@ -815,6 +815,9 @@ struct LogPushData : NonCopyable {
 	// getAllMessages() and is used before writing any other mutations.
 	void setMutations(uint32_t totalMutations, VectorRef<StringRef> mutations);
 
+	Optional<Tag> savedRandomRouterTag;
+	void storeRandomRouterTag() { savedRandomRouterTag = logSystem->getRandomRouterTag(); }
+
 private:
 	Reference<ILogSystem> logSystem;
 	std::vector<Tag> next_message_tags;
@@ -836,13 +839,17 @@ private:
 	// true on a successful write, and false if the location has already been
 	// written.
 	bool writeTransactionInfo(int location, uint32_t subseq);
+
+	Tag chooseRouterTag() {
+		return savedRandomRouterTag.present() ? savedRandomRouterTag.get() : logSystem->getRandomRouterTag();
+	}
 };
 
 template <class T>
 void LogPushData::writeTypedMessage(T const& item, bool metadataMessage, bool allLocations) {
 	prev_tags.clear();
 	if (logSystem->hasRemoteLogs()) {
-		prev_tags.push_back(logSystem->getRandomRouterTag());
+		prev_tags.push_back(chooseRouterTag());
 	}
 	for (auto& tag : next_message_tags) {
 		prev_tags.push_back(tag);


### PR DESCRIPTION
In the commit path, random log routers are chosen to write mutations to. They are chosen after resolution. In version vector all  tags must be chosen prior to resolution to obtain the previous versions for logs. This PR modifies the version vector code to select a single random log router prior to resolution. It is believed a single remote tag for the entire batch of mutations is more performant than a different remote tag per mutation, because fewer logs will be selected.  

version vector enabled `tests/rare/TransactionTagSwizzledApiCorrectness.toml`  `2560436537`

Joshua
`20240905-173820-dlambrig-fb30d554e645f976` 2560436537

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
