### PR TITLE
Replace '...' with actual random data in simulation workloads (#12221)

### DIFF
--- a/fdbserver/include/fdbserver/workloads/ReadWriteWorkload.actor.h
+++ b/fdbserver/include/fdbserver/workloads/ReadWriteWorkload.actor.h
@@ -64,7 +64,6 @@ struct ReadWriteCommon : KVWorkload {
 	// two type of transaction
 	int readsPerTransactionA, writesPerTransactionA;
 	int readsPerTransactionB, writesPerTransactionB;
-	std::string valueString;
 	double alpha; // probability for run TransactionA type
 	// transaction setting
 	bool useRYW;
@@ -108,7 +107,6 @@ struct ReadWriteCommon : KVWorkload {
 		writesPerTransactionB = getOption(options, "writesPerTransactionB"_sr, 9);
 		alpha = getOption(options, "alpha"_sr, 0.1);
 
-		valueString = std::string(maxValueBytes, '.');
 		if (nodePrefix > 0) {
 			keyBytes += 16;
 		}
@@ -164,7 +162,6 @@ struct ReadWriteCommon : KVWorkload {
 
 	Standalone<KeyValueRef> operator()(uint64_t n);
 	bool shouldRecord(double checkTime = now());
-	Value randomValue();
 };
 
 #include "flow/unactorcompiler.h"

--- a/fdbserver/workloads/BulkLoad.actor.cpp
+++ b/fdbserver/workloads/BulkLoad.actor.cpp
@@ -42,7 +42,7 @@ struct BulkLoadWorkload : TestWorkload {
 		actorCount = getOption(options, "actorCount"_sr, 20);
 		writesPerTransaction = getOption(options, "writesPerTransaction"_sr, 10);
 		valueBytes = std::max(getOption(options, "valueBytes"_sr, 96), 16);
-		value = Value(std::string(valueBytes, '.'));
+		value = Value(deterministicRandom()->randomAlphaNumeric(valueBytes));
 		targetBytes = getOption(options, "targetBytes"_sr, std::numeric_limits<uint64_t>::max());
 		keyPrefix = getOption(options, "keyPrefix"_sr, ""_sr);
 		keyPrefix = unprintable(keyPrefix.toString());

--- a/fdbserver/workloads/MemoryLifetime.actor.cpp
+++ b/fdbserver/workloads/MemoryLifetime.actor.cpp
@@ -38,7 +38,7 @@ struct MemoryLifetime : KVWorkload {
 		valueString = std::string(maxValueBytes, '.');
 	}
 
-	Value randomValue() const {
+	Value randomValue() const override {
 		return StringRef((uint8_t*)valueString.c_str(),
 		                 deterministicRandom()->randomInt(minValueBytes, maxValueBytes + 1));
 	}

--- a/fdbserver/workloads/ReadWrite.actor.cpp
+++ b/fdbserver/workloads/ReadWrite.actor.cpp
@@ -323,10 +323,6 @@ void ReadWriteCommon::getMetrics(std::vector<PerfMetric>& m) {
 		m.emplace_back(format("%lld keys imported bytes/sec", ratesItr->first), ratesItr->second, Averaged::False);
 }
 
-Value ReadWriteCommon::randomValue() {
-	return StringRef((uint8_t*)valueString.c_str(), deterministicRandom()->randomInt(minValueBytes, maxValueBytes + 1));
-}
-
 Standalone<KeyValueRef> ReadWriteCommon::operator()(uint64_t n) {
 	return KeyValueRef(keyForIndex(n, false), randomValue());
 }

--- a/fdbserver/workloads/StreamingRangeRead.actor.cpp
+++ b/fdbserver/workloads/StreamingRangeRead.actor.cpp
@@ -80,17 +80,10 @@ ACTOR Future<Void> convertStream(PromiseStream<RangeResult> input, PromiseStream
 struct StreamingRangeReadWorkload : KVWorkload {
 	static constexpr auto NAME = "StreamingRangeRead";
 	double testDuration;
-	std::string valueString;
 	Future<Void> client;
 
 	StreamingRangeReadWorkload(WorkloadContext const& wcx) : KVWorkload(wcx) {
 		testDuration = getOption(options, "testDuration"_sr, 60.0);
-		valueString = std::string(maxValueBytes, '.');
-	}
-
-	Value randomValue() {
-		return StringRef((uint8_t*)valueString.c_str(),
-		                 deterministicRandom()->randomInt(minValueBytes, maxValueBytes + 1));
 	}
 
 	Standalone<KeyValueRef> operator()(uint64_t n) { return KeyValueRef(keyForIndex(n, false), randomValue()); }

--- a/fdbserver/workloads/StreamingRead.actor.cpp
+++ b/fdbserver/workloads/StreamingRead.actor.cpp
@@ -49,7 +49,7 @@ struct StreamingReadWorkload : TestWorkload {
 		nodeCount = getOption(options, "nodeCount"_sr, 100000);
 		keyBytes = std::max(getOption(options, "keyBytes"_sr, 16), 16);
 		valueBytes = std::max(getOption(options, "valueBytes"_sr, 96), 16);
-		std::string valueFormat = "%016llx" + std::string(valueBytes - 16, '.');
+		std::string valueFormat = "%016llx" + deterministicRandom()->randomAlphaNumeric(valueBytes - 16);
 		warmingDelay = getOption(options, "warmingDelay"_sr, 0.0);
 		constantValue = Value(format(valueFormat.c_str(), 42));
 		readSequentially = getOption(options, "readSequentially"_sr, false);

--- a/fdbserver/workloads/WriteBandwidth.actor.cpp
+++ b/fdbserver/workloads/WriteBandwidth.actor.cpp
@@ -33,8 +33,6 @@ struct WriteBandwidthWorkload : KVWorkload {
 
 	int keysPerTransaction;
 	double testDuration, warmingDelay, loadTime, maxInsertRate;
-	std::string valueString;
-
 	std::vector<Future<Void>> clients;
 	PerfIntCounter transactions, retries;
 	DDSketch<double> commitLatencies, GRVLatencies;
@@ -44,8 +42,6 @@ struct WriteBandwidthWorkload : KVWorkload {
 	    GRVLatencies() {
 		testDuration = getOption(options, "testDuration"_sr, 10.0);
 		keysPerTransaction = getOption(options, "keysPerTransaction"_sr, 100);
-		valueString = std::string(maxValueBytes, '.');
-
 		warmingDelay = getOption(options, "warmingDelay"_sr, 0.0);
 		maxInsertRate = getOption(options, "maxInsertRate"_sr, 1e12);
 	}
@@ -80,11 +76,6 @@ struct WriteBandwidthWorkload : KVWorkload {
 		m.emplace_back("Bytes written/sec",
 		               (writes * (keyBytes + (minValueBytes + maxValueBytes) * 0.5)) / duration,
 		               Averaged::False);
-	}
-
-	Value randomValue() {
-		return StringRef((uint8_t*)valueString.c_str(),
-		                 deterministicRandom()->randomInt(minValueBytes, maxValueBytes + 1));
 	}
 
 	Standalone<KeyValueRef> operator()(uint64_t n) { return KeyValueRef(keyForIndex(n, false), randomValue()); }


### PR DESCRIPTION
Cherrypick #12221 

* Replace '...' with actual data

* Add zeroPaddingRatio Knob in simulation workloads.

* Refactor randomValue API to include in KVWorkload

* Addressed comments - Add const and remove valueString - not needed

---------

100k correctness tests:

`20250724-030208-ak_valueString_7.3-f0bd9232d12121bd compressed=True data_size=35183640 duration=6453667 ended=100000 fail=2 fail_fast=10 max_runs=100000 pass=99998 priority=100 remaining=0 runtime=1:00:16 sanity=False started=100000 stopped=20250724-040224 submitted=20250724-030208 timeout=5400 username=ak_valueString_7.3`


Failing tests not related to this change - 
```
Results for test ensemble: 20250724-030208-ak_valueString_7.3-f0bd9232d12121bd
Ensemble stopped
RandomSeed="526754425" SourceVersion="b933c8adea11f385c55f48d59dd9875cfa202d74" Time="1753327307" BuggifyEnabled="1" DeterminismCheck="0" OldBinary="fdbserver-7.4.3" FaultInjectionEnabled="1" TestFile="tests/restarting/from_7.3.50/SnapCycleRestart-1.toml"
RandomSeed="526754426" SourceVersion="" Time="1753327350" BuggifyEnabled="0" DeterminismCheck="0" FaultInjectionEnabled="1" TestFile="tests/restarting/from_7.3.50/SnapCycleRestart-2.toml"
RandomSeed="735740528" SourceVersion="b933c8adea11f385c55f48d59dd9875cfa202d74" Time="1753327634" BuggifyEnabled="1" DeterminismCheck="0" OldBinary="fdbserver-7.4.3" FaultInjectionEnabled="1" TestFile="tests/restarting/from_7.3.50/UpgradeAndBackupRestore-1.toml"
RandomSeed="735740529" SourceVersion="" Time="1753327729" BuggifyEnabled="0" DeterminismCheck="0" FaultInjectionEnabled="1" TestFile="tests/restarting/from_7.3.50/UpgradeAndBackupRestore-2.toml"

```
# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
