### PR TITLE
Turn off shardedrock in cache test

### DIFF
--- a/tests/fast/CacheTest.toml
+++ b/tests/fast/CacheTest.toml
@@ -1,3 +1,6 @@
+[configuration]
+storageEngineExcludeTypes = [5] #FIXME: remove after external timeout is resolved
+
 [[test]]
 testTitle = 'Cached'
 


### PR DESCRIPTION
Recently, shardedrocks experiences external timeout with cache test.
Temporarily turn off shardedrocks in this test until we fix the issue.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
