### PR TITLE
Misc small changes and FIXME comment additions from reading fdbrpc code

### DIFF
--- a/fdbclient/DatabaseContext.actor.cpp
+++ b/fdbclient/DatabaseContext.actor.cpp
@@ -244,7 +244,6 @@ void DatabaseContext::addSSIdTagMapping(const UID& uid, const Tag& tag) {
 }
 
 void DatabaseContext::getLatestCommitVersionForSSID(const UID& ssid, Tag& tag, Version& commitVersion) {
-	// initialization
 	tag = invalidTag;
 	commitVersion = invalidVersion;
 
@@ -611,8 +610,8 @@ ACTOR Future<Void> databaseLogger(DatabaseContext* cx) {
 	loop {
 		wait(delay(CLIENT_KNOBS->SYSTEM_MONITOR_INTERVAL, TaskPriority::FlushTrace));
 
-		bool logTraces = !g_network->isSimulated() || BUGGIFY_WITH_PROB(0.01);
-		if (logTraces) {
+		bool logMetrics = !g_network->isSimulated() || BUGGIFY_WITH_PROB(0.01);
+		if (logMetrics) {
 			TraceEvent ev("TransactionMetrics", cx->dbId);
 
 			ev.detail("Elapsed", (lastLogged == 0) ? 0 : now() - lastLogged)
@@ -648,7 +647,7 @@ ACTOR Future<Void> databaseLogger(DatabaseContext* cx) {
 			    .detail("NumLocalityCacheEntries", cx->locationCache.size());
 		}
 
-		if (cx->usedAnyChangeFeeds && logTraces) {
+		if (cx->usedAnyChangeFeeds && logMetrics) {
 			TraceEvent feedEv("ChangeFeedClientMetrics", cx->dbId);
 
 			feedEv.detail("Elapsed", (lastLogged == 0) ? 0 : now() - lastLogged)
@@ -661,7 +660,7 @@ ACTOR Future<Void> databaseLogger(DatabaseContext* cx) {
 			cx->ccFeed.logToTraceEvent(feedEv);
 		}
 
-		if (cx->anyBGReads && logTraces) {
+		if (cx->anyBGReads && logMetrics) {
 			TraceEvent bgReadEv("BlobGranuleReadMetrics", cx->dbId);
 
 			bgReadEv.detail("Elapsed", (lastLogged == 0) ? 0 : now() - lastLogged)
@@ -788,6 +787,7 @@ ACTOR static Future<Void> delExcessClntTxnEntriesActor(Transaction* tr, int64_t 
 	}
 }
 
+// FIXME: explain what "client status" is
 // The reason for getting a pointer to DatabaseContext instead of a reference counted object is because reference
 // counting will increment reference count for DatabaseContext which holds the future of this actor. This creates a
 // cyclic reference and hence this actor and Database object will not be destroyed at all.
@@ -1030,6 +1030,7 @@ Reference<LocationInfo> addCaches(const Reference<LocationInfo>& loc,
 	return makeReference<LocationInfo>(interfaces, true);
 }
 
+// FIXME: describe what this is supposed to be doing.
 ACTOR Future<Void> updateCachedRanges(DatabaseContext* self, std::map<UID, StorageServerInterface>* cacheServers) {
 	state Transaction tr;
 	state Value trueValue = storageCacheValue(std::vector<uint16_t>{ 0 });
@@ -1107,6 +1108,7 @@ ACTOR Future<Void> updateCachedRanges(DatabaseContext* self, std::map<UID, Stora
 	}
 }
 
+// FIXME: describe what this is supposed to be doing
 // The reason for getting a pointer to DatabaseContext instead of a reference counted object is because reference
 // counting will increment reference count for DatabaseContext which holds the future of this actor. This creates a
 // cyclic reference and hence this actor and Database object will not be destroyed at all.

--- a/fdbclient/StorageServerInterface.cpp
+++ b/fdbclient/StorageServerInterface.cpp
@@ -19,6 +19,9 @@
  */
 
 // TODO this should really be renamed "TSSComparison.cpp"
+// FIXME: actually it should be renamed "ReplyComparison" because TSS vs SS
+// is just one use case.  This code is agnostic to the specific use cases.
+// Fundamentally it is just about comparing replies. Where they came from is incidental.
 #include "fdbclient/StorageServerInterface.h"
 #include "fdbclient/BlobWorkerInterface.h"
 #include "crc32/crc32c.h" // for crc32c_append, to checksum values in tss trace events

--- a/fdbrpc/FlowTransport.actor.cpp
+++ b/fdbrpc/FlowTransport.actor.cpp
@@ -653,7 +653,6 @@ ACTOR Future<Void> connectionMonitor(Reference<Peer> peer) {
 			// the version reported in ConnectPacket.
 			//
 			// TLDR; We can probably close the connection now as we don't have any older clusters running either.
-			/
 			state double lastRefreshed = now();
 			state int64_t lastBytesReceived = peer->bytesReceived;
 			loop {

--- a/fdbrpc/FlowTransport.actor.cpp
+++ b/fdbrpc/FlowTransport.actor.cpp
@@ -63,6 +63,9 @@ void removeCachedDNS(const std::string& host, const std::string& service) {
 	INetworkConnections::net()->removeCachedDNS(host, service);
 }
 
+// FIXME: explain the purpose of these variables, their update
+// discipline, and the API calls that use them.
+
 namespace {
 
 NetworkAddressList g_currentDeliveryPeerAddress = NetworkAddressList();
@@ -71,7 +74,16 @@ Future<Void> g_currentDeliveryPeerDisconnect;
 
 } // namespace
 
+// FIXME: stop referring to messages as "packets".  Packets are known
+// to the network infrastructure (routers, etc) and are layed out in
+// compliance with widely adopted industry standards such as TCP and
+// IP.  Messages, on the other hand, are generally not understoody
+// beyond the boundaries of the application that defines them.
+// Certainly this applies to FDB messages.  So we should refer to FDB
+// messages as "messages".
 constexpr int PACKET_LEN_WIDTH = sizeof(uint32_t);
+
+// FIXME: explain what this is for
 const uint64_t TOKEN_STREAM_FLAG = 1;
 
 FDB_BOOLEAN_PARAM(InReadSocket);
@@ -327,6 +339,7 @@ public:
 	NetworkAddressCachedString localAddresses;
 	std::vector<Future<Void>> listeners;
 	std::unordered_map<NetworkAddress, Reference<struct Peer>> peers;
+	// FIXME: explain what the std::pair<double, double> represent:
 	std::unordered_map<NetworkAddress, std::pair<double, double>> closedPeers;
 	HealthMonitor healthMonitor;
 	std::set<NetworkAddress> orderedAddresses;
@@ -344,9 +357,11 @@ public:
 	Int64MetricHandle countConnClosedWithError;
 	Int64MetricHandle countConnClosedWithoutError;
 
+	// FIXME: explain what the std::pair<int64_t, double> represent:
 	std::map<NetworkAddress, std::pair<uint64_t, double>> incompatiblePeers;
 	AsyncTrigger incompatiblePeersChanged;
 	uint32_t numIncompatibleConnections;
+	// FIXME: explain the map
 	std::map<uint64_t, double> multiVersionConnections;
 	double lastIncompatibleMessage;
 	uint64_t transportId;
@@ -359,6 +374,7 @@ public:
 	std::unordered_map<Standalone<StringRef>, PublicKey> publicKeys;
 
 	struct ConnectionHistoryEntry {
+		// FIXME: explain why int64_t and not double is used to represent time
 		int64_t time;
 		NetworkAddress addr;
 		bool failed;
@@ -521,6 +537,7 @@ ACTOR Future<Void> pingLatencyLogger(TransportData* self) {
 	}
 }
 
+// FIXME: why doesn't this just pass a IPAllowList for this to copy, rather than a pointer?
 TransportData::TransportData(uint64_t transportId, int maxWellKnownEndpoints, IPAllowList const* allowList)
   : endpoints(maxWellKnownEndpoints), endpointNotFoundReceiver(endpoints), pingReceiver(endpoints),
     numIncompatibleConnections(0), lastIncompatibleMessage(0), transportId(transportId),
@@ -538,6 +555,7 @@ TransportData::TransportData(uint64_t transportId, int maxWellKnownEndpoints, IP
 struct ConnectPacket {
 	// The value does not include the size of `connectPacketLength` itself,
 	// but only the other fields of this structure.
+	// FIXME: document the wire protocol in more detail than just the prior sentence.
 	uint32_t connectPacketLength = 0;
 	ProtocolVersion protocolVersion; // Expect currentProtocolVersion
 
@@ -618,6 +636,7 @@ ACTOR Future<Void> connectionMonitor(Reference<Peer> peer) {
 			// Don't send ping messages to clients unless necessary. Instead monitor incoming client pings.
 			// We ignore this block for incompatible clients because pings from server would trigger the
 			// peer->resetPing and prevent 'connection_failed' due to ping timeout.
+			// FIXME: why don't we just close the connection if the peer is incompatible?
 			state double lastRefreshed = now();
 			state int64_t lastBytesReceived = peer->bytesReceived;
 			loop {
@@ -637,6 +656,9 @@ ACTOR Future<Void> connectionMonitor(Reference<Peer> peer) {
 		// We cannot let an error be thrown from connectionMonitor while still on the stack from scanPackets in
 		// connectionReader because then it would not call the destructor of connectionReader when connectionReader is
 		// cancelled.
+		// FIXME: Why should actors are about stacks?  Is there a better way to deal with this than having to
+		// anticipate and insert non-functional (from the point of what this actor is supposed to accomplish)
+		// delays like this just to avoid distributed (across multiple actors) logic bugs and memory leaks?
 		wait(delay(0, TaskPriority::ReadSocket));
 
 		if (peer->reliable.empty() && peer->unsent.empty() && peer->outstandingReplies == 0) {
@@ -697,12 +719,9 @@ ACTOR Future<Void> connectionMonitor(Reference<Peer> peer) {
 ACTOR Future<Void> connectionWriter(Reference<Peer> self, Reference<IConnection> conn) {
 	state double lastWriteTime = now();
 	loop {
-		// wait( delay(0, TaskPriority::WriteSocket) );
 		wait(delayJittered(
 		    std::max<double>(FLOW_KNOBS->MIN_COALESCE_DELAY, FLOW_KNOBS->MAX_COALESCE_DELAY - (now() - lastWriteTime)),
 		    TaskPriority::WriteSocket));
-		// wait( delay(500e-6, TaskPriority::WriteSocket) );
-		// wait( yield(TaskPriority::WriteSocket) );
 
 		// Send until there is nothing left to send
 		loop {
@@ -1111,19 +1130,15 @@ void Peer::onIncomingConnection(Reference<Peer> self, Reference<IConnection> con
 		prependConnectPacket();
 		connect = connectionKeeper(self, conn, reader);
 	} else {
+		// Keep our prior connection
 		TraceEvent("RedundantConnection", conn->getDebugID())
 		    .suppressFor(1.0)
 		    .detail("FromAddr", conn->getPeerAddress().toString())
 		    .detail("CanonicalAddr", destination)
 		    .detail("LocalAddr", compatibleAddr);
 
-		// Keep our prior connection
 		reader.cancel();
 		conn->close();
-
-		// Send an (ignored) packet to make sure that, if our outgoing connection died before the peer made this
-		// connection attempt, we eventually find out that our connection is dead, close it, and then respond to the
-		// next connection reattempt from peer.
 	}
 }
 
@@ -1233,8 +1248,8 @@ ACTOR static void deliver(TransportData* self,
 }
 
 static void scanPackets(TransportData* transport,
-                        uint8_t*& unprocessed_begin,
-                        const uint8_t* e,
+                        uint8_t*& unprocessed_begin, // FIXME: why isn't this called `start`?
+                        const uint8_t* e, // FIXME: why isn't this called `end`?
                         Arena& arena,
                         NetworkAddress const& peerAddress,
                         bool isTrustedPeer,
@@ -1244,12 +1259,17 @@ static void scanPackets(TransportData* transport,
 	// Find each complete packet in the given byte range and queue a ready task to deliver it.
 	// Remove the complete packets from the range by increasing unprocessed_begin.
 	// There won't be more than 64K of data plus one packet, so this shouldn't take a long time.
+	// FIXME: explain how we are sure that it's not more than 64K plus one packet
 	uint8_t* p = unprocessed_begin;
 
 	const bool checksumEnabled = !peerAddress.isTLS();
 	loop {
 		uint32_t packetLen;
 		XXH64_hash_t packetChecksum;
+
+		// Note that these potentially unaligned loads work on x86 and newer ARM but will blow up
+		// on many other architectures.  Whether this will be a problem in the future
+		// is hard to tell.
 
 		// Read packet length if size is sufficient or stop
 		if (e - p < PACKET_LEN_WIDTH)
@@ -1461,6 +1481,8 @@ ACTOR static Future<Void> connectionReader(TransportData* transport,
 				state bool readWillBlock = totalReadBytes != readAllBytes;
 
 				if (expectConnectPacket && unprocessed_end - unprocessed_begin >= CONNECT_PACKET_V0_SIZE) {
+					// FIXME: this block might go in a separate function whose purpose, obviously, would
+					// be to process a connect message.
 					// At the beginning of a connection, we expect to receive a packet containing the protocol version
 					// and the listening port of the remote process
 					int32_t connectPacketSize = ((ConnectPacket*)unprocessed_begin)->totalPacketSize();

--- a/fdbrpc/FlowTransport.actor.cpp
+++ b/fdbrpc/FlowTransport.actor.cpp
@@ -1808,12 +1808,6 @@ Standalone<StringRef> FlowTransport::getLocalAddressAsString() const {
 	return self->localAddresses.getLocalAddressAsString();
 }
 
-void FlowTransport::setLocalAddress(NetworkAddress const& address) {
-	auto newAddress = self->localAddresses.getAddressList();
-	newAddress.address = address;
-	self->localAddresses.setAddressList(newAddress);
-}
-
 const std::unordered_map<NetworkAddress, Reference<Peer>>& FlowTransport::getAllPeers() const {
 	return self->peers;
 }

--- a/fdbrpc/FlowTransport.actor.cpp
+++ b/fdbrpc/FlowTransport.actor.cpp
@@ -636,7 +636,24 @@ ACTOR Future<Void> connectionMonitor(Reference<Peer> peer) {
 			// Don't send ping messages to clients unless necessary. Instead monitor incoming client pings.
 			// We ignore this block for incompatible clients because pings from server would trigger the
 			// peer->resetPing and prevent 'connection_failed' due to ping timeout.
-			// FIXME: why don't we just close the connection if the peer is incompatible?
+			// FIXME: why don't we just close the connection if the peer is incompatible?  This isn't
+			// directly related to the code here but here is info from @vishesh suggesting it might be
+			// possible:
+			// This existed for two reasons (both in context of MultiVersionClient)
+			//  (1) While the peer is incompatible, don't try reconnecting to it.
+			//  (2) We can just mark it incompatible and never
+			//  reconnect however, this will create an issue during
+			//  upgrades when clients will not reconnect unless
+			//  restarted.
+			//
+			// However, since 7.1 or 7.2 I think, we only keep one
+			// version in MultiVersionClient active and dynamically
+			// switch to the compatible one, and if it becomes
+			// incompatible it can swtich over to correct one using
+			// the version reported in ConnectPacket.
+			//
+			// TLDR; We can probably close the connection now as we don't have any older clusters running either.
+			/
 			state double lastRefreshed = now();
 			state int64_t lastBytesReceived = peer->bytesReceived;
 			loop {

--- a/fdbrpc/include/fdbrpc/FlowTransport.h
+++ b/fdbrpc/include/fdbrpc/FlowTransport.h
@@ -37,6 +37,17 @@
 
 class IConnection;
 
+// FIXME: what does "WL" stand for?  Some ideas suggested by AI:
+//   Windows Live
+//   Whitelist
+//   Wallet Token
+//   Work List
+//
+// PRO TIP: Avoid annoying comments like this from future maintainers
+// by writing stuff down.
+//
+// Possible answer: an abbreviation for "well-known".
+//
 enum { WLTOKEN_ENDPOINT_NOT_FOUND = 0, WLTOKEN_PING_PACKET, WLTOKEN_UNAUTHORIZED_ENDPOINT, WLTOKEN_FIRST_AVAILABLE };
 
 #pragma pack(push, 4)
@@ -44,6 +55,8 @@ class Endpoint {
 public:
 	// Endpoint represents a particular service (e.g. a serialized Promise<T> or PromiseStream<T>)
 	// An endpoint is either "local" (used for receiving data) or "remote" (used for sending data)
+	// FIXME: assuming TCP is used, how many Endpoints are associated with a given TCP connection?
+	// Is it 4?  One each for reading/writing at both of two sides?  Is it something else?
 	constexpr static FileIdentifier file_identifier = 10618805;
 	using Token = UID;
 	NetworkAddressList addresses;
@@ -192,6 +205,11 @@ struct Peer : public ReferenceCounted<Peer> {
 
 class IPAllowList;
 
+// FIXME: define what FlowTransport represents.  Some possibilities:
+//   -- A scope of data transport defined over some domain?
+//   -- All data transport local to a process?
+//   -- Something else?
+//
 class FlowTransport : NonCopyable {
 public:
 	FlowTransport(uint64_t transportId, int maxWellKnownEndpoints, IPAllowList const* allowList);
@@ -220,16 +238,13 @@ public:
 	// to avoid unnecessary calls to toString() and fmt overhead.
 	Standalone<StringRef> getLocalAddressAsString() const;
 
-	// Returns first local NetworkAddress.
-	void setLocalAddress(NetworkAddress const&);
-
 	// Returns all local NetworkAddress.
 	NetworkAddressList getLocalAddresses() const;
 
 	// Returns all peers that the FlowTransport is monitoring.
 	const std::unordered_map<NetworkAddress, Reference<Peer>>& getAllPeers() const;
 
-	// Returns the same of all peers that have attempted to connect, but have incompatible protocol versions
+	// Returns the set of all peers that have attempted to connect, but have incompatible protocol versions
 	std::map<NetworkAddress, std::pair<uint64_t, double>>* getIncompatiblePeers();
 
 	// Returns when getIncompatiblePeers has at least one peer which is incompatible.

--- a/fdbrpc/include/fdbrpc/FlowTransport.h
+++ b/fdbrpc/include/fdbrpc/FlowTransport.h
@@ -37,17 +37,7 @@
 
 class IConnection;
 
-// FIXME: what does "WL" stand for?  Some ideas suggested by AI:
-//   Windows Live
-//   Whitelist
-//   Wallet Token
-//   Work List
-//
-// PRO TIP: Avoid annoying comments like this from future maintainers
-// by writing stuff down.
-//
-// Possible answer: an abbreviation for "well-known".
-//
+// FIXME: explain what the "WL" prefix means
 enum { WLTOKEN_ENDPOINT_NOT_FOUND = 0, WLTOKEN_PING_PACKET, WLTOKEN_UNAUTHORIZED_ENDPOINT, WLTOKEN_FIRST_AVAILABLE };
 
 #pragma pack(push, 4)
@@ -205,11 +195,8 @@ struct Peer : public ReferenceCounted<Peer> {
 
 class IPAllowList;
 
-// FIXME: define what FlowTransport represents.  Some possibilities:
-//   -- A scope of data transport defined over some domain?
-//   -- All data transport local to a process?
-//   -- Something else?
-//
+// FIXME: describe what FlowTransport represents.  Is it everything
+// for a given process?  Is it some subset of what a process uses?
 class FlowTransport : NonCopyable {
 public:
 	FlowTransport(uint64_t transportId, int maxWellKnownEndpoints, IPAllowList const* allowList);

--- a/fdbrpc/include/fdbrpc/FlowTransport.h
+++ b/fdbrpc/include/fdbrpc/FlowTransport.h
@@ -37,7 +37,7 @@
 
 class IConnection;
 
-// FIXME: explain what the "WL" prefix means
+// WL: Well-known
 enum { WLTOKEN_ENDPOINT_NOT_FOUND = 0, WLTOKEN_PING_PACKET, WLTOKEN_UNAUTHORIZED_ENDPOINT, WLTOKEN_FIRST_AVAILABLE };
 
 #pragma pack(push, 4)
@@ -45,8 +45,9 @@ class Endpoint {
 public:
 	// Endpoint represents a particular service (e.g. a serialized Promise<T> or PromiseStream<T>)
 	// An endpoint is either "local" (used for receiving data) or "remote" (used for sending data)
-	// FIXME: assuming TCP is used, how many Endpoints are associated with a given TCP connection?
-	// Is it 4?  One each for reading/writing at both of two sides?  Is it something else?
+	// FIXME: confirm if there is one endpoint per client and one per server.  Also,
+	// what if it's the same process talking to itself, does that change anything?
+	// Consider linking to a diagram on a web site.
 	constexpr static FileIdentifier file_identifier = 10618805;
 	using Token = UID;
 	NetworkAddressList addresses;

--- a/fdbrpc/include/fdbrpc/LoadBalance.actor.h
+++ b/fdbrpc/include/fdbrpc/LoadBalance.actor.h
@@ -83,6 +83,7 @@ struct LoadBalancedReply {
 Optional<LoadBalancedReply> getLoadBalancedReply(const LoadBalancedReply* reply);
 Optional<LoadBalancedReply> getLoadBalancedReply(const void*);
 
+// FIXME: use a less obscure name than `P` here
 ACTOR template <class Req, class Resp, class Interface, class Multi, bool P>
 Future<Void> tssComparison(Req req,
                            Future<ErrorOr<Resp>> fSource,
@@ -687,6 +688,8 @@ struct RequestData : NonCopyable {
 // interfaces. If too many interfaces in the same DC are bad, try remote interfaces.
 // If compareReplicas is set, does a consistency check by fetching and comparing results from storage
 // replicas (as many as specified by "requiredReplicas") and throws an exception if an inconsistency is found.
+// FIXME: reformat this minus the long inline comment about one parameter, so that the indentation of
+// the parameters is more to the right and not confusingly lined up with the code of this function.
 ACTOR template <class Interface, class Request, class Multi, bool P>
 Future<REPLY_TYPE(Request)> loadBalance(
     Reference<MultiInterface<Multi>> alternatives,

--- a/fdbrpc/include/fdbrpc/QueueModel.h
+++ b/fdbrpc/include/fdbrpc/QueueModel.h
@@ -83,23 +83,25 @@ typedef double TimeEstimate;
 
 class QueueModel {
 public:
-	// Finishes the request sent to storage server with `id`.
-	//   - latency: the measured client-side latency of the request.
-	//   - penalty: the server side penalty sent along with the response from
-	//              the storage server. Requires >= 1.
-	//   - delta: Update server `id`'s queue model by subtracting this amount.
-	//            This value should be the value returned by `addRequest` below.
-	//   - clean: indicates whether the there was an error or not.
-	// 	 - futureVersion: indicates whether there was "future version" error or
-	//					  not.
-	void endRequest(uint64_t id, double latency, double penalty, double delta, bool clean, bool futureVersion);
-	QueueData const& getMeasurement(uint64_t id);
-
 	// Starts a new request to storage server with `id`. If the storage
 	// server contains a penalty, add it to the queue size, and return the
 	// penalty. The returned penalty should be passed as `delta` to `endRequest`
 	// to make `smoothOutstanding` to reflect the real storage queue size.
 	double addRequest(uint64_t id);
+
+	// Finishes the request sent to storage server with `id`.
+	//   - latency: the measured client-side latency of the request.
+	//   - penalty: the server side penalty sent along with the response from
+	//              the storage server. Requires >= 1.
+	//   - delta: Update server `id`'s queue model by subtracting this amount.
+	//            This value should be the value returned by `addRequest`.
+	//   - clean: indicates whether the there was an error or not.
+	// 	 - futureVersion: indicates whether there was "future version" error or
+	//					  not.
+	void endRequest(uint64_t id, double latency, double penalty, double delta, bool clean, bool futureVersion);
+
+	QueueData const& getMeasurement(uint64_t id);
+
 	double secondMultiplier;
 	double secondBudget;
 	PromiseStream<Future<Void>> addActor;
@@ -131,25 +133,5 @@ public:
 private:
 	std::unordered_map<uint64_t, QueueData> data;
 };
-
-/* old queue model
-class QueueModel {
-public:
-    QueueModel() : new_index(0) {
-        total_time[0] = 0;
-        total_time[1] = 0;
-    }
-    void addMeasurement( uint64_t id, QueueDetails qd );
-    TimeEstimate getTimeEstimate( uint64_t id );
-    TimeEstimate getAverageTimeEstimate();
-    QueueDetails getMeasurement( uint64_t id );
-    void expire();
-
-private:
-    std::map<uint64_t, QueueDetails> data[2];
-    double total_time[2];
-    int new_index; // data[new_index] is the new data
-};
-*/
 
 #endif

--- a/fdbrpc/include/fdbrpc/SimulatorKillType.h
+++ b/fdbrpc/include/fdbrpc/SimulatorKillType.h
@@ -24,6 +24,7 @@
 namespace simulator {
 
 // Order matters!
+// FIXME: explain why it matters.
 enum KillType {
 	KillInstantly,
 	InjectFaults,

--- a/fdbrpc/include/fdbrpc/fdbrpc.h
+++ b/fdbrpc/include/fdbrpc/fdbrpc.h
@@ -687,6 +687,7 @@ struct HasVerify_t<T, decltype(void(std::declval<T>().verify()), 0)> : std::true
 template <class T>
 constexpr bool HasVerify = HasVerify_t<T>::value;
 
+// FIXME: explain what IsPublic means here
 template <class T, bool IsPublic>
 struct NetNotifiedQueue final : NotifiedQueue<T>, FlowReceiver, FastAllocated<NetNotifiedQueue<T, IsPublic>> {
 	using FastAllocated<NetNotifiedQueue<T, IsPublic>>::operator new;
@@ -947,6 +948,7 @@ private:
 	NetNotifiedQueue<T, IsPublic>* queue;
 };
 
+// FIXME: explain what Public and Private mean here
 template <class T>
 using PrivateRequestStream = RequestStream<T, false>;
 template <class T>

--- a/fdbrpc/include/fdbrpc/simulator.h
+++ b/fdbrpc/include/fdbrpc/simulator.h
@@ -72,7 +72,7 @@ public:
 	enum class BackupAgentType { NoBackupAgents, WaitForType, BackupToFile, BackupToDB };
 	enum class ExtraDatabaseMode { Disabled, LocalOrSingle, Single, Local, Multiple };
 
-	static ExtraDatabaseMode stringToExtraDatabaseMode(std::string databaseMode) {
+	static ExtraDatabaseMode stringToExtraDatabaseMode(const std::string& databaseMode) {
 		if (databaseMode == "Disabled") {
 			return ExtraDatabaseMode::Disabled;
 		} else if (databaseMode == "LocalOrSingle") {
@@ -130,7 +130,6 @@ public:
 	                          bool forceKill = false,
 	                          KillType* ktFinal = nullptr) = 0;
 	virtual bool killAll(KillType kt, bool forceKill = false, KillType* ktFinal = nullptr) = 0;
-	// virtual KillType getMachineKillState( UID zoneID ) = 0;
 	virtual void processInjectBlobFault(ProcessInfo* machine, double failureRate) = 0;
 	virtual void processStopInjectBlobFault(ProcessInfo* machine) = 0;
 	virtual bool canKillProcesses(std::vector<ProcessInfo*> const& availableProcesses,
@@ -408,7 +407,7 @@ public:
 
 	std::set<std::pair<std::string, unsigned>> corruptedBlocks;
 
-	// Valdiate at-rest encryption guarantees. If enabled, tests should inject a known 'marker' in Key and/or Values
+	// Validate at-rest encryption guarantees. If enabled, tests should inject a known 'marker' in Key and/or Values
 	// inserted into FDB by the workload. On shutdown, all test generated files (under simfdb/) are scanned to find if
 	// 'plaintext marker' is present.
 	Optional<std::string> dataAtRestPlaintextMarker;
@@ -429,6 +428,8 @@ public:
 	// generate authz token for use in simulation environment
 	WipedString makeToken(int64_t tenantId, uint64_t ttlSecondsFromNow);
 
+	// FIXME: simulation is generally discussed as being deterministic and single-threaded. So
+	// explain why we need thread_local variables here and a mutex just below.
 	static thread_local ProcessInfo* currentProcess;
 	static thread_local bool isMainThread;
 

--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -745,7 +745,7 @@ public:
 	}
 
 private:
-	int h;  // normally this would be called `fd`
+	int h; // normally this would be called `fd`
 
 	// Performance parameters of simulated disk
 	Reference<DiskParameters> diskParameters;

--- a/flow/include/flow/ChaosMetrics.h
+++ b/flow/include/flow/ChaosMetrics.h
@@ -23,10 +23,10 @@
 
 struct TraceEvent;
 
-// FIXME: define the exact nature and scope of what is meant by "ChaosMetrics"
-// and how ChaosMetrics relates to and/or differs from similar techniques, e.g. as described
-// here: https://apple.github.io/foundationdb/testing.html, since this doesn't seem
-// related to that stuff, but that stuff seems related to injecting chaos.
+// FIXME: simulation testing involves injection of a lot of chaos
+// (e.g. from the description here: https://apple.github.io/foundationdb/testing.html).
+// Explain how the specifics in this file differ from normal, background chaos
+// that simulation already puts into the simulated environment.
 
 // Chaos Metrics - We periodically log chaosMetrics to make sure that chaos events are happening
 // Only includes DiskDelays which encapsulates all type delays and BitFlips for now

--- a/flow/include/flow/ChaosMetrics.h
+++ b/flow/include/flow/ChaosMetrics.h
@@ -23,6 +23,11 @@
 
 struct TraceEvent;
 
+// FIXME: define the exact nature and scope of what is meant by "ChaosMetrics"
+// and how ChaosMetrics relates to and/or differs from similar techniques, e.g. as described
+// here: https://apple.github.io/foundationdb/testing.html, since this doesn't seem
+// related to that stuff, but that stuff seems related to injecting chaos.
+
 // Chaos Metrics - We periodically log chaosMetrics to make sure that chaos events are happening
 // Only includes DiskDelays which encapsulates all type delays and BitFlips for now
 // Expand as per need

--- a/flow/include/flow/network.h
+++ b/flow/include/flow/network.h
@@ -177,86 +177,86 @@ public:
 
 	virtual void longTaskCheck(const char* name) {}
 
-	virtual double now() const = 0;
 	// Provides a clock that advances at a similar rate on all connected endpoints
-	// FIXME: Return a fixed point Time class
+	virtual double now() const = 0;
 
-	virtual double timer() = 0;
 	// A wrapper for directly getting the system time. The time returned by now() only updates in the run loop,
 	// so it cannot be used to measure times of functions that do not have wait statements.
+	virtual double timer() = 0;
 
 	// Simulation version of timer_int for convenience, based on timer()
 	// Returns epoch nanoseconds
 	uint64_t timer_int() { return (uint64_t)(g_network->timer() * 1e9); }
 
-	virtual double timer_monotonic() = 0;
 	// Similar to timer, but monotonic
+	virtual double timer_monotonic() = 0;
 
 	virtual void _swiftEnqueue(void* task) = 0;
 
+	// Returns a future that will be set after seconds have elapsed
 	virtual Future<class Void> delay(double seconds, TaskPriority taskID) = 0;
-	// The given future will be set after seconds have elapsed
 
+	// Returns a future that will be set after seconds have
+	// elapsed. Delays with the same time and TaskPriority will be
+	// executed in the order they were issue.
 	virtual Future<class Void> orderedDelay(double seconds, TaskPriority taskID) = 0;
-	// The given future will be set after seconds have elapsed, delays with the same time and TaskPriority will be
-	// executed in the order they were issues
 
+	// Returns a future that will be set immediately or after higher-priority tasks have executed.
 	virtual Future<class Void> yield(TaskPriority taskID) = 0;
-	// The given future will be set immediately or after higher-priority tasks have executed
 
+	// Returns true if a call to yield would result in a delay.
 	virtual bool check_yield(TaskPriority taskID) = 0;
-	// Returns true if a call to yield would result in a delay
 
+	// Returns the taskID/priority of the current task.
 	virtual TaskPriority getCurrentTask() const = 0;
-	// Gets the taskID/priority of the current task
 
+	// Sets the taskID/priority of the current task, without yielding.
 	virtual void setCurrentTask(TaskPriority taskID) = 0;
-	// Sets the taskID/priority of the current task, without yielding
 
 	virtual flowGlobalType global(int id) const = 0;
 	virtual void setGlobal(size_t id, flowGlobalType v) = 0;
 
+	// Terminate the program.
 	virtual void stop() = 0;
-	// Terminate the program
 
-	virtual void addStopCallback(std::function<void()> fn) = 0;
-	// Calls `fn` when stop() is called.
+	// Arranges to call `fn` when stop() is called.
 	// addStopCallback can be called more than once, and each added `fn` will be run once.
+	virtual void addStopCallback(std::function<void()> fn) = 0;
 
+	// Returns true if this network is a local simulation.
 	virtual bool isSimulated() const = 0;
-	// Returns true if this network is a local simulation
 
+	// Returns true if the current thread is the main thread.
 	virtual bool isOnMainThread() const = 0;
-	// Returns true if the current thread is the main thread
 
-	virtual void onMainThread(Promise<Void>&& signal, TaskPriority taskID) = 0;
 	// Executes signal.send(Void()) on a/the thread belonging to this network in FIFO order
+	virtual void onMainThread(Promise<Void>&& signal, TaskPriority taskID) = 0;
 
+	// Starts a thread and returns a handle to it
 	virtual THREAD_HANDLE startThread(THREAD_FUNC_RETURN (*func)(void*),
 	                                  void* arg,
 	                                  int stackSize = 0,
 	                                  const char* name = nullptr) = 0;
-	// Starts a thread and returns a handle to it
 
-	virtual void run() = 0;
 	// Devotes this thread to running the network (generally until stop())
+	virtual void run() = 0;
 
-	virtual void initMetrics() {}
 	// Metrics must be initialized after FlowTransport::createInstance has been called
+	virtual void initMetrics() {}
 
 	// TLS must be initialized before using the network
 	enum ETLSInitState { NONE = 0, CONFIG = 1, CONNECT = 2, LISTEN = 3 };
 	virtual void initTLS(ETLSInitState targetState = CONFIG) {}
 
-	virtual const TLSConfig& getTLSConfig() const = 0;
 	// Return the TLS Configuration
+	virtual const TLSConfig& getTLSConfig() const = 0;
 
-	virtual void getDiskBytes(std::string const& directory, int64_t& free, int64_t& total) = 0;
 	// Gets the number of free and total bytes available on the disk which contains directory
+	virtual void getDiskBytes(std::string const& directory, int64_t& free, int64_t& total) = 0;
 
-	virtual bool isAddressOnThisHost(NetworkAddress const& addr) const = 0;
 	// Returns true if it is reasonably certain that a connection to the given address would be a fast loopback
 	// connection
+	virtual bool isAddressOnThisHost(NetworkAddress const& addr) const = 0;
 
 	// If the network has not been run and this function has not been previously called, returns true. Otherwise,
 	// returns false.


### PR DESCRIPTION
Small changes accumulated while reading through a bunch of files in fdbrpc (mostly).

Throughout: add FIXME comments where it would be useful to have a comment explaining something or suggesting a change of some kind.

Several places: rename a variable to get a better name

A few places: delete code that has been commented out for > 5 years

A few places: delete useless or apparently out of date, incorrect comments

One place: delete a function that has no callers

One place: reorder methods, listing them in the order which users are to call them (i.e. the natural order for explanation)

One or more places: delete unneeded FIXME comments

network.h: put the function comments *before* the functions they describe
