### PR TITLE
Allow BulkLoadEngine to Handle Non-Retriable Task

### DIFF
--- a/fdbclient/include/fdbclient/BulkLoading.h
+++ b/fdbclient/include/fdbclient/BulkLoading.h
@@ -520,7 +520,7 @@ enum class BulkLoadPhase : uint8_t {
 	Running = 3, // Update atomically with updating KeyServer dest servers in startMoveKey
 	Complete = 4, // Update atomically with updating KeyServer src servers in finishMoveKey
 	Acknowledged = 5, // Updated by users; DD automatically clear metadata with this phase
-	Error = 6, // Updated by this task has unretriable error
+	Error = 6, // Updated by DD when this task has unretriable error
 };
 
 struct BulkLoadTaskState {
@@ -915,7 +915,7 @@ struct SSBulkLoadMetadata {
 public:
 	constexpr static FileIdentifier file_identifier = 1384506;
 
-	SSBulkLoadMetadata() : dataMoveId(UID()), conductBulkLoad(false) {};
+	SSBulkLoadMetadata() : dataMoveId(UID()), conductBulkLoad(false){};
 
 	SSBulkLoadMetadata(const UID& dataMoveId) : dataMoveId(dataMoveId) {
 		conductBulkLoad = getConductBulkLoadFromDataMoveId(dataMoveId);

--- a/fdbclient/include/fdbclient/BulkLoading.h
+++ b/fdbclient/include/fdbclient/BulkLoading.h
@@ -520,6 +520,7 @@ enum class BulkLoadPhase : uint8_t {
 	Running = 3, // Update atomically with updating KeyServer dest servers in startMoveKey
 	Complete = 4, // Update atomically with updating KeyServer src servers in finishMoveKey
 	Acknowledged = 5, // Updated by users; DD automatically clear metadata with this phase
+	Error = 6, // Updated by this task has unretriable error
 };
 
 struct BulkLoadTaskState {
@@ -543,7 +544,7 @@ struct BulkLoadTaskState {
 		if (dataMoveId.present()) {
 			res = res + ", [DataMoveId]: " + dataMoveId.get().toString();
 		}
-		res = res + ", [TaskId]: " + taskId.toString();
+		res = res + ", [TaskId]: " + taskId.toString() + ", [Phase]: " + std::to_string(static_cast<uint8_t>(phase));
 		return res;
 	}
 
@@ -914,7 +915,7 @@ struct SSBulkLoadMetadata {
 public:
 	constexpr static FileIdentifier file_identifier = 1384506;
 
-	SSBulkLoadMetadata() : dataMoveId(UID()), conductBulkLoad(false){};
+	SSBulkLoadMetadata() : dataMoveId(UID()), conductBulkLoad(false) {};
 
 	SSBulkLoadMetadata(const UID& dataMoveId) : dataMoveId(dataMoveId) {
 		conductBulkLoad = getConductBulkLoadFromDataMoveId(dataMoveId);

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -1139,6 +1139,31 @@ ACTOR Future<std::pair<BulkLoadTaskState, Version>> triggerBulkLoadTask(Referenc
 	}
 }
 
+// TODO(BulkLoad): add reason to persist
+ACTOR Future<Void> failBulkLoadTask(Reference<DataDistributor> self, KeyRange range, UID taskId) {
+	state Database cx = self->txnProcessor->context();
+	state Transaction tr(cx);
+	state BulkLoadTaskState bulkLoadTaskState;
+	loop {
+		try {
+			tr.setOption(FDBTransactionOptions::LOCK_AWARE);
+			tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+			wait(checkMoveKeysLock(&tr, self->context->lock, self->context->ddEnabledState.get()));
+			wait(store(bulkLoadTaskState, getBulkLoadTask(&tr, range, taskId, { BulkLoadPhase::Triggered })));
+			bulkLoadTaskState.phase = BulkLoadPhase::Error;
+			ASSERT(range == bulkLoadTaskState.getRange() && taskId == bulkLoadTaskState.getTaskId());
+			ASSERT(normalKeys.contains(range));
+			wait(krmSetRange(
+			    &tr, bulkLoadTaskPrefix, bulkLoadTaskState.getRange(), bulkLoadTaskStateValue(bulkLoadTaskState)));
+			wait(tr.commit());
+			break;
+		} catch (Error& e) {
+			wait(tr.onError(e));
+		}
+	}
+	return Void();
+}
+
 // A bulk load task is guaranteed to be either complete or overwritten by another task
 // When a bulk load task is trigged, the range traffic is turned off atomically
 // If the task completes, the task re-enables the traffic atomically
@@ -1189,6 +1214,21 @@ ACTOR Future<Void> doBulkLoadTask(Reference<DataDistributor> self, KeyRange rang
 		    .detail("Duration", now() - beginTime);
 		if (e.code() == error_code_movekeys_conflict) {
 			throw e;
+		}
+		if (e.code() == error_code_bulkload_task_stuck) {
+			// The task is stuck, we need to fail the task
+			TraceEvent(SevWarn, "DDBulkLoadEngineDoBulkLoadTaskStuck", self->ddId)
+			    .detail("Range", range)
+			    .detail("TaskID", taskId);
+			try {
+				wait(failBulkLoadTask(self, range, taskId)); // mark this task failed in system metadata
+			} catch (Error& failTaskError) {
+				if (failTaskError.code() == error_code_actor_cancelled) {
+					throw failTaskError;
+				}
+				ASSERT(failTaskError.code() == error_code_bulkload_task_outdated);
+				// sliently exits
+			}
 		}
 		// sliently exits
 	}
@@ -1268,6 +1308,10 @@ ACTOR Future<Void> scheduleBulkLoadTasks(Reference<DataDistributor> self) {
 						    .detail("TaskID", bulkLoadTaskState.getTaskId());
 						bulkLoadActors.push_back(
 						    eraseBulkLoadTask(self, bulkLoadTaskState.getRange(), bulkLoadTaskState.getTaskId()));
+					} else if (bulkLoadTaskState.phase == BulkLoadPhase::Error) {
+						TraceEvent(SevWarnAlways, "DDBulkLoadEngineFindTaskUnretriableError", self->ddId)
+						    .detail("Range", bulkLoadTaskState.getRange())
+						    .detail("TaskID", bulkLoadTaskState.getTaskId());
 					} else {
 						ASSERT(bulkLoadTaskState.phase == BulkLoadPhase::Complete);
 					}

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -1140,6 +1140,7 @@ ACTOR Future<std::pair<BulkLoadTaskState, Version>> triggerBulkLoadTask(Referenc
 }
 
 // TODO(BulkLoad): add reason to persist
+// TODO(BulkLoad): issue a normal data move if the bulkload data move is issued for team unhealthy
 ACTOR Future<Void> failBulkLoadTask(Reference<DataDistributor> self, KeyRange range, UID taskId) {
 	state Database cx = self->txnProcessor->context();
 	state Transaction tr(cx);

--- a/fdbserver/workloads/BulkLoading.actor.cpp
+++ b/fdbserver/workloads/BulkLoading.actor.cpp
@@ -57,7 +57,7 @@ struct BulkLoading : TestWorkload {
 	static constexpr auto NAME = "BulkLoadingWorkload";
 	const bool enabled;
 	bool pass;
-	bool debugging = true;
+	bool debugging = false;
 	bool backgroundTrafficEnabled = deterministicRandom()->coinflip();
 
 	// This workload is not compatible with following workload because they will race in changing the DD mode

--- a/flow/include/flow/error_definitions.h
+++ b/flow/include/flow/error_definitions.h
@@ -164,6 +164,7 @@ ERROR( bulkdump_task_failed, 1243, "Bulk dumping task failed" )
 ERROR( bulkdump_task_outdated, 1244, "Bulk dumping task outdated" )
 ERROR( bulkload_fileset_invalid_filepath, 1245, "Bulkload fileset provides invalid filepath" )
 ERROR( bulkload_manifest_decode_error, 1246, "Bulkload manifest string is failed to decode" )
+ERROR( bulkload_task_stuck, 1247, "Bulk loading task is stuck" )
 
 // 15xx Platform errors
 ERROR( platform_error, 1500, "Platform error" )

--- a/tests/fast/BulkLoading.toml
+++ b/tests/fast/BulkLoading.toml
@@ -1,9 +1,5 @@
 [configuration]
-config = 'triple'
 storageEngineType = 0
-machineCount = 15
-extraStorageMachineCountPerDC = 5
-processesPerMachine = 2
 
 # Do not support tenant, encryption, and TSS
 tenantModes = ['disabled']


### PR DESCRIPTION
It is possible that a bulkload task can never be completed, e.g. no enough machine, no enough space, network outage of blob store. For those cases, we persist "Error" state to the bulkload metadata. Users can "acknowledge" this error task while the system and client will explicitly trace this operation. 

100K bulkload tests:
  20250214-044539-zhewang-4b0a08c0b4673fa1           compressed=True data_size=36860787 duration=1523915 ended=100000 fail=1 fail_fast=10 max_runs=100000 pass=99999 priority=100 remaining=0 runtime=0:31:05 sanity=False started=100000 stopped=20250214-051644 submitted=20250214-044539 timeout=5400 username=zhewang

100K correctness tests:
  20250214-181348-zhewang-8d2daf1775d4a3e1           compressed=True data_size=36822059 fail_fast=10 max_runs=100000 priority=100 sanity=False submitted=20250214-181348 timeout=5400 username=zhewang
  
# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
