### PR TITLE
Set snapshot restore state from mutation logs information.

### DIFF
--- a/fdbserver/workloads/BackupCorrectness.actor.cpp
+++ b/fdbserver/workloads/BackupCorrectness.actor.cpp
@@ -683,8 +683,10 @@ struct BackupAndRestoreCorrectnessWorkload : TestWorkload {
 					} else if (deterministicRandom()->random01() < 0.1) {
 						targetVersion = desc.maxRestorableVersion.get();
 					} else if (deterministicRandom()->random01() < 0.5) {
-						targetVersion = deterministicRandom()->randomInt64(desc.minRestorableVersion.get(),
-						                                                   desc.contiguousLogEnd.get());
+						targetVersion = (desc.minRestorableVersion.get() != desc.maxRestorableVersion.get())
+						                    ? deterministicRandom()->randomInt64(desc.minRestorableVersion.get(),
+						                                                         desc.maxRestorableVersion.get())
+						                    : desc.maxRestorableVersion.get();
 					}
 				}
 


### PR DESCRIPTION
This PR focuses the production issue of missing backup log ranges and eventually expire workflow blocked and restorable state not set correctly.

- In the case of missing mutation logs, each snapshot restorability has to be recalculated based on whether the snapshot can be restored from the existing logs
- In the case of missing mutation logs, cluster level minRestorableVersion and maxRestorableVersion has to be recalculated from the existing logs
- Apart from this added two new unit tests to test the missing log case.

Testing:
1) Tested with the custom backup binary on iclouddb1/P01_DC2 and iclouddb1/PO2_DC2. The snapshots restore and the cluster level restore are set properly and able to expire the old backups. More details at: https://a1391190.slack.com/archives/C01LS31J3R7/p1740164682214509
2) Ran 100k simulation run
3) New unit tests working in simulation.

NOTE: This PR has TODO items and also need refactoring which I will address in a new PR.


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
