### PR TITLE
Fix rocksdb crash caused because of passing uninitialized metadata to ExportColumnFamily

### DIFF
--- a/fdbserver/KeyValueStoreRocksDB.actor.cpp
+++ b/fdbserver/KeyValueStoreRocksDB.actor.cpp
@@ -337,7 +337,7 @@ std::string getErrorReason(BackgroundErrorReason reason) {
 // could potentially cause segmentation fault.
 class RocksDBErrorListener : public rocksdb::EventListener {
 public:
-	RocksDBErrorListener(UID id) : id(id){};
+	RocksDBErrorListener(UID id) : id(id) {};
 	void OnBackgroundError(rocksdb::BackgroundErrorReason reason, rocksdb::Status* bg_error) override {
 		TraceEvent(SevError, "RocksDBBGError", id)
 		    .detail("Reason", getErrorReason(reason))
@@ -377,7 +377,7 @@ private:
 
 class RocksDBEventListener : public rocksdb::EventListener {
 public:
-	RocksDBEventListener(std::shared_ptr<SharedRocksDBState> sharedState) : sharedState(sharedState){};
+	RocksDBEventListener(std::shared_ptr<SharedRocksDBState> sharedState) : sharedState(sharedState) {};
 
 	void OnFlushCompleted(rocksdb::DB* db, const rocksdb::FlushJobInfo& info) override {
 		sharedState->setLastFlushTime(now());
@@ -2506,7 +2506,7 @@ void RocksDBKeyValueStore::Writer::action(CheckpointAction& a) {
 	const std::string& checkpointDir = abspath(a.request.checkpointDir);
 
 	if (a.request.format == DataMoveRocksCF) {
-		rocksdb::ExportImportFilesMetaData* pMetadata;
+		rocksdb::ExportImportFilesMetaData* pMetadata{ nullptr };
 		platform::eraseDirectoryRecursive(checkpointDir);
 		s = checkpoint->ExportColumnFamily(cf, checkpointDir, &pMetadata);
 		if (!s.ok()) {

--- a/fdbserver/KeyValueStoreRocksDB.actor.cpp
+++ b/fdbserver/KeyValueStoreRocksDB.actor.cpp
@@ -337,7 +337,7 @@ std::string getErrorReason(BackgroundErrorReason reason) {
 // could potentially cause segmentation fault.
 class RocksDBErrorListener : public rocksdb::EventListener {
 public:
-	RocksDBErrorListener(UID id) : id(id) {};
+	RocksDBErrorListener(UID id) : id(id){};
 	void OnBackgroundError(rocksdb::BackgroundErrorReason reason, rocksdb::Status* bg_error) override {
 		TraceEvent(SevError, "RocksDBBGError", id)
 		    .detail("Reason", getErrorReason(reason))
@@ -377,7 +377,7 @@ private:
 
 class RocksDBEventListener : public rocksdb::EventListener {
 public:
-	RocksDBEventListener(std::shared_ptr<SharedRocksDBState> sharedState) : sharedState(sharedState) {};
+	RocksDBEventListener(std::shared_ptr<SharedRocksDBState> sharedState) : sharedState(sharedState){};
 
 	void OnFlushCompleted(rocksdb::DB* db, const rocksdb::FlushJobInfo& info) override {
 		sharedState->setLastFlushTime(now());


### PR DESCRIPTION
# Description

This was found in https://github.com/apple/foundationdb/pull/11956#issuecomment-2664294162, specific error from Joshua log:

```
<StdErrOutput Severity="40"
                  Output="fdbserver: /root/build_output/fdbserver/rocksdb-prefix/src/rocksdb/utilities/checkpoint/checkpoint_impl.cc:321: virtual Status rocksdb::CheckpointImpl::ExportColumnFamily(Colum nFamilyHandle *, const std::string &amp;, ExportImportFilesMetaData **): Assertion `*metadata == nullptr' failed." />
```

Basically we were passing uninitialized pointer variable to rocksdb ExportColumnFamily, sometimes the pointer is not null, and rocksdb asserts that it is null. The fix is to simply initialize to nullptr, not doing so is undefined behavior.

# Testing

100K: `20250218-004547-praza-fix-rocksdb-checkpoint-crash-58a0ea506 compressed=True data_size=35742432 duration=6425654 ended=100000 fail=5 fail_fast=10 max_runs=100000 pass=99995 priority=100 remaining=0 runtime=0:54:04 sanity=False started=100000 stopped=20250218-013951 submitted=20250218-004547 timeout=5400 username=praza-fix-rocksdb-checkpoint-crash-58a0ea506629238c2b91b14c1773e0c418a91cfa`. All failures are unrelated, most of them are related to config test -- @jzhou77  and I had a discussion about these and we were thinking that my fix in https://github.com/apple/foundationdb/pull/11928 may apply to these too (we need to issue aggressive migration outside the if condition (`if (self->allowTestStorageMigration || self->waitStoreTypeCheck)`). 


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
