### PR TITLE
RocksDB Do Compact After BulkLoad

### DIFF
--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -9264,7 +9264,7 @@ ACTOR Future<Void> fetchKeys(StorageServer* data, AddingShard* shard) {
 					const double ingestDuration = g_network->timer() - ingestStartTime;
 					data->counters.ingestDurationLatencySample->addMeasurement(ingestDuration);
 
-					// Compact the range after ingestion to avoid accumulating TODO compaction
+					// Compact the range after ingestion to avoid accumulating compaction overtime
 					wait(data->storage.getKeyValueStore()->compactRange(keys));
 
 					// Process sample files after SST ingestion
@@ -9453,7 +9453,7 @@ ACTOR Future<Void> fetchKeys(StorageServer* data, AddingShard* shard) {
 		    data->storage.getKeyValueStore()->supportsSstIngestion()) {
 			// Wait until the load data has been committed
 			wait(data->durableVersion.whenAtLeast(data->storageVersion() + 1));
-			// Compact the range to avoid accumulating TODO compaction
+			// Compact the range after ingestion to avoid accumulating compaction overtime
 			wait(data->storage.getKeyValueStore()->compactRange(keys));
 		}
 

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -9264,6 +9264,9 @@ ACTOR Future<Void> fetchKeys(StorageServer* data, AddingShard* shard) {
 					const double ingestDuration = g_network->timer() - ingestStartTime;
 					data->counters.ingestDurationLatencySample->addMeasurement(ingestDuration);
 
+					// Compact the range after ingestion to avoid accumulating TODO compaction
+					wait(data->storage.getKeyValueStore()->compactRange(keys));
+
 					// Process sample files after SST ingestion
 					wait(processSampleFiles(data, bulkLoadLocalDir, localBulkLoadFileSets));
 
@@ -9445,6 +9448,14 @@ ACTOR Future<Void> fetchKeys(StorageServer* data, AddingShard* shard) {
 				break;
 			}
 		} // fetchKeys loop.
+
+		if (conductBulkLoad && !SERVER_KNOBS->BULK_LOAD_USE_SST_INGEST &&
+		    data->storage.getKeyValueStore()->supportsSstIngestion()) {
+			// Wait until the load data has been committed
+			wait(data->durableVersion.whenAtLeast(data->storageVersion() + 1));
+			// Compact the range to avoid accumulating TODO compaction
+			wait(data->storage.getKeyValueStore()->compactRange(keys));
+		}
 
 		// We have completed the fetch and write of the data, now we wait for MVCC window to pass.
 		//  As we have finished this work, we will allow more work to start...

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -9451,9 +9451,11 @@ ACTOR Future<Void> fetchKeys(StorageServer* data, AddingShard* shard) {
 
 		if (conductBulkLoad && !SERVER_KNOBS->BULK_LOAD_USE_SST_INGEST &&
 		    data->storage.getKeyValueStore()->supportsSstIngestion()) {
-			// Wait until the load data has been committed
+			// This block is for the fetchKey without SST ingestion case.
+			// For the SST ingestion case, we have already compacted the range right after ingestion.
+			// Wait until the load data has been committed.
 			wait(data->durableVersion.whenAtLeast(data->storageVersion() + 1));
-			// Compact the range after ingestion to avoid accumulating compaction overtime
+			// Compact the range after ingestion to avoid accumulating compaction overtime.
 			wait(data->storage.getKeyValueStore()->compactRange(keys));
 		}
 


### PR DESCRIPTION
At this point, RocksDB bulkload with SST ingestion is as fast as the SQLite bulkload.

100K correctness:
  20250501-170037-zhewang-f3e4b3f8cacecb7b           compressed=True data_size=41162458 duration=5640698 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:24:32 sanity=False started=100000 stopped=20250501-182509 submitted=20250501-170037 timeout=5400 username=zhewang
  
# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
