### PR TITLE
Fix s3client_test ctest 'ERROR: Missing s3client/ls_test/sub1/file2_2…

### DIFF
--- a/fdbclient/tests/s3client_test.sh
+++ b/fdbclient/tests/s3client_test.sh
@@ -403,8 +403,9 @@ function wait_for_files_in_listing {
   
   while [[ $attempt -lt $max_attempts ]]; do
     local output
+    # Capture only stdout (listing output), discard stderr (HTTP debug messages)
     output=$(run_s3client "${s3client}" "${credentials}" "${logsdir}" "false" \
-      --knob_blobstore_list_max_keys_per_page=100 ls --recursive "${url}" 2>&1)
+      --knob_blobstore_list_max_keys_per_page=100 ls --recursive "${url}" 2>/dev/null)
     
     local found_count
     found_count=$(echo "${output}" | grep -c "${pattern}" || true)


### PR DESCRIPTION
… in ls output'

The correct number of files are listed:

2026-01-16T04:59:53+00:00 ERROR: Missing s3client/ls_test/sub1/file2_2 in ls output 2026-01-16T04:59:53+00:00 === DEBUG: Recursive ls output === Contents of blobstore://127.0.0.1:8081/s3client/ls_test?bucket=test-bucket&region=us-east-1&secure_connection=0:
 s3client/ls_test/file1_1 26.00 B
 s3client/ls_test/file1_2 26.00 B
 s3client/ls_test/sub1/file2_1 26.00 B
 s3client/ls_test/sub1/file2_2 26.00 B
 s3client/ls_test/sub1/sub2/file3_1 26.00 B
 s3client/ls_test/sub1/sub2/file3_2 26.00 B
2026-01-16T04:59:53+00:00 === END DEBUG ===

... but we overcount because of the HTTP loggging. Lines like this...

[4a60d5628a4137592fe32d5a5b949bb8] HTTP starting GET /test-bucket/s3client/ls_test/sub1/file2_2?tagging=

.... matches the grep pattern. Just look at stdout. Don't mix in stderr (HTTP logs).