### PR TITLE
Improve compiler flag for ARM64

### DIFF
--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -521,7 +521,7 @@ else()
   if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
     # Graviton2 or later
     # https://github.com/aws/aws-graviton-gettting-started
-    add_compile_options($<${is_cxx_compile}:-march=armv8.2-a+crc+simd>)
+    add_compile_options($<${is_cxx_compile}:-march=armv8.2-a+lse+crc>)
   endif()
 
   if (CMAKE_SYSTEM_PROCESSOR MATCHES "ppc64le")


### PR DESCRIPTION
Replace `-march=armv8.2-a+crc+simd` with `-march=armv8.2-a+lse+crc` since SIMD (NEON) is already mandatory in ARMv8, and LSE (Large System Extensions) is more important, which is supported on Graviton2 and later.