### PR TITLE
Fix several dangling references on coroutine resumption

### DIFF
--- a/fdbcli/BulkLoadCommand.cpp
+++ b/fdbcli/BulkLoadCommand.cpp
@@ -362,7 +362,7 @@ Future<UID> bulkLoadCommandActor(Database cx, std::vector<StringRef> tokens) {
 			fmt::println("{}", BULKLOAD_PRINT_LOCK_OWNER_USAGE);
 			co_return UID();
 		}
-		std::vector<RangeLockOwner> const& owners = co_await getAllRangeLockOwners(cx);
+		std::vector<RangeLockOwner> owners = co_await getAllRangeLockOwners(cx);
 		for (const auto owner : owners) {
 			fmt::println("{}", owner.toString());
 		}

--- a/fdbcli/BulkLoadCommand.cpp
+++ b/fdbcli/BulkLoadCommand.cpp
@@ -51,7 +51,7 @@ static const std::string BULK_LOAD_HELP_MESSAGE =
     BULKLOAD_PRINT_LOCK_USAGE + BULKLOAD_PRINT_LOCK_OWNER_USAGE + BULKLOAD_CLEAR_LOCK_USAGE;
 
 Future<Void> printPastBulkLoadJob(Database cx) {
-	std::vector<BulkLoadJobState> const& jobs = co_await getBulkLoadJobFromHistory(cx);
+	std::vector<BulkLoadJobState> jobs = co_await getBulkLoadJobFromHistory(cx);
 	if (jobs.empty()) {
 		fmt::println("No bulk loading job in the history");
 		co_return;

--- a/fdbcli/GetAuditStatusCommand.cpp
+++ b/fdbcli/GetAuditStatusCommand.cpp
@@ -221,7 +221,7 @@ Future<bool> getAuditStatusCommandActor(Database cx, std::vector<StringRef> toke
 		if (tokens.size() == 4) {
 			count = std::stoi(tokens[3].toString());
 		}
-		std::vector<AuditStorageState> const& res = co_await getAuditStates(cx, type, /*newFirst=*/true, count);
+		std::vector<AuditStorageState> res = co_await getAuditStates(cx, type, /*newFirst=*/true, count);
 		for (const auto& it : res) {
 			fmt::println("Audit result is:\n{}", it.toString());
 		}
@@ -235,7 +235,7 @@ Future<bool> getAuditStatusCommandActor(Database cx, std::vector<StringRef> toke
 		if (tokens.size() == 5) {
 			count = std::stoi(tokens[4].toString());
 		}
-		std::vector<AuditStorageState> const& res = co_await getAuditStates(cx, type, /*newFirst=*/true, count, phase);
+		std::vector<AuditStorageState> res = co_await getAuditStates(cx, type, /*newFirst=*/true, count, phase);
 		for (const auto& it : res) {
 			fmt::println("Audit result is:\n{}", it.toString());
 		}

--- a/fdbcli/GetAuditStatusCommand.cpp
+++ b/fdbcli/GetAuditStatusCommand.cpp
@@ -73,7 +73,7 @@ Future<Void> getAuditProgressByRange(Database cx, AuditType auditType, UID audit
 	fmt::println("Finished range count: {}", finishCount);
 }
 
-Future<std::vector<StorageServerInterface>> getStorageServers(Database cx) {
+AsyncResult<std::vector<StorageServerInterface>> getStorageServers(Database cx) {
 	Transaction tr(cx);
 	while (true) {
 		tr.setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
@@ -142,7 +142,7 @@ Future<Void> getAuditProgress(Database cx, AuditType auditType, UID auditId, Key
 	} else if (auditType == AuditType::ValidateStorageServerShard) {
 		std::vector<Future<Void>> fs;
 		std::unordered_map<UID, bool> res;
-		std::vector<StorageServerInterface> const& interfs = co_await getStorageServers(cx);
+		std::vector<StorageServerInterface> interfs = co_await getStorageServers(cx);
 		int i = 0;
 		int numCompleteServers = 0;
 		int numOngoingServers = 0;

--- a/fdbcli/IdempotencyIdsCommand.cpp
+++ b/fdbcli/IdempotencyIdsCommand.cpp
@@ -47,7 +47,7 @@ Future<bool> idempotencyIdsCommandActor(Database db, std::vector<StringRef> cons
 				printUsage(tokens[0]);
 				co_return false;
 			}
-			JsonBuilderObject const& status = co_await getIdmpKeyStatus(db);
+			JsonBuilderObject status = co_await getIdmpKeyStatus(db);
 			fmt::print("{}\n", status.getJson());
 			co_return true;
 		} else if (action == "clear"_sr) {

--- a/fdbclient/AuditUtils.cpp
+++ b/fdbclient/AuditUtils.cpp
@@ -135,11 +135,11 @@ AuditPhase stringToAuditPhase(std::string auditPhaseStr) {
 }
 
 // This is not transactional
-Future<std::vector<AuditStorageState>> getAuditStates(Database cx,
-                                                      AuditType auditType,
-                                                      bool newFirst,
-                                                      Optional<int> num,
-                                                      Optional<AuditPhase> phase) {
+AsyncResult<std::vector<AuditStorageState>> getAuditStates(Database cx,
+                                                           AuditType auditType,
+                                                           bool newFirst,
+                                                           Optional<int> num,
+                                                           Optional<AuditPhase> phase) {
 	Transaction tr(cx);
 	std::vector<AuditStorageState> auditStates;
 	Key readBegin;

--- a/fdbclient/ManagementAPI.cpp
+++ b/fdbclient/ManagementAPI.cpp
@@ -2755,7 +2755,7 @@ Future<Void> addBulkLoadJobToHistory(Transaction* tr, BulkLoadJobState jobState)
 	tr->set(newJobKey, bulkLoadJobValue(jobState));
 }
 
-Future<std::vector<BulkLoadJobState>> getBulkLoadJobFromHistory(Database cx) {
+AsyncResult<std::vector<BulkLoadJobState>> getBulkLoadJobFromHistory(Database cx) {
 	RangeResult jobHistoryResult;
 	Key beginKey = bulkLoadJobHistoryKeys.begin;
 	Key endKey = bulkLoadJobHistoryKeys.end;

--- a/fdbclient/ManagementAPI.cpp
+++ b/fdbclient/ManagementAPI.cpp
@@ -3639,7 +3639,7 @@ Future<Optional<RangeLockOwner>> getRangeLockOwner(Database cx, RangeLockOwnerNa
 	}
 }
 
-Future<std::vector<RangeLockOwner>> getAllRangeLockOwners(Database cx) {
+AsyncResult<std::vector<RangeLockOwner>> getAllRangeLockOwners(Database cx) {
 	std::vector<RangeLockOwner> res;
 	Key beginKey = rangeLockOwnerKeys.begin;
 	Key endKey = rangeLockOwnerKeys.end;

--- a/fdbclient/include/fdbclient/AuditUtils.h
+++ b/fdbclient/include/fdbclient/AuditUtils.h
@@ -40,11 +40,11 @@ Future<Void> persistAuditState(Database cx,
                                MoveKeyLockInfo lock,
                                bool ddEnabled);
 Future<AuditStorageState> getAuditState(Database cx, AuditType type, UID id);
-Future<std::vector<AuditStorageState>> getAuditStates(Database cx,
-                                                      AuditType auditType,
-                                                      bool newFirst,
-                                                      Optional<int> num = Optional<int>(),
-                                                      Optional<AuditPhase> phase = Optional<AuditPhase>());
+AsyncResult<std::vector<AuditStorageState>> getAuditStates(Database cx,
+                                                           AuditType auditType,
+                                                           bool newFirst,
+                                                           Optional<int> num = Optional<int>(),
+                                                           Optional<AuditPhase> phase = Optional<AuditPhase>());
 
 Future<Void> persistAuditStateByRange(Database cx, AuditStorageState auditState);
 Future<std::vector<AuditStorageState>> getAuditStateByRange(Database cx, AuditType type, UID auditId, KeyRange range);

--- a/fdbclient/include/fdbclient/ManagementAPI.h
+++ b/fdbclient/include/fdbclient/ManagementAPI.h
@@ -363,7 +363,7 @@ Future<Void> registerRangeLockOwner(Database cx, RangeLockOwnerName ownerUniqueI
 Future<Void> removeRangeLockOwner(Database cx, RangeLockOwnerName ownerUniqueID);
 
 // Get all registered rangeLock owner
-Future<std::vector<RangeLockOwner>> getAllRangeLockOwners(Database cx);
+AsyncResult<std::vector<RangeLockOwner>> getAllRangeLockOwners(Database cx);
 
 // Get a rangeLock owner by ownerUniqueID
 Future<Optional<RangeLockOwner>> getRangeLockOwner(Database cx, RangeLockOwnerName ownerUniqueID);

--- a/fdbclient/include/fdbclient/ManagementAPI.h
+++ b/fdbclient/include/fdbclient/ManagementAPI.h
@@ -180,7 +180,7 @@ Future<BulkLoadTaskState> getBulkLoadTask(Transaction* tr,
 Future<Void> addBulkLoadJobToHistory(Transaction* tr, BulkLoadJobState jobState);
 
 // Get all past bulkLoad jobs from history map
-Future<std::vector<BulkLoadJobState>> getBulkLoadJobFromHistory(Database cx);
+AsyncResult<std::vector<BulkLoadJobState>> getBulkLoadJobFromHistory(Database cx);
 
 // Erase all bulkLoad job history metadata if jobId is not provided. Otherwise, erase the job with the given jobId.
 Future<Void> clearBulkLoadJobHistory(Database cx, Optional<UID> jobId = Optional<UID>());

--- a/flow/include/flow/genericactors.actor.h
+++ b/flow/include/flow/genericactors.actor.h
@@ -246,6 +246,24 @@ Future<T> timeoutError(Future<T> what, double time, TaskPriority taskID = TaskPr
 	}
 }
 
+template <class T>
+AsyncResult<T> timeoutError(AsyncResult<T> what,
+                            double time,
+                            TaskPriority taskID = TaskPriority::DefaultDelay,
+                            ExplicitVoid = {}) {
+	if (what.canGet()) {
+		co_return what.get();
+	} else if (what.isError()) {
+		throw what.getError();
+	}
+	auto res = co_await race(std::move(what), delay(time, taskID));
+	if (res.index() == 0) {
+		co_return std::get<0>(std::move(res));
+	} else {
+		throw timed_out();
+	}
+}
+
 ACTOR template <class T>
 Future<T> delayed(Future<T> what, double time = 0.0, TaskPriority taskID = TaskPriority::DefaultDelay) {
 	try {


### PR DESCRIPTION
This PR uses `AsyncResult` to fix unsafe dangling reference accesses while avoiding expensive copies. The following pattern is unsafe:

```
auto const& res = co_await f();
g(res); // accesses dangling reference
```

because `f()` returns a temporary `Future`. 

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
