### PR TITLE
Enforce more `clang-tidy` warnings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,8 @@
 ---
 Checks: >
   -*,
-  bugprone-sizeof-expression
+  bugprone-sizeof-expression,
+  bugprone-suspicious-string-compare,
+  bugprone-use-after-move,
+  performance-for-range-copy
 ...

--- a/bindings/flow/tester/DirectoryTester.actor.cpp
+++ b/bindings/flow/tester/DirectoryTester.actor.cpp
@@ -86,7 +86,7 @@ std::string pathToString(IDirectory::Path const& path) {
 
 IDirectory::Path combinePaths(IDirectory::Path const& path1, IDirectory::Path const& path2) {
 	IDirectory::Path outPath(path1.begin(), path1.end());
-	for (auto p : path2) {
+	for (const auto& p : path2) {
 		outPath.push_back(p);
 	}
 

--- a/contrib/sqlite/CMakeLists.txt
+++ b/contrib/sqlite/CMakeLists.txt
@@ -7,6 +7,8 @@ add_library(sqlite STATIC
   sqliteLimit.h
   sqlite3.amalgamation.c)
 
+set_target_properties(sqlite PROPERTIES C_CLANG_TIDY "")
+
 
 target_include_directories(sqlite PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 # Suppress warnings in sqlite since it's third party

--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -3198,6 +3198,7 @@ ACTOR Future<Void> modifyBackup(Database db, std::string tagName, BackupModifyOp
 	return Void();
 }
 
+// NOLINTBEGIN(bugprone-use-after-move): ignore clang-tidy false positives in parseLine's token buffer handling.
 static std::vector<std::vector<StringRef>> parseLine(std::string& line, bool& err, bool& partial) {
 	err = false;
 	partial = false;
@@ -3289,6 +3290,7 @@ static std::vector<std::vector<StringRef>> parseLine(std::string& line, bool& er
 
 	return ret;
 }
+// NOLINTEND(bugprone-use-after-move)
 
 static void addKeyRange(std::string optionValue, Standalone<VectorRef<KeyRangeRef>>& keyRanges) {
 	bool err = false, partial = false;

--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -351,6 +351,7 @@ static std::string formatStringRef(StringRef item, bool fullEscaping = false) {
 	return ret;
 }
 
+// NOLINTBEGIN(bugprone-use-after-move): ignore clang-tidy false positives in parseLine's token buffer handling.
 static std::vector<std::vector<StringRef>> parseLine(std::string& line, bool& err, bool& partial) {
 	err = false;
 	partial = false;
@@ -468,6 +469,7 @@ static std::vector<std::vector<StringRef>> parseLine(std::string& line, bool& er
 
 	return ret;
 }
+// NOLINTEND(bugprone-use-after-move)
 
 static void printProgramUsage(const char* name) {
 	printf("FoundationDB CLI " FDB_VT_PACKAGE_NAME " (v" FDB_VT_VERSION ")\n"

--- a/fdbmonitor/fdbmonitor.cpp
+++ b/fdbmonitor/fdbmonitor.cpp
@@ -596,7 +596,7 @@ int main(int argc, char** argv) {
 							conffile = confpath.substr(confdir.size());
 
 							// Remove all the old watches
-							for (auto wd : additional_watch_wds) {
+							for (const auto& wd : additional_watch_wds) {
 								if (inotify_rm_watch(ifd, wd.first) < 0) {
 									// log_err("inotify_rm_watch", errno, "Unable to remove symlink watch %d",
 									// wd.first); exit(1);

--- a/fdbmonitor/fdbmonitor_lib.cpp
+++ b/fdbmonitor/fdbmonitor_lib.cpp
@@ -605,7 +605,7 @@ bool argv_equal(const char** a1, const char** a2) {
 	int i = 0;
 
 	while (a1[i] && a2[i]) {
-		if (strcmp(a1[i], a2[i]))
+		if (strcmp(a1[i], a2[i]) != 0)
 			return false;
 		i++;
 	}
@@ -675,12 +675,12 @@ void load_conf(const char* confpath, uid_t& uid, gid_t& gid, sigset_t* mask, fdb
 		/* Any change to uid or gid requires the process to be restarted to take effect */
 		if (uid != _uid || gid != _gid) {
 			std::vector<ProcessID> kill_ids;
-			for (auto i : id_pid) {
+			for (const auto& i : id_pid) {
 				if (id_command[i.first]->kill_on_configuration_change) {
 					kill_ids.push_back(i.first);
 				}
 			}
-			for (auto i : kill_ids) {
+			for (const auto& i : kill_ids) {
 				kill_process(i);
 				id_command.erase(i);
 			}
@@ -693,7 +693,7 @@ void load_conf(const char* confpath, uid_t& uid, gid_t& gid, sigset_t* mask, fdb
 	std::list<ProcessID> kill_ids;
 	std::list<std::pair<ProcessID, Command*>> start_ids;
 
-	for (auto i : id_pid) {
+	for (const auto& i : id_pid) {
 		if (!loadedConf || ini.GetSectionSize(id_command[i.first]->ssection.c_str()) == -1) {
 			/* Process no longer configured; deconfigure it and kill it if required */
 			log_msg(SevInfo, "Deconfigured %s\n", id_command[i.first]->ssection.c_str());
@@ -726,10 +726,10 @@ void load_conf(const char* confpath, uid_t& uid, gid_t& gid, sigset_t* mask, fdb
 		}
 	}
 
-	for (auto i : kill_ids)
+	for (const auto& i : kill_ids)
 		kill_process(i);
 
-	for (auto i : start_ids) {
+	for (const auto& i : start_ids) {
 		start_process(i.second, i.first, uid, gid, 0, mask);
 	}
 
@@ -738,7 +738,7 @@ void load_conf(const char* confpath, uid_t& uid, gid_t& gid, sigset_t* mask, fdb
 	if (loadedConf) {
 		CSimpleIniA::TNamesDepend sections;
 		ini.GetAllSections(sections);
-		for (auto i : sections) {
+		for (const auto& i : sections) {
 			if (auto dot = strrchr(i.pItem, '.')) {
 				ProcessID id = i.pItem;
 				if (!id_pid.count(id)) {

--- a/fdbrpc/FlowTests.actor.cpp
+++ b/fdbrpc/FlowTests.actor.cpp
@@ -557,7 +557,8 @@ TEST_CASE("/flow/flow/callbacks") {
 
 	onReady(std::move(f), [&result](int x) { result = x; }, [&result](Error e) { result = -1; });
 	onReady(p.getFuture(), [&happened](int) { happened = true; }, [&happened](Error) { happened = true; });
-	ASSERT(!f.isValid());
+	ASSERT(
+	    !f.isValid()); // NOLINT(bugprone-use-after-move): this test intentionally checks the moved-from Future state.
 	ASSERT(p.isValid() && !p.isSet() && p.getFutureReferenceCount() == 1);
 	ASSERT(result == 0 && !happened);
 
@@ -574,7 +575,8 @@ TEST_CASE("/flow/flow/callbacks") {
 	f = p.getFuture();
 	result = 0;
 	onReady(std::move(f), [&result](int x) { result = x; }, [&result](Error e) { result = -e.code(); });
-	ASSERT(!f.isValid());
+	ASSERT(
+	    !f.isValid()); // NOLINT(bugprone-use-after-move): this test intentionally checks the moved-from Future state.
 	ASSERT(p.isValid() && !p.isSet() && p.getFutureReferenceCount() == 1);
 	ASSERT(result == 0);
 
@@ -1487,7 +1489,8 @@ TEST_CASE("/flow/flow/PromiseStream/move2") {
 	stream.send(Tracker{});
 	Tracker tracker = waitNext(stream.getFuture());
 	Tracker movedTracker = std::move(tracker);
-	ASSERT(tracker.moved);
+	ASSERT(
+	    tracker.moved); // NOLINT(bugprone-use-after-move): this test intentionally checks the moved-from Tracker state.
 	ASSERT(!movedTracker.moved);
 	ASSERT(movedTracker.copied == 0);
 	return Void();

--- a/flow/IndexedSet.cpp
+++ b/flow/IndexedSet.cpp
@@ -396,7 +396,7 @@ TEST_CASE("/flow/IndexedSets/ints") {
 	ASSERT(is.find(20) != is.end());
 
 	for (int i = 20; i < 200; i += 10) {
-		is.insert(std::move(i), 3);
+		is.insert(i, 3);
 		is.testonly_assertBalanced();
 		ASSERT(is.find(i) != is.end());
 	}
@@ -455,7 +455,7 @@ TEST_CASE("/flow/IndexedSet/comparison to std::set") {
 	std::set<int> ss;
 	for (int i = 0; i < 1000000; i++) {
 		int p = deterministicRandom()->randomInt(0, 2000000);
-		is.insert(std::move(p), 1);
+		is.insert(p, 1);
 		ss.insert(p);
 	}
 

--- a/flow/include/flow/IndexedSet.h
+++ b/flow/include/flow/IndexedSet.h
@@ -875,12 +875,13 @@ typename IndexedSet<T, Metric>::iterator IndexedSet<T, Metric>::insert(T_&& data
 		t = nextT;
 	}
 
+	Metric metricDelta = metric;
 	Node* newNode = new Node(std::forward<T_>(data), std::forward<Metric_>(metric), t);
 	t->child[d] = newNode;
 
 	while (true) {
 		t->balance += d ? 1 : -1;
-		t->total = t->total + metric;
+		t->total = t->total + metricDelta;
 		if (t->balance == 0)
 			break;
 		if (t->balance != 1 && t->balance != -1) {
@@ -909,7 +910,7 @@ typename IndexedSet<T, Metric>::iterator IndexedSet<T, Metric>::insert(T_&& data
 		t = t->parent;
 		if (!t)
 			break;
-		t->total = t->total + metric;
+		t->total = t->total + metricDelta;
 	}
 
 	return iterator{ newNode };

--- a/flow/include/flow/flow.h
+++ b/flow/include/flow/flow.h
@@ -661,7 +661,8 @@ public:
 	explicit LineageReference(ActorLineage* ptr) : Reference<ActorLineage>(ptr), actorName_(""), allocated_(false) {}
 	LineageReference(const LineageReference& r) : Reference<ActorLineage>(r), actorName_(""), allocated_(false) {}
 	LineageReference(LineageReference&& r)
-	  : Reference<ActorLineage>(std::forward<LineageReference>(r)), actorName_(r.actorName_), allocated_(r.allocated_) {
+	  : Reference<ActorLineage>(r.getPtr()), actorName_(r.actorName_), allocated_(r.allocated_) {
+		r.setPtrUnsafe(nullptr);
 		r.actorName_ = "";
 		r.allocated_ = false;
 	}


### PR DESCRIPTION
This PR extends the `clang-tidy` warnings enforced from `.clang-tidy` and fixes resulting warnings. The most serious fixed warnings are `bugprone-use-after-move` violations from `MetricClient.actor.cpp`.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
