### PR TITLE
Address another protocol incompatibility issue between patch releases 7.3.43 and 7.3.53

### DIFF
--- a/fdbserver/include/fdbserver/TLogInterface.h
+++ b/fdbserver/include/fdbserver/TLogInterface.h
@@ -155,13 +155,14 @@ struct TLogLockResult {
 	constexpr static FileIdentifier file_identifier = 11822027;
 	Version end;
 	Version knownCommittedVersion;
+	std::deque<std::tuple<Version, int>> unknownCommittedVersionTuples; // unused, kept for compatibility
 	std::deque<UnknownCommittedVersions> unknownCommittedVersions;
 	UID id; // captures TLogData::dbgid
 	UID logId; // captures LogData::logId
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, end, knownCommittedVersion, id, unknownCommittedVersions, logId);
+		serializer(ar, end, knownCommittedVersion, unknownCommittedVersionTuples, id, unknownCommittedVersions, logId);
 	}
 };
 


### PR DESCRIPTION
Address another log interface related incompatibility issue between patch releases 7.3.43 and 7.3.53.

Testing:

- Joshua job: 20241009-165019-sre-acfb3b9fb88dc679 (no failures)
- Operator upgrade test https://github.com/FoundationDB/fdb-kubernetes-operator/blob/45fe4ccdfe5509b5ef1f02301947e64de7ab41d1/e2e/test_operator_upgrades_variations/operator_upgrades_variations_test.go#L174 (ran successfully)

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
