### PR TITLE
A BulkLoad Job Should Use One Range Lock

### DIFF
--- a/fdbcli/BulkLoadCommand.actor.cpp
+++ b/fdbcli/BulkLoadCommand.actor.cpp
@@ -243,7 +243,7 @@ ACTOR Future<UID> bulkLoadCommandActor(Database cx, std::vector<StringRef> token
 			return UID();
 		}
 		wait(cancelBulkLoadJob(cx, jobId));
-		fmt::println("Job {} has been cancelled. Do clearlock on the cancelled range.", jobId.toString());
+		fmt::println("Job {} has been cancelled. The job range lock has been cleared", jobId.toString());
 		return UID();
 
 	} else if (tokencmp(tokens[1], "status")) {

--- a/fdbcli/BulkLoadCommand.actor.cpp
+++ b/fdbcli/BulkLoadCommand.actor.cpp
@@ -38,9 +38,17 @@ static const std::string BULK_LOAD_STATUS_USAGE = "To get status: bulkload statu
 static const std::string BULK_LOAD_CANCEL_USAGE = "To cancel current bulkload job: bulkload cancel <JOBID>\n";
 static const std::string BULK_LOAD_HISTORY_USAGE = "To print bulkload job history: bulkload history\n";
 static const std::string BULK_LOAD_HISTORY_CLEAR_USAGE = "To clear history: bulkload history clear [all|id]\n";
-static const std::string BULK_LOAD_HELP_MESSAGE = BULK_LOAD_MODE_USAGE + BULK_LOAD_LOAD_USAGE + BULK_LOAD_STATUS_USAGE +
-                                                  BULK_LOAD_CANCEL_USAGE + BULK_LOAD_HISTORY_USAGE +
-                                                  BULK_LOAD_HISTORY_CLEAR_USAGE;
+
+static const std::string BULKLOAD_ADD_LOCK_OWNER_USAGE =
+    "To add a range lock owner: bulkload addlockowner <OWNER_UNIQUE_ID>\n";
+static const std::string BULKLOAD_PRINT_LOCK_USAGE = "To print locked ranges: bulkload printlock\n";
+static const std::string BULKLOAD_PRINT_LOCK_OWNER_USAGE = "To print range lock owners: bulkload printlockowner\n";
+static const std::string BULKLOAD_CLEAR_LOCK_USAGE = "To clear a range lock: bulkload clearlock <OWNER_UNIQUE_ID>\n";
+
+static const std::string BULK_LOAD_HELP_MESSAGE =
+    BULK_LOAD_MODE_USAGE + BULK_LOAD_LOAD_USAGE + BULK_LOAD_STATUS_USAGE + BULK_LOAD_CANCEL_USAGE +
+    BULK_LOAD_HISTORY_USAGE + BULK_LOAD_HISTORY_CLEAR_USAGE + BULKLOAD_ADD_LOCK_OWNER_USAGE +
+    BULKLOAD_PRINT_LOCK_USAGE + BULKLOAD_PRINT_LOCK_OWNER_USAGE + BULKLOAD_CLEAR_LOCK_USAGE;
 
 ACTOR Future<Void> printPastBulkLoadJob(Database cx) {
 	std::vector<BulkLoadJobState> jobs = wait(getBulkLoadJobFromHistory(cx));
@@ -301,10 +309,25 @@ ACTOR Future<UID> bulkLoadCommandActor(Database cx, std::vector<StringRef> token
 		printLongDesc(tokens[0]);
 		return UID();
 
+	} else if (tokencmp(tokens[1], "addlockowner")) {
+		// For debugging purposes and invisible to users.
+		if (tokens.size() != 3) {
+			fmt::println("{}", BULK_LOAD_STATUS_USAGE);
+			return UID();
+		}
+		std::string ownerUniqueID = tokens[2].toString();
+		if (ownerUniqueID.empty()) {
+			fmt::println("ERROR: Owner unique id cannot be empty");
+			fmt::println("{}", BULKLOAD_ADD_LOCK_OWNER_USAGE);
+			return UID();
+		}
+		wait(registerRangeLockOwner(cx, ownerUniqueID, ownerUniqueID));
+		return UID();
+
 	} else if (tokencmp(tokens[1], "printlock")) {
 		// For debugging purposes and invisible to users.
 		if (tokens.size() != 2) {
-			fmt::println("{}", BULK_LOAD_STATUS_USAGE);
+			fmt::println("{}", BULKLOAD_PRINT_LOCK_USAGE);
 			return UID();
 		}
 		std::vector<std::pair<KeyRange, RangeLockState>> lockedRanges =
@@ -326,7 +349,7 @@ ACTOR Future<UID> bulkLoadCommandActor(Database cx, std::vector<StringRef> token
 	} else if (tokencmp(tokens[1], "printlockowner")) {
 		// For debugging purposes and invisible to users.
 		if (tokens.size() != 2) {
-			fmt::println("{}", BULK_LOAD_STATUS_USAGE);
+			fmt::println("{}", BULKLOAD_PRINT_LOCK_OWNER_USAGE);
 			return UID();
 		}
 		std::vector<RangeLockOwner> owners = wait(getAllRangeLockOwners(cx));
@@ -338,7 +361,7 @@ ACTOR Future<UID> bulkLoadCommandActor(Database cx, std::vector<StringRef> token
 	} else if (tokencmp(tokens[1], "clearlock")) {
 		// For debugging purposes and invisible to users.
 		if (tokens.size() != 3) {
-			fmt::println("{}", BULK_LOAD_STATUS_USAGE);
+			fmt::println("{}", BULKLOAD_CLEAR_LOCK_USAGE);
 			return UID();
 		}
 		std::string ownerUniqueID = tokens[2].toString();

--- a/fdbclient/include/fdbclient/ManagementAPI.actor.h
+++ b/fdbclient/include/fdbclient/ManagementAPI.actor.h
@@ -175,16 +175,11 @@ ACTOR Future<int> setBulkLoadMode(Database cx, int mode);
 
 // Create a bulkload task submission transaction without commit
 // Used by ManagementAPI and bulkdumpRestore at DD
-ACTOR Future<Void> setBulkLoadSubmissionTransaction(Transaction* tr,
-                                                    BulkLoadTaskState bulkLoadTask,
-                                                    bool checkTaskExclusive = true);
+ACTOR Future<Void> setBulkLoadSubmissionTransaction(Transaction* tr, BulkLoadTaskState bulkLoadTask);
 
 // Create an bulkload task acknowledge transaction without commit
 // Used by ManagementAPI and bulkdumpRestore at DD
-ACTOR Future<Void> setBulkLoadFinalizeTransaction(Transaction* tr,
-                                                  KeyRange range,
-                                                  UID taskId,
-                                                  bool checkTaskExclusive = true);
+ACTOR Future<Void> setBulkLoadFinalizeTransaction(Transaction* tr, KeyRange range, UID taskId);
 
 // Get bulk load task for the input range and taskId
 ACTOR Future<BulkLoadTaskState> getBulkLoadTask(Transaction* tr,

--- a/fdbclient/tests/bulkload_test.sh
+++ b/fdbclient/tests/bulkload_test.sh
@@ -134,6 +134,13 @@ function bulkload {
   fi
   if ! "${local_build_dir}"/bin/fdbcli \
     -C "${local_scratch_dir}/loopback_cluster/fdb.cluster" \
+    --exec "bulkload addlockowner BulkLoad"
+  then
+    err "Bulkload add BulkLoad lockower failed"
+    return 1
+  fi
+  if ! "${local_build_dir}"/bin/fdbcli \
+    -C "${local_scratch_dir}/loopback_cluster/fdb.cluster" \
     --exec "bulkload load ${jobid} \"\" \xff \"${url}\""
   then
     err "Bulkload start failed"

--- a/fdbserver/workloads/BulkLoading.actor.cpp
+++ b/fdbserver/workloads/BulkLoading.actor.cpp
@@ -109,7 +109,8 @@ struct BulkLoading : TestWorkload {
 		loop {
 			try {
 				state Transaction tr(cx);
-				wait(setBulkLoadSubmissionTransaction(&tr, bulkLoadTask, /*checkTaskExclusive=*/false));
+				wait(setBulkLoadSubmissionTransaction(&tr, bulkLoadTask));
+				wait(takeExclusiveReadLockOnRange(&tr, bulkLoadTask.getRange(), rangeLockNameForBulkLoad));
 				wait(tr.commit());
 				TraceEvent(SevDebug, "BulkLoadingSubmitBulkLoadTask")
 				    .detail("BulkLoadTaskState", bulkLoadTask.toString());
@@ -134,7 +135,8 @@ struct BulkLoading : TestWorkload {
 		loop {
 			try {
 				state Transaction tr(cx);
-				wait(setBulkLoadFinalizeTransaction(&tr, range, taskId, /*checkTaskExclusive=*/false));
+				wait(setBulkLoadFinalizeTransaction(&tr, range, taskId));
+				wait(releaseExclusiveReadLockOnRange(&tr, range, rangeLockNameForBulkLoad));
 				wait(tr.commit());
 				TraceEvent(SevDebug, "BulkLoadingAcknowledgeBulkLoadTask")
 				    .detail("TaskID", taskId.toString())


### PR DESCRIPTION
Previously, a bulkload job requires `task count` amount of range locks. If the task count is large, a job can result in too many range lock, and the commit proxy will be come super busy, causing performance issue.

With PR, we lock a range per job. The job range is locked when the job is submitted. The range is unlocked when the job completes.

In the ctest, we need to manually create a range lock owner, otherwise, the job submission will be failed due to unknown range lock owner.

100K correctness:
  20250712-032026-zhewang-6d95af17ac9dcd38           compressed=True data_size=41276985 duration=5256693 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:59:07 sanity=False started=100000 stopped=20250712-041933 submitted=20250712-032026 timeout=5400 username=zhewang
  
100K BulkLoading:
  20250711-223237-zhewang-c2dd6d58b9eec658           compressed=True data_size=41318779 duration=2032463 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:38:53 sanity=False started=100000 stopped=20250711-231130 submitted=20250711-223237 timeout=5400 username=zhewang

100K BulkDumping:
  20250712-004600-zhewang-42e762e72d050742           compressed=True data_size=41319469 duration=3519416 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:04:01 sanity=False started=100000 stopped=20250712-015001 submitted=20250712-004600 timeout=5400 username=zhewang
      
# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
