### PR TITLE
Fix a race that can cause recovery to be stuck [release 7.4]

### DIFF
--- a/fdbserver/ClusterRecovery.actor.cpp
+++ b/fdbserver/ClusterRecovery.actor.cpp
@@ -465,7 +465,7 @@ ACTOR Future<Void> trackTlogRecovery(Reference<ClusterRecoveryData> self,
 		// We can't purge old generations until we have the new state durable on coordinators,
 		// otherwise old tlogs can be removed before the new state is written,
 		// which may cause immediate recovery to stuck in locking old tlogs.
-		self->logSystem->purgeOldRecoveredGenerations(newState);
+		self->logSystem->purgeOldRecoveredGenerationsCoreState(newState);
 		newState.recoveryCount = recoverCount;
 
 		// Update Coordinators EncryptionAtRest status during the very first recovery of the cluster (empty database)
@@ -489,6 +489,8 @@ ACTOR Future<Void> trackTlogRecovery(Reference<ClusterRecoveryData> self,
 		            configuration.expectedLogSets(self->primaryDcId.size() ? self->primaryDcId[0] : Optional<Key>()))
 		    .detail("RecoveryCount", newState.recoveryCount);
 		wait(self->cstate.write(newState, finalUpdate));
+		// Purge in memory state after durability to avoid race conditions.
+		self->logSystem->purgeOldRecoveredGenerationsInMemory(newState);
 		if (self->cstateUpdated.canBeSet()) {
 			self->cstateUpdated.send(Void());
 		}

--- a/fdbserver/ClusterRecovery.actor.cpp
+++ b/fdbserver/ClusterRecovery.actor.cpp
@@ -461,8 +461,11 @@ ACTOR Future<Void> trackTlogRecovery(Reference<ClusterRecoveryData> self,
 	    self->configuration; // self-configuration can be changed by configurationMonitor so we need a copy
 	loop {
 		state DBCoreState newState;
-		self->logSystem->purgeOldRecoveredGenerations();
 		self->logSystem->toCoreState(newState);
+		// We can't purge old generations until we have the new state durable on coordinators,
+		// otherwise old tlogs can be removed before the new state is written,
+		// which may cause immediate recovery to stuck in locking old tlogs.
+		self->logSystem->purgeOldRecoveredGenerations(newState);
 		newState.recoveryCount = recoverCount;
 
 		// Update Coordinators EncryptionAtRest status during the very first recovery of the cluster (empty database)

--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -333,7 +333,7 @@ Reference<ILogSystem> TagPartitionedLogSystem::fromOldLogSystemConfig(UID const&
 	return logSystem;
 }
 
-void TagPartitionedLogSystem::purgeOldRecoveredGenerations(DBCoreState& newState) {
+void TagPartitionedLogSystem::purgeOldRecoveredGenerationsCoreState(DBCoreState& newState) {
 	Version oldestGenerationRecoverAtVersion = std::min(recoveredVersion->get(), remoteRecoveredVersion->get());
 	TraceEvent("ToCoreStateOldestGenerationRecoverAtVersion")
 	    .detail("RecoveredVersion", recoveredVersion->get())
@@ -361,7 +361,7 @@ void TagPartitionedLogSystem::purgeOldRecoveredGenerations(DBCoreState& newState
 				}
 			}
 			for (int j = i; j < newState.oldTLogData.size(); ++j) {
-				TraceEvent("PurgeOldTLogGeneration")
+				TraceEvent("PurgeOldTLogGenerationCoreState", dbgid)
 				    .detail("Begin", newState.oldTLogData[j].epochBegin)
 				    .detail("End", newState.oldTLogData[j].epochEnd)
 				    .detail("Epoch", newState.oldTLogData[j].epoch)
@@ -371,6 +371,16 @@ void TagPartitionedLogSystem::purgeOldRecoveredGenerations(DBCoreState& newState
 			newState.oldTLogData.resize(i);
 			break;
 		}
+	}
+}
+
+void TagPartitionedLogSystem::purgeOldRecoveredGenerationsInMemory(const DBCoreState& newState) {
+	auto generations = newState.oldTLogData.size();
+	if (generations < oldLogData.size()) {
+		TraceEvent("PurgeOldTLogGenerationsInMemory", dbgid)
+		    .detail("OldGenerations", oldLogData.size())
+		    .detail("NewGenerations", generations);
+		oldLogData.resize(generations);
 	}
 }
 

--- a/fdbserver/include/fdbserver/LogSystem.h
+++ b/fdbserver/include/fdbserver/LogSystem.h
@@ -501,7 +501,7 @@ struct ILogSystem {
 
 	virtual bool remoteStorageRecovered() const = 0;
 
-	virtual void purgeOldRecoveredGenerations() = 0;
+	virtual void purgeOldRecoveredGenerations(DBCoreState&) = 0;
 
 	virtual Future<Void> onCoreStateChanged() const = 0;
 	// Returns if and when the output of toCoreState() would change (for example, when older logs can be discarded from

--- a/fdbserver/include/fdbserver/LogSystem.h
+++ b/fdbserver/include/fdbserver/LogSystem.h
@@ -501,7 +501,8 @@ struct ILogSystem {
 
 	virtual bool remoteStorageRecovered() const = 0;
 
-	virtual void purgeOldRecoveredGenerations(DBCoreState&) = 0;
+	virtual void purgeOldRecoveredGenerationsCoreState(DBCoreState&) = 0;
+	virtual void purgeOldRecoveredGenerationsInMemory(const DBCoreState&) = 0;
 
 	virtual Future<Void> onCoreStateChanged() const = 0;
 	// Returns if and when the output of toCoreState() would change (for example, when older logs can be discarded from

--- a/fdbserver/include/fdbserver/TagPartitionedLogSystem.actor.h
+++ b/fdbserver/include/fdbserver/TagPartitionedLogSystem.actor.h
@@ -199,7 +199,8 @@ struct TagPartitionedLogSystem final : ILogSystem, ReferenceCounted<TagPartition
 	bool remoteStorageRecovered() const final;
 
 	// Checks older TLog generations and remove no longer needed generations from the log system.
-	void purgeOldRecoveredGenerations(DBCoreState& newState) final;
+	void purgeOldRecoveredGenerationsCoreState(DBCoreState&) final;
+	void purgeOldRecoveredGenerationsInMemory(const DBCoreState&) final;
 
 	Future<Void> onCoreStateChanged() const final;
 

--- a/fdbserver/include/fdbserver/TagPartitionedLogSystem.actor.h
+++ b/fdbserver/include/fdbserver/TagPartitionedLogSystem.actor.h
@@ -199,7 +199,7 @@ struct TagPartitionedLogSystem final : ILogSystem, ReferenceCounted<TagPartition
 	bool remoteStorageRecovered() const final;
 
 	// Checks older TLog generations and remove no longer needed generations from the log system.
-	void purgeOldRecoveredGenerations() final;
+	void purgeOldRecoveredGenerations(DBCoreState& newState) final;
 
 	Future<Void> onCoreStateChanged() const final;
 


### PR DESCRIPTION
cherrypick https://github.com/apple/foundationdb/pull/12212

20250630-000131-jzhou-807a320576a5e2eb             compressed=True data_size=35964360 duration=5757872 ended=100000 fail=1 fail_fast=10 max_runs=100000 pass=99999 priority=100 remaining=0 runtime=0:54:29 sanity=False started=100000 stopped=20250630-005600 submitted=20250630-000131 timeout=5400 username=jzhou

The failed seed is external timeout using RocksDB engine, which can't be reproduced.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
