### PR TITLE
Fix platform_error crash for encrypted restores 

### DIFF
--- a/fdbrpc/AsyncFileEncrypted.cpp
+++ b/fdbrpc/AsyncFileEncrypted.cpp
@@ -29,7 +29,8 @@ public:
 	// the filename.
 	static auto getFirstBlockIV(const std::string& filename) {
 		StreamCipher::IV iv;
-		auto salt = basename(filename);
+		auto slashPos = filename.rfind('/');
+		auto salt = (slashPos == std::string::npos) ? filename : filename.substr(slashPos + 1);
 		auto pos = salt.find('.');
 		salt = salt.substr(0, pos);
 		auto hash = XXH3_128bits(salt.c_str(), salt.size());


### PR DESCRIPTION
### Summary

  - getFirstBlockIV() called FDB's basename() on the filename passed to AsyncFileEncrypted, which internally calls abspath() → realpath() to resolve the path
  - For S3 encrypted restores, the filename is an S3 object key (e.g. data/ctests/.../snapshots/snapshot,...) — a relative path, not a local filesystem path
  - When fdbrestore is run via su -u / sudo -u from a directory the target user cannot access, realpath() fails with EACCES and throws platform_error, crashing the process
  - Non-encrypted restores are unaffected since AsyncFileEncrypted is never instantiated

  Fix
  Replace the basename() call in getFirstBlockIV() with a pure string operation that extracts the last path component without touching the filesystem:

  // Before:
  auto salt = basename(filename);

  // After:
  auto slashPos = filename.rfind('/');
  auto salt = (slashPos == std::string::npos) ? filename : filename.substr(slashPos + 1);

  ### Test plan
  - Reproduced crash: run fdbrestore start --encryption-key-file with su -s /bin/bash nobody from a chmod 700 directory against a real S3 encrypted backup → ERROR: Platform error
  - Verified fix: same command after rebuild completes successfully without crash
  
  Before Fix: 
  ```
su -s /bin/bash nobody -c '/root/build_output/bin/fdbrestore start \
    -t test_backup \
    -r "blobstore://@s3.us-west-2.amazonaws.com/ctests/test_s3_repro?bucket=backup-112664522426-us-west-2&region=us-west-2&secure_connection=1" \
    --dest-cluster-file /tmp/fdb.cluster \
    --log --logdir=/tmp \
    --blob-credentials /tmp/s3_blob_credentials.json \
    --tls-ca-file /etc/pki/tls/cert.pem \
    --knob_blobstore_encryption_type=aws:kms \
    --encryption-key-file /tmp/test_encryption_key_file'
No restore target version given, will use maximum restorable version from backup description.
Using target restore version 260267101
Backup Description
URL: blobstore://@s3.us-west-2.amazonaws.com/ctests/test_s3_repro?bucket=backup-112664522426-us-west-2&region=us-west-2&secure_connection=1
Restorable: true
Partitioned logs: false
File-level encryption: true
Snapshot:  type=rangefile  startVersion=240449594 (maxLogEnd -0.00 days)  endVersion=240449594 (maxLogEnd -0.00 days)  totalBytes=178  restorable=true  expiredPct=0.00
SnapshotBytes: 178
MinLogBeginVersion:      240267102 (maxLogEnd -0.00 days)
ContiguousLogEndVersion: 260267102 (maxLogEnd -0.00 days)
MaxLogEndVersion:        260267102 (maxLogEnd -0.00 days)
MinRestorableVersion:    240449594 (maxLogEnd -0.00 days)
MaxRestorableVersion:    260267101 (maxLogEnd -0.00 days)
ERROR: Platform error
Fatal Error: Platform error
```
After Fix:
```

 su -s /bin/bash nobody -c '/root/build_output/bin/fdbrestore start \
    -t test_backup \
    -r "blobstore://@s3.us-west-2.amazonaws.com/ctests/test_s3_repro?bucket=backup-112664522426-us-west-2&region=us-west-2&secure_connection=1" \
    --dest-cluster-file /tmp/fdb.cluster \
    --log --logdir=/tmp \
    --blob-credentials /tmp/s3_blob_credentials.json \
    --tls-ca-file /etc/pki/tls/cert.pem \
    --knob_blobstore_encryption_type=aws:kms \
    --encryption-key-file /tmp/test_encryption_key_file'
No restore target version given, will use maximum restorable version from backup description.
Using target restore version 260267101
Backup Description
URL: blobstore://@s3.us-west-2.amazonaws.com/ctests/test_s3_repro?bucket=backup-112664522426-us-west-2&region=us-west-2&secure_connection=1
Restorable: true
Partitioned logs: false
File-level encryption: true
Snapshot:  type=rangefile  startVersion=240449594 (maxLogEnd -0.00 days)  endVersion=240449594 (maxLogEnd -0.00 days)  totalBytes=178  restorable=true  expiredPct=0.00
SnapshotBytes: 178
MinLogBeginVersion:      240267102 (maxLogEnd -0.00 days)
ContiguousLogEndVersion: 260267102 (maxLogEnd -0.00 days)
MaxLogEndVersion:        260267102 (maxLogEnd -0.00 days)
MinRestorableVersion:    240449594 (maxLogEnd -0.00 days)
MaxRestorableVersion:    260267101 (maxLogEnd -0.00 days)
Restoring backup to version: 260267101
```

- Ran local and s3 ctest to confirm nothing breaks.
- 100k Simulation in progress

` 20260427-231030-ak_encrypt_permission-002ac38108d65383 compressed=True data_size=36637967 fail_fast=10 max_runs=100000 priority=100 remaining=not_started runtime=0:00:07 sanity=False started=45 submitted=20260427-231030 timeout=5400 username=ak_encrypt_permission`
