### PR TITLE
Fix handleTssMismatches crashes. [release-7.4]

### DIFF
--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -1220,10 +1220,12 @@ ACTOR static Future<Void> handleTssMismatches(DatabaseContext* cx) {
 	state KeyBackedMap<UID, UID> tssMapDB = KeyBackedMap<UID, UID>(tssMappingKeys.begin);
 	state KeyBackedMap<Tuple, std::string> tssMismatchDB = KeyBackedMap<Tuple, std::string>(tssMismatchKeys.begin);
 	loop {
+		// return to calling actor, cx might be destroyed already with the tr reset below.
+		// This gives ~DatabaseContext a chance to cancel this actor.
+		wait(delay(0));
+
 		// <tssid, list of detailed mismatch data>
 		state std::pair<UID, std::vector<DetailedTSSMismatch>> data = waitNext(cx->tssMismatchStream.getFuture());
-		// return to calling actor, don't do this as part of metrics loop
-		wait(delay(0));
 		// find ss pair id so we can remove it from the mapping
 		state UID tssPairID;
 		bool found = false;


### PR DESCRIPTION
cherrypick #12328

handleTssMismatches(DatabaseContext* cx) uses a pointer to DatabaseContext object, which can be destroyed when "tr" is reset within this actor. However, the actor can't be destroyed because it's on the stack. Introducing this delay gives a chance to cancel the actor.

20250826-165641-jzhou-a1cbfc05926fdfd9             compressed=True data_size=59276546 duration=4833332 ended=100000 fail=1 fail_fast=10 max_runs=100000 pass=99999 priority=100 remaining=0 runtime=1:22:44 sanity=False started=100000 stopped=20250826-181925 submitted=20250826-165641 timeout=5400 username=jzhou

Interestingly, the failure is `-f ./tests/rare/ClogRemoteTLog.toml -s 870359747 -b off` with `ClogRemoteTLogCheckFailed` Sev40, which is not the crashing failure this PR fixed.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
