### PR TITLE
Remove FLOW_KNOBS->MAX_DECRYPTED_BLOCKS and it's cache from the Backup Encryption Code as it's not needed

### DIFF
--- a/fdbrpc/AsyncFileEncrypted.cpp
+++ b/fdbrpc/AsyncFileEncrypted.cpp
@@ -74,9 +74,7 @@ public:
 		int bytesRead = 0;
 		ASSERT(self->mode == AsyncFileEncrypted::Mode::READ_ONLY);
 		for (block = firstBlock; block <= lastBlock; ++block) {
-			Standalone<StringRef> plaintext;
-
-			plaintext = co_await readBlock(self.getPtr(), block);
+			Standalone<StringRef> plaintext = co_await readBlock(self.getPtr(), block);
 			auto start = (block == firstBlock) ? plaintext.begin() + (offset % FLOW_KNOBS->ENCRYPTION_BLOCK_SIZE)
 			                                   : plaintext.begin();
 			auto end = (block == lastBlock)

--- a/fdbrpc/AsyncFileEncrypted.cpp
+++ b/fdbrpc/AsyncFileEncrypted.cpp
@@ -76,13 +76,7 @@ public:
 		for (block = firstBlock; block <= lastBlock; ++block) {
 			Standalone<StringRef> plaintext;
 
-			auto cachedBlock = self->readBuffers.get(block);
-			if (cachedBlock.present()) {
-				plaintext = cachedBlock.get();
-			} else {
-				plaintext = co_await readBlock(self.getPtr(), block);
-				self->readBuffers.insert(block, plaintext);
-			}
+			plaintext = co_await readBlock(self.getPtr(), block);
 			auto start = (block == firstBlock) ? plaintext.begin() + (offset % FLOW_KNOBS->ENCRYPTION_BLOCK_SIZE)
 			                                   : plaintext.begin();
 			auto end = (block == lastBlock)
@@ -148,7 +142,7 @@ public:
 };
 
 AsyncFileEncrypted::AsyncFileEncrypted(Reference<IAsyncFile> file, Mode mode)
-  : file(file), mode(mode), readBuffers(FLOW_KNOBS->MAX_DECRYPTED_BLOCKS), currentBlock(0) {
+  : file(file), mode(mode), currentBlock(0) {
 	firstBlockIV = AsyncFileEncryptedImpl::getFirstBlockIV(file->getFilename());
 	if (mode == Mode::APPEND_ONLY) {
 		encryptor =
@@ -229,38 +223,6 @@ Future<Void> AsyncFileEncrypted::writeLastBlockToFile() {
 	return uncancellable(
 	    holdWhile(Reference<AsyncFileEncrypted>::addRef(this),
 	              file->write(&writeBuffer[0], offsetInBlock, currentBlock * FLOW_KNOBS->ENCRYPTION_BLOCK_SIZE)));
-}
-
-size_t AsyncFileEncrypted::RandomCache::evict() {
-	ASSERT_EQ(vec.size(), maxSize);
-	auto index = deterministicRandom()->randomInt(0, maxSize);
-	hashMap.erase(vec[index]);
-	return index;
-}
-
-AsyncFileEncrypted::RandomCache::RandomCache(size_t maxSize) : maxSize(maxSize) {
-	vec.reserve(maxSize);
-}
-
-void AsyncFileEncrypted::RandomCache::insert(uint32_t block, const Standalone<StringRef>& value) {
-	auto [_, found] = hashMap.insert({ block, value });
-	if (found) {
-		return;
-	} else if (vec.size() < maxSize) {
-		vec.push_back(block);
-	} else {
-		auto index = evict();
-		vec[index] = block;
-	}
-}
-
-Optional<Standalone<StringRef>> AsyncFileEncrypted::RandomCache::get(uint32_t block) const {
-	auto it = hashMap.find(block);
-	if (it == hashMap.end()) {
-		return {};
-	} else {
-		return it->second;
-	}
 }
 
 // This test writes random data into an encrypted file in random increments,

--- a/fdbrpc/include/fdbrpc/AsyncFileEncrypted.h
+++ b/fdbrpc/include/fdbrpc/AsyncFileEncrypted.h
@@ -26,8 +26,6 @@
 #include "flow/IRandom.h"
 #include "flow/StreamCipher.h"
 
-#include <array>
-
 /*
  * Append-only file encrypted using AES-256-GCM.
  * */
@@ -45,19 +43,6 @@ private:
 	Future<Void> writeLastBlockToFile();
 	friend class AsyncFileEncryptedImpl;
 	int64_t fileSize = -1;
-
-	// Reading:
-	class RandomCache {
-		size_t maxSize;
-		std::vector<uint32_t> vec;
-		std::unordered_map<uint32_t, Standalone<StringRef>> hashMap;
-		size_t evict();
-
-	public:
-		RandomCache(size_t maxSize);
-		void insert(uint32_t block, const Standalone<StringRef>& value);
-		Optional<Standalone<StringRef>> get(uint32_t block) const;
-	} readBuffers;
 
 	// Writing (append only):
 	std::unique_ptr<EncryptionStreamCipher> encryptor;

--- a/flow/Knobs.cpp
+++ b/flow/Knobs.cpp
@@ -177,7 +177,6 @@ void FlowKnobs::initialize(Randomize randomize, IsSimulated isSimulated) {
 
 	//AsyncFileEncrypted
 	init( ENCRYPTION_BLOCK_SIZE,                              4096 );
-	init( MAX_DECRYPTED_BLOCKS,                                 10 );
 
 	//AsyncFileKAIO
 	init( MAX_OUTSTANDING,                                      64 );

--- a/flow/include/flow/Knobs.h
+++ b/flow/include/flow/Knobs.h
@@ -229,7 +229,6 @@ public:
 
 	// AsyncFileEncrypted
 	int ENCRYPTION_BLOCK_SIZE;
-	int MAX_DECRYPTED_BLOCKS;
 
 	// AsyncFileKAIO
 	int MAX_OUTSTANDING;


### PR DESCRIPTION
Remove FLOW_KNOBS->MAX_DECRYPTED_BLOCKS and it's cache logic from the Backup Encryption Code as it's not needed.
The restore is sequential so this cache has not used at all.

Simulation 100k in progress
` 20260427-224501-ak_knob-fdee2f79bad80c4d           compressed=True data_size=36634153 fail_fast=10 max_runs=100000 priority=100 remaining=not_started runtime=0:00:06 sanity=False submitted=20260427-224501 timeout=5400 username=ak_knob`
