### PR TITLE
#6158 | fixed the issue.

### DIFF
--- a/fdbcli/include/fdbcli/fdbcli.actor.h
+++ b/fdbcli/include/fdbcli/fdbcli.actor.h
@@ -170,8 +170,6 @@ void printStatus(StatusObjectReader statusObj,
 // All below actors return true if the command is executed successfully
 // advanceversion command
 ACTOR Future<bool> advanceVersionCommandActor(Reference<IDatabase> db, std::vector<StringRef> tokens);
-// cache_range command
-ACTOR Future<bool> cacheRangeCommandActor(Reference<IDatabase> db, std::vector<StringRef> tokens);
 // configure command
 ACTOR Future<bool> configureCommandActor(Reference<IDatabase> db,
                                          Database localDb,


### PR DESCRIPTION
@jzhou77  


**I discovered the issue for #6158 :**

1. The `cache_range ` command was originally implemented in 2020 as part of the Storage Cache Server feature
2. The Storage Cache Server feature was completely removed in commit `668450f22 ` (October 2025) via PR #12486 
3. When the feature was deleted, the implementation file fdbcli/CacheRangeCommand.actor.cpp was removed
4. However, the function declaration in fdbcli/include/fdbcli/fdbcli.actor.h was accidentally left behind, creating an orphaned reference

**The Fix for this issue:**
Since the Storage Cache Server feature no longer exists in FoundationDB, the proper fix is to remove the orphaned declaration entirely rather than rename it.
Changed file: fdbcli/include/fdbcli/fdbcli.actor.h
I have made changes you can view. Changes made:
I have Removed the orphaned declaration: ACTOR Future<bool> cacheRangeCommandActor(Reference<IDatabase> db, std::vector<StringRef> tokens);
Removed the associated comment: // cache_range command

hope it will get resolved..........