### PR TITLE
Add 7.4 release manager to any PRs that change file(s) in 7.4 branch

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# This is the CODEOWNERS file for 7.4 branch
+# For more info about CODEOWNERS, see https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Rules below
+
+# 7.4 release manager is added to any PRs that change file(s) in 7.4 branch
+* @spraza


### PR DESCRIPTION
File comment has some more details. This is so that I accidentally do not miss any 7.4 PRs. 

Once merged, I will test by asking a colleague to create a toy PR in 7.4 and ensure I am automatically getting added as a reviewer. 

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
