### PR TITLE
Convert `ClusterRecovery.actor.h` to standard coroutines

### DIFF
--- a/fdbserver/clustercontroller/CMakeLists.txt
+++ b/fdbserver/clustercontroller/CMakeLists.txt
@@ -11,6 +11,5 @@ target_include_directories(fdbserver_clustercontroller
   PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/include
   PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_CURRENT_BINARY_DIR})
+    ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(fdbserver_clustercontroller PRIVATE fdbserver_core fdbserver_logsystem)

--- a/fdbserver/clustercontroller/CMakeLists.txt
+++ b/fdbserver/clustercontroller/CMakeLists.txt
@@ -12,7 +12,5 @@ target_include_directories(fdbserver_clustercontroller
     ${CMAKE_CURRENT_SOURCE_DIR}/include
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_CURRENT_BINARY_DIR}
-    ${CMAKE_SOURCE_DIR}/fdbserver/datadistributor/include
-    ${CMAKE_BINARY_DIR}/fdbserver/datadistributor/include)
+    ${CMAKE_CURRENT_BINARY_DIR})
 target_link_libraries(fdbserver_clustercontroller PRIVATE fdbserver_core fdbserver_logsystem)

--- a/fdbserver/clustercontroller/ClusterController.actor.cpp
+++ b/fdbserver/clustercontroller/ClusterController.actor.cpp
@@ -42,7 +42,7 @@
 #include "fdbserver/core/CoordinationInterface.h" // copy constructors for ServerCoordinators class
 #include "fdbserver/clustercontroller/ClusterController.h"
 #include "ClusterController.h"
-#include "ClusterRecovery.actor.h"
+#include "ClusterRecovery.h"
 #include "fdbserver/core/DataDistributorInterface.h"
 #include "fdbserver/core/LeaderElection.h"
 #include "fdbserver/logsystem/LogSystem.h"

--- a/fdbserver/clustercontroller/ClusterRecovery.actor.cpp
+++ b/fdbserver/clustercontroller/ClusterRecovery.actor.cpp
@@ -25,7 +25,7 @@
 #include "fdbrpc/sim_validation.h"
 #include "fdbserver/logsystem/ApplyMetadataMutation.h"
 #include "fdbserver/core/BackupProgress.h"
-#include "ClusterRecovery.actor.h"
+#include "ClusterRecovery.h"
 #include "fdbserver/core/Knobs.h"
 #include "fdbserver/core/MasterInterface.h"
 #include "fdbserver/core/SeedShardServers.h"

--- a/fdbserver/clustercontroller/ClusterRecovery.actor.cpp
+++ b/fdbserver/clustercontroller/ClusterRecovery.actor.cpp
@@ -35,6 +35,7 @@
 #include "flow/ProtocolVersion.h"
 #include "flow/Trace.h"
 
+#include "flow/CoroUtils.h"
 #include "flow/actorcompiler.h" // This must be the last #include.
 
 static std::set<int> const& normalClusterRecoveryErrors() {
@@ -1479,9 +1480,9 @@ ACTOR Future<Void> recoverFrom(Reference<ClusterRecoveryData> self,
 	return Void();
 }
 
-ACTOR Future<Void> clusterRecoveryCore(Reference<ClusterRecoveryData> self) {
-	state TraceInterval recoveryInterval("ClusterRecovery");
-	state double recoverStartTime = now();
+Future<Void> clusterRecoveryCore(Reference<ClusterRecoveryData> self) {
+	TraceInterval recoveryInterval("ClusterRecovery");
+	double recoverStartTime = now();
 
 	self->addActor.send(waitFailureServer(self->masterInterface.waitFailure.getFuture()));
 
@@ -1493,7 +1494,7 @@ ACTOR Future<Void> clusterRecoveryCore(Reference<ClusterRecoveryData> self) {
 	    .detail("Status", RecoveryStatus::names[RecoveryStatus::reading_coordinated_state])
 	    .trackLatest(self->clusterRecoveryStateEventHolder->trackingKey);
 
-	wait(self->cstate.read());
+	co_await self->cstate.read();
 
 	if (self->cstate.prevDBState.lowestCompatibleProtocolVersion > currentProtocolVersion()) {
 		TraceEvent(SevWarnAlways, "IncompatibleProtocolVersion", self->dbgid).log();
@@ -1526,7 +1527,7 @@ ACTOR Future<Void> clusterRecoveryCore(Reference<ClusterRecoveryData> self) {
 			            "Recovery stopped because too many recoveries have happened since the last time the cluster "
 			            "was fully_recovered. Set --knob-max-generations-override on your server processes to a value "
 			            "larger than OldGenerations to resume recovery once the underlying problem has been fixed.");
-			wait(Future<Void>(Never()));
+			co_await Future<Void>(Never());
 		} else if (self->cstate.myDBState.oldTLogData.size() > CLIENT_KNOBS->RECOVERY_DELAY_START_GENERATION) {
 			TraceEvent(SevError, "RecoveryDelayedTooManyOldGenerations")
 			    .detail("OldGenerations", self->cstate.myDBState.oldTLogData.size())
@@ -1534,22 +1535,21 @@ ACTOR Future<Void> clusterRecoveryCore(Reference<ClusterRecoveryData> self) {
 			            "Recovery is delayed because too many recoveries have happened since the last time the cluster "
 			            "was fully_recovered. Set --knob-max-generations-override on your server processes to a value "
 			            "larger than OldGenerations to resume recovery once the underlying problem has been fixed.");
-			wait(delay(CLIENT_KNOBS->RECOVERY_DELAY_SECONDS_PER_GENERATION *
-			           (self->cstate.myDBState.oldTLogData.size() - CLIENT_KNOBS->RECOVERY_DELAY_START_GENERATION)));
+			co_await delay(CLIENT_KNOBS->RECOVERY_DELAY_SECONDS_PER_GENERATION *
+			               (self->cstate.myDBState.oldTLogData.size() - CLIENT_KNOBS->RECOVERY_DELAY_START_GENERATION));
 		}
 		if (g_network->isSimulated() && self->cstate.myDBState.oldTLogData.size() > CLIENT_KNOBS->MAX_GENERATIONS_SIM) {
 			disableConnectionFailures("TooManyGenerations");
 		}
 	}
 
-	state Reference<AsyncVar<Reference<LogSystem>>> oldLogSystems(new AsyncVar<Reference<LogSystem>>);
-	state Future<Void> recoverAndEndEpoch =
-	    recoverAndEndLogSystemEpoch(oldLogSystems,
-	                                self->dbgid,
-	                                self->cstate.prevDBState,
-	                                self->clusterController.tlogRejoin.getFuture(),
-	                                self->controllerData->db.serverInfo->get().myLocality,
-	                                std::addressof(self->forceRecovery));
+	Reference<AsyncVar<Reference<LogSystem>>> oldLogSystems(new AsyncVar<Reference<LogSystem>>);
+	Future<Void> recoverAndEndEpoch = recoverAndEndLogSystemEpoch(oldLogSystems,
+	                                                              self->dbgid,
+	                                                              self->cstate.prevDBState,
+	                                                              self->clusterController.tlogRejoin.getFuture(),
+	                                                              self->controllerData->db.serverInfo->get().myLocality,
+	                                                              std::addressof(self->forceRecovery));
 
 	DBCoreState newState = self->cstate.myDBState;
 	newState.recoveryCount++;
@@ -1560,7 +1560,7 @@ ACTOR Future<Void> clusterRecoveryCore(Reference<ClusterRecoveryData> self) {
 		newState.newestProtocolVersion = currentProtocolVersion();
 		newState.lowestCompatibleProtocolVersion = minCompatibleProtocolVersion;
 	}
-	wait(self->cstate.write(newState) || recoverAndEndEpoch);
+	co_await (self->cstate.write(newState) || recoverAndEndEpoch);
 
 	TraceEvent("ProtocolVersionCompatibilityChecked", self->dbgid)
 	    .detail("NewestProtocolVersion", self->cstate.myDBState.newestProtocolVersion)
@@ -1569,13 +1569,13 @@ ACTOR Future<Void> clusterRecoveryCore(Reference<ClusterRecoveryData> self) {
 
 	self->recoveryState = RecoveryState::RECRUITING;
 
-	state std::vector<StorageServerInterface> seedServers;
-	state std::vector<Standalone<CommitTransactionRef>> initialConfChanges;
-	state Future<Void> logChanges;
-	state Future<Void> minRecoveryDuration;
-	state Future<Version> poppedTxsVersion;
+	std::vector<StorageServerInterface> seedServers;
+	std::vector<Standalone<CommitTransactionRef>> initialConfChanges;
+	Future<Void> logChanges;
+	Future<Void> minRecoveryDuration;
+	Future<Version> poppedTxsVersion;
 
-	loop {
+	while (true) {
 		Reference<LogSystem> oldLogSystem = oldLogSystems->get();
 		if (oldLogSystem) {
 			logChanges = triggerUpdates(self, oldLogSystem);
@@ -1585,24 +1585,26 @@ ACTOR Future<Void> clusterRecoveryCore(Reference<ClusterRecoveryData> self) {
 			}
 		}
 
-		state Future<Void> reg = oldLogSystem ? updateRegistration(self, oldLogSystem) : Never();
+		Future<Void> reg = oldLogSystem ? updateRegistration(self, oldLogSystem) : Never();
 		self->registrationTrigger.trigger();
 
-		choose {
-			when(wait(oldLogSystem
-			              ? recoverFrom(self, oldLogSystem, &seedServers, &initialConfChanges, poppedTxsVersion)
-			              : Never())) {
-				reg.cancel();
-				break;
-			}
-			when(wait(oldLogSystems->onChange())) {}
-			when(wait(reg)) {
-				throw internal_error();
-			}
-			when(wait(recoverAndEndEpoch)) {
-				throw internal_error();
-			}
+		auto res = co_await race(
+		    oldLogSystem ? recoverFrom(self, oldLogSystem, &seedServers, &initialConfChanges, poppedTxsVersion)
+		                 : Never(),
+		    oldLogSystems->onChange(),
+		    reg,
+		    recoverAndEndEpoch);
+		if (res.index() == 0) {
+			reg.cancel();
+			break;
 		}
+		if (res.index() == 1) {
+			continue;
+		}
+		if (res.index() == 2 || res.index() == 3) {
+			throw internal_error();
+		}
+		UNREACHABLE();
 	}
 
 	if (self->neverCreated) {
@@ -1628,7 +1630,7 @@ ACTOR Future<Void> clusterRecoveryCore(Reference<ClusterRecoveryData> self) {
 	    .trackLatest(self->clusterRecoveryStateEventHolder->trackingKey);
 
 	// Recovery transaction
-	state bool debugResult = debug_checkMinRestoredVersion(UID(), self->lastEpochEnd, "DBRecovery", SevWarn);
+	bool debugResult = debug_checkMinRestoredVersion(UID(), self->lastEpochEnd, "DBRecovery", SevWarn);
 
 	CommitTransactionRequest recoveryCommitRequest;
 	recoveryCommitRequest.flags = recoveryCommitRequest.flags | CommitTransactionRequest::FLAG_IS_LOCK_AWARE;
@@ -1725,7 +1727,7 @@ ACTOR Future<Void> clusterRecoveryCore(Reference<ClusterRecoveryData> self) {
 
 	TraceEvent(getRecoveryEventName(ClusterRecoveryEventType::CLUSTER_RECOVERY_COMMIT_EVENT_NAME).c_str(), self->dbgid);
 
-	state Future<ErrorOr<CommitID>> recoveryCommit = self->commitProxies[0].commit.tryGetReply(recoveryCommitRequest);
+	Future<ErrorOr<CommitID>> recoveryCommit = self->commitProxies[0].commit.tryGetReply(recoveryCommitRequest);
 	self->addActor.send(self->logSystem->onError());
 	self->addActor.send(waitResolverFailure(self->resolvers));
 	self->addActor.send(waitCommitProxyFailure(self->commitProxies));
@@ -1733,13 +1735,13 @@ ACTOR Future<Void> clusterRecoveryCore(Reference<ClusterRecoveryData> self) {
 	self->addActor.send(reportErrors(updateRegistration(self, self->logSystem), "UpdateRegistration", self->dbgid));
 	self->registrationTrigger.trigger();
 
-	wait(traceAfter(discardCommit(self->txnStateStore, self->txnStateLogAdapter), "DiscardCommitFinished"));
+	co_await traceAfter(discardCommit(self->txnStateStore, self->txnStateLogAdapter), "DiscardCommitFinished");
 
 	// Wait for the recovery transaction to complete.
 	// SOMEDAY: For faster recovery, do this and setDBState asynchronously and don't wait for them
 	// unless we want to change TLogs
-	wait(traceAfter(success(recoveryCommit), "RecoveryCommitFinished") &&
-	     traceAfter(sendInitialCommitToResolvers(self), "InitialCommitToResolversFinished"));
+	co_await (traceAfter(success(recoveryCommit), "RecoveryCommitFinished") &&
+	          traceAfter(sendInitialCommitToResolvers(self), "InitialCommitToResolversFinished"));
 	if (recoveryCommit.isReady() && recoveryCommit.get().isError()) {
 		TraceEvent(getRecoveryEventName(ClusterRecoveryEventType::CLUSTER_RECOVERY_COMMIT_EVENT_NAME).c_str(),
 		           self->dbgid)
@@ -1770,7 +1772,7 @@ ACTOR Future<Void> clusterRecoveryCore(Reference<ClusterRecoveryData> self) {
 
 	self->addActor.send(trackTlogRecovery(self, oldLogSystems, minRecoveryDuration));
 	debug_advanceMaxCommittedVersion(UID(), self->recoveryTransactionVersion);
-	wait(self->cstateUpdated.getFuture());
+	co_await self->cstateUpdated.getFuture();
 	debug_advanceMinCommittedVersion(UID(), self->recoveryTransactionVersion);
 
 	if (debugResult) {
@@ -1816,7 +1818,7 @@ ACTOR Future<Void> clusterRecoveryCore(Reference<ClusterRecoveryData> self) {
 		self->logSystem->setOldestBackupEpoch(self->cstate.myDBState.recoveryCount);
 	}
 
-	wait(Future<Void>(Never()));
+	co_await Future<Void>(Never());
 	throw internal_error();
 }
 

--- a/fdbserver/clustercontroller/ClusterRecovery.actor.h
+++ b/fdbserver/clustercontroller/ClusterRecovery.actor.h
@@ -20,16 +20,8 @@
 
 #pragma once
 
-// When actually compiled (NO_INTELLISENSE), include the generated version of this file.  In intellisense use the source
-// version.
 #include "flow/Trace.h"
 #include <utility>
-
-#if defined(NO_INTELLISENSE) && !defined(FDBSERVER_CLUSTERCONTROLLER_CLUSTERRECOVERY_ACTOR_G_H)
-#define FDBSERVER_CLUSTERCONTROLLER_CLUSTERRECOVERY_ACTOR_G_H
-#include "ClusterRecovery.actor.g.h"
-#elif !defined(FDBSERVER_CLUSTERCONTROLLER_CLUSTERRECOVERY_ACTOR_H)
-#define FDBSERVER_CLUSTERCONTROLLER_CLUSTERRECOVERY_ACTOR_H
 
 #include "fdbclient/DatabaseContext.h"
 #include "fdbrpc/Replication.h"
@@ -44,10 +36,9 @@
 #include "fdbserver/core/LogSystemConfig.h"
 #include "fdbserver/logsystem/LogSystemDiskQueueAdapter.h"
 #include "fdbserver/core/WorkerInterface.actor.h"
+#include "flow/CoroUtils.h"
 #include "flow/Error.h"
 #include "flow/SystemMonitor.h"
-
-#include "flow/actorcompiler.h" // This must be the last #include.
 
 class ClusterControllerData;
 typedef enum {
@@ -105,8 +96,8 @@ private:
 	Promise<Void> switchedState;
 	UID dbgid;
 
-	ACTOR Future<Void> _read(ReusableCoordinatedState* self) {
-		Value prevDBStateRaw = wait(self->cstate.read());
+	Future<Void> _read(ReusableCoordinatedState* self) {
+		Value prevDBStateRaw = co_await self->cstate.read();
 		Future<Void> onConflict = recoveryTerminateOnConflict(
 		    self->dbgid, self->fullyRecovered, self->cstate.onConflict(), self->switchedState.getFuture());
 		if (onConflict.isReady() && onConflict.isError()) {
@@ -118,13 +109,11 @@ private:
 			self->prevDBState = BinaryReader::fromStringRef<DBCoreState>(prevDBStateRaw, IncludeVersion());
 			self->myDBState = self->prevDBState;
 		}
-
-		return Void();
 	}
 
-	ACTOR Future<Void> _write(ReusableCoordinatedState* self, DBCoreState newState, bool finalWrite) {
+	Future<Void> _write(ReusableCoordinatedState* self, DBCoreState newState, bool finalWrite) {
 		if (self->finalWriteStarted) {
-			wait(Future<Void>(Never()));
+			co_await Future<Void>(Never());
 		}
 
 		if (finalWrite) {
@@ -138,11 +127,11 @@ private:
 			// TODO(gglass): figure out what the above means post-encryption-at-rest deletion.
 			// It's not clear the protocol versioning scheme contemplates the possibility of features being removed.
 			if (SERVER_KNOBS->RECORD_RECOVER_AT_IN_CSTATE) {
-				wait(self->cstate.setExclusive(
-				    BinaryWriter::toValue(newState, IncludeVersion(ProtocolVersion::withGcTxnGenerations()))));
+				co_await self->cstate.setExclusive(
+				    BinaryWriter::toValue(newState, IncludeVersion(ProtocolVersion::withGcTxnGenerations())));
 			} else {
-				wait(self->cstate.setExclusive(
-				    BinaryWriter::toValue(newState, IncludeVersion(ProtocolVersion::withEncryptionAtRest()))));
+				co_await self->cstate.setExclusive(
+				    BinaryWriter::toValue(newState, IncludeVersion(ProtocolVersion::withEncryptionAtRest())));
 			}
 		} catch (Error& e) {
 			CODE_PROBE(true, "Master displaced during writeMasterState");
@@ -154,7 +143,7 @@ private:
 		if (!finalWrite) {
 			self->switchedState.send(Void());
 			self->cstate = MovableCoordinatedState(self->coordinators);
-			Value rereadDBStateRaw = wait(self->cstate.read());
+			Value rereadDBStateRaw = co_await self->cstate.read();
 			DBCoreState readState;
 			if (rereadDBStateRaw.size())
 				readState = BinaryReader::fromStringRef<DBCoreState>(rereadDBStateRaw, IncludeVersion());
@@ -170,8 +159,6 @@ private:
 		} else {
 			self->fullyRecovered.send(Void());
 		}
-
-		return Void();
 	}
 };
 
@@ -321,10 +308,7 @@ Future<Void> recruitNewMaster(ClusterControllerData* cluster,
                               ClusterControllerData::DBInfo* db,
                               MasterInterface* newMaster);
 Future<Void> cleanupRecoveryActorCollection(Reference<ClusterRecoveryData> self);
-ACTOR Future<Void> clusterRecoveryCore(Reference<ClusterRecoveryData> self);
+Future<Void> clusterRecoveryCore(Reference<ClusterRecoveryData> self);
 bool isNormalClusterRecoveryError(const Error&);
 
-#include "flow/unactorcompiler.h"
 #include "fdbserver/core/MoveKeys.h"
-
-#endif

--- a/fdbserver/clustercontroller/ClusterRecovery.h
+++ b/fdbserver/clustercontroller/ClusterRecovery.h
@@ -1,5 +1,5 @@
 /*
- * ClusterRecovery.actor.h
+ * ClusterRecovery.h
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdbserver/clustercontroller/Status.cpp
+++ b/fdbserver/clustercontroller/Status.cpp
@@ -34,10 +34,9 @@
 #include "fdbserver/core/WorkerEvents.h"
 #include "fdbserver/core/WorkerInterface.actor.h"
 #include <time.h>
-#include "ClusterRecovery.actor.h"
+#include "ClusterRecovery.h"
 #include "fdbclient/ClusterConnectionMemoryRecord.h"
 #include "fdbserver/core/CoordinationInterface.h"
-#include "fdbserver/datadistributor/DataDistribution.h"
 #include "fdbclient/ConsistencyScanInterface.h"
 #include "flow/UnitTest.h"
 #include "fdbserver/core/QuietDatabase.h"
@@ -2864,7 +2863,7 @@ AsyncResult<JsonBuilderObject> storageWigglerStatsFetcher(Optional<DataDistribut
 		if (primaryV.present()) {
 			auto obj = primaryV.get().toJSON();
 			auto& reply = stateFut.get();
-			obj["state"] = StorageWiggler::getWiggleStateStr(static_cast<StorageWiggler::State>(reply.primary));
+			obj["state"] = StorageWigglerState::toString(static_cast<StorageWigglerState::Value>(reply.primary));
 			obj["last_state_change_timestamp"] = reply.lastStateChangePrimary;
 			obj["last_state_change_datetime"] = epochsToGMTString(reply.lastStateChangePrimary);
 			res["primary"] = obj;
@@ -2872,7 +2871,7 @@ AsyncResult<JsonBuilderObject> storageWigglerStatsFetcher(Optional<DataDistribut
 		if (conf.regions.size() > 1 && remoteV.present()) {
 			auto obj = remoteV.get().toJSON();
 			auto& reply = stateFut.get();
-			obj["state"] = StorageWiggler::getWiggleStateStr(static_cast<StorageWiggler::State>(reply.remote));
+			obj["state"] = StorageWigglerState::toString(static_cast<StorageWigglerState::Value>(reply.remote));
 			obj["last_state_change_timestamp"] = reply.lastStateChangeRemote;
 			obj["last_state_change_datetime"] = epochsToGMTString(reply.lastStateChangeRemote);
 			res["remote"] = obj;

--- a/fdbserver/core/include/fdbserver/core/DataDistributorInterface.h
+++ b/fdbserver/core/include/fdbserver/core/DataDistributorInterface.h
@@ -25,6 +25,7 @@
 #include "fdbclient/FDBTypes.h"
 #include "fdbrpc/Locality.h"
 #include "fdbrpc/fdbrpc.h"
+#include <string>
 #include <unordered_set>
 
 FDB_BOOLEAN_PARAM(IsMocked);
@@ -221,9 +222,24 @@ struct DistributorSplitRangeRequest {
 	}
 };
 
+struct StorageWigglerState {
+	enum Value : uint8_t { INVALID = 0, RUN = 1, PAUSE = 2 };
+
+	static std::string toString(Value state) {
+		switch (state) {
+		case RUN:
+			return "running";
+		case PAUSE:
+			return "paused";
+		default:
+			return "unknown";
+		}
+	}
+};
+
 struct GetStorageWigglerStateReply {
 	constexpr static FileIdentifier file_identifier = 356721;
-	uint8_t primary = 0, remote = 0; // StorageWiggler::State enum
+	uint8_t primary = 0, remote = 0; // StorageWigglerState::Value enum
 	double lastStateChangePrimary = 0.0, lastStateChangeRemote = 0.0;
 
 	GetStorageWigglerStateReply() = default;

--- a/fdbserver/datadistributor/include/fdbserver/datadistributor/DataDistribution.h
+++ b/fdbserver/datadistributor/include/fdbserver/datadistributor/DataDistribution.h
@@ -24,6 +24,7 @@
 
 #include "fdbclient/BulkLoading.h"
 #include "fdbclient/NativeAPI.actor.h"
+#include "fdbserver/core/DataDistributorInterface.h"
 #include "fdbserver/core/Knobs.h"
 #include "fdbserver/core/MoveKeys.h"
 #include "fdbserver/core/DataMovement.h"
@@ -748,7 +749,10 @@ class DDTeamCollection;
 
 struct StorageWiggler : ReferenceCounted<StorageWiggler> {
 	static constexpr double MIN_ON_CHECK_DELAY_SEC = 5.0;
-	enum State : uint8_t { INVALID = 0, RUN = 1, PAUSE = 2 };
+	using State = StorageWigglerState::Value;
+	static constexpr State INVALID = StorageWigglerState::INVALID;
+	static constexpr State RUN = StorageWigglerState::RUN;
+	static constexpr State PAUSE = StorageWigglerState::PAUSE;
 
 	DDTeamCollection const* teamCollection;
 	StorageWiggleData wiggleData; // the wiggle related data persistent in database
@@ -762,7 +766,7 @@ struct StorageWiggler : ReferenceCounted<StorageWiggler> {
 	    wiggle_pq;
 	std::unordered_map<UID, decltype(wiggle_pq)::handle_type> pq_handles;
 
-	State wiggleState = State::INVALID;
+	State wiggleState = INVALID;
 	double lastStateChangeTs = 0.0; // timestamp describes when did the state change
 
 	explicit StorageWiggler(DDTeamCollection* collection) : teamCollection(collection), stopWiggleSignal(true) {};
@@ -792,16 +796,7 @@ struct StorageWiggler : ReferenceCounted<StorageWiggler> {
 			lastStateChangeTs = g_network->now();
 		}
 	}
-	static std::string getWiggleStateStr(State s) {
-		switch (s) {
-		case State::RUN:
-			return "running";
-		case State::PAUSE:
-			return "paused";
-		default:
-			return "unknown";
-		}
-	}
+	static std::string getWiggleStateStr(State s) { return StorageWigglerState::toString(s); }
 
 	// -- statistic update
 


### PR DESCRIPTION
This PR uses the actor rewrite tool to convert `ClusterRecovery.actor.h` actors to standard coroutines. An unnecessary inter-role dependency of `fdbserver/clustercontroller` on `fdbserver/datadistributor` is also cleaned up