### PR TITLE
Set SSL host flags to validate hostname matches certificate CN and SANs

### DIFF
--- a/flow/Net2.actor.cpp
+++ b/flow/Net2.actor.cpp
@@ -1109,9 +1109,12 @@ public:
 			                   self->peer_address,
 			                   [conn = self.getPtr()](bool verifyOk) { conn->has_trusted_peer = verifyOk; });
 
-			// Set SNI hostname if we have one (for connections made with hostname)
+			// Set SNI hostname if we have one (for connections made with hostname) and SSL flags to check
+			// certificate against.
 			if (!self->sni_hostname.empty()) {
 				int result = SSL_set_tlsext_host_name(self->ssl_sock.native_handle(), self->sni_hostname.c_str());
+				SSL_set1_host(self->ssl_sock.native_handle(), self->sni_hostname.c_str());
+				SSL_set_hostflags(self->ssl_sock.native_handle(), X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS);
 				TraceEvent("SSLSetSNIResult")
 				    .detail("Hostname", self->sni_hostname)
 				    .detail("Result", result)


### PR DESCRIPTION
It looks like we're not verifying that the hostname we are connected to actually matches the certificate Subject Name or any of it's Alternative Names. I added a couple lines from openSSL to do this for us.

OpenSSL’s documentation for the 2 lines I added can be found [here [docs.openssl.org]](https://docs.openssl.org/3.0/man3/X509_check_host/#description). Most notably, these methods should  trigger checking both CN/SAN with wildcards.

In terms of testing, I wrote a small script that isolates some of the client connection code to illustrate/verify the change in behavior [here [github.com]](https://github.com/apple/foundationdb/compare/main...nartmal:foundationdb:ltran/ssl-verify-full#diff-a02b238fbe8215f890de2dcad360901e1f9d04db7119d90dec68e4c154bb5019R30-R33). It attempts to handshake with www.google.com and the IP-Address it resolves to (on my machine at least). The expected behavior is that it fails to verify the peer in the latter case (DNS-ID is an IpAdress which isn’t on google’s certificates). It would successfully connect without my 2 line change.

It is unclear to me how to write a test with my contribution given that I need a remote server (with certificates & self-signed ca's all pre-generated). I could go the docker route and a lot of openssl CLI stuff but it feels excessive.
# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
