### PR TITLE
Finish `MonitorLeader.actor.cpp` coroutine conversion

### DIFF
--- a/design/AI-generated/subsystem_03_client_library.md
+++ b/design/AI-generated/subsystem_03_client_library.md
@@ -283,6 +283,6 @@ Management API exposed as key-value operations:
 | `fdbclient/include/fdbclient/DatabaseContext.h` | DatabaseContext: location cache, proxy tracking, watches |
 | [`fdbclient/include/fdbclient/CommitTransaction.h`](https://github.com/apple/foundationdb/blob/main/fdbclient/include/fdbclient/CommitTransaction.h) | MutationRef, CommitTransactionRef |
 | [`fdbclient/MultiVersionTransaction.cpp`](https://github.com/apple/foundationdb/blob/main/fdbclient/MultiVersionTransaction.cpp) | Multi-version client, DLTransaction |
-| `fdbclient/MonitorLeader.actor.cpp` | Cluster discovery, leader tracking |
+| `fdbclient/MonitorLeader.cpp` | Cluster discovery, leader tracking |
 | [`fdbclient/include/fdbclient/SystemData.h`](https://github.com/apple/foundationdb/blob/main/fdbclient/include/fdbclient/SystemData.h) | System key range definitions |
 | `fdbclient/ProxyLoadBalance.h` | Proxy load balancing templates |

--- a/fdbclient/MonitorLeader.cpp
+++ b/fdbclient/MonitorLeader.cpp
@@ -1,5 +1,5 @@
 /*
- * MonitorLeader.actor.cpp
+ * MonitorLeader.cpp
  *
  * This source file is part of the FoundationDB open source project
  *
@@ -28,7 +28,6 @@
 #include "flow/Platform.h"
 #include "flow/IConnection.h"
 #include "flow/CoroUtils.h"
-#include "flow/actorcompiler.h" // has to be last include
 
 namespace {
 
@@ -127,7 +126,7 @@ ClusterConnectionString::ClusterConnectionString(const std::string& connectionSt
 }
 
 TEST_CASE("/fdbclient/MonitorLeader/parseConnectionString/addresses") {
-	state std::string input;
+	std::string input;
 
 	{
 		input = "asdf:2345@1.1.1.1:345";
@@ -187,7 +186,7 @@ TEST_CASE("/fdbclient/MonitorLeader/parseConnectionString/addresses") {
 }
 
 TEST_CASE("/fdbclient/MonitorLeader/parseConnectionString/hostnames") {
-	state std::string input;
+	std::string input;
 
 	{
 		input = "asdf:2345@localhost:1234";
@@ -296,16 +295,14 @@ TEST_CASE("/fdbclient/MonitorLeader/PartialResolve") {
 	std::string connectionString = "TestCluster:0@host.name:1234,host-name:5678";
 	std::string hn = "host-name", port = "5678";
 
-	state NetworkAddress address = NetworkAddress::parse("1.0.0.0:5678");
+	NetworkAddress address = NetworkAddress::parse("1.0.0.0:5678");
 
 	INetworkConnections::net()->addMockTCPEndpoint(hn, port, { address });
 
 	ClusterConnectionString cs(connectionString);
-	std::vector<NetworkAddress> allCoordinators = wait(cs.tryResolveHostnames());
+	std::vector<NetworkAddress> allCoordinators = co_await cs.tryResolveHostnames();
 	ASSERT(allCoordinators.size() == 1 &&
 	       std::find(allCoordinators.begin(), allCoordinators.end(), address) != allCoordinators.end());
-
-	return Void();
 }
 
 TEST_CASE("/flow/FlatBuffers/LeaderInfo") {
@@ -644,23 +641,23 @@ Future<Void> monitorLeaderInternal(Reference<IClusterConnectionRecord> connRecor
 	}
 }
 
-ACTOR Future<Void> asyncDeserializeClusterInterface(Reference<AsyncVar<Value>> serializedInfo,
-                                                    Reference<AsyncVar<Optional<ClusterInterface>>> outKnownLeader) {
-	state Reference<AsyncVar<Optional<ClusterControllerClientInterface>>> knownLeader(
+Future<Void> asyncDeserializeClusterInterface(Reference<AsyncVar<Value>> serializedInfo,
+                                             Reference<AsyncVar<Optional<ClusterInterface>>> outKnownLeader) {
+	Reference<AsyncVar<Optional<ClusterControllerClientInterface>>> knownLeader(
 	    new AsyncVar<Optional<ClusterControllerClientInterface>>{});
-	state Future<Void> deserializer = asyncDeserialize(serializedInfo, knownLeader);
-	loop {
-		choose {
-			when(wait(deserializer)) {
-				UNSTOPPABLE_ASSERT(false);
+	Future<Void> deserializer = asyncDeserialize(serializedInfo, knownLeader);
+	while (true) {
+		auto res = co_await race(deserializer, knownLeader->onChange());
+		if (res.index() == 0) {
+			UNSTOPPABLE_ASSERT(false);
+		} else if (res.index() == 1) {
+			if (knownLeader->get().present()) {
+				outKnownLeader->set(knownLeader->get().get().clientInterface);
+			} else {
+				outKnownLeader->set(Optional<ClusterInterface>{});
 			}
-			when(wait(knownLeader->onChange())) {
-				if (knownLeader->get().present()) {
-					outKnownLeader->set(knownLeader->get().get().clientInterface);
-				} else {
-					outKnownLeader->set(Optional<ClusterInterface>{});
-				}
-			}
+		} else {
+			UNREACHABLE();
 		}
 	}
 }

--- a/fdbclient/MonitorLeader.cpp
+++ b/fdbclient/MonitorLeader.cpp
@@ -642,7 +642,7 @@ Future<Void> monitorLeaderInternal(Reference<IClusterConnectionRecord> connRecor
 }
 
 Future<Void> asyncDeserializeClusterInterface(Reference<AsyncVar<Value>> serializedInfo,
-                                             Reference<AsyncVar<Optional<ClusterInterface>>> outKnownLeader) {
+                                              Reference<AsyncVar<Optional<ClusterInterface>>> outKnownLeader) {
 	Reference<AsyncVar<Optional<ClusterControllerClientInterface>>> knownLeader(
 	    new AsyncVar<Optional<ClusterControllerClientInterface>>{});
 	Future<Void> deserializer = asyncDeserialize(serializedInfo, knownLeader);

--- a/fdbclient/include/fdbclient/MonitorLeader.h
+++ b/fdbclient/include/fdbclient/MonitorLeader.h
@@ -109,8 +109,8 @@ struct LeaderDeserializer {
 	}
 };
 
-Future<Void> asyncDeserializeClusterInterface(const Reference<AsyncVar<Value>>& serializedInfo,
-                                              const Reference<AsyncVar<Optional<ClusterInterface>>>& outKnownLeader);
+Future<Void> asyncDeserializeClusterInterface(Reference<AsyncVar<Value>> serializedInfo,
+                                              Reference<AsyncVar<Optional<ClusterInterface>>> outKnownLeader);
 
 template <>
 struct LeaderDeserializer<ClusterInterface> {


### PR DESCRIPTION
This PR converts `asyncDeserializeClusterInterface` to a standard coroutine using the actor rewrite tool, allowing `MonitorLeader.actor.cpp` to be renamed. Validated with 10k Joshua tests