### PR TITLE
Add ability to ignore multiple tests

### DIFF
--- a/fdbserver/workloads/UnitTests.actor.cpp
+++ b/fdbserver/workloads/UnitTests.actor.cpp
@@ -162,15 +162,13 @@ struct UnitTestWorkload : TestWorkload {
 			return false;
 		}
 
-		bool matched = true;
 		for (auto ignorePatt : testsIgnored) {
 			if (StringRef(testName).startsWith(ignorePatt)) {
-				matched = false;
-				break;
+				return false;
 			}
 		}
 
-		return matched;
+		return true;
 	}
 
 	ACTOR static Future<Void> runUnitTests(UnitTestWorkload* self) {

--- a/tests/fast/RandomUnitTests.toml
+++ b/tests/fast/RandomUnitTests.toml
@@ -12,4 +12,4 @@ startDelay = 0
     testsMatching = '/'
     # ConfigDB tests persist state, so running these tests
     # sequentially can cause issues
-    testsIgnored = '/fdbserver/ConfigDB/'
+    testsIgnored = '/fdbserver/ConfigDB/;/fdbrpc/grpc'

--- a/tests/rare/AllSimUnitTests.toml
+++ b/tests/rare/AllSimUnitTests.toml
@@ -7,3 +7,4 @@ startDelay = 0
     testName = 'UnitTests'
     #maxTestCases = 1
     testsMatching = '/'
+    testsIgnored = '/fdbrpc/grpc'

--- a/tests/rare/SpecificUnitTests.toml
+++ b/tests/rare/SpecificUnitTests.toml
@@ -12,3 +12,4 @@ runSetup=false
     testName = 'UnitTests'
     maxTestCases = 1
     testsMatching = '/'
+    testsIgnored='/fdbrpc/grpc'


### PR DESCRIPTION
Ignore multiple tests using `;` as delimiter. Also ignores gRPC unit tests

Testing: https://github.com/apple/foundationdb/pull/11956#discussion_r1958756594

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
