### PR TITLE
Fix startMoveShards() caused corruption [release-7.3]

### DIFF
--- a/fdbserver/MoveKeys.actor.cpp
+++ b/fdbserver/MoveKeys.actor.cpp
@@ -1609,6 +1609,7 @@ ACTOR static Future<Void> startMoveShards(Database occ,
 			state Key begin = keys.begin;
 			state KeyRange currentKeys = keys;
 
+			state std::vector<Future<Void>> actors; // Note this clears ongoing actors from the previous iteration
 			state Transaction tr(occ);
 
 			try {
@@ -1690,7 +1691,6 @@ ACTOR static Future<Void> startMoveShards(Database occ,
 				}
 
 				currentKeys = KeyRangeRef(begin, keys.end);
-				state std::vector<Future<Void>> actors;
 
 				if (!currentKeys.empty()) {
 					const int rowLimit = SERVER_KNOBS->MOVE_SHARD_KRM_ROW_LIMIT;


### PR DESCRIPTION
cherrypick #11933

At commit: fff5439e with clang, seed -f ./tests/slow/SharedDefaultBackupCorrectness.toml -s 2189316179 -b on We found a corruption where the destination storage server can get the incorrect serverKeys mutations. Note this only happens when shard_encode_location_metadata is enabled.

The reason is that one of the actors in the previous iteration encountered transaction_too_old error, and the transaction restarted. However, because the actors are not cancelled, these can still modify the next transaction that retried.

20250210-221107-jzhou-0c392d2cdd03d0ae

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
