### PR TITLE
Disable enable_version_vector_reply_recovery in tests disabling version vector.

### DIFF
--- a/tests/fast/BulkDumping.toml
+++ b/tests/fast/BulkDumping.toml
@@ -20,6 +20,7 @@ enable_read_lock_on_range = true
 # Do not support version vector
 enable_version_vector = false
 enable_version_vector_tlog_unicast = false
+enable_version_vector_reply_recovery = false
 
 # Set high enough sample rate to test bytes sampling
 min_byte_sampling_probability = 0.5

--- a/tests/fast/BulkLoading.toml
+++ b/tests/fast/BulkLoading.toml
@@ -20,6 +20,7 @@ enable_read_lock_on_range = true
 # Do not support version vector
 enable_version_vector = false
 enable_version_vector_tlog_unicast = false
+enable_version_vector_reply_recovery = false
 
 # Set high enough sample rate to test bytes sampling
 min_byte_sampling_probability = 0.5

--- a/tests/fast/RangeLockCycle.toml
+++ b/tests/fast/RangeLockCycle.toml
@@ -6,6 +6,7 @@ encryptModes = ['disabled'] # do not support encryption
 enable_read_lock_on_range = true
 enable_version_vector = false
 enable_version_vector_tlog_unicast = false
+enable_version_vector_reply_recovery = false
 
 [[test]]
 testTitle = 'RangeLockCycle'

--- a/tests/fast/RangeLocking.toml
+++ b/tests/fast/RangeLocking.toml
@@ -7,6 +7,7 @@ enable_read_lock_on_range = true
 transaction_lock_rejection_retriable = false
 enable_version_vector = false
 enable_version_vector_tlog_unicast = false
+enable_version_vector_reply_recovery = false
 
 [[test]]
 testTitle = 'RangeLocking'

--- a/tests/fast/RawTenantAccessClean.toml
+++ b/tests/fast/RawTenantAccessClean.toml
@@ -7,6 +7,7 @@ allowCreatingTenants = false
 proxy_use_resolver_private_mutations = false
 enable_version_vector = false
 enable_version_vector_tlog_unicast = false
+enable_version_vector_reply_recovery = false
 
 [[test]]
 testTitle = 'RawTenantAccessClean'

--- a/tests/negative/ResolverIgnoreTooOld.toml
+++ b/tests/negative/ResolverIgnoreTooOld.toml
@@ -1,5 +1,8 @@
 [[knobs]]
 enable_version_vector = false
+enable_version_vector_tlog_unicast = false
+enable_version_vector_reply_recovery = false
+
 max_read_transaction_life_versions = 1000000
 max_write_transaction_life_versions = 1000000
 


### PR DESCRIPTION
Disable enable_version_vector_reply_recovery in tests that disable the version vector feature.

This knob will eventually be removed once version vector testing is completed.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
