### PR TITLE
Do not test bulk loading and version vector simultaneously

### DIFF
--- a/tests/fast/BulkLoading.toml
+++ b/tests/fast/BulkLoading.toml
@@ -19,7 +19,8 @@ dd_physical_shard_move_probability = 1.0
 
 # BulkLoad relies on RangeLock
 enable_read_lock_on_range = true
-proxy_use_resolver_private_mutations = false # do not support version vector
+enable_version_vector = false
+enable_version_vector_tlog_unicast = false
 
 # Set high enough sample rate to test bytes sampling
 min_byte_sampling_probability = 0.5


### PR DESCRIPTION
Do not test bulk loading and version vector simultaneously

tested with proxy_use_resolver_private_mutations enabled
`20241106-165853-dlambrig-01fee3d240275ced`

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
