### PR TITLE
Improve fdb-kubernetes-monitor setup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -297,6 +297,7 @@ if(NOT WIN32)
   if(NOT FOUNDATIONDB_CROSS_COMPILING) # FIXME(swift): make this work when
                                        # x-compiling.
     add_subdirectory(fdbmonitor)
+    add_subdirectory(fdbkubernetesmonitor)
   endif()
 endif()
 add_subdirectory(fdbbackup)

--- a/fdbkubernetesmonitor/CMakeLists.txt
+++ b/fdbkubernetesmonitor/CMakeLists.txt
@@ -1,0 +1,43 @@
+find_program(FDB_K8S_MONITOR_GO_EXECUTABLE go HINTS /usr/local/go/bin/)
+if(NOT FDB_K8S_MONITOR_GO_EXECUTABLE)
+  message(WARNING "Go not found. The 'fdb-kubernetes-monitor' target will not be available.")
+  return()
+endif()
+
+if(WIN32)
+  return()
+endif()
+
+file(GLOB_RECURSE FDB_K8S_MONITOR_GO_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/*.go")
+set(FDB_K8S_MONITOR_GO_MOD "${CMAKE_CURRENT_SOURCE_DIR}/go.mod")
+set(FDB_K8S_MONITOR_GO_SUM "${CMAKE_CURRENT_SOURCE_DIR}/go.sum")
+
+set(FDB_K8S_MONITOR_BINARY "${CMAKE_BINARY_DIR}/bin/fdb-kubernetes-monitor")
+
+add_custom_command(
+  OUTPUT ${FDB_K8S_MONITOR_BINARY}
+  COMMAND ${FDB_K8S_MONITOR_GO_EXECUTABLE} build -o ${FDB_K8S_MONITOR_BINARY} .
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  DEPENDS ${FDB_K8S_MONITOR_GO_SOURCES} ${FDB_K8S_MONITOR_GO_MOD} ${FDB_K8S_MONITOR_GO_SUM}
+  COMMENT "Building fdb-kubernetes-monitor")
+
+add_custom_target(fdb-kubernetes-monitor ALL
+  DEPENDS ${FDB_K8S_MONITOR_BINARY}
+  SOURCES ${FDB_K8S_MONITOR_GO_SOURCES})
+
+add_test(
+  NAME fdb-kubernetes-monitor-go-tests
+  COMMAND ${FDB_K8S_MONITOR_GO_EXECUTABLE} test -race ./...
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+# gofmt should be installed with go, but it's better to check if the binary is available.
+find_program(FDB_K8S_MONITOR_GOFMT_EXECUTABLE gofmt HINTS /usr/local/go/bin/)
+if(FDB_K8S_MONITOR_GOFMT_EXECUTABLE)
+  add_test(
+    NAME fdb-kubernetes-monitor-go-fmt
+    # gofmt -d doesn't return a non-zero exit code, so we have to check if the output is empty.
+    COMMAND bash -c "out=$(\"${FDB_K8S_MONITOR_GOFMT_EXECUTABLE}\" -d \"${CMAKE_CURRENT_SOURCE_DIR}\"); test -z \"$out\" || { echo \"$out\"; exit 1; }"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+else()
+  message(WARNING "gofmt not found. The 'fdb-kubernetes-monitor-go-fmt' test will not be available.")
+endif()

--- a/fdbkubernetesmonitor/CMakeLists.txt
+++ b/fdbkubernetesmonitor/CMakeLists.txt
@@ -1,5 +1,5 @@
-find_program(FDB_K8S_MONITOR_GO_EXECUTABLE go HINTS /usr/local/go/bin/)
-if(NOT FDB_K8S_MONITOR_GO_EXECUTABLE)
+find_program(GO_EXECUTABLE go HINTS /usr/local/go/bin/)
+if(NOT GO_EXECUTABLE)
   message(WARNING "Go not found. The 'fdb-kubernetes-monitor' target will not be available.")
   return()
 endif()
@@ -16,7 +16,7 @@ set(FDB_K8S_MONITOR_BINARY "${CMAKE_BINARY_DIR}/bin/fdb-kubernetes-monitor")
 
 add_custom_command(
   OUTPUT ${FDB_K8S_MONITOR_BINARY}
-  COMMAND ${FDB_K8S_MONITOR_GO_EXECUTABLE} build -o ${FDB_K8S_MONITOR_BINARY} .
+  COMMAND ${GO_EXECUTABLE} build -o ${FDB_K8S_MONITOR_BINARY} .
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   DEPENDS ${FDB_K8S_MONITOR_GO_SOURCES} ${FDB_K8S_MONITOR_GO_MOD} ${FDB_K8S_MONITOR_GO_SUM}
   COMMENT "Building fdb-kubernetes-monitor")
@@ -27,16 +27,16 @@ add_custom_target(fdb-kubernetes-monitor ALL
 
 add_test(
   NAME fdb-kubernetes-monitor-go-tests
-  COMMAND ${FDB_K8S_MONITOR_GO_EXECUTABLE} test -race ./...
+  COMMAND ${GO_EXECUTABLE} test -race ./...
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 # gofmt should be installed with go, but it's better to check if the binary is available.
-find_program(FDB_K8S_MONITOR_GOFMT_EXECUTABLE gofmt HINTS /usr/local/go/bin/)
-if(FDB_K8S_MONITOR_GOFMT_EXECUTABLE)
+find_program(GOFMT_EXECUTABLE gofmt HINTS /usr/local/go/bin/)
+if(GOFMT_EXECUTABLE)
   add_test(
     NAME fdb-kubernetes-monitor-go-fmt
     # gofmt -d doesn't return a non-zero exit code, so we have to check if the output is empty.
-    COMMAND bash -c "out=$(\"${FDB_K8S_MONITOR_GOFMT_EXECUTABLE}\" -d \"${CMAKE_CURRENT_SOURCE_DIR}\"); test -z \"$out\" || { echo \"$out\"; exit 1; }"
+    COMMAND bash -c "out=$(\"${GOFMT_EXECUTABLE}\" -d \"${CMAKE_CURRENT_SOURCE_DIR}\"); test -z \"$out\" || { echo \"$out\"; exit 1; }"
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 else()
   message(WARNING "gofmt not found. The 'fdb-kubernetes-monitor-go-fmt' test will not be available.")

--- a/fdbkubernetesmonitor/internal/certloader/certloader.go
+++ b/fdbkubernetesmonitor/internal/certloader/certloader.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -11,6 +12,8 @@ import (
 
 // CertLoader is used to reload certificates if needed.
 type CertLoader struct {
+	// mu protects cachedCert and cachedCertModTime from concurrent access.
+	mu sync.RWMutex
 	// CertFile specifies the path to the x509 certificate.
 	CertFile string
 	// CertFile specifies the path to the x509 private key.
@@ -41,16 +44,32 @@ func (certLoader *CertLoader) GetCertificate(_ *tls.ClientHelloInfo) (*tls.Certi
 		return nil, err
 	}
 
-	if certLoader.cachedCert == nil || stat.ModTime().After(certLoader.cachedCertModTime) {
-		certLoader.logger.Info("loading new certificates", "certFile", certLoader.CertFile, "keyFile", certLoader.KeyFile, "cachedModificationTime", certLoader.cachedCertModTime.String(), "currentModificationTime", stat.ModTime().String())
-		pair, err := tls.LoadX509KeyPair(certLoader.CertFile, certLoader.KeyFile)
-		if err != nil {
-			return nil, fmt.Errorf("failed loading tls key pair: %w", err)
-		}
+	// Fast path: return cached cert if it is still current.
+	certLoader.mu.RLock()
+	cached := certLoader.cachedCert
+	modTime := certLoader.cachedCertModTime
+	certLoader.mu.RUnlock()
 
-		certLoader.cachedCert = &pair
-		certLoader.cachedCertModTime = stat.ModTime()
+	if cached != nil && !stat.ModTime().After(modTime) {
+		return cached, nil
 	}
 
+	// Slow path: reload cert under write lock.
+	certLoader.mu.Lock()
+	defer certLoader.mu.Unlock()
+
+	// Re-check after acquiring the write lock; another goroutine may have reloaded already.
+	if certLoader.cachedCert != nil && !stat.ModTime().After(certLoader.cachedCertModTime) {
+		return certLoader.cachedCert, nil
+	}
+
+	certLoader.logger.Info("loading new certificates", "certFile", certLoader.CertFile, "keyFile", certLoader.KeyFile, "cachedModificationTime", certLoader.cachedCertModTime.String(), "currentModificationTime", stat.ModTime().String())
+	pair, err := tls.LoadX509KeyPair(certLoader.CertFile, certLoader.KeyFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed loading tls key pair: %w", err)
+	}
+
+	certLoader.cachedCert = &pair
+	certLoader.cachedCertModTime = stat.ModTime()
 	return certLoader.cachedCert, nil
 }

--- a/fdbkubernetesmonitor/internal/certloader/certloader.go
+++ b/fdbkubernetesmonitor/internal/certloader/certloader.go
@@ -13,7 +13,7 @@ import (
 // CertLoader is used to reload certificates if needed.
 type CertLoader struct {
 	// mu protects cachedCert and cachedCertModTime from concurrent access.
-	mu sync.RWMutex
+	mu sync.Mutex
 	// CertFile specifies the path to the x509 certificate.
 	CertFile string
 	// CertFile specifies the path to the x509 private key.
@@ -44,23 +44,14 @@ func (certLoader *CertLoader) GetCertificate(_ *tls.ClientHelloInfo) (*tls.Certi
 		return nil, err
 	}
 
-	// Fast path: return cached cert if it is still current.
-	certLoader.mu.RLock()
+	// Lock to avoid concurrent access to cachedCert and cachedCertModTime.
+	certLoader.mu.Lock()
+	defer certLoader.mu.Unlock()
 	cached := certLoader.cachedCert
 	modTime := certLoader.cachedCertModTime
-	certLoader.mu.RUnlock()
 
 	if cached != nil && !stat.ModTime().After(modTime) {
 		return cached, nil
-	}
-
-	// Slow path: reload cert under write lock.
-	certLoader.mu.Lock()
-	defer certLoader.mu.Unlock()
-
-	// Re-check after acquiring the write lock; another goroutine may have reloaded already.
-	if certLoader.cachedCert != nil && !stat.ModTime().After(certLoader.cachedCertModTime) {
-		return certLoader.cachedCert, nil
 	}
 
 	certLoader.logger.Info("loading new certificates", "certFile", certLoader.CertFile, "keyFile", certLoader.KeyFile, "cachedModificationTime", certLoader.cachedCertModTime.String(), "currentModificationTime", stat.ModTime().String())

--- a/fdbkubernetesmonitor/kubernetes.go
+++ b/fdbkubernetesmonitor/kubernetes.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"path"
 	"strconv"
+	"sync"
 	"time"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -49,6 +50,10 @@ var _ toolscache.ResourceEventHandler = (*kubernetesClient)(nil)
 
 // kubernetesClient is a wrapper around the Kubernetes API.
 type kubernetesClient struct {
+	// mu protects podMetadata and nodeMetadata from concurrent access by informer
+	// callbacks and the monitor goroutine.
+	mu sync.RWMutex
+
 	// podMetadata is the latest metadata that was seen by the fdb-kubernetes-monitor for the according Pod.
 	podMetadata *metav1.PartialObjectMetadata
 
@@ -193,6 +198,18 @@ func createPodClient(ctx context.Context, logger logr.Logger, enableNodeWatcher 
 	return podClient, nil
 }
 
+func (podClient *kubernetesClient) getPodMetadata() *metav1.PartialObjectMetadata {
+	podClient.mu.RLock()
+	defer podClient.mu.RUnlock()
+	return podClient.podMetadata
+}
+
+func (podClient *kubernetesClient) getNodeMetadata() *metav1.PartialObjectMetadata {
+	podClient.mu.RLock()
+	defer podClient.mu.RUnlock()
+	return podClient.nodeMetadata
+}
+
 // retrieveEnvironmentVariables extracts the environment variables we have for
 // an argument into a map.
 func retrieveEnvironmentVariables(monitor *monitor, argument api.Argument, target map[string]string) {
@@ -239,11 +256,12 @@ func (podClient *kubernetesClient) updateFdbClusterTimestampAnnotation() error {
 // updateAnnotationsOnPod will update the annotations with the provided annotationChanges. If an annotation exists, it
 // will be updated if the annotation is absent it will be added.
 func (podClient *kubernetesClient) updateAnnotationsOnPod(annotationChanges map[string]string) error {
-	if podClient.podMetadata == nil {
+	meta := podClient.getPodMetadata()
+	if meta == nil {
 		return fmt.Errorf("pod client has no metadata present")
 	}
 
-	if !podClient.podMetadata.DeletionTimestamp.IsZero() {
+	if !meta.DeletionTimestamp.IsZero() {
 		return fmt.Errorf("pod is marked for deletion, cannot update annotations")
 	}
 
@@ -251,7 +269,7 @@ func (podClient *kubernetesClient) updateAnnotationsOnPod(annotationChanges map[
 	return retry.OnError(retry.DefaultRetry, func(err error) bool {
 		podClient.Logger.Error(err, "could not update annotations of pod")
 		// If the pod is marked for deletion, we don't have to retry the patch.
-		if !podClient.podMetadata.DeletionTimestamp.IsZero() {
+		if !meta.DeletionTimestamp.IsZero() {
 			return false
 		}
 
@@ -262,7 +280,7 @@ func (podClient *kubernetesClient) updateAnnotationsOnPod(annotationChanges map[
 
 		return true
 	}, func() error {
-		currentAnnotations := podClient.podMetadata.Annotations
+		currentAnnotations := meta.Annotations
 		if len(currentAnnotations) == 0 {
 			currentAnnotations = map[string]string{}
 		}
@@ -288,8 +306,8 @@ func (podClient *kubernetesClient) updateAnnotationsOnPod(annotationChanges map[
 				APIVersion: "v1",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace:   podClient.podMetadata.Namespace,
-				Name:        podClient.podMetadata.Name,
+				Namespace:   meta.Namespace,
+				Name:        meta.Name,
 				Annotations: currentAnnotations,
 			},
 		})
@@ -310,16 +328,20 @@ func (podClient *kubernetesClient) OnAdd(obj interface{}, _ bool) {
 	switch castedObj := obj.(type) {
 	case *corev1.Pod:
 		podClient.Logger.Info("Got event for OnAdd for Pod resource", "name", castedObj.Name, "namespace", castedObj.Namespace)
+		podClient.mu.Lock()
 		podClient.podMetadata = &metav1.PartialObjectMetadata{
 			TypeMeta:   castedObj.TypeMeta,
 			ObjectMeta: castedObj.ObjectMeta,
 		}
+		podClient.mu.Unlock()
 	case *corev1.Node:
 		podClient.Logger.Info("Got event for OnAdd for Node resource", "name", castedObj.Name)
+		podClient.mu.Lock()
 		podClient.nodeMetadata = &metav1.PartialObjectMetadata{
 			TypeMeta:   castedObj.TypeMeta,
 			ObjectMeta: castedObj.ObjectMeta,
 		}
+		podClient.mu.Unlock()
 	}
 }
 
@@ -330,24 +352,30 @@ func (podClient *kubernetesClient) OnUpdate(_, newObj interface{}) {
 	switch castedObj := newObj.(type) {
 	case *corev1.Pod:
 		podClient.Logger.Info("Got event for OnUpdate for Pod resource", "name", castedObj.Name, "namespace", castedObj.Namespace, "generation", castedObj.Generation)
+
+		// Hold the write lock for the read-then-write of podMetadata, but
+		// release it before sending to TimestampFeed to avoid holding the lock
+		// while blocked on a channel send.
+		podClient.mu.Lock()
 		var previousAnnotations map[string]string
 		if podClient.podMetadata != nil {
 			previousAnnotations = podClient.podMetadata.Annotations
 		}
-
 		podClient.podMetadata = &metav1.PartialObjectMetadata{
 			TypeMeta:   castedObj.TypeMeta,
 			ObjectMeta: castedObj.ObjectMeta,
 		}
+		newAnnotations := podClient.podMetadata.Annotations
+		podClient.mu.Unlock()
 
-		if podClient.podMetadata.Annotations == nil {
+		if newAnnotations == nil {
 			return
 		}
 
 		// If the IsolateProcessGroupAnnotation changes force a reload of the configuration to make sure the processes
 		// will be shutdown.
 		previousIsolateProcessGroupAnnotationValue := previousAnnotations[api.IsolateProcessGroupAnnotation]
-		newIsolateProcessGroupAnnotationValue := podClient.podMetadata.Annotations[api.IsolateProcessGroupAnnotation]
+		newIsolateProcessGroupAnnotationValue := newAnnotations[api.IsolateProcessGroupAnnotation]
 		if previousIsolateProcessGroupAnnotationValue != newIsolateProcessGroupAnnotationValue {
 			podClient.Logger.Info("Got change in isolate process group annotation", "previous", previousIsolateProcessGroupAnnotationValue, "new", newIsolateProcessGroupAnnotationValue)
 			podClient.TimestampFeed <- time.Now().Unix()
@@ -355,7 +383,7 @@ func (podClient *kubernetesClient) OnUpdate(_, newObj interface{}) {
 			return
 		}
 
-		annotation := podClient.podMetadata.Annotations[api.OutdatedConfigMapAnnotation]
+		annotation := newAnnotations[api.OutdatedConfigMapAnnotation]
 		if annotation == "" {
 			return
 		}
@@ -369,10 +397,12 @@ func (podClient *kubernetesClient) OnUpdate(_, newObj interface{}) {
 		podClient.TimestampFeed <- timestamp
 	case *corev1.Node:
 		podClient.Logger.Info("Got event for OnUpdate for Node resource", "name", castedObj.Name)
+		podClient.mu.Lock()
 		podClient.nodeMetadata = &metav1.PartialObjectMetadata{
 			TypeMeta:   castedObj.TypeMeta,
 			ObjectMeta: castedObj.ObjectMeta,
 		}
+		podClient.mu.Unlock()
 	}
 }
 
@@ -384,9 +414,13 @@ func (podClient *kubernetesClient) OnDelete(obj interface{}) {
 	switch castedObj := obj.(type) {
 	case *corev1.Pod:
 		podClient.Logger.Info("Got event for OnDelete for Pod resource", "name", castedObj.Name, "namespace", castedObj.Namespace)
+		podClient.mu.Lock()
 		podClient.podMetadata = nil
+		podClient.mu.Unlock()
 	case *corev1.Node:
 		podClient.Logger.Info("Got event for OnDelete for Node resource", "name", castedObj.Name)
+		podClient.mu.Lock()
 		podClient.nodeMetadata = nil
+		podClient.mu.Unlock()
 	}
 }

--- a/fdbkubernetesmonitor/kubernetes.go
+++ b/fdbkubernetesmonitor/kubernetes.go
@@ -26,7 +26,6 @@ import (
 	"os"
 	"path"
 	"strconv"
-	"sync"
 	"time"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -50,16 +49,6 @@ var _ toolscache.ResourceEventHandler = (*kubernetesClient)(nil)
 
 // kubernetesClient is a wrapper around the Kubernetes API.
 type kubernetesClient struct {
-	// mu protects podMetadata and nodeMetadata from concurrent access by informer
-	// callbacks and the monitor goroutine.
-	mu sync.RWMutex
-
-	// podMetadata is the latest metadata that was seen by the fdb-kubernetes-monitor for the according Pod.
-	podMetadata *metav1.PartialObjectMetadata
-
-	// nodeMetadata is the latest metadata that was seen by the fdb-kubernetes-monitor for the according node that hosts the Pod.
-	nodeMetadata *metav1.PartialObjectMetadata
-
 	// TimestampFeed is a channel where the kubernetes client will send updates with
 	// the values from api.OutdatedConfigMapAnnotation. If the api.IsolateProcessGroupAnnotation is changed the current
 	// timestamp will be sent to the channel to force the monitor to change its configuration accordingly.
@@ -70,6 +59,16 @@ type kubernetesClient struct {
 
 	// Adds the controller runtime client to the kubernetesClient.
 	client.Client
+
+	// namespace defines the namespace where the pod that hosts the fdbkubernetesmonitor instance is running in.
+	namespace string
+
+	// podName defines the Pod name where the fdbkubernetesmonitor instance is running in.
+	podName string
+
+	// nodeName defines the node name of the Pod where the fdbkubernetesmonitor instance is running in.
+	// This value is only set if the fdbkubernetesmonitor should watch node events.
+	nodeName string
 }
 
 func setupCache(namespace string, podName string, nodeName string) (client.WithWatch, cache.Cache, error) {
@@ -130,11 +129,15 @@ func createPodClient(ctx context.Context, logger logr.Logger, enableNodeWatcher 
 	}
 
 	podClient := &kubernetesClient{
-		podMetadata:   nil,
-		nodeMetadata:  nil,
+		podName:       podName,
+		namespace:     namespace,
 		TimestampFeed: make(chan int64, 10),
 		Logger:        logger,
 		Client:        internalClient,
+	}
+
+	if enableNodeWatcher {
+		podClient.nodeName = nodeName
 	}
 
 	// Fetch the informer for the Pod resource.
@@ -172,42 +175,36 @@ func createPodClient(ctx context.Context, logger logr.Logger, enableNodeWatcher 
 	// This should be fairly quick as no informers are provided by default.
 	_ = internalCache.WaitForCacheSync(ctx)
 
-	// Fetch the current metadata before returning the kubernetesClient
-	currentPodMetadata := &metav1.PartialObjectMetadata{}
-	currentPodMetadata.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Pod"))
-	err = podClient.Client.Get(ctx, client.ObjectKey{Namespace: namespace, Name: podName}, currentPodMetadata)
+	return podClient, nil
+}
+
+// getPodMetadata returns a copy of the pod metadata.
+func (podClient *kubernetesClient) getPodMetadata(ctx context.Context) (*metav1.PartialObjectMetadata, error) {
+	metadata := &metav1.PartialObjectMetadata{}
+	metadata.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Pod"))
+	err := podClient.Client.Get(ctx, client.ObjectKey{Namespace: podClient.namespace, Name: podClient.podName}, metadata)
 	if err != nil {
 		return nil, err
 	}
 
-	podClient.podMetadata = currentPodMetadata
+	return metadata, nil
+}
 
-	// Only if the fdb-kubernetes-monitor should update the node information, add the watcher here by fetching the node
-	// information once during start up.
-	if enableNodeWatcher {
-		currentNodeMetadata := &metav1.PartialObjectMetadata{}
-		currentNodeMetadata.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Node"))
-		err = podClient.Client.Get(ctx, client.ObjectKey{Name: nodeName}, currentNodeMetadata)
-		if err != nil {
-			return nil, err
-		}
-
-		podClient.nodeMetadata = currentNodeMetadata
+// getNodeMetadata returns a copy of the node metadata.
+func (podClient *kubernetesClient) getNodeMetadata(ctx context.Context) (*metav1.PartialObjectMetadata, error) {
+	// Only if the fdb-kubernetes-monitor is watching node events we should be returning the node metadata.
+	if podClient.nodeName == "" {
+		return nil, nil
 	}
 
-	return podClient, nil
-}
+	metadata := &metav1.PartialObjectMetadata{}
+	metadata.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Node"))
+	err := podClient.Client.Get(ctx, client.ObjectKey{Name: podClient.nodeName}, metadata)
+	if err != nil {
+		return nil, err
+	}
 
-func (podClient *kubernetesClient) getPodMetadata() *metav1.PartialObjectMetadata {
-	podClient.mu.RLock()
-	defer podClient.mu.RUnlock()
-	return podClient.podMetadata
-}
-
-func (podClient *kubernetesClient) getNodeMetadata() *metav1.PartialObjectMetadata {
-	podClient.mu.RLock()
-	defer podClient.mu.RUnlock()
-	return podClient.nodeMetadata
+	return metadata, nil
 }
 
 // retrieveEnvironmentVariables extracts the environment variables we have for
@@ -228,7 +225,7 @@ func retrieveEnvironmentVariables(monitor *monitor, argument api.Argument, targe
 
 // updateAnnotations updates annotations on the pod after loading new
 // configuration.
-func (podClient *kubernetesClient) updateAnnotations(monitor *monitor) error {
+func (podClient *kubernetesClient) updateAnnotations(ctx context.Context, monitor *monitor) error {
 	environment := make(map[string]string)
 	for _, argument := range monitor.activeConfiguration.Arguments {
 		retrieveEnvironmentVariables(monitor, argument, environment)
@@ -239,7 +236,7 @@ func (podClient *kubernetesClient) updateAnnotations(monitor *monitor) error {
 		return err
 	}
 
-	return podClient.updateAnnotationsOnPod(map[string]string{
+	return podClient.updateAnnotationsOnPod(ctx, map[string]string{
 		api.CurrentConfigurationAnnotation: string(monitor.activeConfigurationBytes),
 		api.EnvironmentAnnotation:          string(jsonEnvironment),
 	})
@@ -247,16 +244,20 @@ func (podClient *kubernetesClient) updateAnnotations(monitor *monitor) error {
 
 // updateFdbClusterTimestampAnnotation updates the ClusterFileChangeDetectedAnnotation annotation on the pod
 // after a change to the fdb.cluster file was detected, e.g. because the coordinators were changed.
-func (podClient *kubernetesClient) updateFdbClusterTimestampAnnotation() error {
-	return podClient.updateAnnotationsOnPod(map[string]string{
+func (podClient *kubernetesClient) updateFdbClusterTimestampAnnotation(ctx context.Context) error {
+	return podClient.updateAnnotationsOnPod(ctx, map[string]string{
 		api.ClusterFileChangeDetectedAnnotation: strconv.FormatInt(time.Now().Unix(), 10),
 	})
 }
 
 // updateAnnotationsOnPod will update the annotations with the provided annotationChanges. If an annotation exists, it
 // will be updated if the annotation is absent it will be added.
-func (podClient *kubernetesClient) updateAnnotationsOnPod(annotationChanges map[string]string) error {
-	meta := podClient.getPodMetadata()
+func (podClient *kubernetesClient) updateAnnotationsOnPod(ctx context.Context, annotationChanges map[string]string) error {
+	meta, err := podClient.getPodMetadata(ctx)
+	if err != nil {
+		return err
+	}
+
 	if meta == nil {
 		return fmt.Errorf("pod client has no metadata present")
 	}
@@ -324,58 +325,27 @@ func (podClient *kubernetesClient) updateAnnotationsOnPod(annotationChanges map[
 }
 
 // OnAdd is called when an object is added.
-func (podClient *kubernetesClient) OnAdd(obj interface{}, _ bool) {
-	switch castedObj := obj.(type) {
-	case *corev1.Pod:
-		podClient.Logger.Info("Got event for OnAdd for Pod resource", "name", castedObj.Name, "namespace", castedObj.Namespace)
-		podClient.mu.Lock()
-		podClient.podMetadata = &metav1.PartialObjectMetadata{
-			TypeMeta:   castedObj.TypeMeta,
-			ObjectMeta: castedObj.ObjectMeta,
-		}
-		podClient.mu.Unlock()
-	case *corev1.Node:
-		podClient.Logger.Info("Got event for OnAdd for Node resource", "name", castedObj.Name)
-		podClient.mu.Lock()
-		podClient.nodeMetadata = &metav1.PartialObjectMetadata{
-			TypeMeta:   castedObj.TypeMeta,
-			ObjectMeta: castedObj.ObjectMeta,
-		}
-		podClient.mu.Unlock()
-	}
-}
+func (podClient *kubernetesClient) OnAdd(_ interface{}, _ bool) {}
 
 // OnUpdate is also called when a re-list happens, and it will
 // get called even if nothing changed. This is useful for periodically
 // evaluating or syncing something.
-func (podClient *kubernetesClient) OnUpdate(_, newObj interface{}) {
+func (podClient *kubernetesClient) OnUpdate(prevObj, newObj interface{}) {
 	switch castedObj := newObj.(type) {
 	case *corev1.Pod:
 		podClient.Logger.Info("Got event for OnUpdate for Pod resource", "name", castedObj.Name, "namespace", castedObj.Namespace, "generation", castedObj.Generation)
-
-		// Hold the write lock for the read-then-write of podMetadata, but
-		// release it before sending to TimestampFeed to avoid holding the lock
-		// while blocked on a channel send.
-		podClient.mu.Lock()
-		var previousAnnotations map[string]string
-		if podClient.podMetadata != nil {
-			previousAnnotations = podClient.podMetadata.Annotations
-		}
-		podClient.podMetadata = &metav1.PartialObjectMetadata{
-			TypeMeta:   castedObj.TypeMeta,
-			ObjectMeta: castedObj.ObjectMeta,
-		}
-		newAnnotations := podClient.podMetadata.Annotations
-		podClient.mu.Unlock()
-
-		if newAnnotations == nil {
-			return
+		// If the IsolateProcessGroupAnnotation changes, force a reload of the configuration to make sure the processes
+		// will be shutdown or started.
+		var previousIsolateProcessGroupAnnotationValue string
+		prevPod, ok := prevObj.(*corev1.Pod)
+		if ok && prevPod != nil {
+			previousAnnotations := prevPod.Annotations
+			if previousAnnotations != nil {
+				previousIsolateProcessGroupAnnotationValue = previousAnnotations[api.IsolateProcessGroupAnnotation]
+			}
 		}
 
-		// If the IsolateProcessGroupAnnotation changes force a reload of the configuration to make sure the processes
-		// will be shutdown.
-		previousIsolateProcessGroupAnnotationValue := previousAnnotations[api.IsolateProcessGroupAnnotation]
-		newIsolateProcessGroupAnnotationValue := newAnnotations[api.IsolateProcessGroupAnnotation]
+		newIsolateProcessGroupAnnotationValue := castedObj.Annotations[api.IsolateProcessGroupAnnotation]
 		if previousIsolateProcessGroupAnnotationValue != newIsolateProcessGroupAnnotationValue {
 			podClient.Logger.Info("Got change in isolate process group annotation", "previous", previousIsolateProcessGroupAnnotationValue, "new", newIsolateProcessGroupAnnotationValue)
 			podClient.TimestampFeed <- time.Now().Unix()
@@ -383,7 +353,7 @@ func (podClient *kubernetesClient) OnUpdate(_, newObj interface{}) {
 			return
 		}
 
-		annotation := newAnnotations[api.OutdatedConfigMapAnnotation]
+		annotation := castedObj.Annotations[api.OutdatedConfigMapAnnotation]
 		if annotation == "" {
 			return
 		}
@@ -395,14 +365,6 @@ func (podClient *kubernetesClient) OnUpdate(_, newObj interface{}) {
 		}
 
 		podClient.TimestampFeed <- timestamp
-	case *corev1.Node:
-		podClient.Logger.Info("Got event for OnUpdate for Node resource", "name", castedObj.Name)
-		podClient.mu.Lock()
-		podClient.nodeMetadata = &metav1.PartialObjectMetadata{
-			TypeMeta:   castedObj.TypeMeta,
-			ObjectMeta: castedObj.ObjectMeta,
-		}
-		podClient.mu.Unlock()
 	}
 }
 
@@ -410,17 +372,4 @@ func (podClient *kubernetesClient) OnUpdate(_, newObj interface{}) {
 // it will get an object of type DeletedFinalStateUnknown. This can
 // happen if the watch is closed and misses the delete event and we don't
 // notice the deletion until the subsequent re-list.
-func (podClient *kubernetesClient) OnDelete(obj interface{}) {
-	switch castedObj := obj.(type) {
-	case *corev1.Pod:
-		podClient.Logger.Info("Got event for OnDelete for Pod resource", "name", castedObj.Name, "namespace", castedObj.Namespace)
-		podClient.mu.Lock()
-		podClient.podMetadata = nil
-		podClient.mu.Unlock()
-	case *corev1.Node:
-		podClient.Logger.Info("Got event for OnDelete for Node resource", "name", castedObj.Name)
-		podClient.mu.Lock()
-		podClient.nodeMetadata = nil
-		podClient.mu.Unlock()
-	}
-}
+func (podClient *kubernetesClient) OnDelete(_ interface{}) {}

--- a/fdbkubernetesmonitor/kubernetes_test.go
+++ b/fdbkubernetesmonitor/kubernetes_test.go
@@ -96,8 +96,12 @@ var _ = Describe("Testing FDB Pod client", func() {
 			})
 
 			It("should have the metadata for the pod but not the node", func() {
-				Expect(podClient.podMetadata).NotTo(BeNil())
-				Expect(podClient.nodeMetadata).To(BeNil())
+				podMetadata, err := podClient.getPodMetadata(context.Background())
+				Expect(podMetadata).NotTo(BeNil())
+				Expect(err).NotTo(HaveOccurred())
+				nodeMetadata, err := podClient.getNodeMetadata(context.Background())
+				Expect(nodeMetadata).To(BeNil())
+				Expect(err).NotTo(HaveOccurred())
 				Expect(internalCache.InformersByGVK).To(HaveLen(1))
 			})
 		})
@@ -108,8 +112,12 @@ var _ = Describe("Testing FDB Pod client", func() {
 			})
 
 			It("should have the metadata for the pod and node", func() {
-				Expect(podClient.podMetadata).NotTo(BeNil())
-				Expect(podClient.nodeMetadata).NotTo(BeNil())
+				podMetadata, err := podClient.getPodMetadata(context.Background())
+				Expect(podMetadata).NotTo(BeNil())
+				Expect(err).NotTo(HaveOccurred())
+				nodeMetadata, err := podClient.getNodeMetadata(context.Background())
+				Expect(nodeMetadata).NotTo(BeNil())
+				Expect(err).NotTo(HaveOccurred())
 				Expect(internalCache.InformersByGVK).To(HaveLen(2))
 			})
 		})
@@ -148,38 +156,6 @@ var _ = Describe("Testing FDB Pod client", func() {
 				Expect(err).NotTo(HaveOccurred())
 			})
 
-			When("an AddEvent is handled", func() {
-				BeforeEach(func() {
-					fakeInformer.Add(pod)
-				})
-
-				It("should update the pod information", func() {
-					Expect(podClient.podMetadata).NotTo(BeNil())
-					Expect(podClient.podMetadata.Name).To(Equal(podName))
-					Expect(podClient.podMetadata.Namespace).To(Equal(namespace))
-					Expect(podClient.podMetadata.Labels).To(Equal(map[string]string{
-						"testing": "testing",
-					}))
-				})
-			})
-
-			When("an UpdateEvent is handled", func() {
-				BeforeEach(func() {
-					fakeInformer.Update(nil, pod)
-				})
-
-				It("should update the pod information", func() {
-					Expect(podClient.podMetadata).NotTo(BeNil())
-					Expect(podClient.podMetadata.Name).To(Equal(podName))
-					Expect(podClient.podMetadata.Namespace).To(Equal(namespace))
-					Expect(podClient.podMetadata.Labels).To(Equal(map[string]string{
-						"testing": "testing",
-					}))
-
-					Expect(podClient.TimestampFeed).NotTo(Receive())
-				})
-			})
-
 			When("an UpdateEvent is handled that updates the OutdatedConfigMapAnnotation", func() {
 				var timestamp int64
 
@@ -192,13 +168,6 @@ var _ = Describe("Testing FDB Pod client", func() {
 				})
 
 				It("should update the pod information and receive an event", func() {
-					Expect(podClient.podMetadata).NotTo(BeNil())
-					Expect(podClient.podMetadata.Name).To(Equal(podName))
-					Expect(podClient.podMetadata.Namespace).To(Equal(namespace))
-					Expect(podClient.podMetadata.Labels).To(Equal(map[string]string{
-						"testing": "testing",
-					}))
-
 					Expect(podClient.TimestampFeed).To(Receive(&timestamp))
 				})
 			})
@@ -212,84 +181,36 @@ var _ = Describe("Testing FDB Pod client", func() {
 				})
 
 				It("should update the Pod information", func() {
-					Expect(podClient.podMetadata).NotTo(BeNil())
-					Expect(podClient.podMetadata.Name).To(Equal(podName))
-					Expect(podClient.podMetadata.Namespace).To(Equal(namespace))
-					Expect(podClient.podMetadata.Labels).To(Equal(map[string]string{
-						"testing": "testing",
-					}))
-
 					Expect(podClient.TimestampFeed).NotTo(Receive())
 				})
 			})
 
-			When("a DeleteEvent is handled", func() {
+			When("an UpdateEvent is handled that updates the IsolateProcessGroupAnnotation where the value is changed", func() {
 				BeforeEach(func() {
-					fakeInformer.Delete(pod)
+					oldPod := pod.DeepCopy()
+					pod.Annotations = map[string]string{
+						api.IsolateProcessGroupAnnotation: "true",
+					}
+
+					fakeInformer.Update(oldPod, pod)
 				})
 
-				It("should remove the pod information", func() {
-					Expect(podClient.podMetadata).To(BeNil())
-				})
-			})
-		})
-
-		When("events for the node are received", func() {
-			var fakeInformer *controllertest.FakeInformer
-			var node *corev1.Node
-
-			BeforeEach(func() {
-				node = &corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      podName,
-						Namespace: namespace,
-						Labels: map[string]string{
-							"testing": "testing",
-						},
-					},
-				}
-				var err error
-				fakeInformer, err = internalCache.FakeInformerFor(context.Background(), node)
-				Expect(err).NotTo(HaveOccurred())
-			})
-
-			When("an AddEvent is handled", func() {
-				BeforeEach(func() {
-					fakeInformer.Add(node)
-				})
-
-				It("should update the node information", func() {
-					Expect(podClient.nodeMetadata).NotTo(BeNil())
-					Expect(podClient.nodeMetadata.Name).To(Equal(podName))
-					Expect(podClient.nodeMetadata.Namespace).To(Equal(namespace))
-					Expect(podClient.nodeMetadata.Labels).To(Equal(map[string]string{
-						"testing": "testing",
-					}))
+				It("should update the Pod information", func() {
+					Expect(podClient.TimestampFeed).To(Receive())
 				})
 			})
 
-			When("an UpdateEvent is handled", func() {
+			When("an UpdateEvent is handled that updates the IsolateProcessGroupAnnotation where the value is not changed", func() {
 				BeforeEach(func() {
-					fakeInformer.Update(nil, node)
+					pod.Annotations = map[string]string{
+						api.IsolateProcessGroupAnnotation: "true",
+					}
+
+					fakeInformer.Update(pod.DeepCopy(), pod)
 				})
 
-				It("should update the node information", func() {
-					Expect(podClient.nodeMetadata).NotTo(BeNil())
-					Expect(podClient.nodeMetadata.Name).To(Equal(podName))
-					Expect(podClient.nodeMetadata.Namespace).To(Equal(namespace))
-					Expect(podClient.nodeMetadata.Labels).To(Equal(map[string]string{
-						"testing": "testing",
-					}))
-				})
-			})
-
-			When("a DeleteEvent is handled", func() {
-				BeforeEach(func() {
-					fakeInformer.Delete(node)
-				})
-
-				It("should remove the node information", func() {
-					Expect(podClient.nodeMetadata).To(BeNil())
+				It("should update the Pod information", func() {
+					Expect(podClient.TimestampFeed).NotTo(Receive())
 				})
 			})
 		})
@@ -310,7 +231,7 @@ var _ = Describe("Testing FDB Pod client", func() {
 
 			Expect(err).NotTo(HaveOccurred())
 			// Execute the update annotations.
-			Expect(podClient.updateAnnotations(mon)).NotTo(HaveOccurred())
+			Expect(podClient.updateAnnotations(context.Background(), mon)).NotTo(HaveOccurred())
 		})
 
 		When("no additional env variables are set", func() {

--- a/fdbkubernetesmonitor/main.go
+++ b/fdbkubernetesmonitor/main.go
@@ -174,7 +174,11 @@ func main() {
 			logger.Error(err, "Error parsing container version", "currentContainerVersion", currentContainerVersion)
 			os.Exit(1)
 		}
-		startMonitor(context.Background(), logger, path.Join(inputDir, monitorConfFile), customEnvironment, processCount, promConfig, enablePprof, parsedVersion, enableNodeWatch)
+
+		ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+		defer stop()
+
+		startMonitor(ctx, logger, path.Join(inputDir, monitorConfFile), customEnvironment, processCount, promConfig, enablePprof, parsedVersion, enableNodeWatch)
 	case executionModeInit:
 		err = copyFiles(logger, outputDir, copyDetails, requiredCopies)
 		if err != nil {

--- a/fdbkubernetesmonitor/monitor.go
+++ b/fdbkubernetesmonitor/monitor.go
@@ -164,6 +164,7 @@ func startMonitor(ctx context.Context, logger logr.Logger, configFile string, cu
 			certLoader := certloader.NewCertLoader(logger, promConfig.certPath, promConfig.keyPath)
 			tlsConfig := &tls.Config{
 				GetCertificate: certLoader.GetCertificate,
+				MinVersion:     tls.VersionTLS12,
 			}
 			server := &http.Server{
 				Addr:      promConfig.listenAddr,
@@ -340,7 +341,7 @@ func (monitor *monitor) acceptConfiguration(configuration *api.ProcessConfigurat
 
 	// If the monitor has running processes but the processes shouldn't be running, kill them with SIGTERM.
 	if hasRunningProcesses && !monitor.activeConfiguration.ShouldRunServers() {
-		monitor.sendSignalToProcesses(syscall.SIGTERM)
+		monitor.signalProcesses(syscall.SIGTERM, monitor.processIDs)
 	}
 }
 
@@ -375,10 +376,18 @@ func (monitor *monitor) runProcess(processNumber int) {
 			errorCounter = 0
 		}
 
-		arguments, err := monitor.activeConfiguration.GenerateArguments(processNumber, monitor.customEnvironment)
+		monitor.mutex.Lock()
+		config := monitor.activeConfiguration
+		customEnv := make(map[string]string, len(monitor.customEnvironment))
+		for k, v := range monitor.customEnvironment {
+			customEnv[k] = v
+		}
+		monitor.mutex.Unlock()
+
+		arguments, err := config.GenerateArguments(processNumber, customEnv)
 		if err != nil {
 			backoffDuration := getBackoffDuration(errorCounter)
-			logger.Error(err, "Error generating arguments for subprocess", "configuration", monitor.activeConfiguration, "errorCounter", errorCounter, "backoffDuration", backoffDuration.String())
+			logger.Error(err, "Error generating arguments for subprocess", "configuration", config, "errorCounter", errorCounter, "backoffDuration", backoffDuration.String())
 			time.Sleep(backoffDuration)
 			errorCounter++
 			continue
@@ -410,7 +419,7 @@ func (monitor *monitor) runProcess(processNumber int) {
 		}
 
 		// Update the prometheus metrics for the process.
-		monitor.metrics.registerProcessStartup(processNumber, monitor.activeConfiguration.Version.String())
+		monitor.metrics.registerProcessStartup(processNumber, config.Version.String())
 
 		if cmd.Process != nil {
 			pid = cmd.Process.Pid
@@ -587,8 +596,11 @@ func (monitor *monitor) handleFileChange(changedFile string) {
 	monitor.loadConfiguration()
 }
 
-func (monitor *monitor) sendSignalToProcesses(signal os.Signal) {
-	for processNumber, processID := range monitor.processIDs {
+// signalProcesses sends the given signal to all processes in the provided slice.
+// Callers that already hold monitor.mutex should pass monitor.processIDs directly.
+// Callers that do not hold the mutex should snapshot processIDs under the mutex first.
+func (monitor *monitor) signalProcesses(signal os.Signal, processIDs []int) {
+	for processNumber, processID := range processIDs {
 		if processID <= 0 {
 			continue
 		}
@@ -618,9 +630,14 @@ func (monitor *monitor) run() {
 		latestSignal := <-signals
 		monitor.logger.Info("Received system signal", "signal", latestSignal)
 
-		// Reset the processCount to 0 to make sure the monitor doesn't try to restart the processes.
+		// Reset processCount and snapshot processIDs under the mutex, then signal
+		// outside the lock to avoid holding it during OS calls.
+		monitor.mutex.Lock()
 		monitor.processCount = 0
-		monitor.sendSignalToProcesses(latestSignal)
+		ids := make([]int, len(monitor.processIDs))
+		copy(ids, monitor.processIDs)
+		monitor.mutex.Unlock()
+		monitor.signalProcesses(latestSignal, ids)
 
 		if podMeta := monitor.podClient.getPodMetadata(); podMeta != nil {
 			if delayValue, ok := podMeta.Annotations[api.DelayShutdownAnnotation]; ok {

--- a/fdbkubernetesmonitor/monitor.go
+++ b/fdbkubernetesmonitor/monitor.go
@@ -191,11 +191,12 @@ func startMonitor(ctx context.Context, logger logr.Logger, configFile string, cu
 // label "foundationdb.org/testing = awesome" the env variables NODE_LABEL_FOUNDATIONDB_ORG_TESTING = awesome" will be
 // generated.
 func (monitor *monitor) updateCustomEnvironmentFromNodeMetadata() {
-	if monitor.podClient.nodeMetadata == nil {
+	nodeMeta := monitor.podClient.getNodeMetadata()
+	if nodeMeta == nil {
 		return
 	}
 
-	nodeLabels := monitor.podClient.nodeMetadata.Labels
+	nodeLabels := nodeMeta.Labels
 	for key, value := range nodeLabels {
 		sanitizedKey := strings.ReplaceAll(key, "/", "_")
 		sanitizedKey = strings.ReplaceAll(sanitizedKey, ".", "_")
@@ -486,15 +487,16 @@ func (monitor *monitor) processRequired(processNumber int) bool {
 
 // processIsIsolated returns true if the IsolateProcessGroupAnnotation is set to "true".
 func (monitor *monitor) processIsIsolated() bool {
-	if monitor.podClient.podMetadata == nil {
+	podMeta := monitor.podClient.getPodMetadata()
+	if podMeta == nil {
 		return false
 	}
 
-	if monitor.podClient.podMetadata.Annotations == nil {
+	if podMeta.Annotations == nil {
 		return false
 	}
 
-	val, ok := monitor.podClient.podMetadata.Annotations[api.IsolateProcessGroupAnnotation]
+	val, ok := podMeta.Annotations[api.IsolateProcessGroupAnnotation]
 	if !ok {
 		return false
 	}
@@ -527,7 +529,7 @@ func addWatcher(fileName string, watcher *fsnotify.Watcher) error {
 	var err error
 	for retryCnt < maxRetryCnt {
 		err = watcher.Add(fileName)
-		if err != nil {
+		if err == nil {
 			return nil
 		}
 
@@ -620,12 +622,9 @@ func (monitor *monitor) run() {
 		monitor.processCount = 0
 		monitor.sendSignalToProcesses(latestSignal)
 
-		annotations := monitor.podClient.podMetadata.Annotations
-		if len(annotations) > 0 {
-			delayValue, ok := annotations[api.DelayShutdownAnnotation]
-			if ok {
-				delay, err := time.ParseDuration(delayValue)
-				if err == nil {
+		if podMeta := monitor.podClient.getPodMetadata(); podMeta != nil {
+			if delayValue, ok := podMeta.Annotations[api.DelayShutdownAnnotation]; ok {
+				if delay, err := time.ParseDuration(delayValue); err == nil {
 					time.Sleep(delay)
 				}
 			}

--- a/fdbkubernetesmonitor/monitor.go
+++ b/fdbkubernetesmonitor/monitor.go
@@ -32,7 +32,6 @@ import (
 	"net/http/pprof"
 	"os"
 	"os/exec"
-	"os/signal"
 	"path"
 	"strconv"
 	"strings"
@@ -132,7 +131,7 @@ func startMonitor(ctx context.Context, logger logr.Logger, configFile string, cu
 		currentContainerVersion: currentContainerVersion,
 	}
 
-	go func() { mon.watchPodTimestamps() }()
+	go func() { mon.watchPodTimestamps(ctx) }()
 
 	mux := http.NewServeMux()
 	// Enable pprof endpoints for debugging purposes.
@@ -184,17 +183,21 @@ func startMonitor(ctx context.Context, logger logr.Logger, configFile string, cu
 		}
 	}()
 
-	mon.run()
+	mon.run(ctx)
 }
 
 // updateCustomEnvironment will add the node labels and their values to the custom environment map. All the generated
 // environment variables will start with NODE_LABEL and "/" and "." will be replaced in the key as "_", e.g. from the
 // label "foundationdb.org/testing = awesome" the env variables NODE_LABEL_FOUNDATIONDB_ORG_TESTING = awesome" will be
 // generated.
-func (monitor *monitor) updateCustomEnvironmentFromNodeMetadata() {
-	nodeMeta := monitor.podClient.getNodeMetadata()
+func (monitor *monitor) updateCustomEnvironmentFromNodeMetadata(ctx context.Context) error {
+	nodeMeta, err := monitor.podClient.getNodeMetadata(ctx)
+	if err != nil {
+		return err
+	}
+
 	if nodeMeta == nil {
-		return
+		return nil
 	}
 
 	nodeLabels := nodeMeta.Labels
@@ -217,10 +220,12 @@ func (monitor *monitor) updateCustomEnvironmentFromNodeMetadata() {
 		monitor.customEnvironment[envKey] = value
 		continue
 	}
+
+	return nil
 }
 
 // readConfiguration reads the latest configuration from the monitor file.
-func (monitor *monitor) readConfiguration() (*api.ProcessConfiguration, []byte) {
+func (monitor *monitor) readConfiguration(ctx context.Context) (*api.ProcessConfiguration, []byte) {
 	file, err := os.Open(monitor.configFile)
 	if err != nil {
 		monitor.logger.Error(err, "Error reading monitor config file", "monitorConfigPath", monitor.configFile)
@@ -262,7 +267,11 @@ func (monitor *monitor) readConfiguration() (*api.ProcessConfiguration, []byte) 
 		return nil, nil
 	}
 
-	monitor.updateCustomEnvironmentFromNodeMetadata()
+	err = monitor.updateCustomEnvironmentFromNodeMetadata(ctx)
+	if err != nil {
+		monitor.logger.Error(err, "Error updating custom environment from node metadata", "configuration", configuration, "binaryPath", configuration.BinaryPath)
+		return nil, nil
+	}
 	_, err = configuration.GenerateArguments(1, monitor.customEnvironment)
 	if err != nil {
 		monitor.logger.Error(err, "Error generating arguments for latest configuration", "configuration", configuration, "binaryPath", configuration.BinaryPath)
@@ -272,7 +281,7 @@ func (monitor *monitor) readConfiguration() (*api.ProcessConfiguration, []byte) 
 	if configuration.ShouldRunServers() {
 		// In case that the process is isolated we don't want to start the servers and we should terminate the running fdbserver
 		// instances.
-		if monitor.processIsIsolated() {
+		if monitor.processIsIsolated(ctx) {
 			configuration.RunServers = pointer.Bool(false)
 		}
 	}
@@ -281,8 +290,8 @@ func (monitor *monitor) readConfiguration() (*api.ProcessConfiguration, []byte) 
 }
 
 // loadConfiguration loads the latest configuration from the config file.
-func (monitor *monitor) loadConfiguration() {
-	configuration, configurationBytes := monitor.readConfiguration()
+func (monitor *monitor) loadConfiguration(ctx context.Context) {
+	configuration, configurationBytes := monitor.readConfiguration(ctx)
 	if configuration == nil || len(configurationBytes) == 0 {
 		return
 	}
@@ -290,7 +299,7 @@ func (monitor *monitor) loadConfiguration() {
 	monitor.acceptConfiguration(configuration, configurationBytes)
 	// Always update the annotations if needed to handle cases where the fdb-kubernetes-monitor
 	// has loaded the new configuration but was not able to update the annotations.
-	err := monitor.podClient.updateAnnotations(monitor)
+	err := monitor.podClient.updateAnnotations(ctx, monitor)
 	if err != nil {
 		monitor.logger.Error(err, "Error updating pod annotations")
 	}
@@ -495,8 +504,12 @@ func (monitor *monitor) processRequired(processNumber int) bool {
 }
 
 // processIsIsolated returns true if the IsolateProcessGroupAnnotation is set to "true".
-func (monitor *monitor) processIsIsolated() bool {
-	podMeta := monitor.podClient.getPodMetadata()
+func (monitor *monitor) processIsIsolated(ctx context.Context) bool {
+	podMeta, err := monitor.podClient.getPodMetadata(ctx)
+	if err != nil {
+		return false
+	}
+
 	if podMeta == nil {
 		return false
 	}
@@ -556,7 +569,7 @@ func addWatcher(fileName string, watcher *fsnotify.Watcher) error {
 }
 
 // watchConfiguration detects changes to the monitor configuration file.
-func (monitor *monitor) watchConfiguration(watcher *fsnotify.Watcher) {
+func (monitor *monitor) watchConfiguration(ctx context.Context, watcher *fsnotify.Watcher) {
 	for {
 		select {
 		case event, ok := <-watcher.Events:
@@ -566,34 +579,37 @@ func (monitor *monitor) watchConfiguration(watcher *fsnotify.Watcher) {
 
 			monitor.logger.Info("Detected event on monitor conf file or cluster file", "event", event)
 			if event.Op&fsnotify.Write == fsnotify.Write || event.Op&fsnotify.Create == fsnotify.Create {
-				monitor.handleFileChange(event.Name)
+				monitor.handleFileChange(ctx, event.Name)
 			} else if event.Op&fsnotify.Remove == fsnotify.Remove {
 				err := addWatcher(event.Name, watcher)
 				if err != nil {
 					panic(err)
 				}
-				monitor.handleFileChange(event.Name)
+				monitor.handleFileChange(ctx, event.Name)
 			}
 		case err, ok := <-watcher.Errors:
 			if !ok {
 				return
 			}
 			monitor.logger.Error(err, "Error watching for file system events")
+		// Stop watching if the context is shutdown.
+		case <-ctx.Done():
+			return
 		}
 	}
 }
 
 // handleFileChange will perform the required action based on the changed/modified file.
-func (monitor *monitor) handleFileChange(changedFile string) {
+func (monitor *monitor) handleFileChange(ctx context.Context, changedFile string) {
 	if changedFile == fdbClusterFilePath {
-		err := monitor.podClient.updateFdbClusterTimestampAnnotation()
+		err := monitor.podClient.updateFdbClusterTimestampAnnotation(ctx)
 		if err != nil {
 			monitor.logger.Error(err, fmt.Sprintf("could not update %s annotation", api.ClusterFileChangeDetectedAnnotation))
 		}
 		return
 	}
 
-	monitor.loadConfiguration()
+	monitor.loadConfiguration(ctx)
 }
 
 // signalProcesses sends the given signal to all processes in the provided slice.
@@ -621,14 +637,27 @@ func (monitor *monitor) signalProcesses(signal os.Signal, processIDs []int) {
 }
 
 // run runs the monitor loop.
-func (monitor *monitor) run() {
+func (monitor *monitor) run(ctx context.Context) {
 	done := make(chan bool, 1)
-	signals := make(chan os.Signal, 1)
-	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
 
 	go func() {
-		latestSignal := <-signals
-		monitor.logger.Info("Received system signal", "signal", latestSignal)
+		<-ctx.Done()
+		monitor.logger.Info("Received system signal")
+
+		var delayShutdown time.Duration
+		// We cannot use ctx here as the context as cancelled.
+		podMeta, err := monitor.podClient.getPodMetadata(context.Background())
+		if err != nil {
+			monitor.logger.Error(err, "Could not read pod metadata for delayed shutdown")
+		}
+
+		if podMeta != nil {
+			if delayValue, ok := podMeta.Annotations[api.DelayShutdownAnnotation]; ok {
+				if delay, err := time.ParseDuration(delayValue); err == nil {
+					delayShutdown = delay
+				}
+			}
+		}
 
 		// Reset processCount and snapshot processIDs under the mutex, then signal
 		// outside the lock to avoid holding it during OS calls.
@@ -637,20 +666,14 @@ func (monitor *monitor) run() {
 		ids := make([]int, len(monitor.processIDs))
 		copy(ids, monitor.processIDs)
 		monitor.mutex.Unlock()
-		monitor.signalProcesses(latestSignal, ids)
+		monitor.signalProcesses(syscall.SIGTERM, ids)
 
-		if podMeta := monitor.podClient.getPodMetadata(); podMeta != nil {
-			if delayValue, ok := podMeta.Annotations[api.DelayShutdownAnnotation]; ok {
-				if delay, err := time.ParseDuration(delayValue); err == nil {
-					time.Sleep(delay)
-				}
-			}
-		}
+		time.Sleep(delayShutdown)
 
 		done <- true
 	}()
 
-	monitor.loadConfiguration()
+	monitor.loadConfiguration(ctx)
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		panic(err)
@@ -662,12 +685,12 @@ func (monitor *monitor) run() {
 	}
 
 	defer func(watcher *fsnotify.Watcher) {
-		err := watcher.Close()
+		err = watcher.Close()
 		if err != nil {
 			monitor.logger.Error(err, "could not close watcher")
 		}
 	}(watcher)
-	go func() { monitor.watchConfiguration(watcher) }()
+	go func() { monitor.watchConfiguration(ctx, watcher) }()
 
 	// The cluster file will be created and managed by the fdbserver processes, so we have to wait until the fdbserver
 	// processes have been started. Except for the initial cluster creation this file should be present as soon as the
@@ -692,10 +715,18 @@ func (monitor *monitor) run() {
 }
 
 // watchPodTimestamps watches the timestamp feed to reload the configuration.
-func (monitor *monitor) watchPodTimestamps() {
-	for timestamp := range monitor.podClient.TimestampFeed {
-		if timestamp > monitor.lastConfigurationTime.Unix() {
-			monitor.loadConfiguration()
+func (monitor *monitor) watchPodTimestamps(ctx context.Context) {
+	for {
+		select {
+		case timestamp, ok := <-monitor.podClient.TimestampFeed:
+			if !ok {
+				return
+			}
+			if timestamp > monitor.lastConfigurationTime.Unix() {
+				monitor.loadConfiguration(ctx)
+			}
+		case <-ctx.Done():
+			return
 		}
 	}
 }

--- a/fdbkubernetesmonitor/monitor_test.go
+++ b/fdbkubernetesmonitor/monitor_test.go
@@ -2,7 +2,7 @@
 //
 // This source file is part of the FoundationDB open source project
 //
-// Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+// Copyright 2021-2026 Apple Inc. and the FoundationDB project authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,12 +20,15 @@
 package main
 
 import (
+	"context"
 	"os"
 	"path"
 	"time"
 
 	"github.com/apple/foundationdb/fdbkubernetesmonitor/api"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/json"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -47,7 +50,7 @@ var _ = Describe("Testing FDB Kubernetes monitor", func() {
 		})
 
 		JustBeforeEach(func() {
-			mon.updateCustomEnvironmentFromNodeMetadata()
+			Expect(mon.updateCustomEnvironmentFromNodeMetadata(context.Background())).To(Succeed())
 		})
 
 		When("no node metadata is present", func() {
@@ -59,15 +62,17 @@ var _ = Describe("Testing FDB Kubernetes monitor", func() {
 
 		When("node metadata is present", func() {
 			BeforeEach(func() {
-				mon.podClient.nodeMetadata = &metav1.PartialObjectMetadata{
+				mon.podClient.nodeName = "test-node"
+				mon.podClient.Client = fake.NewFakeClient(&corev1.Node{
 					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-node",
 						Labels: map[string]string{
 							// Examples are taken from: https://kubernetes.io/docs/reference/labels-annotations-taints/
 							"topology.kubernetes.io/zone": "us-east-1c",
 							"kubernetes.io/hostname":      "ip-172-20-114-199.ec2.internal",
 						},
 					},
-				}
+				})
 			})
 
 			It("should add the new entries", func() {
@@ -118,16 +123,25 @@ var _ = Describe("Testing FDB Kubernetes monitor", func() {
 			Expect(os.WriteFile(fdbserverPath, []byte(""), 0700)).NotTo(HaveOccurred())
 			configurationFilePath = path.Join(tmpDir, "config.json")
 			mon = &monitor{
-				logger:                  GinkgoLogr,
-				configFile:              configurationFilePath,
-				customEnvironment:       map[string]string{},
-				podClient:               &kubernetesClient{},
+				logger:            GinkgoLogr,
+				configFile:        configurationFilePath,
+				customEnvironment: map[string]string{},
+				podClient: &kubernetesClient{
+					podName:   "test-pod",
+					namespace: "test",
+					Client: fake.NewFakeClient(&corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-pod",
+							Namespace: "test",
+						},
+					}),
+				},
 				currentContainerVersion: defaultVersion,
 			}
 		})
 
 		JustBeforeEach(func() {
-			configuration, configurationBytes = mon.readConfiguration()
+			configuration, configurationBytes = mon.readConfiguration(context.Background())
 		})
 
 		When("the configuration file is empty", func() {
@@ -166,15 +180,15 @@ var _ = Describe("Testing FDB Kubernetes monitor", func() {
 
 			When("the pod has the isolate annotation set to true", func() {
 				BeforeEach(func() {
-					mon.podClient = &kubernetesClient{
-						podMetadata: &metav1.PartialObjectMetadata{
-							ObjectMeta: metav1.ObjectMeta{
-								Annotations: map[string]string{
-									api.IsolateProcessGroupAnnotation: "true",
-								},
+					Expect(mon.podClient.Client.Update(context.Background(), &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-pod",
+							Namespace: "test",
+							Annotations: map[string]string{
+								api.IsolateProcessGroupAnnotation: "true",
 							},
 						},
-					}
+					})).To(Succeed())
 				})
 
 				It("should return the configuration with runServers set to false", func() {


### PR DESCRIPTION
Improve fdb-kubernetes-monitor setup, which fixes possible race conditions, which were reported by AI, and adds the fdb-kubernetes-monitor setup to the CMake setup, so that the tests and `go fmt` are running for each PR. Before the tests were not used by CI. I think the `go fmt` test should be added to the go bindings too, but I would open a new PR for this.

I ran the test setup with a malformed go file and it reported the issue correctly with a test failure:

```diff
diff /root/src/foundationdb/fdbkubernetesmonitor/main.go.orig /root/src/foundationdb/fdbkubernetesmonitor/main.go
--- /root/src/foundationdb/fdbkubernetesmonitor/main.go.orig
+++ /root/src/foundationdb/fdbkubernetesmonitor/main.go
@@ -41,7 +41,7 @@
 )

 var (
-				fdbserverPath        string
+	fdbserverPath        string
 	versionFilePath      string
 	sharedBinaryDir      string
 	monitorConfFile      string
```

and the test results:

```text
97% tests passed, 2 tests failed out of 59

Total Test time (real) = 248.50 sec

The following tests FAILED:
	  3 - gcs_client_test (Failed) <<< Should be unrelated to this PR
	 12 - fdb-kubernetes-monitor-go-fmt (Failed)
Errors while running CTest
```