### PR TITLE
Remove generate synthetic data feature; superseded by bulk load

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -1008,8 +1008,6 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( HOT_SHARD_THROTTLING_TRACKED,                             1 );
 	init( HOT_SHARD_MONITOR_FREQUENCY,                            5.0 );
 
-	init( GENERATE_DATA_ENABLED,                                false );
-	init( GENERATE_DATA_PER_VERSION_MAX,                        10000 );
 
 	//Storage Metrics
 	init( STORAGE_METRICS_AVERAGE_INTERVAL,                    120.0 );

--- a/fdbclient/SystemData.cpp
+++ b/fdbclient/SystemData.cpp
@@ -1141,7 +1141,6 @@ const KeyRef primaryLocalityKey = "\xff/globals/primaryLocality"_sr;
 const KeyRef primaryLocalityPrivateKey = "\xff\xff/globals/primaryLocality"_sr;
 const KeyRef fastLoggingEnabled = "\xff/globals/fastLoggingEnabled"_sr;
 const KeyRef fastLoggingEnabledPrivateKey = "\xff\xff/globals/fastLoggingEnabled"_sr;
-const KeyRef constructDataKey = "\xff/globals/constructData"_sr;
 
 // Whenever configuration changes or DD related system keyspace is changed(e.g.., serverList),
 // actor must grab the moveKeysLockOwnerKey and update moveKeysLockWriteKey.

--- a/fdbclient/include/fdbclient/ServerKnobs.h
+++ b/fdbclient/include/fdbclient/ServerKnobs.h
@@ -1027,11 +1027,6 @@ public:
 	int64_t HOT_SHARD_THROTTLING_TRACKED;
 	double HOT_SHARD_MONITOR_FREQUENCY;
 
-	// allow generating synthetic data for test clusters
-	bool GENERATE_DATA_ENABLED;
-	// maximum number of synthetic mutations per transaction
-	int GENERATE_DATA_PER_VERSION_MAX;
-
 	double MAX_TRANSACTIONS_PER_BYTE;
 
 	int64_t MIN_AVAILABLE_SPACE;

--- a/fdbclient/include/fdbclient/SystemData.h
+++ b/fdbclient/include/fdbclient/SystemData.h
@@ -486,7 +486,6 @@ extern const KeyRef primaryLocalityKey;
 extern const KeyRef primaryLocalityPrivateKey;
 extern const KeyRef fastLoggingEnabled;
 extern const KeyRef fastLoggingEnabledPrivateKey;
-extern const KeyRef constructDataKey;
 
 extern const KeyRef moveKeysLockOwnerKey, moveKeysLockWriteKey;
 

--- a/fdbserver/ApplyMetadataMutation.cpp
+++ b/fdbserver/ApplyMetadataMutation.cpp
@@ -552,46 +552,6 @@ private:
 		    .detail("LogRangeEnd", logRangeEnd);
 	}
 
-	void checkSetConstructKeys(MutationRef m) {
-		if (!SERVER_KNOBS->GENERATE_DATA_ENABLED) {
-			return;
-		}
-		if (!m.param1.startsWith(globalKeysPrefix)) {
-			return;
-		}
-		if (!toCommit) {
-			return;
-		}
-
-		if (m.param1.startsWith(constructDataKey)) {
-			uint64_t valSize, keyCount, seed;
-			Standalone<StringRef> prefix;
-			std::tie(prefix, valSize, keyCount, seed) = decodeConstructKeys(m.param2);
-			if (prefix.size() == 0 || keyCount >= UINT16_MAX || valSize >= CLIENT_KNOBS->VALUE_SIZE_LIMIT) {
-				return;
-			}
-			uint8_t keyBuf[prefix.size() + sizeof(uint16_t)];
-			uint8_t* keyPos = prefix.copyTo(keyBuf);
-			*keyPos = '\xff';
-			StringRef keyEnd(keyBuf, keyPos - keyBuf + 1);
-			std::set<Tag> allTags;
-			for (auto it : keyInfo->intersectingRanges(KeyRangeRef(prefix, keyEnd))) {
-				auto& r = it.value();
-				for (auto info : r.src_info) {
-					allTags.insert(info->tag);
-				}
-				for (auto info : r.dest_info) {
-					allTags.insert(info->tag);
-				}
-			}
-			toCommit->addTags(allTags);
-			TraceEvent(SevInfo, "ConstructDataRequest")
-			    .detail("Prefix", prefix)
-			    .detail("KeyCount", keyCount)
-			    .detail("ValSize", valSize);
-		}
-	}
-
 	void checkSetGlobalKeys(MutationRef m) {
 		if (!m.param1.startsWith(globalKeysPrefix)) {
 			return;
@@ -1172,7 +1132,6 @@ public:
 				checkSetApplyMutationsEndRange(m);
 				checkSetApplyMutationsKeyVersionMapRange(m);
 				checkSetLogRangesRange(m);
-				checkSetConstructKeys(m);
 				checkSetGlobalKeys(m);
 				checkSetWriteRecoverKey(m);
 				checkSetMinRequiredCommitVersionKey(m);


### PR DESCRIPTION
Remove generate synthetic data feature. The feature generates data faster than the SS can process it. To get that to work, better integration with the rate limiter and DD would be needed.  The feature is superseded by bulk load which is in better working state.

tests
20260213-143649-dlambrig-36cfbbc6cf5d3ce8 

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ x] The PR has a description, explaining both the problem and the solution.
- [ x] The description mentions which forms of testing were done and the testing seems reasonable.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
