### PR TITLE
Improvements to the unicast-based recovery version computation algorithm

### DIFF
--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -2088,6 +2088,14 @@ void getTLogLocIds(const std::vector<Reference<LogSet>>& tLogs,
 	}
 }
 
+Version findMaxKCV(const std::tuple<int, std::vector<TLogLockResult>>& logGroupResults) {
+	Version maxKCV = 0;
+	for (auto& tLogResult : std::get<1>(logGroupResults)) {
+		maxKCV = std::max(maxKCV, tLogResult.knownCommittedVersion);
+	}
+	return maxKCV;
+}
+
 void populateBitset(boost::dynamic_bitset<>& bs, const std::vector<uint16_t>& ids) {
 	for (auto& id : ids) {
 		ASSERT(id < bs.size());
@@ -2099,14 +2107,16 @@ void populateBitset(boost::dynamic_bitset<>& bs, const std::vector<uint16_t>& id
 // This function finds the highest recoverable version for each tLog group over all log groups.
 // All prior versions to the chosen RV must also be recoverable.
 // TODO: unit tests to stress UNICAST
-Version getRecoverVersionUnicast(const std::vector<Reference<LogSet>>& logServers,
-                                 const std::tuple<int, std::vector<TLogLockResult>>& logGroupResults,
-                                 Version minDV,
-                                 Version minKCV) {
+Optional<std::tuple<Version, Version>> getRecoverVersionUnicast(
+    const std::vector<Reference<LogSet>>& logServers,
+    const std::tuple<int, std::vector<TLogLockResult>>& logGroupResults,
+    Version minDV) {
 	std::vector<uint16_t> tLogLocIds;
 	uint16_t maxTLogLocId; // maximum possible id, not maximum of id's of available log servers
 	getTLogLocIds(logServers, logGroupResults, tLogLocIds, maxTLogLocId);
 	uint16_t bsSize = maxTLogLocId + 1; // bitset size, used below
+
+	Version maxKCV = findMaxKCV(logGroupResults);
 
 	// Summarize the information sent by various tLogs.
 	// A bitset of available tLogs
@@ -2120,14 +2130,14 @@ Version getRecoverVersionUnicast(const std::vector<Reference<LogSet>>& logServer
 	uint16_t tLogIdx = 0;
 	int replicationFactor = std::get<0>(logGroupResults);
 	for (auto& tLogResult : std::get<1>(logGroupResults)) {
+		uint16_t tLogLocId = tLogLocIds[tLogIdx++];
 		if (tLogResult.unknownCommittedVersions.empty()) {
-			return minKCV;
+			continue;
 		}
-		uint16_t tLogLocId = tLogLocIds[tLogIdx];
 		availableTLogs.set(tLogLocId);
 		for (auto& unknownCommittedVersion : tLogResult.unknownCommittedVersions) {
 			Version k = unknownCommittedVersion.version;
-			if (k > minKCV) {
+			if (k > maxKCV) {
 				if (versionAvailableTLogs[k].empty()) {
 					versionAvailableTLogs[k].resize(bsSize);
 				}
@@ -2139,26 +2149,31 @@ Version getRecoverVersionUnicast(const std::vector<Reference<LogSet>>& logServer
 				populateBitset(versionAllTLogs[k], unknownCommittedVersion.tLogLocIds);
 			}
 		}
-		tLogIdx++;
+	}
+
+	if (versionAllTLogs.empty()) {
+		return std::make_tuple(maxKCV, maxKCV);
 	}
 
 	// Compute recovery version.
+	//
 	// @note we think that the unicast recovery version should always greater than or
-	// equal to "min(DV)" (= "minDV"). To be conservative we use "min(KCV)" (= "minKCV")
+	// equal to "min(DV)" (= "minDV"). To be conservative we use "max(KCV)" (= "maxKCV")
 	// as the default (starting) recovery version and later verify that the computed
 	// recovery version is greater than or equal to "minDV".
-	// @todo modify code to use "minDV" as the default (starting) recovery version
-	// @todo to be investigated: maybe we should use max(KCV) as the starting recovery
-	// version (this is because "known committed version" can advance even after a log
-	// server is locked when unicast is enabled and so all log servers may not preserve
-	// all committed versions, from min(KCV) till the correct recovery version, in
-	// "unknownCommittedVersions" causing the recovery algorithm to not find the correct
-	// recovery version)?
-	Version RV = minKCV; // recovery version
-	std::vector<Version> RVs(maxTLogLocId + 1, minKCV); // recovery versions of various tLogs
-	Version prevVersion = minKCV;
+	//
+	// @note we are not using "min(KCV)" as the default recovery version because "known
+	// committed version" can advance even after a log server is locked when unicast is
+	// enabled and so all log servers may not preserve all committed versions, from
+	// "min(KCV)" till the correct recovery version, in "unknownCommittedVersions" and
+	// this may cause the recovery algorithm to not find the correct recovery version.
+	//
+	// @todo modify code to use "minDV" as the default (starting) recovery version.
+	Version RV = maxKCV; // recovery version
+	std::vector<Version> RVs(maxTLogLocId + 1, maxKCV); // recovery versions of various tLogs
+	Version prevVersion = maxKCV;
 	for (auto const& [version, tLogs] : versionAllTLogs) {
-		if (!(prevVersion == minKCV || prevVersion == prevVersionMap[version])) {
+		if (!(prevVersion == maxKCV || prevVersion == prevVersionMap[version])) {
 			break;
 		}
 		// This version is not recoverable if there is a log server (LS) such that:
@@ -2185,7 +2200,8 @@ Version getRecoverVersionUnicast(const std::vector<Reference<LogSet>>& logServer
 		prevVersion = version;
 	}
 	ASSERT_WE_THINK(RV >= minDV && RV != std::numeric_limits<Version>::max());
-	return RV;
+	ASSERT_WE_THINK(RV >= maxKCV);
+	return std::make_tuple(maxKCV, RV);
 }
 
 ACTOR Future<Void> TagPartitionedLogSystem::epochEnd(Reference<AsyncVar<Reference<ILogSystem>>> outLogSystem,
@@ -2445,7 +2461,7 @@ ACTOR Future<Void> TagPartitionedLogSystem::epochEnd(Reference<AsyncVar<Referenc
 	state Version knownCommittedVersion = 0;
 	loop {
 		Version minEnd = std::numeric_limits<Version>::max();
-		Version minKCV = std::numeric_limits<Version>::max();
+		Version minDV = std::numeric_limits<Version>::max();
 		Version maxEnd = 0;
 		state std::vector<Future<Void>> changes;
 		state std::vector<std::tuple<int, std::vector<TLogLockResult>>> logGroupResults;
@@ -2456,15 +2472,17 @@ ACTOR Future<Void> TagPartitionedLogSystem::epochEnd(Reference<AsyncVar<Referenc
 			auto versions =
 			    TagPartitionedLogSystem::getDurableVersion(dbgid, lockResults[log], logFailed[log], lastEnd);
 			if (versions.present()) {
-				knownCommittedVersion = std::max(knownCommittedVersion, std::get<0>(versions.get()));
 				logGroupResults.emplace_back(logServers[log]->tLogReplicationFactor, std::get<2>(versions.get()));
-				maxEnd = std::max(maxEnd, std::get<1>(versions.get()));
-				minEnd = std::min(minEnd, std::get<1>(versions.get()));
-				minKCV = std::min(minKCV, std::get<0>(versions.get()));
-				if (SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST) {
-					Version version = getRecoverVersionUnicast(logServers, logGroupResults.back(), minEnd, minKCV);
-					maxEnd = std::max(maxEnd, version);
-					minEnd = std::min(minEnd, version);
+				minDV = std::min(minDV, std::get<1>(versions.get()));
+				if (!SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST) {
+					knownCommittedVersion = std::max(knownCommittedVersion, std::get<0>(versions.get()));
+					maxEnd = std::max(maxEnd, std::get<1>(versions.get()));
+					minEnd = std::min(minEnd, std::get<1>(versions.get()));
+				} else {
+					auto unicastVersions = getRecoverVersionUnicast(logServers, logGroupResults.back(), minDV);
+					knownCommittedVersion = std::max(knownCommittedVersion, std::get<0>(unicastVersions.get()));
+					maxEnd = std::max(maxEnd, std::get<1>(unicastVersions.get()));
+					minEnd = std::min(minEnd, std::get<1>(unicastVersions.get()));
 				}
 			}
 			changes.push_back(TagPartitionedLogSystem::getDurableVersionChanged(lockResults[log], logFailed[log]));


### PR DESCRIPTION
Modify the unicast-based recovery version computation algorithm the following ways:

- Make it use "max(KCV)", instead of "min(KCV)", as the default recovery version (details below)
- Make it return the <max(KCV), recovery version> pair as output
- Make the invoker use the "max(KCV)" version returned by the algorithm
- Address a bug related to the computation of recovery version (in the case where a subset of log servers have empty "unknownCommittedVersions" list)

And, make the invoker compute the max() and min() of recovery versions of primary and satellite DCs based on the recovery versions computed by the appropriate (with/without unicast) recovery version computation algorithms.

Testing:

Joshua job (with version vector feature disabled): 20241111-215149-sre-3f2cb6906ac4ea16 (no failures).

More details:

How can the "KnownCommittedVersion" advance after a log server/a subset of log servers are locked when unicast is enabled? This can happen because a commit version may get sent only to a subset of log servers when unicast is enabled and so even after a log server is/a subset of log servers are locked the remaining log servers could receive a version, commit that version, and that could cause the known committed version to advance.

Consider log servers S_a, S_b, S_c, S_d, and RF = 1. Suppose servers S_a and S_b got locked at version V_x, and known committed version on those servers be K_x (K_x < V_x). Now servers S_c and S_d could receive another version V_y (V_x < V_y) before they receive the lock message from the cluster controller, could commit V_y, could advance the known committed version to V_y on the proxy, and could receive V_y as the known committed version before they receive the lock request.

Here is a scenario from a simulation test that was causing a wrong recovery version to be selected because the known committed version was advancing after a log server is locked and we were using "min(kcv)" as the default recovery version:

Log server interfaces and their IDs:

Interface: b5c90942058a7b8c, ID: 0
Interface: ee2db35be3e7caf7, ID: 1
Interface: 727dc80e10ce7857, ID: 2

Versions and the log servers those versions were sent to:

Version 47631442 sent to and received by log server with ID: 1 and sent to and received by log server with ID: 0.

Version 49130513 sent to and received by log server with ID: 2) and sent to and received by log server with ID: 0.

Version 49771720 sent to and received by log server with ID: 2 and sent to but not received by log server with ID: 1.

Version 50985880 sent to but not received by log server with ID: 1 and sent to and received by log server with ID: 0.

Log servers with IDs 0 and 1 are reporting to cluster controller during recovery.

Log server with ID 1 gets stopped/locked at version 47631442, has known committed version 45781955 and reports unknown committed version list: 47631442

Log server with ID 0 gets stopped/locked at version 50985880, has known committed version 49130513 and reports unknown committed version list: 50985880

Note that the known committed version got advanced on log server with ID 0 after log server with ID 1 got locked.

Since the known committed version got advanced on ID 1 it won't report versions below 49130513 as unknown committed versions.

If the recovery algorithm uses "min(KCV)" as the default recovery version it will report 47631442 as the recovery version which is wrong. Using "max(KCV)" will make the algorithm pick the correct recovery version 49130513.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
