### PR TITLE
Recovery trigger observability

### DIFF
--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -297,15 +297,17 @@ ACTOR Future<Void> clusterWatchDatabase(ClusterControllerData* cluster,
 			// really don't want to have to start over
 			loop choose {
 				when(wait(recoveryCore)) {}
-				when(wait(waitFailureClient(
-				              iMaster.waitFailure,
-				              db->masterRegistrationCount
-				                  ? SERVER_KNOBS->MASTER_FAILURE_REACTION_TIME
-				                  : (now() - recoveryStart) * SERVER_KNOBS->MASTER_FAILURE_SLOPE_DURING_RECOVERY,
-				              db->masterRegistrationCount ? -SERVER_KNOBS->MASTER_FAILURE_REACTION_TIME /
-				                                                SERVER_KNOBS->SECONDS_BEFORE_NO_FAILURE_DELAY
-				                                          : SERVER_KNOBS->MASTER_FAILURE_SLOPE_DURING_RECOVERY) ||
-				          db->forceMasterFailure.onTrigger())) {
+				when(wait(
+				    traceAfter(waitFailureClient(
+				                   iMaster.waitFailure,
+				                   db->masterRegistrationCount
+				                       ? SERVER_KNOBS->MASTER_FAILURE_REACTION_TIME
+				                       : (now() - recoveryStart) * SERVER_KNOBS->MASTER_FAILURE_SLOPE_DURING_RECOVERY,
+				                   db->masterRegistrationCount ? -SERVER_KNOBS->MASTER_FAILURE_REACTION_TIME /
+				                                                     SERVER_KNOBS->SECONDS_BEFORE_NO_FAILURE_DELAY
+				                                               : SERVER_KNOBS->MASTER_FAILURE_SLOPE_DURING_RECOVERY),
+				               "CCWDBMasterFailed") ||
+				    traceAfter(db->forceMasterFailure.onTrigger(), "CCWDBForceMasterFailureTriggered"))) {
 					break;
 				}
 				when(wait(db->serverInfo->onChange())) {}

--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -475,33 +475,36 @@ ACTOR Future<Void> TagPartitionedLogSystem::onError_internal(TagPartitionedLogSy
 		for (auto& it : self->tLogs) {
 			for (auto& t : it->logServers) {
 				if (t->get().present()) {
-					failed.push_back(
-					    waitFailureClient(t->get().interf().waitFailure,
-					                      SERVER_KNOBS->TLOG_TIMEOUT,
-					                      -SERVER_KNOBS->TLOG_TIMEOUT / SERVER_KNOBS->SECONDS_BEFORE_NO_FAILURE_DELAY,
-					                      /*trace=*/true));
+					failed.push_back(waitFailureClient(t->get().interf().waitFailure,
+					                                   /* failureReactionTime */ SERVER_KNOBS->TLOG_TIMEOUT,
+					                                   /* failureReactionSlope */ -SERVER_KNOBS->TLOG_TIMEOUT /
+					                                       SERVER_KNOBS->SECONDS_BEFORE_NO_FAILURE_DELAY,
+					                                   /* trace */ true,
+					                                   /* traceMsg */ "TLogFailed"_sr));
 				} else {
 					changes.push_back(t->onChange());
 				}
 			}
 			for (auto& t : it->logRouters) {
 				if (t->get().present()) {
-					failed.push_back(
-					    waitFailureClient(t->get().interf().waitFailure,
-					                      SERVER_KNOBS->TLOG_TIMEOUT,
-					                      -SERVER_KNOBS->TLOG_TIMEOUT / SERVER_KNOBS->SECONDS_BEFORE_NO_FAILURE_DELAY,
-					                      /*trace=*/true));
+					failed.push_back(waitFailureClient(t->get().interf().waitFailure,
+					                                   /* failureReactionTime */ SERVER_KNOBS->TLOG_TIMEOUT,
+					                                   /* failureReactionSlope */ -SERVER_KNOBS->TLOG_TIMEOUT /
+					                                       SERVER_KNOBS->SECONDS_BEFORE_NO_FAILURE_DELAY,
+					                                   /* trace */ true,
+					                                   /* traceMsg */ "LogRouterFailed"_sr));
 				} else {
 					changes.push_back(t->onChange());
 				}
 			}
 			for (const auto& worker : it->backupWorkers) {
 				if (worker->get().present()) {
-					backupFailed.push_back(
-					    waitFailureClient(worker->get().interf().waitFailure,
-					                      SERVER_KNOBS->BACKUP_TIMEOUT,
-					                      -SERVER_KNOBS->BACKUP_TIMEOUT / SERVER_KNOBS->SECONDS_BEFORE_NO_FAILURE_DELAY,
-					                      /*trace=*/true));
+					backupFailed.push_back(waitFailureClient(worker->get().interf().waitFailure,
+					                                         /* failureReactionTime */ SERVER_KNOBS->BACKUP_TIMEOUT,
+					                                         /* failureReactionSlope */ -SERVER_KNOBS->BACKUP_TIMEOUT /
+					                                             SERVER_KNOBS->SECONDS_BEFORE_NO_FAILURE_DELAY,
+					                                         /* trace */ true,
+					                                         /* traceMsg */ "BackupWorkerFailed"_sr));
 				} else {
 					changes.push_back(worker->onChange());
 				}
@@ -514,10 +517,11 @@ ACTOR Future<Void> TagPartitionedLogSystem::onError_internal(TagPartitionedLogSy
 					for (auto& t : it->logRouters) {
 						if (t->get().present()) {
 							failed.push_back(waitFailureClient(t->get().interf().waitFailure,
-							                                   SERVER_KNOBS->TLOG_TIMEOUT,
-							                                   -SERVER_KNOBS->TLOG_TIMEOUT /
+							                                   /* failureReactionTime */ SERVER_KNOBS->TLOG_TIMEOUT,
+							                                   /* failureReactionSlope */ -SERVER_KNOBS->TLOG_TIMEOUT /
 							                                       SERVER_KNOBS->SECONDS_BEFORE_NO_FAILURE_DELAY,
-							                                   /*trace=*/true));
+							                                   /* trace */ true,
+							                                   /* traceMsg */ "OldLogRouterFailed"_sr));
 						} else {
 							changes.push_back(t->onChange());
 						}
@@ -526,11 +530,13 @@ ACTOR Future<Void> TagPartitionedLogSystem::onError_internal(TagPartitionedLogSy
 				// Monitor changes of backup workers for old epochs.
 				for (const auto& worker : old.tLogs[0]->backupWorkers) {
 					if (worker->get().present()) {
-						backupFailed.push_back(waitFailureClient(worker->get().interf().waitFailure,
-						                                         SERVER_KNOBS->BACKUP_TIMEOUT,
-						                                         -SERVER_KNOBS->BACKUP_TIMEOUT /
-						                                             SERVER_KNOBS->SECONDS_BEFORE_NO_FAILURE_DELAY,
-						                                         /*trace=*/true));
+						backupFailed.push_back(
+						    waitFailureClient(worker->get().interf().waitFailure,
+						                      /* failureReactionTime */ SERVER_KNOBS->BACKUP_TIMEOUT,
+						                      /* failureReactionSlope */ -SERVER_KNOBS->BACKUP_TIMEOUT /
+						                          SERVER_KNOBS->SECONDS_BEFORE_NO_FAILURE_DELAY,
+						                      /* trace */ true,
+						                      /* traceMsg */ "OldBackupWorkerFailed"_sr));
 					} else {
 						changes.push_back(worker->onChange());
 					}
@@ -546,8 +552,9 @@ ACTOR Future<Void> TagPartitionedLogSystem::onError_internal(TagPartitionedLogSy
 		changes.push_back(self->backupWorkerChanged.onTrigger());
 
 		ASSERT(failed.size() >= 1);
-		wait(quorum(changes, 1) || tagError<Void>(quorum(failed, 1), tlog_failed()) ||
-		     tagError<Void>(quorum(backupFailed, 1), backup_worker_failed()));
+		wait(quorum(changes, 1) ||
+		     tagError<Void>(traceAfter(quorum(failed, 1), "TPLSOnErrorLogSystemFailed"), tlog_failed()) ||
+		     tagError<Void>(traceAfter(quorum(backupFailed, 1), "TPLSOnErrorBackupFailed"), backup_worker_failed()));
 	}
 }
 

--- a/fdbserver/include/fdbserver/WaitFailure.h
+++ b/fdbserver/include/fdbserver/WaitFailure.h
@@ -32,6 +32,7 @@ Future<Void> waitFailureClient(const RequestStream<ReplyPromise<Void>>& waitFail
                                double const& failureReactionTime = 0,
                                double const& failureReactionSlope = 0,
                                bool const& trace = false,
+                               Optional<Standalone<StringRef>> const& traceMsg = Optional<Standalone<StringRef>>(),
                                TaskPriority const& taskID = TaskPriority::DefaultEndpoint);
 
 // talks to a wait failure server, returns Void on failure, reaction time is always waited


### PR DESCRIPTION
# Description

During a recent investigation, I noticed that our recovery trigger observability could be better. Specifically, if a role in the txn system fails, we don't print out what exactly failed e.g. LogRouter. This PR adds that  in addition to some other 
general observability in this space.

# Testing

100K: 20251030-185401-praza-recovery-trigger-obse-850068c246bc11b9 compressed=True data_size=37393390 duration=4486655 ended=100000 fail=1 fail_fast=10 max_runs=100000 pass=99999 priority=100 remaining=0 runtime=2:10:41 sanity=False started=100000 stopped=20251030-210442 submitted=20251030-185401 timeout=5400 username=praza-recovery-trigger-observability-a6f2647e440e34a87c7cd37c2eaf92bf6fd775fd. The 1 failure is in tests/rare/LargeApiCorrectness.toml and it's a timeout. Luckily, this PR should not change determinism of FDB, so I simply did the following:
- reproduced the issue with seed 1231968406
- noted down unseed 89205 and sev 40 errors
- reverted my change
- ran the test again with seed 1231968406
- ensured unseed is still 89205, implying this change does not change determinism
- looked at sev40s of this run, ensured it's the same issue
- therefore, this pr does not cause the issue

In addition, just for testing, I injected LR faults in ClogRemoteTLog workload [0], then ran the test, and observed:

```
$ fdbserver -r simulation -f /root/src/foundationdb/tests/rare/ClogRemoteTLog.toml --buggify off --seed 3961198004 --logsize 1GiB

....

$ grep -E "Type=\"Foo|Type=\"MasterRecoveryState|Type=\"CCWDB|WaitFailure|MasterRegistrationKill|BetterMasterExists|NewRecruitmentIsWorse|TPLSOnError" trace* | less

......
<Event Severity="10" Time="155.089260" DateTime="2025-10-30T18:08:56Z" Type="FooKillingLogRouterProcess" Machine="[abcd::3:4:3:2]:1" ID="0000000000000000" Process="[abcd::2:1:1:1]:1:tls" ThreadID="17170319412686298737" LogGroup="default" Roles="TS" />
<Event Severity="10" Time="155.089260" DateTime="2025-10-30T18:08:56Z" Type="FooKilledLogRouterProcess" Machine="[abcd::3:4:3:2]:1" ID="0000000000000000" Process="[abcd::2:1:1:1]:1:tls" ThreadID="17170319412686298737" LogGroup="default" Roles="TS" />
<Event Severity="10" Time="161.575472" DateTime="2025-10-30T18:08:57Z" Type="WaitFailureClient" Machine="[abcd::2:0:1:1]:1" ID="0000000000000000" FailedEndpoint="[abcd::2:1:1:1]:1:tls" Token="26b7ba979004ad51" ThreadID="17170319412686298737" LogGroup="default" Roles="BK,CC,CP,RV" />
<Event Severity="10" Time="161.575472" DateTime="2025-10-30T18:08:57Z" Type="CCWDB" Machine="[abcd::2:0:1:1]:1" ID="bc67fe2b4d077ab1" Error="tlog_failed" ErrorDescription="Cluster recovery terminating because a TLog failed" ErrorCode="1205" Master="2a1ea3131cce6d77" ThreadID="17170319412686298737" LogGroup="default" Roles="BK,CC,CP,RV" />
<Event Severity="10" Time="161.610472" DateTime="2025-10-30T18:08:57Z" Type="CCWDB" Machine="[abcd::2:0:1:1]:1" ID="bc67fe2b4d077ab1" ThreadID="17170319412686298737" LogGroup="default" Roles="BK,CC,CP,RV" />
.......
```

As it can be seen, we just get the generic "tlog_failed" message, not possible to know precisely what within log system failed. I reran the same test, this time with observability changes in this PR, and observed:

```
<Event Severity="10" Time="155.089260" DateTime="2025-10-30T18:21:10Z" Type="FooKillingLogRouterProcess" Machine="[abcd::3:4:3:2]:1" ID="0000000000000000" Process="[abcd::2:1:1:1]:1:tls" ThreadID="17170319412686298737" LogGroup="default" Roles="TS" />
<Event Severity="10" Time="155.089260" DateTime="2025-10-30T18:21:10Z" Type="FooKilledLogRouterProcess" Machine="[abcd::3:4:3:2]:1" ID="0000000000000000" Process="[abcd::2:1:1:1]:1:tls" ThreadID="17170319412686298737" LogGroup="default" Roles="TS" />
<Event Severity="10" Time="161.575472" DateTime="2025-10-30T18:21:10Z" Type="WaitFailureClient" Machine="[abcd::2:0:1:1]:1" ID="0000000000000000" FailedEndpoint="[abcd::2:1:1:1]:1:tls" Token="26b7ba979004ad51" Context="LogRouterFailed" ThreadID="17170319412686298737" LogGroup="default" Roles="BK,CC,CP,RV" />
<Event Severity="10" Time="161.575472" DateTime="2025-10-30T18:21:10Z" Type="TPLSOnErrorLogSystemFailed" Machine="[abcd::2:0:1:1]:1" ID="0000000000000000" ThreadID="17170319412686298737" LogGroup="default" Roles="BK,CC,CP,RV" />
<Event Severity="10" Time="161.575472" DateTime="2025-10-30T18:21:10Z" Type="CCWDBForceMasterFailureTriggered" Machine="[abcd::2:0:1:1]:1" ID="0000000000000000" Error="operation_cancelled" ErrorDescription="Asynchronous operation cancelled" ErrorCode="1101" ThreadID="17170319412686298737" LogGroup="default" Roles="BK,CC,CP,RV" />
<Event Severity="10" Time="161.575472" DateTime="2025-10-30T18:21:10Z" Type="CCWDBMasterFailed" Machine="[abcd::2:0:1:1]:1" ID="0000000000000000" Error="operation_cancelled" ErrorDescription="Asynchronous operation cancelled" ErrorCode="1101" ThreadID="17170319412686298737" LogGroup="default" Roles="BK,CC,CP,RV" />
<Event Severity="10" Time="161.575472" DateTime="2025-10-30T18:21:10Z" Type="CCWDB" Machine="[abcd::2:0:1:1]:1" ID="bc67fe2b4d077ab1" Error="tlog_failed" ErrorDescription="Cluster recovery terminating because a TLog failed" ErrorCode="1205" Master="2a1ea3131cce6d77" ThreadID="17170319412686298737" LogGroup="default" Roles="BK,CC,CP,RV" />
<Event Severity="10" Time="161.610472" DateTime="2025-10-30T18:21:10Z" Type="CCWDB" Machine="[abcd::2:0:1:1]:1" ID="bc67fe2b4d077ab1" ThreadID="17170319412686298737" LogGroup="default" Roles="BK,CC,CP,RV" />
<Event Severity="10" Time="161.610472" DateTime="2025-10-30T18:21:10Z" Type="CCWDB" Machine="[abcd::2:0:1:1]:1" ID="bc67fe2b4d077ab1" Recruiting="Master" ThreadID="17170319412686298737" LogGroup="default" Roles="BK,CC,CP,RV" />
```

As we can see, we get a nice LogRouterFailed message now. There's also a higher level TPLSOnErrorLogSystemFailed which is nice since there could be other high level reasons e.g. backup worker failing. 

[0]: 

```
commit bc12221944eeed562d81595a279a0629544b089a (HEAD -> recovery-trigger-observability-testing1)
Author: Syed Paymaan Raza <1238752+spraza@users.noreply.github.com>
Date:   Tue Oct 21 20:33:25 2025 -0700

    lr fault

diff --git a/fdbserver/workloads/ClogRemoteTLog.actor.cpp b/fdbserver/workloads/ClogRemoteTLog.actor.cpp
index 86a507297..06557dba4 100644
--- a/fdbserver/workloads/ClogRemoteTLog.actor.cpp
+++ b/fdbserver/workloads/ClogRemoteTLog.actor.cpp
@@ -370,13 +370,39 @@ struct ClogRemoteTLog : TestWorkload {
                return true;
        }

+       static Optional<NetworkAddress> getLogRouter(ClogRemoteTLog* self) {
+               for (const auto& tLogSet : self->dbInfo->get().logSystemConfig.tLogs) {
+                       if (tLogSet.isLocal) {
+                               continue;
+                       }
+                       for (const auto& lr : tLogSet.logRouters) {
+                               return lr.interf().address();
+                       }
+               }
+               TraceEvent("FooNeverReach");
+               return Optional<NetworkAddress>();
+       }
+
        ACTOR Future<Void> workload(ClogRemoteTLog* self, Database db) {
                state Future<Void> clog = self->clogRemoteTLog(self, db);
                state TestState testState = TestState::TEST_INIT;
                self->actualStatePath.push_back(testState);
                state bool statusCheckPassed = false;
+               state bool didKill = false;
                loop {
                        wait(delay(self->lagMeasurementFrequency));
+                       if (!didKill && now() > 150) {
+                               Optional<NetworkAddress> logRouter = getLogRouter(self);
+                               if (logRouter.present()) {
+                                       ISimulator::ProcessInfo* process = g_simulator->getProcessByAddress(logRouter.get());
+                                       TraceEvent("FooKillingLogRouterProcess").detail("Process", logRouter.get());
+                                       g_simulator->killProcess(process, ISimulator::KillType::KillInstantly);
+                                       TraceEvent("FooKilledLogRouterProcess").detail("Process", logRouter.get());
+                                       didKill = true;
+                               } else {
+                                       TraceEvent("FooNotKillLogRouterNotPresent");
+                               }
+                       }
                        Optional<double> ssLag = wait(measureMaxSSLag(self, db));
                        if (!ssLag.present()) {
                                continue;
```

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
