### PR TITLE
Fix an misaligned access UB in Endpoint class

### DIFF
--- a/fdbrpc/include/fdbrpc/FlowTransport.h
+++ b/fdbrpc/include/fdbrpc/FlowTransport.h
@@ -40,7 +40,6 @@ class IConnection;
 // WL: Well-known
 enum { WLTOKEN_ENDPOINT_NOT_FOUND = 0, WLTOKEN_PING_PACKET, WLTOKEN_UNAUTHORIZED_ENDPOINT, WLTOKEN_FIRST_AVAILABLE };
 
-#pragma pack(push, 4)
 class Endpoint {
 public:
 	// Endpoint represents a particular service (e.g. a serialized Promise<T> or PromiseStream<T>)
@@ -119,7 +118,6 @@ public:
 		}
 	}
 };
-#pragma pack(pop)
 
 namespace std {
 template <>


### PR DESCRIPTION

  `UndefinedBehaviorSanitizer` reports a misaligned address error when accessing `Endpoint::token`:

```
/app/foundationdb/fdbrpc/include/fdbrpc/FlowTransport.h:72:38: runtime error: member call on misaligned address 0x51900003c2ec for type 'UID', which requires 8 byte alignment
0x51900003c2ec: note: pointer points here
  00 be be be 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 be be  be be be be be be be be
              ^ 
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /app/foundationdb/fdbrpc/include/fdbrpc/FlowTransport.h:72:38 
/app/foundationdb/fdbrpc/include/fdbrpc/FlowTransport.h:72:38: runtime error: member call on misaligned address 0x51900003c2ec for type 'UID', which requires 8 byte alignment
0x51900003c2ec: note: pointer points here
  00 be be be 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 be be  be be be be be be be be
              ^ 
```

  

  The `Endpoint` class uses `#pragma pack(push, 4)` which forces 4-byte alignment for all members. However, the `token` member is of type `UID`, which contains `uint64_t part[2]` and requires 8-byte alignment.

  I am not sure why add  `#pragma pack(push, 4)`  here,  but it seems that FlatBuffers  is used for serialization now,  and this seems useless.