### PR TITLE
python: Build and publish wheel alongside source distribution

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -78,15 +78,21 @@ endif()
 
 
 set(setup_file_name foundationdb-${FDB_VERSION}.tar.gz)
+set(wheel_file_name foundationdb-${FDB_VERSION}-py3-none-any.whl)
 set(package_file ${CMAKE_BINARY_DIR}/packages/foundationdb-${FDB_VERSION}${not_fdb_release_string}.tar.gz)
-add_custom_command(OUTPUT ${package_file}
+set(wheel_package_file ${CMAKE_BINARY_DIR}/packages/foundationdb-${FDB_VERSION}${not_fdb_release_string}-py3-none-any.whl)
+
+# Build both source distribution and wheel
+# Note: foundationdb is a pure Python package (uses ctypes), so wheel is py3-none-any
+add_custom_command(OUTPUT ${package_file} ${wheel_package_file}
   COMMAND $<TARGET_FILE:Python3::Interpreter> -m ensurepip
   COMMAND $<TARGET_FILE:Python3::Interpreter> -m pip install --upgrade build
-  COMMAND $<TARGET_FILE:Python3::Interpreter> -m build --sdist &&
-          ${CMAKE_COMMAND} -E copy dist/${setup_file_name} ${package_file}
+  COMMAND $<TARGET_FILE:Python3::Interpreter> -m build
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different dist/${setup_file_name} ${package_file}
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different dist/${wheel_file_name} ${wheel_package_file}
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-  COMMENT "Create Python package")
-add_custom_target(python_package DEPENDS ${package_file})
+  COMMENT "Create Python source distribution and wheel")
+add_custom_target(python_package DEPENDS ${package_file} ${wheel_package_file})
 add_dependencies(python_package python_binding)
 add_dependencies(packages python_package)
 


### PR DESCRIPTION
Fixes #12665

The FoundationDB Python package currently publishes only source distributions to PyPI, requiring users to build the wheel locally during pip install. This adds wheel building to the CMake build process.

PR #12082 incorrectly stated that "wheel files are not accepted anymore" by PyPI. This was a misunderstanding - the linked documentation describes the source distribution format specification, not a deprecation of wheels. Wheels remain the preferred distribution format.




# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
