### PR TITLE
fixup! Use boost_target_program_options instead of Boost::program_opt…

### DIFF
--- a/fdbrpc/tests/CMakeLists.txt
+++ b/fdbrpc/tests/CMakeLists.txt
@@ -9,4 +9,4 @@ if(NOT WIN32)
 endif()
 
 add_flow_target(EXECUTABLE NAME fdbrpc_bench SRCS fdbrpc_bench.actor.cpp)
-target_link_libraries(fdbrpc_bench PUBLIC flow fdbrpc Boost::program_options)
+target_link_libraries(fdbrpc_bench PUBLIC flow fdbrpc boost_target_program_options)


### PR DESCRIPTION
…ions

This is try to fix error

  Target "fdbrpc_bench" links to:

    Boost::program_options

  but the target was not found.  Possible reasons include:

in nightly build

Replace this text with your description here...

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
