### PR TITLE
build: release-7.4 backport of boost and toml11 cleanups

### DIFF
--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -211,7 +211,7 @@ if(NOT WIN32)
   target_link_libraries(fdb_c_client_memory_test PRIVATE fdb_c Threads::Threads)
 
   target_include_directories(fdb_c_api_tester_impl PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}/foundationdb/ ${CMAKE_SOURCE_DIR}/flow/include ${CMAKE_BINARY_DIR}/flow/include)
-  target_link_libraries(fdb_c_api_tester_impl PRIVATE fdb_cpp toml11_target Threads::Threads fmt::fmt boost_target)
+  target_link_libraries(fdb_c_api_tester_impl PRIVATE fdb_cpp toml11::toml11 Threads::Threads fmt::fmt boost_target)
   if(NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     target_link_libraries(fdb_c_api_tester_impl PRIVATE stdc++fs)
   endif()

--- a/cmake/CompileBoost.cmake
+++ b/cmake/CompileBoost.cmake
@@ -162,11 +162,10 @@ set(Boost_USE_STATIC_LIBS ON)
 if (UNIX AND CMAKE_CXX_COMPILER_ID MATCHES "Clang$" AND USE_LIBCXX)
   list(APPEND CMAKE_PREFIX_PATH /opt/boost_1_86_0_clang)
   set(BOOST_HINT_PATHS /opt/boost_1_86_0_clang)
-  message(STATUS "Using Clang version of boost")
+  message(STATUS "Preferring _clang build of boost ...")
 else ()
   list(APPEND CMAKE_PREFIX_PATH /opt/boost_1_86_0)
   set(BOOST_HINT_PATHS /opt/boost_1_86_0)
-  message(STATUS "Using g++ version of boost")
 endif ()
 
 if(BOOST_ROOT)
@@ -180,16 +179,24 @@ if(WIN32)
   # I think depending on the cmake version this will cause weird warnings
   find_package(Boost 1.86 COMPONENTS filesystem iostreams serialization system program_options url)
   add_library(boost_target INTERFACE)
-  target_link_libraries(boost_target INTERFACE Boost::boost Boost::filesystem Boost::iostreams Boost::serialization Boost::system Boost::url)
-
+  target_link_libraries(boost_target
+                        INTERFACE Boost::boost
+                                  Boost::filesystem
+                                  Boost::iostreams
+                                  Boost::serialization
+                                  Boost::system
+                                  Boost::url
+  )
   add_library(boost_target_program_options INTERFACE)
   target_link_libraries(boost_target_program_options INTERFACE Boost::boost Boost::program_options)
   return()
 endif()
 
-find_package(Boost 1.86.0 EXACT QUIET COMPONENTS context filesystem iostreams program_options serialization system url CONFIG PATHS ${BOOST_HINT_PATHS})
-set(FORCE_BOOST_BUILD OFF CACHE BOOL "Forces cmake to build boost and ignores any installed boost")
+find_package(Boost 1.86.0 EXACT QUIET
+             COMPONENTS context filesystem iostreams program_options serialization system url
+             CONFIG PATHS ${BOOST_HINT_PATHS})
 
+set(FORCE_BOOST_BUILD OFF CACHE BOOL "Forces cmake to build boost and ignores any installed boost")
 # The precompiled boost silently broke in CI.  While investigating, I considered extending
 # the old check with something like this, so that it would fail loudly if it found a bad
 # pre-existing boost.  It turns out the error messages we get from CMake explain what is
@@ -204,9 +211,17 @@ set(FORCE_BOOST_BUILD OFF CACHE BOOL "Forces cmake to build boost and ignores an
 #      message(FATAL_ERROR "Unacceptable precompiled boost found")
 #
 if(Boost_FOUND AND NOT FORCE_BOOST_BUILD)
+  message(STATUS "Found Boost: ${Boost_DIR}")
   add_library(boost_target INTERFACE)
-  target_link_libraries(boost_target INTERFACE Boost::boost Boost::context Boost::filesystem Boost::iostreams Boost::serialization Boost::system Boost::url)
-
+  target_link_libraries(boost_target
+                        INTERFACE Boost::boost
+                                  Boost::context
+                                  Boost::filesystem
+                                  Boost::iostreams
+                                  Boost::serialization
+                                  Boost::system
+                                  Boost::url
+  )
   add_library(boost_target_program_options INTERFACE)
   target_link_libraries(boost_target_program_options INTERFACE Boost::boost Boost::program_options)
 elseif(WIN32)

--- a/cmake/FDBComponents.cmake
+++ b/cmake/FDBComponents.cmake
@@ -183,28 +183,15 @@ set(WITH_LIBURING OFF CACHE BOOL "Build with liburing enabled") # Set this to ON
 # TOML11
 ################################################################################
 
-# TOML can download and install itself into the binary directory, so it should
-# always be available.
-find_package(toml11 QUIET)
-if(toml11_FOUND)
-  add_library(toml11_target INTERFACE)
-  target_link_libraries(toml11_target INTERFACE toml11::toml11)
-else()
-  include(ExternalProject)
-  ExternalProject_add(toml11Project
-    URL "https://github.com/ToruNiina/toml11/archive/v3.4.0.tar.gz"
-    URL_HASH SHA256=bc6d733efd9216af8c119d8ac64a805578c79cc82b813e4d1d880ca128bd154d
-    CMAKE_CACHE_ARGS
-      -DCMAKE_POLICY_VERSION_MINIMUM:STRING=3.5  # force compat with newer cmake
-      -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
-      -DCMAKE_C_COMPILER:FILEPATH=${CMAKE_C_COMPILER}
-      -DCMAKE_CXX_COMPILER:FILEPATH=${CMAKE_CXX_COMPILER}
-      -DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_CURRENT_BINARY_DIR}/toml11
-      -Dtoml11_BUILD_TEST:BOOL=OFF
-    BUILD_ALWAYS ON)
-  add_library(toml11_target INTERFACE)
-  add_dependencies(toml11_target toml11Project)
-  target_include_directories(toml11_target SYSTEM INTERFACE ${CMAKE_CURRENT_BINARY_DIR}/toml11/include)
+find_package(toml11 3.8.1 EXACT CONFIG)
+if(NOT toml11_FOUND)
+  include(FetchContent)
+  FetchContent_Declare(
+    toml11
+    URL "https://github.com/ToruNiina/toml11/archive/v3.8.1.tar.gz"
+    URL_HASH SHA256=6a3d20080ecca5ea42102c078d3415bef80920f6c4ea2258e87572876af77849
+  )
+  FetchContent_MakeAvailable(toml11)
 endif()
 
 ################################################################################

--- a/cmake/GetFmt.cmake
+++ b/cmake/GetFmt.cmake
@@ -1,4 +1,4 @@
-find_package(fmt 11.1.4 EXACT QUIET CONFIG)
+find_package(fmt 11.1.4 EXACT CONFIG)
 
 if(NOT fmt_FOUND)
   include(FetchContent)

--- a/fdbserver/CMakeLists.txt
+++ b/fdbserver/CMakeLists.txt
@@ -157,7 +157,7 @@ if(USE_JEMALLOC)
   target_link_libraries(fdbserver PRIVATE jemalloc::jemalloc)
 endif()
 
-target_link_libraries(fdbserver PRIVATE toml11_target rapidjson)
+target_link_libraries(fdbserver PRIVATE toml11::toml11 rapidjson)
 if(WITH_ROCKSDB)
   target_compile_definitions(fdbserver PRIVATE WITH_ROCKSDB)
 endif()


### PR DESCRIPTION
Boost : e402f876aed4 : just logging during configure and line wrapping.

toml11 : 4a12b4404244 : switch from ExternalProject to FetchContent, and update from 3.4.0 to 3.8.1 (which I'm pretty sure does not affect anything at runtime, just loading simulation tests).

