### PR TITLE
build: update to toml11-3.8.1 and switch to FetchContent

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Building FoundationDB requires at least 8GB of memory. More memory is needed whe
 
 ### macOS
 
-The build under macOS will work the same way as on Linux. [Homebrew](https://brew.sh/) can be used to install the `boost` library and the `ninja` build tool. Be carefull, curent main branch use boost 1.86, do install this version or just let cmake download one. Also, if swift binding is not interest, use -DBUILD_SWIFT_BINDING=OFF. One more thing, toml11project may block build process, mannualy change "cmake_minimum_required(VERSION 3.1)" to "cmake_minimum_required(VERSION 4.2)" in <BUILD_DIR>toml11Project-prefix/src/toml11Project/CMakeLists.txt and run again.
+The build under macOS will work the same way as on Linux. [Homebrew](https://brew.sh/) can be used to install the `boost` library and the `ninja` build tool. Be carefull, curent main branch use boost 1.86, do install this version or just let cmake download one. Also, if swift binding is not interest, use -DBUILD_SWIFT_BINDING=OFF.
 
 ```sh
 cmake -G Ninja <FDB_SOURCE_DIR> -B <BUILD_DIR>

--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -211,7 +211,7 @@ if(NOT WIN32)
   target_link_libraries(fdb_c_client_memory_test PRIVATE fdb_c Threads::Threads)
 
   target_include_directories(fdb_c_api_tester_impl PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}/foundationdb/ ${CMAKE_SOURCE_DIR}/flow/include ${CMAKE_BINARY_DIR}/flow/include)
-  target_link_libraries(fdb_c_api_tester_impl PRIVATE fdb_cpp toml11_target Threads::Threads fmt::fmt boost_target)
+  target_link_libraries(fdb_c_api_tester_impl PRIVATE fdb_cpp toml11::toml11 Threads::Threads fmt::fmt boost_target)
   if(NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     target_link_libraries(fdb_c_api_tester_impl PRIVATE stdc++fs)
   endif()

--- a/cmake/FDBComponents.cmake
+++ b/cmake/FDBComponents.cmake
@@ -262,29 +262,15 @@ set(WITH_LIBURING OFF CACHE BOOL "Build with liburing enabled") # Set this to ON
 # TOML11
 ################################################################################
 
-# TOML can download and install itself into the binary directory, so it should
-# always be available.
-find_package(toml11 3.4.0)
-if(toml11_FOUND)
-  message(STATUS "Using TOML11 from system")
-  add_library(toml11_target INTERFACE)
-  target_link_libraries(toml11_target INTERFACE toml11)
-else()
-  include(ExternalProject)
-  ExternalProject_add(toml11Project
-    URL "https://github.com/ToruNiina/toml11/archive/v3.4.0.tar.gz"
-    URL_HASH SHA256=bc6d733efd9216af8c119d8ac64a805578c79cc82b813e4d1d880ca128bd154d
-    CMAKE_CACHE_ARGS
-      -DCMAKE_POLICY_VERSION_MINIMUM:STRING=3.5  # force compat with newer cmake
-      -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
-      -DCMAKE_C_COMPILER:FILEPATH=${CMAKE_C_COMPILER}
-      -DCMAKE_CXX_COMPILER:FILEPATH=${CMAKE_CXX_COMPILER}
-      -DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_CURRENT_BINARY_DIR}/toml11
-      -Dtoml11_BUILD_TEST:BOOL=OFF
-    BUILD_ALWAYS ON)
-  add_library(toml11_target INTERFACE)
-  add_dependencies(toml11_target toml11Project)
-  target_include_directories(toml11_target SYSTEM INTERFACE ${CMAKE_CURRENT_BINARY_DIR}/toml11/include)
+find_package(toml11 3.8.1 EXACT CONFIG)
+if(NOT toml11_FOUND)
+  include(FetchContent)
+  FetchContent_Declare(
+    toml11
+    URL "https://github.com/ToruNiina/toml11/archive/v3.8.1.tar.gz"
+    URL_HASH SHA256=6a3d20080ecca5ea42102c078d3415bef80920f6c4ea2258e87572876af77849
+  )
+  FetchContent_MakeAvailable(toml11)
 endif()
 
 ################################################################################

--- a/cmake/GetFmt.cmake
+++ b/cmake/GetFmt.cmake
@@ -1,4 +1,4 @@
-find_package(fmt 11.1.4 EXACT QUIET CONFIG)
+find_package(fmt 11.1.4 EXACT CONFIG)
 
 if(NOT fmt_FOUND)
   include(FetchContent)

--- a/fdbserver/CMakeLists.txt
+++ b/fdbserver/CMakeLists.txt
@@ -202,7 +202,7 @@ if(USE_JEMALLOC)
   target_link_libraries(fdbserver PRIVATE jemalloc::jemalloc)
 endif()
 
-target_link_libraries(fdbserver PRIVATE toml11_target rapidjson)
+target_link_libraries(fdbserver PRIVATE toml11::toml11 rapidjson)
 if(WITH_ROCKSDB)
   target_compile_definitions(fdbserver PRIVATE WITH_ROCKSDB)
 endif()

--- a/fdbserver/tester/CMakeLists.txt
+++ b/fdbserver/tester/CMakeLists.txt
@@ -9,7 +9,7 @@ configure_fdbserver_common_includes(fdbserver_tester)
 target_include_directories(fdbserver_tester
   PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/include)
-target_link_libraries(fdbserver_tester PRIVATE fdbclient fdbserver_core toml11_target)
+target_link_libraries(fdbserver_tester PRIVATE fdbclient fdbserver_core toml11::toml11)
 
 # Ensure toml11 external project is built before this target if needed
 if(NOT toml11_FOUND AND TARGET toml11Project)


### PR DESCRIPTION
Switch from ExternalProject to FetchContent because it seems light-weight, and this is a header-only library so there's not much "build" to it.

----------------

toml11-3.4.0 is pre-installed in the build docker images (to make builds a bit faster), but I think it's fine for the build to ignore that, and I can open PRs removing those bits from those Dockerfiles if this is accepted.