### PR TITLE
Simple standlone fdb_checksum_tool to checksum fdb database until we

### DIFF
--- a/fdbcli/CMakeLists.txt
+++ b/fdbcli/CMakeLists.txt
@@ -71,3 +71,5 @@ if (NOT WIN32 AND NOT OPEN_FOR_IDE)
     )
   endif()
 endif()
+
+add_subdirectory(fdb_checksum_tool)

--- a/fdbcli/fdb_checksum_tool/CMakeLists.txt
+++ b/fdbcli/fdb_checksum_tool/CMakeLists.txt
@@ -43,9 +43,8 @@ target_link_libraries(fdb_checksum_tool PRIVATE
     fdbrpc
     flow
     fdb_flow
-    "${CMAKE_BINARY_DIR}/boost_install/lib/libboost_program_options.a"
-    "${CMAKE_BINARY_DIR}/boost_install/lib/libboost_system.a"
-    "${CMAKE_BINARY_DIR}/boost_install/lib/libboost_filesystem.a"
+    boost_target
+    boost_target_program_options
     stacktrace
     fmt::fmt
 )

--- a/fdbcli/fdb_checksum_tool/CMakeLists.txt
+++ b/fdbcli/fdb_checksum_tool/CMakeLists.txt
@@ -1,0 +1,59 @@
+# CMakeLists.txt for fdb_checksum_tool
+
+# Source file for the tool
+set(TOOL_SRCS fdb_checksum_tool.actor.cpp)
+
+add_flow_target(EXECUTABLE NAME fdb_checksum_tool SRCS ${TOOL_SRCS})
+
+target_compile_definitions(fdb_checksum_tool PRIVATE WITH_ROCKSDB)
+
+# Include directories. All FDB-specific includes will be relative to CMAKE_SOURCE_DIR.
+set(FDB_SOURCE_DIR ${CMAKE_SOURCE_DIR})
+
+target_include_directories(fdb_checksum_tool PUBLIC
+    # For fdbclient headers (e.g., NativeAPI.actor.h)
+    "${CMAKE_SOURCE_DIR}/fdbclient/include"
+    "${CMAKE_BINARY_DIR}/fdbclient/include"
+
+    # For flow headers (e.g., flow.h, actorcompiler.h)
+    "${CMAKE_SOURCE_DIR}/flow/include"
+    "${CMAKE_BINARY_DIR}/flow/include"
+
+    # For fdbrpc headers
+    "${CMAKE_SOURCE_DIR}/fdbrpc/include"
+    "${CMAKE_BINARY_DIR}/fdbrpc/include"
+
+    # For xxhash.h directly from flow source if not in flow/include
+    "${CMAKE_SOURCE_DIR}/flow"
+
+    # Add C binding directories used by fdbclient
+    "${CMAKE_SOURCE_DIR}/bindings/c/foundationdb"
+    "${CMAKE_BINARY_DIR}/bindings/c/foundationdb"
+
+    # For fmt library
+    ${FMT_INCLUDE_DIRS}
+
+    # For Boost headers
+    "${CMAKE_BINARY_DIR}/boost_install/include"
+)
+
+# Link libraries
+target_link_libraries(fdb_checksum_tool PRIVATE
+    fdbclient
+    fdbrpc
+    flow
+    fdb_flow
+    "${CMAKE_BINARY_DIR}/boost_install/lib/libboost_program_options.a"
+    "${CMAKE_BINARY_DIR}/boost_install/lib/libboost_system.a"
+    "${CMAKE_BINARY_DIR}/boost_install/lib/libboost_filesystem.a"
+    stacktrace
+    fmt::fmt
+)
+
+# Add fdbclient as a dependency to ensure its generated headers are available
+add_dependencies(fdb_checksum_tool fdboptions fdbclient)
+
+# Installation rules
+if(NOT OPEN_FOR_IDE AND FDB_INSTALL_PROGRAMS)
+  fdb_install(TARGETS fdb_checksum_tool DESTINATION bin COMPONENT tools)
+endif() 

--- a/fdbcli/fdb_checksum_tool/fdb_checksum_tool.actor.cpp
+++ b/fdbcli/fdb_checksum_tool/fdb_checksum_tool.actor.cpp
@@ -1,0 +1,364 @@
+/*
+ * fdb_checksum_tool.actor.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2024 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#define FDB_USE_LATEST_API_VERSION
+#include "flow/flow.h"
+#include "flow/Error.h"
+#include "flow/FastRef.h"
+#include "flow/IRandom.h"
+#include "flow/ThreadHelper.actor.h"
+#include "flow/Trace.h"
+#include "flow/Platform.h"
+#include "flow/IThreadPool.h"
+
+#include "fdbclient/FDBTypes.h"
+#include "fdbclient/ReadYourWrites.h"
+#include "fdbclient/DatabaseContext.h"
+#include "fdbclient/FDBOptions.g.h"
+#include "fdbclient/NativeAPI.actor.h"
+#include "fdbclient/CoordinationInterface.h"
+#include "fdbclient/ClusterConnectionFile.h"
+#include "flow/TLSConfig.actor.h"
+#include "flow/xxhash.h"
+#include "fdbclient/ChecksumDatabase.actor.h" // This now brings in actorcompiler.h for its own actors
+
+// Include C API here
+#include "foundationdb/fdb_c.h"
+
+#include <fmt/format.h>
+#include <thread>
+
+#include <iostream>
+#include <string>
+#include <vector>
+#include <stdexcept>
+#include <boost/program_options.hpp>
+
+#include "fdbclient/Tuple.h"
+
+#include "fdbclient/ThreadSafeTransaction.h"
+#include "flow/ApiVersion.h"
+#include "flow/ArgParseUtil.h"
+#include "flow/DeterministicRandom.h"
+
+#include "fdbclient/MultiVersionTransaction.h" // For MultiVersionApi access
+
+#define API ((IClientApi*)MultiVersionApi::api) // Define API like in fdbcli
+
+namespace po = boost::program_options;
+
+// Include actorcompiler.h here, before local actor definitions
+#include "flow/actorcompiler.h"
+
+// Forward declare the fdbclient actor we will call *inside* the wrapper
+namespace fdb {
+ACTOR Future<fdb::ChecksumResult> calculateDatabaseChecksum(Database cx, Optional<KeyRange> range);
+}
+
+// Helper actor to ensure network is stopped
+ACTOR template <class T>
+Future<T> stopNetworkAfter_actor(Future<T> what) {
+	state T result;
+	try {
+		T t = wait(what);
+		result = t;
+	} catch (...) {
+		API->stopNetwork(); // Use API to stop network
+		throw;
+	}
+	API->stopNetwork(); // Use API to stop network
+	return result;
+}
+
+// Helper function to unescape keys (from previous work)
+// Very close to  NativeAPI::unprintable. TODO: Unify them.
+std::string unescapeKeyString(const std::string& s) {
+	std::string result_str; // Renamed to avoid conflict with actor state 'result'
+	result_str.reserve(s.length());
+	for (size_t i = 0; i < s.length(); ++i) {
+		if (s[i] == '\\') {
+			if (i + 1 < s.length()) {
+				char next = s[i + 1];
+				if (next == 'x') {
+					if (i + 3 < s.length()) {
+						try {
+							std::string hex = s.substr(i + 2, 2);
+							char val = static_cast<char>(std::stoi(hex, nullptr, 16));
+							result_str.push_back(val);
+							i += 3;
+						} catch (const std::exception& e) {
+							// Invalid hex sequence, treat as literal '\\x'
+							result_str.push_back(s[i]);
+							result_str.push_back(next);
+							i += 1;
+						}
+					} else {
+						// Incomplete hex, treat as literal '\\x'
+						result_str.push_back(s[i]);
+						result_str.push_back(next);
+						i += 1;
+					}
+				} else if (next == '\\') {
+					result_str.push_back('\\');
+					i += 1;
+				} else {
+					// Unknown escape, treat as literal backslash
+					result_str.push_back(s[i]);
+				}
+			} else {
+				// Trailing backslash
+				result_str.push_back(s[i]);
+			}
+		} else {
+			result_str.push_back(s[i]);
+		}
+	}
+	return result_str;
+}
+
+// Helper function to format bytes for display
+std::string formatBytes(uint64_t bytes) {
+	const char* units[] = { "B", "KB", "MB", "GB", "TB" };
+	int unit = 0;
+	double size = static_cast<double>(bytes);
+
+	while (size >= 1024.0 && unit < 4) {
+		size /= 1024.0;
+		unit++;
+	}
+
+	return fmt::format("{:.2f} {}", size, units[unit]);
+}
+
+// Main tool actor - Modified to create Database inside
+ACTOR Future<Void> checksumToolActor(Reference<ClusterConnectionFile> ccf,
+                                     int apiVersion,
+                                     Optional<Standalone<StringRef>> beginKeyOpt,
+                                     Optional<Standalone<StringRef>> endKeyOpt) {
+	state Database db;
+	state Optional<KeyRange> keyRange;
+	state double startTime;
+	state fdb::ChecksumResult result;
+
+	try {
+		db = Database::createDatabase(ccf, apiVersion, IsInternal::False, LocalityData());
+
+		if (endKeyOpt.present()) {
+			TraceEvent(SevInfo, "ChecksumToolEndKeyOptDebug")
+			    .detail("EndKeyOptPrintable", endKeyOpt.get().printable())
+			    .detail("EndKeyOptSize", endKeyOpt.get().size());
+		}
+
+		if (beginKeyOpt.present() || endKeyOpt.present()) {
+			Key b = beginKeyOpt.present() ? beginKeyOpt.get() : KeyRef();
+			Key e = endKeyOpt.present() ? endKeyOpt.get() : "\\xff\\xff"_sr;
+			keyRange = KeyRangeRef(b, e);
+		}
+
+		printf("Attempting to get read version (timeout 10s)...\n");
+		state ReadYourWritesTransaction trTest(db);
+		try {
+			Version v = wait(trTest.getReadVersion());
+			printf("Successfully connected. Read version: %lld\n", v);
+		} catch (Error& e) {
+			printf("ERROR: Could not connect to database or get read version: %s (%d)\n", e.what(), e.code());
+			throw;
+		}
+
+		printf("Begin key: %s\n", keyRange.present() ? keyRange.get().begin.printable().c_str() : "");
+		printf("End key:   %s\n\n", keyRange.present() ? keyRange.get().end.printable().c_str() : "\\\\xff");
+
+		printf("\nStarting checksum calculation...\n");
+		startTime = timer_monotonic();
+
+		state fdb::ChecksumResult checksum_actor_result = wait(fdb::calculateDatabaseChecksum(db, keyRange));
+		result = checksum_actor_result;
+
+		double duration = timer_monotonic() - startTime;
+		printf("\nChecksum calculation complete.\n");
+		printf("-------------------------------------\n");
+		printf("FoundationDB Database Checksum Result\n");
+		printf("-------------------------------------\n");
+		printf("Checksum:         0x%016llx\n", result.checksum);
+		printf("Total Keys:       %lld\n", result.totalKeys);
+		printf("Total Bytes:      %s (%lld B)\n", formatBytes(result.totalBytes).c_str(), result.totalBytes);
+		printf("Time Taken:       %.2f seconds\n", duration);
+		printf("-------------------------------------\n");
+
+	} catch (Error& e) {
+		throw;
+	}
+
+	return Void();
+}
+
+// Corrected runChecksumTool to take ccf and create Database inside
+ACTOR Future<Void> runChecksumTool(Reference<ClusterConnectionFile> ccf,
+                                   int apiVersion,
+                                   std::string beginKeyStr,
+                                   std::string endKeyStr) {
+	// Database creation moved to checksumToolActor
+
+	Optional<Standalone<StringRef>> beginKeyOpt;
+	if (!beginKeyStr.empty()) {
+		beginKeyOpt = StringRef((const uint8_t*)beginKeyStr.c_str(), beginKeyStr.size());
+	}
+	Optional<Standalone<StringRef>> endKeyOpt;
+	if (!endKeyStr.empty()) {
+		endKeyOpt = StringRef((const uint8_t*)endKeyStr.c_str(), endKeyStr.size());
+	}
+
+	try {
+		// Pass ccf and apiVersion to checksumToolActor
+		wait(checksumToolActor(ccf, apiVersion, beginKeyOpt, endKeyOpt));
+	} catch (Error& e) {
+		// This will now catch any error thrown by checksumToolActor
+		TraceEvent(SevError, "RunChecksumToolError").error(e); // Keep tracing
+		fprintf(stderr, "Error in runChecksumTool: %s (%d)\n", e.what(), e.code()); // Print for clarity
+		throw; // Rethrow to be caught by main
+	}
+	return Void();
+}
+
+int main(int argc, char** argv) {
+	platformInit(); // Add platformInit() like in fdbcli
+	try {
+		// --- Stage 1: Parse command line options ---
+		std::string clusterFile;
+		std::string beginKeyStr = "";
+		std::string endKeyStr = "\xff";
+		std::string tlsCertPath, tlsKeyPath, tlsCaPath;
+		std::string tlsVerifyPeers;
+		int parsedApiVersion = FDB_API_VERSION; // Use a different name to avoid conflict with fdb_c.h FDB_API_VERSION
+		bool logTrace = false;
+		std::string logDir;
+		std::string logGroup;
+		std::vector<std::string> knobs;
+		bool printVersion = false;
+
+		po::options_description desc("fdb_checksum_tool options");
+		desc.add_options()("help,h", "Print help message")(
+		    "version,v", po::bool_switch(&printVersion), "Print version information and exit")(
+		    "cluster-file,C",
+		    po::value<std::string>(&clusterFile)->default_value(""),
+		    "FoundationDB cluster file (defaults to system default)")(
+		    "api-version", po::value<int>(&parsedApiVersion)->default_value(FDB_API_VERSION), "API version to use")(
+		    "begin,b", po::value<std::string>(&beginKeyStr), "Begin key (escaped string)")(
+		    "end,e", po::value<std::string>(&endKeyStr), "End key (escaped string, defaults to \\\\xff)")(
+		    "log", po::bool_switch(&logTrace), "Enable trace logging")(
+		    "log-dir", po::value<std::string>(&logDir), "Directory for trace logs")(
+		    "log-group", po::value<std::string>(&logGroup), "Trace log group name")(
+		    "knob",
+		    po::value<std::vector<std::string>>(&knobs)->composing(),
+		    "Set a knob (e.g., knob_name=knob_value)")(
+		    "tls_certificate_file", po::value<std::string>(&tlsCertPath)->default_value(""), "TLS certificate file")(
+		    "tls_key_file", po::value<std::string>(&tlsKeyPath)->default_value(""), "TLS key file")(
+		    "tls_ca_file", po::value<std::string>(&tlsCaPath)->default_value(""), "TLS CA certificate bundle file")(
+		    "tls_verify_peers",
+		    po::value<std::string>(&tlsVerifyPeers)->default_value(""),
+		    "TLS peer verification rules");
+
+		po::variables_map vm;
+		po::store(po::parse_command_line(argc, argv, desc), vm);
+		po::notify(vm);
+
+		if (vm.count("help")) {
+			std::cout << desc << std::endl;
+			return 0;
+		}
+
+		if (printVersion) {
+			std::cout << "FDB API Version compiled: " << FDB_API_VERSION << std::endl;
+			return 0;
+		}
+
+		// Apply network options BEFORE API version selection or network setup
+		if (!tlsCertPath.empty()) {
+			setNetworkOption(FDBNetworkOptions::TLS_CERT_PATH, StringRef(tlsCertPath));
+		}
+		if (!tlsKeyPath.empty()) {
+			setNetworkOption(FDBNetworkOptions::TLS_KEY_PATH, StringRef(tlsKeyPath));
+		}
+		if (!tlsCaPath.empty()) {
+			setNetworkOption(FDBNetworkOptions::TLS_CA_PATH, StringRef(tlsCaPath));
+		}
+		if (!tlsVerifyPeers.empty()) {
+			setNetworkOption(FDBNetworkOptions::TLS_VERIFY_PEERS, StringRef(tlsVerifyPeers));
+		}
+		// Apply other network options like trace logging if parsed
+		if (logTrace) {
+			setNetworkOption(FDBNetworkOptions::TRACE_ENABLE,
+			                 logDir.empty() ? Optional<StringRef>() : Optional<StringRef>(StringRef(logDir)));
+			if (!logGroup.empty()) {
+				setNetworkOption(FDBNetworkOptions::TRACE_LOG_GROUP, StringRef(logGroup));
+			}
+			// traceFormat is already handled by networkOptions defaults or set via TRACE_FORMAT if explicitly set
+		}
+
+		API->selectApiVersion(parsedApiVersion);
+		API->setupNetwork();
+		TraceEvent::setNetworkThread(); // Set the current thread as the network thread
+
+		// Moved knob application to after setupNetwork, similar to fdbcli's opt.setupKnobs()
+		// Note: fdbcli does IKnobCollection::setupKnobs and then
+		// IKnobCollection::getMutableGlobalKnobCollection().initialize(). Here, we just re-apply via setNetworkOption
+		// which should achieve immediate application.
+		for (const auto& knob_str : knobs) { // 'knobs' is the std::vector<std::string> from arg parsing
+			setNetworkOption(FDBNetworkOptions::KNOB, StringRef(knob_str));
+		}
+
+		// --- Stage 4: Get Cluster Connection File ---
+		Reference<ClusterConnectionFile> ccf;
+		if (clusterFile.empty()) {
+			ccf = ClusterConnectionFile::openOrDefault("");
+		} else {
+			ccf = ClusterConnectionFile::openOrDefault(clusterFile);
+		}
+
+		// Database object created inside runChecksumTool actor
+
+		// Prepare arguments for the main actor
+		std::string unescapedBeginKey = unescapeKeyString(beginKeyStr);
+		std::string unescapedEndKey = unescapeKeyString(endKeyStr);
+
+		Future<Void> checksumFuture = runChecksumTool(ccf, parsedApiVersion, unescapedBeginKey, unescapedEndKey);
+		Future<Void> mainFuture = stopNetworkAfter_actor(checksumFuture); // Use renamed helper
+
+		try {
+			API->runNetwork(); // Use API interface
+
+			if (mainFuture.isError()) {
+				throw mainFuture.getError();
+			}
+
+			return 0;
+		} catch (Error& e) {
+			fprintf(stderr, "ERROR: Network or Actor failed: %s (code: %d)\n", e.what(), e.code());
+			return 1;
+		}
+
+	} catch (const boost::program_options::error& e) {
+		std::cerr << "ERROR parsing command line options: " << e.what() << std::endl;
+		return 1;
+	} catch (const std::exception& e) {
+		std::cerr << "ERROR: " << e.what() << std::endl;
+		return 1;
+	}
+	return 0;
+}

--- a/fdbcli/fdb_checksum_tool/fdb_checksum_tool.actor.cpp
+++ b/fdbcli/fdb_checksum_tool/fdb_checksum_tool.actor.cpp
@@ -17,7 +17,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#ifndef NO_INTELLISENSE
+// In IDE, we need to define the API version explicitly
+#define FDB_API_VERSION 710
+#else
+// In actual build, use the latest version
 #define FDB_USE_LATEST_API_VERSION
+#endif
+
 #include "flow/flow.h"
 #include "flow/Error.h"
 #include "flow/FastRef.h"
@@ -37,9 +44,6 @@
 #include "flow/TLSConfig.actor.h"
 #include "flow/xxhash.h"
 #include "fdbclient/ChecksumDatabase.actor.h" // This now brings in actorcompiler.h for its own actors
-
-// Define FDB_API_VERSION before including fdb_c.h
-#define FDB_API_VERSION 710
 
 // Include C API here
 #include "foundationdb/fdb_c.h"

--- a/fdbcli/fdb_checksum_tool/fdb_checksum_tool.actor.cpp
+++ b/fdbcli/fdb_checksum_tool/fdb_checksum_tool.actor.cpp
@@ -38,6 +38,9 @@
 #include "flow/xxhash.h"
 #include "fdbclient/ChecksumDatabase.actor.h" // This now brings in actorcompiler.h for its own actors
 
+// Define FDB_API_VERSION before including fdb_c.h
+#define FDB_API_VERSION 710
+
 // Include C API here
 #include "foundationdb/fdb_c.h"
 

--- a/fdbclient/CMakeLists.txt
+++ b/fdbclient/CMakeLists.txt
@@ -69,20 +69,6 @@ if(WITH_AWS_BACKUP)
   include(awssdk)
 endif()
 
-# Find Homebrew fmt directly
-find_path(FMT_INCLUDE_DIR NAMES fmt/core.h
-    HINTS /opt/homebrew/opt/fmt/include NO_DEFAULT_PATH)
-find_library(FMT_LIBRARY NAMES fmt
-    HINTS /opt/homebrew/opt/fmt/lib NO_DEFAULT_PATH)
-
-if(FMT_INCLUDE_DIR AND FMT_LIBRARY)
-    message(STATUS "Found Homebrew fmt: ${FMT_LIBRARY} (includes: ${FMT_INCLUDE_DIR})")
-    set(PC_FMT_INCLUDE_DIRS ${FMT_INCLUDE_DIR}) # Keep variable name for compatibility downstream if used
-    set(PC_FMT_LIBRARIES ${FMT_LIBRARY})     # Keep variable name for compatibility downstream if used
-else()
-    message(FATAL_ERROR "Homebrew fmt not found. Please install with 'brew install fmt'")
-endif()
-
 add_flow_target(STATIC_LIBRARY NAME fdbclient SRCS ${FDBCLIENT_SRCS} ADDL_SRCS ${options_srcs})
 target_include_directories(fdbclient PUBLIC
     "${CMAKE_CURRENT_SOURCE_DIR}/include"
@@ -105,7 +91,6 @@ target_include_directories(s3client PRIVATE
     "${CMAKE_SOURCE_DIR}/contrib/md5/include"
     "${CMAKE_SOURCE_DIR}/contrib/libb64/include"
     "/opt/boost_1_86_0_clang/include"
-    ${PC_FMT_INCLUDE_DIRS}
 )
 
 target_link_libraries(s3client PRIVATE
@@ -116,7 +101,7 @@ target_link_libraries(s3client PRIVATE
     md5
     libb64
     stacktrace
-    ${PC_FMT_LIBRARIES}
+    fmt::fmt
     crc32
     eio
     rapidxml

--- a/fdbclient/CMakeLists.txt
+++ b/fdbclient/CMakeLists.txt
@@ -1,5 +1,6 @@
 fdb_find_sources(FDBCLIENT_SRCS)
 list(APPEND FDBCLIENT_SRCS sha1/SHA1.cpp)
+list(APPEND FDBCLIENT_SRCS ChecksumDatabase.actor.cpp)
 
 message(STATUS "FDB version is ${FDB_VERSION}")
 message(STATUS "FDB package name is ${FDB_PACKAGE_NAME}")
@@ -68,8 +69,27 @@ if(WITH_AWS_BACKUP)
   include(awssdk)
 endif()
 
+# Find Homebrew fmt directly
+find_path(FMT_INCLUDE_DIR NAMES fmt/core.h
+    HINTS /opt/homebrew/opt/fmt/include NO_DEFAULT_PATH)
+find_library(FMT_LIBRARY NAMES fmt
+    HINTS /opt/homebrew/opt/fmt/lib NO_DEFAULT_PATH)
+
+if(FMT_INCLUDE_DIR AND FMT_LIBRARY)
+    message(STATUS "Found Homebrew fmt: ${FMT_LIBRARY} (includes: ${FMT_INCLUDE_DIR})")
+    set(PC_FMT_INCLUDE_DIRS ${FMT_INCLUDE_DIR}) # Keep variable name for compatibility downstream if used
+    set(PC_FMT_LIBRARIES ${FMT_LIBRARY})     # Keep variable name for compatibility downstream if used
+else()
+    message(FATAL_ERROR "Homebrew fmt not found. Please install with 'brew install fmt'")
+endif()
+
 add_flow_target(STATIC_LIBRARY NAME fdbclient SRCS ${FDBCLIENT_SRCS} ADDL_SRCS ${options_srcs})
-target_include_directories(fdbclient PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" "${CMAKE_CURRENT_BINARY_DIR}/include")
+target_include_directories(fdbclient PUBLIC
+    "${CMAKE_CURRENT_SOURCE_DIR}/include"
+    "${CMAKE_CURRENT_BINARY_DIR}/include"
+    "${CMAKE_SOURCE_DIR}/bindings/c/foundationdb"
+    "${CMAKE_BINARY_DIR}/bindings/c/foundationdb"
+    )
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/versions.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/include/fdbclient/versions.h)
 add_dependencies(fdbclient fdboptions)
 target_link_libraries(fdbclient PUBLIC fdbrpc msgpack PRIVATE rapidxml)
@@ -85,6 +105,7 @@ target_include_directories(s3client PRIVATE
     "${CMAKE_SOURCE_DIR}/contrib/md5/include"
     "${CMAKE_SOURCE_DIR}/contrib/libb64/include"
     "/opt/boost_1_86_0_clang/include"
+    ${PC_FMT_INCLUDE_DIRS}
 )
 
 target_link_libraries(s3client PRIVATE
@@ -95,7 +116,7 @@ target_link_libraries(s3client PRIVATE
     md5
     libb64
     stacktrace
-    fmt
+    ${PC_FMT_LIBRARIES}
     crc32
     eio
     rapidxml
@@ -156,7 +177,12 @@ endif()
 # fdbserver retain sampling functionality in client code while disabling
 # sampling for pure clients.
 add_flow_target(STATIC_LIBRARY NAME fdbclient_sampling SRCS ${FDBCLIENT_SRCS} ADDL_SRCS ${options_srcs})
-target_include_directories(fdbclient_sampling PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" "${CMAKE_CURRENT_BINARY_DIR}/include")
+target_include_directories(fdbclient_sampling PUBLIC
+    "${CMAKE_CURRENT_SOURCE_DIR}/include"
+    "${CMAKE_CURRENT_BINARY_DIR}/include"
+    "${CMAKE_SOURCE_DIR}/bindings/c/foundationdb"
+    "${CMAKE_BINARY_DIR}/bindings/c/foundationdb"
+    )
 add_dependencies(fdbclient_sampling fdboptions)
 target_link_libraries(fdbclient_sampling PUBLIC fdbrpc_sampling msgpack PRIVATE rapidxml)
 target_compile_definitions(fdbclient_sampling PRIVATE -DENABLE_SAMPLING)

--- a/fdbclient/ChecksumDatabase.actor.cpp
+++ b/fdbclient/ChecksumDatabase.actor.cpp
@@ -59,6 +59,7 @@ struct ShardResult {
 };
 
 // Actor to retrieve shard boundaries for a given key range
+// TODO: Generalize... This is like fdbclient/AuditUtils.actor.cpp getShardMapFromKeyServers.
 ACTOR Future<Standalone<VectorRef<KeyRef>>> getShardBoundaries(Database cx, KeyRangeRef rangeToScanBoundariesFor) {
 	state std::vector<Key> tempBoundaries; // Use std::vector for easy manipulation
 	state Key currentBoundaryScanBegin = rangeToScanBoundariesFor.begin;
@@ -395,14 +396,6 @@ ACTOR Future<ChecksumResult> calculateDatabaseChecksum(Database cx, Optional<Key
 			} // Re-throw
 		}
 	}
-
-	// No longer need the old loop structure
-	// state int boundaryIdx = 0;
-	// state Key currentOuterBeginKey = overallRangeToProcess.begin;
-	// state int64_t maxBytesPerTransactionAttempt = 10 * 1024 * 1024;
-	// loop { ... old processing logic removed ... }
-
-	// finalResult.checksum = XXH64_digest(&xxhStateGlobal); // Done via XOR now
 
 	TraceEvent(SevInfo, "ChecksumFinalResult")
 	    .detail("Checksum", finalResult.checksum) // This is now the XORed checksum

--- a/fdbclient/ChecksumDatabase.actor.cpp
+++ b/fdbclient/ChecksumDatabase.actor.cpp
@@ -1,0 +1,414 @@
+/*
+ * ChecksumDatabase.actor.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2024 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Standard Library
+#include <fmt/format.h> // For fmt::format
+#include <limits> // For std::numeric_limits
+#include <vector> // For std::vector
+#include <algorithm> // For std::sort, std::unique
+
+// Flow Headers (excluding actorcompiler.h)
+#include "flow/flow.h" // Basic Flow types
+#include "flow/xxhash.h" // For XXH64_state_t and functions
+#include "flow/genericactors.actor.h" // For FlowLock and other generic actors
+
+// FDBClient Headers (excluding actorcompiler.h and self .actor.h for now)
+#include "fdbclient/NativeAPI.actor.h" // For Database, Key, KeyRange, etc.
+#include "fdbclient/ReadYourWrites.h" // For ReadYourWritesTransaction
+#include "fdbclient/ClientKnobs.h" // For CLIENT_KNOBS
+#include "fdbclient/SystemData.h" // For allKeys, normalKeys
+// #include "fdbclient/TenantAttentionRouter.h" // Reverted path - Now commented out
+#include "fdbclient/MonitorLeader.h"
+
+// Own .actor.h file
+#include "fdbclient/ChecksumDatabase.actor.h"
+
+// ACTOR COMPILER - MUST BE LAST
+#include "flow/actorcompiler.h"
+
+// The fdbclient/ChecksumDatabase.actor.h should have already included its .actor.g.h
+// so we don't need to include it explicitly here.
+
+namespace fdb {
+
+// Struct to hold the result of checksumming a single shard
+struct ShardResult {
+	uint64_t shardChecksum;
+	int64_t shardTotalKeys;
+	int64_t shardTotalBytes;
+	Key shardBeginKey; // For potential logging/association
+
+	ShardResult() : shardChecksum(0), shardTotalKeys(0), shardTotalBytes(0) {}
+};
+
+// Actor to retrieve shard boundaries for a given key range
+ACTOR Future<Standalone<VectorRef<KeyRef>>> getShardBoundaries(Database cx, KeyRangeRef rangeToScanBoundariesFor) {
+	state std::vector<Key> tempBoundaries; // Use std::vector for easy manipulation
+	state Key currentBoundaryScanBegin = rangeToScanBoundariesFor.begin;
+
+	// Add the beginning of the overall range as the first boundary.
+	tempBoundaries.push_back(rangeToScanBoundariesFor.begin);
+
+	state ReadYourWritesTransaction tr(cx);
+
+	loop {
+		try {
+			tr.setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
+			tr.setOption(FDBTransactionOptions::LOCK_AWARE);
+			tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE); // Recommended for system key reads
+
+			// Construct the range to query within keyServersPrefix
+			std::string beginScanKeyStr = keyServersPrefix.toString() + currentBoundaryScanBegin.toString();
+			Key beginScanKey =
+			    Key(StringRef(reinterpret_cast<const uint8_t*>(beginScanKeyStr.data()), beginScanKeyStr.size()));
+			std::string endScanKeyStr = keyServersPrefix.toString() + rangeToScanBoundariesFor.end.toString();
+			Key endScanKey =
+			    Key(StringRef(reinterpret_cast<const uint8_t*>(endScanKeyStr.data()), endScanKeyStr.size()));
+			KeyRangeRef scanRange = KeyRangeRef(beginScanKey, endScanKey);
+
+			TraceEvent(SevDebug, "GetShardBoundariesScanRange")
+			    .detail("Begin", scanRange.begin.printable())
+			    .detail("End", scanRange.end.printable());
+
+			RangeResult results = wait(
+			    tr.getRange(scanRange, CLIENT_KNOBS->TOO_MANY)); // TOO_MANY should be fine for typical number of shards
+
+			for (auto const& kv : results) {
+				Key boundaryKey = kv.key.removePrefix(keyServersPrefix);
+				// Avoid duplicate entries if currentBoundaryScanBegin was already a boundary
+				if (tempBoundaries.empty() || tempBoundaries.back() != boundaryKey) {
+					tempBoundaries.push_back(boundaryKey);
+				}
+			}
+
+			if (!results.more || results.empty()) {
+				break; // All boundaries in the range fetched
+			}
+
+			// Prepare for the next scan if there's more data
+			currentBoundaryScanBegin = keyAfter(results.back().key.removePrefix(keyServersPrefix));
+			if (currentBoundaryScanBegin >= rangeToScanBoundariesFor.end) {
+				break;
+			}
+			tr.reset(); // Reset for the next iteration if needed, though getRange might do this
+		} catch (Error& e) {
+			if (e.code() == error_code_actor_cancelled) {
+				throw;
+			}
+			TraceEvent(SevWarn, "GetShardBoundariesError").error(e);
+			wait(tr.onError(e));
+		}
+	}
+
+	// Add the end of the overall range as the last boundary, if not already present.
+	if (tempBoundaries.empty() || tempBoundaries.back() != rangeToScanBoundariesFor.end) {
+		tempBoundaries.push_back(rangeToScanBoundariesFor.end);
+	}
+
+	// Sort and unique
+	std::sort(tempBoundaries.begin(), tempBoundaries.end());
+	tempBoundaries.erase(std::unique(tempBoundaries.begin(), tempBoundaries.end()), tempBoundaries.end());
+
+	// Convert std::vector<Key> to Standalone<VectorRef<KeyRef>>
+	state Standalone<VectorRef<KeyRef>> boundaries;
+	for (const auto& k : tempBoundaries) {
+		boundaries.push_back_deep(boundaries.arena(), k);
+	}
+
+	TraceEvent(SevInfo, "GetShardBoundariesResult").detail("NumBoundaries", boundaries.size());
+	// .detail("Boundaries", boundaries); // Potentially too verbose for default logging
+
+	return boundaries;
+}
+
+// Actor to calculate the checksum for a single shard or a part of a shard
+ACTOR Future<ShardResult> calculateSingleShardChecksumActor(Database cx, KeyRangeRef shardRangeToProcess) {
+	state ShardResult result;
+	result.shardBeginKey = shardRangeToProcess.begin;
+	state XXH64_state_t xxhStateShardLocal;
+	XXH64_reset(&xxhStateShardLocal, 0);
+
+	state Key currentProcessingKey = shardRangeToProcess.begin;
+	state int64_t maxBytesPerTransactionAttempt = 10 * 1024 * 1024; // 10 MB example limit, same as outer actor
+
+	// Loop for processing the given shardRangeToProcess, potentially in multiple transactions if byte limit is hit
+	loop {
+		if (currentProcessingKey >= shardRangeToProcess.end) {
+			break; // Entire shard range processed
+		}
+
+		state ReadYourWritesTransaction tr(cx);
+		state uint64_t txAttemptBytes = 0;
+		state uint64_t txAttemptKeys = 0;
+		state Key lastKeyReadInTx;
+
+		// Transaction retry loop for the current part of the shard
+		loop {
+			try {
+				txAttemptBytes = 0;
+				txAttemptKeys = 0;
+				lastKeyReadInTx = currentProcessingKey;
+
+				state KeySelector flussoBegin = firstGreaterOrEqual(currentProcessingKey);
+				state KeySelector flussoEnd = firstGreaterOrEqual(shardRangeToProcess.end);
+				state bool moreDataInThisTx = true;
+				state int64_t bytesReadThisTxAccumulator = 0;
+
+				TraceEvent(SevDebug, "SingleShardActorTxBegin")
+				    .detail("ShardRangeBegin", shardRangeToProcess.begin.printable())
+				    .detail("ShardRangeEnd", shardRangeToProcess.end.printable())
+				    .detail("CurrentProcessingKey", currentProcessingKey.printable());
+
+				// Innermost getRange chunking loop for this transaction
+				loop {
+					if (!moreDataInThisTx)
+						break;
+					if (flussoBegin.getKey() >= shardRangeToProcess.end && flussoBegin.offset == 1) {
+						moreDataInThisTx = false;
+						break;
+					}
+					if (bytesReadThisTxAccumulator >= maxBytesPerTransactionAttempt && txAttemptKeys > 0) {
+						TraceEvent(SevInfo, "SingleShardActorTxByteLimit")
+						    .detail("BytesRead", bytesReadThisTxAccumulator)
+						    .detail("MaxBytes", maxBytesPerTransactionAttempt);
+						break;
+					}
+
+					state Standalone<RangeResultRef> chunkReadResult = wait(tr.getRange(
+					    flussoBegin,
+					    flussoEnd,
+					    GetRangeLimits(GetRangeLimits::ROW_LIMIT_UNLIMITED, CLIENT_KNOBS->REPLY_BYTE_LIMIT)));
+
+					TraceEvent(SevDebug, "SingleShardActorGetRangeResult")
+					    .detail("ChunkSize", chunkReadResult.size())
+					    .detail("ChunkMore", chunkReadResult.more);
+
+					if (chunkReadResult.empty()) {
+						moreDataInThisTx = false;
+					} else {
+						for (const auto& kv : chunkReadResult) {
+							XXH64_update(&xxhStateShardLocal, kv.key.begin(), kv.key.size());
+							XXH64_update(&xxhStateShardLocal, kv.value.begin(), kv.value.size());
+							uint64_t kvBytes = kv.key.size() + kv.value.size();
+							txAttemptBytes += kvBytes;
+							bytesReadThisTxAccumulator += kvBytes;
+							txAttemptKeys++;
+							lastKeyReadInTx = kv.key;
+						}
+						if (!chunkReadResult.more)
+							moreDataInThisTx = false;
+						flussoBegin = firstGreaterThan(chunkReadResult.back().key);
+					}
+				} // End of getRange chunking loop
+
+				result.shardTotalBytes += txAttemptBytes;
+				result.shardTotalKeys += txAttemptKeys;
+
+				TraceEvent(SevDebug, "SingleShardActorTxSuccess")
+				    .detail("OriginalShardBegin", shardRangeToProcess.begin.printable())
+				    .detail("ProcessedUpTo", lastKeyReadInTx.printable())
+				    .detail("KeysInTx", txAttemptKeys)
+				    .detail("BytesInTx", txAttemptBytes);
+
+				if (txAttemptKeys == 0) {
+					currentProcessingKey = shardRangeToProcess.end; // No keys processed, advance to end of shard
+				} else {
+					currentProcessingKey = keyAfter(lastKeyReadInTx);
+				}
+				tr.reset();
+				break; // Successfully processed this transaction for a part of the shard
+			} catch (Error& e) {
+				TraceEvent(SevWarn, "SingleShardActorTxError").error(e);
+				if (e.code() == error_code_actor_cancelled)
+					throw;
+				wait(tr.onError(e));
+			}
+		} // End of transaction retry loop
+	} // End of loop for processing current shard range
+
+	result.shardChecksum = XXH64_digest(&xxhStateShardLocal);
+	TraceEvent(SevInfo, "SingleShardActorCompleted")
+	    .detail("ShardBeginKey", result.shardBeginKey.printable())
+	    .detail("ShardEndKey", shardRangeToProcess.end.printable())
+	    .detail("ShardChecksum", result.shardChecksum)
+	    .detail("ShardTotalKeys", result.shardTotalKeys)
+	    .detail("ShardTotalBytes", result.shardTotalBytes);
+	return result;
+}
+
+// Helper actor that acquires a FlowLock, runs a single shard checksum, and returns its result.
+ACTOR Future<ShardResult> launchSingleShardProcessingWithLock(Database cx,
+                                                              KeyRangeRef shardRange,
+                                                              FlowLock* concurrencyLock) {
+	wait(concurrencyLock->take());
+	state FlowLock::Releaser releaser(*concurrencyLock);
+
+	// TODO: Consider adding a try-catch here to log errors from calculateSingleShardChecksumActor
+	// and potentially return a default/error ShardResult or rethrow. For now, assume
+	// calculateSingleShardChecksumActor handles its own errors or throws, and waitForAll will catch it.
+	ShardResult result = wait(calculateSingleShardChecksumActor(cx, shardRange));
+	return result;
+}
+
+// Actor to calculate the checksum of the database or a key range.
+ACTOR Future<ChecksumResult> calculateDatabaseChecksum(Database cx, Optional<KeyRange> range) {
+	state ChecksumResult finalResult;
+
+	state KeyRangeRef overallRangeToProcess = range.present() ? range.get() : normalKeys;
+
+	TraceEvent(SevInfo, "ChecksumEffectiveOverallRange")
+	    .detail("Begin", overallRangeToProcess.begin.printable())
+	    .detail("End", overallRangeToProcess.end.printable());
+
+	state Standalone<VectorRef<KeyRef>> shardBoundaries = wait(getShardBoundaries(cx, overallRangeToProcess));
+
+	if (shardBoundaries.empty() || shardBoundaries.front() != overallRangeToProcess.begin ||
+	    shardBoundaries.back() != overallRangeToProcess.end) {
+		TraceEvent(SevWarn, "ChecksumInvalidBoundaries")
+		    .detail("Reason", "Boundaries from getShardBoundaries do not properly cover overallRangeToProcess");
+		if (overallRangeToProcess.empty()) {
+			// Empty overall range is fine, result will be 0/0/0
+			return finalResult; // Default 0s
+		}
+		// For non-empty overall range but bad boundaries, this is problematic.
+		// Consider throwing an error here. For now, will likely result in 0 processed.
+		// Or, if only one boundary (begin==end), it might also be fine.
+		if (shardBoundaries.size() < 2 && !overallRangeToProcess.empty()) {
+			// This implies we can't even form one shard range.
+			// Throw an error or return an empty/error result.
+			// For now, returning default (likely 0s) to avoid crash, but this needs thought.
+			return finalResult;
+		}
+	}
+
+	if (overallRangeToProcess.empty()) {
+		TraceEvent(SevInfo, "ChecksumSkippingEmptyOverallRange");
+		return finalResult; // Already initialized to 0s
+	}
+
+	// If shardBoundaries only contains begin and end, and they are the same (empty range),
+	// getShardBoundaries should ideally return just [begin, end].
+	// If overallRangeToProcess is not empty, but shardBoundaries.size() < 2, it's an issue.
+	if (shardBoundaries.size() < 2) {
+		TraceEvent(SevWarn, "ChecksumNotEnoughBoundariesForNonEmptyRange")
+		    .detail("NumBoundaries", shardBoundaries.size())
+		    .detail("OverallRangeBegin", overallRangeToProcess.begin.printable())
+		    .detail("OverallRangeEnd", overallRangeToProcess.end.printable());
+		// This could happen if overallRangeToProcess.begin == overallRangeToProcess.end but it wasn't caught by
+		// overallRangeToProcess.empty() Or if getShardBoundaries has an issue.
+		return finalResult; // Return 0s
+	}
+
+	state std::vector<Future<ShardResult>> allShardFutures;
+	state Reference<FlowLock> concurrencyLimiter =
+	    makeReference<FlowLock>(CLIENT_KNOBS->CHECKSUM_MAX_CONCURRENT_SHARDS);
+
+	for (int i = 0; i < shardBoundaries.size() - 1; ++i) {
+		Key shardBegin = shardBoundaries[i];
+		Key shardEnd = shardBoundaries[i + 1];
+
+		if (shardBegin >= shardEnd) {
+			TraceEvent(SevWarn, "ChecksumSkippingEmptyShardRangeInLoop")
+			    .detail("ShardBegin", shardBegin.printable())
+			    .detail("ShardEnd", shardEnd.printable())
+			    .detail("BoundaryIndex", i);
+			continue;
+		}
+		KeyRangeRef currentShardRange = KeyRangeRef(shardBegin, shardEnd);
+		allShardFutures.push_back(
+		    launchSingleShardProcessingWithLock(cx, currentShardRange, concurrencyLimiter.getPtr()));
+	}
+
+	if (allShardFutures.empty() && !overallRangeToProcess.empty()) {
+		// This case implies that even though overallRangeToProcess was non-empty,
+		// and we had at least 2 boundaries, no valid shard ranges were formed.
+		// This could happen if all shard ranges were skipped (e.g. all begin >= end).
+		// This is unusual if getShardBoundaries and overallRangeToProcess are consistent.
+		TraceEvent(SevWarn, "ChecksumNoShardFuturesGeneratedForNonEmptyRange")
+		    .detail("OverallRangeBegin", overallRangeToProcess.begin.printable())
+		    .detail("OverallRangeEnd", overallRangeToProcess.end.printable())
+		    .detail("NumBoundaries", shardBoundaries.size());
+		// Return current finalResult which is 0s.
+	}
+
+	wait(waitForAll(allShardFutures));
+
+	finalResult.checksum = 0; // Initialize for XOR
+	for (const auto& fut : allShardFutures) {
+		if (fut.isReady() && !fut.isError()) {
+			ShardResult shardRes = fut.get();
+			finalResult.checksum ^= shardRes.shardChecksum;
+			finalResult.totalKeys += shardRes.shardTotalKeys;
+			finalResult.totalBytes += shardRes.shardTotalBytes;
+		} else if (fut.isError()) {
+			// How to handle errors from one of the shards?
+			// Option 1: Propagate the first error and stop.
+			// Option 2: Log error, skip its result, and checksum the rest (partial checksum).
+			// Option 3: Collect all errors and report them.
+			// For now, propagating the error from waitForAll or the first future.get() that throws.
+			// waitForAll itself might throw if one future has an error not caught by isError().
+			// Let's assume fut.get() will throw if there was an error.
+			// This explicit check helps if we want custom error aggregation later.
+			// For now, if waitForAll passed, then all futures should be ready and not in an error state
+			// that wasn't handled by the single shard actor's try-catch.
+			// However, an actor_cancelled could still come through.
+			// The try-catch in calculateSingleShardChecksumActor should handle most things and return a ShardResult.
+			// If an error still propagates here, it's likely serious.
+			// Re-throwing the error from future.get() if it's an error.
+			// Ensure that if fut.get() throws, it stops processing.
+			try {
+				ShardResult shardRes = fut.get(); // Can throw
+				finalResult.checksum ^= shardRes.shardChecksum;
+				finalResult.totalKeys += shardRes.shardTotalKeys;
+				finalResult.totalBytes += shardRes.shardTotalBytes;
+			} catch (Error& e) {
+				TraceEvent(SevWarn, "ChecksumFailedToGetShardResult").error(e);
+				// Option: rethrow e; to stop entire checksum on first shard error
+				// Option: continue; to XOR with 0 for this shard and sum 0s (partial checksum)
+				// For now, let's rethrow to indicate overall failure if any shard fails critically.
+				throw;
+			}
+		} else if (fut.isError()) { // Should ideally be caught by fut.get() above
+			TraceEvent(SevWarn, "ChecksumShardFutureIsError");
+			// To be safe, attempt to get the error to ensure it's handled or rethrown.
+			try {
+				fut.get();
+			} catch (Error& e) {
+				throw;
+			} // Re-throw
+		}
+	}
+
+	// No longer need the old loop structure
+	// state int boundaryIdx = 0;
+	// state Key currentOuterBeginKey = overallRangeToProcess.begin;
+	// state int64_t maxBytesPerTransactionAttempt = 10 * 1024 * 1024;
+	// loop { ... old processing logic removed ... }
+
+	// finalResult.checksum = XXH64_digest(&xxhStateGlobal); // Done via XOR now
+
+	TraceEvent(SevInfo, "ChecksumFinalResult")
+	    .detail("Checksum", finalResult.checksum) // This is now the XORed checksum
+	    .detail("TotalKeys", finalResult.totalKeys)
+	    .detail("TotalBytes", finalResult.totalBytes);
+	return finalResult;
+}
+
+} // namespace fdb

--- a/fdbclient/include/fdbclient/ChecksumDatabase.actor.h
+++ b/fdbclient/include/fdbclient/ChecksumDatabase.actor.h
@@ -38,16 +38,14 @@ struct ChecksumResult {
 };
 } // namespace fdb
 
-// When actually compiled (NO_INTELLISENSE), include the generated version of this file.  In intellisense use the source
-// version.
-#if defined(NO_INTELLISENSE) && !defined(FDBCLIENT_CHECKSUMDATABASE_ACTOR_G_H)
-#define FDBCLIENT_CHECKSUMDATABASE_ACTOR_G_H
+#ifdef NO_INTELLISENSE
+#ifndef FDBCLIENT_CHECKSUMDATABASE_ACTOR_G_H_WRAPPER // New guard specific to this block
+#define FDBCLIENT_CHECKSUMDATABASE_ACTOR_G_H_WRAPPER
 #include "fdbclient/ChecksumDatabase.actor.g.h"
+#endif // FDBCLIENT_CHECKSUMDATABASE_ACTOR_G_H_WRAPPER
 #else
-
-// For Intellisense, ensure other necessary headers are included if not pulled by global ones
-// And critically, include actorcompiler.h here for the linter/intellisense path
-// #include "flow/actorcompiler.h" // No longer needed here, moved up
+// For Intellisense (NO_INTELLISENSE is not defined)
+// #include "flow/actorcompiler.h" // This was correctly commented out previously
 #include "fdbclient/DatabaseContext.h" // Provides 'Database' type, needed for the signature
 
 namespace fdb {
@@ -58,6 +56,6 @@ ACTOR Future<fdb::ChecksumResult> calculateDatabaseChecksum(Database cx,
 
 } // namespace fdb
 
-#endif // #if defined(NO_INTELLISENSE) && !defined(FDBCLIENT_CHECKSUMDATABASE_ACTOR_G_H)
+#endif // NO_INTELLISENSE
 
 #endif // FDBCLIENT_CHECKSUMDATABASE_ACTOR_H

--- a/fdbclient/include/fdbclient/ChecksumDatabase.actor.h
+++ b/fdbclient/include/fdbclient/ChecksumDatabase.actor.h
@@ -48,6 +48,7 @@ struct ChecksumResult {
 // #include "flow/actorcompiler.h" // This was correctly commented out previously
 #include "fdbclient/DatabaseContext.h" // Provides 'Database' type, needed for the signature
 
+#ifndef ACTOR_COMPILER
 namespace fdb {
 // Actor declared within fdb namespace, returning the namespaced fdb::ChecksumResult struct
 // The ChecksumResult struct is now defined globally above.
@@ -55,6 +56,7 @@ ACTOR Future<fdb::ChecksumResult> calculateDatabaseChecksum(Database cx,
                                                             Optional<KeyRange> range = Optional<KeyRange>());
 
 } // namespace fdb
+#endif // ACTOR_COMPILER
 
 #endif // NO_INTELLISENSE
 

--- a/fdbclient/include/fdbclient/ChecksumDatabase.actor.h
+++ b/fdbclient/include/fdbclient/ChecksumDatabase.actor.h
@@ -1,0 +1,65 @@
+/*
+ * ChecksumDatabase.actor.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2024 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef FDBCLIENT_CHECKSUMDATABASE_ACTOR_H
+#define FDBCLIENT_CHECKSUMDATABASE_ACTOR_H
+#pragma once
+
+#include "flow/actorcompiler.h" // Moved for global ACTOR definition
+
+#define XXH_STATIC_LINKING_ONLY // Ensure full xxhash definitions are exposed
+
+// Includes that might be needed by ChecksumResult or the actor
+#include <cstdint> // For uint64_t, int64_t
+#include "fdbclient/FDBTypes.h" // For KeyRange, Optional
+#include "flow/flow.h" // For Future, etc.
+#include "flow/xxhash.h" // For XXH64_state_t
+
+// Define ChecksumResult struct globally within the header, inside its namespace
+namespace fdb {
+struct ChecksumResult {
+	uint64_t checksum;
+	int64_t totalBytes;
+	int64_t totalKeys;
+};
+} // namespace fdb
+
+// When actually compiled (NO_INTELLISENSE), include the generated version of this file.  In intellisense use the source
+// version.
+#if defined(NO_INTELLISENSE) && !defined(FDBCLIENT_CHECKSUMDATABASE_ACTOR_G_H)
+#define FDBCLIENT_CHECKSUMDATABASE_ACTOR_G_H
+#include "fdbclient/ChecksumDatabase.actor.g.h"
+#else
+
+// For Intellisense, ensure other necessary headers are included if not pulled by global ones
+// And critically, include actorcompiler.h here for the linter/intellisense path
+// #include "flow/actorcompiler.h" // No longer needed here, moved up
+#include "fdbclient/DatabaseContext.h" // Provides 'Database' type, needed for the signature
+
+namespace fdb {
+// Actor declared within fdb namespace, returning the namespaced fdb::ChecksumResult struct
+// The ChecksumResult struct is now defined globally above.
+ACTOR Future<fdb::ChecksumResult> calculateDatabaseChecksum(Database cx,
+                                                            Optional<KeyRange> range = Optional<KeyRange>());
+
+} // namespace fdb
+
+#endif // #if defined(NO_INTELLISENSE) && !defined(FDBCLIENT_CHECKSUMDATABASE_ACTOR_G_H)
+
+#endif // FDBCLIENT_CHECKSUMDATABASE_ACTOR_H

--- a/fdbclient/include/fdbclient/ChecksumDatabase.actor.h
+++ b/fdbclient/include/fdbclient/ChecksumDatabase.actor.h
@@ -21,8 +21,6 @@
 #define FDBCLIENT_CHECKSUMDATABASE_ACTOR_H
 #pragma once
 
-#include "flow/actorcompiler.h" // Moved for global ACTOR definition
-
 #define XXH_STATIC_LINKING_ONLY // Ensure full xxhash definitions are exposed
 
 // Includes that might be needed by ChecksumResult or the actor

--- a/fdbclient/include/fdbclient/ClientKnobs.h
+++ b/fdbclient/include/fdbclient/ClientKnobs.h
@@ -367,6 +367,12 @@ public:
 	// Enable to logging verbose trace events related to the accumulative checksum
 	bool ENABLE_ACCUMULATIVE_CHECKSUM_LOGGING;
 
+	// Checksum Tool Knobs
+	int CHECKSUM_MAX_CONCURRENT_SHARDS = 16;
+
+	// Max number of trace logs that can be dumped to disk concurrently.
+	int MAX_CONCURRENT_TRACE_DUMPS = 10;
+
 	ClientKnobs(Randomize randomize);
 	void initialize(Randomize randomize);
 };


### PR DESCRIPTION
figure distributed execution of checksumming task.

Presumes quiescent database. Reads by 'shard' and then inside a shard in 'chunks'. Does 'parallelism' by shard putting up N futures constrained by FlowLock. Checksum is done per shard and then all checksums are XOR'd together so we can proceed even when shards complete out of order.

Checksumming code is under fdbclient and command-line/main is in fdbcli.

Used checking small-scale bulkload/dump. Draft.

(For production scale, we'll need another approach, a distributed compute that we can set running a checksum task on).