### PR TITLE
Ignore remoteSatelliteTLogsDead in kill decision making

### DIFF
--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -1736,7 +1736,9 @@ public:
 					                                   satelliteTLogWriteAntiQuorumFallback,
 					                                   false)
 					        : primarySatelliteProcessesDead.validate(satelliteTLogPolicyFallback);
-					bool remoteSatelliteTLogsDead =
+					// Ignore remoteSatelliteTLogsDead because remote satellites are not used and
+					// not affecting recovery.
+					/* bool remoteSatelliteTLogsDead =
 					    satelliteTLogWriteAntiQuorumFallback
 					        ? !validateAllCombinations(badCombo,
 					                                   remoteSatelliteProcessesDead,
@@ -1744,7 +1746,7 @@ public:
 					                                   remoteSatelliteLocalitiesLeft,
 					                                   satelliteTLogWriteAntiQuorumFallback,
 					                                   false)
-					        : remoteSatelliteProcessesDead.validate(satelliteTLogPolicyFallback);
+					        : remoteSatelliteProcessesDead.validate(satelliteTLogPolicyFallback); */
 
 					if (usableRegions > 1) {
 						notEnoughLeft = !primaryProcessesLeft.validate(tLogPolicy) ||
@@ -1765,8 +1767,7 @@ public:
 					}
 
 					if (usableRegions > 1 && allowLogSetKills) {
-						tooManyDead = (primaryTLogsDead && primarySatelliteTLogsDead) ||
-						              (remoteTLogsDead && remoteSatelliteTLogsDead) ||
+						tooManyDead = (primaryTLogsDead && primarySatelliteTLogsDead) || remoteTLogsDead ||
 						              (primaryTLogsDead && remoteTLogsDead) ||
 						              (primaryProcessesDead.validate(storagePolicy) &&
 						               remoteProcessesDead.validate(storagePolicy));


### PR DESCRIPTION
Remote satellite is not used in recoveries, thus even if they are dead, they have no effect. Simulation found a scenario where remoteTLogsDead is true, but remoteSatelliteTLogsDead is false. In this case, simulator doesn't think it's going to kill too many machines.

However, because one remote tlog missing, recovery can't reach all tlogs recruited state, thus blocking remote SSes from catching up, resulting in consistency check failure.

Reproduction of failure:

Seed: -f ./tests/slow/BackupOldAndNewRestore.toml -s 1884352193 -b on

commit: 53fe3ec741073d9cdb62022ff4fcd2e02064fc36 with gcc build

20251111-172448-jzhou-9c457c5f42e7924a             compressed=True data_size=37442228 duration=5788937 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:07:00 sanity=False started=100000 stopped=20251111-183148 submitted=20251111-172448 timeout=5400 username=jzhou

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
