### PR TITLE
Refactor: some duplicated code patterns found by teamscale

### DIFF
--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -3370,9 +3370,6 @@ int main(int argc, char* argv[]) {
 					    argc - 1, &argv[1], g_rgBackupDiscontinueOptions, SO_O_EXACT | SO_O_HYPHEN_TO_UNDERSCORE);
 					break;
 				case BackupType::PAUSE:
-					args = std::make_unique<CSimpleOpt>(
-					    argc - 1, &argv[1], g_rgBackupPauseOptions, SO_O_EXACT | SO_O_HYPHEN_TO_UNDERSCORE);
-					break;
 				case BackupType::RESUME:
 					args = std::make_unique<CSimpleOpt>(
 					    argc - 1, &argv[1], g_rgBackupPauseOptions, SO_O_EXACT | SO_O_HYPHEN_TO_UNDERSCORE);
@@ -3445,9 +3442,6 @@ int main(int argc, char* argv[]) {
 					    argc - 1, &argv[1], g_rgDBAbortOptions, SO_O_EXACT | SO_O_HYPHEN_TO_UNDERSCORE);
 					break;
 				case DBType::PAUSE:
-					args = std::make_unique<CSimpleOpt>(
-					    argc - 1, &argv[1], g_rgDBPauseOptions, SO_O_EXACT | SO_O_HYPHEN_TO_UNDERSCORE);
-					break;
 				case DBType::RESUME:
 					args = std::make_unique<CSimpleOpt>(
 					    argc - 1, &argv[1], g_rgDBPauseOptions, SO_O_EXACT | SO_O_HYPHEN_TO_UNDERSCORE);
@@ -3741,8 +3735,6 @@ int main(int argc, char* argv[]) {
 				restoreClusterFileOrig = args->OptionArg();
 				break;
 			case OPT_CLUSTERFILE:
-				clusterFile = args->OptionArg();
-				break;
 			case OPT_DEST_CLUSTER:
 				clusterFile = args->OptionArg();
 				break;

--- a/fdbclient/Tuple.cpp
+++ b/fdbclient/Tuple.cpp
@@ -76,9 +76,7 @@ Tuple::Tuple(StringRef const& str, bool exclude_incomplete, bool include_user_ty
 			i += sizeof(float) + 1;
 		} else if (data[i] == 0x21) {
 			i += sizeof(double) + 1;
-		} else if (data[i] == 0x26 || data[i] == 0x27) {
-			i += 1;
-		} else if (data[i] == '\x00') {
+		} else if (data[i] == 0x26 || data[i] == 0x27 || data[i] == '\x00') {
 			i += 1;
 		} else if (data[i] == VERSIONSTAMP_96_CODE) {
 			i += VERSIONSTAMP_TUPLE_SIZE + 1;

--- a/fdbrpc/Locality.cpp
+++ b/fdbrpc/Locality.cpp
@@ -37,14 +37,12 @@ ProcessClass::Fitness ProcessClass::machineClassFitness(ClusterRole role) const 
 		case ProcessClass::UnsetClass:
 			return ProcessClass::UnsetFit;
 		case ProcessClass::TransactionClass:
-			return ProcessClass::WorstFit;
 		case ProcessClass::LogClass:
 			return ProcessClass::WorstFit;
 		case ProcessClass::CoordinatorClass:
 		case ProcessClass::TesterClass:
 		case ProcessClass::StorageCacheClass:
 		case ProcessClass::BlobWorkerClass:
-			return ProcessClass::NeverAssign;
 		default:
 			return ProcessClass::NeverAssign;
 		}
@@ -184,15 +182,10 @@ ProcessClass::Fitness ProcessClass::machineClassFitness(ClusterRole role) const 
 		case ProcessClass::UnsetClass:
 			return ProcessClass::UnsetFit;
 		case ProcessClass::MasterClass:
-			return ProcessClass::OkayFit;
 		case ProcessClass::ResolutionClass:
-			return ProcessClass::OkayFit;
 		case ProcessClass::TransactionClass:
-			return ProcessClass::OkayFit;
 		case ProcessClass::CommitProxyClass:
-			return ProcessClass::OkayFit;
 		case ProcessClass::GrvProxyClass:
-			return ProcessClass::OkayFit;
 		case ProcessClass::LogRouterClass:
 			return ProcessClass::OkayFit;
 		case ProcessClass::CoordinatorClass:
@@ -287,7 +280,6 @@ ProcessClass::Fitness ProcessClass::machineClassFitness(ClusterRole role) const 
 		case ProcessClass::StatelessClass:
 			return ProcessClass::GoodFit;
 		case ProcessClass::MasterClass:
-			return ProcessClass::OkayFit;
 		case ProcessClass::BlobWorkerClass:
 			return ProcessClass::OkayFit;
 		default:

--- a/fdbrpc/include/fdbrpc/SimulatorProcessInfo.h
+++ b/fdbrpc/include/fdbrpc/SimulatorProcessInfo.h
@@ -115,43 +115,26 @@ struct ProcessInfo : NonCopyable {
 	bool isAvailableClass() const {
 		switch (startingClass._class) {
 		case ProcessClass::UnsetClass:
-			return true;
 		case ProcessClass::StorageClass:
-			return true;
 		case ProcessClass::TransactionClass:
-			return true;
-		case ProcessClass::ResolutionClass:
-			return false;
-		case ProcessClass::CommitProxyClass:
-			return false;
-		case ProcessClass::GrvProxyClass:
-			return false;
-		case ProcessClass::MasterClass:
-			return false;
-		case ProcessClass::TesterClass:
-			return false;
-		case ProcessClass::StatelessClass:
-			return false;
 		case ProcessClass::LogClass:
 			return true;
+
+		case ProcessClass::ResolutionClass:
+		case ProcessClass::CommitProxyClass:
+		case ProcessClass::GrvProxyClass:
+		case ProcessClass::MasterClass:
+		case ProcessClass::TesterClass:
+		case ProcessClass::StatelessClass:
 		case ProcessClass::LogRouterClass:
-			return false;
 		case ProcessClass::ClusterControllerClass:
-			return false;
 		case ProcessClass::DataDistributorClass:
-			return false;
 		case ProcessClass::RatekeeperClass:
-			return false;
 		case ProcessClass::ConsistencyScanClass:
-			return false;
 		case ProcessClass::BlobManagerClass:
-			return false;
 		case ProcessClass::StorageCacheClass:
-			return false;
 		case ProcessClass::BackupClass:
-			return false;
 		case ProcessClass::EncryptKeyProxyClass:
-			return false;
 		default:
 			return false;
 		}

--- a/fdbserver/worker.actor.cpp
+++ b/fdbserver/worker.actor.cpp
@@ -374,19 +374,21 @@ KeyValueStoreSuffix shardedRocksdbSuffix = { KeyValueStoreType::SSD_SHARDED_ROCK
 std::string validationFilename = "_validate";
 
 std::string filenameFromSample(KeyValueStoreType storeType, std::string folder, std::string sample_filename) {
-	if (storeType == KeyValueStoreType::SSD_BTREE_V1)
+	switch (storeType.storeType()) {
+	case KeyValueStoreType::SSD_BTREE_V1:
+	case KeyValueStoreType::SSD_BTREE_V2:
+	case KeyValueStoreType::SSD_REDWOOD_V1:
+	case KeyValueStoreType::SSD_ROCKSDB_V1:
+	case KeyValueStoreType::SSD_SHARDED_ROCKSDB:
 		return joinPath(folder, sample_filename);
-	else if (storeType == KeyValueStoreType::SSD_BTREE_V2)
-		return joinPath(folder, sample_filename);
-	else if (storeType == KeyValueStoreType::MEMORY || storeType == KeyValueStoreType::MEMORY_RADIXTREE)
+
+	case KeyValueStoreType::MEMORY:
+	case KeyValueStoreType::MEMORY_RADIXTREE:
 		return joinPath(folder, sample_filename.substr(0, sample_filename.size() - 5));
-	else if (storeType == KeyValueStoreType::SSD_REDWOOD_V1)
-		return joinPath(folder, sample_filename);
-	else if (storeType == KeyValueStoreType::SSD_ROCKSDB_V1)
-		return joinPath(folder, sample_filename);
-	else if (storeType == KeyValueStoreType::SSD_SHARDED_ROCKSDB)
-		return joinPath(folder, sample_filename);
-	UNREACHABLE();
+
+	default:
+		UNREACHABLE();
+	}
 }
 
 std::string filenameFromId(KeyValueStoreType storeType, std::string folder, std::string prefix, UID id) {


### PR DESCRIPTION
100k correctness:  20250515-223418-jzhou-a4203dbe05d36206             compressed=True data_size=36031695 duration=5523122 ended=100000 fail=1 fail_fast=10 max_runs=100000 pass=99999 priority=100 remaining=0 runtime=1:02:16 sanity=False started=100000 stopped=20250515-233634 submitted=20250515-223418 timeout=5400 username=jzhou

The failure is an external timeout with sharded rocks `-f ./tests/slow/ParallelRestoreOldBackupCorrectnessAtomicOp.toml -s 2425397265 -b on`, which can't be reproduced.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
