### PR TITLE
Add multiparting to s3client.

### DIFF
--- a/fdbbackup/tests/s3_backup_test.sh
+++ b/fdbbackup/tests/s3_backup_test.sh
@@ -28,7 +28,7 @@ function cleanup {
     shutdown_weed "${TEST_SCRATCH_DIR}"
   fi
   if type shutdown_aws &> /dev/null; then
-    : # shutdown_aws "${TEST_SCRATCH_DIR}"
+    shutdown_aws "${TEST_SCRATCH_DIR}"
   fi
 }
 

--- a/fdbclient/S3Client.actor.cpp
+++ b/fdbclient/S3Client.actor.cpp
@@ -18,15 +18,12 @@
  * limitations under the License.
  */
 
+#include "fdbclient/ClientKnobs.h"
+#include "fdbclient/Knobs.h"
 #include <algorithm>
-#include <cstdlib>
-#include <iostream>
-#include <limits>
 #include <memory>
 #include <string>
 #include <vector>
-#include <fcntl.h>
-#include <filesystem>
 
 #ifdef _WIN32
 #include <io.h>
@@ -35,66 +32,244 @@
 #include "fdbclient/BackupContainerFileSystem.h"
 #include "fdbclient/BackupTLSConfig.h"
 #include "fdbclient/FDBTypes.h"
-#include "fdbclient/IKnobCollection.h"
-#include "fdbclient/Knobs.h"
-#include "fdbclient/versions.h"
 #include "fdbclient/S3Client.actor.h"
+#include "fdbclient/BulkLoading.h"
 #include "flow/Platform.h"
 #include "flow/FastRef.h"
 #include "flow/Trace.h"
 #include "flow/flow.h"
+#include "flow/network.h"
 #include <boost/url/url.hpp>
 #include <boost/url/parse.hpp>
 #include "flow/TLSConfig.actor.h"
+#include "flow/IAsyncFile.h"
 
 #include "flow/actorcompiler.h" // has to be last include
+
+// State for a part of a multipart upload.
+struct PartState {
+	int partNumber = 0;
+	std::string etag;
+	int64_t offset = 0;
+	int64_t size = 0;
+	std::string md5;
+	bool completed = false;
+
+	PartState() = default; // Add explicit default constructor
+
+	PartState(int pNum, int64_t off, int64_t sz, std::string m = "")
+	  : partNumber(pNum), offset(off), size(sz), md5(m) {}
+};
+
+// Config for a part of a multipart upload.
+struct PartConfig {
+	// Let this be the minimum configured part size.
+	int64_t partSizeBytes = CLIENT_KNOBS->BLOBSTORE_MULTIPART_MIN_PART_SIZE;
+	// TODO: Make this settable via knobs.
+	int retryDelayMs = 1000;
+};
 
 // Get the endpoint for the given s3url.
 // Populates parameters and resource with parse of s3url.
 Reference<S3BlobStoreEndpoint> getEndpoint(const std::string& s3url,
                                            std::string& resource,
                                            S3BlobStoreEndpoint::ParametersT& parameters) {
-	std::string error;
-	Reference<S3BlobStoreEndpoint> endpoint =
-	    S3BlobStoreEndpoint::fromString(s3url, {}, &resource, &error, &parameters);
-	if (resource.empty()) {
-		TraceEvent(SevError, "S3ClientEmptyResource").detail("s3url", s3url);
-		throw backup_invalid_url();
-	}
-	for (auto c : resource) {
-		if (!isalnum(c) && c != '_' && c != '-' && c != '.' && c != '/') {
-			TraceEvent(SevError, "S3ClientIllegalCharacter").detail("s3url", s3url);
+	try {
+		std::string error;
+		Reference<S3BlobStoreEndpoint> endpoint =
+		    S3BlobStoreEndpoint::fromString(s3url, {}, &resource, &error, &parameters);
+
+		if (!endpoint) {
+			TraceEvent(SevError, "S3ClientGetEndpointNullEndpoint").detail("URL", s3url).detail("Error", error);
 			throw backup_invalid_url();
 		}
+
+		if (resource.empty()) {
+			TraceEvent(SevError, "S3ClientGetEndpointEmptyResource").detail("URL", s3url);
+			throw backup_invalid_url();
+		}
+
+		// Validate bucket parameter exists
+		if (parameters.find("bucket") == parameters.end()) {
+			TraceEvent(SevError, "S3ClientGetEndpointMissingBucket").detail("URL", s3url);
+			throw backup_invalid_url();
+		}
+
+		// Validate resource path characters
+		for (char c : resource) {
+			if (!isalnum(c) && c != '_' && c != '-' && c != '.' && c != '/') {
+				TraceEvent(SevError, "S3ClientGetEndpointIllegalCharacter")
+				    .detail("URL", s3url)
+				    .detail("Character", std::string(1, c));
+				throw backup_invalid_url();
+			}
+		}
+
+		if (!error.empty()) {
+			TraceEvent(SevError, "S3ClientGetEndpointError").detail("URL", s3url).detail("Error", error);
+			throw backup_invalid_url();
+		}
+
+		return endpoint;
+
+	} catch (Error& e) {
+		TraceEvent(SevError, "S3ClientGetEndpointFailed").error(e).detail("URL", s3url);
+		throw;
 	}
-	if (error.size()) {
-		TraceEvent(SevError, "S3ClientGetEndpointError").detail("s3url", s3url).detail("error", error);
-		throw backup_invalid_url();
+}
+
+// Upload a part of a multipart upload with retry logic.
+ACTOR static Future<PartState> uploadPartWithRetry(Reference<S3BlobStoreEndpoint> endpoint,
+                                                   std::string bucket,
+                                                   std::string objectName,
+                                                   std::string uploadID,
+                                                   PartState part, // Pass by value for state management
+                                                   std::string partData,
+                                                   int retryDelayMs) {
+	state PartState resultPart = part;
+	state UnsentPacketQueue packets;
+
+	try {
+		PacketWriter pw(packets.getWriteBuffer(partData.size()), nullptr, Unversioned());
+		pw.serializeBytes(partData);
+
+		std::string etag = wait(endpoint->uploadPart(
+		    bucket, objectName, uploadID, resultPart.partNumber, &packets, partData.size(), resultPart.md5));
+
+		resultPart.etag = etag;
+		resultPart.completed = true;
+		return resultPart;
+	} catch (Error& e) {
+		TraceEvent(SevWarnAlways, "S3ClientUploadPartError")
+		    .error(e)
+		    .detail("Bucket", bucket)
+		    .detail("Object", objectName)
+		    .detail("PartNumber", part.partNumber);
+		throw;
 	}
-	return endpoint;
 }
 
 // Copy filepath to bucket at resource in s3.
 ACTOR static Future<Void> copyUpFile(Reference<S3BlobStoreEndpoint> endpoint,
                                      std::string bucket,
-                                     std::string resource,
-                                     std::string filepath) {
-	// Reading an SST file fully into memory is pretty obnoxious. They are about 16MB on
-	// average. Streaming would require changing this s3blobstore interface.
-	// Make 32MB the max size for now even though its arbitrary and way to big.
-	state std::string content = readFileBytes(filepath, 1024 * 1024 * 32);
-	TraceEvent("S3ClientCopyUpFileStart")
-	    .detail("filepath", filepath)
-	    .detail("bucket", bucket)
-	    .detail("resource", resource)
-	    .detail("size", content.size());
-	wait(endpoint->writeEntireFile(bucket, resource, content));
-	TraceEvent("S3ClientCopyUpFileEnd")
-	    .detail("filepath", filepath)
-	    .detail("bucket", bucket)
-	    .detail("resource", resource)
-	    .detail("size", content.size());
-	return Void();
+                                     std::string objectName,
+                                     std::string filepath,
+                                     PartConfig config = PartConfig()) {
+	state double startTime = now();
+	state Reference<IAsyncFile> file;
+	state std::string uploadID;
+	state std::vector<Future<PartState>> uploadFutures;
+	state std::vector<PartState> parts;
+	state std::vector<std::string> partDatas;
+	state int64_t size = fileSize(filepath);
+
+	try {
+		TraceEvent("S3ClientCopyUpFileStart")
+		    .detail("filepath", filepath)
+		    .detail("bucket", bucket)
+		    .detail("objectName", objectName)
+		    .detail("fileSize", size);
+
+		// Start multipart upload
+		std::string id = wait(endpoint->beginMultiPartUpload(bucket, objectName));
+		uploadID = id;
+
+		Reference<IAsyncFile> f = wait(IAsyncFileSystem::filesystem()->open(
+		    filepath, IAsyncFile::OPEN_READONLY | IAsyncFile::OPEN_UNCACHED, 0666));
+		file = f;
+
+		state int64_t offset = 0;
+		state int partNumber = 1;
+
+		// Prepare parts
+		while (offset < size) {
+			state int64_t partSize = std::min(config.partSizeBytes, size - offset);
+
+			// Store part data in our vector to keep it alive
+			partDatas.emplace_back();
+			partDatas.back().resize(partSize);
+
+			int bytesRead = wait(file->read(&partDatas.back()[0], partSize, offset));
+			if (bytesRead != partSize) {
+				TraceEvent(SevError, "S3ClientCopyUpFileReadError")
+				    .detail("expected", partSize)
+				    .detail("actual", bytesRead);
+				throw io_error();
+			}
+
+			std::string md5 = HTTP::computeMD5Sum(partDatas.back());
+			state PartState part;
+			part.partNumber = partNumber;
+			part.offset = offset;
+			part.size = partSize;
+			part.md5 = md5;
+			parts.push_back(part);
+
+			uploadFutures.push_back(uploadPartWithRetry(
+			    endpoint, bucket, objectName, uploadID, part, partDatas.back(), config.retryDelayMs));
+
+			offset += partSize;
+			partNumber++;
+		}
+
+		// Wait for all uploads to complete and collect results
+		std::vector<PartState> p = wait(getAll(uploadFutures));
+		parts = p;
+
+		// Clear upload futures to ensure they're done
+		uploadFutures.clear();
+
+		// Only close the file after all uploads are complete
+		file = Reference<IAsyncFile>();
+
+		// Verify all parts completed and prepare etag map
+		std::map<int, std::string> etagMap;
+		for (const auto& part : parts) {
+			if (!part.completed) {
+				TraceEvent(SevWarnAlways, "S3ClientCopyUpFilePartNotCompleted").detail("partNumber", part.partNumber);
+				throw operation_failed();
+			}
+			etagMap[part.partNumber] = part.etag;
+		}
+
+		wait(endpoint->finishMultiPartUpload(bucket, objectName, uploadID, etagMap));
+		// TODO(BulkLoad): Return map of part numbers to md5 or other checksumming so we can save
+		// aside and check integrity of downloaded file
+
+		// Clear data after successful upload
+		parts.clear();
+		partDatas.clear();
+
+		TraceEvent("S3ClientCopyUpFileEnd")
+		    .detail("bucket", bucket)
+		    .detail("objectName", objectName)
+		    .detail("fileSize", size)
+		    .detail("time", now() - startTime);
+
+		return Void();
+	} catch (Error& e) {
+		TraceEvent(SevWarnAlways, "S3ClientCopyUpFileError")
+		    .error(e)
+		    .detail("Bucket", bucket)
+		    .detail("Object", objectName);
+		state Error err = e;
+
+		// Close file before abort attempt
+		file = Reference<IAsyncFile>();
+
+		// Attempt to abort the upload but don't wait for it
+		try {
+			wait(endpoint->abortMultiPartUpload(bucket, objectName, uploadID));
+		} catch (Error& abortError) {
+			// Log abort failure but throw original error
+			TraceEvent(SevWarnAlways, "S3ClientCopyUpFileAbortError")
+			    .error(abortError)
+			    .detail("Bucket", bucket)
+			    .detail("Object", objectName)
+			    .detail("OriginalError", err.what());
+		}
+		throw err;
+	}
 }
 
 ACTOR Future<Void> copyUpFile(std::string filepath, std::string s3url) {
@@ -138,10 +313,7 @@ ACTOR Future<Void> copyUpBulkDumpFileSet(std::string s3url,
 	    .detail("destinationFileSet", destinationFileSet.toString());
 	state int pNumDeleted = 0;
 	state int64_t pBytesDeleted = 0;
-	// Throws error if s3url is invalid.
-	boost::urls::url url = boost::urls::parse_uri(s3url).value();
-	// Get path to the batch dir.
-	state std::string batch_dir = joinPath(url.path(), destinationFileSet.getRelativePath());
+	state std::string batch_dir = joinPath(getPath(s3url), destinationFileSet.getRelativePath());
 	// Delete the batch dir if it exists already (need to check bucket exists else 404 and s3blobstore errors out).
 	bool exists = wait(endpoint->bucketExists(bucket));
 	if (exists) {
@@ -166,27 +338,178 @@ ACTOR Future<Void> copyUpBulkDumpFileSet(std::string s3url,
 	return Void();
 }
 
+ACTOR static Future<PartState> downloadPartWithRetry(Reference<S3BlobStoreEndpoint> endpoint,
+                                                     std::string bucket,
+                                                     std::string objectName,
+                                                     Reference<IAsyncFile> file,
+                                                     PartState part,
+                                                     int retryDelayMs) {
+	state std::vector<uint8_t> buffer;
+	state PartState resultPart = part;
+
+	try {
+		TraceEvent("S3ClientDownloadPartStart")
+		    .detail("Bucket", bucket)
+		    .detail("Object", objectName)
+		    .detail("PartNumber", part.partNumber)
+		    .detail("Offset", resultPart.offset)
+		    .detail("Size", resultPart.size);
+
+		buffer.resize(resultPart.size);
+
+		// Add range validation
+		if (resultPart.offset < 0 || resultPart.size <= 0) {
+			TraceEvent(SevError, "S3ClientDownloadPartInvalidRange")
+			    .detail("Offset", resultPart.offset)
+			    .detail("Size", resultPart.size);
+			throw operation_failed();
+		}
+
+		int bytesRead =
+		    wait(endpoint->readObject(bucket, objectName, buffer.data(), resultPart.size, resultPart.offset));
+
+		if (bytesRead != resultPart.size) {
+			TraceEvent(SevError, "S3ClientDownloadPartSizeMismatch")
+			    .detail("Expected", resultPart.size)
+			    .detail("Actual", bytesRead)
+			    .detail("Offset", resultPart.offset);
+			throw io_error();
+		}
+
+		// Verify MD5 checksum if provided
+		if (!resultPart.md5.empty()) {
+			std::string calculatedMD5 = HTTP::computeMD5Sum(std::string((char*)buffer.data(), bytesRead));
+			if (resultPart.md5 != calculatedMD5) {
+				TraceEvent(SevWarnAlways, "S3ClientDownloadPartMD5Mismatch")
+				    .detail("Expected", resultPart.md5)
+				    .detail("Calculated", calculatedMD5);
+				throw checksum_failed();
+			}
+		}
+
+		wait(file->write(buffer.data(), bytesRead, resultPart.offset));
+
+		resultPart.completed = true;
+		return resultPart;
+	} catch (Error& e) {
+		TraceEvent(SevWarnAlways, "S3ClientDownloadPartError")
+		    .error(e)
+		    .detail("Bucket", bucket)
+		    .detail("Object", objectName)
+		    .detail("PartNumber", part.partNumber);
+		throw;
+	}
+}
+
 // Copy down file from s3 to filepath.
 ACTOR static Future<Void> copyDownFile(Reference<S3BlobStoreEndpoint> endpoint,
                                        std::string bucket,
-                                       std::string resource,
-                                       std::string filepath) {
-	TraceEvent("S3ClientCopyDownFileStart")
-	    .detail("filepath", filepath)
-	    .detail("bucket", bucket)
-	    .detail("resource", resource);
-	std::string content = wait(endpoint->readEntireFile(bucket, resource));
-	auto parent = std::filesystem::path(filepath).parent_path();
-	if (parent != "" && !std::filesystem::exists(parent)) {
-		std::filesystem::create_directories(parent);
+                                       std::string objectName,
+                                       std::string filepath,
+                                       PartConfig config = PartConfig()) {
+	state double startTime = now();
+	state Reference<IAsyncFile> file;
+	state std::vector<Future<PartState>> downloadFutures;
+	state std::vector<PartState> parts;
+	state int64_t fileSize = 0;
+	state int64_t offset = 0;
+	state int partNumber = 1;
+	state int64_t partSize;
+	state Optional<std::string> md5;
+
+	try {
+		TraceEvent("S3ClientCopyDownFileStart")
+		    .detail("Bucket", bucket)
+		    .detail("Object", objectName)
+		    .detail("FilePath", filepath);
+
+		int64_t s = wait(endpoint->objectSize(bucket, objectName));
+		if (s <= 0) {
+			TraceEvent(SevWarnAlways, "S3ClientCopyDownFileEmptyFile")
+			    .detail("Bucket", bucket)
+			    .detail("Object", objectName);
+			throw file_not_found();
+		}
+		fileSize = s;
+
+		// Create parent directory if it doesn't exist
+		std::string dirPath = filepath.substr(0, filepath.find_last_of("/"));
+		if (!dirPath.empty()) {
+			platform::createDirectory(dirPath);
+		}
+
+		// Pre-allocate vectors to avoid reallocations
+		int numParts = (fileSize + config.partSizeBytes - 1) / config.partSizeBytes;
+		parts.reserve(numParts);
+		downloadFutures.reserve(numParts);
+		Reference<IAsyncFile> f = wait(
+		    IAsyncFileSystem::filesystem()->open(filepath, IAsyncFile::OPEN_CREATE | IAsyncFile::OPEN_READWRITE, 0644));
+		file = f;
+		// Pre-allocate file size to avoid fragmentation
+		wait(file->truncate(fileSize));
+
+		while (offset < fileSize) {
+			partSize = std::min(config.partSizeBytes, fileSize - offset);
+
+			parts.emplace_back(partNumber, offset, partSize, "");
+
+			downloadFutures.push_back(
+			    downloadPartWithRetry(endpoint, bucket, objectName, file, parts.back(), config.retryDelayMs));
+
+			offset += partSize;
+			partNumber++;
+		}
+		std::vector<PartState> completedParts = wait(getAll(downloadFutures));
+
+		// Clear futures to free memory
+		downloadFutures.clear();
+
+		// Verify all parts completed
+		for (const auto& part : completedParts) {
+			if (!part.completed) {
+				TraceEvent(SevError, "S3ClientCopyDownFilePartNotCompleted").detail("PartNumber", part.partNumber);
+				throw operation_failed();
+			}
+		}
+
+		// Set exact file size: without this, file has padding on the end.
+		wait(file->truncate(fileSize));
+		// Ensure all data is written to disk
+		wait(file->sync());
+
+		// Close file properly
+		file = Reference<IAsyncFile>();
+
+		// TODO(Bulkload): Check integrity of downloaded file.
+		TraceEvent("S3ClientCopyDownFileEnd")
+		    .detail("Bucket", bucket)
+		    .detail("Object", objectName)
+		    .detail("FileSize", fileSize)
+		    .detail("TimeTaken", now() - startTime)
+		    .detail("Parts", parts.size());
+
+		return Void();
+	} catch (Error& e) {
+		state Error err = e;
+		TraceEvent(SevWarnAlways, "S3ClientCopyDownFileError")
+		    .error(e)
+		    .detail("Bucket", bucket)
+		    .detail("Object", objectName)
+		    .detail("FilePath", filepath);
+
+		// Clean up the file in case of error
+		if (file) {
+			try {
+				wait(file->sync());
+				file = Reference<IAsyncFile>();
+				IAsyncFileSystem::filesystem()->deleteFile(filepath, false);
+			} catch (Error& e) {
+				TraceEvent(SevWarnAlways, "S3ClientCopyDownFileCleanupError").error(e).detail("FilePath", filepath);
+			}
+		}
+
+		throw err;
 	}
-	writeFile(filepath, content);
-	TraceEvent("S3ClientCopyDownFileEnd")
-	    .detail("filepath", filepath)
-	    .detail("bucket", bucket)
-	    .detail("resource", resource)
-	    .detail("size", content.size());
-	return Void();
 }
 
 ACTOR Future<Void> copyDownFile(std::string s3url, std::string filepath) {

--- a/fdbclient/S3Client_cli.actor.cpp
+++ b/fdbclient/S3Client_cli.actor.cpp
@@ -337,7 +337,10 @@ int main(int argc, char** argv) {
 		    new CSimpleOpt(argc, argv, s3client_cli::Options, SO_O_EXACT | SO_O_HYPHEN_TO_UNDERSCORE | SO_O_NOERR));
 		auto param = makeReference<s3client_cli::Params>();
 		status = s3client_cli::parseCommandLine(param, args.get());
-		std::cout << "Command line: " << commandLine << " " << param->toString() << std::endl;
+		TraceEvent("S3ClientCommandLine")
+		    .detail("CommandLine", commandLine)
+		    .detail("Params", param->toString())
+		    .detail("Status", status);
 		if (status != FDB_EXIT_SUCCESS) {
 			s3client_cli::printUsage(argv[0]);
 			return status;

--- a/fdbclient/include/fdbclient/S3BlobStore.h
+++ b/fdbclient/include/fdbclient/S3BlobStore.h
@@ -424,4 +424,7 @@ public:
 	                                   std::string const& object,
 	                                   std::string const& uploadID,
 	                                   MultiPartSetT const& parts);
+	Future<Void> abortMultiPartUpload(std::string const& bucket,
+	                                  std::string const& object,
+	                                  std::string const& uploadID);
 };

--- a/fdbclient/include/fdbclient/S3Client.actor.h
+++ b/fdbclient/include/fdbclient/S3Client.actor.h
@@ -37,6 +37,11 @@
 //   blobstore://<access_key>:<secret_key>@<endpoint>/resource?bucket=<bucket>, etc.
 // See the section 'Backup URls' in the backup documentation,
 // https://apple.github.io/foundationdb/backups.html, for more information.
+// Checksumming: up and down load are now multipart. While we md5 the upload
+// part -- the upload will be rejected by s3 if it doesn't match its calculation
+// on its side -- a checksum of the whole file is best maintained externally,
+// created before file upload, and then verified as equal the downloaded assembled
+// files checksum.
 // TODO: Handle prefix as a parameter on the URL so can strip the first part
 // of the resource from the blobstore URL.
 

--- a/fdbrpc/HTTP.actor.cpp
+++ b/fdbrpc/HTTP.actor.cpp
@@ -489,10 +489,7 @@ ACTOR Future<Void> read_http_request(Reference<HTTP::IncomingRequest> r, Referen
 	}
 
 	if (ss && !ss.eof()) {
-		TraceEvent(SevWarn, "HTTPRequestExtraData")
-		    .detail("Buffer", buf)
-		    .detail("Pos", pos)
-		    .detail("LineLen", lineLen);
+		TraceEvent(SevWarn, "HTTPRequestExtraData").detail("Buffer", buf).detail("Pos", pos).detail("LineLen", lineLen);
 		throw http_bad_response();
 	}
 

--- a/fdbrpc/HTTP.actor.cpp
+++ b/fdbrpc/HTTP.actor.cpp
@@ -463,8 +463,7 @@ ACTOR Future<Void> read_http_request(Reference<HTTP::IncomingRequest> r, Referen
 		TraceEvent(SevWarn, "HTTPRequestVerbNotFound")
 		    .detail("Buffer", buf)
 		    .detail("Pos", pos)
-		    .detail("LineLen", lineLen)
-		    .log();
+		    .detail("LineLen", lineLen);
 		throw http_bad_response();
 	}
 
@@ -474,8 +473,7 @@ ACTOR Future<Void> read_http_request(Reference<HTTP::IncomingRequest> r, Referen
 		TraceEvent(SevWarn, "HTTPRequestResourceNotFound")
 		    .detail("Buffer", buf)
 		    .detail("Pos", pos)
-		    .detail("LineLen", lineLen)
-		    .log();
+		    .detail("LineLen", lineLen);
 		throw http_bad_response();
 	}
 
@@ -486,8 +484,7 @@ ACTOR Future<Void> read_http_request(Reference<HTTP::IncomingRequest> r, Referen
 		TraceEvent(SevWarn, "HTTPRequestHTTPVersionNotFound")
 		    .detail("Buffer", buf)
 		    .detail("Pos", pos)
-		    .detail("LineLen", lineLen)
-		    .log();
+		    .detail("LineLen", lineLen);
 		throw http_bad_response();
 	}
 
@@ -495,8 +492,7 @@ ACTOR Future<Void> read_http_request(Reference<HTTP::IncomingRequest> r, Referen
 		TraceEvent(SevWarn, "HTTPRequestExtraData")
 		    .detail("Buffer", buf)
 		    .detail("Pos", pos)
-		    .detail("LineLen", lineLen)
-		    .log();
+		    .detail("LineLen", lineLen);
 		throw http_bad_response();
 	}
 
@@ -506,8 +502,7 @@ ACTOR Future<Void> read_http_request(Reference<HTTP::IncomingRequest> r, Referen
 		TraceEvent(SevWarn, "HTTPRequestHTTPVersionLessThan1_1")
 		    .detail("Buffer", buf)
 		    .detail("Pos", pos)
-		    .detail("LineLen", lineLen)
-		    .log();
+		    .detail("LineLen", lineLen);
 		throw http_bad_response();
 	}
 
@@ -737,7 +732,6 @@ ACTOR Future<Reference<HTTP::IncomingResponse>> doRequestActor(Reference<IConnec
 		}
 
 		if (err.present()) {
-			event.detail("IsThisTheDuplicateInlineError", err.get().name());
 			throw err.get();
 		}
 

--- a/fdbrpc/HTTP.actor.cpp
+++ b/fdbrpc/HTTP.actor.cpp
@@ -23,6 +23,7 @@
 
 #include "flow/IRandom.h"
 #include "flow/Net2Packet.h"
+#include "flow/Trace.h"
 #include "md5/md5.h"
 #include "libb64/encode.h"
 #include "flow/Knobs.h"
@@ -127,7 +128,15 @@ std::string IncomingResponse::toString() const {
 	for (auto h : data.headers)
 		r += fmt::format("Response Header: {0}: {1}\n", h.first, h.second);
 	r.append("-- RESPONSE CONTENT--\n");
-	r.append(data.content);
+	// Limit the length of the response content to 1024 bytes for logging.
+	// No one wants 40MB of content dumped to the console.
+	int maxLen = 1024;
+	if (data.content.size() > maxLen) {
+		r.append(data.content.substr(0, maxLen));
+		r.append("...\n");
+	} else {
+		r.append(data.content);
+	}
 	r.append("\n--------\n");
 	return r;
 }
@@ -243,8 +252,9 @@ ACTOR Future<size_t> read_delimited_into_string(Reference<IConnection> conn,
 // Reads from conn (as needed) until there are at least len bytes starting at pos in buf
 ACTOR Future<Void> read_fixed_into_string(Reference<IConnection> conn, int len, std::string* buf, size_t pos) {
 	state int stop_size = pos + len;
-	while (buf->size() < stop_size)
+	while (buf->size() < stop_size) {
 		wait(success(read_into_string(conn, buf, FLOW_KNOBS->HTTP_READ_SIZE)));
+	}
 	return Void();
 }
 
@@ -255,7 +265,6 @@ ACTOR Future<Void> read_http_response_headers(Reference<IConnection> conn,
 	loop {
 		// Get a line, reading more data from conn if necessary
 		size_t lineLen = wait(read_delimited_into_string(conn, "\r\n", buf, *pos));
-
 		// If line is empty we have reached the end of the headers.
 		if (lineLen == 0) {
 			// Increment pos to move past the empty line.
@@ -283,6 +292,7 @@ ACTOR Future<Void> read_http_response_headers(Reference<IConnection> conn,
 			*pos += valueStart;
 		} else {
 			// Malformed header line (at least according to this simple parsing)
+			TraceEvent(SevError, "HTTPReadHeadersMalformed").detail("Buffer", *buf).detail("Pos", *pos);
 			throw http_bad_response();
 		}
 
@@ -295,6 +305,7 @@ ACTOR Future<Void> read_http_response_headers(Reference<IConnection> conn,
 			*pos += len;
 		} else {
 			// Malformed header line (at least according to this simple parsing)
+			TraceEvent(SevError, "HTTPReadHeadersMalformed").detail("Buffer", *buf).detail("Pos", *pos);
 			throw http_bad_response();
 		}
 
@@ -302,6 +313,7 @@ ACTOR Future<Void> read_http_response_headers(Reference<IConnection> conn,
 	}
 }
 
+// buf has the http header line in it at *pos offset.
 // FIXME: should this throw a different error for http requests? Or should we rename http_bad_response to
 // http_bad_<something>?
 ACTOR Future<Void> readHTTPData(HTTPData<std::string>* r,
@@ -316,15 +328,17 @@ ACTOR Future<Void> readHTTPData(HTTPData<std::string>* r,
 	wait(read_http_response_headers(conn, &r->headers, buf, pos));
 
 	auto i = r->headers.find("Content-Length");
-	if (i != r->headers.end())
+	if (i != r->headers.end()) {
 		r->contentLen = strtoll(i->second.c_str(), NULL, 10);
-	else
+	} else {
 		r->contentLen = -1; // Content length unknown
+	}
 
 	state std::string transferEncoding;
 	i = r->headers.find("Transfer-Encoding");
-	if (i != r->headers.end())
+	if (i != r->headers.end()) {
 		transferEncoding = i->second;
+	}
 
 	r->content.clear();
 
@@ -342,11 +356,15 @@ ACTOR Future<Void> readHTTPData(HTTPData<std::string>* r,
 		*pos = 0;
 
 		// Read until there are at least contentLen bytes available at pos
-		wait(read_fixed_into_string(conn, r->contentLen, &r->content, *pos));
+		wait(read_fixed_into_string(conn, r->contentLen - r->content.size(), &r->content, *pos));
 
 		// There shouldn't be any bytes after content.
-		if (r->content.size() != r->contentLen)
+		if (r->content.size() != r->contentLen) {
+			TraceEvent(SevError, "HTTPContentLengthMismatch")
+			    .detail("ContentLength", r->contentLen)
+			    .detail("ContentSize", r->content.size());
 			throw http_bad_response();
+		}
 	} else if (transferEncoding == "chunked") {
 		// Copy remaining buffer data to content which will now be the read buffer for the chunk encoded data.
 		// Overall this will be fairly efficient since most bytes will only be written once but some bytes will
@@ -391,13 +409,20 @@ ACTOR Future<Void> readHTTPData(HTTPData<std::string>* r,
 		wait(read_http_response_headers(conn, &r->headers, &r->content, pos));
 
 		// If the header parsing did not consume all of the buffer then something is wrong
-		if (*pos != r->content.size())
+		if (*pos != r->content.size()) {
+			TraceEvent(SevError, "HTTPContentLengthMismatch2")
+			    .detail("ContentLength", r->contentLen)
+			    .detail("ContentSize", r->content.size());
 			throw http_bad_response();
+		}
 
 		// Now truncate the buffer to just the dechunked contiguous content.
 		r->content.erase(r->contentLen);
 	} else {
 		// Some unrecogize response content scheme is being used.
+		TraceEvent(SevError, "HTTPUnknownContentScheme")
+		    .detail("ContentLength", r->contentLen)
+		    .detail("ContentSize", r->content.size());
 		throw http_bad_response();
 	}
 
@@ -408,10 +433,14 @@ ACTOR Future<Void> readHTTPData(HTTPData<std::string>* r,
 		}
 
 		if (!HTTP::verifyMD5(r, false)) { // false arg means do not fail if the Content-MD5 header is missing.
+			TraceEvent(SevError, "HTTPMD5Mismatch")
+			    .detail("ContentLength", r->contentLen)
+			    .detail("ContentSize", r->content.size());
 			throw http_bad_response();
 		}
 	}
 
+	TraceEvent(SevInfo, "HTTPReadHTTPDataDone").detail("ContentSize", r->content.size());
 	return Void();
 }
 
@@ -432,12 +461,22 @@ ACTOR Future<Void> read_http_request(Reference<HTTP::IncomingRequest> r, Referen
 	// read verb
 	ss >> r->verb;
 	if (ss.fail()) {
+		TraceEvent(SevError, "HTTPRequestVerbNotFound")
+		    .detail("Buffer", buf)
+		    .detail("Pos", pos)
+		    .detail("LineLen", lineLen)
+		    .log();
 		throw http_bad_response();
 	}
 
 	// read resource
 	ss >> r->resource;
 	if (ss.fail()) {
+		TraceEvent(SevError, "HTTPRequestResourceNotFound")
+		    .detail("Buffer", buf)
+		    .detail("Pos", pos)
+		    .detail("LineLen", lineLen)
+		    .log();
 		throw http_bad_response();
 	}
 
@@ -445,16 +484,31 @@ ACTOR Future<Void> read_http_request(Reference<HTTP::IncomingRequest> r, Referen
 	std::string httpVersion;
 	ss >> httpVersion;
 	if (ss.fail()) {
+		TraceEvent(SevError, "HTTPRequestHTTPVersionNotFound")
+		    .detail("Buffer", buf)
+		    .detail("Pos", pos)
+		    .detail("LineLen", lineLen)
+		    .log();
 		throw http_bad_response();
 	}
 
 	if (ss && !ss.eof()) {
+		TraceEvent(SevError, "HTTPRequestExtraData")
+		    .detail("Buffer", buf)
+		    .detail("Pos", pos)
+		    .detail("LineLen", lineLen)
+		    .log();
 		throw http_bad_response();
 	}
 
 	float version;
 	sscanf(httpVersion.c_str(), "HTTP/%f", &version);
 	if (version < 1.1) {
+		TraceEvent(SevError, "HTTPRequestHTTPVersionLessThan1_1")
+		    .detail("Buffer", buf)
+		    .detail("Pos", pos)
+		    .detail("LineLen", lineLen)
+		    .log();
 		throw http_bad_response();
 	}
 
@@ -462,7 +516,6 @@ ACTOR Future<Void> read_http_request(Reference<HTTP::IncomingRequest> r, Referen
 	pos += lineLen + 2;
 
 	wait(readHTTPData(&r->data, conn, &buf, &pos, false, false));
-
 	return Void();
 }
 
@@ -494,8 +547,14 @@ ACTOR Future<Void> read_http_response(Reference<HTTP::IncomingResponse> r,
 
 	int reachedEnd = -1;
 	sscanf(buf.c_str() + pos, "HTTP/%f %d%n", &r->version, &r->code, &reachedEnd);
-	if (reachedEnd < 0)
+	if (reachedEnd < 0) {
+		TraceEvent(SevError, "HTTPResponseCodeNotFound")
+		    .detail("Buffer", buf)
+		    .detail("Pos", pos)
+		    .detail("LineLen", lineLen)
+		    .log();
 		throw http_bad_response();
+	}
 
 	// Move position past the line found and the delimiter length
 	pos += lineLen + 2;
@@ -568,7 +627,9 @@ ACTOR Future<Reference<HTTP::IncomingResponse>> doRequestActor(Reference<IConnec
 		}
 
 		state Reference<HTTP::IncomingResponse> r(new HTTP::IncomingResponse());
+		event.detail("IsHeaderOnlyResponse", request->isHeaderOnlyResponse());
 		state Future<Void> responseReading = r->read(conn, request->isHeaderOnlyResponse());
+		event.detail("ResponseReading", responseReading.isReady());
 
 		send_start = timer();
 
@@ -584,6 +645,8 @@ ACTOR Future<Reference<HTTP::IncomingResponse>> doRequestActor(Reference<IConnec
 				    .detail("Error", responseReading.isError())
 				    .detail("QueueEmpty", request->data.content->empty())
 				    .detail("Verb", request->verb)
+				    .detail("TotalSent", total_sent)
+				    .detail("ContentLen", request->data.contentLen)
 				    .log();
 				conn->close();
 				r->data.headers["Connection"] = "close";
@@ -602,8 +665,9 @@ ACTOR Future<Reference<HTTP::IncomingResponse>> doRequestActor(Reference<IConnec
 			sendRate->returnUnused(trySend - len);
 			total_sent += len;
 			request->data.content->sent(len);
-			if (request->data.content->empty())
+			if (request->data.content->empty()) {
 				break;
+			}
 
 			wait(conn->onWritable());
 			wait(yield(TaskPriority::WriteSocket));
@@ -615,6 +679,7 @@ ACTOR Future<Reference<HTTP::IncomingResponse>> doRequestActor(Reference<IConnec
 		event.detail("ResponseCode", r->code);
 		event.detail("ResponseContentLen", r->data.contentLen);
 		event.detail("Elapsed", elapsed);
+		event.detail("RequestIDHeader", requestIDHeader);
 
 		Optional<Error> err;
 		if (!requestIDHeader.empty()) {
@@ -623,7 +688,6 @@ ACTOR Future<Reference<HTTP::IncomingResponse>> doRequestActor(Reference<IConnec
 			if (iid != r->data.headers.end()) {
 				responseID = iid->second;
 			}
-			event.detail("RequestIDReceived", responseID);
 
 			// If the response code is 5xx (server error) then a response ID is not expected
 			// so a missing id will be ignored but a mismatching id will still be an error.
@@ -632,6 +696,7 @@ ACTOR Future<Reference<HTTP::IncomingResponse>> doRequestActor(Reference<IConnec
 			// If request/response IDs do not match and either this is not a server error
 			// or it is but the response ID is not empty then log an error.
 			if (requestID != responseID && (!serverError || !responseID.empty())) {
+				event.detail("RequestIDMismatch", true);
 				err = http_bad_request_id();
 
 				TraceEvent(SevError, "HTTPRequestFailedIDMismatch")
@@ -662,6 +727,7 @@ ACTOR Future<Reference<HTTP::IncomingResponse>> doRequestActor(Reference<IConnec
 			           total_sent,
 			           r->data.contentLen);
 		}
+
 		if (FLOW_KNOBS->HTTP_VERBOSE_LEVEL > 2) {
 			fmt::print("[{}] HTTP RESPONSE:  {} {}\n{}\n",
 			           conn->getDebugID().toString(),
@@ -671,6 +737,7 @@ ACTOR Future<Reference<HTTP::IncomingResponse>> doRequestActor(Reference<IConnec
 		}
 
 		if (err.present()) {
+			event.detail("IsThisTheDuplicateInlineError", err.get().name());
 			throw err.get();
 		}
 


### PR DESCRIPTION
    Add multiparting uploading/downloading to s3client.
    Fix boost::urls::parse_uri 's dislike of credentialed blobstore urls.
    Add specific logging when an inspecific exception is thrown.
    Limit response content output (big files crashed logging).

    * fdbclient/BulkLoading.cpp
     Add blobstore regex to extract credentials before feeding the boost
     parse_uri.

    * fdbclient/include/fdbclient/S3BlobStore.h
    * fdbclient/S3BlobStore.actor.cpp
     Add cleanup of failed multipart -- abortMultiPartUpload l(s3 will do
     this in the background eventually but lets clean up after ourselves).
     Also add  getObjectRangeMD5 so can do multipart checksumming.

    * fdbclient/S3Client.actor.cpp
     Change upload file and download file to do multipart always.
     Retry too.

    * fdbclient/S3Client_cli.actor.cpp
     Add command line to trace rather than output.
