### PR TITLE
Conditionally disable backup worker

### DIFF
--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -2659,6 +2659,11 @@ ACTOR Future<Void> disableConnectionFailuresAfter(double seconds, std::string co
 }
 
 ACTOR Future<Void> disableBackupWorker(Database cx) {
+	DatabaseConfiguration configuration = wait(getDatabaseConfiguration(cx));
+	if (!configuration.backupWorkerEnabled) {
+		TraceEvent("BackupWorkerAlreadyDisabled");
+		return Void();
+	}
 	ConfigurationResult res = wait(ManagementAPI::changeConfig(cx.getReference(), "backup_worker_enabled:=0", true));
 	if (res != ConfigurationResult::SUCCESS) {
 		TraceEvent("BackupWorkerDisableFailed").detail("Result", res);
@@ -2668,6 +2673,11 @@ ACTOR Future<Void> disableBackupWorker(Database cx) {
 }
 
 ACTOR Future<Void> enableBackupWorker(Database cx) {
+	DatabaseConfiguration configuration = wait(getDatabaseConfiguration(cx));
+	if (configuration.backupWorkerEnabled) {
+		TraceEvent("BackupWorkerAlreadyEnabled");
+		return Void();
+	}
 	ConfigurationResult res = wait(ManagementAPI::changeConfig(cx.getReference(), "backup_worker_enabled:=1", true));
 	if (res != ConfigurationResult::SUCCESS) {
 		TraceEvent("BackupWorkerEnableFailed").detail("Result", res);


### PR DESCRIPTION
# Description

Previously `disableBackupWorker` actor would unconditionally trigger config change to disable backup worker even if the existing db config already has it disabled. This can result in a circular loop and `TracedTooManyLines`:
1. disableBackupWorker -> change config -> `tr->set(moveKeysLockOwnerKey, versionKey)` -> dd restarts
2. dd restarts -> can't do movement and health check -> some ss can't be taken out or have their storage engine type changed
3. storage engine type does not converge -> consistency check fails and keeps retrying -> we call disableBackupWorker again -> back to (1)

To break this circular loop, in step (1), we conditionally disable backup worker only if it is enabled in the db config, which means that we don't issue change config again and again, giving time for DD to perform its actions and have the storage servers converged to the right storage engine type.

I also made a similar change to `enableBackupWorker` for consistency. 

Note: I also considered making the conditional config change as a feature inside management api. The idea was that if `force` is false, then we don't change config again unless it's different from provided config. The problem was that the semantics of `force` is different: it exists to do safety checks and is not a performance/optimization. So I ended up not going down this path. 

# Testing

100K before this change: 

20250220-014020-praza-HEAD-d9ea00ef5e7ca024b44e002290243d924 compressed=True data_size=35753346 duration=6395374 ended=100000 fail=4 fail_fast=10 max_runs=100000 pass=99996 priority=100 remaining=0 runtime=1:16:42 sanity=False started=100000 stopped=20250220-025702 submitted=20250220-014020 timeout=5400 username=praza-HEAD-d9ea00ef5e7ca024b44e002290243d924cd6fdb4

The failures are all "Storage server has wrong key-value store type". 
  

100K after this change:

20250220-035235-praza-fix-nightly-5eda677f439f5d435880d7e2e5 compressed=True data_size=35753790 duration=5549992 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:57:36 sanity=False started=100000 stopped=20250220-045011 submitted=20250220-035235 timeout=5400 username=praza-fix-nightly-5eda677f439f5d435880d7e2e5b0d286144fbf52

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
