### PR TITLE
Unicast recovery algorithm should account for all versions starting from "max(KCV)" onwards

### DIFF
--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -2330,7 +2330,7 @@ Optional<std::tuple<Version, Version>> getRecoverVersionUnicast(
 	bool nonAvailableTLogsCompletePolicy = std::get<2>(logGroupResults);
 	Version prevVersion = maxKCV;
 	for (auto const& [version, tLogs] : versionAllTLogs) {
-		if (!(prevVersion == maxKCV || prevVersion == prevVersionMap[version])) {
+		if (prevVersion != prevVersionMap[version]) {
 			break;
 		}
 		// This version is not recoverable if there is a log server (LS) such that:


### PR DESCRIPTION
The unicast recovery algorithm should ensure that all versions starting from "max(KCV)" onwards are included in the "unknownCommittedVersions" list. The current implementation allows the version whose prevVersion is equal to "max(KCV)" to be skipped (https://github.com/apple/foundationdb/blob/bfe0b4e535fdee4eb02e97574b2d718718430fc6/fdbserver/TagPartitionedLogSystem.actor.cpp#L2333) (and potentially a bunch of versions right after "max(KCV)") and could cause the algorithm to pick an incorrect recovery version. This PR corrects that check.

NOTE: A good unit test for this function "getRecoverVersionUnicast()" could have found this issue. But it could be tedious to write such a test because it requires the population of data structures like LogSets - we should think more about this.

Testing:
Found by a simulation test (multiple simulation tests found this issue, I think. Didn't look in-depth into all of them). Verified that they all succeed over this change. Also, multiple Joshua jobs run over this change (with version vector enabled) didn't show any similar failures.

Joshua job (with version vector disabled): 

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
