### PR TITLE
Go binding: add GetMainThreadBusyness method to Database

### DIFF
--- a/bindings/go/src/fdb/database.go
+++ b/bindings/go/src/fdb/database.go
@@ -162,6 +162,13 @@ func (d Database) GetClientStatus() ([]byte, error) {
 	return b, nil
 }
 
+// GetMainThreadBusyness return network thread busyness (updated every 1s)
+// A value of 0 indicates that the client is more or less idle
+// A value of 1 (or more) indicates that the client is saturated
+func (d Database) GetMainThreadBusyness() float64 {
+	return float64(C.fdb_database_get_main_thread_busyness(d.database.ptr))
+}
+
 func retryable(wrapped func() (interface{}, error), onError func(Error) FutureNil) (ret interface{}, err error) {
 	for {
 		ret, err = wrapped()


### PR DESCRIPTION
add `GetMainThreadBusyness` method to `Database`

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
