### PR TITLE
Fix ASAN errors in `fdbserver/ratekeeper/*TagThrottler.cpp` files

### DIFF
--- a/fdbserver/ratekeeper/GlobalTagThrottler.cpp
+++ b/fdbserver/ratekeeper/GlobalTagThrottler.cpp
@@ -305,6 +305,9 @@ class GlobalTagThrottlerImpl {
 					co_await delay(5.0);
 					break;
 				} catch (Error& e) {
+					if (e.code() == error_code_actor_cancelled) {
+						throw e;
+					}
 					err = e;
 				}
 				TraceEvent("GlobalTagThrottler_MonitoringChangesError", self->id).error(err);

--- a/fdbserver/ratekeeper/TagThrottler.cpp
+++ b/fdbserver/ratekeeper/TagThrottler.cpp
@@ -130,6 +130,9 @@ class TagThrottlerImpl {
 					CODE_PROBE(true, "Tag throttle changes detected");
 					break;
 				} catch (Error& e) {
+					if (e.code() == error_code_actor_cancelled) {
+						throw e;
+					}
 					err = e;
 				}
 


### PR DESCRIPTION
This small PR is part of a larger effort to enable regular ASAN/UBSAN testing. When `GlobalTagThrottlerImpl::monitorThrottlingChanges` is cancelled, `self` is already a dangling pointer, so accessing `self->id` is invalid. This PR fixes that issue, and a similar bug in `TagThrottlerImpl::monitorThrottlingChanges`

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
