### PR TITLE
Convert several coordination actors to standard coroutines

### DIFF
--- a/fdbserver/coordinator/Coordination.actor.cpp
+++ b/fdbserver/coordinator/Coordination.actor.cpp
@@ -501,13 +501,13 @@ struct LeaderRegisterCollection {
 
 	explicit LeaderRegisterCollection(OnDemandStore* pStore) : actors(false), pStore(pStore) {}
 
-	ACTOR static Future<Void> init(LeaderRegisterCollection* self) {
+	static Future<Void> init(LeaderRegisterCollection* self) {
 		if (!self->pStore->exists())
-			return Void();
+			co_return;
 		OnDemandStore& store = *self->pStore;
-		state Future<Standalone<RangeResultRef>> forwardingInfoF = store->readRange(fwdKeys);
-		state Future<Standalone<RangeResultRef>> forwardingTimeF = store->readRange(fwdTimeKeys);
-		wait(success(forwardingInfoF) && success(forwardingTimeF));
+		Future<Standalone<RangeResultRef>> forwardingInfoF = store->readRange(fwdKeys);
+		Future<Standalone<RangeResultRef>> forwardingTimeF = store->readRange(fwdTimeKeys);
+		co_await (success(forwardingInfoF) && success(forwardingTimeF));
 		Standalone<RangeResultRef> forwardingInfo = forwardingInfoF.get();
 		Standalone<RangeResultRef> forwardingTime = forwardingTimeF.get();
 		for (int i = 0; i < forwardingInfo.size(); i++) {
@@ -520,7 +520,6 @@ struct LeaderRegisterCollection {
 			double time = BinaryReader::fromStringRef<double>(forwardingTime[i].value, Unversioned());
 			self->forwardStartTime[forwardingTime[i].key.removePrefix(fwdTimeKeys.begin)] = time;
 		}
-		return Void();
 	}
 
 	Future<Void> onError() const { return actors.getResult(); }
@@ -547,11 +546,11 @@ struct LeaderRegisterCollection {
 	// When the lead coordinator changes, store the new connection ID in the "fwd" keyspace.
 	// If a request arrives using an old connection id, resend it to the new coordinator using the stored connection id.
 	// Store when this change took place in the fwdTime keyspace.
-	ACTOR static Future<Void> setForward(LeaderRegisterCollection* self,
-	                                     KeyRef key,
-	                                     ClusterConnectionString conn,
-	                                     ForwardRequest req,
-	                                     UID id) {
+	static Future<Void> setForward(LeaderRegisterCollection* self,
+	                               KeyRef key,
+	                               ClusterConnectionString conn,
+	                               ForwardRequest req,
+	                               UID id) {
 		double forwardTime = now();
 		LeaderInfo forwardInfo;
 		forwardInfo.forward = true;
@@ -561,10 +560,9 @@ struct LeaderRegisterCollection {
 		OnDemandStore& store = *self->pStore;
 		store->set(KeyValueRef(key.withPrefix(fwdKeys.begin), conn.toString()));
 		store->set(KeyValueRef(key.withPrefix(fwdTimeKeys.begin), BinaryWriter::toValue(forwardTime, Unversioned())));
-		wait(store->commit());
+		co_await store->commit();
 		// Do not process a forwarding request until after it has been made durable in case the coordinator restarts
 		self->getInterface(req.key, id).forward.send(req);
-		return Void();
 	}
 
 	LeaderElectionRegInterface& getInterface(KeyRef key, UID id) {
@@ -582,12 +580,12 @@ struct LeaderRegisterCollection {
 		return i->value;
 	}
 
-	ACTOR static Future<Void> wrap(LeaderRegisterCollection* self, Key key, Future<Void> actor, UID id) {
-		state Error e;
+	static Future<Void> wrap(LeaderRegisterCollection* self, Key key, Future<Void> actor, UID id) {
+		Error e;
 		try {
 			// FIXME: Get worker ID here
 			startRole(Role::COORDINATOR, id, UID());
-			wait(actor || traceRole(Role::COORDINATOR, id));
+			co_await (actor || traceRole(Role::COORDINATOR, id));
 			endRole(Role::COORDINATOR, id, "Coordinator changed");
 		} catch (Error& err) {
 			endRole(Role::COORDINATOR, id, err.what(), err.code() == error_code_actor_cancelled, err);
@@ -598,7 +596,6 @@ struct LeaderRegisterCollection {
 		self->registerInterfaces.erase(key);
 		if (e.code() != invalid_error_code)
 			throw e;
-		return Void();
 	}
 };
 
@@ -744,97 +741,97 @@ ACTOR Future<Void> leaderServer(LeaderElectionRegInterface interf,
 	}
 }
 
-ACTOR Future<Void> coordinationServer(std::string dataFolder, Reference<IClusterConnectionRecord> ccr) {
-	state UID myID = deterministicRandom()->randomUniqueID();
-	state LeaderElectionRegInterface myLeaderInterface(g_network);
-	state GenerationRegInterface myInterface(g_network);
-	state OnDemandStore store(dataFolder, myID, fileCoordinatorPrefix);
+Future<Void> coordinationServer(std::string dataFolder, Reference<IClusterConnectionRecord> ccr) {
+	UID myID = deterministicRandom()->randomUniqueID();
+	LeaderElectionRegInterface myLeaderInterface(g_network);
+	GenerationRegInterface myInterface(g_network);
+	OnDemandStore store(dataFolder, myID, fileCoordinatorPrefix);
 	TraceEvent("CoordinationServer", myID)
 	    .detail("MyInterfaceAddr", myInterface.read.getEndpoint().getPrimaryAddress())
 	    .detail("Folder", dataFolder);
 
+	Error err;
 	try {
 		LocalGenerationReg generationReg(myInterface, &store);
-		wait(generationReg.run() || leaderServer(myLeaderInterface, &store, myID, ccr) || store.getError());
+		co_await (generationReg.run() || leaderServer(myLeaderInterface, &store, myID, ccr) || store.getError());
 		throw internal_error();
 	} catch (Error& e) {
-		state Error err = e;
-		TraceEvent("CoordinationServerError", myID).errorUnsuppressed(e);
-
-		// Handle a rare issue where the coordinator crashes during creation of
-		// its disk queue files. A disk queue consists of two files, created in
-		// the following manner:
-		//
-		//   1. Create two .part files.
-		//   2. Rename each .part file to remove its .part suffix.
-		//
-		// Step 2 can crash in between removing the .part suffix of the first
-		// and second file. If this occurs, the disk queue will refuse to open
-		// on subsequent attempts because it only sees one of its files,
-		// causing a process crash with the file_not_found error. Normally this
-		// behavior is fine, but in simulation it can occasionally cause
-		// problems. Simulation does not take into account injected errors can
-		// cause permanent process death. In most cases this is true. But if
-		// this inconsistent disk queue state occurs on a coordinator, the
-		// coordinator will enter a reboot loop, continuously failing to open
-		// its disk queue and crashing. If the simulation run has a small
-		// number of processes and another process is colocated with the
-		// coordinator, the run may get stuck because the coordinator crashing
-		// brings the other role offline as well. This has been observed in a
-		// stuck simulation run where a tlog colocated with a coordinator that
-		// ran into this issue meant the tlog replication policy couldn't be
-		// achieved.
-		//
-		// As a short term fix, catch file_not_found and fix inconsistent disk
-		// queue state on the coordinator. In the long term, we should either
-		// modify simulation to consider injected errors as fatal or allow the
-		// coordinator to manually fix disk queue state in real clusters.
-		if (g_network->isSimulated() && g_simulator->speedUpSimulation && e.code() == error_code_file_not_found) {
-			state std::vector<Future<Reference<IAsyncFile>>> fs;
-			fs.reserve(2);
-			for (int i = 0; i < 2; ++i) {
-				std::string file = joinPath(dataFolder, format("%s%d.fdq", fileCoordinatorPrefix.c_str(), i));
-				fs.push_back(
-				    IAsyncFileSystem::filesystem()->open(file,
-				                                         IAsyncFile::OPEN_READWRITE | IAsyncFile::OPEN_UNCACHED |
-				                                             IAsyncFile::OPEN_UNBUFFERED | IAsyncFile::OPEN_LOCK,
-				                                         0));
-			}
-			wait(waitForAllReady(fs));
-
-			// Make sure one of the disk queue files is missing. This should be
-			// the only cause of the file_not_found error.
-			ASSERT(((fs[0].isError() && fs[0].getError().code() == error_code_file_not_found) ||
-			        (fs[1].isError() && fs[1].getError().code() == error_code_file_not_found)) &&
-			       fs[0].isError() != fs[1].isError());
-
-			TraceEvent(SevWarnAlways, "CoordinatorDiskQueueInconsistentState")
-			    .detail("File0Missing", fs[0].isError())
-			    .detail("File1Missing", fs[1].isError());
-			;
-
-			// Remove the remaining disk queue file to allow the coordinator to
-			// create new files on next boot.
-			if (fs[0].isError()) {
-				ASSERT(fs[0].getError().code() == error_code_file_not_found);
-				wait(IAsyncFileSystem::filesystem()->deleteFile(joinPath(dataFolder, fileCoordinatorPrefix + "1.fdq"),
-				                                                true));
-			}
-			if (fs[1].isError()) {
-				ASSERT(fs[1].getError().code() == error_code_file_not_found);
-				wait(IAsyncFileSystem::filesystem()->deleteFile(joinPath(dataFolder, fileCoordinatorPrefix + "0.fdq"),
-				                                                true));
-			}
-		}
-
-		throw err;
+		err = e;
 	}
+	TraceEvent("CoordinationServerError", myID).errorUnsuppressed(err);
+
+	// Handle a rare issue where the coordinator crashes during creation of
+	// its disk queue files. A disk queue consists of two files, created in
+	// the following manner:
+	//
+	//   1. Create two .part files.
+	//   2. Rename each .part file to remove its .part suffix.
+	//
+	// Step 2 can crash in between removing the .part suffix of the first
+	// and second file. If this occurs, the disk queue will refuse to open
+	// on subsequent attempts because it only sees one of its files,
+	// causing a process crash with the file_not_found error. Normally this
+	// behavior is fine, but in simulation it can occasionally cause
+	// problems. Simulation does not take into account injected errors can
+	// cause permanent process death. In most cases this is true. But if
+	// this inconsistent disk queue state occurs on a coordinator, the
+	// coordinator will enter a reboot loop, continuously failing to open
+	// its disk queue and crashing. If the simulation run has a small
+	// number of processes and another process is colocated with the
+	// coordinator, the run may get stuck because the coordinator crashing
+	// brings the other role offline as well. This has been observed in a
+	// stuck simulation run where a tlog colocated with a coordinator that
+	// ran into this issue meant the tlog replication policy couldn't be
+	// achieved.
+	//
+	// As a short term fix, catch file_not_found and fix inconsistent disk
+	// queue state on the coordinator. In the long term, we should either
+	// modify simulation to consider injected errors as fatal or allow the
+	// coordinator to manually fix disk queue state in real clusters.
+	if (g_network->isSimulated() && g_simulator->speedUpSimulation && err.code() == error_code_file_not_found) {
+		std::vector<Future<Reference<IAsyncFile>>> fs;
+		fs.reserve(2);
+		for (int i = 0; i < 2; ++i) {
+			std::string file = joinPath(dataFolder, format("%s%d.fdq", fileCoordinatorPrefix.c_str(), i));
+			fs.push_back(IAsyncFileSystem::filesystem()->open(file,
+			                                                  IAsyncFile::OPEN_READWRITE | IAsyncFile::OPEN_UNCACHED |
+			                                                      IAsyncFile::OPEN_UNBUFFERED | IAsyncFile::OPEN_LOCK,
+			                                                  0));
+		}
+		co_await waitForAllReady(fs);
+
+		// Make sure one of the disk queue files is missing. This should be
+		// the only cause of the file_not_found error.
+		ASSERT(((fs[0].isError() && fs[0].getError().code() == error_code_file_not_found) ||
+		        (fs[1].isError() && fs[1].getError().code() == error_code_file_not_found)) &&
+		       fs[0].isError() != fs[1].isError());
+
+		TraceEvent(SevWarnAlways, "CoordinatorDiskQueueInconsistentState")
+		    .detail("File0Missing", fs[0].isError())
+		    .detail("File1Missing", fs[1].isError());
+		;
+
+		// Remove the remaining disk queue file to allow the coordinator to
+		// create new files on next boot.
+		if (fs[0].isError()) {
+			ASSERT(fs[0].getError().code() == error_code_file_not_found);
+			co_await IAsyncFileSystem::filesystem()->deleteFile(joinPath(dataFolder, fileCoordinatorPrefix + "1.fdq"),
+			                                                    true);
+		}
+		if (fs[1].isError()) {
+			ASSERT(fs[1].getError().code() == error_code_file_not_found);
+			co_await IAsyncFileSystem::filesystem()->deleteFile(joinPath(dataFolder, fileCoordinatorPrefix + "0.fdq"),
+			                                                    true);
+		}
+	}
+
+	throw err;
 }
 
-ACTOR Future<Void> changeClusterDescription(std::string datafolder, KeyRef newClusterKey, KeyRef oldClusterKey) {
-	state UID myID = deterministicRandom()->randomUniqueID();
-	state OnDemandStore store(datafolder, myID, fileCoordinatorPrefix);
-	RangeResult res = wait(store->readRange(allKeys));
+Future<Void> changeClusterDescription(std::string datafolder, KeyRef newClusterKey, KeyRef oldClusterKey) {
+	UID myID = deterministicRandom()->randomUniqueID();
+	OnDemandStore store(datafolder, myID, fileCoordinatorPrefix);
+	RangeResult res = co_await store->readRange(allKeys);
 	// Context, in coordinators' kv-store
 	// cluster description and the random id are always appear together as the clusterKey
 	// The old cluster key, (call it oldCKey) below can appear in the following scenarios:
@@ -874,8 +871,7 @@ ACTOR Future<Void> changeClusterDescription(std::string datafolder, KeyRef newCl
 			}
 		}
 	}
-	wait(store->commit());
-	return Void();
+	co_await store->commit();
 }
 
 Future<Void> coordChangeClusterKey(std::string dataFolder, KeyRef newClusterKey, KeyRef oldClusterKey) {

--- a/fdbserver/coordinator/Coordination.actor.cpp
+++ b/fdbserver/coordinator/Coordination.actor.cpp
@@ -29,6 +29,7 @@
 #include "flow/ProtocolVersion.h"
 #include "flow/UnitTest.h"
 #include "flow/IndexedSet.h"
+#include "flow/genericactors.actor.h"
 #include "fdbclient/MonitorLeader.h"
 #include "flow/network.h"
 
@@ -76,19 +77,33 @@ struct GenerationRegVal {
 	}
 };
 
-ACTOR Future<Void> localGenerationReg(GenerationRegInterface interf, OnDemandStore* pstore) {
-	state GenerationRegVal v;
-	state OnDemandStore& store = *pstore;
-	// SOMEDAY: concurrent access to different keys?
-	loop choose {
-		when(GenerationRegReadRequest _req = waitNext(interf.read.getFuture())) {
+class LocalGenerationReg {
+public:
+	LocalGenerationReg(GenerationRegInterface interf, OnDemandStore* pstore)
+	  : readReqs(interf.read.getFuture()), writeReqs(interf.write.getFuture()), pStore(pstore),
+	    storeLock(new FlowLock(1)) {}
+
+	Future<Void> run() {
+		return serveReadReqs(readReqs, pStore, storeLock) || serveWriteReqs(writeReqs, pStore, storeLock);
+	}
+
+private:
+	static Future<Void> serveReadReqs(FutureStream<GenerationRegReadRequest> readReqs,
+	                                  OnDemandStore* pstore,
+	                                  Reference<FlowLock> storeLock) {
+		OnDemandStore& store = *pstore;
+		while (true) {
+			GenerationRegReadRequest req = co_await readReqs;
 			TraceEvent("GenerationRegReadRequest")
-			    .detail("From", _req.reply.getEndpoint().getPrimaryAddress())
-			    .detail("K", _req.key);
-			state GenerationRegReadRequest req = _req;
-			Optional<Value> rawV = wait(store->readValue(req.key));
-			v = rawV.present() ? BinaryReader::fromStringRef<GenerationRegVal>(rawV.get(), IncludeVersion())
-			                   : GenerationRegVal();
+			    .detail("From", req.reply.getEndpoint().getPrimaryAddress())
+			    .detail("K", req.key);
+			// SOMEDAY: concurrent access to different keys?
+			co_await storeLock->take();
+			FlowLock::Releaser storeLockReleaser(*storeLock);
+			Optional<Value> rawV = co_await store->readValue(req.key);
+			GenerationRegVal v = rawV.present()
+			                         ? BinaryReader::fromStringRef<GenerationRegVal>(rawV.get(), IncludeVersion())
+			                         : GenerationRegVal();
 			TraceEvent("GenerationRegReadReply")
 			    .detail("RVSize", rawV.present() ? rawV.get().size() : -1)
 			    .detail("VWG", v.writeGen.generation);
@@ -96,21 +111,31 @@ ACTOR Future<Void> localGenerationReg(GenerationRegInterface interf, OnDemandSto
 				v.readGen = req.gen;
 				store->set(KeyValueRef(
 				    req.key, BinaryWriter::toValue(v, IncludeVersion(ProtocolVersion::withGenerationRegVal()))));
-				wait(store->commit());
+				co_await store->commit();
 			}
 			req.reply.send(GenerationRegReadReply(v.val, v.writeGen, v.readGen));
 		}
-		when(GenerationRegWriteRequest _wrq = waitNext(interf.write.getFuture())) {
-			state GenerationRegWriteRequest wrq = _wrq;
-			Optional<Value> rawV = wait(store->readValue(wrq.kv.key));
-			v = rawV.present() ? BinaryReader::fromStringRef<GenerationRegVal>(rawV.get(), IncludeVersion())
-			                   : GenerationRegVal();
+	}
+
+	static Future<Void> serveWriteReqs(FutureStream<GenerationRegWriteRequest> writeReqs,
+	                                   OnDemandStore* pstore,
+	                                   Reference<FlowLock> storeLock) {
+		OnDemandStore& store = *pstore;
+		while (true) {
+			GenerationRegWriteRequest wrq = co_await writeReqs;
+			// SOMEDAY: concurrent access to different keys?
+			co_await storeLock->take();
+			FlowLock::Releaser storeLockReleaser(*storeLock);
+			Optional<Value> rawV = co_await store->readValue(wrq.kv.key);
+			GenerationRegVal v = rawV.present()
+			                         ? BinaryReader::fromStringRef<GenerationRegVal>(rawV.get(), IncludeVersion())
+			                         : GenerationRegVal();
 			if (v.readGen <= wrq.gen && v.writeGen < wrq.gen) {
 				v.writeGen = wrq.gen;
 				v.val = wrq.kv.value;
 				store->set(KeyValueRef(
 				    wrq.kv.key, BinaryWriter::toValue(v, IncludeVersion(ProtocolVersion::withGenerationRegVal()))));
-				wait(store->commit());
+				co_await store->commit();
 				TraceEvent("GenerationRegWrote")
 				    .detail("From", wrq.reply.getEndpoint().getPrimaryAddress())
 				    .detail("Key", wrq.kv.key)
@@ -128,12 +153,18 @@ ACTOR Future<Void> localGenerationReg(GenerationRegInterface interf, OnDemandSto
 			}
 		}
 	}
-}
+
+	FutureStream<GenerationRegReadRequest> readReqs;
+	FutureStream<GenerationRegWriteRequest> writeReqs;
+	OnDemandStore* pStore;
+	Reference<FlowLock> storeLock;
+};
 
 TEST_CASE("/fdbserver/Coordination/localGenerationReg/simple") {
 	state GenerationRegInterface reg;
 	state OnDemandStore store(params.getDataDir(), deterministicRandom()->randomUniqueID(), fileCoordinatorPrefix);
-	state Future<Void> actor = localGenerationReg(reg, &store);
+	LocalGenerationReg generationReg(reg, &store);
+	state Future<Void> actor = generationReg.run();
 	state Key the_key(deterministicRandom()->randomAlphaNumeric(deterministicRandom()->randomInt(0, 10)));
 
 	state UniqueGeneration firstGen(0, deterministicRandom()->randomUniqueID());
@@ -723,8 +754,8 @@ ACTOR Future<Void> coordinationServer(std::string dataFolder, Reference<ICluster
 	    .detail("Folder", dataFolder);
 
 	try {
-		wait(localGenerationReg(myInterface, &store) || leaderServer(myLeaderInterface, &store, myID, ccr) ||
-		     store.getError());
+		LocalGenerationReg generationReg(myInterface, &store);
+		wait(generationReg.run() || leaderServer(myLeaderInterface, &store, myID, ccr) || store.getError());
 		throw internal_error();
 	} catch (Error& e) {
 		state Error err = e;

--- a/fdbserver/coordinator/include/fdbserver/coordinator/CoordinationServer.h
+++ b/fdbserver/coordinator/include/fdbserver/coordinator/CoordinationServer.h
@@ -24,7 +24,7 @@
 
 #include "fdbserver/core/CoordinationInterface.h"
 
-Future<Void> coordinationServer(std::string const& dataFolder, Reference<IClusterConnectionRecord> const& ccf);
+Future<Void> coordinationServer(std::string dataFolder, Reference<IClusterConnectionRecord> ccf);
 Future<Void> coordChangeClusterKey(std::string dataFolder, KeyRef newClusterKey, KeyRef oldClusterKey);
 
 #endif


### PR DESCRIPTION
This PR's two commits each perform part of the migration of `Coordination.actor.cpp` from Flow to pure C++:

- The first commit refactors `localGenerationReg` to a `LocalGenerationReg` class implemented with standard coroutines, to avoid a large `race` statement
- The second commit uses the actor rewrite tool to migrate other actors in the file

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
