### PR TITLE
Gray failure observability

### DIFF
--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -3071,7 +3071,10 @@ ACTOR Future<Void> workerHealthMonitor(ClusterControllerData* self) {
 							}
 							invalidateExcludedProcessComplaints(self);
 							TraceEvent(SevWarnAlways, "DegradedServerDetectedAndTriggerRecovery")
-							    .detail("RecentRecoveryCountDueToHealth", self->recentRecoveryCountDueToHealth());
+							    .detail("RecentRecoveryCountDueToHealth", self->recentRecoveryCountDueToHealth())
+							    .detail("DegradedServers", degradedServerString)
+							    .detail("DisconnectedServers", disconnectedServerString)
+							    .detail("DegradedSatellite", self->degradationInfo.degradedSatellite);
 							self->db.forceMasterFailure.trigger();
 						} else {
 							TraceEvent(SevWarnAlways, "RecentRecoveryCountHigh")


### PR DESCRIPTION
# Description

For easier/faster debugging, adding more trace events to the gray failure code. Note that this spans both worker code that sends the complaints, and CC code that processes them.

For each trace event, we have to make sure that it is not too verbose. I have added comments in the PR for each trace event explaining the rationale behind the severity. Feel free to recommend changes. 

# Testing

100K correctness: `20250204-081819-praza-e31fb0efda7ef69bb858b6e27322af5b622ec3 compressed=True data_size=36628836 duration=4975910 ended=100000 fail=1 fail_fast=10 max_runs=100000 pass=99999 priority=100 remaining=0 runtime=1:08:49 sanity=False started=100000 stopped=20250204-092708 submitted=20250204-081819 timeout=5400 username=praza-e31fb0efda7ef69bb858b6e27322af5b622ec387`. Only failure is in BulkLoading.toml, which is a known issue and under investigation, we think https://github.com/apple/foundationdb/pull/11898 could solve it. 

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
