### PR TITLE
Improve BulkLoad Test Coverage And Fix Bugs

### DIFF
--- a/fdbserver/BulkLoadUtil.actor.cpp
+++ b/fdbserver/BulkLoadUtil.actor.cpp
@@ -139,10 +139,7 @@ ACTOR Future<Void> writeBulkFileBytes(std::string path, StringRef contentIn) {
 
 		return Void();
 	} catch (Error& e) {
-		TraceEvent(SevWarn, "WriteBulkFileBytesError")
-		    .error(e)
-		    .detail("Path", path)
-		    .detail("ContentSize", content->size());
+		TraceEvent(SevWarn, "WriteBulkFileBytesError").error(e).detail("Path", path);
 		throw;
 	}
 }

--- a/fdbserver/BulkLoadUtil.actor.cpp
+++ b/fdbserver/BulkLoadUtil.actor.cpp
@@ -26,10 +26,6 @@
 #include "fdbserver/Knobs.h"
 #include "fdbserver/RocksDBCheckpointUtils.actor.h"
 #include "fdbserver/StorageMetrics.actor.h"
-#include <cstddef>
-#include <fmt/format.h>
-#include <memory>
-#include "flow/Coroutines.h"
 #include "flow/Error.h"
 #include "flow/IAsyncFile.h"
 #include "flow/IRandom.h"

--- a/fdbserver/BulkLoadUtil.actor.cpp
+++ b/fdbserver/BulkLoadUtil.actor.cpp
@@ -34,7 +34,6 @@
 #include "flow/Platform.h"
 #include "flow/Trace.h"
 #include "flow/actorcompiler.h" // has to be last include
-#include "flow/flow.h"
 
 ACTOR Future<std::string> readBulkFileBytes(std::string path, int64_t maxLength) {
 	try {

--- a/fdbserver/DDRelocationQueue.actor.cpp
+++ b/fdbserver/DDRelocationQueue.actor.cpp
@@ -1559,6 +1559,7 @@ ACTOR Future<Void> dataDistributionRelocator(DDQueue* self,
 				    .detail("DataMoveID", rd.dataMoveId.toString())
 				    .detail("TrackID", rd.randomId)
 				    .detail("Range", rd.keys)
+				    .detail("Priority", rd.priority)
 				    .detail("Reason", rd.reason.toString())
 				    .detail("DataMoveType", dataMoveType)
 				    .detail("DoBulkLoading", doBulkLoading)
@@ -1908,6 +1909,7 @@ ACTOR Future<Void> dataDistributionRelocator(DDQueue* self,
 						    .detail("BulkLoadTask", rd.bulkLoadTask.get().toString())
 						    .detail("DataMoveID", rd.dataMoveId)
 						    .detail("Reason", rd.reason.toString())
+						    .detail("Priority", rd.priority)
 						    .detail("DataMoveReason", static_cast<int>(rd.dmReason));
 						if (rd.bulkLoadTask.get().completeAck.canBeSet()) {
 							// Unretriable error. So, we give up the task at this time.

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -551,14 +551,6 @@ public:
 		// TODO: Complete this.
 	}
 
-	SSBulkLoadMetadata getSSBulkLoadMetadata() const {
-		if (adding) {
-			return adding->getSSBulkLoadMetadata();
-		} else {
-			return SSBulkLoadMetadata();
-		}
-	}
-
 	bool isReadable() const { return readWrite != nullptr; }
 	bool notAssigned() const { return !readWrite && !adding && !moveInShard; }
 	bool assigned() const { return readWrite || adding || moveInShard; }
@@ -1311,6 +1303,7 @@ public:
 	StorageServerDisk storage;
 
 	KeyRangeMap<Reference<ShardInfo>> shards;
+	KeyRangeMap<SSBulkLoadMetadata> ssBulkLoadMetadataMap; // store the latest bulkload task on ranges
 	std::unordered_map<int64_t, SSPhysicalShard> physicalShards;
 	uint64_t shardChangeCounter; // max( shards->changecounter )
 
@@ -9115,6 +9108,7 @@ ACTOR Future<Void> fetchKeys(StorageServer* data, AddingShard* shard) {
 
 					if (conductBulkLoad) {
 						TraceEvent(SevInfo, "SSBulkLoadTaskFetchKey", data->thisServerID)
+						    .detail("FKID", interval.pairID)
 						    .detail("DataMoveId", dataMoveId.toString())
 						    .detail("Range", keys)
 						    .detail("BlockRange", blockRange)
@@ -9186,6 +9180,7 @@ ACTOR Future<Void> fetchKeys(StorageServer* data, AddingShard* shard) {
 						    data, KeyRangeRef(blockBegin, keys.end), shard->reason, shard->getSSBulkLoadMetadata()));
 						if (conductBulkLoad) {
 							TraceEvent(SevInfo, "SSBulkLoadTaskFetchKey", data->thisServerID)
+							    .detail("FKID", interval.pairID)
 							    .detail("DataMoveId", dataMoveId.toString())
 							    .detail("Range", keys)
 							    .detail("NewSplitBeginKey", blockBegin)
@@ -10679,7 +10674,7 @@ void changeServerKeys(StorageServer* data,
 		else {
 			ASSERT(ranges[i].value->adding);
 			data->addShard(ShardInfo::newAdding(
-			    data, ranges[i], ranges[i].value->adding->reason, ranges[i].value->getSSBulkLoadMetadata()));
+			    data, ranges[i], ranges[i].value->adding->reason, ranges[i].value->adding->getSSBulkLoadMetadata()));
 			CODE_PROBE(true, "ChangeServerKeys reFetchKeys");
 		}
 	}
@@ -11300,13 +11295,6 @@ private:
 				} else {
 					// add changes in shard assignment to the mutation log
 					setAssignedStatus(data, keys, nowAssigned);
-					if (conductBulkLoad) {
-						ASSERT(!emptyRange && dataMoveIdIsValidForBulkLoad(dataMoveId));
-						ASSERT(nowAssigned);
-					}
-					if (!nowAssigned) {
-						ASSERT(!conductBulkLoad);
-					}
 					SSBulkLoadMetadata bulkLoadMetadata(dataMoveId, conductBulkLoad);
 					setRangeBasedBulkLoadStatus(data, keys, bulkLoadMetadata);
 
@@ -13235,17 +13223,16 @@ void setRangeBasedBulkLoadStatus(StorageServer* self, KeyRangeRef keys, const SS
 	Version logV = self->data().getLatestVersion();
 	auto& mLV = self->addVersionToMutationLog(logV);
 	KeyRange dataMoveKeys = keys.withPrefix(persistBulkLoadTaskKeys.begin);
-	//TraceEvent("SetRangeBasedBulkLoadStatus", self->thisServerID).detail("Version", mLV.version).detail("RangeBegin", dataMoveKeys.begin).detail("RangeEnd", dataMoveKeys.end);
 	self->addMutationToMutationLog(mLV, MutationRef(MutationRef::ClearRange, dataMoveKeys.begin, dataMoveKeys.end));
 	++self->counters.kvSystemClearRanges;
 	self->addMutationToMutationLog(
 	    mLV, MutationRef(MutationRef::SetValue, dataMoveKeys.begin, ssBulkLoadMetadataValue(ssBulkLoadMetadata)));
 	if (keys.end != allKeys.end) {
-		SSBulkLoadMetadata endBulkLoadMetadata =
-		    self->shards.rangeContaining(keys.end)->value()->getSSBulkLoadMetadata();
+		SSBulkLoadMetadata endBulkLoadMetadata = self->ssBulkLoadMetadataMap.rangeContaining(keys.end)->value();
 		self->addMutationToMutationLog(
 		    mLV, MutationRef(MutationRef::SetValue, dataMoveKeys.end, ssBulkLoadMetadataValue(endBulkLoadMetadata)));
 	}
+	self->ssBulkLoadMetadataMap.insert(keys, ssBulkLoadMetadata);
 	if (BUGGIFY) {
 		self->maybeInjectTargetedRestart(logV);
 	}

--- a/fdbserver/workloads/BulkLoading.actor.cpp
+++ b/fdbserver/workloads/BulkLoading.actor.cpp
@@ -527,7 +527,7 @@ struct BulkLoading : TestWorkload {
 				Key beginKey = StringRef(indexStr);
 				Key endKey = StringRef(indexStrNext);
 				std::string folderPath = joinPath(simulationBulkLoadFolder, indexStr);
-				int dataSize = deterministicRandom()->randomInt(2, 5);
+				int dataSize = std::pow(10, deterministicRandom()->randomInt(0, 4));
 				BulkLoadTaskTestUnit taskUnit =
 				    self->generateBulkLoadTaskUnit(self, folderPath, dataSize, KeyRangeRef(beginKey, endKey));
 				bulkLoadTaskStates.push_back(taskUnit.bulkLoadTask);
@@ -625,7 +625,7 @@ struct BulkLoading : TestWorkload {
 		TraceEvent("BulkLoadingWorkLoadComplexTestSetMode").detail("OldMode", oldBulkLoadMode).detail("NewMode", 1);
 		for (; i < 3; i++) {
 			std::string folderPath = joinPath(simulationBulkLoadFolder, std::to_string(i));
-			int dataSize = deterministicRandom()->randomInt(2, 5);
+			int dataSize = std::pow(10, deterministicRandom()->randomInt(0, 4));
 			taskUnit = self->generateBulkLoadTaskUnit(self, folderPath, dataSize);
 			ASSERT(normalKeys.contains(taskUnit.bulkLoadTask.getRange()));
 			taskMap.insert(taskUnit.bulkLoadTask.getRange(), taskUnit);


### PR DESCRIPTION
**Problem 1**
Increase the bulkload workload to load upto 1000 keys. The probability of fetchKey split increases. Then, we can observe a data inconsistency bug. When a fetchKey splits, the fetchKey range can be partially marked as ReadWrite, which updates the storage server shard key range map. When the data move ends, the storage server will receive the second pair of serverKeys private mutation which updates the storage server bulkload map in the storage server local metadata. When updating the map, we may use the bulkload task value of the ReadWrite part boundary. However, the bulkload task information is not included in the ReadWrite shard. If the SS restarts at this point, SS forgets the existence of bulkload task on the range. As a result, the range can be partially load but mark the task as completed, resulting in data inconsistency.

To solve this problem, we create a dedicated key range map `ssBulkLoadMetadataMap` in the storage server to store the latest bulkload tasks on range.

**Problem 2**
Async file system has assertion failure when a bulkload actor read/write a file. This is caused by the actor cancellation happens in the middle of the file operation. This is a nice assertion to capture memory segfault bug.

To solve this problem, we use shared_ptr to hold the memory used by the read/write. When conducting read/write, we make it uncancellable and holding the shared_ptr when executing. As a result, the read/write actor keeps running when the parent bulkload actor is cancelled. When the parent is cancelled, the read/write actor still has the valid memory buffer because it holds the shared_ptr.

**Note that the usage of the shared_ptr in this PR has unnecessary memory copies. This PR just solves the simulation issues. There will be a separate PR to avoid memory copy using the shared_ptr.**

**Simulation tests**
500K BulkLoad Tests with 1 too many trace event error (will investigate later):
  20250308-170205-zhewang-6427891486cf5f7a           compressed=True data_size=40960530 duration=10738641 ended=500000 fail=1 fail_fast=10 max_runs=500000 pass=499999 priority=100 remaining=0 runtime=1:53:26 sanity=False started=500000 stopped=20250308-185531 submitted=20250308-170205 timeout=5400 username=zhewang
    
500K BulkDump Tests:
  20250308-181057-zhewang-9ecef02d00ce89fc           compressed=True data_size=40957942 duration=10039987 ended=500000 fail_fast=10 max_runs=500000 pass=500000 priority=100 remaining=0 runtime=1:44:06 sanity=False started=500000 stopped=20250308-195503 submitted=20250308-181057 timeout=5400 username=zhewang
  
100K correctness tests:
  20250308-225139-zhewang-7cf3a4d822abe571           compressed=True data_size=40920303 duration=5074987 ended=100000 fail=2 fail_fast=10 max_runs=100000 pass=99998 priority=100 remaining=0 runtime=1:27:10 sanity=False started=100000 stopped=20250309-001849 submitted=20250308-225139 timeout=5400 username=zhewang    
  
# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
