### PR TITLE
A Couple of Fixes and Improvements for BulkLoad/Dump

### DIFF
--- a/fdbcli/BulkLoadCommand.actor.cpp
+++ b/fdbcli/BulkLoadCommand.actor.cpp
@@ -110,11 +110,11 @@ ACTOR Future<Void> printBulkLoadJobProgress(Database cx, BulkLoadJobState job) {
 					return Void();
 				}
 				if (bulkLoadTask.phase == BulkLoadPhase::Complete) {
-					completeTaskCount++;
+					completeTaskCount = completeTaskCount + bulkLoadTask.getManifests().size();
 				} else if (bulkLoadTask.phase == BulkLoadPhase::Error) {
-					errorTaskCount++;
+					errorTaskCount = errorTaskCount + bulkLoadTask.getManifests().size();
 				}
-				submitTaskCount++;
+				submitTaskCount = submitTaskCount + bulkLoadTask.getManifests().size();
 			}
 			readBegin = rangeResult.back().key;
 		} catch (Error& e) {

--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -3326,11 +3326,11 @@ ACTOR Future<Void> acknowledgeAllErrorBulkLoadTasks(Database cx, UID jobId, KeyR
 				}
 				if (existTask.phase == BulkLoadPhase::Error) {
 					TraceEvent(SevWarnAlways, "ManagementAPIAcknowledgeErrorBulkLoadTask")
-					    .setMaxEventLength(-1)
-					    .setMaxFieldLength(-1)
-					    .detail("JobId", jobId.toString())
+					    .detail("JobId", jobId)
 					    .detail("JobRange", jobRange)
-					    .detail("ExistTask", existTask.toString());
+					    .detail("ExistTaskID", existTask.getTaskId())
+					    .detail("ExistTaskRange", existTask.getRange())
+					    .detail("ExistTaskJobId", existTask.getJobId());
 					wait(setBulkLoadFinalizeTransaction(&tr, existTask.getRange(), existTask.getTaskId()));
 				}
 				lastKey = bulkLoadTaskResult[i + 1].key;
@@ -3508,10 +3508,8 @@ ACTOR Future<Void> cancelBulkDumpJob(Database cx, UID jobId) {
 				// if no old metadata exists (the old job metadata has been cleared). So, we can stop at this point.
 				if (existJob.getJobId() != jobId) {
 					TraceEvent(SevWarn, "DDBulkDumpJobHasChanged")
-					    .setMaxEventLength(-1)
-					    .setMaxFieldLength(-1)
-					    .detail("InputJobId", jobId)
-					    .detail("ExistJob", existJob.toString());
+					    .detail("InputJobID", jobId.toString())
+					    .detail("ExistJobID", existJob.getJobId().toString());
 					throw bulkload_task_outdated();
 				}
 			}

--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -383,6 +383,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( DD_BULKLOAD_TASK_METADATA_READ_SIZE,                   100 ); if( randomize && BUGGIFY ) DD_BULKLOAD_TASK_METADATA_READ_SIZE = deterministicRandom()->randomInt(2, 100);
 	init( DD_BULKLOAD_PARALLELISM,                                10 ); if( randomize && BUGGIFY ) DD_BULKLOAD_PARALLELISM = deterministicRandom()->randomInt(1, 10);
 	init( DD_BULKLOAD_SCHEDULE_MIN_INTERVAL_SEC,                 5.0 ); if( randomize && BUGGIFY ) DD_BULKLOAD_SCHEDULE_MIN_INTERVAL_SEC = deterministicRandom()->random01() * 4 + 1;
+	init( DD_BULKLOAD_JOB_MONITOR_PERIOD_SEC,                   30.0 ); if (isSimulated) DD_BULKLOAD_JOB_MONITOR_PERIOD_SEC = deterministicRandom()->random01() * 30 + 10;
 	init( CC_ENFORCE_USE_UNFIT_DD_IN_SIM,                      false );
 	init( DISABLE_AUDIT_STORAGE_FINAL_REPLICA_CHECK_IN_SIM,    false ); 
 	init( SS_BULKLOAD_GETRANGE_BATCH_SIZE,                     10000 ); if (isSimulated) SS_BULKLOAD_GETRANGE_BATCH_SIZE = deterministicRandom()->randomInt(1, 10);

--- a/fdbclient/include/fdbclient/ServerKnobs.h
+++ b/fdbclient/include/fdbclient/ServerKnobs.h
@@ -407,6 +407,8 @@ public:
 	                                              // between two rounds
 	double DD_BULKDUMP_SCHEDULE_MIN_INTERVAL_SEC; // the minimal seconds that the bulk dump scheduler has to wait
 	                                              // between two rounds
+	double DD_BULKLOAD_JOB_MONITOR_PERIOD_SEC; // the seconds that the bulkload job monitor to read the task metadata
+	                                           // when monitoring the task progress
 	int DD_BULKDUMP_BUILD_JOB_MANIFEST_BATCH_SIZE; // the number of lines in a batch when generating bulkload job
 	                                               // manifest file
 	int SS_BULKDUMP_BATCH_COUNT_MAX_PER_REQUEST; // the max number of batch count per bulkdump request to a SS

--- a/fdbclient/include/fdbclient/StorageCheckpoint.h
+++ b/fdbclient/include/fdbclient/StorageCheckpoint.h
@@ -195,7 +195,7 @@ struct DataMoveMetaData {
 		                  ", [Source Servers]: " + describe(src) + ", [Destination Servers]: " + describe(dest) +
 		                  ", [Checkpoints]: " + describe(checkpoints);
 		if (bulkLoadTaskState.present()) {
-			res = res + ", [BulkLoadTaskState]: " + bulkLoadTaskState.get().toString();
+			res = res + ", [BulkLoadTaskID]: " + bulkLoadTaskState.get().getTaskId().toString();
 		}
 		return res;
 	}

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -879,8 +879,8 @@ public:
 				self->relocationProducer.send(rs); // Cancal data move
 				TraceEvent(SevWarnAlways, "DDBulkLoadTaskCancelDataMoveForWrongType", self->ddId)
 				    .detail("Reason", "WrongTypeWhenDDInit")
-				    .detail("DataMove", meta.toString())
-				    .detail("DataMoveType", dataMoveType);
+				    .detail("DataMoveType", dataMoveType)
+				    .detail("DataMove", meta.toString());
 			} else if (it.value()->isCancelled() ||
 			           (it.value()->valid && !SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA)) {
 				RelocateShard rs(meta.ranges.front(), DataMovementReason::RECOVER_MOVE, RelocateReason::OTHER);
@@ -1125,8 +1125,8 @@ ACTOR Future<std::pair<BulkLoadTaskState, Version>> triggerBulkLoadTask(Referenc
 			Version commitVersion = tr.getCommittedVersion();
 			TraceEvent(bulkLoadVerboseEventSev(), "DDBulkLoadTaskPersistTriggerState", self->ddId)
 			    .detail("CommitVersion", commitVersion)
-			    .detail("TaskID", newBulkLoadTaskState.getTaskId().toString())
-			    .detail("JobID", newBulkLoadTaskState.getJobId().toString());
+			    .detail("TaskID", newBulkLoadTaskState.getTaskId())
+			    .detail("JobID", newBulkLoadTaskState.getJobId());
 			ASSERT(commitVersion != invalidVersion);
 			return std::make_pair(newBulkLoadTaskState, commitVersion);
 
@@ -1134,8 +1134,8 @@ ACTOR Future<std::pair<BulkLoadTaskState, Version>> triggerBulkLoadTask(Referenc
 			if (e.code() != error_code_actor_cancelled) {
 				TraceEvent(SevWarn, "DDBulkLoadTaskPersistTriggerStateError", self->ddId)
 				    .errorUnsuppressed(e)
-				    .detail("TaskID", newBulkLoadTaskState.getTaskId().toString())
-				    .detail("JobID", newBulkLoadTaskState.getJobId().toString());
+				    .detail("TaskID", newBulkLoadTaskState.getTaskId())
+				    .detail("JobID", newBulkLoadTaskState.getJobId());
 			}
 			wait(tr.onError(e));
 		}
@@ -1167,15 +1167,15 @@ ACTOR Future<Void> failBulkLoadTask(Reference<DataDistributor> self,
 			Version commitVersion = tr.getCommittedVersion();
 			TraceEvent(bulkLoadVerboseEventSev(), "DDBulkLoadTaskPersistErrorState", self->ddId)
 			    .detail("CommitVersion", commitVersion)
-			    .detail("TaskID", bulkLoadTaskState.getTaskId().toString())
-			    .detail("JobID", bulkLoadTaskState.getJobId().toString());
+			    .detail("TaskID", bulkLoadTaskState.getTaskId())
+			    .detail("JobID", bulkLoadTaskState.getJobId());
 			break;
 		} catch (Error& e) {
 			if (e.code() != error_code_actor_cancelled) {
 				TraceEvent(SevWarn, "DDBulkLoadTaskPersistErrorStateError", self->ddId)
 				    .errorUnsuppressed(e)
-				    .detail("TaskID", bulkLoadTaskState.getTaskId().toString())
-				    .detail("JobID", bulkLoadTaskState.getJobId().toString());
+				    .detail("TaskID", bulkLoadTaskState.getTaskId())
+				    .detail("JobID", bulkLoadTaskState.getJobId());
 			}
 			wait(tr.onError(e));
 		}
@@ -1200,9 +1200,9 @@ ACTOR Future<Void> doBulkLoadTask(Reference<DataDistributor> self, KeyRange rang
 		commitVersion = triggeredBulkLoadTask_.second;
 		TraceEvent(bulkLoadVerboseEventSev(), "DDBulkLoadTaskDoTask", self->ddId)
 		    .detail("Phase", "Triggered")
-		    .detail("TaskID", triggeredBulkLoadTask.getTaskId().toString())
-		    .detail("TaskRange", triggeredBulkLoadTask.getRange().toString())
-		    .detail("JobID", triggeredBulkLoadTask.getJobId().toString())
+		    .detail("TaskID", triggeredBulkLoadTask.getTaskId())
+		    .detail("TaskRange", triggeredBulkLoadTask.getRange())
+		    .detail("JobID", triggeredBulkLoadTask.getJobId())
 		    .detail("CommitVersion", commitVersion)
 		    .detail("Duration", now() - beginTime);
 		ASSERT(triggeredBulkLoadTask.getRange() == range);
@@ -1223,7 +1223,7 @@ ACTOR Future<Void> doBulkLoadTask(Reference<DataDistributor> self, KeyRange rang
 			    .detail("Phase", "See unretrievable error")
 			    .detail("CancelledDataMovePriority", ack.dataMovePriority)
 			    .detail("Range", range)
-			    .detail("TaskID", taskId.toString())
+			    .detail("TaskID", taskId)
 			    .detail("Duration", now() - beginTime);
 			try {
 				// Mark this task failed in system metadata
@@ -1232,7 +1232,7 @@ ACTOR Future<Void> doBulkLoadTask(Reference<DataDistributor> self, KeyRange rang
 				    .detail("Phase", "Marked as error")
 				    .detail("CancelledDataMovePriority", ack.dataMovePriority)
 				    .detail("Range", range)
-				    .detail("TaskID", taskId.toString())
+				    .detail("TaskID", taskId)
 				    .detail("Duration", now() - beginTime);
 			} catch (Error& failTaskError) {
 				if (failTaskError.code() == error_code_actor_cancelled) {
@@ -1243,7 +1243,7 @@ ACTOR Future<Void> doBulkLoadTask(Reference<DataDistributor> self, KeyRange rang
 				    .detail("Phase", "Failed to mark task error. Error should be bulkload_task_outdated")
 				    .detail("CancelledDataMovePriority", ack.dataMovePriority)
 				    .detail("Range", range)
-				    .detail("TaskID", taskId.toString())
+				    .detail("TaskID", taskId)
 				    .detail("Duration", now() - beginTime);
 				if (failTaskError.code() == error_code_movekeys_conflict) {
 					throw failTaskError;
@@ -1255,7 +1255,7 @@ ACTOR Future<Void> doBulkLoadTask(Reference<DataDistributor> self, KeyRange rang
 			TraceEvent(bulkLoadPerfEventSev(), "DDBulkLoadTaskDoTask", self->ddId)
 			    .detail("Phase", "Task complete")
 			    .detail("Range", range)
-			    .detail("TaskID", taskId.toString())
+			    .detail("TaskID", taskId)
 			    .detail("Duration", now() - beginTime);
 		}
 	} catch (Error& e) {
@@ -1266,7 +1266,7 @@ ACTOR Future<Void> doBulkLoadTask(Reference<DataDistributor> self, KeyRange rang
 		    .errorUnsuppressed(e)
 		    .detail("Phase", "Error")
 		    .detail("Range", range)
-		    .detail("TaskID", taskId.toString())
+		    .detail("TaskID", taskId)
 		    .detail("Duration", now() - beginTime);
 		if (e.code() == error_code_movekeys_conflict) {
 			throw e; // trigger DD restarts, which resets bulkLoadEngineParallelismLimitor
@@ -1293,7 +1293,7 @@ ACTOR Future<Void> eraseBulkLoadTask(Reference<DataDistributor> self, KeyRange t
 			TraceEvent(bulkLoadVerboseEventSev(), "DDBulkLoadTaskEraseState", self->ddId)
 			    .detail("CommitVersion", commitVersion)
 			    .detail("TaskRange", taskRange)
-			    .detail("TaskID", taskId.toString());
+			    .detail("TaskID", taskId);
 			self->bulkLoadTaskCollection->eraseTask(bulkLoadTask);
 			Optional<int> cancelledDataMovePriority = bulkLoadTask.getCancelledDataMovePriority();
 			if (cancelledDataMovePriority.present() &&
@@ -1304,7 +1304,7 @@ ACTOR Future<Void> eraseBulkLoadTask(Reference<DataDistributor> self, KeyRange t
 				TraceEvent(bulkLoadVerboseEventSev(), "DDBulkLoadTaskTriggerShardDatamove", self->ddId)
 				    .detail("CommitVersion", commitVersion)
 				    .detail("TaskRange", taskRange)
-				    .detail("TaskID", taskId.toString());
+				    .detail("TaskID", taskId);
 			}
 			break;
 		} catch (Error& e) {
@@ -1312,7 +1312,7 @@ ACTOR Future<Void> eraseBulkLoadTask(Reference<DataDistributor> self, KeyRange t
 				TraceEvent(SevWarn, "DDBulkLoadTaskEraseStateError", self->ddId)
 				    .errorUnsuppressed(e)
 				    .detail("TaskRange", taskRange)
-				    .detail("TaskId", taskId.toString());
+				    .detail("TaskID", taskId);
 			}
 			if (e.code() == error_code_bulkload_task_outdated) {
 				// Silently exit
@@ -1483,10 +1483,12 @@ ACTOR Future<Optional<BulkLoadTaskState>> bulkLoadJobFindTask(Reference<DataDist
 			ASSERT(result[0].key != result[1].key);
 			if (bulkLoadTaskState.getRange() != currentRange) {
 				TraceEvent(SevError, "DDBulkLoadJobExecutorFindRangeMismatch", logId)
-				    .setMaxEventLength(-1)
-				    .setMaxFieldLength(-1)
+				    .detail("InputRange", range)
+				    .detail("InputJobID", jobId)
 				    .detail("CurrentRange", currentRange)
-				    .detail("BulkLoadTask", bulkLoadTaskState.toString());
+				    .detail("TaskRange", bulkLoadTaskState.getRange())
+				    .detail("TaskID", bulkLoadTaskState.getTaskId())
+				    .detail("JobID", bulkLoadTaskState.getJobId());
 				ASSERT(false);
 			}
 			break;
@@ -1514,11 +1516,11 @@ ACTOR Future<BulkLoadTaskState> bulkLoadJobSubmitTask(Reference<DataDistributor>
 			wait(tr.commit());
 			Version commitVersion = tr.getCommittedVersion();
 			TraceEvent(bulkLoadVerboseEventSev(), "DDBulkLoadJobExecutorSubmitTask", self->ddId)
-			    .detail("JobId", jobId.toString())
-			    .detail("Manifest", manifests.size())
-			    .detail("TaskID", bulkLoadTask.getTaskId().toString())
-			    .detail("TaskRange", bulkLoadTask.getRange().toString())
-			    .detail("JobID", bulkLoadTask.getJobId().toString())
+			    .detail("InputJobID", jobId)
+			    .detail("ManifestCount", manifests.size())
+			    .detail("TaskID", bulkLoadTask.getTaskId())
+			    .detail("TaskRange", bulkLoadTask.getRange())
+			    .detail("TaskJobID", bulkLoadTask.getJobId())
 			    .detail("CommitVersion", commitVersion);
 			break;
 		} catch (Error& e) {
@@ -1553,10 +1555,10 @@ ACTOR Future<Void> bulkLoadJobWaitUntilTaskCompleteOrError(Reference<DataDistrib
 			}
 			if (currentTask.phase == BulkLoadPhase::Error) {
 				TraceEvent(SevWarnAlways, "DDBulkLoadJobExecutorFindUnretrievableError", self->ddId)
-				    .setMaxEventLength(-1)
-				    .setMaxFieldLength(-1)
-				    .detail("JobId", jobId.toString())
-				    .detail("Task", currentTask.toString());
+				    .detail("InputJobID", jobId)
+				    .detail("TaskJobID", currentTask.getJobId())
+				    .detail("TaskRange", currentTask.getRange())
+				    .detail("TaskID", currentTask.getTaskId());
 				return Void();
 			}
 			if (currentTask.phase == BulkLoadPhase::Complete || currentTask.phase == BulkLoadPhase::Acknowledged) {
@@ -1565,7 +1567,7 @@ ACTOR Future<Void> bulkLoadJobWaitUntilTaskCompleteOrError(Reference<DataDistrib
 		} catch (Error& e) {
 			wait(tr.onError(e));
 		}
-		wait(delay(10.0));
+		wait(delay(SERVER_KNOBS->DD_BULKLOAD_JOB_MONITOR_PERIOD_SEC));
 	}
 }
 
@@ -1593,7 +1595,7 @@ ACTOR Future<Void> bulkLoadJobNewTask(Reference<DataDistributor> self,
 		               manifestEntries, manifestLocalTempFolder, jobTransportMethod, jobRoot, self->ddId)));
 
 		// Step 2: Check if the task has been created
-		// We define the task range is the range between the min begin key and the max end key of all manifests
+		// We define the task range as the range between the min begin key and the max end key of all manifests
 		Optional<BulkLoadTaskState> bulkLoadTask_ = wait(bulkLoadJobFindTask(
 		    self, KeyRangeRef(manifests.getMinBeginKey(), manifests.getMaxEndKey()), jobId, self->ddId));
 		if (bulkLoadTask_.present()) {
@@ -1604,15 +1606,15 @@ ACTOR Future<Void> bulkLoadJobNewTask(Reference<DataDistributor> self,
 
 		// Step 3: Trigger bulkload task which is handled by bulkload task engine
 		// Discussion about what if another newer job has persist some task on the range with a different
-		// job Id. This case should never happens because before the newer job starts, the old job has been
+		// job Id. This case should never happen because before the newer job starts, the old job has
 		// completed or cancelled.
 		wait(store(bulkLoadTask, bulkLoadJobSubmitTask(self, jobId, manifests)));
 
 		TraceEvent(bulkLoadVerboseEventSev(), "DDBulkLoadJobExecutorTask", self->ddId)
 		    .detail("Phase", "Task submitted")
-		    .detail("JobID", jobId.toString())
-		    .detail("TaskID", bulkLoadTask.getTaskId().toString())
-		    .detail("TaskRange", bulkLoadTask.getRange().toString())
+		    .detail("JobID", jobId)
+		    .detail("TaskID", bulkLoadTask.getTaskId())
+		    .detail("TaskRange", bulkLoadTask.getRange())
 		    .detail("Duration", now() - beginTime);
 
 		if (g_network->isSimulated() && deterministicRandom()->random01() < 0.1) {
@@ -1624,9 +1626,9 @@ ACTOR Future<Void> bulkLoadJobNewTask(Reference<DataDistributor> self,
 		wait(bulkLoadJobWaitUntilTaskCompleteOrError(self, jobId, bulkLoadTask));
 		TraceEvent(bulkLoadPerfEventSev(), "DDBulkLoadJobExecutorTask", self->ddId)
 		    .detail("Phase", "Task complete")
-		    .detail("JobId", jobId.toString())
-		    .detail("TaskId", bulkLoadTask.getTaskId().toString())
-		    .detail("TaskRange", bulkLoadTask.getRange().toString())
+		    .detail("JobID", jobId)
+		    .detail("TaskID", bulkLoadTask.getTaskId())
+		    .detail("TaskRange", bulkLoadTask.getRange())
 		    .detail("Duration", now() - beginTime);
 		self->bulkLoadParallelismLimitor.decrementTaskCounter();
 	} catch (Error& e) {
@@ -1635,9 +1637,9 @@ ACTOR Future<Void> bulkLoadJobNewTask(Reference<DataDistributor> self,
 		}
 		TraceEvent(SevWarn, "DDBulkLoadJobExecutorTaskError", self->ddId)
 		    .errorUnsuppressed(e)
-		    .detail("JobId", jobId.toString())
-		    .detail("TaskId", bulkLoadTask.getTaskId().toString())
-		    .detail("TaskRange", bulkLoadTask.getRange().toString())
+		    .detail("JobID", jobId)
+		    .detail("TaskID", bulkLoadTask.getTaskId())
+		    .detail("TaskRange", bulkLoadTask.getRange())
 		    .detail("Duration", now() - beginTime);
 		self->bulkLoadParallelismLimitor.decrementTaskCounter();
 		if (errorOut.canBeSet()) {
@@ -1672,9 +1674,9 @@ ACTOR Future<Void> bulkLoadJobMonitorTask(Reference<DataDistributor> self,
 		bulkLoadTask = bulkLoadTask_.get();
 		TraceEvent(bulkLoadVerboseEventSev(), "DDBulkLoadJobExecutorTask", self->ddId)
 		    .detail("Phase", "Task found")
-		    .detail("JobID", jobId.toString())
-		    .detail("TaskID", bulkLoadTask.getTaskId().toString())
-		    .detail("TaskRange", bulkLoadTask.getRange().toString())
+		    .detail("JobID", jobId)
+		    .detail("TaskID", bulkLoadTask.getTaskId())
+		    .detail("TaskRange", bulkLoadTask.getRange())
 		    .detail("Duration", now() - beginTime);
 
 		if (g_network->isSimulated() && deterministicRandom()->random01() < 0.1) {
@@ -1686,8 +1688,8 @@ ACTOR Future<Void> bulkLoadJobMonitorTask(Reference<DataDistributor> self,
 		wait(bulkLoadJobWaitUntilTaskCompleteOrError(self, jobId, bulkLoadTask));
 		TraceEvent(bulkLoadPerfEventSev(), "DDBulkLoadJobExecutorTask", self->ddId)
 		    .detail("Phase", "Found task complete")
-		    .detail("JobID", jobId.toString())
-		    .detail("TaskID", bulkLoadTask.getTaskId().toString())
+		    .detail("JobID", jobId)
+		    .detail("TaskID", bulkLoadTask.getTaskId())
 		    .detail("Duration", now() - beginTime);
 		self->bulkLoadParallelismLimitor.decrementTaskCounter();
 	} catch (Error& e) {
@@ -1696,8 +1698,8 @@ ACTOR Future<Void> bulkLoadJobMonitorTask(Reference<DataDistributor> self,
 		}
 		TraceEvent(SevWarn, "DDBulkLoadJobExecutorTaskMonitorError", self->ddId)
 		    .errorUnsuppressed(e)
-		    .detail("JobID", jobId.toString())
-		    .detail("TaskID", bulkLoadTask.getTaskId().toString())
+		    .detail("JobID", jobId)
+		    .detail("TaskID", bulkLoadTask.getTaskId())
 		    .detail("Duration", now() - beginTime);
 		self->bulkLoadParallelismLimitor.decrementTaskCounter();
 		if (errorOut.canBeSet()) {
@@ -1725,12 +1727,11 @@ ACTOR Future<Void> persistBulkLoadJobTaskCount(Reference<DataDistributor> self) 
 			if (currentJobState.getTaskCount().present()) {
 				if (currentJobState.getTaskCount().get() != taskCount) {
 					TraceEvent(SevError, "DDBulkLoadJobManagerFindTaskCountMismatch", self->ddId)
-					    .setMaxEventLength(-1)
-					    .setMaxFieldLength(-1)
-					    .detail("JobID", jobId.toString())
+					    .detail("JobID", jobId)
 					    .detail("JobRange", jobRange)
 					    .detail("InputTaskCount", taskCount)
-					    .detail("CurrentJob", currentJobState.toString());
+					    .detail("CurrentJobID", currentJobState.getJobId())
+					    .detail("CurrentJobRange", currentJobState.getJobRange());
 					ASSERT(false);
 				}
 				return Void();
@@ -1740,7 +1741,7 @@ ACTOR Future<Void> persistBulkLoadJobTaskCount(Reference<DataDistributor> self) 
 			wait(tr.commit());
 			Version commitVersion = tr.getCommittedVersion();
 			TraceEvent(SevInfo, "DDBulkLoadJobManagerPersistTaskCountToJobMetadata", self->ddId)
-			    .detail("JobID", jobId.toString())
+			    .detail("JobID", jobId)
 			    .detail("JobRange", jobRange)
 			    .detail("CommitVersion", commitVersion)
 			    .detail("TaskCount", taskCount);
@@ -1970,26 +1971,26 @@ ACTOR Future<bool> checkBulkLoadTaskCompleteOrError(Reference<DataDistributor> s
 				// So, any existing bulkload job id must match the running job id.
 				if (existTask.getJobId() != jobState.getJobId()) {
 					TraceEvent(SevError, "DDBulkLoadJobManagerFindIdMisMatch", self->ddId)
-					    .setMaxEventLength(-1)
-					    .setMaxFieldLength(-1)
-					    .detail("Task", existTask.toString())
-					    .detail("JobId", jobState.getJobId());
+					    .detail("TaskJobID", existTask.getJobId())
+					    .detail("TaskID", existTask.getTaskId())
+					    .detail("TaskRange", existTask.getRange())
+					    .detail("InputJobID", jobState.getJobId());
 					ASSERT(false);
 				}
 				if (existTask.phase == BulkLoadPhase::Error) {
 					TraceEvent(SevWarnAlways, "DDBulkLoadJobManagerFindErrorTask", self->ddId)
-					    .setMaxEventLength(-1)
-					    .setMaxFieldLength(-1)
-					    .detail("Task", existTask.toString())
-					    .detail("Job", jobState.toString());
+					    .detail("TaskJobID", existTask.getJobId())
+					    .detail("TaskID", existTask.getTaskId())
+					    .detail("TaskRange", existTask.getRange())
+					    .detail("InputJobID", jobState.getJobId());
 					continue;
 				}
 				if (existTask.phase != BulkLoadPhase::Complete) {
 					TraceEvent(SevDebug, "DDBulkLoadJobManageFindRunningTask", self->ddId)
-					    .setMaxEventLength(-1)
-					    .setMaxFieldLength(-1)
-					    .detail("ExistTask", existTask.toString())
-					    .detail("Job", jobState.toString());
+					    .detail("TaskJobID", existTask.getJobId())
+					    .detail("TaskID", existTask.getTaskId())
+					    .detail("TaskRange", existTask.getRange())
+					    .detail("InputJobID", jobState.getJobId());
 					return false;
 				}
 			}
@@ -2038,18 +2039,21 @@ ACTOR Future<Void> finalizeBulkLoadJob(Reference<DataDistributor> self) {
 				ASSERT(existTask.getJobId() == jobState.getJobId());
 				if (existTask.phase == BulkLoadPhase::Error) {
 					TraceEvent(SevWarnAlways, "DDBulkLoadJobManagerStopClearMetadata", self->ddId)
-					    .setMaxEventLength(-1)
-					    .setMaxFieldLength(-1)
-					    .detail("Job", jobState.toString())
-					    .detail("ExistTask", existTask.toString());
+					    .detail("JobID", jobState.getJobId())
+					    .detail("JobRange", jobState.getJobRange())
+					    .detail("ExistTaskJobID", existTask.getJobId())
+					    .detail("ExistTaskID", existTask.getTaskId())
+					    .detail("ExistTaskRange", existTask.getRange());
 					// User should manually ack an error task.
 					hasError = true;
 				} else {
 					if (existTask.phase != BulkLoadPhase::Complete && existTask.phase != BulkLoadPhase::Acknowledged) {
 						TraceEvent(SevError, "DDBulkLoadJobManagerWrongTaskPhase", self->ddId)
-						    .setMaxEventLength(-1)
-						    .setMaxFieldLength(-1)
-						    .detail("Task", existTask.toString());
+						    .detail("JobID", jobState.getJobId())
+						    .detail("JobRange", jobState.getJobRange())
+						    .detail("ExistTaskJobID", existTask.getJobId())
+						    .detail("ExistTaskID", existTask.getTaskId())
+						    .detail("ExistTaskRange", existTask.getRange());
 						ASSERT(false);
 					}
 					// Persist metadata and turn on traffic
@@ -2078,12 +2082,14 @@ ACTOR Future<Void> finalizeBulkLoadJob(Reference<DataDistributor> self) {
 			wait(tr.commit());
 			Version commitVersion = tr.getCommittedVersion();
 			TraceEvent(SevInfo, "DDBulkLoadJobManagerFinalizeRange", self->ddId)
-			    .setMaxEventLength(-1)
-			    .setMaxFieldLength(-1)
 			    .detail("JobCompleteRange", jobCompleteRange)
-			    .detail("Task", existTask.toString())
 			    .detail("CommitVersion", commitVersion)
-			    .detail("AllFinish", allFinish);
+			    .detail("AllFinish", allFinish)
+			    .detail("JobID", jobState.getJobId())
+			    .detail("JobRange", jobState.getJobRange())
+			    .detail("ExistTaskJobID", existTask.getJobId())
+			    .detail("ExistTaskID", existTask.getTaskId())
+			    .detail("ExistTaskRange", existTask.getRange());
 			beginKey = lastKey.get();
 		} catch (Error& e) {
 			wait(tr.onError(e));
@@ -2111,10 +2117,8 @@ ACTOR Future<Void> bulkLoadJobManager(Reference<DataDistributor> self) {
 	// Build up bulkLoadJobManager if a new job starts or the bulkLoadJobManager has not been set up.
 	if (!self->bulkLoadJobManager.present() || self->bulkLoadJobManager.get().jobState.getJobId() != jobId) {
 		TraceEvent(SevInfo, "DDBulkLoadJobManagerBuild", self->ddId)
-		    .setMaxEventLength(-1)
-		    .setMaxFieldLength(-1)
-		    .detail("OldJob",
-		            self->bulkLoadJobManager.present() ? self->bulkLoadJobManager.get().jobState.toString()
+		    .detail("OldJobID",
+		            self->bulkLoadJobManager.present() ? self->bulkLoadJobManager.get().jobState.getJobId().toString()
 		                                               : "No old job")
 		    .detail("NewJobId", jobId)
 		    .detail("NewJobRange", jobRange)
@@ -2134,9 +2138,8 @@ ACTOR Future<Void> bulkLoadJobManager(Reference<DataDistributor> self) {
 		wait(persistBulkLoadJobTaskCount(self));
 	} else {
 		TraceEvent(SevInfo, "DDBulkLoadJobManagerExist", self->ddId)
-		    .setMaxEventLength(-1)
-		    .setMaxFieldLength(-1)
-		    .detail("Job", self->bulkLoadJobManager.get().jobState.toString());
+		    .detail("JobID", self->bulkLoadJobManager.get().jobState.getJobId())
+		    .detail("JobRange", self->bulkLoadJobManager.get().jobState.getJobRange());
 	}
 
 	// At this point, bulkLoadJobManager must be available.
@@ -2151,9 +2154,8 @@ ACTOR Future<Void> bulkLoadJobManager(Reference<DataDistributor> self) {
 		bool complete = wait(checkBulkLoadTaskCompleteOrError(self));
 		if (complete) {
 			TraceEvent(SevInfo, "DDBulkLoadJobManagerAllTaskComplete", self->ddId)
-			    .setMaxEventLength(-1)
-			    .setMaxFieldLength(-1)
-			    .detail("Job", self->bulkLoadJobManager.get().jobState.toString());
+			    .detail("JobID", self->bulkLoadJobManager.get().jobState.getJobId())
+			    .detail("JobRange", self->bulkLoadJobManager.get().jobState.getJobRange());
 			wait(finalizeBulkLoadJob(self));
 			break; // end
 		} else {
@@ -2165,9 +2167,8 @@ ACTOR Future<Void> bulkLoadJobManager(Reference<DataDistributor> self) {
 			// Note that bulkLoadJobExecuteTask simply does transaction to create and monitor
 			// the bulkload task. The error is expected to be bulkload_task_outdated error.
 			TraceEvent(SevInfo, "DDBulkLoadJobManagerTaskDispatched", self->ddId)
-			    .setMaxEventLength(-1)
-			    .setMaxFieldLength(-1)
-			    .detail("Job", self->bulkLoadJobManager.get().jobState.toString());
+			    .detail("JobID", self->bulkLoadJobManager.get().jobState.getJobId())
+			    .detail("JobRange", self->bulkLoadJobManager.get().jobState.getJobRange());
 		}
 		wait(delay(SERVER_KNOBS->DD_BULKLOAD_SCHEDULE_MIN_INTERVAL_SEC));
 	}
@@ -2204,11 +2205,10 @@ ACTOR Future<Void> doBulkDumpTask(Reference<DataDistributor> self,
 	ASSERT(self->bulkDumpParallelismLimitor.canStart());
 	self->bulkDumpParallelismLimitor.incrementTaskCounter();
 	TraceEvent(bulkLoadVerboseEventSev(), "DDBulkDumpDoTaskStart", self->ddId)
-	    .setMaxEventLength(-1)
-	    .setMaxFieldLength(-1)
-	    .detail("TaskId", bulkDumpState.getTaskId())
+	    .detail("TaskID", bulkDumpState.getTaskId())
 	    .detail("TargetSS", ssi.id())
-	    .detail("BulkDumpState", bulkDumpState.toString());
+	    .detail("TaskRange", bulkDumpState.getRange())
+	    .detail("JobID", bulkDumpState.getJobRange());
 	try {
 		ErrorOr<BulkDumpState> vResult =
 		    wait(ssi.bulkdump.tryGetReply(BulkDumpRequest(checksumServers, bulkDumpState)));
@@ -2216,23 +2216,21 @@ ACTOR Future<Void> doBulkDumpTask(Reference<DataDistributor> self,
 			throw vResult.getError();
 		}
 		TraceEvent(bulkLoadVerboseEventSev(), "DDBulkDumpDoTaskComplete", self->ddId)
-		    .setMaxEventLength(-1)
-		    .setMaxFieldLength(-1)
-		    .detail("TaskId", bulkDumpState.getTaskId())
+		    .detail("TaskID", bulkDumpState.getTaskId())
 		    .detail("TargetSS", ssi.id())
-		    .detail("BulkDumpState", bulkDumpState.toString())
+		    .detail("TaskRange", bulkDumpState.getRange())
+		    .detail("JobID", bulkDumpState.getJobRange())
 		    .detail("Duration", now() - beginTime);
 	} catch (Error& e) {
 		if (e.code() == error_code_actor_cancelled) {
 			throw e;
 		}
 		TraceEvent(bulkLoadVerboseEventSev(), "DDBulkDumpDoTaskError", self->ddId)
-		    .setMaxEventLength(-1)
-		    .setMaxFieldLength(-1)
 		    .errorUnsuppressed(e)
-		    .detail("TaskId", bulkDumpState.getTaskId())
+		    .detail("TaskID", bulkDumpState.getTaskId())
 		    .detail("TargetSS", ssi.id())
-		    .detail("BulkDumpState", bulkDumpState.toString())
+		    .detail("TaskRange", bulkDumpState.getRange())
+		    .detail("JobID", bulkDumpState.getJobRange())
 		    .detail("Duration", now() - beginTime);
 		if (e.code() == error_code_movekeys_conflict) {
 			throw e; // trigger DD restarts, which resets bulkDumpParallelismLimitor
@@ -2321,10 +2319,11 @@ ACTOR Future<Void> scheduleBulkDumpJob(Reference<DataDistributor> self) {
 					                                        bulkDumpState.generateRangeTask(taskRange));
 					// Issue task
 					TraceEvent(bulkLoadVerboseEventSev(), "DDBulkDumpJobSpawnRange", self->ddId)
-					    .setMaxEventLength(-1)
-					    .setMaxFieldLength(-1)
-					    .detail("JobId", jobId)
-					    .detail("Task", task.toString());
+					    .detail("JobID", jobId)
+					    .detail("TargetSS", task.targetServer.id())
+					    .detail("TaskJobID", bulkDumpState.getJobId())
+					    .detail("TaskRange", taskRange)
+					    .detail("TaskID", task.bulkDumpState.getTaskId());
 					actors.push_back(doBulkDumpTask(self, task.targetServer, task.bulkDumpState, task.checksumServers));
 				}
 				beginKey = rangeLocations.back().range.end;

--- a/fdbserver/include/fdbserver/DataDistribution.actor.h
+++ b/fdbserver/include/fdbserver/DataDistribution.actor.h
@@ -661,12 +661,12 @@ public:
 				it->value().get().completeAck.sendError(bulkload_task_outdated());
 				TraceEvent(bulkLoadVerboseEventSev(), "DDBulkLoadTaskCollectionPublishTaskOverwriteTask", ddId)
 				    .detail("NewTaskRange", bulkLoadTaskState.getRange())
-				    .detail("NewJobId", task.coreState.getJobId().toString())
-				    .detail("NewTaskId", task.coreState.getTaskId().toString())
+				    .detail("NewJobId", task.coreState.getJobId())
+				    .detail("NewTaskId", task.coreState.getTaskId())
 				    .detail("NewCommitVersion", task.commitVersion)
 				    .detail("OldTaskRange", it->range())
-				    .detail("OldJobId", it->value().get().coreState.getJobId().toString())
-				    .detail("OldTaskId", it->value().get().coreState.getTaskId().toString())
+				    .detail("OldJobId", it->value().get().coreState.getJobId())
+				    .detail("OldTaskId", it->value().get().coreState.getTaskId())
 				    .detail("OldCommitVersion", it->value().get().commitVersion);
 			}
 		}


### PR DESCRIPTION
This PR includes:
1. Make bulkload scheduling more efficient by aggressively submitting bulkload tasks.
2. Remove heavy trace event fields for all bulkload/dump related trace events.
3. Make sure all trace events for Job or Task can be searched by the JobID or TaskID.
4. Add DD Knob `DD_BULKLOAD_JOB_MONITOR_PERIOD_SEC` to tune the period of reading metadata when monitoring the progress of a task.
5. Fix taskCount number in BulkLoadCommand.
6. Add comments and address comments in PR: https://github.com/apple/foundationdb/pull/12036


100K Correctness:
  20250318-221614-zhewang-ced5ce138894c19e           compressed=True data_size=41053244 fail_fast=10 max_runs=100000 priority=100 sanity=False submitted=20250318-221614 timeout=5400 username=zhewang
      
500K BulkDump:
  20250318-184544-zhewang-945a18eb66af3941           compressed=True data_size=41095119 duration=19638610 ended=500000 fail_fast=10 max_runs=500000 pass=500000 priority=100 remaining=0 runtime=3:29:50 sanity=False started=500000 stopped=20250318-221534 submitted=20250318-184544 timeout=5400 username=zhewang
    
500K BulkLoad:
  20250318-230230-zhewang-c9bb00932778c9a4           compressed=True data_size=41095183 fail_fast=10 max_runs=500000 priority=100 sanity=False submitted=20250318-230230 timeout=5400 username=zhewang
      
  
# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
