### PR TITLE
disable version vector with range lock tests

### DIFF
--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -2008,11 +2008,11 @@ void addAccumulativeChecksumMutations(CommitBatchContext* self) {
 		self->toCommit.writeTypedMessage(acsMutation);
 	}
 }
-
 // RangeLock takes effect only when the feature flag is on and database is unlocked and the mutation is not encrypted
 void rejectMutationsForReadLockOnRange(CommitBatchContext* self) {
-	ASSERT(SERVER_KNOBS->ENABLE_READ_LOCK_ON_RANGE && !self->locked &&
-	       !self->pProxyCommitData->encryptMode.isEncryptionEnabled() &&
+	ASSERT(SERVER_KNOBS->ENABLE_READ_LOCK_ON_RANGE && !SERVER_KNOBS->ENABLE_VERSION_VECTOR &&
+	       !SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST && !SERVER_KNOBS->PROXY_USE_RESOLVER_PRIVATE_MUTATIONS &&
+	       !self->locked && !self->pProxyCommitData->encryptMode.isEncryptionEnabled() &&
 	       self->pProxyCommitData->getTenantMode() == TenantMode::DISABLED);
 	ProxyCommitData* const pProxyCommitData = self->pProxyCommitData;
 	ASSERT(pProxyCommitData->rangeLock != nullptr);
@@ -2345,8 +2345,9 @@ ACTOR Future<Void> postResolution(CommitBatchContext* self) {
 	// If a transaction has any mutation accessing to the locked range, reject the transaction with
 	// error_code_transaction_rejected_range_locked
 	// This feature is disabled when the database is locked
-	if (SERVER_KNOBS->ENABLE_READ_LOCK_ON_RANGE && !self->locked &&
-	    !pProxyCommitData->encryptMode.isEncryptionEnabled() &&
+	if (SERVER_KNOBS->ENABLE_READ_LOCK_ON_RANGE && !SERVER_KNOBS->ENABLE_VERSION_VECTOR &&
+	    !SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST && !SERVER_KNOBS->PROXY_USE_RESOLVER_PRIVATE_MUTATIONS &&
+	    !self->locked && !pProxyCommitData->encryptMode.isEncryptionEnabled() &&
 	    self->pProxyCommitData->getTenantMode() == TenantMode::DISABLED) {
 		rejectMutationsForReadLockOnRange(self);
 	}

--- a/fdbserver/include/fdbserver/ProxyCommitData.actor.h
+++ b/fdbserver/include/fdbserver/ProxyCommitData.actor.h
@@ -212,14 +212,18 @@ public:
 	}
 
 	void setPendingRequest(const Key& startKey, const RangeLockStateSet& lockSetState) {
-		ASSERT(SERVER_KNOBS->ENABLE_READ_LOCK_ON_RANGE);
+		ASSERT(SERVER_KNOBS->ENABLE_READ_LOCK_ON_RANGE && !SERVER_KNOBS->ENABLE_VERSION_VECTOR &&
+		       !SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST &&
+		       !SERVER_KNOBS->PROXY_USE_RESOLVER_PRIVATE_MUTATIONS);
 		ASSERT(!pendingRequest());
 		currentRangeLockStartKey = std::make_pair(startKey, lockSetState);
 		return;
 	}
 
 	void consumePendingRequest(const Key& endKey) {
-		ASSERT(SERVER_KNOBS->ENABLE_READ_LOCK_ON_RANGE);
+		ASSERT(SERVER_KNOBS->ENABLE_READ_LOCK_ON_RANGE && !SERVER_KNOBS->ENABLE_VERSION_VECTOR &&
+		       !SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST &&
+		       !SERVER_KNOBS->PROXY_USE_RESOLVER_PRIVATE_MUTATIONS);
 		ASSERT(pendingRequest());
 		ASSERT(endKey <= normalKeys.end);
 		ASSERT(currentRangeLockStartKey.get().first < endKey);
@@ -236,7 +240,9 @@ public:
 	}
 
 	bool isLocked(const KeyRange& range) const {
-		ASSERT(SERVER_KNOBS->ENABLE_READ_LOCK_ON_RANGE);
+		ASSERT(SERVER_KNOBS->ENABLE_READ_LOCK_ON_RANGE && !SERVER_KNOBS->ENABLE_VERSION_VECTOR &&
+		       !SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST &&
+		       !SERVER_KNOBS->PROXY_USE_RESOLVER_PRIVATE_MUTATIONS);
 		if (range.end >= normalKeys.end) {
 			return false;
 		}
@@ -431,7 +437,8 @@ struct ProxyCommitData {
 	                   : nullptr),
 	    epoch(epoch) {
 		commitComputePerOperation.resize(SERVER_KNOBS->PROXY_COMPUTE_BUCKETS, 0.0);
-		rangeLock = SERVER_KNOBS->ENABLE_READ_LOCK_ON_RANGE && !encryptMode.isEncryptionEnabled() &&
+		rangeLock = SERVER_KNOBS->ENABLE_READ_LOCK_ON_RANGE && !SERVER_KNOBS->ENABLE_VERSION_VECTOR &&
+		                    !SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST && !encryptMode.isEncryptionEnabled() &&
 		                    getTenantMode() == TenantMode::DISABLED
 		                ? std::make_shared<RangeLock>()
 		                : nullptr;

--- a/fdbserver/workloads/RandomRangeLock.actor.cpp
+++ b/fdbserver/workloads/RandomRangeLock.actor.cpp
@@ -22,6 +22,7 @@
 #include "fdbclient/ManagementAPI.actor.h"
 #include "fdbclient/RangeLock.h"
 #include "fdbclient/SystemData.h"
+#include "fdbserver/Knobs.h"
 #include "fdbserver/workloads/workloads.actor.h"
 #include "flow/ActorCollection.h"
 #include "flow/Arena.h"
@@ -40,7 +41,10 @@ struct RandomRangeLockWorkload : FailureInjectionWorkload {
 	int lockActorCount = 10;
 
 	RandomRangeLockWorkload(WorkloadContext const& wcx, NoOptions) : FailureInjectionWorkload(wcx) {
-		enabled = (clientId == 0) && g_network->isSimulated();
+		enabled = SERVER_KNOBS->ENABLE_READ_LOCK_ON_RANGE && !SERVER_KNOBS->ENABLE_VERSION_VECTOR &&
+		          !SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST &&
+		          !SERVER_KNOBS->PROXY_USE_RESOLVER_PRIVATE_MUTATIONS;
+		enabled &= (clientId == 0) && g_network->isSimulated();
 	}
 
 	RandomRangeLockWorkload(WorkloadContext const& wcx) : FailureInjectionWorkload(wcx) {

--- a/tests/fast/RangeLockCycle.toml
+++ b/tests/fast/RangeLockCycle.toml
@@ -5,6 +5,8 @@ encryptModes = ['disabled'] # do not support encryption
 [[knobs]]
 enable_read_lock_on_range = true
 proxy_use_resolver_private_mutations = false # do not support version vector
+enable_version_vector = false
+enable_version_vector_tlog_unicast = false
 
 [[test]]
 testTitle = 'RangeLockCycle'

--- a/tests/fast/RangeLocking.toml
+++ b/tests/fast/RangeLocking.toml
@@ -6,6 +6,8 @@ encryptModes = ['disabled'] # do not support encryption
 enable_read_lock_on_range = true
 transaction_lock_rejection_retriable = false
 proxy_use_resolver_private_mutations = false # do not support version vector
+enable_version_vector = false
+enable_version_vector_tlog_unicast = false
 
 [[test]]
 testTitle = 'RangeLocking'


### PR DESCRIPTION
disable version vector with range lock tests.
while developing the feature, we can set three switches to be sure it is disabled.
TODO Range Locking to work with version vector.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
