### PR TITLE
Update ConfigureDatabase workload to issue aggressive storage migration if needed

### DIFF
--- a/fdbserver/workloads/ConfigureDatabase.actor.cpp
+++ b/fdbserver/workloads/ConfigureDatabase.actor.cpp
@@ -524,7 +524,7 @@ struct ConfigureDatabaseWorkload : TestWorkload {
 						state std::vector<StorageServerInterface> storageServers = wait(getStorageServers(cx));
 						std::string localityFilter;
 						int selectSSCount =
-						    deterministicRandom()->randomInt(1, std::min(4, (int)(storageServers.size())));
+						    deterministicRandom()->randomInt(1, std::min(4, (int)(storageServers.size() + 1)));
 						std::vector<StringRef> localityKeys = { LocalityData::keyDcId,
 							                                    LocalityData::keyDataHallId,
 							                                    LocalityData::keyZoneId,

--- a/fdbserver/workloads/ConfigureDatabase.actor.cpp
+++ b/fdbserver/workloads/ConfigureDatabase.actor.cpp
@@ -301,12 +301,42 @@ struct ConfigureDatabaseWorkload : TestWorkload {
 		return Void();
 	}
 
+	// Returns true iff aggressive migration was triggered.
+	// This is needed because there are certain topologies where it's not possible for DD (perpetual wiggle) to migrate
+	// storage servers to the new storage engine. As an example, if the DC has just 1 SS, DD will decide not to do
+	// perpetual wiggle because there's no room. In such cases, we issue aggressive migration which can do in-place
+	// migration.
+	ACTOR Future<bool> issueAggressiveMigrationIfNeeded(Database cx,
+	                                                    DatabaseConfiguration conf,
+	                                                    std::vector<StorageServerInterface> storageServers) {
+		state std::unordered_map<std::string /* dc id */, int /* number of ss in that dc id */> dcIdToSSCount;
+		for (const auto& ss : storageServers) {
+			if (ss.locality.dcId().present()) {
+				const auto& dcId = ss.locality.dcId().get().toString();
+				if (!dcIdToSSCount.contains(dcId)) {
+					dcIdToSSCount[dcId] = 0;
+				}
+				dcIdToSSCount[dcId] += 1;
+			}
+		}
+
+		for (const auto& [_, ssCount] : dcIdToSSCount) {
+			if (ssCount <= conf.storageTeamSize) {
+				wait(success(IssueConfigurationChange(cx, "storage_migration_type=aggressive", false)));
+				return true;
+			}
+		}
+
+		return false;
+	}
+
 	ACTOR Future<bool> _check(ConfigureDatabaseWorkload* self, Database cx) {
 		wait(delay(30.0));
 		// only storage_migration_type=gradual && perpetual_storage_wiggle=1 need this check because in QuietDatabase
 		// perpetual wiggle will be forced to close For other cases, later ConsistencyCheck will check KV store type
 		// there
 		if (self->allowTestStorageMigration || self->waitStoreTypeCheck) {
+			state bool aggressiveMigrationTriggered = false;
 			loop {
 				// There exists a race where the check can start before the last transaction that singleDB issued
 				// finishes, if singleDB gets actor cancelled from a timeout at the end of a test. This means the
@@ -321,6 +351,11 @@ struct ConfigureDatabaseWorkload : TestWorkload {
 
 				state bool pass = true;
 				state std::vector<StorageServerInterface> storageServers = wait(getStorageServers(cx));
+
+				if (!aggressiveMigrationTriggered) {
+					wait(store(aggressiveMigrationTriggered,
+					           self->issueAggressiveMigrationIfNeeded(cx, conf, storageServers)));
+				}
 
 				for (i = 0; i < storageServers.size(); i++) {
 					// Check that each storage server has the correct key value store type


### PR DESCRIPTION
# Description

The `ConfigureDatabase` workload used by tests like `ConfigureStorageMigrationTest.toml` issues multiple db reconfigurations, some of which can be storage engine type changes. In such cases, we rely on perpetual wiggle (driven by DD / data distributor) to eventually move all storage servers to the new storage engine type (specified in the db config). 

There are certain topologies where it's not possible for DD to migrate storage servers to the new storage engine. As an example, if the DC has just 1 SS, [DD will decide not to do perpetual wiggle because there's no room](https://github.com/apple/foundationdb/blob/06cdf2e0303a921c6a88d18e001b9d09ba589fcd/fdbserver/DDTeamCollection.actor.cpp#L2317-L2319). This was happening for some Joshua tests which were then failing the `check` phase of the workload where we assert that all storage servers must migrate to the latest configured storage engine type.

The fix is to do "aggressive" migration which is in-place and can work with just 1 storage server. But this step is taken conditionally based on numbers of storage servers in the DC and storage server replication factor. 

When I did testing, I noticed another issue:
```
int selectSSCount =deterministicRandom()->randomInt(1, std::min(4, (int)(storageServers.size())));
```

If `storageServers.size()` is 1, then we'll assert in DeterminsticRandom.cpp. This is because `randomInt` expects `maxPlusOne` as its second argument. I fixed this issue too. 

# Testing

Ran `ConfigureStorageMigrationTest.toml` 20K times: 

```
20250205-220341-praza-r134572343-fix9-0b19ba4bee5e748cead6fa compressed=True data_size=36661051 duration=1195609 ended=20000 fail=1 fail_fast=50 max_runs=20000 pass=19999 priority=100 remaining=0 runtime=0:42:15 sanity=False started=20000 stopped=20250205-224556 submitted=20250205-220341 timeout=5400 username=praza-r134572343-fix9-0b19ba4bee5e748cead6fac0a3175495952255a6
```

Without my change, I was seeing ~25 failures in 20K. 

The 1 failure above is the DeterminsticRandom assertion mentioned in the description. 

Did two more runs with latest changes, 25K with just `ConfigureStorageMigrationTest.toml`:

```
 20250206-003714-praza-r134572343-fix9-71c3c3ca9b0c844a942bef compressed=True data_size=36661269 duration=1401394 ended=20000 fail_fast=50 max_runs=20000 pass=20000 priority=100 remaining=0 runtime=0:48:13 sanity=False started=20000 stopped=20250206-012527 submitted=20250206-003714 timeout=5400 username=praza-r134572343-fix9-71c3c3ca9b0c844a942bef5357b93d8cbdb39111
 ````
 
 0 failures.

Ran 100K general because other tests could be using the workload changed in this PR:
 ```
  20250206-201858-praza-r134572343-fix9-71c3c3ca9b0c844a942bef compressed=True data_size=36631362 duration=5072628 ended=100000 fail=1 fail_fast=10 max_runs=100000 pass=99999 priority=100 remaining=0 runtime=1:16:04 sanity=False started=100000 stopped=20250206-213502 submitted=20250206-201858 timeout=5400 username=praza-r134572343-fix9-71c3c3ca9b0c844a942bef5357b93d8cbdb39111
```

1 failures which is in GcGenerations is a known issue (should be fixed after https://github.com/apple/foundationdb/pull/11926). 

Made another change, ran same tests again:

20K:
```
20250206-225158-praza-r134572343-fix9-367cc213311e03bf1580bf compressed=True data_size=36661252 duration=1428652 ended=20000 fail_fast=50 max_runs=20000 pass=20000 priority=100 remaining=0 runtime=0:45:52 sanity=False started=20000 stopped=20250206-233750 submitted=20250206-225158 timeout=5400 username=praza-r134572343-fix9-367cc213311e03bf1580bff89c046186ba52db3e
```

100K general currently running:
```
20250207-005140-praza-r134572343-fix9-367cc213311e03bf1580bf compressed=True data_size=36631243 duration=1447035 ended=29066 fail_fast=10 ma
x_runs=100000 pass=29066 priority=100 remaining=1:12:28 runtime=0:29:42 sanity=False started=30455 submitted=20250207-005140 timeout=5400 username=pra
za-r134572343-fix9-367cc213311e03bf1580bff89c046186ba52db3e
```

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
