### PR TITLE
Optimize PolicyAcross key lookup performance with caching

### DIFF
--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -316,12 +316,12 @@ std::map<std::string, std::string> configForToken(std::string const& mode) {
 		redundancy = "2";
 		log_replicas = "2";
 		storagePolicy = tLogPolicy = Reference<IReplicationPolicy>(
-		    new PolicyAcross(2, "zoneid", Reference<IReplicationPolicy>(new PolicyOne()), true));
+		    new PolicyAcross(2, "zoneid", Reference<IReplicationPolicy>(new PolicyOne())));
 	} else if (mode == "triple" || mode == "fast_recovery_triple") {
 		redundancy = "3";
 		log_replicas = "3";
 		storagePolicy = tLogPolicy = Reference<IReplicationPolicy>(
-		    new PolicyAcross(3, "zoneid", Reference<IReplicationPolicy>(new PolicyOne()), true));
+		    new PolicyAcross(3, "zoneid", Reference<IReplicationPolicy>(new PolicyOne())));
 	} else if (mode == "three_datacenter" || mode == "multi_dc") {
 		redundancy = "6";
 		log_replicas = "4";

--- a/fdbrpc/ReplicationPolicy.cpp
+++ b/fdbrpc/ReplicationPolicy.cpp
@@ -189,13 +189,17 @@ bool PolicyAcross::selectReplicas(Reference<LocalitySet>& fromServers,
 	AttribKey indexKey;
 	AttribKey groupIndexKey;
 
-	if (fromServers->_localitygroup->cachedKey.present()) {
-		indexKey = groupIndexKey = fromServers->_localitygroup->cachedKey.get();
+	if (_cacheable && fromServers->_localitygroup->_cachedAttribName.present() &&
+	    fromServers->_localitygroup->_cachedAttribName.get() == _attribKey &&
+	    fromServers->_localitygroup->_cachedKey.present()) {
+		indexKey = groupIndexKey = fromServers->_localitygroup->_cachedKey.get();
 	} else {
 		indexKey = fromServers->keyIndex(_attribKey);
 		groupIndexKey = fromServers->getGroupKeyIndex(indexKey);
 		if (_cacheable) {
-			fromServers->_localitygroup->cachedKey = groupIndexKey;
+			ASSERT_WE_THINK(indexKey == groupIndexKey);
+			fromServers->_localitygroup->_cachedAttribName = _attribKey;
+			fromServers->_localitygroup->_cachedKey = groupIndexKey;
 		}
 	}
 	int resultsSize, resultsAdded;

--- a/fdbrpc/ReplicationUtils.cpp
+++ b/fdbrpc/ReplicationUtils.cpp
@@ -780,28 +780,28 @@ std::vector<Reference<IReplicationPolicy>> const& getStaticPolicies() {
 			// Reference<IReplicationPolicy>(new PolicyOne()))), Reference<IReplicationPolicy>(new PolicyAcross(1,
 			//"zoneid", Reference<IReplicationPolicy>(new PolicyOne()))) } ) ),
 
-			// '(dc^1 x sz^3 x 1)'
+			// 20 '(dc^1 x sz^3 x 1)'
 			Reference<IReplicationPolicy>(
 			    new PolicyAcross(1,
 			                     "dc",
 			                     Reference<IReplicationPolicy>(
 			                         new PolicyAcross(3, "sz", Reference<IReplicationPolicy>(new PolicyOne()))))),
 
-			// '(dc^2 x sz^3 x 1)'
+			// 21 '(dc^2 x sz^3 x 1)'
 			Reference<IReplicationPolicy>(
 			    new PolicyAcross(2,
 			                     "dc",
 			                     Reference<IReplicationPolicy>(
 			                         new PolicyAcross(3, "sz", Reference<IReplicationPolicy>(new PolicyOne()))))),
 
-			// '(dc^2 x az^3 x 1)'
+			// 22 '(dc^2 x az^3 x 1)'
 			Reference<IReplicationPolicy>(
 			    new PolicyAcross(2,
 			                     "dc",
 			                     Reference<IReplicationPolicy>(
 			                         new PolicyAcross(3, "az", Reference<IReplicationPolicy>(new PolicyOne()))))),
 
-			// '(sz^1 x 1) + (dc^2 x az^3 x 1)'
+			// 23 '(sz^1 x 1) + (dc^2 x az^3 x 1)'
 			Reference<IReplicationPolicy>(
 			    new PolicyAnd({ Reference<IReplicationPolicy>(
 			                        new PolicyAcross(1, "sz", Reference<IReplicationPolicy>(new PolicyOne()))),
@@ -817,12 +817,14 @@ std::vector<Reference<IReplicationPolicy>> const& getStaticPolicies() {
 			// PolicyOne()))), Reference<IReplicationPolicy>(new PolicyAcross(2, "sz", Reference<IReplicationPolicy>(new
 			// PolicyOne())))}))) ),
 
-			// Require backtracking
+			// 24 Require backtracking
 			Reference<IReplicationPolicy>(new PolicyAcross(
 			    8,
 			    "zoneid",
 			    Reference<IReplicationPolicy>(
 			        new PolicyAcross(1, "az", Reference<IReplicationPolicy>(new PolicyOne()))))),
+
+			// 25
 			Reference<IReplicationPolicy>(new PolicyAcross(
 			    8,
 			    "zoneid",
@@ -1009,7 +1011,8 @@ int testReplication() {
 				alsoServers.resize(alsoSize);
 			}
 		}
-
+		testServers->_cachedAttribName = Optional<std::string>();
+		testServers->_cachedKey = Optional<AttribKey>();
 		policyIndex =
 		    (policyIndexStatic >= 0) ? policyIndexStatic : deterministicRandom()->randomInt(0, policies.size());
 

--- a/fdbrpc/include/fdbrpc/Replication.h
+++ b/fdbrpc/include/fdbrpc/Replication.h
@@ -62,6 +62,8 @@ public:
 		_keyIndexArray.clear();
 		_cacheArray.clear();
 		_keymap->clear();
+		_cachedAttribName = Optional<std::string>();
+		_cachedKey = Optional<AttribKey>();
 	}
 
 	LocalitySet& copy(LocalitySet const& source) {
@@ -339,7 +341,11 @@ public:
 		       _entryArray.size());
 	}
 
-	void clearCache() { _cacheArray.clear(); }
+	void clearCache() {
+		_cacheArray.clear();
+		_cachedAttribName = Optional<std::string>();
+		_cachedKey = Optional<AttribKey>();
+	}
 
 	AttribKey keyIndex(std::string const& value) const { return AttribKey(_keymap->convertString(value)); }
 	AttribKey keyIndex(char const* value) const { return keyIndex(std::string(value)); }
@@ -486,10 +492,12 @@ public:
 	Reference<StringToIntMap> _keymap;
 
 	virtual std::vector<std::vector<AttribValue>> const& getKeyValueArray() const { return _keyValueArray; }
-	// Pointer to the "head" localitySet within the policy tree.
+	// Pointer to the "root" localitySet within the policy tree.
 	LocalitySet* _localitygroup;
-	// When set, avoids map lookups when there is only a single PolicyAcross in the polcy.
-	Optional<AttribKey> cachedKey;
+	// Caches are stored on the root to be shared by derived sets.
+	// When set, avoids map lookups when there is only a single PolicyAcross rule in the policy.
+	Optional<std::string> _cachedAttribName; // e.g., "zoneid", "rack"
+	Optional<AttribKey> _cachedKey; // relies on invariant: indexKey == groupIndexKey
 
 protected:
 	virtual Reference<StringToIntMap>& getGroupValueMap() { return _localitygroup->getGroupValueMap(); }

--- a/flowbench/BenchSelectReplicas.cpp
+++ b/flowbench/BenchSelectReplicas.cpp
@@ -28,7 +28,11 @@
 static void bench_select_replicas(int repCount, benchmark::State& state) {
 
 	Reference<IReplicationPolicy> policy = Reference<IReplicationPolicy>(
-	    new PolicyAcross(repCount, "rack", Reference<IReplicationPolicy>(new PolicyOne()), true));
+	    new PolicyAcross(repCount, "rack", Reference<IReplicationPolicy>(new PolicyOne())));
+
+	// Pre-warm the depth cache to avoid measuring lazy initialization overhead
+	policy->depth();
+	policy->maxdepth();
 
 	std::vector<std::string> indexes;
 	int dcTotal = 1;


### PR DESCRIPTION
 Cache PolicyAcross key lookups to improve selectReplicas performance

PR12301 added memoization for getValueViaGroupKey() calls in the PolicyAcross selectReplicas hot path. By caching the results of these expensive binary search operations, we avoid repeated lookups. This was enabled for simple policies like double/triple replication modes. This PR strengthens cache validation and invalidation:

  - Adding lazy depth/maxdepth caching to replication policies
  - Runtime pattern detection instead of explicit caching flags (avoids serialization problems from previous revision).

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
