### PR TITLE
Optimize peekVersionCounts to use single map op instead of three lookups.

### DIFF
--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -1705,15 +1705,12 @@ void peekMessagesFromMemory(Reference<LogData> self,
 		++self->emptyPeeks;
 	} else {
 		++self->nonEmptyPeeks;
-
-		// TODO (version vector) check if this should be included in "status details" json
-		if (self->peekVersionCounts.find(tag) == self->peekVersionCounts.end()) {
-			UID ssID = deterministicRandom()->randomUniqueID();
-			std::string s = "PeekVersionCounts " + tag.toString();
-			self->peekVersionCounts.try_emplace(
-			    tag, s, ssID, SERVER_KNOBS->LATENCY_METRICS_LOGGING_INTERVAL, SERVER_KNOBS->LATENCY_SKETCH_ACCURACY);
-		}
-		LatencySample& sample = self->peekVersionCounts.at(tag);
+		auto [it, inserted] = self->peekVersionCounts.try_emplace(tag,
+		                                                          "PeekVersionCounts " + tag.toString(),
+		                                                          deterministicRandom()->randomUniqueID(),
+		                                                          SERVER_KNOBS->LATENCY_METRICS_LOGGING_INTERVAL,
+		                                                          SERVER_KNOBS->LATENCY_SKETCH_ACCURACY);
+		LatencySample& sample = it->second;
 		sample.addMeasurement(versionCount);
 	}
 }
@@ -1910,16 +1907,13 @@ Future<Void> tLogPeekMessages(PromiseType replyPromise,
 			// TODO (version vector) all tags may be too many, instead,  standard deviation?
 			wait(waitForMessagesForTag(logData, reqTag, reqBegin, SERVER_KNOBS->BLOCKING_PEEK_TIMEOUT));
 			double latency = now() - startTime;
-			if (logData->blockingPeekLatencies.find(reqTag) == logData->blockingPeekLatencies.end()) {
-				UID ssID = nondeterministicRandom()->randomUniqueID();
-				std::string s = "BlockingPeekLatencies-" + reqTag.toString();
-				logData->blockingPeekLatencies.try_emplace(reqTag,
-				                                           s,
-				                                           ssID,
-				                                           SERVER_KNOBS->LATENCY_METRICS_LOGGING_INTERVAL,
-				                                           SERVER_KNOBS->LATENCY_SKETCH_ACCURACY);
-			}
-			LatencySample& sample = logData->blockingPeekLatencies.at(reqTag);
+			auto [it, inserted] =
+			    logData->blockingPeekLatencies.try_emplace(reqTag,
+			                                               "BlockingPeekLatencies-" + reqTag.toString(),
+			                                               nondeterministicRandom()->randomUniqueID(),
+			                                               SERVER_KNOBS->LATENCY_METRICS_LOGGING_INTERVAL,
+			                                               SERVER_KNOBS->LATENCY_SKETCH_ACCURACY);
+			LatencySample& sample = it->second;
 			sample.addMeasurement(latency);
 			poppedVer = poppedVersion(logData, reqTag);
 		}

--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -1705,11 +1705,11 @@ void peekMessagesFromMemory(Reference<LogData> self,
 		++self->emptyPeeks;
 	} else {
 		++self->nonEmptyPeeks;
-		auto [it, inserted] = self->peekVersionCounts.try_emplace(tag,
-		                                                          "PeekVersionCounts " + tag.toString(),
-		                                                          deterministicRandom()->randomUniqueID(),
-		                                                          SERVER_KNOBS->LATENCY_METRICS_LOGGING_INTERVAL,
-		                                                          SERVER_KNOBS->LATENCY_SKETCH_ACCURACY);
+		auto [it, _] = self->peekVersionCounts.try_emplace(tag,
+		                                                   "PeekVersionCounts " + tag.toString(),
+		                                                   deterministicRandom()->randomUniqueID(),
+		                                                   SERVER_KNOBS->LATENCY_METRICS_LOGGING_INTERVAL,
+		                                                   SERVER_KNOBS->LATENCY_SKETCH_ACCURACY);
 		LatencySample& sample = it->second;
 		sample.addMeasurement(versionCount);
 	}
@@ -1903,8 +1903,6 @@ Future<Void> tLogPeekMessages(PromiseType replyPromise,
 		    reqBegin > logData->persistentDataDurableVersion && !reqOnlySpilled && reqTag.locality >= 0 &&
 		    !reqReturnIfBlocked && tagRecovered) {
 			state double startTime = now();
-			// TODO (version vector) check if this should be included in "status details" json
-			// TODO (version vector) all tags may be too many, instead,  standard deviation?
 			wait(waitForMessagesForTag(logData, reqTag, reqBegin, SERVER_KNOBS->BLOCKING_PEEK_TIMEOUT));
 			double latency = now() - startTime;
 			auto [it, inserted] =


### PR DESCRIPTION
When clients peek data for a specific tag, the log server:

  1. Counts how many versions contain data for that tag (versionCount)
  2. Records this count as a latency/performance measurement in the LatencySample associated with that tag
  3. Uses this data for monitoring and performance analysis

Instead of doing separate map operations to check if a tag exists, insert if needed, and then retrieve the LatencySample, we do all that in one try_emplace() call to create a new LatencySample for a new tag, or return the existing LatencySample for an existing tag. This reduces the number of tree traversals in std::map from 3 to 1.

100K pass `20250930-135027-dlambrig-a039c1865693d9af `

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
