### PR TITLE
Encryption changes in status json

### DIFF
--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -50,6 +50,7 @@
 #include "fdbclient/S3BlobStore.h"
 #include "fdbclient/SystemData.h"
 #include "fdbclient/json_spirit/json_spirit_writer_template.h"
+#include "fdbclient/BackupContainer.h"
 
 #include "flow/Platform.h"
 
@@ -1601,6 +1602,32 @@ ACTOR Future<std::string> getLayerStatus(Reference<ReadYourWritesTransaction> tr
 		wait(waitForAll(tagLastRestorableVersions) && waitForAll(tagStates) && waitForAll(tagContainers) &&
 		     waitForAll(tagRangeBytes) && waitForAll(tagLogBytes) && success(fBackupPaused));
 
+		state std::vector<Future<Void>> encryptionSetupResults;
+		state std::vector<int> encryptionContainerIndices;
+
+		for (int i = 0; i < tagContainers.size(); i++) {
+			if (tagContainers[i].get()->getEncryptionKeyFileName().present()) {
+				encryptionSetupResults.push_back(tagContainers[i].get()->encryptionSetupComplete());
+				encryptionContainerIndices.push_back(i);
+			}
+		}
+		wait(waitForAllReady(encryptionSetupResults));
+		json_spirit::mArray keysArr;
+		std::unordered_set<std::string> seenKeyPaths;
+		for (int j = 0; j < encryptionContainerIndices.size() && j < 1e6; j++) {
+			int i = encryptionContainerIndices[j];
+			std::string keyPath = tagContainers[i].get()->getEncryptionKeyFileName().get();
+
+			if (seenKeyPaths.find(keyPath) == seenKeyPaths.end()) {
+				seenKeyPaths.insert(keyPath);
+				json_spirit::mObject keyObj;
+				keyObj["path"] = tagContainers[i].get()->getEncryptionKeyFileName().get();
+				keyObj["success"] = !encryptionSetupResults[j].isError();
+				keysArr.push_back(keyObj);
+			}
+		}
+		o.create("encryption_keys") = keysArr;
+
 		JSONDoc tagsRoot = layerRoot.subDoc("tags.$latest");
 		layerRoot.create("tags.timestamp") = now();
 		layerRoot.create("total_workers.$sum") =
@@ -1629,7 +1656,11 @@ ACTOR Future<std::string> getLayerStatus(Reference<ReadYourWritesTransaction> tr
 			tagRoot.create("range_bytes_written") = tagRangeBytes[j].get();
 			tagRoot.create("mutation_log_bytes_written") = tagLogBytes[j].get();
 			tagRoot.create("mutation_stream_id") = backupTagUids[j].toString();
-
+			tagRoot.create("file_level_encryption") =
+			    tagContainers[j].get()->getEncryptionKeyFileName().present() ? true : false;
+			if (tagContainers[j].get()->getEncryptionKeyFileName().present()) {
+				tagRoot.create("encryption_key_file") = tagContainers[j].get()->getEncryptionKeyFileName().get();
+			}
 			j++;
 		}
 	} else if (exe == ProgramExe::DR_AGENT) {

--- a/fdbclient/BackupContainerFileSystem.actor.cpp
+++ b/fdbclient/BackupContainerFileSystem.actor.cpp
@@ -1311,7 +1311,8 @@ public:
 		if (bytesRead != cipherKey->size()) {
 			TraceEvent(SevError, "InvalidEncryptionKeyFileSize")
 			    .detail("ExpectedSize", cipherKey->size())
-			    .detail("ActualSize", bytesRead);
+			    .detail("ActualSize", bytesRead)
+			    .detail("FileName", encryptionKeyFileName);
 			throw invalid_encryption_key_file();
 		}
 		ASSERT_EQ(bytesRead, cipherKey->size());

--- a/fdbclient/include/fdbclient/BackupContainer.h
+++ b/fdbclient/include/fdbclient/BackupContainer.h
@@ -316,6 +316,8 @@ public:
 
 	static std::string lastOpenError;
 
+	virtual Future<Void> encryptionSetupComplete() const = 0;
+
 	// TODO: change the following back to `private` once blob obj access is refactored
 protected:
 	std::string URL;

--- a/fdbclient/include/fdbclient/BackupContainerFileSystem.h
+++ b/fdbclient/include/fdbclient/BackupContainerFileSystem.h
@@ -165,10 +165,14 @@ public:
 
 	Future<Void> writeEncryptionMetadata() override;
 
+	// Waits for encryption initialization to complete by reading encryption key file during container opening.
+	Future<Void> encryptionSetupComplete() const override;
+
 protected:
+	// Returns true if an encryption key file was provided.
 	bool usesEncryption() const;
+
 	void setEncryptionKey(Optional<std::string> const& encryptionKeyFileName);
-	Future<Void> encryptionSetupComplete() const;
 
 	Future<Void> writeEntireFileFallback(const std::string& fileName, const std::string& fileContents);
 


### PR DESCRIPTION
Cherry-pick

- Display Encryption Key Info in status json https://github.com/apple/foundationdb/pull/12649
- EncryptionBackup: Log encryption key file access failures at SevError severity https://github.com/apple/foundationdb/pull/12629

### TESTING
100k tests completed:

`20260126-020817-ak_7.3_bk_status_json-1018ba9501c4b2f6 compressed=True data_size=35197339 duration=5135472 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:50:13 sanity=False started=100000 stopped=20260126-025830 submitted=20260126-020817 timeout=5400 username=ak_7.3_bk_status_json`