### PR TITLE
An issue with populating available log servers during recovery with version vector

### DIFF
--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -2157,10 +2157,10 @@ Optional<std::tuple<Version, Version>> getRecoverVersionUnicast(
 	int replicationFactor = std::get<0>(logGroupResults);
 	for (auto& tLogResult : std::get<1>(logGroupResults)) {
 		uint16_t tLogLocId = tLogLocIds[tLogIdx++];
+		availableTLogs.set(tLogLocId);
 		if (tLogResult.unknownCommittedVersions.empty()) {
 			continue;
 		}
-		availableTLogs.set(tLogLocId);
 		for (auto& unknownCommittedVersion : tLogResult.unknownCommittedVersions) {
 			Version k = unknownCommittedVersion.version;
 			if (k > maxKCV) {
@@ -2176,6 +2176,7 @@ Optional<std::tuple<Version, Version>> getRecoverVersionUnicast(
 			}
 		}
 	}
+	ASSERT(availableTLogs.count() == (std::get<1>(logGroupResults)).size());
 
 	if (versionAllTLogs.empty()) {
 		return std::make_tuple(maxKCV, maxKCV);


### PR DESCRIPTION
Correct an issue to do with populating the list of reporting log servers during recovery with version vector - the list of reporting log servers should include even those that have an empty unknown committed version list.

Testing:

Job id (with version vector disabled): 20250225-202516-sre-bc04a8bf2ed33162 (in progress)

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
