### PR TITLE
Using knob to enable physical shard move in failure injection workloads

### DIFF
--- a/fdbserver/workloads/DataLossRecovery.actor.cpp
+++ b/fdbserver/workloads/DataLossRecovery.actor.cpp
@@ -236,7 +236,10 @@ struct DataLossRecoveryWorkload : TestWorkload {
 				if (SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA) {
 					UID dataMoveId = newDataMoveId(deterministicRandom()->randomUInt64(),
 					                               AssignEmptyRange(false),
-					                               DataMoveType::PHYSICAL,
+					                               deterministicRandom()->random01() <
+					                                       SERVER_KNOBS->DD_PHYSICAL_SHARD_MOVE_PROBABILITY
+					                                   ? DataMoveType::PHYSICAL
+					                                   : DataMoveType::LOGICAL,
 					                               DataMovementReason::TEAM_HEALTHY,
 					                               UnassignShard(false));
 					params = std::make_unique<MoveKeysParams>(dataMoveId,

--- a/fdbserver/workloads/PhysicalShardMove.actor.cpp
+++ b/fdbserver/workloads/PhysicalShardMove.actor.cpp
@@ -22,6 +22,7 @@
 #include "fdbclient/NativeAPI.actor.h"
 #include "fdbrpc/simulator.h"
 #include "fdbserver/IKeyValueStore.h"
+#include "fdbserver/Knobs.h"
 #include "fdbserver/MoveKeys.actor.h"
 #include "fdbserver/QuietDatabase.h"
 #include "fdbserver/ServerCheckpoint.actor.h"
@@ -103,7 +104,10 @@ struct PhysicalShardMoveWorkLoad : TestWorkload {
 		                           cx,
 		                           newDataMoveId(deterministicRandom()->randomUInt64(),
 		                                         AssignEmptyRange::False,
-		                                         DataMoveType::PHYSICAL,
+		                                         deterministicRandom()->random01() <
+		                                                 SERVER_KNOBS->DD_PHYSICAL_SHARD_MOVE_PROBABILITY
+		                                             ? DataMoveType::PHYSICAL
+		                                             : DataMoveType::LOGICAL,
 		                                         dataMoveReason),
 		                           currentRange,
 		                           teamSize,
@@ -122,7 +126,13 @@ struct PhysicalShardMoveWorkLoad : TestWorkload {
 		wait(store(teamA,
 		           self->moveShard(self,
 		                           cx,
-		                           newDataMoveId(sh0, AssignEmptyRange::False, DataMoveType::PHYSICAL, dataMoveReason),
+		                           newDataMoveId(sh0,
+		                                         AssignEmptyRange::False,
+		                                         deterministicRandom()->random01() <
+		                                                 SERVER_KNOBS->DD_PHYSICAL_SHARD_MOVE_PROBABILITY
+		                                             ? DataMoveType::PHYSICAL
+		                                             : DataMoveType::LOGICAL,
+		                                         dataMoveReason),
 		                           currentRange,
 		                           teamSize,
 		                           includes,
@@ -137,14 +147,19 @@ struct PhysicalShardMoveWorkLoad : TestWorkload {
 		// Move range [TestKeyD, TestKeyF) to sh0;
 		includes.insert(teamA.begin(), teamA.end());
 		currentRange = KeyRangeRef("TestKeyD"_sr, "TestKeyF"_sr);
-		state std::vector<UID> teamE =
-		    wait(self->moveShard(self,
-		                         cx,
-		                         newDataMoveId(sh0, AssignEmptyRange::False, DataMoveType::PHYSICAL, dataMoveReason),
-		                         currentRange,
-		                         teamSize,
-		                         includes,
-		                         excludes));
+		state std::vector<UID> teamE = wait(self->moveShard(
+		    self,
+		    cx,
+		    newDataMoveId(sh0,
+		                  AssignEmptyRange::False,
+		                  deterministicRandom()->random01() < SERVER_KNOBS->DD_PHYSICAL_SHARD_MOVE_PROBABILITY
+		                      ? DataMoveType::PHYSICAL
+		                      : DataMoveType::LOGICAL,
+		                  dataMoveReason),
+		    currentRange,
+		    teamSize,
+		    includes,
+		    excludes));
 		TraceEvent(SevDebug, "TestMovedRange3").detail("Range", currentRange).detail("Team", describe(teamE));
 		ASSERT(std::equal(teamA.begin(), teamA.end(), teamE.begin()));
 
@@ -169,14 +184,19 @@ struct PhysicalShardMoveWorkLoad : TestWorkload {
 		// Move range [TestKeyB, TestKeyC) to sh1, on the same server.
 		currentRange = KeyRangeRef("TestKeyB"_sr, "TestKeyC"_sr);
 		includes.insert(teamA.begin(), teamA.end());
-		state std::vector<UID> teamB =
-		    wait(self->moveShard(self,
-		                         cx,
-		                         newDataMoveId(sh1, AssignEmptyRange::False, DataMoveType::PHYSICAL, dataMoveReason),
-		                         currentRange,
-		                         teamSize,
-		                         includes,
-		                         excludes));
+		state std::vector<UID> teamB = wait(self->moveShard(
+		    self,
+		    cx,
+		    newDataMoveId(sh1,
+		                  AssignEmptyRange::False,
+		                  deterministicRandom()->random01() < SERVER_KNOBS->DD_PHYSICAL_SHARD_MOVE_PROBABILITY
+		                      ? DataMoveType::PHYSICAL
+		                      : DataMoveType::LOGICAL,
+		                  dataMoveReason),
+		    currentRange,
+		    teamSize,
+		    includes,
+		    excludes));
 		TraceEvent(SevDebug, "TestMovedRange4").detail("Range", currentRange).detail("Team", describe(teamB));
 		ASSERT(std::equal(teamA.begin(), teamA.end(), teamB.begin()));
 
@@ -200,14 +220,19 @@ struct PhysicalShardMoveWorkLoad : TestWorkload {
 		TraceEvent(SevDebug, "TestCheckpointRestored3");
 
 		currentRange = KeyRangeRef("TestKeyB"_sr, "TestKeyC"_sr);
-		state std::vector<UID> teamC =
-		    wait(self->moveShard(self,
-		                         cx,
-		                         newDataMoveId(sh2, AssignEmptyRange::False, DataMoveType::PHYSICAL, dataMoveReason),
-		                         currentRange,
-		                         teamSize,
-		                         includes,
-		                         excludes));
+		state std::vector<UID> teamC = wait(self->moveShard(
+		    self,
+		    cx,
+		    newDataMoveId(sh2,
+		                  AssignEmptyRange::False,
+		                  deterministicRandom()->random01() < SERVER_KNOBS->DD_PHYSICAL_SHARD_MOVE_PROBABILITY
+		                      ? DataMoveType::PHYSICAL
+		                      : DataMoveType::LOGICAL,
+		                  dataMoveReason),
+		    currentRange,
+		    teamSize,
+		    includes,
+		    excludes));
 		TraceEvent(SevDebug, "TestMovedRange5").detail("Range", currentRange).detail("Team", describe(teamC));
 		ASSERT(std::equal(teamA.begin(), teamA.end(), teamC.begin()));
 

--- a/fdbserver/workloads/RandomMoveKeys.actor.cpp
+++ b/fdbserver/workloads/RandomMoveKeys.actor.cpp
@@ -158,11 +158,14 @@ struct MoveKeysWorkload : FailureInjectionWorkload {
 			state DDEnabledState ddEnabledState;
 			std::unique_ptr<MoveKeysParams> params;
 			if (SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA) {
-				UID dataMoveId = newDataMoveId(deterministicRandom()->randomUInt64(),
-				                               AssignEmptyRange(false),
-				                               DataMoveType::PHYSICAL,
-				                               DataMovementReason::TEAM_HEALTHY,
-				                               UnassignShard(false));
+				UID dataMoveId =
+				    newDataMoveId(deterministicRandom()->randomUInt64(),
+				                  AssignEmptyRange(false),
+				                  deterministicRandom()->random01() < SERVER_KNOBS->DD_PHYSICAL_SHARD_MOVE_PROBABILITY
+				                      ? DataMoveType::PHYSICAL
+				                      : DataMoveType::LOGICAL,
+				                  DataMovementReason::TEAM_HEALTHY,
+				                  UnassignShard(false));
 				params = std::make_unique<MoveKeysParams>(dataMoveId,
 				                                          std::vector<KeyRange>{ keys },
 				                                          destinationTeamIDs,


### PR DESCRIPTION
Currently, createCheckpoint can block the simulation test and causing external timeout. Disable physical shard move everywhere before fully understanding what happens to create checkpoints.

100K correctness test:
  20250128-012736-zhewang-93629742b026f92b           compressed=True data_size=36751089 fail_fast=10 max_runs=100000 priority=100 sanity=False submitted=20250128-012736 timeout=5400 username=zhewang



# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
