### PR TITLE
fix long-standing bug in FreeBSD getDiskStatistics

### DIFF
--- a/flow/Platform.actor.cpp
+++ b/flow/Platform.actor.cpp
@@ -1094,7 +1094,6 @@ void getDiskStatistics(std::string const& directory,
 	kvm_t* kd = nullptr;
 
 	etime = ts.tv_nsec * 1e-6;
-	;
 
 	int dn;
 	u_int64_t total_transfers_read, total_transfers_write;
@@ -1141,8 +1140,8 @@ void getDiskStatistics(std::string const& directory,
 		IOMilliSecs += (u_int64_t)ms_per_transaction;
 		reads += total_transfers_read;
 		writes += total_transfers_write;
-		writeSectors += total_blocks_read;
-		readSectors += total_blocks_write;
+		readSectors += total_blocks_read;
+		writeSectors += total_blocks_write;
 	}
 }
 


### PR DESCRIPTION
Found while looking at code in getDiskStatistics for a different internal feature request.

Testing: confirmed that this code is not compiled in our environment.  So, basically, this is entirely tested by inspection.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
