### PR TITLE
Mitigate rocksdb external timeout in AtomicBackupToDBCorrectness test

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -559,7 +559,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( ROCKSDB_SINGLEKEY_DELETES_MAX,                         200 ); // Max rocksdb::delete calls in a transaction
 	init( ROCKSDB_ENABLE_CLEAR_RANGE_EAGER_READS,              false );
 	init( ROCKSDB_FORCE_DELETERANGE_FOR_CLEARRANGE,            false );
-	init( ROCKSDB_CLEARRANGES_LIMIT_PER_COMMIT,                    0 ); if( isSimulated ) ROCKSDB_CLEARRANGES_LIMIT_PER_COMMIT = deterministicRandom()->randomInt(1000, 10000); // Default: 0 (disabled).
+	init( ROCKSDB_CLEARRANGES_LIMIT_PER_COMMIT,                    0 ); if( isSimulated ) ROCKSDB_CLEARRANGES_LIMIT_PER_COMMIT = deterministicRandom()->randomInt(200, 500); // Default: 0 (disabled).
 	// ROCKSDB_STATS_LEVEL=1 indicates rocksdb::StatsLevel::kExceptHistogramOrTimers
 	// Refer StatsLevel: https://github.com/facebook/rocksdb/blob/main/include/rocksdb/statistics.h#L594
 	init( ROCKSDB_STATS_LEVEL,                                     1 );
@@ -627,7 +627,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( SHARDED_ROCKSDB_VALIDATE_MAPPING_RATIO,               0.01 ); if (isSimulated) SHARDED_ROCKSDB_VALIDATE_MAPPING_RATIO = deterministicRandom()->random01();
 	init( SHARD_METADATA_SCAN_BYTES_LIMIT,                  10485760 ); // 10MB
 	init( ROCKSDB_MAX_MANIFEST_FILE_SIZE,                  100 << 20 ); if (isSimulated) ROCKSDB_MAX_MANIFEST_FILE_SIZE = 500 << 20; // 500MB in simulation
-	init( SHARDED_ROCKSDB_MEMTABLE_MAX_RANGE_DELETIONS,          500 ); if (isSimulated) SHARDED_ROCKSDB_MEMTABLE_MAX_RANGE_DELETIONS = 50;
+	init( SHARDED_ROCKSDB_MEMTABLE_MAX_RANGE_DELETIONS,          500 ); if (isSimulated) SHARDED_ROCKSDB_MEMTABLE_MAX_RANGE_DELETIONS = 5;
 	init( SHARDED_ROCKSDB_AVERAGE_FILE_SIZE,                 8 << 20 ); // 8MB
 	init( SHARDED_ROCKSDB_COMPACTION_PERIOD, isSimulated? 3600 : 2592000 ); // 30d
 	init( SHARDED_ROCKSDB_COMPACTION_ACTOR_DELAY,               3600 ); // 1h

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -599,7 +599,9 @@ struct StorageServerDisk {
 	                                 Version newStorageVersion,
 	                                 int64_t& bytesLeft,
 	                                 UnlimitedCommitBytes unlimitedCommitBytes,
-	                                 int64_t& clearRangesLeft);
+	                                 int64_t& clearRangesLeft,
+	                                 const UID& ssId,
+	                                 bool verbose = false);
 	void makeVersionDurable(Version version);
 	void makeAccumulativeChecksumDurable(const AccumulativeChecksumState& acsState);
 	void clearAccumulativeChecksumState(const AccumulativeChecksumState& acsState);
@@ -12988,12 +12990,22 @@ ACTOR Future<Void> updateStorage(StorageServer* data) {
 			}
 		}
 
+		// When unlimitedCommitBytes is set to true, clearRangesLeft will be ignored.
+		// Make sure unlimitedCommitBytes is set to True only when storage engine is sharded rocksdb.
+		ASSERT(data->shardAware || unlimitedCommitBytes == UnlimitedCommitBytes::False);
+
 		// Write mutations to storage until we reach the desiredVersion or have written too much (bytesleft)
 		// or until we reach clearRanges limit, in case of rocksdb.
 		state double beforeStorageUpdates = now();
 		loop {
-			state bool done = data->storage.makeVersionMutationsDurable(
-			    newOldestVersion, desiredVersion, bytesLeft, unlimitedCommitBytes, clearRangesLeft);
+			state bool done = data->storage.makeVersionMutationsDurable(newOldestVersion,
+			                                                            desiredVersion,
+			                                                            bytesLeft,
+			                                                            unlimitedCommitBytes,
+			                                                            clearRangesLeft,
+			                                                            data->thisServerID,
+			                                                            data->storage.getKeyValueStoreType() ==
+			                                                                KeyValueStoreType::SSD_ROCKSDB_V1);
 			if (data->tenantMap.getLatestVersion() < newOldestVersion) {
 				data->tenantMap.createNewVersion(newOldestVersion);
 			}
@@ -13581,10 +13593,21 @@ bool StorageServerDisk::makeVersionMutationsDurable(Version& prevStorageVersion,
                                                     Version newStorageVersion,
                                                     int64_t& bytesLeft,
                                                     UnlimitedCommitBytes unlimitedCommitBytes,
-                                                    int64_t& clearRangesLeft) {
+                                                    int64_t& clearRangesLeft,
+                                                    const UID& ssId,
+                                                    bool verbose) {
 	if (!unlimitedCommitBytes && (bytesLeft <= 0 || clearRangesLeft <= 0))
 		return true;
 
+	if (clearRangesLeft <= 0 && verbose) {
+		TraceEvent(SevInfo, "MakeVersionMutationsDurableClearRangesLeftZero", ssId)
+		    .suppressFor(5.0)
+		    .detail("PrevStorageVersion", prevStorageVersion)
+		    .detail("NewStorageVersion", newStorageVersion)
+		    .detail("BytesLeft", bytesLeft)
+		    .detail("ClearRangesLeft", clearRangesLeft)
+		    .detail("UnlimitedCommitBytes", unlimitedCommitBytes);
+	}
 	// Apply mutations from the mutationLog
 	auto u = data->getMutationLog().upper_bound(prevStorageVersion);
 	if (u != data->getMutationLog().end() && u->first <= newStorageVersion) {

--- a/tests/fast/AtomicBackupToDBCorrectness.toml
+++ b/tests/fast/AtomicBackupToDBCorrectness.toml
@@ -10,8 +10,8 @@ simBackupAgents = 'BackupToDB'
 
     [[test.workload]]
     testName = 'AtomicOps'
-    nodeCount = 30000
-    transactionsPerSecond = 2500.0
+    nodeCount = 10000
+    transactionsPerSecond = 750.0
     testDuration = 30.0
 
     [[test.workload]]


### PR DESCRIPTION
100K correctness:
  20250610-164440-zhewang-032e866a85878b19           compressed=True data_size=41255833 duration=5387342 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=3:29:27 sanity=False started=100000 stopped=20250610-201407 submitted=20250610-164440 timeout=5400 username=zhewang
  
100K AtomicBackupToDBCorrectness:
  20250610-212947-zhewang-6234e861a99c8ee9           compressed=True data_size=41296380 duration=265406 ended=2401 fail_fast=10 max_runs=100000 pass=2401 priority=100 remaining=1 day, 14:10:35 runtime=0:56:21 sanity=False started=2576 submitted=20250610-212947 timeout=5400 username=zhewang
  
# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
