### PR TITLE
Run cycle tests after restore to validate correctness

### DIFF
--- a/tests/fast/BackupCorrectness.toml
+++ b/tests/fast/BackupCorrectness.toml
@@ -40,3 +40,13 @@ simBackupAgents = 'BackupToFile'
     machinesToLeave = 3
     reboot = true
     testDuration = 90.0
+
+[[test]]
+testTitle = 'BackupAndRestoreAfterRestore'
+clearAfterTest = false
+    [[test.workload]]
+    testName = 'Cycle'
+    nodeCount = 30000
+    transactionsPerSecond = 2500.0
+    testDuration = 30.0
+    expectedRate = 0


### PR DESCRIPTION
Previously cycle tests were run only before restore, thus data
integrity and correctness was never verified after restoring.


joshua: 20241204-223109-flowguru-5fc228517ff3b421

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
