### PR TITLE
Disable SHARD_ENCODE_LOCATION_METADATA in Blob Features

### DIFF
--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -160,7 +160,27 @@ void DataMove::validateShard(const DDShardInfo& shard, KeyRangeRef range, int pr
 		return;
 	}
 
-	ASSERT(!this->meta.ranges.empty() && this->meta.ranges.front().contains(range));
+	if (this->meta.ranges.empty()) {
+		TraceEvent(SevError, "DataMoveValidationError")
+		    .detail("Range", range)
+		    .detail("Reason", "DataMoveMetatdataRangeEmpty")
+		    .detail("DestID", shard.destId)
+		    .detail("DataMoveMetaData", this->meta.toString())
+		    .detail("ShardPrimaryDest", describe(shard.primaryDest))
+		    .detail("ShardRemoteDest", describe(shard.remoteDest));
+		ASSERT(false);
+	}
+
+	if (!this->meta.ranges.front().contains(range)) {
+		TraceEvent(SevError, "DataMoveValidationError")
+		    .detail("Range", range)
+		    .detail("Reason", "DataMoveMetatdataRangeMismatch")
+		    .detail("DestID", shard.destId)
+		    .detail("DataMoveMetaData", this->meta.toString())
+		    .detail("ShardPrimaryDest", describe(shard.primaryDest))
+		    .detail("ShardRemoteDest", describe(shard.remoteDest));
+		ASSERT(false);
+	}
 
 	if (!shard.hasDest) {
 		TraceEvent(SevWarnAlways, "DataMoveValidationError")

--- a/fdbserver/MoveKeys.actor.cpp
+++ b/fdbserver/MoveKeys.actor.cpp
@@ -3471,6 +3471,14 @@ ACTOR Future<Void> prepareBlobRestore(Database occ,
                                       KeyRangeRef keys,
                                       UID bmId,
                                       UID reqId) {
+	if (SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA) {
+		TraceEvent(SevError, "PrepareBlobRestoreError")
+		    .detail("Reason", "SHARD_ENCODE_LOCATION_METADATA is enabled")
+		    .detail("Keys", keys)
+		    .detail("BMID", bmId)
+		    .detail("ReqID", reqId);
+		ASSERT(false);
+	}
 	state int retries = 0;
 	state Transaction tr = Transaction(occ);
 	ASSERT(ddEnabledState->isBlobRestorePreparing());

--- a/tests/rare/BlobGranuleApiCorrectness.toml
+++ b/tests/rare/BlobGranuleApiCorrectness.toml
@@ -5,6 +5,9 @@ allowDefaultTenant = false
 injectTargetedSSRestart = true
 injectSSDelay = true
 
+[[knobs]]
+shard_encode_location_metadata=false # not compatible with this feature
+
 [[test]]
 testTitle = 'BlobGranuleApiCorrectness'
 clearAfterTest = true

--- a/tests/rare/BlobGranuleCorrectness.toml
+++ b/tests/rare/BlobGranuleCorrectness.toml
@@ -9,6 +9,7 @@ injectSSDelay = true
 bg_metadata_source = "tenant"
 bg_key_tuple_truncate_offset = 1
 enable_rest_kms_communication = true
+shard_encode_location_metadata=false # not compatible with this feature
 
 [[test]]
 testTitle = 'BlobGranuleCorrectness'

--- a/tests/rare/BlobGranuleCorrectnessClean.toml
+++ b/tests/rare/BlobGranuleCorrectnessClean.toml
@@ -6,6 +6,7 @@ tenantModes = ['optional', 'required']
 [[knobs]]
 bg_metadata_source = "tenant"
 enable_rest_kms_communication = true
+shard_encode_location_metadata=false # not compatible with this feature
 
 [[test]]
 testTitle = 'BlobGranuleCorrectness'

--- a/tests/rare/BlobGranuleMergeBoundaries.toml
+++ b/tests/rare/BlobGranuleMergeBoundaries.toml
@@ -12,6 +12,7 @@ tenantModes = ['required']
 bg_key_tuple_truncate_offset = 1
 bg_metadata_source = "tenant"
 enable_rest_kms_communication = true
+shard_encode_location_metadata=false # not compatible with this feature
 
 [[test]]
 testTitle = 'BlobGranuleMergeBoundaries'

--- a/tests/rare/BlobGranuleMoveVerifyCycle.toml
+++ b/tests/rare/BlobGranuleMoveVerifyCycle.toml
@@ -3,6 +3,9 @@ testClass = "BlobGranule"
 blobGranulesEnabled = true 
 allowDefaultTenant = false
 
+[[knobs]]
+shard_encode_location_metadata=false # not compatible with this feature
+
 [[test]]
 testTitle = 'BlobGranuleMoveVerifyCycle'
 

--- a/tests/rare/BlobGranuleRanges.toml
+++ b/tests/rare/BlobGranuleRanges.toml
@@ -5,6 +5,9 @@ injectTargetedSSRestart = true
 injectSSDelay = true
 tenantModes = ['optional', 'required']
 
+[[knobs]]
+shard_encode_location_metadata=false # not compatible with this feature
+
 [[test]]
 testTitle = 'BlobGranuleRanges'
 

--- a/tests/rare/BlobGranuleRangesChangeLog.toml
+++ b/tests/rare/BlobGranuleRangesChangeLog.toml
@@ -8,6 +8,7 @@ tenantModes = ['optional', 'required']
 
 [[knobs]]
 bg_use_blob_range_change_log = true
+shard_encode_location_metadata=false # not compatible with this feature
 
 [[test]]
 testTitle = 'BlobGranuleRanges'

--- a/tests/rare/BlobGranuleVerifyAtomicOps.toml
+++ b/tests/rare/BlobGranuleVerifyAtomicOps.toml
@@ -5,6 +5,9 @@ allowDefaultTenant = false
 injectTargetedSSRestart = true
 injectSSDelay = true
 
+[[knobs]]
+shard_encode_location_metadata=false # not compatible with this feature
+
 [[test]]
 testTitle = 'BlobGranuleVerifyAtomicOps'
 

--- a/tests/rare/BlobGranuleVerifyBalance.toml
+++ b/tests/rare/BlobGranuleVerifyBalance.toml
@@ -4,6 +4,9 @@ allowDefaultTenant = false
 injectTargetedSSRestart = true
 injectSSDelay = true
 
+[[knobs]]
+shard_encode_location_metadata=false # not compatible with this feature
+
 [[test]]
 testTitle = 'BlobGranuleVerifyBalance'
 

--- a/tests/rare/BlobGranuleVerifyBalanceClean.toml
+++ b/tests/rare/BlobGranuleVerifyBalanceClean.toml
@@ -2,6 +2,9 @@
 blobGranulesEnabled = true
 allowDefaultTenant = false
 
+[[knobs]]
+shard_encode_location_metadata=false # not compatible with this feature
+
 [[test]]
 testTitle = 'BlobGranuleVerifyBalanceClean'
 

--- a/tests/rare/BlobGranuleVerifyCycle.toml
+++ b/tests/rare/BlobGranuleVerifyCycle.toml
@@ -5,6 +5,9 @@ allowDefaultTenant = false
 injectTargetedSSRestart = true
 injectSSDelay = true
 
+[[knobs]]
+shard_encode_location_metadata=false # not compatible with this feature
+
 [[test]]
 testTitle = 'BlobGranuleVerifyCycle'
 

--- a/tests/rare/BlobGranuleVerifyLarge.toml
+++ b/tests/rare/BlobGranuleVerifyLarge.toml
@@ -4,6 +4,9 @@ allowDefaultTenant = false
 injectTargetedSSRestart = true
 injectSSDelay = true
 
+[[knobs]]
+shard_encode_location_metadata=false # not compatible with this feature
+
 [[test]]
 testTitle = 'BlobGranuleVerifyLarge'
 

--- a/tests/rare/BlobGranuleVerifyLargeClean.toml
+++ b/tests/rare/BlobGranuleVerifyLargeClean.toml
@@ -2,6 +2,9 @@
 blobGranulesEnabled = true 
 allowDefaultTenant = false
 
+[[knobs]]
+shard_encode_location_metadata=false # not compatible with this feature
+
 [[test]]
 testTitle = 'BlobGranuleVerifyLargeClean'
 

--- a/tests/rare/BlobGranuleVerifySmall.toml
+++ b/tests/rare/BlobGranuleVerifySmall.toml
@@ -5,6 +5,9 @@ allowDefaultTenant = false
 injectTargetedSSRestart = true
 injectSSDelay = true
 
+[[knobs]]
+shard_encode_location_metadata=false # not compatible with this feature
+
 [[test]]
 testTitle = 'BlobGranuleVerifySmall'
 

--- a/tests/rare/BlobGranuleVerifySmallClean.toml
+++ b/tests/rare/BlobGranuleVerifySmallClean.toml
@@ -3,6 +3,9 @@ blobGranulesEnabled = true
 allowDefaultTenant = false
 testClass = "BlobGranule"
 
+[[knobs]]
+shard_encode_location_metadata=false # not compatible with this feature
+
 [[test]]
 testTitle = 'BlobGranuleVerifySmallClean'
 

--- a/tests/rare/BlobRestoreBasic.toml
+++ b/tests/rare/BlobRestoreBasic.toml
@@ -9,6 +9,7 @@ disableTss = true
 bg_consistency_check_enabled = 0
 bw_throttling_enabled = false
 blob_restore_skip_empty_ranges = false
+shard_encode_location_metadata=false # not compatible with this feature
 
 [[test]]
 testTitle = 'SetupBlob'

--- a/tests/rare/BlobRestoreLarge.toml
+++ b/tests/rare/BlobRestoreLarge.toml
@@ -9,6 +9,7 @@ disableTss = true
 bg_consistency_check_enabled = 0
 bw_throttling_enabled = false
 blob_restore_skip_empty_ranges = false
+shard_encode_location_metadata=false # not compatible with this feature
 
 [[test]]
 testTitle = 'SetupBlob'

--- a/tests/rare/BlobRestoreTenantMode.toml
+++ b/tests/rare/BlobRestoreTenantMode.toml
@@ -13,6 +13,7 @@ bg_key_tuple_truncate_offset = 1
 enable_rest_kms_communication = true
 bg_consistency_check_enabled = 0
 bw_throttling_enabled = false
+shard_encode_location_metadata=false # not compatible with this feature
 
 [[test]] 
 testTitle = 'BackupMutationLogs'

--- a/tests/rare/BlobRestoreToVersion.toml
+++ b/tests/rare/BlobRestoreToVersion.toml
@@ -9,6 +9,7 @@ disableTss = true
 bg_consistency_check_enabled = 0
 bw_throttling_enabled = false
 blob_restore_skip_empty_ranges = false
+shard_encode_location_metadata=false # not compatible with this feature
 
 [[test]]
 testTitle = 'SetupBlob'


### PR DESCRIPTION
Fix an issue mentioned by https://github.com/apple/foundationdb/pull/12051#issue-2948354091

Blob and SHARD_ENCODE_LOCATION_METADATA  are not compatible. Blob uses `assignKeysToServer` which changes ServerKeys and KeyServers without changing data move metadata. On the other hand, ShardEncodeLocationMetadata requires to update data move metadata when updating the shard maps (see StartMoveShard and FinishMoveShard). 

If `prepareBlobRestore` runs when ShardEncodeLocationMetadata is on, when DD restarts, DD loads data move metadata and key server metadata, there can be a mismatch detected by `DataMove::validateShard`.

100K correctness:
  20250327-004138-zhewang-a7fa5eee90608b1d           compressed=True data_size=41070986 duration=6706291 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:41:12 sanity=False started=100000 stopped=20250327-012250 submitted=20250327-004138 timeout=5400 username=zhewang
    
# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
