### PR TITLE
Mitigate TraceTooManyEvents and ExternalTimeouts in BulkLoading tests

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -197,6 +197,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( ENABLE_DD_PHYSICAL_SHARD,                            false ); // EXPERIMENTAL; If true, SHARD_ENCODE_LOCATION_METADATA must be true; When true, optimization of data move between DCs is disabled
 	init( DD_PHYSICAL_SHARD_MOVE_PROBABILITY,                    0.0 ); // FIXME: re-enable after ShardedRocksDB is well tested by simulation
 	init( ENABLE_PHYSICAL_SHARD_MOVE_EXPERIMENT,               false ); // FIXME: re-enable after ShardedRocksDB is well tested by simulation
+	init( BULKLOAD_ONLY_USE_PHYSICAL_SHARD_MOVE,                true ); // FIXME(BulkLoad): disable after bulk load supports fetchKeys
 	init( MAX_PHYSICAL_SHARD_BYTES,                         10000000 ); // 10 MB; for ENABLE_DD_PHYSICAL_SHARD; smaller leads to larger number of physicalShard per storage server
  	init( PHYSICAL_SHARD_METRICS_DELAY,                        300.0 ); // 300 seconds; for ENABLE_DD_PHYSICAL_SHARD
 	init( ANONYMOUS_PHYSICAL_SHARD_TRANSITION_TIME,            600.0 ); if( randomize && BUGGIFY )  ANONYMOUS_PHYSICAL_SHARD_TRANSITION_TIME = 0.0; // 600 seconds; for ENABLE_DD_PHYSICAL_SHARD

--- a/fdbclient/include/fdbclient/ServerKnobs.h
+++ b/fdbclient/include/fdbclient/ServerKnobs.h
@@ -228,6 +228,7 @@ public:
 	bool ENABLE_DD_PHYSICAL_SHARD; // EXPERIMENTAL; If true, SHARD_ENCODE_LOCATION_METADATA must be true.
 	double DD_PHYSICAL_SHARD_MOVE_PROBABILITY; // Percentage of physical shard move, in the range of [0, 1].
 	bool ENABLE_PHYSICAL_SHARD_MOVE_EXPERIMENT;
+	bool BULKLOAD_ONLY_USE_PHYSICAL_SHARD_MOVE; // If true, bulk load only uses physical shard move
 	int64_t MAX_PHYSICAL_SHARD_BYTES;
 	double PHYSICAL_SHARD_METRICS_DELAY;
 	double ANONYMOUS_PHYSICAL_SHARD_TRANSITION_TIME;

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -606,7 +606,11 @@ bool isHealthySingleton(ClusterControllerData* self,
 		    .detail(roleAbbr + "ID", singleton.getInterface().id())
 		    .detail("Excluded", currWorker.priorityInfo.isExcluded)
 		    .detail("Fitness", currFitness)
-		    .detail("BestFitness", bestFitness);
+		    .detail("BestFitness", bestFitness)
+		    .detail("MasterProcessId", self->masterProcessId)
+		    .detail("CurrentWorkerProcessId", currWorker.details.interf.locality.processId())
+		    .detail("NewWorkerProcessId", newWorker.interf.locality.processId())
+		    .detail("IsUsedNotMaster", self->isUsedNotMaster(currWorker.details.interf.locality.processId()));
 		singleton.recruit(*self); // SIDE EFFECT: initiating recruitment
 		return false; // not healthy since needed to be rerecruited
 	} else {

--- a/fdbserver/DDRelocationQueue.actor.cpp
+++ b/fdbserver/DDRelocationQueue.actor.cpp
@@ -988,6 +988,9 @@ void DDQueue::launchQueuedWork(RelocateData launchData, const DDEnabledState* dd
 }
 
 DataMoveType newDataMoveType(bool doBulkLoading) {
+	if (doBulkLoading && SERVER_KNOBS->BULKLOAD_ONLY_USE_PHYSICAL_SHARD_MOVE) {
+		return DataMoveType::PHYSICAL_BULKLOAD;
+	}
 	DataMoveType type = DataMoveType::LOGICAL;
 	if (deterministicRandom()->random01() < SERVER_KNOBS->DD_PHYSICAL_SHARD_MOVE_PROBABILITY) {
 		type = DataMoveType::PHYSICAL;

--- a/fdbserver/KeyValueStoreShardedRocksDB.actor.cpp
+++ b/fdbserver/KeyValueStoreShardedRocksDB.actor.cpp
@@ -778,6 +778,7 @@ public:
 			}
 		}
 		TraceEvent("RefreshIterators")
+		    .suppressFor(5.0)
 		    .detail("NumReplacedIterators", numReplacedIters)
 		    .detail("NumReusedIterators", numReusedIters)
 		    .detail("NumNewIterators", numNewIterators)

--- a/fdbserver/workloads/BulkLoading.actor.cpp
+++ b/fdbserver/workloads/BulkLoading.actor.cpp
@@ -436,13 +436,13 @@ struct BulkLoading : TestWorkload {
 			bulkLoadStates.clear();
 			bulkLoadDataList.clear();
 			completeRanges.clear();
-			for (int i = 0; i < 3; i++) {
+			for (int i = 0; i < 2; i++) {
 				std::string indexStr = std::to_string(i);
 				std::string indexStrNext = std::to_string(i + 1);
 				Key beginKey = StringRef(indexStr);
 				Key endKey = StringRef(indexStrNext);
 				std::string folderPath = joinPath(simulationBulkLoadFolder, indexStr);
-				int dataSize = deterministicRandom()->randomInt(5, 20);
+				int dataSize = deterministicRandom()->randomInt(2, 5);
 				BulkLoadTaskTestUnit taskUnit =
 				    self->generateBulkLoadTaskUnit(self, folderPath, dataSize, KeyRangeRef(beginKey, endKey));
 				bulkLoadStates.push_back(taskUnit.bulkLoadTask);

--- a/tests/fast/BulkLoading.toml
+++ b/tests/fast/BulkLoading.toml
@@ -15,7 +15,6 @@ encryptModes = ['disabled'] # Do not support encryption
 # The temporary fix is that in SimulatedCluster.cpp:simulationSetupAndRun, we are doing one additional check
 # so for this BulkLoading test, the shard RocksDB storage engine is always turned on.
 shard_encode_location_metadata = true
-dd_physical_shard_move_probability = 1.0
 
 # BulkLoad relies on RangeLock
 enable_read_lock_on_range = true


### PR DESCRIPTION
We observed three causes of TraceTooManyEvents error in BulkLoading tests:
1. `RefreshIterators` trace event pops very frequently;
2. CC repeatedly create a new DD throughout the test (rare, investigating..);
3. QuietDatabaseStartFail keeps happening (rare, investigating..).

We observed that with physical shard move can cause external timeout. One interesting thing here is that we didn't see this external timeout error in the bulkLoading test before the last BulkLoading relevant PR. So, there might be some change recently causing the issue, e.g. new RocksDB binary (rare, investigating..).


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
