### PR TITLE
Hold `ThreadReturnPromiseStream` reference when sending value/error

### DIFF
--- a/flow/include/flow/flow.h
+++ b/flow/include/flow/flow.h
@@ -1226,7 +1226,7 @@ struct NotifiedQueue : private SingleCallback<T>
 		if (error.isValid())
 			return;
 
-		ASSERT(this->error.code() != error_code_success);
+		ASSERT(this->error.code() != error_code_success && this->error.code() != error_code_end_of_stream);
 		this->error = err;
 
 		// end_of_stream error is "expected", don't terminate reading stream early for this

--- a/flow/include/flow/genericactors.actor.h
+++ b/flow/include/flow/genericactors.actor.h
@@ -1455,8 +1455,9 @@ void tagAndForward(Promise<T>* pOutputPromise, U value, Future<Void> signal) {
 
 ACTOR template <class T>
 void tagAndForward(PromiseStream<T>* pOutput, T value, Future<Void> signal) {
+	state PromiseStream<T> out(*pOutput);
 	wait(signal);
-	pOutput->send(std::move(value));
+	out.send(std::move(value));
 }
 
 ACTOR template <class T>
@@ -1468,8 +1469,9 @@ void tagAndForwardError(Promise<T>* pOutputPromise, Error value, Future<Void> si
 
 ACTOR template <class T>
 void tagAndForwardError(PromiseStream<T>* pOutput, Error value, Future<Void> signal) {
+	state PromiseStream<T> out(*pOutput);
 	wait(signal);
-	pOutput->sendError(value);
+	out.sendError(value);
 }
 
 ACTOR template <class T>


### PR DESCRIPTION
When a value/error is sent via `ThreadReturnPromiseStream` we assume that the underlying `PromiseStream` will be alive when the client waits. However, if the last `ThreadReturnPromiseStream` gets destroyed after sending values/end_of_stream(), the underlying `PromiseStream` will as well resulting in `broken_promise`. This happens because the actual work of sending the value/error is deferred on the main thread.

This is likely to happen because the sender did its work and it isn't supposed to check if client got the value. Hence, little reason to keep the promise. Meanwhile, client is free to read values from its future whenever it needs to.

This patch just holds the reference to underlying `NotifiedQueue` by copying `PromiseStream` until the value/error is sent. The test added would fail without this patch.

**Correctness:**
  
20250306-085721-vishesh-37e6e063e1d85eb9           compressed=True data_size=40890673 duration=5671137 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:00:58 sanity=False started=100000 stopped=20250306-095819 submitted=20250306-085721 timeout=5400 username=vishesh

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
