### PR TITLE
Update the base image to RockyLinux 10.2

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM rockylinux/rockylinux:9.6-minimal AS base
+FROM rockylinux/rockylinux:10.2-minimal AS base
 
 # Disable the faulty mirror list for RockyLinux for now. Since all the other images use the base image
 # as base we don't have to repeat this step.

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM rockylinux/rockylinux:9.8-minimal AS base
+FROM rockylinux/rockylinux:10.2-minimal AS base
 
 # It seems mirrorlist can be less reliable, just use original baseurl for package repo.
 RUN sed -i.bak 's/^#baseurl=/baseurl=/; s/^mirrorlist=/#mirrorlist=/' /etc/yum.repos.d/rocky.repo

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -154,18 +154,11 @@ ENTRYPOINT ["/usr/bin/fdb-kubernetes-monitor"]
 
 FROM foundationdb-base AS foundationdb-kubernetes-sidecar
 
-# We use python3.9 here as the tests with 3.12 resulted in the following error:
-# error:0A000126:SSL routines::unexpected eof while reading. This could be an issue
-# with the installed openssl version. Since the sidecar support will be deprecated in the
-# future it's fine to use python 3.9 here.
-# EOL for python 3.9 is 2025-10: https://devguide.python.org/versions/
 RUN microdnf -y install \
-    python3.9 \
-    python3.9-pip && \
+    python3 \
+    python3-pip && \
     microdnf clean all && \
-    update-alternatives --install /usr/bin/python python /usr/bin/python3.9 20 && \
-    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 20 && \
-    python3 -m pip install watchdog==4.0.1
+    python3 -m pip install watchdog==4.0.2
 
 WORKDIR /
 COPY entrypoint.bash sidecar.py /

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -222,7 +222,7 @@ ENTRYPOINT ["/usr/bin/mako"]
 FROM foundationdb-base AS ycsb
 
 RUN microdnf -y install \
-    java-11-openjdk java-11-openjdk-devel && \
+    java-21-openjdk java-21-openjdk-devel && \
     microdnf clean all && \
     rm -rf /var/cache/yum
 


### PR DESCRIPTION
RockyLinux 10 adds new architecture riscv64, a per-requisite for building riscv64 releases.

* Update the base image to RockyLinux 10.1

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
