### PR TITLE
Expand `makeReference` usage

### DIFF
--- a/bindings/flow/DirectoryLayer.actor.cpp
+++ b/bindings/flow/DirectoryLayer.actor.cpp
@@ -101,8 +101,8 @@ Reference<DirectorySubspace> DirectoryLayer::contentsOfNode(Subspace const& node
 		return Reference<DirectorySubspace>(
 		    new DirectoryPartition(toAbsolutePath(path), prefix, Reference<DirectoryLayer>::addRef(this)));
 	} else {
-		return Reference<DirectorySubspace>(
-		    new DirectorySubspace(toAbsolutePath(path), prefix, Reference<DirectoryLayer>::addRef(this), layer));
+		return makeReference<DirectorySubspace>(
+		    toAbsolutePath(path), prefix, Reference<DirectoryLayer>::addRef(this), layer);
 	}
 }
 

--- a/bindings/flow/tester/Tester.actor.cpp
+++ b/bindings/flow/tester/Tester.actor.cpp
@@ -1403,7 +1403,7 @@ struct StartThreadFunc : InstructionFunc {
 		state Standalone<StringRef> prefix = Tuple::unpack(s1).getString(0);
 		// printf("=========START_THREAD:%s\n", printable(prefix).c_str());
 
-		Reference<FlowTesterData> newData = Reference<FlowTesterData>(new FlowTesterData(data->api));
+		Reference<FlowTesterData> newData = makeReference<FlowTesterData>(data->api);
 		data->subThreads.push_back(runTest(newData, data->db, prefix));
 
 		return Void();
@@ -1747,8 +1747,8 @@ ACTOR static Future<Void> doInstructions(Reference<FlowTesterData> data) {
 			// wait(printFlowTesterStack(&(data->stack)));
 			// wait(debugPrintRange(instruction->tr, "\x01test_results", ""));
 
-			state Reference<InstructionData> instruction = Reference<InstructionData>(
-			    new InstructionData(isDatabase, isSnapshot, data->instructions[idx].value, Reference<Transaction>()));
+			state Reference<InstructionData> instruction = makeReference<InstructionData>(
+			    isDatabase, isSnapshot, data->instructions[idx].value, Reference<Transaction>());
 			if (isDatabase) {
 				state Reference<Transaction> tr = data->db->createTransaction();
 				instruction->tr = tr;
@@ -1851,7 +1851,7 @@ ACTOR void startTest(std::string clusterFilename, StringRef prefix, int apiVersi
 		// Connect to the default cluster/database, and create a transaction
 		auto db = fdb->createDatabase(clusterFilename);
 
-		Reference<FlowTesterData> data = Reference<FlowTesterData>(new FlowTesterData(fdb));
+		Reference<FlowTesterData> data = makeReference<FlowTesterData>(fdb);
 		wait(runTest(data, db, prefix));
 
 		// Stopping the network returns from g_network->run() and allows

--- a/fdbclient/FileBackupAgent.actor.cpp
+++ b/fdbclient/FileBackupAgent.actor.cpp
@@ -5934,7 +5934,7 @@ struct RestoreDispatchTaskFunc : RestoreTaskFuncBase {
 		// If adding to existing batch then join the new block tasks to the existing batch future
 		if (addingToExistingBatch) {
 			Key fKey = wait(restore.batchFuture().getD(tr));
-			allPartsDone = Reference<TaskFuture>(new TaskFuture(futureBucket, fKey));
+			allPartsDone = makeReference<TaskFuture>(futureBucket, fKey);
 		} else {
 			// Otherwise create a new future for the new batch
 			allPartsDone = futureBucket->future(tr);
@@ -6313,8 +6313,7 @@ ACTOR Future<ERestoreState> abortRestore(Reference<ReadYourWritesTransaction> tr
 }
 
 ACTOR Future<ERestoreState> abortRestore(Database cx, Key tagName) {
-	state Reference<ReadYourWritesTransaction> tr =
-	    Reference<ReadYourWritesTransaction>(new ReadYourWritesTransaction(cx));
+	state Reference<ReadYourWritesTransaction> tr = makeReference<ReadYourWritesTransaction>(cx);
 
 	loop {
 		try {
@@ -6329,7 +6328,7 @@ ACTOR Future<ERestoreState> abortRestore(Database cx, Key tagName) {
 		}
 	}
 
-	tr = Reference<ReadYourWritesTransaction>(new ReadYourWritesTransaction(cx));
+	tr = makeReference<ReadYourWritesTransaction>(cx);
 
 	// Commit a dummy transaction before returning success, to ensure the mutation applier has stopped submitting
 	// mutations
@@ -7957,8 +7956,7 @@ public:
 	                                           Key addPrefix,
 	                                           Key removePrefix,
 	                                           UsePartitionedLog fastRestore) {
-		state Reference<ReadYourWritesTransaction> ryw_tr =
-		    Reference<ReadYourWritesTransaction>(new ReadYourWritesTransaction(cx));
+		state Reference<ReadYourWritesTransaction> ryw_tr = makeReference<ReadYourWritesTransaction>(cx);
 		state BackupConfig backupConfig;
 		state DatabaseConfiguration config = wait(getDatabaseConfiguration(cx));
 		loop {
@@ -8106,7 +8104,7 @@ public:
 				                     {},
 				                     randomUid)));
 				state Reference<ReadYourWritesTransaction> rywTransaction =
-				    Reference<ReadYourWritesTransaction>(new ReadYourWritesTransaction(cx));
+				    makeReference<ReadYourWritesTransaction>(cx);
 				// clear old restore config associated with system keys
 				loop {
 					try {

--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -1016,7 +1016,7 @@ ACTOR Future<Optional<CoordinatorsResult>> changeQuorumChecker(Transaction* tr,
 	}
 
 	std::vector<Future<Optional<LeaderInfo>>> leaderServers;
-	ClientCoordinators coord(Reference<ClusterConnectionMemoryRecord>(new ClusterConnectionMemoryRecord(*conn)));
+	ClientCoordinators coord(makeReference<ClusterConnectionMemoryRecord>(*conn));
 
 	leaderServers.reserve(coord.clientLeaderServers.size());
 	for (int i = 0; i < coord.clientLeaderServers.size(); i++) {
@@ -1067,12 +1067,11 @@ ACTOR Future<CoordinatorsResult> changeQuorum(Database cx, Reference<IQuorumChan
 			state std::vector<NetworkAddress> oldCoordinators = wait(oldClusterConnectionString.tryResolveHostnames());
 			state CoordinatorsResult result = CoordinatorsResult::SUCCESS;
 			if (!desiredCoordinators.size()) {
-				std::vector<NetworkAddress> _desiredCoordinators = wait(
-				    change->getDesiredCoordinators(&tr,
-				                                   oldCoordinators,
-				                                   Reference<ClusterConnectionMemoryRecord>(
-				                                       new ClusterConnectionMemoryRecord(oldClusterConnectionString)),
-				                                   result));
+				std::vector<NetworkAddress> _desiredCoordinators = wait(change->getDesiredCoordinators(
+				    &tr,
+				    oldCoordinators,
+				    makeReference<ClusterConnectionMemoryRecord>(oldClusterConnectionString),
+				    result));
 				desiredCoordinators = _desiredCoordinators;
 			}
 

--- a/fdbclient/MultiVersionTransaction.actor.cpp
+++ b/fdbclient/MultiVersionTransaction.actor.cpp
@@ -2257,11 +2257,11 @@ void MultiVersionApi::setupNetwork() {
 					auto libCopies = copyExternalLibraryPerThread(path);
 					for (int idx = 0; idx < libCopies.size(); ++idx) {
 						bool unlinkOnLoad = libCopies[idx].second && !retainClientLibCopies;
-						externalClients[filename].push_back(Reference<ClientInfo>(
-						    new ClientInfo(new DLApi(libCopies[idx].first, unlinkOnLoad /*unlink on load*/),
-						                   path,
-						                   useFutureVersion,
-						                   idx)));
+						externalClients[filename].push_back(
+						    makeReference<ClientInfo>(new DLApi(libCopies[idx].first, unlinkOnLoad /*unlink on load*/),
+						                              path,
+						                              useFutureVersion,
+						                              idx));
 					}
 				}
 			}

--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -1945,10 +1945,7 @@ ACTOR static Future<RangeResult> CoordinatorsAutoImplActor(ReadYourWritesTransac
 
 	std::vector<NetworkAddress> oldCoordinators = wait(old.tryResolveHostnames());
 	std::vector<NetworkAddress> _desiredCoordinators = wait(autoQuorumChange()->getDesiredCoordinators(
-	    &tr,
-	    oldCoordinators,
-	    Reference<ClusterConnectionMemoryRecord>(new ClusterConnectionMemoryRecord(old)),
-	    result));
+	    &tr, oldCoordinators, makeReference<ClusterConnectionMemoryRecord>(old), result));
 
 	if (result == CoordinatorsResult::NOT_ENOUGH_MACHINES) {
 		// we could get not_enough_machines if we happen to see the database while the cluster controller is updating

--- a/fdbclient/TaskBucket.actor.cpp
+++ b/fdbclient/TaskBucket.actor.cpp
@@ -695,7 +695,7 @@ public:
 
 		state int idx = 0;
 		for (; idx < CLIENT_KNOBS->TASKBUCKET_CHECK_ACTIVE_AMOUNT; ++idx) {
-			tr = Reference<ReadYourWritesTransaction>(new ReadYourWritesTransaction(cx));
+			tr = makeReference<ReadYourWritesTransaction>(cx);
 			loop {
 				try {
 					taskBucket->setOptions(tr);

--- a/fdbclient/include/fdbclient/AsyncFileS3BlobStore.actor.h
+++ b/fdbclient/include/fdbclient/AsyncFileS3BlobStore.actor.h
@@ -274,9 +274,9 @@ private:
 
 		// Make a new part to write to
 		if (startNew)
-			f->m_parts.push_back(Reference<Part>(new Part(f->m_parts.size() + 1,
-			                                              f->m_bstore->knobs.multipart_min_part_size,
-			                                              f->m_bstore->knobs.enable_object_integrity_check)));
+			f->m_parts.push_back(makeReference<Part>(f->m_parts.size() + 1,
+			                                         f->m_bstore->knobs.multipart_min_part_size,
+			                                         f->m_bstore->knobs.enable_object_integrity_check));
 
 		return Void();
 	}

--- a/fdbrpc/include/fdbrpc/AsyncFileCached.actor.h
+++ b/fdbrpc/include/fdbrpc/AsyncFileCached.actor.h
@@ -345,7 +345,7 @@ private:
 			TraceEvent("AFCUnderlyingOpenEnd").detail("Filename", filename);
 			int64_t l = wait(f->size());
 			TraceEvent("AFCUnderlyingSize").detail("Filename", filename).detail("Size", l);
-			return Reference<AsyncFileCached>(new AsyncFileCached(f, filename, l, pageCache)).castTo<IAsyncFile>();
+			return makeReference<AsyncFileCached>(f, filename, l, pageCache).castTo<IAsyncFile>();
 		} catch (Error& e) {
 			if (e.code() != error_code_actor_cancelled)
 				openFiles.erase(filename);

--- a/fdbrpc/include/fdbrpc/LoadBalance.actor.h
+++ b/fdbrpc/include/fdbrpc/LoadBalance.actor.h
@@ -549,14 +549,14 @@ struct RequestData : NonCopyable {
 		if (backoff > 0) {
 			response = mapAsync(delay(backoff), [this, stream, &request, model, alternatives, channel](Void _) {
 				requestStarted = true;
-				modelHolder = Reference<ModelHolder>(new ModelHolder(model, stream->getEndpoint().token.first()));
+				modelHolder = makeReference<ModelHolder>(model, stream->getEndpoint().token.first());
 				Future<Reply> resp = stream->tryGetReply(request);
 				maybeDuplicateTSSRequest(stream, request, model, resp, alternatives, channel);
 				return resp;
 			});
 		} else {
 			requestStarted = true;
-			modelHolder = Reference<ModelHolder>(new ModelHolder(model, stream->getEndpoint().token.first()));
+			modelHolder = makeReference<ModelHolder>(model, stream->getEndpoint().token.first());
 			response = stream->tryGetReply(request);
 			maybeDuplicateTSSRequest(stream, request, model, response, alternatives, channel);
 		}

--- a/fdbserver/VersionedBTree.actor.cpp
+++ b/fdbserver/VersionedBTree.actor.cpp
@@ -1462,12 +1462,12 @@ struct RedwoodMetrics {
 
 	RedwoodMetrics() {
 		// All histograms have reset their buckets to 0 in the constructor.
-		kvSizeWritten = Reference<Histogram>(
-		    new Histogram(Reference<HistogramRegistry>(), "kvSize", "Written", Histogram::Unit::bytes));
-		kvSizeReadByGet = Reference<Histogram>(
-		    new Histogram(Reference<HistogramRegistry>(), "kvSize", "ReadByGet", Histogram::Unit::bytes));
-		kvSizeReadByGetRange = Reference<Histogram>(
-		    new Histogram(Reference<HistogramRegistry>(), "kvSize", "ReadByGetRange", Histogram::Unit::bytes));
+		kvSizeWritten =
+		    makeReference<Histogram>(Reference<HistogramRegistry>(), "kvSize", "Written", Histogram::Unit::bytes);
+		kvSizeReadByGet =
+		    makeReference<Histogram>(Reference<HistogramRegistry>(), "kvSize", "ReadByGet", Histogram::Unit::bytes);
+		kvSizeReadByGetRange = makeReference<Histogram>(
+		    Reference<HistogramRegistry>(), "kvSize", "ReadByGetRange", Histogram::Unit::bytes);
 
 		ioLock = nullptr;
 
@@ -1476,26 +1476,26 @@ struct RedwoodMetrics {
 		for (RedwoodMetrics::Level& level : levels) {
 			if (levelCounter > 0) {
 				std::string levelString = "L" + std::to_string(levelCounter);
-				level.buildFillPctSketch = Reference<Histogram>(new Histogram(
-				    Reference<HistogramRegistry>(), "buildFillPct", levelString, Histogram::Unit::percentageLinear));
-				level.modifyFillPctSketch = Reference<Histogram>(new Histogram(
-				    Reference<HistogramRegistry>(), "modifyFillPct", levelString, Histogram::Unit::percentageLinear));
-				level.buildStoredPctSketch = Reference<Histogram>(new Histogram(
-				    Reference<HistogramRegistry>(), "buildStoredPct", levelString, Histogram::Unit::percentageLinear));
-				level.modifyStoredPctSketch = Reference<Histogram>(new Histogram(
-				    Reference<HistogramRegistry>(), "modifyStoredPct", levelString, Histogram::Unit::percentageLinear));
-				level.buildItemCountSketch = Reference<Histogram>(new Histogram(Reference<HistogramRegistry>(),
-				                                                                "buildItemCount",
-				                                                                levelString,
-				                                                                Histogram::Unit::countLinear,
-				                                                                0,
-				                                                                maxRecordCount));
-				level.modifyItemCountSketch = Reference<Histogram>(new Histogram(Reference<HistogramRegistry>(),
-				                                                                 "modifyItemCount",
-				                                                                 levelString,
-				                                                                 Histogram::Unit::countLinear,
-				                                                                 0,
-				                                                                 maxRecordCount));
+				level.buildFillPctSketch = makeReference<Histogram>(
+				    Reference<HistogramRegistry>(), "buildFillPct", levelString, Histogram::Unit::percentageLinear);
+				level.modifyFillPctSketch = makeReference<Histogram>(
+				    Reference<HistogramRegistry>(), "modifyFillPct", levelString, Histogram::Unit::percentageLinear);
+				level.buildStoredPctSketch = makeReference<Histogram>(
+				    Reference<HistogramRegistry>(), "buildStoredPct", levelString, Histogram::Unit::percentageLinear);
+				level.modifyStoredPctSketch = makeReference<Histogram>(
+				    Reference<HistogramRegistry>(), "modifyStoredPct", levelString, Histogram::Unit::percentageLinear);
+				level.buildItemCountSketch = makeReference<Histogram>(Reference<HistogramRegistry>(),
+				                                                      "buildItemCount",
+				                                                      levelString,
+				                                                      Histogram::Unit::countLinear,
+				                                                      0,
+				                                                      maxRecordCount);
+				level.modifyItemCountSketch = makeReference<Histogram>(Reference<HistogramRegistry>(),
+				                                                       "modifyItemCount",
+				                                                       levelString,
+				                                                       Histogram::Unit::countLinear,
+				                                                       0,
+				                                                       maxRecordCount);
 			}
 			++levelCounter;
 		}

--- a/fdbserver/include/fdbserver/RestoreApplier.actor.h
+++ b/fdbserver/include/fdbserver/RestoreApplier.actor.h
@@ -396,7 +396,7 @@ struct RestoreApplierData : RestoreRoleData, public ReferenceCounted<RestoreAppl
 
 	void initVersionBatch(int batchIndex) override {
 		TraceEvent("FastRestoreApplierInitVersionBatch", id()).detail("BatchIndex", batchIndex);
-		batch[batchIndex] = Reference<ApplierBatchData>(new ApplierBatchData(nodeID, batchIndex));
+		batch[batchIndex] = makeReference<ApplierBatchData>(nodeID, batchIndex);
 	}
 
 	void resetPerRestoreRequest() override {

--- a/fdbserver/workloads/BackupToDBUpgrade.actor.cpp
+++ b/fdbserver/workloads/BackupToDBUpgrade.actor.cpp
@@ -193,7 +193,7 @@ struct BackupToDBUpgradeWorkload : TestWorkload {
 					printf("%.6f Wait #%4d for %lld tasks to end\n", now(), waitCycles, (long long)taskCount);
 
 					wait(delay(20.0));
-					tr = Reference<ReadYourWritesTransaction>(new ReadYourWritesTransaction(cx));
+					tr = makeReference<ReadYourWritesTransaction>(cx);
 					wait(store(taskCount, backupAgent->getTaskCount(tr)));
 				}
 


### PR DESCRIPTION
This PR uses AST-grep to replace code instances like `Reference<T>(new Reference<T>(...))` with the more succinct `makeReference<T>(...)`.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
