### PR TITLE
Improve code readability for ParallelismLimitor used by BulkLoad

### DIFF
--- a/fdbserver/include/fdbserver/BulkDumpUtil.actor.h
+++ b/fdbserver/include/fdbserver/BulkDumpUtil.actor.h
@@ -133,10 +133,15 @@ public:
 		ASSERT(numRunningTasks.get() >= 0);
 	}
 
+	inline void incrementTaskCounter() {
+		ASSERT(numRunningTasks.get() < maxParallelism);
+		numRunningTasks.set(numRunningTasks.get() + 1);
+		ASSERT(numRunningTasks.get() <= maxParallelism);
+	}
+
 	// return true if succeed
-	inline bool tryIncrementTaskCounter() {
+	inline bool canStart() {
 		if (numRunningTasks.get() < maxParallelism) {
-			numRunningTasks.set(numRunningTasks.get() + 1);
 			return true;
 		} else {
 			return false;


### PR DESCRIPTION
Address comments in PR https://github.com/apple/foundationdb/pull/11937

100K bulkLoad:
  20250211-213711-zhewang-9f4ec6f191089214           compressed=True data_size=36815216 duration=7384577 ended=100000 fail=2 fail_fast=10 max_runs=100000 pass=99998 priority=100 remaining=0 runtime=1:13:21 sanity=False started=100000 stopped=20250211-225032 submitted=20250211-213711 timeout=5400 username=zhewang
  
 100K bulkDump:
  20250212-002253-zhewang-597e2d9511140438           compressed=True data_size=36815258 duration=11831522 ended=100000 fail=1 fail_fast=10 max_runs=100000 pass=99999 priority=100 remaining=0 runtime=1:25:02 sanity=False started=100000 stopped=20250212-014755 submitted=20250212-002253 timeout=5400 username=zhewang
  
    
# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
