### PR TITLE
Design changes to pass encryption_block_size to fdbbackup command and remove knob

### DIFF
--- a/fdbbackup/FileConverter.actor.cpp
+++ b/fdbbackup/FileConverter.actor.cpp
@@ -454,7 +454,7 @@ private:
 
 ACTOR Future<Void> convert(ConvertParams params) {
 	state Reference<IBackupContainer> container =
-	    IBackupContainer::openContainer(params.container_url, params.proxy, {});
+	    IBackupContainer::openContainer(params.container_url, params.proxy, {}, 0);
 	state BackupFileList listing = wait(container->dumpFileList());
 	std::sort(listing.logs.begin(), listing.logs.end());
 	TraceEvent("Container").detail("URL", params.container_url).detail("Logs", listing.logs.size());

--- a/fdbbackup/FileDecoder.actor.cpp
+++ b/fdbbackup/FileDecoder.actor.cpp
@@ -103,6 +103,8 @@ void printDecodeUsage() {
 	             "  --knob-KNOBNAME KNOBVALUE\n"
 	             "                 Changes a knob value. KNOBNAME should be lowercase.\n"
 	             "  -s, --save     Save a copy of downloaded files (default: not saving).\n"
+	             "  --encryption-key-file FILE\n"
+	             "                 AES-128-GCM encryption key file for encrypted backups.\n"
 	             "\n";
 	return;
 }
@@ -130,6 +132,7 @@ struct DecodeParams : public ReferenceCounted<DecodeParams> {
 	Version endVersionFilter = std::numeric_limits<Version>::max();
 
 	std::vector<std::pair<std::string, std::string>> knobs;
+	Optional<std::string> encryptionKeyFileName;
 
 	// Returns if [begin, end) overlap with the filter range
 	bool overlap(Version begin, Version end) const {
@@ -237,6 +240,9 @@ struct DecodeParams : public ReferenceCounted<DecodeParams> {
 			s.append(", KNOB-").append(knob).append(" = ").append(value);
 		}
 		s.append(", SaveFile: ").append(save_file_locally ? "true" : "false");
+		if (encryptionKeyFileName.present()) {
+			s.append(", EncryptionKeyFile: ").append(encryptionKeyFileName.get());
+		}
 		return s;
 	}
 
@@ -392,6 +398,10 @@ int parseDecodeCommandLine(Reference<DecodeParams> param, CSimpleOpt* args) {
 
 		case OPT_SAVE_FILE:
 			param->save_file_locally = true;
+			break;
+
+		case OPT_ENCRYPTION_KEY_FILE:
+			param->encryptionKeyFileName = args->OptionArg();
 			break;
 
 		case TLSConfig::OPT_TLS_PLUGIN:
@@ -808,7 +818,7 @@ ACTOR Future<std::vector<RangeFile>> getRangeFiles(Reference<IBackupContainer> b
 
 ACTOR Future<Void> decode_logs(Reference<DecodeParams> params) {
 	state Reference<IBackupContainer> container =
-	    IBackupContainer::openContainer(params->container_url, params->proxy, {});
+	    IBackupContainer::openContainer(params->container_url, params->proxy, params->encryptionKeyFileName, 0);
 	state UID uid = deterministicRandom()->randomUniqueID();
 	state BackupFileList listing = wait(container->dumpFileList());
 	// remove partitioned logs
@@ -824,6 +834,8 @@ ACTOR Future<Void> decode_logs(Reference<DecodeParams> params) {
 	TraceEvent("DecodeParam", uid).setMaxFieldLength(100000).detail("Value", params->toString());
 
 	BackupDescription desc = wait(container->describeBackup());
+	container->setEncryptionBlockSize(desc.encryptionBlockSize);
+
 	std::cout << "\n" << desc.toString() << "\n";
 
 	state std::vector<LogFile> logFiles;

--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -145,6 +145,7 @@ enum {
 	OPT_BACKUPKEYS_FILTER,
 	OPT_INCREMENTALONLY,
 	OPT_ENCRYPTION_KEY_FILE,
+	OPT_ENCRYPTION_BLOCK_SIZE,
 
 	// Backup Modify
 	OPT_MOD_ACTIVE_INTERVAL,
@@ -282,6 +283,7 @@ CSimpleOpt::SOption g_rgBackupStartOptions[] = {
 	{ OPT_BLOB_CREDENTIALS, "--blob-credentials", SO_REQ_SEP },
 	{ OPT_INCREMENTALONLY, "--incremental", SO_NONE },
 	{ OPT_ENCRYPTION_KEY_FILE, "--encryption-key-file", SO_REQ_SEP },
+	{ OPT_ENCRYPTION_BLOCK_SIZE, "--encryption-block-size", SO_REQ_SEP },
 	{ OPT_ENCRYPT_FILES, "--encrypt-files", SO_REQ_SEP },
 	TLS_OPTION_FLAGS,
 	SO_END_OF_OPTIONS
@@ -1133,6 +1135,9 @@ static void printBackupUsage(bool devhelp) {
 	       "                 For modify operations, need to pass encryption key file only if Backup container URL is "
 	       "changed to "
 	       "re-encrypt all future backup files. \n");
+	printf("  --encryption-block-size"
+	       "                 Block size in bytes for file encryption. Only used with fdbbackup start command. Default "
+	       "is 1048576 (1MB).\n");
 	printf("  --encrypt-files 0/1"
 	       "                 If passed, this argument will allow the user to override the database encryption state to "
 	       "either enable (1) or disable (0) encryption at rest with snapshot backups. This option refers to block "
@@ -2003,7 +2008,8 @@ ACTOR Future<Void> submitBackup(Database db,
                                 StopWhenDone stopWhenDone,
                                 UsePartitionedLog usePartitionedLog,
                                 IncrementalBackupOnly incrementalBackupOnly,
-                                Optional<std::string> encryptionKeyFile) {
+                                Optional<std::string> encryptionKeyFile,
+                                int encryptionBlockSize) {
 	try {
 		state FileBackupAgent backupAgent;
 		ASSERT(!backupRanges.empty());
@@ -2057,7 +2063,8 @@ ACTOR Future<Void> submitBackup(Database db,
 			                              stopWhenDone,
 			                              usePartitionedLog,
 			                              incrementalBackupOnly,
-			                              encryptionKeyFile));
+			                              encryptionKeyFile,
+			                              encryptionBlockSize));
 
 			// Wait for the backup to complete, if requested
 			if (waitForCompletion) {
@@ -2332,7 +2339,8 @@ ACTOR Future<Void> changeDBBackupResumed(Database src, Database dest, bool pause
 Reference<IBackupContainer> openBackupContainer(const char* name,
                                                 const std::string& destinationContainer,
                                                 const Optional<std::string>& proxy,
-                                                const Optional<std::string>& encryptionKeyFile) {
+                                                const Optional<std::string>& encryptionKeyFile,
+                                                int encryptionBlockSize) {
 	// Error, if no dest container was specified
 	if (destinationContainer.empty()) {
 		fprintf(stderr, "ERROR: No backup destination was specified.\n");
@@ -2342,7 +2350,7 @@ Reference<IBackupContainer> openBackupContainer(const char* name,
 
 	Reference<IBackupContainer> c;
 	try {
-		c = IBackupContainer::openContainer(destinationContainer, proxy, encryptionKeyFile);
+		c = IBackupContainer::openContainer(destinationContainer, proxy, encryptionKeyFile, encryptionBlockSize);
 	} catch (Error& e) {
 		std::string msg = format("ERROR: '%s' on URL '%s'", e.what(), destinationContainer.c_str());
 		if (e.code() == error_code_backup_invalid_url && !IBackupContainer::lastOpenError.empty()) {
@@ -2408,9 +2416,10 @@ ACTOR Future<Void> runRestore(Database db,
 	try {
 		state FileBackupAgent backupAgent;
 
-		state Reference<IBackupContainer> bc =
-		    openBackupContainer(exeRestore.toString().c_str(), container, proxy, encryptionKeyFile);
-
+		// encryptionBlockSize is passed 0 because we don't know about the block size yet and it will be read in the
+		// describeBackup call after this.
+		state Reference<IBackupContainer> bc = openBackupContainer(
+		    exeRestore.toString().c_str(), container, proxy, encryptionKeyFile, /*encryptionBlockSize=*/0);
 		// If targetVersion is unset then use the maximum restorable version from the backup description
 		if (targetVersion == invalidVersion) {
 			if (verbose)
@@ -2513,7 +2522,8 @@ ACTOR Future<Void> runFastRestoreTool(Database db,
 		if (performRestore) {
 			if (dbVersion == invalidVersion) {
 				TraceEvent("FastRestoreTool").detail("TargetRestoreVersion", "Largest restorable version");
-				BackupDescription desc = wait(IBackupContainer::openContainer(container, proxy, {})->describeBackup());
+				BackupDescription desc =
+				    wait(IBackupContainer::openContainer(container, proxy, {}, 0)->describeBackup());
 				if (!desc.maxRestorableVersion.present()) {
 					fprintf(stderr, "The specified backup is not restorable to any version.\n");
 					throw restore_error();
@@ -2552,7 +2562,7 @@ ACTOR Future<Void> runFastRestoreTool(Database db,
 
 			restoreVersion = dbVersion;
 		} else {
-			state Reference<IBackupContainer> bc = IBackupContainer::openContainer(container, proxy, {});
+			state Reference<IBackupContainer> bc = IBackupContainer::openContainer(container, proxy, {}, 0);
 			state BackupDescription description = wait(bc->describeBackup());
 
 			if (dbVersion <= 0) {
@@ -2599,7 +2609,7 @@ ACTOR Future<Void> dumpBackupData(const char* name,
                                   Optional<std::string> proxy,
                                   Version beginVersion,
                                   Version endVersion) {
-	state Reference<IBackupContainer> c = openBackupContainer(name, destinationContainer, proxy, {});
+	state Reference<IBackupContainer> c = openBackupContainer(name, destinationContainer, proxy, {}, 0);
 
 	if (beginVersion < 0 || endVersion < 0) {
 		BackupDescription desc = wait(c->describeBackup());
@@ -2652,7 +2662,7 @@ ACTOR Future<Void> expireBackupData(const char* name,
 	}
 
 	try {
-		Reference<IBackupContainer> c = openBackupContainer(name, destinationContainer, proxy, {});
+		Reference<IBackupContainer> c = openBackupContainer(name, destinationContainer, proxy, {}, 0);
 
 		state IBackupContainer::ExpireProgress progress;
 		state std::string lastProgress;
@@ -2704,7 +2714,7 @@ ACTOR Future<Void> deleteBackupContainer(const char* name,
                                          std::string destinationContainer,
                                          Optional<std::string> proxy) {
 	try {
-		state Reference<IBackupContainer> c = openBackupContainer(name, destinationContainer, proxy, {});
+		state Reference<IBackupContainer> c = openBackupContainer(name, destinationContainer, proxy, {}, 0);
 		state int numDeleted = 0;
 		state Future<Void> done = c->deleteContainer(&numDeleted);
 
@@ -2743,7 +2753,7 @@ ACTOR Future<Void> describeBackup(const char* name,
                                   Optional<Database> cx,
                                   bool json) {
 	try {
-		Reference<IBackupContainer> c = openBackupContainer(name, destinationContainer, proxy, {});
+		Reference<IBackupContainer> c = openBackupContainer(name, destinationContainer, proxy, {}, 0);
 		state BackupDescription desc = wait(c->describeBackup(deep));
 		if (cx.present())
 			wait(desc.resolveVersionTimes(cx.get()));
@@ -2841,7 +2851,7 @@ ACTOR Future<Void> queryBackup(const char* name,
 	state JsonBuilderArray rangeFilesJson;
 	state JsonBuilderArray logFilesJson;
 	try {
-		state Reference<IBackupContainer> bc = openBackupContainer(name, destinationContainer, proxy, {});
+		state Reference<IBackupContainer> bc = openBackupContainer(name, destinationContainer, proxy, {}, 0);
 		BackupDescription desc = wait(bc->describeBackup());
 		// Use continuous log end version for the maximum restorable version for the key ranges when a restorable
 		// version doesn't exist.
@@ -3093,9 +3103,13 @@ ACTOR Future<Void> modifyBackup(Database db, std::string tagName, BackupModifyOp
 				    .detail("TagName", tagName)
 				    .detail("DestURL", options.destURL.get())
 				    .detail("EncryptionKeyFile",
-				            options.encryptionKeyFile.present() ? options.encryptionKeyFile.get() : "None");
-				bc = openBackupContainer(
-				    exeBackup.toString().c_str(), options.destURL.get(), options.proxy, options.encryptionKeyFile);
+				            options.encryptionKeyFile.present() ? options.encryptionKeyFile.get() : "None")
+				    .detail("EncryptionBlockSize", prevContainer->getEncryptionBlockSize());
+				bc = openBackupContainer(exeBackup.toString().c_str(),
+				                         options.destURL.get(),
+				                         options.proxy,
+				                         options.encryptionKeyFile,
+				                         prevContainer->getEncryptionBlockSize());
 				try {
 					wait(timeoutError(bc->create(), 30));
 				} catch (Error& e) {
@@ -3109,7 +3123,7 @@ ACTOR Future<Void> modifyBackup(Database db, std::string tagName, BackupModifyOp
 				}
 
 				config.backupContainer().set(tr, bc);
-				wait(bc->writeEncryptionMetadata());
+				wait(bc->writeEncryptionMetadata(bc->getEncryptionBlockSize()));
 			} else if (options.encryptionKeyFile.present()) {
 				fprintf(stdout,
 				        " Encryption key file specified without a new destination URL."
@@ -3602,6 +3616,7 @@ int main(int argc, char* argv[]) {
 		bool jsonOutput = false;
 		DeleteData deleteData{ false };
 		Optional<std::string> encryptionKeyFile;
+		int encryptionBlockSize = 0;
 
 		BackupModifyOptions modifyOptions;
 
@@ -3883,6 +3898,20 @@ int main(int argc, char* argv[]) {
 			case OPT_ENCRYPTION_KEY_FILE:
 				encryptionKeyFile = args->OptionArg();
 				modifyOptions.encryptionKeyFile = encryptionKeyFile;
+				break;
+			case OPT_ENCRYPTION_BLOCK_SIZE:
+				try {
+					encryptionBlockSize = std::stoi(args->OptionArg());
+				} catch (std::exception&) {
+					fprintf(stderr, "ERROR: Invalid encryption block size `%s'\n", args->OptionArg());
+					printHelpTeaser(argv[0]);
+					return FDB_EXIT_ERROR;
+				}
+				if (encryptionBlockSize <= 0) {
+					fprintf(stderr, "ERROR: Invalid encryption block size `%s'\n", args->OptionArg());
+					printHelpTeaser(argv[0]);
+					return FDB_EXIT_ERROR;
+				}
 				break;
 			case OPT_RESTORECONTAINER:
 				restoreContainer = args->OptionArg();
@@ -4221,6 +4250,15 @@ int main(int argc, char* argv[]) {
 			return result.present();
 		};
 
+		if (encryptionKeyFile.present() && encryptionBlockSize == 0) {
+			encryptionBlockSize = DEFAULT_ENCRYPTION_BLOCK_SIZE;
+		}
+
+		if (encryptionBlockSize > 0 && !encryptionKeyFile.present()) {
+			fprintf(stderr, "ERROR: --encryption-block-size option requires --encryption-key-file to be set\n");
+			return FDB_EXIT_ERROR;
+		}
+
 		// The fastrestore tool does not yet support multiple ranges and is incompatible with tenants
 		// or other features that back up data in the system keys
 		if (!restoreSystemKeys && !restoreUserKeys && backupKeys.empty() &&
@@ -4261,7 +4299,7 @@ int main(int argc, char* argv[]) {
 					return FDB_EXIT_ERROR;
 				// Test out the backup url to make sure it parses.  Doesn't test to make sure it's actually
 				// writeable.
-				openBackupContainer(argv[0], destinationContainer, proxy, encryptionKeyFile);
+				openBackupContainer(argv[0], destinationContainer, proxy, encryptionKeyFile, encryptionBlockSize);
 				f = stopAfter(submitBackup(db,
 				                           destinationContainer,
 				                           proxy,
@@ -4275,7 +4313,8 @@ int main(int argc, char* argv[]) {
 				                           stopWhenDone,
 				                           usePartitionedLog,
 				                           incrementalBackupOnly,
-				                           encryptionKeyFile));
+				                           encryptionKeyFile,
+				                           encryptionBlockSize));
 				break;
 			}
 

--- a/fdbbackup/include/fdbbackup/FileConverter.h
+++ b/fdbbackup/include/fdbbackup/FileConverter.h
@@ -52,6 +52,7 @@ enum {
 	OPT_END_VERSION_FILTER,
 	OPT_KNOB,
 	OPT_SAVE_FILE,
+	OPT_ENCRYPTION_KEY_FILE,
 	OPT_HELP
 };
 
@@ -84,6 +85,7 @@ CSimpleOpt::SOption gConverterOptions[] = { { OPT_CONTAINER, "-r", SO_REQ_SEP },
 	                                        { OPT_KNOB, "--knob-", SO_REQ_SEP },
 	                                        { OPT_SAVE_FILE, "-s", SO_NONE },
 	                                        { OPT_SAVE_FILE, "--save", SO_NONE },
+	                                        { OPT_ENCRYPTION_KEY_FILE, "--encryption-key-file", SO_REQ_SEP },
 	                                        { OPT_HELP, "-?", SO_NONE },
 	                                        { OPT_HELP, "-h", SO_NONE },
 	                                        { OPT_HELP, "--help", SO_NONE },

--- a/fdbclient/BackupContainer.actor.cpp
+++ b/fdbclient/BackupContainer.actor.cpp
@@ -135,6 +135,7 @@ std::string BackupDescription::toString() const {
 	info.append(format("Restorable: %s\n", maxRestorableVersion.present() ? "true" : "false"));
 	info.append(format("Partitioned logs: %s\n", partitioned ? "true" : "false"));
 	info.append(format("File-level encryption: %s\n", fileLevelEncryption ? "true" : "false"));
+	info.append(format("Encryption block size: %d\n", encryptionBlockSize));
 
 	auto formatVersion = [&](Version v) {
 		std::string s;
@@ -194,6 +195,7 @@ std::string BackupDescription::toJSON() const {
 	doc.setKey("Restorable", maxRestorableVersion.present());
 	doc.setKey("Partitioned", partitioned);
 	doc.setKey("FileLevelEncryption", fileLevelEncryption);
+	doc.setKey("EncryptionBlockSize", encryptionBlockSize);
 
 	auto formatVersion = [&](Version v) {
 		JsonBuilderObject doc;
@@ -261,17 +263,27 @@ std::vector<std::string> IBackupContainer::getURLFormats() {
 // Get an IBackupContainer based on a container URL string
 Reference<IBackupContainer> IBackupContainer::openContainer(const std::string& url,
                                                             const Optional<std::string>& proxy,
-                                                            const Optional<std::string>& encryptionKeyFileName) {
+                                                            const Optional<std::string>& encryptionKeyFileName,
+                                                            int encryptionBlockSize) {
 	static std::map<std::string, Reference<IBackupContainer>> m_cache;
 
-	Reference<IBackupContainer>& r = m_cache[url];
-	if (r)
+	// disable caching for file:// URLs in simulation:
+	// multiple concurrent backups to the same base URL can have different encryption settings.
+	//
+	// Note: This only affects simulation; production always uses the cache for performance.
+	bool skipCache = g_network && g_network->isSimulated() && url.find("file://") == 0;
+
+	// Use a reference to the cache entry (for automatic cache population) unless we're skipping cache
+	Reference<IBackupContainer> r_local;
+	Reference<IBackupContainer>& r = skipCache ? r_local : m_cache[url];
+	if (r) {
 		return r;
+	}
 
 	try {
 		StringRef u(url);
 		if (u.startsWith("file://"_sr)) {
-			r = makeReference<BackupContainerLocalDirectory>(url, encryptionKeyFileName);
+			r = makeReference<BackupContainerLocalDirectory>(url, encryptionKeyFileName, encryptionBlockSize);
 		} else if (u.startsWith("blobstore://"_sr)) {
 			std::string resource;
 			Optional<std::string> blobstoreProxy;
@@ -294,7 +306,8 @@ Reference<IBackupContainer> IBackupContainer::openContainer(const std::string& u
 			for (auto c : resource)
 				if (!isalnum(c) && c != '_' && c != '-' && c != '.' && c != '/')
 					throw backup_invalid_url();
-			r = makeReference<BackupContainerS3BlobStore>(bstore, resource, backupParams, encryptionKeyFileName, true);
+			r = makeReference<BackupContainerS3BlobStore>(
+			    bstore, resource, backupParams, encryptionKeyFileName, encryptionBlockSize, true);
 		}
 #ifdef BUILD_AZURE_BACKUP
 		else if (u.startsWith("azure://"_sr)) {
@@ -387,7 +400,7 @@ ACTOR Future<std::vector<std::string>> listContainers_impl(std::string baseURL, 
 			}
 
 			// Create a dummy container to parse the backup-specific parameters from the URL and get a final bucket name
-			BackupContainerS3BlobStore dummy(bstore, "dummy", backupParams, {}, true);
+			BackupContainerS3BlobStore dummy(bstore, "dummy", backupParams, {}, 0, true);
 
 			std::vector<std::string> results = wait(BackupContainerS3BlobStore::listURLs(bstore, dummy.getBucket()));
 			return results;

--- a/fdbclient/BackupContainerFileSystem.actor.cpp
+++ b/fdbclient/BackupContainerFileSystem.actor.cpp
@@ -490,6 +490,76 @@ public:
 		return prevEnd;
 	}
 
+	// Read encryption metadata from JSON file
+	ACTOR static Future<std::pair<bool, int>> readEncryptionMetadata(Reference<BackupContainerFileSystem> bc) {
+		try {
+			state Reference<IAsyncFile> f = wait(bc->readFile(BackupContainerFileSystem::encryptionMetadataFileName()));
+			state int64_t size = wait(f->size());
+			state std::string content;
+			content.resize(size);
+			wait(success(uncancellable(holdWhile(f, f->read((uint8_t*)content.data(), size, 0)))));
+
+			json_spirit::mValue json;
+			if (json_spirit::read_string(content, json) && json.type() == json_spirit::obj_type) {
+				auto& obj = json.get_obj();
+
+				// Both fields must be present with correct types.
+				if (!obj.count("is_encryption_enabled") ||
+				    obj.at("is_encryption_enabled").type() != json_spirit::bool_type ||
+				    !obj.count("encryption_block_size") ||
+				    obj.at("encryption_block_size").type() != json_spirit::int_type) {
+					fprintf(stderr, "ERROR: Encryption metadata file is missing required fields or has wrong types.\n");
+					TraceEvent(SevError, "BackupContainerReadEncryptionMetadataMalformed")
+					    .detail("URL", bc->getURL())
+					    .detail("File", BackupContainerFileSystem::encryptionMetadataFileName());
+					throw file_corrupt();
+				}
+
+				bool enabled = obj.at("is_encryption_enabled").get_bool();
+				int blockSize = obj.at("encryption_block_size").get_int();
+
+				if ((enabled && blockSize <= 0) || (!enabled && blockSize != 0)) {
+					fprintf(stderr,
+					        "ERROR: Encryption metadata is inconsistent (enabled=%d, blockSize=%d).\n",
+					        enabled,
+					        blockSize);
+					TraceEvent(SevError, "BackupContainerReadEncryptionMetadataInconsistent")
+					    .detail("URL", bc->getURL())
+					    .detail("IsEncryptionEnabled", enabled)
+					    .detail("EncryptionBlockSize", blockSize);
+					throw file_corrupt();
+				}
+
+				TraceEvent("BackupContainerReadEncryptionMetadata")
+				    .detail("URL", bc->getURL())
+				    .detail("IsEncryptionEnabled", enabled)
+				    .detail("EncryptionBlockSize", blockSize);
+				return std::make_pair(enabled, blockSize);
+			} else {
+				// If the file is malformed, throw an error.
+				fprintf(stderr, "ERROR: Failed to read encryption_metadata file due to incorrect format\n");
+				TraceEvent(SevError, "BackupContainerReadEncryptionMetadataMalformed")
+				    .detail("URL", bc->getURL())
+				    .detail("File", BackupContainerFileSystem::encryptionMetadataFileName());
+				throw file_corrupt();
+			}
+		} catch (Error& e) {
+			if (e.code() == error_code_file_not_found) {
+				// File may not be present for older backups, return encryption disabled.
+				TraceEvent(SevWarn, "BackupContainerEncryptionMetadataNotFound")
+				    .detail("URL", bc->getURL())
+				    .detail("File", BackupContainerFileSystem::encryptionMetadataFileName());
+				return std::make_pair(false, 0);
+			}
+			fprintf(stderr, "ERROR: Failed to read encryption_metadata file due to an error.\n");
+			TraceEvent(SevError, "BackupContainerReadEncryptionMetadataError")
+			    .error(e)
+			    .detail("URL", bc->getURL())
+			    .detail("File", BackupContainerFileSystem::encryptionMetadataFileName());
+			throw file_not_readable();
+		}
+	}
+
 	ACTOR static Future<BackupDescription> describeBackup(Reference<BackupContainerFileSystem> bc,
 	                                                      bool deepScan,
 	                                                      Version logStartVersionOverride) {
@@ -523,13 +593,13 @@ public:
 		state Optional<Version> metaExpiredEnd;
 		state Optional<Version> metaUnreliableEnd;
 		state Optional<Version> metaLogType;
-		state Optional<Version> fileLevelEncryption;
+		state bool fileLevelEncryptionEnabled = false;
+		state int encryptionBlockSize = 0;
 
 		std::vector<Future<Void>> metaReads;
 		metaReads.push_back(store(metaExpiredEnd, bc->expiredEndVersion().get()));
 		metaReads.push_back(store(metaUnreliableEnd, bc->unreliableEndVersion().get()));
 		metaReads.push_back(store(metaLogType, bc->logType().get()));
-		metaReads.push_back(store(fileLevelEncryption, bc->fileLevelEncryption().get()));
 
 		// Only read log begin/end versions if not doing a deep scan, otherwise scan files and recalculate them.
 		if (!deepScan) {
@@ -539,6 +609,10 @@ public:
 
 		wait(waitForAll(metaReads));
 
+		std::pair<bool, int> encryptionMeta = wait(readEncryptionMetadata(bc));
+		fileLevelEncryptionEnabled = encryptionMeta.first;
+		encryptionBlockSize = encryptionMeta.second;
+
 		TraceEvent("BackupContainerDescribe2")
 		    .detail("URL", bc->getURL())
 		    .detail("LogStartVersionOverride", logStartVersionOverride)
@@ -546,10 +620,12 @@ public:
 		    .detail("UnreliableEndVersion", metaUnreliableEnd.orDefault(invalidVersion))
 		    .detail("LogBeginVersion", metaLogBegin.orDefault(invalidVersion))
 		    .detail("LogEndVersion", metaLogEnd.orDefault(invalidVersion))
-		    .detail("LogType", metaLogType.orDefault(-1));
+		    .detail("LogType", metaLogType.orDefault(-1))
+		    .detail("FileLevelEncryption", fileLevelEncryptionEnabled)
+		    .detail("EncryptionBlockSize", encryptionBlockSize);
 
-		// If the logStartVersionOverride is positive (not relative) then ensure that unreliableEndVersion is equal or
-		// greater
+		// If the logStartVersionOverride is positive (not relative) then ensure that unreliableEndVersion is
+		// equal or greater
 		if (logStartVersionOverride != invalidVersion &&
 		    metaUnreliableEnd.orDefault(invalidVersion) < logStartVersionOverride) {
 			metaUnreliableEnd = logStartVersionOverride;
@@ -575,29 +651,30 @@ public:
 			metaLogEnd = Optional<Version>();
 		}
 
-		// If the unreliable end version is not set or is < expiredEndVersion then increase it to expiredEndVersion.
-		// Describe does not update unreliableEnd in the backup metadata for safety reasons as there is no
-		// compare-and-set operation to atomically change it and an expire process could be advancing it simultaneously.
+		// If the unreliable end version is not set or is < expiredEndVersion then increase it to
+		// expiredEndVersion. Describe does not update unreliableEnd in the backup metadata for safety reasons
+		// as there is no compare-and-set operation to atomically change it and an expire process could be
+		// advancing it simultaneously.
 		if (!metaUnreliableEnd.present() || metaUnreliableEnd.get() < metaExpiredEnd.orDefault(0))
 			metaUnreliableEnd = metaExpiredEnd;
 
 		desc.unreliableEndVersion = metaUnreliableEnd;
 		desc.expiredEndVersion = metaExpiredEnd;
 
-		// Start scanning at the end of the unreliable version range, which is the version before which data is likely
-		// missing because an expire process has operated on that range.
+		// Start scanning at the end of the unreliable version range, which is the version before which data is
+		// likely missing because an expire process has operated on that range.
 		state Version scanBegin = desc.unreliableEndVersion.orDefault(0);
 		state Version scanEnd = std::numeric_limits<Version>::max();
 
 		// Use the known log range if present
 		// Logs are assumed to be contiguious between metaLogBegin and metaLogEnd, so initalize desc accordingly
 		if (metaLogBegin.present() && metaLogEnd.present()) {
-			// minLogBegin is the greater of the log begin metadata OR the unreliable end version since we can't count
-			// on log file presence before that version.
+			// minLogBegin is the greater of the log begin metadata OR the unreliable end version since we can't
+			// count on log file presence before that version.
 			desc.minLogBegin = std::max(metaLogBegin.get(), desc.unreliableEndVersion.orDefault(0));
 
-			// Set the maximum known end version of a log file, so far, which is also the assumed contiguous log file
-			// end version
+			// Set the maximum known end version of a log file, so far, which is also the assumed contiguous log
+			// file end version
 			desc.maxLogEnd = metaLogEnd.get();
 			desc.contiguousLogEnd = desc.maxLogEnd;
 
@@ -627,11 +704,8 @@ public:
 			    metaLogType.present() && metaLogType.get() == BackupContainerFileSystemImpl::PARTITIONED_MUTATION_LOG;
 		}
 
-		if (fileLevelEncryption.present() && fileLevelEncryption.get() != 0) {
-			desc.fileLevelEncryption = true;
-		} else {
-			desc.fileLevelEncryption = false;
-		}
+		desc.fileLevelEncryption = fileLevelEncryptionEnabled;
+		desc.encryptionBlockSize = encryptionBlockSize;
 
 		// List logs in version order so log continuity can be analyzed
 		std::sort(logs.begin(), logs.end());
@@ -660,7 +734,8 @@ public:
 		}
 
 		// Only update stored contiguous log begin and end versions if we did NOT use a log start override.
-		// Otherwise, a series of describe operations can result in a version range which is actually missing data.
+		// Otherwise, a series of describe operations can result in a version range which is actually missing
+		// data.
 		if (logStartVersionOverride == invalidVersion) {
 			// If the log metadata begin/end versions are missing (or treated as missing due to invalidity) or
 			// differ from the newly calculated values for minLogBegin and contiguousLogEnd, respectively,
@@ -695,7 +770,8 @@ public:
 		for (auto& s : desc.snapshots) {
 			// Calculate restorability of each snapshot.  Assume true, then try to prove false
 			s.restorable = true;
-			// If this is not a single-version snapshot then see if the available contiguous logs cover its range
+			// If this is not a single-version snapshot then see if the available contiguous logs cover its
+			// range
 			if (s.beginVersion != s.endVersion) {
 				if (!desc.minLogBegin.present() || desc.minLogBegin.get() > s.beginVersion)
 					s.restorable = false;
@@ -738,11 +814,12 @@ public:
 					desc.maxRestorableVersion = desc.contiguousLogEnd.get() - 1;
 			}
 
-			// If there is logs gap after contiguousLogEnd and if current snapshot is restorable(have continuous logs)
+			// If there is logs gap after contiguousLogEnd and if current snapshot is restorable(have continuous
+			// logs)
 			if (desc.contiguousLogEnd.present() &&
 			    ((desc.contiguousLogEnd.get() < s.beginVersion) ||
-			     // if contiguousLogEnd==s.beginVersion==s.endVersion, there is no need to check for continuous logs in
-			     // single version snapshot. And this case is covered in above if condition.
+			     // if contiguousLogEnd==s.beginVersion==s.endVersion, there is no need to check for continuous
+			     // logs in single version snapshot. And this case is covered in above if condition.
 			     (desc.contiguousLogEnd.get() == s.beginVersion && s.beginVersion != s.endVersion)) &&
 			    s.restorable.get()) {
 				if (desc.minRestorableVersion.present() && desc.maxRestorableVersion.present()) {
@@ -769,7 +846,8 @@ public:
 					}
 				} else {
 					// There is no previous snapshot that is restorable.
-					// Since the current snapshot is restorable, set the snapshot beginversion as minRestorableVersion.
+					// Since the current snapshot is restorable, set the snapshot beginversion as
+					// minRestorableVersion.
 					desc.minRestorableVersion = s.endVersion;
 				}
 
@@ -813,12 +891,13 @@ public:
 		restorableBeginVersion = resolveRelativeVersion(
 		    desc.maxLogEnd, restorableBeginVersion, "RestorableBeginVersion", invalid_option_value());
 
-		// It would be impossible to have restorability to any version < expireEndVersion after expiring to that version
+		// It would be impossible to have restorability to any version < expireEndVersion after expiring to that
+		// version
 		if (restorableBeginVersion < expireEndVersion)
 			throw backup_cannot_expire();
 
-		// If the expire request is to a version at or before the previous version to which data was already deleted
-		// then do nothing and just return
+		// If the expire request is to a version at or before the previous version to which data was already
+		// deleted then do nothing and just return
 		if (expireEndVersion <= desc.expiredEndVersion.orDefault(invalidVersion)) {
 			return Void();
 		}
@@ -875,8 +954,8 @@ public:
 			if (last.endVersion == expireEndVersion) {
 				newLogBeginVersion = expireEndVersion;
 			} else {
-				// If the last log overlaps the expiredEnd then use the log's begin version and move the expiredEnd
-				// back to match it and keep the last log file
+				// If the last log overlaps the expiredEnd then use the log's begin version and move the
+				// expiredEnd back to match it and keep the last log file
 				if (last.endVersion > expireEndVersion) {
 					newLogBeginVersion = last.beginVersion;
 
@@ -902,10 +981,10 @@ public:
 
 		// Move filenames out of vector then destroy it to save memory
 		for (auto const& f : ranges) {
-			// The file version must be checked here again because it is likely that expireEndVersion is in the middle
-			// of a log file, in which case after the log and range file listings are done (using the original
-			// expireEndVersion) the expireEndVersion will be moved back slightly to the begin version of the last log
-			// file found (which is also the first log to not be deleted)
+			// The file version must be checked here again because it is likely that expireEndVersion is in the
+			// middle of a log file, in which case after the log and range file listings are done (using the
+			// original expireEndVersion) the expireEndVersion will be moved back slightly to the begin version
+			// of the last log file found (which is also the first log to not be deleted)
 			if (f.version < expireEndVersion) {
 				toDelete.push_back(std::move(f.fileName));
 			}
@@ -919,8 +998,9 @@ public:
 		desc = BackupDescription();
 
 		// We are about to start deleting files, at which point all data prior to expireEndVersion is considered
-		// 'unreliable' as some or all of it will be missing.  So before deleting anything, read unreliableEndVersion
-		// (don't use cached value in desc) and update its value if it is missing or < expireEndVersion
+		// 'unreliable' as some or all of it will be missing.  So before deleting anything, read
+		// unreliableEndVersion (don't use cached value in desc) and update its value if it is missing or <
+		// expireEndVersion
 		if (progress != nullptr) {
 			progress->step = "Initial metadata update";
 		}
@@ -935,8 +1015,8 @@ public:
 			progress->done = 0;
 		}
 
-		// Delete files, but limit parallelism because the file list could use a lot of memory and the corresponding
-		// delete actor states would use even more if they all existed at the same time.
+		// Delete files, but limit parallelism because the file list could use a lot of memory and the
+		// corresponding delete actor states would use even more if they all existed at the same time.
 		state std::list<Future<Void>> deleteFutures;
 
 		while (!toDelete.empty() || !deleteFutures.empty()) {
@@ -1077,7 +1157,8 @@ public:
 			}
 		}
 
-		// Find the most recent keyrange snapshot through which we can restore filtered key ranges into targetVersion.
+		// Find the most recent keyrange snapshot through which we can restore filtered key ranges into
+		// targetVersion.
 		state std::vector<KeyspaceSnapshotFile> snapshots = wait(bc->listKeyspaceSnapshots());
 		state int i = snapshots.size() - 1;
 		for (; i >= 0; i--) {
@@ -1093,8 +1174,8 @@ public:
 			std::pair<std::vector<RangeFile>, std::map<std::string, KeyRange>> results =
 			    wait(bc->readKeyspaceSnapshot(snapshots[i]));
 
-			// If there is no key ranges filter for the restore OR if the snapshot contains no per-file key range info
-			// then return all of the range files
+			// If there is no key ranges filter for the restore OR if the snapshot contains no per-file key
+			// range info then return all of the range files
 			if (keyRangesFilter.empty() || results.second.empty()) {
 				restorable.ranges = std::move(results.first);
 				restorable.keyRanges = std::move(results.second);
@@ -1162,8 +1243,8 @@ public:
 
 			// List logs in version order so log continuity can be analyzed
 			std::sort(logs.begin(), logs.end());
-			// If there are logs and the first one starts at or before the keyrange's snapshot begin version, then
-			// it is valid restore set and proceed
+			// If there are logs and the first one starts at or before the keyrange's snapshot begin version,
+			// then it is valid restore set and proceed
 			if (!logs.empty() && logs.front().beginVersion <= minKeyRangeVersion) {
 				return getRestoreSetFromLogs(logs, targetVersion, restorable);
 			}
@@ -1185,15 +1266,15 @@ public:
 		return vFixedPrecision;
 	}
 
-	// This useful for comparing version folder strings regardless of where their "/" dividers are, as it is possible
-	// that division points would change in the future.
+	// This useful for comparing version folder strings regardless of where their "/" dividers are, as it is
+	// possible that division points would change in the future.
 	static std::string cleanFolderString(std::string f) {
 		f.erase(std::remove(f.begin(), f.end(), '/'), f.end());
 		return f;
 	}
 
-	// The innermost folder covers 100 seconds (1e8 versions) During a full speed backup it is possible though very
-	// unlikely write about 10,000 snapshot range files during that time.
+	// The innermost folder covers 100 seconds (1e8 versions) During a full speed backup it is possible though
+	// very unlikely write about 10,000 snapshot range files during that time.
 	static std::string old_rangeVersionFolderString(Version v) {
 		return format("ranges/%s/", versionFolderString(v, 8).c_str());
 	}
@@ -1266,7 +1347,8 @@ public:
 		return false;
 	}
 
-	// fallback for using existing write api if the underlying blob store doesn't support efficient writeEntireFile
+	// fallback for using existing write api if the underlying blob store doesn't support efficient
+	// writeEntireFile
 	ACTOR static Future<Void> writeEntireFileFallback(Reference<BackupContainerFileSystem> bc,
 	                                                  std::string fileName,
 	                                                  std::string fileContents) {
@@ -1278,8 +1360,8 @@ public:
 
 	ACTOR static Future<Void> createTestEncryptionKeyFile(std::string filename) {
 		if (fileExists(filename)) {
-			// Key file already exists, don't overwrite it -> only for testing between backup and restore workloads to
-			// share the key.
+			// Key file already exists, don't overwrite it -> only for testing between backup and restore
+			// workloads to share the key.
 			TraceEvent("EncryptionKeyFileExists").detail("FileName", filename);
 			return Void();
 		}
@@ -1307,7 +1389,7 @@ public:
 			TraceEvent(SevError, "FailedToOpenEncryptionKeyFile").error(e).detail("FileName", encryptionKeyFileName);
 			throw e;
 		}
-		int bytesRead = wait(keyFile->read(cipherKey->data(), cipherKey->size(), 0));
+		int bytesRead = wait(uncancellable(holdWhile(keyFile, keyFile->read(cipherKey->data(), cipherKey->size(), 0))));
 		if (bytesRead != cipherKey->size()) {
 			TraceEvent(SevError, "InvalidEncryptionKeyFileSize")
 			    .detail("ExpectedSize", cipherKey->size())
@@ -1319,16 +1401,35 @@ public:
 		return Void();
 	}
 
-	ACTOR static Future<Void> writeEncryptionMetadataIfNotExists(Reference<BackupContainerFileSystem> bc) {
-		Optional<Version> existingEncryptionMetadata = wait(bc->fileLevelEncryption().get());
-
-		if (!existingEncryptionMetadata.present()) {
-			bool exists = wait(bc->exists());
-			if (!exists) {
-				wait(bc->create());
+	ACTOR static Future<Void> writeEncryptionMetadataIfNotExists(Reference<BackupContainerFileSystem> bc,
+	                                                             int encryptionBlockSize) {
+		try {
+			state Reference<IAsyncFile> f = wait(bc->readFile(BackupContainerFileSystem::encryptionMetadataFileName()));
+			int64_t size = wait(f->size());
+			TraceEvent("WriteEncryptionMetadataAlreadyExists").detail("URL", bc->getURL()).detail("FileSize", size);
+			return Void();
+		} catch (Error& e) {
+			if (e.code() != error_code_file_not_found) {
+				TraceEvent(SevWarn, "WriteEncryptionMetadataReadError").error(e).detail("URL", bc->getURL());
+				throw e;
 			}
-			wait(bc->fileLevelEncryption().set(bc->encryptionKeyFileName.present() ? 1 : 0));
 		}
+
+		bool exists = wait(bc->exists());
+		if (!exists) {
+			TraceEvent("WriteEncryptionMetadataCreatingContainer").detail("URL", bc->getURL());
+			wait(bc->create());
+		}
+
+		// Write JSON with encryption metadata
+		JsonBuilderObject doc;
+		doc.setKey("is_encryption_enabled", bc->encryptionKeyFileName.present());
+		doc.setKey("encryption_block_size", encryptionBlockSize);
+
+		std::string jsonStr = doc.getJson();
+		TraceEvent("WriteEncryptionMetadataCompleted").detail("URL", bc->getURL()).detail("JSON", jsonStr);
+
+		wait(bc->writeEntireFile(BackupContainerFileSystem::encryptionMetadataFileName(), jsonStr));
 		return Void();
 	}
 
@@ -1516,9 +1617,9 @@ Future<Void> BackupContainerFileSystem::expireData(Version expireEndVersion,
 	    Reference<BackupContainerFileSystem>::addRef(this), expireEndVersion, force, progress, restorableBeginVersion);
 }
 
-Future<Void> BackupContainerFileSystem::writeEncryptionMetadata() {
+Future<Void> BackupContainerFileSystem::writeEncryptionMetadata(int encryptionBlockSize) {
 	return BackupContainerFileSystemImpl::writeEncryptionMetadataIfNotExists(
-	    Reference<BackupContainerFileSystem>::addRef(this));
+	    Reference<BackupContainerFileSystem>::addRef(this), encryptionBlockSize);
 }
 
 ACTOR static Future<KeyRange> getSnapshotFileKeyRange_impl(Reference<BackupContainerFileSystem> bc,
@@ -1647,8 +1748,9 @@ BackupContainerFileSystem::VersionProperty BackupContainerFileSystem::unreliable
 BackupContainerFileSystem::VersionProperty BackupContainerFileSystem::logType() {
 	return { Reference<BackupContainerFileSystem>::addRef(this), "mutation_log_type" };
 }
-BackupContainerFileSystem::VersionProperty BackupContainerFileSystem::fileLevelEncryption() {
-	return { Reference<BackupContainerFileSystem>::addRef(this), "file_level_encryption" };
+
+std::string BackupContainerFileSystem::encryptionMetadataFileName() {
+	return "properties/encryption_metadata";
 }
 
 bool BackupContainerFileSystem::usesEncryption() const {
@@ -1680,6 +1782,7 @@ Reference<BackupContainerFileSystem> BackupContainerFileSystem::openContainerFS(
     const std::string& url,
     const Optional<std::string>& proxy,
     const Optional<std::string>& encryptionKeyFileName,
+    int encryptionBlockSize,
     bool isBackup) {
 	static std::map<std::string, Reference<BackupContainerFileSystem>> m_cache;
 
@@ -1690,7 +1793,7 @@ Reference<BackupContainerFileSystem> BackupContainerFileSystem::openContainerFS(
 	try {
 		StringRef u(url);
 		if (u.startsWith("file://"_sr)) {
-			r = makeReference<BackupContainerLocalDirectory>(url, encryptionKeyFileName);
+			r = makeReference<BackupContainerLocalDirectory>(url, encryptionKeyFileName, encryptionBlockSize);
 		} else if (u.startsWith("blobstore://"_sr)) {
 			std::string resource;
 			Optional<std::string> blobstoreProxy;
@@ -1703,7 +1806,8 @@ Reference<BackupContainerFileSystem> BackupContainerFileSystem::openContainerFS(
 				blobstoreProxy = fileBackupAgentProxy.get();
 			}
 
-			// The URL parameters contain blobstore endpoint tunables as well as possible backup-specific options.
+			// The URL parameters contain blobstore endpoint tunables as well as possible backup-specific
+			// options.
 			S3BlobStoreEndpoint::ParametersT backupParams;
 			Reference<S3BlobStoreEndpoint> bstore =
 			    S3BlobStoreEndpoint::fromString(url, blobstoreProxy, &resource, &lastOpenError, &backupParams);
@@ -1714,7 +1818,7 @@ Reference<BackupContainerFileSystem> BackupContainerFileSystem::openContainerFS(
 				if (!isalnum(c) && c != '_' && c != '-' && c != '.' && c != '/')
 					throw backup_invalid_url();
 			r = makeReference<BackupContainerS3BlobStore>(
-			    bstore, resource, backupParams, encryptionKeyFileName, isBackup);
+			    bstore, resource, backupParams, encryptionKeyFileName, encryptionBlockSize, isBackup);
 		}
 #ifdef BUILD_AZURE_BACKUP
 		else if (u.startsWith("azure://"_sr)) {
@@ -1871,7 +1975,9 @@ ACTOR Future<Void> testBackupContainer(std::string url,
 
 	printf("BackupContainerTest URL %s\n", url.c_str());
 
-	state Reference<IBackupContainer> c = IBackupContainer::openContainer(url, proxy, encryptionKeyFileName);
+	state int encryptionBlockSize = encryptionKeyFileName.present() ? 4096 : 0;
+	state Reference<IBackupContainer> c =
+	    IBackupContainer::openContainer(url, proxy, encryptionKeyFileName, encryptionBlockSize);
 
 	// Make sure container doesn't exist, then create it.
 	try {
@@ -2303,7 +2409,7 @@ ACTOR Future<Void> testBackupContainerWithMissingLogRanges(std::string url, Opti
 	state FlowLock lock(100e6);
 	printf("BackupContainerTest URL %s\n", url.c_str());
 
-	state Reference<IBackupContainer> c = IBackupContainer::openContainer(url, proxy, {});
+	state Reference<IBackupContainer> c = IBackupContainer::openContainer(url, proxy, {}, 0);
 	// Make sure container doesn't exist, then create it.
 	try {
 		wait(c->deleteContainer());
@@ -2440,7 +2546,7 @@ TEST_CASE("/backup/containers/localdir/missingLogRangesRestorability") {
 ACTOR Future<Void> testBackupContinuousLogEndVer(std::string url, Optional<std::string> proxy) {
 	state FlowLock lock(100e6);
 	printf("BackupContainerTest URL %s\n", url.c_str());
-	state Reference<IBackupContainer> c = IBackupContainer::openContainer(url, proxy, {});
+	state Reference<IBackupContainer> c = IBackupContainer::openContainer(url, proxy, {}, 0);
 
 	// Make sure container doesn't exist, then create it.
 	try {

--- a/fdbclient/BackupContainerLocalDirectory.actor.cpp
+++ b/fdbclient/BackupContainerLocalDirectory.actor.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "fdbclient/BackupContainerLocalDirectory.h"
+#include "fdbrpc/AsyncFileEncrypted.h"
 #include "fdbrpc/AsyncFileReadAhead.actor.h"
 #include "flow/IAsyncFile.h"
 #include "flow/FaultInjection.h"
@@ -141,8 +142,10 @@ std::string BackupContainerLocalDirectory::getURLFormat() {
 }
 
 BackupContainerLocalDirectory::BackupContainerLocalDirectory(const std::string& url,
-                                                             const Optional<std::string>& encryptionKeyFileName) {
+                                                             const Optional<std::string>& encryptionKeyFileName,
+                                                             int encryptionBlockSize) {
 	setEncryptionKey(encryptionKeyFileName);
+	this->encryptionBlockSize = encryptionBlockSize;
 
 	std::string path;
 	if (url.find("file://") != 0) {
@@ -233,10 +236,6 @@ Future<bool> BackupContainerLocalDirectory::exists() {
 
 Future<Reference<IAsyncFile>> BackupContainerLocalDirectory::readFile(const std::string& path) {
 	int flags = IAsyncFile::OPEN_NO_AIO | IAsyncFile::OPEN_READONLY | IAsyncFile::OPEN_UNCACHED;
-	// Skip encryption for properties/ folder
-	if (usesEncryption() && !StringRef(path).startsWith("properties/"_sr)) {
-		flags |= IAsyncFile::OPEN_ENCRYPTED;
-	}
 	INJECT_BLOB_FAULT(http_request_failed, "BackupContainerLocalDirectory::readFile");
 	// Simulation does not properly handle opening the same file from multiple machines using a shared filesystem,
 	// so create a symbolic link to make each file opening appear to be unique.  This could also work in production
@@ -261,6 +260,14 @@ Future<Reference<IAsyncFile>> BackupContainerLocalDirectory::readFile(const std:
 // by the same process that failed the first task execution anyway, which is a very rare case.
 #endif
 	Future<Reference<IAsyncFile>> f = IAsyncFileSystem::filesystem()->open(fullPath, flags, 0644);
+	// Skip encryption for properties/ folder
+	if (usesEncryption() && !StringRef(path).startsWith("properties/"_sr)) {
+		int encBlockSize = encryptionBlockSize;
+		f = map(f, [encBlockSize](Reference<IAsyncFile> r) {
+			return Reference<IAsyncFile>(
+			    makeReference<AsyncFileEncrypted>(r, AsyncFileEncrypted::Mode::READ_ONLY, encBlockSize));
+		});
+	}
 
 	if (g_network->isSimulated()) {
 		int blockSize = 0;
@@ -292,15 +299,20 @@ Future<Reference<IBackupFile>> BackupContainerLocalDirectory::writeFile(const st
 	INJECT_BLOB_FAULT(http_request_failed, "BackupContainerLocalDirectory::writeFile");
 	int flags = IAsyncFile::OPEN_NO_AIO | IAsyncFile::OPEN_UNCACHED | IAsyncFile::OPEN_CREATE |
 	            IAsyncFile::OPEN_ATOMIC_WRITE_AND_CREATE | IAsyncFile::OPEN_READWRITE;
-	// Skip encryption for properties/ folder
-	if (usesEncryption() && !StringRef(path).startsWith("properties/"_sr)) {
-		flags |= IAsyncFile::OPEN_ENCRYPTED;
-	}
 	std::string fullPath = joinPath(m_path, path);
 	platform::createDirectory(parentDirectory(fullPath));
 	std::string temp = fullPath + "." + deterministicRandom()->randomUniqueID().toString() + ".temp";
 	Future<Reference<IAsyncFile>> f = IAsyncFileSystem::filesystem()->open(temp, flags, 0644);
-	return map(f, [=](Reference<IAsyncFile> f) { return Reference<IBackupFile>(new BackupFile(path, f, fullPath)); });
+	// Skip encryption for properties/ folder
+	if (usesEncryption() && !StringRef(path).startsWith("properties/"_sr)) {
+		int encBlockSize = encryptionBlockSize;
+		f = map(f, [encBlockSize](Reference<IAsyncFile> r) {
+			return Reference<IAsyncFile>(
+			    makeReference<AsyncFileEncrypted>(r, AsyncFileEncrypted::Mode::APPEND_ONLY, encBlockSize));
+		});
+	}
+	return map(
+	    f, [=](Reference<IAsyncFile> file) { return Reference<IBackupFile>(new BackupFile(path, file, fullPath)); });
 }
 
 Future<Void> BackupContainerLocalDirectory::writeEntireFile(const std::string& path, const std::string& contents) {

--- a/fdbclient/BackupContainerS3BlobStore.actor.cpp
+++ b/fdbclient/BackupContainerS3BlobStore.actor.cpp
@@ -156,9 +156,11 @@ BackupContainerS3BlobStore::BackupContainerS3BlobStore(Reference<S3BlobStoreEndp
                                                        const std::string& name,
                                                        const S3BlobStoreEndpoint::ParametersT& params,
                                                        const Optional<std::string>& encryptionKeyFileName,
+                                                       int encryptionBlockSize,
                                                        bool isBackup)
   : m_bstore(bstore), m_name(name), m_bucket("FDB_BACKUPS_V2"), isBackup(isBackup) {
 	setEncryptionKey(encryptionKeyFileName);
+	this->encryptionBlockSize = encryptionBlockSize;
 	// Currently only one parameter is supported, "bucket"
 	for (const auto& [name, value] : params) {
 		if (name == "bucket") {
@@ -186,7 +188,7 @@ Future<Reference<IAsyncFile>> BackupContainerS3BlobStore::readFile(const std::st
 	Reference<IAsyncFile> f = makeReference<AsyncFileS3BlobStoreRead>(m_bstore, m_bucket, dataPath(path));
 
 	if (usesEncryption() && !StringRef(path).startsWith("properties/"_sr)) {
-		f = makeReference<AsyncFileEncrypted>(f, AsyncFileEncrypted::Mode::READ_ONLY);
+		f = makeReference<AsyncFileEncrypted>(f, AsyncFileEncrypted::Mode::READ_ONLY, encryptionBlockSize);
 	}
 	if (m_bstore->knobs.enable_read_cache) {
 		f = makeReference<AsyncFileReadAheadCache>(f,
@@ -206,7 +208,7 @@ Future<std::vector<std::string>> BackupContainerS3BlobStore::listURLs(Reference<
 Future<Reference<IBackupFile>> BackupContainerS3BlobStore::writeFile(const std::string& path) {
 	Reference<IAsyncFile> f = makeReference<AsyncFileS3BlobStoreWrite>(m_bstore, m_bucket, dataPath(path));
 	if (usesEncryption() && !StringRef(path).startsWith("properties/"_sr)) {
-		f = makeReference<AsyncFileEncrypted>(f, AsyncFileEncrypted::Mode::APPEND_ONLY);
+		f = makeReference<AsyncFileEncrypted>(f, AsyncFileEncrypted::Mode::APPEND_ONLY, encryptionBlockSize);
 	}
 	return Future<Reference<IBackupFile>>(makeReference<BackupContainerS3BlobStoreImpl::BackupFile>(path, f));
 }

--- a/fdbclient/FileBackupAgent.actor.cpp
+++ b/fdbclient/FileBackupAgent.actor.cpp
@@ -1191,7 +1191,8 @@ ACTOR static Future<Void> decodeKVPairs(StringRefReader* reader,
 }
 
 static Reference<IBackupContainer> getBackupContainerWithProxy(Reference<IBackupContainer> _bc) {
-	Reference<IBackupContainer> bc = IBackupContainer::openContainer(_bc->getURL(), fileBackupAgentProxy, {});
+	Reference<IBackupContainer> bc = IBackupContainer::openContainer(
+	    _bc->getURL(), fileBackupAgentProxy, _bc->getEncryptionKeyFileName(), _bc->getEncryptionBlockSize());
 	return bc;
 }
 
@@ -3549,7 +3550,7 @@ struct StartFullBackupTaskFunc : BackupTaskFuncBase {
 		}
 
 		Reference<IBackupContainer> bc = wait(config.backupContainer().getOrThrow(tr));
-		wait(bc->writeEncryptionMetadata());
+		wait(bc->writeEncryptionMetadata(bc->getEncryptionBlockSize()));
 
 		config.stateEnum().set(tr, EBackupState::STATE_RUNNING);
 
@@ -5165,7 +5166,7 @@ public:
 	                                                Key addPrefix,
 	                                                Key removePrefix) {
 		// Sanity check backup is valid
-		state Reference<IBackupContainer> bc = IBackupContainer::openContainer(bcUrl.toString(), proxy, {});
+		state Reference<IBackupContainer> bc = IBackupContainer::openContainer(bcUrl.toString(), proxy, {}, 0);
 		state BackupDescription desc = wait(bc->describeBackup());
 		wait(desc.resolveVersionTimes(cx));
 
@@ -5316,7 +5317,8 @@ public:
 	                                       StopWhenDone stopWhenDone,
 	                                       UsePartitionedLog partitionedLog,
 	                                       IncrementalBackupOnly incrementalBackupOnly,
-	                                       Optional<std::string> encryptionKeyFileName) {
+	                                       Optional<std::string> encryptionKeyFileName,
+	                                       int encryptionBlockSize) {
 		tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 		tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 		tr->setOption(FDBTransactionOptions::COMMIT_ON_FIRST_PROXY);
@@ -5325,7 +5327,9 @@ public:
 		    .detail("TagName", tagName.c_str())
 		    .detail("StopWhenDone", stopWhenDone)
 		    .detail("UsePartitionedLog", partitionedLog)
-		    .detail("OutContainer", outContainer.toString());
+		    .detail("OutContainer", outContainer.toString())
+		    .detail("EncryptionKeyFileName", encryptionKeyFileName.present() ? encryptionKeyFileName.get() : "None")
+		    .detail("EncryptionBlockSize", encryptionBlockSize);
 
 		state KeyBackedTag tag = makeBackupTag(tagName);
 		Optional<UidAndAbortedFlagT> uidAndAbortedFlag = wait(tag.get(tr));
@@ -5355,7 +5359,7 @@ public:
 		}
 
 		state Reference<IBackupContainer> bc =
-		    IBackupContainer::openContainer(backupContainer, proxy, encryptionKeyFileName);
+		    IBackupContainer::openContainer(backupContainer, proxy, encryptionKeyFileName, encryptionBlockSize);
 		try {
 			wait(timeoutError(bc->create(), 30));
 		} catch (Error& e) {
@@ -5457,7 +5461,9 @@ public:
 	                                        OnlyApplyMutationLogs onlyApplyMutationLogs,
 	                                        InconsistentSnapshotOnly inconsistentSnapshotOnly,
 	                                        Version beginVersion,
-	                                        UID uid) {
+	                                        UID uid,
+	                                        Optional<std::string> encryptionKeyFileName,
+	                                        int encryptionBlockSize) {
 		KeyRangeMap<int> restoreRangeSet;
 		for (auto& range : ranges) {
 			restoreRangeSet.insert(range, 1);
@@ -5519,7 +5525,8 @@ public:
 		// Point the tag to the new uid
 		tag.set(tr, { uid, false });
 
-		Reference<IBackupContainer> bc = IBackupContainer::openContainer(backupURL.toString(), proxy, {});
+		Reference<IBackupContainer> bc =
+		    IBackupContainer::openContainer(backupURL.toString(), proxy, encryptionKeyFileName, encryptionBlockSize);
 
 		// Configure the new restore
 		restore.tag().set(tr, tagName.toString());
@@ -6137,8 +6144,8 @@ public:
 			throw restore_error();
 		}
 
-		state Reference<IBackupContainer> bc =
-		    IBackupContainer::openContainer(url.toString(), proxy, encryptionKeyFileName);
+		state Reference<IBackupContainer> bc = IBackupContainer::openContainer(
+		    url.toString(), proxy, /*encryptionKeyFileName=*/{}, /*encryptionBlockSize=*/0);
 
 		state BackupDescription desc = wait(bc->describeBackup(true));
 
@@ -6148,6 +6155,14 @@ public:
 		} else if (!desc.fileLevelEncryption && encryptionKeyFileName.present()) {
 			fprintf(stderr, "ERROR: Backup is not encrypted, please remove the encryption key file path.\n");
 			throw restore_error();
+		}
+
+		if (desc.fileLevelEncryption) {
+			bc =
+			    IBackupContainer::openContainer(url.toString(), proxy, encryptionKeyFileName, desc.encryptionBlockSize);
+			// openContainer may return a cached container that has blockSize=0 (seeded earlier without blockSize).
+			// Set it explicitly to ensure the correct value is used.
+			bc->setEncryptionBlockSize(desc.encryptionBlockSize);
 		}
 
 		if (cxOrig.present()) {
@@ -6207,7 +6222,9 @@ public:
 				                   onlyApplyMutationLogs,
 				                   inconsistentSnapshotOnly,
 				                   beginVersion,
-				                   randomUid));
+				                   randomUid,
+				                   encryptionKeyFileName,
+				                   desc.encryptionBlockSize));
 				wait(tr->commit());
 				break;
 			} catch (Error& e) {
@@ -6726,7 +6743,8 @@ Future<Void> FileBackupAgent::submitBackup(Reference<ReadYourWritesTransaction> 
                                            StopWhenDone stopWhenDone,
                                            UsePartitionedLog partitionedLog,
                                            IncrementalBackupOnly incrementalBackupOnly,
-                                           Optional<std::string> const& encryptionKeyFileName) {
+                                           Optional<std::string> const& encryptionKeyFileName,
+                                           int encryptionBlockSize) {
 	return FileBackupAgentImpl::submitBackup(this,
 	                                         tr,
 	                                         outContainer,
@@ -6739,7 +6757,8 @@ Future<Void> FileBackupAgent::submitBackup(Reference<ReadYourWritesTransaction> 
 	                                         stopWhenDone,
 	                                         partitionedLog,
 	                                         incrementalBackupOnly,
-	                                         encryptionKeyFileName);
+	                                         encryptionKeyFileName,
+	                                         encryptionBlockSize);
 }
 
 Future<Void> FileBackupAgent::discontinueBackup(Reference<ReadYourWritesTransaction> tr, Key tagName) {

--- a/fdbclient/include/fdbclient/BackupAgent.actor.h
+++ b/fdbclient/include/fdbclient/BackupAgent.actor.h
@@ -58,6 +58,7 @@ FDB_BOOLEAN_PARAM(SetValidation);
 FDB_BOOLEAN_PARAM(PartialBackup);
 
 extern Optional<std::string> fileBackupAgentProxy;
+constexpr int DEFAULT_ENCRYPTION_BLOCK_SIZE = 1048576;
 
 class BackupAgentBase : NonCopyable {
 public:
@@ -278,7 +279,8 @@ public:
 	                          StopWhenDone = StopWhenDone::True,
 	                          UsePartitionedLog = UsePartitionedLog::False,
 	                          IncrementalBackupOnly = IncrementalBackupOnly::False,
-	                          Optional<std::string> const& encryptionKeyFileName = {});
+	                          Optional<std::string> const& encryptionKeyFileName = {},
+	                          int encryptionBlockSize = 0);
 	Future<Void> submitBackup(Database cx,
 	                          Key outContainer,
 	                          Optional<std::string> proxy,
@@ -290,7 +292,8 @@ public:
 	                          StopWhenDone stopWhenDone = StopWhenDone::True,
 	                          UsePartitionedLog partitionedLog = UsePartitionedLog::False,
 	                          IncrementalBackupOnly incrementalBackupOnly = IncrementalBackupOnly::False,
-	                          Optional<std::string> const& encryptionKeyFileName = {}) {
+	                          Optional<std::string> const& encryptionKeyFileName = {},
+	                          int encryptionBlockSize = 0) {
 		return runRYWTransactionFailIfLocked(cx, [=](Reference<ReadYourWritesTransaction> tr) {
 			return submitBackup(tr,
 			                    outContainer,
@@ -303,7 +306,8 @@ public:
 			                    stopWhenDone,
 			                    partitionedLog,
 			                    incrementalBackupOnly,
-			                    encryptionKeyFileName);
+			                    encryptionKeyFileName,
+			                    encryptionBlockSize);
 		});
 	}
 
@@ -752,6 +756,8 @@ inline Standalone<StringRef> TupleCodec<Reference<IBackupContainer>>::pack(Refer
 		tuple.append(StringRef());
 	}
 
+	tuple.append((int64_t)bc->getEncryptionBlockSize());
+
 	return tuple.pack();
 }
 template <>
@@ -771,7 +777,11 @@ inline Reference<IBackupContainer> TupleCodec<Reference<IBackupContainer>>::unpa
 		proxy = t.getString(2).toString();
 	}
 
-	return IBackupContainer::openContainer(url, proxy, encryptionKeyFileName);
+	int encryptionBlockSize = 0;
+	if (t.size() > 3) {
+		encryptionBlockSize = (int)t.getInt(3);
+	}
+	return IBackupContainer::openContainer(url, proxy, encryptionKeyFileName, encryptionBlockSize);
 }
 
 class BackupConfig : public KeyBackedTaskConfig {

--- a/fdbclient/include/fdbclient/BackupContainer.h
+++ b/fdbclient/include/fdbclient/BackupContainer.h
@@ -181,6 +181,7 @@ struct BackupDescription {
 	std::string extendedDetail; // Freeform container-specific info.
 	bool partitioned; // If this backup contains partitioned mutation logs.
 	bool fileLevelEncryption; // If this backup contains encrypted files.
+	int encryptionBlockSize; // Block size used for file encryption, 0 if not encrypted.
 
 	// Resolves the versions above to timestamps using a given database's TimeKeeper data.
 	// toString will use this information if present.
@@ -303,7 +304,8 @@ public:
 	// Get an IBackupContainer based on a container spec string
 	static Reference<IBackupContainer> openContainer(const std::string& url,
 	                                                 const Optional<std::string>& proxy,
-	                                                 const Optional<std::string>& encryptionKeyFileName);
+	                                                 const Optional<std::string>& encryptionKeyFileName,
+	                                                 int encryptionBlockSize);
 	static std::vector<std::string> getURLFormats();
 	static Future<std::vector<std::string>> listContainers(const std::string& baseURL,
 	                                                       const Optional<std::string>& proxy);
@@ -312,11 +314,14 @@ public:
 	Optional<std::string> const& getProxy() const { return proxy; }
 	Optional<std::string> const& getEncryptionKeyFileName() const { return encryptionKeyFileName; }
 
-	virtual Future<Void> writeEncryptionMetadata() = 0;
+	virtual Future<Void> writeEncryptionMetadata(int encryptionBlockSize) = 0;
 
 	static std::string lastOpenError;
 
 	virtual Future<Void> encryptionSetupComplete() const = 0;
+
+	virtual int getEncryptionBlockSize() const { return 0; }
+	virtual void setEncryptionBlockSize(int blockSize) {}
 
 	// TODO: change the following back to `private` once blob obj access is refactored
 protected:

--- a/fdbclient/include/fdbclient/BackupContainerFileSystem.h
+++ b/fdbclient/include/fdbclient/BackupContainerFileSystem.h
@@ -82,6 +82,7 @@ public:
 	static Reference<BackupContainerFileSystem> openContainerFS(const std::string& url,
 	                                                            const Optional<std::string>& proxy,
 	                                                            const Optional<std::string>& encryptionKeyFileName,
+	                                                            int encryptionBlockSize,
 	                                                            bool isBackup = true);
 
 	// Get a list of fileNames and their sizes in the container under the given path
@@ -163,10 +164,13 @@ public:
 	                                                  Version beginVersion) final;
 	static Future<Void> createTestEncryptionKeyFile(std::string const& filename);
 
-	Future<Void> writeEncryptionMetadata() override;
+	Future<Void> writeEncryptionMetadata(int encryptionBlockSize) override;
 
 	// Waits for encryption initialization to complete by reading encryption key file during container opening.
 	Future<Void> encryptionSetupComplete() const override;
+
+	int getEncryptionBlockSize() const override { return encryptionBlockSize; }
+	void setEncryptionBlockSize(int blockSize) override { encryptionBlockSize = blockSize; }
 
 protected:
 	// Returns true if an encryption key file was provided.
@@ -175,6 +179,8 @@ protected:
 	void setEncryptionKey(Optional<std::string> const& encryptionKeyFileName);
 
 	Future<Void> writeEntireFileFallback(const std::string& fileName, const std::string& fileContents);
+
+	int encryptionBlockSize = 0;
 
 private:
 	struct VersionProperty {
@@ -202,7 +208,8 @@ private:
 	VersionProperty expiredEndVersion();
 	VersionProperty unreliableEndVersion();
 	VersionProperty logType();
-	VersionProperty fileLevelEncryption();
+
+	static std::string encryptionMetadataFileName();
 
 	// List range files, unsorted, which contain data at or between beginVersion and endVersion
 	// NOTE: This reads the range file folder schema from FDB 6.0.15 and earlier and is provided for backward

--- a/fdbclient/include/fdbclient/BackupContainerLocalDirectory.h
+++ b/fdbclient/include/fdbclient/BackupContainerLocalDirectory.h
@@ -33,7 +33,9 @@ public:
 
 	static std::string getURLFormat();
 
-	BackupContainerLocalDirectory(const std::string& url, Optional<std::string> const& encryptionKeyFileName);
+	BackupContainerLocalDirectory(const std::string& url,
+	                              Optional<std::string> const& encryptionKeyFileName,
+	                              int encryptionBlockSize);
 
 	static Future<std::vector<std::string>> listURLs(const std::string& url);
 

--- a/fdbclient/include/fdbclient/BackupContainerS3BlobStore.h
+++ b/fdbclient/include/fdbclient/BackupContainerS3BlobStore.h
@@ -48,6 +48,7 @@ public:
 	                           const std::string& name,
 	                           const S3BlobStoreEndpoint::ParametersT& params,
 	                           const Optional<std::string>& encryptionKeyFileName,
+	                           int encryptionBlockSize,
 	                           bool isBackup);
 
 	void addref() override;

--- a/fdbrpc/AsyncFileEncrypted.actor.cpp
+++ b/fdbrpc/AsyncFileEncrypted.actor.cpp
@@ -45,14 +45,12 @@ public:
 		return iv;
 	}
 
-	// Read a single block of size ENCRYPTION_BLOCK_SIZE bytes, and decrypt.
+	// Read a single block of size encryptionBlockSize bytes, and decrypt.
 	ACTOR static Future<Standalone<StringRef>> readBlock(AsyncFileEncrypted* self, uint32_t block) {
 		state Arena arena;
-		state unsigned char* encrypted = new (arena) unsigned char[FLOW_KNOBS->ENCRYPTION_BLOCK_SIZE];
-		int bytes = wait(uncancellable(holdWhile(arena,
-		                                         self->file->read(encrypted,
-		                                                          FLOW_KNOBS->ENCRYPTION_BLOCK_SIZE,
-		                                                          FLOW_KNOBS->ENCRYPTION_BLOCK_SIZE * block))));
+		state unsigned char* encrypted = new (arena) unsigned char[self->encryptionBlockSize];
+		int bytes = wait(uncancellable(holdWhile(
+		    arena, self->file->read(encrypted, self->encryptionBlockSize, self->encryptionBlockSize * block))));
 		StreamCipherKey const* cipherKey = StreamCipherKey::getGlobalCipherKey();
 		DecryptionStreamCipher decryptor(cipherKey, self->getIV(block));
 		auto decrypted = decryptor.decrypt(encrypted, bytes, arena);
@@ -70,8 +68,8 @@ public:
 		if (offset + length > self->fileSize) {
 			length = self->fileSize - offset;
 		}
-		state uint32_t firstBlock = offset / FLOW_KNOBS->ENCRYPTION_BLOCK_SIZE;
-		state uint32_t lastBlock = (offset + length - 1) / FLOW_KNOBS->ENCRYPTION_BLOCK_SIZE;
+		state uint32_t firstBlock = offset / self->encryptionBlockSize;
+		state uint32_t lastBlock = (offset + length - 1) / self->encryptionBlockSize;
 		state uint32_t block;
 		state unsigned char* output = reinterpret_cast<unsigned char*>(data);
 		state int bytesRead = 0;
@@ -79,12 +77,11 @@ public:
 		for (block = firstBlock; block <= lastBlock; ++block) {
 			state Standalone<StringRef> plaintext;
 			wait(store(plaintext, readBlock(self.getPtr(), block)));
-			auto start = (block == firstBlock) ? plaintext.begin() + (offset % FLOW_KNOBS->ENCRYPTION_BLOCK_SIZE)
-			                                   : plaintext.begin();
-			auto end = (block == lastBlock)
-			               ? plaintext.begin() + ((offset + length) % FLOW_KNOBS->ENCRYPTION_BLOCK_SIZE)
-			               : plaintext.end();
-			if ((offset + length) % FLOW_KNOBS->ENCRYPTION_BLOCK_SIZE == 0) {
+			auto start =
+			    (block == firstBlock) ? plaintext.begin() + (offset % self->encryptionBlockSize) : plaintext.begin();
+			auto end = (block == lastBlock) ? plaintext.begin() + ((offset + length) % self->encryptionBlockSize)
+			                                : plaintext.end();
+			if ((offset + length) % self->encryptionBlockSize == 0) {
 				end = plaintext.end();
 			}
 
@@ -105,10 +102,10 @@ public:
 	ACTOR static Future<Void> write(Reference<AsyncFileEncrypted> self, void const* data, int length, int64_t offset) {
 		ASSERT(self->mode == AsyncFileEncrypted::Mode::APPEND_ONLY);
 		// All writes must append to the end of the file:
-		ASSERT_EQ(offset, self->currentBlock * FLOW_KNOBS->ENCRYPTION_BLOCK_SIZE + self->offsetInBlock);
+		ASSERT_EQ(offset, self->currentBlock * self->encryptionBlockSize + self->offsetInBlock);
 		state unsigned char const* input = reinterpret_cast<unsigned char const*>(data);
 		while (length > 0) {
-			const auto chunkSize = std::min(length, FLOW_KNOBS->ENCRYPTION_BLOCK_SIZE - self->offsetInBlock);
+			const auto chunkSize = std::min(length, self->encryptionBlockSize - self->offsetInBlock);
 			Arena arena;
 			auto encrypted = self->encryptor->encrypt(input, chunkSize, arena);
 			std::copy(encrypted.begin(), encrypted.end(), &self->writeBuffer[self->offsetInBlock]);
@@ -116,7 +113,7 @@ public:
 			self->offsetInBlock += chunkSize;
 			length -= chunkSize;
 			input += chunkSize;
-			if (self->offsetInBlock == FLOW_KNOBS->ENCRYPTION_BLOCK_SIZE) {
+			if (self->offsetInBlock == self->encryptionBlockSize) {
 				wait(self->writeLastBlockToFile());
 				self->offsetInBlock = 0;
 				ASSERT_LT(self->currentBlock, std::numeric_limits<uint32_t>::max());
@@ -146,13 +143,14 @@ public:
 	}
 };
 
-AsyncFileEncrypted::AsyncFileEncrypted(Reference<IAsyncFile> file, Mode mode)
-  : file(file), mode(mode), currentBlock(0) {
+AsyncFileEncrypted::AsyncFileEncrypted(Reference<IAsyncFile> file, Mode mode, int encryptionBlockSize)
+  : file(file), mode(mode), currentBlock(0), encryptionBlockSize(encryptionBlockSize) {
+	ASSERT(encryptionBlockSize > 0);
 	firstBlockIV = AsyncFileEncryptedImpl::getFirstBlockIV(file->getFilename());
 	if (mode == Mode::APPEND_ONLY) {
 		encryptor =
 		    std::make_unique<EncryptionStreamCipher>(StreamCipherKey::getGlobalCipherKey(), getIV(currentBlock));
-		writeBuffer = std::vector<unsigned char>(FLOW_KNOBS->ENCRYPTION_BLOCK_SIZE, 0);
+		writeBuffer = std::vector<unsigned char>(encryptionBlockSize, 0);
 	}
 }
 
@@ -225,26 +223,27 @@ StreamCipher::IV AsyncFileEncrypted::getIV(uint32_t block) const {
 Future<Void> AsyncFileEncrypted::writeLastBlockToFile() {
 	// The source buffer for the write is owned by *this so this must be kept alive by reference count until the write
 	// is finished.
-	return uncancellable(
-	    holdWhile(Reference<AsyncFileEncrypted>::addRef(this),
-	              file->write(&writeBuffer[0], offsetInBlock, currentBlock * FLOW_KNOBS->ENCRYPTION_BLOCK_SIZE)));
+	return uncancellable(holdWhile(Reference<AsyncFileEncrypted>::addRef(this),
+	                               file->write(&writeBuffer[0], offsetInBlock, currentBlock * encryptionBlockSize)));
 }
 
 // This test writes random data into an encrypted file in random increments,
 // then reads this data back from the file in random increments, then confirms that
 // the bytes read match the bytes written.
 TEST_CASE("fdbrpc/AsyncFileEncrypted") {
-	state const int bytes = FLOW_KNOBS->ENCRYPTION_BLOCK_SIZE * deterministicRandom()->randomInt(0, 1000);
+	state int encryptionBlockSize = 4096;
+	state const int bytes = encryptionBlockSize * deterministicRandom()->randomInt(0, 1000);
 	state std::vector<unsigned char> writeBuffer(bytes, 0);
 	deterministicRandom()->randomBytes(&writeBuffer.front(), bytes);
 	state std::vector<unsigned char> readBuffer(bytes, 0);
 	ASSERT(g_network->isSimulated());
 	StreamCipherKey::initializeGlobalRandomTestKey();
 	int flags = IAsyncFile::OPEN_READWRITE | IAsyncFile::OPEN_CREATE | IAsyncFile::OPEN_ATOMIC_WRITE_AND_CREATE |
-	            IAsyncFile::OPEN_UNBUFFERED | IAsyncFile::OPEN_ENCRYPTED | IAsyncFile::OPEN_UNCACHED |
-	            IAsyncFile::OPEN_NO_AIO;
-	state Reference<IAsyncFile> file =
+	            IAsyncFile::OPEN_UNBUFFERED | IAsyncFile::OPEN_UNCACHED | IAsyncFile::OPEN_NO_AIO;
+	state Reference<IAsyncFile> raw_file =
 	    wait(IAsyncFileSystem::filesystem()->open(joinPath(params.getDataDir(), "test-encrypted-file"), flags, 0600));
+	state Reference<AsyncFileEncrypted> file =
+	    makeReference<AsyncFileEncrypted>(raw_file, AsyncFileEncrypted::Mode::APPEND_ONLY, encryptionBlockSize);
 	state int bytesWritten = 0;
 	state int chunkSize;
 	while (bytesWritten < bytes) {

--- a/fdbrpc/Net2FileSystem.cpp
+++ b/fdbrpc/Net2FileSystem.cpp
@@ -38,7 +38,6 @@
 #include "fdbrpc/AsyncFileCached.actor.h"
 #include "fdbrpc/AsyncFileChaos.h"
 #include "fdbrpc/AsyncFileEIO.actor.h"
-#include "fdbrpc/AsyncFileEncrypted.h"
 #include "fdbrpc/AsyncFileWinASIO.actor.h"
 #include "fdbrpc/AsyncFileKAIO.actor.h"
 #include "flow/AsioReactor.h"
@@ -85,12 +84,6 @@ Future<Reference<class IAsyncFile>> Net2FileSystem::open(const std::string& file
 		f = map(f, [=](Reference<IAsyncFile> r) { return Reference<IAsyncFile>(new AsyncFileWriteChecker(r)); });
 	if (FLOW_KNOBS->ENABLE_CHAOS_FEATURES)
 		f = map(f, [=](Reference<IAsyncFile> r) { return Reference<IAsyncFile>(new AsyncFileChaos(r)); });
-	if (flags & IAsyncFile::OPEN_ENCRYPTED)
-		f = map(f, [flags](Reference<IAsyncFile> r) {
-			auto mode = flags & IAsyncFile::OPEN_READWRITE ? AsyncFileEncrypted::Mode::APPEND_ONLY
-			                                               : AsyncFileEncrypted::Mode::READ_ONLY;
-			return Reference<IAsyncFile>(new AsyncFileEncrypted(r, mode));
-		});
 	return f;
 }
 

--- a/fdbrpc/include/fdbrpc/AsyncFileEncrypted.h
+++ b/fdbrpc/include/fdbrpc/AsyncFileEncrypted.h
@@ -47,10 +47,11 @@ private:
 	uint32_t currentBlock{ 0 };
 	int offsetInBlock{ 0 };
 	std::vector<unsigned char> writeBuffer;
+	int encryptionBlockSize{ 0 };
 	Future<Void> initialize();
 
 public:
-	AsyncFileEncrypted(Reference<IAsyncFile>, Mode);
+	AsyncFileEncrypted(Reference<IAsyncFile>, Mode, int encryptedBlockSize);
 	void addref() override;
 	void delref() override;
 	Future<int> read(void* data, int length, int64_t offset) override;

--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -45,7 +45,6 @@
 #include "flow/WriteOnlySet.h"
 #include "flow/IAsyncFile.h"
 #include "fdbrpc/AsyncFileCached.actor.h"
-#include "fdbrpc/AsyncFileEncrypted.h"
 #include "fdbrpc/SimulatorProcessInfo.h"
 #include "fdbrpc/AsyncFileNonDurable.actor.h"
 #include "fdbrpc/AsyncFileChaos.h"
@@ -3071,12 +3070,6 @@ Future<Reference<class IAsyncFile>> Sim2FileSystem::open(const std::string& file
 		f = AsyncFileDetachable::open(f);
 		if (FLOW_KNOBS->ENABLE_CHAOS_FEATURES)
 			f = map(f, [=](Reference<IAsyncFile> r) { return Reference<IAsyncFile>(new AsyncFileChaos(r)); });
-		if (flags & IAsyncFile::OPEN_ENCRYPTED)
-			f = map(f, [flags](Reference<IAsyncFile> r) {
-				auto mode = flags & IAsyncFile::OPEN_READWRITE ? AsyncFileEncrypted::Mode::APPEND_ONLY
-				                                               : AsyncFileEncrypted::Mode::READ_ONLY;
-				return Reference<IAsyncFile>(new AsyncFileEncrypted(r, mode));
-			});
 		return f;
 	} else
 		return AsyncFileCached::open(filename, flags, mode);

--- a/fdbserver/BlobManager.actor.cpp
+++ b/fdbserver/BlobManager.actor.cpp
@@ -5635,7 +5635,7 @@ ACTOR Future<Void> truncateMutationLogs(Reference<BlobManagerData> bmData) {
 			}
 
 			state std::string mlogsUrl = wait(getMutationLogUrl());
-			state Reference<IBackupContainer> bc = IBackupContainer::openContainer(mlogsUrl, {}, {});
+			state Reference<IBackupContainer> bc = IBackupContainer::openContainer(mlogsUrl, {}, {}, 0);
 			state BackupDescription desc = wait(bc->describeBackup());
 			if (!desc.contiguousLogEnd.present()) {
 				TraceEvent("SkipBlobGranulesFlush").detail("LogUrl", mlogsUrl);

--- a/fdbserver/BlobMigrator.actor.cpp
+++ b/fdbserver/BlobMigrator.actor.cpp
@@ -336,7 +336,7 @@ private:
 	ACTOR static Future<Void> applyMutationLogs(Reference<BlobMigrator> self) {
 		// check last version in mutation logs
 		state std::string mlogsUrl = wait(getMutationLogUrl());
-		state Reference<IBackupContainer> bc = IBackupContainer::openContainer(mlogsUrl, {}, {});
+		state Reference<IBackupContainer> bc = IBackupContainer::openContainer(mlogsUrl, {}, {}, 0);
 		state double beginTs = now();
 		BackupDescription desc = wait(bc->describeBackup(true));
 		TraceEvent("DescribeBackupLatency", self->interf_.id()).detail("Seconds", now() - beginTs);

--- a/fdbserver/RestoreController.actor.cpp
+++ b/fdbserver/RestoreController.actor.cpp
@@ -892,7 +892,7 @@ ACTOR static Future<Void> buildRangeVersions(KeyRangeMap<Version>* pRangeVersion
 		    .detail("Reason", "Parsing all range files is slow and memory intensive");
 		return Void();
 	}
-	Reference<IBackupContainer> bc = IBackupContainer::openContainer(url.toString(), proxy, {});
+	Reference<IBackupContainer> bc = IBackupContainer::openContainer(url.toString(), proxy, {}, 0);
 
 	// Key ranges not in range files are empty;
 	// Assign highest version to avoid applying any mutation in these ranges

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -2472,7 +2472,7 @@ ACTOR static Future<JsonBuilderObject> blobGranulesStatusFetcher(
 		state std::string mlogsUrl = wait(getMutationLogUrl());
 		statusObj["mutation_log_location"] = mlogsUrl;
 		if (mlogsUrl != "") {
-			state Reference<IBackupContainer> bc = IBackupContainer::openContainer(mlogsUrl, {}, {});
+			state Reference<IBackupContainer> bc = IBackupContainer::openContainer(mlogsUrl, {}, {}, 0);
 			BackupDescription desc = wait(timeoutError(bc->describeBackup(), 2.0));
 			if (desc.contiguousLogEnd.present()) {
 				statusObj["mutation_log_end_version"] = desc.contiguousLogEnd.get();

--- a/fdbserver/include/fdbserver/RestoreController.actor.h
+++ b/fdbserver/include/fdbserver/RestoreController.actor.h
@@ -454,7 +454,7 @@ struct RestoreControllerData : RestoreRoleData, public ReferenceCounted<RestoreC
 		    .detail("URL", url)
 		    .detail("Proxy", proxy.present() ? proxy.get() : "");
 		bcUrl = url;
-		bc = IBackupContainer::openContainer(url.toString(), proxy, {});
+		bc = IBackupContainer::openContainer(url.toString(), proxy, {}, 0);
 	}
 };
 

--- a/fdbserver/include/fdbserver/RestoreLoader.actor.h
+++ b/fdbserver/include/fdbserver/RestoreLoader.actor.h
@@ -231,7 +231,7 @@ struct RestoreLoaderData : RestoreRoleData, public ReferenceCounted<RestoreLoade
 			return;
 		}
 		bcUrl = url;
-		bc = IBackupContainer::openContainer(url.toString(), proxy, {});
+		bc = IBackupContainer::openContainer(url.toString(), proxy, {}, 0);
 	}
 };
 

--- a/fdbserver/workloads/BackupAndParallelRestoreCorrectness.actor.cpp
+++ b/fdbserver/workloads/BackupAndParallelRestoreCorrectness.actor.cpp
@@ -234,7 +234,8 @@ struct BackupAndParallelRestoreCorrectnessWorkload : TestWorkload {
 			                               StopWhenDone{ !stopDifferentialDelay },
 			                               self->usePartitionedLogs,
 			                               IncrementalBackupOnly::False,
-			                               self->encryptionKeyFileName));
+			                               self->encryptionKeyFileName,
+			                               self->encryptionKeyFileName.present() ? DEFAULT_ENCRYPTION_BLOCK_SIZE : 0));
 		} catch (Error& e) {
 			TraceEvent("BARW_DoBackupSubmitBackupException", randomID).error(e).detail("Tag", printable(tag));
 			if (e.code() != error_code_backup_unneeded && e.code() != error_code_backup_duplicate)
@@ -493,18 +494,20 @@ struct BackupAndParallelRestoreCorrectnessWorkload : TestWorkload {
 				try {
 					// Note the "partitionedLog" must be false, because we change
 					// the configuration to disable backup workers before restore.
-					extraBackup = backupAgent.submitBackup(cx,
-					                                       "file://simfdb/backups/"_sr,
-					                                       {},
-					                                       deterministicRandom()->randomInt(0, 60),
-					                                       deterministicRandom()->randomInt(0, 100),
-					                                       self->backupTag.toString(),
-					                                       self->backupRanges,
-					                                       true,
-					                                       StopWhenDone::True,
-					                                       UsePartitionedLog::False,
-					                                       IncrementalBackupOnly::False,
-					                                       self->encryptionKeyFileName);
+					extraBackup = backupAgent.submitBackup(
+					    cx,
+					    "file://simfdb/backups/"_sr,
+					    {},
+					    deterministicRandom()->randomInt(0, 60),
+					    deterministicRandom()->randomInt(0, 100),
+					    self->backupTag.toString(),
+					    self->backupRanges,
+					    true,
+					    StopWhenDone::True,
+					    UsePartitionedLog::False,
+					    IncrementalBackupOnly::False,
+					    self->encryptionKeyFileName,
+					    self->encryptionKeyFileName.present() ? DEFAULT_ENCRYPTION_BLOCK_SIZE : 0);
 				} catch (Error& e) {
 					TraceEvent("BARW_SubmitBackup2Exception", randomID)
 					    .error(e)
@@ -546,7 +549,8 @@ struct BackupAndParallelRestoreCorrectnessWorkload : TestWorkload {
 
 				auto container = IBackupContainer::openContainer(lastBackupContainer->getURL(),
 				                                                 lastBackupContainer->getProxy(),
-				                                                 lastBackupContainer->getEncryptionKeyFileName());
+				                                                 lastBackupContainer->getEncryptionKeyFileName(),
+				                                                 lastBackupContainer->getEncryptionBlockSize());
 				BackupDescription desc = wait(container->describeBackup());
 				ASSERT(self->usePartitionedLogs == desc.partitioned);
 				ASSERT(desc.minRestorableVersion.present()); // We must have a valid backup now.

--- a/fdbserver/workloads/BackupCorrectness.actor.cpp
+++ b/fdbserver/workloads/BackupCorrectness.actor.cpp
@@ -345,7 +345,8 @@ struct BackupAndRestoreCorrectnessWorkload : TestWorkload {
 			                               StopWhenDone{ !stopDifferentialDelay },
 			                               UsePartitionedLog::False,
 			                               IncrementalBackupOnly::False,
-			                               self->encryptionKeyFileName));
+			                               self->encryptionKeyFileName,
+			                               self->encryptionKeyFileName.present() ? DEFAULT_ENCRYPTION_BLOCK_SIZE : 0));
 		} catch (Error& e) {
 			TraceEvent("BARW_DoBackupSubmitBackupException", randomID).error(e).detail("Tag", printable(tag));
 			if (e.code() != error_code_backup_unneeded && e.code() != error_code_backup_duplicate)
@@ -661,7 +662,8 @@ struct BackupAndRestoreCorrectnessWorkload : TestWorkload {
 			if (lastBackupContainer && self->performRestore) {
 				auto container = IBackupContainer::openContainer(lastBackupContainer->getURL(),
 				                                                 lastBackupContainer->getProxy(),
-				                                                 lastBackupContainer->getEncryptionKeyFileName());
+				                                                 lastBackupContainer->getEncryptionKeyFileName(),
+				                                                 lastBackupContainer->getEncryptionBlockSize());
 				state BackupDescription desc = wait(container->describeBackup());
 
 				if (deterministicRandom()->random01() < 0.5) {

--- a/fdbserver/workloads/BlobRestoreWorkload.actor.cpp
+++ b/fdbserver/workloads/BlobRestoreWorkload.actor.cpp
@@ -108,7 +108,7 @@ struct BlobRestoreWorkload : TestWorkload {
 			fmt::print("missing mutation logs {}\n", baseUrl);
 			throw restore_missing_data();
 		}
-		state Reference<IBackupContainer> bc = IBackupContainer::openContainer(containers.front(), {}, {});
+		state Reference<IBackupContainer> bc = IBackupContainer::openContainer(containers.front(), {}, {}, 0);
 		BackupDescription desc = wait(bc->describeBackup(true));
 		if (!desc.contiguousLogEnd.present()) {
 			fmt::print("missing mutation logs {}\n", baseUrl);

--- a/fdbserver/workloads/IncrementalBackup.actor.cpp
+++ b/fdbserver/workloads/IncrementalBackup.actor.cpp
@@ -124,8 +124,7 @@ struct IncrementalBackupWorkload : TestWorkload {
 					    .detail("Size", containers.size())
 					    .detail("First", containers.front());
 					if (containers.size()) {
-						backupContainer =
-						    IBackupContainer::openContainer(containers.front(), {}, restoreEncryptionKeyFileName);
+						backupContainer = IBackupContainer::openContainer(containers.front(), {}, {}, 0);
 					}
 				}
 				state bool e = wait(backupContainer->exists());
@@ -181,18 +180,20 @@ struct IncrementalBackupWorkload : TestWorkload {
 
 			TraceEvent("IBackupSubmitAttempt").log();
 			try {
-				wait(self->backupAgent.submitBackup(cx,
-				                                    self->backupDir,
-				                                    {},
-				                                    0,
-				                                    1e8,
-				                                    self->tag.toString(),
-				                                    backupRanges,
-				                                    true,
-				                                    StopWhenDone::False,
-				                                    UsePartitionedLog::False,
-				                                    IncrementalBackupOnly::True,
-				                                    self->encryptionKeyFileName));
+				wait(self->backupAgent.submitBackup(
+				    cx,
+				    self->backupDir,
+				    {},
+				    0,
+				    1e8,
+				    self->tag.toString(),
+				    backupRanges,
+				    true,
+				    StopWhenDone::False,
+				    UsePartitionedLog::False,
+				    IncrementalBackupOnly::True,
+				    self->encryptionKeyFileName,
+				    self->encryptionKeyFileName.present() ? DEFAULT_ENCRYPTION_BLOCK_SIZE : 0));
 			} catch (Error& e) {
 				TraceEvent("IBackupSubmitError").error(e);
 				if (e.code() != error_code_backup_duplicate) {

--- a/fdbserver/workloads/RestoreMultiRanges.actor.cpp
+++ b/fdbserver/workloads/RestoreMultiRanges.actor.cpp
@@ -146,7 +146,9 @@ struct RestoreMultiRangesWorkload : TestWorkload {
 			                                    StopWhenDone::True,
 			                                    UsePartitionedLog::False,
 			                                    IncrementalBackupOnly::False,
-			                                    self->encryptionKeyFileName));
+			                                    self->encryptionKeyFileName,
+			                                    self->encryptionKeyFileName.present() ? DEFAULT_ENCRYPTION_BLOCK_SIZE
+			                                                                          : 0));
 		} catch (Error& e) {
 			if (e.code() != error_code_backup_unneeded && e.code() != error_code_backup_duplicate)
 				throw;

--- a/fdbserver/workloads/SubmitBackup.actor.cpp
+++ b/fdbserver/workloads/SubmitBackup.actor.cpp
@@ -78,7 +78,9 @@ struct SubmitBackupWorkload : TestWorkload {
 			                                    self->stopWhenDone,
 			                                    UsePartitionedLog::False,
 			                                    self->incremental,
-			                                    self->encryptionKeyFileName));
+			                                    self->encryptionKeyFileName,
+			                                    self->encryptionKeyFileName.present() ? DEFAULT_ENCRYPTION_BLOCK_SIZE
+			                                                                          : 0));
 		} catch (Error& e) {
 			TraceEvent("BackupSubmitError").error(e);
 			if (e.code() != error_code_backup_duplicate) {

--- a/flow/Knobs.cpp
+++ b/flow/Knobs.cpp
@@ -175,9 +175,6 @@ void FlowKnobs::initialize(Randomize randomize, IsSimulated isSimulated) {
 	init( EIO_MAX_PARALLELISM,                                  4  );
 	init( EIO_USE_ODIRECT,                                      0  );
 
-	//AsyncFileEncrypted
-	init( ENCRYPTION_BLOCK_SIZE,                              4096 );
-
 	//AsyncFileKAIO
 	init( MAX_OUTSTANDING,                                      64 );
 	init( MIN_SUBMIT,                                           10 );

--- a/flow/include/flow/Knobs.h
+++ b/flow/include/flow/Knobs.h
@@ -241,9 +241,6 @@ public:
 	int EIO_MAX_PARALLELISM;
 	int EIO_USE_ODIRECT;
 
-	// AsyncFileEncrypted
-	int ENCRYPTION_BLOCK_SIZE;
-
 	// AsyncFileKAIO
 	int MAX_OUTSTANDING;
 	int MIN_SUBMIT;

--- a/tests/slow/ParallelRestoreNewBackupCorrectnessAtomicOp.toml
+++ b/tests/slow/ParallelRestoreNewBackupCorrectnessAtomicOp.toml
@@ -37,6 +37,7 @@ timeout = 360000
     backupRangesCount = -1
     # use new backup
     usePartitionedLogs = false
+    encrypted = false
 
     [[test.workload]]
     testName = 'RandomClogging'

--- a/tests/slow/ParallelRestoreNewBackupCorrectnessCycle.toml
+++ b/tests/slow/ParallelRestoreNewBackupCorrectnessCycle.toml
@@ -32,6 +32,7 @@ timeout = 360000
     # backupRangesCount<0 means backup the entire normal keyspace
     backupRangesCount = -1
     usePartitionedLogs = false
+    encrypted = false
 
     [[test.workload]]
     testName = 'RandomClogging'

--- a/tests/slow/ParallelRestoreNewBackupCorrectnessMultiCycles.toml
+++ b/tests/slow/ParallelRestoreNewBackupCorrectnessMultiCycles.toml
@@ -55,6 +55,7 @@ timeout = 360000
     # backupRangesCount<0 means backup the entire normal keyspace
     backupRangesCount = -1
     usePartitionedLogs = false
+    encrypted = false
 
     [[test.workload]]
     testName = 'RandomClogging'

--- a/tests/slow/ParallelRestoreOldBackupCorrectnessAtomicOp.toml
+++ b/tests/slow/ParallelRestoreOldBackupCorrectnessAtomicOp.toml
@@ -36,6 +36,7 @@ timeout = 360000
     backupRangesCount = -1
     #    use old backup
     usePartitionedLogs = false
+    encrypted = false
 
     [[test.workload]]
     testName = 'RandomClogging'

--- a/tests/slow/ParallelRestoreOldBackupCorrectnessCycle.toml
+++ b/tests/slow/ParallelRestoreOldBackupCorrectnessCycle.toml
@@ -32,6 +32,7 @@ timeout = 360000
     # backupRangesCount<0 means backup the entire normal keyspace
     backupRangesCount = -1
     usePartitionedLogs = false
+    encrypted = false
 
     [[test.workload]]
     testName = 'RandomClogging'

--- a/tests/slow/ParallelRestoreOldBackupCorrectnessMultiCycles.toml
+++ b/tests/slow/ParallelRestoreOldBackupCorrectnessMultiCycles.toml
@@ -55,6 +55,7 @@ timeout = 360000
     # backupRangesCount<0 means backup the entire normal keyspace
     backupRangesCount = -1
     usePartitionedLogs = false
+    encrypted = false
 
     [[test.workload]]
     testName = 'RandomClogging'


### PR DESCRIPTION
Backport PR

- https://github.com/apple/foundationdb/pull/13023 
- https://github.com/apple/foundationdb/pull/13129
- https://github.com/apple/foundationdb/pull/13134

100k Simulation running Completed: 
` 20260502-043739-7.3_ak_encryption_7-6162934df37729cd compressed=True data_size=35578026 duration=4548529 ended=100000 fail=1 fail_fast=10 max_runs=100000 pass=99999 priority=100 remaining=0 runtime=1:14:24 sanity=False started=100000 stopped=20260502-055203 submitted=20260502-043739 timeout=5400 username=7.3_ak_encryption_7`
One failure unrelated to this change in SwizzledLargeApiCorrectness.toml