### PR TITLE
Move waitForShardReady outside transaction in finishMoveKeys

### DIFF
--- a/fdbserver/MoveKeys.actor.cpp
+++ b/fdbserver/MoveKeys.actor.cpp
@@ -1611,6 +1611,7 @@ ACTOR static Future<Void> finishMoveKeys(Database occ,
 						// verify dest hasn't changed and commit the metadata update.
 						tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
 						tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+						tr.trState->taskID = TaskPriority::MoveKeys;
 						wait(checkMoveKeysLock(&tr, lock, ddEnabledState));
 
 						// Re-read keyServers to verify dest hasn't changed while we waited
@@ -1625,23 +1626,43 @@ ACTOR static Future<Void> finishMoveKeys(Database occ,
 						                      SERVER_KNOBS->MOVE_KEYS_KRM_LIMIT,
 						                      SERVER_KNOBS->MOVE_KEYS_KRM_LIMIT_BYTES));
 
-						// Verify dest is unchanged — if another DD instance reassigned the
-						// shard while we were waiting, we must not commit stale metadata.
+						// Verify dest is unchanged across the full currentKeys range — if
+						// another DD instance split or reassigned any overlapping subrange
+						// while we were waiting, we must not commit stale metadata.
 						{
-							std::vector<UID> checkSrc, checkDest;
-							if (convergenceCheckKeyServers.size() > 1) {
+							bool destChanged = convergenceCheckKeyServers.size() <= 1;
+							bool boundaryChanged =
+							    convergenceCheckKeyServers.size() <= 1 ||
+							    convergenceCheckKeyServers.back().key != endKey;
+							std::vector<UID> mismatchedDest;
+							for (int i = 0; !destChanged && i + 1 < convergenceCheckKeyServers.size(); ++i) {
+								std::vector<UID> checkSrc, checkDest;
 								decodeKeyServersValue(convergenceCheckUIDtoTagMap,
-								                      convergenceCheckKeyServers[0].value,
+								                      convergenceCheckKeyServers[i].value,
 								                      checkSrc,
 								                      checkDest);
+								if (checkDest != dest) {
+									destChanged = true;
+									mismatchedDest = checkDest;
+								}
 							}
-							if (checkDest != dest) {
-								CODE_PROBE(true, "finishMoveKeys dest changed during waitForShardReady");
+							if (destChanged || boundaryChanged) {
+								CODE_PROBE(true,
+								           "finishMoveKeys dest changed during waitForShardReady");
 								TraceEvent(SevWarn, "FinishMoveKeysDestChanged", relocationIntervalId)
 								    .detail("KeyBegin", keys.begin)
 								    .detail("KeyEnd", keys.end)
+								    .detail("CurrentKeysBegin", currentKeys.begin)
+								    .detail("CurrentKeysEnd", currentKeys.end)
 								    .detail("OrigDest", describe(dest))
-								    .detail("NewDest", describe(checkDest));
+								    .detail("NewDest", describe(mismatchedDest))
+								    .detail("ExpectedEndKey", endKey)
+								    .detail("ObservedEndKey",
+								            convergenceCheckKeyServers.size() > 0
+								                ? convergenceCheckKeyServers.back().key
+								                : KeyRef())
+								    .detail("DestChanged", destChanged)
+								    .detail("BoundaryChanged", boundaryChanged);
 								tr.reset();
 								continue; // retry the inner loop
 							}

--- a/fdbserver/MoveKeys.actor.cpp
+++ b/fdbserver/MoveKeys.actor.cpp
@@ -1505,6 +1505,16 @@ ACTOR static Future<Void> finishMoveKeys(Database occ,
 					// needs a minimum version the dest server must reach. A fresh transaction
 					// later will have a newer version, and the server will already be past this
 					// older version, so the readiness guarantee still holds.
+					//
+					// Correctness of the two-transaction split:
+					// Between the wait and the second transaction's commit, the shard assignment
+					// could change (e.g. another DD instance reassigns the shard after a
+					// movekeys_conflict restart). The second transaction handles this by:
+					//   1. checkMoveKeysLock verifies our DD instance still owns the move
+					//   2. Re-reading keyServers and verifying dest is unchanged
+					//   3. If dest changed, we retry the entire inner loop
+					// The dest servers confirmed readiness at version V1. The second transaction
+					// reads at V2 >= V1, so the readiness guarantee carries forward.
 					state Version readVersion = tr.getReadVersion().get();
 
 					releaser.release();

--- a/fdbserver/MoveKeys.actor.cpp
+++ b/fdbserver/MoveKeys.actor.cpp
@@ -1638,9 +1638,8 @@ ACTOR static Future<Void> finishMoveKeys(Database occ,
 						// while we were waiting, we must not commit stale metadata.
 						{
 							bool destChanged = convergenceCheckKeyServers.size() <= 1;
-							bool boundaryChanged =
-							    convergenceCheckKeyServers.size() <= 1 ||
-							    convergenceCheckKeyServers.back().key != endKey;
+							bool boundaryChanged = convergenceCheckKeyServers.size() <= 1 ||
+							                       convergenceCheckKeyServers.back().key != endKey;
 							std::vector<UID> mismatchedDest;
 							for (int i = 0; !destChanged && i + 1 < convergenceCheckKeyServers.size(); ++i) {
 								std::vector<UID> checkSrc, checkDest;
@@ -1654,8 +1653,7 @@ ACTOR static Future<Void> finishMoveKeys(Database occ,
 								}
 							}
 							if (destChanged || boundaryChanged) {
-								CODE_PROBE(true,
-								           "finishMoveKeys dest changed during waitForShardReady");
+								CODE_PROBE(true, "finishMoveKeys dest changed during waitForShardReady");
 								TraceEvent(SevWarn, "FinishMoveKeysDestChanged", relocationIntervalId)
 								    .detail("KeyBegin", keys.begin)
 								    .detail("KeyEnd", keys.end)

--- a/fdbserver/MoveKeys.actor.cpp
+++ b/fdbserver/MoveKeys.actor.cpp
@@ -1194,6 +1194,13 @@ ACTOR Future<Void> waitForShardReady(StorageServerInterface server,
 			GetShardStateReply rep =
 			    wait(server.getShardState.getReply(GetShardStateRequest(keys, mode), TaskPriority::MoveKeys));
 			if (rep.first >= minVersion) {
+				// Inject delay to simulate slow shard readiness. When finishMoveKeys
+				// waits inside a transaction, this causes transaction_too_old on commit.
+				// With the fix (wait outside transaction), this delay is harmless.
+				if (BUGGIFY_WITH_PROB(0.05)) {
+					CODE_PROBE(true, "waitForShardReady artificial delay");
+					wait(delay(6.0));
+				}
 				return Void();
 			}
 			wait(delayJittered(SERVER_KNOBS->SHARD_READY_DELAY, TaskPriority::MoveKeys));

--- a/fdbserver/MoveKeys.actor.cpp
+++ b/fdbserver/MoveKeys.actor.cpp
@@ -1501,7 +1501,19 @@ ACTOR static Future<Void> finishMoveKeys(Database occ,
 						serverListEntries.push_back(tr.get(serverListKeyFor(newDestinations[s])));
 					state std::vector<Optional<Value>> serverListValues = wait(getAll(serverListEntries));
 
+					// Save the read version before dropping the transaction. waitForShardReady
+					// needs a minimum version the dest server must reach. A fresh transaction
+					// later will have a newer version, and the server will already be past this
+					// older version, so the readiness guarantee still holds.
+					state Version readVersion = tr.getReadVersion().get();
+
 					releaser.release();
+
+					// Drop the transaction BEFORE the potentially long wait. The 15-second
+					// SERVER_READY_QUORUM_TIMEOUT exceeds the ~5-second transaction lifetime,
+					// so waiting inside the transaction guarantees transaction_too_old on commit
+					// when destination servers are slow to respond.
+					tr.reset();
 
 					for (int s = 0; s < serverListValues.size(); s++) {
 						ASSERT(serverListValues[s]
@@ -1511,9 +1523,7 @@ ACTOR static Future<Void> finishMoveKeys(Database occ,
 						storageServerInterfaces.push_back(si);
 					}
 
-					// update client info in case tss mapping changed or server got updated
-
-					// Wait for new destination servers to fetch the keys
+					// Wait for new destination servers to fetch the keys (OUTSIDE any transaction)
 
 					serverReady.reserve(storageServerInterfaces.size());
 					tssReady.reserve(storageServerInterfaces.size());
@@ -1521,7 +1531,7 @@ ACTOR static Future<Void> finishMoveKeys(Database occ,
 					for (int s = 0; s < storageServerInterfaces.size(); s++) {
 						serverReady.push_back(waitForShardReady(storageServerInterfaces[s],
 						                                        keys,
-						                                        tr.getReadVersion().get(),
+						                                        readVersion,
 						                                        GetShardStateRequest::READABLE));
 
 						auto tssPair = tssMapping.find(storageServerInterfaces[s].id());
@@ -1530,12 +1540,12 @@ ACTOR static Future<Void> finishMoveKeys(Database occ,
 						    !tssToIgnore.count(tssPair->second.id())) {
 							tssReadyInterfs.push_back(tssPair->second);
 							tssReady.push_back(waitForShardReady(
-							    tssPair->second, keys, tr.getReadVersion().get(), GetShardStateRequest::READABLE));
+							    tssPair->second, keys, readVersion, GetShardStateRequest::READABLE));
 						}
 					}
 
 					// Wait for all storage server moves, and explicitly swallow errors for tss ones with
-					// waitForAllReady If this takes too long the transaction will time out and retry, which is ok
+					// waitForAllReady. The 15s timeout is safe here — no transaction clock is ticking.
 					wait(timeout(waitForAll(serverReady) && waitForAllReady(tssReady),
 					             SERVER_KNOBS->SERVER_READY_QUORUM_TIMEOUT,
 					             Void(),
@@ -1589,6 +1599,47 @@ ACTOR static Future<Void> finishMoveKeys(Database occ,
 					}
 
 					if (count == dest.size()) {
+						// All destination servers are ready. Start a fresh transaction to
+						// verify dest hasn't changed and commit the metadata update.
+						tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
+						tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+						wait(checkMoveKeysLock(&tr, lock, ddEnabledState));
+
+						// Re-read keyServers to verify dest hasn't changed while we waited
+						state RangeResult convergenceCheckUIDtoTagMap =
+						    wait(tr.getRange(serverTagKeys, CLIENT_KNOBS->TOO_MANY));
+						ASSERT(!convergenceCheckUIDtoTagMap.more &&
+						       convergenceCheckUIDtoTagMap.size() < CLIENT_KNOBS->TOO_MANY);
+						state RangeResult convergenceCheckKeyServers =
+						    wait(krmGetRanges(&tr,
+						                      keyServersPrefix,
+						                      currentKeys,
+						                      SERVER_KNOBS->MOVE_KEYS_KRM_LIMIT,
+						                      SERVER_KNOBS->MOVE_KEYS_KRM_LIMIT_BYTES));
+
+						// Verify dest is unchanged — if another DD instance reassigned the
+						// shard while we were waiting, we must not commit stale metadata.
+						{
+							std::vector<UID> checkSrc, checkDest;
+							if (convergenceCheckKeyServers.size() > 1) {
+								decodeKeyServersValue(convergenceCheckUIDtoTagMap,
+								                      convergenceCheckKeyServers[0].value,
+								                      checkSrc,
+								                      checkDest);
+							}
+							if (checkDest != dest) {
+								CODE_PROBE(true,
+								           "finishMoveKeys dest changed during waitForShardReady");
+								TraceEvent(SevWarn, "FinishMoveKeysDestChanged", relocationIntervalId)
+								    .detail("KeyBegin", keys.begin)
+								    .detail("KeyEnd", keys.end)
+								    .detail("OrigDest", describe(dest))
+								    .detail("NewDest", describe(checkDest));
+								tr.reset();
+								continue; // retry the inner loop
+							}
+						}
+
 						// update keyServers, serverKeys
 						// SOMEDAY: Doing these in parallel is safe because none of them overlap or touch (one per
 						// server)

--- a/fdbserver/MoveKeys.actor.cpp
+++ b/fdbserver/MoveKeys.actor.cpp
@@ -1529,18 +1529,16 @@ ACTOR static Future<Void> finishMoveKeys(Database occ,
 					tssReady.reserve(storageServerInterfaces.size());
 					tssReadyInterfs.reserve(storageServerInterfaces.size());
 					for (int s = 0; s < storageServerInterfaces.size(); s++) {
-						serverReady.push_back(waitForShardReady(storageServerInterfaces[s],
-						                                        keys,
-						                                        readVersion,
-						                                        GetShardStateRequest::READABLE));
+						serverReady.push_back(waitForShardReady(
+						    storageServerInterfaces[s], keys, readVersion, GetShardStateRequest::READABLE));
 
 						auto tssPair = tssMapping.find(storageServerInterfaces[s].id());
 
 						if (tssPair != tssMapping.end() && waitForTSSCounter > 0 &&
 						    !tssToIgnore.count(tssPair->second.id())) {
 							tssReadyInterfs.push_back(tssPair->second);
-							tssReady.push_back(waitForShardReady(
-							    tssPair->second, keys, readVersion, GetShardStateRequest::READABLE));
+							tssReady.push_back(
+							    waitForShardReady(tssPair->second, keys, readVersion, GetShardStateRequest::READABLE));
 						}
 					}
 
@@ -1628,8 +1626,7 @@ ACTOR static Future<Void> finishMoveKeys(Database occ,
 								                      checkDest);
 							}
 							if (checkDest != dest) {
-								CODE_PROBE(true,
-								           "finishMoveKeys dest changed during waitForShardReady");
+								CODE_PROBE(true, "finishMoveKeys dest changed during waitForShardReady");
 								TraceEvent(SevWarn, "FinishMoveKeysDestChanged", relocationIntervalId)
 								    .detail("KeyBegin", keys.begin)
 								    .detail("KeyEnd", keys.end)


### PR DESCRIPTION
SERVER_READY_QUORUM_TIMEOUT (15s) was used INSIDE a transaction that must commit within ~5s (MAX_WRITE_TRANSACTION_LIFE_VERSIONS). When destination servers are slow to respond (e.g. after a team rebuild unsticks moves), the 15s wait guarantees transaction_too_old.

Split the single transaction into two:
1. First transaction reads keyServers metadata and server list
2. waitForShardReady runs outside any transaction (15s timeout is safe)
3. Second transaction re-verifies dest is unchanged, then commits

If dest changed while waiting (another DD reassigned the shard), the code retries from the top of the inner loop.


`
  20260414-005707-stack_logs-bddd63d245354453        compressed=True data_size=50997449 duration=4877944 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:59:04 sanity=False started=100000 stopped=20260414-015611 submitted=20260414-005707 timeout=5400 username=stack_logs`


This is one of a few fixes to address transaction_too_old seen trying to do inRestore moves on startup incident on 7.3
