### PR TITLE
[release-7.3] Fix race condition in bindingtester Python file copy

### DIFF
--- a/cmake/AddFdbTest.cmake
+++ b/cmake/AddFdbTest.cmake
@@ -394,6 +394,10 @@ function(prepare_binding_test_files build_directory target_name target_dependenc
     COMMENT "Copy Flow tester for bindingtester")
 
   set(generated_binding_files python/fdb/fdboptions.py python/fdb/apiversion.py)
+  # Ensure Python binding files are generated before we try to copy them
+  if(WITH_PYTHON_BINDING)
+    add_dependencies(${target_name} fdb_python_options)
+  endif()
   if(WITH_JAVA_BINDING)
     if(NOT FDB_RELEASE)
       set(not_fdb_release_string "-SNAPSHOT")


### PR DESCRIPTION
Backport of #12712. This was already backported to 7.4: https://github.com/apple/foundationdb/pull/12714.

Add dependency on fdb_python_options target in prepare_binding_test_files to ensure fdboptions.py and apiversion.py are generated before the copy step tries to use them.

The race seems more likely in mac builds. I found this when cutting FDB releases. Temporary mitigation was to manually run the step of generating files first and then copying. This is the proper long-term fix for 7.3.

100K running: 20260416-230855-praza-1c83b9f0e3fb3353             compressed=True data_size=35513033 fail_fast=10 max_runs=100000 priority=100 sanity=False submitted=20260416-230855 timeout=5400 username=praza

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
