### PR TITLE
Fix debugRandom() bug introduced in PR #11766 where seed is not provided via cli

### DIFF
--- a/fdbserver/fdbserver.actor.cpp
+++ b/fdbserver/fdbserver.actor.cpp
@@ -1520,7 +1520,6 @@ private:
 					printHelpTeaser(argv[0]);
 					flushAndExit(FDB_EXIT_ERROR);
 				}
-				setThreadLocalDeterministicRandomSeed(randomSeed);
 				break;
 			}
 			case OPT_MACHINEID: {
@@ -1787,6 +1786,8 @@ private:
 			}
 			}
 		}
+
+		setThreadLocalDeterministicRandomSeed(randomSeed);
 
 		try {
 			ProfilerConfig::instance().reset(profilerConfig);


### PR DESCRIPTION
As title, was reported in https://github.com/apple/foundationdb/pull/11766#issuecomment-2475403300. The fix is to call `setThreadLocalDeterministicRandomSeed` even if the seed is not provided. Note that previously for cases where seed was not provided, simulation still worked for function calls like `deterministicRandom`. This is because those functions will lazily initialize the seed. But it does not work for calls to `debugRandom` because that assumes that seed is already setup before, which was not the case after #11766, and what is precisely what this PR fixes. `debugRandom` is currently used by tester and consistency checker. 

Ran simulation without seed and ensured no crash happens.

100K Joshua: `20241114-071804-praza-d516b91e25c11971cb9cce5336741acc83ff1d compressed=True data_size=36049569 duration=5286977 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:57:52 sanity=False started=100000 stopped=20241114-081556 submitted=20241114-071804 timeout=5400 username=praza-d516b91e25c11971cb9cce5336741acc83ff1d29`

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
