### PR TITLE
Forward port #12298: Revert condition for releasing memory from tlog's versionLocation data structure 

### DIFF
--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -1186,7 +1186,7 @@ ACTOR Future<Void> updatePersistentData(TLogData* self, Reference<LogData> logDa
 		}
 		if (minVersion != std::numeric_limits<Version>::max()) {
 			self->persistentQueue->forgetBefore(
-			    minVersion,
+			    newPersistentDataVersion,
 			    logData); // SOMEDAY: this can cause a slow task (~0.5ms), presumably from erasing too many versions.
 			              // Should we limit the number of versions cleared at a time?
 		}


### PR DESCRIPTION
As title. See #12298 for details.

Main branch 100K Joshua: `20250813-230939-praza-main-743-tag-v216-f43-346f6a56cc3980e7 compressed=True data_size=40330757 duration=5860050 ended=100000 fail=1 fail_fast=10 max_runs=100000 pass=99999 priority=100 remaining=0 runtime=1:08:54 sanity=False started=100000 stopped=20250814-001833 submitted=20250813-230939 timeout=5400 username=praza-main-743-tag-v216-f43c339635295f6548ec255e8b42c0cbda2dac00`

The 1 failure is not related. It's a DrUpgrade restart test which is failing because db is not quite at the end, due to dd being stuck. The change here should not change simulation determinism, so I actually went back to the previous change, re ran the test, and it ended up with the same failure, proving that this change is not causing the failure. 

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
