### PR TITLE
Increase determinism in DeterministicRandom::gen64()

### DIFF
--- a/flow/DeterministicRandom.cpp
+++ b/flow/DeterministicRandom.cpp
@@ -26,6 +26,7 @@
 
 uint64_t DeterministicRandom::gen64() {
 	uint64_t curr = next;
+
 	// RE: the previous implementation of this function: order of
 	// evaluation of arguments to the ^ operator is not specified, so
 	// two rng() calls in the same ^ expression may not produce a

--- a/flow/DeterministicRandom.cpp
+++ b/flow/DeterministicRandom.cpp
@@ -26,14 +26,23 @@
 
 uint64_t DeterministicRandom::gen64() {
 	uint64_t curr = next;
-	next = (uint64_t(random()) << 32) ^ random();
+	// Order of evaluation of the ^ operator is not specified, so two
+	// rng() calls in the same ^ expression may not produce a
+	// consistent 64-bit value across compilations.  This is easily
+	// avoided by writing the code so that our output here does not
+	// depend on unspecified order of operations.
+	next = (uint64_t(rng()) << 32);
+	next ^= rng();
 	if (TRACE_SAMPLE())
 		TraceEvent(SevSample, "Random").log();
 	return curr;
 }
 
 DeterministicRandom::DeterministicRandom(uint32_t seed, bool useRandLog)
-  : random((unsigned long)seed), next((uint64_t(random()) << 32) ^ random()), useRandLog(useRandLog) {}
+  : rng((unsigned long)seed), next(0), useRandLog(useRandLog) {
+	next = (uint64_t(rng()) << 32);
+	next ^= rng();
+}
 
 double DeterministicRandom::random01() {
 	double d = gen64() / double(uint64_t(-1));
@@ -94,7 +103,7 @@ uint32_t DeterministicRandom::randomSkewedUInt32(uint32_t min, uint32_t maxPlusO
 	ASSERT_LT(min, maxPlusOne);
 	std::uniform_real_distribution<double> distribution(std::log(std::max<double>(min, 1.0 / M_E)),
 	                                                    std::log(maxPlusOne));
-	double exponent = distribution(random);
+	double exponent = distribution(rng);
 	uint32_t value = static_cast<uint32_t>(std::pow(M_E, exponent));
 	return std::max(std::min(value, maxPlusOne - 1), min);
 }

--- a/flow/DeterministicRandom.cpp
+++ b/flow/DeterministicRandom.cpp
@@ -26,11 +26,13 @@
 
 uint64_t DeterministicRandom::gen64() {
 	uint64_t curr = next;
-	// Order of evaluation of the ^ operator is not specified, so two
-	// rng() calls in the same ^ expression may not produce a
-	// consistent 64-bit value across compilations.  This is easily
-	// avoided by writing the code so that our output here does not
-	// depend on unspecified order of operations.
+	// RE: the previous implementation of this function: order of
+	// evaluation of arguments to the ^ operator is not specified, so
+	// two rng() calls in the same ^ expression may not produce a
+	// consistent 64-bit value across compilations, because we don't
+	// know if the first call was used for the higher order bits and
+	// the second call for the low order bits, or vice-versa.
+	// See https://en.cppreference.com/w/cpp/language/eval_order.html
 	next = (uint64_t(rng()) << 32);
 	next ^= rng();
 	if (TRACE_SAMPLE())

--- a/flow/include/flow/DeterministicRandom.h
+++ b/flow/include/flow/DeterministicRandom.h
@@ -22,6 +22,9 @@
 #define FLOW_DETERIMINISTIC_RANDOM_H
 #pragma once
 
+#include <boost/random/mersenne_twister.hpp>
+#include <boost/random/uniform_int_distribution.hpp>
+
 #include <cinttypes>
 #include "flow/IRandom.h"
 #include "flow/Error.h"
@@ -38,7 +41,14 @@
 class SWIFT_CXX_REF_DETERMINISTICRANDOM DeterministicRandom final : public IRandom,
                                                                     public ReferenceCounted<DeterministicRandom> {
 private:
-	std::mt19937 rng;
+	// Use boost::random::mt19937 to get consistent output across
+	// different compilers and therefore across different C++ standard
+	// library implementations. In other words, don't rely on the
+	// standard library for this.
+	//
+	// This is not expected to affect performance.  See e.g.
+	// https://chatgpt.com/share/68800ee9-3270-800b-aa84-4567167f02ab
+	boost::random::mt19937 rng;
 	uint64_t next;
 	bool useRandLog;
 

--- a/flow/include/flow/DeterministicRandom.h
+++ b/flow/include/flow/DeterministicRandom.h
@@ -38,7 +38,7 @@
 class SWIFT_CXX_REF_DETERMINISTICRANDOM DeterministicRandom final : public IRandom,
                                                                     public ReferenceCounted<DeterministicRandom> {
 private:
-	std::mt19937 random;
+	std::mt19937 rng;
 	uint64_t next;
 	bool useRandLog;
 


### PR DESCRIPTION
Do this by not making gen64() output dependent on unspecified order of execution of arguments to the ^ operator.
Observed when reading code.

Also, replace `std::mt19937` with `boost::random::mt19937` to make the sequence independent of what 
compiler/C++ standard library we are using.

Also, rename the member previously known as `random` to `rng`, as `random` is a C library function.

More background: https://chatgpt.com/c/687ec7df-9a48-800b-9b5d-475f7ad27b52
Also: https://chatgpt.com/share/68800ee9-3270-800b-aa84-4567167f02ab

Testing passed (first diff):   20250721-232440-gglass-3cd701e3b470909a            compressed=True data_size=41305405 duration=3195515 ended=58461 fail_fast=10 max_runs=100000 pass=58461 priority=100 remaining=0:34:35 runtime=0:48:41 sanity=False started=60811 submitted=20250721-232440 timeout=5400 username=gglass

Testing (second diff):     20250723-021053-gglass-5b073ef106edd783            compressed=True data_size=41304473 duration=5542225 ended=100000 fail=1 fail_fast=10 max_runs=100000 pass=99999 priority=100 remaining=0 runtime=1:15:05 sanity=False started=100000 stopped=20250723-032558 submitted=20250723-021053 timeout=5400 username=gglass
