### PR TITLE
fix bug TxnStateStoreCycleTest for version vector

### DIFF
--- a/fdbclient/include/fdbclient/IKeyValueStore.actor.h
+++ b/fdbclient/include/fdbclient/IKeyValueStore.actor.h
@@ -58,9 +58,9 @@ ACTOR static Future<Void> replaceRange_impl(class IKeyValueStore* self,
 class IKeyValueStore : public IClosable {
 public:
 	virtual KeyValueStoreType getType() const = 0;
+	virtual bool getReplaceContent() const { return false; };
 	// Returns true if the KV store supports shards, i.e., implements addRange(), removeRange(), and
 	// persistRangeMapping().
-	virtual bool getReplaceContent() const { return false; };
 	virtual bool shardAware() const { return false; }
 	virtual void set(KeyValueRef keyValue, const Arena* arena = nullptr) = 0;
 	virtual void clear(KeyRangeRef range, const Arena* arena = nullptr) = 0;

--- a/fdbclient/include/fdbclient/IKeyValueStore.actor.h
+++ b/fdbclient/include/fdbclient/IKeyValueStore.actor.h
@@ -60,6 +60,7 @@ public:
 	virtual KeyValueStoreType getType() const = 0;
 	// Returns true if the KV store supports shards, i.e., implements addRange(), removeRange(), and
 	// persistRangeMapping().
+	virtual bool getReplaceContent() const { return false; };
 	virtual bool shardAware() const { return false; }
 	virtual void set(KeyValueRef keyValue, const Arena* arena = nullptr) = 0;
 	virtual void clear(KeyRangeRef range, const Arena* arena = nullptr) = 0;

--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -815,6 +815,11 @@ inline bool shouldBackup(MutationRef const& m) {
 std::set<Tag> CommitBatchContext::getWrittenTagsPreResolution() {
 	std::set<Tag> transactionTags;
 	std::vector<Tag> cacheVector = { cacheTag };
+	if (pProxyCommitData->txnStateStore->getReplaceContent()) {
+		// return empty set if txnStateStore will snapshot.
+		// empty sets are sent to all logs.
+		return transactionTags;
+	}
 	for (int transactionNum = 0; transactionNum < trs.size(); transactionNum++) {
 		int mutationNum = 0;
 		VectorRef<MutationRef>* pMutations = &trs[transactionNum].transaction.mutations;

--- a/fdbserver/KeyValueStoreMemory.actor.cpp
+++ b/fdbserver/KeyValueStoreMemory.actor.cpp
@@ -52,6 +52,7 @@ public:
 	                    bool exactRecovery,
 	                    bool enableEncryption);
 
+	bool getReplaceContent() const override { return replaceContent; }
 	// IClosable
 	Future<Void> getError() const override { return log->getError(); }
 	Future<Void> onClosed() const override { return log->onClosed(); }


### PR DESCRIPTION
In version vector, during commits, all tags in the batch must be known by the post resolution phase. This contract was violated in a special case immediately after `KeyValueStoreMemory` is constructed. During this phase, `KeyValueStoreMemory` will snapshot its data, even though no metadata mutations were done, and hence no transaction tags included in the batch. This phase is denoted by boolean `KeyValueStoreMemory::replaceContent`. The PR checks for that case to ensure the snapshot is sent to all logs.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
