### PR TITLE
Remove the usage of txsTag

### DIFF
--- a/design/transaction-state-store.md
+++ b/design/transaction-state-store.md
@@ -67,7 +67,7 @@ backup data and is *NOT* metadata mutations.
 
 When a commit proxy writes metadata mutations to the log system, the proxy assigns a
 "txs" tag to the mutation. Depending on FDB versions, the "txs" tag can be one special
-tag `txsTag{ tagLocalitySpecial, 1 }` for `TLogVersion::V3` (FDB 6.1) or a randomized
+tag `txsTag{ tagLocalitySpecial, 1 }` for `TLogVersion::V3` (FDB 6.1, obsolete now) or a randomized
 "txs" tag for `TLogVersion::V4` (FDB 6.2 and later) and larger. The idea of randomized
 "txs" tag is to spread metadata mutations to all TLogs for faster parallel recovery of
 `txnStateStore`.

--- a/fdbclient/ReadYourWrites.actor.cpp
+++ b/fdbclient/ReadYourWrites.actor.cpp
@@ -2532,7 +2532,7 @@ void ReadYourWritesTransaction::setOption(FDBTransactionOptions::Option option, 
 }
 
 void ReadYourWritesTransaction::setOptionImpl(FDBTransactionOptions::Option option, Optional<StringRef> value) {
-	TraceEvent(SevDebug, "TransactionSetOption").detail("Option", option).detail("Value", value);
+	TraceEvent(SevVerbose, "TransactionSetOption").detail("Option", option).detail("Value", value);
 	switch (option) {
 	case FDBTransactionOptions::READ_YOUR_WRITES_DISABLE:
 		validateOptionValueNotPresent(value);

--- a/fdbclient/include/fdbclient/FDBTypes.h
+++ b/fdbclient/include/fdbclient/FDBTypes.h
@@ -158,8 +158,6 @@ static const Tag invalidTag{ tagLocalitySpecial, 0 };
 static const Tag txsTag{ tagLocalitySpecial, 1 }; // obsolete now
 static const Tag cacheTag{ tagLocalitySpecial, 2 };
 
-enum { txsTagOld = -1, invalidTagOld = -100 };
-
 struct TagsAndMessage {
 	StringRef message;
 	VectorRef<Tag> tags;

--- a/fdbclient/include/fdbclient/FDBTypes.h
+++ b/fdbclient/include/fdbclient/FDBTypes.h
@@ -155,7 +155,7 @@ struct hash<Tag> {
 } // namespace std
 
 static const Tag invalidTag{ tagLocalitySpecial, 0 };
-static const Tag txsTag{ tagLocalitySpecial, 1 };
+static const Tag txsTag{ tagLocalitySpecial, 1 }; // obsolete now
 static const Tag cacheTag{ tagLocalitySpecial, 2 };
 
 enum { txsTagOld = -1, invalidTagOld = -100 };

--- a/fdbserver/LogSystem.cpp
+++ b/fdbserver/LogSystem.cpp
@@ -179,6 +179,9 @@ void LogSet::checkSatelliteTagLocations() {
 }
 
 int LogSet::bestLocationFor(Tag tag) {
+	if (tag == txsTag) {
+		ASSERT(false);
+	}
 	if (locality == tagLocalitySatellite) {
 		return satelliteTagLocations[tag == txsTag ? 0 : tag.id + 1][0];
 	}
@@ -219,6 +222,7 @@ bool LogSet::satisfiesPolicy(const std::vector<LocalityEntry>& locations) {
 void LogSet::getPushLocations(VectorRef<Tag> tags, std::vector<int>& locations, int locationOffset, bool allLocations) {
 	if (locality == tagLocalitySatellite) {
 		for (auto& t : tags) {
+			ASSERT(t != txsTag);
 			if (t == txsTag || t.locality == tagLocalityTxs || t.locality == tagLocalityLogRouter) {
 				for (int loc : satelliteTagLocations[t == txsTag ? 0 : t.id + 1]) {
 					locations.push_back(locationOffset + loc);
@@ -285,6 +289,7 @@ void LogPushData::addTxsTag() {
 	if (logSystem->getTLogVersion() >= TLogVersion::V4) {
 		next_message_tags.push_back(logSystem->getRandomTxsTag());
 	} else {
+		ASSERT(false);
 		next_message_tags.push_back(txsTag);
 	}
 }

--- a/fdbserver/LogSystem.cpp
+++ b/fdbserver/LogSystem.cpp
@@ -179,16 +179,10 @@ void LogSet::checkSatelliteTagLocations() {
 }
 
 int LogSet::bestLocationFor(Tag tag) {
-	if (tag == txsTag) {
-		ASSERT(false);
-	}
 	if (locality == tagLocalitySatellite) {
-		return satelliteTagLocations[tag == txsTag ? 0 : tag.id + 1][0];
+		return satelliteTagLocations[tag.id + 1][0];
 	}
 
-	// the following logic supports upgrades from 5.X
-	if (tag == txsTag)
-		return txsTagOld % logServers.size();
 	return tag.id % logServers.size();
 }
 
@@ -222,9 +216,8 @@ bool LogSet::satisfiesPolicy(const std::vector<LocalityEntry>& locations) {
 void LogSet::getPushLocations(VectorRef<Tag> tags, std::vector<int>& locations, int locationOffset, bool allLocations) {
 	if (locality == tagLocalitySatellite) {
 		for (auto& t : tags) {
-			ASSERT(t != txsTag);
-			if (t == txsTag || t.locality == tagLocalityTxs || t.locality == tagLocalityLogRouter) {
-				for (int loc : satelliteTagLocations[t == txsTag ? 0 : t.id + 1]) {
+			if (t.locality == tagLocalityTxs || t.locality == tagLocalityLogRouter) {
+				for (int loc : satelliteTagLocations[t.id + 1]) {
 					locations.push_back(locationOffset + loc);
 				}
 			}
@@ -286,12 +279,7 @@ LogPushData::LogPushData(Reference<ILogSystem> logSystem, int tlogCount) : logSy
 }
 
 void LogPushData::addTxsTag() {
-	if (logSystem->getTLogVersion() >= TLogVersion::V4) {
-		next_message_tags.push_back(logSystem->getRandomTxsTag());
-	} else {
-		ASSERT(false);
-		next_message_tags.push_back(txsTag);
-	}
+	next_message_tags.push_back(logSystem->getRandomTxsTag());
 }
 
 void LogPushData::addTransactionInfo(SpanContext const& context) {

--- a/fdbserver/MutationTracking.cpp
+++ b/fdbserver/MutationTracking.cpp
@@ -90,8 +90,8 @@ TraceEvent debugTagsAndMessageEnabled(const char* context, Version version, Stri
 		}
 		TagsAndMessage msg;
 		msg.loadFromArena(&rdr, nullptr);
-		bool logAdapterMessage = std::any_of(
-		    msg.tags.begin(), msg.tags.end(), [](const Tag& t) { return t == txsTag || t.locality == tagLocalityTxs; });
+		bool logAdapterMessage =
+		    std::any_of(msg.tags.begin(), msg.tags.end(), [](const Tag& t) { return t.locality == tagLocalityTxs; });
 		StringRef mutationData = msg.getMessageWithoutTags();
 		uint8_t mutationType = *mutationData.begin();
 		if (logAdapterMessage) {

--- a/fdbserver/StorageCache.actor.cpp
+++ b/fdbserver/StorageCache.actor.cpp
@@ -1402,6 +1402,7 @@ ACTOR Future<Void> fetchKeys(StorageCacheData* data, AddingCacheRange* cacheRang
 					// TODO: NEELAM: what's this for?
 					// FIXME: remove when we no longer support upgrades from 5.X
 					if (debug_getRangeRetries >= 100) {
+						ASSERT(false);
 						data->cx->enableLocalityLoadBalance = EnableLocalityLoadBalance::False;
 					}
 

--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -1161,9 +1161,8 @@ Reference<ILogSystem::IPeekCursor> TagPartitionedLogSystem::peekTxs(UID dbgid,
 	Version end = getEnd();
 	if (!tLogs.size()) {
 		TraceEvent("TLogPeekTxsNoLogs", dbgid).log();
-		// TODO:
 		return makeReference<ILogSystem::ServerPeekCursor>(
-		    Reference<AsyncVar<OptionalInterface<TLogInterface>>>(), txsTag, begin, end, false, false);
+		    Reference<AsyncVar<OptionalInterface<TLogInterface>>>(), invalidTag, begin, end, false, false);
 	}
 	TraceEvent("TLogPeekTxs", dbgid)
 	    .detail("Begin", begin)

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -8747,13 +8747,6 @@ ACTOR Future<Void> fetchKeys(StorageServer* data, AddingShard* shard) {
 					    .suppressFor(1.0)
 					    .detail("FKID", interval.pairID);
 
-					// FIXME: remove when we no longer support upgrades from 5.X
-					if (debug_getRangeRetries >= 100) {
-						ASSERT(false);
-						data->cx->enableLocalityLoadBalance = EnableLocalityLoadBalance::False;
-						TraceEvent(SevWarnAlways, "FKDisableLB").detail("FKID", fetchKeysID);
-					}
-
 					debug_getRangeRetries++;
 					if (debug_nextRetryToLog == debug_getRangeRetries) {
 						debug_nextRetryToLog += std::min(debug_nextRetryToLog, 1024);
@@ -8805,14 +8798,6 @@ ACTOR Future<Void> fetchKeys(StorageServer* data, AddingShard* shard) {
 				}
 				break;
 			}
-		}
-
-		// FIXME: remove when we no longer support upgrades from 5.X
-		if (!data->cx->enableLocalityLoadBalance) {
-			ASSERT(false);
-
-			data->cx->enableLocalityLoadBalance = EnableLocalityLoadBalance::True;
-			TraceEvent(SevWarnAlways, "FKReenableLB").detail("FKID", fetchKeysID);
 		}
 
 		// We have completed the fetch and write of the data, now we wait for MVCC window to pass.

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -8749,6 +8749,7 @@ ACTOR Future<Void> fetchKeys(StorageServer* data, AddingShard* shard) {
 
 					// FIXME: remove when we no longer support upgrades from 5.X
 					if (debug_getRangeRetries >= 100) {
+						ASSERT(false);
 						data->cx->enableLocalityLoadBalance = EnableLocalityLoadBalance::False;
 						TraceEvent(SevWarnAlways, "FKDisableLB").detail("FKID", fetchKeysID);
 					}
@@ -8808,6 +8809,8 @@ ACTOR Future<Void> fetchKeys(StorageServer* data, AddingShard* shard) {
 
 		// FIXME: remove when we no longer support upgrades from 5.X
 		if (!data->cx->enableLocalityLoadBalance) {
+			ASSERT(false);
+
 			data->cx->enableLocalityLoadBalance = EnableLocalityLoadBalance::True;
 			TraceEvent(SevWarnAlways, "FKReenableLB").detail("FKID", fetchKeysID);
 		}

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -8622,7 +8622,7 @@ ACTOR Future<Void> fetchKeys(StorageServer* data, AddingShard* shard) {
 			}
 			ASSERT(fetchVersion >= shard->fetchVersion); // at this point, shard->fetchVersion is the last fetchVersion
 			shard->fetchVersion = fetchVersion;
-			TraceEvent(SevDebug, "FetchKeysUnblocked", data->thisServerID)
+			TraceEvent(SevVerbose, "FetchKeysUnblocked", data->thisServerID)
 			    .detail("FKID", interval.pairID)
 			    .detail("Version", fetchVersion);
 


### PR DESCRIPTION
This tag is used for FDB 6.1 and is no longer needed now.

20240926-235242-jzhou-7ed3304c415ae65e             compressed=True data_size=34265556 duration=7364570 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:42:23 sanity=False started=100000 stopped=20240927-003505 submitted=20240926-235242 timeout=5400 username=jzhou

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
