### PR TITLE
Forward port blob logging on error from 7.3

### DIFF
--- a/fdbclient/BlobStoreCommon.cpp
+++ b/fdbclient/BlobStoreCommon.cpp
@@ -910,7 +910,7 @@ Future<Reference<HTTP::IncomingResponse>> doRequest_impl(Reference<IBlobStoreEnd
 				connectionFailed = true;
 			}
 		}
-		event.suppressFor(60);
+		event.suppressFor(1);
 		if (!err.present()) {
 			event.detail("ResponseCode", r->code);
 		}

--- a/fdbclient/S3BlobStore.cpp
+++ b/fdbclient/S3BlobStore.cpp
@@ -422,6 +422,10 @@ bool isS3TokenError(const std::string& s3Error) {
 	return s3Error == "InvalidToken" || s3Error == "ExpiredToken";
 }
 
+// S3 returns HTTP 400 for token/auth errors (InvalidToken, ExpiredToken).
+// Used by processRequestFailure, preRetryCheck, and simulateRequestFailure.
+constexpr int s3BadRequestCode = 400;
+
 void S3BlobStoreEndpoint::setRequestHeaders(std::string const& verb,
                                             std::string const& resource,
                                             HTTP::Headers& headers) {
@@ -494,7 +498,7 @@ void S3BlobStoreEndpoint::simulateRequestFailure(std::string const& verb,
 	bool isMultipartComplete = verb == "POST" && resource.find("uploadId=") != std::string::npos &&
 	                           resource.find("partNumber=") == std::string::npos;
 	if (!isMultipartComplete) {
-		r->code = 400;
+		r->code = s3BadRequestCode;
 		simulatedTokenError = true;
 	}
 }
@@ -509,15 +513,10 @@ void S3BlobStoreEndpoint::processRequestFailure(Reference<HTTP::IncomingResponse
 		s3Error = parseErrorCodeFromS3(r->data.content);
 	}
 	event.detail("S3ErrorCode", s3Error);
+	event.detail("HttpResponseContent", r->data.content);
 
-	if (r->code == 400) {
-		if (isS3TokenError(s3Error) || simulatedTokenError) {
-			retryExtended = true;
-		}
-		TraceEvent(SevWarnAlways, "S3BlobStoreBadRequest")
-		    .detail("HttpCode", r->code)
-		    .detail("HttpResponseContent", r->data.content)
-		    .detail("S3Error", s3Error);
+	if (r->code == s3BadRequestCode && (isS3TokenError(s3Error) || simulatedTokenError)) {
+		retryExtended = true;
 	}
 }
 
@@ -560,7 +559,7 @@ Future<bool> S3BlobStoreEndpoint::preRetryCheck(std::string const& verb,
 		s3Error = parseErrorCodeFromS3(dryrunR->data.content);
 	}
 
-	if (dryrunR->code == 400 && isS3TokenError(s3Error)) {
+	if (dryrunR->code == s3BadRequestCode && isS3TokenError(s3Error)) {
 		// Token still bad — delay and skip this iteration
 		co_await ::delay(knobs.max_delay_retryable_error);
 		co_return false;


### PR DESCRIPTION
The below addition to 7.3 branch had some extra output on error. Forward-port the differences.

```
commit 3b28859b183f8f96e7fdc79818c6f0199f438726
Author: Michael Stack <saintstack@users.noreply.github.com>
Date:   Wed Apr 15 16:37:13 2026 -0700

    Harden parseErrorCodeFromS3 to never throw on non-XML responses 7.3 (#12997)
```