### PR TITLE
fix "Unknown error" when  configuring regions

### DIFF
--- a/fdbcli/FileConfigureCommand.actor.cpp
+++ b/fdbcli/FileConfigureCommand.actor.cpp
@@ -62,9 +62,6 @@ ACTOR Future<bool> fileConfigureCommandActor(Reference<IDatabase> db,
 	}
 
 	state std::string configString;
-	if (isNewDatabase) {
-		configString = "new";
-	}
 
 	try {
 		configString += DatabaseConfiguration::configureStringFromJSON(configJSON);
@@ -72,6 +69,12 @@ ACTOR Future<bool> fileConfigureCommandActor(Reference<IDatabase> db,
 		fmt::print("ERROR: {}", e.what());
 		printUsage("fileconfigure"_sr);
 		return false;
+	}
+
+	if (isNewDatabase) {
+		configString = "new" + configString;
+	} else {
+		configString.assign(configString.c_str() + 1);
 	}
 
 	ConfigurationResult result = wait(ManagementAPI::changeConfig(db, configString, force));

--- a/fdbcli/FileConfigureCommand.actor.cpp
+++ b/fdbcli/FileConfigureCommand.actor.cpp
@@ -74,7 +74,7 @@ ACTOR Future<bool> fileConfigureCommandActor(Reference<IDatabase> db,
 	if (isNewDatabase) {
 		configString = "new" + configString;
 	} else {
-		configString.assign(configString.c_str() + 1);
+		configString.erase(0, 1); // configureStringFromJSON returns a string with leading space.
 	}
 
 	ConfigurationResult result = wait(ManagementAPI::changeConfig(db, configString, force));


### PR DESCRIPTION
When executing the command "fdbcli --exec 'fileconfigure..." the error message "ERROR: unknown parameter" is displayed.
The error occurred in
ConfigurationResult buildConfiguration(std::vector const& modeTokens, std::map<std::string, std::string>& outConf);
since the vector of modeTokens included reference to an empty string that got into the vector in the function
ConfigurationResult buildConfiguration(std::string const& configMode, std::map<std::string, std::string>& outConf);
since the configMode begins from empty string which added in
std::string DatabaseConfiguration::configureStringFromJSON(const StatusObject& json)

test.sh:

```
#!/bin/bash

set -euo pipefail

log() {
    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1"
}

check_commands() {
    for cmd in curl dpkg fdbcli; do
        if ! command -v $cmd &> /dev/null; then
            log "Error: $cmd is not installed"
            exit 1
        fi
    done
}

main() {

    if [ $# -eq 0 ]; then
      echo "No fdbcli provided. Usage: $0 fdbcli-path"
      exit 1
    fi

    local FDBCLI_PATH=$1  # Get path to fdbcli binary from first argument

    if ! [ -f "$FDBCLI_PATH" ]; then
      log "Error: No custom fdbcli binary provided or file not found"
      exit 1
    fi


    log "Starting FoundationDB in multiregional mode..."

    # 1. Create region configuration file
    log "Creating region.json configuration"
    cat > region.json <<EOF
{
    "regions": [
        {
            "datacenters": [
                { "id": "dc1", "priority": 0 }
            ]
        }
    ]
}
EOF

    # 2. Stop and remove old version
    log "Stopping FoundationDB service"
    service foundationdb stop || true

    log "Removing old packages"
    dpkg --purge foundationdb-server foundationdb-clients || true

    log "Cleaning up directories"
    rm -rf /var/log/foundationdb /var/lib/foundationdb /etc/foundationdb

    # 3. Download and install new packages
    log "Downloading packages"
    VERSION="7.3.63"
    BASE_URL="https://github.com/apple/foundationdb/releases/download/${VERSION}"

    for pkg in clients server; do
        FILE="foundationdb-${pkg}_${VERSION}-1_amd64.deb"
        if [ ! -f "$FILE" ]; then
            curl -LO "${BASE_URL}/${FILE}" || {
                log "Failed to download $FILE"
                exit 1
            }
        fi
    done

    log "Installing packages"
    dpkg -i foundationdb-clients_${VERSION}-1_amd64.deb || {
        log "Failed to install clients package"
        exit 1
    }

    dpkg -i foundationdb-server_${VERSION}-1_amd64.deb || {
        log "Failed to install server package"
        exit 1
    }

    # 4. Configure FoundationDB, add datacenter-id
    log "Configuring FoundationDB, add datacenter-id"
    CONFIG_FILE="/etc/foundationdb/foundationdb.conf"
    sed -i '/\[fdbserver\.4500\]/a datacenter-id = dc1' "$CONFIG_FILE"

    # 5. Apply region configuration
    log "Applying region configuration"

    if ! fdbcli --exec "fileconfigure region.json" &> /dev/null; then
        exit_code=$?
        log "[ERROR] First configuration attempt failed (exit code: $exit_code)"
        log "Installing custom fdbcli from $FDBCLI_PATH"
        cp "$FDBCLI_PATH" /usr/bin/ || {
                log "Failed to copy $FDBCLI_PATH to /usr/bin/"
                exit 1
            }

        if ! fdbcli --exec "fileconfigure region.json" &> /dev/null; then
            retry_exit_code=$?
            log "[CRITICAL ERROR] Fallback also failed (exit code: $retry_exit_code)"
            exit $retry_exit_code
        fi
    fi

    # 6. Verify configuration
    log "Verifying configuration"
    if fdbcli --exec "status" | grep -q "Regions:"; then
        log "[OK] Regions configuration applied"
    else
        log "[ERROR] Regions configuration not found"
        exit 1
    fi

    log "FoundationDB reconfiguration completed successfully"
}

check_commands
main "$@"
```

Result:

```
./test.sh fdbcli
[2025-04-23 13:45:13] Starting FoundationDB in multiregional mode...
[2025-04-23 13:45:13] Creating region.json configuration
[2025-04-23 13:45:13] Stopping FoundationDB service
[2025-04-23 13:45:14] Removing old packages
(Reading database ... 82802 files and directories currently installed.)
Removing foundationdb-server (7.3.63) ...
Purging configuration files for foundationdb-server (7.3.63) ...
FoundationDB does not delete data, log or cluster files on purge.
To remove these files, run (as root):
  # rm -rf /var/lib/foundationdb /var/log/foundationdb
  # rm /etc/foundationdb/fdb.cluster
dpkg: warning: while removing foundationdb-server, directory '/var/log/foundationdb' not empty so not removed
dpkg: warning: while removing foundationdb-server, directory '/var/lib/foundationdb/data' not empty so not removed
Removing foundationdb-clients (7.3.63) ...
Purging configuration files for foundationdb-clients (7.3.63) ...
dpkg: warning: while removing foundationdb-clients, directory '/etc/foundationdb' not empty so not removed
[2025-04-23 13:45:15] Cleaning up directories
[2025-04-23 13:45:15] Downloading packages
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 67.5M  100 67.5M    0     0  32.9M      0  0:00:02  0:00:02 --:--:-- 64.1M
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 33.7M  100 33.7M    0     0  21.9M      0  0:00:01  0:00:01 --:--:-- 56.3M
[2025-04-23 13:45:18] Installing packages
Selecting previously unselected package foundationdb-clients.
(Reading database ... 82770 files and directories currently installed.)
Preparing to unpack foundationdb-clients_7.3.63-1_amd64.deb ...
Unpacking foundationdb-clients (7.3.63) ...
Setting up foundationdb-clients (7.3.63) ...
Selecting previously unselected package foundationdb-server.
(Reading database ... 82794 files and directories currently installed.)
Preparing to unpack foundationdb-server_7.3.63-1_amd64.deb ...
Unpacking foundationdb-server (7.3.63) ...
Setting up foundationdb-server (7.3.63) ...
>>> configure new single memory
Database created
>>> status
Using cluster file `/etc/foundationdb/fdb.cluster'.

Unable to retrieve all status information.

Configuration:
  Redundancy mode        - single
  Storage engine         - memory
  Log engine             - ssd-2
  Encryption at-rest     - disabled
  Coordinators           - 1
  Desired Commit Proxies - 3
  Desired GRV Proxies    - 1
  Desired Resolvers      - 1
  Desired Logs           - 3
  Usable Regions         - 1

Cluster:
  FoundationDB processes - 1
  Zones                  - unknown
  Machines               - 0
  Fault Tolerance        - 0 machines
  Server time            - 04/23/25 13:45:24

Data:
  Replication health     - unknown
  Moving data            - unknown
  Sum of key-value sizes - unknown
  Disk space used        - unknown

Operating space:
  Unable to retrieve operating space status

Workload:
  Read rate              - 0 Hz
  Write rate             - 0 Hz
  Transactions started   - 0 Hz
  Transactions committed - 0 Hz
  Conflict rate          - 0 Hz

Backup and DR:
  Running backups        - 0
  Running DRs            - 0

Client time: 04/23/25 13:45:24
[2025-04-23 13:45:24] Configuring FoundationDB, add datacenter-id
[2025-04-23 13:45:24] Applying region configuration
[2025-04-23 13:45:26] [ERROR] First configuration attempt failed (exit code: 0)
[2025-04-23 13:45:26] Installing custom fdbcli from fdbcli
[2025-04-23 13:45:27] Verifying configuration
[2025-04-23 13:45:27] [OK] Regions configuration applied
[2025-04-23 13:45:27] FoundationDB reconfiguration completed successfully
```