### PR TITLE
Fix handleTssMismatches crashes. [release-7.3]

### DIFF
--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -1216,10 +1216,12 @@ ACTOR static Future<Void> handleTssMismatches(DatabaseContext* cx) {
 	state KeyBackedMap<UID, UID> tssMapDB = KeyBackedMap<UID, UID>(tssMappingKeys.begin);
 	state KeyBackedMap<Tuple, std::string> tssMismatchDB = KeyBackedMap<Tuple, std::string>(tssMismatchKeys.begin);
 	loop {
+		// return to calling actor, cx might be destroyed already with the tr reset below.
+		// This gives ~DatabaseContext a chance to cancel this actor.
+		wait(delay(0));
+
 		// <tssid, list of detailed mismatch data>
 		state std::pair<UID, std::vector<DetailedTSSMismatch>> data = waitNext(cx->tssMismatchStream.getFuture());
-		// return to calling actor, don't do this as part of metrics loop
-		wait(delay(0));
 		// find ss pair id so we can remove it from the mapping
 		state UID tssPairID;
 		bool found = false;


### PR DESCRIPTION
cherrypick #12328

handleTssMismatches(DatabaseContext* cx) uses a pointer to DatabaseContext object, which can be destroyed when "tr" is reset within this actor. However, the actor can't be destroyed because it's on the stack. Introducing this delay gives a chance to cancel the actor.

Replace this text with your description here...

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
