### PR TITLE
Apply latest clang-format in main branch

### DIFF
--- a/bindings/c/foundationdb/fdb_c.h
+++ b/bindings/c/foundationdb/fdb_c.h
@@ -58,8 +58,7 @@
  * ensure a compile error in such cases, and attempt to make the compile error
  * slightly informative.
  */
-#define This_FoundationDB_API_function_is_removed_at_this_FDB_API_VERSION()                                            \
-	{ == == = }
+#define This_FoundationDB_API_function_is_removed_at_this_FDB_API_VERSION() { == == = }
 #define FDB_REMOVED_FUNCTION This_FoundationDB_API_function_is_removed_at_this_FDB_API_VERSION(0)
 
 #include <stdint.h>

--- a/bindings/c/test/apitester/TesterTransactionExecutor.cpp
+++ b/bindings/c/test/apitester/TesterTransactionExecutor.cpp
@@ -134,8 +134,7 @@ public:
 		lock.unlock();
 		fdb::Future f = fdbTx.commit();
 		auto thisRef = shared_from_this();
-		doContinueAfter(
-		    f, [thisRef]() { thisRef->done(); }, true);
+		doContinueAfter(f, [thisRef]() { thisRef->done(); }, true);
 	}
 
 	// Complete the transaction without a commit (for read transactions)

--- a/bindings/c/test/mako/admin_server.hpp
+++ b/bindings/c/test/mako/admin_server.hpp
@@ -49,7 +49,7 @@ struct DefaultResponse {
 
 	template <class Ar>
 	void serialize(Ar& ar, unsigned int) {
-		ar& error_message;
+		ar & error_message;
 	}
 };
 
@@ -61,8 +61,8 @@ struct TenantIdsResponse {
 
 	template <class Ar>
 	void serialize(Ar& ar, unsigned int) {
-		ar& error_message;
-		ar& ids;
+		ar & error_message;
+		ar & ids;
 	}
 };
 
@@ -74,9 +74,9 @@ struct BatchCreateTenantRequest {
 
 	template <class Ar>
 	void serialize(Ar& ar, unsigned int) {
-		ar& cluster_file;
-		ar& id_begin;
-		ar& id_end;
+		ar & cluster_file;
+		ar & id_begin;
+		ar & id_end;
 	}
 };
 
@@ -88,9 +88,9 @@ struct BatchDeleteTenantRequest {
 
 	template <class Ar>
 	void serialize(Ar& ar, unsigned int) {
-		ar& cluster_file;
-		ar& id_begin;
-		ar& id_end;
+		ar & cluster_file;
+		ar & id_begin;
+		ar & id_end;
 	}
 };
 
@@ -102,9 +102,9 @@ struct FetchTenantIdsRequest {
 
 	template <class Ar>
 	void serialize(Ar& ar, unsigned int) {
-		ar& cluster_file;
-		ar& id_begin;
-		ar& id_end;
+		ar & cluster_file;
+		ar & id_begin;
+		ar & id_end;
 	}
 };
 

--- a/bindings/c/test/test.h
+++ b/bindings/c/test/test.h
@@ -78,7 +78,9 @@ struct RunResult {
 	fdb_error_t e;
 };
 #define RES(x, y)                                                                                                      \
-	(struct RunResult) { x, y }
+	(struct RunResult) {                                                                                               \
+		x, y                                                                                                           \
+	}
 
 struct Kpi {
 	const char* name;

--- a/bindings/c/test/unit/trace_partial_file_suffix_test.cpp
+++ b/bindings/c/test/unit/trace_partial_file_suffix_test.cpp
@@ -61,7 +61,9 @@ int main(int argc, char** argv) {
 	    "trace.127.0.0.1." + file_identifier + ".simulated.xml" + trace_partial_file_suffix;
 
 	// Simulate this process crashing previously by creating a ".tmp" file
-	{ std::ofstream file{ simulated_stray_partial_file }; }
+	{
+		std::ofstream file{ simulated_stray_partial_file };
+	}
 
 	set_net_opt(FDBNetworkOption::FDB_NET_OPTION_TRACE_ENABLE, "");
 	set_net_opt(FDBNetworkOption::FDB_NET_OPTION_TRACE_FILE_IDENTIFIER, file_identifier);

--- a/bindings/flow/IDirectory.h
+++ b/bindings/flow/IDirectory.h
@@ -65,7 +65,7 @@ public:
 	virtual const Standalone<StringRef> getLayer() const = 0;
 	virtual const Path getPath() const = 0;
 
-	virtual ~IDirectory(){};
+	virtual ~IDirectory() {};
 };
 } // namespace FDB
 

--- a/bindings/flow/fdb_flow.h
+++ b/bindings/flow/fdb_flow.h
@@ -57,7 +57,7 @@ private:
 
 class ReadTransaction : public ReferenceCounted<ReadTransaction> {
 public:
-	virtual ~ReadTransaction(){};
+	virtual ~ReadTransaction() {};
 	virtual void setReadVersion(Version v) = 0;
 	virtual Future<Version> getReadVersion() = 0;
 
@@ -137,7 +137,7 @@ public:
 
 class Database : public ReferenceCounted<Database> {
 public:
-	virtual ~Database(){};
+	virtual ~Database() {};
 	virtual Reference<Transaction> createTransaction() = 0;
 	virtual void setDatabaseOption(FDBDatabaseOption option, Optional<StringRef> value = Optional<StringRef>()) = 0;
 	virtual Future<int64_t> rebootWorker(const StringRef& address, bool check = false, int duration = 0) = 0;

--- a/contrib/SimpleOpt/include/SimpleOpt/SimpleOpt.h
+++ b/contrib/SimpleOpt/include/SimpleOpt/SimpleOpt.h
@@ -316,8 +316,7 @@ typedef enum _ESOArgType {
 } ESOArgType;
 
 //! this option definition must be the last entry in the table
-#define SO_END_OF_OPTIONS                                                                                              \
-	{ -1, nullptr, SO_NONE }
+#define SO_END_OF_OPTIONS { -1, nullptr, SO_NONE }
 
 #ifdef _DEBUG
 #ifdef _MSC_VER

--- a/contrib/md5/md5.c
+++ b/contrib/md5/md5.c
@@ -59,7 +59,7 @@
  */
 #define STEP(f, a, b, c, d, x, t, s)                                                                                   \
 	(a) += f((b), (c), (d)) + (x) + (t);                                                                               \
-	(a) = (((a) << (s)) | (((a)&0xffffffff) >> (32 - (s))));                                                           \
+	(a) = (((a) << (s)) | (((a) & 0xffffffff) >> (32 - (s))));                                                         \
 	(a) += (b);
 
 /*
@@ -71,12 +71,12 @@
  * doesn't work.
  */
 #if defined(__i386__) || defined(__x86_64__) || defined(__vax__)
-#define SET(n) (*(MD5_u32plus*)&ptr[(n)*4])
+#define SET(n) (*(MD5_u32plus*)&ptr[(n) * 4])
 #define GET(n) SET(n)
 #else
 #define SET(n)                                                                                                         \
-	(ctx->block[(n)] = (MD5_u32plus)ptr[(n)*4] | ((MD5_u32plus)ptr[(n)*4 + 1] << 8) |                                  \
-	                   ((MD5_u32plus)ptr[(n)*4 + 2] << 16) | ((MD5_u32plus)ptr[(n)*4 + 3] << 24))
+	(ctx->block[(n)] = (MD5_u32plus)ptr[(n) * 4] | ((MD5_u32plus)ptr[(n) * 4 + 1] << 8) |                              \
+	                   ((MD5_u32plus)ptr[(n) * 4 + 2] << 16) | ((MD5_u32plus)ptr[(n) * 4 + 3] << 24))
 #define GET(n) (ctx->block[(n)])
 #endif
 

--- a/contrib/rapidjson/rapidjson/document.h
+++ b/contrib/rapidjson/rapidjson/document.h
@@ -938,7 +938,7 @@ public:
 	 */
 	template <typename T>
 	RAPIDJSON_DISABLEIF_RETURN((internal::OrExpr<internal::IsPointer<T>, internal::IsGenericValue<T>>), (bool))
-	operator==(const T& rhs) const {
+	operator==(const T & rhs) const {
 		return *this == GenericValue(rhs);
 	}
 
@@ -958,7 +958,7 @@ public:
 	 */
 	template <typename T>
 	RAPIDJSON_DISABLEIF_RETURN((internal::IsGenericValue<T>), (bool))
-	operator!=(const T& rhs) const {
+	operator!=(const T & rhs) const {
 		return !(*this == rhs);
 	}
 
@@ -966,8 +966,8 @@ public:
 	/*! \return (rhs == lhs)
 	 */
 	template <typename T>
-	friend RAPIDJSON_DISABLEIF_RETURN((internal::IsGenericValue<T>), (bool)) operator==(const T& lhs,
-	                                                                                    const GenericValue& rhs) {
+	friend RAPIDJSON_DISABLEIF_RETURN((internal::IsGenericValue<T>),
+	                                  (bool)) operator==(const T & lhs, const GenericValue & rhs) {
 		return rhs == lhs;
 	}
 
@@ -975,8 +975,8 @@ public:
 	/*! \return !(rhs == lhs)
 	 */
 	template <typename T>
-	friend RAPIDJSON_DISABLEIF_RETURN((internal::IsGenericValue<T>), (bool)) operator!=(const T& lhs,
-	                                                                                    const GenericValue& rhs) {
+	friend RAPIDJSON_DISABLEIF_RETURN((internal::IsGenericValue<T>),
+	                                  (bool)) operator!=(const T & lhs, const GenericValue & rhs) {
 		return !(rhs == lhs);
 	}
 	//@}
@@ -1102,14 +1102,14 @@ public:
 	template <typename T>
 	RAPIDJSON_DISABLEIF_RETURN((internal::NotExpr<internal::IsSame<typename internal::RemoveConst<T>::Type, Ch>>),
 	                           (GenericValue&))
-	operator[](T* name) {
+	operator[](T * name) {
 		GenericValue n(StringRef(name));
 		return (*this)[n];
 	}
 	template <typename T>
 	RAPIDJSON_DISABLEIF_RETURN((internal::NotExpr<internal::IsSame<typename internal::RemoveConst<T>::Type, Ch>>),
 	                           (const GenericValue&))
-	operator[](T* name) const {
+	operator[](T * name) const {
 		return const_cast<GenericValue&>(*this)[name];
 	}
 
@@ -2404,7 +2404,7 @@ public:
 	template <unsigned parseFlags>
 	GenericDocument& ParseInsitu(Ch* str) {
 		GenericInsituStringStream<Encoding> s(str);
-		return ParseStream<parseFlags | kParseInsituFlag>(s);
+		return ParseStream < parseFlags | kParseInsituFlag > (s);
 	}
 
 	//! Parse JSON text from a mutable string (with \ref kParseDefaultFlags)

--- a/contrib/rapidjson/rapidjson/rapidjson.h
+++ b/contrib/rapidjson/rapidjson/rapidjson.h
@@ -492,7 +492,7 @@ RAPIDJSON_NAMESPACE_END
 	while ((void)0, 0)
 
 // adopted from Boost
-#define RAPIDJSON_VERSION_CODE(x, y, z) (((x)*100000) + ((y)*100) + (z))
+#define RAPIDJSON_VERSION_CODE(x, y, z) (((x) * 100000) + ((y) * 100) + (z))
 
 ///////////////////////////////////////////////////////////////////////////////
 // RAPIDJSON_DIAG_PUSH/POP, RAPIDJSON_DIAG_OFF

--- a/contrib/rapidjson/rapidjson/reader.h
+++ b/contrib/rapidjson/rapidjson/reader.h
@@ -369,8 +369,7 @@ inline const char* SkipWhitespace_SIMD(const char* p) {
 			return p;
 
 // The rest of string
-#define C16(c)                                                                                                         \
-	{ c, c, c, c, c, c, c, c, c, c, c, c, c, c, c, c }
+#define C16(c) { c, c, c, c, c, c, c, c, c, c, c, c, c, c, c, c }
 	static const char whitespaces[4][16] = { C16(' '), C16('\n'), C16('\r'), C16('\t') };
 #undef C16
 
@@ -406,8 +405,7 @@ inline const char* SkipWhitespace_SIMD(const char* p, const char* end) {
 		return p;
 
 // The rest of string
-#define C16(c)                                                                                                         \
-	{ c, c, c, c, c, c, c, c, c, c, c, c, c, c, c, c }
+#define C16(c) { c, c, c, c, c, c, c, c, c, c, c, c, c, c, c, c }
 	static const char whitespaces[4][16] = { C16(' '), C16('\n'), C16('\r'), C16('\t') };
 #undef C16
 

--- a/contrib/rapidjson/rapidjson/writer.h
+++ b/contrib/rapidjson/rapidjson/writer.h
@@ -417,7 +417,7 @@ protected:
 					PutUnsafe(*os_, hexDigits[(codepoint >> 12) & 15]);
 					PutUnsafe(*os_, hexDigits[(codepoint >> 8) & 15]);
 					PutUnsafe(*os_, hexDigits[(codepoint >> 4) & 15]);
-					PutUnsafe(*os_, hexDigits[(codepoint)&15]);
+					PutUnsafe(*os_, hexDigits[(codepoint) & 15]);
 				} else {
 					RAPIDJSON_ASSERT(codepoint >= 0x010000 && codepoint <= 0x10FFFF);
 					// Surrogate pair
@@ -427,13 +427,13 @@ protected:
 					PutUnsafe(*os_, hexDigits[(lead >> 12) & 15]);
 					PutUnsafe(*os_, hexDigits[(lead >> 8) & 15]);
 					PutUnsafe(*os_, hexDigits[(lead >> 4) & 15]);
-					PutUnsafe(*os_, hexDigits[(lead)&15]);
+					PutUnsafe(*os_, hexDigits[(lead) & 15]);
 					PutUnsafe(*os_, '\\');
 					PutUnsafe(*os_, 'u');
 					PutUnsafe(*os_, hexDigits[(trail >> 12) & 15]);
 					PutUnsafe(*os_, hexDigits[(trail >> 8) & 15]);
 					PutUnsafe(*os_, hexDigits[(trail >> 4) & 15]);
-					PutUnsafe(*os_, hexDigits[(trail)&15]);
+					PutUnsafe(*os_, hexDigits[(trail) & 15]);
 				}
 			} else if ((sizeof(Ch) == 1 || static_cast<unsigned>(c) < 256) &&
 			           RAPIDJSON_UNLIKELY(escape[static_cast<unsigned char>(c)])) {

--- a/contrib/rapidxml/include/rapidxml/rapidxml.hpp
+++ b/contrib/rapidxml/include/rapidxml/rapidxml.hpp
@@ -2252,7 +2252,7 @@ private:
 				} else {
 					// Child node
 					++text; // Skip '<'
-					if (xml_node<Ch>* child = parse_node<Flags & ~parse_open_only>(text))
+					if (xml_node<Ch>* child = parse_node < Flags & ~parse_open_only > (text))
 						node->append_node(child);
 				}
 				break;

--- a/contrib/sqlite/sqlite3.h
+++ b/contrib/sqlite/sqlite3.h
@@ -3730,7 +3730,7 @@ SQLITE_API void sqlite3_set_auxdata(sqlite3_context*, int N, void*, void (*)(voi
 */
 typedef void (*sqlite3_destructor_type)(void*);
 #define SQLITE_STATIC ((sqlite3_destructor_type)0)
-#define SQLITE_TRANSIENT ((sqlite3_destructor_type)-1)
+#define SQLITE_TRANSIENT ((sqlite3_destructor_type) - 1)
 
 /*
 ** CAPI3REF: Setting The Result Of An SQL Function

--- a/contrib/sqlite/sqliteInt.h
+++ b/contrib/sqlite/sqliteInt.h
@@ -472,7 +472,7 @@ extern const int sqlite3one;
 ** compilers.
 */
 #define LARGEST_INT64 (0xffffffff | (((i64)0x7fffffff) << 32))
-#define SMALLEST_INT64 (((i64)-1) - LARGEST_INT64)
+#define SMALLEST_INT64 (((i64) - 1) - LARGEST_INT64)
 
 /*
 ** Round up a number to the next larger multiple of 8.  This is used
@@ -1046,13 +1046,12 @@ struct FuncDestructor {
 **     parameter.
 */
 #define FUNCTION(zName, nArg, iArg, bNC, xFunc)                                                                        \
-	{ nArg, SQLITE_UTF8, bNC *SQLITE_FUNC_NEEDCOLL, SQLITE_INT_TO_PTR(iArg), 0, xFunc, 0, 0, #zName, 0, 0 }
+	{ nArg, SQLITE_UTF8, bNC * SQLITE_FUNC_NEEDCOLL, SQLITE_INT_TO_PTR(iArg), 0, xFunc, 0, 0, #zName, 0, 0 }
 #define STR_FUNCTION(zName, nArg, pArg, bNC, xFunc)                                                                    \
-	{ nArg, SQLITE_UTF8, bNC *SQLITE_FUNC_NEEDCOLL, pArg, 0, xFunc, 0, 0, #zName, 0, 0 }
-#define LIKEFUNC(zName, nArg, arg, flags)                                                                              \
-	{ nArg, SQLITE_UTF8, flags, (void*)arg, 0, likeFunc, 0, 0, #zName, 0, 0 }
+	{ nArg, SQLITE_UTF8, bNC * SQLITE_FUNC_NEEDCOLL, pArg, 0, xFunc, 0, 0, #zName, 0, 0 }
+#define LIKEFUNC(zName, nArg, arg, flags) { nArg, SQLITE_UTF8, flags, (void*)arg, 0, likeFunc, 0, 0, #zName, 0, 0 }
 #define AGGREGATE(zName, nArg, arg, nc, xStep, xFinal)                                                                 \
-	{ nArg, SQLITE_UTF8, nc *SQLITE_FUNC_NEEDCOLL, SQLITE_INT_TO_PTR(arg), 0, 0, xStep, xFinal, #zName, 0, 0 }
+	{ nArg, SQLITE_UTF8, nc * SQLITE_FUNC_NEEDCOLL, SQLITE_INT_TO_PTR(arg), 0, 0, xStep, xFinal, #zName, 0, 0 }
 
 /*
 ** All current savepoints are stored in a linked list starting at

--- a/fdbclient/BlobGranuleReader.actor.cpp
+++ b/fdbclient/BlobGranuleReader.actor.cpp
@@ -157,7 +157,9 @@ TEST_CASE("/fdbserver/blobgranule/isRangeCoveredByBlob") {
 	testAddChunkRange("key_b1"_sr, "key_b9"_sr, chunks);
 
 	// check empty range. not covered
-	{ ASSERT(isRangeFullyCovered(KeyRangeRef(), chunks) == false); }
+	{
+		ASSERT(isRangeFullyCovered(KeyRangeRef(), chunks) == false);
+	}
 
 	// check empty chunks. not covered
 	{
@@ -166,16 +168,24 @@ TEST_CASE("/fdbserver/blobgranule/isRangeCoveredByBlob") {
 	}
 
 	// check '' to \xff
-	{ ASSERT(isRangeFullyCovered(KeyRangeRef(""_sr, "\xff"_sr), chunks) == false); }
+	{
+		ASSERT(isRangeFullyCovered(KeyRangeRef(""_sr, "\xff"_sr), chunks) == false);
+	}
 
 	// check {key_a1, key_a9}
-	{ ASSERT(isRangeFullyCovered(KeyRangeRef("key_a1"_sr, "key_a9"_sr), chunks)); }
+	{
+		ASSERT(isRangeFullyCovered(KeyRangeRef("key_a1"_sr, "key_a9"_sr), chunks));
+	}
 
 	// check {key_a1, key_a3}
-	{ ASSERT(isRangeFullyCovered(KeyRangeRef("key_a1"_sr, "key_a3"_sr), chunks)); }
+	{
+		ASSERT(isRangeFullyCovered(KeyRangeRef("key_a1"_sr, "key_a3"_sr), chunks));
+	}
 
 	// check {key_a0, key_a3}
-	{ ASSERT(isRangeFullyCovered(KeyRangeRef("key_a0"_sr, "key_a3"_sr), chunks) == false); }
+	{
+		ASSERT(isRangeFullyCovered(KeyRangeRef("key_a0"_sr, "key_a3"_sr), chunks) == false);
+	}
 
 	// check {key_a5, key_b2}
 	{

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -126,7 +126,7 @@ template <class Interface, class Request, bool P>
 Future<REPLY_TYPE(Request)> loadBalance(
     DatabaseContext* ctx,
     const Reference<LocationInfo> alternatives,
-    RequestStream<Request, P> Interface::*channel,
+    RequestStream<Request, P> Interface::* channel,
     const Request& request = Request(),
     TaskPriority taskID = TaskPriority::DefaultPromiseEndpoint,
     AtMostOnce atMostOnce =
@@ -3106,7 +3106,7 @@ template <class F>
 Future<KeyRangeLocationInfo> getKeyLocation(Database const& cx,
                                             TenantInfo const& tenant,
                                             Key const& key,
-                                            F StorageServerInterface::*member,
+                                            F StorageServerInterface::* member,
                                             SpanContext spanContext,
                                             Optional<UID> debugID,
                                             UseProvisionalProxies useProvisionalProxies,
@@ -3140,7 +3140,7 @@ Future<KeyRangeLocationInfo> getKeyLocation(Database const& cx,
 template <class F>
 Future<KeyRangeLocationInfo> getKeyLocation(Reference<TransactionState> trState,
                                             Key const& key,
-                                            F StorageServerInterface::*member,
+                                            F StorageServerInterface::* member,
                                             Reverse isBackward,
                                             UseTenant useTenant) {
 	CODE_PROBE(!useTenant, "Get key location ignoring tenant");
@@ -3256,7 +3256,7 @@ Future<std::vector<KeyRangeLocationInfo>> getKeyRangeLocations(Database const& c
                                                                KeyRange const& keys,
                                                                int limit,
                                                                Reverse reverse,
-                                                               F StorageServerInterface::*member,
+                                                               F StorageServerInterface::* member,
                                                                SpanContext const& spanContext,
                                                                Optional<UID> const& debugID,
                                                                UseProvisionalProxies useProvisionalProxies,
@@ -3299,7 +3299,7 @@ Future<std::vector<KeyRangeLocationInfo>> getKeyRangeLocations(Reference<Transac
                                                                KeyRange const& keys,
                                                                int limit,
                                                                Reverse reverse,
-                                                               F StorageServerInterface::*member,
+                                                               F StorageServerInterface::* member,
                                                                UseTenant useTenant) {
 	CODE_PROBE(!useTenant, "Get key range locations ignoring tenant");
 	return getKeyRangeLocations(trState->cx,
@@ -4282,7 +4282,7 @@ void transformRangeLimits(GetRangeLimits limits, Reverse reverse, GetKeyValuesFa
 }
 
 template <class GetKeyValuesFamilyRequest>
-PublicRequestStream<GetKeyValuesFamilyRequest> StorageServerInterface::*getRangeRequestStream() {
+PublicRequestStream<GetKeyValuesFamilyRequest> StorageServerInterface::* getRangeRequestStream() {
 	if constexpr (std::is_same<GetKeyValuesFamilyRequest, GetKeyValuesRequest>::value) {
 		return &StorageServerInterface::getKeyValues;
 	} else if (std::is_same<GetKeyValuesFamilyRequest, GetMappedKeyValuesRequest>::value) {

--- a/fdbclient/include/fdbclient/Atomic.h
+++ b/fdbclient/include/fdbclient/Atomic.h
@@ -301,7 +301,7 @@ inline void transformVersionstampKey(StringRef& key, Version version, uint16_t t
 }
 
 inline void transformVersionstampMutation(MutationRef& mutation,
-                                          StringRef MutationRef::*param,
+                                          StringRef MutationRef::* param,
                                           Version version,
                                           uint16_t transactionNumber) {
 	mutation.clearChecksumAndAccumulativeIndex();

--- a/fdbclient/include/fdbclient/BlobGranuleRequest.actor.h
+++ b/fdbclient/include/fdbclient/BlobGranuleRequest.actor.h
@@ -46,7 +46,7 @@ Future<Standalone<VectorRef<REPLY_TYPE(Request)>>> txnDoBlobGranuleRequests(
     Key* beginKey,
     Key endKey,
     Request request,
-    RequestStream<Request, P> BlobWorkerInterface::*channel) {
+    RequestStream<Request, P> BlobWorkerInterface::* channel) {
 	// TODO KNOB
 	state RangeResult blobGranuleMapping = wait(krmGetRanges(
 	    tr, blobGranuleMappingKeys.begin, KeyRangeRef(*beginKey, endKey), 64, GetRangeLimits::BYTE_LIMIT_UNLIMITED));
@@ -157,7 +157,7 @@ Future<Standalone<VectorRef<REPLY_TYPE(Request)>>> doBlobGranuleRequests(
     Database cx,
     KeyRange range,
     Request request,
-    RequestStream<Request, P> BlobWorkerInterface::*channel) {
+    RequestStream<Request, P> BlobWorkerInterface::* channel) {
 	state Key beginKey = range.begin;
 	state Key endKey = range.end;
 	state Transaction tr(cx);

--- a/fdbclient/include/fdbclient/BulkLoading.h
+++ b/fdbclient/include/fdbclient/BulkLoading.h
@@ -1059,7 +1059,7 @@ struct SSBulkLoadMetadata {
 public:
 	constexpr static FileIdentifier file_identifier = 1384506;
 
-	SSBulkLoadMetadata() : dataMoveId(UID()), conductBulkLoad(false){};
+	SSBulkLoadMetadata() : dataMoveId(UID()), conductBulkLoad(false) {};
 
 	SSBulkLoadMetadata(const UID& dataMoveId) : dataMoveId(dataMoveId) {
 		conductBulkLoad = getConductBulkLoadFromDataMoveId(dataMoveId);

--- a/fdbclient/include/fdbclient/IConfigTransaction.h
+++ b/fdbclient/include/fdbclient/IConfigTransaction.h
@@ -81,7 +81,7 @@ public:
 	Future<Standalone<StringRef>> getVersionstamp() override { throw client_invalid_operation(); }
 
 	// Implemented:
-	void getWriteConflicts(KeyRangeMap<bool>* result) override{};
+	void getWriteConflicts(KeyRangeMap<bool>* result) override {};
 
 	void debugTrace(BaseTraceEvent&& event) override {
 		event.detail("CommitResult", "Deferred logging unsupported").log();

--- a/fdbclient/include/fdbclient/RandomKeyValueUtils.h
+++ b/fdbclient/include/fdbclient/RandomKeyValueUtils.h
@@ -35,7 +35,7 @@ struct IGenerator {
 	virtual T last() const = 0;
 	virtual std::string toString() const = 0;
 	virtual T next(int distance, bool wrap = false) { throw unsupported_operation(); }
-	virtual ~IGenerator(){};
+	virtual ~IGenerator() {};
 };
 
 struct IKeyGenerator : public IGenerator<Key> {
@@ -301,7 +301,7 @@ typedef RandomStringSetGenerator<RandomStringGenerator> RandomKeySetGenerator;
 // Generate random keys which are composed of tuple segments from a list of RandomKeySets
 // String Definition Format: RandomKeySet[,RandomKeySet]...
 struct RandomKeyTupleGenerator : public IKeyGenerator {
-	RandomKeyTupleGenerator(){};
+	RandomKeyTupleGenerator() {};
 	RandomKeyTupleGenerator(std::vector<RandomKeySetGenerator> tupleParts) : tuples(tupleParts) {}
 	RandomKeyTupleGenerator(std::string s) : RandomKeyTupleGenerator(StringRef(s)) {}
 	RandomKeyTupleGenerator(StringRef s) {

--- a/fdbclient/include/fdbclient/SpecialKeySpace.actor.h
+++ b/fdbclient/include/fdbclient/SpecialKeySpace.actor.h
@@ -80,7 +80,7 @@ public:
 	}
 
 private:
-	ManagementAPIError(){};
+	ManagementAPIError() {};
 };
 
 class SpecialKeyRangeRWImpl : public SpecialKeyRangeReadImpl {

--- a/fdbclient/include/fdbclient/StorageServerInterface.h
+++ b/fdbclient/include/fdbclient/StorageServerInterface.h
@@ -1305,7 +1305,7 @@ struct BulkDumpRequest {
 
 	BulkDumpRequest() {}
 	BulkDumpRequest(const std::vector<UID>& checksumServers, const BulkDumpState& bulkDumpState)
-	  : checksumServers(checksumServers), bulkDumpState(bulkDumpState){};
+	  : checksumServers(checksumServers), bulkDumpState(bulkDumpState) {};
 
 	std::string toString() const {
 		return "[BulkDumpState]: " + bulkDumpState.toString() + ", [ChecksumServers]: " + describe(checksumServers);

--- a/fdbclient/include/fdbclient/TaskBucket.h
+++ b/fdbclient/include/fdbclient/TaskBucket.h
@@ -57,7 +57,7 @@ FDB_BOOLEAN_PARAM(UpdateParams);
 class Task : public ReferenceCounted<Task> {
 public:
 	Task(Value type = StringRef(), uint32_t version = 0, Value done = StringRef(), unsigned int priority = 0);
-	~Task(){};
+	~Task() {};
 
 	// Methods that safely read values from task's params
 	uint32_t getVersion() const;
@@ -439,7 +439,7 @@ public:
 
 struct TaskFuncBase : IDispatched<TaskFuncBase, Standalone<StringRef>, std::function<TaskFuncBase*()>>,
                       ReferenceCounted<TaskFuncBase> {
-	virtual ~TaskFuncBase(){};
+	virtual ~TaskFuncBase() {};
 	static Reference<TaskFuncBase> create(Standalone<StringRef> const& taskFuncType) {
 		return Reference<TaskFuncBase>(dispatch(taskFuncType)());
 	}

--- a/fdbclient/include/fdbclient/TransactionLineage.h
+++ b/fdbclient/include/fdbclient/TransactionLineage.h
@@ -37,11 +37,11 @@ struct TransactionLineage : LineageProperties<TransactionLineage> {
 	UID txID;
 	Operation operation = Operation::Unset;
 
-	bool isSet(uint64_t TransactionLineage::*member) const { return this->*member > 0; }
-	bool isSet(UID TransactionLineage::*member) const {
+	bool isSet(uint64_t TransactionLineage::* member) const { return this->*member > 0; }
+	bool isSet(UID TransactionLineage::* member) const {
 		return static_cast<UID>(this->*member).first() > 0 && static_cast<UID>(this->*member).second() > 0;
 	}
-	bool isSet(Operation TransactionLineage::*member) const { return this->*member != Operation::Unset; }
+	bool isSet(Operation TransactionLineage::* member) const { return this->*member != Operation::Unset; }
 };
 
 struct TransactionLineageCollector : IALPCollector<TransactionLineage> {
@@ -93,11 +93,11 @@ struct TransactionLineageCollector : IALPCollector<TransactionLineage> {
 template <class T, class V>
 class ScopedLineage {
 	V before;
-	V T::*member;
+	V T::* member;
 	bool valid = true;
 
 public:
-	ScopedLineage(V T::*member, V const& value) : member(member) {
+	ScopedLineage(V T::* member, V const& value) : member(member) {
 		auto& val = getCurrentLineage()->modify(member);
 		before = val;
 		val = value;
@@ -127,7 +127,7 @@ public:
 };
 
 template <class T, class V>
-ScopedLineage<T, V> make_scoped_lineage(V T::*member, V const& value) {
+ScopedLineage<T, V> make_scoped_lineage(V T::* member, V const& value) {
 	return ScopedLineage<T, V>(member, value);
 }
 #endif

--- a/fdbclient/sha1/SHA1.cpp
+++ b/fdbclient/sha1/SHA1.cpp
@@ -19,7 +19,7 @@
 #include <fstream>
 
 /* Help macros */
-#define SHA1_ROL(value, bits) (((value) << (bits)) | (((value)&0xffffffff) >> (32 - (bits))))
+#define SHA1_ROL(value, bits) (((value) << (bits)) | (((value) & 0xffffffff) >> (32 - (bits))))
 #define SHA1_BLK(i)                                                                                                    \
 	(block[i & 15] = SHA1_ROL(block[(i + 13) & 15] ^ block[(i + 8) & 15] ^ block[(i + 2) & 15] ^ block[i & 15], 1))
 

--- a/fdbrpc/FlowTests.actor.cpp
+++ b/fdbrpc/FlowTests.actor.cpp
@@ -551,10 +551,8 @@ TEST_CASE("/flow/flow/callbacks") {
 	int result = 0;
 	bool happened = false;
 
-	onReady(
-	    std::move(f), [&result](int x) { result = x; }, [&result](Error e) { result = -1; });
-	onReady(
-	    p.getFuture(), [&happened](int) { happened = true; }, [&happened](Error) { happened = true; });
+	onReady(std::move(f), [&result](int x) { result = x; }, [&result](Error e) { result = -1; });
+	onReady(p.getFuture(), [&happened](int) { happened = true; }, [&happened](Error) { happened = true; });
 	ASSERT(!f.isValid());
 	ASSERT(p.isValid() && !p.isSet() && p.getFutureReferenceCount() == 1);
 	ASSERT(result == 0 && !happened);
@@ -564,16 +562,14 @@ TEST_CASE("/flow/flow/callbacks") {
 	ASSERT(p.isValid() && p.isSet() && p.getFutureReferenceCount() == 0 && p.getFuture().get() == 123);
 
 	result = 0;
-	onReady(
-	    p.getFuture(), [&result](int x) { result = x; }, [&result](Error e) { result = -1; });
+	onReady(p.getFuture(), [&result](int x) { result = x; }, [&result](Error e) { result = -1; });
 	ASSERT(result == 123);
 	ASSERT(p.isValid() && p.isSet() && p.getFutureReferenceCount() == 0 && p.getFuture().get() == 123);
 
 	p = Promise<int>();
 	f = p.getFuture();
 	result = 0;
-	onReady(
-	    std::move(f), [&result](int x) { result = x; }, [&result](Error e) { result = -e.code(); });
+	onReady(std::move(f), [&result](int x) { result = x; }, [&result](Error e) { result = -e.code(); });
 	ASSERT(!f.isValid());
 	ASSERT(p.isValid() && !p.isSet() && p.getFutureReferenceCount() == 1);
 	ASSERT(result == 0);
@@ -588,8 +584,7 @@ TEST_CASE("/flow/flow/promisestream callbacks") {
 
 	int result = 0;
 
-	onReady(
-	    p.getFuture(), [&result](int x) { result = x; }, [&result](Error e) { result = -1; });
+	onReady(p.getFuture(), [&result](int x) { result = x; }, [&result](Error e) { result = -1; });
 
 	ASSERT(result == 0);
 
@@ -599,14 +594,12 @@ TEST_CASE("/flow/flow/promisestream callbacks") {
 	ASSERT(result == 123);
 	result = 0;
 
-	onReady(
-	    p.getFuture(), [&result](int x) { result = x; }, [&result](Error e) { result = -1; });
+	onReady(p.getFuture(), [&result](int x) { result = x; }, [&result](Error e) { result = -1; });
 
 	ASSERT(result == 456);
 	result = 0;
 
-	onReady(
-	    p.getFuture(), [&result](int x) { result = x; }, [&result](Error e) { result = -1; });
+	onReady(p.getFuture(), [&result](int x) { result = x; }, [&result](Error e) { result = -1; });
 
 	ASSERT(result == 0);
 

--- a/fdbrpc/include/fdbrpc/AsyncFileKAIO.actor.h
+++ b/fdbrpc/include/fdbrpc/AsyncFileKAIO.actor.h
@@ -85,8 +85,8 @@ private:
 #pragma pack(push, 1)
 	struct OpLogEntry {
 		OpLogEntry() : result(0) {}
-		enum EOperation{ READ = 1, WRITE = 2, SYNC = 3, TRUNCATE = 4 };
-		enum EStage{ START = 1, LAUNCH = 2, REQUEUE = 3, COMPLETE = 4, READY = 5 };
+		enum EOperation { READ = 1, WRITE = 2, SYNC = 3, TRUNCATE = 4 };
+		enum EStage { START = 1, LAUNCH = 2, REQUEUE = 3, COMPLETE = 4, READY = 5 };
 		int64_t timestamp;
 		uint32_t id;
 		uint32_t checksum;

--- a/fdbrpc/include/fdbrpc/LoadBalance.actor.h
+++ b/fdbrpc/include/fdbrpc/LoadBalance.actor.h
@@ -90,7 +90,7 @@ Future<Void> tssComparison(Req req,
                            TSSEndpointData tssData,
                            uint64_t srcEndpointId,
                            Reference<MultiInterface<Multi>> ssTeam,
-                           RequestStream<Req, P> Interface::*channel) {
+                           RequestStream<Req, P> Interface::* channel) {
 	state double startTime = now();
 	state Future<Optional<ErrorOr<Resp>>> fTssWithTimeout = timeout(fTss, FLOW_KNOBS->LOAD_BALANCE_TSS_TIMEOUT);
 	state int finished = 0;
@@ -286,7 +286,7 @@ Future<Void> replicaComparison(Req req,
                                Future<ErrorOr<Resp>> fSource,
                                uint64_t srcEndpointId,
                                Reference<MultiInterface<Multi>> ssTeam,
-                               RequestStream<Req, P> Interface::*channel,
+                               RequestStream<Req, P> Interface::* channel,
                                int requiredReplicas) {
 	state ErrorOr<Resp> src;
 
@@ -451,7 +451,7 @@ struct RequestData : NonCopyable {
 	                                     QueueModel* model,
 	                                     Future<Reply> ssResponse,
 	                                     Reference<MultiInterface<Multi>> alternatives,
-	                                     RequestStream<Request, P> Interface::*channel) {
+	                                     RequestStream<Request, P> Interface::* channel) {
 		if (model) {
 			// Send parallel request to TSS pair, if it exists
 			Optional<TSSEndpointData> tssData = model->getTssData(stream->getEndpoint().token.first());
@@ -476,7 +476,7 @@ struct RequestData : NonCopyable {
 	Future<Void> maybeDoReplicaComparison(Request& request,
 	                                      QueueModel* model,
 	                                      Reference<MultiInterface<Multi>> alternatives,
-	                                      RequestStream<Request, P> Interface::*channel,
+	                                      RequestStream<Request, P> Interface::* channel,
 	                                      int requiredReplicas) {
 		if (model && (compareReplicas || FLOW_KNOBS->ENABLE_REPLICA_CONSISTENCY_CHECK_ON_READS)) {
 			ASSERT(requestStream != nullptr);
@@ -501,7 +501,7 @@ struct RequestData : NonCopyable {
 	    Request& request,
 	    QueueModel* model,
 	    Reference<MultiInterface<Multi>> alternatives, // alternatives and channel passed through for TSS check
-	    RequestStream<Request, P> Interface::*channel) {
+	    RequestStream<Request, P> Interface::* channel) {
 		modelHolder = Reference<ModelHolder>();
 		requestStream = stream;
 		requestStarted = false;
@@ -651,7 +651,7 @@ struct RequestData : NonCopyable {
 ACTOR template <class Interface, class Request, class Multi, bool P>
 Future<REPLY_TYPE(Request)> loadBalance(
     Reference<MultiInterface<Multi>> alternatives,
-    RequestStream<Request, P> Interface::*channel,
+    RequestStream<Request, P> Interface::* channel,
     Request request = Request(),
     TaskPriority taskID = TaskPriority::DefaultPromiseEndpoint,
     AtMostOnce atMostOnce =
@@ -996,7 +996,7 @@ Optional<BasicLoadBalancedReply> getBasicLoadBalancedReply(const void*);
 // returned future.
 ACTOR template <class Interface, class Request, class Multi, bool P>
 Future<REPLY_TYPE(Request)> basicLoadBalance(Reference<ModelInterface<Multi>> alternatives,
-                                             RequestStream<Request, P> Interface::*channel,
+                                             RequestStream<Request, P> Interface::* channel,
                                              Request request = Request(),
                                              TaskPriority taskID = TaskPriority::DefaultPromiseEndpoint,
                                              AtMostOnce atMostOnce = AtMostOnce::False,

--- a/fdbrpc/include/fdbrpc/MultiInterface.h
+++ b/fdbrpc/include/fdbrpc/MultiInterface.h
@@ -165,7 +165,7 @@ public:
 	}
 
 	template <class F>
-	F const& get(int index, F T::*member) const {
+	F const& get(int index, F T::* member) const {
 		return alternatives[index].interf.*member;
 	}
 
@@ -221,7 +221,7 @@ public:
 	bool alwaysFresh() const { return LBLocalityData<T>::alwaysFresh(); }
 
 	template <class F>
-	F const& get(int index, F T::*member) const {
+	F const& get(int index, F T::* member) const {
 		return alternatives[index]->interf.*member;
 	}
 

--- a/fdbrpc/include/fdbrpc/ReplicationPolicy.h
+++ b/fdbrpc/include/fdbrpc/ReplicationPolicy.h
@@ -96,7 +96,7 @@ inline void save(Archive& ar, const Reference<IReplicationPolicy>& value) {
 }
 
 struct PolicyOne final : IReplicationPolicy {
-	PolicyOne(){};
+	PolicyOne() {};
 	explicit PolicyOne(const PolicyOne& o) {}
 	std::string name() const override { return "One"; }
 	std::string info() const override { return "1"; }

--- a/fdbrpc/include/fdbrpc/grpc/Credentials.h
+++ b/fdbrpc/include/fdbrpc/grpc/Credentials.h
@@ -41,7 +41,7 @@ namespace ge = grpc::experimental;
 // provide secure or insecure credentials based on the underlying configuration.
 class GrpcCredentialProvider {
 public:
-	virtual ~GrpcCredentialProvider(){};
+	virtual ~GrpcCredentialProvider() {};
 
 	virtual std::shared_ptr<grpc::ServerCredentials> serverCredentials() const = 0;
 	virtual std::shared_ptr<grpc::ChannelCredentials> clientCredentials() const = 0;

--- a/fdbrpc/libeio/ecb.h
+++ b/fdbrpc/libeio/ecb.h
@@ -407,7 +407,7 @@ ecb_function_ ecb_bool ecb_little_endian(void) {
 #if ECB_GCC_VERSION(3, 0) || ECB_C99
 #define ecb_mod(m, n) ((m) % (n) + ((m) % (n) < 0 ? (n) : 0))
 #else
-#define ecb_mod(m, n) ((m) < 0 ? ((n)-1 - ((-1 - (m)) % (n))) : ((m) % (n)))
+#define ecb_mod(m, n) ((m) < 0 ? ((n) - 1 - ((-1 - (m)) % (n))) : ((m) % (n)))
 #endif
 
 #if __cplusplus
@@ -420,8 +420,8 @@ static inline T ecb_div_ru(T val, T div) {
 	return val < 0 ? -((-val) / div) : (val + div - 1) / div;
 }
 #else
-#define ecb_div_rd(val, div) ((val) < 0 ? -((-(val) + (div)-1) / (div)) : ((val)) / (div))
-#define ecb_div_ru(val, div) ((val) < 0 ? -((-(val)) / (div)) : ((val) + (div)-1) / (div))
+#define ecb_div_rd(val, div) ((val) < 0 ? -((-(val) + (div) - 1) / (div)) : ((val)) / (div))
+#define ecb_div_ru(val, div) ((val) < 0 ? -((-(val)) / (div)) : ((val) + (div) - 1) / (div))
 #endif
 
 #if ecb_cplusplus_does_not_suck

--- a/fdbserver/ConfigDatabaseUnitTests.actor.cpp
+++ b/fdbserver/ConfigDatabaseUnitTests.actor.cpp
@@ -144,7 +144,7 @@ class ReadFromLocalConfigEnvironment {
 
 	ACTOR template <class T, class V, class E>
 	static Future<Void> checkEventually(Reference<LocalConfiguration const> localConfiguration,
-	                                    V T::*member,
+	                                    V T::* member,
 	                                    Optional<E> expected) {
 		state double lastMismatchTime = now();
 		loop {
@@ -200,7 +200,7 @@ public:
 	}
 
 	template <class T, class V, class E>
-	void checkImmediate(V T::*member, Optional<E> expected) const {
+	void checkImmediate(V T::* member, Optional<E> expected) const {
 		if (expected.present()) {
 			ASSERT_EQ(localConfiguration->getTestKnobs().*member, expected.get());
 		} else {
@@ -209,7 +209,7 @@ public:
 	}
 
 	template <class T, class V, class E>
-	Future<Void> checkEventually(V T::*member, Optional<E> expected) const {
+	Future<Void> checkEventually(V T::* member, Optional<E> expected) const {
 		return checkEventually(localConfiguration, member, expected);
 	}
 
@@ -251,7 +251,7 @@ public:
 		return addMutation(configClass, knobName, knobValue.contents());
 	}
 	template <class T, class V, class E>
-	void check(V T::*member, Optional<E> value) const {
+	void check(V T::* member, Optional<E> value) const {
 		return readFrom.checkImmediate(member, value);
 	}
 };
@@ -295,7 +295,7 @@ public:
 	void clear(Optional<KeyRef> configClass, KeyRef knobName) { addMutation(configClass, knobName, {}); }
 
 	template <class T, class V, class E>
-	Future<Void> check(V T::*member, Optional<E> value) const {
+	Future<Void> check(V T::* member, Optional<E> value) const {
 		return readFrom.checkEventually(member, value);
 	}
 
@@ -484,7 +484,7 @@ public:
 	}
 	Future<Void> clear(Optional<KeyRef> configClass, KeyRef knobName) { return writeTo.clear(configClass, knobName); }
 	template <class T, class V, class E>
-	Future<Void> check(V T::*member, Optional<E> value) const {
+	Future<Void> check(V T::* member, Optional<E> value) const {
 		return readFrom.checkEventually(member, value);
 	}
 	void close() const {

--- a/fdbserver/DDRelocationQueue.actor.cpp
+++ b/fdbserver/DDRelocationQueue.actor.cpp
@@ -130,7 +130,7 @@ DataMovementReason priorityToDataMovementReason(int priority) {
 RelocateData::RelocateData()
   : priority(-1), boundaryPriority(-1), healthPriority(-1), reason(RelocateReason::OTHER), startTime(-1),
     dataMoveId(anonymousShardId), workFactor(0), wantsNewServers(false), cancellable(false),
-    interval("QueuedRelocation"){};
+    interval("QueuedRelocation") {};
 
 RelocateData::RelocateData(RelocateShard const& rs)
   : parent_range(rs.getParentRange()), keys(rs.keys), priority(rs.priority),
@@ -216,7 +216,7 @@ class ParallelTCInfo final : public ReferenceCounted<ParallelTCInfo>, public IDa
 
 public:
 	ParallelTCInfo() = default;
-	explicit ParallelTCInfo(ParallelTCInfo const& info) : teams(info.teams), tempServerIDs(info.tempServerIDs){};
+	explicit ParallelTCInfo(ParallelTCInfo const& info) : teams(info.teams), tempServerIDs(info.tempServerIDs) {};
 
 	void addTeam(Reference<IDataDistributionTeam> team) { teams.push_back(team); }
 

--- a/fdbserver/DiskQueue.actor.cpp
+++ b/fdbserver/DiskQueue.actor.cpp
@@ -1575,7 +1575,7 @@ public:
 	                         DiskQueueVersion diskQueueVersion,
 	                         int64_t fileSizeWarningLimit)
 	  : queue(new DiskQueue(basename, fileExtension, dbgid, diskQueueVersion, fileSizeWarningLimit)), pushed(0),
-	    popped(0), committed(0){};
+	    popped(0), committed(0) {};
 
 	// IClosable
 	Future<Void> getError() const override { return queue->getError(); }

--- a/fdbserver/KeyValueStoreRocksDB.actor.cpp
+++ b/fdbserver/KeyValueStoreRocksDB.actor.cpp
@@ -363,7 +363,7 @@ std::string getErrorReason(BackgroundErrorReason reason) {
 // could potentially cause segmentation fault.
 class RocksDBErrorListener : public rocksdb::EventListener {
 public:
-	RocksDBErrorListener(UID id) : id(id){};
+	RocksDBErrorListener(UID id) : id(id) {};
 	void OnBackgroundError(rocksdb::BackgroundErrorReason reason, rocksdb::Status* bg_error) override {
 		TraceEvent(SevError, "RocksDBBGError", id)
 		    .detail("Reason", getErrorReason(reason))
@@ -403,7 +403,7 @@ private:
 
 class RocksDBEventListener : public rocksdb::EventListener {
 public:
-	RocksDBEventListener(std::shared_ptr<SharedRocksDBState> sharedState) : sharedState(sharedState){};
+	RocksDBEventListener(std::shared_ptr<SharedRocksDBState> sharedState) : sharedState(sharedState) {};
 
 	void OnFlushCompleted(rocksdb::DB* db, const rocksdb::FlushJobInfo& info) override {
 		sharedState->setLastFlushTime(now());

--- a/fdbserver/KeyValueStoreSQLite.actor.cpp
+++ b/fdbserver/KeyValueStoreSQLite.actor.cpp
@@ -1696,7 +1696,7 @@ private:
 			Key key;
 			Optional<UID> debugID;
 			ThreadReturnPromise<Optional<Value>> result;
-			ReadValueAction(Key key, Optional<UID> debugID) : key(key), debugID(debugID){};
+			ReadValueAction(Key key, Optional<UID> debugID) : key(key), debugID(debugID) {};
 			double getTimeEstimate() const override { return SERVER_KNOBS->READ_VALUE_TIME_ESTIMATE; }
 		};
 		void action(ReadValueAction& rv) {
@@ -1724,7 +1724,7 @@ private:
 			Optional<UID> debugID;
 			ThreadReturnPromise<Optional<Value>> result;
 			ReadValuePrefixAction(Key key, int maxLength, Optional<UID> debugID)
-			  : key(key), maxLength(maxLength), debugID(debugID){};
+			  : key(key), maxLength(maxLength), debugID(debugID) {};
 			double getTimeEstimate() const override { return SERVER_KNOBS->READ_VALUE_TIME_ESTIMATE; }
 		};
 		void action(ReadValuePrefixAction& rv) {

--- a/fdbserver/KeyValueStoreShardedRocksDB.actor.cpp
+++ b/fdbserver/KeyValueStoreShardedRocksDB.actor.cpp
@@ -295,7 +295,7 @@ private:
 // could potentially cause segmentation fault.
 class RocksDBErrorListener : public rocksdb::EventListener {
 public:
-	RocksDBErrorListener(){};
+	RocksDBErrorListener() {};
 	void OnBackgroundError(rocksdb::BackgroundErrorReason reason, rocksdb::Status* bg_error) override {
 		if (!bg_error)
 			return;
@@ -3151,7 +3151,7 @@ struct ShardedRocksDBKeyValueStore : IKeyValueStore {
 			    startTime(timer_monotonic()),
 			    sample((deterministicRandom()->random01() < SERVER_KNOBS->SHARDED_ROCKSDB_HISTOGRAMS_SAMPLE_RATE)
 			               ? true
-			               : false){};
+			               : false) {};
 			double getTimeEstimate() const override { return SERVER_KNOBS->READ_VALUE_TIME_ESTIMATE; }
 		};
 

--- a/fdbserver/RocksDBCheckpointUtils.actor.cpp
+++ b/fdbserver/RocksDBCheckpointUtils.actor.cpp
@@ -733,7 +733,7 @@ ACTOR Future<Void> RocksDBColumnFamilyReader::doClose(RocksDBColumnFamilyReader*
 class RocksDBSstFileWriter : public IRocksDBSstFileWriter {
 public:
 	RocksDBSstFileWriter()
-	  : writer(std::make_unique<rocksdb::SstFileWriter>(rocksdb::EnvOptions(), rocksdb::Options())), hasData(false){};
+	  : writer(std::make_unique<rocksdb::SstFileWriter>(rocksdb::EnvOptions(), rocksdb::Options())), hasData(false) {};
 
 	void open(const std::string localFile) override;
 
@@ -789,7 +789,7 @@ bool RocksDBSstFileWriter::finish() {
 
 class RocksDBSstFileReader : public IRocksDBSstFileReader {
 public:
-	RocksDBSstFileReader() : sstReader(std::make_unique<rocksdb::SstFileReader>(rocksdb::Options())){};
+	RocksDBSstFileReader() : sstReader(std::make_unique<rocksdb::SstFileReader>(rocksdb::Options())) {};
 
 	RocksDBSstFileReader(const KeyRange& rangeBoundary, size_t rowLimit, size_t byteLimit)
 	  : sstReader(std::make_unique<rocksdb::SstFileReader>(rocksdb::Options())), rowLimit(rowLimit),

--- a/fdbserver/VersionedBTree.actor.cpp
+++ b/fdbserver/VersionedBTree.actor.cpp
@@ -8328,7 +8328,7 @@ public:
 		}));
 	}
 
-	~KeyValueStoreRedwood() override{};
+	~KeyValueStoreRedwood() override {};
 
 private:
 	std::string m_filename;

--- a/fdbserver/include/fdbserver/BulkDumpUtil.actor.h
+++ b/fdbserver/include/fdbserver/BulkDumpUtil.actor.h
@@ -48,7 +48,7 @@ struct SSBulkDumpTask {
 	SSBulkDumpTask(const StorageServerInterface& targetServer,
 	               const std::vector<UID>& checksumServers,
 	               const BulkDumpState& bulkDumpState)
-	  : targetServer(targetServer), checksumServers(checksumServers), bulkDumpState(bulkDumpState){};
+	  : targetServer(targetServer), checksumServers(checksumServers), bulkDumpState(bulkDumpState) {};
 
 	std::string toString() const {
 		return "[BulkDumpState]: " + bulkDumpState.toString() + ", [TargetServer]: " + targetServer.toString() +

--- a/fdbserver/include/fdbserver/CoordinationInterface.h
+++ b/fdbserver/include/fdbserver/CoordinationInterface.h
@@ -55,7 +55,7 @@ struct GenerationRegInterface {
 	GenerationRegInterface() {}
 	GenerationRegInterface(NetworkAddress const& remote);
 	GenerationRegInterface(INetwork* local);
-	GenerationRegInterface(Hostname const& hostname) : hostname(hostname){};
+	GenerationRegInterface(Hostname const& hostname) : hostname(hostname) {};
 };
 
 struct UniqueGeneration {

--- a/fdbserver/include/fdbserver/DDTxnProcessor.h
+++ b/fdbserver/include/fdbserver/DDTxnProcessor.h
@@ -256,7 +256,7 @@ protected:
 	std::vector<DDShardInfo> getDDShardInfos() const;
 
 public:
-	explicit DDMockTxnProcessor(std::shared_ptr<MockGlobalState> mgs = nullptr) : mgs(std::move(mgs)){};
+	explicit DDMockTxnProcessor(std::shared_ptr<MockGlobalState> mgs = nullptr) : mgs(std::move(mgs)) {};
 
 	Future<ServerWorkerInfos> getServerListAndProcessClasses() override;
 

--- a/fdbserver/include/fdbserver/DataDistribution.actor.h
+++ b/fdbserver/include/fdbserver/DataDistribution.actor.h
@@ -786,7 +786,7 @@ struct StorageWiggler : ReferenceCounted<StorageWiggler> {
 	State wiggleState = State::INVALID;
 	double lastStateChangeTs = 0.0; // timestamp describes when did the state change
 
-	explicit StorageWiggler(DDTeamCollection* collection) : teamCollection(collection), stopWiggleSignal(true){};
+	explicit StorageWiggler(DDTeamCollection* collection) : teamCollection(collection), stopWiggleSignal(true) {};
 	// wiggle related actors will quit when this signal is set to true
 	void setStopSignal(bool value) { stopWiggleSignal.set(value); }
 	bool isStopped() const { return stopWiggleSignal.get(); }

--- a/fdbserver/include/fdbserver/RemoteIKeyValueStore.actor.h
+++ b/fdbserver/include/fdbserver/RemoteIKeyValueStore.actor.h
@@ -135,7 +135,7 @@ struct OpenKVStoreRequest {
 	bool checkIntegrity;
 	ReplyPromise<struct IKVSInterface> reply;
 
-	OpenKVStoreRequest(){};
+	OpenKVStoreRequest() {};
 
 	OpenKVStoreRequest(KeyValueStoreType storeType,
 	                   std::string filename,

--- a/fdbserver/include/fdbserver/RestoreCommon.actor.h
+++ b/fdbserver/include/fdbserver/RestoreCommon.actor.h
@@ -247,7 +247,7 @@ ACTOR Future<Standalone<VectorRef<KeyValueRef>>> decodeLogFileBlock(Reference<IA
 // Save replies to replies if replies != nullptr
 // The UID in a request is the UID of the interface to handle the request
 ACTOR template <class Interface, class Request>
-Future<Void> getBatchReplies(RequestStream<Request> Interface::*channel,
+Future<Void> getBatchReplies(RequestStream<Request> Interface::* channel,
                              std::map<UID, Interface> interfaces,
                              std::vector<std::pair<UID, Request>> requests,
                              std::vector<REPLY_TYPE(Request)>* replies,
@@ -377,7 +377,7 @@ Future<Void> getBatchReplies(RequestStream<Request> Interface::*channel,
 
 // Similar to getBatchReplies except that the caller does not expect to process the reply info.
 ACTOR template <class Interface, class Request>
-Future<Void> sendBatchRequests(RequestStream<Request> Interface::*channel,
+Future<Void> sendBatchRequests(RequestStream<Request> Interface::* channel,
                                std::map<UID, Interface> interfaces,
                                std::vector<std::pair<UID, Request>> requests,
                                TaskPriority taskID = TaskPriority::Low,

--- a/fdbserver/include/fdbserver/RestoreController.actor.h
+++ b/fdbserver/include/fdbserver/RestoreController.actor.h
@@ -49,7 +49,7 @@ struct VersionBatch {
 	double size; // size of data in range and log files
 	int batchIndex; // Never reset
 
-	VersionBatch() : beginVersion(0), endVersion(0), size(0){};
+	VersionBatch() : beginVersion(0), endVersion(0), size(0) {};
 
 	bool operator<(const VersionBatch& rhs) const {
 		return std::tie(batchIndex, beginVersion, endVersion, logFiles, rangeFiles, size) <

--- a/fdbserver/include/fdbserver/RestoreLoader.actor.h
+++ b/fdbserver/include/fdbserver/RestoreLoader.actor.h
@@ -136,7 +136,7 @@ struct RestoreLoaderSchedSendLoadParamRequest {
 	double start;
 
 	explicit RestoreLoaderSchedSendLoadParamRequest(int batchIndex, Promise<Void> toSched, double start)
-	  : batchIndex(batchIndex), toSched(toSched), start(start){};
+	  : batchIndex(batchIndex), toSched(toSched), start(start) {};
 	RestoreLoaderSchedSendLoadParamRequest() = default;
 
 	bool operator<(RestoreLoaderSchedSendLoadParamRequest const& rhs) const {

--- a/fdbserver/include/fdbserver/RestoreRoleCommon.actor.h
+++ b/fdbserver/include/fdbserver/RestoreRoleCommon.actor.h
@@ -101,7 +101,8 @@ public:
 	NotifiedVersion versionBatchId; // The index of the version batch that has been initialized and put into pipeline
 	NotifiedVersion finishedBatch; // The highest batch index all appliers have applied mutations
 
-	RestoreRoleData() : role(RestoreRole::Invalid), cpuUsage(0.0), memory(0.0), residentMemory(0.0), delayedActors(0){};
+	RestoreRoleData()
+	  : role(RestoreRole::Invalid), cpuUsage(0.0), memory(0.0), residentMemory(0.0), delayedActors(0) {};
 
 	virtual ~RestoreRoleData() = default;
 

--- a/fdbserver/include/fdbserver/RestoreWorkerInterface.actor.h
+++ b/fdbserver/include/fdbserver/RestoreWorkerInterface.actor.h
@@ -111,7 +111,7 @@ struct RestoreRoleInterface {
 
 	RestoreRoleInterface() { role = RestoreRole::Invalid; }
 
-	explicit RestoreRoleInterface(RestoreRoleInterface const& interf) : nodeID(interf.nodeID), role(interf.role){};
+	explicit RestoreRoleInterface(RestoreRoleInterface const& interf) : nodeID(interf.nodeID), role(interf.role) {};
 
 	UID id() const { return nodeID; }
 
@@ -543,7 +543,7 @@ struct RestoreLoadFileRequest : TimedRequest {
 	ReplyPromise<RestoreLoadFileReply> reply;
 
 	RestoreLoadFileRequest() = default;
-	explicit RestoreLoadFileRequest(int batchIndex, LoadingParam& param) : batchIndex(batchIndex), param(param){};
+	explicit RestoreLoadFileRequest(int batchIndex, LoadingParam& param) : batchIndex(batchIndex), param(param) {};
 
 	bool operator<(RestoreLoadFileRequest const& rhs) const { return batchIndex > rhs.batchIndex; }
 

--- a/fdbserver/include/fdbserver/RoleLineage.actor.h
+++ b/fdbserver/include/fdbserver/RoleLineage.actor.h
@@ -40,7 +40,7 @@ struct RoleLineage : LineageProperties<RoleLineage> {
 	static std::string_view name;
 	ProcessClass::ClusterRole role = ProcessClass::NoRole;
 
-	bool isSet(ProcessClass::ClusterRole RoleLineage::*member) const { return this->*member != ProcessClass::NoRole; }
+	bool isSet(ProcessClass::ClusterRole RoleLineage::* member) const { return this->*member != ProcessClass::NoRole; }
 };
 
 struct RoleLineageCollector : IALPCollector<RoleLineage> {

--- a/fdbserver/include/fdbserver/TestTLogServer.actor.h
+++ b/fdbserver/include/fdbserver/TestTLogServer.actor.h
@@ -84,7 +84,7 @@ struct TLogContext : NonCopyable, public ReferenceCounted<TLogContext> {
 	Promise<bool> TLogStarted;
 	Promise<bool> TestTLogServerCompleted;
 
-	TLogContext(uint32_t inProcessID = 0) : tagProcessID(inProcessID){};
+	TLogContext(uint32_t inProcessID = 0) : tagProcessID(inProcessID) {};
 };
 
 // test state

--- a/fdbserver/include/fdbserver/workloads/workloads.actor.h
+++ b/fdbserver/include/fdbserver/workloads/workloads.actor.h
@@ -79,7 +79,7 @@ struct TestWorkload : NonCopyable, WorkloadContext, ReferenceCounted<TestWorkloa
 		if (runSetup)
 			phases |= TestWorkload::SETUP;
 	}
-	virtual ~TestWorkload(){};
+	virtual ~TestWorkload() {};
 	virtual Future<Void> initialized() { return Void(); }
 	// WARNING: this method must not be implemented by a workload directly. Instead, this will be implemented by
 	// the workload factory. Instead, provide a static member variable called name.

--- a/fdbserver/workloads/AsyncFileRead.actor.cpp
+++ b/fdbserver/workloads/AsyncFileRead.actor.cpp
@@ -38,7 +38,7 @@ struct IOLog {
 
 		bool logLatency; // when false, log times and compute elapsed, else, interpret the log'd time as a latency
 
-		ProcessLog() : logLatency(false){};
+		ProcessLog() : logLatency(false) {};
 
 		virtual void reset() {
 			startTime = now();

--- a/fdbserver/workloads/PrivateEndpoints.actor.cpp
+++ b/fdbserver/workloads/PrivateEndpoints.actor.cpp
@@ -77,7 +77,7 @@ struct PrivateEndpoints : TestWorkload {
 	}
 
 	template <class I, class RT>
-	void addTestFor(RequestStream<RT, false> I::*channel) {
+	void addTestFor(RequestStream<RT, false> I::* channel) {
 		testFunctions.push_back([channel](Reference<AsyncVar<ClientDBInfo>> const& clientDBInfo) {
 			auto optintf = getInterface<I>(clientDBInfo);
 			if (!optintf.present()) {

--- a/fdbservice/FDBService.cpp
+++ b/fdbservice/FDBService.cpp
@@ -336,7 +336,7 @@ protected:
 				}
 			} else {
 				// FIXME: log error
-				throw(DWORD) 1;
+				throw (DWORD)1;
 			}
 		}
 

--- a/flow/Net2.actor.cpp
+++ b/flow/Net2.actor.cpp
@@ -2296,7 +2296,7 @@ TEST_CASE("noSim/flow/Net2/onMainThreadFIFO") {
 	return Void();
 }
 
-void net2_test(){
+void net2_test() {
 	/*
 	g_network = newNet2();  // for promise serialization below
 

--- a/flow/Platform.actor.cpp
+++ b/flow/Platform.actor.cpp
@@ -2104,9 +2104,9 @@ static void enableLargePages() {
 	ModifyPrivilege(SE_LOCK_MEMORY_NAME, true);
 	largePagesPrivilegeEnabled = true;
 #else
-		// SOMEDAY: can/should we teach the client how to enable large pages
-		// on Linux? Or just rely on the system to have been configured as
-		// desired?
+	// SOMEDAY: can/should we teach the client how to enable large pages
+	// on Linux? Or just rely on the system to have been configured as
+	// desired?
 #endif
 }
 
@@ -2334,8 +2334,8 @@ void atomicReplace(std::string const& path, std::string const& content, bool tex
 		if (!f)
 			throw io_error();
 #ifdef _WIN32
-			// In Windows case, ReplaceFile API is used which preserves the ownership,
-			// ACLs and other attributes of the original file
+		// In Windows case, ReplaceFile API is used which preserves the ownership,
+		// ACLs and other attributes of the original file
 #elif defined(__unixish__)
 		// get the uid/gid/mode bits of old file and set it on new file, else fail
 		struct stat info;

--- a/flow/Trace.cpp
+++ b/flow/Trace.cpp
@@ -277,7 +277,7 @@ public:
 		struct Ping final : TypedAction<WriterThread, Ping> {
 			ThreadReturnPromise<Void> ack;
 
-			explicit Ping(){};
+			explicit Ping() {};
 			double getTimeEstimate() const override { return 0; }
 		};
 		void action(Ping& ping) {

--- a/flow/include/flow/Buggify.h
+++ b/flow/include/flow/Buggify.h
@@ -39,10 +39,18 @@ inline double P_EXPENSIVE_VALIDATION{ 0.05 };
 	inline double P_##TYPE##_BUGGIFIED_SECTION_FIRES{ 0.25 };                                                          \
 	inline double P_##TYPE##_ENABLED{ false };                                                                         \
 	inline std::unordered_map<const char*, bool> Type##_SBVars;                                                        \
-	inline bool is##Type##BuggifyEnabled() noexcept { return P_##TYPE##_ENABLED; }                                     \
-	inline void enable##Type##Buggify() noexcept { P_##TYPE##_ENABLED = true; }                                        \
-	inline void disable##Type##Buggify() noexcept { P_##TYPE##_ENABLED = false; }                                      \
-	inline void clear##Type##BuggifySections() { Type##_SBVars.clear(); }                                              \
+	inline bool is##Type##BuggifyEnabled() noexcept {                                                                  \
+		return P_##TYPE##_ENABLED;                                                                                     \
+	}                                                                                                                  \
+	inline void enable##Type##Buggify() noexcept {                                                                     \
+		P_##TYPE##_ENABLED = true;                                                                                     \
+	}                                                                                                                  \
+	inline void disable##Type##Buggify() noexcept {                                                                    \
+		P_##TYPE##_ENABLED = false;                                                                                    \
+	}                                                                                                                  \
+	inline void clear##Type##BuggifySections() {                                                                       \
+		Type##_SBVars.clear();                                                                                         \
+	}                                                                                                                  \
 	inline bool get##Type##SBVar(const char* file, const int line, const char* combined) {                             \
 		if (Type##_SBVars.count(combined)) [[likely]] {                                                                \
 			return Type##_SBVars[combined];                                                                            \

--- a/flow/include/flow/CodeProbe.h
+++ b/flow/include/flow/CodeProbe.h
@@ -304,16 +304,24 @@ CodeProbeImpl<FileName, Condition, Comment, CompUnit, Line, CodeProbeAnnotations
 
 #define _CODE_PROBE_IMPL(file, line, condition, comment, compUnit, fileType, condType, commentType, compUnitType, ...) \
 	struct fileType {                                                                                                  \
-		constexpr static const char* value() { return file; }                                                          \
+		constexpr static const char* value() {                                                                         \
+			return file;                                                                                               \
+		}                                                                                                              \
 	};                                                                                                                 \
 	struct condType {                                                                                                  \
-		constexpr static const char* value() { return #condition; }                                                    \
+		constexpr static const char* value() {                                                                         \
+			return #condition;                                                                                         \
+		}                                                                                                              \
 	};                                                                                                                 \
 	struct commentType {                                                                                               \
-		constexpr static const char* value() { return comment; }                                                       \
+		constexpr static const char* value() {                                                                         \
+			return comment;                                                                                            \
+		}                                                                                                              \
 	};                                                                                                                 \
 	struct compUnitType {                                                                                              \
-		constexpr static const char* value() { return compUnit; }                                                      \
+		constexpr static const char* value() {                                                                         \
+			return compUnit;                                                                                           \
+		}                                                                                                              \
 	};                                                                                                                 \
 	if (condition) {                                                                                                   \
 		probe::probeInstance<fileType, condType, commentType, compUnitType, line>(__VA_ARGS__).hit();                  \

--- a/flow/include/flow/Error.h
+++ b/flow/include/flow/Error.h
@@ -85,7 +85,9 @@ extern const std::set<int> transactionRetryableErrors;
 
 #undef ERROR
 #define ERROR(name, number, description)                                                                               \
-	inline Error name() { return Error(number); };                                                                     \
+	inline Error name() {                                                                                              \
+		return Error(number);                                                                                          \
+	};                                                                                                                 \
 	enum { error_code_##name = number };
 
 #include "error_definitions.h"
@@ -144,7 +146,9 @@ extern bool isAssertDisabled(int line);
 		}                                                                                                              \
 	} while (false)
 #define UNREACHABLE()                                                                                                  \
-	{ throw internal_error_impl("unreachable", __FILE__, __LINE__); }
+	{                                                                                                                  \
+		throw internal_error_impl("unreachable", __FILE__, __LINE__);                                                  \
+	}
 
 // TODO: magic so this works even if const-ness doesn't not match.
 template <typename T, typename U>

--- a/flow/include/flow/IndexedSet.h
+++ b/flow/include/flow/IndexedSet.h
@@ -95,7 +95,7 @@ private: // Forward-declare IndexedSet::Node because Clang is much stricter abou
 			static_assert(isConst);
 		}
 
-		explicit IteratorImpl(decltype(node) n = nullptr) : node(n){};
+		explicit IteratorImpl(decltype(node) n = nullptr) : node(n) {};
 
 		typename std::conditional_t<isConst, const T, T>& operator*() const { return node->data; }
 
@@ -149,7 +149,7 @@ public:
 	using iterator = IteratorImpl<false>;
 	using const_iterator = IteratorImpl<true>;
 
-	IndexedSet() : root(nullptr){};
+	IndexedSet() : root(nullptr) {};
 	~IndexedSet() { delete root; }
 	IndexedSet(IndexedSet&& r) noexcept : root(r.root) { r.root = nullptr; }
 	IndexedSet& operator=(IndexedSet&& r) noexcept {

--- a/flow/include/flow/Optional.h
+++ b/flow/include/flow/Optional.h
@@ -108,12 +108,12 @@ public:
 	// v.map(&T::member) is equivalent to v.map([](T v) { return v.member; })
 	template <class R, class Rp = std::decay_t<R>>
 	std::enable_if_t<std::is_class_v<T>, Optional<Rp>> map(
-	    R std::conditional_t<std::is_class_v<T>, T, Void>::*member) const& {
+	    R std::conditional_t<std::is_class_v<T>, T, Void>::* member) const& {
 		return present() ? Optional<Rp>(get().*member) : Optional<Rp>();
 	}
 	template <class R, class Rp = std::decay_t<R>>
 	std::enable_if_t<std::is_class_v<T>, Optional<Rp>> map(
-	    R std::conditional_t<std::is_class_v<T>, T, Void>::*member) && {
+	    R std::conditional_t<std::is_class_v<T>, T, Void>::* member) && {
 		return present() ? Optional<Rp>(std::move(*this).get().*member) : Optional<Rp>();
 	}
 
@@ -141,7 +141,7 @@ public:
 	//
 	// v.mapRef(&P::member) is equivalent to Optional<R>(v.get()->member) if v is present and non-null
 	template <class P, class R, class Rp = std::decay_t<R>>
-	std::enable_if_t<std::is_class_v<T> || std::is_pointer_v<T>, Optional<Rp>> mapRef(R P::*member) const& {
+	std::enable_if_t<std::is_class_v<T> || std::is_pointer_v<T>, Optional<Rp>> mapRef(R P::* member) const& {
 		if (!present() || !get()) {
 			return Optional<Rp>();
 		}

--- a/flow/include/flow/TDMetric.actor.h
+++ b/flow/include/flow/TDMetric.actor.h
@@ -772,7 +772,7 @@ struct BaseMetric {
 	virtual void rollMetric(uint64_t t) = 0;
 
 	virtual void flushData(const MetricKeyRef& mk, uint64_t rollTime, MetricBatch& batch) = 0;
-	virtual void registerFields(const MetricKeyRef& mk, std::vector<Standalone<StringRef>>& fieldKeys){};
+	virtual void registerFields(const MetricKeyRef& mk, std::vector<Standalone<StringRef>>& fieldKeys) {};
 
 	// Set the metric's config.  An assert will fail if the metric is enabled before the metrics collection is
 	// available.
@@ -799,7 +799,7 @@ struct BaseMetric {
 	// Metrics should verify their underlying storage on Enable because they could have been initially created
 	// at a time when the knobs were not initialized.
 	virtual void onEnable() = 0;
-	virtual void onDisable(){};
+	virtual void onDisable() {};
 
 	// Combines checking this metric's configured minimum level and any collection-wide throttling
 	// This should only be called after it is determined that a metric is enabled.

--- a/flow/include/flow/ThreadHelper.actor.h
+++ b/flow/include/flow/ThreadHelper.actor.h
@@ -48,7 +48,7 @@ void doOnMainThreadVoid(Future<Void> signal, F f) {
 }
 
 ACTOR template <class F, class T>
-void doOnMainThreadVoid(Future<Void> signal, F f, T* t, Error T::*member) {
+void doOnMainThreadVoid(Future<Void> signal, F f, T* t, Error T::* member) {
 	wait(signal);
 	if (t && (t->*member).code() != invalid_error_code)
 		return;
@@ -77,7 +77,7 @@ void doOnMainThreadVoid(Future<Void> signal, F f, T* t, Error T::*member) {
 //
 // `onMainThreadVoid` is defined here because of the dependency in `ThreadSingleAssignmentVarBase`.
 template <class F, class T>
-void onMainThreadVoid(F f, T* t, Error T::*member, TaskPriority taskID = TaskPriority::DefaultOnMainThread) {
+void onMainThreadVoid(F f, T* t, Error T::* member, TaskPriority taskID = TaskPriority::DefaultOnMainThread) {
 	Promise<Void> signal;
 	internal_thread_helper::doOnMainThreadVoid(signal.getFuture(), f, t, member);
 	g_network->onMainThread(std::move(signal), taskID);

--- a/flow/include/flow/ThreadPrimitives.h
+++ b/flow/include/flow/ThreadPrimitives.h
@@ -106,13 +106,13 @@ public:
 
 class ThreadUnsafeSpinLock {
 public:
-	void enter(){};
-	void leave(){};
-	void assertNotEntered(){};
+	void enter() {};
+	void leave() {};
+	void assertNotEntered() {};
 };
 class ThreadUnsafeSpinLockHolder {
 public:
-	ThreadUnsafeSpinLockHolder(ThreadUnsafeSpinLock&){};
+	ThreadUnsafeSpinLockHolder(ThreadUnsafeSpinLock&) {};
 };
 
 #if FLOW_THREAD_SAFE

--- a/flow/include/flow/Trace.h
+++ b/flow/include/flow/Trace.h
@@ -210,7 +210,9 @@ struct SpecialTraceMetricType
 #define TRACE_METRIC_TYPE(from, to)                                                                                    \
 	template <>                                                                                                        \
 	struct SpecialTraceMetricType<from> : std::true_type {                                                             \
-		static to getValue(from v) { return v; }                                                                       \
+		static to getValue(from v) {                                                                                   \
+			return v;                                                                                                  \
+		}                                                                                                              \
 	}
 
 TRACE_METRIC_TYPE(double, double);

--- a/flow/include/flow/Traceable.h
+++ b/flow/include/flow/Traceable.h
@@ -83,7 +83,9 @@ struct Traceable : std::false_type {};
 #define FORMAT_TRACEABLE(type, fmt)                                                                                    \
 	template <>                                                                                                        \
 	struct Traceable<type> : std::true_type {                                                                          \
-		static std::string toString(type value) { return format(fmt, value); }                                         \
+		static std::string toString(type value) {                                                                      \
+			return format(fmt, value);                                                                                 \
+		}                                                                                                              \
 	}
 
 FORMAT_TRACEABLE(bool, "%d");

--- a/flow/include/flow/WipedString.h
+++ b/flow/include/flow/WipedString.h
@@ -46,10 +46,8 @@ public:
 
 template <class Context>
 concept is_wipe_enabled = requires(Context& context) {
-	                          {
-		                          context.markForWipe(std::declval<uint8_t*>(), std::declval<size_t>())
-		                          } -> std::same_as<void>;
-                          };
+	{ context.markForWipe(std::declval<uint8_t*>(), std::declval<size_t>()) } -> std::same_as<void>;
+};
 
 } // namespace detail
 

--- a/flow/include/flow/ppc-opcode.h
+++ b/flow/include/flow/ppc-opcode.h
@@ -13,11 +13,11 @@
 #ifndef __OPCODES_H
 #define __OPCODES_H
 
-#define __PPC_RA(a) (((a)&0x1f) << 16)
-#define __PPC_RB(b) (((b)&0x1f) << 11)
-#define __PPC_XA(a) ((((a)&0x1f) << 16) | (((a)&0x20) >> 3))
-#define __PPC_XB(b) ((((b)&0x1f) << 11) | (((b)&0x20) >> 4))
-#define __PPC_XS(s) ((((s)&0x1f) << 21) | (((s)&0x20) >> 5))
+#define __PPC_RA(a) (((a) & 0x1f) << 16)
+#define __PPC_RB(b) (((b) & 0x1f) << 11)
+#define __PPC_XA(a) ((((a) & 0x1f) << 16) | (((a) & 0x20) >> 3))
+#define __PPC_XB(b) ((((b) & 0x1f) << 11) | (((b) & 0x20) >> 4))
+#define __PPC_XS(s) ((((s) & 0x1f) << 21) | (((s) & 0x20) >> 5))
 #define __PPC_XT(s) __PPC_XS(s)
 #define VSX_XX3(t, a, b) (__PPC_XT(t) | __PPC_XA(a) | __PPC_XB(b))
 #define VSX_XX1(s, a, b) (__PPC_XS(s) | __PPC_RA(a) | __PPC_RB(b))

--- a/flow/include/flow/singleton.h
+++ b/flow/include/flow/singleton.h
@@ -91,7 +91,7 @@ struct create_static {
 		double double_;
 		long double longDouble_;
 		struct Test;
-		int Test::*pMember_;
+		int Test::* pMember_;
 		int (Test::*pMemberFn_)(int);
 	};
 

--- a/flow/include/flow/sse2neon.h
+++ b/flow/include/flow/sse2neon.h
@@ -314,9 +314,10 @@ FORCE_INLINE __m128i _mm_set_epi8(signed char b15,
                                   signed char b2,
                                   signed char b1,
                                   signed char b0) {
-	int8_t __attribute__((aligned(16)))
-	data[16] = { (int8_t)b0, (int8_t)b1, (int8_t)b2,  (int8_t)b3,  (int8_t)b4,  (int8_t)b5,  (int8_t)b6,  (int8_t)b7,
-		         (int8_t)b8, (int8_t)b9, (int8_t)b10, (int8_t)b11, (int8_t)b12, (int8_t)b13, (int8_t)b14, (int8_t)b15 };
+	int8_t __attribute__((aligned(16))) data[16] = { (int8_t)b0,  (int8_t)b1,  (int8_t)b2,  (int8_t)b3,
+		                                             (int8_t)b4,  (int8_t)b5,  (int8_t)b6,  (int8_t)b7,
+		                                             (int8_t)b8,  (int8_t)b9,  (int8_t)b10, (int8_t)b11,
+		                                             (int8_t)b12, (int8_t)b13, (int8_t)b14, (int8_t)b15 };
 	return (__m128i)vld1q_s8(data);
 }
 
@@ -345,9 +346,10 @@ FORCE_INLINE __m128i _mm_setr_epi8(signed char b0,
                                    signed char b13,
                                    signed char b14,
                                    signed char b15) {
-	int8_t __attribute__((aligned(16)))
-	data[16] = { (int8_t)b0, (int8_t)b1, (int8_t)b2,  (int8_t)b3,  (int8_t)b4,  (int8_t)b5,  (int8_t)b6,  (int8_t)b7,
-		         (int8_t)b8, (int8_t)b9, (int8_t)b10, (int8_t)b11, (int8_t)b12, (int8_t)b13, (int8_t)b14, (int8_t)b15 };
+	int8_t __attribute__((aligned(16))) data[16] = { (int8_t)b0,  (int8_t)b1,  (int8_t)b2,  (int8_t)b3,
+		                                             (int8_t)b4,  (int8_t)b5,  (int8_t)b6,  (int8_t)b7,
+		                                             (int8_t)b8,  (int8_t)b9,  (int8_t)b10, (int8_t)b11,
+		                                             (int8_t)b12, (int8_t)b13, (int8_t)b14, (int8_t)b15 };
 	return (__m128i)vld1q_s8(data);
 }
 
@@ -769,7 +771,7 @@ FORCE_INLINE __m128 _mm_shuffle_ps_default(__m128 a,
 #define _mm_shuffle_ps_default(a, b, imm)                                                                              \
 	__extension__({                                                                                                    \
 		float32x4_t ret;                                                                                               \
-		ret = vmovq_n_f32(vgetq_lane_f32(vreinterpretq_f32_m128(a), (imm)&0x3));                                       \
+		ret = vmovq_n_f32(vgetq_lane_f32(vreinterpretq_f32_m128(a), (imm) & 0x3));                                     \
 		ret = vsetq_lane_f32(vgetq_lane_f32(vreinterpretq_f32_m128(a), ((imm) >> 2) & 0x3), ret, 1);                   \
 		ret = vsetq_lane_f32(vgetq_lane_f32(vreinterpretq_f32_m128(b), ((imm) >> 4) & 0x3), ret, 2);                   \
 		ret = vsetq_lane_f32(vgetq_lane_f32(vreinterpretq_f32_m128(b), ((imm) >> 6) & 0x3), ret, 3);                   \
@@ -784,7 +786,7 @@ FORCE_INLINE __m128 _mm_shuffle_ps_default(__m128 a,
 		float32x4_t _input1 = vreinterpretq_f32_m128(a);                                                               \
 		float32x4_t _input2 = vreinterpretq_f32_m128(b);                                                               \
 		float32x4_t _shuf = __builtin_shufflevector(                                                                   \
-		    _input1, _input2, (imm)&0x3, ((imm) >> 2) & 0x3, (((imm) >> 4) & 0x3) + 4, (((imm) >> 6) & 0x3) + 4);      \
+		    _input1, _input2, (imm) & 0x3, ((imm) >> 2) & 0x3, (((imm) >> 4) & 0x3) + 4, (((imm) >> 6) & 0x3) + 4);    \
 		vreinterpretq_m128_f32(_shuf);                                                                                 \
 	})
 #else // generic
@@ -963,7 +965,7 @@ FORCE_INLINE __m128i _mm_shuffle_epi32_default(__m128i a,
 #define _mm_shuffle_epi32_default(a, imm)                                                                              \
 	__extension__({                                                                                                    \
 		int32x4_t ret;                                                                                                 \
-		ret = vmovq_n_s32(vgetq_lane_s32(vreinterpretq_s32_m128i(a), (imm)&0x3));                                      \
+		ret = vmovq_n_s32(vgetq_lane_s32(vreinterpretq_s32_m128i(a), (imm) & 0x3));                                    \
 		ret = vsetq_lane_s32(vgetq_lane_s32(vreinterpretq_s32_m128i(a), ((imm) >> 2) & 0x3), ret, 1);                  \
 		ret = vsetq_lane_s32(vgetq_lane_s32(vreinterpretq_s32_m128i(a), ((imm) >> 4) & 0x3), ret, 2);                  \
 		ret = vsetq_lane_s32(vgetq_lane_s32(vreinterpretq_s32_m128i(a), ((imm) >> 6) & 0x3), ret, 3);                  \
@@ -989,7 +991,7 @@ FORCE_INLINE __m128i _mm_shuffle_epi32_default(__m128i a,
 	__extension__({                                                                                                    \
 		int32x4_t _input = vreinterpretq_s32_m128i(a);                                                                 \
 		int32x4_t _shuf = __builtin_shufflevector(                                                                     \
-		    _input, _input, (imm)&0x3, ((imm) >> 2) & 0x3, ((imm) >> 4) & 0x3, ((imm) >> 6) & 0x3);                    \
+		    _input, _input, (imm) & 0x3, ((imm) >> 2) & 0x3, ((imm) >> 4) & 0x3, ((imm) >> 6) & 0x3);                  \
 		vreinterpretq_m128i_s32(_shuf);                                                                                \
 	})
 #else // generic
@@ -1057,7 +1059,7 @@ FORCE_INLINE __m128i _mm_shuffle_epi32_default(__m128i a,
 	__extension__({                                                                                                    \
 		int16x8_t ret = vreinterpretq_s16_m128i(a);                                                                    \
 		int16x4_t lowBits = vget_low_s16(ret);                                                                         \
-		ret = vsetq_lane_s16(vget_lane_s16(lowBits, (imm)&0x3), ret, 0);                                               \
+		ret = vsetq_lane_s16(vget_lane_s16(lowBits, (imm) & 0x3), ret, 0);                                             \
 		ret = vsetq_lane_s16(vget_lane_s16(lowBits, ((imm) >> 2) & 0x3), ret, 1);                                      \
 		ret = vsetq_lane_s16(vget_lane_s16(lowBits, ((imm) >> 4) & 0x3), ret, 2);                                      \
 		ret = vsetq_lane_s16(vget_lane_s16(lowBits, ((imm) >> 6) & 0x3), ret, 3);                                      \
@@ -1072,7 +1074,7 @@ FORCE_INLINE __m128i _mm_shuffle_epi32_default(__m128i a,
 		int16x8_t _input = vreinterpretq_s16_m128i(a);                                                                 \
 		int16x8_t _shuf = __builtin_shufflevector(_input,                                                              \
 		                                          _input,                                                              \
-		                                          ((imm)&0x3),                                                         \
+		                                          ((imm) & 0x3),                                                       \
 		                                          (((imm) >> 2) & 0x3),                                                \
 		                                          (((imm) >> 4) & 0x3),                                                \
 		                                          (((imm) >> 6) & 0x3),                                                \
@@ -1095,7 +1097,7 @@ FORCE_INLINE __m128i _mm_shuffle_epi32_default(__m128i a,
 	__extension__({                                                                                                    \
 		int16x8_t ret = vreinterpretq_s16_m128i(a);                                                                    \
 		int16x4_t highBits = vget_high_s16(ret);                                                                       \
-		ret = vsetq_lane_s16(vget_lane_s16(highBits, (imm)&0x3), ret, 4);                                              \
+		ret = vsetq_lane_s16(vget_lane_s16(highBits, (imm) & 0x3), ret, 4);                                            \
 		ret = vsetq_lane_s16(vget_lane_s16(highBits, ((imm) >> 2) & 0x3), ret, 5);                                     \
 		ret = vsetq_lane_s16(vget_lane_s16(highBits, ((imm) >> 4) & 0x3), ret, 6);                                     \
 		ret = vsetq_lane_s16(vget_lane_s16(highBits, ((imm) >> 6) & 0x3), ret, 7);                                     \
@@ -1114,7 +1116,7 @@ FORCE_INLINE __m128i _mm_shuffle_epi32_default(__m128i a,
 		                                          1,                                                                   \
 		                                          2,                                                                   \
 		                                          3,                                                                   \
-		                                          ((imm)&0x3) + 4,                                                     \
+		                                          ((imm) & 0x3) + 4,                                                   \
 		                                          (((imm) >> 2) & 0x3) + 4,                                            \
 		                                          (((imm) >> 4) & 0x3) + 4,                                            \
 		                                          (((imm) >> 6) & 0x3) + 4);                                           \

--- a/flow/include/flow/xxhash.h
+++ b/flow/include/flow/xxhash.h
@@ -685,7 +685,9 @@ struct XXH3_state_s {
  * it's still necessary to use XXH3_NNbits_reset*() afterwards.
  */
 #define XXH3_INITSTATE(XXH3_state_ptr)                                                                                 \
-	{ (XXH3_state_ptr)->seed = 0; }
+	{                                                                                                                  \
+		(XXH3_state_ptr)->seed = 0;                                                                                    \
+	}
 
 /* ===   Experimental API   === */
 /* Symbols defined below must be considered tied to a specific library version. */
@@ -3702,10 +3704,8 @@ static XXH64_hash_t XXH3_mergeAccs(const xxh_u64* XXH_RESTRICT acc, const xxh_u8
 }
 
 #define XXH3_INIT_ACC                                                                                                  \
-	{                                                                                                                  \
-		XXH_PRIME32_3, XXH_PRIME64_1, XXH_PRIME64_2, XXH_PRIME64_3, XXH_PRIME64_4, XXH_PRIME32_2, XXH_PRIME64_5,       \
-		    XXH_PRIME32_1                                                                                              \
-	}
+	{ XXH_PRIME32_3, XXH_PRIME64_1, XXH_PRIME64_2, XXH_PRIME64_3,                                                      \
+	  XXH_PRIME64_4, XXH_PRIME32_2, XXH_PRIME64_5, XXH_PRIME32_1 }
 
 XXH_FORCE_INLINE XXH64_hash_t XXH3_hashLong_64b_internal(const void* XXH_RESTRICT input,
                                                          size_t len,


### PR DESCRIPTION
As title.

Compilation succeeds. 

Formatting change but currently running 100K just in case: `20250408-235413-praza-clang-format-v19.1.5-apply-78fc73207a1 compressed=True data_size=40038210 fail_fast=10 max_runs=100000 priority=100 sanity=False submitted=20250408-235413 timeout=5400 username=praza-clang-format-v19.1.5-apply-78fc73207a1c4aabd10ef4dfa8b8ebd0634bf97e`. 


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
