### PR TITLE
Reduce coroutine overhead

### DIFF
--- a/flow/bench/BenchCoroutineOverhead.cpp
+++ b/flow/bench/BenchCoroutineOverhead.cpp
@@ -1,0 +1,96 @@
+/*
+ * BenchCoroutineOverhead.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "benchmark/benchmark.h"
+
+#include "flow/ThreadHelper.actor.h"
+#include "flow/flow.h"
+
+namespace {
+
+Future<int> returnReadyInt() {
+	co_return 1;
+}
+
+Future<Void> returnReadyVoid() {
+	co_return;
+}
+
+Future<Void> benchCreateReadyIntActor(benchmark::State* state) {
+	int sink = 0;
+	while (state->KeepRunning()) {
+		Future<int> f = returnReadyInt();
+		ASSERT(f.isReady());
+		sink += f.get();
+		benchmark::DoNotOptimize(f);
+	}
+	benchmark::DoNotOptimize(sink);
+	co_return;
+}
+
+Future<Void> benchCreateReadyVoidActor(benchmark::State* state) {
+	while (state->KeepRunning()) {
+		Future<Void> f = returnReadyVoid();
+		ASSERT(f.isReady());
+		benchmark::DoNotOptimize(f);
+	}
+	co_return;
+}
+
+Future<Void> benchAwaitReadyIntActor(benchmark::State* state) {
+	Future<int> ready = 1;
+	int sink = 0;
+	while (state->KeepRunning()) {
+		sink += co_await ready;
+	}
+	benchmark::DoNotOptimize(sink);
+	co_return;
+}
+
+Future<Void> benchAwaitReadyVoidActor(benchmark::State* state) {
+	Future<Void> ready = Void();
+	while (state->KeepRunning()) {
+		co_await ready;
+	}
+	co_return;
+}
+
+void benchCreateReadyInt(benchmark::State& state) {
+	onMainThread([&state] { return benchCreateReadyIntActor(&state); }).blockUntilReady();
+}
+
+void benchCreateReadyVoid(benchmark::State& state) {
+	onMainThread([&state] { return benchCreateReadyVoidActor(&state); }).blockUntilReady();
+}
+
+void benchAwaitReadyInt(benchmark::State& state) {
+	onMainThread([&state] { return benchAwaitReadyIntActor(&state); }).blockUntilReady();
+}
+
+void benchAwaitReadyVoid(benchmark::State& state) {
+	onMainThread([&state] { return benchAwaitReadyVoidActor(&state); }).blockUntilReady();
+}
+
+BENCHMARK(benchCreateReadyInt)->Name("coroutine_overhead/create_ready_int")->ReportAggregatesOnly(true);
+BENCHMARK(benchCreateReadyVoid)->Name("coroutine_overhead/create_ready_void")->ReportAggregatesOnly(true);
+BENCHMARK(benchAwaitReadyInt)->Name("coroutine_overhead/await_ready_int")->ReportAggregatesOnly(true);
+BENCHMARK(benchAwaitReadyVoid)->Name("coroutine_overhead/await_ready_void")->ReportAggregatesOnly(true);
+
+} // namespace

--- a/flow/include/flow/CoroutinesImpl.h
+++ b/flow/include/flow/CoroutinesImpl.h
@@ -483,7 +483,9 @@ struct AwaitableAsyncResult : AwaitCancelHandler {
 	void await_resume()
 	    requires(std::is_void_v<ValueType>)
 	{
-		resumeImpl();
+		if (pt->waitState() != ACTOR_WAIT_STATE_NOT_WAITING) {
+			resumeImpl();
+		}
 		if (result.resultState->isError()) {
 			throw result.resultState->getError();
 		}
@@ -492,7 +494,9 @@ struct AwaitableAsyncResult : AwaitCancelHandler {
 	ValueType await_resume()
 	    requires(!std::is_void_v<ValueType>)
 	{
-		resumeImpl();
+		if (pt->waitState() != ACTOR_WAIT_STATE_NOT_WAITING) {
+			resumeImpl();
+		}
 		if (result.resultState->isError()) {
 			throw result.resultState->getError();
 		}
@@ -510,7 +514,9 @@ template <class Awaiter>
 struct AwaitableResume<Awaiter, Void, /* IsStream = */ false, /* ReturnsExplicitVoid = */ false> {
 	[[maybe_unused]] void await_resume() {
 		auto self = static_cast<Awaiter*>(this);
-		self->resumeImpl();
+		if (self->pt->waitState() != ACTOR_WAIT_STATE_NOT_WAITING) {
+			self->resumeImpl();
+		}
 		if (self->future.isError()) {
 			throw self->future.getError();
 		}
@@ -521,7 +527,9 @@ template <class Awaiter, class ValueType>
 struct AwaitableResume<Awaiter, ValueType, /* IsStream = */ false, /* ReturnsExplicitVoid = */ false> {
 	ValueType const& await_resume() {
 		auto self = static_cast<Awaiter*>(this);
-		self->resumeImpl();
+		if (self->pt->waitState() != ACTOR_WAIT_STATE_NOT_WAITING) {
+			self->resumeImpl();
+		}
 		if (self->future.isError()) {
 			throw self->future.getError();
 		}
@@ -537,7 +545,9 @@ template <class Awaiter>
 struct AwaitableResume<Awaiter, Void, /* IsStream = */ false, /* ReturnsExplicitVoid = */ true> {
 	[[maybe_unused]] ExplicitVoid await_resume() {
 		auto self = static_cast<Awaiter*>(this);
-		self->resumeImpl();
+		if (self->pt->waitState() != ACTOR_WAIT_STATE_NOT_WAITING) {
+			self->resumeImpl();
+		}
 		if (self->future.isError()) {
 			throw self->future.getError();
 		}
@@ -721,7 +731,9 @@ struct AwaitableFutureIgnore : AwaitableFutureOwning<PromiseType, ValueType> {
 
 	Void await_resume() {
 		auto self = static_cast<Base*>(this);
-		self->resumeImpl();
+		if (self->pt->waitState() != ACTOR_WAIT_STATE_NOT_WAITING) {
+			self->resumeImpl();
+		}
 		// Preserve normal Future<T> error propagation while discarding any
 		// successful T payload.
 		if (self->future.isError()) {
@@ -740,7 +752,9 @@ struct AwaitableFutureErrorOr : AwaitableFutureOwning<PromiseType, SourceValue> 
 
 	ResultType await_resume() {
 		auto self = static_cast<Base*>(this);
-		self->resumeImpl();
+		if (self->pt->waitState() != ACTOR_WAIT_STATE_NOT_WAITING) {
+			self->resumeImpl();
+		}
 		// Convert failed Future<T> awaits into ErrorOr instead of throwing so
 		// callers can cheaply observe completion-only state.
 		if (self->future.isError()) {


### PR DESCRIPTION
This PR reduces the overhead of using coroutines, by guarding against unnecessary `resumeImpl` calls when not in `ACTOR_WAIT_STATE_NOT_WAITING` state. New microbenchmarks are added demonstrating the performance benefit:

| Benchmark | Baseline | Optimized | Change
| -- | -- | -- | --
| coroutine_overhead/await_ready_void | 3.10 ns | 1.25 ns | -59.7%
| coroutine_overhead/await_ready_int | 4.65 ns | 4.42 ns | -4.9%
| coroutine_overhead/create_ready_int | 33.5 ns | 33.8 ns | effectively flat
| coroutine_overhead/create_ready_void | 33.6 ns | 33.5 ns | effectively flat
