### PR TITLE
Fix a warning

### DIFF
--- a/fdbserver/workloads/BackupCorrectnessPartitioned.actor.cpp
+++ b/fdbserver/workloads/BackupCorrectnessPartitioned.actor.cpp
@@ -600,7 +600,7 @@ struct BackupAndRestorePartitionedCorrectnessWorkload : TestWorkload {
 				Standalone<StringRef> restoreTag(self->backupTag.toString() + "_" + std::to_string(restoreIndex));
 				restoreTags.push_back(restoreTag);
 				printf("BackupCorrectness, backupAgent.restore is called for restoreIndex:%d tag:%s "
-				       "TargetVersion:%d\n",
+				       "TargetVersion:%" PRId64 "\n",
 				       restoreIndex,
 				       restoreTag.toString().c_str(),
 				       targetVersion);


### PR DESCRIPTION
/root/src/foundationdb/fdbserver/workloads/BackupCorrectnessPartitioned.actor.cpp:602:155: warning: format specifies type 'int' but the argument has type 'Version' (aka 'long')
  [-Wformat]
    602 |  printf("BackupCorrectness, backupAgent.restore is called for restoreIndex:%d tag:%s " "TargetVersion:%d\n", restoreIndex, restoreTag.toString().c_str(), targetVersion);
        |                                                                                                       ~~                                                  ^~~~~~~~~~~~~
        |                                                                                                       %ld

20260219-231445-jzhou-6cd5c66957aa2a88

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
