### PR TITLE
Add `clang-tidy` support

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,5 @@
+---
+Checks: >
+  -*,
+  bugprone-sizeof-expression
+...

--- a/README.md
+++ b/README.md
@@ -185,6 +185,25 @@ CMake will not produce a `compile_commands.json` by default; you must pass `-DCM
 
 Note that if the building is done inside the `foundationdb/build` Docker image, the resulting paths will still be incorrect and require manual fixing. One will wish to re-run `cmake` with `-DCMAKE_EXPORT_COMPILE_COMMANDS=OFF` to prevent it from reverting the manual changes.
 
+### Running `clang-tidy`
+
+FoundationDB's CMake build supports opt-in `clang-tidy` execution during C/C++ compilation via `-DUSE_CLANG_TIDY=ON`.
+
+Example:
+
+```sh
+cmake -S <FDB_SOURCE_DIR> -B build -G Ninja \
+  -DUSE_CLANG_TIDY=ON
+ninja -C build fdbserver
+```
+
+Optional CMake variables:
+
+* `CLANG_TIDY`: path to the `clang-tidy` executable (auto-detected by default)
+* `CLANG_TIDY_EXTRA_ARGS`: additional space-separated arguments passed to `clang-tidy`
+
+If you prefer running `clang-tidy` manually, configure with `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON` and build the `processed_compile_commands` target. The generated source-tree `compile_commands.json` is Flow-aware and is usually the best compilation database to point `clang-tidy` at.
+
 ### Using IDEs
 
 CMake provides built-in support for several popular IDEs. However, most FoundationDB files are written in the `flow` language, which is an extension of the C++ programming language,  for coroutine support (Note that when FoundationDB was being developed, C++20 was not available). The `flow` language will be transpiled into C++ code using `actorcompiler`, while preventing most IDEs from recognizing `flow`-specific syntax.

--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -3862,12 +3862,15 @@ struct DequeAllocator : std::allocator<T> {
 	DequeAllocator(DequeAllocator<U> const& u) : std::allocator<T>(u) {}
 
 	T* allocate(std::size_t n) {
+		// Intentionally count allocated bytes for all allocator rebinds, including deque internals that use pointer
+		// types. NOLINTNEXTLINE(bugprone-sizeof-expression)
 		DequeAllocatorStats::allocatedBytes += n * sizeof(T);
 		// fprintf(stderr, "Allocating %lld objects for %lld bytes (total allocated: %lld)\n", n, n * sizeof(T),
 		// DequeAllocatorStats::allocatedBytes);
 		return std::allocator<T>::allocate(n);
 	}
 	void deallocate(T* p, std::size_t n) {
+		// NOLINTNEXTLINE(bugprone-sizeof-expression)
 		DequeAllocatorStats::allocatedBytes -= n * sizeof(T);
 		// fprintf(stderr, "Deallocating %lld objects for %lld bytes (total allocated: %lld)\n", n, n * sizeof(T),
 		// DequeAllocatorStats::allocatedBytes);


### PR DESCRIPTION
This PR adds support for running `clang-tidy` checks on FDB (including generated actor files). The cmake arguments for running `clang-tidy` are documented in `README.md`. To keep this PR minimal, only a single rule ([bugprone-sizeof-expression](https://clang.llvm.org/extra/clang-tidy/checks/bugprone/sizeof-expression.html)) is enforced for now. However, other rules have caught more serious issues (e.g. `bugprone-use-after-move`), and those warnings will be addressed in a future PR.

To test, I build with `-DUSE_CLANG_TIDY=ON` and confirmed there aren't remaining warnings. However, since there isn't CI enforcement, we aren't protected against regressions.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
