### PR TITLE
Have ctests use s3 if it is available.

### DIFF
--- a/contrib/SimpleOpt/include/SimpleOpt/SimpleOpt.h
+++ b/contrib/SimpleOpt/include/SimpleOpt/SimpleOpt.h
@@ -518,7 +518,9 @@ private:
 	}
 	bool IsEqual(SOCHAR a_cLeft, SOCHAR a_cRight, int a_nArgType) const;
 
-	inline void Copy(SOCHAR** ppDst, SOCHAR** ppSrc, int nCount) const {
+	// Disable ASAN in here. Its complaining memcpy-param-overlap when
+	// we shuffle the argv array by doing Copys in ShuffleArg.
+	__attribute__((no_sanitize("address"))) inline void Copy(SOCHAR** ppDst, SOCHAR** ppSrc, int nCount) const {
 #ifdef SO_MAX_ARGS
 		// keep our promise of no CLIB usage
 		while (nCount-- > 0)

--- a/fdbbackup/tests/s3_backup_test.sh
+++ b/fdbbackup/tests/s3_backup_test.sh
@@ -235,6 +235,9 @@ if [[ "${USE_S3}" == "true" ]]; then
   readonly blob_credentials_file="${configs[2]}"
   readonly region="${configs[3]}"
   query_str="bucket=${bucket}&region=${region}"
+  # Set available when the fdb cluster and the backup_agent starts.
+  export FDB_BLOB_CREDENTIALS="${blob_credentials_file}"
+  export FDB_TLS_CA_FILE="${TLS_CA_FILE}"
 else
   log "Testing against seaweedfs"
   # Now source in the seaweedfs fixture so we can use its methods in the below.
@@ -260,12 +263,6 @@ else
   # Let the connection to seaweed be insecure -- not-TLS -- because just awkward to set up.
   query_str="bucket=${bucket}&region=${region}&secure_connection=0"
 fi
-
-# Set these environment variables so they are available when the fdb cluster and the
-# backup_agent start.
-export FDB_TLS_CA_FILE="${TLS_CA_FILE}"
-#export FDB_TLS_VERIFY_PEERS="Check.Valid=0"
-export FDB_BLOB_CREDENTIALS="${blob_credentials_file}"
 
 # shellcheck source=/dev/null
 if ! source "${cwd}/../../fdbclient/tests/fdb_cluster_fixture.sh"; then

--- a/fdbbackup/tests/s3_backup_test.sh
+++ b/fdbbackup/tests/s3_backup_test.sh
@@ -247,11 +247,11 @@ if ! weed_binary_path="$(download_weed "${base_scratch_dir}")"; then
   exit 1
 fi
 readonly weed_binary_path
-if ! create_weed_dir "${SCRATCH_DIR}"; then
+if ! weed_dir=$( create_weed_dir "${SCRATCH_DIR}" ); then
   err "Failed to create the weed dir."
   exit 1
 fi
-if ! s3_port=$(start_weed "${weed_binary_path}"); then
+if ! s3_port=$(start_weed "${weed_binary_path}" "${weed_dir}" ); then
   err "failed start of weed server."
   exit 1
 fi

--- a/fdbclient/ClientKnobs.cpp
+++ b/fdbclient/ClientKnobs.cpp
@@ -248,7 +248,7 @@ void ClientKnobs::initialize(Randomize randomize) {
 
 	init( BLOBSTORE_MAX_DELAY_RETRYABLE_ERROR,      60  );
 	init( BLOBSTORE_MAX_DELAY_CONNECTION_FAILED,    10  );
-	init (BLOBSTORE_ENABLE_ETAG_ON_GET,             false );
+	init (BLOBSTORE_ENABLE_OBJECT_INTEGRITY_CHECK,false );
 
 	init( BLOBSTORE_LIST_REQUESTS_PER_SECOND,       200 );
 	init( BLOBSTORE_WRITE_REQUESTS_PER_SECOND,       50 );

--- a/fdbclient/S3BlobStore.actor.cpp
+++ b/fdbclient/S3BlobStore.actor.cpp
@@ -1865,7 +1865,7 @@ ACTOR Future<Void> writeEntireFileFromBuffer_impl(Reference<S3BlobStoreEndpoint>
 		headers["x-amz-checksum-sha256"] = contentHash;
 		headers["x-amz-checksum-algorithm"] = "SHA256";
 	} else {
-		headers["Content-MD5"] = contentMD5;
+		headers["Content-MD5"] = contentHash;
 	}
 	if (!CLIENT_KNOBS->BLOBSTORE_ENCRYPTION_TYPE.empty())
 		headers["x-amz-server-side-encryption"] = CLIENT_KNOBS->BLOBSTORE_ENCRYPTION_TYPE;

--- a/fdbclient/S3Client.actor.cpp
+++ b/fdbclient/S3Client.actor.cpp
@@ -88,9 +88,6 @@ ACTOR static Future<Void> copyUpFile(Reference<S3BlobStoreEndpoint> endpoint,
 	    .detail("bucket", bucket)
 	    .detail("resource", resource)
 	    .detail("size", content.size());
-	// On checksumming: The below writeEntireFile will md5 the content we pass in here
-	// and after upload, it will compare to the etag returned by s3. If they don't match,
-	// we fail the upload.
 	wait(endpoint->writeEntireFile(bucket, resource, content));
 	TraceEvent("S3ClientUpload")
 	    .detail("filepath", filepath)
@@ -174,9 +171,6 @@ ACTOR static Future<Void> copyDownFile(Reference<S3BlobStoreEndpoint> endpoint,
                                        std::string bucket,
                                        std::string resource,
                                        std::string filepath) {
-	// On checksumming: The below readEntireFile will check the etag if the
-	// knob blobstore_enable_etag_on_get is set. The default for the s3client is to
-	// check the etag against content. For backup, the default is not to check etag.
 	std::string content = wait(endpoint->readEntireFile(bucket, resource));
 	auto parent = std::filesystem::path(filepath).parent_path();
 	if (parent != "" && !std::filesystem::exists(parent)) {

--- a/fdbclient/include/fdbclient/ClientKnobs.h
+++ b/fdbclient/include/fdbclient/ClientKnobs.h
@@ -256,10 +256,17 @@ public:
 	double BLOBSTORE_LATENCY_LOGGING_ACCURACY;
 	int BLOBSTORE_MAX_DELAY_RETRYABLE_ERROR;
 	int BLOBSTORE_MAX_DELAY_CONNECTION_FAILED;
-	bool BLOBSTORE_ENABLE_ETAG_ON_GET; // On download, compare the md5 of the downloaded object with the ETag of the
-	                                   // object in the cloud (etag is md5 of content). If they don't match, throw an
-	                                   // error. On upload, we do this always. It is optional for download because it
-	                                   // new behavior.
+	bool
+	    BLOBSTORE_ENABLE_OBJECT_INTEGRITY_CHECK; // Enable integrity check of download. When not set, on upload, we
+	                                             // we volunteer an md5 of the content and upload will fail if our
+	                                             // md5 doesn't match that calculated by the server. When this flag
+	                                             // is set, we hash the content using sha256 and have the server store
+	                                             // the hash in the object metadata. On download, if this flag is set
+	                                             // we will check the serverside proffered hash against that we
+	                                             // calculate on the received content.  If no match, throw an error. See
+	                                             // https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html
+	                                             // (We can't depend on etags in the download because they are not the
+	                                             // md5 of the content when the upload uses encryption such as aws:kms)
 	int CONSISTENCY_CHECK_RATE_LIMIT_MAX; // Available in both normal and urgent mode
 	int CONSISTENCY_CHECK_ONE_ROUND_TARGET_COMPLETION_TIME; // Available in normal mode
 	int CONSISTENCY_CHECK_URGENT_NEXT_WAIT_TIME; // Available in urgent mode

--- a/fdbclient/include/fdbclient/S3BlobStore.h
+++ b/fdbclient/include/fdbclient/S3BlobStore.h
@@ -146,8 +146,8 @@ public:
 		    delete_requests_per_second, multipart_max_part_size, multipart_min_part_size, concurrent_requests,
 		    concurrent_uploads, concurrent_lists, concurrent_reads_per_file, concurrent_writes_per_file,
 		    enable_read_cache, read_block_size, read_ahead_blocks, read_cache_blocks_per_file,
-		    max_send_bytes_per_second, max_recv_bytes_per_second, sdk_auth, enable_etag_on_get, global_connection_pool,
-		    max_delay_retryable_error, max_delay_connection_failed;
+		    max_send_bytes_per_second, max_recv_bytes_per_second, sdk_auth, enable_object_integrity_check,
+		    global_connection_pool, max_delay_retryable_error, max_delay_connection_failed;
 
 		bool set(StringRef name, int value);
 		std::string getURLParameters() const;
@@ -187,7 +187,7 @@ public:
 				"failure.",
 				"sdk_auth (or sa)                      Use AWS SDK to resolve credentials. Only valid if "
 				"BUILD_AWS_BACKUP is enabled.",
-				"enable_etag_on_get (or ceog)          Enable checksum (etag) check on GET requests (Default: false).",
+				"enable_object_integrity_check (or eoic) Enable integrity check on GET requests (Default: false).",
 				"global_connection_pool (or gcp)       Enable shared connection pool between all blobstore instances."
 			};
 		}
@@ -406,7 +406,7 @@ public:
 	                                       std::string const& object,
 	                                       UnsentPacketQueue* pContent,
 	                                       int contentLen,
-	                                       std::string const& contentMD5);
+	                                       std::string const& contentHash);
 
 	// MultiPart upload methods
 	// Returns UploadID
@@ -418,7 +418,7 @@ public:
 	                               unsigned int partNumber,
 	                               UnsentPacketQueue* pContent,
 	                               int contentLen,
-	                               std::string const& contentMD5);
+	                               std::string const& contentHash);
 	typedef std::map<int, std::string> MultiPartSetT;
 	Future<Void> finishMultiPartUpload(std::string const& bucket,
 	                                   std::string const& object,

--- a/fdbclient/include/fdbclient/S3Client.actor.h
+++ b/fdbclient/include/fdbclient/S3Client.actor.h
@@ -20,13 +20,13 @@
 
 #pragma once
 
-#include <string>
 #if defined(NO_INTELLISENSE) && !defined(FDBCLIENT_S3CLIENT_ACTOR_G_H)
 #define FDBCLIENT_S3CLIENT_ACTOR_G_H
 #include "fdbclient/S3Client.actor.g.h"
 #elif !defined(FDBCLIENT_S3CLIENT_ACTOR_H)
 #define FDBCLIENT_S3CLIENT_ACTOR_H
 
+#include <string>
 #include "fdbclient/S3BlobStore.h"
 #include "fdbclient/BulkDumping.h"
 #include "flow/actorcompiler.h" // This must be the last #include.

--- a/fdbclient/tests/aws_fixture.sh
+++ b/fdbclient/tests/aws_fixture.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+#
+# Functions for dealing w/ aws/s3
+#
+
+# Cleanup any mess we've made. For calling from signal trap on exit.
+# $1 The aws scratch directory to clean up on exit.
+function shutdown_aws {
+  local scratch_dir="${1}"
+  if [[ -d "${scratch_dir}" ]]; then
+    rm -rf "${scratch_dir}"
+  fi
+}
+
+# Create directory for aws test to use writing temporary data.
+# Call shutdown_aws to clean up the directory created here for test.
+# $1 Directory where we want weed to write data and logs.
+# check $? error code on return.
+function create_aws_dir {
+  local dir="${1}"
+  local aws_dir
+  aws_dir=$(mktemp -d -p "${dir}" -t s3.XXXX)
+  # Exit if the temp directory wasn't created successfully.
+  if [[ ! -d "${aws_dir}" ]]; then
+    echo "ERROR: Failed create of aws  directory ${aws_dir}" >&2
+    return 1
+  fi
+  echo "${aws_dir}"
+}
+
+# Write out blob_credentials
+# $1 The token to use querying credentials
+# $2 Hostname going to aws
+# $3 The scratch dir to write the blob credentials file into
+# Echos the blob_credentials file path.
+function write_blob_credentials {
+  local token="${1}"
+  local local_host="${2}"
+  local dir="${3}"
+  if ! credentials=$( curl -H "X-aws-ec2-metadata-token: ${token}" \
+      http://169.254.169.254/latest/meta-data/iam/security-credentials/foundationdb-dev_node_instance_role ); then
+    echo "ERROR: Failed reading credentials"
+    return 1
+  fi
+  if ! blob_credentials_str=$( echo "${credentials}" | jq --arg host_arg "${local_host}" \
+      '{"accounts": { ($host_arg): {"api_key": .AccessKeyId, "secret": .SecretAccessKey, "token": .Token}}}'); then
+    echo "ERROR: Failed jq'ing ${blob_credentials_str}"
+    return 1
+  fi
+  readonly blob_credentials_file="${dir}/blob_credentials.json"
+  echo "${blob_credentials_str}" > "${blob_credentials_file}"
+  echo "${blob_credentials_file}"
+}
+
+# Check if curl is installed
+if ! command -v curl &> /dev/null; then
+  echo "ERROR: curl is not installed. Please install it to use this script." >&2
+  exit 1
+fi
+# Check if curl is installed
+if ! command -v openssl &> /dev/null; then
+  echo "ERROR: openssl is not installed. Please install it to use this script." >&2
+  exit 1
+fi
+# Check if jq is installed.
+if ! command -v jq &> /dev/null; then
+  echo "ERROR: jq is not installed. Please install it to use this script generating json credentials file." >&2
+  exit 1
+fi

--- a/fdbclient/tests/aws_fixture.sh
+++ b/fdbclient/tests/aws_fixture.sh
@@ -6,9 +6,9 @@
 # Cleanup any mess we've made. For calling from signal trap on exit.
 # $1 The aws scratch directory to clean up on exit.
 function shutdown_aws {
-  local scratch_dir="${1}"
-  if [[ -d "${scratch_dir}" ]]; then
-    rm -rf "${scratch_dir}"
+  local local_scratch_dir="${1}"
+  if [[ -d "${local_scratch_dir}" ]]; then
+    rm -rf "${local_scratch_dir}"
   fi
 }
 

--- a/fdbclient/tests/aws_fixture.sh
+++ b/fdbclient/tests/aws_fixture.sh
@@ -40,7 +40,7 @@ function shutdown_aws {
 function create_aws_dir {
   local dir="${1}"
   local aws_dir
-  aws_dir=$(mktemp -d -p "${dir}" -t s3.XXXX)
+  aws_dir=$(mktemp -d -p "${dir}" -t s3.$$.XXXX)
   # Exit if the temp directory wasn't created successfully.
   if [[ ! -d "${aws_dir}" ]]; then
     echo "ERROR: Failed create of aws  directory ${aws_dir}" >&2
@@ -81,6 +81,8 @@ function write_blob_credentials {
 function aws_setup {
   local local_aws_dir="${1}"
   # Fetch token, region, etc. from our aws environment.
+  # On 169.254.169.254, see
+  # https://www.baeldung.com/linux/cloud-ip-meaning#169254169254-and-other-link-local-addresses-on-the-cloud
   if ! imdsv2_token=$(curl -X PUT "http://169.254.169.254/latest/api/token" \
       -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"); then
     err "Failed reading token"

--- a/fdbclient/tests/aws_fixture.sh
+++ b/fdbclient/tests/aws_fixture.sh
@@ -2,6 +2,27 @@
 #
 # Functions for dealing w/ aws/s3
 #
+# Here is how to use this fixture:
+#  # First source this fixture.
+#  if ! source "${cwd}/aws_fixture.sh"; then
+#    err "Failed to source aws_fixture.sh"
+#    exit 1
+#  fi
+#  # Save off the return from create_aws_dir. You'll need it for shutdown.
+#  if ! TEST_SCRATCH_DIR=$( create_aws_dir "${scratch_dir}" ); then
+#    err "Failed creating local aws_dir"
+#    exit 1
+#  fi
+#  readonly TEST_SCRATCH_DIR
+#  if ! readarray -t configs < <(aws_setup "${TEST_SCRATCH_DIR}"); then
+#    err "Failed aws_setup"
+#    return 1
+#  fi
+#  readonly host="${configs[0]}"
+#  ...etc.
+#  # When done, call shutdown_aws
+#  shutdown_aws "${TEST_SCRATCH_DIR}"
+#
 
 # Cleanup any mess we've made. For calling from signal trap on exit.
 # $1 The aws scratch directory to clean up on exit.
@@ -52,6 +73,56 @@ function write_blob_credentials {
   echo "${blob_credentials_file}"
 }
 
+
+# Set up s3 access.
+# $1 aws_dir (This is what is returned when you call create_aws_dir
+# so call it first).
+# Returns array of configurations to use contacting s3.
+function aws_setup {
+  local local_aws_dir="${1}"
+  # Fetch token, region, etc. from our aws environment.
+  if ! imdsv2_token=$(curl -X PUT "http://169.254.169.254/latest/api/token" \
+      -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"); then
+    err "Failed reading token"
+    exit 1
+  fi
+  readonly imdsv2_token
+  if ! region=$( curl -H "X-aws-ec2-metadata-token: ${imdsv2_token}" \
+      "http://169.254.169.254/latest/meta-data/placement/region"); then
+    err "Failed reading region"
+    exit 1
+  fi
+  readonly region
+  if ! account_id=$( aws --output text sts get-caller-identity --query 'Account' ); then
+    err "Failed reading account id"
+    exit 1
+  fi
+  readonly account_id
+  readonly bucket="backup-${account_id}-${region}"
+  # Add the '@' in front so we force reading of credentials file when s3
+  # When we do lookup for credentials, we don't expect a port but it is expected later going via proxy.
+  readonly host="@s3.${region}.amazonaws.com"
+  if ! blob_credentials_file=$(write_blob_credentials "${imdsv2_token}" "${host}" "${local_aws_dir}"); then
+    err "Failed to write credentials file"
+    exit 1
+  fi
+  results_array=("${host}" "${bucket}" "${blob_credentials_file}" "${region}")
+  printf "%s\n" "${results_array[@]}"
+}
+
+# Check bash version. We require 4.0 or greater. Mac os x is old -- 3.x.
+if ((BASH_VERSINFO[0] < 4)); then
+    echo "Error: This script requires Bash 4.0 or newer." >&2
+    echo "Current version: $BASH_VERSION" >&2
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        echo "On macOS, you can install a newer version of Bash using Homebrew:" >&2
+        echo "    brew install bash" >&2
+        echo "Then change your shell:" >&2
+        echo "    sudo bash -c 'echo /usr/local/bin/bash >> /etc/shells'" >&2
+        echo "    chsh -s /usr/local/bin/bash" >&2
+    fi
+    exit 1
+fi
 # Check if curl is installed
 if ! command -v curl &> /dev/null; then
   echo "ERROR: curl is not installed. Please install it to use this script." >&2

--- a/fdbclient/tests/bulkload_test.sh
+++ b/fdbclient/tests/bulkload_test.sh
@@ -138,19 +138,6 @@ function test_basic_bulkdump_and_bulkload {
   fi
 }
 
-# Log pass or fail.
-# $1 Test errcode
-# $2 Test name
-function log_test_result {
-  local test_errcode=$1
-  local test_name=$2
-  if (( "${test_errcode}" == 0 )); then
-    log "PASSED ${test_name}"
-  else
-    log "FAILED ${test_name}"
-  fi
-}
-
 # Get the working directory for this script.
 if ! path=$(resolve_to_absolute_path "${BASH_SOURCE[0]}"); then
   err "Failed resolve_to_absolute_path"
@@ -161,6 +148,7 @@ if ! cwd=$( cd -P "$( dirname "${path}" )" >/dev/null 2>&1 && pwd ); then
   exit 1
 fi
 readonly cwd
+
 # Source in the fdb cluster, tests_common, and seaweedfs fixtures.
 # shellcheck source=/dev/null
 if ! source "${cwd}/seaweedfs_fixture.sh"; then
@@ -229,11 +217,11 @@ if ! weed_binary_path="$(download_weed "${base_scratch_dir}")"; then
   exit 1
 fi
 readonly weed_binary_path
-if ! create_weed_dir "${SCRATCH_DIR}"; then
+if ! weed_dir=$( create_weed_dir "${SCRATCH_DIR}" ); then
   err "Failed to create the weed dir."
   exit 1
 fi
-if ! s3_port=$(start_weed "${weed_binary_path}"); then
+if ! s3_port=$(start_weed "${weed_binary_path}" "${weed_dir}" ); then
   err "failed start of weed server."
   exit 1
 fi

--- a/fdbclient/tests/bulkload_test.sh
+++ b/fdbclient/tests/bulkload_test.sh
@@ -248,7 +248,7 @@ if false; then
   readonly TEST_SCRATCH_DIR
   if ! readarray -t configs < <(aws_setup "${TEST_SCRATCH_DIR}"); then
     err "Failed aws_setup"
-    return 1
+    exit 1
   fi
   readonly host="${configs[0]}"
   readonly bucket="${configs[1]}"
@@ -268,12 +268,12 @@ else
   fi
   if ! TEST_SCRATCH_DIR=$(create_weed_dir "${scratch_dir}"); then
     err "Failed create of the weed dir." >&2
-    return 1
+    exit 1
   fi
   readonly TEST_SCRATCH_DIR
   if ! host=$( run_weed "${scratch_dir}" "${TEST_SCRATCH_DIR}"); then
     err "Failed to run seaweed"
-    return 1
+    exit 1
   fi
   readonly host
   readonly bucket="${SEAWEED_BUCKET}"

--- a/fdbclient/tests/fdb_cluster_fixture.sh
+++ b/fdbclient/tests/fdb_cluster_fixture.sh
@@ -70,13 +70,15 @@ function start_fdb_cluster {
 # Start backup_agent
 # $1 The build dir.
 # $2 The scratch dir.
+# $@ List of knobs to pass
 function start_backup_agent {
   local local_build_dir="${1}"
   local local_scratch_dir="${2}"
+  shift 2
   "${local_build_dir}/bin/backup_agent" \
     -C "${local_scratch_dir}/loopback_cluster/fdb.cluster" \
     --log --logdir="${local_scratch_dir}" \
-    --knob_http_verbose_level=10 &
+    ${@} &
   local pid=$!
   if ! ps -p "${pid}" &> /dev/null; then
     wait "${pid}"

--- a/fdbclient/tests/fdb_cluster_fixture.sh
+++ b/fdbclient/tests/fdb_cluster_fixture.sh
@@ -25,8 +25,8 @@ function shutdown_fdb_cluster {
 function start_fdb_cluster {
   local local_source_dir="${1}"
   local local_build_dir="${2}"
-  local scratch_dir="${3}"
-  local output="${scratch_dir}/output.$$.txt"
+  local local_scratch_dir="${3}"
+  local output="${local_scratch_dir}/output.$$.txt"
   local port_prefix=1500
   while : ; do
     port_prefix="$(( port_prefix + 100 ))"
@@ -35,7 +35,7 @@ function start_fdb_cluster {
     # 'process substitution'; piping to tee hangs on success..
     set +o errexit  # a.k.a. set +e
     set +o noclobber
-    LOOPBACK_DIR="${scratch_dir}/loopback_cluster" PORT_PREFIX="${port_prefix}" \
+    LOOPBACK_DIR="${local_scratch_dir}/loopback_cluster" PORT_PREFIX="${port_prefix}" \
       "${local_source_dir}/tests/loopback_cluster/run_custom_cluster.sh" \
       "${local_build_dir}" \
       --knobs "--knob_shard_encode_location_metadata=true" \
@@ -51,7 +51,7 @@ function start_fdb_cluster {
     if (( status == 0 )); then
       # Give the db a second to come healthy.
       sleep 1
-      if ! "${local_build_dir}/bin/fdbcli" -C "${scratch_dir}/loopback_cluster/fdb.cluster" --exec status; then
+      if ! "${local_build_dir}/bin/fdbcli" -C "${local_scratch_dir}/loopback_cluster/fdb.cluster" --exec status; then
         err "Client failed to obtain healthy status"
         return 1
       fi
@@ -72,10 +72,10 @@ function start_fdb_cluster {
 # $2 The scratch dir.
 function start_backup_agent {
   local local_build_dir="${1}"
-  local scratch_dir="${2}"
+  local local_scratch_dir="${2}"
   "${local_build_dir}/bin/backup_agent" \
-    -C "${scratch_dir}/loopback_cluster/fdb.cluster" \
-    --log --logdir="${scratch_dir}" \
+    -C "${local_scratch_dir}/loopback_cluster/fdb.cluster" \
+    --log --logdir="${local_scratch_dir}" \
     --knob_http_verbose_level=10 &
   local pid=$!
   if ! ps -p "${pid}" &> /dev/null; then

--- a/fdbclient/tests/s3client_test.sh
+++ b/fdbclient/tests/s3client_test.sh
@@ -184,9 +184,7 @@ function test_dir_upload_and_download {
   fi
 }
 
-# Some copied from down the page on
-# https://stackoverflow.com/questions/192249/how-do-i-parse-command-line-arguments-in-bash
-# set -o xtrace   # a.k.a set -x
+# set -o xtrace   # a.k.a set -x  # Set this one when debugging (or 'bash -x THIS_SCRIPT').
 set -o errexit  # a.k.a. set -e
 set -o nounset  # a.k.a. set -u
 set -o pipefail

--- a/fdbclient/tests/s3client_test.sh
+++ b/fdbclient/tests/s3client_test.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 #
-# Start a weed server and then run tests of the s3client
-# command line tool against it (which uses S3Cp.actor.cpp).
-# For use by ctest. seaweed server takes about 25
-# seconds to come up. Tests run for a few seconds after that.
+# Run s3client against s3 if available or else against a seaweed instance.
+# Seaweed server takes about 25 seconds to come up. Tests run for a few seconds after that.
 #
-# Used https://www.shellcheck.net/, https://bertvv.github.io/cheat-sheets/Bash.html,
-# and https://bertvv.github.io/cheat-sheets/Bash.html
+
+# Globals
+
+# TEST_SCRATCH_DIR gets set below. Tests should be their data in here.
+# It gets cleaned up on the way out of the test.
+TEST_SCRATCH_DIR=
 
 # Some copied from down the page on
 # https://stackoverflow.com/questions/192249/how-do-i-parse-command-line-arguments-in-bash
@@ -16,73 +18,117 @@ set -o nounset  # a.k.a. set -u
 set -o pipefail
 set -o noclobber
 
-# From https://stackoverflow.com/questions/59895/how-can-i-get-the-source-directory-of-a-bash-script-from-within-the-script-itsel
-source=${BASH_SOURCE[0]}
-while [[ -h "${source}" ]]; do # resolve $source until the file is no longer a symlink
-  dir=$( cd -P "$( dirname "${source}" )" >/dev/null 2>&1 && pwd )
-  source=$(readlink "${source}")
-  [[ ${source} != /* ]] && source="${dir}/${source}" # if $source was a relative symlink, we need to resolve it relative to the path where the symlink file was located
-done
-cwd=$( cd -P "$( dirname "${source}" )" >/dev/null 2>&1 && pwd )
-# Now source in the seaweedfs fixture so we can use its methods in the below.
-# shellcheck source=/dev/null
-source "${cwd}/seaweedfs_fixture.sh"
-
-# Globals that get set below and are used when we cleanup.
-# Use one bucket only for all tests. More buckets means
-# we need more volumes which can be an issue when little
-# diskspace.
-readonly BUCKET="${S3_BUCKET:-testbucket}"
-
 # Make sure cleanup on script exit.
 trap "exit 1" HUP INT PIPE QUIT TERM
 trap cleanup  EXIT
 
 # Cleanup. Called from signal trap.
 function cleanup {
-  shutdown_weed
+  if type shutdown_weed &> /dev/null; then
+    shutdown_weed "${TEST_SCRATCH_DIR}"
+  fi
+  if type shutdown_aws &> /dev/null; then
+    : #shutdown_aws "${TEST_SCRATCH_DIR}"
+  fi
 }
 
-# Log a message to STDOUT with timestamp prefix
-# $1 message to log
-function log {
-  printf "%s %s\n" "$(date -Iseconds)" "${1}"
+# Resolve passed in reference to an absolute path.
+# e.g. /tmp on mac is actually /private/tmp.
+# $1 path to resolve
+function resolve_to_absolute_path {
+  local p="${1}"
+  local dir
+  while [[ -h "${p}" ]]; do
+    dir=$( cd -P "$( dirname "${p}" )" >/dev/null 2>&1 && pwd )
+    p=$(readlink "${p}")
+    [[ ${p} != /* ]] && p="${dir}/${p}"
+  done
+  realpath "${p}"
 }
 
 # Test file upload and download
-# $1 The port on localhost where seaweed s3 is running.
+# $1 The url to go against
 # $2 Directory I can write test files in.
-# $3 The s3client binary.
+# $3 credentials file
+# $4 The s3client binary.
 function test_file_upload_and_download {
-  local port="${1}"
+  local url="${1}"
   local dir="${2}"
-  local s3client="${3}"
-  local logsdir="${2}/logs"
+  local credentials="${3}"
+  local s3client="${4}"
+  local logsdir="${dir}/logs"
   if [[ ! -d "${logsdir}" ]]; then
     mkdir "${logsdir}"
   fi
   local testfileup="${dir}/testfile.up"
   local testfiledown="${dir}/testfile.down"
   date -Iseconds &> "${testfileup}"
-  local blobstoreurl="blobstore://localhost:${port}/x/y/z?bucket=${BUCKET}&region=us&secure_connection=0"
-  "${s3client}" rm --knob_http_verbose_level=10 --log --logdir="${logsdir}" "${blobstoreurl}"
-  "${s3client}" cp --knob_http_verbose_level=10 --log --logdir="${logsdir}" "${testfileup}" "${blobstoreurl}"
-  "${s3client}" cp --knob_http_verbose_level=10 --log --logdir="${logsdir}" "${blobstoreurl}" "${testfiledown}"
-  "${s3client}" rm --knob_http_verbose_level=10 --log --logdir="${logsdir}" "${blobstoreurl}"
+  if ! "${s3client}" \
+      --knob_http_verbose_level=10 \
+      --knob_blobstore_encryption_type=aws:kms \
+      --tls-ca-file /etc/ssl/cert.pem \
+      --tls-certificate-file "${dir}/cert.pem" \
+      --tls-key-file "${dir}/key.pem" \
+      --blob-credentials "${credentials}" \
+      --log --logdir "${logsdir}" \
+      rm "${url}"; then
+    err "Failed rm of ${url}"
+    return 1
+  fi
+  if ! "${s3client}" \
+      --knob_http_verbose_level=10 \
+      --knob_blobstore_encryption_type=aws:kms \
+      --tls-ca-file /etc/ssl/cert.pem \
+      --tls-certificate-file "${dir}/cert.pem" \
+      --tls-key-file "${dir}/key.pem" \
+      --blob-credentials "${credentials}" \
+      --log --logdir "${logsdir}" \
+      cp "${testfileup}" "${url}"; then
+    err "Failed cp of ${testfileup} to ${url}"
+    return 1
+  fi
+  if ! "${s3client}" \
+      --knob_http_verbose_level=10 \
+      --knob_blobstore_encryption_type=aws:kms \
+      --tls-ca-file /etc/ssl/cert.pem \
+      --tls-certificate-file "${dir}/cert.pem" \
+      --tls-key-file "${dir}/key.pem" \
+      --blob-credentials "${credentials}" \
+      --log --logdir "${logsdir}" \
+      cp "${url}" "${testfiledown}"; then
+    err "Failed cp ${url} ${testfiledown}"
+    return 1
+  fi
+  if ! "${s3client}" \
+      --knob_http_verbose_level=10 \
+      --knob_blobstore_encryption_type=aws:kms \
+      --tls-ca-file /etc/ssl/cert.pem \
+      --tls-certificate-file "${dir}/cert.pem" \
+      --tls-key-file "${dir}/key.pem" \
+      --blob-credentials "${credentials}" \
+      --log --logdir "${logsdir}" \
+      rm "${url}"; then
+    err "Failed rm ${url}"
+    return 1
+  fi
+  cat "${testfileup}"
+  cat "${testfiledown}"
   if ! diff "${testfileup}" "${testfiledown}"; then
-    echo "ERROR: Test $0 failed; upload and download are not the same." >&2
+    err "ERROR: Test $0 failed; upload and download are not the same." >&2
     return 1
   fi
 }
 
 # Test dir upload and download
-# $1 The port on localhost where seaweed s3 is running.
+# $1 The url to go against
 # $2 Directory I can write test file in.
-# $3 The s3client binary.
+# $3 credentials file
+# $4 The s3client binary.
 function test_dir_upload_and_download {
-  local port="${1}"
+  local url="${1}"
   local dir="${2}"
-  local s3client="${3}"
+  local credentials="${3}"
+  local s3client="${4}"
   local logsdir="${2}/logs"
   if [[ ! -d "${logsdir}" ]]; then
     mkdir "${logsdir}"
@@ -94,30 +140,76 @@ function test_dir_upload_and_download {
   date -Iseconds &> "${testdirup}/two"
   mkdir "${testdirup}/subdir"
   date -Iseconds  &> "${testdirup}/subdir/three"
-  local blobstoreurl="blobstore://localhost:${port}/dir1/dir2?bucket=${BUCKET}&region=us&secure_connection=0"
-  "${s3client}" rm --knob_http_verbose_level=10 --log --logdir="${logsdir}" "${blobstoreurl}"
-  "${s3client}" cp --knob_http_verbose_level=10 --log --logdir="${logsdir}" "${testdirup}" "${blobstoreurl}"
-  "${s3client}" cp --knob_http_verbose_level=10 --log --logdir="${logsdir}" "${blobstoreurl}" "${testdirdown}"
-  "${s3client}" rm --knob_http_verbose_level=10 --log --logdir="${logsdir}" "${blobstoreurl}"
+  if ! "${s3client}" \
+      --knob_http_verbose_level=10 \
+      --knob_blobstore_encryption_type=aws:kms \
+      --tls-ca-file /etc/ssl/cert.pem \
+      --tls-certificate-file "${dir}/cert.pem" \
+      --tls-key-file "${dir}/key.pem" \
+      --blob-credentials "${credentials}" \
+      --log --logdir "${logsdir}" \
+      rm "${url}"; then
+    err "Failed rm ${url}"
+    return 1
+  fi
+  if ! "${s3client}" \
+      --knob_http_verbose_level=10 \
+      --knob_blobstore_encryption_type=aws:kms \
+      --tls-ca-file /etc/ssl/cert.pem \
+      --tls-certificate-file "${dir}/cert.pem" \
+      --tls-key-file "${dir}/key.pem" \
+      --blob-credentials "${credentials}" \
+      --log --logdir "${logsdir}" \
+      cp "${testdirup}" "${url}"; then
+    err "Failed cp ${testdirup}"
+    return 1
+  fi
+  if ! "${s3client}" \
+      --knob_http_verbose_level=10 \
+      --knob_blobstore_encryption_type=aws:kms \
+      --tls-ca-file /etc/ssl/cert.pem \
+      --tls-certificate-file "${dir}/cert.pem" \
+      --tls-key-file "${dir}/key.pem" \
+      --blob-credentials "${credentials}" \
+      --log --logdir "${logsdir}" \
+      cp "${url}" "${testdirdown}"; then
+    err "Failed cp ${url}"
+    return 1
+  fi
+  if ! "${s3client}" \
+      --knob_http_verbose_level=10 \
+      --knob_blobstore_encryption_type=aws:kms \
+      --tls-ca-file /etc/ssl/cert.pem \
+      --tls-certificate-file "${dir}/cert.pem" \
+      --tls-key-file "${dir}/key.pem" \
+      --blob-credentials "${credentials}" \
+      --log --logdir "${logsdir}" \
+      rm "${url}"; then
+    err "Failed rm ${url}"
+    return 1
+  fi
   if ! diff "${testdirup}" "${testdirdown}"; then
-    echo "ERROR: Test $0 failed; upload and download are not the same." >&2
+    err "ERROR: Test $0 failed; upload and download are not the same." >&2
     return 1
   fi
 }
 
-# Log pass or fail.
-# $1 Test errcode
-# $2 Test name
-function log_test_result {
-  local test_errcode=$1
-  local test_name=$2
-  if (( "${test_errcode}" == 0 )); then
-    log "PASSED ${test_name}"
-  else
-    log "FAILED ${test_name}"
-  fi
-}
+# Get the working directory for this script.
+if ! path=$(resolve_to_absolute_path "${BASH_SOURCE[0]}"); then
+  err "Failed resolve_to_absolute_path"
+  exit 1
+fi
+if ! cwd=$( cd -P "$( dirname "${path}" )" >/dev/null 2>&1 && pwd ); then
+  err "Failed dirname on ${path}"
+  exit 1
+fi
+readonly cwd
 
+# shellcheck source=/dev/null
+if ! source "${cwd}/tests_common.sh"; then
+  err "Failed to source tests_common.sh"
+  exit 1
+fi
 # Process command-line options.
 if (( $# < 1 )) || (( $# > 2 )); then
     echo "ERROR: ${0} requires the fdb build directory -- CMAKE_BUILD_DIR -- as its"
@@ -128,7 +220,7 @@ if (( $# < 1 )) || (( $# > 2 )); then
 fi
 readonly build_dir="${1}"
 if [[ ! -d "${build_dir}" ]]; then
-  echo "ERROR: ${build_dir} is not a directory" >&2
+  err "${build_dir} is not a directory" >&2
   exit 1
 fi
 scratch_dir="${TMPDIR:-/tmp}"
@@ -136,27 +228,103 @@ if (( $# == 2 )); then
   scratch_dir="${2}"
 fi
 
-# Download seaweed.
-if ! weed_binary_path="$(download_weed "${scratch_dir}")"; then
-  echo "ERROR: failed download of weed binary." >&2
-  exit 1
+# Set host, bucket, and blob_credentials_file whether seaweed or s3.
+host=
+query_str=
+blob_credentials_file=
+path_prefix=
+if [[ -n "${OKTETO_NAMESPACE+x}" ]]; then
+  # Now source in the aws fixture so we can use its methods in the below.
+  # shellcheck source=/dev/null
+  if ! source "${cwd}/aws_fixture.sh"; then
+    err "Failed to source aws_fixture.sh"
+    exit 1
+  fi
+  if ! TEST_SCRATCH_DIR=$( create_aws_dir "${scratch_dir}" ); then
+    err "Failed creating local aws_dir"
+    exit 1
+  fi
+  readonly TEST_SCRATCH_DIR
+  # Get a pem and cert file for TLS to use (Connection needs to be secure when
+  # going to S3 w/ blobstore_encryption_type=aws:kms. For seaweed we do an
+  # insecure connnection (The TLS args are ignored) just because it is a little
+  # awkward running TLS seaweedfs server. Downloading rather than
+  # generating pem and cert for now because running openssl generation fails in our dev env
+  # with 'DSO support routines:DSO_load:could not load the shared library:crypto/dso/dso_lib.c:162:'
+  curl https://raw.githubusercontent.com/FoundationDB/fdb-kubernetes-operator/refs/heads/main/config/test-certs/cert.pem \
+      -o "${TEST_SCRATCH_DIR}/cert.pem"
+  curl https://raw.githubusercontent.com/FoundationDB/fdb-kubernetes-operator/refs/heads/main/config/test-certs/key.pem \
+      -o "${TEST_SCRATCH_DIR}/key.pem"
+  # Fetch token, region, etc. from our aws environment.
+  if ! imdsv2_token=$(curl -X PUT "http://169.254.169.254/latest/api/token" \
+      -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"); then
+    err "Failed reading token"
+    exit 1
+  fi
+  readonly imdsv2_token
+  if ! region=$( curl -H "X-aws-ec2-metadata-token: ${imdsv2_token}" \
+      "http://169.254.169.254/latest/meta-data/placement/region"); then
+    err "Failed reading region"
+    exit 1
+  fi
+  readonly region
+  if ! account_id=$( aws --output text sts get-caller-identity --query 'Account' ); then
+    err "Failed reading account id"
+    exit 1
+  fi
+  readonly account_id
+  readonly bucket="backup-${account_id}-${region}"
+  # Add the '@' in front so we force reading of credentials file when s3
+  readonly host="@${bucket}.s3.amazonaws.com"
+  if ! blob_credentials_file=$(write_blob_credentials "${imdsv2_token}" "${host}" "${TEST_SCRATCH_DIR}"); then
+    err "Failed to write credentials file"
+    exit 1
+  fi
+  readonly blob_credentials_file
+  # bulkload is where we can write to in apple dev
+  readonly path_prefix="bulkload/test"
+  query_str="bucket=${bucket}&region=${region}"
+else
+  # Now source in the seaweedfs fixture so we can use its methods in the below.
+  # shellcheck source=/dev/null
+  if ! source "${cwd}/seaweedfs_fixture.sh"; then
+    err "Failed to source seaweedfs_fixture.sh"
+    exit 1
+  fi
+  # Download seaweed.
+  if ! weed_binary_path="$(download_weed "${scratch_dir}")"; then
+    err "failed download of weed binary." >&2
+    exit 1
+  fi
+  readonly weed_binary_path
+  # Here we create a tmpdir to hold seaweed logs and data in global WEED_DIR hosted
+  # by seaweedfs_fixture.sh which we sourced above. Call shutdown_weed to clean up.
+  if ! TEST_SCRATCH_DIR=$( create_weed_dir "${scratch_dir}" ); then
+    err "failed create of the weed dir." >&2
+    exit 1
+  fi
+  readonly TEST_SCRATCH_DIR
+  log "Starting seaweed..."
+  if ! s3_port=$(start_weed "${weed_binary_path}" "${TEST_SCRATCH_DIR}"); then
+    err "failed start of weed server." >&2
+    exit 1
+  fi
+  readonly host="localhost:${s3_port}"
+  readonly bucket="${SEAWEED_BUCKET}"
+  readonly region="us"
+  # Reference a non-existent blob file (its ignored by seaweed)
+  readonly blob_credentials_file="${TEST_SCRATCH_DIR}/blob_credentials.json"
+  # Let the connection to seaweed be insecure -- not-TLS -- because just awkward to set up.
+  query_str="bucket=${bucket}&region=${region}&secure_connection=0"
 fi
-readonly weed_binary_path
-if ! create_weed_dir "${scratch_dir}"; then
-  echo "ERROR: failed create of the weed dir." >&2
-  exit 1
-fi
-log "Starting seaweed..."
-if ! s3_port=$(start_weed "${weed_binary_path}"); then
-  echo "ERROR: failed start of weed server." >&2
-  exit 1
-fi
-readonly s3_port
-log "Seaweed server is up; s3.port=${s3_port}"
 
-# Seaweed is up. Run some tests. 
-test_file_upload_and_download "${s3_port}" "${WEED_DIR}" "${build_dir}/bin/s3client"
-log_test_result $? "test_file_upload_and_download"
+# Run tests.
+test="test_file_upload_and_download"
+url="blobstore://${host}/${path_prefix}/${test}?${query_str}"
+test_file_upload_and_download "${url}" "${TEST_SCRATCH_DIR}" "${blob_credentials_file}" "${build_dir}/bin/s3client"
+log_test_result $? "${test}"
 
-test_dir_upload_and_download "${s3_port}" "${WEED_DIR}" "${build_dir}/bin/s3client"
-log_test_result $? "test_dir_upload_and_download"
+test="test_dir_upload_and_download"
+url="blobstore://${host}/${path_prefix}/${test}?${query_str}"
+test_dir_upload_and_download "${url}" "${TEST_SCRATCH_DIR}" "${blob_credentials_file}" "${build_dir}/bin/s3client"
+log_test_result $? "${test}"

--- a/fdbclient/tests/s3client_test.sh
+++ b/fdbclient/tests/s3client_test.sh
@@ -258,7 +258,7 @@ if [[ "${USE_S3}" == "true" ]]; then
   readonly TEST_SCRATCH_DIR
   if ! readarray -t configs < <(aws_setup "${TEST_SCRATCH_DIR}"); then
     err "Failed aws_setup"
-    return 1
+    exit 1
   fi
   readonly host="${configs[0]}"
   readonly bucket="${configs[1]}"
@@ -276,12 +276,12 @@ else
   fi
   if ! TEST_SCRATCH_DIR=$(create_weed_dir "${scratch_dir}"); then
     err "Failed create of the weed dir." >&2
-    return 1
+    exit 1
   fi
   readonly TEST_SCRATCH_DIR
   if ! host=$( run_weed "${scratch_dir}" "${TEST_SCRATCH_DIR}"); then
     err "Failed to run seaweed"
-    return 1
+    exit 1
   fi
   readonly host
   readonly bucket="${SEAWEED_BUCKET}"

--- a/fdbclient/tests/seaweedfs_fixture.sh
+++ b/fdbclient/tests/seaweedfs_fixture.sh
@@ -13,15 +13,15 @@ export SEAWEED_BUCKET
 
 # Cleanup the mess we've made. For calling from signal trap on exit.
 function shutdown_weed {
-  local scratch_dir="${1}"
-  if [[ -f "${scratch_dir}/weed.pid" ]]; then
+  local local_scratch_dir="${1}"
+  if [[ -f "${local_scratch_dir}/weed.pid" ]]; then
     # KILL! If we send SIGTERM, seaweedfs hangs out
     # ten seconds before shutting down (could config.
     # time but just kill it -- there is no state to save).
-    kill -9 $(cat "${scratch_dir}/weed.pid")
+    kill -9 $(cat "${local_scratch_dir}/weed.pid")
   fi
-  if [[ -d "${scratch_dir}" ]]; then
-    rm -rf "${scratch_dir}"
+  if [[ -d "${local_scratch_dir}" ]]; then
+    rm -rf "${local_scratch_dir}"
   fi
 }
 

--- a/fdbclient/tests/seaweedfs_fixture.sh
+++ b/fdbclient/tests/seaweedfs_fixture.sh
@@ -170,7 +170,9 @@ function start_weed {
       sleep 5
     done
     # The process died. If it was because of port clash, go around again w/ new ports.
-    if grep "bind: address already in use" "${dir}/weed.INFO" &> /dev/null ; then
+    # You'll see errors like this:
+    # F0115 05:22:28.312464 master.go:166 Master startup error: listen tcp 127.0.0.1:9334: listen: address already in use
+    if grep "address already in use" "${dir}/weed.INFO" &> /dev/null ; then
       # Clashed w/ existing port. Go around again and get new ports.
       :
     else

--- a/fdbclient/tests/seaweedfs_fixture.sh
+++ b/fdbclient/tests/seaweedfs_fixture.sh
@@ -178,7 +178,7 @@ function start_weed {
       # Dump out the tail of the weed log because its going to get cleaned up when
       # we exit this script. Give the user an idea of what went wrong.
       if [[ -f "${dir}/weed.INFO" ]]; then
-        tail -50 "${dir}/weed.INFO" >&2
+        tail -1000 "${dir}/weed.INFO" >&2
       fi
       echo "ERROR: Failed to start weed" >&2
       return 1

--- a/fdbclient/tests/seaweedfs_fixture.sh
+++ b/fdbclient/tests/seaweedfs_fixture.sh
@@ -121,7 +121,7 @@ function download_weed {
 function create_weed_dir {
   local dir="${1}"
   local weed_dir
-  weed_dir=$(mktemp -d -p "${dir}" -t weed.XXXX)
+  weed_dir=$(mktemp -d -p "${dir}" -t weed.$$.XXXX)
   # Exit if the temp directory wasn't created successfully.
   if [[ ! -d "${weed_dir}" ]]; then
     echo "ERROR: Failed create of weed directory ${weed_dir}" >&2

--- a/fdbclient/tests/tests_common.sh
+++ b/fdbclient/tests/tests_common.sh
@@ -34,9 +34,9 @@ function make_key {
 # $2 scratch directory where we can find fdb.cluster file
 function has_data {
   local local_build_dir="${1}"
-  local scratch_dir="${2}"
+  local local_scratch_dir="${2}"
   if ! result=$("${local_build_dir}/bin/fdbcli" \
-    -C "${scratch_dir}/loopback_cluster/fdb.cluster" \
+    -C "${local_scratch_dir}/loopback_cluster/fdb.cluster" \
     --exec "getrange \"\" \xff 1000" 2>&1 )
   then
     err "Failed to getrange"
@@ -54,9 +54,9 @@ function has_data {
 # $2 scratch directory so we can find fdb.cluster file.
 function has_nodata {
   local local_build_dir="${1}"
-  local scratch_dir="${2}"
+  local local_scratch_dir="${2}"
   if ! result=$("${local_build_dir}/bin/fdbcli" \
-    -C "${scratch_dir}/loopback_cluster/fdb.cluster" \
+    -C "${local_scratch_dir}/loopback_cluster/fdb.cluster" \
     --exec "getrange \"\" \xff 1000" 2>&1 )
   then
     err "Failed to getrange"
@@ -78,7 +78,7 @@ function has_nodata {
 # Sets the FDB_DATA Global array variable.
 function load_data {
   local local_build_dir="${1}"
-  local scratch_dir="${2}"
+  local local_scratch_dir="${2}"
   for (( i=0; i<"${FDB_DATA_KEYCOUNT}"; i++)); do
     FDB_DATA+=("${i}.$(date -Iseconds)")
   done
@@ -87,12 +87,12 @@ function load_data {
     load_str="${load_str} set $(make_key "${i}") ${FDB_DATA[i]};"
   done
   if ! echo "${load_str}" | \
-    "${local_build_dir}/bin/fdbcli" -C "${scratch_dir}/loopback_cluster/fdb.cluster" >&2
+    "${local_build_dir}/bin/fdbcli" -C "${local_scratch_dir}/loopback_cluster/fdb.cluster" >&2
   then
     err "Failed to load data"
     return 1
   fi
-  if ! has_data "${local_build_dir}" "${scratch_dir}"; then
+  if ! has_data "${local_build_dir}" "${local_scratch_dir}"; then
     err "No data"
     return 1
   fi
@@ -103,15 +103,15 @@ function load_data {
 # $2 scratch directory
 function clear_data {
   local local_build_dir="${1}"
-  local scratch_dir="${2}"
+  local local_scratch_dir="${2}"
   if ! "${local_build_dir}/bin/fdbcli" \
-    -C "${scratch_dir}/loopback_cluster/fdb.cluster" \
+    -C "${local_scratch_dir}/loopback_cluster/fdb.cluster" \
     --exec "writemode on; clearrange \"\" \xff;"
   then
     err "Failed to clearrange"
     return 1
   fi
-  if ! has_nodata "${local_build_dir}" "${scratch_dir}"; then
+  if ! has_nodata "${local_build_dir}" "${local_scratch_dir}"; then
     err "Has data"
     return 1
   fi
@@ -124,11 +124,11 @@ function clear_data {
 # Returns an array of the values we loaded.
 function verify_data {
   local local_build_dir="${1}"
-  local scratch_dir="${2}"
+  local local_scratch_dir="${2}"
   local value
   for (( i=0; i<"${#FDB_DATA[@]}"; i++)); do
     value=$("${local_build_dir}/bin/fdbcli" \
-      -C "${scratch_dir}/loopback_cluster/fdb.cluster" \
+      -C "${local_scratch_dir}/loopback_cluster/fdb.cluster" \
       --exec "get $(make_key "${i}")" | \
       sed -e "s/.*is [[:punct:]]//" | sed -e "s/[[:punct:]]*$//")
     if [[ "${FDB_DATA[i]}" != "${value}" ]]; then

--- a/fdbclient/tests/tests_common.sh
+++ b/fdbclient/tests/tests_common.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Globals.
-# Functions shared by backup tests.
+# Functions shared by ctests.
 #
 
 # Globals.


### PR DESCRIPTION
The s3client ctest will now use s3 directly if available (oketeto). The bulkdump ctest is yet to be converted (need
to do work internally to fdbserver so it can talk to S3 first -- a subsequent PR).

Also fix the object integrity check; original approach doesn't work when serverside encryption is enabled (awz:kms).

* contrib/SimpleOpt/include/SimpleOpt/SimpleOpt.h Address sanitizer was complaining about how SimpleOpt manipulates the array of options. While memcpy inside a buffer is 'odd', it seems fine. Its old code. Leaving it.

* fdbbackup/tests/s3_backup_test.sh Pass in weed_dir rather than rely on fixture global (the latter didn't work).

* fdbclient/ClientKnobs.cpp
* fdbclient/include/fdbclient/ClientKnobs.h
* fdbclient/include/fdbclient/S3BlobStore.h Add a knob to ask for object integrity check on download from s3. BLOBSTORE_ENABLE_OBJECT_INTEGRITY_CHECK replaces BLOBSTORE_ENABLE_ETAG_ON_GET which doesn't work when serverside encodes content (found in testing).

* fdbclient/S3BlobStore.actor.cpp Implement object integrity check on download. If enable_object_integrity_check is set, we use sha256 in place of md5 as our hash. Removed a redundant 'verify' of md5 check.

* fdbclient/S3Client.actor.cpp Remove unhelpful comments.

* fdbclient/S3Client_cli.actor.cpp Add support for enable_object_integrity_check. This knob replaces enable_etag_on_get which didn't work when awz:kms serverside encryption was enabled. Add error code on exit when exception.

* fdbclient/include/fdbclient/S3Client.actor.h Move an include (address a review comment from previous commit).

* fdbclient/tests/aws_fixture.sh Add an aws fixture of utility that can be shared.

* fdbclient/tests/bulkload_test.sh Use imported log_test_result

* fdbclient/tests/s3client_test.sh Add using s3 if available; otherwise, do seaweedfs.

* fdbclient/tests/seaweedfs_fixture.sh WEED_DIR global doesn't work so have caller pass it in for each method instead.
