### PR TITLE
Never absorb wrong_shard_server in LoadBalance replicaComparison

### DIFF
--- a/fdbrpc/include/fdbrpc/LoadBalance.actor.h
+++ b/fdbrpc/include/fdbrpc/LoadBalance.actor.h
@@ -389,6 +389,8 @@ Future<Void> replicaComparison(Req req,
 					}
 				}
 
+				// We must always propagate wrong_shard_server to the caller because it is signal to
+				// perform critical operations like invalidating the shard mapping cache.
 				if (replicaErrorCode == error_code_wrong_shard_server) {
 					throw Error(replicaErrorCode);
 				}

--- a/fdbrpc/include/fdbrpc/LoadBalance.actor.h
+++ b/fdbrpc/include/fdbrpc/LoadBalance.actor.h
@@ -30,6 +30,7 @@
 
 #include "flow/BooleanParam.h"
 #include "flow/flow.h"
+#include "flow/Error.h"
 #include "flow/Knobs.h"
 
 #include "fdbrpc/FailureMonitor.h"
@@ -386,6 +387,10 @@ Future<Void> replicaComparison(Req req,
 							}
 						}
 					}
+				}
+
+				if (replicaErrorCode == error_code_wrong_shard_server) {
+					throw Error(replicaErrorCode);
 				}
 			}
 

--- a/fdbrpc/include/fdbrpc/LoadBalance.actor.h
+++ b/fdbrpc/include/fdbrpc/LoadBalance.actor.h
@@ -392,7 +392,7 @@ Future<Void> replicaComparison(Req req,
 				// We must always propagate wrong_shard_server to the caller because it is signal to
 				// perform critical operations like invalidating the shard mapping cache.
 				if (replicaErrorCode == error_code_wrong_shard_server) {
-					throw Error(replicaErrorCode);
+					throw wrong_shard_server();
 				}
 			}
 


### PR DESCRIPTION
# Description

This issue was exposed in a simulation failure (test: fast/UDP.toml, seed: 357604555, buggify: on, compiler: g++).

The symptom was ConsistencyCheckFailure because of TracedTooManyLines. 

TLDR of root cause: native api / client relies on `wrong_shard_server` error to invalidate its shard map cache, but replicaComparison was absorbing this error under certain condition. 

If interested, this is the story from symptom to root cause: 
- ConsistencyCheck workload was stuck in setup phase, eventually leading to TracedTooManyLines
- The reason it was stuck was because it was waiting on QuietDatabase
- The reason QuietDatabase was failing was because it constantly observed DataDistributionQueueSize to be 1
- The reason DataDistributionQueueSize was 1 was because there was 1 InFlight data move
- From DD's pov, there were total 114 data moves, and 113 succeeded. The failing data move id was `89177a4b0d429437`.
- A particular data move succeeds when all dst SS respond with GetShardStateReply to DD's GetShardStateRequest RPC. The SS responds with GetShardStateReply (i.e. its ready) when it successfully fetches all key ranges from src SS(s). 
- This particular data move was a merge operation, where we were trying to merge src (two teams, 3 ss each, 6 total) to dst (1 team, 3 ss). 
- Out of the 3 dst ss, ss `b233eea8e537b984` was not getting ready because it was not able to fetch a key range from the src ss team. Specifically, the key range we were trying to fetch was `["3fdd079e85e3cf47", "3fdd746d2fad4f3c"]`
- SS fetches key ranges via client layer (native api -> load balancer -> replicaComparison). 
- From SS `b233eea8e537b984` pov, it was receiving `unreachable_storage_replica` error, and retries were not helping. 
- From the client layer, specifically at replicaComparison layer, we were seeing a lot of `ReplicaComparisonReadError` with `RequiredReplies="1" SuccessfulReplies="0" SSError="1001"`. 1001 maps to `wrong_shard_sever`. 
- So there are two possibilities: either (1) dst SS and client layer are talking to correct src SS but src SS is incorrectly responding with `wrong_shard_server` even though it owns the range, or (2) the client layer is incorrectly talking to a src SS which does not own the range
- To answer this question above, I saw at different components what they think the mapping is. DD thought that the key range maps to `31e08d856e14c2a5,61f54c5f0d27355a,881ef33250fa0d9e`. However, the client layer thought that the key range maps to `881ef33250fa0d9e,1f95ab3a44086e8c,619cb559d137dc83`. Both these layer should rely on commit proxy (CP) since it should be the source-of-truth for this mapping (it has to attach appropriate SS tags to mutations). 
- CP server at t=128 thought that the range is `881ef33250fa0d9e,1f95ab3a44086e8c,619cb559d137dc83`. But at t=1339, I could see that it knew the range is `881ef33250fa0d9e,1f95ab3a44086e8c,619cb559d137dc83`. This means there's a problem at the client layer.
- The client layer actually talks to CP to get that range, so this was surprising. But for performance, we have a cache at the client layer which caches the shard mapping. I confirmed that the client was not invalidating the cache. 
- The way it works is that: it is sometimes _expected_  that client reads SS info from cache, but then when it talks to it, gets `wrong_shard_server`. In this case, client invalidates the cache and asks CP again to update its mapping. 
- The reason we were not invalidating the cache is that `replicaComparison` absorbs the error code in the case when `requiredReplicas != ALL_REPLICAS`, which is true here (we want to read from 1 additional replica, not 2). But absorbing is a  problem because the upper layer (native api e.g. getRange) relies on this error to invalidates its cache. 
- This is rare but could happen in production. It's rare because absorption only happens if the original read (not comparison read) succeeds. In this case, original read was against ss `881ef33250fa0d9e` and it just so happens that this SS is part of _both_ before and after teams for the key range. Since `881ef33250fa0d9e` was responding fine, we kept retrying on either `1f95ab3a44086e8c` or `619cb559d137dc83` for comparison check, and both of them were responding with `wrong_shard_server`. 


The fix is to simply not absorb `wrong_shard_server` at the `replicaComparison` layer because upper layer rely on this signal for critical operation of invalidating shard mapping cache. And more specifically, if _any_ of the ss that the `replicaComparison` tries to talk to respond with `wrong_shard_server`, we immediately propagate it up so we can invalidate the cache and try again with the correct ss team. 

# Testing

100K correctness: `20250306-230415-praza-r142568840-fix3-b350589085f17130701667 compressed=True data_size=35824776 duration=4585787 ended=100000 fail=2 fail_fast=10 max_runs=100000 pass=99998 priority=100 remaining=0 runtime=1:28:23 sanity=False started=100000 stopped=20250307-003238 submitted=20250306-230415 timeout=5400 username=praza-r142568840-fix3-b350589085f171307016675fb760cf88de20bb45`. The 2 failures are `BulkDumping.toml`, unrelated to this change, and being investigated right now.

Another run on latest commit: `20250307-205927-praza-r142568840-fix3-f7f9bfc1c9cd258f55233a compressed=True data_size=35824595 duration=5428398 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:03:15 sanity=False started=100000 stopped=20250307-220242 submitted=20250307-205927 timeout=5400 username=praza-r142568840-fix3-f7f9bfc1c9cd258f55233ac3e8e7993f3d5a1343`.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
