### PR TITLE
fix: prevent spurious commit_unknown_result_fatal from client buggify

### DIFF
--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -4372,11 +4372,7 @@ ACTOR static Future<Void> tryCommit(Reference<TransactionState> trState, CommitT
 
 	try {
 		if (CLIENT_BUGGIFY) {
-			throw deterministicRandom()->randomChoice(std::vector<Error>{ not_committed(),
-			                                                              transaction_too_old(),
-			                                                              commit_proxy_memory_limit_exceeded(),
-			                                                              grv_proxy_memory_limit_exceeded(),
-			                                                              commit_unknown_result() });
+			throw deterministicRandom()->randomChoice(std::vector<Error>{ not_committed(), transaction_too_old() });
 		}
 
 		if (req.tagSet.present() && trState->options.priority < TransactionPriority::IMMEDIATE) {
@@ -4389,6 +4385,10 @@ ACTOR static Future<Void> tryCommit(Reference<TransactionState> trState, CommitT
 		}
 
 		req.transaction.read_snapshot = trState->readVersion();
+
+		if (CLIENT_BUGGIFY) {
+			throw commit_proxy_memory_limit_exceeded();
+		}
 
 		startTime = now();
 		state Optional<UID> commitID = Optional<UID>();
@@ -5182,6 +5182,9 @@ ACTOR Future<Version> extractReadVersion(Reference<TransactionState> trState,
                                          Promise<Optional<Value>> metadataVersion) {
 	state Span span(spanContext, location, trState->spanContext);
 	GetReadVersionReply rep = wait(f);
+	if (CLIENT_BUGGIFY) {
+		throw grv_proxy_memory_limit_exceeded();
+	}
 	double replyTime = now();
 	double latency = replyTime - trState->startTime;
 	trState->cx->lastProxyRequestTime = trState->startTime;


### PR DESCRIPTION
## Description

CLIENT_BUGGIFY in tryCommit could throw commit_unknown_result before
the read version was fetched, causing determineCommitStatus to be called
with an uninitialized read_snapshot. This made the expiredVersion check
trivially true and raised commit_unknown_result_fatal, which retry loops
are not designed to handle. #10312 

## Fix
Fix by splitting the buggify block into three targeted injection points:
- grv_proxy_memory_limit_exceeded moves to extractReadVersion
- commit_proxy_memory_limit_exceeded moves to after read_snapshot is set
- commit_unknown_result is removed from the pre-read-version block;
  the existing post-reply buggify at the CommitID handler is sufficient