### PR TITLE
Fix S3 ListObjectsV2 regression: restore leading '/' virtual hosting

### DIFF
--- a/fdbclient/S3BlobStore.actor.cpp
+++ b/fdbclient/S3BlobStore.actor.cpp
@@ -2467,7 +2467,7 @@ TEST_CASE("/backup/s3/virtual_hosting_list_resource_path") {
 	Reference<S3BlobStoreEndpoint> s3 = S3BlobStoreEndpoint::fromString(url, {}, &resource, &error, &parameters);
 
 	ASSERT(s3.isValid());
-	ASSERT(resource == "/bulkload/path"); // Path prefix extracted from URL
+	ASSERT(resource == "bulkload/path"); // Path prefix extracted from URL (without leading '/')
 
 	// In virtual hosting mode, constructResourcePath returns "" for empty object
 	std::string listResource = s3->constructResourcePath("test-bucket", "");
@@ -2483,7 +2483,7 @@ TEST_CASE("/backup/s3/virtual_hosting_list_resource_path") {
 	url = "blobstore://s3.us-west-2.amazonaws.com/resource_path?bucket=test-bucket";
 	s3 = S3BlobStoreEndpoint::fromString(url, {}, &resource, &error, &parameters);
 	ASSERT(s3.isValid());
-	ASSERT(resource == "/resource_path"); // Path extracted from URL
+	ASSERT(resource == "resource_path"); // Path extracted from URL (without leading '/')
 
 	// In non-virtual hosting mode, constructResourcePath includes bucket
 	listResource = s3->constructResourcePath("test-bucket", "");


### PR DESCRIPTION
Commit 15dd76a7f9 switched from ListObjectsV1 to ListObjectsV2 and changed:
  resource.append('/?max-keys=1000')
to:
  resource.append('?list-type=2&max-keys=...')

This removed the leading '/' which broke virtual hosting mode URLs with path prefixes. For example, with URL:

  blobstore://@bucket.s3.region.amazonaws.com/prefix/path?bucket=...

In virtual hosting mode, constructResourcePath(bucket, '') returns ''.

Before: '' + '/?...' = '/?...' ✓
After:  '' + '?...' = '?...' ✗ (invalid HTTP, missing path)

This caused S3BlobStoreResourceNotFound (404) errors when listing objects because the HTTP request became 'GET ?list-type=2&...' instead of 'GET /prefix/path?list-type=2&...'.

The fix ensures that if resource is empty after constructResourcePath(), we add '/' before appending the query string.

Adds regression test to verify virtual hosting mode resource path construction.
