### PR TITLE
Remove unused `ACTOR`s

### DIFF
--- a/fdbrpc/include/fdbrpc/LoadBalance.actor.h
+++ b/fdbrpc/include/fdbrpc/LoadBalance.actor.h
@@ -246,42 +246,6 @@ Future<Void> tssComparison(Req req,
 	return Void();
 }
 
-ACTOR template <class Resp>
-Future<Void> waitForQuorumReplies(std::vector<Future<Optional<ErrorOr<Resp>>>>* replies, int required) {
-	state int outstandingReplies = (int)replies->size();
-	state int requiredReplies = std::min(required, (int)replies->size());
-	state std::vector<Future<Optional<ErrorOr<Resp>>>> ongoingReplies;
-	loop {
-		ongoingReplies.clear();
-		for (auto& reply : (*replies)) {
-			if (!reply.isReady()) {
-				ongoingReplies.push_back(reply);
-			}
-		}
-		ASSERT(ongoingReplies.size() == outstandingReplies);
-
-		if (requiredReplies == 0 || outstandingReplies == 0) {
-			break;
-		}
-
-		wait(quorum(ongoingReplies, std::min(requiredReplies, outstandingReplies)));
-
-		for (auto& reply : ongoingReplies) {
-			if (reply.isReady()) {
-				outstandingReplies--;
-				if (!reply.isError() && reply.get().present() && !reply.get().get().isError()) {
-					Optional<LoadBalancedReply> lbReply = getLoadBalancedReply(&reply.get().get().get());
-					if (lbReply.present() && !lbReply.get().error.present()) {
-						requiredReplies--;
-					}
-				}
-			}
-		}
-	}
-
-	return Void();
-}
-
 ACTOR template <class Req, class Resp, class Interface, class Multi, bool P>
 Future<Void> replicaComparison(Req req,
                                Future<ErrorOr<Resp>> fSource,

--- a/fdbrpc/include/fdbrpc/genericactors.actor.h
+++ b/fdbrpc/include/fdbrpc/genericactors.actor.h
@@ -80,17 +80,6 @@ Future<REPLY_TYPE(Req)> retryBrokenPromise(RequestStream<Req, P> to, Req request
 }
 
 ACTOR template <class Req>
-Future<Void> tryInitializeRequestStream(RequestStream<Req>* stream, Hostname hostname, WellKnownEndpoints token) {
-	Optional<NetworkAddress> address = wait(hostname.resolve());
-	if (!address.present()) {
-		return Void();
-	}
-	ASSERT(stream != nullptr);
-	*stream = RequestStream<Req>(Endpoint::wellKnown({ address.get() }, token));
-	return Void();
-}
-
-ACTOR template <class Req>
 Future<ErrorOr<REPLY_TYPE(Req)>> tryGetReplyFromHostname(Req request, Hostname hostname, WellKnownEndpoints token) {
 	// A wrapper of tryGetReply(request), except that the request is sent to an address resolved from a hostname.
 	// If resolving fails, return lookup_failed().

--- a/fdbserver/core/include/fdbserver/core/WorkerInterface.actor.h
+++ b/fdbserver/core/include/fdbserver/core/WorkerInterface.actor.h
@@ -1094,37 +1094,6 @@ Future<T> ioTimeoutError(Future<T> what, double time, const char* context = null
 }
 
 ACTOR template <class T>
-Future<T> ioTimeoutErrorIfCleared(Future<T> what,
-                                  double time,
-                                  Reference<AsyncVar<bool>> condition,
-                                  const char* context = nullptr) {
-	// Before simulation is sped up, IO operations can take a very long time so limit timeouts
-	// to not end until at least time after simulation is sped up.
-	if (g_network->isSimulated() && !g_simulator->speedUpSimulation) {
-		time += std::max(0.0, FLOW_KNOBS->SIM_SPEEDUP_AFTER_SECONDS - now());
-	}
-	Future<Void> end = lowPriorityDelayAfterCleared(condition, time);
-	choose {
-		when(T t = wait(what)) {
-			return t;
-		}
-		when(wait(end)) {
-			Error err = io_timeout();
-			if (isSimulatorProcessUnreliable()) {
-				err = err.asInjectedFault();
-			}
-			TraceEvent e(SevError, "IoTimeoutError");
-			e.error(err);
-			if (context != nullptr) {
-				e.detail("Context", context);
-			}
-			e.log();
-			throw err;
-		}
-	}
-}
-
-ACTOR template <class T>
 Future<T> ioDegradedOrTimeoutError(Future<T> what,
                                    double errTime,
                                    Reference<AsyncVar<bool>> degraded,

--- a/fdbserver/kvstore/DiskQueue.actor.cpp
+++ b/fdbserver/kvstore/DiskQueue.actor.cpp
@@ -1165,27 +1165,6 @@ private:
 		}
 	}
 
-	ACTOR static void verifyCommit(DiskQueue* self,
-	                               Future<Void> commitSynced,
-	                               StringBuffer* buffer,
-	                               loc_t start,
-	                               loc_t end) {
-		state TrackMe trackme(self);
-		try {
-			wait(commitSynced);
-			Standalone<StringRef> pagedData = wait(readPages(self, start, end));
-			const int startOffset = start % _PAGE_SIZE;
-			const int dataLen = end - start;
-			ASSERT(pagedData.substr(startOffset, dataLen).compare(buffer->get().substr(0, dataLen)) == 0);
-		} catch (Error& e) {
-			if (e.code() != error_code_io_error) {
-				delete buffer;
-				throw;
-			}
-		}
-		delete buffer;
-	}
-
 	// Read pages from [start, end) bytes
 	ACTOR static Future<Standalone<StringRef>> readPages(DiskQueue* self, location start, location end) {
 		state TrackMe trackme(self);

--- a/fdbserver/kvstore/KeyValueStoreRocksDB.actor.cpp
+++ b/fdbserver/kvstore/KeyValueStoreRocksDB.actor.cpp
@@ -2049,16 +2049,6 @@ struct RocksDBKeyValueStore : IKeyValueStore {
 		}
 	}
 
-	ACTOR Future<Void> errorListenActor(Future<Void> collection) {
-		try {
-			wait(collection);
-			ASSERT(false);
-			throw internal_error();
-		} catch (Error& e) {
-			throw e;
-		}
-	}
-
 	ACTOR Future<Void> updateHistogram(ThreadFutureStream<std::pair<std::string, double>> metricFutureStream) {
 		state Reference<Histogram> commitLatencyHistogram = Histogram::getHistogram(
 		    ROCKSDBSTORAGE_HISTOGRAM_GROUP, ROCKSDB_COMMIT_LATENCY_HISTOGRAM, Histogram::Unit::milliseconds);

--- a/fdbserver/storageserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver/storageserver.actor.cpp
@@ -2107,30 +2107,6 @@ ACTOR Future<Version> waitForVersionNoTooOld(StorageServer* data, Version versio
 	}
 }
 
-ACTOR Future<Version> waitForMinVersion(StorageServer* data, Version version) {
-	// This could become an Actor transparently, but for now it just does the lookup
-	if (version == latestVersion)
-		version = std::max(Version(1), data->version.get());
-	if (version < data->oldestVersion.get() || version <= 0) {
-		return data->oldestVersion.get();
-	} else if (version <= data->version.get()) {
-		return version;
-	}
-	choose {
-		when(wait(data->version.whenAtLeast(version))) {
-			return version;
-		}
-		when(wait(delay(SERVER_KNOBS->FUTURE_VERSION_DELAY))) {
-			if (deterministicRandom()->random01() < 0.001)
-				TraceEvent(SevWarn, "ShardServerFutureVersion1000x", data->thisServerID)
-				    .detail("Version", version)
-				    .detail("MyVersion", data->version.get())
-				    .detail("ServerID", data->thisServerID);
-			throw future_version();
-		}
-	}
-}
-
 std::vector<StorageServerShard> StorageServer::getStorageServerShards(KeyRangeRef range) {
 	std::vector<StorageServerShard> res;
 	for (auto t : this->shards.intersectingRanges(range)) {

--- a/flow/include/flow/genericactors.actor.h
+++ b/flow/include/flow/genericactors.actor.h
@@ -448,27 +448,6 @@ Future<Void> returnIfTrue(Future<T> what, F pred) {
 	return returnIfTrue(map(what, pred));
 }
 
-// filters a stream
-ACTOR template <class T, class F>
-Future<Void> filter(FutureStream<T> input, F pred, PromiseStream<T> output) {
-	loop {
-		try {
-			T nextInput = waitNext(input);
-			if (pred(nextInput))
-				output.send(nextInput);
-		} catch (Error& e) {
-			if (e.code() == error_code_end_of_stream) {
-				break;
-			} else
-				throw;
-		}
-	}
-
-	output.sendError(end_of_stream());
-
-	return Void();
-}
-
 template <class T>
 struct WorkerCache {
 	// SOMEDAY: Would we do better to use "unreliable" (at most once) transport for the initialize requests and get rid

--- a/flow/include/flow/genericactors.actor.h
+++ b/flow/include/flow/genericactors.actor.h
@@ -266,17 +266,6 @@ Future<Void> trigger(Func what, Future<Void> signal) {
 	return Void();
 }
 
-ACTOR template <class Func>
-Future<Void> triggerOnError(Func what, Future<Void> signal) {
-	try {
-		wait(signal);
-	} catch (Error& e) {
-		what();
-	}
-
-	return Void();
-}
-
 // Waits for a future to complete and cannot be cancelled
 // Most situations will use the overload below, which does not require a promise
 ACTOR template <class T>
@@ -310,12 +299,6 @@ ACTOR template <class T, class X>
 Future<T> holdWhile(X object, Future<T> what) {
 	T val = wait(what);
 	return val;
-}
-
-ACTOR template <class T, class X>
-Future<Void> holdWhileVoid(X object, Future<T> what) {
-	T val = wait(what);
-	return Void();
 }
 
 // Assign the future value of what to out
@@ -479,46 +462,6 @@ Future<Void> filter(FutureStream<T> input, F pred, PromiseStream<T> output) {
 			} else
 				throw;
 		}
-	}
-
-	output.sendError(end_of_stream());
-
-	return Void();
-}
-
-// filters a stream asynchronously
-ACTOR template <class T, class F>
-Future<Void> asyncFilter(FutureStream<T> input, F actorPred, PromiseStream<T> output) {
-	state Deque<std::pair<T, Future<bool>>> futures;
-	state std::pair<T, Future<bool>> p;
-
-	loop {
-		try {
-			choose {
-				when(T nextInput = waitNext(input)) {
-					futures.emplace_back(nextInput, actorPred(nextInput));
-				}
-				when(bool pass = wait(futures.size() == 0 ? Never() : futures.front().second)) {
-					if (pass)
-						output.send(futures.front().first);
-					futures.pop_front();
-				}
-			}
-		} catch (Error& e) {
-			if (e.code() == error_code_end_of_stream) {
-				break;
-			} else {
-				throw e;
-			}
-		}
-	}
-
-	while (futures.size()) {
-		p = futures.front();
-		bool pass = wait(p.second);
-		if (pass)
-			output.send(p.first);
-		futures.pop_front();
 	}
 
 	output.sendError(end_of_stream());
@@ -850,14 +793,6 @@ Future<Void> asyncDeserialize(Reference<AsyncVar<Standalone<StringRef>>> input,
 	}
 }
 
-ACTOR template <class V, class T>
-void forwardVector(Future<V> values, std::vector<Promise<T>> out) {
-	V in = wait(values);
-	ASSERT(in.size() == out.size());
-	for (int i = 0; i < out.size(); i++)
-		out[i].send(in[i]);
-}
-
 ACTOR template <class T>
 Future<Void> delayedAsyncVar(Reference<AsyncVar<T>> in, Reference<AsyncVar<T>> out, double time) {
 	try {
@@ -942,24 +877,6 @@ ACTOR Future<Void> delayAfterCleared(Reference<AsyncVar<bool>> condition,
 
 // Same as delayAfterCleared, but use lowPriorityDelay.
 ACTOR Future<Void> lowPriorityDelayAfterCleared(Reference<AsyncVar<bool>> condition, double time);
-
-// Similar to timeoutError, but does not throw timed_out if condition is true.
-// Once condition becomes false again, reset the timer (e.g. if time is 10s, wait for 10s again before throwing
-// timed_out, if condition remains to be false).
-ACTOR template <class T>
-Future<T> timeoutErrorIfCleared(Future<T> what,
-                                Reference<AsyncVar<bool>> condition,
-                                double time,
-                                TaskPriority taskID = TaskPriority::DefaultDelay) {
-	choose {
-		when(T t = wait(what)) {
-			return t;
-		}
-		when(wait(delayAfterCleared(condition, time, taskID))) {
-			throw timed_out();
-		}
-	}
-}
 
 Future<bool> allTrue(const std::vector<Future<bool>>& all);
 Future<Void> anyTrue(std::vector<Reference<AsyncVar<bool>>> const& input, Reference<AsyncVar<bool>> const& output);
@@ -1975,13 +1892,6 @@ public:
 	}
 };
 
-ACTOR template <class T>
-Future<T> delayActionJittered(Future<T> what, double time) {
-	wait(delayJittered(time));
-	T t = wait(what);
-	return t;
-}
-
 class AndFuture {
 public:
 	AndFuture() = default;
@@ -2050,125 +1960,6 @@ private:
 	std::vector<Future<Void>> futures;
 };
 
-// Performs an unordered merge of a and b.
-ACTOR template <class T>
-Future<Void> unorderedMergeStreams(FutureStream<T> a, FutureStream<T> b, PromiseStream<T> output) {
-	state Future<T> aFuture = waitAndForward(a);
-	state Future<T> bFuture = waitAndForward(b);
-	state bool aOpen = true;
-	state bool bOpen = true;
-
-	loop {
-		try {
-			choose {
-				when(T val = wait(aFuture)) {
-					output.send(val);
-					aFuture = waitAndForward(a);
-				}
-				when(T val = wait(bFuture)) {
-					output.send(val);
-					bFuture = waitAndForward(b);
-				}
-			}
-		} catch (Error& e) {
-			if (e.code() != error_code_end_of_stream) {
-				output.sendError(e);
-				break;
-			}
-
-			ASSERT(!aFuture.isError() || !bFuture.isError() || aFuture.getError().code() == bFuture.getError().code());
-
-			if (aFuture.isError()) {
-				aFuture = Never();
-				aOpen = false;
-			}
-			if (bFuture.isError()) {
-				bFuture = Never();
-				bOpen = false;
-			}
-
-			if (!aOpen && !bOpen) {
-				output.sendError(e);
-				break;
-			}
-		}
-	}
-
-	return Void();
-}
-
-// Returns the ordered merge of a and b, assuming that a and b are both already ordered (prefer a over b if keys are
-// equal). T must be a class that implements compare()
-ACTOR template <class T>
-Future<Void> orderedMergeStreams(FutureStream<T> a, FutureStream<T> b, PromiseStream<T> output) {
-	state Optional<T> savedKVa;
-	state bool aOpen;
-	state Optional<T> savedKVb;
-	state bool bOpen;
-
-	aOpen = bOpen = true;
-
-	loop {
-		if (aOpen && !savedKVa.present()) {
-			try {
-				T KVa = waitNext(a);
-				savedKVa = Optional<T>(KVa);
-			} catch (Error& e) {
-				if (e.code() == error_code_end_of_stream) {
-					aOpen = false;
-					if (!bOpen) {
-						output.sendError(e);
-					}
-				} else {
-					output.sendError(e);
-					break;
-				}
-			}
-		}
-		if (bOpen && !savedKVb.present()) {
-			try {
-				T KVb = waitNext(b);
-				savedKVb = Optional<T>(KVb);
-			} catch (Error& e) {
-				if (e.code() == error_code_end_of_stream) {
-					bOpen = false;
-					if (!aOpen) {
-						output.sendError(e);
-					}
-				} else {
-					output.sendError(e);
-					break;
-				}
-			}
-		}
-
-		if (!aOpen) {
-			output.send(savedKVb.get());
-			savedKVb = Optional<T>();
-		} else if (!bOpen) {
-			output.send(savedKVa.get());
-			savedKVa = Optional<T>();
-		} else {
-			int cmp = savedKVa.get().compare(savedKVb.get());
-
-			if (cmp == 0) {
-				// prefer a
-				output.send(savedKVa.get());
-				savedKVa = Optional<T>();
-				savedKVb = Optional<T>();
-			} else if (cmp < 0) {
-				output.send(savedKVa.get());
-				savedKVa = Optional<T>();
-			} else {
-				output.send(savedKVb.get());
-				savedKVb = Optional<T>();
-			}
-		}
-	}
-
-	return Void();
-}
-
 ACTOR template <class T>
 Future<Void> timeReply(Future<T> replyToTime, PromiseStream<double> timeOutput) {
 	state double startTime = now();
@@ -2198,47 +1989,6 @@ Future<T> forward(Future<T> from, Promise<T> to) {
 		}
 		throw e;
 	}
-}
-
-ACTOR template <class Transaction>
-Future<Void> buggifiedCommit(Transaction tr, bool buggify, int maxDelayDuration = 60.0) {
-	state int buggifyUnknownResultPoint = 0;
-	state int buggifyDelayPoint = 0;
-
-	if (buggify) {
-		int choice = deterministicRandom()->randomInt(1, 9);
-		buggifyUnknownResultPoint = choice / 3;
-		buggifyDelayPoint = choice % 3;
-	}
-
-	// Simulate a delay before commit that could potentially trigger a timeout
-	if (buggifyDelayPoint == 1) {
-		wait(delay(deterministicRandom()->random01() * maxDelayDuration));
-	}
-
-	// Simulate an unknown result that didn't commit
-	if (buggifyUnknownResultPoint == 1) {
-		// The delay avoids a no-wait commit.
-		if (!BUGGIFY) {
-			wait(delay(0));
-		}
-
-		throw commit_unknown_result();
-	}
-
-	wait(safeThreadFutureToFuture(tr->commit()));
-
-	// Simulate a long delay after commit that could potentially trigger a timeout
-	if (buggifyDelayPoint == 2) {
-		wait(delay(deterministicRandom()->random01() * maxDelayDuration));
-	}
-
-	// Simulate an unknown result that did commit
-	if (buggifyUnknownResultPoint == 2) {
-		throw commit_unknown_result();
-	}
-
-	return Void();
 }
 
 // Monad


### PR DESCRIPTION
As part of the coroutine migration, these `ACTOR`s can either be converted or removed. Because they have been in the codebase for a while and are still unused, it seems better to remove the dead code. Some of these generic actors are potentially useful, but they'll still be available in the `git` history to restore if necessary.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
