### PR TITLE
[Experimental] Only track pushed tlog locations in MergedPeekCursor::popped

### DIFF
--- a/fdbserver/LogSystemPeekCursor.actor.cpp
+++ b/fdbserver/LogSystemPeekCursor.actor.cpp
@@ -577,7 +577,7 @@ ILogSystem::MergedPeekCursor::MergedPeekCursor(
     int tLogReplicationFactor)
   : tag(tag), bestServer(bestServer), currentCursor(0), readQuorum(readQuorum), messageVersion(begin),
     hasNextMessage(false), randomID(deterministicRandom()->randomUniqueID()),
-    tLogReplicationFactor(tLogReplicationFactor), pushLocations(pushLocations) {
+    tLogReplicationFactor(tLogReplicationFactor), pushLocations(std::move(pushLocations)) {
 	if (tLogPolicy) {
 		logSet = makeReference<LogSet>();
 		logSet->tLogPolicy = tLogPolicy;

--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -1005,7 +1005,10 @@ Reference<ILogSystem::IPeekCursor> TagPartitionedLogSystem::peekLocal(UID dbgid,
 		    .detail("BestSetStart", tLogs[bestSet]->startVersion)
 		    .detail("LogId", tLogs[bestSet]->logServers[tLogs[bestSet]->bestLocationFor(tag)]->get().id());
 		if (useMergePeekCursors) {
+			std::vector<int> pushLocations;
+			tLogs[bestSet]->getPushLocations(VectorRef<Tag>(&tag, 1), pushLocations, 0);
 			return makeReference<ILogSystem::MergedPeekCursor>(tLogs[bestSet]->logServers,
+			                                                   std::move(pushLocations),
 			                                                   tLogs[bestSet]->bestLocationFor(tag),
 			                                                   tLogs[bestSet]->logServers.size() + 1 -
 			                                                       tLogs[bestSet]->tLogReplicationFactor,
@@ -1033,7 +1036,10 @@ Reference<ILogSystem::IPeekCursor> TagPartitionedLogSystem::peekLocal(UID dbgid,
 			    .detail("BestSetStart", tLogs[bestSet]->startVersion)
 			    .detail("LogId", tLogs[bestSet]->logServers[tLogs[bestSet]->bestLocationFor(tag)]->get().id());
 			if (useMergePeekCursors) {
+				std::vector<int> pushLocations;
+				tLogs[bestSet]->getPushLocations(VectorRef<Tag>(&tag, 1), pushLocations, 0);
 				cursors.push_back(makeReference<ILogSystem::MergedPeekCursor>(tLogs[bestSet]->logServers,
+				                                                              std::move(pushLocations),
 				                                                              tLogs[bestSet]->bestLocationFor(tag),
 				                                                              tLogs[bestSet]->logServers.size() + 1 -
 				                                                                  tLogs[bestSet]->tLogReplicationFactor,
@@ -1131,8 +1137,11 @@ Reference<ILogSystem::IPeekCursor> TagPartitionedLogSystem::peekLocal(UID dbgid,
 					// detail("LogId",
 					// oldLogData[i].tLogs[bestOldSet]->logServers[tLogs[bestOldSet]->bestLocationFor( tag
 					// )]->get().id());
+					std::vector<int> pushLocations;
+					oldLogData[i].tLogs[bestOldSet]->getPushLocations(VectorRef<Tag>(&tag, 1), pushLocations, 0);
 					cursors.push_back(makeReference<ILogSystem::MergedPeekCursor>(
 					    oldLogData[i].tLogs[bestOldSet]->logServers,
+					    std::move(pushLocations),
 					    oldLogData[i].tLogs[bestOldSet]->bestLocationFor(tag),
 					    oldLogData[i].tLogs[bestOldSet]->logServers.size() + 1 -
 					        oldLogData[i].tLogs[bestOldSet]->tLogReplicationFactor,

--- a/fdbserver/include/fdbserver/LogSystem.h
+++ b/fdbserver/include/fdbserver/LogSystem.h
@@ -281,9 +281,10 @@ struct ILogSystem {
 		UID randomID;
 		int tLogReplicationFactor;
 		Future<Void> more;
+		std::vector<int> pushLocations;
 
-		MergedPeekCursor(std::vector<Reference<ILogSystem::IPeekCursor>> const& serverCursors, Version begin);
 		MergedPeekCursor(std::vector<Reference<AsyncVar<OptionalInterface<TLogInterface>>>> const& logServers,
+		                 std::vector<int>&& pushLocations,
 		                 int bestServer,
 		                 int readQuorum,
 		                 Tag tag,


### PR DESCRIPTION
# Description

_Note: I do not think this implementation would work, not exactly sure how it is passing 100K. Will think more. See "Open questions" section for details._

The context here is that I was debugging a failure in `slow/CommitBug.toml` at commit `cf7c8f41b22612c4a8a632ea6f173d891b00380d`, seed `451379071`, buggify `on` with clang compiler. 

Issue there was:
1. cluster reached accepting_commits recovery state 
2. there was 1 seed server (storage team size config was 1)
3. that seed server experienced a [popped from tlog](https://github.com/apple/foundationdb/blob/5f9f5358a8dc32f0cb1c25dbc3d5d138a22a1eed/fdbserver/storageserver.actor.cpp#L11919-L11924) 
4. DD could not start because it [itself relies on SS](https://github.com/apple/foundationdb/blob/5f9f5358a8dc32f0cb1c25dbc3d5d138a22a1eed/fdbserver/DataDistribution.actor.cpp#L2252-L2254)
5. we are left with 0 SS in the cluster as a permanent state
6. change config workload's txn was stuck because it involves a get

This brought an interesting realization: there's a short time window between seed SS being recruited and starting to the point when DD initializes. In this time window, if SS fails, DD can not fix the situation. Storage team size being higher (e.g. 3) reduces the probability of this, but it can still happen. This is a bootstrap (new cluster) edge case where if it happens in practice, the cluster has to be bounced manually. It can also happen outside bootstrap (existing cluster) recovery but there DD starting will depending on which SS own the key range that DD writes to or reads from for its own initialization. 

The remaining question here about the reason behind (3). Based on my understanding, `StorageServerWorkerRemoved` should be rare, but I was noticing it often in simulation, and in this case it was causing the test to fail. 

It turned out that the popped version SS got from tlog was a false positive. Here's why:
- let's say we have this scenario: total recruited tlogs = 3, tlog replication = 2
- let's say we have to commit a txn that has key ranges associated with SS `A`
- commit proxy will push mutation to 2 tlogs (tlog1, tlog2) with SS tag `A`, but will still push an empty message to the 3rd tlog (tlog3)
- on the SS side, a cursor will be created to peek against the tlogs. Generally ss will peek from its buddy/primary tlog (e.g. tlog1), but will still get empty messages from tlog3. This is because SS has to know the latest commit versions so it can know how to respond to the recent read versions. _Update: I think the general case should be that SS only talks to 1 buddy tlog, but there are other cases (e.g. buddy tlog fails, certain parts of recovery?) where we have to talk to all tlogs, even across generations._ 
- for TagPartitionedLogSystem, we can [create a MergedPeekCursor](https://github.com/apple/foundationdb/blob/9adaa6eef2412b94831208d154ee37b5ce55c230/fdbserver/TagPartitionedLogSystem.actor.cpp#L1134-L1145). Before this change, this MergedPeekCursor would get popped version from tlog1,tlog2,tlog3. However, tlog3 does not have the SS `A` tag, so it can [return a > 0 popped version](https://github.com/apple/foundationdb/blob/78d4490acf4c78df6bfe041e05876c3ba5bd9dca/fdbserver/TLogServer.actor.cpp#L1627-L1632). MergedPeekCursor would then return this > 0 popped version (since it takes a [max across tlogs](https://github.com/apple/foundationdb/blob/a63631f68c9386202de850fb3c3136cad1b1412d/fdbserver/LogSystemPeekCursor.actor.cpp#L846)) to SS `A` indicating that cursor peek position is behind what has already been popped. This is incorrect, SS `A` never explicitly popped and if you ask tlog1 and tlog2 about popped version for SS `A` tag, they would return 0 indicating that cursor peek position is >= latest popped position. 
- the fix in this example is to understand in MergedPeekCursor::popped that tlog3 will not have SS `A` tagged mutations, so even though we need tlog3 for peeks of empty messages, for popped computation we can skip it and just rely on tlog1 and tlog2. More generally, MergedPeekCursor::popped is now based on just tlogs that are push locations for SS `A` tag.
 

# Testing

Reran `slow/CommitBug.toml` test and ensured SS gets popped version 0 and therefore we do not get `StorageServerWorkerRemoved` so the test passes. 

100K: `20250226-085538-praza-r142986630-tosubmit-v2-d24e1e8dbdb3a97 compressed=True data_size=35763539 duration=5766989 ended=100000 fail=1 fail_fast=10 max_runs=100000 pass=99999 priority=100 remaining=0 runtime=0:39:39 sanity=False started=100000 stopped=20250226-093517 submitted=20250226-085538 timeout=5400 username=praza-r142986630-tosubmit-v2-d24e1e8dbdb3a97cd1969caa211e0150b483c8ff`. There is 1 failure, will look into whether it's related to this change.

# Open questions

1. For SS `A`, is there any purpose to talk to tlogs that don't have `A` tag for the purpose of popped computation? Somewhat equivalently, is the sole purpose of popped to tell you whether _you_ (in this case, SS `A`) has popped the (version, `A`) combination before?

2. Do we have a reliable API that can tell, given a SS tag, all the tlogs that have that SS tag? I could only find `getPushLocations` but not sure if it's the right API for the problem I am solving here. 

Regarding (1), I thought a bit more and I think it boils down to that we do not have a deterministic way of asking for a given SS tag, what are all the N tlogs? N is the tlog replication factor. We deterministically know the buddy tlog in that set of N, but the others could be random. I believe that acts as a solution to the load balancing problem too. If that is true, the implementation here would be incorrect. This is because my intent here is to go to all tlogs that have the SS tag, and if the buddy fails for some reason, we have to basically ask all tlogs in the cluster for peek as well as popped. 

The alternative implementation could be: for popped, if the buddy tlog replies, ignore other responses. If the buddy tlog does not reply, we fall back to asking all tlogs in the cluster. The challenge here is what if the SS is lagging behind so much that it has to talk to older generation tlogs, in which case, I believe the buddy tlog for each generation could be different. So then we have to wait for a reply from buddy tlog across generations before ignoring other responses. 

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
