### PR TITLE
5s - fuzz read knob value in simulation

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -29,14 +29,23 @@ ServerKnobs::ServerKnobs(Randomize randomize, ClientKnobs* clientKnobs, IsSimula
 	initialize(randomize, clientKnobs, isSimulated);
 }
 
+// Returns a deterministically random transaction timeout value for simulation testing.
+// More weight is given to the famous 5s timeout, but [1, 10] range is returned with lower weight.
+int randomTxnTimeoutSeconds() {
+	if (deterministicRandom()->truePercent(90)) {
+		return 5;
+	} else {
+		return deterministicRandom()->randomInt(1, 11); // [1, 10]
+	}
+}
+
 void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSimulated isSimulated) {
 	// clang-format off
 	init( ALLOW_DANGEROUS_KNOBS,                               isSimulated );
 	
 	// Versions -- knobs that control 5s timeout
 	init( VERSIONS_PER_SECOND,                                   1e6 );
-	bool buggifyShortReadWindow = randomize && BUGGIFY && !ENABLE_VERSION_VECTOR;
-	init( MAX_READ_TRANSACTION_LIFE_VERSIONS,      5 * VERSIONS_PER_SECOND ); if (randomize && BUGGIFY) MAX_READ_TRANSACTION_LIFE_VERSIONS = VERSIONS_PER_SECOND; else if (buggifyShortReadWindow) MAX_READ_TRANSACTION_LIFE_VERSIONS = std::max<int>(1, 0.1 * VERSIONS_PER_SECOND); else if( randomize && BUGGIFY ) MAX_READ_TRANSACTION_LIFE_VERSIONS = 10 * VERSIONS_PER_SECOND;
+	init( MAX_READ_TRANSACTION_LIFE_VERSIONS,      5 * VERSIONS_PER_SECOND ); if (isSimulated) MAX_READ_TRANSACTION_LIFE_VERSIONS = randomTxnTimeoutSeconds() * VERSIONS_PER_SECOND;
 	init( MAX_WRITE_TRANSACTION_LIFE_VERSIONS,     5 * VERSIONS_PER_SECOND ); if (randomize && BUGGIFY) MAX_WRITE_TRANSACTION_LIFE_VERSIONS=std::max<int>(1, 1 * VERSIONS_PER_SECOND);
 	
 	// Versions -- other

--- a/flow/include/flow/DeterministicRandom.h
+++ b/flow/include/flow/DeterministicRandom.h
@@ -66,6 +66,7 @@ public:
 	char randomAlphaNumeric() override;
 	std::string randomAlphaNumeric(int length) override;
 	void randomBytes(uint8_t* buf, int length) override;
+	bool truePercent(const int percent) override;
 	uint64_t peek() const override;
 	void addref() override;
 	void delref() override;

--- a/flow/include/flow/IRandom.h
+++ b/flow/include/flow/IRandom.h
@@ -150,6 +150,16 @@ public:
 	virtual std::string randomAlphaNumeric(int length) = 0;
 	virtual void randomBytes(uint8_t* buf, int length) = 0;
 	virtual uint32_t randomSkewedUInt32(uint32_t min, uint32_t maxPlusOne) = 0;
+
+	// Given an input percentage, returns true with a probability of that percentage.
+	// Valid range: 1 <= percent <= 99
+	// 0 percent -> not allowed since it will always be false anyway
+	// 100 percent -> not allowed since it will always be true anyway
+	// 1 percent -> returns true with a probability of 1% (0.01)
+	// 50 percent -> returns true with a probability of 50% (0.5)
+	// 99 percent -> returns true with a probability of 99% (0.99)
+	virtual bool truePercent(const int percent) = 0;
+
 	virtual uint64_t peek() const = 0; // returns something that is probably different for different random states.
 	                                   // Deterministic (and idempotent) for a deterministic generator.
 


### PR DESCRIPTION
# Description

This PR makes the simulation fuzzing logic for MAX_READ_TRANSACTION_LIFE_VERSIONS simpler by picking a value in range [1, 10] with a lower weight, otherwise 5s is picked. The previous logic was based on buggify, the goal of which is to ensure system behaves correctly in extreme or rare scenarios, including ones with fault injection. But now as we're looking to extend the 5s limit in FDB, we should expect that different txn timeout values are normal / expected.

In addition, a `truePercent` utility is added to DeterministicRandom. Unit tests are added to ensure correctness of the utility.

# Testing

100K: 20251010-173457-praza-5s-milestone1-iter31-5ea5963b8b2444924 compressed=True data_size=37454516 duration=5705360 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:56:20 sanity=False started=100000 stopped=20251010-183117 submitted=20251010-173457 timeout=5400 username=praza-5s-milestone1-iter31-5ea5963b8b244492439547e4bd481f49bec41949

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
