### PR TITLE
Add 'ls' to s3client for the case where 'aws s3' is not installable

### DIFF
--- a/fdbclient/S3BlobStore.actor.cpp
+++ b/fdbclient/S3BlobStore.actor.cpp
@@ -232,7 +232,22 @@ Reference<S3BlobStoreEndpoint> S3BlobStoreEndpoint::fromString(const std::string
 		resourceFromURL->clear();
 
 	try {
-		StringRef t(url);
+		// Replace HTML-encoded ampersands with raw ampersands
+		std::string decoded_url = url;
+		size_t pos = 0;
+		while ((pos = decoded_url.find("&amp;", pos)) != std::string::npos) {
+			decoded_url.replace(pos, 5, "&");
+			pos += 1;
+		}
+
+		// Also handle double-encoded ampersands
+		pos = 0;
+		while ((pos = decoded_url.find("&amp;amp;", pos)) != std::string::npos) {
+			decoded_url.replace(pos, 9, "&");
+			pos += 1;
+		}
+
+		StringRef t(decoded_url);
 		StringRef prefix = t.eat("://");
 		if (prefix != "blobstore"_sr)
 			throw format("Invalid blobstore URL prefix '%s'", prefix.toString().c_str());
@@ -419,18 +434,17 @@ std::string S3BlobStoreEndpoint::getResourceURL(std::string resource, std::strin
 		params.append(v);
 	}
 
-	if (!params.empty())
+	if (!params.empty()) {
 		r.append("?").append(params);
+	}
 
 	return r;
 }
 
-std::string constructResourcePath(Reference<S3BlobStoreEndpoint> b,
-                                  const std::string& bucket,
-                                  const std::string& object) {
+std::string S3BlobStoreEndpoint::constructResourcePath(const std::string& bucket, const std::string& object) const {
 	std::string resource;
 
-	if (b->getHost().find(bucket + ".") != 0) {
+	if (host.find(bucket + ".") != 0) {
 		resource += std::string("/") + bucket; // not virtual hosting mode
 	}
 
@@ -448,11 +462,19 @@ std::string constructResourcePath(Reference<S3BlobStoreEndpoint> b,
 ACTOR Future<bool> bucketExists_impl(Reference<S3BlobStoreEndpoint> b, std::string bucket) {
 	wait(b->requestRateRead->getAllowance(1));
 
-	state std::string resource = constructResourcePath(b, bucket, "");
+	state std::string resource = b->constructResourcePath(bucket, "");
 	state HTTP::Headers headers;
 
-	Reference<HTTP::IncomingResponse> r = wait(b->doRequest("HEAD", resource, headers, nullptr, 0, { 200, 404 }));
-	return r->code == 200;
+	try {
+		Reference<HTTP::IncomingResponse> r = wait(b->doRequest("HEAD", resource, headers, nullptr, 0, { 200, 404 }));
+		return r->code == 200;
+	} catch (Error& e) {
+		TraceEvent(SevError, "S3ClientBucketExistsError")
+		    .detail("Bucket", bucket)
+		    .detail("Host", b->host)
+		    .errorUnsuppressed(e);
+		throw;
+	}
 }
 
 Future<bool> S3BlobStoreEndpoint::bucketExists(std::string const& bucket) {
@@ -462,7 +484,7 @@ Future<bool> S3BlobStoreEndpoint::bucketExists(std::string const& bucket) {
 ACTOR Future<bool> objectExists_impl(Reference<S3BlobStoreEndpoint> b, std::string bucket, std::string object) {
 	wait(b->requestRateRead->getAllowance(1));
 
-	state std::string resource = constructResourcePath(b, bucket, object);
+	state std::string resource = b->constructResourcePath(bucket, object);
 	state HTTP::Headers headers;
 
 	Reference<HTTP::IncomingResponse> r = wait(b->doRequest("HEAD", resource, headers, nullptr, 0, { 200, 404 }));
@@ -476,7 +498,7 @@ Future<bool> S3BlobStoreEndpoint::objectExists(std::string const& bucket, std::s
 ACTOR Future<Void> deleteObject_impl(Reference<S3BlobStoreEndpoint> b, std::string bucket, std::string object) {
 	wait(b->requestRateDelete->getAllowance(1));
 
-	state std::string resource = constructResourcePath(b, bucket, object);
+	state std::string resource = b->constructResourcePath(bucket, object);
 	state HTTP::Headers headers;
 	// 200 or 204 means object successfully deleted, 404 means it already doesn't exist, so any of those are considered
 	// successful
@@ -570,7 +592,7 @@ ACTOR Future<Void> createBucket_impl(Reference<S3BlobStoreEndpoint> b, std::stri
 
 	bool exists = wait(b->bucketExists(bucket));
 	if (!exists) {
-		state std::string resource = constructResourcePath(b, bucket, "");
+		state std::string resource = b->constructResourcePath(bucket, "");
 		state HTTP::Headers headers;
 
 		std::string region = b->getRegion();
@@ -600,7 +622,7 @@ Future<Void> S3BlobStoreEndpoint::createBucket(std::string const& bucket) {
 ACTOR Future<int64_t> objectSize_impl(Reference<S3BlobStoreEndpoint> b, std::string bucket, std::string object) {
 	wait(b->requestRateRead->getAllowance(1));
 
-	state std::string resource = constructResourcePath(b, bucket, object);
+	state std::string resource = b->constructResourcePath(bucket, object);
 	state HTTP::Headers headers;
 
 	Reference<HTTP::IncomingResponse> r = wait(b->doRequest("HEAD", resource, headers, nullptr, 0, { 200, 404 }));
@@ -931,7 +953,13 @@ std::string getCanonicalURI(Reference<S3BlobStoreEndpoint> bstore, Reference<HTT
 	    awsCanonicalURI(req->resource, queryParameters, CLIENT_KNOBS->HTTP_REQUEST_AWS_V4_HEADER);
 	if (!queryParameters.empty()) {
 		canonicalURI += "?";
-		canonicalURI += boost::algorithm::join(queryParameters, "&");
+		// Use raw ampersands when joining query parameters
+		for (size_t i = 0; i < queryParameters.size(); ++i) {
+			if (i > 0) {
+				canonicalURI += "&";
+			}
+			canonicalURI += queryParameters[i];
+		}
 	}
 
 	if (bstore->useProxy && bstore->knobs.secure_connection == 0) {
@@ -952,7 +980,7 @@ void populateDryrunRequest(Reference<HTTP::OutgoingRequest> dryrunRequest,
 	dryrunRequest->data.headers["Host"] = bstore->host;
 	dryrunRequest->data.headers["Accept"] = "application/xml";
 
-	dryrunRequest->resource = constructResourcePath(bstore, bucket, "");
+	dryrunRequest->resource = bstore->constructResourcePath(bucket, "");
 }
 
 bool isWriteRequest(std::string verb) {
@@ -1348,7 +1376,7 @@ ACTOR Future<Void> listObjectsStream_impl(Reference<S3BlobStoreEndpoint> bstore,
                                           int maxDepth,
                                           std::function<bool(std::string const&)> recurseFilter) {
 	// Request 1000 keys at a time, the maximum allowed
-	state std::string resource = constructResourcePath(bstore, bucket, "");
+	state std::string resource = bstore->constructResourcePath(bucket, "");
 
 	resource.append("/?max-keys=1000");
 	if (prefix.present())
@@ -1369,11 +1397,21 @@ ACTOR Future<Void> listObjectsStream_impl(Reference<S3BlobStoreEndpoint> bstore,
 		state std::string fullResource = resource + lastFile;
 		lastFile.clear();
 		Reference<HTTP::IncomingResponse> r =
-		    wait(bstore->doRequest("GET", fullResource, headers, nullptr, 0, { 200 }));
+		    wait(bstore->doRequest("GET", fullResource, headers, nullptr, 0, { 200, 404 }));
 		listReleaser.release();
 
 		try {
 			S3BlobStoreEndpoint::ListResult listResult;
+
+			// If we got a 404, throw an error to indicate the resource doesn't exist
+			if (r->code == 404) {
+				TraceEvent(SevError, "S3BlobStoreResourceNotFound")
+				    .detail("Bucket", bucket)
+				    .detail("Prefix", prefix.present() ? prefix.get() : "")
+				    .detail("Resource", fullResource);
+				throw resource_not_found();
+			}
+
 			xml_document<> doc;
 
 			// Copy content because rapidxml will modify it during parse
@@ -1842,7 +1880,7 @@ ACTOR Future<std::string> readEntireFile_impl(Reference<S3BlobStoreEndpoint> bst
                                               std::string object) {
 	wait(bstore->requestRateRead->getAllowance(1));
 
-	state std::string resource = constructResourcePath(bstore, bucket, object);
+	state std::string resource = bstore->constructResourcePath(bucket, object);
 	state HTTP::Headers headers;
 	// Set this header on the GET for it to volunteer saved checksum in the response headers.
 	// See https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html#API_GetObject_RequestSyntax
@@ -1886,7 +1924,7 @@ ACTOR Future<Void> writeEntireFileFromBuffer_impl(Reference<S3BlobStoreEndpoint>
 	wait(bstore->concurrentUploads.take());
 	state FlowLock::Releaser uploadReleaser(bstore->concurrentUploads, 1);
 
-	state std::string resource = constructResourcePath(bstore, bucket, object);
+	state std::string resource = bstore->constructResourcePath(bucket, object);
 	state HTTP::Headers headers;
 	// contentHash is calculated by the caller. It is md5 or sha256 dependent on
 	// enable_object_integrity_check setting. If the hash (md5 or sha256) we
@@ -1980,7 +2018,7 @@ ACTOR Future<int> readObject_impl(Reference<S3BlobStoreEndpoint> bstore,
 		// Log rate limiter state
 		wait(bstore->requestRateRead->getAllowance(1));
 
-		state std::string resource = constructResourcePath(bstore, bucket, object);
+		state std::string resource = bstore->constructResourcePath(bucket, object);
 		state HTTP::Headers headers;
 		headers["Range"] = format("bytes=%lld-%lld", offset, offset + length - 1);
 
@@ -2035,7 +2073,7 @@ ACTOR static Future<std::string> beginMultiPartUpload_impl(Reference<S3BlobStore
                                                            std::string object) {
 	wait(bstore->requestRateWrite->getAllowance(1));
 
-	state std::string resource = constructResourcePath(bstore, bucket, object);
+	state std::string resource = bstore->constructResourcePath(bucket, object);
 	resource += "?uploads";
 	state HTTP::Headers headers;
 	if (!CLIENT_KNOBS->BLOBSTORE_ENCRYPTION_TYPE.empty())
@@ -2078,7 +2116,7 @@ ACTOR Future<std::string> uploadPart_impl(Reference<S3BlobStoreEndpoint> bstore,
 	wait(bstore->concurrentUploads.take());
 	state FlowLock::Releaser uploadReleaser(bstore->concurrentUploads, 1);
 
-	state std::string resource = constructResourcePath(bstore, bucket, object);
+	state std::string resource = bstore->constructResourcePath(bucket, object);
 	resource += format("?partNumber=%d&uploadId=%s", partNumber, uploadID.c_str());
 	state HTTP::Headers headers;
 	// Send MD5 sum for content so blobstore can verify it
@@ -2131,7 +2169,7 @@ ACTOR Future<Void> finishMultiPartUpload_impl(Reference<S3BlobStoreEndpoint> bst
 		manifest += format("<Part><PartNumber>%d</PartNumber><ETag>%s</ETag></Part>\n", p.first, p.second.c_str());
 	manifest += "</CompleteMultipartUpload>";
 
-	state std::string resource = constructResourcePath(bstore, bucket, object);
+	state std::string resource = bstore->constructResourcePath(bucket, object);
 	resource += format("?uploadId=%s", uploadID.c_str());
 	state HTTP::Headers headers;
 	PacketWriter pw(part_list.getWriteBuffer(manifest.size()), nullptr, Unversioned());
@@ -2158,7 +2196,7 @@ ACTOR Future<Void> abortMultiPartUpload_impl(Reference<S3BlobStoreEndpoint> bsto
                                              std::string uploadID) {
 	wait(bstore->requestRateWrite->getAllowance(1));
 
-	std::string resource = constructResourcePath(bstore, bucket, object);
+	std::string resource = bstore->constructResourcePath(bucket, object);
 	resource += format("?uploadId=%s", uploadID.c_str());
 
 	HTTP::Headers headers;
@@ -2184,7 +2222,7 @@ ACTOR Future<Void> putObjectTags_impl(Reference<S3BlobStoreEndpoint> bstore,
                                       std::map<std::string, std::string> tags) {
 	state UnsentPacketQueue packets;
 	wait(bstore->requestRateWrite->getAllowance(1));
-	state std::string resource = constructResourcePath(bstore, bucket, object);
+	state std::string resource = bstore->constructResourcePath(bucket, object);
 	resource += "?tagging";
 	state int maxRetries = 5;
 	state int retryCount = 0;
@@ -2259,7 +2297,7 @@ ACTOR Future<std::map<std::string, std::string>> getObjectTags_impl(Reference<S3
                                                                     std::string object) {
 	wait(bstore->requestRateRead->getAllowance(1));
 
-	state std::string resource = constructResourcePath(bstore, bucket, object);
+	state std::string resource = bstore->constructResourcePath(bucket, object);
 	resource += "?tagging";
 	state HTTP::Headers headers;
 

--- a/fdbclient/include/fdbclient/S3BlobStore.h
+++ b/fdbclient/include/fdbclient/S3BlobStore.h
@@ -277,6 +277,9 @@ public:
 	// parameters in addition to the passed params string
 	std::string getResourceURL(std::string resource, std::string params) const;
 
+	// Construct a resource path for S3 operations
+	std::string constructResourcePath(const std::string& bucket, const std::string& object) const;
+
 	// FIXME: add periodic connection reaper to pool
 	// local connection pool for this blobstore
 	Reference<ConnectionPoolData> connectionPool;

--- a/fdbclient/include/fdbclient/S3Client.actor.h
+++ b/fdbclient/include/fdbclient/S3Client.actor.h
@@ -126,5 +126,11 @@ ACTOR Future<Void> deleteResource(std::string s3url);
 // Returns a Future that completes with the hex string representation of the checksum
 ACTOR Future<std::string> calculateFileChecksum(Reference<IAsyncFile> file, int64_t size = -1);
 
+// List files and directories at the given S3 URL
+// s3url: S3 URL to list (must include bucket parameter)
+// maxDepth: Maximum depth to recurse (default: 1)
+// Returns a Future that completes when the operation is done
+ACTOR Future<Void> listFiles(std::string s3url, int maxDepth = 1);
+
 #include "flow/unactorcompiler.h"
 #endif

--- a/flow/include/flow/error_definitions.h
+++ b/flow/include/flow/error_definitions.h
@@ -195,7 +195,7 @@ ERROR( lock_file_failure, 1529, "Unable to lock the file")
 ERROR( rest_unsupported_protocol, 1530, "Unsupported REST protocol")
 ERROR( rest_malformed_response, 1531, "Malformed REST response")
 ERROR( rest_max_base_cipher_len, 1532, "Max BaseCipher length violation")
-
+ERROR( resource_not_found, 1533, "Requested resource was not found" )
 
 // 2xxx Attempt (presumably by a _client_) to do something illegal.  If an error is known to
 // be internally caused, it should be 41xx


### PR DESCRIPTION
-- i.e. production -- and we want a tool to test s3 connectivity.

Use it like this:

~/build_output/bin/s3client \
  --tls-ca-file /etc/ssl/cert.pem \
  --blob-credentials /path/to/credentials.json \
  ls "blobstore://backup-us-west-2.s3.amazonaws.com/x?bucket=backup-us-west-2&region=us-west-2"

* fdbclient/S3BlobStore.actor.cpp
* fdbclient/include/fdbclient/S3BlobStore.h Make constructResourcePath method on endpoint so accessible making ls URLs. Handling for encoded ampersands too. Allow 404 when requesting resource that doesn't exist.

* fdbclient/S3Client.actor.cpp
* fdbclient/S3Client_cli.actor.cpp Add in ls implementation.

* fdbclient/tests/s3client_test.sh Add test for new ls facility.