### PR TITLE
DD BulkLoadTask Load Balance

### DIFF
--- a/fdbclient/include/fdbclient/StorageServerInterface.h
+++ b/fdbclient/include/fdbclient/StorageServerInterface.h
@@ -1138,12 +1138,22 @@ struct GetStorageMetricsReply {
 	int64_t versionLag = 0;
 	double lastUpdate = 0;
 	int64_t bytesDurable = 0, bytesInput = 0;
+	int ongoingBulkLoadTaskCount = 0;
 
 	GetStorageMetricsReply() = default;
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, load, available, capacity, bytesInputRate, versionLag, lastUpdate, bytesDurable, bytesInput);
+		serializer(ar,
+		           load,
+		           available,
+		           capacity,
+		           bytesInputRate,
+		           versionLag,
+		           lastUpdate,
+		           bytesDurable,
+		           bytesInput,
+		           ongoingBulkLoadTaskCount);
 	}
 };
 

--- a/fdbserver/DDRelocationQueue.actor.cpp
+++ b/fdbserver/DDRelocationQueue.actor.cpp
@@ -301,6 +301,18 @@ public:
 		return maxQueueSize;
 	}
 
+	Optional<int> getMaxOngoingBulkLoadTaskCount() const override {
+		int maxOngoingBulkLoadTaskCount = 0;
+		for (const auto& team : teams) {
+			Optional<int> ongoingBulkLoadTaskCount = team->getMaxOngoingBulkLoadTaskCount();
+			if (!ongoingBulkLoadTaskCount.present()) {
+				return Optional<int>();
+			}
+			maxOngoingBulkLoadTaskCount = std::max(maxOngoingBulkLoadTaskCount, ongoingBulkLoadTaskCount.get());
+		}
+		return maxOngoingBulkLoadTaskCount;
+	}
+
 	int64_t getMinAvailableSpace(bool includeInFlight = true) const override {
 		int64_t result = std::numeric_limits<int64_t>::max();
 		for (const auto& team : teams) {
@@ -1867,6 +1879,9 @@ ACTOR Future<Void> dataDistributionRelocator(DDQueue* self,
 				// once we've found healthy candidate teams, make sure they're not overloaded with outstanding moves
 				// already
 				anyDestOverloaded = !canLaunchDest(bestTeams, rd.priority, self->destBusymap);
+				if (doBulkLoading) {
+					anyDestOverloaded = false;
+				}
 
 				if (foundTeams && anyHealthy && !anyDestOverloaded) {
 					ASSERT(rd.completeDests.empty());

--- a/fdbserver/DDRelocationQueue.actor.cpp
+++ b/fdbserver/DDRelocationQueue.actor.cpp
@@ -306,6 +306,8 @@ public:
 		for (const auto& team : teams) {
 			Optional<int> ongoingBulkLoadTaskCount = team->getMaxOngoingBulkLoadTaskCount();
 			if (!ongoingBulkLoadTaskCount.present()) {
+				// If a SS tracker cannot get the metrics from the SS, it is possible that this SS has some healthy
+				// issue. So, return an empty result to avoid choosing this server.
 				return Optional<int>();
 			}
 			maxOngoingBulkLoadTaskCount = std::max(maxOngoingBulkLoadTaskCount, ongoingBulkLoadTaskCount.get());

--- a/fdbserver/DDTeamCollection.actor.cpp
+++ b/fdbserver/DDTeamCollection.actor.cpp
@@ -283,17 +283,6 @@ public:
 
 			// Step 2: Conduct Power-of-D-Choice to select a team
 			std::vector<Reference<TCTeamInfo>> candidateTeams;
-
-			/*int nTries = 0;
-			while (candidateTeams.size() < std::min(SERVER_KNOBS->BEST_TEAM_OPTION_COUNT, int(validTeams.size())) &&
-			       nTries < SERVER_KNOBS->BEST_TEAM_MAX_TEAM_TRIES) {
-			    Reference<TCTeamInfo> dest = deterministicRandom()->randomChoice(validTeams);
-			    if (std::find(candidateTeams.begin(), candidateTeams.end(), dest) == candidateTeams.end()) {
-			        candidateTeams.push_back(dest);
-			    }
-			    nTries++;
-			}*/
-
 			if (validTeams.size() <= 4) {
 				candidateTeams = validTeams;
 			} else {

--- a/fdbserver/DDTeamCollection.actor.cpp
+++ b/fdbserver/DDTeamCollection.actor.cpp
@@ -231,10 +231,12 @@ public:
 
 			self->updateTeamPivotValues();
 
-			std::vector<Reference<TCTeamInfo>> candidateTeams;
+			// Step 1: find all valid teams from team collection
+			std::vector<Reference<TCTeamInfo>> validTeams;
 			int unhealthyTeamCount = 0;
 			int notEligibileTeamCount = 0;
 			int duplicatedCount = 0;
+			int failToGetMetricsCount = 0;
 			for (const auto& dest : self->teams) {
 				if (!dest->isHealthy()) {
 					unhealthyTeamCount++;
@@ -253,6 +255,12 @@ public:
 						continue;
 					}
 				}
+				Optional<int> ongoingBulkLoadTaskCount = dest->getMaxOngoingBulkLoadTaskCount();
+				if (!ongoingBulkLoadTaskCount.present()) {
+					// This team may have an unhealthy SS, so avoid selecting it
+					failToGetMetricsCount++;
+					continue;
+				}
 				bool ok = true;
 				for (const auto& srcId : req.src) {
 					std::vector<UID> serverIds = dest->getServerIDs();
@@ -270,20 +278,54 @@ public:
 					duplicatedCount++;
 					continue;
 				}
-				candidateTeams.push_back(dest);
+				validTeams.push_back(dest);
 			}
+
+			// Step 2: Conduct Power-of-D-Choice to select a team
+			std::vector<Reference<TCTeamInfo>> candidateTeams;
+
+			/*int nTries = 0;
+			while (candidateTeams.size() < std::min(SERVER_KNOBS->BEST_TEAM_OPTION_COUNT, int(validTeams.size())) &&
+			       nTries < SERVER_KNOBS->BEST_TEAM_MAX_TEAM_TRIES) {
+			    Reference<TCTeamInfo> dest = deterministicRandom()->randomChoice(validTeams);
+			    if (std::find(candidateTeams.begin(), candidateTeams.end(), dest) == candidateTeams.end()) {
+			        candidateTeams.push_back(dest);
+			    }
+			    nTries++;
+			}*/
+
+			if (validTeams.size() <= 4) {
+				candidateTeams = validTeams;
+			} else {
+				deterministicRandom()->randomShuffle(validTeams);
+				candidateTeams =
+				    std::vector<Reference<TCTeamInfo>>(validTeams.begin(), validTeams.begin() + validTeams.size() / 4);
+			}
+
 			Optional<Reference<IDataDistributionTeam>> res;
-			if (candidateTeams.size() >= 1) {
-				res = deterministicRandom()->randomChoice(candidateTeams);
+			int minOngoingBulkLoadTaskCount = 0;
+			for (int i = 0; i < candidateTeams.size(); i++) {
+				Optional<int> ongoingBulkLoadTaskCount = candidateTeams[i]->getMaxOngoingBulkLoadTaskCount();
+				if (!ongoingBulkLoadTaskCount.present()) {
+					continue;
+				}
+				if (!res.present() || ongoingBulkLoadTaskCount.get() < minOngoingBulkLoadTaskCount) {
+					minOngoingBulkLoadTaskCount = ongoingBulkLoadTaskCount.get();
+					res = candidateTeams[i];
+				}
+			}
+
+			if (res.present()) {
 				TraceEvent(bulkLoadVerboseEventSev(), "DDBulkLoadEngineTaskGetTeamReply", self->distributorId)
 				    .detail("TCReady", self->readyToStart.isReady())
 				    .detail("SrcIds", describe(req.src))
 				    .detail("Primary", self->isPrimary())
 				    .detail("TeamSize", self->teams.size())
-				    .detail("CandidateSize", candidateTeams.size())
+				    .detail("ValidTeamSize", validTeams.size())
 				    .detail("UnhealthyTeamCount", unhealthyTeamCount)
 				    .detail("DuplicatedCount", duplicatedCount)
 				    .detail("NotEligibileTeamCount", notEligibileTeamCount)
+				    .detail("FailToGetMetricsCount", failToGetMetricsCount)
 				    .detail("DestIds", describe(res.get()->getServerIDs()))
 				    .detail("DestTeam", res.get()->getTeamID());
 			} else {
@@ -292,9 +334,10 @@ public:
 				    .detail("SrcIds", describe(req.src))
 				    .detail("Primary", self->isPrimary())
 				    .detail("TeamSize", self->teams.size())
-				    .detail("CandidateSize", candidateTeams.size())
+				    .detail("ValidTeamSize", validTeams.size())
 				    .detail("UnhealthyTeamCount", unhealthyTeamCount)
 				    .detail("DuplicatedCount", duplicatedCount)
+				    .detail("FailToGetMetricsCount", failToGetMetricsCount)
 				    .detail("NotEligibileTeamCount", notEligibileTeamCount);
 			}
 			req.reply.send(std::make_pair(res, false));

--- a/fdbserver/MockGlobalState.actor.cpp
+++ b/fdbserver/MockGlobalState.actor.cpp
@@ -382,7 +382,7 @@ void MockStorageServer::getStorageMetrics(const GetStorageMetricsRequest& req) {
 	StorageBytes storageBytes(
 	    totalDiskSpace - usedDiskSpace, totalDiskSpace, usedDiskSpace, totalDiskSpace - usedDiskSpace);
 	metrics.getStorageMetrics(
-	    req, storageBytes, counters.bytesInput.getRate(), 0, now(), 0, counters.bytesInput.getValue());
+	    req, storageBytes, counters.bytesInput.getRate(), 0, now(), 0, counters.bytesInput.getValue(), 0);
 	// FIXME: MockStorageServer does not support bytesDurable yet
 }
 

--- a/fdbserver/StorageMetrics.actor.cpp
+++ b/fdbserver/StorageMetrics.actor.cpp
@@ -366,7 +366,8 @@ void StorageServerMetrics::getStorageMetrics(GetStorageMetricsRequest req,
                                              int64_t versionLag,
                                              double lastUpdate,
                                              int64_t bytesDurable,
-                                             int64_t bytesInput) const {
+                                             int64_t bytesInput,
+                                             int ongoingBulkLoadTaskCount) const {
 	GetStorageMetricsReply rep;
 
 	// SOMEDAY: make bytes dynamic with hard disk space
@@ -398,6 +399,8 @@ void StorageServerMetrics::getStorageMetrics(GetStorageMetricsRequest req,
 
 	rep.bytesDurable = bytesDurable;
 	rep.bytesInput = bytesInput;
+
+	rep.ongoingBulkLoadTaskCount = ongoingBulkLoadTaskCount;
 
 	req.reply.send(rep);
 }

--- a/fdbserver/TCInfo.actor.cpp
+++ b/fdbserver/TCInfo.actor.cpp
@@ -280,6 +280,10 @@ int64_t TCServerInfo::getStorageQueueSize() const {
 	return getMetrics().bytesInput - getMetrics().bytesDurable;
 }
 
+int TCServerInfo::getMaxOngoingBulkLoadTaskCount() const {
+	return getMetrics().ongoingBulkLoadTaskCount;
+}
+
 void TCServerInfo::removeTeam(Reference<TCTeamInfo> team) {
 	for (int t = 0; t < teams.size(); t++) {
 		if (teams[t] == team) {
@@ -444,6 +448,18 @@ Optional<int64_t> TCTeamInfo::getLongestStorageQueueSize() const {
 		}
 	}
 	return longestQueueSize;
+}
+
+Optional<int> TCTeamInfo::getMaxOngoingBulkLoadTaskCount() const {
+	int count = 0;
+	for (const auto& server : servers) {
+		if (server->metricsPresent()) {
+			count = std::max(count, server->getMaxOngoingBulkLoadTaskCount());
+		} else {
+			return Optional<int>();
+		}
+	}
+	return count;
 }
 
 int64_t TCTeamInfo::getLoadBytes(bool includeInFlight, double inflightPenalty) const {

--- a/fdbserver/include/fdbserver/DataDistributionTeam.h
+++ b/fdbserver/include/fdbserver/DataDistributionTeam.h
@@ -62,6 +62,7 @@ struct IDataDistributionTeam {
 	virtual void addReadInFlightToTeam(int64_t delta) = 0;
 	virtual int64_t getDataInFlightToTeam() const = 0;
 	virtual Optional<int64_t> getLongestStorageQueueSize() const = 0;
+	virtual Optional<int> getMaxOngoingBulkLoadTaskCount() const = 0;
 	virtual int64_t getLoadBytes(bool includeInFlight = true, double inflightPenalty = 1.0) const = 0;
 	virtual int64_t getReadInFlightToTeam() const = 0;
 	virtual double getReadLoad(bool includeInFlight = true, double inflightPenalty = 1.0) const = 0;

--- a/fdbserver/include/fdbserver/StorageMetrics.actor.h
+++ b/fdbserver/include/fdbserver/StorageMetrics.actor.h
@@ -132,7 +132,8 @@ struct StorageServerMetrics {
 	                       int64_t versionLag,
 	                       double lastUpdate,
 	                       int64_t bytesDurable,
-	                       int64_t bytesInput) const;
+	                       int64_t bytesInput,
+	                       int ongoingBulkLoadTaskCount) const;
 
 	Future<Void> waitMetrics(WaitMetricsRequest req, Future<Void> delay);
 

--- a/fdbserver/include/fdbserver/TCInfo.h
+++ b/fdbserver/include/fdbserver/TCInfo.h
@@ -103,6 +103,7 @@ public:
 	KeyValueStoreType getStoreType() const { return storeType; }
 	int64_t getDataInFlightToServer() const { return dataInFlightToServer; }
 	int64_t getStorageQueueSize() const;
+	int getMaxOngoingBulkLoadTaskCount() const;
 	// expect read traffic to server after data movement
 	int64_t getReadInFlightToServer() const { return readInFlightToServer; }
 	void incrementDataInFlightToServer(int64_t bytes) { dataInFlightToServer += bytes; }
@@ -225,6 +226,8 @@ public:
 	int64_t getDataInFlightToTeam() const override;
 
 	Optional<int64_t> getLongestStorageQueueSize() const override;
+
+	Optional<int> getMaxOngoingBulkLoadTaskCount() const override;
 
 	int64_t getLoadBytes(bool includeInFlight = true, double inflightPenalty = 1.0) const override;
 

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -55,7 +55,7 @@ RUN curl -Ls https://github.com/krallin/tini/releases/download/v0.19.0/tini-amd6
 
 WORKDIR /
 
-FROM docker.io/library/golang:1.23.0-bullseye AS go-build
+FROM docker.io/library/golang:1.22.5-bullseye AS go-build
 
 COPY fdbkubernetesmonitor/ /fdbkubernetesmonitor
 WORKDIR /fdbkubernetesmonitor

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -55,7 +55,7 @@ RUN curl -Ls https://github.com/krallin/tini/releases/download/v0.19.0/tini-amd6
 
 WORKDIR /
 
-FROM docker.io/library/golang:1.22.5-bullseye AS go-build
+FROM docker.io/library/golang:1.23.0-bullseye AS go-build
 
 COPY fdbkubernetesmonitor/ /fdbkubernetesmonitor
 WORKDIR /fdbkubernetesmonitor


### PR DESCRIPTION
This PR adds DD BulkLoad load balancing: When DD chooses a dest team to do bulkload, DD filters out any invalid teams for low available disk space and unhealthy status; then DD randomly chooses 1/4 valid teams as the candidates. Finally, DD chooses the team with the minimal concurrent ongoing bulkload tasks. The team ongoing tasks count is the maximum ongoing tasks count among all storage servers.

100K correctness (with 1 irrelevant failure):
  20250424-235519-zhewang-237cc05a9945d7c1           compressed=True data_size=41108679 duration=5653635 ended=100000 fail=1 fail_fast=10 max_runs=100000 pass=99999 priority=100 remaining=0 runtime=1:35:16 sanity=False started=100000 stopped=20250425-013035 submitted=20250424-235519 timeout=5400 username=zhewang
  
500K BulkLoad (with 2 irrelevant failure: 1 failure for change config stuck, 1 failure for perpetual wiggle data moves keep happening):
  20250424-235637-zhewang-c9d59372f199ec45           compressed=True data_size=41150431 duration=10367138 ended=500000 fail=2 fail_fast=10 max_runs=500000 pass=499998 priority=100 remaining=0 runtime=2:26:54 sanity=False started=500000 stopped=20250425-022331 submitted=20250424-235637 timeout=5400 username=zhewang
    
500K BulkDump (with 3 irrelevant failures: perpetual wiggle data moves keep happening):
  20250424-235601-zhewang-9ca9e1fa6515e5e1           compressed=True data_size=41150434 duration=16835091 ended=500000 fail=3 fail_fast=10 max_runs=500000 pass=499997 priority=100 remaining=0 runtime=3:17:41 sanity=False started=500000 stopped=20250425-031342 submitted=20250424-235601 timeout=5400 username=zhewang
  
# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
