### PR TITLE
Fix duplicate secret key in S3BlobStore URL construction

### DIFF
--- a/fdbclient/S3BlobStore.actor.cpp
+++ b/fdbclient/S3BlobStore.actor.cpp
@@ -403,12 +403,9 @@ std::string S3BlobStoreEndpoint::getResourceURL(std::string resource, std::strin
 		}
 		if (!lookupSecret) {
 			credsString += ":" + credentials.get().secret;
-		}
-		if (!lookupSecret) {
-			credsString +=
-			    credentials.get().securityToken.empty()
-			        ? std::string(":") + credentials.get().secret
-			        : std::string(":") + credentials.get().secret + std::string(":") + credentials.get().securityToken;
+			if (!credentials.get().securityToken.empty()) {
+				credsString += ":" + credentials.get().securityToken;
+			}
 		}
 		credsString += "@";
 	}


### PR DESCRIPTION
Fixes #12150
Duplicate printing of a secret in the backup url when using S3 storage.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
