### PR TITLE
Backup URL validation for directory traversals.

### DIFF
--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -2319,6 +2319,13 @@ Reference<IBackupContainer> openBackupContainer(const char* name,
 		throw backup_error();
 	}
 
+	if (destinationContainer.find("../") != std::string::npos) {
+		fprintf(
+		    stderr, "ERROR: Backup Container URL '%s' contains directory traversals\n", destinationContainer.c_str());
+		printHelpTeaser(name);
+		throw backup_invalid_url();
+	}
+
 	Reference<IBackupContainer> c;
 	try {
 		c = IBackupContainer::openContainer(destinationContainer, proxy, encryptionKeyFile);


### PR DESCRIPTION
Backup URL validation for directory traversals.
Running 100k simulation test.
20250508-180315-neethu-url-main-4810fcb2e1710507  ended=100000 fail_fast=10 max_runs=100000 pass=100000 

BEFORE:
```
./fdbbackup describe -d 'file:///tmp/../../../etc/passwd'
ERROR: 'Backup Container URL invalid' on URL 'file:///tmp/../../../etc/passwd': Backup path '/tmp/../../../etc/passwd' must be the absolute path '/etc/passwd'
Try `./fdbbackup --help' for more information.
ERROR: Backup Container URL invalid
Fatal Error: Backup Container URL invalid
```

AFTER:
```
ERROR: Backup Container URL 'file:///tmp/../../../etc/passwd' contains directory traversals
Try `./fdbbackup --help' for more information.
ERROR: Backup Container URL invalid
Fatal Error: Backup Container URL invalid
```

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
