### PR TITLE
[release-7.4] Fix some potential DatabaseContext leaks in NativeApi

### DIFF
--- a/fdbclient/GlobalConfig.actor.cpp
+++ b/fdbclient/GlobalConfig.actor.cpp
@@ -23,6 +23,7 @@
 #include "fdbclient/SpecialKeySpace.actor.h"
 #include "fdbclient/SystemData.h"
 #include "fdbclient/Tuple.h"
+#include "flow/Error.h"
 #include "flow/flow.h"
 #include "flow/genericactors.actor.h"
 
@@ -175,6 +176,10 @@ ACTOR Future<Version> GlobalConfig::refresh(GlobalConfig* self, Version lastKnow
 				wait(delay(0.25));
 			}
 		} catch (Error& e) {
+			if (e.code() == error_code_actor_cancelled) {
+				throw;
+			}
+
 			wait(backoff.onError());
 		}
 	}
@@ -248,6 +253,10 @@ ACTOR Future<Void> GlobalConfig::updater(GlobalConfig* self, const ClientDBInfo*
 				}
 			}
 		} catch (Error& e) {
+			if (e.code() == error_code_actor_cancelled) {
+				throw;
+			}
+
 			// There shouldn't be any uncaught errors that fall to this point,
 			// but in case there are, catch them and restart the updater.
 			TraceEvent("GlobalConfigUpdaterError").error(e);


### PR DESCRIPTION
1. Only start `clientStatusUpdateActor` when `DatabaseContext` successfully established connection to the cluster.

2. `DatabaseContext` starts few actors for monitoring as well as update client status to server. These sometimes pass pointers to `DatabaseContext` and the `Transaction` object created within these actors will increment the refcount. This can lead to cyclic references or holding `DatabaseContext` objects for long period of times if `Transaction` object is not cleaned up or we keep retrying forever without any limit.

3. Some actors don't handle `actor_cancelled` errors which can lead then to stay alive forever. This patch fixes some of those.

rdar://155780163 found that in multi-version client if primary is incompatible with the cluster, we keep trying to reconnect with cluster, and spamming with IncompatibleConnectionClosed messages. (1) should be enough to fix that, but other issues were found during investigation which can potentially lead to similar issues in future.

Testing:

Manually started a 7.1 cluster, with 7.4 primary client and 7.1. secondary client. Started a client. Without this patch we'll see bunch of IncompatibleConnectionClosed messages, and with this patch they will be gone.

Cherry-Pick: https://github.com/apple/foundationdb/pull/12304
Joshua: 20250815-215451-vishesh-2b90562fb390f691  pass=100000  remaining=0

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
