### PR TITLE
Add system keyspace sizes to status output

### DIFF
--- a/fdbcli/StatusCommand.actor.cpp
+++ b/fdbcli/StatusCommand.actor.cpp
@@ -204,13 +204,14 @@ std::string logBackupDR(const char* context, std::map<std::string, std::string> 
 namespace fdb_cli {
 
 std::string toBytesString(double bytes) {
-	const char* sizes[] = { "B", "KB", "MB", "GB", "TB" };
-	int order = 0;
-	while (bytes >= 1024.0 && order < 4) {
-		order++;
-		bytes = bytes / 1024.0;
+	if (bytes >= 1e12) {
+		return format("%.3f TB", (bytes / 1e12));
+	} else if (bytes >= 1e9) {
+		return format("%.3f GB", (bytes / 1e9));
+	} else {
+		// no decimal points for MB
+		return format("%d MB", (int)round(bytes / 1e6));
 	}
-	return format("%.3f %s", bytes, sizes[order]);
 }
 
 void printStatus(StatusObjectReader statusObj,


### PR DESCRIPTION
Fixes https://github.com/apple/foundationdb/issues/12189

Output is like:
```
Data:
  Replication health     - Healthy
  Moving data            - 0.000 GB
  Sum of key-value sizes - 0 MB
  System keyspace sizes  - 0 MB
  Disk space used        - 1.992 GB
```
# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
