### PR TITLE
Fix a few file read cancellation bugs

### DIFF
--- a/fdbclient/BackupContainerFileSystem.actor.cpp
+++ b/fdbclient/BackupContainerFileSystem.actor.cpp
@@ -1310,7 +1310,7 @@ public:
 			TraceEvent(SevError, "FailedToOpenEncryptionKeyFile").error(e).detail("FileName", encryptionKeyFileName);
 			throw e;
 		}
-		int bytesRead = wait(keyFile->read(cipherKey->data(), cipherKey->size(), 0));
+		int bytesRead = wait(uncancellable(keyFile->read(cipherKey->data(), cipherKey->size(), 0)));
 		if (bytesRead != cipherKey->size()) {
 			TraceEvent(SevError, "InvalidEncryptionKeyFileSize")
 			    .detail("ExpectedSize", cipherKey->size())


### PR DESCRIPTION
File read can't be cancelled, so we have to hold on the buffer and issue reads.

This was found in #12642 test, seed:

-f ./tests/slow/BulkDumpingS3WithChaos.toml -s 1554084314 -b off

20260116-223043-jzhou-860a6897a9eb32c2             compressed=True data_size=34489903 duration=4665976 ended=100000 fail=1 fail_fast=10 max_runs=100000 pass=99999 priority=100 remaining=0 runtime=0:53:38 sanity=False started=100000 stopped=20260116-232421 submitted=20260116-223043 timeout=5400 username=jzhou

`-f ./tests/slow/ParallelRestoreOldBackupCorrectnessAtomicOp.toml -s 223090903 -b on`, unrelated error `Assertion batchData.isValid() failed @ /root/src/foundationdb/fdbserver/RestoreApplier.actor.cpp 740:`.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
