### PR TITLE
Disable version vector for tenant test.

### DIFF
--- a/tests/fast/RawTenantAccessClean.toml
+++ b/tests/fast/RawTenantAccessClean.toml
@@ -5,6 +5,8 @@ allowCreatingTenants = false
 
 [[knobs]]
 proxy_use_resolver_private_mutations = false
+enable_version_vector = false
+enable_version_vector_tlog_unicast = false
 
 [[test]]
 testTitle = 'RawTenantAccessClean'


### PR DESCRIPTION
Disable version vector for tenant test. `proxy_use_resolver_private_mutations` was already disabled for the test. I ran Joshua with `proxy_use_resolver_private_mutations` enabled and it passed for the test. However, it is possible the chosen seed did not result in a failure. It is safer to disable version vector entirely for the test. We do not maintain the tenant feature and making it work with experimental features like version vector is premature.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
