### PR TITLE
Add Error Message To BulkLoadJob Metadata

### DIFF
--- a/fdbcli/BulkLoadCommand.actor.cpp
+++ b/fdbcli/BulkLoadCommand.actor.cpp
@@ -43,6 +43,10 @@ ACTOR Future<Void> printPastBulkLoadJob(Database cx) {
 		             job.getJobRange().toString(),
 		             std::to_string((job.getEndTime() - job.getSubmitTime()) / 60.0),
 		             convertBulkLoadJobPhaseToString(job.getPhase()));
+		if (job.getPhase() == BulkLoadJobPhase::Error) {
+			Optional<std::string> errorMessage = job.getErrorMessage();
+			fmt::println("Error message: {}", errorMessage.present() ? errorMessage.get() : "Not provided.");
+		}
 	}
 	return Void();
 }

--- a/fdbclient/BulkLoading.cpp
+++ b/fdbclient/BulkLoading.cpp
@@ -153,6 +153,16 @@ std::string getBulkLoadJobRoot(const std::string& root, const UID& jobId) {
 	return appendToPath(root, jobId.toString());
 }
 
+std::string convertBulkLoadTransportMethodToString(BulkLoadTransportMethod method) {
+	if (method == BulkLoadTransportMethod::CP) {
+		return "Local file copy";
+	} else if (method == BulkLoadTransportMethod::BLOBSTORE) {
+		return "Blob store";
+	} else {
+		UNREACHABLE();
+	}
+}
+
 // For submitting a task manually (for testing)
 BulkLoadTaskState createBulkLoadTask(const UID& jobId,
                                      const KeyRange& range,

--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -3188,7 +3188,7 @@ ACTOR Future<Void> cancelBulkLoadJob(Database cx, UID jobId) {
 			                           bulkLoadTaskStateValue(BulkLoadTaskState())));
 			// Add cancelled job to history
 			aliveJob.get().setEndTime(now());
-			aliveJob.get().setPhase(BulkLoadJobPhase::Cancelled);
+			aliveJob.get().setCancelledPhase();
 			wait(addBulkLoadJobToHistory(&tr, aliveJob.get()));
 			wait(tr.commit());
 			break;

--- a/fdbserver/BulkLoadUtil.actor.cpp
+++ b/fdbserver/BulkLoadUtil.actor.cpp
@@ -311,7 +311,6 @@ ACTOR Future<BulkLoadFileSet> bulkLoadDownloadTaskFileSet(BulkLoadTransportMetho
 			} else {
 				UNREACHABLE();
 			}
-			// TODO(BulkLoad): Check file checksum
 			TraceEvent(SevInfo, "SSBulkLoadTaskDownloadFileSet", logId)
 			    .setMaxEventLength(-1)
 			    .setMaxFieldLength(-1)
@@ -419,7 +418,7 @@ ACTOR Future<Void> getBulkLoadJobFileManifestEntryFromJobManifestFile(
 		TraceEvent(SevError, "ManifestFileTooBig", logId)
 		    .detail("FileSize", fileSize)
 		    .detail("MaxSize", SERVER_KNOBS->BULKLOAD_FILE_BYTES_MAX);
-		throw file_too_large(); // TODO(BulkLoad): handle this unretrievable error
+		throw file_too_large();
 	}
 
 	state int64_t chunkSize = 64 * 1024; // 64KB chunks
@@ -438,7 +437,7 @@ ACTOR Future<Void> getBulkLoadJobFileManifestEntryFromJobManifestFile(
 				TraceEvent(SevError, "ReadFileError", logId)
 				    .detail("BytesRead", bytesRead)
 				    .detail("BytesExpected", bytesToRead);
-				throw io_error(); // TODO(BulkLoad): handle this unretrievable error
+				throw io_error();
 			}
 
 			// Process the chunk line by line

--- a/fdbserver/DDTeamCollection.actor.cpp
+++ b/fdbserver/DDTeamCollection.actor.cpp
@@ -259,7 +259,6 @@ public:
 					for (const auto& serverId : serverIds) {
 						if (serverId == srcId) {
 							ok = false; // Do not select a team that has a server owning the bulk loading range.
-							// TODO(BulkLoad): remove this later. Require the support in SS.
 							break;
 						}
 					}

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -1710,7 +1710,8 @@ ACTOR Future<Void> moveErrorBulkLoadJobToHistory(Reference<DataDistributor> self
 }
 
 // Download the job manifest file from the remoteJobManifestFilePath to the localJobManifestFilePath.
-// If the download failed, we mark the job metadata as error and move the metadata to the history.
+// Build the bulkload manifest range map based on the localJobManifestFilePath file content.
+// For any failure, we mark the job metadata as error and move the metadata to the history.
 ACTOR Future<Void> fetchBulkLoadTaskManifestEntryMap(Reference<DataDistributor> self,
                                                      BulkLoadTransportMethod jobTransportMethod,
                                                      std::string localJobManifestFilePath,


### PR DESCRIPTION
This PR includes:
1. Add error message to the bulkload job metadata;
2. Persist error message for failures when building the job manifest map from a remote path;
3. Add FDBCLI support to print the error message;
4. Clear TODO(BulkLoad) comments.

Error message output when doing `bulkload history`:
```
fdb> bulkload history
Job 3216165d7553b74024f7c2bcba1466a0 submitted at 1741825798.148600 for range { begin=  end=\xff }. The job ran for 0.898142 mins and exited with status Error.
Error message: Failed to build job-manifest map with error code 1511. The remote file path is /root/3216165d7553b74024f7c2bcba1466a0/job-manifest.txt. The local file path is /root/build_output/loopback-cluster/1/data/ddBulkLoadFiles/3216165d7553b74024f7c2bcba1466a0/job-manifest.txt. The transport method is Local file copy.
```

100K correctness:
  20250313-002751-zhewang-e9af25b42ee99490           compressed=True data_size=40950431 duration=4843704 ended=100000 fail=2 fail_fast=10 max_runs=100000 pass=99998 priority=100 remaining=0 runtime=0:49:53 sanity=False started=100000 stopped=20250313-011744 submitted=20250313-002751 timeout=5400 username=zhewang
    
100K bulkdump tests:
  20250313-002816-zhewang-b6ccc27246bc9513           compressed=True data_size=40990296 duration=2345314 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:34:56 sanity=False started=100000 stopped=20250313-010312 submitted=20250313-002816 timeout=5400 username=zhewang
  
# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
