### PR TITLE
Go binding: do not override wrapped transaction error

### DIFF
--- a/bindings/go/CMakeLists.txt
+++ b/bindings/go/CMakeLists.txt
@@ -10,6 +10,7 @@ set(SRCS
   src/fdb/transaction.go
   src/fdb/directory/directoryLayer.go
   src/fdb/errors.go
+  src/fdb/errors_test.go
   src/fdb/keyselector.go
   src/fdb/tuple/tuple.go
   src/fdb/cluster.go

--- a/bindings/go/src/fdb/errors_test.go
+++ b/bindings/go/src/fdb/errors_test.go
@@ -1,0 +1,62 @@
+/*
+ * errors_test.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2024 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// FoundationDB Go API
+
+package fdb
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+const API_VERSION int = 740
+
+func TestErrorWrapping(t *testing.T) {
+	MustAPIVersion(API_VERSION)
+	db := MustOpenDefault()
+
+	testCases := []error{
+		nil,
+		&Error{
+			Code: 2007,
+		},
+		fmt.Errorf("wrapped error: %w", &Error{
+			Code: 2007,
+		}),
+		Error{
+			Code: 2007,
+		},
+		fmt.Errorf("wrapped error: %w", Error{
+			Code: 2007,
+		}),
+		errors.New("custom error"),
+	}
+
+	for _, inputError := range testCases {
+		_, outputError := db.ReadTransact(func(rtr ReadTransaction) (interface{}, error) {
+			return nil, inputError
+		})
+		if inputError != outputError {
+			t.Errorf("expected error %v to be the same as %v", outputError, inputError)
+		}
+	}
+}


### PR DESCRIPTION
When user wraps a FoundationDB error in their transaction function, the `retryable()` logic will always reset it back to a FoundationDB error, without any wrapping.
This change makes sure that original error is preserved, unless `fdb_transaction_on_error()` returned a different error or error code.

NOTE: `fdb_transaction_on_error()` does not currently ever return a different error than original, so the new logic is being defensive for future changes

# Code-Reviewer Section

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
