### PR TITLE
Backup unit test fix.

### DIFF
--- a/fdbclient/BackupContainerFileSystem.actor.cpp
+++ b/fdbclient/BackupContainerFileSystem.actor.cpp
@@ -2283,7 +2283,7 @@ ACTOR Future<Void> testBackupContainerWithMissingLogRanges(std::string url, Opti
 	state Version logEnd = v;
 	state Version snapshotBeginVersion = v;
 	state Version snapshotEndVersion = v;
-	state bool nextSnapshotMissingLogs = false;
+	state Version lastMissedLogFileEnd = 0;
 
 	// create a random number of snapshots
 	state int numSnapshots = deterministicRandom()->randomInt(1, 10);
@@ -2312,8 +2312,9 @@ ACTOR Future<Void> testBackupContainerWithMissingLogRanges(std::string url, Opti
 		                                              deterministicRandom()->randomInt(0, 2e6),
 		                                              IncludeKeyRangeMap(BUGGIFY)));
 
-		snapshotsMissingLogs.push_back(nextSnapshotMissingLogs);
-		nextSnapshotMissingLogs = false;
+		// if the last missing log file overlaps with the current snapshot,
+		// mark snapshotsMissingLogs for current snapshot as true.
+		snapshotsMissingLogs.push_back(lastMissedLogFileEnd > snapshotBeginVersion);
 
 		// creating log files for the snapshot range.
 		while (logStart < logEnd) {
@@ -2325,8 +2326,7 @@ ACTOR Future<Void> testBackupContainerWithMissingLogRanges(std::string url, Opti
 				// If the missing log range falls in the current snapshot range, mark it.
 				if (!(tempLogEnd < snapshotBeginVersion || snapshotEndVersion < logStart))
 					snapshotsMissingLogs.back() = true;
-				if (tempLogEnd > v) // if it overlaps with the next snapshot, mark the next snapshot as well.
-					nextSnapshotMissingLogs = true;
+				lastMissedLogFileEnd = tempLogEnd;
 			}
 			logStart = tempLogEnd;
 		}


### PR DESCRIPTION
Backup unit test fix. The code did not handle the missing log file overlapping with the snapshots after the next one. Fixed it.
Test started failing in simulation runs. Test passed after this fix
Running 100k run:
20250424-153641-neethuhaneeshabingi-0d70a778936e474e compressed=True data_size=51334928 duration=6084626 ended=100000 fail_fast=10 max_runs=100000 pass=100000

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
