### PR TITLE
(7.4 backport) Add FDBWorkloadContext::delay (#12357)

### DIFF
--- a/bindings/c/foundationdb/CWorkload.h
+++ b/bindings/c/foundationdb/CWorkload.h
@@ -25,11 +25,21 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#define FDB_WORKLOAD_API_VERSION 1
+
+typedef struct FDB_future FDBFuture;
 typedef struct FDB_database FDBDatabase;
+
 typedef struct Opaque_promise OpaquePromise;
 typedef struct Opaque_workload OpaqueWorkload;
 typedef struct Opaque_workloadContext OpaqueWorkloadContext;
 typedef struct Opaque_metrics OpaqueMetrics;
+
+// Pure C bindings, equivalent to the C++ bindings in `CppWorkload.h`
+// documented here: https://apple.github.io/foundationdb/client-testing.html.
+
+// API changes may add pointers at the end of the virtual tables (_VT)
+// It is advised to never dereference or copy these structures, only using them through a pointer.
 
 // Log severity levels.
 // FDBSeverity_Error automatically stops the simulation.
@@ -57,60 +67,67 @@ typedef struct FDBMetric {
 	bool avg;
 } FDBMetric;
 
-// Wrapper around an owned C++ string.
+// Wrapper around an owned C++ `string`.
 // The `free` function must be called on `inner` before releasing the string.
 typedef struct FDBString {
 	const char* inner;
-	void (*free)(const char* inner);
+	struct FDBString_VT {
+		void (*free)(const char* inner);
+	}* vt;
 } FDBString;
 
-// Wrapper around a borrowed C++ vector<FDBMetric>.
+// Wrapper around a borrowed C++ `vector<FDBMetric>`.
 typedef struct FDBMetrics {
 	OpaqueMetrics* inner;
-	void (*reserve)(OpaqueMetrics* inner, int n);
-	void (*push)(OpaqueMetrics* inner, FDBMetric val);
+	struct FDBMetrics_VT {
+		void (*reserve)(OpaqueMetrics* inner, int n);
+		void (*push)(OpaqueMetrics* inner, FDBMetric val);
+	}* vt;
 } FDBMetrics;
 
-// Wrapper around an owned C++ GenericPromise<bool>
+// Wrapper around an owned C++ `GenericPromise<bool>`.
 // Calling `send` resolves the promise (the value is meaningless).
 // Calling `free` before resolving the promise triggers a "broken promise" error.
 typedef struct FDBPromise {
 	OpaquePromise* inner;
-	void (*send)(OpaquePromise* inner, bool val);
-	void (*free)(OpaquePromise* inner);
+	struct FDBPromise_VT {
+		void (*free)(OpaquePromise* inner);
+		void (*send)(OpaquePromise* inner, bool val);
+	}* vt;
 } FDBPromise;
 
-// Wrapper around a borrowed ExternalWorkload's context
+// Wrapper around a borrowed `ExternalWorkload`'s context.
 // All pointer-based arguments are borrowed and managed by the workload.
 typedef struct FDBWorkloadContext {
+	int api_version;
 	OpaqueWorkloadContext* inner;
-	// Log a message with severity and optional details.
-	// `details` is an array of key-value pairs, and `n` specifies the array size.
-	void (*trace)(OpaqueWorkloadContext* inner, FDBSeverity sev, const char* name, const FDBStringPair* details, int n);
-	uint64_t (*getProcessID)(OpaqueWorkloadContext* inner);
-	void (*setProcessID)(OpaqueWorkloadContext* inner, uint64_t processID);
-	// Return the current simulated time in seconds (starts at zero)
-	double (*now)(OpaqueWorkloadContext* inner);
-	uint32_t (*rnd)(OpaqueWorkloadContext* inner);
-	// Get an option by name, returning `defaultValue` if the option is not found.
-	// Getting an option consumes it, querying it again returns the empty string.
-	FDBString (*getOption)(OpaqueWorkloadContext* inner, const char* name, const char* defaultValue);
-	int (*clientId)(OpaqueWorkloadContext* inner);
-	int (*clientCount)(OpaqueWorkloadContext* inner);
-	int64_t (*sharedRandomNumber)(OpaqueWorkloadContext* inner);
+	struct FDBWorkloadContext_VT {
+		// Log a message with severity and optional details.
+		// `details` is an array of key-value pairs, and `n` specifies the array size.
+		void (*trace)(OpaqueWorkloadContext* inner,
+		              FDBSeverity sev,
+		              const char* name,
+		              const FDBStringPair* details,
+		              int n);
+		uint64_t (*getProcessID)(OpaqueWorkloadContext* inner);
+		void (*setProcessID)(OpaqueWorkloadContext* inner, uint64_t processID);
+		// Return the current simulated time in seconds (starts at zero).
+		double (*now)(OpaqueWorkloadContext* inner);
+		// Return a random number (different each time and for all clients).
+		uint32_t (*rnd)(OpaqueWorkloadContext* inner);
+		// Return an option by name, returning `defaultValue` if the option is not found.
+		// Return an option, consumming it, querying it again returns the empty string.
+		FDBString (*getOption)(OpaqueWorkloadContext* inner, const char* name, const char* defaultValue);
+		int (*clientId)(OpaqueWorkloadContext* inner);
+		int (*clientCount)(OpaqueWorkloadContext* inner);
+		// Return a random seed (same each time and for all clients).
+		int64_t (*sharedRandomNumber)(OpaqueWorkloadContext* inner);
+		// Return a future that will be ready after a given time. This internally uses TaskPriority::DefaultDelay.
+		FDBFuture* (*delay)(OpaqueWorkloadContext* inner, double seconds);
+	}* vt;
 } FDBWorkloadContext;
 
 // Interface for a workload implementation in C.
-// Workloads must expose an entry point named `workloadCFactory`:
-// extern FDBWorkload workloadCFactory(const char* name, FDBWorkloadContext context);
-// This function must return a valid instance of the FDBWorkload structure.
-// A specific implementation can be chosen based on the name passed.
-// The client C workload must be allocated, initialized and passed as pointer
-// in `inner`. It is advised to store the context alongside the workload as
-// it can't be retrieved it later. No function pointer can be left null.
-//
-// All methods directly map to a corresponding C++ methods in `CppWorkload.h`
-// documented here: https://apple.github.io/foundationdb/client-testing.html.
 //
 // Simulation stages (setup, start, and check) are executed sequentially.
 // A stage finishes when its associated promise is resolved. If a promise
@@ -119,14 +136,25 @@ typedef struct FDBWorkloadContext {
 // Workload functions should not block. If an operation must wait for database interaction,
 // it should initiate the action, register a callback, and return.
 typedef struct FDBWorkload {
+	int api_version;
 	OpaqueWorkload* inner;
-	void (*setup)(OpaqueWorkload* inner, FDBDatabase* db, FDBPromise done);
-	void (*start)(OpaqueWorkload* inner, FDBDatabase* db, FDBPromise done);
-	void (*check)(OpaqueWorkload* inner, FDBDatabase* db, FDBPromise done);
-	void (*getMetrics)(OpaqueWorkload* inner, FDBMetrics out);
-	// The timeout in simulated seconds for the check stage
-	double (*getCheckTimeout)(OpaqueWorkload* inner);
-	void (*free)(OpaqueWorkload* inner);
+	struct FDBWorkload_VT {
+		void (*free)(OpaqueWorkload* inner);
+		void (*setup)(OpaqueWorkload* inner, FDBDatabase* db, FDBPromise done);
+		void (*start)(OpaqueWorkload* inner, FDBDatabase* db, FDBPromise done);
+		void (*check)(OpaqueWorkload* inner, FDBDatabase* db, FDBPromise done);
+		void (*getMetrics)(OpaqueWorkload* inner, FDBMetrics out);
+		// The timeout in simulated seconds for the check stage
+		double (*getCheckTimeout)(OpaqueWorkload* inner);
+	}* vt;
 } FDBWorkload;
+
+// The C workload entrypoint.
+// This function must return a valid instance of the `FDBWorkload` struct.
+// A specific implementation can be chosen based on the name passed.
+// The client C workload must be allocated, initialized and passed as pointer
+// in `inner`. It is advised to store the context alongside the workload as
+// it can't be retrieved later. No function pointer can be left null.
+FDBWorkload workloadCFactory(const char* name, FDBWorkloadContext context);
 
 #endif

--- a/bindings/c/foundationdb/CppWorkload.h
+++ b/bindings/c/foundationdb/CppWorkload.h
@@ -64,6 +64,7 @@ public:
 	virtual int clientId() const = 0;
 	virtual int clientCount() const = 0;
 	virtual int64_t sharedRandomNumber() const = 0;
+	virtual FDBFuture* delay(double seconds) const = 0;
 };
 
 struct FDBPromise {

--- a/bindings/c/test/workloads/CWorkload.c
+++ b/bindings/c/test/workloads/CWorkload.c
@@ -18,24 +18,50 @@
  * limitations under the License.
  */
 
+// gcc -shared CWorkload.c -Ibindings/c/ -lfdb_c -o libc_workload.so
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 #include "foundationdb/CWorkload.h"
 
+// #include "foundationdb/fdb_c.h"
+typedef int fdb_error_t;
+typedef void (*FDBCallback)(FDBFuture* f, void* callback_parameter);
+fdb_error_t fdb_future_set_callback(FDBFuture* f, FDBCallback callback, void* callback_parameter);
+
 typedef struct CWorkload {
 	char* name;
-	int cliend_id;
+	int client_id;
 	FDBWorkloadContext context;
 } CWorkload;
 
+typedef struct DelayParameter {
+	CWorkload* workload;
+	double expected;
+	double start;
+	FDBPromise done;
+} DelayParameter;
+
 #define BIND(W) CWorkload* this = (CWorkload*)W
-#define WITH(C, M, ...) (C).M((C).inner, ##__VA_ARGS__)
+#define WITH(C, M, ...) (C).vt->M((C).inner, ##__VA_ARGS__)
 #define EXPORT extern __attribute__((visibility("default")))
+
+static void delay_callback(void* f, DelayParameter* param) {
+	BIND(param->workload);
+	printf("c_delayed(%s_%d): expected: %.3f, elapsed: %.3f\n",
+	       this->name,
+	       this->client_id,
+	       param->expected,
+	       WITH(this->context, now) - param->start);
+	WITH(param->done, send, true);
+	WITH(param->done, free);
+	free(param);
+}
 
 static void workload_setup(OpaqueWorkload* raw_workload, FDBDatabase* db, FDBPromise done) {
 	BIND(raw_workload);
-	printf("c_setup(%s_%d)\n", this->name, this->cliend_id);
+	printf("c_setup(%s_%d)\n", this->name, this->client_id);
 	FDBStringPair details[2] = {
 		{ .key = "Layer", .val = "C" },
 		{ .key = "Stage", .val = "setup" },
@@ -46,18 +72,25 @@ static void workload_setup(OpaqueWorkload* raw_workload, FDBDatabase* db, FDBPro
 }
 static void workload_start(OpaqueWorkload* raw_workload, FDBDatabase* db, FDBPromise done) {
 	BIND(raw_workload);
-	printf("c_start(%s_%d)\n", this->name, this->cliend_id);
+	printf("c_start(%s_%d)\n", this->name, this->client_id);
 	FDBStringPair details[2] = {
 		{ .key = "Layer", .val = "C" },
 		{ .key = "Stage", .val = "start" },
 	};
 	WITH(this->context, trace, FDBSeverity_Debug, "Test", details, 2);
-	WITH(done, send, true);
-	WITH(done, free);
+
+	double amount = 100 + this->client_id * 10;
+	DelayParameter* param = malloc(sizeof(DelayParameter));
+	param->workload = this;
+	param->expected = amount;
+	param->start = WITH(this->context, now);
+	param->done = done;
+	FDBFuture* f = WITH(this->context, delay, amount);
+	fdb_future_set_callback(f, (FDBCallback)delay_callback, param);
 }
 static void workload_check(OpaqueWorkload* raw_workload, FDBDatabase* db, FDBPromise done) {
 	BIND(raw_workload);
-	printf("c_check(%s_%d)\n", this->name, this->cliend_id);
+	printf("c_check(%s_%d)\n", this->name, this->client_id);
 	FDBStringPair details[2] = {
 		{ .key = "Layer", .val = "C" },
 		{ .key = "Stage", .val = "check" },
@@ -68,21 +101,30 @@ static void workload_check(OpaqueWorkload* raw_workload, FDBDatabase* db, FDBPro
 }
 static void workload_getMetrics(OpaqueWorkload* raw_workload, FDBMetrics out) {
 	BIND(raw_workload);
-	printf("c_getMetrics(%s_%d)\n", this->name, this->cliend_id);
+	printf("c_getMetrics(%s_%d)\n", this->name, this->client_id);
 	WITH(out, reserve, 8);
 	WITH(out, push, (FDBMetric){ .key = "test", .val = 42., .avg = false });
 }
 static double workload_getCheckTimeout(OpaqueWorkload* raw_workload) {
 	BIND(raw_workload);
-	printf("c_getCheckTimeout(%s_%d)\n", this->name, this->cliend_id);
+	printf("c_getCheckTimeout(%s_%d)\n", this->name, this->client_id);
 	return 3000.;
 };
 static void workload_free(OpaqueWorkload* raw_workload) {
 	BIND(raw_workload);
-	printf("c_free(%s_%d)\n", this->name, this->cliend_id);
+	printf("c_free(%s_%d)\n", this->name, this->client_id);
 	free(this->name);
 	free(this);
 }
+
+static struct FDBWorkload_VT CWorkload_vt = {
+	.free = workload_free,
+	.setup = workload_setup,
+	.start = workload_start,
+	.check = workload_check,
+	.getMetrics = workload_getMetrics,
+	.getCheckTimeout = workload_getCheckTimeout,
+};
 
 EXPORT FDBWorkload workloadCFactory(const char* borrow_name, FDBWorkloadContext context) {
 	int len = strlen(borrow_name) + 1;
@@ -91,7 +133,12 @@ EXPORT FDBWorkload workloadCFactory(const char* borrow_name, FDBWorkloadContext 
 
 	int client_id = WITH(context, clientId);
 	int client_count = WITH(context, clientCount);
-	printf("workloadCFactory(%s)[%d/%d]\n", name, client_id, client_count);
+	printf("workloadCFactory(%s)[%d/%d]: client_version: %d, server_version: %d\n",
+	       name,
+	       client_id,
+	       client_count,
+	       FDB_WORKLOAD_API_VERSION,
+	       context.api_version);
 
 	FDBString my_c_option;
 	my_c_option = WITH(context, getOption, "my_c_option", "null");
@@ -103,16 +150,12 @@ EXPORT FDBWorkload workloadCFactory(const char* borrow_name, FDBWorkloadContext 
 
 	CWorkload* workload = (CWorkload*)malloc(sizeof(CWorkload));
 	workload->name = name;
-	workload->cliend_id = client_id;
+	workload->client_id = client_id;
 	workload->context = context;
 
 	return (FDBWorkload){
+		.api_version = FDB_WORKLOAD_API_VERSION,
 		.inner = (OpaqueWorkload*)workload,
-		.setup = workload_setup,
-		.start = workload_start,
-		.check = workload_check,
-		.getMetrics = workload_getMetrics,
-		.getCheckTimeout = workload_getCheckTimeout,
-		.free = workload_free,
+		.vt = &CWorkload_vt,
 	};
 }

--- a/bindings/c/test/workloads/RustWorkload/Cargo.toml
+++ b/bindings/c/test/workloads/RustWorkload/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [build-dependencies]
-bindgen = "0.70.1"
+bindgen = "0.72.1"


### PR DESCRIPTION
Backport #12357 to 7.4 branch. See https://github.com/apple/foundationdb/pull/12357#pullrequestreview-3236205175 for reasoning behind backport.

100K running: 20250924-190205-praza-backport-pr12357-a2f1d58188c743e9f3ed9 compressed=True data_size=37233144 fail_fast=10 max_runs=100000 priority=100 sanity=False submitted=20250924-190205 timeout=5400 username=praza-backport-pr12357-a2f1d58188c743e9f3ed99bac4d8c7d80647860f

Although note that changes here should not affect simulation, so running 100K is out of precaution. 

---------

Replace this text with your description here...

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
