### PR TITLE
Backup v2 pulling based on popVersion fix and disabling v2 simulation tests

### DIFF
--- a/fdbserver/BackupWorker.actor.cpp
+++ b/fdbserver/BackupWorker.actor.cpp
@@ -952,7 +952,7 @@ ACTOR Future<Void> uploadData(BackupData* self) {
 ACTOR Future<Void> pullAsyncData(BackupData* self) {
 	state Future<Void> logSystemChange = Void();
 	state Reference<ILogSystem::IPeekCursor> r;
-	state Version tagAt = std::max(self->pulledVersion.get(), std::max(self->startVersion, self->savedVersion));
+	state Version tagAt = std::max( self->popVersion, std::max(self->pulledVersion.get(), std::max(self->startVersion, self->savedVersion)));
 	state Arena prev;
 
 	TraceEvent("BackupWorkerPull", self->myId).log();

--- a/fdbserver/workloads/AtomicRestore.actor.cpp
+++ b/fdbserver/workloads/AtomicRestore.actor.cpp
@@ -51,7 +51,7 @@ struct AtomicRestoreWorkload : TestWorkload {
 			backupRanges.push_back_deep(backupRanges.arena(), normalKeys);
 		}
 		usePartitionedLogs.set(
-		    getOption(options, "usePartitionedLogs"_sr, deterministicRandom()->random01() < 0.5 ? true : false));
+		    getOption(options, "usePartitionedLogs"_sr, false));
 
 		addPrefix = getOption(options, "addPrefix"_sr, ""_sr);
 		removePrefix = getOption(options, "removePrefix"_sr, ""_sr);

--- a/fdbserver/workloads/BackupAndParallelRestoreCorrectness.actor.cpp
+++ b/fdbserver/workloads/BackupAndParallelRestoreCorrectness.actor.cpp
@@ -78,7 +78,7 @@ struct BackupAndParallelRestoreCorrectnessWorkload : TestWorkload {
 		agentRequest = getOption(options, "simBackupAgents"_sr, true);
 		allowPauses = getOption(options, "allowPauses"_sr, true);
 		shareLogRange = getOption(options, "shareLogRange"_sr, false);
-		usePartitionedLogs.set(getOption(options, "usePartitionedLogs"_sr, deterministicRandom()->coinflip()));
+		usePartitionedLogs.set(getOption(options, "usePartitionedLogs"_sr, false));
 		addPrefix = getOption(options, "addPrefix"_sr, ""_sr);
 		removePrefix = getOption(options, "removePrefix"_sr, ""_sr);
 

--- a/tests/ParallelRestoreApiCorrectnessAtomicRestore.txt
+++ b/tests/ParallelRestoreApiCorrectnessAtomicRestore.txt
@@ -30,7 +30,7 @@ allowDefaultTenant=false
     startAfter=10.0
     restoreAfter=50.0
     fastRestore=true
-    usePartitionedLogs=true
+    usePartitionedLogs=false
 
     ; Each testName=RunRestoreWorkerWorkload creates a restore worker
     ; We need at least 3 restore workers: master, loader, and applier

--- a/tests/slow/ParallelRestoreNewBackupCorrectnessAtomicOp.toml
+++ b/tests/slow/ParallelRestoreNewBackupCorrectnessAtomicOp.toml
@@ -36,7 +36,7 @@ timeout = 360000
     restoreAfter = 60.0
     backupRangesCount = -1
     # use new backup
-    usePartitionedLogs = true
+    usePartitionedLogs = false
 
     [[test.workload]]
     testName = 'RandomClogging'

--- a/tests/slow/ParallelRestoreNewBackupCorrectnessCycle.toml
+++ b/tests/slow/ParallelRestoreNewBackupCorrectnessCycle.toml
@@ -31,7 +31,7 @@ timeout = 360000
     restoreAfter = 60.0
     # backupRangesCount<0 means backup the entire normal keyspace
     backupRangesCount = -1
-    usePartitionedLogs = true
+    usePartitionedLogs = false
 
     [[test.workload]]
     testName = 'RandomClogging'

--- a/tests/slow/ParallelRestoreNewBackupCorrectnessMultiCycles.toml
+++ b/tests/slow/ParallelRestoreNewBackupCorrectnessMultiCycles.toml
@@ -54,7 +54,7 @@ timeout = 360000
     restoreAfter = 60.0
     # backupRangesCount<0 means backup the entire normal keyspace
     backupRangesCount = -1
-    usePartitionedLogs = true
+    usePartitionedLogs = false
 
     [[test.workload]]
     testName = 'RandomClogging'

--- a/tests/slow/ParallelRestoreNewBackupWriteDuringReadAtomicRestore.toml
+++ b/tests/slow/ParallelRestoreNewBackupWriteDuringReadAtomicRestore.toml
@@ -22,7 +22,7 @@ timeout = 360000
     startAfter = 10.0
     restoreAfter = 50.0
     fastRestore = true
-    usePartitionedLogs = true
+    usePartitionedLogs = false
 
     [[test.workload]]
     testName = 'RandomClogging'


### PR DESCRIPTION
**Issue:** tests/slow/ParallelRestoreNewBackupCorrectnessAtomicOp.toml simulation failure during recent 500k release simulation run. https://a1391190.slack.com/archives/C08716ABZQE/p1770849371415939?thread_ts=1770835762.990699&cid=C08716ABZQE

**What Happened:**
BackupWorker started in no-op mode. No-op mode popped entries from Tlog and set the popVersion.
Later backup started, no-op mode changed to pull mode. BW started pulling entries from TLog from savedVersion and uploaded to blob. But it did not consider popVersion and started pulling entries before popVersion (as savedVersion < popVersion). It got mutations before popVersion because tlog not yet deleted them.
This BackupWorker terminated.
New BackupWorker started working on the same tag. It also started pulling entries from Tlog from savedVersion. But by this time, the tlog entries are cleared and couldn't find the entries.. so uploaded the empty file.
**Assert Fired:** Two mutation log files covering the same versionRange have different file sizes.
**Fix:** BackupWorker need to pull mutations after the popVersion.

**This issue is already fixed in main. The main branch contains several additional fixes, and the code has significantly diverged since 7.3. Backporting and stabilizing this change in the 7.3 branch would require non-trivial effort and is not required. Therefore, to minimize risk and engineering overhead in debugging such failures in 7.3, we are disabling Backup V2 in 7.3.**

Correctness run:
20260224-194227-neethu1-c2ab6bbf1908ae8b           compressed=True data_size=35196289 duration=3393186 ended=100000 fail_fast=10 max_runs=100000 pass=100000


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
