### PR TITLE
RandomMoveKey should choose SSes from different data halls

### DIFF
--- a/fdbserver/DDTeamCollection.actor.cpp
+++ b/fdbserver/DDTeamCollection.actor.cpp
@@ -1848,7 +1848,7 @@ public:
 
 		for (auto const& shard : shards) {
 			sizes.emplace_back(brokenPromiseToNever(self->getShardMetrics.getReply(GetMetricsRequest(shard))));
-			TraceEvent(SevWarnAlways, "DDShardLost", self->distributorId)
+			TraceEvent(g_network->isSimulated() ? SevError : SevWarnAlways, "DDShardLost", self->distributorId)
 			    .detail("ServerTeamID", team->getTeamID())
 			    .detail("ShardBegin", shard.begin)
 			    .detail("ShardEnd", shard.end);

--- a/fdbserver/DDTeamCollection.actor.cpp
+++ b/fdbserver/DDTeamCollection.actor.cpp
@@ -1848,7 +1848,7 @@ public:
 
 		for (auto const& shard : shards) {
 			sizes.emplace_back(brokenPromiseToNever(self->getShardMetrics.getReply(GetMetricsRequest(shard))));
-			TraceEvent(g_network->isSimulated() ? SevError : SevWarnAlways, "DDShardLost", self->distributorId)
+			TraceEvent(SevWarnAlways, "DDShardLost", self->distributorId)
 			    .detail("ServerTeamID", team->getTeamID())
 			    .detail("ShardBegin", shard.begin)
 			    .detail("ShardEnd", shard.end);


### PR DESCRIPTION
RandomMoveKey should choose SSes from different data halls if the SS data hall is set.

100K test:
  20250221-033738-zhewang-ab060216fa6d0ec5           compressed=True data_size=36850511 fail_fast=10 max_runs=100000 priority=100 sanity=False submitted=20250221-033738 timeout=5400 username=zhewang


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
