### PR TITLE
Disable BlobRestoreTenantMode.toml which is flaky, but tests stuff we do not use

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -167,7 +167,9 @@ if(WITH_PYTHON)
   add_fdb_test(TEST_FILES rare/BlobRestoreBasic.toml)
   add_fdb_test(TEST_FILES rare/BlobRestoreLarge.toml IGNORE)
   add_fdb_test(TEST_FILES rare/BlobRestoreToVersion.toml)
-  add_fdb_test(TEST_FILES rare/BlobRestoreTenantMode.toml)
+  # IGNORE below because we do not use tenant mode and it is likely to be
+  # deprecated/removed. rdar://157717454, rdar://134522214.
+  add_fdb_test(TEST_FILES rare/BlobRestoreTenantMode.toml IGNORE)
   add_fdb_test(TEST_FILES fast/BulkDumping.toml)
   add_fdb_test(TEST_FILES slow/BulkDumpingS3.toml)
   add_fdb_test(TEST_FILES fast/BulkLoading.toml)


### PR DESCRIPTION
Testing in progress:

  20250820-172658-gglass-61aa1c93fba18c44            compressed=True data_size=41400570 duration=1400375 ended=30328 fail_fast=10 max_runs=100000 pass=30328 priority=100 remaining=0:55:37 runtime=0:24:13 sanity=False started=32660 submitted=20250820-172658 timeout=5400 username=gglass
