### PR TITLE
Fix trace buffer overflows in copyUpFile()

### DIFF
--- a/fdbclient/S3Client.actor.cpp
+++ b/fdbclient/S3Client.actor.cpp
@@ -532,6 +532,9 @@ ACTOR static Future<Void> copyUpFile(Reference<S3BlobStoreEndpoint> endpoint,
 
 			break; // Success - exit retry loop
 		} catch (Error& e) {
+			if (e.code() == error_code_actor_cancelled) {
+				throw;
+			}
 			// File-level retry for specific errors, matching download behavior
 			if ((e.code() == error_code_file_not_found || e.code() == error_code_http_request_failed ||
 			     e.code() == error_code_io_error) &&


### PR DESCRIPTION
To repro:

seed: -f ./tests/slow/BulkDumpingS3.toml -s 1521971787 -b off commit: b7f49b8cd9c0b2a1326985c095f885e8152a5d76
gcc-13



# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
