### PR TITLE
Fix ZLIB not found error

### DIFF
--- a/cmake/FDBComponents.cmake
+++ b/cmake/FDBComponents.cmake
@@ -21,7 +21,7 @@ if(USE_VALGRIND)
 endif()
 
 ################################################################################
-# SSL
+# SSL & ZLIB
 ################################################################################
 
 set(CMAKE_REQUIRED_INCLUDES ${OPENSSL_INCLUDE_DIR})
@@ -32,6 +32,8 @@ set(OPENSSL_USE_STATIC_LIBS TRUE)
 if (WIN32)
   set(OPENSSL_MSVC_STATIC_RT ON)
 endif()
+# SSL requires ZLIB
+find_package(ZLIB REQUIRED)
 find_package(OpenSSL REQUIRED)
 add_compile_options(-DHAVE_OPENSSL)
 


### PR DESCRIPTION
Fixed cmake 3.31 arm (https://github.com/FoundationDB/fdb-build-support/pull/82) build error:

```
CMake Error at /usr/local/share/cmake-3.31/Modules/FindOpenSSL.cmake:186 (set_property):
  The link interface of target "OpenSSL::Crypto" contains:

    ZLIB::ZLIB

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.

Call Stack (most recent call first):
  /usr/local/share/cmake-3.31/Modules/FindOpenSSL.cmake:733 (_OpenSSL_target_add_dependencies)
  cmake/FDBComponents.cmake:35 (find_package)
  CMakeLists.txt:72 (include)
```



# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
