### PR TITLE
Fix for toggling backup_worker_enabled during backup v2 causing assert.

### DIFF
--- a/fdbclient/SystemData.cpp
+++ b/fdbclient/SystemData.cpp
@@ -1005,6 +1005,7 @@ ProcessClass decodeProcessClassValue(ValueRef const& value) {
 const KeyRangeRef configKeys("\xff/conf/"_sr, "\xff/conf0"_sr);
 const KeyRef configKeysPrefix = configKeys.begin;
 
+const KeyRef backupWorkerEnabledKey("\xff/conf/backup_worker_enabled"_sr);
 const KeyRef perpetualStorageWiggleKey("\xff/conf/perpetual_storage_wiggle"_sr);
 const KeyRef perpetualStorageWiggleLocalityKey("\xff/conf/perpetual_storage_wiggle_locality"_sr);
 // The below two are there for compatible upgrade and downgrade. After 7.3, the perpetual wiggle related keys should use

--- a/fdbclient/include/fdbclient/GenericManagementAPI.actor.h
+++ b/fdbclient/include/fdbclient/GenericManagementAPI.actor.h
@@ -532,6 +532,12 @@ Future<ConfigurationResult> changeConfig(Reference<DB> db, std::map<std::string,
 						resetPPWStats = false; // the latter setting will override the former setting
 					}
 				}
+
+				// Clear backup progress when backup workers are disabled
+				if (i->first == backupWorkerEnabledKey && i->second == "0") {
+					tr->clear(backupProgressKeys);
+					TraceEvent("BackupWorkerProgressCleared");
+				}
 			}
 
 			if (!creating && resetPPWStats) {

--- a/fdbclient/include/fdbclient/SystemData.h
+++ b/fdbclient/include/fdbclient/SystemData.h
@@ -356,6 +356,7 @@ UID decodeProcessClassKeyOld(KeyRef const& key);
 extern const KeyRangeRef configKeys;
 extern const KeyRef configKeysPrefix;
 
+extern const KeyRef backupWorkerEnabledKey;
 extern const KeyRef perpetualStorageWiggleKey;
 extern const KeyRef perpetualStorageWiggleLocalityKey;
 extern const KeyRef perpetualStorageWiggleIDPrefix;

--- a/fdbserver/BackupWorker.actor.cpp
+++ b/fdbserver/BackupWorker.actor.cpp
@@ -716,6 +716,13 @@ ACTOR Future<Void> saveProgress(BackupData* self, Version backupVersion) {
 			tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
 			tr.setOption(FDBTransactionOptions::LOCK_AWARE);
 
+			// CHECK: Don't save progress if backup workers are disabled
+			Optional<Value> backupWorkerEnabled = wait(tr.get(backupWorkerEnabledKey));
+			if (!backupWorkerEnabled.present() || backupWorkerEnabled.get() == "0"_sr) {
+				TraceEvent("BackupWorkerProgressSkipped", self->myId).detail("Reason", "BackupWorkersDisabled");
+				return Void();
+			}
+
 			WorkerBackupStatus status(self->backupEpoch, backupVersion, self->tag, self->totalTags);
 			tr.set(key, backupProgressValue(status));
 			tr.addReadConflictRange(singleKeyRange(key));
@@ -1079,7 +1086,8 @@ ACTOR Future<Void> pullAsyncData(BackupData* self) {
 			    .detail("BackupEpoch", self->backupEpoch)
 			    .detail("Popped", r->popped())
 			    .detail("NoopPoppedVersion", maxNoopVersion)
-			    .detail("ExpectedPeekVersion", tagAt);
+			    .detail("ExpectedPeekVersion", tagAt)
+			    .detail("RecruitedEpoch", self->recruitedEpoch);
 			ASSERT(self->backupEpoch < self->recruitedEpoch && maxNoopVersion >= r->popped());
 			// This can only happen when the backup was in NOOP mode in the previous epoch,
 			// where NOOP mode popped version is larger than the expected peek version.


### PR DESCRIPTION
cherry-pick of https://github.com/apple/foundationdb/pull/12666
Fix for toggling backup_worker_enabled during backup v2 causing assert.

Problem: Once the backup v2 started, if we change backup_worker_enabled= 0 and then back to backup_worker_enabled=1. In this scenario the backup workers processing oldEPochs are waiting to start working from where they left before (picking from backupProgress keys in DB). But this is not ideal, because those mutations might have been deleted from TLog'S. The code asserts that it is not finding mutations in TLog.

Solution:
FIx1: When backup_worker_enabled= 0 is configured, the backupProgress keys are deleted.
Fix2: When time backup_workers_enabled = 1, and if there is no backupProgress keys, don't start backupWorkers processing old epochs.

Testing:
-Added appropriate simulation test changes
-Tested this scenario before and after fix in perf/s03
-Tested in simulation before and after the fix.
-Correctness result:
20260130-004925-neethu-toggle-7.4-4d20ff5233c77a5d compressed=True data_size=60579119 duration=4509323 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=6:48:58 sanity=False started=100000 stopped=20260130-073823 submitted=20260130-004925 timeout=5400 username=neethu-toggle-7.4

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
