### PR TITLE
Improve BulkLoading Simulation Test

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -197,6 +197,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( ENABLE_DD_PHYSICAL_SHARD,                            false ); // EXPERIMENTAL; If true, SHARD_ENCODE_LOCATION_METADATA must be true; When true, optimization of data move between DCs is disabled
 	init( DD_PHYSICAL_SHARD_MOVE_PROBABILITY,                    0.0 ); // FIXME: re-enable after ShardedRocksDB is well tested by simulation
 	init( ENABLE_PHYSICAL_SHARD_MOVE_EXPERIMENT,               false ); // FIXME: re-enable after ShardedRocksDB is well tested by simulation
+	init( BULKLOAD_ONLY_USE_PHYSICAL_SHARD_MOVE,                true ); // FIXME(BulkLoad): disable after bulk load supports fetchKeys
 	init( MAX_PHYSICAL_SHARD_BYTES,                         10000000 ); // 10 MB; for ENABLE_DD_PHYSICAL_SHARD; smaller leads to larger number of physicalShard per storage server
  	init( PHYSICAL_SHARD_METRICS_DELAY,                        300.0 ); // 300 seconds; for ENABLE_DD_PHYSICAL_SHARD
 	init( ANONYMOUS_PHYSICAL_SHARD_TRANSITION_TIME,            600.0 ); if( randomize && BUGGIFY )  ANONYMOUS_PHYSICAL_SHARD_TRANSITION_TIME = 0.0; // 600 seconds; for ENABLE_DD_PHYSICAL_SHARD

--- a/fdbclient/include/fdbclient/ServerKnobs.h
+++ b/fdbclient/include/fdbclient/ServerKnobs.h
@@ -228,6 +228,7 @@ public:
 	bool ENABLE_DD_PHYSICAL_SHARD; // EXPERIMENTAL; If true, SHARD_ENCODE_LOCATION_METADATA must be true.
 	double DD_PHYSICAL_SHARD_MOVE_PROBABILITY; // Percentage of physical shard move, in the range of [0, 1].
 	bool ENABLE_PHYSICAL_SHARD_MOVE_EXPERIMENT;
+	bool BULKLOAD_ONLY_USE_PHYSICAL_SHARD_MOVE; // If true, bulk load only uses physical shard move
 	int64_t MAX_PHYSICAL_SHARD_BYTES;
 	double PHYSICAL_SHARD_METRICS_DELAY;
 	double ANONYMOUS_PHYSICAL_SHARD_TRANSITION_TIME;

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -606,7 +606,11 @@ bool isHealthySingleton(ClusterControllerData* self,
 		    .detail(roleAbbr + "ID", singleton.getInterface().id())
 		    .detail("Excluded", currWorker.priorityInfo.isExcluded)
 		    .detail("Fitness", currFitness)
-		    .detail("BestFitness", bestFitness);
+		    .detail("BestFitness", bestFitness)
+		    .detail("MasterProcessId", self->masterProcessId)
+		    .detail("CurrentWorkerProcessId", currWorker.details.interf.locality.processId())
+		    .detail("NewWorkerProcessId", newWorker.interf.locality.processId())
+		    .detail("IsUsedNotMaster", self->isUsedNotMaster(currWorker.details.interf.locality.processId()));
 		singleton.recruit(*self); // SIDE EFFECT: initiating recruitment
 		return false; // not healthy since needed to be rerecruited
 	} else {

--- a/fdbserver/DDRelocationQueue.actor.cpp
+++ b/fdbserver/DDRelocationQueue.actor.cpp
@@ -988,6 +988,9 @@ void DDQueue::launchQueuedWork(RelocateData launchData, const DDEnabledState* dd
 }
 
 DataMoveType newDataMoveType(bool doBulkLoading) {
+	if (doBulkLoading && SERVER_KNOBS->BULKLOAD_ONLY_USE_PHYSICAL_SHARD_MOVE) {
+		return DataMoveType::PHYSICAL_BULKLOAD;
+	}
 	DataMoveType type = DataMoveType::LOGICAL;
 	if (deterministicRandom()->random01() < SERVER_KNOBS->DD_PHYSICAL_SHARD_MOVE_PROBABILITY) {
 		type = DataMoveType::PHYSICAL;

--- a/fdbserver/KeyValueStoreShardedRocksDB.actor.cpp
+++ b/fdbserver/KeyValueStoreShardedRocksDB.actor.cpp
@@ -778,6 +778,7 @@ public:
 			}
 		}
 		TraceEvent("RefreshIterators")
+		    .suppressFor(5.0)
 		    .detail("NumReplacedIterators", numReplacedIters)
 		    .detail("NumReusedIterators", numReusedIters)
 		    .detail("NumNewIterators", numNewIterators)

--- a/tests/fast/BulkLoading.toml
+++ b/tests/fast/BulkLoading.toml
@@ -15,7 +15,6 @@ encryptModes = ['disabled'] # Do not support encryption
 # The temporary fix is that in SimulatedCluster.cpp:simulationSetupAndRun, we are doing one additional check
 # so for this BulkLoading test, the shard RocksDB storage engine is always turned on.
 shard_encode_location_metadata = true
-dd_physical_shard_move_probability = 1.0
 
 # BulkLoad relies on RangeLock
 enable_read_lock_on_range = true


### PR DESCRIPTION
Observed three causes of TraceTooManyEvents error in BulkLoading tests:
1. `RefreshIterators` trace event pops very frequently;
2. CC repeatedly creates a new DD throughout the test (very rare, investigating..);
3. QuietDatabaseStartFail keeps happening (very rare, investigating..).

Observed that physical shard move (BulkLoad replies on PhysicalShardMove) can cause external timeout. One interesting thing here is that we didn't see this external timeout error in the bulkLoading test before the last BulkLoading relevant PR. So, there might be some change recently causing the issue, e.g. new RocksDB binary (rare, investigating..).

This PR:
1. Avoid frequently popping `RefreshIterators` trace event;
2. Add some trace event for debugging;
3. Introduce a knob `BULKLOAD_ONLY_USE_PHYSICAL_SHARD_MOVE` which is set to force to use physical shard move for bulkLoad task when the physical shard move is off (we want to generally turn off physical shard move except for bulk loading data moves before we understand the external timeout root cause).

100K correctness tests:
  20241111-172134-zhewang-ae892a5dc66e5bfb           compressed=True data_size=36907793 duration=5552088 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:57:33 sanity=False started=100000 stopped=20241111-181907 submitted=20241111-172134 timeout=5400 username=zhewang
  
100K BulkLoading Tests:
  20241109-044137-zhewang-803dbb2d57b814cb           compressed=True data_size=36939725 duration=30091252 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=2:05:13 sanity=False started=100000 stopped=20241109-064650 submitted=20241109-044137 timeout=5400 username=zhewang

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
