### PR TITLE
Add counters for DD and MoveKeys transactions (PR #13062 forward-ported to main)

### DIFF
--- a/fdbserver/core/MoveKeys.cpp
+++ b/fdbserver/core/MoveKeys.cpp
@@ -34,7 +34,7 @@
 #include "fdbserver/core/Knobs.h"
 #include "fdbclient/ReadYourWrites.h"
 #include "fdbserver/core/TSSMappingUtil.h"
-#include "flow/SimpleCounter.h"
+#include "flow/TxnCounters.h"
 
 template <typename... T>
 static inline void dprint(fmt::format_string<T...> fmt, T&&... args) {
@@ -277,26 +277,11 @@ Future<MoveKeysLock> readMoveKeysLock(Database cx) {
 	}
 }
 
-static SimpleCounter<int64_t>* counterTakeMoveKeysLockStarted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/takeMoveKeysLock/started");
-	return c;
-}
-static SimpleCounter<int64_t>* counterTakeMoveKeysLockCommitted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/takeMoveKeysLock/committed");
-	return c;
-}
-static SimpleCounter<int64_t>* counterTakeMoveKeysLockAborted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/takeMoveKeysLock/aborted");
-	return c;
-}
-
 Future<MoveKeysLock> takeMoveKeysLock(Database cx, UID ddId) {
-	auto* txnStarted = counterTakeMoveKeysLockStarted();
-	auto* txnCommitted = counterTakeMoveKeysLockCommitted();
-	auto* txnAborted = counterTakeMoveKeysLockAborted();
+	static auto* counters = makeCounters("/movekeys/takeMoveKeysLock");
 	Transaction tr(cx);
 	while (true) {
-		txnStarted->increment(1);
+		counters->started->increment(1);
 		Error err;
 		try {
 			MoveKeysLock lock;
@@ -312,7 +297,7 @@ Future<MoveKeysLock> takeMoveKeysLock(Database cx, UID ddId) {
 			lock.myOwner = deterministicRandom()->randomUniqueID();
 			tr.set(moveKeysLockOwnerKey, BinaryWriter::toValue(lock.myOwner, Unversioned()));
 			co_await tr.commit();
-			txnCommitted->increment(1);
+			counters->committed->increment(1);
 			TraceEvent("TakeMoveKeysLockTransaction", ddId)
 			    .detail("TransactionUID", txnId)
 			    .detail("PrevOwner", lock.prevOwner.toString())
@@ -320,7 +305,7 @@ Future<MoveKeysLock> takeMoveKeysLock(Database cx, UID ddId) {
 			    .detail("MyOwner", lock.myOwner.toString());
 			co_return lock;
 		} catch (Error& e) {
-			txnAborted->increment(1);
+			counters->aborted->increment(1);
 			err = e;
 		}
 		co_await tr.onError(err);
@@ -690,18 +675,6 @@ Future<Void> auditLocationMetadataPostCheck(Database occ, KeyRange range, std::s
 }
 
 // Cleans up dest servers of a single shard, and unassigns the keyrange from the dest servers if necessary.
-static SimpleCounter<int64_t>* counterCleanUpSingleShardDataMoveStarted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/cleanUpSingleShardDataMove/started");
-	return c;
-}
-static SimpleCounter<int64_t>* counterCleanUpSingleShardDataMoveCommitted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/cleanUpSingleShardDataMove/committed");
-	return c;
-}
-static SimpleCounter<int64_t>* counterCleanUpSingleShardDataMoveAborted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/cleanUpSingleShardDataMove/aborted");
-	return c;
-}
 Future<Void> cleanUpSingleShardDataMove(Database occ,
                                         KeyRange keys,
                                         MoveKeysLock lock,
@@ -710,14 +683,12 @@ Future<Void> cleanUpSingleShardDataMove(Database occ,
                                         const DDEnabledState* ddEnabledState) {
 	ASSERT(SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA);
 	TraceEvent(SevInfo, "CleanUpSingleShardDataMoveBegin", dataMoveId).detail("Range", keys);
-	auto* txnStarted = counterCleanUpSingleShardDataMoveStarted();
-	auto* txnCommitted = counterCleanUpSingleShardDataMoveCommitted();
-	auto* txnAborted = counterCleanUpSingleShardDataMoveAborted();
+	static auto* counters = makeCounters("/movekeys/cleanUpSingleShardDataMove");
 
 	bool runPreCheck = true;
 
 	while (true) {
-		txnStarted->increment(1);
+		counters->started->increment(1);
 		Transaction tr(occ);
 
 		Error err;
@@ -780,7 +751,7 @@ Future<Void> cleanUpSingleShardDataMove(Database occ,
 			co_await waitForAll(actors);
 
 			co_await tr.commit();
-			txnCommitted->increment(1);
+			counters->committed->increment(1);
 
 			// Post validate consistency of update of keyServers and serverKeys
 			if (SERVER_KNOBS->AUDIT_DATAMOVE_POST_CHECK) {
@@ -788,7 +759,7 @@ Future<Void> cleanUpSingleShardDataMove(Database occ,
 			}
 			break;
 		} catch (Error& e) {
-			txnAborted->increment(1);
+			counters->aborted->increment(1);
 			err = e;
 		}
 		if (err.code() == error_code_location_metadata_corruption) {
@@ -998,18 +969,6 @@ Future<Void> logWarningAfter(const char* context, double duration, std::vector<U
 // subrange of keys that the server did not already have, = complete for each subrange that it already has. Set
 // serverKeys[dest][keys] = "" for the dest servers of each existing shard in keys (unless that destination is a member
 // of servers OR if the source list is sufficiently degraded)
-static SimpleCounter<int64_t>* counterStartMoveKeysStarted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/startMoveKeys/started");
-	return c;
-}
-static SimpleCounter<int64_t>* counterStartMoveKeysCommitted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/startMoveKeys/committed");
-	return c;
-}
-static SimpleCounter<int64_t>* counterStartMoveKeysAborted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/startMoveKeys/aborted");
-	return c;
-}
 static Future<Void> startMoveKeys(Database occ,
                                   KeyRange keys,
                                   std::vector<UID> servers,
@@ -1021,9 +980,7 @@ static Future<Void> startMoveKeys(Database occ,
 	TraceInterval interval("RelocateShard_StartMoveKeys");
 	Future<Void> warningLogger = logWarningAfter("StartMoveKeysTooLong", 600, servers);
 	// state TraceInterval waitInterval("");
-	auto* txnStarted = counterStartMoveKeysStarted();
-	auto* txnCommitted = counterStartMoveKeysCommitted();
-	auto* txnAborted = counterStartMoveKeysAborted();
+	static auto* counters = makeCounters("/movekeys/startMoveKeys");
 
 	co_await startMoveKeysLock->take(TaskPriority::DataDistributionLaunch);
 	FlowLock::Releaser releaser(*startMoveKeysLock);
@@ -1049,7 +1006,7 @@ static Future<Void> startMoveKeys(Database occ,
 			int retries = 0;
 
 			while (true) {
-				txnStarted->increment(1);
+				counters->started->increment(1);
 				Error err;
 				try {
 					retries++;
@@ -1180,7 +1137,7 @@ static Future<Void> startMoveKeys(Database occ,
 					co_await waitForAll(actors);
 
 					co_await tr->commit();
-					txnCommitted->increment(1);
+					counters->committed->increment(1);
 
 					/*TraceEvent("StartMoveKeysCommitDone", relocationIntervalId)
 					    .detail("CommitVersion", tr.getCommittedVersion())
@@ -1189,7 +1146,7 @@ static Future<Void> startMoveKeys(Database occ,
 					shards += old.size() - 1;
 					break;
 				} catch (Error& e) {
-					txnAborted->increment(1);
+					counters->aborted->increment(1);
 					err = e;
 				}
 				if (err.code() == error_code_move_to_removed_server)
@@ -1325,18 +1282,6 @@ Future<Void> checkFetchingState(Database cx,
 // keyServers[k].dest must be the same for all k in keys
 // Set serverKeys[dest][keys] = true; serverKeys[src][keys] = false for all src not in dest
 // Should be cancelled and restarted if keyServers[keys].dest changes (?so this is no longer true?)
-static SimpleCounter<int64_t>* counterFinishMoveKeysStarted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/finishMoveKeys/started");
-	return c;
-}
-static SimpleCounter<int64_t>* counterFinishMoveKeysCommitted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/finishMoveKeys/committed");
-	return c;
-}
-static SimpleCounter<int64_t>* counterFinishMoveKeysAborted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/finishMoveKeys/aborted");
-	return c;
-}
 static Future<Void> finishMoveKeys(Database occ,
                                    KeyRange keys,
                                    std::vector<UID> destinationTeam,
@@ -1349,9 +1294,7 @@ static Future<Void> finishMoveKeys(Database occ,
 	TraceInterval interval("RelocateShard_FinishMoveKeys");
 	TraceInterval waitInterval("");
 	Future<Void> warningLogger = logWarningAfter("FinishMoveKeysTooLong", 600, destinationTeam);
-	auto* txnStarted = counterFinishMoveKeysStarted();
-	auto* txnCommitted = counterFinishMoveKeysCommitted();
-	auto* txnAborted = counterFinishMoveKeysAborted();
+	static auto* counters = makeCounters("/movekeys/finishMoveKeys");
 	Key begin = keys.begin;
 	Key endKey;
 	int retries = 0;
@@ -1376,7 +1319,7 @@ static Future<Void> finishMoveKeys(Database occ,
 			Transaction tr(occ);
 
 			while (true) {
-				txnStarted->increment(1);
+				counters->started->increment(1);
 				Error err;
 				try {
 					tr.trState->taskID = TaskPriority::MoveKeys;
@@ -1651,7 +1594,7 @@ static Future<Void> finishMoveKeys(Database occ,
 
 						co_await waitForAll(actors);
 						co_await tr.commit();
-						txnCommitted->increment(1);
+						counters->committed->increment(1);
 
 						begin = endKey;
 						break;
@@ -1661,7 +1604,7 @@ static Future<Void> finishMoveKeys(Database occ,
 					tr.reset();
 					continue;
 				} catch (Error& error) {
-					txnAborted->increment(1);
+					counters->aborted->increment(1);
 					err = error;
 				}
 				if (err.code() == error_code_actor_cancelled)
@@ -1694,18 +1637,6 @@ static Future<Void> finishMoveKeys(Database occ,
 // Set keyServers[keys].dest = servers Set serverKeys[servers][keys] = dataMoveId for each
 // subrange of keys.
 // Set dataMoves[dataMoveId] = DataMoveMetaData.
-static SimpleCounter<int64_t>* counterStartMoveShardsStarted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/startMoveShards/started");
-	return c;
-}
-static SimpleCounter<int64_t>* counterStartMoveShardsCommitted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/startMoveShards/committed");
-	return c;
-}
-static SimpleCounter<int64_t>* counterStartMoveShardsAborted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/startMoveShards/aborted");
-	return c;
-}
 static Future<Void> startMoveShards(Database occ,
                                     UID dataMoveId,
                                     std::vector<KeyRange> ranges,
@@ -1718,9 +1649,7 @@ static Future<Void> startMoveShards(Database occ,
                                     CancelConflictingDataMoves cancelConflictingDataMoves,
                                     Optional<BulkLoadTaskState> bulkLoadTaskState) {
 	Future<Void> warningLogger = logWarningAfter("StartMoveShardsTooLong", 600, servers);
-	auto* txnStarted = counterStartMoveShardsStarted();
-	auto* txnCommitted = counterStartMoveShardsCommitted();
-	auto* txnAborted = counterStartMoveShardsAborted();
+	static auto* counters = makeCounters("/movekeys/startMoveShards");
 	co_await startMoveKeysLock->take(TaskPriority::DataDistributionLaunch);
 	FlowLock::Releaser releaser(*startMoveKeysLock);
 	bool loadedTssMapping = false;
@@ -1739,7 +1668,7 @@ static Future<Void> startMoveShards(Database occ,
 	bool runPreCheck = true;
 	try {
 		while (true) {
-			txnStarted->increment(1);
+			counters->started->increment(1);
 			Key begin = keys.begin;
 			KeyRange currentKeys = keys;
 
@@ -2017,7 +1946,7 @@ static Future<Void> startMoveShards(Database occ,
 				co_await waitForAll(actors);
 
 				co_await tr.commit();
-				txnCommitted->increment(1);
+				counters->committed->increment(1);
 
 				if (currentKeys.end == keys.end && bulkLoadTaskState.present()) {
 					Version commitVersion = tr.getCommittedVersion();
@@ -2049,7 +1978,7 @@ static Future<Void> startMoveShards(Database occ,
 				}
 				continue;
 			} catch (Error& e) {
-				txnAborted->increment(1);
+				counters->aborted->increment(1);
 				err = e;
 			}
 			if (err.code() == error_code_location_metadata_corruption) {
@@ -2145,18 +2074,6 @@ static Future<Void> checkDataMoveComplete(Database occ, UID dataMoveId, KeyRange
 // keyServers[k].dest must be the same for all k in keys.
 // Set serverKeys[dest][keys] = dataMoveId; serverKeys[src][keys] = false for all src not in dest.
 // Clear dataMoves[dataMoveId].
-static SimpleCounter<int64_t>* counterFinishMoveShardsStarted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/finishMoveShards/started");
-	return c;
-}
-static SimpleCounter<int64_t>* counterFinishMoveShardsCommitted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/finishMoveShards/committed");
-	return c;
-}
-static SimpleCounter<int64_t>* counterFinishMoveShardsAborted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/finishMoveShards/aborted");
-	return c;
-}
 static Future<Void> finishMoveShards(Database occ,
                                      UID dataMoveId,
                                      std::vector<KeyRange> targetRanges,
@@ -2172,9 +2089,7 @@ static Future<Void> finishMoveShards(Database occ,
 	ASSERT(targetRanges.size() == 1);
 	KeyRange keys = targetRanges[0];
 	Future<Void> warningLogger = logWarningAfter("FinishMoveShardsTooLong", 600, destinationTeam);
-	auto* txnStarted = counterFinishMoveShardsStarted();
-	auto* txnCommitted = counterFinishMoveShardsCommitted();
-	auto* txnAborted = counterFinishMoveShardsAborted();
+	static auto* counters = makeCounters("/movekeys/finishMoveShards");
 	int retries = 0;
 	DataMoveMetaData dataMove;
 	bool cancelDataMove = false;
@@ -2196,7 +2111,7 @@ static Future<Void> finishMoveShards(Database occ,
 		// This process can be split up into multiple transactions if getRange() doesn't return the entire
 		// target range.
 		while (true) {
-			txnStarted->increment(1);
+			counters->started->increment(1);
 			std::vector<UID> completeSrc;
 			std::vector<UID> destServers;
 			std::unordered_set<UID> allServers;
@@ -2484,7 +2399,7 @@ static Future<Void> finishMoveShards(Database occ,
 					}
 
 					co_await tr.commit();
-					txnCommitted->increment(1);
+					counters->committed->increment(1);
 
 					if (range.end == dataMove.ranges.front().end && bulkLoadTaskState.present()) {
 						Version commitVersion = tr.getCommittedVersion();
@@ -2511,7 +2426,7 @@ static Future<Void> finishMoveShards(Database occ,
 					continue;
 				}
 			} catch (Error& error) {
-				txnAborted->increment(1);
+				counters->aborted->increment(1);
 				err = error;
 			}
 			TraceEvent(SevWarn, "TryFinishMoveShardsError", relocationIntervalId)
@@ -2551,22 +2466,8 @@ static Future<Void> finishMoveShards(Database occ,
 
 }; // anonymous namespace
 
-static SimpleCounter<int64_t>* counterAddStorageServerStarted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/addStorageServer/started");
-	return c;
-}
-static SimpleCounter<int64_t>* counterAddStorageServerCommitted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/addStorageServer/committed");
-	return c;
-}
-static SimpleCounter<int64_t>* counterAddStorageServerAborted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/addStorageServer/aborted");
-	return c;
-}
 Future<std::pair<Version, Tag>> addStorageServer(Database cx, StorageServerInterface server) {
-	auto* txnStarted = counterAddStorageServerStarted();
-	auto* txnCommitted = counterAddStorageServerCommitted();
-	auto* txnAborted = counterAddStorageServerAborted();
+	static auto* counters = makeCounters("/movekeys/addStorageServer");
 	auto tr = makeReference<ReadYourWritesTransaction>(cx);
 	KeyBackedMap<UID, UID> tssMapDB = KeyBackedMap<UID, UID>(tssMappingKeys.begin);
 	KeyBackedObjectMap<UID, StorageMetadataType, decltype(IncludeVersion())> metadataMap(serverMetadataKeys.begin,
@@ -2575,7 +2476,7 @@ Future<std::pair<Version, Tag>> addStorageServer(Database cx, StorageServerInter
 	int maxSkipTags = 1;
 
 	while (true) {
-		txnStarted->increment(1);
+		counters->started->increment(1);
 		Error err;
 		try {
 			tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
@@ -2735,14 +2636,14 @@ Future<std::pair<Version, Tag>> addStorageServer(Database cx, StorageServerInter
 
 			tr->set(serverListKeyFor(server.id()), serverListValue(server));
 			co_await tr->commit();
-			txnCommitted->increment(1);
+			counters->committed->increment(1);
 			TraceEvent("AddedStorageServerSystemKey")
 			    .detail("ServerID", server.id())
 			    .detail("CommitVersion", tr->getCommittedVersion());
 
 			co_return std::make_pair(tr->getCommittedVersion(), tag);
 		} catch (Error& e) {
-			txnAborted->increment(1);
+			counters->aborted->increment(1);
 			err = e;
 		}
 		if (err.code() == error_code_commit_unknown_result)
@@ -2786,26 +2687,12 @@ Future<bool> canRemoveStorageServer(Reference<ReadYourWritesTransaction> tr, UID
 	co_return !assigned && keys[1].key == allKeys.end;
 }
 
-static SimpleCounter<int64_t>* counterRemoveStorageServerStarted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/removeStorageServer/started");
-	return c;
-}
-static SimpleCounter<int64_t>* counterRemoveStorageServerCommitted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/removeStorageServer/committed");
-	return c;
-}
-static SimpleCounter<int64_t>* counterRemoveStorageServerAborted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/removeStorageServer/aborted");
-	return c;
-}
 Future<Void> removeStorageServer(Database cx,
                                  UID serverID,
                                  Optional<UID> tssPairID,
                                  MoveKeysLock lock,
                                  const DDEnabledState* ddEnabledState) {
-	auto* txnStarted = counterRemoveStorageServerStarted();
-	auto* txnCommitted = counterRemoveStorageServerCommitted();
-	auto* txnAborted = counterRemoveStorageServerAborted();
+	static auto* counters = makeCounters("/movekeys/removeStorageServer");
 	KeyBackedMap<UID, UID> tssMapDB = KeyBackedMap<UID, UID>(tssMappingKeys.begin);
 	KeyBackedObjectMap<UID, StorageMigrationType, decltype(IncludeVersion())> metadataMap(serverMetadataKeys.begin,
 	                                                                                      IncludeVersion());
@@ -2814,7 +2701,7 @@ Future<Void> removeStorageServer(Database cx,
 	int noCanRemoveCount = 0;
 
 	while (true) {
-		txnStarted->increment(1);
+		counters->started->increment(1);
 		Error err;
 		try {
 			tr->setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
@@ -2914,7 +2801,7 @@ Future<Void> removeStorageServer(Database cx,
 
 				retry = true;
 				co_await tr->commit();
-				txnCommitted->increment(1);
+				counters->committed->increment(1);
 				TraceEvent("RemoveStorageServer")
 				    .detail("State", "Success")
 				    .detail("ServerID", serverID)
@@ -2922,7 +2809,7 @@ Future<Void> removeStorageServer(Database cx,
 				co_return;
 			}
 		} catch (Error& e) {
-			txnAborted->increment(1);
+			counters->aborted->increment(1);
 			err = e;
 		}
 		co_await tr->onError(err);
@@ -2933,26 +2820,12 @@ Future<Void> removeStorageServer(Database cx,
 // Changes to keyServer and serverKey must happen symmetrically in a transaction.
 // If serverID is the last source server for a shard, the shard will be erased, and then be assigned
 // to teamForDroppedRange.
-static SimpleCounter<int64_t>* counterRemoveKeysFromFailedServerStarted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/removeKeysFromFailedServer/started");
-	return c;
-}
-static SimpleCounter<int64_t>* counterRemoveKeysFromFailedServerCommitted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/removeKeysFromFailedServer/committed");
-	return c;
-}
-static SimpleCounter<int64_t>* counterRemoveKeysFromFailedServerAborted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/removeKeysFromFailedServer/aborted");
-	return c;
-}
 Future<Void> removeKeysFromFailedServer(Database cx,
                                         UID serverID,
                                         std::vector<UID> teamForDroppedRange,
                                         MoveKeysLock lock,
                                         const DDEnabledState* ddEnabledState) {
-	auto* txnStarted = counterRemoveKeysFromFailedServerStarted();
-	auto* txnCommitted = counterRemoveKeysFromFailedServerCommitted();
-	auto* txnAborted = counterRemoveKeysFromFailedServerAborted();
+	static auto* counters = makeCounters("/movekeys/removeKeysFromFailedServer");
 	Key begin = allKeys.begin;
 
 	std::vector<UID> src;
@@ -2963,7 +2836,7 @@ Future<Void> removeKeysFromFailedServer(Database cx,
 	while (begin < allKeys.end) {
 		Transaction tr(cx);
 		while (true) {
-			txnStarted->increment(1);
+			counters->started->increment(1);
 			Error err;
 			try {
 				tr.trState->taskID = TaskPriority::MoveKeys;
@@ -3113,7 +2986,7 @@ Future<Void> removeKeysFromFailedServer(Database cx,
 				co_await krmSetRangeCoalescing(
 				    &tr, serverKeysPrefixFor(serverID), currentKeys, allKeys, serverKeysFalse);
 				co_await tr.commit();
-				txnCommitted->increment(1);
+				counters->committed->increment(1);
 				TraceEvent(SevDebug, "FailedServerCommitSuccess", serverID)
 				    .detail("Begin", currentKeys.begin)
 				    .detail("End", currentKeys.end)
@@ -3122,7 +2995,7 @@ Future<Void> removeKeysFromFailedServer(Database cx,
 				begin = currentKeys.end;
 				break;
 			} catch (Error& e) {
-				txnAborted->increment(1);
+				counters->aborted->increment(1);
 				err = e;
 			}
 			TraceEvent("FailedServerError", serverID).error(err);
@@ -3150,18 +3023,6 @@ Future<Void> removeKeysFromFailedServer(Database cx,
 // the place holder on the metadata put by cleanUpDataMoveCore. Then, startMoveShard gives up and exits.
 // No update to the metadata by the startMoveShard
 // For all three cases, the background cleanup only needs to cleanup the place holder
-static SimpleCounter<int64_t>* counterCleanUpDataMoveBackgroundStarted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/cleanUpDataMoveBackground/started");
-	return c;
-}
-static SimpleCounter<int64_t>* counterCleanUpDataMoveBackgroundCommitted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/cleanUpDataMoveBackground/committed");
-	return c;
-}
-static SimpleCounter<int64_t>* counterCleanUpDataMoveBackgroundAborted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/cleanUpDataMoveBackground/aborted");
-	return c;
-}
 Future<Void> cleanUpDataMoveBackground(Database occ,
                                        UID dataMoveId,
                                        MoveKeysLock lock,
@@ -3169,9 +3030,7 @@ Future<Void> cleanUpDataMoveBackground(Database occ,
                                        KeyRange keys,
                                        const DDEnabledState* ddEnabledState,
                                        double delaySeconds) {
-	auto* txnStarted = counterCleanUpDataMoveBackgroundStarted();
-	auto* txnCommitted = counterCleanUpDataMoveBackgroundCommitted();
-	auto* txnAborted = counterCleanUpDataMoveBackgroundAborted();
+	static auto* counters = makeCounters("/movekeys/cleanUpDataMoveBackground");
 	co_await delay(std::max(10.0, delaySeconds));
 	TraceEvent(SevDebug, "CleanUpDataMoveBackgroundBegin", dataMoveId)
 	    .detail("DataMoveID", dataMoveId)
@@ -3181,7 +3040,7 @@ Future<Void> cleanUpDataMoveBackground(Database occ,
 	DataMoveMetaData dataMove;
 	Transaction tr(occ);
 	while (true) {
-		txnStarted->increment(1);
+		counters->started->increment(1);
 		Error err;
 		try {
 			tr.trState->taskID = TaskPriority::MoveKeys;
@@ -3198,10 +3057,10 @@ Future<Void> cleanUpDataMoveBackground(Database occ,
 			ASSERT(dataMove.getPhase() == DataMoveMetaData::Deleting);
 			tr.clear(dataMoveKeyFor(dataMoveId));
 			co_await tr.commit();
-			txnCommitted->increment(1);
+			counters->committed->increment(1);
 			break;
 		} catch (Error& e) {
-			txnAborted->increment(1);
+			counters->aborted->increment(1);
 			err = e;
 		}
 		TraceEvent(SevWarn, "CleanUpDataMoveBackgroundFail", dataMoveId).errorUnsuppressed(err);
@@ -3213,27 +3072,13 @@ Future<Void> cleanUpDataMoveBackground(Database occ,
 	    .detail("DataMoveRange", keys);
 }
 
-static SimpleCounter<int64_t>* counterCleanUpDataMoveCoreStarted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/cleanUpDataMoveCore/started");
-	return c;
-}
-static SimpleCounter<int64_t>* counterCleanUpDataMoveCoreCommitted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/cleanUpDataMoveCore/committed");
-	return c;
-}
-static SimpleCounter<int64_t>* counterCleanUpDataMoveCoreAborted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/cleanUpDataMoveCore/aborted");
-	return c;
-}
 Future<Void> cleanUpDataMoveCore(Database occ,
                                  UID dataMoveId,
                                  MoveKeysLock lock,
                                  FlowLock* cleanUpDataMoveParallelismLock,
                                  KeyRange keys,
                                  const DDEnabledState* ddEnabledState) {
-	auto* txnStarted = counterCleanUpDataMoveCoreStarted();
-	auto* txnCommitted = counterCleanUpDataMoveCoreCommitted();
-	auto* txnAborted = counterCleanUpDataMoveCoreAborted();
+	static auto* counters = makeCounters("/movekeys/cleanUpDataMoveCore");
 	KeyRange range;
 	Severity sevDm = static_cast<Severity>(SERVER_KNOBS->PHYSICAL_SHARD_MOVE_LOG_SEVERITY);
 	TraceEvent(SevInfo, "CleanUpDataMoveBegin", dataMoveId).detail("DataMoveID", dataMoveId).detail("Range", keys);
@@ -3245,7 +3090,7 @@ Future<Void> cleanUpDataMoveCore(Database occ,
 
 	try {
 		while (true) {
-			txnStarted->increment(1);
+			counters->started->increment(1);
 			Transaction tr(occ);
 			std::unordered_map<UID, std::vector<Shard>> physicalShardMap;
 			std::set<UID> oldDests;
@@ -3384,7 +3229,7 @@ Future<Void> cleanUpDataMoveCore(Database occ,
 				co_await waitForAll(actors);
 
 				co_await tr.commit();
-				txnCommitted->increment(1);
+				counters->committed->increment(1);
 
 				TraceEvent(sevDm, "CleanUpDataMoveCommitted", dataMoveId)
 				    .detail("DataMoveID", dataMoveId)
@@ -3400,7 +3245,7 @@ Future<Void> cleanUpDataMoveCore(Database occ,
 				}
 				continue;
 			} catch (Error& e) {
-				txnAborted->increment(1);
+				counters->aborted->increment(1);
 				err = e;
 			}
 			if (err.code() == error_code_location_metadata_corruption) {

--- a/fdbserver/core/MoveKeys.cpp
+++ b/fdbserver/core/MoveKeys.cpp
@@ -34,6 +34,7 @@
 #include "fdbserver/core/Knobs.h"
 #include "fdbclient/ReadYourWrites.h"
 #include "fdbserver/core/TSSMappingUtil.h"
+#include "flow/SimpleCounter.h"
 
 template <typename... T>
 static inline void dprint(fmt::format_string<T...> fmt, T&&... args) {
@@ -276,9 +277,26 @@ Future<MoveKeysLock> readMoveKeysLock(Database cx) {
 	}
 }
 
+static SimpleCounter<int64_t>* counterTakeMoveKeysLockStarted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/takeMoveKeysLock/started");
+	return c;
+}
+static SimpleCounter<int64_t>* counterTakeMoveKeysLockCommitted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/takeMoveKeysLock/committed");
+	return c;
+}
+static SimpleCounter<int64_t>* counterTakeMoveKeysLockAborted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/takeMoveKeysLock/aborted");
+	return c;
+}
+
 Future<MoveKeysLock> takeMoveKeysLock(Database cx, UID ddId) {
+	auto* txnStarted = counterTakeMoveKeysLockStarted();
+	auto* txnCommitted = counterTakeMoveKeysLockCommitted();
+	auto* txnAborted = counterTakeMoveKeysLockAborted();
 	Transaction tr(cx);
 	while (true) {
+		txnStarted->increment(1);
 		Error err;
 		try {
 			MoveKeysLock lock;
@@ -294,6 +312,7 @@ Future<MoveKeysLock> takeMoveKeysLock(Database cx, UID ddId) {
 			lock.myOwner = deterministicRandom()->randomUniqueID();
 			tr.set(moveKeysLockOwnerKey, BinaryWriter::toValue(lock.myOwner, Unversioned()));
 			co_await tr.commit();
+			txnCommitted->increment(1);
 			TraceEvent("TakeMoveKeysLockTransaction", ddId)
 			    .detail("TransactionUID", txnId)
 			    .detail("PrevOwner", lock.prevOwner.toString())
@@ -301,6 +320,7 @@ Future<MoveKeysLock> takeMoveKeysLock(Database cx, UID ddId) {
 			    .detail("MyOwner", lock.myOwner.toString());
 			co_return lock;
 		} catch (Error& e) {
+			txnAborted->increment(1);
 			err = e;
 		}
 		co_await tr.onError(err);
@@ -670,6 +690,18 @@ Future<Void> auditLocationMetadataPostCheck(Database occ, KeyRange range, std::s
 }
 
 // Cleans up dest servers of a single shard, and unassigns the keyrange from the dest servers if necessary.
+static SimpleCounter<int64_t>* counterCleanUpSingleShardDataMoveStarted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/cleanUpSingleShardDataMove/started");
+	return c;
+}
+static SimpleCounter<int64_t>* counterCleanUpSingleShardDataMoveCommitted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/cleanUpSingleShardDataMove/committed");
+	return c;
+}
+static SimpleCounter<int64_t>* counterCleanUpSingleShardDataMoveAborted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/cleanUpSingleShardDataMove/aborted");
+	return c;
+}
 Future<Void> cleanUpSingleShardDataMove(Database occ,
                                         KeyRange keys,
                                         MoveKeysLock lock,
@@ -678,10 +710,14 @@ Future<Void> cleanUpSingleShardDataMove(Database occ,
                                         const DDEnabledState* ddEnabledState) {
 	ASSERT(SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA);
 	TraceEvent(SevInfo, "CleanUpSingleShardDataMoveBegin", dataMoveId).detail("Range", keys);
+	auto* txnStarted = counterCleanUpSingleShardDataMoveStarted();
+	auto* txnCommitted = counterCleanUpSingleShardDataMoveCommitted();
+	auto* txnAborted = counterCleanUpSingleShardDataMoveAborted();
 
 	bool runPreCheck = true;
 
 	while (true) {
+		txnStarted->increment(1);
 		Transaction tr(occ);
 
 		Error err;
@@ -744,6 +780,7 @@ Future<Void> cleanUpSingleShardDataMove(Database occ,
 			co_await waitForAll(actors);
 
 			co_await tr.commit();
+			txnCommitted->increment(1);
 
 			// Post validate consistency of update of keyServers and serverKeys
 			if (SERVER_KNOBS->AUDIT_DATAMOVE_POST_CHECK) {
@@ -751,6 +788,7 @@ Future<Void> cleanUpSingleShardDataMove(Database occ,
 			}
 			break;
 		} catch (Error& e) {
+			txnAborted->increment(1);
 			err = e;
 		}
 		if (err.code() == error_code_location_metadata_corruption) {
@@ -960,6 +998,18 @@ Future<Void> logWarningAfter(const char* context, double duration, std::vector<U
 // subrange of keys that the server did not already have, = complete for each subrange that it already has. Set
 // serverKeys[dest][keys] = "" for the dest servers of each existing shard in keys (unless that destination is a member
 // of servers OR if the source list is sufficiently degraded)
+static SimpleCounter<int64_t>* counterStartMoveKeysStarted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/startMoveKeys/started");
+	return c;
+}
+static SimpleCounter<int64_t>* counterStartMoveKeysCommitted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/startMoveKeys/committed");
+	return c;
+}
+static SimpleCounter<int64_t>* counterStartMoveKeysAborted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/startMoveKeys/aborted");
+	return c;
+}
 static Future<Void> startMoveKeys(Database occ,
                                   KeyRange keys,
                                   std::vector<UID> servers,
@@ -971,6 +1021,9 @@ static Future<Void> startMoveKeys(Database occ,
 	TraceInterval interval("RelocateShard_StartMoveKeys");
 	Future<Void> warningLogger = logWarningAfter("StartMoveKeysTooLong", 600, servers);
 	// state TraceInterval waitInterval("");
+	auto* txnStarted = counterStartMoveKeysStarted();
+	auto* txnCommitted = counterStartMoveKeysCommitted();
+	auto* txnAborted = counterStartMoveKeysAborted();
 
 	co_await startMoveKeysLock->take(TaskPriority::DataDistributionLaunch);
 	FlowLock::Releaser releaser(*startMoveKeysLock);
@@ -996,6 +1049,7 @@ static Future<Void> startMoveKeys(Database occ,
 			int retries = 0;
 
 			while (true) {
+				txnStarted->increment(1);
 				Error err;
 				try {
 					retries++;
@@ -1126,6 +1180,7 @@ static Future<Void> startMoveKeys(Database occ,
 					co_await waitForAll(actors);
 
 					co_await tr->commit();
+					txnCommitted->increment(1);
 
 					/*TraceEvent("StartMoveKeysCommitDone", relocationIntervalId)
 					    .detail("CommitVersion", tr.getCommittedVersion())
@@ -1134,6 +1189,7 @@ static Future<Void> startMoveKeys(Database occ,
 					shards += old.size() - 1;
 					break;
 				} catch (Error& e) {
+					txnAborted->increment(1);
 					err = e;
 				}
 				if (err.code() == error_code_move_to_removed_server)
@@ -1269,6 +1325,18 @@ Future<Void> checkFetchingState(Database cx,
 // keyServers[k].dest must be the same for all k in keys
 // Set serverKeys[dest][keys] = true; serverKeys[src][keys] = false for all src not in dest
 // Should be cancelled and restarted if keyServers[keys].dest changes (?so this is no longer true?)
+static SimpleCounter<int64_t>* counterFinishMoveKeysStarted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/finishMoveKeys/started");
+	return c;
+}
+static SimpleCounter<int64_t>* counterFinishMoveKeysCommitted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/finishMoveKeys/committed");
+	return c;
+}
+static SimpleCounter<int64_t>* counterFinishMoveKeysAborted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/finishMoveKeys/aborted");
+	return c;
+}
 static Future<Void> finishMoveKeys(Database occ,
                                    KeyRange keys,
                                    std::vector<UID> destinationTeam,
@@ -1281,6 +1349,9 @@ static Future<Void> finishMoveKeys(Database occ,
 	TraceInterval interval("RelocateShard_FinishMoveKeys");
 	TraceInterval waitInterval("");
 	Future<Void> warningLogger = logWarningAfter("FinishMoveKeysTooLong", 600, destinationTeam);
+	auto* txnStarted = counterFinishMoveKeysStarted();
+	auto* txnCommitted = counterFinishMoveKeysCommitted();
+	auto* txnAborted = counterFinishMoveKeysAborted();
 	Key begin = keys.begin;
 	Key endKey;
 	int retries = 0;
@@ -1304,8 +1375,8 @@ static Future<Void> finishMoveKeys(Database occ,
 
 			Transaction tr(occ);
 
-			// printf("finishMoveKeys( '%s'-'%s' )\n", begin.toString().c_str(), keys.end.toString().c_str());
 			while (true) {
+				txnStarted->increment(1);
 				Error err;
 				try {
 					tr.trState->taskID = TaskPriority::MoveKeys;
@@ -1580,13 +1651,17 @@ static Future<Void> finishMoveKeys(Database occ,
 
 						co_await waitForAll(actors);
 						co_await tr.commit();
+						txnCommitted->increment(1);
 
 						begin = endKey;
 						break;
 					}
+					// This leads to a count of transactions starting that exceeds the sum of
+					// committed or aborted, but this is intentional here.
 					tr.reset();
 					continue;
 				} catch (Error& error) {
+					txnAborted->increment(1);
 					err = error;
 				}
 				if (err.code() == error_code_actor_cancelled)
@@ -1619,6 +1694,18 @@ static Future<Void> finishMoveKeys(Database occ,
 // Set keyServers[keys].dest = servers Set serverKeys[servers][keys] = dataMoveId for each
 // subrange of keys.
 // Set dataMoves[dataMoveId] = DataMoveMetaData.
+static SimpleCounter<int64_t>* counterStartMoveShardsStarted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/startMoveShards/started");
+	return c;
+}
+static SimpleCounter<int64_t>* counterStartMoveShardsCommitted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/startMoveShards/committed");
+	return c;
+}
+static SimpleCounter<int64_t>* counterStartMoveShardsAborted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/startMoveShards/aborted");
+	return c;
+}
 static Future<Void> startMoveShards(Database occ,
                                     UID dataMoveId,
                                     std::vector<KeyRange> ranges,
@@ -1631,7 +1718,9 @@ static Future<Void> startMoveShards(Database occ,
                                     CancelConflictingDataMoves cancelConflictingDataMoves,
                                     Optional<BulkLoadTaskState> bulkLoadTaskState) {
 	Future<Void> warningLogger = logWarningAfter("StartMoveShardsTooLong", 600, servers);
-
+	auto* txnStarted = counterStartMoveShardsStarted();
+	auto* txnCommitted = counterStartMoveShardsCommitted();
+	auto* txnAborted = counterStartMoveShardsAborted();
 	co_await startMoveKeysLock->take(TaskPriority::DataDistributionLaunch);
 	FlowLock::Releaser releaser(*startMoveKeysLock);
 	bool loadedTssMapping = false;
@@ -1650,6 +1739,7 @@ static Future<Void> startMoveShards(Database occ,
 	bool runPreCheck = true;
 	try {
 		while (true) {
+			txnStarted->increment(1);
 			Key begin = keys.begin;
 			KeyRange currentKeys = keys;
 
@@ -1927,6 +2017,7 @@ static Future<Void> startMoveShards(Database occ,
 				co_await waitForAll(actors);
 
 				co_await tr.commit();
+				txnCommitted->increment(1);
 
 				if (currentKeys.end == keys.end && bulkLoadTaskState.present()) {
 					Version commitVersion = tr.getCommittedVersion();
@@ -1958,6 +2049,7 @@ static Future<Void> startMoveShards(Database occ,
 				}
 				continue;
 			} catch (Error& e) {
+				txnAborted->increment(1);
 				err = e;
 			}
 			if (err.code() == error_code_location_metadata_corruption) {
@@ -2053,6 +2145,18 @@ static Future<Void> checkDataMoveComplete(Database occ, UID dataMoveId, KeyRange
 // keyServers[k].dest must be the same for all k in keys.
 // Set serverKeys[dest][keys] = dataMoveId; serverKeys[src][keys] = false for all src not in dest.
 // Clear dataMoves[dataMoveId].
+static SimpleCounter<int64_t>* counterFinishMoveShardsStarted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/finishMoveShards/started");
+	return c;
+}
+static SimpleCounter<int64_t>* counterFinishMoveShardsCommitted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/finishMoveShards/committed");
+	return c;
+}
+static SimpleCounter<int64_t>* counterFinishMoveShardsAborted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/finishMoveShards/aborted");
+	return c;
+}
 static Future<Void> finishMoveShards(Database occ,
                                      UID dataMoveId,
                                      std::vector<KeyRange> targetRanges,
@@ -2068,6 +2172,9 @@ static Future<Void> finishMoveShards(Database occ,
 	ASSERT(targetRanges.size() == 1);
 	KeyRange keys = targetRanges[0];
 	Future<Void> warningLogger = logWarningAfter("FinishMoveShardsTooLong", 600, destinationTeam);
+	auto* txnStarted = counterFinishMoveShardsStarted();
+	auto* txnCommitted = counterFinishMoveShardsCommitted();
+	auto* txnAborted = counterFinishMoveShardsAborted();
 	int retries = 0;
 	DataMoveMetaData dataMove;
 	bool cancelDataMove = false;
@@ -2089,6 +2196,7 @@ static Future<Void> finishMoveShards(Database occ,
 		// This process can be split up into multiple transactions if getRange() doesn't return the entire
 		// target range.
 		while (true) {
+			txnStarted->increment(1);
 			std::vector<UID> completeSrc;
 			std::vector<UID> destServers;
 			std::unordered_set<UID> allServers;
@@ -2376,6 +2484,7 @@ static Future<Void> finishMoveShards(Database occ,
 					}
 
 					co_await tr.commit();
+					txnCommitted->increment(1);
 
 					if (range.end == dataMove.ranges.front().end && bulkLoadTaskState.present()) {
 						Version commitVersion = tr.getCommittedVersion();
@@ -2402,6 +2511,7 @@ static Future<Void> finishMoveShards(Database occ,
 					continue;
 				}
 			} catch (Error& error) {
+				txnAborted->increment(1);
 				err = error;
 			}
 			TraceEvent(SevWarn, "TryFinishMoveShardsError", relocationIntervalId)
@@ -2441,7 +2551,22 @@ static Future<Void> finishMoveShards(Database occ,
 
 }; // anonymous namespace
 
+static SimpleCounter<int64_t>* counterAddStorageServerStarted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/addStorageServer/started");
+	return c;
+}
+static SimpleCounter<int64_t>* counterAddStorageServerCommitted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/addStorageServer/committed");
+	return c;
+}
+static SimpleCounter<int64_t>* counterAddStorageServerAborted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/addStorageServer/aborted");
+	return c;
+}
 Future<std::pair<Version, Tag>> addStorageServer(Database cx, StorageServerInterface server) {
+	auto* txnStarted = counterAddStorageServerStarted();
+	auto* txnCommitted = counterAddStorageServerCommitted();
+	auto* txnAborted = counterAddStorageServerAborted();
 	auto tr = makeReference<ReadYourWritesTransaction>(cx);
 	KeyBackedMap<UID, UID> tssMapDB = KeyBackedMap<UID, UID>(tssMappingKeys.begin);
 	KeyBackedObjectMap<UID, StorageMetadataType, decltype(IncludeVersion())> metadataMap(serverMetadataKeys.begin,
@@ -2450,6 +2575,7 @@ Future<std::pair<Version, Tag>> addStorageServer(Database cx, StorageServerInter
 	int maxSkipTags = 1;
 
 	while (true) {
+		txnStarted->increment(1);
 		Error err;
 		try {
 			tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
@@ -2609,12 +2735,14 @@ Future<std::pair<Version, Tag>> addStorageServer(Database cx, StorageServerInter
 
 			tr->set(serverListKeyFor(server.id()), serverListValue(server));
 			co_await tr->commit();
+			txnCommitted->increment(1);
 			TraceEvent("AddedStorageServerSystemKey")
 			    .detail("ServerID", server.id())
 			    .detail("CommitVersion", tr->getCommittedVersion());
 
 			co_return std::make_pair(tr->getCommittedVersion(), tag);
 		} catch (Error& e) {
+			txnAborted->increment(1);
 			err = e;
 		}
 		if (err.code() == error_code_commit_unknown_result)
@@ -2658,11 +2786,26 @@ Future<bool> canRemoveStorageServer(Reference<ReadYourWritesTransaction> tr, UID
 	co_return !assigned && keys[1].key == allKeys.end;
 }
 
+static SimpleCounter<int64_t>* counterRemoveStorageServerStarted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/removeStorageServer/started");
+	return c;
+}
+static SimpleCounter<int64_t>* counterRemoveStorageServerCommitted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/removeStorageServer/committed");
+	return c;
+}
+static SimpleCounter<int64_t>* counterRemoveStorageServerAborted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/removeStorageServer/aborted");
+	return c;
+}
 Future<Void> removeStorageServer(Database cx,
                                  UID serverID,
                                  Optional<UID> tssPairID,
                                  MoveKeysLock lock,
                                  const DDEnabledState* ddEnabledState) {
+	auto* txnStarted = counterRemoveStorageServerStarted();
+	auto* txnCommitted = counterRemoveStorageServerCommitted();
+	auto* txnAborted = counterRemoveStorageServerAborted();
 	KeyBackedMap<UID, UID> tssMapDB = KeyBackedMap<UID, UID>(tssMappingKeys.begin);
 	KeyBackedObjectMap<UID, StorageMigrationType, decltype(IncludeVersion())> metadataMap(serverMetadataKeys.begin,
 	                                                                                      IncludeVersion());
@@ -2671,6 +2814,7 @@ Future<Void> removeStorageServer(Database cx,
 	int noCanRemoveCount = 0;
 
 	while (true) {
+		txnStarted->increment(1);
 		Error err;
 		try {
 			tr->setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
@@ -2770,6 +2914,7 @@ Future<Void> removeStorageServer(Database cx,
 
 				retry = true;
 				co_await tr->commit();
+				txnCommitted->increment(1);
 				TraceEvent("RemoveStorageServer")
 				    .detail("State", "Success")
 				    .detail("ServerID", serverID)
@@ -2777,6 +2922,7 @@ Future<Void> removeStorageServer(Database cx,
 				co_return;
 			}
 		} catch (Error& e) {
+			txnAborted->increment(1);
 			err = e;
 		}
 		co_await tr->onError(err);
@@ -2787,11 +2933,26 @@ Future<Void> removeStorageServer(Database cx,
 // Changes to keyServer and serverKey must happen symmetrically in a transaction.
 // If serverID is the last source server for a shard, the shard will be erased, and then be assigned
 // to teamForDroppedRange.
+static SimpleCounter<int64_t>* counterRemoveKeysFromFailedServerStarted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/removeKeysFromFailedServer/started");
+	return c;
+}
+static SimpleCounter<int64_t>* counterRemoveKeysFromFailedServerCommitted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/removeKeysFromFailedServer/committed");
+	return c;
+}
+static SimpleCounter<int64_t>* counterRemoveKeysFromFailedServerAborted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/removeKeysFromFailedServer/aborted");
+	return c;
+}
 Future<Void> removeKeysFromFailedServer(Database cx,
                                         UID serverID,
                                         std::vector<UID> teamForDroppedRange,
                                         MoveKeysLock lock,
                                         const DDEnabledState* ddEnabledState) {
+	auto* txnStarted = counterRemoveKeysFromFailedServerStarted();
+	auto* txnCommitted = counterRemoveKeysFromFailedServerCommitted();
+	auto* txnAborted = counterRemoveKeysFromFailedServerAborted();
 	Key begin = allKeys.begin;
 
 	std::vector<UID> src;
@@ -2802,6 +2963,7 @@ Future<Void> removeKeysFromFailedServer(Database cx,
 	while (begin < allKeys.end) {
 		Transaction tr(cx);
 		while (true) {
+			txnStarted->increment(1);
 			Error err;
 			try {
 				tr.trState->taskID = TaskPriority::MoveKeys;
@@ -2951,6 +3113,7 @@ Future<Void> removeKeysFromFailedServer(Database cx,
 				co_await krmSetRangeCoalescing(
 				    &tr, serverKeysPrefixFor(serverID), currentKeys, allKeys, serverKeysFalse);
 				co_await tr.commit();
+				txnCommitted->increment(1);
 				TraceEvent(SevDebug, "FailedServerCommitSuccess", serverID)
 				    .detail("Begin", currentKeys.begin)
 				    .detail("End", currentKeys.end)
@@ -2959,6 +3122,7 @@ Future<Void> removeKeysFromFailedServer(Database cx,
 				begin = currentKeys.end;
 				break;
 			} catch (Error& e) {
+				txnAborted->increment(1);
 				err = e;
 			}
 			TraceEvent("FailedServerError", serverID).error(err);
@@ -2986,6 +3150,18 @@ Future<Void> removeKeysFromFailedServer(Database cx,
 // the place holder on the metadata put by cleanUpDataMoveCore. Then, startMoveShard gives up and exits.
 // No update to the metadata by the startMoveShard
 // For all three cases, the background cleanup only needs to cleanup the place holder
+static SimpleCounter<int64_t>* counterCleanUpDataMoveBackgroundStarted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/cleanUpDataMoveBackground/started");
+	return c;
+}
+static SimpleCounter<int64_t>* counterCleanUpDataMoveBackgroundCommitted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/cleanUpDataMoveBackground/committed");
+	return c;
+}
+static SimpleCounter<int64_t>* counterCleanUpDataMoveBackgroundAborted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/cleanUpDataMoveBackground/aborted");
+	return c;
+}
 Future<Void> cleanUpDataMoveBackground(Database occ,
                                        UID dataMoveId,
                                        MoveKeysLock lock,
@@ -2993,6 +3169,9 @@ Future<Void> cleanUpDataMoveBackground(Database occ,
                                        KeyRange keys,
                                        const DDEnabledState* ddEnabledState,
                                        double delaySeconds) {
+	auto* txnStarted = counterCleanUpDataMoveBackgroundStarted();
+	auto* txnCommitted = counterCleanUpDataMoveBackgroundCommitted();
+	auto* txnAborted = counterCleanUpDataMoveBackgroundAborted();
 	co_await delay(std::max(10.0, delaySeconds));
 	TraceEvent(SevDebug, "CleanUpDataMoveBackgroundBegin", dataMoveId)
 	    .detail("DataMoveID", dataMoveId)
@@ -3002,6 +3181,7 @@ Future<Void> cleanUpDataMoveBackground(Database occ,
 	DataMoveMetaData dataMove;
 	Transaction tr(occ);
 	while (true) {
+		txnStarted->increment(1);
 		Error err;
 		try {
 			tr.trState->taskID = TaskPriority::MoveKeys;
@@ -3018,8 +3198,10 @@ Future<Void> cleanUpDataMoveBackground(Database occ,
 			ASSERT(dataMove.getPhase() == DataMoveMetaData::Deleting);
 			tr.clear(dataMoveKeyFor(dataMoveId));
 			co_await tr.commit();
+			txnCommitted->increment(1);
 			break;
 		} catch (Error& e) {
+			txnAborted->increment(1);
 			err = e;
 		}
 		TraceEvent(SevWarn, "CleanUpDataMoveBackgroundFail", dataMoveId).errorUnsuppressed(err);
@@ -3031,12 +3213,27 @@ Future<Void> cleanUpDataMoveBackground(Database occ,
 	    .detail("DataMoveRange", keys);
 }
 
+static SimpleCounter<int64_t>* counterCleanUpDataMoveCoreStarted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/cleanUpDataMoveCore/started");
+	return c;
+}
+static SimpleCounter<int64_t>* counterCleanUpDataMoveCoreCommitted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/cleanUpDataMoveCore/committed");
+	return c;
+}
+static SimpleCounter<int64_t>* counterCleanUpDataMoveCoreAborted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/movekeys/cleanUpDataMoveCore/aborted");
+	return c;
+}
 Future<Void> cleanUpDataMoveCore(Database occ,
                                  UID dataMoveId,
                                  MoveKeysLock lock,
                                  FlowLock* cleanUpDataMoveParallelismLock,
                                  KeyRange keys,
                                  const DDEnabledState* ddEnabledState) {
+	auto* txnStarted = counterCleanUpDataMoveCoreStarted();
+	auto* txnCommitted = counterCleanUpDataMoveCoreCommitted();
+	auto* txnAborted = counterCleanUpDataMoveCoreAborted();
 	KeyRange range;
 	Severity sevDm = static_cast<Severity>(SERVER_KNOBS->PHYSICAL_SHARD_MOVE_LOG_SEVERITY);
 	TraceEvent(SevInfo, "CleanUpDataMoveBegin", dataMoveId).detail("DataMoveID", dataMoveId).detail("Range", keys);
@@ -3048,6 +3245,7 @@ Future<Void> cleanUpDataMoveCore(Database occ,
 
 	try {
 		while (true) {
+			txnStarted->increment(1);
 			Transaction tr(occ);
 			std::unordered_map<UID, std::vector<Shard>> physicalShardMap;
 			std::set<UID> oldDests;
@@ -3186,6 +3384,7 @@ Future<Void> cleanUpDataMoveCore(Database occ,
 				co_await waitForAll(actors);
 
 				co_await tr.commit();
+				txnCommitted->increment(1);
 
 				TraceEvent(sevDm, "CleanUpDataMoveCommitted", dataMoveId)
 				    .detail("DataMoveID", dataMoveId)
@@ -3201,6 +3400,7 @@ Future<Void> cleanUpDataMoveCore(Database occ,
 				}
 				continue;
 			} catch (Error& e) {
+				txnAborted->increment(1);
 				err = e;
 			}
 			if (err.code() == error_code_location_metadata_corruption) {

--- a/fdbserver/datadistributor/DDTeamCollection.actor.cpp
+++ b/fdbserver/datadistributor/DDTeamCollection.actor.cpp
@@ -30,7 +30,7 @@
 #include "flow/IRandom.h"
 #include "flow/Trace.h"
 #include "flow/network.h"
-#include "flow/SimpleCounter.h"
+#include "flow/TxnCounters.h"
 
 #include "flow/CoroUtils.h"
 #include "flow/actorcompiler.h" // This must be the last #include.
@@ -76,52 +76,20 @@ int EligibilityCounter::getCount(int combinedType) const {
 
 } // namespace data_distribution
 
-static SimpleCounter<int64_t>* counterUpdateNextWigglingStorageIDStarted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/dd/updateNextWigglingStorageID/started");
+static TxnCounters* updateNextWigglingStorageIDCounters() {
+	static auto* c = makeCounters("/dd/updateNextWigglingStorageID");
 	return c;
 }
-static SimpleCounter<int64_t>* counterUpdateNextWigglingStorageIDCommitted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/dd/updateNextWigglingStorageID/committed");
+static TxnCounters* perpetualStorageWigglerCounters() {
+	static auto* c = makeCounters("/dd/perpetualStorageWiggler");
 	return c;
 }
-static SimpleCounter<int64_t>* counterUpdateNextWigglingStorageIDAborted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/dd/updateNextWigglingStorageID/aborted");
+static TxnCounters* waitHealthyZoneChangeCounters() {
+	static auto* c = makeCounters("/dd/waitHealthyZoneChange");
 	return c;
 }
-static SimpleCounter<int64_t>* counterPerpetualStorageWigglerStarted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/dd/perpetualStorageWiggler/started");
-	return c;
-}
-static SimpleCounter<int64_t>* counterPerpetualStorageWigglerCommitted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/dd/perpetualStorageWiggler/committed");
-	return c;
-}
-static SimpleCounter<int64_t>* counterPerpetualStorageWigglerAborted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/dd/perpetualStorageWiggler/aborted");
-	return c;
-}
-static SimpleCounter<int64_t>* counterWaitHealthyZoneChangeStarted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/dd/waitHealthyZoneChange/started");
-	return c;
-}
-static SimpleCounter<int64_t>* counterWaitHealthyZoneChangeCommitted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/dd/waitHealthyZoneChange/committed");
-	return c;
-}
-static SimpleCounter<int64_t>* counterWaitHealthyZoneChangeAborted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/dd/waitHealthyZoneChange/aborted");
-	return c;
-}
-static SimpleCounter<int64_t>* counterUpdateStorageMetadataStarted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/dd/updateStorageMetadata/started");
-	return c;
-}
-static SimpleCounter<int64_t>* counterUpdateStorageMetadataCommitted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/dd/updateStorageMetadata/committed");
-	return c;
-}
-static SimpleCounter<int64_t>* counterUpdateStorageMetadataAborted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/dd/updateStorageMetadata/aborted");
+static TxnCounters* updateStorageMetadataCounters() {
+	static auto* c = makeCounters("/dd/updateStorageMetadata");
 	return c;
 }
 
@@ -2279,9 +2247,7 @@ public:
 	}
 
 	static Future<Void> updateNextWigglingStorageID(DDTeamCollection* self) {
-		auto* txnStarted = counterUpdateNextWigglingStorageIDStarted();
-		auto* txnCommitted = counterUpdateNextWigglingStorageIDCommitted();
-		auto* txnAborted = counterUpdateNextWigglingStorageIDAborted();
+		auto* counters = updateNextWigglingStorageIDCounters();
 		StorageWiggleData wiggleState;
 		KeyBackedObjectMap<UID, StorageWiggleValue, decltype(IncludeVersion())> metadataMap =
 		    wiggleState.wigglingStorageServer(PrimaryRegion(self->primary));
@@ -2290,17 +2256,17 @@ public:
 		StorageWiggleValue value(nextId);
 		Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(self->dbContext()));
 		while (true) {
-			txnStarted->increment(1);
+			counters->started->increment(1);
 			// write the next server id
 			Error err;
 			try {
 				tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 				metadataMap.set(tr, nextId, value);
 				co_await tr->commit();
-				txnCommitted->increment(1);
+				counters->committed->increment(1);
 				break;
 			} catch (Error& e) {
-				txnAborted->increment(1);
+				counters->aborted->increment(1);
 				err = e;
 			}
 			co_await tr->onError(err);
@@ -2568,9 +2534,7 @@ public:
 	// command `configure perpetual_storage_wiggle=$value` if the value is 1, this actor start 2 actors,
 	// `perpetualStorageWiggleIterator` and `perpetualStorageWiggler`. Otherwise, it sends stop signal to them.
 	static Future<Void> monitorPerpetualStorageWiggle(DDTeamCollection* self) {
-		auto* txnPSWStarted = counterPerpetualStorageWigglerStarted();
-		auto* txnPSWCommitted = counterPerpetualStorageWigglerCommitted();
-		auto* txnPSWAborted = counterPerpetualStorageWigglerAborted();
+		auto* counters = perpetualStorageWigglerCounters();
 		int speed = 0;
 		PromiseStream<Void> finishStorageWiggleSignal;
 		SignalableActorCollection collection;
@@ -2580,7 +2544,7 @@ public:
 		while (true) {
 			ReadYourWritesTransaction tr(self->dbContext());
 			while (true) {
-				txnPSWStarted->increment(1);
+				counters->started->increment(1);
 				Error err;
 				try {
 					tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
@@ -2591,7 +2555,7 @@ public:
 					}
 					Future<Void> watchFuture = tr.watch(perpetualStorageWiggleKey);
 					co_await tr.commit();
-					txnPSWCommitted->increment(1);
+					counters->committed->increment(1);
 
 					ASSERT(speed == 1 || speed == 0);
 					if (speed == 1 && self->storageWiggler->isStopped()) { // avoid duplicated start
@@ -2614,7 +2578,7 @@ public:
 					co_await watchFuture;
 					break;
 				} catch (Error& e) {
-					txnPSWAborted->increment(1);
+					counters->aborted->increment(1);
 					err = e;
 				}
 				co_await tr.onError(err);
@@ -2623,12 +2587,10 @@ public:
 	}
 
 	static Future<Void> waitHealthyZoneChange(DDTeamCollection* self) {
-		auto* txnStarted = counterWaitHealthyZoneChangeStarted();
-		auto* txnCommitted = counterWaitHealthyZoneChangeCommitted();
-		auto* txnAborted = counterWaitHealthyZoneChangeAborted();
+		auto* counters = waitHealthyZoneChangeCounters();
 		ReadYourWritesTransaction tr(self->dbContext());
 		while (true) {
-			txnStarted->increment(1);
+			counters->started->increment(1);
 			Error err;
 			bool hasErr = false;
 			try {
@@ -2671,11 +2633,11 @@ public:
 
 				Future<Void> watchFuture = tr.watch(healthyZoneKey);
 				co_await tr.commit();
-				txnCommitted->increment(1);
+				counters->committed->increment(1);
 				co_await (watchFuture || healthyZoneTimeout);
 				tr.reset();
 			} catch (Error& e) {
-				txnAborted->increment(1);
+				counters->aborted->increment(1);
 				err = e;
 				hasErr = true;
 			}
@@ -3399,9 +3361,7 @@ public:
 	}
 
 	ACTOR static Future<Void> updateStorageMetadata(DDTeamCollection* self, TCServerInfo* server) {
-		state SimpleCounter<int64_t>* txnStarted = counterUpdateStorageMetadataStarted();
-		state SimpleCounter<int64_t>* txnCommitted = counterUpdateStorageMetadataCommitted();
-		state SimpleCounter<int64_t>* txnAborted = counterUpdateStorageMetadataAborted();
+		state TxnCounters* counters = updateStorageMetadataCounters();
 		state KeyBackedObjectMap<UID, StorageMetadataType, decltype(IncludeVersion())> metadataMap(
 		    serverMetadataKeys.begin, IncludeVersion());
 		state Reference<ReadYourWritesTransaction> tr = makeReference<ReadYourWritesTransaction>(self->dbContext());
@@ -3425,7 +3385,7 @@ public:
 
 		// read storage metadata
 		loop {
-			txnStarted->increment(1);
+			counters->started->increment(1);
 			try {
 				tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 				Optional<Value> serverInterfaceValue = wait(tr->get(serverListKeyFor(server->getId())));
@@ -3446,10 +3406,10 @@ public:
 				metadataMap.set(tr, server->getId(), data);
 				tr->set(serverMetadataChangeKey, deterministicRandom()->randomUniqueID().toString());
 				wait(tr->commit());
-				txnCommitted->increment(1);
+				counters->committed->increment(1);
 				break;
 			} catch (Error& e) {
-				txnAborted->increment(1);
+				counters->aborted->increment(1);
 				wait(tr->onError(e));
 			}
 		}

--- a/fdbserver/datadistributor/DDTeamCollection.actor.cpp
+++ b/fdbserver/datadistributor/DDTeamCollection.actor.cpp
@@ -30,6 +30,7 @@
 #include "flow/IRandom.h"
 #include "flow/Trace.h"
 #include "flow/network.h"
+#include "flow/SimpleCounter.h"
 
 #include "flow/CoroUtils.h"
 #include "flow/actorcompiler.h" // This must be the last #include.
@@ -74,6 +75,55 @@ int EligibilityCounter::getCount(int combinedType) const {
 }
 
 } // namespace data_distribution
+
+static SimpleCounter<int64_t>* counterUpdateNextWigglingStorageIDStarted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/dd/updateNextWigglingStorageID/started");
+	return c;
+}
+static SimpleCounter<int64_t>* counterUpdateNextWigglingStorageIDCommitted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/dd/updateNextWigglingStorageID/committed");
+	return c;
+}
+static SimpleCounter<int64_t>* counterUpdateNextWigglingStorageIDAborted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/dd/updateNextWigglingStorageID/aborted");
+	return c;
+}
+static SimpleCounter<int64_t>* counterPerpetualStorageWigglerStarted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/dd/perpetualStorageWiggler/started");
+	return c;
+}
+static SimpleCounter<int64_t>* counterPerpetualStorageWigglerCommitted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/dd/perpetualStorageWiggler/committed");
+	return c;
+}
+static SimpleCounter<int64_t>* counterPerpetualStorageWigglerAborted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/dd/perpetualStorageWiggler/aborted");
+	return c;
+}
+static SimpleCounter<int64_t>* counterWaitHealthyZoneChangeStarted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/dd/waitHealthyZoneChange/started");
+	return c;
+}
+static SimpleCounter<int64_t>* counterWaitHealthyZoneChangeCommitted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/dd/waitHealthyZoneChange/committed");
+	return c;
+}
+static SimpleCounter<int64_t>* counterWaitHealthyZoneChangeAborted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/dd/waitHealthyZoneChange/aborted");
+	return c;
+}
+static SimpleCounter<int64_t>* counterUpdateStorageMetadataStarted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/dd/updateStorageMetadata/started");
+	return c;
+}
+static SimpleCounter<int64_t>* counterUpdateStorageMetadataCommitted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/dd/updateStorageMetadata/committed");
+	return c;
+}
+static SimpleCounter<int64_t>* counterUpdateStorageMetadataAborted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/dd/updateStorageMetadata/aborted");
+	return c;
+}
 
 class DDTeamCollectionImpl {
 	static Future<Void> checkAndRemoveInvalidLocalityAddr(DDTeamCollection* self) {
@@ -2229,6 +2279,9 @@ public:
 	}
 
 	static Future<Void> updateNextWigglingStorageID(DDTeamCollection* self) {
+		auto* txnStarted = counterUpdateNextWigglingStorageIDStarted();
+		auto* txnCommitted = counterUpdateNextWigglingStorageIDCommitted();
+		auto* txnAborted = counterUpdateNextWigglingStorageIDAborted();
 		StorageWiggleData wiggleState;
 		KeyBackedObjectMap<UID, StorageWiggleValue, decltype(IncludeVersion())> metadataMap =
 		    wiggleState.wigglingStorageServer(PrimaryRegion(self->primary));
@@ -2237,14 +2290,17 @@ public:
 		StorageWiggleValue value(nextId);
 		Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(self->dbContext()));
 		while (true) {
+			txnStarted->increment(1);
 			// write the next server id
 			Error err;
 			try {
 				tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 				metadataMap.set(tr, nextId, value);
 				co_await tr->commit();
+				txnCommitted->increment(1);
 				break;
 			} catch (Error& e) {
+				txnAborted->increment(1);
 				err = e;
 			}
 			co_await tr->onError(err);
@@ -2512,6 +2568,9 @@ public:
 	// command `configure perpetual_storage_wiggle=$value` if the value is 1, this actor start 2 actors,
 	// `perpetualStorageWiggleIterator` and `perpetualStorageWiggler`. Otherwise, it sends stop signal to them.
 	static Future<Void> monitorPerpetualStorageWiggle(DDTeamCollection* self) {
+		auto* txnPSWStarted = counterPerpetualStorageWigglerStarted();
+		auto* txnPSWCommitted = counterPerpetualStorageWigglerCommitted();
+		auto* txnPSWAborted = counterPerpetualStorageWigglerAborted();
 		int speed = 0;
 		PromiseStream<Void> finishStorageWiggleSignal;
 		SignalableActorCollection collection;
@@ -2521,6 +2580,7 @@ public:
 		while (true) {
 			ReadYourWritesTransaction tr(self->dbContext());
 			while (true) {
+				txnPSWStarted->increment(1);
 				Error err;
 				try {
 					tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
@@ -2531,6 +2591,7 @@ public:
 					}
 					Future<Void> watchFuture = tr.watch(perpetualStorageWiggleKey);
 					co_await tr.commit();
+					txnPSWCommitted->increment(1);
 
 					ASSERT(speed == 1 || speed == 0);
 					if (speed == 1 && self->storageWiggler->isStopped()) { // avoid duplicated start
@@ -2553,6 +2614,7 @@ public:
 					co_await watchFuture;
 					break;
 				} catch (Error& e) {
+					txnPSWAborted->increment(1);
 					err = e;
 				}
 				co_await tr.onError(err);
@@ -2561,8 +2623,12 @@ public:
 	}
 
 	static Future<Void> waitHealthyZoneChange(DDTeamCollection* self) {
+		auto* txnStarted = counterWaitHealthyZoneChangeStarted();
+		auto* txnCommitted = counterWaitHealthyZoneChangeCommitted();
+		auto* txnAborted = counterWaitHealthyZoneChangeAborted();
 		ReadYourWritesTransaction tr(self->dbContext());
 		while (true) {
+			txnStarted->increment(1);
 			Error err;
 			bool hasErr = false;
 			try {
@@ -2605,9 +2671,11 @@ public:
 
 				Future<Void> watchFuture = tr.watch(healthyZoneKey);
 				co_await tr.commit();
+				txnCommitted->increment(1);
 				co_await (watchFuture || healthyZoneTimeout);
 				tr.reset();
 			} catch (Error& e) {
+				txnAborted->increment(1);
 				err = e;
 				hasErr = true;
 			}
@@ -3331,6 +3399,9 @@ public:
 	}
 
 	ACTOR static Future<Void> updateStorageMetadata(DDTeamCollection* self, TCServerInfo* server) {
+		state SimpleCounter<int64_t>* txnStarted = counterUpdateStorageMetadataStarted();
+		state SimpleCounter<int64_t>* txnCommitted = counterUpdateStorageMetadataCommitted();
+		state SimpleCounter<int64_t>* txnAborted = counterUpdateStorageMetadataAborted();
 		state KeyBackedObjectMap<UID, StorageMetadataType, decltype(IncludeVersion())> metadataMap(
 		    serverMetadataKeys.begin, IncludeVersion());
 		state Reference<ReadYourWritesTransaction> tr = makeReference<ReadYourWritesTransaction>(self->dbContext());
@@ -3354,6 +3425,7 @@ public:
 
 		// read storage metadata
 		loop {
+			txnStarted->increment(1);
 			try {
 				tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 				Optional<Value> serverInterfaceValue = wait(tr->get(serverListKeyFor(server->getId())));
@@ -3374,8 +3446,10 @@ public:
 				metadataMap.set(tr, server->getId(), data);
 				tr->set(serverMetadataChangeKey, deterministicRandom()->randomUniqueID().toString());
 				wait(tr->commit());
+				txnCommitted->increment(1);
 				break;
 			} catch (Error& e) {
+				txnAborted->increment(1);
 				wait(tr->onError(e));
 			}
 		}

--- a/fdbserver/datadistributor/DDTxnProcessor.cpp
+++ b/fdbserver/datadistributor/DDTxnProcessor.cpp
@@ -23,6 +23,7 @@
 #include "fdbclient/ManagementAPI.h"
 #include "fdbserver/datadistributor/DataDistribution.h"
 #include "fdbclient/DatabaseContext.h"
+#include "flow/SimpleCounter.h"
 #include "flow/CoroUtils.h"
 #include "flow/genericactors.actor.h"
 
@@ -40,6 +41,43 @@ static void updateServersAndCompleteSources(std::set<UID>& servers,
 			}
 		}
 	}
+}
+
+static SimpleCounter<int64_t>* counterUpdateReplicaKeysStarted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/dd/updateReplicaKeys/started");
+	return c;
+}
+static SimpleCounter<int64_t>* counterUpdateReplicaKeysCommitted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/dd/updateReplicaKeys/committed");
+	return c;
+}
+static SimpleCounter<int64_t>* counterUpdateReplicaKeysAborted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/dd/updateReplicaKeys/aborted");
+	return c;
+}
+static SimpleCounter<int64_t>* counterTryUpdateReplicasKeyForDcStarted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/dd/tryUpdateReplicasKeyForDc/started");
+	return c;
+}
+static SimpleCounter<int64_t>* counterTryUpdateReplicasKeyForDcCommitted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/dd/tryUpdateReplicasKeyForDc/committed");
+	return c;
+}
+static SimpleCounter<int64_t>* counterTryUpdateReplicasKeyForDcAborted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/dd/tryUpdateReplicasKeyForDc/aborted");
+	return c;
+}
+static SimpleCounter<int64_t>* counterWaitDDTeamInfoPrintSignalStarted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/dd/waitDDTeamInfoPrintSignal/started");
+	return c;
+}
+static SimpleCounter<int64_t>* counterWaitDDTeamInfoPrintSignalCommitted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/dd/waitDDTeamInfoPrintSignal/committed");
+	return c;
+}
+static SimpleCounter<int64_t>* counterWaitDDTeamInfoPrintSignalAborted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/dd/waitDDTeamInfoPrintSignal/aborted");
+	return c;
 }
 
 class DDTxnProcessorImpl {
@@ -185,8 +223,12 @@ class DDTxnProcessorImpl {
 	                                      std::vector<Optional<Key>> primaryDcId,
 	                                      std::vector<Optional<Key>> remoteDcIds,
 	                                      DatabaseConfiguration configuration) {
+		auto* txnStarted = counterUpdateReplicaKeysStarted();
+		auto* txnCommitted = counterUpdateReplicaKeysCommitted();
+		auto* txnAborted = counterUpdateReplicaKeysAborted();
 		Transaction tr(cx);
 		while (true) {
+			txnStarted->increment(1);
 			Error err;
 			try {
 				tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
@@ -208,8 +250,10 @@ class DDTxnProcessorImpl {
 				}
 
 				co_await tr.commit();
+				txnCommitted->increment(1);
 				break;
 			} catch (Error& e) {
+				txnAborted->increment(1);
 				err = e;
 			}
 			co_await tr.onError(err);
@@ -217,8 +261,12 @@ class DDTxnProcessorImpl {
 	}
 
 	static Future<int> tryUpdateReplicasKeyForDc(Database cx, Optional<Key> dcId, int storageTeamSize) {
+		auto* txnStarted = counterTryUpdateReplicasKeyForDcStarted();
+		auto* txnCommitted = counterTryUpdateReplicasKeyForDcCommitted();
+		auto* txnAborted = counterTryUpdateReplicasKeyForDcAborted();
 		Transaction tr(cx);
 		while (true) {
+			txnStarted->increment(1);
 			tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 			tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
 
@@ -234,9 +282,11 @@ class DDTxnProcessorImpl {
 				}
 				tr.set(datacenterReplicasKeyFor(dcId), datacenterReplicasValue(storageTeamSize));
 				co_await tr.commit();
+				txnCommitted->increment(1);
 
 				co_return oldReplicas;
 			} catch (Error& e) {
+				txnAborted->increment(1);
 				err = e;
 			}
 			co_await tr.onError(err);
@@ -686,16 +736,22 @@ class DDTxnProcessorImpl {
 	}
 
 	static Future<Void> waitDDTeamInfoPrintSignal(Database cx) {
+		auto* txnStarted = counterWaitDDTeamInfoPrintSignalStarted();
+		auto* txnCommitted = counterWaitDDTeamInfoPrintSignalCommitted();
+		auto* txnAborted = counterWaitDDTeamInfoPrintSignalAborted();
 		ReadYourWritesTransaction tr(cx);
 		while (true) {
+			txnStarted->increment(1);
 			Error err;
 			try {
 				tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 				Future<Void> watchFuture = tr.watch(triggerDDTeamInfoPrintKey);
 				co_await tr.commit();
+				txnCommitted->increment(1);
 				co_await watchFuture;
 				co_return;
 			} catch (Error& e) {
+				txnAborted->increment(1);
 				err = e;
 			}
 			co_await tr.onError(err);

--- a/fdbserver/datadistributor/DDTxnProcessor.cpp
+++ b/fdbserver/datadistributor/DDTxnProcessor.cpp
@@ -23,7 +23,7 @@
 #include "fdbclient/ManagementAPI.h"
 #include "fdbserver/datadistributor/DataDistribution.h"
 #include "fdbclient/DatabaseContext.h"
-#include "flow/SimpleCounter.h"
+#include "flow/TxnCounters.h"
 #include "flow/CoroUtils.h"
 #include "flow/genericactors.actor.h"
 
@@ -41,43 +41,6 @@ static void updateServersAndCompleteSources(std::set<UID>& servers,
 			}
 		}
 	}
-}
-
-static SimpleCounter<int64_t>* counterUpdateReplicaKeysStarted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/dd/updateReplicaKeys/started");
-	return c;
-}
-static SimpleCounter<int64_t>* counterUpdateReplicaKeysCommitted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/dd/updateReplicaKeys/committed");
-	return c;
-}
-static SimpleCounter<int64_t>* counterUpdateReplicaKeysAborted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/dd/updateReplicaKeys/aborted");
-	return c;
-}
-static SimpleCounter<int64_t>* counterTryUpdateReplicasKeyForDcStarted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/dd/tryUpdateReplicasKeyForDc/started");
-	return c;
-}
-static SimpleCounter<int64_t>* counterTryUpdateReplicasKeyForDcCommitted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/dd/tryUpdateReplicasKeyForDc/committed");
-	return c;
-}
-static SimpleCounter<int64_t>* counterTryUpdateReplicasKeyForDcAborted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/dd/tryUpdateReplicasKeyForDc/aborted");
-	return c;
-}
-static SimpleCounter<int64_t>* counterWaitDDTeamInfoPrintSignalStarted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/dd/waitDDTeamInfoPrintSignal/started");
-	return c;
-}
-static SimpleCounter<int64_t>* counterWaitDDTeamInfoPrintSignalCommitted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/dd/waitDDTeamInfoPrintSignal/committed");
-	return c;
-}
-static SimpleCounter<int64_t>* counterWaitDDTeamInfoPrintSignalAborted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/dd/waitDDTeamInfoPrintSignal/aborted");
-	return c;
 }
 
 class DDTxnProcessorImpl {
@@ -223,12 +186,10 @@ class DDTxnProcessorImpl {
 	                                      std::vector<Optional<Key>> primaryDcId,
 	                                      std::vector<Optional<Key>> remoteDcIds,
 	                                      DatabaseConfiguration configuration) {
-		auto* txnStarted = counterUpdateReplicaKeysStarted();
-		auto* txnCommitted = counterUpdateReplicaKeysCommitted();
-		auto* txnAborted = counterUpdateReplicaKeysAborted();
+		static auto* counters = makeCounters("/dd/updateReplicaKeys");
 		Transaction tr(cx);
 		while (true) {
-			txnStarted->increment(1);
+			counters->started->increment(1);
 			Error err;
 			try {
 				tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
@@ -250,10 +211,10 @@ class DDTxnProcessorImpl {
 				}
 
 				co_await tr.commit();
-				txnCommitted->increment(1);
+				counters->committed->increment(1);
 				break;
 			} catch (Error& e) {
-				txnAborted->increment(1);
+				counters->aborted->increment(1);
 				err = e;
 			}
 			co_await tr.onError(err);
@@ -261,12 +222,10 @@ class DDTxnProcessorImpl {
 	}
 
 	static Future<int> tryUpdateReplicasKeyForDc(Database cx, Optional<Key> dcId, int storageTeamSize) {
-		auto* txnStarted = counterTryUpdateReplicasKeyForDcStarted();
-		auto* txnCommitted = counterTryUpdateReplicasKeyForDcCommitted();
-		auto* txnAborted = counterTryUpdateReplicasKeyForDcAborted();
+		static auto* counters = makeCounters("/dd/tryUpdateReplicasKeyForDc");
 		Transaction tr(cx);
 		while (true) {
-			txnStarted->increment(1);
+			counters->started->increment(1);
 			tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 			tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
 
@@ -282,11 +241,11 @@ class DDTxnProcessorImpl {
 				}
 				tr.set(datacenterReplicasKeyFor(dcId), datacenterReplicasValue(storageTeamSize));
 				co_await tr.commit();
-				txnCommitted->increment(1);
+				counters->committed->increment(1);
 
 				co_return oldReplicas;
 			} catch (Error& e) {
-				txnAborted->increment(1);
+				counters->aborted->increment(1);
 				err = e;
 			}
 			co_await tr.onError(err);
@@ -736,22 +695,20 @@ class DDTxnProcessorImpl {
 	}
 
 	static Future<Void> waitDDTeamInfoPrintSignal(Database cx) {
-		auto* txnStarted = counterWaitDDTeamInfoPrintSignalStarted();
-		auto* txnCommitted = counterWaitDDTeamInfoPrintSignalCommitted();
-		auto* txnAborted = counterWaitDDTeamInfoPrintSignalAborted();
+		static auto* counters = makeCounters("/dd/waitDDTeamInfoPrintSignal");
 		ReadYourWritesTransaction tr(cx);
 		while (true) {
-			txnStarted->increment(1);
+			counters->started->increment(1);
 			Error err;
 			try {
 				tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 				Future<Void> watchFuture = tr.watch(triggerDDTeamInfoPrintKey);
 				co_await tr.commit();
-				txnCommitted->increment(1);
+				counters->committed->increment(1);
 				co_await watchFuture;
 				co_return;
 			} catch (Error& e) {
-				txnAborted->increment(1);
+				counters->aborted->increment(1);
 				err = e;
 			}
 			co_await tr.onError(err);

--- a/fdbserver/datadistributor/DataDistribution.cpp
+++ b/fdbserver/datadistributor/DataDistribution.cpp
@@ -49,7 +49,7 @@
 #include "flow/Buggify.h"
 #include "flow/Error.h"
 #include "flow/Platform.h"
-#include "flow/SimpleCounter.h"
+#include "flow/TxnCounters.h"
 #include "flow/Trace.h"
 #include "flow/UnitTest.h"
 #include "flow/flow.h"
@@ -404,19 +404,6 @@ struct DDBulkDumpJobManager {
 	bool isValid() const { return jobState.isValid(); }
 };
 
-static SimpleCounter<int64_t>* counterRemoveDataMoveTombstoneStarted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/dd/removeDataMoveTombstone/started");
-	return c;
-}
-static SimpleCounter<int64_t>* counterRemoveDataMoveTombstoneCommitted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/dd/removeDataMoveTombstone/committed");
-	return c;
-}
-static SimpleCounter<int64_t>* counterRemoveDataMoveTombstoneAborted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/dd/removeDataMoveTombstone/aborted");
-	return c;
-}
-
 struct DataDistributor : NonCopyable, ReferenceCounted<DataDistributor> {
 public:
 	Reference<AsyncVar<ServerDBInfo> const> dbInfo;
@@ -724,15 +711,13 @@ public:
 	}
 
 	static Future<Void> removeDataMoveTombstoneBackground(Reference<DataDistributor> self) {
-		auto* txnStarted = counterRemoveDataMoveTombstoneStarted();
-		auto* txnCommitted = counterRemoveDataMoveTombstoneCommitted();
-		auto* txnAborted = counterRemoveDataMoveTombstoneAborted();
+		static auto* counters = makeCounters("/dd/removeDataMoveTombstone");
 		UID currentID;
 		try {
 			Database cx = openDBOnServer(self->dbInfo, TaskPriority::DefaultEndpoint, LockAware::True);
 			Transaction tr(cx);
 			while (true) {
-				txnStarted->increment(1);
+				counters->started->increment(1);
 				Error err;
 				try {
 					tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
@@ -743,10 +728,10 @@ public:
 						TraceEvent(SevDebug, "RemoveDataMoveTombstone", self->ddId).detail("DataMoveID", currentID);
 					}
 					co_await tr.commit();
-					txnCommitted->increment(1);
+					counters->committed->increment(1);
 					break;
 				} catch (Error& e) {
-					txnAborted->increment(1);
+					counters->aborted->increment(1);
 					err = e;
 				}
 				co_await tr.onError(err);
@@ -3178,46 +3163,17 @@ Future<std::map<NetworkAddress, std::pair<WorkerInterface, std::string>>> getSta
 	}
 }
 
-static SimpleCounter<int64_t>* counterDdSnapSetRecoveryStarted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/dd/ddSnapSetRecovery/started");
-	return c;
-}
-static SimpleCounter<int64_t>* counterDdSnapSetRecoveryCommitted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/dd/ddSnapSetRecovery/committed");
-	return c;
-}
-static SimpleCounter<int64_t>* counterDdSnapSetRecoveryAborted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/dd/ddSnapSetRecovery/aborted");
-	return c;
-}
-static SimpleCounter<int64_t>* counterDdSnapClearRecoveryStarted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/dd/ddSnapClearRecovery/started");
-	return c;
-}
-static SimpleCounter<int64_t>* counterDdSnapClearRecoveryCommitted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/dd/ddSnapClearRecovery/committed");
-	return c;
-}
-static SimpleCounter<int64_t>* counterDdSnapClearRecoveryAborted() {
-	static auto* c = SimpleCounter<int64_t>::makeCounter("/dd/ddSnapClearRecovery/aborted");
-	return c;
-}
-
 // Coordinates the data-distributor side of snapshot creation by preventing
 // recovery, pausing TLog pops, snapshotting stateful workers, and resuming
 // TLog pops before reporting completion.
 Future<Void> ddSnapCreateCore(DistributorSnapRequest snapReq, Reference<AsyncVar<ServerDBInfo> const> db) {
 	Database cx = openDBOnServer(db, TaskPriority::DefaultDelay, LockAware::True);
-	auto* setRecoveryStarted = counterDdSnapSetRecoveryStarted();
-	auto* setRecoveryCommitted = counterDdSnapSetRecoveryCommitted();
-	auto* setRecoveryAborted = counterDdSnapSetRecoveryAborted();
-	auto* clearRecoveryStarted = counterDdSnapClearRecoveryStarted();
-	auto* clearRecoveryCommitted = counterDdSnapClearRecoveryCommitted();
-	auto* clearRecoveryAborted = counterDdSnapClearRecoveryAborted();
+	static auto* setRecoveryCounters = makeCounters("/dd/ddSnapSetRecovery");
+	static auto* clearRecoveryCounters = makeCounters("/dd/ddSnapClearRecovery");
 
 	ReadYourWritesTransaction tr(cx);
 	while (true) {
-		setRecoveryStarted->increment(1);
+		setRecoveryCounters->started->increment(1);
 		Error err;
 		try {
 			tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
@@ -3227,10 +3183,10 @@ Future<Void> ddSnapCreateCore(DistributorSnapRequest snapReq, Reference<AsyncVar
 			    .detail("SnapUID", snapReq.snapUID);
 			tr.set(writeRecoveryKey, writeRecoveryKeyTrue);
 			co_await tr.commit();
-			setRecoveryCommitted->increment(1);
+			setRecoveryCounters->committed->increment(1);
 			break;
 		} catch (Error& e) {
-			setRecoveryAborted->increment(1);
+			setRecoveryCounters->aborted->increment(1);
 			err = e;
 		}
 		TraceEvent("SnapDataDistributor_WriteFlagError").error(err);
@@ -3323,7 +3279,7 @@ Future<Void> ddSnapCreateCore(DistributorSnapRequest snapReq, Reference<AsyncVar
 		    .detail("SnapUID", snapReq.snapUID);
 		tr.reset();
 		while (true) {
-			clearRecoveryStarted->increment(1);
+			clearRecoveryCounters->started->increment(1);
 			Error err;
 			try {
 				tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
@@ -3333,10 +3289,10 @@ Future<Void> ddSnapCreateCore(DistributorSnapRequest snapReq, Reference<AsyncVar
 				    .detail("SnapUID", snapReq.snapUID);
 				tr.clear(writeRecoveryKey);
 				co_await tr.commit();
-				clearRecoveryCommitted->increment(1);
+				clearRecoveryCounters->committed->increment(1);
 				break;
 			} catch (Error& e) {
-				clearRecoveryAborted->increment(1);
+				clearRecoveryCounters->aborted->increment(1);
 				err = e;
 			}
 			TraceEvent("SnapDataDistributor_ClearFlagError").error(err);

--- a/fdbserver/datadistributor/DataDistribution.cpp
+++ b/fdbserver/datadistributor/DataDistribution.cpp
@@ -49,6 +49,7 @@
 #include "flow/Buggify.h"
 #include "flow/Error.h"
 #include "flow/Platform.h"
+#include "flow/SimpleCounter.h"
 #include "flow/Trace.h"
 #include "flow/UnitTest.h"
 #include "flow/flow.h"
@@ -403,6 +404,19 @@ struct DDBulkDumpJobManager {
 	bool isValid() const { return jobState.isValid(); }
 };
 
+static SimpleCounter<int64_t>* counterRemoveDataMoveTombstoneStarted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/dd/removeDataMoveTombstone/started");
+	return c;
+}
+static SimpleCounter<int64_t>* counterRemoveDataMoveTombstoneCommitted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/dd/removeDataMoveTombstone/committed");
+	return c;
+}
+static SimpleCounter<int64_t>* counterRemoveDataMoveTombstoneAborted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/dd/removeDataMoveTombstone/aborted");
+	return c;
+}
+
 struct DataDistributor : NonCopyable, ReferenceCounted<DataDistributor> {
 public:
 	Reference<AsyncVar<ServerDBInfo> const> dbInfo;
@@ -710,11 +724,15 @@ public:
 	}
 
 	static Future<Void> removeDataMoveTombstoneBackground(Reference<DataDistributor> self) {
+		auto* txnStarted = counterRemoveDataMoveTombstoneStarted();
+		auto* txnCommitted = counterRemoveDataMoveTombstoneCommitted();
+		auto* txnAborted = counterRemoveDataMoveTombstoneAborted();
 		UID currentID;
 		try {
 			Database cx = openDBOnServer(self->dbInfo, TaskPriority::DefaultEndpoint, LockAware::True);
 			Transaction tr(cx);
 			while (true) {
+				txnStarted->increment(1);
 				Error err;
 				try {
 					tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
@@ -725,8 +743,10 @@ public:
 						TraceEvent(SevDebug, "RemoveDataMoveTombstone", self->ddId).detail("DataMoveID", currentID);
 					}
 					co_await tr.commit();
+					txnCommitted->increment(1);
 					break;
 				} catch (Error& e) {
+					txnAborted->increment(1);
 					err = e;
 				}
 				co_await tr.onError(err);
@@ -3158,14 +3178,46 @@ Future<std::map<NetworkAddress, std::pair<WorkerInterface, std::string>>> getSta
 	}
 }
 
+static SimpleCounter<int64_t>* counterDdSnapSetRecoveryStarted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/dd/ddSnapSetRecovery/started");
+	return c;
+}
+static SimpleCounter<int64_t>* counterDdSnapSetRecoveryCommitted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/dd/ddSnapSetRecovery/committed");
+	return c;
+}
+static SimpleCounter<int64_t>* counterDdSnapSetRecoveryAborted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/dd/ddSnapSetRecovery/aborted");
+	return c;
+}
+static SimpleCounter<int64_t>* counterDdSnapClearRecoveryStarted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/dd/ddSnapClearRecovery/started");
+	return c;
+}
+static SimpleCounter<int64_t>* counterDdSnapClearRecoveryCommitted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/dd/ddSnapClearRecovery/committed");
+	return c;
+}
+static SimpleCounter<int64_t>* counterDdSnapClearRecoveryAborted() {
+	static auto* c = SimpleCounter<int64_t>::makeCounter("/dd/ddSnapClearRecovery/aborted");
+	return c;
+}
+
 // Coordinates the data-distributor side of snapshot creation by preventing
 // recovery, pausing TLog pops, snapshotting stateful workers, and resuming
 // TLog pops before reporting completion.
 Future<Void> ddSnapCreateCore(DistributorSnapRequest snapReq, Reference<AsyncVar<ServerDBInfo> const> db) {
 	Database cx = openDBOnServer(db, TaskPriority::DefaultDelay, LockAware::True);
+	auto* setRecoveryStarted = counterDdSnapSetRecoveryStarted();
+	auto* setRecoveryCommitted = counterDdSnapSetRecoveryCommitted();
+	auto* setRecoveryAborted = counterDdSnapSetRecoveryAborted();
+	auto* clearRecoveryStarted = counterDdSnapClearRecoveryStarted();
+	auto* clearRecoveryCommitted = counterDdSnapClearRecoveryCommitted();
+	auto* clearRecoveryAborted = counterDdSnapClearRecoveryAborted();
 
 	ReadYourWritesTransaction tr(cx);
 	while (true) {
+		setRecoveryStarted->increment(1);
 		Error err;
 		try {
 			tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
@@ -3175,8 +3227,10 @@ Future<Void> ddSnapCreateCore(DistributorSnapRequest snapReq, Reference<AsyncVar
 			    .detail("SnapUID", snapReq.snapUID);
 			tr.set(writeRecoveryKey, writeRecoveryKeyTrue);
 			co_await tr.commit();
+			setRecoveryCommitted->increment(1);
 			break;
 		} catch (Error& e) {
+			setRecoveryAborted->increment(1);
 			err = e;
 		}
 		TraceEvent("SnapDataDistributor_WriteFlagError").error(err);
@@ -3269,6 +3323,7 @@ Future<Void> ddSnapCreateCore(DistributorSnapRequest snapReq, Reference<AsyncVar
 		    .detail("SnapUID", snapReq.snapUID);
 		tr.reset();
 		while (true) {
+			clearRecoveryStarted->increment(1);
 			Error err;
 			try {
 				tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
@@ -3278,8 +3333,10 @@ Future<Void> ddSnapCreateCore(DistributorSnapRequest snapReq, Reference<AsyncVar
 				    .detail("SnapUID", snapReq.snapUID);
 				tr.clear(writeRecoveryKey);
 				co_await tr.commit();
+				clearRecoveryCommitted->increment(1);
 				break;
 			} catch (Error& e) {
+				clearRecoveryAborted->increment(1);
 				err = e;
 			}
 			TraceEvent("SnapDataDistributor_ClearFlagError").error(err);

--- a/flow/include/flow/TxnCounters.h
+++ b/flow/include/flow/TxnCounters.h
@@ -1,0 +1,42 @@
+/*
+ * TxnCounters.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FLOW_TXNCOUNTERS_H
+#define FLOW_TXNCOUNTERS_H
+#pragma once
+
+#include "flow/SimpleCounter.h"
+
+struct TxnCounters {
+	SimpleCounter<int64_t>* started;
+	SimpleCounter<int64_t>* committed;
+	SimpleCounter<int64_t>* aborted;
+};
+
+inline TxnCounters* makeCounters(const char* prefix) {
+	std::string p(prefix);
+	auto* c = new TxnCounters();
+	c->started = SimpleCounter<int64_t>::makeCounter(p + "/started");
+	c->committed = SimpleCounter<int64_t>::makeCounter(p + "/committed");
+	c->aborted = SimpleCounter<int64_t>::makeCounter(p + "/aborted");
+	return c;
+}
+
+#endif


### PR DESCRIPTION
See PR #13062.

This has been refactored a bit compared to the code on the maintenance branches to reduce boilerplate.

Testing in progress:
  20260429-011249-gglass-68b9867b03f015d7            compressed=True data_size=36681516 duration=21477 ended=457 fail_fast=10 max_runs=100000 pass=457 priority=100 remaining=14:20:22 runtime=0:03:57 sanity=False started=1467 submitted=20260429-011249 timeout=5400 username=gglass
