### PR TITLE
Convert `networksender.actor.h` to standard coroutines

### DIFF
--- a/fdbrpc/include/fdbrpc/fdbrpc.h
+++ b/fdbrpc/include/fdbrpc/fdbrpc.h
@@ -27,7 +27,7 @@
 #include "flow/serialize.h"
 #include "fdbrpc/FlowTransport.h" // NetworkMessageReceiver Endpoint
 #include "fdbrpc/FailureMonitor.h"
-#include "fdbrpc/networksender.actor.h"
+#include "fdbrpc/networksender.h"
 #include "fdbrpc/simulator.h"
 #ifdef WITH_SWIFT
 #include <swift/bridging>
@@ -215,7 +215,7 @@ void load(Ar& ar, ReplyPromise<T>& value) {
 	ar >> token;
 	Endpoint endpoint = FlowTransport::transport().loadedEndpoint(token);
 	value = ReplyPromise<T>(endpoint);
-	networkSender(value.getFuture(), endpoint);
+	networkSender(Uncancellable(), value.getFuture(), endpoint);
 }
 
 template <class T>
@@ -227,7 +227,7 @@ struct serializable_traits<ReplyPromise<T>> : std::true_type {
 			serializer(ar, token);
 			auto endpoint = FlowTransport::transport().loadedEndpoint(token);
 			p = ReplyPromise<T>(endpoint);
-			networkSender(p.getFuture(), endpoint);
+			networkSender(Uncancellable(), p.getFuture(), endpoint);
 		} else {
 			const auto& ep = p.getEndpoint().token;
 			serializer(ar, ep);

--- a/fdbrpc/include/fdbrpc/networksender.h
+++ b/fdbrpc/include/fdbrpc/networksender.h
@@ -1,5 +1,5 @@
 /*
- * networksender.actor.h
+ * networksender.h
  *
  * This source file is part of the FoundationDB open source project
  *
@@ -18,33 +18,28 @@
  * limitations under the License.
  */
 
-// When actually compiled (NO_INTELLISENSE), include the generated version of this file.  In intellisense use the source
-// version.
-#if defined(NO_INTELLISENSE) && !defined(FDBRPC_NETWORKSENDER_ACTOR_G_H)
-#define FDBRPC_NETWORKSENDER_ACTOR_G_H
-#include "fdbrpc/networksender.actor.g.h"
-#elif !defined(RPCNETWORKSENDER_ACTOR_H)
-#define RPCNETWORKSENDER_ACTOR_H
+#ifndef FDBRPC_NETWORKSENDER_H
+#define FDBRPC_NETWORKSENDER_H
+#pragma once
 
 #include "fdbrpc/FlowTransport.h"
 #include "flow/flow.h"
-#include "flow/actorcompiler.h" // This must be the last #include.
 
-// This actor is used by FlowTransport to serialize the response to a ReplyPromise across the network
-ACTOR template <class T>
-void networkSender(Future<T> input, Endpoint endpoint) {
+// Used by FlowTransport to serialize the response to a ReplyPromise across the network.
+template <class T>
+Future<Void> networkSender(Uncancellable, Future<T> input, Endpoint endpoint, ExplicitVoid = {}) {
 	try {
-		T value = wait(input);
+		T value = co_await input;
 		FlowTransport::transport().sendUnreliable(SerializeSource<ErrorOr<EnsureTable<T>>>(value), endpoint, false);
 	} catch (Error& err) {
 		// if (err.code() == error_code_broken_promise) return;
 		if (err.code() == error_code_never_reply) {
-			return;
+			co_return Void();
 		}
 		ASSERT(err.code() != error_code_actor_cancelled);
 		FlowTransport::transport().sendUnreliable(SerializeSource<ErrorOr<EnsureTable<T>>>(err), endpoint, false);
 	}
+	co_return Void();
 }
-#include "flow/unactorcompiler.h"
 
 #endif


### PR DESCRIPTION
This PR converts `networkSender` to a standard coroutine, allowing the `networksender.actor.h` file to be renamed to `networksender.h`. Performance validation was done with `mako`