### PR TITLE
Address a serialization issue that is blocking a patch upgrade

### DIFF
--- a/fdbserver/include/fdbserver/TLogInterface.h
+++ b/fdbserver/include/fdbserver/TLogInterface.h
@@ -161,7 +161,7 @@ struct TLogLockResult {
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, end, knownCommittedVersion, unknownCommittedVersions, id, logId);
+		serializer(ar, end, knownCommittedVersion, id, unknownCommittedVersions, logId);
 	}
 };
 
@@ -354,13 +354,13 @@ struct TLogCommitRequest : TimedRequest {
 		           version,
 		           knownCommittedVersion,
 		           minKnownCommittedVersion,
-		           seqPrevVersion,
 		           messages,
 		           reply,
 		           debugID,
 		           tLogCount,
-		           tLogLocIds,
 		           spanContext,
+		           seqPrevVersion,
+		           tLogLocIds,
 		           arena);
 	}
 };


### PR DESCRIPTION
Address a serialization issue that was causing a log server crash during a patch upgrade: any fields/members added (to a message) in a patch release should be serialized after the existing fields/members, and not in between them.

Testing:

Joshua job: 20241001-200314-sre-66f14df1e2a4d802 (no failures)

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
