### PR TITLE
Fix fdbcli status json to fetch updated knob_rocksdb_block_cache_size value from StorageServers

### DIFF
--- a/fdbserver/KeyValueStoreRocksDB.actor.cpp
+++ b/fdbserver/KeyValueStoreRocksDB.actor.cpp
@@ -1234,6 +1234,8 @@ ACTOR Future<Void> rocksDBMetricLogger(UID id,
 		e.detail("NumTimesReadIteratorsReused", stat - readIteratorPoolStats["NumTimesReadIteratorsReused"]);
 		readIteratorPoolStats["NumTimesReadIteratorsReused"] = stat;
 
+		e.detail("BlockCacheSize", SERVER_KNOBS->ROCKSDB_BLOCK_CACHE_SIZE);
+
 		counters->cc.logToTraceEvent(e);
 
 		if (SERVER_KNOBS->ROCKSDB_PERFCONTEXT_ENABLE) {

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -627,7 +627,7 @@ struct RolesInfo {
 				rocksdbMetricsObj.setKeyRawNumber("sst_reader_bytes",
 				                                  rocksdbMetrics.getValue("EstimateSstReaderBytes"));
 				rocksdbMetricsObj.setKeyRawNumber("block_cache_usage", rocksdbMetrics.getValue("BlockCacheUsage"));
-				rocksdbMetricsObj.setKey("block_cache_limit", SERVER_KNOBS->ROCKSDB_BLOCK_CACHE_SIZE);
+				rocksdbMetricsObj.setKeyRawNumber("block_cache_limit", rocksdbMetrics.getValue("BlockCacheSize"));
 				rocksdbMetricsObj.setKeyRawNumber("throttled_commits", rocksdbMetrics.getValue("CommitDelayed"));
 				rocksdbMetricsObj.setKeyRawNumber("write_stall_microseconds", rocksdbMetrics.getValue("StallMicros"));
 


### PR DESCRIPTION
Cherrypick -  #12145 

When knob_rocksdb_block_cache_size is updated in the custom parameters section and and storage servers were restarted, fdbcli status json reports the old value for block_cache_limit for rocksdb metrics.
Coordinator was fetching ServerKnob value which was value set for Coordinator rather than fetching updated value from each StorageServer

Testing:
1.  Ran run_custom_cluster.sh with rocksdb as storage engine.
2. Killed one of the fdbserver and restarted that process by passing knob value
`../build_output//bin/fdbserver -p auto:1504 -c storage -d ./loopback-cluster/4/data -L ./loopback-cluster/4/log -C ./loopback-cluster/fdb.cluster --datacenter_id DC1 --locality-zoneid DC1-Z-0 --locality-machineid M-4 --knob_rocksdb_block_cache_size 300000`
3. fdbcli status json shows updated value for restarted fdbserver and remaining processes have default value  
 For other processes:
```
 "rocksdb_metrics" : {
                            "block_cache_hits" : 0,
                            "block_cache_limit" : 4294967296,
                            "block_cache_misses" : 0,
                            "block_cache_usage" : 96,
                            "memtable_bytes" : 8392704,
                            "pending_compaction_bytes" : 0,
                            "sst_reader_bytes" : 0,
                            "throttled_commits" : -999,
                            "write_stall_microseconds" : 0
                        },
```

For restarted fdbserver:
 ```
"rocksdb_metrics" : {
                            "block_cache_hits" : 0,
                            "block_cache_limit" : 300000,
                            "block_cache_misses" : 1,
                            "block_cache_usage" : 2384,
                            "memtable_bytes" : 8392704,
                            "pending_compaction_bytes" : 0,
                            "sst_reader_bytes" : 3978,
                            "throttled_commits" : -999,
                            "write_stall_microseconds" : 0
                        },

```
100K simulation test [Passed all]: 
```
  20250515-202054-akanksha-release-knob-ef123cdd8efba966 compressed=True data_size=41102656 duration=5217758 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:02:09 sanity=False started=100000 stopped=20250515-212303 submitted=20250515-202054 timeout=5400 username=akanksha-release-knob
```


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
