### PR TITLE
Improve BulkLoad Implementation

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -383,7 +383,8 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( DD_BULKLOAD_TASK_METADATA_READ_SIZE,                   100 ); if( randomize && BUGGIFY ) DD_BULKLOAD_TASK_METADATA_READ_SIZE = deterministicRandom()->randomInt(2, 100);
 	init( DD_BULKLOAD_PARALLELISM,                                10 ); if( randomize && BUGGIFY ) DD_BULKLOAD_PARALLELISM = deterministicRandom()->randomInt(1, 10);
 	init( DD_BULKLOAD_SCHEDULE_MIN_INTERVAL_SEC,                 5.0 ); if( randomize && BUGGIFY ) DD_BULKLOAD_SCHEDULE_MIN_INTERVAL_SEC = deterministicRandom()->random01() * 4 + 1;
-	init( CC_ENFORCE_USE_UNFIT_DD_IN_SIM,                      false ); 
+	init( CC_ENFORCE_USE_UNFIT_DD_IN_SIM,                      false );
+	init( DISABLE_AUDIT_STORAGE_FINAL_REPLICA_CHECK_IN_SIM,    false ); 
 	init( SS_BULKLOAD_GETRANGE_BATCH_SIZE,                     10000 ); if (isSimulated) SS_BULKLOAD_GETRANGE_BATCH_SIZE = deterministicRandom()->randomInt(1, 10);
 
 	// BulkDumping

--- a/fdbclient/include/fdbclient/ServerKnobs.h
+++ b/fdbclient/include/fdbclient/ServerKnobs.h
@@ -410,7 +410,8 @@ public:
 	                                              // between two rounds
 	bool CC_ENFORCE_USE_UNFIT_DD_IN_SIM; // Set for CC to enforce to use an unfit DD in the simulation. This knob
 	                                     // takes effect only in the simulation.
-	bool DISABLE_AUDIT_STORAGE_FINAL_REPLICA_CHECK_IN_SIM; // Set to disable audit storage replica check in the simulation.
+	bool DISABLE_AUDIT_STORAGE_FINAL_REPLICA_CHECK_IN_SIM; // Set to disable audit storage replica check in the
+	                                                       // simulation.
 	int DD_BULKDUMP_PARALLELISM; // the max number of concurrent bulk dump tasks in DD
 	int SS_SERVE_BULKDUMP_PARALLELISM; // the number of bulk dump tasks that can concurrently happen at a SS
 	int64_t SS_BULKDUMP_BATCH_BYTES; // the max bytes when SS creates a batch to dump

--- a/fdbclient/include/fdbclient/ServerKnobs.h
+++ b/fdbclient/include/fdbclient/ServerKnobs.h
@@ -410,6 +410,7 @@ public:
 	                                              // between two rounds
 	bool CC_ENFORCE_USE_UNFIT_DD_IN_SIM; // Set for CC to enforce to use an unfit DD in the simulation. This knob
 	                                     // takes effect only in the simulation.
+	bool DISABLE_AUDIT_STORAGE_FINAL_REPLICA_CHECK_IN_SIM; // Set to disable audit storage replica check in the simulation.
 	int DD_BULKDUMP_PARALLELISM; // the max number of concurrent bulk dump tasks in DD
 	int SS_SERVE_BULKDUMP_PARALLELISM; // the number of bulk dump tasks that can concurrently happen at a SS
 	int64_t SS_BULKDUMP_BATCH_BYTES; // the max bytes when SS creates a batch to dump

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -35,19 +35,14 @@
 #include "fdbclient/RunRYWTransaction.actor.h"
 #include "fdbclient/StorageServerInterface.h"
 #include "fdbclient/SystemData.h"
-#include "fdbclient/Tenant.h"
-#include "fdbrpc/Replication.h"
 #include "fdbserver/BulkDumpUtil.actor.h"
 #include "fdbserver/BulkLoadUtil.actor.h"
 #include "fdbserver/DDSharedContext.h"
 #include "fdbserver/DDTeamCollection.h"
 #include "fdbserver/DataDistribution.actor.h"
 #include "fdbserver/FDBExecHelper.actor.h"
-#include "fdbserver/IKeyValueStore.h"
-#include "fdbserver/Knobs.h"
 #include "fdbserver/MoveKeys.actor.h"
 #include "fdbserver/QuietDatabase.h"
-#include "fdbserver/ServerDBInfo.h"
 #include "fdbserver/TLogInterface.h"
 #include "fdbserver/TenantCache.h"
 #include "fdbserver/WaitFailure.h"
@@ -55,7 +50,6 @@
 #include "fdbserver/MockDataDistributor.h"
 #include "flow/ActorCollection.h"
 #include "flow/Arena.h"
-#include "flow/BooleanParam.h"
 #include "flow/Error.h"
 #include "flow/Platform.h"
 #include "flow/Trace.h"
@@ -2016,7 +2010,7 @@ ACTOR Future<Void> bulkDumpUploadJobManifestFile(Reference<DataDistributor> self
 	generateBulkDumpJobManifestFile(localFolder, localJobManifestFilePath, content, self->ddId);
 	wait(uploadBulkDumpJobManifestFile(
 	    transportMethod, localJobManifestFilePath, remoteFolder, jobManifestFileName, self->ddId));
-	clearFileFolder(localFolder);
+	clearFileFolder(localFolder, self->ddId, /*ignoreError=*/true); // best effort to clear the local folder
 	return Void();
 }
 

--- a/fdbserver/include/fdbserver/BulkDumpUtil.actor.h
+++ b/fdbserver/include/fdbserver/BulkDumpUtil.actor.h
@@ -35,7 +35,7 @@ struct SSBulkDumpTask {
 	SSBulkDumpTask(const StorageServerInterface& targetServer,
 	               const std::vector<UID>& checksumServers,
 	               const BulkDumpState& bulkDumpState)
-	  : targetServer(targetServer), checksumServers(checksumServers), bulkDumpState(bulkDumpState) {};
+	  : targetServer(targetServer), checksumServers(checksumServers), bulkDumpState(bulkDumpState){};
 
 	std::string toString() const {
 		return "[BulkDumpState]: " + bulkDumpState.toString() + ", [TargetServer]: " + targetServer.toString() +

--- a/fdbserver/include/fdbserver/BulkDumpUtil.actor.h
+++ b/fdbserver/include/fdbserver/BulkDumpUtil.actor.h
@@ -35,7 +35,7 @@ struct SSBulkDumpTask {
 	SSBulkDumpTask(const StorageServerInterface& targetServer,
 	               const std::vector<UID>& checksumServers,
 	               const BulkDumpState& bulkDumpState)
-	  : targetServer(targetServer), checksumServers(checksumServers), bulkDumpState(bulkDumpState){};
+	  : targetServer(targetServer), checksumServers(checksumServers), bulkDumpState(bulkDumpState) {};
 
 	std::string toString() const {
 		return "[BulkDumpState]: " + bulkDumpState.toString() + ", [TargetServer]: " + targetServer.toString() +
@@ -122,9 +122,6 @@ ACTOR Future<Void> uploadBulkDumpFileSet(BulkLoadTransportMethod transportMethod
                                          BulkLoadFileSet sourceFileSet,
                                          BulkLoadFileSet destinationFileSet,
                                          UID logId);
-
-// Erase file folder
-void clearFileFolder(const std::string& folderPath);
 
 class ParallelismLimitor {
 public:

--- a/fdbserver/include/fdbserver/BulkLoadUtil.actor.h
+++ b/fdbserver/include/fdbserver/BulkLoadUtil.actor.h
@@ -28,11 +28,18 @@
 #include "fdbclient/BulkLoading.h"
 #include "flow/actorcompiler.h" // has to be last include
 
-// Get the bulkLoadTask metadata of the dataMoveMetadata since the minVersion given the dataMoveId
-ACTOR Future<Optional<BulkLoadTaskState>> getBulkLoadTaskStateFromDataMove(Database cx,
-                                                                           UID dataMoveId,
-                                                                           Version minVersion,
-                                                                           UID logId);
+// Erase file folder
+void clearFileFolder(const std::string& folderPath, const UID& logId = UID(), bool ignoreError = false);
+
+// Erase and recreate file folder
+void resetFileFolder(const std::string& folderPath);
+
+// Get the bulkLoadTask metadata of the dataMoveMetadata since the atLeastVersion given the dataMoveId
+// This actor is stuck if the actor is failed to read the dataMoveMetadata.
+ACTOR Future<BulkLoadTaskState> getBulkLoadTaskStateFromDataMove(Database cx,
+                                                                 UID dataMoveId,
+                                                                 Version atLeastVersion,
+                                                                 UID logId);
 
 ACTOR Future<BulkLoadFileSet> bulkLoadDownloadTaskFileSet(BulkLoadTransportMethod transportMethod,
                                                           BulkLoadFileSet fromRemoteFileSet,

--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -1310,6 +1310,9 @@ ACTOR Future<Void> changeConfiguration(Database cx, std::vector<TesterInterface>
 }
 
 ACTOR Future<Void> auditStorageCorrectness(Reference<AsyncVar<ServerDBInfo>> dbInfo, AuditType auditType) {
+	if (SERVER_KNOBS->DISABLE_AUDIT_STORAGE_FINAL_REPLICA_CHECK_IN_SIM && (auditType == AuditType::ValidateHA || auditType == AuditType::ValidateReplica))	{
+		return Void();
+	}
 	TraceEvent(SevDebug, "AuditStorageCorrectnessBegin").detail("AuditType", auditType);
 	state Database cx;
 	state UID auditId;
@@ -1964,6 +1967,9 @@ ACTOR Future<Void> runConsistencyCheckerUrgentHolder(Reference<AsyncVar<Optional
 }
 
 Future<Void> checkConsistencyUrgentSim(Database cx, std::vector<TesterInterface> testers) {
+	if (SERVER_KNOBS->DISABLE_AUDIT_STORAGE_FINAL_REPLICA_CHECK_IN_SIM) {
+		return Void();
+	}
 	return runConsistencyCheckerUrgentHolder(
 	    Reference<AsyncVar<Optional<ClusterControllerFullInterface>>>(), cx, testers, 1, /*repeatRun=*/false);
 }

--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -1310,7 +1310,8 @@ ACTOR Future<Void> changeConfiguration(Database cx, std::vector<TesterInterface>
 }
 
 ACTOR Future<Void> auditStorageCorrectness(Reference<AsyncVar<ServerDBInfo>> dbInfo, AuditType auditType) {
-	if (SERVER_KNOBS->DISABLE_AUDIT_STORAGE_FINAL_REPLICA_CHECK_IN_SIM && (auditType == AuditType::ValidateHA || auditType == AuditType::ValidateReplica))	{
+	if (SERVER_KNOBS->DISABLE_AUDIT_STORAGE_FINAL_REPLICA_CHECK_IN_SIM &&
+	    (auditType == AuditType::ValidateHA || auditType == AuditType::ValidateReplica)) {
 		return Void();
 	}
 	TraceEvent(SevDebug, "AuditStorageCorrectnessBegin").detail("AuditType", auditType);

--- a/tests/fast/BulkDumping.toml
+++ b/tests/fast/BulkDumping.toml
@@ -40,6 +40,7 @@ disable_audit_storage_final_replica_check_in_sim = true
 [[test]]
 testTitle = 'BulkDumpingWorkload'
 useDB = true
+waitForQuiescence = false
 
     [[test.workload]]
     testName = 'BulkDumpingWorkload'

--- a/tests/fast/BulkDumping.toml
+++ b/tests/fast/BulkDumping.toml
@@ -34,6 +34,9 @@ min_byte_sampling_probability = 0.5
 # CC can repeatedly re-recruit new DD for the unfit recruitment which can block the test.
 cc_enforce_use_unfit_dd_in_sim = true
 
+# AuditStorage replica check can cause tooManyTraceEvents because both tests are large
+disable_audit_storage_final_replica_check_in_sim = true
+
 [[test]]
 testTitle = 'BulkDumpingWorkload'
 useDB = true

--- a/tests/fast/BulkLoading.toml
+++ b/tests/fast/BulkLoading.toml
@@ -34,6 +34,9 @@ min_byte_sampling_probability = 0.5
 # CC can repeatedly re-recruit new DD for the unfit recruitment which can block the test.
 cc_enforce_use_unfit_dd_in_sim = true
 
+# AuditStorage replica check can cause tooManyTraceEvents because both tests are large
+disable_audit_storage_final_replica_check_in_sim = true
+
 [[test]]
 testTitle = 'BulkLoadingWorkload'
 useDB = true

--- a/tests/fast/BulkLoading.toml
+++ b/tests/fast/BulkLoading.toml
@@ -40,6 +40,7 @@ disable_audit_storage_final_replica_check_in_sim = true
 [[test]]
 testTitle = 'BulkLoadingWorkload'
 useDB = true
+waitForQuiescence = false
 
     [[test.workload]]
     testName = 'BulkLoadingWorkload'


### PR DESCRIPTION
This PR mainly addresses comments of PR https://github.com/apple/foundationdb/pull/11898:
1. Add comments.
2. Avoid doing fallback when a SS is failed to get the bulkLoad metadata. Here, we assume that if a datamoveId indicating this is a bulkload data move, the data move metadata should contain the bulkLoad metadata. Note that if the cluster is restarts from an old system, it is possible that the data move ID is misleading. However, when DD restarts, any data move with a bulkload id is cancelled. So, if a SS is failed to get the bulkLoad metadata, this data move is guaranteed to be cancelled. 
3. Using clearFileFolder at all places for bulkload to do folder clean up. This code cleanup is helpful in the future when we want to do this operation in background.
4. Add `DISABLE_AUDIT_STORAGE_FINAL_REPLICA_CHECK_IN_SIM` knob to disable auditStorage replica check and distributed consistency check specifically in bulkLoad and bulkDump tests.

100K correctness with 1 irrelevant failure:
  20250207-015704-zhewang-8fa98cdc12534559           compressed=True data_size=36777951 duration=4160254 ended=100000 fail=1 fail_fast=10 max_runs=100000 pass=99999 priority=100 remaining=0 runtime=0:55:45 sanity=False started=100000 stopped=20250207-025249 submitted=20250207-015704 timeout=5400 username=zhewang
    
 100K bulkLoad tests:
  20250207-031518-zhewang-2cdde02bd2f231bb           compressed=True data_size=36814093 duration=8758862 ended=100000 fail=3 fail_fast=10 max_runs=100000 pass=99997 priority=100 remaining=0 runtime=1:07:06 sanity=False started=100000 stopped=20250207-042224 submitted=20250207-031518 timeout=5400 username=zhewang
  
 100K bulkDump tests:
 
   
# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
