### PR TITLE
Extend gray failure recentHealthTriggeredRecoveryTime to reflect any recovery trigger

### DIFF
--- a/fdbclient/include/fdbclient/ServerKnobs.h
+++ b/fdbclient/include/fdbclient/ServerKnobs.h
@@ -776,8 +776,9 @@ public:
 	double CC_TRACKING_HEALTH_RECOVERY_INTERVAL; // The number of recovery count should not exceed
 	                                             // CC_MAX_HEALTH_RECOVERY_COUNT within
 	                                             // CC_TRACKING_HEALTH_RECOVERY_INTERVAL.
-	int CC_MAX_HEALTH_RECOVERY_COUNT; // The max number of recoveries can be triggered due to worker health within
-	                                  // CC_TRACKING_HEALTH_RECOVERY_INTERVAL
+	int CC_MAX_HEALTH_RECOVERY_COUNT; // The max number of gray failure recoveries that can be triggered due to worker
+	                                  // health within CC_TRACKING_HEALTH_RECOVERY_INTERVAL. This count accounts for any
+	                                  // recovery trigger including the ones by gray failure itself.
 	bool CC_HEALTH_TRIGGER_FAILOVER; // Whether to enable health triggered failover in CC.
 	int CC_FAILOVER_DUE_TO_HEALTH_MIN_DEGRADATION; // The minimum number of degraded servers that can trigger a
 	                                               // failover.

--- a/fdbclient/include/fdbclient/ServerKnobs.h
+++ b/fdbclient/include/fdbclient/ServerKnobs.h
@@ -776,9 +776,9 @@ public:
 	double CC_TRACKING_HEALTH_RECOVERY_INTERVAL; // The number of recovery count should not exceed
 	                                             // CC_MAX_HEALTH_RECOVERY_COUNT within
 	                                             // CC_TRACKING_HEALTH_RECOVERY_INTERVAL.
-	int CC_MAX_HEALTH_RECOVERY_COUNT; // The max number of gray failure recoveries that can be triggered due to worker
+	int CC_MAX_HEALTH_RECOVERY_COUNT; // The max number recoveries that can be triggered due to worker
 	                                  // health within CC_TRACKING_HEALTH_RECOVERY_INTERVAL. This count accounts for any
-	                                  // recovery trigger including the ones by gray failure itself.
+	                                  // recovery trigger including non-gray failure ones.
 	bool CC_HEALTH_TRIGGER_FAILOVER; // Whether to enable health triggered failover in CC.
 	int CC_FAILOVER_DUE_TO_HEALTH_MIN_DEGRADATION; // The minimum number of degraded servers that can trigger a
 	                                               // failover.

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -297,6 +297,7 @@ ACTOR Future<Void> clusterWatchDatabase(ClusterControllerData* cluster,
 
 			collection = actorCollection(db->recoveryData->addActor.getFuture());
 			recoveryCore = clusterRecoveryCore(db->recoveryData);
+			cluster->recentHealthTriggeredRecoveryTime.push(now());
 
 			// Master failure detection is pretty sensitive, but if we are in the middle of a very long recovery we
 			// really don't want to have to start over
@@ -3061,7 +3062,6 @@ ACTOR Future<Void> workerHealthMonitor(ClusterControllerData* self) {
 				if (self->shouldTriggerRecoveryDueToDegradedServers()) {
 					if (SERVER_KNOBS->CC_HEALTH_TRIGGER_RECOVERY) {
 						if (self->recentRecoveryCountDueToHealth() < SERVER_KNOBS->CC_MAX_HEALTH_RECOVERY_COUNT) {
-							self->recentHealthTriggeredRecoveryTime.push(now());
 							self->excludedDegradedServers.clear();
 							for (const auto& degradedServer : self->degradationInfo.degradedServers) {
 								self->excludedDegradedServers[degradedServer] = now();

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -3073,6 +3073,10 @@ ACTOR Future<Void> workerHealthMonitor(ClusterControllerData* self) {
 							TraceEvent(SevWarnAlways, "DegradedServerDetectedAndTriggerRecovery")
 							    .detail("RecentRecoveryCountDueToHealth", self->recentRecoveryCountDueToHealth());
 							self->db.forceMasterFailure.trigger();
+						} else {
+							TraceEvent(SevWarnAlways, "RecentRecoveryCountHigh")
+							    .suppressFor(1.0)
+							    .detail("RecentRecoveryCountDueToHealth", self->recentRecoveryCountDueToHealth());
 						}
 					} else {
 						self->excludedDegradedServers.clear();


### PR DESCRIPTION
# Description

Extend gray failure recentHealthTriggeredRecoveryTime state to reflect any recovery, including non-gray failure triggered ones. This helps reduce number of false positive gray failure recoveries.

Let's take an example. `CC_MAX_HEALTH_RECOVERY_COUNT` is 1 and `CC_TRACKING_HEALTH_RECOVERY_INTERVAL` is 120.

Previously, gray failure will trigger another recovery after a non-gray failure recovery regardless of the knob values above.

Now, the knobs account for non-gray failure recoveries as well. So in this example, gray failure will not trigger another recovery after non-gray failure recovery for atleast 2 minutes. After 2 minutes, if complaints have not expired and workers have not recovered, gray failure can decide to trigger a recovery. 

Once accepted, will also create a backport PR for 7.3.

# Testing

1. 100K: `20250111-000712-praza-5160fe051c0f2a507d0339b79b934665fb5403 compressed=True data_size=36362848 duration=5983953 ended=100000 fail=4 fail_fast=10 max_runs=100000 pass=99996 priority=100 remaining=0 runtime=1:39:26 sanity=False started=100000 stopped=20250111-014638 submitted=20250111-000712 timeout=5400 username=praza-5160fe051c0f2a507d0339b79b934665fb54030e`. Looking at logs, there were 3 failures, all related to sharded rocks (1 crash which is known issue, and 2 timeouts which also has been seen before). 
2. Also explicitly ran `fdbserver -r unittests -f /fdbserver/clustercontroller/` which includes gray failure unit tests, all pass.
3. Ran multiple tests in Kubernetes cluster to ensure gray failure recovery is not triggered soon after non-gray failure recovery. Also tested that when there is no non-gray failure recovery, then gray failure recovery is still triggered.

Latest 100K: `20250114-223103-praza-a51203847994ef6ed8c93c667b30f6ab5bb21f compressed=True data_size=36362525 duration=5082269 ended=100000 fail=2 fail_fast=10 max_runs=100000 pass=99998 priority=100 remaining=0 runtime=1:11:30 sanity=False started=100000 stopped=20250114-234233 submitted=20250114-223103 timeout=5400 username=praza-a51203847994ef6ed8c93c667b30f6ab5bb21f80`. Both failures don't seem related (in rocks/shardedrocks unit tests). 

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
