### PR TITLE
fdbkubernetesmonitor: Only log error when there is one

### DIFF
--- a/fdbkubernetesmonitor/monitor.go
+++ b/fdbkubernetesmonitor/monitor.go
@@ -225,7 +225,9 @@ func (monitor *monitor) readConfiguration() (*api.ProcessConfiguration, []byte) 
 	}
 	defer func() {
 		err := file.Close()
-		monitor.logger.Error(err, "Error could not close file", "monitorConfigPath", monitor.configFile)
+		if err != nil {
+			monitor.logger.Error(err, "Error could not close file", "monitorConfigPath", monitor.configFile)
+		}
 	}()
 	configuration := &api.ProcessConfiguration{}
 	configurationBytes, err := io.ReadAll(file)


### PR DESCRIPTION
A "Error could not close file" error is logged, even if error is `nil`. This seems like an obvious mistake. I noticed this when looking over my FDB logs.