### PR TITLE
Encryption backward compatibility changes and formatting

### DIFF
--- a/design/file-level-encryption-backup.md
+++ b/design/file-level-encryption-backup.md
@@ -133,7 +133,7 @@ fdbrestore start \
 ```
 
 `fdbrestore` does **not** take `--encryption-block-size`; the block size
-is read from the backup's `file_level_encryption` metadata file.
+is read from the backup's `encryption_metadata` file.
 
 ### 4.4 Modify a backup destination
 
@@ -320,7 +320,7 @@ without decrypting the entire file.
 Per-block IVs are derived deterministically: the first 12 bytes come from
 a hash of the filename, and the last 4 bytes are the block index. This
 gives every block a unique IV while keeping reads seekable. On restore,
-the `file_level_encryption` metadata file is read first to recover the
+the `encryption_metadata` file is read first to recover the
 enable flag and the block size, so the reader splits each file into the
 exact same blocks that were produced at backup time.
 
@@ -331,12 +331,12 @@ stays unencrypted.
 
 | File                       | Contents                            | Purpose                                                                                |
 | -------------------------- | ----------------------------------- | -------------------------------------------------------------------------------------- |
-| `file_level_encryption`    | JSON object (see below)             | Indicates whether the backup is encrypted and the encryption block size used.          |
+| `encryption_metadata`      | JSON object (see below)             | Indicates whether the backup is encrypted and the encryption block size used.          |
 | `mutation_log_type`        | `"1"` or `"0"` (1 byte)             | Whether the backup uses partitioned mutation logs.                                     |
 | `log_begin_version`        | Version number as text (10 bytes)   | Earliest mutation-log version present in the backup.                                   |
 | `log_end_version`          | Version number as text (10 bytes)   | Latest mutation-log version present in the backup.                                     |
 
-`file_level_encryption` is a JSON object containing both the on/off flag
+`encryption_metadata` is a JSON object containing both the on/off flag
 and the block size used to encrypt the data files:
 
 ```json
@@ -353,7 +353,7 @@ and the block size used to encrypt the data files:
   what restore/decode tools use for the same backup, so it is persisted
   with the backup itself.
 
-The `file_level_encryption` metadata file is created immediately when a
+The `encryption_metadata` metadata file is created immediately when a
 backup starts. The other metadata files are generated only when
 `fdbrestore` or `fdbbackup describe` runs. Those operations scan
 filenames only, not file contents, when reconstructing the on-disk view.
@@ -363,8 +363,8 @@ Example container layout:
 ```
 ls -ltrh properties/
 total 16K
--rw-r--r-- 1 root root  74 Sep 15 21:04 file_level_encryption
--rw-r--r-- 1 root root   1 Sep 15 21:06 mutation_log_type
--rw-r--r-- 1 root root  10 Sep 15 21:41 log_end_version
--rw-r--r-- 1 root root  10 Sep 15 21:41 log_begin_version
+-rw-r--r-- 1 root root  74 May 5 21:04 encryption_metadata
+-rw-r--r-- 1 root root   1 May 5 21:06 mutation_log_type
+-rw-r--r-- 1 root root  10 May 5 21:41 log_end_version
+-rw-r--r-- 1 root root  10 May 5 21:41 log_begin_version
 ```

--- a/fdbbackup/backup.cpp
+++ b/fdbbackup/backup.cpp
@@ -2355,7 +2355,7 @@ Reference<IBackupContainer> openBackupContainer(const char* name,
                                                 const std::string& destinationContainer,
                                                 const Optional<std::string>& proxy,
                                                 const Optional<std::string>& encryptionKeyFile,
-                                                int encryptionBlockSize = 0) {
+                                                int encryptionBlockSize) {
 	// Error, if no dest container was specified
 	if (destinationContainer.empty()) {
 		fprintf(stderr, "ERROR: No backup destination was specified.\n");
@@ -2440,7 +2440,7 @@ Future<Void> runRestore(Database db,
 		FileBackupAgent backupAgent;
 
 		Reference<IBackupContainer> bc =
-		    openBackupContainer(exeRestore.toString().c_str(), container, proxy, encryptionKeyFile);
+		    openBackupContainer(exeRestore.toString().c_str(), container, proxy, encryptionKeyFile, 0);
 		// If targetVersion is unset then use the maximum restorable version from the backup description
 		if (targetVersion == invalidVersion) {
 			if (verbose)
@@ -2515,7 +2515,7 @@ Future<Void> dumpBackupData(const char* name,
                             Optional<std::string> proxy,
                             Version beginVersion,
                             Version endVersion) {
-	Reference<IBackupContainer> c = openBackupContainer(name, destinationContainer, proxy, {});
+	Reference<IBackupContainer> c = openBackupContainer(name, destinationContainer, proxy, {}, 0);
 
 	if (beginVersion < 0 || endVersion < 0) {
 		BackupDescription desc = co_await c->describeBackup();
@@ -2565,7 +2565,7 @@ Future<Void> expireBackupData(const char* name,
 	}
 
 	try {
-		Reference<IBackupContainer> c = openBackupContainer(name, destinationContainer, proxy, {});
+		Reference<IBackupContainer> c = openBackupContainer(name, destinationContainer, proxy, {}, 0);
 
 		IBackupContainer::ExpireProgress progress;
 		std::string lastProgress;
@@ -2610,7 +2610,7 @@ Future<Void> expireBackupData(const char* name,
 
 Future<Void> deleteBackupContainer(const char* name, std::string destinationContainer, Optional<std::string> proxy) {
 	try {
-		Reference<IBackupContainer> c = openBackupContainer(name, destinationContainer, proxy, {});
+		Reference<IBackupContainer> c = openBackupContainer(name, destinationContainer, proxy, {}, 0);
 		int numDeleted = 0;
 		Future<Void> done = c->deleteContainer(&numDeleted);
 
@@ -2644,7 +2644,7 @@ Future<Void> describeBackup(const char* name,
                             Optional<Database> cx,
                             bool json) {
 	try {
-		Reference<IBackupContainer> c = openBackupContainer(name, destinationContainer, proxy, {});
+		Reference<IBackupContainer> c = openBackupContainer(name, destinationContainer, proxy, {}, 0);
 		BackupDescription desc = co_await c->describeBackup(deep);
 		if (cx.present())
 			co_await desc.resolveVersionTimes(cx.get());
@@ -2740,7 +2740,7 @@ Future<Void> queryBackup(const char* name,
 	JsonBuilderArray rangeFilesJson;
 	JsonBuilderArray logFilesJson;
 	try {
-		Reference<IBackupContainer> bc = openBackupContainer(name, destinationContainer, proxy, {});
+		Reference<IBackupContainer> bc = openBackupContainer(name, destinationContainer, proxy, {}, 0);
 		BackupDescription desc = co_await bc->describeBackup();
 		// Use continuous log end version for the maximum restorable version for the key ranges when a restorable
 		// version doesn't exist.
@@ -2994,7 +2994,7 @@ Future<Void> modifyBackup(Database db, std::string tagName, BackupModifyOptions 
 				    .detail("EncryptionKeyFile",
 				            options.encryptionKeyFile.present() ? options.encryptionKeyFile.get() : "None");
 				bc = openBackupContainer(
-				    exeBackup.toString().c_str(), options.destURL.get(), options.proxy, options.encryptionKeyFile);
+				    exeBackup.toString().c_str(), options.destURL.get(), options.proxy, options.encryptionKeyFile, 0);
 				try {
 					co_await timeoutError(bc->create(), 30);
 				} catch (Error& e) {

--- a/fdbbackup/backup.cpp
+++ b/fdbbackup/backup.cpp
@@ -2439,8 +2439,10 @@ Future<Void> runRestore(Database db,
 	try {
 		FileBackupAgent backupAgent;
 
-		Reference<IBackupContainer> bc =
-		    openBackupContainer(exeRestore.toString().c_str(), container, proxy, encryptionKeyFile, 0);
+		// encryptionBlockSize is passed 0 because we don't know about the block size yet and it will be read in the
+		// describeBackup call after this.
+		Reference<IBackupContainer> bc = openBackupContainer(
+		    exeRestore.toString().c_str(), container, proxy, encryptionKeyFile, /*encryptionBlockSize=*/0);
 		// If targetVersion is unset then use the maximum restorable version from the backup description
 		if (targetVersion == invalidVersion) {
 			if (verbose)
@@ -2993,8 +2995,11 @@ Future<Void> modifyBackup(Database db, std::string tagName, BackupModifyOptions 
 				    .detail("DestURL", options.destURL.get())
 				    .detail("EncryptionKeyFile",
 				            options.encryptionKeyFile.present() ? options.encryptionKeyFile.get() : "None");
-				bc = openBackupContainer(
-				    exeBackup.toString().c_str(), options.destURL.get(), options.proxy, options.encryptionKeyFile, 0);
+				bc = openBackupContainer(exeBackup.toString().c_str(),
+				                         options.destURL.get(),
+				                         options.proxy,
+				                         options.encryptionKeyFile,
+				                         prevContainer->getEncryptionBlockSize());
 				try {
 					co_await timeoutError(bc->create(), 30);
 				} catch (Error& e) {
@@ -3006,7 +3011,6 @@ Future<Void> modifyBackup(Database db, std::string tagName, BackupModifyOptions 
 					        e.what());
 					throw backup_error();
 				}
-
 				config.backupContainer().set(tr, bc);
 				co_await bc->writeEncryptionMetadata(bc->getEncryptionBlockSize());
 			} else if (options.encryptionKeyFile.present()) {

--- a/fdbclient/BackupContainer.cpp
+++ b/fdbclient/BackupContainer.cpp
@@ -315,7 +315,7 @@ Reference<IBackupContainer> IBackupContainer::openContainer(const std::string& u
 
 			BackupContainerBlobStore::validateBackupUrl(resource);
 			r = makeReference<BackupContainerBlobStore>(
-			    bstore, resource, backupParams, encryptionKeyFileName, /*isBackup=*/true, encryptionBlockSize);
+			    bstore, resource, backupParams, encryptionKeyFileName, encryptionBlockSize, /*isBackup=*/true);
 		}
 #ifdef BUILD_AZURE_BACKUP
 		else if (u.startsWith("azure://"_sr)) {

--- a/fdbclient/BackupContainerBlobStore.cpp
+++ b/fdbclient/BackupContainerBlobStore.cpp
@@ -158,8 +158,8 @@ BackupContainerBlobStore::BackupContainerBlobStore(Reference<IBlobStoreEndpoint>
                                                    const std::string& name,
                                                    const IBlobStoreEndpoint::ParametersT& params,
                                                    const Optional<std::string>& encryptionKeyFileName,
-                                                   bool isBackup,
-                                                   int encryptionBlockSize)
+                                                   int encryptionBlockSize,
+                                                   bool isBackup)
   : m_bstore(bstore), m_name(name), m_bucket("FDB_BACKUPS_V2"), isBackup(isBackup) {
 	setEncryptionKey(encryptionKeyFileName);
 	this->encryptionBlockSize = encryptionBlockSize;

--- a/fdbclient/BackupContainerBlobStore.h
+++ b/fdbclient/BackupContainerBlobStore.h
@@ -48,8 +48,8 @@ public:
 	                         const std::string& name,
 	                         const IBlobStoreEndpoint::ParametersT& params,
 	                         const Optional<std::string>& encryptionKeyFileName,
-	                         bool isBackup,
-	                         int encryptionBlockSize);
+	                         int encryptionBlockSize,
+	                         bool isBackup);
 
 	void addref() override;
 	void delref() override;

--- a/fdbclient/BackupContainerFileSystem.cpp
+++ b/fdbclient/BackupContainerFileSystem.cpp
@@ -583,10 +583,16 @@ public:
 				    .detail("EncryptionBlockSize", blockSize);
 				co_return std::make_pair(enabled, blockSize);
 			} else {
-				throw backup_invalid_info();
+				// If the file is malformed, log the error and return encryption disabled, don't throw since this file
+				// may be written with older format.
+				TraceEvent(SevWarn, "BackupContainerReadEncryptionMetadataMalformed")
+				    .detail("URL", bc->getURL())
+				    .detail("File", BackupContainerFileSystem::encryptionMetadataFileName());
+				co_return std::make_pair(false, 0);
 			}
 		} catch (Error& e) {
 			if (e.code() == error_code_file_not_found) {
+				// File may not be present for older backups, return encryption disabled.
 				TraceEvent(SevWarn, "BackupContainerEncryptionMetadataNotFound")
 				    .detail("URL", bc->getURL())
 				    .detail("File", BackupContainerFileSystem::encryptionMetadataFileName());
@@ -1821,9 +1827,6 @@ BackupContainerFileSystem::VersionProperty BackupContainerFileSystem::unreliable
 BackupContainerFileSystem::VersionProperty BackupContainerFileSystem::logType() {
 	return { Reference<BackupContainerFileSystem>::addRef(this), "mutation_log_type" };
 }
-BackupContainerFileSystem::VersionProperty BackupContainerFileSystem::fileLevelEncryption() {
-	return { Reference<BackupContainerFileSystem>::addRef(this), "file_level_encryption" };
-}
 
 std::string BackupContainerFileSystem::encryptionMetadataFileName() {
 	return "properties/file_level_encryption";
@@ -1890,7 +1893,7 @@ Reference<BackupContainerFileSystem> BackupContainerFileSystem::openContainerFS(
 
 			BackupContainerBlobStore::validateBackupUrl(resource);
 			r = makeReference<BackupContainerBlobStore>(
-			    bstore, resource, backupParams, encryptionKeyFileName, isBackup, encryptionBlockSize);
+			    bstore, resource, backupParams, encryptionKeyFileName, encryptionBlockSize, isBackup);
 		}
 #ifdef BUILD_AZURE_BACKUP
 		else if (u.startsWith("azure://"_sr)) {

--- a/fdbclient/BackupContainerFileSystem.cpp
+++ b/fdbclient/BackupContainerFileSystem.cpp
@@ -566,29 +566,46 @@ public:
 			json_spirit::mValue json;
 			if (json_spirit::read_string(content, json) && json.type() == json_spirit::obj_type) {
 				auto& obj = json.get_obj();
-				bool enabled = false;
-				int blockSize = 0;
 
-				if (obj.count("is_encryption_enabled") &&
-				    obj.at("is_encryption_enabled").type() == json_spirit::bool_type) {
-					enabled = obj.at("is_encryption_enabled").get_bool();
+				// Both fields must be present with correct types.
+				if (!obj.count("is_encryption_enabled") ||
+				    obj.at("is_encryption_enabled").type() != json_spirit::bool_type ||
+				    !obj.count("encryption_block_size") ||
+				    obj.at("encryption_block_size").type() != json_spirit::int_type) {
+					fprintf(stderr, "ERROR: Encryption metadata file is missing required fields or has wrong types.\n");
+					TraceEvent(SevError, "BackupContainerReadEncryptionMetadataMalformed")
+					    .detail("URL", bc->getURL())
+					    .detail("File", BackupContainerFileSystem::encryptionMetadataFileName());
+					throw file_corrupt();
 				}
-				if (obj.count("encryption_block_size") &&
-				    obj.at("encryption_block_size").type() == json_spirit::int_type) {
-					blockSize = obj.at("encryption_block_size").get_int();
+
+				bool enabled = obj.at("is_encryption_enabled").get_bool();
+				int blockSize = obj.at("encryption_block_size").get_int();
+
+				if ((enabled && blockSize <= 0) || (!enabled && blockSize != 0)) {
+					fprintf(stderr,
+					        "ERROR: Encryption metadata is inconsistent (enabled=%d, blockSize=%d).\n",
+					        enabled,
+					        blockSize);
+					TraceEvent(SevError, "BackupContainerReadEncryptionMetadataInconsistent")
+					    .detail("URL", bc->getURL())
+					    .detail("IsEncryptionEnabled", enabled)
+					    .detail("EncryptionBlockSize", blockSize);
+					throw file_corrupt();
 				}
+
 				TraceEvent("BackupContainerReadEncryptionMetadata")
 				    .detail("URL", bc->getURL())
 				    .detail("IsEncryptionEnabled", enabled)
 				    .detail("EncryptionBlockSize", blockSize);
 				co_return std::make_pair(enabled, blockSize);
 			} else {
-				// If the file is malformed, log the error and return encryption disabled, don't throw since this file
-				// may be written with older format.
-				TraceEvent(SevWarn, "BackupContainerReadEncryptionMetadataMalformed")
+				// If the file is malformed, throw an error.
+				fprintf(stderr, "ERROR: Failed to read encryption_metadata file due to incorrect format\n");
+				TraceEvent(SevError, "BackupContainerReadEncryptionMetadataMalformed")
 				    .detail("URL", bc->getURL())
 				    .detail("File", BackupContainerFileSystem::encryptionMetadataFileName());
-				co_return std::make_pair(false, 0);
+				throw file_corrupt();
 			}
 		} catch (Error& e) {
 			if (e.code() == error_code_file_not_found) {
@@ -598,11 +615,12 @@ public:
 				    .detail("File", BackupContainerFileSystem::encryptionMetadataFileName());
 				co_return std::make_pair(false, 0);
 			}
+			fprintf(stderr, "ERROR: Failed to read encryption_metadata file due to an error.\n");
 			TraceEvent(SevError, "BackupContainerReadEncryptionMetadataError")
 			    .error(e)
 			    .detail("URL", bc->getURL())
 			    .detail("File", BackupContainerFileSystem::encryptionMetadataFileName());
-			throw;
+			throw file_not_readable();
 		}
 	}
 
@@ -1480,8 +1498,9 @@ public:
 		}
 
 		// Write JSON with encryption metadata
+		bool enabled = bc->encryptionKeyFileName.present();
 		JsonBuilderObject doc;
-		doc.setKey("is_encryption_enabled", bc->encryptionKeyFileName.present());
+		doc.setKey("is_encryption_enabled", enabled);
 		doc.setKey("encryption_block_size", encryptionBlockSize);
 
 		std::string jsonStr = doc.getJson();
@@ -1829,7 +1848,7 @@ BackupContainerFileSystem::VersionProperty BackupContainerFileSystem::logType() 
 }
 
 std::string BackupContainerFileSystem::encryptionMetadataFileName() {
-	return "properties/file_level_encryption";
+	return "properties/encryption_metadata";
 }
 
 bool BackupContainerFileSystem::usesEncryption() const {

--- a/fdbclient/FileBackupAgent.cpp
+++ b/fdbclient/FileBackupAgent.cpp
@@ -7275,9 +7275,9 @@ public:
 	                                  Version beginVersion,
 	                                  UID uid,
 	                                  MutationLogType mutationLogType,
-	                                  bool useRangeFileRestore = true,
-	                                  int encryptionBlockSize = 0,
-	                                  Optional<std::string> encryptionKeyFileName = {}) {
+	                                  Optional<std::string> encryptionKeyFileName,
+	                                  int encryptionBlockSize,
+	                                  bool useRangeFileRestore = true) {
 		KeyRangeMap<int> restoreRangeSet;
 		for (auto& range : ranges) {
 			restoreRangeSet.insert(range, 1);
@@ -8204,9 +8204,9 @@ public:
 				                       beginVersion,
 				                       randomUid,
 				                       desc.mutationLogType,
-				                       useRangeFileRestore,
+				                       encryptionKeyFileName,
 				                       desc.encryptionBlockSize,
-				                       encryptionKeyFileName);
+				                       useRangeFileRestore);
 				co_await tr->commit();
 				break;
 			} catch (Error& e) {

--- a/fdbclient/include/fdbclient/BackupContainerFileSystem.h
+++ b/fdbclient/include/fdbclient/BackupContainerFileSystem.h
@@ -219,7 +219,6 @@ private:
 	VersionProperty expiredEndVersion();
 	VersionProperty unreliableEndVersion();
 	VersionProperty logType();
-	VersionProperty fileLevelEncryption();
 
 	static std::string encryptionMetadataFileName();
 

--- a/fdbrpc/AsyncFileEncrypted.cpp
+++ b/fdbrpc/AsyncFileEncrypted.cpp
@@ -138,8 +138,8 @@ public:
 	}
 };
 
-AsyncFileEncrypted::AsyncFileEncrypted(Reference<IAsyncFile> file, Mode mode, int blockSize)
-  : file(file), mode(mode), currentBlock(0), encryptionBlockSize(blockSize) {
+AsyncFileEncrypted::AsyncFileEncrypted(Reference<IAsyncFile> file, Mode mode, int encryptionBlockSize)
+  : file(file), mode(mode), currentBlock(0), encryptionBlockSize(encryptionBlockSize) {
 	ASSERT(encryptionBlockSize > 0);
 	firstBlockIV = AsyncFileEncryptedImpl::getFirstBlockIV(file->getFilename());
 	if (mode == Mode::APPEND_ONLY) {

--- a/fdbrpc/include/fdbrpc/AsyncFileEncrypted.h
+++ b/fdbrpc/include/fdbrpc/AsyncFileEncrypted.h
@@ -53,7 +53,7 @@ private:
 	Future<Void> initialize();
 
 public:
-	AsyncFileEncrypted(Reference<IAsyncFile>, Mode, int blockSize);
+	AsyncFileEncrypted(Reference<IAsyncFile>, Mode, int);
 	void addref() override;
 	void delref() override;
 	Future<int> read(void* data, int length, int64_t offset) override;


### PR DESCRIPTION
This PR covers some minor changes
1. Backward Compatiblity:

Changed the file name to "encryption_metadata" in properties folder with json format. 
for backward compatibility -> if this new file is not present, it will assume it to be unencrypted and return 0
Otherwise, it will read this json format.

```
 cat /root/local_testing/backup_before/backup-2026-05-05-20-01-04.754807/properties/encryption_metadata
{"is_encryption_enabled":true,"encryption_block_size":1048576
```
Added additional checks related to format.

If encryption_metadata format is corrupted:
```
fdbrestore start --dest-cluster-file /root/local_testing/loopback-cluster/fdb.cluster -t mybackup -w -r file:///root/local_testing/backup_before/backup-2026-05-05-20-01-04.754807/
No restore target version given, will use maximum restorable version from backup description.
ERROR: Failed to read encryption_metadata file due to incorrect format
ERROR: File could not be read
Fatal Error: File could not be read
```

```
fdbrestore start --dest-cluster-file /root/local_testing/loopback-cluster/fdb.cluster -t mybackup -w -r file:///root/local_testing/backup_before/backup-2026-05-05-20-01-04.754807/
No restore target version given, will use maximum restorable version from backup description.
ERROR: Encryption metadata file is missing required fields or has wrong types.
ERROR: Failed to read encryption_metadata file due to an error.
Fatal Error: File could not be read
```

```
fdbrestore start --dest-cluster-file /root/local_testing/loopback-cluster/fdb.cluster -t mybackup -w -r file:///root/local_testing/backup_before/backup-2026-05-05-20-01-04.754807/
No restore target version given, will use maximum restorable version from backup description.
ERROR: Encryption metadata is inconsistent (enabled=0, blockSize=1048576).
ERROR: Failed to read encryption_metadata file due to an error.
Fatal Error: File could not be read
```

2. Some minor code formatting.
- Removing unsued code
- Removing Default argument and making it consistent with other.
- keeping encryption key and encryption block size together

### TESTING

` 20260502-003739-ak_test2-1106b8face794146          compressed=True data_size=37061967 duration=4911442 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:58:42 sanity=False started=100000 stopped=20260502-013621 submitted=20260502-003739 timeout=5400 username=ak_test2`

It is able to restore previous unencrypted backups.