### PR TITLE
Backup URL validation for directory traversals

### DIFF
--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -2319,6 +2319,13 @@ Reference<IBackupContainer> openBackupContainer(const char* name,
 		throw backup_error();
 	}
 
+	if (destinationContainer.find("../") != std::string::npos) {
+		fprintf(
+		    stderr, "ERROR: Backup Container URL '%s' contains directory traversals\n", destinationContainer.c_str());
+		printHelpTeaser(name);
+		throw backup_invalid_url();
+	}
+
 	Reference<IBackupContainer> c;
 	try {
 		c = IBackupContainer::openContainer(destinationContainer, proxy, encryptionKeyFile);


### PR DESCRIPTION
cherry-pick of #12139

100K simulation test: 1failure not related to changes(BlobGranule)
20250509-172312-neethuhaneeshabingi-60d2118b157f1e03 compressed=True data_size=56134491 duration=5583647 ended=100000 fail=1 fail_fast=10 max_runs=100000 pass=99999 




# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
