### PR TITLE
[fdbserver][sim] Remove timeout reset in ClogTlog test

### DIFF
--- a/fdbserver/workloads/ClogTlog.actor.cpp
+++ b/fdbserver/workloads/ClogTlog.actor.cpp
@@ -129,16 +129,13 @@ struct ClogTlogWorkload : TestWorkload {
 	}
 
 	ACTOR static Future<Void> excludeFailedLog(ClogTlogWorkload* self, Database cx) {
-		state Future<Void> timeout = delay(30);
-
 		loop choose {
 			when(wait(self->dbInfo->onChange())) {
 				if (self->dbInfo->get().recoveryState >= RecoveryState::ACCEPTING_COMMITS) {
 					return Void();
 				}
-				timeout = delay(30);
 			}
-			when(wait(timeout)) {
+			when(wait(delay(30))) {
 				// recovery state hasn't changed in 30s, exclude the failed tlog
 				CODE_PROBE(true, "Exclude failed tlog");
 				TraceEvent("ExcludeFailedLog")


### PR DESCRIPTION
For some seeds, I found out that the `ClogTlog` test was timing out for force exclude use-case. The reason behind timeout was that when we decide to exclude, dbInfo can still keep changing and timeout value is reset every time. This meant that the test never triggered exclude. 

The fix is simply to not reset the timeout on dbInfo changes. For success, we still rely on dbInfo to reach `>= RecoveryState::ACCEPTING_COMMITS` as before. 

Ran 100K Joshua with only ClogTlog: `20240930-235558-praza-5a534ad91caaaf40`

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
