### PR TITLE
Version vector: compute locations only once during commits.

### DIFF
--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -869,7 +869,6 @@ std::set<Tag> CommitBatchContext::getWrittenTagsPreResolution() {
 		}
 	}
 
-	// if (toCommit.logSystem->hasRemoteLogs()) {
 	if (toCommit.getLogRouterTags()) {
 		toCommit.storeRandomRouterTag();
 		transactionTags.insert(toCommit.savedRandomRouterTag.get());

--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -1787,6 +1787,11 @@ ACTOR Future<Void> applyMetadataToCommittedTransactions(CommitBatchContext* self
 		if (SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST) {
 			// TraceEvent("ResolverReturn").detail("ReturnTags",reply.writtenTags).detail("TPCVsize",reply.tpcvMap.size()).detail("ReqTags",self->writtenTagsPreResolution);
 			self->tpcvMap = reply.tpcvMap;
+			std::vector<int> locations(self->tpcvMap.size());
+			for (const auto& pair : self->tpcvMap) {
+				locations.push_back(pair.first);
+			}
+			self->toCommit.setPushLocations(locations);
 		}
 		self->toCommit.addWrittenTags(reply.writtenTags);
 	}

--- a/fdbserver/LogSystem.cpp
+++ b/fdbserver/LogSystem.cpp
@@ -217,7 +217,7 @@ void LogSet::getPushLocations(VectorRef<Tag> tags,
                               std::vector<int>& locations,
                               int locationOffset,
                               bool allLocations,
-                              Optional<Reference<LocalitySet>> restrictedLogSet) {
+                              const Optional<Reference<LocalitySet>>& restrictedLogSet) {
 	if (locality == tagLocalitySatellite) {
 		for (auto& t : tags) {
 			if (t.locality == tagLocalityTxs || t.locality == tagLocalityLogRouter) {

--- a/fdbserver/LogSystem.cpp
+++ b/fdbserver/LogSystem.cpp
@@ -213,7 +213,11 @@ bool LogSet::satisfiesPolicy(const std::vector<LocalityEntry>& locations) {
 	return resultEntries.size() == 0;
 }
 
-void LogSet::getPushLocations(VectorRef<Tag> tags, std::vector<int>& locations, int locationOffset, bool allLocations) {
+void LogSet::getPushLocations(VectorRef<Tag> tags,
+                              std::vector<int>& locations,
+                              int locationOffset,
+                              bool allLocations,
+                              Optional<Reference<LocalitySet>> restrictedLogSet) {
 	if (locality == tagLocalitySatellite) {
 		for (auto& t : tags) {
 			if (t.locality == tagLocalityTxs || t.locality == tagLocalityLogRouter) {
@@ -256,7 +260,12 @@ void LogSet::getPushLocations(VectorRef<Tag> tags, std::vector<int>& locations, 
 	}
 
 	// Run the policy, assert if unable to satisfy
-	bool result = logServerSet->selectReplicas(tLogPolicy, alsoServers, resultEntries);
+	bool result;
+	if (restrictedLogSet.present()) {
+		result = restrictedLogSet.get()->selectReplicas(tLogPolicy, alsoServers, resultEntries);
+	} else {
+		result = logServerSet->selectReplicas(tLogPolicy, alsoServers, resultEntries);
+	}
 	ASSERT(result);
 
 	// Add the new servers to the location array

--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -638,6 +638,7 @@ Future<Version> TagPartitionedLogSystem::push(const ILogSystem::PushVersionSet& 
 				if (tpcvMap.get().contains(location)) {
 					prevVersion = tpcvMap.get()[location];
 				} else {
+					ASSERT(!msg.size());
 					location++;
 					continue;
 				}

--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -1798,18 +1798,27 @@ Version TagPartitionedLogSystem::getPeekEnd() const {
 		return std::numeric_limits<Version>::max();
 }
 
+/**
+ * This function identifies the locality sets corresponding to a provided list of
+ * numeric locations (a subset of the tLogs), effectively creating a set of restricted
+ * locality sets.
+ *
+ * "fromLocations" is a vector of unique numeric locations representing tLogs.
+ * Returns a vector of Reference<LocalitySet> objects, where each LocalitySet is
+ * restricted to the provided locations that fall within its range.
+ */
 std::vector<Reference<LocalitySet>> TagPartitionedLogSystem::getPushLocationsForTags(
     std::vector<int>& fromLocations) const {
 	std::vector<Reference<LocalitySet>> restrictedLogSets;
+	int locationOffset = 0;
 	for (auto& log : tLogs) {
-		int locationOffset = 0;
-
 		if (!log->isLocal || !log->logServers.size()) {
 			locationOffset += log->logServers.size();
 			continue;
 		}
 		std::vector<LocalityEntry> e;
 		for (int i : fromLocations) {
+			// check if provided location falls within the local logSet's range
 			if (i >= locationOffset && i < locationOffset + log->logServers.size()) {
 				e.emplace_back(LocalityEntry(i));
 			}

--- a/fdbserver/include/fdbserver/LogSystem.h
+++ b/fdbserver/include/fdbserver/LogSystem.h
@@ -102,11 +102,12 @@ public:
 
 	bool satisfiesPolicy(const std::vector<LocalityEntry>& locations);
 
-	void getPushLocations(VectorRef<Tag> tags,
-	                      std::vector<int>& locations,
-	                      int locationOffset,
-	                      bool allLocations = false,
-	                      Optional<Reference<LocalitySet>> restrictedLogSet = Optional<Reference<LocalitySet>>());
+	void getPushLocations(
+	    VectorRef<Tag> tags,
+	    std::vector<int>& locations,
+	    int locationOffset,
+	    bool allLocations = false,
+	    const Optional<Reference<LocalitySet>>& restrictedLogSet = Optional<Reference<LocalitySet>>());
 
 private:
 	std::vector<LocalityEntry> alsoServers, resultEntries;

--- a/fdbserver/include/fdbserver/LogSystem.h
+++ b/fdbserver/include/fdbserver/LogSystem.h
@@ -852,7 +852,7 @@ private:
 			return;
 		}
 		msg_locations.clear();
-		logSystem->getPushLocations(prev_tags, msg_locations, allLocations);
+		logSystem->getPushLocations(tags, msg_locations, allLocations);
 	}
 };
 

--- a/fdbserver/include/fdbserver/TagPartitionedLogSystem.actor.h
+++ b/fdbserver/include/fdbserver/TagPartitionedLogSystem.actor.h
@@ -306,7 +306,12 @@ struct TagPartitionedLogSystem final : ILogSystem, ReferenceCounted<TagPartition
 
 	Version getPeekEnd() const;
 
-	void getPushLocations(VectorRef<Tag> tags, std::vector<int>& locations, bool allLocations) const final;
+	void getPushLocations(VectorRef<Tag> tags,
+	                      std::vector<int>& locations,
+	                      bool allLocations,
+	                      Optional<std::vector<Reference<LocalitySet>>> fromLocations) const final;
+
+	std::vector<Reference<LocalitySet>> getPushLocationsForTags(std::vector<int>& fromLocations) const final;
 
 	bool hasRemoteLogs() const final;
 


### PR DESCRIPTION
During commits with version vector enabled, compute location list only once on the resolver. Recalculating a second time could generate a different random number, hence a different set of locations. The location list is generated with a call to `getPushLocations`, which chooses random locations if the total number of tLogs mod the replica count results in collisions.  

Tested by loading commits from branch version-vector-disk-queue and observing `getPushLocations ` is called in both the resolver and on the CP in `assignMutationsToStorageServers`. Observed different locations chosen without the PR, resulting in data not sent to tLogs when it should have been. Added an assert if data was generated for a location but was not sent to a tLog to catch any such future cases.

This PR exposed another problem where a shard is moved after pre-resolution. That problem will be fixed in a separate PR.

Joshua ` 20250204-185355-dlambrig-83a293ba8c4a1d87`

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
