### PR TITLE
Fix a DD shutdown crash

### DIFF
--- a/fdbserver/DDShardTracker.actor.cpp
+++ b/fdbserver/DDShardTracker.actor.cpp
@@ -1355,6 +1355,8 @@ struct DataDistributionTrackerImpl {
 
 		try {
 			wait(trackInitialShards(self, initData));
+			if (*self->trackerCancelled)
+				return Void();
 			initData.clear(); // Release reference count.
 
 			loop choose {


### PR DESCRIPTION
To reproduce clang build at 7.3.69
seed: -f ./tests/restarting/from_7.3.0_until_7.4.0/SnapTestAttrition-1.toml -s 1392115560 -b on

20260304-212857-jzhou-645ce214174229b7             compressed=True data_size=33138935 duration=5452852 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=2:26:24 sanity=False started=100000 stopped=20260304-235521 submitted=20260304-212857 timeout=5400 username=jzhou

Setup

- dataDistribution is running its main loop. The actors vector (non-state) holds all the sub-actors including DataDistributionTracker::run.
- trackerCancelled (state bool) is false.
- The tracker has finished trackInitialShards and is sitting inside the loop choose, waiting on multiple futures including loggingTrigger.
- loggingTrigger is state Future<Void>. It was initialized as Void() — an already-completed future. After the first firing, it gets reset to delay(...). So on the very first iteration of the loop, it fires immediately.

The trigger — an error in another actor

1. Some other actor in actors throws (e.g. movekeys_conflict from a DDTeamCollection actor). waitForAll(actors) propagates this error out of wait(waitForAll(actors)).
2. Execution enters the catch block at DataDistribution.actor.cpp:1114.
3. Line 1115: trackerCancelled = true.
4. Team collection References are cleared (lines 1129–1131). This destroys DDTeamCollection objects synchronously.
5. The error is not actor_cancelled, so we reach line 1142: wait(shards.clearAsync()). The actor suspends here. shards is a state KeyRangeMap<ShardTrackedData> — clearing a large map is broken into async chunks to avoid starving the event loop.

The pending network response fires during the yield

6. The FDB simulator event loop picks up the next task: a WaitMetrics reply from a storage server arrives for one of the trackShardMetrics actors.
7. SAV<StorageMetrics>::finishSendAndDelPromiseRef() fires its callbacks synchronously in a chain:

    - TrackShardMetricsActor receives the WaitMetrics reply and updates its AsyncVar<Optional<ShardMetrics>> via set().
    - AsyncVar::set destroys the old onChange Promise<Void>, sends to the onChange listeners
    - The QuorumCallback inside changeSizes (or GetFirstSizeActor) fires, completing the quorum. changeSizes completes.
    - trackInitialShards resumes after wait(changeSizes(...)). It calls self->readyToStart.send(Void()), then hits wait(initialSize). If initialSize is already satisfied (all shards have reported), trackInitialShards returns.
    - DataDistributionTrackerImpl::run resumes at a_body1cont2 — i.e., after wait(trackInitialShards(...)).
8. Without any trackerCancelled check, run proceeds straight into the loop choose for the first time — a_body1cont2loopHead1 in the generated code.

The crash

9. The loop choose evaluates which futures are ready. loggingTrigger was initialized as Void() and has never been reset yet (this is the first entry into the loop). It is already complete.
10. The when(wait(loggingTrigger)) branch fires immediately and executes: TraceEvent("DDTrackerStats", self->distributorId)
      .detail("Shards", self->shards->size())   // <-- CRASH
11. self->shards is a raw KeyRangeMap<ShardTrackedData>* pointing at the state shards variable back in dataDistribution. That shards is in the middle of clearAsync() — its internal
  structure is partially destroyed/invalid.
12. Accessing shards->size() on a partially-cleared KeyRangeMap causes a segfault. Signal 11 (SIGSEGV).

Replace this text with your description here...

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
