### PR TITLE
Restricting configure backup_worker_enabled through fdbcli

### DIFF
--- a/fdbcli/ConfigureCommand.actor.cpp
+++ b/fdbcli/ConfigureCommand.actor.cpp
@@ -153,9 +153,20 @@ ACTOR Future<bool> configureCommandActor(Reference<IDatabase> db,
 			}
 		}
 
-		ConfigurationResult r = wait(ManagementAPI::changeConfig(
-		    db, std::vector<StringRef>(tokens.begin() + startToken, tokens.end()), conf, force));
-		result = r;
+		// Check for backup_worker_enabled configuration and reject it.
+		// This setting is now managed automatically by the backup system.
+		for (auto it = tokens.begin() + startToken; it != tokens.end(); ++it) {
+			if (it->startsWith("backup_worker_enabled:="_sr)) {
+				result = ConfigurationResult::BACKUP_WORKER_ENABLED_RESTRICTED;
+				break;
+			}
+		}
+
+		if (result != ConfigurationResult::BACKUP_WORKER_ENABLED_RESTRICTED) {
+			ConfigurationResult r = wait(ManagementAPI::changeConfig(
+			    db, std::vector<StringRef>(tokens.begin() + startToken, tokens.end()), conf, force));
+			result = r;
+		}
 	}
 
 	// Real errors get thrown from makeInterruptable and printed by the catch block in cli(), but
@@ -271,6 +282,12 @@ ACTOR Future<bool> configureCommandActor(Reference<IDatabase> db,
 		break;
 	case ConfigurationResult::INVALID_STORAGE_TYPE:
 		fprintf(stderr, "ERROR: Invalid storage type for storage or TLog.\n");
+		ret = false;
+		break;
+	case ConfigurationResult::BACKUP_WORKER_ENABLED_RESTRICTED:
+		fprintf(stderr,
+		        "ERROR: backup_worker_enabled configuration is restricted in fdbcli and managed automatically by the "
+		        "backup system.\n");
 		ret = false;
 		break;
 	default:

--- a/fdbclient/SystemData.cpp
+++ b/fdbclient/SystemData.cpp
@@ -1005,6 +1005,7 @@ ProcessClass decodeProcessClassValue(ValueRef const& value) {
 const KeyRangeRef configKeys("\xff/conf/"_sr, "\xff/conf0"_sr);
 const KeyRef configKeysPrefix = configKeys.begin;
 
+const KeyRef backupWorkerEnabledKey("\xff/conf/backup_worker_enabled"_sr);
 const KeyRef perpetualStorageWiggleKey("\xff/conf/perpetual_storage_wiggle"_sr);
 const KeyRef perpetualStorageWiggleLocalityKey("\xff/conf/perpetual_storage_wiggle_locality"_sr);
 // The below two are there for compatible upgrade and downgrade. After 7.3, the perpetual wiggle related keys should use

--- a/fdbclient/include/fdbclient/GenericManagementAPI.actor.h
+++ b/fdbclient/include/fdbclient/GenericManagementAPI.actor.h
@@ -71,7 +71,8 @@ enum class ConfigurationResult {
 	DATABASE_CREATED_WARN_SHARDED_ROCKSDB_EXPERIMENTAL,
 	DATABASE_IS_REGISTERED,
 	ENCRYPTION_AT_REST_MODE_ALREADY_SET,
-	INVALID_STORAGE_TYPE
+	INVALID_STORAGE_TYPE,
+	BACKUP_WORKER_ENABLED_RESTRICTED
 };
 
 enum class CoordinatorsResult {
@@ -531,6 +532,12 @@ Future<ConfigurationResult> changeConfig(Reference<DB> db, std::map<std::string,
 					} else if (i->first == "1") {
 						resetPPWStats = false; // the latter setting will override the former setting
 					}
+				}
+
+				// Clear backup progress when backup workers are disabled
+				if (i->first == backupWorkerEnabledKey && i->second == "0") {
+					tr->clear(backupProgressKeys);
+					TraceEvent("BackupWorkerProgressCleared");
 				}
 			}
 

--- a/fdbclient/include/fdbclient/SystemData.h
+++ b/fdbclient/include/fdbclient/SystemData.h
@@ -356,6 +356,7 @@ UID decodeProcessClassKeyOld(KeyRef const& key);
 extern const KeyRangeRef configKeys;
 extern const KeyRef configKeysPrefix;
 
+extern const KeyRef backupWorkerEnabledKey;
 extern const KeyRef perpetualStorageWiggleKey;
 extern const KeyRef perpetualStorageWiggleLocalityKey;
 extern const KeyRef perpetualStorageWiggleIDPrefix;

--- a/fdbserver/BackupWorker.actor.cpp
+++ b/fdbserver/BackupWorker.actor.cpp
@@ -716,6 +716,13 @@ ACTOR Future<Void> saveProgress(BackupData* self, Version backupVersion) {
 			tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
 			tr.setOption(FDBTransactionOptions::LOCK_AWARE);
 
+			// CHECK: Don't save progress if backup workers are disabled
+			Optional<Value> backupWorkerEnabled = wait(tr.get(backupWorkerEnabledKey));
+			if (!backupWorkerEnabled.present() || backupWorkerEnabled.get() == "0"_sr) {
+				TraceEvent("BackupWorkerProgressSkipped", self->myId).detail("Reason", "BackupWorkersDisabled");
+				return Void();
+			}
+
 			WorkerBackupStatus status(self->backupEpoch, backupVersion, self->tag, self->totalTags);
 			tr.set(key, backupProgressValue(status));
 			tr.addReadConflictRange(singleKeyRange(key));
@@ -1079,7 +1086,8 @@ ACTOR Future<Void> pullAsyncData(BackupData* self) {
 			    .detail("BackupEpoch", self->backupEpoch)
 			    .detail("Popped", r->popped())
 			    .detail("NoopPoppedVersion", maxNoopVersion)
-			    .detail("ExpectedPeekVersion", tagAt);
+			    .detail("ExpectedPeekVersion", tagAt)
+			    .detail("RecruitedEpoch", self->recruitedEpoch);
 			ASSERT(self->backupEpoch < self->recruitedEpoch && maxNoopVersion >= r->popped());
 			// This can only happen when the backup was in NOOP mode in the previous epoch,
 			// where NOOP mode popped version is larger than the expected peek version.


### PR DESCRIPTION
Restricting configure backup_worker_enabled through fdbcli. This setting is now managed automatically by the backup system.
cherry-pick of #12666, #12681

Tested on local cluster
<img width="815" height="121" alt="Screenshot 2026-02-06 at 4 39 55 PM" src="https://github.com/user-attachments/assets/451f9a48-471f-475e-bab6-1a9f2428c4f6" />

Simulation Tests:
20260216-063958-neethu-restrict-1-e11a9e8dae552025 compressed=True data_size=60573965 duration=4622854 ended=100000 fail_fast=10 max_runs=100000 pass=100000 


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
