### PR TITLE
(Minor change) Run BulkDumpingS3 tests with 3 replicas instead of 1

### DIFF
--- a/tests/slow/BulkDumpingS3.toml
+++ b/tests/slow/BulkDumpingS3.toml
@@ -12,7 +12,7 @@ simpleConfig = false
 minimumRegions = 1
 # Use ssd-2 storage engine instead of rocksdb to avoid RocksDB bulk loading crashes
 # The RocksDB assertion failure indicates incompatibility with current bulk loading implementation
-config = "single usable_regions=1 storage_engine=ssd-2 perpetual_storage_wiggle=0 commit_proxies=3 grv_proxies=3 resolvers=3 logs=3"
+config = "triple usable_regions=1 storage_engine=ssd-2 perpetual_storage_wiggle=0 commit_proxies=3 grv_proxies=3 resolvers=3 logs=3"
 
 # Disable all fault injection and network failures
 # buggify = false now controls ALL fault injection systems (BUGGIFY, failure workloads, AND global fault injection)

--- a/tests/slow/BulkDumpingS3WithChaos.toml
+++ b/tests/slow/BulkDumpingS3WithChaos.toml
@@ -37,7 +37,7 @@ simpleConfig = false
 minimumRegions = 1
 # Use ssd-2 storage engine instead of rocksdb to avoid RocksDB bulk loading crashes
 # The RocksDB assertion failure indicates incompatibility with current bulk loading implementation
-config = "single usable_regions=1 storage_engine=ssd-2 perpetual_storage_wiggle=0 commit_proxies=3 grv_proxies=3 resolvers=3 logs=3"
+config = "triple usable_regions=1 storage_engine=ssd-2 perpetual_storage_wiggle=0 commit_proxies=3 grv_proxies=3 resolvers=3 logs=3"
 
 # Disable all fault injection and network failures
 # buggify = false now controls ALL fault injection systems (BUGGIFY, failure workloads, AND global fault injection)


### PR DESCRIPTION
These tests run with one replica only. Make it three.

`  20251224-210451-stack_korolov-54898e22d0029503     compressed=True data_size=35340554 duration=5611177 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:47:08 sanity=False started=100000 stopped=20251224-215159 submitted=20251224-210451 timeout=5400 username=stack_korolov`
