### PR TITLE
Update the docs for the reboot worker method

### DIFF
--- a/bindings/go/src/fdb/database.go
+++ b/bindings/go/src/fdb/database.go
@@ -112,7 +112,9 @@ func (d Database) CreateTransaction() (Transaction, error) {
 // from the go bindings. If a suspendDuration > 0 is provided the rebooted process will be
 // suspended for suspendDuration seconds. If checkFile is set to true the process will check
 // if the data directory is writeable by creating a validation file. The address must be a
-// process address is the form of IP:Port pair.
+// process address is the form of IP:Port pair without the :tls suffix if the cluster is running
+// with TLS enabled. The address can also be multiple processes addresses concated by a comma, e.g.
+// "IP1:Port,IP2:port", in this case the RebootWorker will reboot all provided addresses concurrently.
 func (d Database) RebootWorker(address string, checkFile bool, suspendDuration int) error {
 	t := &futureInt64{
 		future: newFutureWithDb(


### PR DESCRIPTION
Clarify the documentation about the `rebootWorker` method in the go bindings and how multiple processes can be rebooted at the same the "same" time.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
