### PR TITLE
[main branch] Reduce frequency of two categories of Sev30s

### DIFF
--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -635,7 +635,9 @@ struct RolesInfo {
 			}
 
 		} catch (AttributeNotFoundError& e) {
-			TraceEvent(SevWarnAlways, "StorageServerStatusJson").detail("MissingAttribute", e.getMissingAttribute());
+			TraceEvent(SevWarnAlways, "StorageServerStatusJson")
+			    .suppressFor(5.0)
+			    .detail("MissingAttribute", e.getMissingAttribute());
 		}
 		if (pDataLagSeconds) {
 			*pDataLagSeconds = dataLagSeconds;

--- a/flow/Trace.cpp
+++ b/flow/Trace.cpp
@@ -1224,19 +1224,14 @@ BaseTraceEvent& TraceEvent::suppressFor(double duration, bool logSuppressedEvent
 			return *this;
 		}
 
-		if (g_network) {
-			if (isNetworkThread()) {
-				bool suppress = false;
-				int64_t suppressedEventCount = suppressedEvents.checkAndInsertSuppression(type, duration, suppress);
-				if (suppress)
-					enabled.suppress();
-				if (enabled && logSuppressedEventCount) {
-					detail("SuppressedEventCount", suppressedEventCount);
-				}
-			} else {
-				TraceEvent(SevWarnAlways, "SuppressionFromNonNetworkThread").detail("Event", type);
-				// Choosing a detail name that is unlikely to collide with other names
-				detail("__InvalidSuppression__", "");
+		if (g_network && isNetworkThread()) {
+			bool suppress = false;
+			int64_t suppressedEventCount = suppressedEvents.checkAndInsertSuppression(type, duration, suppress);
+			if (suppress) {
+				enabled.suppress();
+			}
+			if (enabled && logSuppressedEventCount) {
+				detail("SuppressedEventCount", suppressedEventCount);
 			}
 		}
 


### PR DESCRIPTION
Cherry-pick #12310 to main branch. See that PR for description of the issues. 

100K: `20250819-180858-praza-trace-bugs-v1-main-f6-c0f6aae1349aa899 compressed=True data_size=40325921 fail_fast=10 max_runs=100000 priority=100 sanity=False submitted=20250819-180858 timeout=5400 username=praza-trace-bugs-v1-main-f63020d998062d2691d25982e925578c6cd7c591`. Currently running.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
