### PR TITLE
Reject Range Lock/Unlock Requests with Conflicting Range, User, or Lock Type

### DIFF
--- a/documentation/sphinx/source/rangelock.rst
+++ b/documentation/sphinx/source/rangelock.rst
@@ -45,10 +45,13 @@ A range can only be locked by a registered owner.
 The user can use the following API to register an identity and lock a range.
 
 Put an exclusive read lock on a range. The range must be within the user key space, aka ``"" ~ \xff``.
+The lock is rejected with range_lock_reject error if the range has any lock (of the same user or other users).
 
 ``ACTOR Future<Void> takeExclusiveReadLockOnRange(Database cx, KeyRange range, RangeLockOwnerName ownerUniqueID);``
 
 Release an exclusive read lock on a range. The range must be within the user key space, aka ``"" ~ \xff``.
+The lock is rejected with range_unlock_reject error if the range has any lock from other users or has lock by the same user 
+but the range of the lock is different from the input range.
 
 ``ACTOR Future<Void> releaseExclusiveReadLockOnRange(Database cx, KeyRange range, RangeLockOwnerName ownerUniqueID);``
 
@@ -58,7 +61,7 @@ If the execution is failed, no range is locked/unlocked.
 
 Get exclusive read locks on the input range
 
-``ACTOR Future<std::vector<KeyRange>> getExclusiveReadLockOnRange(Database cx, KeyRange range);``
+``ACTOR Future<std::vector<std::pair<KeyRange, RangeLockState>>> findExclusiveReadLockOnRange(Database cx, KeyRange range);``
 
 Register a range lock owner to database metadata.
 

--- a/documentation/sphinx/source/rangelock.rst
+++ b/documentation/sphinx/source/rangelock.rst
@@ -39,19 +39,19 @@ Ideally, we would use the write lock to achieve this; however, we are currently 
 
 How to use?
 -----------
-Currently, FDB only provides ManagementAPI to lock a range. 
-Before a user can lock a range, the user must register its identity to the database.
-A range can only be locked by a registered owner.
-The user can use the following API to register an identity and lock a range.
+Currently, FDB provides the ManagementAPI for range locking, intended as an interface for FDB feature development.
+Before locking a range, a user must first register their identity with the database.
+Only registered users are permitted to acquire range locks.
+The following API can be used to register an identity and lock a range.
 
 Put an exclusive read lock on a range. The range must be within the user key space, aka ``"" ~ \xff``.
-The lock is rejected with range_lock_reject error if the range has any lock (of the same user or other users).
+The locking request is rejected with a range_lock_reject error if the range contains any existing lock with a different range, user, or lock type.
+Currently, only the ExclusiveReadLock type is supported, but the design allows for future extension.
 
 ``ACTOR Future<Void> takeExclusiveReadLockOnRange(Database cx, KeyRange range, RangeLockOwnerName ownerUniqueID);``
 
 Release an exclusive read lock on a range. The range must be within the user key space, aka ``"" ~ \xff``.
-The lock is rejected with range_unlock_reject error if the range has any lock from other users or has lock by the same user 
-but the range of the lock is different from the input range.
+The release request is rejected with a range_lock_reject error if the range contains any existing lock with a different range, user, or lock type.
 
 ``ACTOR Future<Void> releaseExclusiveReadLockOnRange(Database cx, KeyRange range, RangeLockOwnerName ownerUniqueID);``
 

--- a/fdbcli/BulkLoadCommand.actor.cpp
+++ b/fdbcli/BulkLoadCommand.actor.cpp
@@ -299,7 +299,7 @@ ACTOR Future<UID> bulkLoadCommandActor(Database cx, std::vector<StringRef> token
 		}
 		std::vector<std::pair<KeyRange, RangeLockState>> lockedRanges =
 		    wait(findExclusiveReadLockOnRange(cx, normalKeys));
-		fmt::println("Total {} locked ranges", std::to_string(lockedRanges.size()));
+		fmt::println("Total {} locked ranges", lockedRanges.size());
 		if (lockedRanges.size() > 10) {
 			fmt::println("First 10 locks are:");
 		}
@@ -308,7 +308,7 @@ ACTOR Future<UID> bulkLoadCommandActor(Database cx, std::vector<StringRef> token
 			if (count > 10) {
 				break;
 			}
-			fmt::println("Lock {} on {} for {}", std::to_string(count), lock.first.toString(), lock.second.toString());
+			fmt::println("Lock {} on {} for {}", count, lock.first.toString(), lock.second.toString());
 			count++;
 		}
 		return UID();

--- a/fdbcli/BulkLoadCommand.actor.cpp
+++ b/fdbcli/BulkLoadCommand.actor.cpp
@@ -25,6 +25,7 @@
 #include "flow/IRandom.h"
 #include "flow/ThreadHelper.actor.h"
 #include "flow/actorcompiler.h" // This must be the last #include.
+#include <string>
 
 namespace fdb_cli {
 
@@ -289,6 +290,50 @@ ACTOR Future<UID> bulkLoadCommandActor(Database cx, std::vector<StringRef> token
 			}
 		}
 		printLongDesc(tokens[0]);
+		return UID();
+
+	} else if (tokencmp(tokens[1], "printlock")) {
+		// For debugging purposes and invisible to users.
+		if (tokens.size() != 2) {
+			fmt::println("{}", BULK_LOAD_STATUS_USAGE);
+			return UID();
+		}
+		std::vector<std::pair<KeyRange, RangeLockState>> lockedRanges =
+		    wait(findExclusiveReadLockOnRange(cx, normalKeys));
+		fmt::println("Total {} locked ranges", std::to_string(lockedRanges.size()));
+		if (lockedRanges.size() > 10) {
+			fmt::println("First 10 locks are:");
+		}
+		int count = 1;
+		for (const auto& lock : lockedRanges) {
+			if (count > 10) {
+				break;
+			}
+			fmt::println("Lock {} on {} for {}", std::to_string(count), lock.first.toString(), lock.second.toString());
+			count++;
+		}
+		return UID();
+
+	} else if (tokencmp(tokens[1], "printlockowner")) {
+		// For debugging purposes and invisible to users.
+		if (tokens.size() != 2) {
+			fmt::println("{}", BULK_LOAD_STATUS_USAGE);
+			return UID();
+		}
+		std::vector<RangeLockOwner> owners = wait(getAllRangeLockOwners(cx));
+		for (const auto owner : owners) {
+			fmt::println("{}", owner.toString());
+		}
+		return UID();
+
+	} else if (tokencmp(tokens[1], "clearlock")) {
+		// For debugging purposes and invisible to users.
+		if (tokens.size() != 3) {
+			fmt::println("{}", BULK_LOAD_STATUS_USAGE);
+			return UID();
+		}
+		std::string ownerUniqueID = tokens[2].toString();
+		wait(releaseExclusiveReadLockByUser(cx, ownerUniqueID));
 		return UID();
 
 	} else {

--- a/fdbcli/BulkLoadCommand.actor.cpp
+++ b/fdbcli/BulkLoadCommand.actor.cpp
@@ -25,7 +25,6 @@
 #include "flow/IRandom.h"
 #include "flow/ThreadHelper.actor.h"
 #include "flow/actorcompiler.h" // This must be the last #include.
-#include <string>
 
 namespace fdb_cli {
 

--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -3579,8 +3579,6 @@ ACTOR Future<std::vector<RangeLockOwner>> getAllRangeLockOwners(Database cx) {
 			for (const auto& kv : result) {
 				RangeLockOwner owner = decodeRangeLockOwner(kv.value);
 				ASSERT(owner.isValid());
-				// RangeLockOwnerName uidFromKey = decodeRangeLockOwnerKey(kv.key);
-				// ASSERT(owner.getOwnerUniqueId() == uidFromKey);
 				res.push_back(owner);
 				beginKey = keyAfter(kv.key);
 			}

--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -3794,6 +3794,8 @@ ACTOR Future<Void> releaseExclusiveReadLockByUser(Database cx, RangeLockOwnerNam
 				ASSERT(currentRangeLockStateSet.isValid());
 				if (currentRangeLockStateSet.isLockedFor(RangeLockType::ExclusiveReadLock) &&
 				    currentRangeLockStateSet.getAllLockStats()[0].getOwnerUniqueId() == ownerUniqueID) {
+					// TODO(BulkLoad): krmSetRangeCoalescing per small range is inefficient especially when the lock
+					// count is over 10K. Optimize this.
 					wait(krmSetRangeCoalescing(
 					    &tr, rangeLockPrefix, currentRange, normalKeys, rangeLockStateSetValue(RangeLockStateSet())));
 					wait(tr.commit());

--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -3778,7 +3778,7 @@ ACTOR Future<Void> releaseExclusiveReadLockByUser(Database cx, RangeLockOwnerNam
 	state KeyRange rangeToRead;
 	state RangeLockStateSet currentRangeLockStateSet;
 	state KeyRange currentRange;
-	loop {
+	while (beginKey < endKey) {
 		rangeToRead = Standalone(KeyRangeRef(beginKey, endKey));
 		try {
 			tr.setOption(FDBTransactionOptions::LOCK_AWARE);
@@ -3802,10 +3802,9 @@ ACTOR Future<Void> releaseExclusiveReadLockByUser(Database cx, RangeLockOwnerNam
 					tr.reset();
 					beginKey = currentRange.end;
 					break;
+				} else {
+					beginKey = currentRange.end;
 				}
-			}
-			if (beginKey == endKey) {
-				break;
 			}
 		} catch (Error& e) {
 			wait(tr.onError(e));

--- a/fdbclient/SystemData.cpp
+++ b/fdbclient/SystemData.cpp
@@ -1291,13 +1291,6 @@ const Key rangeLockOwnerKeyFor(const RangeLockOwnerName& ownerUniqueID) {
 	return wr.toValue();
 }
 
-const RangeLockOwnerName decodeRangeLockOwnerKey(const KeyRef& key) {
-	std::string ownerUniqueID;
-	BinaryReader rd(key.removePrefix(rangeLockOwnerPrefix), Unversioned());
-	rd >> ownerUniqueID;
-	return ownerUniqueID;
-}
-
 const Value rangeLockOwnerValue(const RangeLockOwner& rangeLockOwner) {
 	return ObjectWriter::toValue(rangeLockOwner, IncludeVersion());
 }

--- a/fdbclient/include/fdbclient/ManagementAPI.actor.h
+++ b/fdbclient/include/fdbclient/ManagementAPI.actor.h
@@ -273,7 +273,13 @@ ACTOR Future<Void> releaseExclusiveReadLockOnRange(Transaction* tr, KeyRange ran
 ACTOR Future<Void> releaseExclusiveReadLockOnRange(Database cx, KeyRange range, RangeLockOwnerName ownerUniqueID);
 
 // Get locked ranges within the input range (the input range must be within normalKeys)
-ACTOR Future<std::vector<KeyRange>> getExclusiveReadLockOnRange(Database cx, KeyRange range);
+ACTOR Future<std::vector<std::pair<KeyRange, RangeLockState>>> findExclusiveReadLockOnRange(
+    Database cx,
+    KeyRange range,
+    Optional<RangeLockOwnerName> ownerName = Optional<RangeLockOwnerName>());
+
+// Clear all exclusive read lock by the input user. Not transactional.
+ACTOR Future<Void> releaseExclusiveReadLockByUser(Database cx, RangeLockOwnerName ownerUniqueID);
 
 ACTOR Future<Void> printHealthyZone(Database cx);
 ACTOR Future<bool> clearHealthyZone(Database cx, bool printWarning = false, bool clearSSFailureZoneString = false);

--- a/fdbclient/include/fdbclient/ManagementAPI.actor.h
+++ b/fdbclient/include/fdbclient/ManagementAPI.actor.h
@@ -183,17 +183,16 @@ ACTOR Future<std::vector<BulkLoadTaskState>> getBulkLoadTasksWithinRange(
 
 // Create a bulkload task submission transaction without commit
 // Used by ManagementAPI and bulkdumpRestore at DD
-ACTOR Future<Void> setBulkLoadSubmissionTransaction(Transaction* tr, BulkLoadTaskState bulkLoadTask);
-
-// Submit a bulk load task
-ACTOR Future<Void> submitBulkLoadTask(Database cx, BulkLoadTaskState bulkLoadTask);
+ACTOR Future<Void> setBulkLoadSubmissionTransaction(Transaction* tr,
+                                                    BulkLoadTaskState bulkLoadTask,
+                                                    bool checkTaskExclusive = true);
 
 // Create an bulkload task acknowledge transaction without commit
 // Used by ManagementAPI and bulkdumpRestore at DD
-ACTOR Future<Void> setBulkLoadFinalizeTransaction(Transaction* tr, KeyRange range, UID taskId);
-
-// Finalize a bulk load task if it has been completed
-ACTOR Future<Void> finalizeBulkLoadTask(Database cx, KeyRange range, UID taskId);
+ACTOR Future<Void> setBulkLoadFinalizeTransaction(Transaction* tr,
+                                                  KeyRange range,
+                                                  UID taskId,
+                                                  bool checkTaskExclusive = true);
 
 // Get bulk load task for the input range and taskId
 ACTOR Future<BulkLoadTaskState> getBulkLoadTask(Transaction* tr,

--- a/fdbclient/include/fdbclient/ManagementAPI.actor.h
+++ b/fdbclient/include/fdbclient/ManagementAPI.actor.h
@@ -173,14 +173,6 @@ ACTOR Future<UID> cancelAuditStorage(Reference<IClusterConnectionRecord> cluster
 // When the mode is on, DD will periodically check if there is any bulkload task to do by scaning the metadata.
 ACTOR Future<int> setBulkLoadMode(Database cx, int mode);
 
-// Get bulk load tasks which range is fully contained by the input range.
-// If phase is provided, then return the task with the input phase.
-ACTOR Future<std::vector<BulkLoadTaskState>> getBulkLoadTasksWithinRange(
-    Database cx,
-    KeyRange rangeToRead,
-    size_t limit = 10,
-    Optional<BulkLoadPhase> phase = Optional<BulkLoadPhase>());
-
 // Create a bulkload task submission transaction without commit
 // Used by ManagementAPI and bulkdumpRestore at DD
 ACTOR Future<Void> setBulkLoadSubmissionTransaction(Transaction* tr,

--- a/fdbclient/include/fdbclient/SystemData.h
+++ b/fdbclient/include/fdbclient/SystemData.h
@@ -560,7 +560,6 @@ RangeLockStateSet decodeRangeLockStateSet(const ValueRef& value);
 extern const KeyRangeRef rangeLockOwnerKeys;
 extern const KeyRef rangeLockOwnerPrefix;
 const Key rangeLockOwnerKeyFor(const RangeLockOwnerName& ownerUniqueID);
-const RangeLockOwnerName decodeRangeLockOwnerKey(const KeyRef& key);
 const Value rangeLockOwnerValue(const RangeLockOwner& rangeLockOwner);
 RangeLockOwner decodeRangeLockOwner(const ValueRef& value);
 

--- a/fdbserver/workloads/BulkDumping.actor.cpp
+++ b/fdbserver/workloads/BulkDumping.actor.cpp
@@ -323,6 +323,9 @@ struct BulkDumping : TestWorkload {
 		// BulkLoad uses range lock
 		wait(registerRangeLockOwner(cx, rangeLockNameForBulkLoad, rangeLockNameForBulkLoad));
 
+		std::vector<RangeLockOwner> lockOwners = wait(getAllRangeLockOwners(cx));
+		ASSERT(lockOwners.size() == 1 && lockOwners[0].getOwnerUniqueId() == rangeLockNameForBulkLoad);
+
 		// Submit a bulk dump job
 		state int oldBulkDumpMode = 0;
 		wait(store(oldBulkDumpMode, setBulkDumpMode(cx, 1))); // Enable bulkDump
@@ -391,6 +394,9 @@ struct BulkDumping : TestWorkload {
 		ASSERT(res.empty());
 
 		wait(removeRangeLockOwner(cx, rangeLockNameForBulkLoad));
+
+		std::vector<RangeLockOwner> lockOwnersAfterRemove = wait(getAllRangeLockOwners(cx));
+		ASSERT(lockOwnersAfterRemove.empty());
 
 		return Void();
 	}

--- a/fdbserver/workloads/BulkDumping.actor.cpp
+++ b/fdbserver/workloads/BulkDumping.actor.cpp
@@ -385,6 +385,11 @@ struct BulkDumping : TestWorkload {
 			break;
 		}
 
+		// Make sure all ranges locked by the workload are unlocked
+		std::vector<std::pair<KeyRange, RangeLockState>> res =
+		    wait(findExclusiveReadLockOnRange(cx, normalKeys, rangeLockNameForBulkLoad));
+		ASSERT(res.empty());
+
 		wait(removeRangeLockOwner(cx, rangeLockNameForBulkLoad));
 
 		return Void();

--- a/fdbserver/workloads/RandomRangeLock.actor.cpp
+++ b/fdbserver/workloads/RandomRangeLock.actor.cpp
@@ -31,6 +31,7 @@
 #include "flow/Trace.h"
 #include "flow/actorcompiler.h" // This must be the last #include.
 #include <string>
+#include <vector>
 
 struct RandomRangeLockWorkload : FailureInjectionWorkload {
 	static constexpr auto NAME = "RandomRangeLock";
@@ -84,11 +85,11 @@ struct RandomRangeLockWorkload : FailureInjectionWorkload {
 		}
 	}
 
-	ACTOR Future<Void> lockActor(Database cx, RandomRangeLockWorkload* self) {
+	ACTOR Future<Void> lockActor(Database cx, RandomRangeLockWorkload* self, std::string rangeLockOwnerNamePrefix) {
 		state double testDuration = deterministicRandom()->random01() * self->maxLockDuration;
 		state double testStartDelay = deterministicRandom()->random01() * self->maxStartDelay;
 		state std::string rangeLockOwnerName =
-		    "Owner" + std::to_string(deterministicRandom()->randomInt(0, self->lockActorCount));
+		    rangeLockOwnerNamePrefix + "-" + std::to_string(deterministicRandom()->randomInt(0, self->lockActorCount));
 		// Here we intentionally introduced duplicated owner name between different lockActor
 		std::string lockOwnerDescription = rangeLockOwnerName + ":" + self->getRandomStringRef().toString();
 		wait(registerRangeLockOwner(cx, rangeLockOwnerName, lockOwnerDescription));
@@ -111,14 +112,33 @@ struct RandomRangeLockWorkload : FailureInjectionWorkload {
 			ASSERT(range.end <= normalKeys.end);
 		} catch (Error& e) {
 			if (e.code() == error_code_range_lock_failed) {
+				TraceEvent(SevWarnAlways, "InjectRangeLockFailed")
+				    .detail("RangeLockOwnerName", rangeLockOwnerName)
+				    .detail("Range", range)
+				    .detail("LockTime", testDuration);
 				ASSERT(range.end > normalKeys.end);
-			} else if (e.code() == error_code_range_locked_by_different_user) {
+			} else if (e.code() == error_code_range_lock_reject) {
+				TraceEvent(SevWarnAlways, "InjectRangeLockRejected")
+				    .detail("RangeLockOwnerName", rangeLockOwnerName)
+				    .detail("Range", range)
+				    .detail("LockTime", testDuration);
 				// pass
 			} else {
+				TraceEvent(SevError, "InjectRangeLockError")
+				    .errorUnsuppressed(e)
+				    .detail("RangeLockOwnerName", rangeLockOwnerName)
+				    .detail("Range", range)
+				    .detail("LockTime", testDuration);
 				throw e;
 			}
 		}
 		wait(delay(testDuration));
+
+		TraceEvent(SevWarnAlways, "InjectRangeUnlockSubmit")
+		    .detail("RangeLockOwnerName", rangeLockOwnerName)
+		    .detail("Range", range)
+		    .detail("LockStartDelayTime", testStartDelay)
+		    .detail("LockTime", testDuration);
 		try {
 			wait(releaseExclusiveReadLockOnRange(cx, range, rangeLockOwnerName));
 			TraceEvent(SevWarnAlways, "InjectRangeUnlocked")
@@ -127,13 +147,27 @@ struct RandomRangeLockWorkload : FailureInjectionWorkload {
 			ASSERT(range.end <= normalKeys.end);
 		} catch (Error& e) {
 			if (e.code() == error_code_range_lock_failed) {
+				TraceEvent(SevWarnAlways, "InjectRangeUnlockFailed")
+				    .detail("RangeLockOwnerName", rangeLockOwnerName)
+				    .detail("Range", range)
+				    .detail("LockTime", testDuration);
 				ASSERT(range.end > normalKeys.end);
-			} else if (e.code() == error_code_range_locked_by_different_user) {
+			} else if (e.code() == error_code_range_unlock_reject) {
+				TraceEvent(SevWarnAlways, "InjectRangeUnlockRejected")
+				    .detail("RangeLockOwnerName", rangeLockOwnerName)
+				    .detail("Range", range)
+				    .detail("LockTime", testDuration);
 				// pass
 			} else {
+				TraceEvent(SevError, "InjectRangeUnlockError")
+				    .errorUnsuppressed(e)
+				    .detail("RangeLockOwnerName", rangeLockOwnerName)
+				    .detail("Range", range)
+				    .detail("LockTime", testDuration);
 				throw e;
 			}
 		}
+
 		return Void();
 	}
 
@@ -148,11 +182,22 @@ struct RandomRangeLockWorkload : FailureInjectionWorkload {
 			// The rangeLock mechanism should approperiately handled those conflict.
 			// When all actors complete, it is expected that all locks are removed,
 			// and this injected workload should not block other workloads.
+			state std::string rangeLockOwnerNamePrefix = "Owner" + std::to_string(self->clientId);
 			std::vector<Future<Void>> actors;
 			for (int i = 0; i < self->lockActorCount; i++) {
-				actors.push_back(self->lockActor(cx, self));
+				actors.push_back(self->lockActor(cx, self, rangeLockOwnerNamePrefix));
 			}
 			wait(waitForAll(actors));
+
+			// Make sure all ranges locked by the workload client are unlocked
+			state int j = 0;
+			for (; j < self->lockActorCount; j++) {
+				std::vector<std::pair<KeyRange, RangeLockState>> res = wait(
+				    findExclusiveReadLockOnRange(cx, normalKeys, rangeLockOwnerNamePrefix + "-" + std::to_string(j)));
+				ASSERT(res.empty());
+			}
+
+			TraceEvent("RandomRangeLockWorkloadEnd").detail("OwnerPrefix", rangeLockOwnerNamePrefix);
 		}
 		return Void();
 	}

--- a/fdbserver/workloads/RandomRangeLock.actor.cpp
+++ b/fdbserver/workloads/RandomRangeLock.actor.cpp
@@ -30,8 +30,6 @@
 #include "flow/IRandom.h"
 #include "flow/Trace.h"
 #include "flow/actorcompiler.h" // This must be the last #include.
-#include <string>
-#include <vector>
 
 struct RandomRangeLockWorkload : FailureInjectionWorkload {
 	static constexpr auto NAME = "RandomRangeLock";

--- a/fdbserver/workloads/Watches.actor.cpp
+++ b/fdbserver/workloads/Watches.actor.cpp
@@ -49,6 +49,13 @@ struct WatchesWorkload : TestWorkload {
 		tempRand.randomShuffle(nodeOrder);
 	}
 
+	void disableFailureInjectionWorkloads(std::set<std::string>& out) const override {
+		// We disable RandomRangeLock workload injection because watchesWorker() does not handle the
+		// transaction error, in particular, transaction_rejected_range_locked can happen when enabling RandomRangeLock.
+		// TODO: remove after the workload handles the transaction error.
+		out.insert("RandomRangeLock");
+	}
+
 	Future<Void> setup(Database const& cx) override {
 		// return _setup(cx, this);
 		std::vector<Future<Void>> setupActors;

--- a/flow/include/flow/error_definitions.h
+++ b/flow/include/flow/error_definitions.h
@@ -163,7 +163,8 @@ ERROR( bulkdump_task_failed, 1243, "Bulk dumping task failed" )
 ERROR( bulkdump_task_outdated, 1244, "Bulk dumping task outdated" )
 ERROR( bulkload_fileset_invalid_filepath, 1245, "Bulkload fileset provides invalid filepath" )
 ERROR( bulkload_manifest_decode_error, 1246, "Bulkload manifest string is failed to decode" )
-ERROR( range_locked_by_different_user, 1247, "Range has been locked by a different user" )
+ERROR( range_lock_reject, 1247, "Range lock is rejected" )
+ERROR( range_unlock_reject, 1248, "Range unlock is rejected" )
 
 // 15xx Platform errors
 ERROR( platform_error, 1500, "Platform error" )


### PR DESCRIPTION
This PR addresses the issue in the [PR](https://github.com/apple/foundationdb/pull/12044) by making range lock API more clear to use:
A request of locking/releasing a range is rejected if it conflicts to a lock on the range with a different lock.range or a different lock.user or a different lock.type.

This PR also:
1. Add range lock API to bulkload commands, so that the cluster can be recovered from unexpected range lock bugs.
2. Add checks at the end of BulkLoad/BulkDump/RandomRangeLock workload -- the range locked by the workload must be fully unlocked at the end of the workload.
3. Disable range lock injection workload in Watch tests because the watchesWorker() does not catch the transaction error. So, the test can be failed because of the transaction_rejected_range_locked triggered by the range lock.
4. Make sure all BulkLoad/Dump/RangeLock management APIs are tested by simulations.
5. Remove unnecessary code.

100K correctness:
  20250321-214359-zhewang-028afd1e079efab1           compressed=True data_size=41074959 duration=5211041 ended=100000 fail=3 fail_fast=10 max_runs=100000 pass=99997 priority=100 remaining=0 runtime=1:54:42 sanity=False started=100000 stopped=20250321-233841 submitted=20250321-214359 timeout=5400 username=zhewang
  
   20250321-235914-zhewang-752ce7a9dcbeb973           compressed=True data_size=41074628 fail_fast=10 max_runs=100000 priority=100 sanity=False submitted=20250321-235914 timeout=5400 username=zhewang               
                
100K RangeLockCycle:
  20250321-074822-zhewang-a75bf984f5f16ba7           compressed=True data_size=41117627 duration=4746194 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:33:31 sanity=False started=100000 stopped=20250321-092153 submitted=20250321-074822 timeout=5400 username=zhewang
  
100K RangeLocking:
 20250321-221359-zhewang-e421f4455a48f252           compressed=True data_size=41116447 duration=3181829 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:00:11 sanity=False started=100000 stopped=20250321-231410 submitted=20250321-221359 timeout=5400 username=zhewang
       
500K BulkLoading:
  20250321-074705-zhewang-76dbaaeb836449bf           compressed=True data_size=41118190 duration=11458822 ended=500000 fail_fast=10 max_runs=500000 pass=500000 priority=100 remaining=0 runtime=2:55:07 sanity=False started=500000 stopped=20250321-104212 submitted=20250321-074705 timeout=5400 username=zhewang
  
500K BulkDumping:
  20250321-074736-zhewang-17bb34bc85e0ba7a           compressed=True data_size=41118257 duration=16400013 ended=500000 fail_fast=10 max_runs=500000 pass=500000 priority=100 remaining=0 runtime=3:32:42 sanity=False started=500000 stopped=20250321-112018 submitted=20250321-074736 timeout=5400 username=zhewang
    
# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
