### PR TITLE
Add counters for tracking request/process rate of handshakes

### DIFF
--- a/fdbrpc/FlowTransport.actor.cpp
+++ b/fdbrpc/FlowTransport.actor.cpp
@@ -317,6 +317,14 @@ public:
 		countConnClosedWithoutError.init("Net2.CountConnClosedWithoutError"_sr);
 		countConnIncompatible.init("Net2.CountConnIncompatible"_sr);
 		countConnIncompatibleWithOldClient.init("Net2.CountConnIncompatibleWithOldClient"_sr);
+		countConnHandshakeAccepted.init("Net2.CountConnHandshakeAccepted"_sr);
+		countConnHandshakeRequested.init("Net2.CountConnHandshakeRequested"_sr);
+		countIncomingConnRequested.init("Net2.CountIncomingConnRequested"_sr);
+		countIncomingConnAccepted.init("Net2.CountIncomingConnAccepted"_sr);
+		countOutgoingConnHandshakeComplete.init("Net2.CountOutgoingConnHandshakeComplete"_sr);
+		countOutgoingConnHandshakeRequested.init("Net2.CountOutgoingConnHandshakeRequested"_sr);
+		countIncomingConnectionTimedout.init("Net2.CountIncomingConnectionTimedout"_sr);
+		countIncomingConnConnected.init("Net2.CountIncomingConnConnected"_sr);
 	}
 
 	Reference<struct Peer> getPeer(NetworkAddress const& address);
@@ -347,6 +355,14 @@ public:
 	Int64MetricHandle countConnClosedWithoutError;
 	Int64MetricHandle countConnIncompatible;
 	Int64MetricHandle countConnIncompatibleWithOldClient;
+	Int64MetricHandle countConnHandshakeAccepted;
+	Int64MetricHandle countConnHandshakeRequested;
+	Int64MetricHandle countIncomingConnRequested;
+	Int64MetricHandle countIncomingConnAccepted;
+	Int64MetricHandle countOutgoingConnHandshakeComplete;
+	Int64MetricHandle countOutgoingConnHandshakeRequested;
+	Int64MetricHandle countIncomingConnectionTimedout;
+	Int64MetricHandle countIncomingConnConnected;
 
 	std::map<NetworkAddress, std::pair<uint64_t, double>> incompatiblePeers;
 	AsyncTrigger incompatiblePeersChanged;
@@ -816,7 +832,9 @@ ACTOR Future<Void> connectionKeeper(Reference<Peer> self,
 						when(Reference<IConnection> _conn =
 						         wait(INetworkConnections::net()->connect(self->destination))) {
 							conn = _conn;
+							self->transport->countOutgoingConnHandshakeRequested++;
 							wait(conn->connectHandshake());
+							self->transport->countOutgoingConnHandshakeComplete++;
 							self->connectLatencies.addSample(now() - self->lastConnectTime);
 							if (FlowTransport::isClient()) {
 								IFailureMonitor::failureMonitor().setStatus(self->destination, FailureStatus(false));
@@ -1606,7 +1624,9 @@ ACTOR static Future<Void> connectionIncoming(TransportData* self, Reference<ICon
 	entry.time = now();
 	entry.addr = conn->getPeerAddress();
 	try {
+		self->countConnHandshakeRequested++;
 		wait(conn->acceptHandshake());
+		self->countConnHandshakeAccepted++;
 		state Promise<Reference<Peer>> onConnected;
 		state Future<Void> reader = connectionReader(self, conn, Reference<Peer>(), onConnected);
 		if (FLOW_KNOBS->LOG_CONNECTION_ATTEMPTS_ENABLED) {
@@ -1623,9 +1643,11 @@ ACTOR static Future<Void> connectionIncoming(TransportData* self, Reference<ICon
 			}
 			when(wait(delayJittered(FLOW_KNOBS->CONNECTION_MONITOR_TIMEOUT))) {
 				CODE_PROBE(true, "Incoming connection timed out");
+				self->countIncomingConnectionTimedout++;
 				throw timed_out();
 			}
 		}
+		self->countIncomingConnConnected++;
 	} catch (Error& e) {
 		if (e.code() != error_code_actor_cancelled) {
 			TraceEvent("IncomingConnectionError", conn->getDebugID())
@@ -1656,7 +1678,9 @@ ACTOR static Future<Void> listen(TransportData* self, NetworkAddress listenAddr)
 	state uint64_t connectionCount = 0;
 	try {
 		loop {
+			self->countIncomingConnRequested++;
 			Reference<IConnection> conn = wait(listener->accept());
+			self->countIncomingConnAccepted++;
 			if (conn) {
 				TraceEvent("ConnectionFrom", conn->getDebugID())
 				    .suppressFor(1.0)

--- a/flow/Net2.actor.cpp
+++ b/flow/Net2.actor.cpp
@@ -327,6 +327,10 @@ public:
 	Int64MetricHandle countServerTLSHandshakesOnMainThread;
 	Int64MetricHandle countClientTLSHandshakesTimedout;
 	Int64MetricHandle countServerTLSHandshakesTimedout;
+	Int64MetricHandle countServerTLSHandshakeThrottled;
+	Int64MetricHandle countClientTLSHandshakeThrottled;
+	Int64MetricHandle countServerTLSHandshakeLocked;
+	Int64MetricHandle countClientTLSHandshakeLocked;
 
 	EventMetricHandle<SlowTask> slowTaskMetric;
 
@@ -911,6 +915,7 @@ public:
 				if (iter->second.first >= FLOW_KNOBS->TLS_CLIENT_CONNECTION_THROTTLE_ATTEMPTS) {
 					TraceEvent("TLSOutgoingConnectionThrottlingWarning").suppressFor(1.0).detail("PeerIP", addr);
 					wait(delay(FLOW_KNOBS->CONNECTION_MONITOR_TIMEOUT));
+					g_net2->countClientTLSHandshakeThrottled++;
 					throw connection_failed();
 				}
 			} else {
@@ -999,6 +1004,7 @@ public:
 					    .detail("PeerIP", peerIP.first.toString());
 					wait(delay(FLOW_KNOBS->CONNECTION_MONITOR_TIMEOUT));
 					self->closeSocket();
+					g_net2->countServerTLSHandshakeThrottled++;
 					throw connection_failed();
 				}
 			} else {
@@ -1009,6 +1015,7 @@ public:
 		wait(g_network->networkInfo.handshakeLock->take(
 		    getTaskPriorityFromInt(FLOW_KNOBS->TLS_HANDSHAKE_FLOWLOCK_PRIORITY)));
 		state FlowLock::Releaser releaser(*g_network->networkInfo.handshakeLock);
+		g_net2->countServerTLSHandshakeLocked++;
 
 		Promise<Void> connected;
 		doAcceptHandshake(self, connected);
@@ -1089,6 +1096,7 @@ public:
 		wait(g_network->networkInfo.handshakeLock->take(
 		    getTaskPriorityFromInt(FLOW_KNOBS->TLS_HANDSHAKE_FLOWLOCK_PRIORITY)));
 		state FlowLock::Releaser releaser(*g_network->networkInfo.handshakeLock);
+		g_net2->countClientTLSHandshakeLocked++;
 
 		Promise<Void> connected;
 		doConnectHandshake(self, connected);
@@ -1494,6 +1502,10 @@ void Net2::initMetrics() {
 	countServerTLSHandshakesOnMainThread.init("Net2.CountServerTLSHandshakesOnMainThread"_sr);
 	countClientTLSHandshakesTimedout.init("Net2.CountClientTLSHandshakesTimedout"_sr);
 	countServerTLSHandshakesTimedout.init("Net2.CountServerTLSHandshakesTimedout"_sr);
+	countServerTLSHandshakeThrottled.init("Net2.CountServerTLSHandshakeThrottled"_sr);
+	countClientTLSHandshakeThrottled.init("Net2.CountClientTLSHandshakeThrottled"_sr);
+	countServerTLSHandshakeLocked.init("Net2.CountServerTLSHandshakeLocked"_sr);
+	countClientTLSHandshakeLocked.init("Net2.CountClientTLSHandshakeLocked"_sr);
 	taskQueue.initMetrics();
 }
 

--- a/flow/SystemMonitor.cpp
+++ b/flow/SystemMonitor.cpp
@@ -216,6 +216,49 @@ SystemStatistics customSystemMonitor(std::string const& eventName, StatisticsSta
 			            (netData.countServerTLSHandshakesTimedout -
 			             statState->networkState.countServerTLSHandshakesTimedout) /
 			                currentStats.elapsed)
+			    .detail("ConnectionHandshakeAccepted",
+			            (netData.countConnHandshakeAccepted - statState->networkState.countConnHandshakeAccepted) /
+			                currentStats.elapsed)
+			    .detail("ConnectionHandshakeRequested",
+			            (netData.countConnHandshakeRequested - statState->networkState.countConnHandshakeRequested) /
+			                currentStats.elapsed)
+			    .detail("IncomingConnRequested",
+			            (netData.countIncomingConnRequested - statState->networkState.countIncomingConnRequested) /
+			                currentStats.elapsed)
+			    .detail("IncomingConnAccepted",
+			            (netData.countIncomingConnAccepted - statState->networkState.countIncomingConnAccepted) /
+			                currentStats.elapsed)
+			    .detail("ServerTLSHandshakeThrottled",
+			            (netData.countServerTLSHandshakeThrottled -
+			             statState->networkState.countServerTLSHandshakeThrottled) /
+			                currentStats.elapsed)
+			    .detail("ClientTLSHandshakeThrottled",
+			            (netData.countClientTLSHandshakeThrottled -
+			             statState->networkState.countClientTLSHandshakeThrottled) /
+			                currentStats.elapsed)
+			    .detail("OutgoingConnHandshakeComplete",
+			            (netData.countOutgoingConnHandshakeComplete -
+			             statState->networkState.countOutgoingConnHandshakeComplete) /
+			                currentStats.elapsed)
+			    .detail("OutgoingConnHandshakeRequested",
+			            (netData.countOutgoingConnHandshakeRequested -
+			             statState->networkState.countOutgoingConnHandshakeRequested) /
+			                currentStats.elapsed)
+			    .detail("IncomingConnectionTimedout",
+			            (netData.countIncomingConnectionTimedout -
+			             statState->networkState.countIncomingConnectionTimedout) /
+			                currentStats.elapsed)
+			    .detail(
+			        "ServerTLSHandshakeLocked",
+			        (netData.countServerTLSHandshakeLocked - statState->networkState.countServerTLSHandshakeLocked) /
+			            currentStats.elapsed)
+			    .detail(
+			        "ClientTLSHandshakeLocked",
+			        (netData.countClientTLSHandshakeLocked - statState->networkState.countClientTLSHandshakeLocked) /
+			            currentStats.elapsed)
+			    .detail("IncomingConnConnected",
+			            (netData.countIncomingConnConnected - statState->networkState.countIncomingConnConnected) /
+			                currentStats.elapsed)
 
 			    .trackLatest(eventName);
 

--- a/flow/include/flow/SystemMonitor.h
+++ b/flow/include/flow/SystemMonitor.h
@@ -105,6 +105,18 @@ struct NetworkData {
 	                                            // hasInexpensiveMultiVersionClient.
 	int64_t countClientTLSHandshakesTimedout;
 	int64_t countServerTLSHandshakesTimedout;
+	int64_t countConnHandshakeAccepted;
+	int64_t countConnHandshakeRequested;
+	int64_t countIncomingConnRequested;
+	int64_t countIncomingConnAccepted;
+	int64_t countServerTLSHandshakeThrottled;
+	int64_t countClientTLSHandshakeThrottled;
+	int64_t countOutgoingConnHandshakeComplete;
+	int64_t countOutgoingConnHandshakeRequested;
+	int64_t countIncomingConnectionTimedout;
+	int64_t countServerTLSHandshakeLocked;
+	int64_t countClientTLSHandshakeLocked;
+	int64_t countIncomingConnConnected;
 
 	void init() {
 		bytesSent = Int64Metric::getValueOrDefault("Net2.BytesSent"_sr);
@@ -160,6 +172,20 @@ struct NetworkData {
 		    Int64Metric::getValueOrDefault("Net2.CountConnIncompatibleWithOldClient"_sr);
 		countClientTLSHandshakesTimedout = Int64Metric::getValueOrDefault("Net2.CountClientTLSHandshakesTimedout"_sr);
 		countServerTLSHandshakesTimedout = Int64Metric::getValueOrDefault("Net2.CountServerTLSHandshakesTimedout"_sr);
+		countConnHandshakeAccepted = Int64Metric::getValueOrDefault("Net2.CountConnHandshakeAccepted"_sr);
+		countConnHandshakeRequested = Int64Metric::getValueOrDefault("Net2.CountConnHandshakeRequested"_sr);
+		countIncomingConnRequested = Int64Metric::getValueOrDefault("Net2.CountIncomingConnRequested"_sr);
+		countIncomingConnAccepted = Int64Metric::getValueOrDefault("Net2.CountIncomingConnAccepted"_sr);
+		countServerTLSHandshakeThrottled = Int64Metric::getValueOrDefault("Net2.CountServerTLSHandshakeThrottled"_sr);
+		countClientTLSHandshakeThrottled = Int64Metric::getValueOrDefault("Net2.CountClientTLSHandshakeThrottled"_sr);
+		countOutgoingConnHandshakeComplete =
+		    Int64Metric::getValueOrDefault("Net2.CountOutgoingConnHandshakeComplete"_sr);
+		countOutgoingConnHandshakeRequested =
+		    Int64Metric::getValueOrDefault("Net2.CountOutgoingConnHandshakeRequested"_sr);
+		countIncomingConnectionTimedout = Int64Metric::getValueOrDefault("Net2.CountIncomingConnectionTimedout"_sr);
+		countServerTLSHandshakeLocked = Int64Metric::getValueOrDefault("Net2.CountServerTLSHandshakeLocked"_sr);
+		countClientTLSHandshakeLocked = Int64Metric::getValueOrDefault("Net2.CountClientTLSHandshakeLocked"_sr);
+		countIncomingConnConnected = Int64Metric::getValueOrDefault("Net2.CountIncomingConnConnected"_sr);
 	}
 };
 


### PR DESCRIPTION
The PR adds counters to the following steps when a TLS fdbserver receives an incoming connection:
1. The connection arrives at the server accepted by the server (IncomingConnAccepted);
2. The connection starts accepting handshake requests (ConnectionHandshakeRequested);
3. The connection may be rejected (i.e. closed) immediately due to throttling (ServerTLSHandshakeThrottled);
4. The handshake flow lock taken (ServerTLSHandshakeLocked);
5. Doing acceptHandShake (ServerTLSHandshakesOnSideThreads for the background threads and ServerTLSHandshakesOnMainThread for the main thread);
6. Handshake accepted (ConnectionHandshakeAccepted);
7. The connection may be timed out before connected (IncomingConnectionTimedout);
8. Connected (IncomingConnConnected);

With counter indicating the rate at each step, we can identify the bottleneck of throughput when a fdbserver is overloaded by incoming connections.


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
