### PR TITLE
set build_output_directory for cbuild_output when CLANG set

### DIFF
--- a/packaging/docker/build-images.sh
+++ b/packaging/docker/build-images.sh
@@ -46,9 +46,9 @@ function create_fake_website_directory () {
     # 2) fetch the stripped binaries and multiple client library versions
     #    from artifactory_base_url
     # 3) copy the unstripped binaries and client library from the current local
-    #    build_output of foundationdb
+    #    build_output of foundationdb. If CLANG=1 use cbuild_output.
     # 4) copy the stripped binaries and client library from the current local
-    #    build_output of foundationdb
+    #    build_output of foundationdb. If CLANG=1 use cbuild_output.
     ############################################################################
     logg "FETCHING BINARIES"
     case "${stripped_binaries_and_from_where}" in
@@ -272,7 +272,11 @@ if [ -n "${OKTETO_NAMESPACE+x}" ]; then
     imdsv2_token=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
     aws_region=$(curl -H "X-aws-ec2-metadata-token: ${imdsv2_token}" "http://169.254.169.254/latest/meta-data/placement/region")
     aws_account_id=$(aws --output text sts get-caller-identity --query 'Account')
-    build_output_directory="${HOME}/build_output"
+    if [ "${CLANG:-0}" -eq 1 ]; then
+        build_output_directory="${HOME}/cbuild_output"
+    else
+        build_output_directory="${HOME}/build_output"
+    fi
     fdb_library_versions=( "${fdb_version}" )
     registry="${aws_account_id}.dkr.ecr.${aws_region}.amazonaws.com"
     tag_base="${registry}/foundationdb/"


### PR DESCRIPTION
If CLANG is set to 1, copy binaries and client library from the current local `cbuild_output` of foundationdb.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
