### PR TITLE
Initialize lastShardMove for recovery txn and in CommitBatchContext

### DIFF
--- a/fdbserver/ClusterRecovery.actor.cpp
+++ b/fdbserver/ClusterRecovery.actor.cpp
@@ -1335,7 +1335,7 @@ ACTOR Future<Void> sendInitialCommitToResolvers(Reference<ClusterRecoveryData> s
 		req.prevVersion = -1;
 		req.version = self->lastEpochEnd;
 		req.lastReceivedVersion = -1;
-
+		req.lastShardMove = -1;
 		replies.push_back(brokenPromiseToNever(r.resolve.getReply(req)));
 	}
 

--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -877,7 +877,7 @@ CommitBatchContext::CommitBatchContext(ProxyCommitData* const pProxyCommitData_,
     currentBatchMemBytesCount(currentBatchMemBytesCount), startTime(g_network->now()),
     localBatchNumber(++pProxyCommitData->localCommitBatchesStarted),
     toCommit(pProxyCommitData->logSystem, pProxyCommitData->localTLogCount), span("MP:commitBatch"_loc),
-    committed(trs.size()) {
+    committed(trs.size()), lastShardMove(invalidVersion) {
 
 	evaluateBatchSize();
 


### PR DESCRIPTION
# Description

In https://github.com/apple/foundationdb/pull/11977/, we added `lastShardMove` to `ResolverInterface::ResolveTransactionBatchRequest`. So this field gets serialized and sent over the network, and we have a valgrind check in `sendPackets`: https://github.com/apple/foundationdb/blob/95319e4d766d2adaebbe0fafb11bed21e2f9ddb1/fdbrpc/FlowTransport.actor.cpp#L2032-L2040

This valgrind check fails for almost all our simulation tests. It's because in some instances, `lastShardMove` is not initialized:
1. As part of recovery, CC makes a recovery txn and in the process sends a `ResolveTransactionBatchRequest`. Here, we were not initializing `lastShardMove`.  To fix this, before sending the RPC, I initialize `lastShardMove` field similar to other fields.
2. In `CommitBatchContext`, we added `lastShardMove`, which gets initialized to -1 (invalidVersion) as part of `getWrittenTagsPreResolution`, but `getWrittenTagsPreResolution` is not called if `ENABLE_VERSION_VECTOR_TLOG_UNICAST` is false. In this case, we don't initialize `lastShardMove` either. To fix this, I default initialize `lastShardMove` in `CommitBatchContext` constructor. 

# Testing

1. Reran some of the failing test under valgrind again. Do not see `Uninitialised byte(s) found during client check request` anymore.
2. 100K correctness: ``. <TODO>

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
