### PR TITLE
Instrument Arena, FastAlloc, Platform.cpp with SimpleCounter metrics to count allocations and bytes

### DIFF
--- a/fdbserver/VersionedBTree.actor.cpp
+++ b/fdbserver/VersionedBTree.actor.cpp
@@ -10037,8 +10037,8 @@ TEST_CASE("Lredwood/correctness/unit/deltaTree/IntIntPair") {
 	return Void();
 }
 
-struct SimpleCounter {
-	SimpleCounter() : x(0), t(timer()), start(t), xt(0) {}
+struct ReallySimpleCounter {
+	ReallySimpleCounter() : x(0), t(timer()), start(t), xt(0) {}
 	void operator+=(int n) { x += n; }
 	void operator++() { x++; }
 	int64_t get() { return x; }
@@ -10302,12 +10302,12 @@ TEST_CASE("Lredwood/correctness/btree") {
 
 	state Version version = lastVer + 1;
 
-	state SimpleCounter mutationBytes;
-	state SimpleCounter keyBytesInserted;
-	state SimpleCounter valueBytesInserted;
-	state SimpleCounter sets;
-	state SimpleCounter rangeClears;
-	state SimpleCounter keyBytesCleared;
+	state ReallySimpleCounter mutationBytes;
+	state ReallySimpleCounter keyBytesInserted;
+	state ReallySimpleCounter valueBytesInserted;
+	state ReallySimpleCounter sets;
+	state ReallySimpleCounter rangeClears;
+	state ReallySimpleCounter keyBytesCleared;
 	state int mutationBytesThisCommit = 0;
 	state int mutationBytesTargetThisCommit = randomSize(maxCommitSize);
 

--- a/flow/FastAlloc.cpp
+++ b/flow/FastAlloc.cpp
@@ -435,9 +435,9 @@ void* FastAllocator<Size>::allocate() {
 	return p;
 }
 
-void* wrappedNew(size_t nbytes) {
-	static SimpleCounter<int64_t>* calls = SimpleCounter<int64_t>::makeCounter("/flow/fastalloc/wrappedNewCalls");
-	static SimpleCounter<int64_t>* bytes = SimpleCounter<int64_t>::makeCounter("/flow/fastalloc/wrappedNewBytes");
+void* countedNew(size_t nbytes) {
+	static SimpleCounter<int64_t>* calls = SimpleCounter<int64_t>::makeCounter("/flow/fastalloc/newCalls");
+	static SimpleCounter<int64_t>* bytes = SimpleCounter<int64_t>::makeCounter("/flow/fastalloc/newBytes");
 	calls->increment(1);
 	bytes->increment(nbytes);
 
@@ -445,9 +445,9 @@ void* wrappedNew(size_t nbytes) {
 	return p;
 }
 
-void wrappedDelete(size_t nbytes, void* ptr) {
-	static SimpleCounter<int64_t>* calls = SimpleCounter<int64_t>::makeCounter("/flow/fastalloc/wrappedDeleteCalls");
-	static SimpleCounter<int64_t>* bytes = SimpleCounter<int64_t>::makeCounter("/flow/fastalloc/wrappedDeleteBytes");
+void countedDelete(size_t nbytes, void* ptr) {
+	static SimpleCounter<int64_t>* calls = SimpleCounter<int64_t>::makeCounter("/flow/fastalloc/deleteCalls");
+	static SimpleCounter<int64_t>* bytes = SimpleCounter<int64_t>::makeCounter("/flow/fastalloc/deleteBytes");
 	calls->increment(1);
 	bytes->increment(nbytes);
 

--- a/flow/FastAlloc.cpp
+++ b/flow/FastAlloc.cpp
@@ -427,6 +427,19 @@ void* FastAllocator<Size>::allocate() {
 	return p;
 }
 
+void* wrappedNew(size_t nbytes) {
+	// FIXME: metrics
+
+	void* p = new uint8_t[nbytes];
+	return p;
+}
+
+void wrappedDelete(size_t nbytes, void* ptr) {
+	// FIXME: metrics
+
+	delete[] reinterpret_cast<uint8_t*>(ptr);
+}
+
 template <int Size>
 void FastAllocator<Size>::release(void* ptr) {
 	// FIXME-METRICS: count calls and bytes

--- a/flow/FastAlloc.cpp
+++ b/flow/FastAlloc.cpp
@@ -119,8 +119,9 @@ std::map<std::string, std::pair<int, int64_t>> hugeArenaTraces;
 
 void hugeArenaSample(int size) {
 	if (TraceEvent::isNetworkThread()) {
-		// FIXME-METRICS: count calls to this. It should be low but in case somebody
-		// leave it on by mistake (or makes it get called to frequently) we'd like to know.
+		static SimpleCounter<int64_t>* calls = SimpleCounter<int64_t>::makeCounter("/flow/fastalloc/hugeArenaSample");
+		calls->increment(1);
+
 		auto& info = hugeArenaTraces[platform::get_backtrace()];
 		info.first++;
 		info.second += size;
@@ -375,7 +376,14 @@ void* FastAllocator<Size>::allocate() {
 	if (keepalive_allocator::isActive()) [[unlikely]]
 		return keepalive_allocator::allocate(Size);
 
-	// FIXME-METRICS: record calls and bytes
+	// Accounting should mirror release() below.
+	static int size = Size;
+	static SimpleCounter<int64_t>* calls =
+	    SimpleCounter<int64_t>::makeCounter(format("/flow/fastalloc/allocateCallsSize%d", size));
+	static SimpleCounter<int64_t>* bytes =
+	    SimpleCounter<int64_t>::makeCounter(format("/flow/fastalloc/allocateBytesSize%d", size));
+	calls->increment(1);
+	bytes->increment(size);
 
 #if defined(USE_GPERFTOOLS) || defined(ADDRESS_SANITIZER)
 	// Some usages of FastAllocator require 4096 byte alignment.
@@ -428,24 +436,38 @@ void* FastAllocator<Size>::allocate() {
 }
 
 void* wrappedNew(size_t nbytes) {
-	// FIXME: metrics
+	static SimpleCounter<int64_t>* calls = SimpleCounter<int64_t>::makeCounter("/flow/fastalloc/wrappedNewCalls");
+	static SimpleCounter<int64_t>* bytes = SimpleCounter<int64_t>::makeCounter("/flow/fastalloc/wrappedNewBytes");
+	calls->increment(1);
+	bytes->increment(nbytes);
 
 	void* p = new uint8_t[nbytes];
 	return p;
 }
 
 void wrappedDelete(size_t nbytes, void* ptr) {
-	// FIXME: metrics
+	static SimpleCounter<int64_t>* calls = SimpleCounter<int64_t>::makeCounter("/flow/fastalloc/wrappedDeleteCalls");
+	static SimpleCounter<int64_t>* bytes = SimpleCounter<int64_t>::makeCounter("/flow/fastalloc/wrappedDeleteBytes");
+	calls->increment(1);
+	bytes->increment(nbytes);
 
 	delete[] reinterpret_cast<uint8_t*>(ptr);
 }
 
 template <int Size>
 void FastAllocator<Size>::release(void* ptr) {
-	// FIXME-METRICS: count calls and bytes
-
 	if (keepalive_allocator::isActive()) [[unlikely]]
 		return keepalive_allocator::invalidate(ptr);
+
+	// Accounting should mirror allocate() above.  Only count paths where we
+	// allocated/free memory from lower levels or from our magazine cache.
+	static int size = Size;
+	static SimpleCounter<int64_t>* calls =
+	    SimpleCounter<int64_t>::makeCounter(format("/flow/fastalloc/releaseCallsSize%d", size));
+	static SimpleCounter<int64_t>* bytes =
+	    SimpleCounter<int64_t>::makeCounter(format("/flow/fastalloc/releaseBytesSize%d", size));
+	calls->increment(1);
+	bytes->increment(size);
 
 #if defined(USE_GPERFTOOLS) || defined(ADDRESS_SANITIZER)
 	return aligned_free(ptr);
@@ -587,7 +609,6 @@ void FastAllocator<Size>::getMagazine() {
 	                               MEM_COMMIT | MEM_RESERVE,
 	                               PAGE_READWRITE);
 #else
-	// FIXME-METRICS: count calls and bytes here
 	static int alt = 0;
 	alt++;
 	void* desiredBlock = (void*)(((getSizeCode(Size) << 11) + alt) * magazine_size * Size);
@@ -612,6 +633,8 @@ void FastAllocator<Size>::getMagazine() {
 #else
 	const bool includeGuardPages = true;
 #endif
+	// NOTE: rely on lower level metrics in allocate() (and whatever it calls)
+	// for accounting the allocations it does.
 	block = (void**)::allocate(magazine_size * Size, /*allowLargePages*/ false, includeGuardPages);
 #endif
 

--- a/flow/Platform.actor.cpp
+++ b/flow/Platform.actor.cpp
@@ -54,6 +54,7 @@
 #include "flow/Knobs.h"
 #include "flow/Platform.actor.h"
 #include "flow/ScopeExit.h"
+#include "flow/SimpleCounter.h"
 #include "flow/StreamCipher.h"
 #include "flow/Trace.h"
 #include "flow/Trace.h"
@@ -3250,6 +3251,9 @@ void outOfMemory() {
 	TRACEALLOCATOR(8192);
 	g_traceBatch.dump();
 #endif
+
+	TraceEvent(SevWarn, "OutOfMemorySimpleCounterReportFollows");
+	simpleCounterReport(SevWarn);
 
 	criticalError(FDB_EXIT_NO_MEM, "OutOfMemory", "Out of memory");
 }

--- a/flow/SimpleCounter.cpp
+++ b/flow/SimpleCounter.cpp
@@ -55,13 +55,13 @@ static std::string mungeName(const std::string input) {
 }
 
 // This should be called periodically by higher level code somewhere.
-void simpleCounterReport(void) {
+void simpleCounterReport(Severity severity) {
 	static SimpleCounter<int64_t>* reportCount = SimpleCounter<int64_t>::makeCounter("/flow/counters/reports");
 	reportCount->increment(1);
 
 	std::vector<SimpleCounter<int64_t>*> intCounters = SimpleCounter<int64_t>::getCounters();
 	std::vector<SimpleCounter<double>*> doubleCounters = SimpleCounter<double>::getCounters();
-	auto traceEvent = TraceEvent("SimpleCounters");
+	auto traceEvent = TraceEvent(severity, "SimpleCounters");
 	for (SimpleCounter<int64_t>* ic : intCounters) {
 		std::string n = ic->name();
 		n = mungeName(n);

--- a/flow/SimpleCounter.cpp
+++ b/flow/SimpleCounter.cpp
@@ -61,21 +61,37 @@ void simpleCounterReport(Severity severity) {
 
 	std::vector<SimpleCounter<int64_t>*> intCounters = SimpleCounter<int64_t>::getCounters();
 	std::vector<SimpleCounter<double>*> doubleCounters = SimpleCounter<double>::getCounters();
-	auto traceEvent = TraceEvent(severity, "SimpleCounters");
-	for (SimpleCounter<int64_t>* ic : intCounters) {
-		std::string n = ic->name();
-		n = mungeName(n);
-		ASSERT(validateField(n.c_str(), /* allowUnderscores= */ true));
-		traceEvent.detail(std::move(n), ic->get());
+
+	int i = 0;
+	// Avoid trace buffer overflow by assuming average field is O(100) bytes or less.
+	int countersPerTrace = FLOW_KNOBS->MAX_TRACE_EVENT_LENGTH / 100;
+	while (i < intCounters.size()) {
+		auto traceEvent = TraceEvent(severity, "SimpleCounters");
+		int c = 0;
+		do {
+			SimpleCounter<int64_t>* ic = intCounters[i];
+			std::string n = ic->name();
+			n = mungeName(n);
+			ASSERT(validateField(n.c_str(), /* allowUnderscores= */ true));
+			traceEvent.detail(std::move(n), ic->get());
+			i++;
+			c++;
+		} while (i < intCounters.size() && c < countersPerTrace);
 	}
-	for (SimpleCounter<double>* dc : doubleCounters) {
-		std::string n = dc->name();
-		n = mungeName(n);
-		ASSERT(validateField(n.c_str(), /* allowUnderscores= */ true));
-		traceEvent.detail(std::move(n), dc->get());
+	i = 0;
+	while (i < doubleCounters.size()) {
+		auto traceEvent = TraceEvent(severity, "SimpleCounters");
+		int c = 0;
+		do {
+			SimpleCounter<double>* dc = doubleCounters[i];
+			std::string n = dc->name();
+			n = mungeName(n);
+			ASSERT(validateField(n.c_str(), /* allowUnderscores= */ true));
+			traceEvent.detail(std::move(n), dc->get());
+			i++;
+			c++;
+		} while (i < doubleCounters.size() && c < countersPerTrace);
 	}
-	int total = intCounters.size() + doubleCounters.size();
-	traceEvent.detail("SimpleCountersTotalCounters", total);
 }
 
 TEST_CASE("/flow/simplecounter/int64") {

--- a/flow/include/flow/FastAlloc.h
+++ b/flow/include/flow/FastAlloc.h
@@ -24,6 +24,7 @@
 
 #include "flow/Error.h"
 #include "flow/Platform.h"
+#include "flow/SimpleCounter.h"
 #include "flow/config.h"
 
 // ALLOC_INSTRUMENTATION_STDOUT enables non-sampled logging of all allocations and deallocations to stdout to be
@@ -175,8 +176,6 @@ private:
 	}
 	static void* freelist;
 
-	// FIXME-METRICS: consider adding metrics objects here, or maybe in GlobalData.
-
 	static void getMagazine();
 	static void releaseMagazine(void*);
 };
@@ -185,6 +184,11 @@ extern std::atomic<int64_t> g_hugeArenaMemory;
 void hugeArenaSample(int size);
 void releaseAllThreadMagazines();
 int64_t getTotalUnusedAllocatedMemory();
+
+// These are thin wrappers around operator new and operator delete
+// and exist so that we can update metrics inside them.
+void* wrappedNew(size_t nbytes);
+void wrappedDelete(size_t nbytes, void* ptr);
 
 // Allow temporary overriding of default allocators used by arena to let memory survive deallocation and test
 // correctness of memory policy (e.g. zeroing out sensitive contents after use)
@@ -219,7 +223,12 @@ std::vector<std::pair<const uint8_t*, int>> const& getWipedAreaSet();
 } // namespace keepalive_allocator
 
 force_inline uint8_t* allocateAndMaybeKeepalive(size_t size) {
-	// FIXME-METRICS: count calls and bytes
+	static SimpleCounter<int64_t>* calls =
+	    SimpleCounter<int64_t>::makeCounter("/flow/fastalloc/AllocateAndMaybeKeepaliveCalls");
+	static SimpleCounter<int64_t>* bytes =
+	    SimpleCounter<int64_t>::makeCounter("/flow/fastalloc/AllocateAndMaybeKeepaliveBytes");
+	calls->increment(1);
+	bytes->increment(size);
 	uint8_t* p;
 	if (keepalive_allocator::isActive()) [[unlikely]]
 		p = static_cast<uint8_t*>(keepalive_allocator::allocate(size));
@@ -234,10 +243,12 @@ force_inline uint8_t* allocateAndMaybeKeepalive(size_t size) {
 }
 
 force_inline void freeOrMaybeKeepalive(void* ptr) {
+	static SimpleCounter<int64_t>* calls =
+	    SimpleCounter<int64_t>::makeCounter("/flow/fastalloc/FreeOrMaybeKeepaliveCalls");
+	calls->increment(1);
 	if (keepalive_allocator::isActive()) [[unlikely]]
 		keepalive_allocator::invalidate(ptr);
 	else
-		// FIXME-METRICS: count this
 		delete[] static_cast<uint8_t*>(ptr);
 }
 
@@ -269,6 +280,11 @@ inline constexpr int nextFastAllocatedSize(int x) {
 		return 16384;
 }
 
+// NOTE: for maintaining metrics on objects/bytes allocated and deleted,
+// we rely on FastAllocated<T>::allocate, wrappedNew(), and wrappedDelete()
+// to update metrics for code paths that do cause allocations or frees.
+// Do not add uninstrumented operator new or operator delete invocations.
+
 template <class Object>
 class FastAllocated {
 public:
@@ -277,12 +293,11 @@ public:
 			abort();
 		INSTRUMENT_ALLOCATE(typeid(Object).name());
 
-		// FIXME-METRICS: count calls and bytes on both sides of this loop
 		if constexpr (sizeof(Object) <= 256) {
 			void* p = FastAllocator < sizeof(Object) <= 64 ? 64 : nextFastAllocatedSize(sizeof(Object)) > ::allocate();
 			return p;
 		} else {
-			void* p = new uint8_t[nextFastAllocatedSize(sizeof(Object))];
+			void* p = wrappedNew(nextFastAllocatedSize(sizeof(Object)));
 			return p;
 		}
 	}
@@ -290,14 +305,10 @@ public:
 	static void operator delete(void* s) {
 		INSTRUMENT_RELEASE(typeid(Object).name());
 
-		// FIXME-METRICS: count calls. Consider whether putting the byte count
-		// and perhaps a (say) 1% sample of the top 5 call stack addresses is
-		// a thing we should do.
-
 		if constexpr (sizeof(Object) <= 256) {
 			FastAllocator<sizeof(Object) <= 64 ? 64 : nextFastAllocatedSize(sizeof(Object))>::release(s);
 		} else {
-			delete[] reinterpret_cast<uint8_t*>(s);
+			wrappedDelete(nextFastAllocatedSize(sizeof(Object)), s);
 		}
 	}
 	// Redefine placement new so you can still use it
@@ -306,9 +317,6 @@ public:
 };
 
 [[nodiscard]] inline void* allocateFast(int size) {
-	// FIXME-METRICS: count objects and bytes. Make sure the
-	// allocate() method is instrumented, or just count here
-	// to also cover the `new uint8_t[size]` below.
 	if (size <= 16)
 		return FastAllocator<16>::allocate();
 	if (size <= 32)
@@ -321,12 +329,10 @@ public:
 		return FastAllocator<128>::allocate();
 	if (size <= 256)
 		return FastAllocator<256>::allocate();
-	return new uint8_t[size];
+	return wrappedNew(size);
 }
 
 inline void freeFast(int size, void* ptr) {
-	// FIXME-METRICS: count objects and bytes, since we have the
-	// size from the caller.
 	if (size <= 16)
 		return FastAllocator<16>::release(ptr);
 	if (size <= 32)
@@ -339,13 +345,15 @@ inline void freeFast(int size, void* ptr) {
 		return FastAllocator<128>::release(ptr);
 	if (size <= 256)
 		return FastAllocator<256>::release(ptr);
-	delete[] (uint8_t*)ptr;
+	wrappedDelete(size, ptr);
 }
 
 // Allocate a block of memory aligned to 4096 bytes. Size must be a multiple of
 // 4096. Guaranteed not to return null. Use freeFast4kAligned to free.
 [[nodiscard]] inline void* allocateFast4kAligned(int size) {
-	// FIXME-METRICS: count calls and bytes
+	static SimpleCounter<int64_t>* bytes =
+	    SimpleCounter<int64_t>::makeCounter("/flow/fastalloc/Fast4AlignedBytesAllocated");
+	bytes->increment(size);
 
 #if !defined(USE_JEMALLOC)
 	// Use FastAllocator for sizes it supports to avoid internal fragmentation in some implementations of aligned_alloc
@@ -356,6 +364,7 @@ inline void freeFast(int size, void* ptr) {
 	if (size <= 16384)
 		return FastAllocator<16384>::allocate();
 #endif
+
 	auto* result = aligned_alloc(4096, size);
 	if (result == nullptr) {
 		platform::outOfMemory();
@@ -365,7 +374,9 @@ inline void freeFast(int size, void* ptr) {
 
 // Free a pointer returned from allocateFast4kAligned(size)
 inline void freeFast4kAligned(int size, void* ptr) {
-	// FIXME-METRICS: count calls and bytes
+	static SimpleCounter<int64_t>* bytes =
+	    SimpleCounter<int64_t>::makeCounter("/flow/fastalloc/Fast4AlignedBytesFreed");
+	bytes->increment(size);
 
 #if !defined(USE_JEMALLOC)
 	// Sizes supported by FastAllocator must be release via FastAllocator
@@ -376,7 +387,6 @@ inline void freeFast4kAligned(int size, void* ptr) {
 	if (size <= 16384)
 		return FastAllocator<16384>::release(ptr);
 #endif
-	// FIXME-METRICS: count calls and bytes
 	aligned_free(ptr);
 }
 

--- a/flow/include/flow/SimpleCounter.h
+++ b/flow/include/flow/SimpleCounter.h
@@ -27,6 +27,7 @@
 #include <vector>
 
 #include "flow/Error.h"
+#include "flow/Trace.h"
 
 // SimpleCounter metrics class for atomic counters of int64_t or
 // double.  Example usage:
@@ -144,6 +145,6 @@ inline void SimpleCounter<double>::increment(double delta) {
 	}
 }
 
-void simpleCounterReport(void);
+void simpleCounterReport(Severity severity = SevInfo);
 
 #endif


### PR DESCRIPTION
The general approach is to find code paths that actually do allocations and count calls/objects and bytes when we end up doing something that might be expensive.

This ends up adding metrics at about 3 levels (see code), which is fewer than possibly contemplated by the prior round of FIXMEs.  In theory I'm happy with the granularity.  In practice it remains to examine these metrics in various large scale use cases, mainly the recently fixed OOM.

Edit: updated to count bytes copied in StringRef

Edit: updated to instrument Arena.{h, cpp}

Updated: passes j100k 

[root@gglass-dev-okteto-56b45ddbf4-kkwcl foundationdb]# j list --stopped | grep gglass | tail -1
  20250829-202133-gglass-4e0609f3a1962fe7            compressed=True data_size=60850379 duration=5593536 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:01:07 sanity=False started=100000 stopped=20250829-212240 submitted=20250829-202133 timeout=5400 username=gglass
[root@gglass-dev-okteto-56b45ddbf4-kkwcl foundationdb]# 
[root@gglass-dev-okteto-56b45ddbf4-kkwcl foundationdb]# git log -n 1 
commit 665d7677ca9519a21337e8f620975726a0ee170b (HEAD -> metrics3, origin/metrics3)
Author: Gideon Glass <gxglassgithub@gmail.com>
Date:   Fri Aug 29 13:22:41 2025 -0700

    simpleCounterReport: generate TraceEvent in batches of MAX_TRACE_EVENT_LENGTH / 100 counters to avoid trace buffer overflow
[root@gglass-dev-okteto-56b45ddbf4-kkwcl foundationdb]# 
