### PR TITLE
Make DirtyTagsProcessed count only tags that touch persistentData

### DIFF
--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -1041,7 +1041,8 @@ ACTOR Future<Void> updatePersistentData(TLogData* self, Reference<LogData> logDa
 		for (tagId = 0; tagId < logData->tag_data[tagLocality].size(); tagId++) {
 			state Reference<LogData::TagData> tagData = logData->tag_data[tagLocality][tagId];
 			if (tagData) {
-				tagsProcessedThisBatch++;
+				// poppedRecently implies updatePersistentPopped() will touch persistentData
+				state bool tagDidWork = tagData->poppedRecently;
 				wait(tagData->eraseMessagesBefore(tagData->popped, self, logData, TaskPriority::UpdateStorage));
 				state Version currentVersion = 0;
 				// Clear recently popped versions from persistentData if necessary
@@ -1067,6 +1068,7 @@ ACTOR Future<Void> updatePersistentData(TLogData* self, Reference<LogData> logDa
 						}
 						self->persistentData->set(KeyValueRef(
 						    persistTagMessagesKey(logData->logId, tagData->tag, currentVersion), wr.toValue()));
+						tagDidWork = true;
 					} else {
 						// spill everything else by reference
 						const IDiskQueue::location begin = logData->versionLocation[currentVersion].first;
@@ -1092,6 +1094,7 @@ ACTOR Future<Void> updatePersistentData(TLogData* self, Reference<LogData> logDa
 							*(uint32_t*)wr.getData() = refSpilledTagCount;
 							self->persistentData->set(KeyValueRef(
 							    persistTagMessageRefsKey(logData->logId, tagData->tag, lastVersion), wr.toValue()));
+							tagDidWork = true;
 							tagData->poppedLocation = std::min(tagData->poppedLocation, firstLocation);
 							refSpilledTagCount = 0;
 							wr = BinaryWriter(AssumeVersion(logData->protocolVersion));
@@ -1113,10 +1116,15 @@ ACTOR Future<Void> updatePersistentData(TLogData* self, Reference<LogData> logDa
 					*(uint32_t*)wr.getData() = refSpilledTagCount;
 					self->persistentData->set(
 					    KeyValueRef(persistTagMessageRefsKey(logData->logId, tagData->tag, lastVersion), wr.toValue()));
+					tagDidWork = true;
 					tagData->poppedLocation = std::min(tagData->poppedLocation, firstLocation);
 				}
 
 				wait(yield(TaskPriority::UpdateStorage));
+
+				if (tagDidWork) {
+					tagsProcessedThisBatch++;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
DirtyTagsProcessed was inflated because we bumped it for every non-null tagData, even when a tag had no messages or pop updates to persist. That meant the ratio against PersistentDataUpdateBatches reflected “tags visited,” not “tags that actually touched persistentData.” The counters were created to evaluate the payoff of changing the loop to process a "dirty-tag" queue.
* Now use `tagDidWork` per tag inside `updatePersistentData()`. Init the flag from `poppedRecently` (because `updatePersistentPopped()` writes state), and set it whenever we call into persistentData->set/clear, and only increment `tagsProcessedThisBatch` if the flag ends up true.

100K `20251016-154344-dlambrig-5a007a4b52ad7862`

100K (rebase) `20251016-225145-dlambrig-aea03e0804cfe648`

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
