### PR TITLE
[RELEASE-7.1] Refactor locality-based exclusion checks to reduce additional overhead

### DIFF
--- a/fdbcli/ExcludeCommand.actor.cpp
+++ b/fdbcli/ExcludeCommand.actor.cpp
@@ -151,6 +151,9 @@ ACTOR Future<std::set<NetworkAddress>> checkForExcludingServers(Reference<IDatab
                                                                 bool waitForAllExcluded) {
 	state std::set<NetworkAddress> inProgressExclusion;
 	state Reference<ITransaction> tr = db->createTransaction();
+	tr->setOption(FDBTransactionOptions::SPECIAL_KEY_SPACE_ENABLE_WRITES);
+	tr->setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
+
 	loop {
 		inProgressExclusion.clear();
 		try {

--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -1090,9 +1090,8 @@ ACTOR Future<bool> checkExclusion(Database db,
 	// case that someone would exclude all SS processes, this would cause otherwise a division through 0 and therefore
 	// cause the fdbcli to crash, so we calculate the total free and used non excluded KV bytes before calculating the
 	// ratio.
-	double totalKvUsedAndFreeNonExcluded =
-	    totalKvStoreUsedBytesNonExcluded +
-	    totalKvStoreFreeBytes if (ssExcludedCount == ssTotalCount || totalKvUsedAndFreeNonExcluded == 0.0) {
+	double totalKvUsedAndFreeNonExcluded = totalKvStoreUsedBytesNonExcluded + totalKvStoreFreeBytes;
+	if (ssExcludedCount == ssTotalCount || totalKvUsedAndFreeNonExcluded == 0.0) {
 		std::string temp = "ERROR: This exclude may cause the total free space in the cluster to drop below 10%.\n"
 		                   "Call set(\"0xff0xff/management/options/exclude/force\", ...) first to exclude without "
 		                   "checking free space.\n";


### PR DESCRIPTION
Restructure some of the exclusion code to reduce the requests that are made by locality-based exclusions and make sure we fetch the information only once. Under normal circumstances the additional work is not critical but in some cases when the cluster is under heavy load or a set of workers is slow in responding, the additional work can prevent that locality-baed exclusions work (but the IP:port based exclusions work).

I made the PR against 7.1 as I was testing against a 7.1 cluster. Once the changes look good I'll create a PR for main and 7.3 (and make sure we merge the PR for the main branch first).

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [x] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [x] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
