### PR TITLE
Update Javadoc locations

### DIFF
--- a/documentation/sphinx/source/administration.rst
+++ b/documentation/sphinx/source/administration.rst
@@ -755,7 +755,7 @@ For **RHEL/CentOS**, perform the upgrade using the rpm command:
     user@host$ sudo rpm -Uvh |package-rpm-clients| \\
     |package-rpm-server|
 
-The ``foundationdb-clients`` package also installs the :doc:`C <api-c>` API. If your clients use :doc:`Ruby <api-ruby>`, :doc:`Python <api-python>`, `Java <javadoc/index.html>`_, or `Go <https://godoc.org/github.com/apple/foundationdb/bindings/go/src/fdb>`_, follow the instructions in the corresponding language documentation to install the APIs.
+The ``foundationdb-clients`` package also installs the :doc:`C <api-c>` API. If your clients use :doc:`Ruby <api-ruby>`, :doc:`Python <api-python>`, `Java <https://www.javadoc.io/doc/org.foundationdb/fdb-java/latest/index.html>`_, or `Go <https://godoc.org/github.com/apple/foundationdb/bindings/go/src/fdb>`_, follow the instructions in the corresponding language documentation to install the APIs.
 
 Test the database
 -----------------

--- a/documentation/sphinx/source/api-reference.rst
+++ b/documentation/sphinx/source/api-reference.rst
@@ -12,7 +12,7 @@ The following documents give detailed descriptions of the API for each language:
 
    api-python
    api-ruby
-   Java API <relative://javadoc/index.html>
+   Java API <https://www.javadoc.io/doc/org.foundationdb/fdb-java/latest/index.html>
    Go API <https://godoc.org/github.com/apple/foundationdb/bindings/go/src/fdb>
    api-c
    api-error-codes

--- a/documentation/sphinx/source/getting-started-linux.rst
+++ b/documentation/sphinx/source/getting-started-linux.rst
@@ -110,7 +110,7 @@ Managing the FoundationDB service
 Next steps
 ==========
 
-* Install the APIs for :doc:`Ruby <api-ruby>`, :doc:`Python <api-python>`, `Java <javadoc/index.html>`_ or `Go <https://godoc.org/github.com/apple/foundationdb/bindings/go/src/fdb>`_ if you intend to use those languages. The :doc:`C <api-c>` API was installed along with the ``foundationdb-clients`` package above.
+* Install the APIs for :doc:`Ruby <api-ruby>`, :doc:`Python <api-python>`, `Java <https://www.javadoc.io/doc/org.foundationdb/fdb-java/latest/index.html>`_ or `Go <https://godoc.org/github.com/apple/foundationdb/bindings/go/src/fdb>`_ if you intend to use those languages. The :doc:`C <api-c>` API was installed along with the ``foundationdb-clients`` package above.
 * See :doc:`tutorials` for samples of developing applications with FoundationDB.
 * See :doc:`developer-guide` for information of interest to developers, including common design patterns and performance considerations.
 * See :doc:`administration` for detailed administration information.

--- a/documentation/sphinx/source/getting-started-mac.rst
+++ b/documentation/sphinx/source/getting-started-mac.rst
@@ -101,7 +101,7 @@ Managing the FoundationDB service
 Next steps
 ==========
 
-* Install the APIs for :doc:`Ruby <api-ruby>`, `Java <javadoc/index.html>`_, or `Go <https://godoc.org/github.com/apple/foundationdb/bindings/go/src/fdb>`_ if you intend to use those languages.  :doc:`Python <api-python>` and :doc:`C <api-c>` APIs were installed using the FoundationDB installer above.
+* Install the APIs for :doc:`Ruby <api-ruby>`, `Java <https://www.javadoc.io/doc/org.foundationdb/fdb-java/latest/index.html>`_, or `Go <https://godoc.org/github.com/apple/foundationdb/bindings/go/src/fdb>`_ if you intend to use those languages.  :doc:`Python <api-python>` and :doc:`C <api-c>` APIs were installed using the FoundationDB installer above.
 * See :doc:`tutorials` for samples of developing applications with FoundationDB.
 * See :doc:`developer-guide` for information of interest to developers, including common design patterns and performance considerations.
 * See :doc:`administration` for detailed administration information.


### PR DESCRIPTION
Current link relative://javadoc/index.html doesn't work.

I manually checked the generated pages have correct links via `cmk docpreview` target.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
