### PR TITLE
Prevent double-encoding of URIs in requests to S3BlobStore

### DIFF
--- a/fdbclient/S3BlobStore.actor.cpp
+++ b/fdbclient/S3BlobStore.actor.cpp
@@ -1225,6 +1225,9 @@ ACTOR Future<Reference<HTTP::IncomingResponse>> doRequest_impl(Reference<S3BlobS
 		bstore->s_stats.requests_failed++;
 		++bstore->blobStats->requestsFailed;
 
+		// Reset the resource so we don't double-encode
+		req->resource = resource;
+
 		// All errors in err are potentially retryable as well as certain HTTP response codes...
 		bool retryable = err.present() || r->code == 500 || r->code == 502 || r->code == 503 || r->code == 429;
 		// But only if our previous attempt was not the last allowable try.


### PR DESCRIPTION
# Problem

When a request to S3BlobStore fails, it can be retried. Within that loop, we set:

`req->resource = getCanonicalURI(bstore, req);`

However, if this request is a retry, this will result in double-encoding of `resource`.

# Solution

After a failure, reset `req.resource`. `req.resource` is recomputed on each loop because the set headers are reset on each loop, and `setHeaders` expects an unencoded `request.resource`.

# Example
When running `s3_backup_test` with some custom code to force retry, note that the second (retry) PUT has double-encoding:

`[5339570d0947c8ef187555aa69137a04] HTTP starting PUT /testbucket/data/ctests/test_s3_backup_and_restore/snapshots/snapshot%2C3074378%2C3074378%2C4293 ContentLen:313
[5339570d0947c8ef187555aa69137a04] HTTP starting PUT /testbucket/data/ctests/test_s3_backup_and_restore/snapshots/snapshot%252C3074378%252C3074378%252C4293 ContentLen:313`

After the fix:
`[3d478551a6e9843648e52930e65e4359] HTTP starting PUT /testbucket/data/ctests/test_s3_backup_and_restore/snapshots/snapshot%2C3061576%2C3061576%2C4293 ContentLen:313
[3d478551a6e9843648e52930e65e4359] HTTP starting PUT /testbucket/data/ctests/test_s3_backup_and_restore/snapshots/snapshot%2C3061576%2C3061576%2C4293 ContentLen:313`
