### PR TITLE
Conditionally delete tenant map in transaction

### DIFF
--- a/bindings/bindingtester/bindingtester.py
+++ b/bindings/bindingtester/bindingtester.py
@@ -432,17 +432,18 @@ class TestRunner(object):
         util.get_logger().info("\nInserting test into database...")
         del self.db[:]
 
-        while True:
-            tr = self.db.create_transaction()
-            try:
-                tr.options.set_special_key_space_enable_writes()
-                del tr[
-                    b"\xff\xff/management/tenant/map/":b"\xff\xff/management/tenant/map0"
-                ]
-                tr.commit().wait()
-                break
-            except fdb.FDBError as e:
-                tr.on_error(e).wait()
+        if not self.args.no_tenants:
+            while True:
+                tr = self.db.create_transaction()
+                try:
+                    tr.options.set_special_key_space_enable_writes()
+                    del tr[
+                        b"\xff\xff/management/tenant/map/":b"\xff\xff/management/tenant/map0"
+                    ]
+                    tr.commit().wait()
+                    break
+                except fdb.FDBError as e:
+                    tr.on_error(e).wait()
 
         for subspace, thread in test_instructions.items():
             thread.insert_operations(self.db, subspace)


### PR DESCRIPTION
Otherwise results in ERROR: b'Tenants have been disabled in the cluster' (2136) even if --no-tenats is set.

Joshua (bindingtester):

20251007-190204-vishesh-f0c7fe88c996e50b

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
