### PR TITLE
Fix Javadoc build error, RPM packaging, and Dockerfile

### DIFF
--- a/bindings/java/src/main/overview.html.in
+++ b/bindings/java/src/main/overview.html.in
@@ -13,7 +13,7 @@ and then added to your classpath.<br>
 <h1>Getting started</h1>
 To start using FoundationDB from Java, create an instance of the 
 {@link com.apple.foundationdb.FDB FoundationDB API interface} with the version of the
-API that you want to use (this release of the FoundationDB Java API supports versions between {@code 510} and {@link ApiVersion.LATEST}).
+API that you want to use (this release of the FoundationDB Java API supports versions between {@code 510} and {@code 740}).
 With this API object you can then open {@link com.apple.foundationdb.Cluster Cluster}s and
 {@link com.apple.foundationdb.Database Database}s and start using
 {@link com.apple.foundationdb.Transaction Transaction}s.

--- a/cmake/CPackConfig.cmake
+++ b/cmake/CPackConfig.cmake
@@ -1,6 +1,6 @@
 if(CPACK_GENERATOR MATCHES "RPM")
   set(CPACK_PACKAGING_INSTALL_PREFIX "/")
-  set(CPACK_COMPONENTS_ALL clients-el7 server-el7 clients-versioned server-versioned)
+  set(CPACK_COMPONENTS_ALL clients-el9 server-el9 clients-versioned server-versioned)
   set(CPACK_RESOURCE_FILE_README ${CMAKE_SOURCE_DIR}/README.md)
   set(CPACK_RESOURCE_FILE_LICENSE ${CMAKE_SOURCE_DIR}/LICENSE)
 elseif(CPACK_GENERATOR MATCHES "DEB")

--- a/cmake/FDBInstall.cmake
+++ b/cmake/FDBInstall.cmake
@@ -49,7 +49,7 @@ function(install_symlink)
         TO "../${rel_path}bin/${IN_FILE_NAME}"
         DESTINATION "usr/lib64/${IN_LINK_NAME}"
         COMPONENTS
-        "${IN_COMPONENT}-el7"
+        "${IN_COMPONENT}-el9"
         "${IN_COMPONENT}-deb")
       install_symlink_impl(
         TO "../${rel_path}bin/${IN_FILE_NAME}"
@@ -64,7 +64,7 @@ function(install_symlink)
         TO "../${rel_path}bin/${IN_FILE_NAME}"
         DESTINATION "usr/bin/${IN_LINK_NAME}"
         COMPONENTS
-        "${IN_COMPONENT}-el7"
+        "${IN_COMPONENT}-el9"
         "${IN_COMPONENT}-deb")
     elseif("${IN_LINK_DIR}" MATCHES "fdbmonitor")
       install_symlink_impl(
@@ -75,7 +75,7 @@ function(install_symlink)
         TO "../../${rel_path}bin/${IN_FILE_NAME}"
         DESTINATION "usr/lib/foundationdb/${IN_LINK_NAME}"
         COMPONENTS
-        "${IN_COMPONENT}-el7"
+        "${IN_COMPONENT}-el9"
         "${IN_COMPONENT}-deb")
     else()
       message(FATAL_ERROR "Unknown LINK_DIR ${IN_LINK_DIR}")

--- a/cmake/InstallLayout.cmake
+++ b/cmake/InstallLayout.cmake
@@ -39,8 +39,7 @@ function(install_symlink)
         install_symlink_impl(
           TO "../${rel_path}bin/${IN_FILE_NAME}"
           DESTINATION "usr/lib64/${IN_LINK_NAME}"
-          COMPONENTS "${IN_COMPONENT}-el6"
-                     "${IN_COMPONENT}-el7"
+          COMPONENTS "${IN_COMPONENT}-el9"
                      "${IN_COMPONENT}-deb")
         install_symlink_impl(
           TO "../${rel_path}bin/${IN_FILE_NAME}"
@@ -54,8 +53,7 @@ function(install_symlink)
         install_symlink_impl(
           TO "../${rel_path}bin/${IN_FILE_NAME}"
           DESTINATION "usr/bin/${IN_LINK_NAME}"
-          COMPONENTS "${IN_COMPONENT}-el6"
-                     "${IN_COMPONENT}-el7"
+          COMPONENTS "${IN_COMPONENT}-el9"
                      "${IN_COMPONENT}-deb")
       elseif("${IN_LINK_DIR}" MATCHES "fdbmonitor")
         install_symlink_impl(
@@ -65,8 +63,7 @@ function(install_symlink)
         install_symlink_impl(
           TO "../../${rel_path}bin/${IN_FILE_NAME}"
           DESTINATION "usr/lib/foundationdb/${IN_LINK_NAME}"
-          COMPONENTS "${IN_COMPONENT}-el6"
-                     "${IN_COMPONENT}-el7"
+          COMPONENTS "${IN_COMPONENT}-el9"
                      "${IN_COMPONENT}-deb")
       else()
         message(FATAL_ERROR "Unknown LINK_DIR ${IN_LINK_DIR}")
@@ -91,7 +88,7 @@ function(symlink_files)
   endif()
 endfunction()
 
-fdb_install_packages(TGZ DEB EL7 VERSIONED)
+fdb_install_packages(TGZ DEB EL9 VERSIONED)
 fdb_install_dirs(BIN SBIN LIB FDBMONITOR INCLUDE ETC LOG DATA BACKUPAGENT)
 message(STATUS "FDB_INSTALL_DIRS -> ${FDB_INSTALL_DIRS}")
 
@@ -116,8 +113,8 @@ install_destinations(DEB
   ETC etc/foundationdb
   LOG var/log/foundationdb
   DATA var/lib/foundationdb/data)
-copy_install_destinations(DEB EL7)
-install_destinations(EL7 LIB usr/lib64)
+copy_install_destinations(DEB EL9)
+install_destinations(EL9 LIB usr/lib64)
 
 # This can be used for debugging in case above is behaving funky
 #print_install_destinations()
@@ -159,7 +156,7 @@ configure_file("${mv_packaging_dir}/server/prerm" "${script_dir}/server" @ONLY)
 set(LIB_DIR lib)
 configure_file("${mv_packaging_dir}/clients/postinst" "${script_dir}/clients" @ONLY)
 set(LIB_DIR lib64)
-configure_file("${mv_packaging_dir}/clients/postinst" "${script_dir}/clients/postinst-el7" @ONLY)
+configure_file("${mv_packaging_dir}/clients/postinst" "${script_dir}/clients/postinst-el9" @ONLY)
 configure_file("${mv_packaging_dir}/clients/prerm" "${script_dir}/clients" @ONLY)
 
 #make sure all directories we need exist
@@ -200,17 +197,17 @@ set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "FoundationDB is a scalable, fault-toleran
 set(CPACK_PACKAGE_ICON ${CMAKE_SOURCE_DIR}/packaging/foundationdb.ico)
 set(CPACK_PACKAGE_CONTACT "The FoundationDB Community")
 
-set(CPACK_COMPONENT_SERVER-EL7_DEPENDS clients-el7)
+set(CPACK_COMPONENT_SERVER-EL9_DEPENDS clients-el9)
 set(CPACK_COMPONENT_SERVER-DEB_DEPENDS clients-deb)
 set(CPACK_COMPONENT_SERVER-TGZ_DEPENDS clients-tgz)
 set(CPACK_COMPONENT_SERVER-VERSIONED_DEPENDS clients-versioned)
 
-set(CPACK_COMPONENT_SERVER-EL7_DISPLAY_NAME "foundationdb-server")
+set(CPACK_COMPONENT_SERVER-EL9_DISPLAY_NAME "foundationdb-server")
 set(CPACK_COMPONENT_SERVER-DEB_DISPLAY_NAME "foundationdb-server")
 set(CPACK_COMPONENT_SERVER-TGZ_DISPLAY_NAME "foundationdb-server")
 set(CPACK_COMPONENT_SERVER-VERSIONED_DISPLAY_NAME "foundationdb${FDB_VERSION}${FDB_BUILDTIME_STRING}${PRERELEASE_TAG}-server")
 
-set(CPACK_COMPONENT_CLIENTS-EL7_DISPLAY_NAME "foundationdb-clients")
+set(CPACK_COMPONENT_CLIENTS-EL9_DISPLAY_NAME "foundationdb-clients")
 set(CPACK_COMPONENT_CLIENTS-DEB_DISPLAY_NAME "foundationdb-clients")
 set(CPACK_COMPONENT_CLIENTS-TGZ_DISPLAY_NAME "foundationdb-clients")
 set(CPACK_COMPONENT_CLIENTS-VERSIONED_DISPLAY_NAME "foundationdb${FDB_VERSION}${FDB_BUILDTIME_STRING}${PRERELEASE_TAG}-clients")
@@ -237,28 +234,28 @@ string(REPLACE "-" "_" FDB_PACKAGE_VERSION ${FDB_VERSION})
 set(CPACK_RPM_PACKAGE_GROUP                                ${CURRENT_GIT_VERSION})
 set(CPACK_RPM_PACKAGE_LICENSE                              "Apache 2.0")
 set(CPACK_RPM_PACKAGE_NAME                                 "foundationdb")
-set(CPACK_RPM_CLIENTS-EL7_PACKAGE_NAME                     "${CPACK_RPM_PACKAGE_NAME}-clients")
-set(CPACK_RPM_CLIENTS-EL7_FILE_NAME                        "${CPACK_RPM_CLIENTS-EL7_PACKAGE_NAME}-${FDB_PACKAGE_VERSION}${package_version_postfix}.el7.${CMAKE_SYSTEM_PROCESSOR}.rpm")
-set(CPACK_RPM_CLIENTS-EL7_DEBUGINFO_FILE_NAME              "${CPACK_RPM_CLIENTS-EL7_PACKAGE_NAME}-${FDB_PACKAGE_VERSION}${package_version_postfix}.el7-debuginfo.${CMAKE_SYSTEM_PROCESSOR}.rpm")
-set(CPACK_RPM_CLIENTS-EL7_PRE_INSTALL_SCRIPT_FILE          ${CMAKE_SOURCE_DIR}/packaging/rpm/scripts/preclients.sh)
-set(CPACK_RPM_CLIENTS-EL7_POST_INSTALL_SCRIPT_FILE         ${CMAKE_SOURCE_DIR}/packaging/rpm/scripts/postclients.sh)
-set(CPACK_RPM_CLIENTS-EL7_USER_FILELIST                    "%dir /etc/foundationdb")
+set(CPACK_RPM_CLIENTS-EL9_PACKAGE_NAME                     "${CPACK_RPM_PACKAGE_NAME}-clients")
+set(CPACK_RPM_CLIENTS-EL9_FILE_NAME                        "${CPACK_RPM_CLIENTS-EL9_PACKAGE_NAME}-${FDB_PACKAGE_VERSION}${package_version_postfix}.el9.${CMAKE_SYSTEM_PROCESSOR}.rpm")
+set(CPACK_RPM_CLIENTS-EL9_DEBUGINFO_FILE_NAME              "${CPACK_RPM_CLIENTS-EL9_PACKAGE_NAME}-${FDB_PACKAGE_VERSION}${package_version_postfix}.el9-debuginfo.${CMAKE_SYSTEM_PROCESSOR}.rpm")
+set(CPACK_RPM_CLIENTS-EL9_PRE_INSTALL_SCRIPT_FILE          ${CMAKE_SOURCE_DIR}/packaging/rpm/scripts/preclients.sh)
+set(CPACK_RPM_CLIENTS-EL9_POST_INSTALL_SCRIPT_FILE         ${CMAKE_SOURCE_DIR}/packaging/rpm/scripts/postclients.sh)
+set(CPACK_RPM_CLIENTS-EL9_USER_FILELIST                    "%dir /etc/foundationdb")
 
-set(CPACK_RPM_SERVER-EL7_PACKAGE_NAME                      "${CPACK_RPM_PACKAGE_NAME}-server")
-set(CPACK_RPM_SERVER-EL7_FILE_NAME                         "${CPACK_RPM_SERVER-EL7_PACKAGE_NAME}-${FDB_PACKAGE_VERSION}${package_version_postfix}.el7.${CMAKE_SYSTEM_PROCESSOR}.rpm")
-set(CPACK_RPM_SERVER-EL7_DEBUGINFO_FILE_NAME               "${CPACK_RPM_SERVER-EL7_PACKAGE_NAME}-${FDB_PACKAGE_VERSION}${package_version_postfix}.el7-debuginfo.${CMAKE_SYSTEM_PROCESSOR}.rpm")
-set(CPACK_RPM_SERVER-EL7_PACKAGE_REQUIRES                  "${CPACK_RPM_CLIENTS-EL7_PACKAGE_NAME} = ${FDB_PACKAGE_VERSION}")
-set(CPACK_RPM_SERVER-EL7_PRE_INSTALL_SCRIPT_FILE           ${CMAKE_SOURCE_DIR}/packaging/rpm/scripts/preserver.sh)
-set(CPACK_RPM_SERVER-EL7_POST_INSTALL_SCRIPT_FILE          ${CMAKE_SOURCE_DIR}/packaging/rpm/scripts/postserver.sh)
-set(CPACK_RPM_SERVER-EL7_PRE_UNINSTALL_SCRIPT_FILE         ${CMAKE_SOURCE_DIR}/packaging/rpm/scripts/preunserver.sh)
-set(CPACK_RPM_SERVER-EL7_USER_FILELIST                     "%config(noreplace) /etc/foundationdb/foundationdb.conf"
+set(CPACK_RPM_SERVER-EL9_PACKAGE_NAME                      "${CPACK_RPM_PACKAGE_NAME}-server")
+set(CPACK_RPM_SERVER-EL9_FILE_NAME                         "${CPACK_RPM_SERVER-EL9_PACKAGE_NAME}-${FDB_PACKAGE_VERSION}${package_version_postfix}.el9.${CMAKE_SYSTEM_PROCESSOR}.rpm")
+set(CPACK_RPM_SERVER-EL9_DEBUGINFO_FILE_NAME               "${CPACK_RPM_SERVER-EL9_PACKAGE_NAME}-${FDB_PACKAGE_VERSION}${package_version_postfix}.el9-debuginfo.${CMAKE_SYSTEM_PROCESSOR}.rpm")
+set(CPACK_RPM_SERVER-EL9_PACKAGE_REQUIRES                  "${CPACK_RPM_CLIENTS-EL9_PACKAGE_NAME} = ${FDB_PACKAGE_VERSION}")
+set(CPACK_RPM_SERVER-EL9_PRE_INSTALL_SCRIPT_FILE           ${CMAKE_SOURCE_DIR}/packaging/rpm/scripts/preserver.sh)
+set(CPACK_RPM_SERVER-EL9_POST_INSTALL_SCRIPT_FILE          ${CMAKE_SOURCE_DIR}/packaging/rpm/scripts/postserver.sh)
+set(CPACK_RPM_SERVER-EL9_PRE_UNINSTALL_SCRIPT_FILE         ${CMAKE_SOURCE_DIR}/packaging/rpm/scripts/preunserver.sh)
+set(CPACK_RPM_SERVER-EL9_USER_FILELIST                     "%config(noreplace) /etc/foundationdb/foundationdb.conf"
                                                            "%attr(0700,foundationdb,foundationdb) /var/log/foundationdb"
                                                            "%attr(0700,foundationdb,foundationdb) /var/lib/foundationdb")
 
 set(CPACK_RPM_CLIENTS-VERSIONED_PACKAGE_NAME               "${CPACK_RPM_PACKAGE_NAME}${FDB_PACKAGE_VERSION}${FDB_BUILDTIME_STRING}${PRERELEASE_TAG}-clients")
 set(CPACK_RPM_CLIENTS-VERSIONED_FILE_NAME                  "${CPACK_RPM_CLIENTS-VERSIONED_PACKAGE_NAME}-${CPACK_RPM_PACKAGE_RELEASE}.versioned.${CMAKE_SYSTEM_PROCESSOR}.rpm")
 set(CPACK_RPM_CLIENTS-VERSIONED_DEBUGINFO_FILE_NAME        "${CPACK_RPM_CLIENTS-VERSIONED_PACKAGE_NAME}-${CPACK_RPM_PACKAGE_RELEASE}.versioned-debuginfo.${CMAKE_SYSTEM_PROCESSOR}.rpm")
-set(CPACK_RPM_CLIENTS-VERSIONED_POST_INSTALL_SCRIPT_FILE   ${CMAKE_BINARY_DIR}/packaging/multiversion/clients/postinst-el7)
+set(CPACK_RPM_CLIENTS-VERSIONED_POST_INSTALL_SCRIPT_FILE   ${CMAKE_BINARY_DIR}/packaging/multiversion/clients/postinst-el9)
 set(CPACK_RPM_CLIENTS-VERSIONED_PRE_UNINSTALL_SCRIPT_FILE  ${CMAKE_BINARY_DIR}/packaging/multiversion/clients/prerm)
 
 set(CPACK_RPM_SERVER-VERSIONED_PACKAGE_NAME                "${CPACK_RPM_PACKAGE_NAME}${FDB_PACKAGE_VERSION}${FDB_BUILDTIME_STRING}${PRERELEASE_TAG}-server")
@@ -371,7 +368,7 @@ if(NOT WIN32)
     COMPONENT server-deb)
   install(FILES ${CMAKE_SOURCE_DIR}/packaging/rpm/foundationdb.service
     DESTINATION "lib/systemd/system"
-    COMPONENT server-el7)
+    COMPONENT server-el9)
   install(PROGRAMS ${CMAKE_SOURCE_DIR}/packaging/deb/foundationdb-init
     DESTINATION "etc/init.d"
     RENAME "foundationdb"

--- a/documentation/sphinx/source/downloads.rst
+++ b/documentation/sphinx/source/downloads.rst
@@ -12,16 +12,16 @@ macOS
 
 The macOS installation package is supported on macOS 10.7+. It includes the client and (optionally) the server.
 
-* `FoundationDB-7.3.43_x86_64.pkg <https://github.com/apple/foundationdb/releases/download/7.3.43/FoundationDB-7.3.43_x86_64.pkg>`_
-* `FoundationDB-7.3.43_arm64.pkg <https://github.com/apple/foundationdb/releases/download/7.3.43/FoundationDB-7.3.43_arm64.pkg>`_
+* `FoundationDB-7.3.63_x86_64.pkg <https://github.com/apple/foundationdb/releases/download/7.3.63/FoundationDB-7.3.63_x86_64.pkg>`_
+* `FoundationDB-7.3.63_arm64.pkg <https://github.com/apple/foundationdb/releases/download/7.3.63/FoundationDB-7.3.63_arm64.pkg>`_
 
 Ubuntu
 ------
 
 The Ubuntu packages are supported on 64-bit Ubuntu 12.04+, but beware of the Linux kernel bug in Ubuntu 12.x.
 
-* `foundationdb-clients_7.3.43-1_amd64.deb <https://github.com/apple/foundationdb/releases/download/7.3.43/foundationdb-clients_7.3.43-1_amd64.deb>`_
-* `foundationdb-server_7.3.43-1_amd64.deb <https://github.com/apple/foundationdb/releases/download/7.3.43/foundationdb-server_7.3.43-1_amd64.deb>`_ (depends on the clients package)
+* `foundationdb-clients_7.3.63-1_amd64.deb <https://github.com/apple/foundationdb/releases/download/7.3.63/foundationdb-clients_7.3.63-1_amd64.deb>`_
+* `foundationdb-server_7.3.63-1_amd64.deb <https://github.com/apple/foundationdb/releases/download/7.3.63/foundationdb-server_7.3.63-1_amd64.deb>`_ (depends on the clients package)
 
 
 RHEL/CentOS 7
@@ -29,8 +29,8 @@ RHEL/CentOS 7
 
 The RHEL/CentOS EL7 packages are supported on 64-bit RHEL/CentOS 7.x.
 
-* `foundationdb-clients-7.3.43-1.el7.x86_64.rpm <https://github.com/apple/foundationdb/releases/download/7.3.43/foundationdb-clients-7.3.43-1.el7.x86_64.rpm>`_
-* `foundationdb-server-7.3.43-1.el7.x86_64.rpm <https://github.com/apple/foundationdb/releases/download/7.3.43/foundationdb-server-7.3.43-1.el7.x86_64.rpm>`_ (depends on the clients package)
+* `foundationdb-clients-7.3.63-1.el7.x86_64.rpm <https://github.com/apple/foundationdb/releases/download/7.3.63/foundationdb-clients-7.3.63-1.el7.x86_64.rpm>`_
+* `foundationdb-server-7.3.63-1.el7.x86_64.rpm <https://github.com/apple/foundationdb/releases/download/7.3.63/foundationdb-server-7.3.63-1.el7.x86_64.rpm>`_ (depends on the clients package)
 
 Windows
 -------

--- a/documentation/sphinx/source/guide-common.rst.inc
+++ b/documentation/sphinx/source/guide-common.rst.inc
@@ -40,10 +40,10 @@
     foundationdb-server\_\ |release|\ -1\_amd64.deb
 
 .. |package-rpm-clients| replace::
-    foundationdb-clients-|release|\ -1.el7.x86_64.rpm
+    foundationdb-clients-|release|\ -1.el9.x86_64.rpm
 
 .. |package-rpm-server| replace::
-    foundationdb-server-|release|\ -1.el7.x86_64.rpm
+    foundationdb-server-|release|\ -1.el9.x86_64.rpm
 
 .. |package-mac| replace::
     FoundationDB-|release|.pkg

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -55,7 +55,7 @@ RUN curl -Ls https://github.com/krallin/tini/releases/download/v0.19.0/tini-amd6
 
 WORKDIR /
 
-FROM golang:1.22.5-bullseye AS go-build
+FROM docker.io/library/golang:1.22.5-bullseye AS go-build
 
 COPY fdbkubernetesmonitor/ /fdbkubernetesmonitor
 WORKDIR /fdbkubernetesmonitor

--- a/packaging/rpm/buildrpms.sh
+++ b/packaging/rpm/buildrpms.sh
@@ -49,8 +49,8 @@ ln -s ../lib/foundationdb/backup_agent/backup_agent $INSTDIR/usr/bin/dr_agent
 
 (cd $INSTDIR ; tar -czf $TEMPDIR/SOURCES/install-files.tar.gz *)
 
-m4 -DFDBVERSION=$VERSION -DFDBRELEASE=$RELEASE.el7 packaging/rpm/foundationdb.spec.in > $TEMPDIR/SPECS/foundationdb.el7.spec
+m4 -DFDBVERSION=$VERSION -DFDBRELEASE=$RELEASE.el9 packaging/rpm/foundationdb.spec.in > $TEMPDIR/SPECS/foundationdb.el9.spec
 
-fakeroot rpmbuild --quiet --define "%_topdir $TEMPDIR" -bb $TEMPDIR/SPECS/foundationdb.el7.spec
+fakeroot rpmbuild --quiet --define "%_topdir $TEMPDIR" -bb $TEMPDIR/SPECS/foundationdb.el9.spec
 
 cp $TEMPDIR/RPMS/x86_64/*.rpm packages


### PR DESCRIPTION
Fixed issues found when building 7.4 release binaries.

- The Javadoc API version is hard coded.
- Update RPM to be RHEL9
- Fixed a Dockerfile issue: podman doesn't like incomplete URL


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
