### PR TITLE
Avoid using bulkload in tests with `shardedrocksdb`

### DIFF
--- a/tests/fast/TxnStateStoreCycleTest.toml
+++ b/tests/fast/TxnStateStoreCycleTest.toml
@@ -1,4 +1,6 @@
 [configuration]
+# FIXME: remove after bulkloading with fetchKey supports shardedrocksdb
+storageEngineExcludeTypes = [5]
 
 [[test]]
 testTitle = 'PreLoad'


### PR DESCRIPTION
This PR removes testing an [unsupported configuration](https://github.com/apple/foundationdb/blob/1de02c28c588e94be94b826ac11b0f0f55f3e3b7/fdbclient/tests/fdb_cluster_fixture.sh#L129), which caused CI failures on https://github.com/apple/foundationdb/pull/13090.
