### PR TITLE
Finish `ClusterRecovery.actor.cpp` coroutine conversion

### DIFF
--- a/fdbclient/Tracing.cpp
+++ b/fdbclient/Tracing.cpp
@@ -1,5 +1,5 @@
 /*
- * Tracing.actor.cpp
+ * Tracing.cpp
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdbserver/clustercontroller/ClusterRecovery.actor.cpp
+++ b/fdbserver/clustercontroller/ClusterRecovery.actor.cpp
@@ -36,7 +36,6 @@
 #include "flow/Trace.h"
 
 #include "flow/CoroUtils.h"
-#include "flow/actorcompiler.h" // This must be the last #include.
 
 static std::set<int> const& normalClusterRecoveryErrors() {
 	static std::set<int> s;
@@ -1426,11 +1425,11 @@ void updateConfigForForcedRecovery(Reference<ClusterRecoveryData> self,
 	initialConfChanges->push_back(regionCommit);
 }
 
-ACTOR Future<Void> recoverFrom(Reference<ClusterRecoveryData> self,
-                               Reference<LogSystem> oldLogSystem,
-                               std::vector<StorageServerInterface>* seedServers,
-                               std::vector<Standalone<CommitTransactionRef>>* initialConfChanges,
-                               Future<Version> poppedTxsVersion) {
+Future<Void> recoverFrom(Reference<ClusterRecoveryData> self,
+                         Reference<LogSystem> oldLogSystem,
+                         std::vector<StorageServerInterface>* seedServers,
+                         std::vector<Standalone<CommitTransactionRef>>* initialConfChanges,
+                         Future<Version> poppedTxsVersion) {
 	TraceEvent(getRecoveryEventName(ClusterRecoveryEventType::CLUSTER_RECOVERY_STATE_EVENT_NAME).c_str(), self->dbgid)
 	    .detail("StatusCode", RecoveryStatus::reading_transaction_system_state)
 	    .detail("Status", RecoveryStatus::names[RecoveryStatus::reading_transaction_system_state])
@@ -1438,10 +1437,10 @@ ACTOR Future<Void> recoverFrom(Reference<ClusterRecoveryData> self,
 	self->hasConfiguration = false;
 
 	if (BUGGIFY)
-		wait(delay(10.0));
+		co_await delay(10.0);
 
-	Version txsPoppedVersion = wait(poppedTxsVersion);
-	wait(readTransactionSystemState(self, oldLogSystem, txsPoppedVersion));
+	Version txsPoppedVersion = co_await poppedTxsVersion;
+	co_await readTransactionSystemState(self, oldLogSystem, txsPoppedVersion);
 	for (auto& itr : *initialConfChanges) {
 		for (auto& m : itr.mutations) {
 			self->configuration.applyMutation(m);
@@ -1458,58 +1457,57 @@ ACTOR Future<Void> recoverFrom(Reference<ClusterRecoveryData> self,
 	// second, a provisional master is initialized, and an "emergency transaction" is submitted that might change the
 	// configuration so that we can finish recovery.
 
-	state std::map<Optional<Value>, int8_t> originalLocalityMap = self->dcId_locality;
-	state Future<std::vector<Standalone<CommitTransactionRef>>> recruitments =
+	std::map<Optional<Value>, int8_t> originalLocalityMap = self->dcId_locality;
+	Future<std::vector<Standalone<CommitTransactionRef>>> recruitments =
 	    recruitEverything(self, seedServers, oldLogSystem);
-	state double provisionalDelay = SERVER_KNOBS->PROVISIONAL_START_DELAY;
-	loop {
-		state Future<Standalone<CommitTransactionRef>> provisional = provisionalMaster(self, delay(provisionalDelay));
+	double provisionalDelay = SERVER_KNOBS->PROVISIONAL_START_DELAY;
+	while (true) {
+		Future<Standalone<CommitTransactionRef>> provisional = provisionalMaster(self, delay(provisionalDelay));
 		provisionalDelay =
 		    std::min(SERVER_KNOBS->PROVISIONAL_MAX_DELAY, provisionalDelay * SERVER_KNOBS->PROVISIONAL_DELAY_GROWTH);
-		choose {
-			when(std::vector<Standalone<CommitTransactionRef>> confChanges = wait(recruitments)) {
-				initialConfChanges->insert(initialConfChanges->end(), confChanges.begin(), confChanges.end());
-				provisional.cancel();
-				break;
-			}
-			when(Standalone<CommitTransactionRef> _req = wait(provisional)) {
-				state Standalone<CommitTransactionRef> req = _req; // mutable
-				CODE_PROBE(true, "Emergency transaction processing during recovery");
-				TraceEvent("EmergencyTransaction", self->dbgid).log();
-				for (auto m = req.mutations.begin(); m != req.mutations.end(); ++m)
-					TraceEvent("EmergencyTransactionMutation", self->dbgid)
-					    .detail("MType", m->type)
-					    .detail("P1", m->param1)
-					    .detail("P2", m->param2);
+		auto res = co_await race(recruitments, provisional);
+		if (res.index() == 0) {
+			std::vector<Standalone<CommitTransactionRef>> confChanges = std::get<0>(std::move(res));
+			initialConfChanges->insert(initialConfChanges->end(), confChanges.begin(), confChanges.end());
+			provisional.cancel();
+			break;
+		} else if (res.index() == 1) {
+			Standalone<CommitTransactionRef> req = std::get<1>(std::move(res));
+			CODE_PROBE(true, "Emergency transaction processing during recovery");
+			TraceEvent("EmergencyTransaction", self->dbgid).log();
+			for (auto m = req.mutations.begin(); m != req.mutations.end(); ++m)
+				TraceEvent("EmergencyTransactionMutation", self->dbgid)
+				    .detail("MType", m->type)
+				    .detail("P1", m->param1)
+				    .detail("P2", m->param2);
 
-				DatabaseConfiguration oldConf = self->configuration;
+			DatabaseConfiguration oldConf = self->configuration;
+			self->configuration = self->originalConfiguration;
+			for (auto& m : req.mutations)
+				self->configuration.applyMutation(m);
+
+			initialConfChanges->clear();
+			if (self->originalConfiguration.isValid() &&
+			    self->configuration.usableRegions != self->originalConfiguration.usableRegions) {
+				TraceEvent(SevWarnAlways, "CannotChangeUsableRegions", self->dbgid).log();
 				self->configuration = self->originalConfiguration;
-				for (auto& m : req.mutations)
-					self->configuration.applyMutation(m);
-
-				initialConfChanges->clear();
-				if (self->originalConfiguration.isValid() &&
-				    self->configuration.usableRegions != self->originalConfiguration.usableRegions) {
-					TraceEvent(SevWarnAlways, "CannotChangeUsableRegions", self->dbgid).log();
-					self->configuration = self->originalConfiguration;
-				} else {
-					initialConfChanges->push_back(req);
-				}
-				if (self->forceRecovery) {
-					updateConfigForForcedRecovery(self, initialConfChanges);
-				}
-
-				if (self->configuration != oldConf) { // confChange does not trigger when including servers
-					self->dcId_locality = originalLocalityMap;
-					recruitments = recruitEverything(self, seedServers, oldLogSystem);
-				}
+			} else {
+				initialConfChanges->push_back(req);
 			}
+			if (self->forceRecovery) {
+				updateConfigForForcedRecovery(self, initialConfChanges);
+			}
+
+			if (self->configuration != oldConf) { // confChange does not trigger when including servers
+				self->dcId_locality = originalLocalityMap;
+				recruitments = recruitEverything(self, seedServers, oldLogSystem);
+			}
+		} else {
+			UNREACHABLE();
 		}
 
 		provisional.cancel();
 	}
-
-	return Void();
 }
 
 Future<Void> clusterRecoveryCore(Reference<ClusterRecoveryData> self) {

--- a/fdbserver/clustercontroller/ClusterRecovery.actor.cpp
+++ b/fdbserver/clustercontroller/ClusterRecovery.actor.cpp
@@ -845,33 +845,30 @@ Future<Void> updateRegistration(Reference<ClusterRecoveryData> self, Reference<L
 	}
 }
 
-ACTOR Future<Standalone<CommitTransactionRef>> provisionalMaster(Reference<ClusterRecoveryData> parent,
-                                                                 Future<Void> activate) {
-	wait(activate);
+class ProvisionalMaster {
+	Reference<ClusterRecoveryData> parent;
+	bool locked = false;
+	Optional<Value> metadataVersion;
 
-	// Register a fake commit proxy (to be provided right here) to make ourselves available to clients
-	parent->provisionalCommitProxies = std::vector<CommitProxyInterface>(1);
-	parent->provisionalCommitProxies[0].provisional = true;
-	parent->provisionalCommitProxies[0].initEndpoints();
-	parent->provisionalGrvProxies = std::vector<GrvProxyInterface>(1);
-	parent->provisionalGrvProxies[0].provisional = true;
-	parent->provisionalGrvProxies[0].initEndpoints();
-	state Future<Void> waitCommitProxyFailure =
-	    waitFailureServer(parent->provisionalCommitProxies[0].waitFailure.getFuture());
-	state Future<Void> waitGrvProxyFailure =
-	    waitFailureServer(parent->provisionalGrvProxies[0].waitFailure.getFuture());
-	parent->registrationTrigger.trigger();
+	void initializeProxies() {
+		// Register a fake commit proxy (to be provided right here) to make ourselves available to clients
+		parent->provisionalCommitProxies = std::vector<CommitProxyInterface>(1);
+		parent->provisionalCommitProxies[0].provisional = true;
+		parent->provisionalCommitProxies[0].initEndpoints();
+		parent->provisionalGrvProxies = std::vector<GrvProxyInterface>(1);
+		parent->provisionalGrvProxies[0].provisional = true;
+		parent->provisionalGrvProxies[0].initEndpoints();
+		parent->registrationTrigger.trigger();
 
-	auto lockedKey = parent->txnStateStore->readValue(databaseLockedKey).get();
-	state bool locked = lockedKey.present() && lockedKey.get().size();
+		auto lockedKey = parent->txnStateStore->readValue(databaseLockedKey).get();
+		locked = lockedKey.present() && lockedKey.get().size();
 
-	state Optional<Value> metadataVersion = parent->txnStateStore->readValue(metadataVersionKey).get();
+		metadataVersion = parent->txnStateStore->readValue(metadataVersionKey).get();
+	}
 
-	// We respond to a minimal subset of the commit proxy protocol.  Our sole purpose is to receive a single write-only
-	// transaction which might repair our configuration, and return it.
-	loop choose {
-		when(GetReadVersionRequest req =
-		         waitNext(parent->provisionalGrvProxies[0].getConsistentReadVersion.getFuture())) {
+	Future<Void> serveGetReadVersions() {
+		while (true) {
+			GetReadVersionRequest req = co_await parent->provisionalGrvProxies[0].getConsistentReadVersion.getFuture();
 			if ((req.flags & GetReadVersionRequest::FLAG_CAUSAL_READ_RISKY) &&
 			    (req.flags & GetReadVersionRequest::FLAG_USE_PROVISIONAL_PROXIES) && parent->lastEpochEnd) {
 				GetReadVersionReply rep;
@@ -880,10 +877,15 @@ ACTOR Future<Standalone<CommitTransactionRef>> provisionalMaster(Reference<Clust
 				rep.metadataVersion = metadataVersion;
 				rep.proxyId = parent->provisionalGrvProxies[0].id();
 				req.reply.send(rep);
-			} else
+			} else {
 				req.reply.send(Never()); // We can't perform causally consistent reads without recovering
+			}
 		}
-		when(CommitTransactionRequest req = waitNext(parent->provisionalCommitProxies[0].commit.getFuture())) {
+	}
+
+	Future<Standalone<CommitTransactionRef>> serveCommits() {
+		while (true) {
+			CommitTransactionRequest req = co_await parent->provisionalCommitProxies[0].commit.getFuture();
 			req.reply.send(Never()); // don't reply (clients always get commit_unknown_result)
 			auto t = &req.transaction;
 			if (t->read_snapshot == parent->lastEpochEnd && //< So no transactions can fall between the read snapshot
@@ -908,22 +910,52 @@ ACTOR Future<Standalone<CommitTransactionRef>> provisionalMaster(Reference<Clust
 						out.mutations.append_deep(out.arena(), t->mutations.begin(), t->mutations.size());
 						out.write_conflict_ranges.append_deep(
 						    out.arena(), t->write_conflict_ranges.begin(), t->write_conflict_ranges.size());
-						return out;
+						co_return out;
 					}
 				}
 			}
 		}
-		when(GetKeyServerLocationsRequest req =
-		         waitNext(parent->provisionalCommitProxies[0].getKeyServersLocations.getFuture())) {
+	}
+
+	Future<Void> serveGetKeyServerLocations() {
+		while (true) {
+			GetKeyServerLocationsRequest req =
+			    co_await parent->provisionalCommitProxies[0].getKeyServersLocations.getFuture();
 			req.reply.send(Never());
 		}
-		when(wait(waitCommitProxyFailure)) {
-			throw worker_removed();
-		}
-		when(wait(waitGrvProxyFailure)) {
-			throw worker_removed();
-		}
 	}
+
+	Future<Void> waitForCommitProxyFailure() {
+		co_await waitFailureServer(parent->provisionalCommitProxies[0].waitFailure.getFuture());
+		throw worker_removed();
+	}
+
+	Future<Void> waitForGrvProxyFailure() {
+		co_await waitFailureServer(parent->provisionalGrvProxies[0].waitFailure.getFuture());
+		throw worker_removed();
+	}
+
+public:
+	explicit ProvisionalMaster(Reference<ClusterRecoveryData> parent) : parent(parent) {}
+
+	Future<Standalone<CommitTransactionRef>> run(Future<Void> activate) {
+		co_await activate;
+		initializeProxies();
+
+		auto result = co_await race(serveCommits(),
+		                            serveGetReadVersions(),
+		                            serveGetKeyServerLocations(),
+		                            waitForCommitProxyFailure(),
+		                            waitForGrvProxyFailure());
+		ASSERT(result.index() == 0);
+		co_return std::get<0>(std::move(result));
+	}
+};
+
+Future<Standalone<CommitTransactionRef>> provisionalMaster(Reference<ClusterRecoveryData> parent,
+                                                           Future<Void> activate) {
+	ProvisionalMaster master(parent);
+	co_return co_await master.run(activate);
 }
 
 // Monitors the initialization of transaction system roles (commit proxies, GRV proxies, resolvers, TLogs, LogRouters)

--- a/fdbserver/clustercontroller/ClusterRecovery.cpp
+++ b/fdbserver/clustercontroller/ClusterRecovery.cpp
@@ -1,5 +1,5 @@
 /*
- * ClusterRecovery.actor.cpp
+ * ClusterRecovery.cpp
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdbserver/clustercontroller/ClusterRecovery.cpp
+++ b/fdbserver/clustercontroller/ClusterRecovery.cpp
@@ -1502,8 +1502,6 @@ Future<Void> recoverFrom(Reference<ClusterRecoveryData> self,
 				self->dcId_locality = originalLocalityMap;
 				recruitments = recruitEverything(self, seedServers, oldLogSystem);
 			}
-		} else {
-			UNREACHABLE();
 		}
 
 		provisional.cancel();


### PR DESCRIPTION
`provisionalMaster` is migrated to a standard coroutine using a new `ProvisionalMaster` class to push the loop down into concurrent coroutines. `recoverFrom` is migrated with the actor rewrite tool. `Tracing.actor.cpp` is also renamed in this PR, since it has no remaining `ACTOR`s. Validated with 10k Joshua tests.