### PR TITLE
Convert `getWorkerInterfaces` to standard coroutine

### DIFF
--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -146,9 +146,6 @@ Future<Void> refreshTransaction(DatabaseContext* self, Transaction* tr) {
 	*tr = Transaction(Database(Reference<DatabaseContext>::addRef(self)));
 }
 
-// FIXME: get a prototype in a header file, ugh.
-ACTOR Future<RangeResult> getWorkerInterfaces(Reference<IClusterConnectionRecord> clusterRecord);
-
 Optional<KeyRangeLocationInfo> DatabaseContext::getCachedLocation(const KeyRef& key, Reverse isBackward) {
 	Arena arena;
 

--- a/fdbclient/ReadYourWrites.actor.cpp
+++ b/fdbclient/ReadYourWrites.actor.cpp
@@ -25,6 +25,7 @@
 #include "fdbclient/SpecialKeySpace.h"
 #include "fdbclient/StatusClient.h"
 #include "fdbclient/MonitorLeader.h"
+#include "flow/CoroUtils.h"
 #include "flow/Util.h"
 #include "flow/actorcompiler.h" // This must be the last #include.
 
@@ -1595,27 +1596,27 @@ Future<Optional<Value>> getJSON(Database db, std::string jsonField) {
 	co_return getValueFromJSON(statusObj);
 }
 
-ACTOR Future<RangeResult> getWorkerInterfaces(Reference<IClusterConnectionRecord> connRecord) {
-	state Reference<AsyncVar<Optional<ClusterInterface>>> clusterInterface(new AsyncVar<Optional<ClusterInterface>>);
-	state Future<Void> leaderMon = monitorLeader<ClusterInterface>(connRecord, clusterInterface);
+Future<RangeResult> getWorkerInterfaces(Reference<IClusterConnectionRecord> connRecord) {
+	Reference<AsyncVar<Optional<ClusterInterface>>> clusterInterface(new AsyncVar<Optional<ClusterInterface>>);
+	Future<Void> leaderMon = monitorLeader<ClusterInterface>(connRecord, clusterInterface);
 
-	loop {
-		choose {
-			when(std::vector<ClientWorkerInterface> workers =
-			         wait(clusterInterface->get().present()
-			                  ? brokenPromiseToNever(
-			                        clusterInterface->get().get().getClientWorkers.getReply(GetClientWorkersRequest()))
-			                  : Never())) {
-				RangeResult result;
-				for (auto& it : workers) {
-					result.push_back_deep(
-					    result.arena(),
-					    KeyValueRef(it.address().toString(), BinaryWriter::toValue(it, IncludeVersion())));
-				}
+	while (true) {
+		Future<std::vector<ClientWorkerInterface>> workersFuture =
+		    clusterInterface->get().present()
+		        ? brokenPromiseToNever(
+		              clusterInterface->get().get().getClientWorkers.getReply(GetClientWorkersRequest()))
+		        : Never();
+		auto res = co_await race(workersFuture, clusterInterface->onChange());
+		if (res.index() == 0) {
+			std::vector<ClientWorkerInterface> workers = std::get<0>(std::move(res));
 
-				return result;
+			RangeResult result;
+			for (auto& it : workers) {
+				result.push_back_deep(
+				    result.arena(), KeyValueRef(it.address().toString(), BinaryWriter::toValue(it, IncludeVersion())));
 			}
-			when(wait(clusterInterface->onChange())) {}
+
+			co_return result;
 		}
 	}
 }

--- a/fdbclient/SpecialKeySpace.cpp
+++ b/fdbclient/SpecialKeySpace.cpp
@@ -2888,8 +2888,6 @@ Future<Optional<std::string>> FailedLocalitiesRangeImpl::commit(ReadYourWritesTr
 	return excludeLocalityCommitActor(ryw, true);
 }
 
-// Defined in ReadYourWrites.actor.cpp
-Future<RangeResult> getWorkerInterfaces(Reference<IClusterConnectionRecord> const& clusterRecord);
 // Defined in NativeAPI.actor.cpp
 Future<bool> verifyInterfaceActor(Reference<FlowLock> const& connectLock, ClientWorkerInterface const& workerInterf);
 

--- a/fdbclient/include/fdbclient/NativeAPI.actor.h
+++ b/fdbclient/include/fdbclient/NativeAPI.actor.h
@@ -644,7 +644,7 @@ ACTOR Future<Optional<Standalone<VectorRef<KeyRef>>>> splitStorageMetricsWithLoc
     StorageMetrics estimated,
     Optional<int> minSplitBytes);
 
-ACTOR Future<RangeResult> getWorkerInterfaces(Reference<IClusterConnectionRecord> clusterRecord);
+Future<RangeResult> getWorkerInterfaces(Reference<IClusterConnectionRecord> clusterRecord);
 
 namespace NativeAPI {
 Future<std::vector<std::pair<StorageServerInterface, ProcessClass>>> getServerListAndProcessClasses(Transaction* tr);

--- a/fdbclient/include/fdbclient/NativeAPI.actor.h
+++ b/fdbclient/include/fdbclient/NativeAPI.actor.h
@@ -644,6 +644,8 @@ ACTOR Future<Optional<Standalone<VectorRef<KeyRef>>>> splitStorageMetricsWithLoc
     StorageMetrics estimated,
     Optional<int> minSplitBytes);
 
+ACTOR Future<RangeResult> getWorkerInterfaces(Reference<IClusterConnectionRecord> clusterRecord);
+
 namespace NativeAPI {
 Future<std::vector<std::pair<StorageServerInterface, ProcessClass>>> getServerListAndProcessClasses(Transaction* tr);
 }


### PR DESCRIPTION
This PR moves the declaration to a header file and performs a simple coroutine conversion.
