### PR TITLE
Fix double new database in ChangeConfig workLoad

### DIFF
--- a/fdbserver/workloads/ChangeConfig.actor.cpp
+++ b/fdbserver/workloads/ChangeConfig.actor.cpp
@@ -72,6 +72,7 @@ struct ChangeConfigWorkload : TestWorkload {
 				TraceEvent("WaitForReplicasExtra").log();
 				wait(waitForFullReplication(db));
 				TraceEvent("WaitForReplicasExtraEnd").log();
+				existingDB = true;
 			}
 			std::string configMode = self->configMode;
 			if (existingDB) {


### PR DESCRIPTION
When a simulation starts, we use ChangeConfig workload to setup the database configuration. If the simulated cluster needsRemote == true, the workload sets the config using g_simulator->startingDisabledConfiguration at first and then set config using self->configMode. However, since startingDisabledConfiguration and configMode share the same prefix, the workload tries to "new" the database for twice.  However, changeConfig managementAPI is failed to set the second config (suppose to be the expected final state after the workload) because the configuration has been set with the startingDisabledConfiguration. Meanwhile, the startingDisabledConfiguration sets the remote DC priority as -1. As a result, the remote DC cannot be selected to do failover. Then, the recovery gets stuck and the simulation is stuck.

100K correctness tests:
  20250205-211948-zhewang-ec7aa522fccdb0fa           compressed=True data_size=36751932 fail_fast=10 max_runs=100000 priority=100 sanity=False submitted=20250205-211948 timeout=5400 username=zhewang
        
# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
