### PR TITLE
Recovery observability (phase: recovery_transaction)

### DIFF
--- a/fdbserver/ClusterRecovery.actor.cpp
+++ b/fdbserver/ClusterRecovery.actor.cpp
@@ -1653,6 +1653,7 @@ ACTOR Future<Void> clusterRecoveryCore(Reference<ClusterRecoveryData> self) {
 	    .detail("Status", RecoveryStatus::names[RecoveryStatus::recovery_transaction])
 	    .detail("PrimaryLocality", self->primaryLocality)
 	    .detail("DcId", self->masterInterface.locality.dcId())
+	    .detail("LastEpochEnd", self->lastEpochEnd)
 	    .trackLatest(self->clusterRecoveryStateEventHolder->trackingKey);
 
 	// Recovery transaction
@@ -1751,8 +1752,8 @@ ACTOR Future<Void> clusterRecoveryCore(Reference<ClusterRecoveryData> self) {
 	tr.read_snapshot = self->recoveryTransactionVersion; // lastEpochEnd would make more sense, but isn't in the initial
 	                                                     // window of the resolver(s)
 
-	TraceEvent(getRecoveryEventName(ClusterRecoveryEventType::CLUSTER_RECOVERY_COMMIT_EVENT_NAME).c_str(), self->dbgid)
-	    .log();
+	TraceEvent(getRecoveryEventName(ClusterRecoveryEventType::CLUSTER_RECOVERY_COMMIT_EVENT_NAME).c_str(), self->dbgid);
+
 	state Future<ErrorOr<CommitID>> recoveryCommit = self->commitProxies[0].commit.tryGetReply(recoveryCommitRequest);
 	self->addActor.send(self->logSystem->onError());
 	self->addActor.send(waitResolverFailure(self->resolvers));
@@ -1761,13 +1762,17 @@ ACTOR Future<Void> clusterRecoveryCore(Reference<ClusterRecoveryData> self) {
 	self->addActor.send(reportErrors(updateRegistration(self, self->logSystem), "UpdateRegistration", self->dbgid));
 	self->registrationTrigger.trigger();
 
-	wait(discardCommit(self->txnStateStore, self->txnStateLogAdapter));
+	wait(traceAfter(discardCommit(self->txnStateStore, self->txnStateLogAdapter), "DiscardCommitFinished"));
 
 	// Wait for the recovery transaction to complete.
 	// SOMEDAY: For faster recovery, do this and setDBState asynchronously and don't wait for them
 	// unless we want to change TLogs
-	wait((success(recoveryCommit) && sendInitialCommitToResolvers(self)));
+	wait(traceAfter(success(recoveryCommit), "RecoveryCommitFinished") &&
+	     traceAfter(sendInitialCommitToResolvers(self), "InitialCommitToResolversFinished"));
 	if (recoveryCommit.isReady() && recoveryCommit.get().isError()) {
+		TraceEvent(getRecoveryEventName(ClusterRecoveryEventType::CLUSTER_RECOVERY_COMMIT_EVENT_NAME).c_str(),
+		           self->dbgid)
+		    .errorUnsuppressed(recoveryCommit.get().getError());
 		CODE_PROBE(true, "Cluster recovery failed because of the initial commit failed");
 		throw cluster_recovery_failed();
 	}


### PR DESCRIPTION
# Description

While debugging an issue in recovery_transaction phase recently, realized we don't have granular observability to have a good picture of what's going on. This PR adds some of the missing pieces I observed. 

# Testing

100K: 20251009-212521-praza-recovery-observabilit-1df3d613aefe8e7b compressed=True data_size=40532627 duration=6191578 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:26:28 sanity=False started=100000 stopped=20251009-225149 submitted=20251009-212521 timeout=5400 username=praza-recovery-observability-recovery-txn-phase-5903c3086537e9d992609a8c86fd28b44446f271

Did a random simulation run and ensured trace events are appearing as expected:

```
/t/sim1 $ grep "Type=\"MasterRecoveryState\"" trace* | grep "recovery_transaction" | tail -n 1
<Event Severity="10" Time="594.273198" DateTime="2025-10-10T06:53:25Z" Type="MasterRecoveryState" Machine="2.0.1.0:1" ID="3447db0a03a1a693" StatusCode="9" Status="recovery_transaction" PrimaryLocality="0" DcId="0" LastEpochEnd="1179618034" ThreadID="12299272478775920718" LogGroup="default" Roles="CC,CP,RV" TrackLatestType="Original" />
/t/sim1 $ grep "Type=\"MasterRecoveryCommit\"" trace* | tail -n 2
<Event Severity="10" Time="594.273198" DateTime="2025-10-10T06:53:25Z" Type="MasterRecoveryCommit" Machine="2.0.1.0:1" ID="3447db0a03a1a693" ThreadID="12299272478775920718" LogGroup="default" Roles="CC,CP,RV" />
<Event Severity="10" Time="594.300310" DateTime="2025-10-10T06:53:25Z" Type="MasterRecoveryCommit" Machine="2.0.1.0:1" ID="3447db0a03a1a693" TLogs="0: f9e2ed0eb0fdadb7834c67141e4e7215, e701f39e3aef8d59aebc44210b39faad 1: 5bd7cf0d1586327e3b0076abb7f65972, bf0576db782b35a9c185f768eeea83b7, ba093862625c95cd6715c34265c8040a, a4e5476c72731f5d61e6cf04bc348644 2: 69336be65ca4bacc61fd80d8806de218, a073d07f594ae22c70aeb92390d45728, 112e2026c0fec592abd308e2c6a1df15 " RecoveryCount="17" RecoveryTransactionVersion="1279618034" ThreadID="12299272478775920718" LogGroup="default" Roles="CC,CP,RV" />
/t/sim1 $ grep "DiscardCommitFinished" trace* | tail -n 1
<Event Severity="10" Time="594.273198" DateTime="2025-10-10T06:53:25Z" Type="DiscardCommitFinished" Machine="2.0.1.0:1" ID="0000000000000000" ThreadID="12299272478775920718" LogGroup="default" Roles="CC,CP,RV" />
/t/sim1 $ grep "RecoveryCommitFinished" trace* | tail -n 1
<Event Severity="10" Time="594.288978" DateTime="2025-10-10T06:53:25Z" Type="RecoveryCommitFinished" Machine="2.0.1.0:1" ID="0000000000000000" ThreadID="12299272478775920718" LogGroup="default" Roles="CC,CP,RV" />
/t/sim1 $ grep "InitialCommitToResolversFinished" trace* | tail -n 1
<Event Severity="10" Time="594.278979" DateTime="2025-10-10T06:53:25Z" Type="InitialCommitToResolversFinished" Machine="2.0.1.0:1" ID="0000000000000000" ThreadID="12299272478775920718" LogGroup="default" Roles="CC,CP,RV" />
```

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
