### PR TITLE
Resolve an issue related to the assignment of identifiers to logSets (in TagPartitionedLogSystem)

### DIFF
--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -606,6 +606,9 @@ Future<Version> TagPartitionedLogSystem::push(const ILogSystem::PushVersionSet& 
 			if (!it->isLocal) {
 				continue;
 			}
+			if (it->logServers.size() == 0) {
+				continue;
+			}
 			for (size_t loc = 0; loc < it->logServers.size(); loc++) {
 				if (tpcvMapRef.contains(location)) {
 					tLogCount[logGroupLocal]++;


### PR DESCRIPTION
This PR makes the following changes:

- Ensure that the logSets (in TagPartitionedLogSystem) receive identifiers in a consistent way 

Details: The way the identifiers were assigned a logSet could receive different identifiers in different places in TagPartitionedLogSystem::push() in the presence of empty logSets in TagPartitionedLogSystem (the identifier gets incremented here https://github.com/apple/foundationdb/blob/70e7bf8a34f0bd07e2a520a11ad9dcf08670c436/fdbserver/TagPartitionedLogSystem.actor.cpp#L616 even if the current logSet is empty, whereas it doesn't get incremented here https://github.com/apple/foundationdb/blob/70e7bf8a34f0bd07e2a520a11ad9dcf08670c436/fdbserver/TagPartitionedLogSystem.actor.cpp#L687 in that case).

- Resolve an issue that was causing a unicast recovery related unit test to fail (note: the unit test failure here is not related to the above issue)

Testing:
- Ran unicast recovery related unit tests in okteto and verified that they all succeed
- Joshua id (with version vector disabled): 20251030-165002-sre-51ab1da26bea40aa (no failures)

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
