### PR TITLE
Fix go ctest failures [release-7.3]

### DIFF
--- a/bindings/go/src/fdb/errors_test.go
+++ b/bindings/go/src/fdb/errors_test.go
@@ -28,7 +28,7 @@ import (
 	"testing"
 )
 
-const API_VERSION int = 740
+const API_VERSION int = 730
 
 func TestErrorWrapping(t *testing.T) {
 	MustAPIVersion(API_VERSION)

--- a/bindings/go/src/fdb/generated.go
+++ b/bindings/go/src/fdb/generated.go
@@ -682,9 +682,9 @@ func (o TransactionOptions) SetAutoThrottleTag(param string) error {
 	return o.setOpt(801, []byte(param))
 }
 
-// Adds a parent to the Span of this transaction. Used for transaction tracing. A span can be identified with any 16 bytes
+// Adds a parent to the Span of this transaction. Used for transaction tracing. A span can be identified with a 33 bytes serialized binary format which consists of: 8 bytes protocol version, e.g. ``0x0FDB00B073000000LL`` in little-endian format, 16 bytes trace id, 8 bytes span id, 1 byte set to 1 if sampling is enabled
 //
-// Parameter: A byte string of length 16 used to associate the span of this transaction with a parent
+// Parameter: A serialized binary byte string of length 33 used to associate the span of this transaction with a parent
 func (o TransactionOptions) SetSpanParent(param []byte) error {
 	return o.setOpt(900, param)
 }


### PR DESCRIPTION
Found by nightly. Manually validate the fixes:

```
# ctest -R fdb_go_test
Test project /root/cbuild_output
    Start  2: test_venv_setup
1/2 Test  #2: test_venv_setup ..................   Passed    2.26 sec
    Start 64: fdb_go_test
2/2 Test #64: fdb_go_test ......................   Passed    3.45 sec

# ctest -R update_bindings_go_src_fdb_generated_go
Test project /root/cbuild_output
    Start 66: update_bindings_go_src_fdb_generated_go
1/1 Test #66: update_bindings_go_src_fdb_generated_go ...   Passed    0.00 sec

100% tests passed, 0 tests failed out of 1

Total Test time (real) =   0.01 sec
```

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
