### PR TITLE
Check the requested path in the fdb Kubernetes sidecar

### DIFF
--- a/packaging/docker/sidecar_test.py
+++ b/packaging/docker/sidecar_test.py
@@ -70,26 +70,26 @@ class TestSidecar(unittest.TestCase):
         self.test_server_port = port
 
     def test_get_ready(self):
-        r = requests.get(f"{self.server_url }/ready")
+        r = requests.get(f"{self.server_url}/ready")
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.text, "OK\n")
 
     def test_get_substitutions(self):
         expected = {"key": "value"}
         self.mock_config.substitutions = expected
-        r = requests.get(f"{self.server_url }/substitutions")
+        r = requests.get(f"{self.server_url}/substitutions")
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.json(), expected)
 
     def test_get_check_hash_no_found(self):
-        r = requests.get(f"{self.server_url }/check_hash/foobar")
+        r = requests.get(f"{self.server_url}/check_hash/foobar")
         self.assertEqual(r.status_code, 404)
         self.assertRegex(r.text, "foobar not found")
 
     def test_get_check_hash(self):
         with open(os.path.join(self.mock_config.output_dir, "foobar"), "w") as f:
             f.write("hello world")
-        r = requests.get(f"{self.server_url }/check_hash/foobar")
+        r = requests.get(f"{self.server_url}/check_hash/foobar")
         self.assertEqual(r.status_code, 200)
         self.assertEqual(
             r.text, "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
@@ -100,21 +100,21 @@ class TestSidecar(unittest.TestCase):
         os.makedirs(os.path.dirname(test_path), exist_ok=True)
         with open(test_path, "w") as f:
             f.write("hello world")
-        r = requests.get(f"{self.server_url }/check_hash/nested/foobar")
+        r = requests.get(f"{self.server_url}/check_hash/nested/foobar")
         self.assertEqual(r.status_code, 200)
         self.assertEqual(
             r.text, "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
         )
 
     def test_get_is_present_no_found(self):
-        r = requests.get(f"{self.server_url }/is_present/foobar")
+        r = requests.get(f"{self.server_url}/is_present/foobar")
         self.assertEqual(r.status_code, 404)
         self.assertRegex(r.text, "foobar not found")
 
     def test_get_is_present(self):
         with open(os.path.join(self.mock_config.output_dir, "foobar"), "w") as f:
             f.write("hello world")
-        r = requests.get(f"{self.server_url }/is_present/foobar")
+        r = requests.get(f"{self.server_url}/is_present/foobar")
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.text, "OK\n")
 
@@ -123,14 +123,14 @@ class TestSidecar(unittest.TestCase):
         os.makedirs(os.path.dirname(test_path), exist_ok=True)
         with open(test_path, "w") as f:
             f.write("hello world")
-        r = requests.get(f"{self.server_url }/is_present/nested/foobar")
+        r = requests.get(f"{self.server_url}/is_present/nested/foobar")
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.text, "OK\n")
 
     def test_get_not_found(self):
-        r = requests.get(f"{self.server_url }/foobar")
+        r = requests.get(f"{self.server_url}/foobar")
         self.assertEqual(r.status_code, 404)
-        self.assertRegex(r.text, "Path not found")
+        self.assertRegex(r.text, "Path /foobar not found")
 
 
 # TODO(johscheuer): Add test cases for post requests.

--- a/packaging/docker/sidecar_test.py
+++ b/packaging/docker/sidecar_test.py
@@ -31,7 +31,7 @@ from unittest.mock import MagicMock
 
 import requests
 
-from sidecar import SidecarHandler
+from sidecar import SidecarHandler, RequestException, check_hash, is_present
 
 
 # This test suite starts a real server with a mocked configuration and will do some requests against it.
@@ -106,6 +106,13 @@ class TestSidecar(unittest.TestCase):
             r.text, "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
         )
 
+    def test_get_check_hash_outside(self):
+        with open(os.path.join(self.mock_config.output_dir, "foobar"), "w") as f:
+            f.write("hello world")
+
+        with self.assertRaises(RequestException):
+            check_hash(self.mock_config.output_dir, "../foobar")
+
     def test_get_is_present_no_found(self):
         r = requests.get(f"{self.server_url}/is_present/foobar")
         self.assertEqual(r.status_code, 404)
@@ -126,6 +133,13 @@ class TestSidecar(unittest.TestCase):
         r = requests.get(f"{self.server_url}/is_present/nested/foobar")
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.text, "OK\n")
+
+    def test_get_check_is_present(self):
+        with open(os.path.join(self.mock_config.output_dir, "foobar"), "w") as f:
+            f.write("hello world")
+
+        with self.assertRaises(RequestException):
+            is_present(self.mock_config.output_dir, "../foobar")
 
     def test_get_not_found(self):
         r = requests.get(f"{self.server_url}/foobar")


### PR DESCRIPTION
Ran the unit tests:

```bash
$ python3 sidecar_test.py
...........
----------------------------------------------------------------------
Ran 11 tests in 0.048s

OK
```

I tried to setup a test for the new code but it seems like doing directly a request against the mocked server doesn't work as the relative path is resolved by the server before passing the path into the methods. So I ended up building dedicated tests for new methods.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
