### PR TITLE
Speed up range lock clear for bulkload cancellation

### DIFF
--- a/fdbcli/BulkLoadCommand.actor.cpp
+++ b/fdbcli/BulkLoadCommand.actor.cpp
@@ -235,7 +235,7 @@ ACTOR Future<UID> bulkLoadCommandActor(Database cx, std::vector<StringRef> token
 			return UID();
 		}
 		wait(cancelBulkLoadJob(cx, jobId));
-		fmt::println("Job {} has been cancelled.", jobId.toString());
+		fmt::println("Job {} has been cancelled. Do clearlock on the cancelled range.", jobId.toString());
 		return UID();
 
 	} else if (tokencmp(tokens[1], "status")) {

--- a/fdbserver/workloads/RangeLock.actor.cpp
+++ b/fdbserver/workloads/RangeLock.actor.cpp
@@ -485,8 +485,21 @@ struct RangeLocking : TestWorkload {
 			    .detail("Phase", "CheckDBCorrectness");
 			iteration++;
 		}
+		std::vector<std::pair<KeyRange, RangeLockState>> locks2 = wait(findExclusiveReadLockOnRange(cx, normalKeys));
+		for (const auto& lock : locks2) {
+			TraceEvent("RangeLockWorkloadProgress")
+			    .detail("Phase", "BeforeLockRelease")
+			    .detail("Range", lock.first)
+			    .detail("State", lock.second.toString());
+		}
 		wait(releaseExclusiveReadLockByUser(cx, self->rangeLockOwnerName));
 		std::vector<std::pair<KeyRange, RangeLockState>> locks = wait(findExclusiveReadLockOnRange(cx, normalKeys));
+		for (const auto& lock : locks) {
+			TraceEvent("RangeLockWorkloadProgress")
+			    .detail("Phase", "AfterLockRelease")
+			    .detail("Range", lock.first)
+			    .detail("State", lock.second.toString());
+		}
 		ASSERT(locks.empty());
 
 		TraceEvent("RangeLockWorkloadProgress").detail("Phase", "End");


### PR DESCRIPTION
100K RangeLocking:
  20250708-214821-zhewang-f6ec471ccaf15bf0           compressed=True data_size=41317720 duration=4117323 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:57:09 sanity=False started=100000 stopped=20250708-224530 submitted=20250708-214821 timeout=5400 username=zhewang
  
100K correctness:
  20250710-033955-zhewang-62e2f9a6317cdb3d           compressed=True data_size=41275330 duration=5727513 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:57:05 sanity=False started=100000 stopped=20250710-043700 submitted=20250710-033955 timeout=5400 username=zhewang
    
# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
