### PR TITLE
Fix lambda closure bug in bindingtester's test generator

### DIFF
--- a/contrib/local_cluster/binding_test.py
+++ b/contrib/local_cluster/binding_test.py
@@ -305,9 +305,12 @@ def _generate_test_list(test_set: TestSet, api_languages: List[str] = API_LANGUA
         test_set.run_directory_test,
         test_set.run_directory_hca_test,
     ]
-    return [
-        lambda: test(api_language) for test in tests for api_language in api_languages
-    ]
+
+    result = []
+    for test in tests:
+        for api_language in api_languages:
+            result.append(lambda lang=api_language: test(lang))
+    return result
 
 
 async def run_binding_tests(


### PR DESCRIPTION
The lambdas created in _generate_test_list were capturing the api_language variable by reference rather than by value. This caused all generated test lambdas to use the last value in the loop (typically "flow"), resulting in only Flow binding tests being executed instead of every known language bindings.

Fixed by using a default parameter (lang=api_language) to capture the current loop variable value in each lambda closure.

Joshua (bindingtester):

20251022-082207-vishesh-d6dcbc250ce0aadf

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
