### PR TITLE
Add an option to Cycle workload to skip setup phase

### DIFF
--- a/fdbserver/workloads/Cycle.actor.cpp
+++ b/fdbserver/workloads/Cycle.actor.cpp
@@ -59,6 +59,7 @@ struct CycleWorkload : TestWorkload, CycleMembers<MultiTenancy> {
 	int actorCount, nodeCount;
 	double testDuration, transactionsPerSecond, minExpectedTransactionsPerSecond, traceParentProbability;
 	bool unseedCheck{ true };
+	bool skipSetup{ false }; // Useful for restarting tests
 	Key keyPrefix;
 
 	std::vector<Future<Void>> clients;
@@ -76,6 +77,7 @@ struct CycleWorkload : TestWorkload, CycleMembers<MultiTenancy> {
 		traceParentProbability = getOption(options, "traceParentProbability"_sr, 0.01);
 		minExpectedTransactionsPerSecond = transactionsPerSecond * getOption(options, "expectedRate"_sr, 0.7);
 		unseedCheck = getOption(options, "unseedCheck"_sr, true);
+		skipSetup = getOption(options, "skipSetup"_sr, false);
 		if constexpr (MultiTenancy) {
 			ASSERT(g_network->isSimulated());
 			this->useToken = getOption(options, "useToken"_sr, true);
@@ -87,6 +89,9 @@ struct CycleWorkload : TestWorkload, CycleMembers<MultiTenancy> {
 	Future<Void> setup(Database const& cx) override {
 		if (!unseedCheck) {
 			noUnseed = true;
+		}
+		if (skipSetup) {
+			return Void();
 		}
 		Future<Void> prepare;
 		if constexpr (MultiTenancy) {

--- a/tests/restarting/from_7.3.29/CycleTestRestart-2.toml
+++ b/tests/restarting/from_7.3.29/CycleTestRestart-2.toml
@@ -7,6 +7,7 @@ runSetup=false
     transactionsPerSecond=2500.0
     nodeCount=2500
     testDuration=10.0
+    skipSetup=true
     expectedRate=0
 
     [[test.workload]]

--- a/tests/restarting/to_7.4.0/CycleTestRestart-2.toml
+++ b/tests/restarting/to_7.4.0/CycleTestRestart-2.toml
@@ -14,6 +14,7 @@ runSetup = false
     [[test.workload]]
     testName = 'Cycle'
     transactionsPerSecond = 2500.0
+    skipSetup = true
     nodeCount = 2500
     testDuration = 10.0
     expectedRate = 0


### PR DESCRIPTION
Useful for testing upgrade/downgrade tests. Otherwise, the second phase's setup re-initialize the cycle data, thus not actually testing the consistency after the upgrade.

100k correctness of two restarting tests:

20250301-061614-jzhou-fdbafbf4175a72ed             compressed=True data_size=35835172 duration=2806102 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:36:48 sanity=False started=100000 stopped=20250301-065302 submitted=20250301-061614 timeout=5400 username=jzhou

100k regular correctness has a RocksDB DR ExternalTimeout error (`-f ./tests/fast/AtomicBackupToDBCorrectness.toml -s 3645469319 -b on`, which can't be reproduced): 
20250301-194836-jzhou-ba1a8e1268a38bca             compressed=True data_size=35792829 duration=5645259 ended=100000 fail=1 fail_fast=10 max_runs=100000 pass=99999 priority=100 remaining=0 runtime=1:03:02 sanity=False started=100000 stopped=20250301-205138 submitted=20250301-194836 timeout=5400 username=jzhou



# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
