### PR TITLE
Go: [BREAKING] explicit destruction for futures and transactions

### DIFF
--- a/bindings/go/src/fdb/database.go
+++ b/bindings/go/src/fdb/database.go
@@ -323,7 +323,7 @@ func (d Database) LocalityGetBoundaryKeys(er ExactRange, limit int, readVersion 
 		append(Key("\xFF/keyServers/"), ek.FDBKey()...),
 	}
 
-	kvs, err := tr.Snapshot().GetRange(ffer, RangeOptions{Limit: limit}).GetSliceWithError()
+	kvs, err := tr.Snapshot().GetRange(ffer, RangeOptions{Limit: limit}).Get()
 	if err != nil {
 		return nil, err
 	}

--- a/bindings/go/src/fdb/directory/allocator.go
+++ b/bindings/go/src/fdb/directory/allocator.go
@@ -95,6 +95,7 @@ func (hca highContentionAllocator) allocate(tr fdb.Transaction, s subspace.Subsp
 			// Increment the allocation count for the current window
 			tr.Add(hca.counters.Sub(start), oneBytes)
 			countFuture := tr.Snapshot().Get(hca.counters.Sub(start))
+			defer countFuture.Close()
 
 			allocatorMutex.Unlock()
 
@@ -134,6 +135,7 @@ func (hca highContentionAllocator) allocate(tr fdb.Transaction, s subspace.Subsp
 
 			latestCounter := tr.Snapshot().GetRange(hca.counters, fdb.RangeOptions{Limit: 1, Reverse: true})
 			candidateValue := tr.Get(key)
+			defer candidateValue.Close()
 			tr.Options().SetNextWriteNoWriteConflictRange()
 			tr.Set(key, []byte(""))
 

--- a/bindings/go/src/fdb/directory/allocator.go
+++ b/bindings/go/src/fdb/directory/allocator.go
@@ -24,6 +24,7 @@ package directory
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"math/rand"
 	"sync"
@@ -63,10 +64,10 @@ func windowSize(start int64) int64 {
 	return 8192
 }
 
-func (hca highContentionAllocator) allocate(tr fdb.Transaction, s subspace.Subspace) (subspace.Subspace, error) {
+func (hca highContentionAllocator) allocate(ctx context.Context, tr fdb.Transaction, s subspace.Subspace) (subspace.Subspace, error) {
 	for {
 		rr := tr.Snapshot().GetRange(hca.counters, fdb.RangeOptions{Limit: 1, Reverse: true})
-		kvs, err := rr.Get()
+		kvs, err := rr.Get(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -99,7 +100,7 @@ func (hca highContentionAllocator) allocate(tr fdb.Transaction, s subspace.Subsp
 
 			allocatorMutex.Unlock()
 
-			countStr, err := countFuture.Get()
+			countStr, err := countFuture.Get(ctx)
 			if err != nil {
 				return nil, err
 			}
@@ -141,7 +142,7 @@ func (hca highContentionAllocator) allocate(tr fdb.Transaction, s subspace.Subsp
 
 			allocatorMutex.Unlock()
 
-			kvs, err = latestCounter.Get()
+			kvs, err = latestCounter.Get(ctx)
 			if err != nil {
 				return nil, err
 			}
@@ -156,7 +157,7 @@ func (hca highContentionAllocator) allocate(tr fdb.Transaction, s subspace.Subsp
 				}
 			}
 
-			v, err := candidateValue.Get()
+			v, err := candidateValue.Get(ctx)
 			if err != nil {
 				return nil, err
 			}

--- a/bindings/go/src/fdb/directory/allocator.go
+++ b/bindings/go/src/fdb/directory/allocator.go
@@ -66,7 +66,7 @@ func windowSize(start int64) int64 {
 func (hca highContentionAllocator) allocate(tr fdb.Transaction, s subspace.Subspace) (subspace.Subspace, error) {
 	for {
 		rr := tr.Snapshot().GetRange(hca.counters, fdb.RangeOptions{Limit: 1, Reverse: true})
-		kvs, err := rr.GetSliceWithError()
+		kvs, err := rr.Get()
 		if err != nil {
 			return nil, err
 		}
@@ -141,7 +141,7 @@ func (hca highContentionAllocator) allocate(tr fdb.Transaction, s subspace.Subsp
 
 			allocatorMutex.Unlock()
 
-			kvs, err = latestCounter.GetSliceWithError()
+			kvs, err = latestCounter.Get()
 			if err != nil {
 				return nil, err
 			}

--- a/bindings/go/src/fdb/directory/directory_layer.go
+++ b/bindings/go/src/fdb/directory/directory_layer.go
@@ -72,8 +72,8 @@ func NewDirectoryLayer(nodeSS, contentSS subspace.Subspace, allowManualPrefixes 
 	return dl
 }
 
-func (dl directoryLayer) createOrOpen(rtr fdb.ReadTransaction, tr *fdb.Transaction, path []string, layer []byte, prefix []byte, allowCreate, allowOpen bool) (DirectorySubspace, error) {
-	if err := dl.checkVersion(rtr, nil); err != nil {
+func (dl directoryLayer) createOrOpen(ctx context.Context, rtr fdb.ReadTransaction, tr *fdb.Transaction, path []string, layer []byte, prefix []byte, allowCreate, allowOpen bool) (DirectorySubspace, error) {
+	if err := dl.checkVersion(ctx, rtr, nil); err != nil {
 		return nil, err
 	}
 
@@ -88,16 +88,16 @@ func (dl directoryLayer) createOrOpen(rtr fdb.ReadTransaction, tr *fdb.Transacti
 		return nil, errors.New("the root directory cannot be opened")
 	}
 
-	existingNode, exists := dl.find(rtr, path).prefetchMetadata(rtr)
+	existingNode, exists := dl.find(ctx, rtr, path).prefetchMetadata(rtr)
 	if exists {
 		defer existingNode._layer.Close()
-		if existingNode.isInPartition(nil, false) {
+		if existingNode.isInPartition(ctx, nil, false) {
 			subpath := existingNode.getPartitionSubpath()
-			enc, err := existingNode.getContents(dl, nil)
+			enc, err := existingNode.getContents(ctx, dl, nil)
 			if err != nil {
 				return nil, err
 			}
-			return enc.(directoryPartition).createOrOpen(rtr, tr, subpath, layer, prefix, allowCreate, allowOpen)
+			return enc.(directoryPartition).createOrOpen(ctx, rtr, tr, subpath, layer, prefix, allowCreate, allowOpen)
 		}
 
 		if !allowOpen {
@@ -105,35 +105,35 @@ func (dl directoryLayer) createOrOpen(rtr fdb.ReadTransaction, tr *fdb.Transacti
 		}
 
 		if layer != nil {
-			if l, err := existingNode._layer.Get(); err != nil || bytes.Compare(l, layer) != 0 {
+			if l, err := existingNode._layer.Get(ctx); err != nil || bytes.Compare(l, layer) != 0 {
 				return nil, errors.New("the directory was created with an incompatible layer")
 			}
 		}
 
-		return existingNode.getContents(dl, nil)
+		return existingNode.getContents(ctx, dl, nil)
 	}
 
 	if !allowCreate {
 		return nil, ErrDirNotExists
 	}
 
-	if err := dl.checkVersion(rtr, tr); err != nil {
+	if err := dl.checkVersion(ctx, rtr, tr); err != nil {
 		return nil, err
 	}
 
 	if prefix == nil {
-		newss, err := dl.allocator.allocate(*tr, dl.contentSS)
+		newss, err := dl.allocator.allocate(ctx, *tr, dl.contentSS)
 		if err != nil {
 			return nil, fmt.Errorf("unable to allocate new directory prefix (%s)", err.Error())
 		}
 
-		if !isRangeEmpty(rtr, newss) {
+		if !isRangeEmpty(ctx, rtr, newss) {
 			return nil, fmt.Errorf("the database has keys stored at the prefix chosen by the automatic prefix allocator: %v", prefix)
 		}
 
 		prefix = newss.Bytes()
 
-		pf, err := dl.isPrefixFree(rtr.Snapshot(), prefix)
+		pf, err := dl.isPrefixFree(ctx, rtr.Snapshot(), prefix)
 		if err != nil {
 			return nil, err
 		}
@@ -141,7 +141,7 @@ func (dl directoryLayer) createOrOpen(rtr fdb.ReadTransaction, tr *fdb.Transacti
 			return nil, errors.New("the directory layer has manually allocated prefixes that conflict with the automatic prefix allocator")
 		}
 	} else {
-		pf, err := dl.isPrefixFree(rtr, prefix)
+		pf, err := dl.isPrefixFree(ctx, rtr, prefix)
 		if err != nil {
 			return nil, err
 		}
@@ -153,7 +153,7 @@ func (dl directoryLayer) createOrOpen(rtr fdb.ReadTransaction, tr *fdb.Transacti
 	var parentNode subspace.Subspace
 
 	if len(path) > 1 {
-		pd, err := dl.createOrOpen(rtr, tr, path[:len(path)-1], nil, nil, true, true)
+		pd, err := dl.createOrOpen(ctx, rtr, tr, path[:len(path)-1], nil, nil, true, true)
 		if err != nil {
 			return nil, err
 		}
@@ -180,7 +180,7 @@ func (dl directoryLayer) createOrOpen(rtr fdb.ReadTransaction, tr *fdb.Transacti
 
 func (dl directoryLayer) CreateOrOpen(ctx context.Context, t fdb.Transactor, path []string, layer []byte) (DirectorySubspace, error) {
 	r, txClose, err := t.Transact(ctx, func(tr fdb.Transaction) (interface{}, error) {
-		return dl.createOrOpen(tr, &tr, path, layer, nil, true, true)
+		return dl.createOrOpen(ctx, tr, &tr, path, layer, nil, true, true)
 	})
 	if err != nil {
 		return nil, err
@@ -191,7 +191,7 @@ func (dl directoryLayer) CreateOrOpen(ctx context.Context, t fdb.Transactor, pat
 
 func (dl directoryLayer) Create(ctx context.Context, t fdb.Transactor, path []string, layer []byte) (DirectorySubspace, error) {
 	r, txClose, err := t.Transact(ctx, func(tr fdb.Transaction) (interface{}, error) {
-		return dl.createOrOpen(tr, &tr, path, layer, nil, true, false)
+		return dl.createOrOpen(ctx, tr, &tr, path, layer, nil, true, false)
 	})
 	if err != nil {
 		return nil, err
@@ -205,7 +205,7 @@ func (dl directoryLayer) CreatePrefix(ctx context.Context, t fdb.Transactor, pat
 		prefix = []byte{}
 	}
 	r, txClose, err := t.Transact(ctx, func(tr fdb.Transaction) (interface{}, error) {
-		return dl.createOrOpen(tr, &tr, path, layer, prefix, true, false)
+		return dl.createOrOpen(ctx, tr, &tr, path, layer, prefix, true, false)
 	})
 	if err != nil {
 		return nil, err
@@ -216,7 +216,7 @@ func (dl directoryLayer) CreatePrefix(ctx context.Context, t fdb.Transactor, pat
 
 func (dl directoryLayer) Open(ctx context.Context, rt fdb.ReadTransactor, path []string, layer []byte) (DirectorySubspace, error) {
 	r, txClose, err := rt.ReadTransact(ctx, func(rtr fdb.ReadTransaction) (interface{}, error) {
-		return dl.createOrOpen(rtr, nil, path, layer, nil, false, true)
+		return dl.createOrOpen(ctx, rtr, nil, path, layer, nil, false, true)
 	})
 	if err != nil {
 		return nil, err
@@ -227,19 +227,19 @@ func (dl directoryLayer) Open(ctx context.Context, rt fdb.ReadTransactor, path [
 
 func (dl directoryLayer) Exists(ctx context.Context, rt fdb.ReadTransactor, path []string) (bool, error) {
 	r, txClose, err := rt.ReadTransact(ctx, func(rtr fdb.ReadTransaction) (interface{}, error) {
-		if err := dl.checkVersion(rtr, nil); err != nil {
+		if err := dl.checkVersion(ctx, rtr, nil); err != nil {
 			return false, err
 		}
 
-		node, exists := dl.find(rtr, path).prefetchMetadata(rtr)
+		node, exists := dl.find(ctx, rtr, path).prefetchMetadata(rtr)
 		if !exists {
 			return false, nil
 		} else {
 			defer node._layer.Close()
 		}
 
-		if node.isInPartition(nil, false) {
-			nc, err := node.getContents(dl, nil)
+		if node.isInPartition(ctx, nil, false) {
+			nc, err := node.getContents(ctx, dl, nil)
 			if err != nil {
 				return false, err
 			}
@@ -257,26 +257,26 @@ func (dl directoryLayer) Exists(ctx context.Context, rt fdb.ReadTransactor, path
 
 func (dl directoryLayer) List(ctx context.Context, rt fdb.ReadTransactor, path []string) ([]string, error) {
 	r, txClose, err := rt.ReadTransact(ctx, func(rtr fdb.ReadTransaction) (interface{}, error) {
-		if err := dl.checkVersion(rtr, nil); err != nil {
+		if err := dl.checkVersion(ctx, rtr, nil); err != nil {
 			return nil, err
 		}
 
-		node, exists := dl.find(rtr, path).prefetchMetadata(rtr)
+		node, exists := dl.find(ctx, rtr, path).prefetchMetadata(rtr)
 		if !exists {
 			return nil, ErrDirNotExists
 		} else {
 			defer node._layer.Close()
 		}
 
-		if node.isInPartition(nil, true) {
-			nc, err := node.getContents(dl, nil)
+		if node.isInPartition(ctx, nil, true) {
+			nc, err := node.getContents(ctx, dl, nil)
 			if err != nil {
 				return nil, err
 			}
 			return nc.List(ctx, rtr, node.getPartitionSubpath())
 		}
 
-		return dl.subdirNames(rtr, node.subspace)
+		return dl.subdirNames(ctx, rtr, node.subspace)
 	})
 	if err != nil {
 		return nil, err
@@ -291,7 +291,7 @@ func (dl directoryLayer) MoveTo(ctx context.Context, t fdb.Transactor, newAbsolu
 
 func (dl directoryLayer) Move(ctx context.Context, t fdb.Transactor, oldPath []string, newPath []string) (DirectorySubspace, error) {
 	r, txClose, err := t.Transact(ctx, func(tr fdb.Transaction) (interface{}, error) {
-		if err := dl.checkVersion(tr, &tr); err != nil {
+		if err := dl.checkVersion(ctx, tr, &tr); err != nil {
 			return nil, err
 		}
 
@@ -303,11 +303,11 @@ func (dl directoryLayer) Move(ctx context.Context, t fdb.Transactor, oldPath []s
 			return nil, errors.New("the destination directory cannot be a subdirectory of the source directory")
 		}
 
-		oldNode, oldNodeExists := dl.find(tr, oldPath).prefetchMetadata(tr)
+		oldNode, oldNodeExists := dl.find(ctx, tr, oldPath).prefetchMetadata(tr)
 		if oldNodeExists {
 			defer oldNode._layer.Close()
 		}
-		newNode, newNodeExists := dl.find(tr, newPath).prefetchMetadata(tr)
+		newNode, newNodeExists := dl.find(ctx, tr, newPath).prefetchMetadata(tr)
 		if newNodeExists {
 			defer newNode._layer.Close()
 		}
@@ -316,12 +316,12 @@ func (dl directoryLayer) Move(ctx context.Context, t fdb.Transactor, oldPath []s
 			return nil, errors.New("the source directory does not exist")
 		}
 
-		if oldNode.isInPartition(nil, false) || newNode.isInPartition(nil, false) {
-			if !oldNode.isInPartition(nil, false) || !newNode.isInPartition(nil, false) || !stringsEqual(oldNode.path, newNode.path) {
+		if oldNode.isInPartition(ctx, nil, false) || newNode.isInPartition(ctx, nil, false) {
+			if !oldNode.isInPartition(ctx, nil, false) || !newNode.isInPartition(ctx, nil, false) || !stringsEqual(oldNode.path, newNode.path) {
 				return nil, errors.New("cannot move between partitions")
 			}
 
-			nnc, err := newNode.getContents(dl, nil)
+			nnc, err := newNode.getContents(ctx, dl, nil)
 			if err != nil {
 				return nil, err
 			}
@@ -332,7 +332,7 @@ func (dl directoryLayer) Move(ctx context.Context, t fdb.Transactor, oldPath []s
 			return nil, errors.New("the destination directory already exists. Remove it first")
 		}
 
-		parentNode := dl.find(tr, newPath[:len(newPath)-1])
+		parentNode := dl.find(ctx, tr, newPath[:len(newPath)-1])
 		if !parentNode.exists() {
 			return nil, errors.New("the parent of the destination directory does not exist. Create it first")
 		}
@@ -343,9 +343,9 @@ func (dl directoryLayer) Move(ctx context.Context, t fdb.Transactor, oldPath []s
 		}
 		tr.Set(parentNode.subspace.Sub(_SUBDIRS, newPath[len(newPath)-1]), p[0].([]byte))
 
-		dl.removeFromParent(tr, oldPath)
+		dl.removeFromParent(ctx, tr, oldPath)
 
-		l, err := oldNode._layer.Get()
+		l, err := oldNode._layer.Get(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -360,7 +360,7 @@ func (dl directoryLayer) Move(ctx context.Context, t fdb.Transactor, oldPath []s
 
 func (dl directoryLayer) Remove(ctx context.Context, t fdb.Transactor, path []string) (bool, error) {
 	r, txClose, err := t.Transact(ctx, func(tr fdb.Transaction) (interface{}, error) {
-		if err := dl.checkVersion(tr, &tr); err != nil {
+		if err := dl.checkVersion(ctx, tr, &tr); err != nil {
 			return false, err
 		}
 
@@ -368,25 +368,25 @@ func (dl directoryLayer) Remove(ctx context.Context, t fdb.Transactor, path []st
 			return false, errors.New("the root directory cannot be removed")
 		}
 
-		node, exists := dl.find(tr, path).prefetchMetadata(tr)
+		node, exists := dl.find(ctx, tr, path).prefetchMetadata(tr)
 		if !exists {
 			return false, nil
 		} else {
 			defer node._layer.Close()
 		}
 
-		if node.isInPartition(nil, false) {
-			nc, err := node.getContents(dl, nil)
+		if node.isInPartition(ctx, nil, false) {
+			nc, err := node.getContents(ctx, dl, nil)
 			if err != nil {
 				return false, err
 			}
 			return nc.(directoryPartition).Remove(ctx, tr, node.getPartitionSubpath())
 		}
 
-		if err := dl.removeRecursive(tr, node.subspace); err != nil {
+		if err := dl.removeRecursive(ctx, tr, node.subspace); err != nil {
 			return false, err
 		}
-		dl.removeFromParent(tr, path)
+		dl.removeFromParent(ctx, tr, path)
 
 		return true, nil
 	})
@@ -397,10 +397,10 @@ func (dl directoryLayer) Remove(ctx context.Context, t fdb.Transactor, path []st
 	return r.(bool), nil
 }
 
-func (dl directoryLayer) removeRecursive(tr fdb.Transaction, node subspace.Subspace) error {
-	nodes := dl.subdirNodes(tr, node)
+func (dl directoryLayer) removeRecursive(ctx context.Context, tr fdb.Transaction, node subspace.Subspace) error {
+	nodes := dl.subdirNodes(ctx, tr, node)
 	for i := range nodes {
-		if err := dl.removeRecursive(tr, nodes[i]); err != nil {
+		if err := dl.removeRecursive(ctx, tr, nodes[i]); err != nil {
 			return err
 		}
 	}
@@ -420,8 +420,8 @@ func (dl directoryLayer) removeRecursive(tr fdb.Transaction, node subspace.Subsp
 	return nil
 }
 
-func (dl directoryLayer) removeFromParent(tr fdb.Transaction, path []string) {
-	parent := dl.find(tr, path[:len(path)-1])
+func (dl directoryLayer) removeFromParent(ctx context.Context, tr fdb.Transaction, path []string) {
+	parent := dl.find(ctx, tr, path[:len(path)-1])
 	tr.Clear(parent.subspace.Sub(_SUBDIRS, path[len(path)-1]))
 }
 
@@ -433,13 +433,13 @@ func (dl directoryLayer) GetPath() []string {
 	return dl.path
 }
 
-func (dl directoryLayer) subdirNames(rtr fdb.ReadTransaction, node subspace.Subspace) ([]string, error) {
+func (dl directoryLayer) subdirNames(ctx context.Context, rtr fdb.ReadTransaction, node subspace.Subspace) ([]string, error) {
 	sd := node.Sub(_SUBDIRS)
 
 	rr := rtr.GetRange(sd, fdb.RangeOptions{})
 
 	var ret []string
-	kvs := rr.MustGet()
+	kvs := rr.MustGet(ctx)
 	for _, kv := range kvs {
 		p, err := sd.Unpack(kv.Key)
 		if err != nil {
@@ -452,13 +452,13 @@ func (dl directoryLayer) subdirNames(rtr fdb.ReadTransaction, node subspace.Subs
 	return ret, nil
 }
 
-func (dl directoryLayer) subdirNodes(tr fdb.Transaction, node subspace.Subspace) []subspace.Subspace {
+func (dl directoryLayer) subdirNodes(ctx context.Context, tr fdb.Transaction, node subspace.Subspace) []subspace.Subspace {
 	sd := node.Sub(_SUBDIRS)
 
 	rr := tr.GetRange(sd, fdb.RangeOptions{})
 
 	var ret []subspace.Subspace
-	kvs := rr.MustGet()
+	kvs := rr.MustGet(ctx)
 	for _, kv := range kvs {
 		ret = append(ret, dl.nodeWithPrefix(kv.Value))
 	}
@@ -466,7 +466,7 @@ func (dl directoryLayer) subdirNodes(tr fdb.Transaction, node subspace.Subspace)
 	return ret
 }
 
-func (dl directoryLayer) nodeContainingKey(rtr fdb.ReadTransaction, key []byte) (subspace.Subspace, error) {
+func (dl directoryLayer) nodeContainingKey(ctx context.Context, rtr fdb.ReadTransaction, key []byte) (subspace.Subspace, error) {
 	if bytes.HasPrefix(key, dl.nodeSS.Bytes()) {
 		return dl.rootNode, nil
 	}
@@ -474,7 +474,7 @@ func (dl directoryLayer) nodeContainingKey(rtr fdb.ReadTransaction, key []byte) 
 	bk, _ := dl.nodeSS.FDBRangeKeys()
 	kr := fdb.KeyRange{bk, fdb.Key(append(dl.nodeSS.Pack(tuple.Tuple{key}), 0x00))}
 
-	kvs, err := rtr.GetRange(kr, fdb.RangeOptions{Reverse: true, Limit: 1}).Get()
+	kvs, err := rtr.GetRange(kr, fdb.RangeOptions{Reverse: true, Limit: 1}).Get(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -492,12 +492,12 @@ func (dl directoryLayer) nodeContainingKey(rtr fdb.ReadTransaction, key []byte) 
 	return nil, nil
 }
 
-func (dl directoryLayer) isPrefixFree(rtr fdb.ReadTransaction, prefix []byte) (bool, error) {
+func (dl directoryLayer) isPrefixFree(ctx context.Context, rtr fdb.ReadTransaction, prefix []byte) (bool, error) {
 	if len(prefix) == 0 {
 		return false, nil
 	}
 
-	nck, err := dl.nodeContainingKey(rtr, prefix)
+	nck, err := dl.nodeContainingKey(ctx, rtr, prefix)
 	if err != nil {
 		return false, err
 	}
@@ -511,18 +511,18 @@ func (dl directoryLayer) isPrefixFree(rtr fdb.ReadTransaction, prefix []byte) (b
 	}
 
 	bk, ek := kr.FDBRangeKeys()
-	if !isRangeEmpty(rtr, fdb.KeyRange{dl.nodeSS.Pack(tuple.Tuple{bk}), dl.nodeSS.Pack(tuple.Tuple{ek})}) {
+	if !isRangeEmpty(ctx, rtr, fdb.KeyRange{dl.nodeSS.Pack(tuple.Tuple{bk}), dl.nodeSS.Pack(tuple.Tuple{ek})}) {
 		return false, nil
 	}
 
 	return true, nil
 }
 
-func (dl directoryLayer) checkVersion(rtr fdb.ReadTransaction, tr *fdb.Transaction) error {
+func (dl directoryLayer) checkVersion(ctx context.Context, rtr fdb.ReadTransaction, tr *fdb.Transaction) error {
 	f := rtr.Get(dl.rootNode.Sub([]byte("version")))
 	defer f.Close()
 
-	version, err := f.Get()
+	version, err := f.Get(ctx)
 	if err != nil {
 		return err
 	}
@@ -605,7 +605,7 @@ func (dl directoryLayer) nodeWithPrefix(prefix []byte) subspace.Subspace {
 
 // find will find the specified path using multiple futures.
 // Caller is responsible for closing the layer information future of the returned node.
-func (dl directoryLayer) find(rtr fdb.ReadTransaction, path []string) *node {
+func (dl directoryLayer) find(ctx context.Context, rtr fdb.ReadTransaction, path []string) *node {
 	n := &node{dl.rootNode, []string{}, path, nil}
 	futures := make([]fdb.FutureByteSlice, len(path))
 	for i := range path {
@@ -624,8 +624,8 @@ func (dl directoryLayer) find(rtr fdb.ReadTransaction, path []string) *node {
 			n._layer.Close()
 		}
 
-		n = &node{dl.nodeWithPrefix(f.MustGet()), path[:i+1], path, nil}
-		if !n.exists() || bytes.Compare(n.layer(rtr).MustGet(), []byte("partition")) == 0 {
+		n = &node{dl.nodeWithPrefix(f.MustGet(ctx)), path[:i+1], path, nil}
+		if !n.exists() || bytes.Compare(n.layer(rtr).MustGet(ctx), []byte("partition")) == 0 {
 			return n
 		}
 	}
@@ -640,8 +640,8 @@ func (dl directoryLayer) partitionSubpath(lpath, rpath []string) []string {
 	return r
 }
 
-func isRangeEmpty(rtr fdb.ReadTransaction, r fdb.Range) bool {
-	kvs := rtr.GetRange(r, fdb.RangeOptions{Limit: 1}).MustGet()
+func isRangeEmpty(ctx context.Context, rtr fdb.ReadTransaction, r fdb.Range) bool {
+	kvs := rtr.GetRange(r, fdb.RangeOptions{Limit: 1}).MustGet(ctx)
 
 	return len(kvs) == 0
 }

--- a/bindings/go/src/fdb/directory/directory_layer.go
+++ b/bindings/go/src/fdb/directory/directory_layer.go
@@ -430,7 +430,7 @@ func (dl directoryLayer) subdirNames(rtr fdb.ReadTransaction, node subspace.Subs
 	rr := rtr.GetRange(sd, fdb.RangeOptions{})
 
 	var ret []string
-	kvs := rr.GetSliceOrPanic()
+	kvs := rr.MustGet()
 	for _, kv := range kvs {
 		p, err := sd.Unpack(kv.Key)
 		if err != nil {
@@ -449,7 +449,7 @@ func (dl directoryLayer) subdirNodes(tr fdb.Transaction, node subspace.Subspace)
 	rr := tr.GetRange(sd, fdb.RangeOptions{})
 
 	var ret []subspace.Subspace
-	kvs := rr.GetSliceOrPanic()
+	kvs := rr.MustGet()
 	for _, kv := range kvs {
 		ret = append(ret, dl.nodeWithPrefix(kv.Value))
 	}
@@ -465,7 +465,7 @@ func (dl directoryLayer) nodeContainingKey(rtr fdb.ReadTransaction, key []byte) 
 	bk, _ := dl.nodeSS.FDBRangeKeys()
 	kr := fdb.KeyRange{bk, fdb.Key(append(dl.nodeSS.Pack(tuple.Tuple{key}), 0x00))}
 
-	kvs, err := rtr.GetRange(kr, fdb.RangeOptions{Reverse: true, Limit: 1}).GetSliceWithError()
+	kvs, err := rtr.GetRange(kr, fdb.RangeOptions{Reverse: true, Limit: 1}).Get()
 	if err != nil {
 		return nil, err
 	}
@@ -623,7 +623,7 @@ func (dl directoryLayer) partitionSubpath(lpath, rpath []string) []string {
 }
 
 func isRangeEmpty(rtr fdb.ReadTransaction, r fdb.Range) bool {
-	kvs := rtr.GetRange(r, fdb.RangeOptions{Limit: 1}).GetSliceOrPanic()
+	kvs := rtr.GetRange(r, fdb.RangeOptions{Limit: 1}).MustGet()
 
 	return len(kvs) == 0
 }

--- a/bindings/go/src/fdb/directory/directory_partition.go
+++ b/bindings/go/src/fdb/directory/directory_partition.go
@@ -23,6 +23,8 @@
 package directory
 
 import (
+	"context"
+
 	"github.com/apple/foundationdb/bindings/go/src/fdb"
 	"github.com/apple/foundationdb/bindings/go/src/fdb/subspace"
 	"github.com/apple/foundationdb/bindings/go/src/fdb/tuple"
@@ -80,16 +82,16 @@ func (dp directoryPartition) getLayerForPath(path []string) directoryLayer {
 	return dp.directoryLayer
 }
 
-func (dp directoryPartition) MoveTo(t fdb.Transactor, newAbsolutePath []string) (DirectorySubspace, error) {
-	return moveTo(t, dp.parentDirectoryLayer, dp.path, newAbsolutePath)
+func (dp directoryPartition) MoveTo(ctx context.Context, t fdb.Transactor, newAbsolutePath []string) (DirectorySubspace, error) {
+	return moveTo(ctx, t, dp.parentDirectoryLayer, dp.path, newAbsolutePath)
 }
 
-func (dp directoryPartition) Remove(t fdb.Transactor, path []string) (bool, error) {
+func (dp directoryPartition) Remove(ctx context.Context, t fdb.Transactor, path []string) (bool, error) {
 	dl := dp.getLayerForPath(path)
-	return dl.Remove(t, dl.partitionSubpath(dp.path, path))
+	return dl.Remove(ctx, t, dl.partitionSubpath(dp.path, path))
 }
 
-func (dp directoryPartition) Exists(rt fdb.ReadTransactor, path []string) (bool, error) {
+func (dp directoryPartition) Exists(ctx context.Context, rt fdb.ReadTransactor, path []string) (bool, error) {
 	dl := dp.getLayerForPath(path)
-	return dl.Exists(rt, dl.partitionSubpath(dp.path, path))
+	return dl.Exists(ctx, rt, dl.partitionSubpath(dp.path, path))
 }

--- a/bindings/go/src/fdb/directory/directory_subspace.go
+++ b/bindings/go/src/fdb/directory/directory_subspace.go
@@ -23,6 +23,7 @@
 package directory
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -58,40 +59,40 @@ func (ds directorySubspace) String() string {
 	return fmt.Sprintf("DirectorySubspace(%s, %s)", path, fdb.Printable(ds.Bytes()))
 }
 
-func (d directorySubspace) CreateOrOpen(t fdb.Transactor, path []string, layer []byte) (DirectorySubspace, error) {
-	return d.dl.CreateOrOpen(t, d.dl.partitionSubpath(d.path, path), layer)
+func (d directorySubspace) CreateOrOpen(ctx context.Context, t fdb.Transactor, path []string, layer []byte) (DirectorySubspace, error) {
+	return d.dl.CreateOrOpen(ctx, t, d.dl.partitionSubpath(d.path, path), layer)
 }
 
-func (d directorySubspace) Create(t fdb.Transactor, path []string, layer []byte) (DirectorySubspace, error) {
-	return d.dl.Create(t, d.dl.partitionSubpath(d.path, path), layer)
+func (d directorySubspace) Create(ctx context.Context, t fdb.Transactor, path []string, layer []byte) (DirectorySubspace, error) {
+	return d.dl.Create(ctx, t, d.dl.partitionSubpath(d.path, path), layer)
 }
 
-func (d directorySubspace) CreatePrefix(t fdb.Transactor, path []string, layer []byte, prefix []byte) (DirectorySubspace, error) {
-	return d.dl.CreatePrefix(t, d.dl.partitionSubpath(d.path, path), layer, prefix)
+func (d directorySubspace) CreatePrefix(ctx context.Context, t fdb.Transactor, path []string, layer []byte, prefix []byte) (DirectorySubspace, error) {
+	return d.dl.CreatePrefix(ctx, t, d.dl.partitionSubpath(d.path, path), layer, prefix)
 }
 
-func (d directorySubspace) Open(rt fdb.ReadTransactor, path []string, layer []byte) (DirectorySubspace, error) {
-	return d.dl.Open(rt, d.dl.partitionSubpath(d.path, path), layer)
+func (d directorySubspace) Open(ctx context.Context, rt fdb.ReadTransactor, path []string, layer []byte) (DirectorySubspace, error) {
+	return d.dl.Open(ctx, rt, d.dl.partitionSubpath(d.path, path), layer)
 }
 
-func (d directorySubspace) MoveTo(t fdb.Transactor, newAbsolutePath []string) (DirectorySubspace, error) {
-	return moveTo(t, d.dl, d.path, newAbsolutePath)
+func (d directorySubspace) MoveTo(ctx context.Context, t fdb.Transactor, newAbsolutePath []string) (DirectorySubspace, error) {
+	return moveTo(ctx, t, d.dl, d.path, newAbsolutePath)
 }
 
-func (d directorySubspace) Move(t fdb.Transactor, oldPath []string, newPath []string) (DirectorySubspace, error) {
-	return d.dl.Move(t, d.dl.partitionSubpath(d.path, oldPath), d.dl.partitionSubpath(d.path, newPath))
+func (d directorySubspace) Move(ctx context.Context, t fdb.Transactor, oldPath []string, newPath []string) (DirectorySubspace, error) {
+	return d.dl.Move(ctx, t, d.dl.partitionSubpath(d.path, oldPath), d.dl.partitionSubpath(d.path, newPath))
 }
 
-func (d directorySubspace) Remove(t fdb.Transactor, path []string) (bool, error) {
-	return d.dl.Remove(t, d.dl.partitionSubpath(d.path, path))
+func (d directorySubspace) Remove(ctx context.Context, t fdb.Transactor, path []string) (bool, error) {
+	return d.dl.Remove(ctx, t, d.dl.partitionSubpath(d.path, path))
 }
 
-func (d directorySubspace) Exists(rt fdb.ReadTransactor, path []string) (bool, error) {
-	return d.dl.Exists(rt, d.dl.partitionSubpath(d.path, path))
+func (d directorySubspace) Exists(ctx context.Context, rt fdb.ReadTransactor, path []string) (bool, error) {
+	return d.dl.Exists(ctx, rt, d.dl.partitionSubpath(d.path, path))
 }
 
-func (d directorySubspace) List(rt fdb.ReadTransactor, path []string) ([]string, error) {
-	return d.dl.List(rt, d.dl.partitionSubpath(d.path, path))
+func (d directorySubspace) List(ctx context.Context, rt fdb.ReadTransactor, path []string) ([]string, error) {
+	return d.dl.List(ctx, rt, d.dl.partitionSubpath(d.path, path))
 }
 
 func (d directorySubspace) GetLayer() []byte {

--- a/bindings/go/src/fdb/directory/node.go
+++ b/bindings/go/src/fdb/directory/node.go
@@ -43,6 +43,9 @@ func (n *node) exists() bool {
 	return true
 }
 
+// prefetchMetadata will make sure that layer information starts being prefetched.
+// If subspace is nil, this is a no-op and returns false.
+// Caller is responsible for closing the future used to fetch layer information.
 func (n *node) prefetchMetadata(rtr fdb.ReadTransaction) (*node, bool) {
 	if n.exists() {
 		n.layer(rtr)
@@ -51,6 +54,8 @@ func (n *node) prefetchMetadata(rtr fdb.ReadTransaction) (*node, bool) {
 	return n, false
 }
 
+// layer will start a future to fetch layer information, unless one already exists.
+// Caller is responsible for properly closing this future.
 func (n *node) layer(rtr fdb.ReadTransaction) fdb.FutureByteSlice {
 	if n._layer == nil {
 		fv := rtr.Get(n.subspace.Sub([]byte("layer")))

--- a/bindings/go/src/fdb/directory/node.go
+++ b/bindings/go/src/fdb/directory/node.go
@@ -43,11 +43,12 @@ func (n *node) exists() bool {
 	return true
 }
 
-func (n *node) prefetchMetadata(rtr fdb.ReadTransaction) *node {
+func (n *node) prefetchMetadata(rtr fdb.ReadTransaction) (*node, bool) {
 	if n.exists() {
 		n.layer(rtr)
+		return n, true
 	}
-	return n
+	return n, false
 }
 
 func (n *node) layer(rtr fdb.ReadTransaction) fdb.FutureByteSlice {

--- a/bindings/go/src/fdb/directory/node.go
+++ b/bindings/go/src/fdb/directory/node.go
@@ -24,6 +24,7 @@ package directory
 
 import (
 	"bytes"
+	"context"
 
 	"github.com/apple/foundationdb/bindings/go/src/fdb"
 	"github.com/apple/foundationdb/bindings/go/src/fdb/subspace"
@@ -65,16 +66,16 @@ func (n *node) layer(rtr fdb.ReadTransaction) fdb.FutureByteSlice {
 	return n._layer
 }
 
-func (n *node) isInPartition(tr *fdb.Transaction, includeEmptySubpath bool) bool {
-	return n.exists() && bytes.Compare(n._layer.MustGet(), []byte("partition")) == 0 && (includeEmptySubpath || len(n.targetPath) > len(n.path))
+func (n *node) isInPartition(ctx context.Context, tr *fdb.Transaction, includeEmptySubpath bool) bool {
+	return n.exists() && bytes.Compare(n._layer.MustGet(ctx), []byte("partition")) == 0 && (includeEmptySubpath || len(n.targetPath) > len(n.path))
 }
 
 func (n *node) getPartitionSubpath() []string {
 	return n.targetPath[len(n.path):]
 }
 
-func (n *node) getContents(dl directoryLayer, tr *fdb.Transaction) (DirectorySubspace, error) {
-	l, err := n._layer.Get()
+func (n *node) getContents(ctx context.Context, dl directoryLayer, tr *fdb.Transaction) (DirectorySubspace, error) {
+	l, err := n._layer.Get(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/bindings/go/src/fdb/errors_test.go
+++ b/bindings/go/src/fdb/errors_test.go
@@ -23,6 +23,7 @@
 package fdb
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -52,11 +53,16 @@ func TestErrorWrapping(t *testing.T) {
 	}
 
 	for _, inputError := range testCases {
-		_, outputError := db.ReadTransact(func(rtr ReadTransaction) (interface{}, error) {
+		_, txClose, outputError := db.ReadTransact(context.Background(), func(rtr ReadTransaction) (interface{}, error) {
 			return nil, inputError
 		})
 		if inputError != outputError {
 			t.Errorf("expected error %v to be the same as %v", outputError, inputError)
+		}
+		if outputError == nil && txClose == nil {
+			t.Error("close function should not be nil on success")
+		} else if outputError != nil && txClose != nil {
+			t.Error("close function should be nil in case of error")
 		}
 	}
 }

--- a/bindings/go/src/fdb/fdb.go
+++ b/bindings/go/src/fdb/fdb.go
@@ -51,10 +51,10 @@ var (
 // exports and functions in preamble
 // (https://code.google.com/p/go-wiki/wiki/cgo#Global_functions)
 //
-//export unlockMutex
-func unlockMutex(p unsafe.Pointer) {
-	m := (*sync.Mutex)(p)
-	m.Unlock()
+//export goFutureReadyCallback
+func goFutureReadyCallback(pF, pRs unsafe.Pointer) {
+	rs := (*readySignal)(pRs)
+	close(*rs)
 }
 
 // A Transactor can execute a function that requires a Transaction. Functions

--- a/bindings/go/src/fdb/fdb.go
+++ b/bindings/go/src/fdb/fdb.go
@@ -29,6 +29,7 @@ import "C"
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"sync"
@@ -64,7 +65,8 @@ type Transactor interface {
 	// Transact executes the caller-provided function, providing it with a
 	// Transaction (itself a Transactor, allowing composition of transactional
 	// functions).
-	Transact(func(Transaction) (interface{}, error)) (interface{}, error)
+	// The returned function must be called after all futures have been closed, and is nil in case of error.
+	Transact(context.Context, func(Transaction) (interface{}, error)) (interface{}, func(), error)
 
 	// All Transactors are also ReadTransactors, allowing them to be used with
 	// read-only transactional functions.
@@ -79,7 +81,8 @@ type ReadTransactor interface {
 	// ReadTransact executes the caller-provided function, providing it with a
 	// ReadTransaction (itself a ReadTransactor, allowing composition of
 	// read-only transactional functions).
-	ReadTransact(func(ReadTransaction) (interface{}, error)) (interface{}, error)
+	// The returned function must be called after all futures have been closed, and is nil in case of error.
+	ReadTransact(context.Context, func(ReadTransaction) (interface{}, error)) (interface{}, func(), error)
 }
 
 func setOpt(setter func(*C.uint8_t, C.int) C.fdb_error_t, param []byte) error {

--- a/bindings/go/src/fdb/snapshot.go
+++ b/bindings/go/src/fdb/snapshot.go
@@ -66,11 +66,13 @@ func (s Snapshot) Snapshot() Snapshot {
 }
 
 // Get is equivalent to (Transaction).Get, performed as a snapshot read.
+// Close() must be called on the returned future to avoid a memory leak.
 func (s Snapshot) Get(key KeyConvertible) FutureByteSlice {
 	return s.get(key.FDBKey(), 1)
 }
 
 // GetKey is equivalent to (Transaction).GetKey, performed as a snapshot read.
+// Close() must be called on the returned future to avoid a memory leak.
 func (s Snapshot) GetKey(sel Selectable) FutureKey {
 	return s.getKey(sel.FDBKeySelector(), 1)
 }
@@ -83,6 +85,7 @@ func (s Snapshot) GetRange(r Range, options RangeOptions) RangeResult {
 
 // GetReadVersion is equivalent to (Transaction).GetReadVersion, performed as
 // a snapshot read.
+// Close() must be called on the returned future to avoid a memory leak.
 func (s Snapshot) GetReadVersion() FutureInt64 {
 	return s.getReadVersion()
 }
@@ -95,6 +98,7 @@ func (s Snapshot) GetDatabase() Database {
 
 // GetEstimatedRangeSizeBytes returns an estimate for the number of bytes
 // stored in the given range.
+// Close() must be called on the returned future to avoid a memory leak.
 func (s Snapshot) GetEstimatedRangeSizeBytes(r ExactRange) FutureInt64 {
 	beginKey, endKey := r.FDBRangeKeys()
 	return s.getEstimatedRangeSizeBytes(


### PR DESCRIPTION
* Explicit destruction for futures and transactions.
* Introduction of context for transactions and futures.
* Simplification of Future interface and internal value caching

**This is a breaking change**

This change makes the Go binding stop relying on Go's GC finalizers and instead use explicit Close() calls to release resources, which is more Go-idiomatic; additionally, `context.Context` is added to function signatures and supported through transaction cancellation.

NOTE: once merged this will be a breaking change for users because memory leaks would start appear on their FoundationDB clients, unless `Close()` is called for futures, transactions and range iterators.

# Code-Reviewer Section

- [x] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

I have not yet updated test code as I'd like to discuss this change first.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
