### PR TITLE
Rename CC_ENABLE_REMOTE_LOG_ROUTER_MONITORING to CC_ENABLE_REMOTE_LOG_ROUTER_DISCONNECT_MONITORING

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -835,7 +835,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( CC_SATELLITE_DEGRADATION_MIN_COMPLAINER,                 3 );
 	init( CC_SATELLITE_DEGRADATION_MIN_BAD_SERVER,                 3 );
 	init( CC_ENABLE_REMOTE_LOG_ROUTER_DEGRADATION_MONITORING,   false); 
-	init( CC_ENABLE_REMOTE_LOG_ROUTER_MONITORING,                true); 
+	init( CC_ENABLE_REMOTE_LOG_ROUTER_DISCONNECT_MONITORING,                true);
 	init( CC_ENABLE_REMOTE_TLOG_DEGRADATION_MONITORING,         false); if (isSimulated) CC_ENABLE_REMOTE_TLOG_DEGRADATION_MONITORING = deterministicRandom()->coinflip();
 	init( CC_ENABLE_REMOTE_TLOG_DISCONNECT_MONITORING,          false); if (isSimulated) CC_ENABLE_REMOTE_TLOG_DISCONNECT_MONITORING = deterministicRandom()->coinflip();
 	init( CC_ONLY_CONSIDER_INTRA_DC_LATENCY,                    false); if (isSimulated) CC_ONLY_CONSIDER_INTRA_DC_LATENCY = deterministicRandom()->coinflip();

--- a/fdbclient/include/fdbclient/ServerKnobs.h
+++ b/fdbclient/include/fdbclient/ServerKnobs.h
@@ -830,9 +830,9 @@ public:
 	                                                         // remote log routers are experiencing degradation
 	                                                         // (latency) with their peers. Gray failure may trigger
 	                                                         // recovery based on this.
-	bool CC_ENABLE_REMOTE_LOG_ROUTER_MONITORING; // When enabled, gray failure tries to detect whether
-	                                             // remote log routers are disconnected from their peers. Gray failure
-	                                             // may trigger recovery based on this.
+	bool CC_ENABLE_REMOTE_LOG_ROUTER_DISCONNECT_MONITORING; // When enabled, gray failure tries to detect whether
+	                                                        // remote log routers are disconnected from their peers.
+	                                                        // Gray failure may trigger recovery based on this.
 	bool CC_ENABLE_REMOTE_TLOG_DEGRADATION_MONITORING; // When enabled, gray failure tries to detect whether remote
 	                                                   // tlogs are experiencing degradation (latency) with their peers.
 	                                                   // Gray failure may trigger recovery based on this.

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -201,10 +201,11 @@ bool ClusterControllerData::transactionSystemContainsDegradedServers() {
 	                               /*skipRemoteLogRouter*/
 	                               !(SERVER_KNOBS->CC_ONLY_CONSIDER_INTRA_DC_LATENCY &&
 	                                 SERVER_KNOBS->CC_ENABLE_REMOTE_LOG_ROUTER_DEGRADATION_MONITORING)) ||
-	       transactionWorkerInList(degradationInfo.disconnectedServers,
-	                               /*skipSatellite=*/false,
-	                               /*skipRemoteTLog=*/!SERVER_KNOBS->CC_ENABLE_REMOTE_TLOG_DISCONNECT_MONITORING,
-	                               /*skipRemoteLogRouter*/ !SERVER_KNOBS->CC_ENABLE_REMOTE_LOG_ROUTER_MONITORING);
+	       transactionWorkerInList(
+	           degradationInfo.disconnectedServers,
+	           /*skipSatellite=*/false,
+	           /*skipRemoteTLog=*/!SERVER_KNOBS->CC_ENABLE_REMOTE_TLOG_DISCONNECT_MONITORING,
+	           /*skipRemoteLogRouter*/ !SERVER_KNOBS->CC_ENABLE_REMOTE_LOG_ROUTER_DISCONNECT_MONITORING);
 }
 
 bool ClusterControllerData::remoteTransactionSystemContainsDegradedServers() {
@@ -3916,7 +3917,7 @@ TEST_CASE("/fdbserver/clustercontroller/shouldTriggerRecoveryDueToDegradedServer
 	}
 
 	// Trigger recovery when remote log router is disconnected.
-	if (SERVER_KNOBS->CC_ENABLE_REMOTE_LOG_ROUTER_MONITORING) {
+	if (SERVER_KNOBS->CC_ENABLE_REMOTE_LOG_ROUTER_DISCONNECT_MONITORING) {
 		data.degradationInfo.disconnectedServers.insert(logRouter);
 		ASSERT(data.shouldTriggerRecoveryDueToDegradedServers());
 		data.degradationInfo.disconnectedServers.clear();


### PR DESCRIPTION
This to keep the naming consistent for gray failure knobs. 

Trivial change so should not cause any issues, but 100K results: 

```
20250915-004611-praza-rename-enable-remote--a9374ae6d006256d compressed=True data_size=40470937 duration=5636180 ended=100000 fail=2 fail_fast=10 max_runs=100000 pass=99998 priority=100 remaining=0 runtime=1:19:11 sanity=False started=100000 stopped=20250915-020522 submitted=20250915-004611 timeout=5400 username=praza-rename-enable-remote-log-router-knob-fa5b21bef9ba484e2c73a0bc6c72e2765bd157ed
```

Both failures are not related. One is an external timeout. The other is an assertion in client metric code, which should not be related to this PR change. This PR overall does not change any functional behavior of the code.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
