### PR TITLE
Add transaction store mutation tracking capability

### DIFF
--- a/fdbserver/KeyValueStoreMemory.actor.cpp
+++ b/fdbserver/KeyValueStoreMemory.actor.cpp
@@ -535,7 +535,7 @@ private:
 			log->push(cipherText);
 		}
 		IDiskQueue::location loc = log->push("\x01"_sr); // Changes here should be reflected in OP_DISK_OVERHEAD
-		DEBUG_TRANSACTION_STATE_STORE("LogOpTransactionStoreMutation", loc, v1, id);
+		DEBUG_TRANSACTION_STATE_STORE("LogOp", v1, id, loc);
 		return loc;
 	}
 
@@ -676,7 +676,7 @@ private:
 						StringRef p1 = data.substr(0, h.len1);
 						StringRef p2 = data.substr(h.len1, h.len2);
 
-						DEBUG_TRANSACTION_STATE_STORE("RecoverTransactionStoreMutation", self->log->getNextReadLocation(), p1, self->id);
+						DEBUG_TRANSACTION_STATE_STORE("Recover", p1, self->id);
 
 						if (h.op == OpSnapshotItem || h.op == OpSnapshotItemDelta) { // snapshot data item
 							/*if (p1 < uncommittedNextKey) {
@@ -830,6 +830,7 @@ private:
 		int64_t snapshotSize = 0;
 		for (auto kv = snapshotData.begin(); kv != snapshotData.end(); ++kv) {
 			StringRef tempKey = kv.getKey(reserved_buffer);
+			DEBUG_TRANSACTION_STATE_STORE("FullSnapshot", tempKey, id);
 			log_op(OpSnapshotItem, tempKey, kv.getValue());
 			snapshotSize += tempKey.size() + kv.getValue().size() + OP_DISK_OVERHEAD;
 			++count;
@@ -946,6 +947,8 @@ private:
 					// to be a proper KeyRef of the key. This intentionally leaves the Arena alone and doesn't copy
 					// anything into it.
 					destKey.contents() = KeyRef(destKey.begin(), tempKey.size());
+
+					DEBUG_TRANSACTION_STATE_STORE("SnapshotItem", destKey.toString(), self->id);
 
 					// Get the common prefix between this key and the previous one, or 0 if there was no previous one.
 					int commonPrefix;

--- a/fdbserver/TransactionStoreMutationTracking.cpp
+++ b/fdbserver/TransactionStoreMutationTracking.cpp
@@ -1,0 +1,77 @@
+/*
+ * TxnMutationTracking.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2024 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "fdbserver/TransactionStoreMutationTracking.h"
+#if defined(FDB_CLEAN_BUILD) && DEBUG_TRANSACTION_STATE_STORE_ENABLED
+#error "You cannot use transaction store mutation tracking in a clean/release build."
+#endif
+
+// If DEBUG_TRANSACTION_STATE_STORE_ENABLED is set, tracking events will be logged for the
+// keys in debugKeys and the ranges in debugRanges.
+// Each entry is a pair of (label, keyOrRange) and the Label will be attached to the
+// TransactionStoreMutationTracking TraceEvent for easier searching/recognition.
+
+static std::vector<std::pair<const char*, KeyRef>> debugKeys = { { "SomeKey",
+	                                                               "\xff/serverList/\x09I\x8c\xc7\xdd"_sr } };
+static std::vector<std::pair<const char*, KeyRangeRef>> debugRanges = {
+	{ "SomeRange", { "\xff/serverList/\x09I\x8c\xc7\xdd"_sr, "\xff/serverList/\x09I\x8c\xc7\xdd\xff"_sr } }
+};
+
+TraceEvent transactionStoreDebugMutationEnabled(const char* context,
+                                                const std::string version,
+                                                StringRef const& mutation,
+                                                UID id) {
+	const char* label = nullptr;
+
+	for (auto& labelKey : debugKeys) {
+		if (mutation == labelKey.second) {
+			label = labelKey.first;
+			break;
+		}
+	}
+
+	for (auto& labelRange : debugRanges) {
+		if (labelRange.second.contains(mutation)) {
+			label = labelRange.first;
+			break;
+		}
+	}
+
+	if (label != nullptr) {
+		TraceEvent event("TransactionStoreMutationTracking", id);
+		event.detail("Label", label).detail("At", context).detail("Version", version).detail("Mutation", mutation);
+		return event;
+	}
+
+	return TraceEvent();
+}
+
+#if DEBUG_TRANSACTION_STATE_STORE_ENABLED
+TraceEvent transactionStoreDebugMutation(const char* context,
+                                         const std::string version,
+                                         StringRef const& mutation,
+                                         UID id) {
+	return transactionStoreDebugMutationEnabled(context, version, mutation, id);
+}
+#else
+TraceEvent transactionStoreDebugMutation(const char* context, Version version, StringRef const& mutation, UID id) {
+	return TraceEvent();
+}
+#endif

--- a/fdbserver/include/fdbserver/TransactionStoreMutationTracking.h
+++ b/fdbserver/include/fdbserver/TransactionStoreMutationTracking.h
@@ -1,0 +1,37 @@
+/*
+ * TxnMutationTracking.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2024 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _FDBSERVER_TRANSACTION_STORE_TRACKING_H_
+#define _FDBSERVER_TRANSACTION_STORE_TRACKING_H_
+#pragma once
+
+#include "fdbclient/FDBTypes.h"
+
+// The keys to track are defined in the .cpp file to limit recompilation.
+#define DEBUG_TRANSACTION_STATE_STORE_ENABLED 0
+
+#define DEBUG_TRANSACTION_STATE_STORE(...)                                                                             \
+	DEBUG_TRANSACTION_STATE_STORE_ENABLED&& transactionStoreDebugMutation(__VA_ARGS__)
+TraceEvent transactionStoreDebugMutation(const char* context,
+                                         const std::string version,
+                                         StringRef const& mutation,
+                                         UID id = UID());
+
+#endif

--- a/fdbserver/include/fdbserver/TransactionStoreMutationTracking.h
+++ b/fdbserver/include/fdbserver/TransactionStoreMutationTracking.h
@@ -30,8 +30,8 @@
 #define DEBUG_TRANSACTION_STATE_STORE(...)                                                                             \
 	DEBUG_TRANSACTION_STATE_STORE_ENABLED&& transactionStoreDebugMutation(__VA_ARGS__)
 TraceEvent transactionStoreDebugMutation(const char* context,
-                                         const std::string version,
                                          StringRef const& mutation,
-                                         UID id = UID());
+                                         UID id = UID(),
+                                         const std::string version = "-1");
 
 #endif


### PR DESCRIPTION
Add transaction store mutation tracking capability. This works similar to normal mutation tracking. The first iteration of the feature does not support encryption.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
