### PR TITLE
Use cluster controller interface ID in recovery trace events

### DIFF
--- a/fdbserver/include/fdbserver/ClusterRecovery.actor.h
+++ b/fdbserver/include/fdbserver/ClusterRecovery.actor.h
@@ -277,7 +277,7 @@ struct ClusterRecoveryData : NonCopyable, ReferenceCounted<ClusterRecoveryData> 
 	                    PromiseStream<Future<Void>> const& addActor,
 	                    bool forceRecovery)
 
-	  : controllerData(controllerData), dbgid(masterInterface.id()), lastEpochEnd(invalidVersion),
+	  : controllerData(controllerData), dbgid(clusterController.id()), lastEpochEnd(invalidVersion),
 	    recoveryTransactionVersion(invalidVersion), lastCommitTime(0), liveCommittedVersion(invalidVersion),
 	    databaseLocked(false), minKnownCommittedVersion(invalidVersion), hasConfiguration(false),
 	    coordinators(coordinators), lastVersionTime(0), txnStateStore(nullptr), memoryLimit(2e9), dbId(dbId),


### PR DESCRIPTION
When working on some simulation failure, I noticed that the main recovery event `MasterRecoveryState` is using the sequencer interface id, so when I map the trace event to the role emitting the trace event, that logic was not working. That's because we changed recovery orchestration to be via cluster controller now. So the id we should use in recovery trace events should be that of the cluster controller interface.

To verify this works, I ran a random test in simulation:

Before: 

```
Time=4.899379 Type=Role Severity=10 As=ClusterController OnWorker=0000000000000000 Origination=Recruited Transition=Begin ID=c1a7f8032fa9507f

Time=5.076033 Type=Role Severity=10 As=MasterServer OnWorker=d55576399d459bad Origination=Recruited Transition=Begin ID=cc2d2027731f6a59

Time=5.078025 Type=MasterRecoveryState Severity=10 Status=reading_coordinated_state StatusCode=0 ID=cc2d2027731f6a59
```

After:

```
Time=4.899379 Type=Role Severity=10 As=ClusterController OnWorker=0000000000000000 Origination=Recruited Transition=Begin ID=c1a7f8032fa9507f

Time=5.076033 Type=Role Severity=10 As=MasterServer OnWorker=d55576399d459bad Origination=Recruited Transition=Begin ID=cc2d2027731f6a59

Time=5.078025 Type=MasterRecoveryState Severity=10 Status=reading_coordinated_state StatusCode=0 ID=c1a7f8032fa9507f
```

150K: 20251118-031954-praza-recovery-cc-id-bbbbab-b3589270572a7b84 compressed=True data_size=37416783 duration=6824621 ended=150000 fail_fast=10 max_runs=150000 pass=150000 priority=100 remaining=0 runtime=1:55:34 sanity=False started=150000 stopped=20251118-051528 submitted=20251118-031954 timeout=5400 username=praza-recovery-cc-id-bbbbab7848a5dc2c1bd4cdfff176206c02ab7aec

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
