### PR TITLE
Fix valgrind errors of uninitialised values

### DIFF
--- a/fdbserver/include/fdbserver/StorageServerUtils.h
+++ b/fdbserver/include/fdbserver/StorageServerUtils.h
@@ -26,7 +26,7 @@
 #include "flow/flow.h"
 #include "fdbclient/StorageCheckpoint.h"
 
-enum class MoveInPhase {
+enum class MoveInPhase : std::int8_t {
 	Pending = 0,
 	Fetching = 1,
 	Ingesting = 2,
@@ -45,13 +45,13 @@ struct MoveInShardMetaData {
 	UID id;
 	UID dataMoveId;
 	std::vector<KeyRange> ranges; // The key ranges to be fetched.
-	Version createVersion;
-	Version highWatermark; // The highest version that has been applied to the MoveInShard.
-	int8_t phase; // MoveInPhase.
+	Version createVersion = invalidVersion;
+	Version highWatermark = invalidVersion; // The highest version that has been applied to the MoveInShard.
+	int8_t phase = static_cast<int8_t>(MoveInPhase::Error); // MoveInPhase.
 	std::vector<CheckpointMetaData> checkpoints; // All related checkpoints, they should cover `ranges`.
 	Optional<std::string> error;
-	double startTime;
-	bool conductBulkLoad;
+	double startTime = 0.0;
+	bool conductBulkLoad = false;
 
 	MoveInShardMetaData() = default;
 	MoveInShardMetaData(const UID& id,


### PR DESCRIPTION
Found by Valgrind nightly

| Test File                                           |       Seed |   Buggify |
|-----------------------------------------------------|------------|-----------|
| slow/ParallelRestoreNewBackupWriteDuringReadAtomicRestore.toml| 4164037972 |         1 |
| fast/MoveKeysCycle.toml                             |  642705924 |         0 |
| fast/BulkLoading.toml                               |  608748010 |         0 |

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
