### PR TITLE
Fix flaky `/flow/Hostname/parse` unit test

### DIFF
--- a/flow/Hostname.cpp
+++ b/flow/Hostname.cpp
@@ -130,6 +130,7 @@ TEST_CASE("/flow/Hostname/parse") {
 	std::string hn11s = "[::1]:4800";
 	std::string hn12s = "[::1]:4800:tls";
 	std::string hn13s = "1234";
+	std::string unresolvableHostnameString = "host-name.invalid:1234";
 
 	auto hn1 = Hostname::parse(hn1s);
 	ASSERT(hn1.toString() == hn1s);
@@ -165,15 +166,17 @@ TEST_CASE("/flow/Hostname/parse") {
 	ASSERT(!Hostname::isHostname(hn12s));
 	ASSERT(!Hostname::isHostname(hn13s));
 
-	Optional<NetworkAddress> optionalAddress = co_await hn2.resolve();
+	Hostname unresolvableHostname = Hostname::parse(unresolvableHostnameString);
+
+	Optional<NetworkAddress> optionalAddress = co_await unresolvableHostname.resolve();
 	ASSERT(!optionalAddress.present());
 
-	optionalAddress = hn2.resolveBlocking();
+	optionalAddress = unresolvableHostname.resolveBlocking();
 	ASSERT(!optionalAddress.present());
 
 	NetworkAddress address;
 	try {
-		address = co_await timeoutError(hn2.resolveWithRetry(), 1);
+		address = co_await timeoutError(unresolvableHostname.resolveWithRetry(), 1);
 	} catch (Error& e) {
 		ASSERT(e.code() == error_code_timed_out);
 	}

--- a/flow/Hostname.cpp
+++ b/flow/Hostname.cpp
@@ -130,6 +130,8 @@ TEST_CASE("/flow/Hostname/parse") {
 	std::string hn11s = "[::1]:4800";
 	std::string hn12s = "[::1]:4800:tls";
 	std::string hn13s = "1234";
+	// This host name is guaranteed not to be resolvable:
+	// https://www.rfc-editor.org/rfc/rfc2606.html
 	std::string unresolvableHostnameString = "host-name.invalid:1234";
 
 	auto hn1 = Hostname::parse(hn1s);


### PR DESCRIPTION
In https://github.com/apple/foundationdb/pull/13090, I hit a gcc CI failure that I was unable to reproduce, and I suspect the cause is that `host-name` is sometimes resolvable, causing flakiness. In this PR, the host name is replaced with a more intentionally unresolvable hostname to remove this flakiness.
