### PR TITLE
cherry pick counters for dirty tags in TLogServer (#12427)

### DIFF
--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -572,6 +572,8 @@ struct LogData : NonCopyable, public ReferenceCounted<LogData> {
 	Counter blockingPeekTimeouts;
 	Counter emptyPeeks;
 	Counter nonEmptyPeeks;
+	Counter persistentDataUpdateBatches;
+	Counter dirtyTagsProcessed;
 	std::map<Tag, LatencySample> blockingPeekLatencies;
 
 	UID logId;
@@ -660,7 +662,8 @@ struct LogData : NonCopyable, public ReferenceCounted<LogData> {
 	    unpoppedRecoveredTagCount(0), cc("TLog", interf.id().toString()), bytesInput("BytesInput", cc),
 	    bytesDurable("BytesDurable", cc), blockingPeeks("BlockingPeeks", cc),
 	    blockingPeekTimeouts("BlockingPeekTimeouts", cc), emptyPeeks("EmptyPeeks", cc),
-	    nonEmptyPeeks("NonEmptyPeeks", cc), logId(interf.id()), protocolVersion(protocolVersion),
+	    nonEmptyPeeks("NonEmptyPeeks", cc), persistentDataUpdateBatches("PersistentDataUpdateBatches", cc),
+	    dirtyTagsProcessed("DirtyTagsProcessed", cc), logId(interf.id()), protocolVersion(protocolVersion),
 	    newPersistentDataVersion(invalidVersion), tLogData(tLogData), unrecoveredBefore(1), recoveredAt(1),
 	    recoveryTxnVersion(1), logSystem(new AsyncVar<Reference<ILogSystem>>()), remoteTag(remoteTag),
 	    isPrimary(isPrimary), logRouterTags(logRouterTags), logRouterPoppedVersion(0), logRouterPopToVersion(0),
@@ -868,15 +871,17 @@ ACTOR Future<Void> tLogLock(TLogData* self, ReplyPromise<TLogLockResult> reply, 
 }
 
 void updatePersistentPopped(TLogData* self, Reference<LogData> logData, Reference<LogData::TagData> data) {
-	if (!data->poppedRecently)
+	if (!data->poppedRecently) {
 		return;
+	}
 	self->persistentData->set(
 	    KeyValueRef(persistTagPoppedKey(logData->logId, data->tag), persistTagPoppedValue(data->popped)));
 	data->poppedRecently = false;
 	data->persistentPopped = data->popped;
 
-	if (data->nothingPersistent)
+	if (data->nothingPersistent) {
 		return;
+	}
 
 	if (logData->shouldSpillByValue(data->tag)) {
 		self->persistentData->clear(KeyRangeRef(persistTagMessagesKey(logData->logId, data->tag, Version(0)),
@@ -897,8 +902,9 @@ ACTOR Future<Void> updatePoppedLocation(TLogData* self, Reference<LogData> logDa
 		return Void();
 	}
 
-	if (data->versionForPoppedLocation >= data->persistentPopped)
+	if (data->versionForPoppedLocation >= data->persistentPopped) {
 		return Void();
+	}
 	data->versionForPoppedLocation = data->persistentPopped;
 
 	// Use persistentPopped and not popped, so that a pop update received after spilling doesn't cause
@@ -948,8 +954,9 @@ ACTOR Future<Void> updatePoppedLocation(TLogData* self, Reference<LogData> logDa
 // data, and then issues a pop to the disk queue at that location so that anything earlier can be
 // removed/forgotten/overwritten. In effect, it applies the effect of TLogPop RPCs to disk.
 ACTOR Future<Void> popDiskQueue(TLogData* self, Reference<LogData> logData) {
-	if (!logData->initialized)
+	if (!logData->initialized) {
 		return Void();
+	}
 
 	std::vector<Future<Void>> updates;
 	for (int tagLocality = 0; tagLocality < logData->tag_data.size(); tagLocality++) {
@@ -1015,6 +1022,12 @@ ACTOR Future<Void> updatePersistentData(TLogData* self, Reference<LogData> logDa
 
 	state bool anyData = false;
 
+	// Track total batch runs (including empty batches with no work)
+	logData->persistentDataUpdateBatches += 1;
+
+	// Track successfully processed tags (incremented at end after all work completes)
+	state int64_t tagsProcessedThisBatch = 0;
+
 	// For all existing tags
 	state int tagLocality = 0;
 	state int tagId = 0;
@@ -1023,6 +1036,7 @@ ACTOR Future<Void> updatePersistentData(TLogData* self, Reference<LogData> logDa
 		for (tagId = 0; tagId < logData->tag_data[tagLocality].size(); tagId++) {
 			state Reference<LogData::TagData> tagData = logData->tag_data[tagLocality][tagId];
 			if (tagData) {
+				tagsProcessedThisBatch++;
 				wait(tagData->eraseMessagesBefore(tagData->popped, self, logData, TaskPriority::UpdateStorage));
 				state Version currentVersion = 0;
 				// Clear recently popped versions from persistentData if necessary
@@ -1101,6 +1115,9 @@ ACTOR Future<Void> updatePersistentData(TLogData* self, Reference<LogData> logDa
 			}
 		}
 	}
+
+	// Only update counter after all tags successfully processed
+	logData->dirtyTagsProcessed += tagsProcessedThisBatch;
 
 	auto locationIter = logData->versionLocation.lower_bound(newPersistentDataVersion);
 	if (locationIter != logData->versionLocation.end()) {


### PR DESCRIPTION
cherry pick counters for dirty tags in TLogServer (#12427)

100K `20251016-003030-dlambrig-20478ae529d4eb9c`

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
