### PR TITLE
Revamp fdbbackup/fdbrestore status messages (bulkload/bulkdump)

### DIFF
--- a/fdbclient/FileBackupAgent.cpp
+++ b/fdbclient/FileBackupAgent.cpp
@@ -705,7 +705,7 @@ Future<std::string> RestoreConfig::getProgress_impl(RestoreConfig restore, Refer
 	          success(submittedTasks) && success(triggeredTasks) && success(runningTasks) && success(totalTasks) &&
 	          success(useRangeFileRestore));
 
-	bool useRangeFile = useRangeFileRestore.get().present() && useRangeFileRestore.get().get();
+	bool useRangeFile = !useRangeFileRestore.get().present() || useRangeFileRestore.get().get();
 
 	std::string errstr = "None";
 	if (lastError.get().second != 0)
@@ -749,12 +749,11 @@ Future<std::string> RestoreConfig::getProgress_impl(RestoreConfig restore, Refer
 		                      submittedTasks.get(),
 		                      triggeredTasks.get(),
 		                      runningTasks.get());
-		progressStr += format(" Tasks complete: %lld / %lld total\n", triggeredTasks.get(), totalTasks.get());
+		progressStr += format(" Tasks triggered: %lld / %lld total\n", triggeredTasks.get(), totalTasks.get());
 		progressStr += format(" Bytes written: %s\n", formatBytesHumanReadable(bytesWritten.get()).c_str());
-		double throughput =
-		    triggeredTasks.get() > 0 && totalTasks.get() > 0 ? (double)bytesWritten.get() / totalTasks.get() : 0;
-		if (throughput > 0) {
-			progressStr += format(" Avg bytes/task: %s\n", formatBytesHumanReadable((int64_t)throughput).c_str());
+		double avgBytesPerTask = triggeredTasks.get() > 0 ? (double)bytesWritten.get() / triggeredTasks.get() : 0;
+		if (avgBytesPerTask > 0) {
+			progressStr += format(" Avg bytes/task: %s\n", formatBytesHumanReadable((int64_t)avgBytesPerTask).c_str());
 		}
 	}
 
@@ -7991,7 +7990,6 @@ public:
 							statusText += format(" Bytes written: %s\n",
 							                     formatBytesHumanReadable(rangeBytesWritten.orDefault(0)).c_str());
 
-							std::string rangefileStatus;
 							if (backupState == EBackupState::STATE_RUNNING_DIFFERENTIAL) {
 								double pct = 100.0 * (recentReadVersion - snapshotBeginVersion) /
 								             (snapshotTargetEndVersion - snapshotBeginVersion);

--- a/fdbclient/FileBackupAgent.cpp
+++ b/fdbclient/FileBackupAgent.cpp
@@ -7988,8 +7988,8 @@ public:
 
 						if (showRangeFile) {
 							statusText += "\nRangefile Snapshot:\n";
-							statusText +=
-							    format(" Bytes written: %s\n", formatBytesHumanReadable(rangeBytesWritten.orDefault(0)).c_str());
+							statusText += format(" Bytes written: %s\n",
+							                     formatBytesHumanReadable(rangeBytesWritten.orDefault(0)).c_str());
 
 							std::string rangefileStatus;
 							if (backupState == EBackupState::STATE_RUNNING_DIFFERENTIAL) {
@@ -8004,7 +8004,8 @@ public:
 						}
 
 						statusText += format("\nMutation Logs:\n");
-						statusText += format(" Bytes written: %s\n", formatBytesHumanReadable(logBytesWritten.orDefault(0)).c_str());
+						statusText += format(" Bytes written: %s\n",
+						                     formatBytesHumanReadable(logBytesWritten.orDefault(0)).c_str());
 						statusText += format(" Last complete version: %s (%s)\n",
 						                     versionToString(latestLogEndVersion).c_str(),
 						                     timeStampToString(latestLogEndVersionTimestamp).c_str());

--- a/fdbclient/FileBackupAgent.cpp
+++ b/fdbclient/FileBackupAgent.cpp
@@ -692,18 +692,20 @@ Future<std::string> RestoreConfig::getProgress_impl(RestoreConfig restore, Refer
 	Future<Version> firstConsistentVersion = restore.firstConsistentVersion().getD(tr);
 	Future<std::string> tag = restore.tag().getD(tr);
 	Future<std::pair<std::string, Version>> lastError = restore.lastError().getD(tr);
-	// BulkLoad sub-phase counts for detailed progress
 	Future<int64_t> submittedTasks = restore.bulkLoadSubmittedTasks().getD(tr);
 	Future<int64_t> triggeredTasks = restore.bulkLoadTriggeredTasks().getD(tr);
 	Future<int64_t> runningTasks = restore.bulkLoadRunningTasks().getD(tr);
 	Future<int64_t> totalTasks = restore.bulkLoadTotalTasks().getD(tr);
+	Future<Optional<bool>> useRangeFileRestore = restore.useRangeFileRestore().get(tr);
 
-	// restore might no longer be valid after the first wait so make sure it is not needed anymore.
 	UID uid = restore.getUid();
 	co_await (success(fileCount) && success(fileBlockCount) && success(fileBlocksDispatched) &&
 	          success(fileBlocksFinished) && success(bytesWritten) && success(status) && success(currentVersion) &&
 	          success(lag) && success(firstConsistentVersion) && success(tag) && success(lastError) &&
-	          success(submittedTasks) && success(triggeredTasks) && success(runningTasks) && success(totalTasks));
+	          success(submittedTasks) && success(triggeredTasks) && success(runningTasks) && success(totalTasks) &&
+	          success(useRangeFileRestore));
+
+	bool useRangeFile = useRangeFileRestore.get().present() && useRangeFileRestore.get().get();
 
 	std::string errstr = "None";
 	if (lastError.get().second != 0)
@@ -728,23 +730,35 @@ Future<std::string> RestoreConfig::getProgress_impl(RestoreConfig restore, Refer
 	    .detail("FirstConsistentVersion", firstConsistentVersion.get())
 	    .detail("ApplyLag", lag.get());
 
-	co_return format("Tag: %s  UID: %s  State: %s  Blocks: %lld/%lld  BlocksInProgress: %lld  "
-	                 "Submitted: %lld  Triggered: %lld  Running: %lld  TotalTasks: %lld  "
-	                 "Files: %lld  BytesWritten: %lld  ApplyVersionLag: %lld  LastError: %s",
-	                 tag.get().c_str(),
-	                 uid.toString().c_str(),
-	                 status.get().toString().c_str(),
-	                 fileBlocksFinished.get(),
-	                 fileBlockCount.get(),
-	                 fileBlocksDispatched.get() - fileBlocksFinished.get(),
-	                 submittedTasks.get(),
-	                 triggeredTasks.get(),
-	                 runningTasks.get(),
-	                 totalTasks.get(),
-	                 fileCount.get(),
-	                 bytesWritten.get(),
-	                 lag.get(),
-	                 errstr.c_str());
+	std::string progressStr;
+	if (useRangeFile) {
+		progressStr = format("Tag: %s  UID: %s  State: %s\n",
+		                     tag.get().c_str(),
+		                     uid.toString().c_str(),
+		                     status.get().toString().c_str());
+		progressStr += format(" Blocks: %lld/%lld complete\n", fileBlocksFinished.get(), fileBlockCount.get());
+		progressStr += format(" Files: %lld\n", fileCount.get());
+		progressStr += format(" Bytes written: %s\n", formatBytesHumanReadable(bytesWritten.get()).c_str());
+		progressStr += format(" Apply version lag: %s\n", versionToString(lag.get()).c_str());
+	} else {
+		progressStr = format("Tag: %s  UID: %s  State: %s\n",
+		                     tag.get().c_str(),
+		                     uid.toString().c_str(),
+		                     status.get().toString().c_str());
+		progressStr += format(" Tasks submitted: %lld  triggered: %lld  running: %lld\n",
+		                      submittedTasks.get(),
+		                      triggeredTasks.get(),
+		                      runningTasks.get());
+		progressStr += format(" Tasks complete: %lld / %lld total\n", triggeredTasks.get(), totalTasks.get());
+		progressStr += format(" Bytes written: %s\n", formatBytesHumanReadable(bytesWritten.get()).c_str());
+		double throughput =
+		    triggeredTasks.get() > 0 && totalTasks.get() > 0 ? (double)bytesWritten.get() / totalTasks.get() : 0;
+		if (throughput > 0) {
+			progressStr += format(" Avg bytes/task: %s\n", formatBytesHumanReadable((int64_t)throughput).c_str());
+		}
+	}
+
+	co_return progressStr;
 }
 
 Future<std::string> RestoreConfig::getFullStatus_impl(RestoreConfig restore, Reference<ReadYourWritesTransaction> tr) {
@@ -7887,55 +7901,8 @@ public:
 					bool bulkLoadCompatible = bulkDumpJobIdOpt.present() && !bulkDumpJobIdOpt.get().empty();
 					statusText += format("BulkLoad Compatible: %s\n", bulkLoadCompatible ? "yes" : "no");
 
-					// If using bulkdump mode, show bulkdump progress
-					if (snapshotModeValue == 1 || snapshotModeValue == 2) {
-						Optional<BulkDumpProgress> bulkDumpProgressOpt = co_await getBulkDumpProgress(cx);
-						if (bulkDumpProgressOpt.present()) {
-							BulkDumpProgress bdProgress = bulkDumpProgressOpt.get();
-							statusText += "\nBulkDump progress:\n";
-							statusText += format(" Tasks completed - %d / %d (%.1f%%)\n",
-							                     bdProgress.completeTasks,
-							                     bdProgress.totalTasks,
-							                     bdProgress.progressPercent());
-
-							statusText +=
-							    format(" Bytes completed - %s\n",
-							           formatBytesProgress(bdProgress.completedBytes, bdProgress.totalBytes).c_str());
-
-							double throughput = bdProgress.avgBytesPerSecond();
-							if (throughput > 0) {
-								statusText += format(" Throughput - %.1f MB/s\n", throughput / 1048576.0);
-							}
-
-							if (bdProgress.etaSeconds().present()) {
-								statusText +=
-								    format(" Estimated time remaining - %s\n",
-								           formatDurationHumanReadable((int)bdProgress.etaSeconds().get()).c_str());
-							}
-
-							if (bdProgress.elapsedSeconds > 0) {
-								statusText +=
-								    format(" Elapsed time - %s\n",
-								           formatDurationHumanReadable((int)bdProgress.elapsedSeconds).c_str());
-							}
-
-							// Show stalled tasks as warnings
-							if (!bdProgress.stalledTasks.empty()) {
-								statusText += format("\nWARNING: %zu stalled tasks (no progress > 60s):\n",
-								                     bdProgress.stalledTasks.size());
-								for (const auto& stalled : bdProgress.stalledTasks) {
-									statusText += format(" Task %s: %s, stalled %.0fs, %d restarts\n",
-									                     stalled.taskId.shortString().c_str(),
-									                     stalled.range.toString().c_str(),
-									                     stalled.stalledSeconds,
-									                     stalled.restartCount);
-									if (!stalled.lastError.empty()) {
-										statusText += format("           Last error: %s\n", stalled.lastError.c_str());
-									}
-								}
-							}
-						}
-					}
+					bool showBulkDump = (snapshotModeValue == 1 || snapshotModeValue == 2);
+					bool showRangeFile = (snapshotModeValue == 0 || snapshotModeValue == 2);
 
 					if (snapshotProgress) {
 						int64_t snapshotInterval{ 0 };
@@ -7969,32 +7936,80 @@ public:
 						    store(snapshotTargetEndVersionTimestamp,
 						          timeKeeperEpochsFromVersion(snapshotTargetEndVersion, tr)));
 
-						statusText += format("Snapshot interval is %lld seconds.  ", snapshotInterval);
-						if (backupState == EBackupState::STATE_RUNNING_DIFFERENTIAL)
-							statusText += format("Current snapshot progress target is %3.2f%% (>100%% means the "
-							                     "snapshot is supposed to be done)\n",
-							                     100.0 * (recentReadVersion - snapshotBeginVersion) /
-							                         (snapshotTargetEndVersion - snapshotBeginVersion));
-						else
-							statusText += "The initial snapshot is still running.\n";
+						if (showBulkDump) {
+							Optional<BulkDumpProgress> bulkDumpProgressOpt = co_await getBulkDumpProgress(cx);
+							statusText += "\nBulkDump Snapshot:\n";
+							if (bulkDumpProgressOpt.present()) {
+								BulkDumpProgress bdProgress = bulkDumpProgressOpt.get();
+								statusText += format(" Tasks: %d/%d complete (%.1f%%)\n",
+								                     bdProgress.completeTasks,
+								                     bdProgress.totalTasks,
+								                     bdProgress.progressPercent());
+								statusText += format(
+								    " Bytes: %s\n",
+								    formatBytesProgress(bdProgress.completedBytes, bdProgress.totalBytes).c_str());
 
-						statusText += format("\nDetails:\n LogBytes written - %lld\n RangeBytes written - %lld\n "
-						                     "Last complete log version and timestamp        - %s, %s\n "
-						                     "Last complete snapshot version and timestamp   - %s, %s\n "
-						                     "Current Snapshot start version and timestamp   - %s, %s\n "
-						                     "Expected snapshot end version and timestamp    - %s, %s\n "
-						                     "Backup supposed to stop at next snapshot completion - %s\n",
-						                     logBytesWritten.orDefault(0),
-						                     rangeBytesWritten.orDefault(0),
+								double throughput = bdProgress.avgBytesPerSecond();
+								if (throughput > 0) {
+									statusText += format(" Throughput: %.1f MB/s\n", throughput / 1048576.0);
+								}
+
+								if (bdProgress.elapsedSeconds > 0) {
+									statusText +=
+									    format(" Elapsed: %s\n",
+									           formatDurationHumanReadable((int)bdProgress.elapsedSeconds).c_str());
+								}
+
+								if (bdProgress.etaSeconds().present()) {
+									statusText +=
+									    format(" ETA: %s\n",
+									           formatDurationHumanReadable((int)bdProgress.etaSeconds().get()).c_str());
+								}
+
+								if (!bdProgress.stalledTasks.empty()) {
+									statusText += format("\nWARNING: %zu stalled tasks (no progress > 60s):\n",
+									                     bdProgress.stalledTasks.size());
+									for (const auto& stalled : bdProgress.stalledTasks) {
+										statusText += format(" Task %s: %s, stalled %.0fs, %d restarts\n",
+										                     stalled.taskId.shortString().c_str(),
+										                     stalled.range.toString().c_str(),
+										                     stalled.stalledSeconds,
+										                     stalled.restartCount);
+										if (!stalled.lastError.empty()) {
+											statusText +=
+											    format("           Last error: %s\n", stalled.lastError.c_str());
+										}
+									}
+								}
+							} else {
+								statusText += " Status: pending\n";
+							}
+						}
+
+						if (showRangeFile) {
+							statusText += "\nRangefile Snapshot:\n";
+							statusText +=
+							    format(" Bytes written: %s\n", formatBytesHumanReadable(rangeBytesWritten.orDefault(0)).c_str());
+
+							std::string rangefileStatus;
+							if (backupState == EBackupState::STATE_RUNNING_DIFFERENTIAL) {
+								double pct = 100.0 * (recentReadVersion - snapshotBeginVersion) /
+								             (snapshotTargetEndVersion - snapshotBeginVersion);
+								statusText += format(" Progress: %.2f%%\n", pct);
+							} else {
+								statusText += " Status: Initial snapshot still running\n";
+							}
+							statusText +=
+							    format(" Started: %s\n", timeStampToString(snapshotBeginVersionTimestamp).c_str());
+						}
+
+						statusText += format("\nMutation Logs:\n");
+						statusText += format(" Bytes written: %s\n", formatBytesHumanReadable(logBytesWritten.orDefault(0)).c_str());
+						statusText += format(" Last complete version: %s (%s)\n",
 						                     versionToString(latestLogEndVersion).c_str(),
-						                     timeStampToString(latestLogEndVersionTimestamp).c_str(),
-						                     versionToString(latestSnapshotEndVersion).c_str(),
-						                     timeStampToString(latestSnapshotEndVersionTimestamp).c_str(),
-						                     versionToString(snapshotBeginVersion).c_str(),
-						                     timeStampToString(snapshotBeginVersionTimestamp).c_str(),
-						                     versionToString(snapshotTargetEndVersion).c_str(),
-						                     timeStampToString(snapshotTargetEndVersionTimestamp).c_str(),
-						                     boolToYesOrNo(stopWhenDone).c_str());
+						                     timeStampToString(latestLogEndVersionTimestamp).c_str());
+
+						statusText += format("\nSnapshot interval is %lld seconds.\n", snapshotInterval);
 					}
 
 					// Append the errors, if requested


### PR DESCRIPTION
BEFORE (old output):

```
fdbbackup status:
Snapshot Mode: both
BulkLoad Compatible: no
BulkDump progress:
 Tasks completed - 35546 / 35633 (99.8%)
 Bytes completed - 3081282401872 (2.80 TB) / 3081282401785 (2.80 TB)
 Throughput - 600.9 MB/s
 Elapsed time - 1 hours 21 minutes
Snapshot interval is 864000 seconds.  The initial snapshot is still running. Details:
 LogBytes written - 0
 RangeBytes written - 4128760861276
 Last complete log version and timestamp        - 224414452771, 2026/04/27.17:14:19+0000
 Last complete snapshot version and timestamp   - 221170099677, 2026/04/27.16:20:15+0000
 Current Snapshot start version and timestamp   - 221175893391, 2026/04/27.16:20:21+0000
 Expected snapshot end version and timestamp    - 1085175893391, 2026/05/07.16:20:20+0000

fdbrestore status:
Tag: backup_4tb  UID: abc123  State: running  Blocks: 500/2000  BlocksInProgress: 1500  Submitted: 100  Triggered: 50  Running: 5  TotalTasks: 100  Files: 42  BytesWritten: 4123456789  ApplyVersionLag: 5000000  LastError: None
```

AFTER (new output):
```

fdbbackup status:
Snapshot Mode: both
BulkLoad Compatible: yes
BulkDump Snapshot:
 Tasks: 35546/35633 complete (99.8%)
 Bytes: 2.80 TB / 2.80 TB
 Throughput: 600.9 MB/s
 Elapsed: 1 hours 21 minutes
Rangefile Snapshot:
 Bytes written: 4.1 TB
 Status: Initial snapshot still running
 Started: 2026/04/27.16:20:21+0000
Mutation Logs:
 Bytes written: 0
 Last complete version: 224414452771 (2026/04/27.17:14:19+0000)
Snapshot interval is 864000 seconds.

fdbrestore status (mode=rangefile):
Tag: backup_4tb  UID: abc123  State: running
 Blocks: 500/2000 complete
 Files: 42
 Bytes written: 4.1 TB
 Apply version lag: 5000000

fdbrestore status (mode=bulkload):
Tag: backup_4tb  UID: abc123  State: running
 Tasks submitted: 100  triggered: 50  running: 5
 Tasks complete: 50 / 100 total
 Bytes written: 2.1 TB
 Avg bytes/task: 21 MB

```

Or here is from a ctest


```
Backup status (mode=both):
BulkDump Snapshot:
 Status: pending
Rangefile Snapshot:
 Bytes written: 423 bytes
 Status: Initial snapshot still running
Mutation Logs:
 Bytes written: 0 bytes
```

```
Restore (rangefile mode):
Tag: test_backup  UID: 80bb...  State: completed
 Blocks: 1/1 complete
 Files: 2
 Bytes written: 330 bytes
Restore (bulkload mode):
Tag: test_backup  UID: d135...  State: running
 Tasks submitted: 0  triggered: 0  running: 0
 Tasks complete: 0 / 0 total

```