### PR TITLE
build: fix fdbserver_corelinktest for cmake 3.25 on macOS

### DIFF
--- a/fdbserver/core/CMakeLists.txt
+++ b/fdbserver/core/CMakeLists.txt
@@ -9,8 +9,7 @@ endif()
 
 add_flow_target(STATIC_LIBRARY NAME fdbserver_core SRCS ${FDBSERVER_CORE_SRCS})
 add_fdbserver_link_test(fdbserver_corelinktest
-  fdbserver_core
-  fdbserver_logsystem)
+  fdbserver_core)
 
 configure_fdbserver_common_includes(fdbserver_core)
 target_include_directories(fdbserver_core


### PR DESCRIPTION
One of the PR test suites has been failing since this test was updated by 6d39afbb0899 "Remove ILogSystem interface", the CI test "foundationdb-pr-macos-m1 on macOS Ventura 13.x", with:

    CMake Error at cmake/FlowCommands.cmake:319 (add_executable):
      Impossible to link target 'fdbserver_corelinktest' because the link item
      'fdbserver_core', specified without any feature or 'DEFAULT' feature, has
      already occurred with the feature 'WHOLE_ARCHIVE', which is not allowed.
    Call Stack (most recent call first):
      cmake/AddFdbServerLinkTest.cmake:6 (add_flow_target)
      fdbserver/core/CMakeLists.txt:11 (add_fdbserver_link_test)

I think this is because add_fdbserver_link_test() tries to make sure that all members of the static archive can successfully link with only the expected dependency libraries, by doing:

    target_link_libraries(${target_name} PRIVATE "$<LINK_LIBRARY:WHOLE_ARCHIVE,${primary_lib}>" ${link_libs} rapidxml)

but in this case fdbserver_logsystem already has a DEFAULT link to fdbserver_core, so adding WHOLE_ARCHIVE link of fdbserver_core in front of that sort of conflicts. Newer cmake seems to handle this OK, but this can be reproduced with cmake-3.25.2 which the macos-m1 runner has.

------------

Maybe fdbserver_logsystem isn't really needed to link fdbserver_core? Let's see if build/test on all CI platforms are successful without it ... @tclinkenbeard-oai maybe you have some good insight about this change?