### PR TITLE
boost::urls::parse_uri doesn't like credentialed blobstore urls

### DIFF
--- a/fdbclient/BulkLoading.cpp
+++ b/fdbclient/BulkLoading.cpp
@@ -86,25 +86,41 @@ std::string generateBulkLoadJobManifestFileContent(const std::map<Key, BulkLoadM
 	return res;
 }
 
+// For now, we only support blobstore:// urls. Later, lets add support for file:// urls, etc.
+// 'blobstore://' is the first match, credentials including '@' are optional and second regex match.
+// The third match is the host + path, etc. of the url.
+static const std::regex BLOBSTORE_URL_PATTERN(R"((blobstore://)([A-Za-z0-9_-]+:[A-Za-z0-9_-]+:[A-Za-z0-9_-]+@)?(.+)$)");
+
 std::string getPath(const std::string& path) {
-	boost::system::result<boost::urls::url_view> parse_result = boost::urls::parse_uri(path);
-	return parse_result.has_value() ? parse_result.value().path() : path;
+	std::smatch matches;
+	if (!std::regex_match(path, matches, BLOBSTORE_URL_PATTERN)) {
+		return path;
+	}
+	// We want boost::url to parse out the path but it cannot digest credentials. Strip them out
+	// before passing to boost::url.
+	try {
+		boost::urls::url url = boost::urls::parse_uri(matches[1].str() + matches[3].str()).value();
+		return url.path();
+	} catch (const boost::urls::system_error& e) {
+		throw std::invalid_argument("Invalid url " + path + " " + e.what());
+	}
 }
 
 // TODO(BulkLoad): use this everywhere
 std::string appendToPath(const std::string& path, const std::string& append) {
-	boost::system::result<boost::urls::url_view> parse_result = boost::urls::parse_uri(path);
-	if (!parse_result.has_value()) {
-		// Failed to parse 'path' as an URL. Do the default path join.
+	std::smatch matches;
+	if (!std::regex_match(path, matches, BLOBSTORE_URL_PATTERN)) {
 		return joinPath(path, append);
 	}
-	// boost::urls::url thinks its an URL.
-	boost::urls::url url = parse_result.value();
-	if (url.scheme() != "blobstore") {
-		// For now, until we add support for other urls like file:///.
-		throw std::invalid_argument("Invalid url scheme");
+	// We want boost::url to parse out the path but it cannot digest credentials. Strip them out
+	// before passing to boost::url.
+	try {
+		boost::urls::url url = boost::urls::parse_uri(matches[1].str() + matches[3].str()).value();
+		auto newUrl = std::string(url.set_path(joinPath(url.path(), append)).buffer());
+		return matches[1].str() + matches[2].str() + newUrl.substr(matches[1].str().length());
+	} catch (const boost::urls::system_error& e) {
+		throw std::invalid_argument("Invalid url " + path + " " + e.what());
 	}
-	return std::string(url.set_path(joinPath(url.path(), append)).buffer());
 }
 
 std::string getBulkLoadJobRoot(const std::string& root, const UID& jobId) {

--- a/fdbclient/BulkLoading.cpp
+++ b/fdbclient/BulkLoading.cpp
@@ -101,7 +101,7 @@ std::string getPath(const std::string& path) {
 	try {
 		boost::urls::url url = boost::urls::parse_uri(matches[1].str() + matches[3].str()).value();
 		return url.path();
-	} catch (const boost::urls::system_error& e) {
+	} catch (std::system_error& e) {
 		throw std::invalid_argument("Invalid url " + path + " " + e.what());
 	}
 }
@@ -118,7 +118,7 @@ std::string appendToPath(const std::string& path, const std::string& append) {
 		boost::urls::url url = boost::urls::parse_uri(matches[1].str() + matches[3].str()).value();
 		auto newUrl = std::string(url.set_path(joinPath(url.path(), append)).buffer());
 		return matches[1].str() + matches[2].str() + newUrl.substr(matches[1].str().length());
-	} catch (const boost::urls::system_error& e) {
+	} catch (std::system_error& e) {
 		throw std::invalid_argument("Invalid url " + path + " " + e.what());
 	}
 }

--- a/fdbclient/S3Client.actor.cpp
+++ b/fdbclient/S3Client.actor.cpp
@@ -39,6 +39,7 @@
 #include "fdbclient/Knobs.h"
 #include "fdbclient/versions.h"
 #include "fdbclient/S3Client.actor.h"
+#include "fdbclient/BulkLoading.h"
 #include "flow/Platform.h"
 #include "flow/FastRef.h"
 #include "flow/Trace.h"
@@ -138,10 +139,7 @@ ACTOR Future<Void> copyUpBulkDumpFileSet(std::string s3url,
 	    .detail("destinationFileSet", destinationFileSet.toString());
 	state int pNumDeleted = 0;
 	state int64_t pBytesDeleted = 0;
-	// Throws error if s3url is invalid.
-	boost::urls::url url = boost::urls::parse_uri(s3url).value();
-	// Get path to the batch dir.
-	state std::string batch_dir = joinPath(url.path(), destinationFileSet.getRelativePath());
+	state std::string batch_dir = joinPath(getPath(s3url), destinationFileSet.getRelativePath());
 	// Delete the batch dir if it exists already (need to check bucket exists else 404 and s3blobstore errors out).
 	bool exists = wait(endpoint->bucketExists(bucket));
 	if (exists) {


### PR DESCRIPTION
    Was causing appendToPath and getPath to fail.

    * fdbclient/BulkLoading.cpp
     Add a regex so can extract credentials before feeding the
     boost uri parse. Add a tracevent on failed parse.

    * fdbclient/S3Client.actor.cpp
     Use BLOBSTORE_MULTIPART_MAX_PART_SIZE setting maximum size to download.
     THis is what is used elsewhere in the system.