### PR TITLE
FDB release 7.4: use RocksDB v8.11.5

### DIFF
--- a/cmake/RocksDBVersion.cmake
+++ b/cmake/RocksDBVersion.cmake
@@ -16,8 +16,8 @@
 # OPTION 1: RocksDB Release Number
 # If you use this option, make sure Option 2 below is commented out.
 ###############################################################################
-# set(ROCKSDB_VERSION "9.7.3")
-# set(ROCKSDB_VERSION_SHA256 "acfabb989cbfb5b5c4d23214819b059638193ec33dad2d88373c46448d16d38b")
+set(ROCKSDB_VERSION "8.11.5")
+set(ROCKSDB_VERSION_SHA256 "2641eb63ee2d691c0e96de0a55edfcc4cab181d9b6c31fa4a33c478423062196")
 
 ###############################################################################
 # OPTION 2: RocksDB Git Commit Hash
@@ -26,5 +26,5 @@
 # Note: CMake will auto-fetch the version from GitHub at configure time.
 # This requires network access during cmake configure.
 ###############################################################################
-set(ROCKSDB_GIT_HASH "2732f118497ab75cd2e44bc327746be180b42dcf")
-set(ROCKSDB_GIT_HASH_SHA256 "5f0dd06680c0bf302abb9bc70b4698fdcd0d5623c7264c8b3af7a1fe4f8b3078")
+# set(ROCKSDB_GIT_HASH "2732f118497ab75cd2e44bc327746be180b42dcf")
+# set(ROCKSDB_GIT_HASH_SHA256 "5f0dd06680c0bf302abb9bc70b4698fdcd0d5623c7264c8b3af7a1fe4f8b3078")


### PR DESCRIPTION
Fb has tagged the rocksdb v8.11.5 release: https://github.com/facebook/rocksdb/pull/14145#issuecomment-3779898718, https://github.com/facebook/rocksdb/releases/tag/v8.11.5

So we can go back to version based approach. This PR does that.

100K running: 20260122-001902-praza-fdb-7.4-rocksdb-8.11.-04e8014b8255b29a compressed=True data_size=40238024 duration=5066335 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=2:37:11 sanity=False started=100000 stopped=20260122-025613 submitted=20260122-001902 timeout=5400 username=praza-fdb-7.4-rocksdb-8.11.5-97a59accef3674ab24406ebe41d5cb6a50af4d8d

Also ensured `fdbserver --version` reports correct output:

```
FoundationDB 7.4 (v7.4.6)
source version 97a59accef3674ab24406ebe41d5cb6a50af4d8d
protocol fdb00b074000000
rocksdb 8.11.5
```

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
