### PR TITLE
Fix ASAN build errors

### DIFF
--- a/cmake/CompileBoost.cmake
+++ b/cmake/CompileBoost.cmake
@@ -77,7 +77,7 @@ function(compile_boost)
   if(USE_ASAN)
     set(BOOST_SRC_URL https://boostorg.jfrog.io/artifactory/main/release/1.86.0/source/boost_1_86_0.tar.bz2)
     set(BOOST_SRC_SHA SHA256=1bed88e40401b2cb7a1f76d4bab499e352fa4d0c5f31c0dbae64e24d34d7513b)
-    set(COMPILE_BOOST_BUILD_ARGS context-impl=ucontext)
+    set(B2_ADDTTIONAL_BUILD_ARGS context-impl=ucontext)
   endif()
   set(BOOST_INSTALL_DIR "${CMAKE_BINARY_DIR}/boost_install")
   ExternalProject_add("${COMPILE_BOOST_TARGET}Project"
@@ -88,7 +88,7 @@ function(compile_boost)
                        --with-libraries=${BOOTSTRAP_LIBRARIES}
                        --with-toolset=${BOOST_TOOLSET}
     BUILD_COMMAND      ${B2_COMMAND}
-                       link=static
+                       link=static ${B2_ADDTTIONAL_BUILD_ARGS}
                        ${COMPILE_BOOST_BUILD_ARGS}
                        --prefix=${BOOST_INSTALL_DIR}
                        ${USER_CONFIG_FLAG} install

--- a/flow/include/flow/FastAlloc.h
+++ b/flow/include/flow/FastAlloc.h
@@ -40,6 +40,10 @@
 bool valgrindPrecise();
 #endif
 
+#ifdef ADDRESS_SANITIZER
+#include <sanitizer/lsan_interface.h>
+#endif
+
 #include "flow/Hash3.h"
 
 #include <assert.h>
@@ -209,10 +213,17 @@ std::vector<std::pair<const uint8_t*, int>> const& getWipedAreaSet();
 } // namespace keepalive_allocator
 
 force_inline uint8_t* allocateAndMaybeKeepalive(size_t size) {
+	uint8_t* p;
 	if (keepalive_allocator::isActive()) [[unlikely]]
-		return static_cast<uint8_t*>(keepalive_allocator::allocate(size));
+		p = static_cast<uint8_t*>(keepalive_allocator::allocate(size));
 	else
-		return new uint8_t[size];
+		p = new uint8_t[size];
+
+#ifdef ADDRESS_SANITIZER
+	__lsan_ignore_object(p);
+#endif
+
+	return p;
 }
 
 force_inline void freeOrMaybeKeepalive(void* ptr) {


### PR DESCRIPTION
This fixes https://github.com/apple/foundationdb/issues/10813

There are multiple problems:
- The boost 1.78 doesn't work well with ASAN build, which was fixed in later versions
- The compiling missed "context-impl=ucontext" flag for b2 command
- missing /usr/local/include/c++/v1/__config_site in the developer environment

I didn't make boost 1.86 as the default for normal build, because of issues in developer environment. We can make the change after developer environment is fixed.

I ran ctest and the problem from #10813 is gone, but the test failed for other errors, i.e., memory leaks, which can be investigated/fixed in a separate PR.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
