### PR TITLE
Clear vv on client when recovery detected via dbinfo update.

### DIFF
--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -298,6 +298,10 @@ void DatabaseContext::getLatestCommitVersions(const Reference<LocationInfo>& loc
 		    "TransactionDebug", info->readOptions.get().debugID.get().first(), "NativeAPI.getLatestCommitVersions");
 	}
 
+	if (info->readVersion() <= ssVersionVectorCache.lastCleared) {
+		return;
+	}
+
 	if (!info->readVersionObtainedFromGrvProxy) {
 		return;
 	}
@@ -2758,7 +2762,7 @@ void DatabaseContext::updateProxies() {
 	proxiesLastChange = clientInfo->get().id;
 	commitProxies.clear();
 	grvProxies.clear();
-	ssVersionVectorCache.clear();
+	ssVersionVectorCache.clear(true);
 	bool commitProxyProvisional = false, grvProxyProvisional = false;
 	if (clientInfo->get().commitProxies.size()) {
 		commitProxies = makeReference<CommitProxyInfo>(clientInfo->get().commitProxies);

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -298,10 +298,6 @@ void DatabaseContext::getLatestCommitVersions(const Reference<LocationInfo>& loc
 		    "TransactionDebug", info->readOptions.get().debugID.get().first(), "NativeAPI.getLatestCommitVersions");
 	}
 
-	if (info->readVersion() <= ssVersionVectorCache.lastCleared) {
-		return;
-	}
-
 	if (!info->readVersionObtainedFromGrvProxy) {
 		return;
 	}
@@ -1023,6 +1019,7 @@ ACTOR static Future<Void> monitorClientDBInfoChange(DatabaseContext* cx,
 					}
 					curCommitProxies = clientDBInfo->get().commitProxies;
 					curGrvProxies = clientDBInfo->get().grvProxies;
+					cx->ssVersionVectorCache.clear();
 					proxiesChangeTrigger->trigger();
 				}
 			}
@@ -2762,7 +2759,6 @@ void DatabaseContext::updateProxies() {
 	proxiesLastChange = clientInfo->get().id;
 	commitProxies.clear();
 	grvProxies.clear();
-	ssVersionVectorCache.clear(true);
 	bool commitProxyProvisional = false, grvProxyProvisional = false;
 	if (clientInfo->get().commitProxies.size()) {
 		commitProxies = makeReference<CommitProxyInfo>(clientInfo->get().commitProxies);

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -1019,6 +1019,8 @@ ACTOR static Future<Void> monitorClientDBInfoChange(DatabaseContext* cx,
 					}
 					curCommitProxies = clientDBInfo->get().commitProxies;
 					curGrvProxies = clientDBInfo->get().grvProxies;
+					// Commits in the previous epoch may have been recovered but not included in the version vector.
+					// Clear the version vector to ensure the latest commit versions are received.
 					cx->ssVersionVectorCache.clear();
 					proxiesChangeTrigger->trigger();
 				}

--- a/fdbclient/include/fdbclient/VersionVector.h
+++ b/fdbclient/include/fdbclient/VersionVector.h
@@ -41,9 +41,10 @@ struct VersionVector {
 	Version maxVersion; // Specifies the max version in this version vector. (Note:
 	                    // there may or may not be a corresponding entry for this
 	                    // version in the "versions" map.)
-
-	VersionVector() : maxVersion(invalidVersion), cachedEncodedSize(InvalidEncodedSize) {}
-	VersionVector(Version version) : maxVersion(version), cachedEncodedSize(InvalidEncodedSize) {}
+	Version lastCleared;
+	VersionVector() : maxVersion(invalidVersion), lastCleared(invalidVersion), cachedEncodedSize(InvalidEncodedSize) {}
+	VersionVector(Version version)
+	  : maxVersion(version), lastCleared(invalidVersion), cachedEncodedSize(InvalidEncodedSize) {}
 
 private:
 	// Only invoked by getDelta() and applyDelta(), where tag has been validated
@@ -106,8 +107,12 @@ public:
 		return iter->second;
 	}
 
-	void clear() {
+	void clear(bool setLastClear = false) {
 		versions.clear();
+		if (setLastClear) {
+			lastCleared = maxVersion;
+		}
+
 		maxVersion = invalidVersion;
 		invalidateCachedEncodedSize();
 	}

--- a/fdbclient/include/fdbclient/VersionVector.h
+++ b/fdbclient/include/fdbclient/VersionVector.h
@@ -41,10 +41,9 @@ struct VersionVector {
 	Version maxVersion; // Specifies the max version in this version vector. (Note:
 	                    // there may or may not be a corresponding entry for this
 	                    // version in the "versions" map.)
-	Version lastCleared;
-	VersionVector() : maxVersion(invalidVersion), lastCleared(invalidVersion), cachedEncodedSize(InvalidEncodedSize) {}
-	VersionVector(Version version)
-	  : maxVersion(version), lastCleared(invalidVersion), cachedEncodedSize(InvalidEncodedSize) {}
+
+	VersionVector() : maxVersion(invalidVersion), cachedEncodedSize(InvalidEncodedSize) {}
+	VersionVector(Version version) : maxVersion(version), cachedEncodedSize(InvalidEncodedSize) {}
 
 private:
 	// Only invoked by getDelta() and applyDelta(), where tag has been validated
@@ -107,12 +106,8 @@ public:
 		return iter->second;
 	}
 
-	void clear(bool setLastClear = false) {
+	void clear() {
 		versions.clear();
-		if (setLastClear) {
-			lastCleared = maxVersion;
-		}
-
 		maxVersion = invalidVersion;
 		invalidateCachedEncodedSize();
 	}


### PR DESCRIPTION
Clear the client's version vector when recovery is detected when the set of proxies in the dbinfo changed. Clearing the version vector when the proxy changes indicates recovery occurred and all proxies will have a new epoch's version.

It is necessary to clear the version vector on recovery, otherwise commits right before recovery may not be returned back to the client to populate the version vector (see [PR](https://github.com/apple/foundationdb/pull/5942)).

Prior, the version vector was cleared when the cluster id was detected to have changed. At that point, transactions may have already started in the new epoch, and a race condition can break the invariant `info->readVersion() > ssVersionVectorCache.getMaxVersion())` (scenario below).

----

Versions V1<V2<V3

1. There are two GRVProxies A and B.
2. The client sends GRV request [1] to B with maxVersion V1
3. The client sends GRV request [2] to A with maxVersion V1
4. GRVProxy A processes [2], with maxVersion V1. A's maxVersion is V3. V1<V3 so A returns V3.
5. Client maxVersion becomes V3. Transaction T sets grv to V3.
6. The client sends GRV request [3] to B with maxVersion V3.
7. The client learns the cluster id changed in `updateProxies`. 
8. The client sets maxVersion to -1.
9. GRVProxy B processes request [1] with maxVersion V1. B's maxVersion is V2. V1<V2 so B returns maxVersion V2.
10. GRVProxy B gets reply from master, and increases its max version to V3.
11. GRVProxy B processes request [3] with maxVersion V3. B's maxVersion is V3. They are equal. B returns maxVersion -1. 
12. Client gets reply to [1]. Client changes maxVersion from -1 to V2.
13. Client gets reply to [3]. Reply is -1, so client maxVersion stays V2. 
14. The client asserts on T: V3 > V2. `info->readVersion() > ssVersionVectorCache.getMaxVersion())`

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
