### PR TITLE
[Release-7.3] Reduce workload of MutationLogReaderCorrectness

### DIFF
--- a/fdbserver/workloads/MutationLogReaderCorrectness.actor.cpp
+++ b/fdbserver/workloads/MutationLogReaderCorrectness.actor.cpp
@@ -60,7 +60,7 @@ struct MutationLogReaderCorrectnessWorkload : TestWorkload {
 
 		beginVersion = deterministicRandom()->randomInt64(
 		    0, std::numeric_limits<int32_t>::max()); // intentionally not max of int64
-		records = deterministicRandom()->randomInt(0, 1e6);
+		records = deterministicRandom()->randomInt(0, 1e5);
 		versionRange = deterministicRandom()->randomInt64(records, std::numeric_limits<Version>::max());
 		versionIncrement = versionRange / (records + 1);
 


### PR DESCRIPTION
MutationLogReaderCorrectness is too heavy, which can cause TracedTooManyLines failures in simulation tests.

100K MutationLogReaderCorrectness tests with the change:
  20240923-220004-zhewang-0a9705842327e11e           compressed=True data_size=35146791 duration=3279293 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:38:59 sanity=False started=100000 stopped=20240923-223903 submitted=20240923-220004 timeout=5400 username=zhewang
  
# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
