### PR TITLE
[main] Make getTeamByServers O(1) in time (#12938)

### DIFF
--- a/fdbserver/core/ServerKnobs.cpp
+++ b/fdbserver/core/ServerKnobs.cpp
@@ -1135,6 +1135,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( DD_PREFER_LOW_READ_UTIL_TEAM,                          true );
 	init( DD_TRACE_MOVE_BYTES_AVERAGE_INTERVAL,                   120);
 	init( MOVING_WINDOW_SAMPLE_SIZE,                         10000000); // 10MB
+	init( DD_TEAMS_BY_SERVER_IDS_CONSISTENCY_CHECK_PROB_SIM,       0.0 ); if( isSimulated ) DD_TEAMS_BY_SERVER_IDS_CONSISTENCY_CHECK_PROB_SIM = (deterministicRandom()->random01() * 0.4) + 0.1;
 
 	//Storage Server
 	init( STORAGE_LOGGING_DELAY,                                 5.0 );

--- a/fdbserver/core/ServerKnobs.cpp
+++ b/fdbserver/core/ServerKnobs.cpp
@@ -1125,6 +1125,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( DD_PREFER_LOW_READ_UTIL_TEAM,                          true );
 	init( DD_TRACE_MOVE_BYTES_AVERAGE_INTERVAL,                   120);
 	init( MOVING_WINDOW_SAMPLE_SIZE,                         10000000); // 10MB
+	init( DD_TEAMS_BY_SERVER_IDS_CONSISTENCY_CHECK_PROB_SIM,       0.0 ); if( isSimulated ) DD_TEAMS_BY_SERVER_IDS_CONSISTENCY_CHECK_PROB_SIM = (deterministicRandom()->random01() * 0.4) + 0.1;
 
 	//Storage Server
 	init( STORAGE_LOGGING_DELAY,                                 5.0 );

--- a/fdbserver/core/include/fdbserver/core/Knobs.h
+++ b/fdbserver/core/include/fdbserver/core/Knobs.h
@@ -1063,6 +1063,9 @@ public:
 	// Rolling window duration over which the average bytes moved by DD is calculated for the 'MovingData' trace event.
 	double DD_TRACE_MOVE_BYTES_AVERAGE_INTERVAL;
 	int64_t MOVING_WINDOW_SAMPLE_SIZE;
+	// Probability of running the consistency check between teams and teamsByServerIDs
+	// in getTeamByServers (simulation only). 0.0 in prod, random [0.1, 0.5) in simulation.
+	double DD_TEAMS_BY_SERVER_IDS_CONSISTENCY_CHECK_PROB_SIM;
 
 	// Storage Server
 	double STORAGE_LOGGING_DELAY;

--- a/fdbserver/core/include/fdbserver/core/Knobs.h
+++ b/fdbserver/core/include/fdbserver/core/Knobs.h
@@ -1064,7 +1064,7 @@ public:
 	double DD_TRACE_MOVE_BYTES_AVERAGE_INTERVAL;
 	int64_t MOVING_WINDOW_SAMPLE_SIZE;
 	// Probability of running the consistency check between teams and teamsByServerIDs
-	// in getTeamByServers (simulation only). 0.0 in prod, random [0.1, 0.5) in simulation.
+	// in getTeamByServers (simulation only).
 	double DD_TEAMS_BY_SERVER_IDS_CONSISTENCY_CHECK_PROB_SIM;
 
 	// Storage Server

--- a/fdbserver/core/include/fdbserver/core/ServerKnobs.h
+++ b/fdbserver/core/include/fdbserver/core/ServerKnobs.h
@@ -1093,6 +1093,9 @@ public:
 	// Rolling window duration over which the average bytes moved by DD is calculated for the 'MovingData' trace event.
 	double DD_TRACE_MOVE_BYTES_AVERAGE_INTERVAL;
 	int64_t MOVING_WINDOW_SAMPLE_SIZE;
+	// Probability of running the consistency check between teams and teamsByServerIDs
+	// in getTeamByServers (simulation only). 0.0 in prod, random [0.1, 0.5) in simulation.
+	double DD_TEAMS_BY_SERVER_IDS_CONSISTENCY_CHECK_PROB_SIM;
 
 	// Storage Server
 	double STORAGE_LOGGING_DELAY;

--- a/fdbserver/datadistributor/DDTeamCollection.actor.cpp
+++ b/fdbserver/datadistributor/DDTeamCollection.actor.cpp
@@ -179,13 +179,11 @@ public:
 
 	// Find the team with the exact storage servers as req.src.
 	static void getTeamByServers(DDTeamCollection* self, GetTeamRequest req) {
-		const std::string servers = TCTeamInfo::serversToString(req.src);
+		getTeamByServersConsistencyCheckInSim(self);
 		Optional<Reference<IDataDistributionTeam>> res;
-		for (const auto& team : self->teams) {
-			if (team->getServerIDsStr() == servers) {
-				res = team;
-				break;
-			}
+		auto it = self->teamsByServerIDs.find(TCTeamInfo::serversToString(req.src));
+		if (it != self->teamsByServerIDs.end()) {
+			res = it->second;
 		}
 		req.reply.send(std::make_pair(res, false));
 	}
@@ -321,6 +319,34 @@ public:
 			if (e.code() != error_code_actor_cancelled && req.reply.canBeSet())
 				req.reply.sendError(e);
 			throw;
+		}
+	}
+
+	// Probabilistic consistency check between teams and teamsByServerIDs
+	// Run only in simulation with a probability of DD_TEAMS_BY_SERVER_IDS_CONSISTENCY_CHECK_PROB_SIM
+	// We may need to tune this knob if simulation runs too slowly (in real-time) and results in
+	// ExternalTimeout in Joshua
+	static void getTeamByServersConsistencyCheckInSim(DDTeamCollection* self) {
+		// This check can be expensive in prod so only run it in simulation
+		if (!g_network->isSimulated()) {
+			return;
+		}
+
+		if (deterministicRandom()->random01() < SERVER_KNOBS->DD_TEAMS_BY_SERVER_IDS_CONSISTENCY_CHECK_PROB_SIM) {
+			std::unordered_map<std::string, Reference<TCTeamInfo>> expected;
+			for (const auto& team : self->teams) {
+				expected[team->getServerIDsStr()] = team;
+			}
+			ASSERT(expected.size() == self->teamsByServerIDs.size());
+			for (const auto& [key, value] : expected) {
+				auto it = self->teamsByServerIDs.find(key);
+				ASSERT(it != self->teamsByServerIDs.end());
+				ASSERT(it->second == value);
+			}
+			TraceEvent("TeamByServerIDsConsistencyCheckPassed")
+			    .suppressFor(5.0)
+			    .detail("TeamsSize", self->teams.size())
+			    .detail("MapSize", self->teamsByServerIDs.size());
 		}
 	}
 
@@ -4874,6 +4900,7 @@ void DDTeamCollection::addTeam(const std::vector<Reference<TCServerInfo>>& newTe
 
 	// For a good team, we add it to teams and create machine team for it when necessary
 	teams.push_back(teamInfo);
+	teamsByServerIDs[teamInfo->getServerIDsStr()] = teamInfo;
 	for (auto& server : newTeamServers) {
 		server->addTeam(teamInfo);
 	}
@@ -5800,6 +5827,10 @@ void DDTeamCollection::addServer(StorageServerInterface newServer,
 
 bool DDTeamCollection::removeTeam(Reference<TCTeamInfo> team) {
 	TraceEvent("RemovedServerTeam", distributorId).detail("Team", team->getDesc());
+	auto it = teamsByServerIDs.find(team->getServerIDsStr());
+	if (it != teamsByServerIDs.end()) {
+		teamsByServerIDs.erase(it);
+	}
 	bool found = false;
 	for (int t = 0; t < teams.size(); t++) {
 		if (teams[t] == team) {

--- a/fdbserver/datadistributor/DDTeamCollection.actor.cpp
+++ b/fdbserver/datadistributor/DDTeamCollection.actor.cpp
@@ -196,13 +196,11 @@ public:
 
 	// Find the team with the exact storage servers as req.src.
 	static void getTeamByServers(DDTeamCollection* self, GetTeamRequest req) {
-		const std::string servers = TCTeamInfo::serversToString(req.src);
+		getTeamByServersConsistencyCheckInSim(self);
 		Optional<Reference<IDataDistributionTeam>> res;
-		for (const auto& team : self->teams) {
-			if (team->getServerIDsStr() == servers) {
-				res = team;
-				break;
-			}
+		auto it = self->teamsByServerIDs.find(TCTeamInfo::serversToString(req.src));
+		if (it != self->teamsByServerIDs.end()) {
+			res = it->second;
 		}
 		req.reply.send(std::make_pair(res, false));
 	}
@@ -338,6 +336,34 @@ public:
 			if (e.code() != error_code_actor_cancelled && req.reply.canBeSet())
 				req.reply.sendError(e);
 			throw;
+		}
+	}
+
+	// Probabilistic consistency check between teams and teamsByServerIDs
+	// Run only in simulation with a probability of DD_TEAMS_BY_SERVER_IDS_CONSISTENCY_CHECK_PROB_SIM
+	// We may need to tune this knob if simulation runs too slowly (in real-time) and results in
+	// ExternalTimeout in Joshua
+	static void getTeamByServersConsistencyCheckInSim(DDTeamCollection* self) {
+		// This check can be expensive in prod so only run it in simulation
+		if (!g_network->isSimulated()) {
+			return;
+		}
+
+		if (deterministicRandom()->random01() < SERVER_KNOBS->DD_TEAMS_BY_SERVER_IDS_CONSISTENCY_CHECK_PROB_SIM) {
+			std::unordered_map<std::string, Reference<TCTeamInfo>> expected;
+			for (const auto& team : self->teams) {
+				expected[team->getServerIDsStr()] = team;
+			}
+			ASSERT(expected.size() == self->teamsByServerIDs.size());
+			for (const auto& [key, value] : expected) {
+				auto it = self->teamsByServerIDs.find(key);
+				ASSERT(it != self->teamsByServerIDs.end());
+				ASSERT(it->second == value);
+			}
+			TraceEvent("TeamByServerIDsConsistencyCheckPassed")
+			    .suppressFor(5.0)
+			    .detail("TeamsSize", self->teams.size())
+			    .detail("MapSize", self->teamsByServerIDs.size());
 		}
 	}
 
@@ -4919,6 +4945,7 @@ void DDTeamCollection::addTeam(const std::vector<Reference<TCServerInfo>>& newTe
 
 	// For a good team, we add it to teams and create machine team for it when necessary
 	teams.push_back(teamInfo);
+	teamsByServerIDs[teamInfo->getServerIDsStr()] = teamInfo;
 	for (auto& server : newTeamServers) {
 		server->addTeam(teamInfo);
 	}
@@ -5845,6 +5872,10 @@ void DDTeamCollection::addServer(StorageServerInterface newServer,
 
 bool DDTeamCollection::removeTeam(Reference<TCTeamInfo> team) {
 	TraceEvent("RemovedServerTeam", distributorId).detail("Team", team->getDesc());
+	auto it = teamsByServerIDs.find(team->getServerIDsStr());
+	if (it != teamsByServerIDs.end()) {
+		teamsByServerIDs.erase(it);
+	}
 	bool found = false;
 	for (int t = 0; t < teams.size(); t++) {
 		if (teams[t] == team) {

--- a/fdbserver/datadistributor/include/fdbserver/datadistributor/DDTeamCollection.h
+++ b/fdbserver/datadistributor/include/fdbserver/datadistributor/DDTeamCollection.h
@@ -687,7 +687,12 @@ public:
 	std::map<Standalone<StringRef>, Reference<TCMachineInfo>> machine_info;
 	std::vector<Reference<TCMachineTeamInfo>> machineTeams; // all machine teams
 
+	// IMPORTANT: teams and teamsByServerIDs MUST be consistent, so any time we
+	// mutate teams, we must also mutate teamsByServerIDs
 	std::vector<Reference<TCTeamInfo>> teams;
+	// O(1) hash map from server ID string to team information
+	// Currently used by getTeamByServers
+	std::unordered_map<std::string, Reference<TCTeamInfo>> teamsByServerIDs;
 
 	std::vector<DDTeamCollection*> teamCollections;
 	AsyncTrigger printDetailedTeamsInfo;

--- a/fdbserver/datadistributor/include/fdbserver/datadistributor/DDTeamCollection.h
+++ b/fdbserver/datadistributor/include/fdbserver/datadistributor/DDTeamCollection.h
@@ -686,7 +686,12 @@ public:
 	std::map<Standalone<StringRef>, Reference<TCMachineInfo>> machine_info;
 	std::vector<Reference<TCMachineTeamInfo>> machineTeams; // all machine teams
 
+	// IMPORTANT: teams and teamsByServerIDs MUST be consistent, so any time we
+	// mutate teams, we must also mutate teamsByServerIDs
 	std::vector<Reference<TCTeamInfo>> teams;
+	// O(1) hash map from server ID string to team information
+	// Currently used by getTeamByServers
+	std::unordered_map<std::string, Reference<TCTeamInfo>> teamsByServerIDs;
 
 	std::vector<DDTeamCollection*> teamCollections;
 	AsyncTrigger printDetailedTeamsInfo;


### PR DESCRIPTION
Forward port of https://github.com/apple/foundationdb/pull/12938. 

Under certain workloads (large data movement, storage migration, etc.), with SHARD_ENCODE_LOCATION_METADATA enabled, DD can get indefinitely stuck at initialization time, because getTeamByServers function saturates the CPU and starves other critical DD actors to complete (symptom: txn_too_old).

This PR is a perf optimization that makes getTeamByServers O(1) instead of O(teams). Previously, for every team, we were doing expensive CPU operations.

## Testing and analysis

100K results:

20260518-182541-praza-fwd-port-getTeamBySer-e4f98f2296c5aa71 compressed=True data_size=35941392 duration=4250904 ended=100000 fail=3 fail_fast=10 max_runs=100000 pass=99997 priority=100 remaining=0 runtime=1:05:02 sanity=False started=100000 stopped=20260518-193043 submitted=20260518-182541 timeout=5400 username=praza-fwd-port-getTeamByServers-main-20453d9676098857888b1d862830b25dadbbe55e

3 failures:

```
[1] TestFile=tests/slow/WriteDuringReadSwitchover.toml  RandomSeed=2666891645  BuggifyEnabled=1
    UnseedMismatch  Unseed=48713  ExpectedUnseed=72392  Severity=40

[2] TestFile=tests/fast/InventoryTestSomeWrites.toml  RandomSeed=389468833  BuggifyEnabled=1
    QuietDatabaseFailure  Severity=40  ErrorKind=Unset  Time=22458.953045  DateTime=2026-05-18T18:54:10Z  Type=QuietDatabaseFailure  Machine=[abcd::2:3:1:0]:1  ID=0000000000000000  Error=test_failed  ErrorDescription=Test failed  ErrorCode=1228  EventName=TracedTooManyLines  EventMessage=Traced 1000001 lines  Reasons=[no items]  ThreadID=12501697803017906063  Backtrace=/usr/local/bin/llvm-addr2line -e /var/joshua/ensembles/20260518-182541-praza-fwd-port-getTeamBySer-e4f98f2296c5aa71/bin/fdbserver -p -C -f -i 0x4f488af 0x4f48ba9 0x346c90d 0x4f1af6d 0x4f42d50 0x227dd1b 0x15dba68 0x4788237 0x4787d60 0x16028b1 0x7fa44dc06610  LogGroup=default  Roles=TL

[3] TestFile=tests/fast/SidebandWithStatus.toml  RandomSeed=508357272  BuggifyEnabled=1
    QuietDatabaseFailure  Severity=40  ErrorKind=Unset  Time=15200.705780  DateTime=2026-05-18T19:30:21Z  Type=QuietDatabaseFailure  Machine=[abcd::2:1:1:0]:1  ID=0000000000000000  Error=test_failed  ErrorDescription=Test failed  ErrorCode=1228  EventName=TracedTooManyLines  EventMessage=Traced 1000001 lines  Reasons=[no items]  ThreadID=10891599674997048062  Backtrace=/usr/local/bin/llvm-addr2line -e /var/joshua/ensembles/20260518-182541-praza-fwd-port-getTeamBySer-e4f98f2296c5aa71/bin/fdbserver -p -C -f -i 0x4f488af 0x4f48ba9 0x346c90d 0x4f1af6d 0x4f42d50 0x473e987 0x15dba68 0x4788237 0x4787d60 0x16028b1 0x7fdb47be1610  LogGroup=default  Roles=CC,CP,RV,SS,TL
```

Investigating.

re (1):

I don't see an obvious way I am introducing non-determinism. Let me run this test 250K times, with my change, and without my change. I'll analyze if it's my change introducing non-determinism or it's there for this test to begin with.

running tests/slow/WriteDuringReadSwitchover.toml, 250K with fail fast of 10

with my change: 20260518-195437-praza-fwd-port-getTeamBySer-0eabfa61e1710d55 compressed=True data_size=35954619 fail_fast=10 max_runs=250000 priority=100 sanity=False submitted=20260518-195437 timeout=5400 username=praza-fwd-port-getTeamByServers-main-2def2427c3455c2dd02f76c32bbc730c71baf4dc

without my change: 20260518-200016-praza-fwd-port-getTeamBySer-651b00370962678e compressed=True data_size=35953413 fail_fast=10 max_runs=250000 priority=100 sanity=False submitted=20260518-200016 timeout=5400 username=praza-fwd-port-getTeamByServers-main-7462a3ade10dc699b20e5f4e3a89117896537885

re (2): 

```
/t/r1 $ grep -ri "Type=\"Knob\".*shard_encode_location_metadata" trace.0.0.0.0.2695399.1779132312.eP2Ofz.0.1.xml
<Event Severity="10" Time="0.000000" DateTime="2026-05-18T19:25:12Z" Type="Knob" Machine="0.0.0.0:0" ID="0000000000000000" Name="shard_encode_location_metadata" Value="0" ThreadID="12501697803017906063" LogGroup="default" />
```

So shard_encode_location_metadata is off. My change should have no effect including on determinism. Easiest and quickest way to confirm: revert my change and expect same failure. 

250K with my change: 20260519-190248-praza-fwd-port-getTeamBySer-dae6d43bf770574a compressed=True data_size=35954495 fail_fast=10 max_runs=250000 priority=100 sanity=False submitted=20260519-190248 timeout=5400 username=praza-fwd-port-getTeamByServers-main-2def2427c3455c2dd02f76c32bbc730c71baf4dc

250K without my change: 20260519-191053-praza-fwd-port-getTeamBySer-4c26026f397f51a8 compressed=True data_size=35952831 fail_fast=10 max_runs=250000 priority=100 sanity=False submitted=20260519-191053 timeout=5400 username=praza-fwd-port-getTeamByServers-main-revert-7462a3ade10dc699b20e5f4e3a89117896537885

I believe the issue is not related to my change here. It has to do with recovery and LR peeks, probably similar to https://github.com/apple/foundationdb/pull/13238. Regardless see table [1] below which confirms that the tracedtoomanylines symptom exists in the baseline (without my changes) code as well. 

re (3):

```
/t/r1 $ grep -ri "Type=\"Knob\".*shard_encode_location_metadata" trace.0.0.0.0.2698823.1779133284.IOrbEB.0.1.xml
<Event Severity="10" Time="0.000000" DateTime="2026-05-18T19:41:24Z" Type="Knob" Machine="0.0.0.0:0" ID="0000000000000000" Name="shard_encode_location_metadata" Value="1" ThreadID="10891599674997048062" LogGroup="default" />
```

So could be my change. 

250K with my change: 20260519-190345-praza-fwd-port-getTeamBySer-3f716bfae8fca260 compressed=True data_size=35954485 fail_fast=10 max_runs=250000 priority=100 sanity=False submitted=20260519-190345 timeout=5400 username=praza-fwd-port-getTeamByServers-main-2def2427c3455c2dd02f76c32bbc730c71baf4dc

250K without my change: 20260519-191040-praza-fwd-port-getTeamBySer-3dec3fa1685072e3 compressed=True data_size=35953095 fail_fast=10 max_runs=250000 priority=100 sanity=False submitted=20260519-191040 timeout=5400 username=praza-fwd-port-getTeamByServers-main-revert-7462a3ade10dc699b20e5f4e3a89117896537885

I believe the issue is not related to my change here. See table [1] below which confirms that the tracedtoomanylines symptom exists in the baseline (without my changes) code as well. 


[1]: 

Findings: across all 4 ensembles, every recorded failure is TracedTooManyLines in InventoryTestSomeWrites.toml or SidebandWithStatus.toml:

  | Ensemble  | Branch              | Test                    | Failures captured            | ended / 250k |
  | --------- | ------------------- | ----------------------- | ---------------------------- | ------------ |
  | 4c26026f  | revert (no change)  | InventoryTestSomeWrites | 3 - all TracedTooManyLines   | 82,577       |
  | dae6d43b  | with change         | InventoryTestSomeWrites | 3 - all TracedTooManyLines   | 95,044       |
  | 3dec3fa1  | revert (no change)  | SidebandWithStatus      | 3 - all TracedTooManyLines   | 75,604       |
  | 3f716bfa  | with change         | SidebandWithStatus      | 1 - TracedTooManyLines       | 86,336       |

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
