### PR TITLE
Make `ByteArrayUtil#EMPTY_BYTES` public

### DIFF
--- a/bindings/java/src/main/com/apple/foundationdb/tuple/ByteArrayUtil.java
+++ b/bindings/java/src/main/com/apple/foundationdb/tuple/ByteArrayUtil.java
@@ -36,7 +36,10 @@ import com.apple.foundationdb.Transaction;
  *
  */
 public class ByteArrayUtil extends FastByteComparisons {
-	private static final byte[] EMPTY_BYTES = new byte[0];
+	/**
+	 * A zero-length byte array.
+	 */
+	public static final byte[] EMPTY_BYTES = new byte[0];
 
 	/**
 	 * Joins a set of byte arrays into a larger array. The {@code interlude} is placed


### PR DESCRIPTION
As a very, very modest suggestion, it might be nice to make `ByteArrayUtil#EMPTY_BYTES` public. Many use cases ([simple indices](https://apple.github.io/foundationdb/simple-indexes.html), for example) call for empty byte arrays, and having a static zero-length array available is handy. While users can certainly manage this bit of engineering on their own, it can be nice to have a named, centrally-located instance in a utility class that's clearly associated with FoundationDB.