### PR TITLE
Extensions to log server disk queue (made in the context of version vector/unicast)

### DIFF
--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -986,7 +986,7 @@ ACTOR Future<Void> popDiskQueue(TLogData* self, Reference<LogData> logData) {
 	// If version vector is enabled then we need to preserve all versions from "knownCommittedVersion"
 	// onwards (for recovery purpose). Adjust the iterator position accordingly.
 	if (SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST &&
-	    logData->knownCommittedVersion < logData->persistentDataVersion) {
+	    logData->knownCommittedVersion <= logData->persistentDataVersion) {
 		locationIter = logData->versionLocation.lastLessOrEqual(logData->knownCommittedVersion);
 	}
 	if (locationIter != logData->versionLocation.end()) {

--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -1223,7 +1223,9 @@ ACTOR Future<Void> updatePersistentData(TLogData* self, Reference<LogData> logDa
 		}
 		if (minVersion != std::numeric_limits<Version>::max()) {
 			self->persistentQueue->forgetBefore(
-			    newPersistentDataVersion,
+			    (!SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST
+			         ? newPersistentDataVersion
+			         : std::min(newPersistentDataVersion, logData->knownCommittedVersion)),
 			    logData); // SOMEDAY: this can cause a slow task (~0.5ms), presumably from erasing too many versions.
 			              // Should we limit the number of versions cleared at a time?
 		}

--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -3613,7 +3613,6 @@ ACTOR Future<Void> restorePersistentState(TLogData* self,
 	CODE_PROBE(now() - startt >= 1.0, "TLog recovery took more than 1 second");
 
 	for (auto it : self->id_data) {
-		ASSERT_WE_THINK(it.second->knownCommittedVersion <= it.second->version.get());
 		if (it.second->queueCommittedVersion.get() == 0) {
 			TraceEvent("TLogZeroVersion", self->dbgid).detail("LogId", it.first);
 			it.second->queueCommittedVersion.set(it.second->version.get());

--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -1225,7 +1225,7 @@ ACTOR Future<Void> updatePersistentData(TLogData* self, Reference<LogData> logDa
 			self->persistentQueue->forgetBefore(
 			    (!SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST
 			         ? newPersistentDataVersion
-			         : std::min(newPersistentDataVersion, logData->knownCommittedVersion)),
+			         : std::min(minVersion, logData->knownCommittedVersion)),
 			    logData); // SOMEDAY: this can cause a slow task (~0.5ms), presumably from erasing too many versions.
 			              // Should we limit the number of versions cleared at a time?
 		}

--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -1270,7 +1270,7 @@ ACTOR Future<Void> updatePersistentData(TLogData* self, Reference<LogData> logDa
 			self->persistentQueue->forgetBefore(
 			    (!SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST
 			         ? newPersistentDataVersion
-			         : std::min(minVersion, unicastRelevantMinimumVersion)),
+			         : std::min(newPersistentDataVersion, unicastRelevantMinimumVersion)),
 			    logData); // SOMEDAY: this can cause a slow task (~0.5ms), presumably from erasing too many versions.
 			              // Should we limit the number of versions cleared at a time?
 		}


### PR DESCRIPTION
Goal: 

The goal is to hold (version incompatible) disk queue related changes, made in the context of getting recovery to work with version vector, in a branch ("version-vector-disk-queue").

Changes:

Commit 37485d27b47311566ab8a6d0c7f1fc3e3f77e2c9:

- Extend the disk queue entry data structure to hold the following information, needed by the recovery algorithm when unicast is enabled:
- PrevVersion of a version
- List of log servers that a commit proxy sends a commit version to

And, extend the code to populate "unknownCommittedVersions" list (the list of commit versions whose commit status is not known, and to be determined by the recovery version computation algorithm) on a log server restart.

Commit 0b7fbaeea2667d38d2cb8109c2a949d96583c912:

Extend the log server restart logic to read versions from disk queue from known committed version onwards (instead of from the latest known persistent data durable version). The unicast recovery algorithm needs to know all commit versions, from known committed version onwards, that have been received by a log server in order to correctly compute the recovery version.

Commit c6f99e29bec4b64159dceeb0620f13e5f7be958e:

Do not let a log server delete any versions from known committed version onwards from its disk queue.

Commit dfb2d97765d89f2de0e684732c1d822a633b61f1:

Make log servers preserve the disk queue positions of all versions from known committed version onwards (when version vector is enabled).

Commit 9249ca1a01ce0e3e118bec657bd35130d15b8421: 

This change is related to the change made in PR https://github.com/apple/foundationdb/pull/11815 in "main".

In case of spill by reference, log servers should use the logic that is based over "TagData::popped" to decide how long to keep the disk queue positions of versions in memory (instead of using the logic that is based over "LogData::persistentDataVersion", which is applicable to spill by value case).

Commit 5837fd1c58cef0fb6dcc46bfd0b7ae57f71a299f:

Consider all LogData structures while deciding where to start reading the disk queue
from on log server restart.

Commit 16b3aa9579be33a5c05201208726fefe1c67db22:

The known committed version of a LogData structure could be greater than the LogData's version in certain cases (on re-start, because the known committed version could get set based on "revert"). So drop the assertion related to this case.

NOTE: Please note that these changes will cause version incompatibility and so additional code/logic will need to be added to make sure that upgrades/restart related simulation tests work properly.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
