### PR TITLE
Added direct download path to CMake

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ $SRCDIR/packaging/osx/buildpkg.sh . $SRCDIR
 Under Windows, only Visual Studio with ClangCl is supported
 
 1. Install Visual Studio 2019 (IDE or Build Tools), and enable llvm support
-1. Install  [CMake 3.24.2](https://cmake.org/) or higher
+1. Install  [CMake 3.24.2](https://cmake.org/download/) or higher
 1. Download [Boost 1.86.0](https://archives.boost.io/release/1.86.0/source/boost_1_86_0.tar.bz2)
 1. Unpack boost to C:\boost, or use `-DBOOST_ROOT=<PATH_TO_BOOST>` with `cmake` if unpacked elsewhere
 1. Install [Python](https://www.python.org/downloads/) if is not already installed by Visual Studio


### PR DESCRIPTION
The path was leading to the generic site, so added a more direct link to the download resources

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
