### PR TITLE
Require Swift compiler to be at-least 6.1 in build

### DIFF
--- a/cmake/FDBComponents.cmake
+++ b/cmake/FDBComponents.cmake
@@ -162,7 +162,29 @@ if(NOT BUILD_SWIFT_BINDING OR NOT BUILD_C_BINDING OR OPEN_FOR_IDE)
 else()
   find_program(SWIFT_EXECUTABLE swift)
   if(SWIFT_EXECUTABLE AND CMAKE_Swift_COMPILER)
-    set(WITH_SWIFT_BINDING ON)
+    # Check Swift version - require 6.1 or higher
+    execute_process(
+      COMMAND ${SWIFT_EXECUTABLE} --version
+      OUTPUT_VARIABLE SWIFT_VERSION_OUTPUT
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    string(REGEX MATCH "Swift version ([0-9]+)\\.([0-9]+)" SWIFT_VERSION_MATCH "${SWIFT_VERSION_OUTPUT}")
+    if(SWIFT_VERSION_MATCH)
+      set(SWIFT_VERSION_MAJOR ${CMAKE_MATCH_1})
+      set(SWIFT_VERSION_MINOR ${CMAKE_MATCH_2})
+      set(SWIFT_VERSION "${SWIFT_VERSION_MAJOR}.${SWIFT_VERSION_MINOR}")
+      message(STATUS "Found Swift version ${SWIFT_VERSION}")
+
+      if(SWIFT_VERSION_MAJOR LESS 6 OR (SWIFT_VERSION_MAJOR EQUAL 6 AND SWIFT_VERSION_MINOR LESS 1))
+        message(STATUS "Swift bindings require Swift 6.1 or higher (found ${SWIFT_VERSION})")
+        set(WITH_SWIFT_BINDING OFF)
+      else()
+        set(WITH_SWIFT_BINDING ON)
+      endif()
+    else()
+      message(STATUS "Could not determine Swift version")
+      set(WITH_SWIFT_BINDING OFF)
+    endif()
   else()
     set(WITH_SWIFT_BINDING OFF)
   endif()


### PR DESCRIPTION
Mac CI is still running on Venture and is failing. 

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
