### PR TITLE
Suppress a few verbose trace events

### DIFF
--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -1579,7 +1579,7 @@ DatabaseContext::DatabaseContext(Reference<AsyncVar<Reference<IClusterConnection
     specialKeySpace(std::make_unique<SpecialKeySpace>(specialKeys.begin, specialKeys.end, /* test */ false)),
     connectToDatabaseEventCacheHolder(format("ConnectToDatabase/%s", dbId.toString().c_str())) {
 
-	TraceEvent("DatabaseContextCreated", dbId).backtrace();
+	DisabledTraceEvent("DatabaseContextCreated", dbId).backtrace();
 
 	connected = (clientInfo->get().commitProxies.size() && clientInfo->get().grvProxies.size())
 	                ? Void()
@@ -1939,7 +1939,7 @@ DatabaseContext::~DatabaseContext() {
 		it.second->context = nullptr;
 	}
 
-	TraceEvent("DatabaseContextDestructed", dbId).backtrace();
+	DisabledTraceEvent("DatabaseContextDestructed", dbId).backtrace();
 }
 
 Optional<KeyRangeLocationInfo> DatabaseContext::getCachedLocation(const TenantInfo& tenant,

--- a/flow/Platform.actor.cpp
+++ b/flow/Platform.actor.cpp
@@ -815,7 +815,7 @@ void getMachineLoad(uint64_t& idleTime, uint64_t& totalTime, bool logDetails) {
 	totalTime = t_user + t_nice + t_system + t_idle + t_iowait + t_irq + t_softirq + t_steal + t_guest;
 	idleTime = t_idle + t_iowait;
 
-	if (!DEBUG_DETERMINISM && logDetails)
+	if (!DEBUG_DETERMINISM && logDetails && !g_network->isSimulated())
 		TraceEvent("MachineLoadDetail")
 		    .detail("User", t_user)
 		    .detail("Nice", t_nice)

--- a/flow/include/flow/Trace.h
+++ b/flow/include/flow/Trace.h
@@ -594,7 +594,8 @@ extern std::atomic<trace_clock_t> g_trace_clock;
 extern TraceBatch g_traceBatch;
 
 #define DUMPTOKEN(name)                                                                                                \
-	TraceEvent("DumpToken", recruited.id()).detail("Name", #name).detail("Token", name.getEndpoint().token)
+	!g_network->isSimulated() &&                                                                                       \
+	    TraceEvent("DumpToken", recruited.id()).detail("Name", #name).detail("Token", name.getEndpoint().token)
 
 #define DisabledTraceEvent(...) false && TraceEvent()
 #endif


### PR DESCRIPTION
Mostly in simulation, to address TraceTooManyLines errors.

  20250326-041623-jzhou-f1b84849666be150             compressed=True data_size=36909535 duration=5387674 ended=100000 fail=1 fail_fast=10 max_runs=100000 pass=99999 priority=100 remaining=0 runtime=2:05:32 sanity=False started=100000 stopped=20250326-062155 submitted=20250326-041623 timeout=5400 username=jzhou

The failed seed `-f ./tests/rare/BlobRestoreToVersion.toml -s 599190995 -b on` is an assertion failure on DD (unrelated to this PR):

```
FailedAssertion=!this-&gt;meta.ranges.empty() &amp;&amp; this-&gt;meta.ranges.front().contains(range) File=/root/src/foundationdb/fdbserver/DataDistribution.actor.cpp Line=163

DataMove::validateShard(DDShardInfo const&, KeyRangeRef, int) at /root/src/foundationdb/fdbserver/DataDistribution.actor.cpp:163
~Reference at /root/src/foundationdb/flow/include/flow/FastRef.h:127
 (inlined by) ~Arena at /root/src/foundationdb/flow/include/flow/Arena.h:108
 (inlined by) DDTxnProcessorImpl::GetInitialDataDistributionActorState<DDTxnProcessorImpl::GetInitialDataDistributionActor>::a_body1cont4(int) at /root/src/foundationdb/fdbserver/DDTxnProcessor.actor.cpp:502
DDTxnProcessorImpl::GetInitialDataDistributionActorState<DDTxnProcessorImpl::GetInitialDataDistributionActor>::a_body1cont3break1(int) at /root/cbuild_output/fdbserver/DDTxnProcessor.actor.g.cpp:0
a_body1cont3loopBody1 at /root/cbuild_output/fdbserver/DDTxnProcessor.actor.g.cpp:0
 (inlined by) a_body1cont3loopHead1 at /root/cbuild_output/fdbserver/DDTxnProcessor.actor.g.cpp:4337
 (inlined by) a_body1cont3loopBody1cont1 at /root/cbuild_output/fdbserver/DDTxnProcessor.actor.g.cpp:4376
 (inlined by) DDTxnProcessorImpl::GetInitialDataDistributionActorState<DDTxnProcessorImpl::GetInitialDataDistributionActor>::a_body1cont3loopBody1break1(int) at /root/cbuild_output/fdbserver/DDTxnProcessor.actor.g.cpp:4422
DDTxnProcessorImpl::GetInitialDataDistributionActorState<DDTxnProcessorImpl::GetInitialDataDistributionActor>::a_body1cont3loopBody1loopBody1cont4(Standalone<RangeResultRef> const&, int) at /root/cbuild_output/fdbserver/DDTxnProcessor.actor.g.cpp:0
DDTxnProcessorImpl::GetInitialDataDistributionActorState<DDTxnProcessorImpl::GetInitialDataDistributionActor>::a_callback_fire(ActorCallback<DDTxnProcessorImpl::GetInitialDataDistributionActor, 10, Standalone<RangeResultRef>>*, Standalone<RangeResultRef> const&) at /root/cbuild_output/fdbserver/DDTxnProcessor.actor.g.cpp:5021
finishSendAndDelPromiseRef at /root/src/foundationdb/flow/include/flow/flow.h:817
 (inlined by) a_body1cont1 at /root/cbuild_output/fdbclient/KeyRangeMap.actor.g.cpp:170
 (inlined by) (anonymous namespace)::KrmGetRangesActorState<(anonymous namespace)::KrmGetRangesActor>::a_body1when1(Standalone<RangeResultRef> const&, int) at /root/cbuild_output/fdbclient/KeyRangeMap.actor.g.cpp:189
ActorCallback<(anonymous namespace)::KrmGetRangesActor, 0, Standalone<RangeResultRef>>::fire(Standalone<RangeResultRef> const&) at /root/src/foundationdb/flow/include/flow/flow.h:1537
finishSendAndDelPromiseRef at /root/src/foundationdb/flow/include/flow/flow.h:0
 (inlined by) a_body1cont3loopBody1cont10 at /root/cbuild_output/fdbclient/NativeAPI.actor.g.cpp:23077
 (inlined by) (anonymous namespace)::GetRangeActorState<GetKeyValuesRequest, GetKeyValuesReply, Standalone<RangeResultRef>, (anonymous namespace)::GetRangeActor<GetKeyValuesRequest, GetKeyValuesReply, Standalone<RangeResultRef>>>::a_body1cont3loopBody1cont12cont2(int) at /root/cbuild_output/fdbclient/NativeAPI.actor.g.cpp:23287
ActorCallback<(anonymous namespace)::GetRangeActor<GetKeyValuesRequest, GetKeyValuesReply, Standalone<RangeResultRef>>, 2, GetKeyValuesReply>::fire(GetKeyValuesReply const&) at /root/src/foundationdb/flow/include/flow/flow.h:1537
finishSendAndDelPromiseRef at /root/src/foundationdb/flow/include/flow/flow.h:817
 (inlined by) a_body1cont1 at /root/cbuild_output/flow/include/flow/genericactors.actor.g.h:25233
 (inlined by) (anonymous namespace)::FmapActorState<Future<decltype(getReplyPromise(std::declval<GetKeyValuesRequest>()).getFuture().getValue())> (anonymous namespace)::loadBalance<StorageServerInterface, GetKeyValuesRequest, true>(DatabaseContext*, Reference<LocationInfo>, RequestStream<GetKeyValuesRequest, true> StorageServerInterface::*, GetKeyValuesRequest const&, TaskPriority, AtMostOnce, QueueModel*, bool, int)::'lambda'(StorageServerInterface const&), GetKeyValuesReply, (anonymous namespace)::FmapActor<Future<decltype(getReplyPromise(std::declval<GetKeyValuesRequest>()).getFuture().getValue())> (anonymous namespace)::loadBalance<StorageServerInterface, GetKeyValuesRequest, true>(DatabaseContext*, Reference<LocationInfo>, RequestStream<GetKeyValuesRequest, true> StorageServerInterface::*, GetKeyValuesRequest const&, TaskPriority, AtMostOnce, QueueModel*, bool, int)::'lambda'(StorageServerInterface const&), GetKeyValuesReply>>::a_body1when1(GetKeyValuesReply const&, int) at /root/cbuild_output/flow/include/flow/genericactors.actor.g.h:25252
ActorCallback<(anonymous namespace)::FmapActor<Future<decltype(getReplyPromise(std::declval<GetKeyValuesRequest>()).getFuture().getValue())> (anonymous namespace)::loadBalance<StorageServerInterface, GetKeyValuesRequest, true>(DatabaseContext*, Reference<LocationInfo>, RequestStream<GetKeyValuesRequest, true> StorageServerInterface::*, GetKeyValuesRequest const&, TaskPriority, AtMostOnce, QueueModel*, bool, int)::'lambda'(StorageServerInterface const&), GetKeyValuesReply>, 0, GetKeyValuesReply>::fire(GetKeyValuesReply const&) at /root/src/foundationdb/flow/include/flow/flow.h:1537
finishSendAndDelPromiseRef at /root/src/foundationdb/flow/include/flow/flow.h:817
 (inlined by) a_body1loopBody1loopBody2when1cont3 at /root/cbuild_output/fdbrpc/include/fdbrpc/LoadBalance.actor.g.h:3850
 (inlined by) (anonymous namespace)::LoadBalanceActorState<StorageServerInterface, GetKeyValuesRequest, ReferencedInterface<StorageServerInterface>, true, (anonymous namespace)::LoadBalanceActor<StorageServerInterface, GetKeyValuesRequest, ReferencedInterface<StorageServerInterface>, true>>::a_body1loopBody1loopBody2when1when1(Void const&, int) at /root/cbuild_output/fdbrpc/include/fdbrpc/LoadBalance.actor.g.h:3871
Future at /root/src/foundationdb/flow/include/flow/flow.h:1015
 (inlined by) StrictFuture at /root/src/foundationdb/flow/include/flow/flow.h:1093
 (inlined by) (anonymous namespace)::LoadBalanceActorState<StorageServerInterface, GetKeyValuesRequest, ReferencedInterface<StorageServerInterface>, true, (anonymous namespace)::LoadBalanceActor<StorageServerInterface, GetKeyValuesRequest, ReferencedInterface<StorageServerInterface>, true>>::a_body1loopBody1loopBody2when1(Void const&, int) at /root/src/foundationdb/fdbrpc/include/fdbrpc/LoadBalance.actor.h:946
ActorCallback<(anonymous namespace)::LoadBalanceActor<StorageServerInterface, GetKeyValuesRequest, ReferencedInterface<StorageServerInterface>, true>, 7, Void>::fire(Void const&) at /root/src/foundationdb/flow/include/flow/flow.h:1537
finishSendAndDelPromiseRef at /root/src/foundationdb/flow/include/flow/flow.h:817
 (inlined by) a_body1cont1 at /root/cbuild_output/flow/include/flow/genericactors.actor.g.h:13596
 (inlined by) (anonymous namespace)::SuccessActorState<ErrorOr<GetKeyValuesReply>, (anonymous namespace)::SuccessActor<ErrorOr<GetKeyValuesReply>>>::a_body1when1(ErrorOr<GetKeyValuesReply> const&, int) at /root/cbuild_output/flow/include/flow/genericactors.actor.g.h:13617
ActorCallback<(anonymous namespace)::SuccessActor<ErrorOr<GetKeyValuesReply>>, 0, ErrorOr<GetKeyValuesReply>>::fire(ErrorOr<GetKeyValuesReply> const&) at /root/src/foundationdb/flow/include/flow/flow.h:1537
finishSendAndDelPromiseRef at /root/src/foundationdb/flow/include/flow/flow.h:817
 (inlined by) (anonymous namespace)::WaitValueOrSignalActorState<GetKeyValuesReply, (anonymous namespace)::WaitValueOrSignalActor<GetKeyValuesReply>>::a_body1loopBody1when1(GetKeyValuesReply const&, int) at /root/cbuild_output/fdbrpc/include/fdbrpc/genericactors.actor.g.h:6530
ActorCallback<(anonymous namespace)::WaitValueOrSignalActor<GetKeyValuesReply>, 0, GetKeyValuesReply>::fire(GetKeyValuesReply const&) at /root/src/foundationdb/flow/include/flow/flow.h:1537
finishSendAndDelPromiseRef at /root/src/foundationdb/flow/include/flow/flow.h:817
 (inlined by) void SAV<GetKeyValuesReply>::sendAndDelPromiseRef<GetKeyValuesReply&>(GetKeyValuesReply&) at /root/src/foundationdb/flow/include/flow/flow.h:811
index at /usr/local/bin/../include/c++/v1/variant:797
 (inlined by) valueless_by_exception at /usr/local/bin/../include/c++/v1/variant:792
 (inlined by) __destroy at /usr/local/bin/../include/c++/v1/variant:854
 (inlined by) ~__dtor at /usr/local/bin/../include/c++/v1/variant:854
 (inlined by) ~variant at /usr/local/bin/../include/c++/v1/variant:1375
 (inlined by) ~ErrorOr at /root/src/foundationdb/flow/include/flow/flow.h:136
 (inlined by) NetSAV<GetKeyValuesReply>::receive(ArenaObjectReader&) at /root/src/foundationdb/fdbrpc/include/fdbrpc/fdbrpc.h:125
(anonymous namespace)::DeliverActorState<(anonymous namespace)::DeliverActor>::a_body1cont1(int) at /root/src/foundationdb/fdbrpc/FlowTransport.actor.cpp:1177
ActorCallback<(anonymous namespace)::DeliverActor, 0, Void>::fire(Void const&) at /root/src/foundationdb/flow/include/flow/flow.h:1537
void SAV<Void>::send<Void>(Void&&) at /root/src/foundationdb/flow/include/flow/flow.h:783
Sim2::execTask(Sim2::PromiseTask&) at /root/src/foundationdb/fdbrpc/sim2.actor.cpp:2647
~Promise at /root/src/foundationdb/flow/include/flow/flow.h:1133
 (inlined by) ~PromiseTask at /root/src/foundationdb/fdbrpc/sim2.actor.cpp:2621
 (inlined by) Sim2::runLoop(Sim2*) at /root/src/foundationdb/fdbrpc/sim2.actor.cpp:1429
__root at /usr/local/bin/../include/c++/v1/__tree:1088
 (inlined by) ~__tree at /usr/local/bin/../include/c++/v1/__tree:1788
 (inlined by) ~set at /usr/local/bin/../include/c++/v1/set:676
 (inlined by) main at /root/src/foundationdb/fdbserver/fdbserver.actor.cpp:2368
?? at ??:0
```
# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
