### PR TITLE
Block until a signal is received in sidecar mode

### DIFF
--- a/fdbkubernetesmonitor/main.go
+++ b/fdbkubernetesmonitor/main.go
@@ -187,8 +187,10 @@ func main() {
 				os.Exit(1)
 			}
 		}
+		done := make(chan os.Signal, 1)
+		signal.Notify(done, syscall.SIGINT, syscall.SIGTERM)
 		logger.Info("Waiting for process to be terminated")
-		done := make(chan bool)
+		// Will block here until a signal is received, e.g. when the container/pod is shutdown
 		<-done
 	default:
 		logger.Error(nil, "Unknown execution mode", "mode", mode)

--- a/fdbkubernetesmonitor/main.go
+++ b/fdbkubernetesmonitor/main.go
@@ -24,9 +24,11 @@ import (
 	"context"
 	"io"
 	"os"
+	"os/signal"
 	"path"
 	"regexp"
 	"strings"
+	"syscall"
 
 	"github.com/apple/foundationdb/fdbkubernetesmonitor/api"
 


### PR DESCRIPTION
I think it's better to listen to the signals instead of ignoring it and just block the whole time. This should improve the interactions with the sidecar when the pod is shutdown.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
