### PR TITLE
Fix bug in PR 11628, which did not account for pseudo tags

### DIFF
--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -836,8 +836,10 @@ std::set<Tag> CommitBatchContext::getWrittenTagsPreResolution() {
 		}
 	}
 
-	toCommit.storeRandomRouterTag();
-	transactionTags.insert(toCommit.savedRandomRouterTag.get());
+	if (toCommit.getLogRouterTags()) {
+		toCommit.storeRandomRouterTag();
+		transactionTags.insert(toCommit.savedRandomRouterTag.get());
+	}
 
 	return transactionTags;
 }

--- a/fdbserver/include/fdbserver/LogSystem.h
+++ b/fdbserver/include/fdbserver/LogSystem.h
@@ -817,6 +817,7 @@ struct LogPushData : NonCopyable {
 
 	Optional<Tag> savedRandomRouterTag;
 	void storeRandomRouterTag() { savedRandomRouterTag = logSystem->getRandomRouterTag(); }
+	int getLogRouterTags() { return logSystem->getLogRouterTags(); }
 
 private:
 	Reference<ILogSystem> logSystem;


### PR DESCRIPTION
Fix bug in PR 11628, which did not account for pseudo tags. We should only choose a random log router if they exist.

Joshua
`20240910-143156-dlambrig-d0c459c96e5eae1d`

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
