### PR TITLE
go bindings: Skip ExampleGetClientStatus

### DIFF
--- a/bindings/go/src/fdb/fdb_test.go
+++ b/bindings/go/src/fdb/fdb_test.go
@@ -406,6 +406,8 @@ func TestGetClientStatus(t *testing.T) {
 	}
 }
 
+// Skip this example because multi-version client is currently not available in CI
+/*
 func ExampleGetClientStatus() {
 	fdb.MustAPIVersion(API_VERSION)
 	err := fdb.Options().SetDisableClientBypass()
@@ -431,3 +433,4 @@ func ExampleGetClientStatus() {
 
 	// Output:
 }
+*/


### PR DESCRIPTION
Skipping `ExampleGetClientStatus`, this example cannot run in our CI and I'm a bit surprised that the error was not caught earlier 🤔 

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
