### PR TITLE
use sni in the tls handshake

### DIFF
--- a/fdbbackup/tests/s3_backup_test.sh
+++ b/fdbbackup/tests/s3_backup_test.sh
@@ -24,19 +24,18 @@ trap cleanup  EXIT
 
 # Cleanup. Called from signal trap.
 function cleanup {
-  :
-#  if type shutdown_fdb_cluster &> /dev/null; then
-#    shutdown_fdb_cluster
-#  fi
-#  if type shutdown_weed &> /dev/null; then
-#    shutdown_weed "${TEST_SCRATCH_DIR}"
-#  fi
-#  if type shutdown_aws &> /dev/null; then
-#    shutdown_aws "${TEST_SCRATCH_DIR}"
-#  fi
-#  if [[ -n "${ENCRYPTION_KEY_FILE:-}" ]] && [[ -f "${ENCRYPTION_KEY_FILE}" ]]; then
-#    rm -f "${ENCRYPTION_KEY_FILE}"
-#  fi
+  if type shutdown_fdb_cluster &> /dev/null; then
+    shutdown_fdb_cluster
+  fi
+  if type shutdown_weed &> /dev/null; then
+    shutdown_weed "${TEST_SCRATCH_DIR}"
+  fi
+  if type shutdown_aws &> /dev/null; then
+    shutdown_aws "${TEST_SCRATCH_DIR}"
+  fi
+  if [[ -n "${ENCRYPTION_KEY_FILE:-}" ]] && [[ -f "${ENCRYPTION_KEY_FILE}" ]]; then
+    rm -f "${ENCRYPTION_KEY_FILE}"
+  fi
 }
 
 # Resolve passed in reference to an absolute path.

--- a/fdbbackup/tests/s3_backup_test.sh
+++ b/fdbbackup/tests/s3_backup_test.sh
@@ -24,18 +24,19 @@ trap cleanup  EXIT
 
 # Cleanup. Called from signal trap.
 function cleanup {
-  if type shutdown_fdb_cluster &> /dev/null; then
-    shutdown_fdb_cluster
-  fi
-  if type shutdown_weed &> /dev/null; then
-    shutdown_weed "${TEST_SCRATCH_DIR}"
-  fi
-  if type shutdown_aws &> /dev/null; then
-    shutdown_aws "${TEST_SCRATCH_DIR}"
-  fi
-  if [[ -n "${ENCRYPTION_KEY_FILE:-}" ]] && [[ -f "${ENCRYPTION_KEY_FILE}" ]]; then
-    rm -f "${ENCRYPTION_KEY_FILE}"
-  fi
+  :
+#  if type shutdown_fdb_cluster &> /dev/null; then
+#    shutdown_fdb_cluster
+#  fi
+#  if type shutdown_weed &> /dev/null; then
+#    shutdown_weed "${TEST_SCRATCH_DIR}"
+#  fi
+#  if type shutdown_aws &> /dev/null; then
+#    shutdown_aws "${TEST_SCRATCH_DIR}"
+#  fi
+#  if [[ -n "${ENCRYPTION_KEY_FILE:-}" ]] && [[ -f "${ENCRYPTION_KEY_FILE}" ]]; then
+#    rm -f "${ENCRYPTION_KEY_FILE}"
+#  fi
 }
 
 # Resolve passed in reference to an absolute path.

--- a/flow/Net2.actor.cpp
+++ b/flow/Net2.actor.cpp
@@ -143,6 +143,7 @@ public:
 	// INetworkConnections interface
 	Future<Reference<IConnection>> connect(NetworkAddress toAddr, tcp::socket* existingSocket = nullptr) override;
 	Future<Reference<IConnection>> connectExternal(NetworkAddress toAddr) override;
+	Future<Reference<IConnection>> connectExternalWithHostname(NetworkAddress toAddr, const std::string& hostname) override;
 	Future<Reference<IUDPSocket>> createUDPSocket(NetworkAddress toAddr) override;
 	Future<Reference<IUDPSocket>> createUDPSocket(bool isV6) override;
 	// The mock DNS methods should only be used in simulation.
@@ -940,6 +941,52 @@ public:
 		}
 	}
 
+	// Connect with hostname for SNI (Server Name Indication) support
+	ACTOR static Future<Reference<IConnection>> connectWithHostname(
+	    boost::asio::io_service* ios,
+	    Reference<ReferencedObject<boost::asio::ssl::context>> context,
+	    NetworkAddress addr,
+	    std::string hostname) {
+		std::pair<IPAddress, uint16_t> peerIP = std::make_pair(addr.ip, addr.port);
+		auto iter(g_network->networkInfo.serverTLSConnectionThrottler.find(peerIP));
+		if (iter != g_network->networkInfo.serverTLSConnectionThrottler.end()) {
+			if (now() < iter->second.second) {
+				if (iter->second.first >= FLOW_KNOBS->TLS_CLIENT_CONNECTION_THROTTLE_ATTEMPTS) {
+					TraceEvent("TLSOutgoingConnectionThrottlingWarning").suppressFor(1.0).detail("PeerIP", addr);
+					wait(delay(FLOW_KNOBS->CONNECTION_MONITOR_TIMEOUT));
+					throw connection_failed();
+				}
+			} else {
+				g_network->networkInfo.serverTLSConnectionThrottler.erase(peerIP);
+			}
+		}
+
+		state Reference<SSLConnection> self(new SSLConnection(*ios, context));
+		self->peer_address = addr;
+		self->sni_hostname = hostname; // Store hostname for SNI during handshake
+		
+		// Store hostname for SNI use during handshake  
+		TraceEvent("SSLConnectionWithHostname").detail("Hostname", hostname).detail("Addr", addr);
+		
+		try {
+			auto to = tcpEndpoint(self->peer_address);
+			BindPromise p("N2_ConnectError", self->id);
+			Future<Void> onConnected = p.getFuture();
+			self->socket.async_connect(to, std::move(p));
+
+			wait(onConnected);
+			
+			// SNI will be set later in doConnectHandshake before SSL handshake
+			
+			self->init();
+			return self;
+		} catch (Error&) {
+			// Either the connection failed, or was cancelled by the caller
+			self->closeSocket();
+			throw;
+		}
+	}
+
 	// This is not part of the IConnection interface, because it is wrapped by IListener::accept()
 	void accept(NetworkAddress peerAddr) {
 		this->peer_address = peerAddr;
@@ -1061,6 +1108,15 @@ public:
 			                   self->ssl_sock,
 			                   self->peer_address,
 			                   [conn = self.getPtr()](bool verifyOk) { conn->has_trusted_peer = verifyOk; });
+
+			// Set SNI hostname if we have one (for connections made with hostname)
+			if (!self->sni_hostname.empty()) {
+				TraceEvent("SSLSetSNI").detail("Hostname", self->sni_hostname).detail("Addr", self->peer_address);
+				int result = SSL_set_tlsext_host_name(self->ssl_sock.native_handle(), self->sni_hostname.c_str());
+				TraceEvent("SSLSetSNIResult").detail("Hostname", self->sni_hostname).detail("Result", result).detail("Addr", self->peer_address);
+			} else {
+				TraceEvent("SSLNoSNIHostname").detail("Addr", self->peer_address);
+			}
 
 			// If the background handshakers are not all busy, use one
 
@@ -1241,6 +1297,7 @@ private:
 	NetworkAddress peer_address;
 	Reference<ReferencedObject<boost::asio::ssl::context>> sslContext;
 	bool has_trusted_peer;
+	std::string sni_hostname; // For Server Name Indication
 
 	void init() {
 		// Socket settings that have to be set after connect or accept succeeds
@@ -1915,6 +1972,14 @@ Future<Reference<IConnection>> Net2::connect(NetworkAddress toAddr, tcp::socket*
 }
 
 Future<Reference<IConnection>> Net2::connectExternal(NetworkAddress toAddr) {
+	return connect(toAddr);
+}
+
+Future<Reference<IConnection>> Net2::connectExternalWithHostname(NetworkAddress toAddr, const std::string& hostname) {
+	if (toAddr.isTLS()) {
+		initTLS(ETLSInitState::CONNECT);
+		return SSLConnection::connectWithHostname(&this->reactor.ios, this->sslContextVar.get(), toAddr, hostname);
+	}
 	return connect(toAddr);
 }
 

--- a/flow/Net2.actor.cpp
+++ b/flow/Net2.actor.cpp
@@ -143,7 +143,8 @@ public:
 	// INetworkConnections interface
 	Future<Reference<IConnection>> connect(NetworkAddress toAddr, tcp::socket* existingSocket = nullptr) override;
 	Future<Reference<IConnection>> connectExternal(NetworkAddress toAddr) override;
-	Future<Reference<IConnection>> connectExternalWithHostname(NetworkAddress toAddr, const std::string& hostname) override;
+	Future<Reference<IConnection>> connectExternalWithHostname(NetworkAddress toAddr,
+	                                                           const std::string& hostname) override;
 	Future<Reference<IUDPSocket>> createUDPSocket(NetworkAddress toAddr) override;
 	Future<Reference<IUDPSocket>> createUDPSocket(bool isV6) override;
 	// The mock DNS methods should only be used in simulation.
@@ -964,10 +965,10 @@ public:
 		state Reference<SSLConnection> self(new SSLConnection(*ios, context));
 		self->peer_address = addr;
 		self->sni_hostname = hostname; // Store hostname for SNI during handshake
-		
-		// Store hostname for SNI use during handshake  
+
+		// Store hostname for SNI use during handshake
 		TraceEvent("SSLConnectionWithHostname").detail("Hostname", hostname).detail("Addr", addr);
-		
+
 		try {
 			auto to = tcpEndpoint(self->peer_address);
 			BindPromise p("N2_ConnectError", self->id);
@@ -975,9 +976,9 @@ public:
 			self->socket.async_connect(to, std::move(p));
 
 			wait(onConnected);
-			
+
 			// SNI will be set later in doConnectHandshake before SSL handshake
-			
+
 			self->init();
 			return self;
 		} catch (Error&) {
@@ -1113,7 +1114,10 @@ public:
 			if (!self->sni_hostname.empty()) {
 				TraceEvent("SSLSetSNI").detail("Hostname", self->sni_hostname).detail("Addr", self->peer_address);
 				int result = SSL_set_tlsext_host_name(self->ssl_sock.native_handle(), self->sni_hostname.c_str());
-				TraceEvent("SSLSetSNIResult").detail("Hostname", self->sni_hostname).detail("Result", result).detail("Addr", self->peer_address);
+				TraceEvent("SSLSetSNIResult")
+				    .detail("Hostname", self->sni_hostname)
+				    .detail("Result", result)
+				    .detail("Addr", self->peer_address);
 			} else {
 				TraceEvent("SSLNoSNIHostname").detail("Addr", self->peer_address);
 			}

--- a/flow/Net2.actor.cpp
+++ b/flow/Net2.actor.cpp
@@ -965,8 +965,8 @@ public:
 		state Reference<SSLConnection> self(new SSLConnection(*ios, context));
 		self->peer_address = addr;
 		self->sni_hostname = hostname; // Store hostname for SNI during handshake
-		
-		// Store hostname for SNI use during handshake  
+
+		// Store hostname for SNI use during handshake
 
 		try {
 			auto to = tcpEndpoint(self->peer_address);
@@ -1112,7 +1112,10 @@ public:
 			// Set SNI hostname if we have one (for connections made with hostname)
 			if (!self->sni_hostname.empty()) {
 				int result = SSL_set_tlsext_host_name(self->ssl_sock.native_handle(), self->sni_hostname.c_str());
-				TraceEvent("SSLSetSNIResult").detail("Hostname", self->sni_hostname).detail("Result", result).detail("Addr", self->peer_address);
+				TraceEvent("SSLSetSNIResult")
+				    .detail("Hostname", self->sni_hostname)
+				    .detail("Result", result)
+				    .detail("Addr", self->peer_address);
 			}
 
 			// If the background handshakers are not all busy, use one

--- a/flow/Net2.actor.cpp
+++ b/flow/Net2.actor.cpp
@@ -965,9 +965,8 @@ public:
 		state Reference<SSLConnection> self(new SSLConnection(*ios, context));
 		self->peer_address = addr;
 		self->sni_hostname = hostname; // Store hostname for SNI during handshake
-
-		// Store hostname for SNI use during handshake
-		TraceEvent("SSLConnectionWithHostname").detail("Hostname", hostname).detail("Addr", addr);
+		
+		// Store hostname for SNI use during handshake  
 
 		try {
 			auto to = tcpEndpoint(self->peer_address);
@@ -1112,14 +1111,8 @@ public:
 
 			// Set SNI hostname if we have one (for connections made with hostname)
 			if (!self->sni_hostname.empty()) {
-				TraceEvent("SSLSetSNI").detail("Hostname", self->sni_hostname).detail("Addr", self->peer_address);
 				int result = SSL_set_tlsext_host_name(self->ssl_sock.native_handle(), self->sni_hostname.c_str());
-				TraceEvent("SSLSetSNIResult")
-				    .detail("Hostname", self->sni_hostname)
-				    .detail("Result", result)
-				    .detail("Addr", self->peer_address);
-			} else {
-				TraceEvent("SSLNoSNIHostname").detail("Addr", self->peer_address);
+				TraceEvent("SSLSetSNIResult").detail("Hostname", self->sni_hostname).detail("Result", result).detail("Addr", self->peer_address);
 			}
 
 			// If the background handshakers are not all busy, use one

--- a/flow/include/flow/IConnection.h
+++ b/flow/include/flow/IConnection.h
@@ -138,6 +138,12 @@ public:
 
 	virtual Future<Reference<IConnection>> connectExternal(NetworkAddress toAddr) = 0;
 
+	// Make an outgoing connection to the given address with hostname for SNI (TLS Server Name Indication)
+	virtual Future<Reference<IConnection>> connectExternalWithHostname(NetworkAddress toAddr, const std::string& hostname) {
+		// Default implementation ignores hostname - subclasses can override for SNI support
+		return connectExternal(toAddr);
+	}
+
 	// Make an outgoing udp connection and connect to the passed address.
 	virtual Future<Reference<IUDPSocket>> createUDPSocket(NetworkAddress toAddr) = 0;
 	// Make an outgoing udp connection without establishing a connection

--- a/flow/include/flow/IConnection.h
+++ b/flow/include/flow/IConnection.h
@@ -139,7 +139,8 @@ public:
 	virtual Future<Reference<IConnection>> connectExternal(NetworkAddress toAddr) = 0;
 
 	// Make an outgoing connection to the given address with hostname for SNI (TLS Server Name Indication)
-	virtual Future<Reference<IConnection>> connectExternalWithHostname(NetworkAddress toAddr, const std::string& hostname) {
+	virtual Future<Reference<IConnection>> connectExternalWithHostname(NetworkAddress toAddr,
+	                                                                   const std::string& hostname) {
 		// Default implementation ignores hostname - subclasses can override for SNI support
 		return connectExternal(toAddr);
 	}

--- a/flow/network.cpp
+++ b/flow/network.cpp
@@ -370,6 +370,10 @@ Future<Reference<IConnection>> INetworkConnections::connect(const std::string& h
 	// Wait for the endpoint to return, then wait for connect(endpoint) and return it.
 	// Template types are being provided explicitly because they can't be automatically deduced for some reason.
 	return mapAsync(pickEndpoint, [=](NetworkAddress const& addr) -> Future<Reference<IConnection>> {
+		// Pass the original hostname for SNI if this is a TLS connection from hostname
+		if (addr.isTLS() && addr.fromHostname) {
+			return connectExternalWithHostname(addr, host);
+		}
 		return connectExternal(addr);
 	});
 }


### PR DESCRIPTION
Original PR is in #12366


Problem
FoundationDB's network layer was not properly setting Server Name Indication (SNI) when making TLS connections to hostnames that require SNI for proper certificate selection. This caused failures when connecting to services like Google Cloud Storage, which returns a dummy self-signed certificate when SNI is not provided.

Symptoms:

Backup agent fails with "VerifyError": "self signed certificate" when connecting to storage.googleapis.com
TLS handshake errors: "certificate verify failed"
Network captures showed TLS Client Hello without SNI extension

Root Cause: The connection flow resolved hostnames to IP addresses early in the process but lost the original hostname string needed for SNI. When INetworkConnections::connect(host, service, isTLS) was called:
    - resolveTCPEndpoint() resolved hostname to IP addresses
    - One IP was selected and addr.fromHostname = true was set
    - The original hostname string was discarded
    - connectExternal(addr) was called with only the IP address
    - During TLS handshake, no SNI was set because the hostname was lost

Solution
Modified the network connection chain to preserve hostname information for SNI

Testing
Verification Methods:

Network capture: tshark -Y "tls.handshake.extensions_server_name" confirms SNI is now sent in TLS Client Hello
Trace logs: Added SSLConnectionWithHostname and SSLSetSNI events for debugging
Real-world test: Backup agent connecting to storage.googleapis.com now sends proper SNI

[x] The PR has a description, explaining both the problem and the solution.
[x] The description mentions which forms of testing were done and the testing seems reasonable.
[x] Every function/class/actor that was touched is reasonably well documented.