### PR TITLE
Add checksum checking of downloads. Add cleanup of test data.

### DIFF
--- a/fdbclient/ClientKnobs.cpp
+++ b/fdbclient/ClientKnobs.cpp
@@ -248,6 +248,7 @@ void ClientKnobs::initialize(Randomize randomize) {
 
 	init( BLOBSTORE_MAX_DELAY_RETRYABLE_ERROR,      60  );
 	init( BLOBSTORE_MAX_DELAY_CONNECTION_FAILED,    10  );
+	init (BLOBSTORE_ENABLE_ETAG_ON_GET,             false );
 
 	init( BLOBSTORE_LIST_REQUESTS_PER_SECOND,       200 );
 	init( BLOBSTORE_WRITE_REQUESTS_PER_SECOND,       50 );

--- a/fdbclient/include/fdbclient/ClientKnobs.h
+++ b/fdbclient/include/fdbclient/ClientKnobs.h
@@ -256,7 +256,10 @@ public:
 	double BLOBSTORE_LATENCY_LOGGING_ACCURACY;
 	int BLOBSTORE_MAX_DELAY_RETRYABLE_ERROR;
 	int BLOBSTORE_MAX_DELAY_CONNECTION_FAILED;
-
+	bool BLOBSTORE_ENABLE_ETAG_ON_GET; // On download, compare the md5 of the downloaded object with the ETag of the
+	                                   // object in the cloud (etag is md5 of content). If they don't match, throw an
+	                                   // error. On upload, we do this always. It is optional for download because it
+	                                   // new behavior.
 	int CONSISTENCY_CHECK_RATE_LIMIT_MAX; // Available in both normal and urgent mode
 	int CONSISTENCY_CHECK_ONE_ROUND_TARGET_COMPLETION_TIME; // Available in normal mode
 	int CONSISTENCY_CHECK_URGENT_NEXT_WAIT_TIME; // Available in urgent mode

--- a/fdbclient/include/fdbclient/S3BlobStore.h
+++ b/fdbclient/include/fdbclient/S3BlobStore.h
@@ -146,7 +146,7 @@ public:
 		    delete_requests_per_second, multipart_max_part_size, multipart_min_part_size, concurrent_requests,
 		    concurrent_uploads, concurrent_lists, concurrent_reads_per_file, concurrent_writes_per_file,
 		    enable_read_cache, read_block_size, read_ahead_blocks, read_cache_blocks_per_file,
-		    max_send_bytes_per_second, max_recv_bytes_per_second, sdk_auth, global_connection_pool,
+		    max_send_bytes_per_second, max_recv_bytes_per_second, sdk_auth, enable_etag_on_get, global_connection_pool,
 		    max_delay_retryable_error, max_delay_connection_failed;
 
 		bool set(StringRef name, int value);
@@ -187,6 +187,7 @@ public:
 				"failure.",
 				"sdk_auth (or sa)                      Use AWS SDK to resolve credentials. Only valid if "
 				"BUILD_AWS_BACKUP is enabled.",
+				"enable_etag_on_get (or ceog)          Enable checksum (etag) check on GET requests (Default: false).",
 				"global_connection_pool (or gcp)       Enable shared connection pool between all blobstore instances."
 			};
 		}

--- a/fdbclient/include/fdbclient/S3Client.actor.h
+++ b/fdbclient/include/fdbclient/S3Client.actor.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <string>
 #if defined(NO_INTELLISENSE) && !defined(FDBCLIENT_S3CLIENT_ACTOR_G_H)
 #define FDBCLIENT_S3CLIENT_ACTOR_G_H
 #include "fdbclient/S3Client.actor.g.h"
@@ -58,6 +59,9 @@ ACTOR Future<Void> copyDownDirectory(std::string s3url, std::string dirpath);
 ACTOR Future<Void> copyUpBulkDumpFileSet(std::string s3url,
                                          BulkLoadFileSet sourceFileSet,
                                          BulkLoadFileSet destinationFileSet);
+
+// Delete the file or directory at s3url -- recursively.
+ACTOR Future<Void> deleteResource(std::string s3url);
 
 #include "flow/unactorcompiler.h"
 #endif

--- a/fdbclient/tests/s3client_test.sh
+++ b/fdbclient/tests/s3client_test.sh
@@ -65,8 +65,10 @@ function test_file_upload_and_download {
   local testfiledown="${dir}/testfile.down"
   date -Iseconds &> "${testfileup}"
   local blobstoreurl="blobstore://localhost:${port}/x/y/z?bucket=${BUCKET}&region=us&secure_connection=0"
-  "${s3client}" --knob_http_verbose_level=10 --log --logdir="${logsdir}" "${testfileup}" "${blobstoreurl}"
-  "${s3client}" --knob_http_verbose_level=10 --log --logdir="${logsdir}" "${blobstoreurl}" "${testfiledown}"
+  "${s3client}" rm --knob_http_verbose_level=10 --log --logdir="${logsdir}" "${blobstoreurl}"
+  "${s3client}" cp --knob_http_verbose_level=10 --log --logdir="${logsdir}" "${testfileup}" "${blobstoreurl}"
+  "${s3client}" cp --knob_http_verbose_level=10 --log --logdir="${logsdir}" "${blobstoreurl}" "${testfiledown}"
+  "${s3client}" rm --knob_http_verbose_level=10 --log --logdir="${logsdir}" "${blobstoreurl}"
   if ! diff "${testfileup}" "${testfiledown}"; then
     echo "ERROR: Test $0 failed; upload and download are not the same." >&2
     return 1
@@ -93,8 +95,10 @@ function test_dir_upload_and_download {
   mkdir "${testdirup}/subdir"
   date -Iseconds  &> "${testdirup}/subdir/three"
   local blobstoreurl="blobstore://localhost:${port}/dir1/dir2?bucket=${BUCKET}&region=us&secure_connection=0"
-  "${s3client}" --knob_http_verbose_level=10 --log --logdir="${logsdir}" "${testdirup}" "${blobstoreurl}"
-  "${s3client}" --knob_http_verbose_level=10 --log --logdir="${logsdir}" "${blobstoreurl}" "${testdirdown}"
+  "${s3client}" rm --knob_http_verbose_level=10 --log --logdir="${logsdir}" "${blobstoreurl}"
+  "${s3client}" cp --knob_http_verbose_level=10 --log --logdir="${logsdir}" "${testdirup}" "${blobstoreurl}"
+  "${s3client}" cp --knob_http_verbose_level=10 --log --logdir="${logsdir}" "${blobstoreurl}" "${testdirdown}"
+  "${s3client}" rm --knob_http_verbose_level=10 --log --logdir="${logsdir}" "${blobstoreurl}"
   if ! diff "${testdirup}" "${testdirdown}"; then
     echo "ERROR: Test $0 failed; upload and download are not the same." >&2
     return 1


### PR DESCRIPTION
* fdbclient/ClientKnobs.cpp
* fdbclient/include/fdbclient/ClientKnobs.h Add knob BLOBSTORE_ENABLE_ETAG_ON_GET

* fdbclient/S3BlobStore.actor.cpp Optionally check etag (md5) volunteered by s3 against the content we have downloaded and fail if not equal (TODO: check the checksum after we've saved the content to the filesystem --  would require  good bit of a refactoring).

* fdbclient/S3Client.actor.cpp Add deleteResource support.

* fdbclient/S3Client_cli.actor.cpp Add COMMAND support; currently either 'cp' or 'rm'. Set the knob blobstore_enable_etag_on_get to true by default for s3client.

* fdbclient/tests/s3client_test.sh Add clean up of resources written up to s3 at end of test. (Awkward in bash)

Replace this text with your description here...

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
