### PR TITLE
DataMove Should Decide BulkLoading After Old DataMove Actor Has Been Cleared

### DIFF
--- a/fdbserver/DDRelocationQueue.actor.cpp
+++ b/fdbserver/DDRelocationQueue.actor.cpp
@@ -1546,7 +1546,7 @@ ACTOR Future<Void> dataDistributionRelocator(DDQueue* self,
 				DataMoveType dataMoveType = newDataMoveType(doBulkLoading);
 				rd.dataMoveId = newDataMoveId(
 				    deterministicRandom()->randomUInt64(), AssignEmptyRange::False, dataMoveType, rd.dmReason);
-				TraceEvent(SevInfo, "DDBulkLoadNewDataMoveID", this->distributorId)
+				TraceEvent(SevInfo, "DDBulkLoadNewDataMoveID", self->distributorId)
 				    .detail("DataMoveID", rd.dataMoveId.toString())
 				    .detail("TrackID", rd.randomId)
 				    .detail("Range", rd.keys)


### PR DESCRIPTION
This PR fixes a bulkload bug causing DD restarts.

In the bulkLoad datamove mechanism, when a bulkload is triggered, this task is registered on a map. For any following data move on the same range, the data move is converted to a "bulkload" data move, which triggers SS to load data. When the bulkload data move starts. it updates the bulkload metadata. At this time, it checks if the metadata shows correct phase (the metadata should not indicate the move has been completed). If the task has been marked as completed, the data move triggers DD restart.

The problem happens when a previous data move for the bulkload task is cancelled by the new data move for the same task. The issue happens when the previous data move marks the bulkload task as completed, before the new data move starts the same task. As a result, when the new data move tries to start the task, it finds that the bulkload metadata has been marked as completed which is unexpected and triggers DD restarts.

The fix is that the new data move should decide to do bulk loading after the cancellation of the old data move. So, after the cancellation of the old data move, if the bulkload task metadata has been marked as completed, the new data move does not do bulk loading.

100K bulkload tests:
20250213-174727-zhewang-aa06c0d4d7bf86be           compressed=True data_size=36849755 duration=8769146 ended=100000 fail=2 fail_fast=10 max_runs=100000 pass=99998 priority=100 remaining=0 runtime=1:11:07 sanity=False started=100000 stopped=20250213-185834 submitted=20250213-174727 timeout=5400 username=zhewang
  
100K bulkdump tests:
  20250213-190617-zhewang-a7491d9a121a5380           compressed=True data_size=36849352 duration=11450458 ended=100000 fail=1 fail_fast=10 max_runs=100000 pass=99999 priority=100 remaining=0 runtime=1:22:49 sanity=False started=100000 stopped=20250213-202906 submitted=20250213-190617 timeout=5400 username=zhewang

100K correctness tests with 1 irrelevant failure:
  20250213-213207-zhewang-0e91c2ddace17da4           compressed=True data_size=36812798 duration=5090791 ended=100000 fail=1 fail_fast=10 max_runs=100000 pass=99999 priority=100 remaining=0 runtime=0:54:29 sanity=False started=100000 stopped=20250213-222636 submitted=20250213-213207 timeout=5400 username=zhewang
        
# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
