### PR TITLE
Use rocksdb 8.11.4 as before 

### DIFF
--- a/cmake/CompileRocksDB.cmake
+++ b/cmake/CompileRocksDB.cmake
@@ -1,6 +1,6 @@
 # FindRocksDB
 
-find_package(RocksDB 8.11.5)
+find_package(RocksDB 8.11.4)
 
 include(ExternalProject)
 
@@ -49,8 +49,8 @@ if(ROCKSDB_FOUND)
       ${BINARY_DIR}/librocksdb.a)
 else()
   ExternalProject_Add(rocksdb
-    URL https://github.com/facebook/rocksdb/archive/refs/tags/v8.11.5.tar.gz
-    URL_HASH SHA256=2641eb63ee2d691c0e96de0a55edfcc4cab181d9b6c31fa4a33c478423062196
+    URL https://github.com/facebook/rocksdb/archive/refs/tags/v8.11.4.tar.gz
+    URL_HASH SHA256=1b84c7d7214360fd536349917c57ebd5030d5b4fc214a343ba628b0c6e3d2711
     CMAKE_ARGS ${RocksDB_CMAKE_ARGS}
     BUILD_BYPRODUCTS <BINARY_DIR>/librocksdb.a
     INSTALL_COMMAND ""

--- a/fdbserver/include/fdbserver/FDBRocksDBVersion.h
+++ b/fdbserver/include/fdbserver/FDBRocksDBVersion.h
@@ -23,6 +23,6 @@
 
 #define FDB_ROCKSDB_MAJOR 8
 #define FDB_ROCKSDB_MINOR 11
-#define FDB_ROCKSDB_PATCH 5
+#define FDB_ROCKSDB_PATCH 4
 
 #endif


### PR DESCRIPTION
This reverts commit ce08c22c1b2de036d7d66d35f18c10552429c312, which used rocksdb 8.11.5 to run an experiment related to 7.4 -> 7.3 downgrade. We need to figure out what rocksdb version we want in 7.3, but until then, this PR uses the previous rocksdb version (8.11.4).

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
