### PR TITLE
Cherry pick PR 12427 and PR 12468 Counters for dirty tags in TLogServer

### DIFF
--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -1037,7 +1037,8 @@ ACTOR Future<Void> updatePersistentData(TLogData* self, Reference<LogData> logDa
 		for (tagId = 0; tagId < logData->tag_data[tagLocality].size(); tagId++) {
 			state Reference<LogData::TagData> tagData = logData->tag_data[tagLocality][tagId];
 			if (tagData) {
-				tagsProcessedThisBatch++;
+				// poppedRecently implies updatePersistentPopped() will touch persistentData
+				state bool tagDidWork = tagData->poppedRecently;
 				wait(tagData->eraseMessagesBefore(tagData->popped, self, logData, TaskPriority::UpdateStorage));
 				state Version currentVersion = 0;
 				// Clear recently popped versions from persistentData if necessary
@@ -1063,6 +1064,7 @@ ACTOR Future<Void> updatePersistentData(TLogData* self, Reference<LogData> logDa
 						}
 						self->persistentData->set(KeyValueRef(
 						    persistTagMessagesKey(logData->logId, tagData->tag, currentVersion), wr.toValue()));
+						tagDidWork = true;
 					} else {
 						// spill everything else by reference
 						const IDiskQueue::location begin = logData->versionLocation[currentVersion].first;
@@ -1088,6 +1090,7 @@ ACTOR Future<Void> updatePersistentData(TLogData* self, Reference<LogData> logDa
 							*(uint32_t*)wr.getData() = refSpilledTagCount;
 							self->persistentData->set(KeyValueRef(
 							    persistTagMessageRefsKey(logData->logId, tagData->tag, lastVersion), wr.toValue()));
+							tagDidWork = true;
 							tagData->poppedLocation = std::min(tagData->poppedLocation, firstLocation);
 							refSpilledTagCount = 0;
 							wr = BinaryWriter(AssumeVersion(logData->protocolVersion));
@@ -1109,10 +1112,15 @@ ACTOR Future<Void> updatePersistentData(TLogData* self, Reference<LogData> logDa
 					*(uint32_t*)wr.getData() = refSpilledTagCount;
 					self->persistentData->set(
 					    KeyValueRef(persistTagMessageRefsKey(logData->logId, tagData->tag, lastVersion), wr.toValue()));
+					tagDidWork = true;
 					tagData->poppedLocation = std::min(tagData->poppedLocation, firstLocation);
 				}
 
 				wait(yield(TaskPriority::UpdateStorage));
+
+				if (tagDidWork) {
+					tagsProcessedThisBatch++;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Cherry pick PR 12427 counters for dirty tags in TLogServer
Cherry pick PR 12460 - Track temp tag message counts in TLogMetrics

100K `20251017-163600-dlambrig-ac1e18d231fa54fd  ` one failure in TestFile="tests/slow/VersionStampSwitchover.toml" which does not appear related.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
