### PR TITLE
Debug fixes for cluster recovery version

### DIFF
--- a/fdbserver/LogSystemPeekCursor.actor.cpp
+++ b/fdbserver/LogSystemPeekCursor.actor.cpp
@@ -593,6 +593,9 @@ ILogSystem::MergedPeekCursor::MergedPeekCursor(
 		logSet->updateLocalitySet(logSet->tLogLocalities);
 	}
 
+	if (SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST) {
+		bestServer = -1;
+	}
 	for (int i = 0; i < logServers.size(); i++) {
 		auto cursor = makeReference<ILogSystem::ServerPeekCursor>(
 		    logServers[i], tag, begin, end, bestServer >= 0, parallelGetMore);
@@ -612,6 +615,9 @@ ILogSystem::MergedPeekCursor::MergedPeekCursor(std::vector<Reference<ILogSystem:
   : logSet(logSet), serverCursors(serverCursors), bestServer(bestServer), currentCursor(0), readQuorum(readQuorum),
     nextVersion(nextVersion), messageVersion(messageVersion), hasNextMessage(false),
     randomID(deterministicRandom()->randomUniqueID()), tLogReplicationFactor(tLogReplicationFactor) {
+	if (SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST) {
+		bestServer = -1;
+	}
 	sortedVersions.resize(serverCursors.size());
 	calcHasMessage();
 }
@@ -858,6 +864,9 @@ ILogSystem::SetPeekCursor::SetPeekCursor(std::vector<Reference<LogSet>> const& l
     messageVersion(begin), hasNextMessage(false), useBestSet(true), randomID(deterministicRandom()->randomUniqueID()) {
 	serverCursors.resize(logSets.size());
 	int maxServers = 0;
+	if (SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST) {
+		bestServer = -1;
+	}
 	for (int i = 0; i < logSets.size(); i++) {
 		for (int j = 0; j < logSets[i]->logServers.size(); j++) {
 			auto cursor = makeReference<ILogSystem::ServerPeekCursor>(
@@ -880,6 +889,9 @@ ILogSystem::SetPeekCursor::SetPeekCursor(std::vector<Reference<LogSet>> const& l
     currentCursor(0), nextVersion(nextVersion), messageVersion(messageVersion), hasNextMessage(false),
     useBestSet(useBestSet), randomID(deterministicRandom()->randomUniqueID()) {
 	int maxServers = 0;
+	if (SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST) {
+		bestServer = -1;
+	}
 	for (int i = 0; i < logSets.size(); i++) {
 		maxServers = std::max<int>(maxServers, serverCursors[i].size());
 	}

--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -1826,8 +1826,8 @@ Future<Void> tLogPeekMessages(PromiseType replyPromise,
 	//   - Otherwise, wait for new data as long as the tLog isn't locked.
 	state Optional<Version> replyWithRecoveryVersion = Optional<Version>();
 	if (logData->version.get() < reqBegin) {
-		if (SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST && logData->stopped() && reqEnd.present() &&
-		    reqEnd.get() != std::numeric_limits<Version>::max()) {
+		if (SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST && logData->isPrimary && logData->stopped() &&
+		    reqEnd.present() && reqEnd.get() != std::numeric_limits<Version>::max()) {
 			replyWithRecoveryVersion = reqEnd;
 		} else if (reqReturnIfBlocked) {
 			replyPromise.sendError(end_of_stream());


### PR DESCRIPTION
Debug fixes for cluster recovery version. Leave in draft for now.

1. do not use "best server" for set and merge cursors
2. remote dc does not use cluster recovery version

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
