### PR TITLE
Fix two recent simulation failures

### DIFF
--- a/fdbserver/workloads/ClogRemoteTLog.actor.cpp
+++ b/fdbserver/workloads/ClogRemoteTLog.actor.cpp
@@ -337,8 +337,13 @@ struct ClogRemoteTLog : TestWorkload {
 			if (self->cloggedRemoteTLog.get().ip == ip) {
 				continue;
 			}
-			TraceEvent("ClogRemoteTLog").detail("SrcIP", self->cloggedRemoteTLog->ip).detail("DstIP", ip);
-			g_simulator->clogPair(ip, self->cloggedRemoteTLog.get().ip, self->testDuration);
+			double clogDuration = self->testDuration * (0.5 + 0.4 * deterministicRandom()->random01());
+			// clogDuration must be less than testDuration to ensure that the clogging ends before the test ends
+			g_simulator->clogPair(ip, self->cloggedRemoteTLog.get().ip, clogDuration);
+			TraceEvent("ClogRemoteTLog")
+			    .detail("SrcIP", self->cloggedRemoteTLog->ip)
+			    .detail("DstIP", ip)
+			    .detail("Duration", clogDuration);
 			numClogged++;
 		}
 

--- a/tests/restarting/to_7.3.0_until_7.3.51/ConfigureStorageMigrationTestRestart-1.toml
+++ b/tests/restarting/to_7.3.0_until_7.3.51/ConfigureStorageMigrationTestRestart-1.toml
@@ -1,5 +1,7 @@
 [configuration]
 extraMachineCountDC = 2
+extraStorageMachineCountPerDC = 2 # adding more SS to avoid remote DC perpetual wiggle stuck when converting storage engine
+
 maxTLogVersion=7
 disableHostname=true
 tenantModes = ['disabled']


### PR DESCRIPTION
100K simulation tests:
  20251013-214047-zhewang-9518c9cb40188fca           compressed=True data_size=41611657 duration=5895381 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:02:43 sanity=False started=100000 stopped=20251013-224330 submitted=20251013-214047 timeout=5400 username=zhewang

  
  
Failure 1: ClogRemoteTLogCheckFailed for ClogRemoteTLog.toml
ClogRemoteTLog failed because the test observes a SS lag goes up but never goes down until the test ends. The test injects network clog in the simulation by specifying the clog period same as the testDuration. In a test failure instance, we see that the clog does not get removed until the test ends. This is because the order of test termination and clog termination is not strictly enforced.

Fix: Give a shorter period of clog duration than the test duration.

Failure 2: SetupAndRunError for ConfigureStorageMigrationTestRestart-1.toml
The test relies on perpetual wiggle to convert the storage engine to the specific engine for all storage servers. In a test failure instance, the remote DC only contains a single SS, which blocks the remote DC perpetual wiggle. As a result, the remote DC storage servers' storage engine keeps failing to convert.

Fix: Give more storage servers to remote DC. 

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
