### PR TITLE
Fix for toggling backup_worker_enabled during backup v2 causing assert.

### DIFF
--- a/fdbclient/SystemData.cpp
+++ b/fdbclient/SystemData.cpp
@@ -965,6 +965,7 @@ ProcessClass decodeProcessClassValue(ValueRef const& value) {
 const KeyRangeRef configKeys("\xff/conf/"_sr, "\xff/conf0"_sr);
 const KeyRef configKeysPrefix = configKeys.begin;
 
+const KeyRef backupWorkerEnabledKey("\xff/conf/backup_worker_enabled"_sr);
 const KeyRef perpetualStorageWiggleKey("\xff/conf/perpetual_storage_wiggle"_sr);
 const KeyRef perpetualStorageWiggleLocalityKey("\xff/conf/perpetual_storage_wiggle_locality"_sr);
 // The below two are there for compatible upgrade and downgrade. After 7.3, the perpetual wiggle related keys should use

--- a/fdbclient/include/fdbclient/GenericManagementAPI.actor.h
+++ b/fdbclient/include/fdbclient/GenericManagementAPI.actor.h
@@ -447,6 +447,12 @@ Future<ConfigurationResult> changeConfig(Reference<DB> db, std::map<std::string,
 						resetPPWStats = false; // the latter setting will override the former setting
 					}
 				}
+
+				// Clear backup progress when backup workers are disabled
+				if (i->first == backupWorkerEnabledKey && i->second == "0") {
+					tr->clear(backupProgressKeys);
+					TraceEvent("BackupWorkerProgressCleared");
+				}
 			}
 
 			if (!creating && resetPPWStats) {

--- a/fdbclient/include/fdbclient/SystemData.h
+++ b/fdbclient/include/fdbclient/SystemData.h
@@ -324,6 +324,7 @@ UID decodeProcessClassKeyOld(KeyRef const& key);
 extern const KeyRangeRef configKeys;
 extern const KeyRef configKeysPrefix;
 
+extern const KeyRef backupWorkerEnabledKey;
 extern const KeyRef perpetualStorageWiggleKey;
 extern const KeyRef perpetualStorageWiggleLocalityKey;
 extern const KeyRef perpetualStorageWiggleIDPrefix;

--- a/fdbserver/workloads/BackupCorrectnessPartitioned.actor.cpp
+++ b/fdbserver/workloads/BackupCorrectnessPartitioned.actor.cpp
@@ -328,11 +328,14 @@ struct BackupAndRestorePartitionedCorrectnessWorkload : TestWorkload {
 				}
 
 			} catch (Error& e) {
+				if (e.code() == error_code_actor_cancelled) {
+					throw e;
+				}
 				TraceEvent(SevError, "BARW_BackupWorkerToggleException", randomID)
 				    .error(e)
 				    .detail("Tag", printable(tag))
 				    .detail("ToggleCount", toggleCount);
-				throw e;
+				throw;
 			}
 		}
 		return Void();

--- a/fdbserver/workloads/BackupCorrectnessPartitioned.actor.cpp
+++ b/fdbserver/workloads/BackupCorrectnessPartitioned.actor.cpp
@@ -52,9 +52,11 @@ struct BackupAndRestorePartitionedCorrectnessWorkload : TestWorkload {
 	static int backupAgentRequests;
 	LockDB locked{ false };
 	bool allowPauses;
+	bool allowBackupWorkerToggle;
 	bool shareLogRange;
 	bool shouldSkipRestoreRanges;
 	bool defaultBackup;
+	bool mightMissMutationLogs;
 	Optional<std::string> encryptionKeyFileName;
 
 	BackupAndRestorePartitionedCorrectnessWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
@@ -86,8 +88,10 @@ struct BackupAndRestorePartitionedCorrectnessWorkload : TestWorkload {
 		                                 : 0.0);
 		agentRequest = getOption(options, "simBackupAgents"_sr, true);
 		allowPauses = getOption(options, "allowPauses"_sr, true);
+		allowBackupWorkerToggle = getOption(options, "allowBackupWorkerToggle"_sr, true);
 		shareLogRange = getOption(options, "shareLogRange"_sr, false);
 		defaultBackup = getOption(options, "defaultBackup"_sr, false);
+		mightMissMutationLogs = false;
 
 		std::vector<std::string> restorePrefixesToInclude =
 		    getOption(options, "restorePrefixesToInclude"_sr, std::vector<std::string>());
@@ -213,6 +217,7 @@ struct BackupAndRestorePartitionedCorrectnessWorkload : TestWorkload {
 		    .detail("DifferentialBackup", differentialBackup)
 		    .detail("StopDifferentialAfter", stopDifferentialAfter)
 		    .detail("AgentRequest", agentRequest)
+		    .detail("AllowBackupWorkerToggle", allowBackupWorkerToggle)
 		    .detail("Encrypted", encryptionKeyFileName.present());
 
 		return _start(cx, this);
@@ -272,6 +277,67 @@ struct BackupAndRestorePartitionedCorrectnessWorkload : TestWorkload {
 		}
 	}
 
+	ACTOR static Future<Void> testBackupWorkerToggle(BackupAndRestorePartitionedCorrectnessWorkload* self,
+	                                                 Database cx,
+	                                                 Key tag,
+	                                                 UID randomID) {
+		// Currently disabling this toggling, as it is causing missing mutation logs,
+		// restorableState for each snapshot is not set properly in this scenario for backup v2
+		// which is causing the restore to fail.
+		// After fixing the issue, I will re-enable the toggling again.
+		if (self->allowBackupWorkerToggle && deterministicRandom()->random01() < 0) {
+			state int toggleCount = deterministicRandom()->randomInt(1, 4); // Random 1 to 3 toggles
+			TraceEvent("BARW_BackupWorkerToggleTest", randomID)
+			    .detail("Tag", printable(tag))
+			    .detail("TestingBackupWorkerToggle", true)
+			    .detail("ToggleCount", toggleCount);
+
+			// Waiting for the backup to start.
+			wait(delay(50));
+
+			// When we toggle backup_worker_enabled flag, we might miss uplaoding few mutation logs
+			self->mightMissMutationLogs = true;
+
+			try {
+				state int i;
+				for (i = 0; i < toggleCount; i++) {
+					// Disable backup workers
+					wait(disableBackupWorker(cx));
+					TraceEvent("BARW_BackupWorkerDisabled", randomID)
+					    .detail("Tag", printable(tag))
+					    .detail("ToggleIteration", i + 1)
+					    .detail("TotalToggles", toggleCount);
+
+					// Wait for a random period (5-15 seconds) with backup workers disabled
+					state double disabledDuration = deterministicRandom()->random01() * 10.0 + 5.0;
+					wait(delay(disabledDuration));
+
+					// Re-enable backup workers
+					wait(enableBackupWorker(cx));
+					TraceEvent("BARW_BackupWorkerReenabled", randomID)
+					    .detail("Tag", printable(tag))
+					    .detail("DisabledDuration", disabledDuration)
+					    .detail("ToggleIteration", i + 1)
+					    .detail("TotalToggles", toggleCount);
+
+					// Wait a bit before next toggle (if not the last one)
+					if (i < toggleCount - 1) {
+						state double betweenToggleDelay = deterministicRandom()->random01() * 5.0 + 2.0; // 2-7 seconds
+						wait(delay(betweenToggleDelay));
+					}
+				}
+
+			} catch (Error& e) {
+				TraceEvent(SevError, "BARW_BackupWorkerToggleException", randomID)
+				    .error(e)
+				    .detail("Tag", printable(tag))
+				    .detail("ToggleCount", toggleCount);
+				// Continue with the test even if toggle fails
+			}
+		}
+		return Void();
+	}
+
 	ACTOR static Future<Void> doBackup(BackupAndRestorePartitionedCorrectnessWorkload* self,
 	                                   double startDelay,
 	                                   FileBackupAgent* backupAgent,
@@ -323,6 +389,9 @@ struct BackupAndRestorePartitionedCorrectnessWorkload : TestWorkload {
 			if (e.code() != error_code_backup_unneeded && e.code() != error_code_backup_duplicate)
 				throw;
 		}
+
+		state Future<Void> backupWorkerToggleTest = testBackupWorkerToggle(self, cx, tag, randomID);
+		wait(backupWorkerToggleTest);
 
 		// Stop the differential backup, if enabled
 		if (stopDifferentialDelay) {
@@ -555,79 +624,91 @@ struct BackupAndRestorePartitionedCorrectnessWorkload : TestWorkload {
 						                    : desc.maxRestorableVersion.get();
 					}
 				}
-				wait(runRYWTransaction(cx, [=](Reference<ReadYourWritesTransaction> tr) -> Future<Void> {
-					tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
-					for (auto& kvrange : self->backupRanges) {
-						// version needs to be decided before this transaction otherwise
-						// this clear mutation might be backup as well
-						tr->clear(kvrange);
-					}
-					return Void();
-				}));
 
-				// restore database
-				TraceEvent("BARW_Restore", randomID)
-				    .detail("LastBackupContainer", lastBackupContainer->getURL())
-				    .detail("RestoreAfter", self->restoreAfter)
-				    .detail("BackupTag", printable(self->backupTag))
-				    .detail("TargetVersion", targetVersion);
-				state std::vector<Future<Version>> restores;
-				state std::vector<Standalone<StringRef>> restoreTags;
-				state int restoreIndex = 0;
-				// make sure system keys are not present in the restoreRanges as they will get restored first separately
-				// from the rest
-				Standalone<VectorRef<KeyRangeRef>> modifiedRestoreRanges;
-				Standalone<VectorRef<KeyRangeRef>> systemRestoreRanges;
-				for (int i = 0; i < self->restoreRanges.size(); ++i) {
-					if (!self->restoreRanges[i].intersects(getSystemBackupRanges())) {
-						modifiedRestoreRanges.push_back_deep(modifiedRestoreRanges.arena(), self->restoreRanges[i]);
-					} else {
-						KeyRangeRef normalKeyRange = self->restoreRanges[i] & normalKeys;
-						KeyRangeRef systemKeyRange = self->restoreRanges[i] & systemKeys;
-						if (!normalKeyRange.empty()) {
-							modifiedRestoreRanges.push_back_deep(modifiedRestoreRanges.arena(), normalKeyRange);
+				if (targetVersion == -1 && !desc.maxRestorableVersion.present()) {
+					// Because of backup_worker_enabled toggle, we might miss mutation logs and the backup is not
+					// restorable. In that case, skip restore.
+					TraceEvent("BARW_RestoreSkipped", randomID)
+					    .detail("Reason", "BackupWorkers are disabled for some time")
+					    .detail("BackupDesc", desc.toString().c_str());
+					printf("Backup Description\n%s", desc.toString().c_str());
+					ASSERT(self->mightMissMutationLogs && desc.contiguousLogEnd.get() != desc.maxLogEnd.get() - 1);
+				} else {
+					wait(runRYWTransaction(cx, [=](Reference<ReadYourWritesTransaction> tr) -> Future<Void> {
+						tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+						for (auto& kvrange : self->backupRanges) {
+							// version needs to be decided before this transaction otherwise
+							// this clear mutation might be backup as well
+							tr->clear(kvrange);
 						}
-						if (!systemKeyRange.empty()) {
-							systemRestoreRanges.push_back_deep(systemRestoreRanges.arena(), systemKeyRange);
+						return Void();
+					}));
+
+					// restore database
+					TraceEvent("BARW_Restore", randomID)
+					    .detail("LastBackupContainer", lastBackupContainer->getURL())
+					    .detail("RestoreAfter", self->restoreAfter)
+					    .detail("BackupTag", printable(self->backupTag))
+					    .detail("TargetVersion", targetVersion);
+					state std::vector<Future<Version>> restores;
+					state std::vector<Standalone<StringRef>> restoreTags;
+					state int restoreIndex = 0;
+					// make sure system keys are not present in the restoreRanges as they will get restored first
+					// separately from the rest
+					Standalone<VectorRef<KeyRangeRef>> modifiedRestoreRanges;
+					Standalone<VectorRef<KeyRangeRef>> systemRestoreRanges;
+					for (int i = 0; i < self->restoreRanges.size(); ++i) {
+						if (!self->restoreRanges[i].intersects(getSystemBackupRanges())) {
+							modifiedRestoreRanges.push_back_deep(modifiedRestoreRanges.arena(), self->restoreRanges[i]);
+						} else {
+							KeyRangeRef normalKeyRange = self->restoreRanges[i] & normalKeys;
+							KeyRangeRef systemKeyRange = self->restoreRanges[i] & systemKeys;
+							if (!normalKeyRange.empty()) {
+								modifiedRestoreRanges.push_back_deep(modifiedRestoreRanges.arena(), normalKeyRange);
+							}
+							if (!systemKeyRange.empty()) {
+								systemRestoreRanges.push_back_deep(systemRestoreRanges.arena(), systemKeyRange);
+							}
 						}
 					}
-				}
-				self->restoreRanges = modifiedRestoreRanges;
-				if (!systemRestoreRanges.empty()) {
-					// We are able to restore system keys first since we restore an entire cluster at once rather than
-					// partial key ranges.
-					// this is where it fails
-					wait(clearAndRestoreSystemKeys(
-					    cx, self, &backupAgent, targetVersion, lastBackupContainer, systemRestoreRanges));
-				}
-				// and here
+					self->restoreRanges = modifiedRestoreRanges;
+					if (!systemRestoreRanges.empty()) {
+						// We are able to restore system keys first since we restore an entire cluster at once rather
+						// than partial key ranges. this is where it fails
+						wait(clearAndRestoreSystemKeys(
+						    cx, self, &backupAgent, targetVersion, lastBackupContainer, systemRestoreRanges));
+					}
+					// and here
 
-				Standalone<StringRef> restoreTag(self->backupTag.toString() + "_" + std::to_string(restoreIndex));
-				restoreTags.push_back(restoreTag);
-				printf("BackupCorrectness, backupAgent.restore is called for restoreIndex:%d tag:%s\n",
-				       restoreIndex,
-				       restoreTag.toString().c_str());
-				restores.push_back(backupAgent.restore(cx,
-				                                       cx,
-				                                       restoreTag,
-				                                       KeyRef(lastBackupContainer->getURL()),
-				                                       lastBackupContainer->getProxy(),
-				                                       self->restoreRanges,
-				                                       WaitForComplete::True,
-				                                       targetVersion,
-				                                       Verbose::True,
-				                                       Key(),
-				                                       Key(),
-				                                       self->locked,
-				                                       UnlockDB::True,
-				                                       OnlyApplyMutationLogs::False,
-				                                       InconsistentSnapshotOnly::False,
-				                                       ::invalidVersion,
-				                                       self->encryptionKeyFileName));
-				wait(waitForAll(restores));
+					Standalone<StringRef> restoreTag(self->backupTag.toString() + "_" + std::to_string(restoreIndex));
+					restoreTags.push_back(restoreTag);
+					printf("BackupCorrectness, backupAgent.restore is called for restoreIndex:%d tag:%s "
+					       "TargetVersion:%d\n",
+					       restoreIndex,
+					       restoreTag.toString().c_str(),
+					       targetVersion);
+					restores.push_back(backupAgent.restore(cx,
+					                                       cx,
+					                                       restoreTag,
+					                                       KeyRef(lastBackupContainer->getURL()),
+					                                       lastBackupContainer->getProxy(),
+					                                       self->restoreRanges,
+					                                       WaitForComplete::True,
+					                                       targetVersion,
+					                                       Verbose::True,
+					                                       Key(),
+					                                       Key(),
+					                                       self->locked,
+					                                       UnlockDB::True,
+					                                       OnlyApplyMutationLogs::False,
+					                                       InconsistentSnapshotOnly::False,
+					                                       ::invalidVersion,
+					                                       self->encryptionKeyFileName));
+					wait(waitForAll(restores));
 
-				for (auto& restore : restores) {
-					ASSERT(!restore.isError());
+					for (auto& restore : restores) {
+						ASSERT(!restore.isError());
+					}
 				}
 			}
 			state Key backupAgentKey = uidPrefixKey(logRangesRange.begin, logUid);


### PR DESCRIPTION
Fix for toggling backup_worker_enabled during backup v2 causing assert.

Problem: Once the backup v2 started, if we change backup_worker_enabled= 0 and then back to backup_worker_enabled=1. In this  scenario the backup workers processing oldEPochs are waiting to start working from where they left before (picking from backupProgress keys in DB). But this is not ideal, because those mutations might have been deleted from TLog'S. The code asserts that it is not finding mutations in TLog.

Solution: 
FIx1: When backup_worker_enabled= 0 is configured, the backupProgress keys are deleted. 
Fix2: When time backup_workers_enabled = 1, and if there is no backupProgress keys, don't start backupWorkers processing old epochs.

Testing:
- Added appropriate simulation test changes
- Tested this scenario before and after fix in perf/s03
- Tested in simulation before and after the fix.
- Correctness result:
20260129-234128-neethu-toggle-main-1-f1b65e069e8a6765 compressed=True data_size=50278667 duration=4146915 ended=100000 fail_fast=10 max_runs=100000 pass=100000 
Latest 100K result
20260131-030547-neethu-main-toggle-bd7ec07ba116a271 compressed=True data_size=50279043 duration=4456884 ended=100000 fail_fast=10 


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
