### PR TITLE
Refactor version vector related recovery version computation logic

### DIFF
--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -1933,11 +1933,18 @@ void SimulationConfig::setReplicationType(const TestConfig& testConfig) {
 			// FIXME: log replicas must be more than storage replicas because otherwise better master exists will not
 			// recognize it needs to change dcs
 			int replication_factor = deterministicRandom()->randomInt(storage_servers, generateFearless ? 4 : 5);
-			int anti_quorum = deterministicRandom()->randomInt(
-			    0,
-			    (replication_factor / 2) +
-			        1); // The anti quorum cannot be more than half of the replication factor, or the
-			            // log system will continue to accept commits when a recovery is impossible
+			// Version vector is an experimental feature that does not support logWriteAntiQuorum
+			// feature. Disable logWriteAntiQuorum (when version vector is enabled) in simulation
+			// tests for now.
+			// @todo extend version vector to support logWriteAntiQuorum feature.
+			int anti_quorum =
+			    SERVER_KNOBS->ENABLE_VERSION_VECTOR
+			        ? 0
+			        : (deterministicRandom()->randomInt(
+			              0,
+			              (replication_factor / 2) +
+			                  1)); // The anti quorum cannot be more than half of the replication factor, or the
+			                       // log system will continue to accept commits when a recovery is impossible
 			// Go through buildConfiguration, as it sets tLogPolicy/storagePolicy.
 			set_config(format("storage_replicas:=%d log_replicas:=%d log_anti_quorum:=%d "
 			                  "replica_datacenters:=1 min_replica_datacenters:=1",

--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -2086,8 +2086,8 @@ ACTOR Future<Void> TagPartitionedLogSystem::getDurableVersionChanged(LogLockInfo
 	return Void();
 }
 
-void getTLogLocIds(std::vector<Reference<LogSet>>& tLogs,
-                   std::tuple<int, std::vector<TLogLockResult>>& logGroupResults,
+void getTLogLocIds(const std::vector<Reference<LogSet>>& tLogs,
+                   const std::tuple<int, std::vector<TLogLockResult>>& logGroupResults,
                    std::vector<uint16_t>& tLogLocIds,
                    uint16_t& maxTLogLocId) {
 	// Initialization.
@@ -2119,7 +2119,7 @@ void getTLogLocIds(std::vector<Reference<LogSet>>& tLogs,
 	}
 }
 
-void populateBitset(boost::dynamic_bitset<>& bs, std::vector<uint16_t>& ids) {
+void populateBitset(boost::dynamic_bitset<>& bs, const std::vector<uint16_t>& ids) {
 	for (auto& id : ids) {
 		ASSERT(id < bs.size());
 		bs.set(id);
@@ -2131,7 +2131,7 @@ void populateBitset(boost::dynamic_bitset<>& bs, std::vector<uint16_t>& ids) {
 // All prior versions to the chosen RV must also be recoverable.
 // TODO: unit tests to stress UNICAST
 Version getRecoverVersionUnicast(std::vector<Reference<LogSet>>& logServers,
-                                 std::tuple<int, std::vector<TLogLockResult>>& logGroupResults,
+                                 const std::tuple<int, std::vector<TLogLockResult>>& logGroupResults,
                                  Version minDV,
                                  Version minKCV) {
 	std::vector<uint16_t> tLogLocIds;

--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -2130,7 +2130,7 @@ void populateBitset(boost::dynamic_bitset<>& bs, const std::vector<uint16_t>& id
 // This function finds the highest recoverable version for each tLog group over all log groups.
 // All prior versions to the chosen RV must also be recoverable.
 // TODO: unit tests to stress UNICAST
-Version getRecoverVersionUnicast(std::vector<Reference<LogSet>>& logServers,
+Version getRecoverVersionUnicast(const std::vector<Reference<LogSet>>& logServers,
                                  const std::tuple<int, std::vector<TLogLockResult>>& logGroupResults,
                                  Version minDV,
                                  Version minKCV) {


### PR DESCRIPTION
Changes:
- Disable logWriteAntiQuorum when version vector is enabled (as we don't use logWriteAntiQuorum in production and we don't like to put in the effort needed to make version vector work with logWriteAntiQuorum at this stage)
- Refactor the version vector related recovery version computation logic in order to make it work better with the recovery restart logic

Testing:
Joshua job (with version vector disabled): 20240911-200559-sre-99f295f99cda7e02 (started)

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
