### PR TITLE
Fix version vector incompatibility with backup range changes

### DIFF
--- a/fdbserver/ApplyMetadataMutation.cpp
+++ b/fdbserver/ApplyMetadataMutation.cpp
@@ -286,7 +286,7 @@ private:
 		uniquify(info.tags);
 		keyInfo->insert(insertRange, info);
 		if (toCommit && SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST) {
-			toCommit->setShardChanged();
+			toCommit->setLogsChanged();
 		}
 	}
 
@@ -657,7 +657,7 @@ private:
 			txnStateStore->set(KeyValueRef(m.param1, m.param2));
 
 		if (toCommit && SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST) {
-			toCommit->setShardChanged();
+			toCommit->setLogsChanged();
 		}
 
 		if (!vecBackupKeys) {
@@ -978,7 +978,7 @@ private:
 			                    ? ServerCacheInfo()
 			                    : keyInfo->rangeContainingKeyBefore(clearRange.begin).value());
 			if (toCommit && SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST) {
-				toCommit->setShardChanged();
+				toCommit->setLogsChanged();
 			}
 		}
 
@@ -1196,7 +1196,7 @@ private:
 		    .detail("IntersectEnd", commonLogRange.end);
 
 		if (toCommit && SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST) {
-			toCommit->setShardChanged();
+			toCommit->setLogsChanged();
 		}
 
 		// Remove the key range from the vector, if defined

--- a/fdbserver/ApplyMetadataMutation.cpp
+++ b/fdbserver/ApplyMetadataMutation.cpp
@@ -655,6 +655,11 @@ private:
 		}
 		if (!initialCommit)
 			txnStateStore->set(KeyValueRef(m.param1, m.param2));
+
+		if (toCommit && SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST) {
+			toCommit->setShardChanged();
+		}
+
 		if (!vecBackupKeys) {
 			return;
 		}
@@ -1189,6 +1194,10 @@ private:
 		    .detail("RangeEnd", range.end)
 		    .detail("IntersectBegin", commonLogRange.begin)
 		    .detail("IntersectEnd", commonLogRange.end);
+
+		if (toCommit && SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST) {
+			toCommit->setShardChanged();
+		}
 
 		// Remove the key range from the vector, if defined
 		if (vecBackupKeys) {

--- a/fdbserver/Resolver.actor.cpp
+++ b/fdbserver/Resolver.actor.cpp
@@ -432,9 +432,9 @@ ACTOR Future<Void> resolveBatch(Reference<Resolver> self,
 
 		// If shardChanged at or before this commit version, the proxy may have computed
 		// the wrong set of groups. Then we need to broadcast to all groups below.
-		stateTransactionsPair.first = toCommit && toCommit->isShardChanged();
+		stateTransactionsPair.first = toCommit && toCommit->haveLogsChanged();
 		bool shardChanged = self->recentStateTransactionsInfo.applyStateTxnsToBatchReply(
-		    &reply, firstUnseenVersion, req.version, toCommit && toCommit->isShardChanged());
+		    &reply, firstUnseenVersion, req.version, toCommit && toCommit->haveLogsChanged());
 
 		// Adds private mutation messages to the reply message.
 		if (SERVER_KNOBS->PROXY_USE_RESOLVER_PRIVATE_MUTATIONS) {

--- a/fdbserver/include/fdbserver/LogSystem.h
+++ b/fdbserver/include/fdbserver/LogSystem.h
@@ -795,8 +795,8 @@ struct LogPushData : NonCopyable {
 		writtenTLogs.insert(msg_locations.begin(), msg_locations.end());
 	}
 
-	void setShardChanged() { shardChanged = true; }
-	bool isShardChanged() const { return shardChanged; }
+	void setLogsChanged() { logsChanged = true; }
+	bool haveLogsChanged() const { return logsChanged; }
 
 	void writeMessage(StringRef rawMessageWithoutLength, bool usePreviousLocations);
 
@@ -846,7 +846,7 @@ private:
 	std::unordered_set<int> writtenLocations;
 	uint32_t subsequence;
 	SpanContext spanContext;
-	bool shardChanged = false; // if keyServers has any changes, i.e., shard boundary modifications.
+	bool logsChanged = false; // if keyServers has any changes, i.e., shard boundary modifications.
 
 	// Writes transaction info to the message stream at the given location if
 	// it has not already been written (for the current transaction). Returns


### PR DESCRIPTION
Fix version vector incompatibility with backup range changes. When a change to the range set is detected (clear range or add range), indicate the transaction must be sent to all logs in the same manner as shard moves. This is because new ranges can mean additional tags than the set originally found pre resolution.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
