### PR TITLE
ENABLE_VERSION_VECTOR_REPLY_RECOVERY can be T only if ENABLE_VERSION_VECTOR_TLOG_UNICAST is T

### DIFF
--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -1825,9 +1825,9 @@ Future<Void> tLogPeekMessages(PromiseType replyPromise,
 	//   - If a valid 'end' version was provided in the request (the Recovery Version), return with that version.
 	//   - Otherwise, wait for new data as long as the tLog isn't locked.
 	state Optional<Version> replyWithRecoveryVersion = Optional<Version>();
-	ASSERT(!SERVER_KNOBS->ENABLE_VERSION_VECTOR_REPLY_RECOVERY || SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST);
+	ASSERT(!SERVER_KNOBS->ENABLE_VERSION_VECTOR_REPLY_RECOVERY || SERVER_KNOBS->ENABLE_VERSION_VECTOR);
 	if (logData->version.get() < reqBegin) {
-		if (SERVER_KNOBS->ENABLE_VERSION_VECTOR_REPLY_RECOVERY && SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST &&
+		if (SERVER_KNOBS->ENABLE_VERSION_VECTOR_REPLY_RECOVERY && SERVER_KNOBS->ENABLE_VERSION_VECTOR &&
 		    logData->stopped() && reqEnd.present() && reqEnd.get() != std::numeric_limits<Version>::max()) {
 			replyWithRecoveryVersion = reqEnd;
 		} else if (reqReturnIfBlocked) {

--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -1825,9 +1825,10 @@ Future<Void> tLogPeekMessages(PromiseType replyPromise,
 	//   - If a valid 'end' version was provided in the request (the Recovery Version), return with that version.
 	//   - Otherwise, wait for new data as long as the tLog isn't locked.
 	state Optional<Version> replyWithRecoveryVersion = Optional<Version>();
+	ASSERT(!SERVER_KNOBS->ENABLE_VERSION_VECTOR_REPLY_RECOVERY || SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST);
 	if (logData->version.get() < reqBegin) {
-		if (SERVER_KNOBS->ENABLE_VERSION_VECTOR_REPLY_RECOVERY && logData->stopped() && reqEnd.present() &&
-		    reqEnd.get() != std::numeric_limits<Version>::max()) {
+		if (SERVER_KNOBS->ENABLE_VERSION_VECTOR_REPLY_RECOVERY && SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST &&
+		    logData->stopped() && reqEnd.present() && reqEnd.get() != std::numeric_limits<Version>::max()) {
 			replyWithRecoveryVersion = reqEnd;
 		} else if (reqReturnIfBlocked) {
 			replyPromise.sendError(end_of_stream());


### PR DESCRIPTION
`ENABLE_VERSION_VECTOR_REPLY_RECOVERY` can be true only if `ENABLE_VERSION_VECTOR_TLOG_UNICAST` is true. There are some tests which set `ENABLE_VERSION_VECTOR_TLOG_UNICAST` to true (`tests/fast/RawTenantAccessClean.toml`) and it should not be necessary to set `ENABLE_VERSION_VECTOR_REPLY_RECOVERY` for each of those tests individually. 

Joshua:
`20250312-192846-dlambrig-13074ff7154a31fc `

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
