### PR TITLE
A Couple for Fixes for BulkDump and RangeLock

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -394,6 +394,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( DD_BULKDUMP_BUILD_JOB_MANIFEST_BATCH_SIZE,           10000 ); if( isSimulated ) DD_BULKDUMP_BUILD_JOB_MANIFEST_BATCH_SIZE = deterministicRandom()->randomInt(1, 100);
 	init( SS_SERVE_BULKDUMP_PARALLELISM,                           1 ); // TODO(BulkDump): Do not set to 1 after SS can resolve the file folder conflict
 	init( SS_BULKDUMP_BATCH_BYTES,                     100*1024*1024 ); if( isSimulated ) SS_BULKDUMP_BATCH_BYTES = deterministicRandom()->randomInt(1000, 10000);
+	init( SS_BULKDUMP_BATCH_COUNT_MAX_PER_REQUEST,                10 ); if( isSimulated ) SS_BULKDUMP_BATCH_COUNT_MAX_PER_REQUEST = deterministicRandom()->randomInt(1, 10);
 
 	// TeamRemover
 	init( TR_LOW_SPACE_PIVOT_DELAY_SEC,                            0 ); if (isSimulated) TR_LOW_SPACE_PIVOT_DELAY_SEC = deterministicRandom()->randomInt(0, 3);

--- a/fdbclient/include/fdbclient/ServerKnobs.h
+++ b/fdbclient/include/fdbclient/ServerKnobs.h
@@ -409,6 +409,7 @@ public:
 	                                              // between two rounds
 	int DD_BULKDUMP_BUILD_JOB_MANIFEST_BATCH_SIZE; // the number of lines in a batch when generating bulkload job
 	                                               // manifest file
+	int SS_BULKDUMP_BATCH_COUNT_MAX_PER_REQUEST; // the max number of batch count per bulkdump request to a SS
 	int BULKLOAD_ASYNC_READ_WRITE_BLOCK_SIZE; // the block size when performing async read/write for bulkload
 	bool CC_ENFORCE_USE_UNFIT_DD_IN_SIM; // Set for CC to enforce to use an unfit DD in the simulation. This knob takes
 	                                     // effect only in the simulation.

--- a/fdbserver/BulkLoadUtil.actor.cpp
+++ b/fdbserver/BulkLoadUtil.actor.cpp
@@ -47,9 +47,10 @@ ACTOR Future<Void> readBulkFileBytes(std::string path, int64_t maxLength, std::s
 		// Read in chunks to avoid memory pressure
 		state int64_t offset = 0;
 		state int64_t remaining = fileSize;
+		state std::shared_ptr<std::string> chunk = std::make_shared<std::string>();
 		while (remaining > 0) {
 			state int64_t bytesToRead = std::min(chunkSize, remaining);
-			state std::shared_ptr<std::string> chunk = std::make_shared<std::string>();
+			chunk->clear();
 			chunk->resize(bytesToRead);
 			state int bytesRead = wait(uncancellable(holdWhile(chunk, file->read(chunk->data(), bytesToRead, offset))));
 			if (bytesRead != bytesToRead) {

--- a/fdbserver/BulkLoadUtil.actor.cpp
+++ b/fdbserver/BulkLoadUtil.actor.cpp
@@ -61,11 +61,6 @@ ACTOR Future<Void> readBulkFileBytes(std::string path, int64_t maxLength, std::s
 			output->append(*chunk);
 			offset += bytesRead;
 			remaining -= bytesRead;
-
-			// Yield every 4 chunks to allow other actors to run
-			if (offset % (4 * chunkSize) == 0) {
-				wait(yield());
-			}
 		}
 		return Void();
 	} catch (Error& e) {
@@ -91,11 +86,6 @@ ACTOR Future<Void> writeBulkFileBytes(std::string path, std::shared_ptr<std::str
 			wait(uncancellable(holdWhile(content, file->write(content->data() + offset, bytesToWrite, offset))));
 			offset += bytesToWrite;
 			remaining -= bytesToWrite;
-
-			// Yield every 4 chunks to allow other actors to run
-			if (offset % (4 * chunkSize) == 0) {
-				wait(yield());
-			}
 		}
 
 		// Ensure the file size is correct and data is synced

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -6193,7 +6193,7 @@ ACTOR Future<Void> bulkDumpQ(StorageServer* data, BulkDumpRequest req) {
 
 			// Move to the next range
 			rangeBegin = keyAfter(rangeDumpRawData->lastKey);
-			if (rangeBegin >= rangeEnd) {
+			if (rangeBegin >= rangeEnd || batchNum >= SERVER_KNOBS->SS_BULKDUMP_BATCH_COUNT_MAX_PER_REQUEST) {
 				req.reply.send(req.bulkDumpState);
 				break;
 			}

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -6049,8 +6049,7 @@ ACTOR Future<Void> getRangeDataToDump(StorageServer* data,
 			break;
 		}
 
-		// Yield and go to the next round
-		wait(delay(0.1));
+		// Go to the next round
 		beginKey = keyAfter(output->lastKey);
 	}
 


### PR DESCRIPTION
This PR includes:
1. Fix range lock assertion failure due to operation_cancelled.
2. When SS receives a bulkdump request, it creates at most 10 batches for the request. To avoid a SS slows down the entire bulkdump progress. This can also increase the test coverage in the simulation.
3. When DDBulkDump scheduler finds a complete task, the scheduler should update the beginKey to avoid DDBulkDump scheduling stuck.

100K correctness:
  20250311-201413-zhewang-00f48817ad9f26a3           compressed=True data_size=40925829 duration=4732358 ended=100000 fail=4 fail_fast=10 max_runs=100000 pass=99996 priority=100 remaining=0 runtime=1:45:47 sanity=False started=100000 stopped=20250311-220000 submitted=20250311-201413 timeout=5400 username=zhewang
    
100K bulkdump:
  20250311-201502-zhewang-ab21b5b9543e18c2           compressed=True data_size=40968986 duration=2531622 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:03:30 sanity=False started=100000 stopped=20250311-211832 submitted=20250311-201502 timeout=5400 username=zhewang
      
100K range lock:
  20250311-201438-zhewang-ab762d5e9f1b2c8b           compressed=True data_size=40968361 duration=3217713 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:14:23 sanity=False started=100000 stopped=20250311-212901 submitted=20250311-201438 timeout=5400 username=zhewang
    
# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
