### PR TITLE
Fix assertion failure in GcGenerations workload.

### DIFF
--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -2641,7 +2641,7 @@ ACTOR Future<Void> disableConnectionFailuresAfter(double seconds, std::string co
 		wait(delay(seconds));
 		while (true) {
 			double delaySeconds = disableConnectionFailures(context, ForceDisable::False);
-			if (delaySeconds > 0) {
+			if (delaySeconds > 0.001) {
 				wait(delay(delaySeconds));
 			} else {
 				break;

--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -2639,7 +2639,14 @@ ACTOR Future<Void> disableConnectionFailuresAfter(double seconds, std::string co
 		TraceEvent(SevWarnAlways, ("ScheduleDisableConnectionFailures_" + context).c_str())
 		    .detail("At", now() + seconds);
 		wait(delay(seconds));
-		disableConnectionFailures(context);
+		while (true) {
+			double delaySeconds = disableConnectionFailures(context, ForceDisable::False);
+			if (delaySeconds > 0) {
+				wait(delay(delaySeconds));
+			} else {
+				break;
+			}
+		}
 	}
 	return Void();
 }
@@ -2859,7 +2866,7 @@ ACTOR Future<Void> runTests(Reference<AsyncVar<Optional<struct ClusterController
 		}
 	}
 
-	enableConnectionFailures("Tester");
+	enableConnectionFailures("Tester", FLOW_KNOBS->SIM_SPEEDUP_AFTER_SECONDS);
 	state Future<Void> disabler = disableConnectionFailuresAfter(FLOW_KNOBS->SIM_SPEEDUP_AFTER_SECONDS, "Tester");
 	state Future<Void> repairDataCenter;
 	if (useDB) {

--- a/fdbserver/workloads/GcGenerations.actor.cpp
+++ b/fdbserver/workloads/GcGenerations.actor.cpp
@@ -194,9 +194,13 @@ struct GcGenerationsWorkload : TestWorkload {
 		double startTime = now();
 		double workloadEnd = now() + self->testDuration;
 		TraceEvent("GcGenerations").detail("StartTime", startTime).detail("EndTime", workloadEnd);
+		// Sometimes Cycle Setup can take a long time, so we need to enable connection failures
+		// injection for clogRemoteDc() to work properly.
+		enableConnectionFailures("GcGenerations");
 
 		wait(self->generateMultipleTxnGenerations(self, cx));
 		self->unclogAll();
+		disableConnectionFailures("GcGenerations");
 
 		wait(self->generationReduced(self));
 

--- a/fdbserver/workloads/GcGenerations.actor.cpp
+++ b/fdbserver/workloads/GcGenerations.actor.cpp
@@ -200,6 +200,7 @@ struct GcGenerationsWorkload : TestWorkload {
 
 		wait(self->generateMultipleTxnGenerations(self, cx));
 		self->unclogAll();
+		disableConnectionFailures("GcGenerations");
 
 		wait(self->generationReduced(self));
 

--- a/fdbserver/workloads/GcGenerations.actor.cpp
+++ b/fdbserver/workloads/GcGenerations.actor.cpp
@@ -196,11 +196,10 @@ struct GcGenerationsWorkload : TestWorkload {
 		TraceEvent("GcGenerations").detail("StartTime", startTime).detail("EndTime", workloadEnd);
 		// Sometimes Cycle Setup can take a long time, so we need to enable connection failures
 		// injection for clogRemoteDc() to work properly.
-		enableConnectionFailures("GcGenerations");
+		extendConnectionFailures("GcGenerations", FLOW_KNOBS->SIM_SPEEDUP_AFTER_SECONDS);
 
 		wait(self->generateMultipleTxnGenerations(self, cx));
 		self->unclogAll();
-		disableConnectionFailures("GcGenerations");
 
 		wait(self->generationReduced(self));
 


### PR DESCRIPTION
Sometimes Cycle Setup can take a long time (`setupRange()` in BulkSetup.actor.h probably has high conflict rate, maybe need a fix in a separate PR), so we need to enable connection failures injection for clogRemoteDc() to work properly. Otherwise, assertions in generateMultipleTxnGenerations() can fire, because of no clogging, and the recovery count can go down.

100k correctness 20250206-050816-jzhou-d6d9cbed80c1e96d             compressed=True data_size=36488909 duration=5076752 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:29:32 sanity=False started=100000 stopped=20250206-063748 submitted=20250206-050816 timeout=5400 username=jzhou

100k GcGeneration tests 20250206-055005-jzhou-05f58be99772b35b             compressed=True data_size=36522282 duration=15775411 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:23:14 sanity=False started=100000 stopped=20250206-071319 submitted=20250206-055005 timeout=5400 username=jzhou

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
