### PR TITLE
foundationdb-pr-macos-m1 on macOS Ventura 13.x fails downloading jar

### DIFF
--- a/bindings/java/CMakeLists.txt
+++ b/bindings/java/CMakeLists.txt
@@ -322,33 +322,31 @@ if(NOT OPEN_FOR_IDE)
     else()
       set(JUNIT_JARS "${CMAKE_BINARY_DIR}/packages")
       # We use Junit libraries for both JUnit and integration testing structures, so download in either case
-      # https://search.maven.org/remotecontent?filepath=org/junit/jupiter/junit-jupiter-engine/5.7.1/junit-jupiter-engine-5.7.1.jar
-      file(DOWNLOAD "https://search.maven.org/remotecontent?filepath=org/junit/jupiter/junit-jupiter-engine/5.7.1/junit-jupiter-engine-5.7.1.jar"
+      file(DOWNLOAD "https://repo1.maven.org/maven2/org/junit/jupiter/junit-jupiter-engine/5.7.1/junit-jupiter-engine-5.7.1.jar"
         ${JUNIT_JARS}/junit-jupiter-engine-5.7.1.jar
         EXPECTED_HASH SHA256=56616c9350b3624f76cffef6b24ce7bb222915bfd5688f96d3cf4cef34f077cb)
-      # https://search.maven.org/remotecontent?filepath=org/junit/jupiter/junit-jupiter-api/5.7.1/junit-jupiter-api-5.7.1.jar
-      file(DOWNLOAD "https://search.maven.org/remotecontent?filepath=org/junit/jupiter/junit-jupiter-api/5.7.1/junit-jupiter-api-5.7.1.jar"
+      file(DOWNLOAD "https://repo1.maven.org/maven2/org/junit/jupiter/junit-jupiter-api/5.7.1/junit-jupiter-api-5.7.1.jar"
         ${JUNIT_JARS}/junit-jupiter-api-5.7.1.jar
         EXPECTED_HASH SHA256=ce7b985bc469e2625759a4ebc45533c70581a05a348278c1d6408e9b2e35e314)
-      file(DOWNLOAD "https://search.maven.org/remotecontent?filepath=org/junit/jupiter/junit-jupiter-params/5.7.1/junit-jupiter-params-5.7.1.jar"
+      file(DOWNLOAD "https://repo1.maven.org/maven2/org/junit/jupiter/junit-jupiter-params/5.7.1/junit-jupiter-params-5.7.1.jar"
         ${JUNIT_JARS}/junit-jupiter-params-5.7.1.jar
         EXPECTED_HASH SHA256=8effdd7f8a4ba5558b568184dee08008b2443c86c673ef81de5861fbc7ef0613)
-      file(DOWNLOAD "https://search.maven.org/remotecontent?filepath=org/junit/platform/junit-platform-commons/1.7.1/junit-platform-commons-1.7.1.jar"
+      file(DOWNLOAD "https://repo1.maven.org/maven2/org/junit/platform/junit-platform-commons/1.7.1/junit-platform-commons-1.7.1.jar"
         ${JUNIT_JARS}/junit-platform-commons-1.7.1.jar
         EXPECTED_HASH SHA256=7c546be86864718fbaceb79fa84ff1d3a516500fc428f1b21d061c2e0fbc5a4b)
-      file(DOWNLOAD "https://search.maven.org/remotecontent?filepath=org/junit/platform/junit-platform-engine/1.7.1/junit-platform-engine-1.7.1.jar"
+      file(DOWNLOAD "https://repo1.maven.org/maven2/org/junit/platform/junit-platform-engine/1.7.1/junit-platform-engine-1.7.1.jar"
         ${JUNIT_JARS}/junit-platform-engine-1.7.1.jar
         EXPECTED_HASH SHA256=37df5a9cd6dbc1f754ba2b46f96b8874a83660e1796bf38c738f022dcf86c23f)
-      file(DOWNLOAD "https://search.maven.org/remotecontent?filepath=org/junit/platform/junit-platform-launcher/1.7.1/junit-platform-launcher-1.7.1.jar"
+      file(DOWNLOAD "https://repo1.maven.org/maven2/org/junit/platform/junit-platform-launcher/1.7.1/junit-platform-launcher-1.7.1.jar"
         ${JUNIT_JARS}/junit-platform-launcher-1.7.1.jar
         EXPECTED_HASH SHA256=3122ac6fb284bc50e3afe46419fc977f94d580e9d3d1ea58805d200b510a99ee)
-      file(DOWNLOAD "https://search.maven.org/remotecontent?filepath=org/junit/platform/junit-platform-console/1.7.1/junit-platform-console-1.7.1.jar"
+      file(DOWNLOAD "https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console/1.7.1/junit-platform-console-1.7.1.jar"
         ${JUNIT_JARS}/junit-platform-console-1.7.1.jar
         EXPECTED_HASH SHA256=11ed48fcdfcea32f2fa98872db7ecba2d49d178f76493e7a149a2242363ad12e)
-      file(DOWNLOAD "https://search.maven.org/remotecontent?filepath=org/apiguardian/apiguardian-api/1.1.1/apiguardian-api-1.1.1.jar"
+      file(DOWNLOAD "https://repo1.maven.org/maven2/org/apiguardian/apiguardian-api/1.1.1/apiguardian-api-1.1.1.jar"
         ${JUNIT_JARS}/apiguardian-api-1.1.1.jar
         EXPECTED_HASH SHA256=fc68f0d28633caccf3980fdf1e99628fba9c49424ee56dc685cd8b4d2a9fefde)
-      file(DOWNLOAD "https://search.maven.org/remotecontent?filepath=org/opentest4j/opentest4j/1.2.0/opentest4j-1.2.0.jar"
+      file(DOWNLOAD "https://repo1.maven.org/maven2/org/opentest4j/opentest4j/1.2.0/opentest4j-1.2.0.jar"
         ${JUNIT_JARS}/opentest4j-1.2.0.jar)
     endif()
 

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -9056,6 +9056,7 @@ ACTOR Future<Void> fetchKeys(StorageServer* data, AddingShard* shard) {
 				// Test using GRV version for fetchKey.
 				lastError = transaction_too_old();
 			}
+
 			if (lastError.code() == error_code_transaction_too_old) {
 				try {
 					Version grvVersion = wait(tr.getRawReadVersion());


### PR DESCRIPTION
cmake is not following the redirect. Trying repo1.maven.org instead of search.maven.org (works locally -- see if it works up here in ci/cd).  Here is the error:

```

-- Building fat jar to /Users/ec2-user/foundationdb_build_output_macos_x86_64/packages
CMake Error at bindings/java/CMakeLists.txt:339 (file):
  file DOWNLOAD HASH mismatch

    for file: [/Users/ec2-user/foundationdb_build_output_macos_x86_64/packages/junit-platform-engine-1.7.1.jar]
      expected hash: [37df5a9cd6dbc1f754ba2b46f96b8874a83660e1796bf38c738f022dcf86c23f]
        actual hash: [e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855]
             status: [22;"HTTP response code said error"]



CMake Error at bindings/java/CMakeLists.txt:348 (file):
  file DOWNLOAD HASH mismatch

    for file: [/Users/ec2-user/foundationdb_build_output_macos_x86_64/packages/apiguardian-api-1.1.1.jar]
      expected hash: [fc68f0d28633caccf3980fdf1e99628fba9c49424ee56dc685cd8b4d2a9fefde]
        actual hash: [e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855]
             status: [22;"HTTP response code said error"]

```

On the command line, when I run the download of jars... I see we are being asked to redirect:


```
  curl -I https://search.maven.org/remotecontent?filepath=org/junit/platform/junit-platform-engine/1.7.1/junit-platform-engine-1.7.1.jar
HTTP/1.1 200 Connection established

HTTP/2 302
date: Thu, 24 Apr 2025 15:20:36 GMT
content-type: text/html
content-length: 138
location: https://repo1.maven.org/maven2/org/junit/platform/junit-platform-engine/1.7.1/junit-platform-engine-1.7.1.jar
server: nginx
x-request_uri: /remotecontent?filepath=org/junit/platform/junit-platform-engine/1.7.1/junit-platform-engine-1.7.1.jar
x-query_string: filepath=org/junit/platform/junit-platform-engine/1.7.1/junit-platform-engine-1.7.1.jar

```

If I use repo1.maven.org instead of search.maven.org, the download succeeds.
