### PR TITLE
Version vector related extensions to the recovery restart logic

### DIFF
--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -2353,6 +2353,27 @@ Optional<std::tuple<Version, Version>> getRecoverVersionUnicast(
 	return std::make_tuple(maxKCV, RV);
 }
 
+/**
+ * Returns true if:
+ *   for each <key, value> in "mapA":
+ *     - "key" is present in "mapB"
+ *     - each element in (the vector in) "mapA[key]" is present in (the vector in) "mapB[key]"
+ * Assumes that the elements in the vectors in "mapA" and "mapB" are in sorted order.
+ */
+static bool isSubset(const std::map<uint8_t, std::vector<uint16_t>>& mapA,
+                     const std::map<uint8_t, std::vector<uint16_t>>& mapB) {
+	for (const auto& [keyA, valueA] : mapA) {
+		if (mapB.find(keyA) == mapB.end()) {
+			return false;
+		}
+		const auto& valueB = mapB.at(keyA);
+		if (!std::includes(valueB.begin(), valueB.end(), valueA.begin(), valueA.end())) {
+			return false;
+		}
+	}
+	return true;
+}
+
 ACTOR Future<Void> TagPartitionedLogSystem::epochEnd(Reference<AsyncVar<Reference<ILogSystem>>> outLogSystem,
                                                      UID dbgid,
                                                      DBCoreState prevState,
@@ -2609,13 +2630,15 @@ ACTOR Future<Void> TagPartitionedLogSystem::epochEnd(Reference<AsyncVar<Referenc
 
 	state Optional<Version> lastEnd;
 	state Version knownCommittedVersion = 0;
+	state std::map<uint8_t, std::vector<uint16_t>> lastKnownLockedTLogIds;
+	state bool knownLockedTLogIdsChanged = false;
 	loop {
 		Version minEnd = std::numeric_limits<Version>::max();
 		Version minDV = std::numeric_limits<Version>::max();
 		Version maxEnd = 0;
 		state std::vector<Future<Void>> changes;
 		state std::vector<std::tuple<int, std::vector<TLogLockResult>, bool>> logGroupResults;
-		state std::map<uint8_t, std::vector<uint16_t>> knownLockedTLogIds;
+		state std::map<uint8_t, std::vector<uint16_t>> currentKnownLockedTLogIds;
 		for (int log = 0; log < logServers.size(); log++) {
 			if (!logServers[log]->isLocal) {
 				continue;
@@ -2626,7 +2649,7 @@ ACTOR Future<Void> TagPartitionedLogSystem::epochEnd(Reference<AsyncVar<Referenc
 				logGroupResults.emplace_back(logServers[log]->tLogReplicationFactor,
 				                             durableVersionInfo.get().lockResults,
 				                             durableVersionInfo.get().policyResult);
-				knownLockedTLogIds[log] = durableVersionInfo.get().knownLockedTLogIds;
+				currentKnownLockedTLogIds[log] = std::move(durableVersionInfo.get().knownLockedTLogIds);
 				minDV = std::min(minDV, durableVersionInfo.get().minimumDurableVersion);
 				if (!SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST) {
 					knownCommittedVersion =
@@ -2642,7 +2665,13 @@ ACTOR Future<Void> TagPartitionedLogSystem::epochEnd(Reference<AsyncVar<Referenc
 			}
 			changes.push_back(TagPartitionedLogSystem::getDurableVersionChanged(lockResults[log], logFailed[log]));
 		}
-		if (maxEnd > 0 && (!lastEnd.present() || maxEnd < lastEnd.get())) {
+		if (SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST && maxEnd > 0 && lastEnd.present() &&
+		    maxEnd >= lastEnd.get()) {
+			// Are the locked servers that were available in the previous iteration still available? If not,
+			// restart recovery (as there is a chance that the recovery of the previous iteration would stall).
+			knownLockedTLogIdsChanged = !isSubset(lastKnownLockedTLogIds, currentKnownLockedTLogIds);
+		}
+		if (maxEnd > 0 && (!lastEnd.present() || maxEnd < lastEnd.get() || knownLockedTLogIdsChanged)) {
 			CODE_PROBE(lastEnd.present(), "Restarting recovery at an earlier point");
 
 			state Reference<TagPartitionedLogSystem> logSystem =
@@ -2657,7 +2686,8 @@ ACTOR Future<Void> TagPartitionedLogSystem::epochEnd(Reference<AsyncVar<Referenc
 			logSystem->logSystemType = prevState.logSystemType;
 			logSystem->rejoins = rejoins;
 			logSystem->lockResults = lockResults;
-			logSystem->knownLockedTLogIds = knownLockedTLogIds;
+			logSystem->knownLockedTLogIds = currentKnownLockedTLogIds;
+			lastKnownLockedTLogIds = std::move(currentKnownLockedTLogIds);
 			if (knownCommittedVersion > minEnd) {
 				knownCommittedVersion = minEnd;
 			}


### PR DESCRIPTION
Version vector/Unicast specific: Restart recovery if the list of available tLogs change in such a way that the current in-progress recovery could stall.

More details: Let "listA" be the list of known locked tLogs of the current in-progress recovery. Suppose the list of known locked tLogs change and "listB" be the current list. If "listA" is not a subset of "listB" then there is a chance that the current in-progress recovery would stall, hence restart recovery (even if the recovery version hasn't changed).

We don't need to restart recovery in "main" in this case because the cursor logic tracks these changes (code: https://github.com/apple/foundationdb/blob/d45a17b6576b1dc246104155ff4777e7880b782e/fdbserver/LogSystemPeekCursor.actor.cpp#L1155) and can reset "bestServer" after that (code: https://github.com/apple/foundationdb/blob/d45a17b6576b1dc246104155ff4777e7880b782e/fdbserver/LogSystemPeekCursor.actor.cpp#L1120) (this is what I think happens in "main", I haven't verified it by going through a simulation test). We can't dynamically change "bestServer" when version vector/unicast is enabled (because we explicitly specify "returnEmptyIfStopped" flag based on whether "bestServer" is enabled or not at the time the cursor is built, code: https://github.com/apple/foundationdb/blob/d45a17b6576b1dc246104155ff4777e7880b782e/fdbserver/LogSystemPeekCursor.actor.cpp#L898) and hence we need to restart recovery in this case.

Testing:
Joshua id (with version vector disabled): 20250911-192206-sre-419d68d40f0255a2 (no failures)

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
