### PR TITLE
[RELEASE-7.3] Only delay the restart of fdbserver if the process exited with an exit code other than 0

### DIFF
--- a/fdbmonitor/fdbmonitor.cpp
+++ b/fdbmonitor/fdbmonitor.cpp
@@ -1920,7 +1920,16 @@ int main(int argc, char** argv) {
 					int delay = cmd->get_and_update_current_restart_delay();
 					if (!cmd->quiet) {
 						if (WIFEXITED(child_status)) {
-							Severity priority = (WEXITSTATUS(child_status) == 0) ? SevWarn : SevError;
+							Severity priority;
+							// If the process exited successfully, e.g. because someone restarted the process
+							// with fdbcli kill we don't want to delay the restart. We only want to delay
+							// the restart if the process was exited unsuccessfully (exit code different from 0).
+							if (WEXITSTATUS(child_status) == 0) {
+								priority = SevWarn;
+								delay = 0;
+							} else {
+								priority = SevError;
+							}
 							log_process_msg(priority,
 							                cmd->ssection.c_str(),
 							                "Process %d exited %d, restarting in %d seconds\n",


### PR DESCRIPTION
https://github.com/apple/foundationdb/pull/11802 for release-7.3 (I'm not cherry picking this change for 7.1).

Replace this text with your description here...

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [x] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [x] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
