### PR TITLE
BackupWorkerRangePartitioned new file to process range partitioned mutation logs

### DIFF
--- a/fdbserver/BackupWorkerRangePartitioned.actor.cpp
+++ b/fdbserver/BackupWorkerRangePartitioned.actor.cpp
@@ -1,0 +1,111 @@
+/*
+ * BackupWorkerRangePartitioned.actor.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "fdbserver/WaitFailure.h"
+#include "fdbserver/LogSystem.h"
+#include "fdbclient/DatabaseContext.h"
+
+#include "fdbclient/Tracing.h"
+#include "flow/actorcompiler.h" // This must be the last #include.
+
+struct BackupRangePartitionedData {
+	const UID myId;
+	const Tag tag; // tag for this backup worker
+	const int totalTags; // Total backup worker tags
+	const Version startVersion; // This worker's start version
+	const Optional<Version> endVersion; // old epoch's end version (inclusive), or empty for current epoch
+	const LogEpoch recruitedEpoch; // current epoch whose tLogs are receiving mutations
+	const LogEpoch backupEpoch; // the epoch workers should pull mutations
+
+	explicit BackupRangePartitionedData(UID id,
+	                                    Reference<AsyncVar<ServerDBInfo> const> db,
+	                                    const InitializeBackupRequest& req)
+	  : myId(id), tag(req.routerTag), totalTags(req.totalTags), startVersion(req.startVersion),
+	    endVersion(req.endVersion), recruitedEpoch(req.recruitedEpoch), backupEpoch(req.backupEpoch) {}
+};
+
+ACTOR Future<Void> checkRemoved(Reference<AsyncVar<ServerDBInfo> const> db,
+                                LogEpoch recoveryCount,
+                                BackupRangePartitionedData* self) {
+	loop {
+		bool isDisplaced =
+		    db->get().recoveryCount > recoveryCount && db->get().recoveryState != RecoveryState::UNINITIALIZED;
+		if (isDisplaced) {
+			TraceEvent("BWRangePartitionedDisplaced", self->myId)
+			    .detail("RecoveryCount", recoveryCount)
+			    .detail("RecoveryState", (int)db->get().recoveryState);
+			throw worker_removed();
+		}
+		wait(db->onChange());
+	}
+}
+
+ACTOR Future<Void> backupWorkerRangePartitioned(BackupInterface interf,
+                                                InitializeBackupRequest req,
+                                                Reference<AsyncVar<ServerDBInfo> const> db) {
+	state BackupRangePartitionedData self(interf.id(), db, req);
+	state PromiseStream<Future<Void>> addActor;
+	state Future<Void> error = actorCollection(addActor.getFuture());
+	state Future<Void> dbInfoChange = Void();
+	state Future<Void> done;
+
+	TraceEvent("BWRangePartitionedStart", self.myId)
+	    .detail("Tag", req.routerTag.toString())
+	    .detail("TotalTags", req.totalTags)
+	    .detail("StartVersion", req.startVersion)
+	    .detail("EndVersion", req.endVersion.present() ? req.endVersion.get() : -1)
+	    .detail("LogEpoch", req.recruitedEpoch)
+	    .detail("BackupEpoch", req.backupEpoch);
+
+	try {
+		addActor.send(checkRemoved(db, req.recruitedEpoch, &self));
+		addActor.send(waitFailureServer(interf.waitFailure.getFuture()));
+
+		loop choose {
+			when(wait(dbInfoChange)) {
+				dbInfoChange = db->onChange();
+				Reference<ILogSystem> ls = ILogSystem::fromServerDBInfo(self.myId, db->get(), true);
+			}
+			when(wait(done)) {
+				TraceEvent("BWRangePartitionedDone", self.myId).detail("BackupEpoch", self.backupEpoch);
+				// Notify master so that this worker can be removed from log system, then this
+				// worker (for an old epoch's unfinished work) can safely exit.
+				wait(brokenPromiseToNever(db->get().clusterInterface.notifyBackupWorkerDone.getReply(
+				    BackupWorkerDoneRequest(self.myId, self.backupEpoch))));
+				break;
+			}
+			when(wait(error)) {}
+		}
+	} catch (Error& e) {
+		state Error err = e;
+		if (e.code() == error_code_worker_removed) {
+			try {
+				wait(done);
+			} catch (Error& e) {
+				TraceEvent("BWRangePartitionedShutdownError", self.myId).errorUnsuppressed(e);
+			}
+		}
+		TraceEvent("BWRangePartitionedTerminated", self.myId).errorUnsuppressed(err);
+		if (err.code() != error_code_actor_cancelled && err.code() != error_code_worker_removed) {
+			throw err;
+		}
+	}
+	return Void();
+}


### PR DESCRIPTION
BackupWorkerRangePartitioned new file to process range partitioned mutation logs.
Contains only the initial couple functions.

Simulation:
20260203-023953-neethu-rlogs-100k-2ed7d45f1ee75eb9 compressed=True data_size=50377051 duration=4466640 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=2:38:54 sanity=False started=100000 stopped=20260203-051847 submitted=20260203-023953 timeout=5400 username=neethu-rlogs-100k

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
