### PR TITLE
Change backup worker memory accounting to use message sizes

### DIFF
--- a/fdbclient/include/fdbclient/FDBTypes.h
+++ b/fdbclient/include/fdbclient/FDBTypes.h
@@ -186,11 +186,11 @@ struct TagsAndMessage {
 	}
 
 	// Returns the size of the header, including: msg_length, version.sub, tag_count, tags.
-	int32_t getHeaderSize() const {
-		return sizeof(int32_t) + sizeof(uint32_t) + sizeof(uint16_t) + tags.size() * sizeof(Tag);
+	static int32_t getHeaderSize(int numTags) {
+		return sizeof(int32_t) + sizeof(uint32_t) + sizeof(uint16_t) + numTags * sizeof(Tag);
 	}
 
-	StringRef getMessageWithoutTags() const { return message.substr(getHeaderSize()); }
+	StringRef getMessageWithoutTags() const { return message.substr(getHeaderSize(tags.size())); }
 
 	// Returns the message with the header.
 	StringRef getRawMessage() const { return message; }

--- a/fdbserver/BackupWorker.actor.cpp
+++ b/fdbserver/BackupWorker.actor.cpp
@@ -42,9 +42,6 @@
 
 #define SevDebugMemory SevVerbose
 
-// Based on TagsAndMessage::getHeaderSize(): assume 6 tags.
-#define MessageOverheadBytes (sizeof(int32_t) + sizeof(uint32_t) + sizeof(uint16_t) + 6 * sizeof(Tag))
-
 struct VersionedMessage {
 	LogMessageVersion version;
 	StringRef message;
@@ -56,7 +53,8 @@ struct VersionedMessage {
 	  : version(v), message(m), tags(t), arena(a) {}
 	Version getVersion() const { return version.version; }
 	uint32_t getSubVersion() const { return version.sub; }
-	size_t getEstimatedSize() const { return message.size() + MessageOverheadBytes; }
+	// Returns the estimated size of the message in bytes, assuming 6 tags.
+	size_t getEstimatedSize() const { return message.size() + TagsAndMessage::getHeaderSize(6); }
 
 	// Returns true if the message is a mutation that could be backed up (normal keys, system key backup ranges, or the
 	// metadata version key)

--- a/fdbserver/LogSystemPeekCursor.actor.cpp
+++ b/fdbserver/LogSystemPeekCursor.actor.cpp
@@ -149,7 +149,7 @@ void ILogSystem::ServerPeekCursor::nextMessage() {
 	DEBUG_TAGS_AND_MESSAGE("ServerPeekCursor", messageVersion.version, messageAndTags.getRawMessage(), this->randomID);
 	// Rewind and consume the header so that reader() starts from the message.
 	rd.rewind();
-	rd.readBytes(messageAndTags.getHeaderSize());
+	rd.readBytes(TagsAndMessage::getHeaderSize(messageAndTags.tags.size()));
 	hasMsg = true;
 	DebugLogTraceEvent("SPC_NextMessageB", randomID)
 	    .detail("Tag", tag.toString())
@@ -165,7 +165,8 @@ StringRef ILogSystem::ServerPeekCursor::getMessage() {
 
 StringRef ILogSystem::ServerPeekCursor::getMessageWithTags() {
 	StringRef rawMessage = messageAndTags.getRawMessage();
-	rd.readBytes(rawMessage.size() - messageAndTags.getHeaderSize()); // Consumes the message.
+	rd.readBytes(rawMessage.size() -
+	             TagsAndMessage::getHeaderSize(messageAndTags.tags.size())); // Consumes the message.
 	return rawMessage;
 }
 


### PR DESCRIPTION
Previously I used arena size for accouting, which has problems such as arena memory usage changes and arena memory block circular reference. And we are acquiring flow lock multiple times, even though the cursor has already fetched data into memory.

This change simplifies the accounting to just use message sizes, reducing the number of flow lock acquisitions.

 20250319-002950-jzhou-a9ecc09dd1c8812a             compressed=True data_size=53104759 duration=4787313 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:49:48 sanity=False started=100000 stopped=20250319-011938 submitted=20250319-002950 timeout=5400 username=jzhou

20250313-220439-jzhou-95096a8b4f3411fa             compressed=True data_size=36851302 duration=4408042 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:11:59 sanity=False started=100000 stopped=20250313-231638 submitted=20250313-220439 timeout=5400 username=jzhou

20250313-041908-jzhou-279c3b77def4d408             compressed=True data_size=35853736 duration=6006710 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:08:17 sanity=False started=100000 stopped=20250313-052725 submitted=20250313-041908 timeout=5400 username=jzhou

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
