### PR TITLE
Add a limit on the number of attempts at reading \xff\x02/healthyZone on startup

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -368,6 +368,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( REBALANCE_STORAGE_QUEUE_SHARD_PER_KSEC_MIN, SHARD_MIN_BYTES_PER_KSEC);
 	init( DD_ENABLE_REBALANCE_STORAGE_QUEUE_WITH_LIGHT_WRITE_SHARD, true ); if ( isSimulated ) DD_ENABLE_REBALANCE_STORAGE_QUEUE_WITH_LIGHT_WRITE_SHARD = deterministicRandom()->coinflip();
 	init( DD_WAIT_TSS_DATA_MOVE_DELAY,                          15.0 ); if (isSimulated) DD_WAIT_TSS_DATA_MOVE_DELAY = deterministicRandom()->randomInt(5, 30);
+	init( DD_HEALTHY_ZONE_READ_RETRY_COUNT,                        5 );
 
 	// Large teams are disabled when SHARD_ENCODE_LOCATION_METADATA is enabled
 	init( DD_MAX_SHARDS_ON_LARGE_TEAMS,                          100 ); if( randomize && BUGGIFY ) DD_MAX_SHARDS_ON_LARGE_TEAMS = deterministicRandom()->randomInt(0, 3);

--- a/fdbclient/include/fdbclient/ServerKnobs.h
+++ b/fdbclient/include/fdbclient/ServerKnobs.h
@@ -431,6 +431,7 @@ public:
 	int SS_SERVE_BULKDUMP_PARALLELISM; // the number of bulk dump tasks that can concurrently happen at a SS
 	int64_t SS_BULKDUMP_BATCH_BYTES; // the max bytes when SS creates a batch to dump
 	int SS_BULKLOAD_GETRANGE_BATCH_SIZE; // the max number of keys to scan before do context switch
+	int DD_HEALTHY_ZONE_READ_RETRY_COUNT; // numbers of attempts to read \xff\02/healthyZone on startup
 
 	// Run storage engine on a child process on the same machine with storage process
 	bool REMOTE_KV_STORE;

--- a/fdbserver/DDTxnProcessor.actor.cpp
+++ b/fdbserver/DDTxnProcessor.actor.cpp
@@ -256,11 +256,6 @@ class DDTxnProcessorImpl {
 				break;
 			} catch (Error& e) {
 				TraceEvent("ReadHealthyZone", distributorId).error(e);
-				if (!g_network->isSimulated()) {
-					TraceEvent(SevError, "ReadHealthyZone", distributorId)
-					    .error(e)
-					    .detail("AdditionalInfo", "Maintenance mode settings will be ignored");
-				}
 				wait(tr.onError(e));
 			}
 		}
@@ -270,6 +265,12 @@ class DDTxnProcessorImpl {
 				if (p.second > tr.getReadVersion().get() || p.first == ignoreSSFailuresZoneString) {
 					return Optional<Key>(p.first);
 				}
+			}
+		} else {
+			if (!g_network->isSimulated()) {
+				TraceEvent(SevError, "ReadHealthyZone", distributorId)
+					.error(e)
+					.detail("AdditionalInfo", "Maintenance mode settings will be ignored");
 			}
 		}
 		return Optional<Key>();

--- a/fdbserver/DDTxnProcessor.actor.cpp
+++ b/fdbserver/DDTxnProcessor.actor.cpp
@@ -269,7 +269,6 @@ class DDTxnProcessorImpl {
 		} else {
 			if (!g_network->isSimulated()) {
 				TraceEvent(SevError, "ReadHealthyZone", distributorId)
-					.error(e)
 					.detail("AdditionalInfo", "Maintenance mode settings will be ignored");
 			}
 		}

--- a/fdbserver/DDTxnProcessor.actor.cpp
+++ b/fdbserver/DDTxnProcessor.actor.cpp
@@ -258,7 +258,7 @@ class DDTxnProcessorImpl {
 				TraceEvent("ReadHealthyZone", distributorId).error(e);
 				if (!g_network->isSimulated()) {
 					TraceEvent(SevError, "ReadHealthyZone", distributorId)
-						.error(e)
+					    .error(e)
 					    .detail("AdditionalInfo", "Maintenance mode settings will be ignored");
 				}
 				wait(tr.onError(e));

--- a/fdbserver/DDTxnProcessor.actor.cpp
+++ b/fdbserver/DDTxnProcessor.actor.cpp
@@ -269,7 +269,7 @@ class DDTxnProcessorImpl {
 		} else {
 			if (!g_network->isSimulated()) {
 				TraceEvent(SevError, "ReadHealthyZone", distributorId)
-					.detail("AdditionalInfo", "Maintenance mode settings will be ignored");
+				    .detail("AdditionalInfo", "Maintenance mode settings will be ignored");
 			}
 		}
 		return Optional<Key>();

--- a/fdbserver/DDTxnProcessor.actor.cpp
+++ b/fdbserver/DDTxnProcessor.actor.cpp
@@ -238,8 +238,8 @@ class DDTxnProcessorImpl {
 		// Occasionally this can be slow to read.  This is due to hotspots on the \xff\x02 shard
 		// due to over-aggressive use of this feature:
 		// https://apple.github.io/foundationdb/transaction-profiler-analyzer.html
-		// All in all, it's better to succeed in starting up with a risk to future uses
-		// of maintenance mode (i.e. healthyZone) than to block DD startup indefinitely.
+		// All in all, it's better to succeed in starting up with a risk to a
+		// non-default feature (maintenance mode) than to block DD startup indefinitely.
 		state Transaction tr(cx);
 		state int maxRetries = SERVER_KNOBS->DD_HEALTHY_ZONE_READ_RETRY_COUNT;
 		state bool healthyZoneRead = false;


### PR DESCRIPTION
Rationale, from a comment in this diff.  

// Read healthyZone value which is later used to determine on/off of failure triggered DD. 
// Occasionally this can be slow to read.  This is due to hotspots on the \xff\x02 shard 
// due to over-aggressive use of this feature:
// https://apple.github.io/foundationdb/transaction-profiler-analyzer.html 
// All in all, it's better to succeed in starting up with a risk to future uses 
// of maintenance mode (i.e. healthyZone) than to block DD startup indefinitely.

Testing: 20250807-023046-gglass-dfdd460f6e653ad1
had 1 I think unrelated failure in functionality I'm not sure we use.  I filed rdar://157717454.

BTW a prior version of this diff used SevError instead of SevWarnAlways.  This turned out to fail about 10-20 runs out of 
100k in simulation.  I think what happens is that delays on that transaction accumulate > 5x in a small number of runs,
which is kind of interesting and cool.

I guess the presence of a Sev 40 fails the run.  Instead of fighting with that I changed it to SevWarnAlways.
