### PR TITLE
Fix the scope of sharded rocks checkpoint determinism flag

### DIFF
--- a/fdbserver/KeyValueStoreShardedRocksDB.actor.cpp
+++ b/fdbserver/KeyValueStoreShardedRocksDB.actor.cpp
@@ -4070,6 +4070,9 @@ struct ShardedRocksDBKeyValueStore : IKeyValueStore {
 	}
 
 	Future<CheckpointMetaData> checkpoint(const CheckpointRequest& request) override {
+		// ShardedRocks with checkpoint is known to be non-deterministic
+		// so setting noUnseed=true. See https://github.com/apple/foundationdb/pull/11841
+		// for more context.
 		if (g_network->isSimulated() && !noUnseed) {
 			noUnseed = true;
 		}

--- a/fdbserver/KeyValueStoreShardedRocksDB.actor.cpp
+++ b/fdbserver/KeyValueStoreShardedRocksDB.actor.cpp
@@ -4070,6 +4070,9 @@ struct ShardedRocksDBKeyValueStore : IKeyValueStore {
 	}
 
 	Future<CheckpointMetaData> checkpoint(const CheckpointRequest& request) override {
+		if (g_network->isSimulated() && !noUnseed) {
+			noUnseed = true;
+		}
 		auto a = new Writer::CheckpointAction(&shardManager, request);
 
 		auto res = a->reply.getFuture();

--- a/fdbserver/MoveKeys.actor.cpp
+++ b/fdbserver/MoveKeys.actor.cpp
@@ -59,11 +59,7 @@ bool shouldCreateCheckpoint(const UID& dataMoveId) {
 	DataMoveType type;
 	DataMovementReason reason;
 	decodeDataMoveId(dataMoveId, assigned, emptyRange, type, reason);
-	const bool ret = (type == DataMoveType::PHYSICAL || type == DataMoveType::PHYSICAL_EXP);
-	if (ret && g_network->isSimulated() && !noUnseed) {
-		noUnseed = true;
-	}
-	return ret;
+	return (type == DataMoveType::PHYSICAL || type == DataMoveType::PHYSICAL_EXP);
 }
 
 // Unassigns keyrange `range` from server `ssId`, except ranges in `shards`.


### PR DESCRIPTION
# Description

In https://github.com/apple/foundationdb/pull/11841, sharded rocks was made deterministic in simulation except for code paths where we create checkpoint metadata and process it. As a result, the noUnseed flag was conditionally set to true when checkpoint is created (before, it was set to true always for sharded rocks storage engine). However, checkpoint creation at a high level follows these code paths:

1. DD and moveKeys creates the CheckpointMetadata request. 
2. Storage server processes this request and takes action by calling IKeyValue implementation for sharded rocks. 

I set noUnseed=true at (1) above but the problem is that for non sharded rocks storage engine, we can still determine that we need to create checkpoints and then create CheckpointMetadata request. It's only at the storage server level that we drop this request if the storage engine is not sharded rocks. This meant that my initial check was more aggressive than it should be since we can set noUnseed to true for non sharded rocks storage engine - this should not be the case because every storage engine should be fully deterministic except sharded rocks (which is partial right now).

I found this issue when debugging an issue for another unrelated PR. 

The fix is to simply set noUnseed to true at (2) instead of (1), specifically at `KeyValueStoreShardedRocksDB.actor:checkpoint(..)`.

# Testing

100K: `20250116-225152-praza-21e2a8ad6633de91beeb7191ed58110c34783d compressed=True data_size=36470324 duration=5261573 ended=100000 fail=2 fail_fast=10 max_runs=100000 pass=99998 priority=100 remaining=0 runtime=1:50:03 sanity=False started=100000 stopped=20250117-004155 submitted=20250116-225152 timeout=5400 username=praza-21e2a8ad6633de91beeb7191ed58110c34783db8`. 0 instances of UnseedMismatch. 

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
