### PR TITLE
Fix S3 upload XXH64 checksum race condition causing download failures

### DIFF
--- a/fdbclient/S3Client.actor.cpp
+++ b/fdbclient/S3Client.actor.cpp
@@ -324,7 +324,7 @@ ACTOR static Future<PartState> uploadPart(Reference<S3BlobStoreEndpoint> endpoin
 
 			// Store part data for sequential XXH64 checksum calculation after concurrent uploads complete
 			// to avoid race condition where multiple concurrent uploadPart actors all call
-      // XXH64_update(hashState, ...) on the same hash state simultaneously, corrupting it.
+			// XXH64_update(hashState, ...) on the same hash state simultaneously, corrupting it.
 			resultPart.partData = std::move(partData);
 
 			// Calculate hash for this part - use SHA256 if integrity check enabled, otherwise MD5


### PR DESCRIPTION
XXH64 checksum calculation had a race condition during concurrent multipart uploads, causing checksum_failed errors on download.

- uploadPart() was called concurrently (up to BLOBSTORE_CONCURRENT_WRITES_PER_FILE times)
- All concurrent actors called XXH64_update(hashState, ...) on the SAME hash state
- This corrupted the hash state's internal data structures due to concurrent writes
- Result: Incorrect XXH64 checksum stored in S3
- Download would calculate correct checksum and detect mismatch -> checksum_failed

Symptoms:
- Bulk dump succeeded (files uploaded to S3)
- Bulk load failed with checksum_failed errors
- Affected many different files (not random corruption)
- Only occurred when BLOBSTORE_CONCURRENT_WRITES_PER_FILE > 1

Fix:
1. After concurrent uploads complete, iterate parts in sequential order
2. Call XXH64_update for each part IN ORDER (no race condition)
3. Then finalize the hash with XXH64_digest
4. Clear parts to free memory

- Reads file only once (during upload)
- Uploads happen concurrently
- XXH64 hash calculated sequentially
- Zero extra memory
- Only holds maxConcurrentUploads parts in memory at a time

This bug was likely introduced in commit 2d851b0123 which made 'checksumming and upload one-pass' but didn't account for XXH64_update not being thread-safe.

Hard to test outside of integration test: needs multipart upload with manufactured race and then a download and verification of checksum on disk.