### PR TITLE
Fix accumulative checksum

### DIFF
--- a/fdbserver/AccumulativeChecksumUtil.cpp
+++ b/fdbserver/AccumulativeChecksumUtil.cpp
@@ -259,7 +259,8 @@ void AccumulativeChecksumValidator::restore(const AccumulativeChecksumState& acs
 		    .detail("AcsState", acsState.toString());
 		throw please_reboot();
 	}
-	acsTable[acsIndex] = acsState;
+	auto res = acsTable.insert({ acsIndex, acsState });
+	ASSERT(res.second); // Each acsIndex has persisted ACS value for at most one epoch -> The insert must be complete
 	if (CLIENT_KNOBS->ENABLE_ACCUMULATIVE_CHECKSUM_LOGGING) {
 		TraceEvent(SevInfo, "AcsValidatorRestore", ssid)
 		    .detail("AcsIndex", acsIndex)

--- a/fdbserver/AccumulativeChecksumUtil.cpp
+++ b/fdbserver/AccumulativeChecksumUtil.cpp
@@ -260,7 +260,7 @@ void AccumulativeChecksumValidator::restore(const AccumulativeChecksumState& acs
 		throw please_reboot();
 	}
 	auto res = acsTable.insert({ acsIndex, acsState });
-	ASSERT(res.second); // Each acsIndex has persisted ACS value for at most one epoch -> The insert must be complete
+	ASSERT(res.second); // Each acsIndex has persisted one ACS value
 	if (CLIENT_KNOBS->ENABLE_ACCUMULATIVE_CHECKSUM_LOGGING) {
 		TraceEvent(SevInfo, "AcsValidatorRestore", ssid)
 		    .detail("AcsIndex", acsIndex)

--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -1997,16 +1997,15 @@ void addAccumulativeChecksumMutations(CommitBatchContext* self) {
 		MutationRef acsMutation;
 		acsMutation.type = MutationRef::SetValue;
 		acsMutation.param1 = accumulativeChecksumKey; // private mutation
-		Value acsValue = accumulativeChecksumValue(
-		    AccumulativeChecksumState(acsIndex, acsState.acs, self->commitVersion, self->pProxyCommitData->epoch));
+		AccumulativeChecksumState acsToSend(acsIndex, acsState.acs, self->commitVersion, self->pProxyCommitData->epoch);
+		Value acsValue = accumulativeChecksumValue(acsToSend);
 		acsMutation.param2 = acsValue;
 		acsMutation.setAccumulativeChecksumIndex(acsIndex);
 		if (CLIENT_KNOBS->ENABLE_ACCUMULATIVE_CHECKSUM_LOGGING) {
 			TraceEvent(SevInfo, "AcsBuilderIssueAccumulativeChecksumMutation", self->pProxyCommitData->dbgid)
-			    .detail("Acs", acsState.acs)
 			    .detail("AcsTag", tag)
 			    .detail("AcsIndex", acsIndex)
-			    .detail("CommitVersion", self->commitVersion)
+			    .detail("AcsToSend", acsToSend.toString())
 			    .detail("Mutation", acsMutation)
 			    .detail("CommitProxyIndex", self->pProxyCommitData->commitProxyIndex);
 		}


### PR DESCRIPTION
When SS persists accumulative checksum value, each acsIndex has exactly one value. Do not persist the value by epoch. 

100K correctness tests:
  20241104-192732-zhewang-c7ae1f5843aa7835           compressed=True data_size=36888178 duration=6140327 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:14:52 sanity=False started=100000 stopped=20241104-204224 submitted=20241104-192732 timeout=5400 username=zhewang

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
