### PR TITLE
Fix GcGenerations test: block trackRecoveryReq when disableTLogRecove…

### DIFF
--- a/fdbserver/tlog/TLogServer.actor.cpp
+++ b/fdbserver/tlog/TLogServer.actor.cpp
@@ -2665,7 +2665,7 @@ Future<Void> respondToRecovered(TLogInterface tli, Promise<Void> recoveryComplet
 	// This delay is added for testing purpose in simulation where by setting `disableTLogRecoveryFinish`, we disable
 	// TLogs to send back `TLogRecoveryFinishedRequest`.
 	while (g_network->isSimulated() && g_simulator->disableTLogRecoveryFinish) {
-		TraceEvent("WaitingToBeUnblocked", tli.id());
+		TraceEvent("WaitingToBeUnblocked", tli.id()).suppressFor(60);
 		co_await delay(10);
 	}
 

--- a/fdbserver/tlog/TLogServer.actor.cpp
+++ b/fdbserver/tlog/TLogServer.actor.cpp
@@ -2681,6 +2681,14 @@ Future<Void> respondToRecovered(TLogInterface tli, Promise<Void> recoveryComplet
 }
 
 Future<Void> trackRecoveryReq(TLogInterface tli, TrackTLogRecoveryRequest req, Reference<LogData> logData) {
+	// Block recovery version tracking when disableTLogRecoveryFinish is set in simulation.
+	// This prevents recoveredVersion from advancing in trackTLogRecoveryActor, which in turn
+	// prevents purgeOldRecoveredGenerationsCoreState from GC'ing old TLog generations.
+	// Without this, the GcGenerations test accumulation phase races with generation GC.
+	while (g_network->isSimulated() && g_simulator->disableTLogRecoveryFinish) {
+		co_await delay(10);
+	}
+
 	while (true) {
 		Version oldestGenerationRecoverAtVersion = invalidVersion;
 		for (const auto& [tag, genVersions] : logData->tagUnpoppedOldGenerations) {

--- a/fdbserver/workloads/GcGenerations.cpp
+++ b/fdbserver/workloads/GcGenerations.cpp
@@ -186,8 +186,7 @@ struct GcGenerationsWorkload : TestWorkload {
 
 			auto masterAddr = self->dbInfo->get().master.address();
 			TraceEvent("RebootingPrimaryDcMaster").detail("Iteration", successfulReboots).detail("Master", masterAddr);
-			g_simulator->rebootProcess(g_simulator->getProcessByAddress(masterAddr),
-			                           ISimulator::KillType::Reboot);
+			g_simulator->rebootProcess(g_simulator->getProcessByAddress(masterAddr), ISimulator::KillType::Reboot);
 
 			// Wait for recovery to create a new generation.
 			while (self->dbInfo->get().logSystemConfig.oldTLogs.size() == generationCount ||
@@ -243,8 +242,7 @@ struct GcGenerationsWorkload : TestWorkload {
 			co_await self->dbAvailable(self);
 			auto masterAddr = self->dbInfo->get().master.address();
 			TraceEvent("RebootMasterForGC").detail("Master", masterAddr);
-			g_simulator->rebootProcess(g_simulator->getProcessByAddress(masterAddr),
-			                           ISimulator::KillType::Reboot);
+			g_simulator->rebootProcess(g_simulator->getProcessByAddress(masterAddr), ISimulator::KillType::Reboot);
 			// Give this recovery cycle time to GC before retrying.
 			co_await delay(60);
 			co_await self->dbAvailable(self);

--- a/fdbserver/workloads/GcGenerations.cpp
+++ b/fdbserver/workloads/GcGenerations.cpp
@@ -149,8 +149,11 @@ struct GcGenerationsWorkload : TestWorkload {
 			g_simulator->rebootProcess(g_simulator->getProcessByAddress(self->dbInfo->get().master.address()),
 			                           ISimulator::KillType::Reboot);
 
-			// Wait for recovery
-			while (self->dbInfo->get().logSystemConfig.oldTLogs.size() == generationCount ||
+			// Wait for recovery to create a new generation.
+			// Use <= (not ==) so the loop only exits when oldTLogs has strictly grown.
+			// With ==, a generation GC that reduces oldTLogs.size() below generationCount
+			// would also exit the loop, then the ASSERT(size > generationCount) would fire.
+			while (self->dbInfo->get().logSystemConfig.oldTLogs.size() <= generationCount ||
 			       self->dbInfo->get().recoveryState < RecoveryState::RECOVERY_TRANSACTION) {
 				co_await self->dbInfo->onChange();
 			}

--- a/fdbserver/workloads/GcGenerations.cpp
+++ b/fdbserver/workloads/GcGenerations.cpp
@@ -156,25 +156,6 @@ struct GcGenerationsWorkload : TestWorkload {
 		}
 	}
 
-	// Reboot the master, but only if it's in the primary DC. If the master is in the
-	// remote DC, wait and retry until a primary DC master is elected.
-	Future<Void> rebootPrimaryMaster(GcGenerationsWorkload* self) {
-		while (true) {
-			co_await self->dbAvailable(self);
-			if (self->isMasterInRemoteDc(self)) {
-				TraceEvent("RebootPrimaryMasterSkipRemote")
-				    .detail("MasterAddr", self->dbInfo->get().master.address());
-				co_await delay(5);
-				continue;
-			}
-			TraceEvent("RebootPrimaryMaster").detail("Master", self->dbInfo->get().master.address());
-			g_simulator->rebootProcess(
-			    g_simulator->getProcessByAddress(self->dbInfo->get().master.address()),
-			    ISimulator::KillType::Reboot);
-			co_return;
-		}
-	}
-
 	Future<Void> generateMultipleTxnGenerations(GcGenerationsWorkload* self, Database cx) {
 		co_await self->clogRemoteDc(self, cx);
 		int generationCount = 0;
@@ -256,8 +237,14 @@ struct GcGenerationsWorkload : TestWorkload {
 		// generations before remoteRecoveredVersion advances past their recoverAt,
 		// and purgeOldRecoveredGenerationsCoreState only purges generations below that.
 		// Retry periodically until oldTLogs is reduced.
+		// Note: the remote DC is unclogged now, so any master (including remote DC)
+		// can coordinate recovery. No need for the primary-DC-only guard here.
 		while (self->dbInfo->get().logSystemConfig.oldTLogs.size() > 1) {
-			co_await self->rebootPrimaryMaster(self);
+			co_await self->dbAvailable(self);
+			auto masterAddr = self->dbInfo->get().master.address();
+			TraceEvent("RebootMasterForGC").detail("Master", masterAddr);
+			g_simulator->rebootProcess(g_simulator->getProcessByAddress(masterAddr),
+			                           ISimulator::KillType::Reboot);
 			// Give this recovery cycle time to GC before retrying.
 			co_await delay(60);
 			co_await self->dbAvailable(self);

--- a/fdbserver/workloads/GcGenerations.cpp
+++ b/fdbserver/workloads/GcGenerations.cpp
@@ -66,6 +66,17 @@ struct GcGenerationsWorkload : TestWorkload {
 	Future<bool> check(Database const& cx) override { return true; }
 	void getMetrics(std::vector<PerfMetric>& m) override {}
 
+	// Ensure simulator state is cleaned up even if the workload is cancelled by timeout.
+	// Without this, a timeout leaves the cluster permanently degraded: remote DC clogged,
+	// connection failures active, disableTLogRecoveryFinish=true — causing Cycle check to fail.
+	~GcGenerationsWorkload() {
+		if (g_network && g_network->isSimulated()) {
+			unclogAll();
+			disableConnectionFailures("GcGenerations");
+			g_simulator->disableTLogRecoveryFinish = false;
+		}
+	}
+
 	void unclogAll() {
 		TraceEvent("GcGenerationsUnclogRemote").detail("UnclogConnectionCount", cloggedPairs.size());
 		// unclog previously clogged connections
@@ -129,7 +140,8 @@ struct GcGenerationsWorkload : TestWorkload {
 	Future<Void> generateMultipleTxnGenerations(GcGenerationsWorkload* self, Database cx) {
 		co_await self->clogRemoteDc(self, cx);
 		int generationCount = 0;
-		for (int i = 0; i < 6; ++i) {
+		int successfulReboots = 0;
+		while (successfulReboots < 6) {
 			// Sometimes Cycle Setup can take a long time, so we need to extend
 			// connection failures injection for clogRemoteDc() to work properly.
 			// We also want to make sure connection failures are still active when we
@@ -139,15 +151,28 @@ struct GcGenerationsWorkload : TestWorkload {
 
 			co_await delay(30);
 			TraceEvent("WaitingForDbAvailable")
-			    .detail("Index", i)
+			    .detail("Iteration", successfulReboots)
 			    .detail("RecoveryState", self->dbInfo->get().recoveryState);
 			co_await self->dbAvailable(self);
 			generationCount = self->dbInfo->get().logSystemConfig.oldTLogs.size();
-			TraceEvent("WaitingForDbAvailableDone")
-			    .detail("Index", i)
-			    .detail("Master", self->dbInfo->get().master.address());
-			g_simulator->rebootProcess(g_simulator->getProcessByAddress(self->dbInfo->get().master.address()),
-			                           ISimulator::KillType::Reboot);
+
+			// Only reboot the master if it's in the primary DC. If it's in the clogged
+			// remote DC, recovery will stall because the master can't communicate with
+			// primary DC processes. Loop back and try again.
+			auto masterAddr = self->dbInfo->get().master.address();
+			auto* masterProc = g_simulator->getProcessByAddress(masterAddr);
+			if (!masterProc || !masterProc->locality.dcId().present() ||
+			    masterProc->locality.dcId() == g_simulator->remoteDcId) {
+				TraceEvent("RetryingRemoteDcMaster")
+				    .detail("Iteration", successfulReboots)
+				    .detail("MasterAddr", masterAddr);
+				continue;
+			}
+
+			TraceEvent("RebootingPrimaryDcMaster")
+			    .detail("Iteration", successfulReboots)
+			    .detail("Master", masterAddr);
+			g_simulator->rebootProcess(masterProc, ISimulator::KillType::Reboot);
 
 			// Wait for recovery to create a new generation.
 			// Use <= (not ==) so the loop only exits when oldTLogs has strictly grown.
@@ -158,10 +183,12 @@ struct GcGenerationsWorkload : TestWorkload {
 				co_await self->dbInfo->onChange();
 			}
 			TraceEvent("CurrentGenerations")
+			    .detail("Iteration", successfulReboots)
 			    .detail("PrevCount", generationCount)
 			    .detail("New", self->dbInfo->get().logSystemConfig.oldTLogs.size());
 			ASSERT(self->dbInfo->get().logSystemConfig.oldTLogs.size() > generationCount);
 			generationCount = self->dbInfo->get().logSystemConfig.oldTLogs.size();
+			++successfulReboots;
 		}
 		TraceEvent("AfterMultipleRecovery")
 		    .detail("OldGenerationCount", self->dbInfo->get().logSystemConfig.oldTLogs.size());

--- a/fdbserver/workloads/GcGenerations.cpp
+++ b/fdbserver/workloads/GcGenerations.cpp
@@ -224,9 +224,18 @@ struct GcGenerationsWorkload : TestWorkload {
 		self->unclogAll();
 		disableConnectionFailures("GcGenerations");
 
-		// Unblock TLogs before waiting for generation reduction
-		// The June 2025 fix prevents generation GC when TLogs are blocked
+		// Unblock TLogs before waiting for generation reduction.
+		// The trackRecoveryReq blocking prevented TLogs from reporting recovered state
+		// during accumulation. The current recovery's tracking is now stale (FinalUpdate
+		// will never fire), so we must trigger a fresh recovery by rebooting the master.
+		// The new recovery starts with clean tracking state, allowing GC to proceed.
 		g_simulator->disableTLogRecoveryFinish = false;
+
+		co_await self->dbAvailable(self);
+		auto masterAddr = self->dbInfo->get().master.address();
+		TraceEvent("RebootingMasterForGC").detail("Master", masterAddr);
+		g_simulator->rebootProcess(g_simulator->getProcessByAddress(masterAddr),
+		                           ISimulator::KillType::Reboot);
 
 		co_await self->generationReduced(self);
 

--- a/fdbserver/workloads/GcGenerations.cpp
+++ b/fdbserver/workloads/GcGenerations.cpp
@@ -173,10 +173,7 @@ struct GcGenerationsWorkload : TestWorkload {
 			g_simulator->rebootProcess(masterProc, ISimulator::KillType::Reboot);
 
 			// Wait for recovery to create a new generation.
-			// Use <= (not ==) so the loop only exits when oldTLogs has strictly grown.
-			// With ==, a generation GC that reduces oldTLogs.size() below generationCount
-			// would also exit the loop, then the ASSERT(size > generationCount) would fire.
-			while (self->dbInfo->get().logSystemConfig.oldTLogs.size() <= generationCount ||
+			while (self->dbInfo->get().logSystemConfig.oldTLogs.size() == generationCount ||
 			       self->dbInfo->get().recoveryState < RecoveryState::RECOVERY_TRANSACTION) {
 				co_await self->dbInfo->onChange();
 			}

--- a/fdbserver/workloads/GcGenerations.cpp
+++ b/fdbserver/workloads/GcGenerations.cpp
@@ -137,17 +137,35 @@ struct GcGenerationsWorkload : TestWorkload {
 		}
 	}
 
+	// Reboot the master, but only if it's in the primary DC. If the master is in the
+	// remote DC, wait and retry until a primary DC master is elected.
+	Future<Void> rebootPrimaryMaster(GcGenerationsWorkload* self) {
+		while (true) {
+			co_await self->dbAvailable(self);
+			auto masterAddr = self->dbInfo->get().master.address();
+			auto* masterProc = g_simulator->getProcessByAddress(masterAddr);
+			if (!masterProc || !masterProc->locality.dcId().present() ||
+			    masterProc->locality.dcId() == g_simulator->remoteDcId) {
+				TraceEvent("RebootPrimaryMasterSkipRemote").detail("MasterAddr", masterAddr);
+				co_await delay(5);
+				continue;
+			}
+			TraceEvent("RebootPrimaryMaster").detail("Master", masterAddr);
+			g_simulator->rebootProcess(masterProc, ISimulator::KillType::Reboot);
+			co_return;
+		}
+	}
+
 	Future<Void> generateMultipleTxnGenerations(GcGenerationsWorkload* self, Database cx) {
 		co_await self->clogRemoteDc(self, cx);
 		int generationCount = 0;
 		int successfulReboots = 0;
 		while (successfulReboots < 6) {
-			// Sometimes Cycle Setup can take a long time, so we need to extend
-			// connection failures injection for clogRemoteDc() to work properly.
-			// We also want to make sure connection failures are still active when we
-			// are triggering recoveries within this actor, so the assertion below
-			// is true.
-			extendConnectionFailures("GcGenerations", FLOW_KNOBS->SIM_SPEEDUP_AFTER_SECONDS);
+			// Re-enable connection failures each iteration to keep the partition active.
+			// Using enableConnectionFailures (not extendConnectionFailures) resets
+			// connectionFailureEnableTime, which prevents the peek cursor assertion
+			// in LogSystemPeekCursor from firing while clogged pairs are still active.
+			enableConnectionFailures("GcGenerations", FLOW_KNOBS->SIM_SPEEDUP_AFTER_SECONDS);
 
 			co_await delay(30);
 			TraceEvent("WaitingForDbAvailable")
@@ -189,22 +207,6 @@ struct GcGenerationsWorkload : TestWorkload {
 		    .detail("OldGenerationCount", self->dbInfo->get().logSystemConfig.oldTLogs.size());
 	}
 
-	Future<Void> generationReduced(GcGenerationsWorkload* self) {
-		TraceEvent("WaitForGenerationReduction")
-		    .detail("GenerationCount", self->dbInfo->get().logSystemConfig.oldTLogs.size())
-		    .detail("RecoveryState", self->dbInfo->get().recoveryState);
-		while (self->dbInfo->get().logSystemConfig.oldTLogs.size() > 1 ||
-		       self->dbInfo->get().recoveryState < RecoveryState::ACCEPTING_COMMITS) {
-			TraceEvent("WaitForGenerationReduction")
-			    .detail("GenerationCount", self->dbInfo->get().logSystemConfig.oldTLogs.size())
-			    .detail("RecoveryState", self->dbInfo->get().recoveryState);
-			co_await self->dbInfo->onChange();
-		}
-		TraceEvent("WaitForGenerationReduction")
-		    .detail("GenerationCount", self->dbInfo->get().logSystemConfig.oldTLogs.size())
-		    .detail("RecoveryState", self->dbInfo->get().recoveryState);
-	}
-
 	Future<Void> gcGenerationsTestClient(GcGenerationsWorkload* self, Database cx) {
 		co_await delay(self->startDelay);
 
@@ -231,13 +233,20 @@ struct GcGenerationsWorkload : TestWorkload {
 		// The new recovery starts with clean tracking state, allowing GC to proceed.
 		g_simulator->disableTLogRecoveryFinish = false;
 
-		co_await self->dbAvailable(self);
-		auto masterAddr = self->dbInfo->get().master.address();
-		TraceEvent("RebootingMasterForGC").detail("Master", masterAddr);
-		g_simulator->rebootProcess(g_simulator->getProcessByAddress(masterAddr),
-		                           ISimulator::KillType::Reboot);
-
-		co_await self->generationReduced(self);
+		// Reboot the master to trigger fresh recoveries with clean tracking state.
+		// GC may need multiple recovery cycles: remote TLogs must catch up from old
+		// generations before remoteRecoveredVersion advances past their recoverAt,
+		// and purgeOldRecoveredGenerationsCoreState only purges generations below that.
+		// Retry periodically until oldTLogs is reduced.
+		while (self->dbInfo->get().logSystemConfig.oldTLogs.size() > 1) {
+			co_await self->rebootPrimaryMaster(self);
+			// Give this recovery cycle time to GC before retrying.
+			co_await delay(60);
+			co_await self->dbAvailable(self);
+			TraceEvent("GcGenerationsWaitingForReduction")
+			    .detail("OldTLogs", self->dbInfo->get().logSystemConfig.oldTLogs.size())
+			    .detail("RecoveryState", self->dbInfo->get().recoveryState);
+		}
 
 		TraceEvent("WaitingForDbFullyRecovered").detail("RecoveryState", self->dbInfo->get().recoveryState);
 		while (self->dbInfo->get().recoveryState != RecoveryState::FULLY_RECOVERED) {

--- a/fdbserver/workloads/GcGenerations.cpp
+++ b/fdbserver/workloads/GcGenerations.cpp
@@ -169,9 +169,7 @@ struct GcGenerationsWorkload : TestWorkload {
 				continue;
 			}
 
-			TraceEvent("RebootingPrimaryDcMaster")
-			    .detail("Iteration", successfulReboots)
-			    .detail("Master", masterAddr);
+			TraceEvent("RebootingPrimaryDcMaster").detail("Iteration", successfulReboots).detail("Master", masterAddr);
 			g_simulator->rebootProcess(masterProc, ISimulator::KillType::Reboot);
 
 			// Wait for recovery to create a new generation.

--- a/fdbserver/workloads/GcGenerations.cpp
+++ b/fdbserver/workloads/GcGenerations.cpp
@@ -131,9 +131,28 @@ struct GcGenerationsWorkload : TestWorkload {
 		    .detail("CloggedRemoteProcess", describe(remoteIps));
 	}
 
+	bool isMasterInRemoteDc(GcGenerationsWorkload* self) {
+		auto masterAddr = self->dbInfo->get().master.address();
+		auto* masterProc = g_simulator->getProcessByAddress(masterAddr);
+		return !masterProc || !masterProc->locality.dcId().present() ||
+		       masterProc->locality.dcId() == g_simulator->remoteDcId;
+	}
+
+	// Wait for the DB to reach ACCEPTING_COMMITS. If the master is in the clogged
+	// remote DC, reboot it to force the CC to elect a primary DC master — otherwise
+	// recovery can never complete and we'd block forever.
 	Future<Void> dbAvailable(GcGenerationsWorkload* self) {
 		while (self->dbInfo->get().recoveryState < RecoveryState::ACCEPTING_COMMITS) {
 			co_await self->dbInfo->onChange();
+			if (self->dbInfo->get().recoveryState < RecoveryState::ACCEPTING_COMMITS &&
+			    self->isMasterInRemoteDc(self)) {
+				auto masterAddr = self->dbInfo->get().master.address();
+				auto* masterProc = g_simulator->getProcessByAddress(masterAddr);
+				TraceEvent("DbAvailableRebootRemoteMaster").detail("MasterAddr", masterAddr);
+				if (masterProc) {
+					g_simulator->rebootProcess(masterProc, ISimulator::KillType::Reboot);
+				}
+			}
 		}
 	}
 
@@ -142,16 +161,16 @@ struct GcGenerationsWorkload : TestWorkload {
 	Future<Void> rebootPrimaryMaster(GcGenerationsWorkload* self) {
 		while (true) {
 			co_await self->dbAvailable(self);
-			auto masterAddr = self->dbInfo->get().master.address();
-			auto* masterProc = g_simulator->getProcessByAddress(masterAddr);
-			if (!masterProc || !masterProc->locality.dcId().present() ||
-			    masterProc->locality.dcId() == g_simulator->remoteDcId) {
-				TraceEvent("RebootPrimaryMasterSkipRemote").detail("MasterAddr", masterAddr);
+			if (self->isMasterInRemoteDc(self)) {
+				TraceEvent("RebootPrimaryMasterSkipRemote")
+				    .detail("MasterAddr", self->dbInfo->get().master.address());
 				co_await delay(5);
 				continue;
 			}
-			TraceEvent("RebootPrimaryMaster").detail("Master", masterAddr);
-			g_simulator->rebootProcess(masterProc, ISimulator::KillType::Reboot);
+			TraceEvent("RebootPrimaryMaster").detail("Master", self->dbInfo->get().master.address());
+			g_simulator->rebootProcess(
+			    g_simulator->getProcessByAddress(self->dbInfo->get().master.address()),
+			    ISimulator::KillType::Reboot);
 			co_return;
 		}
 	}
@@ -177,18 +196,17 @@ struct GcGenerationsWorkload : TestWorkload {
 			// Only reboot the master if it's in the primary DC. If it's in the clogged
 			// remote DC, recovery will stall because the master can't communicate with
 			// primary DC processes. Loop back and try again.
-			auto masterAddr = self->dbInfo->get().master.address();
-			auto* masterProc = g_simulator->getProcessByAddress(masterAddr);
-			if (!masterProc || !masterProc->locality.dcId().present() ||
-			    masterProc->locality.dcId() == g_simulator->remoteDcId) {
+			if (self->isMasterInRemoteDc(self)) {
 				TraceEvent("RetryingRemoteDcMaster")
 				    .detail("Iteration", successfulReboots)
-				    .detail("MasterAddr", masterAddr);
+				    .detail("MasterAddr", self->dbInfo->get().master.address());
 				continue;
 			}
 
+			auto masterAddr = self->dbInfo->get().master.address();
 			TraceEvent("RebootingPrimaryDcMaster").detail("Iteration", successfulReboots).detail("Master", masterAddr);
-			g_simulator->rebootProcess(masterProc, ISimulator::KillType::Reboot);
+			g_simulator->rebootProcess(g_simulator->getProcessByAddress(masterAddr),
+			                           ISimulator::KillType::Reboot);
 
 			// Wait for recovery to create a new generation.
 			while (self->dbInfo->get().logSystemConfig.oldTLogs.size() == generationCount ||


### PR DESCRIPTION
…ryFinish is set

disableTLogRecoveryFinish only blocked TLogRecoveryFinishedRequest but not TrackTLogRecoveryRequest. This allowed recoveredVersion to advance and purgeOldRecoveredGenerationsCoreState to GC generations during the accumulation phase, causing the test assertion to fire when oldTLogs shrank instead of grew. Also fix the wait loop predicate to use <= instead of == so it only exits on strict growth.

Fixes fdbserver -r simulation -f tests/slow/GcGenerations.toml -s 661112997 -b on
