### PR TITLE
avoid lookups for simple (tripple/double) replication policies

### DIFF
--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -316,12 +316,12 @@ std::map<std::string, std::string> configForToken(std::string const& mode) {
 		redundancy = "2";
 		log_replicas = "2";
 		storagePolicy = tLogPolicy = Reference<IReplicationPolicy>(
-		    new PolicyAcross(2, "zoneid", Reference<IReplicationPolicy>(new PolicyOne())));
+		    new PolicyAcross(2, "zoneid", Reference<IReplicationPolicy>(new PolicyOne()), true));
 	} else if (mode == "triple" || mode == "fast_recovery_triple") {
 		redundancy = "3";
 		log_replicas = "3";
 		storagePolicy = tLogPolicy = Reference<IReplicationPolicy>(
-		    new PolicyAcross(3, "zoneid", Reference<IReplicationPolicy>(new PolicyOne())));
+		    new PolicyAcross(3, "zoneid", Reference<IReplicationPolicy>(new PolicyOne()), true));
 	} else if (mode == "three_datacenter" || mode == "multi_dc") {
 		redundancy = "6";
 		log_replicas = "4";

--- a/fdbrpc/ReplicationPolicy.cpp
+++ b/fdbrpc/ReplicationPolicy.cpp
@@ -92,12 +92,15 @@ bool PolicyOne::validate(std::vector<LocalityEntry> const& solutionSet,
 	return ((solutionSet.size() > 0) && (fromServers->size() > 0));
 }
 
-PolicyAcross::PolicyAcross(int count, std::string const& attribKey, Reference<IReplicationPolicy> const policy)
-  : _count(count), _attribKey(attribKey), _policy(policy) {
+PolicyAcross::PolicyAcross(int count,
+                           std::string const& attribKey,
+                           Reference<IReplicationPolicy> const policy,
+                           Optional<bool> cacheable)
+  : _count(count), _attribKey(attribKey), _policy(policy), _cacheable(cacheable) {
 	return;
 }
 
-PolicyAcross::PolicyAcross() : _policy(new PolicyOne()) {}
+PolicyAcross::PolicyAcross() : _policy(new PolicyOne()), _cacheable(false) {}
 
 PolicyAcross::~PolicyAcross() {}
 
@@ -182,8 +185,19 @@ bool PolicyAcross::selectReplicas(Reference<LocalitySet>& fromServers,
                                   std::vector<LocalityEntry> const& alsoServers,
                                   std::vector<LocalityEntry>& results) {
 	int count = 0;
-	AttribKey indexKey = fromServers->keyIndex(_attribKey);
-	auto groupIndexKey = fromServers->getGroupKeyIndex(indexKey);
+
+	AttribKey indexKey;
+	AttribKey groupIndexKey;
+
+	if (fromServers->_localitygroup->cachedKey.present()) {
+		indexKey = groupIndexKey = fromServers->_localitygroup->cachedKey.get();
+	} else {
+		indexKey = fromServers->keyIndex(_attribKey);
+		groupIndexKey = fromServers->getGroupKeyIndex(indexKey);
+		if (_cacheable.present()) {
+			fromServers->_localitygroup->cachedKey = groupIndexKey;
+		}
+	}
 	int resultsSize, resultsAdded;
 	int resultsInit = results.size();
 

--- a/fdbrpc/ReplicationPolicy.cpp
+++ b/fdbrpc/ReplicationPolicy.cpp
@@ -95,7 +95,7 @@ bool PolicyOne::validate(std::vector<LocalityEntry> const& solutionSet,
 PolicyAcross::PolicyAcross(int count,
                            std::string const& attribKey,
                            Reference<IReplicationPolicy> const policy,
-                           Optional<bool> cacheable)
+                           bool cacheable)
   : _count(count), _attribKey(attribKey), _policy(policy), _cacheable(cacheable) {
 	return;
 }
@@ -194,7 +194,7 @@ bool PolicyAcross::selectReplicas(Reference<LocalitySet>& fromServers,
 	} else {
 		indexKey = fromServers->keyIndex(_attribKey);
 		groupIndexKey = fromServers->getGroupKeyIndex(indexKey);
-		if (_cacheable.present()) {
+		if (_cacheable) {
 			fromServers->_localitygroup->cachedKey = groupIndexKey;
 		}
 	}

--- a/fdbrpc/include/fdbrpc/Replication.h
+++ b/fdbrpc/include/fdbrpc/Replication.h
@@ -486,8 +486,9 @@ public:
 	Reference<StringToIntMap> _keymap;
 
 	virtual std::vector<std::vector<AttribValue>> const& getKeyValueArray() const { return _keyValueArray; }
+	// Pointer to the "head" localitySet within the policy tree.
 	LocalitySet* _localitygroup;
-
+	// When set, avoids map lookups when there is only a single PolicyAcross in the polcy.
 	Optional<AttribKey> cachedKey;
 
 protected:
@@ -503,7 +504,6 @@ protected:
 	std::vector<AttribKey> _keyIndexArray;
 	std::vector<LocalityCacheRecord> _cacheArray;
 
-	// LocalitySet* _localitygroup;
 	long long unsigned int _cachehits;
 	long long unsigned int _cachemisses;
 };

--- a/fdbrpc/include/fdbrpc/Replication.h
+++ b/fdbrpc/include/fdbrpc/Replication.h
@@ -486,6 +486,9 @@ public:
 	Reference<StringToIntMap> _keymap;
 
 	virtual std::vector<std::vector<AttribValue>> const& getKeyValueArray() const { return _keyValueArray; }
+	LocalitySet* _localitygroup;
+
+	Optional<AttribKey> cachedKey;
 
 protected:
 	virtual Reference<StringToIntMap>& getGroupValueMap() { return _localitygroup->getGroupValueMap(); }
@@ -500,7 +503,7 @@ protected:
 	std::vector<AttribKey> _keyIndexArray;
 	std::vector<LocalityCacheRecord> _cacheArray;
 
-	LocalitySet* _localitygroup;
+	// LocalitySet* _localitygroup;
 	long long unsigned int _cachehits;
 	long long unsigned int _cachemisses;
 };

--- a/fdbrpc/include/fdbrpc/ReplicationPolicy.h
+++ b/fdbrpc/include/fdbrpc/ReplicationPolicy.h
@@ -117,9 +117,13 @@ struct PolicyOne final : IReplicationPolicy {
 
 struct PolicyAcross final : IReplicationPolicy {
 	friend struct serializable_traits<PolicyAcross*>;
-	PolicyAcross(int count, std::string const& attribKey, Reference<IReplicationPolicy> const policy, Optional<bool> cacheable=Optional<bool>());
+	PolicyAcross(int count,
+	             std::string const& attribKey,
+	             Reference<IReplicationPolicy> const policy,
+	             bool cacheable = false);
 	explicit PolicyAcross();
-	explicit PolicyAcross(const PolicyAcross& other) : PolicyAcross(other._count, other._attribKey, other._policy, other._cacheable) {}
+	explicit PolicyAcross(const PolicyAcross& other)
+	  : PolicyAcross(other._count, other._attribKey, other._policy, other._cacheable) {}
 	~PolicyAcross() override;
 	std::string name() const override { return "Across"; }
 	std::string embeddedPolicyName() const { return _policy->name(); }
@@ -156,7 +160,7 @@ struct PolicyAcross final : IReplicationPolicy {
 	const std::string& attributeKey() const { return _attribKey; }
 
 protected:
-	Optional<bool> _cacheable;
+	bool _cacheable;
 	int _count;
 	std::string _attribKey;
 	Reference<IReplicationPolicy> _policy;

--- a/fdbrpc/include/fdbrpc/ReplicationPolicy.h
+++ b/fdbrpc/include/fdbrpc/ReplicationPolicy.h
@@ -117,9 +117,9 @@ struct PolicyOne final : IReplicationPolicy {
 
 struct PolicyAcross final : IReplicationPolicy {
 	friend struct serializable_traits<PolicyAcross*>;
-	PolicyAcross(int count, std::string const& attribKey, Reference<IReplicationPolicy> const policy);
+	PolicyAcross(int count, std::string const& attribKey, Reference<IReplicationPolicy> const policy, Optional<bool> cacheable=Optional<bool>());
 	explicit PolicyAcross();
-	explicit PolicyAcross(const PolicyAcross& other) : PolicyAcross(other._count, other._attribKey, other._policy) {}
+	explicit PolicyAcross(const PolicyAcross& other) : PolicyAcross(other._count, other._attribKey, other._policy, other._cacheable) {}
 	~PolicyAcross() override;
 	std::string name() const override { return "Across"; }
 	std::string embeddedPolicyName() const { return _policy->name(); }
@@ -156,6 +156,7 @@ struct PolicyAcross final : IReplicationPolicy {
 	const std::string& attributeKey() const { return _attribKey; }
 
 protected:
+	Optional<bool> _cacheable;
 	int _count;
 	std::string _attribKey;
 	Reference<IReplicationPolicy> _policy;

--- a/flowbench/BenchSelectReplicas.cpp
+++ b/flowbench/BenchSelectReplicas.cpp
@@ -28,7 +28,7 @@
 static void bench_select_replicas(int repCount, benchmark::State& state) {
 
 	Reference<IReplicationPolicy> policy = Reference<IReplicationPolicy>(
-	    new PolicyAcross(repCount, "rack", Reference<IReplicationPolicy>(new PolicyOne())));
+	    new PolicyAcross(repCount, "rack", Reference<IReplicationPolicy>(new PolicyOne()), true));
 
 	std::vector<std::string> indexes;
 	int dcTotal = 1;


### PR DESCRIPTION
Avoid map lookups for simple (triple/double) replication policies, saving between 5-8% of total time to call `selectReplicas`.

Lookups are not needed in double or triple configurations because there is only a single `PolicyAcross` level, so only a single `groupIndexKey`. When there are multiple `PolicyAcross` levels the top level `groupIndexKey` may be a different index than those at the lower level.

```
without optinization
bench_select_replicas_tripple/4       1013 ns         1020 ns       690486 dcTotal=1 items_per_second=0/s szTotal=1
bench_select_replicas_tripple/8        950 ns          954 ns       738778 dcTotal=1 items_per_second=0/s szTotal=1

with
bench_select_replicas_tripple/4        959 ns          964 ns       731058 dcTotal=1 items_per_second=0/s szTotal=1
bench_select_replicas_tripple/8        871 ns          875 ns       802559 dcTotal=1 items_per_second=0/s szTotal=1
```


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
