### PR TITLE
Backup v2 fails in s3_backup_test.sh as backupworkers miss knobs.

### DIFF
--- a/tests/loopback_cluster/run_custom_cluster.sh
+++ b/tests/loopback_cluster/run_custom_cluster.sh
@@ -58,6 +58,7 @@ function start_servers {
     # this native bash behavior, we printf the KNOBS string.
     ${2} "${FDB}" -p auto:"${port}" ${KNOBS:+$(printf "%s" "${KNOBS}")} -c "${3}" \
       -d "${datadir}" -L "${logdir}" -C "${CLUSTER}" \
+      --knob_blobstore_encryption_type=aws:kms \
       --datacenter_id="${4}" \
       --locality-zoneid "${zone}" \
       --locality-machineid M-$SERVER_COUNT &


### PR DESCRIPTION
cherry-pick of #12749
Backup v2 fails in s3_backup_test.sh as backupworkers misses knobs.
If s3_backup_test.sh uses partitioned_logs backup. It will start backup workers on fdbservers and it requires --knob_blobstore_encryption_type=aws:kms knob to upload to S3. This PR adds this knob to fdbservers to make them able to upload to S3.

Ran s3_backup_test.sh test:
Before fix, ctest is always stuck.
After fix, ctest passes.

Simulation test (100K passed):
20260304-215453-neethu1-c0505cd595ce9a2a           compressed=True data_size=60545399 duration=3981090 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=2:18:07 sanity=False started=100000 stopped=20260305-001300 submitted=20260304-215453 timeout=5400 username=neethu1


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
