### PR TITLE
Revert condition for releasing memory from tlog's versionLocation data structure

### DIFF
--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -1186,7 +1186,7 @@ ACTOR Future<Void> updatePersistentData(TLogData* self, Reference<LogData> logDa
 		}
 		if (minVersion != std::numeric_limits<Version>::max()) {
 			self->persistentQueue->forgetBefore(
-			    minVersion,
+			    newPersistentDataVersion,
 			    logData); // SOMEDAY: this can cause a slow task (~0.5ms), presumably from erasing too many versions.
 			              // Should we limit the number of versions cleared at a time?
 		}


### PR DESCRIPTION
# Description

We introduced this change in #11815. The idea was that for tlog spill by reference, we should be using popped version, not persistent version, for the purposes of releasing memory from the logData->versionLocation data structure. This causes OOMs in remote tlogs under certain high traffic workloads after a multi-hour primary-remote disconnect i.e. after the disconnect is healed, remote tlogs' RSS footprint grows in an unbounded way, presumably because some storage server wasn't able to pop fast enough, causing memory build up in tlog. 

This got us thinking whether we really need this change in the first place and whether it's safe to revert. After discussion with a few people, the understanding is that this should not cause a correctness issue since tlog restart can rebuild the state from disk. Joshua/simulation also have not shown this issue, we made the fix pre-emptively. Worst case *potential* cost is disk build up and that's because the versionLocation in-memory state is used for disk queue popping, and lack of the versions in memory could mean we don't release disk space fast enough. Having said that, we think even if it were to happen, this is transient and disk space would eventually be released because of how disk queue popping works. 

Overall, we think this change is safe to revert. 

# Testing

- Tested in a cluster that OOMs no longer happen. 
- 100K Joshua: `20250813-225250-praza-743-tag-v216-01060c4e-43f3c5618750bb80 compressed=True data_size=40160171 fail_fast=10 max_runs=100000 priority=100 sanity=False submitted=20250813-225250 timeout=5400 username=praza-743-tag-v216-01060c4ee1fb5386e045bb9c0b086f07315ac3ef`


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
