### PR TITLE
More post-coroutine-conversion linting

### DIFF
--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -1494,7 +1494,7 @@ Future<Void> warmRange_impl(Reference<TransactionState> trState, KeyRange keys) 
 				try {
 					tr.setOption(FDBTransactionOptions::LOCK_AWARE);
 					tr.setOption(FDBTransactionOptions::CAUSAL_READ_RISKY);
-					co_await success(tr.getReadVersion());
+					co_await tr.getReadVersion();
 					break;
 				} catch (Error& e) {
 					err = e;
@@ -2064,7 +2064,7 @@ Future<Void> sameVersionDiffValue(Database cx, Reference<WatchParameters> parame
 				cx->setWatchMetadata(metadata);
 
 				metadata->watchFutureSS = watchStorageServerResp(parameters->key, cx);
-				co_await success(metadata->watchPromise.getFuture());
+				co_await metadata->watchPromise.getFuture();
 			}
 
 			co_return;
@@ -6050,7 +6050,7 @@ Future<std::vector<std::pair<UID, StorageWiggleValue>>> readStorageWiggleValues(
 			if (use_system_priority) {
 				tr->setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
 			}
-			co_await store(res, metadataMap.getRange(tr, UID(0, 0), Optional<UID>(), CLIENT_KNOBS->TOO_MANY));
+			res = co_await metadataMap.getRange(tr, UID(0, 0), Optional<UID>(), CLIENT_KNOBS->TOO_MANY);
 			co_await tr->commit();
 			co_return res.results;
 		} catch (Error& e) {

--- a/fdbclient/include/fdbclient/RunTransaction.h
+++ b/fdbclient/include/fdbclient/RunTransaction.h
@@ -129,7 +129,10 @@ auto SystemDB(Reference<DB> db, bool write = false, bool lockAware = false, bool
 // SystemDB with all options true
 template <typename DB>
 auto SystemDBWriteLockedNow(Reference<DB> db) {
-	return makeReference<SystemTransactionGenerator<DB>>(db, true, true, true);
+	constexpr bool write = true;
+	constexpr bool lockAware = true;
+	constexpr bool immediate = true;
+	return makeReference<SystemTransactionGenerator<DB>>(db, write, lockAware, immediate);
 }
 
 #if defined(__GNUC__) && !defined(__clang__)

--- a/fdbrpc/AsyncFileKAIO.h
+++ b/fdbrpc/AsyncFileKAIO.h
@@ -721,7 +721,7 @@ private:
 
 	static Future<Void> poll(Uncancellable, Reference<IEventFD> ev) {
 		while (true) {
-			co_await success(ev->read());
+			co_await ev->read();
 
 			co_await delay(0, TaskPriority::DiskIOComplete);
 

--- a/fdbrpc/FlowTransport.cpp
+++ b/fdbrpc/FlowTransport.cpp
@@ -2258,7 +2258,7 @@ static Future<Void> watchPublicKeyJwksFile(std::string filePath, TransportData* 
 				TraceEvent(SevWarn, "AuthzPublicKeySetEmpty").suppressFor(60);
 				continue;
 			}
-			co_await success(file->read(&json[0], filesize, 0));
+			co_await file->read(&json[0], filesize, 0);
 			self->applyPublicKeySet(StringRef(json));
 			errorCount = 0;
 		} catch (Error& e) {

--- a/fdbrpc/include/fdbrpc/AsyncFileCached.h
+++ b/fdbrpc/include/fdbrpc/AsyncFileCached.h
@@ -340,7 +340,7 @@ private:
 			TraceEvent("AFCUnderlyingOpenEnd").detail("Filename", filename);
 			int64_t l = co_await f->size();
 			TraceEvent("AFCUnderlyingSize").detail("Filename", filename).detail("Size", l);
-			Reference<AsyncFileCached> cachedFile = makeReference<AsyncFileCached>(f, filename, l, pageCache);
+			auto cachedFile = makeReference<AsyncFileCached>(f, filename, l, pageCache);
 			co_return Reference<IAsyncFile>(cachedFile);
 		} catch (Error& e) {
 			if (e.code() != error_code_actor_cancelled)

--- a/fdbserver/core/RocksDBCheckpointUtils.cpp
+++ b/fdbserver/core/RocksDBCheckpointUtils.cpp
@@ -196,7 +196,7 @@ Future<int64_t> doFetchCheckpointFile(Database cx,
 			co_await IAsyncFileSystem::filesystem()->deleteFile(localFile, true);
 			const int64_t flags = IAsyncFile::OPEN_ATOMIC_WRITE_AND_CREATE | IAsyncFile::OPEN_READWRITE |
 			                      IAsyncFile::OPEN_CREATE | IAsyncFile::OPEN_UNCACHED | IAsyncFile::OPEN_NO_AIO;
-			co_await store(asyncFile, IAsyncFileSystem::filesystem()->open(localFile, flags, 0666));
+			asyncFile = co_await IAsyncFileSystem::filesystem()->open(localFile, flags, 0666);
 
 			ReplyPromiseStream<FetchCheckpointReply> stream =
 			    ssi.fetchCheckpoint.getReplyStream(FetchCheckpointRequest(checkpointId, remoteFile));
@@ -257,8 +257,7 @@ Future<Void> fetchCheckpointBytesSampleFile(Database cx,
 	ASSERT(!metaData->src.empty());
 	UID ssId = metaData->src.front();
 
-	co_await success(
-	    doFetchCheckpointFile(cx, metaData->bytesSampleFile.get(), localFile, ssId, metaData->checkpointID));
+	co_await doFetchCheckpointFile(cx, metaData->bytesSampleFile.get(), localFile, ssId, metaData->checkpointID);
 	metaData->bytesSampleFile = localFile;
 	if (cFun) {
 		co_await cFun(*metaData);
@@ -1040,7 +1039,7 @@ Future<Void> fetchCheckpointFile(Database cx,
 	ASSERT_EQ(metaData->src.size(), 1);
 	const UID ssId = metaData->src.front();
 
-	co_await success(doFetchCheckpointFile(cx, remoteFile, localFile, ssId, metaData->checkpointID));
+	co_await doFetchCheckpointFile(cx, remoteFile, localFile, ssId, metaData->checkpointID);
 	rocksCF.sstFiles[idx].db_path = dir;
 	rocksCF.sstFiles[idx].fetched = true;
 	metaData->setSerializedCheckpoint(ObjectWriter::toValue(rocksCF, IncludeVersion()));

--- a/fdbserver/datadistributor/DDRelocationQueue.actor.cpp
+++ b/fdbserver/datadistributor/DDRelocationQueue.actor.cpp
@@ -1599,7 +1599,7 @@ Future<Void> dataDistributionRelocator(DDQueue* self,
 			    brokenPromiseToNever(self->getShardMetrics.getReply(GetMetricsRequest(rd.getParentRange().get())));
 			co_await (store(metrics, metricsF) && store(parentMetrics, parentMetricsF));
 		} else {
-			co_await store(metrics, metricsF);
+			metrics = co_await metricsF;
 		}
 
 		std::unordered_set<uint64_t> excludedDstPhysicalShards;

--- a/fdbserver/kvstore/KeyValueStoreSQLite.cpp
+++ b/fdbserver/kvstore/KeyValueStoreSQLite.cpp
@@ -2325,7 +2325,7 @@ Future<Void> KVFileCheck(std::string filename, bool integrity) {
 	ASSERT(store != nullptr);
 
 	// Wait for integry check to finish
-	co_await success(store->readValue(StringRef()));
+	co_await store->readValue(StringRef());
 
 	if (store->getError().isError())
 		co_await store->getError();

--- a/fdbserver/kvstore/VersionedBTree.actor.cpp
+++ b/fdbserver/kvstore/VersionedBTree.actor.cpp
@@ -8003,7 +8003,7 @@ Future<Void> verifyRangeBTreeCursor(VersionedBTree* btree,
 		             start.printable().c_str(),
 		             end.printable().c_str(),
 		             randomKey.toString().c_str());
-		co_await success(cur.seek(randomKey));
+		co_await cur.seek(randomKey);
 	}
 
 	debug_printf(

--- a/fdbserver/logsystem/LogSystem.cpp
+++ b/fdbserver/logsystem/LogSystem.cpp
@@ -2884,7 +2884,7 @@ Future<Void> LogSystem::epochEnd(Reference<AsyncVar<Reference<LogSystem>>> outLo
 		if (maxEnd > 0 && (!lastEnd.present() || maxEnd < lastEnd.get() || knownLockedTLogIdsChanged)) {
 			CODE_PROBE(lastEnd.present(), "Restarting recovery at an earlier point");
 
-			Reference<LogSystem> logSystem = makeReference<LogSystem>(dbgid, locality, prevState.recoveryCount);
+			auto logSystem = makeReference<LogSystem>(dbgid, locality, prevState.recoveryCount);
 
 			logSystem->recoverAt = minEnd;
 			lastEnd = minEnd;

--- a/fdbserver/resolver/Resolver.cpp
+++ b/fdbserver/resolver/Resolver.cpp
@@ -779,7 +779,7 @@ Future<Void> resolverCore(ResolverInterface resolver,
 		    self->logAdapter, db, resolver.id(), 2e9, DisableSnapshot::True, ReplaceContent::True, ExactRecovery::True);
 
 		// wait for txnStateStore recovery
-		co_await success(self->txnStateStore->readValue(StringRef()));
+		co_await self->txnStateStore->readValue(StringRef());
 
 		// This has to be declared after the self->txnStateStore get initialized
 		transactionStateResolveContext = TransactionStateResolveContext(self, &addActor);

--- a/fdbserver/storageserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver/storageserver.actor.cpp
@@ -4729,10 +4729,10 @@ Future<Void> auditStorageShardReplicaQ(StorageServer* data, AuditStorageRequest 
 							serverListEntries.push_back(tr.get(serverListKeyFor(id)));
 						}
 					}
-					co_await store(serverListValues, getAll(serverListEntries));
+					serverListValues = co_await getAll(serverListEntries);
 
 					// Decide version to compare
-					co_await store(version, tr.getReadVersion());
+					version = co_await tr.getReadVersion();
 
 					// Read remote servers
 					for (const auto& v : serverListValues) {
@@ -5108,7 +5108,7 @@ Future<Void> getRangeDataToDump(StorageServer* data,
 			localReq.limitBytes = SERVER_KNOBS->MOVE_SHARD_KRM_BYTE_LIMIT;
 			localReq.tags = TagSet();
 			data->actors.add(getKeyValuesQ(data, localReq));
-			co_await store(rep, errorOr(localReq.reply.getFuture()));
+			rep = co_await errorOr(localReq.reply.getFuture());
 			if (rep.isError()) {
 				throw rep.getError();
 			}
@@ -5218,7 +5218,7 @@ Future<Void> bulkDumpQ(StorageServer* data, BulkDumpRequest req) {
 
 			// Get version to dump
 			tr.reset();
-			co_await store(versionToDump, tr.getReadVersion());
+			versionToDump = co_await tr.getReadVersion();
 
 			// Read data
 			// TODO(BulkDump): Read data from other servers at the versionToDump as much as possible
@@ -7746,12 +7746,11 @@ Future<Void> fetchShardCheckpoint(StorageServer* data, MoveInShard* moveInShard,
 		{
 			Error err;
 			try {
-				co_await store(records,
-				               getCheckpointMetaData(data->cx,
-				                                     moveInShard->ranges(),
-				                                     moveInShard->meta->createVersion,
-				                                     DataMoveRocksCF,
-				                                     moveInShard->dataMoveId()));
+				records = co_await getCheckpointMetaData(data->cx,
+				                                         moveInShard->ranges(),
+				                                         moveInShard->meta->createVersion,
+				                                         DataMoveRocksCF,
+				                                         moveInShard->dataMoveId());
 				if (moveInShard->failed()) {
 					co_return;
 				}
@@ -7778,7 +7777,7 @@ Future<Void> fetchShardCheckpoint(StorageServer* data, MoveInShard* moveInShard,
 					}
 					fFetchCheckpoint.push_back(fetchCheckpointRanges(data->cx, record, checkpointDir, { range }));
 				}
-				co_await store(localRecords, getAll(fFetchCheckpoint));
+				localRecords = co_await getAll(fFetchCheckpoint);
 				if (moveInShard->failed()) {
 					co_return;
 				}
@@ -8103,9 +8102,8 @@ Future<Void> fetchShard(StorageServer* data, MoveInShard* moveInShard) {
 	bool conductBulkLoad = moveInShard->meta->conductBulkLoad;
 	if (conductBulkLoad) {
 		// Get the bulkload task metadata from the data move metadata. For details, see the comments in the fetchKeys.
-		co_await store(bulkLoadTaskState,
-		               getBulkLoadTaskStateFromDataMove(
-		                   data->cx, moveInShard->dataMoveId(), data->version.get(), data->thisServerID));
+		bulkLoadTaskState = co_await getBulkLoadTaskStateFromDataMove(
+		    data->cx, moveInShard->dataMoveId(), data->version.get(), data->thisServerID);
 	}
 
 	while (true) {
@@ -11578,7 +11576,7 @@ Future<Void> watchValueWaitForVersion(StorageServer* self,
 
 	getCurrentLineage()->modify(&TransactionLineage::txID) = req.spanContext.traceID;
 	try {
-		co_await success(waitForVersionNoTooOld(self, req.version));
+		co_await waitForVersionNoTooOld(self, req.version);
 		stream.send(req);
 	} catch (Error& e) {
 		if (!canReplyWith(e))
@@ -12109,7 +12107,7 @@ Future<Void> memoryStoreRecover(IKeyValueStore* store, Reference<IClusterConnect
 	// create a temp client connect to DB
 	Database cx = Database::createDatabase(connRecord, ApiVersion::LATEST_VERSION);
 
-	Reference<ReadYourWritesTransaction> tr = makeReference<ReadYourWritesTransaction>(cx);
+	auto tr = makeReference<ReadYourWritesTransaction>(cx);
 	int noCanRemoveCount = 0;
 	while (true) {
 		{
@@ -12236,7 +12234,7 @@ ACTOR Future<Void> replaceInterface(StorageServer* self, StorageServerInterface 
 
 Future<Void> replaceTSSInterface(StorageServer* self, StorageServerInterface ssi) {
 	// RYW for KeyBackedMap
-	Reference<ReadYourWritesTransaction> tr = makeReference<ReadYourWritesTransaction>(self->cx);
+	auto tr = makeReference<ReadYourWritesTransaction>(self->cx);
 	KeyBackedMap<UID, UID> tssMapDB = KeyBackedMap<UID, UID>(tssMappingKeys.begin);
 
 	ASSERT(ssi.isTss());


### PR DESCRIPTION
Similar to https://github.com/apple/foundationdb/pull/12951, this PR performs simple linting enabled by coroutine conversions, using AST-grep.
