### PR TITLE
Make ClogRemoteTLog more resilient and refactor StatusClient

### DIFF
--- a/fdbclient/include/fdbclient/Status.h
+++ b/fdbclient/include/fdbclient/Status.h
@@ -68,9 +68,35 @@ struct StatusValue : json_spirit::mValue {
 	StatusValue(json_spirit::mValue const& o) : json_spirit::mValue(o) {}
 };
 
-inline StatusObject makeMessage(const char* name, const char* description) {
+enum class MessageType {
+	INCORRECT_CLUSTER_FILE_CONTENTS,
+	NO_CLUSTER_CONTROLLER,
+	QUORUM_NOT_REACHABLE,
+	SERVER_OVERLOADED,
+	STATUS_INCOMPLETE_CLIENT,
+	STATUS_INCOMPLETE_CLUSTER,
+	STATUS_INCOMPLETE_COORDINATORS,
+	STATUS_INCOMPLETE_ERROR,
+	STATUS_INCOMPLETE_TIMEOUT,
+	UNREACHABLE_CLUSTER_CONTROLLER,
+};
+
+inline const std::unordered_map<MessageType, std::string> messageTypeToName{
+	{ MessageType::INCORRECT_CLUSTER_FILE_CONTENTS, "incorrect_cluster_file_contents" },
+	{ MessageType::NO_CLUSTER_CONTROLLER, "no_cluster_controller" },
+	{ MessageType::QUORUM_NOT_REACHABLE, "quorum_not_reachable" },
+	{ MessageType::SERVER_OVERLOADED, "server_overloaded" },
+	{ MessageType::STATUS_INCOMPLETE_CLIENT, "status_incomplete_client" },
+	{ MessageType::STATUS_INCOMPLETE_CLUSTER, "status_incomplete_cluster" },
+	{ MessageType::STATUS_INCOMPLETE_COORDINATORS, "status_incomplete_coordinators" },
+	{ MessageType::STATUS_INCOMPLETE_ERROR, "status_incomplete_error" },
+	{ MessageType::STATUS_INCOMPLETE_TIMEOUT, "status_incomplete_timeout" },
+	{ MessageType::UNREACHABLE_CLUSTER_CONTROLLER, "unreachable_cluster_controller" },
+};
+
+inline StatusObject makeMessage(const MessageType messageType, const char* description) {
 	StatusObject out;
-	out["name"] = name;
+	out["name"] = messageTypeToName.at(messageType);
 	out["description"] = description;
 	return out;
 }


### PR DESCRIPTION
# Description

In #11758, I added capability to include gray failure information in machine readable status. To test this, I modified ClogRemoteTLog simulation test to also fetch status json, and assert that relevant fields are present. 100K passed. However, as we run simulation more, there are cases where the assert I added fails. The reason is that it's normal for status json to sometimes fail outside of gray failure check e.g. network issue between client and CC. This PR makes the test more resilient by accounting for these errors. 

There are two changes:

1. The first commit is a pure refactor of StatusClient such that there should be no functionality change. The refactor introduces a hash map of message enum type to message name. 
2. The second commit modifies the check to reuse this map to skip the status check if the error message matches the one in the map.

Unlike most PRs, for this one we should not squash and merge two commits separately, since one is a refactor/functional change, and the other is the test flakiness fix which relies on the refactor. If curious, this is inspired from https://github.com/axboe/liburing/blob/master/CONTRIBUTING.md#commit-format. 

# Testing

100K Joshua (currently running): `20241120-075234-praza-afd08c7b1ba0ba52daa3a1ff590d8a83b623c2 compressed=True data_size=36063448 duration=3515211 ended=65864 fail_fast=10 max_runs=100000 pass=65864 priority=100 remaining=0:23:07 runtime=0:44:37 sanity=False started=69516 submitted=20241120-075234 timeout=5400 username=praza-afd08c7b1ba0ba52daa3a1ff590d8a83b623c254`

10K Joshua with just ClogRemoteTLog: `20241120-080511-praza-afd08c7b1ba0ba52daa3a1ff590d8a83b623c2 compressed=True data_size=36097012 duration=748733 ended=10000 fail_fast=10 max_runs=10000 pass=10000 priority=100 remaining=0 runtime=0:19:04 sanity=False started=10000 stopped=20241120-082415 submitted=20241120-080511 timeout=5400 username=praza-afd08c7b1ba0ba52daa3a1ff590d8a83b623c254`


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
