### PR TITLE
EncryptionBackup: Log encryption key file access failures at SevError severity

### DIFF
--- a/fdbclient/BackupContainerFileSystem.actor.cpp
+++ b/fdbclient/BackupContainerFileSystem.actor.cpp
@@ -1307,9 +1307,7 @@ public:
 			    0400));
 			keyFile = _keyFile;
 		} catch (Error& e) {
-			TraceEvent(SevError, "FailedToOpenEncryptionKeyFile")
-			    .error(e)
-			    .detail("FileName", encryptionKeyFileName);
+			TraceEvent(SevError, "FailedToOpenEncryptionKeyFile").error(e).detail("FileName", encryptionKeyFileName);
 			throw e;
 		}
 		int bytesRead = wait(keyFile->read(cipherKey->data(), cipherKey->size(), 0));


### PR DESCRIPTION
Change the TraceEvent severity for encryption key file access failures from  SevWarn (30) to SevError (40).
When a backup agent on any host cannot access the encryption key file, it must be logged at error severity to ensure immediate visibility and that backup agent doesn't proceed.

### Testing
Tested with a local cluster running two backup agents - one with access to the encryption key file and one without access by changing permissions of encryption key file.

Agent WITHOUT access to encryption key file logs Sev 40 and doesn't upload anything

```
<Event Severity="40" ErrorKind="DiskIssue" Type="FailedToOpenEncryptionKeyFile" 
       Error="io_error" ErrorDescription="Disk i/o operation failed" 
       FileName="/root/local_testing/key_file" />
```

Agent WITH proper access proceeds succesfully - 

```
<Event Severity="10" Type="FileBackupWroteRangeFile" BackupUID="a429058d7c4e8332" Size="4293" Keys="100" />
<Event Severity="10" Type="FileBackupRangeFinish" BackupUID="a429058d7c4e8332" />

```

100k simulation tests completed
`  20260108-234734-ak_bk_multipleagents-10beade19fef8ec9 compressed=True data_size=35340193 duration=4638277 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=3:00:27 sanity=False started=100000 stopped=20260109-024801 submitted=20260108-234734 timeout=5400 username=ak_bk_multipleagents
`  
# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
