### PR TITLE
Backup Encryption Fixes and Metadata Changes (#12287)

### DIFF
--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -1993,6 +1993,7 @@ ACTOR Future<Void> submitBackup(Database db,
                                 StopWhenDone stopWhenDone,
                                 UsePartitionedLog usePartitionedLog,
                                 IncrementalBackupOnly incrementalBackupOnly,
+                                Optional<std::string> encryptionKeyFile,
                                 Optional<std::string> blobManifestUrl) {
 	try {
 		state FileBackupAgent backupAgent;
@@ -2047,7 +2048,7 @@ ACTOR Future<Void> submitBackup(Database db,
 			                              stopWhenDone,
 			                              usePartitionedLog,
 			                              incrementalBackupOnly,
-			                              {},
+			                              encryptionKeyFile,
 			                              blobManifestUrl));
 
 			// Wait for the backup to complete, if requested
@@ -4269,6 +4270,7 @@ int main(int argc, char* argv[]) {
 				                           stopWhenDone,
 				                           usePartitionedLog,
 				                           incrementalBackupOnly,
+				                           encryptionKeyFile,
 				                           blobManifestUrl));
 				break;
 			}

--- a/fdbclient/BackupContainer.actor.cpp
+++ b/fdbclient/BackupContainer.actor.cpp
@@ -134,6 +134,7 @@ std::string BackupDescription::toString() const {
 	info.append(format("URL: %s\n", url.c_str()));
 	info.append(format("Restorable: %s\n", maxRestorableVersion.present() ? "true" : "false"));
 	info.append(format("Partitioned logs: %s\n", partitioned ? "true" : "false"));
+	info.append(format("File-level encryption: %s\n", fileLevelEncryption ? "true" : "false"));
 
 	auto formatVersion = [&](Version v) {
 		std::string s;

--- a/fdbclient/BackupContainerFileSystem.actor.cpp
+++ b/fdbclient/BackupContainerFileSystem.actor.cpp
@@ -58,9 +58,14 @@ public:
 		state Standalone<StringRef> buf = makeString(size);
 		wait(success(f->read(mutateString(buf), buf.size(), 0)));
 		json_spirit::mValue json;
-		json_spirit::read_string(buf.toString(), json);
-		JSONDoc doc(json);
+		if (!json_spirit::read_string(buf.toString(), json)) {
+			fprintf(stderr,
+			        "ERROR: Failed to read data. Verify that backup and restore encryption keys match (if provided) or "
+			        "the data is corrupted.\n");
+			throw restore_error();
+		}
 
+		JSONDoc doc(json);
 		Version v;
 		if (!doc.tryGet("beginVersion", v) || v != snapshot.beginVersion)
 			throw restore_corrupted_data();

--- a/fdbclient/BackupContainerFileSystem.actor.cpp
+++ b/fdbclient/BackupContainerFileSystem.actor.cpp
@@ -521,11 +521,13 @@ public:
 		state Optional<Version> metaExpiredEnd;
 		state Optional<Version> metaUnreliableEnd;
 		state Optional<Version> metaLogType;
+		state Optional<Version> fileLevelEncryption;
 
 		std::vector<Future<Void>> metaReads;
 		metaReads.push_back(store(metaExpiredEnd, bc->expiredEndVersion().get()));
 		metaReads.push_back(store(metaUnreliableEnd, bc->unreliableEndVersion().get()));
 		metaReads.push_back(store(metaLogType, bc->logType().get()));
+		metaReads.push_back(store(fileLevelEncryption, bc->fileLevelEncryption().get()));
 
 		// Only read log begin/end versions if not doing a deep scan, otherwise scan files and recalculate them.
 		if (!deepScan) {
@@ -621,6 +623,12 @@ public:
 		} else {
 			desc.partitioned =
 			    metaLogType.present() && metaLogType.get() == BackupContainerFileSystemImpl::PARTITIONED_MUTATION_LOG;
+		}
+
+		if (fileLevelEncryption.present() && fileLevelEncryption.get() != 0) {
+			desc.fileLevelEncryption = true;
+		} else {
+			desc.fileLevelEncryption = false;
 		}
 
 		// List logs in version order so log continuity can be analyzed
@@ -1308,6 +1316,15 @@ public:
 		return Void();
 	}
 
+	ACTOR static Future<Void> writeEncryptionMetadataIfNotExists(Reference<BackupContainerFileSystem> bc) {
+		Optional<Version> existingEncryptionMetadata = wait(bc->fileLevelEncryption().get());
+
+		if (!existingEncryptionMetadata.present()) {
+			wait(bc->fileLevelEncryption().set(bc->encryptionKeyFileName.present() ? 1 : 0));
+		}
+		return Void();
+	}
+
 }; // class BackupContainerFileSystemImpl
 
 Future<Reference<IBackupFile>> BackupContainerFileSystem::writeLogFile(Version beginVersion,
@@ -1492,6 +1509,11 @@ Future<Void> BackupContainerFileSystem::expireData(Version expireEndVersion,
 	    Reference<BackupContainerFileSystem>::addRef(this), expireEndVersion, force, progress, restorableBeginVersion);
 }
 
+Future<Void> BackupContainerFileSystem::writeEncryptionMetadata() {
+	return BackupContainerFileSystemImpl::writeEncryptionMetadataIfNotExists(
+	    Reference<BackupContainerFileSystem>::addRef(this));
+}
+
 ACTOR static Future<KeyRange> getSnapshotFileKeyRange_impl(Reference<BackupContainerFileSystem> bc,
                                                            RangeFile file,
                                                            Database cx) {
@@ -1618,6 +1640,10 @@ BackupContainerFileSystem::VersionProperty BackupContainerFileSystem::unreliable
 BackupContainerFileSystem::VersionProperty BackupContainerFileSystem::logType() {
 	return { Reference<BackupContainerFileSystem>::addRef(this), "mutation_log_type" };
 }
+BackupContainerFileSystem::VersionProperty BackupContainerFileSystem::fileLevelEncryption() {
+	return { Reference<BackupContainerFileSystem>::addRef(this), "file_level_encryption" };
+}
+
 bool BackupContainerFileSystem::usesEncryption() const {
 	return encryptionSetupFuture.isValid();
 }

--- a/fdbclient/BackupContainerFileSystem.actor.cpp
+++ b/fdbclient/BackupContainerFileSystem.actor.cpp
@@ -1267,6 +1267,12 @@ public:
 	}
 
 	ACTOR static Future<Void> createTestEncryptionKeyFile(std::string filename) {
+		if (fileExists(filename)) {
+			// Key file already exists, don't overwrite it -> only for testing between backup and restore workloads to
+			// share the key.
+			TraceEvent("EncryptionKeyFileExists").detail("FileName", filename);
+			return Void();
+		}
 		state Reference<IAsyncFile> keyFile = wait(IAsyncFileSystem::filesystem()->open(
 		    filename,
 		    IAsyncFile::OPEN_ATOMIC_WRITE_AND_CREATE | IAsyncFile::OPEN_READWRITE | IAsyncFile::OPEN_CREATE,

--- a/fdbclient/BackupContainerLocalDirectory.actor.cpp
+++ b/fdbclient/BackupContainerLocalDirectory.actor.cpp
@@ -233,7 +233,8 @@ Future<bool> BackupContainerLocalDirectory::exists() {
 
 Future<Reference<IAsyncFile>> BackupContainerLocalDirectory::readFile(const std::string& path) {
 	int flags = IAsyncFile::OPEN_NO_AIO | IAsyncFile::OPEN_READONLY | IAsyncFile::OPEN_UNCACHED;
-	if (usesEncryption()) {
+	// Skip encryption for properties/ folder
+	if (usesEncryption() && !StringRef(path).startsWith("properties/"_sr)) {
 		flags |= IAsyncFile::OPEN_ENCRYPTED;
 	}
 	INJECT_BLOB_FAULT(http_request_failed, "BackupContainerLocalDirectory::readFile");
@@ -291,7 +292,8 @@ Future<Reference<IBackupFile>> BackupContainerLocalDirectory::writeFile(const st
 	INJECT_BLOB_FAULT(http_request_failed, "BackupContainerLocalDirectory::writeFile");
 	int flags = IAsyncFile::OPEN_NO_AIO | IAsyncFile::OPEN_UNCACHED | IAsyncFile::OPEN_CREATE |
 	            IAsyncFile::OPEN_ATOMIC_WRITE_AND_CREATE | IAsyncFile::OPEN_READWRITE;
-	if (usesEncryption()) {
+	// Skip encryption for properties/ folder
+	if (usesEncryption() && !StringRef(path).startsWith("properties/"_sr)) {
 		flags |= IAsyncFile::OPEN_ENCRYPTED;
 	}
 	std::string fullPath = joinPath(m_path, path);

--- a/fdbclient/BackupContainerS3BlobStore.actor.cpp
+++ b/fdbclient/BackupContainerS3BlobStore.actor.cpp
@@ -185,7 +185,7 @@ std::string BackupContainerS3BlobStore::getURLFormat() {
 Future<Reference<IAsyncFile>> BackupContainerS3BlobStore::readFile(const std::string& path) {
 	Reference<IAsyncFile> f = makeReference<AsyncFileS3BlobStoreRead>(m_bstore, m_bucket, dataPath(path));
 
-	if (usesEncryption()) {
+	if (usesEncryption() && !StringRef(path).startsWith("properties/"_sr)) {
 		f = makeReference<AsyncFileEncrypted>(f, AsyncFileEncrypted::Mode::READ_ONLY);
 	}
 	if (m_bstore->knobs.enable_read_cache) {
@@ -205,7 +205,7 @@ Future<std::vector<std::string>> BackupContainerS3BlobStore::listURLs(Reference<
 
 Future<Reference<IBackupFile>> BackupContainerS3BlobStore::writeFile(const std::string& path) {
 	Reference<IAsyncFile> f = makeReference<AsyncFileS3BlobStoreWrite>(m_bstore, m_bucket, dataPath(path));
-	if (usesEncryption()) {
+	if (usesEncryption() && !StringRef(path).startsWith("properties/"_sr)) {
 		f = makeReference<AsyncFileEncrypted>(f, AsyncFileEncrypted::Mode::APPEND_ONLY);
 	}
 	return Future<Reference<IBackupFile>>(makeReference<BackupContainerS3BlobStoreImpl::BackupFile>(path, f));

--- a/fdbclient/ClientKnobs.cpp
+++ b/fdbclient/ClientKnobs.cpp
@@ -233,7 +233,7 @@ void ClientKnobs::initialize(Randomize randomize) {
 
 	init( BLOBSTORE_CONCURRENT_WRITES_PER_FILE,      5 );
 	init( BLOBSTORE_CONCURRENT_READS_PER_FILE,       3 );
-	init( BLOBSTORE_ENABLE_READ_CACHE,            true );
+	init( BLOBSTORE_ENABLE_READ_CACHE,            true ); if ( randomize && BUGGIFY ) BLOBSTORE_ENABLE_READ_CACHE = deterministicRandom()->coinflip();
 	init( BLOBSTORE_READ_BLOCK_SIZE,       1024 * 1024 );
 	init( BLOBSTORE_READ_AHEAD_BLOCKS,               0 );
 	init( BLOBSTORE_READ_CACHE_BLOCKS_PER_FILE,      2 );

--- a/fdbclient/FileBackupAgent.actor.cpp
+++ b/fdbclient/FileBackupAgent.actor.cpp
@@ -4180,6 +4180,9 @@ struct StartFullBackupTaskFunc : BackupTaskFuncBase {
 			}
 		}
 
+		Reference<IBackupContainer> bc = wait(config.backupContainer().getOrThrow(tr));
+		wait(bc->writeEncryptionMetadata());
+
 		config.stateEnum().set(tr, EBackupState::STATE_RUNNING);
 
 		state Reference<TaskFuture> backupFinished = futureBucket->future(tr);
@@ -7730,6 +7733,15 @@ public:
 		    IBackupContainer::openContainer(url.toString(), proxy, encryptionKeyFileName);
 
 		state BackupDescription desc = wait(bc->describeBackup(true));
+
+		if (desc.fileLevelEncryption && !encryptionKeyFileName.present()) {
+			fprintf(stderr, "ERROR: Backup is encrypted, please provide the encryption key file path.\n");
+			throw restore_error();
+		} else if (!desc.fileLevelEncryption && encryptionKeyFileName.present()) {
+			fprintf(stderr, "ERROR: Backup is not encrypted, please remove the encryption key file path.\n");
+			throw restore_error();
+		}
+
 		if (cxOrig.present()) {
 			wait(desc.resolveVersionTimes(cxOrig.get()));
 		}

--- a/fdbclient/FileBackupAgent.actor.cpp
+++ b/fdbclient/FileBackupAgent.actor.cpp
@@ -7726,7 +7726,8 @@ public:
 			throw restore_error();
 		}
 
-		state Reference<IBackupContainer> bc = IBackupContainer::openContainer(url.toString(), proxy, {});
+		state Reference<IBackupContainer> bc =
+		    IBackupContainer::openContainer(url.toString(), proxy, encryptionKeyFileName);
 
 		state BackupDescription desc = wait(bc->describeBackup(true));
 		if (cxOrig.present()) {
@@ -7909,6 +7910,7 @@ public:
 		}
 
 		state Reference<IBackupContainer> bc = wait(backupConfig.backupContainer().getOrThrow(cx.getReference()));
+
 		bc = fileBackup::getBackupContainerWithProxy(bc);
 
 		if (fastRestore) {

--- a/fdbclient/azure_backup/BackupContainerAzureBlobStore.actor.cpp
+++ b/fdbclient/azure_backup/BackupContainerAzureBlobStore.actor.cpp
@@ -228,7 +228,8 @@ public:
 		}
 		Reference<IAsyncFile> f =
 		    makeReference<ReadFile>(self->asyncTaskThread, self->containerName, fileName, self->client);
-		if (self->usesEncryption()) {
+		// Skip encryption for properties/ folder
+		if (self->usesEncryption() && !StringRef(fileName).startsWith("properties/"_sr)) {
 			f = encryptFile(f, AsyncFileEncrypted::Mode::READ_ONLY);
 		}
 		return f;
@@ -245,7 +246,8 @@ public:
 		    }));
 		Reference<IAsyncFile> f =
 		    makeReference<WriteFile>(self->asyncTaskThread, self->containerName, fileName, self->client);
-		if (self->usesEncryption()) {
+		// Skip encryption for properties/ folder
+		if (self->usesEncryption() && !StringRef(fileName).startsWith("properties/"_sr)) {
 			f = encryptFile(f, AsyncFileEncrypted::Mode::APPEND_ONLY);
 		}
 		return makeReference<BackupFile>(fileName, f);

--- a/fdbclient/include/fdbclient/BackupContainer.h
+++ b/fdbclient/include/fdbclient/BackupContainer.h
@@ -180,6 +180,7 @@ struct BackupDescription {
 	Optional<Version> minRestorableVersion;
 	std::string extendedDetail; // Freeform container-specific info.
 	bool partitioned; // If this backup contains partitioned mutation logs.
+	bool fileLevelEncryption; // If this backup contains encrypted files.
 
 	// Resolves the versions above to timestamps using a given database's TimeKeeper data.
 	// toString will use this information if present.
@@ -310,6 +311,8 @@ public:
 	std::string const& getURL() const { return URL; }
 	Optional<std::string> const& getProxy() const { return proxy; }
 	Optional<std::string> const& getEncryptionKeyFileName() const { return encryptionKeyFileName; }
+
+	virtual Future<Void> writeEncryptionMetadata() = 0;
 
 	static std::string lastOpenError;
 

--- a/fdbclient/include/fdbclient/BackupContainerFileSystem.h
+++ b/fdbclient/include/fdbclient/BackupContainerFileSystem.h
@@ -163,6 +163,8 @@ public:
 	                                                  Version beginVersion) final;
 	static Future<Void> createTestEncryptionKeyFile(std::string const& filename);
 
+	Future<Void> writeEncryptionMetadata() override;
+
 protected:
 	bool usesEncryption() const;
 	void setEncryptionKey(Optional<std::string> const& encryptionKeyFileName);
@@ -196,6 +198,7 @@ private:
 	VersionProperty expiredEndVersion();
 	VersionProperty unreliableEndVersion();
 	VersionProperty logType();
+	VersionProperty fileLevelEncryption();
 
 	// List range files, unsorted, which contain data at or between beginVersion and endVersion
 	// NOTE: This reads the range file folder schema from FDB 6.0.15 and earlier and is provided for backward

--- a/fdbrpc/include/fdbrpc/AsyncFileEncrypted.h
+++ b/fdbrpc/include/fdbrpc/AsyncFileEncrypted.h
@@ -44,6 +44,7 @@ private:
 	Mode mode;
 	Future<Void> writeLastBlockToFile();
 	friend class AsyncFileEncryptedImpl;
+	int64_t fileSize = -1;
 
 	// Reading:
 	class RandomCache {

--- a/fdbserver/workloads/AtomicRestore.actor.cpp
+++ b/fdbserver/workloads/AtomicRestore.actor.cpp
@@ -21,6 +21,7 @@
 #include "fdbclient/ManagementAPI.actor.h"
 #include "fdbrpc/simulator.h"
 #include "fdbclient/BackupAgent.actor.h"
+#include "fdbclient/BackupContainerFileSystem.h"
 #include "fdbserver/Knobs.h"
 #include "fdbserver/RestoreCommon.actor.h"
 #include "fdbserver/workloads/workloads.actor.h"
@@ -37,6 +38,7 @@ struct AtomicRestoreWorkload : TestWorkload {
 	UsePartitionedLog usePartitionedLogs{ false };
 	Key addPrefix, removePrefix; // Original key will be first applied removePrefix and then applied addPrefix
 	// CAVEAT: When removePrefix is used, we must ensure every key in backup have the removePrefix
+	Optional<std::string> encryptionKeyFileName;
 
 	AtomicRestoreWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
 
@@ -54,6 +56,10 @@ struct AtomicRestoreWorkload : TestWorkload {
 
 		addPrefix = getOption(options, "addPrefix"_sr, ""_sr);
 		removePrefix = getOption(options, "removePrefix"_sr, ""_sr);
+
+		if (getOption(options, "encrypted"_sr, deterministicRandom()->random01() < 0.5)) {
+			encryptionKeyFileName = "simfdb/" + getTestEncryptionFileName();
+		}
 
 		// Correctness is not clean for addPrefix feature yet. Uncomment below to enable the test
 		// Generate addPrefix
@@ -95,6 +101,10 @@ struct AtomicRestoreWorkload : TestWorkload {
 		wait(delay(self->startAfter * deterministicRandom()->random01()));
 		TraceEvent("AtomicRestore_Start").detail("UsePartitionedLog", self->usePartitionedLogs);
 
+		if (self->encryptionKeyFileName.present()) {
+			wait(BackupContainerFileSystem::createTestEncryptionKeyFile(self->encryptionKeyFileName.get()));
+		}
+
 		state std::string backupContainer = "file://simfdb/backups/";
 		try {
 			wait(backupAgent.submitBackup(cx,
@@ -106,7 +116,9 @@ struct AtomicRestoreWorkload : TestWorkload {
 			                              self->backupRanges,
 			                              true,
 			                              StopWhenDone::False,
-			                              self->usePartitionedLogs));
+			                              self->usePartitionedLogs,
+			                              IncrementalBackupOnly::False,
+			                              self->encryptionKeyFileName));
 		} catch (Error& e) {
 			if (e.code() != error_code_backup_unneeded && e.code() != error_code_backup_duplicate)
 				throw;

--- a/fdbserver/workloads/Backup.actor.cpp
+++ b/fdbserver/workloads/Backup.actor.cpp
@@ -74,7 +74,7 @@ struct BackupWorkload : TestWorkload {
 		std::vector<std::string> restorePrefixesToInclude =
 		    getOption(options, "restorePrefixesToInclude"_sr, std::vector<std::string>());
 
-		if (getOption(options, "encrypted"_sr, deterministicRandom()->random01() < 0.1)) {
+		if (getOption(options, "encrypted"_sr, deterministicRandom()->random01() < 0.5)) {
 			encryptionKeyFileName = "simfdb/" + getTestEncryptionFileName();
 		}
 

--- a/fdbserver/workloads/BackupCorrectness.actor.cpp
+++ b/fdbserver/workloads/BackupCorrectness.actor.cpp
@@ -481,7 +481,8 @@ struct BackupAndRestoreCorrectnessWorkload : TestWorkload {
 	                                              Database cx,
 	                                              FileBackupAgent* backupAgent,
 	                                              Standalone<StringRef> lastBackupContainer,
-	                                              UID randomID) {
+	                                              UID randomID,
+	                                              Optional<std::string> encryptionKeyFileName) {
 		state Transaction tr(cx);
 		state int rowCount = 0;
 		loop {
@@ -508,7 +509,11 @@ struct BackupAndRestoreCorrectnessWorkload : TestWorkload {
 				                                  normalKeys,
 				                                  Key(),
 				                                  Key(),
-				                                  self->locked)));
+				                                  self->locked,
+				                                  OnlyApplyMutationLogs::False,
+				                                  InconsistentSnapshotOnly::False,
+				                                  ::invalidVersion,
+				                                  encryptionKeyFileName)));
 				TraceEvent(SevError, "BARW_RestoreAllowedOverwrittingDatabase", randomID).log();
 				ASSERT(false);
 			} catch (Error& e) {
@@ -552,7 +557,7 @@ struct BackupAndRestoreCorrectnessWorkload : TestWorkload {
 		                                  OnlyApplyMutationLogs::False,
 		                                  InconsistentSnapshotOnly::False,
 		                                  ::invalidVersion,
-		                                  self->encryptionKeyFileName)));
+		                                  lastBackupContainer->getEncryptionKeyFileName())));
 		printf("BackupCorrectness, backupAgent.restore finished for tag:%s\n", restoreTag.toString().c_str());
 		return Void();
 	}
@@ -658,10 +663,20 @@ struct BackupAndRestoreCorrectnessWorkload : TestWorkload {
 			wait(startRestore);
 
 			if (lastBackupContainer && self->performRestore) {
+				auto container = IBackupContainer::openContainer(lastBackupContainer->getURL(),
+				                                                 lastBackupContainer->getProxy(),
+				                                                 lastBackupContainer->getEncryptionKeyFileName());
+				state BackupDescription desc = wait(container->describeBackup());
+
 				if (deterministicRandom()->random01() < 0.5) {
-					wait(attemptDirtyRestore(
-					    self, cx, &backupAgent, StringRef(lastBackupContainer->getURL()), randomID));
+					wait(attemptDirtyRestore(self,
+					                         cx,
+					                         &backupAgent,
+					                         StringRef(lastBackupContainer->getURL()),
+					                         randomID,
+					                         lastBackupContainer->getEncryptionKeyFileName()));
 				}
+
 				wait(runRYWTransaction(cx, [=](Reference<ReadYourWritesTransaction> tr) -> Future<Void> {
 					tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 					for (auto& kvrange : self->backupRanges)
@@ -674,11 +689,6 @@ struct BackupAndRestoreCorrectnessWorkload : TestWorkload {
 				    .detail("LastBackupContainer", lastBackupContainer->getURL())
 				    .detail("RestoreAfter", self->restoreAfter)
 				    .detail("BackupTag", printable(self->backupTag));
-
-				auto container = IBackupContainer::openContainer(lastBackupContainer->getURL(),
-				                                                 lastBackupContainer->getProxy(),
-				                                                 lastBackupContainer->getEncryptionKeyFileName());
-				BackupDescription desc = wait(container->describeBackup());
 
 				state Version targetVersion = -1;
 				if (desc.maxRestorableVersion.present()) {
@@ -752,7 +762,7 @@ struct BackupAndRestoreCorrectnessWorkload : TestWorkload {
 						                                       OnlyApplyMutationLogs::False,
 						                                       InconsistentSnapshotOnly::False,
 						                                       ::invalidVersion,
-						                                       self->encryptionKeyFileName));
+						                                       lastBackupContainer->getEncryptionKeyFileName()));
 					}
 				} else {
 					multipleRangesInOneTag = true;
@@ -777,7 +787,7 @@ struct BackupAndRestoreCorrectnessWorkload : TestWorkload {
 					                                       OnlyApplyMutationLogs::False,
 					                                       InconsistentSnapshotOnly::False,
 					                                       ::invalidVersion,
-					                                       self->encryptionKeyFileName));
+					                                       lastBackupContainer->getEncryptionKeyFileName()));
 				}
 
 				// Sometimes kill and restart the restore
@@ -794,23 +804,24 @@ struct BackupAndRestoreCorrectnessWorkload : TestWorkload {
 									tr->clear(range);
 								return Void();
 							}));
-							restores[restoreIndex] = backupAgent.restore(cx,
-							                                             cx,
-							                                             restoreTags[restoreIndex],
-							                                             KeyRef(lastBackupContainer->getURL()),
-							                                             lastBackupContainer->getProxy(),
-							                                             self->restoreRanges,
-							                                             WaitForComplete::True,
-							                                             ::invalidVersion,
-							                                             Verbose::True,
-							                                             Key(),
-							                                             Key(),
-							                                             self->locked,
-							                                             UnlockDB::True,
-							                                             OnlyApplyMutationLogs::False,
-							                                             InconsistentSnapshotOnly::False,
-							                                             ::invalidVersion,
-							                                             self->encryptionKeyFileName);
+							restores[restoreIndex] =
+							    backupAgent.restore(cx,
+							                        cx,
+							                        restoreTags[restoreIndex],
+							                        KeyRef(lastBackupContainer->getURL()),
+							                        lastBackupContainer->getProxy(),
+							                        self->restoreRanges,
+							                        WaitForComplete::True,
+							                        ::invalidVersion,
+							                        Verbose::True,
+							                        Key(),
+							                        Key(),
+							                        self->locked,
+							                        UnlockDB::True,
+							                        OnlyApplyMutationLogs::False,
+							                        InconsistentSnapshotOnly::False,
+							                        ::invalidVersion,
+							                        lastBackupContainer->getEncryptionKeyFileName());
 						}
 					} else {
 						for (restoreIndex = 0; restoreIndex < restores.size(); restoreIndex++) {
@@ -826,22 +837,23 @@ struct BackupAndRestoreCorrectnessWorkload : TestWorkload {
 									    tr->clear(self->restoreRanges[restoreIndex]);
 									    return Void();
 								    }));
-								restores[restoreIndex] = backupAgent.restore(cx,
-								                                             cx,
-								                                             restoreTags[restoreIndex],
-								                                             KeyRef(lastBackupContainer->getURL()),
-								                                             lastBackupContainer->getProxy(),
-								                                             WaitForComplete::True,
-								                                             ::invalidVersion,
-								                                             Verbose::True,
-								                                             self->restoreRanges[restoreIndex],
-								                                             Key(),
-								                                             Key(),
-								                                             self->locked,
-								                                             OnlyApplyMutationLogs::False,
-								                                             InconsistentSnapshotOnly::False,
-								                                             ::invalidVersion,
-								                                             self->encryptionKeyFileName);
+								restores[restoreIndex] =
+								    backupAgent.restore(cx,
+								                        cx,
+								                        restoreTags[restoreIndex],
+								                        KeyRef(lastBackupContainer->getURL()),
+								                        lastBackupContainer->getProxy(),
+								                        WaitForComplete::True,
+								                        ::invalidVersion,
+								                        Verbose::True,
+								                        self->restoreRanges[restoreIndex],
+								                        Key(),
+								                        Key(),
+								                        self->locked,
+								                        OnlyApplyMutationLogs::False,
+								                        InconsistentSnapshotOnly::False,
+								                        ::invalidVersion,
+								                        lastBackupContainer->getEncryptionKeyFileName());
 							}
 						}
 					}

--- a/fdbserver/workloads/BackupCorrectness.actor.cpp
+++ b/fdbserver/workloads/BackupCorrectness.actor.cpp
@@ -93,7 +93,7 @@ struct BackupAndRestoreCorrectnessWorkload : TestWorkload {
 		    getOption(options, "restorePrefixesToInclude"_sr, std::vector<std::string>());
 
 		shouldSkipRestoreRanges = deterministicRandom()->random01() < 0.3 ? true : false;
-		if (getOption(options, "encrypted"_sr, deterministicRandom()->random01() < 0.1)) {
+		if (getOption(options, "encrypted"_sr, deterministicRandom()->random01() < 0.5)) {
 			encryptionKeyFileName = "simfdb/" + getTestEncryptionFileName();
 		}
 

--- a/fdbserver/workloads/BackupCorrectnessPartitioned.actor.cpp
+++ b/fdbserver/workloads/BackupCorrectnessPartitioned.actor.cpp
@@ -88,7 +88,7 @@ struct BackupAndRestorePartitionedCorrectnessWorkload : TestWorkload {
 		    getOption(options, "restorePrefixesToInclude"_sr, std::vector<std::string>());
 
 		shouldSkipRestoreRanges = deterministicRandom()->random01() < 0.3 ? true : false;
-		if (getOption(options, "encrypted"_sr, deterministicRandom()->random01() < 0.1)) {
+		if (getOption(options, "encrypted"_sr, deterministicRandom()->random01() < 0.5)) {
 			encryptionKeyFileName = "simfdb/" + getTestEncryptionFileName();
 		}
 

--- a/fdbserver/workloads/IncrementalBackup.actor.cpp
+++ b/fdbserver/workloads/IncrementalBackup.actor.cpp
@@ -27,9 +27,12 @@
 #include "fdbrpc/simulator.h"
 #include "fdbclient/BackupAgent.actor.h"
 #include "fdbclient/BackupContainer.h"
+#include "fdbclient/BackupContainerFileSystem.h"
 #include "fdbserver/Knobs.h"
 #include "fdbserver/workloads/workloads.actor.h"
 #include "flow/Arena.h"
+#include "flow/Platform.h"
+#include "flow/Trace.h"
 #include "flow/serialize.h"
 #include "flow/actorcompiler.h" // This must be the last #include.
 
@@ -47,6 +50,7 @@ struct IncrementalBackupWorkload : TestWorkload {
 	bool checkBeginVersion;
 	bool clearBackupAgentKeys;
 	Standalone<StringRef> blobManifestUrl;
+	Optional<std::string> encryptionKeyFileName;
 
 	IncrementalBackupWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
 		backupDir = getOption(options, "backupDir"_sr, "file://simfdb/backups/"_sr);
@@ -59,6 +63,10 @@ struct IncrementalBackupWorkload : TestWorkload {
 		checkBeginVersion = getOption(options, "checkBeginVersion"_sr, false);
 		clearBackupAgentKeys = getOption(options, "clearBackupAgentKeys"_sr, false);
 		blobManifestUrl = getOption(options, "blobManifestUrl"_sr, ""_sr);
+
+		if (getOption(options, "encrypted"_sr, deterministicRandom()->random01() < 0.5)) {
+			encryptionKeyFileName = "simfdb/" + getTestEncryptionFileName();
+		}
 	}
 
 	Future<Void> setup(Database const& cx) override { return Void(); }
@@ -99,6 +107,12 @@ struct IncrementalBackupWorkload : TestWorkload {
 				TraceEvent("IBackupWaitContainer").log();
 				wait(success(self->backupAgent.waitBackup(
 				    cx, self->tag.toString(), StopWhenDone::False, &backupContainer, &backupUID)));
+
+				state Optional<std::string> restoreEncryptionKeyFileName;
+				if (self->encryptionKeyFileName.present() && fileExists(self->encryptionKeyFileName.get())) {
+					restoreEncryptionKeyFileName = self->encryptionKeyFileName.get();
+				}
+
 				if (!backupContainer.isValid()) {
 					TraceEvent("IBackupCheckListContainersAttempt").log();
 					state std::vector<std::string> containers =
@@ -107,7 +121,8 @@ struct IncrementalBackupWorkload : TestWorkload {
 					    .detail("Size", containers.size())
 					    .detail("First", containers.front());
 					if (containers.size()) {
-						backupContainer = IBackupContainer::openContainer(containers.front(), {}, {});
+						backupContainer =
+						    IBackupContainer::openContainer(containers.front(), {}, restoreEncryptionKeyFileName);
 					}
 				}
 				state bool e = wait(backupContainer->exists());
@@ -157,6 +172,10 @@ struct IncrementalBackupWorkload : TestWorkload {
 		addDefaultBackupRanges(backupRanges);
 
 		if (self->submitOnly) {
+			if (self->encryptionKeyFileName.present()) {
+				wait(BackupContainerFileSystem::createTestEncryptionKeyFile(self->encryptionKeyFileName.get()));
+			}
+
 			TraceEvent("IBackupSubmitAttempt").log();
 			try {
 				Optional<std::string> blobManifestUrl;
@@ -174,7 +193,7 @@ struct IncrementalBackupWorkload : TestWorkload {
 				                                    StopWhenDone::False,
 				                                    UsePartitionedLog::False,
 				                                    IncrementalBackupOnly::True,
-				                                    {},
+				                                    self->encryptionKeyFileName,
 				                                    blobManifestUrl));
 			} catch (Error& e) {
 				TraceEvent("IBackupSubmitError").error(e);
@@ -205,6 +224,12 @@ struct IncrementalBackupWorkload : TestWorkload {
 			state Version beginVersion = invalidVersion;
 			wait(success(self->backupAgent.waitBackup(
 			    cx, self->tag.toString(), StopWhenDone::False, &backupContainer, &backupUID)));
+
+			state Optional<std::string> restoreEncryptionKeyFileName;
+			if (self->encryptionKeyFileName.present() && fileExists(self->encryptionKeyFileName.get())) {
+				restoreEncryptionKeyFileName = self->encryptionKeyFileName.get();
+			}
+
 			if (self->checkBeginVersion) {
 				TraceEvent("IBackupReadSystemKeys").log();
 				state Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
@@ -275,7 +300,8 @@ struct IncrementalBackupWorkload : TestWorkload {
 				                                       UnlockDB::True,
 				                                       OnlyApplyMutationLogs::True,
 				                                       InconsistentSnapshotOnly::False,
-				                                       beginVersion)));
+				                                       beginVersion,
+				                                       restoreEncryptionKeyFileName)));
 			}
 			TraceEvent("IBackupRestoreAttempt").detail("BeginVersion", beginVersion);
 			wait(success(self->backupAgent.restore(cx,
@@ -293,7 +319,8 @@ struct IncrementalBackupWorkload : TestWorkload {
 			                                       UnlockDB::True,
 			                                       OnlyApplyMutationLogs::True,
 			                                       InconsistentSnapshotOnly::False,
-			                                       beginVersion)));
+			                                       beginVersion,
+			                                       restoreEncryptionKeyFileName)));
 			TraceEvent("IBackupRestoreSuccess").log();
 		}
 		return Void();

--- a/fdbserver/workloads/IncrementalBackup.actor.cpp
+++ b/fdbserver/workloads/IncrementalBackup.actor.cpp
@@ -64,7 +64,13 @@ struct IncrementalBackupWorkload : TestWorkload {
 		clearBackupAgentKeys = getOption(options, "clearBackupAgentKeys"_sr, false);
 		blobManifestUrl = getOption(options, "blobManifestUrl"_sr, ""_sr);
 
-		if (getOption(options, "encrypted"_sr, deterministicRandom()->random01() < 0.5)) {
+		if (restoreOnly) {
+			// During restore, the encryption key file depends on whether the backup was encrypted or not.
+			std::string temp_encryptionKeyFileName = "simfdb/" + getTestEncryptionFileName();
+			if (fileExists(temp_encryptionKeyFileName)) {
+				encryptionKeyFileName = temp_encryptionKeyFileName;
+			}
+		} else if (getOption(options, "encrypted"_sr, deterministicRandom()->random01() < 0.5)) {
 			encryptionKeyFileName = "simfdb/" + getTestEncryptionFileName();
 		}
 	}

--- a/fdbserver/workloads/Restore.actor.cpp
+++ b/fdbserver/workloads/Restore.actor.cpp
@@ -60,7 +60,7 @@ struct RestoreWorkload : TestWorkload {
 		    getOption(options, "restorePrefixesToInclude"_sr, std::vector<std::string>());
 
 		shouldSkipRestoreRanges = deterministicRandom()->random01() < 0.3 ? true : false;
-		if (getOption(options, "encrypted"_sr, deterministicRandom()->random01() < 0.1)) {
+		if (getOption(options, "encrypted"_sr, deterministicRandom()->random01() < 0.5)) {
 			encryptionKeyFileName = "simfdb/" + getTestEncryptionFileName();
 		}
 

--- a/fdbserver/workloads/RestoreBackup.actor.cpp
+++ b/fdbserver/workloads/RestoreBackup.actor.cpp
@@ -26,6 +26,7 @@
 #include "fdbrpc/simulator.h"
 #include "fdbclient/BackupAgent.actor.h"
 #include "fdbclient/BackupContainer.h"
+#include "fdbclient/BackupContainerFileSystem.h"
 #include "fdbserver/Knobs.h"
 #include "fdbserver/workloads/workloads.actor.h"
 #include "flow/actorcompiler.h" // This must be the last #include.
@@ -39,12 +40,17 @@ struct RestoreBackupWorkload : TestWorkload {
 	Standalone<StringRef> tag;
 	double delayFor;
 	StopWhenDone stopWhenDone{ false };
+	Optional<std::string> encryptionKeyFileName;
 
 	RestoreBackupWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
 		backupDir = getOption(options, "backupDir"_sr, "file://simfdb/backups/"_sr);
 		tag = getOption(options, "tag"_sr, "default"_sr);
 		delayFor = getOption(options, "delayFor"_sr, 10.0);
 		stopWhenDone.set(getOption(options, "stopWhenDone"_sr, false));
+
+		if (getOption(options, "encrypted"_sr, deterministicRandom()->random01() < 0.5)) {
+			encryptionKeyFileName = "simfdb/" + getTestEncryptionFileName();
+		}
 	}
 
 	static constexpr auto NAME = "RestoreBackup";
@@ -115,6 +121,11 @@ struct RestoreBackupWorkload : TestWorkload {
 
 	ACTOR static Future<Void> _start(RestoreBackupWorkload* self, Database cx) {
 		state DatabaseConfiguration config = wait(getDatabaseConfiguration(cx));
+
+		if (self->encryptionKeyFileName.present()) {
+			wait(BackupContainerFileSystem::createTestEncryptionKeyFile(self->encryptionKeyFileName.get()));
+		}
+
 		wait(delay(self->delayFor));
 		wait(waitOnBackup(self, cx));
 		wait(clearDatabase(cx));
@@ -129,7 +140,15 @@ struct RestoreBackupWorkload : TestWorkload {
 			                                       getSystemBackupRanges(),
 			                                       WaitForComplete::True,
 			                                       ::invalidVersion,
-			                                       Verbose::True)));
+			                                       Verbose::True,
+			                                       Key(),
+			                                       Key(),
+			                                       LockDB::True,
+			                                       UnlockDB::True,
+			                                       OnlyApplyMutationLogs::False,
+			                                       InconsistentSnapshotOnly::False,
+			                                       ::invalidVersion,
+			                                       self->encryptionKeyFileName)));
 			// restore user data
 			wait(success(self->backupAgent.restore(cx,
 			                                       cx,
@@ -139,7 +158,14 @@ struct RestoreBackupWorkload : TestWorkload {
 			                                       WaitForComplete::True,
 			                                       ::invalidVersion,
 			                                       Verbose::True,
-			                                       normalKeys)));
+			                                       normalKeys,
+			                                       Key(),
+			                                       Key(),
+			                                       LockDB::True,
+			                                       OnlyApplyMutationLogs::False,
+			                                       InconsistentSnapshotOnly::False,
+			                                       ::invalidVersion,
+			                                       self->encryptionKeyFileName)));
 		} else {
 			wait(success(self->backupAgent.restore(cx,
 			                                       cx,
@@ -148,7 +174,15 @@ struct RestoreBackupWorkload : TestWorkload {
 			                                       self->backupContainer->getProxy(),
 			                                       WaitForComplete::True,
 			                                       ::invalidVersion,
-			                                       Verbose::True)));
+			                                       Verbose::True,
+			                                       KeyRange(),
+			                                       Key(),
+			                                       Key(),
+			                                       LockDB::True,
+			                                       OnlyApplyMutationLogs::False,
+			                                       InconsistentSnapshotOnly::False,
+			                                       ::invalidVersion,
+			                                       self->encryptionKeyFileName)));
 		}
 
 		return Void();

--- a/tests/rare/BlobRestoreBasic.toml
+++ b/tests/rare/BlobRestoreBasic.toml
@@ -33,6 +33,7 @@ waitForQuiescence = false
     blobManifestUrl = 'file://simfdb/fdbblob/manifest'
     submitOnly = true
     waitForBackup = true
+    encrypted = false
     
 [[test]]
 testTitle = 'CycleTest'
@@ -53,6 +54,7 @@ clearAfterTest = false
     tag = 'default'
     waitForBackup = true
     stopBackup = true
+    encrypted = false
 
 [[test]]
 testTitle = 'BlobRestore'

--- a/tests/rare/BlobRestoreTenantMode.toml
+++ b/tests/rare/BlobRestoreTenantMode.toml
@@ -26,6 +26,7 @@ waitForQuiescence = false
     blobManifestUrl = 'file://simfdb/fdbblob/manifest'
     submitOnly = true
     waitForBackup = true
+    encrypted = false
 
 [[test]]
 testTitle = 'BlobGranuleCorrectness'
@@ -42,6 +43,7 @@ clearAfterTest = false
     tag = 'default'
     waitForBackup = true
     stopBackup = true
+    encrypted = false
 
 [[test]]
 testTitle = 'BlobRestore'

--- a/tests/rare/BlobRestoreToVersion.toml
+++ b/tests/rare/BlobRestoreToVersion.toml
@@ -33,6 +33,7 @@ waitForQuiescence = false
     blobManifestUrl = 'file://simfdb/fdbblob/manifest'
     submitOnly = true
     waitForBackup = true
+    encrypted = false
         
 [[test]]
 testTitle = 'WriteTest'
@@ -68,6 +69,7 @@ waitForQuiescence = false
     tag = 'default'
     stopBackup = true
     waitForBackup = true
+    encrypted = false
 
 [[test]]
 testTitle = 'BlobRestore'

--- a/tests/slow/BackupNewAndOldRestore.toml
+++ b/tests/slow/BackupNewAndOldRestore.toml
@@ -19,7 +19,6 @@ simBackupAgents = 'BackupToFile'
     [[test.workload]]
     testName = 'Backup'
     usePartitionedLog = true
-    encrypted = false
     backupTag = 'newBackup'
     backupAfter = 10.0
     restoreAfter = 60.0
@@ -42,7 +41,6 @@ simBackupAgents = 'BackupToFile'
     [[test.workload]]
     testName = 'Backup'
     usePartitionedLog = false
-    encrypted = false
     backupTag = 'oldBackup'
     backupAfter = 10.0
     restoreAfter = 60.0
@@ -59,7 +57,6 @@ clearAfterTest = false
     testName = 'Restore'
     backupTag1 = 'newBackup'
     backupTag2 = 'oldBackup'
-    encrypted = false
 
 # check consistency after restore
 [[test]]

--- a/tests/slow/BackupOldAndNewRestore.toml
+++ b/tests/slow/BackupOldAndNewRestore.toml
@@ -18,11 +18,9 @@ simBackupAgents = 'BackupToFile'
     testDuration = 30.0
     expectedRate = 0
 
-# TODO: pass encrypted file across backup and restore workload
     [[test.workload]]
     testName = 'Backup'
     usePartitionedLog = false
-    encrypted = false
     backupTag = 'oldBackup'
     backupAfter = 10.0
     restoreAfter = 60.0
@@ -45,7 +43,6 @@ simBackupAgents = 'BackupToFile'
     [[test.workload]]
     testName = 'Backup'
     usePartitionedLog = true
-    encrypted = false
     backupTag = 'newBackup'
     backupAfter = 10.0
     restoreAfter = 60.0
@@ -62,7 +59,6 @@ clearAfterTest = false
     testName = 'Restore'
     backupTag1 = 'oldBackup'
     backupTag2 = 'newBackup'
-    encrypted = false
 
 # check consistency after restore
 [[test]]


### PR DESCRIPTION
Cherrypick in order: 
 https://github.com/apple/foundationdb/pull/12287  
 https://github.com/apple/foundationdb/pull/12289
 https://github.com/apple/foundationdb/pull/12293
 https://github.com/apple/foundationdb/pull/12354
 https://github.com/apple/foundationdb/pull/12375


### Testing
Completed 500K Simulation tests:

`
  20250923-214132-ak_bk1-d79919c41efab1a1            compressed=True data_size=41383872 duration=23066098 ended=500000 fail=3 fail_fast=10 max_runs=500000 pass=499997 priority=100 remaining=0 runtime=3:25:35 sanity=False started=500000 stopped=20250924-010707 submitted=20250923-214132 timeout=5400 username=ak_bk1
`