### PR TITLE
Provide encryption support with fdbbackup modify command (#12554)

### DIFF
--- a/fdbclient/BackupContainerFileSystem.actor.cpp
+++ b/fdbclient/BackupContainerFileSystem.actor.cpp
@@ -1327,6 +1327,10 @@ public:
 		Optional<Version> existingEncryptionMetadata = wait(bc->fileLevelEncryption().get());
 
 		if (!existingEncryptionMetadata.present()) {
+			bool exists = wait(bc->exists());
+			if (!exists) {
+				wait(bc->create());
+			}
 			wait(bc->fileLevelEncryption().set(bc->encryptionKeyFileName.present() ? 1 : 0));
 		}
 		return Void();


### PR DESCRIPTION
Cherrypick https://github.com/apple/foundationdb/pull/12554

* Provide encryption support with fdbbackup modify command

* Update backup help

* format

* Fix errors

* Error out if different encryption key files are passed for same url

* Addressed comments

Simulation 100k tests completed:
`  20251210-180833-ak_modify_bk_7.4-0f1352ace7ce8d63  compressed=True data_size=41382457 duration=5607862 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:01:15 sanity=False started=100000 stopped=20251210-190948 submitted=20251210-180833 timeout=5400 username=ak_modify_bk_7.4
`
# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
