### PR TITLE
Do not use "safe range" logic in recovery code when version vector is enabled

### DIFF
--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -2002,8 +2002,9 @@ Optional<std::tuple<Version, Version, std::vector<TLogLockResult>>> TagPartition
 		// to decide whether to restart recovery not. In "main" we use the version at index
 		// "(safe_range_end - 1)" - this is to minimize the chances of restarting the current recovery
 		// process. With "version vector" we use the version at index "new_safe_range_begin" - this is
-		// because choosing any other version will invalidate the changes that we made to the peek logic
-		// in the context of version vector.
+		// because choosing any other version may result in not copying the correct version range to the
+		// log servers in the latest epoch and also will invalidate the changes that we made to the peek
+		// logic in the context of version vector.
 		int version_index =
 		    (!SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST ? (safe_range_end - 1) : new_safe_range_begin);
 
@@ -2038,8 +2039,9 @@ Optional<std::tuple<Version, Version, std::vector<TLogLockResult>>> TagPartition
 			// picked as the recovery version. We pick the version at index "new_safe_range_begin" in order
 			// to minimize the number of recovery restarts and also to minimize the amount of data we need
 			// to copy during recovery. With "version vector" we pick the version "new_safe_range_begin"
-			// as choosing any other version will invalidate the changes that we made to the peek logic
-			// in the context of version vector.
+			// as choosing any other version may result in not copying the correct version range to the
+			// log servers in the latest epoch and also will invalidate the changes that we made to the
+			// peek logic in the context of version vector.
 			return std::make_tuple(knownCommittedVersion, results[new_safe_range_begin].end, results);
 		}
 	}

--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -2005,11 +2005,11 @@ Optional<std::tuple<Version, Version, std::vector<TLogLockResult>>> TagPartition
 		// because choosing any other version may result in not copying the correct version range to the
 		// log servers in the latest epoch and also will invalidate the changes that we made to the peek
 		// logic in the context of version vector.
-		int version_index =
+		int versionIndex =
 		    (!SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST ? (safe_range_end - 1) : new_safe_range_begin);
 
 		if (!lastEnd.present() ||
-		    ((version_index >= 0) && (version_index < results.size()) && results[version_index].end < lastEnd.get())) {
+		    ((versionIndex >= 0) && (versionIndex < results.size()) && results[versionIndex].end < lastEnd.get())) {
 			Version knownCommittedVersion = 0;
 			for (int i = 0; i < results.size(); i++) {
 				knownCommittedVersion = std::max(knownCommittedVersion, results[i].knownCommittedVersion);


### PR DESCRIPTION
When version vector is enabled use "min(DV)" as the recovery version when trying to decide whether to restart recovery or not. Otherwise, we may not copy all the needed data to the log servers in the latest epoch during recovery and also the changes that we made to the cursor peek logic in the context of version vector may cause it to return incorrect results.

Testing:
- Simulation test "tests/fast/MoveKeysCycle.toml -b off -s 4070406963" fails with an assertion failure in storage server code without this change, succeeds with this change (the failure was because the "pullAsync" logic was not copying all the needed versions to a log server in the latest epoch during recovery).
- Joshua id (with version vector disabled): 20250115-115834-sre-1d6488b208a8980a (no failures)

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
