### PR TITLE
Fix two cases of non-determinism in simulation

### DIFF
--- a/fdbserver/fdbserver.actor.cpp
+++ b/fdbserver/fdbserver.actor.cpp
@@ -1520,6 +1520,7 @@ private:
 					printHelpTeaser(argv[0]);
 					flushAndExit(FDB_EXIT_ERROR);
 				}
+				setThreadLocalDeterministicRandomSeed(randomSeed);
 				break;
 			}
 			case OPT_MACHINEID: {
@@ -1988,8 +1989,6 @@ int main(int argc, char* argv[]) {
 
 		if (opts.zoneId.present())
 			printf("ZoneId set to %s, dcId to %s\n", printable(opts.zoneId).c_str(), printable(opts.dcId).c_str());
-
-		setThreadLocalDeterministicRandomSeed(opts.randomSeed);
 
 		if (opts.buggifyEnabled) {
 			enableGeneralBuggify();

--- a/flow/Knobs.cpp
+++ b/flow/Knobs.cpp
@@ -243,7 +243,7 @@ void FlowKnobs::initialize(Randomize randomize, IsSimulated isSimulated) {
 	init( MAX_CLOGGING_LATENCY,                                  0 ); if( randomize && BUGGIFY ) MAX_CLOGGING_LATENCY =  0.1 * deterministicRandom()->random01();
 	init( MAX_BUGGIFIED_DELAY,                                   0 ); if( randomize && BUGGIFY ) MAX_BUGGIFIED_DELAY =  0.2 * deterministicRandom()->random01();
 	init( MAX_RUNLOOP_SLEEP_DELAY,                               0 );
-	init( SIM_CONNECT_ERROR_MODE, deterministicRandom()->randomInt(0,3) );
+	init( SIM_CONNECT_ERROR_MODE,                                0 ); if( randomize && BUGGIFY ) SIM_CONNECT_ERROR_MODE = deterministicRandom()->randomInt(0,3);
 
 	//Tracefiles
 	init( ZERO_LENGTH_FILE_PAD,                                  1 );


### PR DESCRIPTION
# Description

For both cases, the root cause is that `deterministicRandom` is called before rng is setup based on cli provided seed (in `setThreadLocalDeterministicRandomSeed`). Below are brief descriptions of the issues and their fixes.

1. `SIM_CONNECT_ERROR_MODE` used `deterministicRandom` unconditionally unlike other knobs in the file guarded by `randomize && BUGGIFY`. Fix is to do the same for `SIM_CONNECT_ERROR_MODE`. Picked 0 as the default value based on usage. 

2. The call stack `fdbserver main -> parseArgsInternal -> machineId = getSharedMemoryMachineId() -> newUID = deterministicRandom()->randomUniqueID()` runs _before_ `setThreadLocalDeterministicRandomSeed` is called in fdbserver main. This meant that `machineId` was different across runs with the same seed. Unfortunately, the random seed itself is parsed as part of `parseArgsInternal`. The fix is to call `setThreadLocalDeterministicRandomSeed` immediately after random seed is parsed, that way when we call `getSharedMemoryMachineId` later in the function, it picks up the rng based on cli provided seed. I did attempt to just change the callsite of `setThreadLocalDeterministicRandomSeed` in fdbserver main by moving it before `parseArgs`, but that was complicated because of the circular issue (parseArgs gives random seed, setThreadLocalDeterministicRandomSeed needs that random seed). At that point, I did try a bit to parse _just_ the random seed as a first phase, but the code was more complicated than I would have liked. So at the end, resorted to the fix mentioned here.

# Testing

- Manual test to ensure that previous non-determinism is gone. Specifically, the machine id used to be different across runs with the same seed, now it's the same. 
- 100K Joshua currently running: `20241108-213053-praza-0d5304daeb6fdd7e060e7f492d7c695fa5e35a compressed=True data_size=36044538 duration=344550 ended=6696 fail_fast=10 max_runs=100000 pass=6696 priority=100 remaining=1:16:10 runtime=0:05:28 sanity=False started=9416 submitted=20241108-213053 timeout=5400 username=praza-0d5304daeb6fdd7e060e7f492d7c695fa5e35abc`.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
