### PR TITLE
Do not print an erroneous message 404 error message when /check_hash is called

### DIFF
--- a/packaging/docker/sidecar.py
+++ b/packaging/docker/sidecar.py
@@ -493,6 +493,7 @@ class SidecarHandler(BaseHTTPRequestHandler):
                     )
                 except FileNotFoundError:
                     self.send_error(404, f"{file_path} not found")
+                return
             if self.path.startswith("/is_present/"):
                 file_path = os.path.relpath(self.path, "/is_present")
                 if self.is_present(file_path):
@@ -504,7 +505,7 @@ class SidecarHandler(BaseHTTPRequestHandler):
             elif self.path == "/substitutions":
                 self.send_text(self.get_substitutions())
             else:
-                self.send_error(404, "Path not found")
+                self.send_error(404, f"Path {self.path} not found")
         except RequestException as e:
             self.send_error(400, e.message)
         except (ConnectionResetError, BrokenPipeError) as ex:


### PR DESCRIPTION
The lack of return is causing both the 200 /check_hash/fdbmonitor.conf and 404 Path not found to be printed in the logs of the sidecar

Replace this text with your description here...

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
