### PR TITLE
Increase mode_bytes for the StreamingMode.WANT_ALL

### DIFF
--- a/bindings/c/fdb_c.cpp
+++ b/bindings/c/fdb_c.cpp
@@ -589,7 +589,7 @@ FDBFuture* validate_and_update_parameters(int& limit,
 
 	/* _ITERATOR mode maps to one of the known streaming modes
 	   depending on iteration */
-	const int mode_bytes_array[] = { GetRangeLimits::BYTE_LIMIT_UNLIMITED, 256, 1000, 4096, 80000 };
+	const int mode_bytes_array[] = { GetRangeLimits::BYTE_LIMIT_UNLIMITED, 256, 1000, 4096, 120000 };
 
 	/* The progression used for FDB_STREAMING_MODE_ITERATOR.
 	   Goes 1.5 * previous. */


### PR DESCRIPTION
Related [forum discussion](https://forums.foundationdb.org/t/throughput-of-streamingmode-want-all-vs-iterator-on-large-payloads/5158).

This PR changes target_bytes for the `WANT_ALL` StreamingMode to match the last iterator progression. 

While `WANT_ALL` is generally recommended by the documentation for complete extraction of the desired range at maximum throughput, practically it is less performant than `ITERATOR` on payloads ~ >= 1.6MiB , as the last “state” of iteration_progress is 1.5 times bigger than what `WANT_ALL` is configured with currently (120000 > 80000). Which means that after 20 iteration steps an accumulated throughput of the `ITERATOR` will exceed the one provided by `WANT_ALL`. 

This behavior was introduced by [4416](https://github.com/apple/foundationdb/pull/4416).

-----------

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
