### PR TITLE
Fix external timeout with ShardedRocksDB and re-enable ShardedRocksDB in simulation tests

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -191,8 +191,8 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( MAX_LARGE_SHARD_BYTES,                          1000000000 ); // 1G
 	init( SHARD_ENCODE_LOCATION_METADATA,                      false ); if( randomize && BUGGIFY )  SHARD_ENCODE_LOCATION_METADATA = true;
 	init( ENABLE_DD_PHYSICAL_SHARD,                            false ); // EXPERIMENTAL; If true, SHARD_ENCODE_LOCATION_METADATA must be true; When true, optimization of data move between DCs is disabled
-	init( DD_PHYSICAL_SHARD_MOVE_PROBABILITY,                    0.0 ); if( isSimulated )  DD_PHYSICAL_SHARD_MOVE_PROBABILITY = 0.5;
-	init( ENABLE_PHYSICAL_SHARD_MOVE_EXPERIMENT,               false ); if( isSimulated )  ENABLE_PHYSICAL_SHARD_MOVE_EXPERIMENT = deterministicRandom()->coinflip();
+	init( DD_PHYSICAL_SHARD_MOVE_PROBABILITY,                    0.0 ); // FIXME: re-enable after ShardedRocksDB is well tested by simulation
+	init( ENABLE_PHYSICAL_SHARD_MOVE_EXPERIMENT,               false ); // FIXME: re-enable after ShardedRocksDB is well tested by simulation
 	init( MAX_PHYSICAL_SHARD_BYTES,                         10000000 ); // 10 MB; for ENABLE_DD_PHYSICAL_SHARD; smaller leads to larger number of physicalShard per storage server
  	init( PHYSICAL_SHARD_METRICS_DELAY,                        300.0 ); // 300 seconds; for ENABLE_DD_PHYSICAL_SHARD
 	init( ANONYMOUS_PHYSICAL_SHARD_TRANSITION_TIME,            600.0 ); if( randomize && BUGGIFY )  ANONYMOUS_PHYSICAL_SHARD_TRANSITION_TIME = 0.0; // 600 seconds; for ENABLE_DD_PHYSICAL_SHARD

--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -210,7 +210,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	bool buggifySmallShards = randomize && BUGGIFY;
 	bool simulationMediumShards = !buggifySmallShards && isSimulated && randomize && !BUGGIFY; // prefer smaller shards in simulation
 	// FIXME: increase this even more eventually
-	init( MIN_SHARD_BYTES,                                  10000000 ); if( buggifySmallShards ) MIN_SHARD_BYTES = 40000; if (simulationMediumShards) MIN_SHARD_BYTES = 200000; //FIXME: data distribution tracker (specifically StorageMetrics) relies on this number being larger than the maximum size of a key value pair
+	init( MIN_SHARD_BYTES,                                  10000000 ); if( buggifySmallShards ) MIN_SHARD_BYTES = 400000; if (simulationMediumShards) MIN_SHARD_BYTES = 2000000; //FIXME: data distribution tracker (specifically StorageMetrics) relies on this number being larger than the maximum size of a key value pair
 	init( SHARD_BYTES_RATIO,                                       4 );
 	init( SHARD_BYTES_PER_SQRT_BYTES,                             45 ); if( buggifySmallShards ) SHARD_BYTES_PER_SQRT_BYTES = 0;//Approximately 10000 bytes per shard
 	init( MAX_SHARD_BYTES,                                 500000000 );
@@ -236,7 +236,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	*/
 	init( SHARD_MAX_BYTES_READ_PER_KSEC_JITTER,     0.1 );
 	bool buggifySmallBandwidthSplit = randomize && BUGGIFY;
-	init( SHARD_MAX_BYTES_PER_KSEC,                 1LL*1000000*1000 ); if( buggifySmallBandwidthSplit ) SHARD_MAX_BYTES_PER_KSEC = 10LL*1000*1000;
+	init( SHARD_MAX_BYTES_PER_KSEC,                 1LL*1000000*1000 ); if( buggifySmallBandwidthSplit ) SHARD_MAX_BYTES_PER_KSEC = 1LL*100000*1000;
 	/* 1*1MB/sec * 1000sec/ksec
 		Shards with more than this bandwidth will be split immediately.
 		For a large shard (100MB), it will be split into multiple shards with sizes < SHARD_SPLIT_BYTES_PER_KSEC;
@@ -247,7 +247,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 		team indefinitely, limiting performance.
 		*/
 
-	init( SHARD_MIN_BYTES_PER_KSEC,                100 * 1000 * 1000 ); if( buggifySmallBandwidthSplit ) SHARD_MIN_BYTES_PER_KSEC = 200*1*1000;
+	init( SHARD_MIN_BYTES_PER_KSEC,                100 * 1000 * 1000 ); if( buggifySmallBandwidthSplit ) SHARD_MIN_BYTES_PER_KSEC = 20*1000*1000;
 	/* 100*1KB/sec * 1000sec/ksec
 		Shards with more than this bandwidth will not be merged.
 		Obviously this needs to be significantly less than SHARD_MAX_BYTES_PER_KSEC, else we will repeatedly merge and split.
@@ -598,8 +598,8 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( SHARDED_ROCKSDB_COMPACTION_PERIOD, isSimulated? 3600 : 2592000 ); // 30d
 	init( SHARDED_ROCKSDB_COMPACTION_ACTOR_DELAY,               3600 ); // 1h
 	init( SHARDED_ROCKSDB_COMPACTION_SHARD_LIMIT,                 -1 );
-	init( SHARDED_ROCKSDB_WRITE_BUFFER_SIZE,                16 << 20 ); // 16MB
-	init( SHARDED_ROCKSDB_TOTAL_WRITE_BUFFER_SIZE,           1 << 30 ); // 1GB
+	init( SHARDED_ROCKSDB_WRITE_BUFFER_SIZE, (isSimulated && !buggifySmallShards && !buggifySmallBandwidthSplit && !simulationMediumShards) ? 128 << 20 : 16 << 20 );  // 16MB
+	init( SHARDED_ROCKSDB_TOTAL_WRITE_BUFFER_SIZE, isSimulated ? 0 : 1 << 30 ); // 1GB
 	init( SHARDED_ROCKSDB_MEMTABLE_BUDGET,                  64 << 20 ); // 64MB
 	init( SHARDED_ROCKSDB_MAX_WRITE_BUFFER_NUMBER,                 6 ); // RocksDB default.
 	init( SHARDED_ROCKSDB_TARGET_FILE_SIZE_BASE,            16 << 20 ); // 16MB
@@ -615,7 +615,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( SHARDED_ROCKSDB_LEVEL0_FILENUM_COMPACTION_TRIGGER,       4 );
 	init( SHARDED_ROCKSDB_LEVEL0_SLOWDOWN_WRITES_TRIGGER,         20 ); // RocksDB default.
 	init( SHARDED_ROCKSDB_LEVEL0_STOP_WRITES_TRIGGER,             36 ); // RocksDB default.
-	init( SHARDED_ROCKSDB_DELAY_COMPACTION_FOR_DATA_MOVE,      false ); if (isSimulated) SHARDED_ROCKSDB_DELAY_COMPACTION_FOR_DATA_MOVE = deterministicRandom()->coinflip();
+	init( SHARDED_ROCKSDB_DELAY_COMPACTION_FOR_DATA_MOVE,      false ); if (isSimulated) SHARDED_ROCKSDB_DELAY_COMPACTION_FOR_DATA_MOVE = true;
 	init( SHARDED_ROCKSDB_MAX_OPEN_FILES,                      50000 ); // Should be smaller than OS's fd limit.
 	init (SHARDED_ROCKSDB_READ_ASYNC_IO,                       false ); if (isSimulated) SHARDED_ROCKSDB_READ_ASYNC_IO = deterministicRandom()->coinflip();
 	init( SHARDED_ROCKSDB_PREFIX_LEN,                              0 ); if( randomize && BUGGIFY )  SHARDED_ROCKSDB_PREFIX_LEN = deterministicRandom()->randomInt(1, 20);

--- a/fdbserver/KeyValueStoreShardedRocksDB.actor.cpp
+++ b/fdbserver/KeyValueStoreShardedRocksDB.actor.cpp
@@ -577,6 +577,11 @@ rocksdb::ColumnFamilyOptions getCFOptions() {
 }
 
 rocksdb::ColumnFamilyOptions getCFOptionsForInactiveShard() {
+	if (g_network->isSimulated()) {
+		return getCFOptions();
+	} else {
+		ASSERT(false); // FIXME: remove when SHARDED_ROCKSDB_DELAY_COMPACTION_FOR_DATA_MOVE feature is well tuned
+	}
 	auto options = getCFOptions();
 	// never slowdown ingest.
 	options.level0_file_num_compaction_trigger = (1 << 30);

--- a/tests/fast/AtomicBackupToDBCorrectness.toml
+++ b/tests/fast/AtomicBackupToDBCorrectness.toml
@@ -2,7 +2,6 @@
 extraDatabaseMode = 'LocalOrSingle'
 # DR is not currently supported in required tenant mode
 tenantModes = ['disabled', 'optional']
-storageEngineExcludeTypes = [5]
 
 [[test]]
 testTitle = 'BackupAndRestore'

--- a/tests/fast/AuthzSecurityWithBlobGranules.toml
+++ b/tests/fast/AuthzSecurityWithBlobGranules.toml
@@ -2,8 +2,6 @@
 allowDefaultTenant = false
 tenantModes = ['optional', 'required']
 blobGranulesEnabled = true
-# FIXME: re-enable rocks at some point
-storageEngineExcludeTypes = [5]
 
 [[knobs]]
 audit_logging_enabled = false

--- a/tests/fast/BackupCorrectnessClean.toml
+++ b/tests/fast/BackupCorrectnessClean.toml
@@ -1,7 +1,5 @@
 testClass = "Backup"
 
-[configuration]
-storageEngineExcludeTypes = [5]
 
 [[test]]
 testTitle = 'BackupAndRestore'

--- a/tests/fast/BackupToDBCorrectness.toml
+++ b/tests/fast/BackupToDBCorrectness.toml
@@ -4,7 +4,6 @@ testClass = "Backup"
 extraDatabaseMode = 'LocalOrSingle'
 # DR is not currently supported in required tenant mode
 tenantModes = ['disabled', 'optional']
-storageEngineExcludeTypes = [5]
 
 [[test]]
 testTitle = 'BackupAndRestore'

--- a/tests/fast/BackupToDBCorrectnessClean.toml
+++ b/tests/fast/BackupToDBCorrectnessClean.toml
@@ -4,7 +4,6 @@ testClass = "Backup"
 extraDatabaseMode = 'LocalOrSingle'
 # DR is not currently supported in required tenant mode
 tenantModes = ['disabled', 'optional']
-storageEngineExcludeTypes = [5]
 
 [[test]]
 testTitle = 'BackupAndRestore'

--- a/tests/fast/BlobRestoreBasic.toml
+++ b/tests/fast/BlobRestoreBasic.toml
@@ -4,11 +4,9 @@ blobGranulesEnabled = true
 extraDatabaseMode = 'Single'
 allowDefaultTenant = false
 disableTss = true
-storageEngineExcludeTypes = [5]
 
 [[knobs]]
 bg_consistency_check_enabled = 0
-shard_encode_location_metadata = false
 bw_throttling_enabled = false
 blob_restore_skip_empty_ranges = false
 

--- a/tests/fast/BlobRestoreLarge.toml
+++ b/tests/fast/BlobRestoreLarge.toml
@@ -4,11 +4,9 @@ blobGranulesEnabled = true
 extraDatabaseMode = 'Single'
 allowDefaultTenant = false
 disableTss = true
-storageEngineExcludeTypes = [5]
 
 [[knobs]]
 bg_consistency_check_enabled = 0
-shard_encode_location_metadata = false
 bw_throttling_enabled = false
 blob_restore_skip_empty_ranges = false
 

--- a/tests/fast/BlobRestoreTenantMode.toml
+++ b/tests/fast/BlobRestoreTenantMode.toml
@@ -6,14 +6,12 @@ tenantModes = ['optional', 'required']
 injectTargetedSSRestart = true
 injectSSDelay = true
 disableTss = true
-storageEngineExcludeTypes = [5]
 
 [[knobs]]
 bg_metadata_source = "tenant"
 bg_key_tuple_truncate_offset = 1
 enable_rest_kms_communication = true
 bg_consistency_check_enabled = 0
-shard_encode_location_metadata = false
 bw_throttling_enabled = false
 
 [[test]] 

--- a/tests/fast/BlobRestoreToVersion.toml
+++ b/tests/fast/BlobRestoreToVersion.toml
@@ -4,11 +4,9 @@ blobGranulesEnabled = true
 extraDatabaseMode = 'Single'
 allowDefaultTenant = false
 disableTss = true
-storageEngineExcludeTypes = [5]
 
 [[knobs]]
 bg_consistency_check_enabled = 0
-shard_encode_location_metadata = false
 bw_throttling_enabled = false
 blob_restore_skip_empty_ranges = false
 

--- a/tests/fast/GetEstimatedRangeSize.toml
+++ b/tests/fast/GetEstimatedRangeSize.toml
@@ -1,7 +1,6 @@
 [configuration]
 allowDefaultTenant = false
 tenantModes = ['optional', 'required']
-storageEngineExcludeTypes = [5]
 
 [[test]]
 testTitle = 'TenantCreation'

--- a/tests/fast/IDDTxnProcessorMoveKeys.toml
+++ b/tests/fast/IDDTxnProcessorMoveKeys.toml
@@ -4,7 +4,6 @@ disableTss = true # There's no TSS in MGS this prevent the DD operate TSS mappin
 
 [[knobs]]
 max_added_sources_multiplier = 0 # set to 0 because it's impossible to make sure SS and mock SS will finish fetch keys at the same time.
-shard_encode_location_metadata = false
 
 [[test]]
 testTitle = 'IDDTxnProcessorRawStartMovement'

--- a/tests/fast/KillRegionCycle.toml
+++ b/tests/fast/KillRegionCycle.toml
@@ -1,6 +1,5 @@
 [configuration]
 minimumRegions = 2
-storageEngineExcludeTypes = [5]
 
 [[test]]
 testTitle = 'KillRegionCycle'

--- a/tests/fast/MemoryLifetime.toml
+++ b/tests/fast/MemoryLifetime.toml
@@ -1,6 +1,3 @@
-[configuration]
-storageEngineExcludeTypes = [5]
-
 [[test]]
 testTitle = 'MemoryLifetimeTest'
 

--- a/tests/fast/MockDDReadWrite.toml
+++ b/tests/fast/MockDDReadWrite.toml
@@ -3,7 +3,6 @@ testClass = 'MockDD'
 
 [[knobs]]
 enable_dd_physical_shard = false
-shard_encode_location_metadata = false
 dd_tenant_awareness_enabled = false
 storage_quota_enabled = false
 

--- a/tests/fast/MutationLogReaderCorrectness.toml
+++ b/tests/fast/MutationLogReaderCorrectness.toml
@@ -1,6 +1,3 @@
-[configuration]
-storageEngineExcludeTypes = [5]
-
 [[test]]
 testTitle = 'MutationLogReaderCorrectness'
 useDB = true

--- a/tests/fast/StreamingRangeRead.toml
+++ b/tests/fast/StreamingRangeRead.toml
@@ -1,6 +1,3 @@
-[configuration]
-storageEngineExcludeTypes = [5]
-
 [[test]]
 testTitle = 'StreamingRangeReadTest'
 

--- a/tests/fast/Watches.toml
+++ b/tests/fast/Watches.toml
@@ -1,6 +1,3 @@
-[configuration]
-storageEngineExcludeTypes = [5]
-
 [[test]]
 testTitle = 'WatchesTest'
 

--- a/tests/rare/CheckRelocation.toml
+++ b/tests/rare/CheckRelocation.toml
@@ -1,6 +1,3 @@
-[configuration]
-storageEngineExcludeTypes = [5]
-
 [[test]]
 testTitle = 'RandomReadWriteTest'
 simCheckRelocationDuration = true

--- a/tests/rare/ClogTlog.toml
+++ b/tests/rare/ClogTlog.toml
@@ -5,7 +5,6 @@ machineCount = 20
 commitProxyCount = 4
 config = 'triple'
 desiredTLogCount = 6
-storageEngineExcludeTypes = [5]
 
 [[knobs]]
 enable_worker_health_monitor = true

--- a/tests/rare/LargeApiCorrectness.toml
+++ b/tests/rare/LargeApiCorrectness.toml
@@ -1,6 +1,3 @@
-[configuration]
-storageEngineExcludeTypes = [5]
-
 [[test]]
 testTitle = 'ApiCorrectnessTest'
 clearAfterTest = true

--- a/tests/rare/LargeApiCorrectnessStatus.toml
+++ b/tests/rare/LargeApiCorrectnessStatus.toml
@@ -1,6 +1,3 @@
-[configuration]
-storageEngineExcludeTypes = [5]
-
 [[test]]
 testTitle = 'ApiCorrectnessTest'
 clearAfterTest = true

--- a/tests/rare/SwizzledLargeApiCorrectness.toml
+++ b/tests/rare/SwizzledLargeApiCorrectness.toml
@@ -1,6 +1,3 @@
-[configuration]
-storageEngineExcludeTypes = [5]
-
 [[test]]
 testTitle = 'ApiCorrectnessTest'
 clearAfterTest = true

--- a/tests/rare/Throttling.toml
+++ b/tests/rare/Throttling.toml
@@ -2,9 +2,6 @@
 # Priority 1.0 is the default in TestHarness2
 testPriority = '20'
 
-[configuration]
-storageEngineExcludeTypes = [5]
-
 [[test]]
 testTitle='ThrottlingTest'
     [[test.workload]]

--- a/tests/rare/TransactionCost.toml
+++ b/tests/rare/TransactionCost.toml
@@ -2,9 +2,6 @@
 # Priority 1.0 is the default in TestHarness2
 testPriority = '20'
 
-[configuration]
-storageEngineExcludeTypes=[5]
-
 [[test]]
 testTitle = 'TransactionCostTest'
 

--- a/tests/rare/TransactionTagApiCorrectness.toml
+++ b/tests/rare/TransactionTagApiCorrectness.toml
@@ -1,6 +1,3 @@
-[configuration]
-storageEngineExcludeTypes = [5]
-
 [[test]]
 testTitle = 'TransactionTagWithApiCorrectness'
 clearAfterTest = true

--- a/tests/rare/TransactionTagSwizzledApiCorrectness.toml
+++ b/tests/rare/TransactionTagSwizzledApiCorrectness.toml
@@ -1,6 +1,3 @@
-[configuration]
-storageEngineExcludeTypes = [5]
-
 [[test]]
 testTitle = 'TransactionTagWithSwizzledApiCorrectnessTest'
 clearAfterTest = true

--- a/tests/rare/WriteTagThrottling.toml
+++ b/tests/rare/WriteTagThrottling.toml
@@ -1,6 +1,3 @@
-[configuration]
-storageEngineExcludeTypes = [5]
-
 [[test]]
 testTitle = 'withoutWriteThrottling'
 

--- a/tests/restarting/from_7.3.0/BlobGranuleRestartCycle-1.toml
+++ b/tests/restarting/from_7.3.0/BlobGranuleRestartCycle-1.toml
@@ -6,8 +6,6 @@ blobGranulesEnabled = true
 allowDefaultTenant = false
 injectTargetedSSRestart = true
 injectSSDelay = true
-# FIXME: re-enable rocks at some point
-storageEngineExcludeTypes = [5]
 tenantModes = ['disabled']
 
 [[knobs]]

--- a/tests/restarting/from_7.3.0/BlobGranuleRestartCycle-2.toml
+++ b/tests/restarting/from_7.3.0/BlobGranuleRestartCycle-2.toml
@@ -6,8 +6,6 @@ blobGranulesEnabled = true
 allowDefaultTenant = false
 injectTargetedSSRestart = true
 injectSSDelay = true
-# FIXME: re-enable rocks at some point
-storageEngineExcludeTypes = [5]
 
 [[test]]
 testTitle = 'BlobGranuleRestartCycle'

--- a/tests/restarting/from_7.3.0/BlobGranuleRestartLarge-1.toml
+++ b/tests/restarting/from_7.3.0/BlobGranuleRestartLarge-1.toml
@@ -6,8 +6,6 @@ blobGranulesEnabled = true
 allowDefaultTenant = false
 injectTargetedSSRestart = true
 injectSSDelay = true
-# FIXME: re-enable rocks at some point
-storageEngineExcludeTypes = [5]
 tenantModes = ['disabled']
 
 [[knobs]]

--- a/tests/restarting/from_7.3.0/BlobGranuleRestartLarge-2.toml
+++ b/tests/restarting/from_7.3.0/BlobGranuleRestartLarge-2.toml
@@ -6,8 +6,6 @@ blobGranulesEnabled = true
 allowDefaultTenant = false
 injectTargetedSSRestart = true
 injectSSDelay = true
-# FIXME: re-enable rocks at some point
-storageEngineExcludeTypes = [5]
 
 [[test]]
 testTitle = 'BlobGranuleRestartLarge'

--- a/tests/restarting/from_7.3.0/UpgradeAndBackupRestore-1.toml
+++ b/tests/restarting/from_7.3.0/UpgradeAndBackupRestore-1.toml
@@ -1,5 +1,5 @@
 [configuration]
-storageEngineExcludeTypes=[3,5]
+storageEngineExcludeTypes=[3]
 tenantModes=['disabled']
 
 [[test]]

--- a/tests/restarting/to_7.1.0_until_7.2.0/ConfigureStorageMigrationTestRestart-1.toml
+++ b/tests/restarting/to_7.1.0_until_7.2.0/ConfigureStorageMigrationTestRestart-1.toml
@@ -2,14 +2,12 @@
 extraMachineCountDC = 2
 maxTLogVersion=6
 disableHostname=true
-storageEngineExcludeTypes=[3, 5]
+storageEngineExcludeTypes=[3]
 tenantModes=['disabled']
 encryptModes=['disabled']
 simHTTPServerEnabled=false
 
 [[knobs]]
-# This can be removed once the lower bound of this downgrade test is a version that understands the new protocol
-shard_encode_location_metadata = false
 # Mutation checksum and accumulative checksum is not compatible with release-7.1.x
 enable_mutation_checksum = false
 enable_accumulative_checksum = false

--- a/tests/restarting/to_7.1.0_until_7.2.0/CycleTestRestart-1.toml
+++ b/tests/restarting/to_7.1.0_until_7.2.0/CycleTestRestart-1.toml
@@ -1,5 +1,5 @@
 [configuration]
-storageEngineExcludeTypes = [3, 5]
+storageEngineExcludeTypes = [3]
 maxTLogVersion = 6
 disableTss = true
 disableHostname = true
@@ -8,8 +8,6 @@ tenantModes=['disabled']
 simHTTPServerEnabled=false
 
 [[knobs]]
-# This can be removed once the lower bound of this downgrade test is a version that understands the new protocol
-shard_encode_location_metadata = false
 # Mutation checksum and accumulative checksum is not compatible with release-7.1.x
 enable_mutation_checksum = false
 enable_accumulative_checksum = false

--- a/tests/slow/ApiCorrectness.toml
+++ b/tests/slow/ApiCorrectness.toml
@@ -1,6 +1,3 @@
-[configuration]
-storageEngineExcludeTypes = [5]
-
 [[test]]
 testTitle = 'ApiCorrectnessTest'
 clearAfterTest = true

--- a/tests/slow/ApiCorrectnessAtomicRestore.toml
+++ b/tests/slow/ApiCorrectnessAtomicRestore.toml
@@ -1,7 +1,6 @@
 [configuration]
 # Tenant lookups fail during the atomic restore because they aren't affected by locking
 allowDefaultTenant = false
-storageEngineExcludeTypes = [5]
 
 [[knobs]]
 rocksdb_read_value_timeout=300.0

--- a/tests/slow/ApiCorrectnessSwitchover.toml
+++ b/tests/slow/ApiCorrectnessSwitchover.toml
@@ -2,7 +2,6 @@
 extraDatabaseMode = 'Single'
 # required tenant mode is not supported for Disaster Recovery yet
 tenantModes = ['disabled', 'optional']
-storageEngineExcludeTypes = [5]
 
 [[test]]
 testTitle = 'ApiCorrectnessTest'

--- a/tests/slow/ApiCorrectnessWithConsistencyCheck.toml
+++ b/tests/slow/ApiCorrectnessWithConsistencyCheck.toml
@@ -1,6 +1,3 @@
-[configuration]
-storageEngineExcludeTypes = [5]
-
 [[knobs]]
 enable_replica_consistency_check_on_reads = true
 

--- a/tests/slow/ClogWithRollbacks.toml
+++ b/tests/slow/ClogWithRollbacks.toml
@@ -1,6 +1,3 @@
-[configuration]
-storageEngineExcludeTypes = [5]
-
 [[test]]
 testTitle = 'CloggedCycleTest'
 

--- a/tests/slow/DDBalanceAndRemove.toml
+++ b/tests/slow/DDBalanceAndRemove.toml
@@ -1,6 +1,3 @@
-[configuration]
-storageEngineExcludeTypes = [5]
-
 [[test]]
 testTitle = 'DDBalance_Test'
 

--- a/tests/slow/DDBalanceAndRemoveStatus.toml
+++ b/tests/slow/DDBalanceAndRemoveStatus.toml
@@ -1,6 +1,3 @@
-[configuration]
-storageEngineExcludeTypes=[5]
-
 [[test]]
 testTitle = 'DDBalance_Test'
 

--- a/tests/slow/GcGenerations.toml
+++ b/tests/slow/GcGenerations.toml
@@ -5,7 +5,6 @@ machineCount = 20
 minimumRegions = 2
 coordinators = 1
 remoteConfig = 'remote_double'
-storageEngineExcludeTypes = [5]
 
 [[knobs]]
 max_write_transaction_life_versions = 5000000

--- a/tests/slow/ParallelRestoreNewBackupCorrectnessAtomicOp.toml
+++ b/tests/slow/ParallelRestoreNewBackupCorrectnessAtomicOp.toml
@@ -1,6 +1,5 @@
 [configuration]
 allowDefaultTenant = false
-storageEngineExcludeTypes = [5]
 
 [[test]]
 testTitle = 'BackupAndParallelRestoreWithAtomicOp'

--- a/tests/slow/ParallelRestoreOldBackupCorrectnessAtomicOp.toml
+++ b/tests/slow/ParallelRestoreOldBackupCorrectnessAtomicOp.toml
@@ -1,7 +1,6 @@
 [configuration]
 # tenants are not supported with parallel restore
 allowDefaultTenant = false
-storageEngineExcludeTypes = [5]
 
 [[test]]
 testTitle = 'BackupAndParallelRestoreWithAtomicOp'

--- a/tests/slow/SharedBackupCorrectness.toml
+++ b/tests/slow/SharedBackupCorrectness.toml
@@ -2,7 +2,6 @@
 extraDatabaseMode = 'LocalOrSingle'
 # DR is not currently supported in required tenant mode
 tenantModes = ['disabled', 'optional']
-storageEngineExcludeTypes = [5]
 
 [[test]]
 testTitle = 'BackupAndRestore'

--- a/tests/slow/SharedDefaultBackupCorrectness.toml
+++ b/tests/slow/SharedDefaultBackupCorrectness.toml
@@ -2,7 +2,6 @@
 extraDatabaseMode = 'Single'
 # required tenant mode is not supported for Disaster Recovery yet
 tenantModes = ['disabled', 'optional']
-storageEngineExcludeTypes = [5]
 
 [[test]]
 testTitle = 'SharedDefaultBackupToFileThenDB'

--- a/tests/slow/SwizzledApiCorrectness.toml
+++ b/tests/slow/SwizzledApiCorrectness.toml
@@ -1,6 +1,3 @@
-[configuration]
-storageEngineExcludeTypes = [5]
-
 [[test]]
 testTitle = 'ApiCorrectnessTest'
 clearAfterTest = true

--- a/tests/slow/SwizzledDdBalance.toml
+++ b/tests/slow/SwizzledDdBalance.toml
@@ -1,6 +1,3 @@
-[configuration]
-storageEngineExcludeTypes = [5]
-
 [[test]]
 testTitle = 'DDBalance_Test'
 

--- a/tests/slow/VersionStampBackupToDB.toml
+++ b/tests/slow/VersionStampBackupToDB.toml
@@ -2,7 +2,6 @@
 extraDatabaseMode = 'Single'
 # required tenant mode is not supported for Disaster Recovery yet
 tenantModes = ['disabled', 'optional']
-storageEngineExcludeTypes = [5]
 
 [[test]]
 testTitle = 'VersionStampBackupToDB'

--- a/tests/slow/ddbalance.toml
+++ b/tests/slow/ddbalance.toml
@@ -1,6 +1,3 @@
-[configuration]
-storageEngineExcludeTypes = [5]
-
 [[test]]
 testTitle = 'DDBalance_Test'
 


### PR DESCRIPTION
This PR includes:
- Speedup ShardedRocksDB in simulation tests such that no external timeout is expected to happen. We found that most of the time is spent on commit operations. We found that (1) reducing the shard count in buggify cases and (2) conducting compaction when data move completes can significantly speedup the simulation.
- Re-enable ShardedRocksDB in simulation tests;
- Re-enable EncodeShardLocationMetadata in simulation tests, which is a dependency to use ShardedRocksDB in the test;
- Disable PhysicalShardMove in simulation tests (will re-enable once ShardedRocksDB is well tested).

Passed 500K simulation tests with 7 failures but none of them is an external timeout failure:
  20240907-202158-zhewang-11dc73ea71ef059e           compressed=True data_size=37215663 duration=20283071 ended=500000 fail=7 fail_fast=10 max_runs=500000 pass=499993 priority=100 remaining=0 runtime=2:05:19 sanity=False started=500000 stopped=20240907-222717 submitted=20240907-202158 timeout=5400 username=zhewang

Note that current 500K correct tests only include 10000 tests with ShardedRocksDB because ShardedRocksDB is excluded if ShardEncodeLocationMetadata is off.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
