### PR TITLE
Backport #12374 to `release-7.3`

### DIFF
--- a/flow/Net2.actor.cpp
+++ b/flow/Net2.actor.cpp
@@ -143,6 +143,8 @@ public:
 	// INetworkConnections interface
 	Future<Reference<IConnection>> connect(NetworkAddress toAddr, tcp::socket* existingSocket = nullptr) override;
 	Future<Reference<IConnection>> connectExternal(NetworkAddress toAddr) override;
+	Future<Reference<IConnection>> connectExternalWithHostname(NetworkAddress toAddr,
+	                                                           const std::string& hostname) override;
 	Future<Reference<IUDPSocket>> createUDPSocket(NetworkAddress toAddr) override;
 	Future<Reference<IUDPSocket>> createUDPSocket(bool isV6) override;
 	// The mock DNS methods should only be used in simulation.
@@ -928,6 +930,51 @@ public:
 		}
 	}
 
+	// Connect with hostname for SNI (Server Name Indication) support
+	ACTOR static Future<Reference<IConnection>> connectWithHostname(
+	    boost::asio::io_service* ios,
+	    Reference<ReferencedObject<boost::asio::ssl::context>> context,
+	    NetworkAddress addr,
+	    std::string hostname) {
+		std::pair<IPAddress, uint16_t> peerIP = std::make_pair(addr.ip, addr.port);
+		auto iter(g_network->networkInfo.serverTLSConnectionThrottler.find(peerIP));
+		if (iter != g_network->networkInfo.serverTLSConnectionThrottler.end()) {
+			if (now() < iter->second.second) {
+				if (iter->second.first >= FLOW_KNOBS->TLS_CLIENT_CONNECTION_THROTTLE_ATTEMPTS) {
+					TraceEvent("TLSOutgoingConnectionThrottlingWarning").suppressFor(1.0).detail("PeerIP", addr);
+					wait(delay(FLOW_KNOBS->CONNECTION_MONITOR_TIMEOUT));
+					throw connection_failed();
+				}
+			} else {
+				g_network->networkInfo.serverTLSConnectionThrottler.erase(peerIP);
+			}
+		}
+
+		state Reference<SSLConnection> self(new SSLConnection(*ios, context));
+		self->peer_address = addr;
+		self->sni_hostname = hostname; // Store hostname for SNI during handshake
+
+		// Store hostname for SNI use during handshake
+
+		try {
+			auto to = tcpEndpoint(self->peer_address);
+			BindPromise p("N2_ConnectError", self->id);
+			Future<Void> onConnected = p.getFuture();
+			self->socket.async_connect(to, std::move(p));
+
+			wait(onConnected);
+
+			// SNI will be set later in doConnectHandshake before SSL handshake
+
+			self->init();
+			return self;
+		} catch (Error&) {
+			// Either the connection failed, or was cancelled by the caller
+			self->closeSocket();
+			throw;
+		}
+	}
+
 	// This is not part of the IConnection interface, because it is wrapped by IListener::accept()
 	void accept(NetworkAddress peerAddr) {
 		this->peer_address = peerAddr;
@@ -1044,6 +1091,15 @@ public:
 			ConfigureSSLStream(N2::g_net2->activeTlsPolicy, self->ssl_sock, [conn = self.getPtr()](bool verifyOk) {
 				conn->has_trusted_peer = verifyOk;
 			});
+
+			// Set SNI hostname if we have one (for connections made with hostname)
+			if (!self->sni_hostname.empty()) {
+				int result = SSL_set_tlsext_host_name(self->ssl_sock.native_handle(), self->sni_hostname.c_str());
+				TraceEvent("SSLSetSNIResult")
+				    .detail("Hostname", self->sni_hostname)
+				    .detail("Result", result)
+				    .detail("Addr", self->peer_address);
+			}
 
 			// If the background handshakers are not all busy, use one
 
@@ -1221,6 +1277,7 @@ private:
 	NetworkAddress peer_address;
 	Reference<ReferencedObject<boost::asio::ssl::context>> sslContext;
 	bool has_trusted_peer;
+	std::string sni_hostname; // For Server Name Indication
 
 	void init() {
 		// Socket settings that have to be set after connect or accept succeeds
@@ -1891,6 +1948,14 @@ Future<Reference<IConnection>> Net2::connect(NetworkAddress toAddr, tcp::socket*
 }
 
 Future<Reference<IConnection>> Net2::connectExternal(NetworkAddress toAddr) {
+	return connect(toAddr);
+}
+
+Future<Reference<IConnection>> Net2::connectExternalWithHostname(NetworkAddress toAddr, const std::string& hostname) {
+	if (toAddr.isTLS()) {
+		initTLS(ETLSInitState::CONNECT);
+		return SSLConnection::connectWithHostname(&this->reactor.ios, this->sslContextVar.get(), toAddr, hostname);
+	}
 	return connect(toAddr);
 }
 

--- a/flow/include/flow/IConnection.h
+++ b/flow/include/flow/IConnection.h
@@ -137,6 +137,13 @@ public:
 
 	virtual Future<Reference<IConnection>> connectExternal(NetworkAddress toAddr) = 0;
 
+	// Make an outgoing connection to the given address with hostname for SNI (TLS Server Name Indication)
+	virtual Future<Reference<IConnection>> connectExternalWithHostname(NetworkAddress toAddr,
+	                                                                   const std::string& hostname) {
+		// Default implementation ignores hostname - subclasses can override for SNI support
+		return connectExternal(toAddr);
+	}
+
 	// Make an outgoing udp connection and connect to the passed address.
 	virtual Future<Reference<IUDPSocket>> createUDPSocket(NetworkAddress toAddr) = 0;
 	// Make an outgoing udp connection without establishing a connection

--- a/flow/network.cpp
+++ b/flow/network.cpp
@@ -373,6 +373,10 @@ Future<Reference<IConnection>> INetworkConnections::connect(const std::string& h
 	// Wait for the endpoint to return, then wait for connect(endpoint) and return it.
 	// Template types are being provided explicitly because they can't be automatically deduced for some reason.
 	return mapAsync(pickEndpoint, [=](NetworkAddress const& addr) -> Future<Reference<IConnection>> {
+		// Pass the original hostname for SNI if this is a TLS connection from hostname
+		if (addr.isTLS() && addr.fromHostname) {
+			return connectExternalWithHostname(addr, host);
+		}
 		return connectExternal(addr);
 	});
 }


### PR DESCRIPTION
cherrypick https://github.com/apple/foundationdb/pull/12374, similar to https://github.com/apple/foundationdb/pull/12385 which was for release-7.4. i believe this is a bug fix that should be backported since it affects the usage of some S3-compatible blob storages, such as GCS, as can be seen in the original PR's description

* use sni in the tls handshake

* Ran clang-format -i

* Remove accidental overcommit

* drop too spamy logs

* clang-format -style=file -i flow/Net2.actor.cpp

---------

(cherry picked commit e810d6447ed41b07e2846c990942e275387bb968)