### PR TITLE
Gray failure machine readable status

### DIFF
--- a/documentation/sphinx/source/mr-status-json-schemas.rst.inc
+++ b/documentation/sphinx/source/mr-status-json-schemas.rst.inc
@@ -540,8 +540,8 @@
          "lock_uid":"00000000000000000000000000000000" // Only present when database is locked
       },
       "generation":2,
-      "gray_failure" : {
-         "excluded_processes" : [
+      "gray_failure" : { // Displays subset of gray failure in-memory state. Currently, shows exclude server network address (ip + port) as well as time when the server was last excluded. Based on these exclusions, recovery is triggered.
+         "excluded_servers" : [
          ]
       },    
       "latency_probe":{ // all measurements are based on running sample transactions

--- a/documentation/sphinx/source/mr-status-json-schemas.rst.inc
+++ b/documentation/sphinx/source/mr-status-json-schemas.rst.inc
@@ -540,6 +540,10 @@
          "lock_uid":"00000000000000000000000000000000" // Only present when database is locked
       },
       "generation":2,
+      "gray_failure" : {
+         "excluded_processes" : [
+         ]
+      },    
       "latency_probe":{ // all measurements are based on running sample transactions
          "read_seconds":7, // time to perform a single read
          "immediate_priority_transaction_start_seconds":0.0, // time to start a sample transaction at system immediate priority

--- a/documentation/sphinx/source/mr-status-json-schemas.rst.inc
+++ b/documentation/sphinx/source/mr-status-json-schemas.rst.inc
@@ -540,7 +540,7 @@
          "lock_uid":"00000000000000000000000000000000" // Only present when database is locked
       },
       "generation":2,
-      "gray_failure" : { // Displays subset of gray failure in-memory state. Currently, shows exclude server network address (ip + port) as well as time when the server was last excluded. Based on these exclusions, recovery is triggered.
+      "gray_failure" : { // Displays subset of gray failure in-memory state. Currently, shows excluded server network address (ip + port) as well as time when the server was last excluded. Based on these exclusions, recovery is triggered.
          "excluded_servers" : [
          ]
       },    

--- a/fdbclient/Schemas.cpp
+++ b/fdbclient/Schemas.cpp
@@ -529,6 +529,10 @@ const KeyRef JSONSchemas::statusSchema = R"statusSchema(
       "generation":2,
       "gray_failure" : {
          "excluded_servers" : [
+            {
+               "address": "127.0.0.1:4500",
+               "time": 1731294251
+            }
          ]
       },
       "latency_probe":{

--- a/fdbclient/Schemas.cpp
+++ b/fdbclient/Schemas.cpp
@@ -527,6 +527,10 @@ const KeyRef JSONSchemas::statusSchema = R"statusSchema(
          "lock_uid": "00000000000000000000000000000000"
       },
       "generation":2,
+      "gray_failure" : {
+         "excluded_processes" : [
+         ]
+      },
       "latency_probe":{
          "read_seconds":7,
          "immediate_priority_transaction_start_seconds":0.0,

--- a/fdbclient/Schemas.cpp
+++ b/fdbclient/Schemas.cpp
@@ -528,7 +528,7 @@ const KeyRef JSONSchemas::statusSchema = R"statusSchema(
       },
       "generation":2,
       "gray_failure" : {
-         "excluded_processes" : [
+         "excluded_servers" : [
          ]
       },
       "latency_probe":{

--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -801,6 +801,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( CC_ENABLE_REMOTE_TLOG_DISCONNECT_MONITORING,          false); if (isSimulated) CC_ENABLE_REMOTE_TLOG_DISCONNECT_MONITORING = deterministicRandom()->coinflip();
 	init( CC_ONLY_CONSIDER_INTRA_DC_LATENCY,                    false); if (isSimulated) CC_ONLY_CONSIDER_INTRA_DC_LATENCY = deterministicRandom()->coinflip();
 	init( CC_INVALIDATE_EXCLUDED_PROCESSES,                     false); if (isSimulated) CC_INVALIDATE_EXCLUDED_PROCESSES = deterministicRandom()->coinflip();
+	init( CC_GRAY_FAILURE_STATUS_JSON,                           true); if (isSimulated && deterministicRandom()->coinflip()) CC_GRAY_FAILURE_STATUS_JSON = true; // todo: turn default false
 	init( CC_THROTTLE_SINGLETON_RERECRUIT_INTERVAL,              0.5 );
 
 	init( INCOMPATIBLE_PEERS_LOGGING_INTERVAL,                   600 ); if( randomize && BUGGIFY ) INCOMPATIBLE_PEERS_LOGGING_INTERVAL = 60.0;

--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -801,7 +801,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( CC_ENABLE_REMOTE_TLOG_DISCONNECT_MONITORING,          false); if (isSimulated) CC_ENABLE_REMOTE_TLOG_DISCONNECT_MONITORING = deterministicRandom()->coinflip();
 	init( CC_ONLY_CONSIDER_INTRA_DC_LATENCY,                    false); if (isSimulated) CC_ONLY_CONSIDER_INTRA_DC_LATENCY = deterministicRandom()->coinflip();
 	init( CC_INVALIDATE_EXCLUDED_PROCESSES,                     false); if (isSimulated) CC_INVALIDATE_EXCLUDED_PROCESSES = deterministicRandom()->coinflip();
-	init( CC_GRAY_FAILURE_STATUS_JSON,                           true); if (isSimulated && deterministicRandom()->coinflip()) CC_GRAY_FAILURE_STATUS_JSON = true; // todo: turn default false
+	init( CC_GRAY_FAILURE_STATUS_JSON,                          false); if (isSimulated) CC_GRAY_FAILURE_STATUS_JSON = true;
 	init( CC_THROTTLE_SINGLETON_RERECRUIT_INTERVAL,              0.5 );
 
 	init( INCOMPATIBLE_PEERS_LOGGING_INTERVAL,                   600 ); if( randomize && BUGGIFY ) INCOMPATIBLE_PEERS_LOGGING_INTERVAL = 60.0;

--- a/fdbclient/include/fdbclient/ServerKnobs.h
+++ b/fdbclient/include/fdbclient/ServerKnobs.h
@@ -794,7 +794,7 @@ public:
 	                                        // challenging to pick a good latency threshold.
 	bool CC_INVALIDATE_EXCLUDED_PROCESSES; // When enabled, invalidate the complaints by processes that were excluded
 	                                       // in gray failure triggered recoveries.
-	bool CC_GRAY_FAILURE_STATUS_JSON; // When enabled, returns gray failure information in machine readable status json
+	bool CC_GRAY_FAILURE_STATUS_JSON; // When enabled, returns gray failure information in machine readable status json.
 	double CC_THROTTLE_SINGLETON_RERECRUIT_INTERVAL; // The interval to prevent re-recruiting the same singleton if a
 	                                                 // recruiting fight between two cluster controllers occurs.
 

--- a/fdbclient/include/fdbclient/ServerKnobs.h
+++ b/fdbclient/include/fdbclient/ServerKnobs.h
@@ -794,7 +794,7 @@ public:
 	                                        // challenging to pick a good latency threshold.
 	bool CC_INVALIDATE_EXCLUDED_PROCESSES; // When enabled, invalidate the complaints by processes that were excluded
 	                                       // in gray failure triggered recoveries.
-	bool CC_GRAY_FAILURE_STATUS_JSON; // todo
+	bool CC_GRAY_FAILURE_STATUS_JSON; // When enabled, returns gray failure information in machine readable status json
 	double CC_THROTTLE_SINGLETON_RERECRUIT_INTERVAL; // The interval to prevent re-recruiting the same singleton if a
 	                                                 // recruiting fight between two cluster controllers occurs.
 

--- a/fdbclient/include/fdbclient/ServerKnobs.h
+++ b/fdbclient/include/fdbclient/ServerKnobs.h
@@ -794,6 +794,7 @@ public:
 	                                        // challenging to pick a good latency threshold.
 	bool CC_INVALIDATE_EXCLUDED_PROCESSES; // When enabled, invalidate the complaints by processes that were excluded
 	                                       // in gray failure triggered recoveries.
+	bool CC_GRAY_FAILURE_STATUS_JSON; // todo
 	double CC_THROTTLE_SINGLETON_RERECRUIT_INTERVAL; // The interval to prevent re-recruiting the same singleton if a
 	                                                 // recruiting fight between two cluster controllers occurs.
 

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -1574,7 +1574,8 @@ ACTOR Future<Void> statusServer(FutureStream<StatusRequest> requests,
 			                                                                  self->dcStorageServerVersionDifference,
 			                                                                  configBroadcaster,
 			                                                                  self->db.metaclusterRegistration,
-			                                                                  self->db.metaclusterMetrics)));
+			                                                                  self->db.metaclusterMetrics,
+			                                                                  self->excludedDegradedServers)));
 
 			if (result.isError() && result.getError().code() == error_code_actor_cancelled)
 				throw result.getError();

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -3026,8 +3026,9 @@ ACTOR Future<Void> workerHealthMonitor(ClusterControllerData* self) {
 			// recovered.
 			bool hasRecoveredServer = false;
 			for (auto it = self->excludedDegradedServers.begin(); it != self->excludedDegradedServers.end();) {
-				if (self->degradationInfo.degradedServers.find(*it) == self->degradationInfo.degradedServers.end() &&
-				    self->degradationInfo.disconnectedServers.find(*it) ==
+				if (self->degradationInfo.degradedServers.find(it->first) ==
+				        self->degradationInfo.degradedServers.end() &&
+				    self->degradationInfo.disconnectedServers.find(it->first) ==
 				        self->degradationInfo.disconnectedServers.end()) {
 					self->excludedDegradedServers.erase(it++);
 					hasRecoveredServer = true;
@@ -3057,9 +3058,13 @@ ACTOR Future<Void> workerHealthMonitor(ClusterControllerData* self) {
 					if (SERVER_KNOBS->CC_HEALTH_TRIGGER_RECOVERY) {
 						if (self->recentRecoveryCountDueToHealth() < SERVER_KNOBS->CC_MAX_HEALTH_RECOVERY_COUNT) {
 							self->recentHealthTriggeredRecoveryTime.push(now());
-							self->excludedDegradedServers = self->degradationInfo.degradedServers;
-							self->excludedDegradedServers.insert(self->degradationInfo.disconnectedServers.begin(),
-							                                     self->degradationInfo.disconnectedServers.end());
+							self->excludedDegradedServers.clear();
+							for (const auto& degradedServer : self->degradationInfo.degradedServers) {
+								self->excludedDegradedServers[degradedServer] = now();
+							}
+							for (const auto& disconnectedServer : self->degradationInfo.disconnectedServers) {
+								self->excludedDegradedServers[disconnectedServer] = now();
+							}
 							invalidateExcludedProcessComplaints(self);
 							TraceEvent(SevWarnAlways, "DegradedServerDetectedAndTriggerRecovery")
 							    .detail("RecentRecoveryCountDueToHealth", self->recentRecoveryCountDueToHealth());

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -3008,7 +3008,7 @@ static void invalidateExcludedProcessComplaints(ClusterControllerData* self) {
 	if (!SERVER_KNOBS->CC_INVALIDATE_EXCLUDED_PROCESSES) {
 		return;
 	}
-	for (const auto& addr : self->excludedDegradedServers) {
+	for (const auto& [addr, _] : self->excludedDegradedServers) {
 		self->workerHealth.erase(addr);
 	}
 }
@@ -4107,7 +4107,9 @@ TEST_CASE("/fdbserver/clustercontroller/invalidateExcludedProcessComplaints") {
 
 	// Compute degraded processes
 	data.degradationInfo = data.getDegradationInfo();
-	data.excludedDegradedServers = data.degradationInfo.degradedServers;
+	for (const auto& addr : data.degradationInfo.degradedServers) {
+		data.excludedDegradedServers[addr] = now();
+	}
 
 	// Ensure badPeer is successfully added to excluded list
 	// At this point, recovery would also be triggered in a production setting
@@ -4125,7 +4127,9 @@ TEST_CASE("/fdbserver/clustercontroller/invalidateExcludedProcessComplaints") {
 
 	// Compute degraded processes again
 	data.degradationInfo = data.getDegradationInfo();
-	data.excludedDegradedServers = data.degradationInfo.degradedServers;
+	for (const auto& addr : data.degradationInfo.degradedServers) {
+		data.excludedDegradedServers[addr] = now();
+	}
 
 	if (SERVER_KNOBS->CC_INVALIDATE_EXCLUDED_PROCESSES) {
 		// With CC_INVALIDATE_EXCLUDE_PROCESSES, we should got 0 degraded processes

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -1141,11 +1141,14 @@ ACTOR static Future<JsonBuilderObject> processStatusFetcher(
 	return processMap;
 }
 
-static JsonBuilderObject grayFailureStatus(const std::unordered_set<NetworkAddress>& excludedDegradedServers) {
+static JsonBuilderObject grayFailureStatus(const std::unordered_map<NetworkAddress, double>& excludedDegradedServers) {
 	JsonBuilderObject status;
 	JsonBuilderArray excludedProcesses;
-	for (const auto& excludedServer : excludedDegradedServers) {
-		excludedProcesses.push_back(excludedServer.toString());
+	for (const auto& [excludedServer, time] : excludedDegradedServers) {
+		JsonBuilderObject process;
+		process["address"] = excludedServer.toString();
+		process["time"] = time;
+		excludedProcesses.push_back(process);
 	}
 	status["excluded_processes"] = excludedProcesses;
 	return status;
@@ -3057,7 +3060,7 @@ ACTOR Future<StatusReply> clusterGetStatus(
     ConfigBroadcaster const* configBroadcaster,
     Optional<UnversionedMetaclusterRegistrationEntry> metaclusterRegistration,
     metacluster::MetaclusterMetrics metaclusterMetrics,
-    std::unordered_set<NetworkAddress> excludedDegradedServers) {
+    std::unordered_map<NetworkAddress, double> excludedDegradedServers) {
 
 	state double tStart = timer();
 

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -1143,14 +1143,14 @@ ACTOR static Future<JsonBuilderObject> processStatusFetcher(
 
 static JsonBuilderObject grayFailureStatus(const std::unordered_map<NetworkAddress, double>& excludedDegradedServers) {
 	JsonBuilderObject status;
-	JsonBuilderArray excludedProcesses;
+	JsonBuilderArray excludedServers;
 	for (const auto& [excludedServer, time] : excludedDegradedServers) {
-		JsonBuilderObject process;
-		process["address"] = excludedServer.toString();
-		process["time"] = time;
-		excludedProcesses.push_back(process);
+		JsonBuilderObject server;
+		server["address"] = excludedServer.toString();
+		server["time"] = time;
+		excludedServers.push_back(server);
 	}
-	status["excluded_processes"] = excludedProcesses;
+	status["excluded_servers"] = excludedServers;
 	return status;
 }
 

--- a/fdbserver/include/fdbserver/ClusterController.actor.h
+++ b/fdbserver/include/fdbserver/ClusterController.actor.h
@@ -20,7 +20,6 @@
 
 // When actually compiled (NO_INTELLISENSE), include the generated version of this file.  In intellisense use the source
 // version.
-#include "flow/IPAddress.h"
 #if defined(NO_INTELLISENSE) && !defined(FDBSERVER_CLUSTERCONTROLLER_ACTOR_G_H)
 #define FDBSERVER_CLUSTERCONTROLLER_ACTOR_G_H
 #include "fdbserver/ClusterController.actor.g.h"
@@ -3403,7 +3402,9 @@ public:
 	};
 	std::unordered_map<NetworkAddress, WorkerHealth> workerHealth;
 	DegradationInfo degradationInfo;
-	std::unordered_map<NetworkAddress, double /* latest time at which address was excluded */> excludedDegradedServers;
+	std::unordered_map<NetworkAddress /* degraded servers to be excluded when assigning workers to roles */,
+	                   double /* latest time at which address was excluded */>
+	    excludedDegradedServers;
 	std::queue<double> recentHealthTriggeredRecoveryTime;
 
 	// Capture cluster's Encryption data at-rest mode; the status is set 'only' at the time of cluster creation.

--- a/fdbserver/include/fdbserver/ClusterController.actor.h
+++ b/fdbserver/include/fdbserver/ClusterController.actor.h
@@ -20,6 +20,7 @@
 
 // When actually compiled (NO_INTELLISENSE), include the generated version of this file.  In intellisense use the source
 // version.
+#include "flow/IPAddress.h"
 #if defined(NO_INTELLISENSE) && !defined(FDBSERVER_CLUSTERCONTROLLER_ACTOR_G_H)
 #define FDBSERVER_CLUSTERCONTROLLER_ACTOR_G_H
 #include "fdbserver/ClusterController.actor.g.h"
@@ -3318,7 +3319,7 @@ public:
 
 	bool isExcludedDegradedServer(const NetworkAddressList& a) const {
 		for (const auto& server : excludedDegradedServers) {
-			if (a.contains(server))
+			if (a.contains(server.first))
 				return true;
 		}
 		return false;
@@ -3402,8 +3403,7 @@ public:
 	};
 	std::unordered_map<NetworkAddress, WorkerHealth> workerHealth;
 	DegradationInfo degradationInfo;
-	std::unordered_set<NetworkAddress>
-	    excludedDegradedServers; // The degraded servers to be excluded when assigning workers to roles.
+	std::unordered_map<NetworkAddress, double /* latest time at which address was excluded */> excludedDegradedServers;
 	std::queue<double> recentHealthTriggeredRecoveryTime;
 
 	// Capture cluster's Encryption data at-rest mode; the status is set 'only' at the time of cluster creation.

--- a/fdbserver/include/fdbserver/Status.actor.h
+++ b/fdbserver/include/fdbserver/Status.actor.h
@@ -57,7 +57,8 @@ Future<StatusReply> clusterGetStatus(
     Version const& dcStorageServerVersionDifference,
     ConfigBroadcaster const* const& conifgBroadcaster,
     Optional<UnversionedMetaclusterRegistrationEntry> const& metaclusterRegistration,
-    metacluster::MetaclusterMetrics const& metaclusterMetrics);
+    metacluster::MetaclusterMetrics const& metaclusterMetrics,
+    std::unordered_set<NetworkAddress> const& excludedDegradedServers);
 
 StatusReply clusterGetFaultToleranceStatus(const std::string& statusString);
 

--- a/fdbserver/include/fdbserver/Status.actor.h
+++ b/fdbserver/include/fdbserver/Status.actor.h
@@ -58,7 +58,8 @@ Future<StatusReply> clusterGetStatus(
     ConfigBroadcaster const* const& conifgBroadcaster,
     Optional<UnversionedMetaclusterRegistrationEntry> const& metaclusterRegistration,
     metacluster::MetaclusterMetrics const& metaclusterMetrics,
-    std::unordered_set<NetworkAddress> const& excludedDegradedServers);
+    std::unordered_map<NetworkAddress, double /* latest time at which address was excluded */> const&
+        excludedDegradedServers);
 
 StatusReply clusterGetFaultToleranceStatus(const std::string& statusString);
 

--- a/fdbserver/workloads/ClogRemoteTLog.actor.cpp
+++ b/fdbserver/workloads/ClogRemoteTLog.actor.cpp
@@ -344,8 +344,7 @@ struct ClogRemoteTLog : TestWorkload {
 				    remoteTLogNotInDbInfo(self->cloggedRemoteTLog.get(), self->dbInfo->get())) {
 					localState = TestState::CLOGGED_REMOTE_TLOG_EXCLUDED;
 					if (!statusCheckPassed) {
-						bool statusCheckPassed_ = wait(grayFailureStatusCheck(db, self->cloggedRemoteTLog.get()));
-						statusCheckPassed = statusCheckPassed_;
+						wait(store(statusCheckPassed, grayFailureStatusCheck(db, self->cloggedRemoteTLog.get())));
 						ASSERT(statusCheckPassed);
 					}
 					stateTransition = localState != testState;

--- a/fdbserver/workloads/ClogRemoteTLog.actor.cpp
+++ b/fdbserver/workloads/ClogRemoteTLog.actor.cpp
@@ -195,7 +195,7 @@ struct ClogRemoteTLog : TestWorkload {
 			ASSERT(process.has("time"));
 			TraceEvent("GrayFailureStatus")
 			    .detail("Address", process["address"].get_str())
-			    .detail("Time", process["time"].get_real());
+			    .detail("Ts", process["time"].get_real());
 		}
 		return true;
 	}

--- a/fdbserver/workloads/ClogRemoteTLog.actor.cpp
+++ b/fdbserver/workloads/ClogRemoteTLog.actor.cpp
@@ -195,7 +195,7 @@ struct ClogRemoteTLog : TestWorkload {
 			ASSERT(process.has("time"));
 			TraceEvent("GrayFailureStatus")
 			    .detail("Address", process["address"].get_str())
-			    .detail("time", process["time"].get_real());
+			    .detail("Time", process["time"].get_real());
 		}
 		return true;
 	}

--- a/fdbserver/workloads/ClogRemoteTLog.actor.cpp
+++ b/fdbserver/workloads/ClogRemoteTLog.actor.cpp
@@ -188,17 +188,16 @@ struct ClogRemoteTLog : TestWorkload {
 			TraceEvent("NoGrayFailure");
 			return false;
 		}
-		ASSERT(grayFailure.has("excluded_processes"));
-		StatusArray excludedProcesses = grayFailure["excluded_processes"].get_array();
+		ASSERT(grayFailure.has("excluded_servers"));
+		StatusArray excludedProcesses = grayFailure["excluded_servers"].get_array();
 		for (StatusObjectReader process : excludedProcesses) {
 			ASSERT(process.has("address"));
 			ASSERT(process.has("time"));
-			if (process["address"].get_str() == cloggedRemoteTLog.toString()) {
-				ASSERT(process["time"].get_real() < now());
-				return true;
-			}
+			TraceEvent("GrayFailureStatus")
+			    .detail("Address", process["address"].get_str())
+			    .detail("time", process["time"].get_real());
 		}
-		return false;
+		return true;
 	}
 
 	ACTOR static Future<std::vector<IPAddress>> getRemoteSSIPs(Database db) {


### PR DESCRIPTION
# Description

Under a server side (specifically, cluster controller) knob, status json now returns data about gray failure. Something like this is shown:

<img width="494" alt="image" src="https://github.com/user-attachments/assets/29892c95-d204-4b01-af80-a572ba72126e">


This is under the `cluster` section of status json. 

If there are no excluded processes, we still display empty section to communicate _absence_ of excluded processes.

The definition of exclusion here is based on whatever gray failure algorithm decides. These are the same processes based on which recovery is triggered. 

The definition of time is whenever the process was _most recently_ or _last_ excluded by gray failure. The unit of time is the same as whatever `now()` returns.

The intent behind exposing this information in a machine readable way is that components like FDB's Kubernetes operator can leverage it and potentially make host/pod level decisions at a higher level of abstraction than FDB server binary itself.

# Testing 

- Updated existing simulation test such that whenever process is excluded, we assert that status json returns information about that process.
- 100K Joshua running: `20241112-005252-praza-bd96a9bfc8b2b82017133773e1b8694e243a5e compressed=True data_size=36050950 fail_fast=10 max_runs=100000 priority=100 sanity=False submitted=20241112-005252 timeout=5400 username=praza-bd96a9bfc8b2b82017133773e1b8694e243a5e71`

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
