### PR TITLE
Fix clog longer than test duration

### DIFF
--- a/fdbserver/workloads/DcLag.actor.cpp
+++ b/fdbserver/workloads/DcLag.actor.cpp
@@ -158,7 +158,8 @@ struct DcLagWorkload : TestWorkload {
 		TraceEvent("DcLag").detail("StartTime", startTime).detail("EndTime", workloadEnd);
 
 		// Clog and wait for recovery to happen
-		if (!self->clogTlog(self->testDuration)) {
+		double clogDuration = self->testDuration * (0.5 + 0.4 * deterministicRandom()->random01());
+		if (!self->clogTlog(clogDuration)) {
 			return Void(); // skip the test if no satellite found
 		}
 

--- a/fdbserver/workloads/FailoverWithSSLag.actor.cpp
+++ b/fdbserver/workloads/FailoverWithSSLag.actor.cpp
@@ -259,7 +259,8 @@ struct FailoverWithSSLagWorkload : TestWorkload {
 		}
 
 		// Clog connections between remote tlogs and storage servers.
-		if (!self->findAndClogRemoteStorages(self->testDuration)) {
+		double clogDuration = self->testDuration * (0.5 + 0.4 * deterministicRandom()->random01());
+		if (!self->findAndClogRemoteStorages(clogDuration)) {
 			// Couldn't find remote tlogs/storage servers. Probably configuration will
 			// need to be adjusted.
 			self->testSuccess = false;


### PR DESCRIPTION
When injecting a clog in simulation, the goal is often to apply it before the test ends. However, if the clog duration is set equal to the test duration, the clog may persist after the workload completes, lasting longer than intended.

100K correctness test:
  20251014-010706-zhewang-7bedcfbdb57ce5a3           compressed=True data_size=38897360 fail_fast=10 max_runs=100000 priority=100 sanity=False submitted=20251014-010706 timeout=5400 username=zhewang


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
