### PR TITLE
Fix RangeLock in BulkDump Test and Avoid Memory Copy For Async Read/Write Bulk Files

### DIFF
--- a/fdbclient/BulkLoading.cpp
+++ b/fdbclient/BulkLoading.cpp
@@ -105,26 +105,6 @@ std::string convertBulkLoadJobPhaseToString(const BulkLoadJobPhase& phase) {
 	}
 }
 
-// Generate the bulkload job manifest file. Here is an example.
-// Assuming the job manifest file is in the folder: "/tmp".
-// Row 0: [FormatVersion]: 1, [ManifestCount]: 3;
-// Row 1: "", "01", 100, 9000, "range1", "manifest1.txt"
-// Row 2: "01", "02 ff", 200, 0, "range2", "manifest2.txt"
-// Row 3: "02 ff", "ff", 300, 8100, "range3", "manifest3.txt"
-// In this example, the job manifest file is in the format of version 1.
-// The file contains three ranges: "" ~ "\x01", "\x01" ~ "\x02\xff", and "\x02\xff" ~ "\xff".
-// For the first range, the data version is at 100, the data size is 9KB, the manifest file path is
-// "/tmp/range1/manifest1.txt". For the second range, the data version is at 200, the data size is 0 indicating this is
-// an empty range. The manifest file path is "/tmp/range2/manifest2.txt". For the third range, the data version is at
-// 300, the data size is 8.1KB, the manifest file path is "/tmp/range1/manifest3.txt".
-std::string generateBulkLoadJobManifestFileContent(const std::map<Key, BulkLoadManifest>& manifests) {
-	std::string res = BulkLoadJobManifestFileHeader(bulkLoadManifestFormatVersion, manifests.size()).toString() + "\n";
-	for (const auto& [beginKey, manifest] : manifests) {
-		res = res + BulkLoadJobFileManifestEntry(manifest).toString() + "\n";
-	}
-	return res;
-}
-
 // TODO(BulkLoad): Support file:// urls, etc.
 // For now, we only support blobstore:// urls.
 // 'blobstore://' is the first match, credentials including '@' are optional and second regex match.

--- a/fdbclient/BulkLoading.cpp
+++ b/fdbclient/BulkLoading.cpp
@@ -20,7 +20,6 @@
 
 #include "fdbclient/BulkLoading.h"
 #include "fdbclient/SystemData.h"
-#include "flow/Error.h"
 
 #include <boost/url/url.hpp>
 #include <boost/url/parse.hpp>

--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -2894,7 +2894,7 @@ ACTOR Future<Void> setBulkLoadSubmissionTransaction(Transaction* tr, BulkLoadTas
 	try {
 		wait(takeExclusiveReadLockOnRange(tr, bulkLoadTask.getRange(), rangeLockNameForBulkLoad));
 	} catch (Error& e) {
-		ASSERT(e.code() != error_code_range_lock_failed); // Currently, only bulkload uses the range lock.
+		ASSERT(e.code() != error_code_range_locked_by_different_user); // Currently, only bulkload uses the range lock.
 		throw e;
 	}
 	bulkLoadTask.submitTime = now();
@@ -3008,7 +3008,7 @@ ACTOR Future<Void> setBulkLoadFinalizeTransaction(Transaction* tr, KeyRange rang
 	try {
 		wait(releaseExclusiveReadLockOnRange(tr, bulkLoadTaskState.getRange(), rangeLockNameForBulkLoad));
 	} catch (Error& e) {
-		ASSERT(e.code() != error_code_range_lock_failed); // Currently, only bulkload uses the range lock.
+		ASSERT(e.code() != error_code_range_locked_by_different_user); // Currently, only bulkload uses the range lock.
 		throw e;
 	}
 	return Void();

--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -386,10 +386,12 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( CC_ENFORCE_USE_UNFIT_DD_IN_SIM,                      false );
 	init( DISABLE_AUDIT_STORAGE_FINAL_REPLICA_CHECK_IN_SIM,    false ); 
 	init( SS_BULKLOAD_GETRANGE_BATCH_SIZE,                     10000 ); if (isSimulated) SS_BULKLOAD_GETRANGE_BATCH_SIZE = deterministicRandom()->randomInt(1, 10);
+	init( BULKLOAD_ASYNC_READ_WRITE_BLOCK_SIZE,            1024*1024 ); if (isSimulated) BULKLOAD_ASYNC_READ_WRITE_BLOCK_SIZE = deterministicRandom()->randomInt(1024, 10240);
 
 	// BulkDumping
 	init( DD_BULKDUMP_SCHEDULE_MIN_INTERVAL_SEC,                 5.0 ); if( randomize && BUGGIFY ) DD_BULKDUMP_SCHEDULE_MIN_INTERVAL_SEC = deterministicRandom()->random01() * 10 + 1;
 	init( DD_BULKDUMP_PARALLELISM,                                50 ); if( randomize && BUGGIFY ) DD_BULKDUMP_PARALLELISM = deterministicRandom()->randomInt(1, 5);
+	init( DD_BULKDUMP_BUILD_JOB_MANIFEST_BATCH_SIZE,           10000 ); if( isSimulated ) DD_BULKDUMP_BUILD_JOB_MANIFEST_BATCH_SIZE = deterministicRandom()->randomInt(1, 100);
 	init( SS_SERVE_BULKDUMP_PARALLELISM,                           1 ); // TODO(BulkDump): Do not set to 1 after SS can resolve the file folder conflict
 	init( SS_BULKDUMP_BATCH_BYTES,                     100*1024*1024 ); if( isSimulated ) SS_BULKDUMP_BATCH_BYTES = deterministicRandom()->randomInt(1000, 10000);
 

--- a/fdbclient/include/fdbclient/BulkLoading.h
+++ b/fdbclient/include/fdbclient/BulkLoading.h
@@ -31,6 +31,8 @@
 #include "fdbclient/FDBTypes.h"
 #include "fdbrpc/fdbrpc.h"
 
+const std::string bulkLoadJobManifestLineTerminator = "\n";
+
 // Remove the input prefix from the input str. Throw bulkload_manifest_decode_error if no prefix found in str.
 std::string stringRemovePrefix(std::string str, const std::string& prefix);
 
@@ -933,11 +935,6 @@ std::string generateBulkLoadBytesSampleFileNameFromDataFileName(const std::strin
 // Return a manifest filename as a place holder when testing bulkload feature, where we issue bulkload tasks without
 // providing a manifest file. So, this manifest file is never read in this scenario.
 std::string generateEmptyManifestFileName();
-
-// Define human readable BulkLoad job manifest content in the following format:
-// Head: Manifest count: <count>, Root: <root>
-// Rows: BeginKey, EndKey, Version, Bytes, ManifestPath
-std::string generateBulkLoadJobManifestFileContent(const std::map<Key, BulkLoadManifest>& manifests);
 
 // Return path.
 // If the input is a filesystem path, return the path.

--- a/fdbclient/include/fdbclient/ServerKnobs.h
+++ b/fdbclient/include/fdbclient/ServerKnobs.h
@@ -407,8 +407,11 @@ public:
 	                                              // between two rounds
 	double DD_BULKDUMP_SCHEDULE_MIN_INTERVAL_SEC; // the minimal seconds that the bulk dump scheduler has to wait
 	                                              // between two rounds
-	bool CC_ENFORCE_USE_UNFIT_DD_IN_SIM; // Set for CC to enforce to use an unfit DD in the simulation. This knob
-	                                     // takes effect only in the simulation.
+	int DD_BULKDUMP_BUILD_JOB_MANIFEST_BATCH_SIZE; // the number of lines in a batch when generating bulkload job
+	                                               // manifest file
+	int BULKLOAD_ASYNC_READ_WRITE_BLOCK_SIZE; // the block size when performing async read/write for bulkload
+	bool CC_ENFORCE_USE_UNFIT_DD_IN_SIM; // Set for CC to enforce to use an unfit DD in the simulation. This knob takes
+	                                     // effect only in the simulation.
 	bool DISABLE_AUDIT_STORAGE_FINAL_REPLICA_CHECK_IN_SIM; // Set to disable audit storage replica check in the
 	                                                       // simulation.
 	int DD_BULKDUMP_PARALLELISM; // the max number of concurrent bulk dump tasks in DD

--- a/fdbserver/BulkDumpUtil.actor.cpp
+++ b/fdbserver/BulkDumpUtil.actor.cpp
@@ -22,20 +22,12 @@
 #include "fdbclient/BulkLoading.h"
 #include "fdbclient/FDBTypes.h"
 #include "fdbclient/KeyRangeMap.h"
+#include "fdbclient/S3Client.actor.h"
 #include "fdbserver/BulkDumpUtil.actor.h"
 #include "fdbserver/BulkLoadUtil.actor.h"
 #include "fdbserver/Knobs.h"
 #include "fdbserver/RocksDBCheckpointUtils.actor.h"
 #include "fdbserver/StorageMetrics.actor.h"
-#include "flow/Error.h"
-#include "flow/IRandom.h"
-#include "flow/Optional.h"
-#include "flow/Platform.h"
-#include "flow/Trace.h"
-#include "fdbclient/S3Client.actor.h" // include the header for S3Client
-#include "flow/flow.h"
-#include <memory>
-#include <string>
 #include "flow/actorcompiler.h" // has to be last include
 
 SSBulkDumpTask getSSBulkDumpTask(const std::map<std::string, std::vector<StorageServerInterface>>& locations,

--- a/fdbserver/BulkDumpUtil.actor.cpp
+++ b/fdbserver/BulkDumpUtil.actor.cpp
@@ -34,6 +34,7 @@
 #include "flow/Trace.h"
 #include "fdbclient/S3Client.actor.h" // include the header for S3Client
 #include "flow/flow.h"
+#include <memory>
 #include <string>
 #include "flow/actorcompiler.h" // has to be last include
 
@@ -119,18 +120,13 @@ void writeKVSToSSTFile(std::string filePath, std::map<Key, Value>& sortedKVS, UI
 	return;
 }
 
-// TODO(BulkDump): This copy of sortedData and sortedSample can be baaaaadddd if data is large. Fix.
-// Tried using a Reference to a map but flow doesn't like that.
 ACTOR Future<BulkLoadManifest> dumpDataFileToLocalDirectory(UID logId,
-                                                            std::map<Key, Value> sortedData,
-                                                            std::map<Key, Value> sortedSample,
+                                                            std::shared_ptr<RangeDumpRawData> rangeDumpRawData,
                                                             BulkLoadFileSet localFileSet,
                                                             BulkLoadFileSet remoteFileSet,
                                                             BulkLoadByteSampleSetting byteSampleSetting,
                                                             Version dumpVersion,
                                                             KeyRange dumpRange,
-                                                            int64_t dumpBytes,
-                                                            int64_t dumpKeyCount,
                                                             BulkLoadType dumpType,
                                                             BulkLoadTransportMethod transportMethod) {
 	// Step 1: Clean up local folder
@@ -138,20 +134,18 @@ ACTOR Future<BulkLoadManifest> dumpDataFileToLocalDirectory(UID logId,
 
 	// Step 2: Dump data to file
 	bool containDataFile = false;
-	if (sortedData.size() > 0) {
-		// TODO(BulkDump): This copy of sortedData can be baaaaadddd if data is large. Fix.
-		writeKVSToSSTFile(abspath(localFileSet.getDataFileFullPath()), sortedData, logId);
+	if (rangeDumpRawData->kvs.size() > 0) {
+		writeKVSToSSTFile(abspath(localFileSet.getDataFileFullPath()), rangeDumpRawData->kvs, logId);
 		containDataFile = true;
 	} else {
-		ASSERT(sortedSample.empty());
+		ASSERT(rangeDumpRawData->sampled.empty());
 		containDataFile = false;
 	}
 
 	// Step 3: Dump sample to file
 	bool containByteSampleFile = false;
-	if (sortedSample.size() > 0) {
-		// TODO(BulkDump): This copy of sortedSample can be baaaaadddd if data is large. Fix.
-		writeKVSToSSTFile(abspath(localFileSet.getBytesSampleFileFullPath()), sortedSample, logId);
+	if (rangeDumpRawData->sampled.size() > 0) {
+		writeKVSToSSTFile(abspath(localFileSet.getBytesSampleFileFullPath()), rangeDumpRawData->sampled, logId);
 		containByteSampleFile = true;
 	} else {
 		containByteSampleFile = false;
@@ -171,18 +165,19 @@ ACTOR Future<BulkLoadManifest> dumpDataFileToLocalDirectory(UID logId,
 	                              containDataFile ? remoteFileSet.getDataFileName() : std::string(),
 	                              containByteSampleFile ? remoteFileSet.getByteSampleFileName() : std::string(),
 	                              BulkLoadChecksum());
-	state BulkLoadManifest manifest(fileSetRemote,
-	                                dumpRange.begin,
-	                                dumpRange.end,
-	                                dumpVersion,
-	                                dumpBytes,
-	                                dumpKeyCount,
-	                                byteSampleSetting,
-	                                dumpType,
-	                                transportMethod);
-	state std::string manifestStr = manifest.toString();
-	wait(writeBulkFileBytes(abspath(localFileSet.getManifestFileFullPath()), StringRef(manifestStr)));
-	return manifest;
+	state BulkLoadManifest manifestMetadata(fileSetRemote,
+	                                        dumpRange.begin,
+	                                        dumpRange.end,
+	                                        dumpVersion,
+	                                        rangeDumpRawData->kvsBytes,
+	                                        rangeDumpRawData->kvs.size(),
+	                                        byteSampleSetting,
+	                                        dumpType,
+	                                        transportMethod);
+	state std::string manifestStr = manifestMetadata.toString();
+	state std::shared_ptr<std::string> manifest = std::make_shared<std::string>(std::move(manifestStr));
+	wait(writeBulkFileBytes(abspath(localFileSet.getManifestFileFullPath()), manifest));
+	return manifestMetadata;
 }
 
 // Validate the invariant of filenames. Source is the file stored locally. Destination is the file going to move to.
@@ -268,18 +263,6 @@ ACTOR Future<Void> uploadBulkDumpFileSet(BulkLoadTransportMethod transportMethod
 		    .detail("TransportMethod", transportMethod);
 		ASSERT(false);
 	}
-	return Void();
-}
-
-ACTOR Future<Void> generateBulkDumpJobManifestFile(std::string workFolder,
-                                                   std::string localJobManifestFilePath,
-                                                   StringRef content,
-                                                   UID logId) {
-	resetFileFolder(workFolder);
-	wait(writeBulkFileBytes(localJobManifestFilePath, content));
-	TraceEvent(SevInfo, "GenerateBulkDumpJobManifestWriteLocal", logId)
-	    .detail("LocalJobManifestFilePath", localJobManifestFilePath)
-	    .detail("Content", content);
 	return Void();
 }
 

--- a/fdbserver/BulkLoadUtil.actor.cpp
+++ b/fdbserver/BulkLoadUtil.actor.cpp
@@ -26,11 +26,6 @@
 #include "fdbserver/Knobs.h"
 #include "fdbserver/RocksDBCheckpointUtils.actor.h"
 #include "fdbserver/StorageMetrics.actor.h"
-#include "flow/Error.h"
-#include "flow/IAsyncFile.h"
-#include "flow/IRandom.h"
-#include "flow/Platform.h"
-#include "flow/Trace.h"
 #include "flow/genericactors.actor.h"
 #include "flow/actorcompiler.h" // has to be last include
 

--- a/fdbserver/BulkLoadUtil.actor.cpp
+++ b/fdbserver/BulkLoadUtil.actor.cpp
@@ -34,11 +34,12 @@
 #include "flow/genericactors.actor.h"
 #include "flow/actorcompiler.h" // has to be last include
 
-ACTOR Future<std::string> readBulkFileBytes(std::string path, int64_t maxLength) {
+ACTOR Future<Void> readBulkFileBytes(std::string path, int64_t maxLength, std::shared_ptr<std::string> output) {
 	try {
+		output->clear();
+		state int64_t chunkSize = SERVER_KNOBS->BULKLOAD_ASYNC_READ_WRITE_BLOCK_SIZE;
 		state Reference<IAsyncFile> file = wait(IAsyncFileSystem::filesystem()->open(
 		    abspath(path), IAsyncFile::OPEN_NO_AIO | IAsyncFile::OPEN_READONLY | IAsyncFile::OPEN_UNCACHED, 0644));
-
 		state int64_t fileSize = wait(file->size());
 		if (fileSize > maxLength) {
 			TraceEvent(SevError, "ReadBulkFileBytesTooLarge")
@@ -46,103 +47,76 @@ ACTOR Future<std::string> readBulkFileBytes(std::string path, int64_t maxLength)
 			    .detail("MaxLength", maxLength);
 			throw file_too_large();
 		}
+		output->reserve(fileSize); // Pre-allocate the full size
 
-		state std::shared_ptr<std::string> content = std::make_shared<std::string>();
-		content->reserve(fileSize); // Pre-allocate the full size
-
-		// For small files (< 1MB), do a single read
-		if (fileSize < 1024 * 1024) {
-			content->resize(fileSize);
-			int bytesRead = wait(uncancellable(holdWhile(content, file->read(content->data(), fileSize, 0))));
-			if (bytesRead != fileSize) {
+		// Read in chunks to avoid memory pressure
+		state int64_t offset = 0;
+		state int64_t remaining = fileSize;
+		while (remaining > 0) {
+			state int64_t bytesToRead = std::min(chunkSize, remaining);
+			state std::shared_ptr<std::string> chunk = std::make_shared<std::string>();
+			chunk->resize(bytesToRead);
+			state int bytesRead = wait(uncancellable(holdWhile(chunk, file->read(chunk->data(), bytesToRead, offset))));
+			if (bytesRead != bytesToRead) {
 				TraceEvent(SevError, "ReadBulkFileBytesError")
 				    .detail("BytesRead", bytesRead)
-				    .detail("BytesExpected", fileSize);
+				    .detail("BytesExpected", bytesToRead);
 				throw io_error();
 			}
-		} else {
-			// For large files, read in chunks to avoid memory pressure
-			state int64_t chunkSize = 1024 * 1024; // 1MB chunks
-			state int64_t offset = 0;
-			state int64_t remaining = fileSize;
+			output->append(*chunk);
+			offset += bytesRead;
+			remaining -= bytesRead;
 
-			while (remaining > 0) {
-				state int64_t bytesToRead = std::min(chunkSize, remaining);
-				state std::shared_ptr<std::string> chunk = std::make_shared<std::string>();
-				chunk->resize(bytesToRead);
-
-				state int bytesRead =
-				    wait(uncancellable(holdWhile(chunk, file->read(chunk->data(), bytesToRead, offset))));
-				if (bytesRead != bytesToRead) {
-					TraceEvent(SevError, "ReadBulkFileBytesError")
-					    .detail("BytesRead", bytesRead)
-					    .detail("BytesExpected", bytesToRead);
-					throw io_error();
-				}
-
-				content->append(*chunk);
-				offset += bytesRead;
-				remaining -= bytesRead;
-
-				// Yield every 4MB to allow other actors to run
-				if (offset % (4 * 1024 * 1024) == 0) {
-					wait(yield());
-				}
+			// Yield every 4 chunks to allow other actors to run
+			if (offset % (4 * chunkSize) == 0) {
+				wait(yield());
 			}
 		}
-
-		return *content;
+		return Void();
 	} catch (Error& e) {
 		TraceEvent(SevWarn, "ReadBulkFileBytesError").error(e).detail("Path", path).detail("MaxLength", maxLength);
-		throw;
+		throw e;
 	}
 }
 
-ACTOR Future<Void> writeBulkFileBytes(std::string path, StringRef contentIn) {
+ACTOR Future<Void> writeBulkFileBytes(std::string path, std::shared_ptr<std::string> content) {
 	try {
-		state std::string contentString = contentIn.toString();
-		state std::shared_ptr<std::string> content = std::make_shared<std::string>(std::move(contentString));
+		state int64_t chunkSize = SERVER_KNOBS->BULKLOAD_ASYNC_READ_WRITE_BLOCK_SIZE;
 		state Reference<IAsyncFile> file = wait(IAsyncFileSystem::filesystem()->open(
 		    abspath(path),
 		    IAsyncFile::OPEN_ATOMIC_WRITE_AND_CREATE | IAsyncFile::OPEN_READWRITE | IAsyncFile::OPEN_CREATE,
 		    0644));
 
-		// For small files (< 1MB), do a single write
-		if (content->size() < 1024 * 1024) {
-			wait(uncancellable(holdWhile(content, file->write(content->data(), content->size(), 0))));
-		} else {
-			// For large files, write in chunks to avoid memory pressure
-			state int64_t chunkSize = 1024 * 1024; // 1MB chunks
-			state int64_t offset = 0;
-			state int64_t remaining = content->size();
+		// For large files, write in chunks to avoid memory pressure
+		state int64_t offset = 0;
+		state int64_t remaining = content->size();
 
-			while (remaining > 0) {
-				state int64_t bytesToWrite = std::min(chunkSize, remaining);
-				wait(file->write(content->data() + offset, bytesToWrite, offset));
-				offset += bytesToWrite;
-				remaining -= bytesToWrite;
+		while (remaining > 0) {
+			state int64_t bytesToWrite = std::min(chunkSize, remaining);
+			wait(uncancellable(holdWhile(content, file->write(content->data() + offset, bytesToWrite, offset))));
+			offset += bytesToWrite;
+			remaining -= bytesToWrite;
 
-				// Yield every 4MB to allow other actors to run
-				if (offset % (4 * 1024 * 1024) == 0) {
-					wait(yield());
-				}
+			// Yield every 4 chunks to allow other actors to run
+			if (offset % (4 * chunkSize) == 0) {
+				wait(yield());
 			}
 		}
 
 		// Ensure the file size is correct and data is synced
-		wait(uncancellable(file->truncate(content->size())));
-		wait(uncancellable(file->sync()));
-
+		wait(file->truncate(content->size()));
+		wait(file->sync());
 		return Void();
 	} catch (Error& e) {
 		TraceEvent(SevWarn, "WriteBulkFileBytesError").error(e).detail("Path", path);
-		throw;
+		throw e;
 	}
 }
 
 ACTOR Future<Void> copyBulkFile(std::string fromFile, std::string toFile, size_t fileBytesMax) {
-	state std::string content = wait(readBulkFileBytes(abspath(fromFile), fileBytesMax));
-	wait(writeBulkFileBytes(toFile, StringRef(content)));
+	state std::shared_ptr<std::string> content = std::make_shared<std::string>();
+	wait(readBulkFileBytes(abspath(fromFile), fileBytesMax, /*output=*/content));
+	wait(writeBulkFileBytes(toFile, content));
 	return Void();
 }
 
@@ -482,7 +456,7 @@ getBulkLoadJobFileManifestEntryFromJobManifestFile(std::string localJobManifestF
 			state size_t pos = 0;
 			state size_t lineStart = 0;
 
-			while ((pos = chunk.find('\n', lineStart)) != std::string::npos) {
+			while ((pos = chunk.find(bulkLoadJobManifestLineTerminator, lineStart)) != std::string::npos) {
 				state std::string line = chunk.substr(lineStart, pos - lineStart);
 				if (!line.empty()) {
 					if (!headerProcessed) {
@@ -548,8 +522,8 @@ ACTOR Future<BulkLoadManifest> getBulkLoadManifestMetadataFromEntry(BulkLoadJobF
 	    joinPath(manifestLocalTempFolder,
 	             deterministicRandom()->randomUniqueID().toString() + "-" + basename(getPath(remoteManifestFilePath)));
 	wait(downloadManifestFile(transportMethod, remoteManifestFilePath, localManifestFilePath, logId));
-	std::string manifestRawString =
-	    wait(readBulkFileBytes(abspath(localManifestFilePath), SERVER_KNOBS->BULKLOAD_FILE_BYTES_MAX));
-	ASSERT(!manifestRawString.empty());
-	return BulkLoadManifest(manifestRawString);
+	state std::shared_ptr<std::string> manifestRawString = std::make_shared<std::string>();
+	wait(readBulkFileBytes(abspath(localManifestFilePath), SERVER_KNOBS->BULKLOAD_FILE_BYTES_MAX, manifestRawString));
+	ASSERT(!manifestRawString->empty());
+	return BulkLoadManifest(*manifestRawString);
 }

--- a/fdbserver/include/fdbserver/BulkLoadUtil.actor.h
+++ b/fdbserver/include/fdbserver/BulkLoadUtil.actor.h
@@ -18,6 +18,7 @@
  * limitations under the License.
  */
 
+#include <memory>
 #if defined(NO_INTELLISENSE) && !defined(FDBSERVER_BULKLOADUTIL_ACTOR_G_H)
 #define FDBSERVER_BULKLOADUTIL_ACTOR_G_H
 #include "fdbserver/BulkLoadUtil.actor.g.h"
@@ -38,10 +39,10 @@ void resetFileFolder(const std::string& folderPath);
 ACTOR Future<Void> copyBulkFile(std::string fromFile, std::string toFile, size_t fileBytesMax);
 
 // Asynchronously read file bytes from local file.
-ACTOR Future<std::string> readBulkFileBytes(std::string path, int64_t maxLength);
+ACTOR Future<Void> readBulkFileBytes(std::string path, int64_t maxLength, std::shared_ptr<std::string> output);
 
 // Asynchronously write file bytes to local file.
-ACTOR Future<Void> writeBulkFileBytes(std::string path, StringRef content);
+ACTOR Future<Void> writeBulkFileBytes(std::string path, std::shared_ptr<std::string> content);
 
 // Get the bulkLoadTask metadata of the dataMoveMetadata since the atLeastVersion given the dataMoveId
 // This actor is stuck if the actor is failed to read the dataMoveMetadata.

--- a/fdbserver/workloads/BulkDumping.actor.cpp
+++ b/fdbserver/workloads/BulkDumping.actor.cpp
@@ -320,6 +320,9 @@ struct BulkDumping : TestWorkload {
 		state std::map<Key, Value> kvs = self->generateOrderedKVS(self, normalKeys, 1000);
 		wait(self->setKeys(cx, kvs));
 
+		// BulkLoad uses range lock
+		wait(registerRangeLockOwner(cx, rangeLockNameForBulkLoad, rangeLockNameForBulkLoad));
+
 		// Submit a bulk dump job
 		state int oldBulkDumpMode = 0;
 		wait(store(oldBulkDumpMode, setBulkDumpMode(cx, 1))); // Enable bulkDump
@@ -381,6 +384,8 @@ struct BulkDumping : TestWorkload {
 			wait(self->validateBulkLoadJobHistory(cx, bulkLoadJob.getJobId(), hasError));
 			break;
 		}
+
+		wait(removeRangeLockOwner(cx, rangeLockNameForBulkLoad));
 
 		return Void();
 	}


### PR DESCRIPTION
This PR includes:
1. Fix RangeLock assert error in BulkDump tests. The error happens if the DD registers the lock owner after the workload submits a task. In this case, when the workload submits a task, it finds that no lock owner has been registered. To solve this issue, we register the lock owner at the beginning of the workload.
2. Simplify the async write/read bulk file code and avoid memory copy of the string.

100K Correctness Test with 1 irrelevant failure:
  20250309-232400-zhewang-ba2181eb902cf272           compressed=True data_size=40925783 duration=5300730 ended=100000 fail=1 fail_fast=10 max_runs=100000 pass=99999 priority=100 remaining=0 runtime=1:12:08 sanity=False started=100000 stopped=20250310-003608 submitted=20250309-232400 timeout=5400 username=zhewang
  
500K BulkLoad Test:
  20250309-222340-zhewang-fd6cb825540fa9ae           compressed=True data_size=40969364 duration=12305843 ended=500000 fail=2 fail_fast=10 max_runs=500000 pass=499998 priority=100 remaining=0 runtime=2:26:51 sanity=False started=500000 stopped=20250310-005031 submitted=20250309-222340 timeout=5400 username=zhewang
  
500K BulkDump Test:
  20250309-231147-zhewang-bee8fa18eac58a02           compressed=True data_size=40970109 duration=12269532 ended=500000 fail_fast=10 max_runs=500000 pass=500000 priority=100 remaining=0 runtime=2:07:57 sanity=False started=500000 stopped=20250310-011944 submitted=20250309-231147 timeout=5400 username=zhewang

Tested by Kubernetes test.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
