### PR TITLE
Fix a restore stuck bug

### DIFF
--- a/fdbclient/FileBackupAgent.actor.cpp
+++ b/fdbclient/FileBackupAgent.actor.cpp
@@ -5160,36 +5160,41 @@ struct RestoreLogDataPartitionedTaskFunc : RestoreFileTaskFuncBase {
 	                                      Version end) {
 		// mergeSort all iterator until all are exhausted
 		// it stores all mutations for the next min version, in new format
-		state bool atLeastOneIteratorHasNext = true;
-		state Version minVersion, lastMinVersion = invalidVersion;
-		while (atLeastOneIteratorHasNext) {
-			std::pair<Version, bool> minVersionAndHasNext = wait(findNextVersion(iterators));
-			minVersion = minVersionAndHasNext.first;
-			atLeastOneIteratorHasNext = minVersionAndHasNext.second;
-			ASSERT_LT(lastMinVersion, minVersion);
-			lastMinVersion = minVersion;
+		try {
+			state bool atLeastOneIteratorHasNext = true;
+			state Version minVersion, lastMinVersion = invalidVersion;
+			while (atLeastOneIteratorHasNext) {
+				std::pair<Version, bool> minVersionAndHasNext = wait(findNextVersion(iterators));
+				minVersion = minVersionAndHasNext.first;
+				atLeastOneIteratorHasNext = minVersionAndHasNext.second;
+				ASSERT_LT(lastMinVersion, minVersion);
+				lastMinVersion = minVersion;
 
-			if (atLeastOneIteratorHasNext) {
-				std::vector<Standalone<VectorRef<VersionedMutation>>> mutationsSingleVersion =
-				    wait(getMutationsForVersion(iterators, minVersion));
+				if (atLeastOneIteratorHasNext) {
+					std::vector<Standalone<VectorRef<VersionedMutation>>> mutationsSingleVersion =
+					    wait(getMutationsForVersion(iterators, minVersion));
 
-				if (minVersion < begin) {
-					// skip generating mutations, because this is not within desired range
-					// this is already handled by the previous taskfunc
-					continue;
-				} else if (minVersion >= end) {
-					// all valid data has been consumed
-					break;
+					if (minVersion < begin) {
+						// skip generating mutations, because this is not within desired range
+						// this is already handled by the previous taskfunc
+						continue;
+					} else if (minVersion >= end) {
+						// all valid data has been consumed
+						break;
+					}
+
+					// transform from new format to old format(param1, param2) for this version.
+					// This transformation has to be done version by version.
+					Standalone<VectorRef<KeyValueRef>> oldFormatMutations =
+					    generateOldFormatMutations(minVersion, mutationsSingleVersion);
+					mutationStream.send(oldFormatMutations);
 				}
-
-				// transform from new format to old format(param1, param2) for this version.
-				// This transformation has to be done version by version.
-				Standalone<VectorRef<KeyValueRef>> oldFormatMutations =
-				    generateOldFormatMutations(minVersion, mutationsSingleVersion);
-				mutationStream.send(oldFormatMutations);
 			}
+			mutationStream.sendError(end_of_stream());
+		} catch (Error& e) {
+			TraceEvent(SevWarn, "FileRestoreLogReadError").error(e);
+			mutationStream.sendError(e);
 		}
-		mutationStream.sendError(end_of_stream());
 		return Void();
 	}
 
@@ -5217,7 +5222,8 @@ struct RestoreLogDataPartitionedTaskFunc : RestoreFileTaskFuncBase {
 	ACTOR static Future<Void> writeMutations(Database cx,
 	                                         std::vector<Standalone<VectorRef<KeyValueRef>>> mutations,
 	                                         Key mutationLogPrefix,
-	                                         Reference<Task> task) {
+	                                         Reference<Task> task,
+	                                         Reference<TaskBucket> taskBucket) {
 		state Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
 		state Standalone<VectorRef<KeyValueRef>> oldFormatMutations;
 		state int mutationIndex = 0;
@@ -5253,7 +5259,9 @@ struct RestoreLogDataPartitionedTaskFunc : RestoreFileTaskFuncBase {
 					txBytes += v.expectedSize();
 					++mutationCount;
 				}
+				wait(taskBucket->keepRunning(tr, task));
 				wait(tr->commit());
+
 				int64_t oldBytes = Params.bytesWritten().get(task);
 				Params.bytesWritten().set(task, oldBytes + txBytes);
 				DisabledTraceEvent("FileRestorePartitionedLogCommittData")
@@ -5364,7 +5372,7 @@ struct RestoreLogDataPartitionedTaskFunc : RestoreFileTaskFuncBase {
 				// batching mutations from multiple versions together before writing to the database
 				state int64_t bytes = oneVersionData.expectedSize();
 				if (totalBytes + bytes > CLIENT_KNOBS->RESTORE_WRITE_TX_SIZE) {
-					wait(writeMutations(cx, mutations, restore.mutationLogPrefix(), task));
+					wait(writeMutations(cx, mutations, restore.mutationLogPrefix(), task, taskBucket));
 					mutations.clear();
 					totalBytes = 0;
 				}
@@ -5373,7 +5381,7 @@ struct RestoreLogDataPartitionedTaskFunc : RestoreFileTaskFuncBase {
 			} catch (Error& e) {
 				if (e.code() == error_code_end_of_stream) {
 					if (mutations.size() > 0) {
-						wait(writeMutations(cx, mutations, restore.mutationLogPrefix(), task));
+						wait(writeMutations(cx, mutations, restore.mutationLogPrefix(), task, taskBucket));
 					}
 					break;
 				} else {


### PR DESCRIPTION
readLogData() may encounter an error but the caller is not waiting on the Future. As a result, the caller waiting on the PromiseStream will become stuck. The fix is to send the error to the PromiseStream.

Another fix is to call taskBucket->keepRunning() in writeMutations(), which is part of the work in _execute().

Reproduction:
```
Branch:  foundationdb-nightly-clang-rhel9 release-7.4
SHA256: d20a925e12ede701902c6a039f5e0b9d82e5c06d
Seed: bin/fdbserver -r simulation -b on -f .correctness/tests/slow/BackupAndRestore.toml -s 2551795224
```

20251009-170645-jzhou-69edcb629b8e738c             compressed=True data_size=40533557 duration=5449238 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:05:29 sanity=False started=100000 stopped=20251009-181214 submitted=20251009-170645 timeout=5400 username=jzhou

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
