### PR TITLE
Add FileLevelEncryption field to BackupDescription JSON output

### DIFF
--- a/fdbclient/BackupContainer.actor.cpp
+++ b/fdbclient/BackupContainer.actor.cpp
@@ -197,6 +197,7 @@ std::string BackupDescription::toJSON() const {
 	doc.setKey("URL", url.c_str());
 	doc.setKey("Restorable", maxRestorableVersion.present());
 	doc.setKey("Partitioned", partitioned);
+	doc.setKey("FileLevelEncryption", fileLevelEncryption);
 
 	auto formatVersion = [&](Version v) {
 		JsonBuilderObject doc;


### PR DESCRIPTION
This PR adds the `FileLevelEncryption` field to the BackupDescription JSON output to expose whether a backup uses file-level encryption. This field was already present in the text-based output but was missing from the JSON output.

## Testing Results

### Encrypted Backup (BEFORE - this change)
```
fdbbackup describe -C backup_testing/s3.511207.dMmp/loopback_cluster/fdb.cluster  -d  file:///root/local_testing/backup_before/backup-2026-01-06-04-09-54.636650/ --json

{
  "SchemaVersion": "1.0.0",
  "URL": "file:///root/local_testing/backup_before/backup-2026-01-06-04-09-54.636650/",
  "Restorable": true,
  "Partitioned": false,
  "Snapshots": [
    .....
}

```

### Encrypted Backup (After - this change)
```
fdbbackup describe -C backup_testing/s3.511207.dMmp/loopback_cluster/fdb.cluster  -d  file:///root/local_testing/backup_before/backup-2026-01-06-04-03-08.320838/ --json
{
  "SchemaVersion": "1.0.0",
  "URL": "file:///root/local_testing/backup_before/backup-2026-01-06-04-03-08.320838/",
  "Restorable": true,
  "Partitioned": false,
  "FileLevelEncryption": true,
  "Snapshots": [
    ...
}

```

100k Simulation tests Completed
` 20260106-025412-ak_bk_json-579c3056269ca1ea        compressed=True data_size=35340918 duration=4946981 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:25:04 sanity=False started=100000 stopped=20260106-041916 submitted=20260106-025412 timeout=5400 username=ak_bk_json
`
# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
