### PR TITLE
Gray failure allows storage servers to complain

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -1101,7 +1101,9 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( PEER_TIMEOUT_PERCENTAGE_DEGRADATION_THRESHOLD,         0.1 );
 	init( PEER_DEGRADATION_CONNECTION_FAILURE_COUNT,               5 );
 	init( WORKER_HEALTH_REPORT_RECENT_DESTROYED_PEER,           true );
-	init( GRAY_FAILURE_ENABLE_TLOG_RECOVERY_MONITORING,         true );
+	init( GRAY_FAILURE_ENABLE_TLOG_RECOVERY_MONITORING,         true );	
+	init( GRAY_FAILURE_ALLOW_PRIMARY_SS_TO_COMPLAIN,           false ); if (isSimulated && deterministicRandom()->coinflip()) GRAY_FAILURE_ALLOW_PRIMARY_SS_TO_COMPLAIN = true;
+	init( GRAY_FAILURE_ALLOW_REMOTE_SS_TO_COMPLAIN,            false ); if (isSimulated && deterministicRandom()->coinflip()) GRAY_FAILURE_ALLOW_REMOTE_SS_TO_COMPLAIN = true;
 	init( STORAGE_SERVER_REBOOT_ON_IO_TIMEOUT,                 false ); if ( randomize && BUGGIFY ) STORAGE_SERVER_REBOOT_ON_IO_TIMEOUT = true;
 	init( STORAGE_DISK_CLEANUP_MAX_RETRIES,                       10 );
 	init( STORAGE_DISK_CLEANUP_RETRY_INTERVAL,  isSimulated ? 2 : 30 );

--- a/fdbclient/include/fdbclient/ServerKnobs.h
+++ b/fdbclient/include/fdbclient/ServerKnobs.h
@@ -1127,6 +1127,12 @@ public:
 	                                                 // cluster controller.
 	bool GRAY_FAILURE_ENABLE_TLOG_RECOVERY_MONITORING; // When enabled, health monitor will try to detect any gray
 	                                                   // failure during tlog recovery during the recovery process.
+	bool GRAY_FAILURE_ALLOW_PRIMARY_SS_TO_COMPLAIN; // When enabled, storage servers in the primary DC are allowed to
+	                                                // complain about their peers in the transaction subsystem e.g.
+	                                                // buddy tlogs.
+	bool GRAY_FAILURE_ALLOW_REMOTE_SS_TO_COMPLAIN; // When enabled, storage servers in the remote DC are allowed to
+	                                               // complain about their peers in the transaction subsystem e.g. buddy
+	                                               // tlogs.
 	bool STORAGE_SERVER_REBOOT_ON_IO_TIMEOUT; // When enabled, storage server's worker will crash on io_timeout error;
 	                                          // this allows fdbmonitor to restart the worker and recreate the same SS.
 	                                          // When SS can be temporarily throttled by infrastructure, e.g, k8s,

--- a/fdbserver/include/fdbserver/WorkerInterface.actor.h
+++ b/fdbserver/include/fdbserver/WorkerInterface.actor.h
@@ -1297,7 +1297,10 @@ void registerThreadForProfiling();
 bool addressInDbAndPrimarySatelliteDc(const NetworkAddress& address, Reference<AsyncVar<ServerDBInfo> const> dbInfo);
 
 // Returns true if `address` is used in the db (indicated by `dbInfo`) transaction system and in the db's remote DC.
-bool addressInDbAndRemoteDc(const NetworkAddress& address, Reference<AsyncVar<ServerDBInfo> const> dbInfo);
+bool addressInDbAndRemoteDc(
+    const NetworkAddress& address,
+    Reference<AsyncVar<ServerDBInfo> const> dbInfo,
+    Optional<std::vector<NetworkAddress>> storageServers = Optional<std::vector<NetworkAddress>>{});
 
 void updateCpuProfiler(ProfilerRequest req);
 

--- a/tests/rare/ClogRemoteTLog.toml
+++ b/tests/rare/ClogRemoteTLog.toml
@@ -21,6 +21,7 @@ cc_tracking_health_recovery_interval = 60
 peer_latency_degradation_threshold = 1
 peer_latency_degradation_percentile = 1
 peer_latency_check_min_population = 2
+cc_max_exclusion_due_to_health = 5
 
 [[test]]
 testTitle = "ClogRemoteTLog"


### PR DESCRIPTION
# Description

There are two main changes:

1. This PR lets storage servers, both in primary and/or remote DCs, to complain about workers in the txn subsystem. For example, if a remote tlog is degraded (e.g. network issue), remote storage servers to which this tlog is a buddy of, can report the tlog to CC. This gives an opportunity for CC and gray failure to then exclude this degraded tlog and trigger recovery. This is especially useful in pathological network failure modes e.g. tlog's network link to SS is degraded, but to log router is fine. In this scenario, log routers won't complain about this tlog, and this tlog will remain degraded and exist in the cluster. This PR fixes that problem.

2. The existing remote tlog simulation test is improved in different ways. The test now _always_ checks that it passes through a series of test phases aka `expectedStatePaths`. Previously, the test path was conditionally (based on process placement) expected to end in `SS_LAG_NORMAL`. Now, that condition is removed, and we unconditionally do the check. To make this unconditional, a new test phase `CLOGGED_REMOTE_TLOG_EXCLUDED` is added, and is computed via server dbInfo. This state is always expected to be reached even if `SS_LAG_NORMAL` is not reached. Finally, there could be a lot of test state paths. In order to not hard code all possible state paths, a concept of prefix matching is introduced, and every path in `expectedStatePaths` can be marked as prefix true or false, depending on how strict we want the matching to be (at the end in `check()`). 

# Testing

- Enhanced current simulation test to clog only tlog->SS network if the feature flag in this PR is on. This means the test can give signal for general network problems, but also specifically for tlog->SS network problems.
- 100K Joshua: `20241104-234909-praza-5bbe014302e5c6b1350ad9a294fbc7f0a65397 compressed=True data_size=36041745 duration=5521908 ended=100000 fail=2 fail_fast=10 max_runs=100000 pass=99998 priority=100 remaining=0 runtime=0:52:26 sanity=False started=100000 stopped=20241105-004135 submitted=20241104-234909 timeout=5400 username=praza-5bbe014302e5c6b1350ad9a294fbc7f0a653975d`. 2 failures but don't seem related to my change, will confirm. 

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
