### PR TITLE
Ingest sst files rather than their keyvalue content (2nd attempt)

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -620,7 +620,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( ROCKSDB_MEMTABLE_PROTECTION_BYTES_PER_KEY,               0 ); if ( randomize && BUGGIFY ) ROCKSDB_MEMTABLE_PROTECTION_BYTES_PER_KEY = 8; // Default: 0 (disabled). Supported values: 0, 1, 2, 4, 8.
 	// Block cache key-value checksum. Checksum is validated during read, so has non-trivial impact on read performance.
 	init( ROCKSDB_BLOCK_PROTECTION_BYTES_PER_KEY,                  0 ); if ( randomize && BUGGIFY ) ROCKSDB_BLOCK_PROTECTION_BYTES_PER_KEY = 8; // Default: 0 (disabled). Supported values: 0, 1, 2, 4, 8.
-	init( ROCKSDB_ENABLE_NONDETERMINISM,                      false );
+	init( ROCKSDB_ENABLE_NONDETERMINISM,                       false );
 	init( SHARDED_ROCKSDB_ALLOW_WRITE_STALL_ON_FLUSH,          false );	
 	init( SHARDED_ROCKSDB_VALIDATE_MAPPING_RATIO,               0.01 ); if (isSimulated) SHARDED_ROCKSDB_VALIDATE_MAPPING_RATIO = deterministicRandom()->random01();
 	init( SHARD_METADATA_SCAN_BYTES_LIMIT,                  10485760 ); // 10MB
@@ -1410,10 +1410,5 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 		    std::min(MAX_READ_TRANSACTION_LIFE_VERSIONS, MAX_WRITE_TRANSACTION_LIFE_VERSIONS) /
 		    (5.0 * VERSIONS_PER_SECOND);
 		clientKnobs->INIT_MID_SHARD_BYTES = MIN_SHARD_BYTES;
-	}
-
-	init(BULK_LOAD_USE_SST_INGEST, true); // Enable SST ingestion by default
-	if (isSimulated) {
-		BULK_LOAD_USE_SST_INGEST = deterministicRandom()->coinflip();
 	}
 }

--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -620,7 +620,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( ROCKSDB_MEMTABLE_PROTECTION_BYTES_PER_KEY,               0 ); if ( randomize && BUGGIFY ) ROCKSDB_MEMTABLE_PROTECTION_BYTES_PER_KEY = 8; // Default: 0 (disabled). Supported values: 0, 1, 2, 4, 8.
 	// Block cache key-value checksum. Checksum is validated during read, so has non-trivial impact on read performance.
 	init( ROCKSDB_BLOCK_PROTECTION_BYTES_PER_KEY,                  0 ); if ( randomize && BUGGIFY ) ROCKSDB_BLOCK_PROTECTION_BYTES_PER_KEY = 8; // Default: 0 (disabled). Supported values: 0, 1, 2, 4, 8.
-	init( ROCKSDB_ENABLE_NONDETERMINISM,                       false );
+	init( ROCKSDB_ENABLE_NONDETERMINISM,                      false );
 	init( SHARDED_ROCKSDB_ALLOW_WRITE_STALL_ON_FLUSH,          false );	
 	init( SHARDED_ROCKSDB_VALIDATE_MAPPING_RATIO,               0.01 ); if (isSimulated) SHARDED_ROCKSDB_VALIDATE_MAPPING_RATIO = deterministicRandom()->random01();
 	init( SHARD_METADATA_SCAN_BYTES_LIMIT,                  10485760 ); // 10MB
@@ -1410,5 +1410,10 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 		    std::min(MAX_READ_TRANSACTION_LIFE_VERSIONS, MAX_WRITE_TRANSACTION_LIFE_VERSIONS) /
 		    (5.0 * VERSIONS_PER_SECOND);
 		clientKnobs->INIT_MID_SHARD_BYTES = MIN_SHARD_BYTES;
+	}
+
+	init(BULK_LOAD_USE_SST_INGEST, true); // Enable SST ingestion by default
+	if (isSimulated) {
+		BULK_LOAD_USE_SST_INGEST = deterministicRandom()->coinflip();
 	}
 }

--- a/fdbclient/include/fdbclient/IKeyValueStore.actor.h
+++ b/fdbclient/include/fdbclient/IKeyValueStore.actor.h
@@ -62,6 +62,8 @@ public:
 	// Returns true if the KV store supports shards, i.e., implements addRange(), removeRange(), and
 	// persistRangeMapping().
 	virtual bool shardAware() const { return false; }
+	// Returns true if the store supports external SST file ingestion.
+	virtual bool supportsSstIngestion() const { return false; }
 	virtual void set(KeyValueRef keyValue, const Arena* arena = nullptr) = 0;
 	virtual void clear(KeyRangeRef range, const Arena* arena = nullptr) = 0;
 	virtual Future<Void> canCommit() { return Void(); }
@@ -134,6 +136,9 @@ public:
 	// Delete a checkpoint.
 	virtual Future<Void> deleteCheckpoint(const CheckpointMetaData& checkpoint) { throw not_implemented(); }
 
+	// Compact a range of keys in the store
+	virtual Future<Void> compactRange(KeyRangeRef range) { throw not_implemented(); }
+
 	/*
 	Concurrency contract
 	    Causal consistency:
@@ -156,6 +161,13 @@ public:
 
 	// Obtain the encryption mode of the storage. The encryption mode needs to match the encryption mode of the cluster.
 	virtual Future<EncryptionAtRestMode> encryptionMode() = 0;
+
+	// the files in localFileSets.
+	// Throws an error if the store does not support SST ingestion or if ingestion fails.
+	// It is the responsibility of the caller to ensure the directory exists and the fileSetMap is valid.
+	virtual Future<Void> ingestSSTFiles(std::shared_ptr<BulkLoadFileSetKeyMap> localFileSets) {
+		throw not_implemented();
+	}
 
 protected:
 	virtual ~IKeyValueStore() {}

--- a/fdbclient/include/fdbclient/IKeyValueStore.actor.h
+++ b/fdbclient/include/fdbclient/IKeyValueStore.actor.h
@@ -62,8 +62,6 @@ public:
 	// Returns true if the KV store supports shards, i.e., implements addRange(), removeRange(), and
 	// persistRangeMapping().
 	virtual bool shardAware() const { return false; }
-	// Returns true if the store supports external SST file ingestion.
-	virtual bool supportsSstIngestion() const { return false; }
 	virtual void set(KeyValueRef keyValue, const Arena* arena = nullptr) = 0;
 	virtual void clear(KeyRangeRef range, const Arena* arena = nullptr) = 0;
 	virtual Future<Void> canCommit() { return Void(); }
@@ -136,9 +134,6 @@ public:
 	// Delete a checkpoint.
 	virtual Future<Void> deleteCheckpoint(const CheckpointMetaData& checkpoint) { throw not_implemented(); }
 
-	// Compact a range of keys in the store
-	virtual Future<Void> compactRange(KeyRangeRef range) { throw not_implemented(); }
-
 	/*
 	Concurrency contract
 	    Causal consistency:
@@ -161,13 +156,6 @@ public:
 
 	// Obtain the encryption mode of the storage. The encryption mode needs to match the encryption mode of the cluster.
 	virtual Future<EncryptionAtRestMode> encryptionMode() = 0;
-
-	// the files in localFileSets.
-	// Throws an error if the store does not support SST ingestion or if ingestion fails.
-	// It is the responsibility of the caller to ensure the directory exists and the fileSetMap is valid.
-	virtual Future<Void> ingestSSTFiles(std::shared_ptr<BulkLoadFileSetKeyMap> localFileSets) {
-		throw not_implemented();
-	}
 
 protected:
 	virtual ~IKeyValueStore() {}

--- a/fdbclient/include/fdbclient/ServerKnobs.h
+++ b/fdbclient/include/fdbclient/ServerKnobs.h
@@ -1457,6 +1457,8 @@ public:
 	// Swift: Enable the Swift runtime hooks and use Swift implementations where possible
 	bool FLOW_WITH_SWIFT;
 
+	bool BULK_LOAD_USE_SST_INGEST; // Enable direct SST file ingestion for RocksDB storage engines
+
 	ServerKnobs(Randomize, ClientKnobs*, IsSimulated);
 	void initialize(Randomize, ClientKnobs*, IsSimulated);
 };

--- a/fdbclient/include/fdbclient/ServerKnobs.h
+++ b/fdbclient/include/fdbclient/ServerKnobs.h
@@ -1457,8 +1457,6 @@ public:
 	// Swift: Enable the Swift runtime hooks and use Swift implementations where possible
 	bool FLOW_WITH_SWIFT;
 
-	bool BULK_LOAD_USE_SST_INGEST; // Enable direct SST file ingestion for RocksDB storage engines
-
 	ServerKnobs(Randomize, ClientKnobs*, IsSimulated);
 	void initialize(Randomize, ClientKnobs*, IsSimulated);
 };

--- a/fdbclient/tests/fdb_cluster_fixture.sh
+++ b/fdbclient/tests/fdb_cluster_fixture.sh
@@ -58,7 +58,7 @@ function start_fdb_cluster {
       "${local_build_dir}" \
       --knobs "${knobs}" \
       --stateless_count 1 --replication_count 1 --logs_count 1 \
-      --storage_count "${ss_count}" --storage_type ssd \
+      --storage_count "${ss_count}" --storage_type ssd-rocksdb-v1 \
       --dump_pids on \
       > >(tee "${output}") \
       2> >(tee "${output}" >&2)

--- a/fdbclient/tests/fdb_cluster_fixture.sh
+++ b/fdbclient/tests/fdb_cluster_fixture.sh
@@ -58,7 +58,7 @@ function start_fdb_cluster {
       "${local_build_dir}" \
       --knobs "${knobs}" \
       --stateless_count 1 --replication_count 1 --logs_count 1 \
-      --storage_count "${ss_count}" --storage_type ssd-rocksdb-v1 \
+      --storage_count "${ss_count}" --storage_type ssd \
       --dump_pids on \
       > >(tee "${output}") \
       2> >(tee "${output}" >&2)

--- a/fdbserver/KeyValueStoreRocksDB.actor.cpp
+++ b/fdbserver/KeyValueStoreRocksDB.actor.cpp
@@ -61,7 +61,6 @@
 #include <memory>
 #include <tuple>
 #include <vector>
-#include <fstream>
 
 #endif // WITH_ROCKSDB
 
@@ -1319,82 +1318,6 @@ struct RocksDBKeyValueStore : IKeyValueStore {
 
 		void init() override {}
 
-		struct IngestSSTFilesAction : TypedAction<Writer, IngestSSTFilesAction> {
-			IngestSSTFilesAction(std::shared_ptr<BulkLoadFileSetKeyMap> localFileSets) : localFileSets(localFileSets) {}
-
-			double getTimeEstimate() const override { return SERVER_KNOBS->COMMIT_TIME_ESTIMATE; }
-
-			std::shared_ptr<BulkLoadFileSetKeyMap> localFileSets;
-			ThreadReturnPromise<Void> done;
-		};
-
-		void action(IngestSSTFilesAction& a) {
-			// Create a list of SST files to ingest
-			std::vector<std::string> sstFiles;
-			for (const auto& [range, fileSet] : *a.localFileSets) {
-				if (fileSet.hasDataFile()) {
-					sstFiles.push_back(fileSet.getDataFileFullPath());
-				}
-			}
-
-			if (sstFiles.empty()) {
-				TraceEvent(SevInfo, "RocksDBIngestSSTFilesNoFiles", id);
-				a.done.send(Void()); // Nothing to ingest
-				return;
-			}
-
-			// Configure ingestion options
-			rocksdb::IngestExternalFileOptions options;
-			options.move_files = true;
-			options.verify_checksums_before_ingest = true;
-			options.allow_blocking_flush = true;
-			// write_global_seqno is default true which means on ingest the SST file is rewritten w/ seqno injected for
-			// each KV.
-
-			// Ingest the SST files
-			// The default column family parameter is necessary here; w/o it the ingested keyvalues are unreadable
-			rocksdb::Status status = db->IngestExternalFile(cf, sstFiles, options);
-
-			if (!status.ok()) {
-				logRocksDBError(id, status, "IngestSSTFiles");
-				a.done.sendError(statusToError(status));
-				return;
-			}
-
-			a.done.send(Void());
-		}
-
-		struct CompactRangeAction : TypedAction<Writer, CompactRangeAction> {
-			CompactRangeAction(KeyRangeRef range) : range(range) {}
-
-			double getTimeEstimate() const override { return SERVER_KNOBS->COMMIT_TIME_ESTIMATE; }
-
-			const KeyRange range;
-			ThreadReturnPromise<Void> done;
-		};
-
-		void action(CompactRangeAction& a) {
-			// Configure compaction options
-			rocksdb::CompactRangeOptions options;
-			// Force RocksDB to rewrite file to last level
-			options.bottommost_level_compaction = rocksdb::BottommostLevelCompaction::kForceOptimized;
-
-			// Convert key range to slices
-			auto begin = toSlice(a.range.begin);
-			auto end = toSlice(a.range.end);
-
-			// Perform the compaction
-			rocksdb::Status status = db->CompactRange(options, cf, &begin, &end);
-
-			if (!status.ok()) {
-				logRocksDBError(id, status, "CompactRange");
-				a.done.sendError(statusToError(status));
-				return;
-			}
-
-			a.done.send(Void());
-		}
-
 		struct OpenAction : TypedAction<Writer, OpenAction> {
 			std::string path;
 			ThreadReturnPromise<Void> done;
@@ -2218,7 +2141,6 @@ struct RocksDBKeyValueStore : IKeyValueStore {
 	void close() override { doClose(this, false); }
 
 	KeyValueStoreType getType() const override { return KeyValueStoreType(KeyValueStoreType::SSD_ROCKSDB_V1); }
-	bool supportsSstIngestion() const override { return true; }
 
 	Future<Void> init() override {
 		if (openFuture.isValid()) {
@@ -2568,20 +2490,6 @@ struct RocksDBKeyValueStore : IKeyValueStore {
 
 	Future<EncryptionAtRestMode> encryptionMode() override {
 		return EncryptionAtRestMode(EncryptionAtRestMode::DISABLED);
-	}
-
-	Future<Void> ingestSSTFiles(std::shared_ptr<BulkLoadFileSetKeyMap> localFileSets) override {
-		auto a = new Writer::IngestSSTFilesAction(localFileSets);
-		auto res = a->done.getFuture();
-		writeThread->post(a);
-		return res;
-	}
-
-	Future<Void> compactRange(KeyRangeRef range) override {
-		auto a = new Writer::CompactRangeAction(range);
-		auto res = a->done.getFuture();
-		writeThread->post(a);
-		return res;
 	}
 
 	DB db = nullptr;
@@ -3055,54 +2963,6 @@ TEST_CASE("noSim/RocksDB/RangeClear") {
 	wait(closed);
 	return Void();
 }
-
-TEST_CASE("noSim/fdbserver/KeyValueStoreRocksDB/IngestSSTFileVisibility") {
-	state std::string testDir = "test_ingest_sst_visibility";
-	state UID testStoreID = deterministicRandom()->randomUniqueID();
-	state RocksDBKeyValueStore* kvStore = new RocksDBKeyValueStore(testDir, testStoreID);
-
-	// Initialize the store
-	wait(kvStore->init());
-
-	// Create an SST file
-	state std::string sstFilename = "test.sst"; // Base filename
-	state std::string sstFileFullPath = joinPath(testDir, sstFilename); // Full path for writer
-	rocksdb::SstFileWriter sstWriter(rocksdb::EnvOptions(), kvStore->sharedState->getOptions());
-	ASSERT(sstWriter.Open(sstFileFullPath).ok()); // Use full path here
-	ASSERT(sstWriter.Put("test_key", "test_value").ok());
-	ASSERT(sstWriter.Finish().ok());
-
-	// Create and populate the file set map (which is a vector)
-	state std::shared_ptr<BulkLoadFileSetKeyMap> fileSetMap = std::make_shared<BulkLoadFileSetKeyMap>();
-	state std::string dummyManifestFile = "dummy_manifest.txt"; // Dummy filename for validation
-
-	// Create the BulkLoadFileSet using its constructor.
-	// Pass the test directory, dummy manifest, and the base SST filename.
-	BulkLoadFileSet fileSet(testDir, // rootPath
-	                        /*relativePath=*/"",
-	                        dummyManifestFile, // manifestFileName
-	                        sstFilename, // dataFileName (use base name)
-	                        /*byteSampleFileName=*/"",
-	                        BulkLoadChecksum()); // checksum
-
-	fileSetMap->emplace_back(allKeys, fileSet); // Use emplace_back for std::vector
-
-	// Ingest the SST file using the populated map
-	wait(kvStore->ingestSSTFiles(fileSetMap));
-
-	// Verify the key is visible
-	Optional<Value> value = wait(kvStore->readValue("test_key"_sr, Optional<ReadOptions>()));
-	ASSERT(value.present());
-	ASSERT(value.get() == "test_value"_sr);
-
-	// Clean up
-	Future<Void> closed = kvStore->onClosed(); // Get future before dispose
-	kvStore->dispose();
-	wait(closed); // Wait for close completion
-	platform::eraseDirectoryRecursive(testDir);
-
-	return Void();
-}
-
 } // namespace
+
 #endif // WITH_ROCKSDB

--- a/fdbserver/KeyValueStoreRocksDB.actor.cpp
+++ b/fdbserver/KeyValueStoreRocksDB.actor.cpp
@@ -61,6 +61,7 @@
 #include <memory>
 #include <tuple>
 #include <vector>
+#include <fstream>
 
 #endif // WITH_ROCKSDB
 
@@ -1318,6 +1319,82 @@ struct RocksDBKeyValueStore : IKeyValueStore {
 
 		void init() override {}
 
+		struct IngestSSTFilesAction : TypedAction<Writer, IngestSSTFilesAction> {
+			IngestSSTFilesAction(std::shared_ptr<BulkLoadFileSetKeyMap> localFileSets) : localFileSets(localFileSets) {}
+
+			double getTimeEstimate() const override { return SERVER_KNOBS->COMMIT_TIME_ESTIMATE; }
+
+			std::shared_ptr<BulkLoadFileSetKeyMap> localFileSets;
+			ThreadReturnPromise<Void> done;
+		};
+
+		void action(IngestSSTFilesAction& a) {
+			// Create a list of SST files to ingest
+			std::vector<std::string> sstFiles;
+			for (const auto& [range, fileSet] : *a.localFileSets) {
+				if (fileSet.hasDataFile()) {
+					sstFiles.push_back(fileSet.getDataFileFullPath());
+				}
+			}
+
+			if (sstFiles.empty()) {
+				TraceEvent(SevInfo, "RocksDBIngestSSTFilesNoFiles", id);
+				a.done.send(Void()); // Nothing to ingest
+				return;
+			}
+
+			// Configure ingestion options
+			rocksdb::IngestExternalFileOptions options;
+			options.move_files = true;
+			options.verify_checksums_before_ingest = true;
+			options.allow_blocking_flush = true;
+			// write_global_seqno is default true which means on ingest the SST file is rewritten w/ seqno injected for
+			// each KV.
+
+			// Ingest the SST files
+			// The default column family parameter is necessary here; w/o it the ingested keyvalues are unreadable
+			rocksdb::Status status = db->IngestExternalFile(cf, sstFiles, options);
+
+			if (!status.ok()) {
+				logRocksDBError(id, status, "IngestSSTFiles");
+				a.done.sendError(statusToError(status));
+				return;
+			}
+
+			a.done.send(Void());
+		}
+
+		struct CompactRangeAction : TypedAction<Writer, CompactRangeAction> {
+			CompactRangeAction(KeyRangeRef range) : range(range) {}
+
+			double getTimeEstimate() const override { return SERVER_KNOBS->COMMIT_TIME_ESTIMATE; }
+
+			const KeyRange range;
+			ThreadReturnPromise<Void> done;
+		};
+
+		void action(CompactRangeAction& a) {
+			// Configure compaction options
+			rocksdb::CompactRangeOptions options;
+			// Force RocksDB to rewrite file to last level
+			options.bottommost_level_compaction = rocksdb::BottommostLevelCompaction::kForceOptimized;
+
+			// Convert key range to slices
+			auto begin = toSlice(a.range.begin);
+			auto end = toSlice(a.range.end);
+
+			// Perform the compaction
+			rocksdb::Status status = db->CompactRange(options, cf, &begin, &end);
+
+			if (!status.ok()) {
+				logRocksDBError(id, status, "CompactRange");
+				a.done.sendError(statusToError(status));
+				return;
+			}
+
+			a.done.send(Void());
+		}
+
 		struct OpenAction : TypedAction<Writer, OpenAction> {
 			std::string path;
 			ThreadReturnPromise<Void> done;
@@ -2141,6 +2218,7 @@ struct RocksDBKeyValueStore : IKeyValueStore {
 	void close() override { doClose(this, false); }
 
 	KeyValueStoreType getType() const override { return KeyValueStoreType(KeyValueStoreType::SSD_ROCKSDB_V1); }
+	bool supportsSstIngestion() const override { return true; }
 
 	Future<Void> init() override {
 		if (openFuture.isValid()) {
@@ -2490,6 +2568,20 @@ struct RocksDBKeyValueStore : IKeyValueStore {
 
 	Future<EncryptionAtRestMode> encryptionMode() override {
 		return EncryptionAtRestMode(EncryptionAtRestMode::DISABLED);
+	}
+
+	Future<Void> ingestSSTFiles(std::shared_ptr<BulkLoadFileSetKeyMap> localFileSets) override {
+		auto a = new Writer::IngestSSTFilesAction(localFileSets);
+		auto res = a->done.getFuture();
+		writeThread->post(a);
+		return res;
+	}
+
+	Future<Void> compactRange(KeyRangeRef range) override {
+		auto a = new Writer::CompactRangeAction(range);
+		auto res = a->done.getFuture();
+		writeThread->post(a);
+		return res;
 	}
 
 	DB db = nullptr;
@@ -2963,6 +3055,54 @@ TEST_CASE("noSim/RocksDB/RangeClear") {
 	wait(closed);
 	return Void();
 }
-} // namespace
 
+TEST_CASE("noSim/fdbserver/KeyValueStoreRocksDB/IngestSSTFileVisibility") {
+	state std::string testDir = "test_ingest_sst_visibility";
+	state UID testStoreID = deterministicRandom()->randomUniqueID();
+	state RocksDBKeyValueStore* kvStore = new RocksDBKeyValueStore(testDir, testStoreID);
+
+	// Initialize the store
+	wait(kvStore->init());
+
+	// Create an SST file
+	state std::string sstFilename = "test.sst"; // Base filename
+	state std::string sstFileFullPath = joinPath(testDir, sstFilename); // Full path for writer
+	rocksdb::SstFileWriter sstWriter(rocksdb::EnvOptions(), kvStore->sharedState->getOptions());
+	ASSERT(sstWriter.Open(sstFileFullPath).ok()); // Use full path here
+	ASSERT(sstWriter.Put("test_key", "test_value").ok());
+	ASSERT(sstWriter.Finish().ok());
+
+	// Create and populate the file set map (which is a vector)
+	state std::shared_ptr<BulkLoadFileSetKeyMap> fileSetMap = std::make_shared<BulkLoadFileSetKeyMap>();
+	state std::string dummyManifestFile = "dummy_manifest.txt"; // Dummy filename for validation
+
+	// Create the BulkLoadFileSet using its constructor.
+	// Pass the test directory, dummy manifest, and the base SST filename.
+	BulkLoadFileSet fileSet(testDir, // rootPath
+	                        /*relativePath=*/"",
+	                        dummyManifestFile, // manifestFileName
+	                        sstFilename, // dataFileName (use base name)
+	                        /*byteSampleFileName=*/"",
+	                        BulkLoadChecksum()); // checksum
+
+	fileSetMap->emplace_back(allKeys, fileSet); // Use emplace_back for std::vector
+
+	// Ingest the SST file using the populated map
+	wait(kvStore->ingestSSTFiles(fileSetMap));
+
+	// Verify the key is visible
+	Optional<Value> value = wait(kvStore->readValue("test_key"_sr, Optional<ReadOptions>()));
+	ASSERT(value.present());
+	ASSERT(value.get() == "test_value"_sr);
+
+	// Clean up
+	Future<Void> closed = kvStore->onClosed(); // Get future before dispose
+	kvStore->dispose();
+	wait(closed); // Wait for close completion
+	platform::eraseDirectoryRecursive(testDir);
+
+	return Void();
+}
+
+} // namespace
 #endif // WITH_ROCKSDB

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -1643,10 +1643,10 @@ public:
 		                                                           self->thisServerID,
 		                                                           SERVER_KNOBS->LATENCY_METRICS_LOGGING_INTERVAL,
 		                                                           SERVER_KNOBS->LATENCY_SKETCH_ACCURACY)),
-			ingestDurationLatencySample(std::make_unique<LatencySample>("IngestDurationMetrics",
-								self->thisServerID,
-		                          SERVER_KNOBS->LATENCY_METRICS_LOGGING_INTERVAL,
-		                          SERVER_KNOBS->LATENCY_SKETCH_ACCURACY)) {
+		    ingestDurationLatencySample(std::make_unique<LatencySample>("IngestDurationMetrics",
+		                                                                self->thisServerID,
+		                                                                SERVER_KNOBS->LATENCY_METRICS_LOGGING_INTERVAL,
+		                                                                SERVER_KNOBS->LATENCY_SKETCH_ACCURACY)) {
 
 			specialCounter(cc, "LastTLogVersion", [self]() { return self->lastTLogVersion; });
 			specialCounter(cc, "Version", [self]() { return self->version.get(); });
@@ -15292,7 +15292,7 @@ ACTOR Future<Void> storageServer(IKeyValueStore* persistentData,
 	static_assert(sizeof(self) < 16384, "FastAlloc doesn't allow allocations larger than 16KB");
 	TraceEvent("StorageServerInitProgress", ssi.id())
 	    .detail("EngineType", self.storage.getKeyValueStoreType().toString())
-		.detail("Size", sizeof(self))
+	    .detail("Size", sizeof(self))
 	    .detail("Step", "4.StartInit");
 
 	self.sk = serverKeysPrefixFor(self.tssPairID.present() ? self.tssPairID.get() : self.thisServerID)

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -20,7 +20,6 @@
 
 #include <cinttypes>
 #include <functional>
-#include <fstream>
 #include <iterator>
 #include <limits>
 #include <memory>
@@ -1556,7 +1555,6 @@ public:
 		LatencySample kvReadRangeLatencySample;
 		LatencySample updateLatencySample;
 		LatencySample updateEncryptionLatencySample;
-		LatencySample ingestDurationSample;
 
 		LatencyBands readLatencyBands;
 		std::unique_ptr<LatencySample> mappedRangeSample; // Samples getMappedRange latency
@@ -1632,10 +1630,6 @@ public:
 		                                  self->thisServerID,
 		                                  SERVER_KNOBS->LATENCY_METRICS_LOGGING_INTERVAL,
 		                                  SERVER_KNOBS->LATENCY_SKETCH_ACCURACY),
-		    ingestDurationSample("IngestDurationMetrics",
-		                         self->thisServerID,
-		                         SERVER_KNOBS->LATENCY_METRICS_LOGGING_INTERVAL,
-		                         SERVER_KNOBS->LATENCY_SKETCH_ACCURACY),
 		    readLatencyBands("ReadLatencyBands", self->thisServerID, SERVER_KNOBS->STORAGE_LOGGING_DELAY),
 		    mappedRangeSample(std::make_unique<LatencySample>("GetMappedRangeMetrics",
 		                                                      self->thisServerID,
@@ -1649,7 +1643,6 @@ public:
 		                                                           self->thisServerID,
 		                                                           SERVER_KNOBS->LATENCY_METRICS_LOGGING_INTERVAL,
 		                                                           SERVER_KNOBS->LATENCY_SKETCH_ACCURACY)) {
-
 			specialCounter(cc, "LastTLogVersion", [self]() { return self->lastTLogVersion; });
 			specialCounter(cc, "Version", [self]() { return self->version.get(); });
 			specialCounter(cc, "StorageVersion", [self]() { return self->storageVersion(); });
@@ -8911,84 +8904,6 @@ ACTOR Future<Void> tryGetRangeForBulkLoad(PromiseStream<RangeResult> results,
 	}
 }
 
-// Utility function to process sample files during bulk load
-ACTOR static Future<Void> processSampleFiles(StorageServer* data,
-                                             std::string bulkLoadLocalDir,
-                                             std::shared_ptr<BulkLoadFileSetKeyMap> localFileSets) {
-	state BulkLoadFileSetKeyMap::const_iterator iter = localFileSets->begin();
-	state BulkLoadFileSetKeyMap::const_iterator end = localFileSets->end();
-	state std::vector<KeyValue> rawSamples;
-	state std::unique_ptr<IRocksDBSstFileReader> reader;
-
-	while (iter != end) {
-		const auto& [range, fileSet] = *iter;
-		if (fileSet.hasByteSampleFile()) {
-			state std::string sampleFilePath = fileSet.getBytesSampleFileFullPath();
-			state int retryCount = 0;
-			state int maxRetries = 10; // Consider making this a KNOB
-			state Error lastError;
-
-			// This outer loop retries reading the entire file if errors occur during opening/reading
-			while (retryCount < maxRetries) {
-				try {
-					// Read all samples from the SST file into memory first
-					// Store as KeyValueRef to keep the original encoded size value
-					rawSamples.clear();
-					reader = newRocksDBSstFileReader();
-					reader->open(abspath(sampleFilePath));
-
-					TraceEvent(SevInfo, "StorageServerProcessingSampleFile", data->thisServerID)
-					    .detail("File", sampleFilePath);
-
-					// Read all samples
-					while (reader->hasNext()) {
-						// Copy the next kv to rawSamples.
-						rawSamples.push_back(reader->next());
-					}
-
-					// Now apply all read samples to the in-memory set and update metrics
-					for (const auto& kv : rawSamples) {
-						const KeyRef& key = kv.key;
-						int64_t size = BinaryReader::fromStringRef<int64_t>(kv.value, Unversioned());
-						data->metrics.byteSample.sample.insert(key, size);
-						data->metrics.notifyBytes(key, size);
-						data->addMutationToMutationLogOrStorage(
-						    invalidVersion,
-						    MutationRef(MutationRef::SetValue, key.withPrefix(persistByteSampleKeys.begin), kv.value));
-					}
-
-					// If we get here, processing was successful for this file
-					break; // Exit the retry loop
-
-				} catch (Error& e) {
-					lastError = e;
-					retryCount++;
-					TraceEvent(retryCount < maxRetries ? SevWarn : SevError,
-					           "StorageServerSampleFileProcessingError",
-					           data->thisServerID)
-					    .error(e) // Log the actual error 'e'
-					    .detail("File", sampleFilePath)
-					    // REMOVED: .detail("Key", kv.key).detail("Value", kv.value) as 'kv' is out of scope
-					    .detail("RetryCount", retryCount)
-					    .detail("MaxRetries", maxRetries);
-
-					// No need to check/close reader here, unique_ptr handles it.
-
-					if (retryCount < maxRetries) {
-						// Wait before retrying, with exponential backoff
-						wait(delay(0.1 * pow(2, retryCount))); // Consider adding jitter
-						continue; // Retry reading the file
-					}
-					// On final retry failure, throw the last error encountered
-					throw lastError;
-				}
-			} // end retry loop
-		}
-		++iter;
-	} // end file iteration loop
-	return Void();
-}
-
 ACTOR Future<Void> fetchKeys(StorageServer* data, AddingShard* shard) {
 	state const UID fetchKeysID = deterministicRandom()->randomUniqueID();
 	state TraceInterval interval("FetchKeys");
@@ -9235,52 +9150,9 @@ ACTOR Future<Void> fetchKeys(StorageServer* data, AddingShard* shard) {
 				TraceEvent(bulkLoadVerboseEventSev(), "SSBulkLoadTaskFetchKey", data->thisServerID)
 				    .detail("DataMoveId", dataMoveId.toString())
 				    .detail("Range", keys)
-				    .detail("Knobs", SERVER_KNOBS->BULK_LOAD_USE_SST_INGEST)
-				    .detail("SupportsSstIngestion", data->storage.getKeyValueStore()->supportsSstIngestion())
 				    .detail("Phase", "File download");
-				// Attempt SST ingestion...
-				if (SERVER_KNOBS->BULK_LOAD_USE_SST_INGEST &&
-				    data->storage.getKeyValueStore()->supportsSstIngestion()) {
-					TraceEvent(bulkLoadVerboseEventSev(), "SSBulkLoadTaskFetchKey", data->thisServerID)
-					    .detail("DataMoveId", dataMoveId.toString())
-					    .detail("Range", keys)
-					    .detail("Phase", "SST ingestion");
-					// Verify ranges...
-					for (const auto& [range, fileSet] : *localBulkLoadFileSets) {
-						ASSERT(keys.contains(range));
-					}
-					// Clear the key range before ingestion. This mirrors the replaceRange done in the case were
-					// we do not ingest SST files.
-					data->storage.getKeyValueStore()->clear(keys);
-
-					// Now wait on the durableVersion to be updated so clear has been committed.
-					wait(data->durableVersion.whenAtLeast(data->storageVersion() + 1));
-
-					// Compact the range before ingestion to optimize storage
-					wait(data->storage.getKeyValueStore()->compactRange(keys));
-
-					// Ingest the SST files.
-					// Measure duration at this level so we capture the inter-thread handoff time.
-					state double ingestStartTime = now(); // Record start time
-					wait(data->storage.getKeyValueStore()->ingestSSTFiles(localBulkLoadFileSets));
-					data->counters.ingestDurationSample.addMeasurement(now() - ingestStartTime);
-
-					// Process sample files after SST ingestion
-					wait(processSampleFiles(data, bulkLoadLocalDir, localBulkLoadFileSets));
-
-					// Ensure all changes are durable
-					wait(data->durableVersion.whenAtLeast(data->storageVersion() + 1));
-
-					// Add a small delay to ensure audit system sees the changes
-					wait(delay(0.1));
-
-					// NOTICE: We break the 'fetchKeys' loop here if we successfully ingest the SST files.
-					// EARLY EXIT FROM 'fetchKeys' LOOP!!!
-					break;
-				} else {
-					hold = tryGetRangeForBulkLoad(results, keys, localBulkLoadFileSets);
-					rangeEnd = keys.end;
-				}
+				hold = tryGetRangeForBulkLoad(results, keys, localBulkLoadFileSets);
+				rangeEnd = keys.end;
 			} else {
 				hold = tryGetRange(results, &tr, keys);
 				rangeEnd = keys.end;
@@ -9362,7 +9234,6 @@ ACTOR Future<Void> fetchKeys(StorageServer* data, AddingShard* shard) {
 					for (; kvItr != this_block.end(); ++kvItr) {
 						data->byteSampleApplySet(*kvItr, invalidVersion);
 					}
-
 					if (this_block.more) {
 						blockBegin = this_block.getReadThrough();
 					} else {
@@ -9451,7 +9322,7 @@ ACTOR Future<Void> fetchKeys(StorageServer* data, AddingShard* shard) {
 				}
 				break;
 			}
-		} // fetchKeys loop.
+		}
 
 		// We have completed the fetch and write of the data, now we wait for MVCC window to pass.
 		//  As we have finished this work, we will allow more work to start...

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -8910,6 +8910,84 @@ ACTOR Future<Void> tryGetRangeForBulkLoad(PromiseStream<RangeResult> results,
 	}
 }
 
+// Utility function to process sample files during bulk load
+ACTOR static Future<Void> processSampleFiles(StorageServer* data,
+                                             std::string bulkLoadLocalDir,
+                                             std::shared_ptr<BulkLoadFileSetKeyMap> localFileSets) {
+	state BulkLoadFileSetKeyMap::const_iterator iter = localFileSets->begin();
+	state BulkLoadFileSetKeyMap::const_iterator end = localFileSets->end();
+	state std::vector<KeyValue> rawSamples;
+	state std::unique_ptr<IRocksDBSstFileReader> reader;
+
+	while (iter != end) {
+		const auto& [range, fileSet] = *iter;
+		if (fileSet.hasByteSampleFile()) {
+			state std::string sampleFilePath = fileSet.getBytesSampleFileFullPath();
+			state int retryCount = 0;
+			state int maxRetries = 10; // Consider making this a KNOB
+			state Error lastError;
+
+			// This outer loop retries reading the entire file if errors occur during opening/reading
+			while (retryCount < maxRetries) {
+				try {
+					// Read all samples from the SST file into memory first
+					// Store as KeyValueRef to keep the original encoded size value
+					rawSamples.clear();
+					reader = newRocksDBSstFileReader();
+					reader->open(abspath(sampleFilePath));
+
+					TraceEvent(SevInfo, "StorageServerProcessingSampleFile", data->thisServerID)
+					    .detail("File", sampleFilePath);
+
+					// Read all samples
+					while (reader->hasNext()) {
+						// Copy the next kv to rawSamples.
+						rawSamples.push_back(reader->next());
+					}
+
+					// Now apply all read samples to the in-memory set and update metrics
+					for (const auto& kv : rawSamples) {
+						const KeyRef& key = kv.key;
+						int64_t size = BinaryReader::fromStringRef<int64_t>(kv.value, Unversioned());
+						data->metrics.byteSample.sample.insert(key, size);
+						data->metrics.notifyBytes(key, size);
+						data->addMutationToMutationLogOrStorage(
+						    invalidVersion,
+						    MutationRef(MutationRef::SetValue, key.withPrefix(persistByteSampleKeys.begin), kv.value));
+					}
+
+					// If we get here, processing was successful for this file
+					break; // Exit the retry loop
+
+				} catch (Error& e) {
+					lastError = e;
+					retryCount++;
+					TraceEvent(retryCount < maxRetries ? SevWarn : SevError,
+					           "StorageServerSampleFileProcessingError",
+					           data->thisServerID)
+					    .error(e) // Log the actual error 'e'
+					    .detail("File", sampleFilePath)
+					    // REMOVED: .detail("Key", kv.key).detail("Value", kv.value) as 'kv' is out of scope
+					    .detail("RetryCount", retryCount)
+					    .detail("MaxRetries", maxRetries);
+
+					// No need to check/close reader here, unique_ptr handles it.
+
+					if (retryCount < maxRetries) {
+						// Wait before retrying, with exponential backoff
+						wait(delay(0.1 * pow(2, retryCount))); // Consider adding jitter
+						continue; // Retry reading the file
+					}
+					// On final retry failure, throw the last error encountered
+					throw lastError;
+				}
+			} // end retry loop
+		}
+		++iter;
+	} // end file iteration loop
+	return Void();
+}
+
 ACTOR Future<Void> fetchKeys(StorageServer* data, AddingShard* shard) {
 	state const UID fetchKeysID = deterministicRandom()->randomUniqueID();
 	state TraceInterval interval("FetchKeys");
@@ -9156,9 +9234,52 @@ ACTOR Future<Void> fetchKeys(StorageServer* data, AddingShard* shard) {
 				TraceEvent(bulkLoadVerboseEventSev(), "SSBulkLoadTaskFetchKey", data->thisServerID)
 				    .detail("DataMoveId", dataMoveId.toString())
 				    .detail("Range", keys)
+				    .detail("Knobs", SERVER_KNOBS->BULK_LOAD_USE_SST_INGEST)
+				    .detail("SupportsSstIngestion", data->storage.getKeyValueStore()->supportsSstIngestion())
 				    .detail("Phase", "File download");
-				hold = tryGetRangeForBulkLoad(results, keys, localBulkLoadFileSets);
-				rangeEnd = keys.end;
+				// Attempt SST ingestion...
+				if (SERVER_KNOBS->BULK_LOAD_USE_SST_INGEST &&
+				    data->storage.getKeyValueStore()->supportsSstIngestion()) {
+					TraceEvent(bulkLoadVerboseEventSev(), "SSBulkLoadTaskFetchKey", data->thisServerID)
+					    .detail("DataMoveId", dataMoveId.toString())
+					    .detail("Range", keys)
+					    .detail("Phase", "SST ingestion");
+					// Verify ranges...
+					for (const auto& [range, fileSet] : *localBulkLoadFileSets) {
+						ASSERT(keys.contains(range));
+					}
+					// Clear the key range before ingestion. This mirrors the replaceRange done in the case were
+					// we do not ingest SST files.
+					data->storage.getKeyValueStore()->clear(keys);
+
+					// Now wait on the durableVersion to be updated so clear has been committed.
+					wait(data->durableVersion.whenAtLeast(data->storageVersion() + 1));
+
+					// Compact the range before ingestion to optimize storage
+					wait(data->storage.getKeyValueStore()->compactRange(keys));
+
+					// Ingest the SST files.
+					// Measure duration at this level so we capture the inter-thread handoff time.
+					state double ingestStartTime = now(); // Record start time
+					wait(data->storage.getKeyValueStore()->ingestSSTFiles(localBulkLoadFileSets));
+					// DESTABILIZER data->counters.ingestDurationSample.addMeasurement(now() - ingestStartTime);
+
+					// Process sample files after SST ingestion
+					wait(processSampleFiles(data, bulkLoadLocalDir, localBulkLoadFileSets));
+
+					// Ensure all changes are durable
+					wait(data->durableVersion.whenAtLeast(data->storageVersion() + 1));
+
+					// Add a small delay to ensure audit system sees the changes
+					wait(delay(0.1));
+
+					// NOTICE: We break the 'fetchKeys' loop here if we successfully ingest the SST files.
+					// EARLY EXIT FROM 'fetchKeys' LOOP!!!
+					break;
+				} else {
+					hold = tryGetRangeForBulkLoad(results, keys, localBulkLoadFileSets);
+					rangeEnd = keys.end;
+				}
 			} else {
 				hold = tryGetRange(results, &tr, keys);
 				rangeEnd = keys.end;

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -1555,6 +1555,7 @@ public:
 		LatencySample kvReadRangeLatencySample;
 		LatencySample updateLatencySample;
 		LatencySample updateEncryptionLatencySample;
+		// DESTABILIZER LatencySample ingestDurationSample;
 
 		LatencyBands readLatencyBands;
 		std::unique_ptr<LatencySample> mappedRangeSample; // Samples getMappedRange latency
@@ -1630,6 +1631,10 @@ public:
 		                                  self->thisServerID,
 		                                  SERVER_KNOBS->LATENCY_METRICS_LOGGING_INTERVAL,
 		                                  SERVER_KNOBS->LATENCY_SKETCH_ACCURACY),
+		    // ingestDurationSample("IngestDurationMetrics",
+		    //                      self->thisServerID,
+		    //                      SERVER_KNOBS->LATENCY_METRICS_LOGGING_INTERVAL,
+		    //                      SERVER_KNOBS->LATENCY_SKETCH_ACCURACY),
 		    readLatencyBands("ReadLatencyBands", self->thisServerID, SERVER_KNOBS->STORAGE_LOGGING_DELAY),
 		    mappedRangeSample(std::make_unique<LatencySample>("GetMappedRangeMetrics",
 		                                                      self->thisServerID,
@@ -1643,6 +1648,7 @@ public:
 		                                                           self->thisServerID,
 		                                                           SERVER_KNOBS->LATENCY_METRICS_LOGGING_INTERVAL,
 		                                                           SERVER_KNOBS->LATENCY_SKETCH_ACCURACY)) {
+
 			specialCounter(cc, "LastTLogVersion", [self]() { return self->lastTLogVersion; });
 			specialCounter(cc, "Version", [self]() { return self->version.get(); });
 			specialCounter(cc, "StorageVersion", [self]() { return self->storageVersion(); });
@@ -9234,6 +9240,7 @@ ACTOR Future<Void> fetchKeys(StorageServer* data, AddingShard* shard) {
 					for (; kvItr != this_block.end(); ++kvItr) {
 						data->byteSampleApplySet(*kvItr, invalidVersion);
 					}
+
 					if (this_block.more) {
 						blockBegin = this_block.getReadThrough();
 					} else {
@@ -9322,7 +9329,7 @@ ACTOR Future<Void> fetchKeys(StorageServer* data, AddingShard* shard) {
 				}
 				break;
 			}
-		}
+		} // fetchKeys loop.
 
 		// We have completed the fetch and write of the data, now we wait for MVCC window to pass.
 		//  As we have finished this work, we will allow more work to start...


### PR DESCRIPTION
* fdbclient/ServerKnobs.cpp
* fdbclient/include/fdbclient/ServerKnobs.h Add BULK_LOAD_USE_SST_INGEST knob.

* fdbclient/include/fdbclient/IKeyValueStore.actor.h Add ingestSSTFiles and supportSStIngestion.

* fdbserver/KeyValueStoreRocksDB.actor.cpp
* fdbserver/KeyValueStoreShardedRocksDB.actor.cpp Implement ingestSSTFiles and supportSStIngestion

* fdbserver/storageserver.actor.cpp If BULK_LOAD_USE_SST_INGEST and BulkLoadType::SST, ingest sst file rather than read keyvalues.

* fdbclient/tests/fdb_cluster_fixture.sh Use rocksdb instead of sqllite in tests.
