### PR TITLE
Pass encryption file name to backup to encrypt backup files locally

### DIFF
--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -1994,6 +1994,7 @@ ACTOR Future<Void> submitBackup(Database db,
                                 StopWhenDone stopWhenDone,
                                 UsePartitionedLog usePartitionedLog,
                                 IncrementalBackupOnly incrementalBackupOnly,
+                                Optional<std::string> encryptionKeyFile,
                                 Optional<std::string> blobManifestUrl) {
 	try {
 		state FileBackupAgent backupAgent;
@@ -2048,7 +2049,7 @@ ACTOR Future<Void> submitBackup(Database db,
 			                              stopWhenDone,
 			                              usePartitionedLog,
 			                              incrementalBackupOnly,
-			                              {},
+			                              encryptionKeyFile,
 			                              blobManifestUrl));
 
 			// Wait for the backup to complete, if requested
@@ -4255,6 +4256,7 @@ int main(int argc, char* argv[]) {
 				                           stopWhenDone,
 				                           usePartitionedLog,
 				                           incrementalBackupOnly,
+				                           encryptionKeyFile,
 				                           blobManifestUrl));
 				break;
 			}


### PR DESCRIPTION
Pass encryption file name to backup to encrypt backup files locally.

### Testing:
1. Ran local cluster and supplied workload to add some key values to database.
2. Started backup agent - 
` backup_agent --cluster_file ./loopback-cluster/fdb.cluster  & `
3. Create a key : 
`openssl rand 32 > key`
4. Ran fdbbackup :
` fdbbackup start -d file:///root/local_testing/backup -C ~/local_testing/loopback-cluster/fdb.cluster --encryption-key-file ~/local_testing/key  --log --logdir .`
5. Checked the files inside backup directory. Before this change files were not encrypted and after this fix, all files (kvranges, logs, snapshots) shows encrypted.
6. fdbrestore completed successfully :
`fdbrestore start -r  file:///root/local_testing/backup/backup-2025-07-31-18-24-29.748382/ --dest-cluster-file ~/local_testing/loopback-cluster/fdb.cluster --encryption-key-file ~/local_testing/key  --log --logdir .
`

Also ran the script which does the above steps by adding encryption parameter
` 
bash -x ~/src/foundationdb/fdbbackup/tests/dir_backup_test.sh  ~/src/foundationdb/ ~/build_output/  ~/backup_testing/
`

**Completed 100k correctness tests:**
` 20250805-200457-ak_local_bk1-a995df392c47ac6b      compressed=True data_size=41375584 duration=5946779 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:04:46 sanity=False started=100000 stopped=20250805-210943 submitted=20250805-200457 timeout=5400 username=ak_local_bk1`


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
