### PR TITLE
Fix alignment on mac arm

### DIFF
--- a/fdbrpc/Locality.cpp
+++ b/fdbrpc/Locality.cpp
@@ -21,12 +21,12 @@
 #include "fdbrpc/Locality.h"
 
 const UID LocalityData::UNSET_ID = UID(0x0ccb4e0feddb5583, 0x010f6b77d9d10ece);
-const StringRef LocalityData::keyProcessId = "processid"_sr;
-const StringRef LocalityData::keyZoneId = "zoneid"_sr;
-const StringRef LocalityData::keyDcId = "dcid"_sr;
-const StringRef LocalityData::keyMachineId = "machineid"_sr;
-const StringRef LocalityData::keyDataHallId = "data_hall"_sr;
-const StringRef LocalityData::ExcludeLocalityPrefix = "locality_"_sr;
+alignas(8) const StringRef LocalityData::keyProcessId = "processid"_sr;
+alignas(8) const StringRef LocalityData::keyZoneId = "zoneid"_sr;
+alignas(8) const StringRef LocalityData::keyDcId = "dcid"_sr;
+alignas(8) const StringRef LocalityData::keyMachineId = "machineid"_sr;
+alignas(8) const StringRef LocalityData::keyDataHallId = "data_hall"_sr;
+alignas(8) const StringRef LocalityData::ExcludeLocalityPrefix = "locality_"_sr;
 
 ProcessClass::Fitness ProcessClass::machineClassFitness(ClusterRole role) const {
 	switch (role) {

--- a/fdbrpc/include/fdbrpc/Locality.h
+++ b/fdbrpc/include/fdbrpc/Locality.h
@@ -261,11 +261,11 @@ public:
 struct LocalityData {
 	std::map<Standalone<StringRef>, Optional<Standalone<StringRef>>> _data;
 
-	static const StringRef keyProcessId;
-	static const StringRef keyZoneId;
-	static const StringRef keyDcId;
-	static const StringRef keyMachineId;
-	static const StringRef keyDataHallId;
+	alignas(8) static const StringRef keyProcessId;
+	alignas(8) static const StringRef keyZoneId;
+	alignas(8) static const StringRef keyDcId;
+	alignas(8) static const StringRef keyMachineId;
+	alignas(8) static const StringRef keyDataHallId;
 
 public:
 	LocalityData() {}
@@ -382,7 +382,7 @@ public:
 	}
 
 	static const UID UNSET_ID;
-	static const StringRef ExcludeLocalityPrefix;
+	alignas(8) static const StringRef ExcludeLocalityPrefix;
 };
 
 static std::string describe(std::vector<LocalityData> const& items, StringRef const key, int max_items = -1) {

--- a/flow/TDMetric.cpp
+++ b/flow/TDMetric.cpp
@@ -26,15 +26,15 @@
 #include <cstddef>
 #include <string>
 
-const StringRef BaseEventMetric::metricType = "Event"_sr;
+alignas(8) const StringRef BaseEventMetric::metricType = "Event"_sr;
 template <>
-const StringRef Int64Metric::metricType = "Int64"_sr;
+alignas(8) const StringRef Int64Metric::metricType = "Int64"_sr;
 template <>
-const StringRef DoubleMetric::metricType = "Double"_sr;
+alignas(8) const StringRef DoubleMetric::metricType = "Double"_sr;
 template <>
-const StringRef BoolMetric::metricType = "Bool"_sr;
+alignas(8) const StringRef BoolMetric::metricType = "Bool"_sr;
 template <>
-const StringRef StringMetric::metricType = "String"_sr;
+alignas(8) const StringRef StringMetric::metricType = "String"_sr;
 
 std::string reduceFilename(std::string const& filename) {
 	std::string r = filename;

--- a/flow/include/flow/TDMetric.actor.h
+++ b/flow/include/flow/TDMetric.actor.h
@@ -823,7 +823,7 @@ struct BaseEventMetric : BaseMetric {
 	BaseEventMetric(MetricNameRef const& name) : BaseMetric(name) {}
 
 	// Needed for MetricUtil
-	static const StringRef metricType;
+	alignas(8) static const StringRef metricType;
 	Void getValue() const { return Void(); }
 	~BaseEventMetric() override {}
 
@@ -1271,7 +1271,7 @@ struct ContinuousMetric final : NonCopyable,
                                 MetricUtil<ContinuousMetric<T>, T>,
                                 BaseMetric {
 	// Needed for MetricUtil
-	static const StringRef metricType;
+	alignas(8) static const StringRef metricType;
 
 private:
 	EventField<TimeAndValue<T>> field;


### PR DESCRIPTION
Follow-on from #12225

Actually fix all the alignment complaints from compiler on mac osx such as the one below

`ld: building fixups: pointer not aligned at __ZN12LocalityData9keyZoneIdE+0x0 from lib/libfdbrpc.a[20](Locality.cpp.o)`