### PR TITLE
Add BulkLoad History

### DIFF
--- a/fdbcli/BulkLoadCommand.actor.cpp
+++ b/fdbcli/BulkLoadCommand.actor.cpp
@@ -230,7 +230,7 @@ ACTOR Future<UID> bulkLoadCommandActor(Database cx, std::vector<StringRef> token
 
 CommandFactory bulkLoadFactory(
     "bulkload",
-    CommandHelp("bulkload [mode|local|blobstore|status|cancel|history|historyclear] [ARGs]",
+    CommandHelp("bulkload [mode|local|blobstore|status|cancel|history|clearhistory] [ARGs]",
                 "bulkload commands",
                 "To set bulkload mode: `bulkload mode [on|off]'\n"
                 "To load a range from SST files: `bulkload [local|blobstore] <BeginKey> <EndKey> dumpFolder`\n"

--- a/fdbcli/BulkLoadCommand.actor.cpp
+++ b/fdbcli/BulkLoadCommand.actor.cpp
@@ -37,7 +37,7 @@ ACTOR Future<Void> printPastBulkLoadJob(Database cx) {
 	for (const auto& job : jobs) {
 		ASSERT(job.getPhase() == BulkLoadJobPhase::Complete || job.getPhase() == BulkLoadJobPhase::Error ||
 		       job.getPhase() == BulkLoadJobPhase::Cancelled);
-		fmt::println("Job {} submitted at {} for range {}. The job ends by {} mins for {} status",
+		fmt::println("Job {} submitted at {} for range {}. The job ran for {} mins and exited with status {}.",
 		             job.getJobId().toString(),
 		             std::to_string(job.getSubmitTime()),
 		             job.getJobRange().toString(),

--- a/fdbclient/BulkLoading.cpp
+++ b/fdbclient/BulkLoading.cpp
@@ -89,6 +89,22 @@ std::string generateEmptyManifestFileName() {
 	return "manifest-empty.sst";
 }
 
+std::string convertBulkLoadJobPhaseToString(const BulkLoadJobPhase& phase) {
+	if (phase == BulkLoadJobPhase::Invalid) {
+		return "Invalid";
+	} else if (phase == BulkLoadJobPhase::Submitted) {
+		return "Submitted";
+	} else if (phase == BulkLoadJobPhase::Complete) {
+		return "Complete";
+	} else if (phase == BulkLoadJobPhase::Error) {
+		return "Error";
+	} else if (phase == BulkLoadJobPhase::Cancelled) {
+		return "Cancelled";
+	} else {
+		UNREACHABLE();
+	}
+}
+
 // Generate the bulkload job manifest file. Here is an example.
 // Assuming the job manifest file is in the folder: "/tmp".
 // Row 0: [FormatVersion]: 1, [ManifestCount]: 3;

--- a/fdbclient/ClientKnobs.cpp
+++ b/fdbclient/ClientKnobs.cpp
@@ -201,6 +201,7 @@ void ClientKnobs::initialize(Randomize randomize) {
 	init( BACKUP_CONTAINER_LOCAL_ALLOW_RELATIVE_PATH, false );
 	init( ENABLE_REPLICA_CONSISTENCY_CHECK_ON_BACKUP_READS, true );
 	init( CONSISTENCY_CHECK_REQUIRED_REPLICAS,      -2 ); // Do consistency check based on all available storage replicas
+	init( BULKLOAD_JOB_HISTORY_COUNT_MAX,           10 ); if (randomize && BUGGIFY) BULKLOAD_JOB_HISTORY_COUNT_MAX = deterministicRandom()->randomInt(1, 10);
 
 	// Configuration
 	init( DEFAULT_AUTO_COMMIT_PROXIES,               3 );

--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -3021,8 +3021,8 @@ ACTOR Future<Void> finalizeBulkLoadTask(Database cx, KeyRange range, UID taskId)
 	return Void();
 }
 
-// This is the only place to update job history map. So, we check the number of job history entries here is suffient
-// to maintain the number of job in the history is no more than BULKLOAD_JOB_HISTORY_COUNT_MAX.
+// This is the only place to update job history map. So, we check the number of job history entries here is sufficient
+// to maintain that the number of jobs in the history is no more than BULKLOAD_JOB_HISTORY_COUNT_MAX.
 ACTOR Future<Void> addBulkLoadJobToHistory(Transaction* tr, BulkLoadJobState jobState) {
 	state Key newJobKey = bulkLoadJobHistoryKeyFor(jobState.getJobId());
 	state RangeResult jobHistoryResult;
@@ -3050,7 +3050,7 @@ ACTOR Future<Void> addBulkLoadJobToHistory(Transaction* tr, BulkLoadJobState job
 			}
 			if (jobStateInHistory.getJobId() == jobState.getJobId()) {
 				tr->set(newJobKey, bulkLoadJobValue(jobState));
-				// BulkLoad job with the same jobId can run for multiple times, we only kept the latest one
+				// BulkLoad job with the same jobId can run for multiple times, we only keep the latest one
 				// in the history.
 				return Void();
 			}

--- a/fdbclient/SystemData.cpp
+++ b/fdbclient/SystemData.cpp
@@ -1236,6 +1236,18 @@ BulkLoadJobState decodeBulkLoadJobState(const ValueRef& value) {
 	return bulkLoadJobState;
 }
 
+const KeyRangeRef bulkLoadJobHistoryKeys = KeyRangeRef("\xff/bulkLoadJobHistory/"_sr, "\xff/bulkLoadJobHistory0"_sr);
+const KeyRef bulkLoadJobHistoryPrefix = bulkLoadJobHistoryKeys.begin;
+
+// BulkLoad job with the same jobId can run for multiple times, we only kept the latest one
+// in the history.
+const Key bulkLoadJobHistoryKeyFor(const UID& jobId) {
+	BinaryWriter wr(Unversioned());
+	wr.serializeBytes(bulkLoadJobHistoryPrefix);
+	wr.serializeBytes(StringRef(jobId.toString()));
+	return wr.toValue();
+}
+
 // Bulk dumping keys
 const KeyRef bulkDumpModeKey = "\xff/bulkDumpMode"_sr;
 const KeyRangeRef bulkDumpKeys = KeyRangeRef("\xff/bulkDump/"_sr, "\xff/bulkDump0"_sr);

--- a/fdbclient/SystemData.cpp
+++ b/fdbclient/SystemData.cpp
@@ -1239,7 +1239,7 @@ BulkLoadJobState decodeBulkLoadJobState(const ValueRef& value) {
 const KeyRangeRef bulkLoadJobHistoryKeys = KeyRangeRef("\xff/bulkLoadJobHistory/"_sr, "\xff/bulkLoadJobHistory0"_sr);
 const KeyRef bulkLoadJobHistoryPrefix = bulkLoadJobHistoryKeys.begin;
 
-// BulkLoad job with the same jobId can run for multiple times, we only kept the latest one
+// BulkLoad job with the same jobId can run for multiple times, we only keep the latest one
 // in the history.
 const Key bulkLoadJobHistoryKeyFor(const UID& jobId) {
 	BinaryWriter wr(Unversioned());

--- a/fdbclient/include/fdbclient/ClientKnobs.h
+++ b/fdbclient/include/fdbclient/ClientKnobs.h
@@ -201,6 +201,9 @@ public:
 	bool BACKUP_CONTAINER_LOCAL_ALLOW_RELATIVE_PATH;
 	bool ENABLE_REPLICA_CONSISTENCY_CHECK_ON_BACKUP_READS;
 	int CONSISTENCY_CHECK_REQUIRED_REPLICAS;
+	int BULKLOAD_JOB_HISTORY_COUNT_MAX; // the max number of bulk load job history to keep. The oldest job history will
+	                                    // be removed when the count exceeds this value. Set to 0 to disable history.
+	                                    // Do not set the value to a large number, e.g. <= 10.
 
 	// Configuration
 	int32_t DEFAULT_AUTO_COMMIT_PROXIES;

--- a/fdbclient/include/fdbclient/ManagementAPI.actor.h
+++ b/fdbclient/include/fdbclient/ManagementAPI.actor.h
@@ -201,6 +201,15 @@ ACTOR Future<BulkLoadTaskState> getBulkLoadTask(Transaction* tr,
                                                 UID taskId,
                                                 std::vector<BulkLoadPhase> phases);
 
+// Add bulkLoad job to history map
+ACTOR Future<Void> addBulkLoadJobToHistory(Transaction* tr, BulkLoadJobState jobState);
+
+// Get all past bulkLoad jobs from history map
+ACTOR Future<std::vector<BulkLoadJobState>> getBulkLoadJobFromHistory(Database cx);
+
+// Erase all bulkLoad job history metadata if jobId is not provided. Otherwise, erase the job with the given jobId.
+ACTOR Future<Void> clearBulkLoadJobHistory(Database cx, Optional<UID> jobId = Optional<UID>());
+
 // Get the current running bulk load job
 ACTOR Future<Optional<BulkLoadJobState>> getRunningBulkLoadJob(Database cx);
 
@@ -216,9 +225,6 @@ ACTOR Future<Void> acknowledgeAllErrorBulkLoadTasks(Database cx, UID jobId, KeyR
 // There is at most one BulkLoad or one BulkDump job at a time.
 // If there is any existing BulkLoad or BulkDump job, reject the new job.
 ACTOR Future<Void> submitBulkLoadJob(Database cx, BulkLoadJobState jobState);
-
-// Get total number of completed tasks within the input range
-ACTOR Future<size_t> getBulkLoadCompleteTaskCount(Database cx, KeyRange rangeToRead);
 
 // Set bulk dump mode. When the mode is on, DD will periodically check if there is any bulkdump task to do by scaning
 // the metadata.

--- a/fdbclient/include/fdbclient/SystemData.h
+++ b/fdbclient/include/fdbclient/SystemData.h
@@ -541,6 +541,10 @@ extern const KeyRef bulkLoadJobPrefix;
 const Value bulkLoadJobValue(const BulkLoadJobState& bulkLoadJobState);
 BulkLoadJobState decodeBulkLoadJobState(const ValueRef& value);
 
+extern const KeyRangeRef bulkLoadJobHistoryKeys;
+extern const KeyRef bulkLoadJobHistoryPrefix;
+const Key bulkLoadJobHistoryKeyFor(const UID& jobId);
+
 extern const KeyRef bulkDumpModeKey;
 extern const KeyRangeRef bulkDumpKeys;
 extern const KeyRef bulkDumpPrefix;


### PR DESCRIPTION
When a bulkload job completes, the metadata is moved from the job key range map to the history metadata. The history metadata is a map. The key is the job Id, and the value is the job metadata. 

If the number of jobs in the history is more than `BULKLOAD_JOB_HISTORY_COUNT_MAX`, clear the oldest one before inserting a new one. 

Note that it is possible that a job with the same job id is repeatedly submitted and executed. The history only keeps the job metadata with the latest execution.

500K bulkdump:
  20250304-054123-zhewang-9ce7c36a50ada097           compressed=True data_size=40898659 duration=10230830 ended=500000 fail_fast=10 max_runs=500000 pass=500000 priority=100 remaining=0 runtime=1:50:53 sanity=False started=500000 stopped=20250304-073216 submitted=20250304-054123 timeout=5400 username=zhewang

100K correctness:
  20250304-175906-zhewang-e19e9621a3f7d8a6           compressed=True data_size=40854329 duration=6114129 ended=100000 fail=4 fail_fast=10 max_runs=100000 pass=99996 priority=100 remaining=0 runtime=1:03:17 sanity=False started=100000 stopped=20250304-190223 submitted=20250304-175906 timeout=5400 username=zhewang
        
# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
