### PR TITLE
Exclude sharded rocks from 7.3 restart tests

### DIFF
--- a/tests/restarting/from_7.3.0/ConfigureStorageMigrationTestRestart-1.toml
+++ b/tests/restarting/from_7.3.0/ConfigureStorageMigrationTestRestart-1.toml
@@ -1,4 +1,5 @@
 [configuration]
+storageEngineExcludeTypes=[5]
 extraMachineCountDC = 2
 tenantModes = ['disabled']
 

--- a/tests/restarting/from_7.3.0/ConfigureStorageMigrationTestRestart-2.toml
+++ b/tests/restarting/from_7.3.0/ConfigureStorageMigrationTestRestart-2.toml
@@ -1,4 +1,5 @@
 [configuration]
+storageEngineExcludeTypes=[5]
 extraMachineCountDC = 2
 
 [[test]]

--- a/tests/restarting/from_7.3.0/ConfigureTestRestart-1.toml
+++ b/tests/restarting/from_7.3.0/ConfigureTestRestart-1.toml
@@ -1,4 +1,5 @@
 [configuration]
+storageEngineExcludeTypes=[5]
 tenantModes = ['disabled']
 
 [[test]]

--- a/tests/restarting/from_7.3.0/ConfigureTestRestart-2.toml
+++ b/tests/restarting/from_7.3.0/ConfigureTestRestart-2.toml
@@ -1,4 +1,5 @@
 [configuration]
+storageEngineExcludeTypes=[5]
 randomlyRenameZoneId=true
 
 [[test]]

--- a/tests/restarting/from_7.3.0/DrUpgradeRestart-2.toml
+++ b/tests/restarting/from_7.3.0/DrUpgradeRestart-2.toml
@@ -1,5 +1,6 @@
 [configuration]
 extraDatabaseMode = "Local"
+storageEngineExcludeTypes=[4,5]
 
 [[test]]
 testTitle = "DrUpgrade"

--- a/tests/restarting/from_7.3.0/StorefrontTestRestart-1.toml
+++ b/tests/restarting/from_7.3.0/StorefrontTestRestart-1.toml
@@ -1,5 +1,5 @@
 [configuration]
-storageEngineExcludeTypes=[3]
+storageEngineExcludeTypes=[3,5]
 tenantModes = ['disabled']
 
 [[test]]

--- a/tests/restarting/from_7.3.0/StorefrontTestRestart-2.toml
+++ b/tests/restarting/from_7.3.0/StorefrontTestRestart-2.toml
@@ -1,3 +1,6 @@
+[configuration]
+storageEngineExcludeTypes=[3,5]
+
 [[test]]
 testTitle="StorefrontTest"
 runSetup=false

--- a/tests/restarting/from_7.3.0/UpgradeAndBackupRestore-1.toml
+++ b/tests/restarting/from_7.3.0/UpgradeAndBackupRestore-1.toml
@@ -1,5 +1,5 @@
 [configuration]
-storageEngineExcludeTypes=[3]
+storageEngineExcludeTypes=[3,5]
 tenantModes=['disabled']
 
 [[test]]

--- a/tests/restarting/from_7.3.0/UpgradeAndBackupRestore-2.toml
+++ b/tests/restarting/from_7.3.0/UpgradeAndBackupRestore-2.toml
@@ -1,3 +1,6 @@
+[configuration]
+storageEngineExcludeTypes=[3,5]
+
 [[test]]
 testTitle = 'SecondCycleTest'
 simBackupAgents = 'BackupToFile'

--- a/tests/restarting/from_7.3.0/VersionVectorDisableRestart-1.toml
+++ b/tests/restarting/from_7.3.0/VersionVectorDisableRestart-1.toml
@@ -1,4 +1,5 @@
 [configuration]
+storageEngineExcludeTypes=[5]
 tenantModes = ['disabled']
 
 [[knobs]]

--- a/tests/restarting/from_7.3.0/VersionVectorDisableRestart-2.toml
+++ b/tests/restarting/from_7.3.0/VersionVectorDisableRestart-2.toml
@@ -1,3 +1,6 @@
+[configuration]
+storageEngineExcludeTypes=[5]
+
 [[knobs]]
 enable_version_vector = false
 enable_version_vector_tlog_unicast = false

--- a/tests/restarting/from_7.3.0/VersionVectorEnableRestart-1.toml
+++ b/tests/restarting/from_7.3.0/VersionVectorEnableRestart-1.toml
@@ -1,4 +1,5 @@
 [configuration]
+storageEngineExcludeTypes=[5]
 tenantModes = ['disabled']
 
 [[knobs]]

--- a/tests/restarting/from_7.3.0/VersionVectorEnableRestart-2.toml
+++ b/tests/restarting/from_7.3.0/VersionVectorEnableRestart-2.toml
@@ -1,3 +1,6 @@
+[configuration]
+storageEngineExcludeTypes=[5]
+
 [[knobs]]
 enable_version_vector = true
 enable_version_vector_tlog_unicast = true

--- a/tests/restarting/from_7.3.29/ClientTransactionProfilingCorrectness-1.toml
+++ b/tests/restarting/from_7.3.29/ClientTransactionProfilingCorrectness-1.toml
@@ -1,5 +1,5 @@
 [configuration]
-storageEngineExcludeTypes=[3]
+storageEngineExcludeTypes=[3,5]
 tenantModes = ['disabled']
 
 [[test]]

--- a/tests/restarting/from_7.3.29/ClientTransactionProfilingCorrectness-2.toml
+++ b/tests/restarting/from_7.3.29/ClientTransactionProfilingCorrectness-2.toml
@@ -1,3 +1,6 @@
+[configuration]
+storageEngineExcludeTypes=[3,5]
+
 [[test]]
 testTitle="ClientTransactionProfilingCorrectness"
 clearAfterTest=true

--- a/tests/restarting/from_7.3.29/CycleTestRestart-1.toml
+++ b/tests/restarting/from_7.3.29/CycleTestRestart-1.toml
@@ -1,5 +1,5 @@
 [configuration]
-storageEngineExcludeTypes=[3]
+storageEngineExcludeTypes=[3,5]
 tenantModes = ['disabled']
 
 [[test]]

--- a/tests/restarting/from_7.3.29/CycleTestRestart-2.toml
+++ b/tests/restarting/from_7.3.29/CycleTestRestart-2.toml
@@ -1,3 +1,6 @@
+[configuration]
+storageEngineExcludeTypes=[3,5]
+
 [[test]]
 testTitle="Clogged"
 runSetup=false

--- a/tests/restarting/from_7.3.49/ClientMetricRestart-1.toml
+++ b/tests/restarting/from_7.3.49/ClientMetricRestart-1.toml
@@ -1,4 +1,5 @@
 [configuration]
+storageEngineExcludeTypes=[5]
 tenantModes = ['disabled']
 
 [[test]]

--- a/tests/restarting/from_7.3.49/ClientMetricRestart-2.toml
+++ b/tests/restarting/from_7.3.49/ClientMetricRestart-2.toml
@@ -1,3 +1,6 @@
+[configuration]
+storageEngineExcludeTypes=[5]
+
 [[test]]
 testTitle='ClientMetricRestartTest'
 clearAfterTest=false


### PR DESCRIPTION
We do not plan to enable sharded rocks in 7.4, therefore 7.3 -> 7.4 upgrade path with sharded rocks is not something we need to test. This upgrade path is causing issues e.g. 7.4 and main have changes for https://github.com/apple/foundationdb/pull/12203, but 7.3 does not, so assertions fire expecting padding in serialized checkpoints.

200K: 20251029-230309-praza-r163519981-fix-a86a29-3680e25583b8e7d3 compressed=True data_size=37376776 duration=9972432 ended=200000 fail=4 fail_fast=10 max_runs=200000 pass=199996 priority=100 remaining=0 runtime=2:00:11 sanity=False started=200000 stopped=20251030-010320 submitted=20251029-230309 timeout=5400 username=praza-r163519981-fix-a86a29f3dace404912e6fa5d74101e4b31bd88ca

4 failures are in:
- tests/rare/MetaclusterRecovery.toml
- tests/slow/GcGenerations.toml
- tests/rare/ReadSkewReadWrite.toml
- tests/rare/ReadSkewReadWrite.toml

I did not change any of these tests so I don't believe these failures are caused by this PR. 

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
