### PR TITLE
Fix circular recursion in Snapshot.Option

### DIFF
--- a/bindings/go/src/fdb/snapshot.go
+++ b/bindings/go/src/fdb/snapshot.go
@@ -118,5 +118,5 @@ func (s Snapshot) GetRangeSplitPoints(r ExactRange, chunkSize int64) FutureKeyAr
 // Snapshot returns the receiver and allows Snapshot to satisfy the
 // ReadTransaction interface.
 func (s Snapshot) Options() TransactionOptions {
-	return s.Options()
+	return TransactionOptions{s.transaction}
 }


### PR DESCRIPTION
I found this circular recursion in `Snapshot`, fixing it by copying the code from `Transaction` : https://github.com/apple/foundationdb/blob/2257b4ed8be2a7239ed23f0569aa69c20a827488/bindings/go/src/fdb/transaction.go#L581-L585

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
