### PR TITLE
Log size has 1GiB default in simulation

### DIFF
--- a/fdbserver/fdbserver.actor.cpp
+++ b/fdbserver/fdbserver.actor.cpp
@@ -667,7 +667,7 @@ static void printUsage(const char* name, bool devhelp) {
 	printOptionUsage("-L PATH, --logdir PATH", " Store log files in the given folder (default is `.').");
 	printOptionUsage("--logsize SIZE",
 	                 "Roll over to a new log file after the current log file"
-	                 " exceeds SIZE bytes. The default value is 10MiB.");
+	                 " exceeds SIZE bytes. The default value is 10MiB (1GiB in simulation).");
 	printOptionUsage("--maxlogs SIZE, --maxlogssize SIZE",
 	                 " Delete the oldest log file when the total size of all log"
 	                 " files exceeds SIZE bytes. If set to 0, old log files will not"
@@ -1119,6 +1119,7 @@ struct CLIOptions {
 	    logFolder = ".", metricsConnFile, metricsPrefix, newClusterKey, authzPublicKeyFile;
 	std::string logGroup = "default";
 	uint64_t rollsize = TRACE_DEFAULT_ROLL_SIZE;
+	bool rollsizeSet = false;
 	uint64_t maxLogsSize = TRACE_DEFAULT_MAX_LOGS_SIZE;
 	bool maxLogsSizeSet = false;
 	int maxLogs = 0;
@@ -1518,6 +1519,7 @@ private:
 					flushAndExit(FDB_EXIT_ERROR);
 				}
 				rollsize = ti.get();
+				rollsizeSet = true;
 				break;
 			}
 			case OPT_MAXLOGSSIZE: {
@@ -1872,6 +1874,16 @@ private:
 			}
 			}
 		}
+
+		if (role == ServerRole::Simulation) {
+			if (!rollsizeSet) {
+				rollsize = TRACE_DEFAULT_ROLL_SIZE_SIM;
+			}
+			if (!maxLogsSizeSet) {
+				maxLogsSize = TRACE_DEFAULT_MAX_LOGS_SIZE_SIM;
+			}
+		}
+
 		// Sets up blob credentials, including one from the environment FDB_BLOB_CREDENTIALS.
 		// Below is top-half of BackupTLSConfig::setupBlobCredentials().
 		const char* blobCredsFromENV = getenv("FDB_BLOB_CREDENTIALS");

--- a/flow/include/flow/Trace.h
+++ b/flow/include/flow/Trace.h
@@ -37,8 +37,17 @@
 #include "flow/ITrace.h"
 #include "flow/Traceable.h"
 
-#define TRACE_DEFAULT_ROLL_SIZE (10 << 20)
-#define TRACE_DEFAULT_MAX_LOGS_SIZE (10 * TRACE_DEFAULT_ROLL_SIZE)
+// Note: this default only applies to non-simulation fdbserver process invocations
+//       i.e. when -r is not set to simulation
+#define TRACE_DEFAULT_ROLL_SIZE (10ULL << 20)
+
+// Same as above, but default for when -r is set to simulation
+// Having a higher default (1GiB) is useful because you don't have to
+// grep multiple trace files when debugging.
+#define TRACE_DEFAULT_ROLL_SIZE_SIM (1ULL << 30)
+
+#define TRACE_DEFAULT_MAX_LOGS_SIZE (10ULL * TRACE_DEFAULT_ROLL_SIZE)
+#define TRACE_DEFAULT_MAX_LOGS_SIZE_SIM (10ULL * TRACE_DEFAULT_ROLL_SIZE_SIM)
 
 FDB_BOOLEAN_PARAM(InitializeTraceMetrics);
 


### PR DESCRIPTION
# Description 

When debugging in simulation, the default 10MiB logsize is too small, resulting in multiple trace files, making it slightly more cumbersome to grep. I switched the default to a somewhat big number here (1GiB). I've been using this via --logsize override over 1 year and don't remember seeing more than 1 trace file, so this should be big enough. 

I initially thought the change would be quite simple but it ended being slightly complex due to various factors e.g. default value is a preprocessor macro, dependency on maxlogsize. The final code should be simple to review though.

# Testing

100K results: 20251031-063837-praza-logsize-increase-daed-c3df2d790a9a51ae compressed=True data_size=37393388 duration=5605098 ended=100000 fail=5 fail_fast=10 max_runs=100000 pass=99995 priority=100 remaining=0 runtime=1:15:25 sanity=False started=100000 stopped=20251031-075402 submitted=20251031-063837 timeout=5400 username=praza-logsize-increase-daed60c8f7ab34e195045c2126851d704214f225.

The 5 failures are:
- tests/rare/ReadSkewReadWrite.toml. Sev40 = OpearationTimedOut. Does not seem related. 
- tests/rare/CycleWithDeadHall.toml. Sev40 = RocksDBError with some rocksdb IO LOCK error message. Does not seem related.
- tests/rare/CheckRelocation.toml. OperationTimedOut. We have seen this test failing in nightly as well, so should not be related. 
- tests/rare/CheckRelocation.toml. Same as above.
- tests/rare/CheckRelocation.toml. Same as above.

I will double check the first two issues and ensure they are not related. Update: since this change should not affect FDB determinism, the easiest way to test was to revert my change and ensure I still see the same failures in those tests. I just did that and without my changes, these tests are still failing, implying the failures are not related to my change. We're tracking these separately. 

This change should only affect simulation. To that end, I ensured in simulation new default and override works as expected.

```
$ fdbserver -r simulation -f /root/src/foundationdb/tests/rare/ClogRemoteTLog.toml --buggify off --seed 3961198004
....
$ ls -lh
total 35M
drwxr-xr-x 53 root root 4.0K Oct 30 23:31 simfdb/
-rw-r--r--  1 root root  35M Oct 30 23:32 trace.0.0.0.0.1700231.1761892261.ZcDHMl.0.1.xml
```

```
$ fdbserver -r simulation -f /root/src/foundationdb/tests/rare/ClogRemoteTLog.toml --buggify off --seed 3961198004 --logsize 10MiB
....
$ ls -lh
total 35M
drwxr-xr-x 53 root root 4.0K Oct 30 23:36 simfdb/
-rw-r--r--  1 root root  14M Oct 30 23:36 trace.0.0.0.0.1700527.1761892587.ZcDHMl.0.1.xml
-rw-r--r--  1 root root  14M Oct 30 23:37 trace.0.0.0.0.1700527.1761892587.ZcDHMl.0.2.xml
-rw-r--r--  1 root root 8.3M Oct 30 23:37 trace.0.0.0.0.1700527.1761892587.ZcDHMl.0.3.xml
```

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
