### PR TITLE
Convert `FailureMonitor.actor.cpp` to standard coroutines

### DIFF
--- a/fdbrpc/FailureMonitor.actor.cpp
+++ b/fdbrpc/FailureMonitor.actor.cpp
@@ -19,27 +19,27 @@
  */
 
 #include "fdbrpc/FailureMonitor.h"
-#include "flow/actorcompiler.h" // This must be the last #include.
+#include "flow/CoroUtils.h"
 
-ACTOR Future<Void> waitForStateEqual(IFailureMonitor* monitor, Endpoint endpoint, FailureStatus status) {
-	loop {
+Future<Void> waitForStateEqual(IFailureMonitor* monitor, Endpoint endpoint, FailureStatus status) {
+	while (true) {
 		Future<Void> change = monitor->onStateChanged(endpoint);
 		if (monitor->getState(endpoint) == status)
-			return Void();
-		wait(change);
+			co_return;
+		co_await change;
 	}
 }
 
-ACTOR Future<Void> waitForContinuousFailure(IFailureMonitor* monitor,
-                                            Endpoint endpoint,
-                                            double sustainedFailureDuration,
-                                            double slope) {
-	state double startT = now();
+Future<Void> waitForContinuousFailure(IFailureMonitor* monitor,
+                                      Endpoint endpoint,
+                                      double sustainedFailureDuration,
+                                      double slope) {
+	double startT = now();
 
-	loop {
-		wait(monitor->onFailed(endpoint));
+	while (true) {
+		co_await monitor->onFailed(endpoint);
 		if (monitor->permanentlyFailed(endpoint))
-			return Void();
+			co_return;
 
 		// X == sustainedFailureDuration + slope * (now()-startT+X)
 		double waitDelay = (sustainedFailureDuration + slope * (now() - startT)) / (1 - slope);
@@ -50,12 +50,14 @@ ACTOR Future<Void> waitForContinuousFailure(IFailureMonitor* monitor,
 		             FLOW_KNOBS->SERVER_REQUEST_INTERVAL)) // We will not get a failure monitoring update in this amount
 		                                                   // of time, so there is no point in waiting for changes
 			waitDelay = 0;
-		choose {
-			when(wait(monitor->onStateEqual(endpoint, FailureStatus(false)))) {
-			} // SOMEDAY: Use onStateChanged() for efficiency
-			when(wait(delay(waitDelay))) {
-				return Void();
-			}
+
+		auto res = co_await race(monitor->onStateEqual(endpoint, FailureStatus(false)), delay(waitDelay));
+		if (res.index() == 0) {
+			// SOMEDAY: Use onStateChanged() for efficiency
+		} else if (res.index() == 1) {
+			co_return;
+		} else {
+			UNREACHABLE();
 		}
 	}
 }

--- a/fdbrpc/FailureMonitor.actor.cpp
+++ b/fdbrpc/FailureMonitor.actor.cpp
@@ -51,13 +51,10 @@ Future<Void> waitForContinuousFailure(IFailureMonitor* monitor,
 		                                                   // of time, so there is no point in waiting for changes
 			waitDelay = 0;
 
-		auto res = co_await race(monitor->onStateEqual(endpoint, FailureStatus(false)), delay(waitDelay));
-		if (res.index() == 0) {
-			// SOMEDAY: Use onStateChanged() for efficiency
-		} else if (res.index() == 1) {
+		// SOMEDAY: Use onStateChanged() for efficiency
+		if (auto healthy = co_await timeout(monitor->onStateEqual(endpoint, FailureStatus(false)), waitDelay);
+		    !healthy.present()) {
 			co_return;
-		} else {
-			UNREACHABLE();
 		}
 	}
 }

--- a/fdbrpc/FailureMonitor.cpp
+++ b/fdbrpc/FailureMonitor.cpp
@@ -1,5 +1,5 @@
 /*
- * FailureMonitor.actor.cpp
+ * FailureMonitor.cpp
  *
  * This source file is part of the FoundationDB open source project
  *


### PR DESCRIPTION
This small PR continues the deprecation of Flow, using the same actor rewrite tool as other PRs

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
