### PR TITLE
Fix duplicate names VersionedMutation

### DIFF
--- a/fdbserver/RestoreApplier.actor.cpp
+++ b/fdbserver/RestoreApplier.actor.cpp
@@ -166,7 +166,7 @@ ACTOR static Future<Void> handleSendMutationVectorRequest(RestoreSendVersionedMu
 		isDuplicated = false;
 
 		for (int mIndex = 0; mIndex < req.versionedMutations.size(); mIndex++) {
-			const VersionedMutation& versionedMutation = req.versionedMutations[mIndex];
+			const VersionedMutationSerialized& versionedMutation = req.versionedMutations[mIndex];
 			TraceEvent(SevFRDebugInfo, "FastRestoreApplierPhaseReceiveMutations", self->id())
 			    .detail("RestoreAsset", req.asset.toString())
 			    .detail("Version", versionedMutation.version.toString())

--- a/fdbserver/RestoreLoader.actor.cpp
+++ b/fdbserver/RestoreLoader.actor.cpp
@@ -943,7 +943,8 @@ ACTOR Future<Void> sendMutationsToApplier(
 					// CAREFUL: The split mutations' lifetime is shorter than the for-loop
 					// Must use deep copy for split mutations
 					applierVersionedMutationsBuffer[applierID].push_back_deep(
-					    applierVersionedMutationsBuffer[applierID].arena(), VersionedMutation(mutation, commitVersion));
+					    applierVersionedMutationsBuffer[applierID].arena(),
+					    VersionedMutationSerialized(mutation, commitVersion));
 					msgSize += mutation.expectedSize();
 
 					kvCount++;
@@ -960,7 +961,7 @@ ACTOR Future<Void> sendMutationsToApplier(
 				    .detail("SubVersion", commitVersion.toString());
 				// kvm data is saved in pkvOps in batchData, so shallow copy is ok here.
 				applierVersionedMutationsBuffer[applierID].push_back(applierVersionedMutationsBuffer[applierID].arena(),
-				                                                     VersionedMutation(kvm, commitVersion));
+				                                                     VersionedMutationSerialized(kvm, commitVersion));
 				msgSize += kvm.expectedSize();
 			}
 

--- a/fdbserver/include/fdbserver/RestoreUtil.h
+++ b/fdbserver/include/fdbserver/RestoreUtil.h
@@ -43,14 +43,14 @@
 #define SevFRDebugInfo SevVerbose
 // #define SevFRDebugInfo SevInfo
 
-struct VersionedMutation {
+struct VersionedMutationSerialized {
 	MutationRef mutation;
 	LogMessageVersion version;
 
-	VersionedMutation() = default;
-	explicit VersionedMutation(MutationRef mutation, LogMessageVersion version)
+	VersionedMutationSerialized() = default;
+	explicit VersionedMutationSerialized(MutationRef mutation, LogMessageVersion version)
 	  : mutation(mutation), version(version) {}
-	explicit VersionedMutation(Arena& arena, const VersionedMutation& vm)
+	explicit VersionedMutationSerialized(Arena& arena, const VersionedMutationSerialized& vm)
 	  : mutation(arena, vm.mutation), version(vm.version) {}
 
 	template <class Ar>
@@ -77,7 +77,7 @@ struct SampledMutation {
 
 using MutationsVec = Standalone<VectorRef<MutationRef>>;
 using LogMessageVersionVec = Standalone<VectorRef<LogMessageVersion>>;
-using VersionedMutationsVec = Standalone<VectorRef<VersionedMutation>>;
+using VersionedMutationsVec = Standalone<VectorRef<VersionedMutationSerialized>>;
 using SampledMutationsVec = Standalone<VectorRef<SampledMutation>>;
 
 enum class RestoreRole { Invalid = 0, Controller = 1, Loader, Applier };


### PR DESCRIPTION
VersionedMutation was defined in `PartitionedLogIterator.h` and `RestoreUtil.h`. The compiler mixed these two definitions up in some cases. Because the definitions of the structures are different, this resulted in a seg fault.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
