### PR TITLE
[release-7.3] Fix some potential DatabaseContext leaks in NativeApi

### DIFF
--- a/fdbclient/GlobalConfig.actor.cpp
+++ b/fdbclient/GlobalConfig.actor.cpp
@@ -23,6 +23,7 @@
 #include "fdbclient/SpecialKeySpace.actor.h"
 #include "fdbclient/SystemData.h"
 #include "fdbclient/Tuple.h"
+#include "flow/Error.h"
 #include "flow/flow.h"
 #include "flow/genericactors.actor.h"
 
@@ -175,6 +176,10 @@ ACTOR Future<Version> GlobalConfig::refresh(GlobalConfig* self, Version lastKnow
 				wait(delay(0.25));
 			}
 		} catch (Error& e) {
+			if (e.code() == error_code_actor_cancelled) {
+				throw;
+			}
+
 			wait(backoff.onError());
 		}
 	}
@@ -248,6 +253,10 @@ ACTOR Future<Void> GlobalConfig::updater(GlobalConfig* self, const ClientDBInfo*
 				}
 			}
 		} catch (Error& e) {
+			if (e.code() == error_code_actor_cancelled) {
+				throw;
+			}
+
 			// There shouldn't be any uncaught errors that fall to this point,
 			// but in case there are, catch them and restart the updater.
 			TraceEvent("GlobalConfigUpdaterError").error(e);

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -777,6 +777,10 @@ ACTOR static Future<Void> delExcessClntTxnEntriesActor(Transaction* tr, int64_t 
 	state const Key clientLatencyName = CLIENT_LATENCY_INFO_PREFIX.withPrefix(fdbClientInfoPrefixRange.begin);
 	state const Key clientLatencyAtomicCtr = CLIENT_LATENCY_INFO_CTR_PREFIX.withPrefix(fdbClientInfoPrefixRange.begin);
 	TraceEvent(SevInfo, "DelExcessClntTxnEntriesCalled").log();
+
+	// If we don't limit it with retries, the DatabaseContext will never cleanup as Transaction
+	// object will be alive and hold reference to DatabaseContext.
+	state int retries = 0;
 	loop {
 		try {
 			tr->reset();
@@ -817,6 +821,10 @@ ACTOR static Future<Void> delExcessClntTxnEntriesActor(Transaction* tr, int64_t 
 			if (txInfoSize - numBytesToDel <= clientTxInfoSizeLimit)
 				return Void();
 		} catch (Error& e) {
+			if (e.code() == error_code_actor_cancelled || retries++ >= 10) {
+				throw;
+			}
+
 			wait(tr->onError(e));
 		}
 	}
@@ -841,8 +849,12 @@ ACTOR static Future<Void> clientStatusUpdateActor(DatabaseContext* cx) {
 	state int txBytes = 0;
 
 	loop {
-		// Need to make sure that we eventually destroy tr. We can't rely on getting cancelled to do this because of
-		// the cyclic reference to self.
+		// Make sure we are connected to the server. Otherwise we may just try to keep reconnecting
+		// with incompatible clusters.
+		wait(cx->onConnected());
+
+		// Need to make sure that we eventually destroy tr. We can't rely on getting cancelled to do
+		// this because of the cyclic reference to self.
 		wait(refreshTransaction(cx, &tr));
 		try {
 			ASSERT(cx->clientStatusUpdater.outStatusQ.empty());
@@ -927,13 +939,18 @@ ACTOR static Future<Void> clientStatusUpdateActor(DatabaseContext* cx) {
 			if (!trChunksQ.empty() && deterministicRandom()->random01() < clientSamplingProbability)
 				wait(delExcessClntTxnEntriesActor(&tr, clientTxnInfoSizeLimit));
 
+			// Cleanup Transaction sooner than later, so that we don't hold reference to context.
+			tr = Transaction();
 			wait(delay(CLIENT_KNOBS->CSI_STATUS_DELAY));
 		} catch (Error& e) {
+			TraceEvent(SevWarnAlways, "UnableToWriteClientStatus").error(e);
 			if (e.code() == error_code_actor_cancelled) {
 				throw;
 			}
 			cx->clientStatusUpdater.outStatusQ.clear();
-			TraceEvent(SevWarnAlways, "UnableToWriteClientStatus").error(e);
+
+			// Cleanup Transaction sooner than later, so that we don't hold reference to context.
+			tr = Transaction();
 			wait(delay(10.0));
 		}
 	}


### PR DESCRIPTION
1. Only start `clientStatusUpdateActor` when `DatabaseContext` successfully established connection to the cluster.

2. `DatabaseContext` starts few actors for monitoring as well as update client status to server. These sometimes pass pointers to `DatabaseContext` and the `Transaction` object created within these actors will increment the refcount. This can lead to cyclic references or holding `DatabaseContext` objects for long period of times if `Transaction` object is not cleaned up or we keep retrying forever without any limit.

3. Some actors don't handle `actor_cancelled` errors which can lead then to stay alive forever. This patch fixes some of those.

rdar://155780163 found that in multi-version client if primary is incompatible with the cluster, we keep trying to reconnect with cluster, and spamming with IncompatibleConnectionClosed messages. (1) should be enough to fix that, but other issues were found during investigation which can potentially lead to similar issues in future.

Testing:

Manually started a 7.1 cluster, with 7.4 primary client and 7.1. secondary client. Started a client. Without this patch we'll see bunch of IncompatibleConnectionClosed messages, and with this patch they will be gone.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
