### PR TITLE
Extend consistency checkers to be compatible with version vector

### DIFF
--- a/fdbserver/ConsistencyScan.actor.cpp
+++ b/fdbserver/ConsistencyScan.actor.cpp
@@ -156,8 +156,9 @@ ACTOR Future<std::vector<StorageServerInterface>> loadShardInterfaces(Reference<
 	// though
 	decodeKeyServersValue(UIDtoTagMap, shardBoundaries[0].value, sourceStorageServers, destStorageServers, true);
 
-	state std::map<UID, Tag> storageServerToTagMap;
+	state std::unordered_map<UID, Tag> storageServerToTagMap;
 	if (SERVER_KNOBS->ENABLE_VERSION_VECTOR) {
+		storageServerToTagMap.reserve(UIDtoTagMap.size());
 		for (auto& it : UIDtoTagMap) {
 			storageServerToTagMap[decodeServerTagKey(it.key)] = decodeServerTagValue(it.value);
 		}
@@ -184,7 +185,7 @@ ACTOR Future<std::vector<StorageServerInterface>> loadShardInterfaces(Reference<
 	if (SERVER_KNOBS->ENABLE_VERSION_VECTOR) {
 		for (int j = 0; j < storageServers.size(); j++) {
 			auto iter = storageServerToTagMap.find(storageServers[j]);
-			ASSERT(iter != storageServerToTagMap.end());
+			ASSERT_WE_THINK(iter != storageServerToTagMap.end());
 			// Note: This workload doesn't use the NativeAPI getRange() API for reading
 			// data, so we will need to explicitly populate the (ssid, tag) mapping in
 			// "db" - this is so version vector APIs can correctly fetch the latest commit

--- a/fdbserver/ConsistencyScan.actor.cpp
+++ b/fdbserver/ConsistencyScan.actor.cpp
@@ -142,7 +142,8 @@ ACTOR Future<Void> pollDatabaseSize(Reference<ConsistencyScanMemoryState> memSta
 
 ACTOR Future<std::vector<StorageServerInterface>> loadShardInterfaces(Reference<ConsistencyScanMemoryState> memState,
                                                                       Reference<ReadYourWritesTransaction> tr,
-                                                                      Future<RangeResult> readShardBoundaries) {
+                                                                      Future<RangeResult> readShardBoundaries,
+                                                                      Database db) {
 	state RangeResult UIDtoTagMap = wait(tr->getRange(serverTagKeys, CLIENT_KNOBS->TOO_MANY));
 	ASSERT(!UIDtoTagMap.more && UIDtoTagMap.size() < CLIENT_KNOBS->TOO_MANY);
 	state RangeResult shardBoundaries = wait(readShardBoundaries);
@@ -155,8 +156,15 @@ ACTOR Future<std::vector<StorageServerInterface>> loadShardInterfaces(Reference<
 	// though
 	decodeKeyServersValue(UIDtoTagMap, shardBoundaries[0].value, sourceStorageServers, destStorageServers, true);
 
+	state std::map<UID, Tag> storageServerToTagMap;
+	if (SERVER_KNOBS->ENABLE_VERSION_VECTOR) {
+		for (auto& it : UIDtoTagMap) {
+			storageServerToTagMap[decodeServerTagKey(it.key)] = decodeServerTagValue(it.value);
+		}
+	}
+
 	// if shard move in progress, use destination
-	std::vector<UID> storageServers = (!destStorageServers.empty()) ? destStorageServers : sourceStorageServers;
+	state std::vector<UID> storageServers = (!destStorageServers.empty()) ? destStorageServers : sourceStorageServers;
 
 	state std::vector<Future<Optional<Value>>> serverListEntries;
 	serverListEntries.reserve(storageServers.size());
@@ -171,6 +179,18 @@ ACTOR Future<std::vector<StorageServerInterface>> loadShardInterfaces(Reference<
 	for (auto& it : serverListValues) {
 		ASSERT(it.present());
 		storageServerInterfaces.push_back(decodeServerListValue(it.get()));
+	}
+
+	if (SERVER_KNOBS->ENABLE_VERSION_VECTOR) {
+		for (int j = 0; j < storageServers.size(); j++) {
+			auto iter = storageServerToTagMap.find(storageServers[j]);
+			ASSERT(iter != storageServerToTagMap.end());
+			// Note: This workload doesn't use the NativeAPI getRange() API for reading
+			// data, so we will need to explicitly populate the (ssid, tag) mapping in
+			// "db" - this is so version vector APIs can correctly fetch the latest commit
+			// versions of storage servers.
+			db->addSSIdTagMapping(storageServerInterfaces[j].id(), iter->second);
+		}
 	}
 
 	return storageServerInterfaces;
@@ -712,7 +732,7 @@ ACTOR Future<Void> consistencyScanCore(Database db,
 					                 limits,
 					                 Snapshot::True);
 					wait(store(shardBoundaries, readShardBoundaries) &&
-					     store(storageServerInterfaces, loadShardInterfaces(memState, tr, readShardBoundaries)) &&
+					     store(storageServerInterfaces, loadShardInterfaces(memState, tr, readShardBoundaries, db)) &&
 					     store(csVersion, cs.trigger.get(tr)) &&
 					     store(configRange, cs.rangeConfig().getRangeForKey(tr, statsCurrentRound.lastEndKey)));
 

--- a/fdbserver/workloads/ConsistencyCheckUrgent.actor.cpp
+++ b/fdbserver/workloads/ConsistencyCheckUrgent.actor.cpp
@@ -189,7 +189,7 @@ struct ConsistencyCheckUrgentWorkload : TestWorkload {
 			// Step 1: Get source server id of the shard
 			state std::vector<UID> sourceStorageServers;
 			state std::vector<UID> destStorageServers;
-			state std::map<UID, Tag> storageServerToTagMap;
+			state std::map<UID, Tag> storageServerToTagMap; // populated only when version vector is enabled
 			retryCount = 0;
 			loop {
 				try {
@@ -283,7 +283,7 @@ struct ConsistencyCheckUrgentWorkload : TestWorkload {
 						storageServerInterfaces.push_back(decodeServerListValue(serverListValues[s].get()));
 					}
 					if (SERVER_KNOBS->ENABLE_VERSION_VECTOR) {
-						for (j = 0; j < storageServers.size(); j++) {
+						for (int j = 0; j < storageServers.size(); j++) {
 							auto iter = storageServerToTagMap.find(storageServers[j]);
 							ASSERT(iter != storageServerToTagMap.end());
 							// Note: This workload doesn't use the NativeAPI getRange() API for reading

--- a/fdbserver/workloads/ConsistencyCheckUrgent.actor.cpp
+++ b/fdbserver/workloads/ConsistencyCheckUrgent.actor.cpp
@@ -189,7 +189,7 @@ struct ConsistencyCheckUrgentWorkload : TestWorkload {
 			// Step 1: Get source server id of the shard
 			state std::vector<UID> sourceStorageServers;
 			state std::vector<UID> destStorageServers;
-			state std::map<UID, Tag> storageServerToTagMap; // populated only when version vector is enabled
+			state std::unordered_map<UID, Tag> storageServerToTagMap; // populated only when version vector is enabled
 			retryCount = 0;
 			loop {
 				try {
@@ -205,6 +205,7 @@ struct ConsistencyCheckUrgentWorkload : TestWorkload {
 					                      destStorageServers,
 					                      false);
 					if (SERVER_KNOBS->ENABLE_VERSION_VECTOR) {
+						storageServerToTagMap.reserve(UIDtoTagMap.size());
 						for (auto& it : UIDtoTagMap) {
 							storageServerToTagMap[decodeServerTagKey(it.key)] = decodeServerTagValue(it.value);
 						}
@@ -285,7 +286,7 @@ struct ConsistencyCheckUrgentWorkload : TestWorkload {
 					if (SERVER_KNOBS->ENABLE_VERSION_VECTOR) {
 						for (int j = 0; j < storageServers.size(); j++) {
 							auto iter = storageServerToTagMap.find(storageServers[j]);
-							ASSERT(iter != storageServerToTagMap.end());
+							ASSERT_WE_THINK(iter != storageServerToTagMap.end());
 							// Note: This workload doesn't use the NativeAPI getRange() API for reading
 							// data, so we will need to explicitly populate the (ssid, tag) mapping in
 							// "cx" - this is so version vector APIs can correctly fetch the latest commit

--- a/fdbserver/workloads/ConsistencyCheckUrgent.actor.cpp
+++ b/fdbserver/workloads/ConsistencyCheckUrgent.actor.cpp
@@ -189,6 +189,7 @@ struct ConsistencyCheckUrgentWorkload : TestWorkload {
 			// Step 1: Get source server id of the shard
 			state std::vector<UID> sourceStorageServers;
 			state std::vector<UID> destStorageServers;
+			state std::map<UID, Tag> storageServerToTagMap;
 			retryCount = 0;
 			loop {
 				try {
@@ -203,6 +204,11 @@ struct ConsistencyCheckUrgentWorkload : TestWorkload {
 					                      sourceStorageServers,
 					                      destStorageServers,
 					                      false);
+					if (SERVER_KNOBS->ENABLE_VERSION_VECTOR) {
+						for (auto& it : UIDtoTagMap) {
+							storageServerToTagMap[decodeServerTagKey(it.key)] = decodeServerTagValue(it.value);
+						}
+					}
 					break;
 				} catch (Error& e) {
 					if (e.code() == error_code_actor_cancelled) {
@@ -276,6 +282,17 @@ struct ConsistencyCheckUrgentWorkload : TestWorkload {
 						}
 						storageServerInterfaces.push_back(decodeServerListValue(serverListValues[s].get()));
 					}
+					if (SERVER_KNOBS->ENABLE_VERSION_VECTOR) {
+						for (j = 0; j < storageServers.size(); j++) {
+							auto iter = storageServerToTagMap.find(storageServers[j]);
+							ASSERT(iter != storageServerToTagMap.end());
+							// Note: This workload doesn't use the NativeAPI getRange() API for reading
+							// data, so we will need to explicitly populate the (ssid, tag) mapping in
+							// "cx" - this is so version vector APIs can correctly fetch the latest commit
+							// versions of storage servers.
+							cx->addSSIdTagMapping(storageServerInterfaces[j].id(), iter->second);
+						}
+					}
 					break;
 				} catch (Error& e) {
 					if (e.code() == error_code_actor_cancelled) {
@@ -317,6 +334,10 @@ struct ConsistencyCheckUrgentWorkload : TestWorkload {
 					state int j = 0;
 					for (j = 0; j < storageServerInterfaces.size(); j++) {
 						resetReply(req);
+						if (SERVER_KNOBS->ENABLE_VERSION_VECTOR) {
+							cx->getLatestCommitVersion(
+							    storageServerInterfaces[j], req.version, req.ssLatestCommitVersions);
+						}
 						keyValueFutures.push_back(
 						    storageServerInterfaces[j].getKeyValues.getReplyUnlessFailedFor(req, 2, 0));
 					}


### PR DESCRIPTION
DatabaseContext maintains a mapping of storage server interface UIDs to the corresponding storage server tags. NativeAPI APIs populate this (UID -> tag) map in DatabaseContext and also make use of it while reading data from storage servers (note that version vector maintains a mapping of storage server tags to their latest commit versions, and storage server read APIs take storage server interface UIDs as input). 

Consistency checker code doesn't use NativeAPI APIs, and uses direct storage server RPCs to read data from storage servers. This PR extends the consistency checker code to provide the (UID -> tag) mapping in DatabaseContext so the code can use the version vector APIs to fetch the latest commit versions of storage servers while they make read calls to storage servers.

Joshua id (with version vector disabled): 20251002-204204-sre-12ca6e776f192e62 (no failures).

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
