### PR TITLE
Update error message for encryption key mismatches between backup and restore

### DIFF
--- a/fdbbackup/tests/s3_backup_test.sh
+++ b/fdbbackup/tests/s3_backup_test.sh
@@ -179,6 +179,10 @@ function test_s3_backup_and_restore {
     err "Failed clear data in fdb"
     return 1
   fi
+  # Test encryption mismatches (always run to test both encrypted and unencrypted scenarios)
+  log "Testing encryption mismatches"
+  test_encryption_mismatches "${local_build_dir}" "${local_scratch_dir}" "${local_url}" "${credentials}" "${local_encryption_key_file}"
+
   log "Restore from s3"
   if ! restore "${local_build_dir}" "${local_scratch_dir}" "${local_url}" "${credentials}" "${local_encryption_key_file}"; then
     err "Failed restore"
@@ -211,6 +215,126 @@ function test_s3_backup_and_restore {
     err "Found Severity=40 errors in logs"
     return 1
   fi
+}
+
+# Test all encryption mismatch scenarios - all should fail
+# $1 The build directory
+# $2 The scratch directory
+# $3 The S3 url
+# $4 credentials file
+# $5 encryption key file used for backup (empty if no encryption)
+function test_encryption_mismatches {
+  local local_build_dir="${1}"
+  local local_scratch_dir="${2}"
+  local local_url="${3}"
+  local local_credentials="${4}"
+  local backup_encryption_key_file="${5}"
+
+  # Create separate log directory for encryption mismatch tests
+  local mismatch_logdir="${local_scratch_dir}/encryption_mismatch_logs"
+  mkdir -p "${mismatch_logdir}"
+
+  if [[ -n "${backup_encryption_key_file}" ]]; then
+    # Backup was encrypted - test mismatches
+    log "Testing encryption mismatches for encrypted backup"
+
+    # Test 1: Encrypted backup → restore without encryption (should fail)
+    log "Test 1: Attempting restore without encryption on encrypted backup (should fail)"
+    local cmd_args1=(
+      "--dest-cluster-file" "${local_scratch_dir}/loopback_cluster/fdb.cluster"
+      "-t" "${TAG}" "-w"
+      "-r" "${local_url}"
+      "--log" "--logdir=${mismatch_logdir}"
+      "--blob-credentials" "${local_credentials}"
+    )
+    for knob in "${KNOBS[@]}"; do
+      cmd_args1+=("${knob}")
+    done
+
+    set +e
+    "${local_build_dir}"/bin/fdbrestore start "${cmd_args1[@]}"
+    local exit_code1=$?
+    set -e
+
+    if [[ ${exit_code1} -eq 0 ]]; then
+      err "ERROR: Restore without encryption on encrypted backup succeeded when it should have failed!"
+      rm -rf "${mismatch_logdir}"
+      return 1
+    fi
+    log "SUCCESS: Restore without encryption on encrypted backup failed as expected"
+
+    # Test 3: Encrypted backup → restore with wrong encryption key (should fail)
+    local wrong_key_file="${local_scratch_dir}/wrong_key"
+    create_encryption_key_file "${wrong_key_file}"
+
+    log "Test 3: Attempting restore with wrong encryption key (should fail)"
+    local cmd_args3=(
+      "--dest-cluster-file" "${local_scratch_dir}/loopback_cluster/fdb.cluster"
+      "-t" "${TAG}" "-w"
+      "-r" "${local_url}"
+      "--log" "--logdir=${mismatch_logdir}"
+      "--blob-credentials" "${local_credentials}"
+      "--encryption-key-file" "${wrong_key_file}"
+    )
+    for knob in "${KNOBS[@]}"; do
+      cmd_args3+=("${knob}")
+    done
+
+    set +e
+    "${local_build_dir}"/bin/fdbrestore start "${cmd_args3[@]}"
+    local exit_code3=$?
+    set -e
+
+    rm -f "${wrong_key_file}"
+
+    if [[ ${exit_code3} -eq 0 ]]; then
+      err "ERROR: Restore with wrong encryption key succeeded when it should have failed!"
+      rm -rf "${mismatch_logdir}"
+      return 1
+    fi
+    log "SUCCESS: Restore with wrong encryption key failed as expected"
+
+  else
+    # Backup was not encrypted - test mismatch
+    log "Testing encryption mismatch for unencrypted backup"
+
+    # Test 2: Unencrypted backup → restore with encryption (should fail)
+    local any_key_file="${local_scratch_dir}/any_key"
+    create_encryption_key_file "${any_key_file}"
+
+    log "Test 2: Attempting restore with encryption on unencrypted backup (should fail)"
+    local cmd_args2=(
+      "--dest-cluster-file" "${local_scratch_dir}/loopback_cluster/fdb.cluster"
+      "-t" "${TAG}" "-w"
+      "-r" "${local_url}"
+      "--log" "--logdir=${mismatch_logdir}"
+      "--blob-credentials" "${local_credentials}"
+      "--encryption-key-file" "${any_key_file}"
+    )
+    for knob in "${KNOBS[@]}"; do
+      cmd_args2+=("${knob}")
+    done
+
+    set +e
+    "${local_build_dir}"/bin/fdbrestore start "${cmd_args2[@]}"
+    local exit_code2=$?
+    set -e
+
+    rm -f "${any_key_file}"
+
+    if [[ ${exit_code2} -eq 0 ]]; then
+      err "ERROR: Restore with encryption on unencrypted backup succeeded when it should have failed!"
+      rm -rf "${mismatch_logdir}"
+      return 1
+    fi
+    log "SUCCESS: Restore with encryption on unencrypted backup failed as expected"
+  fi
+
+  # Clean up separate log directory
+  rm -rf "${mismatch_logdir}"
+
+  log "All encryption mismatch tests completed successfully"
+  return 0
 }
 
 # set -o xtrace   # a.k.a set -x  # Set this one when debugging (or 'bash -x THIS_SCRIPT').

--- a/fdbclient/BackupContainerFileSystem.actor.cpp
+++ b/fdbclient/BackupContainerFileSystem.actor.cpp
@@ -58,9 +58,14 @@ public:
 		state Standalone<StringRef> buf = makeString(size);
 		wait(success(f->read(mutateString(buf), buf.size(), 0)));
 		json_spirit::mValue json;
-		json_spirit::read_string(buf.toString(), json);
-		JSONDoc doc(json);
+		if (!json_spirit::read_string(buf.toString(), json)) {
+			fprintf(stderr,
+			        "ERROR: Failed to read data. Verify that backup and restore encryption keys match (if provided) or "
+			        "the data is corrupted.\n");
+			throw restore_error();
+		}
 
+		JSONDoc doc(json);
 		Version v;
 		if (!doc.tryGet("beginVersion", v) || v != snapshot.beginVersion)
 			throw restore_corrupted_data();


### PR DESCRIPTION
Added logic to return a clear error message when the backup and restore encryption keys do not match:
```
ERROR: Failed to read data. Verify that backup and restore encryption keys match (if provided) or 
       the data is corrupted.
```

Because snapshot files are read first during restore, the check is implemented while reading/decrypting snapshot files. If the JSON parsing fails at this stage, it indicates either:
- an encryption key mismatch, or
- corrupted snapshot data.


**Example: Snapshot file without encryption**

```
{"beginVersion":1839108,"endVersion":1853166,"files":["kvranges/snapshot.000000000001793504/0/range,1842360,7012f82e5a32aa06695e7c3c302384fb,1048576",
"kvranges/snapshot.000000000001793504/0/range,1853166,5698a5782a1eaa145bd791bb0d29bbc0,1048576",
"kvranges/snapshot.000000000001793504/0/range,1839108,39768e7acba5628aeb710340cba17a0b,1048576",
"kvranges/snapshot.000000000001793504/0/range,1842360,a672b9cbad3d629ff0ea1f32416fed8b,1048576"],
"keyRanges":
{"kvranges/snapshot.000000000001793504/0/range,1839108,39768e7acba5628aeb710340cba17a0b,1048576":
{"beginKey":"\u00FF\u0002/blobRange/","endKey":"\u00FF\u0002/blobRange0"},
"kvranges/snapshot.000000000001793504/0/range,1842360,7012f82e5a32aa06695e7c3c302384fb,1048576":
{"beginKey":"\u00FF/tenant/","endKey":"\u00FF/tenant0"},
"kvranges/snapshot.000000000001793504/0/range,1842360,a672b9cbad3d629ff0ea1f32416fed8b,1048576":
{"beginKey":"","endKey":"\u00FF"},"kvranges/snapshot.000000000001793504/0/range,1853166,5698a5782a1eaa145bd791bb0d29bbc0,1048576":
{"beginKey":"\u00FF/metacluster/clusterRegistration","endKey":"\u00FF/metacluster/clusterRegistration\u0000"}},"totalBytes":570}
```

### Testing

- 100k simulation tests (Completed)
   `   compressed=True data_size=41552603 duration=5599984 ended=100000 fail=1 fail_fast=10 max_runs=100000 pass=99999 priority=100 remaining=0 runtime=1:04:47 sanity=False started=100000 stopped=20250919-201408 submitted=20250919-190921 timeout=5400 username=ak_pr1`
   One test failure is unrelated to this change in `BlobGranuleApiCorrectness.toml`
- Extended `s3_backup_test.sh` to cover 3 conflicting scenarios (randomized based on whether encryption is enabled):
   - Backup is encrypted,
        - restore runs without an encryption key, and
        - restore runs with a different encryption key
   - Backup is unencrypted
        -  restore runs with an encryption key.
   - In all cases, restore is then re-run with the correct command, completing successfully.
   
`s3_backup_test.sh` – Test Results

```
-- RESPONSE CONTENT--

--------

ERROR: Backup is encrypted, please provide the encryption key file path.
ERROR: Restore error
Fatal Error: Restore error
+ local exit_code1=1
+ set -e
+ [[ 1 -eq 0 ]]
+ log 'SUCCESS: Restore without encryption on encrypted backup failed as expected'
```

```
-- RESPONSE CONTENT--
G^SZüsõ<82>Ç%<92>çþ^Qüjµ¥F^B^D¼w^G^PyMÆ5`â<81>çIõ~<96>5Ékú<8e>
^Y|     ¶ÒÕpÛ&{ë^B<97>q<84> 8O<8d>Í^Q<99>%Ð<91>¹ßÁÁ×<82>¾t^Z<80><9c>Ü ^^±^@Û-%áv^H1ò­+<87>p¨Ýè«^H<83>^Lø_}{XÆ^F^AR<85>úiJ^[^Uzæ!+oã±V^OµK(^Qà^^-û§^^Á<85>^U^Y<8d> 7^]õW%$ÏVs¿^_^X1!è6î^?>`^K^K<99>¼HdÍõ^Gë^FJ<99>À¸>ð^E'Â<97>DfÁB^X°^L<98>C5é^YÇ<8e>K<96>2Ð^E0Q5g<8c>^LqIÉ.X<8c><8f>Ö7d1a±7Ä2õ<8e>çXþH/<85>å:Á<9e>^VZ=Ø·_)o[<96>^@^[C^HA<85>$7^L`ü<90>^HRÄw^Y²w^KÔú¦¨:¥^Vg^@¨rgâ®ø¯Ç³9FT,x}ö ~)<91>@<92>[kÅt^[ðëq9<82>-<93>kû¢^H
--------

ERROR: Failed to read data. Verify that backup and restore encryption keys match (if provided) or the data is corrupted.
ERROR: Restore error
Fatal Error: Restore error
+ local exit_code3=1
+ set -e
+ rm -f /root/backup_testing//s3.1740021.3HEs/wrong_key
+ [[ 1 -eq 0 ]]
+ log 'SUCCESS: Restore with wrong encryption key failed as expected'
++ date -Iseconds
+ printf '%s %s\n' 2025-09-19T16:32:38+00:00 'SUCCESS: Restore with wrong encryption key failed as expected'
```

```
 --------
ERROR: Backup is not encrypted, please remove the encryption key file path.
ERROR: Restore error
Fatal Error: Restore error
+ local exit_code2=1
 ```
**Note**:
I couldn’t add this testing logic to the simulation tests because backup containers return a cached container reference instead of creating a new one ([BackupContainer.actor.cpp#L266](https://github.com/apple/foundationdb/blob/670788c050777a6b1b3499af07a5ae71203f350b/fdbclient/BackupContainer.actor.cpp#L266)).
Additionally, the encryption key is global ([StreamCipher.cpp#L31C51-L31C60](https://github.com/apple/foundationdb/blob/670788c050777a6b1b3499af07a5ae71203f350b/flow/StreamCipher.cpp#L31C51-L31C60)), which makes it difficult to open two containers with the same URL but different keys in a simulation test (same process)
I mainly wanted to test that if a restore fails due to encryption key mismatch, the restore completes successfully on rerun with correct encryption key.

