### PR TITLE
ThreadReturnPromiseStream: do ref-counting safely

### DIFF
--- a/fdbrpc/FlowGrpcTests.actor.cpp
+++ b/fdbrpc/FlowGrpcTests.actor.cpp
@@ -86,7 +86,7 @@ TEST_CASE("/fdbrpc/grpc/actor_basic_stream_server") {
 	try {
 		EchoRequest request;
 		request.set_message("Ping!");
-		state FutureStream<EchoResponse> stream = client.call(&TestEchoService::Stub::EchoRecvStream10, request);
+		state ThreadFutureStream<EchoResponse> stream = client.call(&TestEchoService::Stub::EchoRecvStream10, request);
 		while (true) {
 			EchoResponse response = waitNext(stream);
 			ASSERT_EQ(response.message(), "Echo: Ping!");

--- a/fdbrpc/FlowTests.actor.cpp
+++ b/fdbrpc/FlowTests.actor.cpp
@@ -20,7 +20,10 @@
 
 // Unit tests for the flow language and libraries
 
+#include <chrono>
+#include <thread>
 #include "flow/Arena.h"
+#include "flow/Error.h"
 #include "flow/ProtocolVersion.h"
 #include "flow/UnitTest.h"
 #include "flow/DeterministicRandom.h"
@@ -29,6 +32,7 @@
 #include "fdbrpc/fdbrpc.h"
 #include "flow/IAsyncFile.h"
 #include "flow/TLSConfig.actor.h"
+#include "fdbrpc/grpc/AsyncTaskExecutor.h"
 #include "flow/actorcompiler.h" // This must be the last #include.
 
 void forceLinkFlowTests() {}
@@ -1606,6 +1610,178 @@ TEST_CASE("/flow/flow/FlowMutex") {
 	} catch (Error& e) {
 		printf("Error at count=%d\n", count + 1);
 		ASSERT(false);
+	}
+
+	return Void();
+}
+
+using namespace std::chrono_literals;
+
+TEST_CASE("/flow/thread/ThreadReturnPromiseStream_Simple") {
+	state AsyncTaskExecutor exc(1);
+	ThreadReturnPromiseStream<int> stream;
+	state ThreadFutureStream<int> f = stream.getFuture();
+	state Future<Void> t = exc.post([stream = std::move(stream)]() mutable {
+		for (int i = 0; i < 10; ++i) {
+			stream.send(i);
+			std::cout << "Sent: " << i << std::endl;
+			std::this_thread::sleep_for(10ms);
+		}
+		stream.sendError(end_of_stream());
+		return Void();
+	});
+
+	state int n = 0;
+	while (true) {
+		try {
+			state int i = waitNext(f);
+			std::cout << "Got: " << i << std::endl;
+			wait(delay(0.1));
+			ASSERT(i == n);
+			++n;
+		} catch (Error& e) {
+			ASSERT(e.code() == error_code_end_of_stream);
+			ASSERT(n == 10);
+			break;
+		}
+	}
+
+	wait(t);
+	return Void();
+}
+
+TEST_CASE("/flow/thread/ThreadReturnPromiseStream_Seq") {
+	state AsyncTaskExecutor exc(1);
+	ThreadReturnPromiseStream<int> stream;
+	state ThreadFutureStream<int> f = stream.getFuture();
+	state Future<Void> t = exc.post([stream = std::move(stream)]() mutable {
+		for (int i = 0; i <= 3; ++i) {
+			stream.send(i);
+			std::this_thread::sleep_for(100ms);
+		}
+		stream.sendError(end_of_stream());
+		return Void();
+	});
+
+	state int n = 0;
+	int r0 = waitNext(f);
+	ASSERT(r0 == 0);
+	int r1 = waitNext(f);
+	ASSERT(r1 == 1);
+	int r2 = waitNext(f);
+	ASSERT(r2 == 2);
+	wait(delay(1.0));
+	int r3 = waitNext(f);
+	ASSERT(r3 == 3);
+	wait(t);
+	return Void();
+}
+
+TEST_CASE("/flow/thread/ThreadReturnPromiseStream_Error") {
+	state AsyncTaskExecutor exc(1);
+
+	{
+		ThreadReturnPromiseStream<int> s1;
+		state ThreadFutureStream<int> f1 = s1.getFuture();
+		state Future<Void> t1 = exc.post([s1 = std::move(s1)]() mutable {
+			std::this_thread::sleep_for(2s);
+			return Void();
+		});
+
+		try {
+			int _ = waitNext(f1);
+			ASSERT(false);
+		} catch (Error& e) {
+			ASSERT(e.code() == error_code_broken_promise);
+		}
+
+		wait(t1);
+	}
+
+	{
+		ThreadReturnPromiseStream<int> s2;
+		state ThreadFutureStream<int> f2 = s2.getFuture();
+		state Future<Void> t2 = exc.post([s2 = std::move(s2)]() mutable {
+			std::this_thread::sleep_for(2s);
+			s2.sendError(transaction_too_old());
+			return Void();
+		});
+
+		try {
+			int _ = waitNext(f2);
+			ASSERT(false);
+		} catch (Error& e) {
+			ASSERT(e.code() == error_code_transaction_too_old);
+		}
+
+		wait(t2);
+	}
+
+	return Void();
+}
+
+TEST_CASE("/flow/IThreadPool/ThreadReturnPromiseStream_DestroyPromise") {
+	{
+		std::cout << "ThreadReturnPromiseStream with future > 0, promise == 0, end_of_stream sent\n";
+		// After all references to PromiseStream are gone, FutureStream should still be able to get
+		// all the values if PromiseStream had reached end_of_stream.
+		state ThreadFutureStream<int> fs1 = ([]() {
+			ThreadReturnPromiseStream<int> p;
+			auto ret = p.getFuture();
+			for (int i = 0; i < 10; i++) {
+				p.send(i);
+			}
+			p.sendError(end_of_stream());
+			ASSERT(p.getFutureReferenceCount() == 1);
+			return ret;
+		})();
+
+		wait(delay(1));
+
+		state int recvd = 0;
+		try {
+			while (true) {
+				int _ = waitNext(fs1);
+				recvd += 1;
+			}
+		} catch (Error& err) {
+			if (err.code() == error_code_end_of_stream) {
+				ASSERT_EQ(recvd, 10);
+			} else {
+				ASSERT(false);
+			}
+		}
+	}
+
+	std::cout << "ThreadReturnPromiseStream with future > 0,  promise == 0, no end_of_stream\n";
+	{
+		// After all references to PromiseStream are gone, but the stream was not ended cleanly
+		// by sending end_of_stream, we should instead get broken_promise.
+		state ThreadFutureStream<int> fs2 = ([]() {
+			ThreadReturnPromiseStream<int> p;
+			auto ret = p.getFuture();
+			for (int i = 0; i < 10; i++) {
+				p.send(i);
+			}
+			ASSERT(p.getFutureReferenceCount() == 1);
+			return ret;
+		})();
+
+		wait(delay(1));
+
+		try {
+			while (true) {
+				choose {
+					when(int _ = waitNext(fs2)) {}
+					when(wait(delay(1))) {
+						ASSERT(false); // shouldn't hangup if end_of_stream is not sent.
+						break;
+					}
+				}
+			}
+		} catch (Error& err) {
+			ASSERT(err.code() == error_code_broken_promise);
+		}
 	}
 
 	return Void();

--- a/fdbrpc/include/fdbrpc/grpc/AsyncGrpcClient.h
+++ b/fdbrpc/include/fdbrpc/grpc/AsyncGrpcClient.h
@@ -117,7 +117,8 @@ public:
 	// NOTE: Must be called from network thread. This is because the underlying primitive used
 	//   is ThreadReturnPromise.
 	template <class RequestType, class ResponseType>
-	FutureStream<ResponseType> call(ServerStreamingRpcFn<RequestType, ResponseType> rpc, const RequestType& request) {
+	ThreadFutureStream<ResponseType> call(ServerStreamingRpcFn<RequestType, ResponseType> rpc,
+	                                      const RequestType& request) {
 		ASSERT_WE_THINK(g_network->isOnMainThread());
 		auto promise = ThreadReturnPromiseStream<ResponseType>();
 		auto future = promise.getFuture();

--- a/fdbrpc/include/fdbrpc/grpc/AsyncTaskExecutor.h
+++ b/fdbrpc/include/fdbrpc/grpc/AsyncTaskExecutor.h
@@ -18,7 +18,6 @@
  * limitations under the License.
  */
 
-#ifdef FLOW_GRPC_ENABLED
 #ifndef FDBRPC_FLOW_GRPC_THREAD_POOL_H
 #define FDBRPC_FLOW_GRPC_THREAD_POOL_H
 
@@ -121,7 +120,7 @@ private:
 // `ThreadAction` implementation for tasks that return non-void values.
 template <typename Func>
 struct AsyncTaskExecutor::Action<Func, typename std::enable_if_t<!IsVoidReturn<Func>>> : ThreadAction {
-	using Ret = std::invoke_result<Func>::type;
+	using Ret = typename std::invoke_result<Func>::type;
 
 	Action(Func&& fn) : fn_(std::move(fn)) {}
 
@@ -158,7 +157,7 @@ private:
 // `ThreadAction` implementation for tasks that return void.
 template <typename Func>
 struct AsyncTaskExecutor::Action<Func, typename std::enable_if_t<IsVoidReturn<Func>>> : ThreadAction {
-	using Ret = std::invoke_result<Func>::type;
+	using Ret = typename std::invoke_result<Func>::type;
 
 	Action(Func&& fn) : fn_(std::move(fn)) {}
 
@@ -178,4 +177,3 @@ private:
 };
 
 #endif // FDBRPC_FLOW_GRPC_THREAD_POOL_H
-#endif // FLOW_GRPC_ENABLED

--- a/fdbserver/KeyValueStoreRocksDB.actor.cpp
+++ b/fdbserver/KeyValueStoreRocksDB.actor.cpp
@@ -363,7 +363,7 @@ std::string getErrorReason(BackgroundErrorReason reason) {
 // could potentially cause segmentation fault.
 class RocksDBErrorListener : public rocksdb::EventListener {
 public:
-	RocksDBErrorListener(UID id) : id(id){};
+	RocksDBErrorListener(UID id) : id(id) {};
 	void OnBackgroundError(rocksdb::BackgroundErrorReason reason, rocksdb::Status* bg_error) override {
 		TraceEvent(SevError, "RocksDBBGError", id)
 		    .detail("Reason", getErrorReason(reason))
@@ -403,7 +403,7 @@ private:
 
 class RocksDBEventListener : public rocksdb::EventListener {
 public:
-	RocksDBEventListener(std::shared_ptr<SharedRocksDBState> sharedState) : sharedState(sharedState){};
+	RocksDBEventListener(std::shared_ptr<SharedRocksDBState> sharedState) : sharedState(sharedState) {};
 
 	void OnFlushCompleted(rocksdb::DB* db, const rocksdb::FlushJobInfo& info) override {
 		sharedState->setLastFlushTime(now());

--- a/flow/IThreadPoolTest.actor.cpp
+++ b/flow/IThreadPoolTest.actor.cpp
@@ -133,7 +133,7 @@ TEST_CASE("/flow/IThreadPool/ThreadReturnPromiseStream") {
 		pool->post(a);
 	}
 
-	state FutureStream<std::string> futs = notifications->getFuture();
+	state ThreadFutureStream<std::string> futs = notifications->getFuture();
 
 	state int n = 0;
 	while (n < num) {

--- a/flow/actorcompiler/ActorCompiler.cs
+++ b/flow/actorcompiler/ActorCompiler.cs
@@ -977,6 +977,8 @@ namespace actorcompiler
                 LineNumber(cx.target, ch.Stmt.wait.FirstSourceLine);
                 if (ch.Stmt.wait.isWaitNext) {
                     cx.target.WriteLine("auto {0} = {1};", ch.Future, ch.Stmt.wait.futureExpression);
+                    cx.target.WriteLine("static_assert(std::is_same<decltype({0}), FutureStream<{1}>>::value || std::is_same<decltype({0}), ThreadFutureStream<{1}>>::value, \"invalid type\");", ch.Future, ch.Stmt.wait.result.type);
+
                 } else {
                     cx.target.WriteLine("{2}<{3}> {0} = {1};", ch.Future, ch.Stmt.wait.futureExpression, "StrictFuture", ch.Stmt.wait.result.type);
                 }

--- a/flow/actorcompiler/ActorCompiler.cs
+++ b/flow/actorcompiler/ActorCompiler.cs
@@ -975,7 +975,11 @@ namespace actorcompiler
             {
                 string getFunc = ch.Stmt.wait.isWaitNext ? "pop" : "get";
                 LineNumber(cx.target, ch.Stmt.wait.FirstSourceLine);
-                cx.target.WriteLine("{2}<{3}> {0} = {1};", ch.Future, ch.Stmt.wait.futureExpression, ch.Stmt.wait.isWaitNext ? "FutureStream" : "StrictFuture", ch.Stmt.wait.result.type);
+                if (ch.Stmt.wait.isWaitNext) {
+                    cx.target.WriteLine("auto {0} = {1};", ch.Future, ch.Stmt.wait.futureExpression);
+                } else {
+                    cx.target.WriteLine("{2}<{3}> {0} = {1};", ch.Future, ch.Stmt.wait.futureExpression, "StrictFuture", ch.Stmt.wait.result.type);
+                }
 
                 if (firstChoice)
                 {

--- a/flow/include/flow/FlowThread.h
+++ b/flow/include/flow/FlowThread.h
@@ -294,4 +294,10 @@ private:
 	ThreadNotifiedQueue<T>* queue;
 };
 
+// Fixes IDE build.
+#ifndef NO_INTELLISENSE
+template <class T>
+T waitNext(const ThreadFutureStream<T>&);
+#endif
+
 #endif

--- a/flow/include/flow/FlowThread.h
+++ b/flow/include/flow/FlowThread.h
@@ -89,7 +89,7 @@ public:
 
 		addPromiseRef();
 		onMainThreadVoid([this, value = std::forward<U>(value)]() {
-			ScopeExit scope([&]() {this->delPromiseRef(); });
+			ScopeExit scope([&]() { this->delPromiseRef(); });
 			mutex.enter();
 			if (this->next != this) {
 				auto n = this->next;

--- a/flow/include/flow/FlowThread.h
+++ b/flow/include/flow/FlowThread.h
@@ -1,0 +1,294 @@
+/*
+ * FlowThread.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FLOW_FLOW_THREAD_H
+#define FLOW_FLOW_THREAD_H
+#include "flow/Buggify.h"
+#pragma once
+
+#include <flow/flow.h>
+#include <flow/FastAlloc.h>
+#include <flow/ThreadPrimitives.h>
+#include <flow/ThreadHelper.actor.h>
+
+// NOTE: Currently futures should only be used from main thread.
+template <class T>
+class ThreadNotifiedQueue : private SingleCallback<T>, public FastAllocated<ThreadNotifiedQueue<T>> {
+public:
+	int promises;
+	int futures;
+	Error error;
+
+	// Invariant: SingleCallback<T>::next==this || (queue.empty() && !error.isValid())
+	std::queue<T, Deque<T>> queue;
+	ThreadSpinLock mutex;
+
+	ThreadNotifiedQueue(int futures, int promises) : promises(promises), futures(futures) {
+		SingleCallback<T>::next = this;
+	}
+
+	virtual ~ThreadNotifiedQueue() = default;
+
+	bool isReady() {
+		ThreadSpinLockHolder holder(mutex);
+		return !queue.empty() || error.isValid();
+	}
+
+	bool isError() {
+		ThreadSpinLockHolder holder(mutex);
+		return queue.empty() && error.isValid();
+	} // the *next* thing queued is an error
+
+	bool hasError() {
+		ThreadSpinLockHolder holder(mutex);
+		return error.isValid();
+	} // there is an error queued
+
+	uint32_t size() {
+		ThreadSpinLockHolder holder(mutex);
+		return queue.size();
+	}
+
+	virtual T pop() {
+		ThreadSpinLockHolder holder(mutex);
+		if (queue.empty()) {
+			if (error.isValid())
+				throw error;
+			throw internal_error();
+		}
+		auto copy = std::move(queue.front());
+		queue.pop();
+		return copy;
+	}
+
+	template <class U>
+	void send(U&& value) {
+		if (error.isValid())
+			return;
+
+		addPromiseRef();
+		onMainThreadVoid([this, value = std::forward<U>(value)]() {
+			mutex.enter();
+			if (this->next != this) {
+				auto n = this->next;
+				mutex.leave();
+				n->fire(value);
+			} else {
+				this->queue.emplace(value);
+				mutex.leave();
+			}
+			this->delPromiseRef();
+		});
+	}
+
+	void sendError(Error err) {
+		if (error.isValid())
+			return;
+
+		ASSERT(this->error.code() != error_code_success);
+		this->error = err;
+
+		addPromiseRef();
+		onMainThreadVoid([this, err]() {
+			// end_of_stream error is "expected", don't terminate reading stream early for this
+			SingleCallback<T>* n = nullptr;
+			{
+				ThreadSpinLockHolder holder(mutex);
+				if (this->shouldFireImmediatelyUnsafe()) {
+					n = this->next;
+				}
+			}
+
+			if (n)
+				n->error(err);
+
+			this->delPromiseRef();
+		});
+	}
+
+	void addPromiseRef() {
+		ThreadSpinLockHolder holder(mutex);
+		promises++;
+	}
+
+	void addFutureRef() {
+		ThreadSpinLockHolder holder(mutex);
+		futures++;
+	}
+
+	void delPromiseRef() {
+		mutex.enter();
+		if (!--promises) {
+			if (futures) {
+				mutex.leave();
+				sendError(broken_promise());
+			} else {
+				mutex.leave();
+				destroy();
+			}
+		} else {
+			mutex.leave();
+		}
+	}
+
+	void delFutureRef() {
+		mutex.enter();
+		if (!--futures) {
+			if (promises) {
+				mutex.leave();
+				cancel();
+			} else {
+				mutex.leave();
+				destroy();
+			}
+		} else {
+			mutex.leave();
+		}
+	}
+
+	int getFutureReferenceCount() {
+		ThreadSpinLockHolder holder(mutex);
+		return futures;
+	}
+
+	int getPromiseReferenceCount() {
+		ThreadSpinLockHolder holder(mutex);
+		return promises;
+	}
+
+	void addCallbackAndDelFutureRef(SingleCallback<T>* cb) {
+		ThreadSpinLockHolder holder(mutex);
+		ASSERT(SingleCallback<T>::next == this);
+		cb->insert(this);
+	}
+
+	virtual void destroy() { delete this; }
+	virtual void cancel() {}
+	virtual void unwait() override { delFutureRef(); }
+	virtual void fire(T const&) override { ASSERT(false); }
+	virtual void fire(T&&) override { ASSERT(false); }
+
+protected:
+	bool shouldFireImmediatelyUnsafe() { return SingleCallback<T>::next != this; }
+};
+
+template <class T>
+class ThreadFutureStream {
+public:
+	ThreadFutureStream() : queue(nullptr) {}
+	ThreadFutureStream(const ThreadFutureStream& rhs) : queue(rhs.queue) { queue->addFutureRef(); }
+	ThreadFutureStream(ThreadFutureStream&& rhs) noexcept : queue(rhs.queue) { rhs.queue = 0; }
+	explicit ThreadFutureStream(ThreadNotifiedQueue<T>* queue) : queue(queue) {}
+	~ThreadFutureStream() {
+		if (queue)
+			queue->delFutureRef();
+	}
+
+	bool isValid() const { return queue != nullptr; }
+	bool isReady() const { return queue->isReady(); }
+	bool isError() const {
+		// This means that the next thing to be popped is an error - it will be false if there is an
+		// error in the stream but some actual data first
+		return queue->isError();
+	}
+
+	void addCallbackAndClear(SingleCallback<T>* cb) {
+		queue->addCallbackAndDelFutureRef(cb);
+		queue = nullptr;
+	}
+
+	void operator=(const ThreadFutureStream& rhs) {
+		rhs.queue->addFutureRef();
+		if (queue)
+			queue->delFutureRef();
+		queue = rhs.queue;
+	}
+
+	void operator=(ThreadFutureStream&& rhs) noexcept {
+		if (rhs.queue != queue) {
+			if (queue)
+				queue->delFutureRef();
+			queue = rhs.queue;
+			rhs.queue = nullptr;
+		}
+	}
+
+	bool operator==(const ThreadFutureStream& rhs) { return rhs.queue == queue; }
+	bool operator!=(const ThreadFutureStream& rhs) { return rhs.queue != queue; }
+
+	T pop() {
+		ASSERT(g_network->isOnMainThread());
+		return queue->pop();
+	}
+
+	Error getError() const {
+		// TODO: (vishesh)
+		ASSERT(queue->isError());
+		return queue->error;
+	}
+
+private:
+	ThreadNotifiedQueue<T>* queue;
+};
+
+template <class T>
+class ThreadReturnPromiseStream {
+public:
+	ThreadReturnPromiseStream() : queue(new ThreadNotifiedQueue<T>(0, 1)) {}
+	ThreadReturnPromiseStream(const ThreadReturnPromiseStream& rhs) = delete;
+	ThreadReturnPromiseStream(ThreadReturnPromiseStream&& rhs) noexcept : queue(rhs.queue) { rhs.queue = 0; }
+	~ThreadReturnPromiseStream() {
+		if (queue)
+			queue->delPromiseRef();
+	}
+
+	void send(const T& value) { queue->send(value); }
+	void send(T&& value) { queue->send(std::forward<T>(value)); }
+	void sendError(Error error) { queue->sendError(error); }
+
+	ThreadFutureStream<T> getFuture() {
+		queue->addFutureRef(); // TODO: (vishesh) - put it in constructor.
+		return ThreadFutureStream<T>(queue);
+	}
+
+	void operator=(const ThreadReturnPromiseStream& rhs) {
+		rhs.queue->addPromiseRef();
+		if (queue)
+			queue->delPromiseRef();
+		queue = rhs.queue;
+	}
+
+	void operator=(ThreadReturnPromiseStream&& rhs) noexcept {
+		if (queue != rhs.queue) {
+			if (queue)
+				queue->delPromiseRef();
+			queue = rhs.queue;
+			rhs.queue = 0;
+		}
+	}
+
+	int getFutureReferenceCount() const { return queue->getFutureReferenceCount(); }
+	int getPromiseReferenceCount() const { return queue->getPromiseReferenceCount(); }
+
+private:
+	ThreadNotifiedQueue<T>* queue;
+};
+
+#endif

--- a/flow/include/flow/ThreadPrimitives.h
+++ b/flow/include/flow/ThreadPrimitives.h
@@ -107,13 +107,13 @@ public:
 
 class ThreadUnsafeSpinLock {
 public:
-	void enter(){};
-	void leave(){};
-	void assertNotEntered(){};
+	void enter() {};
+	void leave() {};
+	void assertNotEntered() {};
 };
 class ThreadUnsafeSpinLockHolder {
 public:
-	ThreadUnsafeSpinLockHolder(ThreadUnsafeSpinLock&){};
+	ThreadUnsafeSpinLockHolder(ThreadUnsafeSpinLock&) {};
 };
 
 #if FLOW_THREAD_SAFE

--- a/flow/include/flow/ThreadPrimitives.h
+++ b/flow/include/flow/ThreadPrimitives.h
@@ -101,18 +101,19 @@ class ThreadSpinLockHolder {
 
 public:
 	ThreadSpinLockHolder(ThreadSpinLock& lock) : lock(lock) { lock.enter(); }
+	ThreadSpinLockHolder(const ThreadSpinLockHolder& lock) = delete;
 	~ThreadSpinLockHolder() { lock.leave(); }
 };
 
 class ThreadUnsafeSpinLock {
 public:
-	void enter() {};
-	void leave() {};
-	void assertNotEntered() {};
+	void enter(){};
+	void leave(){};
+	void assertNotEntered(){};
 };
 class ThreadUnsafeSpinLockHolder {
 public:
-	ThreadUnsafeSpinLockHolder(ThreadUnsafeSpinLock&) {};
+	ThreadUnsafeSpinLockHolder(ThreadUnsafeSpinLock&){};
 };
 
 #if FLOW_THREAD_SAFE


### PR DESCRIPTION
The original `ThreadReturnPromiseStream` didn't handle reference counting
in a thread-safe way. This led to subtle and hard-to-debug race conditions, especially since Future
and Promise often live on different threads in this use case.

This patch introduces a new implementation of ThreadReturnPromiseStream that uses an atomics backed
spinlock to safely manage reference counts. As a result, the Flow compiler also needs to support a
new type: `ThreadFutureStream`, in addition to the existing `FutureStream`.

The underlying `NotifiedQueue` now has a parallel implementation called `ThreadNotifiedQueue` to
make this possible. The higher-level thread-safe promise and promise counterpart are built on top of
that.

The new `ThreadFutureStream` is compatible with both Flow and C++ coroutines. The original
non-threaded Flow primitives remain untouched and free from the overhead of atomics.

*Joshua:*

  20250417-000356-vishesh-16ce18efeab40158           compressed=True data_size=41124943 duration=5436274 ended=99998 fail=1 fail_fast=10 max_runs=100000 pass=99997 priority=100 remaining=0:00:00 runtime=1:00:47 sanity=False started=100000 submitted=20250417-000356 timeout=5400 username=vishesh


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
