### PR TITLE
DD 7.3 finish movekeys backoff

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -824,6 +824,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( SERVER_READY_QUORUM_TIMEOUT,                          15.0 ); if( randomize && BUGGIFY ) SERVER_READY_QUORUM_TIMEOUT = 1.0;
 	init( REMOVE_RETRY_DELAY,                                    1.0 );
 	init( MOVE_KEYS_KRM_LIMIT,                                  2000 ); if( randomize && BUGGIFY ) MOVE_KEYS_KRM_LIMIT = 2;
+	init( FINISH_MOVE_KEYS_MAX_RETRIES,                           50 );
 	init( MOVE_KEYS_KRM_LIMIT_BYTES,                             1e5 ); if( randomize && BUGGIFY ) MOVE_KEYS_KRM_LIMIT_BYTES = 5e4; //This must be sufficiently larger than CLIENT_KNOBS->KEY_SIZE_LIMIT (fdbclient/Knobs.h) to ensure that at least two entries will be returned from an attempt to read a key range map
 	init( MOVE_SHARD_KRM_ROW_LIMIT,                            20000 );
  	init( MOVE_SHARD_KRM_BYTE_LIMIT,                             1e6 );

--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -824,7 +824,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( SERVER_READY_QUORUM_TIMEOUT,                          15.0 ); if( randomize && BUGGIFY ) SERVER_READY_QUORUM_TIMEOUT = 1.0;
 	init( REMOVE_RETRY_DELAY,                                    1.0 );
 	init( MOVE_KEYS_KRM_LIMIT,                                  2000 ); if( randomize && BUGGIFY ) MOVE_KEYS_KRM_LIMIT = 2;
-	init( FINISH_MOVE_KEYS_MAX_RETRIES,                           50 );
+	init( FINISH_MOVE_KEYS_MAX_RETRIES,                           50 ); // ~4 min total with exponential backoff (0.2s to 5s cap)
 	init( MOVE_KEYS_KRM_LIMIT_BYTES,                             1e5 ); if( randomize && BUGGIFY ) MOVE_KEYS_KRM_LIMIT_BYTES = 5e4; //This must be sufficiently larger than CLIENT_KNOBS->KEY_SIZE_LIMIT (fdbclient/Knobs.h) to ensure that at least two entries will be returned from an attempt to read a key range map
 	init( MOVE_SHARD_KRM_ROW_LIMIT,                            20000 );
  	init( MOVE_SHARD_KRM_BYTE_LIMIT,                             1e6 );

--- a/fdbclient/include/fdbclient/ServerKnobs.h
+++ b/fdbclient/include/fdbclient/ServerKnobs.h
@@ -804,7 +804,8 @@ public:
 	double SERVER_READY_QUORUM_TIMEOUT;
 	double REMOVE_RETRY_DELAY;
 	int MOVE_KEYS_KRM_LIMIT;
-	int FINISH_MOVE_KEYS_MAX_RETRIES; // Max retries in finishMoveKeys before returning move to queue; set very high to disable
+	int FINISH_MOVE_KEYS_MAX_RETRIES; // Max retries in finishMoveKeys before returning move to queue; set very high to
+	                                  // disable
 	int MOVE_KEYS_KRM_LIMIT_BYTES; // This must be sufficiently larger than CLIENT_KNOBS->KEY_SIZE_LIMIT
 	                               // (fdbclient/Knobs.h) to ensure that at least two entries will be returned from an
 	                               // attempt to read a key range map

--- a/fdbclient/include/fdbclient/ServerKnobs.h
+++ b/fdbclient/include/fdbclient/ServerKnobs.h
@@ -804,6 +804,7 @@ public:
 	double SERVER_READY_QUORUM_TIMEOUT;
 	double REMOVE_RETRY_DELAY;
 	int MOVE_KEYS_KRM_LIMIT;
+	int FINISH_MOVE_KEYS_MAX_RETRIES; // Max retries in finishMoveKeys before returning move to queue
 	int MOVE_KEYS_KRM_LIMIT_BYTES; // This must be sufficiently larger than CLIENT_KNOBS->KEY_SIZE_LIMIT
 	                               // (fdbclient/Knobs.h) to ensure that at least two entries will be returned from an
 	                               // attempt to read a key range map

--- a/fdbclient/include/fdbclient/ServerKnobs.h
+++ b/fdbclient/include/fdbclient/ServerKnobs.h
@@ -804,7 +804,7 @@ public:
 	double SERVER_READY_QUORUM_TIMEOUT;
 	double REMOVE_RETRY_DELAY;
 	int MOVE_KEYS_KRM_LIMIT;
-	int FINISH_MOVE_KEYS_MAX_RETRIES; // Max retries in finishMoveKeys before returning move to queue
+	int FINISH_MOVE_KEYS_MAX_RETRIES; // Max retries in finishMoveKeys before returning move to queue; set very high to disable
 	int MOVE_KEYS_KRM_LIMIT_BYTES; // This must be sufficiently larger than CLIENT_KNOBS->KEY_SIZE_LIMIT
 	                               // (fdbclient/Knobs.h) to ensure that at least two entries will be returned from an
 	                               // attempt to read a key range map

--- a/fdbserver/DDRelocationQueue.actor.cpp
+++ b/fdbserver/DDRelocationQueue.actor.cpp
@@ -1903,7 +1903,8 @@ ACTOR Future<Void> dataDistributionRelocator(DDQueue* self,
 
 			//TraceEvent("RelocateShardFinished", distributorId).detail("RelocateId", relocateShardInterval.pairID);
 
-			if (error.code() != error_code_move_to_removed_server) {
+			if (error.code() != error_code_move_to_removed_server &&
+			    error.code() != error_code_finish_move_keys_too_many_retries) {
 				if (!error.code()) {
 					try {
 						wait(healthyDestinations

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -307,6 +307,7 @@ static std::set<int> const& normalDDQueueErrors() {
 		s.insert(error_code_broken_promise);
 		s.insert(error_code_data_move_cancelled);
 		s.insert(error_code_data_move_dest_team_not_found);
+		s.insert(error_code_finish_move_keys_too_many_retries);
 	}
 	return s;
 }

--- a/fdbserver/MoveKeys.actor.cpp
+++ b/fdbserver/MoveKeys.actor.cpp
@@ -39,7 +39,8 @@
 namespace {
 
 // Exponential backoff for transaction_too_old retries in finishMoveKeys.
-// Starts at 0.1s, doubles each retry, capped at 5.0s.
+// Formula: 0.1 * 2^retries, capped at 5.0s. Called with retries >= 1
+// (retries is incremented before the call), so effective start is 0.2s.
 double finishMoveKeysBackoff(int retries) {
 	return std::min(0.1 * (1 << std::min(retries, 6)), 5.0);
 }
@@ -3511,7 +3512,8 @@ void seedShardServers(Arena& arena, CommitTransactionRef& tr, std::vector<Storag
 //      finishMoveKeys may not be called if no moves are scheduled
 // So we test the backoff arithmetic directly.
 TEST_CASE("/fdbserver/MoveKeys/finishMoveKeysBackoff") {
-	// Verify exponential backoff: 0.1s base, doubles each retry, capped at 5.0s
+	// Verify exponential backoff: 0.1 * 2^retries, capped at 5.0s.
+	// In production retries >= 1 at call site, so effective start is 0.2s.
 	ASSERT(finishMoveKeysBackoff(0) == 0.1);
 	ASSERT(finishMoveKeysBackoff(1) == 0.2);
 	ASSERT(finishMoveKeysBackoff(2) == 0.4);

--- a/fdbserver/MoveKeys.actor.cpp
+++ b/fdbserver/MoveKeys.actor.cpp
@@ -1608,6 +1608,7 @@ ACTOR static Future<Void> finishMoveKeys(Database occ,
 						}
 
 						wait(waitForAll(actors));
+
 						wait(tr.commit());
 						txnCommitted->increment(1);
 
@@ -1624,6 +1625,29 @@ ACTOR static Future<Void> finishMoveKeys(Database occ,
 					state Error err = error;
 					wait(tr.onError(error));
 					retries++;
+					// tr.onError has no backoff for transaction_too_old — it returns immediately.
+					// With 15 FlowLock slots all retrying, this creates a retry storm. Add
+					// exponential backoff capped at 5s, and give up after too many retries so
+					// the move returns to the queue for reassignment.
+					if (err.code() == error_code_transaction_too_old) {
+						double backoff = std::min(0.1 * (1 << std::min(retries, 6)), 5.0);
+						CODE_PROBE(true, "finishMoveKeys transaction_too_old backoff");
+						TraceEvent("FinishMoveKeysBackoff", relocationIntervalId)
+						    .detail("Retries", retries)
+						    .detail("BackoffSeconds", backoff);
+						wait(delay(backoff));
+					}
+					// Give up after too many retries of any error type — if finishMoveKeys
+					// can't succeed, return the move to DD's queue for reassignment.
+					if (retries > SERVER_KNOBS->FINISH_MOVE_KEYS_MAX_RETRIES) {
+						CODE_PROBE(true, "finishMoveKeys giving up after max retries");
+						TraceEvent(SevWarnAlways, "RelocateShard_FinishMoveKeysGivingUp", relocationIntervalId)
+						    .error(err)
+						    .detail("KeyBegin", keys.begin)
+						    .detail("KeyEnd", keys.end)
+						    .detail("Retries", retries);
+						throw movekeys_conflict();
+					}
 					if (retries % 10 == 0) {
 						TraceEvent(retries == 20 ? SevWarnAlways : SevWarn,
 						           "RelocateShard_FinishMoveKeysRetrying",
@@ -3472,4 +3496,33 @@ void seedShardServers(Arena& arena, CommitTransactionRef& tr, std::vector<Storag
 			    tr, arena, serverKeysPrefixFor(s.id()), allKeys, serverKeysTrue, serverKeysFalse);
 		}
 	}
+}
+
+// Unit test for the finishMoveKeys backoff formula. A simulation workload can't reliably
+// trigger transaction_too_old in finishMoveKeys because:
+//   1. finishMoveKeys only runs when DD schedules data moves, which depends on cluster
+//      configuration and shard placement — not guaranteed in all simulation configs
+//   2. Even with injection, the injection point must fire before check() runs, but
+//      finishMoveKeys may not be called if no moves are scheduled
+// So we test the backoff arithmetic directly.
+TEST_CASE("/fdbserver/MoveKeys/finishMoveKeysBackoff") {
+	// Verify exponential backoff formula: min(0.1 * (1 << min(retries, 6)), 5.0)
+	// retries=1: 0.2s, retries=2: 0.4s, ..., retries=6: 6.4->capped to 5.0s
+	auto backoffFor = [](int retries) { return std::min(0.1 * (1 << std::min(retries, 6)), 5.0); };
+
+	ASSERT(backoffFor(0) == 0.1);
+	ASSERT(backoffFor(1) == 0.2);
+	ASSERT(backoffFor(2) == 0.4);
+	ASSERT(backoffFor(3) == 0.8);
+	ASSERT(backoffFor(4) == 1.6);
+	ASSERT(backoffFor(5) == 3.2);
+	ASSERT(backoffFor(6) == 5.0); // capped
+	ASSERT(backoffFor(7) == 5.0); // still capped
+	ASSERT(backoffFor(100) == 5.0); // still capped
+
+	// Verify the retry limit knob exists and has a reasonable default
+	ASSERT(SERVER_KNOBS->FINISH_MOVE_KEYS_MAX_RETRIES > 0);
+	ASSERT(SERVER_KNOBS->FINISH_MOVE_KEYS_MAX_RETRIES <= 100);
+
+	return Void();
 }

--- a/fdbserver/MoveKeys.actor.cpp
+++ b/fdbserver/MoveKeys.actor.cpp
@@ -1632,6 +1632,12 @@ ACTOR static Future<Void> finishMoveKeys(Database occ,
 					if (error.code() == error_code_actor_cancelled)
 						throw;
 					state Error err = error;
+					// Inject transaction_too_old to exercise the retry limit and
+					// finish_move_keys_too_many_retries error path.
+					if (BUGGIFY_WITH_PROB(0.01)) {
+						CODE_PROBE(true, "finishMoveKeys injecting transaction_too_old");
+						err = transaction_too_old();
+					}
 					wait(tr.onError(error));
 					retries++;
 					// tr.onError delays are short for transaction_too_old. With 15

--- a/fdbserver/MoveKeys.actor.cpp
+++ b/fdbserver/MoveKeys.actor.cpp
@@ -1617,6 +1617,12 @@ ACTOR static Future<Void> finishMoveKeys(Database occ,
 
 						wait(waitForAll(actors));
 
+						// Inject transaction_too_old before commit to exercise the
+						// retry limit and finish_move_keys_too_many_retries path.
+						if (BUGGIFY_WITH_PROB(0.01)) {
+							CODE_PROBE(true, "finishMoveKeys injecting transaction_too_old before commit");
+							throw transaction_too_old();
+						}
 						wait(tr.commit());
 						txnCommitted->increment(1);
 
@@ -1632,12 +1638,6 @@ ACTOR static Future<Void> finishMoveKeys(Database occ,
 					if (error.code() == error_code_actor_cancelled)
 						throw;
 					state Error err = error;
-					// Inject transaction_too_old to exercise the retry limit and
-					// finish_move_keys_too_many_retries error path.
-					if (BUGGIFY_WITH_PROB(0.01)) {
-						CODE_PROBE(true, "finishMoveKeys injecting transaction_too_old");
-						err = transaction_too_old();
-					}
 					wait(tr.onError(error));
 					retries++;
 					// tr.onError delays are short for transaction_too_old. With 15

--- a/fdbserver/MoveKeys.actor.cpp
+++ b/fdbserver/MoveKeys.actor.cpp
@@ -1650,7 +1650,7 @@ ACTOR static Future<Void> finishMoveKeys(Database occ,
 							    .detail("KeyBegin", keys.begin)
 							    .detail("KeyEnd", keys.end)
 							    .detail("Retries", retries);
-							throw movekeys_conflict();
+							throw finish_move_keys_too_many_retries();
 						}
 						wait(delay(backoff));
 					}

--- a/fdbserver/MoveKeys.actor.cpp
+++ b/fdbserver/MoveKeys.actor.cpp
@@ -37,6 +37,13 @@
 #include "flow/actorcompiler.h" // This must be the last #include.
 
 namespace {
+
+// Exponential backoff for transaction_too_old retries in finishMoveKeys.
+// Starts at 0.1s, doubles each retry, capped at 5.0s.
+double finishMoveKeysBackoff(int retries) {
+	return std::min(0.1 * (1 << std::min(retries, 6)), 5.0);
+}
+
 struct Shard {
 	Shard() = default;
 	Shard(KeyRangeRef range, const UID& id) : range(range), id(id) {}
@@ -1613,6 +1620,7 @@ ACTOR static Future<Void> finishMoveKeys(Database occ,
 						txnCommitted->increment(1);
 
 						begin = endKey;
+						retries = 0;
 						break;
 					}
 					// This leads to a count of transactions starting that exceeds the sum of
@@ -1625,12 +1633,11 @@ ACTOR static Future<Void> finishMoveKeys(Database occ,
 					state Error err = error;
 					wait(tr.onError(error));
 					retries++;
-					// tr.onError has no backoff for transaction_too_old — it returns immediately.
-					// With 15 FlowLock slots all retrying, this creates a retry storm. Add
-					// exponential backoff capped at 5s, and give up after too many retries so
-					// the move returns to the queue for reassignment.
+					// tr.onError delays are short for transaction_too_old. With 15
+					// FlowLock slots all retrying, this creates a retry storm. Add
+					// additional exponential backoff capped at 5s.
 					if (err.code() == error_code_transaction_too_old) {
-						double backoff = std::min(0.1 * (1 << std::min(retries, 6)), 5.0);
+						double backoff = finishMoveKeysBackoff(retries);
 						CODE_PROBE(true, "finishMoveKeys transaction_too_old backoff");
 						TraceEvent("FinishMoveKeysBackoff", relocationIntervalId)
 						    .detail("Retries", retries)
@@ -3506,19 +3513,16 @@ void seedShardServers(Arena& arena, CommitTransactionRef& tr, std::vector<Storag
 //      finishMoveKeys may not be called if no moves are scheduled
 // So we test the backoff arithmetic directly.
 TEST_CASE("/fdbserver/MoveKeys/finishMoveKeysBackoff") {
-	// Verify exponential backoff formula: min(0.1 * (1 << min(retries, 6)), 5.0)
-	// retries=1: 0.2s, retries=2: 0.4s, ..., retries=6: 6.4->capped to 5.0s
-	auto backoffFor = [](int retries) { return std::min(0.1 * (1 << std::min(retries, 6)), 5.0); };
-
-	ASSERT(backoffFor(0) == 0.1);
-	ASSERT(backoffFor(1) == 0.2);
-	ASSERT(backoffFor(2) == 0.4);
-	ASSERT(backoffFor(3) == 0.8);
-	ASSERT(backoffFor(4) == 1.6);
-	ASSERT(backoffFor(5) == 3.2);
-	ASSERT(backoffFor(6) == 5.0); // capped
-	ASSERT(backoffFor(7) == 5.0); // still capped
-	ASSERT(backoffFor(100) == 5.0); // still capped
+	// Verify exponential backoff: 0.1s base, doubles each retry, capped at 5.0s
+	ASSERT(finishMoveKeysBackoff(0) == 0.1);
+	ASSERT(finishMoveKeysBackoff(1) == 0.2);
+	ASSERT(finishMoveKeysBackoff(2) == 0.4);
+	ASSERT(finishMoveKeysBackoff(3) == 0.8);
+	ASSERT(finishMoveKeysBackoff(4) == 1.6);
+	ASSERT(finishMoveKeysBackoff(5) == 3.2);
+	ASSERT(finishMoveKeysBackoff(6) == 5.0); // capped
+	ASSERT(finishMoveKeysBackoff(7) == 5.0); // still capped
+	ASSERT(finishMoveKeysBackoff(100) == 5.0); // still capped
 
 	// Verify the retry limit knob exists and has a reasonable default
 	ASSERT(SERVER_KNOBS->FINISH_MOVE_KEYS_MAX_RETRIES > 0);

--- a/fdbserver/MoveKeys.actor.cpp
+++ b/fdbserver/MoveKeys.actor.cpp
@@ -1642,18 +1642,16 @@ ACTOR static Future<Void> finishMoveKeys(Database occ,
 						TraceEvent("FinishMoveKeysBackoff", relocationIntervalId)
 						    .detail("Retries", retries)
 						    .detail("BackoffSeconds", backoff);
+						if (retries > SERVER_KNOBS->FINISH_MOVE_KEYS_MAX_RETRIES) {
+							CODE_PROBE(true, "finishMoveKeys giving up after max retries");
+							TraceEvent(SevWarnAlways, "RelocateShard_FinishMoveKeysGivingUp", relocationIntervalId)
+							    .error(err)
+							    .detail("KeyBegin", keys.begin)
+							    .detail("KeyEnd", keys.end)
+							    .detail("Retries", retries);
+							throw movekeys_conflict();
+						}
 						wait(delay(backoff));
-					}
-					// Give up after too many retries of any error type — if finishMoveKeys
-					// can't succeed, return the move to DD's queue for reassignment.
-					if (retries > SERVER_KNOBS->FINISH_MOVE_KEYS_MAX_RETRIES) {
-						CODE_PROBE(true, "finishMoveKeys giving up after max retries");
-						TraceEvent(SevWarnAlways, "RelocateShard_FinishMoveKeysGivingUp", relocationIntervalId)
-						    .error(err)
-						    .detail("KeyBegin", keys.begin)
-						    .detail("KeyEnd", keys.end)
-						    .detail("Retries", retries);
-						throw movekeys_conflict();
 					}
 					if (retries % 10 == 0) {
 						TraceEvent(retries == 20 ? SevWarnAlways : SevWarn,
@@ -3524,9 +3522,8 @@ TEST_CASE("/fdbserver/MoveKeys/finishMoveKeysBackoff") {
 	ASSERT(finishMoveKeysBackoff(7) == 5.0); // still capped
 	ASSERT(finishMoveKeysBackoff(100) == 5.0); // still capped
 
-	// Verify the retry limit knob exists and has a reasonable default
+	// Verify the retry limit knob exists and is positive
 	ASSERT(SERVER_KNOBS->FINISH_MOVE_KEYS_MAX_RETRIES > 0);
-	ASSERT(SERVER_KNOBS->FINISH_MOVE_KEYS_MAX_RETRIES <= 100);
 
 	return Void();
 }

--- a/flow/include/flow/error_definitions.h
+++ b/flow/include/flow/error_definitions.h
@@ -152,6 +152,7 @@ ERROR( cancel_audit_storage_failed, 1231, "Failed to cancel an audit" )
 ERROR( audit_storage_cancelled, 1232, "Audit has been cancelled" )
 ERROR( location_metadata_corruption, 1233, "Found location metadata corruption" )
 ERROR( audit_storage_task_outdated, 1234, "Audit task is scheduled by an outdated DD" )
+ERROR( finish_move_keys_too_many_retries, 1235, "finishMoveKeys exceeded retry limit" )
 
 // 15xx Platform errors
 ERROR( platform_error, 1500, "Platform error" )


### PR DESCRIPTION
    Add backoff and retry limit for transaction_too_old in finishMoveKeys

    tr.onError has no backoff for transaction_too_old so with 15 FlowLock
    slots all retrying, the attempt rate explodes (550 to 4,161+/min).

    Add exponential backoff (0.1s to 5s) for transaction_too_old retries,
    and give up after 50 retries by throwing movekeys_conflict so the move
    returns to the DD queue for reassignment.


Another fix to stem the spew of transaction too old that tends to clog up event loop when under stress on DD startup, tied to #12981

`
 20260414-180438-stack_backoff-ac50ebeebbb59f68     compressed=True data_size=51148152 duration=4317675 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:57:07 sanity=False started=100000 stopped=20260414-190145 submitted=20260414-180438 timeout=5400 username=stack_backoff`