### PR TITLE
Harden parseErrorCodeFromS3 to never throw on non-XML responses 7.3

### DIFF
--- a/fdbclient/S3BlobStore.actor.cpp
+++ b/fdbclient/S3BlobStore.actor.cpp
@@ -923,7 +923,6 @@ ACTOR Future<Reference<HTTP::IncomingResponse>> doRequest_impl(Reference<S3BlobS
 
 	state int maxTries = std::min(bstore->knobs.request_tries, bstore->knobs.connect_tries);
 	state int thisTry = 1;
-	state int badRequestCode = 400;
 	state double nextRetryDelay = 2.0;
 
 	loop {
@@ -1066,8 +1065,8 @@ ACTOR Future<Reference<HTTP::IncomingResponse>> doRequest_impl(Reference<S3BlobS
 			event.detail("ResponseCode", r->code);
 			std::string s3Error = parseErrorCodeFromS3(r->data.content);
 			event.detail("S3ErrorCode", s3Error);
-			if (r->code == badRequestCode) {
-				TraceEvent(SevWarnAlways, "S3BlobStoreBadRequest")
+			if (r->code >= 400 && r->code < 500) {
+				TraceEvent(SevWarnAlways, "S3BlobStoreClientError")
 				    .detail("HttpCode", r->code)
 				    .detail("HttpResponseContent", r->data.content)
 				    .detail("S3Error", s3Error);

--- a/fdbclient/S3BlobStore.actor.cpp
+++ b/fdbclient/S3BlobStore.actor.cpp
@@ -1027,13 +1027,16 @@ ACTOR Future<Reference<HTTP::IncomingResponse>> doRequest_impl(Reference<S3BlobS
 
 		// If err is not present then r is valid.
 		// If r->code is in successCodes then record the successful request and return r.
-		if (!err.present() && successCodes.count(r->code) != 0) {
-			bstore->s_stats.requests_successful++;
-			++bstore->blobStats->requestsSuccessful;
-			return r;
+		if (!err.present()) {
+			ASSERT(r);
+			if (successCodes.count(r->code) != 0) {
+				bstore->s_stats.requests_successful++;
+				++bstore->blobStats->requestsSuccessful;
+				return r;
+			}
 		}
 
-		// Otherwise, this request is considered failed.  Update failure count.
+		// This request is considered failed.  Update failure count.
 		bstore->s_stats.requests_failed++;
 		++bstore->blobStats->requestsFailed;
 
@@ -1051,25 +1054,14 @@ ACTOR Future<Reference<HTTP::IncomingResponse>> doRequest_impl(Reference<S3BlobS
 		                 retryable ? (fastRetry ? "S3BlobStoreEndpointRequestFailedFastRetryable"
 		                                        : "S3BlobStoreEndpointRequestFailedRetryable")
 		                           : "S3BlobStoreEndpointRequestFailed");
+		event.suppressFor(1);
 
 		bool connectionFailed = false;
-		// Attach err to trace event if present, otherwise extract some stuff from the response
+
 		if (err.present()) {
 			event.errorUnsuppressed(err.get());
 			if (err.get().code() == error_code_connection_failed) {
 				connectionFailed = true;
-			}
-		}
-		event.suppressFor(60);
-		if (!err.present()) {
-			event.detail("ResponseCode", r->code);
-			std::string s3Error = parseErrorCodeFromS3(r->data.content);
-			event.detail("S3ErrorCode", s3Error);
-			if (r->code >= 400 && r->code < 500) {
-				TraceEvent(SevWarnAlways, "S3BlobStoreClientError")
-				    .detail("HttpCode", r->code)
-				    .detail("HttpResponseContent", r->data.content)
-				    .detail("S3Error", s3Error);
 			}
 		}
 
@@ -1085,6 +1077,19 @@ ACTOR Future<Reference<HTTP::IncomingResponse>> doRequest_impl(Reference<S3BlobS
 			event.detail("RemoteEndpoint", remoteAddress.get());
 		else
 			event.detail("RemoteHost", bstore->host);
+
+		if (r) {
+			event.detail("ResponseCode", r->code);
+			event.detail("HttpResponseContent", r->data.content);
+			std::string s3Error = parseErrorCodeFromS3(r->data.content);
+			event.detail("S3ErrorCode", s3Error);
+			if (r->code >= 400 && r->code < 500) {
+				TraceEvent(SevWarnAlways, "S3BlobStoreClientError")
+				    .detail("HttpCode", r->code)
+				    .detail("HttpResponseContent", r->data.content)
+				    .detail("S3Error", s3Error);
+			}
+		}
 
 		event.detail("Verb", verb)
 		    .detail("Resource", resource)

--- a/fdbclient/S3BlobStore.actor.cpp
+++ b/fdbclient/S3BlobStore.actor.cpp
@@ -846,6 +846,38 @@ std::string awsCanonicalURI(const std::string& resource, std::vector<std::string
 	return canonicalURI;
 }
 
+// ref: https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html
+// Returns the S3 error code string from an XML error response, or "" if the response
+// cannot be parsed. This is best-effort for logging/diagnostics only — many HTTP error
+// responses (502/503 from load balancers, empty bodies, HTML responses) are not XML.
+std::string parseErrorCodeFromS3(const std::string& response) {
+	if (response.empty()) {
+		return "";
+	}
+	try {
+		std::vector<char> xmlBuffer(response.begin(), response.end());
+		xmlBuffer.push_back('\0');
+		xml_document<> doc;
+		doc.parse<0>(&xmlBuffer[0]);
+		xml_node<>* root = doc.first_node("Error");
+		if (!root) {
+			return "";
+		}
+		xml_node<>* codeNode = root->first_node("Code");
+		if (!codeNode) {
+			return "";
+		}
+		return std::string(codeNode->value());
+	} catch (...) {
+		// Parse failures are expected for non-XML responses (HTML error pages, empty bodies, etc.)
+		TraceEvent("ParseS3ErrorCodeNonXML")
+		    .suppressFor(60)
+		    .detail("ResponseSize", response.size())
+		    .detail("ResponseHead", response.substr(0, 200));
+		return "";
+	}
+}
+
 // Do a request, get a Response.
 // Request content is provided as UnsentPacketQueue *pContent which will be depleted as bytes are sent but the queue
 // itself must live for the life of this actor and be destroyed by the caller
@@ -891,6 +923,7 @@ ACTOR Future<Reference<HTTP::IncomingResponse>> doRequest_impl(Reference<S3BlobS
 
 	state int maxTries = std::min(bstore->knobs.request_tries, bstore->knobs.connect_tries);
 	state int thisTry = 1;
+	state int badRequestCode = 400;
 	state double nextRetryDelay = 2.0;
 
 	loop {
@@ -1031,6 +1064,14 @@ ACTOR Future<Reference<HTTP::IncomingResponse>> doRequest_impl(Reference<S3BlobS
 		event.suppressFor(60);
 		if (!err.present()) {
 			event.detail("ResponseCode", r->code);
+			std::string s3Error = parseErrorCodeFromS3(r->data.content);
+			event.detail("S3ErrorCode", s3Error);
+			if (r->code == badRequestCode) {
+				TraceEvent(SevWarnAlways, "S3BlobStoreBadRequest")
+				    .detail("HttpCode", r->code)
+				    .detail("HttpResponseContent", r->data.content)
+				    .detail("S3Error", s3Error);
+			}
 		}
 
 		event.detail("ConnectionEstablished", connectionEstablished);
@@ -1932,5 +1973,68 @@ TEST_CASE("/backup/s3/guess_region") {
 		// conversion of 922337203685477580700 to long int will overflow
 		ASSERT_EQ(e.code(), error_code_backup_invalid_url);
 	}
+	return Void();
+}
+
+TEST_CASE("/backup/s3/parseErrorCodeFromS3") {
+	// Valid S3 error XML — should extract the error code
+	{
+		std::string xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+		                  "<Error><Code>AccessDenied</Code>"
+		                  "<Message>Access Denied</Message></Error>";
+		ASSERT(parseErrorCodeFromS3(xml) == "AccessDenied");
+	}
+
+	// InvalidToken error
+	{
+		std::string xml = "<Error><Code>InvalidToken</Code>"
+		                  "<Message>The provided token is malformed or otherwise invalid.</Message></Error>";
+		ASSERT(parseErrorCodeFromS3(xml) == "InvalidToken");
+	}
+
+	// ExpiredToken error
+	{
+		std::string xml = "<Error><Code>ExpiredToken</Code><Message>Token expired</Message></Error>";
+		ASSERT(parseErrorCodeFromS3(xml) == "ExpiredToken");
+	}
+
+	// Missing <Code> node — should return ""
+	{
+		std::string xml = "<Error><Message>Something went wrong</Message></Error>";
+		ASSERT(parseErrorCodeFromS3(xml) == "");
+	}
+
+	// No <Error> root — should return ""
+	{
+		std::string xml = "<ListBucketResult><Name>bucket</Name></ListBucketResult>";
+		ASSERT(parseErrorCodeFromS3(xml) == "");
+	}
+
+	// Empty response — should return ""
+	{
+		ASSERT(parseErrorCodeFromS3("") == "");
+	}
+
+	// HTML error page from load balancer (502/503) — should return "", not throw
+	{
+		std::string html = "<html><body><h1>502 Bad Gateway</h1></body></html>";
+		ASSERT(parseErrorCodeFromS3(html) == "");
+	}
+
+	// Completely invalid / garbage — should return "", not throw
+	{
+		ASSERT(parseErrorCodeFromS3("not xml at all {{{") == "");
+	}
+
+	// Partial XML — should return "", not throw
+	{
+		ASSERT(parseErrorCodeFromS3("<Error><Code>Incomple") == "");
+	}
+
+	// Plain text error — should return "", not throw
+	{
+		ASSERT(parseErrorCodeFromS3("Internal Server Error") == "");
+	}
+
 	return Void();
 }

--- a/fdbclient/S3BlobStore.actor.cpp
+++ b/fdbclient/S3BlobStore.actor.cpp
@@ -1083,12 +1083,6 @@ ACTOR Future<Reference<HTTP::IncomingResponse>> doRequest_impl(Reference<S3BlobS
 			event.detail("HttpResponseContent", r->data.content);
 			std::string s3Error = parseErrorCodeFromS3(r->data.content);
 			event.detail("S3ErrorCode", s3Error);
-			if (r->code >= 400 && r->code < 500) {
-				TraceEvent(SevWarnAlways, "S3BlobStoreClientError")
-				    .detail("HttpCode", r->code)
-				    .detail("HttpResponseContent", r->data.content)
-				    .detail("S3Error", s3Error);
-			}
 		}
 
 		event.detail("Verb", verb)

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -1172,7 +1172,7 @@ ACTOR Future<Void> dataDistribution(Reference<DataDistributor> self,
 			// Log every DD exit with the reason. movekeys_conflict is the most common
 			// non-kill cause — it's a normal internal restart, but was previously
 			// invisible because reportErrorsExcept suppresses logging for "normal" DD errors.
-			TraceEvent(SevWarn, "DDExiting", self->ddId).error(e).detail("ErrorCode", e.code());
+			TraceEvent(SevWarn, "DDExiting", self->ddId).error(e);
 			state std::vector<UID> teamForDroppedRange;
 			if (removeFailedServer.getFuture().isReady() && !removeFailedServer.getFuture().isError()) {
 				// Choose a random healthy team to host the to-be-dropped range.


### PR DESCRIPTION
Return "" instead of throwing on parse failures since many HTTP error responses (502/503 HTML pages, empty bodies) are not XML. Remove unused backup_parse_s3_response_failure error code. Fix const-ref parameter and add unit tests.

This is backport of #12996 and then makes use of the backported method so this PR subsumes #12979

