### PR TITLE
[release-7.3] Fix cycle test valgrind issue

### DIFF
--- a/fdbserver/workloads/Cycle.actor.cpp
+++ b/fdbserver/workloads/Cycle.actor.cpp
@@ -124,9 +124,9 @@ struct CycleWorkload : TestWorkload, CycleMembers<MultiTenancy> {
 	Key keyForIndex(int n) { return key(n); }
 	Key key(int n) { return doubleToTestKey((double)n / nodeCount, keyPrefix); }
 	Value value(int n) { return doubleToTestKey(n, keyPrefix); }
-	KeyRangeRef keyRange(int n) {
-		KeyRef beginKey = doubleToTestKey((double)n / nodeCount, keyPrefix);
-		KeyRef endKey = beginKey.withSuffix(" end"_sr);
+	KeyRange keyRange(int n) {
+		Key beginKey = doubleToTestKey((double)n / nodeCount, keyPrefix);
+		Key endKey = beginKey.withSuffix(" end"_sr);
 		return KeyRangeRef(beginKey, endKey);
 	}
 	int fromValue(const ValueRef& v) { return testKeyToDouble(v, keyPrefix); }


### PR DESCRIPTION
Cherry-pick https://github.com/apple/foundationdb/pull/11906 to 7.3 branch.

100K correctness: ` 20250124-234338-praza-a6fafae2ad6ea434c92a663740003edbd1b26e compressed=True data_size=34272699 duration=3261773 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:25:26 sanity=False started=100000 stopped=20250125-010904 submitted=20250124-234338 timeout=5400 username=praza-a6fafae2ad6ea434c92a663740003edbd1b26e2a`

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
