### PR TITLE
Fix RawTenantAccessWorkload Unsigned difference expression compared to zero

### DIFF
--- a/fdbserver/workloads/RawTenantAccessWorkload.actor.cpp
+++ b/fdbserver/workloads/RawTenantAccessWorkload.actor.cpp
@@ -87,7 +87,7 @@ struct RawTenantAccessWorkload : TestWorkload {
 
 	bool hasNonexistentTenant() const { return lastCreatedTenants.size() + idx2Tid.size() < tenantCount; }
 
-	bool hasExistingTenant() const { return idx2Tid.size() - lastDeletedTenants.size() > 0; }
+	bool hasExistingTenant() const { return (int64_t)idx2Tid.size() - (int64_t)lastDeletedTenants.size() > 0; }
 
 	int64_t extractTenantId(ValueRef value) const {
 		int64_t id;


### PR DESCRIPTION
https://github.com/apple/foundationdb/blob/c289917d17fd50307576f0ce6d969b209460c9b7/fdbserver/workloads/RawTenantAccessWorkload.actor.cpp#L90-L90

This rule finds relational comparisons between the result of an unsigned subtraction and the value `0`. Such comparisons are likely to be wrong as the value of an unsigned subtraction can never be negative. So the relational comparison ends up checking whether the result of the subtraction is equal to `0`. This is probably not what the programmer intended.


Fix the issue, we need to ensure that the subtraction operation does not underflow. The best approach is to cast the unsigned values to a signed type (e.g., `int64_t`) before performing the subtraction. This ensures that the result of the subtraction can represent negative values if `lastDeletedTenants.size()` is greater than `idx2Tid.size()`. The comparison will then behave as intended.

The specific change involves modifying the expression `idx2Tid.size() - lastDeletedTenants.size() > 0` to `(int64_t)idx2Tid.size() - (int64_t)lastDeletedTenants.size() > 0`.

```cpp
uint32_t limit = get_limit();
uint32_t total = 0;

while (limit - total > 0) { // BAD: if `total` is greater than `limit` this will underflow and continue executing the loop.
  total += get_data();
}

while (total < limit) { // GOOD: never underflows here because there is no arithmetic.
  total += get_data();
}

while ((int64_t)limit - total > 0) { // GOOD: never underflows here because the result always fits in an `int64_t`.
  total += get_data();
}
```

[INT02-C. Understand integer conversion rules](https://wiki.sei.cmu.edu/confluence/display/c/INT02-C.+Understand+integer+conversion+rules)



---






# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [x] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [x] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
