### PR TITLE
Add metrics to count how often we run TLS handshake on the main thread

### DIFF
--- a/flow/Net2.actor.cpp
+++ b/flow/Net2.actor.cpp
@@ -320,6 +320,8 @@ public:
 	DoubleMetricHandle countLaunchTime;
 	DoubleMetricHandle countReactTime;
 	BoolMetricHandle awakeMetric;
+	Int64MetricHandle countTLSHandshakesOnSideThreads;
+	Int64MetricHandle countTLSHandshakesOnMainThread;
 
 	EventMetricHandle<SlowTask> slowTaskMetric;
 
@@ -1027,7 +1029,16 @@ public:
 			                   [conn = self.getPtr()](bool verifyOk) { conn->has_trusted_peer = verifyOk; });
 
 			// If the background handshakers are not all busy, use one
+
+			// FIXME: this should probably be changed never to use the
+			// main thread, as waiting for potentially high-RTT TLS
+			// handshakes can delay execution of everything else that
+			// runs on the main thread.  The cost of that (in terms of
+			// unpredictable system performance and reliability) is
+			// much, much higher than the cost a few hundred or
+			// thousand incremental threads.
 			if (N2::g_net2->sslPoolHandshakesInProgress < N2::g_net2->sslHandshakerThreadsStarted) {
+				g_net2->countTLSHandshakesOnSideThreads++;
 				holder = Hold(&N2::g_net2->sslPoolHandshakesInProgress);
 				auto handshake =
 				    new SSLHandshakerThread::Handshake(self->ssl_sock, boost::asio::ssl::stream_base::client);
@@ -1035,6 +1046,7 @@ public:
 				N2::g_net2->sslHandshakerPool->post(handshake);
 			} else {
 				// Otherwise use flow network thread
+				g_net2->countTLSHandshakesOnMainThread++;
 				BindPromise p("N2_ConnectHandshakeError"_audit, self->id);
 				p.setPeerAddr(self->getPeerAddress());
 				onHandshook = p.getFuture();
@@ -1450,6 +1462,8 @@ void Net2::initMetrics() {
 	slowTaskMetric.init("Net2.SlowTask"_sr);
 	countLaunchTime.init("Net2.CountLaunchTime"_sr);
 	countReactTime.init("Net2.CountReactTime"_sr);
+	countTLSHandshakesOnSideThreads.init("Net2.CountTLSHandshakesOnSideThreads"_sr);
+	countTLSHandshakesOnMainThread.init("Net2.CountTLSHandshakesOnMainThread"_sr);
 	taskQueue.initMetrics();
 }
 

--- a/flow/SystemMonitor.cpp
+++ b/flow/SystemMonitor.cpp
@@ -185,6 +185,14 @@ SystemStatistics customSystemMonitor(std::string const& eventName, StatisticsSta
 			    .detail("TLSPolicyFailures",
 			            (netData.countTLSPolicyFailures - statState->networkState.countTLSPolicyFailures) /
 			                currentStats.elapsed)
+			    .detail("TLSHandshakesOnSideThreads",
+			            (netData.countTLSHandshakesOnSideThreads -
+			             statState->networkState.countTLSHandshakesOnSideThreads) /
+			                currentStats.elapsed)
+			    .detail(
+			        "TLSHandshakesOnMainThread",
+			        (netData.countTLSHandshakesOnMainThread - statState->networkState.countTLSHandshakesOnMainThread) /
+			            currentStats.elapsed)
 			    .trackLatest(eventName);
 
 			TraceEvent("MemoryMetrics")

--- a/flow/include/flow/SystemMonitor.h
+++ b/flow/include/flow/SystemMonitor.h
@@ -95,6 +95,8 @@ struct NetworkData {
 	int64_t countTLSPolicyFailures;
 	double countLaunchTime;
 	double countReactTime;
+	int64_t countTLSHandshakesOnSideThreads;
+	int64_t countTLSHandshakesOnMainThread;
 
 	void init() {
 		bytesSent = Int64Metric::getValueOrDefault("Net2.BytesSent"_sr);
@@ -137,6 +139,8 @@ struct NetworkData {
 		countFilePageCacheHits = Int64Metric::getValueOrDefault("AsyncFile.CountCachePageReadsHit"_sr);
 		countFilePageCacheMisses = Int64Metric::getValueOrDefault("AsyncFile.CountCachePageReadsMissed"_sr);
 		countFilePageCacheEvictions = Int64Metric::getValueOrDefault("EvictablePageCache.CacheEvictions"_sr);
+		countTLSHandshakesOnSideThreads = Int64Metric::getValueOrDefault("Net2.CountTLSHandshakesOnSideThreads"_sr);
+		countTLSHandshakesOnMainThread = Int64Metric::getValueOrDefault("Net2.CountTLSHandshakesOnMainThread"_sr);
 	}
 };
 


### PR DESCRIPTION
Also add a comment suggesting that using the main thread for this is a bad idea.

Copied the metrics idioms from related stats.
To emit these stats it seems like we need to do lookup by name, using hard-coded strings.
If any of these strings have typos, I'm not sure it would be caught.
I manually confirmed by git diff | less and then typing in the two string constants and ensuring there were exactly two places where they were found.

Also, testing in progress:   20250722-220537-gglass-5b21e0dddb9c2a32            compressed=True data_size=41305257 duration=32016 ended=452 fail_fast=10 max_runs=100000 pass=452 priority=100 remaining=1 day, 0:13:34 runtime=0:06:36 sanity=False started=872 submitted=20250722-220537 timeout=5400 username=gglass

