### PR TITLE
Fix isOnMainThread in Simulation and Testing

### DIFF
--- a/fdbrpc/include/fdbrpc/simulator.h
+++ b/fdbrpc/include/fdbrpc/simulator.h
@@ -430,6 +430,7 @@ public:
 	WipedString makeToken(int64_t tenantId, uint64_t ttlSecondsFromNow);
 
 	static thread_local ProcessInfo* currentProcess;
+	static thread_local bool isMainThread;
 
 	bool checkInjectedCorruption();
 

--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -71,6 +71,7 @@
 
 ISimulator* g_simulator = nullptr;
 thread_local ISimulator::ProcessInfo* ISimulator::currentProcess = nullptr;
+thread_local bool ISimulator::isMainThread = false;
 
 ISimulator::ISimulator()
   : desiredCoordinators(1), physicalDatacenters(1), processesPerMachine(0), listenersPerProcess(1), usableRegions(1),
@@ -1401,6 +1402,7 @@ public:
 
 	static void runLoop(Sim2* self) {
 		ISimulator::ProcessInfo* callingMachine = self->currentProcess;
+		ISimulator::isMainThread = true;
 		int lastPrintTime = 0;
 		while (!self->isStopped) {
 			if (self->taskQueue.canSleep()) {
@@ -2666,7 +2668,7 @@ public:
 		PromiseTask* p = new PromiseTask(getCurrentProcess(), std::move(signal));
 		taskQueue.addReadyThreadSafe(isOnMainThread(), taskID, p);
 	}
-	bool isOnMainThread() const override { return net2->isOnMainThread(); }
+	bool isOnMainThread() const override { return ISimulator::isMainThread; }
 	Future<Void> onProcess(ISimulator::ProcessInfo* process, TaskPriority taskID) override {
 		return delay(0, taskID, process);
 	}

--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -2730,6 +2730,10 @@ ACTOR Future<Void> runTests(Reference<AsyncVar<Optional<struct ClusterController
 	state bool enableDD = false;
 	state TesterConsistencyScanState consistencyScanState;
 
+	// Gives change for g_network->run() to let this run inside event loop and hence let
+	// the tests see correct value for `isOnMainThread()`.
+	wait(yield());
+
 	if (tests.empty())
 		useDB = true;
 	for (auto iter = tests.begin(); iter != tests.end(); ++iter) {

--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -2730,7 +2730,7 @@ ACTOR Future<Void> runTests(Reference<AsyncVar<Optional<struct ClusterController
 	state bool enableDD = false;
 	state TesterConsistencyScanState consistencyScanState;
 
-	// Gives change for g_network->run() to let this run inside event loop and hence let
+	// Gives chance for g_network->run() to run inside event loop and hence let
 	// the tests see correct value for `isOnMainThread()`.
 	wait(yield());
 


### PR DESCRIPTION
isOnMainThread() is used to check if the currently running task is on the FDB's event loop. However, in simulation this behaviour is broken and always returns false.

In other modes such as UnitTest mode since `runTests()` is called before `g_network->run()`, but without a wait() statement the event loop never gets chance to set itself as main thread and the tests never sees current thread as main thread. Therefore we add a yield inside `runTests()` so yield control back to caller block and continue with g_network->run() which eventually schedule it back after initialization.

Correctness:

20250227-185124-vishesh-9307854450c9b575           compressed=True data_size=40831150 duration=4429189 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=
100 remaining=0 runtime=0:53:17 sanity=False started=100000 stopped=20250227-194441 submitted=20250227-185124 timeout=5400 username=vishesh

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
