### PR TITLE
Fix backup worker assertion failure on memory usage

### DIFF
--- a/design/backup_v2_partitioned_logs.md
+++ b/design/backup_v2_partitioned_logs.md
@@ -168,7 +168,7 @@ From an end-to-end perspective, the new backup system works in the following ste
 4. Periodically, backup workers upload mutations to the requested blob storage, and save the progress into the database;
 5. The backup is restorable when backup workers have saved versions that are larger than the complete snapshot’s end version, and the backup is stopped if a stop on restorable flag is set in the request.
 
-The new backup has four major components: 1) backup workers; 2) recruitment of backup workers; 3) extension of tag partitioned log system to support pseudo tags; 4) integration with existing `TaskBucket` based backup command interface; and 5) integration with the Performant Restore System.
+The new backup has the following major components: 1) backup workers; 2) recruitment of backup workers; 3) extension of tag partitioned log system to support pseudo tags; 4) integration with existing `TaskBucket` based backup command interface; and 5) integration with the existing `TaskBucket` based restore system to read partitioned mutation logs.
 
 ### Backup workers
 

--- a/fdbserver/BackupWorker.actor.cpp
+++ b/fdbserver/BackupWorker.actor.cpp
@@ -1085,8 +1085,8 @@ ACTOR Future<Void> pullAsyncData(BackupData* self) {
 		// messages/mutations will be flushed to disk/blob in uploadData().
 		state int64_t peekedBytes = 0;
 		// Hold messages until we know how many we can take, self->messages always
-		// contains messages that have been reserved memory for. I.e., lock->release()
-		// will not encounter message that has not been reserved memory.
+		// contains messages that we have reserved memory for. Therefore, lock->release()
+		// will always encounter message with reserved memory.
 		state std::vector<VersionedMessage> tmpMessages;
 		while (r->hasMessage()) {
 			tmpMessages.emplace_back(r->version(), r->getMessage(), r->getTags(), r->arena());

--- a/fdbserver/BackupWorker.actor.cpp
+++ b/fdbserver/BackupWorker.actor.cpp
@@ -480,7 +480,7 @@ struct BackupData {
 				// Save the noop pop version, which sets min version for
 				// the next backup job. Note this version may change after the wait.
 				state Version popVersion = self->popTrigger.get();
-				ASSERT(self->popVersion < popVersion);
+				ASSERT(self->popVersion <= popVersion);
 				wait(_saveNoopVersion(self, popVersion));
 				self->popVersion = popVersion;
 				TraceEvent("BackupWorkerNoopPop", self->myId)
@@ -1157,7 +1157,7 @@ ACTOR Future<Void> monitorBackupKeyOrPullData(BackupData* self, bool keyPresent)
 						    std::max(committedVersion.get(), self->minKnownCommittedVersion);
 						if (newPopVersion < self->popTrigger.get()) {
 							// this can happen if a different GRV proxy replies
-							DisabledTraceEvent("BackupWorkerNoopPop", self->myId)
+							DisabledTraceEvent("BackupWorkerSkipTrigger", self->myId)
 							    .detail("Version", newPopVersion)
 							    .detail("OldPop", self->popTrigger.get());
 						} else {

--- a/fdbserver/BackupWorker.actor.cpp
+++ b/fdbserver/BackupWorker.actor.cpp
@@ -381,7 +381,7 @@ struct BackupData {
 		    .detail("Release", toRelease)
 		    .detail("Total", lock->activePermits());
 		lock->release(toRelease); // Unblocks lock->take()
-		if (bytes > toRelease) {
+		if (bytes > toRelease && pulling) {
 			TraceEvent(SevDebugMemory, "BackupWorkerMemory2", myId)
 			    .detail("Release", bytes - toRelease)
 			    .detail("Total", lock->activePermits());

--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -253,7 +253,7 @@ Version TagPartitionedLogSystem::popPseudoLocalityTag(Tag tag, Version upTo) {
 	for (const int8_t locality : pseudoLocalities) {
 		minVersion = std::min(minVersion, pseudoLocalityPopVersion[Tag(locality, tag.id)]);
 	}
-	// TraceEvent("TLogPopPseudoTag", dbgid).detail("Tag", tag.toString()).detail("Version", upTo).detail("PopVersion", minVersion);
+	// TraceEvent("TLogPopPseudoTag", dbgid).detail("Tag", tag).detail("Version", upTo).detail("PopVersion", minVersion);
 	return minVersion;
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,7 +8,7 @@ set(TEST_KEEP_LOGS "FAILED" CACHE STRING "Which logs to keep (NONE, FAILED, ALL)
 set(TEST_KEEP_SIMDIR "NONE" CACHE STRING "Which simfdb directories to keep (NONE, FAILED, ALL)")
 set(TEST_AGGREGATE_TRACES "NONE" CACHE STRING "Create aggregated trace files (NONE, FAILED, ALL)")
 set(TEST_LOG_FORMAT "xml" CACHE STRING "Format for test trace files (xml, json)")
-set(TEST_INCLUDE ".*" CACHE STRING "Include only tests that match the given regex")
+set(TEST_INCLUDE "ParallelRestoreNewBackupCorrectnessAtomicOp.toml" CACHE STRING "Include only tests that match the given regex")
 set(TEST_EXCLUDE ".^" CACHE STRING "Exclude all tests matching the given regex")
 set(SANITIZER_OPTIONS "UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1;TSAN_OPTIONS=suppressions=${CMAKE_SOURCE_DIR}/contrib/tsan.suppressions;LSAN_OPTIONS=suppressions=${CMAKE_SOURCE_DIR}/contrib/lsan.suppressions" CACHE STRING "Environment variables setting sanitizer options")
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,7 +8,7 @@ set(TEST_KEEP_LOGS "FAILED" CACHE STRING "Which logs to keep (NONE, FAILED, ALL)
 set(TEST_KEEP_SIMDIR "NONE" CACHE STRING "Which simfdb directories to keep (NONE, FAILED, ALL)")
 set(TEST_AGGREGATE_TRACES "NONE" CACHE STRING "Create aggregated trace files (NONE, FAILED, ALL)")
 set(TEST_LOG_FORMAT "xml" CACHE STRING "Format for test trace files (xml, json)")
-set(TEST_INCLUDE "ParallelRestoreNewBackupCorrectnessAtomicOp.toml" CACHE STRING "Include only tests that match the given regex")
+set(TEST_INCLUDE ".*" CACHE STRING "Include only tests that match the given regex")
 set(TEST_EXCLUDE ".^" CACHE STRING "Exclude all tests matching the given regex")
 set(SANITIZER_OPTIONS "UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1;TSAN_OPTIONS=suppressions=${CMAKE_SOURCE_DIR}/contrib/tsan.suppressions;LSAN_OPTIONS=suppressions=${CMAKE_SOURCE_DIR}/contrib/lsan.suppressions" CACHE STRING "Environment variables setting sanitizer options")
 


### PR DESCRIPTION
Refactor such that messages in the queue have to reserve memory first. Thus, when we release the memory, it must have already been reserved.

The second bug fix is to disallow popped version to go lower, because different GRV proxies may return lower version.

100k ParallelRestoreNewBackupCorrectnessAtomicOp.toml
    20250321-025532-jzhou-77e2dbd5fd035157             compressed=True data_size=35955443 duration=7391647 ended=100000 fail=1 fail_fast=10 max_runs=100000 pass=99999 priority=100 remaining=0 runtime=1:25:42 sanity=False started=100000 stopped=20250321-042114 submitted=20250321-025532 timeout=5400 username=jzhou

The failure is `TracedTooManyLines` due to 200+k `CommitDummyTransactionError` and `CommitDummyTransaction` events.

100k regular  20250321-025429-jzhou-a088c3f119331b93             compressed=True data_size=35915879 duration=5379674 ended=100000 fail=1 fail_fast=10 max_runs=100000 pass=99999 priority=100 remaining=0 runtime=1:17:22 sanity=False started=100000 stopped=20250321-041151 submitted=20250321-025429 timeout=5400 username=jzhou

Unrelated ./tests/noSim/KeyValueStoreRocksDBTest.toml failure

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
