### PR TITLE
error: invalid operands to binary expression in ClogRemoteTLog.actor.cpp on appleclang

### DIFF
--- a/fdbserver/workloads/ClogRemoteTLog.actor.cpp
+++ b/fdbserver/workloads/ClogRemoteTLog.actor.cpp
@@ -251,7 +251,8 @@ struct ClogRemoteTLog : TestWorkload {
 				std::vector<std::pair<StorageServerInterface, ProcessClass>> results =
 				    wait(NativeAPI::getServerListAndProcessClasses(&tr));
 				for (auto& [ssi, p] : results) {
-					if (ssi.locality.dcId().present() && g_simulator->remoteDcId.present() && ssi.locality.dcId().get() == g_simulator->remoteDcId.get()) {
+					if (ssi.locality.dcId().present() && g_simulator->remoteDcId.present() &&
+					    ssi.locality.dcId().get() == g_simulator->remoteDcId.get()) {
 						ret.push_back(ssi.address().ip);
 					}
 				}

--- a/fdbserver/workloads/ClogRemoteTLog.actor.cpp
+++ b/fdbserver/workloads/ClogRemoteTLog.actor.cpp
@@ -251,7 +251,7 @@ struct ClogRemoteTLog : TestWorkload {
 				std::vector<std::pair<StorageServerInterface, ProcessClass>> results =
 				    wait(NativeAPI::getServerListAndProcessClasses(&tr));
 				for (auto& [ssi, p] : results) {
-					if (ssi.locality.dcId().present() && ssi.locality.dcId().get() == g_simulator->remoteDcId.get()) {
+					if (ssi.locality.dcId().present() && g_simulator->remoteDcId.present() && ssi.locality.dcId().get() == g_simulator->remoteDcId.get()) {
 						ret.push_back(ssi.address().ip);
 					}
 				}

--- a/fdbserver/workloads/ClogRemoteTLog.actor.cpp
+++ b/fdbserver/workloads/ClogRemoteTLog.actor.cpp
@@ -251,7 +251,7 @@ struct ClogRemoteTLog : TestWorkload {
 				std::vector<std::pair<StorageServerInterface, ProcessClass>> results =
 				    wait(NativeAPI::getServerListAndProcessClasses(&tr));
 				for (auto& [ssi, p] : results) {
-					if (ssi.locality.dcId().present() && ssi.locality.dcId().get() == g_simulator->remoteDcId) {
+					if (ssi.locality.dcId().present() && ssi.locality.dcId().get() == g_simulator->remoteDcId.get()) {
 						ret.push_back(ssi.address().ip);
 					}
 				}


### PR DESCRIPTION
On both Apple clang (M2) version 15.0.0 (clang-1500.1.0.2.5) and 16.0.0, compile fails here:

/Users/stack/checkouts/fdb/foundationdb/fdbserver/workloads/ClogRemoteTLog.actor.cpp:254:67: error: invalid operands to binary expression ('Standalone<StringRef>' and 'Optional<Standalone<StringRef>>')
                        if (ssi.locality.dcId().present() && ssi.locality.dcId().get() == g_simulator->remoteDcId)

