### PR TITLE
Add FileLevelEncryption field to BackupDescription JSON output (#12619)

### DIFF
--- a/fdbclient/BackupContainer.actor.cpp
+++ b/fdbclient/BackupContainer.actor.cpp
@@ -193,6 +193,7 @@ std::string BackupDescription::toJSON() const {
 	doc.setKey("URL", url.c_str());
 	doc.setKey("Restorable", maxRestorableVersion.present());
 	doc.setKey("Partitioned", partitioned);
+	doc.setKey("FileLevelEncryption", fileLevelEncryption);
 
 	auto formatVersion = [&](Version v) {
 		JsonBuilderObject doc;


### PR DESCRIPTION
Cherrypick https://github.com/apple/foundationdb/pull/12619

100k simulation tests completed
` 20260106-220433-bk_json_7.3-d7d7a247ecfbe6f9       compressed=True data_size=35197427 duration=4662310 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:54:44 sanity=False started=100000 stopped=20260106-225917 submitted=20260106-220433 timeout=5400 username=bk_json_7.3
`
# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
