### PR TITLE
FdbDecode memory issues fix

### DIFF
--- a/fdbclient/S3BlobStore.actor.cpp
+++ b/fdbclient/S3BlobStore.actor.cpp
@@ -73,8 +73,6 @@ S3BlobStoreEndpoint::Stats S3BlobStoreEndpoint::Stats::operator-(const Stats& rh
 }
 
 S3BlobStoreEndpoint::Stats S3BlobStoreEndpoint::s_stats;
-std::unique_ptr<S3BlobStoreEndpoint::BlobStats> S3BlobStoreEndpoint::blobStats;
-Future<Void> S3BlobStoreEndpoint::statsLogger = Never();
 
 std::unordered_map<BlobStoreConnectionPoolKey, Reference<S3BlobStoreEndpoint::ConnectionPoolData>>
     S3BlobStoreEndpoint::globalConnectionPool;

--- a/fdbclient/include/fdbclient/S3BlobStore.h
+++ b/fdbclient/include/fdbclient/S3BlobStore.h
@@ -110,8 +110,8 @@ public:
 		                   CLIENT_KNOBS->BLOBSTORE_LATENCY_LOGGING_ACCURACY) {}
 	};
 	// null when initialized, so no blob stats until a blob connection is used
-	static std::unique_ptr<BlobStats> blobStats;
-	static Future<Void> statsLogger;
+	std::unique_ptr<BlobStats> blobStats;
+	Future<Void> statsLogger;
 
 	void maybeStartStatsLogger() {
 		if (!blobStats && CLIENT_KNOBS->BLOBSTORE_ENABLE_LOGGING) {


### PR DESCRIPTION
cherry-pick of #12456 

**FdbDecode memory issues fix.**
The fdbdecode command was throwing memory-related errors such as:
double free or corruption (!prev), free(): invalid pointer, munmap_chunk(): invalid pointer, Segmentation fault
These errors occurred only during the program’s shutdown phase, after all decoding work was completed. They did not affect the correctness of the decoded key–value output.

**Root Cause**
Valgrind analysis revealed that the crashes were caused by static object destruction order issues, leading to use-after-free and double-free situations.
**Issue 1:** EventCacheHolder
A static EventCacheHolder instance invoked clear() during its destruction, which accessed a LatestEventCache object that had already been destroyed.
**Issue 2**: BlobStats
Another static variable, BlobStats, owned an EventCacheHolder instance. During shutdown, its destruction triggered the same invalid access pattern described above.

```
==40744== Invalid read of size 2
==40744==    at 0x14571E4: operator< (NetworkAddress.h:64)
==40744==    by 0x14571E4: operator() (stl_function.h:400)
==40744==    by 0x14571E4: _M_lower_bound (stl_tree.h:1905)
==40744==    by 0x14571E4: lower_bound (stl_tree.h:1270)
==40744==    by 0x14571E4: lower_bound (stl_map.h:1259)
==40744==    by 0x14571E4: operator[] (stl_map.h:517)
==40744==    by 0x14571E4: LatestEventCache::clear(std::string const&) (Trace.cpp:632)
==40744==    by 0x1243F58: ~EventCacheHolder (Trace.h:524)
==40744==    by 0x1243F58: delref (FastRef.h:70)
==40744==    by 0x1243F58: delref<EventCacheHolder> (FastRef.h:95)
==40744==    by 0x1243F58: ~Reference (FastRef.h:126)
==40744==    by 0x1243F58: CounterCollectionImpl::TraceCountersActorState<CounterCollectionImpl::TraceCountersActor>::~TraceCountersActorState() (Stats.actor.g.cpp:162)
==40744==    by 0x1244270: a_body1Catch1 (Stats.actor.g.cpp:188)
==40744==    by 0x1244270: CounterCollectionImpl::TraceCountersActorState<CounterCollectionImpl::TraceCountersActor>::a_callback_error(ActorCallback<CounterCollectionImpl::TraceCountersActor, 1, Void>*, Error) (Stats.actor.g.cpp:417)
==40744==    by 0x69691E: delFutureRef (flow.h:866)
==40744==    by 0x69691E: delFutureRef (flow.h:863)
==40744==    by 0x69691E: Future<Void>::~Future() (flow.h:948)
==40744==    by 0x498A2DC: __run_exit_handlers (in /usr/lib64/libc.so.6)
==40744==    by 0x498A42F: exit (in /usr/lib64/libc.so.6)
==40744==    by 0x49725D6: (below main) (in /usr/lib64/libc.so.6)

```

```
==40744== Invalid read of size 8
==40744==    at 0x1452988: _M_lower_bound (stl_tree.h:1904)
==40744==    by 0x1452988: lower_bound (stl_tree.h:1270)
==40744==    by 0x1452988: lower_bound (stl_map.h:1259)
==40744==    by 0x1452988: clearPrefix_internal(std::map<std::string, TraceEventFields, std::less<std::string>, std::allocator<std::pair<std::string const, TraceEventFields> > >&, std::string const&) (Trace.cpp:627)
==40744==    by 0x1457232: LatestEventCache::clear(std::string const&) (Trace.cpp:632)
==40744==    by 0xE91777: ~EventCacheHolder (Trace.h:524)
==40744==    by 0xE91777: delref (FastRef.h:70)
==40744==    by 0xE91777: delref<EventCacheHolder> (FastRef.h:95)
==40744==    by 0xE91777: ~Reference (FastRef.h:126)
==40744==    by 0xE91777: ~LatencySample (Stats.h:227)
==40744==    by 0xE91777: ~BlobStats (S3BlobStore.h:88)
==40744==    by 0xE91777: operator() (unique_ptr.h:85)
==40744==    by 0xE91777: std::unique_ptr<S3BlobStoreEndpoint::BlobStats, std::default_delete<S3BlobStoreEndpoint::BlobStats> >::~unique_ptr() (unique_ptr.h:361)
==40744==    by 0x498A2DC: __run_exit_handlers (in /usr/lib64/libc.so.6)
==40744==    by 0x498A42F: exit (in /usr/lib64/libc.so.6)
==40744==    by 0x49725D6: (below main) (in /usr/lib64/libc.so.6)
```