### PR TITLE
Fix for continuousLogEnd not updating correctly.

### DIFF
--- a/fdbclient/BackupContainerFileSystem.actor.cpp
+++ b/fdbclient/BackupContainerFileSystem.actor.cpp
@@ -2467,6 +2467,7 @@ ACTOR Future<Void> testBackupContinuousLogEndVer(std::string url, Optional<std::
 
 	// writing random number of more continuous log files
 	state int newNumLogFiles = deterministicRandom()->randomInt(2, 8);
+	numLogFiles += newNumLogFiles;
 	writes.clear();
 	while (newNumLogFiles) {
 		Reference<IBackupFile> log = wait(c->writeLogFile(v, v + logSize, blockSize));
@@ -2478,9 +2479,9 @@ ACTOR Future<Void> testBackupContinuousLogEndVer(std::string url, Optional<std::
 
 	state BackupFileList fileList1 = wait(c->dumpFileList());
 	printFileList(fileList1);
-	ASSERT_EQ(fileList.ranges.size(), numRangeFiles);
-	ASSERT_EQ(fileList.logs.size(), numLogFiles + newNumLogFiles);
-	ASSERT_EQ(fileList.snapshots.size(), 1);
+	ASSERT_EQ(fileList1.ranges.size(), numRangeFiles);
+	ASSERT_EQ(fileList1.logs.size(), numLogFiles);
+	ASSERT_EQ(fileList1.snapshots.size(), 1);
 
 	state BackupDescription desc1 = wait(c->describeBackup());
 	printf("\n%s\n", desc1.toString().c_str());
@@ -2488,7 +2489,7 @@ ACTOR Future<Void> testBackupContinuousLogEndVer(std::string url, Optional<std::
 	ASSERT_EQ(desc1.maxLogEnd, v);
 	ASSERT_EQ(desc1.minRestorableVersion, snapshotEndVersion);
 	ASSERT_EQ(desc1.maxRestorableVersion, v - 1);
-	ASSERT_EQ(desc.snapshots[0].restorable, true);
+	ASSERT_EQ(desc1.snapshots[0].restorable, true);
 	ASSERT_EQ(desc1.contiguousLogEnd, v);
 
 	return Void();


### PR DESCRIPTION
Fix for continuousLogEnd not updating correctly.

Testing:
- Manually running fdbbackup in iCloud/p01_DC2 cluster
- Simulation passed:
- 20250402-070850-neethu2-513a0e2db70671b6           compressed=True data_size=51318294 duration=5423037 ended=100000 fail_fast=10 max_runs=100000 pass=100000 
- Simulation also passed with the new unit test:
- 20250403-013206-neethubackup-100k-31486078ff7f3894 compressed=True data_size=51333966 duration=5258662 ended=100000 fail_fast=10 max_runs=100000 pass=100000

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
