### PR TITLE
Adding rocksdb obsolete files size property in metrics.

### DIFF
--- a/fdbserver/KeyValueStoreRocksDB.actor.cpp
+++ b/fdbserver/KeyValueStoreRocksDB.actor.cpp
@@ -1127,6 +1127,7 @@ ACTOR Future<Void> rocksDBMetricLogger(UID id,
 		{ "BlockCacheUsage", rocksdb::DB::Properties::kBlockCacheUsage },
 		{ "BlockCachePinnedUsage", rocksdb::DB::Properties::kBlockCachePinnedUsage },
 		{ "LiveSstFilesSize", rocksdb::DB::Properties::kLiveSstFilesSize },
+		{ "ObsoleteSstFilesSize", rocksdb::DB::Properties::kObsoleteSstFilesSize },
 	};
 
 	state std::vector<std::pair<const char*, std::string>> strPropertyStats = {
@@ -2372,20 +2373,23 @@ struct RocksDBKeyValueStore : IKeyValueStore {
 	}
 
 	StorageBytes getStorageBytes() const override {
-		uint64_t live = 0;
-		ASSERT(db->GetAggregatedIntProperty(rocksdb::DB::Properties::kLiveSstFilesSize, &live));
+		uint64_t liveFilesSize = 0;
+		uint64_t obsoleteFilesSize = 0;
+		ASSERT(db->GetAggregatedIntProperty(rocksdb::DB::Properties::kLiveSstFilesSize, &liveFilesSize));
+		ASSERT(db->GetAggregatedIntProperty(rocksdb::DB::Properties::kObsoleteSstFilesSize, &obsoleteFilesSize));
 
 		int64_t free;
 		int64_t total;
 		g_network->getDiskBytes(path, free, total);
 
-		// Rocksdb metadata kLiveSstFilesSize is not deterministic so don't rely on it for simulation. Instead, we pick
-		// a sane value that is deterministically random.
+		// Rocksdb metadata kLiveSstFilesSize and kObsoleteSstFilesSize are not deterministic so don't rely on it for
+		// simulation. Instead, we pick a sane value that is deterministically random.
 		if (g_network->isSimulated()) {
-			live = (total - free) * deterministicRandom()->random01();
+			liveFilesSize = (total - free) * deterministicRandom()->random01();
+			obsoleteFilesSize = 0;
 		}
 
-		return StorageBytes(free, total, live, free);
+		return StorageBytes(free, total, liveFilesSize + obsoleteFilesSize, free);
 	}
 
 	Future<CheckpointMetaData> checkpoint(const CheckpointRequest& request) override {


### PR DESCRIPTION
Adding rocksdb obsolete files size property in metrics. Include it in the rocksd kv store used space.
cherry-pick of #11993

Simulation run:
20250311-221716-neethu-obsolete-c73da44d92e4befa   compressed=True data_size=55975135 duration=5953557 ended=100000 fail=6 fail_fast=10 max_runs=100000 pass=99994 priority=100 remaining=0 runtime=1:56:18 sanity=False started=100000 stopped=20250312-001334 submitted=20250311-221716 timeout=5400 username=neethu-obsolete
I don't see any errors in j tail.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
