### PR TITLE
Don't run /flow/thread tests in simulation

### DIFF
--- a/tests/fast/RandomUnitTests.toml
+++ b/tests/fast/RandomUnitTests.toml
@@ -12,4 +12,4 @@ startDelay = 0
     testsMatching = '/'
     # ConfigDB tests persist state, so running these tests
     # sequentially can cause issues
-    testsIgnored = '/fdbserver/ConfigDB/;/fdbrpc/grpc'
+    testsIgnored = '/fdbserver/ConfigDB/;/fdbrpc/grpc;/flow/thread'


### PR DESCRIPTION
There is some mixup b/w simulated and real delays causing issues with end_of_stream. Have to verify behavior of NotifiedQueue when there is stream of messages which are unread and follows by end_of_stream. Ideally, it should queue end_of_stream at the end.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
