### PR TITLE
Monitor and Update Progress of BackupWorkers

### DIFF
--- a/fdbclient/SystemData.cpp
+++ b/fdbclient/SystemData.cpp
@@ -1075,23 +1075,6 @@ const KeyRef backupProgressPrefix = backupProgressKeys.begin;
 const KeyRef backupStartedKey = "\xff\x02/backupStarted"_sr;
 extern const KeyRef backupPausedKey = "\xff\x02/backupPaused"_sr;
 
-// Backup keys related to Range Partitioned.
-const KeyRef backupRangePartitionedMapUploadedPrefix = "\xff\x02/backupRangePartitionedMapUploaded/"_sr;
-const KeyRangeRef backupRangePartitionedProgressKeys("\xff\x02/backupRangePartitionedProgress/"_sr,
-                                                     "\xff\x02/backupRangePartitionedProgress0"_sr);
-const KeyRef backupRangePartitionedProgressPrefix = backupRangePartitionedProgressKeys.begin;
-
-Key backupRangePartitionedMapUploadedKeyFor(Version v) {
-	return backupRangePartitionedMapUploadedPrefix.withSuffix(format("%lld", v));
-}
-
-Key backupRangePartitionedProgressKey(UID workerID) {
-	BinaryWriter wr(Unversioned());
-	wr.serializeBytes(backupRangePartitionedProgressPrefix);
-	wr << workerID;
-	return wr.toValue();
-}
-
 Key backupProgressKeyFor(UID workerID) {
 	BinaryWriter wr(Unversioned());
 	wr.serializeBytes(backupProgressPrefix);
@@ -1135,6 +1118,43 @@ std::vector<std::pair<UID, Version>> decodeBackupStartedValue(const ValueRef& va
 
 bool mutationForKey(const MutationRef& m, const KeyRef& key) {
 	return isSingleKeyMutation((MutationRef::Type)m.type) && m.param1 == key;
+}
+
+// Backup keys related to Range Partitioned.
+const KeyRef backupRangePartitionedMapUploadedPrefix = "\xff\x02/backupRangePartitionedMapUploaded/"_sr;
+const KeyRangeRef backupRangePartitionedProgressKeys("\xff\x02/backupRangePartitionedProgress/"_sr,
+                                                     "\xff\x02/backupRangePartitionedProgress0"_sr);
+const KeyRef backupRangePartitionedProgressPrefix = backupRangePartitionedProgressKeys.begin;
+
+Key backupRangePartitionedMapUploadedKeyFor(Version v) {
+	return backupRangePartitionedMapUploadedPrefix.withSuffix(format("%lld", v));
+}
+
+Key backupRangePartitionedProgressKey(UID workerID) {
+	BinaryWriter wr(Unversioned());
+	wr.serializeBytes(backupRangePartitionedProgressPrefix);
+	wr << workerID;
+	return wr.toValue();
+}
+
+Value backupRangePartitionedProgressValue(const WorkerBackupStatus& status) {
+	BinaryWriter wr(IncludeVersion(ProtocolVersion::withBackupProgressValue()));
+	wr << status;
+	return wr.toValue();
+}
+
+UID decodeBackupRangePartitionedProgressKey(const KeyRef& key) {
+	UID serverID;
+	BinaryReader rd(key.removePrefix(backupRangePartitionedProgressPrefix), Unversioned());
+	rd >> serverID;
+	return serverID;
+}
+
+WorkerBackupStatus decodeBackupRangePartitionedProgressValue(const ValueRef& value) {
+	WorkerBackupStatus status;
+	BinaryReader reader(value, IncludeVersion());
+	reader >> status;
+	return status;
 }
 
 const KeyRef previousCoordinatorsKey = "\xff/previousCoordinators"_sr;

--- a/fdbclient/include/fdbclient/SystemData.h
+++ b/fdbclient/include/fdbclient/SystemData.h
@@ -427,6 +427,9 @@ WorkerBackupStatus decodeBackupProgressValue(const ValueRef& value);
 extern const KeyRangeRef backupRangePartitionedProgressKeys;
 extern const KeyRef backupRangePartitionedProgressPrefix;
 Key backupRangePartitionedProgressKey(UID workerID);
+Value backupRangePartitionedProgressValue(const WorkerBackupStatus& status);
+UID decodeBackupRangePartitionedProgressKey(const KeyRef& key);
+WorkerBackupStatus decodeBackupRangePartitionedProgressValue(const ValueRef& value);
 
 // The key to signal when partition map has been uploaded for a given version.
 //    "\xff\x02/backupRangePartitionedMapUploaded/<version>" := "1"

--- a/fdbserver/backupworker/BackupWorker.cpp
+++ b/fdbserver/backupworker/BackupWorker.cpp
@@ -588,7 +588,7 @@ Future<Void> monitorBackupProgress(BackupData* self) {
 		// check all workers have started by checking their progress is larger
 		// than the backup's start version.
 		Reference<BackupProgress> progress(new BackupProgress(self->myId, {}));
-		co_await getBackupProgress(self->cx, self->myId, progress, /*logging=*/false);
+		co_await getBackupProgress(self->cx, self->myId, progress, SevDebug);
 		std::map<Tag, Version> tagVersions = progress->getEpochStatus(self->recruitedEpoch);
 		std::map<UID, Version> savedLogVersions;
 		if (tagVersions.size() != self->totalTags) {

--- a/fdbserver/backupworker/BackupWorkerRangePartitioned.cpp
+++ b/fdbserver/backupworker/BackupWorkerRangePartitioned.cpp
@@ -765,8 +765,29 @@ Future<Void> saveMutationsToFile(BackupRangePartitionedData* self, Version lastV
 	}
 }
 
+static Future<Void> updateLogBytesWritten(BackupRangePartitionedData* self,
+                                          std::vector<UID> backupUids,
+                                          std::vector<Reference<IBackupFile>> logFiles) {
+	// TODO akanksha: Implement in next PR.
+	co_return;
+}
+
+static Future<bool> shouldBackupWorkerExitEarly(BackupRangePartitionedData* self) {
+	// TODO akanksha: Implement in next PR.
+	co_return true;
+}
+
+static Future<Void> monitorBackupStartedKeyChanges(BackupRangePartitionedData* self) {
+	// TODO akanksha: Implement in next PR.
+	co_return;
+}
+
 Future<Void> setBackupKeys(BackupRangePartitionedData* self, std::map<UID, Version> savedLogVersions) {
 	// TODO akanksha: Implement in next PR.
+	co_return;
+}
+
+static Future<Void> monitorWorkerPause(BackupRangePartitionedData* self) {
 	co_return;
 }
 
@@ -813,7 +834,6 @@ Future<Void> monitorBackupRangePartitionedProgress(BackupRangePartitionedData* s
 	}
 }
 
-// TODO akanksha: Implement getBackupRangePartitionedProgress during Monitoring.
 Future<Void> saveProgress(BackupRangePartitionedData* self, Version backupVersion) {
 	Transaction tr(self->cx);
 	Key key = backupRangePartitionedProgressKey(self->myId);
@@ -928,6 +948,7 @@ Future<Void> backupWorkerRangePartitioned(BackupInterface interf,
 	PromiseStream<Future<Void>> addActor;
 	Future<Void> error = actorCollection(addActor.getFuture());
 	Future<Void> dbInfoChange = Void();
+	Future<Void> pull;
 	Future<Void> done;
 	Error err;
 
@@ -947,11 +968,33 @@ Future<Void> backupWorkerRangePartitioned(BackupInterface interf,
 			addActor.send(monitorBackupRangePartitionedProgress(&self));
 		}
 
+		// If the worker is on an old epoch and all backups starts a version >= the endVersion
+		bool exitEarly = co_await shouldBackupWorkerExitEarly(&self);
+		TraceEvent("BWRangePartitionedExitEarly", self.myId).detail("ExitEarly", exitEarly);
+		if (!exitEarly) {
+			addActor.send(monitorBackupStartedKeyChanges(&self));
+		}
+
+		pull = exitEarly ? Void() : pullAsyncData(&self);
+		addActor.send(pull);
+		done = exitEarly ? Void() : uploadData(&self);
+
 		while (true) {
 			auto res = co_await race(dbInfoChange, done, error);
 			if (res.index() == 0) {
 				dbInfoChange = db->onChange();
-				[[maybe_unused]] Reference<ILogSystem> ls = makeLogSystemFromServerDBInfo(self.myId, db->get(), true);
+				Reference<ILogSystem> ls = makeLogSystemFromServerDBInfo(self.myId, db->get(), true);
+
+				if (ls.isValid()) {
+					self.logSystem.set(ls);
+					self.oldestBackupEpoch = std::max(self.oldestBackupEpoch, ls->getOldestBackupEpoch());
+					TraceEvent("BWRangePartitionedLogSystemUpdate", self.myId)
+					    .detail("Tag", self.tag.toString())
+					    .detail("TagLocality", self.tag.locality)
+					    .detail("OldestEpoch", self.oldestBackupEpoch);
+				} else {
+					TraceEvent("BWRangePartitionedNoLogSystem", self.myId);
+				}
 			} else if (res.index() == 1) {
 				TraceEvent("BWRangePartitionedDone", self.myId).detail("BackupEpoch", self.backupEpoch);
 				// Notify master so that this worker can be removed from log system, then this
@@ -969,6 +1012,7 @@ Future<Void> backupWorkerRangePartitioned(BackupInterface interf,
 	}
 
 	if (err.code() == error_code_worker_removed) {
+		pull = Void(); // cancels pulling
 		try {
 			co_await done;
 		} catch (Error& shutdownErr) {

--- a/fdbserver/backupworker/BackupWorkerRangePartitioned.cpp
+++ b/fdbserver/backupworker/BackupWorkerRangePartitioned.cpp
@@ -803,7 +803,7 @@ Future<Void> monitorBackupRangePartitionedProgress(BackupRangePartitionedData* s
 		// check all workers have started by checking their progress is larger
 		// than the backup's start version.
 		Reference<BackupRangePartitionedProgress> progress(new BackupRangePartitionedProgress(self->myId));
-		co_await getBackupRangePartitionedProgress(self->cx, self->myId, progress, /*logging=*/false);
+		co_await getBackupRangePartitionedProgress(self->cx, self->myId, progress, SevDebug);
 
 		std::map<Tag, Version> tagVersions = progress->getEpochStatus(self->recruitedEpoch);
 		if (tagVersions.size() != self->totalTags) {

--- a/fdbserver/backupworker/BackupWorkerRangePartitioned.cpp
+++ b/fdbserver/backupworker/BackupWorkerRangePartitioned.cpp
@@ -71,6 +71,8 @@ struct BackupRangePartitionedData {
 	const Optional<Version> endVersion; // old epoch's end version (inclusive), or empty for current epoch
 	const LogEpoch recruitedEpoch; // current epoch whose tLogs are receiving mutations
 	const LogEpoch backupEpoch; // the epoch workers should pull mutations
+	// TODO akanksha: Update oldestBackupEpoch wherever needed.
+	LogEpoch oldestBackupEpoch = 0; // oldest epoch that still has data on tLogs for backup to pull
 	// Minimumum known committed version in StorageServers.
 	Version minKnownCommittedVersion;
 	Version savedVersion; // Largest version saved to blob storage
@@ -815,6 +817,57 @@ Future<Void> saveMutationsToFile(BackupRangePartitionedData* self, Version lastV
 
 	for (auto& lf : activeFiles) {
 		self->backups[lf.backupUid].nextFileBeginVersion = lastVersionInFile + 1;
+	}
+}
+
+Future<Void> setBackupKeys(BackupData* self, std::map<UID, Version> savedLogVersions) {
+	// TODO akanksha: Implement in next PR.
+	co_return;
+}
+
+// TODO akanksha: Do we need a new class BackupProgress.h for Backup V3???
+Future<Void> monitorBackupProgress(BackupRangePartitionedData* self) {
+	Future<Void> interval;
+
+	while (true) {
+		interval = delay(SERVER_KNOBS->BACKUP_PROGRESS_SAVE_INTERVAL);
+		while (self->backups.empty() || !self->logSystem.get()) {
+			co_await (self->changedTrigger.onTrigger() || self->logSystem.onChange());
+		}
+
+		// check all workers have started by checking their progress is larger
+		// than the backup's start version.
+		Reference<BackupProgress> progress(new BackupProgress(self->myId, /*infos=*/{}));
+		// TODO akanksha: getBackupProgress for this worker defined in BackupProgress.cpp - based on progress key, fetch
+		// the progress.
+		co_await getBackupProgress(self->cx, self->myId, progress, /*logging=*/false);
+
+		std::map<Tag, Version> tagVersions = progress->getEpochStatus(self->recruitedEpoch);
+		if (tagVersions.size() != self->totalTags) {
+			co_await interval;
+			continue;
+		}
+
+		std::map<UID, Version> savedLogVersions;
+		// update progress so far if previous epochs are done.
+		if (self->recruitedEpoch == self->oldestBackupEpoch) {
+			Version v = std::numeric_limits<Version>::max();
+			// Find the version we can gurantee is fully backed up for all backup workers.
+			for (const auto& [tag, version] : tagVersions) {
+				v = std::min(v, version);
+			}
+
+			for (auto& [uid, info] : self->backups) {
+				savedLogVersions.emplace(uid, v);
+				TraceEvent("BWRangePartitionedSavedBackupVersion", self->myId)
+				    .detail("BackupID", uid)
+				    .detail("Version", v);
+			}
+		}
+
+		// TODO akanksha: Implement and explain what setBackupKeys does in next PR.
+		Future<Void> setKeys = savedLogVersions.empty() ? Void() : setBackupKeys(self, savedLogVersions);
+		co_await (interval && setKeys);
 	}
 }
 

--- a/fdbserver/backupworker/BackupWorkerRangePartitioned.cpp
+++ b/fdbserver/backupworker/BackupWorkerRangePartitioned.cpp
@@ -330,66 +330,6 @@ Future<Void> checkRemoved(Reference<AsyncVar<ServerDBInfo> const> db,
 	}
 }
 
-Future<Void> backupWorkerRangePartitioned(BackupInterface interf,
-                                          InitializeBackupRequest req,
-                                          Reference<AsyncVar<ServerDBInfo> const> db) {
-	BackupRangePartitionedData self(interf.id(), db, req);
-	PromiseStream<Future<Void>> addActor;
-	Future<Void> error = actorCollection(addActor.getFuture());
-	Future<Void> dbInfoChange = Void();
-	Future<Void> done;
-	Error err;
-
-	TraceEvent("BWRangePartitionedStart", self.myId)
-	    .detail("Tag", req.routerTag.toString())
-	    .detail("TotalTags", req.totalTags)
-	    .detail("StartVersion", req.startVersion)
-	    .detail("EndVersion", req.endVersion.present() ? req.endVersion.get() : -1)
-	    .detail("LogEpoch", req.recruitedEpoch)
-	    .detail("BackupEpoch", req.backupEpoch);
-
-	try {
-		addActor.send(checkRemoved(db, req.recruitedEpoch, &self));
-		addActor.send(waitFailureServer(interf.waitFailure.getFuture()));
-
-		if (req.recruitedEpoch == req.backupEpoch && req.routerTag.id == 0) {
-			addActor.send(monitorBackupProgress(&self));
-		}
-
-		while (true) {
-			auto res = co_await race(dbInfoChange, done, error);
-			if (res.index() == 0) {
-				dbInfoChange = db->onChange();
-				[[maybe_unused]] Reference<ILogSystem> ls = makeLogSystemFromServerDBInfo(self.myId, db->get(), true);
-			} else if (res.index() == 1) {
-				TraceEvent("BWRangePartitionedDone", self.myId).detail("BackupEpoch", self.backupEpoch);
-				// Notify master so that this worker can be removed from log system, then this
-				// worker (for an old epoch's unfinished work) can safely exit.
-				co_await brokenPromiseToNever(db->get().clusterInterface.notifyBackupWorkerDone.getReply(
-				    BackupWorkerDoneRequest(self.myId, self.backupEpoch)));
-				break;
-			} else if (res.index() != 2) {
-				UNREACHABLE();
-			}
-		}
-		co_return;
-	} catch (Error& e) {
-		err = e;
-	}
-
-	if (err.code() == error_code_worker_removed) {
-		try {
-			co_await done;
-		} catch (Error& shutdownErr) {
-			TraceEvent("BWRangePartitionedShutdownError", self.myId).errorUnsuppressed(shutdownErr);
-		}
-	}
-	TraceEvent("BWRangePartitionedTerminated", self.myId).errorUnsuppressed(err);
-	if (err.code() != error_code_actor_cancelled && err.code() != error_code_worker_removed) {
-		throw err;
-	}
-}
-
 Future<Version> pullPartitionMapFromTLog(BackupRangePartitionedData* self, PartitionMap* outPartitionMap) {
 	Reference<ILogSystem::IPeekCursor> cursor;
 	Version partitionMapVersion = invalidVersion;
@@ -978,5 +918,65 @@ Future<Void> uploadData(BackupRangePartitionedData* self) {
 		if (!self->pullFinished()) {
 			co_await (uploadDelay || self->doneTrigger.onTrigger());
 		}
+	}
+}
+
+Future<Void> backupWorkerRangePartitioned(BackupInterface interf,
+                                          InitializeBackupRequest req,
+                                          Reference<AsyncVar<ServerDBInfo> const> db) {
+	BackupRangePartitionedData self(interf.id(), db, req);
+	PromiseStream<Future<Void>> addActor;
+	Future<Void> error = actorCollection(addActor.getFuture());
+	Future<Void> dbInfoChange = Void();
+	Future<Void> done;
+	Error err;
+
+	TraceEvent("BWRangePartitionedStart", self.myId)
+	    .detail("Tag", req.routerTag.toString())
+	    .detail("TotalTags", req.totalTags)
+	    .detail("StartVersion", req.startVersion)
+	    .detail("EndVersion", req.endVersion.present() ? req.endVersion.get() : -1)
+	    .detail("LogEpoch", req.recruitedEpoch)
+	    .detail("BackupEpoch", req.backupEpoch);
+
+	try {
+		addActor.send(checkRemoved(db, req.recruitedEpoch, &self));
+		addActor.send(waitFailureServer(interf.waitFailure.getFuture()));
+
+		if (req.recruitedEpoch == req.backupEpoch && req.routerTag.id == 0) {
+			addActor.send(monitorBackupRangePartitionedProgress(&self));
+		}
+
+		while (true) {
+			auto res = co_await race(dbInfoChange, done, error);
+			if (res.index() == 0) {
+				dbInfoChange = db->onChange();
+				[[maybe_unused]] Reference<ILogSystem> ls = makeLogSystemFromServerDBInfo(self.myId, db->get(), true);
+			} else if (res.index() == 1) {
+				TraceEvent("BWRangePartitionedDone", self.myId).detail("BackupEpoch", self.backupEpoch);
+				// Notify master so that this worker can be removed from log system, then this
+				// worker (for an old epoch's unfinished work) can safely exit.
+				co_await brokenPromiseToNever(db->get().clusterInterface.notifyBackupWorkerDone.getReply(
+				    BackupWorkerDoneRequest(self.myId, self.backupEpoch)));
+				break;
+			} else if (res.index() != 2) {
+				UNREACHABLE();
+			}
+		}
+		co_return;
+	} catch (Error& e) {
+		err = e;
+	}
+
+	if (err.code() == error_code_worker_removed) {
+		try {
+			co_await done;
+		} catch (Error& shutdownErr) {
+			TraceEvent("BWRangePartitionedShutdownError", self.myId).errorUnsuppressed(shutdownErr);
+		}
+	}
+	TraceEvent("BWRangePartitionedTerminated", self.myId).errorUnsuppressed(err);
+	if (err.code() != error_code_actor_cancelled && err.code() != error_code_worker_removed) {
+		throw err;
 	}
 }

--- a/fdbserver/backupworker/BackupWorkerRangePartitioned.cpp
+++ b/fdbserver/backupworker/BackupWorkerRangePartitioned.cpp
@@ -25,10 +25,11 @@
 #include "fdbclient/SystemData.h"
 #include "fdbclient/Tracing.h"
 #include "BackupPartitionMap.h"
+#include "fdbserver/core/BackupRangePartitionedProgress.h"
 #include "fdbserver/core/Knobs.h"
 #include "fdbserver/core/LogSystem.h"
-#include "fdbserver/logsystem/LogSystemFactory.h"
 #include "fdbserver/core/WaitFailure.h"
+#include "fdbserver/logsystem/LogSystemFactory.h"
 #include "flow/CoroUtils.h"
 
 #define SevDebugMemory SevVerbose
@@ -350,6 +351,10 @@ Future<Void> backupWorkerRangePartitioned(BackupInterface interf,
 	try {
 		addActor.send(checkRemoved(db, req.recruitedEpoch, &self));
 		addActor.send(waitFailureServer(interf.waitFailure.getFuture()));
+
+		if (req.recruitedEpoch == req.backupEpoch && req.routerTag.id == 0) {
+			addActor.send(monitorBackupProgress(&self));
+		}
 
 		while (true) {
 			auto res = co_await race(dbInfoChange, done, error);
@@ -820,27 +825,24 @@ Future<Void> saveMutationsToFile(BackupRangePartitionedData* self, Version lastV
 	}
 }
 
-Future<Void> setBackupKeys(BackupData* self, std::map<UID, Version> savedLogVersions) {
+Future<Void> setBackupKeys(BackupRangePartitionedData* self, std::map<UID, Version> savedLogVersions) {
 	// TODO akanksha: Implement in next PR.
 	co_return;
 }
 
-// TODO akanksha: Do we need a new class BackupProgress.h for Backup V3???
-Future<Void> monitorBackupProgress(BackupRangePartitionedData* self) {
+Future<Void> monitorBackupRangePartitionedProgress(BackupRangePartitionedData* self) {
 	Future<Void> interval;
 
 	while (true) {
-		interval = delay(SERVER_KNOBS->BACKUP_PROGRESS_SAVE_INTERVAL);
+		interval = delay(SERVER_KNOBS->WORKER_LOGGING_INTERVAL / 2.0);
 		while (self->backups.empty() || !self->logSystem.get()) {
 			co_await (self->changedTrigger.onTrigger() || self->logSystem.onChange());
 		}
 
 		// check all workers have started by checking their progress is larger
 		// than the backup's start version.
-		Reference<BackupProgress> progress(new BackupProgress(self->myId, /*infos=*/{}));
-		// TODO akanksha: getBackupProgress for this worker defined in BackupProgress.cpp - based on progress key, fetch
-		// the progress.
-		co_await getBackupProgress(self->cx, self->myId, progress, /*logging=*/false);
+		Reference<BackupRangePartitionedProgress> progress(new BackupRangePartitionedProgress(self->myId));
+		co_await getBackupRangePartitionedProgress(self->cx, self->myId, progress, /*logging=*/false);
 
 		std::map<Tag, Version> tagVersions = progress->getEpochStatus(self->recruitedEpoch);
 		if (tagVersions.size() != self->totalTags) {
@@ -871,7 +873,7 @@ Future<Void> monitorBackupProgress(BackupRangePartitionedData* self) {
 	}
 }
 
-// TODO akanksha: Implement getBackupProgress during Monitoring.
+// TODO akanksha: Implement getBackupRangePartitionedProgress during Monitoring.
 Future<Void> saveProgress(BackupRangePartitionedData* self, Version backupVersion) {
 	Transaction tr(self->cx);
 	Key key = backupRangePartitionedProgressKey(self->myId);
@@ -893,7 +895,7 @@ Future<Void> saveProgress(BackupRangePartitionedData* self, Version backupVersio
 			}
 
 			WorkerBackupStatus status(self->backupEpoch, backupVersion, self->tag, self->totalTags);
-			tr.set(key, backupProgressValue(status));
+			tr.set(key, backupRangePartitionedProgressValue(status));
 			tr.addReadConflictRange(singleKeyRange(key));
 			co_await tr.commit();
 			co_return;

--- a/fdbserver/clustercontroller/ClusterRecovery.actor.cpp
+++ b/fdbserver/clustercontroller/ClusterRecovery.actor.cpp
@@ -664,7 +664,7 @@ ACTOR static Future<Void> recruitBackupWorkers(Reference<ClusterRecoveryData> se
 	state LogEpoch epoch = self->cstate.myDBState.recoveryCount;
 	state Reference<BackupProgress> backupProgress(
 	    new BackupProgress(self->dbgid, self->logSystem->getOldEpochTagsVersionsInfo()));
-	state Future<Void> gotProgress = getBackupProgress(cx, self->dbgid, backupProgress, /*logging=*/true);
+	state Future<Void> gotProgress = getBackupProgress(cx, self->dbgid, backupProgress, SevInfo);
 	state std::vector<Future<InitializeBackupReply>> initializationReplies;
 
 	state std::vector<std::pair<UID, Tag>> idsTags; // worker IDs and tags for current epoch

--- a/fdbserver/core/BackupProgress.cpp
+++ b/fdbserver/core/BackupProgress.cpp
@@ -143,7 +143,7 @@ std::map<std::tuple<LogEpoch, Version, int>, std::map<Tag, Version>> BackupProgr
 }
 
 // Save each tag's savedVersion for all epochs into "bStatus".
-Future<Void> getBackupProgress(Database cx, UID dbgid, Reference<BackupProgress> bStatus, bool logging) {
+Future<Void> getBackupProgress(Database cx, UID dbgid, Reference<BackupProgress> bStatus, Severity severity) {
 	Transaction tr(cx);
 
 	while (true) {
@@ -162,14 +162,12 @@ Future<Void> getBackupProgress(Database cx, UID dbgid, Reference<BackupProgress>
 				const UID workerID = decodeBackupProgressKey(it.key);
 				const WorkerBackupStatus status = decodeBackupProgressValue(it.value);
 				bStatus->addBackupStatus(status);
-				if (logging) {
-					TraceEvent("GotBackupProgress", dbgid)
-					    .detail("BackupWorker", workerID)
-					    .detail("Epoch", status.epoch)
-					    .detail("Version", status.version)
-					    .detail("Tag", status.tag.toString())
-					    .detail("TotalTags", status.totalTags);
-				}
+				TraceEvent(severity, "GotBackupProgress", dbgid)
+				    .detail("BackupWorker", workerID)
+				    .detail("Epoch", status.epoch)
+				    .detail("Version", status.version)
+				    .detail("Tag", status.tag.toString())
+				    .detail("TotalTags", status.totalTags);
 			}
 			co_return;
 		} catch (Error& e) {

--- a/fdbserver/core/BackupRangePartitionedProgress.cpp
+++ b/fdbserver/core/BackupRangePartitionedProgress.cpp
@@ -39,7 +39,7 @@ void BackupRangePartitionedProgress::addBackupStatus(const WorkerBackupStatus& s
 Future<Void> getBackupRangePartitionedProgress(Database cx,
                                                UID dbgid,
                                                Reference<BackupRangePartitionedProgress> bStatus,
-                                               bool logging) {
+                                               Severity severity) {
 	Transaction tr(cx);
 
 	while (true) {
@@ -56,14 +56,13 @@ Future<Void> getBackupRangePartitionedProgress(Database cx,
 				const UID workerID = decodeBackupRangePartitionedProgressKey(it.key);
 				const WorkerBackupStatus status = decodeBackupRangePartitionedProgressValue(it.value);
 				bStatus->addBackupStatus(status);
-				if (logging) {
-					TraceEvent("GotBackupRangePartitionedProgress", dbgid)
-					    .detail("BackupWorker", workerID)
-					    .detail("Epoch", status.epoch)
-					    .detail("Version", status.version)
-					    .detail("Tag", status.tag.toString())
-					    .detail("TotalTags", status.totalTags);
-				}
+
+				TraceEvent(severity, "GotBackupRangePartitionedProgress", dbgid)
+				    .detail("BackupWorker", workerID)
+				    .detail("Epoch", status.epoch)
+				    .detail("Version", status.version)
+				    .detail("Tag", status.tag.toString())
+				    .detail("TotalTags", status.totalTags);
 			}
 			co_return;
 		} catch (Error& e) {

--- a/fdbserver/core/BackupRangePartitionedProgress.cpp
+++ b/fdbserver/core/BackupRangePartitionedProgress.cpp
@@ -1,0 +1,75 @@
+/*
+ * BackupRangePartitionedProgress.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "fdbserver/core/BackupRangePartitionedProgress.h"
+
+#include "fdbclient/NativeAPI.actor.h"
+#include "fdbclient/SystemData.h"
+
+void BackupRangePartitionedProgress::addBackupStatus(const WorkerBackupStatus& status) {
+	auto& it = progress[status.epoch];
+	auto lb = it.lower_bound(status.tag);
+	if (lb != it.end() && status.tag == lb->first) {
+		if (lb->second < status.version) {
+			lb->second = status.version;
+		}
+	} else {
+		it.insert(lb, { status.tag, status.version });
+	}
+}
+
+// Save each tag's savedVersion for all epochs into "bStatus".
+Future<Void> getBackupRangePartitionedProgress(Database cx,
+                                               UID dbgid,
+                                               Reference<BackupRangePartitionedProgress> bStatus,
+                                               bool logging) {
+	Transaction tr(cx);
+
+	while (true) {
+		Error err;
+		try {
+			tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+			tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
+			tr.setOption(FDBTransactionOptions::LOCK_AWARE);
+
+			RangeResult results = co_await tr.getRange(backupRangePartitionedProgressKeys, CLIENT_KNOBS->TOO_MANY);
+			ASSERT(!results.more && results.size() < CLIENT_KNOBS->TOO_MANY);
+
+			for (auto& it : results) {
+				const UID workerID = decodeBackupRangePartitionedProgressKey(it.key);
+				const WorkerBackupStatus status = decodeBackupRangePartitionedProgressValue(it.value);
+				bStatus->addBackupStatus(status);
+				if (logging) {
+					TraceEvent("GotBackupRangePartitionedProgress", dbgid)
+					    .detail("BackupWorker", workerID)
+					    .detail("Epoch", status.epoch)
+					    .detail("Version", status.version)
+					    .detail("Tag", status.tag.toString())
+					    .detail("TotalTags", status.totalTags);
+				}
+			}
+			co_return;
+		} catch (Error& e) {
+			err = e;
+		}
+
+		co_await tr.onError(err);
+	}
+}

--- a/fdbserver/core/include/fdbserver/core/BackupProgress.h
+++ b/fdbserver/core/include/fdbserver/core/BackupProgress.h
@@ -99,4 +99,4 @@ private:
 	Optional<Value> backupStartedValue;
 };
 
-Future<Void> getBackupProgress(Database cx, UID dbgid, Reference<BackupProgress> bStatus, bool logging);
+Future<Void> getBackupProgress(Database cx, UID dbgid, Reference<BackupProgress> bStatus, Severity severity);

--- a/fdbserver/core/include/fdbserver/core/BackupRangePartitionedProgress.h
+++ b/fdbserver/core/include/fdbserver/core/BackupRangePartitionedProgress.h
@@ -62,4 +62,4 @@ private:
 Future<Void> getBackupRangePartitionedProgress(Database cx,
                                                UID dbgid,
                                                Reference<BackupRangePartitionedProgress> bStatus,
-                                               bool logging);
+                                               Severity severity);

--- a/fdbserver/core/include/fdbserver/core/BackupRangePartitionedProgress.h
+++ b/fdbserver/core/include/fdbserver/core/BackupRangePartitionedProgress.h
@@ -1,0 +1,65 @@
+/*
+ * BackupRangePartitionedProgress.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <map>
+#include <tuple>
+
+#include "fdbclient/FDBTypes.h"
+#include "fdbserver/core/LogSystem.h"
+#include "flow/Arena.h"
+#include "flow/FastRef.h"
+
+class BackupRangePartitionedProgress : NonCopyable, ReferenceCounted<BackupRangePartitionedProgress> {
+public:
+	BackupRangePartitionedProgress(UID id) : dbgid(id) {}
+	~BackupRangePartitionedProgress() {}
+
+	// Adds a backup status. If the tag already has an entry, then the max of
+	// savedVersion is used.
+	void addBackupStatus(const WorkerBackupStatus& status);
+
+	// Returns progress for an epoch.
+	std::map<Tag, Version> getEpochStatus(LogEpoch epoch) const {
+		const auto it = progress.find(epoch);
+		if (it == progress.end())
+			return {};
+		return it->second;
+	}
+
+	void addref() { ReferenceCounted<BackupRangePartitionedProgress>::addref(); }
+
+	void delref() { ReferenceCounted<BackupRangePartitionedProgress>::delref(); }
+
+private:
+	// Used for logging and debugging purpose to identify which backup progress it is.
+	const UID dbgid;
+
+	// Backup progress saved in the system keyspace. Note there can be multiple
+	// progress status for a tag in an epoch due to later epoch trying to fill
+	// the gap. "progress" MUST be iterated in ascending order.
+	std::map<LogEpoch, std::map<Tag, Version>> progress;
+};
+
+Future<Void> getBackupRangePartitionedProgress(Database cx,
+                                               UID dbgid,
+                                               Reference<BackupRangePartitionedProgress> bStatus,
+                                               bool logging);


### PR DESCRIPTION
This PR implements:
1. `monitorBackupRangePartitionedProgress` which reads the progress of all backup workers and set up backupkeys accordingly.
2. New file `BackupRangePartitionedProgress` that has minimal functions needed as of now (because it doesn't need log router stuff and key name and their respective decoding functions will be different).
3.  Complete 'BackupWorkerRangePartitioned' which calls multiple actors like `pullAsync`, `uploadData`, `shouldExitEarly` etc
4. Add decoding of backupProgressKeys and it's value
 
### Flow:

1. Each backup worker uses a key in the key range  \xff\x02/backupRangePartitionedProgress/
   which is \xff\x02/backupRangePartitionedProgress/<workerID>
   
   UID_abc123 is backup worker id
┌────────────────────────────── ──┐
 │   FDB System Keyspace (backupRangePartitionedProgressKeys range)              |         
 │─────────────────────────────────┤
 │                                                                                                                           │
 │ Key:   \xff\x02/backupRangePartitionedProgress/<UID_abc123>                                            │
 │ Value: {epoch: 5, pop version: 1000000, tag: Tag(-2,0), totalTags: 3}       │
│        ↑ Worker 0 progress                                                                                │
│                                                                                                                           │
│ Key:   \xff\x02/backupRangePartitionedProgress/<UID_def456>                                            │
│ Value: {epoch: 5, pop version: 999500, tag: Tag(-2,1), totalTags: 3}         │
│        ↑ Worker 1 progress                                                                                 │
│                                                                                                                            │
│ Key:   \xff\x02/backupRangePartitionedProgress/<UID_ghi789>                                             │
│ Value: {epoch: 5, pop version: 1001000, tag: Tag(-2,2), totalTags: 3}       │
│        ↑ Worker 2 progress                                                                                │
│                                                                                                                           │
└────────────────────────────────┘

4. Each worker periodically calls saveProgress() to write to the database. Each worker writes it progress (Value) (same for all backups it is handling).

5. Only Worker 0 calls BackupWorker.monitorBackupRangePartitionedProgress() which further calls BackupRangePartitionedProgress.getBackupRangePartitionedProgress.

6. BackupProgress.getBackupRangePartitionedProgress:
    a. It reads all the keys and values in tr.getRange(backupRangePartitionedProgressKeys) which is \xff\x02/backupRangePartitionedProgress/ and gets
	    a flat list of key value pairs. For ex:

```
UID_a is backup worker id.

results = [
    		{key: "/progress/UID_a", value: {epoch: 5, version: 1.8M, tag: (-2,0), totalTags: 3}},
    		{key: "/progress/UID_b", value: {epoch: 5, version: 1.7M, tag: (-2,1), totalTags: 3}},
    		{key: "/progress/UID_c", value: {epoch: 5, version: 1.9M, tag: (-2,2), totalTags: 3}},
    		{key: "/progress/UID_d", value: {epoch: 6, version: 2.1M, tag: (-2,0), totalTags: 3}},
    		{key: "/progress/UID_e", value: {epoch: 6, version: 2.0M, tag: (-2,1), totalTags: 3}},
    		{key: "/progress/UID_f", value: {epoch: 6, version: 2.2M, tag: (-2,2), totalTags: 3}}
	    ]


```

    b.  It Iterates over all keys and values, and constructs the progress map for each epoch. For ex:

```
progress = {
			5: {  // Group all Epoch 5 workers together
				Tag(-2,0): 1.8M,
				Tag(-2,1): 1.7M, 
				Tag(-2,2): 1.9M
			},
			6: {  // Group all Epoch 6 workers together
				Tag(-2,0): 2.1M,
				Tag(-2,1): 2.0M,
				Tag(-2,2): 2.2M
			}
	    }
```
		bStatus->addBackupStatus(status);

7.  Now BackupWorker calls progress->getEpochStatus(recuitedEpoch) to get the progress of all workers in the recruited epoch. 
    For ex:
		
```
tagVersions = {
			Tag(-2,0): 1.8M,
			Tag(-2,1): 1.7M, 
			Tag(-2,2): 1.9M
		}
```

8. It iterates over all tagVersions and find minimum version backup up among all workers and set the backup keys. according.