### PR TITLE
Fix a bug where speedUpSimulation is not enabled [release-7.4]

### DIFF
--- a/fdbrpc/include/fdbrpc/simulator.h
+++ b/fdbrpc/include/fdbrpc/simulator.h
@@ -59,6 +59,9 @@ struct MachineInfo;
 
 constexpr double DISABLE_CONNECTION_FAILURE_FOREVER = 1e6;
 
+// Minimum interval to disable connection failures. If less than this, connection failures are always disabled.
+constexpr double DISABLE_CONNECTION_FAILURE_MIN_INTERVAL = 1e-3;
+
 class ISimulator : public INetwork {
 
 public:

--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -371,6 +371,8 @@ struct Sim2Conn final : IConnection, ReferenceCounted<Sim2Conn> {
 		}
 
 		TraceEvent("Sim2Connection")
+		    .detail("From", process->address)
+		    .detail("To", peerProcess->address)
 		    .detail("SendBufSize", sendBufSize)
 		    .detail("Latency", latency)
 		    .detail("StableConnection", stableConnection);
@@ -3029,11 +3031,14 @@ void enableConnectionFailures(std::string const& context, double duration) {
 
 double disableConnectionFailures(std::string const& context, ForceDisable flag) {
 	if (g_network->isSimulated()) {
-		if (now() < g_simulator->connectionFailureDisableTime && flag == ForceDisable::False) {
+		if (now() + DISABLE_CONNECTION_FAILURE_MIN_INTERVAL < g_simulator->connectionFailureDisableTime &&
+		    flag == ForceDisable::False) {
 			TraceEvent(("DisableConnectionFailuresDelayed_" + context).c_str())
+			    .detail("Gap", g_simulator->connectionFailureDisableTime - now())
 			    .detail("Until", g_simulator->connectionFailureDisableTime);
-			return g_simulator->connectionFailureDisableTime - now();
+			return g_simulator->connectionFailureDisableTime - now(); // return remaining time (>0.001s)
 		} else {
+			// if remaining time is less than 0.001s, or forced to disable, disable now
 			g_simulator->connectionFailuresDisableDuration = DISABLE_CONNECTION_FAILURE_FOREVER;
 			g_simulator->speedUpSimulation = true;
 			TraceEvent(SevWarnAlways, ("DisableConnectionFailures_" + context).c_str());

--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -2655,9 +2655,11 @@ ACTOR Future<Void> disableConnectionFailuresAfter(double seconds, std::string co
 		wait(delay(seconds));
 		while (true) {
 			double delaySeconds = disableConnectionFailures(context, ForceDisable::False);
-			if (delaySeconds > 0.001) {
+			if (delaySeconds > DISABLE_CONNECTION_FAILURE_MIN_INTERVAL) {
 				wait(delay(delaySeconds));
 			} else {
+				// disableConnectionFailures will always take effect if less than
+				// DISABLE_CONNECTION_FAILURE_MIN_INTERVAL is returned.
 				break;
 			}
 		}


### PR DESCRIPTION
cherrypick #12476 

20251020-205703-jzhou-e51312cd5a7ebd24             compressed=True data_size=40314038 duration=6072767 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:50:50 sanity=False started=100000 stopped=20251020-214753 submitted=20251020-205703 timeout=5400 username=jzhou

If the connectionFailureDisableTime is slightly larger than connectionFailureDisableTime, disableConnectionFailures returns a small value such that disableConnectionFailuresAfter() is not retrying. As a result, clogging is still in place, and cause many test failures.

A typical symptom is that some transaction can't commit due to transaction_too_old errors. If we look closely, we'll find that there are many ProxyReject errors with QDelay > 5s. A failure I looked at has only one commit proxy and one resolver, and the latency between them is quite high:

5.494145 Sim2Connection Machine=2.0.2.1:2 ID=0000000000000000 From=2.0.2.1:2 To=2.0.2.2:2 SendBufSize=1736851 Latency=0.0292578 StableConnection=0 5.494145 Sim2Connection Machine=2.0.2.1:2 ID=0000000000000000 From=2.0.2.2:2 To=2.0.2.1:2 SendBufSize=510278 Latency=0.0158367 StableConnection=0

So after a while, all transactions got either transaction_too_old errors or ProxyReject'ed, because resolution took about 100ms on average.

To reproduce:
Commit: a3720567a247329e0a05756e79a7b7fcb37febb5
Seed: -b on -f tests/fast/BackupCorrectnessWithEKPKeyFetchFailures.toml -s 2458961283



# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
