### PR TITLE
fix compiler warning for virtual ReadYourWritesTransaction.debugTrace()

### DIFF
--- a/fdbclient/include/fdbclient/ReadYourWrites.h
+++ b/fdbclient/include/fdbclient/ReadYourWrites.h
@@ -205,7 +205,8 @@ public:
 	template <typename Type>
 	using FutureT = Future<Type>;
 
-	virtual void debugTrace(BaseTraceEvent&& event);
+	// not virtual because final class
+	void debugTrace(BaseTraceEvent&& event);
 	void debugPrint(std::string const& message);
 
 	// Used by ThreadSafeTransaction for exceptions thrown in void methods.


### PR DESCRIPTION
> ReadYourWrites.h:208:15: warning: virtual method 'debugTrace' is inside
> a 'final' class and can never be overridden [-Wunnecessary-virtual-specifier]

this warning comes out a few hundred times, for every cpp file that transitively includes this header