### PR TITLE
Refactor TestTLogServer to use a shared fixture and helpers for deter…

### DIFF
--- a/fdbserver/TestTLogServer.actor.cpp
+++ b/fdbserver/TestTLogServer.actor.cpp
@@ -62,21 +62,78 @@ std::string makeKVStoreBasename(const TestTLogOptions& options, const TLogTestCo
 }
 
 InitializeTLogRequest buildInitializeRequest(const TLogTestContext& ctx) {
-	InitializeTLogRequest initReq;
+	InitializeTLogRequest req;
 	std::vector<Tag> tags;
 	tags.reserve(ctx.numTags);
 	for (uint32_t tagID = 0; tagID < ctx.numTags; tagID++) {
 		tags.emplace_back(ctx.tagLocality, tagID);
 	}
-	initReq.epoch = 1;
-	initReq.allTags = tags;
-	initReq.isPrimary = true;
-	initReq.locality = ctx.primaryLocality;
-	initReq.recoveryTransactionVersion = ctx.initVersion;
-	return initReq;
+	req.epoch = 1;
+	req.allTags = tags;
+	req.isPrimary = true;
+	req.locality = ctx.primaryLocality;
+	req.recoveryTransactionVersion = ctx.initVersion;
+	return req;
 }
 
-} // namespace
+struct TempStorageFiles {
+	std::string queueBase;
+	std::string queueExt;
+	std::string kvBase;
+	std::string kvExt;
+	bool active{ false };
+
+	TempStorageFiles() = default;
+	TempStorageFiles(std::string queueBase, std::string queueExt, std::string kvBase, std::string kvExt)
+	  : queueBase(std::move(queueBase)), queueExt(std::move(queueExt)), kvBase(std::move(kvBase)),
+	    kvExt(std::move(kvExt)), active(true) {}
+
+	~TempStorageFiles() { cleanup(); }
+
+	void cleanup() {
+		if (!active)
+			return;
+		if (!queueBase.empty()) {
+			deleteFile(queueBase + "0." + queueExt);
+			deleteFile(queueBase + "1." + queueExt);
+		}
+		if (!kvBase.empty()) {
+			deleteFile(kvBase + "0." + kvExt);
+			deleteFile(kvBase + "1." + kvExt);
+		}
+		active = false;
+	}
+};
+
+struct StorageResources {
+	std::string diskQueueFilename;
+	std::string kvStoreFilename;
+	TempStorageFiles tempFiles;
+
+	StorageResources() = default;
+	StorageResources(std::string dq, std::string kv, TempStorageFiles files)
+	  : diskQueueFilename(std::move(dq)), kvStoreFilename(std::move(kv)), tempFiles(std::move(files)) {}
+};
+
+StorageResources setupPersistentStorage(Reference<TLogContext> tLogContext,
+                                        const TLogTestContext& testContext,
+                                        const TestTLogOptions& options) {
+	std::string diskQueueFilename = options.dataFolder + "/" + makeDiskQueueBasename(testContext, tLogContext->tLogID);
+	tLogContext->persistentQueue =
+	    openDiskQueue(diskQueueFilename, options.diskQueueExtension, tLogContext->tLogID, DiskQueueVersion::V2);
+
+	std::string kvStoreFilename =
+	    options.dataFolder + "/" + makeKVStoreBasename(options, testContext, tLogContext->tLogID);
+	tLogContext->persistentData = keyValueStoreMemory(kvStoreFilename,
+	                                                  tLogContext->tLogID,
+	                                                  options.kvMemoryLimit,
+	                                                  options.kvStoreExtension,
+	                                                  KeyValueStoreType::MEMORY_RADIXTREE);
+
+	TempStorageFiles tempFiles(
+	    diskQueueFilename, options.diskQueueExtension, kvStoreFilename, options.kvStoreExtension);
+	return StorageResources(diskQueueFilename, kvStoreFilename, std::move(tempFiles));
+}
 
 Reference<TLogTestContext> initTLogTestContext(TestTLogOptions tLogOptions,
                                                Optional<Reference<TLogTestContext>> oldTLogTestContext) {
@@ -107,6 +164,8 @@ Reference<TLogTestContext> initTLogTestContext(TestTLogOptions tLogOptions,
 	return context;
 }
 
+} // namespace
+
 // Create and start a tLog. If optional parmeters are set, the tLog is a new generation of "tLogID"
 // as described by initReq. Otherwise, it is a newborn generation 0 tLog.
 ACTOR Future<Void> getTLogCreateActor(Reference<TLogTestContext> pTLogTestContext,
@@ -126,18 +185,7 @@ ACTOR Future<Void> getTLogCreateActor(Reference<TLogTestContext> pTLogTestContex
 	std::filesystem::create_directory(tLogOptions.dataFolder);
 
 	// create persistent storage
-	std::string diskQueueBasename = makeDiskQueueBasename(*pTLogTestContext, pTLogContext->tLogID);
-	state std::string diskQueueFilename = tLogOptions.dataFolder + "/" + diskQueueBasename;
-	pTLogContext->persistentQueue =
-	    openDiskQueue(diskQueueFilename, tLogOptions.diskQueueExtension, pTLogContext->tLogID, DiskQueueVersion::V2);
-
-	state std::string kvStoreFilename =
-	    tLogOptions.dataFolder + "/" + makeKVStoreBasename(tLogOptions, *pTLogTestContext, pTLogContext->tLogID);
-	pTLogContext->persistentData = keyValueStoreMemory(kvStoreFilename,
-	                                                   pTLogContext->tLogID,
-	                                                   tLogOptions.kvMemoryLimit,
-	                                                   tLogOptions.kvStoreExtension,
-	                                                   KeyValueStoreType::MEMORY_RADIXTREE);
+	state StorageResources storage = setupPersistentStorage(pTLogContext, *pTLogTestContext, tLogOptions);
 
 	// prepare tLog construction.
 	Standalone<StringRef> machineID = "machine"_sr;
@@ -168,12 +216,7 @@ ACTOR Future<Void> getTLogCreateActor(Reference<TLogTestContext> pTLogTestContex
 	                               activeSharedTLog,
 	                               enablePrimaryTxnSystemHealthCheck);
 
-	state InitializeTLogRequest initTLogReq = InitializeTLogRequest();
-	if (initReq != nullptr) {
-		initTLogReq = *initReq;
-	} else {
-		initTLogReq = buildInitializeRequest(*pTLogTestContext);
-	}
+	state InitializeTLogRequest initTLogReq = initReq != nullptr ? *initReq : buildInitializeRequest(*pTLogTestContext);
 
 	TLogInterface interface = wait(promiseStream.getReply(initTLogReq));
 	pTLogContext->TestTLogInterface = interface;
@@ -194,11 +237,7 @@ ACTOR Future<Void> getTLogCreateActor(Reference<TLogTestContext> pTLogTestContex
 
 	wait(delay(1.0));
 
-	// delete old disk queue files
-	deleteFile(diskQueueFilename + "0." + tLogOptions.diskQueueExtension);
-	deleteFile(diskQueueFilename + "1." + tLogOptions.diskQueueExtension);
-	deleteFile(kvStoreFilename + "0." + tLogOptions.kvStoreExtension);
-	deleteFile(kvStoreFilename + "1." + tLogOptions.kvStoreExtension);
+	storage.tempFiles.cleanup();
 
 	return Void();
 }


### PR DESCRIPTION
* add TLogFixture so epoch creation, actor tracking, and tLog startup live in one place
* replace ad-hoc string formatting with reusable helpers for mutation key/value construction
* update the recovery test harness to spin up both generations of tLogs through the new fixture while preserving existing validation flow



# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
