### PR TITLE
Add Verbose Level for BulkLoad Trace Events

### DIFF
--- a/fdbclient/ClientKnobs.cpp
+++ b/fdbclient/ClientKnobs.cpp
@@ -202,6 +202,8 @@ void ClientKnobs::initialize(Randomize randomize) {
 	init( ENABLE_REPLICA_CONSISTENCY_CHECK_ON_BACKUP_READS, true );
 	init( CONSISTENCY_CHECK_REQUIRED_REPLICAS,      -2 ); // Do consistency check based on all available storage replicas
 	init( BULKLOAD_JOB_HISTORY_COUNT_MAX,           10 ); if (randomize && BUGGIFY) BULKLOAD_JOB_HISTORY_COUNT_MAX = deterministicRandom()->randomInt(1, 10);
+	init( BULKLOAD_VERBOSE_LEVEL,                   10 );
+	init( S3CLIENT_VERBOSE_LEVEL,                   10 );
 
 	// Configuration
 	init( DEFAULT_AUTO_COMMIT_PROXIES,               3 );

--- a/fdbclient/S3Client.actor.cpp
+++ b/fdbclient/S3Client.actor.cpp
@@ -197,7 +197,7 @@ ACTOR static Future<Void> copyUpFile(Reference<S3BlobStoreEndpoint> endpoint,
 	state int64_t size = fileSize(filepath);
 
 	try {
-		TraceEvent(SevInfo, "S3ClientCopyUpFileStart")
+		TraceEvent(s3VerboseEventSev(), "S3ClientCopyUpFileStart")
 		    .detail("Filepath", filepath)
 		    .detail("Bucket", bucket)
 		    .detail("ObjectName", objectName)
@@ -283,7 +283,7 @@ ACTOR static Future<Void> copyUpFile(Reference<S3BlobStoreEndpoint> endpoint,
 		tags[S3_CHECKSUM_TAG_NAME] = checksum;
 		wait(endpoint->putObjectTags(bucket, objectName, tags));
 
-		TraceEvent(SevInfo, "S3ClientCopyUpFileEnd")
+		TraceEvent(s3PerfEventSev(), "S3ClientCopyUpFileEnd")
 		    .detail("Bucket", bucket)
 		    .detail("ObjectName", objectName)
 		    .detail("FileSize", size)
@@ -331,7 +331,7 @@ ACTOR Future<Void> copyUpDirectory(std::string dirpath, std::string s3url) {
 	state std::string bucket = parameters["bucket"];
 	state std::vector<std::string> files;
 	platform::findFilesRecursively(dirpath, files);
-	TraceEvent("S3ClientUploadDirStart")
+	TraceEvent(s3VerboseEventSev(), "S3ClientUploadDirStart")
 	    .detail("Filecount", files.size())
 	    .detail("Bucket", bucket)
 	    .detail("Resource", resource);
@@ -340,7 +340,7 @@ ACTOR Future<Void> copyUpDirectory(std::string dirpath, std::string s3url) {
 		std::string s3path = resource + "/" + file.substr(dirpath.size() + 1);
 		wait(copyUpFile(endpoint, bucket, s3path, filepath));
 	}
-	TraceEvent("S3ClientUploadDirEnd").detail("Bucket", bucket).detail("Resource", resource);
+	TraceEvent(s3VerboseEventSev(), "S3ClientUploadDirEnd").detail("Bucket", bucket).detail("Resource", resource);
 	return Void();
 }
 
@@ -351,7 +351,7 @@ ACTOR Future<Void> copyUpBulkDumpFileSet(std::string s3url,
 	S3BlobStoreEndpoint::ParametersT parameters;
 	state Reference<S3BlobStoreEndpoint> endpoint = getEndpoint(s3url, resource, parameters);
 	state std::string bucket = parameters["bucket"];
-	TraceEvent("S3ClientCopyUpBulkDumpFileSetStart")
+	TraceEvent(s3VerboseEventSev(), "S3ClientCopyUpBulkDumpFileSetStart")
 	    .detail("Bucket", bucket)
 	    .detail("SourceFileSet", sourceFileSet.toString())
 	    .detail("DestinationFileSet", destinationFileSet.toString());
@@ -375,7 +375,7 @@ ACTOR Future<Void> copyUpBulkDumpFileSet(std::string s3url,
 		auto destinationByteSamplePath = joinPath(batch_dir, destinationFileSet.getByteSampleFileName());
 		wait(copyUpFile(endpoint, bucket, destinationByteSamplePath, sourceFileSet.getBytesSampleFileFullPath()));
 	}
-	TraceEvent("S3ClientCopyUpBulkDumpFileSetEnd")
+	TraceEvent(s3VerboseEventSev(), "S3ClientCopyUpBulkDumpFileSetEnd")
 	    .detail("BatchDir", batch_dir)
 	    .detail("NumDeleted", pNumDeleted)
 	    .detail("BytesDeleted", pBytesDeleted);
@@ -469,7 +469,7 @@ ACTOR static Future<Void> copyDownFile(Reference<S3BlobStoreEndpoint> endpoint,
 	state std::string expectedChecksum;
 
 	try {
-		TraceEvent(SevInfo, "S3ClientCopyDownFileStart")
+		TraceEvent(s3VerboseEventSev(), "S3ClientCopyDownFileStart")
 		    .detail("Bucket", bucket)
 		    .detail("Object", objectName)
 		    .detail("FilePath", filepath);
@@ -549,7 +549,7 @@ ACTOR static Future<Void> copyDownFile(Reference<S3BlobStoreEndpoint> endpoint,
 		// Close file properly
 		file = Reference<IAsyncFile>();
 
-		TraceEvent(SevInfo, "S3ClientCopyDownFileEnd")
+		TraceEvent(s3VerboseEventSev(), "S3ClientCopyDownFileEnd")
 		    .detail("Bucket", bucket)
 		    .detail("Object", objectName)
 		    .detail("FileSize", fileSize)
@@ -597,7 +597,7 @@ ACTOR Future<Void> copyDownDirectory(std::string s3url, std::string dirpath) {
 	state std::string bucket = parameters["bucket"];
 	S3BlobStoreEndpoint::ListResult items = wait(endpoint->listObjects(bucket, resource));
 	state std::vector<S3BlobStoreEndpoint::ObjectInfo> objects = items.objects;
-	TraceEvent("S3ClientDownDirectoryStart")
+	TraceEvent(s3VerboseEventSev(), "S3ClientDownDirectoryStart")
 	    .detail("Filecount", objects.size())
 	    .detail("Bucket", bucket)
 	    .detail("Resource", resource);
@@ -606,7 +606,7 @@ ACTOR Future<Void> copyDownDirectory(std::string s3url, std::string dirpath) {
 		std::string s3path = object.name;
 		wait(copyDownFile(endpoint, bucket, s3path, filepath));
 	}
-	TraceEvent("S3ClientDownDirectoryEnd").detail("Bucket", bucket).detail("Resource", resource);
+	TraceEvent(s3VerboseEventSev(), "S3ClientDownDirectoryEnd").detail("Bucket", bucket).detail("Resource", resource);
 	return Void();
 }
 

--- a/fdbclient/include/fdbclient/BulkLoading.h
+++ b/fdbclient/include/fdbclient/BulkLoading.h
@@ -29,7 +29,18 @@
 #pragma once
 
 #include "fdbclient/FDBTypes.h"
+#include "fdbclient/Knobs.h"
 #include "fdbrpc/fdbrpc.h"
+
+// For all trace events for bulkload/dump operations
+inline Severity bulkLoadVerboseEventSev() {
+	return !g_network->isSimulated() && CLIENT_KNOBS->BULKLOAD_VERBOSE_LEVEL >= 10 ? SevInfo : SevDebug;
+}
+
+// For all trace events measuring the performance of bulkload/dump operations
+inline Severity bulkLoadPerfEventSev() {
+	return !g_network->isSimulated() && CLIENT_KNOBS->BULKLOAD_VERBOSE_LEVEL >= 5 ? SevInfo : SevDebug;
+}
 
 const std::string bulkLoadJobManifestLineTerminator = "\n";
 
@@ -269,7 +280,7 @@ public:
 			    .detail("FileSet", toString());
 			throw bulkload_fileset_invalid_filepath();
 		} else {
-			TraceEvent(SevInfo, "BulkLoadFileSetProvideDataFile")
+			TraceEvent(bulkLoadVerboseEventSev(), "BulkLoadFileSetProvideDataFile")
 			    .detail("DataFile", dataFileName)
 			    .detail("Relative", getRelativePath())
 			    .detail("Folder", getFolder());

--- a/fdbclient/include/fdbclient/ClientKnobs.h
+++ b/fdbclient/include/fdbclient/ClientKnobs.h
@@ -204,6 +204,9 @@ public:
 	int BULKLOAD_JOB_HISTORY_COUNT_MAX; // the max number of bulk load job history to keep. The oldest job history will
 	                                    // be removed when the count exceeds this value. Set to 0 to disable history.
 	                                    // Do not set the value to a large number, e.g. <= 10.
+	int BULKLOAD_VERBOSE_LEVEL; // Set to 1 to minimize the verbosity. Set to 5 to turn on all events for performance
+	                            // insights. Set to 10 to turn on all events.
+	int S3CLIENT_VERBOSE_LEVEL; // Similar to BULKLOAD_VERBOSE_LEVEL
 
 	// Configuration
 	int32_t DEFAULT_AUTO_COMMIT_PROXIES;

--- a/fdbclient/include/fdbclient/S3Client.actor.h
+++ b/fdbclient/include/fdbclient/S3Client.actor.h
@@ -45,6 +45,16 @@
 // TODO: Handle prefix as a parameter on the URL so can strip the first part
 // of the resource from the blobstore URL.
 
+// For all trace events for s3 client operations
+inline Severity s3VerboseEventSev() {
+	return !g_network->isSimulated() && CLIENT_KNOBS->S3CLIENT_VERBOSE_LEVEL >= 10 ? SevInfo : SevDebug;
+}
+
+// For all trace events measuring the performance of s3 client operations
+inline Severity s3PerfEventSev() {
+	return !g_network->isSimulated() && CLIENT_KNOBS->S3CLIENT_VERBOSE_LEVEL >= 5 ? SevInfo : SevDebug;
+}
+
 const std::string BLOBSTORE_PREFIX = "blobstore://";
 
 // Copy the directory content from the local filesystem up to s3.

--- a/fdbserver/BulkLoadUtil.actor.cpp
+++ b/fdbserver/BulkLoadUtil.actor.cpp
@@ -209,7 +209,7 @@ ACTOR Future<bool> doBytesSamplingOnDataFile(std::string dataFileFullPath, // in
 			retryCount++;
 		}
 	}
-	TraceEvent(SevInfo, "SSBulkLoadTaskSamplingComplete", logId)
+	TraceEvent(bulkLoadVerboseEventSev(), "SSBulkLoadTaskSamplingComplete", logId)
 	    .detail("DataFileFullPath", dataFileFullPath)
 	    .detail("ByteSampleFileFullPath", byteSampleFileFullPath)
 	    .detail("Duration", now() - startTime)
@@ -311,7 +311,7 @@ ACTOR Future<BulkLoadFileSet> bulkLoadDownloadTaskFileSet(BulkLoadTransportMetho
 			} else {
 				UNREACHABLE();
 			}
-			TraceEvent(SevInfo, "SSBulkLoadTaskDownloadFileSet", logId)
+			TraceEvent(bulkLoadVerboseEventSev(), "SSBulkLoadTaskDownloadFileSet", logId)
 			    .setMaxEventLength(-1)
 			    .setMaxFieldLength(-1)
 			    .detail("FromRemoteFileSet", fromRemoteFileSet.toString())
@@ -360,7 +360,7 @@ ACTOR Future<Void> downloadManifestFile(BulkLoadTransportMethod transportMethod,
 			if (!fileExists(abspath(toLocalPath))) {
 				throw retry();
 			}
-			TraceEvent(SevInfo, "BulkLoadDownloadManifestFile", logId)
+			TraceEvent(bulkLoadVerboseEventSev(), "BulkLoadDownloadManifestFile", logId)
 			    .detail("FromRemotePath", fromRemotePath)
 			    .detail("ToLocalPath", toLocalPath)
 			    .detail("Duration", now() - startTime)

--- a/fdbserver/DDShardTracker.actor.cpp
+++ b/fdbserver/DDShardTracker.actor.cpp
@@ -993,8 +993,9 @@ void createShardToBulkLoad(DataDistributionTracker* self,
 	KeyRange keys = bulkLoadTaskState.getRange();
 	ASSERT(!keys.empty());
 	bool issueDataMoveForCancel = cancelledDataMovePriority.present();
-	TraceEvent e(
-	    issueDataMoveForCancel ? SevWarnAlways : SevInfo, "DDBulkLoadEngineCreateShardToBulkLoad", self->distributorId);
+	TraceEvent e(issueDataMoveForCancel ? SevWarnAlways : bulkLoadVerboseEventSev(),
+	             "DDBulkLoadEngineCreateShardToBulkLoad",
+	             self->distributorId);
 	e.detail("TaskId", bulkLoadTaskState.getTaskId());
 	e.detail("BulkLoadRange", keys);
 	// Create shards at the two ends and do not data move for those shards

--- a/fdbserver/DDTeamCollection.actor.cpp
+++ b/fdbserver/DDTeamCollection.actor.cpp
@@ -199,7 +199,7 @@ public:
 	// Random selection for load balance
 	ACTOR static Future<Void> getTeamForBulkLoad(DDTeamCollection* self, GetTeamRequest req) {
 		try {
-			TraceEvent(SevInfo, "DDBulkLoadEngineTaskGetTeamReqReceived", self->distributorId)
+			TraceEvent(bulkLoadVerboseEventSev(), "DDBulkLoadEngineTaskGetTeamReqReceived", self->distributorId)
 			    .detail("TCReady", self->readyToStart.isReady())
 			    .detail("TeamBuilderValid", self->teamBuilder.isValid())
 			    .detail("TeamBuilderReady", self->teamBuilder.isValid() ? self->teamBuilder.isReady() : false)
@@ -208,7 +208,7 @@ public:
 			    .detail("TeamSize", self->teams.size());
 			wait(self->checkBuildTeams());
 
-			TraceEvent(SevInfo, "DDBulkLoadEngineTaskGetTeamCheckBuildTeamDone", self->distributorId)
+			TraceEvent(bulkLoadVerboseEventSev(), "DDBulkLoadEngineTaskGetTeamCheckBuildTeamDone", self->distributorId)
 			    .detail("TCReady", self->readyToStart.isReady())
 			    .detail("TeamBuilderValid", self->teamBuilder.isValid())
 			    .detail("TeamBuilderReady", self->teamBuilder.isValid() ? self->teamBuilder.isReady() : false)
@@ -275,7 +275,7 @@ public:
 			Optional<Reference<IDataDistributionTeam>> res;
 			if (candidateTeams.size() >= 1) {
 				res = deterministicRandom()->randomChoice(candidateTeams);
-				TraceEvent(SevInfo, "DDBulkLoadEngineTaskGetTeamReply", self->distributorId)
+				TraceEvent(bulkLoadVerboseEventSev(), "DDBulkLoadEngineTaskGetTeamReply", self->distributorId)
 				    .detail("TCReady", self->readyToStart.isReady())
 				    .detail("SrcIds", describe(req.src))
 				    .detail("Primary", self->isPrimary())

--- a/fdbserver/MoveKeys.actor.cpp
+++ b/fdbserver/MoveKeys.actor.cpp
@@ -1895,7 +1895,8 @@ ACTOR static Future<Void> startMoveShards(Database occ,
 						                 bulkLoadTaskPrefix,
 						                 newBulkLoadTaskState.getRange(),
 						                 bulkLoadTaskStateValue(newBulkLoadTaskState)));
-						TraceEvent(SevInfo, "DDBulkLoadTaskSetRunningStateTransaction", relocationIntervalId)
+						TraceEvent(
+						    bulkLoadVerboseEventSev(), "DDBulkLoadTaskSetRunningStateTransaction", relocationIntervalId)
 						    .setMaxEventLength(-1)
 						    .setMaxFieldLength(-1)
 						    .detail("DataMoveID", dataMoveId)
@@ -1925,7 +1926,7 @@ ACTOR static Future<Void> startMoveShards(Database occ,
 
 				if (currentKeys.end == keys.end && bulkLoadTaskState.present()) {
 					Version commitVersion = tr.getCommittedVersion();
-					TraceEvent(SevInfo, "DDBulkLoadTaskPersistRunningState", relocationIntervalId)
+					TraceEvent(bulkLoadVerboseEventSev(), "DDBulkLoadTaskPersistRunningState", relocationIntervalId)
 					    .setMaxEventLength(-1)
 					    .setMaxFieldLength(-1)
 					    .detail("DataMoveID", dataMoveId)
@@ -2346,7 +2347,8 @@ ACTOR static Future<Void> finishMoveShards(Database occ,
 							                 bulkLoadTaskPrefix,
 							                 newBulkLoadTaskState.getRange(),
 							                 bulkLoadTaskStateValue(newBulkLoadTaskState)));
-							TraceEvent(SevInfo, "DDBulkLoadTaskSetCompleteTransaction", relocationIntervalId)
+							TraceEvent(
+							    bulkLoadVerboseEventSev(), "DDBulkLoadTaskSetCompleteTransaction", relocationIntervalId)
 							    .setMaxEventLength(-1)
 							    .setMaxFieldLength(-1)
 							    .detail("DataMoveID", dataMoveId)
@@ -2372,7 +2374,8 @@ ACTOR static Future<Void> finishMoveShards(Database occ,
 
 					if (range.end == dataMove.ranges.front().end && bulkLoadTaskState.present()) {
 						Version commitVersion = tr.getCommittedVersion();
-						TraceEvent(SevInfo, "DDBulkLoadTaskPersistCompleteState", relocationIntervalId)
+						TraceEvent(
+						    bulkLoadVerboseEventSev(), "DDBulkLoadTaskPersistCompleteState", relocationIntervalId)
 						    .setMaxEventLength(-1)
 						    .setMaxFieldLength(-1)
 						    .detail("DataMoveID", dataMoveId)

--- a/fdbserver/include/fdbserver/DataDistribution.actor.h
+++ b/fdbserver/include/fdbserver/DataDistribution.actor.h
@@ -18,7 +18,6 @@
  * limitations under the License.
  */
 
-#include "fdbclient/Knobs.h"
 #if defined(NO_INTELLISENSE) && !defined(FDBSERVER_DATA_DISTRIBUTION_ACTOR_G_H)
 #define FDBSERVER_DATA_DISTRIBUTION_ACTOR_G_H
 #include "fdbserver/DataDistribution.actor.g.h"

--- a/fdbserver/include/fdbserver/DataDistribution.actor.h
+++ b/fdbserver/include/fdbserver/DataDistribution.actor.h
@@ -18,6 +18,7 @@
  * limitations under the License.
  */
 
+#include "fdbclient/Knobs.h"
 #if defined(NO_INTELLISENSE) && !defined(FDBSERVER_DATA_DISTRIBUTION_ACTOR_G_H)
 #define FDBSERVER_DATA_DISTRIBUTION_ACTOR_G_H
 #include "fdbserver/DataDistribution.actor.g.h"
@@ -637,7 +638,7 @@ public:
 			}
 			if (it->value().get().completeAck.canBeSet()) {
 				it->value().get().completeAck.sendError(bulkload_task_outdated());
-				TraceEvent(SevInfo, "DDBulkLoadTaskCollectionPublishTaskOverwriteTask", ddId)
+				TraceEvent(bulkLoadVerboseEventSev(), "DDBulkLoadTaskCollectionPublishTaskOverwriteTask", ddId)
 				    .setMaxEventLength(-1)
 				    .setMaxFieldLength(-1)
 				    .detail("NewRange", bulkLoadTaskState.getRange())

--- a/fdbserver/workloads/BulkLoading.actor.cpp
+++ b/fdbserver/workloads/BulkLoading.actor.cpp
@@ -109,13 +109,13 @@ struct BulkLoading : TestWorkload {
 			loop {
 				try {
 					wait(submitBulkLoadTask(cx, tasks[i]));
-					TraceEvent("BulkLoadingSubmitBulkLoadTask")
+					TraceEvent(bulkLoadVerboseEventSev(), "BulkLoadingSubmitBulkLoadTask")
 					    .setMaxEventLength(-1)
 					    .setMaxFieldLength(-1)
 					    .detail("BulkLoadTaskState", tasks[i].toString());
 					break;
 				} catch (Error& e) {
-					TraceEvent("BulkLoadingSubmitBulkLoadTaskError")
+					TraceEvent(SevWarn, "BulkLoadingSubmitBulkLoadTaskError")
 					    .setMaxEventLength(-1)
 					    .setMaxFieldLength(-1)
 					    .errorUnsuppressed(e)
@@ -133,13 +133,13 @@ struct BulkLoading : TestWorkload {
 			loop {
 				try {
 					wait(finalizeBulkLoadTask(cx, tasks[i].getRange(), tasks[i].getTaskId()));
-					TraceEvent("BulkLoadingAcknowledgeBulkLoadTask")
+					TraceEvent(bulkLoadVerboseEventSev(), "BulkLoadingAcknowledgeBulkLoadTask")
 					    .setMaxEventLength(-1)
 					    .setMaxFieldLength(-1)
 					    .detail("BulkLoadTaskState", tasks[i].toString());
 					break;
 				} catch (Error& e) {
-					TraceEvent("BulkLoadingAcknowledgeBulkLoadTaskError")
+					TraceEvent(SevWarn, "BulkLoadingAcknowledgeBulkLoadTaskError")
 					    .setMaxEventLength(-1)
 					    .setMaxFieldLength(-1)
 					    .errorUnsuppressed(e)


### PR DESCRIPTION
Add two client knobs to control the verbose of trace events for bulkloading.

```
int BULKLOAD_VERBOSE_LEVEL; // Set to 1 to minimize the verbosity. Set to 5 to turn on all events for performance insights. Set to 10 to turn on all events.
int S3CLIENT_VERBOSE_LEVEL; // Similar to BULKLOAD_VERBOSE_LEVEL
```

100K correctness:
  20250315-005936-zhewang-8d2555a5f1f1439e           compressed=True data_size=40961034 duration=6006744 ended=100000 fail=1 fail_fast=10 max_runs=100000 pass=99999 priority=100 remaining=0 runtime=1:14:41 sanity=False started=100000 stopped=20250315-021417 submitted=20250315-005936 timeout=5400 username=zhewang
      
# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
