### PR TITLE
Fix isOnMainThread in Sim2

### DIFF
--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -2609,7 +2609,7 @@ public:
 		// create a key pair for AuthZ testing
 		auto key = mkcert::makeEcP256();
 		authKeys.insert(std::make_pair(Standalone<StringRef>("DefaultKey"_sr), key));
-		g_network = net2 = newNet2(TLSConfig(), /*useThreadPool=*/false, true);
+		g_network = net2 = newNet2(TLSConfig(), /*useThreadPool=*/false, true, true /* setAsMainThread */);
 		g_network->addStopCallback(Net2FileSystem::stop);
 		Net2FileSystem::newFileSystem();
 		check_yield(TaskPriority::Zero);

--- a/flow/Net2.actor.cpp
+++ b/flow/Net2.actor.cpp
@@ -2112,9 +2112,12 @@ boost::asio::const_buffer SendBufferIterator::operator*() const {
 	return boost::asio::const_buffer(p->data() + p->bytes_sent, std::min(limit, p->bytes_written - p->bytes_sent));
 }
 
-INetwork* newNet2(const TLSConfig& tlsConfig, bool useThreadPool, bool useMetrics) {
+INetwork* newNet2(const TLSConfig& tlsConfig, bool useThreadPool, bool useMetrics, bool setAsMainThread) {
 	try {
 		N2::g_net2 = new N2::Net2(tlsConfig, useThreadPool, useMetrics);
+		if (setAsMainThread) {
+			N2::thread_network = N2::g_net2;
+		}
 	} catch (boost::system::system_error e) {
 		TraceEvent("Net2InitError").detail("Message", e.what());
 		throw unknown_error();

--- a/flow/include/flow/network.h
+++ b/flow/include/flow/network.h
@@ -134,7 +134,7 @@ class TLSConfig;
 class SWIFT_CXX_IMMORTAL_SINGLETON_TYPE INetwork;
 
 extern INetwork* g_network;
-extern INetwork* newNet2(const TLSConfig& tlsConfig, bool useThreadPool = false, bool useMetrics = false);
+extern INetwork* newNet2(const TLSConfig& tlsConfig, bool useThreadPool = false, bool useMetrics = false, bool setAsMainThread = false);
 inline INetwork* _swift_newNet2(const TLSConfig* tlsConfig, bool useThreadPool = false, bool useMetrics = false) {
 	return newNet2(*tlsConfig, useThreadPool, useMetrics);
 }


### PR DESCRIPTION
`isOnMainThread()` method in Net2 checks if the
task is running on the main/network thread. This
is done by setting `thread_network` thread_local object from the thread where Net2::run() is called.

However, in simulation we access the same variable which isn't initialized. IsOnMainThread in Sim2
calls IsOnMainThread of net2 variable inside Sim2. This patch just manually sets `thread_network` object to that Sim2::net2.


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
