### PR TITLE
Do not force using pypi.python.org when installing sphinx

### DIFF
--- a/documentation/sphinx/.pip.conf
+++ b/documentation/sphinx/.pip.conf
@@ -1,3 +1,2 @@
 [global]
 timeout = 60
-index-url = https://pypi.python.org/simple

--- a/documentation/sphinx/requirements.txt
+++ b/documentation/sphinx/requirements.txt
@@ -1,4 +1,3 @@
---index-url https://pypi.python.org/simple
 setuptools==78.1.1
 sphinx==5.1.1
 sphinx-bootstrap-theme==0.8.1


### PR DESCRIPTION
In certain situation, e.g., internal build of FoundationDB that does not allows access to external websites, forcing a
https://pypi.python.org/simple will prevent from using other pypis.

This patch will remove this hard requirement.

Replace this text with your description here...

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
