### PR TITLE
Explicitly type 1e3 as int

### DIFF
--- a/bindings/bindingtester/tests/test_util.py
+++ b/bindings/bindingtester/tests/test_util.py
@@ -154,7 +154,7 @@ class RandomGenerator(object):
         elif random.random() < 0.75:
             limit = 0
         else:
-            limit = random.randint(1e8, (1 << 31) - 1)
+            limit = random.randint(int(1e8), (1 << 31) - 1)
 
         return (limit, random.randint(0, 1), random.randint(-2, 4))
 

--- a/bindings/bindingtester/tests/test_util.py
+++ b/bindings/bindingtester/tests/test_util.py
@@ -150,7 +150,7 @@ class RandomGenerator(object):
 
     def random_range_params(self):
         if random.random() < 0.75:
-            limit = random.randint(1, 1e3)
+            limit = random.randint(1, int(1e3))
         elif random.random() < 0.75:
             limit = 0
         else:


### PR DESCRIPTION
Fixes issue causing binding tester to throw error ('float' object cannot be interpreted as an integer) when using certain Python versions (encountered with 3.12.6).