### PR TITLE
Fix missing case in `getWorkersForTlogsComplex`

### DIFF
--- a/documentation/sphinx/source/mr-status-json-schemas.rst.inc
+++ b/documentation/sphinx/source/mr-status-json-schemas.rst.inc
@@ -348,6 +348,7 @@
                         "trace_log_file_write_error",
                         "trace_log_could_not_create_file",
                         "trace_log_writer_thread_unresponsive",
+                        "exclude_from_tlog_recruitment_low_disk",
                         "process_error",
                         "io_error",
                         "io_timeout",
@@ -625,7 +626,8 @@
                         "incorrect_cluster_file_contents",
                         "trace_log_file_write_error",
                         "trace_log_could_not_create_file",
-                        "trace_log_writer_thread_unresponsive"
+                        "trace_log_writer_thread_unresponsive",
+                        "exclude_from_tlog_recruitment_low_disk"
                      ]
                   },
                   "description":"Cluster file contents do not match current cluster connection string. Verify cluster file is writable and has not been overwritten externally."

--- a/fdbclient/Schemas.cpp
+++ b/fdbclient/Schemas.cpp
@@ -333,6 +333,7 @@ const KeyRef JSONSchemas::statusSchema = R"statusSchema(
                         "trace_log_file_write_error",
                         "trace_log_could_not_create_file",
                         "trace_log_writer_thread_unresponsive",
+                        "exclude_from_tlog_recruitment_low_disk",
                         "process_error",
                         "io_error",
                         "io_timeout",
@@ -619,7 +620,8 @@ const KeyRef JSONSchemas::statusSchema = R"statusSchema(
                         "incorrect_cluster_file_contents",
                         "trace_log_file_write_error",
                         "trace_log_could_not_create_file",
-                        "trace_log_writer_thread_unresponsive"
+                        "trace_log_writer_thread_unresponsive",
+                        "exclude_from_tlog_recruitment_low_disk"
                      ]
                   },
                   "description":"Cluster file contents do not match current cluster connection string. Verify cluster file is writable and has not been overwritten externally."

--- a/fdbserver/clustercontroller/ClusterController.h
+++ b/fdbserver/clustercontroller/ClusterController.h
@@ -628,6 +628,16 @@ public:
 				    SevDebug, id, "complex", "Worker is not in the target DC", worker_details, fitness, dcIds);
 				continue;
 			}
+			if (excludesFromTLogRecruitmentDueToLowDisk(worker_info.issues)) {
+				logWorkerUnavailable(SevInfo,
+				                     id,
+				                     "complex",
+				                     "Worker is excluded from TLog recruitment due to low disk",
+				                     worker_details,
+				                     fitness,
+				                     dcIds);
+				continue;
+			}
 			if (!allowDegraded && worker_details.degraded) {
 				logWorkerUnavailable(
 				    SevInfo, id, "complex", "Worker is degraded and not allowed", worker_details, fitness, dcIds);

--- a/fdbserver/clustercontroller/Status.actor.cpp
+++ b/fdbserver/clustercontroller/Status.actor.cpp
@@ -2553,6 +2553,10 @@ static std::string getIssueDescription(std::string name) {
 		       "its "
 		       "parent directory are writable and that the cluster file has not been overwritten externally.";
 	}
+	if (name == "exclude_from_tlog_recruitment_low_disk") {
+		return "Process is temporarily excluded from TLog recruitment because its available disk space is below the "
+		       "minimum TLog threshold.";
+	}
 
 	// FIXME: name and description will be the same unless the message is 'incorrect_cluster_file_contents', which
 	// is currently the only possible message

--- a/fdbserver/core/ServerKnobs.cpp
+++ b/fdbserver/core/ServerKnobs.cpp
@@ -1047,7 +1047,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( TLOG_SPILL_THRESHOLD,                               1500e6 ); if( smallTlogTarget ) TLOG_SPILL_THRESHOLD = 1500e3; if( randomize && BUGGIFY ) TLOG_SPILL_THRESHOLD = 0;
 	init( REFERENCE_SPILL_UPDATE_STORAGE_BYTE_LIMIT,            20e6 ); if( (randomize && BUGGIFY) || smallTlogTarget ) REFERENCE_SPILL_UPDATE_STORAGE_BYTE_LIMIT = 1e6;
 	init( TLOG_HARD_LIMIT_BYTES,                              3000e6 ); if( smallTlogTarget ) TLOG_HARD_LIMIT_BYTES = 30e6;
-	init( TLOG_MIN_AVAILABLE_SPACE_RATIO,                        0.0 ); if( randomize && BUGGIFY ) TLOG_MIN_AVAILABLE_SPACE_RATIO = 0.05;
+	init( TLOG_MIN_AVAILABLE_SPACE_RATIO,                        0.0 ); if( randomize && BUGGIFY ) TLOG_MIN_AVAILABLE_SPACE_RATIO = 0.1;
 	init( TLOG_RECOVER_MEMORY_LIMIT, TARGET_BYTES_PER_TLOG + SPRING_BYTES_TLOG );
 
 	init( MAX_TRANSACTIONS_PER_BYTE,                            1000 );

--- a/fdbserver/datadistributor/DDTeamCollection.actor.cpp
+++ b/fdbserver/datadistributor/DDTeamCollection.actor.cpp
@@ -2722,17 +2722,18 @@ public:
 				    .detail("TSSLocality", candidateWorker.worker.locality.toString())
 				    .detail("Primary", self->primary);
 
-				Optional<std::pair<UID, Version>> ssPairInfoResult = wait(tssState->waitOnSS());
-				if (ssPairInfoResult.present()) {
-					isr.tssPairIDAndVersion = ssPairInfoResult.get();
+				Optional<Optional<std::pair<UID, Version>>> ssPairInfoResult =
+				    wait(timeout(tssState->waitOnSS(), SERVER_KNOBS->TSS_RECRUITMENT_TIMEOUT));
+				if (ssPairInfoResult.present() && ssPairInfoResult.get().present()) {
+					isr.tssPairIDAndVersion = ssPairInfoResult.get().get();
 
 					TraceEvent("TSS_Recruit", self->distributorId)
 					    .detail("ReqID", isr.reqId)
-					    .detail("SSID", ssPairInfoResult.get().first)
+					    .detail("SSID", ssPairInfoResult.get().get().first)
 					    .detail("TSSID", interfaceId)
 					    .detail("Stage", "TSSGotPair")
 					    .detail("TSSAddr", candidateWorker.worker.address())
-					    .detail("SSVersion", ssPairInfoResult.get().second)
+					    .detail("SSVersion", ssPairInfoResult.get().get().second)
 					    .detail("TSSLocality", candidateWorker.worker.locality.toString())
 					    .detail("Primary", self->primary);
 				} else {
@@ -2741,7 +2742,9 @@ public:
 					TraceEvent(SevWarnAlways, "TSS_RecruitError", self->distributorId)
 					    .detail("ReqID", isr.reqId)
 					    .detail("TSSID", interfaceId)
-					    .detail("Reason", "TSS failed to get SS pair for some reason")
+					    .detail("Reason",
+					            ssPairInfoResult.present() ? "TSS failed to get SS pair for some reason"
+					                                       : "TSS timed out waiting for SS pair")
 					    .detail("TSSAddr", candidateWorker.worker.address())
 					    .detail("TSSLocality", candidateWorker.worker.locality.toString())
 					    .detail("Primary", self->primary);

--- a/fdbserver/datadistributor/DDTeamCollection.actor.cpp
+++ b/fdbserver/datadistributor/DDTeamCollection.actor.cpp
@@ -2722,18 +2722,17 @@ public:
 				    .detail("TSSLocality", candidateWorker.worker.locality.toString())
 				    .detail("Primary", self->primary);
 
-				Optional<Optional<std::pair<UID, Version>>> ssPairInfoResult =
-				    wait(timeout(tssState->waitOnSS(), SERVER_KNOBS->TSS_RECRUITMENT_TIMEOUT));
-				if (ssPairInfoResult.present() && ssPairInfoResult.get().present()) {
-					isr.tssPairIDAndVersion = ssPairInfoResult.get().get();
+				Optional<std::pair<UID, Version>> ssPairInfoResult = wait(tssState->waitOnSS());
+				if (ssPairInfoResult.present()) {
+					isr.tssPairIDAndVersion = ssPairInfoResult.get();
 
 					TraceEvent("TSS_Recruit", self->distributorId)
 					    .detail("ReqID", isr.reqId)
-					    .detail("SSID", ssPairInfoResult.get().get().first)
+					    .detail("SSID", ssPairInfoResult.get().first)
 					    .detail("TSSID", interfaceId)
 					    .detail("Stage", "TSSGotPair")
 					    .detail("TSSAddr", candidateWorker.worker.address())
-					    .detail("SSVersion", ssPairInfoResult.get().get().second)
+					    .detail("SSVersion", ssPairInfoResult.get().second)
 					    .detail("TSSLocality", candidateWorker.worker.locality.toString())
 					    .detail("Primary", self->primary);
 				} else {
@@ -2742,9 +2741,7 @@ public:
 					TraceEvent(SevWarnAlways, "TSS_RecruitError", self->distributorId)
 					    .detail("ReqID", isr.reqId)
 					    .detail("TSSID", interfaceId)
-					    .detail("Reason",
-					            ssPairInfoResult.present() ? "TSS failed to get SS pair for some reason"
-					                                       : "TSS timed out waiting for SS pair")
+					    .detail("Reason", "TSS failed to get SS pair for some reason")
 					    .detail("TSSAddr", candidateWorker.worker.address())
 					    .detail("TSSLocality", candidateWorker.worker.locality.toString())
 					    .detail("Primary", self->primary);

--- a/fdbserver/tlog/TLogServer.actor.cpp
+++ b/fdbserver/tlog/TLogServer.actor.cpp
@@ -2984,6 +2984,20 @@ static void failIfTLogCannotAcceptNewData(TLogData* self, Reference<LogData> log
 	if (self->shouldAcceptNewData(kvStoreBytes, queueBytes, minAvailableSpaceRatio)) {
 		return;
 	}
+	if (g_network->isSimulated() && !g_simulator->speedUpSimulation) {
+		TraceEvent(SevWarnAlways, "TLogPullAsyncDataLowDiskSpeedUpSimulation", logData->logId)
+		    .detail("MinAvailableSpaceRatio", minAvailableSpaceRatio)
+		    .detail("AvailableSpaceRatio", self->availableSpaceRatio(kvStoreBytes, queueBytes))
+		    .detail("KvstoreBytesAvailable", kvStoreBytes.available)
+		    .detail("KvstoreBytesTotal", kvStoreBytes.total)
+		    .detail("QueueDiskBytesAvailable", queueBytes.available)
+		    .detail("QueueDiskBytesTotal", queueBytes.total)
+		    .detail("Version", ver);
+		g_simulator->speedUpSimulation = true;
+		if (self->shouldAcceptNewData(kvStoreBytes, queueBytes, effectiveTLogMinAvailableSpaceRatio())) {
+			return;
+		}
+	}
 	CODE_PROBE(true, "pullAsyncData blocked by TLOG_MIN_AVAILABLE_SPACE_RATIO");
 	// Outside speedUpSimulation, fail recovery and temporarily exclude this worker from TLog recruitment until disk
 	// space recovers.


### PR DESCRIPTION
This PR is a follow-up to https://github.com/apple/foundationdb/pull/12809. The buggified value of `TLOG_MIN_AVAILABLE_SPACE_RATIO` is increased to 0.1 to improve test coverage. This uncovered a bug in `getWorkersForTlogsComplex` leading to rare (~1/2k) test failures. This bug is fixed by aligning `getWorkersForTlogsComplex` with other tlog recruitment functions.

Validated with 25k unfiltered correctness tests using Joshua

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
