### PR TITLE
Address various `FIXME` comments

### DIFF
--- a/fdbclient/DatabaseContext.cpp
+++ b/fdbclient/DatabaseContext.cpp
@@ -737,7 +737,8 @@ static Future<Void> delExcessClntTxnEntriesActor(Transaction* tr, int64_t client
 	}
 }
 
-// FIXME: explain what "client status" is
+// Client status is the client-side transaction profiling data persisted under
+// fdbClientInfoPrefixRange for status reporting.
 // The reason for getting a pointer to DatabaseContext instead of a reference counted object is because reference
 // counting will increment reference count for DatabaseContext which holds the future of this actor. This creates a
 // cyclic reference and hence this actor and Database object will not be destroyed at all.

--- a/fdbrpc/include/fdbrpc/SimulatorKillType.h
+++ b/fdbrpc/include/fdbrpc/SimulatorKillType.h
@@ -23,8 +23,8 @@
 
 namespace simulator {
 
-// Order matters!
-// FIXME: explain why it matters.
+// Order matters: simulation code compares kill types to decide whether one fault mode is
+// more destructive than another.
 enum KillType {
 	KillInstantly,
 	InjectFaults,

--- a/fdbrpc/include/fdbrpc/fdbrpc.h
+++ b/fdbrpc/include/fdbrpc/fdbrpc.h
@@ -687,7 +687,8 @@ struct HasVerify_t<T, decltype(void(std::declval<T>().verify()), 0)> : std::true
 template <class T>
 constexpr bool HasVerify = HasVerify_t<T>::value;
 
-// FIXME: explain what IsPublic means here
+// IsPublic streams accept messages from clients outside the cluster and verify
+// each request before delivering it to the local queue.
 template <class T, bool IsPublic>
 struct NetNotifiedQueue final : NotifiedQueue<T>, FlowReceiver, FastAllocated<NetNotifiedQueue<T, IsPublic>> {
 	using FastAllocated<NetNotifiedQueue<T, IsPublic>>::operator new;
@@ -948,7 +949,8 @@ private:
 	NetNotifiedQueue<T, IsPublic>* queue;
 };
 
-// FIXME: explain what Public and Private mean here
+// Public request streams require T::verify() and reject unauthorized messages.
+// Private request streams are used for trusted intra-cluster traffic.
 template <class T>
 using PrivateRequestStream = RequestStream<T, false>;
 template <class T>

--- a/fdbserver/core/include/fdbserver/core/DataDistributorInterface.h
+++ b/fdbserver/core/include/fdbserver/core/DataDistributorInterface.h
@@ -159,7 +159,8 @@ struct GetDataDistributorMetricsRequest {
 	}
 };
 
-// FIXME: explain purpose
+// Request sent to the data distributor to coordinate a snapshot across
+// stateful workers for a single snapshot UID.
 struct DistributorSnapRequest {
 	constexpr static FileIdentifier file_identifier = 5427684;
 	Arena arena;

--- a/fdbserver/core/include/fdbserver/core/WorkerInterface.actor.h
+++ b/fdbserver/core/include/fdbserver/core/WorkerInterface.actor.h
@@ -843,7 +843,7 @@ struct ExecuteRequest {
 	}
 };
 
-// FIXME: describe purpose
+// Request sent to a worker to run the snapshot command for one local role.
 struct WorkerSnapRequest {
 	constexpr static FileIdentifier file_identifier = 8194122;
 	ReplyPromise<Void> reply;

--- a/fdbserver/datadistributor/DDTeamCollection.actor.cpp
+++ b/fdbserver/datadistributor/DDTeamCollection.actor.cpp
@@ -1472,7 +1472,7 @@ public:
 				}
 				otherChanges.push_back(self->excludedServers.onChange(worstAddr));
 
-				// FIXME: explain the 3 here
+				// Check the remaining exclusion forms: primary IP, secondary address and port, and secondary IP.
 				for (int i = 0; i < 3; i++) {
 					if (i > 0 && !server->getLastKnownInterface().secondaryAddress().present()) {
 						break;

--- a/fdbserver/datadistributor/DataDistribution.cpp
+++ b/fdbserver/datadistributor/DataDistribution.cpp
@@ -3158,7 +3158,9 @@ Future<std::map<NetworkAddress, std::pair<WorkerInterface, std::string>>> getSta
 	}
 }
 
-// FIXME: explain what this is trying to accomplish
+// Coordinates the data-distributor side of snapshot creation by preventing
+// recovery, pausing TLog pops, snapshotting stateful workers, and resuming
+// TLog pops before reporting completion.
 Future<Void> ddSnapCreateCore(DistributorSnapRequest snapReq, Reference<AsyncVar<ServerDBInfo> const> db) {
 	Database cx = openDBOnServer(db, TaskPriority::DefaultDelay, LockAware::True);
 
@@ -3208,8 +3210,8 @@ Future<Void> ddSnapCreateCore(DistributorSnapRequest snapReq, Reference<AsyncVar
 		    .detail("SnapUID", snapReq.snapUID)
 		    .detail("StorageFaultTolerance", storageFaultTolerance);
 
-		// we need to snapshot storage nodes before snapshot any tlogs
-		// FIXME: if it's non-obvious enough to comment about, then also explain why
+		// Snapshot storage nodes before TLogs so storage files are captured
+		// while TLogs still retain the mutations needed to recover them.
 		std::vector<Future<ErrorOr<Void>>> storageSnapReqs;
 		for (const auto& [addr, entry] : statefulWorkers) {
 			auto& [interf, role] = entry;

--- a/fdbserver/workloads/FuzzApiCorrectness.cpp
+++ b/fdbserver/workloads/FuzzApiCorrectness.cpp
@@ -37,7 +37,7 @@
 
 namespace ph = std::placeholders;
 
-// FIXME(gglass): figure out what this test is actually tring to test, and
+// FIXME(gglass): figure out what this test is actually trying to test, and
 // restructure it to be useful in a post-tenant world.  For now leave the
 // tenant crap in so that the distribution of keys/values generated is
 // actually sane.  An earlier attempt at removing the tenant stuff caused
@@ -54,7 +54,7 @@ using TenantGroupName = Standalone<TenantGroupNameRef>;
 
 // This allows us to dictate which exceptions we SHOULD get.
 // We can use this to suppress expected exceptions, and take action
-// if we don't get an exception wqe should have gotten.
+// if we don't get an exception we should have gotten.
 struct ExceptionContract {
 	enum occurance_t { Never = 0, Possible = 1, Always = 2 };
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,11 +12,9 @@ set(TEST_INCLUDE ".*" CACHE STRING "Include only tests that match the given rege
 set(TEST_EXCLUDE ".^" CACHE STRING "Exclude all tests matching the given regex")
 set(SANITIZER_OPTIONS "UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1;TSAN_OPTIONS=suppressions=${CMAKE_SOURCE_DIR}/contrib/tsan.suppressions;LSAN_OPTIONS=suppressions=${CMAKE_SOURCE_DIR}/contrib/lsan.suppressions" CACHE STRING "Environment variables setting sanitizer options")
 
-# for the restart test we optimally want to use the last stable fdbserver
-# to test upgrades.
-# FIXME: explain what `last stable` means in the above comment.  Does it mean "last stable non-main release?"
-# Below we are using 7.1.* so that is pretty old stuff.  Does it mean "most recent patch release of the oldest X.Y release family"?
-# FIXME: Regardless of what "last stable" refers to, explain why this is important.
+# For the restart test, prefer an installed fdbserver from an older stable release
+# to exercise upgrade paths from existing on-disk state. If it is unavailable,
+# the current build is used instead.
 if(WITH_PYTHON)
   find_program(OLD_FDBSERVER_BINARY
     fdbserver-7.1.69 fdbserver fdbserver.exe


### PR DESCRIPTION
Codex was used to identify some relatively easy-to-address `FIXME` comments in the codebase. There are still many remaining `FIXME` comments that can be addressed in future PRs
