### PR TITLE
Convert `PriorityMultiLock` to standard coroutines

### DIFF
--- a/fdbserver/kvstore/VersionedBTree.actor.cpp
+++ b/fdbserver/kvstore/VersionedBTree.actor.cpp
@@ -40,7 +40,7 @@
 #include "flow/IRandom.h"
 #include "flow/Knobs.h"
 #include "flow/ObjectSerializer.h"
-#include "flow/PriorityMultiLock.actor.h"
+#include "flow/PriorityMultiLock.h"
 #include "flow/network.h"
 #include "flow/serialize.h"
 #include "flow/Trace.h"

--- a/fdbserver/storageserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver/storageserver.actor.cpp
@@ -65,7 +65,7 @@
 #include "flow/Error.h"
 #include "flow/Hash3.h"
 #include "flow/Histogram.h"
-#include "flow/PriorityMultiLock.actor.h"
+#include "flow/PriorityMultiLock.h"
 #include "flow/IRandom.h"
 #include "flow/IndexedSet.h"
 #include "flow/SystemMonitor.h"

--- a/flow/bench/BenchPriorityMultiLock.actor.cpp
+++ b/flow/bench/BenchPriorityMultiLock.actor.cpp
@@ -22,7 +22,7 @@
 
 #include "flow/flow.h"
 #include "flow/ThreadHelper.actor.h"
-#include "flow/PriorityMultiLock.actor.h"
+#include "flow/PriorityMultiLock.h"
 #include <deque>
 #include "flow/actorcompiler.h" // This must be the last #include.
 #include "fmt/printf.h"

--- a/flow/include/flow/PriorityMultiLock.actor.h
+++ b/flow/include/flow/PriorityMultiLock.actor.h
@@ -20,17 +20,8 @@
 
 #pragma once
 
-// When actually compiled (NO_INTELLISENSE), include the generated version of this file.  In intellisense use the source
-// version.
-#if defined(NO_INTELLISENSE) && !defined(FLOW_PRIORITYMULTILOCK_ACTOR_G_H)
-#define FLOW_PRIORITYMULTILOCK_ACTOR_G_H
-#include "flow/PriorityMultiLock.actor.g.h"
-#elif !defined(PRIORITYMULTILOCK_ACTOR_H)
-#define PRIORITYMULTILOCK_ACTOR_H
-
 #include "flow/flow.h"
 #include <boost/intrusive/list.hpp>
-#include "flow/actorcompiler.h" // This must be the last #include.
 
 #define PRIORITYMULTILOCK_DEBUG 0
 
@@ -252,10 +243,13 @@ private:
 	Promise<Void> brokenOnDestruct;
 	bool killed;
 
-	ACTOR static void handleRelease(Reference<PriorityMultiLock> self, Priority* priority, Future<Void> holder) {
+	static Future<Void> handleRelease(Uncancellable,
+	                                  Reference<PriorityMultiLock> self,
+	                                  Priority* priority,
+	                                  Future<Void> holder) {
 		pml_debug_printf("%f handleRelease self=%p start\n", now(), self.getPtr());
 		try {
-			wait(holder);
+			co_await holder;
 			pml_debug_printf("%f handleRelease self=%p success\n", now(), self.getPtr());
 		} catch (Error& e) {
 			pml_debug_printf("%f handleRelease self=%p error %s\n", now(), self.getPtr(), e.what());
@@ -276,7 +270,7 @@ private:
 	void addRunner(Lock& lock, Priority* priority) {
 		priority->runners += 1;
 		--available;
-		handleRelease(Reference<PriorityMultiLock>::addRef(this), priority, lock.promise.getFuture());
+		handleRelease(Uncancellable(), Reference<PriorityMultiLock>::addRef(this), priority, lock.promise.getFuture());
 	}
 
 	// Current maximum running tasks for the specified priority, which must have waiters
@@ -287,18 +281,18 @@ private:
 		return ceil((float)weight / totalPendingWeights * concurrency);
 	}
 
-	ACTOR static Future<Void> runner(PriorityMultiLock* self) {
-		state Future<Void> error = self->brokenOnDestruct.getFuture();
+	static Future<Void> runner(PriorityMultiLock* self) {
+		Future<Void> error = self->brokenOnDestruct.getFuture();
 
 		// Priority to try to run tasks from next
-		state WaitingPrioritiesList::iterator p = self->waitingPriorities.end();
+		WaitingPrioritiesList::iterator p = self->waitingPriorities.end();
 
-		loop {
+		while (true) {
 			pml_debug_printf("runner loop start  priority=%d  %s\n", p->priority, self->toString().c_str());
 
 			// Wait for a runner to release its lock
 			pml_debug_printf("runner loop waitTrigger  priority=%d  %s\n", p->priority, self->toString().c_str());
-			wait(self->wakeRunner.onTrigger());
+			co_await self->wakeRunner.onTrigger();
 			pml_debug_printf("%f runner loop wake  priority=%d  %s\n", now(), p->priority, self->toString().c_str());
 
 			// While there are available slots and there are waiters, launch tasks
@@ -306,7 +300,7 @@ private:
 				pml_debug_printf("  launch loop start  priority=%d  %s\n", p->priority, self->toString().c_str());
 
 				// Find the next priority with waiters and capacity.  There must be at least one.
-				loop {
+				while (true) {
 					if (p == self->waitingPriorities.end()) {
 						p = self->waitingPriorities.begin();
 					}
@@ -357,7 +351,3 @@ private:
 		}
 	}
 };
-
-#include "flow/unactorcompiler.h"
-
-#endif

--- a/flow/include/flow/PriorityMultiLock.actor.h
+++ b/flow/include/flow/PriorityMultiLock.actor.h
@@ -243,6 +243,19 @@ private:
 	Promise<Void> brokenOnDestruct;
 	bool killed;
 
+	static void releaseRunner(Reference<PriorityMultiLock> self, Priority* priority) {
+		pml_debug_printf("lock release priority %d  %s\n", (int)(priority->priority), self->toString().c_str());
+
+		pml_debug_printf("%f handleRelease self=%p releasing\n", now(), self.getPtr());
+		++self->available;
+		priority->runners -= 1;
+
+		// If there are any waiters or if the runners array is getting large, trigger the runner loop
+		if (self->waiting > 0) {
+			self->wakeRunner.trigger();
+		}
+	}
+
 	struct ReleaseHandler final : Callback<Void>, FastAllocated<ReleaseHandler> {
 		Reference<PriorityMultiLock> self;
 		Priority* priority;
@@ -250,30 +263,17 @@ private:
 		ReleaseHandler(Reference<PriorityMultiLock> self, Priority* priority)
 		  : self(std::move(self)), priority(priority) {}
 
-		void release() {
-			pml_debug_printf("lock release priority %d  %s\n", (int)(priority->priority), self->toString().c_str());
-
-			pml_debug_printf("%f handleRelease self=%p releasing\n", now(), self.getPtr());
-			++self->available;
-			priority->runners -= 1;
-
-			// If there are any waiters or if the runners array is getting large, trigger the runner loop
-			if (self->waiting > 0) {
-				self->wakeRunner.trigger();
-			}
-		}
-
 		void fire(Void const&) override {
 			Callback<Void>::remove();
 			pml_debug_printf("%f handleRelease self=%p success\n", now(), self.getPtr());
-			release();
+			releaseRunner(std::move(self), priority);
 			delete this;
 		}
 
 		void error(Error e) override {
 			Callback<Void>::remove();
 			pml_debug_printf("%f handleRelease self=%p error %s\n", now(), self.getPtr(), e.what());
-			release();
+			releaseRunner(std::move(self), priority);
 			delete this;
 		}
 	};
@@ -289,16 +289,7 @@ private:
 				pml_debug_printf("%f handleRelease self=%p success\n", now(), self.getPtr());
 			}
 
-			pml_debug_printf("lock release priority %d  %s\n", (int)(priority->priority), self->toString().c_str());
-
-			pml_debug_printf("%f handleRelease self=%p releasing\n", now(), self.getPtr());
-			++self->available;
-			priority->runners -= 1;
-
-			// If there are any waiters or if the runners array is getting large, trigger the runner loop
-			if (self->waiting > 0) {
-				self->wakeRunner.trigger();
-			}
+			releaseRunner(std::move(self), priority);
 			return;
 		}
 

--- a/flow/include/flow/PriorityMultiLock.actor.h
+++ b/flow/include/flow/PriorityMultiLock.actor.h
@@ -243,34 +243,72 @@ private:
 	Promise<Void> brokenOnDestruct;
 	bool killed;
 
-	static Future<Void> handleRelease(Uncancellable,
-	                                  Reference<PriorityMultiLock> self,
-	                                  Priority* priority,
-	                                  Future<Void> holder) {
-		pml_debug_printf("%f handleRelease self=%p start\n", now(), self.getPtr());
-		try {
-			co_await holder;
+	struct ReleaseHandler final : Callback<Void>, FastAllocated<ReleaseHandler> {
+		Reference<PriorityMultiLock> self;
+		Priority* priority;
+
+		ReleaseHandler(Reference<PriorityMultiLock> self, Priority* priority)
+		  : self(std::move(self)), priority(priority) {}
+
+		void release() {
+			pml_debug_printf("lock release priority %d  %s\n", (int)(priority->priority), self->toString().c_str());
+
+			pml_debug_printf("%f handleRelease self=%p releasing\n", now(), self.getPtr());
+			++self->available;
+			priority->runners -= 1;
+
+			// If there are any waiters or if the runners array is getting large, trigger the runner loop
+			if (self->waiting > 0) {
+				self->wakeRunner.trigger();
+			}
+		}
+
+		void fire(Void const&) override {
+			Callback<Void>::remove();
 			pml_debug_printf("%f handleRelease self=%p success\n", now(), self.getPtr());
-		} catch (Error& e) {
+			release();
+			delete this;
+		}
+
+		void error(Error e) override {
+			Callback<Void>::remove();
 			pml_debug_printf("%f handleRelease self=%p error %s\n", now(), self.getPtr(), e.what());
+			release();
+			delete this;
+		}
+	};
+
+	static void handleRelease(Reference<PriorityMultiLock> self, Priority* priority, Future<Void> holder) {
+		pml_debug_printf("%f handleRelease self=%p start\n", now(), self.getPtr());
+
+		if (holder.isReady()) {
+			if (holder.isError()) {
+				pml_debug_printf("%f handleRelease self=%p error %s\n", now(), self.getPtr(), holder.getError().what());
+			} else {
+				holder.get();
+				pml_debug_printf("%f handleRelease self=%p success\n", now(), self.getPtr());
+			}
+
+			pml_debug_printf("lock release priority %d  %s\n", (int)(priority->priority), self->toString().c_str());
+
+			pml_debug_printf("%f handleRelease self=%p releasing\n", now(), self.getPtr());
+			++self->available;
+			priority->runners -= 1;
+
+			// If there are any waiters or if the runners array is getting large, trigger the runner loop
+			if (self->waiting > 0) {
+				self->wakeRunner.trigger();
+			}
+			return;
 		}
 
-		pml_debug_printf("lock release priority %d  %s\n", (int)(priority->priority), self->toString().c_str());
-
-		pml_debug_printf("%f handleRelease self=%p releasing\n", now(), self.getPtr());
-		++self->available;
-		priority->runners -= 1;
-
-		// If there are any waiters or if the runners array is getting large, trigger the runner loop
-		if (self->waiting > 0) {
-			self->wakeRunner.trigger();
-		}
+		holder.addCallbackAndClear(new ReleaseHandler(std::move(self), priority));
 	}
 
 	void addRunner(Lock& lock, Priority* priority) {
 		priority->runners += 1;
 		--available;
-		handleRelease(Uncancellable(), Reference<PriorityMultiLock>::addRef(this), priority, lock.promise.getFuture());
+		handleRelease(Reference<PriorityMultiLock>::addRef(this), priority, lock.promise.getFuture());
 	}
 
 	// Current maximum running tasks for the specified priority, which must have waiters

--- a/flow/include/flow/PriorityMultiLock.actor.h
+++ b/flow/include/flow/PriorityMultiLock.actor.h
@@ -256,6 +256,8 @@ private:
 		}
 	}
 
+	// Keep this as a plain callback instead of a detached coroutine: this path runs once per granted
+	// lock, and the coroutine conversion added enough per-release overhead to regress the microbench.
 	struct ReleaseHandler final : Callback<Void>, FastAllocated<ReleaseHandler> {
 		Reference<PriorityMultiLock> self;
 		Priority* priority;
@@ -281,6 +283,7 @@ private:
 	static void handleRelease(Reference<PriorityMultiLock> self, Priority* priority, Future<Void> holder) {
 		pml_debug_printf("%f handleRelease self=%p start\n", now(), self.getPtr());
 
+		// Handle immediately-ready releases inline so the hot path avoids allocating a callback object.
 		if (holder.isReady()) {
 			if (holder.isError()) {
 				pml_debug_printf("%f handleRelease self=%p error %s\n", now(), self.getPtr(), holder.getError().what());

--- a/flow/include/flow/PriorityMultiLock.h
+++ b/flow/include/flow/PriorityMultiLock.h
@@ -1,5 +1,5 @@
 /*
- * PriorityMultiLock.actor.h
+ * PriorityMultiLock.h
  *
  * This source file is part of the FoundationDB open source project
  *


### PR DESCRIPTION
This PR converts `PriorityMultiLock` to standard coroutines. The first commit performed a naive conversion with the actor rewrite tool, but the following commits fixed a performance regression and even improved performance over the previous baseline. This was validated both with the `bench_priorityMultiLock` microbenchmark and end-to-end `mako` runs. Microbenchmark results are shared below:

```
  - bench_priorityMultiLock/5/0
      - 6c876a89c0dd...: 119.784 ns real, 119.776 ns cpu
      - 8d1455ef6a4d...: 1184.545 ns real, 1184.467 ns cpu
      - a9c79b257ddb...: 108.293 ns real, 108.285 ns cpu
  - bench_priorityMultiLock/1/128
      - 6c876a89c0dd...: 121.398 ns real, 121.394 ns cpu
      - 8d1455ef6a4d...: 1197.092 ns real, 1197.036 ns cpu
      - a9c79b257ddb...: 111.625 ns real, 111.608 ns cpu
  - bench_priorityMultiLock/64/128
      - 6c876a89c0dd...: 128.263 ns real, 128.253 ns cpu
      - 8d1455ef6a4d...: 1208.221 ns real, 1208.177 ns cpu
      - a9c79b257ddb...: 110.532 ns real, 110.523 ns cpu
```

Because this class is used on a very hot path, a 10:1 read-write ratio Mako test (bottlenecked on storage server CPU) showed a ~16% throughput regression with the first commit, then a ~1% throughput improvement over baseline after the final commit (this final ~1% throughput improvement may be noise, but heavily indicates there's no remaining regression).

The regression from the initial naive conversion was caused by extra coroutine overhead on each release, which was removed in the later optimization with the new `ReleaseHandler` class.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
