### PR TITLE
add github actions stale bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,7 +1,7 @@
-name: 'Close stale issues and PRs'
+name: 'Close stale pull requests'
 on:
   schedule:
-    - cron: '20 6 * * *' # 06:20 UTC
+    - cron: '15 20 * * *' # 20:15 UTC
 
 permissions:
   issues: write
@@ -13,14 +13,12 @@ jobs:
     steps:
       - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
         with:
-          stale-issue-message: >
-            This issue is stale because it has been open 350 days with no activity.
-            Remove stale label or add a comment to prevent automatic closure in 14 days.
           stale-pr-message: >
             This PR is stale because it has been open 150 days with no activity.
             Remove stale label or add a comment to prevent automatic closure in 14 days.
-          days-before-issue-stale: 350
-          days-before-issue-close: 14
           days-before-pr-stale: 150
-          days-before-pr-close: 14
+          days-before-close: 14
+          days-before-issue-stale: 5475 # 15 years, basically disabled for issues
+          # throttled to 20 per day
           operations-per-run: 20
+          ascending: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,26 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '20 6 * * *' # 06:20 UTC
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
+        with:
+          stale-issue-message: >
+            This issue is stale because it has been open 350 days with no activity.
+            Remove stale label or add a comment to prevent automatic closure in 14 days.
+          stale-pr-message: >
+            This PR is stale because it has been open 150 days with no activity.
+            Remove stale label or add a comment to prevent automatic closure in 14 days.
+          days-before-issue-stale: 350
+          days-before-issue-close: 14
+          days-before-pr-stale: 150
+          days-before-pr-close: 14
+          operations-per-run: 20


### PR DESCRIPTION
conservatively mark PRs stale after 150 days, and issues after 350 days

--------------

There was discussion of cleanup of the many older PRs which we'll probably never look at. I'm pushing up this PR just to show what this trivial config could look like, I'm not sure if it will work, or if GHA has been disabled for this apple repo.

Consider this up for debate :)