### PR TITLE
Fix for minRestorableVersion and maxRestorableVersion not updating correctly in case of missing mutation logs.

### DIFF
--- a/fdbclient/BackupContainerFileSystem.actor.cpp
+++ b/fdbclient/BackupContainerFileSystem.actor.cpp
@@ -716,24 +716,26 @@ public:
 
 			desc.snapshotBytes += s.totalSize;
 
-			// If the snapshot is at a single version then it requires no logs.  Update min and max restorable.
-			// TODO:  Somehow check / report if the restorable range is not or may not be contiguous.
-			if (s.beginVersion == s.endVersion &&
-			    (!desc.contiguousLogEnd.present() || // no logs
-			     (desc.contiguousLogEnd.present() &&
-			      desc.contiguousLogEnd.get() >= s.beginVersion)) // have logs, then should cover snapshot
-			) {
-				if (!desc.minRestorableVersion.present() || s.endVersion < desc.minRestorableVersion.get())
-					desc.minRestorableVersion = s.endVersion;
-
-				if (!desc.maxRestorableVersion.present() || s.endVersion > desc.maxRestorableVersion.get())
-					desc.maxRestorableVersion = s.endVersion;
+			// If the snapshot is at a single version and then it requires no logs.  Update min and max restorable.
+			// Update only if minRestorableVersion and maxRestorableVersion are not set. If they are set, we should
+			// check for log continuity between current minRestorableVersion to s.endVersion which happens in the
+			// next if block.
+			if (s.beginVersion == s.endVersion && !desc.minRestorableVersion.present() &&
+			    !desc.maxRestorableVersion.present()) {
+				desc.minRestorableVersion = s.endVersion;
+				desc.maxRestorableVersion = s.endVersion;
 			}
 
 			// If the snapshot is covered by the contiguous log chain then update min/max restorable.
 			if (desc.minLogBegin.present() && s.beginVersion >= desc.minLogBegin.get() &&
 			    s.endVersion < desc.contiguousLogEnd.get()) {
-				if (!desc.minRestorableVersion.present() || s.endVersion < desc.minRestorableVersion.get())
+				// If minRestorableVersion not present, update minRestorableVersion to snapshot endVersion.
+				// If minRestorableVersion present and if it has continuous logs from minRestorableVersion
+				// to snapshot endVersion, don't update the minRestorableVersion.
+				// Else, means it has no continous logs, so update minRestorableVersion to s.endVersion.
+				if (!desc.minRestorableVersion.present() ||
+				    !(desc.minRestorableVersion.get() >= desc.minLogBegin.get() &&
+				      desc.minRestorableVersion.get() < desc.contiguousLogEnd.get()))
 					desc.minRestorableVersion = s.endVersion;
 
 				if (!desc.maxRestorableVersion.present() ||
@@ -749,8 +751,6 @@ public:
 			     (desc.contiguousLogEnd.get() == s.beginVersion && s.beginVersion != s.endVersion)) &&
 			    s.restorable.get()) {
 				if (desc.minRestorableVersion.present() && desc.maxRestorableVersion.present()) {
-					ASSERT(desc.minRestorableVersion.get() < s.beginVersion);
-
 					// check if we have contiguous logs from minRestorableVersion to current snapshot endVersion
 					bool contiguousLogs = false;
 					if (desc.partitioned)

--- a/fdbserver/workloads/BackupAndParallelRestoreCorrectness.actor.cpp
+++ b/fdbserver/workloads/BackupAndParallelRestoreCorrectness.actor.cpp
@@ -561,16 +561,11 @@ struct BackupAndParallelRestoreCorrectnessWorkload : TestWorkload {
 						targetVersion = desc.minRestorableVersion.get();
 					} else if (deterministicRandom()->random01() < 0.1) {
 						targetVersion = desc.maxRestorableVersion.get();
-					} else if (deterministicRandom()->random01() < 0.5 &&
-					           desc.minRestorableVersion.get() < desc.contiguousLogEnd.get()) {
-						// The assertion may fail because minRestorableVersion may be decided by snapshot version.
-						// ASSERT_WE_THINK(desc.minRestorableVersion.get() <= desc.contiguousLogEnd.get());
-						// This assertion can fail when contiguousLogEnd < maxRestorableVersion and
-						// the snapshot version > contiguousLogEnd. I.e., there is a gap between
-						// contiguousLogEnd and snapshot version.
-						// ASSERT_WE_THINK(desc.contiguousLogEnd.get() > desc.maxRestorableVersion.get());
-						targetVersion = deterministicRandom()->randomInt64(desc.minRestorableVersion.get(),
-						                                                   desc.contiguousLogEnd.get());
+					} else if (deterministicRandom()->random01() < 0.5) {
+						targetVersion = (desc.minRestorableVersion.get() != desc.maxRestorableVersion.get())
+						                    ? deterministicRandom()->randomInt64(desc.minRestorableVersion.get(),
+						                                                         desc.maxRestorableVersion.get())
+						                    : desc.maxRestorableVersion.get();
 					}
 				}
 


### PR DESCRIPTION
cherry-pick of #12673

Fix for minRestorableVersion and maxRestorableVersion not updating correctly in case of missing mutation logs.

Why all of a sudden simulation is failing with wrong minRestorableVersion and maxRestorableVersion?
This PR https://github.com/apple/foundationdb/pull/12666 caused a scenario to miss mutation logs and this got several simulations to fail because of wrong minRestorableVersion and maxRestorableVersion.

PR https://github.com/apple/foundationdb/pull/12666 is: BackupWorkers starts processing, but did not save any progress to DB yet. Recovery happens. Since there is no progress saved, oldEpochs did not recruit. New Epoch BW's started processing new version which is much later than the 1st snapshot.beginVersion. This is causing to miss mutation logs in the beginning of the backup. I will fix this issue in a separate PR.

```
Snapshot: startVersion=305065438 endVersion=305065438  totalBytes=120013 restorable=true 
Snapshot: startVersion=1562749426 endVersion=1562749426 totalBytes=120013 restorable=true 
MinLogBeginVersion:   318035366 
ContiguousLogEndVersion: 1680457164 
MaxLogEndVersion:    1680457164

Old output:
MinRestorableVersion:  305065438 
MaxRestorableVersion:  1680457163

New output:
MinRestorableVersion:  1562749426 
MaxRestorableVersion:  1680457163
```

Simulation running:
20260216-052957-neethu2-push-970f1ab437e382a0      compressed=True data_size=60575300 duration=4524326 ended=100000 fail_fast=10 max_runs=100000 pass=100000

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
