### PR TITLE
Extend gray failure recentHealthTriggeredRecoveryTime state to reflect any recovery

### DIFF
--- a/fdbclient/include/fdbclient/ServerKnobs.h
+++ b/fdbclient/include/fdbclient/ServerKnobs.h
@@ -773,7 +773,9 @@ public:
 	                                             // CC_MAX_HEALTH_RECOVERY_COUNT within
 	                                             // CC_TRACKING_HEALTH_RECOVERY_INTERVAL.
 	int CC_MAX_HEALTH_RECOVERY_COUNT; // The max number of recoveries can be triggered due to worker health within
-	                                  // CC_TRACKING_HEALTH_RECOVERY_INTERVAL
+	                                  // CC_TRACKING_HEALTH_RECOVERY_INTERVAL. This count accounts for recoveries
+	                                  // triggered by gray failure, as well as by CC (due to sequencer reporting
+	                                  // failure).
 	bool CC_HEALTH_TRIGGER_FAILOVER; // Whether to enable health triggered failover in CC.
 	int CC_FAILOVER_DUE_TO_HEALTH_MIN_DEGRADATION; // The minimum number of degraded servers that can trigger a
 	                                               // failover.

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -311,6 +311,7 @@ ACTOR Future<Void> clusterWatchDatabase(ClusterControllerData* cluster,
 				                                                SERVER_KNOBS->SECONDS_BEFORE_NO_FAILURE_DELAY
 				                                          : SERVER_KNOBS->MASTER_FAILURE_SLOPE_DURING_RECOVERY) ||
 				          db->forceMasterFailure.onTrigger())) {
+					cluster->recentHealthTriggeredRecoveryTime.push(now());
 					break;
 				}
 				when(wait(db->serverInfo->onChange())) {}
@@ -3061,7 +3062,6 @@ ACTOR Future<Void> workerHealthMonitor(ClusterControllerData* self) {
 				if (self->shouldTriggerRecoveryDueToDegradedServers()) {
 					if (SERVER_KNOBS->CC_HEALTH_TRIGGER_RECOVERY) {
 						if (self->recentRecoveryCountDueToHealth() < SERVER_KNOBS->CC_MAX_HEALTH_RECOVERY_COUNT) {
-							self->recentHealthTriggeredRecoveryTime.push(now());
 							self->excludedDegradedServers.clear();
 							for (const auto& degradedServer : self->degradationInfo.degradedServers) {
 								self->excludedDegradedServers[degradedServer] = now();


### PR DESCRIPTION
Extend gray failure recentHealthTriggeredRecoveryTime state to reflect any recovery, including non-gray failure triggered ones. 

100K: `20241217-202817-praza-dd26679afd856420caeddc8c509783b1f2b233 compressed=True data_size=36247183 fail_fast=10 max_runs=100000 priority=100 sanity=False submitted=20241217-202817 timeout=5400 username=praza-dd26679afd856420caeddc8c509783b1f2b23302`

Also explicitly ran `fdbserver -r unittests -f /fdbserver/clustercontroller/` which includes gray failure unit tests, all pass.

TODO: kubernetes test

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
