### PR TITLE
Make ClogRemoteTlog pass when check failures count as Joshua failures

### DIFF
--- a/fdbserver/workloads/ClogRemoteTLog.actor.cpp
+++ b/fdbserver/workloads/ClogRemoteTLog.actor.cpp
@@ -10,6 +10,7 @@
 #include "fdbserver/Knobs.h"
 #include "fdbserver/ServerDBInfo.actor.h"
 #include "fdbserver/workloads/workloads.actor.h"
+#include "flow/Buggify.h"
 #include "flow/Error.h"
 #include "flow/IPAddress.h"
 #include "flow/IRandom.h"
@@ -104,7 +105,7 @@ struct ClogRemoteTLog : TestWorkload {
 			return ret;
 		};
 		TraceEvent("ClogRemoteTLogCheck").detail("ActualStatePath", print(actualStatePath)).detail("DoCheck", doCheck);
-		if (!doCheck) {
+		if (!doCheck || isGeneralBuggifyEnabled()) {
 			return true;
 		}
 

--- a/fdbserver/workloads/ClogRemoteTLog.actor.cpp
+++ b/fdbserver/workloads/ClogRemoteTLog.actor.cpp
@@ -13,6 +13,7 @@
 #include "flow/Error.h"
 #include "flow/IPAddress.h"
 #include "flow/IRandom.h"
+#include "flow/NetworkAddress.h"
 #include "flow/Optional.h"
 #include "flow/Trace.h"
 #include "flow/flow.h"
@@ -24,22 +25,25 @@ struct ClogRemoteTLog : TestWorkload {
 	static constexpr auto NAME = "ClogRemoteTLog";
 
 	bool enabled{ false };
+	bool doCheck{ false };
 	double testDuration{ 0.0 };
 	double lagMeasurementFrequency{ 0 };
 	double clogInitDelay{ 0 };
-	double clogDuration{ 0 };
 	double lagThreshold{ 0 };
 
 	enum TestState { TEST_INIT, SS_LAG_NORMAL, SS_LAG_HIGH, CLOGGED_REMOTE_TLOG_EXCLUDED };
 	struct StatePath {
 		std::vector<TestState> path;
-		bool prefixMatch{ false };
+		bool prefixMatch{ true };
 	};
 	const std::vector<StatePath> expectedStatePaths{
-		{ .path = { TEST_INIT, SS_LAG_NORMAL, SS_LAG_HIGH, SS_LAG_NORMAL }, .prefixMatch = true },
+		{ .path = { TEST_INIT, SS_LAG_NORMAL, SS_LAG_HIGH, SS_LAG_NORMAL } },
 		// For some topology and process placements, it's possible that the lag does not recover. However, we still
 		// allow the test to pass as long as the bad/clogged remote tlog was excluded by gray failure.
-		{ .path = { TEST_INIT, SS_LAG_NORMAL, SS_LAG_HIGH, CLOGGED_REMOTE_TLOG_EXCLUDED }, .prefixMatch = true }
+		{ .path = { TEST_INIT, SS_LAG_NORMAL, SS_LAG_HIGH, CLOGGED_REMOTE_TLOG_EXCLUDED } },
+		{ .path = { TEST_INIT, SS_LAG_NORMAL, CLOGGED_REMOTE_TLOG_EXCLUDED } },
+		{ .path = { TEST_INIT, SS_LAG_HIGH, CLOGGED_REMOTE_TLOG_EXCLUDED } },
+		{ .path = { TEST_INIT, SS_LAG_HIGH, SS_LAG_NORMAL } }
 	};
 	std::vector<TestState>
 	    actualStatePath; // to be populated when the test runs, and finally checked at the end in check()
@@ -54,7 +58,6 @@ struct ClogRemoteTLog : TestWorkload {
 		testDuration = getOption(options, "testDuration"_sr, 120);
 		lagMeasurementFrequency = getOption(options, "lagMeasurementFrequency"_sr, 5);
 		clogInitDelay = getOption(options, "clogInitDelay"_sr, 10);
-		clogDuration = getOption(options, "clogDuration"_sr, 110);
 		lagThreshold = getOption(options, "lagThreshold"_sr, 20);
 	}
 
@@ -100,7 +103,10 @@ struct ClogRemoteTLog : TestWorkload {
 			}
 			return ret;
 		};
-		TraceEvent("ClogRemoteTLogCheck").detail("ActualStatePath", print(actualStatePath));
+		TraceEvent("ClogRemoteTLogCheck").detail("ActualStatePath", print(actualStatePath)).detail("DoCheck", doCheck);
+		if (!doCheck) {
+			return true;
+		}
 
 		// Then, do the actual check
 		auto match =
@@ -126,6 +132,7 @@ struct ClogRemoteTLog : TestWorkload {
 				return true;
 			}
 		}
+		TraceEvent(SevError, "ClogRemoteTLogCheckFailed");
 		return false;
 	}
 
@@ -296,51 +303,46 @@ struct ClogRemoteTLog : TestWorkload {
 		ASSERT(!remoteSSIPs.empty());
 
 		// Then, attempt to find a remote tlog that is not on the same machine as a remote SS
-		Optional<NetworkAddress> remoteTLogIP_temp;
+		Optional<NetworkAddress> isolatedRemoteTLog;
 		for (const auto& addr : remoteTLogs) {
 			if (std::find(remoteSSIPs.begin(), remoteSSIPs.end(), addr.ip) == remoteSSIPs.end()) {
-				remoteTLogIP_temp = addr;
+				isolatedRemoteTLog = addr;
 			}
 		}
 
 		// If we can find such a machine that is just running a remote tlog, then we will do extra checking at the end
 		// (in check() method). If we can't find such a machine, we pick a random machhine and still run the test to
 		// ensure no crashes or correctness issues are observed.
-		if (remoteTLogIP_temp.present()) {
-			self->cloggedRemoteTLog = remoteTLogIP_temp.get();
-		} else {
-			self->cloggedRemoteTLog = remoteTLogs[deterministicRandom()->randomInt(0, remoteTLogs.size())];
-		}
-
+		self->cloggedRemoteTLog = isolatedRemoteTLog.present()
+		                              ? isolatedRemoteTLog.get()
+		                              : self->cloggedRemoteTLog =
+		                                    remoteTLogs[deterministicRandom()->randomInt(0, remoteTLogs.size())];
 		ASSERT(self->cloggedRemoteTLog.present());
 
 		// Then, find all processes that the remote tlog will have degraded connection with
 		IPAddress cc = self->dbInfo->get().clusterInterface.address().ip;
 		state std::vector<IPAddress> processes;
-		if (SERVER_KNOBS->GRAY_FAILURE_ALLOW_REMOTE_SS_TO_COMPLAIN) {
-			for (const auto& remoteSSIP : remoteSSIPs) {
-				if (remoteSSIP != cc) {
-					processes.push_back(remoteSSIP);
-				}
-			}
-		} else {
-			for (const auto& process : g_simulator->getAllProcesses()) {
-				const auto& ip = process->address.ip;
-				if (process->startingClass != ProcessClass::TesterClass && ip != cc) {
-					processes.push_back(ip);
-				}
+		for (const auto& process : g_simulator->getAllProcesses()) {
+			const auto& ip = process->address.ip;
+			if (process->startingClass != ProcessClass::TesterClass && ip != cc) {
+				processes.push_back(ip);
 			}
 		}
 		ASSERT(!processes.empty());
 
 		// Finally, start the clogging between the remote tlog and the processes calculated above
+		int numClogged{ 0 };
 		for (const auto& ip : processes) {
 			if (self->cloggedRemoteTLog.get().ip == ip) {
 				continue;
 			}
 			TraceEvent("ClogRemoteTLog").detail("SrcIP", self->cloggedRemoteTLog->ip).detail("DstIP", ip);
-			g_simulator->clogPair(self->cloggedRemoteTLog.get().ip, ip, self->testDuration);
 			g_simulator->clogPair(ip, self->cloggedRemoteTLog.get().ip, self->testDuration);
+			numClogged++;
+		}
+
+		if (isolatedRemoteTLog.present() && numClogged > 1) {
+			self->doCheck = true;
 		}
 
 		wait(Never());
@@ -379,8 +381,18 @@ struct ClogRemoteTLog : TestWorkload {
 			state bool stateTransition = localState != testState;
 			// If ss lag state did not change, see if clogged remote tlog got excluded
 			if (!stateTransition) {
-				const bool dbReady = self->dbInfo->get().recoveryState == RecoveryState::FULLY_RECOVERED;
-				if (dbReady && self->cloggedRemoteTLog.present() &&
+				const bool acceptingCommits = self->dbInfo->get().recoveryState >= RecoveryState::ACCEPTING_COMMITS;
+				TraceEvent("ClogRemoteTLogMoreInfo")
+				    .detail("CloggedRemoteTLogPresent", self->cloggedRemoteTLog.present())
+				    .detail("Addr",
+				            self->cloggedRemoteTLog.present() ? self->cloggedRemoteTLog.get().toString() : "DidNotFind")
+				    .detail("NotInDbInfo",
+				            self->cloggedRemoteTLog.present()
+				                ? remoteTLogNotInDbInfo(self->cloggedRemoteTLog.get(), self->dbInfo->get())
+				                : false)
+				    .detail("AcceptingCommits", acceptingCommits)
+				    .detail("RecoveryState", self->dbInfo->get().recoveryState);
+				if (acceptingCommits && self->cloggedRemoteTLog.present() &&
 				    remoteTLogNotInDbInfo(self->cloggedRemoteTLog.get(), self->dbInfo->get())) {
 					localState = TestState::CLOGGED_REMOTE_TLOG_EXCLUDED;
 					if (!statusCheckPassed) {

--- a/tests/rare/ClogRemoteTLog.toml
+++ b/tests/rare/ClogRemoteTLog.toml
@@ -5,7 +5,6 @@ generateFearless = true
 minimumRegions = 2
 remoteDesiredTLogCount = 4
 statelessProcessClassesPerDC = 2
-buggify = false
 
 [[knobs]]
 enable_worker_health_monitor = true

--- a/tests/rare/ClogRemoteTLog.toml
+++ b/tests/rare/ClogRemoteTLog.toml
@@ -5,6 +5,7 @@ generateFearless = true
 minimumRegions = 2
 remoteDesiredTLogCount = 4
 statelessProcessClassesPerDC = 2
+buggify = false
 
 [[knobs]]
 enable_worker_health_monitor = true
@@ -12,16 +13,17 @@ worker_health_monitor_interval = 10
 cc_enable_worker_health_monitor = true
 cc_health_trigger_recovery = true
 cc_enable_remote_tlog_degradation_monitoring = true
+gray_failure_allow_remote_ss_to_complain = true
 cc_worker_health_checking_interval = 45
 cc_min_degradation_interval = 30
 cc_degraded_peer_degree_to_exclude = 10
-cc_max_health_recovery_count = 1
+cc_max_health_recovery_count = 3
 cc_only_consider_intra_dc_latency = true
 cc_tracking_health_recovery_interval = 60
 peer_latency_degradation_threshold = 1
-peer_latency_degradation_percentile = 1
-peer_latency_check_min_population = 2
-cc_max_exclusion_due_to_health = 5
+peer_latency_degradation_percentile = 0.5
+peer_latency_check_min_population = 10
+cc_max_exclusion_due_to_health = 3
 
 [[test]]
 testTitle = "ClogRemoteTLog"
@@ -30,13 +32,12 @@ testTitle = "ClogRemoteTLog"
 testName = 'Cycle'
 nodeCount = 30
 transactionsPerSecond = 250.0
-testDuration = 120.0
+testDuration = 360.0
 expectedRate = 0
 
 [[test.workload]]
 testName = 'ClogRemoteTLog'
 lagMeasurementFrequency = 5.0
 clogInitDelay = 10.0
-clogDuration = 110.0
-testDuration = 120.0
+testDuration = 360.0
 lagThreshold = 20.0


### PR DESCRIPTION
When writing the gray failure simulation test, I make sure that the test goes through a series of phases by doing an invariant check in the `check` phase of the test. I made the incorrect assumption that `check` failures would result in Joshua failures too, but that is not true. To count check failures as Joshua failures, this PR makes it so that the test emits a severity 40 error if `check` failed. When I did that, I got Joshua failures because the test needed more tuning. This PR tunes the test to ensure Joshua passes now, meaning that `check` is also passing. There are a bunch of tunings I had to do, mostly because these got compounded as `check` failures were getting masked over time. 

100K Joshua: `20241216-033032-praza-81a7cd863636dbf9c9020ba8b6a74e88d204d7 compressed=True data_size=36246418 duration=5308284 ended=100000 fail=2 fail_fast=10 max_runs=100000 pass=99998 priority=100 remaining=0 runtime=1:13:12 sanity=False started=100000 stopped=20241216-044344 submitted=20241216-033032 timeout=5400 username=praza-81a7cd863636dbf9c9020ba8b6a74e88d204d7de`. Both failures not for the test I modified, so not related to this PR.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
