### PR TITLE
Add partitioned log option and encryption in ctest fors3 and local dir test

### DIFF
--- a/fdbbackup/tests/s3_backup_test.sh
+++ b/fdbbackup/tests/s3_backup_test.sh
@@ -93,6 +93,10 @@ function backup {
     cmd_args+=("--encryption-key-file" "${local_encryption_key_file}")
   fi
 
+  if [[ "${USE_PARTITIONED_LOG}" == "true" ]]; then
+    cmd_args+=("--partitioned-log-experimental")
+  fi
+
   for knob in "${KNOBS[@]}"; do
     cmd_args+=("${knob}")
   done
@@ -352,6 +356,7 @@ set -o noclobber
 
 # Parse command line arguments
 USE_ENCRYPTION=false
+USE_PARTITIONED_LOG=$(((RANDOM % 2)) && echo true || echo false )
 PARAMS=()
 
 while (( "$#" )); do
@@ -362,6 +367,14 @@ while (( "$#" )); do
       ;;
     --encrypt-at-random)
       USE_ENCRYPTION=$(((RANDOM % 2)) && echo true || echo false )
+      shift
+      ;;
+    --partitioned-log-experimental)
+      USE_PARTITIONED_LOG=true
+      shift
+      ;;
+    --partitioned-log-experimental-at-random)
+      USE_PARTITIONED_LOG=$(((RANDOM % 2)) && echo true || echo false )
       shift
       ;;
     -*|--*=) # unsupported flags
@@ -479,6 +492,7 @@ else
   log "Using plaintext for backups"
 fi
 readonly ENCRYPTION_KEY_FILE
+readonly USE_PARTITIONED_LOG
 
 # Set host, bucket, and blob_credentials_file whether MockS3Server or s3.
 readonly path_prefix="ctests"


### PR DESCRIPTION
Add partitioned log (backup v2) option and encryption in ctest for s3 and local dir test for test coverage. These options will be selected at random.

### TESTING
Ran these two tests multiple times to check the combinations of encryption and partitioned backup passing:
- `bash -x ~/src/repo/foundationdb/fdbbackup/tests/s3_backup_test.sh  ~/src/repo/foundationdb/ ~/build_output/ ~/local_backup_testing/` 
- ` bash -x ~/src/repo/foundationdb/fdbbackup/tests/dir_backup_test.sh  ~/src/repo/foundationdb/ ~/build_output/ ~/local_backup_testing/`

100k simulation correctness tests completed:
 ` 20251115-023919-bk_ctest1-ea7379f1175893cc         compressed=True data_size=38554005 duration=5031246 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:52:19 sanity=False started=100000 stopped=20251115-033138 submitted=20251115-023919 timeout=5400 username=bk_ctest1`
