### PR TITLE
Set max_read_transaction_life_versions for KillRegionCycle.toml

### DIFF
--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -2004,8 +2004,10 @@ void addAccumulativeChecksumMutations(CommitBatchContext* self) {
 			    .detail("AcsIndex", acsIndex)
 			    .detail("AcsToSend", acsToSend.toString())
 			    .detail("Mutation", acsMutation)
+			    .detail("Version", self->commitVersion)
 			    .detail("CommitProxyIndex", self->pProxyCommitData->commitProxyIndex);
 		}
+		DEBUG_MUTATION("ProxyCommit", self->commitVersion, acsMutation, self->pProxyCommitData->dbgid);
 		self->toCommit.addTag(tag);
 		self->toCommit.writeTypedMessage(acsMutation);
 	}

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -12332,12 +12332,17 @@ ACTOR Future<Void> update(StorageServer* data, bool* pReceivedUpdate) {
 			proposedOldestVersion = std::max(proposedOldestVersion, data->desiredOldestVersion.get());
 			proposedOldestVersion = std::max(proposedOldestVersion, data->initialClusterVersion);
 
-			//TraceEvent("StorageServerUpdated", data->thisServerID).detail("Ver", ver).detail("DataVersion", data->version.get())
-			//	.detail("LastTLogVersion", data->lastTLogVersion).detail("NewOldest",
-			// data->oldestVersion.get()).detail("DesiredOldest",data->desiredOldestVersion.get())
-			//	.detail("MaxVersionInMemory", maxVersionsInMemory).detail("Proposed",
-			// proposedOldestVersion).detail("PrimaryLocality", data->primaryLocality).detail("Tag",
-			// data->tag.toString());
+			DisabledTraceEvent("StorageServerUpdated", data->thisServerID)
+			    .detail("Ver", ver)
+			    .detail("DataVersion", data->version.get())
+			    .detail("LastTLogVersion", data->lastTLogVersion)
+			    .detail("NewOldest", data->oldestVersion.get())
+			    .detail("DesiredOldest", data->desiredOldestVersion.get())
+			    .detail("MinKCV", cursor->getMinKnownCommittedVersion())
+			    .detail("MaxVersionInMemory", maxVersionsInMemory)
+			    .detail("Proposed", proposedOldestVersion)
+			    .detail("PrimaryLocality", data->primaryLocality)
+			    .detail("Tag", data->tag.toString());
 
 			while (!data->recoveryVersionSkips.empty() &&
 			       proposedOldestVersion > data->recoveryVersionSkips.front().first) {

--- a/tests/fast/KillRegionCycle.toml
+++ b/tests/fast/KillRegionCycle.toml
@@ -1,6 +1,9 @@
 [configuration]
 minimumRegions = 2
 
+[[knobs]]
+max_read_transaction_life_versions = 5000000
+
 [[test]]
 testTitle = 'KillRegionCycle'
 clearAfterTest = false


### PR DESCRIPTION
Simulation found an assertion failure in SS:
	ASSERT(rollbackVersion >= data->storageVersion());

The reason is that storage version is updated to a version larger than the forced recovery version, due to only 1'000'000 for max_read_transaction_life_versions. Also added debugging for cumulative checksum mutations.

See rdar://144550725

20250309-185039-jzhou-5145c65b0e8071b7             compressed=True data_size=35841048 duration=5476425 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:57:08 sanity=False started=100000 stopped=20250309-194747 submitted=20250309-185039 timeout=5400 username=jzhou

Replace this text with your description here...

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
