### PR TITLE
Remove outdated `CMAKE_CURRENT_BINARY_DIR` references from `CMakeLists.txt` files

### DIFF
--- a/bindings/flow/CMakeLists.txt
+++ b/bindings/flow/CMakeLists.txt
@@ -21,10 +21,8 @@ target_link_libraries(fdb_flow PUBLIC fdb_c)
 target_link_libraries(fdb_flow PUBLIC fdbclient)
 target_include_directories(fdb_flow PUBLIC
   "${CMAKE_SOURCE_DIR}"
-  "${CMAKE_CURRENT_BINARY_DIR}"
   "${CMAKE_CURRENT_SOURCE_DIR}"
   "${CMAKE_CURRENT_SOURCE_DIR}/tester"
-  "${CMAKE_CURRENT_BINARY_DIR}/tester"
   )
 
 add_subdirectory(tester)

--- a/fdbbackup/CMakeLists.txt
+++ b/fdbbackup/CMakeLists.txt
@@ -3,20 +3,20 @@ set(FDBBACKUP_SRCS
 	backup.cpp)
 
 add_flow_target(EXECUTABLE NAME fdbbackup SRCS ${FDBBACKUP_SRCS})
-target_include_directories(fdbbackup PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/include" "${CMAKE_CURRENT_BINARY_DIR}/include")
+target_include_directories(fdbbackup PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/include")
 target_link_libraries(fdbbackup PRIVATE fdbclient)
 
 set(FDBCONVERT_SRCS
 	FileConverter.cpp)
 add_flow_target(EXECUTABLE NAME fdbconvert SRCS ${FDBCONVERT_SRCS})
-target_include_directories(fdbconvert PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/include" "${CMAKE_CURRENT_BINARY_DIR}/include")
+target_include_directories(fdbconvert PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/include")
 target_link_libraries(fdbconvert PRIVATE fdbclient)
 
 set(FDBDECODE_SRCS
 	Decode.cpp
 	FileDecoder.cpp)
 add_flow_target(EXECUTABLE NAME fdbdecode SRCS ${FDBDECODE_SRCS})
-target_include_directories(fdbdecode PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/include" "${CMAKE_CURRENT_BINARY_DIR}/include")
+target_include_directories(fdbdecode PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/include")
 target_link_libraries(fdbdecode PRIVATE fdbclient)
 
 if(NOT OPEN_FOR_IDE)
@@ -45,7 +45,7 @@ if(NOT OPEN_FOR_IDE)
 
   # Test version of backup.cpp without main() function
   add_flow_target(EXECUTABLE NAME backup_tests SRCS backup.cpp)
-  target_include_directories(backup_tests PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/include" "${CMAKE_CURRENT_BINARY_DIR}/include")
+  target_include_directories(backup_tests PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/include")
   target_link_libraries(backup_tests PRIVATE fdbclient)
   target_compile_definitions(backup_tests PRIVATE EXCLUDE_MAIN_FUNCTION=1)
   add_test(NAME BackupTests COMMAND backup_tests)

--- a/fdbclient/CMakeLists.txt
+++ b/fdbclient/CMakeLists.txt
@@ -97,8 +97,7 @@ target_include_directories(fdbclient
     "${CMAKE_CURRENT_SOURCE_DIR}/include"
     "${CMAKE_CURRENT_BINARY_DIR}/include"
   PRIVATE
-    "${CMAKE_CURRENT_SOURCE_DIR}"
-    "${CMAKE_CURRENT_BINARY_DIR}")
+    "${CMAKE_CURRENT_SOURCE_DIR}")
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/versions.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/include/fdbclient/versions.h)
 add_dependencies(fdbclient fdboptions)
 target_link_libraries(fdbclient PUBLIC fdbrpc msgpack PRIVATE rapidxml)
@@ -106,7 +105,6 @@ target_link_libraries(fdbclient PUBLIC fdbrpc msgpack PRIVATE rapidxml)
 add_flow_target(EXECUTABLE NAME s3client SRCS S3Client_cli.cpp)
 target_include_directories(s3client PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}/include"
-    "${CMAKE_CURRENT_BINARY_DIR}/include"
     "${CMAKE_SOURCE_DIR}/flow/include"
     "${CMAKE_BINARY_DIR}/flow/include"
     "${CMAKE_SOURCE_DIR}/fdbrpc/include"
@@ -190,8 +188,7 @@ target_include_directories(fdbclient_sampling
     "${CMAKE_CURRENT_SOURCE_DIR}/include"
     "${CMAKE_CURRENT_BINARY_DIR}/include"
   PRIVATE
-    "${CMAKE_CURRENT_SOURCE_DIR}"
-    "${CMAKE_CURRENT_BINARY_DIR}")
+    "${CMAKE_CURRENT_SOURCE_DIR}")
 add_dependencies(fdbclient_sampling fdboptions)
 target_link_libraries(fdbclient_sampling PUBLIC fdbrpc_sampling msgpack PRIVATE rapidxml)
 target_compile_definitions(fdbclient_sampling PRIVATE -DENABLE_SAMPLING)

--- a/fdbclient/bench/CMakeLists.txt
+++ b/fdbclient/bench/CMakeLists.txt
@@ -7,7 +7,6 @@ fdb_setup_googlebenchmark()
 
 target_include_directories(
   fdbclient_bench
-  PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}"
-          "${CMAKE_CURRENT_BINARY_DIR}")
+  PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
 
 target_link_libraries(fdbclient_bench PRIVATE Threads::Threads fdb_google_benchmark fdbclient)

--- a/fdbctl/CMakeLists.txt
+++ b/fdbctl/CMakeLists.txt
@@ -2,7 +2,7 @@ fdb_find_sources(FDBCTL_SRCS)
 
 add_flow_target(STATIC_LIBRARY NAME fdbctl
   SRCS ${FDBCTL_SRCS})
-target_include_directories(fdbctl PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" "${CMAKE_CURRENT_BINARY_DIR}/include")
+target_include_directories(fdbctl PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
 target_link_libraries(fdbctl PRIVATE fdbclient)
 
 if (WITH_GRPC)

--- a/fdbrpc/CMakeLists.txt
+++ b/fdbrpc/CMakeLists.txt
@@ -67,7 +67,6 @@ target_include_directories(fdbrpc
     "${CMAKE_CURRENT_BINARY_DIR}/include"
   PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}"
-    "${CMAKE_CURRENT_BINARY_DIR}"
     "${CMAKE_CURRENT_SOURCE_DIR}/libeio")
 target_link_libraries(fdbrpc PUBLIC flow libb64 md5 PRIVATE rapidjson)
 
@@ -91,7 +90,6 @@ target_include_directories(fdbrpc_sampling
     "${CMAKE_CURRENT_BINARY_DIR}/include"
   PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}"
-    "${CMAKE_CURRENT_BINARY_DIR}"
     "${CMAKE_CURRENT_SOURCE_DIR}/libeio")
 target_link_libraries(fdbrpc_sampling PUBLIC flow_sampling libb64 md5 PRIVATE rapidjson)
 

--- a/fdbrpc/bench/CMakeLists.txt
+++ b/fdbrpc/bench/CMakeLists.txt
@@ -8,9 +8,7 @@ fdb_setup_googlebenchmark()
 target_include_directories(
   fdbrpc_bench
   PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}"
-          "${CMAKE_CURRENT_BINARY_DIR}"
           "${CMAKE_CURRENT_SOURCE_DIR}/.."
-          "${CMAKE_CURRENT_SOURCE_DIR}/include"
-          "${CMAKE_CURRENT_BINARY_DIR}/include")
+          "${CMAKE_CURRENT_SOURCE_DIR}/include")
 
 target_link_libraries(fdbrpc_bench PRIVATE Threads::Threads fdb_google_benchmark flow fdbrpc)

--- a/fdbserver/backupworker/CMakeLists.txt
+++ b/fdbserver/backupworker/CMakeLists.txt
@@ -10,8 +10,6 @@ configure_fdbserver_common_includes(fdbserver_backupworker)
 target_include_directories(fdbserver_backupworker
   PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/include
-    ${CMAKE_CURRENT_BINARY_DIR}/include
   PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_CURRENT_BINARY_DIR})
+    ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(fdbserver_backupworker PRIVATE fdbserver_core fdbserver_logsystem)

--- a/fdbserver/clustercontroller/CMakeLists.txt
+++ b/fdbserver/clustercontroller/CMakeLists.txt
@@ -11,7 +11,6 @@ configure_fdbserver_common_includes(fdbserver_clustercontroller)
 target_include_directories(fdbserver_clustercontroller
   PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/include
-    ${CMAKE_CURRENT_BINARY_DIR}/include
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_BINARY_DIR}

--- a/fdbserver/commitproxy/CMakeLists.txt
+++ b/fdbserver/commitproxy/CMakeLists.txt
@@ -10,10 +10,8 @@ add_fdbserver_link_test(fdbserver_commitproxylinktest
 configure_fdbserver_common_includes(fdbserver_commitproxy)
 target_include_directories(fdbserver_commitproxy
   PUBLIC
-    ${CMAKE_CURRENT_SOURCE_DIR}/include
-    ${CMAKE_CURRENT_BINARY_DIR}/include)
+    ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_include_directories(fdbserver_commitproxy
   PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_CURRENT_BINARY_DIR})
+    ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(fdbserver_commitproxy PRIVATE fdbserver_core fdbserver_kvstore fdbserver_logsystem)

--- a/fdbserver/consistencyscan/CMakeLists.txt
+++ b/fdbserver/consistencyscan/CMakeLists.txt
@@ -8,6 +8,5 @@ add_fdbserver_link_test(fdbserver_consistencyscanlinktest
 configure_fdbserver_common_includes(fdbserver_consistencyscan)
 target_include_directories(fdbserver_consistencyscan
   PUBLIC
-    ${CMAKE_CURRENT_SOURCE_DIR}/include
-    ${CMAKE_CURRENT_BINARY_DIR}/include)
+    ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_link_libraries(fdbserver_consistencyscan PRIVATE fdbserver_core)

--- a/fdbserver/coordinator/CMakeLists.txt
+++ b/fdbserver/coordinator/CMakeLists.txt
@@ -10,8 +10,6 @@ configure_fdbserver_common_includes(fdbserver_coordinator)
 target_include_directories(fdbserver_coordinator
   PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/include
-    ${CMAKE_CURRENT_BINARY_DIR}/include
   PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_CURRENT_BINARY_DIR})
+    ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(fdbserver_coordinator PRIVATE fdbserver_core)

--- a/fdbserver/datadistributor/CMakeLists.txt
+++ b/fdbserver/datadistributor/CMakeLists.txt
@@ -9,8 +9,6 @@ configure_fdbserver_common_includes(fdbserver_datadistributor)
 target_include_directories(fdbserver_datadistributor
   PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/include
-    ${CMAKE_CURRENT_BINARY_DIR}/include
   PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_CURRENT_BINARY_DIR})
+    ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(fdbserver_datadistributor PRIVATE fdbserver_core)

--- a/fdbserver/grvproxy/CMakeLists.txt
+++ b/fdbserver/grvproxy/CMakeLists.txt
@@ -10,8 +10,6 @@ configure_fdbserver_common_includes(fdbserver_grvproxy)
 target_include_directories(fdbserver_grvproxy
   PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/include
-    ${CMAKE_CURRENT_BINARY_DIR}/include
   PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_CURRENT_BINARY_DIR})
+    ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(fdbserver_grvproxy PRIVATE fdbserver_core fdbserver_logsystem)

--- a/fdbserver/logsystem/CMakeLists.txt
+++ b/fdbserver/logsystem/CMakeLists.txt
@@ -9,8 +9,6 @@ configure_fdbserver_common_includes(fdbserver_logsystem)
 target_include_directories(fdbserver_logsystem
   PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/include
-    ${CMAKE_CURRENT_BINARY_DIR}/include
   PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_CURRENT_BINARY_DIR})
+    ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(fdbserver_logsystem PUBLIC fdbserver_core)

--- a/fdbserver/mocks3/CMakeLists.txt
+++ b/fdbserver/mocks3/CMakeLists.txt
@@ -5,8 +5,7 @@ add_flow_target(STATIC_LIBRARY NAME fdbserver_mocks3 SRCS ${FDBSERVER_MOCKS3_SRC
 configure_fdbserver_common_includes(fdbserver_mocks3)
 target_include_directories(fdbserver_mocks3
   PUBLIC
-    ${CMAKE_CURRENT_SOURCE_DIR}/include
-    ${CMAKE_CURRENT_BINARY_DIR}/include)
+    ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_include_directories(fdbserver_mocks3 PRIVATE
   ${CMAKE_SOURCE_DIR}/contrib/rapidjson)
 target_link_libraries(fdbserver_mocks3 PRIVATE fdbclient)

--- a/fdbserver/ratekeeper/CMakeLists.txt
+++ b/fdbserver/ratekeeper/CMakeLists.txt
@@ -9,8 +9,6 @@ configure_fdbserver_common_includes(fdbserver_ratekeeper)
 target_include_directories(fdbserver_ratekeeper
   PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/include
-    ${CMAKE_CURRENT_BINARY_DIR}/include
   PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_CURRENT_BINARY_DIR})
+    ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(fdbserver_ratekeeper PRIVATE fdbserver_core)

--- a/fdbserver/resolver/CMakeLists.txt
+++ b/fdbserver/resolver/CMakeLists.txt
@@ -11,8 +11,6 @@ configure_fdbserver_common_includes(fdbserver_resolver)
 target_include_directories(fdbserver_resolver
   PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/include
-    ${CMAKE_CURRENT_BINARY_DIR}/include
   PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_CURRENT_BINARY_DIR})
+    ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(fdbserver_resolver PRIVATE fdbserver_core fdbserver_logsystem)

--- a/fdbserver/sequencer/CMakeLists.txt
+++ b/fdbserver/sequencer/CMakeLists.txt
@@ -9,8 +9,6 @@ configure_fdbserver_common_includes(fdbserver_sequencer)
 target_include_directories(fdbserver_sequencer
   PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/include
-    ${CMAKE_CURRENT_BINARY_DIR}/include
   PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_CURRENT_BINARY_DIR})
+    ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(fdbserver_sequencer PRIVATE fdbserver_core)

--- a/fdbserver/storageserver/CMakeLists.txt
+++ b/fdbserver/storageserver/CMakeLists.txt
@@ -13,6 +13,5 @@ target_include_directories(fdbserver_storageserver
     ${CMAKE_CURRENT_SOURCE_DIR}/include
     ${CMAKE_CURRENT_BINARY_DIR}/include
   PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_CURRENT_BINARY_DIR})
+    ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(fdbserver_storageserver PRIVATE fdbserver_core fdbserver_kvstore fdbserver_logsystem)

--- a/fdbserver/tester/CMakeLists.txt
+++ b/fdbserver/tester/CMakeLists.txt
@@ -8,8 +8,7 @@ add_fdbserver_link_test(fdbserver_testerlinktest
 configure_fdbserver_common_includes(fdbserver_tester)
 target_include_directories(fdbserver_tester
   PUBLIC
-    ${CMAKE_CURRENT_SOURCE_DIR}/include
-    ${CMAKE_CURRENT_BINARY_DIR}/include)
+    ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_link_libraries(fdbserver_tester PRIVATE fdbclient fdbserver_core toml11_target)
 
 # Ensure toml11 external project is built before this target if needed

--- a/fdbserver/tlog/CMakeLists.txt
+++ b/fdbserver/tlog/CMakeLists.txt
@@ -13,6 +13,5 @@ target_include_directories(fdbserver_tlog
     ${CMAKE_CURRENT_SOURCE_DIR}/include
     ${CMAKE_CURRENT_BINARY_DIR}/include
   PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_CURRENT_BINARY_DIR})
+    ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(fdbserver_tlog PRIVATE fdbserver_core fdbserver_kvstore fdbserver_logsystem)

--- a/fdbserver/worker/CMakeLists.txt
+++ b/fdbserver/worker/CMakeLists.txt
@@ -26,7 +26,6 @@ configure_fdbserver_common_includes(fdbserver_worker)
 target_include_directories(fdbserver_worker
   PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/include
-    ${CMAKE_CURRENT_BINARY_DIR}/include
   PRIVATE
     ${CMAKE_SOURCE_DIR}/fdbserver/include
     ${CMAKE_BINARY_DIR}/fdbserver/include

--- a/fdbserver/workloads/CMakeLists.txt
+++ b/fdbserver/workloads/CMakeLists.txt
@@ -4,8 +4,7 @@ add_flow_target(STATIC_LIBRARY NAME fdbserver_workloads SRCS ${FDBSERVER_WORKLOA
 
 configure_fdbserver_common_includes(fdbserver_workloads)
 target_include_directories(fdbserver_workloads PRIVATE
-  ${CMAKE_CURRENT_SOURCE_DIR}
-  ${CMAKE_CURRENT_BINARY_DIR})
+  ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(fdbserver_workloads PRIVATE
   fdbserver_consistencyscan
   fdbserver_core

--- a/flow/CMakeLists.txt
+++ b/flow/CMakeLists.txt
@@ -129,8 +129,7 @@ foreach(ft flow flow_sampling flowlinktest)
     PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include"
            "${CMAKE_CURRENT_BINARY_DIR}/include"
            "${CMAKE_SOURCE_DIR}/contrib/libb64/include"
-    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}"
-            "${CMAKE_CURRENT_BINARY_DIR}")
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
 
   if(FLOW_USE_ZSTD)
     target_include_directories(${ft} PRIVATE SYSTEM ${ZSTD_LIB_INCLUDE_DIR})

--- a/flow/bench/CMakeLists.txt
+++ b/flow/bench/CMakeLists.txt
@@ -8,11 +8,8 @@ fdb_setup_googlebenchmark()
 target_include_directories(
   flow_bench
   PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}"
-          "${CMAKE_CURRENT_BINARY_DIR}"
           "${CMAKE_CURRENT_SOURCE_DIR}/.."
-          "${CMAKE_CURRENT_BINARY_DIR}/.."
-          "${CMAKE_CURRENT_SOURCE_DIR}/include"
-          "${CMAKE_CURRENT_BINARY_DIR}/include")
+          "${CMAKE_CURRENT_SOURCE_DIR}/include")
 
 if(FLOW_USE_ZSTD)
   target_include_directories(flow_bench PRIVATE ${ZSTD_LIB_INCLUDE_DIR})


### PR DESCRIPTION
These parts of `target_include_directories` calls were only necessary when generated actor files were included. With the coroutine conversion, many of these actor header files are now regular header files, so we can clean up `CMakeLists.txt` files.