### PR TITLE
Fix how non local restricted log sets are built.

### DIFF
--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -1820,7 +1820,7 @@ std::vector<Reference<LocalitySet>> TagPartitionedLogSystem::getPushLocationsFor
 		for (int i : fromLocations) {
 			// check if provided location falls within the local logSet's range
 			if (i >= locationOffset && i < locationOffset + log->logServers.size()) {
-				e.emplace_back(LocalityEntry(i));
+				e.emplace_back(LocalityEntry(i - locationOffset));
 			}
 		}
 		restrictedLogSets.push_back(log->logServerSet->restrict(e));


### PR DESCRIPTION
In version vector, a "restricted" locality set is created representing which logs were chosen on the commit proxy. They are returned from the RV in the tpcv structure and numbered 0..n where n is the total # logs on the cluster. However, the locality set object uses a different numbering scheme. Each log in the set is numbered from 0 up to the number of logs in the locality. This bug is not seen with single region tests, only in multi region tests. 

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
