### PR TITLE
Add a SimpleCounter template for counter metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,7 @@ flow/coveragetool/obj
 /.ccls-cache
 /.clangd
 /.cache
+TAGS
 
 # Temporary and user configuration files
 *~

--- a/fdbserver/workloads/UnitTests.actor.cpp
+++ b/fdbserver/workloads/UnitTests.actor.cpp
@@ -56,6 +56,7 @@ void forceLinkRESTSimKmsVaultTest();
 void forceLinkActorFuzzUnitTests();
 void forceLinkGrpcTests();
 void forceLinkGrpcTests2();
+void forceLinkSimpleCounterTests();
 
 struct UnitTestWorkload : TestWorkload {
 	static constexpr auto NAME = "UnitTests";
@@ -130,6 +131,7 @@ struct UnitTestWorkload : TestWorkload {
 		forceLinkSimKmsVaultTests();
 		forceLinkRESTSimKmsVaultTest();
 		forceLinkActorFuzzUnitTests();
+		forceLinkSimpleCounterTests();
 
 #ifdef FLOW_GRPC_ENABLED
 		forceLinkGrpcTests();

--- a/flow/SimpleCounter.cpp
+++ b/flow/SimpleCounter.cpp
@@ -18,24 +18,24 @@
  * limitations under the License.
  */
 
-#include "flow/SimplerCounter.h"
+#include "flow/SimpleCounter.h"
 #include "flow/UnitTest.h"
 
 TEST_CASE("/flow/simplecounter/int64") {
-	SimpleCounter<int64_t> *foo = SimpleCounter<int64_t>::makeCounter("foo");
-	SimpleCounter<int64_t> *bar = SimpleCounter<int64_t>::makeCounter("bar");
-	
+	SimpleCounter<int64_t>* foo = SimpleCounter<int64_t>::makeCounter("foo");
+	SimpleCounter<int64_t>* bar = SimpleCounter<int64_t>::makeCounter("bar");
+
 	foo->increment(5);
 	foo->increment(1);
 
 	for (int i = 0; i < 100; i++) {
-		SimpleCounter<int64_t> *p = SimpleCounter<int64_t>::makeCounter(std::string("many") + std::to_string(i));
+		SimpleCounter<int64_t>* p = SimpleCounter<int64_t>::makeCounter(std::string("many") + std::to_string(i));
 		p->increment(i);
 	}
 
 	bar->increment(10);
 
-	SimpleCounter<int64_t> *conflict = SimpleCounter<int64_t>::makeCounter("lots_of_increments");
+	SimpleCounter<int64_t>* conflict = SimpleCounter<int64_t>::makeCounter("lots_of_increments");
 
 	auto int_inclots = [conflict]() {
 		for (int i = 1; i <= 1'000'000; i++) {
@@ -53,7 +53,7 @@ TEST_CASE("/flow/simplecounter/int64") {
 		threads[i].join();
 	}
 
-	int64_t int_expected_count = int64_t{10} * int64_t{1'000'000 + 1} * uint64_t{500'000};
+	int64_t int_expected_count = int64_t{ 10 } * int64_t{ 1'000'000 + 1 } * uint64_t{ 500'000 };
 	ASSERT(conflict->get() == int_expected_count);
 
 	std::vector<SimpleCounter<int64_t>*> intCounters = SimpleCounter<int64_t>::getCounters();
@@ -63,13 +63,13 @@ TEST_CASE("/flow/simplecounter/int64") {
 }
 
 TEST_CASE("/flow/simplecounter/double") {
-	SimpleCounter<double> *baz = SimpleCounter<double>::makeCounter("baz");
+	SimpleCounter<double>* baz = SimpleCounter<double>::makeCounter("baz");
 
 	// We intend to compute a floating point sum with an exact representation.
 	// A way to do this is to only add values with exact representations.
 	// Integers and powers of two (within the limits of the number of mantissa
 	// and exponent bits) do have exact representations.  Hence the 0.5 increment.
-	auto double_inclots= [baz]() {
+	auto double_inclots = [baz]() {
 		for (double i = 0.5; i <= 1'000'000; i += 0.5) {
 			baz->increment(i);
 		}

--- a/flow/SimpleCounter.cpp
+++ b/flow/SimpleCounter.cpp
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2013-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2013-2025 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,9 @@ TEST_CASE("/flow/simplecounter/int64") {
 
 	bar->increment(10);
 
+	ASSERT(foo->get() == 6);
+	ASSERT(bar->get() == 10);
+
 	SimpleCounter<int64_t>* conflict = SimpleCounter<int64_t>::makeCounter("lots_of_increments");
 
 	auto int_inclots = [conflict]() {
@@ -53,11 +56,12 @@ TEST_CASE("/flow/simplecounter/int64") {
 		threads[i].join();
 	}
 
+	// 10 threads * sum of series ==>  10 threads * (min + max) * (num entries in series)/2
 	int64_t int_expected_count = int64_t{ 10 } * int64_t{ 1'000'000 + 1 } * uint64_t{ 500'000 };
 	ASSERT(conflict->get() == int_expected_count);
 
 	std::vector<SimpleCounter<int64_t>*> intCounters = SimpleCounter<int64_t>::getCounters();
-	ASSERT(intCounters.size() == 102);
+	ASSERT(intCounters.size() == 103);
 
 	return Void();
 }
@@ -96,3 +100,5 @@ TEST_CASE("/flow/simplecounter/double") {
 
 	return Void();
 }
+
+void forceLinkSimpleCounterTests() {}

--- a/flow/SimpleCounter.cpp
+++ b/flow/SimpleCounter.cpp
@@ -1,0 +1,98 @@
+/*
+ * SimpleCounter.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2024 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "flow/SimplerCounter.h"
+#include "flow/UnitTest.h"
+
+TEST_CASE("/flow/simplecounter/int64") {
+	SimpleCounter<int64_t> *foo = SimpleCounter<int64_t>::makeCounter("foo");
+	SimpleCounter<int64_t> *bar = SimpleCounter<int64_t>::makeCounter("bar");
+	
+	foo->increment(5);
+	foo->increment(1);
+
+	for (int i = 0; i < 100; i++) {
+		SimpleCounter<int64_t> *p = SimpleCounter<int64_t>::makeCounter(std::string("many") + std::to_string(i));
+		p->increment(i);
+	}
+
+	bar->increment(10);
+
+	SimpleCounter<int64_t> *conflict = SimpleCounter<int64_t>::makeCounter("lots_of_increments");
+
+	auto int_inclots = [conflict]() {
+		for (int i = 1; i <= 1'000'000; i++) {
+			conflict->increment(i);
+		}
+	};
+
+	std::vector<std::thread> threads;
+
+	for (int i = 0; i < 10; i++) {
+		threads.emplace_back(int_inclots);
+	}
+
+	for (int i = 0; i < 10; i++) {
+		threads[i].join();
+	}
+
+	int64_t int_expected_count = int64_t{10} * int64_t{1'000'000 + 1} * uint64_t{500'000};
+	ASSERT(conflict->get() == int_expected_count);
+
+	std::vector<SimpleCounter<int64_t>*> intCounters = SimpleCounter<int64_t>::getCounters();
+	ASSERT(intCounters.size() == 102);
+
+	return Void();
+}
+
+TEST_CASE("/flow/simplecounter/double") {
+	SimpleCounter<double> *baz = SimpleCounter<double>::makeCounter("baz");
+
+	// We intend to compute a floating point sum with an exact representation.
+	// A way to do this is to only add values with exact representations.
+	// Integers and powers of two (within the limits of the number of mantissa
+	// and exponent bits) do have exact representations.  Hence the 0.5 increment.
+	auto double_inclots= [baz]() {
+		for (double i = 0.5; i <= 1'000'000; i += 0.5) {
+			baz->increment(i);
+		}
+	};
+
+	std::vector<std::thread> threads;
+
+	for (int i = 0; i < 10; i++) {
+		threads.emplace_back(double_inclots);
+	}
+
+	for (int i = 0; i < 10; i++) {
+		threads[i].join();
+	}
+
+	double double_expected_count = 10.0 * (1'000'000 + 0.5) * 1'000'000.0;
+	// printf("double_expected_count: %.10f; baz: %.10f\n", double_expected_count, baz->get());
+	ASSERT(double_expected_count == baz->get());
+	// double ratio = baz->get()/double_expected_count;
+	// ASSERT(ratio >= 0.999 && ratio < 1.001);
+
+	std::vector<SimpleCounter<double>*> doubleCounters = SimpleCounter<double>::getCounters();
+	ASSERT(doubleCounters.size() == 1);
+
+	return Void();
+}

--- a/flow/SimpleCounter.cpp
+++ b/flow/SimpleCounter.cpp
@@ -28,37 +28,39 @@ TEST_CASE("/flow/simplecounter/int64") {
 	foo->increment(5);
 	foo->increment(1);
 
-	for (int i = 0; i < 100; i++) {
-		SimpleCounter<int64_t>* p = SimpleCounter<int64_t>::makeCounter(std::string("many") + std::to_string(i));
-		p->increment(i);
-	}
-
 	bar->increment(10);
 
 	ASSERT(foo->get() == 6);
 	ASSERT(bar->get() == 10);
 
+	for (int i = 0; i < 100; i++) {
+		SimpleCounter<int64_t>* p = SimpleCounter<int64_t>::makeCounter(std::string("many") + std::to_string(i));
+		p->increment(i);
+		ASSERT(p->get() == i);
+	}
+
 	SimpleCounter<int64_t>* conflict = SimpleCounter<int64_t>::makeCounter("lots_of_increments");
 
-	auto int_inclots = [conflict]() {
+	// Increment by all values in [1, 1000000] across 10 threads.
+	// Expected sum: 10 * (min + max) * (num entries in series)/2
+	// ==>  10 * ( 1 + 1M ) * 500K
+	int64_t expectedSum = int64_t{ 10 } * int64_t{ 1'000'000 + 1 } * uint64_t{ 500'000 };
+
+	auto inclots = [conflict]() {
 		for (int i = 1; i <= 1'000'000; i++) {
 			conflict->increment(i);
 		}
 	};
 
 	std::vector<std::thread> threads;
-
 	for (int i = 0; i < 10; i++) {
-		threads.emplace_back(int_inclots);
+		threads.emplace_back(inclots);
 	}
-
 	for (int i = 0; i < 10; i++) {
 		threads[i].join();
 	}
 
-	// 10 threads * sum of series ==>  10 threads * (min + max) * (num entries in series)/2
-	int64_t int_expected_count = int64_t{ 10 } * int64_t{ 1'000'000 + 1 } * uint64_t{ 500'000 };
-	ASSERT(conflict->get() == int_expected_count);
+	ASSERT(conflict->get() == expectedSum);
 
 	std::vector<SimpleCounter<int64_t>*> intCounters = SimpleCounter<int64_t>::getCounters();
 	ASSERT(intCounters.size() == 103);
@@ -73,6 +75,8 @@ TEST_CASE("/flow/simplecounter/double") {
 	// A way to do this is to only add values with exact representations.
 	// Integers and powers of two (within the limits of the number of mantissa
 	// and exponent bits) do have exact representations.  Hence the 0.5 increment.
+	double expectedSum = 10.0 * (0.5 + 1'000'000.0) * 1'000'000.0;
+
 	auto double_inclots = [baz]() {
 		for (double i = 0.5; i <= 1'000'000; i += 0.5) {
 			baz->increment(i);
@@ -80,20 +84,14 @@ TEST_CASE("/flow/simplecounter/double") {
 	};
 
 	std::vector<std::thread> threads;
-
 	for (int i = 0; i < 10; i++) {
 		threads.emplace_back(double_inclots);
 	}
-
 	for (int i = 0; i < 10; i++) {
 		threads[i].join();
 	}
 
-	double double_expected_count = 10.0 * (1'000'000 + 0.5) * 1'000'000.0;
-	// printf("double_expected_count: %.10f; baz: %.10f\n", double_expected_count, baz->get());
-	ASSERT(double_expected_count == baz->get());
-	// double ratio = baz->get()/double_expected_count;
-	// ASSERT(ratio >= 0.999 && ratio < 1.001);
+	ASSERT(baz->get() == expectedSum);
 
 	std::vector<SimpleCounter<double>*> doubleCounters = SimpleCounter<double>::getCounters();
 	ASSERT(doubleCounters.size() == 1);

--- a/flow/include/flow/SimpleCounter.h
+++ b/flow/include/flow/SimpleCounter.h
@@ -1,0 +1,146 @@
+/*
+ * SimpleCounter.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FLOW_SIMPLECOUNTER_H
+#define FLOW_SIMPLECOUNTER_H
+#pragma once
+
+#include <atomic>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+#include "flow/Error.h"
+
+// SimpleCounter metrics class for atomic counters of int64_t or
+// double.  Example usage:
+//
+// static SimpleCounter<int64_t> *foo = SimpleCounter::makeCounter("/mymodule/foo");
+//
+// if (...) {
+//   // condition of interest
+//   foo->increment(1);
+//   ...
+// }
+//
+// This class is thread safe, i.e. can be used by code which does limited-scope
+// synchronous work in side threads, but is intended to generally be very
+// light weight.
+//
+// FIXME: periodically log the counters, and give the name of the TraceEvent
+// where they can be found.
+//
+// More background: https://quip-apple.com/PyfZA6Qkbc7w
+//
+// Caveat: if you allocate two different counters with the same name, they will
+// accumulate updates independently. You probably don't want to do that.
+//
+// FIXME: add support for metric labels.  This needs some type of
+// variadic template to let callers specify a set of <type, name> tuples
+// for each label dimension.  Alternatively, make all label types be
+// strings and have users specify a set of 0 or more label dimension names.
+//
+// FIXME: add support for gauges.
+
+template<class T>
+class SimpleCounter {
+    static_assert(std::is_same_v<T, int64_t> || std::is_same_v<T, double>,
+				  "T must be int64_t or double");
+
+private:
+	SimpleCounter(std::string_view n) : value(T(0)), name_(n) {}
+
+	// Not copyable or movable.
+	SimpleCounter(const SimpleCounter&) = delete;
+    SimpleCounter& operator=(const SimpleCounter&) = delete;
+    SimpleCounter(SimpleCounter&&) = delete;
+    SimpleCounter& operator=(SimpleCounter&&) = delete;
+
+private:
+	std::atomic<T> value;
+	std::string name_;
+
+	static inline std::mutex mutex; // protects 3 static values below
+	// Track all counters of type T.  This isn't a std::vector because
+	// 1) it's static, and 2) we want no dependency on order of initialization
+	// of static objects.  These members are not objects, they are statically
+	// initialized plain old data.  Thus we can count on them being initialized
+	// from the start of the process.
+	static inline int numCounters{0};
+	static inline int allCountersSize{0};
+	static inline SimpleCounter<T> **allCounters{nullptr};
+
+public:
+	// Defined in template instantiations below.
+	void increment(T delta);
+
+	T get(void) {
+		return value.load();
+	}
+
+	const std::string& name(void) {
+		return name_;
+	}
+
+	static SimpleCounter<T> *makeCounter(std::string_view name) {
+		SimpleCounter<T> *rv = new SimpleCounter<T>(name);
+
+		std::lock_guard<std::mutex> lock(mutex);
+		ASSERT(numCounters <= allCountersSize);
+		if (numCounters == allCountersSize) {
+			if (allCountersSize == 0) {
+				allCountersSize = 64;
+			} else {
+				allCountersSize *= 2;
+			}
+			// printf("allCountersSize now [%d]; numCounters now [%d]\n", allCountersSize, numCounters);
+			allCounters = static_cast<SimpleCounter<T>**>(realloc(allCounters, allCountersSize * sizeof(SimpleCounter<T>*)));
+		}
+		ASSERT(numCounters < allCountersSize);
+		allCounters[numCounters++] = rv;
+
+		return rv;
+	}
+
+	static std::vector<SimpleCounter<T>*> getCounters() {
+		std::vector<SimpleCounter<T>*> rv;
+		std::lock_guard<std::mutex> lock(mutex);
+		rv.reserve(numCounters);
+		for (int i = 0; i < numCounters; i++) {
+			rv.push_back(allCounters[i]);
+		}
+		return rv;
+	}
+};
+
+template<>
+void SimpleCounter<int64_t>::increment(int64_t delta) {
+	value.fetch_add(delta, std::memory_order_relaxed);
+}
+
+template<>
+void SimpleCounter<double>::increment(double delta) {
+	double old = value.load();
+	while (!value.compare_exchange_weak(old, old + delta)) {
+		;
+	}
+}
+
+#endif


### PR DESCRIPTION
Comments in the header file explain the purpose and usage.
Anticipated upcoming development:
-- Add something to log the metrics to a TraceEvent periodically
-- Instrument flow/Arena and related code, and flow/Net2 and related code

Testing:

[root@gglass-dev-okteto-56b45ddbf4-kkwcl flow]# !fdb
fdbserver -r unittests -f /flow/simplecounter
startingConfiguration: start
useDB: false
Run test:UnitTests start
setting up test (UnitTests)...
Test received trigger for setup...
running test (UnitTests)...
Found 2 tests
Testing /flow/simplecounter/int64
Testing /flow/simplecounter/double
UnitTests complete
UnitTests complete
checking test (UnitTests)...
fetching metrics (UnitTests)...
Metric (0, 0): UnitTests.Test Cases Available, 2.000000, 2
Metric (0, 1): UnitTests.Test Cases Executed, 2.000000, 2
Metric (0, 2): UnitTests.Test Cases Failed, 0.000000, 0
Metric (0, 3): UnitTests.Total wall clock time (s), 1.355200, 1.36
Metric (0, 4): UnitTests.Total flow time (s), 0.000000, 0
Test complete
1 test clients passed; 0 test clients failed
Run test:UnitTests Done.

1 tests passed; 0 tests failed.

[root@gglass-dev-okteto-56b45ddbf4-kkwcl flow]# 
