### PR TITLE
Fix a restore bug due to a race [release-7.3]

### DIFF
--- a/fdbclient/FileBackupAgent.actor.cpp
+++ b/fdbclient/FileBackupAgent.actor.cpp
@@ -5086,7 +5086,7 @@ struct LogInfo : public ReferenceCounted<LogInfo> {
 	Version endVersion;
 	int64_t offset;
 
-	LogInfo() : offset(0){};
+	LogInfo() : offset(0) {}
 };
 
 class FileBackupAgentImpl {

--- a/fdbclient/include/fdbclient/BackupAgent.actor.h
+++ b/fdbclient/include/fdbclient/BackupAgent.actor.h
@@ -520,12 +520,13 @@ public:
 
 using RangeResultWithVersion = std::pair<RangeResult, Version>;
 
+// RCGroup contains the backup mutations for a commit version, i.e., groupKey.
 struct RCGroup {
 	RangeResult items;
-	Version version;
-	uint64_t groupKey;
+	Version version; // this is read version for this group
+	Version groupKey; // this is the original commit version for this group
 
-	RCGroup() : version(-1), groupKey(ULLONG_MAX){};
+	RCGroup() : version(-1), groupKey(ULLONG_MAX) {}
 
 	template <class Ar>
 	void serialize(Ar& ar) {
@@ -569,6 +570,8 @@ ACTOR Future<Void> readCommitted(Database cx,
                                  Terminator terminator = Terminator::True,
                                  AccessSystemKeys systemAccess = AccessSystemKeys::False,
                                  LockAware lockAware = LockAware::False);
+
+// Applies the mutations between the beginVersion and endVersion to the database during a restore.
 ACTOR Future<Void> applyMutations(Database cx,
                                   Key uid,
                                   Key addPrefix,


### PR DESCRIPTION
cherrypick #12037

20250319-043859-jzhou-f180ec751c099669             compressed=True data_size=34291720 duration=6526800 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:05:30 sanity=False started=100000 stopped=20250319-054429 submitted=20250319-043859 timeout=5400 username=jzhou

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
