### PR TITLE
Urgent consistency checker fixes

### DIFF
--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -26,6 +26,7 @@
 #include <iterator>
 #include <map>
 #include <streambuf>
+#include <numeric>
 
 #include <fmt/ranges.h>
 #include <toml.hpp>
@@ -1765,7 +1766,13 @@ std::unordered_map<int, std::vector<KeyRange>> makeTaskAssignment(Database cx,
                                                                   std::vector<KeyRange> shardsToCheck,
                                                                   int testersCount,
                                                                   int round) {
+	ASSERT(testersCount >= 1);
 	std::unordered_map<int, std::vector<KeyRange>> assignment;
+
+	std::vector<size_t> shuffledIndices(testersCount);
+	std::iota(shuffledIndices.begin(), shuffledIndices.end(), 0); // creates [0, 1, ..., testersCount - 1]
+	deterministicRandom()->randomShuffle(shuffledIndices);
+
 	int batchSize = CLIENT_KNOBS->CONSISTENCY_CHECK_URGENT_BATCH_SHARD_COUNT;
 	int startingPoint = 0;
 	if (shardsToCheck.size() > batchSize * testersCount) {
@@ -1780,7 +1787,17 @@ std::unordered_map<int, std::vector<KeyRange>> makeTaskAssignment(Database cx,
 		if (testerIdx > testersCount - 1) {
 			break; // Have filled up all testers
 		}
-		assignment[testerIdx].push_back(shardsToCheck[i]);
+		// When assigning a shards/batch to a tester idx, there are certain edge cases which can result in urgent
+		// consistency checker being infinetely stuck in a loop. Examples:
+		//      1. if there is 1 remaining shard, and tester 0 consistently fails, we will still always pick tester 0
+		//      2. if there are 10 remaining shards, and batch size is 10, and tester 0 consistently fails, we will
+		//      still always pick tester 0
+		//      3. if there are 20 remaining shards, and batch size is 20, and testers {0, 1} consistently fail, we will
+		//      keep picking testers {0, 1}
+		// To avoid repeatedly picking the same testers even though they could be failing, shuffledIndices provides an
+		// indirection to a random tester idx. That way, each invocation of makeTaskAssignment won't
+		// result in the same task assignment for the class of edge cases mentioned above.
+		assignment[shuffledIndices[testerIdx]].push_back(shardsToCheck[i]);
 	}
 	std::unordered_map<int, std::vector<KeyRange>>::iterator assignIt;
 	for (assignIt = assignment.begin(); assignIt != assignment.end(); assignIt++) {

--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -1792,7 +1792,7 @@ std::unordered_map<int, std::vector<KeyRange>> makeTaskAssignment(Database cx,
 		//      1. if there is 1 remaining shard, and tester 0 consistently fails, we will still always pick tester 0
 		//      2. if there are 10 remaining shards, and batch size is 10, and tester 0 consistently fails, we will
 		//      still always pick tester 0
-		//      3. if there are 20 remaining shards, and batch size is 20, and testers {0, 1} consistently fail, we will
+		//      3. if there are 20 remaining shards, and batch size is 10, and testers {0, 1} consistently fail, we will
 		//      keep picking testers {0, 1}
 		// To avoid repeatedly picking the same testers even though they could be failing, shuffledIndices provides an
 		// indirection to a random tester idx. That way, each invocation of makeTaskAssignment won't

--- a/flow/include/flow/error_definitions.h
+++ b/flow/include/flow/error_definitions.h
@@ -108,6 +108,8 @@ ERROR( duplicate_snapshot_request, 1083, "A duplicate snapshot request has been 
 ERROR( dd_config_changed, 1084, "DataDistribution configuration changed." )
 ERROR( consistency_check_urgent_task_failed, 1085, "Consistency check urgent task is failed")
 ERROR( data_move_conflict, 1086, "Data move conflict in SS")
+ERROR( consistency_check_urgent_duplicate_request, 1087, "Consistency check urgent got a duplicate request")
+ERROR( consistency_check_urgent_conflicting_request, 1088, "Consistency check urgent can process 1 workload at a time")
 
 ERROR( broken_promise, 1100, "Broken promise" )
 ERROR( operation_cancelled, 1101, "Asynchronous operation cancelled" )


### PR DESCRIPTION
1. As part of a different PR, I found an issue in urgent consistency checker where because of its handling of duplicate tester requests, the tester recruitment endpoint was marked as permanently failed. This means that subsequent phases e.g. consistency check were stuck since that phase relies to get interfaces for _all_ testers. To fix this, I changed the duplicate request handling in urgent consistency checker to be more explicit: the tester server drops the requests and explicitly sends a duplicate error back to the client. This way, the endpoint is not marked as permanently failed since no promise was broken.

2. After the change in (1), the urgent consistency checker itself started becoming stuck for some tests. After debugging, it was because the shards/batch mapping to tester ids had edge cases such that we keep picking the same testers which were not able to serve the requests (because they could be getting duplicate error back). To fix this, I changed the mapping algorithm to be deterministically random i.e. we don't pick the same testers for the same shards again and again, with high probability. Details in the code comments.

100K Joshua: 

`20241025-215413-praza-ebe4b5af5aced377ce58d158106b23de790ee4 compressed=True data_size=35842098 duration=5463198 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:01:54 sanity=False started=100000 stopped=20241025-225607 submitted=20241025-215413 timeout=5400 username=praza-ebe4b5af5aced377ce58d158106b23de790ee4e9`

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
