### PR TITLE
grpc: AsyncTaskExecutor and basic server lifecycle

### DIFF
--- a/fdbrpc/FlowGrpc.cpp
+++ b/fdbrpc/FlowGrpc.cpp
@@ -18,44 +18,135 @@
  * limitations under the License.
  */
 
-#include <cstdio>
-#include <thread>
 #include "fdbrpc/FlowGrpc.h"
-
 #include "flow/actorcompiler.h" // This must be the last #include.
 
 #ifdef FLOW_GRPC_ENABLED
 
-GrpcServer::GrpcServer(const NetworkAddress& addr) : address_(addr) {}
+GrpcServer::GrpcServer(const NetworkAddress& addr) : pool_(1), address_(addr) {}
 
 GrpcServer::~GrpcServer() {
-	if (server_) {
-		shutdown();
-	}
+	if (!server_)
+		return;
 
-	if (server_thread_.joinable()) {
-		server_thread_.join();
-	}
+	stopServerSync();
+	run_actor_.cancel();
+	server_ = nullptr;
+	state_ = State::Shutdown;
 }
 
 Future<Void> GrpcServer::run() {
-	grpc::ServerBuilder builder_;
-	builder_.AddListeningPort(address_.toString(), grpc::InsecureServerCredentials());
-	for (auto& service : registered_services_) {
-		builder_.RegisterService(service.get());
+	try {
+		run_actor_ = run_internal();
+		co_await run_actor_;
+	} catch (Error& err) {
+		if (state_ == State::Shutdown) {
+			run_actor_.cancel();
+		} else {
+			throw err;
+		}
 	}
-	server_ = builder_.BuildAndStart();
-	return server_promise_.getFuture();
 }
 
-void GrpcServer::shutdown() {
-	server_->Shutdown(); // TODO (Vishesh): This needs to be Future.
-	server_promise_.send(Void());
+Future<Void> GrpcServer::run_internal() {
+	ASSERT(state_ == State::Stopped);
+	ASSERT(server_ == nullptr);
+	ASSERT(g_network->isOnMainThread());
+
+	Future<Void> next = Void();
+	loop {
+		ASSERT(state_ != State::Shutdown);
+
+		loop {
+			co_await next;
+			co_await delay(CONFIG_STARTUP_DELAY_BETWEEN_RESTART);
+
+			// gRPC can't run a server without registered service.
+			if (registered_services_.size() > 0) {
+				break;
+			} else {
+				next = on_services_changed_.onTrigger();
+			}
+		}
+
+		co_await stopServer();
+
+		// Even if service list is changed after stopServer(), we'll have those here.
+		grpc::ServerBuilder builder;
+		builder.AddListeningPort(address_.toString(), grpc::InsecureServerCredentials());
+		for (auto& [_, services] : registered_services_) {
+			for (auto& service : services) {
+				builder.RegisterService(service.get());
+			}
+		}
+
+		server_ = builder.BuildAndStart();
+		ASSERT(server_ != nullptr);
+		++num_starts_;
+		state_ = State::Running;
+		on_next_start_.trigger();
+		next = on_services_changed_.onTrigger();
+	}
+}
+
+Future<Void> GrpcServer::shutdown() {
+	co_await stopServer();
+	registered_services_.clear();
+	state_ = State::Shutdown;
+	run_actor_.cancel();
+	co_return;
+}
+
+Future<Void> GrpcServer::stopServer() {
+	ASSERT(g_network->isOnMainThread());
+
+	if (server_ == nullptr) {
+		ASSERT(state_ == State::Stopped || state_ == State::Shutdown);
+		co_return;
+	}
+
+	state_ = State::Stopping;
+	co_await pool_.post([&]() {
+		stopServerSync();
+		return Void();
+	});
+
+	if (state_ == State::Shutdown) {
+		co_return;
+	}
+
 	server_ = nullptr;
+	state_ = State::Stopped;
+}
+
+void GrpcServer::stopServerSync() {
+	if (server_ != nullptr) {
+		return;
+	}
+
+	server_->Shutdown();
+	server_->Wait();
 }
 
 void GrpcServer::registerService(std::shared_ptr<grpc::Service> service) {
-	registered_services_.push_back(service);
+	ASSERT(g_network->isOnMainThread());
+	registered_services_[UID()].push_back(service);
+	on_services_changed_.trigger();
+}
+
+void GrpcServer::registerRoleServices(const UID& owner_id, const ServiceList& services) {
+	ASSERT(g_network->isOnMainThread());
+	for (const auto& svc : services) {
+		registered_services_[owner_id].push_back(svc);
+	}
+	on_services_changed_.trigger();
+}
+
+Future<Void> GrpcServer::deregisterRoleServices(const UID& owner_id) {
+	ASSERT(g_network->isOnMainThread());
+	co_await stopServer();
+	registered_services_.erase(owner_id);
+	on_services_changed_.trigger();
 }
 
 #endif

--- a/fdbrpc/include/fdbrpc/FlowGrpc.h
+++ b/fdbrpc/include/fdbrpc/FlowGrpc.h
@@ -17,177 +17,146 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #ifdef FLOW_GRPC_ENABLED
 #ifndef FDBRPC_FLOW_GRPC_H
 #define FDBRPC_FLOW_GRPC_H
 
-#include <memory>
-#include <thread>
-#include <boost/asio.hpp>
-
-#undef loop
-#include <grpcpp/grpcpp.h>
-
-#include "flow/IThreadPool.h"
 #include "flow/flow.h"
+#include "flow/NetworkAddress.h"
 
+#include "fdbrpc/grpc/AsyncGrpcClient.h"
+#include "fdbrpc/grpc/AsyncTaskExecutor.h"
+
+// GrpcServer class is responsible for configuring, starting, and shutting down a gRPC server.
+// It also manages `grpc::Service` instances associated with the server.
+//
+// Methods in this class should always be called from main thread.
+//
+// ## Service Lifecycle:
+// - Each FDB worker is assigned a unique UID, which may change across different runs.
+// - Workers can register services by calling `registerRoleServices`, providing their UID and references
+//   to `grpc::Service` objects. If a UID is already registered, new services are appended to the existing list.
+// - Services can be removed using the `deregisterRoleService()` method. Currently, this method only supports
+//   removing all services associated with a given worker.
+// - When a worker restarts or terminates, its associated services are automatically removed. The worker is
+//   responsible for performing a clean shutdown and destruction.
+// - Any modification to the service list triggers a restart of the gRPC server. To minimize disruptions,
+//   it is recommended to keep these operations minimal.
+// - Destruction of GrpcServer will block the thread. This isn't a problem as we use a global singleton.
+//
+// ## Usage:
+//   - Get the singleton instance:
+//     auto gs = GrpcServer::instance()
+//
+//   - Register services:
+//     // Usually in the worker actors of each individual roles so that each component
+//     // can manage their services.
+//     gs->registerRoleServices(my_id, {
+//         make_shared<FileTransferService>(),
+//         make_shared<FileTransferService>()
+//     });
+//
+//   - Remove services:
+//     // Automatically called when worker reboots or dies, but can also be managed by
+//     // directly if they need more control for their use-case.
+//     gs->deregisterServices()
+//
 class GrpcServer {
 public:
+	using ServiceList = std::vector<std::shared_ptr<grpc::Service>>;
+
 	GrpcServer(const NetworkAddress& addr);
 	~GrpcServer();
 
-	Future<Void> run();
-	void shutdown();
-	void registerService(std::shared_ptr<grpc::Service> service);
-
+	// Initializes the singleton.
 	static GrpcServer* initInstance(const NetworkAddress& addr) {
 		GrpcServer* server = new GrpcServer(addr);
 		g_network->setGlobal(INetwork::enGrpcServer, (flowGlobalType)server);
 		return server;
 	}
 
+	// Returns the singleton instance.
 	static GrpcServer* instance() { return static_cast<GrpcServer*>((void*)g_network->global(INetwork::enGrpcServer)); }
+
+	// Returns the gRPC server address. Currently, we only listen on single port globally.
+	NetworkAddress getAddress() const { return address_; }
+
+	// Starts the server and returns a future which is only fulfilled after shutdown(). However, the gRPC server itself
+	// can stop and start internally multiple times within. This is expected when regsitered services are changed.
+	Future<Void> run();
+
+	// Stops the server and returns future that is fulfilled when stop is successfully finished. Unlike shutdown()
+	// server can be resumed later.
+	Future<Void> stopServer();
+
+	// Shutdowns the server and returns future that is fulfilled when stop is successfully finished. Once shutdown,
+	// server can't be restarted.
+	Future<Void> shutdown();
+
+	// Returns future object which is set when server is running.
+	Future<Void> onRunning() const { return state_ == State::Running ? Void() : onNextStart(); }
+
+	// Returns a future object which is set when the server is started. If the server is already
+	// running, it is set by next start.
+	Future<Void> onNextStart() const { return on_next_start_.onTrigger(); }
+
+	// Returns future object which is set when the server is stopped.
+	Future<Void> onStop() const;
+
+	// Registers given services with the gRPC server. Return doesn't necessarily means the service has started.
+	// TODO: should we add notification when service is alive?
+	void registerService(std::shared_ptr<grpc::Service> service);
+	void registerRoleServices(const UID& owner_id, const ServiceList& services);
+
+	// Removes services associated with given `owner_id` from the server. Returns future that is fulfilled onced the
+	// services are no longer alive (however, server may not have restarted yet).
+	Future<Void> deregisterRoleServices(const UID& owner_id);
+
+	// Returns `true` if the server has running and there is no shutdown in progress.
+	bool hasStarted() const { return state_ == State::Running && server_ != nullptr; }
+
+	// Returns number of times gRPC server has started. For testing.
+	int numStarts() const { return num_starts_; }
+
+	// How long to wait before restarting the server after change to registered services.
+	// It is to give some buffer time to workers from different roles register services
+	// indepdendently and avoid multiple restarts.
+	//
+	// TODO: Make it configurable.
+	static const int CONFIG_STARTUP_DELAY_BETWEEN_RESTART = 2; /* seconds */
+private:
+	Future<Void> run_internal();
+	void stopServerSync();
 
 private:
 	NetworkAddress address_;
+
+	// Pool is mostly needed for converting the synchronous gRPC server operations into asynchronous.
+	AsyncTaskExecutor pool_;
+
+	Future<Void> run_actor_;
+	AsyncTrigger on_next_start_;
+	AsyncTrigger on_services_changed_;
+	std::unordered_map<UID, ServiceList> registered_services_;
+
+	// Underlying gRPC server. `nullptr` when there server is not running/stopped.
 	std::unique_ptr<grpc::Server> server_;
-	ThreadReturnPromise<Void> server_promise_;
-	std::thread server_thread_;
-	std::vector<std::shared_ptr<grpc::Service>> registered_services_;
-};
 
-template <class ServiceType>
-class AsyncGrpcClient {
-	template <class Request, class Response>
-	using UnaryRpcFn = grpc::Status (ServiceType::Stub::*)(grpc::ClientContext*, const Request&, Response*);
+	// Represents different states that the server can be in.
+	enum class State {
+		Running, // Server is actively running and serving requests.
+		Stopping, // Server is currently in processs of shutting down.
+		Stopped, // Server is stopped, but can be resumed later.
+		Shutdown, // End-of-life. Can't be resumed if true.
+	};
+	State state_ = State::Stopped;
 
-	template <class Request, class Response>
-	using ServerStreamingRpcFn =
-	    std::unique_ptr<grpc::ClientReader<Response>> (ServiceType::Stub::*)(grpc::ClientContext*, const Request&);
+	// Returns true if the server is currently in processs of shutting down.
+	// bool is_shutting_down_ = false;
 
-	template <class Request, class Response>
-	using ClientStreamingRpcFn =
-	    std::unique_ptr<grpc::ClientWriter<Request>> (ServiceType::Stub::*)(grpc::ClientContext*, Response*);
-
-public:
-	using Rpc = typename ServiceType::Stub;
-
-	AsyncGrpcClient() {}
-	AsyncGrpcClient(const std::string& endpoint, std::shared_ptr<boost::asio::thread_pool> pool)
-	  : pool_(pool), channel_(grpc::CreateChannel(endpoint, grpc::InsecureChannelCredentials())),
-	    stub_(ServiceType::NewStub(channel_)) {}
-
-	// NOTE: Must be called from network thread. This is because the underlying primitive used
-	//   is ThreadReturnPromise.
-	template <class RequestType, class ResponseType>
-	Future<grpc::Status> call(UnaryRpcFn<RequestType, ResponseType> rpc,
-	                          const RequestType& request,
-	                          ResponseType* response) {
-		ASSERT_WE_THINK(g_network->isOnMainThread());
-		auto promise = std::make_shared<ThreadReturnPromise<grpc::Status>>();
-
-		boost::asio::post(*pool_, [this, promise, rpc, request, response]() {
-			grpc::ClientContext context;
-			auto status = (stub_.get()->*rpc)(&context, request, response);
-			if (promise->getFutureReferenceCount() == 0) {
-				return;
-			}
-			promise->send(status);
-		});
-
-		return promise->getFuture();
-	}
-
-	// NOTE: Must be called from network thread. This is because the underlying primitive used
-	//   is ThreadReturnPromise.
-	template <class RequestType, class ResponseType>
-	Future<ResponseType> call(UnaryRpcFn<RequestType, ResponseType> rpc, const RequestType& request) {
-		ASSERT_WE_THINK(g_network->isOnMainThread());
-		auto promise = std::make_shared<ThreadReturnPromise<ResponseType>>();
-
-		boost::asio::post(*pool_, [this, promise, rpc, request]() {
-			if (promise->getFutureReferenceCount() == 0) {
-				return;
-			}
-
-			grpc::ClientContext context;
-			ResponseType response;
-			auto status = (stub_.get()->*rpc)(&context, request, &response);
-
-			if (promise->getFutureReferenceCount() == 0) {
-				return;
-			}
-
-			if (status.ok()) {
-				promise->send(response);
-			} else {
-				// std::cout << "Error: " << status.error_message() << std::endl;
-				promise->sendError(grpc_error()); // TODO (Vishesh): Propogate the gRPC error codes.
-			}
-		});
-
-		return promise->getFuture();
-	}
-	// NOTE: Must be called from network thread. This is because the underlying primitive used
-	//   is ThreadReturnPromise.
-	template <class RequestType, class ResponseType>
-	FutureStream<ResponseType> call(ServerStreamingRpcFn<RequestType, ResponseType> rpc, const RequestType& request) {
-		ASSERT_WE_THINK(g_network->isOnMainThread());
-		auto promise = std::make_shared<ThreadReturnPromiseStream<ResponseType>>();
-
-		boost::asio::post(*pool_, [this, promise, rpc, request]() {
-			grpc::ClientContext context;
-			ResponseType response;
-			auto reader = (stub_.get()->*rpc)(&context, request);
-			while (reader->Read(&response)) {
-				if (promise->getFutureReferenceCount() == 0) {
-					// std::cout << "Stream cancelled.\n";
-					context.TryCancel();
-					return;
-				}
-
-				promise->send(response);
-			}
-
-			auto status = reader->Finish();
-			if (status.ok()) {
-				promise->sendError(end_of_stream());
-			} else {
-				// std::cout << "Error: " << status.error_message() << std::endl;
-				promise->sendError(grpc_error()); // TODO (Vishesh): Propogate the gRPC error codes.
-			}
-		});
-
-		return promise->getFuture();
-	}
-
-	// template <class RequestType, class ResponseType>
-	// void call(ClientStreamingRpcFn<RequestType, ResponseType> rpc, const RequestType& request) {
-	// 	auto promise = std::make_shared<ThreadReturnPromiseStream<ResponseType>>();
-
-	// 	boost::asio::post(*pool_, [this, promise, rpc, request]() {
-	// 		grpc::ClientContext context;
-	// 		ResponseType response;
-	// 		auto reader = (stub_.get()->*rpc)(&context, request);
-	// 		while (reader->Read(&response)) {
-	// 			promise->send(response);
-	// 		}
-
-	// 		auto status = reader->Finish();
-	// 		if (status.ok()) {
-	// 			promise->sendError(end_of_stream());
-	// 		} else {
-	// 			promise->sendError(grpc_error()); // TODO (Vishesh): Propogate the gRPC error codes.
-	// 		}
-	// 	});
-
-	// 	return promise->getFuture();
-	// }
-
-private:
-	std::shared_ptr<boost::asio::thread_pool> pool_;
-	std::shared_ptr<grpc::Channel> channel_;
-	std::unique_ptr<typename ServiceType::Stub> stub_;
+	// Number of server starts. For testing.
+	int num_starts_ = 0;
 };
 
 #endif // FDBRPC_FLOW_GRPC_H

--- a/fdbrpc/include/fdbrpc/grpc/AsyncGrpcClient.h
+++ b/fdbrpc/include/fdbrpc/grpc/AsyncGrpcClient.h
@@ -1,0 +1,168 @@
+/**
+ * AsyncGrpcClient.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2024 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef FLOW_GRPC_ENABLED
+#ifndef FDBRPC_FLOW_ASYNC_GRPC_CLIENT_H
+#define FDBRPC_FLOW_ASYNC_GRPC_CLIENT_H
+
+#include <memory>
+#undef loop
+#include <grpcpp/grpcpp.h>
+
+#include "flow/flow.h"
+#include "flow/IThreadPool.h"
+#include "fdbrpc/grpc/AsyncTaskExecutor.h"
+
+template <class ServiceType>
+class AsyncGrpcClient {
+	template <class Request, class Response>
+	using UnaryRpcFn = grpc::Status (ServiceType::Stub::*)(grpc::ClientContext*, const Request&, Response*);
+
+	template <class Request, class Response>
+	using ServerStreamingRpcFn =
+	    std::unique_ptr<grpc::ClientReader<Response>> (ServiceType::Stub::*)(grpc::ClientContext*, const Request&);
+
+	template <class Request, class Response>
+	using ClientStreamingRpcFn =
+	    std::unique_ptr<grpc::ClientWriter<Request>> (ServiceType::Stub::*)(grpc::ClientContext*, Response*);
+
+public:
+	using Rpc = typename ServiceType::Stub;
+
+	AsyncGrpcClient() {}
+	AsyncGrpcClient(const std::string& endpoint, std::shared_ptr<AsyncTaskExecutor> pool)
+	  : pool_(pool), channel_(grpc::CreateChannel(endpoint, grpc::InsecureChannelCredentials())),
+	    stub_(ServiceType::NewStub(channel_)) {}
+
+	// NOTE: Must be called from network thread. This is because the underlying primitive used
+	//   is ThreadReturnPromise.
+	template <class RequestType, class ResponseType>
+	Future<grpc::Status> call(UnaryRpcFn<RequestType, ResponseType> rpc,
+	                          const RequestType& request,
+	                          ResponseType* response) {
+		ASSERT_WE_THINK(g_network->isOnMainThread());
+		auto promise = std::make_shared<ThreadReturnPromise<grpc::Status>>();
+
+		pool_->post([this, promise, rpc, request, response]() {
+			grpc::ClientContext context;
+			auto status = (stub_.get()->*rpc)(&context, request, response);
+			if (promise->getFutureReferenceCount() == 0) {
+				return;
+			}
+			promise->send(status);
+		});
+
+		return promise->getFuture();
+	}
+
+	// NOTE: Must be called from network thread. This is because the underlying primitive used
+	//   is ThreadReturnPromise.
+	template <class RequestType, class ResponseType>
+	Future<ResponseType> call(UnaryRpcFn<RequestType, ResponseType> rpc, const RequestType& request) {
+		ASSERT_WE_THINK(g_network->isOnMainThread());
+		auto promise = std::make_shared<ThreadReturnPromise<ResponseType>>();
+
+		pool_->post([this, promise, rpc, request]() {
+			if (promise->getFutureReferenceCount() == 0) {
+				return;
+			}
+
+			grpc::ClientContext context;
+			ResponseType response;
+			auto status = (stub_.get()->*rpc)(&context, request, &response);
+
+			if (promise->getFutureReferenceCount() == 0) {
+				return;
+			}
+
+			if (status.ok()) {
+				promise->send(response);
+			} else {
+				// std::cout << "Error: " << status.error_message() << std::endl;
+				promise->sendError(grpc_error()); // TODO (Vishesh): Propogate the gRPC error codes.
+			}
+		});
+
+		return promise->getFuture();
+	}
+	// NOTE: Must be called from network thread. This is because the underlying primitive used
+	//   is ThreadReturnPromise.
+	template <class RequestType, class ResponseType>
+	FutureStream<ResponseType> call(ServerStreamingRpcFn<RequestType, ResponseType> rpc, const RequestType& request) {
+		ASSERT_WE_THINK(g_network->isOnMainThread());
+		auto promise = std::make_shared<ThreadReturnPromiseStream<ResponseType>>();
+
+		pool_->post([this, promise, rpc, request]() {
+			grpc::ClientContext context;
+			ResponseType response;
+			auto reader = (stub_.get()->*rpc)(&context, request);
+			while (reader->Read(&response)) {
+				if (promise->getFutureReferenceCount() == 0) {
+					// std::cout << "Stream cancelled.\n";
+					context.TryCancel();
+					return;
+				}
+
+				promise->send(response);
+			}
+
+			auto status = reader->Finish();
+			if (status.ok()) {
+				promise->sendError(end_of_stream());
+			} else {
+				// std::cout << "Error: " << status.error_message() << std::endl;
+				promise->sendError(grpc_error()); // TODO (Vishesh): Propogate the gRPC error codes.
+			}
+		});
+
+		return promise->getFuture();
+	}
+
+	// template <class RequestType, class ResponseType>
+	// void call(ClientStreamingRpcFn<RequestType, ResponseType> rpc, const RequestType& request) {
+	// 	auto promise = std::make_shared<ThreadReturnPromiseStream<ResponseType>>();
+
+	// 	boost::asio::post(*pool_, [this, promise, rpc, request]() {
+	// 		grpc::ClientContext context;
+	// 		ResponseType response;
+	// 		auto reader = (stub_.get()->*rpc)(&context, request);
+	// 		while (reader->Read(&response)) {
+	// 			promise->send(response);
+	// 		}
+
+	// 		auto status = reader->Finish();
+	// 		if (status.ok()) {
+	// 			promise->sendError(end_of_stream());
+	// 		} else {
+	// 			promise->sendError(grpc_error()); // TODO (Vishesh): Propogate the gRPC error codes.
+	// 		}
+	// 	});
+
+	// 	return promise->getFuture();
+	// }
+
+private:
+	std::shared_ptr<AsyncTaskExecutor> pool_;
+	std::shared_ptr<grpc::Channel> channel_;
+	std::unique_ptr<typename ServiceType::Stub> stub_;
+};
+
+#endif // FDBRPC_FLOW_ASYNC_GRPC_CLIENT_H
+#endif // FLOW_GRPC_ENABLED

--- a/fdbrpc/include/fdbrpc/grpc/AsyncTaskExecutor.h
+++ b/fdbrpc/include/fdbrpc/grpc/AsyncTaskExecutor.h
@@ -1,0 +1,168 @@
+/**
+ * AsyncTaskExecutor.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2024 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef FLOW_GRPC_ENABLED
+#ifndef FDBRPC_FLOW_GRPC_THREAD_POOL_H
+#define FDBRPC_FLOW_GRPC_THREAD_POOL_H
+
+#include "flow/flow.h"
+#include "flow/IThreadPool.h"
+
+// Checks whether `Func` return type is `void`. FDB's `Void` will not return true.
+template <typename Func>
+concept IsVoidReturn = std::is_void_v<std::invoke_result_t<Func>>;
+
+// `AsyncTaskExecutor` is a lightweight wrapper around `IThreadPool`, designed to provide
+// functionality similar to `std::async` or `asio::post`. It allows asynchronous task execution
+// without directly managing threads, making it easier to offload work to a thread pool. . The API
+// is designed to be easy-to-use and integrates well with FDB's Flow primitives.
+//
+// - All tasks must be posted from FDB's main thread.
+// - Using this can potentially break simulation. Setting `num_threads=` to 1 in simulation should
+//   serialize all the tasks and will keep the execution deterministic.
+//
+// Usage:
+//
+//     // Create an instance.
+//     AsyncTaskExecutor exc(4 /* num_threads */);
+//
+//     // Schedule a task using `post`. This task doesn't return a value, neither we
+//     // need to wait for completion.
+//     exc->post([]() {
+//        // Do some expensive operations.
+//     });
+//
+//     // For waiting for task to finish just return Void.
+//     Future<Void> f = exc->post([]() -> Void { ... do stuff .. });
+//     wait(f);  --  or --  co_await f;
+
+//     // Schedule a task that returns a value using `post`.
+//     Object res = co_await exc->post([]() -> Object {
+//       // Do some expensive operations.
+//       return res_obj;
+//     });
+//
+// - TODO: Move this to more standard location inside codebase.
+// - TODO: Remove AsyncTaskThread which has similar purpose however implemented differently?
+class AsyncTaskExecutor {
+public:
+	explicit AsyncTaskExecutor(int num_threads) {
+		for (int ii = 0; ii < num_threads; ++ii) {
+			pool_->addThread(new Receiver());
+		}
+	}
+	~AsyncTaskExecutor() { pool_->stop(success()); }
+
+	// Schedules a non-void function for asynchronous execution in a thread pool.
+	//
+	// This function posts a callable task (function, lambda, function) to a thread pool for
+	// execution. The task must return a non-void type. This function must be called from
+	// main thread.
+	//
+	// Returns a `Future<R>` object representing the return value of task.
+	template <typename Func>
+	    requires(!IsVoidReturn<Func>)
+	[[nodiscard]] auto post(Func&& task) -> Future<typename std::invoke_result<Func>::type> {
+		ASSERT_WE_THINK(g_network->isOnMainThread());
+		auto action = new Action<Func>(std::forward<Func>(task));
+		pool_->post(action);
+		return action->getFuture();
+	}
+
+	// Schedules a function that returns void for asynchronous execution in a thread pool.
+	//
+	// This function posts a callable task (function, lambda, function) to a thread pool for
+	// execution. Unlike the other overload, this version is intended for tasks that do not return a
+	// result, when the caller does not need the result, or when the caller prefers to use custom
+	// primitives to interact with the underlying task (e.g., streaming).
+	//
+	// Returns a `Future<R>` object representing the return value of task.
+	template <typename Func>
+	    requires(IsVoidReturn<Func>)
+	void post(Func&& task) {
+		ASSERT_WE_THINK(g_network->isOnMainThread());
+		auto action = new Action<Func>(std::forward<Func>(task));
+		pool_->post(action);
+	}
+
+private:
+	// Serves no purpose for us, but needed for `IThreadPool`.
+	struct Receiver : IThreadPoolReceiver {
+		void init() {}
+	};
+
+	template <typename Func, class __Enable = void>
+	struct Action;
+
+	Reference<IThreadPool> pool_ = createGenericThreadPool();
+};
+
+//-- Internal types.
+
+// `ThreadAction` implementation for tasks that return non-void values.
+template <typename Func>
+struct AsyncTaskExecutor::Action<Func, typename std::enable_if_t<!IsVoidReturn<Func>>> : ThreadAction {
+	using Ret = std::invoke_result<Func>::type;
+
+	Action(Func&& fn) : fn_(std::forward<Func>(fn)) {}
+
+	void operator()(IThreadPoolReceiver* action) override {
+		promise_.send(fn_());
+		delete this;
+	}
+
+	// Returns `Future` representing the value returned by `fn_`.
+	Future<Ret> getFuture() { return promise_.getFuture(); }
+
+	// `promise_` will automatically send `broken_promise` to its futures.
+	void cancel() override {}
+
+	// TODO:
+	double getTimeEstimate() const override { return 0.1; }
+
+private:
+	Func fn_;
+	ThreadReturnPromise<Ret> promise_;
+};
+
+// `ThreadAction` implementation for tasks that return void.
+template <typename Func>
+struct AsyncTaskExecutor::Action<Func, typename std::enable_if_t<IsVoidReturn<Func>>> : ThreadAction {
+	using Ret = std::invoke_result<Func>::type;
+
+	Action(Func&& fn) : fn_(std::forward<Func>(fn)) {}
+
+	void operator()(IThreadPoolReceiver* action) override {
+		fn_();
+		delete this;
+	}
+
+	// `promise_` will automatically send `broken_promise` to its futures.
+	void cancel() override {}
+
+	// TODO:
+	double getTimeEstimate() const override { return 0.1; }
+
+private:
+	Func fn_;
+};
+
+#endif // FDBRPC_FLOW_GRPC_THREAD_POOL_H
+#endif // FLOW_GRPC_ENABLED


### PR DESCRIPTION
This PR has three changes:

- gRPC Lifecycle: Adds methods that can be used by worker to register/unregister services. The gRPC wrapper will automatically shutdown/restart services accordingly. Later PR will use these methods to tie life of gRPC service to the life of the worker role.
- AsyncTaskExeuctor: Just a wrapper around IThreadPool that is easier to use, somewhat like `asio::post` or `std::async`. There is `AsyncTaskThread` in fdbclient which serves similar purpose, however it doesn't use `IThreadPool` hence doesn't set the simulation thread_locals correcly, and also just uses one thread. That should be equivalent of setting num_thread = 1 in this class.
- Update existing GrpcServer and  AsyncGrpcClient to use the AsyncTaskExeuctor instead of `asio::thread_pool`.

**Testing:**

Some correctness issues around RockDB. Debugging, but some were unrelated to this. e.g. https://github.com/apple/foundationdb/pull/11981

Has some basic unit-tests and will keep adding more in subsequent PRs where I'm actually making use of these.

Update: 

  20250306-003951-vishesh-7d25265389131d54           compressed=True data_size=40885293 duration=5971889 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:48:08 sanity=False started=100000 stopped=20250306-012759 submitted=20250306-003951 timeout=5400 username=vishesh

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
