### PR TITLE
Mark store returned value as nodiscard

### DIFF
--- a/flow/include/flow/genericactors.actor.h
+++ b/flow/include/flow/genericactors.actor.h
@@ -333,7 +333,7 @@ Future<Void> holdWhileVoid(X object, Future<T> what) {
 
 // Assign the future value of what to out
 template <class T, class X>
-Future<Void> store(X& out, Future<T> what) {
+[[nodiscard]] Future<Void> store(X& out, Future<T> what) {
 	return map(what, [&out](T const& v) {
 		out = v;
 		return Void();


### PR DESCRIPTION
Because store() returns a future that should be waited on. This will expose compiling errors if we don't wait() on the return value.

See a bug fixed in #11774


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
