### PR TITLE
Update `fdbcli` to consistently use `fmt` library

### DIFF
--- a/fdbcli/AdvanceVersionCommand.actor.cpp
+++ b/fdbcli/AdvanceVersionCommand.actor.cpp
@@ -53,7 +53,7 @@ ACTOR Future<bool> advanceVersionCommandActor(Reference<IDatabase> db, std::vect
 						tr->set(advanceVersionSpecialKey, boost::lexical_cast<std::string>(v));
 						wait(safeThreadFutureToFuture(tr->commit()));
 					} else {
-						fmt::print("Current read version is {}\n", rv);
+						fmt::println("Current read version is {}", rv);
 						return true;
 					}
 				} catch (Error& e) {

--- a/fdbcli/ConfigureCommand.actor.cpp
+++ b/fdbcli/ConfigureCommand.actor.cpp
@@ -28,6 +28,7 @@
 #include "flow/Arena.h"
 #include "flow/FastRef.h"
 #include "flow/ThreadHelper.actor.h"
+#include "fmt/format.h"
 #include "flow/actorcompiler.h" // This must be the last #include.
 
 namespace fdb_cli {
@@ -60,7 +61,7 @@ ACTOR Future<bool> configureCommandActor(Reference<IDatabase> db,
 				state ThreadFuture<Optional<Value>> statusValueF = tr->get("\xff\xff/status/json"_sr);
 				Optional<Value> statusValue = wait(safeThreadFutureToFuture(statusValueF));
 				if (!statusValue.present()) {
-					fprintf(stderr, "ERROR: Failed to get status json from the cluster\n");
+					fmt::println(stderr, "ERROR: Failed to get status json from the cluster");
 					return false;
 				}
 				json_spirit::mValue mv;
@@ -74,7 +75,7 @@ ACTOR Future<bool> configureCommandActor(Reference<IDatabase> db,
 			conf = parseConfig(s);
 
 			if (!conf.get().isValid()) {
-				printf("Unable to provide advice for the current configuration.\n");
+				fmt::println("Unable to provide advice for the current configuration.");
 				return false;
 			}
 
@@ -94,8 +95,8 @@ ACTOR Future<bool> configureCommandActor(Reference<IDatabase> db,
 			std::string outputString;
 
 			outputString += "\nYour cluster has:\n\n";
-			outputString += format("  processes %d\n", conf.get().processes);
-			outputString += format("  machines  %d\n", conf.get().machines);
+			outputString += fmt::format("  processes {}\n", conf.get().processes);
+			outputString += fmt::format("  machines  {}\n", conf.get().machines);
 
 			if (noDesiredChanges)
 				outputString += "\nConfigure recommends keeping your current configuration:\n\n";
@@ -107,40 +108,40 @@ ACTOR Future<bool> configureCommandActor(Reference<IDatabase> db,
 			outputString += " ------------------------------------------------------------------- \n";
 			outputString += "| parameter                   | old              | new              |\n";
 			outputString += " ------------------------------------------------------------------- \n";
-			outputString += format("| replication                 | %16s | %16s |\n",
-			                       conf.get().old_replication.c_str(),
-			                       conf.get().auto_replication.c_str());
-			outputString +=
-			    format("| logs                        | %16d | %16d |", conf.get().old_logs, conf.get().auto_logs);
+			outputString += fmt::format("| replication                 | {:>16} | {:>16} |\n",
+			                            conf.get().old_replication,
+			                            conf.get().auto_replication);
+			outputString += fmt::format(
+			    "| logs                        | {:16} | {:16} |", conf.get().old_logs, conf.get().auto_logs);
 			outputString += conf.get().auto_logs != conf.get().desired_logs
-			                    ? format(" (manually set; would be %d)\n", conf.get().desired_logs)
+			                    ? fmt::format(" (manually set; would be {})\n", conf.get().desired_logs)
 			                    : "\n";
-			outputString += format("| commit_proxies              | %16d | %16d |",
-			                       conf.get().old_commit_proxies,
-			                       conf.get().auto_commit_proxies);
+			outputString += fmt::format("| commit_proxies              | {:16} | {:16} |",
+			                            conf.get().old_commit_proxies,
+			                            conf.get().auto_commit_proxies);
 			outputString += conf.get().auto_commit_proxies != conf.get().desired_commit_proxies
-			                    ? format(" (manually set; would be %d)\n", conf.get().desired_commit_proxies)
+			                    ? fmt::format(" (manually set; would be {})\n", conf.get().desired_commit_proxies)
 			                    : "\n";
-			outputString += format("| grv_proxies                 | %16d | %16d |",
-			                       conf.get().old_grv_proxies,
-			                       conf.get().auto_grv_proxies);
+			outputString += fmt::format("| grv_proxies                 | {:16} | {:16} |",
+			                            conf.get().old_grv_proxies,
+			                            conf.get().auto_grv_proxies);
 			outputString += conf.get().auto_grv_proxies != conf.get().desired_grv_proxies
-			                    ? format(" (manually set; would be %d)\n", conf.get().desired_grv_proxies)
+			                    ? fmt::format(" (manually set; would be {})\n", conf.get().desired_grv_proxies)
 			                    : "\n";
-			outputString += format(
-			    "| resolvers                   | %16d | %16d |", conf.get().old_resolvers, conf.get().auto_resolvers);
+			outputString += fmt::format(
+			    "| resolvers                   | {:16} | {:16} |", conf.get().old_resolvers, conf.get().auto_resolvers);
 			outputString += conf.get().auto_resolvers != conf.get().desired_resolvers
-			                    ? format(" (manually set; would be %d)\n", conf.get().desired_resolvers)
+			                    ? fmt::format(" (manually set; would be {})\n", conf.get().desired_resolvers)
 			                    : "\n";
-			outputString += format("| transaction-class processes | %16d | %16d |\n",
-			                       conf.get().old_processes_with_transaction,
-			                       conf.get().auto_processes_with_transaction);
-			outputString += format("| transaction-class machines  | %16d | %16d |\n",
-			                       conf.get().old_machines_with_transaction,
-			                       conf.get().auto_machines_with_transaction);
+			outputString += fmt::format("| transaction-class processes | {:16} | {:16} |\n",
+			                            conf.get().old_processes_with_transaction,
+			                            conf.get().auto_processes_with_transaction);
+			outputString += fmt::format("| transaction-class machines  | {:16} | {:16} |\n",
+			                            conf.get().old_machines_with_transaction,
+			                            conf.get().auto_machines_with_transaction);
 			outputString += " ------------------------------------------------------------------- \n\n";
 
-			std::printf("%s", outputString.c_str());
+			fmt::print("{}", outputString);
 
 			if (noChanges)
 				return true;
@@ -181,110 +182,108 @@ ACTOR Future<bool> configureCommandActor(Reference<IDatabase> db,
 		ret = false;
 		break;
 	case ConfigurationResult::INVALID_CONFIGURATION:
-		fprintf(stderr, "ERROR: These changes would make the configuration invalid\n");
+		fmt::println(stderr, "ERROR: These changes would make the configuration invalid");
 		ret = false;
 		break;
 	case ConfigurationResult::STORAGE_MIGRATION_DISABLED:
-		fprintf(stderr,
-		        "ERROR: Storage engine type cannot be changed because "
-		        "storage_migration_type=disabled.\n");
-		fprintf(stderr,
-		        "Type `configure perpetual_storage_wiggle=1 storage_migration_type=gradual' to enable gradual "
-		        "migration with the perpetual wiggle, or `configure "
-		        "storage_migration_type=aggressive' for aggressive migration.\n");
+		fmt::println(stderr, "ERROR: Storage engine type cannot be changed because storage_migration_type=disabled.");
+		fmt::println(
+		    stderr,
+		    "Type `configure perpetual_storage_wiggle=1 storage_migration_type=gradual' to enable gradual migration "
+		    "with the perpetual wiggle, or `configure storage_migration_type=aggressive' for aggressive migration.");
 		ret = false;
 		break;
 	case ConfigurationResult::DATABASE_ALREADY_CREATED:
-		fprintf(stderr, "ERROR: Database already exists! To change configuration, don't say `new'\n");
+		fmt::println(stderr, "ERROR: Database already exists! To change configuration, don't say `new'");
 		ret = false;
 		break;
 	case ConfigurationResult::DATABASE_CREATED:
-		printf("Database created\n");
+		fmt::println("Database created");
 		break;
 	case ConfigurationResult::DATABASE_CREATED_WARN_SHARDED_ROCKSDB_EXPERIMENTAL:
-		printf("Database created\n");
-		fprintf(
+		fmt::println("Database created");
+		fmt::println(
 		    stderr,
-		    "WARN: Sharded RocksDB storage engine type is still in experimental stage, not yet production tested.\n");
+		    "WARN: Sharded RocksDB storage engine type is still in experimental stage, not yet production tested.");
 		break;
 	case ConfigurationResult::DATABASE_UNAVAILABLE:
-		fprintf(stderr, "ERROR: The database is unavailable\n");
-		fprintf(stderr, "Type `configure FORCE <TOKEN...>' to configure without this check\n");
+		fmt::println(stderr, "ERROR: The database is unavailable");
+		fmt::println(stderr, "Type `configure FORCE <TOKEN...>' to configure without this check");
 		ret = false;
 		break;
 	case ConfigurationResult::STORAGE_IN_UNKNOWN_DCID:
-		fprintf(stderr, "ERROR: All storage servers must be in one of the known regions\n");
-		fprintf(stderr, "Type `configure FORCE <TOKEN...>' to configure without this check\n");
+		fmt::println(stderr, "ERROR: All storage servers must be in one of the known regions");
+		fmt::println(stderr, "Type `configure FORCE <TOKEN...>' to configure without this check");
 		ret = false;
 		break;
 	case ConfigurationResult::REGION_NOT_FULLY_REPLICATED:
-		fprintf(stderr,
-		        "ERROR: When usable_regions > 1, all regions with priority >= 0 must be fully replicated "
-		        "before changing the configuration\n");
-		fprintf(stderr, "Type `configure FORCE <TOKEN...>' to configure without this check\n");
+		fmt::println(stderr,
+		             "ERROR: When usable_regions > 1, all regions with priority >= 0 must be fully replicated before "
+		             "changing the configuration");
+		fmt::println(stderr, "Type `configure FORCE <TOKEN...>' to configure without this check");
 		ret = false;
 		break;
 	case ConfigurationResult::MULTIPLE_ACTIVE_REGIONS:
-		fprintf(stderr, "ERROR: When changing usable_regions, only one region can have priority >= 0\n");
-		fprintf(stderr, "Type `configure FORCE <TOKEN...>' to configure without this check\n");
+		fmt::println(stderr, "ERROR: When changing usable_regions, only one region can have priority >= 0");
+		fmt::println(stderr, "Type `configure FORCE <TOKEN...>' to configure without this check");
 		ret = false;
 		break;
 	case ConfigurationResult::REGIONS_CHANGED:
-		fprintf(stderr,
-		        "ERROR: The region configuration cannot be changed while simultaneously changing usable_regions\n");
-		fprintf(stderr, "Type `configure FORCE <TOKEN...>' to configure without this check\n");
+		fmt::println(stderr,
+		             "ERROR: The region configuration cannot be changed while simultaneously changing usable_regions");
+		fmt::println(stderr, "Type `configure FORCE <TOKEN...>' to configure without this check");
 		ret = false;
 		break;
 	case ConfigurationResult::NOT_ENOUGH_WORKERS:
-		fprintf(stderr, "ERROR: Not enough processes exist to support the specified configuration\n");
-		fprintf(stderr, "Type `configure FORCE <TOKEN...>' to configure without this check\n");
+		fmt::println(stderr, "ERROR: Not enough processes exist to support the specified configuration");
+		fmt::println(stderr, "Type `configure FORCE <TOKEN...>' to configure without this check");
 		ret = false;
 		break;
 	case ConfigurationResult::REGION_REPLICATION_MISMATCH:
-		fprintf(stderr, "ERROR: `three_datacenter' replication is incompatible with region configuration\n");
-		fprintf(stderr, "Type `configure FORCE <TOKEN...>' to configure without this check\n");
+		fmt::println(stderr, "ERROR: `three_datacenter' replication is incompatible with region configuration");
+		fmt::println(stderr, "Type `configure FORCE <TOKEN...>' to configure without this check");
 		ret = false;
 		break;
 	case ConfigurationResult::DCID_MISSING:
-		fprintf(stderr, "ERROR: `No storage servers in one of the specified regions\n");
-		fprintf(stderr, "Type `configure FORCE <TOKEN...>' to configure without this check\n");
+		fmt::println(stderr, "ERROR: `No storage servers in one of the specified regions");
+		fmt::println(stderr, "Type `configure FORCE <TOKEN...>' to configure without this check");
 		ret = false;
 		break;
 	case ConfigurationResult::SUCCESS:
-		printf("Configuration changed\n");
+		fmt::println("Configuration changed");
 		break;
 	case ConfigurationResult::LOCKED_NOT_NEW:
-		fprintf(stderr, "ERROR: `only new databases can be configured as locked`\n");
+		fmt::println(stderr, "ERROR: `only new databases can be configured as locked`");
 		ret = false;
 		break;
 	case ConfigurationResult::SUCCESS_WARN_PPW_GRADUAL:
-		printf("Configuration changed, with warnings\n");
-		fprintf(stderr,
-		        "WARN: To make progress toward the desired storage type with storage_migration_type=gradual, the "
-		        "Perpetual Wiggle must be enabled.\n");
-		fprintf(stderr,
-		        "Type `configure perpetual_storage_wiggle=1' to enable the perpetual wiggle, or `configure "
-		        "storage_migration_type=gradual' to set the gradual migration type.\n");
+		fmt::println("Configuration changed, with warnings");
+		fmt::println(stderr,
+		             "WARN: To make progress toward the desired storage type with storage_migration_type=gradual, the "
+		             "Perpetual Wiggle must be enabled.");
+		fmt::println(stderr,
+		             "Type `configure perpetual_storage_wiggle=1' to enable the perpetual wiggle, or `configure "
+		             "storage_migration_type=gradual' to set the gradual migration type.");
 		break;
 	case ConfigurationResult::SUCCESS_WARN_SHARDED_ROCKSDB_EXPERIMENTAL:
-		printf("Configuration changed\n");
-		fprintf(
+		fmt::println("Configuration changed");
+		fmt::println(
 		    stderr,
-		    "WARN: Sharded RocksDB storage engine type is still in experimental stage, not yet production tested.\n");
+		    "WARN: Sharded RocksDB storage engine type is still in experimental stage, not yet production tested.");
 		break;
 	case ConfigurationResult::DATABASE_IS_REGISTERED:
-		fprintf(stderr,
-		        "ERROR: a result of type `ConfigurationResult::DATABASE_IS_REGISTERED` was unexpectedly seen.\n");
+		fmt::println(stderr,
+		             "ERROR: a result of type `ConfigurationResult::DATABASE_IS_REGISTERED` was unexpectedly seen.");
 		ret = false;
 		break;
 	case ConfigurationResult::INVALID_STORAGE_TYPE:
-		fprintf(stderr, "ERROR: Invalid storage type for storage or TLog.\n");
+		fmt::println(stderr, "ERROR: Invalid storage type for storage or TLog.");
 		ret = false;
 		break;
 	case ConfigurationResult::BACKUP_WORKER_ENABLED_RESTRICTED:
-		fprintf(stderr,
-		        "ERROR: backup_worker_enabled configuration is restricted in fdbcli and managed automatically by the "
-		        "backup system.\n");
+		fmt::println(stderr,
+		             "ERROR: backup_worker_enabled configuration is restricted in fdbcli and managed automatically by "
+		             "the backup system.");
 		ret = false;
 		break;
 	default:

--- a/fdbcli/ConsistencyCheckCommand.cpp
+++ b/fdbcli/ConsistencyCheckCommand.cpp
@@ -26,6 +26,7 @@
 #include "flow/Arena.h"
 #include "flow/FastRef.h"
 #include "flow/ThreadHelper.actor.h"
+#include "fmt/format.h"
 namespace fdb_cli {
 
 const KeyRef consistencyCheckSpecialKey = "\xff\xff/management/consistency_check_suspended"_sr;
@@ -40,7 +41,7 @@ Future<bool> consistencyCheckCommandActor(Reference<ITransaction> tr,
 		// hold the returned standalone object's memory
 		ThreadFuture<Optional<Value>> suspendedF = tr->get(consistencyCheckSpecialKey);
 		Optional<Value> suspended = co_await safeThreadFutureToFuture(suspendedF);
-		printf("ConsistencyCheck is %s\n", suspended.present() ? "off" : "on");
+		fmt::println("ConsistencyCheck is {}", suspended.present() ? "off" : "on");
 	} else if (tokens.size() == 2 && tokencmp(tokens[1], "off")) {
 		tr->set(consistencyCheckSpecialKey, Value());
 		if (!intrans)

--- a/fdbcli/ConsistencyScanCommand.cpp
+++ b/fdbcli/ConsistencyScanCommand.cpp
@@ -25,6 +25,7 @@
 #include "fdbclient/ReadYourWrites.h"
 #include "fdbclient/RunTransaction.actor.h"
 #include "fdbclient/ConsistencyScanInterface.actor.h"
+#include "fmt/format.h"
 
 namespace fdb_cli {
 
@@ -33,11 +34,10 @@ Future<Void> dumpStats(ConsistencyScanState* cs, Reference<ReadYourWritesTransac
 	ConsistencyScanState::RoundStats statsCurrentRound;
 	co_await (store(statsLifetime, cs->lifetimeStats().getD(tr)) &&
 	          store(statsCurrentRound, cs->currentRoundStats().getD(tr)));
-	printf(
-	    "Current Round:\n%s\n",
-	    json_spirit::write_string(json_spirit::mValue(statsCurrentRound.toJSON()), json_spirit::pretty_print).c_str());
-	printf("Lifetime:\n%s\n",
-	       json_spirit::write_string(json_spirit::mValue(statsLifetime.toJSON()), json_spirit::pretty_print).c_str());
+	fmt::print("Current Round:\n{}\n",
+	           json_spirit::write_string(json_spirit::mValue(statsCurrentRound.toJSON()), json_spirit::pretty_print));
+	fmt::print("Lifetime:\n{}\n",
+	           json_spirit::write_string(json_spirit::mValue(statsLifetime.toJSON()), json_spirit::pretty_print));
 	co_return;
 }
 
@@ -57,9 +57,8 @@ Future<bool> consistencyScanCommandActor(Database db, std::vector<StringRef> con
 			ConsistencyScanState::Config config = co_await ConsistencyScanState().config().getD(tr);
 
 			if (args.empty()) {
-				printf(
-				    "%s\n",
-				    json_spirit::write_string(json_spirit::mValue(config.toJSON()), json_spirit::pretty_print).c_str());
+				fmt::println(
+				    "{}", json_spirit::write_string(json_spirit::mValue(config.toJSON()), json_spirit::pretty_print));
 				break;
 			}
 

--- a/fdbcli/CoordinatorsCommand.actor.cpp
+++ b/fdbcli/CoordinatorsCommand.actor.cpp
@@ -31,6 +31,7 @@
 #include "flow/Arena.h"
 #include "flow/FastRef.h"
 #include "flow/ThreadHelper.actor.h"
+#include "fmt/format.h"
 #include "flow/actorcompiler.h" // This must be the last #include.
 
 namespace {
@@ -43,15 +44,15 @@ ACTOR Future<Void> printCoordinatorsInfo(Reference<IDatabase> db) {
 			state ThreadFuture<Optional<Value>> descriptionF = tr->get(fdb_cli::clusterDescriptionSpecialKey);
 			Optional<Value> description = wait(safeThreadFutureToFuture(descriptionF));
 			ASSERT(description.present());
-			printf("Cluster description: %s\n", description.get().toString().c_str());
+			fmt::println("Cluster description: {}", description.get().toString());
 			// Hold the reference to the standalone's memory
 			state ThreadFuture<Optional<Value>> processesF = tr->get(fdb_cli::coordinatorsProcessSpecialKey);
 			Optional<Value> processes = wait(safeThreadFutureToFuture(processesF));
 			ASSERT(processes.present());
 			std::vector<std::string> process_addresses;
 			boost::split(process_addresses, processes.get().toString(), [](char c) { return c == ','; });
-			printf("Cluster coordinators (%zu): %s\n", process_addresses.size(), processes.get().toString().c_str());
-			printf("Type `help coordinators' to learn how to change this information.\n");
+			fmt::println("Cluster coordinators ({}): {}", process_addresses.size(), processes.get().toString());
+			fmt::println("Type `help coordinators' to learn how to change this information.");
 			return Void();
 		} catch (Error& e) {
 			wait(safeThreadFutureToFuture(tr->onError(e)));
@@ -107,9 +108,7 @@ ACTOR Future<bool> changeCoordinators(Reference<IDatabase> db, std::vector<Strin
 							// We do not resolve hostnames here. We commit them as is.
 							const auto& hostname = Hostname::parse(t->toString());
 							if (new_coordinators_hostnames.count(hostname)) {
-								fprintf(stderr,
-								        "ERROR: passed redundant coordinators: `%s'\n",
-								        hostname.toString().c_str());
+								fmt::println(stderr, "ERROR: passed redundant coordinators: `{}'", hostname.toString());
 								return true;
 							}
 							new_coordinators_hostnames.insert(hostname);
@@ -117,8 +116,7 @@ ACTOR Future<bool> changeCoordinators(Reference<IDatabase> db, std::vector<Strin
 						} else {
 							const auto& addr = NetworkAddress::parse(t->toString());
 							if (new_coordinators_addresses.count(addr)) {
-								fprintf(
-								    stderr, "ERROR: passed redundant coordinators: `%s'\n", addr.toString().c_str());
+								fmt::println(stderr, "ERROR: passed redundant coordinators: `{}'", addr.toString());
 								return true;
 							}
 							new_coordinators_addresses.insert(addr);
@@ -126,8 +124,7 @@ ACTOR Future<bool> changeCoordinators(Reference<IDatabase> db, std::vector<Strin
 						}
 					} catch (Error& e) {
 						if (e.code() == error_code_connection_string_invalid) {
-							fprintf(
-							    stderr, "ERROR: '%s' is not a valid network endpoint address\n", t->toString().c_str());
+							fmt::println(stderr, "ERROR: '{}' is not a valid network endpoint address", t->toString());
 							return true;
 						}
 						throw;
@@ -155,12 +152,12 @@ ACTOR Future<bool> changeCoordinators(Reference<IDatabase> db, std::vector<Strin
 				} else if (errorMsgStr ==
 				           ManagementAPI::generateErrorMessage(CoordinatorsResult::SAME_NETWORK_ADDRESSES)) {
 					if (retries)
-						printf("Coordination state changed\n");
+						fmt::println("Coordination state changed");
 					else
-						printf("No change (existing configuration satisfies request)\n");
+						fmt::println("No change (existing configuration satisfies request)");
 					return true;
 				} else {
-					fprintf(stderr, "ERROR: %s\n", errorMsgStr.c_str());
+					fmt::println(stderr, "ERROR: {}", errorMsgStr);
 					return false;
 				}
 			}

--- a/fdbcli/DataDistributionCommand.actor.cpp
+++ b/fdbcli/DataDistributionCommand.actor.cpp
@@ -29,6 +29,7 @@
 #include "flow/Arena.h"
 #include "flow/FastRef.h"
 #include "flow/ThreadHelper.actor.h"
+#include "fmt/format.h"
 #include "flow/actorcompiler.h" // This must be the last #include.
 
 namespace {
@@ -121,23 +122,23 @@ ACTOR Future<bool> dataDistributionCommandActor(Reference<IDatabase> db, std::ve
 	} else {
 		if (tokencmp(tokens[1], "on")) {
 			wait(success(setDDMode(db, 1)));
-			printf("Data distribution is turned on.\n");
+			fmt::println("Data distribution is turned on.");
 		} else if (tokencmp(tokens[1], "off")) {
 			wait(success(setDDMode(db, 0)));
-			printf("Data distribution is turned off.\n");
+			fmt::println("Data distribution is turned off.");
 		} else if (tokencmp(tokens[1], "disable")) {
 			if (tokencmp(tokens[2], "ssfailure")) {
 				wait(success((setHealthyZone(db, "IgnoreSSFailures"_sr, 0))));
-				printf("Data distribution is disabled for storage server failures.\n");
+				fmt::println("Data distribution is disabled for storage server failures.");
 			} else if (tokencmp(tokens[2], "rebalance")) {
 				wait(setDDIgnoreRebalanceOn(db, DDIgnore::REBALANCE_DISK | DDIgnore::REBALANCE_READ));
-				printf("Data distribution is disabled for rebalance.\n");
+				fmt::println("Data distribution is disabled for rebalance.");
 			} else if (tokencmp(tokens[2], "rebalance_disk")) {
 				wait(setDDIgnoreRebalanceOn(db, DDIgnore::REBALANCE_DISK));
-				printf("Data distribution is disabled for rebalance_disk.\n");
+				fmt::println("Data distribution is disabled for rebalance_disk.");
 			} else if (tokencmp(tokens[2], "rebalance_read")) {
 				wait(setDDIgnoreRebalanceOn(db, DDIgnore::REBALANCE_READ));
-				printf("Data distribution is disabled for rebalance_read.\n");
+				fmt::println("Data distribution is disabled for rebalance_read.");
 			} else {
 				printf(usage);
 				result = false;
@@ -145,16 +146,16 @@ ACTOR Future<bool> dataDistributionCommandActor(Reference<IDatabase> db, std::ve
 		} else if (tokencmp(tokens[1], "enable")) {
 			if (tokencmp(tokens[2], "ssfailure")) {
 				wait(success((clearHealthyZone(db, false, true))));
-				printf("Data distribution is enabled for storage server failures.\n");
+				fmt::println("Data distribution is enabled for storage server failures.");
 			} else if (tokencmp(tokens[2], "rebalance")) {
 				wait(setDDIgnoreRebalanceOff(db, DDIgnore::REBALANCE_DISK | DDIgnore::REBALANCE_READ));
-				printf("Data distribution is enabled for rebalance.\n");
+				fmt::println("Data distribution is enabled for rebalance.");
 			} else if (tokencmp(tokens[2], "rebalance_disk")) {
 				wait(setDDIgnoreRebalanceOff(db, DDIgnore::REBALANCE_DISK));
-				printf("Data distribution is enabled for rebalance_disk.\n");
+				fmt::println("Data distribution is enabled for rebalance_disk.");
 			} else if (tokencmp(tokens[2], "rebalance_read")) {
 				wait(setDDIgnoreRebalanceOff(db, DDIgnore::REBALANCE_READ));
-				printf("Data distribution is enabled for rebalance_read.\n");
+				fmt::println("Data distribution is enabled for rebalance_read.");
 			} else {
 				printf(usage);
 				result = false;

--- a/fdbcli/DebugCommands.actor.cpp
+++ b/fdbcli/DebugCommands.actor.cpp
@@ -25,6 +25,7 @@
 #include "fdbclient/FDBTypes.h"
 #include "fdbclient/NativeAPI.actor.h"
 
+#include "fmt/format.h"
 #include "flow/actorcompiler.h" // This must be the last #include.
 
 namespace fdb_cli {
@@ -33,7 +34,7 @@ std::string toHex(StringRef v) {
 	std::string result;
 	result.reserve(v.size() * 4);
 	for (int i = 0; i < v.size(); i++) {
-		result.append(format("\\x%02x", v[i]));
+		result.append(fmt::format("\\x{:02x}", v[i]));
 	}
 	return result;
 }

--- a/fdbcli/ExcludeCommand.actor.cpp
+++ b/fdbcli/ExcludeCommand.actor.cpp
@@ -29,6 +29,7 @@
 #include "flow/Arena.h"
 #include "flow/FastRef.h"
 #include "flow/ThreadHelper.actor.h"
+#include "fmt/format.h"
 #include "flow/actorcompiler.h" // This must be the last #include.
 
 namespace {
@@ -71,12 +72,13 @@ ACTOR Future<bool> excludeServersAndLocalities(Reference<IDatabase> db,
 				auto pos = errorMsgStr.find_last_of("\n", errorMsgStr.size() - 2);
 				auto last_line = errorMsgStr.substr(pos + 1);
 				// customized the error message for fdbcli
-				fprintf(stderr,
-				        "%s\n%s\n",
-				        errorMsgStr.substr(0, pos).c_str(),
-				        last_line.find("free space") != std::string::npos
-				            ? "Type `exclude FORCE <ADDRESS...>' to exclude without checking free space."
-				            : "Type `exclude FORCE failed <ADDRESS...>' to exclude without performing safety checks.");
+				fmt::print(
+				    stderr,
+				    "{}\n{}\n",
+				    errorMsgStr.substr(0, pos),
+				    last_line.find("free space") != std::string::npos
+				        ? "Type `exclude FORCE <ADDRESS...>' to exclude without checking free space."
+				        : "Type `exclude FORCE failed <ADDRESS...>' to exclude without performing safety checks.");
 				return false;
 			}
 			TraceEvent(SevWarn, "ExcludeServersAndLocalitiesError").error(err);
@@ -256,13 +258,13 @@ ACTOR Future<Void> checkForCoordinators(Reference<IDatabase> db, std::set<Addres
 	for (const auto& c : coordinatorList) {
 		if (exclusions.find(AddressExclusion(c.ip, c.port)) != exclusions.end() ||
 		    exclusions.find(AddressExclusion(c.ip)) != exclusions.end()) {
-			fprintf(stderr, "WARNING: %s is a coordinator!\n", c.toString().c_str());
+			fmt::println(stderr, "WARNING: {} is a coordinator!", c.toString());
 			foundCoordinator = true;
 		}
 	}
 	if (foundCoordinator)
-		printf("Type `help coordinators' for information on how to change the\n"
-		       "cluster's coordination servers before removing them.\n");
+		fmt::print("Type `help coordinators' for information on how to change the\ncluster's coordination servers "
+		           "before removing them.\n");
 	return Void();
 }
 
@@ -293,44 +295,45 @@ ACTOR Future<bool> excludeCommandActor(Reference<IDatabase> db, std::vector<Stri
 
 		if (!excludedAddresses.size() && !excludedLocalities.size() && !failedAddresses.size() &&
 		    !failedLocalities.size()) {
-			printf("There are currently no servers or localities excluded from the database.\n"
-			       "To learn how to exclude a server, type `help exclude'.\n");
+			fmt::print("There are currently no servers or localities excluded from the database.\nTo learn how to "
+			           "exclude a server, type `help exclude'.\n");
 			return true;
 		}
 
-		printf("There are currently %zu servers or localities being excluded from the database:\n",
-		       excludedAddresses.size() + excludedLocalities.size());
+		fmt::println("There are currently {} servers or localities being excluded from the database:",
+		             excludedAddresses.size() + excludedLocalities.size());
 		for (const auto& e : excludedAddresses)
-			printf("  %s\n", e.c_str());
+			fmt::println("  {}", e);
 		for (const auto& e : excludedLocalities)
-			printf("  %s\n", e.c_str());
+			fmt::println("  {}", e);
 
 		if (excludedAddresses.size() || excludedLocalities.size()) {
-			printf("To find out whether it is safe to remove one or more of these\n"
-			       "servers from the cluster, type `exclude <addresses>'.\n"
-			       "To return one of these servers to the cluster, type `include <addresses>'.\n");
+			fmt::print(
+			    "To find out whether it is safe to remove one or more of these\nservers from the cluster, type "
+			    "`exclude <addresses>'.\nTo return one of these servers to the cluster, type `include <addresses>'.\n");
 		}
 
-		printf("\n");
+		fmt::println("");
 
-		printf("There are currently %zu servers or localities marked as failed in the database:\n",
-		       failedAddresses.size() + failedLocalities.size());
+		fmt::println("There are currently {} servers or localities marked as failed in the database:",
+		             failedAddresses.size() + failedLocalities.size());
 		for (const auto& f : failedAddresses)
-			printf("  %s\n", f.c_str());
+			fmt::println("  {}", f);
 		for (const auto& f : failedLocalities)
-			printf("  %s\n", f.c_str());
+			fmt::println("  {}", f);
 
 		if (failedAddresses.size() || failedLocalities.size()) {
-			printf("To return one of these servers to the cluster, type `include failed <addresses>'.\n");
+			fmt::println("To return one of these servers to the cluster, type `include failed <addresses>'.");
 		}
 
-		printf("\n");
+		fmt::println("");
 
 		Reference<ITransaction> tr = db->createTransaction();
 		std::set<NetworkAddress> inProgressExclusion = wait(getInProgressExclusion(tr));
-		printf("There are currently %zu processes for which exclusion is in progress:\n", inProgressExclusion.size());
+		fmt::println("There are currently {} processes for which exclusion is in progress:",
+		             inProgressExclusion.size());
 		for (const auto& addr : inProgressExclusion) {
-			printf("%s\n", addr.toString().c_str());
+			fmt::println("{}", addr.toString());
 		}
 
 		return true;
@@ -375,11 +378,11 @@ ACTOR Future<bool> excludeCommandActor(Reference<IDatabase> db, std::vector<Stri
 			} else {
 				auto a = AddressExclusion::parse(*t);
 				if (!a.isValid()) {
-					fprintf(stderr,
-					        "ERROR: '%s' is neither a valid network endpoint address nor a locality\n",
-					        t->toString().c_str());
+					fmt::println(stderr,
+					             "ERROR: '{}' is neither a valid network endpoint address nor a locality",
+					             t->toString());
 					if (t->toString().find(":tls") != std::string::npos)
-						printf("        Do not include the `:tls' suffix when naming a process\n");
+						fmt::println("        Do not include the `:tls' suffix when naming a process");
 					return true;
 				}
 				exclusionSet.insert(a);
@@ -390,7 +393,7 @@ ACTOR Future<bool> excludeCommandActor(Reference<IDatabase> db, std::vector<Stri
 		// The validation if a locality or address has no match is done below and will result in a warning. If we abort
 		// here the provided locality and/or address will not be excluded.
 		if (exclusionAddresses.empty() && exclusionLocalities.empty()) {
-			fprintf(stderr, "ERROR: At least one valid network endpoint address or a locality must be provided\n");
+			fmt::println(stderr, "ERROR: At least one valid network endpoint address or a locality must be provided");
 			return false;
 		}
 
@@ -399,8 +402,8 @@ ACTOR Future<bool> excludeCommandActor(Reference<IDatabase> db, std::vector<Stri
 			return false;
 
 		if (waitForAllExcluded) {
-			printf("Waiting for state to be removed from all excluded servers. This may take a while.\n");
-			printf("(Interrupting this wait with CTRL+C will not cancel the data movement.)\n");
+			fmt::println("Waiting for state to be removed from all excluded servers. This may take a while.");
+			fmt::println("(Interrupting this wait with CTRL+C will not cancel the data movement.)");
 		}
 
 		if (warn.isValid())
@@ -425,49 +428,48 @@ ACTOR Future<bool> excludeCommandActor(Reference<IDatabase> db, std::vector<Stri
 		for (const auto& exclusion : exclusionSet) {
 			if (absentExclusions.find(exclusion) != absentExclusions.end()) {
 				if (exclusion.port == 0) {
-					fprintf(stderr,
-					        "  %s(Whole machine)  ---- WARNING: Missing from cluster!Be sure that you excluded the "
-					        "correct machines before removing them from the cluster!\n",
-					        exclusion.ip.toString().c_str());
+					fmt::println(stderr,
+					             "  {}(Whole machine)  ---- WARNING: Missing from cluster!Be sure that you excluded "
+					             "the correct machines before removing them from the cluster!",
+					             exclusion.ip.toString());
 				} else {
-					fprintf(stderr,
-					        "  %s  ---- WARNING: Missing from cluster! Be sure that you excluded the correct processes "
-					        "before removing them from the cluster!\n",
-					        exclusion.toString().c_str());
+					fmt::println(stderr,
+					             "  {}  ---- WARNING: Missing from cluster! Be sure that you excluded the correct "
+					             "processes before removing them from the cluster!",
+					             exclusion.toString());
 				}
 			} else if (std::any_of(notExcludedServers.begin(), notExcludedServers.end(), [&](const NetworkAddress& a) {
 				           return addressExcluded({ exclusion }, a);
 			           })) {
 				if (exclusion.port == 0) {
-					fprintf(stderr,
-					        "  %s(Whole machine)  ---- WARNING: Exclusion in progress! It is not safe to remove this "
-					        "machine from the cluster\n",
-					        exclusion.ip.toString().c_str());
+					fmt::println(stderr,
+					             "  {}(Whole machine)  ---- WARNING: Exclusion in progress! It is not safe to remove "
+					             "this machine from the cluster",
+					             exclusion.ip.toString());
 				} else {
-					fprintf(stderr,
-					        "  %s  ---- WARNING: Exclusion in progress! It is not safe to remove this process from the "
-					        "cluster\n",
-					        exclusion.toString().c_str());
+					fmt::println(stderr,
+					             "  {}  ---- WARNING: Exclusion in progress! It is not safe to remove this process "
+					             "from the cluster",
+					             exclusion.toString());
 				}
 			} else {
 				if (exclusion.port == 0) {
-					printf("  %s(Whole machine)  ---- Successfully excluded. It is now safe to remove this machine "
-					       "from the cluster.\n",
-					       exclusion.ip.toString().c_str());
+					fmt::println("  {}(Whole machine)  ---- Successfully excluded. It is now safe to remove this "
+					             "machine from the cluster.",
+					             exclusion.ip.toString());
 				} else {
-					printf(
-					    "  %s  ---- Successfully excluded. It is now safe to remove this process from the cluster.\n",
-					    exclusion.toString().c_str());
+					fmt::println(
+					    "  {}  ---- Successfully excluded. It is now safe to remove this process from the cluster.",
+					    exclusion.toString());
 				}
 			}
 		}
 
 		for (const auto& locality : noMatchLocalities) {
-			fprintf(
-			    stderr,
-			    "  %s  ---- WARNING: Currently no servers found with this locality match! Be sure that you excluded "
-			    "the correct locality.\n",
-			    locality.c_str());
+			fmt::println(stderr,
+			             "  {}  ---- WARNING: Currently no servers found with this locality match! Be sure that you "
+			             "excluded the correct locality.",
+			             locality);
 		}
 
 		wait(checkForCoordinators(db, exclusionSet));

--- a/fdbcli/ExpensiveDataCheckCommand.actor.cpp
+++ b/fdbcli/ExpensiveDataCheckCommand.actor.cpp
@@ -29,6 +29,7 @@
 #include "flow/Arena.h"
 #include "flow/FastRef.h"
 #include "flow/ThreadHelper.actor.h"
+#include "fmt/format.h"
 #include "flow/actorcompiler.h" // This must be the last #include.
 
 namespace fdb_cli {
@@ -50,21 +51,21 @@ ACTOR Future<bool> expensiveDataCheckCommandActor(
 	}
 	if (tokens.size() == 1 || tokencmp(tokens[1], "list")) {
 		if (address_interface->size() == 0) {
-			printf("\nNo addresses can be checked.\n");
+			fmt::print("\nNo addresses can be checked.\n");
 		} else if (address_interface->size() == 1) {
-			printf("\nThe following address can be checked:\n");
+			fmt::print("\nThe following address can be checked:\n");
 		} else {
-			printf("\nThe following %zu addresses can be checked:\n", address_interface->size());
+			fmt::print("\nThe following {} addresses can be checked:\n", address_interface->size());
 		}
 		for (auto it : *address_interface) {
-			printf("%s\n", printable(it.first).c_str());
+			fmt::println("{}", printable(it.first));
 		}
-		printf("\n");
+		fmt::println("");
 	} else if (tokencmp(tokens[1], "all")) {
 		if (address_interface->size() == 0) {
-			fprintf(stderr,
-			        "ERROR: no processes to check. You must run the `expensive_data_check’ "
-			        "command before running `expensive_data_check all’.\n");
+			fmt::println(stderr,
+			             "ERROR: no processes to check. You must run the `expensive_data_checkâ command before "
+			             "running `expensive_data_check allâ.");
 		} else {
 			std::vector<std::string> addressesVec;
 			for (const auto& [address, _] : *address_interface) {
@@ -75,18 +76,18 @@ ACTOR Future<bool> expensiveDataCheckCommandActor(
 			int64_t checkRequestsSent = wait(safeThreadFutureToFuture(db->rebootWorker(addressesStr, true, 0)));
 			if (!checkRequestsSent) {
 				result = false;
-				fprintf(stderr,
-				        "ERROR: failed to send requests to check all processes, please run the `expensive_data_check’ "
-				        "command again to fetch latest addresses.\n");
+				fmt::println(stderr,
+				             "ERROR: failed to send requests to check all processes, please run the "
+				             "`expensive_data_checkâ command again to fetch latest addresses.");
 			} else {
-				printf("Attempted to kill and check %zu processes\n", address_interface->size());
+				fmt::println("Attempted to kill and check {} processes", address_interface->size());
 			}
 		}
 	} else {
 		state int i;
 		for (i = 1; i < tokens.size(); i++) {
 			if (!address_interface->count(tokens[i])) {
-				fprintf(stderr, "ERROR: process `%s' not recognized.\n", printable(tokens[i]).c_str());
+				fmt::println(stderr, "ERROR: process `{}' not recognized.", printable(tokens[i]));
 				result = false;
 				break;
 			}
@@ -101,12 +102,12 @@ ACTOR Future<bool> expensiveDataCheckCommandActor(
 			int64_t checkRequestsSent = wait(safeThreadFutureToFuture(db->rebootWorker(addressesStr, true, 0)));
 			if (!checkRequestsSent) {
 				result = false;
-				fprintf(stderr,
-				        "ERROR: failed to send requests to check processes `%s', please run the `expensive_data_check’ "
-				        "command again to fetch latest addresses.\n",
-				        addressesStr.c_str());
+				fmt::println(stderr,
+				             "ERROR: failed to send requests to check processes `{}', please run the "
+				             "`expensive_data_checkâ command again to fetch latest addresses.",
+				             addressesStr);
 			} else {
-				printf("Attempted to kill and check %zu processes\n", tokens.size() - 1);
+				fmt::println("Attempted to kill and check {} processes", tokens.size() - 1);
 			}
 		}
 	}

--- a/fdbcli/FileConfigureCommand.cpp
+++ b/fdbcli/FileConfigureCommand.cpp
@@ -30,6 +30,7 @@
 #include "flow/Arena.h"
 #include "flow/FastRef.h"
 #include "flow/ThreadHelper.actor.h"
+#include "fmt/format.h"
 namespace fdb_cli {
 
 Future<bool> fileConfigureCommandActor(Reference<IDatabase> db,
@@ -40,11 +41,11 @@ Future<bool> fileConfigureCommandActor(Reference<IDatabase> db,
 	std::string contents(readFileBytes(filePath, 100000));
 	json_spirit::mValue config;
 	if (!json_spirit::read_string(contents, config)) {
-		fprintf(stderr, "ERROR: Invalid JSON\n");
+		fmt::println(stderr, "ERROR: Invalid JSON");
 		co_return false;
 	}
 	if (config.type() != json_spirit::obj_type) {
-		fprintf(stderr, "ERROR: Configuration file must contain a JSON object\n");
+		fmt::println(stderr, "ERROR: Configuration file must contain a JSON object");
 		co_return false;
 	}
 	StatusObject configJSON = config.get_obj();
@@ -56,7 +57,7 @@ Future<bool> fileConfigureCommandActor(Reference<IDatabase> db,
 
 	std::string errorStr;
 	if (!schemaMatch(schema.get_obj(), configJSON, errorStr)) {
-		printf("%s", errorStr.c_str());
+		fmt::print("{}", errorStr);
 		co_return false;
 	}
 
@@ -89,83 +90,83 @@ Future<bool> fileConfigureCommandActor(Reference<IDatabase> db,
 	bool ret = true;
 	switch (result) {
 	case ConfigurationResult::NO_OPTIONS_PROVIDED:
-		fprintf(stderr, "ERROR: No options provided\n");
+		fmt::println(stderr, "ERROR: No options provided");
 		ret = false;
 		break;
 	case ConfigurationResult::CONFLICTING_OPTIONS:
-		fprintf(stderr, "ERROR: Conflicting options\n");
+		fmt::println(stderr, "ERROR: Conflicting options");
 		ret = false;
 		break;
 	case ConfigurationResult::UNKNOWN_OPTION:
-		fprintf(stderr, "ERROR: Unknown option\n"); // This should not be possible because of schema match
+		fmt::println(stderr, "ERROR: Unknown option"); // This should not be possible because of schema match
 		ret = false;
 		break;
 	case ConfigurationResult::INCOMPLETE_CONFIGURATION:
-		fprintf(stderr,
-		        "ERROR: Must specify both a replication level and a storage engine when creating a new database\n");
+		fmt::println(stderr,
+		             "ERROR: Must specify both a replication level and a storage engine when creating a new database");
 		ret = false;
 		break;
 	case ConfigurationResult::INVALID_CONFIGURATION:
-		fprintf(stderr, "ERROR: These changes would make the configuration invalid\n");
+		fmt::println(stderr, "ERROR: These changes would make the configuration invalid");
 		ret = false;
 		break;
 	case ConfigurationResult::DATABASE_ALREADY_CREATED:
-		fprintf(stderr, "ERROR: Database already exists! To change configuration, don't say `new'\n");
+		fmt::println(stderr, "ERROR: Database already exists! To change configuration, don't say `new'");
 		ret = false;
 		break;
 	case ConfigurationResult::DATABASE_CREATED:
-		printf("Database created\n");
+		fmt::println("Database created");
 		break;
 	case ConfigurationResult::DATABASE_UNAVAILABLE:
-		fprintf(stderr, "ERROR: The database is unavailable\n");
-		printf("Type `fileconfigure FORCE <FILENAME>' to configure without this check\n");
+		fmt::println(stderr, "ERROR: The database is unavailable");
+		fmt::println("Type `fileconfigure FORCE <FILENAME>' to configure without this check");
 		ret = false;
 		break;
 	case ConfigurationResult::STORAGE_IN_UNKNOWN_DCID:
-		fprintf(stderr, "ERROR: All storage servers must be in one of the known regions\n");
-		printf("Type `fileconfigure FORCE <FILENAME>' to configure without this check\n");
+		fmt::println(stderr, "ERROR: All storage servers must be in one of the known regions");
+		fmt::println("Type `fileconfigure FORCE <FILENAME>' to configure without this check");
 		ret = false;
 		break;
 	case ConfigurationResult::REGION_NOT_FULLY_REPLICATED:
-		fprintf(stderr,
-		        "ERROR: When usable_regions > 1, All regions with priority >= 0 must be fully replicated "
-		        "before changing the configuration\n");
-		printf("Type `fileconfigure FORCE <FILENAME>' to configure without this check\n");
+		fmt::println(stderr,
+		             "ERROR: When usable_regions > 1, All regions with priority >= 0 must be fully replicated before "
+		             "changing the configuration");
+		fmt::println("Type `fileconfigure FORCE <FILENAME>' to configure without this check");
 		ret = false;
 		break;
 	case ConfigurationResult::MULTIPLE_ACTIVE_REGIONS:
-		fprintf(stderr, "ERROR: When changing usable_regions, only one region can have priority >= 0\n");
-		printf("Type `fileconfigure FORCE <FILENAME>' to configure without this check\n");
+		fmt::println(stderr, "ERROR: When changing usable_regions, only one region can have priority >= 0");
+		fmt::println("Type `fileconfigure FORCE <FILENAME>' to configure without this check");
 		ret = false;
 		break;
 	case ConfigurationResult::REGIONS_CHANGED:
-		fprintf(stderr,
-		        "ERROR: The region configuration cannot be changed while simultaneously changing usable_regions\n");
-		printf("Type `fileconfigure FORCE <FILENAME>' to configure without this check\n");
+		fmt::println(stderr,
+		             "ERROR: The region configuration cannot be changed while simultaneously changing usable_regions");
+		fmt::println("Type `fileconfigure FORCE <FILENAME>' to configure without this check");
 		ret = false;
 		break;
 	case ConfigurationResult::NOT_ENOUGH_WORKERS:
-		fprintf(stderr, "ERROR: Not enough processes exist to support the specified configuration\n");
-		printf("Type `fileconfigure FORCE <FILENAME>' to configure without this check\n");
+		fmt::println(stderr, "ERROR: Not enough processes exist to support the specified configuration");
+		fmt::println("Type `fileconfigure FORCE <FILENAME>' to configure without this check");
 		ret = false;
 		break;
 	case ConfigurationResult::REGION_REPLICATION_MISMATCH:
-		fprintf(stderr, "ERROR: `three_datacenter' replication is incompatible with region configuration\n");
-		printf("Type `fileconfigure FORCE <TOKEN...>' to configure without this check\n");
+		fmt::println(stderr, "ERROR: `three_datacenter' replication is incompatible with region configuration");
+		fmt::println("Type `fileconfigure FORCE <TOKEN...>' to configure without this check");
 		ret = false;
 		break;
 	case ConfigurationResult::DCID_MISSING:
-		fprintf(stderr, "ERROR: `No storage servers in one of the specified regions\n");
-		printf("Type `fileconfigure FORCE <TOKEN...>' to configure without this check\n");
+		fmt::println(stderr, "ERROR: `No storage servers in one of the specified regions");
+		fmt::println("Type `fileconfigure FORCE <TOKEN...>' to configure without this check");
 		ret = false;
 		break;
 	case ConfigurationResult::SUCCESS:
-		printf("Configuration changed\n");
+		fmt::println("Configuration changed");
 		break;
 	case ConfigurationResult::BACKUP_WORKER_ENABLED_RESTRICTED:
-		fprintf(stderr,
-		        "ERROR: backup_worker_enabled configuration is restricted in fdbcli and managed automatically by the "
-		        "backup system\n");
+		fmt::println(stderr,
+		             "ERROR: backup_worker_enabled configuration is restricted in fdbcli and managed automatically by "
+		             "the backup system");
 		ret = false;
 		break;
 	default:

--- a/fdbcli/HotRangeCommand.cpp
+++ b/fdbcli/HotRangeCommand.cpp
@@ -31,6 +31,7 @@
 #include "flow/FastRef.h"
 #include "flow/NetworkAddress.h"
 #include "flow/ThreadHelper.actor.h"
+#include "fmt/format.h"
 namespace {
 
 ReadHotSubRangeRequest::SplitType parseSplitType(const std::string& typeStr) {
@@ -42,7 +43,7 @@ ReadHotSubRangeRequest::SplitType parseSplitType(const std::string& typeStr) {
 	} else if (typeStr == "readOps") {
 		type = ReadHotSubRangeRequest::READ_OPS;
 	} else {
-		fmt::print("Error: {} is not a valid split type. Will use bytes as the default split type\n", typeStr);
+		fmt::println("Error: {} is not a valid split type. Will use bytes as the default split type", typeStr);
 	}
 	return type;
 }
@@ -62,25 +63,26 @@ Future<bool> hotRangeCommandActor(Database localdb,
 		co_await getStorageServerInterfaces(db, storage_interface);
 		fmt::print("\nThe following {} storage servers can be queried:\n", storage_interface->size());
 		for (const auto& [addr, _] : *storage_interface) {
-			fmt::print("{}\n", addr);
+			fmt::println("{}", addr);
 		}
-		fmt::print("\n");
+		fmt::println("");
 	} else if (tokens.size() == 6) {
 		if (storage_interface->empty()) {
-			fprintf(stderr, "ERROR: no storage processes to query. You must run the `hotrange’ command first.\n");
+			fmt::println(stderr,
+			             "ERROR: no storage processes to query. You must run the `hotrangeâ command first.");
 			co_return false;
 		}
 		Key address = tokens[1];
 		// At present we only support one process(IP:Port) at a time
 		if (!storage_interface->count(address.toString())) {
-			fprintf(stderr, "ERROR: storage process `%s' not recognized.\n", printable(address).c_str());
+			fmt::println(stderr, "ERROR: storage process `{}' not recognized.", printable(address));
 			co_return false;
 		}
 		int splitCount{ 0 };
 		try {
 			splitCount = boost::lexical_cast<int>(tokens[5].toString());
 		} catch (...) {
-			fmt::print("Error: splitCount value: '{}', cannot be parsed to an Integer\n", tokens[5].toString());
+			fmt::println("Error: splitCount value: '{}', cannot be parsed to an Integer", tokens[5].toString());
 			co_return false;
 		}
 		ReadHotSubRangeRequest::SplitType splitType = parseSplitType(tokens[2].toString());

--- a/fdbcli/IdempotencyIdsCommand.cpp
+++ b/fdbcli/IdempotencyIdsCommand.cpp
@@ -22,6 +22,7 @@
 #include "fdbclient/IdempotencyId.actor.h"
 #include "fdbclient/JsonBuilder.h"
 #include "fdbclient/json_spirit/json_spirit_reader_template.h"
+#include "fmt/format.h"
 namespace {
 
 Optional<double> parseAgeValue(StringRef token) {
@@ -48,7 +49,7 @@ Future<bool> idempotencyIdsCommandActor(Database db, std::vector<StringRef> cons
 				co_return false;
 			}
 			JsonBuilderObject const& status = co_await getIdmpKeyStatus(db);
-			fmt::print("{}\n", status.getJson());
+			fmt::println("{}", status.getJson());
 			co_return true;
 		} else if (action == "clear"_sr) {
 			if (tokens.size() != 3) {
@@ -61,7 +62,7 @@ Future<bool> idempotencyIdsCommandActor(Database db, std::vector<StringRef> cons
 				co_return false;
 			}
 			co_await cleanIdempotencyIds(db, age.get());
-			fmt::print("Successfully cleared idempotency IDs.\n");
+			fmt::println("Successfully cleared idempotency IDs.");
 			co_return true;
 		} else {
 			printUsage(tokens[0]);

--- a/fdbcli/IncludeCommand.actor.cpp
+++ b/fdbcli/IncludeCommand.actor.cpp
@@ -27,6 +27,7 @@
 #include "flow/Arena.h"
 #include "flow/FastRef.h"
 #include "flow/ThreadHelper.actor.h"
+#include "fmt/format.h"
 #include "flow/actorcompiler.h" // This must be the last #include.
 
 namespace {
@@ -121,11 +122,10 @@ ACTOR Future<bool> include(Reference<IDatabase> db, std::vector<StringRef> token
 		} else {
 			auto a = AddressExclusion::parse(*t);
 			if (!a.isValid()) {
-				fprintf(stderr,
-				        "ERROR: '%s' is neither a valid network endpoint address nor a locality\n",
-				        t->toString().c_str());
+				fmt::println(
+				    stderr, "ERROR: '{}' is neither a valid network endpoint address nor a locality", t->toString());
 				if (t->toString().find(":tls") != std::string::npos)
-					printf("        Do not include the `:tls' suffix when naming a process\n");
+					fmt::println("        Do not include the `:tls' suffix when naming a process");
 				return false;
 			}
 			addresses.push_back(a);

--- a/fdbcli/KillCommand.actor.cpp
+++ b/fdbcli/KillCommand.actor.cpp
@@ -75,9 +75,10 @@ ACTOR Future<bool> killCommandActor(Reference<IDatabase> db,
 			int64_t killRequestsSent = wait(safeThreadFutureToFuture(db->rebootWorker(addressesStr, false, 0)));
 			if (!killRequestsSent) {
 				result = false;
-				fmt::println(stderr,
-				             "ERROR: failed to send requests to all processes, please run the `killâ command again "
-				             "to fetch latest addresses.");
+				fmt::println(
+				    stderr,
+				    "ERROR: failed to send requests to all processes, please run the `killâ command again "
+				    "to fetch latest addresses.");
 			} else {
 				fmt::println("Attempted to kill {} processes", address_interface->size());
 			}
@@ -101,10 +102,11 @@ ACTOR Future<bool> killCommandActor(Reference<IDatabase> db,
 			int64_t killRequestsSent = wait(safeThreadFutureToFuture(db->rebootWorker(addressesStr, false, 0)));
 			if (!killRequestsSent) {
 				result = false;
-				fmt::println(stderr,
-				             "ERROR: failed to send requests to kill processes `{}', please run the `killâ command "
-				             "again to fetch latest addresses.",
-				             addressesStr);
+				fmt::println(
+				    stderr,
+				    "ERROR: failed to send requests to kill processes `{}', please run the `killâ command "
+				    "again to fetch latest addresses.",
+				    addressesStr);
 			} else {
 				// delay in case the network queue is not flush before the client exits
 				wait(delay(3.0));

--- a/fdbcli/KillCommand.actor.cpp
+++ b/fdbcli/KillCommand.actor.cpp
@@ -30,6 +30,7 @@
 #include "flow/FastRef.h"
 #include "flow/ThreadHelper.actor.h"
 #include "flow/CodeProbe.h"
+#include "fmt/format.h"
 #include "flow/actorcompiler.h" // This must be the last #include.
 
 namespace fdb_cli {
@@ -48,22 +49,22 @@ ACTOR Future<bool> killCommandActor(Reference<IDatabase> db,
 	}
 	if (tokens.size() == 1 || tokencmp(tokens[1], "list")) {
 		if (address_interface->size() == 0) {
-			printf("\nNo addresses can be killed.\n");
+			fmt::print("\nNo addresses can be killed.\n");
 		} else if (address_interface->size() == 1) {
-			printf("\nThe following address can be killed:\n");
+			fmt::print("\nThe following address can be killed:\n");
 		} else {
-			printf("\nThe following %zu addresses can be killed:\n", address_interface->size());
+			fmt::print("\nThe following {} addresses can be killed:\n", address_interface->size());
 		}
 		for (auto it : *address_interface) {
-			printf("%s\n", printable(it.first).c_str());
+			fmt::println("{}", printable(it.first));
 		}
-		printf("\n");
+		fmt::println("");
 	} else if (tokencmp(tokens[1], "all")) {
 		if (address_interface->size() == 0) {
 			result = false;
-			fprintf(stderr,
-			        "ERROR: no processes to kill. You must run the `kill’ command before "
-			        "running `kill all’.\n");
+			fmt::println(
+			    stderr,
+			    "ERROR: no processes to kill. You must run the `killâ command before running `kill allâ.");
 		} else {
 			std::vector<std::string> addressesVec;
 			for (const auto& [address, _] : *address_interface) {
@@ -74,18 +75,18 @@ ACTOR Future<bool> killCommandActor(Reference<IDatabase> db,
 			int64_t killRequestsSent = wait(safeThreadFutureToFuture(db->rebootWorker(addressesStr, false, 0)));
 			if (!killRequestsSent) {
 				result = false;
-				fprintf(stderr,
-				        "ERROR: failed to send requests to all processes, please run the `kill’ command again to fetch "
-				        "latest addresses.\n");
+				fmt::println(stderr,
+				             "ERROR: failed to send requests to all processes, please run the `killâ command again "
+				             "to fetch latest addresses.");
 			} else {
-				printf("Attempted to kill %zu processes\n", address_interface->size());
+				fmt::println("Attempted to kill {} processes", address_interface->size());
 			}
 		}
 	} else {
 		state int i;
 		for (i = 1; i < tokens.size(); i++) {
 			if (!address_interface->count(tokens[i])) {
-				fprintf(stderr, "ERROR: process `%s' not recognized.\n", printable(tokens[i]).c_str());
+				fmt::println(stderr, "ERROR: process `{}' not recognized.", printable(tokens[i]));
 				result = false;
 				break;
 			}
@@ -100,14 +101,14 @@ ACTOR Future<bool> killCommandActor(Reference<IDatabase> db,
 			int64_t killRequestsSent = wait(safeThreadFutureToFuture(db->rebootWorker(addressesStr, false, 0)));
 			if (!killRequestsSent) {
 				result = false;
-				fprintf(stderr,
-				        "ERROR: failed to send requests to kill processes `%s', please run the `kill’ command again to "
-				        "fetch latest addresses.\n",
-				        addressesStr.c_str());
+				fmt::println(stderr,
+				             "ERROR: failed to send requests to kill processes `{}', please run the `killâ command "
+				             "again to fetch latest addresses.",
+				             addressesStr);
 			} else {
 				// delay in case the network queue is not flush before the client exits
 				wait(delay(3.0));
-				printf("Attempted to kill %zu processes\n", tokens.size() - 1);
+				fmt::println("Attempted to kill {} processes", tokens.size() - 1);
 			}
 		}
 	}

--- a/fdbcli/LocationMetadataCommand.actor.cpp
+++ b/fdbcli/LocationMetadataCommand.actor.cpp
@@ -26,6 +26,7 @@
 #include "flow/FastRef.h"
 #include "flow/ThreadHelper.actor.h"
 
+#include "fmt/format.h"
 #include "flow/actorcompiler.h" // This must be the last #include.
 
 namespace {
@@ -58,11 +59,11 @@ ACTOR Future<Void> printKeyServersEntry(Reference<ReadYourWritesTransaction> tr,
 	decodeKeyServersValue(UIDtoTagMap, entry, src, dest, srcId, destId);
 	state std::string srcDesc = wait(describeServers(tr, src));
 	std::string destDesc = wait(describeServers(tr, dest));
-	printf("Range: %s, ShardID: %s, Src Servers: %s, Dest Servers: %s\n",
-	       Traceable<KeyRangeRef>::toString(range).c_str(),
-	       srcId.toString().c_str(),
-	       srcDesc.c_str(),
-	       destDesc.c_str());
+	fmt::println("Range: {}, ShardID: {}, Src Servers: {}, Dest Servers: {}",
+	             Traceable<KeyRangeRef>::toString(range),
+	             srcId.toString(),
+	             srcDesc,
+	             destDesc);
 	return Void();
 }
 
@@ -109,7 +110,7 @@ ACTOR Future<Void> printRandomShards(Database cx, int n, bool physicalShard) {
 		}
 	}
 
-	printf("Found %d %s shards\n", numShards, physicalShard ? "Physical" : "Non-physical");
+	fmt::println("Found {} {} shards", numShards, physicalShard ? "Physical" : "Non-physical");
 
 	return Void();
 }
@@ -156,7 +157,7 @@ ACTOR Future<Void> printPhysicalShardCount(Database cx) {
 		}
 	}
 
-	printf("Total number of shards: %d, number of physical shards: %d\n", numShards, numPhysicalShards);
+	fmt::println("Total number of shards: {}, number of physical shards: {}", numShards, numPhysicalShards);
 
 	return Void();
 }
@@ -185,10 +186,10 @@ ACTOR Future<Void> printServerShards(Database cx, UID serverId) {
 					DataMovementReason dataMoveReason = DataMovementReason::INVALID;
 					decodeServerKeysValue(
 					    serverShards[i].value, assigned, emptyRange, dataMoveType, shardId, dataMoveReason);
-					printf("Range: %s, ShardID: %s, Assigned: %s\n",
-					       Traceable<KeyRangeRef>::toString(currentRange).c_str(),
-					       shardId.toString().c_str(),
-					       assigned ? "true" : "false");
+					fmt::println("Range: {}, ShardID: {}, Assigned: {}",
+					             Traceable<KeyRangeRef>::toString(currentRange),
+					             shardId.toString(),
+					             assigned ? "true" : "false");
 				}
 
 				begin = serverShards.back().key;

--- a/fdbcli/LockCommand.cpp
+++ b/fdbcli/LockCommand.cpp
@@ -28,6 +28,7 @@
 #include "flow/Arena.h"
 #include "flow/FastRef.h"
 #include "flow/ThreadHelper.actor.h"
+#include "fmt/format.h"
 namespace {
 
 Future<bool> lockDatabase(Reference<IDatabase> db, UID id) {
@@ -38,7 +39,7 @@ Future<bool> lockDatabase(Reference<IDatabase> db, UID id) {
 		try {
 			tr->set(fdb_cli::lockSpecialKey, id.toString());
 			co_await safeThreadFutureToFuture(tr->commit());
-			printf("Database locked.\n");
+			fmt::println("Database locked.");
 			co_return true;
 		} catch (Error& e) {
 			err = e;
@@ -47,7 +48,7 @@ Future<bool> lockDatabase(Reference<IDatabase> db, UID id) {
 			throw err;
 		if (err.code() == error_code_special_keys_api_failure) {
 			std::string errorMsgStr = co_await fdb_cli::getSpecialKeysFailureErrorMessage(tr);
-			fprintf(stderr, "%s\n", errorMsgStr.c_str());
+			fmt::println(stderr, "{}", errorMsgStr);
 			co_return false;
 		}
 		co_await safeThreadFutureToFuture(tr->onError(err));
@@ -66,7 +67,7 @@ Future<bool> lockCommandActor(Reference<IDatabase> db, std::vector<StringRef> co
 		co_return false;
 	} else {
 		UID lockUID = deterministicRandom()->randomUniqueID();
-		printf("Locking database with lockUID: %s\n", lockUID.toString().c_str());
+		fmt::println("Locking database with lockUID: {}", lockUID.toString());
 		bool result = co_await lockDatabase(db, lockUID);
 		co_return result;
 	}
@@ -85,20 +86,20 @@ Future<bool> unlockDatabaseActor(Reference<IDatabase> db, UID uid) {
 				co_return true;
 
 			if (val.present() && UID::fromString(val.get().toString()) != uid) {
-				printf("Unable to unlock database. Make sure to unlock with the correct lock UID.\n");
+				fmt::println("Unable to unlock database. Make sure to unlock with the correct lock UID.");
 				co_return false;
 			}
 
 			tr->clear(fdb_cli::lockSpecialKey);
 			co_await safeThreadFutureToFuture(tr->commit());
-			printf("Database unlocked.\n");
+			fmt::println("Database unlocked.");
 			co_return true;
 		} catch (Error& e) {
 			err = e;
 		}
 		if (err.code() == error_code_special_keys_api_failure) {
 			std::string errorMsgStr = co_await fdb_cli::getSpecialKeysFailureErrorMessage(tr);
-			fprintf(stderr, "%s\n", errorMsgStr.c_str());
+			fmt::println(stderr, "{}", errorMsgStr);
 			co_return false;
 		}
 		co_await safeThreadFutureToFuture(tr->onError(err));

--- a/fdbcli/MaintenanceCommand.actor.cpp
+++ b/fdbcli/MaintenanceCommand.actor.cpp
@@ -49,14 +49,14 @@ ACTOR Future<Void> printHealthyZone(Reference<IDatabase> db) {
 			RangeResult res = wait(safeThreadFutureToFuture(resultFuture));
 			ASSERT(res.size() <= 1);
 			if (res.size() == 1 && res[0].key == fdb_cli::ignoreSSFailureSpecialKey) {
-				printf("Data distribution has been disabled for all storage server failures in this cluster and thus "
-				       "maintenance mode is not active.\n");
+				fmt::println("Data distribution has been disabled for all storage server failures in this cluster and "
+				             "thus maintenance mode is not active.");
 			} else if (!res.size() || boost::lexical_cast<double>(res[0].value.toString()) <= 0) {
-				printf("No ongoing maintenance.\n");
+				fmt::println("No ongoing maintenance.");
 			} else {
 				std::string zoneId = res[0].key.removePrefix(fdb_cli::maintenanceSpecialKeyRange.begin).toString();
 				int64_t seconds = static_cast<int64_t>(boost::lexical_cast<double>(res[0].value.toString()));
-				fmt::print("Maintenance for zone {0} will continue for {1} seconds.\n", zoneId, seconds);
+				fmt::println("Maintenance for zone {0} will continue for {1} seconds.", zoneId, seconds);
 			}
 			return Void();
 		} catch (Error& e) {
@@ -88,9 +88,9 @@ ACTOR Future<bool> setHealthyZone(Reference<IDatabase> db, StringRef zoneId, dou
 			ASSERT(res.size() <= 1);
 			if (res.size() == 1 && res[0].key == fdb_cli::ignoreSSFailureSpecialKey) {
 				if (printWarning) {
-					fprintf(stderr,
-					        "ERROR: Maintenance mode cannot be used while data distribution is disabled for storage "
-					        "server failures. Use 'datadistribution on' to reenable data distribution.\n");
+					fmt::println(stderr,
+					             "ERROR: Maintenance mode cannot be used while data distribution is disabled for "
+					             "storage server failures. Use 'datadistribution on' to reenable data distribution.");
 				}
 				return false;
 			}
@@ -118,9 +118,9 @@ ACTOR Future<bool> clearHealthyZone(Reference<IDatabase> db, bool printWarning, 
 			ASSERT(res.size() <= 1);
 			if (!clearSSFailureZoneString && res.size() == 1 && res[0].key == fdb_cli::ignoreSSFailureSpecialKey) {
 				if (printWarning) {
-					fprintf(stderr,
-					        "ERROR: Maintenance mode cannot be used while data distribution is disabled for storage "
-					        "server failures. Use 'datadistribution on' to reenable data distribution.\n");
+					fmt::println(stderr,
+					             "ERROR: Maintenance mode cannot be used while data distribution is disabled for "
+					             "storage server failures. Use 'datadistribution on' to reenable data distribution.");
 				}
 				return false;
 			}

--- a/fdbcli/ProfileCommand.actor.cpp
+++ b/fdbcli/ProfileCommand.actor.cpp
@@ -31,6 +31,7 @@
 #include "flow/Arena.h"
 #include "flow/FastRef.h"
 #include "flow/ThreadHelper.actor.h"
+#include "fmt/format.h"
 #include "flow/actorcompiler.h" // This must be the last #include.
 
 namespace fdb_cli {
@@ -45,13 +46,13 @@ ACTOR Future<bool> profileCommandActor(Database db,
 		result = false;
 	} else if (tokencmp(tokens[1], "client")) {
 		if (tokens.size() == 2) {
-			fprintf(stderr, "ERROR: Usage: profile client <get|set>\n");
+			fmt::println(stderr, "ERROR: Usage: profile client <get|set>");
 			return false;
 		}
 		wait(db->globalConfig->onInitialized());
 		if (tokencmp(tokens[2], "get")) {
 			if (tokens.size() != 3) {
-				fprintf(stderr, "ERROR: Additional arguments to `get` are not supported.\n");
+				fmt::println(stderr, "ERROR: Additional arguments to `get` are not supported.");
 				return false;
 			}
 			std::string sampleRateStr = "default";
@@ -65,12 +66,11 @@ ACTOR Future<bool> profileCommandActor(Database db,
 			if (sizeLimit != -1) {
 				sizeLimitStr = boost::lexical_cast<std::string>(sizeLimit);
 			}
-			printf("Client profiling rate is set to %s and size limit is set to %s.\n",
-			       sampleRateStr.c_str(),
-			       sizeLimitStr.c_str());
+			fmt::println(
+			    "Client profiling rate is set to {} and size limit is set to {}.", sampleRateStr, sizeLimitStr);
 		} else if (tokencmp(tokens[2], "set")) {
 			if (tokens.size() != 5) {
-				fprintf(stderr, "ERROR: Usage: profile client set <RATE|default> <SIZE|default>\n");
+				fmt::println(stderr, "ERROR: Usage: profile client set <RATE|default> <SIZE|default>");
 				return false;
 			}
 			double sampleRate;
@@ -80,7 +80,7 @@ ACTOR Future<bool> profileCommandActor(Database db,
 				char* end;
 				sampleRate = std::strtod((const char*)tokens[3].begin(), &end);
 				if (!std::isspace(*end)) {
-					fprintf(stderr, "ERROR: %s failed to parse.\n", printable(tokens[3]).c_str());
+					fmt::println(stderr, "ERROR: {} failed to parse.", printable(tokens[3]));
 					return false;
 				}
 			}
@@ -92,7 +92,7 @@ ACTOR Future<bool> profileCommandActor(Database db,
 				if (parsed.present()) {
 					sizeLimit = parsed.get();
 				} else {
-					fprintf(stderr, "ERROR: `%s` failed to parse.\n", printable(tokens[4]).c_str());
+					fmt::println(stderr, "ERROR: `{}` failed to parse.", printable(tokens[4]));
 					return false;
 				}
 			}
@@ -106,12 +106,12 @@ ACTOR Future<bool> profileCommandActor(Database db,
 				wait(safeThreadFutureToFuture(tr->commit()));
 			}
 		} else {
-			fprintf(stderr, "ERROR: Unknown action: %s\n", printable(tokens[2]).c_str());
+			fmt::println(stderr, "ERROR: Unknown action: {}", printable(tokens[2]));
 			result = false;
 		}
 	} else if (tokencmp(tokens[1], "list")) {
 		if (tokens.size() != 2) {
-			fprintf(stderr, "ERROR: Usage: profile list\n");
+			fmt::println(stderr, "ERROR: Usage: profile list");
 			return false;
 		}
 		// Hold the reference to the standalone's memory
@@ -122,10 +122,10 @@ ACTOR Future<bool> profileCommandActor(Database db,
 		for (const auto& pair : kvs) {
 			auto ip_port = (pair.key.endsWith(":tls"_sr) ? pair.key.removeSuffix(":tls"_sr) : pair.key)
 			                   .removePrefix("\xff\xff/worker_interfaces/"_sr);
-			printf("%s\n", printable(ip_port).c_str());
+			fmt::println("{}", printable(ip_port));
 		}
 	} else {
-		fprintf(stderr, "ERROR: Unknown type: %s\n", printable(tokens[1]).c_str());
+		fmt::println(stderr, "ERROR: Unknown type: {}", printable(tokens[1]));
 		result = false;
 	}
 	return result;

--- a/fdbcli/RangeConfigCommand.actor.cpp
+++ b/fdbcli/RangeConfigCommand.actor.cpp
@@ -27,6 +27,7 @@
 #include "fdbclient/NativeAPI.actor.h"
 #include "fdbclient/DataDistributionConfig.actor.h"
 
+#include "fmt/format.h"
 #include "flow/actorcompiler.h" // This must be the last #include.
 
 namespace fdb_cli {
@@ -34,7 +35,7 @@ namespace fdb_cli {
 ACTOR Future<bool> rangeConfigCommandActor(Database cx, std::vector<StringRef> tokens) {
 	state std::function<bool(std::string)> fail = [&](std::string msg) {
 		if (!msg.empty()) {
-			fmt::print(stderr, "ERROR: {}\n", msg);
+			fmt::println(stderr, "ERROR: {}", msg);
 		}
 		printUsage(tokens[0]);
 		return false;
@@ -75,8 +76,8 @@ ACTOR Future<bool> rangeConfigCommandActor(Database cx, std::vector<StringRef> t
 		Reference<DDConfiguration::RangeConfigMapSnapshot> config =
 		    wait(DDConfiguration().userRangeConfig().getSnapshot(
 		        SystemDBWriteLockedNow(cx.getReference()), allKeys.begin, allKeys.end));
-		fmt::print(
-		    "{}\n",
+		fmt::println(
+		    "{}",
 		    json_spirit::write_string(DDConfiguration::toJSON(*config, includeDefault), json_spirit::pretty_print));
 
 	} else if (cmd == "update"_sr || cmd == "set"_sr) {

--- a/fdbcli/SetClassCommand.actor.cpp
+++ b/fdbcli/SetClassCommand.actor.cpp
@@ -49,8 +49,8 @@ ACTOR Future<Void> printProcessClass(Reference<IDatabase> db) {
 			RangeResult processSourceList = classSourceFuture.get();
 			ASSERT(processSourceList.size() == processTypeList.size());
 			if (!processTypeList.size())
-				printf("No processes are registered in the database.\n");
-			fmt::print("There are currently {} processes in the database:\n", processTypeList.size());
+				fmt::println("No processes are registered in the database.");
+			fmt::println("There are currently {} processes in the database:", processTypeList.size());
 			for (int index = 0; index < processTypeList.size(); index++) {
 				std::string address =
 				    processTypeList[index].key.removePrefix(fdb_cli::processClassTypeSpecialKeyRange.begin).toString();
@@ -60,10 +60,10 @@ ACTOR Future<Void> printProcessClass(Reference<IDatabase> db) {
 				        .key.removePrefix(fdb_cli::processClassSourceSpecialKeyRange.begin)
 				        .toString();
 				ASSERT(address == addressFromSourceList);
-				printf("  %s: %s (%s)\n",
-				       address.c_str(),
-				       processTypeList[index].value.toString().c_str(),
-				       processSourceList[index].value.toString().c_str());
+				fmt::println("  {}: {} ({})",
+				             address,
+				             processTypeList[index].value.toString(),
+				             processSourceList[index].value.toString());
 			}
 			return Void();
 		} catch (Error& e) {
@@ -81,7 +81,7 @@ ACTOR Future<bool> setProcessClass(Reference<IDatabase> db, KeyRef network_addre
 			    tr->get(network_address.withPrefix(fdb_cli::processClassTypeSpecialKeyRange.begin));
 			Optional<Value> val = wait(safeThreadFutureToFuture(result));
 			if (!val.present()) {
-				printf("No matching addresses found\n");
+				fmt::println("No matching addresses found");
 				return false;
 			}
 			tr->set(network_address.withPrefix(fdb_cli::processClassTypeSpecialKeyRange.begin), class_type);
@@ -92,7 +92,7 @@ ACTOR Future<bool> setProcessClass(Reference<IDatabase> db, KeyRef network_addre
 			if (e.code() == error_code_special_keys_api_failure) {
 				std::string errorMsgStr = wait(fdb_cli::getSpecialKeysFailureErrorMessage(tr));
 				// error message already has \n at the end
-				fprintf(stderr, "%s", errorMsgStr.c_str());
+				fmt::print(stderr, "{}", errorMsgStr);
 				return false;
 			}
 			wait(safeThreadFutureToFuture(tr->onError(err)));

--- a/fdbcli/SnapshotCommand.cpp
+++ b/fdbcli/SnapshotCommand.cpp
@@ -25,6 +25,7 @@
 #include "flow/Arena.h"
 #include "flow/FastRef.h"
 #include "flow/ThreadHelper.actor.h"
+#include "fmt/format.h"
 namespace fdb_cli {
 
 Future<bool> snapshotCommandActor(Reference<IDatabase> db, std::vector<StringRef> const& tokens) {
@@ -43,14 +44,14 @@ Future<bool> snapshotCommandActor(Reference<IDatabase> db, std::vector<StringRef
 		}
 		try {
 			co_await safeThreadFutureToFuture(db->createSnapshot(uid, snap_cmd));
-			printf("Snapshot command succeeded with UID %s\n", uid.toString().c_str());
+			fmt::println("Snapshot command succeeded with UID {}", uid.toString());
 		} catch (Error& e) {
-			fprintf(stderr,
-			        "Snapshot command failed %d (%s)."
-			        " Please cleanup any instance level snapshots created with UID %s.\n",
-			        e.code(),
-			        e.what(),
-			        uid.toString().c_str());
+			fmt::println(
+			    stderr,
+			    "Snapshot command failed {} ({}). Please cleanup any instance level snapshots created with UID {}.",
+			    e.code(),
+			    e.what(),
+			    uid.toString());
 			result = false;
 		}
 	}

--- a/fdbcli/StatusCommand.actor.cpp
+++ b/fdbcli/StatusCommand.actor.cpp
@@ -39,9 +39,8 @@ std::string getCoordinatorsInfoString(StatusObjectReader statusObj) {
 	try {
 		StatusArray coordinatorsArr = statusObj["client.coordinators.coordinators"].get_array();
 		for (StatusObjectReader coor : coordinatorsArr)
-			outputString += format("\n  %s  (%s)",
-			                       coor["address"].get_str().c_str(),
-			                       coor["reachable"].get_bool() ? "reachable" : "unreachable");
+			outputString += fmt::format(
+			    "\n  {}  ({})", coor["address"].get_str(), coor["reachable"].get_bool() ? "reachable" : "unreachable");
 	} catch (std::runtime_error&) {
 		outputString = "\n  Unable to retrieve list of coordination servers";
 	}
@@ -61,7 +60,7 @@ std::string lineWrap(const char* text, int col) {
 		if (*iter == '\n' || *iter == '\0' || (iter - start == col)) {
 			if (!space)
 				space = iter;
-			out += format("%.*s\n", (int)(space - start), start);
+			out += fmt::format("{:.{}}\n", start, (int)(space - start));
 			start = space;
 			if (*start == ' ' /* || *start == '\n'*/)
 				start++;
@@ -156,7 +155,7 @@ std::string getWorkloadRates(StatusObjectReader statusObj,
 	std::string path = first + "." + second;
 	double value;
 	if (!unknown && statusObj.get(path, value)) {
-		return format("%d Hz", (int)round(value));
+		return fmt::format("{} Hz", (int)round(value));
 	}
 	return "unknown";
 }
@@ -164,7 +163,7 @@ std::string getWorkloadRates(StatusObjectReader statusObj,
 void getBackupDRTags(StatusObjectReader& statusObjCluster,
                      const char* context,
                      std::map<std::string, std::string>& tagMap) {
-	std::string path = format("layers.%s.tags", context);
+	std::string path = fmt::format("layers.{}.tags", context);
 	StatusObjectReader tags;
 	if (statusObjCluster.tryGet(path, tags)) {
 		for (auto itr : tags.obj()) {
@@ -186,11 +185,11 @@ void getBackupDRTags(StatusObjectReader& statusObjCluster,
 std::string logBackupDR(const char* context, std::map<std::string, std::string> const& tagMap) {
 	std::string outputString = "";
 	if (tagMap.size() > 0) {
-		outputString += format("\n\n%s:", context);
+		outputString += fmt::format("\n\n{}:", context);
 		for (auto itr : tagMap) {
-			outputString += format("\n  %-22s", itr.first.c_str());
+			outputString += fmt::format("\n  {:<22}", itr.first);
 			if (itr.second.size() > 0) {
-				outputString += format(" - %s", itr.second.c_str());
+				outputString += fmt::format(" - {}", itr.second);
 			}
 		}
 	}
@@ -204,12 +203,12 @@ namespace fdb_cli {
 
 std::string toBytesString(double bytes) {
 	if (bytes >= 1e12) {
-		return format("%.3f TB", (bytes / 1e12));
+		return fmt::format("{:.3f} TB", (bytes / 1e12));
 	} else if (bytes >= 1e9) {
-		return format("%.3f GB", (bytes / 1e9));
+		return fmt::format("{:.3f} GB", (bytes / 1e9));
 	} else {
 		// no decimal points for MB
-		return format("%d MB", (int)round(bytes / 1e6));
+		return fmt::format("{} MB", (int)round(bytes / 1e6));
 	}
 }
 
@@ -218,7 +217,7 @@ void printStatus(StatusObjectReader statusObj,
                  bool displayDatabaseAvailable,
                  bool hideErrorMessages) {
 	if (FlowTransport::transport().incompatibleOutgoingConnectionsPresent()) {
-		fprintf(
+		fmt::print(
 		    stderr,
 		    "WARNING: One or more of the processes in the cluster is incompatible with this version of fdbcli.\n\n");
 	}
@@ -237,7 +236,7 @@ void printStatus(StatusObjectReader statusObj,
 			std::string outputString = "";
 			std::string clusterFilePath;
 			if (statusObjClient.get("cluster_file.path", clusterFilePath))
-				outputString = format("Using cluster file `%s'.\n", clusterFilePath.c_str());
+				outputString = fmt::format("Using cluster file `{}'.\n", clusterFilePath);
 			else
 				outputString = "Using unknown cluster file.\n";
 
@@ -256,7 +255,7 @@ void printStatus(StatusObjectReader statusObj,
 				outputString += "\nCould not communicate with a quorum of coordination servers:";
 				outputString += getCoordinatorsInfoString(statusObj);
 
-				printf("%s\n", outputString.c_str());
+				fmt::println("{}", outputString);
 				return;
 			} else {
 				for (StatusObjectReader coor : coordinatorsArr) {
@@ -299,26 +298,25 @@ void printStatus(StatusObjectReader statusObj,
 							fatalRecoveryState = true;
 
 							if (name == "recruiting_transaction_servers") {
-								description +=
-								    format("\nNeed at least %d log servers across unique zones, %d commit proxies, "
-								           "%d GRV proxies and %d resolvers.",
-								           recoveryState["required_logs"].get_int(),
-								           recoveryState["required_commit_proxies"].get_int(),
-								           recoveryState["required_grv_proxies"].get_int(),
-								           recoveryState["required_resolvers"].get_int());
+								description += fmt::format("\nNeed at least {} log servers across unique zones, {} "
+								                           "commit proxies, {} GRV proxies and {} resolvers.",
+								                           recoveryState["required_logs"].get_int(),
+								                           recoveryState["required_commit_proxies"].get_int(),
+								                           recoveryState["required_grv_proxies"].get_int(),
+								                           recoveryState["required_resolvers"].get_int());
 								if (statusObjCluster.has("machines") && statusObjCluster.has("processes")) {
 									auto numOfNonExcludedProcessesAndZones =
 									    getNumOfNonExcludedProcessAndZones(statusObjCluster);
 									description +=
-									    format("\nHave %d non-excluded processes on %d machines across %d zones.",
-									           numOfNonExcludedProcessesAndZones.first,
-									           getNumofNonExcludedMachines(statusObjCluster),
-									           numOfNonExcludedProcessesAndZones.second);
+									    fmt::format("\nHave {} non-excluded processes on {} machines across {} zones.",
+									                numOfNonExcludedProcessesAndZones.first,
+									                getNumofNonExcludedMachines(statusObjCluster),
+									                numOfNonExcludedProcessesAndZones.second);
 								}
 							} else if (name == "locking_old_transaction_servers" &&
 							           recoveryState["missing_logs"].get_str().size()) {
-								description += format("\nNeed one or more of the following log servers: %s",
-								                      recoveryState["missing_logs"].get_str().c_str());
+								description += fmt::format("\nNeed one or more of the following log servers: {}",
+								                           recoveryState["missing_logs"].get_str());
 							}
 							description = lineWrap(description.c_str(), 80);
 							if (!printedCoordinators &&
@@ -379,14 +377,13 @@ void printStatus(StatusObjectReader statusObj,
 										countStr = "Some client(s)";
 									} else {
 										addresses = issue["addresses"].get_array();
-										countStr = format("%d client(s)", addresses.size());
+										countStr = fmt::format("{} client(s)", addresses.size());
 									}
-									outputString +=
-									    format("\n%s reported: %s\n", countStr.c_str(), description.c_str());
+									outputString += fmt::format("\n{} reported: {}\n", countStr, description);
 
 									if (level == StatusClient::StatusLevel::DETAILED) {
 										for (int i = 0; i < addresses.size() && i < 4; ++i) {
-											outputString += format("  %s\n", addresses[i].get_str().c_str());
+											outputString += fmt::format("  {}\n", addresses[i].get_str());
 										}
 										if (addresses.size() > 4) {
 											outputString += "  ...\n";
@@ -404,7 +401,7 @@ void printStatus(StatusObjectReader statusObj,
 			}
 
 			if (fatalRecoveryState) {
-				printf("%s", outputString.c_str());
+				fmt::print("{}", outputString);
 				return;
 			}
 
@@ -458,37 +455,37 @@ void printStatus(StatusObjectReader statusObj,
 					outputString += "unknown";
 
 				if (excludedServersArr.size()) {
-					outputString += format("\n  Exclusions             - %d (type `exclude' for details)",
-					                       excludedServersArr.size());
+					outputString += fmt::format("\n  Exclusions             - {} (type `exclude' for details)",
+					                            excludedServersArr.size());
 				}
 
 				if (statusObjConfig.get("commit_proxies", intVal))
-					outputString += format("\n  Desired Commit Proxies - %d", intVal);
+					outputString += fmt::format("\n  Desired Commit Proxies - {}", intVal);
 
 				if (statusObjConfig.get("grv_proxies", intVal))
-					outputString += format("\n  Desired GRV Proxies    - %d", intVal);
+					outputString += fmt::format("\n  Desired GRV Proxies    - {}", intVal);
 
 				if (statusObjConfig.get("resolvers", intVal))
-					outputString += format("\n  Desired Resolvers      - %d", intVal);
+					outputString += fmt::format("\n  Desired Resolvers      - {}", intVal);
 
 				if (statusObjConfig.get("logs", intVal))
-					outputString += format("\n  Desired Logs           - %d", intVal);
+					outputString += fmt::format("\n  Desired Logs           - {}", intVal);
 
 				if (statusObjConfig.get("remote_logs", intVal))
-					outputString += format("\n  Desired Remote Logs    - %d", intVal);
+					outputString += fmt::format("\n  Desired Remote Logs    - {}", intVal);
 
 				if (statusObjConfig.get("log_routers", intVal))
-					outputString += format("\n  Desired Log Routers    - %d", intVal);
+					outputString += fmt::format("\n  Desired Log Routers    - {}", intVal);
 
 				if (statusObjConfig.get("tss_count", intVal) && intVal > 0) {
 					int activeTss = 0;
 					if (statusObjCluster.has("active_tss_count")) {
 						statusObjCluster.get("active_tss_count", activeTss);
 					}
-					outputString += format("\n  TSS                    - %d/%d", activeTss, intVal);
+					outputString += fmt::format("\n  TSS                    - {}/{}", activeTss, intVal);
 
 					if (statusObjConfig.get("tss_storage_engine", strVal))
-						outputString += format("\n  TSS Storage Engine     - %s", strVal.c_str());
+						outputString += fmt::format("\n  TSS Storage Engine     - {}", strVal);
 				}
 
 				outputString += "\n  Usable Regions         - ";
@@ -525,35 +522,35 @@ void printStatus(StatusObjectReader statusObj,
 						} else {
 							outputString += "\n    Region -";
 						}
-						outputString += format("\n        Datacenter                    - %s", regionDC.c_str());
+						outputString += fmt::format("\n        Datacenter                    - {}", regionDC);
 						if (regionSatelliteDCs.size() > 0) {
 							outputString += "\n        Satellite datacenters         - ";
 							for (int i = 0; i < regionSatelliteDCs.size(); i++) {
 								if (i != regionSatelliteDCs.size() - 1) {
-									outputString += format("%s, ", regionSatelliteDCs[i].c_str());
+									outputString += fmt::format("{}, ", regionSatelliteDCs[i]);
 								} else {
-									outputString += format("%s", regionSatelliteDCs[i].c_str());
+									outputString += fmt::format("{}", regionSatelliteDCs[i]);
 								}
 							}
 						}
 						isPrimary = false;
 						if (region.get("satellite_redundancy_mode", strVal)) {
-							outputString += format("\n        Satellite Redundancy Mode     - %s", strVal.c_str());
+							outputString += fmt::format("\n        Satellite Redundancy Mode     - {}", strVal);
 						}
 						if (region.get("satellite_anti_quorum", intVal)) {
-							outputString += format("\n        Satellite Anti Quorum         - %d", intVal);
+							outputString += fmt::format("\n        Satellite Anti Quorum         - {}", intVal);
 						}
 						if (region.get("satellite_logs", intVal)) {
-							outputString += format("\n        Satellite Logs                - %d", intVal);
+							outputString += fmt::format("\n        Satellite Logs                - {}", intVal);
 						}
 						if (region.get("satellite_log_policy", strVal)) {
-							outputString += format("\n        Satellite Log Policy          - %s", strVal.c_str());
+							outputString += fmt::format("\n        Satellite Log Policy          - {}", strVal);
 						}
 						if (region.get("satellite_log_replicas", intVal)) {
-							outputString += format("\n        Satellite Log Replicas        - %d", intVal);
+							outputString += fmt::format("\n        Satellite Log Replicas        - {}", intVal);
 						}
 						if (region.get("satellite_usable_dcs", intVal)) {
-							outputString += format("\n        Satellite Usable DCs          - %d", intVal);
+							outputString += fmt::format("\n        Satellite Usable DCs          - {}", intVal);
 						}
 					}
 				}
@@ -575,7 +572,7 @@ void printStatus(StatusObjectReader statusObj,
 				outputString += "\n  FoundationDB processes - ";
 				if (statusObjCluster.get("processes", processesMap)) {
 
-					outputString += format("%d", processesMap.obj().size());
+					outputString += fmt::format("{}", processesMap.obj().size());
 
 					int errors = 0;
 					int processExclusions = 0;
@@ -603,14 +600,14 @@ void printStatus(StatusObjectReader statusObj,
 					}
 
 					if (errors > 0 || processExclusions) {
-						outputString += format(" (less %d excluded; %d with errors)", processExclusions, errors);
+						outputString += fmt::format(" (less {} excluded; {} with errors)", processExclusions, errors);
 					}
 
 				} else
 					outputString += "unknown";
 
 				if (zones.size() > 0) {
-					outputString += format("\n  Zones                  - %d", zones.size());
+					outputString += fmt::format("\n  Zones                  - {}", zones.size());
 					int zoneExclusions = 0;
 					for (auto itr : zones) {
 						if (itr.second == 0) {
@@ -618,7 +615,7 @@ void printStatus(StatusObjectReader statusObj,
 						}
 					}
 					if (zoneExclusions > 0) {
-						outputString += format(" (less %d excluded)", zoneExclusions);
+						outputString += fmt::format(" (less {} excluded)", zoneExclusions);
 					}
 				} else {
 					outputString += "\n  Zones                  - unknown";
@@ -626,7 +623,7 @@ void printStatus(StatusObjectReader statusObj,
 
 				outputString += "\n  Machines               - ";
 				if (statusObjCluster.get("machines", machinesMap)) {
-					outputString += format("%d", machinesMap.obj().size());
+					outputString += fmt::format("{}", machinesMap.obj().size());
 
 					int machineExclusions = 0;
 					for (auto mach : machinesMap.obj()) {
@@ -636,7 +633,7 @@ void printStatus(StatusObjectReader statusObj,
 					}
 
 					if (machineExclusions) {
-						outputString += format(" (less %d excluded)", machineExclusions);
+						outputString += fmt::format(" (less {} excluded)", machineExclusions);
 					}
 
 					int64_t minMemoryAvailable = std::numeric_limits<int64_t>::max();
@@ -651,7 +648,8 @@ void printStatus(StatusObjectReader statusObj,
 					if (minMemoryAvailable < std::numeric_limits<int64_t>::max()) {
 						double worstServerGb = minMemoryAvailable / (1024.0 * 1024 * 1024);
 						outputString += "\n  Memory availability    - ";
-						outputString += format("%.1f GB per process on machine with least available", worstServerGb);
+						outputString +=
+						    fmt::format("{:.1f} GB per process on machine with least available", worstServerGb);
 						outputString += minMemoryAvailable < 4294967296
 						                    ? "\n                           >>>>> (WARNING: 4.0 GB recommended) <<<<<"
 						                    : "";
@@ -666,7 +664,7 @@ void printStatus(StatusObjectReader statusObj,
 					}
 
 					if (retransCount > 0) {
-						outputString += format("\n  Retransmissions rate   - %d Hz", (int)round(retransCount));
+						outputString += fmt::format("\n  Retransmissions rate   - {} Hz", (int)round(retransCount));
 					}
 				} else
 					outputString += "\n  Machines               - unknown";
@@ -682,18 +680,17 @@ void printStatus(StatusObjectReader statusObj,
 
 						int minLoss = std::min(availLoss, dataLoss);
 						const char* faultDomain = machinesAreZones ? "machine" : "zone";
-						outputString += format("%d %ss", minLoss, faultDomain);
+						outputString += fmt::format("{} {}s", minLoss, faultDomain);
 
 						if (dataLoss > availLoss) {
-							outputString += format(" (%d without data loss)", dataLoss);
+							outputString += fmt::format(" ({} without data loss)", dataLoss);
 						}
 
 						if (dataLoss == -1) {
 							ASSERT_WE_THINK(availLoss == -1);
-							outputString += format(
-							    "\n\n  Warning: the database may have data loss and availability loss. Please restart "
-							    "following tlog interfaces, otherwise storage servers may never be able to catch "
-							    "up.\n");
+							outputString += fmt::format("\n\n  Warning: the database may have data loss and "
+							                            "availability loss. Please restart following tlog interfaces, "
+							                            "otherwise storage servers may never be able to catch up.\n");
 							StatusObjectReader logs;
 							if (statusObjCluster.has("logs")) {
 								for (StatusObjectReader logEpoch : statusObjCluster.last().get_array()) {
@@ -717,18 +714,18 @@ void printStatus(StatusObjectReader statusObj,
 											if (logInterface.get("healthy", healthy) && !healthy) {
 												logInterface.get("id", id);
 												logInterface.get("address", address);
-												missing_log_interfaces += format("%s,%s ", id.c_str(), address.c_str());
+												missing_log_interfaces += fmt::format("{},{} ", id, address);
 											}
 										}
 									}
-									outputString += format(
-									    "  %s log epoch: %lld begin: %lld end: %s, missing "
-									    "log interfaces(id,address): %s\n",
+									outputString += fmt::format(
+									    "  {} log epoch: {} begin: {} end: {}, missing log interfaces(id,address): "
+									    "{}\n",
 									    current ? "Current" : "Old",
 									    epoch,
 									    beginVersion,
-									    endVersion == invalidVersion ? "(unknown)" : format("%lld", endVersion).c_str(),
-									    missing_log_interfaces.c_str());
+									    endVersion == invalidVersion ? "(unknown)" : format("%lld", endVersion),
+									    missing_log_interfaces);
 								}
 							}
 						}
@@ -780,8 +777,8 @@ void printStatus(StatusObjectReader statusObj,
 					double dataInQueue, dataInFlight;
 					if (movingData.get("in_queue_bytes", dataInQueue) &&
 					    movingData.get("in_flight_bytes", dataInFlight))
-						outputString += format("\n  Moving data            - %.3f GB",
-						                       ((double)dataInQueue + (double)dataInFlight) / 1e9);
+						outputString += fmt::format("\n  Moving data            - {:.3f} GB",
+						                            ((double)dataInQueue + (double)dataInFlight) / 1e9);
 				} else if (dataState == "initializing") {
 					outputString += "\n  Moving data            - unknown (initializing)";
 				} else {
@@ -847,12 +844,12 @@ void printStatus(StatusObjectReader statusObj,
 			try {
 				int64_t val;
 				if (statusObjData.get("least_operating_space_bytes_storage_server", val))
-					operatingSpaceString += format("\n  Storage server         - %.1f GB free on most full server",
-					                               std::max(val / 1e9, 0.0));
+					operatingSpaceString += fmt::format(
+					    "\n  Storage server         - {:.1f} GB free on most full server", std::max(val / 1e9, 0.0));
 
 				if (statusObjData.get("least_operating_space_bytes_log_server", val))
-					operatingSpaceString += format("\n  Log server             - %.1f GB free on most full server",
-					                               std::max(val / 1e9, 0.0));
+					operatingSpaceString += fmt::format(
+					    "\n  Log server             - {:.1f} GB free on most full server", std::max(val / 1e9, 0.0));
 
 			} catch (std::runtime_error&) {
 				operatingSpaceString = "";
@@ -885,13 +882,13 @@ void printStatus(StatusObjectReader statusObj,
 						std::string serverID;
 						limit.get("reason_server_id", serverID);
 						std::string procAddr = getProcessAddressByServerID(processesMap, serverID);
-						performanceLimited = format("\n  Performance limited by %s: %s",
-						                            (procAddr == "unknown")
-						                                ? ("server" + (serverID == "" ? "" : (" " + serverID))).c_str()
-						                                : "process",
-						                            desc.c_str());
+						performanceLimited = fmt::format(
+						    "\n  Performance limited by {}: {}",
+						    (procAddr == "unknown") ? ("server" + (serverID == "" ? "" : (" " + serverID))).c_str()
+						                            : "process",
+						    desc);
 						if (procAddr != "unknown")
-							performanceLimited += format("\n  Most limiting process: %s", procAddr.c_str());
+							performanceLimited += fmt::format("\n  Most limiting process: {}", procAddr);
 					}
 				} catch (std::exception&) {
 					// If anything here throws (such as for an incompatible type) ignore it.
@@ -952,8 +949,8 @@ void printStatus(StatusObjectReader statusObj,
 					}
 				}
 				if (messagesAddrs.size()) {
-					outputString += format("\n\n%d FoundationDB processes reported unable to update cluster file:",
-					                       messagesAddrs.size());
+					outputString += fmt::format("\n\n{} FoundationDB processes reported unable to update cluster file:",
+					                            messagesAddrs.size());
 					for (auto msg : messagesAddrs) {
 						outputString += "\n  " + msg;
 					}
@@ -975,20 +972,20 @@ void printStatus(StatusObjectReader statusObj,
 			std::map<std::string, std::string> drSecondaryTags;
 			getBackupDRTags(statusObjCluster, "dr_backup_dest", drSecondaryTags);
 
-			outputString += format("\n  Running backups        - %d", backupTags.size());
-			outputString += format("\n  Running DRs            - ");
+			outputString += fmt::format("\n  Running backups        - {}", backupTags.size());
+			outputString += fmt::format("\n  Running DRs            - ");
 
 			if (drPrimaryTags.size() == 0 && drSecondaryTags.size() == 0) {
-				outputString += format("%d", 0);
+				outputString += fmt::format("{}", 0);
 			} else {
 				if (drPrimaryTags.size() > 0) {
-					outputString += format("%d as primary", drPrimaryTags.size());
+					outputString += fmt::format("{} as primary", drPrimaryTags.size());
 					if (drSecondaryTags.size() > 0) {
 						outputString += ", ";
 					}
 				}
 				if (drSecondaryTags.size() > 0) {
-					outputString += format("%d as secondary", drSecondaryTags.size());
+					outputString += fmt::format("{} as secondary", drSecondaryTags.size());
 				}
 			}
 
@@ -1015,7 +1012,7 @@ void printStatus(StatusObjectReader statusObj,
 							parsedAddress = NetworkAddress::parse(address);
 						} catch (Error&) {
 							// Groups all invalid IP address/port pair in the end of this detail group.
-							line = format("  %-22s (invalid IP address or port)", address.c_str());
+							line = fmt::format("  {:<22} (invalid IP address or port)", address);
 							IPAddress::IPAddressStore maxIp;
 							for (int i = 0; i < maxIp.size(); ++i) {
 								maxIp[i] = std::numeric_limits<std::remove_reference<decltype(maxIp[0])>::type>::max();
@@ -1054,24 +1051,26 @@ void printStatus(StatusObjectReader statusObj,
 							StatusObjectReader procCPUObj;
 							procObj.get("cpu", procCPUObj);
 
-							line = format("  %-22s (", address.c_str());
+							line = fmt::format("  {:<22} (", address);
 
 							double usageCores;
 							if (procCPUObj.get("usage_cores", usageCores))
-								line += format("%3.0f%% cpu;", usageCores * 100);
+								line += fmt::format("{:3.0f}% cpu;", usageCores * 100);
 
-							line += mCPUUtil != -1 ? format("%3.0f%% machine;", mCPUUtil * 100) : "";
-							line += std::min(tx, rx) != -1 ? format("%6.3f Gbps;", std::max(tx, rx) / 1000.0) : "";
+							line += mCPUUtil != -1 ? fmt::format("{:3.0f}% machine;", mCPUUtil * 100) : "";
+							line +=
+							    std::min(tx, rx) != -1 ? fmt::format("{:6.3f} Gbps;", std::max(tx, rx) / 1000.0) : "";
 
 							double diskBusy;
 							if (procObj.get("disk.busy", diskBusy))
-								line += format("%3.0f%% disk IO;", 100.0 * diskBusy);
+								line += fmt::format("{:3.0f}% disk IO;", 100.0 * diskBusy);
 
-							line += processRSS != -1 ? format("%4.1f GB", processRSS / (1024.0 * 1024 * 1024)) : "";
+							line +=
+							    processRSS != -1 ? fmt::format("{:4.1f} GB", processRSS / (1024.0 * 1024 * 1024)) : "";
 
 							double availableBytes;
 							if (procObj.get("memory.available_bytes", availableBytes))
-								line += format(" / %3.1f GB RAM  )", availableBytes / (1024.0 * 1024 * 1024));
+								line += fmt::format(" / {:3.1f} GB RAM  )", availableBytes / (1024.0 * 1024 * 1024));
 							else
 								line += "  )";
 
@@ -1092,12 +1091,12 @@ void printStatus(StatusObjectReader statusObj,
 						}
 
 						catch (std::runtime_error&) {
-							std::string noMetrics = format("  %-22s (no metrics available)", address.c_str());
+							std::string noMetrics = fmt::format("  {:<22} (no metrics available)", address);
 							workerDetails[parsedAddress] = noMetrics;
 						}
 					}
 					for (auto w : workerDetails)
-						outputString += "\n" + format("%s", w.second.c_str());
+						outputString += "\n" + fmt::format("{}", w.second);
 				} catch (std::runtime_error&) {
 					outputString = outputStringCache;
 					outputString += "\n  Unable to retrieve process performance details";
@@ -1143,7 +1142,7 @@ void printStatus(StatusObjectReader statusObj,
 				}
 			}
 
-			printf("%s\n", outputString.c_str());
+			fmt::println("{}", outputString);
 		}
 
 		// status minimal
@@ -1160,7 +1159,7 @@ void printStatus(StatusObjectReader statusObj,
 
 				// Database unavailable
 				if (!available) {
-					printf("%s", "The database is unavailable; type `status' for more information.\n");
+					fmt::print("{}", "The database is unavailable; type `status' for more information.\n");
 				} else {
 					try {
 						bool healthy = statusObjClientDatabaseStatus["healthy"].get_bool();
@@ -1168,43 +1167,43 @@ void printStatus(StatusObjectReader statusObj,
 						// Database available without issues
 						if (healthy) {
 							if (displayDatabaseAvailable) {
-								printf("The database is available.\n");
+								fmt::println("The database is available.");
 							}
 						} else { // Database running but with issues
-							printf("The database is available, but has issues (type 'status' for more information).\n");
+							fmt::println(
+							    "The database is available, but has issues (type 'status' for more information).");
 						}
 					} catch (std::runtime_error&) {
-						printf("The database is available, but has issues (type 'status' for more information).\n");
+						fmt::println("The database is available, but has issues (type 'status' for more information).");
 					}
 				}
 
 				bool upToDate;
 				if (!statusObjClient.get("cluster_file.up_to_date", upToDate) || !upToDate) {
-					fprintf(stderr,
-					        "WARNING: The cluster file is not up to date. Type 'status' for more information.\n");
+					fmt::println(stderr,
+					             "WARNING: The cluster file is not up to date. Type 'status' for more information.");
 				}
 			} catch (std::runtime_error&) {
-				printf("Unable to determine database state, type 'status' for more information.\n");
+				fmt::println("Unable to determine database state, type 'status' for more information.");
 			}
 
 		}
 
 		// status JSON
 		else if (level == StatusClient::JSON) {
-			printf("%s\n",
-			       json_spirit::write_string(json_spirit::mValue(statusObj.obj()),
-			                                 json_spirit::Output_options::pretty_print)
-			           .c_str());
+			fmt::println("{}",
+			             json_spirit::write_string(json_spirit::mValue(statusObj.obj()),
+			                                       json_spirit::Output_options::pretty_print));
 		}
 	} catch (Error&) {
 		if (hideErrorMessages)
 			return;
 		if (level == StatusClient::MINIMAL) {
-			printf("Unable to determine database state, type 'status' for more information.\n");
+			fmt::println("Unable to determine database state, type 'status' for more information.");
 		} else if (level == StatusClient::JSON) {
-			printf("Could not retrieve status json.\n\n");
+			fmt::print("Could not retrieve status json.\n\n");
 		} else {
-			printf("Could not retrieve status, type 'status json' for more information.\n");
+			fmt::println("Could not retrieve status, type 'status json' for more information.");
 		}
 	}
 }
@@ -1241,7 +1240,7 @@ ACTOR Future<bool> statusCommandActor(Reference<IDatabase> db,
 		state ThreadFuture<Optional<Value>> statusValueF = tr->get("\xff\xff/status/json"_sr);
 		Optional<Value> statusValue = wait(safeThreadFutureToFuture(statusValueF));
 		if (!statusValue.present()) {
-			fprintf(stderr, "ERROR: Failed to get status json from the cluster\n");
+			fmt::println(stderr, "ERROR: Failed to get status json from the cluster");
 		}
 		json_spirit::mValue mv;
 		json_spirit::read_string(statusValue.get().toString(), mv);
@@ -1249,10 +1248,10 @@ ACTOR Future<bool> statusCommandActor(Reference<IDatabase> db,
 	}
 
 	if (!isExecMode)
-		printf("\n");
+		fmt::println("");
 	printStatus(s, level);
 	if (!isExecMode)
-		printf("\n");
+		fmt::println("");
 	return true;
 }
 

--- a/fdbcli/SuspendCommand.cpp
+++ b/fdbcli/SuspendCommand.cpp
@@ -29,6 +29,7 @@
 #include "flow/Arena.h"
 #include "flow/FastRef.h"
 #include "flow/ThreadHelper.actor.h"
+#include "fmt/format.h"
 namespace fdb_cli {
 
 Future<bool> suspendCommandActor(Reference<IDatabase> db,
@@ -43,23 +44,23 @@ Future<bool> suspendCommandActor(Reference<IDatabase> db,
 		address_interface->clear();
 		co_await getWorkerInterfaces(tr, address_interface, true);
 		if (address_interface->empty()) {
-			printf("\nNo addresses can be suspended.\n");
+			fmt::print("\nNo addresses can be suspended.\n");
 		} else if (address_interface->size() == 1) {
-			printf("\nThe following address can be suspended:\n");
+			fmt::print("\nThe following address can be suspended:\n");
 		} else {
-			printf("\nThe following %zu addresses can be suspended:\n", address_interface->size());
+			fmt::print("\nThe following {} addresses can be suspended:\n", address_interface->size());
 		}
 		for (const auto& it : *address_interface) {
-			printf("%s\n", printable(it.first).c_str());
+			fmt::println("{}", printable(it.first));
 		}
-		printf("\n");
+		fmt::println("");
 	} else if (tokens.size() == 2) {
 		printUsage(tokens[0]);
 		result = false;
 	} else {
 		for (int i = 2; i < tokens.size(); i++) {
 			if (!address_interface->count(tokens[i])) {
-				fprintf(stderr, "ERROR: process `%s' not recognized.\n", printable(tokens[i]).c_str());
+				fmt::println(stderr, "ERROR: process `{}' not recognized.", printable(tokens[i]));
 				result = false;
 				break;
 			}
@@ -83,13 +84,12 @@ Future<bool> suspendCommandActor(Reference<IDatabase> db,
 				    co_await safeThreadFutureToFuture(db->rebootWorker(addressesStr, false, static_cast<int>(seconds)));
 				if (!suspendRequestSent) {
 					result = false;
-					fprintf(
-					    stderr,
-					    "ERROR: failed to send requests to suspend processes `%s', please run the `suspend’ command "
-					    "to fetch latest addresses.\n",
-					    addressesStr.c_str());
+					fmt::println(stderr,
+					             "ERROR: failed to send requests to suspend processes `{}', please run the "
+					             "`suspendâ command to fetch latest addresses.",
+					             addressesStr);
 				} else {
-					printf("Attempted to suspend %zu processes\n", tokens.size() - 2);
+					fmt::println("Attempted to suspend {} processes", tokens.size() - 2);
 				}
 			}
 		}

--- a/fdbcli/ThrottleCommand.actor.cpp
+++ b/fdbcli/ThrottleCommand.actor.cpp
@@ -29,6 +29,7 @@
 #include "flow/Arena.h"
 #include "flow/ThreadHelper.actor.h"
 #include "flow/genericactors.actor.h"
+#include "fmt/format.h"
 #include "flow/actorcompiler.h" // This must be the last #include.
 
 namespace fdb_cli {
@@ -43,8 +44,8 @@ ACTOR Future<bool> throttleCommandActor(Reference<IDatabase> db, std::vector<Str
 	} else if (tokencmp(tokens[1], "list")) {
 		if (tokens.size() > 4) {
 			fmt::print("Usage: throttle list [throttled|recommended|all] [LIMIT]\n\n");
-			fmt::print("Lists tags that are currently throttled.\n");
-			fmt::print("The default LIMIT is {} tags.\n", defaultThrottleListLimit);
+			fmt::println("Lists tags that are currently throttled.");
+			fmt::println("The default LIMIT is {} tags.", defaultThrottleListLimit);
 			return false;
 		}
 
@@ -58,7 +59,7 @@ ACTOR Future<bool> throttleCommandActor(Reference<IDatabase> db, std::vector<Str
 				reportThrottled = true;
 				reportRecommended = true;
 			} else if (!tokencmp(tokens[2], "throttled")) {
-				printf("ERROR: failed to parse `%s'.\n", printable(tokens[2]).c_str());
+				fmt::println("ERROR: failed to parse `{}'.", printable(tokens[2]));
 				return false;
 			}
 		}
@@ -68,7 +69,7 @@ ACTOR Future<bool> throttleCommandActor(Reference<IDatabase> db, std::vector<Str
 			char* end;
 			throttleListLimit = std::strtol((const char*)tokens[3].begin(), &end, 10);
 			if ((tokens.size() > 4 && !std::isspace(*end)) || (tokens.size() == 4 && *end != '\0')) {
-				fprintf(stderr, "ERROR: failed to parse limit `%s'.\n", printable(tokens[3]).c_str());
+				fmt::println(stderr, "ERROR: failed to parse limit `{}'.", printable(tokens[3]));
 				return false;
 			}
 		}
@@ -86,9 +87,9 @@ ACTOR Future<bool> throttleCommandActor(Reference<IDatabase> db, std::vector<Str
 		for (auto itr = tags.begin(); itr != tags.end(); ++itr) {
 			if (itr->expirationTime > now()) {
 				if (!anyLogged) {
-					printf("Throttled tags:\n\n");
-					printf("  Rate (txn/s) | Expiration (s) | Priority  | Type   | Reason     |Tag\n");
-					printf(" --------------+----------------+-----------+--------+------------+------\n");
+					fmt::print("Throttled tags:\n\n");
+					fmt::println("  Rate (txn/s) | Expiration (s) | Priority  | Type   | Reason     |Tag");
+					fmt::println(" --------------+----------------+-----------+--------+------------+------");
 
 					anyLogged = true;
 				}
@@ -102,34 +103,34 @@ ACTOR Future<bool> throttleCommandActor(Reference<IDatabase> db, std::vector<Str
 					reasonStr = "busy read";
 				}
 
-				printf("  %12d | %13ds | %9s | %6s | %10s |%s\n",
-				       (int)(itr->tpsRate),
-				       std::min((int)(itr->expirationTime - now()), (int)(itr->initialDuration)),
-				       transactionPriorityToString(itr->priority, false),
-				       itr->throttleType == TagThrottleType::AUTO ? "auto" : "manual",
-				       reasonStr.c_str(),
-				       itr->tag.toString().c_str());
+				fmt::println("  {:12} | {:13}s | {:>9} | {:>6} | {:>10} |{}",
+				             (int)(itr->tpsRate),
+				             std::min((int)(itr->expirationTime - now()), (int)(itr->initialDuration)),
+				             transactionPriorityToString(itr->priority, false),
+				             itr->throttleType == TagThrottleType::AUTO ? "auto" : "manual",
+				             reasonStr,
+				             itr->tag.toString());
 			}
 		}
 
 		if (tags.size() == throttleListLimit) {
-			printf("\nThe tag limit `%d' was reached. Use the [LIMIT] argument to view additional tags.\n",
-			       throttleListLimit);
-			printf("Usage: throttle list [LIMIT]\n");
+			fmt::print("\nThe tag limit `{}' was reached. Use the [LIMIT] argument to view additional tags.\n",
+			           throttleListLimit);
+			fmt::println("Usage: throttle list [LIMIT]");
 		}
 		if (!anyLogged) {
-			printf("There are no %s tags\n", reportThrottled ? "throttled" : "recommended");
+			fmt::println("There are no {} tags", reportThrottled ? "throttled" : "recommended");
 		}
 	} else if (tokencmp(tokens[1], "on")) {
 		if (tokens.size() < 4 || !tokencmp(tokens[2], "tag") || tokens.size() > 7) {
-			printf("Usage: throttle on tag <TAG> [RATE] [DURATION] [PRIORITY]\n");
-			printf("\n");
-			printf("Enables throttling for transactions with the specified tag.\n");
-			printf("An optional transactions per second rate can be specified (default 0).\n");
-			printf("An optional duration can be specified, which must include a time suffix (s, m, h, "
-			       "d) (default 1h).\n");
-			printf("An optional priority can be specified. Choices are `default', `immediate', and "
-			       "`batch' (default `default').\n");
+			fmt::println("Usage: throttle on tag <TAG> [RATE] [DURATION] [PRIORITY]");
+			fmt::println("");
+			fmt::println("Enables throttling for transactions with the specified tag.");
+			fmt::println("An optional transactions per second rate can be specified (default 0).");
+			fmt::println(
+			    "An optional duration can be specified, which must include a time suffix (s, m, h, d) (default 1h).");
+			fmt::println("An optional priority can be specified. Choices are `default', `immediate', and `batch' "
+			             "(default `default').");
 			return false;
 		}
 
@@ -141,24 +142,24 @@ ACTOR Future<bool> throttleCommandActor(Reference<IDatabase> db, std::vector<Str
 			char* end;
 			tpsRate = std::strtod((const char*)tokens[4].begin(), &end);
 			if ((tokens.size() > 5 && !std::isspace(*end)) || (tokens.size() == 5 && *end != '\0')) {
-				fprintf(stderr, "ERROR: failed to parse rate `%s'.\n", printable(tokens[4]).c_str());
+				fmt::println(stderr, "ERROR: failed to parse rate `{}'.", printable(tokens[4]));
 				return false;
 			}
 			if (tpsRate < 0) {
-				fprintf(stderr, "ERROR: rate cannot be negative `%f'\n", tpsRate);
+				fmt::println(stderr, "ERROR: rate cannot be negative `{:f}'", tpsRate);
 				return false;
 			}
 		}
 		if (tokens.size() == 6) {
 			Optional<uint64_t> parsedDuration = parseDuration(tokens[5].toString());
 			if (!parsedDuration.present()) {
-				fprintf(stderr, "ERROR: failed to parse duration `%s'.\n", printable(tokens[5]).c_str());
+				fmt::println(stderr, "ERROR: failed to parse duration `{}'.", printable(tokens[5]));
 				return false;
 			}
 			duration = parsedDuration.get();
 
 			if (duration == 0) {
-				fprintf(stderr, "ERROR: throttle duration cannot be 0\n");
+				fmt::println(stderr, "ERROR: throttle duration cannot be 0");
 				return false;
 			}
 		}
@@ -170,10 +171,9 @@ ACTOR Future<bool> throttleCommandActor(Reference<IDatabase> db, std::vector<Str
 			} else if (tokens[6] == "batch"_sr) {
 				priority = TransactionPriority::BATCH;
 			} else {
-				fprintf(stderr,
-				        "ERROR: unrecognized priority `%s'. Must be one of `default',\n  `immediate', "
-				        "or `batch'.\n",
-				        tokens[6].toString().c_str());
+				fmt::print(stderr,
+				           "ERROR: unrecognized priority `{}'. Must be one of `default',\n  `immediate', or `batch'.\n",
+				           tokens[6].toString());
 				return false;
 			}
 		}
@@ -182,7 +182,7 @@ ACTOR Future<bool> throttleCommandActor(Reference<IDatabase> db, std::vector<Str
 		tagSet.addTag(tokens[3]);
 
 		wait(ThrottleApi::throttleTags(db, tagSet, tpsRate, duration, TagThrottleType::MANUAL, priority));
-		printf("Tag `%s' has been throttled\n", tokens[3].toString().c_str());
+		fmt::println("Tag `{}' has been throttled", tokens[3].toString());
 	} else if (tokencmp(tokens[1], "off")) {
 		int nextIndex = 2;
 		state TagSet tagSet;
@@ -257,51 +257,51 @@ ACTOR Future<bool> throttleCommandActor(Reference<IDatabase> db, std::vector<Str
 			state const char* throttleTypeString =
 			    !throttleType.present() ? "" : (throttleType.get() == TagThrottleType::AUTO ? "auto-" : "manually ");
 			state std::string priorityString =
-			    priority.present() ? format(" at %s priority", transactionPriorityToString(priority.get(), false)) : "";
+			    priority.present() ? fmt::format(" at {} priority", transactionPriorityToString(priority.get(), false))
+			                       : "";
 
 			if (tagSet.size() > 0) {
 				bool success = wait(ThrottleApi::unthrottleTags(db, tagSet, throttleType, priority));
 				if (success) {
-					fmt::print("Unthrottled {0}{1}\n", tagSet.toString(), priorityString);
+					fmt::println("Unthrottled {0}{1}", tagSet.toString(), priorityString);
 				} else {
-					fmt::print("{0} was not {1}throttled{2}\n",
-					           tagSet.toString(Capitalize::True),
-					           throttleTypeString,
-					           priorityString);
+					fmt::println("{0} was not {1}throttled{2}",
+					             tagSet.toString(Capitalize::True),
+					             throttleTypeString,
+					             priorityString);
 				}
 			} else {
 				bool unthrottled = wait(ThrottleApi::unthrottleAll(db, throttleType, priority));
 				if (unthrottled) {
-					printf("Unthrottled all %sthrottled tags%s\n", throttleTypeString, priorityString.c_str());
+					fmt::println("Unthrottled all {}throttled tags{}", throttleTypeString, priorityString);
 				} else {
-					printf("There were no tags being %sthrottled%s\n", throttleTypeString, priorityString.c_str());
+					fmt::println("There were no tags being {}throttled{}", throttleTypeString, priorityString);
 				}
 			}
 		} else {
-			printf("Usage: throttle off [all|auto|manual] [tag <TAG>] [PRIORITY]\n");
-			printf("\n");
-			printf("Disables throttling for throttles matching the specified filters. At least one "
-			       "filter must be used.\n\n");
-			printf("An optional qualifier `all', `auto', or `manual' can be used to specify the type "
-			       "of throttle\n");
-			printf("affected. `all' targets all throttles, `auto' targets those created by the "
-			       "cluster, and\n");
-			printf("`manual' targets those created manually (default `manual').\n\n");
-			printf("The `tag' filter can be use to turn off only a specific tag.\n\n");
-			printf("The priority filter can be used to turn off only throttles at specific priorities. "
-			       "Choices are\n");
-			printf("`default', `immediate', or `batch'. By default, all priorities are targeted.\n");
+			fmt::println("Usage: throttle off [all|auto|manual] [tag <TAG>] [PRIORITY]");
+			fmt::println("");
+			fmt::print("Disables throttling for throttles matching the specified filters. At least one filter must be "
+			           "used.\n\n");
+			fmt::println(
+			    "An optional qualifier `all', `auto', or `manual' can be used to specify the type of throttle");
+			fmt::println("affected. `all' targets all throttles, `auto' targets those created by the cluster, and");
+			fmt::print("`manual' targets those created manually (default `manual').\n\n");
+			fmt::print("The `tag' filter can be use to turn off only a specific tag.\n\n");
+			fmt::println(
+			    "The priority filter can be used to turn off only throttles at specific priorities. Choices are");
+			fmt::println("`default', `immediate', or `batch'. By default, all priorities are targeted.");
 		}
 	} else if (tokencmp(tokens[1], "enable") || tokencmp(tokens[1], "disable")) {
 		if (tokens.size() != 3 || !tokencmp(tokens[2], "auto")) {
-			printf("Usage: throttle <enable|disable> auto\n");
-			printf("\n");
-			printf("Enables or disable automatic tag throttling.\n");
+			fmt::println("Usage: throttle <enable|disable> auto");
+			fmt::println("");
+			fmt::println("Enables or disable automatic tag throttling.");
 			return false;
 		}
 		state bool autoTagThrottlingEnabled = tokencmp(tokens[1], "enable");
 		wait(ThrottleApi::enableAuto(db, autoTagThrottlingEnabled));
-		printf("Automatic tag throttling has been %s\n", autoTagThrottlingEnabled ? "enabled" : "disabled");
+		fmt::println("Automatic tag throttling has been {}", autoTagThrottlingEnabled ? "enabled" : "disabled");
 	} else {
 		printUsage(tokens[0]);
 		return false;

--- a/fdbcli/TriggerDDTeamInfoLogCommand.cpp
+++ b/fdbcli/TriggerDDTeamInfoLogCommand.cpp
@@ -27,6 +27,7 @@
 #include "flow/Arena.h"
 #include "flow/FastRef.h"
 #include "flow/ThreadHelper.actor.h"
+#include "fmt/format.h"
 namespace fdb_cli {
 
 Future<bool> triggerddteaminfologCommandActor(Reference<IDatabase> db) {
@@ -39,7 +40,7 @@ Future<bool> triggerddteaminfologCommandActor(Reference<IDatabase> db) {
 			std::string v = deterministicRandom()->randomUniqueID().toString();
 			tr->set(triggerDDTeamInfoPrintKey, v);
 			co_await safeThreadFutureToFuture(tr->commit());
-			printf("Triggered team info logging in data distribution.\n");
+			fmt::println("Triggered team info logging in data distribution.");
 			co_return true;
 		} catch (Error& e) {
 			err = e;

--- a/fdbcli/TssqCommand.actor.cpp
+++ b/fdbcli/TssqCommand.actor.cpp
@@ -28,6 +28,7 @@
 #include "flow/Arena.h"
 #include "flow/FastRef.h"
 #include "flow/ThreadHelper.actor.h"
+#include "fmt/format.h"
 #include "flow/actorcompiler.h" // This must be the last #include.
 
 namespace {
@@ -43,9 +44,9 @@ ACTOR Future<Void> tssQuarantineList(Reference<IDatabase> db) {
 			RangeResult result = wait(safeThreadFutureToFuture(resultFuture));
 			// shouldn't have many quarantined TSSes
 			ASSERT(!result.more);
-			printf("Found %d quarantined TSS processes%s\n", result.size(), result.size() == 0 ? "." : ":");
+			fmt::println("Found {} quarantined TSS processes{}", result.size(), result.size() == 0 ? "." : ":");
 			for (auto& it : result) {
-				printf("  %s\n", decodeTssQuarantineKey(it.key).toString().c_str());
+				fmt::println("  {}", decodeTssQuarantineKey(it.key).toString());
 			}
 			return Void();
 		} catch (Error& e) {
@@ -68,12 +69,12 @@ ACTOR Future<bool> tssQuarantine(Reference<IDatabase> db, bool enable, UID tssId
 			state ThreadFuture<Optional<Value>> serverListValueF = tr->get(serverListKeyFor(tssId));
 			Optional<Value> serverListValue = wait(safeThreadFutureToFuture(serverListValueF));
 			if (!serverListValue.present()) {
-				printf("No TSS %s found in cluster!\n", tssId.toString().c_str());
+				fmt::println("No TSS {} found in cluster!", tssId.toString());
 				return false;
 			}
 			state StorageServerInterface ssi = decodeServerListValue(serverListValue.get());
 			if (!ssi.isTss()) {
-				printf("Cannot quarantine Non-TSS storage ID %s!\n", tssId.toString().c_str());
+				fmt::println("Cannot quarantine Non-TSS storage ID {}!", tssId.toString());
 				return false;
 			}
 
@@ -81,10 +82,10 @@ ACTOR Future<bool> tssQuarantine(Reference<IDatabase> db, bool enable, UID tssId
 			state ThreadFuture<Optional<Value>> currentQuarantineValueF = tr->get(tssQuarantineKeyFor(tssId));
 			Optional<Value> currentQuarantineValue = wait(safeThreadFutureToFuture(currentQuarantineValueF));
 			if (enable && currentQuarantineValue.present()) {
-				printf("TSS %s already in quarantine, doing nothing.\n", tssId.toString().c_str());
+				fmt::println("TSS {} already in quarantine, doing nothing.", tssId.toString());
 				return false;
 			} else if (!enable && !currentQuarantineValue.present()) {
-				printf("TSS %s is not in quarantine, cannot remove from quarantine!.\n", tssId.toString().c_str());
+				fmt::println("TSS {} is not in quarantine, cannot remove from quarantine!.", tssId.toString());
 				return false;
 			}
 
@@ -102,7 +103,7 @@ ACTOR Future<bool> tssQuarantine(Reference<IDatabase> db, bool enable, UID tssId
 			wait(safeThreadFutureToFuture(tr->onError(e)));
 		}
 	}
-	printf("Successfully %s TSS %s\n", enable ? "quarantined" : "removed", tssId.toString().c_str());
+	fmt::println("Successfully {} TSS {}", enable ? "quarantined" : "removed", tssId.toString());
 	return true;
 }
 

--- a/fdbcli/Util.actor.cpp
+++ b/fdbcli/Util.actor.cpp
@@ -26,6 +26,7 @@
 #include "flow/Arena.h"
 
 #include "flow/ThreadHelper.actor.h"
+#include "fmt/format.h"
 #include "flow/actorcompiler.h" // This must be the last #include.
 
 namespace fdb_cli {
@@ -41,18 +42,18 @@ void printUsage(StringRef command) {
 	const auto& helpMap = CommandFactory::commands();
 	auto i = helpMap.find(command.toString());
 	if (i != helpMap.end())
-		printf("Usage: %s\n", i->second.usage.c_str());
+		fmt::println("Usage: {}", i->second.usage);
 	else
-		fprintf(stderr, "ERROR: Unknown command `%s'\n", command.toString().c_str());
+		fmt::println(stderr, "ERROR: Unknown command `{}'", command.toString());
 }
 
 void printLongDesc(StringRef command) {
 	const auto& helpMap = CommandFactory::commands();
 	auto i = helpMap.find(command.toString());
 	if (i != helpMap.end())
-		printf("%s\n", i->second.long_desc.c_str());
+		fmt::println("{}", i->second.long_desc);
 	else
-		fprintf(stderr, "ERROR: Unknown command `%s'\n", command.toString().c_str());
+		fmt::println(stderr, "ERROR: Unknown command `{}'", command.toString());
 }
 
 ACTOR Future<std::string> getSpecialKeysFailureErrorMessage(Reference<ITransaction> tr) {
@@ -79,7 +80,7 @@ void addInterfacesFromKVs(RangeResult& kvs,
 			// the interface is back-ward compatible, thus if parsing failed, it needs to upgrade cli version
 			workerInterf = BinaryReader::fromStringRef<ClientWorkerInterface>(kv.value, IncludeVersion());
 		} catch (Error& e) {
-			fprintf(stderr, "Error: %s; CLI version is too old, please update to use a newer version\n", e.what());
+			fmt::println(stderr, "Error: {}; CLI version is too old, please update to use a newer version", e.what());
 			return;
 		}
 		ClientLeaderRegInterface leaderInterf(workerInterf.address());
@@ -138,7 +139,7 @@ ACTOR Future<bool> getWorkers(Reference<IDatabase> db, std::vector<ProcessData>*
 					id_class[decodeProcessClassKey(processClasses.get()[i].key)] =
 					    decodeProcessClassValue(processClasses.get()[i].value);
 				} catch (Error& e) {
-					fprintf(stderr, "Error: %s; Client version is too old, please use a newer version\n", e.what());
+					fmt::println(stderr, "Error: {}; Client version is too old, please use a newer version", e.what());
 					return false;
 				}
 			}

--- a/fdbcli/VersionEpochCommand.actor.cpp
+++ b/fdbcli/VersionEpochCommand.actor.cpp
@@ -28,6 +28,7 @@
 #include "flow/Arena.h"
 #include "flow/FastRef.h"
 #include "flow/ThreadHelper.actor.h"
+#include "fmt/format.h"
 #include "flow/actorcompiler.h" // This must be the last #include.
 
 namespace fdb_cli {
@@ -83,7 +84,7 @@ ACTOR Future<bool> versionEpochCommandActor(Reference<IDatabase> db, Database cx
 				printf("Expected:   %" PRId64 "\n", versionInfo.get().expectedVersion);
 				printf("Difference: %" PRId64 " (%.2fs)\n", diff, 1.0 * diff / CLIENT_KNOBS->VERSIONS_PER_SECOND);
 			} else {
-				printf("Version epoch is unset\n");
+				fmt::println("Version epoch is unset");
 			}
 			return true;
 		} else if (tokens.size() == 2 && tokencmp(tokens[1], "get")) {
@@ -91,7 +92,7 @@ ACTOR Future<bool> versionEpochCommandActor(Reference<IDatabase> db, Database cx
 			if (versionEpoch.present()) {
 				printf("Current version epoch is %" PRId64 "\n", versionEpoch.get());
 			} else {
-				printf("Version epoch is unset\n");
+				fmt::println("Version epoch is unset");
 			}
 			return true;
 		} else if (tokens.size() == 2 && tokencmp(tokens[1], "disable")) {
@@ -133,8 +134,8 @@ ACTOR Future<bool> versionEpochCommandActor(Reference<IDatabase> db, Database cx
 						tr->set(versionEpochSpecialKey, BinaryWriter::toValue(v, Unversioned()));
 						wait(safeThreadFutureToFuture(tr->commit()));
 					} else {
-						printf("Version epoch enabled. Run `versionepoch commit` to irreversibly jump to the target "
-						       "version\n");
+						fmt::println("Version epoch enabled. Run `versionepoch commit` to irreversibly jump to the "
+						             "target version");
 						return true;
 					}
 				} catch (Error& e) {
@@ -146,7 +147,7 @@ ACTOR Future<bool> versionEpochCommandActor(Reference<IDatabase> db, Database cx
 			if (versionInfo.present()) {
 				wait(advanceVersion(cx, versionInfo.get().expectedVersion));
 			} else {
-				printf("Must set the version epoch before committing it (see `versionepoch enable`)\n");
+				fmt::println("Must set the version epoch before committing it (see `versionepoch enable`)");
 			}
 			return true;
 		}

--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -146,7 +146,7 @@ void printAtCol(const char* text, int col, FILE* stream = stdout) {
 		if (*iter == '\n' || *iter == '\0' || (iter - start == col)) {
 			if (!space)
 				space = iter;
-			fprintf(stream, "%.*s\n", (int)(space - start), start);
+			fmt::println(stream, "{:.{}}", start, (int)(space - start));
 			start = space;
 			if (*start == ' ' || *start == '\n')
 				start++;
@@ -167,9 +167,9 @@ public:
 		if (transactionItr != transactionOptions.legalOptions.end())
 			setTransactionOption(tr, transactionItr->second, enabled, arg, intrans);
 		else {
-			fprintf(stderr,
-			        "ERROR: invalid option '%s'. Try `help options' for a list of available options.\n",
-			        optionStr.toString().c_str());
+			fmt::println(stderr,
+			             "ERROR: invalid option '{}'. Try `help options' for a list of available options.",
+			             optionStr.toString());
 			throw invalid_option();
 		}
 	}
@@ -190,7 +190,7 @@ public:
 		found = found || transactionOptions.print();
 
 		if (!found)
-			printf("There are no options enabled\n");
+			fmt::println("There are no options enabled");
 	}
 
 	// Returns a vector of the names of all documented options
@@ -212,7 +212,7 @@ private:
 		if (enabled) {
 			auto optionInfo = FDBTransactionOptions::optionInfo.getMustExist(option);
 			if (arg.present() != optionInfo.hasParameter) {
-				fprintf(stderr, "ERROR: option %s a parameter\n", arg.present() ? "did not expect" : "expected");
+				fmt::println(stderr, "ERROR: option {} a parameter", arg.present() ? "did not expect" : "expected");
 				throw invalid_option_value();
 			}
 			if (arg.present() && optionInfo.paramType == FDBOptionInfo::ParamType::Int) {
@@ -221,13 +221,12 @@ private:
 					std::string value = arg.get().toString();
 					parsedInt = std::stoll(value, &nextIdx);
 					if (nextIdx != value.length()) {
-						fprintf(
-						    stderr, "ERROR: could not parse value `%s' as an integer\n", arg.get().toString().c_str());
+						fmt::println(stderr, "ERROR: could not parse value `{}' as an integer", arg.get().toString());
 						throw invalid_option_value();
 					}
 					arg = StringRef(reinterpret_cast<uint8_t*>(&parsedInt), 8);
 				} catch (std::exception e) {
-					fprintf(stderr, "ERROR: could not parse value `%s' as an integer\n", arg.get().toString().c_str());
+					fmt::println(stderr, "ERROR: could not parse value `{}' as an integer", arg.get().toString());
 					throw invalid_option_value();
 				}
 			}
@@ -273,9 +272,9 @@ private:
 				auto optionItr = options.find(itr->second);
 				if (optionItr != options.end()) {
 					if (optionItr->second.present())
-						printf("%s: `%s'\n", itr->first.c_str(), formatStringRef(optionItr->second.get()).c_str());
+						fmt::println("{}: `{}'", itr->first, formatStringRef(optionItr->second.get()));
 					else
-						printf("%s\n", itr->first.c_str());
+						fmt::println("{}", itr->first);
 
 					found = true;
 				}
@@ -341,11 +340,11 @@ static std::string formatStringRef(StringRef item, bool fullEscaping = false) {
 		else if (fullEscaping && item[i] == '"')
 			ret += "\\\"";
 		else if (fullEscaping && item[i] == ' ')
-			ret += format("\\x%02x", item[i]);
+			ret += fmt::format("\\x{:02x}", item[i]);
 		else if (item[i] >= 32 && item[i] < 127)
 			ret += item[i];
 		else
-			ret += format("\\x%02x", item[i]);
+			ret += fmt::format("\\x{:02x}", item[i]);
 	}
 
 	return ret;
@@ -476,11 +475,10 @@ static void printProgramUsage(const char* name) {
 	       "usage: %s [OPTIONS]\n"
 	       "\n",
 	       name);
-	printf("  -C CONNFILE    The path of a file containing the connection string for the\n"
-	       "                 FoundationDB cluster. The default is first the value of the\n"
-	       "                 FDB_CLUSTER_FILE environment variable, then `./fdb.cluster',\n"
-	       "                 then `%s'.\n",
-	       platform::getDefaultClusterFilePath().c_str());
+	fmt::print("  -C CONNFILE    The path of a file containing the connection string for the\n                 "
+	           "FoundationDB cluster. The default is first the value of the\n                 FDB_CLUSTER_FILE "
+	           "environment variable, then `./fdb.cluster',\n                 then `{}'.\n",
+	           platform::getDefaultClusterFilePath());
 	printf("  --log          Enables trace file logging for the CLI session.\n"
 	       "  --log-dir PATH Specifies the output directory for trace files. If\n"
 	       "                 unspecified, defaults to the current directory. Has\n"
@@ -594,38 +592,38 @@ void initHelp() {
 
 void printVersion() {
 	printf("FoundationDB CLI " FDB_VT_PACKAGE_NAME " (v" FDB_VT_VERSION ")\n");
-	printf("source version %s\n", getSourceVersion());
+	fmt::println("source version {}", getSourceVersion());
 	printf("protocol %" PRIx64 "\n", currentProtocolVersion().version());
 }
 
 void printBuildInformation() {
-	printf("%s", jsonBuildInformation().c_str());
+	fmt::print("{}", jsonBuildInformation());
 }
 
 void printHelpOverview() {
-	printf("\nList of commands:\n\n");
+	fmt::print("\nList of commands:\n\n");
 	for (const auto& [command, help] : helpMap) {
 		if (help.short_desc.size())
-			printf(" %s:\n      %s\n", command.c_str(), help.short_desc.c_str());
+			fmt::print(" {}:\n      {}\n", command, help.short_desc);
 	}
-	printf("\nFor information on a specific command, type `help <command>'.");
-	printf("\nFor information on escaping keys and values, type `help escaping'.");
-	printf("\nFor information on available options, type `help options'.\n\n");
+	fmt::print("\nFor information on a specific command, type `help <command>'.");
+	fmt::print("\nFor information on escaping keys and values, type `help escaping'.");
+	fmt::print("\nFor information on available options, type `help options'.\n\n");
 }
 
 void printHelp(StringRef command) {
 	auto i = helpMap.find(command.toString());
 	if (i != helpMap.end() && i->second.short_desc.size()) {
-		printf("\n%s\n\n", i->second.usage.c_str());
+		fmt::print("\n{}\n\n", i->second.usage);
 		auto cstr = i->second.short_desc.c_str();
-		printf("%c%s.\n", toupper(cstr[0]), cstr + 1);
+		fmt::println("{:c}{}.", toupper(cstr[0]), cstr + 1);
 		if (!i->second.long_desc.empty()) {
-			printf("\n");
+			fmt::println("");
 			printAtCol(i->second.long_desc.c_str(), 80);
 		}
-		printf("\n");
+		fmt::println("");
 	} else
-		printf("I don't know anything about `%s'\n", formatStringRef(command).c_str());
+		fmt::println("I don't know anything about `{}'", formatStringRef(command));
 }
 
 int printStatusFromJSON(std::string const& jsonFileName) {
@@ -637,13 +635,13 @@ int printStatusFromJSON(std::string const& jsonFileName) {
 
 		return 0;
 	} catch (std::exception& e) {
-		printf("Exception printing status: %s\n", e.what());
+		fmt::println("Exception printing status: {}", e.what());
 		return 1;
 	} catch (Error& e) {
-		printf("Error printing status: %d %s\n", e.code(), e.what());
+		fmt::println("Error printing status: {} {}", e.code(), e.what());
 		return 2;
 	} catch (...) {
-		printf("Unknown exception printing status.\n");
+		fmt::println("Unknown exception printing status.");
 		return 3;
 	}
 }
@@ -669,16 +667,16 @@ ACTOR Future<Void> checkStatus(Future<Void> f,
 		state ThreadFuture<Optional<Value>> statusValueF = tr->get("\xff\xff/status/json"_sr);
 		Optional<Value> statusValue = wait(safeThreadFutureToFuture(statusValueF));
 		if (!statusValue.present()) {
-			fprintf(stderr, "ERROR: Failed to get status json from the cluster\n");
+			fmt::println(stderr, "ERROR: Failed to get status json from the cluster");
 			return Void();
 		}
 		json_spirit::mValue mv;
 		json_spirit::read_string(statusValue.get().toString(), mv);
 		s = StatusObject(mv.get_obj());
 	}
-	printf("\n");
+	fmt::println("");
 	printStatus(s, StatusClient::MINIMAL, displayDatabaseAvailable);
-	printf("\n");
+	fmt::println("");
 	return Void();
 }
 
@@ -700,9 +698,9 @@ ACTOR Future<Void> commitTransaction(Reference<ITransaction> tr) {
 	wait(makeInterruptable(safeThreadFutureToFuture(tr->commit())));
 	auto ver = tr->getCommittedVersion();
 	if (ver != invalidVersion)
-		fmt::print("Committed ({})\n", ver);
+		fmt::println("Committed ({})", ver);
 	else
-		fmt::print("Nothing to commit\n");
+		fmt::println("Nothing to commit");
 	return Void();
 }
 
@@ -717,14 +715,14 @@ ACTOR Future<bool> createSnapshot(Database db, std::vector<StringRef> tokens) {
 	}
 	try {
 		wait(makeInterruptable(mgmtSnapCreate(db, snapCmd, snapUID)));
-		printf("Snapshot command succeeded with UID %s\n", snapUID.toString().c_str());
+		fmt::println("Snapshot command succeeded with UID {}", snapUID.toString());
 	} catch (Error& e) {
-		fprintf(stderr,
-		        "Snapshot command failed %d (%s)."
-		        " Please cleanup any instance level snapshots created with UID %s.\n",
-		        e.code(),
-		        e.what(),
-		        snapUID.toString().c_str());
+		fmt::println(
+		    stderr,
+		    "Snapshot command failed {} ({}). Please cleanup any instance level snapshots created with UID {}.",
+		    e.code(),
+		    e.what(),
+		    snapUID.toString());
 		return true;
 	}
 	return false;
@@ -746,7 +744,7 @@ Reference<ITransaction> getTransaction(Reference<IDatabase> db,
 }
 
 std::string newCompletion(const char* base, const char* name) {
-	return format("%s%s ", base, name);
+	return fmt::format("{}{} ", base, name);
 }
 
 void compGenerator(const char* text, bool help, std::vector<std::string>& lc) {
@@ -867,7 +865,7 @@ void fdbcliCompCmd(std::string const& text, std::vector<std::string>& lc) {
 }
 
 void LogCommand(std::string line, UID randomID, std::string errMsg) {
-	printf("%s\n", errMsg.c_str());
+	fmt::println("{}", errMsg);
 	TraceEvent(SevInfo, "CLICommandLog", randomID).detail("Command", line).detail("Error", errMsg);
 }
 
@@ -920,7 +918,7 @@ struct CLIOptions {
 			}
 		}
 		if (exit_timeout && !exec.present()) {
-			fprintf(stderr, "ERROR: --timeout may only be specified with --exec\n");
+			fmt::println(stderr, "ERROR: --timeout may only be specified with --exec");
 			exit_code = FDB_EXIT_ERROR;
 			return;
 		}
@@ -947,14 +945,14 @@ struct CLIOptions {
 			char* endptr;
 			apiVersion = strtoul((char*)args.OptionArg(), &endptr, 10);
 			if (*endptr != '\0') {
-				fprintf(stderr, "ERROR: invalid client version %s\n", args.OptionArg());
+				fmt::println(stderr, "ERROR: invalid client version {}", args.OptionArg());
 				return 1;
 			} else if (apiVersion < 700 || apiVersion > ApiVersion::LATEST_VERSION) {
 				// multi-version fdbcli only available after 7.0
-				fprintf(stderr,
-				        "ERROR: api version %s is not supported. (Min: 700, Max: %d)\n",
-				        args.OptionArg(),
-				        ApiVersion::LATEST_VERSION);
+				fmt::println(stderr,
+				             "ERROR: api version {} is not supported. (Min: 700, Max: {})",
+				             args.OptionArg(),
+				             ApiVersion::LATEST_VERSION);
 				return 1;
 			}
 			break;
@@ -977,7 +975,7 @@ struct CLIOptions {
 			char* endptr;
 			exit_timeout = strtoul((char*)args.OptionArg(), &endptr, 10);
 			if (*endptr != '\0') {
-				fprintf(stderr, "ERROR: invalid timeout %s\n", args.OptionArg());
+				fmt::println(stderr, "ERROR: invalid timeout {}", args.OptionArg());
 				return 1;
 			}
 			break;
@@ -1028,14 +1026,14 @@ struct CLIOptions {
 			return printStatusFromJSON(args.OptionArg());
 		case OPT_TRACE_FORMAT:
 			if (!validateTraceFormat(args.OptionArg())) {
-				fprintf(stderr, "WARNING: Unrecognized trace format `%s'\n", args.OptionArg());
+				fmt::println(stderr, "WARNING: Unrecognized trace format `{}'", args.OptionArg());
 			}
 			traceFormat = args.OptionArg();
 			break;
 		case OPT_KNOB: {
 			Optional<std::string> knobName = extractPrefixedArgument("--knob", args.OptionSyntax());
 			if (!knobName.present()) {
-				fprintf(stderr, "ERROR: unable to parse knob option '%s'\n", args.OptionSyntax());
+				fmt::println(stderr, "ERROR: unable to parse knob option '{}'", args.OptionSyntax());
 				return FDB_EXIT_ERROR;
 			}
 			knobs.emplace_back(knobName.get(), args.OptionArg());
@@ -1093,12 +1091,12 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise, Reference<ClusterCo
 	try {
 		localDb = Database::createDatabase(ccf, opt.apiVersion, IsInternal::False);
 		if (!opt.exec.present()) {
-			printf("Using cluster file `%s'.\n", ccf->getLocation().c_str());
+			fmt::println("Using cluster file `{}'.", ccf->getLocation());
 		}
 		db = API->createDatabase(opt.clusterFile.c_str());
 	} catch (Error& e) {
-		fprintf(stderr, "ERROR: %s (%d)\n", e.what(), e.code());
-		printf("Unable to connect to cluster from `%s'\n", ccf->getLocation().c_str());
+		fmt::println(stderr, "ERROR: {} ({})", e.what(), e.code());
+		fmt::println("Unable to connect to cluster from `{}'", ccf->getLocation());
 		return 1;
 	}
 
@@ -1134,7 +1132,8 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise, Reference<ClusterCo
 				wait(safeThreadFutureToFuture(tr->onError(e)));
 			} else {
 				// unexpected errors
-				fprintf(stderr, "ERROR: unexpected error %d while initializing the multiversion database\n", e.code());
+				fmt::println(
+				    stderr, "ERROR: unexpected error {} while initializing the multiversion database", e.code());
 				tr->reset();
 				break;
 			}
@@ -1146,10 +1145,10 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise, Reference<ClusterCo
 			Future<Void> checkStatusF = checkStatus(Void(), db, localDb);
 			wait(makeInterruptable(success(checkStatusF)));
 		} else {
-			printf("\n");
+			fmt::println("");
 		}
 
-		printf("Welcome to the fdbcli. For help, type `help'.\n");
+		fmt::println("Welcome to the fdbcli. For help, type `help'.");
 		validOptions = options->getValidOptions();
 	}
 
@@ -1166,7 +1165,7 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise, Reference<ClusterCo
 		} else {
 			Optional<std::string> rawline = wait(linenoise.read("fdb> "));
 			if (!rawline.present()) {
-				printf("\n");
+				fmt::println("");
 				return 0;
 			}
 			line = rawline.get();
@@ -1209,7 +1208,7 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise, Reference<ClusterCo
 				state std::vector<StringRef> tokens = *iter;
 
 				if (is_error) {
-					printf("WARNING: the previous command failed, the remaining commands will not be executed.\n");
+					fmt::println("WARNING: the previous command failed, the remaining commands will not be executed.");
 					break;
 				}
 
@@ -1217,26 +1216,26 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise, Reference<ClusterCo
 					continue;
 
 				if (tokencmp(tokens[0], "parse_error")) {
-					fprintf(stderr, "ERROR: Command failed to completely parse.\n");
+					fmt::println(stderr, "ERROR: Command failed to completely parse.");
 					if (tokens.size() > 1) {
-						fprintf(stderr, "ERROR: Not running partial or malformed command:");
+						fmt::print(stderr, "ERROR: Not running partial or malformed command:");
 						for (auto t = tokens.begin() + 1; t != tokens.end(); ++t)
-							printf(" %s", formatStringRef(*t, true).c_str());
-						printf("\n");
+							fmt::print(" {}", formatStringRef(*t, true));
+						fmt::println("");
 					}
 					is_error = true;
 					continue;
 				}
 
 				if (multi) {
-					printf(">>>");
+					fmt::print(">>>");
 					for (auto t = tokens.begin(); t != tokens.end(); ++t)
-						printf(" %s", formatStringRef(*t, true).c_str());
-					printf("\n");
+						fmt::print(" {}", formatStringRef(*t, true));
+					fmt::println("");
 				}
 
 				if (!helpMap.count(tokens[0].toString()) && !hiddenCommands.count(tokens[0].toString())) {
-					fprintf(stderr, "ERROR: Unknown command `%s'. Try `help'?\n", formatStringRef(tokens[0]).c_str());
+					fmt::println(stderr, "ERROR: Unknown command `{}'. Try `help'?", formatStringRef(tokens[0]));
 					is_error = true;
 					continue;
 				}
@@ -1250,36 +1249,43 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise, Reference<ClusterCo
 						printHelpOverview();
 					} else if (tokens.size() == 2) {
 						if (tokencmp(tokens[1], "escaping"))
-							printf("\n"
-							       "When parsing commands, fdbcli considers a space to delimit individual tokens.\n"
-							       "To include a space in a single token, you may either enclose the token in\n"
-							       "quotation marks (\"hello world\"), prefix the space with a backslash\n"
-							       "(hello\\ world), or encode the space as a hex byte (hello\\x20world).\n"
-							       "\n"
-							       "To include a literal quotation mark in a token, precede it with a backslash\n"
-							       "(\\\"hello\\ world\\\").\n"
-							       "\n"
-							       "To express a binary value, encode each byte as either\n"
-							       "   a) a two-digit hex byte preceded by \\x\n"
-							       "   b) a four-digit hex byte in the range of 0x0000-0x00FF preceded by \\u\n"
-							       "(e.g. \\x20 or \\u0020 for a space character, or \\x0a\\x00\\x00\\x00 or\n"
-							       "\\u000a\\u0000\\u0000\\u0000 for a 32-bit, little-endian representation of\n"
-							       "the integer 10.  Any byte can use either syntax, so \\u000a\\x00\\x00\\x00\n"
-							       "is also a valid representation of a little-endian value of 10).\n"
-							       "\n"
-							       "All keys and values are displayed by the fdbcli with non-printable characters\n"
-							       "and spaces encoded as two-digit hex bytes.\n\n");
+							fmt::
+							    print(
+							        "\nWhen parsing commands, fdbcli considers a space to delimit individual "
+							        "tokens.\nTo include a space in a single token, you may either enclose the token "
+							        "in\nquotation marks (\\" hello
+							            world\\"), prefix the space with a backslash\n(hello\\ world), or encode the "
+							                   "space as a hex byte (hello\\x20world).\n\nTo include a literal "
+							                   "quotation mark in a token, precede it with a "
+							                   "backslash\n(\\\\" hello\\ world\\\\").\n\nTo express a binary value, "
+							                                                       "encode each byte as either\n   a) "
+							                                                       "a two-digit hex byte preceded by "
+							                                                       "\\x\n   b) a four-digit hex byte "
+							                                                       "in the range of 0x0000-0x00FF "
+							                                                       "preceded by \\u\n(e.g. \\x20 or "
+							                                                       "\\u0020 for a space character, or "
+							                                                       "\\x0a\\x00\\x00\\x00 "
+							                                                       "or\n\\u000a\\u0000\\u0000\\u0000 "
+							                                                       "for a 32-bit, little-endian "
+							                                                       "representation of\nthe integer 10. "
+							                                                       " Any byte can use either syntax, "
+							                                                       "so \\u000a\\x00\\x00\\x00\nis also "
+							                                                       "a valid representation of a "
+							                                                       "little-endian value of 10).\n\nAll "
+							                                                       "keys and values are displayed by "
+							                                                       "the fdbcli with non-printable "
+							                                                       "characters\nand spaces encoded as "
+							                                                       "two-digit hex bytes.\n\n");
 						else if (tokencmp(tokens[1], "options")) {
-							printf("\n"
-							       "The following options are available to be set using the `option' command:\n"
-							       "\n");
+							fmt::print(
+							    "\nThe following options are available to be set using the `option' command:\n\n");
 							options->printHelpString();
 						} else if (tokencmp(tokens[1], "help"))
 							printHelpOverview();
 						else
 							printHelp(tokens[1]);
 					} else
-						printf("Usage: help [topic]\n");
+						fmt::println("Usage: help [topic]");
 					continue;
 				}
 
@@ -1398,11 +1404,11 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise, Reference<ClusterCo
 					} else {
 						state std::string passPhrase = deterministicRandom()->randomAlphaNumeric(10);
 						warn.cancel(); // don't warn while waiting on user input
-						printf("Unlocking the database is a potentially dangerous operation.\n");
-						printf("%s\n", passPhrase.c_str());
+						fmt::println("Unlocking the database is a potentially dangerous operation.");
+						fmt::println("{}", passPhrase);
 						fflush(stdout);
-						Optional<std::string> input =
-						    wait(linenoise.read(format("Repeat the above passphrase if you would like to proceed:")));
+						Optional<std::string> input = wait(
+						    linenoise.read(fmt::format("Repeat the above passphrase if you would like to proceed:")));
 						warn =
 						    checkStatus(timeWarning(5.0, "\nWARNING: Long delay (Ctrl-C to interrupt)\n"), db, localDb);
 						if (input.present() && input.get() == passPhrase) {
@@ -1411,7 +1417,7 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise, Reference<ClusterCo
 							if (!_result)
 								is_error = true;
 						} else {
-							fprintf(stderr, "ERROR: Incorrect passphrase entered.\n");
+							fmt::println(stderr, "ERROR: Incorrect passphrase entered.");
 							is_error = true;
 						}
 					}
@@ -1430,14 +1436,14 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise, Reference<ClusterCo
 						printUsage(tokens[0]);
 						is_error = true;
 					} else if (intrans) {
-						fprintf(stderr, "ERROR: Already in transaction\n");
+						fmt::println(stderr, "ERROR: Already in transaction");
 						is_error = true;
 					} else {
 						activeOptions = FdbOptions(globalOptions);
 						options = &activeOptions;
 						intrans = true;
 						getTransaction(db, tr, options, false);
-						printf("Transaction started\n");
+						fmt::println("Transaction started");
 					}
 					continue;
 				}
@@ -1447,7 +1453,7 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise, Reference<ClusterCo
 						printUsage(tokens[0]);
 						is_error = true;
 					} else if (!intrans) {
-						fprintf(stderr, "ERROR: No active transaction\n");
+						fmt::println(stderr, "ERROR: No active transaction");
 						is_error = true;
 					} else {
 						warn =
@@ -1465,14 +1471,14 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise, Reference<ClusterCo
 						printUsage(tokens[0]);
 						is_error = true;
 					} else if (!intrans) {
-						fprintf(stderr, "ERROR: No active transaction\n");
+						fmt::println(stderr, "ERROR: No active transaction");
 						is_error = true;
 					} else {
 						tr->reset();
 						activeOptions = FdbOptions(globalOptions);
 						options = &activeOptions;
 						options->apply(tr);
-						printf("Transaction reset\n");
+						fmt::println("Transaction reset");
 					}
 					continue;
 				}
@@ -1482,12 +1488,12 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise, Reference<ClusterCo
 						printUsage(tokens[0]);
 						is_error = true;
 					} else if (!intrans) {
-						fprintf(stderr, "ERROR: No active transaction\n");
+						fmt::println(stderr, "ERROR: No active transaction");
 						is_error = true;
 					} else {
 						intrans = false;
 						options = &globalOptions;
-						printf("Transaction rolled back\n");
+						fmt::println("Transaction rolled back");
 					}
 					continue;
 				}
@@ -1502,9 +1508,9 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise, Reference<ClusterCo
 						Optional<Standalone<StringRef>> v = wait(makeInterruptable(safeThreadFutureToFuture(valueF)));
 
 						if (v.present())
-							printf("`%s' is `%s'\n", printable(tokens[1]).c_str(), printable(v.get()).c_str());
+							fmt::println("`{}' is `{}'", printable(tokens[1]), printable(v.get()));
 						else
-							printf("`%s': not found\n", printable(tokens[1]).c_str());
+							fmt::println("`{}': not found", printable(tokens[1]));
 					}
 					continue;
 				}
@@ -1539,7 +1545,7 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise, Reference<ClusterCo
 					} else {
 						Version v = wait(makeInterruptable(
 						    safeThreadFutureToFuture(getTransaction(db, tr, options, intrans)->getReadVersion())));
-						fmt::print("{}\n", v);
+						fmt::println("{}", v);
 					}
 					continue;
 				}
@@ -1579,9 +1585,9 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise, Reference<ClusterCo
 					if (!auditId.isValid()) {
 						is_error = true;
 					} else {
-						printf("%s audit: %s\n",
-						       tokencmp(tokens[1], "cancel") ? "Cancelled" : "Started",
-						       auditId.toString().c_str());
+						fmt::println("{} audit: {}",
+						             tokencmp(tokens[1], "cancel") ? "Cancelled" : "Started",
+						             auditId.toString());
 					}
 					continue;
 				}
@@ -1605,7 +1611,7 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise, Reference<ClusterCo
 				if (tokencmp(tokens[0], "bulkload")) {
 					UID taskId = wait(makeInterruptable(bulkLoadCommandActor(localDb, tokens)));
 					if (taskId.isValid()) {
-						printf("Received Job ID: %s\n", taskId.toString().c_str());
+						fmt::println("Received Job ID: {}", taskId.toString());
 					}
 					continue;
 				}
@@ -1613,7 +1619,7 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise, Reference<ClusterCo
 				if (tokencmp(tokens[0], "bulkdump")) {
 					UID jobId = wait(makeInterruptable(bulkDumpCommandActor(localDb, tokens)));
 					if (jobId.isValid()) {
-						printf("Received Job ID: %s\n", jobId.toString().c_str());
+						fmt::println("Received Job ID: {}", jobId.toString());
 					}
 					continue;
 				}
@@ -1678,7 +1684,7 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise, Reference<ClusterCo
 							// limit at the (already absurd)
 							// nearly-a-billion
 							if (tokens[3].size() > 9) {
-								fprintf(stderr, "ERROR: bad limit\n");
+								fmt::println(stderr, "ERROR: bad limit");
 								is_error = true;
 								continue;
 							}
@@ -1694,7 +1700,7 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise, Reference<ClusterCo
 								place *= 10;
 							}
 							if (!valid) {
-								fprintf(stderr, "ERROR: bad limit\n");
+								fmt::println(stderr, "ERROR: bad limit");
 								is_error = true;
 								continue;
 							}
@@ -1719,15 +1725,14 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise, Reference<ClusterCo
 						state ThreadFuture<RangeResult> kvsF = tr->getRange(KeyRangeRef(tokens[1], endKey), limit);
 						RangeResult kvs = wait(makeInterruptable(safeThreadFutureToFuture(kvsF)));
 
-						printf("\nRange limited to %d keys\n", limit);
+						fmt::print("\nRange limited to {} keys\n", limit);
 						for (auto iter = kvs.begin(); iter < kvs.end(); iter++) {
 							if (tokencmp(tokens[0], "getrangekeys"))
-								printf("`%s'\n", printable((*iter).key).c_str());
+								fmt::println("`{}'", printable((*iter).key));
 							else
-								printf(
-								    "`%s' is `%s'\n", printable((*iter).key).c_str(), printable((*iter).value).c_str());
+								fmt::println("`{}' is `{}'", printable((*iter).key), printable((*iter).value));
 						}
-						printf("\n");
+						fmt::println("");
 					}
 					continue;
 				}
@@ -1751,7 +1756,7 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise, Reference<ClusterCo
 
 				if (tokencmp(tokens[0], "set")) {
 					if (!writeMode) {
-						fprintf(stderr, "ERROR: writemode must be enabled to set or clear keys in the database.\n");
+						fmt::println(stderr, "ERROR: writemode must be enabled to set or clear keys in the database.");
 						is_error = true;
 						continue;
 					}
@@ -1772,7 +1777,7 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise, Reference<ClusterCo
 
 				if (tokencmp(tokens[0], "clear")) {
 					if (!writeMode) {
-						fprintf(stderr, "ERROR: writemode must be enabled to set or clear keys in the database.\n");
+						fmt::println(stderr, "ERROR: writemode must be enabled to set or clear keys in the database.");
 						is_error = true;
 						continue;
 					}
@@ -1793,7 +1798,7 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise, Reference<ClusterCo
 
 				if (tokencmp(tokens[0], "clearrange")) {
 					if (!writeMode) {
-						fprintf(stderr, "ERROR: writemode must be enabled to set or clear keys in the database.\n");
+						fmt::println(stderr, "ERROR: writemode must be enabled to set or clear keys in the database.");
 						is_error = true;
 						continue;
 					}
@@ -1826,11 +1831,11 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise, Reference<ClusterCo
 					} else {
 						if (tokens.size() == 1) {
 							if (options->hasAnyOptionsEnabled()) {
-								printf("\nCurrently enabled options:\n\n");
+								fmt::print("\nCurrently enabled options:\n\n");
 								options->print();
-								printf("\n");
+								fmt::println("");
 							} else
-								fprintf(stderr, "There are no options enabled\n");
+								fmt::println(stderr, "There are no options enabled");
 
 							continue;
 						}
@@ -1839,23 +1844,23 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise, Reference<ClusterCo
 							isOn = true;
 						} else if (tokencmp(tokens[1], "off")) {
 							if (intrans) {
-								fprintf(
+								fmt::println(
 								    stderr,
-								    "ERROR: Cannot turn option off when using a transaction created with `begin'\n");
+								    "ERROR: Cannot turn option off when using a transaction created with `begin'");
 								is_error = true;
 								continue;
 							}
 							if (tokens.size() > 3) {
-								fprintf(stderr, "ERROR: Cannot specify option argument when turning option off\n");
+								fmt::println(stderr, "ERROR: Cannot specify option argument when turning option off");
 								is_error = true;
 								continue;
 							}
 
 							isOn = false;
 						} else {
-							fprintf(stderr,
-							        "ERROR: Invalid option state `%s': option must be turned `on' or `off'\n",
-							        formatStringRef(tokens[1]).c_str());
+							fmt::println(stderr,
+							             "ERROR: Invalid option state `{}': option must be turned `on' or `off'",
+							             formatStringRef(tokens[1]));
 							is_error = true;
 							continue;
 						}
@@ -1864,9 +1869,9 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise, Reference<ClusterCo
 
 						try {
 							options->setOption(tr, tokens[2], isOn, arg, intrans);
-							printf("Option %s for %s\n",
-							       isOn ? "enabled" : "disabled",
-							       intrans ? "current transaction" : "all transactions");
+							fmt::println("Option {} for {}",
+							             isOn ? "enabled" : "disabled",
+							             intrans ? "current transaction" : "all transactions");
 						} catch (Error& e) {
 							// options->setOption() prints error message
 							TraceEvent(SevWarn, "CLISetOptionError").error(e).detail("Option", tokens[2]);
@@ -1908,7 +1913,7 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise, Reference<ClusterCo
 					continue;
 				}
 
-				fprintf(stderr, "ERROR: Unknown command `%s'. Try `help'?\n", formatStringRef(tokens[0]).c_str());
+				fmt::println(stderr, "ERROR: Unknown command `{}'. Try `help'?", formatStringRef(tokens[0]));
 				is_error = true;
 			}
 
@@ -1917,11 +1922,11 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise, Reference<ClusterCo
 			if (e.code() == error_code_operation_cancelled) {
 				throw;
 			} else if (e.code() != error_code_actor_cancelled) {
-				fprintf(stderr, "ERROR: %s (%d)\n", e.what(), e.code());
+				fmt::println(stderr, "ERROR: {} ({})", e.what(), e.code());
 			}
 			is_error = true;
 			if (intrans) {
-				printf("Rolling back current transaction\n");
+				fmt::println("Rolling back current transaction");
 				intrans = false;
 				options = &globalOptions;
 				options->apply(tr);
@@ -2017,7 +2022,7 @@ ACTOR Future<int> runCli(CLIOptions opt, Reference<ClusterConnectionFile> ccf) {
 
 ACTOR Future<Void> timeExit(double duration) {
 	wait(delay(duration));
-	fprintf(stderr, "Specified timeout reached -- exiting...\n");
+	fmt::println(stderr, "Specified timeout reached -- exiting...");
 	return Void();
 }
 
@@ -2089,7 +2094,7 @@ int main(int argc, char** argv) {
 		try {
 			setNetworkOption(FDBNetworkOptions::TLS_CERT_PATH, opt.tlsCertPath);
 		} catch (Error& e) {
-			fprintf(stderr, "ERROR: cannot set TLS certificate path to `%s' (%s)\n", opt.tlsCertPath.c_str(), e.what());
+			fmt::println(stderr, "ERROR: cannot set TLS certificate path to `{}' ({})", opt.tlsCertPath, e.what());
 			return 1;
 		}
 	}
@@ -2098,7 +2103,7 @@ int main(int argc, char** argv) {
 		try {
 			setNetworkOption(FDBNetworkOptions::TLS_CA_PATH, opt.tlsCAPath);
 		} catch (Error& e) {
-			fprintf(stderr, "ERROR: cannot set TLS CA path to `%s' (%s)\n", opt.tlsCAPath.c_str(), e.what());
+			fmt::println(stderr, "ERROR: cannot set TLS CA path to `{}' ({})", opt.tlsCAPath, e.what());
 			return 1;
 		}
 	}
@@ -2109,7 +2114,7 @@ int main(int argc, char** argv) {
 
 			setNetworkOption(FDBNetworkOptions::TLS_KEY_PATH, opt.tlsKeyPath);
 		} catch (Error& e) {
-			fprintf(stderr, "ERROR: cannot set TLS key path to `%s' (%s)\n", opt.tlsKeyPath.c_str(), e.what());
+			fmt::println(stderr, "ERROR: cannot set TLS key path to `{}' ({})", opt.tlsKeyPath, e.what());
 			return 1;
 		}
 	}
@@ -2117,8 +2122,7 @@ int main(int argc, char** argv) {
 		try {
 			setNetworkOption(FDBNetworkOptions::TLS_VERIFY_PEERS, opt.tlsVerifyPeers);
 		} catch (Error& e) {
-			fprintf(
-			    stderr, "ERROR: cannot set TLS peer verification to `%s' (%s)\n", opt.tlsVerifyPeers.c_str(), e.what());
+			fmt::println(stderr, "ERROR: cannot set TLS peer verification to `{}' ({})", opt.tlsVerifyPeers, e.what());
 			return 1;
 		}
 	}
@@ -2127,7 +2131,7 @@ int main(int argc, char** argv) {
 		try {
 			setNetworkOption(FDBNetworkOptions::TLS_DISABLE_PLAINTEXT_CONNECTION);
 		} catch (Error& e) {
-			fprintf(stderr, "ERROR: cannot disable non-TLS connections (%s)\n", e.what());
+			fmt::println(stderr, "ERROR: cannot disable non-TLS connections ({})", e.what());
 			return 1;
 		}
 	}
@@ -2135,26 +2139,27 @@ int main(int argc, char** argv) {
 	try {
 		setNetworkOption(FDBNetworkOptions::DISABLE_CLIENT_STATISTICS_LOGGING);
 	} catch (Error& e) {
-		fprintf(stderr, "ERROR: cannot disable logging client related information (%s)\n", e.what());
+		fmt::println(stderr, "ERROR: cannot disable logging client related information ({})", e.what());
 		return 1;
 	}
 
 	if (opt.debugTLS) {
 		// Backdoor into NativeAPI's tlsConfig, which is where the above network option settings ended up.
 		extern TLSConfig tlsConfig;
-		printf("TLS Configuration:\n");
-		printf("\tCertificate Path: %s\n", tlsConfig.getCertificatePathSync().c_str());
-		printf("\tKey Path: %s\n", tlsConfig.getKeyPathSync().c_str());
-		printf("\tCA Path: %s\n", tlsConfig.getCAPathSync().c_str());
-		printf("\tPlaintext Connection Disable: %s\n", tlsConfig.getDisablePlainTextConnection() ? "true" : "false");
+		fmt::println("TLS Configuration:");
+		fmt::println("\tCertificate Path: {}", tlsConfig.getCertificatePathSync());
+		fmt::println("\tKey Path: {}", tlsConfig.getKeyPathSync());
+		fmt::println("\tCA Path: {}", tlsConfig.getCAPathSync());
+		fmt::println("\tPlaintext Connection Disable: {}",
+		             tlsConfig.getDisablePlainTextConnection() ? "true" : "false");
 		try {
 			LoadedTLSConfig loaded = tlsConfig.loadSync();
-			printf("\tPassword: %s\n", loaded.getPassword().empty() ? "Not configured" : "Exists, but redacted");
-			printf("\n");
+			fmt::println("\tPassword: {}", loaded.getPassword().empty() ? "Not configured" : "Exists, but redacted");
+			fmt::println("");
 			loaded.print(stdout);
 		} catch (Error& e) {
-			fprintf(stderr, "ERROR: %s (%d)\n", e.what(), e.code());
-			printf("Use --log and look at the trace logs for more detailed information on the failure.\n");
+			fmt::println(stderr, "ERROR: {} ({})", e.what(), e.code());
+			fmt::println("Use --log and look at the trace logs for more detailed information on the failure.");
 			return 1;
 		}
 		return 0;
@@ -2169,13 +2174,13 @@ int main(int argc, char** argv) {
 		if (e.code() == error_code_operation_cancelled) {
 			throw;
 		}
-		fprintf(stderr, "%s\n", ClusterConnectionFile::getErrorString(resolvedClusterFile, e).c_str());
+		fmt::println(stderr, "{}", ClusterConnectionFile::getErrorString(resolvedClusterFile, e));
 		return 1;
 	}
 
 	// Make sure that TLS configuration lines up with ":tls" prefix on coordinator addresses
 	if (auto errorMsg = checkTlsConfigAgainstCoordAddrs(ccf->getConnectionString())) {
-		fprintf(stderr, "ERROR: %s\n", errorMsg);
+		fmt::println(stderr, "ERROR: {}", errorMsg);
 		return 1;
 	}
 
@@ -2201,7 +2206,7 @@ int main(int argc, char** argv) {
 			return 1;
 		}
 	} catch (Error& e) {
-		fprintf(stderr, "ERROR: %s (%d)\n", e.what(), e.code());
+		fmt::println(stderr, "ERROR: {} ({})", e.what(), e.code());
 		return 1;
 	}
 }

--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -1249,33 +1249,22 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise, Reference<ClusterCo
 						printHelpOverview();
 					} else if (tokens.size() == 2) {
 						if (tokencmp(tokens[1], "escaping"))
-							fmt::
-							    print(
-							        "\nWhen parsing commands, fdbcli considers a space to delimit individual "
-							        "tokens.\nTo include a space in a single token, you may either enclose the token "
-							        "in\nquotation marks (\\" hello
-							            world\\"), prefix the space with a backslash\n(hello\\ world), or encode the "
-							                   "space as a hex byte (hello\\x20world).\n\nTo include a literal "
-							                   "quotation mark in a token, precede it with a "
-							                   "backslash\n(\\\\" hello\\ world\\\\").\n\nTo express a binary value, "
-							                                                       "encode each byte as either\n   a) "
-							                                                       "a two-digit hex byte preceded by "
-							                                                       "\\x\n   b) a four-digit hex byte "
-							                                                       "in the range of 0x0000-0x00FF "
-							                                                       "preceded by \\u\n(e.g. \\x20 or "
-							                                                       "\\u0020 for a space character, or "
-							                                                       "\\x0a\\x00\\x00\\x00 "
-							                                                       "or\n\\u000a\\u0000\\u0000\\u0000 "
-							                                                       "for a 32-bit, little-endian "
-							                                                       "representation of\nthe integer 10. "
-							                                                       " Any byte can use either syntax, "
-							                                                       "so \\u000a\\x00\\x00\\x00\nis also "
-							                                                       "a valid representation of a "
-							                                                       "little-endian value of 10).\n\nAll "
-							                                                       "keys and values are displayed by "
-							                                                       "the fdbcli with non-printable "
-							                                                       "characters\nand spaces encoded as "
-							                                                       "two-digit hex bytes.\n\n");
+							fmt::print(
+							    "\nWhen parsing commands, fdbcli considers a space to delimit individual tokens.\n"
+							    "To include a space in a single token, you may either enclose the token in\n"
+							    "quotation marks (\"hello world\"), prefix the space with a backslash\n"
+							    "(hello\\ world), or encode the space as a hex byte (hello\\x20world).\n\n"
+							    "To include a literal quotation mark in a token, precede it with a backslash\n"
+							    "(\\\"hello\\ world\\\").\n\n"
+							    "To express a binary value, encode each byte as either\n"
+							    "   a) a two-digit hex byte preceded by \\x\n"
+							    "   b) a four-digit hex byte in the range of 0x0000-0x00FF preceded by \\u\n"
+							    "(e.g. \\x20 or \\u0020 for a space character, or \\x0a\\x00\\x00\\x00 or\n"
+							    "\\u000a\\u0000\\u0000\\u0000 for a 32-bit, little-endian representation of\n"
+							    "the integer 10. Any byte can use either syntax, so \\u000a\\x00\\x00\\x00\n"
+							    "is also a valid representation of a little-endian value of 10).\n\n"
+							    "All keys and values are displayed by the fdbcli with non-printable characters\n"
+							    "and spaces encoded as two-digit hex bytes.\n\n");
 						else if (tokencmp(tokens[1], "options")) {
 							fmt::print(
 							    "\nThe following options are available to be set using the `option' command:\n\n");


### PR DESCRIPTION
The `fmt` library is already an available dependency, and it has several advantages over `format`, `printf`, `sprintf`, etc.:

- Stronger compile-time type safety checks
- Better performance
- Compatibility with C++20 standard functions like `std::format`, making a future migration to STL easier

More details are available at https://fmt.dev/12.0/. `fmt` is already in use in some places, so this PR helps standardize formatting across the repo. In future PRs, other libraries can be updated to use `fmt` consistently.

This PR was implemented using a treesitter-based tool that rewrites string formatting functions with `fmt` equivalents.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
