### PR TITLE
Do not choose two_satellite_fast in simulation tests with version vector

### DIFF
--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -2031,6 +2031,11 @@ void SimulationConfig::setRegions(const TestConfig& testConfig) {
 			// FIXME: we cannot use one satellite replication with more than one satellite per region because
 			// canKillProcesses does not respect usable_dcs
 			int satellite_replication_type = deterministicRandom()->randomInt(0, 3);
+			if (SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST && satellite_replication_type == 1) {
+				// two_satellite_fast sets antiQuorum to 2, because only one out of two satellites need reply before
+				// commit. disabling for version vector in simulation until quorum feature works with it.
+				satellite_replication_type = 2;
+			}
 			switch (satellite_replication_type) {
 			case 0: {
 				CODE_PROBE(true, "Simulated cluster using no satellite redundancy mode (>4 datacenters)");


### PR DESCRIPTION
Do not choose `two_satellite_fast` in simulation tests when version vector unitcast is enabled. This configuration sets `antiQuorum` to 2, because only one out of two satellites need reply before commit. The unicast recovery does not yet work with the quorum feature.

Joshua
`20241108-181740-dlambrig-fb666c04e0900aff `

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
