### PR TITLE
Allow One BulkloadTask Do Multiple Manifests 

### DIFF
--- a/fdbclient/BulkLoading.cpp
+++ b/fdbclient/BulkLoading.cpp
@@ -179,7 +179,9 @@ BulkLoadTaskState createBulkLoadTask(const UID& jobId,
                                      const BulkLoadTransportMethod& transportMethod) {
 	BulkLoadManifest manifest(
 	    fileSet, range.begin, range.end, snapshotVersion, bytes, keyCount, byteSampleSetting, type, transportMethod);
-	return BulkLoadTaskState(jobId, manifest);
+	BulkLoadManifestSet manifests(1);
+	manifests.addManifest(manifest);
+	return BulkLoadTaskState(jobId, manifests);
 }
 
 BulkLoadJobState createBulkLoadJob(const UID& dumpJobIdToLoad,

--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -387,6 +387,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( DISABLE_AUDIT_STORAGE_FINAL_REPLICA_CHECK_IN_SIM,    false ); 
 	init( SS_BULKLOAD_GETRANGE_BATCH_SIZE,                     10000 ); if (isSimulated) SS_BULKLOAD_GETRANGE_BATCH_SIZE = deterministicRandom()->randomInt(1, 10);
 	init( BULKLOAD_ASYNC_READ_WRITE_BLOCK_SIZE,            1024*1024 ); if (isSimulated) BULKLOAD_ASYNC_READ_WRITE_BLOCK_SIZE = deterministicRandom()->randomInt(1024, 10240);
+	init( MANIFEST_COUNT_MAX_PER_BULKLOAD_TASK,                   10 ); if (isSimulated) MANIFEST_COUNT_MAX_PER_BULKLOAD_TASK = deterministicRandom()->randomInt(1, 11);
 
 	// BulkDumping
 	init( DD_BULKDUMP_SCHEDULE_MIN_INTERVAL_SEC,                 5.0 ); if( randomize && BUGGIFY ) DD_BULKDUMP_SCHEDULE_MIN_INTERVAL_SEC = deterministicRandom()->random01() * 10 + 1;

--- a/fdbclient/include/fdbclient/ServerKnobs.h
+++ b/fdbclient/include/fdbclient/ServerKnobs.h
@@ -411,6 +411,7 @@ public:
 	                                               // manifest file
 	int SS_BULKDUMP_BATCH_COUNT_MAX_PER_REQUEST; // the max number of batch count per bulkdump request to a SS
 	int BULKLOAD_ASYNC_READ_WRITE_BLOCK_SIZE; // the block size when performing async read/write for bulkload
+	int MANIFEST_COUNT_MAX_PER_BULKLOAD_TASK; // the max number of manifest that a bulkload task can process
 	bool CC_ENFORCE_USE_UNFIT_DD_IN_SIM; // Set for CC to enforce to use an unfit DD in the simulation. This knob takes
 	                                     // effect only in the simulation.
 	bool DISABLE_AUDIT_STORAGE_FINAL_REPLICA_CHECK_IN_SIM; // Set to disable audit storage replica check in the

--- a/fdbserver/BulkLoadUtil.actor.cpp
+++ b/fdbserver/BulkLoadUtil.actor.cpp
@@ -312,8 +312,6 @@ ACTOR Future<BulkLoadFileSet> bulkLoadDownloadTaskFileSet(BulkLoadTransportMetho
 				UNREACHABLE();
 			}
 			TraceEvent(bulkLoadVerboseEventSev(), "SSBulkLoadTaskDownloadFileSet", logId)
-			    .setMaxEventLength(-1)
-			    .setMaxFieldLength(-1)
 			    .detail("FromRemoteFileSet", fromRemoteFileSet.toString())
 			    .detail("ToLocalRoot", toLocalRoot)
 			    .detail("Duration", now() - startTime)
@@ -326,8 +324,6 @@ ACTOR Future<BulkLoadFileSet> bulkLoadDownloadTaskFileSet(BulkLoadTransportMetho
 				throw e;
 			}
 			TraceEvent(SevWarn, "SSBulkLoadTaskDownloadFileSetError", logId)
-			    .setMaxEventLength(-1)
-			    .setMaxFieldLength(-1)
 			    .errorUnsuppressed(e)
 			    .detail("FromRemoteFileSet", fromRemoteFileSet.toString())
 			    .detail("ToLocalRoot", toLocalRoot)

--- a/fdbserver/DDShardTracker.actor.cpp
+++ b/fdbserver/DDShardTracker.actor.cpp
@@ -996,7 +996,7 @@ void createShardToBulkLoad(DataDistributionTracker* self,
 	TraceEvent e(issueDataMoveForCancel ? SevWarnAlways : bulkLoadVerboseEventSev(),
 	             "DDBulkLoadEngineCreateShardToBulkLoad",
 	             self->distributorId);
-	e.detail("TaskId", bulkLoadTaskState.getTaskId());
+	e.detail("TaskID", bulkLoadTaskState.getTaskId());
 	e.detail("BulkLoadRange", keys);
 	// Create shards at the two ends and do not data move for those shards
 	// Create a new shard and trigger data move for bulk loading on the new shard

--- a/fdbserver/DDShardTracker.actor.cpp
+++ b/fdbserver/DDShardTracker.actor.cpp
@@ -952,7 +952,7 @@ static bool shardForwardMergeFeasible(DataDistributionTracker* self, KeyRange co
 		return false;
 	}
 
-	if (self->bulkLoadEnabled && self->bulkLoadTaskCollection->onBulkLoading(nextRange)) {
+	if (self->bulkLoadEnabled && self->bulkLoadTaskCollection->bulkLoading(nextRange)) {
 		TraceEvent(SevWarn, "ShardCanForwardMergeButUnderBulkLoading", self->distributorId)
 		    .suppressFor(5.0)
 		    .detail("ShardMerging", keys)
@@ -972,7 +972,7 @@ static bool shardBackwardMergeFeasible(DataDistributionTracker* self, KeyRange c
 		return false;
 	}
 
-	if (self->bulkLoadEnabled && self->bulkLoadTaskCollection->onBulkLoading(prevRange)) {
+	if (self->bulkLoadEnabled && self->bulkLoadTaskCollection->bulkLoading(prevRange)) {
 		TraceEvent(SevWarn, "ShardCanBackwardMergeButUnderBulkLoading", self->distributorId)
 		    .suppressFor(5.0)
 		    .detail("ShardMerging", keys)
@@ -1333,7 +1333,7 @@ ACTOR Future<Void> shardTracker(DataDistributionTracker::SafeAccessor self,
 
 	try {
 		loop {
-			while (self()->bulkLoadEnabled && self()->bulkLoadTaskCollection->onBulkLoading(keys)) {
+			while (self()->bulkLoadEnabled && self()->bulkLoadTaskCollection->bulkLoading(keys)) {
 				TraceEvent(SevWarn, "ShardBoundaryChangeDisabledForBulkLoad", self()->distributorId)
 				    .suppressFor(60.0)
 				    .detail("KeyRange", keys);

--- a/fdbserver/MoveKeys.actor.cpp
+++ b/fdbserver/MoveKeys.actor.cpp
@@ -1897,10 +1897,9 @@ ACTOR static Future<Void> startMoveShards(Database occ,
 						                 bulkLoadTaskStateValue(newBulkLoadTaskState)));
 						TraceEvent(
 						    bulkLoadVerboseEventSev(), "DDBulkLoadTaskSetRunningStateTransaction", relocationIntervalId)
-						    .setMaxEventLength(-1)
-						    .setMaxFieldLength(-1)
 						    .detail("DataMoveID", dataMoveId)
-						    .detail("BulkLoadTaskState", newBulkLoadTaskState.toString());
+						    .detail("JobID", newBulkLoadTaskState.getJobId().toString())
+						    .detail("TaskID", newBulkLoadTaskState.getTaskId().toString());
 						dataMove.bulkLoadTaskState = newBulkLoadTaskState;
 					}
 					dataMove.setPhase(DataMoveMetaData::Running);
@@ -1927,10 +1926,10 @@ ACTOR static Future<Void> startMoveShards(Database occ,
 				if (currentKeys.end == keys.end && bulkLoadTaskState.present()) {
 					Version commitVersion = tr.getCommittedVersion();
 					TraceEvent(bulkLoadVerboseEventSev(), "DDBulkLoadTaskPersistRunningState", relocationIntervalId)
-					    .setMaxEventLength(-1)
-					    .setMaxFieldLength(-1)
-					    .detail("DataMoveID", dataMoveId)
-					    .detail("BulkLoadTaskState", bulkLoadTaskState.get().toString())
+					    .detail("JobID", bulkLoadTaskState.get().getJobId().toString())
+					    .detail("DataMoveID", dataMoveId.toString())
+					    .detail("TaskID", bulkLoadTaskState.get().getTaskId().toString())
+					    .detail("TaskRange", bulkLoadTaskState.get().getRange().toString())
 					    .detail("CommitVersion", commitVersion);
 				}
 
@@ -2349,10 +2348,9 @@ ACTOR static Future<Void> finishMoveShards(Database occ,
 							                 bulkLoadTaskStateValue(newBulkLoadTaskState)));
 							TraceEvent(
 							    bulkLoadVerboseEventSev(), "DDBulkLoadTaskSetCompleteTransaction", relocationIntervalId)
-							    .setMaxEventLength(-1)
-							    .setMaxFieldLength(-1)
 							    .detail("DataMoveID", dataMoveId)
-							    .detail("BulkLoadTaskState", newBulkLoadTaskState.toString());
+							    .detail("JobID", newBulkLoadTaskState.getJobId().toString())
+							    .detail("TaskID", newBulkLoadTaskState.getTaskId().toString());
 							dataMove.bulkLoadTaskState = newBulkLoadTaskState;
 						}
 						wait(deleteCheckpoints(&tr, dataMove.checkpoints, dataMoveId));
@@ -2376,10 +2374,10 @@ ACTOR static Future<Void> finishMoveShards(Database occ,
 						Version commitVersion = tr.getCommittedVersion();
 						TraceEvent(
 						    bulkLoadVerboseEventSev(), "DDBulkLoadTaskPersistCompleteState", relocationIntervalId)
-						    .setMaxEventLength(-1)
-						    .setMaxFieldLength(-1)
-						    .detail("DataMoveID", dataMoveId)
-						    .detail("BulkLoadTaskState", bulkLoadTaskState.get().toString())
+						    .detail("JobID", bulkLoadTaskState.get().getJobId().toString())
+						    .detail("DataMoveID", dataMoveId.toString())
+						    .detail("TaskID", bulkLoadTaskState.get().getTaskId().toString())
+						    .detail("TaskRange", bulkLoadTaskState.get().getRange().toString())
 						    .detail("CommitVersion", commitVersion);
 					}
 

--- a/fdbserver/include/fdbserver/BulkLoadUtil.actor.h
+++ b/fdbserver/include/fdbserver/BulkLoadUtil.actor.h
@@ -56,6 +56,12 @@ ACTOR Future<BulkLoadFileSet> bulkLoadDownloadTaskFileSet(BulkLoadTransportMetho
                                                           std::string toLocalRoot,
                                                           UID logId);
 
+ACTOR Future<Void> bulkLoadDownloadTaskFileSets(BulkLoadTransportMethod transportMethod,
+                                                std::shared_ptr<BulkLoadFileSetKeyMap> fromRemoteFileSets,
+                                                std::shared_ptr<BulkLoadFileSetKeyMap> localFileSets,
+                                                std::string toLocalRoot,
+                                                UID logId);
+
 ACTOR Future<bool> doBytesSamplingOnDataFile(std::string dataFileFullPath,
                                              std::string byteSampleFileFullPath,
                                              UID logId);
@@ -74,11 +80,12 @@ ACTOR Future<Void> getBulkLoadJobFileManifestEntryFromJobManifestFile(
     std::shared_ptr<BulkLoadManifestFileMap> manifestMap);
 
 // Get BulkLoad manifest metadata from the entry in the job manifest file
-ACTOR Future<BulkLoadManifest> getBulkLoadManifestMetadataFromEntry(BulkLoadJobFileManifestEntry manifestEntry,
-                                                                    std::string manifestLocalTempFolder,
-                                                                    BulkLoadTransportMethod transportMethod,
-                                                                    std::string jobRoot,
-                                                                    UID logId);
+ACTOR Future<BulkLoadManifestSet> getBulkLoadManifestMetadataFromEntry(
+    std::vector<BulkLoadJobFileManifestEntry> manifestEntries,
+    std::string manifestLocalTempFolder,
+    BulkLoadTransportMethod transportMethod,
+    std::string jobRoot,
+    UID logId);
 
 #include "flow/unactorcompiler.h"
 #endif

--- a/fdbserver/include/fdbserver/DataDistribution.actor.h
+++ b/fdbserver/include/fdbserver/DataDistribution.actor.h
@@ -660,12 +660,14 @@ public:
 			if (it->value().get().completeAck.canBeSet()) {
 				it->value().get().completeAck.sendError(bulkload_task_outdated());
 				TraceEvent(bulkLoadVerboseEventSev(), "DDBulkLoadTaskCollectionPublishTaskOverwriteTask", ddId)
-				    .setMaxEventLength(-1)
-				    .setMaxFieldLength(-1)
-				    .detail("NewRange", bulkLoadTaskState.getRange())
-				    .detail("NewTask", task.toString())
+				    .detail("NewTaskRange", bulkLoadTaskState.getRange())
+				    .detail("NewJobId", task.coreState.getJobId().toString())
+				    .detail("NewTaskId", task.coreState.getTaskId().toString())
+				    .detail("NewCommitVersion", task.commitVersion)
 				    .detail("OldTaskRange", it->range())
-				    .detail("OldTask", it->value().get().toString());
+				    .detail("OldJobId", it->value().get().coreState.getJobId().toString())
+				    .detail("OldTaskId", it->value().get().coreState.getTaskId().toString())
+				    .detail("OldCommitVersion", it->value().get().commitVersion);
 			}
 		}
 		bulkLoadTaskMap.insert(bulkLoadTaskState.getRange(), task);

--- a/fdbserver/include/fdbserver/DataDistribution.actor.h
+++ b/fdbserver/include/fdbserver/DataDistribution.actor.h
@@ -585,7 +585,7 @@ public:
 
 	// Return true if there exists a bulk load job/task or the collection has not been initialized.
 	// This takes effect only when DDBulkLoad Mode is enabled.
-	bool onBulkLoading(KeyRange range) {
+	bool bulkLoading(const KeyRange& range) {
 		if (!initialized) {
 			return true;
 		}

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -8748,9 +8748,8 @@ ACTOR Future<Void> bulkLoadFetchKeyValueFileToLoad(StorageServer* data,
 	localFileSets->clear();
 	ASSERT(bulkLoadTaskState.getLoadType() == BulkLoadType::SST);
 	TraceEvent(bulkLoadVerboseEventSev(), "SSBulkLoadTaskFetchSSTFile", data->thisServerID)
-	    .setMaxEventLength(-1)
-	    .setMaxFieldLength(-1)
-	    .detail("BulkLoadTask", bulkLoadTaskState.toString())
+	    .detail("JobID", bulkLoadTaskState.getJobId().toString())
+	    .detail("TaskID", bulkLoadTaskState.getTaskId().toString())
 	    .detail("Dir", abspath(dir));
 	state double fetchStartTime = now();
 	// Download data file from fromRemoteFileSet to toLocalFileSet
@@ -8774,9 +8773,8 @@ ACTOR Future<Void> bulkLoadFetchKeyValueFileToLoad(StorageServer* data,
 		}
 	}
 	TraceEvent(bulkLoadVerboseEventSev(), "SSBulkLoadTaskFetchSSTFileFetched", data->thisServerID)
-	    .setMaxEventLength(-1)
-	    .setMaxFieldLength(-1)
-	    .detail("BulkLoadTask", bulkLoadTaskState.toString())
+	    .detail("JobID", bulkLoadTaskState.getJobId().toString())
+	    .detail("TaskID", bulkLoadTaskState.getTaskId().toString())
 	    .detail("Dir", abspath(dir))
 	    .detail("LocalFileSetMap", localFileSetString)
 	    .detail("Duration", duration)
@@ -9633,9 +9631,8 @@ ACTOR Future<Void> bulkLoadFetchShardFileToLoad(StorageServer* data,
                                                 BulkLoadTaskState bulkLoadTaskState) {
 	ASSERT(bulkLoadTaskState.getLoadType() == BulkLoadType::SST);
 	TraceEvent(bulkLoadVerboseEventSev(), "SSBulkLoadTaskFetchShardFile", data->thisServerID)
-	    .setMaxEventLength(-1)
-	    .setMaxFieldLength(-1)
-	    .detail("BulkLoadTask", bulkLoadTaskState.toString())
+	    .detail("JobID", bulkLoadTaskState.getJobId().toString())
+	    .detail("TaskID", bulkLoadTaskState.getTaskId().toString())
 	    .detail("MoveInShard", moveInShard->toString())
 	    .detail("LocalRoot", abspath(localRoot));
 
@@ -9662,9 +9659,8 @@ ACTOR Future<Void> bulkLoadFetchShardFileToLoad(StorageServer* data,
 	state BulkLoadFileSet toLocalFileSet = wait(bulkLoadDownloadTaskFileSet(
 	    bulkLoadTaskState.getTransportMethod(), fromRemoteFileSet, localRoot, data->thisServerID));
 	TraceEvent(bulkLoadVerboseEventSev(), "SSBulkLoadTaskFetchShardSSTFileFetched", data->thisServerID)
-	    .setMaxEventLength(-1)
-	    .setMaxFieldLength(-1)
-	    .detail("BulkLoadTask", bulkLoadTaskState.toString())
+	    .detail("JobID", bulkLoadTaskState.getJobId().toString())
+	    .detail("TaskID", bulkLoadTaskState.getTaskId().toString())
 	    .detail("MoveInShard", moveInShard->toString())
 	    .detail("RemoteFileSet", fromRemoteFileSet.toString())
 	    .detail("LocalFileSet", toLocalFileSet.toString());
@@ -9673,9 +9669,8 @@ ACTOR Future<Void> bulkLoadFetchShardFileToLoad(StorageServer* data,
 	if (!toLocalFileSet.hasByteSampleFile()) {
 		TraceEvent(
 		    bulkLoadVerboseEventSev(), "SSBulkLoadTaskFetchShardSSTFileValidByteSampleNotFound", data->thisServerID)
-		    .setMaxEventLength(-1)
-		    .setMaxFieldLength(-1)
-		    .detail("BulkLoadTaskState", bulkLoadTaskState.toString())
+		    .detail("JobID", bulkLoadTaskState.getJobId().toString())
+		    .detail("TaskID", bulkLoadTaskState.getTaskId().toString())
 		    .detail("LocalFileSet", toLocalFileSet.toString());
 		state std::string byteSampleFileName =
 		    generateBulkLoadBytesSampleFileNameFromDataFileName(toLocalFileSet.getDataFileName());
@@ -9687,9 +9682,8 @@ ACTOR Future<Void> bulkLoadFetchShardFileToLoad(StorageServer* data,
 		}
 	}
 	TraceEvent(bulkLoadVerboseEventSev(), "SSBulkLoadTaskFetchShardByteSampled", data->thisServerID)
-	    .setMaxEventLength(-1)
-	    .setMaxFieldLength(-1)
-	    .detail("BulkLoadTask", bulkLoadTaskState.toString())
+	    .detail("JobID", bulkLoadTaskState.getJobId().toString())
+	    .detail("TaskID", bulkLoadTaskState.getTaskId().toString())
 	    .detail("MoveInShard", moveInShard->toString())
 	    .detail("RemoteFileSet", fromRemoteFileSet.toString())
 	    .detail("LocalFileSet", toLocalFileSet.toString());
@@ -9728,9 +9722,8 @@ ACTOR Future<Void> bulkLoadFetchShardFileToLoad(StorageServer* data,
 	const double duration = now() - fetchStartTime;
 	const int64_t totalBytes = getTotalFetchedBytes(moveInShard->meta->checkpoints);
 	TraceEvent(bulkLoadVerboseEventSev(), "SSBulkLoadTaskFetchShardSSTFileBuildMetadata", data->thisServerID)
-	    .setMaxEventLength(-1)
-	    .setMaxFieldLength(-1)
-	    .detail("BulkLoadTask", bulkLoadTaskState.toString())
+	    .detail("JobID", bulkLoadTaskState.getJobId().toString())
+	    .detail("TaskID", bulkLoadTaskState.getTaskId().toString())
 	    .detail("MoveInShard", moveInShard->toString())
 	    .detail("LocalRoot", abspath(localRoot))
 	    .detail("LocalFileSet", toLocalFileSet.toString())

--- a/fdbserver/workloads/BulkLoading.actor.cpp
+++ b/fdbserver/workloads/BulkLoading.actor.cpp
@@ -109,9 +109,7 @@ struct BulkLoading : TestWorkload {
 			loop {
 				try {
 					wait(submitBulkLoadTask(cx, tasks[i]));
-					TraceEvent(bulkLoadVerboseEventSev(), "BulkLoadingSubmitBulkLoadTask")
-					    .setMaxEventLength(-1)
-					    .setMaxFieldLength(-1)
+					TraceEvent(SevDebug, "BulkLoadingSubmitBulkLoadTask")
 					    .detail("BulkLoadTaskState", tasks[i].toString());
 					break;
 				} catch (Error& e) {
@@ -133,7 +131,7 @@ struct BulkLoading : TestWorkload {
 			loop {
 				try {
 					wait(finalizeBulkLoadTask(cx, tasks[i].getRange(), tasks[i].getTaskId()));
-					TraceEvent(bulkLoadVerboseEventSev(), "BulkLoadingAcknowledgeBulkLoadTask")
+					TraceEvent(SevDebug, "BulkLoadingAcknowledgeBulkLoadTask")
 					    .setMaxEventLength(-1)
 					    .setMaxFieldLength(-1)
 					    .detail("BulkLoadTaskState", tasks[i].toString());


### PR DESCRIPTION
This PR significantly reduces the DD business and improves SS efficiency by batching multiple manifests into a single bulkload task.

A manifest includes one SST file and one byte sample file, where all keys of the SST files are dumped at a single version. Each SST file is around 15 ~ 30 MB.
Previously, each bulkload task only does one manifest. As a result, while DD has to maintains thousands of bulkload tasks and data moves at the same time, DD still cannot achieve a high utilization at SSes for bulk loading, as a result DD is very busy and becomes a bottleneck of the cluster-wide bulkloading throughput.

This PR solves this issue by batching multiple manifests into a single bulkload task. As a result, each task includes more data to load at storage servers. Given the same amount of bulkload task running by DD at a time, SSes have more bulk loading work to do.

This PR also removes heavy trace event fields.

500K BulkDump:
  20250317-034934-zhewang-b7e5fa5bea7694e6           compressed=True data_size=41047810 duration=15281840 ended=500000 fail_fast=10 max_runs=500000 pass=500000 priority=100 remaining=0 runtime=2:22:31 sanity=False started=500000 stopped=20250317-061205 submitted=20250317-034934 timeout=5400 username=zhewang
      
500K BulkLoad:
  20250317-035016-zhewang-b9fdfb3107c7fa3f           compressed=True data_size=41047950 duration=12551810 ended=500000 fail=2 fail_fast=10 max_runs=500000 pass=499998 priority=100 remaining=0 runtime=2:00:41 sanity=False started=500000 stopped=20250317-055057 submitted=20250317-035016 timeout=5400 username=zhewang
      
100K Correctness:
  20250317-061422-zhewang-6357c901e541a14b           compressed=True data_size=41006497 duration=6015993 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:30:57 sanity=False started=100000 stopped=20250317-064519 submitted=20250317-061422 timeout=5400 username=zhewang
        
# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
