### PR TITLE
Fix a bug where speedUpSimulation is not enabled

### DIFF
--- a/fdbrpc/include/fdbrpc/simulator.h
+++ b/fdbrpc/include/fdbrpc/simulator.h
@@ -54,6 +54,9 @@ struct MachineInfo;
 
 constexpr double DISABLE_CONNECTION_FAILURE_FOREVER = 1e6;
 
+// Minimum interval to disable connection failures. If less than this, connection failures are always disabled.
+constexpr double DISABLE_CONNECTION_FAILURE_MIN_INTERVAL = 1e-3;
+
 class ISimulator : public INetwork {
 
 public:

--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -2981,7 +2981,8 @@ void enableConnectionFailures(std::string const& context, double duration) {
 
 double disableConnectionFailures(std::string const& context, ForceDisable flag) {
 	if (g_network->isSimulated()) {
-		if (now() + 0.001 < g_simulator->connectionFailureDisableTime && flag == ForceDisable::False) {
+		if (now() + DISABLE_CONNECTION_FAILURE_MIN_INTERVAL < g_simulator->connectionFailureDisableTime &&
+		    flag == ForceDisable::False) {
 			TraceEvent(("DisableConnectionFailuresDelayed_" + context).c_str())
 			    .detail("Gap", g_simulator->connectionFailureDisableTime - now())
 			    .detail("Until", g_simulator->connectionFailureDisableTime);

--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -2651,9 +2651,11 @@ ACTOR Future<Void> disableConnectionFailuresAfter(double seconds, std::string co
 		wait(delay(seconds));
 		while (true) {
 			double delaySeconds = disableConnectionFailures(context, ForceDisable::False);
-			if (delaySeconds > 0.001) {
+			if (delaySeconds > DISABLE_CONNECTION_FAILURE_MIN_INTERVAL) {
 				wait(delay(delaySeconds));
 			} else {
+				// disableConnectionFailures will always take effect if less than
+				// DISABLE_CONNECTION_FAILURE_MIN_INTERVAL is returned.
 				break;
 			}
 		}


### PR DESCRIPTION
If the connectionFailureDisableTime is only slightly larger than now(), `disableConnectionFailures()` returns a small value such that `disableConnectionFailuresAfter()` is not retrying. As a result, clogging is still in place, and causes many test failures.

A typical symptom is that some transaction can't commit due to `transaction_too_old` errors. If we look closely, we'll find that there are many ProxyReject errors with QDelay > 5s. A failure I looked at has only one commit proxy and one resolver, and the latency between them is quite high:

```
5.494145 Sim2Connection Machine=2.0.2.1:2 ID=0000000000000000 From=2.0.2.1:2 To=2.0.2.2:2 SendBufSize=1736851 Latency=0.0292578 StableConnection=0
5.494145 Sim2Connection Machine=2.0.2.1:2 ID=0000000000000000 From=2.0.2.2:2 To=2.0.2.1:2 SendBufSize=510278 Latency=0.0158367 StableConnection=0
```

So after a while, all transactions got either transaction_too_old errors or ProxyReject'ed, because resolution took about 100ms on average.

To reproduce:

Commit: a3720567a247329e0a05756e79a7b7fcb37febb5

Seed: `-b on -f tests/fast/BackupCorrectnessWithEKPKeyFetchFailures.toml -s 2458961283`

 20251018-231050-jzhou-46db92d2b560f4d8             compressed=True data_size=37501442 duration=5074434 ended=100000 fail=1 fail_fast=10 max_runs=100000 pass=99999 priority=100 remaining=0 runtime=0:57:59 sanity=False started=100000 stopped=20251019-000849 submitted=20251018-231050 timeout=5400 username=jzhou

Failure is `-f ./tests/fast/BackupS3BlobCorrectness.toml -s 1985518187 -b off`, `TestFailure` due to `restore_invalid_version` error thrown from:
```
254.038495 FileBackupAgentRestoreNotPossible Machine=[abcd::3:4:3:4]:1 ID=0000000000000000 BackupContainer=blobstore://mocks3:mocksecret:mocktoken@127.0.0.1:8080/backup_container?bucket=backup_bucket&amp;region=us-east-1&amp;secure_connection=0&amp;cwpf=1&amp;cu=1 BeginVersion=-1 TargetVersion=-1 TS
```
This doesn't look like related to this PR.

To debug similar issues, look for these events:
```
20.560022 DisableConnectionFailures_Tester Machine=0.0.0.0:0 ID=0000000000000000
69.034127 EnableConnectionFailures_Tester Machine=0.0.0.0:0 ID=0000000000000000 Duration=450
69.034127 ScheduleDisableConnectionFailures_Tester Machine=0.0.0.0:0 ID=0000000000000000 At=519.034
519.034127 DisableConnectionFailuresDelayed_Tester Machine=0.0.0.0:0 ID=0000000000000000 Until=519.034
```

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
