### PR TITLE
Remove unused code probes at master role

### DIFF
--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -596,21 +596,6 @@ ACTOR Future<Void> masterServerCxx(MasterInterface mi,
 			addActor.getFuture().pop();
 		}
 
-		CODE_PROBE(
-		    err.code() == error_code_tlog_failed, "Master: terminated due to tLog failure", probe::decoration::rare);
-		CODE_PROBE(err.code() == error_code_commit_proxy_failed,
-		           "Master: terminated due to commit proxy failure",
-		           probe::decoration::rare);
-		CODE_PROBE(err.code() == error_code_grv_proxy_failed,
-		           "Master: terminated due to GRV proxy failure",
-		           probe::decoration::rare);
-		CODE_PROBE(err.code() == error_code_resolver_failed,
-		           "Master: terminated due to resolver failure",
-		           probe::decoration::rare);
-		CODE_PROBE(err.code() == error_code_backup_worker_failed,
-		           "Master: terminated due to backup worker failure",
-		           probe::decoration::rare);
-
 		if (normalMasterErrors().contains(err.code())) {
 			TraceEvent("MasterTerminated", mi.id()).error(err);
 			return Void();


### PR DESCRIPTION
Coverage tool found no match for these events, because the refactoring has moved monitoring of txn system failures from master role to CC now.

20260114-191638-jzhou-8b0375f79fbded8c             compressed=True data_size=34486159 duration=4535093 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=3:15:47 sanity=False started=100000 stopped=20260114-223225 submitted=20260114-191638 timeout=5400 username=jzhou

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
