### PR TITLE
go bindings: rename error variables from e to err in tests (#8828)

### DIFF
--- a/bindings/go/src/fdb/fdb_test.go
+++ b/bindings/go/src/fdb/fdb_test.go
@@ -397,9 +397,9 @@ func TestGetClientStatus(t *testing.T) {
 	fdb.MustAPIVersion(API_VERSION)
 	db := fdb.MustOpenDefault()
 
-	st, e := db.GetClientStatus()
-	if e != nil {
-		t.Fatalf("GetClientStatus failed %v", e)
+	st, err := db.GetClientStatus()
+	if err != nil {
+		t.Fatalf("GetClientStatus failed %v", err)
 	}
 	if len(st) == 0 {
 		t.Fatal("returned status is empty")
@@ -416,8 +416,8 @@ func ExampleDatabase_GetClientStatus() {
 
 	db := fdb.MustOpenDefault()
 
-	st, e := db.GetClientStatus()
-	if e != nil {
+	st, err := db.GetClientStatus()
+	if err != nil {
 		fmt.Errorf("Unable to get client status: %v\n", err)
 		return
 	}


### PR DESCRIPTION
- This PR fixes issue #8828.
- Renames error variable e → err in Go test files for consistency with Go conventions in fdb_test.go alone.
- Fixed a regression of referring to err (where referring to e is needed) - commit id 288a6c1b450cfa77a36748465e0a05668e5e6596