### PR TITLE
Acknowledge state store commits after receiving a reply from the sequencer

### DIFF
--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -1671,7 +1671,6 @@ void applyMetadataEffect(CommitBatchContext* self) {
 				self->forceRecovery = false;
 			}
 		}
-
 		// These changes to txnStateStore will be committed by the other proxy, so we simply discard the commit message
 		auto fcm = self->pProxyCommitData->logAdapter->getCommitMessage();
 		self->storeCommits.emplace_back(fcm, self->pProxyCommitData->txnStateStore->commit());
@@ -2642,12 +2641,20 @@ ACTOR Future<Void> reply(CommitBatchContext* self) {
 	state const Optional<UID>& debugID = self->debugID;
 
 	if (!SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST) {
-		// Do not advance min committed version at this point when version vector is enabled, as we can treat the
-		// current transaction as committed only after receiving a reply from the sequencer (at which point we can
-		// guarantee that all the versions prior to the current version have also been made durable).
+		// Version vector/unicast is disabled: Logging completed, so the current version (and all versions prior to
+		// the current versions) can be treated as commited.
+
+		// Advance min committed version.
 		if (self->prevVersion && self->commitVersion - self->prevVersion < SERVER_KNOBS->MAX_VERSIONS_IN_FLIGHT / 2) {
 			//TraceEvent("CPAdvanceMinVersion", self->pProxyCommitData->dbgid).detail("PrvVersion", self->prevVersion).detail("CommitVersion", self->commitVersion).detail("Master", self->pProxyCommitData->master.id().toString()).detail("TxSize", self->trs.size());
 			debug_advanceMinCommittedVersion(UID(), self->commitVersion);
+		}
+
+		// Acknowledge transaction state store commits.
+		for (auto& p : self->storeCommits) {
+			ASSERT(!p.second.isReady());
+			p.first.get().acknowledge.send(Void());
+			ASSERT(p.second.isReady());
 		}
 	}
 
@@ -2656,12 +2663,6 @@ ACTOR Future<Void> reply(CommitBatchContext* self) {
 	//     .detail("Version", self->commitVersion);
 	if (debugID.present())
 		g_traceBatch.addEvent("CommitDebug", debugID.get().first(), "CommitProxyServer.commitBatch.AfterLogPush");
-
-	for (auto& p : self->storeCommits) {
-		ASSERT(!p.second.isReady());
-		p.first.get().acknowledge.send(Void());
-		ASSERT(p.second.isReady());
-	}
 
 	// After logging finishes, we report the commit version to master so that every other proxy can get the most
 	// up-to-date live committed version. We also maintain the invariant that master's committed version >=
@@ -2693,11 +2694,20 @@ ACTOR Future<Void> reply(CommitBatchContext* self) {
 	}
 
 	if (SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST) {
-		// We have received a reply from the sequencer, so all versions prior to the current version have been
-		// made durable and we can consider the current transaction to be committed - advance min commit version now.
+		// Version vector/unicast is enabled: Received a reply from the sequencer, so we can treat the
+		// current version (and all versions prior to the current version) as committed.
+
+		// Advance min committed version now.
 		if (self->prevVersion && self->commitVersion - self->prevVersion < SERVER_KNOBS->MAX_VERSIONS_IN_FLIGHT / 2) {
 			//TraceEvent("CPAdvanceMinVersion", self->pProxyCommitData->dbgid).detail("PrvVersion", self->prevVersion).detail("CommitVersion", self->commitVersion).detail("Master", self->pProxyCommitData->master.id().toString()).detail("TxSize", self->trs.size());
 			debug_advanceMinCommittedVersion(UID(), self->commitVersion);
+		}
+
+		// Acknowledge transaction state store commits.
+		for (auto& p : self->storeCommits) {
+			ASSERT(!p.second.isReady());
+			p.first.get().acknowledge.send(Void());
+			ASSERT(p.second.isReady());
 		}
 	}
 


### PR DESCRIPTION
Transaction state store commits need to be acknowledged after the current version is known to be committed. When version vector is enabled, a version is known to be committed only after receiving a reply from the sequencer and hence the state store commits need to happen after that point. This PR makes that change. 

Testing:

This issue was exposed by a simulation test. We were acknowledging state store commits after logging completed and that could cause all full snapshots of transaction state store to be popped from logs and that was causing recovery to fail. The failing simulation test succeeded after this change. Also, Joshua jobs are not showing any transaction state store related failures after this change.

Joshua id (with version vector disabled):



In "main" (with version vector disabled) this is done after
If version vector is enabled, do not acknowledge transaction state store commits until the proxy receives a reply from the sequencer (at which point the current version and all versions prior to the current version can be treated as committed)

Replace this text with your description here...

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
