### PR TITLE
Fix CentOS 7 compilation: Replace std::format with format()

### DIFF
--- a/fdbserver/workloads/TxnTimeout.actor.cpp
+++ b/fdbserver/workloads/TxnTimeout.actor.cpp
@@ -102,7 +102,7 @@ struct TxnTimeout : TestWorkload {
 	// Format: "txntimeout_c{clientId}_a{actorIdx}_n{nodeIdx}"
 	// This ensures the same key is used during populate and transaction phases
 	static Key makeKey(int clientId, int actorIdx, int nodeIdx) {
-		return Key(std::format("txntimeout_c{}_a{}_n{}", clientId, actorIdx, nodeIdx));
+		return Key(format("txntimeout_c%d_a%d_n%d", clientId, actorIdx, nodeIdx));
 	}
 
 	// Initializes the database with test data for each actor to operate on


### PR DESCRIPTION
I see this on internal builds:

 foundationdb-nightly-asan for main on Linux CentOS 7
 foundationdb-nightly-valgrind for main on Linux CentOS 7

```
distcc[29506] ERROR: compile /codebuild/output/src1865249132/src/github.com/apple/foundationdb/build_output/fdbserver/workloads/TxnTimeout.actor.g.cpp on distcc-c0afcb341c31fb8c.elb.us-west-2.amazonaws.com/96 failed /codebuild/output/src1865249132/src/github.com/apple/foundationdb/fdbserver/workloads/TxnTimeout.actor.cpp:105:14: error: no member named 'format' in namespace 'std'; did you mean simply 'format'?
  return Key(std::format("txntimeout_c{}_a{}_n{}", clientId, actorIdx, nodeIdx));
             ^~~~~~~~~~~
             format
/codebuild/output/src1865249132/src/github.com/apple/foundationdb/flow/include/flow/flow.h:74:20: note: 'format' declared here extern std::string format(const char* form, ...);
                   ^
1 error generated.

```
std::format is a C++20 feature not available in older compilers. CentOS 7 typically ships with GCC versions that don't support C++20. Use FoundationDB's existing format() function (flow/flow.h) instead, which provides printf-style formatting compatible with older compilers.
