### PR TITLE
Cherry-pick PR #11623 (Address a bug related to computing the ids of log servers)

### DIFF
--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -2065,11 +2065,14 @@ void getTLogLocIds(std::vector<Reference<LogSet>>& tLogs,
 		}
 		for (uint16_t i = 0; i < it->logServers.size(); i++) {
 			if (it->logServers[i]->get().present()) {
-				interfLocMap[it->logServers[i]->get().interf().id()] = location++;
+				interfLocMap[it->logServers[i]->get().interf().id()] = location;
 			}
-			maxTLogLocId++;
+			location++;
 		}
 	}
+
+	// Set maxTLogLocId.
+	maxTLogLocId = location;
 
 	// Find the locations of tLogs in "logGroupResults".
 	uint8_t logGroupId = 0;


### PR DESCRIPTION
Cherry-pick PR https://github.com/apple/foundationdb/pull/11623.

Testing:

Joshua job: 20240905-231740-sre-cf375feac6ff1aa9 (no failures)

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
