### PR TITLE
BulkLoad Job Root Should Overwrite Task Root Path

### DIFF
--- a/fdbclient/include/fdbclient/BulkLoading.h
+++ b/fdbclient/include/fdbclient/BulkLoading.h
@@ -302,6 +302,16 @@ public:
 		       ", [ByteSampleFileName]: " + byteSampleFileName + ", " + checksum.toString();
 	}
 
+	void setRootPath(const std::string& inputRootPath) {
+		if (rootPath != inputRootPath) {
+			TraceEvent(SevWarn, "DDBulkLoadFileSetRootPathChanged")
+			    .suppressFor(10.0)
+			    .detail("OldRootPath", rootPath)
+			    .detail("NewRootPath", inputRootPath);
+			rootPath = inputRootPath;
+		}
+	}
+
 	template <class Ar>
 	void serialize(Ar& ar) {
 		serializer(ar, rootPath, relativePath, manifestFileName, dataFileName, byteSampleFileName, checksum);
@@ -501,6 +511,8 @@ public:
 		       ", [TransportMethod]: " + std::to_string(static_cast<uint8_t>(transportMethod));
 	}
 
+	void setRootPath(const std::string& rootPath) { fileSet.setRootPath(rootPath); }
+
 	template <class Ar>
 	void serialize(Ar& ar) {
 		serializer(ar,
@@ -658,6 +670,12 @@ public:
 	}
 
 	std::string toString() const { return describe(manifests); }
+
+	void setRootPath(const std::string& rootPath) {
+		for (auto& manifest : manifests) {
+			manifest.setRootPath(rootPath);
+		}
+	}
 
 	template <class Ar>
 	void serialize(Ar& ar) {

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -1626,6 +1626,7 @@ ACTOR Future<Void> bulkLoadJobNewTask(Reference<DataDistributor> self,
 		// Discussion about what if another newer job has persist some task on the range with a different
 		// job Id. This case should never happen because before the newer job starts, the old job has
 		// completed or cancelled.
+		manifests.setRootPath(jobRoot);
 		wait(store(bulkLoadTask, bulkLoadJobSubmitTask(self, jobId, manifests)));
 
 		TraceEvent(bulkLoadVerboseEventSev(), "DDBulkLoadJobExecutorTask", self->ddId)


### PR DESCRIPTION
In case the dataset folder is moved across different roots, we still want to load the data. In this case, the root path in the task metadata is not consistent to the job root path. The job root should overwrite the task root in the task metadata.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
