### PR TITLE
Extensions to the peek logic to get it to work correctly with version vector/unicast

### DIFF
--- a/fdbserver/include/fdbserver/LogSystem.h
+++ b/fdbserver/include/fdbserver/LogSystem.h
@@ -298,7 +298,8 @@ struct ILogSystem {
 		                 bool parallelGetMore,
 		                 std::vector<LocalityData> const& tLogLocalities,
 		                 Reference<IReplicationPolicy> const tLogPolicy,
-		                 int tLogReplicationFactor);
+		                 int tLogReplicationFactor,
+		                 Optional<std::vector<uint16_t>> knownLockedTLogIds = Optional<std::vector<uint16_t>>());
 		MergedPeekCursor(std::vector<Reference<IPeekCursor>> const& serverCursors,
 		                 LogMessageVersion const& messageVersion,
 		                 int bestServer,
@@ -355,7 +356,8 @@ struct ILogSystem {
 		              Tag tag,
 		              Version begin,
 		              Version end,
-		              bool parallelGetMore);
+		              bool parallelGetMore,
+		              Optional<std::vector<uint16_t>> knownLockedTLogIds = Optional<std::vector<uint16_t>>());
 		SetPeekCursor(std::vector<Reference<LogSet>> const& logSets,
 		              std::vector<std::vector<Reference<IPeekCursor>>> const& serverCursors,
 		              LogMessageVersion const& messageVersion,


### PR DESCRIPTION
More version vector/unicast related changes in order to get the peek logic to work correctly during recovery:
- Ensure that non-buddy servers can return an empty version range only if they are known to have been locked
- Make the MergePeekCursor follow the same logic that the SetPeekCursor does when version vector/unicast is enabled

More details:

- It is fine for a buddy server (that is available and known to have been locked) to return an empty version range because the proxy sends all versions (that mutate the tag(s) that the server is buddy of) to the buddy server, and this check (https://github.com/apple/foundationdb/blob/d45a17b6576b1dc246104155ff4777e7880b782e/fdbserver/TagPartitionedLogSystem.actor.cpp#L2314) ensures that the buddy has received all such (relevant) versions till the recovery version.

- It is fine for a non-buddy server (that is available and known to have been locked) to return an empty version range because the above check ensures that all non-buddies (that the proxies selected for all versions till the recovery version) that are available during recovery have received those versions and the SetPeekCursor logic waits for (N - RF + 1) servers (where N = number of tLog servers and RF is the replication factor) to send an empty version range before inferring that it has received all versions for a tag (check: https://github.com/apple/foundationdb/blob/d45a17b6576b1dc246104155ff4777e7880b782e/fdbserver/LogSystemPeekCursor.actor.cpp#L1043). Non-buddy servers that aren't known to have been locked aren't guaranteed to have cleared this check (https://github.com/apple/foundationdb/blob/d45a17b6576b1dc246104155ff4777e7880b782e/fdbserver/TagPartitionedLogSystem.actor.cpp#L2314) for all versions till the recovery version and hence they cannot send an empty version range (since that can invalidate the above SetPeekCursor logic check).

Testing:

Joshua id (with version vector disabled): 

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
