### PR TITLE
benchmark for selectReplicas function

### DIFF
--- a/fdbrpc/ReplicationPolicy.cpp
+++ b/fdbrpc/ReplicationPolicy.cpp
@@ -174,12 +174,10 @@ bool PolicyAcross::validate(std::vector<LocalityEntry> const& solutionSet,
 	return valid;
 }
 
-// Choose new servers from "least utilized" alsoServers and append the new servers to results
-// fromserverse are the servers that have already been chosen and
-// that should be excluded from being selected as replicas.
-// FIXME: Simplify this function, such as removing unnecessary printf
-// fromServers are the servers that must have;
-// alsoServers are the servers you can choose.
+// alsoServers are the servers that have already been chosen. If "_count"
+// alsoServers match this policy with the same _attrib_key, then the policy is satisfied.
+// Otherwise, choose a different server from fromServers; such "new" servers
+// are returned in "results". If _count servers cannot be found, return false.
 bool PolicyAcross::selectReplicas(Reference<LocalitySet>& fromServers,
                                   std::vector<LocalityEntry> const& alsoServers,
                                   std::vector<LocalityEntry>& results) {

--- a/fdbrpc/include/fdbrpc/ReplicationUtils.h
+++ b/fdbrpc/include/fdbrpc/ReplicationUtils.h
@@ -78,6 +78,14 @@ extern bool validateAllCombinations(LocalityGroup const& localitySet,
                                     unsigned int nCombinationSize,
                                     bool bCheckIfValid = true);
 
+extern Reference<LocalitySet> createTestLocalityMap(std::vector<repTestType>& indexes,
+                                                    int dcTotal,
+                                                    int szTotal,
+                                                    int rackTotal,
+                                                    int slotTotal,
+                                                    int independentItems,
+                                                    int independentTotal);
+
 /// Remove all pieces of locality information from the LocalityData that will not be used when validating the policy.
 void filterLocalityDataForPolicyDcAndProcess(Reference<IReplicationPolicy> policy, LocalityData* ld);
 void filterLocalityDataForPolicy(Reference<IReplicationPolicy> policy, LocalityData* ld);

--- a/flowbench/BenchSelectReplicas.cpp
+++ b/flowbench/BenchSelectReplicas.cpp
@@ -1,0 +1,77 @@
+/*
+ * BenchSelectReplicas.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "flow/Arena.h"
+#include "benchmark/benchmark.h"
+#include "fdbrpc/ReplicationPolicy.h"
+#include "fdbrpc/Replication.h"
+#include "fdbrpc/ReplicationUtils.h"
+#include <cstdint>
+
+static void bench_select_replicas(int repCount, benchmark::State& state) {
+
+	Reference<IReplicationPolicy> policy = Reference<IReplicationPolicy>(
+	    new PolicyAcross(repCount, "rack", Reference<IReplicationPolicy>(new PolicyOne())));
+
+	std::vector<std::string> indexes;
+	int dcTotal = 1;
+	int szTotal = 1;
+	int rackTotal = 1; // createTestLocalityMap will create two additional racks.
+	int slotTotal = 3;
+	int independentItems = 0;
+	int independentTotal = 0;
+	std::vector<LocalityEntry> results;
+
+	Reference<LocalitySet> fromServersSet =
+	    createTestLocalityMap(indexes, dcTotal, szTotal, rackTotal, slotTotal, independentItems, independentTotal);
+	LocalityGroup* fromServersGroup = (LocalityGroup*)fromServersSet.getPtr();
+
+	const Reference<LocalitySet> alreadyServersSet = Reference<LocalitySet>(new LocalityGroup());
+
+	alreadyServersSet->deep_copy(*fromServersGroup);
+	std::vector<LocalityEntry> localityGroupEntries;
+	int serverCount = state.range(0);
+
+	// fromServersSet->DisplayEntries();
+
+	for (int i = 0; i < serverCount; i++) {
+		localityGroupEntries.push_back(fromServersGroup->getEntry(i));
+	}
+
+	for (auto _ : state) {
+		state.PauseTiming();
+		results.clear();
+		state.ResumeTiming();
+		policy->selectReplicas(fromServersSet, localityGroupEntries, results);
+		state.SetItemsProcessed(static_cast<long>(state.iterations()));
+	}
+	state.counters.insert({ { "dcTotal", dcTotal }, { "szTotal", szTotal } });
+}
+
+static void bench_select_replicas_tripple(benchmark::State& state) {
+	return bench_select_replicas(3, state);
+}
+
+static void bench_select_replicas_double(benchmark::State& state) {
+	return bench_select_replicas(2, state);
+}
+
+BENCHMARK(bench_select_replicas_tripple)->Args({ 4 })->Args({ 8 })->ReportAggregatesOnly(true);
+BENCHMARK(bench_select_replicas_double)->Args({ 2 })->Args({ 8 })->ReportAggregatesOnly(true);


### PR DESCRIPTION
This benchmark for the `selectReplicas` function tests triple and double replica topologies and sets the policy's fault domain (aka locality_zoneid) to be the "rack". Arguments to the test try varying numbers of "already chosen" servers. The intention is to test two cases
1. too few "already chosen" servers, so the code selects "additional" servers from the locality's pool until the desired replication count is met. 
2. enough "already chosen" servers, and there is no need to select "additional" servers.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
