### PR TITLE
Request reboot for TSS data move conflicts in simulation

### DIFF
--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -2463,6 +2463,15 @@ std::vector<StorageServerShard> StorageServer::getStorageServerShards(KeyRangeRe
 	return res;
 }
 
+static Error dataMoveConflictError(const bool isTss) {
+	if (isTss && g_network->isSimulated()) {
+		// Tss data move conflicts are expected in simulation, and can be safely ignored
+		// by restarting the server.
+		return please_reboot();
+	}
+	return data_move_conflict();
+}
+
 std::shared_ptr<MoveInShard> StorageServer::getMoveInShard(const UID& dataMoveId,
                                                            const Version version,
                                                            const ConductBulkLoad conductBulkLoad) {
@@ -10855,7 +10864,7 @@ void changeServerKeysWithPhysicalShards(StorageServer* data,
 				    .detail("DataMoveId", dataMoveId)
 				    .detail("Version", version)
 				    .detail("InitialVersion", currentShard->version);
-				throw data_move_conflict();
+				throw dataMoveConflictError(data->isTss());
 			}
 		} else if (currentShard->notAssigned()) {
 			if (!nowAssigned) {
@@ -10868,7 +10877,7 @@ void changeServerKeysWithPhysicalShards(StorageServer* data,
 				    .detail("ConflictingShard", currentShard->shardId)
 				    .detail("DesiredShardId", currentShard->desiredShardId)
 				    .detail("InitialVersion", currentShard->version);
-				throw data_move_conflict();
+				throw dataMoveConflictError(data->isTss());
 			}
 			StorageServerShard newShard = currentShard->toStorageServerShard();
 			newShard.range = currentRange;
@@ -10898,7 +10907,7 @@ void changeServerKeysWithPhysicalShards(StorageServer* data,
 				    .detail("ConflictingShard", currentShard->shardId)
 				    .detail("DesiredShardId", currentShard->desiredShardId)
 				    .detail("InitialVersion", currentShard->version);
-				throw data_move_conflict();
+				throw dataMoveConflictError(data->isTss());
 			}
 			StorageServerShard newShard = currentShard->toStorageServerShard();
 			newShard.range = currentRange;
@@ -10919,7 +10928,7 @@ void changeServerKeysWithPhysicalShards(StorageServer* data,
 				    .detail("ConflictingShard", currentShard->shardId)
 				    .detail("DesiredShardId", currentShard->desiredShardId)
 				    .detail("InitialVersion", currentShard->version);
-				throw data_move_conflict();
+				throw dataMoveConflictError(data->isTss());
 			}
 			currentShard->moveInShard->cancel();
 			updatedMoveInShards.emplace(currentShard->moveInShard->id(), currentShard->moveInShard);
@@ -11034,13 +11043,7 @@ void changeServerKeysWithPhysicalShards(StorageServer* data,
 						    .detailf("CurrentShard", "%016llx", shard->desiredShardId)
 						    .detail("IsTSS", data->isTss())
 						    .detail("Version", cVer);
-						if (data->isTss() && g_network->isSimulated()) {
-							// Tss data move conflicts are expected in simulation, and can be safely ignored
-							// by restarting the server.
-							throw please_reboot();
-						} else {
-							throw data_move_conflict();
-						}
+						throw dataMoveConflictError(data->isTss());
 					} else {
 						TraceEvent(SevInfo, "CSKMoveInToSameShard", data->thisServerID)
 						    .detail("DataMoveID", dataMoveId)

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -2466,7 +2466,7 @@ std::vector<StorageServerShard> StorageServer::getStorageServerShards(KeyRangeRe
 static Error dataMoveConflictError(const bool isTss) {
 	if (isTss && g_network->isSimulated()) {
 		// TSS data move conflicts can happen in both sim and prod, but in sim,
-		// the sev40s it causes fails Joshua tests. We have been using please_reboot
+		// the sev40s cause failures of Joshua tests. We have been using please_reboot
 		// as means to avoid sev40s, but semantically this is undesired because rebooting
 		// will not fix/heal the TSS.
 		// TODO: think of a proper TSS move conflict error that does not trigger

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -2465,8 +2465,12 @@ std::vector<StorageServerShard> StorageServer::getStorageServerShards(KeyRangeRe
 
 static Error dataMoveConflictError(const bool isTss) {
 	if (isTss && g_network->isSimulated()) {
-		// Tss data move conflicts are expected in simulation, and can be safely ignored
-		// by restarting the server.
+		// TSS data move conflicts can happen in both sim and prod, but in sim,
+		// the sev40s it causes fails Joshua tests. We have been using please_reboot
+		// as means to avoid sev40s, but semantically this is undesired because rebooting
+		// will not fix/heal the TSS.
+		// TODO: think of a proper TSS move conflict error that does not trigger
+		// reboot but also avoids sev40. And throw that error regardless of sim or prod.
 		return please_reboot();
 	}
 	return data_move_conflict();


### PR DESCRIPTION
# Description 

MutationLogReaderCorrectness.toml sometimes fails with sharded rocks and PSM:

```
<Event Severity="40" ErrorKind="Unset" Time="227.606157" DateTime="2025-03-07T23:48:34Z" Type="SSUpdateError" Machine="[abcd::2:0:1:1]:1" ID="8a92bc88d663ff8a" Error="data_move_conflict"
ErrorDescription="Data move conflict in SS" ErrorCode="1086" ThreadID="851768266932647122" Backtrace="addr2line -e fdbserver.debug -p -C -f -i 0x5be2f6d 0x5be3233 0x5bdd324 0x36ffacd 0x37
02685 0x3702323 0x3701753 0x37009dc 0x37005b6 0x36fe8c4 0x2d66ae8 0x2d6620c 0x2d671a8 0x2d66c4a 0x2d62de8 0x2d624ac 0x20ff468 0x20ff19a 0x59aa72d 0x59aa003 0x1dddde8 0x5ab19b5 0x5ab14ea 0
x35bafdc 0x7fc1250115d0" LogGroup="default" Roles="BK,CS,DD,GP,MS,RK,ST" />
<Event Severity="40" ErrorKind="Unset" Time="227.606157" DateTime="2025-03-07T23:48:34Z" Type="TestingStorageServerFailed" Machine="[abcd::2:0:1:1]:1" ID="8a92bc88d663ff8a" Error="data_mo
ve_conflict" ErrorDescription="Data move conflict in SS" ErrorCode="1086" Reason="Error" ThreadID="851768266932647122" Backtrace="addr2line -e fdbserver.debug -p -C -f -i 0x5be2f6d 0x5be3
233 0x5bdd324 0x38b3bcd 0x38e38f6 0x38e34fe 0x38e1c02 0x38e1f66 0x1e74309 0x38f123f 0x38f0d4b 0x23f1d38 0x23f2186 0x1e74309 0x38e21f3 0x1dddde8 0x2c82039 0x2c7eb64 0x5ae7538 0x5ae6ddc 0x5
ae6c04 0x2c10758 0x1dddde8 0x5ab19b5 0x5ab14ea 0x35bafdc 0x7fc1250115d0" LogGroup="default" Roles="BK,CS,DD,GP,MS,RK,ST" />
```

For TSS, these data move conflicts are expected in simulation. We've had similar PRs in the past:
- https://github.com/apple/foundationdb/pull/11944/files
- https://github.com/apple/foundationdb/pull/11714/files

But there were still cases where we throw data_move_conflict with sev30 warning, which ended ss role and caused a sev40 error. 

This PR refactors the code and ensures all instances of data move conflicts in TSS are consistent in terms of what error we throw. This means we'll consistently throw please_reboot which will avoid the unexpected ss end role that caused sev40. 

# Testing

General 100K:

20250310-190036-praza-r146128031-shardedrocks-psm-fix-tosubm compressed=True data_size=36814299 fail_fast=10 max_runs=100000 priority=100 sanity=False submitted=20250310-190036 timeout=5400 username=praza-r146128031-shardedrocks-psm-fix-tosubmit-ea9e333e2b496305864273b0d9c7ea8101775c27
  
Ran MutationLogReaderCorrectness 100K times while forcing sharded rocks storage engine:

20250310-202516-praza-r146128031-shardedrocks-psm-fix-tosubm compressed=True data_size=36845575 duration=6254901 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=2:29:56 sanity=False started=100000 stopped=20250310-225512 submitted=20250310-202516 timeout=5400 username=praza-r146128031-shardedrocks-psm-fix-tosubmit-force-b9be0fd16884c44c7795a921b5c6c039d1f218fc

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
