### PR TITLE
fix vv unicast recovery for streaming peek.

### DIFF
--- a/fdbserver/LogSystemPeekCursor.actor.cpp
+++ b/fdbserver/LogSystemPeekCursor.actor.cpp
@@ -37,8 +37,11 @@ ACTOR Future<Void> tryEstablishPeekStream(ILogSystem::ServerPeekCursor* self) {
 	wait(IFailureMonitor::failureMonitor().onStateEqual(self->interf->get().interf().peekStreamMessages.getEndpoint(),
 	                                                    FailureStatus(false)));
 
-	auto req = TLogPeekStreamRequest(
-	    self->messageVersion.version, self->tag, self->returnIfBlocked, std::numeric_limits<int>::max());
+	auto req = TLogPeekStreamRequest(self->messageVersion.version,
+	                                 self->tag,
+	                                 self->returnIfBlocked,
+	                                 std::numeric_limits<int>::max(),
+	                                 self->end.version);
 	self->peekReplyStream = self->interf->get().interf().peekStreamMessages.getReplyStream(req);
 	DebugLogTraceEvent(SevDebug, "SPC_StreamCreated", self->randomID)
 	    .detail("Tag", self->tag)

--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -2205,7 +2205,15 @@ ACTOR Future<Void> tLogPeekStream(TLogData* self, TLogPeekStreamRequest req, Ref
 		state Future<TLogPeekReply> future(promise.getFuture());
 		try {
 			wait(req.reply.onReady() && store(reply.rep, future) &&
-			     tLogPeekMessages(promise, self, logData, begin, req.tag, req.returnIfBlocked, onlySpilled));
+			     tLogPeekMessages(promise,
+			                      self,
+			                      logData,
+			                      begin,
+			                      req.tag,
+			                      req.returnIfBlocked,
+			                      onlySpilled,
+			                      Optional<std::pair<UID, int>>(),
+			                      req.end));
 
 			reply.rep.begin = begin;
 			req.reply.send(reply);

--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -927,7 +927,7 @@ Reference<ILogSystem::IPeekCursor> TagPartitionedLogSystem::peek(UID dbgid,
 	if (tag.locality == tagLocalityRemoteLog) {
 		return peekRemote(dbgid, begin, end, tag, parallelGetMore);
 	} else {
-		return peekAll(dbgid, begin, getPeekEnd(), tag, parallelGetMore);
+		return peekAll(dbgid, begin, end.present() ? end.get() + 1 : getPeekEnd(), tag, parallelGetMore);
 	}
 }
 

--- a/fdbserver/include/fdbserver/TLogInterface.h
+++ b/fdbserver/include/fdbserver/TLogInterface.h
@@ -260,15 +260,20 @@ struct TLogPeekStreamRequest {
 	Tag tag;
 	bool returnIfBlocked;
 	int limitBytes;
+	Optional<Version> end; // when set is exclusive to the desired range
 	ReplyPromiseStream<TLogPeekStreamReply> reply;
 
 	TLogPeekStreamRequest() {}
-	TLogPeekStreamRequest(Version version, Tag tag, bool returnIfBlocked, int limitBytes)
-	  : begin(version), tag(tag), returnIfBlocked(returnIfBlocked), limitBytes(limitBytes) {}
+	TLogPeekStreamRequest(Version version,
+	                      Tag tag,
+	                      bool returnIfBlocked,
+	                      int limitBytes,
+	                      Optional<Version> end = Optional<Version>())
+	  : begin(version), tag(tag), returnIfBlocked(returnIfBlocked), limitBytes(limitBytes), end(end) {}
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, begin, tag, returnIfBlocked, limitBytes, reply);
+		serializer(ar, begin, tag, returnIfBlocked, limitBytes, reply, end);
 	}
 };
 


### PR DESCRIPTION
An [earlier PR](https://github.com/apple/foundationdb/pull/11677) added `end` as a parameter to Peek requests. This is used in version vector unicast recovery to indicate the final version to be recovered. It has to be set for streaming peek as well; when `PEEK_USING_STREAMING` is set, the tLog will use the feature to retrieve data from old tlogs on recovery.

Joshua `20241030-161218-dlambrig-d0ef240536265fd1`

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
