### PR TITLE
Fix the build with toml11 4.0

### DIFF
--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -137,7 +137,7 @@ bool destructed = false;
 // environment details
 class TestConfig : public BasicTestConfig {
 	class ConfigBuilder {
-		using value_type = toml::basic_value<toml::discard_comments>;
+		using value_type = toml::value;
 		using base_variant = std::variant<int,
 		                                  float,
 		                                  double,


### PR DESCRIPTION
In toml11 3.0, comments were discarded by default, so this declaration was redundant. In toml11 ≥ 4.0, they are preserved by default, but opting out is more baroque. It doesn’t seem clear to me why discarding comments is specifically relevant here, so I’ve opted to simplify the code by using the default uniformly, but a version conditional would be possible if this is important.

Many major Linux distributions have already moved to toml11 ≥ 4.0, so this simplifies packaging.

Replace this text with your description here...

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
