### PR TITLE
Version vector feature specific: add a counter to capture the unknown committed version count

### DIFF
--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -575,7 +575,6 @@ struct LogData : NonCopyable, public ReferenceCounted<LogData> {
 	Counter nonEmptyPeeks;
 	Counter persistentDataUpdateBatches;
 	Counter dirtyTagsProcessed;
-	Counter unknownCommittedVersionCount;
 	std::map<Tag, LatencySample> blockingPeekLatencies;
 	std::map<Tag, LatencySample> peekVersionCounts;
 
@@ -670,13 +669,12 @@ struct LogData : NonCopyable, public ReferenceCounted<LogData> {
 	    blockingPeeks("BlockingPeeks", cc), blockingPeekTimeouts("BlockingPeekTimeouts", cc),
 	    emptyPeeks("EmptyPeeks", cc), nonEmptyPeeks("NonEmptyPeeks", cc),
 	    persistentDataUpdateBatches("PersistentDataUpdateBatches", cc), dirtyTagsProcessed("DirtyTagsProcessed", cc),
-	    unknownCommittedVersionCount("UnknownCommittedVersionCount", cc), logId(interf.id()),
-	    protocolVersion(protocolVersion), newPersistentDataVersion(invalidVersion), tLogData(tLogData),
-	    unrecoveredBefore(1), recoveredAt(1), recoveryTxnVersion(1), logSystem(new AsyncVar<Reference<ILogSystem>>()),
-	    remoteTag(remoteTag), isPrimary(isPrimary), logRouterTags(logRouterTags), logRouterPoppedVersion(0),
-	    logRouterPopToVersion(0), locality(tagLocalityInvalid), recruitmentID(recruitmentID),
-	    logSpillType(logSpillType), allTags(tags.begin(), tags.end()), terminated(tLogData->terminated.getFuture()),
-	    execOpCommitInProgress(false), txsTags(txsTags) {
+	    logId(interf.id()), protocolVersion(protocolVersion), newPersistentDataVersion(invalidVersion),
+	    tLogData(tLogData), unrecoveredBefore(1), recoveredAt(1), recoveryTxnVersion(1),
+	    logSystem(new AsyncVar<Reference<ILogSystem>>()), remoteTag(remoteTag), isPrimary(isPrimary),
+	    logRouterTags(logRouterTags), logRouterPoppedVersion(0), logRouterPopToVersion(0), locality(tagLocalityInvalid),
+	    recruitmentID(recruitmentID), logSpillType(logSpillType), allTags(tags.begin(), tags.end()),
+	    terminated(tLogData->terminated.getFuture()), execOpCommitInProgress(false), txsTags(txsTags) {
 		startRole(Role::TRANSACTION_LOG,
 		          interf.id(),
 		          tLogData->workerID,
@@ -709,6 +707,7 @@ struct LogData : NonCopyable, public ReferenceCounted<LogData> {
 		specialCounter(cc, "PeekMemoryRequestsStalled", [tLogData]() { return tLogData->peekMemoryLimiter.waiters(); });
 		specialCounter(cc, "Generation", [this]() { return this->recoveryCount; });
 		specialCounter(cc, "ActivePeekStreams", [tLogData]() { return tLogData->activePeekStreams; });
+		specialCounter(cc, "UnknownCommittedVersionCount", [this]() { return this->unknownCommittedVersions.size(); });
 	}
 
 	~LogData() {


### PR DESCRIPTION
Add a counter to capture the number of unknown committed versions on a tLog.

Testing:

Ran a simulation test in okteto and verified that the counter is getting populated by checking the counter's value in the output metrics.

Joshua id (with version vector disabled): 20251030-200123-sre-f1042f3a2bbe436a  (shows a failure in "fast/FuzzApiCorrectnessClean.toml", it is unlikely to be related to this change)

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
