### PR TITLE
Make log servers return an empty version range only when it is correct to do so

### DIFF
--- a/fdbserver/LogSystemPeekCursor.actor.cpp
+++ b/fdbserver/LogSystemPeekCursor.actor.cpp
@@ -41,7 +41,8 @@ ACTOR Future<Void> tryEstablishPeekStream(ILogSystem::ServerPeekCursor* self) {
 	                                 self->tag,
 	                                 self->returnIfBlocked,
 	                                 std::numeric_limits<int>::max(),
-	                                 self->end.version);
+	                                 self->end.version,
+	                                 self->returnEmptyIfStopped);
 	self->peekReplyStream = self->interf->get().interf().peekStreamMessages.getReplyStream(req);
 	DebugLogTraceEvent(SevDebug, "SPC_StreamCreated", self->randomID)
 	    .detail("Tag", self->tag)
@@ -56,12 +57,13 @@ ILogSystem::ServerPeekCursor::ServerPeekCursor(Reference<AsyncVar<OptionalInterf
                                                Version begin,
                                                Version end,
                                                bool returnIfBlocked,
-                                               bool parallelGetMore)
+                                               bool parallelGetMore,
+                                               bool returnEmptyIfStopped)
   : interf(interf), tag(tag), rd(results.arena, results.messages, Unversioned()), messageVersion(begin), end(end),
     poppedVersion(0), hasMsg(false), randomID(deterministicRandom()->randomUniqueID()),
     returnIfBlocked(returnIfBlocked), onlySpilled(false), parallelGetMore(parallelGetMore),
     usePeekStream(SERVER_KNOBS->PEEK_USING_STREAMING), sequence(0), lastReset(0), resetCheck(Void()), slowReplies(0),
-    fastReplies(0), unknownReplies(0) {
+    fastReplies(0), unknownReplies(0), returnEmptyIfStopped(returnEmptyIfStopped) {
 	this->results.maxKnownVersion = 0;
 	this->results.minKnownCommittedVersion = 0;
 	DebugLogTraceEvent(SevDebug, "SPC_Starting", randomID)
@@ -84,7 +86,7 @@ ILogSystem::ServerPeekCursor::ServerPeekCursor(TLogPeekReply const& results,
     end(end), poppedVersion(poppedVersion), messageAndTags(message), hasMsg(hasMsg),
     randomID(deterministicRandom()->randomUniqueID()), returnIfBlocked(false), onlySpilled(false),
     parallelGetMore(false), usePeekStream(false), sequence(0), lastReset(0), resetCheck(Void()), slowReplies(0),
-    fastReplies(0), unknownReplies(0) {
+    fastReplies(0), unknownReplies(0), returnEmptyIfStopped(false) {
 	//TraceEvent("SPC_Clone", randomID);
 	this->results.maxKnownVersion = 0;
 	this->results.minKnownCommittedVersion = 0;
@@ -278,6 +280,7 @@ ACTOR Future<Void> serverPeekParallelGetMore(ILogSystem::ServerPeekCursor* self,
 		    .detail("Seq", self->sequence)
 		    .detail("Sizes", self->futureResults.size())
 		    .detail("Interf", self->interf->get().present() ? self->interf->get().id() : UID());
+
 		state Version expectedBegin = self->messageVersion.version;
 		try {
 			if (self->parallelGetMore || self->onlySpilled) {
@@ -292,7 +295,8 @@ ACTOR Future<Void> serverPeekParallelGetMore(ILogSystem::ServerPeekCursor* self,
 					                        self->returnIfBlocked,
 					                        self->onlySpilled,
 					                        std::make_pair(self->randomID, self->sequence++),
-					                        self->end.version),
+					                        self->end.version,
+					                        self->returnEmptyIfStopped),
 					        taskID)));
 				}
 				if (self->sequence == std::numeric_limits<decltype(self->sequence)>::max()) {
@@ -450,7 +454,8 @@ ACTOR Future<Void> serverPeekGetMore(ILogSystem::ServerPeekCursor* self, TaskPri
 				                                        self->returnIfBlocked,
 				                                        self->onlySpilled,
 				                                        Optional<std::pair<UID, int>>(),
-				                                        self->end.version),
+				                                        self->end.version,
+				                                        self->returnEmptyIfStopped),
 				                        taskID))
 				                  : Never())) {
 					updateCursorWithReply(self, res);
@@ -594,8 +599,12 @@ ILogSystem::MergedPeekCursor::MergedPeekCursor(
 	}
 
 	for (int i = 0; i < logServers.size(); i++) {
+		bool returnEmptyIfStopped =
+		    ((SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST && end != std::numeric_limits<Version>::max())
+		         ? (bestServer < 0 || i == bestServer)
+		         : false);
 		auto cursor = makeReference<ILogSystem::ServerPeekCursor>(
-		    logServers[i], tag, begin, end, bestServer >= 0, parallelGetMore);
+		    logServers[i], tag, begin, end, bestServer >= 0, parallelGetMore, returnEmptyIfStopped);
 		//TraceEvent("MPC_Starting", randomID).detail("Cursor", cursor->randomID).detail("End", end);
 		serverCursors.push_back(cursor);
 	}
@@ -855,13 +864,18 @@ ILogSystem::SetPeekCursor::SetPeekCursor(std::vector<Reference<LogSet>> const& l
                                          Version end,
                                          bool parallelGetMore)
   : logSets(logSets), tag(tag), bestSet(bestSet), bestServer(bestServer), currentSet(bestSet), currentCursor(0),
-    messageVersion(begin), hasNextMessage(false), useBestSet(true), randomID(deterministicRandom()->randomUniqueID()) {
+    messageVersion(begin), hasNextMessage(false), useBestSet(true), randomID(deterministicRandom()->randomUniqueID()),
+    end(end) {
 	serverCursors.resize(logSets.size());
 	int maxServers = 0;
 	for (int i = 0; i < logSets.size(); i++) {
 		for (int j = 0; j < logSets[i]->logServers.size(); j++) {
+			bool returnEmptyIfStopped =
+			    ((SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST && end != std::numeric_limits<Version>::max())
+			         ? (bestServer < 0 || (i == bestSet && j == bestServer))
+			         : false);
 			auto cursor = makeReference<ILogSystem::ServerPeekCursor>(
-			    logSets[i]->logServers[j], tag, begin, end, true, parallelGetMore);
+			    logSets[i]->logServers[j], tag, begin, end, true, parallelGetMore, returnEmptyIfStopped);
 			serverCursors[i].push_back(cursor);
 		}
 		maxServers = std::max<int>(maxServers, serverCursors[i].size());

--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -1223,7 +1223,9 @@ ACTOR Future<Void> updatePersistentData(TLogData* self, Reference<LogData> logDa
 		}
 		if (minVersion != std::numeric_limits<Version>::max()) {
 			self->persistentQueue->forgetBefore(
-			    minVersion,
+			    (!SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST
+			         ? minVersion
+			         : std::min(newPersistentDataVersion, logData->knownCommittedVersion)),
 			    logData); // SOMEDAY: this can cause a slow task (~0.5ms), presumably from erasing too many versions.
 			              // Should we limit the number of versions cleared at a time?
 		}

--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -1225,7 +1225,7 @@ ACTOR Future<Void> updatePersistentData(TLogData* self, Reference<LogData> logDa
 			self->persistentQueue->forgetBefore(
 			    (!SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST
 			         ? minVersion
-			         : std::min(newPersistentDataVersion, logData->knownCommittedVersion)),
+			         : std::min(minVersion, logData->knownCommittedVersion)),
 			    logData); // SOMEDAY: this can cause a slow task (~0.5ms), presumably from erasing too many versions.
 			              // Should we limit the number of versions cleared at a time?
 		}

--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -1789,7 +1789,8 @@ Future<Void> tLogPeekMessages(PromiseType replyPromise,
                               bool reqReturnIfBlocked = false,
                               bool reqOnlySpilled = false,
                               Optional<std::pair<UID, int>> reqSequence = Optional<std::pair<UID, int>>(),
-                              Optional<Version> reqEnd = Optional<Version>()) {
+                              Optional<Version> reqEnd = Optional<Version>(),
+                              Optional<bool> reqReturnEmptyIfStopped = Optional<bool>()) {
 	state BinaryWriter messages(Unversioned());
 	state BinaryWriter messages2(Unversioned());
 	state int sequence = -1;
@@ -1866,7 +1867,9 @@ Future<Void> tLogPeekMessages(PromiseType replyPromise,
 	state Optional<Version> replyWithRecoveryVersion = Optional<Version>();
 	if (logData->version.get() < reqBegin) {
 		if (SERVER_KNOBS->ENABLE_VERSION_VECTOR_REPLY_RECOVERY && logData->stopped() && reqEnd.present() &&
-		    reqEnd.get() != std::numeric_limits<Version>::max()) {
+		    reqEnd.get() != std::numeric_limits<Version>::max() && reqReturnEmptyIfStopped.present() &&
+		    reqReturnEmptyIfStopped.get()) {
+			ASSERT(SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST);
 			replyWithRecoveryVersion = reqEnd;
 		} else if (reqReturnIfBlocked) {
 			replyPromise.sendError(end_of_stream());
@@ -2252,7 +2255,8 @@ ACTOR Future<Void> tLogPeekStream(TLogData* self, TLogPeekStreamRequest req, Ref
 			                      req.returnIfBlocked,
 			                      onlySpilled,
 			                      Optional<std::pair<UID, int>>(),
-			                      req.end));
+			                      req.end,
+			                      req.returnEmptyIfStopped));
 
 			reply.rep.begin = begin;
 			req.reply.send(reply);
@@ -2888,7 +2892,8 @@ ACTOR Future<Void> serveTLogInterface(TLogData* self,
 			                                        req.returnIfBlocked,
 			                                        req.onlySpilled,
 			                                        req.sequence,
-			                                        req.end));
+			                                        req.end,
+			                                        req.returnEmptyIfStopped));
 		}
 		when(TLogPopRequest req = waitNext(tli.popMessages.getFuture())) {
 			logData->addActor.send(tLogPop(self, req, logData));

--- a/fdbserver/include/fdbserver/LogSystem.h
+++ b/fdbserver/include/fdbserver/LogSystem.h
@@ -229,12 +229,15 @@ struct ILogSystem {
 		int fastReplies;
 		int unknownReplies;
 
+		bool returnEmptyIfStopped; // valid only when unicast is enabled
+
 		ServerPeekCursor(Reference<AsyncVar<OptionalInterface<TLogInterface>>> const& interf,
 		                 Tag tag,
 		                 Version begin,
 		                 Version end,
 		                 bool returnIfBlocked,
-		                 bool parallelGetMore);
+		                 bool parallelGetMore,
+		                 bool returnEmtpyIfStopped = false);
 		ServerPeekCursor(TLogPeekReply const& results,
 		                 LogMessageVersion const& messageVersion,
 		                 LogMessageVersion const& end,
@@ -343,6 +346,7 @@ struct ILogSystem {
 		bool useBestSet;
 		UID randomID;
 		Future<Void> more;
+		Optional<Version> end;
 
 		SetPeekCursor(std::vector<Reference<LogSet>> const& logSets,
 		              int bestSet,
@@ -557,11 +561,14 @@ struct ILogSystem {
 	// Same contract as peek(), but blocks until the preferred log server(s) for the given tag are available (and is
 	// correspondingly less expensive)
 
-	virtual Reference<IPeekCursor> peekLogRouter(UID dbgid,
-	                                             Version begin,
-	                                             Tag tag,
-	                                             bool useSatellite,
-	                                             Optional<Version> end = Optional<Version>()) = 0;
+	virtual Reference<IPeekCursor> peekLogRouter(
+	    UID dbgid,
+	    Version begin,
+	    Tag tag,
+	    bool useSatellite,
+	    Optional<Version> end = Optional<Version>(),
+	    Optional<std::map<uint8_t, std::vector<uint16_t>>> knownStoppedTLogIds =
+	        Optional<std::map<uint8_t, std::vector<uint16_t>>>()) = 0;
 	// Same contract as peek(), but can only peek from the logs elected in the same generation.
 	// If the preferred log server is down, a different log from the same generation will merge results locally before
 	// sending them to the log router.

--- a/fdbserver/include/fdbserver/LogSystemConfig.h
+++ b/fdbserver/include/fdbserver/LogSystemConfig.h
@@ -182,6 +182,7 @@ struct LogSystemConfig {
 	std::set<int8_t> pseudoLocalities;
 	LogEpoch epoch;
 	LogEpoch oldestBackupEpoch;
+	std::map<uint8_t, std::vector<uint16_t>> knownLockedTLogIds;
 
 	LogSystemConfig(LogEpoch e = 0)
 	  : logSystemType(LogSystemType::empty), logRouterTags(0), txsTags(0), expectedLogSets(0), stopped(false), epoch(e),
@@ -235,7 +236,8 @@ void LogSystemConfig::serialize(Ar& ar) {
 	           pseudoLocalities,
 	           txsTags,
 	           epoch,
-	           oldestBackupEpoch);
+	           oldestBackupEpoch,
+	           knownLockedTLogIds);
 }
 
 #endif // FDBSERVER_LOGSYSTEMCONFIG_H

--- a/fdbserver/include/fdbserver/TLogInterface.h
+++ b/fdbserver/include/fdbserver/TLogInterface.h
@@ -222,20 +222,22 @@ struct TLogPeekRequest {
 	Optional<std::pair<UID, int>> sequence;
 	ReplyPromise<TLogPeekReply> reply;
 	Optional<Version> end; // when set is exclusive to the desired range
+	Optional<bool> returnEmptyIfStopped;
 
 	TLogPeekRequest(Version begin,
 	                Tag tag,
 	                bool returnIfBlocked,
 	                bool onlySpilled,
 	                Optional<std::pair<UID, int>> sequence = Optional<std::pair<UID, int>>(),
-	                Optional<Version> end = Optional<Version>())
+	                Optional<Version> end = Optional<Version>(),
+	                Optional<bool> returnEmptyIfStopped = Optional<bool>())
 	  : begin(begin), tag(tag), returnIfBlocked(returnIfBlocked), onlySpilled(onlySpilled), sequence(sequence),
-	    end(end) {}
+	    end(end), returnEmptyIfStopped(returnEmptyIfStopped) {}
 	TLogPeekRequest() {}
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, begin, tag, returnIfBlocked, onlySpilled, sequence, reply, end);
+		serializer(ar, begin, tag, returnIfBlocked, onlySpilled, sequence, reply, end, returnEmptyIfStopped);
 	}
 };
 
@@ -262,18 +264,21 @@ struct TLogPeekStreamRequest {
 	int limitBytes;
 	Optional<Version> end; // when set is exclusive to the desired range
 	ReplyPromiseStream<TLogPeekStreamReply> reply;
+	Optional<bool> returnEmptyIfStopped;
 
 	TLogPeekStreamRequest() {}
 	TLogPeekStreamRequest(Version version,
 	                      Tag tag,
 	                      bool returnIfBlocked,
 	                      int limitBytes,
-	                      Optional<Version> end = Optional<Version>())
-	  : begin(version), tag(tag), returnIfBlocked(returnIfBlocked), limitBytes(limitBytes), end(end) {}
+	                      Optional<Version> end = Optional<Version>(),
+	                      Optional<bool> returnEmptyIfStopped = Optional<bool>())
+	  : begin(version), tag(tag), returnIfBlocked(returnIfBlocked), limitBytes(limitBytes), end(end),
+	    returnEmptyIfStopped(returnEmptyIfStopped) {}
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, begin, tag, returnIfBlocked, limitBytes, reply, end);
+		serializer(ar, begin, tag, returnIfBlocked, limitBytes, reply, end, returnEmptyIfStopped);
 	}
 };
 

--- a/fdbserver/include/fdbserver/WorkerInterface.actor.h
+++ b/fdbserver/include/fdbserver/WorkerInterface.actor.h
@@ -669,10 +669,21 @@ struct InitializeLogRouterRequest {
 	int8_t locality;
 	ReplyPromise<struct TLogInterface> reply;
 	Optional<Version> recoverAt = Optional<Version>();
+	Optional<std::map<uint8_t, std::vector<uint16_t>>> knownLockedTLogIds =
+	    Optional<std::map<uint8_t, std::vector<uint16_t>>>();
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, recoveryCount, routerTag, startVersion, tLogLocalities, tLogPolicy, locality, reply, recoverAt);
+		serializer(ar,
+		           recoveryCount,
+		           routerTag,
+		           startVersion,
+		           tLogLocalities,
+		           tLogPolicy,
+		           locality,
+		           reply,
+		           recoverAt,
+		           knownLockedTLogIds);
 	}
 };
 


### PR DESCRIPTION
In the context of version vector/unicast, make log servers return an empty version range (on peeks) such that the receiver won't miss any versions that it is supposed to receive.

- Make the cluster controller collect the set of log servers participated in recovery and propagate that information to the other processes

- Extend the ServerPeekCursor to take a flag that tells the source log server whether it can return an empty version range or not (in the context of version vector/unicast), and make the source log server return an empty version range only when this flag is set

- Make the peek APIs set the flag appropriately when initializing ServerPeekCursors

- Also, take the internal logic used by SetPeekCursor and MergedPeekCursor into account while initializing the above mentioned flag.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
