### PR TITLE
Fix peer disconnect detection in waitValueOrSignal (#12935)

### DIFF
--- a/fdbrpc/FlowTests.actor.cpp
+++ b/fdbrpc/FlowTests.actor.cpp
@@ -27,6 +27,7 @@
 #include "flow/IThreadPool.h"
 #include "flow/WriteOnlySet.h"
 #include "fdbrpc/fdbrpc.h"
+#include "fdbrpc/FlowTransport.h"
 #include "flow/IAsyncFile.h"
 #include "flow/TLSConfig.actor.h"
 #include "flow/actorcompiler.h" // This must be the last #include.
@@ -1607,6 +1608,129 @@ TEST_CASE("/flow/flow/FlowMutex") {
 		printf("Error at count=%d\n", count + 1);
 		ASSERT(false);
 	}
+
+	return Void();
+}
+
+TEST_CASE("/fdbrpc/waitValueOrSignal/peerDisconnect") {
+	// Test that waitValueOrSignal detects peer disconnect and returns request_maybe_delivered.
+	// This reproduces the bug where DD would hang forever because waitValueOrSignal didn't
+	// watch peer->disconnect, so dead connections (e.g., from K8s NAT timeouts) were never detected.
+
+	// Construct a minimal Peer. We pass nullptr for TransportData since waitValueOrSignal
+	// only accesses peer->disconnect and PeerHolder only touches outstandingReplies.
+	NetworkAddress fakeAddr = NetworkAddress::parse("1.2.3.4:1234");
+	state Reference<Peer> peer = makeReference<Peer>(nullptr, fakeAddr);
+
+	// Create a value future that never resolves (simulating a stuck RPC to unreachable storage server)
+	state Promise<Void> neverReply;
+
+	// No failure signal either (simulating failure monitor not yet detecting the failure)
+	state Endpoint ep;
+
+	// Call waitValueOrSignal with the peer
+	state Future<ErrorOr<Void>> result =
+	    waitValueOrSignal(neverReply.getFuture(), Never(), ep, ReplyPromise<Void>(), peer);
+
+	// Result should not be ready yet - the reply hasn't come and disconnect hasn't fired
+	ASSERT(!result.isReady());
+
+	// Simulate peer disconnection (as would happen when connectionReader/connectionKeeper detects failure)
+	peer->disconnect.send(Void());
+
+	// Now waitValueOrSignal should detect the disconnect and return request_maybe_delivered
+	ASSERT(result.isReady());
+	ErrorOr<Void> r = result.get();
+	ASSERT(r.isError());
+	ASSERT(r.getError().code() == error_code_request_maybe_delivered);
+
+	return Void();
+}
+
+TEST_CASE("/fdbrpc/waitValueOrSignal/noPeerFallback") {
+	// Test that waitValueOrSignal still works correctly when no peer is provided (the default).
+	// The broken_promise path should still be handled: when the reply promise breaks,
+	// the endpoint should be marked as not found and value set to Never().
+
+	state Promise<Void> reply;
+
+	// Call waitValueOrSignal without a peer (default behavior)
+	state Future<ErrorOr<Void>> result = waitValueOrSignal(reply.getFuture(), Never(), Endpoint());
+
+	ASSERT(!result.isReady());
+
+	// Break the promise (simulating endpoint failure)
+	reply.sendError(broken_promise());
+
+	// waitValueOrSignal should handle broken_promise by setting value = Never() and looping.
+	// Since signal is Never() and there's no peer disconnect, it should now wait forever.
+	// We verify it doesn't crash and the result is NOT ready (it's stuck in the loop).
+	wait(delay(0.1));
+	ASSERT(!result.isReady());
+
+	return Void();
+}
+
+TEST_CASE("/fdbrpc/waitValueOrSignal/retryOnDisconnect") {
+	// End-to-end test of the retry pattern that loadBalance uses:
+	// 1. First attempt: RPC to peer1, peer1 disconnects → request_maybe_delivered
+	// 2. Second attempt: RPC to peer2, peer2 responds → success
+	// 3. Verify numAttempts > 1
+	//
+	// This reproduces the exact scenario in production: DD sends waitMetrics to a storage
+	// server, the K8s NAT kills the connection at ~3 minutes, and the fix ensures the
+	// request_maybe_delivered error propagates so loadBalance can retry on another server.
+
+	NetworkAddress addr1 = NetworkAddress::parse("1.2.3.4:1234");
+	NetworkAddress addr2 = NetworkAddress::parse("1.2.3.5:1234");
+	state Reference<Peer> peer1 = makeReference<Peer>(nullptr, addr1);
+	state Reference<Peer> peer2 = makeReference<Peer>(nullptr, addr2);
+
+	state int numAttempts = 0;
+
+	// --- Attempt 1: peer1 disconnects mid-request (simulating K8s NAT timeout) ---
+	{
+		state Promise<Void> reply1;
+		state Endpoint ep1;
+
+		state Future<ErrorOr<Void>> result1 =
+		    waitValueOrSignal(reply1.getFuture(), Never(), ep1, ReplyPromise<Void>(), peer1);
+
+		numAttempts++;
+		ASSERT(!result1.isReady());
+
+		// Connection killed by external factor (K8s NAT, network partition, etc.)
+		peer1->disconnect.send(Void());
+
+		// waitValueOrSignal must detect the disconnect and return request_maybe_delivered
+		ASSERT(result1.isReady());
+		ErrorOr<Void> r1 = result1.get();
+		ASSERT(r1.isError());
+		ASSERT(r1.getError().code() == error_code_request_maybe_delivered);
+	}
+
+	// --- Attempt 2: retry to peer2, which responds successfully ---
+	// This is what loadBalance does: on request_maybe_delivered, pick next alternative and retry
+	{
+		state Promise<Void> reply2;
+		state Endpoint ep2;
+
+		state Future<ErrorOr<Void>> result2 =
+		    waitValueOrSignal(reply2.getFuture(), Never(), ep2, ReplyPromise<Void>(), peer2);
+
+		numAttempts++;
+
+		// Second server is healthy and responds
+		reply2.send(Void());
+
+		ASSERT(result2.isReady());
+		ErrorOr<Void> r2 = result2.get();
+		ASSERT(r2.present()); // Success!
+	}
+
+	// The critical assertion: retries happened (numAttempts > 1)
+	ASSERT_GE(numAttempts, 2);
+	TraceEvent("WaitValueOrSignalRetryTest").detail("NumAttempts", numAttempts);
 
 	return Void();
 }

--- a/fdbrpc/FlowTests.actor.cpp
+++ b/fdbrpc/FlowTests.actor.cpp
@@ -27,7 +27,6 @@
 #include "flow/IThreadPool.h"
 #include "flow/WriteOnlySet.h"
 #include "fdbrpc/fdbrpc.h"
-#include "fdbrpc/FlowTransport.h"
 #include "flow/IAsyncFile.h"
 #include "flow/TLSConfig.actor.h"
 #include "flow/actorcompiler.h" // This must be the last #include.

--- a/fdbrpc/include/fdbrpc/genericactors.actor.h
+++ b/fdbrpc/include/fdbrpc/genericactors.actor.h
@@ -377,6 +377,13 @@ Future<ErrorOr<X>> waitValueOrSignal(Future<X> value,
 					                      ? unauthorized_attempt()
 					                      : request_maybe_delivered());
 				}
+				when(wait(peer.isValid() ? peer->disconnect.getFuture() : Never())) {
+					CODE_PROBE(true, "waitValueOrSignal detected peer disconnect");
+					TraceEvent("WaitValueOrSignalPeerDisconnect")
+					    .detail("Endpoint", endpoint.getPrimaryAddress())
+					    .detail("Token", endpoint.token);
+					return ErrorOr<X>(request_maybe_delivered());
+				}
 			}
 		} catch (Error& e) {
 			if (signal.isError()) {

--- a/fdbrpc/include/fdbrpc/genericactors.actor.h
+++ b/fdbrpc/include/fdbrpc/genericactors.actor.h
@@ -380,6 +380,7 @@ Future<ErrorOr<X>> waitValueOrSignal(Future<X> value,
 				when(wait(peer.isValid() ? peer->disconnect.getFuture() : Never())) {
 					CODE_PROBE(true, "waitValueOrSignal detected peer disconnect");
 					TraceEvent("WaitValueOrSignalPeerDisconnect")
+					    .suppressFor(1.0)
 					    .detail("Endpoint", endpoint.getPrimaryAddress())
 					    .detail("Token", endpoint.token);
 					return ErrorOr<X>(request_maybe_delivered());


### PR DESCRIPTION
Forward-port from 7.3 to 7.4.

Add a when() clause watching peer->disconnect in waitValueOrSignal (genericactors.actor.h) so dead connections (e.g., from NAT timeouts) are detected immediately instead of hanging indefinitely waiting on a connection the lower layer has already replaced.

We saw this in an incident where waiting on a long reply on a network with frequent disconnects; low level fdb would make a new connection but high-level would wait until we timed out on the original.

Includes unit tests for the peer disconnect detection.

`  20260418-153449-stack_forward_port_waitValu-96d073ac1c50ff92 compressed=True data_size=41481497 duration=4484727 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:51:47 sanity=False started=100000 stopped=20260418-162636 submitted=20260418-153449 timeout=5400 username=stack_forward_port_waitValueOrSignal`