### PR TITLE
Backport "Invalidate gray failure complaints from excluded processes" to 7.3 (#11749)

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -788,6 +788,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( CC_SATELLITE_DEGRADATION_MIN_COMPLAINER,                 3 );
 	init( CC_SATELLITE_DEGRADATION_MIN_BAD_SERVER,                 3 );
 	init( CC_ENABLE_REMOTE_LOG_ROUTER_MONITORING,               true );
+	init( CC_INVALIDATE_EXCLUDED_PROCESSES,                     false); if (isSimulated && deterministicRandom()->coinflip()) CC_INVALIDATE_EXCLUDED_PROCESSES = true;
 	init( CC_THROTTLE_SINGLETON_RERECRUIT_INTERVAL,              0.5 );
 
 	init( INCOMPATIBLE_PEERS_LOGGING_INTERVAL,                   600 ); if( randomize && BUGGIFY ) INCOMPATIBLE_PEERS_LOGGING_INTERVAL = 60.0;

--- a/fdbclient/include/fdbclient/ServerKnobs.h
+++ b/fdbclient/include/fdbclient/ServerKnobs.h
@@ -763,6 +763,8 @@ public:
 	                                             // determined as degraded satellite.
 	bool CC_ENABLE_REMOTE_LOG_ROUTER_MONITORING; // When enabled, gray failure tries to detect whether the remote log
 	                                             // router is degraded and may use trigger recovery to recover from it.
+	bool CC_INVALIDATE_EXCLUDED_PROCESSES; // When enabled, invalidate the complaints by processes that were excluded
+	                                       // in gray failure triggered recoveries.
 	double CC_THROTTLE_SINGLETON_RERECRUIT_INTERVAL; // The interval to prevent re-recruiting the same singleton if a
 	                                                 // recruiting fight between two cluster controllers occurs.
 

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -3962,10 +3962,6 @@ TEST_CASE("/fdbserver/clustercontroller/invalidateExcludedProcessComplaints") {
 	NetworkAddress worker3(IPAddress::parse("1.1.1.2").get(), 1);
 	NetworkAddress badPeer(IPAddress::parse("1.1.1.3").get(), 1);
 
-	if (SERVER_KNOBS->CC_ONLY_CONSIDER_INTRA_DC_LATENCY) {
-		addProcessesToSameDC(data, { worker1, worker2, worker3, badPeer });
-	}
-
 	ASSERT(data.workerHealth.empty());
 
 	// {worker1, worker2, worker3} complain about badPeer

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -2917,6 +2917,18 @@ ACTOR Future<Void> dbInfoUpdater(ClusterControllerData* self) {
 	}
 }
 
+// If we are excluding processes and triggering recovery because of gray failure, also
+// invalidate the past complaints from such processes because that signal is no longer
+// reliable.
+static void invalidateExcludedProcessComplaints(ClusterControllerData* self) {
+	if (!SERVER_KNOBS->CC_INVALIDATE_EXCLUDED_PROCESSES) {
+		return;
+	}
+	for (const auto& addr : self->excludedDegradedServers) {
+		self->workerHealth.erase(addr);
+	}
+}
+
 // The actor that periodically monitors the health of tracked workers.
 ACTOR Future<Void> workerHealthMonitor(ClusterControllerData* self) {
 	loop {
@@ -2964,6 +2976,7 @@ ACTOR Future<Void> workerHealthMonitor(ClusterControllerData* self) {
 							self->excludedDegradedServers = self->degradationInfo.degradedServers;
 							self->excludedDegradedServers.insert(self->degradationInfo.disconnectedServers.begin(),
 							                                     self->degradationInfo.disconnectedServers.end());
+							invalidateExcludedProcessComplaints(self);
 							TraceEvent(SevWarnAlways, "DegradedServerDetectedAndTriggerRecovery")
 							    .detail("RecentRecoveryCountDueToHealth", self->recentRecoveryCountDueToHealth());
 							self->db.forceMasterFailure.trigger();
@@ -3934,6 +3947,85 @@ TEST_CASE("/fdbserver/clustercontroller/shouldTriggerFailoverDueToDegradedServer
 	data.degradationInfo.disconnectedServers.insert(remoteTlog);
 	ASSERT(!data.shouldTriggerFailoverDueToDegradedServers());
 	data.degradationInfo.disconnectedServers.clear();
+
+	return Void();
+}
+
+TEST_CASE("/fdbserver/clustercontroller/invalidateExcludedProcessComplaints") {
+	ClusterControllerData data(ClusterControllerFullInterface(),
+	                           LocalityData(),
+	                           ServerCoordinators(Reference<IClusterConnectionRecord>(
+	                               new ClusterConnectionMemoryRecord(ClusterConnectionString()))),
+	                           makeReference<AsyncVar<Optional<UID>>>());
+	NetworkAddress worker1(IPAddress::parse("1.1.1.0").get(), 1);
+	NetworkAddress worker2(IPAddress::parse("1.1.1.1").get(), 1);
+	NetworkAddress worker3(IPAddress::parse("1.1.1.2").get(), 1);
+	NetworkAddress badPeer(IPAddress::parse("1.1.1.3").get(), 1);
+
+	if (SERVER_KNOBS->CC_ONLY_CONSIDER_INTRA_DC_LATENCY) {
+		addProcessesToSameDC(data, { worker1, worker2, worker3, badPeer });
+	}
+
+	ASSERT(data.workerHealth.empty());
+
+	// {worker1, worker2, worker3} complain about badPeer
+	data.workerHealth[worker1].degradedPeers[badPeer] = { now() - SERVER_KNOBS->CC_MIN_DEGRADATION_INTERVAL - 1,
+		                                                  now() };
+	data.workerHealth[worker2].degradedPeers[badPeer] = { now() - SERVER_KNOBS->CC_MIN_DEGRADATION_INTERVAL - 1,
+		                                                  now() };
+	data.workerHealth[worker3].degradedPeers[badPeer] = { now() - SERVER_KNOBS->CC_MIN_DEGRADATION_INTERVAL - 1,
+		                                                  now() };
+
+	// badPeer complains about {worker1, worker2, worker3}
+	data.workerHealth[badPeer].degradedPeers[worker1] = { now() - SERVER_KNOBS->CC_MIN_DEGRADATION_INTERVAL - 1,
+		                                                  now() };
+	data.workerHealth[badPeer].degradedPeers[worker2] = { now() - SERVER_KNOBS->CC_MIN_DEGRADATION_INTERVAL - 1,
+		                                                  now() };
+	data.workerHealth[badPeer].degradedPeers[worker3] = { now() - SERVER_KNOBS->CC_MIN_DEGRADATION_INTERVAL - 1,
+		                                                  now() };
+
+	// At this point, we should have 4 complaints total
+	ASSERT(data.workerHealth.contains(worker1));
+	ASSERT(data.workerHealth.contains(worker2));
+	ASSERT(data.workerHealth.contains(worker3));
+	ASSERT(data.workerHealth.contains(badPeer));
+	ASSERT(data.workerHealth.size() == 4);
+
+	// Compute degraded processes
+	data.degradationInfo = data.getDegradationInfo();
+	data.excludedDegradedServers = data.degradationInfo.degradedServers;
+
+	// Ensure badPeer is successfully added to excluded list
+	// At this point, recovery would also be triggered in a production setting
+	// We would also invalidate complaints by the excluded process at this point
+	ASSERT(data.degradationInfo.degradedServers.size() == 1);
+	ASSERT(data.degradationInfo.degradedServers.contains(badPeer));
+	invalidateExcludedProcessComplaints(&data);
+
+	// Now it's possible because of various factors (e.g. timing, expiration) that
+	// the complaints against badPeer disappear, but the initial complaints that badPeer
+	// made against others are still there.
+	data.workerHealth[worker1].degradedPeers.erase(badPeer);
+	data.workerHealth[worker2].degradedPeers.erase(badPeer);
+	data.workerHealth[worker3].degradedPeers.erase(badPeer);
+
+	// Compute degraded processes again
+	data.degradationInfo = data.getDegradationInfo();
+	data.excludedDegradedServers = data.degradationInfo.degradedServers;
+
+	if (SERVER_KNOBS->CC_INVALIDATE_EXCLUDED_PROCESSES) {
+		// With CC_INVALIDATE_EXCLUDE_PROCESSES, we should got 0 degraded processes
+		// because the original complaints by the now excluded badPeer were invalidated
+		ASSERT(data.degradationInfo.degradedServers.empty());
+	} else {
+		// However, without CC_INVALIDATE_EXCLUDE_PROCESSES, we would get 3 degraded processes
+		// which are: worker1, worker2, worker3. This is because we did not invalidate workerHealth
+		// to remove badPeer complaints when badPeer was excluded and recovery was triggered.
+		ASSERT(data.degradationInfo.degradedServers.size() == 3);
+		ASSERT(data.degradationInfo.degradedServers.contains(worker1));
+		ASSERT(data.degradationInfo.degradedServers.contains(worker2));
+		ASSERT(data.degradationInfo.degradedServers.contains(worker3));
+	}
 
 	return Void();
 }


### PR DESCRIPTION
Backport of #11749 to 7.3. This helps reduce the number of false positive recoveries caused by gray failure. 

100K Joshua: `20241220-220204-praza-ca639e469878f9980f8963f2e1e18114e5d6f2 compressed=True data_size=34270926 duration=5812375 ended=100000 fail_fast=100 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:56:11 sanity=False started=100000 stopped=20241220-225815 submitted=20241220-220204 timeout=5400 username=praza-ca639e469878f9980f8963f2e1e18114e5d6f2f8`

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
