### PR TITLE
Add BulkloadJob Cancellation

### DIFF
--- a/fdbcli/BulkLoadCommand.actor.cpp
+++ b/fdbcli/BulkLoadCommand.actor.cpp
@@ -247,7 +247,7 @@ ACTOR Future<UID> bulkLoadCommandActor(Database cx, std::vector<StringRef> token
 		wait(submitBulkLoadJob(cx, bulkLoadJob));
 		return bulkLoadJob.getJobId();
 
-	} else if (tokencmp(tokens[1], "cancel")) {
+	} else if (tokencmp(tokens[1], "clear")) {
 		if (tokens.size() != 3) {
 			printUsage(tokens[0]);
 			return UID();
@@ -257,7 +257,7 @@ ACTOR Future<UID> bulkLoadCommandActor(Database cx, std::vector<StringRef> token
 			printUsage(tokens[0]);
 			return UID();
 		}
-		fmt::println("Job {} has been cancelled.", jobId.toString());
+		fmt::println("Job {} has been cleared.", jobId.toString());
 		wait(cancelBulkLoadJob(cx, jobId));
 		return UID();
 
@@ -291,7 +291,7 @@ ACTOR Future<UID> bulkLoadCommandActor(Database cx, std::vector<StringRef> token
 CommandFactory bulkLoadFactory(
     "bulkload",
     CommandHelp(
-        "bulkload [mode|local|blobstore|status|unittest] [ARGs]",
+        "bulkload [mode|local|blobstore|status|clear|unittest] [ARGs]",
         "bulkload commands",
         "To set bulkload mode: `bulkload mode [on|off]'\n"
         "To load a range from SST files: `bulkload [local|blobstore] <BeginKey> <EndKey> dumpFolder`\n"

--- a/fdbcli/BulkLoadCommand.actor.cpp
+++ b/fdbcli/BulkLoadCommand.actor.cpp
@@ -257,8 +257,8 @@ ACTOR Future<UID> bulkLoadCommandActor(Database cx, std::vector<StringRef> token
 			printUsage(tokens[0]);
 			return UID();
 		}
-		fmt::println("Job {} has been cleared.", jobId.toString());
 		wait(cancelBulkLoadJob(cx, jobId));
+		fmt::println("Job {} has been cleared.", jobId.toString());
 		return UID();
 
 	} else if (tokencmp(tokens[1], "status")) {

--- a/fdbcli/BulkLoadCommand.actor.cpp
+++ b/fdbcli/BulkLoadCommand.actor.cpp
@@ -247,14 +247,18 @@ ACTOR Future<UID> bulkLoadCommandActor(Database cx, std::vector<StringRef> token
 		wait(submitBulkLoadJob(cx, bulkLoadJob));
 		return bulkLoadJob.getJobId();
 
-	} else if (tokencmp(tokens[1], "clear")) {
+	} else if (tokencmp(tokens[1], "cancel")) {
 		if (tokens.size() != 3) {
 			printUsage(tokens[0]);
 			return UID();
 		}
-		state UID jobId = UID::fromString(tokens[2].toString());
-		fmt::println("Job {} has been cleared. No task will be spawned.", jobId.toString());
-		// TODO(Zhe)
+		UID jobId = UID::fromString(tokens[2].toString());
+		if (!jobId.isValid()) {
+			printUsage(tokens[0]);
+			return UID();
+		}
+		fmt::println("Job {} has been cancelled.", jobId.toString());
+		wait(cancelBulkLoadJob(cx, jobId));
 		return UID();
 
 	} else if (tokencmp(tokens[1], "status")) {

--- a/fdbcli/BulkLoadCommand.actor.cpp
+++ b/fdbcli/BulkLoadCommand.actor.cpp
@@ -247,18 +247,18 @@ ACTOR Future<UID> bulkLoadCommandActor(Database cx, std::vector<StringRef> token
 		wait(submitBulkLoadJob(cx, bulkLoadJob));
 		return bulkLoadJob.getJobId();
 
-	} else if (tokencmp(tokens[1], "clear")) {
+	} else if (tokencmp(tokens[1], "cancel")) {
 		if (tokens.size() != 3) {
 			printUsage(tokens[0]);
 			return UID();
 		}
-		UID jobId = UID::fromString(tokens[2].toString());
+		state UID jobId = UID::fromString(tokens[2].toString());
 		if (!jobId.isValid()) {
 			printUsage(tokens[0]);
 			return UID();
 		}
 		wait(cancelBulkLoadJob(cx, jobId));
-		fmt::println("Job {} has been cleared.", jobId.toString());
+		fmt::println("Job {} has been cancelled.", jobId.toString());
 		return UID();
 
 	} else if (tokencmp(tokens[1], "status")) {
@@ -291,11 +291,11 @@ ACTOR Future<UID> bulkLoadCommandActor(Database cx, std::vector<StringRef> token
 CommandFactory bulkLoadFactory(
     "bulkload",
     CommandHelp(
-        "bulkload [mode|local|blobstore|status|clear|unittest] [ARGs]",
+        "bulkload [mode|local|blobstore|status|cancel|unittest] [ARGs]",
         "bulkload commands",
         "To set bulkload mode: `bulkload mode [on|off]'\n"
         "To load a range from SST files: `bulkload [local|blobstore] <BeginKey> <EndKey> dumpFolder`\n"
-        "To clear current bulkload job: `bulkload clear <Non-Zero JobID>`\n"
+        "To cancel current bulkload job: `bulkload cancel <Non-Zero JobID>`\n"
         "To get completed bulkload ranges: `bulkload status <BeginKey> <EndKey>`\n"
         "BulkLoad tasks are operated when setting unittest.\n"
         "To acknowledge completed tasks within a range: `bulkload unittest acknowledge <TaskID> <BeginKey> <EndKey>'\n"

--- a/fdbclient/include/fdbclient/ManagementAPI.actor.h
+++ b/fdbclient/include/fdbclient/ManagementAPI.actor.h
@@ -204,6 +204,9 @@ ACTOR Future<BulkLoadTaskState> getBulkLoadTask(Transaction* tr,
 // Get the current running bulk load job
 ACTOR Future<Optional<BulkLoadJobState>> getRunningBulkLoadJob(Database cx);
 
+// Cancel bulkLoad job for the given jobId
+ACTOR Future<Void> cancelBulkLoadJob(Database cx, UID jobId);
+
 // Acknowledge all bulk load tasks that are in the Error phase.
 // After acknowledge, the write traffic to the task's range is turned on and the task's metadata is cleared by the bulk
 // load engine.

--- a/fdbserver/workloads/BulkDumping.actor.cpp
+++ b/fdbserver/workloads/BulkDumping.actor.cpp
@@ -76,13 +76,12 @@ struct BulkDumping : TestWorkload {
 			Standalone<StringRef> keyB = self->getRandomStringRef();
 			if (!scope.contains(keyA) || !scope.contains(keyB)) {
 				continue;
-			} else if (keyA < keyB) {
-				return Standalone(KeyRangeRef(keyA, keyB));
-			} else if (keyA > keyB) {
-				return Standalone(KeyRangeRef(keyB, keyA));
-			} else {
+			}
+			KeyRange range = keyA < keyB ? KeyRangeRef(keyA, keyB) : KeyRangeRef(keyB, keyA);
+			if (range.empty() || range.singleKeyRange()) {
 				continue;
 			}
+			return range;
 		}
 	}
 

--- a/fdbserver/workloads/BulkDumping.actor.cpp
+++ b/fdbserver/workloads/BulkDumping.actor.cpp
@@ -24,10 +24,8 @@
 #include "fdbclient/NativeAPI.actor.h"
 #include "fdbserver/workloads/workloads.actor.h"
 #include "flow/Error.h"
-#include "flow/IRandom.h"
 #include "flow/Platform.h"
 #include "flow/actorcompiler.h" // This must be the last #include.
-#include "flow/flow.h"
 
 const std::string simulationBulkDumpFolder = joinPath("simfdb", "bulkdump");
 

--- a/fdbserver/workloads/BulkDumping.actor.cpp
+++ b/fdbserver/workloads/BulkDumping.actor.cpp
@@ -265,6 +265,7 @@ struct BulkDumping : TestWorkload {
 				if (self->enableCancellation && !self->cancelled && deterministicRandom()->random01() < 0.1) {
 					wait(cancelBulkLoadJob(cx, jobId));
 					self->cancelled = true; // Inject cancellation. Then the bulkload job should run again.
+					TraceEvent("BulkDumpingWorkLoad").detail("Phase", "Job Cancelled").detail("Job", jobId.toString());
 					return std::vector<BulkLoadTaskState>();
 				}
 				wait(delay(10.0));

--- a/fdbserver/workloads/BulkLoading.actor.cpp
+++ b/fdbserver/workloads/BulkLoading.actor.cpp
@@ -55,8 +55,8 @@ struct BulkLoadTaskTestUnit {
 
 struct BulkLoading : TestWorkload {
 	static constexpr auto NAME = "BulkLoadingWorkload";
-	const bool enabled;
-	bool pass;
+	const bool enabled = true;
+	bool pass = true;
 	bool debugging = false;
 	bool backgroundTrafficEnabled = deterministicRandom()->coinflip();
 	UID jobId = deterministicRandom()->randomUniqueID();

--- a/fdbserver/workloads/BulkLoading.actor.cpp
+++ b/fdbserver/workloads/BulkLoading.actor.cpp
@@ -325,13 +325,12 @@ struct BulkLoading : TestWorkload {
 			Standalone<StringRef> keyB = self->getRandomStringRef();
 			if (!scope.contains(keyA) || !scope.contains(keyB)) {
 				continue;
-			} else if (keyA < keyB) {
-				return Standalone(KeyRangeRef(keyA, keyB));
-			} else if (keyA > keyB) {
-				return Standalone(KeyRangeRef(keyB, keyA));
-			} else {
+			}
+			KeyRange range = keyA < keyB ? KeyRangeRef(keyA, keyB) : KeyRangeRef(keyB, keyA);
+			if (range.empty() || range.singleKeyRange()) {
 				continue;
 			}
+			return range;
 		}
 	}
 


### PR DESCRIPTION
This PR introduces bulkLoad cancellation. By providing a jobId, the management API clears all metadata for the bulkload job and triggers DD restarts. When DD restarts, DD cancels all data moves for the bulkload. DD will not spawn new tasks and data moves for the bulkload job since the metadata has been cleared. At this point, the bulkload job is fully cancelled.

To test this, the bulkdump workload randomly injects the job cancellation after submitting a job. If the job is cancelled, the workload submit a new job and wait for the completion.

500K BulkDump tests:
  20250227-070228-zhewang-1ebfa498f23d96a7           compressed=True data_size=40881809 duration=10586190 ended=500000 fail_fast=10 max_runs=500000 pass=500000 priority=100 remaining=0 runtime=2:18:38 sanity=False started=500000 stopped=20250227-092106 submitted=20250227-070228 timeout=5400 username=zhewang

500K BulkLoad tests:
  20250227-172703-zhewang-03feb494d0a31fca           compressed=True data_size=40882141 fail_fast=10 max_runs=500000 priority=100 sanity=False submitted=20250227-172703 timeout=5400 username=zhewang        

FDBCLI command is tested by kube cluster.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
