### PR TITLE
Fix ClientMetricRestart: Remove encryptModes and tenantModes from restart test TOMLs

### DIFF
--- a/tests/restarting/from_7.2.0_until_7.3.0/ConfigureStorageMigrationTestRestart-1.toml
+++ b/tests/restarting/from_7.2.0_until_7.3.0/ConfigureStorageMigrationTestRestart-1.toml
@@ -1,7 +1,5 @@
 [configuration]
 extraMachineCountDC = 2
-encryptModes = ['disabled']
-tenantModes = ['disabled']
 
 [[test]]
 testTitle = 'CloggedConfigureDatabaseTest'

--- a/tests/restarting/from_7.2.0_until_7.3.0/ConfigureTestRestart-1.toml
+++ b/tests/restarting/from_7.2.0_until_7.3.0/ConfigureTestRestart-1.toml
@@ -1,6 +1,4 @@
 [configuration]
-encryptModes = ['disabled']
-tenantModes = ['disabled']
 
 [[test]]
 testTitle='CloggedConfigureDatabaseTest'

--- a/tests/restarting/from_7.2.0_until_7.3.0/DrUpgradeRestart-1.toml
+++ b/tests/restarting/from_7.2.0_until_7.3.0/DrUpgradeRestart-1.toml
@@ -1,7 +1,5 @@
 [configuration]
 extraDatabaseMode = "Local"
-encryptModes = ['disabled']
-tenantModes = ['disabled']
 
 [[test]]
 testTitle = "DrUpgrade"

--- a/tests/restarting/from_7.2.4_until_7.3.0/UpgradeAndBackupRestore-1.toml
+++ b/tests/restarting/from_7.2.4_until_7.3.0/UpgradeAndBackupRestore-1.toml
@@ -1,7 +1,5 @@
 [configuration]
 storageEngineExcludeTypes = [3]
-encryptModes = ['disabled']
-tenantModes = ['disabled']
 
 [[test]]
 testTitle = 'SubmitBackup'

--- a/tests/restarting/from_7.3.0/ConfigureStorageMigrationTestRestart-1.toml
+++ b/tests/restarting/from_7.3.0/ConfigureStorageMigrationTestRestart-1.toml
@@ -1,8 +1,6 @@
 [configuration]
 storageEngineExcludeTypes=[3,5]
 extraMachineCountDC = 2
-encryptModes=['disabled']
-tenantModes=['disabled']
 
 [[test]]
 testTitle = 'CloggedConfigureDatabaseTest'

--- a/tests/restarting/from_7.3.0/ConfigureTestRestart-1.toml
+++ b/tests/restarting/from_7.3.0/ConfigureTestRestart-1.toml
@@ -1,7 +1,5 @@
 [configuration]
 storageEngineExcludeTypes=[3,5]
-tenantModes = ['disabled']
-encryptModes=['disabled']
 
 [[test]]
 testTitle='CloggedConfigureDatabaseTest'

--- a/tests/restarting/from_7.3.0/DrUpgradeRestart-1.toml
+++ b/tests/restarting/from_7.3.0/DrUpgradeRestart-1.toml
@@ -1,8 +1,6 @@
 [configuration]
 extraDatabaseMode = "Local"
 storageEngineExcludeTypes = [3,4,5]
-encryptModes = ['disabled']
-tenantModes=['disabled']
 
 
 [[test]]

--- a/tests/restarting/from_7.3.0/StorefrontTestRestart-1.toml
+++ b/tests/restarting/from_7.3.0/StorefrontTestRestart-1.toml
@@ -1,7 +1,5 @@
 [configuration]
 storageEngineExcludeTypes=[3,5]
-tenantModes = ['disabled']
-encryptModes=['disabled']
 
 [[test]]
 testTitle="StorefrontTest"

--- a/tests/restarting/from_7.3.0/UpgradeAndBackupRestore-1.toml
+++ b/tests/restarting/from_7.3.0/UpgradeAndBackupRestore-1.toml
@@ -1,7 +1,5 @@
 [configuration]
 storageEngineExcludeTypes=[3,5]
-tenantModes=['disabled']
-encryptModes=['disabled']
 
 [[test]]
 testTitle = 'SubmitBackup'

--- a/tests/restarting/from_7.3.0/VersionVectorDisableRestart-1.toml
+++ b/tests/restarting/from_7.3.0/VersionVectorDisableRestart-1.toml
@@ -1,7 +1,5 @@
 [configuration]
 storageEngineExcludeTypes=[5]
-tenantModes = ['disabled']
-encryptModes=['disabled']
 
 [[knobs]]
 enable_version_vector = true

--- a/tests/restarting/from_7.3.0/VersionVectorEnableRestart-1.toml
+++ b/tests/restarting/from_7.3.0/VersionVectorEnableRestart-1.toml
@@ -1,7 +1,5 @@
 [configuration]
 storageEngineExcludeTypes=[5]
-tenantModes = ['disabled']
-encryptModes=['disabled']
 
 [[knobs]]
 enable_version_vector = false

--- a/tests/restarting/from_7.3.0_until_7.4.0/SnapCycleRestart-1.toml
+++ b/tests/restarting/from_7.3.0_until_7.4.0/SnapCycleRestart-1.toml
@@ -1,8 +1,6 @@
 [configuration]
 storageEngineExcludeTypes=[3,4,5]
 logAntiQuorum=0
-encryptModes=['disabled']
-tenantModes=['disabled']
 
 [[test]]
 testTitle="SnapCyclePre"

--- a/tests/restarting/from_7.3.0_until_7.4.0/SnapTestAttrition-1.toml
+++ b/tests/restarting/from_7.3.0_until_7.4.0/SnapTestAttrition-1.toml
@@ -1,8 +1,6 @@
 [configuration]
 storageEngineExcludeTypes=[3,4,5]
 logAntiQuorum=0
-encryptModes=['disabled']
-tenantModes=['disabled']
 
 [[test]]
 testTitle="SnapTestPre"

--- a/tests/restarting/from_7.3.0_until_7.4.0/SnapTestRestart-1.toml
+++ b/tests/restarting/from_7.3.0_until_7.4.0/SnapTestRestart-1.toml
@@ -1,8 +1,6 @@
 [configuration]
 storageEngineExcludeTypes=[3,4,5]
 logAntiQuorum=0
-encryptModes=['disabled']
-tenantModes=['disabled']
 
 [[test]]
 testTitle="SnapTestPre"

--- a/tests/restarting/from_7.3.0_until_7.4.0/SnapTestSimpleRestart-1.toml
+++ b/tests/restarting/from_7.3.0_until_7.4.0/SnapTestSimpleRestart-1.toml
@@ -1,8 +1,6 @@
 [configuration]
 storageEngineExcludeTypes=[3,4,5]
 logAntiQuorum=0
-encryptModes=['disabled']
-tenantModes=['disabled']
 
 [[test]]
 testTitle="SnapSimplePre"

--- a/tests/restarting/from_7.3.29/ClientTransactionProfilingCorrectness-1.toml
+++ b/tests/restarting/from_7.3.29/ClientTransactionProfilingCorrectness-1.toml
@@ -1,7 +1,5 @@
 [configuration]
 storageEngineExcludeTypes=[3,5]
-tenantModes = ['disabled']
-encryptModes=['disabled']
 
 [[test]]
 testTitle="ClientTransactionProfilingCorrectness"

--- a/tests/restarting/from_7.3.29/CycleTestRestart-1.toml
+++ b/tests/restarting/from_7.3.29/CycleTestRestart-1.toml
@@ -1,7 +1,5 @@
 [configuration]
 storageEngineExcludeTypes=[3,5]
-encryptModes=['disabled']
-tenantModes=['disabled']
 
 [[test]]
 testTitle="Clogged"

--- a/tests/restarting/from_7.3.49/ClientMetricRestart-1.toml
+++ b/tests/restarting/from_7.3.49/ClientMetricRestart-1.toml
@@ -1,7 +1,5 @@
 [configuration]
 storageEngineExcludeTypes=[3,5]
-tenantModes = ['disabled']
-encryptModes=['disabled']
 
 [[test]]
 testTitle='ClientMetricRestartTest'

--- a/tests/restarting/from_7.3.5_until_7.3.29/ClientTransactionProfilingCorrectness-1.toml
+++ b/tests/restarting/from_7.3.5_until_7.3.29/ClientTransactionProfilingCorrectness-1.toml
@@ -1,6 +1,5 @@
 [configuration]
 storageEngineExcludeTypes=[3]
-tenantModes = ['disabled']
 
 [[knobs]]
 dd_physical_shard_move_probability = 0

--- a/tests/restarting/from_7.3.5_until_7.3.29/CycleTestRestart-1.toml
+++ b/tests/restarting/from_7.3.5_until_7.3.29/CycleTestRestart-1.toml
@@ -1,7 +1,5 @@
 [configuration]
 storageEngineExcludeTypes=[3]
-encryptModes=['disabled']
-tenantModes=['disabled']
 
 [[knobs]]
 dd_physical_shard_move_probability = 0

--- a/tests/restarting/from_7.4.0/SnapCycleRestart-1.toml
+++ b/tests/restarting/from_7.4.0/SnapCycleRestart-1.toml
@@ -1,8 +1,6 @@
 [configuration]
 storageEngineExcludeTypes=[3,4,5]
 logAntiQuorum=0
-tenantModes = ['disabled']
-encryptModes = ['disabled']
 
 [[knobs]]
 enable_read_lock_on_range = false 

--- a/tests/restarting/from_7.4.0/SnapTestAttrition-1.toml
+++ b/tests/restarting/from_7.4.0/SnapTestAttrition-1.toml
@@ -1,8 +1,6 @@
 [configuration]
 storageEngineExcludeTypes=[3,4,5]
 logAntiQuorum=0
-tenantModes = ['disabled']
-encryptModes = ['disabled']
 
 [[knobs]]
 enable_read_lock_on_range = false 

--- a/tests/restarting/from_7.4.0/SnapTestRestart-1.toml
+++ b/tests/restarting/from_7.4.0/SnapTestRestart-1.toml
@@ -1,8 +1,6 @@
 [configuration]
 storageEngineExcludeTypes=[3,4,5]
 logAntiQuorum=0
-tenantModes = ['disabled']
-encryptModes = ['disabled']
 
 [[knobs]]
 enable_read_lock_on_range = false 

--- a/tests/restarting/from_7.4.0/SnapTestSimpleRestart-1.toml
+++ b/tests/restarting/from_7.4.0/SnapTestSimpleRestart-1.toml
@@ -1,8 +1,6 @@
 [configuration]
 storageEngineExcludeTypes=[3,4,5]
 logAntiQuorum=0
-tenantModes = ['disabled']
-encryptModes = ['disabled']
 
 [[knobs]]
 enable_read_lock_on_range = false 


### PR DESCRIPTION
These configuration attributes were removed from SimulatedCluster when encryption at rest (#12667) and multitenant features (#12583) were deleted, but the restart test TOML files were not updated. This causes all 23 restart tests to abort with "Unknown configuration attribute".
