### PR TITLE
Improve BulkDump Implementation

### DIFF
--- a/fdbcli/BulkDumpCommand.actor.cpp
+++ b/fdbcli/BulkDumpCommand.actor.cpp
@@ -34,9 +34,9 @@ ACTOR Future<bool> getOngoingBulkDumpJob(Database cx) {
 	state Transaction tr(cx);
 	loop {
 		try {
-			Optional<UID> jobId = wait(getSubmittedBulkDumpJob(&tr));
-			if (jobId.present()) {
-				fmt::println("Running bulk dumping job: {}", jobId.get().toString());
+			Optional<BulkDumpState> job = wait(getSubmittedBulkDumpJob(&tr));
+			if (job.present()) {
+				fmt::println("Running bulk dumping job: {}", job.get().getJobId().toString());
 				return true;
 			} else {
 				fmt::println("No bulk dumping job is running");

--- a/fdbcli/BulkLoadCommand.actor.cpp
+++ b/fdbcli/BulkLoadCommand.actor.cpp
@@ -207,6 +207,10 @@ ACTOR Future<UID> bulkLoadCommandActor(Database cx, std::vector<StringRef> token
 			return UID();
 		}
 		UID jobId = UID::fromString(tokens[2].toString());
+		if (!jobId.isValid()) {
+			printUsage(tokens[0]);
+			return UID();
+		}
 		Key rangeBegin = tokens[3];
 		Key rangeEnd = tokens[4];
 		// Bulk load can only inject data to normal key space, aka "" ~ \xff
@@ -226,6 +230,10 @@ ACTOR Future<UID> bulkLoadCommandActor(Database cx, std::vector<StringRef> token
 			return UID();
 		}
 		UID jobId = UID::fromString(tokens[2].toString());
+		if (!jobId.isValid()) {
+			printUsage(tokens[0]);
+			return UID();
+		}
 		Key rangeBegin = tokens[3];
 		Key rangeEnd = tokens[4];
 		// Bulk load can only inject data to normal key space, aka "" ~ \xff
@@ -283,7 +291,7 @@ CommandFactory bulkLoadFactory(
         "bulkload commands",
         "To set bulkload mode: `bulkload mode [on|off]'\n"
         "To load a range from SST files: `bulkload [local|blobstore] <BeginKey> <EndKey> dumpFolder`\n"
-        "To clear current bulkload job: `bulkload clear <JobID>`\n"
+        "To clear current bulkload job: `bulkload clear <Non-Zero JobID>`\n"
         "To get completed bulkload ranges: `bulkload status <BeginKey> <EndKey>`\n"
         "BulkLoad tasks are operated when setting unittest.\n"
         "To acknowledge completed tasks within a range: `bulkload unittest acknowledge <TaskID> <BeginKey> <EndKey>'\n"

--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -3045,14 +3045,14 @@ ACTOR Future<Void> submitBulkLoadJob(Database cx, BulkLoadJobState jobState) {
 	loop {
 		try {
 			// There is at most one bulkLoad job or bulkDump job at a time globally
-			Optional<UID> aliveBulkDumpJob = wait(getSubmittedBulkDumpJob(&tr));
+			Optional<BulkDumpState> aliveBulkDumpJob = wait(getSubmittedBulkDumpJob(&tr));
 			if (aliveBulkDumpJob.present()) {
 				TraceEvent(SevInfo, "SubmitBulkLoadJobFailed")
 				    .setMaxEventLength(-1)
 				    .setMaxFieldLength(-1)
 				    .detail("Reason", "Conflict to a running BulkDump job")
 				    .detail("SubmitBulkLoadJob", jobState.toString())
-				    .detail("ExistBulkDumpJob", aliveBulkDumpJob.get());
+				    .detail("ExistBulkDumpJob", aliveBulkDumpJob.get().toString());
 				throw bulkload_task_failed();
 			}
 			Optional<BulkLoadJobState> aliveJob = wait(getSubmittedBulkLoadJob(&tr));
@@ -3281,45 +3281,11 @@ ACTOR Future<int> getBulkDumpMode(Database cx) {
 	}
 }
 
-ACTOR Future<Optional<BulkDumpState>> getRunningBulkDumpJob(Database cx) {
-	state Key beginKey = normalKeys.begin;
-	state Key endKey = normalKeys.end;
-	state RangeResult bulkDumpResult;
-	state BulkDumpState bulkDumpState;
-	state KeyRange rangeToRead;
-	state Transaction tr(cx);
-	while (beginKey < endKey) {
-		try {
-			rangeToRead = Standalone(KeyRangeRef(beginKey, endKey));
-			bulkDumpResult.clear();
-			wait(store(bulkDumpResult, krmGetRanges(&tr, bulkDumpPrefix, rangeToRead)));
-			for (int i = 0; i < bulkDumpResult.size() - 1; i++) {
-				if (bulkDumpResult[i].value.empty()) {
-					continue;
-				}
-				bulkDumpState = decodeBulkDumpState(bulkDumpResult[i].value);
-				if (!bulkDumpState.isValid()) {
-					continue;
-				}
-				if (bulkDumpState.getPhase() == BulkDumpPhase::Complete) {
-					continue;
-				}
-				ASSERT(bulkDumpState.getPhase() == BulkDumpPhase::Submitted);
-				return bulkDumpState;
-			}
-			beginKey = bulkDumpResult.back().key;
-		} catch (Error& e) {
-			wait(tr.onError(e));
-		}
-	}
-	return Optional<BulkDumpState>();
-}
-
 // Return job Id if existing any bulk dump job globally.
 // There is at most one bulk dump job at any time on the entire key space.
 // A job of a range can spawn multiple tasks according to the shard boundary.
 // Those tasks share the same job Id (aka belonging to the same job).
-ACTOR Future<Optional<UID>> getSubmittedBulkDumpJob(Transaction* tr) {
+ACTOR Future<Optional<BulkDumpState>> getSubmittedBulkDumpJob(Transaction* tr) {
 	state RangeResult rangeResult;
 	wait(store(rangeResult,
 	           krmGetRanges(tr,
@@ -3337,9 +3303,9 @@ ACTOR Future<Optional<UID>> getSubmittedBulkDumpJob(Transaction* tr) {
 		if (!bulkDumpState.isValid()) {
 			continue;
 		}
-		return bulkDumpState.getJobId();
+		return bulkDumpState;
 	}
-	return Optional<UID>();
+	return Optional<BulkDumpState>();
 }
 
 ACTOR Future<Void> submitBulkDumpJob(Database cx, BulkDumpState bulkDumpJob) {
@@ -3359,16 +3325,16 @@ ACTOR Future<Void> submitBulkDumpJob(Database cx, BulkDumpState bulkDumpJob) {
 				    .detail("NewJob", bulkDumpJob.toString());
 				throw bulkdump_task_failed();
 			}
-			Optional<UID> aliveJobId = wait(getSubmittedBulkDumpJob(&tr));
-			if (aliveJobId.present()) {
-				if (aliveJobId.get() == bulkDumpJob.getJobId()) {
+			Optional<BulkDumpState> aliveJob = wait(getSubmittedBulkDumpJob(&tr));
+			if (aliveJob.present()) {
+				if (aliveJob.get().getJobId() == bulkDumpJob.getJobId()) {
 					return Void(); // The job has been persisted
 				}
 				TraceEvent(SevWarn, "SubmitBulkDumpJobFailed")
 				    .setMaxEventLength(-1)
 				    .setMaxFieldLength(-1)
 				    .detail("Reason", "Conflict to a running BulkDump job")
-				    .detail("AliveJobId", aliveJobId.get().toString())
+				    .detail("AliveJob", aliveJob.get().toString())
 				    .detail("NewJob", bulkDumpJob.toString());
 				throw bulkdump_task_failed();
 			}
@@ -3415,6 +3381,9 @@ ACTOR Future<Void> clearBulkDumpJob(Database cx, UID jobId) {
 					continue;
 				}
 				existJob = decodeBulkDumpState(bulkDumpResult[i].value);
+				if (!existJob.isValid()) {
+					continue;
+				}
 				// We only clear the metadata if it has the same jobId as the input Id.
 				// When there is a new jobId persisted different than the input Id,
 				// a new job has been submitted successfully. Since a new job can be submitted successfully if and only

--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -388,8 +388,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( SS_BULKLOAD_GETRANGE_BATCH_SIZE,                     10000 ); if (isSimulated) SS_BULKLOAD_GETRANGE_BATCH_SIZE = deterministicRandom()->randomInt(1, 10);
 
 	// BulkDumping
-	init( DD_BULKLOAD_AND_DUMP_TASK_METADATA_READ_SIZE,          100 ); if( randomize && BUGGIFY ) DD_BULKLOAD_AND_DUMP_TASK_METADATA_READ_SIZE = deterministicRandom()->randomInt(2, 100);
-	init( DD_BULKDUMP_SCHEDULE_MIN_INTERVAL_SEC,                 2.0 ); if( randomize && BUGGIFY ) DD_BULKDUMP_SCHEDULE_MIN_INTERVAL_SEC = deterministicRandom()->random01() * 10 + 1;
+	init( DD_BULKDUMP_SCHEDULE_MIN_INTERVAL_SEC,                 5.0 ); if( randomize && BUGGIFY ) DD_BULKDUMP_SCHEDULE_MIN_INTERVAL_SEC = deterministicRandom()->random01() * 10 + 1;
 	init( DD_BULKDUMP_PARALLELISM,                                50 ); if( randomize && BUGGIFY ) DD_BULKDUMP_PARALLELISM = deterministicRandom()->randomInt(1, 5);
 	init( SS_SERVE_BULKDUMP_PARALLELISM,                           1 ); // TODO(BulkDump): Do not set to 1 after SS can resolve the file folder conflict
 	init( SS_BULKDUMP_BATCH_BYTES,                     100*1024*1024 ); if( isSimulated ) SS_BULKDUMP_BATCH_BYTES = deterministicRandom()->randomInt(1000, 10000);

--- a/fdbclient/include/fdbclient/BulkDumping.h
+++ b/fdbclient/include/fdbclient/BulkDumping.h
@@ -46,6 +46,7 @@ struct BulkDumpState {
 	              std::string jobRoot)
 	  : jobId(deterministicRandom()->randomUniqueID()), jobRange(jobRange), phase(BulkDumpPhase::Submitted) {
 		manifest = BulkLoadManifest(loadType, transportMethod, jobRoot);
+		ASSERT(isValid());
 	}
 
 	bool operator==(const BulkDumpState& rhs) const {
@@ -79,7 +80,7 @@ struct BulkDumpState {
 
 	BulkLoadType getType() const { return manifest.getLoadType(); }
 
-	bool isValid() const {
+	bool isMetadataValid() const {
 		if (!jobId.isValid()) {
 			return false;
 		}
@@ -97,6 +98,8 @@ struct BulkDumpState {
 		}
 		return true;
 	}
+
+	bool isValid() const { return jobId.isValid(); }
 
 	// The user job spawns a series of ranges tasks based on shard boundary to cover the user task range.
 	// Those spawned tasks are sent to SSes and executed by the SSes.
@@ -131,7 +134,7 @@ struct BulkDumpState {
 		BulkDumpState res = *this;
 		res.phase = BulkDumpPhase::Complete;
 		res.manifest = manifest;
-		ASSERT(res.isValid());
+		ASSERT(res.isMetadataValid());
 		return res;
 	}
 

--- a/fdbclient/include/fdbclient/BulkDumping.h
+++ b/fdbclient/include/fdbclient/BulkDumping.h
@@ -34,6 +34,7 @@ enum class BulkDumpPhase : uint8_t {
 
 // Definition of bulkdump metadata
 struct BulkDumpState {
+public:
 	constexpr static FileIdentifier file_identifier = 1384498;
 
 	BulkDumpState() = default;

--- a/fdbclient/include/fdbclient/BulkLoading.h
+++ b/fdbclient/include/fdbclient/BulkLoading.h
@@ -310,6 +310,7 @@ private:
 // The manifest file stores the ground true of metadata of dumped data file, such as range and version.
 // The manifest file is uploaded along with the data file.
 struct BulkLoadManifest {
+public:
 	constexpr static FileIdentifier file_identifier = 1384502;
 
 	BulkLoadManifest() = default;
@@ -469,6 +470,8 @@ struct BulkLoadManifest {
 
 	bool hasDataFile() const { return fileSet.hasDataFile(); }
 
+	bool hasByteSampleFile() const { return fileSet.hasByteSampleFile(); }
+
 	void setRange(const KeyRange& range) {
 		ASSERT(!range.empty() && beginKey.empty() && endKey.empty());
 		beginKey = range.begin;
@@ -501,6 +504,7 @@ struct BulkLoadManifest {
 		           transportMethod);
 	}
 
+private:
 	int formatVersion = -1;
 	BulkLoadFileSet fileSet;
 	Key beginKey;
@@ -524,6 +528,7 @@ enum class BulkLoadPhase : uint8_t {
 };
 
 struct BulkLoadTaskState {
+public:
 	constexpr static FileIdentifier file_identifier = 1384499;
 
 	BulkLoadTaskState() = default;

--- a/fdbclient/include/fdbclient/BulkLoading.h
+++ b/fdbclient/include/fdbclient/BulkLoading.h
@@ -675,9 +675,7 @@ public:
 	                 const KeyRange& jobRange,
 	                 const BulkLoadTransportMethod& transportMethod)
 	  : jobId(jobId), jobRoot(jobRoot), jobRange(jobRange), phase(BulkLoadJobPhase::Submitted),
-	    transportMethod(transportMethod) {
-		ASSERT(isValid());
-	}
+	    transportMethod(transportMethod) {}
 
 	std::string toString() const {
 		std::string res = "[BulkLoadJobState]: [JobId]: " + jobId.toString() + ", [JobRoot]: " + jobRoot +
@@ -699,7 +697,7 @@ public:
 
 	void setPhase(BulkLoadJobPhase inputPhase) { phase = inputPhase; }
 
-	bool isValid() const {
+	bool isMetadataValid() const {
 		if (!jobId.isValid()) {
 			return false;
 		}
@@ -714,6 +712,8 @@ public:
 		}
 		return true;
 	}
+
+	bool isValid() const { return jobId.isValid(); }
 
 	template <class Ar>
 	void serialize(Ar& ar) {

--- a/fdbclient/include/fdbclient/ManagementAPI.actor.h
+++ b/fdbclient/include/fdbclient/ManagementAPI.actor.h
@@ -232,11 +232,8 @@ ACTOR Future<Void> clearBulkDumpJob(Database cx, UID jobId);
 // If there is any existing BulkLoad or BulkDump job, reject the new job.
 ACTOR Future<Void> submitBulkDumpJob(Database cx, BulkDumpState bulkDumpJob);
 
-// Return the running job metadata
-ACTOR Future<Optional<BulkDumpState>> getRunningBulkDumpJob(Database cx);
-
-// Return the existing Job ID
-ACTOR Future<Optional<UID>> getSubmittedBulkDumpJob(Transaction* tr);
+// Return the existing job metadata
+ACTOR Future<Optional<BulkDumpState>> getSubmittedBulkDumpJob(Transaction* tr);
 
 // Get total number of completed tasks within the input range
 ACTOR Future<size_t> getBulkDumpCompleteTaskCount(Database cx, KeyRange rangeToRead);

--- a/fdbclient/include/fdbclient/ManagementAPI.actor.h
+++ b/fdbclient/include/fdbclient/ManagementAPI.actor.h
@@ -232,6 +232,9 @@ ACTOR Future<Void> clearBulkDumpJob(Database cx, UID jobId);
 // If there is any existing BulkLoad or BulkDump job, reject the new job.
 ACTOR Future<Void> submitBulkDumpJob(Database cx, BulkDumpState bulkDumpJob);
 
+// Return the running job metadata
+ACTOR Future<Optional<BulkDumpState>> getRunningBulkDumpJob(Database cx);
+
 // Return the existing Job ID
 ACTOR Future<Optional<UID>> getSubmittedBulkDumpJob(Transaction* tr);
 

--- a/fdbclient/include/fdbclient/ServerKnobs.h
+++ b/fdbclient/include/fdbclient/ServerKnobs.h
@@ -405,7 +405,6 @@ public:
 	int DD_BULKLOAD_PARALLELISM; // the maximum number of running bulk load tasks
 	double DD_BULKLOAD_SCHEDULE_MIN_INTERVAL_SEC; // the minimal seconds that the bulk load scheduler has to wait
 	                                              // between two rounds
-	int DD_BULKLOAD_AND_DUMP_TASK_METADATA_READ_SIZE; // the number of bulk dump tasks read from metadata at a time
 	double DD_BULKDUMP_SCHEDULE_MIN_INTERVAL_SEC; // the minimal seconds that the bulk dump scheduler has to wait
 	                                              // between two rounds
 	bool CC_ENFORCE_USE_UNFIT_DD_IN_SIM; // Set for CC to enforce to use an unfit DD in the simulation. This knob

--- a/fdbserver/BulkDumpUtil.actor.cpp
+++ b/fdbserver/BulkDumpUtil.actor.cpp
@@ -327,7 +327,7 @@ ACTOR Future<Void> uploadBulkDumpJobManifestFile(BulkLoadTransportMethod transpo
 
 ACTOR Future<Void> persistCompleteBulkDumpRange(Database cx, BulkDumpState bulkDumpState) {
 	state Transaction tr(cx);
-	ASSERT(bulkDumpState.isValid());
+	ASSERT(bulkDumpState.isMetadataValid());
 	state Key beginKey = bulkDumpState.getRange().begin;
 	state Key endKey = bulkDumpState.getRange().end;
 	state KeyRange rangeToPersist;

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -6184,25 +6184,25 @@ ACTOR Future<Void> bulkDumpQ(StorageServer* data, BulkDumpRequest req) {
 			    .detail("RelativeFolder", relativeFolder)
 			    .detail("DataKeyCount", rangeDumpData.kvs.size())
 			    .detail("DataBytes", rangeDumpData.kvsBytes)
-			    .detail("RemoteFileSet", manifest.fileSet.toString())
+			    .detail("RemoteFileSet", manifest.getFileSet().toString())
 			    .detail("BatchNum", batchNum);
 
 			// Upload Files
 			state BulkLoadFileSet localFileSet = localFileSetSetting;
-			if (!manifest.fileSet.hasDataFile()) {
+			if (!manifest.hasDataFile()) {
 				localFileSet.removeDataFile();
 			}
-			if (!manifest.fileSet.hasByteSampleFile()) {
+			if (!manifest.hasByteSampleFile()) {
 				localFileSet.removeByteSampleFile();
 			}
 			wait(uploadBulkDumpFileSet(
-			    req.bulkDumpState.getTransportMethod(), localFileSet, manifest.fileSet, data->thisServerID));
+			    req.bulkDumpState.getTransportMethod(), localFileSet, manifest.getFileSet(), data->thisServerID));
 
 			// Progressively set metadata of the data range as complete phase
 			// Persist remoteFilePaths to the corresponding range
 			if (!dataRange.empty()) {
 				// The persisting range (dataRange) must be exactly same as the range presented in the manifest file
-				ASSERT(dataRange == KeyRangeRef(manifest.beginKey, manifest.endKey));
+				ASSERT(dataRange == manifest.getRange());
 				wait(persistCompleteBulkDumpRange(data->cx,
 				                                  req.bulkDumpState.generateBulkDumpMetadataToPersist(manifest)));
 			}

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -14689,6 +14689,8 @@ ACTOR Future<Void> storageServerCore(StorageServer* self, StorageServerInterface
 				}
 			}
 			when(BulkDumpRequest req = waitNext(ssi.bulkdump.getFuture())) {
+				TraceEvent(SevInfo, "SSBulkDumpRequestReceived", self->thisServerID)
+				    .detail("BulkDumpRequest", req.toString());
 				self->actors.add(bulkDumpQ(self, req));
 			}
 			when(wait(updateProcessStatsTimer)) {

--- a/fdbserver/workloads/BulkDumping.actor.cpp
+++ b/fdbserver/workloads/BulkDumping.actor.cpp
@@ -123,7 +123,7 @@ struct BulkDumping : TestWorkload {
 			try {
 				tr.setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
 				tr.setOption(FDBTransactionOptions::LOCK_AWARE);
-				Optional<UID> aliveJob = wait(getSubmittedBulkDumpJob(&tr));
+				Optional<BulkDumpState> aliveJob = wait(getSubmittedBulkDumpJob(&tr));
 				if (!aliveJob.present()) {
 					break;
 				}


### PR DESCRIPTION
More clear logic and better trace events.

500K bulkDump tests:
  20250226-064557-zhewang-bafded6719b54226           compressed=True data_size=40872385 duration=8890904 ended=500000 fail_fast=10 max_runs=500000 pass=500000 priority=100 remaining=0 runtime=1:47:43 sanity=False started=500000 stopped=20250226-083340 submitted=20250226-064557 timeout=5400 username=zhewang
  
500K bulkLoad tests:
  20250226-183127-zhewang-eae0a34e7a14f617           compressed=True data_size=40875651 duration=7105827 ended=500000 fail_fast=10 max_runs=500000 pass=500000 priority=100 remaining=0 runtime=1:50:40 sanity=False started=500000 stopped=20250226-202207 submitted=20250226-183127 timeout=5400 username=zhewang
        
100K correctness with 1 irrelevant failure:
  20250226-210202-zhewang-ea1e57fa7ffd4175           compressed=True data_size=40831766 duration=5660602 ended=100000 fail=1 fail_fast=10 max_runs=100000 pass=99999 priority=100 remaining=0 runtime=0:55:30 sanity=False started=100000 stopped=20250226-215732 submitted=20250226-210202 timeout=5400 username=zhewang
  
# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
