### PR TITLE
Enable BulkLoad Job to Give Up Unretrievable Task and Fix DDStuck Bug

### DIFF
--- a/fdbclient/include/fdbclient/BulkLoading.h
+++ b/fdbclient/include/fdbclient/BulkLoading.h
@@ -645,6 +645,7 @@ enum class BulkLoadJobPhase : uint8_t {
 	Submitted = 1,
 	Triggered = 2,
 	Complete = 3,
+	Error = 4,
 };
 
 struct BulkLoadJobState {
@@ -711,6 +712,12 @@ public:
 	void markComplete() {
 		ASSERT(phase == BulkLoadJobPhase::Triggered || phase == BulkLoadJobPhase::Complete);
 		phase = BulkLoadJobPhase::Complete;
+		return;
+	}
+
+	void markUnretrievableError() {
+		ASSERT(phase == BulkLoadJobPhase::Triggered || phase == BulkLoadJobPhase::Complete);
+		phase = BulkLoadJobPhase::Error;
 		return;
 	}
 

--- a/flow/include/flow/error_definitions.h
+++ b/flow/include/flow/error_definitions.h
@@ -164,7 +164,6 @@ ERROR( bulkdump_task_failed, 1243, "Bulk dumping task failed" )
 ERROR( bulkdump_task_outdated, 1244, "Bulk dumping task outdated" )
 ERROR( bulkload_fileset_invalid_filepath, 1245, "Bulkload fileset provides invalid filepath" )
 ERROR( bulkload_manifest_decode_error, 1246, "Bulkload manifest string is failed to decode" )
-ERROR( bulkload_task_stuck, 1247, "Bulk loading task is stuck" )
 
 // 15xx Platform errors
 ERROR( platform_error, 1500, "Platform error" )

--- a/tests/fast/BulkDumping.toml
+++ b/tests/fast/BulkDumping.toml
@@ -1,9 +1,5 @@
 [configuration]
-config = 'triple'
-storageEngineType = 0
-machineCount = 15
-extraStorageMachineCountPerDC = 5
-processesPerMachine = 2
+storageEngineExcludeTypes = [5] #FIXME: remove after allowing to do bulkloading with fetchKey and shardedrocksdb
 
 # Do not support tenant, encryption, and TSS
 tenantModes = ['disabled']
@@ -17,9 +13,6 @@ disableTss = true # TODO(BulkLoad): support TSS. finishMoveShard should wait for
 # The shard rocksdb storage engine is set up before this knob is overridden
 # The temporary fix is that in SimulatedCluster.cpp:simulationSetupAndRun, we are doing one additional check.
 shard_encode_location_metadata = true
-
-# Mitigate perpetual wiggle since it causes bulkload engine hard to get a valid team to inject data
-dd_storage_wiggle_pause_threshold = 1
 
 # Rely on RangeLock
 enable_read_lock_on_range = true

--- a/tests/fast/BulkLoading.toml
+++ b/tests/fast/BulkLoading.toml
@@ -1,5 +1,5 @@
 [configuration]
-storageEngineType = 0
+storageEngineExcludeTypes = [5] #FIXME: remove after allowing to do bulkloading with fetchKey and shardedrocksdb
 
 # Do not support tenant, encryption, and TSS
 tenantModes = ['disabled']
@@ -13,9 +13,6 @@ disableTss = true # TODO(BulkLoad): support TSS. finishMoveShard should wait for
 # The shard rocksdb storage engine is set up before this knob is overridden
 # The temporary fix is that in SimulatedCluster.cpp:simulationSetupAndRun, we are doing one additional check.
 shard_encode_location_metadata = true
-
-# Mitigate perpetual wiggle since it causes bulkload engine hard to get a valid team to inject data
-dd_storage_wiggle_pause_threshold = 1
 
 # Rely on RangeLock
 enable_read_lock_on_range = true


### PR DESCRIPTION
**Enable BulkLoad Job to Give Up Unretrievable Task**
PR https://github.com/apple/foundationdb/pull/11950 introduced BulkLoad task engine to handle unretrievable task. 
As the bulkload job system relies on the bulkload task engine, the job range is marked as Error if the corresponding task on the range is Error. A job metadata does not erase by the system automatically if the job has some range is marked as Error.

**Fix DDStuck/MaxTLogQueue bugs** 
This issue happens when a bulkload task is failed for an unretrievable error. In this scenario, with the previous mechanism, there is always a data move that gets stuck because the data move keeps retrying to find a valid destination team. If the data move is triggered for team unhealthy, the stuck data move causes the above bugs. To fix this, we cancel the task's data move after the task is failed for an unretrievable error. If the task's data move is a team unhealthy data move, we issue a new data move (without setting bulkLoading) on the same range as the bulkload task range. The new data move cancels the task's data move. If the task's data move is a teamHealthy data move, we cancel the task's data move without triggering any new data move. If DD restarts during the above operations, DD removes the stuck data move and DD issues a new data move to heal replica if DD finds any team is unhealthy.

**This PR also addresses comments in the previous PR**.

**Simulation tests change**
For the bulk load/dump simulation tests, we only disable ShardedRocksDB engine. We will re-allow this engine type once bulkload is allowed when ShardedRocksDB uses fetchKeys.
 
100K correctness tests with 2 irrelevant failures:
  20250215-030053-zhewang-63c45a3e022a15e7           compressed=True data_size=36830849 duration=4605036 ended=100000 fail=2 fail_fast=10 max_runs=100000 pass=99998 priority=100 remaining=0 runtime=0:49:24 sanity=False started=100000 stopped=20250215-035017 submitted=20250215-030053 timeout=5400 username=zhewang
  
100K BulkDump tests:
  20250215-021918-zhewang-a4bd4c816b21ec4c           compressed=True data_size=36872598 duration=1855641 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:28:55 sanity=False started=100000 stopped=20250215-024813 submitted=20250215-021918 timeout=5400 username=zhewang
    
100K BulkLoad tests:
  20250215-022358-zhewang-73a4eade3fff3776           compressed=True data_size=36872663 duration=1554873 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:24:28 sanity=False started=100000 stopped=20250215-024826 submitted=20250215-022358 timeout=5400 username=zhewang
    
# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
