### PR TITLE
Populate committedVersion on automatic idempotency replay path

### DIFF
--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -4536,6 +4536,7 @@ ACTOR static Future<Void> tryCommit(Reference<TransactionState> trState, CommitT
 					    req.transaction.read_snapshot + CLIENT_KNOBS->MAX_WRITE_TRANSACTION_LIFE_VERSIONS,
 					    req.idempotencyId));
 					if (commitResult.present()) {
+						trState->committedVersion = commitResult.get().commitVersion;
 						Standalone<StringRef> ret = makeString(10);
 						placeVersionstamp(
 						    mutateString(ret), commitResult.get().commitVersion, commitResult.get().batchIndex);

--- a/fdbserver/workloads/AutomaticIdempotencyWorkload.cpp
+++ b/fdbserver/workloads/AutomaticIdempotencyWorkload.cpp
@@ -114,12 +114,17 @@ struct AutomaticIdempotencyWorkload : TestWorkload {
 			Value idempotencyId = makeString(length);
 			deterministicRandom()->randomBytes(mutateString(idempotencyId), length);
 			TraceEvent("IdempotencyIdWorkloadTransaction").detail("Id", idempotencyId);
+			bool automatic = deterministicRandom()->random01() < automaticPercentage;
+			Reference<ReadYourWritesTransaction> committedTr;
 			co_await runRYWTransaction(
-			    cx, [this, idempotencyId = idempotencyId](Reference<ReadYourWritesTransaction> tr) {
+			    cx,
+			    [this, idempotencyId = idempotencyId, automatic, &committedTr](
+			        Reference<ReadYourWritesTransaction> tr) {
+				    committedTr = tr;
 				    // If we don't set AUTOMATIC_IDEMPOTENCY the idempotency id won't automatically get cleaned up, so
 				    // it should create work for the cleaner.
 				    tr->setOption(FDBTransactionOptions::IDEMPOTENCY_ID, idempotencyId);
-				    if (deterministicRandom()->random01() < automaticPercentage) {
+				    if (automatic) {
 					    // We also want to exercise the automatic idempotency code path.
 					    tr->setOption(FDBTransactionOptions::AUTOMATIC_IDEMPOTENCY);
 				    }
@@ -132,6 +137,12 @@ struct AutomaticIdempotencyWorkload : TestWorkload {
 				                 MutationRef::SetVersionstampedKey);
 				    return Future<Void>(Void());
 			    });
+			if (committedTr->getCommittedVersion() == invalidVersion) {
+				TraceEvent(SevError, "IdempotencyCommitMissingVersion")
+				    .detail("Id", idempotencyId)
+				    .detail("AutomaticIdempotency", automatic);
+				ok = false;
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Client-side gap in `tryCommit`: on the automatic idempotency replay path, `determineCommitStatus` recovers the original commit version but never writes it into `trState->committedVersion`. `getCommittedVersion()` then returns `invalidVersion` after a successful replay.
- One-line fix mirrors the normal-path assignment at `NativeAPI.actor.cpp:4456`. No wire / system keyspace changes; storage already has the version.
- Regression guard added in `AutomaticIdempotencyWorkload`: every successful commit must report a non-invalid version. Exercised by existing `CLIENT_BUGGIFY`.

Closes #12582.

## Test plan
- [x] `AutomaticIdempotency.toml` simulation fails before the fix (seed 12345: 10x `IdempotencyCommitMissingVersion` SevError)
- [x] Same seed passes after the fix, with `AutomaticIdempotencyCommitted` `CODE_PROBE` firing (replay branch actually exercised)
- [ ] CI across many seeds (requires core committer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)