### PR TITLE
Long recovery observability (phase: initializing_transaction_servers)

### DIFF
--- a/fdbserver/ClusterRecovery.actor.cpp
+++ b/fdbserver/ClusterRecovery.actor.cpp
@@ -270,6 +270,7 @@ ACTOR Future<Void> newTLogServers(Reference<ClusterRecoveryData> self,
                                   RecruitFromConfigurationReply recr,
                                   Reference<ILogSystem> oldLogSystem,
                                   std::vector<Standalone<CommitTransactionRef>>* initialConfChanges) {
+	TraceEvent("LogSystemInitializationStart", self->dbgid).detail("UsableRegions", self->configuration.usableRegions);
 	if (self->configuration.usableRegions > 1) {
 		state Optional<Key> remoteDcId = self->remoteDcIds.size() ? self->remoteDcIds[0] : Optional<Key>();
 		if (!self->dcId_locality.contains(recr.dcId)) {
@@ -339,6 +340,7 @@ ACTOR Future<Void> newTLogServers(Reference<ClusterRecoveryData> self,
 		                                                                 self->recruitmentStalled));
 		self->logSystem = newLogSystem;
 	}
+	TraceEvent("LogSystemInitializationComplete", self->dbgid);
 	return Void();
 }
 

--- a/fdbserver/ClusterRecovery.actor.cpp
+++ b/fdbserver/ClusterRecovery.actor.cpp
@@ -270,7 +270,7 @@ ACTOR Future<Void> newTLogServers(Reference<ClusterRecoveryData> self,
                                   RecruitFromConfigurationReply recr,
                                   Reference<ILogSystem> oldLogSystem,
                                   std::vector<Standalone<CommitTransactionRef>>* initialConfChanges) {
-	TraceEvent("LogSystemInitializationStart", self->dbgid).detail("UsableRegions", self->configuration.usableRegions);
+	TraceEvent("NewTLogServersStarted", self->dbgid).detail("UsableRegions", self->configuration.usableRegions);
 	if (self->configuration.usableRegions > 1) {
 		state Optional<Key> remoteDcId = self->remoteDcIds.size() ? self->remoteDcIds[0] : Optional<Key>();
 		if (!self->dcId_locality.contains(recr.dcId)) {
@@ -340,7 +340,7 @@ ACTOR Future<Void> newTLogServers(Reference<ClusterRecoveryData> self,
 		                                                                 self->recruitmentStalled));
 		self->logSystem = newLogSystem;
 	}
-	TraceEvent("LogSystemInitializationComplete", self->dbgid);
+	TraceEvent("NewTLogServersFinished", self->dbgid);
 	return Void();
 }
 

--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -3099,9 +3099,9 @@ ACTOR Future<Void> TagPartitionedLogSystem::newRemoteEpoch(TagPartitionedLogSyst
 	    .detail("StartVersion", logSet->startVersion)
 	    .detail("LocalStart", self->tLogs[0]->startVersion)
 	    .detail("LogRouterTags", self->logRouterTags);
-	wait(traceAfter(waitForAll(remoteTLogInitializationReplies), "RemoteTLogInitializationRepliesReceived"_sr) &&
-	     traceAfter(waitForAll(logRouterInitializationReplies), "LogRouterInitializationRepliesReceived"_sr) &&
-	     traceAfter(oldRouterRecruitment, "OldRouterRecruitmentFinished"_sr));
+	wait(traceAfter(waitForAll(remoteTLogInitializationReplies), "RemoteTLogInitializationRepliesReceived") &&
+	     traceAfter(waitForAll(logRouterInitializationReplies), "LogRouterInitializationRepliesReceived") &&
+	     traceAfter(oldRouterRecruitment, "OldRouterRecruitmentFinished"));
 
 	for (int i = 0; i < logRouterInitializationReplies.size(); i++) {
 		logSet->logRouters.push_back(makeReference<AsyncVar<OptionalInterface<TLogInterface>>>(
@@ -3451,8 +3451,8 @@ ACTOR Future<Reference<ILogSystem>> TagPartitionedLogSystem::newEpoch(
 			    cluster_recovery_failed()));
 		}
 
-		wait(traceAfter(waitForAll(satelliteInitializationReplies), "SatelliteInitializationRepliesReceived"_sr) ||
-		     traceAfter(oldRouterRecruitment, "OldRouterRecruitmentFinished"_sr));
+		wait(traceAfter(waitForAll(satelliteInitializationReplies), "SatelliteInitializationRepliesReceived") ||
+		     traceAfter(oldRouterRecruitment, "OldRouterRecruitmentFinished"));
 		TraceEvent("PrimarySatelliteTLogInitializationComplete", logSystem->getDebugID()).log();
 
 		for (int i = 0; i < satelliteInitializationReplies.size(); i++) {
@@ -3472,8 +3472,8 @@ ACTOR Future<Reference<ILogSystem>> TagPartitionedLogSystem::newEpoch(
 		}
 	}
 
-	wait(traceAfter(waitForAll(primaryTLogReplies), "PrimaryTLogRepliesReceived"_sr) ||
-	     traceAfter(oldRouterRecruitment, "OldRouterRecruitmentFinished"_sr));
+	wait(traceAfter(waitForAll(primaryTLogReplies), "PrimaryTLogRepliesReceived") ||
+	     traceAfter(oldRouterRecruitment, "OldRouterRecruitmentFinished"));
 	TraceEvent("PrimaryTLogInitializationComplete", logSystem->getDebugID()).log();
 
 	for (int i = 0; i < primaryTLogReplies.size(); i++) {

--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -3100,7 +3100,7 @@ ACTOR Future<Void> TagPartitionedLogSystem::newRemoteEpoch(TagPartitionedLogSyst
 	    .detail("LocalStart", self->tLogs[0]->startVersion)
 	    .detail("LogRouterTags", self->logRouterTags);
 	wait(traceAfter(waitForAll(remoteTLogInitializationReplies), "RemoteTLogInitializationRepliesReceived"_sr) &&
-	     traceAfter(waitForAll(logRouterInitializationReplies), "logRouterInitializationRepliesReceived"_sr) &&
+	     traceAfter(waitForAll(logRouterInitializationReplies), "LogRouterInitializationRepliesReceived"_sr) &&
 	     traceAfter(oldRouterRecruitment, "OldRouterRecruitmentFinished"_sr));
 
 	for (int i = 0; i < logRouterInitializationReplies.size(); i++) {

--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -3472,7 +3472,7 @@ ACTOR Future<Reference<ILogSystem>> TagPartitionedLogSystem::newEpoch(
 		}
 	}
 
-	wait(traceAfter(waitForAll(primaryTLogReplies), "InitializationRepliesReceived"_sr) ||
+	wait(traceAfter(waitForAll(primaryTLogReplies), "PrimaryTLogRepliesReceived"_sr) ||
 	     traceAfter(oldRouterRecruitment, "OldRouterRecruitmentFinished"_sr));
 	TraceEvent("PrimaryTLogInitializationComplete", logSystem->getDebugID()).log();
 

--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -3099,8 +3099,9 @@ ACTOR Future<Void> TagPartitionedLogSystem::newRemoteEpoch(TagPartitionedLogSyst
 	    .detail("StartVersion", logSet->startVersion)
 	    .detail("LocalStart", self->tLogs[0]->startVersion)
 	    .detail("LogRouterTags", self->logRouterTags);
-	wait(waitForAll(remoteTLogInitializationReplies) && waitForAll(logRouterInitializationReplies) &&
-	     oldRouterRecruitment);
+	wait(traceAfter(waitForAll(remoteTLogInitializationReplies), "RemoteTLogInitializationRepliesReceived"_sr) &&
+	     traceAfter(waitForAll(logRouterInitializationReplies), "logRouterInitializationRepliesReceived"_sr) &&
+	     traceAfter(oldRouterRecruitment, "OldRouterRecruitmentFinished"_sr));
 
 	for (int i = 0; i < logRouterInitializationReplies.size(); i++) {
 		logSet->logRouters.push_back(makeReference<AsyncVar<OptionalInterface<TLogInterface>>>(
@@ -3305,7 +3306,7 @@ ACTOR Future<Reference<ILogSystem>> TagPartitionedLogSystem::newEpoch(
 	std::vector<Tag> localTags = TagPartitionedLogSystem::getLocalTags(primaryLocality, allTags);
 	state LogSystemConfig oldLogSystemConfig = oldLogSystem->getLogSystemConfig();
 
-	state std::vector<Future<TLogInterface>> initializationReplies;
+	state std::vector<Future<TLogInterface>> primaryTLogReplies;
 	std::vector<InitializeTLogRequest> reqs(recr.tLogs.size());
 
 	logSystem->tLogs[0]->tLogLocalities.resize(recr.tLogs.size());
@@ -3373,10 +3374,10 @@ ACTOR Future<Reference<ILogSystem>> TagPartitionedLogSystem::newEpoch(
 		req.oldGenerationRecoverAtVersions = oldGenerationRecoverAtVersions;
 	}
 
-	initializationReplies.reserve(recr.tLogs.size());
+	primaryTLogReplies.reserve(recr.tLogs.size());
 	for (int i = 0; i < recr.tLogs.size(); i++) {
-		TraceEvent("PrimaryTLogReplies", logSystem->getDebugID()).detail("WorkerID", recr.tLogs[i].id());
-		initializationReplies.push_back(transformErrors(
+		TraceEvent("PrimaryTLogReqSent", logSystem->getDebugID()).detail("WorkerID", recr.tLogs[i].id());
+		primaryTLogReplies.push_back(transformErrors(
 		    throwErrorOr(recr.tLogs[i].tLog.getReplyUnlessFailedFor(
 		        reqs[i], SERVER_KNOBS->TLOG_TIMEOUT, SERVER_KNOBS->MASTER_FAILURE_SLOPE_DURING_RECOVERY)),
 		    cluster_recovery_failed()));
@@ -3450,7 +3451,8 @@ ACTOR Future<Reference<ILogSystem>> TagPartitionedLogSystem::newEpoch(
 			    cluster_recovery_failed()));
 		}
 
-		wait(waitForAll(satelliteInitializationReplies) || oldRouterRecruitment);
+		wait(traceAfter(waitForAll(satelliteInitializationReplies), "SatelliteInitializationRepliesReceived"_sr) ||
+		     traceAfter(oldRouterRecruitment, "OldRouterRecruitmentFinished"_sr));
 		TraceEvent("PrimarySatelliteTLogInitializationComplete", logSystem->getDebugID()).log();
 
 		for (int i = 0; i < satelliteInitializationReplies.size(); i++) {
@@ -3470,12 +3472,13 @@ ACTOR Future<Reference<ILogSystem>> TagPartitionedLogSystem::newEpoch(
 		}
 	}
 
-	wait(waitForAll(initializationReplies) || oldRouterRecruitment);
+	wait(traceAfter(waitForAll(primaryTLogReplies), "InitializationRepliesReceived"_sr) ||
+	     traceAfter(oldRouterRecruitment, "OldRouterRecruitmentFinished"_sr));
 	TraceEvent("PrimaryTLogInitializationComplete", logSystem->getDebugID()).log();
 
-	for (int i = 0; i < initializationReplies.size(); i++) {
+	for (int i = 0; i < primaryTLogReplies.size(); i++) {
 		logSystem->tLogs[0]->logServers[i] = makeReference<AsyncVar<OptionalInterface<TLogInterface>>>(
-		    OptionalInterface<TLogInterface>(initializationReplies[i].get()));
+		    OptionalInterface<TLogInterface>(primaryTLogReplies[i].get()));
 		logSystem->tLogs[0]->tLogLocalities[i] = recr.tLogs[i].locality;
 	}
 	filterLocalityDataForPolicy(logSystem->tLogs[0]->tLogPolicy, &logSystem->tLogs[0]->tLogLocalities);

--- a/flow/include/flow/genericactors.actor.h
+++ b/flow/include/flow/genericactors.actor.h
@@ -50,32 +50,16 @@
 #pragma warning(disable : 4355) // 'this' : used in base member initializer list
 #endif
 
-ACTOR template <class T, class X>
-Future<T> traceAfter(Future<T> what, const char* type, const char* key, X value, bool traceErrors = false) {
+ACTOR template <class T>
+Future<T> traceAfter(Future<T> what, Standalone<StringRef> type, bool traceErrors = true) {
 	try {
 		T val = wait(what);
-		TraceEvent(type).detail(key, value);
+		TraceEvent(type.toString().c_str());
 		return val;
 	} catch (Error& e) {
-		if (traceErrors)
-			TraceEvent(type).errorUnsuppressed(e).detail(key, value);
-		throw;
-	}
-}
-
-ACTOR template <class T, class X>
-Future<T> traceAfterCall(Future<T> what, const char* type, const char* key, X func, bool traceErrors = false) {
-	try {
-		state T val = wait(what);
-		try {
-			TraceEvent(type).detail(key, func(val));
-		} catch (Error& e) {
-			TraceEvent(SevError, "TraceAfterCallError").error(e);
+		if (traceErrors) {
+			TraceEvent(type.toString().c_str()).errorUnsuppressed(e);
 		}
-		return val;
-	} catch (Error& e) {
-		if (traceErrors)
-			TraceEvent(type).errorUnsuppressed(e);
 		throw;
 	}
 }

--- a/flow/include/flow/genericactors.actor.h
+++ b/flow/include/flow/genericactors.actor.h
@@ -51,8 +51,8 @@
 #endif
 
 ACTOR template <class T>
-Future<T> traceAfter(Future<T> what, Standalone<StringRef> type, bool traceErrors = true) {
-	state std::string typeStr = type.toString();
+Future<T> traceAfter(Future<T> what, std::string type, bool traceErrors = true) {
+	state std::string typeStr = type;
 	try {
 		T val = wait(what);
 		TraceEvent(typeStr.c_str());

--- a/flow/include/flow/genericactors.actor.h
+++ b/flow/include/flow/genericactors.actor.h
@@ -52,13 +52,14 @@
 
 ACTOR template <class T>
 Future<T> traceAfter(Future<T> what, Standalone<StringRef> type, bool traceErrors = true) {
+	state std::string typeStr = type.toString();
 	try {
 		T val = wait(what);
-		TraceEvent(type.toString().c_str());
+		TraceEvent(typeStr.c_str());
 		return val;
 	} catch (Error& e) {
 		if (traceErrors) {
-			TraceEvent(type.toString().c_str()).errorUnsuppressed(e);
+			TraceEvent(typeStr.c_str()).errorUnsuppressed(e);
 		}
 		throw;
 	}


### PR DESCRIPTION
## Description

Whenever we've a recovery that takes too long, TraceEvents are invaluable to debug why it took so long. The recovery state trace event generally is enough to point out what phase takes long. For initializing_transaction_servers phase, we can have better observability to do fine grained analysis. This PR adds trace events in that direction. 

A common pattern of waiting in FDB is:

```
wait(A && B && C)
```

In such cases, having a trace event _after the entire_ wait is not good enough if we're stuck in A or B or C. To _easily_ have _finer grained_ trace events, I was thinking to have a library function:

```
Future<T> observable(Future<T> in, const std::string& msg)
```

It turns out that genericactor.actor.h already had traceAfter, which was similar to my implementation. No one is using traceAfter today, so I rewrote it based on what I think the interface and implementation should be. The code should be self readable. With this library, I can then do:

```
wait(traceAfter(A) && traceAfter(B) && traceAfter(C))
```

Now if A is stuck but B and C are ready, it's easy to spot since trace events for B and C will be logged but not for A.  

If the github diff viewer is not easy to read, here's the library interface and implementation:

```
ACTOR template <class T>
Future<T> traceAfter(Future<T> what, Standalone<StringRef> type, bool traceErrors = true) {
	try {
		T val = wait(what);
		TraceEvent(type.toString().c_str());
		return val;
	} catch (Error& e) {
		if (traceErrors) {
			TraceEvent(type.toString().c_str()).errorUnsuppressed(e);
		}
		throw;
	}
}
```

## Testing

100K: 20250919-235055-praza-long-recovery-observa-39ff1eac87c7c1bd compressed=True data_size=40491235 duration=5833743 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:56:10 sanity=False started=100000 stopped=20250920-004705 submitted=20250919-235055 timeout=5400 username=praza-long-recovery-observability-v3-e5e0324f2c8c448077127c8008b6880fe29d4adf

100K on latest commit running: 20250923-164500-praza-long-recovery-observa-6e278090b7156e12 compressed=True data_size=40491494 duration=5971071 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:31:26 sanity=False started=100000 stopped=20250923-181626 submitted=20250923-164500 timeout=5400 username=praza-long-recovery-observability-v3-acb8eaf5a51525c51ed21ab59f04491c9e2b2031

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
