### PR TITLE
DCC Tester Should Always Accept New Request from ConsistencyCheckUrgent Role

### DIFF
--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -57,6 +57,7 @@
 #include "fdbserver/MoveKeys.actor.h"
 #include "flow/Platform.h"
 
+#include "flow/Trace.h"
 #include "flow/actorcompiler.h" // This must be the last #include.
 
 WorkloadContext::WorkloadContext() {}
@@ -964,20 +965,26 @@ ACTOR Future<Void> testerServerCore(TesterInterface interf,
 			} else if (work.title == "ConsistencyCheckUrgent") {
 				// The workload is a consistency checker urgent workload
 				if (work.sharedRandomNumber == consistencyCheckerUrgentTester.first) {
-					TraceEvent(SevInfo, "ConsistencyCheckUrgent_TesterDuplicatedRequest", interf.id())
+					// A single req can be sent for multiple times. In this case, the sharedRandomNumber is same as
+					// the existing one. For this scenario, we reply an error. This case should be rare.
+					TraceEvent(SevWarn, "ConsistencyCheckUrgent_TesterDuplicatedRequest", interf.id())
 					    .detail("ConsistencyCheckerId", work.sharedRandomNumber)
 					    .detail("ClientId", work.clientId)
 					    .detail("ClientCount", work.clientCount);
 					work.reply.sendError(consistency_check_urgent_duplicate_request());
-				} else if (consistencyCheckerUrgentTester.second.isValid() &&
-				           !consistencyCheckerUrgentTester.second.isReady()) {
-					TraceEvent(SevWarnAlways, "ConsistencyCheckUrgent_TesterWorkloadConflict", interf.id())
-					    .detail("ExistingConsistencyCheckerId", consistencyCheckerUrgentTester.first)
-					    .detail("ArrivingConsistencyCheckerId", work.sharedRandomNumber)
-					    .detail("ClientId", work.clientId)
-					    .detail("ClientCount", work.clientCount);
-					work.reply.sendError(consistency_check_urgent_conflicting_request());
 				} else {
+					// When the req.sharedRandomNumber is different from the existing one, the cluster has muiltiple
+					// consistencycheckurgent roles at the same time. Evenutally, the cluster will have only one
+					// consistencycheckurgent role in a stable state. So, in this case, we simply let the new request to
+					// overwrite the old request. After the work is destroyed, the broken_promise will be replied.
+					if (consistencyCheckerUrgentTester.second.isValid() &&
+					    !consistencyCheckerUrgentTester.second.isReady()) {
+						TraceEvent(SevWarnAlways, "ConsistencyCheckUrgent_TesterWorkloadConflict", interf.id())
+						    .detail("ExistingConsistencyCheckerId", consistencyCheckerUrgentTester.first)
+						    .detail("ArrivingConsistencyCheckerId", work.sharedRandomNumber)
+						    .detail("ClientId", work.clientId)
+						    .detail("ClientCount", work.clientCount);
+					}
 					consistencyCheckerUrgentTester = std::make_pair(
 					    work.sharedRandomNumber, testerServerConsistencyCheckerUrgentWorkload(work, ccr, dbInfo));
 					TraceEvent(SevInfo, "ConsistencyCheckUrgent_TesterWorkloadInitialized", interf.id())

--- a/flow/include/flow/error_definitions.h
+++ b/flow/include/flow/error_definitions.h
@@ -109,7 +109,6 @@ ERROR( dd_config_changed, 1084, "DataDistribution configuration changed." )
 ERROR( consistency_check_urgent_task_failed, 1085, "Consistency check urgent task is failed")
 ERROR( data_move_conflict, 1086, "Data move conflict in SS")
 ERROR( consistency_check_urgent_duplicate_request, 1087, "Consistency check urgent got a duplicate request")
-ERROR( consistency_check_urgent_conflicting_request, 1088, "Consistency check urgent can process 1 workload at a time")
 
 ERROR( broken_promise, 1100, "Broken promise" )
 ERROR( operation_cancelled, 1101, "Asynchronous operation cancelled" )


### PR DESCRIPTION
Previously, when tester receives a request from the DCC leader, the tester always rejects the request if existing an old request sent by a different leader. However, it is possible the old task never completes when the old leader is dead.

To fix this, testers should always accept the new request.

100K correctness:
  20250305-203526-zhewang-622b988368a8b648           compressed=True data_size=40857908 fail_fast=10 max_runs=100000 priority=100 sanity=False submitted=20250305-203526 timeout=5400 username=zhewang

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
