### PR TITLE
[RELEASE-7.3] fdbkubernetesmonitor: Only log error when there is one (#12085)

### DIFF
--- a/fdbkubernetesmonitor/monitor.go
+++ b/fdbkubernetesmonitor/monitor.go
@@ -225,7 +225,9 @@ func (monitor *monitor) readConfiguration() (*api.ProcessConfiguration, []byte) 
 	}
 	defer func() {
 		err := file.Close()
-		monitor.logger.Error(err, "Error could not close file", "monitorConfigPath", monitor.configFile)
+		if err != nil {
+			monitor.logger.Error(err, "Error could not close file", "monitorConfigPath", monitor.configFile)
+		}
 	}()
 	configuration := &api.ProcessConfiguration{}
 	configurationBytes, err := io.ReadAll(file)


### PR DESCRIPTION
Back-port of https://github.com/apple/foundationdb/pull/12085

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [x] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [x] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
