### PR TITLE
A bug in the code that computes the (version vector) recovery version

### DIFF
--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -2170,7 +2170,9 @@ Optional<std::tuple<Version, Version>> getRecoverVersionUnicast(
 	//
 	// @todo modify code to use "minDV" as the default (starting) recovery version.
 	Version RV = maxKCV; // recovery version
-	std::vector<Version> RVs(maxTLogLocId + 1, maxKCV); // recovery versions of various tLogs
+	// @note we currently don't use "RVs", but we may use this information later (maybe for
+	// doing error checking). Commenting out the RVs related code for now.
+	// std::vector<Version> RVs(maxTLogLocId + 1, maxKCV); // recovery versions of various tLogs
 	Version prevVersion = maxKCV;
 	for (auto const& [version, tLogs] : versionAllTLogs) {
 		if (!(prevVersion == maxKCV || prevVersion == prevVersionMap[version])) {
@@ -2185,17 +2187,21 @@ Optional<std::tuple<Version, Version>> getRecoverVersionUnicast(
 		}
 		// If the commit proxy sent this version to "N" log servers then at least
 		// (N - replicationFactor + 1) log servers must be available.
-		if (!(versionAvailableTLogs[version].size() >= tLogs.size() - replicationFactor + 1)) {
+		if (!(versionAvailableTLogs[version].count() >= tLogs.count() - replicationFactor + 1)) {
 			break;
 		}
 		// Update RV.
 		RV = version;
+		/*
+		// @note We currently don't use "RVs", but we may use this information later (maybe for doing
+		// error checking). Commenting out this code for now.
 		// Update recovery version vector.
 		for (boost::dynamic_bitset<>::size_type id = 0; id < versionAvailableTLogs[version].size(); id++) {
-			if (versionAvailableTLogs[version][id]) {
-				RVs[id] = version;
-			}
+		    if (versionAvailableTLogs[version][id]) {
+		        RVs[id] = version;
+		    }
 		}
+		*/
 		// Update prevVersion.
 		prevVersion = version;
 	}


### PR DESCRIPTION
- The code was using "size()", instead of "count()", to find the number of bits set in a dynamic_bitset structure. Correct this.

Found this while going through this code in the context of another version vector recovery related issue. We can theorize that this issue could cause a version to be recovered even though not enough log servers that received this version are available during recovery.

- Comment out code that computes the recovery versions of individual log servers ("RVs") in "getRecoverVersionUnicast()" (this was a review comment in another PR). This information is not currently used, but we may use this information to do error checking later.

Testing:

Joshua job id (with version vector disabled): 20250102-101000-sre-8b17f3a3070c548a (in progress).

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
