### PR TITLE
Release notes for 7.4.{4,5,6,7}

### DIFF
--- a/documentation/sphinx/source/release-notes/release-notes-740.rst
+++ b/documentation/sphinx/source/release-notes/release-notes-740.rst
@@ -12,8 +12,7 @@ Release Notes
 * Fixed a restore stuck bug where readLogData() errors were not propagated correctly. `(PR #12433) <https://github.com/apple/foundationdb/pull/12433>`_
 * Fixed FdbDecode memory issues. `(PR #12495) <https://github.com/apple/foundationdb/pull/12495>`_
 * Fixed decode range file keys and values interpretation bug. `(PR #12420) <https://github.com/apple/foundationdb/pull/12420>`_
-* Fixed mutation conversion to skip Tx mutations, LogProtocolMessage, and SpanContextMessage. `(PR #12604) <https://github.com/apple/foundationdb/pull/12604>`_
-* Fixed the flags used for opening the encryption key file. `(PR #12424) <https://github.com/apple/foundationdb/pull/12424>`_
+* Fixed the flags used for opening the backup encryption key file. `(PR #12424) <https://github.com/apple/foundationdb/pull/12424>`_
 * Fixed backup encryption on S3. `(PR #12289) <https://github.com/apple/foundationdb/pull/12289>`_
 * Added support for backup encryption via fdbbackup modify command. `(PR #12591) <https://github.com/apple/foundationdb/pull/12591>`_
 * Added support for backup worker to use proxy from command line to upload to S3. `(PR #12566) <https://github.com/apple/foundationdb/pull/12566>`_
@@ -23,7 +22,7 @@ Release Notes
 * Added SNI in TLS handshake. `(PR #12385) <https://github.com/apple/foundationdb/pull/12385>`_
 * Added ARM support for Docker images. `(PR #12425) <https://github.com/apple/foundationdb/pull/12425>`_
 * Added restore validation feature allowing backup/restore validation in a single cluster. `(PR #12648) <https://github.com/apple/foundationdb/pull/12648>`_
-* Upgraded RocksDB to 8.11.5. `(PR #12651) <https://github.com/apple/foundationdb/pull/12651>`_
+* Downgraded RocksDB to 8.11.5. `(PR #12651) <https://github.com/apple/foundationdb/pull/12651>`_
 
 7.4.5
 =====
@@ -34,14 +33,11 @@ Release Notes
 
 * Fixed a race that could cause recovery to be stuck when purging old generations. `(PR #12214) <https://github.com/apple/foundationdb/pull/12214>`_
 * Fixed TSS mismatch handling crashes. `(PR #12330) <https://github.com/apple/foundationdb/pull/12330>`_
-* Fixed potential DatabaseContext leaks in multi-version client.
+* Fixed potential DatabaseContext leaks in multi-version client. `(PR #12308) <https://github.com/apple/foundationdb/pull/12308>`_
 * Fixed double-encoding of URIs in requests to S3BlobStore. `(PR #12302) <https://github.com/apple/foundationdb/pull/12302>`_
 * Fixed "Unknown error" when configuring regions. `(PR #12314) <https://github.com/apple/foundationdb/pull/12314>`_
 * Improved TLS handshake process to avoid blocking main thread. `(PR #12346) <https://github.com/apple/foundationdb/pull/12346>`_
-* Fixed TLS to accept same key with different values. `(PR #12321) <https://github.com/apple/foundationdb/pull/12321>`_
-* Added network and connection counters for improved observability. `(PR #12295) <https://github.com/apple/foundationdb/pull/12295>`_, `(PR #12355) <https://github.com/apple/foundationdb/pull/12355>`_
-* Added TLS stats. `(PR #12277) <https://github.com/apple/foundationdb/pull/12277>`_
-* Reverted a spill by reference change that caused issues. `(PR #12298) <https://github.com/apple/foundationdb/pull/12298>`_
+* Fixed an issue in TLog server code that was causing OOMs. `(PR #12298) <https://github.com/apple/foundationdb/pull/12298>`_
 
 7.4.3
 =====


### PR DESCRIPTION
As title. 

Note: non-avx (even numbers) will not be needed in the future. Needs some thought on whether we're ok with +1 and even avx releases in the future, or just do +2 and keep odd avx releases. Until then, keeping 7.4.6 in the release notes, can change if needed. 

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
