### PR TITLE
Resolve BulkLoad test failure for TooManyTraceEvent issue

### DIFF
--- a/fdbserver/worker.actor.cpp
+++ b/fdbserver/worker.actor.cpp
@@ -1129,6 +1129,7 @@ TEST_CASE("/fdbserver/worker/addressIsRemoteLogRouter") {
 // Returns true if the `peer` has enough measurement samples that should be checked by the health monitor.
 bool shouldCheckPeer(Reference<Peer> peer) {
 	TraceEvent(SevDebug, "ShouldCheckPeer")
+	    .suppressFor(0.1)
 	    .detail("ConnectFailedCount", peer->connectFailedCount)
 	    .detail("PingLatencyPopulationSize", peer->pingLatencies.getPopulationSize());
 

--- a/tests/fast/BulkDumping.toml
+++ b/tests/fast/BulkDumping.toml
@@ -37,6 +37,9 @@ cc_enforce_use_unfit_dd_in_sim = true
 # AuditStorage replica check can cause tooManyTraceEvents because both tests are large
 disable_audit_storage_final_replica_check_in_sim = true
 
+# Since the machineCount is large, this test produces more trace events to complete
+max_trace_lines = 5000000
+
 [[test]]
 testTitle = 'BulkDumpingWorkload'
 useDB = true

--- a/tests/fast/BulkLoading.toml
+++ b/tests/fast/BulkLoading.toml
@@ -37,6 +37,9 @@ cc_enforce_use_unfit_dd_in_sim = true
 # AuditStorage replica check can cause tooManyTraceEvents because both tests are large
 disable_audit_storage_final_replica_check_in_sim = true
 
+# Since the machineCount is large, this test produces more trace events to complete
+max_trace_lines = 5000000
+
 [[test]]
 testTitle = 'BulkLoadingWorkload'
 useDB = true


### PR DESCRIPTION
Reduce ShouldCheckPeer frequency and increase max_trace_lines for bulkload tests.

100K correctness tests:
  20250210-231437-zhewang-9dda6b1ec86a55b8           compressed=True data_size=36782485 fail_fast=10 max_runs=100000 priority=100 sanity=False submitted=20250210-231437 timeout=5400 username=zhewang

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
