### PR TITLE
Fix go compiling errors [release-7.3]

### DIFF
--- a/bindings/go/src/fdb/fdb_test.go
+++ b/bindings/go/src/fdb/fdb_test.go
@@ -537,7 +537,7 @@ func TestGetClientStatus(t *testing.T) {
 	}
 }
 
-func ExampleGetClientStatus() {
+func ExampleDatabase_GetClientStatus() {
 	fdb.MustAPIVersion(API_VERSION)
 	err := fdb.Options().SetDisableClientBypass()
 	if err != nil {


### PR DESCRIPTION
fdb_test.go:409:1: ExampleGetClientStatus refers to unknown identifier: GetClientStatus

cherrypick #12239

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
