### PR TITLE
Fix for minRestorableVersion and maxRestorableVersion not updating correctly in case of missing mutation logs.

### DIFF
--- a/fdbserver/workloads/BackupAndParallelRestoreCorrectness.actor.cpp
+++ b/fdbserver/workloads/BackupAndParallelRestoreCorrectness.actor.cpp
@@ -558,16 +558,11 @@ struct BackupAndParallelRestoreCorrectnessWorkload : TestWorkload {
 						targetVersion = desc.minRestorableVersion.get();
 					} else if (deterministicRandom()->random01() < 0.1) {
 						targetVersion = desc.maxRestorableVersion.get();
-					} else if (deterministicRandom()->random01() < 0.5 &&
-					           desc.minRestorableVersion.get() < desc.contiguousLogEnd.get()) {
-						// The assertion may fail because minRestorableVersion may be decided by snapshot version.
-						// ASSERT_WE_THINK(desc.minRestorableVersion.get() <= desc.contiguousLogEnd.get());
-						// This assertion can fail when contiguousLogEnd < maxRestorableVersion and
-						// the snapshot version > contiguousLogEnd. I.e., there is a gap between
-						// contiguousLogEnd and snapshot version.
-						// ASSERT_WE_THINK(desc.contiguousLogEnd.get() > desc.maxRestorableVersion.get());
-						targetVersion = deterministicRandom()->randomInt64(desc.minRestorableVersion.get(),
-						                                                   desc.contiguousLogEnd.get());
+					} else if (deterministicRandom()->random01() < 0.5) {
+						targetVersion = (desc.minRestorableVersion.get() != desc.maxRestorableVersion.get())
+						                    ? deterministicRandom()->randomInt64(desc.minRestorableVersion.get(),
+						                                                         desc.maxRestorableVersion.get())
+						                    : desc.maxRestorableVersion.get();
 					}
 				}
 


### PR DESCRIPTION
Fix for minRestorableVersion and maxRestorableVersion not updating correctly in case of missing mutation logs.

Why all of a sudden simulation is failing with wrong minRestorableVersion and maxRestorableVersion?
This PR https://github.com/apple/foundationdb/pull/12666 caused a scenario to miss mutation logs and this got several simulations to fail because of wrong minRestorableVersion and maxRestorableVersion.

PR https://github.com/apple/foundationdb/pull/12666 is: BackupWorkers starts processing, but did not save any progress to DB yet. Recovery happens. Since there is no progress saved, oldEpochs did not recruit. New Epoch BW's started processing new version which is much later than the 1st snapshot.beginVersion. This is causing to miss mutation logs in the beginning of the backup. I will fix this issue in a separate PR.

```
Snapshot: startVersion=305065438 endVersion=305065438  totalBytes=120013 restorable=true 
Snapshot: startVersion=1562749426 endVersion=1562749426 totalBytes=120013 restorable=true 
MinLogBeginVersion:   318035366 
ContiguousLogEndVersion: 1680457164 
MaxLogEndVersion:    1680457164

Old output:
MinRestorableVersion:  305065438 
MaxRestorableVersion:  1680457163

New output:
MinRestorableVersion:  1562749426 
MaxRestorableVersion:  1680457163
```

Simulation run:
20260204-082856-neethu-r1-2-71c4a34cad616a0c       compressed=True data_size=50276045 duration=4377812 ended=100000 fail_fast=10 max_runs=100000 pass=100000 p


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
