### PR TITLE
Fix use-after-move issue in AsyncTaskExecutor

### DIFF
--- a/flow/IThreadPoolTest.actor.cpp
+++ b/flow/IThreadPoolTest.actor.cpp
@@ -229,6 +229,18 @@ TEST_CASE("/flow/IThreadPool/ThreadReturnPromiseStream_DestroyPromise") {
 	return Void();
 }
 
+// FIXME: Someday fix ThreadReturnPromise for this testcase.
+// TEST_CASE("/flow/IThreadPool/ThreadReturnPromiseGetFutureAfterSend") {
+// 	auto get_f = [&]() {
+// 		ThreadReturnPromise<int> p;
+// 		p.send(1234);
+// 		return p.getFuture();
+// 	};
+// 	int res = wait(get_f());
+// 	ASSERT_EQ(res, 1234);
+// 	return Void();
+// }
+
 #else
 void forceLinkIThreadPoolTests() {}
 #endif

--- a/flow/include/flow/IThreadPool.h
+++ b/flow/include/flow/IThreadPool.h
@@ -91,7 +91,12 @@ public:
 			sendError(broken_promise());
 	}
 
-	Future<T> getFuture() const { // Call only on the originating thread!
+	// NOTE:
+	// - Call only on the originating thread.
+	// - Must be called before `send` or `sendError`. Will result into crash otherwise, since
+	//   tagAndForward() will take ownership of underlying promise.
+	Future<T> getFuture() const {
+		ASSERT(isValid());
 		return promise.getFuture();
 	}
 


### PR DESCRIPTION
`getFuture()` should be called before post as `send`/`sendError` operation in `ThreadReturnPromise` moves the underlying Promise to `tagAndForward()`.

Ideally, `ThreadReturnPromise` behaviour should stay consistent with the `Promise`. However, the problem is that it relies on the invariant that there will always be one owner of its internal `Promise` which is either itself or `tagOrForward`  -- which is necessary to ensure that only one thread can operate on the Promise's internal state (ref count, flags etc) and avoid race conditions.

This patch (1) makes sure that in case of `post()` function we get future before, (2) adds an ASSERT as this should never happen, (3) documentation for future users and (4) a test case for potentially fixing this in future.

Correctness:

  20250314-064839-vishesh-746b2b3d56ffe7b3           compressed=True data_size=40953505 duration=5646448 ended=100000 fail=1 fail_fast=10 max_runs=100000 pass=99999 priority=100 remaining=0 runtime=0:58:31 sanity=False started=100000 stopped=20250314-074710 submitted=20250314-064839 timeout=5400 username=vishesh

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
