### PR TITLE
Support to set options for IUDPSocket.

### DIFF
--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -2864,6 +2864,13 @@ public:
 		_localAddress = addr;
 		g_sim2.addressMap.emplace(_localAddress, process);
 	}
+	// Ignore those options
+	void setOptionReuseAddress(bool reuse) override { (void)reuse; }
+	void setOptionEnableLoopback(bool enable) override { (void)enable; }
+	void setOptionMulticastGroup(NetworkAddress const& ifaddr, NetworkAddress const& mcaddr) override {
+		(void)ifaddr;
+		(void)mcaddr;
+	}
 
 	NetworkAddress localAddress() const override { return _localAddress; }
 

--- a/flow/Net2.actor.cpp
+++ b/flow/Net2.actor.cpp
@@ -697,6 +697,41 @@ public:
 		return res;
 	}
 
+	void setOptionReuseAddress(bool reuse) override {
+		boost::system::error_code ec;
+		socket.set_option(boost::asio::ip::udp::socket::reuse_address(reuse), ec);
+		if (ec) {
+			Error x = invalid_option_value();
+			TraceEvent(SevWarnAlways, "Net2UDPSetOptReuseAddressError").error(x);
+			throw x;
+		}
+	}
+
+	void setOptionMulticastGroup(NetworkAddress const& ifaddr, NetworkAddress const& mcaddr) override {
+		boost::system::error_code ec;
+		boost::asio::ip::address i;
+		boost::asio::ip::address m;
+		i = boost::asio::ip::address::from_string(ifaddr.ip.toString());
+		m = boost::asio::ip::address::from_string(mcaddr.ip.toString());
+
+		socket.set_option(boost::asio::ip::multicast::join_group(m.to_v4(), i.to_v4()), ec);
+		if (ec) {
+			Error x = invalid_option_value();
+			TraceEvent(SevWarnAlways, "Net2UDPSetOptMulticastGroupError").error(x);
+			throw x;
+		}
+	}
+
+	void setOptionEnableLoopback(bool enable) override {
+		boost::system::error_code ec;
+		socket.set_option(boost::asio::ip::multicast::enable_loopback(enable), ec);
+		if (ec) {
+			Error x = invalid_option_value();
+			TraceEvent(SevWarnAlways, "Net2UDPSetOptEnableLoopbackError").error(x);
+			throw x;
+		}
+	}
+
 	void bind(NetworkAddress const& addr) override {
 		boost::system::error_code ec;
 		socket.bind(udpEndpoint(addr), ec);

--- a/flow/include/flow/IUDPSocket.h
+++ b/flow/include/flow/IUDPSocket.h
@@ -40,6 +40,9 @@ public:
 	virtual Future<int> receive(uint8_t* begin, uint8_t* end) = 0;
 	virtual Future<int> receiveFrom(uint8_t* begin, uint8_t* end, NetworkAddress* sender) = 0;
 	virtual void bind(NetworkAddress const& addr) = 0;
+	virtual void setOptionReuseAddress(bool reuse) = 0;
+	virtual void setOptionMulticastGroup(NetworkAddress const& ifaddr, NetworkAddress const& mcaddr) = 0;
+	virtual void setOptionEnableLoopback(bool reuse) = 0;
 
 	virtual UID getDebugID() const = 0;
 	virtual NetworkAddress localAddress() const = 0;


### PR DESCRIPTION
This PR introduces three new methods to the IUDPSocket class.

```
setOptionReuseAddress
setOptionMulticastGroup
setOptionEnableLoopback
```

These methods are implemented in Net2.actor.cpp to enhance some popular functionality of UDP sockets. However, they are not implemented in sim2.actor.cpp because I’m unsure how to simulate these options in the simulation environment. Any guidance or feedback on how to address this would be greatly appreciated.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
