### PR TITLE
Add a test for logging XML formatted text through TraceEvent

### DIFF
--- a/flow/XmlTraceLogFormatter.cpp
+++ b/flow/XmlTraceLogFormatter.cpp
@@ -19,6 +19,8 @@
  */
 
 #include "flow/flow.h"
+#include "flow/ScopeExit.h"
+#include "flow/UnitTest.h"
 #include "flow/XmlTraceLogFormatter.h"
 
 void XmlTraceLogFormatter::addref() {
@@ -41,6 +43,8 @@ const char* XmlTraceLogFormatter::getFooter() const {
 	return "</Trace>\r\n";
 }
 
+static Severity xmlIllegalCharSeverity = SevWarnAlways;
+
 void XmlTraceLogFormatter::escape(std::ostringstream& oss, std::string source) const {
 	for (;;) {
 		int index = source.find_first_of(std::string({ '&', '"', '<', '>', '\r', '\n', '\0' }));
@@ -61,7 +65,7 @@ void XmlTraceLogFormatter::escape(std::ostringstream& oss, std::string source) c
 			oss << " ";
 		} else if (source[index] == '\0') {
 			oss << " ";
-			TraceEvent(SevWarnAlways, "StrippedIllegalCharacterFromTraceEvent")
+			TraceEvent(xmlIllegalCharSeverity, "StrippedIllegalCharacterFromTraceEvent")
 			    .detail("Source", StringRef(source).printable())
 			    .detail("Character", StringRef(source.substr(index, 1)).printable());
 		} else {
@@ -87,4 +91,53 @@ std::string XmlTraceLogFormatter::formatEvent(const TraceEventFields& fields) co
 
 	oss << "/>\n";
 	return std::move(oss).str();
+}
+
+// Test that TraceEvent details with XML junk get escaped.
+//
+// This doesn't attempt to ensure that whatever we log is valid XML.
+// We might be logging a response from a remote server which may or
+// may not be 100% well formed.  In this situation we want to know
+// exactly what it is telling us, so we escape meta characters but log
+// the string regardless of its parseability.
+TEST_CASE("/flow/XmlTraceEscape") {
+	std::string garbage_input = "<root attr=\"value&weird\">\n"
+	                            "  <child>Some <b>bold</b> & \"quoted\" text</child>\n"
+	                            "  <child2><![CDATA[<not>really</not> xml]]></child2>\n"
+	                            "  <empty/>\n"
+	                            "  <<<mismatched>>>>>>><<\n"
+	                            "  <weird attr='><&\"'><inner>><<&&\"\"</inner></weird>\n"
+	                            "  <!-- comment with <tags> & stuff -->\n"
+	                            "  <deep>\n"
+	                            "    <level1>\n"
+	                            "      <level2>\n"
+	                            "        <level3 attr=\"a&b<c>d\">text & more text</level3>\n"
+	                            "      </level2>\n"
+	                            "    </level1>\n"
+	                            "  </deep>\n"
+	                            "</root>"
+	                            "more junk\n"
+	                            "<<even more>\n";
+
+	auto defaultSeverity = xmlIllegalCharSeverity;
+	ScopeExit cleanup = [&]() { xmlIllegalCharSeverity = defaultSeverity; };
+
+	xmlIllegalCharSeverity = SevInfo;
+
+	TraceEvent event("TestEvent");
+	event.detail("Garbage", garbage_input);
+
+	XmlTraceLogFormatter formatter;
+	std::ostringstream output;
+	for (const auto& f : event.getFields()) {
+		formatter.escape(output, f.first);
+		formatter.escape(output, f.second);
+	}
+
+	std::string str = output.str();
+	for (const char ch : str) {
+		ASSERT(ch != '<' && ch != '>');
+	}
+
+	return Void();
 }

--- a/flow/XmlTraceLogFormatter.cpp
+++ b/flow/XmlTraceLogFormatter.cpp
@@ -93,7 +93,7 @@ std::string XmlTraceLogFormatter::formatEvent(const TraceEventFields& fields) co
 	return std::move(oss).str();
 }
 
-// Test that TraceEvent details with XML junk get escaped.
+// Test case to ensure that TraceEvent details with XML junk get escaped.
 //
 // This doesn't attempt to ensure that whatever we log is valid XML.
 // We might be logging a response from a remote server which may or


### PR DESCRIPTION
Recently there has been discussion of whether it is safe or reasonable to log a XML formatted response received from a remote server.  We do not want to have any doubt or hesitation that this is a reasonable thing to do for normal purposes of logging error details to enable future debugging.


  20260415-193055-gglass-14696c1825cf1c8c            compressed=True data_size=41359228 duration=2364296 ended=48844 fail_fast=1000 max_runs=100000 pass=48844 priority=100 remaining=0:53:33 runtime=0:51:08 sanity=False started=50549 submitted=20260415-193055 timeout=5400 username=gglass
