### PR TITLE
disallow config region changes when NO_MULTIREGION_TEST set

### DIFF
--- a/fdbserver/workloads/ConfigureDatabase.actor.cpp
+++ b/fdbserver/workloads/ConfigureDatabase.actor.cpp
@@ -53,6 +53,9 @@ static const char* backupTypes[] = { "backup_worker_enabled:=0", "backup_worker_
 
 std::string generateRegions() {
 	std::string result;
+#ifdef NO_MULTIREGION_TEST
+	return result;
+#endif
 	if (g_simulator->physicalDatacenters == 1 ||
 	    (g_simulator->physicalDatacenters == 2 && deterministicRandom()->random01() < 0.25) ||
 	    g_simulator->physicalDatacenters == 3) {


### PR DESCRIPTION
Disallow config region changes when NO_MULTIREGION_TEST set.

This does not cover changing the `log_version`, which will be handled separately (see PR 12141).

Tested by enabling version vector and running `tests/slow/ConfigureTest.toml` 100000 times.
`20250721-235410-dlambrig-346e57742af4138b `


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
