### PR TITLE
Updates to Platform.cpp relating to format_backtrace

### DIFF
--- a/flow/Platform.actor.cpp
+++ b/flow/Platform.actor.cpp
@@ -3473,7 +3473,7 @@ std::string format_backtrace(void** addresses, int numAddresses) {
 	// /root/.bashrc.  It is easier to change the code here to
 	// emit a better command than it is to edit or remove that alias
 	// from the .bashrc, so that is what we are going to do.
-	// Also, one less moving part means confusion.
+	// Also, one less moving part means less confusion.
 	std::string addr2linePath;
 #ifdef __clang__
 	addr2linePath = "/usr/local/bin/llvm-addr2line";

--- a/flow/Platform.actor.cpp
+++ b/flow/Platform.actor.cpp
@@ -3466,7 +3466,7 @@ std::string get_backtrace() {
 	return format_backtrace(addresses, size);
 }
 } // namespace platform
-#endif  // __unixish__
+#endif // __unixish__
 
 namespace platform {
 std::string format_backtrace(void** addresses, int numAddresses) {
@@ -3503,7 +3503,7 @@ std::string format_backtrace(void** addresses, int numAddresses) {
 		s += format(" %p", (char*)addresses[i] - (char*)imageInfo.offset);
 	}
 #endif
-#endif	
+#endif
 	return s;
 }
 } // namespace platform

--- a/flow/Platform.actor.cpp
+++ b/flow/Platform.actor.cpp
@@ -3211,16 +3211,7 @@ void outOfMemory() {
 
 	for (auto i = traceCounts.begin(); i != traceCounts.end(); ++i) {
 		std::vector<void*>* frames = i->second.backTrace;
-		std::string backTraceStr;
-#if defined(_WIN32)
-		char buf[1024];
-		for (int j = 1; j < frames->size(); j++) {
-			_snprintf(buf, 1024, "%p ", frames->at(j));
-			backTraceStr += buf;
-		}
-#else
-		backTraceStr = format_backtrace(&(*frames)[0], frames->size());
-#endif
+		std::string backTraceStr = format_backtrace(&(*frames)[0], frames->size());
 		TraceEvent("MemSample")
 		    .detail("Count", (int64_t)i->second.count)
 		    .detail("TotalSize", i->second.totalSize)
@@ -3425,23 +3416,13 @@ platform::ImageInfo getImageInfo(const void* symbol) {
 
 	if (res != 0) {
 		imageInfo.fileName = info.dli_fname;
-		std::string imageFile = basename(info.dli_fname);
-		// If we have a client library that doesn't end in the appropriate extension, we will get the wrong debug
-		// suffix. This should only be a cosmetic problem, though.
-#ifdef __linux__
-		imageInfo.offset = (void*)linkMap->l_addr;
-		if (imageFile.length() >= 3 && imageFile.rfind(".so") == imageFile.length() - 3) {
-			imageInfo.symbolFileName = imageFile + "-debug";
-		}
-#else
-		imageInfo.offset = info.dli_fbase;
-		if (imageFile.length() >= 6 && imageFile.rfind(".dylib") == imageFile.length() - 6) {
-			imageInfo.symbolFileName = imageFile + "-debug";
-		}
-#endif
-		else {
-			imageInfo.symbolFileName = imageFile + ".debug";
-		}
+		// Previously this code would guess "debug" related binary name suffixes.
+		// If you run a binary called fdbserver.debug, it would emit an addr2line
+		// command referencing a binary called "fdbserver.debug.debug".
+		// That is just brain dead.  If the developer needs to point the command
+		// to a different binary than then one they executed, then they can
+		// simply edit the emitted command.
+		imageInfo.symbolFileName = info.dli_fname;
 	}
 
 	return imageInfo;
@@ -3472,17 +3453,39 @@ size_t raw_backtrace(void** addresses, int maxStackDepth) {
 
 std::string format_backtrace(void** addresses, int numAddresses) {
 	ImageInfo const& imageInfo = getCachedImageInfo();
+
+	std::string s;
+#if defined(_WIN32)
+	char buf[32];
+	for (int j = 1; j < numAddresses; j++) {
+		_snprintf(buf, sizeof(buf), "%p ", addresses[i]);
+		s += buf;
+	}
+#else
 #ifdef __APPLE__
-	std::string s = format("atos -o %s -arch x86_64 -l %p", imageInfo.symbolFileName.c_str(), imageInfo.offset);
+	s = format("atos -o %s -arch x86_64 -l %p", imageInfo.symbolFileName.c_str(), imageInfo.offset);
 	for (int i = 1; i < numAddresses; i++) {
 		s += format(" %p", addresses[i]);
 	}
 #else
-	std::string s = format("addr2line -e %s -p -C -f -i", imageInfo.symbolFileName.c_str());
+	// Specify an absolute addr2line path to avoid the unhelpful
+	// `addr2line` shell alias that is baked into the FDB dev VM
+	// /root/.bashrc.  It is easier to change the code here to
+	// emit a better command than it is to edit or remove that alias
+	// from the .bashrc, so that is what we are going to do.
+	// Also, one less moving part means confusion.
+	std::string addr2linePath;
+#ifdef __clang__
+	addr2linePath = "/usr/local/bin/llvm-addr2line";
+#else
+	addr2linePath = "/usr/bin/addr2line";
+#endif
+	s = format("%s -e %s -p -C -f -i", addr2linePath.c_str(), imageInfo.symbolFileName.c_str());
 	for (int i = 1; i < numAddresses; i++) {
 		s += format(" %p", (char*)addresses[i] - (char*)imageInfo.offset);
 	}
 #endif
+#endif	
 	return s;
 }
 

--- a/flow/Platform.actor.cpp
+++ b/flow/Platform.actor.cpp
@@ -3475,7 +3475,7 @@ std::string format_backtrace(void** addresses, int numAddresses) {
 	std::string s;
 #if defined(_WIN32)
 	char buf[32];
-	for (int j = 1; j < numAddresses; j++) {
+	for (int i = 1; i < numAddresses; i++) {
 		_snprintf(buf, sizeof(buf), "%p ", addresses[i]);
 		s += buf;
 	}

--- a/flow/Platform.actor.cpp
+++ b/flow/Platform.actor.cpp
@@ -3419,7 +3419,7 @@ platform::ImageInfo getImageInfo(const void* symbol) {
 		// Previously this code would guess "debug" related binary name suffixes.
 		// If you run a binary called fdbserver.debug, it would emit an addr2line
 		// command referencing a binary called "fdbserver.debug.debug".
-		// That is just brain dead.  If the developer needs to point the command
+		// This is not helpful.  If the developer needs to point the command
 		// to a different binary than then one they executed, then they can
 		// simply edit the emitted command.
 		imageInfo.symbolFileName = info.dli_fname;

--- a/flow/SystemMonitor.cpp
+++ b/flow/SystemMonitor.cpp
@@ -432,17 +432,7 @@ SystemStatistics customSystemMonitor(std::string const& eventName, StatisticsSta
 			uint64_t totalCount = 0;
 			for (auto i = traceCounts.begin(); i != traceCounts.end(); ++i) {
 				std::vector<void*>* frames = i->second.backTrace;
-				std::string backTraceStr;
-#if defined(_WIN32)
-				char buf[1024];
-				for (int j = 1; j < frames->size(); j++) {
-					_snprintf(buf, 1024, "%p ", frames->at(j));
-					backTraceStr += buf;
-				}
-#else
-				backTraceStr = platform::format_backtrace(&(*frames)[0], frames->size());
-#endif
-
+				std::string backTraceStr = platform::format_backtrace(&(*frames)[0], frames->size());
 				TraceEvent("MemSample")
 				    .detail("Count", (int64_t)i->second.count)
 				    .detail("TotalSize", i->second.totalSize)


### PR DESCRIPTION
* Refactor ifdefs to make format_backtrace() be exposed for _WIN32, and remove WIN32 ifdefs in non-Platform.cpp code.

* In shell commands emitted by format_backtrace, change the addr2line command to specify the full path to the addr2line binary, to avoid people getting hung up by the broken shell alias in /root/.bashrc.  As far as I can tell this alias exists to invoke gcc- or clang-specific addr2line binaries, which is easy enough to solve in the .cpp code.

* Delete logic that naively appends "debug" related suffixes to the fdbserver binary name.  The code doesn't know if it's a debug binary or not, and if it's not, the most obvious solution is to rebuild everything.  Copying binaries around manually is not needed and the emitted commands shouldn't encourage this, as far as I can tell.  They should just use the given binary name.

Tested the addr2line invocations by inserting some segfaults and running the commands (with minor updates to give the absolute path to the fdbserver binary).  Tested on gcc and clang debug builds.

j100k:

[root@gglass-dev-okteto-56b45ddbf4-kkwcl foundationdb]# git log -n 1 ; j list --stopped | grep gglass | tail -1 
commit aaa203d9e9e5e6dfd91144a09f2b99e121a7f67f (HEAD -> metrics5, origin/metrics5)
Author: Gideon Glass <gxglassgithub@gmail.com>
Date:   Sat Aug 30 18:15:55 2025 -0700

    format code
  20250831-010825-gglass-d6f011a4e956114a            compressed=True data_size=41536206 duration=5816899 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:01:21 sanity=False started=100000 stopped=20250831-020946 submitted=20250831-010825 timeout=5400 username=gglass
[root@gglass-dev-okteto-56b45ddbf4-kkwcl foundationdb]# 
