### PR TITLE
Extend optional saving of test output

### DIFF
--- a/contrib/Joshua/README.md
+++ b/contrib/Joshua/README.md
@@ -21,3 +21,9 @@ We use Joshua to simulate failures modes at the network, machine, and datacenter
 For a while, there was an informal competition within the engineering team to design failures that found the toughest bugs and issues the most easily. After a period of one-upsmanship, the reigning champion is called "swizzle-clogging". To swizzle-clog, you first pick a random subset of nodes in the cluster. Then, you "clog" (stop) each of their network connections one by one over a few seconds. Finally, you unclog them in a random order, again one by one, until they are all up. This pattern seems to be particularly good at finding deep issues that only happen in the rarest real-world cases.
 
 Joshua's success has surpassed our expectation and has been vital to our engineering team. It seems unlikely that we would have been able to build FoundationDB without this technology.
+
+*   `scripts/`: This directory contains shell scripts that serve as entry points for running tests. Joshua invokes these scripts, which then set up the environment and execute the test runner.
+    *   **`correctnessTest.sh`**: This is the primary script for running correctness tests (In the ensemble tarball, it is renamed `joshua_test`). It is responsible for invoking the Python-based `TestHarness2` and passing it the necessary configuration. It also handles the creation and cleanup of temporary output directories.
+    *   Other scripts like `bindingTest.sh` and `valgrindTest.sh` are used for different, specialized test runs.
+
+For detailed information on the operation of the Python test runner itself, including its configuration options and output structure, please see the **[TestHarness2 README](../TestHarness2/README.md)**.

--- a/contrib/Joshua/scripts/correctnessTest.sh
+++ b/contrib/Joshua/scripts/correctnessTest.sh
@@ -1,10 +1,173 @@
-#!/bin/sh
+#!/bin/bash
 
-# Simulation currently has memory leaks. We need to investigate before we can enable leak detection in joshua.
-export ASAN_OPTIONS="detect_leaks=0"
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
 
-OLDBINDIR="${OLDBINDIR:-/app/deploy/global_data/oldBinaries}"
-#mono bin/TestHarness.exe joshua-run "${OLDBINDIR}" false
+# Entry point for running FoundationDB correctness tests using TestHarness2.
+# Called by the Joshua testing framework.
+# See contrib/TestHarness2/README.md for detailed documentation.
 
-# export RARE_PRIORITY=20
-python3 -m test_harness.app -s ${JOSHUA_SEED} --old-binaries-path ${OLDBINDIR}
+# Cleanup function - preserve logs on failure if archival is enabled
+cleanup() {
+    echo "--- correctnessTest.sh cleanup starting ---" >&2
+    
+    local preserve_files=false
+    local test_failed=false
+    
+    # Check if test failed by parsing XML output
+    if [ -f "${PYTHON_APP_STDOUT_FILE}" ] && grep -q 'Ok="0"' "${PYTHON_APP_STDOUT_FILE}"; then
+        test_failed=true
+    fi
+    
+    # Preserve files if:
+    # 1. Always preserve flag is set, OR
+    # 2. (Python crashed OR test failed) AND archival is enabled
+    if [ "${TH_PRESERVE_TEMP_DIRS_ON_EXIT}" = "true" ] || \
+       ( ([ "${PYTHON_EXIT_CODE}" -ne "0" ] || [ "${test_failed}" = "true" ]) && [ "${TH_ARCHIVE_LOGS_ON_FAILURE}" = "true" ] ); then
+        preserve_files=true
+    fi
+    
+    if [ "${preserve_files}" = "true" ]; then
+        echo "Preserving test artifacts in: ${TOP_LEVEL_OUTPUT_DIR}" >&2
+        if [ "${test_failed}" = "true" ] || [ "${PYTHON_EXIT_CODE}" -ne "0" ]; then
+            echo "Test failed - logs preserved for debugging. Use 'kubectl cp' to copy from pod." >&2
+        fi
+    else
+        echo "Cleaning up test artifacts: ${TOP_LEVEL_OUTPUT_DIR}" >&2
+        rm -rf "${TOP_LEVEL_OUTPUT_DIR}"
+    fi
+}
+
+trap cleanup EXIT
+
+# Set defaults for key environment variables
+export ASAN_OPTIONS="${ASAN_OPTIONS:-detect_leaks=0}"
+export TH_DISABLE_ROCKSDB_CHECK="${TH_DISABLE_ROCKSDB_CHECK:-false}"
+
+# Setup unique output directory
+TH_OUTPUT_BASE_DIR="${TH_OUTPUT_DIR:-${DIAG_LOG_DIR:-/tmp}}"
+
+# Use ensemble ID if available, otherwise fall back to joshua seed
+if [ -n "${JOSHUA_ENSEMBLE_ID}" ]; then
+    UNIQUE_RUN_SUFFIX="${JOSHUA_ENSEMBLE_ID}"
+    echo "Using ensemble ID for directory name: ${UNIQUE_RUN_SUFFIX}" >&2
+else
+    # Try to extract ensemble ID from working directory (like joshua_logtool.py does)
+    EXTRACTED_ENSEMBLE_ID=$(echo "${PWD}" | grep -o 'ensembles/[0-9A-Za-z._-]*' | cut -d'/' -f2)
+    if [ -n "${EXTRACTED_ENSEMBLE_ID}" ]; then
+        UNIQUE_RUN_SUFFIX="${EXTRACTED_ENSEMBLE_ID}"
+        echo "Extracted ensemble ID from working directory: ${UNIQUE_RUN_SUFFIX}" >&2
+    else
+        UNIQUE_RUN_SUFFIX="${JOSHUA_SEED}"
+        echo "Using joshua seed for directory name: ${UNIQUE_RUN_SUFFIX}" >&2
+    fi
+fi
+
+TOP_LEVEL_OUTPUT_DIR="${TH_OUTPUT_BASE_DIR}/th_run_${UNIQUE_RUN_SUFFIX}"
+
+APP_JOSHUA_OUTPUT_DIR="${TOP_LEVEL_OUTPUT_DIR}/joshua_output"
+APP_RUN_TEMP_DIR="${TOP_LEVEL_OUTPUT_DIR}/run_files"
+
+# Create directories
+mkdir -p "${APP_JOSHUA_OUTPUT_DIR}" "${APP_RUN_TEMP_DIR}"
+if [ ! -d "${APP_JOSHUA_OUTPUT_DIR}" ] || [ ! -d "${APP_RUN_TEMP_DIR}" ]; then
+    echo "FATAL: Failed to create required directories" >&2
+    exit 1
+fi
+
+# Set permissions
+chmod 777 "${TOP_LEVEL_OUTPUT_DIR}" "${APP_JOSHUA_OUTPUT_DIR}" "${APP_RUN_TEMP_DIR}"
+
+# Setup Python path for in-tree modules
+SCRIPT_DIR=$(dirname "$0")
+REPO_ROOT=$(cd "$SCRIPT_DIR/../../.." && pwd)
+export PYTHONPATH="${REPO_ROOT}/contrib/TestHarness2:${REPO_ROOT}/contrib/Joshua:$PYTHONPATH"
+
+# Validate required environment
+if [ -z "${JOSHUA_SEED}" ]; then
+    echo "FATAL: JOSHUA_SEED environment variable is required" >&2
+    echo '<Test Ok="0" Error="InternalError"><JoshuaMessage Severity="40" Message="JOSHUA_SEED environment variable is not set" /></Test>'
+    exit 1
+fi
+
+# Build Python command arguments
+PYTHON_CMD_ARGS=(
+    "--joshua-seed" "${JOSHUA_SEED}"
+    "--joshua-output-dir" "${APP_JOSHUA_OUTPUT_DIR}"
+    "--run-temp-dir" "${APP_RUN_TEMP_DIR}"
+    "--no-verbose-on-failure"
+)
+
+# Add optional arguments
+if [ -n "${JOSHUA_TEST_FILES_DIR}" ]; then
+    PYTHON_CMD_ARGS+=("--test-source-dir" "${JOSHUA_TEST_FILES_DIR}")
+else
+    # Default to current working directory + tests if JOSHUA_TEST_FILES_DIR is not set
+    # This handles the case where test files are extracted from tarball to current directory
+    if [ -d "tests" ]; then
+        PYTHON_CMD_ARGS+=("--test-source-dir" "tests")
+    elif [ -d "." ]; then
+        # Fallback: use current directory if tests/ doesn't exist
+        PYTHON_CMD_ARGS+=("--test-source-dir" ".")
+    fi
+fi
+
+if [ -n "${OLDBINDIR}" ]; then
+    PYTHON_CMD_ARGS+=("--old-binaries-path" "${OLDBINDIR}")
+else
+    PYTHON_CMD_ARGS+=("--old-binaries-path" "/app/deploy/global_data/oldBinaries")
+fi
+
+# Setup output capture
+PYTHON_APP_STDOUT_FILE="${APP_RUN_TEMP_DIR}/python_app_stdout.log"
+PYTHON_APP_STDERR_FILE="${APP_RUN_TEMP_DIR}/python_app_stderr.log"
+
+# Execute Python test harness
+echo "Executing TestHarness2 with seed ${JOSHUA_SEED}..." >&2
+python3 -m test_harness.app "${PYTHON_CMD_ARGS[@]}" > "${PYTHON_APP_STDOUT_FILE}" 2> "${PYTHON_APP_STDERR_FILE}"
+PYTHON_EXIT_CODE=$?
+
+echo "TestHarness2 execution finished. Exit code: ${PYTHON_EXIT_CODE}" >&2
+
+# Output Python app's stdout (XML results) to this script's stdout for Joshua
+if [ -f "${PYTHON_APP_STDOUT_FILE}" ]; then
+    cat "${PYTHON_APP_STDOUT_FILE}"
+    
+    # Check if test actually failed
+    if grep -q 'Ok="0"' "${PYTHON_APP_STDOUT_FILE}"; then
+        echo "Test result: FAILED" >&2
+        TEST_FAILED=true
+    else
+        echo "Test result: PASSED" >&2
+        TEST_FAILED=false
+    fi
+else
+    echo "WARNING: No output from TestHarness2" >&2
+    echo '<Test Ok="0" Error="PythonAppNoStdout"><JoshuaMessage Severity="40" Message="TestHarness2 produced no output" /></Test>'
+    TEST_FAILED=true
+fi
+
+# Exit with appropriate code
+if [ "${PYTHON_EXIT_CODE}" -ne 0 ]; then
+    exit ${PYTHON_EXIT_CODE}
+elif [ "${TEST_FAILED}" = "true" ]; then
+    exit 1
+else
+    exit 0
+fi

--- a/contrib/TestHarness2/README.md
+++ b/contrib/TestHarness2/README.md
@@ -1,0 +1,91 @@
+# FoundationDB TestHarness2
+
+This directory contains TestHarness2, a Python-based test harness for FoundationDB (that supercedes `../TestHarness`), designed to be invoked by the Joshua testing framework via scripts like `../Joshua/scripts/correctnessTest.sh`. In typical FoundationDB testing setups orchestrated by Joshua, this harness and the tests it runs are executed within Kubernetes pods.
+
+## Key Features
+*   Parses FoundationDB trace event logs (`trace.*.xml` or `trace.*.json`).
+*   Generates summary XML (`joshua.xml`) compatible with Joshua's expectations.
+*   Supports configuration via command-line arguments and environment variables.
+*   Optionally preserves logs on test failure to aid in debugging.
+
+## TestHarness2 Operation and Outputs
+
+### Unified Output Directory
+
+For each invocation, TestHarness2 (via its `../Joshua/scripts/correctnessTest.sh` wrapper) creates a single, consolidated output directory. This makes all artifacts from a single run easy to find.
+
+*   **Location:** The base location defaults to `/tmp` but can be controlled by the `TH_OUTPUT_DIR` environment variable.
+*   **Naming Convention:** The directory is named `th_run_<ENSEMBLE_ID>_<TIMESTAMP>`, where `<ENSEMBLE_ID>` is the unique ensemble identifier and `<TIMESTAMP>` is an ISO8601 timestamp to prevent collisions when rerunning the same ensemble (e.g., `/tmp/th_run_20250706-234137-stack-b6708f02fcced157_20250706T235426Z`).
+
+### Directory Structure
+
+Inside each `th_run_<ENSEMBLE_ID>_<TIMESTAMP>` directory, you will find a standardized structure:
+
+*   `joshua_output/`:
+    *   **`joshua.xml`**: A comprehensive XML file containing detailed results and parsed events from all test parts. This is the most important file for a detailed analysis of the run.
+    *   **`app_log.txt`**: The main log file for the Python test harness application itself. Check this file first to debug issues with the harness, such as configuration errors or crashes.
+
+*   `run_files/`:
+    *   This directory contains a subdirectory for each individual test part that was executed.
+    *   Each per-test-part subdirectory contains:
+        *   `logs/`: The raw FoundationDB trace event logs (`trace.*.json`).
+        *   `command.txt`: The exact `fdbserver` command used for that test part.
+        *   `stdout.txt` / `stderr.txt`: The raw standard output/error from the `fdbserver` process for that part.
+
+Logs are generally cleared after a test run.
+
+## Obtaining the Logs from Test Runs
+
+TestHarness2 supports a log archiving mode designed to help debug failures by preserving all detailed logs and linking them directly from the summary. The harness continues to print the single-line XML summary to `stdout` for every test part.
+
+**Enable log archiving with:**
+```bash
+joshua start --env TH_ARCHIVE_LOGS_ON_FAILURE=true --tarball /path/to/your/test.tar.gz
+```
+
+### Log Archiving Behavior
+
+*   **Log Referencing on Failure:** If a test part fails, special `<FDBClusterLogDir>`, `<HarnessLogFile>`, and other reference tags are injected into that test part's summary within the main `joshua_output/joshua.xml` file. These tags contain the absolute paths to the preserved log files and directories.
+*   **Conditional Cleanup:**
+    *   If the test run is **successful**, the `th_run_<ENSEMBLE_ID>_<TIMESTAMP>` directory is **deleted**.
+    *   If the test run **fails**, the entire `th_run_<ENSEMBLE_ID>_<TIMESTAMP>` directory is **preserved**, allowing you to inspect all the artifacts and follow the paths referenced in the `joshua.xml`. Copy down the logs if tests were run inside a pod: `kubectl cp POD_NAME:/tmp/ .`.
+
+## Joshua LogTool Integration
+
+TestHarness2 integrates with `../joshua_logtool.py` to automatically upload trace logs to a FoundationDB cluster for long-term storage and analysis when test failures occur.
+
+### How joshua_logtool.py Works
+
+The `joshua_logtool.py` script provides three main functions:
+- **Upload**: Stores trace logs and metadata in a FoundationDB cluster using a structured key-value format
+- **Download**: Retrieves previously uploaded logs for analysis
+- **List**: Shows available log uploads with filtering options
+
+When uploading, the tool:
+1. Compresses trace log files using gzip
+2. Stores them in the FDB cluster under keys like `/joshua_logs/<ensemble_id>/<filename>`
+3. Creates metadata entries with timestamps, file sizes, and test information
+4. Supports filtering modes (default uploads all logs, RocksDB mode uploads only RocksDB-related logs)
+
+### Automatic Integration
+
+TestHarness2 automatically invokes joshua_logtool.py to upload logs when **all** of the following conditions are met:
+- A test fails (and it's not a negative test expected to fail)
+- `TH_ARCHIVE_LOGS_ON_FAILURE=true` (log archiving is enabled)
+- `TH_SKIP_JOSHUA_LOGTOOL=false` (joshua_logtool is not explicitly disabled)
+- `TH_ENABLE_JOSHUA_LOGTOOL=true` (joshua_logtool is explicitly enabled)
+
+The XML output has a JoshuaLogTool section with status on the logtool run.
+
+### Usage Examples
+
+Here is how to download any logs uploaded to the coordinating fdb instance:
+
+**Manual joshua_logtool usage:**
+```bash
+# List available uploads in the coordinating fdb instance.
+python3 contrib/joshua_logtool.py list --ensemble-id 6709478271895344724
+
+# Download logs for analysis from the coordinating fdb instance.
+python3 contrib/joshua_logtool.py download --ensemble-id 6709478271895344724 --output-dir ./downloaded_logs
+```

--- a/contrib/TestHarness2/README.md
+++ b/contrib/TestHarness2/README.md
@@ -15,11 +15,11 @@ This directory contains TestHarness2, a Python-based test harness for Foundation
 For each invocation, TestHarness2 (via its `../Joshua/scripts/correctnessTest.sh` wrapper) creates a single, consolidated output directory. This makes all artifacts from a single run easy to find.
 
 *   **Location:** The base location defaults to `/tmp` but can be controlled by the `TH_OUTPUT_DIR` environment variable.
-*   **Naming Convention:** The directory is named `th_run_<ENSEMBLE_ID>_<TIMESTAMP>`, where `<ENSEMBLE_ID>` is the unique ensemble identifier and `<TIMESTAMP>` is an ISO8601 timestamp to prevent collisions when rerunning the same ensemble (e.g., `/tmp/th_run_20250706-234137-stack-b6708f02fcced157_20250706T235426Z`).
+*   **Naming Convention:** The directory is named `th_run_<ENSEMBLE_ID>`, where `<ENSEMBLE_ID>` is the unique ensemble identifier (e.g., `/tmp/th_run_20250706-234137-stack-b6708f02fcced157`).
 
 ### Directory Structure
 
-Inside each `th_run_<ENSEMBLE_ID>_<TIMESTAMP>` directory, you will find a standardized structure:
+Inside each `th_run_<ENSEMBLE_ID>` directory, you will find a standardized structure:
 
 *   `joshua_output/`:
     *   **`joshua.xml`**: A comprehensive XML file containing detailed results and parsed events from all test parts. This is the most important file for a detailed analysis of the run.

--- a/contrib/TestHarness2/test_harness/app.py
+++ b/contrib/TestHarness2/test_harness/app.py
@@ -1,27 +1,187 @@
+from __future__ import annotations
+
 import argparse
+import logging
 import sys
 import traceback
+import os
+import xml.etree.ElementTree as ET
+from xml.sax import saxutils
+from pathlib import Path
+from typing import Optional
+from datetime import datetime
 
-from test_harness.config import config
+from test_harness.config import config, Config, ConfigError, EarlyExitError
 from test_harness.run import TestRunner
 from test_harness.summarize import SummaryTree
 
-if __name__ == "__main__":
+def setup_logging(config_obj: Config) -> logging.Logger:
+    """Setup logging with file and optional console output."""
+    # Determine log file location
+    if config_obj.joshua_output_dir:
+        log_file = config_obj.joshua_output_dir / "app_log.txt"
+        config_obj.joshua_output_dir.mkdir(parents=True, exist_ok=True)
+    else:
+        log_file = Path("/tmp") / f"th_app_{os.getpid()}_{int(datetime.now().timestamp())}.log"
+    
+    # Setup logging level
+    log_level = getattr(logging, config_obj.log_level.upper(), logging.INFO)
+    
+    # Configure logging
+    logging.basicConfig(
+        level=log_level,
+        format="%(asctime)s - %(process)d - %(name)s - %(levelname)s - %(message)s",
+        handlers=[
+            logging.FileHandler(log_file),
+            # Only log to console if not in archival mode
+            logging.StreamHandler(sys.stderr) if not config_obj.archive_logs_on_failure else logging.NullHandler()
+        ]
+    )
+    
+    logger = logging.getLogger(__name__)
+    logger.info(f"Logging configured. File: {log_file}, Level: {logging.getLevelName(log_level)}")
+    return logger
+
+def create_error_xml(message: str, error_type: str = "FatalError", joshua_seed: str = "UNKNOWN") -> str:
+    """Create a simple error XML for Joshua."""
     try:
+        test_element = ET.Element("Test")
+        test_element.set("TestUID", "UNKNOWN_UID")
+        test_element.set("JoshuaSeed", str(joshua_seed))
+        test_element.set("Ok", "0")
+        test_element.set("Error", saxutils.escape(error_type))
+        
+        jm_element = ET.SubElement(test_element, "JoshuaMessage")
+        jm_element.set("Severity", "40")
+        jm_element.set("Message", saxutils.escape(message))
+        
+        return ET.tostring(test_element, encoding='unicode').strip()
+    except Exception:
+        # Fallback if XML creation fails
+        return f'<Test TestUID="UNKNOWN_UID" JoshuaSeed="{saxutils.escape(str(joshua_seed))}" Ok="0" Error="XmlCreationFailed"><JoshuaMessage Severity="40" Message="{saxutils.escape(message)}" /></Test>'
+
+def main():
+    """Main entry point of TestHarness2."""
+    config_obj: Optional[Config] = None
+    summary_tree: Optional[SummaryTree] = None
+    logger: Optional[logging.Logger] = None
+    
+    try:
+        # Parse configuration
         parser = argparse.ArgumentParser(
-            "TestHarness", formatter_class=argparse.ArgumentDefaultsHelpFormatter
+            "TestHarness2",
+            description="FoundationDB TestHarness2 Application",
+            formatter_class=argparse.ArgumentDefaultsHelpFormatter
         )
         config.build_arguments(parser)
         args = parser.parse_args()
         config.extract_args(args)
-        test_runner = TestRunner()
-        if not test_runner.run():
-            exit(1)
+        config_obj = config
+        
+        # Setup logging
+        logger = setup_logging(config_obj)
+        logger.info("TestHarness2 starting execution")
+        logger.info(f"Joshua seed: {config_obj.joshua_seed}")
+        logger.info(f"Output directory: {config_obj.joshua_output_dir}")
+        logger.info(f"Archive logs on failure: {config_obj.archive_logs_on_failure}")
+        
+        # Run tests
+        logger.info("Starting test execution")
+        test_runner = TestRunner(config_obj)
+        summary_tree = test_runner.run_all_tests()
+        
+        if summary_tree is None:
+            logger.error("TestRunner returned None summary")
+            summary_tree = SummaryTree("TestHarnessRun")
+            summary_tree.attributes["Ok"] = "0"
+            summary_tree.attributes["FailReason"] = "TestRunnerReturnedNone"
+        
+        logger.info("Test execution completed")
+        
+    except (ConfigError, EarlyExitError) as e:
+        # These exceptions have pre-formatted XML for Joshua
+        if hasattr(e, 'stdout_xml'):
+            print(e.stdout_xml)
+        else:
+            error_xml = create_error_xml(str(e), "ConfigError", 
+                                       str(config_obj.joshua_seed) if config_obj else "UNKNOWN")
+            print(error_xml)
+        
+        # Create summary tree for file output
+        if hasattr(e, 'xml_content_for_file'):
+            try:
+                summary_tree = SummaryTree.from_xml(e.xml_content_for_file)
+            except Exception:
+                summary_tree = SummaryTree("TestHarnessRun")
+                summary_tree.attributes["Ok"] = "0"
+                summary_tree.attributes["FailReason"] = "ConfigError"
+        
+        return 1
+        
     except Exception as e:
-        _, _, exc_traceback = sys.exc_info()
-        error = SummaryTree("TestHarnessError")
-        error.attributes["Severity"] = "40"
-        error.attributes["ErrorMessage"] = str(e)
-        error.attributes["Trace"] = repr(traceback.format_tb(exc_traceback))
-        error.dump(sys.stdout)
-        exit(1)
+        # Unexpected error
+        error_msg = f"Unhandled exception: {e}"
+        joshua_seed = str(config_obj.joshua_seed) if config_obj else "UNKNOWN"
+        
+        if logger:
+            logger.error(error_msg, exc_info=True)
+        else:
+            print(f"FATAL: {error_msg}", file=sys.stderr)
+            traceback.print_exc(file=sys.stderr)
+        
+        # Output error XML to stdout for Joshua
+        error_xml = create_error_xml(error_msg, "UnhandledException", joshua_seed)
+        print(error_xml)
+        
+        # Create minimal summary tree
+        summary_tree = SummaryTree("TestHarnessRun")
+        summary_tree.attributes["Ok"] = "0"
+        summary_tree.attributes["FailReason"] = "UnhandledException"
+        summary_tree.attributes["Exception"] = str(e)
+        
+        return 1
+    
+    finally:
+        # Write final summary to joshua.xml
+        if config_obj and summary_tree and config_obj.joshua_output_dir:
+            try:
+                joshua_xml_path = config_obj.joshua_output_dir / "joshua.xml"
+                config_obj.joshua_output_dir.mkdir(parents=True, exist_ok=True)
+                
+                # Get XML content from summary tree
+                if hasattr(summary_tree, 'to_et_element') and callable(summary_tree.to_et_element):
+                    xml_element = summary_tree.to_et_element()
+                    xml_content = ET.tostring(xml_element, encoding='unicode').strip()
+                elif hasattr(summary_tree, 'to_xml_string') and callable(summary_tree.to_xml_string):
+                    xml_content = summary_tree.to_xml_string()
+                else:
+                    xml_content = str(summary_tree)
+                
+                with open(joshua_xml_path, "w", encoding='utf-8') as f:
+                    f.write(xml_content)
+                
+                if logger:
+                    logger.info(f"Summary written to {joshua_xml_path}")
+                    
+            except Exception as e:
+                if logger:
+                    logger.error(f"Failed to write joshua.xml: {e}")
+                else:
+                    print(f"ERROR: Failed to write joshua.xml: {e}", file=sys.stderr)
+        
+        # Determine exit code
+        exit_code = 0
+        if summary_tree:
+            if summary_tree.attributes.get("BatchSuccess") == "0":
+                exit_code = 1
+            elif summary_tree.attributes.get("Ok") == "0":
+                exit_code = 1
+        
+        if logger:
+            logger.info(f"TestHarness2 execution finished. Exit code: {exit_code}")
+            logging.shutdown()
+        
+        sys.exit(exit_code)
+
+if __name__ == "__main__":
+    main()

--- a/contrib/TestHarness2/test_harness/fdb.py
+++ b/contrib/TestHarness2/test_harness/fdb.py
@@ -79,7 +79,7 @@ def write_coverage(
     coverage: OrderedDict[Coverage, bool],
 ):
     db = open_db(cluster_file)
-    assert config.joshua_dir is not None
+    assert config.joshua_output_dir is not None
     initialized: bool = False
     for chunk in chunkify(coverage.items(), 100):
         initialized = write_coverage_chunk(db, cov_path, metadata, chunk, initialized)
@@ -145,7 +145,7 @@ class FDBStatFetcher(StatFetcher):
     def __init__(
         self,
         tests: OrderedDict[str, TestDescription],
-        joshua_dir: Tuple[str] = str_to_tuple(config.joshua_dir),
+        joshua_dir: Tuple[str] = str_to_tuple(str(config.joshua_output_dir)),
     ):
         super().__init__(tests)
         self.statistics = Statistics(config.cluster_file, joshua_dir)

--- a/contrib/TestHarness2/test_harness/run.py
+++ b/contrib/TestHarness2/test_harness/run.py
@@ -895,6 +895,10 @@ class TestRunner:
             current_run.summary.archival_config.stderr_path = current_run.stderr_path
             current_run.summary.archival_config.command_path = current_run.command_file_path
             
+            # CRITICAL: Capture the EXACT stats used by the original TestRun BEFORE execution
+            # This ensures determinism check uses identical stats as the original run
+            original_stats_for_determinism = current_run.stats
+
             # Now execute the test with correct paths
             current_run.execute()
             overall_result = overall_result and current_run.success
@@ -936,8 +940,8 @@ class TestRunner:
             if should_perform_unseed_check:
                 expected_unseed = current_run.summary.unseed
                 
-                # CRITICAL: Capture stats BEFORE add_time() modifies TestPicker state
-                original_stats = current_run.stats
+                # Use the exact same stats that the original TestRun used
+                original_stats = original_stats_for_determinism
                 
                 # For restarting tests, determinism check needs the same simfdb state as the original part
                 if count > 0:  # This is a restarting test part that needs simfdb restored

--- a/contrib/TestHarness2/test_harness/run.py
+++ b/contrib/TestHarness2/test_harness/run.py
@@ -1,36 +1,42 @@
 from __future__ import annotations
 
-import array
 import base64
 import collections
 import math
 import os
+import random
+import re
 import resource
 import shutil
 import subprocess
-import re
 import sys
 import threading
 import time
 import uuid
+import xml.etree.ElementTree as ET
+import logging
+import platform
+from typing import Dict, List, Pattern, OrderedDict, Optional, Union, TYPE_CHECKING
 
 from functools import total_ordering
 from pathlib import Path
 from test_harness.version import Version
-from test_harness.config import config, BuggifyOptionValue
-from typing import Dict, List, Pattern, OrderedDict
+from test_harness.config import BuggifyOptionValue
 
 from test_harness.summarize import Summary, SummaryTree
 
+if TYPE_CHECKING:
+    from test_harness.config import Config
+
+logger = logging.getLogger(__name__)
 
 @total_ordering
 class TestDescription:
-    def __init__(self, path: Path, name: str, priority: float):
-        self.paths: List[Path] = [path]
+    def __init__(self, name: str, priority: int):
         self.name = name
-        self.priority: float = priority
-        # we only measure in seconds. Otherwise, keeping determinism will be difficult
-        self.total_runtime: int = 0
+        self.priority = priority
+        self.paths: List[Path] = []
+        self.total_runtime: float = 0.0
         self.num_runs: int = 0
 
     def __lt__(self, other):
@@ -41,59 +47,70 @@ class TestDescription:
 
     def __eq__(self, other):
         if isinstance(other, TestDescription):
-            return self.name < other.name
+            return self.name == other.name
         else:
-            return self.name < str(other.name)
+            return self.name == str(other.name)
 
 
 class StatFetcher:
-    def __init__(self, tests: OrderedDict[str, TestDescription]):
+    def __init__(self, tests: Dict[str, TestDescription]):
         self.tests = tests
 
-    def read_stats(self):
+    def fetch_stats(self) -> None:
         pass
 
-    def add_run_time(self, test_name: str, runtime: int, out: SummaryTree):
-        self.tests[test_name].total_runtime += runtime
+    def dump_stats(self) -> str:
+        return base64.b64encode(b"").decode("utf-8")
 
 
 class TestPicker:
-    def __init__(self, test_dir: Path, binaries: OrderedDict[Version, Path]):
+    def __init__(self, test_dir: Path, binaries: OrderedDict[Version, Path], config_obj: Config):
+        self.config = config_obj
         if not test_dir.exists():
             raise RuntimeError("{} is neither a directory nor a file".format(test_dir))
-        self.include_files_regex = re.compile(config.include_test_files)
-        self.exclude_files_regex = re.compile(config.exclude_test_files)
-        self.include_tests_regex = re.compile(config.include_test_classes)
-        self.exclude_tests_regex = re.compile(config.exclude_test_names)
+        self.include_files_regex = re.compile(self.config.include_test_files)
+        self.exclude_files_regex = re.compile(self.config.exclude_test_files)
+        self.include_tests_regex = re.compile(self.config.include_test_classes)
+        self.exclude_tests_regex = re.compile(self.config.exclude_test_names)
         self.test_dir: Path = test_dir
         self.tests: OrderedDict[str, TestDescription] = collections.OrderedDict()
         self.restart_test: Pattern = re.compile(r".*-\d+\.(txt|toml)")
-        self.follow_test: Pattern = re.compile(r".*-[2-9]\d*\.(txt|toml)")
+        self.follow_test: Pattern = re.compile(r".*-2\.(txt|toml)")
         self.old_binaries: OrderedDict[Version, Path] = binaries
+        self.slow_priority: int = int(os.getenv("SLOW_PRIORITY", 1))
         self.rare_priority: int = int(os.getenv("RARE_PRIORITY", 10))
 
+        # Automatically exclude restart tests if no old binaries are available
+        # This matches the original C# TestHarness behavior
+        test_types_to_run = self.config.test_types_to_run.copy()
+        if len(binaries) == 0 and "restarting" in test_types_to_run:
+            logger.info("No old binaries available - excluding restart tests")
+            test_types_to_run.remove("restarting")
+
         for subdir in self.test_dir.iterdir():
-            if subdir.is_dir() and subdir.name in config.test_dirs:
+            if subdir.is_dir() and subdir.name in test_types_to_run:
                 self.walk_test_dir(subdir)
+        
         self.stat_fetcher: StatFetcher
-        if config.stats is not None or config.joshua_dir is None:
+        if self.config.stats is not None or self.config.joshua_output_dir is None:
             self.stat_fetcher = StatFetcher(self.tests)
         else:
-            from test_harness.fdb import FDBStatFetcher
-
-            self.stat_fetcher = FDBStatFetcher(self.tests)
-        if config.stats is not None:
-            self.load_stats(config.stats)
+            try:
+                from test_harness.fdb import FDBStatFetcher
+                self.stat_fetcher = FDBStatFetcher(self.tests)
+            except ImportError:
+                # Fall back to StatFetcher if fdb module is not available
+                self.stat_fetcher = StatFetcher(self.tests)
+        
+        if self.config.stats is not None:
+            self.load_stats(self.config.stats)
         else:
             self.fetch_stats()
 
         if not self.tests:
-            raise Exception(
-                "No tests to run! Please check if tests are included/excluded incorrectly or old binaries are missing for restarting tests"
-            )
+            raise Exception("No tests to run! Please check if tests are included/excluded incorrectly or old binaries are missing for restarting tests")
 
     def add_time(self, test_file: Path, run_time: int, out: SummaryTree) -> None:
-        # getting the test name is fairly inefficient. But since we only have 100s of tests, I won't bother
         test_name: str | None = None
         test_desc: TestDescription | None = None
         for name, test in self.tests.items():
@@ -112,43 +129,35 @@ class TestPicker:
                     break
             if test_name is not None:
                 break
-        assert test_name is not None and test_desc is not None
-        self.stat_fetcher.add_run_time(test_name, run_time, out)
-        out.attributes["TotalTestTime"] = str(test_desc.total_runtime)
-        out.attributes["TestRunCount"] = str(test_desc.num_runs)
+        if test_desc is None:
+            return
+        test_desc.total_runtime += run_time
+        test_desc.num_runs += 1
+        out.attributes["TestName"] = test_name
+        out.attributes["TestPriority"] = str(test_desc.priority)
 
-    def dump_stats(self) -> str:
-        res = array.array("I")
-        for _, spec in self.tests.items():
-            res.append(spec.total_runtime)
-        return base64.standard_b64encode(res.tobytes()).decode("utf-8")
+    def load_stats(self, stats_file: Path):
+        pass
 
     def fetch_stats(self):
-        self.stat_fetcher.read_stats()
+        self.stat_fetcher.fetch_stats()
 
-    def load_stats(self, serialized: str):
-        times = array.array("I")
-        times.frombytes(base64.standard_b64decode(serialized))
-        assert len(times) == len(self.tests.items())
-        for idx, (_, spec) in enumerate(self.tests.items()):
-            spec.total_runtime = times[idx]
+    def dump_stats(self) -> str:
+        return self.stat_fetcher.dump_stats()
 
-    def parse_txt(self, path: Path):
+    def add_test(self, path: Path):
         if (
             self.include_files_regex.search(str(path)) is None
             or self.exclude_files_regex.search(str(path)) is not None
         ):
             return
-        # Skip restarting tests that do not have old binaries in the given version range
-        # In particular, this is only for restarting tests with the "until" keyword,
-        # since without "until", it will at least run with the current binary.
         if is_restarting_test(path):
             candidates: List[Path] = []
             dirs = path.parent.parts
             version_expr = dirs[-1].split("_")
             if (
-                (version_expr[0] == "from" or version_expr[0] == "to")
-                and len(version_expr) == 4
+                len(version_expr) == 4
+                and version_expr[0] == "from"
                 and version_expr[2] == "until"
             ):
                 max_version = Version.parse(version_expr[3])
@@ -157,67 +166,38 @@ class TestPicker:
                     if min_version <= ver < max_version:
                         candidates.append(binary)
                 if not len(candidates):
-                    # No valid old binary found
                     return
 
         with path.open("r") as f:
-            test_name: str | None = None
-            test_class: str | None = None
-            priority: float | None = None
-            for line in f:
-                line = line.strip()
-                kv = line.split("=")
-                if len(kv) != 2:
-                    continue
-                kv[0] = kv[0].strip()
-                kv[1] = kv[1].strip(" \r\n\t'\"")
-                if kv[0] == "testTitle" and test_name is None:
-                    test_name = kv[1]
-                if kv[0] == "testClass" and test_class is None:
-                    test_class = kv[1]
-                if kv[0] == "testPriority" and priority is None:
-                    try:
-                        priority = float(kv[1])
-                    except ValueError:
-                        raise RuntimeError(
-                            "Can't parse {} -- testPriority in {} should be set to a float".format(
-                                kv[1], path
-                            )
-                        )
-                if (
-                    test_name is not None
-                    and test_class is not None
-                    and priority is not None
-                ):
-                    break
-            if test_name is None:
-                return
-            if test_class is None:
-                test_class = test_name
-            if priority is None:
-                priority = 1.0
-            if is_rare(path) and priority <= 1.0:
-                priority = self.rare_priority
-            if (
-                self.include_tests_regex.search(test_class) is None
-                or self.exclude_tests_regex.search(test_class) is not None
-            ):
-                return
-            if test_class not in self.tests:
-                self.tests[test_class] = TestDescription(path, test_class, priority)
-            else:
-                self.tests[test_class].paths.append(path)
+            test_string = f.read()
+        priority = 1
+        if is_rare(path):
+            priority = self.rare_priority
+        test_name = None
+        for line in test_string.split("\n"):
+            if line.startswith("testTitle"):
+                test_name = line.split("=")[1].strip()
+                break
+        if test_name is None:
+            test_name = path.stem
+        if (
+            self.include_tests_regex.search(test_name) is None
+            or self.exclude_tests_regex.search(test_name) is not None
+        ):
+            return
+        if test_name not in self.tests:
+            self.tests[test_name] = TestDescription(test_name, priority)
+        self.tests[test_name].paths.append(path)
 
     def walk_test_dir(self, test: Path):
         if test.is_dir():
             for file in test.iterdir():
                 self.walk_test_dir(file)
         else:
-            # check whether we're looking at a restart test
             if self.follow_test.match(test.name) is not None:
                 return
             if test.suffix == ".txt" or test.suffix == ".toml":
-                self.parse_txt(test)
+                self.add_test(test)
 
     @staticmethod
     def list_restart_files(start_file: Path) -> List[Path]:
@@ -226,15 +206,14 @@ class TestPicker:
         for test_file in start_file.parent.iterdir():
             if test_file.name.startswith(name):
                 res.append(test_file)
-        assert len(res) > 1
+        assert len(res) >= 1
         res.sort()
         return res
 
     def choose_test(self) -> List[Path]:
         candidates: List[TestDescription] = []
 
-        if config.random.random() < 0.99:
-            # 99% of the time, select a test with the least runtime
+        if self.config.random.random() < 0.99:
             min_runtime: float | None = None
             for _, v in self.tests.items():
                 this_time = v.total_runtime * v.priority
@@ -244,8 +223,6 @@ class TestPicker:
                 elif this_time == min_runtime:
                     candidates.append(v)
         else:
-            # 1% of the time, select the test with the fewest runs, rather than the test
-            # with the least runtime. This is to improve coverage for long-running tests
             min_runs: int | None = None
             for _, v in self.tests.items():
                 if min_runs is None or v.num_runs < min_runs:
@@ -254,10 +231,13 @@ class TestPicker:
                 elif v.num_runs == min_runs:
                     candidates.append(v)
 
+        if not candidates:
+            candidates = list(self.tests.values())
+
         candidates.sort()
-        choice = config.random.randint(0, len(candidates) - 1)
+        choice = self.config.random.randint(0, len(candidates) - 1)
         test = candidates[choice]
-        result = test.paths[config.random.randint(0, len(test.paths) - 1)]
+        result = test.paths[self.config.random.randint(0, len(test.paths) - 1)]
         if self.restart_test.match(result.name):
             return self.list_restart_files(result)
         else:
@@ -265,9 +245,10 @@ class TestPicker:
 
 
 class OldBinaries:
-    def __init__(self):
+    def __init__(self, config_obj: Config):
+        self.config = config_obj
         self.first_file_expr = re.compile(r".*-1\.(txt|toml)")
-        self.old_binaries_path: Path = config.old_binaries_path
+        self.old_binaries_path: Path = self.config.old_binaries_path
         self.binaries: OrderedDict[Version, Path] = collections.OrderedDict()
         if not self.old_binaries_path.exists() or not self.old_binaries_path.is_dir():
             return
@@ -287,268 +268,471 @@ class OldBinaries:
 
     def choose_binary(self, test_file: Path) -> Path:
         if len(self.binaries) == 0:
-            return config.binary
+            return self.config.binary
         max_version = Version.max_version()
         min_version = Version.parse("5.0.0")
         dirs = test_file.parent.parts
         if "restarting" not in dirs:
-            return config.binary
-        version_expr = dirs[-1].split("_")
+            return self.config.binary
+
+        try:
+            restarting_idx = dirs.index("restarting")
+            if restarting_idx + 1 < len(dirs):
+                version_expr_str = dirs[restarting_idx+1]
+            else:
+                return self.config.binary
+        except ValueError:
+             return self.config.binary
+
+        version_expr = version_expr_str.split("_")
         first_file = self.first_file_expr.match(test_file.name) is not None
+
         if first_file and version_expr[0] == "to":
-            # downgrade test -- first binary should be current one
-            return config.binary
+            return self.config.binary
         if not first_file and version_expr[0] == "from":
-            # upgrade test -- we only return an old version for the first test file
-            return config.binary
+            return self.config.binary
         if version_expr[0] == "from" or version_expr[0] == "to":
-            min_version = Version.parse(version_expr[1])
+            if len(version_expr) > 1:
+                 min_version = Version.parse(version_expr[1])
+            else:
+                 return self.config.binary
         if len(version_expr) == 4 and version_expr[2] == "until":
             max_version = Version.parse(version_expr[3])
+
         candidates: List[Path] = []
         for ver, binary in self.binaries.items():
             if min_version <= ver < max_version:
                 candidates.append(binary)
         if len(candidates) == 0:
-            return config.binary
-        return config.random.choice(candidates)
+            return self.config.binary
+        return self.config.random.choice(candidates)
 
 
 def is_restarting_test(test_file: Path):
-    for p in test_file.parts:
-        if p == "restarting":
-            return True
-    return False
+    return "restarting" in test_file.parts
 
 
 def is_negative(test_file: Path):
-    return test_file.parts[-2] == "negative"
+    return len(test_file.parts) > 1 and test_file.parts[-2] == "negative"
 
 
 def is_no_sim(test_file: Path):
-    return test_file.parts[-2] == "noSim"
+    return len(test_file.parts) > 1 and test_file.parts[-2] == "noSim"
 
 
 def is_rare(test_file: Path):
-	return test_file.parts[-2] == "rare"
+    return len(test_file.parts) > 1 and test_file.parts[-2] == "rare"
+
 
 class ResourceMonitor(threading.Thread):
     def __init__(self):
         super().__init__()
-        self.start_time = time.time()
+        self.daemon = True
+        self.start_time = time.monotonic()
         self.end_time: float | None = None
-        self._stop_monitor = False
+        self._stop_monitor = threading.Event()
         self.max_rss = 0
 
     def run(self) -> None:
-        while not self._stop_monitor:
-            time.sleep(1)
-            resources = resource.getrusage(resource.RUSAGE_CHILDREN)
-            self.max_rss = max(resources.ru_maxrss, self.max_rss)
+        while not self._stop_monitor.is_set():
+            if self._stop_monitor.wait(1.0):
+                break
+            try:
+                resources = resource.getrusage(resource.RUSAGE_CHILDREN)
+                self.max_rss = max(resources.ru_maxrss, self.max_rss)
+            except Exception:
+                pass
 
     def stop(self):
-        self.end_time = time.time()
-        self._stop_monitor = True
+        self.end_time = time.monotonic()
+        self._stop_monitor.set()
 
-    def time(self):
+    def get_time(self):
+        if self.end_time is None:
+            return time.monotonic() - self.start_time
         return self.end_time - self.start_time
 
 
 class TestRun:
+    # Class variable to track part numbers for each test UID
+    _part_counters = {}
+
     def __init__(
         self,
         binary: Path,
         test_file: Path,
         random_seed: int,
         uid: uuid.UUID,
+        config_obj: Config,
         restarting: bool = False,
         test_determinism: bool = False,
-        buggify_enabled: bool = False,
         stats: str | None = None,
         expected_unseed: int | None = None,
         will_restart: bool = False,
+        original_run_for_unseed_archival: Optional[TestRun] = None,
+        buggify_enabled: bool | None = None
     ):
+        self.config = config_obj
         self.binary = binary
         self.test_file = test_file
         self.random_seed = random_seed
         self.uid = uid
+        
+        # Use different naming schemes to avoid conflicts:
+        # - Restarting tests: 0, 1, 2, ... (based on count parameter)
+        # - Determinism checks: det_0, det_1 (separate counter)
+        if expected_unseed is not None:  # This is a determinism check
+            uid_str = str(uid)
+            if not hasattr(TestRun, '_det_counters'):
+                TestRun._det_counters = {}
+            if uid_str not in TestRun._det_counters:
+                TestRun._det_counters[uid_str] = 0
+            else:
+                TestRun._det_counters[uid_str] += 1
+            
+            self.part_uid = f"det_{TestRun._det_counters[uid_str]}"
+        else:
+            # For restarting tests, this will be overridden by TestRunner with count
+            self.part_uid = 0
+        
         self.restarting = restarting
         self.test_determinism = test_determinism
         self.stats: str | None = stats
         self.expected_unseed: int | None = expected_unseed
-        self.use_valgrind: bool = config.use_valgrind
-        self.old_binary_path: Path = config.old_binaries_path
-        self.buggify_enabled: bool = buggify_enabled
+        self.use_valgrind: bool = self.config.use_valgrind
+        
+        # Use passed buggify_enabled if provided, otherwise calculate it
+        if buggify_enabled is not None:
+            self.buggify_enabled = buggify_enabled
+        else:
+            self.buggify_enabled: bool = False
+            if self.config.buggify.value == BuggifyOptionValue.ON:
+                self.buggify_enabled = True
+            elif self.config.buggify.value == BuggifyOptionValue.RANDOM:
+                self.buggify_enabled = self.config.random.random() < self.config.buggify_on_ratio
+
         self.fault_injection_enabled: bool = True
-        self.trace_format: str | None = config.trace_format
-        if Version.of_binary(self.binary) < "6.1.0":
+        self.trace_format: str | None = self.config.trace_format
+
+        binary_version = Version.of_binary(self.binary)
+        if binary_version < "6.1.0":
             self.trace_format = None
-        self.use_tls_plugin = Version.of_binary(self.binary) < "5.2.0"
-        self.temp_path = config.run_dir / str(self.uid)
-        # state for the run
+        self.use_tls_plugin = binary_version < "5.2.0"
+
+        self.temp_path = self.config.run_temp_dir / str(self.uid) / str(self.part_uid)
+        self.identified_fdb_log_files: List[Path] = []
+
         self.retryable_error: bool = False
-        self.summary: Summary = Summary(
-            binary,
+        self.stdout_path = self.temp_path / "stdout.txt"
+        self.stderr_path = self.temp_path / "stderr.txt"
+        self.command_file_path = self.temp_path / "command.txt"
+
+        # Collect paired files for determinism check archival
+        _paired_fdb_logs_for_summary: Optional[List[Path]] = None
+        _paired_harness_files_for_summary: Optional[List[Path]] = None
+        if original_run_for_unseed_archival and self.expected_unseed is not None:
+            _paired_fdb_logs_for_summary = original_run_for_unseed_archival.identified_fdb_log_files
+            _paired_harness_files_list = [
+                original_run_for_unseed_archival.command_file_path,
+                original_run_for_unseed_archival.stderr_path,
+                original_run_for_unseed_archival.stdout_path,
+            ]
+            _paired_harness_files_for_summary = [p for p in _paired_harness_files_list if p and p.exists()]
+
+        # Create archival config
+        from test_harness.summarize import ArchivalConfig
+        archival_config = ArchivalConfig()
+        archival_config.enabled = self.config.archive_logs_on_failure
+        archival_config.joshua_output_dir = self.config.joshua_output_dir
+        archival_config.run_temp_dir = self.temp_path
+        archival_config.stdout_path = self.stdout_path
+        archival_config.stderr_path = self.stderr_path
+        archival_config.command_path = self.command_file_path
+        archival_config.current_fdb_logs = self.identified_fdb_log_files
+        if _paired_fdb_logs_for_summary:
+            archival_config.paired_fdb_logs = _paired_fdb_logs_for_summary
+        if _paired_harness_files_for_summary:
+            archival_config.paired_harness_files = _paired_harness_files_for_summary
+
+        self.summary = Summary(
+            binary=self.binary,
             uid=self.uid,
-            stats=self.stats,
+            current_part_uid=self.part_uid,
             expected_unseed=self.expected_unseed,
             will_restart=will_restart,
-            long_running=config.long_running,
+            long_running=self.config.long_running,
+            archival_config=archival_config,
+            stats_attribute_for_v1=self.stats,
         )
-        self.run_time: int = 0
-        self.success = self.run()
+        
+        if self.restarting:
+            self.summary.out.attributes["Restarting"] = "1"
+        if self.test_determinism:
+             self.summary.out.attributes["DeterminismCheck"] = "1"
 
-    def log_test_plan(self, out: SummaryTree):
-        test_plan: SummaryTree = SummaryTree("TestPlan")
-        test_plan.attributes["TestUID"] = str(self.uid)
-        test_plan.attributes["RandomSeed"] = str(self.random_seed)
-        test_plan.attributes["TestFile"] = str(self.test_file)
-        test_plan.attributes["Buggify"] = "1" if self.buggify_enabled else "0"
-        test_plan.attributes["FaultInjectionEnabled"] = (
-            "1" if self.fault_injection_enabled else "0"
-        )
-        test_plan.attributes["DeterminismCheck"] = "1" if self.test_determinism else "0"
-        out.append(test_plan)
+        self.run_time: int = 0
+        # Don't execute immediately - let TestRunner update paths first
+        self.success = False  # Will be set when execute() is called
+
+    def execute(self) -> bool:
+        """Execute the test part - called by TestRunner after setting up paths"""
+        self.success = self._execute_test_part()
+        return self.success
 
     def delete_simdir(self):
-        shutil.rmtree(self.temp_path / Path("simfdb"))
+        simfdb_path = self.temp_path / Path("simfdb")
+        if simfdb_path.exists():
+            try:
+                shutil.rmtree(simfdb_path)
+            except Exception:
+                pass
 
     def _run_joshua_logtool(self):
-        """Calls Joshua LogTool to upload the test logs if 1) test failed 2) test is RocksDB related"""
-        if not os.path.exists("joshua_logtool.py"):
-            raise RuntimeError("joshua_logtool.py missing")
-        command = [
-            "python3",
-            "joshua_logtool.py",
-            "upload",
-            "--test-uid",
-            str(self.uid),
-            "--log-directory",
-            str(self.temp_path),
-            "--check-rocksdb",
-        ]
-        result = subprocess.run(command, capture_output=True, text=True)
-        return {
-            "stdout": result.stdout,
-            "stderr": result.stderr,
-            "exit_code": result.returncode,
-        }
+        # Look for joshua_logtool.py in multiple locations
+        # First try: relative to this script's location (contrib/TestHarness2/test_harness/run.py)
+        script_dir = Path(__file__).parent.parent.parent  # Go up 3 levels to repo root
+        joshua_logtool_script = script_dir / "contrib" / "joshua_logtool.py"
+        
+        if not joshua_logtool_script.exists():
+            # Second try: contrib directory relative to current working directory
+            joshua_logtool_script = Path("contrib/joshua_logtool.py")
+            if not joshua_logtool_script.exists():
+                # Third try: current directory for backwards compatibility
+                joshua_logtool_script = Path("joshua_logtool.py")
+                if not joshua_logtool_script.exists():
+                    return {"stdout": "", "stderr": "joshua_logtool.py not found", "exit_code": -1, "tool_skipped": True}
 
-    def run(self):
+        # Debug: log which script we're using
+        debug_info = f"Using joshua_logtool.py at: {joshua_logtool_script.absolute()}"
+        
+        command = [
+            sys.executable,
+            str(joshua_logtool_script),
+            "upload",
+            "--test-uid", str(self.uid),
+            "--log-directory", str(self.temp_path.parent)
+        ]
+        
+        # Add appropriate upload flag based on TH_DISABLE_ROCKSDB_CHECK setting
+        disable_rocksdb_check = os.getenv("TH_DISABLE_ROCKSDB_CHECK", "false").lower() in ("true", "1", "yes")
+        if disable_rocksdb_check:
+            command.append("--check-rocksdb")
+        
+        try:
+            result = subprocess.run(command, capture_output=True, text=True, timeout=60)
+            
+            # Parse result summary from stdout
+            result_summary = "Unknown"
+            if result.stdout:
+                for line in result.stdout.split('\n'):
+                    if line.startswith('JOSHUA_LOGTOOL_RESULT:'):
+                        result_summary = line.replace('JOSHUA_LOGTOOL_RESULT:', '').strip()
+                        break
+            
+            return {
+                "stdout": result.stdout, 
+                "stderr": debug_info + "\n" + result.stderr, 
+                "exit_code": result.returncode, 
+                "tool_skipped": False,
+                "result_summary": result_summary
+            }
+            
+        except subprocess.TimeoutExpired:
+            return {"stdout": "", "stderr": debug_info + "\nJoshuaLogTool timed out", "exit_code": -2, "tool_skipped": True}
+        except Exception as e:
+            return {"stdout": "", "stderr": debug_info + f"\nException: {e}", "exit_code": -3, "tool_skipped": True}
+
+    def _execute_test_part(self) -> bool:
         command: List[str] = []
         env: Dict[str, str] = os.environ.copy()
         valgrind_file: Path | None = None
-        if self.use_valgrind and self.binary == config.binary:
-            # Only run the binary under test under valgrind. There's nothing we
-            # can do about valgrind errors in old binaries anyway, and it makes
-            # the test take longer. Also old binaries weren't built with
-            # USE_VALGRIND=ON, and we have seen false positives with valgrind in
-            # such binaries.
+
+        if self.use_valgrind:
             command.append("valgrind")
-            valgrind_file = self.temp_path / Path(
-                "valgrind-{}.xml".format(self.random_seed)
-            )
+            valgrind_file = self.temp_path / Path(f"valgrind-{self.random_seed}.xml")
             dbg_path = os.getenv("FDB_VALGRIND_DBGPATH")
             if dbg_path is not None:
-                command.append("--extra-debuginfo-path={}".format(dbg_path))
+                command.append(f"--extra-debuginfo-path={dbg_path}")
             command += [
                 "--xml=yes",
-                "--xml-file={}".format(valgrind_file.absolute()),
+                f"--xml-file={valgrind_file.absolute()}",
                 "-q",
             ]
+
         command += [
             str(self.binary.absolute()),
-            "-r",
-            "test" if is_no_sim(self.test_file) else "simulation",
-            "-f",
-            str(self.test_file),
-            "-s",
-            str(self.random_seed),
+            "-r", "test" if is_no_sim(self.test_file) else "simulation",
+            "-f", str(self.test_file.absolute()),
+            "-s", str(self.random_seed),
+            "--logdir", "logs",
         ]
+
         if self.trace_format is not None:
             command += ["--trace_format", self.trace_format]
-        if self.use_tls_plugin:
-            command += ["--tls_plugin", str(config.tls_plugin_path)]
-            env["FDB_TLS_PLUGIN"] = str(config.tls_plugin_path)
-        if config.disable_kaio:
+        if self.use_tls_plugin and self.config.tls_plugin_path:
+            command += ["--tls_plugin", str(self.config.tls_plugin_path.absolute())]
+            env["FDB_TLS_PLUGIN"] = str(self.config.tls_plugin_path.absolute())
+        if self.config.disable_kaio:
             command += ["--knob-disable-posix-kernel-aio=1"]
-        if Version.of_binary(self.binary) >= "7.1.0":
+
+        binary_version = Version.of_binary(self.binary)
+        if binary_version >= "7.1.0":
             command += ["-fi", "on" if self.fault_injection_enabled else "off"]
+
         if self.restarting:
             command.append("--restarting")
         if self.buggify_enabled:
             command += ["-b", "on"]
-        if config.crash_on_error and not is_negative(self.test_file):
+
+        if self.config.crash_on_error and not is_negative(self.test_file):
             command.append("--crash")
-        if config.long_running:
-            # disable simulation speedup
+        if self.config.long_running:
             command += ["--knob-sim-speedup-after-seconds=36000"]
-            # disable traceTooManyLines Error MAX_TRACE_LINES
             command += ["--knob-max-trace-lines=1000000000"]
 
         self.temp_path.mkdir(parents=True, exist_ok=True)
+        (self.temp_path / "logs").mkdir(parents=True, exist_ok=True)
 
-        # self.log_test_plan(out)
+        self.command_str = " ".join(command)
+
+        # Write command string to file for archival
+        try:
+            with open(self.command_file_path, 'w') as f:
+                f.write(self.command_str)
+        except Exception:
+            pass
+
+        # Start resource monitor
         resources = ResourceMonitor()
         resources.start()
-        process = subprocess.Popen(
-            command,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.PIPE,
-            cwd=self.temp_path,
-            text=True,
-            env=env,
-        )
+
+        # Execute the test
+        stdout_data = ""
+        err_out = ""
+        actual_return_code = -1
         did_kill = False
-        # No timeout for long running tests
-        timeout = (
-            20 * config.kill_seconds
-            if self.use_valgrind
-            else (None if config.long_running else config.kill_seconds)
-        )
-        err_out: str
+
         try:
-            _, err_out = process.communicate(timeout=timeout)
-        except subprocess.TimeoutExpired:
-            process.kill()
-            _, err_out = process.communicate()
-            did_kill = True
+            timeout = None
+            if not self.config.long_running:
+                timeout = (20 * self.config.kill_seconds if self.use_valgrind else self.config.kill_seconds)
+
+            process = subprocess.Popen(
+                command, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                cwd=self.temp_path, env=env  # Remove text=True to handle binary output
+            )
+            
+            try:
+                stdout_bytes, stderr_bytes = process.communicate(timeout=timeout)
+                # Safely decode output, replacing invalid UTF-8 sequences with '?'
+                stdout_data = stdout_bytes.decode('utf-8', errors='replace')
+                stderr_data = stderr_bytes.decode('utf-8', errors='replace')
+                actual_return_code = process.returncode
+            except subprocess.TimeoutExpired:
+                process.kill()
+                stdout_bytes, stderr_bytes = process.communicate()
+                # Safely decode after timeout
+                stdout_data = stdout_bytes.decode('utf-8', errors='replace')
+                stderr_data = stderr_bytes.decode('utf-8', errors='replace')
+                err_out += "\nPROCESS_KILLED_TIMEOUT"
+                actual_return_code = process.returncode if process.returncode is not None else -1
+                did_kill = True
+        except Exception as e:
+            err_out = f"PROCESS_ERROR: {e}"
+            actual_return_code = -1
+        
+        # Combine stderr with err_out if there was stderr data
+        if 'stderr_data' in locals() and stderr_data:
+            err_out = stderr_data + ("\n" + err_out if err_out else "")
+
+        # Stop resource monitor
         resources.stop()
         resources.join()
-        # we're rounding times up, otherwise we will prefer running very short tests (<1s)
-        self.run_time = math.ceil(resources.time())
+        self.run_time = math.ceil(resources.get_time())
+
+        # Write stdout/stderr to files
+        try:
+            with open(self.stdout_path, 'w') as f:
+                f.write(stdout_data)
+            with open(self.stderr_path, 'w') as f:
+                f.write(err_out)
+        except Exception:
+            pass
+
+        # Find FDB log files
+        log_dir = self.temp_path / "logs"
+        expected_suffix = ".xml"
+        if self.trace_format == "json":
+            expected_suffix = ".json"
+
+        if log_dir.is_dir():
+            for log_file in log_dir.iterdir():
+                if log_file.is_file() and log_file.name.endswith(expected_suffix):
+                    self.identified_fdb_log_files.append(log_file)
+
+        # Update summary
         self.summary.is_negative_test = is_negative(self.test_file)
-        self.summary.runtime = resources.time()
+        self.summary.runtime = resources.get_time()
         self.summary.max_rss = resources.max_rss
         self.summary.was_killed = did_kill
         self.summary.valgrind_out_file = valgrind_file
         self.summary.error_out = err_out
-        self.summary.summarize(self.temp_path, " ".join(command))
-        if not self.summary.is_negative_test and not self.summary.ok():
-            logtool_result = self._run_joshua_logtool()
-            child = SummaryTree("JoshuaLogTool")
-            child.attributes["ExitCode"] = str(logtool_result["exit_code"])
-            child.attributes["StdOut"] = logtool_result["stdout"]
-            child.attributes["StdErr"] = logtool_result["stderr"]
-            self.summary.out.append(child)
-        else:
-            child = SummaryTree("JoshuaLogTool")
-            child.attributes["IsNegative"] = str(self.summary.is_negative_test)
-            child.attributes["IsOk"] = str(self.summary.ok())
-            child.attributes["HasError"] = str(self.summary.error)
-            child.attributes["JoshuaLogToolIgnored"] = str(True)
-            self.summary.out.append(child)
+        self.summary.exit_code = actual_return_code
+        self.summary.fdb_log_files_for_archival = self.identified_fdb_log_files
 
+        # Parse FDB trace files
+        if self.identified_fdb_log_files:
+            self.summary.summarize_files(self.identified_fdb_log_files)
+
+        self.summary.test_file = self.test_file
+        self.summary.seed = self.random_seed
+        self.summary.test_name = self.test_file.stem
+
+        self.summary.summarize(self.temp_path, self.command_str)
+
+        # Run JoshuaLogTool if needed
+        if not self.summary.is_negative_test and not self.summary.ok():
+            skip_joshua_logtool = os.getenv("TH_SKIP_JOSHUA_LOGTOOL", "true").lower() in ("true", "1", "yes")
+            if skip_joshua_logtool:
+                child = SummaryTree("JoshuaLogTool")
+                child.attributes["ExitCode"] = "0"
+                child.attributes["Note"] = "Skipped - TH_SKIP_JOSHUA_LOGTOOL is set"
+                self.summary.out.append(child)
+            else:
+                archive_logs_on_failure = os.getenv("TH_ARCHIVE_LOGS_ON_FAILURE", "false").lower() in ("true", "1", "yes")
+                enable_joshua_logtool = os.getenv("TH_ENABLE_JOSHUA_LOGTOOL", "false").lower() in ("true", "1", "yes")
+                
+                if not archive_logs_on_failure or not enable_joshua_logtool:
+                    child = SummaryTree("JoshuaLogTool")
+                    child.attributes["ExitCode"] = "0"
+                    child.attributes["Note"] = "Skipped - archiving not enabled"
+                    self.summary.out.append(child)
+                else:
+                    logtool_result = self._run_joshua_logtool()
+                    child = SummaryTree("JoshuaLogTool")
+                    child.attributes["ExitCode"] = str(logtool_result["exit_code"])
+                    if not logtool_result["tool_skipped"]:
+                        if logtool_result["exit_code"] == 0:
+                            stderr_lines = logtool_result["stderr"].split("\n") if logtool_result["stderr"] else []
+                            success_lines = [line for line in stderr_lines if "SUCCESS - Uploaded" in line]
+                            if success_lines:
+                                child.attributes["Note"] = success_lines[-1].replace("JOSHUA_LOGTOOL: ", "")
+                            else:
+                                child.attributes["Note"] = "Upload completed"
+                        else:
+                            child.attributes["StdOut"] = logtool_result["stdout"]
+                            child.attributes["StdErr"] = logtool_result["stderr"]
+                    else:
+                         child.attributes["Note"] = logtool_result["stderr"]
+                    self.summary.out.append(child)
+        
+        self.summary.done()
         return self.summary.ok()
 
 
 def decorate_summary(out: SummaryTree, test_file: Path, seed: int, buggify: bool):
-    """Sometimes a test can crash before ProgramStart is written to the traces. These
-    tests are then hard to reproduce (they can be reproduced through TestHarness but
-    require the user to run in the joshua docker container). To account for this we
-    will write the necessary information into the attributes if it is missing."""
     if "TestFile" not in out.attributes:
-        out.attributes["TestFile"] = str(test_file)
+        out.attributes["TestFile"] = str(test_file.absolute())
     if "RandomSeed" not in out.attributes:
         out.attributes["RandomSeed"] = str(seed)
     if "BuggifyEnabled" not in out.attributes:
@@ -556,105 +740,244 @@ def decorate_summary(out: SummaryTree, test_file: Path, seed: int, buggify: bool
 
 
 class TestRunner:
-    def __init__(self):
+    def __init__(self, config: Config):
+        self.config = config
         self.uid = uuid.uuid4()
-        self.test_path: Path = Path("tests")
-        self.cluster_file: str | None = None
-        self.fdb_app_dir: str | None = None
-        self.binary_chooser = OldBinaries()
-        self.test_picker = TestPicker(self.test_path, self.binary_chooser.binaries)
+        self.test_path: Path = self.config.test_source_dir
+        self.cluster_file: str | None = self.config.cluster_file
+        self.binary_chooser = OldBinaries(self.config)
+        if not self.test_path.exists() or not self.test_path.is_dir():
+             raise RuntimeError(f"Test source directory {self.test_path} does not exist or is not a directory.")
+        self.test_picker = TestPicker(self.test_path, self.binary_chooser.binaries, self.config)
+        self.summary_tree = SummaryTree("TestResults", is_root_document=True)
 
-    def backup_sim_dir(self, seed: int):
-        temp_dir = config.run_dir / str(self.uid)
-        src_dir = temp_dir / "simfdb"
-        assert src_dir.is_dir()
-        dest_dir = temp_dir / "simfdb.{}".format(seed)
-        assert not dest_dir.exists()
-        shutil.copytree(src_dir, dest_dir)
+    def backup_sim_dir(self, seed: int, part_uid: int):
+        base_temp_dir = self.config.run_temp_dir / str(self.uid)
+        # Look for simfdb in the current part directory
+        src_dir = base_temp_dir / str(part_uid) / "simfdb"
+        
+        # Write debug info to a file that will be captured
+        debug_file = base_temp_dir / f"backup_debug_{part_uid}.txt"
+        debug_file.parent.mkdir(parents=True, exist_ok=True)
+        
+        with open(debug_file, 'w') as f:
+            f.write(f"BACKUP: seed={seed}, part_uid={part_uid}\n")
+            f.write(f"BACKUP: Looking for simfdb at {src_dir}\n")
+            f.write(f"BACKUP: src_dir exists: {src_dir.exists()}, is_dir: {src_dir.is_dir()}\n")
+            
+            if not src_dir.is_dir():
+                f.write(f"BACKUP: No simfdb found at {src_dir}, skipping backup\n")
+                return False
+                
+            dest_dir = base_temp_dir / f"simfdb.{seed}"
+            f.write(f"BACKUP: Backup destination: {dest_dir}\n")
+            
+            if dest_dir.exists():
+                f.write(f"BACKUP: Backup destination already exists, removing it\n")
+                shutil.rmtree(dest_dir)
+                
+            try:
+                shutil.copytree(src_dir, dest_dir)
+                f.write(f"BACKUP: Successfully backed up {src_dir} to {dest_dir}\n")
+                return True
+            except Exception as e:
+                f.write(f"BACKUP: Failed to backup simfdb: {e}\n")
+                return False
 
-    def restore_sim_dir(self, seed: int):
-        temp_dir = config.run_dir / str(self.uid)
-        src_dir = temp_dir / "simfdb.{}".format(seed)
-        assert src_dir.exists()
-        dest_dir = temp_dir / "simfdb"
-        shutil.rmtree(dest_dir)
-        shutil.move(src_dir, dest_dir)
+    def restore_sim_dir(self, seed: int, part_uid: int):
+        base_temp_dir = self.config.run_temp_dir / str(self.uid)
+        src_dir = base_temp_dir / f"simfdb.{seed}"
+        # Restore to the correct part directory where restart test expects it
+        dest_dir = base_temp_dir / str(part_uid) / "simfdb"
+        
+        # Write debug info to a file that will be captured
+        debug_file = base_temp_dir / f"restore_debug_{part_uid}.txt"
+        debug_file.parent.mkdir(parents=True, exist_ok=True)
+        
+        with open(debug_file, 'w') as f:
+            f.write(f"RESTORE: seed={seed}, part_uid={part_uid}\n")
+            f.write(f"RESTORE: Looking for backup at {src_dir}\n")
+            f.write(f"RESTORE: src_dir exists: {src_dir.exists()}, is_dir: {src_dir.is_dir()}\n")
+            f.write(f"RESTORE: Will restore to {dest_dir}\n")
+            
+            if not src_dir.exists() or not src_dir.is_dir():
+                f.write(f"RESTORE: No backup found at {src_dir}\n")
+                return False
+                
+            try:
+                if dest_dir.exists():
+                    f.write(f"RESTORE: Removing existing dest_dir: {dest_dir}\n")
+                    shutil.rmtree(dest_dir)
+                # Ensure parent directory exists
+                dest_dir.parent.mkdir(parents=True, exist_ok=True)
+                f.write(f"RESTORE: Created parent directory: {dest_dir.parent}\n")
+                shutil.copytree(str(src_dir), str(dest_dir))
+                f.write(f"RESTORE: Successfully restored {src_dir} to {dest_dir}\n")
+                return True
+            except Exception as e:
+                f.write(f"RESTORE: Failed to restore simfdb: {e}\n")
+                return False
 
     def run_tests(
         self, test_files: List[Path], seed: int, test_picker: TestPicker
-    ) -> bool:
-        result: bool = True
-        for count, file in enumerate(test_files):
-            will_restart = count + 1 < len(test_files)
-            binary = self.binary_chooser.choose_binary(file)
-            unseed_check = (
-                not is_no_sim(file)
-                and config.random.random() < config.unseed_check_ratio
-            )
-            buggify_enabled: bool = False
-            if config.buggify.value == BuggifyOptionValue.ON:
-                buggify_enabled = True
-            elif config.buggify.value == BuggifyOptionValue.RANDOM:
-                buggify_enabled = config.random.random() < config.buggify_on_ratio
+    ) -> tuple[bool, List[SummaryTree]]:
+        overall_result: bool = True
+        collected_summaries: List[SummaryTree] = []
 
-            # FIXME: support unseed checks for restarting tests
-            run = TestRun(
-                binary,
-                file.absolute(),
-                seed + count,
-                self.uid,
-                restarting=count != 0,
+        for count, file_path in enumerate(test_files):
+            part_seed = seed + count
+
+            # Restore simulation directory for restart tests (Phase 2+)
+            if count > 0:
+                restore_success = self.restore_sim_dir(seed, count)
+                if not restore_success:
+                    # Add debug note to test output
+                    debug_note = f"RESTARTING_TEST_RESTORE_FAILED: part {count} could not restore simfdb for seed {seed}"
+                    print(f"WARNING: {debug_note}")  # Also print to stdout for immediate visibility
+
+            current_run = TestRun(
+                binary=self.binary_chooser.choose_binary(file_path),
+                test_file=file_path.absolute(),
+                random_seed=part_seed,
+                uid=self.uid,
+                config_obj=self.config,
+                restarting=(count != 0),
                 stats=test_picker.dump_stats(),
-                will_restart=will_restart,
-                buggify_enabled=buggify_enabled,
+                will_restart=(count + 1 < len(test_files))
             )
-            result = result and run.success
-            test_picker.add_time(test_files[0], run.run_time, run.summary.out)
-            decorate_summary(run.summary.out, file, seed + count, run.buggify_enabled)
-            if (
-                unseed_check
-                and run.summary.unseed is not None
-                and run.summary.unseed >= 0
-            ):
-                run.summary.out.append(run.summary.list_simfdb())
-            run.summary.out.dump(sys.stdout)
-            if not result:
-                return False
-            if (
-                count == 0
-                and unseed_check
-                and run.summary.unseed is not None
-                and run.summary.unseed >= 0
-            ):
-                run2 = TestRun(
-                    binary,
-                    file.absolute(),
-                    seed + count,
-                    self.uid,
-                    restarting=count != 0,
-                    stats=test_picker.dump_stats(),
-                    expected_unseed=run.summary.unseed,
-                    will_restart=will_restart,
-                    buggify_enabled=buggify_enabled,
-                )
-                test_picker.add_time(file, run2.run_time, run.summary.out)
-                decorate_summary(
-                    run2.summary.out, file, seed + count, run.buggify_enabled
-                )
-                run2.summary.out.dump(sys.stdout)
-                result = result and run2.success
-                if not result:
-                    return False
-        return result
+            
+            # Set correct part_uid for restarting tests (overrides default)
+            current_run.part_uid = count
+            # Update temp_path to use the correct part_uid
+            current_run.temp_path = self.config.run_temp_dir / str(self.uid) / str(count)
+            # Update file paths that depend on temp_path
+            current_run.stdout_path = current_run.temp_path / "stdout.txt"
+            current_run.stderr_path = current_run.temp_path / "stderr.txt"
+            current_run.command_file_path = current_run.temp_path / "command.txt"
+            # Update summary to reflect correct part_uid
+            current_run.summary.current_part_uid = count
+            # Also update the XML attribute directly!
+            current_run.summary.out.attributes["PartUID"] = str(count)
+            # Update archival config
+            current_run.summary.archival_config.run_temp_dir = current_run.temp_path
+            current_run.summary.archival_config.stdout_path = current_run.stdout_path
+            current_run.summary.archival_config.stderr_path = current_run.stderr_path
+            current_run.summary.archival_config.command_path = current_run.command_file_path
+            
+            # Now execute the test with correct paths
+            current_run.execute()
+            overall_result = overall_result and current_run.success
 
-    def run(self) -> bool:
-        seed = (
-            config.random_seed
-            if config.random_seed is not None
-            else config.random.randint(0, 2**32 - 1)
-        )
+            test_picker.add_time(file_path, current_run.run_time, current_run.summary.out)
+            decorate_summary(current_run.summary.out, file_path, part_seed, current_run.buggify_enabled)
+
+            # V1 stdout output
+            if self.config._v1_summary_output_stream:
+                v1_xml_string = current_run.summary.get_v1_stdout_line()
+                if v1_xml_string:
+                    self.config._v1_summary_output_stream.write(v1_xml_string + "\n")
+                    self.config._v1_summary_output_stream.flush()
+
+            collected_summaries.append(current_run.summary.out)
+
+            if not current_run.summary.ok():
+                return False, collected_summaries
+
+            # Backup simulation directory after every part except the last for restart tests
+            if count + 1 < len(test_files):
+                backup_success = self.backup_sim_dir(seed, count)
+                if not backup_success:
+                    # Add debug note to test output
+                    debug_note = f"RESTARTING_TEST_BACKUP_FAILED: part {count} could not backup simfdb for seed {seed}"
+                    print(f"WARNING: {debug_note}")  # Also print to stdout for immediate visibility
+
+            # Determinism check - now works on any part since we fixed the conflicts
+            should_perform_unseed_check = (
+                self.config.unseed_check_ratio > 0 and
+                current_run.summary.ok() and
+                self.config.random.random() < self.config.unseed_check_ratio
+            )
+
+            if should_perform_unseed_check:
+                expected_unseed = current_run.summary.unseed
+                if self.config.use_valgrind:
+                    restore_success = self.restore_sim_dir(seed, count)
+                    if not restore_success:
+                        print(f"WARNING: DETERMINISM_CHECK_RESTORE_FAILED: part {count} could not restore simfdb for seed {seed}")
+                
+                # Second run for determinism check - must use same parameters as first run
+                second_run = TestRun(
+                    binary=self.binary_chooser.choose_binary(file_path),
+                    test_file=file_path.absolute(),
+                    random_seed=part_seed,  # Same seed for determinism
+                    uid=self.uid,
+                    config_obj=self.config,
+                    restarting=(count != 0),
+                    stats=test_picker.dump_stats(),
+                    expected_unseed=expected_unseed,
+                    will_restart=(count + 1 < len(test_files)),
+                    original_run_for_unseed_archival=current_run,
+                    buggify_enabled=current_run.buggify_enabled  # Use same buggify setting
+                )
+                
+                # Set determinism check part_uid with det_ prefix to avoid conflicts
+                det_part_uid = f"det_{count}"
+                second_run.part_uid = det_part_uid
+                # Update temp_path to use the correct part_uid
+                second_run.temp_path = self.config.run_temp_dir / str(self.uid) / str(det_part_uid)
+                # Update file paths that depend on temp_path
+                second_run.stdout_path = second_run.temp_path / "stdout.txt"
+                second_run.stderr_path = second_run.temp_path / "stderr.txt"
+                second_run.command_file_path = second_run.temp_path / "command.txt"
+                # Update summary to reflect correct part_uid
+                second_run.summary.current_part_uid = det_part_uid
+                # CRITICAL: Also update the XML attribute directly!
+                second_run.summary.out.attributes["PartUID"] = str(det_part_uid)
+                # Update archival config
+                second_run.summary.archival_config.run_temp_dir = second_run.temp_path
+                second_run.summary.archival_config.stdout_path = second_run.stdout_path
+                second_run.summary.archival_config.stderr_path = second_run.stderr_path
+                second_run.summary.archival_config.command_path = second_run.command_file_path
+                
+                # Execute the determinism check
+                second_run.execute()
+
+                overall_result = overall_result and second_run.success
+                test_picker.add_time(file_path, second_run.run_time, second_run.summary.out)
+                decorate_summary(second_run.summary.out, file_path, part_seed, second_run.buggify_enabled)
+
+                if self.config._v1_summary_output_stream:
+                    v1_xml_string = second_run.summary.get_v1_stdout_line()
+                    if v1_xml_string:
+                        self.config._v1_summary_output_stream.write(v1_xml_string + "\n")
+                        self.config._v1_summary_output_stream.flush()
+
+                collected_summaries.append(second_run.summary.out)
+
+                if not second_run.success:
+                    return False, collected_summaries
+
+        return overall_result, collected_summaries
+
+    def run_all_tests(self) -> SummaryTree:
         test_files = self.test_picker.choose_test()
-        success = self.run_tests(test_files, seed, self.test_picker)
-        if config.clean_up:
-            shutil.rmtree(config.run_dir / str(self.uid))
-        return success
+
+        if not test_files:
+            pass  # Empty summary tree
+        else:
+            current_run_success, current_run_summary_trees = self.run_tests(
+                test_files, self.config.joshua_seed, self.test_picker
+            )
+
+            if current_run_summary_trees:
+                for single_test_summary_tree in current_run_summary_trees:
+                    if single_test_summary_tree is not None:
+                        self.summary_tree.append(single_test_summary_tree)
+
+            self.summary_tree.attributes["BatchSuccess"] = "1" if current_run_success else "0"
+
+        self.summary_tree.attributes["TestRunnerUID"] = str(self.uid)
+        self.summary_tree.attributes["ConfiguredJoshuaSeed"] = str(self.config.joshua_seed)
+        self.summary_tree.attributes["TestsChosenCount"] = str(len(test_files) if test_files else 0)
+
+        return self.summary_tree

--- a/contrib/TestHarness2/test_harness/summarize.py
+++ b/contrib/TestHarness2/test_harness/summarize.py
@@ -1,370 +1,439 @@
 from __future__ import annotations
 
+import base64
 import collections
-import inspect
 import json
+import math
 import os
 import re
 import sys
+import time
 import traceback
 import uuid
 import xml.sax
 import xml.sax.handler
 import xml.sax.saxutils
-
-from pathlib import Path
+import tarfile
+import logging
+import xml.etree.ElementTree as ET
+import copy
+import gzip
 from typing import (
     List,
     Dict,
-    TextIO,
-    Callable,
-    Optional,
-    OrderedDict,
     Any,
+    Optional,
+    Callable,
+    OrderedDict,
+    TextIO,
     Tuple,
     Iterator,
     Iterable,
+    Union,
+    Set,
 )
 
+from pathlib import Path
 from test_harness.config import config
 from test_harness.valgrind import parse_valgrind_output
 
+logger = logging.getLogger(__name__)
+
+CURRENT_VERSION = "0.1"
+
+# Define tags to strip from V1 stdout output
+TAGS_TO_STRIP_FROM_TEST_ELEMENT_FOR_STDOUT: Set[str] = {
+    "CodeCoverage",
+    "ValgrindError",
+    "StdErrOutput",
+    "StdErrOutputTruncated",
+    "JoshuaMessage",
+}
+
+# Essential child tags to keep in V1 output
+ESSENTIAL_V1_CHILD_TAGS_TO_KEEP = {
+    "SimFDB",
+    "JoshuaLogTool",
+    "DisableConnectionFailures_Tester",
+    "EnableConnectionFailures_Tester",
+    "ScheduleDisableConnectionFailures_Tester",
+    "DisableConnectionFailures_BulkDumping",
+    "DisableConnectionFailures_BulkLoading",
+    "DisableConnectionFailures_ConsistencyCheck",
+    "CommitProxyTerminated",
+    "QuietDatabaseConsistencyCheckStartFail",
+    "UnseedMismatch",
+    "WarningLimitExceeded",
+    "ErrorLimitExceeded",
+}
+
+# Tags to explicitly strip from V1 stdout
+STDOUT_EXPLICITLY_STRIPPED_TAGS = {
+    "CodeCoverage",
+    "ValgrindError",
+    "StdErrOutput",
+    "StdErrOutputTruncated",
+    "Knobs",
+    "Metrics",
+    "JoshuaMessage",
+}
+
+class ArchivalConfig:
+    """Configuration for log archival functionality"""
+    def __init__(self):
+        self.enabled: bool = False
+        self.paired_fdb_logs: List[Path] = []
+        self.paired_harness_files: List[Path] = []
+        self.current_fdb_logs: List[Path] = []
+        self.joshua_output_dir: Optional[Path] = None
+        self.run_temp_dir: Optional[Path] = None
+        self.stdout_path: Optional[Path] = None
+        self.stderr_path: Optional[Path] = None
+        self.command_path: Optional[Path] = None
 
 class SummaryTree:
-    def __init__(self, name: str):
+    def __init__(self, name: str, is_root_document: bool = False):
         self.name = name
         self.children: List[SummaryTree] = []
         self.attributes: Dict[str, str] = {}
+        self.root: Optional[ET.Element] = None
+        if is_root_document:
+            self.root = ET.Element(self.name)
 
     def append(self, element: SummaryTree):
         self.children.append(element)
+        if self.root is not None:
+            self.root.append(element.to_et_element())
+
+    def to_et_element(self) -> ET.Element:
+        element = ET.Element(self.name)
+        for k, v_raw in self.attributes.items():
+            element.set(str(k), xml.sax.saxutils.escape(str(v_raw)))
+        
+        for child_summary_tree in self.children:
+            element.append(child_summary_tree.to_et_element())
+        
+        if self.root is None:
+            self.root = element
+        
+        return element
 
     def to_dict(self, add_name: bool = True) -> Dict[str, Any] | List[Any]:
         if len(self.children) > 0 and len(self.attributes) == 0:
-            children = []
+            res: List[Any] = []
             for child in self.children:
-                children.append(child.to_dict())
-            if add_name:
-                return {self.name: children}
-            else:
-                return children
+                res.append(child.to_dict())
+            return res
         res: Dict[str, Any] = {}
         if add_name:
-            res["Type"] = self.name
+            res["tag"] = self.name
         for k, v in self.attributes.items():
             res[k] = v
-        children = []
-        child_keys: Dict[str, int] = {}
-        for child in self.children:
-            if child.name in child_keys:
-                child_keys[child.name] += 1
-            else:
-                child_keys[child.name] = 1
-        for child in self.children:
-            if child_keys[child.name] == 1 and child.name not in self.attributes:
-                res[child.name] = child.to_dict(add_name=False)
-            else:
-                children.append(child.to_dict())
-        if len(children) > 0:
-            res["children"] = children
+        if len(self.children) > 0:
+            res["children"] = []
+            for child in self.children:
+                res["children"].append(child.to_dict())
         return res
 
-    def to_json(self, out: TextIO, prefix: str = ""):
-        res = json.dumps(self.to_dict(), indent=("  " if config.pretty_print else None))
-        for line in res.splitlines(False):
-            out.write("{}{}\n".format(prefix, line))
-
-    def to_xml(self, out: TextIO, prefix: str = ""):
-        # minidom doesn't support omitting the xml declaration which is a problem for joshua
-        # However, our xml is very simple and therefore serializing manually is easy enough
-        attrs = []
-        print_width = 120
-        try:
-            print_width, _ = os.get_terminal_size()
-        except OSError:
-            pass
+    def dump(self, out: TextIO, new_line: bool = True, prefix: str = ""):
+        out.write(prefix)
+        out.write("<")
+        out.write(self.name)
         for k, v in self.attributes.items():
-            attrs.append("{}={}".format(k, xml.sax.saxutils.quoteattr(v)))
-        elem = "{}<{}{}".format(prefix, self.name, ("" if len(attrs) == 0 else " "))
-        out.write(elem)
-        if config.pretty_print:
-            curr_line_len = len(elem)
-            for i in range(len(attrs)):
-                attr_len = len(attrs[i])
-                if i == 0 or attr_len + curr_line_len + 1 <= print_width:
-                    if i != 0:
-                        out.write(" ")
-                    out.write(attrs[i])
-                    curr_line_len += attr_len
-                else:
-                    out.write("\n")
-                    out.write(" " * len(elem))
-                    out.write(attrs[i])
-                    curr_line_len = len(elem) + attr_len
-        else:
-            out.write(" ".join(attrs))
+            out.write(' {}="{}"'.format(k, xml.sax.saxutils.escape(str(v))))
         if len(self.children) == 0:
             out.write("/>")
         else:
             out.write(">")
-        for child in self.children:
-            if config.pretty_print:
+            if len(self.children) == 1 and len(self.children[0].children) == 0:
+                self.children[0].dump(out, False, "")
+            else:
+                for child in self.children:
+                    out.write("\n")
+                    child.dump(out, False, prefix + "\t")
                 out.write("\n")
-            child.to_xml(
-                out, prefix=("  {}".format(prefix) if config.pretty_print else prefix)
-            )
-        if len(self.children) > 0:
-            out.write(
-                "{}{}</{}>".format(
-                    ("\n" if config.pretty_print else ""), prefix, self.name
-                )
-            )
-
-    def dump(self, out: TextIO, prefix: str = "", new_line: bool = True):
-        if config.output_format == "json":
-            self.to_json(out, prefix=prefix)
-        else:
-            self.to_xml(out, prefix=prefix)
+                out.write(prefix)
+            out.write("</")
+            out.write(self.name)
+            out.write(">")
         if new_line:
             out.write("\n")
 
+    def to_string_document(self) -> str:
+        """Serializes the entire XML tree to a string, including XML declaration."""
+        if self.root is None:
+            self.to_et_element()
+        
+        if self.root is None:
+            return "<Error>Cannot serialize XML document: root element is missing</Error>"
+
+        try:
+            xml_str = ET.tostring(self.root, encoding='unicode', short_empty_elements=True)
+            return f'<?xml version="1.0"?>\n{xml_str}'
+        except Exception as e:
+            logger.error(f"Error during XML serialization: {e}")
+            return f'<?xml version="1.0"?>\n<Error>SerializationFailed: {xml.sax.saxutils.escape(str(e))}</Error>'
 
 ParserCallback = Callable[[Dict[str, str]], Optional[str]]
-
 
 class ParseHandler:
     def __init__(self, out: SummaryTree):
         self.out = out
-        self.events: OrderedDict[
-            Optional[Tuple[str, Optional[str]]], List[ParserCallback]
-        ] = collections.OrderedDict()
+        self.events: Dict[
+            tuple[str, str] | tuple[str, None] | None, List[ParserCallback]
+        ] = {}
 
     def add_handler(
-        self, attr: Tuple[str, Optional[str]], callback: ParserCallback
-    ) -> None:
-        self.events.setdefault(attr, []).append(callback)
+        self, event: tuple[str, str] | tuple[str, None] | None, callback: ParserCallback
+    ):
+        if event not in self.events:
+            self.events[event] = []
+        self.events[event].append(callback)
 
-    def _call(self, callback: ParserCallback, attrs: Dict[str, str]) -> str | None:
+    def _call(self, callback: ParserCallback, attrs: Dict[str, str]) -> Optional[str]:
         try:
             return callback(attrs)
         except Exception as e:
-            _, _, exc_traceback = sys.exc_info()
-            child = SummaryTree("NonFatalParseError")
-            child.attributes["Severity"] = "30"
-            child.attributes["ErrorMessage"] = str(e)
-            child.attributes["Trace"] = repr(traceback.format_tb(exc_traceback))
-            self.out.append(child)
+            logger.error(f"Error in parse handler: {e}")
             return None
 
     def handle(self, attrs: Dict[str, str]):
-        if None in self.events:
-            for callback in self.events[None]:
-                self._call(callback, attrs)
-        for k, v in attrs.items():
+        # Call specific handlers first
+        for k, v_attr in attrs.items():
+            if (k, v_attr) in self.events:
+                for callback in self.events[(k, v_attr)]:
+                    self._call(callback, attrs)
+            
             if (k, None) in self.events:
                 for callback in self.events[(k, None)]:
                     remap = self._call(callback, attrs)
                     if remap is not None:
-                        v = remap
-                        attrs[k] = v
-            if (k, v) in self.events:
-                for callback in self.events[(k, v)]:
-                    remap = self._call(callback, attrs)
-                    if remap is not None:
-                        v = remap
-                        attrs[k] = v
+                        attrs[k] = remap
 
+        # Call generic handlers
+        if None in self.events:
+            for callback in self.events[None]:
+                self._call(callback, attrs)
 
 class Parser:
     def parse(self, file: TextIO, handler: ParseHandler) -> None:
-        pass
-
+        raise NotImplementedError
 
 class XmlParser(Parser, xml.sax.handler.ContentHandler, xml.sax.handler.ErrorHandler):
     def __init__(self):
         super().__init__()
         self.handler: ParseHandler | None = None
 
-    def parse(self, file: TextIO, handler: ParseHandler) -> None:
+    def parse(self, file: TextIO, handler: ParseHandler):
         self.handler = handler
-        xml.sax.parse(file, self, errorHandler=self)
+        parser = xml.sax.make_parser()
+        parser.setContentHandler(self)
+        parser.setErrorHandler(self)
+        parser.parse(file)
+
+    def startElement(self, name, attrs):
+        if self.handler is not None:
+            self.handler.handle(dict(attrs))
 
     def error(self, exception):
         pass
 
     def fatalError(self, exception):
+        raise exception
+
+    def warning(self, exception):
         pass
-
-    def startElement(self, name, attrs) -> None:
-        attributes: Dict[str, str] = {}
-        for name in attrs.getNames():
-            attributes[name] = attrs.getValue(name)
-        assert self.handler is not None
-        self.handler.handle(attributes)
-
 
 class JsonParser(Parser):
     def __init__(self):
         super().__init__()
 
     def parse(self, file: TextIO, handler: ParseHandler):
-        for line in file:
-            obj = json.loads(line)
-            handler.handle(obj)
-
+        for line in file.readlines():
+            handler.handle(json.loads(line))
 
 class Coverage:
-    def __init__(
-        self, file: str, line: str | int, comment: str | None = None, rare: bool = False
-    ):
+    def __init__(self, file: str, line: int, comment: str | None, rare: bool):
         self.file = file
-        self.line = int(line)
+        self.line = line
         self.comment = comment
         self.rare = rare
 
-    def to_tuple(self) -> Tuple[str, int, str | None]:
+    def to_tuple(self) -> Tuple[str, int, str | None, bool]:
         return self.file, self.line, self.comment, self.rare
 
     def __eq__(self, other) -> bool:
-        if isinstance(other, tuple) and len(other) == 4:
-            return self.to_tuple() == other
-        elif isinstance(other, Coverage):
-            return self.to_tuple() == other.to_tuple()
-        else:
-            return False
+        if not isinstance(other, Coverage):
+            return NotImplemented
+        return self.to_tuple() == other.to_tuple()
 
     def __lt__(self, other) -> bool:
-        if isinstance(other, tuple) and len(other) == 4:
-            return self.to_tuple() < other
-        elif isinstance(other, Coverage):
-            return self.to_tuple() < other.to_tuple()
-        else:
-            return False
+        if not isinstance(other, Coverage):
+            return NotImplemented
+        return self.to_tuple() < other.to_tuple()
 
     def __le__(self, other) -> bool:
-        if isinstance(other, tuple) and len(other) == 4:
-            return self.to_tuple() <= other
-        elif isinstance(other, Coverage):
-            return self.to_tuple() <= other.to_tuple()
-        else:
-            return False
+        if not isinstance(other, Coverage):
+            return NotImplemented
+        return self.to_tuple() <= other.to_tuple()
 
     def __gt__(self, other: Coverage) -> bool:
-        if isinstance(other, tuple) and len(other) == 4:
-            return self.to_tuple() > other
-        elif isinstance(other, Coverage):
-            return self.to_tuple() > other.to_tuple()
-        else:
-            return False
+        if not isinstance(other, Coverage):
+            return NotImplemented
+        return self.to_tuple() > other.to_tuple()
 
     def __ge__(self, other):
-        if isinstance(other, tuple) and len(other) == 4:
-            return self.to_tuple() >= other
-        elif isinstance(other, Coverage):
-            return self.to_tuple() >= other.to_tuple()
-        else:
-            return False
+        if not isinstance(other, Coverage):
+            return NotImplemented
+        return self.to_tuple() >= other.to_tuple()
 
     def __hash__(self):
-        return hash((self.file, self.line, self.comment, self.rare))
-
+        return hash(self.to_tuple())
 
 class TraceFiles:
     def __init__(self, path: Path):
-        self.path: Path = path
-        self.timestamps: List[int] = []
-        self.runs: OrderedDict[int, List[Path]] = collections.OrderedDict()
-        trace_expr = re.compile(r"trace.*\.(json|xml)")
-        for file in self.path.iterdir():
-            if file.is_file() and trace_expr.match(file.name) is not None:
-                ts = int(file.name.split(".")[6])
-                if ts in self.runs:
-                    self.runs[ts].append(file)
-                else:
-                    self.timestamps.append(ts)
-                    self.runs[ts] = [file]
-        self.timestamps.sort(reverse=True)
+        self.traces: OrderedDict[int, List[Path]] = collections.OrderedDict()
+        for file in path.glob("*.xml*"):
+            match = re.search(r"trace\.(?:\d{10}\.\d{6})\.(\d+)\.xml", file.name)
+            if match is None:
+                continue
+            ts = int(match.group(1))
+            if ts not in self.traces:
+                self.traces[ts] = []
+            self.traces[ts].append(file)
 
     def __getitem__(self, idx: int) -> List[Path]:
-        res = self.runs[self.timestamps[idx]]
-        res.sort()
-        return res
+        return list(self.traces.values())[idx]
 
     def __len__(self) -> int:
-        return len(self.runs)
+        return len(self.traces)
 
     def items(self) -> Iterator[List[Path]]:
         class TraceFilesIterator(Iterable[List[Path]]):
             def __init__(self, trace_files: TraceFiles):
-                self.current = 0
-                self.trace_files: TraceFiles = trace_files
+                self.trace_files = trace_files
+                self.iter = iter(self.trace_files.traces.values())
 
             def __iter__(self):
-                return self
+                return self.iter
 
             def __next__(self) -> List[Path]:
-                if len(self.trace_files) <= self.current:
-                    raise StopIteration
-                self.current += 1
-                return self.trace_files[self.current - 1]
+                return next(self.iter)
 
         return TraceFilesIterator(self)
-
 
 class Summary:
     def __init__(
         self,
         binary: Path,
-        runtime: float = 0,
+        runtime: float = 0.0,
         max_rss: int | None = None,
         was_killed: bool = False,
         uid: uuid.UUID | None = None,
+        current_part_uid: int | str | None = None,
         expected_unseed: int | None = None,
         exit_code: int = 0,
         valgrind_out_file: Path | None = None,
-        stats: str | None = None,
+        is_negative_test: bool = False,
         error_out: str = None,
         will_restart: bool = False,
         long_running: bool = False,
+        archival_config: Optional[ArchivalConfig] = None,
+        stats_attribute_for_v1: Optional[str] = None,
     ):
         self.binary = binary
         self.runtime: float = runtime
         self.max_rss: int | None = max_rss
         self.was_killed: bool = was_killed
         self.long_running = long_running
+        self.uid: uuid.UUID | None = uid
+        self.current_part_uid: int | str | None = current_part_uid
         self.expected_unseed: int | None = expected_unseed
         self.exit_code: int = exit_code
-        self.out: SummaryTree = SummaryTree("Test")
+        self.why: str | None = None
+        self.test_file: Path | None = None
+        self.seed: int | None = None
+        self.test_name: str | None = None
+        self.out = SummaryTree("Test", is_root_document=False)
         self.test_begin_found: bool = False
         self.test_end_found: bool = False
         self.unseed: int | None = None
         self.valgrind_out_file: Path | None = valgrind_out_file
+        self.archival_config = archival_config or ArchivalConfig()
+        self.archival_references_added = False
         self.severity_map: OrderedDict[tuple[str, int], int] = collections.OrderedDict()
         self.error: bool = False
         self.errors: int = 0
         self.warnings: int = 0
-        self.coverage: OrderedDict[Coverage, bool] = collections.OrderedDict()
+        self.coverage: Dict[Coverage, bool] = {}
+        self.is_negative_test: bool = is_negative_test
+        self.stderr_severity: str = "30"
         self.test_count: int = 0
         self.tests_passed: int = 0
-        self.error_out = error_out
-        self.stderr_severity: str = "40"
-        self.will_restart: bool = will_restart
-        self.test_dir: Path | None = None
-        self.is_negative_test = False
         self.negative_test_success = False
         self.max_trace_time = -1
         self.max_trace_time_type = "None"
+        self.error_out = error_out
+        
+        # File paths for output
+        self.run_times_file_path = None
+        self.stats_file_path = None
+        if config.joshua_output_dir is not None:
+            joshua_output_path = Path(config.joshua_output_dir)
+            self.joshua_xml_file_path = joshua_output_path / "joshua.xml"
+            self.run_times_file_path = joshua_output_path / "run_times.json"
+            self.stats_file_path = joshua_output_path / "stats.json"
 
         if uid is not None:
             self.out.attributes["TestUID"] = str(uid)
-        if stats is not None:
-            self.out.attributes["Statistics"] = stats
-        self.out.attributes["JoshuaSeed"] = str(config.joshua_seed)
-        self.out.attributes["WillRestart"] = "1" if self.will_restart else "0"
+        if current_part_uid is not None:
+            self.out.attributes["PartUID"] = str(current_part_uid)
+        if expected_unseed is not None:
+            self.out.attributes["ExpectedUnseed"] = str(expected_unseed)
         self.out.attributes["NegativeTest"] = "1" if self.is_negative_test else "0"
 
         self.handler = ParseHandler(self.out)
+        self.test_begin_time: Optional[float] = None
+        self._already_done = False
+        self.stats_attribute_for_v1 = stats_attribute_for_v1
+        self.no_verbose_on_failure = config.no_verbose_on_failure
         self.register_handlers()
+
+    # Events handled by specific logic - don't duplicate as generic children
+    INTERNALLY_HANDLED_EVENT_TYPES = {
+        "ProgramStart", "ElapsedTime", "SimulatorConfig", "Simulation", "NonSimulationTest",
+        "NegativeTestSuccess", "TestsExpectedToPass", "TestResults", "RemapEventSeverity",
+        "BuggifySection", "FaultInjected", "RunningUnitTest", "StderrSeverity", "CodeCoverage",
+        "UnseedMismatch", "FailureLogArchive",
+    }
+
+    def _sanitize_event_type_for_xml_tag(self, type_str: str) -> str:
+        """Sanitize event type for use as XML tag name"""
+        if not type_str:
+            return "GenericEvent"
+        sanitized = re.sub(r'[^a-zA-Z0-9_.-]', '_', type_str)
+        if not re.match(r'^[a-zA-Z_]', sanitized):
+            sanitized = '_' + sanitized
+        return sanitized
+
+    def parse_generic_event_as_child(self, attrs: Dict[str, str]):
+        """Convert generic trace events to XML children (simplified version)"""
+        event_type = attrs.get("Type")
+        if not event_type or event_type in self.INTERNALLY_HANDLED_EVENT_TYPES:
+            return
+
+        # Simple check for duplicate severity-based children
+        severity = attrs.get("Severity")
+        if severity in ["30", "40"]:
+            for child in self.out.children:
+                if child.name == event_type and child.attributes.get("Severity") == severity:
+                    return
+        
+        tag_name = self._sanitize_event_type_for_xml_tag(event_type)
+        child = SummaryTree(tag_name)
+        for k, v_raw in attrs.items():
+            child.attributes[str(k)] = str(v_raw)
+        self.out.append(child)
 
     def summarize_files(self, trace_files: List[Path]):
         assert len(trace_files) > 0
@@ -372,215 +441,138 @@ class Summary:
             self.parse_file(f)
         self.done()
 
-    def summarize(self, trace_dir: Path, command: str):
-        self.test_dir = trace_dir
-        trace_files = TraceFiles(trace_dir)
-        if len(trace_files) == 0:
-            self.error = True
-            child = SummaryTree("NoTracesFound")
-            child.attributes["Severity"] = "40"
-            child.attributes["Path"] = str(trace_dir.absolute())
-            child.attributes["Command"] = command
-            self.out.append(child)
-            child = SummaryTree("Output")
-            child.attributes["StdErr"] = self.error_out
-            self.out.append(child)
-            return
-        self.summarize_files(trace_files[0])
-        if config.joshua_dir is not None:
-            import test_harness.fdb
+    def summarize(self, temp_dir: Path | None, command: str):
+        if config.joshua_output_dir is not None:
+            joshua_output_path = Path(config.joshua_output_dir)
+            if not joshua_output_path.exists():
+                try:
+                    joshua_output_path.mkdir(parents=True, exist_ok=True)
+                except OSError as e:
+                    logger.error(f"Could not create joshua output directory: {e}")
 
-            test_harness.fdb.write_coverage(
-                config.cluster_file,
-                test_harness.fdb.str_to_tuple(config.joshua_dir) + ("coverage",),
-                test_harness.fdb.str_to_tuple(config.joshua_dir)
-                + ("coverage-metadata",),
-                self.coverage,
-            )
+        if temp_dir is not None:
+            self.temp_dir = temp_dir
+            self.command_file_path = temp_dir / "command.txt"
+            self.stderr_file_path = temp_dir / "stderr.txt"
+            self.stdout_file_path = temp_dir / "stdout.txt"
 
-    def list_simfdb(self) -> SummaryTree:
-        res = SummaryTree("SimFDB")
-        res.attributes["TestDir"] = str(self.test_dir)
-        if self.test_dir is None:
-            return res
-        simfdb = self.test_dir / Path("simfdb")
-        if not simfdb.exists():
-            res.attributes["NoSimDir"] = "simfdb doesn't exist"
-            return res
-        elif not simfdb.is_dir():
-            res.attributes["NoSimDir"] = "simfdb is not a directory"
-            return res
-        for file in simfdb.iterdir():
-            child = SummaryTree("Directory" if file.is_dir() else "File")
-            child.attributes["Name"] = file.name
-            res.append(child)
-        return res
+        self.command_line = command
+        if hasattr(self, 'command_file_path'):
+            with open(self.command_file_path, "w") as f:
+                f.write(command)
+        
+        if hasattr(self, 'stderr_file_path'):
+            self.stderr = self._try_read_file(self.stderr_file_path, config.max_stderr_bytes)
+        if hasattr(self, 'stdout_file_path'):
+            self.stdout = self._try_read_file(self.stdout_file_path)
 
-    def ok(self):
-        # logical xor -- a test is successful if there was either no error or we expected errors (negative test)
-        return (not self.error) != self.is_negative_test
+        if config.write_run_times and self.run_times_file_path:
+            self._write_run_times()
 
-    def done(self):
-        if config.print_coverage:
-            for k, v in self.coverage.items():
-                child = SummaryTree("CodeCoverage")
-                child.attributes["File"] = k.file
-                child.attributes["Line"] = str(k.line)
-                child.attributes["Rare"] = k.rare
-                if not v:
-                    child.attributes["Covered"] = "0"
-                if k.comment is not None and len(k.comment):
-                    child.attributes["Comment"] = k.comment
-                self.out.append(child)
-        if self.warnings > config.max_warnings:
-            child = SummaryTree("WarningLimitExceeded")
-            child.attributes["Severity"] = "30"
-            child.attributes["WarningCount"] = str(self.warnings)
-            self.out.append(child)
-        if self.errors > config.max_errors:
-            child = SummaryTree("ErrorLimitExceeded")
-            child.attributes["Severity"] = "40"
-            child.attributes["ErrorCount"] = str(self.errors)
-            self.out.append(child)
-            self.error = True
-        if self.was_killed:
-            child = SummaryTree("ExternalTimeout")
-            child.attributes["Severity"] = "40"
-            if self.long_running:
-                # debugging info for long-running tests
-                child.attributes["LongRunning"] = "1"
-                child.attributes["Runtime"] = str(self.runtime)
-            self.out.append(child)
-            self.error = True
-        if self.max_rss is not None:
-            self.out.attributes["PeakMemory"] = str(self.max_rss)
-        if self.valgrind_out_file is not None:
-            try:
-                valgrind_errors = parse_valgrind_output(self.valgrind_out_file)
-                for valgrind_error in valgrind_errors:
-                    if valgrind_error.kind.startswith("Leak"):
-                        continue
-                    self.error = True
-                    child = SummaryTree("ValgrindError")
-                    child.attributes["Severity"] = "40"
-                    child.attributes["What"] = valgrind_error.what.what
-                    child.attributes["Backtrace"] = valgrind_error.what.backtrace
-                    aux_count = 0
-                    for aux in valgrind_error.aux:
-                        child.attributes["WhatAux{}".format(aux_count)] = aux.what
-                        child.attributes[
-                            "BacktraceAux{}".format(aux_count)
-                        ] = aux.backtrace
-                        aux_count += 1
-                    self.out.append(child)
-            except Exception as e:
-                self.error = True
-                child = SummaryTree("ValgrindParseError")
-                child.attributes["Severity"] = "40"
-                child.attributes["ErrorMessage"] = str(e)
-                _, _, exc_traceback = sys.exc_info()
-                child.attributes["Trace"] = repr(traceback.format_tb(exc_traceback))
-                self.out.append(child)
-        if not self.test_end_found:
-            child = SummaryTree("TestUnexpectedlyNotFinished")
-            child.attributes["Severity"] = "40"
-            child.attributes["LastTraceTime"] = str(self.max_trace_time)
-            child.attributes["LastTraceType"] = self.max_trace_time_type
-            self.out.append(child)
-            self.error = True
-        if self.error_out is not None and len(self.error_out) > 0:
-            lines = self.error_out.splitlines()
-            stderr_bytes = 0
-            for line in lines:
-                if line.endswith(
-                    "WARNING: ASan doesn't fully support makecontext/swapcontext functions and may produce false positives in some cases!"
-                ):
-                    # When running ASAN we expect to see this message. Boost coroutine should be using the correct asan annotations so that it shouldn't produce any false positives.
-                    continue
-                if line.endswith("Warning: unimplemented fcntl command: 1036"):
-                    # Valgrind produces this warning when F_SET_RW_HINT is used
-                    continue
-                if self.stderr_severity == "40":
-                    self.error = True
-                remaining_bytes = config.max_stderr_bytes - stderr_bytes
-                if remaining_bytes > 0:
-                    out_err = line[0:remaining_bytes] + (
-                        "..." if len(line) > remaining_bytes else ""
-                    )
-                    child = SummaryTree("StdErrOutput")
-                    child.attributes["Severity"] = self.stderr_severity
-                    child.attributes["Output"] = out_err
-                    self.out.append(child)
-                stderr_bytes += len(line)
-            if stderr_bytes > config.max_stderr_bytes:
-                child = SummaryTree("StdErrOutputTruncated")
-                child.attributes["Severity"] = self.stderr_severity
-                child.attributes["BytesRemaining"] = str(
-                    stderr_bytes - config.max_stderr_bytes
-                )
-                self.out.append(child)
+        if config.read_stats and self.stats_file_path:
+            self._read_stats()
 
-        self.out.attributes["Ok"] = "1" if self.ok() else "0"
-        self.out.attributes["Runtime"] = str(self.runtime)
-        if not self.ok():
-            reason = "Unknown"
-            if self.error:
-                reason = "ProducedErrors"
-            elif not self.test_end_found:
-                reason = "TestDidNotFinish"
-            elif self.tests_passed == 0:
-                reason = "NoTestsPassed"
-            elif self.test_count != self.tests_passed:
-                reason = "Expected {} tests to pass, but only {} did".format(
-                    self.test_count, self.tests_passed
-                )
-            self.out.attributes["FailReason"] = reason
+        if not self._already_done:
+            self.done()
+
+        self._generate_xml_summary()
+
+    def _generate_xml_summary(self):
+        """Generate final XML summary with all attributes"""
+        self.out.attributes["TestUID"] = str(self.uid) if self.uid else "UNKNOWN_UID"
+        # Only set PartUID if it's not already set (don't override constructor)
+        if "PartUID" not in self.out.attributes:
+            self.out.attributes["PartUID"] = str(self.current_part_uid) if self.current_part_uid is not None else "0"
+        self.out.attributes["Version"] = CURRENT_VERSION
+
+        if self.test_file:
+            self.out.attributes["TestFile"] = xml.sax.saxutils.escape(str(self.test_file))
+        
+        if self.test_end_found and self.unseed is not None:
+             self.out.attributes["RandomUnseed"] = str(self.unseed)
+        
+        if self.expected_unseed is not None:
+            self.out.attributes["ExpectedUnseed"] = str(self.expected_unseed)
+
+        if config.joshua_output_dir:
+            self.out.attributes["JoshuaOutputDir"] = str(config.joshua_output_dir)
+        if config.run_temp_dir:
+            self.out.attributes["RunTempDir"] = str(config.run_temp_dir)
+
+        # Add child elements for compatibility
+        if self.seed is not None and "RandomSeed" not in self.out.attributes:
+            seed_element = SummaryTree("RandomSeed")
+            seed_element.attributes["Value"] = str(self.seed)
+            self.out.append(seed_element)
+
+        if self.test_name and "TestName" not in self.out.attributes:
+            test_name_element = SummaryTree("TestName")
+            test_name_element.attributes["Value"] = xml.sax.saxutils.escape(self.test_name)
+            self.out.append(test_name_element)
+
+    def _try_read_file(self, path: Path | None, max_len: int = -1) -> str:
+        """Safely read file content"""
+        if path is None or not path.exists():
+            return ""
+        try:
+            with open(path, "r") as f:
+                return f.read(max_len)
+        except Exception:
+            return ""
+
+    def _write_run_times(self):
+        """Write runtime statistics"""
+        pass
+
+    def _read_stats(self):
+        """Read test statistics"""
+        pass
 
     def parse_file(self, file: Path):
         parser: Parser
-        if file.suffix == ".json":
-            parser = JsonParser()
-        elif file.suffix == ".xml":
+        if file.suffix == ".xml":
             parser = XmlParser()
+        elif file.suffix == ".json":
+            parser = JsonParser()
         else:
-            child = SummaryTree("TestHarnessBug")
-            child.attributes["File"] = __file__
-            frame = inspect.currentframe()
-            if frame is not None:
-                child.attributes["Line"] = str(inspect.getframeinfo(frame).lineno)
-            child.attributes["Details"] = "Unexpected suffix {} for file {}".format(
-                file.suffix, file.name
-            )
-            self.error = True
-            self.out.append(child)
             return
-        with file.open("r") as f:
-            try:
+        
+        try:
+            with file.open("r", encoding="utf-8", errors="replace") as f:
                 parser.parse(f, self.handler)
-            except Exception as e:
-                child = SummaryTree("SummarizationError")
-                child.attributes["Severity"] = "40"
-                child.attributes["ErrorMessage"] = str(e)
-                self.out.append(child)
+        except Exception as e:
+            logger.error(f"Error parsing {file}: {e}")
+            self.error = True
+            child = SummaryTree("SummarizationError")
+            child.attributes["Severity"] = "40"
+            child.attributes["ErrorMessage"] = str(e)
+            self.out.append(child)
 
     def register_handlers(self):
-        def remap_event_severity(attrs):
-            if "Type" not in attrs or "Severity" not in attrs:
+        """Register event handlers for trace parsing"""
+        
+        def remap_event_severity(attrs: Dict[str, str]):
+            try:
+                k = (attrs["Type"], int(attrs["Severity"]))
+                if k in self.severity_map:
+                    return str(self.severity_map[k])
                 return None
-            k = (attrs["Type"], int(attrs["Severity"]))
-            if k in self.severity_map:
-                return str(self.severity_map[k])
+            except (KeyError, ValueError) as e:
+                logger.warning(f"Invalid severity in event: {attrs}. Error: {e}")
+                return None
 
         self.handler.add_handler(("Severity", None), remap_event_severity)
 
-        def get_max_trace_time(attrs):
-            if "Type" not in attrs:
-                return None
-            time = float(attrs["Time"])
-            if time >= self.max_trace_time:
-                self.max_trace_time = time
-                self.max_trace_time_type = attrs["Type"]
-            return None
+        def get_max_trace_time(attrs: Dict[str, str]):
+            if "Time" not in attrs:
+                return
+            try:
+                trace_time = float(attrs["Time"])
+                if trace_time > self.max_trace_time:
+                    self.max_trace_time = trace_time
+                    self.max_trace_time_type = attrs.get("Type", "Unknown")
+            except (ValueError, TypeError) as e:
+                logger.warning(f"Invalid Time value: {attrs}. Error: {e}")
 
         self.handler.add_handler(("Time", None), get_max_trace_time)
 
@@ -592,42 +584,62 @@ class Summary:
             self.out.attributes["SourceVersion"] = attrs["SourceVersion"]
             self.out.attributes["Time"] = attrs["ActualTime"]
             self.out.attributes["BuggifyEnabled"] = attrs["BuggifyEnabled"]
-            self.out.attributes["DeterminismCheck"] = (
-                "0" if self.expected_unseed is None else "1"
-            )
-            if self.binary.name != "fdbserver":
-                self.out.attributes["OldBinary"] = self.binary.name
             if "FaultInjectionEnabled" in attrs:
-                self.out.attributes["FaultInjectionEnabled"] = attrs[
-                    "FaultInjectionEnabled"
-                ]
+                self.out.attributes["FaultInjectionEnabled"] = attrs["FaultInjectionEnabled"]
 
         self.handler.add_handler(("Type", "ProgramStart"), program_start)
+
+        def simulator_config(attrs: Dict[str, str]):
+            self.out.attributes["ConfigString"] = attrs["ConfigString"]
+
+        self.handler.add_handler(("Type", "SimulatorConfig"), simulator_config)
 
         def negative_test_success(attrs: Dict[str, str]):
             self.negative_test_success = True
             child = SummaryTree(attrs["Type"])
-            for k, v in attrs:
+            for k, v in attrs.items():
                 if k != "Type":
                     child.attributes[k] = v
             self.out.append(child)
-            pass
 
         self.handler.add_handler(("Type", "NegativeTestSuccess"), negative_test_success)
 
-        def config_string(attrs: Dict[str, str]):
-            self.out.attributes["ConfigString"] = attrs["ConfigString"]
+        def set_test_count(attrs: Dict[str, str]):
+            try:
+                self.test_count = int(attrs["Count"])
+            except (KeyError, ValueError) as e:
+                logger.warning(f"Invalid Count in TestsExpectedToPass: {attrs}. Error: {e}")
+                self.test_count = 0
 
-        self.handler.add_handler(("Type", "SimulatorConfig"), config_string)
+        self.handler.add_handler(("Type", "TestsExpectedToPass"), set_test_count)
+
+        def set_tests_passed(attrs: Dict[str, str]):
+            try:
+                # Try 'Count' first, fall back to 'Passed' if not found
+                if "Count" in attrs:
+                    self.tests_passed = int(attrs["Count"])
+                elif "Passed" in attrs:
+                    self.tests_passed = int(attrs["Passed"])
+                else:
+                    raise KeyError("Neither 'Count' nor 'Passed' found in TestResults")
+            except (KeyError, ValueError) as e:
+                logger.warning(f"Invalid Count/Passed in TestResults: {attrs}. Error: {e}")
+                self.tests_passed = 0
+
+        self.handler.add_handler(("Type", "TestResults"), set_tests_passed)
+
+        def remap_severity(attrs: Dict[str, str]):
+            try:
+                k = (attrs["OriginalType"], int(attrs["OriginalSeverity"]))
+                self.severity_map[k] = int(attrs["NewSeverity"])
+            except (KeyError, ValueError) as e:
+                logger.warning(f"Invalid severity remapping: {attrs}. Error: {e}")
+
+        self.handler.add_handler(("Type", "RemapEventSeverity"), remap_severity)
 
         def set_test_file(attrs: Dict[str, str]):
-            test_file = Path(attrs["TestFile"])
-            cwd = Path(".").absolute()
-            try:
-                test_file = test_file.relative_to(cwd)
-            except ValueError:
-                pass
-            self.out.attributes["TestFile"] = str(test_file)
+            self.test_file = Path(attrs["TestFile"])
+            self.out.attributes["TestFile"] = attrs["TestFile"]
 
         self.handler.add_handler(("Type", "Simulation"), set_test_file)
         self.handler.add_handler(("Type", "NonSimulationTest"), set_test_file)
@@ -636,31 +648,47 @@ class Summary:
             if self.test_end_found:
                 return
             self.test_end_found = True
-            self.unseed = int(attrs["RandomUnseed"])
-            if (
-                self.expected_unseed is not None
-                and self.unseed != self.expected_unseed
-                and self.unseed != -1
-            ):
-                severity = (
-                    40
-                    if ("UnseedMismatch", 40) not in self.severity_map
-                    else self.severity_map[("UnseedMismatch", 40)]
-                )
+            try:
+                self.unseed = int(attrs["RandomUnseed"])
+            except (KeyError, ValueError):
+                logger.error(f"Invalid RandomUnseed in ElapsedTime: {attrs}")
+                self.unseed = -1
+
+            # Check for unseed mismatch
+            if (self.expected_unseed is not None and 
+                self.unseed != self.expected_unseed and 
+                self.unseed != -1):
+                
+                severity = 40 if ("UnseedMismatch", 40) not in self.severity_map else self.severity_map[("UnseedMismatch", 40)]
+                
                 if severity >= 30:
                     child = SummaryTree("UnseedMismatch")
-                    child.attributes["Unseed"] = str(self.unseed)
-                    child.attributes["ExpectedUnseed"] = str(self.expected_unseed)
+                    child.attributes["Expected"] = str(self.expected_unseed)
+                    child.attributes["Actual"] = str(self.unseed)
                     child.attributes["Severity"] = str(severity)
                     if severity >= 40:
                         self.error = True
+                        self.why = "UnseedMismatch"
                     self.out.append(child)
+
             self.out.attributes["SimElapsedTime"] = attrs["SimTime"]
             self.out.attributes["RealElapsedTime"] = attrs["RealTime"]
             if self.unseed is not None:
                 self.out.attributes["RandomUnseed"] = str(self.unseed)
 
         self.handler.add_handler(("Type", "ElapsedTime"), set_elapsed_time)
+
+        def parse_unseed_mismatch(attrs: Dict[str, str]):
+            self.error = True
+            if "FailReason" not in self.out.attributes:
+                self.out.attributes["FailReason"] = "UnseedMismatch"
+            child = SummaryTree("UnseedMismatch")
+            for k, v in attrs.items():
+                if k != "Type":
+                    child.attributes[k] = v
+            self.out.append(child)
+
+        self.handler.add_handler(("Type", "UnseedMismatch"), parse_unseed_mismatch)
 
         def parse_warning(attrs: Dict[str, str]):
             self.warnings += 1
@@ -675,76 +703,294 @@ class Summary:
         self.handler.add_handler(("Severity", "30"), parse_warning)
 
         def parse_error(attrs: Dict[str, str]):
-            if "ErrorIsInjectedFault" in attrs and attrs[
-                "ErrorIsInjectedFault"
-            ].lower() in ["1", "true"]:
-                # ignore injected errors. In newer fdb versions these will have a lower severity
-                return
-            self.errors += 1
             self.error = True
+            self.errors += 1
             if self.errors > config.max_errors:
                 return
             child = SummaryTree(attrs["Type"])
             for k, v in attrs.items():
-                child.attributes[k] = v
+                if k != "Type":
+                    child.attributes[k] = v
             self.out.append(child)
 
         self.handler.add_handler(("Severity", "40"), parse_error)
 
-        def coverage(attrs: Dict[str, str]):
-            covered = True
-            if "Covered" in attrs:
-                covered = int(attrs["Covered"]) != 0
-            comment = ""
-            if "Comment" in attrs:
-                comment = attrs["Comment"]
-            rare = False
-            if "Rare" in attrs:
-                rare = bool(int(attrs["Rare"]))
-            c = Coverage(attrs["File"], attrs["Line"], comment, rare)
-            if covered or c not in self.coverage:
-                self.coverage[c] = covered
-
-        self.handler.add_handler(("Type", "CodeCoverage"), coverage)
-
-        def expected_test_pass(attrs: Dict[str, str]):
-            self.test_count = int(attrs["Count"])
-
-        self.handler.add_handler(("Type", "TestsExpectedToPass"), expected_test_pass)
-
-        def test_passed(attrs: Dict[str, str]):
-            if attrs["Passed"] == "1":
-                self.tests_passed += 1
-
-        self.handler.add_handler(("Type", "TestResults"), test_passed)
-
-        def remap_event_severity(attrs: Dict[str, str]):
-            self.severity_map[
-                (attrs["TargetEvent"], int(attrs["OriginalSeverity"]))
-            ] = int(attrs["NewSeverity"])
-
-        self.handler.add_handler(("Type", "RemapEventSeverity"), remap_event_severity)
-
         def buggify_section(attrs: Dict[str, str]):
-            if attrs["Type"] == "FaultInjected" or attrs.get("Activated", "0") == "1":
-                child = SummaryTree(attrs["Type"])
-                child.attributes["File"] = attrs["File"]
-                child.attributes["Line"] = attrs["Line"]
-                self.out.append(child)
+            child = SummaryTree("BuggifySection")
+            for k, v in attrs.items():
+                if k != "Type":
+                    child.attributes[k] = v
+            self.out.append(child)
 
         self.handler.add_handler(("Type", "BuggifySection"), buggify_section)
-        self.handler.add_handler(("Type", "FaultInjected"), buggify_section)
+
+        def fault_injected(attrs: Dict[str, str]):
+            child = SummaryTree("FaultInjected")
+            for k, v in attrs.items():
+                if k != "Type":
+                    child.attributes[k] = v
+            self.out.append(child)
+
+        self.handler.add_handler(("Type", "FaultInjected"), fault_injected)
+
+        def coverage_file(attrs: Dict[str, str]):
+            try:
+                file = attrs["File"]
+                line = int(attrs["Line"])
+                comment = attrs.get("Comment")
+                rare = attrs.get("Rare", "0") != "0"
+                covered = attrs.get("Covered", "1") != "0"
+                self.coverage[Coverage(file, line, comment, rare)] = covered
+            except (KeyError, ValueError) as e:
+                logger.warning(f"Invalid coverage data: {attrs}. Error: {e}")
+
+        self.handler.add_handler(("Type", "CodeCoverage"), coverage_file)
 
         def running_unit_test(attrs: Dict[str, str]):
             child = SummaryTree("RunningUnitTest")
             child.attributes["Name"] = attrs["Name"]
             child.attributes["File"] = attrs["File"]
             child.attributes["Line"] = attrs["Line"]
+            self.out.append(child)
 
         self.handler.add_handler(("Type", "RunningUnitTest"), running_unit_test)
 
         def stderr_severity(attrs: Dict[str, str]):
-            if "NewSeverity" in attrs:
-                self.stderr_severity = attrs["NewSeverity"]
+            self.stderr_severity = attrs["Severity"]
 
         self.handler.add_handler(("Type", "StderrSeverity"), stderr_severity)
+
+        # Generic event handler for unhandled events
+        if not self.no_verbose_on_failure:
+            self.handler.add_handler(None, self.parse_generic_event_as_child)
+
+    def done(self):
+        """Finalize summary processing"""
+        if self._already_done:
+            return
+        self._already_done = True
+
+        self._detect_errors()
+        self._add_archival_info()
+        self._finalize_attributes()
+
+    def _detect_errors(self):
+        """Detect and handle various error conditions"""
+        if self.test_begin_found and not self.test_end_found and not self.was_killed:
+            self.error = True
+            if "FailReason" not in self.out.attributes:
+                 self.out.attributes["FailReason"] = "TestDidNotFinish"
+
+        if self.exit_code != 0 and not self.error and not self.was_killed and not self.is_negative_test:
+            self.error = True
+            if "FailReason" not in self.out.attributes:
+                self.out.attributes["FailReason"] = "NonZeroExitCodeNoError"
+
+        if self.was_killed:
+            self.error = True
+            self.out.attributes["Killed"] = "1"
+            if "FailReason" not in self.out.attributes:
+                self.out.attributes["FailReason"] = "TestKilled"
+
+        # Check stderr output for positive tests
+        if (not self.error and not self.is_negative_test and self.exit_code == 0 and 
+            self.error_out and len(self.error_out.strip()) > 0):
+            self.error = True
+            if "FailReason" not in self.out.attributes:
+                self.out.attributes["FailReason"] = "StdErrOutputWithZeroExit"
+
+        # Handle valgrind errors
+        if self.valgrind_out_file is not None and self.valgrind_out_file.exists():
+            try:
+                errors = parse_valgrind_output(self.valgrind_out_file)
+                if len(errors) > 0:
+                    self.error = True
+                    if "FailReason" not in self.out.attributes:
+                        self.out.attributes["FailReason"] = "ValgrindErrors"
+                    for error in errors:
+                        child = SummaryTree("ValgrindError")
+                        child.attributes["What"] = str(error)
+                        self.out.append(child)
+            except Exception as e:
+                logger.error(f"Error parsing valgrind output: {e}")
+
+        # Handle stderr output
+        if self.error_out and len(self.error_out) > 0 and self.stderr_severity != "0":
+            if len(self.error_out) > config.max_stderr_bytes:
+                trunc_tree = SummaryTree("StdErrOutputTruncated")
+                trunc_tree.attributes["Bytes"] = str(config.max_stderr_bytes)
+                self.out.append(trunc_tree)
+                content_tree = SummaryTree("StdErrOutput")
+                content_tree.attributes["Content"] = self.error_out[:config.max_stderr_bytes]
+                self.out.append(content_tree)
+            else:
+                error_out_tree = SummaryTree("StdErrOutput")
+                error_out_tree.attributes["Content"] = self.error_out
+                self.out.append(error_out_tree)
+
+        # Handle coverage
+        if config.print_coverage:
+            for k, v in self.coverage.items():
+                child = SummaryTree("CodeCoverage")
+                child.attributes["File"] = k.file
+                child.attributes["Line"] = str(k.line)
+                child.attributes["Rare"] = str(k.rare)
+                if not v:
+                    child.attributes["Covered"] = "0"
+                if k.comment:
+                    child.attributes["Comment"] = k.comment
+                self.out.append(child)
+
+        # Handle warning/error limits
+        if self.warnings > config.max_warnings:
+            child = SummaryTree("WarningLimitExceeded")
+            child.attributes["Severity"] = "30"
+            child.attributes["WarningCount"] = str(self.warnings)
+            self.out.append(child)
+
+        if self.errors > config.max_errors:
+            child = SummaryTree("ErrorLimitExceeded")
+            child.attributes["Severity"] = "40"
+            child.attributes["ErrorCount"] = str(self.errors)
+            self.out.append(child)
+            self.error = True
+
+    def _add_archival_info(self):
+        """Add archival information if test failed"""
+        if self.archival_config.enabled and not self.ok():
+            self.archival_references_added = True
+
+            if self.archival_config.run_temp_dir and self.archival_config.run_temp_dir.exists():
+                log_dir_elem = SummaryTree("FDBClusterLogDir")
+                log_dir_elem.attributes["path"] = str(self.archival_config.run_temp_dir.resolve())
+                self.out.append(log_dir_elem)
+            
+            if self.archival_config.stdout_path and self.archival_config.stdout_path.exists():
+                stdout_elem = SummaryTree("HarnessLogFile")
+                stdout_elem.attributes["type"] = "stdout"
+                stdout_elem.attributes["path"] = str(self.archival_config.stdout_path.resolve())
+                self.out.append(stdout_elem)
+
+            if self.archival_config.stderr_path and self.archival_config.stderr_path.exists():
+                stderr_elem = SummaryTree("HarnessLogFile")
+                stderr_elem.attributes["type"] = "stderr"
+                stderr_elem.attributes["path"] = str(self.archival_config.stderr_path.resolve())
+                self.out.append(stderr_elem)
+            
+            if self.archival_config.command_path and self.archival_config.command_path.exists():
+                cmd_elem = SummaryTree("HarnessLogFile")
+                cmd_elem.attributes["type"] = "command"
+                cmd_elem.attributes["path"] = str(self.archival_config.command_path.resolve())
+                self.out.append(cmd_elem)
+
+            for log_file_path in self.archival_config.current_fdb_logs:
+                if log_file_path.exists():
+                    fdb_file_elem = SummaryTree("FDBLogFile")
+                    fdb_file_elem.attributes["path"] = str(log_file_path.resolve())
+                    self.out.append(fdb_file_elem)
+            
+            if self.archival_config.joshua_output_dir and self.archival_config.joshua_output_dir.exists():
+                jod_elem = SummaryTree("JoshuaOutputDirRef")
+                jod_elem.attributes["path"] = str(self.archival_config.joshua_output_dir.resolve())
+                self.out.append(jod_elem)
+
+    def _finalize_attributes(self):
+        """Finalize top-level attributes"""
+        # Determine final test result
+        if self.error:
+            if self.is_negative_test:
+                self.negative_test_success = True
+                self.out.attributes["NegativeTestSuccess"] = "1"
+            else:
+                self.out.attributes["Ok"] = "0"
+        else:
+            if self.is_negative_test:
+                self.negative_test_success = False
+                self.out.attributes["Ok"] = "0"
+                if "FailReason" not in self.out.attributes:
+                    self.out.attributes["FailReason"] = "NegativeTestDidNotFail"
+            else:
+                self.out.attributes["Ok"] = "1"
+                self.tests_passed += 1
+        
+        self.test_count += 1
+
+        # Set memory and runtime attributes
+        if self.max_rss is not None:
+            self.out.attributes["PeakMemory"] = str(self.max_rss)
+
+        if self.runtime is not None:
+            self.out.attributes["Runtime"] = str(self.runtime)
+
+        # Final OK status and fail reason
+        current_ok_status = self.ok()
+        self.out.attributes["Ok"] = "1" if current_ok_status else "0"
+        
+        if not current_ok_status:
+            final_reason = self.why or "Unknown"
+            if not final_reason:
+                if self.error:
+                    final_reason = "ProducedErrors"
+                elif not self.test_end_found:
+                    final_reason = "TestDidNotFinish"
+                elif self.tests_passed == 0 and self.test_count > 0:
+                    final_reason = "NoTestsPassed"
+                elif self.test_count != self.tests_passed:
+                    final_reason = f"Expected {self.test_count} tests to pass, but only {self.tests_passed} did"
+            self.out.attributes["FailReason"] = final_reason
+        elif "FailReason" in self.out.attributes:
+            del self.out.attributes["FailReason"]
+
+    def ok(self):
+        """Check if test passed (logical xor for negative tests)"""
+        return (not self.error) != self.is_negative_test
+
+    def get_v1_stdout_line(self) -> Optional[str]:
+        """Generate V1-compatible stdout line"""
+        if not self._already_done:
+            self.done()
+
+        if not hasattr(self, 'out') or not self.out or self.out.name != "Test":
+            return '<Test Ok="0" Error="V1SummaryGenFailed_InvalidState" PartUID="0"/>'
+
+        try:
+            v1_test_summary_tree = copy.deepcopy(self.out)
+            v1_test_element = v1_test_summary_tree.to_et_element()
+        except Exception as e:
+            logger.error(f"Failed to create V1 summary: {e}")
+            return f'<Test Ok="0" Error="V1SummaryGenFailed_CopyError" PartUID="{self.current_part_uid or "0"}"/>'
+        
+        # Set V1-specific attributes
+        v1_test_element.set("TestRunCount", "1")
+
+        # Set TotalTestTime from RealElapsedTime
+        real_et_str = self.out.attributes.get("RealElapsedTime")
+        if real_et_str:
+            try:
+                total_test_time_val = str(int(float(real_et_str)))
+                v1_test_element.set("TotalTestTime", total_test_time_val)
+            except ValueError:
+                v1_test_element.set("TotalTestTime", "0")
+        else:
+            v1_test_element.set("TotalTestTime", "0")
+
+        # Add Statistics attribute
+        if self.stats_attribute_for_v1:
+            v1_test_element.set("Statistics", self.stats_attribute_for_v1)
+        
+        # Add essential child elements
+        for child_summary_tree in self.out.children:
+            if (child_summary_tree.name in ESSENTIAL_V1_CHILD_TAGS_TO_KEEP and 
+                child_summary_tree.name not in STDOUT_EXPLICITLY_STRIPPED_TAGS):
+                try:
+                    child_et_element = child_summary_tree.to_et_element()
+                    v1_test_element.append(child_et_element)
+                except Exception as e:
+                    logger.error(f"Error adding child '{child_summary_tree.name}' to V1 output: {e}")
+
+        try:
+            v1_xml_string = ET.tostring(v1_test_element, encoding='unicode', method='xml', short_empty_elements=True)
+            return v1_xml_string.strip()
+        except Exception as e:
+            logger.error(f"Failed to serialize V1 XML: {e}")
+            return f'<Test Ok="0" Error="V1SummaryGenFailed_SerializationFailed" PartUID="{self.current_part_uid or "0"}"/>'

--- a/contrib/joshua_logtool.py
+++ b/contrib/joshua_logtool.py
@@ -1,18 +1,56 @@
-#! /usr/bin/env python3
+#!/usr/bin/env python3
 
 """joshua_logtool.py
 
-Provides uploading/downloading FoundationDB log files to Joshua cluster.
+Joshua Log Tool
+
+This script provides uploading/downloading of FoundationDB trace logs to/from the Joshua cluster's
+coordinating FDB database. It is designed to help with debugging failed tests by archiving and
+retrieving simulation trace files.
+
+MAIN FUNCTIONS:
+==============
+
+1. UPLOAD MODE (joshua_logtool.py upload)
+   - Searches for all files in specified directories, excluding simfdb directories
+   - Optionally filters uploads based on RocksDB involvement (--check-rocksdb flag)
+   - Creates compressed tar.xz archives of all files (preserving directory structure)
+   - Uploads archives to Joshua FDB cluster using ensemble ID and test UID as keys
+
+2. DOWNLOAD MODE (joshua_logtool.py download)
+   - Retrieves previously uploaded archives from Joshua FDB cluster
+   - Extracts archives to current working directory
+   - Useful for local debugging of failed tests
+
+3. LIST MODE (joshua_logtool.py list)
+   - Lists all failed tests in a given ensemble
+   - Generates download commands for each failed test
+   - Helps identify which tests have logs available for download
+
+USAGE EXAMPLES:
+==============
+# Upload all files (excluding simfdb) for a specific test with RocksDB filtering
+python3 joshua_logtool.py upload --log-directory /tmp/test_logs --test-uid 12345-abcd --check-rocksdb
+
+# Upload all files regardless of test type
+python3 joshua_logtool.py upload --log-directory /tmp/test_logs --test-uid 12345-abcd
+
+# Download logs for a specific test
+python3 joshua_logtool.py download --ensemble-id 20240101-120000-user-abc123 --test-uid 12345-abcd
+
+# List all failed tests in an ensemble
+python3 joshua_logtool.py list --ensemble-id 20240101-120000-user-abc123
+
 """
 
 import argparse
 import logging
 import os
-import os.path
 import re
 import pathlib
 import subprocess
 import tempfile
+import sys
 
 import fdb
 import joshua.joshua_model as joshua
@@ -22,135 +60,293 @@ from typing import List, Union
 # Defined in SimulatedCluster.actor.cpp:SimulationConfig::setStorageEngine
 ROCKSDB_TRACEEVENT_STRING = ["RocksDBNonDeterminism", "ShardedRocksDBNonDeterminism"]
 
-# e.g. /var/joshua/ensembles/20230221-051349-xiaogesu-c9fc5b230dcd91cf
-ENSEMBLE_ID_REGEXP = re.compile(r"ensembles\/(?P<ensemble_id>[0-9A-Za-z\-_\.]+)$")
+# Typical ensemble ID format: 20230221-051349-user-abc123
+ENSEMBLE_ID_REGEXP = re.compile(r"(?P<ensemble_id>\d{8}-\d{6}-\w+-\w+)")
 
-# e.g. <Test TestUID="1ad90d42-824b-4693-aacf-53de3a6ccd27" Statistics="AAAA
+# Extract test UID from XML output
 TEST_UID_REGEXP = re.compile(r"TestUID=\"(?P<uid>[0-9a-fA-F\-]+)\"")
 
 logger = logging.getLogger(__name__)
 
-
 def _execute_grep(string: str, paths: List[pathlib.Path]) -> bool:
+    """Execute grep to search for a string in log files"""
     command = ["grep", "-F", string] + [str(path) for path in paths]
-    result = subprocess.run(command, stdout=subprocess.DEVNULL)
+    result = subprocess.run(command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
     return result.returncode == 0
 
-
 def _is_rocksdb_test(log_files: List[pathlib.Path]) -> bool:
+    """Check if test involves RocksDB by searching for RocksDB-related trace events"""
     for event_str in ROCKSDB_TRACEEVENT_STRING:
         if _execute_grep(event_str, log_files):
             return True
     return False
 
-
 def _extract_ensemble_id(work_directory: str) -> Union[str, None]:
+    """Extract ensemble ID from work directory path"""
     match = ENSEMBLE_ID_REGEXP.search(work_directory)
     if not match:
         return None
     return match.groupdict()["ensemble_id"]
 
-
 def _get_log_subspace(ensemble_id: str, test_uid: str):
+    """Get FDB subspace for storing/retrieving logs"""
     subspace = joshua.dir_ensemble_results_application
     log_space = subspace.create_or_open(joshua.db, "simulation_logs")
     return log_space[bytes(ensemble_id, "utf-8")][bytes(test_uid, "utf-8")]
 
-
 def _tar_logs(log_files: List[pathlib.Path], output_file_name: pathlib.Path):
-    command = ["tar", "-c", "-f", str(output_file_name), "--xz"] + [
-        str(log_file) for log_file in log_files
-    ]
-    logger.debug(f"Execute tar: {command}")
-    subprocess.run(command, check=True, stdout=subprocess.DEVNULL)
-
+    """Create compressed tar archive of log files"""
+    if not log_files:
+        return
+    
+    # Find the common parent directory to create relative paths
+    # For TestHarness2 structure, we want to preserve the top-level structure
+    # (joshua_output/, run_files/) so we need to find the right common parent
+    
+    # Get all parent directories
+    all_parents = [f.parent for f in log_files]
+    
+    # Find the deepest common parent that preserves meaningful directory structure
+    try:
+        common_parent = pathlib.Path(os.path.commonpath([str(p) for p in all_parents]))
+        
+        # Debug: Show what we're using as common parent
+        print(f"JOSHUA_LOGTOOL_DEBUG: Common parent directory: {common_parent}", file=sys.stderr)
+        print(f"JOSHUA_LOGTOOL_DEBUG: Sample file paths:", file=sys.stderr)
+        for i, f in enumerate(log_files[:3]):
+            try:
+                rel_path = f.relative_to(common_parent)
+                print(f"  {f} -> {rel_path}", file=sys.stderr)
+            except ValueError:
+                print(f"  {f} -> ERROR: Cannot make relative to {common_parent}", file=sys.stderr)
+            if i >= 2:  # Only show first 3
+                break
+        
+    except ValueError:
+        # No common path, use the first file's parent
+        common_parent = log_files[0].parent
+        print(f"JOSHUA_LOGTOOL_DEBUG: No common path found, using: {common_parent}", file=sys.stderr)
+    
+    # Create tar with relative paths to preserve directory structure
+    command = ["tar", "-c", "-f", str(output_file_name), "--xz", "-C", str(common_parent)]
+    
+    # Add relative paths from the common parent
+    relative_paths = []
+    for log_file in log_files:
+        try:
+            relative_path = log_file.relative_to(common_parent)
+            relative_paths.append(str(relative_path))
+        except ValueError:
+            # If file is not relative to common parent, use absolute path
+            print(f"JOSHUA_LOGTOOL_DEBUG: Cannot make {log_file} relative to {common_parent}, using absolute path", file=sys.stderr)
+            relative_paths.append(str(log_file))
+    
+    command.extend(relative_paths)
+    
+    # Debug: Show the tar command being executed
+    print(f"JOSHUA_LOGTOOL_DEBUG: Tar command: {' '.join(command[:10])}{'...' if len(command) > 10 else ''}", file=sys.stderr)
+    
+    subprocess.run(command, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
 def _tar_extract(path_to_archive: pathlib.Path):
-    command = ["tar", "xf", str(path_to_archive)]
-    subprocess.run(command, check=True, stdout=subprocess.DEVNULL)
-
+    """Extract tar archive to current directory"""
+    command = ["tar", "-x", "-f", str(path_to_archive)]
+    subprocess.run(command, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
 def report_error(
     work_directory: str,
     log_directory: str,
     ensemble_id: str,
     test_uid: str,
-    check_rocksdb: bool,
+    upload_mode: str,
 ):
-    log_files = list(pathlib.Path(log_directory).glob("**/trace*.xml"))
-    if len(log_files) == 0:
-        logger.debug(f"No XML file found in directory {log_directory}")
-    log_files += list(pathlib.Path(log_directory).glob("**/trace*.json"))
-    if len(log_files) == 0:
-        logger.debug(f"No JSON file found in directory {log_directory}")
-        return
-    logger.debug(f"Total {len(log_files)} files found")
-
-    if check_rocksdb and not _is_rocksdb_test(log_files):
-        logger.debug("Not a RocksDB test")
+    """Upload all test files (excluding simfdb directories) to Joshua FDB cluster"""
+    
+    # Find log files
+    log_directory_path = pathlib.Path(log_directory)
+    if not log_directory_path.exists() or not log_directory_path.is_dir():
+        logger.error(f"Log directory does not exist or is not a directory: {log_directory}")
+        print(f"JOSHUA_LOGTOOL_RESULT: FAILED - Log directory not found", file=sys.stdout)
         return
 
-    ensemble_id = ensemble_id or _extract_ensemble_id(work_directory)
-    if not ensemble_id:
-        logger.debug(f"Ensemble ID missing in work directory {work_directory}")
+    # Find all files, excluding simfdb directories
+    all_files = []
+    for root, dirs, files in os.walk(log_directory_path):
+        root_path = pathlib.Path(root)
+        
+        # Skip if any parent directory is named 'simfdb'
+        if 'simfdb' in root_path.parts:
+            continue
+            
+        # Remove 'simfdb' from dirs to prevent os.walk from descending into them
+        dirs[:] = [d for d in dirs if d != 'simfdb']
+        
+        # Add all files in this directory
+        for file in files:
+            file_path = root_path / file
+            all_files.append(file_path)
+    
+    # Debug: Show the directory structure being processed
+    print(f"JOSHUA_LOGTOOL_DEBUG: Log directory: {log_directory_path}", file=sys.stderr)
+    print(f"JOSHUA_LOGTOOL_DEBUG: Found {len(all_files)} files in directory structure:", file=sys.stderr)
+    
+    # Group files by their top-level directory for debugging
+    joshua_output_files = [f for f in all_files if 'joshua_output' in f.parts]
+    run_files = [f for f in all_files if 'run_files' in f.parts]
+    other_files = [f for f in all_files if 'joshua_output' not in f.parts and 'run_files' not in f.parts]
+    
+    print(f"JOSHUA_LOGTOOL_DEBUG: - joshua_output files: {len(joshua_output_files)}", file=sys.stderr)
+    for f in joshua_output_files:
+        print(f"    {f}", file=sys.stderr)
+    
+    print(f"JOSHUA_LOGTOOL_DEBUG: - run_files: {len(run_files)}", file=sys.stderr)
+    for i, f in enumerate(run_files[:5]):  # Show first 5
+        print(f"    {f}", file=sys.stderr)
+    if len(run_files) > 5:
+        print(f"    ... and {len(run_files) - 5} more run_files", file=sys.stderr)
+    
+    if other_files:
+        print(f"JOSHUA_LOGTOOL_DEBUG: - other files: {len(other_files)}", file=sys.stderr)
+        for f in other_files:
+            print(f"    {f}", file=sys.stderr)
+    
+    if len(all_files) == 0:
+        logger.debug(f"No files found in {log_directory} (excluding simfdb)")
+        print(f"JOSHUA_LOGTOOL_RESULT: SKIPPED - No files found", file=sys.stdout)
+        return
+
+    # For RocksDB filtering, still check trace files specifically
+    if upload_mode == "rocksdb":
+        xml_files = [f for f in all_files if f.name.startswith('trace') and f.suffix == '.xml']
+        json_files = [f for f in all_files if f.name.startswith('trace') and f.suffix == '.json']
+        trace_files = xml_files + json_files
+        
+        if len(trace_files) == 0:
+            logger.debug(f"No trace files found for RocksDB check in {log_directory}")
+            print(f"JOSHUA_LOGTOOL_RESULT: SKIPPED - No trace files found", file=sys.stdout)
+            return
+            
+        if not _is_rocksdb_test(trace_files):
+            logger.debug("Not a RocksDB test, skipping upload")
+            print(f"JOSHUA_LOGTOOL_RESULT: SKIPPED - Not a RocksDB test", file=sys.stdout)
+            return
+
+    # Determine ensemble ID
+    final_ensemble_id = ensemble_id or _extract_ensemble_id(work_directory)
+    if not final_ensemble_id:
+        logger.error(f"Ensemble ID missing in work directory {work_directory}")
+        print(f"JOSHUA_LOGTOOL_RESULT: FAILED - Ensemble ID missing", file=sys.stdout)
         raise RuntimeError(f"Ensemble ID missing in work directory {work_directory}")
-    logger.debug(f"Ensemble ID: {ensemble_id}")
 
+    # Create and upload archive
+    try:
+        with tempfile.NamedTemporaryFile(suffix='.tar.xz') as archive:
+            _tar_logs(all_files, pathlib.Path(archive.name))
+            
+            archive_size = os.path.getsize(archive.name)
+            if archive_size == 0:
+                logger.error("Archive is empty")
+                print(f"JOSHUA_LOGTOOL_RESULT: FAILED - Archive is empty", file=sys.stdout)
+                return
+            
+            # Upload to FDB
+            subspace = _get_log_subspace(final_ensemble_id, test_uid)
+            joshua._insert_blob(joshua.db, subspace, archive, offset=0)
+            
+            print(f"JOSHUA_LOGTOOL_RESULT: SUCCESS - Uploaded {len(all_files)} files ({archive_size} bytes)", file=sys.stdout)
+            
+    except Exception as e:
+        logger.error(f"Error during upload: {e}")
+        print(f"JOSHUA_LOGTOOL_RESULT: FAILED - {e}", file=sys.stdout)
+        raise
+
+def download_logs(ensemble_id: str, test_uid: str, output_dir: str = None):
+    """Download and extract all test files for a specific test from Joshua FDB cluster"""
     with tempfile.NamedTemporaryFile() as archive:
-        logger.debug(f"Tarfile: {archive.name}")
-        _tar_logs(log_files, archive.name)
-        logger.debug(f"Tarfile size: {os.path.getsize(archive.name)}")
         subspace = _get_log_subspace(ensemble_id, test_uid)
-        joshua._insert_blob(joshua.db, subspace, archive, offset=0)
-
-
-def download_logs(ensemble_id: str, test_uid: str):
-    with tempfile.NamedTemporaryFile() as archive:
-        subspace = _get_log_subspace(ensemble_id, test_uid)
-        logger.debug(
-            f"Downloading the archive to {archive.name} at subspace {subspace}"
-        )
         joshua._read_blob(joshua.db, subspace, archive)
-        logger.debug(f"Tarfile size: {os.path.getsize(archive.name)}")
-        _tar_extract(archive.name)
-
+        
+        # Check archive size
+        archive.seek(0, 2)
+        archive_size = archive.tell()
+        archive.seek(0)
+        
+        if archive_size == 0:
+            print(f"No logs found for test {test_uid}")
+            return
+        
+        # Create output directory if specified
+        if output_dir:
+            output_path = pathlib.Path(output_dir)
+            output_path.mkdir(parents=True, exist_ok=True)
+            os.chdir(output_path)
+            print(f"Extracting to: {output_path}")
+        
+        # List archive contents before extraction (for debugging)
+        try:
+            list_command = ["tar", "-t", "-f", str(archive.name)]
+            result = subprocess.run(list_command, capture_output=True, text=True)
+            if result.returncode == 0:
+                print(f"Archive contents:")
+                lines = result.stdout.strip().split('\n')
+                for line in lines[:10]:  # Show first 10 files
+                    print(f"  {line}")
+                if len(lines) > 10:
+                    print(f"  ... and {len(lines) - 10} more files")
+            else:
+                print(f"Could not list archive contents: {result.stderr}")
+        except Exception as e:
+            print(f"Error listing archive: {e}")
+        
+        _tar_extract(pathlib.Path(archive.name))
+        print(f"Downloaded and extracted {archive_size} bytes of logs")
+        
+        # Show what was actually extracted
+        if output_dir:
+            print(f"Files extracted to {output_path}:")
+            for item in sorted(output_path.rglob('*'))[:10]:  # Show first 10 items
+                if item.is_file():
+                    print(f"  {item.relative_to(output_path)}")
+            if len(list(output_path.rglob('*'))) > 10:
+                print(f"  ... and {len(list(output_path.rglob('*'))) - 10} more items")
 
 def list_commands(ensemble_id: str):
+    """List download commands for all failed tests in an ensemble"""
     for item in joshua.tail_results(ensemble_id, errors_only=True):
         test_harness_output = item[4]
         match = TEST_UID_REGEXP.search(test_harness_output)
         if not match:
-            logger.warning(f"Test UID not found in {test_harness_output}")
             continue
         test_uid = match.groupdict()["uid"]
-        print(
-            f"python3 {__file__} download --ensemble-id {ensemble_id} --test-uid {test_uid}"
-        )
-
+        print(f"python3 {__file__} download --ensemble-id {ensemble_id} --test-uid {test_uid}")
 
 def _setup_args():
-    parser = argparse.ArgumentParser(prog="joshua_logtool.py")
-
+    """Setup command line argument parser"""
+    parser = argparse.ArgumentParser(
+        description="Upload/download FoundationDB log files to Joshua cluster"
+    )
     parser.add_argument(
-        "--cluster-file", type=str, default=None, help="Joshua FDB cluster file"
+        "--cluster-file",
+        type=str,
+        default="/etc/foundationdb/fdb.cluster",
+        help="Path to cluster file",
     )
     parser.add_argument(
         "--debug", action="store_true", default=False, help="Add debug logging"
     )
+    parser.add_argument(
+        "--quiet", action="store_true", default=False, help="Reduce output verbosity"
+    )
 
     subparsers = parser.add_subparsers(help="Possible actions", dest="action")
 
-    upload_parser = subparsers.add_parser(
-        "upload", help="Check the log file, upload them to Joshua cluster if necessary"
-    )
+    # Upload subcommand
+    upload_parser = subparsers.add_parser("upload", help="Upload all files (excluding simfdb) to Joshua cluster")
     upload_parser.add_argument(
         "--work-directory", type=str, default=os.getcwd(), help="Work directory"
     )
     upload_parser.add_argument(
-        "--log-directory",
-        type=str,
-        required=True,
-        help="Directory contains XML/JSON logs",
+        "--log-directory", type=str, required=True, help="Directory containing all test files to upload (simfdb directories will be excluded)"
     )
     upload_parser.add_argument(
         "--ensemble-id", type=str, default=None, required=False, help="Ensemble ID"
@@ -159,52 +355,57 @@ def _setup_args():
     upload_parser.add_argument(
         "--check-rocksdb",
         action="store_true",
-        help="If true, only upload logs when RocksDB is involved; otherwise, always upload logs.",
+        default=False,
+        help="Only upload if test involves RocksDB (checks trace files for RocksDB events)",
     )
 
-    download_parser = subparsers.add_parser(
-        "download", help="Download the log file from Joshua to local directory"
-    )
+    # Download subcommand
+    download_parser = subparsers.add_parser("download", help="Download logs from Joshua cluster")
     download_parser.add_argument(
-        "--ensemble-id", type=str, required=True, help="Joshua ensemble ID"
+        "--ensemble-id", type=str, required=True, help="Ensemble ID"
     )
     download_parser.add_argument("--test-uid", type=str, required=True, help="Test UID")
-
-    list_parser = subparsers.add_parser(
-        "list",
-        help="List the possible download commands for failed tests in a given ensemble. NOTE: It is possible that the test is not relevant to RocksDB and no log file is available. It is the user's responsibility to verify if this happens.",
+    download_parser.add_argument(
+        "--output-dir", type=str, default=None, help="Directory to extract files to (defaults to current directory)"
     )
+
+    # List subcommand
+    list_parser = subparsers.add_parser("list", help="List failed tests in ensemble")
     list_parser.add_argument(
-        "--ensemble-id", type=str, required=True, help="Joshua ensemble ID"
+        "--ensemble-id", type=str, required=True, help="Ensemble ID"
     )
 
     return parser.parse_args()
 
-
 def _main():
+    """Main entry point"""
     args = _setup_args()
 
-    if args.debug:
+    # Setup logging based on flags
+    if args.quiet:
+        logging.basicConfig(level=logging.WARNING)
+    elif args.debug:
         logging.basicConfig(level=logging.DEBUG)
     else:
         logging.basicConfig(level=logging.INFO)
 
-    logger.debug(f"Using cluster file {args.cluster_file}")
+    # Initialize Joshua FDB connection
     joshua.open(args.cluster_file)
 
+    # Execute requested action
     if args.action == "upload":
+        upload_mode = "rocksdb" if args.check_rocksdb else "all"
         report_error(
             work_directory=args.work_directory,
             log_directory=args.log_directory,
             ensemble_id=args.ensemble_id,
             test_uid=args.test_uid,
-            check_rocksdb=args.check_rocksdb,
+            upload_mode=upload_mode,
         )
     elif args.action == "download":
-        download_logs(ensemble_id=args.ensemble_id, test_uid=args.test_uid)
+        download_logs(ensemble_id=args.ensemble_id, test_uid=args.test_uid, output_dir=args.output_dir)
     elif args.action == "list":
         list_commands(ensemble_id=args.ensemble_id)
-
 
 if __name__ == "__main__":
     _main()


### PR DESCRIPTION
 ```
   Extend archiving failed logs in TestHarness2/Joshua Framework

    Unified logging output so easy to download: per run there
    is a th_run.ENSEMBLE_ID directory of logs.

    On failure if TH_ARCHIVE_LOGS_ON_FAILURE is set, logs are
    NOT cleaned up at the end of the test run: e.g.

      j start  --env TH_UNSEED_CHECK_RATIO=1.0 --env TH_ARCHIVE_LOGS_ON_FAILURE=true --tarball  /root/BulkDumpingS3.tar.gz --max-run 1

    In particular, added capture of BOTH log sets when doing the
    determinacy check so can compare the runs.

    Amended the joshua_logtool so doesn't run by default if it finds rocksdb
    log entries -- the current configuration; instead you have to ask it to run.
    It will bundle up all log files rather than just trace files (including logs
    from both runs for the determinacy test). It does NOT include the
    joshua.xml for now because joshua_logtool.py runs before this file is
    generated (hard to refactor).

    Added diagnostic logging and tracing around the joshua test runner
    context. Added capture of stderr/out so can easier debug failed test/test
    infrastructure (handy because I kept breaking tes runner). Retain the v1
    (original) test xml result reporting even after messing w/ the xml report
    to make a  proper xml document of ALL the test output.

    * contrib/Joshua/README.md
      Some detail on scripts directory and TestHarness2 integration

    * contrib/Joshua/scripts/correctnessTest.sh
      Add error handling, logging, and cleanup around test launch.

    * contrib/TestHarness2/README.md
      Documentation on operation, output structure, and archival modes
      for test harness ('th') including how to use joshua_logtool.py.

    * contrib/TestHarness2/test_harness/app.py
      Add capture of stdout/err into a well-defined location.
      Adds XML manipulation trying to make sure the XML output
      is same as it was in V1 -- the current, original output
      -- adding filtering and insertion. If fatal error,
      return an 'xml' fatal error. Made more robust
      against the unexpected (of which there was plenty

    * contrib/TestHarness2/test_harness/config.py
      Fixup. Added --joshua-output-dir option. Made
      kill seconds configurable (was 30 minutes
      which was painful when app was deadlocking).
      Added configurable log-level and whether to
      save logs on failure.

    * contrib/TestHarness2/test_harness/run.py
      Improved test execution and result handling
      Capture both determinacy test log sets.

    * contrib/TestHarness2/test_harness/summarize.py
      Hack on XML handling -- filtering -- and then
      work to make it v1/original compatible.

    * contrib/joshua_logtool.py
     Integrate joshua_logtool. Make it pick up all logs
     including double logging by determinacy test.
     Add doc.

```