### PR TITLE
Fix for continuousLogEnd not updating correctly.

### DIFF
--- a/fdbclient/BackupContainerFileSystem.actor.cpp
+++ b/fdbclient/BackupContainerFileSystem.actor.cpp
@@ -397,10 +397,6 @@ public:
 	                                     Version* end,
 	                                     Version targetVersion) {
 		auto i = logs.begin();
-		if (outLogs != nullptr) {
-			outLogs->push_back(*i);
-			++i; // skip the first file
-		}
 
 		// Add logs to restorable logs set until continuity is broken OR we reach targetVersion
 		while (i != logs.end()) {
@@ -501,7 +497,8 @@ public:
 
 		TraceEvent("BackupContainerDescribe1")
 		    .detail("URL", bc->getURL())
-		    .detail("LogStartVersionOverride", logStartVersionOverride);
+		    .detail("LogStartVersionOverride", logStartVersionOverride)
+		    .detail("DeepScan", deepScan);
 
 		bool e = wait(bc->exists());
 		if (!e) {
@@ -640,7 +637,7 @@ public:
 					// for other partitions. Set to its beginVersion to be safe.
 					desc.contiguousLogEnd = logs.begin()->beginVersion;
 				} else {
-					desc.contiguousLogEnd = logs.begin()->endVersion;
+					desc.contiguousLogEnd = logs.begin()->beginVersion;
 				}
 			}
 
@@ -1030,7 +1027,7 @@ public:
 	static Optional<RestorableFileSet> getRestoreSetFromLogs(const std::vector<LogFile>& logs,
 	                                                         Version targetVersion,
 	                                                         RestorableFileSet restorable) {
-		Version end = logs.begin()->endVersion;
+		Version end = logs.begin()->beginVersion;
 		computeRestoreEndVersion(logs, &restorable.logs, &end, targetVersion);
 		if (end >= targetVersion) {
 			restorable.continuousBeginVersion = logs.begin()->beginVersion;
@@ -2259,7 +2256,7 @@ void printFileList(BackupFileList& backupFileList) {
 
 	printf("\nSnapshotFiles count:%lu", backupFileList.snapshots.size());
 	for (auto s : backupFileList.snapshots)
-		printf("\n%lld, %lld, %s, %lld", s.beginVersion, s.endVersion, s.fileName.c_str(), s.totalSize);
+		printf("\n%lld, %lld, %s, %lld\n", s.beginVersion, s.endVersion, s.fileName.c_str(), s.totalSize);
 }
 
 // Intentionally missing some log range files and checking if the snapshot can be restored.
@@ -2398,6 +2395,112 @@ ACTOR Future<Void> testBackupContainerWithMissingLogRanges(std::string url, Opti
 TEST_CASE("/backup/containers/localdir/missingLogRangesRestorability") {
 	wait(testBackupContainerWithMissingLogRanges(
 	    format("file://%s/fdb_backups/%llx", params.getDataDir().c_str(), timer_int()), {}));
+	return Void();
+}
+
+ACTOR Future<Void> testBackupContinuousLogEndVer(std::string url, Optional<std::string> proxy) {
+	state FlowLock lock(100e6);
+	printf("BackupContainerTest URL %s\n", url.c_str());
+	state Reference<IBackupContainer> c = IBackupContainer::openContainer(url, proxy, {});
+
+	// Make sure container doesn't exist, then create it.
+	try {
+		wait(c->deleteContainer());
+	} catch (Error& e) {
+		if (e.code() != error_code_backup_invalid_url && e.code() != error_code_backup_does_not_exist)
+			throw;
+	}
+
+	wait(c->create());
+
+	state int blockSize = 1024;
+	state std::vector<std::string> rangeFileNames;
+	state Key begin = randomKeyBetween(normalKeys);
+	state Key end = randomKeyBetween(KeyRangeRef(begin, normalKeys.end));
+	state std::pair<Key, Key> beginEndKeys = std::make_pair(begin, end);
+	state std::vector<std::pair<Key, Key>> snapshotBeginEndKeys;
+
+	// writing random number of range files with rangeSize 100
+	state std::vector<Future<Void>> writes;
+	state Version snapshotBeginVersion = 10;
+	state Version snapshotEndVersion = deterministicRandom()->randomInt(500, 1000);
+	state Version rangeSize = 100;
+	state Version v = snapshotBeginVersion;
+	state int numRangeFiles = 0;
+	while (v <= snapshotEndVersion) {
+		state Reference<IBackupFile> range = wait(c->writeRangeFile(v, 0, v, blockSize));
+		writes.push_back(writeAndVerifyFile(c, range, 100, &lock));
+		rangeFileNames.push_back(range->getFileName());
+		snapshotBeginEndKeys.push_back(beginEndKeys);
+		v += rangeSize;
+		++numRangeFiles;
+	}
+	snapshotEndVersion = v - rangeSize;
+
+	// writing random number of log files with logSize 70, covering the entire snapshot
+	state Version logSize = 70;
+	v = snapshotBeginVersion;
+	state int numLogFiles = 0;
+	while (v <= snapshotEndVersion) {
+		Reference<IBackupFile> log = wait(c->writeLogFile(v, v + logSize, blockSize));
+		writes.push_back(writeAndVerifyFile(c, log, 100, &lock));
+		++numLogFiles;
+		v += logSize;
+	}
+
+	// writing snapshot file
+	writes.push_back(c->writeKeyspaceSnapshotFile(
+	    rangeFileNames, snapshotBeginEndKeys, deterministicRandom()->randomInt(0, 2e6), IncludeKeyRangeMap(BUGGIFY)));
+	wait(waitForAll(writes));
+
+	state BackupFileList fileList = wait(c->dumpFileList());
+	printFileList(fileList);
+	ASSERT_EQ(fileList.ranges.size(), numRangeFiles);
+	ASSERT_EQ(fileList.logs.size(), numLogFiles);
+	ASSERT_EQ(fileList.snapshots.size(), 1);
+
+	state BackupDescription desc = wait(c->describeBackup());
+	printf("\n%s\n", desc.toString().c_str());
+	ASSERT_EQ(desc.minLogBegin, snapshotBeginVersion);
+	ASSERT_EQ(desc.maxLogEnd, v);
+	ASSERT_EQ(desc.minRestorableVersion, snapshotEndVersion);
+	ASSERT_EQ(desc.maxRestorableVersion, v - 1);
+	ASSERT_EQ(desc.snapshots[0].restorable, true);
+	ASSERT_EQ(desc.contiguousLogEnd, v);
+
+	// writing random number of more continuous log files
+	state int newNumLogFiles = deterministicRandom()->randomInt(2, 8);
+	numLogFiles += newNumLogFiles;
+	writes.clear();
+	while (newNumLogFiles) {
+		Reference<IBackupFile> log = wait(c->writeLogFile(v, v + logSize, blockSize));
+		writes.push_back(writeAndVerifyFile(c, log, 100, &lock));
+		--newNumLogFiles;
+		v += logSize;
+	}
+	wait(waitForAll(writes));
+
+	state BackupFileList fileList1 = wait(c->dumpFileList());
+	printFileList(fileList1);
+	ASSERT_EQ(fileList1.ranges.size(), numRangeFiles);
+	ASSERT_EQ(fileList1.logs.size(), numLogFiles);
+	ASSERT_EQ(fileList1.snapshots.size(), 1);
+
+	state BackupDescription desc1 = wait(c->describeBackup());
+	printf("\n%s\n", desc1.toString().c_str());
+	ASSERT_EQ(desc1.minLogBegin, snapshotBeginVersion);
+	ASSERT_EQ(desc1.maxLogEnd, v);
+	ASSERT_EQ(desc1.minRestorableVersion, snapshotEndVersion);
+	ASSERT_EQ(desc1.maxRestorableVersion, v - 1);
+	ASSERT_EQ(desc1.snapshots[0].restorable, true);
+	ASSERT_EQ(desc1.contiguousLogEnd, v);
+
+	return Void();
+}
+
+TEST_CASE("/backup/containers/localdir/continuousLogEndVersion") {
+	wait(testBackupContinuousLogEndVer(format("file://%s/fdb_backups/%llx", params.getDataDir().c_str(), timer_int()),
+	                                   {}));
 	return Void();
 }
 


### PR DESCRIPTION
cherry-pick #12069
Fix for continuousLogEnd not updating correctly.

Simulation testing:
20250403-072448-neethubackupfix-main-b88eda4781cc32e7  duration=6198884 ended=100000 fail_fast=10 max_runs=100000 pass=100000

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
