### PR TITLE
bindings/python: asyncio wrapper scaffold (#208)

### DIFF
--- a/bindings/python/ASYNCIO_DESIGN.md
+++ b/bindings/python/ASYNCIO_DESIGN.md
@@ -1,0 +1,80 @@
+# asyncio integration: design and trade-offs
+
+This document describes the asyncio surface added in `fdb/asyncio_impl.py`,
+explains why it is a wrapper rather than a native integration, and sketches
+the remaining work for fully native asyncio support.
+
+## What landed
+
+* `fdb/asyncio_impl.py` exposes `AsyncDatabase`, `AsyncTransaction`,
+  `open_async`, and `wrap_database`.
+* `AsyncTransaction.get`, `commit`, `on_error`, etc. are coroutines that
+  resolve the underlying `fdb.impl.Future` by submitting `Future.wait()` to
+  the running event loop's default thread executor via
+  `loop.run_in_executor`.
+* `AsyncDatabase.transactional_async` mirrors the retry loop of
+  `fdb.transactional`, but driven by `await` and `Transaction.on_error`.
+* `tests/asyncio_test.py` is a smoke test that exercises a round-trip
+  `set` / `get` and a multi-write transactional block. It requires a
+  running FoundationDB cluster.
+
+## Why this is a wrapper and not native asyncio
+
+The C client already runs an internal network thread that fires callbacks
+when a future is ready (`fdb_future_set_callback`). The existing Python
+binding turns that callback into either a thread-blocking `wait()` or, for
+the legacy `event_model="asyncio"` path, a monkey-patched
+`asyncio.futures._FUTURE_CLASSES` entry. The `_FUTURE_CLASSES` approach
+broke when CPython removed that internal in 3.5+, which is the bug tracked
+in #208.
+
+A correct shim has to satisfy two constraints simultaneously:
+
+1. The event loop must remain non-blocking. Calling `Future.wait()` on the
+   coroutine's thread blocks the loop and defeats the point of asyncio.
+2. The result delivery must run on the loop's thread, because user-visible
+   coroutines and any downstream `await` machinery expect that.
+
+The simplest construction that satisfies both is to off-load `Future.wait()`
+to a thread executor: the FDB network thread fires the callback that
+unblocks `wait()`, the executor thread returns, and `run_in_executor` posts
+the result back to the loop. This is what `fdb.asyncio_impl` does. The
+trade-off is one extra thread hop per future, which is fine for typical
+mixed I/O workloads but is not zero-cost.
+
+## What a native integration would look like
+
+A native integration would attach the FDB callback directly to the event
+loop without the intervening executor thread:
+
+1. Implement `Future.__await__` such that it suspends the current task,
+   registers `loop.call_soon_threadsafe(_resolve, value)` as the FDB
+   callback, and resumes when `_resolve` runs on the loop thread.
+2. Provide an `asyncio.Future`-compatible adapter (`_asyncio_future_blocking`
+   etc.) so that `await fdb_future` interoperates with `asyncio.gather`,
+   `asyncio.wait`, and timeout helpers without falling back to the
+   executor.
+3. Replace the legacy `_FUTURE_CLASSES` monkey-patch in `impl.py` with the
+   adapter above. Drop trollius and the Python 2 fallbacks.
+4. Audit the binding tester (`bindings/python/tests/tester.py`) so the
+   asyncio path is exercised in CI rather than only the default event
+   model. The tester currently runs only the default model (see issue
+   discussion).
+
+The wrapper here is intended to coexist with that future work: callers
+written against `AsyncDatabase` / `AsyncTransaction` continue to work when
+the underlying futures gain native `__await__`, since the wrapper would
+then become a near zero-cost passthrough.
+
+## Limitations of the current shim
+
+* Every awaited future consumes one slot on the default thread executor.
+  Workloads that issue thousands of concurrent reads should configure a
+  larger executor via `loop.set_default_executor(...)`.
+* `get_range` is materialised eagerly into a list. Streaming async
+  iteration is left for the native integration.
+* `transactional_async` does not support the same decorator-style
+  ergonomics as `fdb.transactional`. A decorator can be added once the
+  shape of the native integration is settled.
+* The shim does not interact with the legacy `event_model="asyncio"` path
+  in `fdb.impl.init`; callers should leave `event_model` unset.

--- a/bindings/python/fdb/asyncio_impl.py
+++ b/bindings/python/fdb/asyncio_impl.py
@@ -1,0 +1,235 @@
+#
+# asyncio_impl.py
+#
+# This source file is part of the FoundationDB open source project
+#
+# Copyright 2013-2026 Apple Inc. and the FoundationDB project authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""asyncio-friendly wrapper for FoundationDB Python bindings.
+
+This module provides a thin shim that lets callers ``await`` FoundationDB
+futures and run transactional functions inside an asyncio event loop. The
+implementation is intentionally a wrapper rather than a native integration:
+
+* The blocking ``Future.wait()`` calls supplied by ``fdb.impl`` are dispatched
+  to a thread executor via ``loop.run_in_executor``. This isolates the asyncio
+  event loop from the underlying C-extension blocking semantics without
+  requiring changes to the FDB network thread.
+* ``transactional_async`` mirrors ``fdb.transactional`` but awaits each step
+  through that executor and retries via ``Transaction.on_error``.
+
+A native asyncio integration would attach the FDB callback machinery directly
+to the event loop's ``call_soon_threadsafe`` queue and skip the executor; the
+work is sketched in ``ASYNCIO_DESIGN.md``. This shim is meant as a
+forward-compatible scaffold so users can write ``await`` code today while the
+native path lands.
+
+Typical usage::
+
+    import asyncio
+    import fdb
+    from fdb.asyncio_impl import open_async
+
+    fdb.api_version(fdb.LATEST_API_VERSION)
+
+    async def main():
+        db = await open_async()
+        await db.set_async(b"hello", b"world")
+        value = await db.get_async(b"hello")
+        print(value)
+
+    asyncio.run(main())
+"""
+
+from __future__ import annotations
+
+import asyncio
+import functools
+from typing import Any, Awaitable, Callable, Optional
+
+
+# Resolved lazily so that ``import fdb.asyncio_impl`` does not require the
+# caller to have already invoked ``fdb.api_version``.
+def _impl():
+    import fdb.impl
+
+    return fdb.impl
+
+
+async def _await_future(future: Any) -> Any:
+    """Await an ``fdb.impl.Future`` by resolving it on the default executor.
+
+    The underlying ``Future.wait()`` is a blocking call backed by the C
+    client's network thread. Running it in an executor lets the event loop
+    keep servicing other coroutines while the FDB future resolves. This is
+    not zero-copy asyncio integration, but it is correct: the thread blocks,
+    the event loop does not.
+    """
+    if future.is_ready():
+        # Fast path: avoid scheduling work onto the executor when the future
+        # has already completed.
+        return future.wait()
+
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(None, future.wait)
+
+
+class AsyncTransaction:
+    """Async wrapper around ``fdb.impl.Transaction``.
+
+    Every read returns a coroutine that awaits the underlying FDB future via
+    the executor shim above. Writes are synchronous in the C client so they
+    are forwarded directly without await semantics.
+    """
+
+    def __init__(self, tr: Any) -> None:
+        self._tr = tr
+
+    # ----- reads ---------------------------------------------------------
+    async def get(self, key: bytes) -> Optional[bytes]:
+        return await _await_future(self._tr.get(key))
+
+    async def get_key(self, key_selector: Any) -> bytes:
+        return await _await_future(self._tr.get_key(key_selector))
+
+    async def get_range(self, begin: Any, end: Any, limit: int = 0) -> list:
+        # ``get_range`` returns an FDBRange container whose ``to_list`` is
+        # itself driven off futures. We materialise eagerly here for
+        # simplicity; callers who need streaming should use the lower level
+        # ``Transaction`` directly.
+        future = self._tr.get_range(begin, end, limit)._future
+        await _await_future(future)
+        return list(self._tr.get_range(begin, end, limit))
+
+    # ----- writes --------------------------------------------------------
+    def set(self, key: bytes, value: bytes) -> None:
+        self._tr.set(key, value)
+
+    def clear(self, key: bytes) -> None:
+        self._tr.clear(key)
+
+    def clear_range(self, begin: bytes, end: bytes) -> None:
+        self._tr.clear_range(begin, end)
+
+    # ----- lifecycle -----------------------------------------------------
+    async def commit(self) -> None:
+        await _await_future(self._tr.commit())
+
+    async def on_error(self, code: int) -> None:
+        await _await_future(self._tr.on_error(code))
+
+    def reset(self) -> None:
+        self._tr.reset()
+
+    @property
+    def raw(self) -> Any:
+        """Escape hatch: the underlying ``fdb.impl.Transaction``."""
+        return self._tr
+
+
+class AsyncDatabase:
+    """Async wrapper around ``fdb.impl.Database``."""
+
+    def __init__(self, db: Any) -> None:
+        self._db = db
+
+    def create_transaction(self) -> AsyncTransaction:
+        return AsyncTransaction(self._db.create_transaction())
+
+    # Convenience single-shot helpers. They open a transaction, perform the
+    # operation, commit, and retry on retryable errors -- mirroring the
+    # behaviour of ``Database.get`` / ``Database.set`` in the sync bindings.
+    async def get_async(self, key: bytes) -> Optional[bytes]:
+        async def op(tr: AsyncTransaction) -> Optional[bytes]:
+            return await tr.get(key)
+
+        return await self.transactional_async(op)
+
+    async def set_async(self, key: bytes, value: bytes) -> None:
+        async def op(tr: AsyncTransaction) -> None:
+            tr.set(key, value)
+
+        await self.transactional_async(op)
+
+    async def clear_async(self, key: bytes) -> None:
+        async def op(tr: AsyncTransaction) -> None:
+            tr.clear(key)
+
+        await self.transactional_async(op)
+
+    async def transactional_async(
+        self,
+        func: Callable[[AsyncTransaction], Awaitable[Any]],
+    ) -> Any:
+        """Run ``func`` inside a retry loop driven by ``Transaction.on_error``.
+
+        The semantics match ``fdb.transactional``: the callable is invoked
+        with an ``AsyncTransaction``, its result awaited, the transaction
+        committed, and any retryable ``FDBError`` retried. Non-retryable
+        errors propagate.
+        """
+        impl = _impl()
+        FDBError = impl.FDBError
+
+        tr = self.create_transaction()
+        while True:
+            try:
+                result = await func(tr)
+                await tr.commit()
+                return result
+            except FDBError as exc:
+                # ``on_error`` raises if the error is non-retryable, in
+                # which case we propagate. Otherwise the transaction is
+                # reset and we loop.
+                await tr.on_error(exc.code)
+
+    @property
+    def raw(self) -> Any:
+        """Escape hatch: the underlying ``fdb.impl.Database``."""
+        return self._db
+
+
+async def open_async(cluster_file: Optional[str] = None) -> AsyncDatabase:
+    """Open a database and return an :class:`AsyncDatabase` wrapper.
+
+    ``fdb.api_version`` must have been called before this. The underlying
+    ``fdb.open`` is itself synchronous; we run it in the default executor so
+    the event loop is not blocked while the network thread is brought up.
+    """
+    import fdb
+
+    loop = asyncio.get_running_loop()
+    db = await loop.run_in_executor(
+        None, functools.partial(fdb.open, cluster_file)
+    )
+    return AsyncDatabase(db)
+
+
+def wrap_database(db: Any) -> AsyncDatabase:
+    """Wrap an already-opened ``fdb.impl.Database`` in an :class:`AsyncDatabase`.
+
+    Useful when an application has existing sync code paths that hold a
+    Database handle and wants to add an async surface alongside.
+    """
+    return AsyncDatabase(db)
+
+
+__all__ = [
+    "AsyncDatabase",
+    "AsyncTransaction",
+    "open_async",
+    "wrap_database",
+]

--- a/bindings/python/tests/asyncio_test.py
+++ b/bindings/python/tests/asyncio_test.py
@@ -1,0 +1,88 @@
+#!/usr/bin/python
+#
+# asyncio_test.py
+#
+# This source file is part of the FoundationDB open source project
+#
+# Copyright 2013-2026 Apple Inc. and the FoundationDB project authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Smoke tests for fdb.asyncio_impl.
+
+These tests require a running FoundationDB cluster. Skip if the C client
+or a cluster is not available.
+
+Run with::
+
+    python -m bindings.python.tests.asyncio_test [cluster-file]
+"""
+
+import asyncio
+import os
+import sys
+import uuid
+
+
+async def _run_smoke(cluster_file=None):
+    import fdb
+    from fdb.asyncio_impl import open_async
+
+    fdb.api_version(fdb.LATEST_API_VERSION)
+
+    db = await open_async(cluster_file)
+
+    # Use a unique key prefix so concurrent runs do not collide.
+    prefix = b"asyncio_test/" + uuid.uuid4().hex.encode("ascii") + b"/"
+    key = prefix + b"hello"
+    value = b"world"
+
+    # Round-trip a single key.
+    await db.set_async(key, value)
+    got = await db.get_async(key)
+    assert got == value, f"expected {value!r}, got {got!r}"
+
+    # Mutate inside a transactional block and verify retry semantics.
+    async def add_two(tr):
+        tr.set(prefix + b"a", b"1")
+        tr.set(prefix + b"b", b"2")
+
+    await db.transactional_async(add_two)
+    a = await db.get_async(prefix + b"a")
+    b = await db.get_async(prefix + b"b")
+    assert a == b"1" and b == b"2", (a, b)
+
+    # Clean up.
+    async def cleanup(tr):
+        tr.clear_range(prefix, prefix + b"\xff")
+
+    await db.transactional_async(cleanup)
+
+    print("asyncio_test: OK")
+
+
+def main(argv):
+    cluster_file = argv[1] if len(argv) > 1 else os.environ.get("FDB_CLUSTER_FILE")
+    try:
+        asyncio.run(_run_smoke(cluster_file))
+    except Exception as exc:  # pragma: no cover - exercised by humans
+        # The most common failure mode is "no cluster reachable" before any
+        # FDB code runs; surface that clearly rather than as a stack trace.
+        print(f"asyncio_test: FAILED ({exc!r})", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
## Note on scope
Refs #208. This PR ships a **thread-pool-backed asyncio wrapper**, not a native asyncio integration. Native integration into FDB's network-thread callback machinery is multi-week work and a separate undertaking. This wrapper lets users `await fdb_future` cleanly today and stays forward-compatible with a future native implementation.

## What's added
- `bindings/python/fdb/asyncio_impl.py` (216 LOC) — `AsyncDatabase`, `AsyncTransaction`, `_await_future` shim using `loop.run_in_executor`, `open_async`, `wrap_database`, `transactional_async` retry loop driven by `Transaction.on_error`.
- `bindings/python/tests/asyncio_test.py` (87 LOC) — smoke test (round-trip set/get, multi-write transactional block, cleanup). Requires a running cluster.
- `bindings/python/ASYNCIO_DESIGN.md` — documents the trade-off, the native-integration path (`Future.__await__` + `call_soon_threadsafe`), and known limitations (executor slot per await, eager `get_range` materialisation, no decorator API).

## Test plan
- `python -m py_compile` on both files: pass.
- `mypy`: only fdb-module import errors (CMake-generated, expected); no type errors in the new code.
- Module loads without fdb installed (lazy `_impl()` import).
- Mocked `_await_future` semantic test (fast path + executor path): pass.
- Did NOT run against a real cluster (no fdb runtime available locally).

## Confidence
LOW for runtime correctness against a live cluster. MEDIUM for design — the executor-shim approach is a well-trodden pattern for bridging blocking C-extension calls to asyncio, and `transactional_async` mirrors the existing `fdb.transactional` retry loop using documented `on_error` semantics.

Marking draft because the wrapper-vs-native distinction deserves maintainer triage before this lands.
