### PR TITLE
Ensure that the begin version filter is smaller than the end version filter

### DIFF
--- a/fdbbackup/CMakeLists.txt
+++ b/fdbbackup/CMakeLists.txt
@@ -50,6 +50,12 @@ if(NOT OPEN_FOR_IDE)
   target_compile_definitions(backup_tests PRIVATE EXCLUDE_MAIN_FUNCTION=1)
   add_test(NAME BackupTests COMMAND backup_tests)
 
+  # Test version of FileDecoder.cpp without main() function
+  add_flow_target(EXECUTABLE NAME fdbdecode_tests SRCS Decode.cpp FileDecoder.cpp)
+  target_include_directories(fdbdecode_tests PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/include")
+  target_link_libraries(fdbdecode_tests PRIVATE fdbclient)
+  target_compile_definitions(fdbdecode_tests PRIVATE EXCLUDE_MAIN_FUNCTION=1)
+  add_test(NAME FileDecoderTests COMMAND fdbdecode_tests)
 endif()
 
 if (GPERFTOOLS_FOUND)

--- a/fdbbackup/FileDecoder.cpp
+++ b/fdbbackup/FileDecoder.cpp
@@ -135,6 +135,8 @@ struct DecodeParams : public ReferenceCounted<DecodeParams> {
 
 	bool overlap(Version version) const { return version >= beginVersionFilter && version < endVersionFilter; }
 
+	bool validVersionFilters() { return beginVersionFilter < endVersionFilter; }
+
 	void updateRangeMap() { filters.updateFilters(prefixes); }
 
 	bool matchFilters(const MutationRef& m) const {
@@ -858,6 +860,7 @@ Future<Void> decode_logs(Reference<DecodeParams> params) {
 
 } // namespace file_converter
 
+#ifndef EXCLUDE_MAIN_FUNCTION
 int main(int argc, char** argv) {
 	std::string commandLine;
 	for (int a = 0; a < argc; a++) {
@@ -876,6 +879,15 @@ int main(int argc, char** argv) {
 		if (status != FDB_EXIT_SUCCESS) {
 			file_converter::printDecodeUsage();
 			return status;
+		}
+
+		// Check if the beginVersionFilter is greater than the endVersionFilter, otherwise the filtering will be
+		// invalid.
+		if (!param->validVersionFilters()) {
+			std::cerr << "--begin-version-filter " << param->beginVersionFilter
+			          << " cannot be equal or greater than --end-version-filter" << param->endVersionFilter << "\n";
+			file_converter::printDecodeUsage();
+			return FDB_EXIT_ERROR;
 		}
 
 		if (param->log_enabled) {
@@ -940,3 +952,36 @@ int main(int argc, char** argv) {
 		return FDB_EXIT_MAIN_EXCEPTION;
 	}
 }
+#else // EXCLUDE_MAIN_FUNCTION
+
+int main() {
+	auto assertValid = [](file_converter::DecodeParams& p, bool expected, const char* label) {
+		bool result = p.validVersionFilters();
+		if (result != expected) {
+			fprintf(stderr, "FAIL [%s]: expected %s\n", label, expected ? "valid" : "invalid");
+			return false;
+		}
+		printf("PASS [%s]\n", label);
+		return true;
+	};
+
+	bool ok = true;
+	file_converter::DecodeParams p;
+
+	ok &= assertValid(p, true, "defaults");
+
+	p.beginVersionFilter = 100;
+	p.endVersionFilter = 200;
+	ok &= assertValid(p, true, "begin < end");
+
+	p.beginVersionFilter = 200;
+	p.endVersionFilter = 200;
+	ok &= assertValid(p, false, "begin == end");
+
+	p.beginVersionFilter = 300;
+	p.endVersionFilter = 200;
+	ok &= assertValid(p, false, "begin > end");
+
+	return ok ? 0 : 1;
+}
+#endif // EXCLUDE_MAIN_FUNCTION

--- a/fdbbackup/FileDecoder.cpp
+++ b/fdbbackup/FileDecoder.cpp
@@ -885,7 +885,7 @@ int main(int argc, char** argv) {
 		// invalid.
 		if (!param->validVersionFilters()) {
 			std::cerr << "--begin-version-filter " << param->beginVersionFilter
-			          << " cannot be equal or greater than --end-version-filter" << param->endVersionFilter << "\n";
+			          << " cannot be equal or greater than --end-version-filter " << param->endVersionFilter << "\n";
 			file_converter::printDecodeUsage();
 			return FDB_EXIT_ERROR;
 		}


### PR DESCRIPTION
When a user runs the `fdbdecode` command and fat fingers the start and begin version filter, in a case where the begin version is smaller than the end version the `fdbdecode` command should reject this as invalid input in stead of silently doing nothing.