### PR TITLE
Remove EncryptionKey from Backup APIs that doesn't need it

### DIFF
--- a/fdbbackup/backup.cpp
+++ b/fdbbackup/backup.cpp
@@ -2530,8 +2530,7 @@ Future<Void> expireBackupData(const char* name,
                               Database db,
                               bool force,
                               Version restorableAfterVersion,
-                              std::string restorableAfterDatetime,
-                              Optional<std::string> encryptionKeyFile) {
+                              std::string restorableAfterDatetime) {
 	if (!endDatetime.empty()) {
 		Version v = co_await timeKeeperVersionFromDatetime(endDatetime, db);
 		endVersion = v;
@@ -2549,7 +2548,7 @@ Future<Void> expireBackupData(const char* name,
 	}
 
 	try {
-		Reference<IBackupContainer> c = openBackupContainer(name, destinationContainer, proxy, encryptionKeyFile);
+		Reference<IBackupContainer> c = openBackupContainer(name, destinationContainer, proxy, {});
 
 		IBackupContainer::ExpireProgress progress;
 		std::string lastProgress;
@@ -2626,10 +2625,9 @@ Future<Void> describeBackup(const char* name,
                             Optional<std::string> proxy,
                             bool deep,
                             Optional<Database> cx,
-                            bool json,
-                            Optional<std::string> encryptionKeyFile) {
+                            bool json) {
 	try {
-		Reference<IBackupContainer> c = openBackupContainer(name, destinationContainer, proxy, encryptionKeyFile);
+		Reference<IBackupContainer> c = openBackupContainer(name, destinationContainer, proxy, {});
 		BackupDescription desc = co_await c->describeBackup(deep);
 		if (cx.present())
 			co_await desc.resolveVersionTimes(cx.get());
@@ -4344,8 +4342,7 @@ int main(int argc, char* argv[]) {
 				                               db,
 				                               forceAction,
 				                               expireRestorableAfterVersion,
-				                               expireRestorableAfterDatetime,
-				                               encryptionKeyFile));
+				                               expireRestorableAfterDatetime));
 				break;
 
 			case BackupType::DELETE_BACKUP:
@@ -4366,8 +4363,7 @@ int main(int argc, char* argv[]) {
 				                             proxy,
 				                             describeDeep,
 				                             describeTimestamps ? Optional<Database>(db) : Optional<Database>(),
-				                             jsonOutput,
-				                             encryptionKeyFile));
+				                             jsonOutput));
 				break;
 
 			case BackupType::LIST:


### PR DESCRIPTION
Remove EncryptionKey from backup expire API and describe API and  as these doesn't need encryption key because they don't read any range/snapshot -> encrypted data

Simulation 100k completed
`
 20260416-185840-ak_expire_encryption-741851f6b4d6bae1 compressed=True data_size=35676450 duration=5097227 ended=100000 fail=7 fail_fast=10 max_runs=100000 pass=99993 priority=100 remaining=0 runtime=1:05:28 sanity=False started=100000 stopped=20260416-200408 submitted=20260416-185840 timeout=5400 username=ak_expire_encryption
`

Failures unrelated to this PR
