### PR TITLE
Design changes to pass encryption_block_size to fdbbackup command and remove knob

### DIFF
--- a/fdbbackup/CMakeLists.txt
+++ b/fdbbackup/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if (NOT WIN32 AND NOT OPEN_FOR_IDE)
   enable_testing()
   add_test(NAME dir_backup_tests COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/tests/dir_backup_test.sh ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
-  add_test(NAME blob_backup_restore_tests COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/tests/blob_backup_restore_test.sh ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR} --encrypt-at-random)
+  add_test(NAME blob_backup_restore_tests COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/tests/blob_backup_restore_test.sh ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
   # Note: No --encrypt flag - BulkLoad doesn't support encryption yet
   add_test(NAME s3_backup_bulkdump_bulkload_tests COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/tests/s3_backup_bulkdump_bulkload.sh ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
 endif()

--- a/fdbbackup/FileConverter.cpp
+++ b/fdbbackup/FileConverter.cpp
@@ -447,7 +447,7 @@ private:
 };
 
 Future<Void> convert(ConvertParams params) {
-	Reference<IBackupContainer> container = IBackupContainer::openContainer(params.container_url, params.proxy, {});
+	Reference<IBackupContainer> container = IBackupContainer::openContainer(params.container_url, params.proxy, {}, 0);
 	BackupFileList listing = co_await container->dumpFileList();
 	std::sort(listing.logs.begin(), listing.logs.end());
 	TraceEvent("Container").detail("URL", params.container_url).detail("Logs", listing.logs.size());

--- a/fdbbackup/FileDecoder.cpp
+++ b/fdbbackup/FileDecoder.cpp
@@ -795,7 +795,8 @@ Future<std::vector<RangeFile>> getRangeFiles(Reference<IBackupContainer> bc, Ref
 }
 
 Future<Void> decode_logs(Reference<DecodeParams> params) {
-	Reference<IBackupContainer> container = IBackupContainer::openContainer(params->container_url, params->proxy, {});
+	Reference<IBackupContainer> container =
+	    IBackupContainer::openContainer(params->container_url, params->proxy, {}, 0);
 	UID uid = deterministicRandom()->randomUniqueID();
 	BackupFileList listing = co_await container->dumpFileList();
 	// remove partitioned logs

--- a/fdbbackup/FileDecoder.cpp
+++ b/fdbbackup/FileDecoder.cpp
@@ -99,6 +99,8 @@ void printDecodeUsage() {
 	             "  --knob-KNOBNAME KNOBVALUE\n"
 	             "                 Changes a knob value. KNOBNAME should be lowercase.\n"
 	             "  -s, --save     Save a copy of downloaded files (default: not saving).\n"
+	             "  --encryption-key-file FILE\n"
+	             "                 AES-128-GCM encryption key file for encrypted backups.\n"
 	             "\n";
 	return;
 }
@@ -126,6 +128,7 @@ struct DecodeParams : public ReferenceCounted<DecodeParams> {
 	Version endVersionFilter = std::numeric_limits<Version>::max();
 
 	std::vector<std::pair<std::string, std::string>> knobs;
+	Optional<std::string> encryptionKeyFileName;
 
 	// Returns if [begin, end) overlap with the filter range
 	bool overlap(Version begin, Version end) const {
@@ -233,6 +236,9 @@ struct DecodeParams : public ReferenceCounted<DecodeParams> {
 			s.append(", KNOB-").append(knob).append(" = ").append(value);
 		}
 		s.append(", SaveFile: ").append(save_file_locally ? "true" : "false");
+		if (encryptionKeyFileName.present()) {
+			s.append(", EncryptionKeyFile: ").append(encryptionKeyFileName.get());
+		}
 		return s;
 	}
 
@@ -388,6 +394,10 @@ int parseDecodeCommandLine(Reference<DecodeParams> param, CSimpleOpt* args) {
 
 		case OPT_SAVE_FILE:
 			param->save_file_locally = true;
+			break;
+
+		case OPT_ENCRYPTION_KEY_FILE:
+			param->encryptionKeyFileName = args->OptionArg();
 			break;
 
 		case TLSConfig::OPT_TLS_PLUGIN:
@@ -796,9 +806,11 @@ Future<std::vector<RangeFile>> getRangeFiles(Reference<IBackupContainer> bc, Ref
 
 Future<Void> decode_logs(Reference<DecodeParams> params) {
 	Reference<IBackupContainer> container =
-	    IBackupContainer::openContainer(params->container_url, params->proxy, {}, 0);
+	    IBackupContainer::openContainer(params->container_url, params->proxy, params->encryptionKeyFileName, 0);
 	UID uid = deterministicRandom()->randomUniqueID();
+
 	BackupFileList listing = co_await container->dumpFileList();
+
 	// remove partitioned logs
 	listing.logs.erase(std::remove_if(listing.logs.begin(),
 	                                  listing.logs.end(),
@@ -812,6 +824,9 @@ Future<Void> decode_logs(Reference<DecodeParams> params) {
 	TraceEvent("DecodeParam", uid).setMaxFieldLength(100000).detail("Value", params->toString());
 
 	BackupDescription desc = co_await container->describeBackup();
+
+	container->setEncryptionBlockSize(desc.encryptionBlockSize);
+
 	std::cout << "\n" << desc.toString() << "\n";
 
 	std::vector<LogFile> logFiles;

--- a/fdbbackup/backup.cpp
+++ b/fdbbackup/backup.cpp
@@ -2092,8 +2092,8 @@ Future<Void> submitBackup(Database db,
 			                                  usePartitionedLog,
 			                                  incrementalBackupOnly,
 			                                  encryptionKeyFile,
-			                                  static_cast<int>(snapshotMode),
-			                                  encryptionBlockSize);
+			                                  encryptionBlockSize,
+			                                  static_cast<int>(snapshotMode));
 
 			// Wait for the backup to complete, if requested
 			if (waitForCompletion) {
@@ -3867,7 +3867,13 @@ int main(int argc, char* argv[]) {
 				modifyOptions.encryptionKeyFile = encryptionKeyFile;
 				break;
 			case OPT_ENCRYPTION_BLOCK_SIZE:
-				encryptionBlockSize = std::stoi(args->OptionArg());
+				try {
+					encryptionBlockSize = std::stoi(args->OptionArg());
+				} catch (std::exception&) {
+					fprintf(stderr, "ERROR: Invalid encryption block size `%s'\n", args->OptionArg());
+					printHelpTeaser(newArgV[0]);
+					return FDB_EXIT_ERROR;
+				}
 				if (encryptionBlockSize <= 0) {
 					fprintf(stderr, "ERROR: Invalid encryption block size `%s'\n", args->OptionArg());
 					printHelpTeaser(newArgV[0]);

--- a/fdbbackup/backup.cpp
+++ b/fdbbackup/backup.cpp
@@ -146,6 +146,7 @@ enum {
 	OPT_BACKUPKEYS_FILTER,
 	OPT_INCREMENTALONLY,
 	OPT_ENCRYPTION_KEY_FILE,
+	OPT_ENCRYPTION_BLOCK_SIZE,
 
 	// Backup Modify
 	OPT_MOD_ACTIVE_INTERVAL,
@@ -283,6 +284,7 @@ CSimpleOpt::SOption g_rgBackupStartOptions[] = {
 	{ OPT_BLOB_CREDENTIALS, "--blob-credentials", SO_REQ_SEP },
 	{ OPT_INCREMENTALONLY, "--incremental", SO_NONE },
 	{ OPT_ENCRYPTION_KEY_FILE, "--encryption-key-file", SO_REQ_SEP },
+	{ OPT_ENCRYPTION_BLOCK_SIZE, "--encryption-block-size", SO_REQ_SEP },
 	{ OPT_MODE, "--mode", SO_REQ_SEP },
 	TLS_OPTION_FLAGS,
 	SO_END_OF_OPTIONS
@@ -1139,6 +1141,9 @@ static void printBackupUsage(bool devhelp) {
 	       "                 For modify operations, need to pass encryption key file only if Backup container URL is "
 	       "changed to "
 	       "re-encrypt all future backup files. \n");
+	printf("  --encryption-block-size"
+	       "                 Block size in bytes for file encryption. Only used with fdbbackup start command. Default "
+	       "is 1048576 (1MB).\n");
 
 	printf(TLS_HELP);
 	printf("  -w, --wait     Wait for the backup to complete (allowed with `start' and `discontinue').\n");
@@ -2032,6 +2037,7 @@ Future<Void> submitBackup(Database db,
                           UsePartitionedLog usePartitionedLog,
                           IncrementalBackupOnly incrementalBackupOnly,
                           Optional<std::string> encryptionKeyFile,
+                          int encryptionBlockSize,
                           SnapshotMode snapshotMode = SnapshotMode::RANGEFILE) {
 	try {
 		FileBackupAgent backupAgent;
@@ -2086,7 +2092,8 @@ Future<Void> submitBackup(Database db,
 			                                  usePartitionedLog,
 			                                  incrementalBackupOnly,
 			                                  encryptionKeyFile,
-			                                  static_cast<int>(snapshotMode));
+			                                  static_cast<int>(snapshotMode),
+			                                  encryptionBlockSize);
 
 			// Wait for the backup to complete, if requested
 			if (waitForCompletion) {
@@ -2336,7 +2343,8 @@ Future<Void> changeDBBackupResumed(Database src, Database dest, bool pause) {
 Reference<IBackupContainer> openBackupContainer(const char* name,
                                                 const std::string& destinationContainer,
                                                 const Optional<std::string>& proxy,
-                                                const Optional<std::string>& encryptionKeyFile) {
+                                                const Optional<std::string>& encryptionKeyFile,
+                                                int encryptionBlockSize = 0) {
 	// Error, if no dest container was specified
 	if (destinationContainer.empty()) {
 		fprintf(stderr, "ERROR: No backup destination was specified.\n");
@@ -2353,7 +2361,7 @@ Reference<IBackupContainer> openBackupContainer(const char* name,
 
 	Reference<IBackupContainer> c;
 	try {
-		c = IBackupContainer::openContainer(destinationContainer, proxy, encryptionKeyFile);
+		c = IBackupContainer::openContainer(destinationContainer, proxy, encryptionKeyFile, encryptionBlockSize);
 	} catch (Error& e) {
 		std::string msg = format("ERROR: '%s' on URL '%s'", e.what(), destinationContainer.c_str());
 		if (e.code() == error_code_backup_invalid_url && !IBackupContainer::lastOpenError.empty()) {
@@ -2422,7 +2430,6 @@ Future<Void> runRestore(Database db,
 
 		Reference<IBackupContainer> bc =
 		    openBackupContainer(exeRestore.toString().c_str(), container, proxy, encryptionKeyFile);
-
 		// If targetVersion is unset then use the maximum restorable version from the backup description
 		if (targetVersion == invalidVersion) {
 			if (verbose)
@@ -2990,7 +2997,7 @@ Future<Void> modifyBackup(Database db, std::string tagName, BackupModifyOptions 
 				}
 
 				config.backupContainer().set(tr, bc);
-				co_await bc->writeEncryptionMetadata();
+				co_await bc->writeEncryptionMetadata(bc->getEncryptionBlockSize());
 			} else if (options.encryptionKeyFile.present()) {
 				fprintf(stdout,
 				        " Encryption key file specified without a new destination URL."
@@ -3595,6 +3602,7 @@ int main(int argc, char* argv[]) {
 		bool jsonOutput = false;
 		DeleteData deleteData{ false };
 		Optional<std::string> encryptionKeyFile;
+		int encryptionBlockSize = 0;
 		Optional<std::string> blobManifestUrl;
 		SnapshotMode snapshotMode = SnapshotMode::RANGEFILE; // Default to legacy rangefile mode
 
@@ -3857,6 +3865,14 @@ int main(int argc, char* argv[]) {
 			case OPT_ENCRYPTION_KEY_FILE:
 				encryptionKeyFile = args->OptionArg();
 				modifyOptions.encryptionKeyFile = encryptionKeyFile;
+				break;
+			case OPT_ENCRYPTION_BLOCK_SIZE:
+				encryptionBlockSize = std::stoi(args->OptionArg());
+				if (encryptionBlockSize <= 0) {
+					fprintf(stderr, "ERROR: Invalid encryption block size `%s'\n", args->OptionArg());
+					printHelpTeaser(newArgV[0]);
+					return FDB_EXIT_ERROR;
+				}
 				break;
 			case OPT_RESTORECONTAINER:
 				restoreContainer = args->OptionArg();
@@ -4228,6 +4244,15 @@ int main(int argc, char* argv[]) {
 			return result.present();
 		};
 
+		if (encryptionKeyFile.present() && encryptionBlockSize == 0) {
+			encryptionBlockSize = DEFAULT_ENCRYPTION_BLOCK_SIZE;
+		}
+
+		if (encryptionBlockSize > 0 && !encryptionKeyFile.present()) {
+			fprintf(stderr, "ERROR: --encryption-block-size option requires --encryption-key-file to be set\n");
+			return FDB_EXIT_ERROR;
+		}
+
 		if (!restoreSystemKeys && !restoreUserKeys && backupKeys.empty()) {
 			addDefaultBackupRanges(backupKeys);
 		}
@@ -4260,7 +4285,7 @@ int main(int argc, char* argv[]) {
 					return FDB_EXIT_ERROR;
 				// Test out the backup url to make sure it parses.  Doesn't test to make sure it's actually
 				// writeable.
-				openBackupContainer(newArgV[0], destinationContainer, proxy, encryptionKeyFile);
+				openBackupContainer(newArgV[0], destinationContainer, proxy, encryptionKeyFile, encryptionBlockSize);
 				f = stopAfter(submitBackup(db,
 				                           destinationContainer,
 				                           proxy,
@@ -4274,6 +4299,7 @@ int main(int argc, char* argv[]) {
 				                           usePartitionedLog,
 				                           incrementalBackupOnly,
 				                           encryptionKeyFile,
+				                           encryptionBlockSize,
 				                           snapshotMode));
 				break;
 			}

--- a/fdbbackup/include/fdbbackup/FileConverter.h
+++ b/fdbbackup/include/fdbbackup/FileConverter.h
@@ -52,6 +52,7 @@ enum {
 	OPT_END_VERSION_FILTER,
 	OPT_KNOB,
 	OPT_SAVE_FILE,
+	OPT_ENCRYPTION_KEY_FILE,
 	OPT_HELP
 };
 
@@ -84,6 +85,7 @@ CSimpleOpt::SOption gConverterOptions[] = { { OPT_CONTAINER, "-r", SO_REQ_SEP },
 	                                        { OPT_KNOB, "--knob-", SO_REQ_SEP },
 	                                        { OPT_SAVE_FILE, "-s", SO_NONE },
 	                                        { OPT_SAVE_FILE, "--save", SO_NONE },
+	                                        { OPT_ENCRYPTION_KEY_FILE, "--encryption-key-file", SO_REQ_SEP },
 	                                        { OPT_HELP, "-?", SO_NONE },
 	                                        { OPT_HELP, "-h", SO_NONE },
 	                                        { OPT_HELP, "--help", SO_NONE },

--- a/fdbbackup/tests/backup_tests_common.sh
+++ b/fdbbackup/tests/backup_tests_common.sh
@@ -160,6 +160,10 @@ function run_backup {
     cmd_args+=("--partitioned-log-experimental")
   fi
 
+  if [[ "${USE_ENCRYPTION_BLOCK_SIZE:-false}" == "true" ]]; then
+    cmd_args+=("--encryption-block-size" "4096")
+  fi
+
   # Start backup without -w flag to avoid hanging
   if ! "${local_build_dir}"/bin/fdbbackup start "${cmd_args[@]}"; then
     err "Start fdbbackup failed"
@@ -421,7 +425,9 @@ function test_encryption_mismatches {
 
     if [[ ${exit_code1} -eq 0 ]]; then
       err "Restore without encryption on encrypted backup succeeded when it should have failed!"
-      rm -rf "${mismatch_logdir}"
+      if [[ "${PRESERVE_TEST_DATA:-0}" != "1" ]]; then
+        rm -rf "${mismatch_logdir}"
+      fi
       return 1
     fi
     log "SUCCESS: Restore without encryption on encrypted backup failed as expected (exit code: ${exit_code1})"
@@ -443,7 +449,9 @@ function test_encryption_mismatches {
 
     if [[ ${exit_code2} -eq 0 ]]; then
       err "Restore with wrong encryption key succeeded when it should have failed!"
-      rm -rf "${mismatch_logdir}"
+      if [[ "${PRESERVE_TEST_DATA:-0}" != "1" ]]; then
+        rm -rf "${mismatch_logdir}"
+      fi
       return 1
     fi
     log "SUCCESS: Restore with wrong encryption key failed as expected (exit code: ${exit_code2})"
@@ -469,14 +477,18 @@ function test_encryption_mismatches {
 
     if [[ ${exit_code} -eq 0 ]]; then
       err "Restore with encryption on unencrypted backup succeeded when it should have failed!"
-      rm -rf "${mismatch_logdir}"
+      if [[ "${PRESERVE_TEST_DATA:-0}" != "1" ]]; then
+        rm -rf "${mismatch_logdir}"
+      fi
       return 1
     fi
     log "SUCCESS: Restore with encryption on unencrypted backup failed as expected (exit code: ${exit_code})"
   fi
 
   # Clean up separate log directory
-  rm -rf "${mismatch_logdir}"
+  if [[ "${PRESERVE_TEST_DATA:-0}" != "1" ]]; then
+    rm -rf "${mismatch_logdir}"
+  fi
 
   log "All encryption mismatch tests completed successfully"
   return 0

--- a/fdbbackup/tests/blob_backup_restore_test.sh
+++ b/fdbbackup/tests/blob_backup_restore_test.sh
@@ -131,10 +131,12 @@ function test_s3_backup_and_restore {
     err "Failed verification of data in fdb"
     return 1
   fi
-  
-  # Cleanup test data.
-  if ! s3_cleanup_url "${local_build_dir}" "${local_scratch_dir}" "${edited_url}" "${credentials}"; then
-    return 1
+
+  # Cleanup test data (skip if preserving test data for debugging).
+  if [[ "${PRESERVE_TEST_DATA:-0}" != "1" ]]; then
+    if ! s3_cleanup_url "${local_build_dir}" "${local_scratch_dir}" "${edited_url}" "${credentials}"; then
+      return 1
+    fi
   fi
   log "Check for Severity=40 errors"
   if ! grep_for_severity40 "${local_scratch_dir}"; then
@@ -150,42 +152,13 @@ set -o pipefail
 set -o noclobber
 
 # Parse command line arguments
-USE_ENCRYPTION=false
+USE_ENCRYPTION=$(((RANDOM % 2)) && echo true || echo false )
 USE_PARTITIONED_LOG=$(((RANDOM % 2)) && echo true || echo false )
-PARAMS=()
 
-while (( "$#" )); do
-  case "$1" in
-    --encrypt)
-      USE_ENCRYPTION=true
-      shift
-      ;;
-    --encrypt-at-random)
-      USE_ENCRYPTION=$(((RANDOM % 2)) && echo true || echo false )
-      shift
-      ;;
-    --partitioned-log-experimental)
-      USE_PARTITIONED_LOG=true
-      shift
-      ;;
-    --partitioned-log-experimental-at-random)
-      USE_PARTITIONED_LOG=$(((RANDOM % 2)) && echo true || echo false )
-      shift
-      ;;
-    -*|--*=) # unsupported flags
-      err "Error: Unsupported flag $1" >&2
-      exit 1
-      ;;
-    *) # preserve positional arguments
-      PARAMS+=("$1")
-      shift
-      ;;
-  esac
-done
-
-# Set positional arguments in their proper place
-if [ ${#PARAMS[@]} -ne 0 ]; then
-  set -- "${PARAMS[@]}"
+# Set USE_ENCRYPTION_BLOCK_SIZE only if encryption is enabled
+USE_ENCRYPTION_BLOCK_SIZE=false
+if [[ "${USE_ENCRYPTION}" == "true" ]]; then
+  USE_ENCRYPTION_BLOCK_SIZE=$(((RANDOM % 2)) && echo true || echo false)
 fi
 
 # Get the working directory for this script.
@@ -257,6 +230,7 @@ else
 fi
 readonly ENCRYPTION_KEY_FILE
 readonly USE_PARTITIONED_LOG
+readonly USE_ENCRYPTION_BLOCK_SIZE
 
 # Setup S3/MockS3 environment using common function
 readonly temp_dir_prefix="mocks3_backup_test"

--- a/fdbbackup/tests/dir_backup_test.sh
+++ b/fdbbackup/tests/dir_backup_test.sh
@@ -19,6 +19,10 @@ SCRATCH_DIR=
 readonly TAG="test_backup"
 USE_PARTITIONED_LOG=$(((RANDOM % 2)) && echo true || echo false )
 USE_ENCRYPTION=$(((RANDOM % 2)) && echo true || echo false )
+USE_ENCRYPTION_BLOCK_SIZE=false
+if [[ "${USE_ENCRYPTION}" == "true" ]]; then
+  USE_ENCRYPTION_BLOCK_SIZE=$(((RANDOM % 2)) && echo true || echo false)
+fi
 ENCRYPTION_KEY_FILE=
 
 # Install signal traps. Calls the cleanup function.
@@ -30,21 +34,27 @@ trap cleanup  EXIT
 function cleanup {
   echo "$(date -Iseconds) cleanup: starting (with 30s hard timeout)"
   start_cleanup_watchdog 30
-  
+
+  if cleanup_with_preserve_check; then
+    echo "$(date -Iseconds) cleanup: preserving test data, skipping cleanup"
+    cancel_cleanup_watchdog
+    return 0
+  fi
+
   echo "$(date -Iseconds) cleanup: shutting down FDB cluster"
   shutdown_fdb_cluster
-  
+
   if [[ -d "${SCRATCH_DIR}" ]]; then
     echo "$(date -Iseconds) cleanup: removing scratch dir: ${SCRATCH_DIR}"
     rm -rf "${SCRATCH_DIR}"
   fi
-  
+
   # Clean up encryption key file
   if [[ -n "${ENCRYPTION_KEY_FILE:-}" ]] && [[ -f "${ENCRYPTION_KEY_FILE}" ]]; then
     echo "$(date -Iseconds) cleanup: removing encryption key file: ${ENCRYPTION_KEY_FILE}"
     rm -f "${ENCRYPTION_KEY_FILE}"
   fi
-  
+
   echo "$(date -Iseconds) cleanup: complete"
   cancel_cleanup_watchdog
 }
@@ -80,6 +90,10 @@ function backup {
 
   if [[ -n "${local_encryption_key_file}" ]]; then
     cmd_args+=("--encryption-key-file" "${local_encryption_key_file}")
+  fi
+
+  if [[ "${USE_ENCRYPTION_BLOCK_SIZE}" == "true" ]]; then
+    cmd_args+=("--encryption-block-size" "4096")
   fi
 
   if [[ "${USE_PARTITIONED_LOG}" == "true" ]]; then
@@ -157,6 +171,17 @@ function test_dir_backup_and_restore {
     err "Failed clear data in fdb"
     return 1
   fi
+
+  log "Testing encryption mismatches"
+  local backup
+  local backup_name
+  if ! backup=$(ls -dt "${scratch_dir}"/backups/backup-* | head -1); then
+    err "Failed to list backups under ${scratch_dir}/backups/"
+    return 1
+  fi
+  backup_name=$(basename "${backup}")
+  test_encryption_mismatches "${local_build_dir}" "${scratch_dir}" "file://${scratch_dir}/backups/${backup_name}" "${TAG}" "${local_encryption_key_file}"
+
   log "Restore"
   if ! restore "${local_build_dir}" "${scratch_dir}" "${local_encryption_key_file}"; then
     err "Failed restore"
@@ -195,6 +220,11 @@ export FDB_DATA_KEYCOUNT=10
 # shellcheck source=/dev/null
 if ! source "${cwd}/../../fdbclient/tests/tests_common.sh"; then
   err "Failed to source tests_common.sh"
+  exit 1
+fi
+# shellcheck source=/dev/null
+if ! source "${cwd}/backup_tests_common.sh"; then
+  err "Failed to source backup_tests_common.sh"
   exit 1
 fi
 
@@ -238,6 +268,7 @@ fi
 
 readonly USE_PARTITIONED_LOG
 readonly USE_ENCRYPTION
+readonly USE_ENCRYPTION_BLOCK_SIZE
 readonly ENCRYPTION_KEY_FILE
 
 # Startup fdb cluster and backup agent.

--- a/fdbclient/BackupContainer.cpp
+++ b/fdbclient/BackupContainer.cpp
@@ -135,6 +135,7 @@ std::string BackupDescription::toString() const {
 	info.append(format("Restorable: %s\n", maxRestorableVersion.present() ? "true" : "false"));
 	info.append(format("Partitioned logs: %s\n", partitioned ? "true" : "false"));
 	info.append(format("File-level encryption: %s\n", fileLevelEncryption ? "true" : "false"));
+	info.append(format("Encryption block size: %d\n", encryptionBlockSize));
 
 	auto formatVersion = [&](Version v) {
 		std::string s;
@@ -196,6 +197,7 @@ std::string BackupDescription::toJSON() const {
 	doc.setKey("Restorable", maxRestorableVersion.present());
 	doc.setKey("Partitioned", partitioned);
 	doc.setKey("FileLevelEncryption", fileLevelEncryption);
+	doc.setKey("EncryptionBlockSize", encryptionBlockSize);
 
 	auto formatVersion = [&](Version v) {
 		JsonBuilderObject doc;
@@ -263,7 +265,8 @@ std::vector<std::string> IBackupContainer::getURLFormats() {
 // Get an IBackupContainer based on a container URL string
 Reference<IBackupContainer> IBackupContainer::openContainer(const std::string& url,
                                                             const Optional<std::string>& proxy,
-                                                            const Optional<std::string>& encryptionKeyFileName) {
+                                                            const Optional<std::string>& encryptionKeyFileName,
+                                                            int encryptionBlockSize) {
 	static std::map<std::string, Reference<IBackupContainer>> m_cache;
 
 	// In simulation, disable caching for blobstore:// URLs to prevent cross-process connection issues.
@@ -276,21 +279,23 @@ Reference<IBackupContainer> IBackupContainer::openContainer(const std::string& u
 	//   "g_simulator->getCurrentProcess() == self->peerProcess" at sim2.cpp:500
 	//
 	// Fix: Disable caching for blobstore:// URLs in simulation so each process creates its own
-	// container with its own connection pool. File-based backups don't have this issue because they
-	// don't use process-bound network connections.
+	// container with its own connection pool. Also disable caching for file:// URLs in simulation:
+	// multiple concurrent backups to the same base URL can have different encryption settings.
 	//
 	// Note: This only affects simulation; production always uses the cache for performance.
-	bool skipCache = g_network && g_network->isSimulated() && isBlobstoreUrl(url);
+	bool skipCache = g_network && g_network->isSimulated() && (isBlobstoreUrl(url) || url.find("file://") == 0);
 
 	// Use a reference to the cache entry (for automatic cache population) unless we're skipping cache
 	Reference<IBackupContainer> r_local;
 	Reference<IBackupContainer>& r = skipCache ? r_local : m_cache[url];
-	if (r)
+	if (r) {
 		return r;
+	}
+
 	try {
 		StringRef u(url);
 		if (u.startsWith("file://"_sr)) {
-			r = makeReference<BackupContainerLocalDirectory>(url, encryptionKeyFileName);
+			r = makeReference<BackupContainerLocalDirectory>(url, encryptionKeyFileName, encryptionBlockSize);
 		} else if (u.startsWith("blobstore://"_sr)) {
 			std::string resource;
 			Optional<std::string> blobstoreProxy;
@@ -309,7 +314,8 @@ Reference<IBackupContainer> IBackupContainer::openContainer(const std::string& u
 			    IBlobStoreEndpoint::fromString(url, blobstoreProxy, &resource, &lastOpenError, &backupParams);
 
 			BackupContainerBlobStore::validateBackupUrl(resource);
-			r = makeReference<BackupContainerBlobStore>(bstore, resource, backupParams, encryptionKeyFileName, true);
+			r = makeReference<BackupContainerBlobStore>(
+			    bstore, resource, backupParams, encryptionKeyFileName, /*isBackup=*/true, encryptionBlockSize);
 		}
 #ifdef BUILD_AZURE_BACKUP
 		else if (u.startsWith("azure://"_sr)) {
@@ -402,7 +408,12 @@ Future<std::vector<std::string>> listContainers_impl(std::string baseURL, Option
 			}
 
 			// Create a dummy container to parse the backup-specific parameters from the URL and get a final bucket name
-			BackupContainerBlobStore dummy(bstore, "dummy", backupParams, {}, true);
+			BackupContainerBlobStore dummy(bstore,
+			                               "dummy",
+			                               backupParams,
+			                               /*encryptionKeyFileName=*/{},
+			                               /*isBackup=*/true,
+			                               /*encryptionBlockSize=*/0);
 
 			std::vector<std::string> results = co_await BackupContainerBlobStore::listURLs(bstore, dummy.getBucket());
 			co_return results;
@@ -418,7 +429,6 @@ Future<std::vector<std::string>> listContainers_impl(std::string baseURL, Option
 			IBackupContainer::lastOpenError = "invalid URL prefix";
 			throw backup_invalid_url();
 		}
-
 	} catch (Error& e) {
 		if (e.code() == error_code_actor_cancelled)
 			throw;

--- a/fdbclient/BackupContainerBlobStore.cpp
+++ b/fdbclient/BackupContainerBlobStore.cpp
@@ -158,9 +158,11 @@ BackupContainerBlobStore::BackupContainerBlobStore(Reference<IBlobStoreEndpoint>
                                                    const std::string& name,
                                                    const IBlobStoreEndpoint::ParametersT& params,
                                                    const Optional<std::string>& encryptionKeyFileName,
-                                                   bool isBackup)
+                                                   bool isBackup,
+                                                   int encryptionBlockSize)
   : m_bstore(bstore), m_name(name), m_bucket("FDB_BACKUPS_V2"), isBackup(isBackup) {
 	setEncryptionKey(encryptionKeyFileName);
+	this->encryptionBlockSize = encryptionBlockSize;
 	// Currently only one parameter is supported, "bucket"
 	for (const auto& [name, value] : params) {
 		if (name == "bucket") {
@@ -197,7 +199,7 @@ Future<Reference<IAsyncFile>> BackupContainerBlobStore::readFile(const std::stri
 	Reference<IAsyncFile> f = makeReference<AsyncFileBlobStoreRead>(m_bstore, m_bucket, dataPath(path));
 
 	if (usesEncryption() && !StringRef(path).startsWith("properties/"_sr)) {
-		f = makeReference<AsyncFileEncrypted>(f, AsyncFileEncrypted::Mode::READ_ONLY);
+		f = makeReference<AsyncFileEncrypted>(f, AsyncFileEncrypted::Mode::READ_ONLY, encryptionBlockSize);
 	}
 	if (m_bstore->knobs.enable_read_cache) {
 		f = makeReference<AsyncFileReadAheadCache>(f,
@@ -217,7 +219,7 @@ Future<std::vector<std::string>> BackupContainerBlobStore::listURLs(Reference<IB
 Future<Reference<IBackupFile>> BackupContainerBlobStore::writeFile(const std::string& path) {
 	Reference<IAsyncFile> f = makeReference<AsyncFileBlobStoreWrite>(m_bstore, m_bucket, dataPath(path));
 	if (usesEncryption() && !StringRef(path).startsWith("properties/"_sr)) {
-		f = makeReference<AsyncFileEncrypted>(f, AsyncFileEncrypted::Mode::APPEND_ONLY);
+		f = makeReference<AsyncFileEncrypted>(f, AsyncFileEncrypted::Mode::APPEND_ONLY, encryptionBlockSize);
 	}
 	return Future<Reference<IBackupFile>>(makeReference<BackupContainerBlobStoreImpl::BackupFile>(path, f));
 }

--- a/fdbclient/BackupContainerBlobStore.h
+++ b/fdbclient/BackupContainerBlobStore.h
@@ -48,7 +48,8 @@ public:
 	                         const std::string& name,
 	                         const IBlobStoreEndpoint::ParametersT& params,
 	                         const Optional<std::string>& encryptionKeyFileName,
-	                         bool isBackup);
+	                         bool isBackup,
+	                         int encryptionBlockSize);
 
 	void addref() override;
 	void delref() override;

--- a/fdbclient/BackupContainerFileSystem.cpp
+++ b/fdbclient/BackupContainerFileSystem.cpp
@@ -557,6 +557,40 @@ public:
 		return prevEnd;
 	}
 
+	// Read encryption metadata from JSON file
+	static Future<std::pair<bool, int>> readEncryptionMetadata(Reference<BackupContainerFileSystem> bc) {
+		try {
+			Reference<IAsyncFile> f = co_await bc->readFile(BackupContainerFileSystem::encryptionMetadataFileName());
+			int64_t size = co_await f->size();
+			std::string content;
+			content.resize(size);
+			co_await f->read((uint8_t*)content.data(), size, 0);
+
+			json_spirit::mValue json;
+			if (json_spirit::read_string(content, json) && json.type() == json_spirit::obj_type) {
+				auto& obj = json.get_obj();
+				bool enabled = false;
+				int blockSize = 0;
+
+				if (obj.count("is_encryption_enabled") &&
+				    obj.at("is_encryption_enabled").type() == json_spirit::bool_type) {
+					enabled = obj.at("is_encryption_enabled").get_bool();
+				}
+				if (obj.count("encryption_block_size") &&
+				    obj.at("encryption_block_size").type() == json_spirit::int_type) {
+					blockSize = obj.at("encryption_block_size").get_int();
+				}
+				TraceEvent("BackupContainerReadEncryptionMetadata")
+				    .detail("URL", bc->getURL())
+				    .detail("IsEncryptionEnabled", enabled)
+				    .detail("EncryptionBlockSize", blockSize);
+				co_return std::make_pair(enabled, blockSize);
+			}
+		} catch (Error& e) {
+		}
+		co_return std::make_pair(false, 0);
+	}
+
 	static Future<BackupDescription> describeBackup(Reference<BackupContainerFileSystem> bc,
 	                                                bool deepScan,
 	                                                Version logStartVersionOverride) {
@@ -590,13 +624,13 @@ public:
 		Optional<Version> metaExpiredEnd;
 		Optional<Version> metaUnreliableEnd;
 		Optional<Version> metaLogType;
-		Optional<Version> fileLevelEncryption;
+		bool fileLevelEncryptionEnabled = false;
+		int encryptionBlockSize = 0;
 
 		std::vector<Future<Void>> metaReads;
 		metaReads.push_back(store(metaExpiredEnd, bc->expiredEndVersion().get()));
 		metaReads.push_back(store(metaUnreliableEnd, bc->unreliableEndVersion().get()));
 		metaReads.push_back(store(metaLogType, bc->logType().get()));
-		metaReads.push_back(store(fileLevelEncryption, bc->fileLevelEncryption().get()));
 
 		// Only read log begin/end versions if not doing a deep scan, otherwise scan files and recalculate them.
 		if (!deepScan) {
@@ -606,6 +640,10 @@ public:
 
 		co_await waitForAll(metaReads);
 
+		std::pair<bool, int> encryptionMeta = co_await readEncryptionMetadata(bc);
+		fileLevelEncryptionEnabled = encryptionMeta.first;
+		encryptionBlockSize = encryptionMeta.second;
+
 		TraceEvent("BackupContainerDescribe2")
 		    .detail("URL", bc->getURL())
 		    .detail("LogStartVersionOverride", logStartVersionOverride)
@@ -613,7 +651,9 @@ public:
 		    .detail("UnreliableEndVersion", metaUnreliableEnd.orDefault(invalidVersion))
 		    .detail("LogBeginVersion", metaLogBegin.orDefault(invalidVersion))
 		    .detail("LogEndVersion", metaLogEnd.orDefault(invalidVersion))
-		    .detail("LogType", metaLogType.orDefault(-1));
+		    .detail("LogType", metaLogType.orDefault(-1))
+		    .detail("FileLevelEncryption", fileLevelEncryptionEnabled)
+		    .detail("EncryptionBlockSize", encryptionBlockSize);
 
 		// If the logStartVersionOverride is positive (not relative) then ensure that unreliableEndVersion is equal or
 		// greater
@@ -694,11 +734,8 @@ public:
 			    metaLogType.present() && metaLogType.get() == BackupContainerFileSystemImpl::PARTITIONED_MUTATION_LOG;
 		}
 
-		if (fileLevelEncryption.present() && fileLevelEncryption.get() != 0) {
-			desc.fileLevelEncryption = true;
-		} else {
-			desc.fileLevelEncryption = false;
-		}
+		desc.fileLevelEncryption = fileLevelEncryptionEnabled;
+		desc.encryptionBlockSize = encryptionBlockSize;
 
 		// List logs in version order so log continuity can be analyzed
 		std::sort(logs.begin(), logs.end());
@@ -1405,16 +1442,35 @@ public:
 		ASSERT_EQ(bytesRead, cipherKey->size());
 	}
 
-	static Future<Void> writeEncryptionMetadataIfNotExists(Reference<BackupContainerFileSystem> bc) {
-		Optional<Version> existingEncryptionMetadata = co_await bc->fileLevelEncryption().get();
-
-		if (!existingEncryptionMetadata.present()) {
-			bool exists = co_await bc->exists();
-			if (!exists) {
-				co_await bc->create();
+	static Future<Void> writeEncryptionMetadataIfNotExists(Reference<BackupContainerFileSystem> bc,
+	                                                       int encryptionBlockSize) {
+		try {
+			Reference<IAsyncFile> f = co_await bc->readFile(BackupContainerFileSystem::encryptionMetadataFileName());
+			int64_t size = co_await f->size();
+			TraceEvent("WriteEncryptionMetadataAlreadyExists").detail("URL", bc->getURL()).detail("FileSize", size);
+			co_return;
+		} catch (Error& e) {
+			if (e.code() != error_code_file_not_found) {
+				TraceEvent(SevWarn, "WriteEncryptionMetadataReadError").error(e).detail("URL", bc->getURL());
+				throw e;
 			}
-			co_await bc->fileLevelEncryption().set(bc->encryptionKeyFileName.present() ? 1 : 0);
 		}
+
+		bool exists = co_await bc->exists();
+		if (!exists) {
+			TraceEvent("WriteEncryptionMetadataCreatingContainer").detail("URL", bc->getURL());
+			co_await bc->create();
+		}
+
+		// Write JSON with encryption metadata
+		JsonBuilderObject doc;
+		doc.setKey("is_encryption_enabled", bc->encryptionKeyFileName.present());
+		doc.setKey("encryption_block_size", encryptionBlockSize);
+
+		std::string jsonStr = doc.getJson();
+		TraceEvent("WriteEncryptionMetadataCompleted").detail("URL", bc->getURL()).detail("JSON", jsonStr);
+
+		co_await bc->writeEntireFile(BackupContainerFileSystem::encryptionMetadataFileName(), jsonStr);
 	}
 
 }; // class BackupContainerFileSystemImpl
@@ -1622,9 +1678,9 @@ Future<Void> BackupContainerFileSystem::expireData(Version expireEndVersion,
 	    Reference<BackupContainerFileSystem>::addRef(this), expireEndVersion, force, progress, restorableBeginVersion);
 }
 
-Future<Void> BackupContainerFileSystem::writeEncryptionMetadata() {
+Future<Void> BackupContainerFileSystem::writeEncryptionMetadata(int encryptionBlockSize) {
 	return BackupContainerFileSystemImpl::writeEncryptionMetadataIfNotExists(
-	    Reference<BackupContainerFileSystem>::addRef(this));
+	    Reference<BackupContainerFileSystem>::addRef(this), encryptionBlockSize);
 }
 
 static Future<KeyRange> getSnapshotFileKeyRange_impl(Reference<BackupContainerFileSystem> bc,
@@ -1756,6 +1812,10 @@ BackupContainerFileSystem::VersionProperty BackupContainerFileSystem::fileLevelE
 	return { Reference<BackupContainerFileSystem>::addRef(this), "file_level_encryption" };
 }
 
+std::string BackupContainerFileSystem::encryptionMetadataFileName() {
+	return "properties/file_level_encryption";
+}
+
 bool BackupContainerFileSystem::usesEncryption() const {
 	return encryptionSetupFuture.isValid();
 }
@@ -1774,6 +1834,7 @@ void BackupContainerFileSystem::setEncryptionKey(Optional<std::string> const& en
 		encryptionSetupFuture = BackupContainerFileSystemImpl::readEncryptionKey(encryptionKeyFileName.get());
 	}
 }
+
 Future<Void> BackupContainerFileSystem::createTestEncryptionKeyFile(std::string const& filename) {
 	return BackupContainerFileSystemImpl::createTestEncryptionKeyFile(filename);
 }
@@ -1785,6 +1846,7 @@ Reference<BackupContainerFileSystem> BackupContainerFileSystem::openContainerFS(
     const std::string& url,
     const Optional<std::string>& proxy,
     const Optional<std::string>& encryptionKeyFileName,
+    int encryptionBlockSize,
     bool isBackup) {
 	static std::map<std::string, Reference<BackupContainerFileSystem>> m_cache;
 
@@ -1795,7 +1857,7 @@ Reference<BackupContainerFileSystem> BackupContainerFileSystem::openContainerFS(
 	try {
 		StringRef u(url);
 		if (u.startsWith("file://"_sr)) {
-			r = makeReference<BackupContainerLocalDirectory>(url, encryptionKeyFileName);
+			r = makeReference<BackupContainerLocalDirectory>(url, encryptionKeyFileName, encryptionBlockSize);
 		} else if (u.startsWith("blobstore://"_sr)) {
 			std::string resource;
 			Optional<std::string> blobstoreProxy;
@@ -1815,7 +1877,7 @@ Reference<BackupContainerFileSystem> BackupContainerFileSystem::openContainerFS(
 
 			BackupContainerBlobStore::validateBackupUrl(resource);
 			r = makeReference<BackupContainerBlobStore>(
-			    bstore, resource, backupParams, encryptionKeyFileName, isBackup);
+			    bstore, resource, backupParams, encryptionKeyFileName, isBackup, encryptionBlockSize);
 		}
 #ifdef BUILD_AZURE_BACKUP
 		else if (u.startsWith("azure://"_sr)) {
@@ -1967,7 +2029,9 @@ Future<Void> testBackupContainer(std::string url,
 
 	printf("BackupContainerTest URL %s\n", url.c_str());
 
-	Reference<IBackupContainer> c = IBackupContainer::openContainer(url, proxy, encryptionKeyFileName);
+	int encryptionBlockSize = encryptionKeyFileName.present() ? DEFAULT_ENCRYPTION_BLOCK_SIZE : 0;
+	Reference<IBackupContainer> c =
+	    IBackupContainer::openContainer(url, proxy, encryptionKeyFileName, encryptionBlockSize);
 
 	// Make sure container doesn't exist, then create it.
 	try {
@@ -2399,7 +2463,8 @@ Future<Void> testBackupContainerWithMissingLogRanges(std::string url, Optional<s
 	FlowLock lock(100e6);
 	printf("BackupContainerTest URL %s\n", url.c_str());
 
-	Reference<IBackupContainer> c = IBackupContainer::openContainer(url, proxy, {});
+	Reference<IBackupContainer> c =
+	    IBackupContainer::openContainer(url, proxy, /*encryptionKeyFileName=*/{}, /*encryptionBlockSize=*/0);
 	// Make sure container doesn't exist, then create it.
 	try {
 		co_await c->deleteContainer();
@@ -2533,7 +2598,8 @@ TEST_CASE("/backup/containers/localdir/missingLogRangesRestorability") {
 Future<Void> testBackupContinuousLogEndVer(std::string url, Optional<std::string> proxy) {
 	FlowLock lock(100e6);
 	printf("BackupContainerTest URL %s\n", url.c_str());
-	Reference<IBackupContainer> c = IBackupContainer::openContainer(url, proxy, {});
+	Reference<IBackupContainer> c =
+	    IBackupContainer::openContainer(url, proxy, /*encryptionKeyFileName=*/{}, /*encryptionBlockSize=*/0);
 
 	// Make sure container doesn't exist, then create it.
 	try {

--- a/fdbclient/BackupContainerFileSystem.cpp
+++ b/fdbclient/BackupContainerFileSystem.cpp
@@ -585,10 +585,22 @@ public:
 				    .detail("IsEncryptionEnabled", enabled)
 				    .detail("EncryptionBlockSize", blockSize);
 				co_return std::make_pair(enabled, blockSize);
+			} else {
+				throw backup_invalid_info();
 			}
 		} catch (Error& e) {
+			if (e.code() == error_code_file_not_found) {
+				TraceEvent(SevWarn, "BackupContainerEncryptionMetadataNotFound")
+				    .detail("URL", bc->getURL())
+				    .detail("File", BackupContainerFileSystem::encryptionMetadataFileName());
+				co_return std::make_pair(false, 0);
+			}
+			TraceEvent(SevError, "BackupContainerReadEncryptionMetadataError")
+			    .error(e)
+			    .detail("URL", bc->getURL())
+			    .detail("File", BackupContainerFileSystem::encryptionMetadataFileName());
+			throw;
 		}
-		co_return std::make_pair(false, 0);
 	}
 
 	static Future<BackupDescription> describeBackup(Reference<BackupContainerFileSystem> bc,

--- a/fdbclient/BackupContainerLocalDirectory.cpp
+++ b/fdbclient/BackupContainerLocalDirectory.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "BackupContainerLocalDirectory.h"
+#include "fdbrpc/AsyncFileEncrypted.h"
 #include "fdbrpc/AsyncFileReadAhead.h"
 #include "flow/IAsyncFile.h"
 #include "flow/FaultInjection.h"
@@ -137,8 +138,10 @@ std::string BackupContainerLocalDirectory::getURLFormat() {
 }
 
 BackupContainerLocalDirectory::BackupContainerLocalDirectory(const std::string& url,
-                                                             const Optional<std::string>& encryptionKeyFileName) {
+                                                             const Optional<std::string>& encryptionKeyFileName,
+                                                             int encryptionBlockSize) {
 	setEncryptionKey(encryptionKeyFileName);
+	this->encryptionBlockSize = encryptionBlockSize;
 
 	std::string path;
 	if (url.find("file://") != 0) {
@@ -229,10 +232,6 @@ Future<bool> BackupContainerLocalDirectory::exists() {
 
 Future<Reference<IAsyncFile>> BackupContainerLocalDirectory::readFile(const std::string& path) {
 	int flags = IAsyncFile::OPEN_NO_AIO | IAsyncFile::OPEN_READONLY | IAsyncFile::OPEN_UNCACHED;
-	// Skip encryption for properties/ folder
-	if (usesEncryption() && !StringRef(path).startsWith("properties/"_sr)) {
-		flags |= IAsyncFile::OPEN_ENCRYPTED;
-	}
 	INJECT_BLOB_FAULT(http_request_failed, "BackupContainerLocalDirectory::readFile");
 	// Simulation does not properly handle opening the same file from multiple machines using a shared filesystem,
 	// so create a symbolic link to make each file opening appear to be unique.  This could also work in production
@@ -257,6 +256,14 @@ Future<Reference<IAsyncFile>> BackupContainerLocalDirectory::readFile(const std:
 // by the same process that failed the first task execution anyway, which is a very rare case.
 #endif
 	Future<Reference<IAsyncFile>> f = IAsyncFileSystem::filesystem()->open(fullPath, flags, 0644);
+	// Skip encryption for properties/ folder
+	if (usesEncryption() && !StringRef(path).startsWith("properties/"_sr)) {
+		int encBlockSize = encryptionBlockSize;
+		f = map(f, [encBlockSize](Reference<IAsyncFile> r) {
+			return Reference<IAsyncFile>(
+			    makeReference<AsyncFileEncrypted>(r, AsyncFileEncrypted::Mode::READ_ONLY, encBlockSize));
+		});
+	}
 
 	if (g_network->isSimulated()) {
 		int blockSize = 0;
@@ -288,15 +295,20 @@ Future<Reference<IBackupFile>> BackupContainerLocalDirectory::writeFile(const st
 	INJECT_BLOB_FAULT(http_request_failed, "BackupContainerLocalDirectory::writeFile");
 	int flags = IAsyncFile::OPEN_NO_AIO | IAsyncFile::OPEN_UNCACHED | IAsyncFile::OPEN_CREATE |
 	            IAsyncFile::OPEN_ATOMIC_WRITE_AND_CREATE | IAsyncFile::OPEN_READWRITE;
-	// Skip encryption for properties/ folder
-	if (usesEncryption() && !StringRef(path).startsWith("properties/"_sr)) {
-		flags |= IAsyncFile::OPEN_ENCRYPTED;
-	}
 	std::string fullPath = joinPath(m_path, path);
 	platform::createDirectory(parentDirectory(fullPath));
 	std::string temp = fullPath + "." + deterministicRandom()->randomUniqueID().toString() + ".temp";
 	Future<Reference<IAsyncFile>> f = IAsyncFileSystem::filesystem()->open(temp, flags, 0644);
-	return map(f, [=](Reference<IAsyncFile> f) { return Reference<IBackupFile>(new BackupFile(path, f, fullPath)); });
+	// Skip encryption for properties/ folder
+	if (usesEncryption() && !StringRef(path).startsWith("properties/"_sr)) {
+		int encBlockSize = encryptionBlockSize;
+		f = map(f, [encBlockSize](Reference<IAsyncFile> r) {
+			return Reference<IAsyncFile>(
+			    makeReference<AsyncFileEncrypted>(r, AsyncFileEncrypted::Mode::APPEND_ONLY, encBlockSize));
+		});
+	}
+	return map(
+	    f, [=](Reference<IAsyncFile> file) { return Reference<IBackupFile>(new BackupFile(path, file, fullPath)); });
 }
 
 Future<Void> BackupContainerLocalDirectory::writeEntireFile(const std::string& path, const std::string& contents) {

--- a/fdbclient/BackupContainerLocalDirectory.h
+++ b/fdbclient/BackupContainerLocalDirectory.h
@@ -33,7 +33,9 @@ public:
 
 	static std::string getURLFormat();
 
-	BackupContainerLocalDirectory(const std::string& url, Optional<std::string> const& encryptionKeyFileName);
+	BackupContainerLocalDirectory(const std::string& url,
+	                              Optional<std::string> const& encryptionKeyFileName,
+	                              int encryptionBlockSize);
 
 	static Future<std::vector<std::string>> listURLs(const std::string& url);
 

--- a/fdbclient/FileBackupAgent.cpp
+++ b/fdbclient/FileBackupAgent.cpp
@@ -1636,7 +1636,8 @@ void decodeKVPairs(StringRefReader* reader, Standalone<VectorRef<KeyValueRef>>* 
 }
 
 static Reference<IBackupContainer> getBackupContainerWithProxy(Reference<IBackupContainer> _bc) {
-	Reference<IBackupContainer> bc = IBackupContainer::openContainer(_bc->getURL(), fileBackupAgentProxy, {});
+	Reference<IBackupContainer> bc = IBackupContainer::openContainer(
+	    _bc->getURL(), fileBackupAgentProxy, _bc->getEncryptionKeyFileName(), _bc->getEncryptionBlockSize());
 	return bc;
 }
 
@@ -2301,6 +2302,7 @@ struct BackupRangeTaskFunc : BackupTaskFuncBase {
 		if (!_bc) {
 			co_return;
 		}
+
 		Reference<IBackupContainer> bc = getBackupContainerWithProxy(_bc);
 		bool done = false;
 		int64_t nrKeys = 0;
@@ -3685,7 +3687,6 @@ struct BackupSnapshotManifest : BackupTaskFuncBase {
 					Reference<IBackupContainer> _bc = co_await config.backupContainer().getOrThrow(tr);
 					bc = getBackupContainerWithProxy(_bc);
 				}
-
 				BackupConfig::RangeFileMapT::RangeResultType rangeresults =
 				    co_await config.snapshotRangeFileMap().getRange(tr, startKey, {}, batchSize);
 
@@ -4295,9 +4296,10 @@ struct StartFullBackupTaskFunc : BackupTaskFuncBase {
 			}
 		}
 
+		// Properties folder is created here to ensure backup container exists because localDirectory doesn't create
+		// container during in constructor.
 		Reference<IBackupContainer> bc = co_await config.backupContainer().getOrThrow(tr);
-		co_await bc->writeEncryptionMetadata();
-
+		co_await bc->writeEncryptionMetadata(bc->getEncryptionBlockSize());
 		config.stateEnum().set(tr, EBackupState::STATE_RUNNING);
 
 		Reference<TaskFuture> backupFinished = futureBucket->future(tr);
@@ -4430,7 +4432,7 @@ struct BulkLoadRestoreTaskFunc : RestoreTaskFuncBase {
 			Error savedError;
 			try {
 				// Open backup container for metadata access
-				Reference<IBackupContainer> bcRef = IBackupContainer::openContainer(backupUrl, {}, {});
+				Reference<IBackupContainer> bcRef = IBackupContainer::openContainer(backupUrl, {}, {}, 0);
 
 				// Get restore ranges using a transaction
 				Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
@@ -7124,7 +7126,8 @@ public:
 	                                 UsePartitionedLog partitionedLog,
 	                                 IncrementalBackupOnly incrementalBackupOnly,
 	                                 Optional<std::string> encryptionKeyFileName,
-	                                 int snapshotMode) {
+	                                 int snapshotMode,
+	                                 int encryptionBlockSize) {
 		tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 		tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 		tr->setOption(FDBTransactionOptions::COMMIT_ON_FIRST_PROXY);
@@ -7133,7 +7136,9 @@ public:
 		    .detail("TagName", tagName.c_str())
 		    .detail("StopWhenDone", stopWhenDone)
 		    .detail("UsePartitionedLog", partitionedLog)
-		    .detail("OutContainer", outContainer.toString());
+		    .detail("OutContainer", outContainer.toString())
+		    .detail("EncryptionKeyFileName", encryptionKeyFileName.present() ? encryptionKeyFileName.get() : "None")
+		    .detail("EncryptionBlockSize", encryptionBlockSize);
 
 		KeyBackedTag tag = makeBackupTag(tagName);
 		Optional<UidAndAbortedFlagT> uidAndAbortedFlag = co_await tag.get(tr);
@@ -7162,7 +7167,14 @@ public:
 			backupContainer = joinPath(backupContainer, std::string("backup-") + nowStr.toString());
 		}
 
-		Reference<IBackupContainer> bc = IBackupContainer::openContainer(backupContainer, proxy, encryptionKeyFileName);
+		// TODO: Remove
+		if (encryptionKeyFileName.present() && encryptionBlockSize == 0) {
+			assert(false);
+			encryptionBlockSize = DEFAULT_ENCRYPTION_BLOCK_SIZE;
+		}
+
+		Reference<IBackupContainer> bc =
+		    IBackupContainer::openContainer(backupContainer, proxy, encryptionKeyFileName, encryptionBlockSize);
 		try {
 			// Use longer timeout for blobstore:// URLs in simulation to handle slow S3 mock operations
 			double createTimeout = (g_network->isSimulated() && isBlobstoreUrl(backupContainer)) ? 300.0 : 30.0;
@@ -7245,7 +7257,6 @@ public:
 		config.partitionedLogEnabled().set(tr, partitionedLog);
 		config.incrementalBackupOnly().set(tr, incrementalBackupOnly);
 		config.snapshotMode().set(tr, snapshotMode);
-
 		Key taskKey = co_await fileBackup::StartFullBackupTaskFunc::addTask(
 		    tr, backupAgent->taskBucket, uid, TaskCompletionKey::noSignal());
 
@@ -7268,7 +7279,9 @@ public:
 	                                  Version beginVersion,
 	                                  UID uid,
 	                                  TransformPartitionedLog transformPartitionedLog,
-	                                  bool useRangeFileRestore = true) {
+	                                  bool useRangeFileRestore = true,
+	                                  int encryptionBlockSize = 0,
+	                                  Optional<std::string> encryptionKeyFileName = {}) {
 		KeyRangeMap<int> restoreRangeSet;
 		for (auto& range : ranges) {
 			restoreRangeSet.insert(range, 1);
@@ -7333,7 +7346,13 @@ public:
 		// Point the tag to the new uid
 		tag.set(tr, { uid, false });
 
-		Reference<IBackupContainer> bc = IBackupContainer::openContainer(backupURL.toString(), proxy, {});
+		// TODO akanksha: Remove.
+		if (encryptionKeyFileName.present() && encryptionBlockSize == 0) {
+			assert(false);
+			encryptionBlockSize = DEFAULT_ENCRYPTION_BLOCK_SIZE;
+		}
+		Reference<IBackupContainer> bc =
+		    IBackupContainer::openContainer(backupURL.toString(), proxy, encryptionKeyFileName, encryptionBlockSize);
 
 		// Configure the new restore
 		restore.tag().set(tr, tagName.toString());
@@ -7355,7 +7374,6 @@ public:
 		}
 		// this also sets restore.add/removePrefix.
 		restore.initApplyMutations(tr, addPrefix, removePrefix, onlyApplyMutationLogs);
-
 		Key taskKey = co_await fileBackup::StartFullRestoreTaskFunc::addTask(
 		    tr, backupAgent->taskBucket, uid, TaskCompletionKey::noSignal());
 
@@ -8120,7 +8138,8 @@ public:
 		}
 
 		std::string urlStr = url.toString();
-		Reference<IBackupContainer> bc = IBackupContainer::openContainer(urlStr, proxy, encryptionKeyFileName);
+		Reference<IBackupContainer> bc =
+		    IBackupContainer::openContainer(urlStr, proxy, /*encryptionKeyFileName=*/{}, /*encryptionBlockSize=*/0);
 
 		// For blobstore:// URLs, use invalidVersion to allow describeBackup to write missing version properties
 		// This is needed for S3 where metadata may not be immediately consistent
@@ -8132,6 +8151,13 @@ public:
 		} else if (!desc.fileLevelEncryption && encryptionKeyFileName.present()) {
 			fprintf(stderr, "ERROR: Backup is not encrypted, please remove the encryption key file path.\n");
 			throw restore_error();
+		}
+
+		if (desc.fileLevelEncryption) {
+			bc = IBackupContainer::openContainer(urlStr, proxy, encryptionKeyFileName, desc.encryptionBlockSize);
+			// openContainer may return a cached container that has blockSize=0 (seeded earlier without blockSize).
+			// Set it explicitly to ensure the correct value is used.
+			bc->setEncryptionBlockSize(desc.encryptionBlockSize);
 		}
 
 		if (cxOrig.present()) {
@@ -8187,7 +8213,9 @@ public:
 				                       beginVersion,
 				                       randomUid,
 				                       TransformPartitionedLog(desc.partitioned),
-				                       useRangeFileRestore);
+				                       useRangeFileRestore,
+				                       desc.encryptionBlockSize,
+				                       encryptionKeyFileName);
 				co_await tr->commit();
 				break;
 			} catch (Error& e) {
@@ -8574,7 +8602,8 @@ Future<Void> FileBackupAgent::submitBackup(Reference<ReadYourWritesTransaction> 
                                            UsePartitionedLog partitionedLog,
                                            IncrementalBackupOnly incrementalBackupOnly,
                                            Optional<std::string> const& encryptionKeyFileName,
-                                           int snapshotMode) {
+                                           int snapshotMode,
+                                           int encryptionBlockSize) {
 	return FileBackupAgentImpl::submitBackup(this,
 	                                         tr,
 	                                         outContainer,
@@ -8587,7 +8616,8 @@ Future<Void> FileBackupAgent::submitBackup(Reference<ReadYourWritesTransaction> 
 	                                         partitionedLog,
 	                                         incrementalBackupOnly,
 	                                         encryptionKeyFileName,
-	                                         snapshotMode);
+	                                         snapshotMode,
+	                                         encryptionBlockSize);
 }
 
 Future<Void> FileBackupAgent::discontinueBackup(Reference<ReadYourWritesTransaction> tr, Key tagName) {

--- a/fdbclient/FileBackupAgent.cpp
+++ b/fdbclient/FileBackupAgent.cpp
@@ -7167,12 +7167,6 @@ public:
 			backupContainer = joinPath(backupContainer, std::string("backup-") + nowStr.toString());
 		}
 
-		// TODO: Remove
-		if (encryptionKeyFileName.present() && encryptionBlockSize == 0) {
-			assert(false);
-			encryptionBlockSize = DEFAULT_ENCRYPTION_BLOCK_SIZE;
-		}
-
 		Reference<IBackupContainer> bc =
 		    IBackupContainer::openContainer(backupContainer, proxy, encryptionKeyFileName, encryptionBlockSize);
 		try {
@@ -7346,11 +7340,6 @@ public:
 		// Point the tag to the new uid
 		tag.set(tr, { uid, false });
 
-		// TODO akanksha: Remove.
-		if (encryptionKeyFileName.present() && encryptionBlockSize == 0) {
-			assert(false);
-			encryptionBlockSize = DEFAULT_ENCRYPTION_BLOCK_SIZE;
-		}
 		Reference<IBackupContainer> bc =
 		    IBackupContainer::openContainer(backupURL.toString(), proxy, encryptionKeyFileName, encryptionBlockSize);
 

--- a/fdbclient/FileBackupAgent.cpp
+++ b/fdbclient/FileBackupAgent.cpp
@@ -7126,8 +7126,8 @@ public:
 	                                 UsePartitionedLog partitionedLog,
 	                                 IncrementalBackupOnly incrementalBackupOnly,
 	                                 Optional<std::string> encryptionKeyFileName,
-	                                 int snapshotMode,
-	                                 int encryptionBlockSize) {
+	                                 int encryptionBlockSize,
+	                                 int snapshotMode) {
 		tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 		tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 		tr->setOption(FDBTransactionOptions::COMMIT_ON_FIRST_PROXY);
@@ -8591,8 +8591,8 @@ Future<Void> FileBackupAgent::submitBackup(Reference<ReadYourWritesTransaction> 
                                            UsePartitionedLog partitionedLog,
                                            IncrementalBackupOnly incrementalBackupOnly,
                                            Optional<std::string> const& encryptionKeyFileName,
-                                           int snapshotMode,
-                                           int encryptionBlockSize) {
+                                           int encryptionBlockSize,
+                                           int snapshotMode) {
 	return FileBackupAgentImpl::submitBackup(this,
 	                                         tr,
 	                                         outContainer,
@@ -8605,8 +8605,8 @@ Future<Void> FileBackupAgent::submitBackup(Reference<ReadYourWritesTransaction> 
 	                                         partitionedLog,
 	                                         incrementalBackupOnly,
 	                                         encryptionKeyFileName,
-	                                         snapshotMode,
-	                                         encryptionBlockSize);
+	                                         encryptionBlockSize,
+	                                         snapshotMode);
 }
 
 Future<Void> FileBackupAgent::discontinueBackup(Reference<ReadYourWritesTransaction> tr, Key tagName) {

--- a/fdbclient/include/fdbclient/BackupAgent.h
+++ b/fdbclient/include/fdbclient/BackupAgent.h
@@ -278,8 +278,8 @@ public:
 	                          UsePartitionedLog = UsePartitionedLog::False,
 	                          IncrementalBackupOnly = IncrementalBackupOnly::False,
 	                          Optional<std::string> const& encryptionKeyFileName = {},
-	                          int snapshotMode = 0,
-	                          int encryptionBlockSize = 0);
+	                          int encryptionBlockSize = 0,
+	                          int snapshotMode = 0);
 	// snapshotMode: 0=RANGEFILE (default), 1=BULKDUMP, 2=BOTH
 	Future<Void> submitBackup(Database cx,
 	                          Key outContainer,
@@ -292,8 +292,8 @@ public:
 	                          UsePartitionedLog partitionedLog = UsePartitionedLog::False,
 	                          IncrementalBackupOnly incrementalBackupOnly = IncrementalBackupOnly::False,
 	                          Optional<std::string> const& encryptionKeyFileName = {},
-	                          int snapshotMode = 0,
-	                          int encryptionBlockSize = 0) {
+	                          int encryptionBlockSize = 0,
+	                          int snapshotMode = 0) {
 		// Note: Do NOT call checkAndDisableBackupWorkers here. That function is for cleanup
 		// when backups END (abort/discontinue), not when they START. Calling it here causes
 		// a race where backup workers get disabled while a backup is being submitted,
@@ -310,8 +310,8 @@ public:
 			                    partitionedLog,
 			                    incrementalBackupOnly,
 			                    encryptionKeyFileName,
-			                    snapshotMode,
-			                    encryptionBlockSize);
+			                    encryptionBlockSize,
+			                    snapshotMode);
 		});
 	}
 
@@ -779,7 +779,6 @@ inline Reference<IBackupContainer> TupleCodec<Reference<IBackupContainer>>::unpa
 	auto url = t.getString(0).toString();
 
 	Optional<std::string> encryptionKeyFileName;
-	std::string rawIndex1 = t.size() > 1 ? t.getString(1).toString() : "<missing>";
 	if (t.size() > 1 && !t.getString(1).empty()) {
 		encryptionKeyFileName = t.getString(1).toString();
 	}

--- a/fdbclient/include/fdbclient/BackupAgent.h
+++ b/fdbclient/include/fdbclient/BackupAgent.h
@@ -55,6 +55,8 @@ FDB_BOOLEAN_PARAM(ReadLowPriority);
 
 extern Optional<std::string> fileBackupAgentProxy;
 
+constexpr int DEFAULT_ENCRYPTION_BLOCK_SIZE = 1048576;
+
 class BackupAgentBase : NonCopyable {
 public:
 	// Time formatter for anything backup or restore related
@@ -276,7 +278,8 @@ public:
 	                          UsePartitionedLog = UsePartitionedLog::False,
 	                          IncrementalBackupOnly = IncrementalBackupOnly::False,
 	                          Optional<std::string> const& encryptionKeyFileName = {},
-	                          int snapshotMode = 0);
+	                          int snapshotMode = 0,
+	                          int encryptionBlockSize = 0);
 	// snapshotMode: 0=RANGEFILE (default), 1=BULKDUMP, 2=BOTH
 	Future<Void> submitBackup(Database cx,
 	                          Key outContainer,
@@ -289,7 +292,8 @@ public:
 	                          UsePartitionedLog partitionedLog = UsePartitionedLog::False,
 	                          IncrementalBackupOnly incrementalBackupOnly = IncrementalBackupOnly::False,
 	                          Optional<std::string> const& encryptionKeyFileName = {},
-	                          int snapshotMode = 0) {
+	                          int snapshotMode = 0,
+	                          int encryptionBlockSize = 0) {
 		// Note: Do NOT call checkAndDisableBackupWorkers here. That function is for cleanup
 		// when backups END (abort/discontinue), not when they START. Calling it here causes
 		// a race where backup workers get disabled while a backup is being submitted,
@@ -306,7 +310,8 @@ public:
 			                    partitionedLog,
 			                    incrementalBackupOnly,
 			                    encryptionKeyFileName,
-			                    snapshotMode);
+			                    snapshotMode,
+			                    encryptionBlockSize);
 		});
 	}
 
@@ -763,6 +768,7 @@ inline Standalone<StringRef> TupleCodec<Reference<IBackupContainer>>::pack(Refer
 		tuple.append(StringRef());
 	}
 
+	tuple.append((int64_t)bc->getEncryptionBlockSize());
 	return tuple.pack();
 }
 template <>
@@ -773,6 +779,7 @@ inline Reference<IBackupContainer> TupleCodec<Reference<IBackupContainer>>::unpa
 	auto url = t.getString(0).toString();
 
 	Optional<std::string> encryptionKeyFileName;
+	std::string rawIndex1 = t.size() > 1 ? t.getString(1).toString() : "<missing>";
 	if (t.size() > 1 && !t.getString(1).empty()) {
 		encryptionKeyFileName = t.getString(1).toString();
 	}
@@ -782,7 +789,11 @@ inline Reference<IBackupContainer> TupleCodec<Reference<IBackupContainer>>::unpa
 		proxy = t.getString(2).toString();
 	}
 
-	return IBackupContainer::openContainer(url, proxy, encryptionKeyFileName);
+	int blockSize = 0;
+	if (t.size() > 3) {
+		blockSize = (int)t.getInt(3);
+	}
+	return IBackupContainer::openContainer(url, proxy, encryptionKeyFileName, blockSize);
 }
 
 class BackupConfig : public KeyBackedTaskConfig {

--- a/fdbclient/include/fdbclient/BackupContainer.h
+++ b/fdbclient/include/fdbclient/BackupContainer.h
@@ -210,6 +210,7 @@ struct BackupDescription {
 	std::string extendedDetail; // Freeform container-specific info.
 	bool partitioned; // If this backup contains partitioned mutation logs.
 	bool fileLevelEncryption; // If this backup contains encrypted files.
+	int encryptionBlockSize; // Block size used for file encryption, 0 if not encrypted.
 
 	// Resolves the versions above to timestamps using a given database's TimeKeeper data.
 	// toString will use this information if present.
@@ -345,7 +346,8 @@ public:
 	// Get an IBackupContainer based on a container spec string
 	static Reference<IBackupContainer> openContainer(const std::string& url,
 	                                                 const Optional<std::string>& proxy,
-	                                                 const Optional<std::string>& encryptionKeyFileName);
+	                                                 const Optional<std::string>& encryptionKeyFileName,
+	                                                 int encryptionBlockSize);
 	static std::vector<std::string> getURLFormats();
 	static Future<std::vector<std::string>> listContainers(const std::string& baseURL,
 	                                                       const Optional<std::string>& proxy);
@@ -354,11 +356,14 @@ public:
 	Optional<std::string> const& getProxy() const { return proxy; }
 	Optional<std::string> const& getEncryptionKeyFileName() const { return encryptionKeyFileName; }
 
-	virtual Future<Void> writeEncryptionMetadata() = 0;
+	virtual Future<Void> writeEncryptionMetadata(int encryptionBlockSize) = 0;
 
 	static std::string lastOpenError;
 
 	virtual Future<Void> encryptionSetupComplete() const = 0;
+
+	virtual int getEncryptionBlockSize() const { return 0; }
+	virtual void setEncryptionBlockSize(int blockSize) {}
 
 	// TODO: change the following back to `private` once blob obj access is refactored
 protected:

--- a/fdbclient/include/fdbclient/BackupContainerFileSystem.h
+++ b/fdbclient/include/fdbclient/BackupContainerFileSystem.h
@@ -82,6 +82,7 @@ public:
 	static Reference<BackupContainerFileSystem> openContainerFS(const std::string& url,
 	                                                            const Optional<std::string>& proxy,
 	                                                            const Optional<std::string>& encryptionKeyFileName,
+	                                                            int encryptionBlockSize,
 	                                                            bool isBackup = true);
 
 	// Get a list of fileNames and their sizes in the container under the given path
@@ -172,10 +173,13 @@ public:
 	                                                  Version beginVersion) final;
 	static Future<Void> createTestEncryptionKeyFile(std::string const& filename);
 
-	Future<Void> writeEncryptionMetadata() override;
+	Future<Void> writeEncryptionMetadata(int encryptionBlockSize) override;
 
 	// Waits for encryption initialization to complete by reading encryption key file during container opening.
 	Future<Void> encryptionSetupComplete() const override;
+
+	int getEncryptionBlockSize() const override { return encryptionBlockSize; }
+	void setEncryptionBlockSize(int blockSize) override { encryptionBlockSize = blockSize; }
 
 protected:
 	// Returns true if an encryption key file was provided.
@@ -184,6 +188,8 @@ protected:
 	void setEncryptionKey(Optional<std::string> const& encryptionKeyFileName);
 
 	Future<Void> writeEntireFileFallback(const std::string& fileName, const std::string& fileContents);
+
+	int encryptionBlockSize = 0;
 
 private:
 	struct VersionProperty {
@@ -212,6 +218,8 @@ private:
 	VersionProperty unreliableEndVersion();
 	VersionProperty logType();
 	VersionProperty fileLevelEncryption();
+
+	static std::string encryptionMetadataFileName();
 
 	// List range files, unsorted, which contain data at or between beginVersion and endVersion
 	// NOTE: This reads the range file folder schema from FDB 6.0.15 and earlier and is provided for backward

--- a/fdbclient/tests/tests_common.sh
+++ b/fdbclient/tests/tests_common.sh
@@ -326,7 +326,7 @@ function log_test_result {
 # $1 Dir to search under.
 function grep_for_severity40 {
   local dir="${1}"
-  if grep -r -C 3 -e "Severity=\"40\"" "${dir}"; then
+  if grep -r --exclude-dir=encryption_mismatch_logs -C 3 -e "Severity=\"40\"" "${dir}"; then
     err "Found 'Severity=40' errors"
     return 1
   fi

--- a/fdbrpc/AsyncFileEncrypted.cpp
+++ b/fdbrpc/AsyncFileEncrypted.cpp
@@ -75,8 +75,6 @@ public:
 		ASSERT(self->mode == AsyncFileEncrypted::Mode::READ_ONLY);
 		for (block = firstBlock; block <= lastBlock; ++block) {
 			Standalone<StringRef> plaintext = co_await readBlock(self.getPtr(), block);
-			self->readBuffers.insert(block, plaintext);
-		
 			auto start =
 			    (block == firstBlock) ? plaintext.begin() + (offset % self->encryptionBlockSize) : plaintext.begin();
 			auto end = (block == lastBlock) ? plaintext.begin() + ((offset + length) % self->encryptionBlockSize)
@@ -141,8 +139,7 @@ public:
 };
 
 AsyncFileEncrypted::AsyncFileEncrypted(Reference<IAsyncFile> file, Mode mode, int blockSize)
-  : file(file), mode(mode), currentBlock(0),
-    encryptionBlockSize(blockSize) {
+  : file(file), mode(mode), currentBlock(0), encryptionBlockSize(blockSize) {
 	ASSERT(encryptionBlockSize > 0);
 	firstBlockIV = AsyncFileEncryptedImpl::getFirstBlockIV(file->getFilename());
 	if (mode == Mode::APPEND_ONLY) {

--- a/fdbrpc/AsyncFileEncrypted.cpp
+++ b/fdbrpc/AsyncFileEncrypted.cpp
@@ -44,13 +44,12 @@ public:
 		return iv;
 	}
 
-	// Read a single block of size ENCRYPTION_BLOCK_SIZE bytes, and decrypt.
+	// Read a single block of size encryptionBlockSize bytes, and decrypt.
 	static Future<Standalone<StringRef>> readBlock(AsyncFileEncrypted* self, uint32_t block) {
 		Arena arena;
-		auto* encrypted = new (arena) unsigned char[FLOW_KNOBS->ENCRYPTION_BLOCK_SIZE];
+		auto* encrypted = new (arena) unsigned char[self->encryptionBlockSize];
 		int bytes = co_await uncancellable(holdWhile(
-		    arena,
-		    self->file->read(encrypted, FLOW_KNOBS->ENCRYPTION_BLOCK_SIZE, FLOW_KNOBS->ENCRYPTION_BLOCK_SIZE * block)));
+		    arena, self->file->read(encrypted, self->encryptionBlockSize, self->encryptionBlockSize * block)));
 		StreamCipherKey const* cipherKey = StreamCipherKey::getGlobalCipherKey();
 		DecryptionStreamCipher decryptor(cipherKey, self->getIV(block));
 		auto decrypted = decryptor.decrypt(encrypted, bytes, arena);
@@ -68,20 +67,21 @@ public:
 		if (offset + length > self->fileSize) {
 			length = self->fileSize - offset;
 		}
-		uint32_t firstBlock = offset / FLOW_KNOBS->ENCRYPTION_BLOCK_SIZE;
-		uint32_t lastBlock = (offset + length - 1) / FLOW_KNOBS->ENCRYPTION_BLOCK_SIZE;
+		uint32_t firstBlock = offset / self->encryptionBlockSize;
+		uint32_t lastBlock = (offset + length - 1) / self->encryptionBlockSize;
 		uint32_t block{ 0 };
 		auto* output = reinterpret_cast<unsigned char*>(data);
 		int bytesRead = 0;
 		ASSERT(self->mode == AsyncFileEncrypted::Mode::READ_ONLY);
 		for (block = firstBlock; block <= lastBlock; ++block) {
 			Standalone<StringRef> plaintext = co_await readBlock(self.getPtr(), block);
-			auto start = (block == firstBlock) ? plaintext.begin() + (offset % FLOW_KNOBS->ENCRYPTION_BLOCK_SIZE)
-			                                   : plaintext.begin();
-			auto end = (block == lastBlock)
-			               ? plaintext.begin() + ((offset + length) % FLOW_KNOBS->ENCRYPTION_BLOCK_SIZE)
-			               : plaintext.end();
-			if ((offset + length) % FLOW_KNOBS->ENCRYPTION_BLOCK_SIZE == 0) {
+			self->readBuffers.insert(block, plaintext);
+		
+			auto start =
+			    (block == firstBlock) ? plaintext.begin() + (offset % self->encryptionBlockSize) : plaintext.begin();
+			auto end = (block == lastBlock) ? plaintext.begin() + ((offset + length) % self->encryptionBlockSize)
+			                                : plaintext.end();
+			if ((offset + length) % self->encryptionBlockSize == 0) {
 				end = plaintext.end();
 			}
 
@@ -102,10 +102,10 @@ public:
 	static Future<Void> write(Reference<AsyncFileEncrypted> self, void const* data, int length, int64_t offset) {
 		ASSERT(self->mode == AsyncFileEncrypted::Mode::APPEND_ONLY);
 		// All writes must append to the end of the file:
-		ASSERT_EQ(offset, self->currentBlock * FLOW_KNOBS->ENCRYPTION_BLOCK_SIZE + self->offsetInBlock);
+		ASSERT_EQ(offset, self->currentBlock * self->encryptionBlockSize + self->offsetInBlock);
 		auto const* input = reinterpret_cast<unsigned char const*>(data);
 		while (length > 0) {
-			const auto chunkSize = std::min(length, FLOW_KNOBS->ENCRYPTION_BLOCK_SIZE - self->offsetInBlock);
+			const auto chunkSize = std::min(length, self->encryptionBlockSize - self->offsetInBlock);
 			Arena arena;
 			auto encrypted = self->encryptor->encrypt(input, chunkSize, arena);
 			std::copy(encrypted.begin(), encrypted.end(), &self->writeBuffer[self->offsetInBlock]);
@@ -113,7 +113,7 @@ public:
 			self->offsetInBlock += chunkSize;
 			length -= chunkSize;
 			input += chunkSize;
-			if (self->offsetInBlock == FLOW_KNOBS->ENCRYPTION_BLOCK_SIZE) {
+			if (self->offsetInBlock == self->encryptionBlockSize) {
 				co_await self->writeLastBlockToFile();
 				self->offsetInBlock = 0;
 				ASSERT_LT(self->currentBlock, std::numeric_limits<uint32_t>::max());
@@ -140,13 +140,15 @@ public:
 	}
 };
 
-AsyncFileEncrypted::AsyncFileEncrypted(Reference<IAsyncFile> file, Mode mode)
-  : file(file), mode(mode), currentBlock(0) {
+AsyncFileEncrypted::AsyncFileEncrypted(Reference<IAsyncFile> file, Mode mode, int blockSize)
+  : file(file), mode(mode), currentBlock(0),
+    encryptionBlockSize(blockSize) {
+	ASSERT(encryptionBlockSize > 0);
 	firstBlockIV = AsyncFileEncryptedImpl::getFirstBlockIV(file->getFilename());
 	if (mode == Mode::APPEND_ONLY) {
 		encryptor =
 		    std::make_unique<EncryptionStreamCipher>(StreamCipherKey::getGlobalCipherKey(), getIV(currentBlock));
-		writeBuffer = std::vector<unsigned char>(FLOW_KNOBS->ENCRYPTION_BLOCK_SIZE, 0);
+		writeBuffer = std::vector<unsigned char>(encryptionBlockSize, 0);
 	}
 }
 
@@ -219,16 +221,16 @@ StreamCipher::IV AsyncFileEncrypted::getIV(uint32_t block) const {
 Future<Void> AsyncFileEncrypted::writeLastBlockToFile() {
 	// The source buffer for the write is owned by *this so this must be kept alive by reference count until the write
 	// is finished.
-	return uncancellable(
-	    holdWhile(Reference<AsyncFileEncrypted>::addRef(this),
-	              file->write(&writeBuffer[0], offsetInBlock, currentBlock * FLOW_KNOBS->ENCRYPTION_BLOCK_SIZE)));
+	return uncancellable(holdWhile(Reference<AsyncFileEncrypted>::addRef(this),
+	                               file->write(&writeBuffer[0], offsetInBlock, currentBlock * encryptionBlockSize)));
 }
 
 // This test writes random data into an encrypted file in random increments,
 // then reads this data back from the file in random increments, then confirms that
 // the bytes read match the bytes written.
 TEST_CASE("fdbrpc/AsyncFileEncrypted") {
-	const int bytes = FLOW_KNOBS->ENCRYPTION_BLOCK_SIZE * deterministicRandom()->randomInt(0, 1000);
+	int encryptionBlockSize = 4096;
+	const int bytes = encryptionBlockSize * deterministicRandom()->randomInt(0, 1000);
 	std::vector<unsigned char> writeBuffer(bytes, 0);
 	if (bytes > 0) {
 		deterministicRandom()->randomBytes(writeBuffer.data(), bytes);
@@ -237,10 +239,11 @@ TEST_CASE("fdbrpc/AsyncFileEncrypted") {
 	ASSERT(g_network->isSimulated());
 	StreamCipherKey::initializeGlobalRandomTestKey();
 	int flags = IAsyncFile::OPEN_READWRITE | IAsyncFile::OPEN_CREATE | IAsyncFile::OPEN_ATOMIC_WRITE_AND_CREATE |
-	            IAsyncFile::OPEN_UNBUFFERED | IAsyncFile::OPEN_ENCRYPTED | IAsyncFile::OPEN_UNCACHED |
-	            IAsyncFile::OPEN_NO_AIO;
-	Reference<IAsyncFile> file = co_await IAsyncFileSystem::filesystem()->open(
+	            IAsyncFile::OPEN_UNBUFFERED | IAsyncFile::OPEN_UNCACHED | IAsyncFile::OPEN_NO_AIO;
+	Reference<IAsyncFile> rawFile = co_await IAsyncFileSystem::filesystem()->open(
 	    joinPath(params.getDataDir(), "test-encrypted-file"), flags, 0600);
+	Reference<IAsyncFile> file =
+	    makeReference<AsyncFileEncrypted>(rawFile, AsyncFileEncrypted::Mode::APPEND_ONLY, encryptionBlockSize);
 	int bytesWritten = 0;
 	int chunkSize;
 	while (bytesWritten < bytes) {

--- a/fdbrpc/Net2FileSystem.cpp
+++ b/fdbrpc/Net2FileSystem.cpp
@@ -38,7 +38,6 @@
 #include "fdbrpc/AsyncFileCached.h"
 #include "AsyncFileChaos.h"
 #include "AsyncFileEIO.h"
-#include "fdbrpc/AsyncFileEncrypted.h"
 #include "AsyncFileWinASIO.h"
 #include "AsyncFileKAIO.h"
 #include "flow/AsioReactor.h"
@@ -170,12 +169,6 @@ Future<Reference<class IAsyncFile>> Net2FileSystem::open(const std::string& file
 		f = map(f, [=](Reference<IAsyncFile> r) { return Reference<IAsyncFile>(new AsyncFileWriteChecker(r)); });
 	if (FLOW_KNOBS->ENABLE_CHAOS_FEATURES)
 		f = map(f, [=](Reference<IAsyncFile> r) { return Reference<IAsyncFile>(new AsyncFileChaos(r)); });
-	if (flags & IAsyncFile::OPEN_ENCRYPTED)
-		f = map(f, [flags](Reference<IAsyncFile> r) {
-			auto mode = flags & IAsyncFile::OPEN_READWRITE ? AsyncFileEncrypted::Mode::APPEND_ONLY
-			                                               : AsyncFileEncrypted::Mode::READ_ONLY;
-			return Reference<IAsyncFile>(new AsyncFileEncrypted(r, mode));
-		});
 	return f;
 }
 

--- a/fdbrpc/include/fdbrpc/AsyncFileEncrypted.h
+++ b/fdbrpc/include/fdbrpc/AsyncFileEncrypted.h
@@ -49,10 +49,11 @@ private:
 	uint32_t currentBlock{ 0 };
 	int offsetInBlock{ 0 };
 	std::vector<unsigned char> writeBuffer;
+	int encryptionBlockSize{ 0 };
 	Future<Void> initialize();
 
 public:
-	AsyncFileEncrypted(Reference<IAsyncFile>, Mode);
+	AsyncFileEncrypted(Reference<IAsyncFile>, Mode, int blockSize);
 	void addref() override;
 	void delref() override;
 	Future<int> read(void* data, int length, int64_t offset) override;

--- a/fdbrpc/sim2.cpp
+++ b/fdbrpc/sim2.cpp
@@ -41,7 +41,6 @@
 #include "flow/Util.h"
 #include "flow/IAsyncFile.h"
 #include "fdbrpc/AsyncFileCached.h"
-#include "fdbrpc/AsyncFileEncrypted.h"
 #include "fdbrpc/SimulatorProcessInfo.h"
 #include "fdbrpc/AsyncFileNonDurable.h"
 #include "AsyncFileChaos.h"
@@ -2804,12 +2803,6 @@ Future<Reference<class IAsyncFile>> Sim2FileSystem::open(const std::string& file
 		f = AsyncFileDetachable::open(f);
 		if (FLOW_KNOBS->ENABLE_CHAOS_FEATURES)
 			f = map(f, [=](Reference<IAsyncFile> r) { return Reference<IAsyncFile>(new AsyncFileChaos(r)); });
-		if (flags & IAsyncFile::OPEN_ENCRYPTED)
-			f = map(f, [flags](Reference<IAsyncFile> r) {
-				auto mode = flags & IAsyncFile::OPEN_READWRITE ? AsyncFileEncrypted::Mode::APPEND_ONLY
-				                                               : AsyncFileEncrypted::Mode::READ_ONLY;
-				return Reference<IAsyncFile>(new AsyncFileEncrypted(r, mode));
-			});
 		return f;
 	} else
 		return AsyncFileCached::open(filename, flags, mode);

--- a/fdbserver/workloads/Backup.cpp
+++ b/fdbserver/workloads/Backup.cpp
@@ -179,8 +179,8 @@ struct BackupWorkload : TestWorkload {
 			                                   usePartitionedLog,
 			                                   IncrementalBackupOnly::False,
 			                                   encryptionKeyFileName,
-			                                   /*snapshotMode=*/0,
-			                                   encryptionKeyFileName.present() ? DEFAULT_ENCRYPTION_BLOCK_SIZE : 0);
+			                                   encryptionKeyFileName.present() ? DEFAULT_ENCRYPTION_BLOCK_SIZE : 0,
+			                                   /*snapshotMode=*/0);
 		} catch (Error& e) {
 			TraceEvent("BW_DoBackupSubmitBackupException", randomID).error(e).detail("Tag", printable(tag));
 			if (e.code() != error_code_backup_unneeded && e.code() != error_code_backup_duplicate)

--- a/fdbserver/workloads/Backup.cpp
+++ b/fdbserver/workloads/Backup.cpp
@@ -178,7 +178,9 @@ struct BackupWorkload : TestWorkload {
 			                                   StopWhenDone{ !stopDifferentialDelay },
 			                                   usePartitionedLog,
 			                                   IncrementalBackupOnly::False,
-			                                   encryptionKeyFileName);
+			                                   encryptionKeyFileName,
+			                                   /*snapshotMode=*/0,
+			                                   encryptionKeyFileName.present() ? DEFAULT_ENCRYPTION_BLOCK_SIZE : 0);
 		} catch (Error& e) {
 			TraceEvent("BW_DoBackupSubmitBackupException", randomID).error(e).detail("Tag", printable(tag));
 			if (e.code() != error_code_backup_unneeded && e.code() != error_code_backup_duplicate)

--- a/fdbserver/workloads/BackupCorrectness.cpp
+++ b/fdbserver/workloads/BackupCorrectness.cpp
@@ -318,8 +318,8 @@ struct BackupAndRestoreCorrectnessWorkload : TestWorkload {
 			                                   UsePartitionedLog::False,
 			                                   IncrementalBackupOnly::False,
 			                                   encryptionKeyFileName,
-			                                   /*snapshotMode=*/0,
-			                                   encryptionKeyFileName.present() ? DEFAULT_ENCRYPTION_BLOCK_SIZE : 0);
+			                                   encryptionKeyFileName.present() ? DEFAULT_ENCRYPTION_BLOCK_SIZE : 0,
+			                                   /*snapshotMode=*/0);
 		} catch (Error& e) {
 			TraceEvent("BARW_DoBackupSubmitBackupException", randomID).error(e).detail("Tag", printable(tag));
 			if (e.code() != error_code_backup_unneeded && e.code() != error_code_backup_duplicate)

--- a/fdbserver/workloads/BackupCorrectness.cpp
+++ b/fdbserver/workloads/BackupCorrectness.cpp
@@ -317,7 +317,9 @@ struct BackupAndRestoreCorrectnessWorkload : TestWorkload {
 			                                   StopWhenDone{ !stopDifferentialDelay },
 			                                   UsePartitionedLog::False,
 			                                   IncrementalBackupOnly::False,
-			                                   encryptionKeyFileName);
+			                                   encryptionKeyFileName,
+			                                   /*snapshotMode=*/0,
+			                                   encryptionKeyFileName.present() ? DEFAULT_ENCRYPTION_BLOCK_SIZE : 0);
 		} catch (Error& e) {
 			TraceEvent("BARW_DoBackupSubmitBackupException", randomID).error(e).detail("Tag", printable(tag));
 			if (e.code() != error_code_backup_unneeded && e.code() != error_code_backup_duplicate)
@@ -625,7 +627,8 @@ struct BackupAndRestoreCorrectnessWorkload : TestWorkload {
 			if (lastBackupContainer && performRestore) {
 				auto container = IBackupContainer::openContainer(lastBackupContainer->getURL(),
 				                                                 lastBackupContainer->getProxy(),
-				                                                 lastBackupContainer->getEncryptionKeyFileName());
+				                                                 lastBackupContainer->getEncryptionKeyFileName(),
+				                                                 lastBackupContainer->getEncryptionBlockSize());
 				BackupDescription desc = co_await container->describeBackup();
 
 				if (deterministicRandom()->random01() < 0.5) {

--- a/fdbserver/workloads/BackupCorrectnessPartitioned.cpp
+++ b/fdbserver/workloads/BackupCorrectnessPartitioned.cpp
@@ -316,7 +316,9 @@ struct BackupAndRestorePartitionedCorrectnessWorkload : TestWorkload {
 			                                   StopWhenDone{ !stopDifferentialDelay },
 			                                   UsePartitionedLog::True, // enable partitioned log here
 			                                   IncrementalBackupOnly::False,
-			                                   encryptionKeyFileName);
+			                                   encryptionKeyFileName,
+			                                   /*snapshotMode=*/0,
+			                                   encryptionKeyFileName.present() ? DEFAULT_ENCRYPTION_BLOCK_SIZE : 0);
 		} catch (Error& e) {
 			TraceEvent("BARW_DoBackupSubmitBackupException", randomID).error(e).detail("Tag", printable(tag));
 			if (e.code() != error_code_backup_unneeded && e.code() != error_code_backup_duplicate)
@@ -535,7 +537,8 @@ struct BackupAndRestorePartitionedCorrectnessWorkload : TestWorkload {
 			if (lastBackupContainer && performRestore) {
 				auto container = IBackupContainer::openContainer(lastBackupContainer->getURL(),
 				                                                 lastBackupContainer->getProxy(),
-				                                                 lastBackupContainer->getEncryptionKeyFileName());
+				                                                 lastBackupContainer->getEncryptionKeyFileName(),
+				                                                 lastBackupContainer->getEncryptionBlockSize());
 				BackupDescription desc = co_await container->describeBackup();
 				Version targetVersion = -1;
 				if (desc.maxRestorableVersion.present()) {

--- a/fdbserver/workloads/BackupCorrectnessPartitioned.cpp
+++ b/fdbserver/workloads/BackupCorrectnessPartitioned.cpp
@@ -317,8 +317,8 @@ struct BackupAndRestorePartitionedCorrectnessWorkload : TestWorkload {
 			                                   UsePartitionedLog::True, // enable partitioned log here
 			                                   IncrementalBackupOnly::False,
 			                                   encryptionKeyFileName,
-			                                   /*snapshotMode=*/0,
-			                                   encryptionKeyFileName.present() ? DEFAULT_ENCRYPTION_BLOCK_SIZE : 0);
+			                                   encryptionKeyFileName.present() ? DEFAULT_ENCRYPTION_BLOCK_SIZE : 0,
+			                                   /*snapshotMode=*/0);
 		} catch (Error& e) {
 			TraceEvent("BARW_DoBackupSubmitBackupException", randomID).error(e).detail("Tag", printable(tag));
 			if (e.code() != error_code_backup_unneeded && e.code() != error_code_backup_duplicate)

--- a/fdbserver/workloads/BackupS3BlobCorrectness.cpp
+++ b/fdbserver/workloads/BackupS3BlobCorrectness.cpp
@@ -522,8 +522,8 @@ struct BackupS3BlobCorrectnessWorkload : TestWorkload {
 			                                   UsePartitionedLog::False,
 			                                   IncrementalBackupOnly::False,
 			                                   encryptionKeyFileName,
-			                                   snapshotMode,
-			                                   encryptionKeyFileName.present() ? DEFAULT_ENCRYPTION_BLOCK_SIZE : 0);
+			                                   encryptionKeyFileName.present() ? DEFAULT_ENCRYPTION_BLOCK_SIZE : 0,
+			                                   snapshotMode);
 		} catch (Error& e) {
 			TraceEvent("BS3BCW_DoBackupSubmitBackupException", randomID).error(e).detail("Tag", printable(tag));
 			if (e.code() != error_code_backup_unneeded && e.code() != error_code_backup_duplicate)

--- a/fdbserver/workloads/BackupS3BlobCorrectness.cpp
+++ b/fdbserver/workloads/BackupS3BlobCorrectness.cpp
@@ -522,7 +522,8 @@ struct BackupS3BlobCorrectnessWorkload : TestWorkload {
 			                                   UsePartitionedLog::False,
 			                                   IncrementalBackupOnly::False,
 			                                   encryptionKeyFileName,
-			                                   snapshotMode);
+			                                   snapshotMode,
+			                                   encryptionKeyFileName.present() ? DEFAULT_ENCRYPTION_BLOCK_SIZE : 0);
 		} catch (Error& e) {
 			TraceEvent("BS3BCW_DoBackupSubmitBackupException", randomID).error(e).detail("Tag", printable(tag));
 			if (e.code() != error_code_backup_unneeded && e.code() != error_code_backup_duplicate)

--- a/fdbserver/workloads/IncrementalBackup.cpp
+++ b/fdbserver/workloads/IncrementalBackup.cpp
@@ -132,7 +132,7 @@ struct IncrementalBackupWorkload : TestWorkload {
 					    .detail("First", containers.front());
 					if (!containers.empty()) {
 						backupContainer =
-						    IBackupContainer::openContainer(containers.front(), {}, restoreEncryptionKeyFileName);
+						    IBackupContainer::openContainer(containers.front(), {}, {}, 0);
 					}
 				}
 				bool e = co_await backupContainer->exists();
@@ -202,7 +202,9 @@ struct IncrementalBackupWorkload : TestWorkload {
 				                                  StopWhenDone::False,
 				                                  UsePartitionedLog::False,
 				                                  IncrementalBackupOnly::True,
-				                                  encryptionKeyFileName);
+				                                  encryptionKeyFileName,
+				                                  0,
+				                                  encryptionKeyFileName.present() ? DEFAULT_ENCRYPTION_BLOCK_SIZE : 0);
 			} catch (Error& e) {
 				TraceEvent("IBackupSubmitError").error(e);
 				if (e.code() != error_code_backup_duplicate) {

--- a/fdbserver/workloads/IncrementalBackup.cpp
+++ b/fdbserver/workloads/IncrementalBackup.cpp
@@ -202,8 +202,8 @@ struct IncrementalBackupWorkload : TestWorkload {
 				                                  UsePartitionedLog::False,
 				                                  IncrementalBackupOnly::True,
 				                                  encryptionKeyFileName,
-				                                  0,
-				                                  encryptionKeyFileName.present() ? DEFAULT_ENCRYPTION_BLOCK_SIZE : 0);
+				                                  encryptionKeyFileName.present() ? DEFAULT_ENCRYPTION_BLOCK_SIZE : 0,
+				                                  0);
 			} catch (Error& e) {
 				TraceEvent("IBackupSubmitError").error(e);
 				if (e.code() != error_code_backup_duplicate) {

--- a/fdbserver/workloads/IncrementalBackup.cpp
+++ b/fdbserver/workloads/IncrementalBackup.cpp
@@ -131,8 +131,7 @@ struct IncrementalBackupWorkload : TestWorkload {
 					    .detail("Size", containers.size())
 					    .detail("First", containers.front());
 					if (!containers.empty()) {
-						backupContainer =
-						    IBackupContainer::openContainer(containers.front(), {}, {}, 0);
+						backupContainer = IBackupContainer::openContainer(containers.front(), {}, {}, 0);
 					}
 				}
 				bool e = co_await backupContainer->exists();

--- a/fdbserver/workloads/Restore.cpp
+++ b/fdbserver/workloads/Restore.cpp
@@ -155,7 +155,8 @@ struct RestoreWorkload : TestWorkload {
 			if (lastBackupContainer && performRestore) {
 				auto container = IBackupContainer::openContainer(lastBackupContainer->getURL(),
 				                                                 lastBackupContainer->getProxy(),
-				                                                 lastBackupContainer->getEncryptionKeyFileName());
+				                                                 lastBackupContainer->getEncryptionKeyFileName(),
+				                                                 lastBackupContainer->getEncryptionBlockSize());
 				BackupDescription desc = co_await container->describeBackup();
 				TraceEvent("RW_Restore", randomID)
 				    .setMaxEventLength(12000)

--- a/fdbserver/workloads/RestoreMultiRanges.cpp
+++ b/fdbserver/workloads/RestoreMultiRanges.cpp
@@ -152,8 +152,8 @@ struct RestoreMultiRangesWorkload : TestWorkload {
 			                                  UsePartitionedLog::False,
 			                                  IncrementalBackupOnly::False,
 			                                  encryptionKeyFileName,
-			                                  0,
-			                                  encryptionKeyFileName.present() ? DEFAULT_ENCRYPTION_BLOCK_SIZE : 0);
+			                                  encryptionKeyFileName.present() ? DEFAULT_ENCRYPTION_BLOCK_SIZE : 0,
+			                                  0);
 		} catch (Error& e) {
 			if (e.code() != error_code_backup_unneeded && e.code() != error_code_backup_duplicate)
 				throw;

--- a/fdbserver/workloads/RestoreMultiRanges.cpp
+++ b/fdbserver/workloads/RestoreMultiRanges.cpp
@@ -151,7 +151,9 @@ struct RestoreMultiRangesWorkload : TestWorkload {
 			                                  StopWhenDone::True,
 			                                  UsePartitionedLog::False,
 			                                  IncrementalBackupOnly::False,
-			                                  encryptionKeyFileName);
+			                                  encryptionKeyFileName,
+			                                  0,
+			                                  encryptionKeyFileName.present() ? DEFAULT_ENCRYPTION_BLOCK_SIZE : 0);
 		} catch (Error& e) {
 			if (e.code() != error_code_backup_unneeded && e.code() != error_code_backup_duplicate)
 				throw;

--- a/fdbserver/workloads/SubmitBackup.cpp
+++ b/fdbserver/workloads/SubmitBackup.cpp
@@ -78,8 +78,8 @@ struct SubmitBackupWorkload : TestWorkload {
 			                                  UsePartitionedLog::False,
 			                                  incremental,
 			                                  encryptionKeyFileName,
-			                                  0,
-			                                  encryptionKeyFileName.present() ? DEFAULT_ENCRYPTION_BLOCK_SIZE : 0);
+			                                  encryptionKeyFileName.present() ? DEFAULT_ENCRYPTION_BLOCK_SIZE : 0,
+			                                  0);
 		} catch (Error& e) {
 			TraceEvent("BackupSubmitError").error(e);
 			if (e.code() != error_code_backup_duplicate) {

--- a/fdbserver/workloads/SubmitBackup.cpp
+++ b/fdbserver/workloads/SubmitBackup.cpp
@@ -77,7 +77,9 @@ struct SubmitBackupWorkload : TestWorkload {
 			                                  stopWhenDone,
 			                                  UsePartitionedLog::False,
 			                                  incremental,
-			                                  encryptionKeyFileName);
+			                                  encryptionKeyFileName,
+			                                  0,
+			                                  encryptionKeyFileName.present() ? DEFAULT_ENCRYPTION_BLOCK_SIZE : 0);
 		} catch (Error& e) {
 			TraceEvent("BackupSubmitError").error(e);
 			if (e.code() != error_code_backup_duplicate) {

--- a/flow/Knobs.cpp
+++ b/flow/Knobs.cpp
@@ -175,9 +175,6 @@ void FlowKnobs::initialize(Randomize randomize, IsSimulated isSimulated) {
 	init( EIO_MAX_PARALLELISM,                                  4  );
 	init( EIO_USE_ODIRECT,                                      0  );
 
-	//AsyncFileEncrypted
-	init( ENCRYPTION_BLOCK_SIZE,                              4096 );
-
 	//AsyncFileKAIO
 	init( MAX_OUTSTANDING,                                      64 );
 	init( MIN_SUBMIT,                                           10 );

--- a/flow/include/flow/Knobs.h
+++ b/flow/include/flow/Knobs.h
@@ -227,9 +227,6 @@ public:
 	int EIO_MAX_PARALLELISM;
 	int EIO_USE_ODIRECT;
 
-	// AsyncFileEncrypted
-	int ENCRYPTION_BLOCK_SIZE;
-
 	// AsyncFileKAIO
 	int MAX_OUTSTANDING;
 	int MIN_SUBMIT;


### PR DESCRIPTION
### Summary

This PR adds` --encryption-block-size` to fdbbackup start and makes it an explicit, stored property of each backup — ensuring backups and restores always use the same block size regardless of process configuration.

Previously, `AsyncFileEncrypted` used `FLOW_KNOBS->ENCRYPTION_BLOCK_SIZE`, a process-wide knob. This made it impossible to recover the correct block size during restore, since the knob value at restore time might differ from the one used at backup time.

This PR also provides support for encryption in `fdbdecode`

#### Approach

The block size is established at `fdbbackup start`, stored in three places so it survives across processes and time, and automatically threaded through to every file open:

  1. FDB keyspace (BackupConfig / RestoreConfig) — persists the value for backup and restore agent tasks
  2. TupleCodec (TupleCodec<Reference<IBackupContainer>>) — block size is now a 4th field in the serialized container tuple alongside URL, encryption key, and proxy. When any task deserializes a container from FDB,
   the block size is automatically restored without any explicit per-task handling
  3. Backup metadata file (properties/file_level_encryption) — written as 
```  {"file_level_encryption": true, "encryption_block_size": N} ```
  so fdbrestore can read the correct value from the backup itself, independent of
  FDB state
 
Net2FileSystem / Sim2FileSystem: Local directory backups open encrypted files through the IAsyncFileSystem abstraction. Since the block size is per-backup rather than a global knob, the filesystem interface needed a way to accept it before each file open.

 On the restore side, `StartFullRestoreTaskFunc` reads `desc.encryptionBlockSize` from the backup metadata after `describeBackup()` and calls `bc->setEncryptionBlockSize()` directly on the container — bypassing the URL
  container cache which may have been seeded with blockSize=0 during URL validation.

  `AsyncFileEncrypted` is updated to take block size as a constructor parameter (with ASSERT(blockSize > 0)), removing all uses of `FLOW_KNOBS->ENCRYPTION_BLOCK_SIZE` from backup code paths.

 #### Key behaviors

  - Default block size is 1 MB (1,048,576 bytes) when `--encryption-key-file` is provided without `--encryption-block-size`
  - Errors out if --encryption-block-size is passed without --encryption-key-file
  ```
2026-04-23T20:30:18+00:00 Run blob storage backup
ERROR: --encryption-block-size option requires --encryption-key-file to be set
2026-04-23T20:30:18+00:00 ERROR: Start fdbbackup failed
2026-04-23T20:30:18+00:00 ERROR: Failed backup
```
  - fdbbackup modify picks up the block size from the existing backup config
  ```
 fdbbackup modify  -C  /root/local_testing/loopback-cluster/fdb.cluster -t mybackup -d file:///root/local_testing/backup_after/ --encryption-key-file /root/local_testing/key_file --log --logdir=/root/local_testing/logs --encryption_block_size=4096
ERROR: unknown option `--encryption_block_size'
Try `fdbbackup --help' for more information.
```
  - Unencrypted backups are unaffected
  - Describe Backup commands show the encryption block size
  ```
Backup Description
URL: blobstore://@s3.us-west-2.amazonaws.com/ctests/test_s3_backup_and_restore?bucket=backup-112664522426-us-west-2&region=us-west-2&secure_connection=1
Restorable: true
Partitioned logs: false
File-level encryption: true
Encryption block size: 1048576
```
```
Backup Description
URL: blobstore://@s3.us-west-2.amazonaws.com/ctests/test_s3_backup_and_restore?bucket=backup-112664522426-us-west-2&region=us-west-2&secure_connection=1
Restorable: true
Partitioned logs: true
File-level encryption: false
Encryption block size: 0
```

### Testing

  - blob_backup_restore_test.sh and dir_backup_test.sh with and without encryption (S3 + local file)
  - --encryption-block-size randomly passed or omitted when encryption is enabled, covering both paths
  - Encryption key mismatch testing added for local backups.
  - Partitioned backups also running successfully with encryption enabled.
  - Simulation 100k Completed
   ``` 20260426-212948-ak_encrypt_bk2-74662613f993dbb3    compressed=True data_size=36360139 duration=5101081 ended=100000 fail=1 fail_fast=10 max_runs=100000 pass=99999 priority=100 remaining=0 runtime=1:18:36 sanity=False started=100000 stopped=20260426-224824 submitted=20260426-212948 timeout=5400 username=ak_encrypt_bk2```
   Failure unrelated to this change in `ProtocolVersion.toml`
   
   - fdbdecode with encryption on local directory:
   
  ```
 fdbdecode     -r file:///root/backup_testing/s3backup.fQjJ/backups/backup-2026-04-27-01-47-05.696749/     -t range   -k key__   --encryption-key-file /root/backup_testing/s3backup.fQjJ/test_encryption_key_file
Params: ContainerURL: file:///root/backup_testing/s3backup.fQjJ/backups/backup-2026-04-27-01-47-05.696749/, FileFilter: , list_only: false, validate_filters: false, KeyPrefixes: key__, SaveFile: false, EncryptionKeyFile: /root/backup_testing/s3backup.fQjJ/test_encryption_key_file

URL: file:///root/backup_testing/s3backup.fQjJ/backups/backup-2026-04-27-01-47-05.696749/
Restorable: true
Partitioned logs: false
File-level encryption: true
Encryption block size: 4096
Snapshot:  startVersion=1860027 (maxLogEnd -0.00 days)  endVersion=1860027 (maxLogEnd -0.00 days)  totalBytes=423  restorable=true  expiredPct=0.00
SnapshotBytes: 423
MinLogBeginVersion:      1830422 (maxLogEnd -0.00 days)
ContiguousLogEndVersion: 21830422 (maxLogEnd -0.00 days)
MaxLogEndVersion:        21830422 (maxLogEnd -0.00 days)
MinRestorableVersion:    1860027 (maxLogEnd -0.00 days)
MaxRestorableVersion:    21830421 (maxLogEnd -0.00 days)

Relevant range files are:  1 total
version:1860027 blockSize:1048576 fileName:kvranges/snapshot.000000000001830422/0/range,1860027,6ca770f4e5cc88300acc5e26608c2244,1048576 fileSize:423

1860027 key: 6b65795f5f30  value: 302e323032362d30342d32375430313a34373a30352b30303a3030
1860027 key: 6b65795f5f31  value: 312e323032362d30342d32375430313a34373a30352b30303a3030
1860027 key: 6b65795f5f32  value: 322e323032362d30342d32375430313a34373a30352b30303a3030
1860027 key: 6b65795f5f33  value: 332e323032362d30342d32375430313a34373a30352b30303a3030
1860027 key: 6b65795f5f34  value: 342e323032362d30342d32375430313a34373a30352b30303a3030
1860027 key: 6b65795f5f35  value: 352e323032362d30342d32375430313a34373a30352b30303a3030
1860027 key: 6b65795f5f36  value: 362e323032362d30342d32375430313a34373a30352b30303a3030
1860027 key: 6b65795f5f37  value: 372e323032362d30342d32375430313a34373a30352b30303a3030
1860027 key: 6b65795f5f38  value: 382e323032362d30342d32375430313a34373a30352b30303a3030
1860027 key: 6b65795f5f39  value: 392e323032362d30342d32375430313a34373a30352b30303a3030
```

on S3

```
Params: ContainerURL: blobstore://@s3.us-west-2.amazonaws.com/ctests/test_s3_backup_and_restore?bucket=backup-112664522426-us-west-2&region=us-west-2&secure_connection=1, FileFilter:  LogDir:/tmp/fdbdecode-logs, list_only: false, validate_filters: false, KeyPrefixes: key__, SaveFile: false, EncryptionKeyFile: /root/backup_testing/test_encryption_key_file

URL: blobstore://@s3.us-west-2.amazonaws.com/ctests/test_s3_backup_and_restore?bucket=backup-112664522426-us-west-2&region=us-west-2&secure_connection=1
Restorable: true
Partitioned logs: false
File-level encryption: true
Encryption block size: 4096
Snapshot:  startVersion=2504387 (maxLogEnd -0.00 days)  endVersion=2504387 (maxLogEnd -0.00 days)  totalBytes=4293  restorable=true  expiredPct=0.00
SnapshotBytes: 4293
MinLogBeginVersion:      2334178 (maxLogEnd -0.00 days)
ContiguousLogEndVersion: 22334178 (maxLogEnd -0.00 days)
MaxLogEndVersion:        22334178 (maxLogEnd -0.00 days)
MinRestorableVersion:    2504387 (maxLogEnd -0.00 days)
MaxRestorableVersion:    22334177 (maxLogEnd -0.00 days)

Relevant range files are:  1 total
version:2504387 blockSize:1048576 fileName:kvranges/snapshot.000000000002334178/0/range,2504387,b891ab27ab555aa958c3a09ee151e726,1048576 fileSize:4293

2504387 key: 6b65795f5f30  value: 302e323032362d30342d32375430323a32323a31362b30303a3030
2504387 key: 6b65795f5f31  value: 312e323032362d30342d32375430323a32323a31362b30303a3030
2504387 key: 6b65795f5f3130  value: 31302e323032362d30342d32375430323a32323a31362b30303a3030
2504387 key: 6b65795f5f3131  value: 31312e323032362d30342d32375430323a32323a31362b30303a3030
2504387 key: 6b65795f5f3132  value: 31322e323032362d30342d32375430323a32323a31362b30303a3030
2504387 key: 6b65795f5f3133  value: 31332e323032362d30342d32375430323a32323a31362b30303a3030
```