### PR TITLE
Documentation says backup blob URL can optionally contain key/secret/token

### DIFF
--- a/documentation/sphinx/source/backups.rst
+++ b/documentation/sphinx/source/backups.rst
@@ -64,7 +64,7 @@ If instead you want to perform a backup to the local disk of a particular machin
 Backup URLs
 ===========
 
-Backup and Restore locations are specified by Backup URLs.  Currently there are two valid Backup URL formats.
+Backup and Restore locations are specified by Backup URLs.  Currently there are two valid Backup URL formats: local directories and blob store.
 
 Note that items in angle brackets (< and >) are just placeholders and must be replaced (including the brackets) with meaningful values.  Items within square brackets ([ and ]) are optional.
 
@@ -77,7 +77,7 @@ For local directories, the Backup URL format is
 An example would be ``file:///home/backups`` which would refer to the directory ``/home/backups``.
 Note that since paths must be absolute this will result in three slashes (/) in a row in the URL.
 
-Note that for local directory URLs the actual backup files will not be written to <base_dir> directly but rather to a uniquely timestamped subdirectory.  When starting a restore the path to the timestamped subdirectory must be specified.
+For local directory URLs the actual backup files will not be written to <base_dir> directly but rather to a uniquely timestamped subdirectory.  When starting a restore the path to the timestamped subdirectory must be specified.
 
 For blob store backup locations, the Backup URL format is
 
@@ -85,22 +85,24 @@ For blob store backup locations, the Backup URL format is
 
     blobstore://[<api_key>][:<secret>[:<security_token>]]@<hostname>[:<port>]/<name>?bucket=<bucket_name>[&region=<region_name>][&<param>=<value>]...]
 
-      <api_key> - API key to use for authentication. Optional.
-      <secret> - API key's secret.  Optional.
-      <security_token> - Security token if temporary credentials are used. Optional.
-      <hostname> - Remote hostname or IP address to connect to
-      <port> - Remote port to connect to.  Optional.  Default is 80.
-      <name> - Name of the backup within the backup bucket.  It can contain '/' characters in order to organize backups into a folder-like structure.
-      <bucket_name> - Name of the bucket to use for backup data.
-      <region_name> - If <hostname> is not in s3 compatible form (s3.region-name.example.com) and aws v4 signature is enabled, region name is required.
-      
-      <param>=<value> - Optional URL parameters.  See below for details.
+      <api_key>         API key to use for authentication. If S3, it is AWS_ACCESS_KEY_ID. Optional.
+      <secret>          API key's secret.  If S3, it is AWS_SECRET_ACCESS_KEY. Optional.
+      <security_token>  Security token if temporary credentials are used. If S3, it is AWS_SESSION_TOKEN. Optional.
+      <hostname>        Remote hostname or IP address to connect to
+      <port>            Remote port to connect to.  Optional.  Default is 80.
+      <name>            Name of the backup within the backup bucket.  It can contain '/' characters in order to organize backups into a folder-like structure.
+      <bucket_name>     Name of the bucket to use for backup data.
+      <region_name>     If <hostname> is not in s3 compatible form (s3.region-name.example.com) and aws v4 signature is enabled, region name is required.
+      <param>=<value>   Optional URL parameters.  See below for details.
 
 A single bucket (specified by <bucket_name>) can hold any number of backups, each with a different <name>.
 
-If <secret> is not specified, it will be looked up in :ref:`blob credential sources<blob-credential-files>`.
+If <secret> is not specified on the URL, it will be looked up in :ref:`blob credential sources<blob-credential-files>`.
 
 An example blob store Backup URL would be ``blobstore://myKey:mySecret@something.domain.com:80/dec_1_2017_0400?bucket=backups``.
+If S3 is the target blobstore, the URL would look like: ``blobstore://${AWS_ACCESS_KEY_ID}:${AWS_SECRET_ACCESS_KEY}:${AWS_SESSION_TOKEN}@backup-12345-us-west-2.s3.amazonaws.com/dailies?bucket=backup-12345-us-west-2&region=us-west-2``
+The <secret> and <security_token> may be ommitted from the URL and instead picked up from ref:`blob credential sources<blob-credential-files>`: ``blobstore://${AWS_ACCESS_KEY_ID}@backup-12345-us-west-2.s3.amazonaws.com/dailies?bucket=backup-12345-us-west-2&region=us-west-2``
+To pickup the <api_key>, <secret>, and <security_token> from ref:`blob credential sources<blob-credential-files>`, write the blob backup URL as: ``blobstore://@backup-12345-us-west-2.s3.amazonaws.com/dailies?bucket=backup-12345-us-west-2&region=us-west-2`` (Notice the '@' in front of the hostname).
 
 Blob store Backup URLs can have optional parameters at the end which set various limits or options used when communicating with the store.  All values must be positive decimal integers unless otherwise specified.  The speed related default values are not very restrictive. A parameter is applied individually on each ``backup_agent``, meaning that a global restriction should be calculated based on the number of agent running. The most likely parameter a user would want to change is ``max_send_bytes_per_second`` (or ``sbps`` for short) which determines the upload speed to the blob service. 
 
@@ -175,9 +177,12 @@ If the knob is set to ``true`` then v4 signature will be used and if set to ``fa
 Blob Credential Files
 ==============================
 
-In order to help safeguard blob store credentials, the <SECRET> can optionally be omitted from blobstore:// URLs on the command line.  Omitted secrets will be resolved at connect time using 1 or more Blob Credential files.
+In order to help safeguard blob store credentials, the <secret> can optionally be omitted from ``blobstore://`` URLs on the command line.
+Omitted secrets will be resolved at connect time using 1 or more Blob Credential files
+(In fact, the <api_key>, <secret>, and <security_token> may all be omitted from the backup URL and instead read from the credential file;
+for how to write the backup URL in this case see ref:`backup URLs<backup-urls>`).
 
-Blob Credential files can be specified on the command line (via --blob-credentials <FILE>) or via the environment variable FDB_BLOB_CREDENTIALS which can be set to a colon-separated list of files.  The command line takes priority over the environment variable however all files from both sources will be used.
+Blob Credential files can be specified on the command line (via ``--blob-credentials <FILE>``) or via the environment variable ``FDB_BLOB_CREDENTIALS`` which can be set to a colon-separated list of files.  The command line takes priority over the environment variable however all files from both sources will be used.
 
 At connect time, the specified files are read in order and the first matching account specification (user@host)
 will be used to obtain the secret key.
@@ -199,8 +204,22 @@ If temporary credentials are being used, the following schema is also supported
 
   {
     "accounts" : {
-      "@host" :     { "api_key" : user, "secret" : "SECRETKEY", token: "TOKEN1" },
-      "@host2" :    { "api_key" : user2, "secret" : "SECRETKEY2", token: "TOKEN2" }
+      "@host" :     { "api_key" : user, "secret" : "SECRETKEY", "token": "TOKEN1" },
+      "@host2" :    { "api_key" : user2, "secret" : "SECRETKEY2", "token": "TOKEN2" }
+    }
+  }
+
+For example:
+
+::
+
+  {
+    "accounts": {
+      "@backup-12345-us-west-2.s3.amazonaws.com": {
+        "api_key": "AWS_ACCESS_KEY_ID",
+        "secret": "AWS_SECRET_ACCESS_KEY",
+        "token": "AWS_SESSION_TOKEN"
+      }
     }
   }
 

--- a/documentation/sphinx/source/backups.rst
+++ b/documentation/sphinx/source/backups.rst
@@ -61,6 +61,8 @@ By default, the FoundationDB packages are configured to start a single ``backup_
 
 If instead you want to perform a backup to the local disk of a particular machine or machines which are not network accessible to the FoundationDB servers, then you should disable the backup agents on the FoundationDB servers. This is accomplished by commenting out all of the ``[backup_agent.<ID>]`` sections in :ref:`foundationdb.conf <foundationdb-conf>`. Do not comment out the global ``[backup_agent]`` section. Next, start backup agents on the destination machine or machines. Now, when you start a backup, you can specify the destination directory (as a Backup URL) using a local path on the destination machines. The backup agents will fetch data from the database and store it locally on the destination machines.
 
+.. _backup-urls:
+
 Backup URLs
 ===========
 
@@ -101,8 +103,8 @@ If <secret> is not specified on the URL, it will be looked up in :ref:`blob cred
 
 An example blob store Backup URL would be ``blobstore://myKey:mySecret@something.domain.com:80/dec_1_2017_0400?bucket=backups``.
 If S3 is the target blobstore, the URL would look like: ``blobstore://${AWS_ACCESS_KEY_ID}:${AWS_SECRET_ACCESS_KEY}:${AWS_SESSION_TOKEN}@backup-12345-us-west-2.s3.amazonaws.com/dailies?bucket=backup-12345-us-west-2&region=us-west-2``
-The <secret> and <security_token> may be ommitted from the URL and instead picked up from ref:`blob credential sources<blob-credential-files>`: ``blobstore://${AWS_ACCESS_KEY_ID}@backup-12345-us-west-2.s3.amazonaws.com/dailies?bucket=backup-12345-us-west-2&region=us-west-2``
-To pickup the <api_key>, <secret>, and <security_token> from ref:`blob credential sources<blob-credential-files>`, write the blob backup URL as: ``blobstore://@backup-12345-us-west-2.s3.amazonaws.com/dailies?bucket=backup-12345-us-west-2&region=us-west-2`` (Notice the '@' in front of the hostname).
+The <secret> and <security_token> may be ommitted from the URL and instead picked up from :ref:`blob credential sources<blob-credential-files>`: ``blobstore://${AWS_ACCESS_KEY_ID}@backup-12345-us-west-2.s3.amazonaws.com/dailies?bucket=backup-12345-us-west-2&region=us-west-2``
+To pickup the <api_key>, <secret>, and <security_token> from :ref:`blob credentials file<blob-credential-files>`, write the blob backup URL as: ``blobstore://@backup-12345-us-west-2.s3.amazonaws.com/dailies?bucket=backup-12345-us-west-2&region=us-west-2`` (Notice the '@' in front of the hostname).
 
 Blob store Backup URLs can have optional parameters at the end which set various limits or options used when communicating with the store.  All values must be positive decimal integers unless otherwise specified.  The speed related default values are not very restrictive. A parameter is applied individually on each ``backup_agent``, meaning that a global restriction should be calculated based on the number of agent running. The most likely parameter a user would want to change is ``max_send_bytes_per_second`` (or ``sbps`` for short) which determines the upload speed to the blob service. 
 
@@ -180,7 +182,7 @@ Blob Credential Files
 In order to help safeguard blob store credentials, the <secret> can optionally be omitted from ``blobstore://`` URLs on the command line.
 Omitted secrets will be resolved at connect time using 1 or more Blob Credential files
 (In fact, the <api_key>, <secret>, and <security_token> may all be omitted from the backup URL and instead read from the credential file;
-for how to write the backup URL in this case see ref:`backup URLs<backup-urls>`).
+for how to write the backup URL in this case see :ref:`backup URLs<backup-urls>`).
 
 Blob Credential files can be specified on the command line (via ``--blob-credentials <FILE>``) or via the environment variable ``FDB_BLOB_CREDENTIALS`` which can be set to a colon-separated list of files.  The command line takes priority over the environment variable however all files from both sources will be used.
 

--- a/fdbclient/S3Client_cli.actor.cpp
+++ b/fdbclient/S3Client_cli.actor.cpp
@@ -111,18 +111,23 @@ static void printUsage(std::string const& programName) {
 	             "                 Has no effect unless --log is specified.\n"
 	             "  --blob-credentials FILE\n"
 	             "                 File containing blob credentials in JSON format.\n"
-	             "                 The same credential format/file fdbbackup uses.\n" TLS_HELP
+	             "                 The same credential format/file fdbbackup uses.\n"
+	             "                 See 'Blob Credential Files' in https://apple.github.io/foundationdb/backups.html.\n"
 	             "  --build-flags  Print build information and exit.\n"
 	             "  --knob-KNOBNAME KNOBVALUE\n"
 	             "                 Changes a knob value. KNOBNAME should be lowercase.\n"
+	             "Arguments:\n"
+	             " SOURCE          File, directory, or s3 bucket URL to copy from.\n"
+	             "                 If SOURCE is an s3 bucket URL, TARGET must be a directory and vice versa.\n"
+	             "                 See 'Backup URLs' in https://apple.github.io/foundationdb/backups.html for\n"
+	             "                 the fdb s3 'blobstore://' url format.\n"
+	             " TARGET          Where to place the copy.\n" TLS_HELP
 	             "EXAMPLES:\n"
 	             " "
 	          << programName
-	          << " --blob-credentials /path/to/credentials.json cp /path/to/source /path/to/target\n"
-	             " "
-	          << programName
-	          << " --knob_http_verbose_level=10 --log  "
-	             "cp 'blobstore://localhost:8333/x?bucket=backup&region=us&secure_connection=0' dir3\n";
+	          << " --knob_http_verbose_level=10 --log   --knob_blobstore_encryption_type=aws:kms "
+	          << " --tls-ca-file /etc/ssl/cert.pem "
+	             "'blobstore://AWS_ACCESS_KEY_ID:AWS_SECRET_ACCESS_KEY:AWS_SESSION_TOKEN@localhost:8333/x?bucket=backup&region=us' dir3\n";
 	return;
 }
 

--- a/fdbclient/S3Client_cli.actor.cpp
+++ b/fdbclient/S3Client_cli.actor.cpp
@@ -118,9 +118,11 @@ static void printUsage(std::string const& programName) {
 	             "                 Changes a knob value. KNOBNAME should be lowercase.\n"
 	             "EXAMPLES:\n"
 	             " "
-	          << programName << " --knob_http_verbose_level=10 --tls-ca-file /etc/ssl/cert.pem \\\n"
-               " --blob-credentials /tmp/s3.6GWo/blob_credentials.json --log --logdir /tmp/s3.6GWo/logs cp \\\n"
-               " 'blobstore://@backup-us-west-2.s3.amazonaws.com/dir/x.txt?bucket=backup-us-west-2&region=us-west-2' /tmp/x.txt\n";
+	          << programName
+	          << " --knob_http_verbose_level=10 --tls-ca-file /etc/ssl/cert.pem \\\n"
+	             " --blob-credentials /tmp/s3.6GWo/blob_credentials.json --log --logdir /tmp/s3.6GWo/logs cp \\\n"
+	             " 'blobstore://@backup-us-west-2.s3.amazonaws.com/dir/x.txt?bucket=backup-us-west-2&region=us-west-2' "
+	             "/tmp/x.txt\n";
 	return;
 }
 

--- a/fdbclient/S3Client_cli.actor.cpp
+++ b/fdbclient/S3Client_cli.actor.cpp
@@ -116,18 +116,11 @@ static void printUsage(std::string const& programName) {
 	             "  --build-flags  Print build information and exit.\n"
 	             "  --knob-KNOBNAME KNOBVALUE\n"
 	             "                 Changes a knob value. KNOBNAME should be lowercase.\n"
-	             "Arguments:\n"
-	             " SOURCE          File, directory, or s3 bucket URL to copy from.\n"
-	             "                 If SOURCE is an s3 bucket URL, TARGET must be a directory and vice versa.\n"
-	             "                 See 'Backup URLs' in https://apple.github.io/foundationdb/backups.html for\n"
-	             "                 the fdb s3 'blobstore://' url format.\n"
-	             " TARGET          Where to place the copy.\n" TLS_HELP
 	             "EXAMPLES:\n"
 	             " "
-	          << programName
-	          << " --knob_http_verbose_level=10 --log   --knob_blobstore_encryption_type=aws:kms "
-	          << " --tls-ca-file /etc/ssl/cert.pem "
-	             "'blobstore://AWS_ACCESS_KEY_ID:AWS_SECRET_ACCESS_KEY:AWS_SESSION_TOKEN@localhost:8333/x?bucket=backup&region=us' dir3\n";
+	          << programName << " --knob_http_verbose_level=10 --tls-ca-file /etc/ssl/cert.pem \\\n"
+               " --blob-credentials /tmp/s3.6GWo/blob_credentials.json --log --logdir /tmp/s3.6GWo/logs cp \\\n"
+               " 'blobstore://@backup-us-west-2.s3.amazonaws.com/dir/x.txt?bucket=backup-us-west-2&region=us-west-2' /tmp/x.txt\n";
 	return;
 }
 


### PR DESCRIPTION
Clarifying documentation on blob backup URL and credentials file.

* documentation/sphinx/source/backups.rst
     Minor edit. Add more examples making it clearer how to do S3
     backup URLs in particular. Explain the 'trick' for omitting
     api_key, secret, and token from URL instead picking them up from
     the credentials file.

 * fdbclient/S3Client_cli.actor.cpp
     Minor cleanup of usage.