### PR TITLE
fix: add explicit StringRef(const char*) ctor to fix dangling pointer

### DIFF
--- a/flow/Arena.cpp
+++ b/flow/Arena.cpp
@@ -930,6 +930,25 @@ TEST_CASE("flow/StringRef/eat") {
 	return Void();
 }
 
+// Verifies StringRef(const char*) borrows the pointer directly (like std::string_view)
+// rather than routing through a temporary std::string, which would leave a dangling pointer.
+TEST_CASE("/flow/StringRef/ConstCharConstructor") {
+	StringRef s("Hello world!");
+	ASSERT(s == "Hello world!"_sr);
+	ASSERT(s.size() == 12);
+
+	const char* cstr = "another string";
+	StringRef s2(cstr);
+	ASSERT(s2 == "another string"_sr);
+	ASSERT(s2.begin() == reinterpret_cast<const uint8_t*>(cstr));
+
+	StringRef empty("");
+	ASSERT(empty.empty());
+	ASSERT(empty.size() == 0);
+
+	return Void();
+}
+
 struct TestOptionalMapClass {
 	StringRef value;
 	Optional<StringRef> optionalValue;

--- a/flow/include/flow/Arena.h
+++ b/flow/include/flow/Arena.h
@@ -176,7 +176,7 @@ struct ArenaBlock : NonCopyable, ThreadSafeReferenceCounted<ArenaBlock> {
 
 	enum { NOT_TINY = 127, TINY_HEADER = 6 };
 
-	// int32_t referenceCount;    // 4 bytes (in ThreadSafeReferenceCounted)
+	// int32_t referenceCount;	  // 4 bytes (in ThreadSafeReferenceCounted)
 	bool secure : 1; // If this is set, block is zero-ed out after use
 	uint8_t tinySize : 7, tinyUsed; // If these == NOT_TINY, use bigSize, bigUsed instead
 	// if tinySize != NOT_TINY, following variables aren't used

--- a/flow/include/flow/Arena.h
+++ b/flow/include/flow/Arena.h
@@ -384,6 +384,9 @@ public:
 		}
 	}
 	StringRef(const uint8_t* data, int length) : data(data), length(length) {}
+	// For string literals prefer "foo"_sr, which captures the length at compile time and
+	// avoids the runtime strlen walk this ctor performs. This ctor is for const char*
+	// values whose length isn't known at compile time (e.g: from  C APIs or interop).
 	// Borrows the pointer and computes length via strlen, like std::string_view.
 	// Marked explicit so that existing `f("literal")` calls that resolve against
 	// overload pairs like f(std::string) / f(StringRef) keep picking std::string,

--- a/flow/include/flow/Arena.h
+++ b/flow/include/flow/Arena.h
@@ -176,7 +176,7 @@ struct ArenaBlock : NonCopyable, ThreadSafeReferenceCounted<ArenaBlock> {
 
 	enum { NOT_TINY = 127, TINY_HEADER = 6 };
 
-	// int32_t referenceCount;	  // 4 bytes (in ThreadSafeReferenceCounted)
+	// int32_t referenceCount;    // 4 bytes (in ThreadSafeReferenceCounted)
 	bool secure : 1; // If this is set, block is zero-ed out after use
 	uint8_t tinySize : 7, tinyUsed; // If these == NOT_TINY, use bigSize, bigUsed instead
 	// if tinySize != NOT_TINY, following variables aren't used
@@ -354,6 +354,12 @@ private:
 		return bytesCopied;
 	}
 
+	// Delegated-to by StringRef(const char*) so strlen runs once and overflow is checked before truncation.
+	StringRef(const char* str, size_t len)
+	  : data(reinterpret_cast<const uint8_t*>(str)), length(static_cast<int>(len)) {
+		UNSTOPPABLE_ASSERT(len <= std::numeric_limits<int>::max());
+	}
+
 public:
 	constexpr static FileIdentifier file_identifier = 13300811;
 	StringRef() : data(0), length(0) {}
@@ -378,6 +384,17 @@ public:
 		}
 	}
 	StringRef(const uint8_t* data, int length) : data(data), length(length) {}
+	// Borrows the pointer and computes length via strlen, like std::string_view.
+	// Marked explicit so that existing `f("literal")` calls that resolve against
+	// overload pairs like f(std::string) / f(StringRef) keep picking std::string,
+	// avoiding ambiguity. Direct-init `StringRef s("literal")` still selects this
+	// constructor — which is the actual use-after-free case this guards against.
+	// Precondition: str is not null.
+	explicit StringRef(const char* str) : StringRef(str, strlen(str)) {}
+	StringRef(std::nullptr_t) = delete;
+	// Reject integer literals (e.g. StringRef(0)), which would otherwise pick the const char*
+	// overload via null-pointer conversion and crash in strlen.
+	StringRef(int) = delete;
 	StringRef(const std::string& s) : data((const uint8_t*)s.c_str()), length((int)s.size()) {
 		if (s.size() > std::numeric_limits<int>::max())
 			abort();


### PR DESCRIPTION
## Problem
`StringRef s("some literal");` silently produces a dangling pointer (issue #7802). Previously, `StringRef` had no `const char*` constructor, so `const char*` arguments went through `StringRef(const std::string&)` via an implicit temporary `std::string`. That temporary died at the end of the full-expression, leaving the `StringRef` pointing at freed memory.

## Solution
Add an `explicit StringRef(const char*)` constructor that borrows the pointer directly (like `std::string_view`) and computes length via `strlen`. Key details:            
- **`explicit`** is load-bearing. A non-explicit overload created equally-ranked user-defined conversion paths from `const char*` at any call site with both `f(std::string)` and `f(StringRef)` overloads — introducing hard ambiguity errors. An earlier iteration of this PR surfaced such ambiguities in `flow/Trace.cpp`, `fdbclient/Tracing.actor.cpp`, and `fdbclient/JsonBuilder.h`. `explicit` preserves legacy overload resolution while still letting `StringRef s("literal");` (direct initialization) select the new constructor — which is the actual #7802 case.
- Length/overflow is checked in a private delegated constructor so `strlen` runs once, and overflow is detected before the `size_t → int` truncation.
- `StringRef(std::nullptr_t) = delete;` and `StringRef(int) = delete;` reject `StringRef(nullptr)` and `StringRef(0)` at compile time rather than crashing inside `strlen`.

## Testing
- Added regression test `/flow/StringRef/ConstCharConstructor` in `flow/Arena.cpp`, which verifies:                                        
- `StringRef("literal")` survives past its initializer (no dangling pointer).
- The constructor borrows the source pointer (`s.begin() == source_ptr`) rather than copying.
- Empty string behaves correctly (`empty()`, `size() == 0`).
- Full local `ninja` build across `flow`, `fdbrpc`, and `fdbclient` (including linking `bin/fdbcli`) completed with zero compile errors, confirming the `explicit` qualifier prevents overload-resolution regressions.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:                                                                                              

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)