### PR TITLE
Finish `KeyValueStoreSQLite` coroutine conversion

### DIFF
--- a/fdbserver/kvstore/CMakeLists.txt
+++ b/fdbserver/kvstore/CMakeLists.txt
@@ -1,19 +1,4 @@
-set(FDBSERVER_KVSTORE_SRCS
-  DiskQueue.actor.cpp
-  FDBExecHelper.cpp
-  IKeyValueStore.cpp
-  IPager.cpp
-  KeyValueStoreCompressTestData.cpp
-  KeyValueStoreMemory.actor.cpp
-  KeyValueStoreRocksDB.actor.cpp
-  KeyValueStoreShardedRocksDB.actor.cpp
-  KeyValueStoreSQLite.cpp
-  RocksDBCommon.cpp
-  RocksDBLogForwarder.cpp
-  TransactionStoreMutationTracking.cpp
-  VFSAsync.cpp
-  VersionedBTree.actor.cpp
-  VersionedBTreeDebug.cpp)
+fdb_find_sources(FDBSERVER_KVSTORE_SRCS)
 
 add_flow_target(STATIC_LIBRARY NAME fdbserver_kvstore SRCS ${FDBSERVER_KVSTORE_SRCS})
 add_fdbserver_link_test(fdbserver_kvstorelinktest

--- a/fdbserver/kvstore/CMakeLists.txt
+++ b/fdbserver/kvstore/CMakeLists.txt
@@ -7,7 +7,7 @@ set(FDBSERVER_KVSTORE_SRCS
   KeyValueStoreMemory.actor.cpp
   KeyValueStoreRocksDB.actor.cpp
   KeyValueStoreShardedRocksDB.actor.cpp
-  KeyValueStoreSQLite.actor.cpp
+  KeyValueStoreSQLite.cpp
   RocksDBCommon.cpp
   RocksDBLogForwarder.cpp
   TransactionStoreMutationTracking.cpp

--- a/fdbserver/kvstore/KeyValueStoreSQLite.actor.cpp
+++ b/fdbserver/kvstore/KeyValueStoreSQLite.actor.cpp
@@ -1612,8 +1612,8 @@ struct ThreadSafeCounter {
 
 class KeyValueStoreSQLite final : public IKeyValueStore {
 public:
-	void dispose() override { doClose(this, true); }
-	void close() override { doClose(this, false); }
+	void dispose() override { doClose(Uncancellable(), this, true); }
+	void close() override { doClose(Uncancellable(), this, false); }
 
 	Future<Void> getError() const override { return delayed(readThreads->getError() || writeThread->getError()); }
 	Future<Void> onClosed() const override { return stopped.getFuture(); }
@@ -2084,8 +2084,8 @@ private:
 		}
 	}
 
-	ACTOR static void doClose(KeyValueStoreSQLite* self, bool deleteOnClose) {
-		state Error error = success();
+	static Future<Void> doClose(Uncancellable, KeyValueStoreSQLite* self, bool deleteOnClose) {
+		Error error = success();
 
 		self->disableRateControl();
 
@@ -2094,10 +2094,10 @@ private:
 			self->starting.cancel();
 			self->cleaning.cancel();
 			self->logging.cancel();
-			wait(self->readThreads->stop() && self->writeThread->stop());
+			co_await (self->readThreads->stop() && self->writeThread->stop());
 			if (deleteOnClose) {
-				wait(IAsyncFileSystem::filesystem()->incrementalDeleteFile(self->filename, true));
-				wait(IAsyncFileSystem::filesystem()->incrementalDeleteFile(self->filename + "-wal", false));
+				co_await IAsyncFileSystem::filesystem()->incrementalDeleteFile(self->filename, true);
+				co_await IAsyncFileSystem::filesystem()->incrementalDeleteFile(self->filename + "-wal", false);
 			}
 		} catch (Error& e) {
 			TraceEvent(SevError, "KVDoCloseError", self->logID)

--- a/fdbserver/kvstore/KeyValueStoreSQLite.cpp
+++ b/fdbserver/kvstore/KeyValueStoreSQLite.cpp
@@ -1694,7 +1694,7 @@ private:
 			Key key;
 			Optional<UID> debugID;
 			ThreadReturnPromise<Optional<Value>> result;
-			ReadValueAction(Key key, Optional<UID> debugID) : key(key), debugID(debugID){};
+			ReadValueAction(Key key, Optional<UID> debugID) : key(key), debugID(debugID) {};
 			double getTimeEstimate() const override { return SERVER_KNOBS->READ_VALUE_TIME_ESTIMATE; }
 		};
 		void action(ReadValueAction& rv) {
@@ -1722,7 +1722,7 @@ private:
 			Optional<UID> debugID;
 			ThreadReturnPromise<Optional<Value>> result;
 			ReadValuePrefixAction(Key key, int maxLength, Optional<UID> debugID)
-			  : key(key), maxLength(maxLength), debugID(debugID){};
+			  : key(key), maxLength(maxLength), debugID(debugID) {};
 			double getTimeEstimate() const override { return SERVER_KNOBS->READ_VALUE_TIME_ESTIMATE; }
 		};
 		void action(ReadValuePrefixAction& rv) {

--- a/fdbserver/kvstore/KeyValueStoreSQLite.cpp
+++ b/fdbserver/kvstore/KeyValueStoreSQLite.cpp
@@ -1958,7 +1958,7 @@ private:
 			                   std::max(1, SERVER_KNOBS->SPRING_CLEANING_LAZY_DELETE_BATCH_SIZE));
 			bool vacuumFinished = false;
 
-			loop {
+			while (true) {
 				double begin = now();
 				bool canDelete = !freeTableEmpty &&
 				                 (now() < lazyDeleteEnd || workPerformed.lazyDeletePages <

--- a/fdbserver/kvstore/KeyValueStoreSQLite.cpp
+++ b/fdbserver/kvstore/KeyValueStoreSQLite.cpp
@@ -1,5 +1,5 @@
 /*
- * KeyValueStoreSQLite.actor.cpp
+ * KeyValueStoreSQLite.cpp
  *
  * This source file is part of the FoundationDB open source project
  *
@@ -1694,7 +1694,7 @@ private:
 			Key key;
 			Optional<UID> debugID;
 			ThreadReturnPromise<Optional<Value>> result;
-			ReadValueAction(Key key, Optional<UID> debugID) : key(key), debugID(debugID) {};
+			ReadValueAction(Key key, Optional<UID> debugID) : key(key), debugID(debugID){};
 			double getTimeEstimate() const override { return SERVER_KNOBS->READ_VALUE_TIME_ESTIMATE; }
 		};
 		void action(ReadValueAction& rv) {
@@ -1722,7 +1722,7 @@ private:
 			Optional<UID> debugID;
 			ThreadReturnPromise<Optional<Value>> result;
 			ReadValuePrefixAction(Key key, int maxLength, Optional<UID> debugID)
-			  : key(key), maxLength(maxLength), debugID(debugID) {};
+			  : key(key), maxLength(maxLength), debugID(debugID){};
 			double getTimeEstimate() const override { return SERVER_KNOBS->READ_VALUE_TIME_ESTIMATE; }
 		};
 		void action(ReadValuePrefixAction& rv) {


### PR DESCRIPTION
This PR converts the final remaining `KeyValueStoreSQLite::doClose` `ACTOR` to a standard coroutine, allowing `KeyValueStoreSQLite.actor.cpp` to be renamed

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
