### PR TITLE
Lower bound version of CC_DEGRADED_PEER_DEGREE_TO_EXCLUDE

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -799,6 +799,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( CC_MIN_DEGRADATION_INTERVAL,                         120.0 );
 	init( ENCRYPT_KEY_PROXY_FAILURE_TIME,                        0.1 ); if ( isSimulated ) ENCRYPT_KEY_PROXY_FAILURE_TIME = 1.0 + deterministicRandom()->random01();
 	init( CC_DEGRADED_PEER_DEGREE_TO_EXCLUDE,                      3 );
+	init( CC_DEGRADED_PEER_DEGREE_TO_EXCLUDE_MIN,                  1 );
 	init( CC_MAX_EXCLUSION_DUE_TO_HEALTH,                          2 );
 	init( CC_HEALTH_TRIGGER_RECOVERY,                          false, Atomic::NO );
 	init( CC_TRACKING_HEALTH_RECOVERY_INTERVAL,               3600.0 );

--- a/fdbclient/include/fdbclient/ServerKnobs.h
+++ b/fdbclient/include/fdbclient/ServerKnobs.h
@@ -765,6 +765,8 @@ public:
 	int CC_DEGRADED_PEER_DEGREE_TO_EXCLUDE; // The maximum number of degraded peers when excluding a server. When the
 	                                        // number of degraded peers is more than this value, we will not exclude
 	                                        // this server since it may because of server overload.
+	int CC_DEGRADED_PEER_DEGREE_TO_EXCLUDE_MIN; // Similar to CC_DEGRADED_PEER_DEGREE_TO_EXCLUDE which is an upper
+	                                            // bound, this is a lower bound.
 	int CC_MAX_EXCLUSION_DUE_TO_HEALTH; // The max number of degraded servers to exclude by Cluster Controller due to
 	                                    // degraded health.
 	bool CC_HEALTH_TRIGGER_RECOVERY; // If true, cluster controller will kill the master to trigger recovery when

--- a/fdbserver/include/fdbserver/ClusterController.actor.h
+++ b/fdbserver/include/fdbserver/ClusterController.actor.h
@@ -3208,7 +3208,8 @@ public:
 		// For degraded server that are complained by more than SERVER_KNOBS->CC_DEGRADED_PEER_DEGREE_TO_EXCLUDE, we
 		// don't know if it is a hot server, or the network is bad. We remove from the returned degraded server list.
 		for (const auto& badServer : currentDegradedServers) {
-			if (degradedLinkDst2Src[badServer].size() <= SERVER_KNOBS->CC_DEGRADED_PEER_DEGREE_TO_EXCLUDE) {
+			if (degradedLinkDst2Src[badServer].size() >= SERVER_KNOBS->CC_DEGRADED_PEER_DEGREE_TO_EXCLUDE_MIN &&
+			    degradedLinkDst2Src[badServer].size() <= SERVER_KNOBS->CC_DEGRADED_PEER_DEGREE_TO_EXCLUDE) {
 				currentDegradationInfo.degradedServers.insert(badServer);
 			}
 		}

--- a/tests/rare/ClogRemoteTLog.toml
+++ b/tests/rare/ClogRemoteTLog.toml
@@ -23,6 +23,7 @@ peer_latency_degradation_threshold = 1
 peer_latency_degradation_percentile = 0.5
 peer_latency_check_min_population = 10
 cc_max_exclusion_due_to_health = 3
+cc_degraded_peer_degree_to_exclude_min = 2
 
 [[test]]
 testTitle = "ClogRemoteTLog"


### PR DESCRIPTION
# Description

In the context of gray failure, sometimes we want to only trigger recovery if the minimum number of complainers is greater or equal to a configurable value (lower bound). An upper bound version of this functionality is already present, specifically we only trigger recovery if the number of complainers is less or equal to `CC_DEGRADED_PEER_DEGREE_TO_EXCLUDE`. This PR adds a lower bound version (`CC_DEGRADED_PEER_DEGREE_TO_EXCLUDE_MIN`).

# Testing

100K: `20241217-203855-praza-2de25e1368238ed05c025adfe68b43c5a88451 compressed=True data_size=36247064 fail_fast=10 max_runs=100000 priority=100 sanity=False submitted=20241217-203855 timeout=5400 username=praza-2de25e1368238ed05c025adfe68b43c5a884518b`

Explicitly ran `fdbserver -r unittests -f /fdbserver/clustercontroller/` to run gray failure unit tests, all pass. 

Also specifically ran `ClogRemoteTlog` sim test with different `degraded_peer_degree_to_exclude_min` knob values (1, 2, 5, 10). With 1 and 2, the test passes. With higher numbers like 5 and 10, the test fails sometimes when there are not enough (5 or 10) complainers for the degraded process, so no recovery is triggered and the degraded process is not excluded and SS lag does not decrease. 

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
