### PR TITLE
Fix cycle test valgrind issue

### DIFF
--- a/fdbserver/workloads/Cycle.actor.cpp
+++ b/fdbserver/workloads/Cycle.actor.cpp
@@ -130,9 +130,9 @@ struct CycleWorkload : TestWorkload, CycleMembers<MultiTenancy> {
 	Key keyForIndex(int n) { return key(n); }
 	Key key(int n) { return doubleToTestKey((double)n / nodeCount, keyPrefix); }
 	Value value(int n) { return doubleToTestKey(n, keyPrefix); }
-	KeyRangeRef keyRange(int n) {
-		KeyRef beginKey = doubleToTestKey((double)n / nodeCount, keyPrefix);
-		KeyRef endKey = beginKey.withSuffix(" end"_sr);
+	KeyRange keyRange(int n) {
+		Key beginKey = doubleToTestKey((double)n / nodeCount, keyPrefix);
+		Key endKey = beginKey.withSuffix(" end"_sr);
 		return KeyRangeRef(beginKey, endKey);
 	}
 	int fromValue(const ValueRef& v) { return testKeyToDouble(v, keyPrefix); }


### PR DESCRIPTION
Valgrind caught a "invalid read of size 1" issue because of the [recent cycle workload changes](https://github.com/apple/foundationdb/pull/11890/files#diff-ac00cde936baa1f06996a1d58bef8e99fea94cccec7be3f47cd4c26839c51b68R127-R189). The issue is that we return a `KeyRangeRef` so no one holds the value, and so when it's referenced, valgrind complains. 

As a result, most (all?) tests that rely on Cycle workload were failing valgrind. 

Ran valgrind again and ensured 0 instances of "invalid read of size 1".

100K correctness: `  20250124-230058-praza-923fa93d522695e134a1e4d3e9ce842de01b6c compressed=True data_size=36476956 duration=3800253 ended=100000 fail=5 fail_fast=10 max_runs=100000 pass=99995 priority=100 remaining=0 runtime=2:11:42 sanity=False started=100000 stopped=20250125-011240 submitted=20250124-230058 timeout=5400 username=praza-923fa93d522695e134a1e4d3e9ce842de01b6c97`. All failures known issues and not related to this PR.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
