### PR TITLE
Fix unseed mismatch in newly added tests

### DIFF
--- a/fdbserver/workloads/UnitTests.actor.cpp
+++ b/fdbserver/workloads/UnitTests.actor.cpp
@@ -205,7 +205,8 @@ struct UnitTestWorkload : TestWorkload {
 			TraceEvent(SevInfo, "RunningUnitTest")
 			    .detail("Name", test->name)
 			    .detail("File", test->file)
-			    .detail("Line", test->line);
+			    .detail("Line", test->line)
+			    .detail("Rand", deterministicRandom()->randomInt(0, 100001));
 
 			state Error result = success();
 			state double start_now = now();

--- a/flow/IThreadPoolTest.actor.cpp
+++ b/flow/IThreadPoolTest.actor.cpp
@@ -192,6 +192,8 @@ Reference<IThreadPool> initTestPool() {
 // See the comments within ThreadPool::stop() for more details.
 
 TEST_CASE("/flow/IThreadPool/ExplicitStop") {
+	noUnseed = true;
+
 	state Reference<IThreadPool> pool = initTestPool();
 	auto task = new MockTask();
 	auto future = task->promise.getFuture();
@@ -202,6 +204,8 @@ TEST_CASE("/flow/IThreadPool/ExplicitStop") {
 }
 
 TEST_CASE("/flow/IThreadPool/ImplicitStop") {
+	noUnseed = true;
+
 	state Reference<IThreadPool> pool = initTestPool();
 	auto task = new MockTask();
 	auto future = task->promise.getFuture();


### PR DESCRIPTION
/flow/IThreadPool/ tests are non-deterministic.

Seed: -f tests/fast/RandomUnitTests.toml -s 2889898182 -b on
commit: 841e1e1b478c649dd5b5bb690cd3be00b8707409

20251023-203307-jzhou-665416532ac612b1             compressed=True data_size=37337022 duration=5719515 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:59:31 sanity=False started=100000 stopped=20251023-213238 submitted=20251023-203307 timeout=5400 username=jzhou

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
