### PR TITLE
Rust external workload modifications

### DIFF
--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -382,21 +382,30 @@ if(NOT WIN32)
 
 endif()
 
-set(c_workloads_srcs
+set(cpp_workloads_srcs
   test/workloads/workloads.cpp
   test/workloads/workloads.h
   test/workloads/SimpleWorkload.cpp)
 
+set(c_workloads_srcs
+  test/workloads/CWorkload.c)
+
 if(OPEN_FOR_IDE)
+  add_library(cpp_workloads OBJECT ${cpp_workloads_srcs})
   add_library(c_workloads OBJECT ${c_workloads_srcs})
 else()
+  add_library(cpp_workloads SHARED ${cpp_workloads_srcs})
   add_library(c_workloads SHARED ${c_workloads_srcs})
 endif()
+set_target_properties(cpp_workloads PROPERTIES
+  LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/share/foundationdb")
 set_target_properties(c_workloads PROPERTIES
   LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/share/foundationdb")
-target_link_libraries(c_workloads PUBLIC fdb_c)
+target_link_libraries(cpp_workloads PUBLIC fdb_c)
+target_include_directories(c_workloads PUBLIC ${CMAKE_SOURCE_DIR}/bindings/c)
 
 if(NOT WIN32 AND NOT APPLE AND NOT OPEN_FOR_IDE)
+  target_link_options(cpp_workloads PRIVATE "LINKER:--version-script=${CMAKE_CURRENT_SOURCE_DIR}/external_workload.map,-z,nodelete")
   target_link_options(c_workloads PRIVATE "LINKER:--version-script=${CMAKE_CURRENT_SOURCE_DIR}/external_workload.map,-z,nodelete")
 endif()
 

--- a/bindings/c/external_workload.map
+++ b/bindings/c/external_workload.map
@@ -1,6 +1,7 @@
 {
   global:
     workloadFactory;
+    workloadCFactory;
   local:
     *;
 };

--- a/bindings/c/foundationdb/CppWorkload.h
+++ b/bindings/c/foundationdb/CppWorkload.h
@@ -85,7 +85,7 @@ struct FDBPerfMetric {
 	std::string name;
 	double value;
 	bool averaged;
-	std::string format_code = "0.3g";
+	std::string format_code = "%.3g";
 };
 
 class DLLEXPORT FDBWorkload {

--- a/bindings/c/test/workloads/CWorkload.c
+++ b/bindings/c/test/workloads/CWorkload.c
@@ -31,6 +31,7 @@ typedef struct CWorkload {
 
 #define BIND(W) CWorkload* this = (CWorkload*)W
 #define WITH(C, M, ...) (C).M((C).inner, ##__VA_ARGS__)
+#define EXPORT extern __attribute__((visibility("default")))
 
 static void workload_setup(OpaqueWorkload* raw_workload, FDBDatabase* db, FDBPromise done) {
 	BIND(raw_workload);
@@ -83,7 +84,7 @@ static void workload_free(OpaqueWorkload* raw_workload) {
 	free(this);
 }
 
-extern FDBWorkload workloadCFactory(const char* borrow_name, FDBWorkloadContext context) {
+EXPORT FDBWorkload workloadCFactory(const char* borrow_name, FDBWorkloadContext context) {
 	int len = strlen(borrow_name) + 1;
 	char* name = (char*)malloc(len);
 	memcpy(name, borrow_name, len);

--- a/bindings/c/test/workloads/RustWorkload/README.md
+++ b/bindings/c/test/workloads/RustWorkload/README.md
@@ -1,0 +1,31 @@
+# RustWorkload
+
+This repository showcases an example workload written in Rust, designed to
+interact with the FoundationDB simulation environment via the C API. The
+workload provided here is not integrated into the CMake build system and serves
+purely as a reference implementation.
+
+## Building the Workload
+
+You can build this crate in any standard Rust environment using the following command:
+
+```shell
+cargo build --release
+```
+
+This will generate a shared library that can be used as an `ExternalWorkload`
+within the FoundationDB simulation. To inject this library into the simulation,
+use the command:
+
+```shell
+fdbserver -r simulation -f test_file.toml
+```
+
+Its behavior should be equivalent to the `CWorkload.c` test workload.
+
+## Limitations and Further Examples
+
+This example workload does not include functionality for interacting with the
+database. For examples with working database bindings, refer to the
+[foundationdb-rs](https://github.com/foundationdb-rs/foundationdb-rs/tree/main/foundationdb-simulation)
+project.

--- a/bindings/c/test/workloads/RustWorkload/src/mock.rs
+++ b/bindings/c/test/workloads/RustWorkload/src/mock.rs
@@ -1,6 +1,6 @@
 use crate::{
-    register_factory, wrap, FDBWorkload, Metric, Metrics, MockDatabase, Promise, RustWorkload,
-    RustWorkloadFactory, Severity, WorkloadContext,
+    register_factory, Metric, Metrics, MockDatabase, Promise, RustWorkload, RustWorkloadFactory,
+    Severity, WorkloadContext, WrappedWorkload,
 };
 
 struct MockWorkload {
@@ -64,20 +64,20 @@ impl Drop for MockWorkload {
 
 struct MockFactory;
 impl RustWorkloadFactory for MockFactory {
-    fn create(name: String, context: WorkloadContext) -> FDBWorkload {
+    fn create(name: String, context: WorkloadContext) -> WrappedWorkload {
         let client_id = context.client_id();
         let client_count = context.client_count();
         println!("RustWorkloadFactory::create({name})[{client_id}/{client_count}]");
         println!(
             "my_c_option: {:?}",
-            context.get_option::<String>("my_c_option")
+            context.get_option::<String>("my_rust_option")
         );
         println!(
             "my_c_option: {:?}",
-            context.get_option::<String>("my_c_option")
+            context.get_option::<String>("my_rust_option")
         );
         match name.as_str() {
-            "MockWorkload" => wrap(MockWorkload::new(name, client_id, context)),
+            "MockWorkload" => WrappedWorkload::new(MockWorkload::new(name, client_id, context)),
             _ => panic!("Unknown workload name: {name}"),
         }
     }

--- a/bindings/c/test/workloads/RustWorkload/test_file.toml
+++ b/bindings/c/test/workloads/RustWorkload/test_file.toml
@@ -1,0 +1,11 @@
+[[test]]
+testTitle = 'Rust_CAPI_Test'
+
+  [[test.workload]]
+    testName = 'External'
+    useCAPI = true
+    libraryPath = './target/release'
+    libraryName = 'rust_workload'
+    workloadName = 'MockWorkload'
+    my_rust_option = 'my_value'
+

--- a/bindings/java/src/main/com/apple/foundationdb/testing/PerfMetric.java
+++ b/bindings/java/src/main/com/apple/foundationdb/testing/PerfMetric.java
@@ -27,11 +27,11 @@ public class PerfMetric {
 	private String formatCode;
 
 	public PerfMetric(String name, double value) {
-		this(name, value, true, "0.3g");
+		this(name, value, true, "%.3g");
 	}
 
 	public PerfMetric(String name, double value, boolean averaged) {
-		this(name, value, averaged, "0.3g");
+		this(name, value, averaged, "%.3g");
 	}
 
 	public PerfMetric(String name, double value, boolean averaged, String formatCode) {

--- a/tests/SimpleExternalTest.txt
+++ b/tests/SimpleExternalTest.txt
@@ -1,4 +1,4 @@
 testTitle=SimpleExternalTest
     testName=External
-    libraryName=c_workloads
+    libraryName=cpp_workloads
     workloadName=SimpleWorkload


### PR DESCRIPTION
Follow up to #11288.
As you asked @spraza I added a README to the Rust crate and fixed the `format_code` in the C++ (and java) bindings.
I also added the corresponding `test_file.toml`, ran the Rust formatter, refactored some small parts, and updated some doc strings.