### PR TITLE
Backup encryption fix on S3

### DIFF
--- a/fdbbackup/tests/s3_backup_test.sh
+++ b/fdbbackup/tests/s3_backup_test.sh
@@ -82,10 +82,14 @@ function restore {
   local local_scratch_dir="${2}"
   local local_url="${3}"
   local local_credentials="${4}"
+
+  # enable read cache randomly to test both code paths.
+  local erc_value=$((RANDOM % 2))
+
   if ! "${local_build_dir}"/bin/fdbrestore start \
     --dest-cluster-file "${local_scratch_dir}/loopback_cluster/fdb.cluster" \
     -t "${TAG}" -w \
-    -r "${url}" \
+    -r "${url}&erc=${erc_value}" \
     --log --logdir="${local_scratch_dir}" \
     --blob-credentials "${local_credentials}" \
     "${KNOBS[@]}"

--- a/fdbbackup/tests/s3_backup_test.sh
+++ b/fdbbackup/tests/s3_backup_test.sh
@@ -82,14 +82,10 @@ function restore {
   local local_scratch_dir="${2}"
   local local_url="${3}"
   local local_credentials="${4}"
-
-  # enable read cache randomly to test both code paths.
-  local erc_value=$((RANDOM % 2))
-
   if ! "${local_build_dir}"/bin/fdbrestore start \
     --dest-cluster-file "${local_scratch_dir}/loopback_cluster/fdb.cluster" \
     -t "${TAG}" -w \
-    -r "${url}&erc=${erc_value}" \
+    -r "${url}" \
     --log --logdir="${local_scratch_dir}" \
     --blob-credentials "${local_credentials}" \
     "${KNOBS[@]}"

--- a/fdbclient/ClientKnobs.cpp
+++ b/fdbclient/ClientKnobs.cpp
@@ -233,7 +233,7 @@ void ClientKnobs::initialize(Randomize randomize) {
 
 	init( BLOBSTORE_CONCURRENT_WRITES_PER_FILE,      5 );
 	init( BLOBSTORE_CONCURRENT_READS_PER_FILE,       3 );
-	init( BLOBSTORE_ENABLE_READ_CACHE,            true );
+	init( BLOBSTORE_ENABLE_READ_CACHE,            true ); if ( randomize && BUGGIFY ) BLOBSTORE_ENABLE_READ_CACHE = deterministicRandom()->coinflip();
 	init( BLOBSTORE_READ_BLOCK_SIZE,       1024 * 1024 );
 	init( BLOBSTORE_READ_AHEAD_BLOCKS,               0 );
 	init( BLOBSTORE_READ_CACHE_BLOCKS_PER_FILE,      2 );

--- a/fdbrpc/include/fdbrpc/AsyncFileEncrypted.h
+++ b/fdbrpc/include/fdbrpc/AsyncFileEncrypted.h
@@ -44,6 +44,7 @@ private:
 	Mode mode;
 	Future<Void> writeLastBlockToFile();
 	friend class AsyncFileEncryptedImpl;
+	int64_t fileSize = -1;
 
 	// Reading:
 	class RandomCache {


### PR DESCRIPTION
When backup encyrption is enabled for S3, it gives an error - `Range missing `because mutation_log_type is 1 bytes and encryption tries to read beyond the file size.

```
<Error><Code>InvalidRange</Code><Message>The requested range is not satisfiable</Message><RangeRequested>bytes=4096-8191</RangeRequested><ActualObjectSize>1</ActualObjectSize><RequestId>898ZDME8HDHCWZ3Y</RequestId><HostId>WiW+gUJF90iu+7BgSRiYuNPOU1EgXw6H7m3Bb8vF5IWY92ACR03q1Y0fy55PUMV+8SwsT3i12eI=</HostId></Error>
```

When encryption is enabled, the code path is:
`AsyncFileReadAheadCache` → `AsyncFileEncrypted` → `AsyncFileS3BlobStoreRead`
The `AsyncFileReadAheadCache` tries to read 1048576 bytes starting at offset 0.
The `AsyncFileEncrypted` layer reads data in fixed-size encrypted blocks (4096 bytes based on FLOW_KNOBS->ENCRYPTION_BLOCK_SIZE).
Block 0: Tries to read bytes 0-4095 and gets the 1 byte of actual data
Block 1: Tries to read bytes 4096-8191 and fails with HTTP 416 because file is only 1 byte.

When encryption is disabled, the code path is:
`AsyncFileReadAheadCache` → `AsyncFileS3BlobStoreRead`
The `AsyncFileReadAheadCache` tries to read 1048576 bytes starting at offset 0, but the underlying `S3BlobStoreRead` layer returns 1 byte and it doesn't read further.


### Testing:
1. Run with enable_read_cache = true by default - 
   - Create a key  `openssl rand 32 > key`
   - Change the s3_backup_test.sh  to have `--encryption-key-file "/root/backup_testing/key" ` fdbbackup and fdbrestore
   - Run  `bash -x ~/src/foundationdb/fdbbackup/tests/s3_backup_test.sh  ~/src/foundationdb/ ~/build_output/  ~/backup_testing`

2. Run with enable_read_cache =  false-
    - passing erc=0 in the url in the script 
    ``` /root/build_output_main//bin/fdbrestore start --dest-cluster-file /root/backup_testing//s3.605531.P1Px/loopback_cluster/fdb.cluster -t test_backup -w -r 'blobstore://@s3.us-west-2.amazonaws.com/ctests/test_s3_backup_and_restore?bucket=backup-112664522426-us-west-2&region=us-west-2&secure_connection=1&erc=0' --log --logdir=/root/backup_testing//s3.605531.P1Px --blob-credentials /root/backup_testing//s3.605531.P1Px/s3_blob_credentials.json --encryption_key_file /root/backup_testing/key --knob_blobstore_encryption_type=aws:kms --knob_http_verbose_level=10 ```
    
Passed successfully with this PR and without this PR.


3. 100k correctness tests completed:

`  20250804-235456-ak_s3-3252f17e5c8e4407             compressed=True data_size=41376424 duration=5169618 ended=100000 fail=1 fail_fast=10 max_runs=100000 pass=99999 priority=100 remaining=0 runtime=1:13:43 sanity=False started=100000 stopped=20250805-010839 submitted=20250804-235456 timeout=5400 username=ak_s3`

4. Added randomization to `enable_read_cache` knob in ctest to cover both code paths.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
