### PR TITLE
Fix backup submitBackup causing txn subsystem restart

### DIFF
--- a/tests/slow/BackupS3BlobBulkLoadRestore.toml
+++ b/tests/slow/BackupS3BlobBulkLoadRestore.toml
@@ -35,7 +35,7 @@ minimumRegions = 1
 extraMachineCountDC = 3
 
 # Explicit simple config - single replication, single region, explicit process counts
-config = "single usable_regions=1 storage_engine=ssd-2 perpetual_storage_wiggle=0 commit_proxies=3 grv_proxies=3 resolvers=3 logs=3"
+config = "triple usable_regions=1 storage_engine=ssd-2 perpetual_storage_wiggle=0 commit_proxies=3 grv_proxies=3 resolvers=3 logs=3"
 
 # Disable buggify and fault injection to avoid interference with MockS3/BulkLoad
 buggify = false

--- a/tests/slow/BackupS3BlobBulkLoadRestoreMultiRange.toml
+++ b/tests/slow/BackupS3BlobBulkLoadRestoreMultiRange.toml
@@ -26,9 +26,9 @@ disableTss = true # TODO(BulkLoad): support TSS
 
 # HA (multi-region) configuration - randomly enabled for test coverage
 # Note: generateFearless controls "fearless DR" configs, simpleConfig=false allows complex configs
-generateFearless = false
+generateFearless = true
 simpleConfig = false
-minimumRegions = 1
+minimumRegions = 2
 # singleRegion not set - allows random HA configuration
 
 # Ensure enough storage servers for non-overlapping BulkLoad teams

--- a/tests/slow/BackupS3BlobBulkLoadRestoreWithChaos.toml
+++ b/tests/slow/BackupS3BlobBulkLoadRestoreWithChaos.toml
@@ -24,9 +24,9 @@ encryptModes = ['disabled']
 disableTss = true # TODO(BulkLoad): support TSS
 
 # HA (multi-region) configuration - randomly enabled for test coverage
-generateFearless = false
+generateFearless = true
 simpleConfig = false
-minimumRegions = 1
+minimumRegions = 2
 # singleRegion not set - allows random HA configuration
 
 # Ensure enough storage servers for non-overlapping BulkLoad teams


### PR DESCRIPTION
Remove checkAndDisableBackupWorkers() from submitBackup() - it was incorrectly disabling backup workers when starting a backup, triggering config changes that cause transaction subsystem restarts and commit proxy failures. This function is for cleanup when backups END, not START.

Also enable HA/multi-region testing in BulkLoad backup tests.

This is follow-up to remarks made by @spraza in #12656

Here are 250ks for each test and then for all tests:

```
  20260202-234740-stack_multirange-1227cae32485c882  compressed=True data_size=35719038 duration=16223610 ended=250000 fail_fast=10 max_runs=250000 pass=250000 priority=100 remaining=0 runtime=5:51:11 sanity=False started=250000 stopped=20260203-053851 submitted=20260202-234740 timeout=5400 username=stack_multirange

  20260203-054342-stack_chaos-bf0e2326a94b59c0       compressed=True data_size=35719289 duration=15069644 ended=250000 fail_fast=10 max_runs=250000 pass=250000 priority=100 remaining=0 runtime=5:47:10 sanity=False started=250000 stopped=20260203-113052 submitted=20260203-054342 timeout=5400 username=stack_chaos

  20260203-055312-stack_all-0ceb5e85739d45e5         compressed=True data_size=35693054 duration=10639866 ended=250000 fail=1 fail_fast=10 max_runs=250000 pass=249999 priority=100 remaining=0 runtime=5:00:11 sanity=False started=250000 stopped=20260203-105323 submitted=20260203-055312 timeout=5400 username=stack_all

Failure was RandomSeed="1844242021" SourceVersion="87b13c555888a68b0578688293782b341f0c0497" Time="1770104350" BuggifyEnabled="1" DeterminismCheck="0" FaultInjectionEnabled="1" TestFile="tests/noSim/KeyValueStoreRocksDBTest.toml"
```

... which looks unrelated.
