### PR TITLE
Suggested fix for the crashing brought on by https://github.com/apple…

### DIFF
--- a/flow/include/flow/genericactors.actor.h
+++ b/flow/include/flow/genericactors.actor.h
@@ -1455,23 +1455,22 @@ void tagAndForward(Promise<T>* pOutputPromise, U value, Future<Void> signal) {
 
 ACTOR template <class T>
 void tagAndForward(PromiseStream<T>* pOutput, T value, Future<Void> signal) {
-	state PromiseStream<T> out(*pOutput);
 	wait(signal);
-	out.send(std::move(value));
+	pOutput->send(std::move(value));
 }
 
 ACTOR template <class T>
 void tagAndForwardError(Promise<T>* pOutputPromise, Error value, Future<Void> signal) {
-	state Promise<T> out(std::move(*pOutputPromise));
 	wait(signal);
-	out.sendError(value);
+	pOutputPromise->sendError(value);
 }
 
 ACTOR template <class T>
 void tagAndForwardError(PromiseStream<T>* pOutput, Error value, Future<Void> signal) {
-	state PromiseStream<T> out(*pOutput);
 	wait(signal);
-	out.sendError(value);
+	if (pOutput && pOutput->getFutureReferenceCount() > 0) {
+		pOutput->sendError(value);
+	}
 }
 
 ACTOR template <class T>


### PR DESCRIPTION
…/foundationdb/pull/12003/files #12003 makes a new PS instance but the backing NotificationQueue is shared between the instances. Double delete?

Restoring the original send-value-on-original-ps seems to fix the crashing I was seeing in k8s test but the tests in IThreadPoolTest.actor.cpp would then fail. .... hmmm.. they still fail w/ this patch.... looking.
