### PR TITLE
Update SimpleCounter unit tests not to use metric names that break Trace.cpp simulation-only checks

### DIFF
--- a/flow/SimpleCounter.cpp
+++ b/flow/SimpleCounter.cpp
@@ -23,6 +23,13 @@
 #include "flow/SimpleCounter.h"
 #include "flow/UnitTest.h"
 
+// NOTE: this code emits trace events with modified trace field names.
+// To ensure that this does not run afoul of poorly documented invariants
+// in Trace.cpp, run a 100k simulation run even if the unit tests in
+// this file pass.  Run this specifically to ensure that the unit tests
+// themselves do not break expectations embedded elsewhere in any code
+// that enables itself in simulation.
+
 // Trace.cpp::validateField insists on applying some rules to trace
 // field names.  Instead of fighting this, for now just make our
 // hierarchical names comply by converting / to 'U'.  Yes, 'U'.
@@ -81,8 +88,8 @@ void simpleCounterReport(void) {
 }
 
 TEST_CASE("/flow/simplecounter/int64") {
-	SimpleCounter<int64_t>* foo = SimpleCounter<int64_t>::makeCounter("foo");
-	SimpleCounter<int64_t>* bar = SimpleCounter<int64_t>::makeCounter("bar");
+	SimpleCounter<int64_t>* foo = SimpleCounter<int64_t>::makeCounter("/flow/counters/foo");
+	SimpleCounter<int64_t>* bar = SimpleCounter<int64_t>::makeCounter("/flow/counters/bar");
 
 	foo->increment(5);
 	foo->increment(1);
@@ -93,12 +100,12 @@ TEST_CASE("/flow/simplecounter/int64") {
 	ASSERT(bar->get() == 10);
 
 	for (int i = 0; i < 100; i++) {
-		SimpleCounter<int64_t>* p = SimpleCounter<int64_t>::makeCounter(std::string("many") + std::to_string(i));
+		SimpleCounter<int64_t>* p = SimpleCounter<int64_t>::makeCounter(std::string("/flow/counters/many") + std::to_string(i));
 		p->increment(i);
 		ASSERT(p->get() == i);
 	}
 
-	SimpleCounter<int64_t>* conflict = SimpleCounter<int64_t>::makeCounter("lots_of_increments");
+	SimpleCounter<int64_t>* conflict = SimpleCounter<int64_t>::makeCounter("/flow/counters/lots_of_increments");
 
 	// Increment by all values in [1, 1000000] across 10 threads.
 	// Expected sum: 10 * (min + max) * (num entries in series)/2

--- a/flow/SimpleCounter.cpp
+++ b/flow/SimpleCounter.cpp
@@ -106,7 +106,7 @@ TEST_CASE("/flow/simplecounter/int64") {
 		ASSERT(p->get() == i);
 	}
 
-	SimpleCounter<int64_t>* conflict = SimpleCounter<int64_t>::makeCounter("/flow/counters/lots_of_increments");
+	SimpleCounter<int64_t>* conflict = SimpleCounter<int64_t>::makeCounter("/flow/counters/lots");
 
 	// Increment by all values in [1, 1000000] across 10 threads.
 	// Expected sum: 10 * (min + max) * (num entries in series)/2

--- a/flow/SimpleCounter.cpp
+++ b/flow/SimpleCounter.cpp
@@ -133,6 +133,9 @@ TEST_CASE("/flow/simplecounter/int64") {
 	// environment.
 	ASSERT(intCounters.size() >= 103);
 
+	// Give asserts here a chance to run.
+	simpleCounterReport();
+
 	return Void();
 }
 
@@ -163,6 +166,9 @@ TEST_CASE("/flow/simplecounter/double") {
 
 	std::vector<SimpleCounter<double>*> doubleCounters = SimpleCounter<double>::getCounters();
 	ASSERT(doubleCounters.size() >= 1);
+
+	// Give asserts here a chance to run.
+	simpleCounterReport();
 
 	return Void();
 }

--- a/flow/SimpleCounter.cpp
+++ b/flow/SimpleCounter.cpp
@@ -23,13 +23,6 @@
 #include "flow/SimpleCounter.h"
 #include "flow/UnitTest.h"
 
-// NOTE: this code emits trace events with modified trace field names.
-// To ensure that this does not run afoul of poorly documented invariants
-// in Trace.cpp, run a 100k simulation run even if the unit tests in
-// this file pass.  Run this specifically to ensure that the unit tests
-// themselves do not break expectations embedded elsewhere in any code
-// that enables itself in simulation.
-
 // Trace.cpp::validateField insists on applying some rules to trace
 // field names.  Instead of fighting this, for now just make our
 // hierarchical names comply by converting / to 'U'.  Yes, 'U'.
@@ -74,6 +67,7 @@ void simpleCounterReport(void) {
 		if (g_network->isSimulated()) {
 			n = mungeName(n);
 		}
+		ASSERT(validateField(n))
 		traceEvent.detail(std::move(n), ic->get());
 	}
 	for (SimpleCounter<double>* dc : doubleCounters) {
@@ -81,6 +75,7 @@ void simpleCounterReport(void) {
 		if (g_network->isSimulated()) {
 			n = mungeName(n);
 		}
+		ASSERT(validateField(n));
 		traceEvent.detail(std::move(n), dc->get());
 	}
 	int total = intCounters.size() + doubleCounters.size();

--- a/flow/SimpleCounter.cpp
+++ b/flow/SimpleCounter.cpp
@@ -67,7 +67,7 @@ void simpleCounterReport(void) {
 		if (g_network->isSimulated()) {
 			n = mungeName(n);
 		}
-		ASSERT(validateField(n))
+		ASSERT(validateField(n.c_str()));
 		traceEvent.detail(std::move(n), ic->get());
 	}
 	for (SimpleCounter<double>* dc : doubleCounters) {
@@ -75,7 +75,7 @@ void simpleCounterReport(void) {
 		if (g_network->isSimulated()) {
 			n = mungeName(n);
 		}
-		ASSERT(validateField(n));
+		ASSERT(validateField(n.c_str()));
 		traceEvent.detail(std::move(n), dc->get());
 	}
 	int total = intCounters.size() + doubleCounters.size();

--- a/flow/SimpleCounter.cpp
+++ b/flow/SimpleCounter.cpp
@@ -64,17 +64,13 @@ void simpleCounterReport(void) {
 	auto traceEvent = TraceEvent("SimpleCounters");
 	for (SimpleCounter<int64_t>* ic : intCounters) {
 		std::string n = ic->name();
-		if (g_network->isSimulated()) {
-			n = mungeName(n);
-		}
+		n = mungeName(n);
 		ASSERT(validateField(n.c_str(), /* allowUnderscores= */ true));
 		traceEvent.detail(std::move(n), ic->get());
 	}
 	for (SimpleCounter<double>* dc : doubleCounters) {
 		std::string n = dc->name();
-		if (g_network->isSimulated()) {
-			n = mungeName(n);
-		}
+		n = mungeName(n);
 		ASSERT(validateField(n.c_str(), /* allowUnderscores= */ true));
 		traceEvent.detail(std::move(n), dc->get());
 	}

--- a/flow/SimpleCounter.cpp
+++ b/flow/SimpleCounter.cpp
@@ -67,7 +67,7 @@ void simpleCounterReport(void) {
 		if (g_network->isSimulated()) {
 			n = mungeName(n);
 		}
-		ASSERT(validateField(n.c_str()));
+		ASSERT(validateField(n.c_str(), /* allowUnderscores= */ true));
 		traceEvent.detail(std::move(n), ic->get());
 	}
 	for (SimpleCounter<double>* dc : doubleCounters) {
@@ -75,7 +75,7 @@ void simpleCounterReport(void) {
 		if (g_network->isSimulated()) {
 			n = mungeName(n);
 		}
-		ASSERT(validateField(n.c_str()));
+		ASSERT(validateField(n.c_str(), /* allowUnderscores= */ true));
 		traceEvent.detail(std::move(n), dc->get());
 	}
 	int total = intCounters.size() + doubleCounters.size();

--- a/flow/SimpleCounter.cpp
+++ b/flow/SimpleCounter.cpp
@@ -100,7 +100,8 @@ TEST_CASE("/flow/simplecounter/int64") {
 	ASSERT(bar->get() == 10);
 
 	for (int i = 0; i < 100; i++) {
-		SimpleCounter<int64_t>* p = SimpleCounter<int64_t>::makeCounter(std::string("/flow/counters/many") + std::to_string(i));
+		SimpleCounter<int64_t>* p =
+		    SimpleCounter<int64_t>::makeCounter(std::string("/flow/counters/many") + std::to_string(i));
 		p->increment(i);
 		ASSERT(p->get() == i);
 	}
@@ -141,7 +142,7 @@ TEST_CASE("/flow/simplecounter/int64") {
 }
 
 TEST_CASE("/flow/simplecounter/double") {
-	SimpleCounter<double>* baz = SimpleCounter<double>::makeCounter("baz");
+	SimpleCounter<double>* baz = SimpleCounter<double>::makeCounter("/flow/counters/baz");
 
 	// We intend to compute a floating point sum with an exact representation.
 	// A way to do this is to only add values with exact representations.

--- a/flow/Trace.cpp
+++ b/flow/Trace.cpp
@@ -1806,9 +1806,7 @@ bool validateField(const char* key, bool allowUnderscores) {
 }
 
 void TraceEventFields::validateFormat() const {
-	// FIXME: have a way to call validateField even if simulation is
-	// not enabled.  Currently this code does not run in fdbserver -r
-	// unittest mode.
+	// FIXME: this condition should be expanded to include any unit test mode.
 	if (g_network && g_network->isSimulated()) {
 		for (Field field : fields) {
 			if (!validateField(field.first.c_str(), false)) {

--- a/flow/Trace.cpp
+++ b/flow/Trace.cpp
@@ -1787,6 +1787,7 @@ std::string TraceEventFields::toString() const {
 	return str;
 }
 
+// FIXME: give the rationale for the naming scheme that this is enforcing
 bool validateField(const char* key, bool allowUnderscores) {
 	if ((key[0] < 'A' || key[0] > 'Z') && key[0] != '_') {
 		return false;
@@ -1805,6 +1806,9 @@ bool validateField(const char* key, bool allowUnderscores) {
 }
 
 void TraceEventFields::validateFormat() const {
+	// FIXME: have a way to call validateField even if simulation is
+	// not enabled.  Currently this code does not run in fdbserver -r
+	// unittest mode.
 	if (g_network && g_network->isSimulated()) {
 		for (Field field : fields) {
 			if (!validateField(field.first.c_str(), false)) {

--- a/flow/include/flow/Trace.h
+++ b/flow/include/flow/Trace.h
@@ -586,6 +586,8 @@ void disposeTraceFileWriter();
 std::string getTraceFormatExtension();
 uint64_t getTraceThreadId();
 
+bool validateField(const char* key, bool allowUnderscores);
+
 template <class T>
 class Future;
 class Void;

--- a/flow/include/flow/UnitTest.h
+++ b/flow/include/flow/UnitTest.h
@@ -25,7 +25,7 @@
 /*
  * Flow unit testing framework
  *
- * This is an simple framework for writing optionally asynchronous,
+ * This is a simple framework for writing optionally asynchronous,
  * optionally randomized unit tests.
  *
  * This framework is not trivial to use correctly. For example, your
@@ -33,7 +33,7 @@
  * fdbserver process. If things done in your unit test are not in
  * accordance with global expectations that are only enabled in
  * simulation, then you may break simulation even though your unit
- * test runs fine via fdbserver -r unittests.  As a result, to test
+ * test itself runs fine via fdbserver -r unittests.  As a result, to test
  * that your unit tests themselves do not break simulation, you should
  * also run a 100k simulation run.  If you think this sounds
  * backwards, you may be right.

--- a/flow/include/flow/UnitTest.h
+++ b/flow/include/flow/UnitTest.h
@@ -25,8 +25,18 @@
 /*
  * Flow unit testing framework
  *
- * This is an *extremely* lightweight framework for writing optionally asynchronous,
+ * This is an simple framework for writing optionally asynchronous,
  * optionally randomized unit tests.
+ *
+ * This framework is not trivial to use correctly. For example, your
+ * unit tests will affect the global execution environment of a
+ * fdbserver process. If things done in your unit test are not in
+ * accordance with global expectations that are only enabled in
+ * simulation, then you may break simulation even though your unit
+ * test runs fine via fdbserver -r unittests.  As a result, to test
+ * that your unit tests themselves do not break simulation, you should
+ * also run a 100k simulation run.  If you think this sounds
+ * backwards, you may be right.
  *
  * Usage:
  *


### PR DESCRIPTION
Expose validateField() from Trace.cpp and just call it directly from "unit tests" in SimpleCounter.cpp.  Add some
comments in various places about the unit test execution environment.  The updated test cases would catch the 
prior issue where they themselves manufacture counters with invalid label names.  Updated the tests to use 
hierarchical metrix names that get munged into compliant field names.

Unit test:
[root@gglass-dev-okteto-56b45ddbf4-kkwcl flow]# git log -n 1 
commit 4e5d9b2a846f0dcef38b61b208f5fd4cce5aaebc (HEAD -> tracenames, origin/tracenames)
Author: Gideon Glass <gxglassgithub@gmail.com>
Date:   Wed Aug 27 18:30:20 2025 -0700

    always be munging metric names
[root@gglass-dev-okteto-56b45ddbf4-kkwcl flow]# !fdbserver
fdbserver -r unittests -f /flow/simplecounter
startingConfiguration: start
useDB: false
Run test:UnitTests start
setting up test (UnitTests)...
Test received trigger for setup...
running test (UnitTests)...
Found 2 tests
Testing /flow/simplecounter/double
Testing /flow/simplecounter/int64
UnitTests complete
UnitTests complete
checking test (UnitTests)...
fetching metrics (UnitTests)...
Metric (0, 0): UnitTests.Test Cases Available, 2.000000, 2
Metric (0, 1): UnitTests.Test Cases Executed, 2.000000, 2
Metric (0, 2): UnitTests.Test Cases Failed, 0.000000, 0
Metric (0, 3): UnitTests.Total wall clock time (s), 1.590469, 1.59
Metric (0, 4): UnitTests.Total flow time (s), 0.000000, 0
Test complete
1 test clients passed; 0 test clients failed
Run test:UnitTests Done.

1 tests passed; 0 tests failed.

[root@gglass-dev-okteto-56b45ddbf4-kkwcl flow]# 

Simulation:

[root@gglass-dev-okteto-56b45ddbf4-kkwcl ~]# j list --stopped |  grep gglass | tail -1 
  20250828-013346-gglass-ce2142694517650b            compressed=True data_size=60675767 duration=6423706 ended=100000 fail=2 fail_fast=10 max_runs=100000 pass=99998 priority=100 remaining=0 runtime=0:35:35 sanity=False started=100000 stopped=20250828-020921 submitted=20250828-013346 timeout=5400 username=gglass

Here are the 2 failures:
[root@gglass-dev-okteto-56b45ddbf4-kkwcl ~]# j_errors_last | grep TestFile 2>/dev/null 
+ tidy -xml -i -q
Results for test ensemble: 20250828-013346-gglass-ce2142694517650b
.
.
.
meh, 2>/dev/null did not result in no garbage warnings on the terminal so I will just edit them out
.
.
.
FaultInjectionEnabled="1" TestFile="tests/slow/BulkDumpingS3.toml"
TestFile="tests/restarting/from_7.3.0/ConfigureTestRestart-1.toml"
TestFile="tests/restarting/from_7.3.0/ConfigureTestRestart-2.toml"
[root@gglass-dev-okteto-56b45ddbf4-kkwcl ~]# 

With the old bug this would have failed in tests/fast/RandomUnitTests.toml I think.