### PR TITLE
Add replica comparison wrong_shard_server trace event

### DIFF
--- a/fdbrpc/include/fdbrpc/LoadBalance.actor.h
+++ b/fdbrpc/include/fdbrpc/LoadBalance.actor.h
@@ -392,6 +392,10 @@ Future<Void> replicaComparison(Req req,
 				// We must always propagate wrong_shard_server to the caller because it is signal to
 				// perform critical operations like invalidating the shard mapping cache.
 				if (replicaErrorCode == error_code_wrong_shard_server) {
+					TraceEvent(SevWarnAlways, "ReplicaComparisonReadError")
+					    .detail("TeamSize", restOfTeamFutures.size() + 1)
+					    .detail("RequiredReplies", requiredReplicas)
+					    .detail("SSError", error_code_wrong_shard_server);
 					throw wrong_shard_server();
 				}
 			}

--- a/fdbrpc/include/fdbrpc/LoadBalance.actor.h
+++ b/fdbrpc/include/fdbrpc/LoadBalance.actor.h
@@ -393,6 +393,7 @@ Future<Void> replicaComparison(Req req,
 				// perform critical operations like invalidating the shard mapping cache.
 				if (replicaErrorCode == error_code_wrong_shard_server) {
 					TraceEvent(SevWarnAlways, "ReplicaComparisonReadError")
+					    .suppressFor(1.0)
 					    .detail("TeamSize", restOfTeamFutures.size() + 1)
 					    .detail("RequiredReplies", requiredReplicas)
 					    .detail("SSError", error_code_wrong_shard_server);


### PR DESCRIPTION
As title. This is useful for debugging.

100K: `20250311-235946-praza-wrongshard-trace-b53b275e154e2928a5594 compressed=True data_size=36820573 duration=7094906 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:00:49 sanity=False started=100000 stopped=20250312-010035 submitted=20250311-235946 timeout=5400 username=praza-wrongshard-trace-b53b275e154e2928a5594df9ffde95d99686bdab`

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
