### PR TITLE
Encryption changes in status json

### DIFF
--- a/fdbbackup/tests/dir_backup_test.sh
+++ b/fdbbackup/tests/dir_backup_test.sh
@@ -104,6 +104,9 @@ function test_dir_backup_and_restore {
     err "Failed backup"
     return 1
   fi
+
+  test_fdbcli_status_json_for_bkup "${local_build_dir}" "${scratch_dir}"
+
   log "Clear fdb data"
   if ! clear_data "${local_build_dir}" "${scratch_dir}"; then
     err "Failed clear data in fdb"

--- a/fdbbackup/tests/s3_backup_test.sh
+++ b/fdbbackup/tests/s3_backup_test.sh
@@ -132,6 +132,9 @@ function test_s3_backup_and_restore {
     err "Failed backup"
     return 1
   fi
+
+  test_fdbcli_status_json_for_bkup "${local_build_dir}" "${local_scratch_dir}"
+
   log "Clear fdb data"
   if ! clear_data "${local_build_dir}" "${local_scratch_dir}"; then
     err "Failed clear data in fdb"

--- a/fdbclient/BackupContainerFileSystem.actor.cpp
+++ b/fdbclient/BackupContainerFileSystem.actor.cpp
@@ -1314,7 +1314,8 @@ public:
 		if (bytesRead != cipherKey->size()) {
 			TraceEvent(SevError, "InvalidEncryptionKeyFileSize")
 			    .detail("ExpectedSize", cipherKey->size())
-			    .detail("ActualSize", bytesRead);
+			    .detail("ActualSize", bytesRead)
+			    .detail("FileName", encryptionKeyFileName);
 			throw invalid_encryption_key_file();
 		}
 		ASSERT_EQ(bytesRead, cipherKey->size());

--- a/fdbclient/include/fdbclient/BackupContainer.h
+++ b/fdbclient/include/fdbclient/BackupContainer.h
@@ -316,6 +316,8 @@ public:
 
 	static std::string lastOpenError;
 
+	virtual Future<Void> encryptionSetupComplete() const = 0;
+
 	// TODO: change the following back to `private` once blob obj access is refactored
 protected:
 	std::string URL;

--- a/fdbclient/include/fdbclient/BackupContainerFileSystem.h
+++ b/fdbclient/include/fdbclient/BackupContainerFileSystem.h
@@ -165,10 +165,14 @@ public:
 
 	Future<Void> writeEncryptionMetadata() override;
 
+	// Waits for encryption initialization to complete by reading encryption key file during container opening.
+	Future<Void> encryptionSetupComplete() const override;
+
 protected:
+	// Returns true if an encryption key file was provided.
 	bool usesEncryption() const;
+
 	void setEncryptionKey(Optional<std::string> const& encryptionKeyFileName);
-	Future<Void> encryptionSetupComplete() const;
 
 	Future<Void> writeEntireFileFallback(const std::string& fileName, const std::string& fileContents);
 

--- a/fdbclient/tests/tests_common.sh
+++ b/fdbclient/tests/tests_common.sh
@@ -176,3 +176,11 @@ function grep_for_severity40 {
     return 1
   fi
 }
+
+function test_fdbcli_status_json_for_bkup {
+  local local_build_dir="${1}"
+  local local_scratch_dir="${2}"
+  # Give backup agent time to write status
+  sleep 5
+  "${local_build_dir}"/bin/fdbcli -C "${local_scratch_dir}/loopback_cluster/fdb.cluster" --exec 'status json' | jq '.cluster.layers'
+}


### PR DESCRIPTION
Cherry-pick 

- Display Encryption Key Info in status json  https://github.com/apple/foundationdb/pull/12649
- EncryptionBackup: Log encryption key file access failures at SevError severity https://github.com/apple/foundationdb/pull/12629

### Testing
100k simulation tests completed:
`  20260124-232538-ak_7.4_status_json_bk-53300c347502666a compressed=True data_size=41376205 duration=4930427 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:57:32 sanity=False started=100000 stopped=20260125-002310 submitted=20260124-232538 timeout=5400 username=ak_7.4_status_json_bk
`