### PR TITLE
Do not check for PROXY_USE_RESOLVER_PRIVATE_MUTATIONS in rangeLockEnabled

### DIFF
--- a/fdbserver/include/fdbserver/ProxyCommitData.actor.h
+++ b/fdbserver/include/fdbserver/ProxyCommitData.actor.h
@@ -343,8 +343,7 @@ struct ProxyCommitData {
 	// RangeLock feature currently is not compatible with encryption and tenant
 	bool rangeLockEnabled() {
 		return SERVER_KNOBS->ENABLE_READ_LOCK_ON_RANGE && !SERVER_KNOBS->ENABLE_VERSION_VECTOR &&
-		       !SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST &&
-		       !SERVER_KNOBS->PROXY_USE_RESOLVER_PRIVATE_MUTATIONS && !encryptMode.isEncryptionEnabled() &&
+		       !SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST && !encryptMode.isEncryptionEnabled() &&
 		       getTenantMode() == TenantMode::DISABLED;
 	}
 

--- a/tests/fast/RangeLockCycle.toml
+++ b/tests/fast/RangeLockCycle.toml
@@ -4,7 +4,6 @@ encryptModes = ['disabled'] # do not support encryption
 
 [[knobs]]
 enable_read_lock_on_range = true
-proxy_use_resolver_private_mutations = false # do not support version vector
 enable_version_vector = false
 enable_version_vector_tlog_unicast = false
 

--- a/tests/fast/RangeLocking.toml
+++ b/tests/fast/RangeLocking.toml
@@ -5,7 +5,6 @@ encryptModes = ['disabled'] # do not support encryption
 [[knobs]]
 enable_read_lock_on_range = true
 transaction_lock_rejection_retriable = false
-proxy_use_resolver_private_mutations = false # do not support version vector
 enable_version_vector = false
 enable_version_vector_tlog_unicast = false
 


### PR DESCRIPTION
Do not check for PROXY_USE_RESOLVER_PRIVATE_MUTATIONS in rangeLockEnabled


Joshua with `PROXY_USE_RESOLVER_PRIVATE_MUTATIONS` enabled and `ENABLE_READ_LOCK_ON_RANGE` 
disabled:

`20241104-211756-dlambrig-a5cb3b9fac7ed2ca` 

with `ENABLE_READ_LOCK_ON_RANGE` and `PROXY_USE_RESOLVER_PRIVATE_MUTATIONS` enabled:

`20241104-231600-dlambrig-bfad63339bc07b5e`

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
