### PR TITLE
Add BlockCacheStats metrics for RocksDB

### DIFF
--- a/fdbserver/KeyValueStoreRocksDB.actor.cpp
+++ b/fdbserver/KeyValueStoreRocksDB.actor.cpp
@@ -1161,6 +1161,7 @@ ACTOR Future<Void> rocksDBMetricLogger(UID id,
 
 	state std::vector<std::pair<const char*, std::string>> strPropertyStats = {
 		{ "LevelStats", rocksdb::DB::Properties::kLevelStats },
+		{ "BlockCacheEntryStats", rocksdb::DB::Properties::kBlockCacheEntryStats },
 	};
 
 	state std::vector<std::pair<const char*, std::string>> levelStrPropertyStats = {


### PR DESCRIPTION
Add BlockCacheStats metrics for RocksDB

### TESTING
On local cluster, added some data and new metric BlockCacheStats in RocksDBMetrics Type is shown as below:

```
<Event Severity="10" Time="1763165486.866028" DateTime="2025-11-15T00:11:26Z" Type="RocksDBMetrics" 
ID="f81c97909ffa9ed9" StallMicros="0" .....
BlockCacheUsage="96" BlockCachePinnedUsage="96" LiveSstFilesSize="0" ObsoleteSstFilesSize="0"
LevelStats="Level Files Size(MB)\x0a--------------------\x0a  0        0        0\x0a  1        0        0\x0a  2 
       0        0\x0a  3        0        0\x0a  4        0        0\x0a  5        0        0\x0a  6        0        0\x0a" 
BlockCacheEntryStats="Block cache LRUCache@0x7f25e0e782e0#235989 capacity: 4.00 GB seed:
 1467357450 usage: 0.09 KB table_size: 1024 occupancy: 1 collections: 2 last_copies: 0
  last_secs: 4.5e-05 secs_since: 0\x0aBlock cache entry stats(count,size,portion): Misc(1,0.00 KB,0%)\x0a" 
CompressionRatioAtLevel="0:-1.000000,1:-1.000000,2:-1.000000,3:-1.000000,4:-1.000000,5:-1.000000,6:-1.000000" 
NumReadIteratorsCreated="0" NumTimesReadIteratorsReused="0" BlockCacheSize="4294967296"
ImmediateThrottle="0 -1 0" FailedToAcquire="0 -1 0"
DeleteKeyRequests="0 -1 0" DeleteRangeRequests="0 -1 0"
ConvertedDeleteKeyRequests="0 -1 0" ConvertedDeleteRangeRequests="0 -1 0"
RocksdbReadRangeQueries="0 -1 0" CommitDelayed="0 -1 0"
ThreadID="16667934443910511455" Machine="127.0.0.1:1504" LogGroup="default"
 Roles="SS" TrackLatestType="Original" />
```

100k correctness tests completed:
`20251115-000951-ak_metrics1-016aa1b40822bce4       compressed=True data_size=38554434 duration=3941215 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=2:08:15 sanity=False started=100000 stopped=20251115-021806 submitted=20251115-000951 timeout=5400 username=ak_metrics1`