### PR TITLE
Set snapshot restore state from mutation logs information.

### DIFF
--- a/fdbclient/BackupContainerFileSystem.actor.cpp
+++ b/fdbclient/BackupContainerFileSystem.actor.cpp
@@ -417,6 +417,81 @@ public:
 		}
 	}
 
+	// Checks if list of sorted logfiles have the logs from snapshotBeginVersion to snapshotEndversion.
+	// Which means the sorted log files(have beginVersion and endVersion) should cover
+	// all the versions between snapshotBegingVersion and snapshotEndversion.
+	// Note: logs should be pre-sorted according to version order.
+	static bool hasContinuousLogsForSnapshot(const std::vector<LogFile>& logs,
+	                                         Version snapshotBeginVersion,
+	                                         Version snapshotEndVersion) {
+		auto it = logs.begin();
+
+		// find the first mutation log file that covers snapshotBeginVersion
+		while (it != logs.end()) {
+			if (it->beginVersion <= snapshotBeginVersion && it->endVersion > snapshotBeginVersion)
+				break;
+			++it;
+		}
+
+		// no log find found covering snaphostBeginVersion, return false
+		if (it == logs.end())
+			return false;
+
+		// If current log entry(it), covers the entire snapshot, return true
+		if (it->endVersion > snapshotEndVersion)
+			return true;
+
+		// Iterate over the next logs, check if they are continuous and if
+		// the log file is covering the snapshot.
+		Version prevEnd = it->endVersion;
+		++it;
+
+		while (it != logs.end()) {
+			if (it->beginVersion == prevEnd &&
+			    it->endVersion > snapshotEndVersion) // continuous logs until snapshot is covered
+				return true;
+			else if (it->beginVersion != prevEnd) // not continuous logs
+				return false;
+
+			prevEnd = it->endVersion;
+			++it;
+		} // comes out if the logs are not found until snapshotEndVersion.
+
+		return prevEnd > snapshotEndVersion;
+	}
+
+	// Find the continuous log end version starting from beginVersion in the
+	// given list of sorted logfiles.
+	// Note: logs should be pre-sorted according to version order.
+	static Version findContinuousLogEnd(const std::vector<LogFile>& logs, Version beginVersion) {
+		auto it = logs.begin();
+
+		// find the first mutation log file that covers beginVersion
+		while (it != logs.end()) {
+			if (it->beginVersion <= beginVersion && it->endVersion > beginVersion)
+				break;
+			++it;
+		}
+
+		// no log find found covering beginVersion, return invalidVersion
+		if (it == logs.end())
+			return invalidVersion;
+
+		// Iterate over the next logs, check if they are continuous
+		Version prevEnd = it->endVersion;
+		++it;
+
+		while (it != logs.end()) {
+			if (it->beginVersion != prevEnd) // not continuous logs
+				return prevEnd;
+
+			prevEnd = it->endVersion;
+			++it;
+		} // out of logs.
+
+		return prevEnd;
+	}
+
 	ACTOR static Future<BackupDescription> describeBackup(Reference<BackupContainerFileSystem> bc,
 	                                                      bool deepScan,
 	                                                      Version logStartVersionOverride) {
@@ -619,13 +694,25 @@ public:
 					s.restorable = false;
 				if (!desc.contiguousLogEnd.present() || desc.contiguousLogEnd.get() <= s.endVersion)
 					s.restorable = false;
+				// If there is logs gap after contiguousLogEnd, then check whether the current snapshot
+				// can be restored from the logs available after contiguousLogEnd.
+				if (desc.contiguousLogEnd.present() && desc.contiguousLogEnd.get() <= s.beginVersion) {
+					if (desc.partitioned)
+						s.restorable = isPartitionedLogsContinuous(logs, s.beginVersion, s.endVersion);
+					else
+						s.restorable = hasContinuousLogsForSnapshot(logs, s.beginVersion, s.endVersion);
+				}
 			}
 
 			desc.snapshotBytes += s.totalSize;
 
 			// If the snapshot is at a single version then it requires no logs.  Update min and max restorable.
 			// TODO:  Somehow check / report if the restorable range is not or may not be contiguous.
-			if (s.beginVersion == s.endVersion) {
+			if (s.beginVersion == s.endVersion &&
+			    (!desc.contiguousLogEnd.present() || // no logs
+			     (desc.contiguousLogEnd.present() &&
+			      desc.contiguousLogEnd.get() >= s.beginVersion)) // have logs, then should cover snapshot
+			) {
 				if (!desc.minRestorableVersion.present() || s.endVersion < desc.minRestorableVersion.get())
 					desc.minRestorableVersion = s.endVersion;
 
@@ -642,6 +729,53 @@ public:
 				if (!desc.maxRestorableVersion.present() ||
 				    (desc.contiguousLogEnd.get() - 1) > desc.maxRestorableVersion.get())
 					desc.maxRestorableVersion = desc.contiguousLogEnd.get() - 1;
+			}
+
+			// If there is logs gap after contiguousLogEnd and if current snapshot is restorable(have continuous logs)
+			if (desc.contiguousLogEnd.present() &&
+			    ((desc.contiguousLogEnd.get() < s.beginVersion) ||
+			     // if contiguousLogEnd==s.beginVersion==s.endVersion, there is no need to check for continuous logs in
+			     // single version snapshot. And this case is covered in above if condition.
+			     (desc.contiguousLogEnd.get() == s.beginVersion && s.beginVersion != s.endVersion)) &&
+			    s.restorable.get()) {
+				if (desc.minRestorableVersion.present() && desc.maxRestorableVersion.present()) {
+					ASSERT(desc.minRestorableVersion.get() < s.beginVersion);
+
+					// check if we have contiguous logs from minRestorableVersion to current snapshot endVersion
+					bool contiguousLogs = false;
+					if (desc.partitioned)
+						contiguousLogs =
+						    isPartitionedLogsContinuous(logs, desc.minRestorableVersion.get(), s.endVersion);
+					else
+						contiguousLogs =
+						    hasContinuousLogsForSnapshot(logs, desc.minRestorableVersion.get(), s.endVersion);
+
+					if (contiguousLogs) {
+						// The previous restorable version can be extended to current snapshot version,
+						// so minRestorableVersion remain same
+						desc.maxRestorableVersion = s.endVersion;
+					} else {
+						// Previous restorable version cannot be extended to current snapshot version,
+						// means some logs are missing inbetween.
+						// So set the snapshot beginversion as minRestorableVersion.
+						desc.minRestorableVersion = s.endVersion;
+					}
+				} else {
+					// There is no previous snapshot that is restorable.
+					// Since the current snapshot is restorable, set the snapshot beginversion as minRestorableVersion.
+					desc.minRestorableVersion = s.endVersion;
+				}
+
+				// Find the continuousLogEnd after snapshotEndVersion and set it as
+				// maxRestorableVersion.
+				if (desc.partitioned) {
+					// TO DO: Yet to implement similar function findContinuousLogEnd for partitioned logs.
+					desc.maxRestorableVersion = s.endVersion;
+				} else {
+					Version maxContinuousLogEnd = findContinuousLogEnd(logs, s.endVersion);
+					desc.maxRestorableVersion =
+					    (maxContinuousLogEnd == invalidVersion) ? s.endVersion : maxContinuousLogEnd - 1;
+				}
 			}
 		}
 
@@ -1961,6 +2095,309 @@ TEST_CASE("/backup/continuous") {
 	ASSERT(BackupContainerFileSystemImpl::getPartitionedLogsContinuousEndVersion(files, 99) == 399);
 	ASSERT(BackupContainerFileSystemImpl::getPartitionedLogsContinuousEndVersion(files, 250) == 399);
 
+	return Void();
+}
+
+TEST_CASE("/backup/logs_continuous") {
+	std::vector<LogFile> files;
+
+	// [10, 100)
+	files.push_back({ 10, 100, 10, "file1", 100 });
+	ASSERT(!BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 0, 5));
+	ASSERT(!BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 5, 50));
+	ASSERT(!BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 5, 105));
+	ASSERT(!BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 100, 101));
+	ASSERT(!BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 101, 150));
+	ASSERT(BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 10, 99));
+	ASSERT(!BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 10, 100));
+	ASSERT(!BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 10, 101));
+	ASSERT(!BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 10, 150));
+	ASSERT(BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 50, 70));
+	ASSERT(BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 50, 99));
+	ASSERT(!BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 50, 100));
+	ASSERT(BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 10, 11));
+	ASSERT(BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 98, 99));
+	ASSERT(!BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 99, 100));
+	ASSERT(BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 99, 99));
+	ASSERT(!BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 100, 100));
+	ASSERT(BackupContainerFileSystemImpl::findContinuousLogEnd(files, 0) == invalidVersion);
+	ASSERT(BackupContainerFileSystemImpl::findContinuousLogEnd(files, 5) == invalidVersion);
+	ASSERT(BackupContainerFileSystemImpl::findContinuousLogEnd(files, 10) == 100);
+	ASSERT(BackupContainerFileSystemImpl::findContinuousLogEnd(files, 50) == 100);
+	ASSERT(BackupContainerFileSystemImpl::findContinuousLogEnd(files, 99) == 100);
+	ASSERT(BackupContainerFileSystemImpl::findContinuousLogEnd(files, 100) == invalidVersion);
+	ASSERT(BackupContainerFileSystemImpl::findContinuousLogEnd(files, 101) == invalidVersion);
+
+	// [10, 100), [100, 200)
+	files.push_back({ 100, 200, 10, "file2", 100 });
+	std::sort(files.begin(), files.end());
+	ASSERT(!BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 0, 5));
+	ASSERT(!BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 5, 50));
+	ASSERT(!BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 5, 105));
+	ASSERT(BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 100, 101));
+	ASSERT(BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 101, 150));
+	ASSERT(BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 10, 99));
+	ASSERT(BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 10, 100));
+	ASSERT(BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 10, 101));
+	ASSERT(BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 10, 150));
+	ASSERT(BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 50, 70));
+	ASSERT(BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 50, 99));
+	ASSERT(BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 50, 100));
+	ASSERT(BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 10, 11));
+	ASSERT(BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 98, 99));
+	ASSERT(BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 99, 100));
+	ASSERT(BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 99, 99));
+	ASSERT(BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 100, 100));
+
+	ASSERT(!BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 5, 150));
+	ASSERT(!BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 5, 205));
+	ASSERT(!BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 200, 201));
+	ASSERT(!BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 201, 250));
+	ASSERT(BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 10, 199));
+	ASSERT(!BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 10, 200));
+	ASSERT(!BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 10, 201));
+	ASSERT(BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 70, 170));
+	ASSERT(!BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 70, 200));
+	ASSERT(!BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 199, 200));
+	ASSERT(BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 199, 199));
+	ASSERT(!BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 200, 200));
+
+	ASSERT(BackupContainerFileSystemImpl::findContinuousLogEnd(files, 0) == invalidVersion);
+	ASSERT(BackupContainerFileSystemImpl::findContinuousLogEnd(files, 5) == invalidVersion);
+	ASSERT(BackupContainerFileSystemImpl::findContinuousLogEnd(files, 10) == 200);
+	ASSERT(BackupContainerFileSystemImpl::findContinuousLogEnd(files, 50) == 200);
+	ASSERT(BackupContainerFileSystemImpl::findContinuousLogEnd(files, 99) == 200);
+	ASSERT(BackupContainerFileSystemImpl::findContinuousLogEnd(files, 100) == 200);
+	ASSERT(BackupContainerFileSystemImpl::findContinuousLogEnd(files, 101) == 200);
+	ASSERT(BackupContainerFileSystemImpl::findContinuousLogEnd(files, 199) == 200);
+	ASSERT(BackupContainerFileSystemImpl::findContinuousLogEnd(files, 200) == invalidVersion);
+	ASSERT(BackupContainerFileSystemImpl::findContinuousLogEnd(files, 201) == invalidVersion);
+
+	// [10, 100), [100, 200), [300, 400)
+	files.push_back({ 300, 400, 10, "file3", 100 });
+	std::sort(files.begin(), files.end());
+	ASSERT(!BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 0, 5));
+	ASSERT(!BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 5, 50));
+	ASSERT(!BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 5, 105));
+	ASSERT(BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 100, 101));
+	ASSERT(BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 101, 150));
+	ASSERT(BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 10, 99));
+	ASSERT(BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 10, 100));
+	ASSERT(BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 10, 101));
+	ASSERT(BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 10, 150));
+	ASSERT(BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 50, 70));
+	ASSERT(BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 50, 99));
+	ASSERT(BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 50, 100));
+	ASSERT(BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 10, 11));
+	ASSERT(BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 98, 99));
+	ASSERT(BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 99, 100));
+	ASSERT(BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 99, 99));
+	ASSERT(BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 100, 100));
+
+	ASSERT(!BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 5, 150));
+	ASSERT(!BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 5, 205));
+	ASSERT(!BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 200, 201));
+	ASSERT(!BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 201, 250));
+	ASSERT(BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 10, 199));
+	ASSERT(!BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 10, 200));
+	ASSERT(!BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 10, 201));
+	ASSERT(BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 70, 170));
+	ASSERT(!BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 70, 200));
+	ASSERT(!BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 199, 200));
+	ASSERT(BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 199, 199));
+	ASSERT(!BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 200, 200));
+
+	ASSERT(!BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 250, 260));
+	ASSERT(!BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 250, 310));
+	ASSERT(!BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 250, 405));
+	ASSERT(!BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 400, 401));
+	ASSERT(!BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 401, 450));
+	ASSERT(BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 300, 399));
+	ASSERT(!BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 300, 400));
+	ASSERT(!BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 300, 401));
+	ASSERT(BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 300, 350));
+	ASSERT(BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 350, 370));
+	ASSERT(!BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 350, 400));
+	ASSERT(!BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 10, 400));
+	ASSERT(!BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 100, 400));
+	ASSERT(!BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 200, 400));
+	ASSERT(!BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 299, 400));
+	ASSERT(!BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 399, 400));
+	ASSERT(BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 399, 399));
+	ASSERT(!BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(files, 400, 400));
+
+	ASSERT(BackupContainerFileSystemImpl::findContinuousLogEnd(files, 0) == invalidVersion);
+	ASSERT(BackupContainerFileSystemImpl::findContinuousLogEnd(files, 5) == invalidVersion);
+	ASSERT(BackupContainerFileSystemImpl::findContinuousLogEnd(files, 10) == 200);
+	ASSERT(BackupContainerFileSystemImpl::findContinuousLogEnd(files, 50) == 200);
+	ASSERT(BackupContainerFileSystemImpl::findContinuousLogEnd(files, 99) == 200);
+	ASSERT(BackupContainerFileSystemImpl::findContinuousLogEnd(files, 100) == 200);
+	ASSERT(BackupContainerFileSystemImpl::findContinuousLogEnd(files, 101) == 200);
+	ASSERT(BackupContainerFileSystemImpl::findContinuousLogEnd(files, 199) == 200);
+	ASSERT(BackupContainerFileSystemImpl::findContinuousLogEnd(files, 200) == invalidVersion);
+	ASSERT(BackupContainerFileSystemImpl::findContinuousLogEnd(files, 201) == invalidVersion);
+	ASSERT(BackupContainerFileSystemImpl::findContinuousLogEnd(files, 250) == invalidVersion);
+	ASSERT(BackupContainerFileSystemImpl::findContinuousLogEnd(files, 299) == invalidVersion);
+	ASSERT(BackupContainerFileSystemImpl::findContinuousLogEnd(files, 300) == 400);
+	ASSERT(BackupContainerFileSystemImpl::findContinuousLogEnd(files, 301) == 400);
+	ASSERT(BackupContainerFileSystemImpl::findContinuousLogEnd(files, 399) == 400);
+	ASSERT(BackupContainerFileSystemImpl::findContinuousLogEnd(files, 400) == invalidVersion);
+	ASSERT(BackupContainerFileSystemImpl::findContinuousLogEnd(files, 401) == invalidVersion);
+	ASSERT(BackupContainerFileSystemImpl::findContinuousLogEnd(files, 450) == invalidVersion);
+
+	return Void();
+}
+
+void printFileList(BackupFileList& backupFileList) {
+	printf("\nRangeFiles count:%lu", backupFileList.ranges.size());
+	for (auto r : backupFileList.ranges)
+		printf("\n%s", r.toString().c_str());
+
+	printf("\nLogFiles count:%lu", backupFileList.logs.size());
+	for (auto l : backupFileList.logs)
+		printf("\n%s", l.toString().c_str());
+
+	printf("\nSnapshotFiles count:%lu", backupFileList.snapshots.size());
+	for (auto s : backupFileList.snapshots)
+		printf("\n%lld, %lld, %s, %lld", s.beginVersion, s.endVersion, s.fileName.c_str(), s.totalSize);
+}
+
+// Intentionally missing some log range files and checking if the snapshot can be restored.
+ACTOR Future<Void> testBackupContainerWithMissingLogRanges(std::string url, Optional<std::string> proxy) {
+	state FlowLock lock(100e6);
+	printf("BackupContainerTest URL %s\n", url.c_str());
+
+	state Reference<IBackupContainer> c = IBackupContainer::openContainer(url, proxy, {});
+	// Make sure container doesn't exist, then create it.
+	try {
+		wait(c->deleteContainer());
+	} catch (Error& e) {
+		if (e.code() != error_code_backup_invalid_url && e.code() != error_code_backup_does_not_exist)
+			throw;
+	}
+	wait(c->create());
+
+	state Key begin = randomKeyBetween(normalKeys);
+	state Key end = randomKeyBetween(KeyRangeRef(begin, normalKeys.end));
+	state int blockSize = 3 * sizeof(uint32_t) + begin.size() + end.size() + 8;
+	state std::vector<Future<Void>> writes;
+	state std::pair<Key, Key> beginEndKeys = std::make_pair(begin, end);
+	state std::vector<bool> snapshotsMissingLogs;
+	state Version v = deterministicRandom()->randomInt64(0, std::numeric_limits<Version>::max() / 2);
+	state Version tempLogEnd = 0;
+	state Version logStart = v;
+	state Version logEnd = v;
+	state Version snapshotBeginVersion = v;
+	state Version snapshotEndVersion = v;
+	state bool nextSnapshotMissingLogs = false;
+
+	// create a random number of snapshots
+	state int numSnapshots = deterministicRandom()->randomInt(1, 10);
+	while (numSnapshots) {
+		state std::vector<std::string> rangeFileNames;
+		state std::vector<std::pair<Key, Key>> snapshotBeginEndKeys;
+
+		// create a random number of range files per snapshot
+		state int numRangeFiles = deterministicRandom()->randomInt(2, 5);
+		snapshotBeginVersion = v;
+		while (numRangeFiles) {
+			state Reference<IBackupFile> range = wait(c->writeRangeFile(v, 0, v, blockSize));
+			writes.push_back(writeAndVerifyFile(c, range, deterministicRandom()->randomInt(0, 2e6), &lock));
+			rangeFileNames.push_back(range->getFileName());
+			snapshotBeginEndKeys.push_back(beginEndKeys);
+
+			logEnd = v;
+			v = nextVersion(v);
+			--numRangeFiles;
+		}
+		snapshotEndVersion = logEnd;
+
+		// writing the snapshot file
+		writes.push_back(c->writeKeyspaceSnapshotFile(rangeFileNames,
+		                                              snapshotBeginEndKeys,
+		                                              deterministicRandom()->randomInt(0, 2e6),
+		                                              IncludeKeyRangeMap(BUGGIFY)));
+
+		snapshotsMissingLogs.push_back(nextSnapshotMissingLogs);
+		nextSnapshotMissingLogs = false;
+
+		// creating log files for the snapshot range.
+		while (logStart < logEnd) {
+			tempLogEnd = nextVersion(logStart);
+			if (deterministicRandom()->random01() < 0.5) {
+				state Reference<IBackupFile> log = wait(c->writeLogFile(logStart, tempLogEnd, blockSize));
+				writes.push_back(writeAndVerifyFile(c, log, deterministicRandom()->randomInt(0, 2e6), &lock));
+			} else { // intentionally missing writing of some log files.
+				// If the missing log range falls in the current snapshot range, mark it.
+				if (!(tempLogEnd < snapshotBeginVersion || snapshotEndVersion < logStart))
+					snapshotsMissingLogs.back() = true;
+				if (tempLogEnd > v) // if it overlaps with the next snapshot, mark the next snapshot as well.
+					nextSnapshotMissingLogs = true;
+			}
+			logStart = tempLogEnd;
+		}
+
+		--numSnapshots;
+	}
+
+	wait(waitForAll(writes));
+	state BackupFileList listing = wait(c->dumpFileList());
+	printFileList(listing);
+
+	printf("\n\nSnapshots missing logs:");
+	state int i = 0;
+	for (; i < snapshotsMissingLogs.size(); ++i)
+		printf("\nSnapshot%d: %s", i, snapshotsMissingLogs[i] ? "true" : "false");
+
+	state BackupDescription desc = wait(c->describeBackup());
+	printf("\n\n%s\n", desc.toString().c_str());
+
+	for (i = 0; i < listing.snapshots.size(); ++i) {
+		// Ensure we can restore to the end version of snapshot i
+		Optional<RestorableFileSet> rest = wait(c->getRestoreSet(listing.snapshots[i].endVersion));
+		if (snapshotsMissingLogs[i])
+			ASSERT(!rest.present());
+		else
+			ASSERT(rest.present());
+	}
+
+	for (i = snapshotsMissingLogs.size() - 1; i >= 0; --i) {
+		if (!snapshotsMissingLogs[i]) {
+			int j = i - 1;
+			for (; j >= 0; --j) {
+				if (snapshotsMissingLogs[j] ||
+				    !BackupContainerFileSystemImpl::hasContinuousLogsForSnapshot(
+				        listing.logs, listing.snapshots[j].endVersion, listing.snapshots[j + 1].beginVersion))
+					break;
+			}
+			ASSERT(desc.minRestorableVersion.get() == listing.snapshots[j + 1].endVersion);
+			ASSERT(desc.maxRestorableVersion.get() >= listing.snapshots[i].endVersion);
+			if (i + 1 < snapshotsMissingLogs.size())
+				ASSERT(desc.maxRestorableVersion.get() < listing.snapshots[i + 1].endVersion);
+			break;
+		}
+	}
+
+	printf("DELETING\n");
+	wait(c->deleteContainer());
+
+	state Future<BackupDescription> d = c->describeBackup();
+	wait(ready(d));
+	ASSERT(d.isError() && d.getError().code() == error_code_backup_does_not_exist);
+
+	BackupFileList empty = wait(c->dumpFileList());
+	ASSERT_EQ(empty.ranges.size(), 0);
+	ASSERT_EQ(empty.logs.size(), 0);
+	ASSERT_EQ(empty.snapshots.size(), 0);
+
+	printf("BackupContainerTest URL=%s PASSED.\n", url.c_str());
+
+	return Void();
+}
+
+TEST_CASE("/backup/containers/localdir/missingLogRangesRestorability") {
+	wait(testBackupContainerWithMissingLogRanges(
+	    format("file://%s/fdb_backups/%llx", params.getDataDir().c_str(), timer_int()), {}));
 	return Void();
 }
 

--- a/fdbserver/workloads/BackupCorrectness.actor.cpp
+++ b/fdbserver/workloads/BackupCorrectness.actor.cpp
@@ -687,8 +687,10 @@ struct BackupAndRestoreCorrectnessWorkload : TestWorkload {
 					} else if (deterministicRandom()->random01() < 0.1) {
 						targetVersion = desc.maxRestorableVersion.get();
 					} else if (deterministicRandom()->random01() < 0.5) {
-						targetVersion = deterministicRandom()->randomInt64(desc.minRestorableVersion.get(),
-						                                                   desc.contiguousLogEnd.get());
+						targetVersion = (desc.minRestorableVersion.get() != desc.maxRestorableVersion.get())
+						                    ? deterministicRandom()->randomInt64(desc.minRestorableVersion.get(),
+						                                                         desc.maxRestorableVersion.get())
+						                    : desc.maxRestorableVersion.get();
 					}
 				}
 


### PR DESCRIPTION
cherry-pick of #12038

This PR focuses the production issue of missing backup log ranges and eventually expire workflow blocked and restorable state not set correctly.

In the case of missing mutation logs, each snapshot restorability has to be recalculated based on whether the snapshot can be restored from the existing logs
In the case of missing mutation logs, cluster level minRestorableVersion and maxRestorableVersion has to be recalculated from the existing logs
Apart from this added two new unit tests to test the missing log case.


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
