### PR TITLE
Enable SS upload/download to S3 (for BulkLoad)

### DIFF
--- a/fdbbackup/tests/dir_backup_test.sh
+++ b/fdbbackup/tests/dir_backup_test.sh
@@ -183,7 +183,7 @@ SCRATCH_DIR=$(resolve_to_absolute_path "${tmpdir}")
 readonly SCRATCH_DIR
 
 # Startup fdb cluster and backup agent.
-if ! start_fdb_cluster "${source_dir}" "${build_dir}" "${SCRATCH_DIR}"; then
+if ! start_fdb_cluster "${source_dir}" "${build_dir}" "${SCRATCH_DIR}" 1; then
   err "Failed start FDB cluster"
   exit 1
 fi

--- a/fdbbackup/tests/s3_backup_test.sh
+++ b/fdbbackup/tests/s3_backup_test.sh
@@ -296,12 +296,12 @@ if ! source "${cwd}/../../fdbclient/tests/fdb_cluster_fixture.sh"; then
   exit 1
 fi
 # Startup fdb cluster and backup agent.
-if ! start_fdb_cluster "${source_dir}" "${build_dir}" "${TEST_SCRATCH_DIR}"; then
+if ! start_fdb_cluster "${source_dir}" "${build_dir}" "${TEST_SCRATCH_DIR}" 1; then
   err "Failed start FDB cluster"
   exit 1
 fi
 log "FDB cluster is up"
-if ! start_backup_agent "${build_dir}" "${TEST_SCRATCH_DIR}" "${KNOBS[*]}"; then
+if ! start_backup_agent "${build_dir}" "${TEST_SCRATCH_DIR}" "${KNOBS[@]}"; then
   err "Failed start backup_agent"
   exit 1
 fi

--- a/fdbcli/BulkLoadCommand.actor.cpp
+++ b/fdbcli/BulkLoadCommand.actor.cpp
@@ -77,7 +77,7 @@ ACTOR Future<bool> getOngoingBulkLoadJob(Database cx) {
 		try {
 			Optional<BulkLoadJobState> job = wait(getAliveBulkLoadJob(&tr));
 			if (job.present()) {
-				fmt::println("Running bulk loading job: {}", job.get().toString());
+				fmt::println("Running bulk loading job: {}", job.get().getJobId().toString());
 				return true;
 			} else {
 				fmt::println("No bulk loading job is running");

--- a/fdbclient/BulkLoading.cpp
+++ b/fdbclient/BulkLoading.cpp
@@ -86,6 +86,11 @@ std::string generateBulkLoadJobManifestFileContent(const std::map<Key, BulkLoadM
 	return res;
 }
 
+std::string getPath(const std::string& path) {
+	boost::system::result<boost::urls::url_view> parse_result = boost::urls::parse_uri(path);
+	return parse_result.has_value() ? parse_result.value().path() : path;
+}
+
 // TODO(BulkLoad): use this everywhere
 std::string appendToPath(const std::string& path, const std::string& append) {
 	boost::system::result<boost::urls::url_view> parse_result = boost::urls::parse_uri(path);

--- a/fdbclient/S3BlobStore.actor.cpp
+++ b/fdbclient/S3BlobStore.actor.cpp
@@ -431,7 +431,10 @@ std::string constructResourcePath(Reference<S3BlobStoreEndpoint> b,
 	}
 
 	if (!object.empty()) {
-		resource += "/";
+		// Don't add a slash if the object starts with one
+		if (!object.starts_with("/")) {
+			resource += "/";
+		}
 		resource += object;
 	}
 

--- a/fdbclient/include/fdbclient/BulkLoading.h
+++ b/fdbclient/include/fdbclient/BulkLoading.h
@@ -52,6 +52,13 @@ enum class BulkLoadTransportMethod : uint8_t {
 // The number should increase by 1 when we change the metadata in a release.
 const int bulkLoadManifestFormatVersion = 1;
 
+// Append a string to a path.
+// 'path' is a filesystem path or an URL.
+// 'append' is what to append to path.
+// URLs can have query strings so we need to be careful where we append.
+// TODO(BulkDump): use this everywhere
+std::string appendToPath(const std::string& path, const std::string& append);
+
 // Here are important metadata: (1) BulkLoadTaskState; (2) BulkDumpState; (3) BulkLoadManifest. BulkLoadTaskState is
 // only used for bulkload core engine which persists the metadata for each unit bulkload range (aka. task).
 // BulkDumpState is used for bulk dumping. BulkLoadManifest is the metadata for persisting core information of the
@@ -235,7 +242,7 @@ public:
 		} else if (relativePath.empty()) {
 			return rootPath;
 		} else {
-			return joinPath(rootPath, relativePath);
+			return appendToPath(rootPath, relativePath);
 		}
 	}
 
@@ -259,7 +266,11 @@ public:
 			    .detail("FileSet", toString());
 			throw bulkload_fileset_invalid_filepath();
 		} else {
-			return joinPath(getFolder(), dataFileName);
+			TraceEvent(SevInfo, "BulkLoadFileSetProvideDataFile")
+			    .detail("DataFile", dataFileName)
+			    .detail("Relative", getRelativePath())
+			    .detail("Folder", getFolder());
+			return appendToPath(getFolder(), dataFileName);
 		}
 	}
 
@@ -271,7 +282,7 @@ public:
 			    .detail("FileSet", toString());
 			throw bulkload_fileset_invalid_filepath();
 		} else {
-			return joinPath(getFolder(), byteSampleFileName);
+			return appendToPath(getFolder(), byteSampleFileName);
 		}
 	}
 
@@ -904,8 +915,10 @@ std::string generateEmptyManifestFileName();
 // Rows: BeginKey, EndKey, Version, Bytes, ManifestPath
 std::string generateBulkLoadJobManifestFileContent(const std::map<Key, BulkLoadManifest>& manifests);
 
-// Append a string to a path. 'path' is a filesystem path or an URL.
-std::string appendToPath(const std::string& path, const std::string& append);
+// Return path.
+// If the input is a filesystem path, return the path.
+// If the input is an URL, return the path part of the URL.
+std::string getPath(const std::string& path_or_url);
 
 // Define bulkLoad/bulkDump job folder using the root path and the jobId.
 std::string getBulkLoadJobRoot(const std::string& root, const UID& jobId);
@@ -925,5 +938,4 @@ BulkLoadJobState createBulkLoadJob(const UID& dumpJobIdToLoad,
                                    const KeyRange& range,
                                    const std::string& jobRoot,
                                    const BulkLoadTransportMethod& transportMethod);
-
 #endif

--- a/fdbclient/tests/fdb_cluster_fixture.sh
+++ b/fdbclient/tests/fdb_cluster_fixture.sh
@@ -30,11 +30,12 @@ function start_fdb_cluster {
   local local_scratch_dir="${3}"
   local ss_count="${4}"
   shift 4
-  local extra_knobs=("${@}")
   local knobs="--knob_shard_encode_location_metadata=true"
-  for item in "${extra_knobs[@]}"; do
-    knobs="${knobs} ${item}"
-  done
+  if (( $# > 0 )); then
+    for item in "${@}"; do
+      knobs="${knobs} ${item}"
+    done
+  fi
   knobs=$(echo "$knobs" | sed 's/^[[:space:]]*//')
   local output="${local_scratch_dir}/output.$$.txt"
   local port_prefix=1500
@@ -90,7 +91,10 @@ function start_backup_agent {
   local local_build_dir="${1}"
   local local_scratch_dir="${2}"
   shift 2
-  local extra_knobs=("${@}")
+  local local_knobs=""
+  if (( $# > 0 )); then
+    local_knobs="${*}"
+  fi
   # Just using ${extra_knobs[*]} in the below will output a string
   # quoted by single quotes; its what bash does when string has spaces
   # or special characters. To get around this, we printf the string instead;
@@ -99,7 +103,7 @@ function start_backup_agent {
   "${local_build_dir}/bin/backup_agent" \
     -C "${local_scratch_dir}/loopback_cluster/fdb.cluster" \
     --log --logdir="${local_scratch_dir}" \
-    $(printf "%s" "${extra_knobs[*]}") &
+    $(printf "%s" "${local_knobs}") &
   local pid=$!
   if ! ps -p "${pid}" &> /dev/null; then
     wait "${pid}"

--- a/fdbclient/tests/fdb_cluster_fixture.sh
+++ b/fdbclient/tests/fdb_cluster_fixture.sh
@@ -21,27 +21,42 @@ function shutdown_fdb_cluster {
 # $1 source directory
 # $2 build directory
 # $3 scratch directory
+# $4 How many SS to run
+# ... knobs to apply to the cluster.
 # Check $? on return.
 function start_fdb_cluster {
   local local_source_dir="${1}"
   local local_build_dir="${2}"
   local local_scratch_dir="${3}"
+  local ss_count="${4}"
+  shift 4
+  local extra_knobs=("${@}")
+  local knobs="--knob_shard_encode_location_metadata=true"
+  for item in "${extra_knobs[@]}"; do
+    knobs="${knobs} ${item}"
+  done
+  knobs=$(echo "$knobs" | sed 's/^[[:space:]]*//')
   local output="${local_scratch_dir}/output.$$.txt"
   local port_prefix=1500
   while : ; do
     port_prefix="$(( port_prefix + 100 ))"
     # Disable exit on error temporarily so can capture result from run cluster.
     # Then redirect the output of the run_customer_cluster.sh via tee via
-    # 'process substitution'; piping to tee hangs on success..
+    # 'process substitution'; piping to tee hangs on success.
     set +o errexit  # a.k.a. set +e
     set +o noclobber
+    # In the below $knobs will pick up single quotes -- its what bash does when it
+    # outputs strings with spaces or special characters. In this case, we want the
+    # single quotes.
     LOOPBACK_DIR="${local_scratch_dir}/loopback_cluster" PORT_PREFIX="${port_prefix}" \
       "${local_source_dir}/tests/loopback_cluster/run_custom_cluster.sh" \
       "${local_build_dir}" \
-      --knobs "--knob_shard_encode_location_metadata=true" \
+      --knobs "${knobs}" \
       --stateless_count 1 --replication_count 1 --logs_count 1 \
-      --storage_count 1 --storage_type ssd-rocksdb-v1 \
-      --dump_pids on > >( tee "${output}" ) 2>&1
+      --storage_count "${ss_count}" --storage_type ssd-sharded-rocksdb \
+      --dump_pids on \
+      > >(tee "${output}") \
+      2> >(tee "${output}" >&2)
     status="$?"
     # Restore exit on error.
     set -o errexit  # a.k.a. set -e
@@ -75,10 +90,16 @@ function start_backup_agent {
   local local_build_dir="${1}"
   local local_scratch_dir="${2}"
   shift 2
+  local extra_knobs=("${@}")
+  # Just using ${extra_knobs[*]} in the below will output a string
+  # quoted by single quotes; its what bash does when string has spaces
+  # or special characters. To get around this, we printf the string instead;
+  # this will print out string w/ spaces w/o quotes.
+  # Don't quote the printf substatement... bash will add single quotes.
   "${local_build_dir}/bin/backup_agent" \
     -C "${local_scratch_dir}/loopback_cluster/fdb.cluster" \
     --log --logdir="${local_scratch_dir}" \
-    ${@} &
+    $(printf "%s" "${extra_knobs[*]}") &
   local pid=$!
   if ! ps -p "${pid}" &> /dev/null; then
     wait "${pid}"

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -1835,7 +1835,7 @@ ACTOR Future<Void> bulkLoadingCore(Reference<DataDistributor> self, Future<Void>
 				std::string remoteFolder = getBulkLoadJobRoot(jobRoot, jobId);
 				std::string jobManifestFileName = getBulkLoadJobManifestFileName();
 				std::string localJobManifestFilePath = joinPath(localFolder, jobManifestFileName);
-				std::string remoteJobManifestFilePath = joinPath(remoteFolder, jobManifestFileName);
+				std::string remoteJobManifestFilePath = appendToPath(remoteFolder, jobManifestFileName);
 				std::unordered_map<Key, BulkLoadJobFileManifestEntry> manifestEntryMap =
 				    wait(fetchBulkLoadTaskManifestEntryMap(
 				        jobTransportMethod, localJobManifestFilePath, remoteJobManifestFilePath, jobRange, self->ddId));

--- a/tests/loopback_cluster/run_custom_cluster.sh
+++ b/tests/loopback_cluster/run_custom_cluster.sh
@@ -52,7 +52,11 @@ function start_servers {
     fi
     local port=$(( PORT_PREFIX + SERVER_COUNT ))
     local zone="${4}-Z-$(( j % REPLICATION_COUNT ))"
-    ${2} "${FDB}" -p auto:"${port}" ${KNOBS:+"$KNOBS"} -c "${3}" \
+    # There may be more than one knob in KNOBS separated by spaces. Bash will quote
+    # it all with single-quotes because the string has a space in it. We don't want
+    # that behavior; fdbserver won't be able to parse the quoted knobs. To get around
+    # this native bash behavior, we printf the KNOBS string.
+    ${2} "${FDB}" -p auto:"${port}" ${KNOBS:+$(printf "%s" "${KNOBS}")} -c "${3}" \
       -d "${datadir}" -L "${logdir}" -C "${CLUSTER}" \
       --datacenter_id="${4}" \
       --locality-zoneid "${zone}" \


### PR DESCRIPTION
Add using s3 if available when running the bulkload ctest.
It was disabled until we made it so the SS could talk to s3
(Added by this PR). Also finish the bulkload test. It was
missing bulkload support recently.

Added passing knobs to the fdb cluster so available to the
fdbserver when it goes to talk to s3. Also added passing SS
count to start in fdb cluster.

* fdbclient/tests/fdb_cluster_fixture.sh Add ability to pass multiple knobs to fdb cluster and to specify more than just one SS.

* fdbserver/fdbserver.actor.cpp Add --blob-server option and processing of FDB_BLOB_CREDENTIALS if present (hijacked the unused, unadvertised -- blob-credentials-file).

* tests/loopback_cluster/run_custom_cluster.sh Allow passing more than just one knob.

* fdbclient/BulkLoading.cpp
* fdbclient/include/fdbclient/BulkLoading.h Added getPath

* fdbclient/S3BlobStore.actor.cpp Fix bug where we were doubling up the first '/' on a path if it had a root '/' already (s3 treats /a/b as distinct from /a//b).

* fdbclient/S3Client.actor.cpp Fix up of traceevent Types.

* fdbclient/tests/bulkload_test.sh Enable being able to use s3 if available. Pick up jobid when bulkdumping. Feed it to new bulkload method. Add verification all data present post-bulkload.

* fdbserver/BulkLoadUtil.actor.cpp Add support for blobstore.

* tests/loopback_cluster/run_custom_cluster.sh Bug fix -- we were only able to pass in one knob. Allow passing multiple.
