### PR TITLE
When the determinacy check runs, save both sets of logs.

### DIFF
--- a/contrib/TestHarness2/README.md
+++ b/contrib/TestHarness2/README.md
@@ -1,28 +1,46 @@
 # FoundationDB TestHarness2
 
-This directory contains TestHarness2, a Python-based test harness for FoundationDB (that supercedes [`../TestHarness`](../TestHarness)), designed to be invoked by the Joshua testing framework via scripts like [`../Joshua/scripts/correctnessTest.sh`](../Joshua/scripts/correctnessTest.sh). In typical FoundationDB testing setups orchestrated by Joshua, this harness and the tests it runs are executed within Kubernetes pods.
+This directory contains TestHarness2, a Python-based test harness for FoundationDB (that supercedes [`../TestHarness`](../TestHarness)). It can be used standalone or invoked by the Joshua testing framework via scripts like [`../Joshua/scripts/correctnessTest.sh`](../Joshua/scripts/correctnessTest.sh).
 
-## TestHarness2 Operation and Outputs
-
-TestHarness2 outputs individual test results directly to stdout in XML format. Each test that runs produces a single XML summary that is immediately printed to stdout. Joshua consumes these XML outputs from stdout to track test results.
+## Quick Start
 
 Here is an example of how to run the test harness standalone:
-```
+```bash
 cd ${FOUNDATIONDB_SRC_DIR}/contrib/TestHarness2
 python3 -m test_harness.app --run-temp-dir /tmp/fdb-test-run --binary ~/build_output/bin/fdbserver --test-source-dir ../../tests/ -s 54321 --no-clean-up
 ```
+
 The above will choose a test to run at random and then output result as XML. We've passed the `--no-clean-up` so take a look at what is leftover under `/tmp/fdb-test-run`.
 
-Pass `-h` to see usage/options.
+To run a specific test, use the `--include-test-files` option:
+```bash
+python3 -m test_harness.app --run-temp-dir /tmp/fdb-test-run --binary ~/build_output/bin/fdbserver --test-source-dir ../../tests/ --include-test-files "BulkDumping.toml" -s 54321 --no-clean-up
+```
 
-Set environment variables when you start joshua and [`correctnessTest.sh`](../Joshua/scripts/correctnessTest.sh)) 
-will set options the corresponding `test_harness.app` options on invocation.
+To output results in JSON format instead of XML, use the `--output-format json` option:
+```bash
+python3 -m test_harness.app --run-temp-dir /tmp/fdb-test-run --binary ~/build_output/bin/fdbserver --test-source-dir ../../tests/ --include-test-files "BulkDumping.toml" --output-format json -s 54321 --no-clean-up
+```
+
+To run a test with determinism check enabled (100% probability instead of default 5%), use the `--unseed-check-ratio 1.0` option:
+```bash
+python3 -m test_harness.app --run-temp-dir /tmp/fdb-test-run --binary ~/build_output/bin/fdbserver --test-source-dir ../../tests/ --include-test-files "BulkDumpingS3.toml" --unseed-check-ratio 1.0 -s 54321 --no-clean-up
+```
+
+Pass `-h` to see usage/options:
+```bash
+python3 -m test_harness.app -h
+```
+
+## TestHarness2 Operation and Outputs
+
+TestHarness2 outputs individual test results directly to stdout in XML format (default) or JSON format. Each test that runs produces a single summary that is immediately printed to stdout.
 
 ### Test Execution Directory Structure
 
-TestHarness2 uses directories typically created by the calling script, [`correctnessTest.sh`](../Joshua/scripts/correctnessTest.sh).
+TestHarness2 uses directories created by a calling script such as [`correctnessTest.sh`](../Joshua/scripts/correctnessTest.sh).
 
-*   **Main Directory:** `config.run_temp_dir` which defaults as `th_run_<ENSEMBLE_ID>`
+*   **Main Directory:** `config.run_temp_dir` (the `--run-temp-dir` passed on the command line)
     *   **`app_log.txt`**: The main log file for the Python test harness application itself. Check this file first to debug issues with the harness, such as configuration errors or crashes.
 
 *   **Individual Test Directories:** `config.run_temp_dir/<test_uid>/`
@@ -33,90 +51,25 @@ TestHarness2 uses directories typically created by the calling script, [`correct
         *   `valgrind-<seed>.xml`: Valgrind output files (if running with valgrind).
         *   Other test artifacts generated during execution.
 
-### Cleanup Behavior
 
-When using [`correctnessTest.sh`](../Joshua/scripts/correctnessTest.sh), cleanup is handled by the shell script, not by TestHarness2 itself. The cleanup behavior is controlled by three environment variables:
-
-**Log Preservation Logic:**
-- **Always preserve** if `TH_PRESERVE_TEMP_DIRS_ON_EXIT=true`
-- **Preserve on success** if `TH_PRESERVE_TEMP_DIRS_ON_SUCCESS=true` AND test passed
-- **Preserve on failure** if `TH_ARCHIVE_LOGS_ON_FAILURE=true` AND (test failed OR Python crashed)
-
-## Joshua LogTool Integration
-
-TestHarness2 integrates with [`../joshua_logtool.py`](../joshua_logtool.py) to automatically upload trace logs to a FoundationDB cluster for long-term storage and analysis when test failures occur.
-
-### How joshua_logtool.py Works
-
-The [`joshua_logtool.py`](../joshua_logtool.py) script provides three main functions:
-- **Upload**: Stores trace logs and metadata in a FoundationDB cluster using a structured key-value format
-- **List**: Shows available log uploads for all tests in an ensemble
-- **Download**: Retrieves previously uploaded logs for analysis
-
-When uploading, the tool:
-1. Compresses trace log files using tar.xz compression
-2. Stores them in the FDB cluster under ensemble-specific subspaces with test UIDs
-3. Excludes simfdb directories and core files to reduce upload size
-4. Can be configured to upload all logs or only RocksDB-related logs
-
-### Automatic Integration
-
-TestHarness2 automatically invokes [`joshua_logtool.py`](../joshua_logtool.py) to upload logs when **all** of the following conditions are met:
-- A test fails (and it's not a negative test expected to fail) OR `TH_FORCE_JOSHUA_LOGTOOL=true`
-- `TH_ARCHIVE_LOGS_ON_FAILURE=true` (enables joshua_logtool integration AND preserves logs on failure)
-- `TH_ENABLE_JOSHUA_LOGTOOL=true` (explicitly enables joshua_logtool)
-
-**Note:** `TH_ARCHIVE_LOGS_ON_FAILURE` serves dual purposes - it both preserves logs when tests fail AND enables joshua_logtool integration. This ensures logs are available for upload before cleanup occurs.
-
-The individual test XML output includes a `<JoshuaLogTool>` section with status on the logtool run.
-
-### Usage Examples
-
-**Manual joshua_logtool usage:**
-```bash
-# See the general usage
-python3 contrib/joshua_logtool.py -h
-
-# List available uploads for all tests in an ensemble
-python3 contrib/joshua_logtool.py list --ensemble-id 20250710-191937-stack-4b0b134a11ad9c5b
-
-# Download logs for a specific test UID
-python3 contrib/joshua_logtool.py download --ensemble-id 20250710-191937-stack-4b0b134a11ad9c5b --test-uid 4d345bea-966a-48bf-9041-5031ecffce1d
-```
 
 ## Environment Variables
 
-TestHarness2 supports environment variables for configuration. There are two mapping systems:
-
-### Environment Variable Mapping
-
-1. **Via correctnessTest.sh**: Shell script maps specific env vars to command line args
-2. **Via TestHarness2**: Most variables follow the pattern `TH_<VARIABLE_NAME>` and are read directly by TestHarness2
+TestHarness2 supports environment variables for configuration. Most variables follow the pattern `TH_<VARIABLE_NAME>` and are read directly by TestHarness2.
 
 **Example mappings:**
-- `JOSHUA_SEED` → `--joshua-seed` (via correctnessTest.sh)
-- `TH_ARCHIVE_LOGS_ON_FAILURE=true` → `--archive-logs-on-failure` (via correctnessTest.sh)
-- `TH_PRESERVE_TEMP_DIRS_ON_EXIT=true` → Used by cleanup logic in correctnessTest.sh
-- `TH_KILL_SECONDS=3600` → `config.kill_seconds = 3600` (read directly by TestHarness2)
+- `TH_RUN_TEMP_DIR=/tmp/test` → `--run-temp-dir /tmp/test` → `config.run_temp_dir = /tmp/test`
+- `TH_KILL_SECONDS=3600` → `--kill-seconds 3600` → `config.kill_seconds = 3600`
 
 ### Environment Variables
 
 **Core Configuration:**
-- **`JOSHUA_SEED`**: Random seed for test execution (required)
 - **`TH_RUN_TEMP_DIR`**: Base directory for test execution (required)
 
 **Test Sources:**
-- **`JOSHUA_TEST_FILES_DIR`**: Directory containing test files (default: [`tests/`](../../tests/))
 - **`OLDBINDIR`**: Path to old FDB binaries directory (for restarting tests)
 
-**Log Preservation Control:**
-- **`TH_PRESERVE_TEMP_DIRS_ON_EXIT`**: Always preserve test artifacts regardless of test result (`true`/`false`, default: `false`)
-- **`TH_PRESERVE_TEMP_DIRS_ON_SUCCESS`**: Preserve test artifacts when test passes (`true`/`false`, default: `false`)
-- **`TH_ARCHIVE_LOGS_ON_FAILURE`**: Preserve test artifacts when test fails AND enable joshua_logtool integration (`true`/`false`, default: `false`)
 
-**Joshua LogTool Integration:**
-- **`TH_ENABLE_JOSHUA_LOGTOOL`**: Enable automatic log uploads (`true`/`false`, default: `false`)
-- **`TH_FORCE_JOSHUA_LOGTOOL`**: Force log uploads even for passing tests (`true`/`false`, default: `false`)
 
 **Test Execution Control:**
 - **`TH_KILL_SECONDS`**: Timeout for individual tests in seconds (default: `1800`)
@@ -125,16 +78,14 @@ TestHarness2 supports environment variables for configuration. There are two map
 - **`TH_LONG_RUNNING`**: Enable long-running test mode (`true`/`false`, default: `false`)
 
 **Optional Configuration:**
-- **`JOSHUA_CLUSTER_FILE`**: Path to FDB cluster file (for stats and joshua_logtool)
 - **`TH_RANDOM_SEED`**: Force specific random seed for debugging
 - **`TH_OUTPUT_FORMAT`**: Output format (`xml` or `json`, default: `xml`)
-- **`TH_DISABLE_ROCKSDB_CHECK`**: Disable RocksDB filtering in joshua_logtool (`true`/`false`, default: `false`)
 
 For a complete list of all variables, run: `python3 -m test_harness.app --help`
 
-## XML Output Format
+## Output Format
 
-TestHarness2 produces XML output with the following structure:
+TestHarness2 produces output in XML format (default) or JSON format. The XML output has the following structure:
 
 ```xml
 <Test TestUID="..." JoshuaSeed="..." Ok="1" Runtime="..." ...>
@@ -155,7 +106,135 @@ Key XML attributes:
 
 ## Error Handling
 
-When TestHarness2 encounters fatal errors, it outputs an error XML document to stdout and exits with code 1. The error XML includes:
+When TestHarness2 encounters fatal errors, it outputs an error document to stdout (in the same format as normal output) and exits with code 1. The error document includes:
 - Error message and type
 - Joshua seed (if available)
 - Test UID (if available)
+
+## Determinism Analysis
+
+TestHarness2 includes built-in support for analyzing determinism check failures. When a determinism check fails, the system preserves trace files from both runs for comparison.
+
+**Note:** Determinism checks are probabilistic (5% chance by default) and only occur for certain test types. Use `--unseed-check-ratio` to control the probability of determinism checks.
+
+### How It Works
+
+1. **Before determinism check**: Initial run trace files are automatically backed up
+2. **During determinism check**: The second run proceeds normally, overwriting trace files
+3. **After failed determinism check**: Both sets of traces are organized for analysis
+
+### Analysis Files
+
+When determinism checks fail, analysis files are created in:
+```
+<run_temp_dir>/determinism_analysis_{uid}/
+├── initial_run/          # Trace files from first run
+├── determinism_check/    # Trace files from second run  
+└── README.txt           # Analysis instructions
+```
+
+### Usage
+
+To analyze determinism failures:
+```bash
+python3 contrib/TestHarness2/analyze_determinism_failure.py determinism_analysis_{uid}/initial_run/ determinism_analysis_{uid}/determinism_check/
+```
+
+**Note:** The analysis script is generic but includes optimizations for S3 and bulk dumping operations. It can be used as a basis for debugging other determinism failures by modifying the `relevant_types` list in the script to include event types specific to your test.
+
+**Example:** To run BulkDumpingS3.toml with determinism check enabled (100% probability instead of default 5%):
+```bash
+python3 -m test_harness.app --run-temp-dir /tmp/fdb-test-run --binary ~/build_output/bin/fdbserver --test-source-dir ../../tests/ --include-test-files "BulkDumpingS3.toml" --unseed-check-ratio 1.0 -s 54321 --no-clean-up
+```
+
+## Joshua Integration
+
+> **Note**: The following sections are specific to Joshua testing framework integration. If you're using TestHarness2 standalone, you can skip these sections.
+
+### Joshua Context
+
+In typical FoundationDB testing setups orchestrated by Joshua, this harness and the tests it runs are executed within Kubernetes pods. Joshua consumes the XML outputs from stdout to track test results.
+
+TestHarness2 is typically invoked by the [`../Joshua/scripts/correctnessTest.sh`](../Joshua/scripts/correctnessTest.sh) script, which handles test orchestration, cleanup, and integration with the Joshua framework.
+
+Set environment variables when you start joshua, and [`correctnessTest.sh`](../Joshua/scripts/correctnessTest.sh) will map them to the corresponding `test_harness.app` options on invocation.
+
+### Joshua-Specific Environment Variables
+
+**For comprehensive documentation of all Joshua environment variables, including their TestHarness2 command-line option mappings, defaults, and usage examples, see the detailed documentation at the head of [`../Joshua/scripts/correctnessTest.sh`](../Joshua/scripts/correctnessTest.sh).**
+
+### Joshua LogTool Integration
+
+TestHarness2 integrates with [`../joshua_logtool.py`](../joshua_logtool.py) to automatically upload trace logs to a FoundationDB cluster for long-term storage and analysis when test failures occur.
+
+TODO: Integerate joshua_logtool.py into TestHarness2
+
+#### How joshua_logtool.py Works
+
+The [`joshua_logtool.py`](../joshua_logtool.py) script provides three main functions:
+- **Upload**: Stores trace logs and metadata in a FoundationDB cluster using a structured key-value format
+- **List**: Shows available log uploads for all tests in an ensemble
+- **Download**: Retrieves previously uploaded logs for analysis
+
+
+
+#### Automatic Integration
+
+TestHarness2 automatically invokes [`joshua_logtool.py`](../joshua_logtool.py) to upload logs when **all** of the following conditions are met:
+- A test fails (and it's not a negative test expected to fail) OR `TH_FORCE_JOSHUA_LOGTOOL=true`
+- `TH_ARCHIVE_LOGS_ON_FAILURE=true` (enables joshua_logtool integration AND preserves logs on failure)
+- `TH_ENABLE_JOSHUA_LOGTOOL=true` (explicitly enables joshua_logtool)
+
+**Note:** `TH_ARCHIVE_LOGS_ON_FAILURE` serves dual purposes - it both preserves logs when tests fail AND enables joshua_logtool integration. This ensures logs are available for upload before cleanup occurs.
+
+**Log Upload Behavior:** When enabled, joshua_logtool uploads logs for all tests regardless of whether they contain RocksDB events or not.
+
+**App Log Inclusion:** When `TH_INCLUDE_APP_LOGS=true` is set, joshua_logtool will also include diagnostic files from the top-level directory:
+- `app_log.txt` - Main application log file
+- `python_app_stdout.log` - Python stdout log (Joshua integration)
+- `python_app_stderr.log` - Python stderr log (Joshua integration)
+
+This is useful for debugging test runner crashes where the test produces minimal output instead of a proper XML report.
+
+The individual test XML output includes a `<JoshuaLogTool>` section with status on the logtool run.
+
+#### Environment Variables
+
+**Required for joshua_logtool integration:**
+- `TH_ARCHIVE_LOGS_ON_FAILURE=true` - Enables log archiving and joshua_logtool integration
+- `TH_ENABLE_JOSHUA_LOGTOOL=true` - Explicitly enables joshua_logtool functionality
+
+**Optional joshua_logtool settings:**
+- `TH_FORCE_JOSHUA_LOGTOOL=true` - Force upload even if test passes (default: false)
+- `TH_INCLUDE_APP_LOGS=true` - Include app_log.txt and python_std* files from parent directory (default: false)
+
+#### Usage Examples
+
+**Basic usage (upload RocksDB tests on failure):**
+```bash
+TH_ARCHIVE_LOGS_ON_FAILURE=true TH_ENABLE_JOSHUA_LOGTOOL=true python3 -m test_harness.app --include-test-files "BulkDumpingS3.toml"
+```
+
+
+
+**Force upload (even on success):**
+```bash
+TH_ARCHIVE_LOGS_ON_FAILURE=true TH_ENABLE_JOSHUA_LOGTOOL=true TH_FORCE_JOSHUA_LOGTOOL=true python3 -m test_harness.app --include-test-files "BulkDumpingS3.toml"
+```
+
+**Include app logs for debugging crashes:**
+```bash
+TH_ARCHIVE_LOGS_ON_FAILURE=true TH_ENABLE_JOSHUA_LOGTOOL=true TH_INCLUDE_APP_LOGS=true python3 -m test_harness.app --include-test-files "BulkDumpingS3.toml"
+```
+
+**Manual joshua_logtool usage:**
+```bash
+# See the general usage
+python3 contrib/joshua_logtool.py -h
+
+# List available uploads for all tests in an ensemble
+python3 contrib/joshua_logtool.py list --ensemble-id 20250710-191937-stack-4b0b134a11ad9c5b
+
+# Download logs for a specific test UID
+python3 contrib/joshua_logtool.py download --ensemble-id 20250710-191937-stack-4b0b134a11ad9c5b --test-uid 4d345bea-966a-48bf-9041-5031ecffce1d
+```

--- a/contrib/TestHarness2/analyze_determinism_failure.py
+++ b/contrib/TestHarness2/analyze_determinism_failure.py
@@ -1,0 +1,434 @@
+#!/usr/bin/env python3
+"""
+Script to analyze FoundationDB determinism check failures.
+
+This script compares trace files from two runs of the same test to identify
+where determinism broke down. It focuses on S3 operations, bulk dump events,
+and other timing-sensitive operations that commonly cause determinism failures.
+
+Usage: python3 analyze_determinism_failure.py <initial_run_dir> <determinism_check_dir>
+"""
+
+import json
+import sys
+import os
+import re
+from pathlib import Path
+from collections import defaultdict
+
+def parse_trace_file(file_path):
+    """Parse a trace file and extract relevant events."""
+    events = []
+    
+    try:
+        with open(file_path, 'r') as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                    
+                try:
+                    event = json.loads(line)
+                    events.append(event)
+                except json.JSONDecodeError:
+                    # Skip non-JSON lines
+                    continue
+    except FileNotFoundError:
+        print(f"Warning: File not found: {file_path}")
+        return []
+    
+    return events
+
+def extract_key_events(events):
+    """Extract events that are relevant for determinism analysis."""
+    key_events = []
+    
+    # Events we care about for determinism
+    relevant_types = {
+        'BulkDumpDeterministicVersion',
+        'BulkDumpingWorkLoadTransportMethod', 
+        'S3ClientCopyUpFileEnd',
+        'S3ClientCopyDownFileEnd',
+        'S3ClientDeleteResourceEnd',
+        'BulkDumpingWorkload',
+        'WorkloadComplete',
+        'TestResults',
+        'ParseS3XMLResponse',
+        'BulkDumpJobSpawnRange',
+        'BulkDumpDoTaskStart',
+        'BulkDumpDoTaskComplete',
+        'BulkDumpDoTaskError'
+    }
+    
+    for event in events:
+        event_type = event.get('Type', '')
+        
+        # Include relevant event types
+        if event_type in relevant_types:
+            key_events.append(event)
+            continue
+            
+        # Include events with S3-related details
+        if any(key in event for key in ['S3URL', 'S3Error', 'Bucket', 'Object']):
+            key_events.append(event)
+            continue
+            
+        # Include events with version information
+        if any(key in event for key in ['Version', 'DeterministicVersion', 'BaseVersion']):
+            key_events.append(event)
+            continue
+    
+    return key_events
+
+def normalize_event(event):
+    """Normalize an event for comparison by removing timing-specific fields."""
+    normalized = event.copy()
+    
+    # Remove fields that are expected to differ between runs
+    fields_to_remove = [
+        'Time', 'DateTime', 'ActualTime', 'Timestamp',
+        'Machine', 'LogGroup', 'ID', 'ThreadID',
+        'Duration'  # We'll handle this specially
+    ]
+    
+    for field in fields_to_remove:
+        normalized.pop(field, None)
+    
+    # Keep Duration but round it to reduce noise
+    if 'Duration' in event:
+        try:
+            duration = float(event['Duration'])
+            normalized['Duration'] = round(duration, 3)  # Round to milliseconds
+        except (ValueError, TypeError):
+            pass
+    
+    return normalized
+
+def compare_event_sequences(events1, events2, label1="Run 1", label2="Run 2"):
+    """Compare two sequences of events and identify differences."""
+    print(f"\n=== Comparing {label1} vs {label2} ===")
+    
+    # Group events by type
+    events1_by_type = defaultdict(list)
+    events2_by_type = defaultdict(list)
+    
+    for event in events1:
+        events1_by_type[event.get('Type', 'Unknown')].append(normalize_event(event))
+    
+    for event in events2:
+        events2_by_type[event.get('Type', 'Unknown')].append(normalize_event(event))
+    
+    all_types = set(events1_by_type.keys()) | set(events2_by_type.keys())
+    
+    differences_found = False
+    
+    for event_type in sorted(all_types):
+        events1_type = events1_by_type[event_type]
+        events2_type = events2_by_type[event_type]
+        
+        if len(events1_type) != len(events2_type):
+            print(f"\n❌ {event_type}: Different counts - {label1}: {len(events1_type)}, {label2}: {len(events2_type)}")
+            differences_found = True
+            continue
+        
+        # Compare each event of this type
+        for i, (e1, e2) in enumerate(zip(events1_type, events2_type)):
+            if e1 != e2:
+                print(f"\n❌ {event_type} #{i+1}: Events differ")
+                
+                # Show specific differences
+                all_keys = set(e1.keys()) | set(e2.keys())
+                for key in sorted(all_keys):
+                    val1 = e1.get(key, '<missing>')
+                    val2 = e2.get(key, '<missing>')
+                    if val1 != val2:
+                        print(f"  {key}: {label1}={val1}, {label2}={val2}")
+                
+                differences_found = True
+            else:
+                print(f"✅ {event_type} #{i+1}: Match")
+    
+    if not differences_found:
+        print(f"\n✅ All events match between {label1} and {label2}!")
+    
+    return not differences_found
+
+def extract_s3_operations(events):
+    """Extract S3 operations and their file names."""
+    s3_ops = []
+    
+    for event in events:
+        # Look for S3 file operations
+        if 'S3URL' in event or 'Object' in event:
+            op_info = {
+                'Type': event.get('Type', 'Unknown'),
+                'Time': event.get('Time', 0),
+                'Object': event.get('Object', ''),
+                'S3URL': event.get('S3URL', ''),
+                'Duration': event.get('Duration', 0)
+            }
+            
+            # Extract filename from URL or Object
+            filename = ''
+            if op_info['Object']:
+                filename = op_info['Object']
+            elif op_info['S3URL']:
+                # Extract filename from URL
+                match = re.search(r'/([^/]+)$', op_info['S3URL'])
+                if match:
+                    filename = match.group(1)
+            
+            op_info['Filename'] = filename
+            s3_ops.append(op_info)
+    
+    return s3_ops
+
+def analyze_s3_operations(events1, events2):
+    """Analyze S3 operations for determinism issues."""
+    print("\n=== S3 Operations Analysis ===")
+    
+    s3_ops1 = extract_s3_operations(events1)
+    s3_ops2 = extract_s3_operations(events2)
+    
+    print(f"Run 1: {len(s3_ops1)} S3 operations")
+    print(f"Run 2: {len(s3_ops2)} S3 operations")
+    
+    # Extract unique filenames
+    files1 = set(op['Filename'] for op in s3_ops1 if op['Filename'])
+    files2 = set(op['Filename'] for op in s3_ops2 if op['Filename'])
+    
+    print(f"\nFiles in Run 1: {sorted(files1)}")
+    print(f"Files in Run 2: {sorted(files2)}")
+    
+    if files1 == files2:
+        print("✅ Same files used in both runs")
+    else:
+        print("❌ Different files used!")
+        print(f"Only in Run 1: {files1 - files2}")
+        print(f"Only in Run 2: {files2 - files1}")
+    
+    return files1 == files2
+
+def compare_early_events(initial_events, determinism_events, num_events=200):
+    """Compare the first N events from each run to see if they start identically."""
+    print(f"\n=== Comparing First {num_events} Events ===")
+    
+    if len(initial_events) < num_events:
+        print(f"Warning: Initial run only has {len(initial_events)} events")
+        num_events = min(num_events, len(initial_events))
+    
+    if len(determinism_events) < num_events:
+        print(f"Warning: Determinism check only has {len(determinism_events)} events")
+        num_events = min(num_events, len(determinism_events))
+    
+    differences = []
+    
+    for i in range(num_events):
+        event1 = initial_events[i]
+        event2 = determinism_events[i]
+        
+        # Compare event types
+        type1 = event1.get('Type', 'Unknown')
+        type2 = event2.get('Type', 'Unknown')
+        
+        if type1 != type2:
+            differences.append(f"Event {i}: Type differs - Run1: {type1}, Run2: {type2}")
+            continue
+            
+        # For timing-sensitive events, compare key fields
+        if type1 in ['BulkDumpingWorkLoadSetKey', 'BulkDumpingWorkLoadTransportMethod', 'S3ClientCopyUpFileEnd']:
+            # Compare all fields except timing-related ones
+            fields_to_compare = set(event1.keys()) | set(event2.keys())
+            timing_fields = {'Time', 'DateTime', 'Machine', 'LogGroup', 'Roles'}
+            
+            for field in fields_to_compare - timing_fields:
+                val1 = event1.get(field)
+                val2 = event2.get(field)
+                if val1 != val2:
+                    differences.append(f"Event {i} ({type1}): {field} differs - Run1: {val1}, Run2: {val2}")
+    
+    if differences:
+        print(f"❌ Found {len(differences)} differences in first {num_events} events:")
+        for diff in differences[:10]:  # Show first 10 differences
+            print(f"  {diff}")
+        if len(differences) > 10:
+            print(f"  ... and {len(differences) - 10} more differences")
+        return False
+    else:
+        print(f"✅ First {num_events} events are identical!")
+        return True
+
+def find_divergence_point(initial_events, determinism_events, max_events=None):
+    """Find the exact point where the two runs diverge."""
+    if max_events is None:
+        max_events = max(len(initial_events), len(determinism_events))
+    
+    print(f"\n=== Finding Exact Divergence Point (up to {max_events} events) ===")
+    
+    max_compare = min(len(initial_events), len(determinism_events), max_events)
+    
+    for i in range(max_compare):
+        event1 = initial_events[i]
+        event2 = determinism_events[i]
+        
+        # Compare event types first
+        type1 = event1.get('Type', 'Unknown')
+        type2 = event2.get('Type', 'Unknown')
+        
+        if type1 != type2:
+            print(f"🎯 FIRST DIVERGENCE at event {i}: Type differs")
+            print(f"  Run 1: {type1}")
+            print(f"  Run 2: {type2}")
+            
+            # Show context around divergence
+            print(f"\n📋 Context around divergence (events {max(0, i-3)} to {min(max_compare, i+3)}):")
+            for j in range(max(0, i-3), min(max_compare, i+4)):
+                marker = " 🔥" if j == i else "   "
+                if j < len(initial_events):
+                    print(f"  {j:3d}{marker} Run1: {initial_events[j].get('Type', 'Unknown')}")
+                if j < len(determinism_events):
+                    print(f"      {marker} Run2: {determinism_events[j].get('Type', 'Unknown')}")
+                if j < len(initial_events) and j < len(determinism_events):
+                    print()
+            
+            return i
+            
+        # For same event types, compare key fields (excluding timing)
+        if type1 in ['BulkDumpingWorkLoadSetKey', 'BulkDumpingWorkLoadTransportMethod', 'S3ClientCopyUpFileEnd', 'S3BlobStoreBadRequest']:
+            fields_to_compare = set(event1.keys()) | set(event2.keys())
+            timing_fields = {'Time', 'DateTime', 'Machine', 'LogGroup', 'Roles'}
+            
+            for field in fields_to_compare - timing_fields:
+                val1 = event1.get(field)
+                val2 = event2.get(field)
+                if val1 != val2:
+                    print(f"🎯 FIRST DIVERGENCE at event {i}: {type1}.{field} differs")
+                    print(f"  Run 1: {val1}")
+                    print(f"  Run 2: {val2}")
+                    return i
+    
+    print(f"✅ All {max_compare} events are identical!")
+    if len(initial_events) != len(determinism_events):
+        print(f"⚠️  However, total event counts differ: {len(initial_events)} vs {len(determinism_events)}")
+    
+    return -1  # No divergence found
+
+def analyze_duplication_pattern(initial_events, determinism_events):
+    """Analyze where the duplication pattern starts."""
+    print(f"\n=== Analyzing Duplication Pattern ===")
+    
+    # Look for where Run 2 starts having "extra" events
+    len1, len2 = len(initial_events), len(determinism_events)
+    print(f"Total events: Run 1 = {len1}, Run 2 = {len2}")
+    
+    if len2 < len1:
+        print("⚠️ Run 2 has fewer events than Run 1 - unusual pattern")
+        return
+    
+    # Check if Run 2 has roughly 2x the events
+    ratio = len2 / len1 if len1 > 0 else 0
+    print(f"Event count ratio: {ratio:.2f}x")
+    
+    if 1.8 <= ratio <= 2.2:
+        print("🎯 Perfect ~2x duplication pattern detected!")
+        
+        # Estimate where duplication starts
+        duplication_start = len1
+        print(f"💡 Hypothesis: Duplication likely starts around event {duplication_start}")
+        print(f"   Run 1 ends at event {len1}")
+        print(f"   Run 2 continues with {len2 - len1} additional events")
+        
+        # Look at the events right at the boundary
+        if duplication_start < len2:
+            print(f"\n📋 Events around the duplication boundary:")
+            start_idx = max(0, duplication_start - 5)
+            end_idx = min(len2, duplication_start + 10)
+            
+            for i in range(start_idx, end_idx):
+                marker = " 🔥" if i == duplication_start else "   "
+                if i < len1:
+                    print(f"  {i:4d}{marker} Run1&2: {initial_events[i].get('Type', 'Unknown')}")
+                else:
+                    print(f"  {i:4d}{marker} Run2 only: {determinism_events[i].get('Type', 'Unknown')}")
+    else:
+        print(f"⚠️ Not a simple 2x pattern - ratio is {ratio:.2f}x")
+
+def main():
+    if len(sys.argv) < 3:
+        print("Usage: python3 analyze_determinism_failure.py <initial_run_trace_dir> <determinism_check_trace_dir>")
+        print("Example: python3 analyze_determinism_failure.py trace_initial_run trace_determinism_check")
+        sys.exit(1)
+    
+    initial_dir = Path(sys.argv[1])
+    determinism_dir = Path(sys.argv[2])
+    
+    print(f"Analyzing determinism logs:")
+    print(f"  Initial run: {initial_dir}")
+    print(f"  Determinism check: {determinism_dir}")
+    
+    # Find trace files
+    initial_traces = list(initial_dir.glob("*.json"))
+    determinism_traces = list(determinism_dir.glob("*.json"))
+    
+    if not initial_traces:
+        print(f"No trace files found in {initial_dir}")
+        sys.exit(1)
+    
+    if not determinism_traces:
+        print(f"No trace files found in {determinism_dir}")
+        sys.exit(1)
+    
+    print(f"Found {len(initial_traces)} initial trace files")
+    print(f"Found {len(determinism_traces)} determinism check trace files")
+    
+    # Parse all events
+    initial_events = []
+    for trace_file in initial_traces:
+        initial_events.extend(parse_trace_file(trace_file))
+    
+    determinism_events = []
+    for trace_file in determinism_traces:
+        determinism_events.extend(parse_trace_file(trace_file))
+    
+    print(f"Parsed {len(initial_events)} events from initial run")
+    print(f"Parsed {len(determinism_events)} events from determinism check")
+    
+    # Compare early events to see if runs start identically
+    early_match = compare_early_events(initial_events, determinism_events)
+    
+    # Find the exact divergence point
+    divergence_point = find_divergence_point(initial_events, determinism_events)
+    
+    # Analyze duplication pattern
+    analyze_duplication_pattern(initial_events, determinism_events)
+    
+    # Extract key events
+    key_initial = extract_key_events(initial_events)
+    key_determinism = extract_key_events(determinism_events)
+    
+    print(f"Extracted {len(key_initial)} key events from initial run")
+    print(f"Extracted {len(key_determinism)} key events from determinism check")
+    
+    # Analyze S3 operations
+    s3_match = analyze_s3_operations(key_initial, key_determinism)
+    
+    # Compare event sequences
+    events_match = compare_event_sequences(key_initial, key_determinism, "Initial Run", "Determinism Check")
+    
+    # Summary
+    print("\n=== SUMMARY ===")
+    if early_match and s3_match and events_match:
+        print("✅ DETERMINISM CHECK PASSED: All events match!")
+    else:
+        print("❌ DETERMINISM CHECK FAILED: Differences found")
+        if not early_match:
+            print("  - Early events differ (runs diverge from the start)")
+        if divergence_point >= 0:
+            print(f"  - First divergence at event {divergence_point}")
+        if not s3_match:
+            print("  - S3 operations differ")
+        if not events_match:
+            print("  - Event sequences differ")
+
+if __name__ == "__main__":
+    main()

--- a/contrib/TestHarness2/test_harness/run.py
+++ b/contrib/TestHarness2/test_harness/run.py
@@ -419,7 +419,7 @@ class TestRun:
         # First try: relative to this script's location (contrib/TestHarness2/test_harness/run.py)
         script_dir = Path(__file__).parent.parent.parent  # Go up 3 levels to repo root
         joshua_logtool_script = script_dir / "contrib" / "joshua_logtool.py"
-        
+
         if not joshua_logtool_script.exists():
             # Second try: contrib directory relative to current working directory
             joshua_logtool_script = Path("contrib/joshua_logtool.py")
@@ -429,18 +429,26 @@ class TestRun:
                 if not joshua_logtool_script.exists():
                     return {"stdout": "", "stderr": "joshua_logtool.py not found", "exit_code": -1, "tool_skipped": True}
 
+        # Debug: Print paths to understand directory structure
+        print(f"DEBUG: self.temp_path = {self.temp_path}", file=sys.stderr)
+        print(f"DEBUG: self.temp_path.parent = {self.temp_path.parent}", file=sys.stderr)
+        print(f"DEBUG: self.temp_path.parent.parent = {self.temp_path.parent.parent}", file=sys.stderr)
+        
+        # The app logs (app_log.txt, python_app_stdout.log, python_app_stderr.log) are in the test-specific directory
+        # which is self.temp_path.parent, not the top-level directory
+        test_specific_dir = self.temp_path.parent
+        print(f"DEBUG: test_specific_dir (self.temp_path.parent) = {test_specific_dir}", file=sys.stderr)
+        
         command = [
             sys.executable,
             str(joshua_logtool_script),
             "upload",
             "--test-uid", str(self.uid),
-            "--log-directory", str(self.temp_path.parent)
+            "--log-directory", str(test_specific_dir)
         ]
-        
-        # Add appropriate upload flag based on TH_DISABLE_ROCKSDB_CHECK setting
-        disable_rocksdb_check = os.getenv("TH_DISABLE_ROCKSDB_CHECK", "false").lower() in ("true", "1", "yes")
-        if not disable_rocksdb_check:
-            command.append("--check-rocksdb")
+
+        # Note: joshua_logtool now uploads all tests by default when enabled
+        # No RocksDB filtering is applied unless explicitly requested
         result = subprocess.run(command, capture_output=True, text=True)
         return {
             "stdout": result.stdout,
@@ -539,44 +547,8 @@ class TestRun:
         self.summary.valgrind_out_file = valgrind_file
         self.summary.error_out = err_out
         self.summary.summarize(self.temp_path, " ".join(command))
-        # Run JoshuaLogTool if needed
-        force_joshua_logtool = os.getenv("TH_FORCE_JOSHUA_LOGTOOL", "false").lower() in ("true", "1", "yes")
-        if not self.summary.is_negative_test and (not self.summary.ok() or force_joshua_logtool):
-            archive_logs_on_failure = os.getenv("TH_ARCHIVE_LOGS_ON_FAILURE", "false").lower() in ("true", "1", "yes")
-            enable_joshua_logtool = os.getenv("TH_ENABLE_JOSHUA_LOGTOOL", "false").lower() in ("true", "1", "yes")
-            
-            if not archive_logs_on_failure or not enable_joshua_logtool:
-                child = SummaryTree("JoshuaLogTool")
-                child.attributes["ExitCode"] = "0"
-                child.attributes["Note"] = "Skipped - joshua_logtool not enabled"
-                self.summary.out.append(child)
-            else:
-                try:
-                    logtool_result = self._run_joshua_logtool()
-                except Exception as e:
-                    logtool_result = {
-                        "stdout": "",
-                        "stderr": f"joshua_logtool failed: {e}",
-                        "exit_code": -1,
-                        "tool_skipped": True
-                    }
-                
-                child = SummaryTree("JoshuaLogTool")
-                child.attributes["ExitCode"] = str(logtool_result["exit_code"])
-                if not logtool_result.get("tool_skipped", False):
-                    if logtool_result["exit_code"] == 0:
-                        stderr_lines = logtool_result["stderr"].split("\n") if logtool_result["stderr"] else []
-                        success_lines = [line for line in stderr_lines if "SUCCESS - Uploaded" in line]
-                        if success_lines:
-                            child.attributes["Note"] = success_lines[-1].replace("JOSHUA_LOGTOOL: ", "")
-                        else:
-                            child.attributes["Note"] = "Upload completed"
-                    else:
-                        child.attributes["StdOut"] = logtool_result["stdout"]
-                        child.attributes["StdErr"] = logtool_result["stderr"]
-                else:
-                    child.attributes["Note"] = logtool_result["stderr"]
-                self.summary.out.append(child)
+        # Note: joshua_logtool is called after determinism analysis file organization
+        # in the run_tests method to ensure files are properly organized
 
         return self.summary.ok()
 
@@ -603,6 +575,8 @@ class TestRunner:
         self.binary_chooser = OldBinaries()
         self.test_picker = TestPicker(self.test_path, self.binary_chooser.binaries)
 
+
+
     def backup_sim_dir(self, seed: int):
         temp_dir = config.run_temp_dir / str(self.uid)
         src_dir = temp_dir / "simfdb"
@@ -618,6 +592,150 @@ class TestRunner:
         dest_dir = temp_dir / "simfdb"
         shutil.rmtree(dest_dir)
         shutil.move(src_dir, dest_dir)
+
+
+    def backup_trace_files(self, seed: int):
+        """Backup trace files before determinism check to preserve initial run traces."""
+        temp_dir = config.run_temp_dir / str(self.uid)
+        trace_files = list(temp_dir.glob("trace.*.json"))
+        
+        if not trace_files:
+            return
+            
+        # Create backup directory for initial run traces
+        backup_dir = temp_dir / f"trace_backup_{seed}"
+        backup_dir.mkdir(exist_ok=True)
+        
+        # Move trace files to backup (not copy) to clear the main directory
+        for trace_file in trace_files:
+            shutil.move(trace_file, backup_dir / trace_file.name)
+            
+        print(f"Moved {len(trace_files)} trace files to backup {backup_dir}", file=sys.stderr)
+
+    def restore_trace_files(self, seed: int):
+        """Restore trace files after determinism check for analysis."""
+        temp_dir = config.run_temp_dir / str(self.uid)
+        backup_dir = temp_dir / f"trace_backup_{seed}"
+        
+        if not backup_dir.exists():
+            return
+            
+        # Create analysis directory structure
+        analysis_dir = temp_dir / f"determinism_analysis_{self.uid}"
+        analysis_dir.mkdir(exist_ok=True)
+        
+        initial_run_dir = analysis_dir / "initial_run"
+        determinism_check_dir = analysis_dir / "determinism_check"
+        
+        initial_run_dir.mkdir(exist_ok=True)
+        determinism_check_dir.mkdir(exist_ok=True)
+        
+        # Get initial trace names before moving them
+        initial_trace_names = {f.name for f in backup_dir.glob("trace.*.json")}
+        
+        # Move backed up traces to initial_run directory
+        for trace_file in backup_dir.glob("trace.*.json"):
+            shutil.move(trace_file, initial_run_dir / trace_file.name)
+        
+        # Move ONLY the determinism check trace files to determinism_check directory
+        # These are the NEW files from the determinism check run
+        current_traces = list(temp_dir.glob("trace.*.json"))
+        
+        for trace_file in current_traces:
+            # Only move files that are NOT duplicates of the initial run
+            if trace_file.name not in initial_trace_names:
+                shutil.move(trace_file, determinism_check_dir / trace_file.name)
+            else:
+                # This is a duplicate of an initial run file - check if it's identical
+                initial_file = initial_run_dir / trace_file.name
+                if initial_file.exists():
+                    # Compare file contents
+                    if trace_file.read_bytes() == initial_file.read_bytes():
+                        # Identical file - remove the duplicate
+                        trace_file.unlink()
+                        print(f"Removed identical duplicate trace file: {trace_file.name}", file=sys.stderr)
+                    else:
+                        # Same name but different content - keep it with a new name
+                        new_name = f"determinism_check_{trace_file.name}"
+                        shutil.move(trace_file, determinism_check_dir / new_name)
+                        print(f"Renamed non-identical duplicate: {trace_file.name} -> {new_name}", file=sys.stderr)
+                else:
+                    # Shouldn't happen, but move it anyway
+                    shutil.move(trace_file, determinism_check_dir / trace_file.name)
+        
+        # Clean up backup directory
+        shutil.rmtree(backup_dir)
+        
+        # Create analysis instructions
+        readme_file = analysis_dir / "README.txt"
+        with open(readme_file, 'w') as f:
+            f.write(f"DETERMINISM CHECK FAILED - Analysis Files\n")
+            f.write(f"==========================================\n\n")
+            f.write(f"Test UID: {self.uid}\n")
+            f.write(f"Seed: {seed}\n\n")
+            f.write(f"Directory Structure:\n")
+            f.write(f"- initial_run/: Trace files from the first run\n")
+            f.write(f"- determinism_check/: Trace files from the determinism check (second run only)\n\n")
+            f.write(f"To analyze the determinism failure:\n")
+            f.write(f"python3 contrib/TestHarness2/analyze_determinism_failure.py {initial_run_dir} {determinism_check_dir}\n\n")
+        
+        print(f"Determinism check failed. Analysis files created in {analysis_dir}", file=sys.stderr)
+
+    def _run_joshua_logtool_for_test(self, test_run):
+        """Run joshua_logtool for a test run after file organization is complete."""
+        print(f"DEBUG: _run_joshua_logtool_for_test called for test {test_run.uid}", file=sys.stderr)
+        print(f"DEBUG: test_run.summary.is_negative_test = {test_run.summary.is_negative_test}", file=sys.stderr)
+        print(f"DEBUG: test_run.summary.ok() = {test_run.summary.ok()}", file=sys.stderr)
+        
+        force_joshua_logtool = os.getenv("TH_FORCE_JOSHUA_LOGTOOL", "false").lower() in ("true", "1", "yes")
+        archive_logs_on_failure = os.getenv("TH_ARCHIVE_LOGS_ON_FAILURE", "false").lower() in ("true", "1", "yes")
+        enable_joshua_logtool = os.getenv("TH_ENABLE_JOSHUA_LOGTOOL", "false").lower() in ("true", "1", "yes")
+        
+        print(f"DEBUG: TH_FORCE_JOSHUA_LOGTOOL = {force_joshua_logtool}", file=sys.stderr)
+        print(f"DEBUG: TH_ARCHIVE_LOGS_ON_FAILURE = {archive_logs_on_failure}", file=sys.stderr)
+        print(f"DEBUG: TH_ENABLE_JOSHUA_LOGTOOL = {enable_joshua_logtool}", file=sys.stderr)
+        
+        if not test_run.summary.is_negative_test and (not test_run.summary.ok() or force_joshua_logtool):
+            print(f"DEBUG: Conditions met for joshua_logtool execution", file=sys.stderr)
+            
+            if not archive_logs_on_failure or not enable_joshua_logtool:
+                print(f"DEBUG: joshua_logtool skipped - archive_logs_on_failure={archive_logs_on_failure}, enable_joshua_logtool={enable_joshua_logtool}", file=sys.stderr)
+                child = SummaryTree("JoshuaLogTool")
+                child.attributes["ExitCode"] = "0"
+                child.attributes["Note"] = "Skipped - joshua_logtool not enabled"
+                test_run.summary.out.append(child)
+            else:
+                print(f"DEBUG: Calling joshua_logtool", file=sys.stderr)
+                try:
+                    logtool_result = test_run._run_joshua_logtool()
+                    print(f"DEBUG: joshua_logtool result: {logtool_result}", file=sys.stderr)
+                except Exception as e:
+                    print(f"DEBUG: joshua_logtool exception: {e}", file=sys.stderr)
+                    logtool_result = {
+                        "stdout": "",
+                        "stderr": f"joshua_logtool failed: {e}",
+                        "exit_code": -1,
+                        "tool_skipped": True
+                    }
+
+                child = SummaryTree("JoshuaLogTool")
+                child.attributes["ExitCode"] = str(logtool_result["exit_code"])
+                if not logtool_result.get("tool_skipped", False):
+                    if logtool_result["exit_code"] == 0:
+                        stderr_lines = logtool_result["stderr"].split("\n") if logtool_result["stderr"] else []
+                        success_lines = [line for line in stderr_lines if "SUCCESS - Uploaded" in line]
+                        if success_lines:
+                            child.attributes["Note"] = success_lines[-1].replace("JOSHUA_LOGTOOL: ", "")
+                        else:
+                            child.attributes["Note"] = "Upload completed"
+                    else:
+                        child.attributes["StdOut"] = logtool_result["stdout"]
+                        child.attributes["StdErr"] = logtool_result["stderr"]
+                else:
+                    child.attributes["Note"] = logtool_result["stderr"]
+                test_run.summary.out.append(child)
+        else:
+            print(f"DEBUG: Conditions NOT met for joshua_logtool execution", file=sys.stderr)
 
     def run_tests(
         self, test_files: List[Path], seed: int, test_picker: TestPicker
@@ -656,6 +774,11 @@ class TestRunner:
                 and run.summary.unseed >= 0
             ):
                 run.summary.out.append(run.summary.list_simfdb())
+            
+            # Run joshua_logtool for regular test failures (non-determinism)
+            if not result:
+                self._run_joshua_logtool_for_test(run)
+            
             run.summary.out.dump(sys.stdout)
             if not result:
                 return False
@@ -665,6 +788,9 @@ class TestRunner:
                 and run.summary.unseed is not None
                 and run.summary.unseed >= 0
             ):
+                # Backup trace files before determinism check
+                self.backup_trace_files(seed + count)
+                
                 run2 = TestRun(
                     binary,
                     file.absolute(),
@@ -680,8 +806,18 @@ class TestRunner:
                 decorate_summary(
                     run2.summary.out, file, seed + count, run.buggify_enabled
                 )
-                run2.summary.out.dump(sys.stdout)
                 result = result and run2.success
+
+                # Organize trace files for analysis if determinism check failed
+                if not result:
+                    self.restore_trace_files(seed + count)
+                    
+                    # Run joshua_logtool after file organization for determinism failures
+                    self._run_joshua_logtool_for_test(run2)
+                
+                # Dump XML output after joshua_logtool has been called
+                run2.summary.out.dump(sys.stdout)
+
                 if not result:
                     return False
         return result
@@ -694,6 +830,13 @@ class TestRunner:
         )
         test_files = self.test_picker.choose_test()
         success = self.run_tests(test_files, seed, self.test_picker)
-        if config.clean_up:
+        
+        # Check if we should preserve logs on failure
+        archive_logs_on_failure = os.getenv("TH_ARCHIVE_LOGS_ON_FAILURE", "false").lower() in ("true", "1", "yes")
+        if config.clean_up and (success or not archive_logs_on_failure):
+            # Only clean up if test succeeded OR if archive_logs_on_failure is not set
             shutil.rmtree(config.run_temp_dir / str(self.uid))
+        elif not success and archive_logs_on_failure:
+            print(f"DEBUG: Preserving logs due to TH_ARCHIVE_LOGS_ON_FAILURE=true", file=sys.stderr)
+        
         return success


### PR DESCRIPTION
Previous the second run would overwrite the logs from the first run.

The below also includes a hefty edit of the
contrib/TestHarness2/README.md that fills out the example, removes joshua context specifics, and adds section on this new saving of the determinacy runs.

This is https://github.com/apple/foundationdb/pull/12184 but simplified, only focused on the determinacy check.
