### PR TITLE
Cherry-pick two recent SimpleCounters related PRs to release-7.4

### DIFF
--- a/flow/Arena.cpp
+++ b/flow/Arena.cpp
@@ -107,7 +107,6 @@ void makeUndefined(void*, size_t) {}
 #endif
 } // namespace
 
-
 static SimpleCounter<int64_t>* arenasCreated(void) {
 	static SimpleCounter<int64_t>* p = SimpleCounter<int64_t>::makeCounter("/flow/arena/arenasCreated");
 	return p;

--- a/flow/Arena.cpp
+++ b/flow/Arena.cpp
@@ -117,7 +117,6 @@ Arena::Arena() : impl(nullptr) {
 	arenasCreated()->increment(1);
 }
 
->>>>>>> dd891027a (Address issues noticed by retroactive AI code review (#12930))
 Arena::Arena(size_t reservedSize) : impl(0) {
 	UNSTOPPABLE_ASSERT(reservedSize < std::numeric_limits<int>::max());
 	arenasCreated()->increment(1);

--- a/flow/Arena.cpp
+++ b/flow/Arena.cpp
@@ -107,11 +107,20 @@ void makeUndefined(void*, size_t) {}
 #endif
 } // namespace
 
-Arena::Arena() : impl(nullptr) {}
+
+static SimpleCounter<int64_t>* arenasCreated(void) {
+	static SimpleCounter<int64_t>* p = SimpleCounter<int64_t>::makeCounter("/flow/arena/arenasCreated");
+	return p;
+}
+
+Arena::Arena() : impl(nullptr) {
+	arenasCreated()->increment(1);
+}
+
+>>>>>>> dd891027a (Address issues noticed by retroactive AI code review (#12930))
 Arena::Arena(size_t reservedSize) : impl(0) {
 	UNSTOPPABLE_ASSERT(reservedSize < std::numeric_limits<int>::max());
-	static SimpleCounter<int64_t>* created = SimpleCounter<int64_t>::makeCounter("/flow/arena/arenasCreated");
-	created->increment(1);
+	arenasCreated()->increment(1);
 	if (reservedSize) {
 		allowAccess(impl.getPtr());
 		ArenaBlock::create((int)reservedSize, impl);

--- a/flow/Net2.actor.cpp
+++ b/flow/Net2.actor.cpp
@@ -24,6 +24,7 @@
 #include "flow/Arena.h"
 #include "flow/Knobs.h"
 #include "flow/Platform.h"
+#include "flow/SimpleCounter.h"
 #include "flow/Trace.h"
 #include "flow/swift.h"
 #include "flow/swift_concurrency_hooks.h"
@@ -1670,6 +1671,7 @@ void Net2::run() {
 		[[maybe_unused]] int queueSize = taskQueue.getNumReadyTasks();
 
 		FDB_TRACE_PROBE(run_loop_tasks_start, queueSize);
+		int tasksExecuted = 0;
 		while (taskQueue.hasReadyTask()) {
 			++countTasks;
 			currentTaskID = taskQueue.getReadyTaskID();
@@ -1678,6 +1680,7 @@ void Net2::run() {
 			taskQueue.popReadyTask();
 
 			try {
+				++tasksExecuted;
 				++tasksSinceReact;
 				(*task)();
 			} catch (Error& e) {
@@ -1713,6 +1716,9 @@ void Net2::run() {
 			taskBegin = newTaskBegin;
 			tscBegin = tscNow;
 		}
+		static SimpleCounter<int64_t>* callbacksExecuted =
+		    SimpleCounter<int64_t>::makeCounter("/Net2/callbacksExecuted");
+		callbacksExecuted->increment(tasksExecuted);
 
 		trackAtPriority(TaskPriority::RunLoop, taskBegin);
 
@@ -1764,16 +1770,23 @@ void Net2::run() {
 		}
 #endif
 		nnow = timer_monotonic();
+		auto time_delta = nnow - now;
 
-		if ((nnow - now) > FLOW_KNOBS->SLOW_LOOP_CUTOFF &&
-		    nondeterministicRandom()->random01() < (nnow - now) * FLOW_KNOBS->SLOW_LOOP_SAMPLING_RATE)
-			TraceEvent("SomewhatSlowRunLoopBottom")
-			    .detail("Elapsed", nnow - now); // This includes the time spent running tasks
+		static SimpleCounter<double>* exec_time = SimpleCounter<double>::makeCounter("/Net2/mainThreadExecutionTime");
+		exec_time->increment(time_delta);
+
+		if (time_delta > FLOW_KNOBS->SLOW_LOOP_CUTOFF &&
+		    nondeterministicRandom()->random01() < time_delta * FLOW_KNOBS->SLOW_LOOP_SAMPLING_RATE) {
+			TraceEvent("SomewhatSlowRunLoopBottom").detail("Elapsed", time_delta);
+		}
 	}
 
 	for (auto& fn : stopCallbacks) {
 		fn();
 	}
+
+	// Emit at least one batch of counters, for manual inspection.
+	simpleCounterReport();
 
 #ifdef WIN32
 	timeEndPeriod(1);

--- a/flow/include/flow/SimpleCounter.h
+++ b/flow/include/flow/SimpleCounter.h
@@ -44,15 +44,10 @@
 // synchronous work in side threads, but is intended to generally be very
 // light weight.  `makeCounter` can be called in constructors of global objects.
 //
-// If you want to use hierarchical metric names (e.g., '/'-separated
-// components), please use ALL LOWER CASE METRIC NAMES AS PER THE EXAMPLE ABOVE.
-// This enables the implementation to smuggle path component
-// separators into the trace output by replacing path separaters like '/' with
-// carefully chosen capital letters.  This obtains compatibility with current FDB
-// "field name" naming conventions.
-//
+// Hierarchical counter names with '/' separaters are encouraged.
 // In the future we might replace '/' with '_' to obtain Prometheus-compatible
-// metric names that don't actually look terrible.
+// metric names that don't actually look terrible. For now software does this
+// conversion on back-end TraceEvent generation.
 //
 // If you don't want to use hierarchical metric names, then your counter
 // names should be ReallyVerboseConcatenatedNamesWithCaps and must be globally

--- a/flow/include/flow/Trace.h
+++ b/flow/include/flow/Trace.h
@@ -136,7 +136,6 @@ public:
 	Field& mutate(int index);
 
 	std::string toString() const;
-	void validateFormat() const;
 	template <class Archiver>
 	void serialize(Archiver& ar) {
 		static_assert(is_fb_function<Archiver>, "Streaming serializer has to use load/save");


### PR DESCRIPTION
release-7.4 has the main SimpleCounters PRs.  This cherry-picks two recent small additions which are in main:

0f58ac5895292f585023c24c5b394a14d9d4be7f
dd891027ac2af104da03b99ef577c6bdaa107273

WIth this PR, the intent is for release-7.4 to have the same functionality as main.  release-7.3 is also getting this functionality by way of https://github.com/apple/foundationdb/pull/12937 (which is larger, because release-7.3 doesn't currently have the base functionality).

Testing (in progress):
  20260413-215003-gglass-14696c1825cf1c8c            compressed=True data_size=41359228 duration=4639483 ended=99997 fail_fast=1000 max_runs=100000 pass=99997 priority=100 remaining=0:00:00 runtime=2:09:29 sanity=False started=100000 submitted=20260413-215003 timeout=5400 username=gglass

