### PR TITLE
fix: filter auto-idempotency from cleaner progress checks

### DIFF
--- a/fdbserver/workloads/AutomaticIdempotencyWorkload.cpp
+++ b/fdbserver/workloads/AutomaticIdempotencyWorkload.cpp
@@ -35,6 +35,8 @@ struct ValueType {
 
 	template <class Ar>
 	void serialize(Ar& ar) {
+		// `automatic` is appended after the original two fields. Safe with Unversioned() because
+		// this struct is only written and read within the same test run — never persisted across binaries.
 		serializer(ar, idempotencyId, createdTime, automatic);
 	}
 };
@@ -133,10 +135,10 @@ struct AutomaticIdempotencyWorkload : TestWorkload {
 				    Value suffix = makeString(14);
 				    memset(mutateString(suffix), 0, 10);
 				    memcpy(mutateString(suffix) + 10, &index, 4);
-				    tr->atomicOp(keyPrefix.withSuffix(suffix),
-				                 ObjectWriter::toValue(ValueType{ idempotencyId, int64_t(now()), useAutomatic },
-				                                       Unversioned()),
-				                 MutationRef::SetVersionstampedKey);
+				    tr->atomicOp(
+				        keyPrefix.withSuffix(suffix),
+				        ObjectWriter::toValue(ValueType{ idempotencyId, int64_t(now()), automatic }, Unversioned()),
+				        MutationRef::SetVersionstampedKey);
 				    return Future<Void>(Void());
 			    });
 			if (committedTr->getCommittedVersion() == invalidVersion) {
@@ -303,46 +305,62 @@ struct AutomaticIdempotencyWorkload : TestWorkload {
 	}
 
 	// Only non-automatic IDs are deleted exclusively by the cleaner, so use them to track cleaner progress.
+	// Returns -1 if no non-automatic IDs remain (either none were created or all have been cleaned up).
 	Future<int64_t> getOldestCreatedTime(Database db) {
-		ReadYourWritesTransaction tr(db);
-		Key key;
-		Version commitVersion{ 0 };
-
 		RangeResult result = co_await runRYWTransaction(db, [](Reference<ReadYourWritesTransaction> tr) {
 			tr->setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
 			return tr->getRange(idempotencyIdKeys, CLIENT_KNOBS->TOO_MANY);
 		});
+
+		ASSERT(!result.more);
 
 		if (result.empty()) {
 			TraceEvent("AutomaticIdempotencyNoIdsLeft").log();
 			co_return -1;
 		}
 
-		for (const auto& kv : result) {
-			int64_t timestamp;
-			std::vector<Key> keys = idempotencyKeyValueToTestKeys(kv, &commitVersion, &timestamp);
-
-			for (const auto& currentKey : keys) {
-				key = currentKey;
-				// We use a different transaction because we set READ_SYSTEM_KEYS above, and we might be using a tenant.
-				Optional<Value> entry = co_await runRYWTransaction(
-				    db, [key = key](Reference<ReadYourWritesTransaction> tr) { return tr->get(key); });
-
-				if (!entry.present()) {
-					TraceEvent(SevError, "AutomaticIdempotencyKeyMissing")
-					    .detail("Key", key)
-					    .detail("CommitVersion", commitVersion)
-					    .detail("ReadVersion", tr.getReadVersion().get());
-					continue;
-				}
-
-				auto e = ObjectReader::fromStringRef<ValueType>(entry.get(), Unversioned());
-				if (!e.automatic) {
-					co_return e.createdTime;
+		// Collect all test keys in commit-version order before issuing any reads.
+		std::vector<Key> allKeys;
+		{
+			Version commitVersion{ 0 };
+			for (const auto& kv : result) {
+				int64_t timestamp;
+				for (auto& k : idempotencyKeyValueToTestKeys(kv, &commitVersion, &timestamp)) {
+					allKeys.push_back(std::move(k));
 				}
 			}
 		}
-		co_return -1;
+
+		// Batch-read all test entries in one transaction to avoid per-key round-trips.
+		// We use a separate transaction because READ_SYSTEM_KEYS was set above, and we might be using a tenant.
+		ReadYourWritesTransaction tr(db);
+		while (true) {
+			Error err;
+			try {
+				std::vector<Future<Optional<Value>>> futures;
+				futures.reserve(allKeys.size());
+				for (const auto& k : allKeys) {
+					futures.push_back(tr.get(k));
+				}
+				co_await waitForAll(futures);
+
+				for (int i = 0; i < static_cast<int>(futures.size()); ++i) {
+					const auto& entry = futures[i].get();
+					if (!entry.present()) {
+						TraceEvent(SevError, "AutomaticIdempotencyKeyMissing").detail("Key", allKeys[i]);
+						continue;
+					}
+					auto e = ObjectReader::fromStringRef<ValueType>(entry.get(), Unversioned());
+					if (!e.automatic) {
+						co_return e.createdTime;
+					}
+				}
+				co_return -1;
+			} catch (Error& e) {
+				err = e;
+			}
+			co_await tr.onError(err);
+		}
 	}
 
 	Future<bool> testCleanerOneIteration(Database db,
@@ -439,7 +457,10 @@ struct AutomaticIdempotencyWorkload : TestWorkload {
 		int64_t minAgeSeconds{ 0 };
 		std::vector<int64_t> createdTimes;
 
-		// Initialize minAgeSeconds to match the current status
+		// Initialize minAgeSeconds to match the current status. getOldestCreatedTime returns -1 if no
+		// non-automatic IDs remain; fmap then produces now()+1. The first outer-loop iteration passes
+		// this large value to testCleanerOneIteration, which also finds no non-automatic IDs and
+		// returns done=true, breaking the loop — the correct early-out for this case.
 		co_await (store(minAgeSeconds, fmap([](int64_t t) { return int64_t(now()) - t; }, getOldestCreatedTime(db))) &&
 		          store(createdTimes, runRYWTransaction(db, [this](Reference<ReadYourWritesTransaction> tr) {
 			                return getCreatedTimes(tr);

--- a/fdbserver/workloads/AutomaticIdempotencyWorkload.cpp
+++ b/fdbserver/workloads/AutomaticIdempotencyWorkload.cpp
@@ -31,10 +31,11 @@ struct ValueType {
 
 	Value idempotencyId;
 	int64_t createdTime;
+	bool automatic;
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, idempotencyId, createdTime);
+		serializer(ar, idempotencyId, createdTime, automatic);
 	}
 };
 } // namespace
@@ -133,7 +134,8 @@ struct AutomaticIdempotencyWorkload : TestWorkload {
 				    memset(mutateString(suffix), 0, 10);
 				    memcpy(mutateString(suffix) + 10, &index, 4);
 				    tr->atomicOp(keyPrefix.withSuffix(suffix),
-				                 ObjectWriter::toValue(ValueType{ idempotencyId, int64_t(now()) }, Unversioned()),
+				                 ObjectWriter::toValue(ValueType{ idempotencyId, int64_t(now()), useAutomatic },
+				                                       Unversioned()),
 				                 MutationRef::SetVersionstampedKey);
 				    return Future<Void>(Void());
 			    });
@@ -300,6 +302,7 @@ struct AutomaticIdempotencyWorkload : TestWorkload {
 		}
 	}
 
+	// Only non-automatic IDs are deleted exclusively by the cleaner, so use them to track cleaner progress.
 	Future<int64_t> getOldestCreatedTime(Database db) {
 		ReadYourWritesTransaction tr(db);
 		Key key;
@@ -307,7 +310,7 @@ struct AutomaticIdempotencyWorkload : TestWorkload {
 
 		RangeResult result = co_await runRYWTransaction(db, [](Reference<ReadYourWritesTransaction> tr) {
 			tr->setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
-			return tr->getRange(idempotencyIdKeys, 1);
+			return tr->getRange(idempotencyIdKeys, CLIENT_KNOBS->TOO_MANY);
 		});
 
 		if (result.empty()) {
@@ -315,24 +318,31 @@ struct AutomaticIdempotencyWorkload : TestWorkload {
 			co_return -1;
 		}
 
-		int64_t timestamp;
-		key = idempotencyKeyValueToTestKeys(result[0], &commitVersion, &timestamp)[0];
+		for (const auto& kv : result) {
+			int64_t timestamp;
+			std::vector<Key> keys = idempotencyKeyValueToTestKeys(kv, &commitVersion, &timestamp);
 
-		// We need to use a different transaction because we set READ_SYSTEM_KEYS on this one, and we might
-		// be using a tenant.
-		Optional<Value> entry = co_await runRYWTransaction(
-		    db, [key = key](Reference<ReadYourWritesTransaction> tr) { return tr->get(key); });
+			for (const auto& currentKey : keys) {
+				key = currentKey;
+				// We use a different transaction because we set READ_SYSTEM_KEYS above, and we might be using a tenant.
+				Optional<Value> entry = co_await runRYWTransaction(
+				    db, [key = key](Reference<ReadYourWritesTransaction> tr) { return tr->get(key); });
 
-		if (!entry.present()) {
-			TraceEvent(SevError, "AutomaticIdempotencyKeyMissing")
-			    .detail("Key", key)
-			    .detail("CommitVersion", commitVersion)
-			    .detail("ReadVersion", tr.getReadVersion().get());
+				if (!entry.present()) {
+					TraceEvent(SevError, "AutomaticIdempotencyKeyMissing")
+					    .detail("Key", key)
+					    .detail("CommitVersion", commitVersion)
+					    .detail("ReadVersion", tr.getReadVersion().get());
+					continue;
+				}
+
+				auto e = ObjectReader::fromStringRef<ValueType>(entry.get(), Unversioned());
+				if (!e.automatic) {
+					co_return e.createdTime;
+				}
+			}
 		}
-		ASSERT(entry.present());
-
-		auto e = ObjectReader::fromStringRef<ValueType>(entry.get(), Unversioned());
-		co_return e.createdTime;
+		co_return -1;
 	}
 
 	Future<bool> testCleanerOneIteration(Database db,
@@ -411,9 +421,13 @@ struct AutomaticIdempotencyWorkload : TestWorkload {
 		RangeResult result = co_await tr->getRange(prefixRange(keyPrefix), CLIENT_KNOBS->TOO_MANY);
 		ASSERT(!result.more);
 		std::vector<int64_t> createdTimes;
+
+		// Only non-automatic IDs reflect cleaner progress; auto IDs can be deleted immediately.
 		for (const auto& [k, v] : result) {
 			auto e = ObjectReader::fromStringRef<ValueType>(v, Unversioned());
-			createdTimes.emplace_back(e.createdTime);
+			if (!e.automatic) {
+				createdTimes.emplace_back(e.createdTime);
+			}
 		}
 		std::sort(createdTimes.begin(), createdTimes.end());
 		co_return createdTimes;


### PR DESCRIPTION
## Description 
Issue #12581

The automatic idempotency test used the oldest remaining idempotency ID as a proxy for cleaner progress. When automatic idempotency is enabled, the client deletes its IDs immediately after commit, which can make the “oldest remaining” jump forward and falsely trigger “cleaned too far.” This change records whether each transaction used automatic idempotency and filters the cleaner progress checks to non‑auto IDs only.

Changes
- Add automatic flag to the workload’s stored ValueType
- Record automatic per transaction in _start
- Filter getCreatedTimes and getOldestCreatedTime to only non‑auto IDs
- Adjust getOldestCreatedTime to scan idempotency keys until it finds a non‑auto entry

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
