### PR TITLE
Ignore some ctests for ASAN

### DIFF
--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -295,9 +295,29 @@ if(NOT WIN32)
     )
 
     file(GLOB API_TEST_FILES "${CMAKE_CURRENT_SOURCE_DIR}/test/apitester/tests/*.toml")
+    set(PATTERNS_TO_SKIP "XXXX")
+    if (USE_ASAN)
+      set(PATTERNS_TO_SKIP
+        ".*BlobGranule.*"  # skip BlobGranule tests because we don't use
+        ".*Tenant.*"       # skip Tenant tests because we don't use
+      )
+    endif()
     foreach(test_file ${API_TEST_FILES})
       get_filename_component(file_name "${test_file}" NAME_WE)
       set(test_name "fdb_c_api_test_${file_name}")
+
+      # skip tests that match the patterns in PATTERNS_TO_SKIP
+      set(SKIP_FILE FALSE)
+      foreach(PATTERN ${PATTERNS_TO_SKIP})
+          if(file_name MATCHES "${PATTERN}")
+              set(SKIP_FILE TRUE)
+              break()
+          endif()
+      endforeach()
+      if(SKIP_FILE)
+        continue()
+      endif()
+
       add_python_venv_test(NAME "${test_name}"
         COMMAND python ${CMAKE_SOURCE_DIR}/bindings/c/test/apitester/run_c_api_tests.py
           --build-dir ${CMAKE_BINARY_DIR}

--- a/cmake/AddFdbTest.cmake
+++ b/cmake/AddFdbTest.cmake
@@ -390,6 +390,7 @@ function(prepare_binding_test_files build_directory target_name target_dependenc
   add_custom_target(${target_name} DEPENDS ${target_dependency})
   add_custom_command(
     TARGET ${target_name}
+    POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:fdb_flow_tester> ${build_directory}/tests/flow/bin/fdb_flow_tester
     COMMENT "Copy Flow tester for bindingtester")
 
@@ -402,6 +403,7 @@ function(prepare_binding_test_files build_directory target_name target_dependenc
     endif()
     add_custom_command(
       TARGET ${target_name}
+      POST_BUILD
       COMMAND ${CMAKE_COMMAND} -E copy
         ${CMAKE_BINARY_DIR}/packages/fdb-java-${FDB_VERSION}${not_fdb_release_string}.jar
         ${build_directory}/tests/java/foundationdb-client.jar
@@ -426,6 +428,7 @@ function(prepare_binding_test_files build_directory target_name target_dependenc
   foreach(generated IN LISTS generated_binding_files)
     add_custom_command(
       TARGET ${target_name}
+      POST_BUILD
       COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/bindings/${generated} ${build_directory}/tests/${generated}
       COMMENT "Copy ${generated} to bindingtester")
   endforeach()

--- a/fdbcli/CMakeLists.txt
+++ b/fdbcli/CMakeLists.txt
@@ -42,13 +42,16 @@ if (NOT WIN32 AND NOT OPEN_FOR_IDE)
             @CLUSTER_FILE@
             5
             )
-  add_fdbclient_test(
-  NAME single_process_external_client_fdbcli_tests
-  COMMAND ${CMAKE_SOURCE_DIR}/fdbcli/tests/fdbcli_tests.py
-          ${CMAKE_BINARY_DIR}
-          @CLUSTER_FILE@
-          --external-client-library ${CMAKE_BINARY_DIR}/bindings/c/libfdb_c_external.so
-          )
+  if(NOT USE_ASAN)
+    # TODO: this is known to fail with ASAN, fix needed
+    add_fdbclient_test(
+    NAME single_process_external_client_fdbcli_tests
+    COMMAND ${CMAKE_SOURCE_DIR}/fdbcli/tests/fdbcli_tests.py
+            ${CMAKE_BINARY_DIR}
+            @CLUSTER_FILE@
+            --external-client-library ${CMAKE_BINARY_DIR}/bindings/c/libfdb_c_external.so
+    )
+  endif()
   add_fdbclient_test(
   NAME multi_process_external_client_fdbcli_tests
   PROCESS_NUMBER 5
@@ -59,9 +62,12 @@ if (NOT WIN32 AND NOT OPEN_FOR_IDE)
           --external-client-library ${CMAKE_BINARY_DIR}/bindings/c/libfdb_c_external.so
           )
 
-  add_multi_fdbclient_test(
-    NAME metacluster_fdbcli_tests
-    COMMAND ${CMAKE_SOURCE_DIR}/fdbcli/tests/metacluster_fdbcli_tests.py
-            ${CMAKE_BINARY_DIR}
-            )
+  if (NOT USE_ASAN)
+    # skip metacluster tests because it often times out on ASAN
+    add_multi_fdbclient_test(
+      NAME metacluster_fdbcli_tests
+      COMMAND ${CMAKE_SOURCE_DIR}/fdbcli/tests/metacluster_fdbcli_tests.py
+              ${CMAKE_BINARY_DIR}
+    )
+  endif()
 endif()


### PR DESCRIPTION
Mostly are unused and noisy tests, `single_process_external_client_fdbcli_tests` complains memory leak, which is a TODO item.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
