### PR TITLE
Make bulkload file reads and writes async and memory parsimonious

### DIFF
--- a/fdbserver/BulkDumpUtil.actor.cpp
+++ b/fdbserver/BulkDumpUtil.actor.cpp
@@ -90,10 +90,9 @@ std::pair<BulkLoadFileSet, BulkLoadFileSet> getLocalRemoteFileSetSetting(Version
 	return std::make_pair(fileSetLocal, fileSetRemote);
 }
 
-// Generate SST file given the input sortedKVS to the input filePath
-// TODO(BulkDump): This copy of sortedKVS can be baaaaadddd if data is large. Fix.
-// Tried using a Reference to a map but flow doesn't like that.
-void writeKVSToSSTFile(std::string filePath, std::map<Key, Value> sortedKVS, UID logId) {
+// Generate SST file given the input sortedKVS to the input filePath.
+// TODO(BulkDump): This copy of sortedKVS can be a slow task if data is large.
+void writeKVSToSSTFile(std::string filePath, std::map<Key, Value>& sortedKVS, UID logId) {
 	const std::string absFilePath = abspath(filePath);
 	// Check file
 	if (fileExists(absFilePath)) {
@@ -181,7 +180,8 @@ ACTOR Future<BulkLoadManifest> dumpDataFileToLocalDirectory(UID logId,
 	                                byteSampleSetting,
 	                                dumpType,
 	                                transportMethod);
-	wait(writeBulkFileBytes(abspath(localFileSet.getManifestFileFullPath()), StringRef(manifest.toString())));
+	state std::string manifestStr = manifest.toString();
+	wait(writeBulkFileBytes(abspath(localFileSet.getManifestFileFullPath()), StringRef(manifestStr)));
 	return manifest;
 }
 

--- a/fdbserver/BulkDumpUtil.actor.cpp
+++ b/fdbserver/BulkDumpUtil.actor.cpp
@@ -91,7 +91,9 @@ std::pair<BulkLoadFileSet, BulkLoadFileSet> getLocalRemoteFileSetSetting(Version
 }
 
 // Generate SST file given the input sortedKVS to the input filePath
-void writeKVSToSSTFile(std::string filePath, const std::map<Key, Value>& sortedKVS, UID logId) {
+// TODO(BulkDump): This copy of sortedKVS can be baaaaadddd if data is large. Fix.
+// Tried using a Reference to a map but flow doesn't like that.
+void writeKVSToSSTFile(std::string filePath, std::map<Key, Value> sortedKVS, UID logId) {
 	const std::string absFilePath = abspath(filePath);
 	// Check file
 	if (fileExists(absFilePath)) {
@@ -118,42 +120,28 @@ void writeKVSToSSTFile(std::string filePath, const std::map<Key, Value>& sortedK
 	return;
 }
 
-void writeStringToFile(const std::string& path, const std::string& content) {
-	return writeFile(abspath(path), content);
-}
-
-void bulkDumpFileCopy(std::string fromFile, std::string toFile, size_t fileBytesMax, UID logId) {
-	const std::string content = readFileBytes(abspath(fromFile), fileBytesMax);
-	writeStringToFile(toFile, content);
-	TraceEvent(SevInfo, "SSBulkDumpSSTFileCopied", logId)
-	    .detail("FromFile", abspath(fromFile))
-	    .detail("ToFile", abspath(toFile))
-	    .detail("ContentSize", content.size());
-	return;
-}
-
-// Generate key-value data, byte sampling data, and manifest file given a range at a version with a certain bytes
-// Return BulkLoadManifest metadata (equivalent to content of the manifest file)
-// TODO(BulkDump): can cause slow tasks, do the task in a separate thread in the future.
-BulkLoadManifest dumpDataFileToLocalDirectory(UID logId,
-                                              const std::map<Key, Value>& sortedData,
-                                              const std::map<Key, Value>& sortedSample,
-                                              const BulkLoadFileSet& localFileSetConfig,
-                                              const BulkLoadFileSet& remoteFileSetConfig,
-                                              const BulkLoadByteSampleSetting& byteSampleSetting,
-                                              Version dumpVersion,
-                                              const KeyRange& dumpRange,
-                                              int64_t dumpBytes,
-                                              int64_t dumpKeyCount,
-                                              BulkLoadType dumpType,
-                                              BulkLoadTransportMethod transportMethod) {
+// TODO(BulkDump): This copy of sortedData and sortedSample can be baaaaadddd if data is large. Fix.
+// Tried using a Reference to a map but flow doesn't like that.
+ACTOR Future<BulkLoadManifest> dumpDataFileToLocalDirectory(UID logId,
+                                                            std::map<Key, Value> sortedData,
+                                                            std::map<Key, Value> sortedSample,
+                                                            BulkLoadFileSet localFileSet,
+                                                            BulkLoadFileSet remoteFileSet,
+                                                            BulkLoadByteSampleSetting byteSampleSetting,
+                                                            Version dumpVersion,
+                                                            KeyRange dumpRange,
+                                                            int64_t dumpBytes,
+                                                            int64_t dumpKeyCount,
+                                                            BulkLoadType dumpType,
+                                                            BulkLoadTransportMethod transportMethod) {
 	// Step 1: Clean up local folder
-	resetFileFolder((abspath(localFileSetConfig.getFolder())));
+	resetFileFolder((abspath(localFileSet.getFolder())));
 
 	// Step 2: Dump data to file
 	bool containDataFile = false;
 	if (sortedData.size() > 0) {
-		writeKVSToSSTFile(abspath(localFileSetConfig.getDataFileFullPath()), sortedData, logId);
+		// TODO(BulkDump): This copy of sortedData can be baaaaadddd if data is large. Fix.
+		writeKVSToSSTFile(abspath(localFileSet.getDataFileFullPath()), sortedData, logId);
 		containDataFile = true;
 	} else {
 		ASSERT(sortedSample.empty());
@@ -163,37 +151,37 @@ BulkLoadManifest dumpDataFileToLocalDirectory(UID logId,
 	// Step 3: Dump sample to file
 	bool containByteSampleFile = false;
 	if (sortedSample.size() > 0) {
-		writeKVSToSSTFile(abspath(localFileSetConfig.getBytesSampleFileFullPath()), sortedSample, logId);
-		ASSERT(containDataFile);
+		// TODO(BulkDump): This copy of sortedSample can be baaaaadddd if data is large. Fix.
+		writeKVSToSSTFile(abspath(localFileSet.getBytesSampleFileFullPath()), sortedSample, logId);
 		containByteSampleFile = true;
 	} else {
 		containByteSampleFile = false;
 	}
 
 	// Step 4: Generate manifest file
-	if (fileExists(abspath(localFileSetConfig.getManifestFileFullPath()))) {
+	if (fileExists(abspath(localFileSet.getManifestFileFullPath()))) {
 		TraceEvent(SevWarn, "SSBulkDumpRetriableError", logId)
 		    .detail("Reason", "exist old manifestFile")
-		    .detail("ManifestFilePathLocal", abspath(localFileSetConfig.getManifestFileFullPath()));
+		    .detail("ManifestFilePathLocal", abspath(localFileSet.getManifestFileFullPath()));
 		ASSERT_WE_THINK(false);
 		throw retry();
 	}
-	BulkLoadFileSet fileSetRemote(remoteFileSetConfig.getRootPath(),
-	                              remoteFileSetConfig.getRelativePath(),
-	                              remoteFileSetConfig.getManifestFileName(),
-	                              containDataFile ? remoteFileSetConfig.getDataFileName() : "",
-	                              containByteSampleFile ? remoteFileSetConfig.getByteSampleFileName() : "",
+	BulkLoadFileSet fileSetRemote(remoteFileSet.getRootPath(),
+	                              remoteFileSet.getRelativePath(),
+	                              remoteFileSet.getManifestFileName(),
+	                              containDataFile ? remoteFileSet.getDataFileName() : std::string(),
+	                              containByteSampleFile ? remoteFileSet.getByteSampleFileName() : std::string(),
 	                              BulkLoadChecksum());
-	BulkLoadManifest manifest(fileSetRemote,
-	                          dumpRange.begin,
-	                          dumpRange.end,
-	                          dumpVersion,
-	                          dumpBytes,
-	                          dumpKeyCount,
-	                          byteSampleSetting,
-	                          dumpType,
-	                          transportMethod);
-	writeStringToFile(abspath(localFileSetConfig.getManifestFileFullPath()), manifest.toString());
+	state BulkLoadManifest manifest(fileSetRemote,
+	                                dumpRange.begin,
+	                                dumpRange.end,
+	                                dumpVersion,
+	                                dumpBytes,
+	                                dumpKeyCount,
+	                                byteSampleSetting,
+	                                dumpType,
+	                                transportMethod);
+	wait(writeBulkFileBytes(abspath(localFileSet.getManifestFileFullPath()), StringRef(manifest.toString())));
 	return manifest;
 }
 
@@ -222,33 +210,28 @@ bool validateSourceDestinationFileSets(const BulkLoadFileSet& source, const Bulk
 }
 
 // Copy files between local file folders, used to mock blobstore in the test.
-void bulkDumpTransportCP_impl(const BulkLoadFileSet& sourceFileSet,
-                              const BulkLoadFileSet& destinationFileSet,
-                              size_t fileBytesMax,
-                              UID logId) {
+ACTOR Future<Void> bulkDumpTransportCP_impl(BulkLoadFileSet srcFileSet,
+                                            BulkLoadFileSet destFileSet,
+                                            size_t fileBytesMax,
+                                            UID logId) {
 	// Clear remote existing folder
-	resetFileFolder(abspath(destinationFileSet.getFolder()));
+	resetFileFolder(abspath(destFileSet.getFolder()));
 	// Copy bulk dump files to the remote folder
-	ASSERT(sourceFileSet.hasManifestFile() && destinationFileSet.hasManifestFile());
-	bulkDumpFileCopy(abspath(sourceFileSet.getManifestFileFullPath()),
-	                 abspath(destinationFileSet.getManifestFileFullPath()),
-	                 fileBytesMax,
-	                 logId);
-	if (sourceFileSet.hasDataFile()) {
-		ASSERT(destinationFileSet.hasDataFile());
-		bulkDumpFileCopy(abspath(sourceFileSet.getDataFileFullPath()),
-		                 abspath(destinationFileSet.getDataFileFullPath()),
-		                 fileBytesMax,
-		                 logId);
+	ASSERT(srcFileSet.hasManifestFile() && destFileSet.hasManifestFile());
+	wait(copyBulkFile(
+	    abspath(srcFileSet.getManifestFileFullPath()), abspath(destFileSet.getManifestFileFullPath()), fileBytesMax));
+	if (srcFileSet.hasDataFile()) {
+		ASSERT(destFileSet.hasDataFile());
+		wait(copyBulkFile(
+		    abspath(srcFileSet.getDataFileFullPath()), abspath(destFileSet.getDataFileFullPath()), fileBytesMax));
 	}
-	if (sourceFileSet.hasByteSampleFile()) {
-		ASSERT(sourceFileSet.hasDataFile() && destinationFileSet.hasByteSampleFile());
-		bulkDumpFileCopy(abspath(sourceFileSet.getBytesSampleFileFullPath()),
-		                 abspath(destinationFileSet.getBytesSampleFileFullPath()),
-		                 fileBytesMax,
-		                 logId);
+	if (srcFileSet.hasByteSampleFile()) {
+		ASSERT(srcFileSet.hasDataFile() && destFileSet.hasByteSampleFile());
+		wait(copyBulkFile(abspath(srcFileSet.getBytesSampleFileFullPath()),
+		                  abspath(destFileSet.getBytesSampleFileFullPath()),
+		                  fileBytesMax));
 	}
-	return;
+	return Void();
 }
 
 // Dump files to blobstore.
@@ -278,7 +261,7 @@ ACTOR Future<Void> uploadBulkDumpFileSet(BulkLoadTransportMethod transportMethod
 		wait(bulkDumpTransportBlobstore_impl(
 		    sourceFileSet, destinationFileSet, SERVER_KNOBS->BULKLOAD_FILE_BYTES_MAX, logId));
 	} else if (transportMethod == BulkLoadTransportMethod::CP) {
-		bulkDumpTransportCP_impl(sourceFileSet, destinationFileSet, SERVER_KNOBS->BULKLOAD_FILE_BYTES_MAX, logId);
+		wait(bulkDumpTransportCP_impl(sourceFileSet, destinationFileSet, SERVER_KNOBS->BULKLOAD_FILE_BYTES_MAX, logId));
 	} else {
 		TraceEvent(SevError, "SSBulkDumpUploadFilesError", logId)
 		    .detail("Reason", "Transport method is not implemented")
@@ -288,16 +271,16 @@ ACTOR Future<Void> uploadBulkDumpFileSet(BulkLoadTransportMethod transportMethod
 	return Void();
 }
 
-void generateBulkDumpJobManifestFile(const std::string& workFolder,
-                                     const std::string& localJobManifestFilePath,
-                                     const std::string& content,
-                                     const UID& logId) {
+ACTOR Future<Void> generateBulkDumpJobManifestFile(std::string workFolder,
+                                                   std::string localJobManifestFilePath,
+                                                   StringRef content,
+                                                   UID logId) {
 	resetFileFolder(workFolder);
-	writeStringToFile(localJobManifestFilePath, content);
+	wait(writeBulkFileBytes(localJobManifestFilePath, content));
 	TraceEvent(SevInfo, "GenerateBulkDumpJobManifestWriteLocal", logId)
 	    .detail("LocalJobManifestFilePath", localJobManifestFilePath)
 	    .detail("Content", content);
-	return;
+	return Void();
 }
 
 ACTOR Future<Void> uploadBulkDumpJobManifestFile(BulkLoadTransportMethod transportMethod,
@@ -311,10 +294,9 @@ ACTOR Future<Void> uploadBulkDumpJobManifestFile(BulkLoadTransportMethod transpo
 	if (transportMethod == BulkLoadTransportMethod::BLOBSTORE) {
 		wait(copyUpFile(localJobManifestFilePath, remoteJobManifestFilePath));
 	} else if (transportMethod == BulkLoadTransportMethod::CP) {
-		bulkDumpFileCopy(abspath(localJobManifestFilePath),
-		                 abspath(remoteJobManifestFilePath),
-		                 SERVER_KNOBS->BULKLOAD_FILE_BYTES_MAX,
-		                 logId);
+		wait(copyBulkFile(abspath(localJobManifestFilePath),
+		                  abspath(remoteJobManifestFilePath),
+		                  SERVER_KNOBS->BULKLOAD_FILE_BYTES_MAX));
 	} else {
 		TraceEvent(SevError, "UploadBulkDumpJobManifestFileError", logId)
 		    .detail("Reason", "Transport method is not implemented")

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -2115,7 +2115,7 @@ ACTOR Future<Void> bulkDumpUploadJobManifestFile(Reference<DataDistributor> self
 	state std::string jobRoot = self->bulkDumpJobManager.jobState.getJobRoot();
 	state BulkLoadTransportMethod transportMethod = self->bulkDumpJobManager.jobState.getTransportMethod();
 	// Upload job manifest file
-	std::string content = generateBulkLoadJobManifestFileContent(self->bulkDumpJobManager.jobManifest);
+	state std::string content = generateBulkLoadJobManifestFileContent(self->bulkDumpJobManager.jobManifest);
 	ASSERT(!content.empty() && !self->bulkDumpFolder.empty());
 	state std::string localFolder = getBulkLoadJobRoot(self->bulkDumpFolder, jobId);
 	state std::string remoteFolder = getBulkLoadJobRoot(jobRoot, jobId);

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -2113,15 +2113,15 @@ ACTOR Future<Void> bulkDumpUploadJobManifestFile(Reference<DataDistributor> self
 	}
 	state UID jobId = self->bulkDumpJobManager.jobState.getJobId();
 	state std::string jobRoot = self->bulkDumpJobManager.jobState.getJobRoot();
-	BulkLoadTransportMethod transportMethod = self->bulkDumpJobManager.jobState.getTransportMethod();
+	state BulkLoadTransportMethod transportMethod = self->bulkDumpJobManager.jobState.getTransportMethod();
 	// Upload job manifest file
 	std::string content = generateBulkLoadJobManifestFileContent(self->bulkDumpJobManager.jobManifest);
 	ASSERT(!content.empty() && !self->bulkDumpFolder.empty());
 	state std::string localFolder = getBulkLoadJobRoot(self->bulkDumpFolder, jobId);
 	state std::string remoteFolder = getBulkLoadJobRoot(jobRoot, jobId);
 	state std::string jobManifestFileName = getBulkLoadJobManifestFileName();
-	std::string localJobManifestFilePath = joinPath(localFolder, jobManifestFileName);
-	generateBulkDumpJobManifestFile(localFolder, localJobManifestFilePath, content, self->ddId);
+	state std::string localJobManifestFilePath = joinPath(localFolder, jobManifestFileName);
+	wait(generateBulkDumpJobManifestFile(localFolder, localJobManifestFilePath, StringRef(content), self->ddId));
 	wait(uploadBulkDumpJobManifestFile(
 	    transportMethod, localJobManifestFilePath, remoteFolder, jobManifestFileName, self->ddId));
 	clearFileFolder(localFolder, self->ddId, /*ignoreError=*/true); // best effort to clear the local folder

--- a/fdbserver/include/fdbserver/BulkLoadUtil.actor.h
+++ b/fdbserver/include/fdbserver/BulkLoadUtil.actor.h
@@ -34,6 +34,15 @@ void clearFileFolder(const std::string& folderPath, const UID& logId = UID(), bo
 // Erase and recreate file folder
 void resetFileFolder(const std::string& folderPath);
 
+// Asynchronously copy file from one path to another.
+ACTOR Future<Void> copyBulkFile(std::string fromFile, std::string toFile, size_t fileBytesMax);
+
+// Asynchronously read file bytes from local file.
+ACTOR Future<std::string> readBulkFileBytes(std::string path, int64_t maxLength);
+
+// Asynchronously write file bytes to local file.
+ACTOR Future<Void> writeBulkFileBytes(std::string path, StringRef content);
+
 // Get the bulkLoadTask metadata of the dataMoveMetadata since the atLeastVersion given the dataMoveId
 // This actor is stuck if the actor is failed to read the dataMoveMetadata.
 ACTOR Future<BulkLoadTaskState> getBulkLoadTaskStateFromDataMove(Database cx,

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -6160,18 +6160,18 @@ ACTOR Future<Void> bulkDumpQ(StorageServer* data, BulkDumpRequest req) {
 			// Write to SST file
 			state KeyRange dataRange = rangeToDump & KeyRangeRef(rangeBegin, keyAfter(rangeDumpData.lastKey));
 			state BulkLoadManifest manifest =
-			    dumpDataFileToLocalDirectory(data->thisServerID,
-			                                 rangeDumpData.kvs,
-			                                 rangeDumpData.sampled,
-			                                 localFileSetSetting,
-			                                 remoteFileSetSetting,
-			                                 byteSampleSetting,
-			                                 versionToDump,
-			                                 dataRange, // the actual range of the rangeDumpData.kvs
-			                                 rangeDumpData.kvsBytes,
-			                                 rangeDumpData.kvs.size(),
-			                                 dumpType,
-			                                 transportMethod);
+			    wait(dumpDataFileToLocalDirectory(data->thisServerID,
+			                                      rangeDumpData.kvs,
+			                                      rangeDumpData.sampled,
+			                                      localFileSetSetting,
+			                                      remoteFileSetSetting,
+			                                      byteSampleSetting,
+			                                      versionToDump,
+			                                      dataRange, // the actual range of the rangeDumpData.kvs
+			                                      rangeDumpData.kvsBytes,
+			                                      rangeDumpData.kvs.size(),
+			                                      dumpType,
+			                                      transportMethod));
 			readBytes = readBytes + rangeDumpData.kvsBytes;
 			TraceEvent(SevInfo, "SSBulkDumpDataFileGenerated", data->thisServerID)
 			    .setMaxEventLength(-1)

--- a/packaging/docker/fdb-aws-s3-credentials-fetcher/fdb-aws-s3-credentials-fetcher.go
+++ b/packaging/docker/fdb-aws-s3-credentials-fetcher/fdb-aws-s3-credentials-fetcher.go
@@ -96,20 +96,9 @@ func refreshCredentials(ctx context.Context, bucket, region, credFile string, ex
         return fmt.Errorf("failed to get credentials: %v", err)
     }
 
-    // Check if the credentials file exists
-    _, err = os.Stat(credFile)
-    fileExists := !os.IsNotExist(err)
-
-    // Check if credentials are expired or will expire soon
-    if fileExists && !creds.Expires.IsZero() {
-        timeUntilExpiry := time.Until(creds.Expires)
-        if timeUntilExpiry > expiryThreshold {
-            log.Printf("Current credentials valid for %v, skipping refresh", timeUntilExpiry.Round(time.Second))
-            return nil
-        }
-        log.Printf("Credentials expire in %v, refreshing", timeUntilExpiry.Round(time.Second))
-    }
-
+    // Just write the credentials file each time. I was checking the expiry time, but
+    // looking at it and then the blob_credentials.json file, comparing, and then
+    // updating made the script more complicated than it needed to be.
     return writeCredentialsFile(bucket, region, credFile, creds.AccessKeyID, creds.SecretAccessKey, creds.SessionToken)
 }
 


### PR DESCRIPTION
    In tests at scale, processing a large job-manifest.txt was blocking
    and causing the bulk job to fail. This is part 1 of two patches.
    The second is to address data copy added in the below when we
    made methods ACTORs (ACTOR doesn't allow passing by reference).

    * fdbserver/BulkDumpUtil.actor.cpp
     Removed writeStringToFile and buldDumpFileCopy in favor of new methods
     in BulkLoadUtil. Made hosting functions ACTORs so could wait on
     async calls.

    * fdbserver/BulkLoadUtil.actor.cpp
     Added async read and write functions.

    * fdbserver/DataDistribution.actor.cpp
     Making uploadBulkDumpJobManifestFile async made it so big bulkloads
     work.