### PR TITLE
Fix physical shard move external timeout

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -271,7 +271,7 @@ if(WITH_PYTHON)
     else()
       add_fdb_test(TEST_FILES noSim/PerfShardedRocksDBTest.toml UNIT)
     endif()
-    add_fdb_test(TEST_FILES fast/PhysicalShardMove.toml IGNORE)
+    add_fdb_test(TEST_FILES fast/PhysicalShardMove.toml)
     add_fdb_test(TEST_FILES fast/StorageServerCheckpointRestore.toml IGNORE)
 
     # Mock DD Tests

--- a/tests/fast/PhysicalShardMove.toml
+++ b/tests/fast/PhysicalShardMove.toml
@@ -20,7 +20,6 @@ shard_encode_location_metadata = true
 # min_byte_sampling_probability = 0.99
 # rocksdb_read_range_reuse_iterators = false
 dd_physical_shard_move_probability = 1.0
-rocksdb_clearranges_limit_per_commit = 10000
 sharded_rocksdb_memtable_max_range_deletions = 50
 
 [[test]]

--- a/tests/fast/PhysicalShardMove.toml
+++ b/tests/fast/PhysicalShardMove.toml
@@ -20,6 +20,8 @@ shard_encode_location_metadata = true
 # min_byte_sampling_probability = 0.99
 # rocksdb_read_range_reuse_iterators = false
 dd_physical_shard_move_probability = 1.0
+rocksdb_clearranges_limit_per_commit = 10000
+sharded_rocksdb_memtable_max_range_deletions = 50
 
 [[test]]
 testTitle = 'PhysicalShardMove'


### PR DESCRIPTION
100K physical shard move:
  20250614-003601-zhewang-bb980ea0cdcf3cae           compressed=True data_size=41296503 duration=3960350 ended=100000 fail=1 fail_fast=10 max_runs=100000 pass=99999 priority=100 remaining=0 runtime=2:45:40 sanity=False started=100000 stopped=20250614-032141 submitted=20250614-003601 timeout=5400 username=zhewang

100K correctness:
  20250614-034427-zhewang-ac439db66a590a6e           compressed=True data_size=41255650 duration=4796963 ended=100000 fail=2 fail_fast=10 max_runs=100000 pass=99998 priority=100 remaining=0 runtime=3:07:59 sanity=False started=100000 stopped=20250614-065226 submitted=20250614-034427 timeout=5400 username=zhewang

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
