### PR TITLE
Reduce retry count when SS interface is not found

### DIFF
--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -1869,7 +1869,7 @@ ACTOR Future<Void> runConsistencyCheckerUrgentCore(Reference<AsyncVar<Optional<C
 			} else { // In simulation
 				ts = testers.get();
 			}
-			TraceEvent(SevInfo, "ConsistencyCheckUrgent_GoTTesters")
+			TraceEvent(SevInfo, "ConsistencyCheckUrgent_GotTesters")
 			    .detail("ConsistencyCheckerId", consistencyCheckerId)
 			    .detail("Round", round)
 			    .detail("RetryTimes", retryTimes)

--- a/fdbserver/workloads/ConsistencyCheckUrgent.actor.cpp
+++ b/fdbserver/workloads/ConsistencyCheckUrgent.actor.cpp
@@ -283,7 +283,8 @@ struct ConsistencyCheckUrgentWorkload : TestWorkload {
 					}
 					wait(delay(5.0));
 					retryCount++;
-					if (retryCount > 50) {
+					if (retryCount > 10) {
+						// SS could be removed from the cluster
 						throw timed_out();
 					}
 				}
@@ -324,6 +325,7 @@ struct ConsistencyCheckUrgentWorkload : TestWorkload {
 							valueAvailableToCheck = false;
 							TraceEvent e(SevInfo, "ConsistencyCheckUrgent_TesterGetRangeError");
 							e.detail("ResultPresent", rangeResult.present());
+							e.detail("StorageServer", storageServerInterfaces[j].uniqueID);
 							if (rangeResult.present()) {
 								e.detail("ErrorPresent", rangeResult.get().error.present());
 								if (rangeResult.get().error.present()) {
@@ -331,6 +333,10 @@ struct ConsistencyCheckUrgentWorkload : TestWorkload {
 								}
 							} else {
 								e.detail("ResultNotPresentWithError", rangeResult.getError().what());
+								if (g_network->isSimulated() &&
+								    g_simulator->getProcessByAddress(storageServerInterfaces[j].address())->failed) {
+									e.detail("MachineFailed", "True");
+								}
 							}
 							break;
 						}


### PR DESCRIPTION
To speed up ConsistencyCheckUrgent workload that can take very long time in simulation.


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
