### PR TITLE
Delete copy constructor and add move constructors for `ThreadReturnPromise*` and delete copy constructors

### DIFF
--- a/flow/include/flow/IThreadPool.h
+++ b/flow/include/flow/IThreadPool.h
@@ -83,6 +83,9 @@ template <class T>
 class ThreadReturnPromise : NonCopyable {
 public:
 	ThreadReturnPromise() {}
+	ThreadReturnPromise(const ThreadReturnPromise& p) = delete;
+	ThreadReturnPromise(ThreadReturnPromise&& other) : promise(std::move(other.promise)) {}
+
 	~ThreadReturnPromise() {
 		if (promise.isValid())
 			sendError(broken_promise());
@@ -121,6 +124,9 @@ template <class T>
 class ThreadReturnPromiseStream : NonCopyable {
 public:
 	ThreadReturnPromiseStream() {}
+	ThreadReturnPromiseStream(const ThreadReturnPromiseStream& p) = delete;
+	ThreadReturnPromiseStream(ThreadReturnPromiseStream&& other) : promiseStream(std::move(other.promiseStream)) {}
+
 	~ThreadReturnPromiseStream() {}
 
 	FutureStream<T> getFuture() { // Call only on the originating thread!


### PR DESCRIPTION
Copy-constructor can be added back if necessary. Meanwhile, its simpler to enforce only copy of ThreadReturnPromise* family, and avoid scattering it all over places. 

Correctness:

Shouldn't have any impact as default move contructor probably generates same definition, but this change was including in run done in other PR https://github.com/apple/foundationdb/pull/12003

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
