### PR TITLE
Add error wrapping to provide better error context for debugging

### DIFF
--- a/bindings/go/src/fdb/database.go
+++ b/bindings/go/src/fdb/database.go
@@ -28,6 +28,7 @@ import "C"
 
 import (
 	"errors"
+	"fmt"
 	"runtime"
 )
 
@@ -96,7 +97,7 @@ func (d Database) CreateTransaction() (Transaction, error) {
 	var outt *C.FDBTransaction
 
 	if err := C.fdb_database_create_transaction(d.ptr, &outt); err != 0 {
-		return Transaction{}, Error{int(err)}
+		return Transaction{}, fmt.Errorf("failed to create transaction: %w", Error{int(err)})
 	}
 
 	t := &transaction{outt, d}

--- a/bindings/go/src/fdb/fdb.go
+++ b/bindings/go/src/fdb/fdb.go
@@ -84,7 +84,7 @@ type ReadTransactor interface {
 
 func setOpt(setter func(*C.uint8_t, C.int) C.fdb_error_t, param []byte) error {
 	if err := setter(byteSliceToPtr(param), C.int(len(param))); err != 0 {
-		return Error{int(err)}
+		return fmt.Errorf("failed to set option: %w", Error{int(err)})
 	}
 
 	return nil
@@ -157,7 +157,7 @@ func APIVersion(version int) error {
 				}
 				return fmt.Errorf("API version %d is not supported by the installed FoundationDB C library.", version)
 			}
-			return Error{int(e)}
+			return fmt.Errorf("failed to select API version: %w", Error{int(e)})
 		}
 	}
 
@@ -428,7 +428,7 @@ func OpenWithConnectionString(connectionString string) (Database, error) {
 	var createErr error
 	if err := executeWithRunningNetworkThread(func() {
 		if err := C.fdb_create_database_from_connection_string(cf, &outdb); err != 0 {
-			createErr = Error{int(err)}
+			createErr = fmt.Errorf("failed to create database from connection string: %w", Error{int(err)})
 		}
 	}); err != nil {
 		return Database{}, err

--- a/bindings/go/src/fdb/futures.go
+++ b/bindings/go/src/fdb/futures.go
@@ -39,6 +39,7 @@ package fdb
 import "C"
 
 import (
+	"fmt"
 	"runtime"
 	"sync"
 	"unsafe"
@@ -165,7 +166,7 @@ func (f *futureByteSlice) Get() ([]byte, error) {
 		f.BlockUntilReady()
 
 		if err := C.fdb_future_get_value(f.ptr, &present, &value, &length); err != 0 {
-			f.e = Error{int(err)}
+			f.e = fmt.Errorf("failed to get future value: %w", Error{int(err)})
 			return
 		}
 
@@ -221,7 +222,7 @@ func (f *futureKey) Get() (Key, error) {
 		f.BlockUntilReady()
 
 		if err := C.fdb_future_get_key(f.ptr, &value, &length); err != 0 {
-			f.e = Error{int(err)}
+			f.e = fmt.Errorf("failed to get future key: %w", Error{int(err)})
 			return
 		}
 
@@ -266,7 +267,7 @@ func (f *futureNil) Get() error {
 
 	f.BlockUntilReady()
 	if err := C.fdb_future_get_error(f.ptr); err != 0 {
-		return Error{int(err)}
+		return fmt.Errorf("failed to get future error: %w", Error{int(err)})
 	}
 
 	return nil
@@ -305,7 +306,7 @@ func (f *futureKeyValueArray) Get() ([]KeyValue, bool, error) {
 	var more C.fdb_bool_t
 
 	if err := C.fdb_future_get_keyvalue_array(f.ptr, &kvs, &count, &more); err != 0 {
-		return nil, false, Error{int(err)}
+		return nil, false, fmt.Errorf("failed to get key-value array: %w", Error{int(err)})
 	}
 
 	ret := make([]KeyValue, int(count))
@@ -349,7 +350,7 @@ func (f *futureKeyArray) Get() ([]Key, error) {
 	var count C.int
 
 	if err := C.fdb_future_get_key_array(f.ptr, &ks, &count); err != 0 {
-		return nil, Error{int(err)}
+		return nil, fmt.Errorf("failed to get key array: %w", Error{int(err)})
 	}
 
 	ret := make([]Key, int(count))
@@ -399,7 +400,7 @@ func (f *futureInt64) Get() (int64, error) {
 
 	var ver C.int64_t
 	if err := C.fdb_future_get_int64(f.ptr, &ver); err != 0 {
-		return 0, Error{int(err)}
+		return 0, fmt.Errorf("failed to get int64 value: %w", Error{int(err)})
 	}
 
 	return int64(ver), nil
@@ -444,7 +445,7 @@ func (f *futureStringSlice) Get() ([]string, error) {
 	var count C.int
 
 	if err := C.fdb_future_get_string_array(f.ptr, (***C.char)(unsafe.Pointer(&strings)), &count); err != 0 {
-		return nil, Error{int(err)}
+		return nil, fmt.Errorf("failed to get string array: %w", Error{int(err)})
 	}
 
 	ret := make([]string, int(count))

--- a/bindings/go/src/fdb/transaction.go
+++ b/bindings/go/src/fdb/transaction.go
@@ -421,7 +421,7 @@ func (t Transaction) GetCommittedVersion() (int64, error) {
 	var version C.int64_t
 
 	if err := C.fdb_transaction_get_committed_version(t.ptr, &version); err != 0 {
-		return 0, Error{int(err)}
+		return 0, fmt.Errorf("failed to get committed version: %w", Error{int(err)})
 	}
 
 	return int64(version), nil
@@ -515,7 +515,7 @@ func addConflictRange(t *transaction, er ExactRange, crtype conflictRangeType) e
 		C.int(len(ekb)),
 		C.FDBConflictRangeType(crtype),
 	); err != 0 {
-		return Error{int(err)}
+		return fmt.Errorf("failed to add conflict range: %w", Error{int(err)})
 	}
 
 	return nil


### PR DESCRIPTION
Improve error handling in Go bindings by wrapping FoundationDB errors with descriptive context using fmt.Errorf. This change makes error messages more informative and easier to debug by providing better context for transaction, database, and future operations.

Testing: Verified error handling improvements across all modified files.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
