### PR TITLE
Replace '...' with actual random data in simulation workloads (#12221)

### DIFF
--- a/fdbserver/include/fdbserver/workloads/ReadWriteWorkload.actor.h
+++ b/fdbserver/include/fdbserver/workloads/ReadWriteWorkload.actor.h
@@ -65,7 +65,6 @@ struct ReadWriteCommon : KVWorkload {
 	// two type of transaction
 	int readsPerTransactionA, writesPerTransactionA;
 	int readsPerTransactionB, writesPerTransactionB;
-	std::string valueString;
 	double alpha; // probability for run TransactionA type
 	// transaction setting
 	bool useRYW;
@@ -109,7 +108,6 @@ struct ReadWriteCommon : KVWorkload {
 		writesPerTransactionB = getOption(options, "writesPerTransactionB"_sr, 9);
 		alpha = getOption(options, "alpha"_sr, 0.1);
 
-		valueString = std::string(maxValueBytes, '.');
 		if (nodePrefix > 0) {
 			keyBytes += 16;
 		}
@@ -165,7 +163,6 @@ struct ReadWriteCommon : KVWorkload {
 
 	Standalone<KeyValueRef> operator()(uint64_t n);
 	bool shouldRecord(double checkTime = now());
-	Value randomValue();
 };
 
 #include "flow/unactorcompiler.h"

--- a/fdbserver/workloads/BulkLoad.actor.cpp
+++ b/fdbserver/workloads/BulkLoad.actor.cpp
@@ -42,7 +42,7 @@ struct BulkLoadWorkload : TestWorkload {
 		actorCount = getOption(options, "actorCount"_sr, 20);
 		writesPerTransaction = getOption(options, "writesPerTransaction"_sr, 10);
 		valueBytes = std::max(getOption(options, "valueBytes"_sr, 96), 16);
-		value = Value(std::string(valueBytes, '.'));
+		value = Value(deterministicRandom()->randomAlphaNumeric(valueBytes));
 		targetBytes = getOption(options, "targetBytes"_sr, std::numeric_limits<uint64_t>::max());
 		keyPrefix = getOption(options, "keyPrefix"_sr, ""_sr);
 		keyPrefix = unprintable(keyPrefix.toString());

--- a/fdbserver/workloads/MemoryLifetime.actor.cpp
+++ b/fdbserver/workloads/MemoryLifetime.actor.cpp
@@ -38,7 +38,7 @@ struct MemoryLifetime : KVWorkload {
 		valueString = std::string(maxValueBytes, '.');
 	}
 
-	Value randomValue() const {
+	Value randomValue() const override {
 		return StringRef((uint8_t*)valueString.c_str(),
 		                 deterministicRandom()->randomInt(minValueBytes, maxValueBytes + 1));
 	}

--- a/fdbserver/workloads/ReadWrite.actor.cpp
+++ b/fdbserver/workloads/ReadWrite.actor.cpp
@@ -323,10 +323,6 @@ void ReadWriteCommon::getMetrics(std::vector<PerfMetric>& m) {
 		m.emplace_back(format("%lld keys imported bytes/sec", ratesItr->first), ratesItr->second, Averaged::False);
 }
 
-Value ReadWriteCommon::randomValue() {
-	return StringRef((uint8_t*)valueString.c_str(), deterministicRandom()->randomInt(minValueBytes, maxValueBytes + 1));
-}
-
 Standalone<KeyValueRef> ReadWriteCommon::operator()(uint64_t n) {
 	return KeyValueRef(keyForIndex(n, false), randomValue());
 }

--- a/fdbserver/workloads/StreamingRangeRead.actor.cpp
+++ b/fdbserver/workloads/StreamingRangeRead.actor.cpp
@@ -80,17 +80,10 @@ ACTOR Future<Void> convertStream(PromiseStream<RangeResult> input, PromiseStream
 struct StreamingRangeReadWorkload : KVWorkload {
 	static constexpr auto NAME = "StreamingRangeRead";
 	double testDuration;
-	std::string valueString;
 	Future<Void> client;
 
 	StreamingRangeReadWorkload(WorkloadContext const& wcx) : KVWorkload(wcx) {
 		testDuration = getOption(options, "testDuration"_sr, 60.0);
-		valueString = std::string(maxValueBytes, '.');
-	}
-
-	Value randomValue() {
-		return StringRef((uint8_t*)valueString.c_str(),
-		                 deterministicRandom()->randomInt(minValueBytes, maxValueBytes + 1));
 	}
 
 	Standalone<KeyValueRef> operator()(uint64_t n) { return KeyValueRef(keyForIndex(n, false), randomValue()); }

--- a/fdbserver/workloads/StreamingRead.actor.cpp
+++ b/fdbserver/workloads/StreamingRead.actor.cpp
@@ -49,7 +49,7 @@ struct StreamingReadWorkload : TestWorkload {
 		nodeCount = getOption(options, "nodeCount"_sr, 100000);
 		keyBytes = std::max(getOption(options, "keyBytes"_sr, 16), 16);
 		valueBytes = std::max(getOption(options, "valueBytes"_sr, 96), 16);
-		std::string valueFormat = "%016llx" + std::string(valueBytes - 16, '.');
+		std::string valueFormat = "%016llx" + deterministicRandom()->randomAlphaNumeric(valueBytes - 16);
 		warmingDelay = getOption(options, "warmingDelay"_sr, 0.0);
 		constantValue = Value(format(valueFormat.c_str(), 42));
 		readSequentially = getOption(options, "readSequentially"_sr, false);

--- a/fdbserver/workloads/WriteBandwidth.actor.cpp
+++ b/fdbserver/workloads/WriteBandwidth.actor.cpp
@@ -33,8 +33,6 @@ struct WriteBandwidthWorkload : KVWorkload {
 
 	int keysPerTransaction;
 	double testDuration, warmingDelay, loadTime, maxInsertRate;
-	std::string valueString;
-
 	std::vector<Future<Void>> clients;
 	PerfIntCounter transactions, retries;
 	DDSketch<double> commitLatencies, GRVLatencies;
@@ -44,8 +42,6 @@ struct WriteBandwidthWorkload : KVWorkload {
 	    GRVLatencies() {
 		testDuration = getOption(options, "testDuration"_sr, 10.0);
 		keysPerTransaction = getOption(options, "keysPerTransaction"_sr, 100);
-		valueString = std::string(maxValueBytes, '.');
-
 		warmingDelay = getOption(options, "warmingDelay"_sr, 0.0);
 		maxInsertRate = getOption(options, "maxInsertRate"_sr, 1e12);
 	}
@@ -80,11 +76,6 @@ struct WriteBandwidthWorkload : KVWorkload {
 		m.emplace_back("Bytes written/sec",
 		               (writes * (keyBytes + (minValueBytes + maxValueBytes) * 0.5)) / duration,
 		               Averaged::False);
-	}
-
-	Value randomValue() {
-		return StringRef((uint8_t*)valueString.c_str(),
-		                 deterministicRandom()->randomInt(minValueBytes, maxValueBytes + 1));
 	}
 
 	Standalone<KeyValueRef> operator()(uint64_t n) { return KeyValueRef(keyForIndex(n, false), randomValue()); }


### PR DESCRIPTION
Cherry-pick #12221 
* Replace '...' with actual data

* Add zeroPaddingRatio Knob in simulation workloads.

* Refactor randomValue API to include in KVWorkload

* Addressed comments - Add const and remove valueString - not needed


100k Correctness tests Running:

` 20250716-203553-ak_7.4_randomValue-17b9377078b84932 compressed=True data_size=41224799 duration=2287 ended=71 fail_fast=10 max_runs=100000 pass=71 priority=100 remaining=1 day, 22:31:26 runtime=0:01:59 sanity=False started=180 submitted=20250716-203553 timeout=5400 username=ak_7.4_randomValue`
 
---------

Replace this text with your description here...

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
