### PR TITLE
Exclude single_process_fdbcli_tests when ASAN enabled

### DIFF
--- a/fdbcli/CMakeLists.txt
+++ b/fdbcli/CMakeLists.txt
@@ -29,12 +29,15 @@ endif()
 if (NOT WIN32 AND NOT OPEN_FOR_IDE)
   add_dependencies(fdbcli external_client)
 
-  add_fdbclient_test(
-    NAME single_process_fdbcli_tests
-    COMMAND ${CMAKE_SOURCE_DIR}/fdbcli/tests/fdbcli_tests.py
-            ${CMAKE_BINARY_DIR}
-            @CLUSTER_FILE@
-            )
+  if(NOT USE_ASAN)
+    # TODO: this is known to fail with ASAN, fix needed
+    add_fdbclient_test(
+      NAME single_process_fdbcli_tests
+      COMMAND ${CMAKE_SOURCE_DIR}/fdbcli/tests/fdbcli_tests.py
+              ${CMAKE_BINARY_DIR}
+              @CLUSTER_FILE@
+              )
+  endif()
   add_fdbclient_test(
     NAME multi_process_fdbcli_tests
     PROCESS_NUMBER 5


### PR DESCRIPTION
 (as we do single_process_external_client_fdbcli_tests). This ctest fails regularly in our internal ci/cd nightly runs with ASAN enabled -- not because of memory issue but because goes on too long.
