### PR TITLE
Add FDBWorkloadContext::delay

### DIFF
--- a/bindings/c/foundationdb/CWorkload.h
+++ b/bindings/c/foundationdb/CWorkload.h
@@ -25,7 +25,9 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+typedef struct FDB_future FDBFuture;
 typedef struct FDB_database FDBDatabase;
+
 typedef struct Opaque_promise OpaquePromise;
 typedef struct Opaque_workload OpaqueWorkload;
 typedef struct Opaque_workloadContext OpaqueWorkloadContext;
@@ -98,6 +100,7 @@ typedef struct FDBWorkloadContext {
 	int (*clientId)(OpaqueWorkloadContext* inner);
 	int (*clientCount)(OpaqueWorkloadContext* inner);
 	int64_t (*sharedRandomNumber)(OpaqueWorkloadContext* inner);
+	FDBFuture* (*delay)(double seconds);
 } FDBWorkloadContext;
 
 // Interface for a workload implementation in C.

--- a/bindings/c/foundationdb/CWorkload.h
+++ b/bindings/c/foundationdb/CWorkload.h
@@ -25,6 +25,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#define FDB_WORKLOAD_API_VERSION 1
+
 typedef struct FDB_future FDBFuture;
 typedef struct FDB_database FDBDatabase;
 
@@ -97,6 +99,7 @@ typedef struct FDBPromise {
 // Wrapper around a borrowed `ExternalWorkload`'s context.
 // All pointer-based arguments are borrowed and managed by the workload.
 typedef struct FDBWorkloadContext {
+	int api_version;
 	OpaqueWorkloadContext* inner;
 	struct FDBWorkloadContext_VT {
 		// Log a message with severity and optional details.
@@ -133,6 +136,7 @@ typedef struct FDBWorkloadContext {
 // Workload functions should not block. If an operation must wait for database interaction,
 // it should initiate the action, register a callback, and return.
 typedef struct FDBWorkload {
+	int api_version;
 	OpaqueWorkload* inner;
 	struct FDBWorkload_VT {
 		void (*free)(OpaqueWorkload* inner);

--- a/bindings/c/foundationdb/CWorkload.h
+++ b/bindings/c/foundationdb/CWorkload.h
@@ -122,7 +122,7 @@ typedef struct FDBWorkloadContext {
 		int (*clientCount)(OpaqueWorkloadContext* inner);
 		// Return a random seed (same each time and for all clients).
 		int64_t (*sharedRandomNumber)(OpaqueWorkloadContext* inner);
-		// Return a future that will be resolved after a given time.
+		// Return a future that will be ready after a given time. This internally uses TaskPriority::DefaultDelay.
 		FDBFuture* (*delay)(OpaqueWorkloadContext* inner, double seconds);
 	}* vt;
 } FDBWorkloadContext;

--- a/bindings/c/foundationdb/CppWorkload.h
+++ b/bindings/c/foundationdb/CppWorkload.h
@@ -64,6 +64,7 @@ public:
 	virtual int clientId() const = 0;
 	virtual int clientCount() const = 0;
 	virtual int64_t sharedRandomNumber() const = 0;
+	virtual FDBFuture* delay(double seconds) const = 0;
 };
 
 struct FDBPromise {

--- a/bindings/c/test/workloads/CWorkload.c
+++ b/bindings/c/test/workloads/CWorkload.c
@@ -133,7 +133,12 @@ EXPORT FDBWorkload workloadCFactory(const char* borrow_name, FDBWorkloadContext 
 
 	int client_id = WITH(context, clientId);
 	int client_count = WITH(context, clientCount);
-	printf("workloadCFactory(%s)[%d/%d]\n", name, client_id, client_count);
+	printf("workloadCFactory(%s)[%d/%d]: client_version: %d, server_version: %d\n",
+	       name,
+	       client_id,
+	       client_count,
+	       FDB_WORKLOAD_API_VERSION,
+	       context.api_version);
 
 	FDBString my_c_option;
 	my_c_option = WITH(context, getOption, "my_c_option", "null");
@@ -143,17 +148,13 @@ EXPORT FDBWorkload workloadCFactory(const char* borrow_name, FDBWorkloadContext 
 	printf("my_c_option: \"%s\"\n", my_c_option.inner);
 	WITH(my_c_option, free);
 
-	printf("c_init(%s_%d) rnd: %u\n", name, client_id, WITH(context, rnd));
-	printf("c_init(%s_%d) rnd: %u\n", name, client_id, WITH(context, rnd));
-	printf("c_init(%s_%d) shared_rnd: %lu\n", name, client_id, WITH(context, sharedRandomNumber));
-	printf("c_init(%s_%d) shared_rnd: %lu\n", name, client_id, WITH(context, sharedRandomNumber));
-
 	CWorkload* workload = (CWorkload*)malloc(sizeof(CWorkload));
 	workload->name = name;
 	workload->client_id = client_id;
 	workload->context = context;
 
 	return (FDBWorkload){
+		.api_version = FDB_WORKLOAD_API_VERSION,
 		.inner = (OpaqueWorkload*)workload,
 		.vt = &CWorkload_vt,
 	};

--- a/bindings/c/test/workloads/RustWorkload/Cargo.toml
+++ b/bindings/c/test/workloads/RustWorkload/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [build-dependencies]
-bindgen = "0.70.1"
+bindgen = "0.72.1"

--- a/bindings/c/test/workloads/RustWorkload/src/bindings.rs
+++ b/bindings/c/test/workloads/RustWorkload/src/bindings.rs
@@ -9,7 +9,8 @@ mod raw_bindings {
     include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 }
 pub use raw_bindings::{
-    FDBDatabase, FDBMetrics, FDBPromise, FDBWorkload, FDBWorkloadContext, OpaqueWorkload,
+    FDBDatabase, FDBMetrics, FDBPromise, FDBWorkload, FDBWorkloadContext,
+    FDBWorkload_FDBWorkload_VT as FDBWorkload_VT, OpaqueWorkload,
 };
 use raw_bindings::{
     FDBMetric, FDBSeverity, FDBSeverity_FDBSeverity_Debug, FDBSeverity_FDBSeverity_Error,
@@ -74,6 +75,12 @@ pub enum Severity {
 // -----------------------------------------------------------------------------
 // Implementations
 
+macro_rules! with {
+    ($this:expr=>$method:ident($($args:expr),* $(,)?)) => {
+        unsafe { (*$this.vt).$method.unwrap_unchecked()($this.inner $(, $args)*) }
+    };
+}
+
 impl WorkloadContext {
     pub fn new(raw: FDBWorkloadContext) -> Self {
         Self(raw)
@@ -99,9 +106,7 @@ impl WorkloadContext {
                 val: val.as_ptr(),
             })
             .collect::<Vec<_>>();
-        unsafe {
-            self.0.trace.unwrap_unchecked()(
-                self.0.inner,
+        with! {self.0 => trace(
                 severity as FDBSeverity,
                 name.as_ptr(),
                 details.as_ptr(),
@@ -111,19 +116,19 @@ impl WorkloadContext {
     }
     /// Get the process id of the workload
     pub fn get_process_id(&self) -> u64 {
-        unsafe { self.0.getProcessID.unwrap_unchecked()(self.0.inner) }
+        with! {self.0 => getProcessID() }
     }
     /// Set the process id of the workload
     pub fn set_process_id(&self, id: u64) {
-        unsafe { self.0.setProcessID.unwrap_unchecked()(self.0.inner, id) }
+        with! {self.0 => setProcessID(id) }
     }
     /// Get the current simulated time in seconds (starts at zero)
     pub fn now(&self) -> f64 {
-        unsafe { self.0.now.unwrap_unchecked()(self.0.inner) }
+        with! {self.0 => now() }
     }
     /// Get a determinist 32-bit random number
     pub fn rnd(&self) -> u32 {
-        unsafe { self.0.rnd.unwrap_unchecked()(self.0.inner) }
+        with! {self.0 => rnd() }
     }
     /// Get the value of a parameter from the simulation config file
     ///
@@ -139,11 +144,9 @@ impl WorkloadContext {
         let null = "";
         let name = str_for_c(name);
         let default_value = str_for_c(null);
-        let raw_value = unsafe {
-            self.0.getOption.unwrap_unchecked()(self.0.inner, name.as_ptr(), default_value.as_ptr())
-        };
+        let raw_value = with! {self.0 => getOption(name.as_ptr(), default_value.as_ptr()) };
         let value = str_from_c(raw_value.inner);
-        unsafe { raw_value.free.unwrap_unchecked()(raw_value.inner) };
+        with! {raw_value => free() };
         if value == null {
             None
         } else {
@@ -152,15 +155,15 @@ impl WorkloadContext {
     }
     /// Get the client id of the workload
     pub fn client_id(&self) -> i32 {
-        unsafe { self.0.clientId.unwrap_unchecked()(self.0.inner) }
+        with! {self.0 => clientId() }
     }
     /// Get the number of clients of the workload
     pub fn client_count(&self) -> i32 {
-        unsafe { self.0.clientCount.unwrap_unchecked()(self.0.inner) }
+        with! {self.0 => clientCount() }
     }
     /// Get a determinist 64-bit random number
     pub fn shared_random_number(&self) -> i64 {
-        unsafe { self.0.sharedRandomNumber.unwrap_unchecked()(self.0.inner) }
+        with! {self.0 => sharedRandomNumber() }
     }
 }
 
@@ -173,12 +176,12 @@ impl Promise {
     ///
     /// note: FoundationDB disregards the value sent, so sending `true` or `false` is equivalent
     pub fn send(self, value: bool) {
-        unsafe { self.0.send.unwrap_unchecked()(self.0.inner, value) };
+        with! {self.0 => send(value) };
     }
 }
 impl Drop for Promise {
     fn drop(&mut self) {
-        unsafe { self.0.free.unwrap_unchecked()(self.0.inner) };
+        with! {self.0 => free() };
     }
 }
 
@@ -188,22 +191,18 @@ impl Metrics {
     }
     /// Call `reserve` on the underlying C++ vector of metrics
     pub fn reserve(&mut self, n: usize) {
-        unsafe { self.0.reserve.unwrap_unchecked()(self.0.inner, n as i32) }
+        with! {self.0 => reserve(n as i32) }
     }
     /// Add a single metric to the sink
     pub fn push(&mut self, metric: Metric) {
         let key_storage = str_for_c(metric.key);
         let fmt_storage = str_for_c(metric.fmt.as_deref().unwrap_or("%.3g"));
-        unsafe {
-            self.0.push.unwrap_unchecked()(
-                self.0.inner,
-                FDBMetric {
-                    key: key_storage.as_ptr(),
-                    fmt: fmt_storage.as_ptr(),
-                    val: metric.val,
-                    avg: metric.avg,
-                },
-            )
+        with! {self.0 => push(FDBMetric {
+                key: key_storage.as_ptr(),
+                fmt: fmt_storage.as_ptr(),
+                val: metric.val,
+                avg: metric.avg,
+            })
         }
     }
     /// Add multiple metrics, ensuring the sink reallocates at most once

--- a/bindings/c/test/workloads/RustWorkload/src/bindings.rs
+++ b/bindings/c/test/workloads/RustWorkload/src/bindings.rs
@@ -18,6 +18,8 @@ use raw_bindings::{
     FDBStringPair,
 };
 
+pub const FDB_WORKLOAD_API_VERSION: i32 = raw_bindings::FDB_WORKLOAD_API_VERSION as i32;
+
 // -----------------------------------------------------------------------------
 // String conversions
 
@@ -84,6 +86,10 @@ macro_rules! with {
 impl WorkloadContext {
     pub fn new(raw: FDBWorkloadContext) -> Self {
         Self(raw)
+    }
+    /// Get the server FDB_WORKLOAD_API_VERSION
+    pub fn get_workload_api_version(&self) -> i32 {
+        self.0.api_version
     }
     /// Add a log entry in the FoundationDB logs
     pub fn trace<S>(&self, severity: Severity, name: S, details: &[(&str, &str)])

--- a/bindings/c/test/workloads/RustWorkload/src/lib.rs
+++ b/bindings/c/test/workloads/RustWorkload/src/lib.rs
@@ -6,6 +6,7 @@ mod mock;
 use bindings::{
     str_from_c, FDBDatabase, FDBMetrics, FDBPromise, FDBWorkload, FDBWorkloadContext,
     FDBWorkload_VT, Metric, Metrics, OpaqueWorkload, Promise, Severity, WorkloadContext,
+    FDB_WORKLOAD_API_VERSION,
 };
 
 /// Should be replaced by a Rust wrapper over the `FDBDatabase` bindings, like the one provided by foundationdb-rs
@@ -28,6 +29,7 @@ pub trait RustWorkload: Sized {
     fn wrap(self) -> WrappedWorkload {
         let inner = Box::into_raw(Box::new(self));
         WrappedWorkload {
+            api_version: FDB_WORKLOAD_API_VERSION,
             inner: inner as *mut _,
             vt: &Self::VT as *const _ as *mut _,
         }

--- a/bindings/c/test/workloads/RustWorkload/src/lib.rs
+++ b/bindings/c/test/workloads/RustWorkload/src/lib.rs
@@ -4,8 +4,8 @@ mod bindings;
 mod mock;
 
 use bindings::{
-    str_from_c, FDBDatabase, FDBMetrics, FDBPromise, FDBWorkload, FDBWorkloadContext, Metric,
-    Metrics, OpaqueWorkload, Promise, Severity, WorkloadContext,
+    str_from_c, FDBDatabase, FDBMetrics, FDBPromise, FDBWorkload, FDBWorkloadContext,
+    FDBWorkload_VT, Metric, Metrics, OpaqueWorkload, Promise, Severity, WorkloadContext,
 };
 
 /// Should be replaced by a Rust wrapper over the `FDBDatabase` bindings, like the one provided by foundationdb-rs
@@ -14,7 +14,25 @@ pub type MockDatabase = NonNull<FDBDatabase>;
 pub type WrappedWorkload = FDBWorkload;
 
 /// Equivalent to the C++ abstract class `FDBWorkload`
-pub trait RustWorkload {
+pub trait RustWorkload: Sized {
+    const VT: FDBWorkload_VT = FDBWorkload_VT {
+        setup: Some(workload_setup::<Self>),
+        start: Some(workload_start::<Self>),
+        check: Some(workload_check::<Self>),
+        getMetrics: Some(workload_get_metrics::<Self>),
+        getCheckTimeout: Some(workload_get_check_timeout::<Self>),
+        free: Some(workload_drop::<Self>),
+    };
+
+    /// Wrap the underlying Rust type so it can be passed to the C API
+    fn wrap(self) -> WrappedWorkload {
+        let inner = Box::into_raw(Box::new(self));
+        WrappedWorkload {
+            inner: inner as *mut _,
+            vt: &Self::VT as *const _ as *mut _,
+        }
+    }
+
     /// This method is called by the tester during the setup phase.
     /// It should be used to populate the database.
     ///
@@ -22,7 +40,7 @@ pub trait RustWorkload {
     ///
     /// * `db` - The simulated database.
     /// * `done` - A promise that should be resolved to indicate completion
-    fn setup(&'static mut self, db: MockDatabase, done: Promise);
+    fn setup(&mut self, db: MockDatabase, done: Promise);
 
     /// This method should run the actual test.
     ///
@@ -30,7 +48,7 @@ pub trait RustWorkload {
     ///
     /// * `db` - The simulated database.
     /// * `done` - A promise that should be resolved to indicate completion
-    fn start(&'static mut self, db: MockDatabase, done: Promise);
+    fn start(&mut self, db: MockDatabase, done: Promise);
 
     /// This method is called when the tester completes.
     /// A workload should run any consistency/correctness tests during this phase.
@@ -39,7 +57,7 @@ pub trait RustWorkload {
     ///
     /// * `db` - The simulated database.
     /// * `done` - A promise that should be resolved to indicate completion
-    fn check(&'static mut self, db: MockDatabase, done: Promise);
+    fn check(&mut self, db: MockDatabase, done: Promise);
 
     /// If a workload collects metrics (like latencies or throughput numbers), these should be reported back here.
     /// The multitester (or test orchestrator) will collect all metrics from all test clients and it will aggregate them.
@@ -61,7 +79,7 @@ pub trait RustWorkloadFactory {
     fn create(name: String, context: WorkloadContext) -> WrappedWorkload;
 }
 
-unsafe extern "C" fn workload_setup<W: RustWorkload + 'static>(
+unsafe extern "C" fn workload_setup<W: RustWorkload>(
     raw_workload: *mut OpaqueWorkload,
     raw_database: *mut FDBDatabase,
     raw_promise: FDBPromise,
@@ -71,7 +89,7 @@ unsafe extern "C" fn workload_setup<W: RustWorkload + 'static>(
     let done = Promise::new(raw_promise);
     workload.setup(database, done)
 }
-unsafe extern "C" fn workload_start<W: RustWorkload + 'static>(
+unsafe extern "C" fn workload_start<W: RustWorkload>(
     raw_workload: *mut OpaqueWorkload,
     raw_database: *mut FDBDatabase,
     raw_promise: FDBPromise,
@@ -81,7 +99,7 @@ unsafe extern "C" fn workload_start<W: RustWorkload + 'static>(
     let done = Promise::new(raw_promise);
     workload.start(database, done)
 }
-unsafe extern "C" fn workload_check<W: RustWorkload + 'static>(
+unsafe extern "C" fn workload_check<W: RustWorkload>(
     raw_workload: *mut OpaqueWorkload,
     raw_database: *mut FDBDatabase,
     raw_promise: FDBPromise,
@@ -107,21 +125,6 @@ unsafe extern "C" fn workload_get_check_timeout<W: RustWorkload>(
 }
 unsafe extern "C" fn workload_drop<W: RustWorkload>(raw_workload: *mut OpaqueWorkload) {
     unsafe { drop(Box::from_raw(raw_workload as *mut W)) };
-}
-
-impl WrappedWorkload {
-    pub fn new<W: RustWorkload + 'static>(workload: W) -> Self {
-        let workload = Box::into_raw(Box::new(workload));
-        WrappedWorkload {
-            inner: workload as *mut _,
-            setup: Some(workload_setup::<W>),
-            start: Some(workload_start::<W>),
-            check: Some(workload_check::<W>),
-            getMetrics: Some(workload_get_metrics::<W>),
-            getCheckTimeout: Some(workload_get_check_timeout::<W>),
-            free: Some(workload_drop::<W>),
-        }
-    }
 }
 
 /// Register a `RustWorkloadFactory` in the FoundationDB simulation.

--- a/bindings/c/test/workloads/RustWorkload/src/mock.rs
+++ b/bindings/c/test/workloads/RustWorkload/src/mock.rs
@@ -10,7 +10,7 @@ struct MockWorkload {
 }
 
 impl RustWorkload for MockWorkload {
-    fn setup(&'static mut self, _db: MockDatabase, done: Promise) {
+    fn setup(&mut self, _db: MockDatabase, done: Promise) {
         println!("rust_setup({}_{})", self.name, self.client_id);
         self.context.trace(
             Severity::Debug,
@@ -19,7 +19,7 @@ impl RustWorkload for MockWorkload {
         );
         done.send(true);
     }
-    fn start(&'static mut self, _db: MockDatabase, done: Promise) {
+    fn start(&mut self, _db: MockDatabase, done: Promise) {
         println!("rust_start({}_{})", self.name, self.client_id);
         self.context.trace(
             Severity::Debug,
@@ -28,7 +28,7 @@ impl RustWorkload for MockWorkload {
         );
         done.send(true);
     }
-    fn check(&'static mut self, _db: MockDatabase, done: Promise) {
+    fn check(&mut self, _db: MockDatabase, done: Promise) {
         println!("rust_check({}_{})", self.name, self.client_id);
         self.context.trace(
             Severity::Debug,
@@ -77,7 +77,7 @@ impl RustWorkloadFactory for MockFactory {
             context.get_option::<String>("my_rust_option")
         );
         match name.as_str() {
-            "MockWorkload" => WrappedWorkload::new(MockWorkload::new(name, client_id, context)),
+            "MockWorkload" => MockWorkload::new(name, client_id, context).wrap(),
             _ => panic!("Unknown workload name: {name}"),
         }
     }

--- a/bindings/c/test/workloads/RustWorkload/src/mock.rs
+++ b/bindings/c/test/workloads/RustWorkload/src/mock.rs
@@ -1,6 +1,6 @@
 use crate::{
     register_factory, Metric, Metrics, MockDatabase, Promise, RustWorkload, RustWorkloadFactory,
-    Severity, WorkloadContext, WrappedWorkload,
+    Severity, WorkloadContext, WrappedWorkload, FDB_WORKLOAD_API_VERSION,
 };
 
 struct MockWorkload {
@@ -67,7 +67,7 @@ impl RustWorkloadFactory for MockFactory {
     fn create(name: String, context: WorkloadContext) -> WrappedWorkload {
         let client_id = context.client_id();
         let client_count = context.client_count();
-        println!("RustWorkloadFactory::create({name})[{client_id}/{client_count}]");
+        println!("RustWorkloadFactory::create({name})[{client_id}/{client_count}]: client_version: {FDB_WORKLOAD_API_VERSION}, server_version: {}", context.get_workload_api_version());
         println!(
             "my_c_option: {:?}",
             context.get_option::<String>("my_rust_option")

--- a/fdbserver/workloads/ExternalWorkload.actor.cpp
+++ b/fdbserver/workloads/ExternalWorkload.actor.cpp
@@ -251,6 +251,7 @@ capi::FDBWorkloadContext wrap(FDBWorkloadContext* context) {
 		.delay = delay,
 	};
 	return capi::FDBWorkloadContext{
+		.api_version = FDB_WORKLOAD_API_VERSION,
 		.inner = (capi::OpaqueWorkloadContext*)context,
 		.vt = &vt,
 	};
@@ -315,7 +316,6 @@ struct ExternalWorkload : TestWorkload, FDBWorkloadContext {
 		libraryPath = ::getOption(options, "libraryPath"_sr, Value(getDefaultLibraryPath())).toString();
 		auto wName = ::getOption(options, "workloadName"_sr, ""_sr);
 		auto fullPath = joinPath(libraryPath, toLibName(libraryName));
-		std::cout << "ExternalWorkload::useCAPI: " << useCAPI << "\n";
 		TraceEvent("ExternalWorkloadLoad")
 		    .detail("LibraryName", libraryName)
 		    .detail("LibraryPath", fullPath)

--- a/fdbserver/workloads/ExternalWorkload.actor.cpp
+++ b/fdbserver/workloads/ExternalWorkload.actor.cpp
@@ -224,6 +224,11 @@ int64_t sharedRandomNumber(capi::OpaqueWorkloadContext* c_context) {
 	auto context = (FDBWorkloadContext*)c_context;
 	return context->sharedRandomNumber();
 }
+capi::FDBFuture* delay(double seconds) {
+	ThreadFuture<Void> future =
+	    onMainThread([seconds]() -> Future<Void> { return g_network->delay(seconds, TaskPriority::DefaultDelay); });
+	return (capi::FDBFuture*)future.extractPtr();
+}
 capi::FDBWorkloadContext wrap(FDBWorkloadContext* context) {
 	return capi::FDBWorkloadContext{
 		.inner = (capi::OpaqueWorkloadContext*)context,
@@ -236,6 +241,7 @@ capi::FDBWorkloadContext wrap(FDBWorkloadContext* context) {
 		.clientId = clientId,
 		.clientCount = clientCount,
 		.sharedRandomNumber = sharedRandomNumber,
+		.delay = delay,
 	};
 }
 } // namespace context


### PR DESCRIPTION
Implementation proposal for issue #12343.
Continuation of #11288.

I added a `delay` method on the `FDBWorkloadContext` of the C simulation API.
It returns a `FDBFuture` pointer and can be treated like any other futures returned by the `fdb_c` API.
Two problems still need to be addressed:
- should we update the C++ simulation API (updating the `CppWorkload.h` to also include `delay`)?
- how to make the C simulation API more resilient to API changes?

The first point is quite straightforward, I can provide the C++ implementation easily, but what about the Java bindings? Should we update them as well?

For the second point, the problem is that the full API is a list of function pointers the fdbserver sends to the workload as a struct on the stack:
https://github.com/apple/foundationdb/blob/a2940a7e891f8f2a63b09ada5a2f6ab08e49a6a7/bindings/c/test/workloads/CWorkload.c#L87
https://github.com/apple/foundationdb/blob/a2940a7e891f8f2a63b09ada5a2f6ab08e49a6a7/bindings/c/foundationdb/CWorkload.h#L85-L101
Adding a new binding, like `delay`, is a breaking change since it changes the size of the struct. A simple way to fix this, I think, would be to pass a pointer to the `FDBWorkloadContext` instead of the struct directly. If we only add entries in this struct, never removing or swapping fields, older workloads can still run as they access the bindings by their offset in the context. Newer workloads can use newer bindings located at higher offsets in the struct

This was an oversight on my part. I hope we can merge both the `delay` addition and the "by pointer" API in 7.4 before the end of the release candidate phase, so the API is fixed before it’s officially released.