### PR TITLE
Workaround for macos x arm build: find zstd for boost and fmt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,17 +81,6 @@ include(ConfigureCompiler)
 
 include(FDBComponents)
 
-# Workaround for macOS ARM64 builds with Xcode versions newer than 14.3.x
-# Addresses "pointer not aligned" linker errors
-# You'll see lots of 'ld: warning: -ld_classic is deprecated and will be removed in a future release'
-# but it links.
-if(APPLE AND CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
-    message(STATUS "Applying macOS ARM64 linker compatibility flags for Xcode beyond 14.3.x")
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-ld_classic")
-    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-ld_classic")
-    set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -Wl,-ld_classic")
-endif()
-
 ################################################################################
 # Get repository information
 ################################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,17 @@ include(ConfigureCompiler)
 
 include(FDBComponents)
 
+# Workaround for macOS ARM64 builds with Xcode versions newer than 14.3.x
+# Addresses "pointer not aligned" linker errors
+# You'll see lots of 'ld: warning: -ld_classic is deprecated and will be removed in a future release'
+# but it links.
+if(APPLE AND CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
+    message(STATUS "Applying macOS ARM64 linker compatibility flags for Xcode beyond 14.3.x")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-ld_classic")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-ld_classic")
+    set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -Wl,-ld_classic")
+endif()
+
 ################################################################################
 # Get repository information
 ################################################################################

--- a/cmake/CompileBoost.cmake
+++ b/cmake/CompileBoost.cmake
@@ -181,6 +181,16 @@ if(WIN32)
   find_package(Boost 1.86 COMPONENTS filesystem iostreams serialization system program_options url)
   add_library(boost_target INTERFACE)
   target_link_libraries(boost_target INTERFACE Boost::boost Boost::filesystem Boost::iostreams Boost::serialization Boost::system Boost::url)
+  
+  # Add zstd library since boost::iostreams may depend on it
+  find_package(PkgConfig QUIET)
+  if(PkgConfig_FOUND)
+    pkg_check_modules(ZSTD QUIET libzstd)
+    if(ZSTD_FOUND)
+      target_link_libraries(boost_target INTERFACE ${ZSTD_LIBRARIES})
+      target_link_directories(boost_target INTERFACE ${ZSTD_LIBRARY_DIRS})
+    endif()
+  endif()
 
   add_library(boost_target_program_options INTERFACE)
   target_link_libraries(boost_target_program_options INTERFACE Boost::boost Boost::program_options)
@@ -206,6 +216,12 @@ set(FORCE_BOOST_BUILD OFF CACHE BOOL "Forces cmake to build boost and ignores an
 if(Boost_FOUND AND NOT FORCE_BOOST_BUILD)
   add_library(boost_target INTERFACE)
   target_link_libraries(boost_target INTERFACE Boost::boost Boost::context Boost::filesystem Boost::iostreams Boost::serialization Boost::system Boost::url)
+  
+  # Add zstd library since boost::iostreams depends on it when compiled with homebrew
+  find_package(PkgConfig REQUIRED)
+  pkg_check_modules(ZSTD REQUIRED libzstd)
+  target_link_libraries(boost_target INTERFACE ${ZSTD_LIBRARIES})
+  target_link_directories(boost_target INTERFACE ${ZSTD_LIBRARY_DIRS})
 
   add_library(boost_target_program_options INTERFACE)
   target_link_libraries(boost_target_program_options INTERFACE Boost::boost Boost::program_options)

--- a/cmake/CompileBoost.cmake
+++ b/cmake/CompileBoost.cmake
@@ -217,11 +217,17 @@ if(Boost_FOUND AND NOT FORCE_BOOST_BUILD)
   add_library(boost_target INTERFACE)
   target_link_libraries(boost_target INTERFACE Boost::boost Boost::context Boost::filesystem Boost::iostreams Boost::serialization Boost::system Boost::url)
   
-  # Add zstd library since boost::iostreams depends on it when compiled with homebrew
-  find_package(PkgConfig REQUIRED)
-  pkg_check_modules(ZSTD REQUIRED libzstd)
-  target_link_libraries(boost_target INTERFACE ${ZSTD_LIBRARIES})
-  target_link_directories(boost_target INTERFACE ${ZSTD_LIBRARY_DIRS})
+  # Add zstd library since boost::iostreams may depend on it when compiled with homebrew on macOS
+  if(APPLE)
+    find_package(PkgConfig QUIET)
+    if(PkgConfig_FOUND)
+      pkg_check_modules(ZSTD QUIET libzstd)
+      if(ZSTD_FOUND)
+        target_link_libraries(boost_target INTERFACE ${ZSTD_LIBRARIES})
+        target_link_directories(boost_target INTERFACE ${ZSTD_LIBRARY_DIRS})
+      endif()
+    endif()
+  endif()
 
   add_library(boost_target_program_options INTERFACE)
   target_link_libraries(boost_target_program_options INTERFACE Boost::boost Boost::program_options)

--- a/cmake/GetFmt.cmake
+++ b/cmake/GetFmt.cmake
@@ -1,5 +1,24 @@
-find_package(fmt 11.0.2 EXACT QUIET CONFIG)
+# Try to find fmt using pkg-config first (for homebrew installations)
+find_package(PkgConfig QUIET)
+if(PkgConfig_FOUND)
+  pkg_check_modules(FMT QUIET fmt)
+  if(FMT_FOUND)
+    # Create an imported target for fmt
+    add_library(fmt::fmt INTERFACE IMPORTED)
+    target_link_libraries(fmt::fmt INTERFACE ${FMT_LIBRARIES})
+    target_link_directories(fmt::fmt INTERFACE ${FMT_LIBRARY_DIRS})
+    target_include_directories(fmt::fmt INTERFACE ${FMT_INCLUDE_DIRS})
+    target_compile_options(fmt::fmt INTERFACE ${FMT_CFLAGS_OTHER})
+    set(fmt_FOUND TRUE)
+  endif()
+endif()
 
+# Fall back to standard find_package
+if(NOT fmt_FOUND)
+  find_package(fmt 11.0.2 EXACT QUIET CONFIG)
+endif()
+
+# Fall back to FetchContent if still not found
 if(NOT fmt_FOUND)
   include(FetchContent)
   FetchContent_Declare(


### PR DESCRIPTION
Find zstd lib on macosx so we pick it up even when homebrew installed so boost can compile.

Ditto for fmt.