### PR TITLE
Fix issues with clang 19

### DIFF
--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -428,16 +428,27 @@ if(NOT WIN32 AND NOT APPLE AND NOT OPEN_FOR_IDE)
   # Add the -Wl,--undefined-version flag to the linker command to allow
   # undefined symbols in version scripts. Clang 19 doesn't allow this and would
   # complain with "symbol not defined" errors.
-  target_link_options(cpp_workloads PRIVATE
-    "LINKER:--version-script=${CMAKE_CURRENT_SOURCE_DIR}/external_workload.map"
-    "LINKER:-z,nodelete"
-    "LINKER:--undefined-version"
-  )
-  target_link_options(c_workloads PRIVATE
-    "LINKER:--version-script=${CMAKE_CURRENT_SOURCE_DIR}/external_workload.map"
-    "LINKER:-z,nodelete"
-    "LINKER:--undefined-version"
-  )
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "19.0.0")
+    target_link_options(cpp_workloads PRIVATE
+      "LINKER:--version-script=${CMAKE_CURRENT_SOURCE_DIR}/external_workload.map"
+      "LINKER:-z,nodelete"
+      "LINKER:--undefined-version"
+    )
+    target_link_options(c_workloads PRIVATE
+      "LINKER:--version-script=${CMAKE_CURRENT_SOURCE_DIR}/external_workload.map"
+      "LINKER:-z,nodelete"
+      "LINKER:--undefined-version"
+    )
+  else()
+    target_link_options(cpp_workloads PRIVATE
+      "LINKER:--version-script=${CMAKE_CURRENT_SOURCE_DIR}/external_workload.map"
+      "LINKER:-z,nodelete"
+    )
+    target_link_options(c_workloads PRIVATE
+      "LINKER:--version-script=${CMAKE_CURRENT_SOURCE_DIR}/external_workload.map"
+      "LINKER:-z,nodelete"
+    )
+  endif()
 endif()
 
 # Generate shim library in Linux builds

--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -425,8 +425,19 @@ target_link_libraries(cpp_workloads PUBLIC fdb_c)
 target_include_directories(c_workloads PUBLIC ${CMAKE_SOURCE_DIR}/bindings/c)
 
 if(NOT WIN32 AND NOT APPLE AND NOT OPEN_FOR_IDE)
-  target_link_options(cpp_workloads PRIVATE "LINKER:--version-script=${CMAKE_CURRENT_SOURCE_DIR}/external_workload.map,-z,nodelete")
-  target_link_options(c_workloads PRIVATE "LINKER:--version-script=${CMAKE_CURRENT_SOURCE_DIR}/external_workload.map,-z,nodelete")
+  # Add the -Wl,--undefined-version flag to the linker command to allow
+  # undefined symbols in version scripts. Clang 19 doesn't allow this and would
+  # complain with "symbol not defined" errors.
+  target_link_options(cpp_workloads PRIVATE
+    "LINKER:--version-script=${CMAKE_CURRENT_SOURCE_DIR}/external_workload.map"
+    "LINKER:-z,nodelete"
+    "LINKER:--undefined-version"
+  )
+  target_link_options(c_workloads PRIVATE
+    "LINKER:--version-script=${CMAKE_CURRENT_SOURCE_DIR}/external_workload.map"
+    "LINKER:-z,nodelete"
+    "LINKER:--undefined-version"
+  )
 endif()
 
 # Generate shim library in Linux builds

--- a/bindings/c/test/fdb_api.hpp
+++ b/bindings/c/test/fdb_api.hpp
@@ -42,62 +42,47 @@
 namespace std {
 template <>
 struct char_traits<uint8_t> {
-    using char_type = uint8_t;
-    using int_type = int;
-    using off_type = streamoff;
-    using pos_type = streampos;
-    using state_type = mbstate_t;
+	using char_type = uint8_t;
+	using int_type = int;
+	using off_type = streamoff;
+	using pos_type = streampos;
+	using state_type = mbstate_t;
 
-    static void assign(char_type& c1, const char_type& c2) noexcept { c1 = c2; }
-    static bool eq(char_type c1, char_type c2) noexcept { return c1 == c2; }
-    static bool lt(char_type c1, char_type c2) noexcept { return c1 < c2; }
+	static void assign(char_type& c1, const char_type& c2) noexcept { c1 = c2; }
+	static bool eq(char_type c1, char_type c2) noexcept { return c1 == c2; }
+	static bool lt(char_type c1, char_type c2) noexcept { return c1 < c2; }
 
-    static int compare(const char_type* s1, const char_type* s2, size_t n) {
-        return memcmp(s1, s2, n);
-    }
+	static int compare(const char_type* s1, const char_type* s2, size_t n) { return memcmp(s1, s2, n); }
 
-    static size_t length(const char_type* s) {
-        return strlen(reinterpret_cast<const char*>(s));
-    }
+	static size_t length(const char_type* s) { return strlen(reinterpret_cast<const char*>(s)); }
 
-    static const char_type* find(const char_type* s, size_t n, const char_type& a) {
-        return reinterpret_cast<const char_type*>(memchr(s, a, n));
-    }
+	static const char_type* find(const char_type* s, size_t n, const char_type& a) {
+		return reinterpret_cast<const char_type*>(memchr(s, a, n));
+	}
 
-    static char_type* move(char_type* s1, const char_type* s2, size_t n) {
-        return reinterpret_cast<char_type*>(memmove(s1, s2, n));
-    }
+	static char_type* move(char_type* s1, const char_type* s2, size_t n) {
+		return reinterpret_cast<char_type*>(memmove(s1, s2, n));
+	}
 
-    static char_type* copy(char_type* s1, const char_type* s2, size_t n) {
-        return reinterpret_cast<char_type*>(memcpy(s1, s2, n));
-    }
+	static char_type* copy(char_type* s1, const char_type* s2, size_t n) {
+		return reinterpret_cast<char_type*>(memcpy(s1, s2, n));
+	}
 
-    static char_type* assign(char_type* s, size_t n, char_type a) {
-        return reinterpret_cast<char_type*>(memset(s, a, n));
-    }
+	static char_type* assign(char_type* s, size_t n, char_type a) {
+		return reinterpret_cast<char_type*>(memset(s, a, n));
+	}
 
-    static int_type not_eof(int_type c) noexcept {
-        return (c == eof()) ? 0 : c;
-    }
+	static int_type not_eof(int_type c) noexcept { return (c == eof()) ? 0 : c; }
 
-    static char_type to_char_type(int_type c) noexcept {
-        return static_cast<char_type>(c);
-    }
+	static char_type to_char_type(int_type c) noexcept { return static_cast<char_type>(c); }
 
-    static int_type to_int_type(char_type c) noexcept {
-        return static_cast<int_type>(c);
-    }
+	static int_type to_int_type(char_type c) noexcept { return static_cast<int_type>(c); }
 
-    static bool eq_int_type(int_type c1, int_type c2) noexcept {
-        return c1 == c2;
-    }
+	static bool eq_int_type(int_type c1, int_type c2) noexcept { return c1 == c2; }
 
-    static int_type eof() noexcept {
-        return static_cast<int_type>(EOF);
-    }
+	static int_type eof() noexcept { return static_cast<int_type>(EOF); }
 };
-}
-
+} // namespace std
 
 namespace fdb {
 

--- a/bindings/c/test/fdb_api.hpp
+++ b/bindings/c/test/fdb_api.hpp
@@ -39,6 +39,66 @@
 // introduce the option enums
 #include <fdb_c_options.g.h>
 
+namespace std {
+template <>
+struct char_traits<uint8_t> {
+    using char_type = uint8_t;
+    using int_type = int;
+    using off_type = streamoff;
+    using pos_type = streampos;
+    using state_type = mbstate_t;
+
+    static void assign(char_type& c1, const char_type& c2) noexcept { c1 = c2; }
+    static bool eq(char_type c1, char_type c2) noexcept { return c1 == c2; }
+    static bool lt(char_type c1, char_type c2) noexcept { return c1 < c2; }
+
+    static int compare(const char_type* s1, const char_type* s2, size_t n) {
+        return memcmp(s1, s2, n);
+    }
+
+    static size_t length(const char_type* s) {
+        return strlen(reinterpret_cast<const char*>(s));
+    }
+
+    static const char_type* find(const char_type* s, size_t n, const char_type& a) {
+        return reinterpret_cast<const char_type*>(memchr(s, a, n));
+    }
+
+    static char_type* move(char_type* s1, const char_type* s2, size_t n) {
+        return reinterpret_cast<char_type*>(memmove(s1, s2, n));
+    }
+
+    static char_type* copy(char_type* s1, const char_type* s2, size_t n) {
+        return reinterpret_cast<char_type*>(memcpy(s1, s2, n));
+    }
+
+    static char_type* assign(char_type* s, size_t n, char_type a) {
+        return reinterpret_cast<char_type*>(memset(s, a, n));
+    }
+
+    static int_type not_eof(int_type c) noexcept {
+        return (c == eof()) ? 0 : c;
+    }
+
+    static char_type to_char_type(int_type c) noexcept {
+        return static_cast<char_type>(c);
+    }
+
+    static int_type to_int_type(char_type c) noexcept {
+        return static_cast<int_type>(c);
+    }
+
+    static bool eq_int_type(int_type c1, int_type c2) noexcept {
+        return c1 == c2;
+    }
+
+    static int_type eof() noexcept {
+        return static_cast<int_type>(EOF);
+    }
+};
+}
+
+
 namespace fdb {
 
 // hide C API to discourage mixing C/C++ API

--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -96,6 +96,7 @@ set(CMAKE_REQUIRED_INCLUDES stdlib.h malloc.h)
 set(CMAKE_REQUIRED_LIBRARIES c)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 
@@ -436,6 +437,8 @@ else()
       $<${is_cxx_compile}:-Wno-unused-command-line-argument>
       # Disable C++ 20 warning for ambiguous operator.
       $<${is_cxx_compile}:-Wno-ambiguous-reversed-operator>
+      # Disable for clang 19
+      $<${is_cxx_compile}:-Wno-vla-cxx-extension>
       )
     # These need to be disabled for FDB's RocksDB storage server implementation
     add_compile_options(
@@ -485,6 +488,7 @@ else()
     # Needed for gcc 13
     #add_compile_options($<${is_cxx_compile}:-Wno-missing-template-keyword>)
     add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-missing-template-keyword>)
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-free-nonheap-object>)
   endif()
   add_compile_options(
     $<${is_cxx_compile}:-Wno-error=format>

--- a/fdbserver/KeyValueStoreShardedRocksDB.actor.cpp
+++ b/fdbserver/KeyValueStoreShardedRocksDB.actor.cpp
@@ -54,7 +54,6 @@ static_assert((ROCKSDB_MAJOR == FDB_ROCKSDB_MAJOR && ROCKSDB_MINOR == FDB_ROCKSD
                ROCKSDB_PATCH == FDB_ROCKSDB_PATCH),
               "Unsupported rocksdb version.");
 
-const std::string rocksDataFolderSuffix = "-data";
 const std::string METADATA_SHARD_ID = "kvs-metadata";
 const std::string DEFAULT_CF_NAME = "default"; // `specialKeys` is stored in this culoumn family.
 const std::string manifestFilePrefix = "MANIFEST-";

--- a/fdbserver/worker.actor.cpp
+++ b/fdbserver/worker.actor.cpp
@@ -4209,7 +4209,7 @@ ACTOR Future<Void> serveProcess() {
 
 				std::vector<SerializedSample> serializedSamples;
 				for (const auto& samplePtr : samples) {
-					auto serialized = SerializedSample{ .time = samplePtr->time };
+					auto serialized = SerializedSample{ .time = samplePtr->time, .data = {} };
 					for (const auto& [waitState, pair] : samplePtr->data) {
 						if (waitState >= req.waitStateStart && waitState <= req.waitStateEnd) {
 							serialized.data[waitState] = std::string(pair.first, pair.second);


### PR DESCRIPTION
Found with clang 19 compiling the code.

For mako, the problem is that
`std::char_traits<T>` is being [deprecated](https://github.com/jtv/libpqxx/issues/738) for types other than char, wchar_t, char8_t, char16_t, and char32_t. So code `using ByteString = std::basic_string<uint8_t>;` causes compiling errors:

```
In file included from /root/foundationdb/bindings/c/test/fdb_api.hpp:34:
/usr/local/bin/../include/c++/v1/string:820:42: error: implicit instantiation of undefined template 'std::char_traits<unsigned char>'
  820 |   static_assert(is_same<_CharT, typename traits_type::char_type>::value,
      |                                          ^
/root/foundationdb/bindings/c/test/fdb_api.hpp:58:6: note: in instantiation of template class 'std::basic_string<unsigned char>' requested here
   58 |         Key key;
      |             ^
/usr/local/bin/../include/c++/v1/__fwd/string.h:23:29: note: template is declared here
   23 | struct _LIBCPP_TEMPLATE_VIS char_traits;

```

20241213-171820-jzhou-9a2efa6785847001

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
