### PR TITLE
Extend `generic_coro` namespace

### DIFF
--- a/flow/genericactors.actor.cpp
+++ b/flow/genericactors.actor.cpp
@@ -20,6 +20,7 @@
 
 #include "flow/flow.h"
 #include "flow/UnitTest.h"
+#include "flow/genericcoros.h"
 #include "flow/actorcompiler.h" // This must be the last #include.
 
 ACTOR Future<bool> allTrue(std::vector<Future<bool>> all) {
@@ -237,6 +238,16 @@ static Future<ErrorOr<Void>> badTestFuture(double duration, Error e) {
 	return tag(delay(duration), ErrorOr<Void>(e));
 }
 
+ACTOR Future<int> getErrorCode(Future<int> future) {
+	try {
+		int value = wait(future);
+		(void)value;
+		return 0;
+	} catch (Error& e) {
+		return e.code();
+	}
+}
+
 } // namespace
 
 TEST_CASE("/flow/genericactors/AsyncListener") {
@@ -280,6 +291,68 @@ TEST_CASE("/flow/genericactors/WaitForMost") {
 			ASSERT_EQ(e.code(), error_code_operation_failed);
 		}
 	}
+	return Void();
+}
+
+TEST_CASE("/flow/genericcoros/ThrowErrorOr") {
+	int value = wait(generic_coro::throwErrorOr<int>(Future<ErrorOr<int>>(ErrorOr<int>(7))));
+	ASSERT_EQ(value, 7);
+
+	int errorCode =
+	    wait(getErrorCode(generic_coro::throwErrorOr<int>(Future<ErrorOr<int>>(ErrorOr<int>(operation_failed())))));
+	ASSERT_EQ(errorCode, error_code_operation_failed);
+
+	return Void();
+}
+
+TEST_CASE("/flow/genericcoros/TraceAfter") {
+	int value = wait(generic_coro::traceAfter<int>(Future<int>(7), "GenericCorosTraceAfter"));
+	ASSERT_EQ(value, 7);
+
+	int errorCode = wait(
+	    getErrorCode(generic_coro::traceAfter<int>(Future<int>(operation_failed()), "GenericCorosTraceAfterError")));
+	ASSERT_EQ(errorCode, error_code_operation_failed);
+
+	return Void();
+}
+
+TEST_CASE("/flow/genericcoros/TransformErrors") {
+	int value = wait(generic_coro::transformErrors<int>(Future<int>(7), operation_failed()));
+	ASSERT_EQ(value, 7);
+
+	int errorCode =
+	    wait(getErrorCode(generic_coro::transformErrors<int>(Future<int>(transaction_too_old()), operation_failed())));
+	ASSERT_EQ(errorCode, error_code_operation_failed);
+
+	return Void();
+}
+
+TEST_CASE("/flow/genericcoros/WaitForAllReady") {
+	state std::vector<Future<int>> results;
+	results = { Future<int>(1), Future<int>(operation_failed()), Future<int>(3) };
+
+	wait(generic_coro::waitForAllReady<int>(results));
+
+	return Void();
+}
+
+TEST_CASE("/flow/genericcoros/Timeout") {
+	int readyValue = wait(generic_coro::timeout<int>(Future<int>(7), 0.0, -1));
+	ASSERT_EQ(readyValue, 7);
+
+	int timedOutValue = wait(generic_coro::timeout<int>(Future<int>(Never()), 0.0, -1));
+	ASSERT_EQ(timedOutValue, -1);
+
+	Optional<int> readyOptional = wait(generic_coro::timeout<int>(Future<int>(7), 0.0));
+	ASSERT(readyOptional.present());
+	ASSERT_EQ(readyOptional.get(), 7);
+
+	Optional<int> timedOutOptional = wait(generic_coro::timeout<int>(Future<int>(Never()), 0.0));
+	ASSERT(!timedOutOptional.present());
+
+	int errorCode = wait(getErrorCode(generic_coro::timeoutError<int>(Future<int>(Never()), 0.0)));
+	ASSERT_EQ(errorCode, error_code_timed_out);
+
 	return Void();
 }
 

--- a/flow/genericactors.actor.cpp
+++ b/flow/genericactors.actor.cpp
@@ -200,6 +200,11 @@ ACTOR Future<Void> lowPriorityDelayAfterCleared(Reference<AsyncVar<bool>> condit
 	}
 }
 
+struct SetAsyncVarTrue {
+	Reference<AsyncVar<bool>> value;
+	void operator()() const { value->set(true); }
+};
+
 namespace {
 
 struct DummyState {
@@ -207,11 +212,6 @@ struct DummyState {
 	int unchanged{ 0 };
 	bool operator==(DummyState const& rhs) const { return changed == rhs.changed && unchanged == rhs.unchanged; }
 	bool operator!=(DummyState const& rhs) const { return !(*this == rhs); }
-};
-
-struct SetAsyncVarTrue {
-	Reference<AsyncVar<bool>> value;
-	void operator()() const { value->set(true); }
 };
 
 ACTOR Future<Void> testPublisher(Reference<AsyncVar<DummyState>> input) {

--- a/flow/genericactors.actor.cpp
+++ b/flow/genericactors.actor.cpp
@@ -209,6 +209,11 @@ struct DummyState {
 	bool operator!=(DummyState const& rhs) const { return !(*this == rhs); }
 };
 
+struct SetAsyncVarTrue {
+	Reference<AsyncVar<bool>> value;
+	void operator()() const { value->set(true); }
+};
+
 ACTOR Future<Void> testPublisher(Reference<AsyncVar<DummyState>> input) {
 	state int i = 0;
 	for (; i < 100; ++i) {
@@ -242,6 +247,15 @@ ACTOR Future<int> getErrorCode(Future<int> future) {
 	try {
 		int value = wait(future);
 		(void)value;
+		return 0;
+	} catch (Error& e) {
+		return e.code();
+	}
+}
+
+ACTOR Future<int> getVoidErrorCode(Future<Void> future) {
+	try {
+		wait(future);
 		return 0;
 	} catch (Error& e) {
 		return e.code();
@@ -377,6 +391,40 @@ TEST_CASE("/flow/genericcoros/Delayed") {
 
 	int errorCode = wait(getErrorCode(generic_coro::delayed<int>(Future<int>(operation_failed()))));
 	ASSERT_EQ(errorCode, error_code_operation_failed);
+
+	return Void();
+}
+
+TEST_CASE("/flow/genericcoros/Trigger") {
+	state Reference<AsyncVar<bool>> called = makeReference<AsyncVar<bool>>(false);
+	state Promise<Void> signal;
+	state Future<Void> triggered = generic_coro::trigger(SetAsyncVarTrue{ called }, signal.getFuture());
+
+	ASSERT(!called->get());
+	ASSERT(!triggered.isReady());
+
+	signal.send(Void());
+	wait(triggered);
+	ASSERT(called->get());
+
+	called->set(false);
+	int errorCode =
+	    wait(getVoidErrorCode(generic_coro::trigger(SetAsyncVarTrue{ called }, Future<Void>(operation_failed()))));
+	ASSERT_EQ(errorCode, error_code_operation_failed);
+	ASSERT(!called->get());
+
+	return Void();
+}
+
+TEST_CASE("/flow/genericcoros/TriggerOnError") {
+	state Reference<AsyncVar<bool>> called = makeReference<AsyncVar<bool>>(false);
+	wait(generic_coro::triggerOnError(SetAsyncVarTrue{ called }, Future<Void>(Void())));
+	ASSERT(!called->get());
+
+	int errorCode = wait(
+	    getVoidErrorCode(generic_coro::triggerOnError(SetAsyncVarTrue{ called }, Future<Void>(operation_failed()))));
+	ASSERT_EQ(errorCode, 0);
+	ASSERT(called->get());
 
 	return Void();
 }

--- a/flow/genericactors.actor.cpp
+++ b/flow/genericactors.actor.cpp
@@ -327,6 +327,21 @@ TEST_CASE("/flow/genericcoros/TransformErrors") {
 	return Void();
 }
 
+TEST_CASE("/flow/genericcoros/TransformError") {
+	int value = wait(generic_coro::transformError<int>(Future<int>(7), transaction_too_old(), operation_failed()));
+	ASSERT_EQ(value, 7);
+
+	int transformedErrorCode = wait(getErrorCode(generic_coro::transformError<int>(
+	    Future<int>(transaction_too_old()), transaction_too_old(), operation_failed())));
+	ASSERT_EQ(transformedErrorCode, error_code_operation_failed);
+
+	int preservedErrorCode = wait(getErrorCode(
+	    generic_coro::transformError<int>(Future<int>(process_behind()), transaction_too_old(), operation_failed())));
+	ASSERT_EQ(preservedErrorCode, error_code_process_behind);
+
+	return Void();
+}
+
 TEST_CASE("/flow/genericcoros/WaitForAllReady") {
 	state std::vector<Future<int>> results;
 	results = { Future<int>(1), Future<int>(operation_failed()), Future<int>(3) };
@@ -352,6 +367,16 @@ TEST_CASE("/flow/genericcoros/Timeout") {
 
 	int errorCode = wait(getErrorCode(generic_coro::timeoutError<int>(Future<int>(Never()), 0.0)));
 	ASSERT_EQ(errorCode, error_code_timed_out);
+
+	return Void();
+}
+
+TEST_CASE("/flow/genericcoros/Delayed") {
+	int value = wait(generic_coro::delayed<int>(Future<int>(7)));
+	ASSERT_EQ(value, 7);
+
+	int errorCode = wait(getErrorCode(generic_coro::delayed<int>(Future<int>(operation_failed()))));
+	ASSERT_EQ(errorCode, error_code_operation_failed);
 
 	return Void();
 }

--- a/flow/include/flow/genericcoros.h
+++ b/flow/include/flow/genericcoros.h
@@ -163,4 +163,18 @@ Future<T> timeoutError(Future<T> what,
 	}
 }
 
+template <class T>
+Future<T> delayed(Future<T> what,
+                  double time = 0.0,
+                  TaskPriority taskID = TaskPriority::DefaultDelay,
+                  ExplicitVoid = {}) {
+	ErrorOr<T> t = co_await coro::errorOr(what);
+	co_await delay(time, taskID);
+	if (t.present()) {
+		co_return std::move(t).get();
+	} else {
+		throw t.getError();
+	}
+}
+
 } // namespace generic_coro

--- a/flow/include/flow/genericcoros.h
+++ b/flow/include/flow/genericcoros.h
@@ -62,6 +62,15 @@ Future<Optional<T>> stopAfter(Future<T> what, ExplicitVoid = {}) {
 }
 
 template <class T>
+Future<T> throwErrorOr(Future<ErrorOr<T>> f, ExplicitVoid = {}) {
+	ErrorOr<T> t = co_await f;
+	if (t.isError()) {
+		throw t.getError();
+	}
+	co_return std::move(t).get();
+}
+
+template <class T>
 Future<Void> waitForAllReady(std::vector<Future<T>> results) {
 	for (auto const& result : results) {
 		if (result.isReady()) {

--- a/flow/include/flow/genericcoros.h
+++ b/flow/include/flow/genericcoros.h
@@ -177,4 +177,18 @@ Future<T> delayed(Future<T> what,
 	}
 }
 
+template <class Func>
+Future<Void> trigger(Func what, Future<Void> signal) {
+	co_await signal;
+	what();
+}
+
+template <class Func>
+Future<Void> triggerOnError(Func what, Future<Void> signal) {
+	ErrorOr<Void> res = co_await coro::errorOr(coro::ignore(signal));
+	if (res.isError()) {
+		what();
+	}
+}
+
 } // namespace generic_coro

--- a/flow/include/flow/genericcoros.h
+++ b/flow/include/flow/genericcoros.h
@@ -71,6 +71,19 @@ Future<T> throwErrorOr(Future<ErrorOr<T>> f, ExplicitVoid = {}) {
 }
 
 template <class T>
+Future<T> transformErrors(Future<T> f, Error err, ExplicitVoid = {}) {
+	ErrorOr<T> t = co_await coro::errorOr(f);
+	if (t.present()) {
+		co_return std::move(t).get();
+	}
+	Error e = t.getError();
+	if (e.code() == error_code_actor_cancelled) {
+		throw e;
+	}
+	throw err;
+}
+
+template <class T>
 Future<Void> waitForAllReady(std::vector<Future<T>> results) {
 	for (auto const& result : results) {
 		if (result.isReady()) {

--- a/flow/include/flow/genericcoros.h
+++ b/flow/include/flow/genericcoros.h
@@ -84,6 +84,19 @@ Future<T> transformErrors(Future<T> f, Error err, ExplicitVoid = {}) {
 }
 
 template <class T>
+Future<T> transformError(Future<T> f, Error inErr, Error outErr, ExplicitVoid = {}) {
+	ErrorOr<T> t = co_await coro::errorOr(f);
+	if (t.present()) {
+		co_return std::move(t).get();
+	}
+	Error e = t.getError();
+	if (e.code() == inErr.code()) {
+		throw outErr;
+	}
+	throw e;
+}
+
+template <class T>
 Future<Void> waitForAllReady(std::vector<Future<T>> results) {
 	for (auto const& result : results) {
 		if (result.isReady()) {

--- a/flow/include/flow/genericcoros.h
+++ b/flow/include/flow/genericcoros.h
@@ -28,6 +28,40 @@
 namespace generic_coro {
 
 template <class T>
+Future<T> traceAfter(Future<T> what, std::string type, bool traceErrors = true) {
+	try {
+		T val = co_await what;
+		TraceEvent(type.c_str());
+		co_return val;
+	} catch (Error& e) {
+		// Don't trace operation_cancelled as it's a normal control flow mechanism, not an error
+		if (traceErrors && e.code() != error_code_operation_cancelled) {
+			TraceEvent(type.c_str()).errorUnsuppressed(e);
+		}
+		throw;
+	}
+}
+
+template <class T>
+Future<Optional<T>> stopAfter(Future<T> what) {
+	Optional<T> ret = T();
+	try {
+		T res = co_await what;
+		ret = Optional<T>(res);
+	} catch (Error& e) {
+		bool ok = e.code() == error_code_please_reboot || e.code() == error_code_please_reboot_delete ||
+		          e.code() == error_code_actor_cancelled || e.code() == error_code_local_config_changed;
+		TraceEvent(ok ? SevInfo : SevError, "StopAfterError").error(e);
+		if (!ok) {
+			fprintf(stderr, "Fatal Error: %s\n", e.what());
+			ret = Optional<T>();
+		}
+	}
+	g_network->stop();
+	co_return ret;
+}
+
+template <class T>
 Future<Void> waitForAllReady(std::vector<Future<T>> results) {
 	for (auto const& result : results) {
 		if (result.isReady()) {

--- a/flow/include/flow/genericcoros.h
+++ b/flow/include/flow/genericcoros.h
@@ -58,4 +58,40 @@ Future<T> timeout(Future<T> what,
 	}
 }
 
+template <class T>
+Future<Optional<T>> timeout(Future<T> what,
+                            double time,
+                            TaskPriority taskID = TaskPriority::DefaultDelay,
+                            ExplicitVoid = {}) {
+	if (what.canGet()) {
+		co_return what.get();
+	} else if (what.isError()) {
+		throw what.getError();
+	}
+	auto res = co_await race(what, delay(time, taskID));
+	if (res.index() == 0) {
+		co_return std::get<0>(std::move(res));
+	} else {
+		co_return Optional<T>();
+	}
+}
+
+template <class T>
+Future<T> timeoutError(Future<T> what,
+                       double time,
+                       TaskPriority taskID = TaskPriority::DefaultDelay,
+                       ExplicitVoid = {}) {
+	if (what.canGet()) {
+		co_return what.get();
+	} else if (what.isError()) {
+		throw what.getError();
+	}
+	auto res = co_await race(what, delay(time, taskID));
+	if (res.index() == 0) {
+		co_return std::get<0>(std::move(res));
+	} else {
+		throw timed_out();
+	}
+}
+
 } // namespace generic_coro

--- a/flow/include/flow/genericcoros.h
+++ b/flow/include/flow/genericcoros.h
@@ -28,7 +28,7 @@
 namespace generic_coro {
 
 template <class T>
-Future<T> traceAfter(Future<T> what, std::string type, bool traceErrors = true) {
+Future<T> traceAfter(Future<T> what, std::string type, bool traceErrors = true, ExplicitVoid = {}) {
 	try {
 		T val = co_await what;
 		TraceEvent(type.c_str());
@@ -43,7 +43,7 @@ Future<T> traceAfter(Future<T> what, std::string type, bool traceErrors = true) 
 }
 
 template <class T>
-Future<Optional<T>> stopAfter(Future<T> what) {
+Future<Optional<T>> stopAfter(Future<T> what, ExplicitVoid = {}) {
 	Optional<T> ret = T();
 	try {
 		T res = co_await what;


### PR DESCRIPTION
This PR builds on https://github.com/apple/foundationdb/pull/12901 to port more of `flow/include/flow/genericactors.actor.h` to standard coroutines in the `generic_coro` namespace. Unit tests are added in `genericactors.actor.cpp`.

The next steps are:

- Add additional microbenchmarks in `flow/bench`, optimizing as necessary
- Add a CMake variable to statically select `generic_coro` implementations or legacy `ACTOR` implementations of generic actors
- Run end-to-end performance comparisons with Mako
- Once performance is acceptable, deprecate the CMake variable and remove `genericactors.actor.h`, only using the new standard coroutine implementations

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
