### PR TITLE
Splunk dashboards: add nullValueMode=connect to charts and version=1.…

### DIFF
--- a/contrib/observability_splunk_dashboard/details.xml
+++ b/contrib/observability_splunk_dashboard/details.xml
@@ -1,4 +1,4 @@
-<form theme="light">
+<form version="1.1" theme="light">
   <label>FoundationDB - Details</label>
   <description>Details for FoundationDB Cluster</description>
   <fieldset submitButton="false">
@@ -62,6 +62,7 @@
           <latest>$TimeRange.latest$</latest>
         </search>
         <option name="charting.chart">line</option>
+        <option name="charting.chart.nullValueMode">connect</option>
         <option name="charting.drilldown">none</option>
         <option name="refresh.display">progressbar</option>
       </chart>
@@ -75,6 +76,7 @@
           <latest>$TimeRange.latest$</latest>
         </search>
         <option name="charting.chart">line</option>
+        <option name="charting.chart.nullValueMode">connect</option>
         <option name="charting.drilldown">none</option>
         <option name="refresh.display">progressbar</option>
       </chart>
@@ -88,6 +90,7 @@
           <latest>$TimeRange.latest$</latest>
         </search>
         <option name="charting.chart">line</option>
+        <option name="charting.chart.nullValueMode">connect</option>
         <option name="charting.drilldown">none</option>
         <option name="refresh.display">progressbar</option>
       </chart>
@@ -104,6 +107,7 @@
         </search>
         <option name="charting.axisY.maximumNumber">2</option>
         <option name="charting.chart">line</option>
+        <option name="charting.chart.nullValueMode">connect</option>
         <option name="charting.drilldown">none</option>
         <option name="refresh.display">progressbar</option>
       </chart>
@@ -118,6 +122,7 @@
         </search>
         <option name="charting.axisY.maximumNumber">2</option>
         <option name="charting.chart">line</option>
+        <option name="charting.chart.nullValueMode">connect</option>
         <option name="charting.drilldown">none</option>
         <option name="refresh.display">progressbar</option>
       </chart>
@@ -131,6 +136,7 @@
           <latest>$TimeRange.latest$</latest>
         </search>
         <option name="charting.chart">line</option>
+        <option name="charting.chart.nullValueMode">connect</option>
         <option name="charting.drilldown">none</option>
         <option name="refresh.display">progressbar</option>
       </chart>
@@ -146,6 +152,7 @@
           <latest>$TimeRange.latest$</latest>
         </search>
         <option name="charting.chart">line</option>
+        <option name="charting.chart.nullValueMode">connect</option>
         <option name="charting.drilldown">none</option>
         <option name="refresh.display">progressbar</option>
       </chart>
@@ -159,6 +166,7 @@
           <latest>$TimeRange.latest$</latest>
         </search>
         <option name="charting.chart">line</option>
+        <option name="charting.chart.nullValueMode">connect</option>
         <option name="charting.drilldown">none</option>
         <option name="refresh.display">progressbar</option>
       </chart>
@@ -172,6 +180,7 @@
           <latest>$TimeRange.latest$</latest>
         </search>
         <option name="charting.chart">line</option>
+        <option name="charting.chart.nullValueMode">connect</option>
         <option name="charting.drilldown">none</option>
         <option name="refresh.display">progressbar</option>
       </chart>
@@ -196,19 +205,19 @@
       <chart>
         <title>Pairwise Connection Timeouts Between Datacenters</title>
         <search>
-          <query>index=$Index$ LogGroup=$LogGroup$ (Type=ConnectionTimeout OR Type=ConnectionTimedOut)  host=* Machine=* NOT TrackLatestType=Rolled 
-| eval WithAddr=if(Type=="ConnectionTimedOut", PeerAddr, WithAddr) 
-| rex field=host "(?&lt;Datacenter&gt;..).*" 
-| eval Datacenter=if(isnotnull(pie_work_unit), pie_work_unit, Datacenter) 
-| rex field=WithAddr "(?&lt;OtherIP&gt;[^:]*):.*" 
-| join OtherIP 
-    [search index=$Index$ LogGroup=$LogGroup$ Type=ProcessMetrics NOT TrackLatestType=Rolled 
-    | rex field=Machine "(?&lt;OtherIP&gt;[^:]*):.*" 
+          <query>index=$Index$ LogGroup=$LogGroup$ (Type=ConnectionTimeout OR Type=ConnectionTimedOut)  host=* Machine=* NOT TrackLatestType=Rolled
+| eval WithAddr=if(Type=="ConnectionTimedOut", PeerAddr, WithAddr)
+| rex field=host "(?&lt;Datacenter&gt;..).*"
+| eval Datacenter=if(isnotnull(pie_work_unit), pie_work_unit, Datacenter)
+| rex field=WithAddr "(?&lt;OtherIP&gt;[^:]*):.*"
+| join OtherIP
+    [search index=$Index$ LogGroup=$LogGroup$ Type=ProcessMetrics NOT TrackLatestType=Rolled
+    | rex field=Machine "(?&lt;OtherIP&gt;[^:]*):.*"
     | rex field=host "(?&lt;OtherDatacenter&gt;..).*"
     | eval OtherDatacenter=if(isnotnull(pie_work_unit), pie_work_unit, OtherDatacenter)]
-| eval DC1=if(Datacenter&gt;OtherDatacenter, Datacenter, OtherDatacenter), DC2=if(Datacenter&gt;OtherDatacenter, OtherDatacenter, Datacenter) 
-| eval Connection=DC1+" &lt;-&gt; " + DC2 
-| eval Count=1+SuppressedEventCount 
+| eval DC1=if(Datacenter&gt;OtherDatacenter, Datacenter, OtherDatacenter), DC2=if(Datacenter&gt;OtherDatacenter, OtherDatacenter, Datacenter)
+| eval Connection=DC1+" &lt;-&gt; " + DC2
+| eval Count=1+SuppressedEventCount
 | timechart count by Connection</query>
           <earliest>$TimeRange.earliest$</earliest>
           <latest>$TimeRange.latest$</latest>
@@ -242,6 +251,7 @@
           <latest>$TimeRange.latest$</latest>
         </search>
         <option name="charting.chart">line</option>
+        <option name="charting.chart.nullValueMode">connect</option>
         <option name="charting.drilldown">none</option>
         <option name="refresh.display">progressbar</option>
       </chart>
@@ -255,6 +265,7 @@
           <latest>$TimeRange.latest$</latest>
         </search>
         <option name="charting.chart">line</option>
+        <option name="charting.chart.nullValueMode">connect</option>
         <option name="charting.drilldown">none</option>
         <option name="refresh.display">progressbar</option>
       </chart>
@@ -269,6 +280,7 @@
         </search>
         <option name="charting.axisY.scale">log</option>
         <option name="charting.chart">line</option>
+        <option name="charting.chart.nullValueMode">connect</option>
         <option name="charting.drilldown">none</option>
         <option name="refresh.display">progressbar</option>
       </chart>
@@ -350,6 +362,7 @@
         </search>
         <option name="charting.axisY.maximumNumber">1</option>
         <option name="charting.chart">line</option>
+        <option name="charting.chart.nullValueMode">connect</option>
         <option name="charting.drilldown">none</option>
         <option name="refresh.display">progressbar</option>
       </chart>
@@ -396,6 +409,7 @@
         </search>
         <option name="charting.axisY.scale">log</option>
         <option name="charting.chart">line</option>
+        <option name="charting.chart.nullValueMode">connect</option>
         <option name="charting.drilldown">none</option>
         <option name="refresh.display">progressbar</option>
       </chart>
@@ -409,6 +423,7 @@
           <latest>$TimeRange.latest$</latest>
         </search>
         <option name="charting.chart">line</option>
+        <option name="charting.chart.nullValueMode">connect</option>
         <option name="charting.drilldown">none</option>
         <option name="refresh.display">progressbar</option>
       </chart>

--- a/contrib/observability_splunk_dashboard/performance_overview.xml
+++ b/contrib/observability_splunk_dashboard/performance_overview.xml
@@ -1,4 +1,4 @@
-<form theme="dark">
+<form version="1.1" theme="dark">
   <label>FoundationDB - Performance Overview (Dev WiP)</label>
   <fieldset submitButton="false" autoRun="true">
     <input type="text" token="Index" searchWhenChanged="true">
@@ -41,6 +41,7 @@
           <latest>$TimeSpan.latest$</latest>
         </search>
         <option name="charting.chart">line</option>
+        <option name="charting.chart.nullValueMode">connect</option>
         <option name="charting.drilldown">none</option>
         <option name="refresh.display">progressbar</option>
       </chart>
@@ -61,6 +62,7 @@
         </search>
         <option name="charting.axisY.scale">linear</option>
         <option name="charting.chart">line</option>
+        <option name="charting.chart.nullValueMode">connect</option>
         <option name="charting.drilldown">none</option>
         <option name="refresh.display">progressbar</option>
       </chart>
@@ -86,6 +88,7 @@
         <option name="charting.axisY.abbreviation">none</option>
         <option name="charting.axisY.scale">linear</option>
         <option name="charting.chart">line</option>
+        <option name="charting.chart.nullValueMode">connect</option>
         <option name="charting.drilldown">none</option>
         <option name="charting.layout.splitSeries">0</option>
         <option name="refresh.display">progressbar</option>
@@ -103,6 +106,7 @@
           <latest>$TimeSpan.latest$</latest>
         </search>
         <option name="charting.chart">line</option>
+        <option name="charting.chart.nullValueMode">connect</option>
         <option name="charting.drilldown">none</option>
         <option name="refresh.display">progressbar</option>
       </chart>
@@ -120,6 +124,7 @@
           <latest>$TimeSpan.latest$</latest>
         </search>
         <option name="charting.chart">line</option>
+        <option name="charting.chart.nullValueMode">connect</option>
         <option name="charting.drilldown">none</option>
         <option name="charting.legend.placement">bottom</option>
         <option name="refresh.display">progressbar</option>
@@ -136,6 +141,7 @@
           <latest>$TimeSpan.latest$</latest>
         </search>
         <option name="charting.chart">line</option>
+        <option name="charting.chart.nullValueMode">connect</option>
         <option name="charting.drilldown">none</option>
         <option name="charting.legend.placement">bottom</option>
         <option name="refresh.display">progressbar</option>
@@ -152,6 +158,7 @@
           <latest>$TimeSpan.latest$</latest>
         </search>
         <option name="charting.chart">line</option>
+        <option name="charting.chart.nullValueMode">connect</option>
         <option name="charting.drilldown">none</option>
         <option name="charting.legend.placement">bottom</option>
         <option name="refresh.display">progressbar</option>
@@ -173,6 +180,7 @@
         </search>
         <option name="charting.axisY.scale">log</option>
         <option name="charting.chart">line</option>
+        <option name="charting.chart.nullValueMode">connect</option>
         <option name="charting.drilldown">none</option>
         <option name="height">251</option>
         <option name="refresh.display">progressbar</option>
@@ -193,6 +201,7 @@
         <option name="charting.axisY.abbreviation">none</option>
         <option name="charting.axisY.scale">linear</option>
         <option name="charting.chart">area</option>
+        <option name="charting.chart.nullValueMode">connect</option>
         <option name="charting.drilldown">none</option>
         <option name="charting.legend.mode">standard</option>
         <option name="height">249</option>
@@ -233,6 +242,7 @@
         </search>
         <option name="charting.axisY.maximumNumber">10</option>
         <option name="charting.chart">line</option>
+        <option name="charting.chart.nullValueMode">connect</option>
         <option name="charting.drilldown">none</option>
         <option name="charting.legend.placement">bottom</option>
       </chart>
@@ -249,6 +259,7 @@ Roles=*DD* host=* Machine=*  Type=DDTrackerStats TrackLatestType=Original
           <latest>$TimeSpan.latest$</latest>
         </search>
         <option name="charting.chart">line</option>
+        <option name="charting.chart.nullValueMode">connect</option>
         <option name="charting.drilldown">none</option>
         <option name="charting.legend.placement">bottom</option>
         <option name="refresh.display">progressbar</option>
@@ -267,6 +278,7 @@ Roles=*DD* host=* Machine=*  Type=DDTrackerStats TrackLatestType=Original
           <latest>$TimeSpan.latest$</latest>
         </search>
         <option name="charting.chart">line</option>
+        <option name="charting.chart.nullValueMode">connect</option>
         <option name="charting.drilldown">none</option>
         <option name="charting.legend.placement">bottom</option>
         <option name="refresh.display">progressbar</option>
@@ -315,6 +327,7 @@ Roles=*DD* host=* Machine=*  Type=DDTrackerStats TrackLatestType=Original
           <latest>$TimeSpan.latest$</latest>
         </search>
         <option name="charting.chart">line</option>
+        <option name="charting.chart.nullValueMode">connect</option>
         <option name="charting.drilldown">none</option>
         <option name="refresh.display">progressbar</option>
       </chart>

--- a/contrib/observability_splunk_dashboard/ratekeeper.xml
+++ b/contrib/observability_splunk_dashboard/ratekeeper.xml
@@ -1,4 +1,4 @@
-<form theme="dark">
+<form version="1.1" theme="dark">
   <label>FoundationDB - RateKeeper (Dev)</label>
   <fieldset submitButton="false">
     <input type="text" token="Index" searchWhenChanged="true">

--- a/contrib/observability_splunk_dashboard/recovery.xml
+++ b/contrib/observability_splunk_dashboard/recovery.xml
@@ -1,4 +1,4 @@
-<form theme="dark">
+<form version="1.1" theme="dark">
   <label>FoundationDB - Long Recovery (Dev)</label>
   <fieldset submitButton="false" autoRun="false"></fieldset>
   <row>

--- a/contrib/observability_splunk_dashboard/transaction_latency.xml
+++ b/contrib/observability_splunk_dashboard/transaction_latency.xml
@@ -1,4 +1,4 @@
-<form theme="dark">
+<form version="1.1" theme="dark">
   <label>FoundationDB - Tracing GRV and Commit Long Latency of CC Transactions (6.3 and 7.0+) (DEV)</label>
   <description>Design for ClusterController issued transactions.</description>
   <fieldset submitButton="false" autoRun="true">


### PR DESCRIPTION
Improve Splunk dashboard chart rendering by setting consistent null value for charts handling and updating form versions.
- Added `nullValueMode=connect` to all charts in `details.xml` and `performance_overview.xml` to improve readability.
- Updated `<form>` tags to `version="1.1"` in `ratekeeper.xml`, `recovery.xml`, and `transaction_latency.xml` (new splunk [requirement](https://splunk-qa.if1.apple.com/en-US/help?location=jquery2.dashboard.unavailable)).
- removed some whitespace for cleanup.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
