### PR TITLE
Persist BulkLoad Task Count in BulkLoadJob Metadata

### DIFF
--- a/fdbclient/include/fdbclient/BulkLoading.h
+++ b/fdbclient/include/fdbclient/BulkLoading.h
@@ -694,6 +694,9 @@ public:
 		                  ", [TransportMethod]: " + std::to_string(static_cast<uint8_t>(transportMethod));
 		res = res + ", [SubmitTime]: " + std::to_string(submitTime);
 		res = res + ", [SinceSubmitMins]: " + std::to_string((now() - submitTime) / 60.0);
+		if (taskCount.present()) {
+			res = res + ", [TaskCount]: " + std::to_string(taskCount.get());
+		}
 		return res;
 	}
 
@@ -715,6 +718,10 @@ public:
 
 	double getEndTime() const { return endTime; }
 
+	void setTaskCount(uint64_t count) { taskCount = count; }
+
+	Optional<uint64_t> getTaskCount() const { return taskCount; }
+
 	bool isMetadataValid() const {
 		if (!jobId.isValid()) {
 			return false;
@@ -735,7 +742,7 @@ public:
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, jobId, jobRange, transportMethod, jobRoot, phase, submitTime, endTime);
+		serializer(ar, jobId, jobRange, transportMethod, jobRoot, phase, submitTime, endTime, taskCount);
 	}
 
 private:
@@ -749,6 +756,7 @@ private:
 	BulkLoadJobPhase phase;
 	double submitTime = 0;
 	double endTime = 0;
+	Optional<uint64_t> taskCount;
 };
 
 // Define the bulkload job manifest file header
@@ -877,6 +885,8 @@ private:
 	Version version;
 	size_t bytes;
 };
+
+using BulkLoadManifestFileMap = std::unordered_map<Key, BulkLoadJobFileManifestEntry>;
 
 bool dataMoveIdIsValidForBulkLoad(const UID& dataMoveId);
 

--- a/fdbserver/include/fdbserver/BulkLoadUtil.actor.h
+++ b/fdbserver/include/fdbserver/BulkLoadUtil.actor.h
@@ -67,8 +67,11 @@ ACTOR Future<Void> downloadBulkLoadJobManifestFile(BulkLoadTransportMethod trans
                                                    UID logId);
 
 // Extract manifest entries from job manifest file with the input range
-ACTOR Future<std::unordered_map<Key, BulkLoadJobFileManifestEntry>>
-getBulkLoadJobFileManifestEntryFromJobManifestFile(std::string localJobManifestFilePath, KeyRange range, UID logId);
+ACTOR Future<Void> getBulkLoadJobFileManifestEntryFromJobManifestFile(
+    std::string localJobManifestFilePath,
+    KeyRange range,
+    UID logId,
+    std::shared_ptr<BulkLoadManifestFileMap> manifestMap);
 
 // Get BulkLoad manifest metadata from the entry in the job manifest file
 ACTOR Future<BulkLoadManifest> getBulkLoadManifestMetadataFromEntry(BulkLoadJobFileManifestEntry manifestEntry,


### PR DESCRIPTION
This PR includes:
1. Persist bulkload taskCount in the job metadata so that the user can check the progress using fdbcli.
2. Avoid memory copy when a BulkLoadJob loads bulkload job-manifest.txt.

100K BulkDump Test:
  20250312-193056-zhewang-3017858d2af6ea7f           compressed=True data_size=40967788 fail_fast=10 max_runs=100000 priority=100 sanity=False submitted=20250312-193056 timeout=5400 username=zhewang

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
