### PR TITLE
gen_compile_db: use raw string for regex to suppress SyntaxWarning

### DIFF
--- a/contrib/gen_compile_db.py
+++ b/contrib/gen_compile_db.py
@@ -19,7 +19,7 @@ def rreplace(s, old, new, occurrence=1):
 
 
 def actorCommand(cmd: str, build: str, src: str):
-    r1 = re.compile("-c (.+)(actor\.g\.cpp)")
+    r1 = re.compile(r"-c (.+)(actor\.g\.cpp)")
     m1 = r1.search(cmd)
     if m1 is None:
         return cmd


### PR DESCRIPTION
```
❯ ninja -v processed_compile_commands
[0/2] /usr/bin/cmake -P /home/zhscn/project/foundationdb/build/CMakeFiles/VerifyGlobs.cmake
[1/2] cd /home/zhscn/project/foundationdb/build && /usr/bin/python3.13 /home/zhscn/project/foundationdb/contrib/gen_compile_db.py -b /home/zhscn/project/foundationdb/build -s /home/zhscn/project/foundationdb -o /home/zhscn/project/foundationdb/compile_commands.json -ninjatool /usr/bin/ninja-build /home/zhscn/project/foundationdb/build/compile_commands.json
/home/zhscn/project/foundationdb/contrib/gen_compile_db.py:22: SyntaxWarning: invalid escape sequence '\.'
  r1 = re.compile("-c (.+)(actor\.g\.cpp)")
transform /home/zhscn/project/foundationdb/build/compile_commands.json with build directory /home/zhscn/project/foundationdb/build
aquiring Swift compile commands using /usr/bin/ninja-build
```
Use raw string to suppress this warning.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
