### PR TITLE
fix: invert addWatcher error check and prevent HTTP/TLS server fallthrough in fdbkubernetesmonitor

### DIFF
--- a/fdbkubernetesmonitor/monitor.go
+++ b/fdbkubernetesmonitor/monitor.go
@@ -175,6 +175,7 @@ func startMonitor(ctx context.Context, logger logr.Logger, configFile string, cu
 				logger.Error(err, "could not start HTTPS server")
 				os.Exit(1)
 			}
+			return
 		}
 		err := http.ListenAndServe(promConfig.listenAddr, mux)
 		if err != nil {
@@ -527,7 +528,7 @@ func addWatcher(fileName string, watcher *fsnotify.Watcher) error {
 	var err error
 	for retryCnt < maxRetryCnt {
 		err = watcher.Add(fileName)
-		if err != nil {
+		if err == nil {
 			return nil
 		}
 


### PR DESCRIPTION
addWatcher returned nil on error and retried on success due to err != nil instead of err == nil. This caused file-watch re-establishment to silently fail after ConfigMap remounts, permanently stopping config change detection.

When TLS is configured, the goroutine falls through from the HTTPS block to also start a plain HTTP server on the same port. Added return after the HTTPS block to make the HTTPS-or-HTTP intent explicit.






# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
