### PR TITLE
[Release-7.3] Do not select a machine to build team if each SS of the machine has too many ServerTeams

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -354,7 +354,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( REBALANCE_STORAGE_QUEUE_SHARD_PER_KSEC_MIN, SHARD_MIN_BYTES_PER_KSEC);
 	init( DD_ENABLE_REBALANCE_STORAGE_QUEUE_WITH_LIGHT_WRITE_SHARD, true ); if ( isSimulated ) DD_ENABLE_REBALANCE_STORAGE_QUEUE_WITH_LIGHT_WRITE_SHARD = deterministicRandom()->coinflip();
 	init( DD_WAIT_TSS_DATA_MOVE_DELAY,                          15.0 ); if (isSimulated) DD_WAIT_TSS_DATA_MOVE_DELAY = deterministicRandom()->randomInt(5, 30);
-	init( CHECK_SERVER_TEAM_WHEN_SELECT_MACHINE_TO_BUILD_SERVER_TEAM, false ); if (isSimulated) CHECK_SERVER_TEAM_WHEN_SELECT_MACHINE_TO_BUILD_SERVER_TEAM = deterministicRandom()->coinflip();
+	init( BUDGET_CHECK_SERVER_CONTEXT_WHEN_BUILD_TEAM,             0 ); if (isSimulated) BUDGET_CHECK_SERVER_CONTEXT_WHEN_BUILD_TEAM = deterministicRandom()->randomInt(0, 10);
 
 	// Large teams are disabled when SHARD_ENCODE_LOCATION_METADATA is enabled
 	init( DD_MAX_SHARDS_ON_LARGE_TEAMS,                          100 ); if( randomize && BUGGIFY ) DD_MAX_SHARDS_ON_LARGE_TEAMS = deterministicRandom()->randomInt(0, 3);

--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -354,6 +354,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( REBALANCE_STORAGE_QUEUE_SHARD_PER_KSEC_MIN, SHARD_MIN_BYTES_PER_KSEC);
 	init( DD_ENABLE_REBALANCE_STORAGE_QUEUE_WITH_LIGHT_WRITE_SHARD, true ); if ( isSimulated ) DD_ENABLE_REBALANCE_STORAGE_QUEUE_WITH_LIGHT_WRITE_SHARD = deterministicRandom()->coinflip();
 	init( DD_WAIT_TSS_DATA_MOVE_DELAY,                          15.0 ); if (isSimulated) DD_WAIT_TSS_DATA_MOVE_DELAY = deterministicRandom()->randomInt(5, 30);
+	init( CHECK_SERVER_TEAM_WHEN_SELECT_MACHINE_TO_BUILD_SERVER_TEAM, false ); if (isSimulated) CHECK_SERVER_TEAM_WHEN_SELECT_MACHINE_TO_BUILD_SERVER_TEAM = deterministicRandom()->coinflip();
 
 	// Large teams are disabled when SHARD_ENCODE_LOCATION_METADATA is enabled
 	init( DD_MAX_SHARDS_ON_LARGE_TEAMS,                          100 ); if( randomize && BUGGIFY ) DD_MAX_SHARDS_ON_LARGE_TEAMS = deterministicRandom()->randomInt(0, 3);

--- a/fdbclient/include/fdbclient/ServerKnobs.h
+++ b/fdbclient/include/fdbclient/ServerKnobs.h
@@ -337,8 +337,8 @@ public:
 	bool DD_ENABLE_REBALANCE_STORAGE_QUEUE_WITH_LIGHT_WRITE_SHARD; // Enable to allow storage queue rebalancer to move
 	                                                               // light-traffic shards out of the overloading server
 	double DD_WAIT_TSS_DATA_MOVE_DELAY;
-	bool CHECK_SERVER_TEAM_WHEN_SELECT_MACHINE_TO_BUILD_SERVER_TEAM; // Enable to build team on servers which do not
-	                                                                 // have teams exceeding the target count
+	int BUDGET_CHECK_SERVER_CONTEXT_WHEN_BUILD_TEAM; // Enable to check if server context when building teams in the
+	                                                 // first considerContextBudget attempts
 
 	// TeamRemover to remove redundant teams
 	bool TR_FLAG_DISABLE_MACHINE_TEAM_REMOVER; // disable the machineTeamRemover actor

--- a/fdbclient/include/fdbclient/ServerKnobs.h
+++ b/fdbclient/include/fdbclient/ServerKnobs.h
@@ -338,7 +338,7 @@ public:
 	                                                               // light-traffic shards out of the overloading server
 	double DD_WAIT_TSS_DATA_MOVE_DELAY;
 	int BUDGET_CHECK_SERVER_CONTEXT_WHEN_BUILD_TEAM; // Enable to check if server context when building teams in the
-	                                                 // first considerContextBudget attempts
+	                                                 // first specified attempts
 
 	// TeamRemover to remove redundant teams
 	bool TR_FLAG_DISABLE_MACHINE_TEAM_REMOVER; // disable the machineTeamRemover actor

--- a/fdbclient/include/fdbclient/ServerKnobs.h
+++ b/fdbclient/include/fdbclient/ServerKnobs.h
@@ -337,6 +337,8 @@ public:
 	bool DD_ENABLE_REBALANCE_STORAGE_QUEUE_WITH_LIGHT_WRITE_SHARD; // Enable to allow storage queue rebalancer to move
 	                                                               // light-traffic shards out of the overloading server
 	double DD_WAIT_TSS_DATA_MOVE_DELAY;
+	bool CHECK_SERVER_TEAM_WHEN_SELECT_MACHINE_TO_BUILD_SERVER_TEAM; // Enable to build team on servers which do not
+	                                                                 // have teams exceeding the target count
 
 	// TeamRemover to remove redundant teams
 	bool TR_FLAG_DISABLE_MACHINE_TEAM_REMOVER; // disable the machineTeamRemover actor

--- a/fdbserver/include/fdbserver/DDTeamCollection.h
+++ b/fdbserver/include/fdbserver/DDTeamCollection.h
@@ -389,6 +389,10 @@ protected:
 	// Return the healthy server with the least number of correct-size server teams
 	Reference<TCServerInfo> findOneLeastUsedServer() const;
 
+	// Return true if each machine of the input machineTeam has at least one server that has server team size is smaller
+	// than the target server teams, i,e, still has room to add more serverTeam
+	bool isAvailableToBuildMoreServerTeam(const TCMachineTeamInfo& machineTeam) const;
+
 	// A server team should always come from servers on a machine team
 	// Check if it is true
 	bool isOnSameMachineTeam(TCTeamInfo const& team) const;

--- a/fdbserver/include/fdbserver/DDTeamCollection.h
+++ b/fdbserver/include/fdbserver/DDTeamCollection.h
@@ -389,9 +389,15 @@ protected:
 	// Return the healthy server with the least number of correct-size server teams
 	Reference<TCServerInfo> findOneLeastUsedServer() const;
 
-	// Return true if each machine of the input machineTeam has at least one server that has server team size is smaller
-	// than the target server teams, i,e, still has room to add more serverTeam
-	bool isAvailableToBuildMoreServerTeam(const TCMachineTeamInfo& machineTeam) const;
+	// Return ture if the input server has server team size smaller than the target server teams
+	bool isServerAvailableToBuildMoreServerTeam(const TCServerInfo& server) const;
+
+	// Return true if any server on the input machine has server team size smaller than the target server teams
+	bool isMachineAvailableToBuildMoreServerTeam(const TCMachineInfo& machine) const;
+
+	// Return true if each machine of the input machineTeam has at least one server that has server team size is
+	// smaller than the target server teams, i,e, still has room to add more serverTeam
+	bool isMachineTeamAvailableToBuildMoreServerTeam(const TCMachineTeamInfo& machineTeam) const;
 
 	// A server team should always come from servers on a machine team
 	// Check if it is true

--- a/fdbserver/include/fdbserver/DDTeamCollection.h
+++ b/fdbserver/include/fdbserver/DDTeamCollection.h
@@ -325,7 +325,7 @@ protected:
 
 	// Randomly choose one machine team that has chosenServer and has the correct size
 	// When configuration is changed, we may have machine teams with old storageTeamSize
-	Reference<TCMachineTeamInfo> findOneRandomMachineTeam(TCServerInfo const& chosenServer) const;
+	Reference<TCMachineTeamInfo> findOneRandomMachineTeam(TCServerInfo const& chosenServer, bool considerContext) const;
 
 	// Returns a server team from given "servers", empty team if not found.
 	// When "wantHealthy" is true, only return if the team is healthy.

--- a/fdbserver/include/fdbserver/DDTeamCollection.h
+++ b/fdbserver/include/fdbserver/DDTeamCollection.h
@@ -403,6 +403,9 @@ protected:
 	// Check if it is true
 	bool isOnSameMachineTeam(TCTeamInfo const& team) const;
 
+	// Return the targetTeamNumPerServer. For the calculation, see comments of the implementation
+	int getTargetTeamNumPerServer() const;
+
 	int calculateHealthyServerCount() const;
 
 	int calculateHealthyMachineCount() const;


### PR DESCRIPTION
TeamBuilder and TeamRemover have a target of the number of teams for each server. However, this target is not enforced when finding a machine to add more server team. It is possible that some server has significantly more teams than the target. As a result, the number of teams is unbalanced among servers.

100K correctness tests:

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
