### PR TITLE
Fix mac build

### DIFF
--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -423,6 +423,7 @@ set_target_properties(c_workloads PROPERTIES
   LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/share/foundationdb")
 target_link_libraries(cpp_workloads PUBLIC fdb_c)
 target_include_directories(c_workloads PUBLIC ${CMAKE_SOURCE_DIR}/bindings/c)
+target_link_libraries(c_workloads PUBLIC fdb_c)
 
 if(NOT WIN32 AND NOT APPLE AND NOT OPEN_FOR_IDE)
   # Add the -Wl,--undefined-version flag to the linker command to allow


### PR DESCRIPTION
This broke because of https://github.com/apple/foundationdb/pull/12357. From the build logs:

```
FAILED: share/foundationdb/libc_workloads.dylib : && /Library/Developer/CommandLineTools/usr/bin/cc -O3 -DNDEBUG -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX13.0.sdk -dynamiclib -Wl,-headerpad_max_install_names -o share/foundationdb/libc_workloads.dylib -install_name @rpath/libc_workloads.dylib bindings/c/CM akeFiles/c_workloads.dir/test/workloads/CWorkload.c.o && : Undefined symbols for architecture x86_64: "_fdb_future_set_callback", referenced from: _workload_start in CWorkload.c.o ld: symbol(s) not found for architecture x86_64
```

More context: https://github.com/apple/foundationdb/pull/12390/files#r2377140614. 

This PR fixes that. Test is CI not giving the same error as above. 

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
