### PR TITLE
Add HTTP range header support to mocks3

### DIFF
--- a/fdbrpc/HTTP.actor.cpp
+++ b/fdbrpc/HTTP.actor.cpp
@@ -28,6 +28,7 @@
 #include "libb64/encode.h"
 #include "flow/Knobs.h"
 #include <cctype>
+#include <sstream>
 #include "flow/IConnection.h"
 #include <unordered_map>
 
@@ -67,6 +68,28 @@ std::string urlEncode(const std::string& s) {
 	return o;
 }
 
+std::string urlDecode(const std::string& encoded) {
+	std::string decoded;
+	decoded.reserve(encoded.size());
+	for (size_t i = 0; i < encoded.length(); ++i) {
+		if (encoded[i] == '%' && i + 2 < encoded.length()) {
+			int value;
+			std::istringstream is(encoded.substr(i + 1, 2));
+			if (is >> std::hex >> value) {
+				decoded += static_cast<char>(value);
+				i += 2;
+			} else {
+				decoded += encoded[i];
+			}
+		} else if (encoded[i] == '+') {
+			decoded += ' ';
+		} else {
+			decoded += encoded[i];
+		}
+	}
+	return decoded;
+}
+
 template <typename T>
 std::string ResponseBase<T>::getCodeDescription() {
 	if (code == HTTP_STATUS_CODE_OK) {
@@ -77,6 +100,8 @@ std::string ResponseBase<T>::getCodeDescription() {
 		return "Accepted";
 	} else if (code == HTTP_STATUS_CODE_NO_CONTENT) {
 		return "No Content";
+	} else if (code == HTTP_STATUS_CODE_PARTIAL_CONTENT) {
+		return "Partial Content";
 	} else if (code == HTTP_STATUS_CODE_BAD_REQUEST) {
 		return "Bad Request";
 	} else if (code == HTTP_STATUS_CODE_UNAUTHORIZED) {

--- a/fdbrpc/include/fdbrpc/HTTP.h
+++ b/fdbrpc/include/fdbrpc/HTTP.h
@@ -39,6 +39,7 @@ constexpr int HTTP_STATUS_CODE_OK = 200;
 constexpr int HTTP_STATUS_CODE_CREATED = 201;
 constexpr int HTTP_STATUS_CODE_ACCEPTED = 202;
 constexpr int HTTP_STATUS_CODE_NO_CONTENT = 204;
+constexpr int HTTP_STATUS_CODE_PARTIAL_CONTENT = 206;
 constexpr int HTTP_STATUS_CODE_BAD_REQUEST = 400;
 constexpr int HTTP_STATUS_CODE_UNAUTHORIZED = 401;
 constexpr int HTTP_STATUS_CODE_NOT_FOUND = 404;
@@ -63,6 +64,9 @@ const std::string HTTP_VERB_CONNECT = "CONNECT";
 typedef std::map<std::string, std::string, is_iless> Headers;
 
 std::string urlEncode(const std::string& s);
+// URL decode a percent-encoded string, converting %XX hex sequences to characters
+// and + characters to spaces. Used for parsing query parameters and form data.
+std::string urlDecode(const std::string& s);
 std::string awsV4URIEncode(const std::string& s, bool encodeSlash);
 
 template <class T>

--- a/fdbserver/MockS3Server.actor.cpp
+++ b/fdbserver/MockS3Server.actor.cpp
@@ -1012,7 +1012,7 @@ void clearMockS3Storage() {
 }
 
 // Unit Tests for MockS3Server
-TEST_CASE("/fdbserver/MockS3Server/parseS3Request/ValidBucketParameter") {
+TEST_CASE("/MockS3Server/parseS3Request/ValidBucketParameter") {
 
 	MockS3ServerImpl server;
 	std::string resource = "/testbucket?region=us-east-1";
@@ -1028,7 +1028,7 @@ TEST_CASE("/fdbserver/MockS3Server/parseS3Request/ValidBucketParameter") {
 	return Void();
 }
 
-TEST_CASE("/fdbserver/MockS3Server/parseS3Request/MissingBucketParameter") {
+TEST_CASE("/MockS3Server/parseS3Request/MissingBucketParameter") {
 
 	MockS3ServerImpl server;
 	std::string resource = "/?region=us-east-1"; // Empty path - no bucket
@@ -1045,7 +1045,7 @@ TEST_CASE("/fdbserver/MockS3Server/parseS3Request/MissingBucketParameter") {
 	return Void();
 }
 
-TEST_CASE("/fdbserver/MockS3Server/parseS3Request/EmptyQueryString") {
+TEST_CASE("/MockS3Server/parseS3Request/EmptyQueryString") {
 
 	MockS3ServerImpl server;
 	std::string resource = "/"; // Empty path - no bucket
@@ -1062,7 +1062,7 @@ TEST_CASE("/fdbserver/MockS3Server/parseS3Request/EmptyQueryString") {
 	return Void();
 }
 
-TEST_CASE("/fdbserver/MockS3Server/parseS3Request/BucketParameterOverride") {
+TEST_CASE("/MockS3Server/parseS3Request/BucketParameterOverride") {
 
 	MockS3ServerImpl server;
 	std::string resource = "/testbucket/testobject?region=us-east-1";
@@ -1078,7 +1078,7 @@ TEST_CASE("/fdbserver/MockS3Server/parseS3Request/BucketParameterOverride") {
 	return Void();
 }
 
-TEST_CASE("/fdbserver/MockS3Server/parseS3Request/ComplexPath") {
+TEST_CASE("/MockS3Server/parseS3Request/ComplexPath") {
 
 	MockS3ServerImpl server;
 	std::string resource = "/testbucket/folder/subfolder/file.txt?region=us-east-1";
@@ -1094,7 +1094,7 @@ TEST_CASE("/fdbserver/MockS3Server/parseS3Request/ComplexPath") {
 	return Void();
 }
 
-TEST_CASE("/fdbserver/MockS3Server/parseS3Request/URLEncodedParameters") {
+TEST_CASE("/MockS3Server/parseS3Request/URLEncodedParameters") {
 
 	MockS3ServerImpl server;
 	std::string resource = "/testbucket?region=us-east-1&param=value%3Dtest";
@@ -1110,7 +1110,7 @@ TEST_CASE("/fdbserver/MockS3Server/parseS3Request/URLEncodedParameters") {
 	return Void();
 }
 
-TEST_CASE("/fdbserver/MockS3Server/parseS3Request/EmptyPath") {
+TEST_CASE("/MockS3Server/parseS3Request/EmptyPath") {
 
 	MockS3ServerImpl server;
 	std::string resource = "/testbucket?region=us-east-1";
@@ -1126,7 +1126,7 @@ TEST_CASE("/fdbserver/MockS3Server/parseS3Request/EmptyPath") {
 	return Void();
 }
 
-TEST_CASE("/fdbserver/MockS3Server/parseS3Request/OnlyBucketInPath") {
+TEST_CASE("/MockS3Server/parseS3Request/OnlyBucketInPath") {
 
 	MockS3ServerImpl server;
 	std::string resource = "/testbucket?region=us-east-1";
@@ -1142,7 +1142,7 @@ TEST_CASE("/fdbserver/MockS3Server/parseS3Request/OnlyBucketInPath") {
 	return Void();
 }
 
-TEST_CASE("/fdbserver/MockS3Server/parseS3Request/MultipleParameters") {
+TEST_CASE("/MockS3Server/parseS3Request/MultipleParameters") {
 
 	MockS3ServerImpl server;
 	std::string resource = "/testbucket?region=us-east-1&version=1&encoding=utf8";
@@ -1160,7 +1160,7 @@ TEST_CASE("/fdbserver/MockS3Server/parseS3Request/MultipleParameters") {
 	return Void();
 }
 
-TEST_CASE("/fdbserver/MockS3Server/parseS3Request/ParametersWithoutValues") {
+TEST_CASE("/MockS3Server/parseS3Request/ParametersWithoutValues") {
 
 	MockS3ServerImpl server;
 	std::string resource = "/testbucket?flag&region=us-east-1";
@@ -1176,7 +1176,7 @@ TEST_CASE("/fdbserver/MockS3Server/parseS3Request/ParametersWithoutValues") {
 	return Void();
 }
 
-TEST_CASE("/fdbserver/MockS3Server/RangeHeader/SimpleByteRange") {
+TEST_CASE("/MockS3Server/RangeHeader/SimpleByteRange") {
 	std::string rangeHeader = "bytes=0-99";
 	int64_t rangeStart, rangeEnd;
 
@@ -1189,7 +1189,7 @@ TEST_CASE("/fdbserver/MockS3Server/RangeHeader/SimpleByteRange") {
 	return Void();
 }
 
-TEST_CASE("/fdbserver/MockS3Server/RangeHeader/MiddleRange") {
+TEST_CASE("/MockS3Server/RangeHeader/MiddleRange") {
 	std::string rangeHeader = "bytes=100-199";
 	int64_t rangeStart, rangeEnd;
 
@@ -1202,7 +1202,7 @@ TEST_CASE("/fdbserver/MockS3Server/RangeHeader/MiddleRange") {
 	return Void();
 }
 
-TEST_CASE("/fdbserver/MockS3Server/RangeHeader/LargeOffsets") {
+TEST_CASE("/MockS3Server/RangeHeader/LargeOffsets") {
 	std::string rangeHeader = "bytes=1000000-1999999";
 	int64_t rangeStart, rangeEnd;
 
@@ -1215,7 +1215,7 @@ TEST_CASE("/fdbserver/MockS3Server/RangeHeader/LargeOffsets") {
 	return Void();
 }
 
-TEST_CASE("/fdbserver/MockS3Server/RangeHeader/InvalidFormat") {
+TEST_CASE("/MockS3Server/RangeHeader/InvalidFormat") {
 	std::string rangeHeader = "invalid-range";
 	int64_t rangeStart, rangeEnd;
 
@@ -1226,7 +1226,7 @@ TEST_CASE("/fdbserver/MockS3Server/RangeHeader/InvalidFormat") {
 	return Void();
 }
 
-TEST_CASE("/fdbserver/MockS3Server/RangeHeader/MissingBytesPrefix") {
+TEST_CASE("/MockS3Server/RangeHeader/MissingBytesPrefix") {
 	std::string rangeHeader = "0-99";
 	int64_t rangeStart, rangeEnd;
 
@@ -1237,7 +1237,7 @@ TEST_CASE("/fdbserver/MockS3Server/RangeHeader/MissingBytesPrefix") {
 	return Void();
 }
 
-TEST_CASE("/fdbserver/MockS3Server/RangeHeader/MissingDash") {
+TEST_CASE("/MockS3Server/RangeHeader/MissingDash") {
 	std::string rangeHeader = "bytes=0";
 	int64_t rangeStart, rangeEnd;
 
@@ -1248,7 +1248,7 @@ TEST_CASE("/fdbserver/MockS3Server/RangeHeader/MissingDash") {
 	return Void();
 }
 
-TEST_CASE("/fdbserver/MockS3Server/RangeHeader/EmptyString") {
+TEST_CASE("/MockS3Server/RangeHeader/EmptyString") {
 	std::string rangeHeader = "";
 	int64_t rangeStart, rangeEnd;
 
@@ -1259,7 +1259,7 @@ TEST_CASE("/fdbserver/MockS3Server/RangeHeader/EmptyString") {
 	return Void();
 }
 
-TEST_CASE("/fdbserver/MockS3Server/RangeHeader/NegativeStart") {
+TEST_CASE("/MockS3Server/RangeHeader/NegativeStart") {
 	std::string rangeHeader = "bytes=-100-200";
 	int64_t rangeStart, rangeEnd;
 
@@ -1271,7 +1271,7 @@ TEST_CASE("/fdbserver/MockS3Server/RangeHeader/NegativeStart") {
 	return Void();
 }
 
-TEST_CASE("/fdbserver/MockS3Server/RangeHeader/StartGreaterThanEnd") {
+TEST_CASE("/MockS3Server/RangeHeader/StartGreaterThanEnd") {
 	std::string rangeHeader = "bytes=200-100";
 	int64_t rangeStart, rangeEnd;
 

--- a/fdbserver/MockS3Server.actor.cpp
+++ b/fdbserver/MockS3Server.actor.cpp
@@ -234,7 +234,7 @@ public:
 		// For bucket operations: HEAD /bucket_name
 		// For object operations: HEAD /bucket_name/object_path
 		if (bucket.empty()) {
-			TraceEvent(SevError, "MockS3MissingBucketInPath").detail("Resource", resource).detail("QueryString", query);
+			TraceEvent(SevWarn, "MockS3MissingBucketInPath").detail("Resource", resource).detail("QueryString", query);
 			throw backup_invalid_url();
 		}
 

--- a/fdbserver/RESTKmsConnector.actor.cpp
+++ b/fdbserver/RESTKmsConnector.actor.cpp
@@ -1740,7 +1740,7 @@ void testMalformedDetailNotObj(Reference<RESTKmsConnectorCtx> ctx, bool isCipher
 	doc.SetObject();
 
 	rapidjson::Value cDetails(rapidjson::kArrayType);
-	rapidjson::Value detail;
+	rapidjson::Value detail(rapidjson::kObjectType);
 	rapidjson::Value key(isCipher ? BASE_CIPHER_ID_TAG : BLOB_METADATA_DOMAIN_ID_TAG, doc.GetAllocator());
 	rapidjson::Value id;
 	id.SetUint(12345);

--- a/fdbserver/RESTKmsConnector.actor.cpp
+++ b/fdbserver/RESTKmsConnector.actor.cpp
@@ -1407,6 +1407,7 @@ void getFakeEncryptCipherResponse(StringRef jsonReqRef,
 
 	rapidjson::Value cipherKeyDetails(rapidjson::kArrayType);
 	for (const auto& detail : reqDoc[CIPHER_KEY_DETAILS_TAG].GetArray()) {
+		// Fix: Initialize JSON value as object type to prevent undefined behavior
 		rapidjson::Value keyDetail(rapidjson::kObjectType);
 
 		ASSERT(detail.HasMember(ENCRYPT_DOMAIN_ID_TAG));

--- a/fdbserver/include/fdbserver/MockS3Server.h
+++ b/fdbserver/include/fdbserver/MockS3Server.h
@@ -23,6 +23,7 @@
 #include "flow/flow.h"
 #include "flow/network.h"
 #include "fdbrpc/HTTP.h"
+#include <atomic>
 
 // Mock S3 Server for deterministic testing of S3 operations
 // Supports:
@@ -35,13 +36,33 @@
 // HTTP request handler for Mock S3 Server
 class MockS3RequestHandler : public HTTP::IRequestHandler, public ReferenceCounted<MockS3RequestHandler> {
 public:
+	MockS3RequestHandler() : destructing(false) {}
+
+	// Prevent virtual function calls during destruction
+	~MockS3RequestHandler() { destructing = true; }
+
 	Future<Void> handleRequest(Reference<HTTP::IncomingRequest> req,
 	                           Reference<HTTP::OutgoingResponse> response) override;
 	Reference<HTTP::IRequestHandler> clone() override;
 
-	void addref() override { ReferenceCounted<MockS3RequestHandler>::addref(); }
-	void delref() override { ReferenceCounted<MockS3RequestHandler>::delref(); }
+	void addref() override {
+		if (!destructing) {
+			ReferenceCounted<MockS3RequestHandler>::addref();
+		}
+	}
+	void delref() override {
+		if (!destructing) {
+			ReferenceCounted<MockS3RequestHandler>::delref();
+		}
+	}
+
+private:
+	std::atomic<bool> destructing;
 };
 
 // Start a mock S3 server listening on the specified address
 Future<Void> startMockS3Server(const NetworkAddress& listenAddress);
+
+// Clear all MockS3 global storage - called at the start of each simulation test
+// to prevent data accumulation across multiple tests
+void clearMockS3Storage();


### PR DESCRIPTION
Support HEAD range requests.

Made mocks3 storage global rather than instance-based.

Enabled some tests disabled in simulation; required some fixups.


  20251002-143002-stack-8f737ba026f25da9             compressed=True data_size=41596786 duration=5769725 ended=100000 env=username=stack2 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:58:33 sanity=False started=100000 stopped=20251002-152835 submitted=20251002-143002 timeout=5400 username=stack

