### PR TITLE
Don't build `replay` target if its src files (.go) are unchanged

### DIFF
--- a/contrib/replay/CMakeLists.txt
+++ b/contrib/replay/CMakeLists.txt
@@ -25,27 +25,23 @@ file(MAKE_DIRECTORY ${REPLAY_OUTPUT_DIR})
 
 # Get all Go source files for dependency tracking
 file(GLOB REPLAY_GO_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/*.go")
+set(REPLAY_GO_MOD "${CMAKE_CURRENT_SOURCE_DIR}/go.mod")
+set(REPLAY_GO_SUM "${CMAKE_CURRENT_SOURCE_DIR}/go.sum")
 
-# Custom target to build replay
-# This handles all Go dependencies automatically - users just need Go installed
-# ALL means it builds by default (but only if Go is available - see check above)
-add_custom_target(replay ALL
-    COMMAND ${CMAKE_COMMAND} -E echo "Downloading Go dependencies..."
-    COMMAND ${GO_EXECUTABLE} mod download
-    COMMAND ${CMAKE_COMMAND} -E echo "Tidying Go modules..."
-    COMMAND ${GO_EXECUTABLE} mod tidy
-    COMMAND ${CMAKE_COMMAND} -E echo "Building replay..."
+# Custom command to build replay - only rebuilds when source files change
+# go build handles dependencies automatically (downloads if needed)
+add_custom_command(
+    OUTPUT ${REPLAY_BINARY}
     COMMAND ${GO_EXECUTABLE} build -o ${REPLAY_BINARY} .
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    COMMENT "Building FDB trace replay tool (all dependencies handled automatically)"
-    BYPRODUCTS ${REPLAY_BINARY}
-    SOURCES ${REPLAY_GO_SOURCES}
+    DEPENDS ${REPLAY_GO_SOURCES} ${REPLAY_GO_MOD} ${REPLAY_GO_SUM}
+    COMMENT "Building FDB trace replay tool"
 )
 
-# Make sure the binary is executable
-add_custom_command(TARGET replay POST_BUILD
-    COMMAND chmod +x ${REPLAY_BINARY}
-    COMMENT "Making replay executable"
+# Target that depends on the binary - only triggers rebuild when deps change
+add_custom_target(replay ALL
+    DEPENDS ${REPLAY_BINARY}
+    SOURCES ${REPLAY_GO_SOURCES}
 )
 
 message(STATUS "replay will be built by default (Go found)")


### PR DESCRIPTION
# Description

Reported by @gxglass who observed seeing `replay` target being built when changing fdbserver cpp files. I investigated and turns out `replay` was being rebuilt even if its go source files are unchanged. To fix this, CMake expects an explicit `DEPENDS`, and just mentioning `SOURCES` is insufficient. 

# Testing

Took a series of steps (below) and observed cmake and ninja logs.

Before this fix:

1. did a cold/fresh build, ensured fdbserver and replay are built as expected
2. did a follow-up warm build (no changes), observed replay was being built again (unexpected)
3. changed some fdbserver cpp file, observed replay was being built again (unexpected)
4. changed replay go file, observed replay was being built again (expected)

After this fix:

1. did a cold/fresh build, ensured fdbserver and replay are built as expected
2. did a follow-up warm build (no changes), observed replay was NOT being built again (expected)
3. changed some fdbserver cpp file, observed replay was NOT being built again (expected)
4. changed replay go file, observed replay was being built again (expected)


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
