### PR TITLE
Handle cases when backup worker pulling may miss mutations

### DIFF
--- a/fdbclient/SystemData.cpp
+++ b/fdbclient/SystemData.cpp
@@ -1119,6 +1119,7 @@ const KeyRangeRef backupProgressKeys("\xff\x02/backupProgress/"_sr, "\xff\x02/ba
 const KeyRef backupProgressPrefix = backupProgressKeys.begin;
 const KeyRef backupStartedKey = "\xff\x02/backupStarted"_sr;
 extern const KeyRef backupPausedKey = "\xff\x02/backupPaused"_sr;
+extern const KeyRef backupWorkerMaxNoopVersionKey = "\xff\x02/backupWorkerMaxNoopVersion"_sr;
 
 const Key backupProgressKeyFor(UID workerID) {
 	BinaryWriter wr(Unversioned());

--- a/fdbclient/include/fdbclient/SystemData.h
+++ b/fdbclient/include/fdbclient/SystemData.h
@@ -472,6 +472,9 @@ std::vector<std::pair<UID, Version>> decodeBackupStartedValue(const ValueRef& va
 // 1 = Send a signal to pause/already paused.
 extern const KeyRef backupPausedKey;
 
+// The key to store the maximum version that backup workers popped in NOOP mode.
+extern const KeyRef backupWorkerMaxNoopVersionKey;
+
 //	"\xff/previousCoordinators" = "[[ClusterConnectionString]]"
 //	Set to the encoded structure of the cluster's previous set of coordinators.
 //	Changed when performing quorumChange.

--- a/fdbserver/QuietDatabase.actor.cpp
+++ b/fdbserver/QuietDatabase.actor.cpp
@@ -1015,6 +1015,8 @@ ACTOR Future<Void> disableConsistencyScanInSim(Database db, bool waitForCompleti
 	return Void();
 }
 
+ACTOR Future<Void> disableBackupWorker(Database cx);
+
 // Waits until a database quiets down (no data in flight, small tlog queue, low SQ, no active data distribution). This
 // requires the database to be available and healthy in order to succeed.
 ACTOR Future<Void> waitForQuietDatabase(Database cx,
@@ -1057,6 +1059,10 @@ ACTOR Future<Void> waitForQuietDatabase(Database cx,
 	printf("Set perpetual_storage_wiggle=0 ...\n");
 	state Version version = wait(setPerpetualStorageWiggle(cx, false, LockAware::True));
 	printf("Set perpetual_storage_wiggle=0 Done.\n");
+
+	printf("Disabling backup worker ...\n");
+	wait(disableBackupWorker(cx));
+	printf("Disabled backup worker.\n");
 
 	wait(disableConsistencyScanInSim(cx, false));
 


### PR DESCRIPTION
When TLog replies with a popped version, it means the peek request is missing mutations from the peek's begin version to the popped version. This was not handled in backup worker previously. (#10990 has a different fix of removing the noop mode.)

This PR addresses this by checking if the missing versions are caused by NOOP mode pops. This can only happen when the worker requests mutations in the previous epoch. If so, the worker reads the max popped version due to noop mode, which should be >= tlog reply's popped version. If not, an assertion is triggered, because mutations are missing.

In the NOOP mode, we save the popped version in the system key space "backupWorkerMaxNoopVersionKey". The transaction that saves noop version can cause QuietDatabase workload failure, so I disabled it before the consistency check.

100k BackupCorrectnessPartitioned.toml  20250210-050111-jzhou-37ef394139f3b154
100k regular correctness 20250217-175836-jzhou-bd7a8310904ebc19 , 20250207-033912-jzhou-e83d1a7d767205be

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
