### PR TITLE
Fix handleTssMismatches crashes.

### DIFF
--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -1223,10 +1223,12 @@ ACTOR static Future<Void> handleTssMismatches(DatabaseContext* cx) {
 	state KeyBackedMap<UID, UID> tssMapDB = KeyBackedMap<UID, UID>(tssMappingKeys.begin);
 	state KeyBackedMap<Tuple, std::string> tssMismatchDB = KeyBackedMap<Tuple, std::string>(tssMismatchKeys.begin);
 	loop {
+		// return to calling actor, cx might be destroyed already with the tr reset below.
+		// This gives ~DatabaseContext a chance to cancel this actor.
+		wait(delay(0));
+
 		// <tssid, list of detailed mismatch data>
 		state std::pair<UID, std::vector<DetailedTSSMismatch>> data = waitNext(cx->tssMismatchStream.getFuture());
-		// return to calling actor, don't do this as part of metrics loop
-		wait(delay(0));
 		// find ss pair id so we can remove it from the mapping
 		state UID tssPairID;
 		bool found = false;


### PR DESCRIPTION
handleTssMismatches(DatabaseContext* cx) uses a pointer to DatabaseContext object, which can be destroyed when "tr" is reset within this actor. However, the actor can't be destroyed because it's on the stack. Introducing this delay gives a chance to cancel the actor.

Seed: `-f ./tests/rare/ClogRemoteTLog.toml -s 3597495253 -b on`
commit: 75f4081870
gcc-13

20250825-223853-jzhou-e22041c3ca2b47b3             compressed=True data_size=59578958 duration=5500266 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:13:42 sanity=False started=100000 stopped=20250825-235235 submitted=20250825-223853 timeout=5400 username=jzhou

hints from AI
```
  Potential Causes

  1. DatabaseContext destruction during stream operation: The crash stack shows destruction of various objects (Arena, Standalone) which suggests
  the DatabaseContext* cx might be getting destroyed while the handleTssMismatches actor is still waiting on the stream. This is a classic
  use-after-free scenario.
  2. PromiseStream corruption or invalid state: The tssMismatchStream is a PromiseStream<std::pair<UID, std::vector<DetailedTSSMismatch>>> (line
  496 in DatabaseContext.h). If the stream gets into an invalid state or its internal data structures are corrupted, waitNext() could crash.
  3. Memory corruption in DetailedTSSMismatch objects: The crash involves copying/moving std::pair<UID, std::vector<DetailedTSSMismatch>> objects.
   If the DetailedTSSMismatch objects in the vector have corrupted data, the copy constructor could fail.
  4. Race condition between sender and receiver: The tssLogger function sends data to the stream while handleTssMismatches receives it. If there's
   a race condition where the sender is destroyed or the stream is closed while the receiver is waiting, this could cause the crash.

  Most Likely Root Cause

  Looking at the stack trace pattern with destructor calls (Arena::~Arena(), Standalone<StringRef>::~Standalone()), this appears to be a
  DatabaseContext lifetime issue. The handleTssMismatches actor holds a raw pointer to DatabaseContext* cx, but if the DatabaseContext gets
  destroyed while the actor is still running, accessing cx->tssMismatchStream becomes undefined behavior.

  Suggested Investigation Steps

  1. Check if tssMismatchHandler (which runs handleTssMismatches) is properly cancelled when DatabaseContext is destroyed
  2. Verify that the DatabaseContext lifetime exceeds the actor's lifetime
  3. Look for any recent changes to TSS mismatch handling or DatabaseContext destruction logic
  4. Add defensive null checks and ensure proper actor cancellation

  The fix would likely involve ensuring proper actor lifecycle management relative to the DatabaseContext.
```

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
