### PR TITLE
Refactor initialize_logger_level and unit_tests_version_510

### DIFF
--- a/bindings/bindingtester/util.py
+++ b/bindings/bindingtester/util.py
@@ -27,10 +27,7 @@ import fdb
 
 
 def initialize_logger_level(logging_level):
-    """
-    Refactored to use a dictionary to map logging levels to their corresponding
-    constants, making the function more concise and avoiding repetitive if-elif blocks.
-    """
+  
     logger = get_logger()
 
     # Map logging levels to their corresponding constants
@@ -43,8 +40,11 @@ def initialize_logger_level(logging_level):
 
     if logging_level not in LOGGING_LEVELS:
         raise ValueError(f"Invalid logging level: {logging_level}")
-
+    
     logger.setLevel(LOGGING_LEVELS[logging_level])
+
+
+
 
 
 

--- a/bindings/bindingtester/util.py
+++ b/bindings/bindingtester/util.py
@@ -27,18 +27,25 @@ import fdb
 
 
 def initialize_logger_level(logging_level):
+    """
+    Refactored to use a dictionary to map logging levels to their corresponding
+    constants, making the function more concise and avoiding repetitive if-elif blocks.
+    """
     logger = get_logger()
 
-    assert logging_level in ["DEBUG", "INFO", "WARNING", "ERROR"]
+    # Map logging levels to their corresponding constants
+    LOGGING_LEVELS = {
+        "DEBUG": logging.DEBUG,
+        "INFO": logging.INFO,
+        "WARNING": logging.WARNING,
+        "ERROR": logging.ERROR,
+    }
 
-    if logging_level == "DEBUG":
-        logger.setLevel(logging.DEBUG)
-    elif logging_level == "INFO":
-        logger.setLevel(logging.INFO)
-    elif logging_level == "WARNING":
-        logger.setLevel(logging.WARNING)
-    elif logging_level == "ERROR":
-        logger.setLevel(logging.ERROR)
+    if logging_level not in LOGGING_LEVELS:
+        raise ValueError(f"Invalid logging level: {logging_level}")
+
+    logger.setLevel(LOGGING_LEVELS[logging_level])
+
 
 
 def get_logger():

--- a/bindings/c/test/unit/unit_tests_version_510.cpp
+++ b/bindings/c/test/unit/unit_tests_version_510.cpp
@@ -69,6 +69,38 @@ struct Transaction {
 // assembly code that handles emulating older api versions, but there's no
 // reason why this shouldn't also test api version 510 specific behavior.
 
+
+//  Case 1 : -  Adding Test case for " to Ensures the ability to set and retrieve a key-value pair using transactions."
+TEST_CASE("Set and Get Key-Value") {
+    Transaction tr;
+    fdb_check(fdb_database_create_transaction(db, &tr.tr));
+
+    // Set a key-value pair
+    std::string key = prefix + "testKey";
+    std::string value = "testValue";
+    fdb_check(fdb_transaction_set(tr.tr, (const uint8_t*)key.c_str(), key.size(), (const uint8_t*)value.c_str(), value.size()));
+
+   
+    Future commitFuture{ fdb_transaction_commit(tr.tr) };
+    fdb_check(fdb_future_block_until_ready(commitFuture.f));
+
+    
+    Transaction tr2;
+    fdb_check(fdb_database_create_transaction(db, &tr2.tr));
+    Future getFuture{ fdb_transaction_get(tr2.tr, (const uint8_t*)key.c_str(), key.size(), 0) };
+    fdb_check(fdb_future_block_until_ready(getFuture.f));
+
+   
+    const uint8_t* valueOut;
+    int valueLen;
+    fdb_check(fdb_future_get_value(getFuture.f, nullptr, &valueOut, &valueLen));
+    std::string retrievedValue((const char*)valueOut, valueLen);
+
+    CHECK(retrievedValue == value);
+}
+
+
+// Test Case 2 : 
 TEST_CASE("GRV") {
 	Transaction tr;
 	fdb_check(fdb_database_create_transaction(db, &tr.tr));

--- a/bindings/c/test/unit/unit_tests_version_510.cpp
+++ b/bindings/c/test/unit/unit_tests_version_510.cpp
@@ -70,7 +70,7 @@ struct Transaction {
 // reason why this shouldn't also test api version 510 specific behavior.
 
 
-//  Case 1 : -  Adding Test case for " to Ensures the ability to set and retrieve a key-value pair using transactions."
+//  Case 1 : - Adding Test case for " to Ensures the ability to set and retrieve a key-value pair using transactions."
 TEST_CASE("Set and Get Key-Value") {
     Transaction tr;
     fdb_check(fdb_database_create_transaction(db, &tr.tr));
@@ -78,26 +78,26 @@ TEST_CASE("Set and Get Key-Value") {
     // Set a key-value pair
     std::string key = prefix + "testKey";
     std::string value = "testValue";
-    fdb_check(fdb_transaction_set(tr.tr, (const uint8_t*)key.c_str(), key.size(), (const uint8_t*)value.c_str(), value.size()));
+    fdb_check(fdb_transaction_set(tr.tr, (const uint8_t *)key.c_str(), key.size(),
+                                  (const uint8_t *)value.c_str(), value.size()));
 
-   
-    Future commitFuture{ fdb_transaction_commit(tr.tr) };
+    Future commitFuture{fdb_transaction_commit(tr.tr)};
     fdb_check(fdb_future_block_until_ready(commitFuture.f));
 
-    
     Transaction tr2;
     fdb_check(fdb_database_create_transaction(db, &tr2.tr));
-    Future getFuture{ fdb_transaction_get(tr2.tr, (const uint8_t*)key.c_str(), key.size(), 0) };
+    Future getFuture{fdb_transaction_get(tr2.tr, (const uint8_t *)key.c_str(), key.size(), 0)};
     fdb_check(fdb_future_block_until_ready(getFuture.f));
 
-   
-    const uint8_t* valueOut;
+    const uint8_t *valueOut;
     int valueLen;
     fdb_check(fdb_future_get_value(getFuture.f, nullptr, &valueOut, &valueLen));
-    std::string retrievedValue((const char*)valueOut, valueLen);
+    std::string retrievedValue((const char *)valueOut, valueLen);
 
     CHECK(retrievedValue == value);
 }
+
+
 
 
 // Test Case 2 : 


### PR DESCRIPTION

## Problem
The initialize_logger_level function was implemented using repetitive if-elif blocks, reducing readability and maintainability.
The unit tests for FoundationDB API version 510 lacked coverage for core functionality, including key-value operations, range reads, and transaction handling.

## Solution
Refactor initialize_logger_level:
Replaced the repetitive if-elif blocks with a dictionary mapping of logging levels to their corresponding constants.
Improved readability and maintainability while ensuring the function’s correctness.
Added validation to handle invalid logging levels using a ValueError.
Enhanced Unit Tests for Version 510:

## Test Set and Get Key-Value: 
A unit test was added to verify the ability to set and retrieve key-value pairs using transactions. Ensures correctness by:
Writing a key-value pair to the database.
Committing the transaction.
Reading the value back in a new transaction and comparing it to the expected result.
