### PR TITLE
Reduce Bulkload Workload Size

### DIFF
--- a/fdbserver/workloads/BulkLoading.actor.cpp
+++ b/fdbserver/workloads/BulkLoading.actor.cpp
@@ -436,13 +436,13 @@ struct BulkLoading : TestWorkload {
 			bulkLoadStates.clear();
 			bulkLoadDataList.clear();
 			completeRanges.clear();
-			for (int i = 0; i < 3; i++) {
+			for (int i = 0; i < 2; i++) {
 				std::string indexStr = std::to_string(i);
 				std::string indexStrNext = std::to_string(i + 1);
 				Key beginKey = StringRef(indexStr);
 				Key endKey = StringRef(indexStrNext);
 				std::string folderPath = joinPath(simulationBulkLoadFolder, indexStr);
-				int dataSize = deterministicRandom()->randomInt(5, 20);
+				int dataSize = deterministicRandom()->randomInt(2, 5);
 				BulkLoadTaskTestUnit taskUnit =
 				    self->generateBulkLoadTaskUnit(self, folderPath, dataSize, KeyRangeRef(beginKey, endKey));
 				bulkLoadStates.push_back(taskUnit.bulkLoadTask);


### PR DESCRIPTION
Reduce bulkload workload size to mitigate trace too many events and external timeout.

100K bulk loading tests:
20241107-221205-zhewang-b8e3c370da084c29

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
