### PR TITLE
Rewrite PR template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,18 +1,19 @@
-Replace this text with your description here...
+## PLEASE DELETE THIS TEMPLATE WHEN YOU POST YOUR PR FOR REVIEW
 
-# Code-Reviewer Section
+Please describe the following in your PR description:
+  * The problem being solved. If this is a bug you found, please describe how/where you encountered it.
+  * The nature of the solution.
+  * Testing you have done, if any.
 
-The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).
+We encourage you to use AI coding assistants to review diffs in advance.  Save your diff to a file first.  This can be done easily by
+```
+git diff upstream/main -- . > /tmp/pr.diff
+```
 
-Please check each of the following things and check *all* boxes before accepting a PR.
+Then have your agent review the diff. We have had good results with the following prompt:
 
-- [ ] The PR has a description, explaining both the problem and the solution.
-- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
-- [ ] Every function/class/actor that was touched is reasonably well documented.
+```
+Review /tmp/pr.diff. What is it trying to do? Is it correct? Are there bugs? Are there omissions? Are there better ways of doing things? Should this CL be LGTMd?
+```
 
-## For Release-Branches
-
-If this PR is made against a release-branch, please also check the following:
-
-- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
-- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
+## END OF TEMPLATE TO DELETE

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,17 +1,16 @@
 ## PLEASE DELETE THIS TEMPLATE WHEN YOU POST YOUR PR FOR REVIEW
 
-Please describe the following in your PR description:
-  * The problem being solved. If this is a bug you found, please describe how/where you encountered it.
-  * The nature of the solution.
-  * Testing you have done, if any.
+Please describe:
+  * The problem (for bugs: how/where you encountered it).
+  * The solution.
+  * Testing done, if any.
 
-We encourage you to use AI coding assistants to review diffs in advance. This can be done by saving your diff to a file:
+We encourage AI-assisted review. Save your diff:
 ```
 git diff upstream/main -- . > /tmp/pr.diff
 ```
 
-Then have your agent review the diff. We have had good results with the following prompt:
-
+Then review it with a prompt like:
 ```
 Review /tmp/pr.diff. What is it trying to do? Is it correct? Are there bugs? Are there omissions? Are there better ways of doing things? Should this CL be LGTMd?
 ```

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -5,7 +5,7 @@ Please describe the following in your PR description:
   * The nature of the solution.
   * Testing you have done, if any.
 
-We encourage you to use AI coding assistants to review diffs in advance.  Save your diff to a file first.  This can be done easily by
+We encourage you to use AI coding assistants to review diffs in advance. This can be done by saving your diff to a file:
 ```
 git diff upstream/main -- . > /tmp/pr.diff
 ```


### PR DESCRIPTION
There are many problems with the existing template:
  * It links to a page which has many points which are widely ignored and which by their nature will tend to evolve/drift over time.
  * There is no need to have contributors read that page.  Most of that is relevant only to Apple people
  *  It's so generally useless and disregarded that people look right past it and leave it in their PR descriptions without even deleting it, so we end up with a lot of commit messages cluttered with junk template text
  * It misses the opportunity to remind people posting PRs to have AI review their code 
  * It misses the opportunity to ask people for potentially useful information, like where they found a problem. This isn't always applicable but sometimes it is.
  * The comment about confirming that "every function/class/actor that was touched is reasonably well documented" is particularly problematic.  FDB is perhaps the least well documented source base I have ever worked on and asking PR submitters to document every function/class/actor is a credibility loss.  The solution for PR purposes is obviously to have code reviewers ask for documentation where they see gaps.