### PR TITLE
Fix a restore bug due to a race

### DIFF
--- a/fdbclient/FileBackupAgent.actor.cpp
+++ b/fdbclient/FileBackupAgent.actor.cpp
@@ -5572,6 +5572,7 @@ struct RestoreDispatchPartitionedTaskFunc : RestoreTaskFuncBase {
 };
 StringRef RestoreDispatchPartitionedTaskFunc::name = "restore_dispatch_partitioned"_sr;
 REGISTER_TASKFUNC(RestoreDispatchPartitionedTaskFunc);
+
 struct RestoreDispatchTaskFunc : RestoreTaskFuncBase {
 	static StringRef name;
 	static constexpr uint32_t version = 1;

--- a/fdbclient/include/fdbclient/BackupAgent.actor.h
+++ b/fdbclient/include/fdbclient/BackupAgent.actor.h
@@ -531,12 +531,13 @@ public:
 
 using RangeResultWithVersion = std::pair<RangeResult, Version>;
 
+// RCGroup contains the backup mutations for a commit version, i.e., groupKey.
 struct RCGroup {
 	RangeResult items;
 	Version version; // this is read version for this group
-	uint64_t groupKey; // this is the original version for this group
+	Version groupKey; // this is the original commit version for this group
 
-	RCGroup() : version(-1), groupKey(ULLONG_MAX){};
+	RCGroup() : version(-1), groupKey(ULLONG_MAX) {}
 
 	template <class Ar>
 	void serialize(Ar& ar) {
@@ -580,6 +581,8 @@ ACTOR Future<Void> readCommitted(Database cx,
                                  Terminator terminator = Terminator::True,
                                  AccessSystemKeys systemAccess = AccessSystemKeys::False,
                                  LockAware lockAware = LockAware::False);
+
+// Applies the mutations between the beginVersion and endVersion to the database during a restore.
 ACTOR Future<Void> applyMutations(Database cx,
                                   Key uid,
                                   Key addPrefix,


### PR DESCRIPTION
Found by simulation:
seed:  -f tests/slow/ApiCorrectnessAtomicRestore.toml -s 177856328 -b on Commit: 51ad8428e0fbe1d82bc76cf42b1579f51ecf2773
Compiler: clang++
Env: Rhel9 okteto

applyMutations() has processed version 801400000-803141392, and before calling sendCommitTransactionRequest(), which was going to update apply begin version to 803141392. But DID NOT wait for the transaction commit.

Then there is an update on the apply end version to 845345760, which picks up the PREVIOUS apply begin version 801400000. Thus started another applyMutation() with version range 801400000-845345760. Note because previous applyMutation() has finished and didn't wait for the transaction commit, thus the starting version is wrong. As a result, this applyMutation() re-processed version range 801400000-803141392.

The test failed during re-processing, because mutations are missing for the overlapped range.

The fix is to wait for the transaction to commit in sendCommitTransactionRequest().

This bug probably affects DR as well.

See rdar://146877552

20250317-162835-jzhou-ff4c4d6d7c51bfed


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
