### PR TITLE
Fix unit test failure in Encrypted Backup test

### DIFF
--- a/fdbclient/BackupContainerFileSystem.cpp
+++ b/fdbclient/BackupContainerFileSystem.cpp
@@ -2041,7 +2041,7 @@ Future<Void> testBackupContainer(std::string url,
 
 	printf("BackupContainerTest URL %s\n", url.c_str());
 
-	int encryptionBlockSize = encryptionKeyFileName.present() ? DEFAULT_ENCRYPTION_BLOCK_SIZE : 0;
+	int encryptionBlockSize = encryptionKeyFileName.present() ? 4096 : 0;
 	Reference<IBackupContainer> c =
 	    IBackupContainer::openContainer(url, proxy, encryptionKeyFileName, encryptionBlockSize);
 


### PR DESCRIPTION
Fix unit test failure in Encrypted Backup test.

### TESTING
Ran RandomUnitTest.toml with encrypted test. 
Without the fix, tests were stuck but after reducing the size, it passes.