### PR TITLE
Disable RandomRangeLock in Watches workload

### DIFF
--- a/fdbserver/workloads/Watches.actor.cpp
+++ b/fdbserver/workloads/Watches.actor.cpp
@@ -88,6 +88,16 @@ struct WatchesWorkload : TestWorkload {
 		}
 	}
 
+	void disableFailureInjectionWorkloads(std::set<std::string>& out) const override {
+		// The Watches workload creates a chain of nodes (key-value pairs). It's the job of watcher
+		// actor to then propagate value from node i to node i+1. Eventually the value should propagate
+		// all the way to the end of the chain. The watchesWorker actor has a watch on the end node's key.
+		// RandomRangeLocks workload can lock ranges that are in this node chain keyspace. As a result, sometimes
+		// value propagation is blocked, and therefore, the watch on the end node's key never fires, causing
+		// the test to fail. To fix this issue, we disable RandomRangeLock workload injection.
+		out.insert("RandomRangeLock");
+	}
+
 	Key keyForIndex(uint64_t index) {
 		Key result = makeString(keyBytes);
 		uint8_t* data = mutateString(result);


### PR DESCRIPTION
# Description

The Watches workload creates a chain of nodes (key-value pairs). It's the job of watcher actor to then propagate value from node i to node i+1. Eventually the value should propagate all the way to the end of the chain. The watchesWorker actor has a watch on the end node's key. 

RandomRangeLocks workload can lock ranges that are in this node chain keyspace. As a result, sometimes value propagation is blocked, and therefore, the watch on the end node's key never fires, causing the test to fail. 

To fix this issue, I disabled RandomRangeLock workload injection in the Watches workload.

# Testing

Ran Watches.toml 100K times.

Before this change: `20250320-071005-praza-r146970225-fix-6fa83c231dcb131572f2919`

After this change: `20250320-071151-praza-r146970225-fix-b0a8bbe9ad5bd232b8e33c1`

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
