### PR TITLE
Update README to recommend building using the official docker container

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ ninja
 ```
 
 Slightly more elaborate compile commands can be found in the shell aliases
-defined in `/root.bashrc` in the container image.
+defined in `/root/.bashrc` in the container image.
 
 #### Build Locally
 


### PR DESCRIPTION
The "build from source" section is out of date and incomplete, and users are likely to be confused/frustrated by this.
Somebody posted on forums about this recently and it reminded me of my own experience trying to follow the
"build from source" steps.  Basically, I kept discovering specific dependencies that needed to be updated, and
gave up after about 8 or 10 IIRC.  This was back in April.
