### PR TITLE
Add support to close an open database to clean up resources

### DIFF
--- a/bindings/go/src/fdb/database.go
+++ b/bindings/go/src/fdb/database.go
@@ -40,6 +40,8 @@ import (
 // usually created and committed automatically by the (Database).Transact
 // method.
 type Database struct {
+	// String reference to the cluster file.
+	clusterFile string
 	*database
 }
 
@@ -58,6 +60,22 @@ func (opt DatabaseOptions) setOpt(code int, param []byte) error {
 	return setOpt(func(p *C.uint8_t, pl C.int) C.fdb_error_t {
 		return C.fdb_database_set_option(opt.d.ptr, C.FDBDatabaseOption(code), p, pl)
 	}, param)
+}
+
+// Close will close the Database and clean up all resources.
+// You have to ensure that you're not resuing this database.
+func (d *Database) Close() {
+	networkMutex.Lock()
+	defer networkMutex.Unlock()
+
+	// If an entry for this database exists remove it.
+	if _, ok := openDatabases[d.clusterFile]; ok {
+		// Remove database object from the cached databases
+		delete(openDatabases, d.clusterFile)
+	}
+
+	// Destroy the database
+	d.destroy()
 }
 
 func (d *database) destroy() {

--- a/bindings/go/src/fdb/database.go
+++ b/bindings/go/src/fdb/database.go
@@ -75,10 +75,6 @@ func (d *Database) Close() {
 	}
 
 	// Destroy the database
-	d.destroy()
-}
-
-func (d *database) destroy() {
 	C.fdb_database_destroy(d.ptr)
 }
 

--- a/bindings/go/src/fdb/fdb.go
+++ b/bindings/go/src/fdb/fdb.go
@@ -337,7 +337,7 @@ func createDatabase(clusterFile string) (Database, error) {
 	db := &database{outdb}
 	runtime.SetFinalizer(db, (*database).destroy)
 
-	return Database{db}, nil
+	return Database{clusterFile, db}, nil
 }
 
 // Deprecated: Use OpenDatabase instead.

--- a/bindings/go/src/fdb/fdb.go
+++ b/bindings/go/src/fdb/fdb.go
@@ -31,7 +31,6 @@ import (
 	"bytes"
 	"fmt"
 	"log"
-	"runtime"
 	"sync"
 	"unsafe"
 )
@@ -334,10 +333,7 @@ func createDatabase(clusterFile string) (Database, error) {
 		return Database{}, Error{int(err)}
 	}
 
-	db := &database{outdb}
-	runtime.SetFinalizer(db, (*database).destroy)
-
-	return Database{clusterFile, db}, nil
+	return Database{clusterFile, &database{outdb}}, nil
 }
 
 // Deprecated: Use OpenDatabase instead.

--- a/bindings/go/src/fdb/fdb_test.go
+++ b/bindings/go/src/fdb/fdb_test.go
@@ -47,7 +47,7 @@ func ExampleOpenDefault() {
 		return
 	}
 
-	_ = db
+	db.Close()
 
 	// Output:
 }
@@ -55,6 +55,7 @@ func ExampleOpenDefault() {
 func TestVersionstamp(t *testing.T) {
 	fdb.MustAPIVersion(710)
 	db := fdb.MustOpenDefault()
+	defer db.Close()
 
 	setVs := func(t fdb.Transactor, key fdb.Key) (fdb.FutureKey, error) {
 		fmt.Printf("setOne called with:  %T\n", t)
@@ -101,6 +102,8 @@ func TestVersionstamp(t *testing.T) {
 func TestReadTransactionOptions(t *testing.T) {
 	fdb.MustAPIVersion(710)
 	db := fdb.MustOpenDefault()
+	defer db.Close()
+
 	_, e := db.ReadTransact(func(rtr fdb.ReadTransaction) (interface{}, error) {
 		rtr.Options().SetAccessSystemKeys()
 		return rtr.Get(fdb.Key("\xff/")).MustGet(), nil
@@ -113,6 +116,7 @@ func TestReadTransactionOptions(t *testing.T) {
 func ExampleTransactor() {
 	fdb.MustAPIVersion(710)
 	db := fdb.MustOpenDefault()
+	defer db.Close()
 
 	setOne := func(t fdb.Transactor, key fdb.Key, value []byte) error {
 		fmt.Printf("setOne called with:  %T\n", t)
@@ -164,6 +168,7 @@ func ExampleTransactor() {
 func ExampleReadTransactor() {
 	fdb.MustAPIVersion(710)
 	db := fdb.MustOpenDefault()
+	defer db.Close()
 
 	getOne := func(rt fdb.ReadTransactor, key fdb.Key) ([]byte, error) {
 		fmt.Printf("getOne called with: %T\n", rt)
@@ -217,6 +222,7 @@ func ExampleReadTransactor() {
 func ExamplePrefixRange() {
 	fdb.MustAPIVersion(710)
 	db := fdb.MustOpenDefault()
+	defer db.Close()
 
 	tr, e := db.CreateTransaction()
 	if e != nil {
@@ -256,6 +262,7 @@ func ExamplePrefixRange() {
 func ExampleRangeIterator() {
 	fdb.MustAPIVersion(710)
 	db := fdb.MustOpenDefault()
+	defer db.Close()
 
 	tr, e := db.CreateTransaction()
 	if e != nil {
@@ -323,6 +330,7 @@ var (
 func TestCreateTenant(t *testing.T) {
 	fdb.MustAPIVersion(710)
 	db := fdb.MustOpenDefault()
+	defer db.Close()
 
 	testTenantName := fdb.Key("test-create-tenant")
 
@@ -340,6 +348,7 @@ func TestCreateTenant(t *testing.T) {
 func TestCreateExistTenant(t *testing.T) {
 	fdb.MustAPIVersion(710)
 	db := fdb.MustOpenDefault()
+	defer db.Close()
 
 	testTenantName := fdb.Key("test-exist-tenant")
 
@@ -369,6 +378,7 @@ func TestOpenNotExistTenant(t *testing.T) {
 func TestDeleteNotExistTenant(t *testing.T) {
 	fdb.MustAPIVersion(710)
 	db := fdb.MustOpenDefault()
+	defer db.Close()
 
 	testTenantName := fdb.Key("test-not-exist-tenant")
 
@@ -404,6 +414,7 @@ func assertErrorCodeEqual(t *testing.T, actual error, expected fdb.Error) {
 func TestListTenant(t *testing.T) {
 	fdb.MustAPIVersion(710)
 	db := fdb.MustOpenDefault()
+	defer db.Close()
 
 	testTenantName1 := fdb.Key("1-test-list-1-tenant-1")
 	testTenantName2 := fdb.Key("2-test-list-2-tenant-2")
@@ -435,6 +446,7 @@ func TestListTenant(t *testing.T) {
 func TestInvalidPrefixTenant(t *testing.T) {
 	fdb.MustAPIVersion(710)
 	db := fdb.MustOpenDefault()
+	defer db.Close()
 
 	testTenantName := fdb.Key("\xFFtest-invalid-prefix-tenant")
 


### PR DESCRIPTION
# Code-Reviewer Section

Allow the database to be closed from the go bindings. We already support this in 7.3 and main but we are missing the close method in 7.1. This change does not require a new release as only the go bindings are affected. I ran the unit tests and will perform some additional tests with the operator. Related operator PR: https://github.com/FoundationDB/fdb-kubernetes-operator/pull/2216.

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
