### PR TITLE
DD finish movekeys backoff (cherry-pick of 2553727 to main)

### DIFF
--- a/fdbserver/core/MoveKeys.cpp
+++ b/fdbserver/core/MoveKeys.cpp
@@ -43,6 +43,14 @@ static inline void dprint(fmt::format_string<T...> fmt, T&&... args) {
 }
 
 namespace {
+
+// Exponential backoff for transaction_too_old retries in finishMoveKeys.
+// Formula: 0.1 * 2^retries, capped at 5.0s. Called with retries >= 1
+// (retries is incremented before the call), so effective start is 0.2s.
+double finishMoveKeysBackoff(int retries) {
+	return std::min(0.1 * (1 << std::min(retries, 6)), 5.0);
+}
+
 struct Shard {
 	Shard() = default;
 	Shard(KeyRangeRef range, const UID& id) : range(range), id(id) {}
@@ -1593,10 +1601,18 @@ static Future<Void> finishMoveKeys(Database occ,
 						}
 
 						co_await waitForAll(actors);
+
+						// Inject transaction_too_old before commit to exercise the
+						// retry limit and finish_move_keys_too_many_retries path.
+						if (BUGGIFY_WITH_PROB(0.01)) {
+							CODE_PROBE(true, "finishMoveKeys injecting transaction_too_old before commit");
+							throw transaction_too_old();
+						}
 						co_await tr.commit();
 						counters->committed->increment(1);
 
 						begin = endKey;
+						retries = 0;
 						break;
 					}
 					// This leads to a count of transactions starting that exceeds the sum of
@@ -1611,6 +1627,27 @@ static Future<Void> finishMoveKeys(Database occ,
 					throw err;
 				co_await tr.onError(err);
 				retries++;
+				// tr.onError delays are short for transaction_too_old. With 15
+				// FlowLock slots all retrying, this creates a retry storm. Add
+				// additional exponential backoff capped at 5s.
+				if (err.code() == error_code_transaction_too_old) {
+					double backoff = finishMoveKeysBackoff(retries);
+					CODE_PROBE(true, "finishMoveKeys transaction_too_old backoff");
+					TraceEvent("FinishMoveKeysBackoff", relocationIntervalId)
+					    .suppressFor(1.0)
+					    .detail("Retries", retries)
+					    .detail("BackoffSeconds", backoff);
+					if (retries > SERVER_KNOBS->FINISH_MOVE_KEYS_MAX_RETRIES) {
+						CODE_PROBE(true, "finishMoveKeys giving up after max retries");
+						TraceEvent(SevWarnAlways, "RelocateShard_FinishMoveKeysGivingUp", relocationIntervalId)
+						    .error(err)
+						    .detail("KeyBegin", keys.begin)
+						    .detail("KeyEnd", keys.end)
+						    .detail("Retries", retries);
+						throw finish_move_keys_too_many_retries();
+					}
+					co_await delay(backoff);
+				}
 				if (retries % 10 == 0) {
 					TraceEvent(retries == 20 ? SevWarnAlways : SevWarn,
 					           "RelocateShard_FinishMoveKeysRetrying",
@@ -3429,4 +3466,30 @@ Future<Void> unassignServerKeys(UID traceId, TrType tr, KeyRangeRef keys, std::s
 			TraceEvent("UnassignKeys", traceId).detail("Keys", keys).detail("SS", id);
 		}
 	}
+}
+
+// Unit test for the finishMoveKeys backoff formula. A simulation workload can't reliably
+// trigger transaction_too_old in finishMoveKeys because:
+//   1. finishMoveKeys only runs when DD schedules data moves, which depends on cluster
+//      configuration and shard placement — not guaranteed in all simulation configs
+//   2. Even with injection, the injection point must fire before check() runs, but
+//      finishMoveKeys may not be called if no moves are scheduled
+// So we test the backoff arithmetic directly.
+TEST_CASE("/fdbserver/MoveKeys/finishMoveKeysBackoff") {
+	// Verify exponential backoff: 0.1 * 2^retries, capped at 5.0s.
+	// In production retries >= 1 at call site, so effective start is 0.2s.
+	ASSERT(finishMoveKeysBackoff(0) == 0.1);
+	ASSERT(finishMoveKeysBackoff(1) == 0.2);
+	ASSERT(finishMoveKeysBackoff(2) == 0.4);
+	ASSERT(finishMoveKeysBackoff(3) == 0.8);
+	ASSERT(finishMoveKeysBackoff(4) == 1.6);
+	ASSERT(finishMoveKeysBackoff(5) == 3.2);
+	ASSERT(finishMoveKeysBackoff(6) == 5.0); // capped
+	ASSERT(finishMoveKeysBackoff(7) == 5.0); // still capped
+	ASSERT(finishMoveKeysBackoff(100) == 5.0); // still capped
+
+	// Verify the retry limit knob exists and is positive
+	ASSERT(SERVER_KNOBS->FINISH_MOVE_KEYS_MAX_RETRIES > 0);
+
+	return Void();
 }

--- a/fdbserver/core/MoveKeys.cpp
+++ b/fdbserver/core/MoveKeys.cpp
@@ -44,11 +44,13 @@ static inline void dprint(fmt::format_string<T...> fmt, T&&... args) {
 
 namespace {
 
-// Exponential backoff for transaction_too_old retries in finishMoveKeys.
-// Formula: 0.1 * 2^retries, capped at 5.0s. Called with retries >= 1
-// (retries is incremented before the call), so effective start is 0.2s.
+// Exponential backoff with jitter for transaction_too_old retries in finishMoveKeys.
+// Base formula: 0.1 * 2^retries, capped at 5.0s, then jittered to [0.75x, 1.25x].
+// Called with retries >= 1 (retries is incremented before the call), so effective
+// start is ~0.2s. Jitter prevents FlowLock slots from retrying in lockstep.
 double finishMoveKeysBackoff(int retries) {
-	return std::min(0.1 * (1 << std::min(retries, 6)), 5.0);
+	double base = std::min(0.1 * (1 << std::min(retries, 6)), 5.0);
+	return base * (0.75 + 0.5 * deterministicRandom()->random01()); // jitter: [0.75x, 1.25x]
 }
 
 struct Shard {
@@ -3476,17 +3478,20 @@ Future<Void> unassignServerKeys(UID traceId, TrType tr, KeyRangeRef keys, std::s
 //      finishMoveKeys may not be called if no moves are scheduled
 // So we test the backoff arithmetic directly.
 TEST_CASE("/fdbserver/MoveKeys/finishMoveKeysBackoff") {
-	// Verify exponential backoff: 0.1 * 2^retries, capped at 5.0s.
-	// In production retries >= 1 at call site, so effective start is 0.2s.
-	ASSERT(finishMoveKeysBackoff(0) == 0.1);
-	ASSERT(finishMoveKeysBackoff(1) == 0.2);
-	ASSERT(finishMoveKeysBackoff(2) == 0.4);
-	ASSERT(finishMoveKeysBackoff(3) == 0.8);
-	ASSERT(finishMoveKeysBackoff(4) == 1.6);
-	ASSERT(finishMoveKeysBackoff(5) == 3.2);
-	ASSERT(finishMoveKeysBackoff(6) == 5.0); // capped
-	ASSERT(finishMoveKeysBackoff(7) == 5.0); // still capped
-	ASSERT(finishMoveKeysBackoff(100) == 5.0); // still capped
+	// Verify exponential backoff with jitter: base = 0.1 * 2^retries capped at 5.0s,
+	// then jittered to [0.75x, 1.25x]. In production retries >= 1 at call site.
+	for (int i = 0; i < 100; i++) {
+		double v0 = finishMoveKeysBackoff(0);
+		ASSERT(v0 >= 0.1 * 0.75 && v0 <= 0.1 * 1.25);
+		double v1 = finishMoveKeysBackoff(1);
+		ASSERT(v1 >= 0.2 * 0.75 && v1 <= 0.2 * 1.25);
+		double v3 = finishMoveKeysBackoff(3);
+		ASSERT(v3 >= 0.8 * 0.75 && v3 <= 0.8 * 1.25);
+		double v6 = finishMoveKeysBackoff(6);
+		ASSERT(v6 >= 5.0 * 0.75 && v6 <= 5.0 * 1.25); // capped at 5.0 base
+		double v100 = finishMoveKeysBackoff(100);
+		ASSERT(v100 >= 5.0 * 0.75 && v100 <= 5.0 * 1.25); // still capped
+	}
 
 	// Verify the retry limit knob exists and is positive
 	ASSERT(SERVER_KNOBS->FINISH_MOVE_KEYS_MAX_RETRIES > 0);

--- a/fdbserver/core/MoveKeys.cpp
+++ b/fdbserver/core/MoveKeys.cpp
@@ -50,7 +50,7 @@ namespace {
 // start is ~0.2s. Jitter prevents FlowLock slots from retrying in lockstep.
 double finishMoveKeysBackoff(int retries) {
 	double base = std::min(0.1 * (1 << std::min(retries, 6)), 5.0);
-	return base * (0.75 + 0.5 * deterministicRandom()->random01()); // jitter: [0.75x, 1.25x]
+	return std::min(base * (0.75 + 0.5 * deterministicRandom()->random01()), 5.0); // jitter: [0.75x, 1.25x], capped
 }
 
 struct Shard {
@@ -3488,9 +3488,9 @@ TEST_CASE("/fdbserver/MoveKeys/finishMoveKeysBackoff") {
 		double v3 = finishMoveKeysBackoff(3);
 		ASSERT(v3 >= 0.8 * 0.75 && v3 <= 0.8 * 1.25);
 		double v6 = finishMoveKeysBackoff(6);
-		ASSERT(v6 >= 5.0 * 0.75 && v6 <= 5.0 * 1.25); // capped at 5.0 base
+		ASSERT(v6 >= 5.0 * 0.75 && v6 <= 5.0); // capped at 5.0
 		double v100 = finishMoveKeysBackoff(100);
-		ASSERT(v100 >= 5.0 * 0.75 && v100 <= 5.0 * 1.25); // still capped
+		ASSERT(v100 >= 5.0 * 0.75 && v100 <= 5.0); // still capped
 	}
 
 	// Verify the retry limit knob exists and is positive

--- a/fdbserver/core/ServerKnobs.cpp
+++ b/fdbserver/core/ServerKnobs.cpp
@@ -995,6 +995,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( SERVER_READY_QUORUM_TIMEOUT,                          15.0 ); if( randomize && BUGGIFY ) SERVER_READY_QUORUM_TIMEOUT = 1.0;
 	init( REMOVE_RETRY_DELAY,                                    1.0 );
 	init( MOVE_KEYS_KRM_LIMIT,                                  2000 ); if( randomize && BUGGIFY ) MOVE_KEYS_KRM_LIMIT = 2;
+	init( FINISH_MOVE_KEYS_MAX_RETRIES,                           50 ); // ~4 min total with exponential backoff (0.2s to 5s cap)
 	init( MOVE_KEYS_KRM_LIMIT_BYTES,                             1e5 ); if( randomize && BUGGIFY ) MOVE_KEYS_KRM_LIMIT_BYTES = 5e4; //This must be sufficiently larger than CLIENT_KNOBS->KEY_SIZE_LIMIT (fdbclient/Knobs.h) to ensure that at least two entries will be returned from an attempt to read a key range map
 	init( MOVE_SHARD_KRM_ROW_LIMIT,                            20000 );
  	init( MOVE_SHARD_KRM_BYTE_LIMIT,                             1e6 );

--- a/fdbserver/core/include/fdbserver/core/Knobs.h
+++ b/fdbserver/core/include/fdbserver/core/Knobs.h
@@ -917,6 +917,8 @@ public:
 	double SERVER_READY_QUORUM_TIMEOUT;
 	double REMOVE_RETRY_DELAY;
 	int MOVE_KEYS_KRM_LIMIT;
+	int FINISH_MOVE_KEYS_MAX_RETRIES; // Max retries in finishMoveKeys before returning move to queue; set very high to
+	                                  // disable
 	int MOVE_KEYS_KRM_LIMIT_BYTES; // This must be sufficiently larger than CLIENT_KNOBS->KEY_SIZE_LIMIT
 	                               // (fdbclient/Knobs.h) to ensure that at least two entries will be returned from an
 	                               // attempt to read a key range map

--- a/fdbserver/datadistributor/DDRelocationQueue.actor.cpp
+++ b/fdbserver/datadistributor/DDRelocationQueue.actor.cpp
@@ -2203,7 +2203,8 @@ Future<Void> dataDistributionRelocator(DDQueue* self,
 
 			//TraceEvent("RelocateShardFinished", distributorId).detail("RelocateId", relocateShardInterval.pairID);
 
-			if (error.code() != error_code_move_to_removed_server) {
+			if (error.code() != error_code_move_to_removed_server &&
+			    error.code() != error_code_finish_move_keys_too_many_retries) {
 				if (!error.code()) {
 					try {
 						co_await healthyDestinations

--- a/fdbserver/datadistributor/DataDistribution.cpp
+++ b/fdbserver/datadistributor/DataDistribution.cpp
@@ -83,7 +83,8 @@ std::set<int> const& normalDDQueueErrors() {
 	static std::set<int> s{ error_code_movekeys_conflict,
 		                    error_code_broken_promise,
 		                    error_code_data_move_cancelled,
-		                    error_code_data_move_dest_team_not_found };
+		                    error_code_data_move_dest_team_not_found,
+		                    error_code_finish_move_keys_too_many_retries };
 	return s;
 }
 

--- a/flow/include/flow/error_definitions.h
+++ b/flow/include/flow/error_definitions.h
@@ -167,6 +167,7 @@ ERROR( range_unlock_reject, 1248, "Range unlock is rejected" )
 ERROR( bulkload_dataset_not_cover_required_range, 1249, "Bulkload dataset does not cover the required range" )
 ERROR( bulkload_invalid_configuration, 1250, "BulkLoad requires cluster configuration with both shard_encode_location_metadata=1 and enable_read_lock_on_range=1" )
 ERROR( transaction_grv_queue_rejected, 1251, "GRV request rejected because estimated queue wait exceeds transaction limit" )
+ERROR( finish_move_keys_too_many_retries, 1252, "finishMoveKeys exceeded retry limit" )
 
 // 15xx Platform errors
 ERROR( platform_error, 1500, "Platform error" )


### PR DESCRIPTION
Cherry-pick of 255372768cd4 ("DD 7.3 finish movekeys backoff (#12991)") adapted for main branch file renames (coroutines migration). Adds exponential backoff for transaction_too_old retries in finishMoveKeys with a configurable retry limit (FINISH_MOVE_KEYS_MAX_RETRIES knob, default 50). Error code uses 1251 since 1235 is taken on main.
`
  20260503-030816-stack_cherrypick-d8314720669ab3cd  compressed=True data_size=37064896 duration=5170006 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:22:56 sanity=False started=100000 stopped=20260503-043112 submitted=20260503-030816 timeout=5400 username=stack_cherrypick`