### PR TITLE
Fix actorcompiler target in CMake add_flow_target

### DIFF
--- a/cmake/CompileActorCompiler.cmake
+++ b/cmake/CompileActorCompiler.cmake
@@ -19,7 +19,7 @@ else()
   set(ACTOR_COMPILER_REFERENCES
     "-r:System,System.Core,System.Xml.Linq,System.Data.DataSetExtensions,Microsoft.CSharp,System.Data,System.Xml")
 
-  add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/actorcompiler.exe
+  add_custom_command(OUTPUT actorcompiler.exe
     COMMAND ${MCS_EXECUTABLE} ARGS ${ACTOR_COMPILER_REFERENCES} ${ACTORCOMPILER_SRCS} "-target:exe" "-out:actorcompiler.exe"
     DEPENDS ${ACTORCOMPILER_SRCS}
     COMMENT "Compile actor compiler" VERBATIM)

--- a/cmake/FlowCommands.cmake
+++ b/cmake/FlowCommands.cmake
@@ -237,12 +237,12 @@ function(add_flow_target)
         if(WIN32)
           add_custom_command(OUTPUT "${out_file}"
             COMMAND $<TARGET_FILE:actorcompiler> "${in_file}" "${out_file}" ${actor_compiler_flags}
-            DEPENDS "${in_file}" ${actor_exe}
+            DEPENDS "${in_file}" actorcompiler
             COMMENT "Compile actor: ${src}")
         else()
           add_custom_command(OUTPUT "${out_file}"
             COMMAND ${MONO_EXECUTABLE} ${actor_exe} "${in_file}" "${out_file}" ${actor_compiler_flags} > /dev/null
-            DEPENDS "${in_file}" ${actor_exe}
+            DEPENDS "${in_file}" actorcompiler
             COMMENT "Compile actor: ${src}")
         endif()
       endif()


### PR DESCRIPTION
I noticed this when working on a minimal Linux environment.

This also fixes #11595 - if Unix Makefiles is chosen for CMake builds, build was failing with:

```
make[2]: *** No rule to make target 'actorcompiler.exe', needed by 'flow/ActorCollection.actor.g.cpp'.  Stop.
```

I suspect it could have been a problem for Ninja as well since the issue was due to race condition, but probably it didn't happened so far for other unknown factors.

See this example in CMake add_custom_command documentation:

https://cmake.org/cmake/help/latest/command/add_custom_command.html#example-generating-files-for-multiple-targets

The correct target to depend on is `actorcompiler` for CMake to generate the right dependency order, `${actor_exe}` is just a string that points to the location of the actor compiler. See here:

https://github.com/apple/foundationdb/blob/4260bbb3c2e81531e1ec1493424544a2bea0c867/cmake/CompileActorCompiler.cmake#L26-L27

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
