### PR TITLE
rocksdb: fix crash due to uninitialized/stale ColumnFamilyHandle

### DIFF
--- a/fdbserver/KeyValueStoreRocksDB.actor.cpp
+++ b/fdbserver/KeyValueStoreRocksDB.actor.cpp
@@ -2579,6 +2579,7 @@ void RocksDBKeyValueStore::Writer::action(RestoreAction& a) {
 			ASSERT(db->DropColumnFamily(cf).ok());
 			db->DestroyColumnFamilyHandle(cf);
 			cfHandles.erase(cf);
+			cf = nullptr;
 		}
 
 		rocksdb::ExportImportFilesMetaData metaData = getMetaData(a.checkpoints[0]);

--- a/fdbserver/KeyValueStoreShardedRocksDB.actor.cpp
+++ b/fdbserver/KeyValueStoreShardedRocksDB.actor.cpp
@@ -993,6 +993,7 @@ struct PhysicalShard {
 		const CheckpointFormat format = checkpoint.getFormat();
 		rocksdb::Status status;
 		if (format == DataMoveRocksCF) {
+			ASSERT(cf == nullptr);
 			rocksdb::ExportImportFilesMetaData metaData = getMetaData(checkpoint);
 			if (metaData.files.empty()) {
 				TraceEvent(SevInfo, "RocksDBRestoreEmptyShard")
@@ -2737,7 +2738,7 @@ struct ShardedRocksDBKeyValueStore : IKeyValueStore {
 				if (!metadata.files.empty() && SERVER_KNOBS->ROCKSDB_ENABLE_CHECKPOINT_VALIDATION) {
 					rocksdb::ImportColumnFamilyOptions importOptions;
 					importOptions.move_files = false;
-					rocksdb::ColumnFamilyHandle* handle;
+					rocksdb::ColumnFamilyHandle* handle{ nullptr };
 					const std::string cfName = deterministicRandom()->randomAlphaNumeric(8);
 					s = a.shardManager->getDb()->CreateColumnFamilyWithImport(
 					    rocksdb::ColumnFamilyOptions(), cfName, importOptions, metadata, &handle);


### PR DESCRIPTION
`CreateColumnFamilyWithImport()` expects that the value inside handle is `nullptr`. This patch fixed a codepath where we pass a stale handle left by destroyed column family.

Correctness:

  20250228-050542-vishesh-092ebfeaa86e077c           compressed=True data_size=40840277 duration=5414232 ended=100000 fail=1 fail_fast=10 max_runs=100000 pass=99999 priority=100 remaining=0 runtime=0:52:30 sanity=False started=100000 stopped=20250228-0558
12 submitted=20250228-050542 timeout=5400 username=vishesh
# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
