### PR TITLE
Disable attrition fault injection in snapshot workload

### DIFF
--- a/fdbserver/workloads/SnapTest.actor.cpp
+++ b/fdbserver/workloads/SnapTest.actor.cpp
@@ -101,6 +101,12 @@ public: // workload functions
 		// FIXME: the data movement should be delayed while taking snapshots, the workload at present doesn't know the
 		// DD is disabled by the snapshot
 		out.insert("RandomMoveKeys");
+
+		// A combination of this workload only doing snapshot once and attrition fault injection means that it's
+		// possible that not all ss/tlog/coordinator data gets snapshotted. This workload does retry on snapshot errors
+		// but note that the absence of machines is not considered an error from snapshot request point of view.
+		// Since snapshot restart tests rely on snapshot data, attrition fault injection is disabled for this workload.
+		out.insert("Attrition");
 	}
 
 	ACTOR Future<Void> _create_keys(Database cx, std::string prefix, bool even = true) {


### PR DESCRIPTION
# Description

A combination of this workload only doing snapshot once and attrition fault injection means that it's possible that not all ss/tlog/coordinator data gets snapshotted. This workload does retry on snapshot errors but note that the absence of machines is not considered an error from snapshot request point of view. Since snapshot restart tests rely on snapshot data, I disabled attrition fault injection for this workload.

The sequence of events that led to this fix:
- Our nightly run found `SnapCycleRestart` failure
- This is an update test, the old binary runs fine, then the new binary gets stuck
- The symptom was that one of the tester process could not successfully run ChangeConfig workload which makes a txn against the cluster. 
- The reason txn failed was because cluster did not fully recovery
- Recovery was stuck on `configuration_never_created`
- The reason of above was that CC could not read coordinated state from the coordinators
- The reason CC could not read coordinated state was because in fdbserver, for snapshot tests, we wipe any non-snaphot data
- So with snapshot tests, the expectation is that data is always snapshotted
- But the old binary did not leave any snapshot data for coordinator, which it should have, so the issue was in the old binary
- Old binary snapshots data based on  cli / snapshot workload -> nativeapi -> commit proxy -> DD -> workers (ss/tlog/coordinator) do the snapshot locally
- Simulation introduced machine attrition fault injection which killed the coordinator just before DD captured the worker list. The worker list did not have the killed worker because we removed it from worker map in CC based on health.
- So DD never sends snapshot request to coordinator, it did not even know about existence of coordinator. The absence of coordinator does not result in snapshot request error.
- The test got snapshot request success and it waits for only 1 success
- So by the end of old binary execution, coordinator state was not snapshotted, thus causing issues in new binary

# Testing

Ran tests in [0] 100K times. These tests are using the workload I am changing here. Results:

`20250212-193107-praza-r142428623-fix-ad37abb945f1d6f9f996933 compressed=True data_size=36685407 duration=8344357 ended=100000 fail_fast=25 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:32:07 sanity=False started=100000 stopped=20250212-210314 submitted=20250212-193107 timeout=5400 username=praza-r142428623-fix-ad37abb945f1d6f9f99693345bef66f5684b910a`

Also ran the test without my changes, 100K results for the same tests in [0]:

`20250212-193259-praza-HEAD-277e82b79a76e116a3dacff23ab41f05b compressed=True data_size=36687380 duration=8478277 ended=100000 fail=1 fail_fast=25 max_runs=100000 pass=99999 priority=100 remaining=0 runtime=1:30:39 sanity=False started=100000 stopped=20250212-210338 submitted=20250212-193259 timeout=5400 username=praza-HEAD-277e82b79a76e116a3dacff23ab41f05be49f7e6`. 

That 1 failure is the timeout issue so it reproducible, just very rare. 

[0]:
 tests/restarting/from_7.3.0/SnapCycleRestart-1.toml tests/restarting/from_7.3.0/SnapCycleRestart-2.toml tests/restarting/from_7.3.0/SnapTestAttrition-1.toml tests/restarting/from_7.3.0/SnapTestAttrition-2.toml tests/restarting/from_7.3.0/SnapTestRestart-1.toml tests/restarting/from_7.3.0/SnapTestRestart-2.toml tests/restarting/from_7.3.0/SnapTestSimpleRestart-1.toml tests/restarting/from_7.3.0/SnapTestSimpleRestart-2.toml


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
