### PR TITLE
Check `StorageQueueInfo::acceptingRequests` in version-lag throttling calculation

### DIFF
--- a/fdbserver/Ratekeeper.actor.cpp
+++ b/fdbserver/Ratekeeper.actor.cpp
@@ -934,7 +934,9 @@ void Ratekeeper::updateRate(RatekeeperLimits* limits) {
 		Version minLimitingSSVer = std::numeric_limits<Version>::max();
 		for (const auto& it : storageQueueInfo) {
 			auto& ss = it.value;
-			if (!ss.valid || (remoteDC.present() && ss.locality.dcId() == remoteDC)) {
+			// Keep version-lag based throttling consistent with queue/durability lag calculations:
+			// ignore storage servers until they are accepting requests.
+			if (!ss.valid || !ss.acceptingRequests || (remoteDC.present() && ss.locality.dcId() == remoteDC)) {
 				continue;
 			}
 


### PR DESCRIPTION
When storage servers restart, we already ignore their storage queue for ratekeeper throttling (because the high storage queue is not caused by workload). We should do the same for version-lag throttling, because the version lag is likewise not caused by workload.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
