### PR TITLE
[Release-7.4] Cherry-pick TLS should accept same key with different values (#11763)

### DIFF
--- a/flow/include/flow/TLSConfig.actor.h
+++ b/flow/include/flow/TLSConfig.actor.h
@@ -42,7 +42,6 @@
 #include "flow/FastRef.h"
 #include "flow/Knobs.h"
 #include "flow/flow.h"
-
 #include "flow/actorcompiler.h" // This must be the last #include.
 
 typedef int NID;
@@ -75,6 +74,17 @@ struct Criteria {
 	}
 
 	bool operator!=(const Criteria& c) const noexcept { return !(*this == c); }
+
+	bool operator<(const Criteria& c) const {
+		if (criteria != c.criteria) {
+			return criteria < c.criteria;
+		} else if (match_type != c.match_type) {
+			return match_type < c.match_type;
+		} else if (location != c.location) {
+			return location < c.location;
+		}
+		return false;
+	}
 };
 
 enum class TLSEndpointType { UNSET = 0, CLIENT, SERVER };
@@ -247,7 +257,7 @@ public:
 	std::string toString() const;
 
 	struct Rule {
-		using CriteriaMap = std::map<NID, Criteria>;
+		using CriteriaMap = std::set<std::pair<NID, Criteria>>;
 
 		explicit Rule(std::string input);
 


### PR DESCRIPTION
Cherrypick https://github.com/apple/foundationdb/pull/12014

Replace this text with your description here...

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
