### PR TITLE
Fix MemoryLifetime workload and update remaining workloads with value as random string

### DIFF
--- a/fdbserver/workloads/MemoryLifetime.actor.cpp
+++ b/fdbserver/workloads/MemoryLifetime.actor.cpp
@@ -20,7 +20,6 @@
 
 #include "fdbclient/NativeAPI.actor.h"
 #include "fdbserver/TesterInterface.actor.h"
-#include "flow/DeterministicRandom.h"
 #include "fdbserver/workloads/workloads.actor.h"
 #include "fdbserver/workloads/BulkSetup.actor.h"
 #include "fdbclient/ReadYourWrites.h"
@@ -31,16 +30,8 @@ struct MemoryLifetime : KVWorkload {
 	double testDuration;
 	std::vector<Future<Void>> clients;
 
-	std::string valueString;
-
 	MemoryLifetime(WorkloadContext const& wcx) : KVWorkload(wcx) {
 		testDuration = getOption(options, "testDuration"_sr, 60.0);
-		valueString = std::string(maxValueBytes, '.');
-	}
-
-	Value randomValue() const override {
-		return StringRef((uint8_t*)valueString.c_str(),
-		                 deterministicRandom()->randomInt(minValueBytes, maxValueBytes + 1));
 	}
 
 	KeySelector getRandomKeySelector() const {
@@ -72,6 +63,7 @@ struct MemoryLifetime : KVWorkload {
 		state Snapshot snapshot = Snapshot::False;
 		loop {
 			try {
+				tr = ReadYourWritesTransaction(cx);
 				int op = deterministicRandom()->randomInt(0, 4);
 				if (op == 0) {
 					reverse.set(deterministicRandom()->coinflip());

--- a/fdbserver/workloads/QueuePush.actor.cpp
+++ b/fdbserver/workloads/QueuePush.actor.cpp
@@ -19,6 +19,7 @@
  */
 #include <vector>
 
+#include "fdbclient/FDBTypes.h"
 #include "fdbrpc/DDSketch.h"
 #include "fdbclient/NativeAPI.actor.h"
 #include "fdbserver/TesterInterface.actor.h"
@@ -46,7 +47,7 @@ struct QueuePushWorkload : TestWorkload {
 		actorCount = getOption(options, "actorCount"_sr, 50);
 
 		valueBytes = getOption(options, "valueBytes"_sr, 96);
-		valueString = std::string(valueBytes, 'x');
+		valueString = deterministicRandom()->randomAlphaNumeric(valueBytes);
 
 		forward = getOption(options, "forward"_sr, true);
 


### PR DESCRIPTION
Fix MemoryLifetime workload and update remaining workloads with value as random string

Changes:
- In MemoryLifetime file, transaction was not resetting in the begining of the loop. As result it was retaining the value changes from previous loop's transaction and resulting in values mismatch when value is changed to random string. Initially because of value = "..." it didn't matter as value would always be the same.
- Updated all remaining workloads as random string.

100k correctness tests completed:
`  20250715-212420-ak_random_value-13649e8ba9d8009d   compressed=True data_size=41300258 duration=5501480 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:39:50 sanity=False started=100000 stopped=20250715-230410 submitted=20250715-212420 timeout=5400 username=ak_random_value`

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
