### PR TITLE
Invalidate gray failure complaints from excluded processes

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -795,6 +795,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( CC_ENABLE_REMOTE_TLOG_DEGRADATION_MONITORING,         false); if (isSimulated && deterministicRandom()->coinflip()) CC_ENABLE_REMOTE_TLOG_DEGRADATION_MONITORING = true;
 	init( CC_ENABLE_REMOTE_TLOG_DISCONNECT_MONITORING,          false); if (isSimulated && deterministicRandom()->coinflip()) CC_ENABLE_REMOTE_TLOG_DISCONNECT_MONITORING = true;
 	init( CC_ONLY_CONSIDER_INTRA_DC_LATENCY,                    false); if (isSimulated && deterministicRandom()->coinflip()) CC_ONLY_CONSIDER_INTRA_DC_LATENCY = true;
+	init( CC_INVALIDATE_EXCLUDED_PROCESSES,                     false); if (isSimulated && deterministicRandom()->coinflip()) CC_INVALIDATE_EXCLUDED_PROCESSES = true;
 	init( CC_THROTTLE_SINGLETON_RERECRUIT_INTERVAL,              0.5 );
 
 	init( INCOMPATIBLE_PEERS_LOGGING_INTERVAL,                   600 ); if( randomize && BUGGIFY ) INCOMPATIBLE_PEERS_LOGGING_INTERVAL = 60.0;

--- a/fdbclient/include/fdbclient/ServerKnobs.h
+++ b/fdbclient/include/fdbclient/ServerKnobs.h
@@ -781,7 +781,7 @@ public:
 	                                        // turned on, because inter-DC latency signal is not reliable and it's
 	                                        // challenging to pick a good latency threshold.
 	bool CC_INVALIDATE_EXCLUDED_PROCESSES; // When enabled, invalidate the complaints by processes that were excluded
-	                                       // in gray failure triggered recoveries
+	                                       // in gray failure triggered recoveries.
 	double CC_THROTTLE_SINGLETON_RERECRUIT_INTERVAL; // The interval to prevent re-recruiting the same singleton if a
 	                                                 // recruiting fight between two cluster controllers occurs.
 

--- a/fdbclient/include/fdbclient/ServerKnobs.h
+++ b/fdbclient/include/fdbclient/ServerKnobs.h
@@ -780,7 +780,8 @@ public:
 	                                        // CC_ENABLE_REMOTE_LOG_ROUTER_DEGRADATION_MONITORING), this knob must be
 	                                        // turned on, because inter-DC latency signal is not reliable and it's
 	                                        // challenging to pick a good latency threshold.
-	bool CC_INVALIDATE_EXCLUDED_PROCESSES; // gray failure, todo
+	bool CC_INVALIDATE_EXCLUDED_PROCESSES; // When enabled, invalidate the complaints by processes that were excluded
+	                                       // in gray failure triggered recoveries
 	double CC_THROTTLE_SINGLETON_RERECRUIT_INTERVAL; // The interval to prevent re-recruiting the same singleton if a
 	                                                 // recruiting fight between two cluster controllers occurs.
 

--- a/fdbclient/include/fdbclient/ServerKnobs.h
+++ b/fdbclient/include/fdbclient/ServerKnobs.h
@@ -780,6 +780,7 @@ public:
 	                                        // CC_ENABLE_REMOTE_LOG_ROUTER_DEGRADATION_MONITORING), this knob must be
 	                                        // turned on, because inter-DC latency signal is not reliable and it's
 	                                        // challenging to pick a good latency threshold.
+	bool CC_INVALIDATE_EXCLUDED_PROCESSES; // gray failure, todo
 	double CC_THROTTLE_SINGLETON_RERECRUIT_INTERVAL; // The interval to prevent re-recruiting the same singleton if a
 	                                                 // recruiting fight between two cluster controllers occurs.
 

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -4101,6 +4101,7 @@ TEST_CASE("/fdbserver/clustercontroller/invalidateExcludedProcessComplaints") {
 
 	// Compute degraded processes
 	data.degradationInfo = data.getDegradationInfo();
+	data.excludedDegradedServers = data.degradationInfo.degradedServers;
 
 	// Ensure badPeer is successfully added to excluded list
 	// At this point, recovery would also be triggered in a production setting
@@ -4118,6 +4119,7 @@ TEST_CASE("/fdbserver/clustercontroller/invalidateExcludedProcessComplaints") {
 
 	// Compute degraded processes again
 	data.degradationInfo = data.getDegradationInfo();
+	data.excludedDegradedServers = data.degradationInfo.degradedServers;
 
 	if (SERVER_KNOBS->CC_INVALIDATE_EXCLUDED_PROCESSES) {
 		// With CC_INVALIDATE_EXCLUDE_PROCESSES, we should got 0 degraded processes


### PR DESCRIPTION
## Description

In gray failure, processes complain about each other. There are scenarios where multiple workers complain about a bad process to CC, but at the same time, that bad process also complains about those workers. In such cases, gray failure algorithm in CC goes by unique complainer count, so workers complaining against bad process would win, recovery would be triggered in which bad process will not be recruited again because it would have been added to an excluded list. 

However, in the example above, there could be another subsequent recovery (or theoretically, multiple recoveries) because of the original complaints from the bad process. This PR fixes that by immediately invalidating the complaints from bad process (or multiple bad processes) when it's added to exclude list and recovery is triggered.

Overall, for such pathological scenarios, having this PR feature turned on will reduce the number of false positive recoveries, thus increasing cluster availability. 

## Testing

1. Added unit test.  You can follow along the code step by step to better understand the pathological scenario mentioned above.
2. 100K Joshua: `20241104-194642-praza-361f73b35f1d5ac66dcc439ad4da0e32a13180 compressed=True data_size=36032827 duration=6509796 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:02:26 sanity=False started=100000 stopped=20241104-204908 submitted=20241104-194642 timeout=5400 username=praza-361f73b35f1d5ac66dcc439ad4da0e32a1318077`

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
