### PR TITLE
Address another patch release version incompatibility issue

### DIFF
--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -2414,8 +2414,6 @@ ACTOR Future<Void> tLogCommit(TLogData* self,
 			       self->unknownCommittedVersions.back().version <= req.knownCommittedVersion) {
 				self->unknownCommittedVersions.pop_back();
 			}
-		} else {
-			ASSERT(req.prevVersion == req.seqPrevVersion); // @todo remove this assert later
 		}
 
 		if (req.debugID.present())


### PR DESCRIPTION
Remove an assertion (that validates prevVersion in the proxy to log server commit message) that is causing version incompatibility between 7.3.43 and 7.3.53 patch releases. The assertion can fail, even on a valid commit message, when the proxy and the log server are running on 7.3.43 and 7.3.53 patch release versions.

Testing:
Joshua job: 20241025-201225-sre-667b90991a0a5f57 (had a failure in "ReadSkewReadWrite.toml" test with RocksDB storage engine). 20241025-212258-sre-667b90991a0a5f57 (no failures).
Operator upgrade and downgrade tests: Ran the tests over image "7.3.54-sre-dev" (that's built over this PR's commit) and the tests succeeded (note: ran the downgrade test five times).


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
