### PR TITLE
Convert several `VersionedBTree.actor.cpp` actors to standard coroutines

### DIFF
--- a/fdbserver/kvstore/VersionedBTree.actor.cpp
+++ b/fdbserver/kvstore/VersionedBTree.actor.cpp
@@ -1610,21 +1610,21 @@ int RedwoodMetrics::maxRecordCount = 315;
 RedwoodMetrics g_redwoodMetrics = {};
 Future<Void> g_redwoodMetricsActor;
 
-ACTOR Future<Void> redwoodHistogramsLogger(double interval) {
-	state double currTime;
-	loop {
+Future<Void> redwoodHistogramsLogger(double interval) {
+	double currTime{ 0 };
+	while (true) {
 		currTime = now();
-		wait(delay(interval));
+		co_await delay(interval);
 		double elapsed = now() - currTime;
 		g_redwoodMetrics.logHistograms(elapsed);
 	}
 }
 
-ACTOR Future<Void> redwoodMetricsLogger() {
+Future<Void> redwoodMetricsLogger() {
 	g_redwoodMetrics.clear();
-	state Future<Void> loggingFuture = redwoodHistogramsLogger(SERVER_KNOBS->REDWOOD_HISTOGRAM_INTERVAL);
-	loop {
-		wait(delay(SERVER_KNOBS->REDWOOD_METRICS_INTERVAL));
+	[[maybe_unused]] Future<Void> loggingFuture = redwoodHistogramsLogger(SERVER_KNOBS->REDWOOD_HISTOGRAM_INTERVAL);
+	while (true) {
+		co_await delay(SERVER_KNOBS->REDWOOD_METRICS_INTERVAL);
 
 		TraceEvent e("RedwoodMetrics");
 		double elapsed = now() - g_redwoodMetrics.startTime;
@@ -1900,11 +1900,11 @@ private:
 	EvictionOrderT prioritizedEvictions;
 };
 
-ACTOR template <class T>
-Future<T> forwardError(Future<T> f, Promise<Void> target) {
+template <class T>
+Future<T> forwardError(Future<T> f, Promise<Void> target, ExplicitVoid = {}) {
 	try {
-		T x = wait(f);
-		return x;
+		T x = co_await f;
+		co_return x;
 	} catch (Error& e) {
 		if (e.code() != error_code_actor_cancelled && target.canBeSet()) {
 			target.sendError(e);
@@ -7969,42 +7969,42 @@ KeyValue randomKV(int maxKeySize = 10, int maxValueSize = 5) {
 
 // Verify a range using a BTreeCursor.
 // Assumes that the BTree holds a single data version and the version is 0.
-ACTOR Future<Void> verifyRangeBTreeCursor(VersionedBTree* btree,
-                                          Key start,
-                                          Key end,
-                                          Version v,
-                                          std::map<std::pair<std::string, Version>, Optional<std::string>>* written,
-                                          int64_t* pRecordsRead) {
+Future<Void> verifyRangeBTreeCursor(VersionedBTree* btree,
+                                    Key start,
+                                    Key end,
+                                    Version v,
+                                    std::map<std::pair<std::string, Version>, Optional<std::string>>* written,
+                                    int64_t* pRecordsRead) {
 	if (end <= start)
 		end = keyAfter(start);
 
-	state std::map<std::pair<std::string, Version>, Optional<std::string>>::const_iterator i =
+	std::map<std::pair<std::string, Version>, Optional<std::string>>::const_iterator i =
 	    written->lower_bound(std::make_pair(start.toString(), 0));
-	state std::map<std::pair<std::string, Version>, Optional<std::string>>::const_iterator iEnd =
+	std::map<std::pair<std::string, Version>, Optional<std::string>>::const_iterator iEnd =
 	    written->upper_bound(std::make_pair(end.toString(), initialVersion));
-	state std::map<std::pair<std::string, Version>, Optional<std::string>>::const_iterator iLast;
+	std::map<std::pair<std::string, Version>, Optional<std::string>>::const_iterator iLast;
 
-	state VersionedBTree::BTreeCursor cur;
-	wait(btree->initBTreeCursor(&cur, v, PagerEventReasons::RangeRead));
+	VersionedBTree::BTreeCursor cur;
+	co_await btree->initBTreeCursor(&cur, v, PagerEventReasons::RangeRead);
 	debug_printf("VerifyRange(@%" PRId64 ", %s, %s): Start\n", v, start.printable().c_str(), end.printable().c_str());
 
 	// Randomly use the cursor for something else first.
 	if (deterministicRandom()->coinflip()) {
-		state Key randomKey = randomKV().key;
+		Key randomKey = randomKV().key;
 		debug_printf("VerifyRange(@%" PRId64 ", %s, %s): Dummy seek to '%s'\n",
 		             v,
 		             start.printable().c_str(),
 		             end.printable().c_str(),
 		             randomKey.toString().c_str());
-		wait(success(cur.seek(randomKey)));
+		co_await success(cur.seek(randomKey));
 	}
 
 	debug_printf(
 	    "VerifyRange(@%" PRId64 ", %s, %s): Actual seek\n", v, start.printable().c_str(), end.printable().c_str());
 
-	wait(cur.seekGTE(start));
+	co_await cur.seekGTE(start);
 
-	state Standalone<VectorRef<KeyValueRef>> results;
+	Standalone<VectorRef<KeyValueRef>> results;
 
 	while (cur.isValid() && cur.get().key < end) {
 		// Find the next written kv pair that would be present at this version
@@ -8061,7 +8061,7 @@ ACTOR Future<Void> verifyRangeBTreeCursor(VersionedBTree* btree,
 		results.arena().dependsOn(cur.back().cursor.cache->arena);
 		results.arena().dependsOn(cur.back().page->getArena());
 
-		wait(cur.moveNext());
+		co_await cur.moveNext();
 	}
 
 	// Make sure there are no further written kv pairs that would be present at this version.
@@ -8092,13 +8092,13 @@ ACTOR Future<Void> verifyRangeBTreeCursor(VersionedBTree* btree,
 	// opening new cursors
 	if (v >= btree->getOldestReadableVersion() && deterministicRandom()->coinflip()) {
 		cur = VersionedBTree::BTreeCursor();
-		wait(btree->initBTreeCursor(&cur, v, PagerEventReasons::RangeRead));
+		co_await btree->initBTreeCursor(&cur, v, PagerEventReasons::RangeRead);
 	}
 
 	// Now read the range from the tree in reverse order and compare to the saved results
-	wait(cur.seekLT(end));
+	co_await cur.seekLT(end);
 
-	state std::reverse_iterator<const KeyValueRef*> r = results.rbegin();
+	std::reverse_iterator<const KeyValueRef*> r = results.rbegin();
 
 	while (cur.isValid() && cur.get().key >= start) {
 		++*pRecordsRead;
@@ -8133,7 +8133,7 @@ ACTOR Future<Void> verifyRangeBTreeCursor(VersionedBTree* btree,
 		}
 
 		++r;
-		wait(cur.movePrev());
+		co_await cur.movePrev();
 	}
 
 	if (r != results.rend()) {
@@ -8144,31 +8144,29 @@ ACTOR Future<Void> verifyRangeBTreeCursor(VersionedBTree* btree,
 		       r->key.toString().c_str());
 		ASSERT(false);
 	}
-
-	return Void();
 }
 
 // Verify the result of point reads for every set or cleared key change made at exactly v
-ACTOR Future<Void> seekAllBTreeCursor(VersionedBTree* btree,
-                                      Version v,
-                                      std::map<std::pair<std::string, Version>, Optional<std::string>>* written,
-                                      int64_t* pRecordsRead) {
-	state std::map<std::pair<std::string, Version>, Optional<std::string>>::const_iterator i = written->cbegin();
-	state std::map<std::pair<std::string, Version>, Optional<std::string>>::const_iterator iEnd = written->cend();
-	state VersionedBTree::BTreeCursor cur;
+Future<Void> seekAllBTreeCursor(VersionedBTree* btree,
+                                Version v,
+                                std::map<std::pair<std::string, Version>, Optional<std::string>>* written,
+                                int64_t* pRecordsRead) {
+	auto i = written->cbegin();
+	auto iEnd = written->cend();
+	VersionedBTree::BTreeCursor cur;
 
-	wait(btree->initBTreeCursor(&cur, v, PagerEventReasons::RangeRead));
+	co_await btree->initBTreeCursor(&cur, v, PagerEventReasons::RangeRead);
 
 	while (i != iEnd) {
 		// Since the written map gets larger and takes longer to scan each time, count visits to all written recs
 		++*pRecordsRead;
-		state std::string key = i->first.first;
-		state Version ver = i->first.second;
+		std::string key = i->first.first;
+		Version ver = i->first.second;
 		if (ver == v) {
-			state Optional<std::string> val = i->second;
+			Optional<std::string> val = i->second;
 			debug_printf("Verifying @%" PRId64 " '%s'\n", ver, key.c_str());
-			state Arena arena;
-			wait(cur.seekGTE(RedwoodRecordRef(KeyRef(arena, key))));
+			Arena arena;
+			co_await cur.seekGTE(RedwoodRecordRef(KeyRef(arena, key)));
 			bool foundKey = cur.isValid() && cur.get().key == key;
 			bool hasValue = foundKey && cur.get().value.present();
 
@@ -8204,21 +8202,20 @@ ACTOR Future<Void> seekAllBTreeCursor(VersionedBTree* btree,
 		}
 		++i;
 	}
-	return Void();
 }
 
-ACTOR Future<Void> verify(VersionedBTree* btree,
-                          FutureStream<Version> vStream,
-                          std::map<std::pair<std::string, Version>, Optional<std::string>>* written,
-                          int64_t* pRecordsRead,
-                          bool serial) {
+Future<Void> verify(VersionedBTree* btree,
+                    FutureStream<Version> vStream,
+                    std::map<std::pair<std::string, Version>, Optional<std::string>>* written,
+                    int64_t* pRecordsRead,
+                    bool serial) {
 
 	// Queue of committed versions still readable from btree
-	state std::deque<Version> committedVersions;
+	std::deque<Version> committedVersions;
 
 	try {
-		loop {
-			state Version v = waitNext(vStream);
+		while (true) {
+			Version v = co_await vStream;
 			committedVersions.push_back(v);
 
 			// Remove expired versions
@@ -8238,14 +8235,13 @@ ACTOR Future<Void> verify(VersionedBTree* btree,
 			debug_printf("Using committed version %" PRId64 "\n", v);
 
 			// Get a cursor at v so that v doesn't get expired between the possibly serial steps below.
-			state VersionedBTree::BTreeCursor cur;
-			wait(btree->initBTreeCursor(&cur, v, PagerEventReasons::RangeRead));
+			VersionedBTree::BTreeCursor cur;
+			co_await btree->initBTreeCursor(&cur, v, PagerEventReasons::RangeRead);
 
 			debug_printf("Verifying entire key range at version %" PRId64 "\n", v);
-			state Future<Void> fRangeAll =
-			    verifyRangeBTreeCursor(btree, ""_sr, "\xff\xff"_sr, v, written, pRecordsRead);
+			Future<Void> fRangeAll = verifyRangeBTreeCursor(btree, ""_sr, "\xff\xff"_sr, v, written, pRecordsRead);
 			if (serial) {
-				wait(fRangeAll);
+				co_await fRangeAll;
 			}
 
 			Key begin = randomKV().key;
@@ -8253,18 +8249,18 @@ ACTOR Future<Void> verify(VersionedBTree* btree,
 
 			debug_printf(
 			    "Verifying range (%s, %s) at version %" PRId64 "\n", toString(begin).c_str(), toString(end).c_str(), v);
-			state Future<Void> fRangeRandom = verifyRangeBTreeCursor(btree, begin, end, v, written, pRecordsRead);
+			Future<Void> fRangeRandom = verifyRangeBTreeCursor(btree, begin, end, v, written, pRecordsRead);
 			if (serial) {
-				wait(fRangeRandom);
+				co_await fRangeRandom;
 			}
 
 			debug_printf("Verifying seeks to each changed key at version %" PRId64 "\n", v);
-			state Future<Void> fSeekAll = seekAllBTreeCursor(btree, v, written, pRecordsRead);
+			Future<Void> fSeekAll = seekAllBTreeCursor(btree, v, written, pRecordsRead);
 			if (serial) {
-				wait(fSeekAll);
+				co_await fSeekAll;
 			}
 
-			wait(fRangeAll && fRangeRandom && fSeekAll);
+			co_await (fRangeAll && fRangeRandom && fSeekAll);
 
 			printf("Verified version %" PRId64 "\n", v);
 		}
@@ -8273,7 +8269,6 @@ ACTOR Future<Void> verify(VersionedBTree* btree,
 			throw;
 		}
 	}
-	return Void();
 }
 
 // Does a random range read, doesn't trap/report errors


### PR DESCRIPTION
Similar to other recent PRs, this PR uses the actor rewrite tool to convert non-performance-sensitive actors to standard coroutines, in an attempt to reduce the size of future performance-sensitive migration PRs.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
