### PR TITLE
Increase retry limit in ClientMetricRestart

### DIFF
--- a/fdbserver/workloads/ClientMetric.cpp
+++ b/fdbserver/workloads/ClientMetric.cpp
@@ -176,11 +176,14 @@ struct ClientMetricWorkload : TestWorkload {
 	                                               int numKeys,
 	                                               uint64_t previousVS) {
 		int retry = 0;
-		int max_retry = 10;
+		int max_retry = 50;
 		int keysLimit = 1;
 		while (true) {
 			if (retry > max_retry) {
-				// this should not happen, it should succeed after a few retry
+				TraceEvent(SevError, "WriteKeysAndGetLatencyVersionFailed")
+				    .detail("Retry", retry)
+				    .detail("MaxRetry", max_retry)
+				    .detail("PreviousVS", previousVS);
 				ASSERT(false);
 			}
 			// write random keys to generate some latency metrics


### PR DESCRIPTION
...to allow GlobalConfig propagation after restart

After an upgrade restart, GlobalConfig initialization (which carries the profiling sample rate and size limit) can take longer than the previous 10-retry limit allowed (Perhaps exposed by recent coroutine conversions and GRV proxy interface refactoring that subtly changed initialization timing). Increase to 50 retries and add a TraceEvent before the assert for easier diagnosis of future failures.

`  20260417-152816-stack_clientmetricrestart-081db78714a6fdf7 compressed=True data_size=35678478 duration=5636038 ended=99999 fail=2 fail_fast=10 max_runs=100000 pass=99997 priority=100 remaining=0:00:00 runtime=0:58:09 sanity=False started=100000 submitted=20260417-152816 timeout=5400 username=stack_clientmetricrestart`

One failure is GcGenerations, #12992. The other is tests/slow/DDBalanceAndRemoveStatus.toml which will be addressed elsewhere.
