### PR TITLE
Improve BulkLoad TraceEvent

### DIFF
--- a/fdbserver/BulkLoadUtil.actor.cpp
+++ b/fdbserver/BulkLoadUtil.actor.cpp
@@ -69,7 +69,7 @@ ACTOR Future<BulkLoadTaskState> getBulkLoadTaskStateFromDataMove(Database cx,
 					continue;
 				}
 			}
-			TraceEvent(SevWarnAlways, "SSBulkLoadDataMoveIdNotExist", logId)
+			TraceEvent(SevWarnAlways, "SSBulkLoadTaskDataMoveIdNotExist", logId)
 			    .detail("Message", "This fetchKey is blocked and will be cancelled later")
 			    .detail("DataMoveID", dataMoveId)
 			    .detail("ReadVersion", tr.getReadVersion().get())
@@ -246,7 +246,7 @@ ACTOR Future<BulkLoadFileSet> bulkLoadDownloadTaskFileSet(BulkLoadTransportMetho
 				UNREACHABLE();
 			}
 			// TODO(BulkLoad): Check file checksum
-			TraceEvent(SevInfo, "SSBulkLoadDownloadTaskFileSet", logId)
+			TraceEvent(SevInfo, "SSBulkLoadTaskDownloadFileSet", logId)
 			    .setMaxEventLength(-1)
 			    .setMaxFieldLength(-1)
 			    .detail("FromRemoteFileSet", fromRemoteFileSet.toString())
@@ -260,7 +260,7 @@ ACTOR Future<BulkLoadFileSet> bulkLoadDownloadTaskFileSet(BulkLoadTransportMetho
 			if (e.code() == error_code_actor_cancelled) {
 				throw e;
 			}
-			TraceEvent(SevWarn, "SSBulkLoadDownloadTaskFileSetError", logId)
+			TraceEvent(SevWarn, "SSBulkLoadTaskDownloadFileSetError", logId)
 			    .setMaxEventLength(-1)
 			    .setMaxFieldLength(-1)
 			    .errorUnsuppressed(e)
@@ -294,7 +294,7 @@ ACTOR Future<Void> downloadManifestFile(BulkLoadTransportMethod transportMethod,
 			if (!fileExists(abspath(toLocalPath))) {
 				throw retry();
 			}
-			TraceEvent(SevInfo, "DownloadManifestFile", logId)
+			TraceEvent(SevInfo, "BulkLoadDownloadManifestFile", logId)
 			    .detail("FromRemotePath", fromRemotePath)
 			    .detail("ToLocalPath", toLocalPath)
 			    .detail("Duration", now() - startTime)
@@ -304,7 +304,7 @@ ACTOR Future<Void> downloadManifestFile(BulkLoadTransportMethod transportMethod,
 			if (e.code() == error_code_actor_cancelled) {
 				throw e;
 			}
-			TraceEvent(SevWarnAlways, "DownloadManifestFileError", logId)
+			TraceEvent(SevWarnAlways, "BulkLoadDownloadManifestFileError", logId)
 			    .errorUnsuppressed(e)
 			    .detail("TransportMethod", transportMethod)
 			    .detail("FromRemotePath", fromRemotePath)

--- a/fdbserver/DDRelocationQueue.actor.cpp
+++ b/fdbserver/DDRelocationQueue.actor.cpp
@@ -129,7 +129,7 @@ DataMovementReason priorityToDataMovementReason(int priority) {
 RelocateData::RelocateData()
   : priority(-1), boundaryPriority(-1), healthPriority(-1), reason(RelocateReason::OTHER), startTime(-1),
     dataMoveId(anonymousShardId), workFactor(0), wantsNewServers(false), cancellable(false),
-    interval("QueuedRelocation"){};
+    interval("QueuedRelocation") {};
 
 RelocateData::RelocateData(RelocateShard const& rs)
   : parent_range(rs.getParentRange()), keys(rs.keys), priority(rs.priority),
@@ -215,7 +215,7 @@ class ParallelTCInfo final : public ReferenceCounted<ParallelTCInfo>, public IDa
 
 public:
 	ParallelTCInfo() = default;
-	explicit ParallelTCInfo(ParallelTCInfo const& info) : teams(info.teams), tempServerIDs(info.tempServerIDs){};
+	explicit ParallelTCInfo(ParallelTCInfo const& info) : teams(info.teams), tempServerIDs(info.tempServerIDs) {};
 
 	void addTeam(Reference<IDataDistributionTeam> team) { teams.push_back(team); }
 
@@ -1019,9 +1019,9 @@ bool runPendingBulkLoadTaskWithRelocateData(DDQueue* self, RelocateData& rd) {
 		} catch (Error& e) {
 			ASSERT_WE_THINK(e.code() == error_code_bulkload_task_outdated);
 			if (e.code() == error_code_bulkload_task_outdated) {
-				TraceEvent(g_network->isSimulated() ? SevError : SevWarnAlways,
-				           "DDBulkLoadEngineTaskOutdatedWhenStartRelocator",
-				           self->distributorId) // unexpected
+				TraceEvent(SevError, "DDBulkLoadTaskOutdatedWhenStartRelocator", self->distributorId)
+				    .setMaxEventLength(-1)
+				    .setMaxFieldLength(-1)
 				    .detail("NewDataMoveID", rd.dataMoveId)
 				    .detail("NewDataMovePriority", rd.priority)
 				    .detail("NewDataMoveRange", rd.keys)
@@ -1052,7 +1052,9 @@ void DDQueue::launchQueuedWork(std::set<RelocateData, std::greater<RelocateData>
 		// for unhealthy. Make the bulk load task visible on the global task map
 		bool doBulkLoading = runPendingBulkLoadTaskWithRelocateData(this, rd);
 		if (doBulkLoading) {
-			TraceEvent(SevInfo, "DDBulkLoadEngineRunTaskWithRelocateData", this->distributorId)
+			TraceEvent(SevInfo, "DDBulkLoadTaskLaunchingDataMove", this->distributorId)
+			    .setMaxEventLength(-1)
+			    .setMaxFieldLength(-1)
 			    .detail("NewDataMoveId", rd.dataMoveId)
 			    .detail("NewDataMovePriority", rd.priority)
 			    .detail("NewDataMoveRange", rd.keys)
@@ -1100,9 +1102,9 @@ void DDQueue::launchQueuedWork(std::set<RelocateData, std::greater<RelocateData>
 		if (!rd.isRestore() && !canLaunchSrc(rd, teamSize, singleRegionTeamSize, busymap, cancellableRelocations)) {
 			// logRelocation( rd, "SkippingQueuedRelocation" );
 			if (rd.bulkLoadTask.present()) {
-				TraceEvent(g_network->isSimulated() ? SevError : SevWarnAlways,
-				           "DDBulkLoadEngineDelayedByBusySrc",
-				           this->distributorId)
+				TraceEvent(SevError, "DDBulkLoadTaskDelayedByBusySrc", this->distributorId)
+				    .setMaxEventLength(-1)
+				    .setMaxFieldLength(-1)
 				    .detail("BulkLoadTask", rd.bulkLoadTask.get().toString());
 			}
 			continue;
@@ -1407,7 +1409,7 @@ static int nonOverlappedServerCount(const std::vector<UID>& srcIds, const std::v
 void validateBulkLoadRelocateData(const RelocateData& rd, const std::vector<UID>& destIds, UID logId) {
 	BulkLoadTaskState bulkLoadTaskState = rd.bulkLoadTask.get().coreState;
 	if (rd.keys != bulkLoadTaskState.getRange()) {
-		TraceEvent(g_network->isSimulated() ? SevError : SevWarnAlways, "DDBulkLoadEngineTaskLaunchFailed", logId)
+		TraceEvent(SevError, "DDBulkLoadTaskLaunchFailed", logId)
 		    .detail("Reason", "Wrong data move range")
 		    .detail("BulkLoadTask", bulkLoadTaskState.toString())
 		    .detail("DataMovePriority", rd.priority)
@@ -1420,7 +1422,7 @@ void validateBulkLoadRelocateData(const RelocateData& rd, const std::vector<UID>
 		if (std::find(rd.src.begin(), rd.src.end(), destId) != rd.src.end()) {
 			// In this case, getTeam has to select src as dest when remote team collection is not ready
 			// This is not expected
-			TraceEvent(g_network->isSimulated() ? SevError : SevWarnAlways, "DDBulkLoadEngineTaskLaunchFailed", logId)
+			TraceEvent(SevError, "DDBulkLoadEngineTaskLaunchFailed", logId)
 			    .detail("Reason", "Conflict src and destd due to remote recovery")
 			    .detail("BulkLoadTask", bulkLoadTaskState.toString())
 			    .detail("DataMovePriority", rd.priority)
@@ -1520,6 +1522,11 @@ ACTOR Future<Void> dataDistributionRelocator(DDQueue* self,
 						                         rd.bulkLoadTask.get().coreState.getRange(),
 						                         rd.bulkLoadTask.get().coreState.getTaskId(),
 						                         { BulkLoadPhase::Triggered, BulkLoadPhase::Running }));
+						TraceEvent(SevInfo, "DDBulkLoadTaskDataMoveLaunched", self->distributorId)
+						    .setMaxEventLength(-1)
+						    .setMaxFieldLength(-1)
+						    .detail("BulkLoadTask", rd.bulkLoadTask.get().coreState.toString())
+						    .detail("ExistState", currentBulkLoadTaskState.toString());
 						break;
 					} catch (Error& e) {
 						if (e.code() == error_code_bulkload_task_outdated) {
@@ -1536,6 +1543,10 @@ ACTOR Future<Void> dataDistributionRelocator(DDQueue* self,
 							// rd with bulkLoadTask set.
 							// TODO(BulkLoad): reset rd.bulkLoadTask here for the risk of overloading the source
 							// servers.
+							TraceEvent(SevWarn, "DDBulkLoadTaskFallbackToNormalDataMove", self->distributorId)
+							    .setMaxEventLength(-1)
+							    .setMaxFieldLength(-1)
+							    .detail("BulkLoadTask", rd.bulkLoadTask.get().coreState.toString());
 							break;
 						}
 						wait(tr.onError(e));
@@ -1544,7 +1555,7 @@ ACTOR Future<Void> dataDistributionRelocator(DDQueue* self,
 				DataMoveType dataMoveType = newDataMoveType(doBulkLoading);
 				rd.dataMoveId = newDataMoveId(
 				    deterministicRandom()->randomUInt64(), AssignEmptyRange::False, dataMoveType, rd.dmReason);
-				TraceEvent(SevInfo, "DDBulkLoadNewDataMoveID", self->distributorId)
+				TraceEvent(SevInfo, "DDBulkLoadTaskNewDataMoveID", self->distributorId)
 				    .detail("DataMoveID", rd.dataMoveId.toString())
 				    .detail("TrackID", rd.randomId)
 				    .detail("Range", rd.keys)
@@ -1640,7 +1651,9 @@ ACTOR Future<Void> dataDistributionRelocator(DDQueue* self,
 						anyHealthy = true;
 						bestTeams.emplace_back(bestTeam.first.get(), bestTeam.second);
 						if (doBulkLoading) {
-							TraceEvent(SevInfo, "DDBulkLoadEngineTaskSelectDestTeam", self->distributorId)
+							TraceEvent(SevInfo, "DDBulkLoadTaskSelectDestTeam", self->distributorId)
+							    .setMaxEventLength(-1)
+							    .setMaxFieldLength(-1)
 							    .detail("Context", "Restore")
 							    .detail("SrcIds", describe(rd.src))
 							    .detail("DestIds", bestTeam.first.get()->getServerIDs())
@@ -1716,7 +1729,7 @@ ACTOR Future<Void> dataDistributionRelocator(DDQueue* self,
 						bestTeamReady = fbestTeam.isReady();
 						std::pair<Optional<Reference<IDataDistributionTeam>>, bool> bestTeam = wait(fbestTeam);
 						if (doBulkLoading) {
-							TraceEvent(SevInfo, "DDBulkLoadEngineTaskRelocatorBestTeamReceived", self->distributorId)
+							TraceEvent(SevInfo, "DDBulkLoadTaskRelocatorBestTeamReceived", self->distributorId)
 							    .detail("DataMoveID", rd.dataMoveId)
 							    .detail("BulkLoadTask", rd.bulkLoadTask.get().toString())
 							    .detail("BestTeamReady", bestTeamReady);
@@ -1818,7 +1831,7 @@ ACTOR Future<Void> dataDistributionRelocator(DDQueue* self,
 						} else {
 							bestTeams.emplace_back(bestTeam.first.get(), bestTeam.second);
 							if (doBulkLoading) {
-								TraceEvent(SevInfo, "DDBulkLoadEngineTaskSelectDestTeam", self->distributorId)
+								TraceEvent(SevInfo, "DDBulkLoadTaskSelectDestTeam", self->distributorId)
 								    .detail("Context", "New")
 								    .detail("SrcIds", describe(rd.src))
 								    .detail("DestIds", bestTeam.first.get()->getServerIDs())
@@ -2249,7 +2262,9 @@ ACTOR Future<Void> dataDistributionRelocator(DDQueue* self,
 					if (doBulkLoading) {
 						try {
 							self->bulkLoadTaskCollection->terminateTask(rd.bulkLoadTask.get().coreState);
-							TraceEvent(SevInfo, "DDBulkLoadEngineTaskRelocatorComplete", self->distributorId)
+							TraceEvent(SevInfo, "DDBulkLoadTaskRelocatorComplete", self->distributorId)
+							    .setMaxEventLength(-1)
+							    .setMaxFieldLength(-1)
 							    .detail("Dests", describe(destIds))
 							    .detail("Task", rd.bulkLoadTask.get().toString());
 						} catch (Error& bulkLoadError) {
@@ -2257,7 +2272,9 @@ ACTOR Future<Void> dataDistributionRelocator(DDQueue* self,
 							if (bulkLoadError.code() != error_code_bulkload_task_outdated) {
 								throw bulkLoadError;
 							}
-							TraceEvent(SevInfo, "DDBulkLoadEngineTaskRelocatorCompleteButOutdated", self->distributorId)
+							TraceEvent(SevInfo, "DDBulkLoadTaskRelocatorCompleteButOutdated", self->distributorId)
+							    .setMaxEventLength(-1)
+							    .setMaxFieldLength(-1)
 							    .detail("Dests", describe(destIds))
 							    .detail("Task", rd.bulkLoadTask.get().toString());
 						}
@@ -2265,7 +2282,9 @@ ACTOR Future<Void> dataDistributionRelocator(DDQueue* self,
 					return Void();
 				} else {
 					if (doBulkLoading) {
-						TraceEvent(SevInfo, "DDBulkLoadEngineTaskRelocatorError")
+						TraceEvent(SevInfo, "DDBulkLoadTaskRelocatorError")
+						    .setMaxEventLength(-1)
+						    .setMaxFieldLength(-1)
 						    .errorUnsuppressed(error)
 						    .detail("Task", rd.bulkLoadTask.get().toString());
 					}
@@ -2308,7 +2327,9 @@ ACTOR Future<Void> dataDistributionRelocator(DDQueue* self,
 		relocationComplete.send(rd);
 
 		if (doBulkLoading && e.code() != error_code_actor_cancelled && e.code() != error_code_movekeys_conflict) {
-			TraceEvent(SevWarnAlways, "DDBulkLoadEngineTaskRelocatorFailed", self->distributorId)
+			TraceEvent(SevWarnAlways, "DDBulkLoadTaskRelocatorFailed", self->distributorId)
+			    .setMaxEventLength(-1)
+			    .setMaxFieldLength(-1)
 			    .errorUnsuppressed(e)
 			    .detail("BulkLoadTask", rd.bulkLoadTask.get().toString());
 		}

--- a/fdbserver/DDRelocationQueue.actor.cpp
+++ b/fdbserver/DDRelocationQueue.actor.cpp
@@ -129,7 +129,7 @@ DataMovementReason priorityToDataMovementReason(int priority) {
 RelocateData::RelocateData()
   : priority(-1), boundaryPriority(-1), healthPriority(-1), reason(RelocateReason::OTHER), startTime(-1),
     dataMoveId(anonymousShardId), workFactor(0), wantsNewServers(false), cancellable(false),
-    interval("QueuedRelocation") {};
+    interval("QueuedRelocation"){};
 
 RelocateData::RelocateData(RelocateShard const& rs)
   : parent_range(rs.getParentRange()), keys(rs.keys), priority(rs.priority),
@@ -215,7 +215,7 @@ class ParallelTCInfo final : public ReferenceCounted<ParallelTCInfo>, public IDa
 
 public:
 	ParallelTCInfo() = default;
-	explicit ParallelTCInfo(ParallelTCInfo const& info) : teams(info.teams), tempServerIDs(info.tempServerIDs) {};
+	explicit ParallelTCInfo(ParallelTCInfo const& info) : teams(info.teams), tempServerIDs(info.tempServerIDs){};
 
 	void addTeam(Reference<IDataDistributionTeam> team) { teams.push_back(team); }
 

--- a/fdbserver/include/fdbserver/DataDistribution.actor.h
+++ b/fdbserver/include/fdbserver/DataDistribution.actor.h
@@ -760,7 +760,7 @@ struct StorageWiggler : ReferenceCounted<StorageWiggler> {
 	State wiggleState = State::INVALID;
 	double lastStateChangeTs = 0.0; // timestamp describes when did the state change
 
-	explicit StorageWiggler(DDTeamCollection* collection) : teamCollection(collection), stopWiggleSignal(true) {};
+	explicit StorageWiggler(DDTeamCollection* collection) : teamCollection(collection), stopWiggleSignal(true){};
 	// wiggle related actors will quit when this signal is set to true
 	void setStopSignal(bool value) { stopWiggleSignal.set(value); }
 	bool isStopped() const { return stopWiggleSignal.get(); }

--- a/fdbserver/include/fdbserver/DataDistribution.actor.h
+++ b/fdbserver/include/fdbserver/DataDistribution.actor.h
@@ -618,7 +618,7 @@ public:
 			throw bulkload_task_outdated();
 		}
 		DDBulkLoadEngineTask task(bulkLoadTaskState, commitVersion, completeAck);
-		TraceEvent(SevDebug, "DDBulkLoadEngineCollectionPublishTask", ddId)
+		TraceEvent(SevDebug, "DDBulkLoadTaskCollectionPublishTask", ddId)
 		    .setMaxEventLength(-1)
 		    .setMaxFieldLength(-1)
 		    .detail("Range", bulkLoadTaskState.getRange())
@@ -637,7 +637,7 @@ public:
 			}
 			if (it->value().get().completeAck.canBeSet()) {
 				it->value().get().completeAck.sendError(bulkload_task_outdated());
-				TraceEvent(SevInfo, "DDBulkLoadEngineCollectionPublishTaskOverwriteTask", ddId)
+				TraceEvent(SevInfo, "DDBulkLoadTaskCollectionPublishTaskOverwriteTask", ddId)
 				    .setMaxEventLength(-1)
 				    .setMaxFieldLength(-1)
 				    .detail("NewRange", bulkLoadTaskState.getRange())
@@ -656,7 +656,7 @@ public:
 			if (!it->value().present() || it->value().get().coreState.getTaskId() != bulkLoadTaskState.getTaskId()) {
 				throw bulkload_task_outdated();
 			}
-			TraceEvent(SevDebug, "DDBulkLoadEngineCollectionStartTask", ddId)
+			TraceEvent(SevDebug, "DDBulkLoadTaskCollectionStartTask", ddId)
 			    .detail("Range", bulkLoadTaskState.getRange())
 			    .detail("TaskRange", it->range())
 			    .detail("Task", it->value().get().toString());
@@ -673,7 +673,7 @@ public:
 			// It is possible that the task has been completed by a past data move
 			if (it->value().get().completeAck.canBeSet()) {
 				it->value().get().completeAck.send(BulkLoadAck());
-				TraceEvent(SevDebug, "DDBulkLoadEngineCollectionTerminateTask", ddId)
+				TraceEvent(SevDebug, "DDBulkLoadTaskCollectionTerminateTask", ddId)
 				    .detail("Range", bulkLoadTaskState.getRange())
 				    .detail("TaskRange", it->range())
 				    .detail("Task", it->value().get().toString());
@@ -689,7 +689,7 @@ public:
 			if (!it->value().present() || it->value().get().coreState.getTaskId() != bulkLoadTaskState.getTaskId()) {
 				continue;
 			}
-			TraceEvent(SevDebug, "DDBulkLoadEngineCollectionEraseTaskdata", ddId)
+			TraceEvent(SevDebug, "DDBulkLoadTaskCollectionEraseTaskdata", ddId)
 			    .detail("Range", bulkLoadTaskState.getRange())
 			    .detail("TaskRange", it->range())
 			    .detail("Task", it->value().get().toString());
@@ -710,7 +710,7 @@ public:
 				continue;
 			}
 			DDBulkLoadEngineTask bulkLoadTask = it->value().get();
-			TraceEvent(SevDebug, "DDBulkLoadEngineCollectionGetPublishedTaskEach", ddId)
+			TraceEvent(SevDebug, "DDBulkLoadTaskCollectionGetPublishedTaskEach", ddId)
 			    .detail("Range", range)
 			    .detail("TaskRange", it->range())
 			    .detail("Task", bulkLoadTask.toString());
@@ -719,7 +719,7 @@ public:
 				res = bulkLoadTask;
 			}
 		}
-		TraceEvent(SevDebug, "DDBulkLoadEngineCollectionGetPublishedTask", ddId)
+		TraceEvent(SevDebug, "DDBulkLoadTaskCollectionGetPublishedTask", ddId)
 		    .detail("Range", range)
 		    .detail("Task", res.present() ? describe(res.get()) : "");
 		return res;
@@ -760,7 +760,7 @@ struct StorageWiggler : ReferenceCounted<StorageWiggler> {
 	State wiggleState = State::INVALID;
 	double lastStateChangeTs = 0.0; // timestamp describes when did the state change
 
-	explicit StorageWiggler(DDTeamCollection* collection) : teamCollection(collection), stopWiggleSignal(true){};
+	explicit StorageWiggler(DDTeamCollection* collection) : teamCollection(collection), stopWiggleSignal(true) {};
 	// wiggle related actors will quit when this signal is set to true
 	void setStopSignal(bool value) { stopWiggleSignal.set(value); }
 	bool isStopped() const { return stopWiggleSignal.get(); }


### PR DESCRIPTION
Make bulkLoad trace event name organized:
1. Search `DDBulkLoad*` to get all trace events generated by DD.
2. Search `SSBulkLoad*` to get all events generated by SS.
3. Search `DDBulkLoadJob*` to get all events from the DD BulkLoad Job module.
4. Search `DDBulkLoadTask*` to get all events from the DD BulkLoad Task module.
5. Search `DDBulkLoadTaskPersist*` to get all events for DD updating bulkLoad task metadata.

100K correctness:
  20250225-213220-zhewang-018d0a5991f04f6e           compressed=True data_size=40825804 duration=5271737 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:00:10 sanity=False started=100000 stopped=20250225-223230 submitted=20250225-213220 timeout=5400 username=zhewang
  
# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
