### PR TITLE
Partitioned logs backup test fix

### DIFF
--- a/fdbserver/workloads/BackupCorrectnessPartitioned.actor.cpp
+++ b/fdbserver/workloads/BackupCorrectnessPartitioned.actor.cpp
@@ -581,8 +581,10 @@ struct BackupAndRestorePartitionedCorrectnessWorkload : TestWorkload {
 					} else if (deterministicRandom()->random01() < 0.1) {
 						targetVersion = desc.maxRestorableVersion.get();
 					} else if (deterministicRandom()->random01() < 0.5) {
-						targetVersion = deterministicRandom()->randomInt64(desc.minRestorableVersion.get(),
-						                                                   desc.contiguousLogEnd.get());
+						targetVersion = (desc.minRestorableVersion.get() != desc.maxRestorableVersion.get())
+						                    ? deterministicRandom()->randomInt64(desc.minRestorableVersion.get(),
+						                                                         desc.maxRestorableVersion.get())
+						                    : desc.maxRestorableVersion.get();
 					}
 				}
 				wait(runRYWTransaction(cx, [=](Reference<ReadYourWritesTransaction> tr) -> Future<Void> {


### PR DESCRIPTION
Partitioned logs backup test fix.
This test does not exist in 7.3 release, so missed in my testing.

This particular test fails in the scenario like:
```
URL: file://simfdb/backups/backup-1970-01-01-00-01-31.083618
Restorable: true
Partitioned logs: true
Snapshot:  startVersion=188535558 (maxLogEnd -0.00 days)  endVersion=188535558 (maxLogEnd -0.00 days)  totalBytes=120013  restorable=true  expiredPct=0.00
Snapshot:  startVersion=593303745 (maxLogEnd +-0.00 days)  endVersion=593303745 (maxLogEnd +-0.00 days)  totalBytes=120013  restorable=true  expiredPct=0.00
SnapshotBytes: 240026
MinLogBeginVersion:      82953666 (maxLogEnd -0.01 days)
ContiguousLogEndVersion: 585088375 (maxLogEnd -0.00 days)
MaxLogEndVersion:        585088375 (maxLogEnd -0.00 days)
MinRestorableVersion:    593303745 (maxLogEnd +-0.00 days)
MaxRestorableVersion:    593303745 (maxLogEnd +-0.00 days)

```

Testing: Running 100k correctness run.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
