### PR TITLE
Fix missing `bindingtester` dependency

### DIFF
--- a/cmake/AddFdbTest.cmake
+++ b/cmake/AddFdbTest.cmake
@@ -394,6 +394,7 @@ function(prepare_binding_test_files build_directory target_name target_dependenc
     COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:fdb_flow_tester> ${build_directory}/tests/flow/bin/fdb_flow_tester
     COMMENT "Copy Flow tester for bindingtester")
 
+  add_dependencies(${target_name} python_binding)
   set(generated_binding_files python/fdb/fdboptions.py python/fdb/apiversion.py)
   if(WITH_JAVA_BINDING)
     if(NOT FDB_RELEASE)


### PR DESCRIPTION
Something changed and `bindingtester` was trying to build before the Python bindings. Turns out there's no dependency between them.