### PR TITLE
Fix race condition in bindingtester Python file copy

### DIFF
--- a/cmake/AddFdbTest.cmake
+++ b/cmake/AddFdbTest.cmake
@@ -402,6 +402,10 @@ function(prepare_binding_test_files build_directory target_name target_dependenc
 
   add_dependencies(${target_name} python_binding)
   set(generated_binding_files python/fdb/fdboptions.py python/fdb/apiversion.py)
+  # Ensure Python binding files are generated before we try to copy them
+  if(WITH_PYTHON_BINDING)
+    add_dependencies(${target_name} fdb_python_options)
+  endif()
   if(WITH_JAVA_BINDING)
     if(NOT FDB_RELEASE)
       set(not_fdb_release_string "-SNAPSHOT")


### PR DESCRIPTION
Add dependency on fdb_python_options target in prepare_binding_test_files to ensure fdboptions.py and apiversion.py are generated before the copy step tries to use them.

The race seems more likely in mac builds. I found this when cutting the 7.4.6 release. Temporary mitigation was to manually run the step of generating files first and then copying. This is the proper long-term fix. 

Once merged, I'll backport to 7.4. 

Other than ctest, it's hard to test this because I can't reproduce the original issue easily. 

100K shouldn't be needed but running 10K just in case: 20260217-002300-praza-bindings-race-main-e1-03efca57493e2f4f compressed=True data_size=33972500 duration=543269 ended=10000 fail=1 fail_fast=10 max_runs=10000 pass=9999 priority=100 remaining=0 runtime=0:13:07 sanity=False started=10000 stopped=20260217-003607 submitted=20260217-002300 timeout=5400 username=praza-bindings-race-main-e1cb62828c2131397e03ec101b25c6beed45d680. The 1 failure (Sideband.toml, TraceTooManyLines) does not look related.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
