### PR TITLE
Use human-readable strings for storage engine exclusion in test files

### DIFF
--- a/fdbserver/SimulatedCluster.cpp
+++ b/fdbserver/SimulatedCluster.cpp
@@ -113,7 +113,22 @@ std::string describe(int const& val) {
 
 template <>
 std::string describe(const SimulationStorageEngine& val) {
-	return std::to_string(static_cast<uint32_t>(val));
+	switch (val) {
+	case SimulationStorageEngine::SSD:
+		return "ssd";
+	case SimulationStorageEngine::MEMORY:
+		return "memory";
+	case SimulationStorageEngine::RADIX_TREE:
+		return "memory-radixtree";
+	case SimulationStorageEngine::REDWOOD:
+		return "ssd-redwood-1";
+	case SimulationStorageEngine::ROCKSDB:
+		return "ssd-rocksdb-v1";
+	case SimulationStorageEngine::SHARDED_ROCKSDB:
+		return "ssd-sharded-rocksdb";
+	default:
+		return std::to_string(static_cast<uint32_t>(val));
+	}
 }
 
 namespace {
@@ -121,6 +136,28 @@ namespace {
 bool isValidSimulationStorageEngineValue(const std::underlying_type_t<SimulationStorageEngine>& value) {
 	return value < static_cast<std::underlying_type_t<SimulationStorageEngine>>(
 	                   SimulationStorageEngine::SIMULATION_STORAGE_ENGINE_INVALID_VALUE);
+}
+
+SimulationStorageEngine parseSimulationStorageEngine(const toml::value& value) {
+	if (value.type() == toml::value_t::integer) {
+		const auto intVal = static_cast<uint8_t>(value.as_integer());
+		ASSERT(isValidSimulationStorageEngineValue(intVal));
+		return static_cast<SimulationStorageEngine>(intVal);
+	}
+
+	ASSERT(value.type() == toml::value_t::string);
+	const auto& stringVal = value.as_string();
+	static const std::unordered_map<std::string, SimulationStorageEngine> STORAGE_ENGINE_NAME_MAPPER = {
+		{ "ssd", SimulationStorageEngine::SSD },
+		{ "memory", SimulationStorageEngine::MEMORY },
+		{ "memory-radixtree", SimulationStorageEngine::RADIX_TREE },
+		{ "ssd-redwood-1", SimulationStorageEngine::REDWOOD },
+		{ "ssd-rocksdb-v1", SimulationStorageEngine::ROCKSDB },
+		{ "ssd-sharded-rocksdb", SimulationStorageEngine::SHARDED_ROCKSDB },
+	};
+	const auto iter = STORAGE_ENGINE_NAME_MAPPER.find(stringVal);
+	ASSERT(iter != STORAGE_ENGINE_NAME_MAPPER.end());
+	return iter->second;
 }
 
 constexpr int MACHINE_REBOOT_TIME = 10;
@@ -183,9 +220,7 @@ class TestConfig : public BasicTestConfig {
 			void operator()(std::set<SimulationStorageEngine>* val) const {
 				auto arr = value.as_array();
 				for (const auto& i : arr) {
-					const auto intVal = static_cast<uint8_t>(i.as_integer());
-					ASSERT(isValidSimulationStorageEngineValue(intVal));
-					val->insert(static_cast<SimulationStorageEngine>(intVal));
+					val->insert(parseSimulationStorageEngine(i));
 				}
 			}
 			void operator()(Optional<std::set<SimulationStorageEngine>>* val) const {
@@ -400,14 +435,8 @@ public:
 	// 7.1 cannot be downgraded to 7.0 and below after enabling hostname, so disable hostname for 7.0 downgrade tests
 	bool disableHostname = false;
 	// Storage Engine Types: Verify match with SimulationConfig::generateNormalConfig
-	//	0 = "ssd"
-	//	1 = "memory"
-	//	2 = "memory-radixtree"
-	//	3 = "ssd-redwood-1"
-	//	4 = "ssd-rocksdb-v1"
-	//	5 = "ssd-sharded-rocksdb"
-	// Requires a comma-separated list of numbers WITHOUT whitespaces
-	// See SimulationStorageEngine for more details
+	// TOML tests may use either the canonical string names or legacy integer values. Restart tests
+	// parsed by older binaries must keep using legacy integers for compatibility.
 	std::set<SimulationStorageEngine> storageEngineExcludeTypes;
 	Optional<int> datacenters, stderrSeverity, processesPerMachine;
 	// Set the maximum TLog version that can be selected for a test
@@ -1632,7 +1661,7 @@ const std::vector<SimulationStorageEngine> SIMULATION_STORAGE_ENGINE = {
 std::string getExcludedStorageEngineTypesInString(const std::set<SimulationStorageEngine>& excluded) {
 	std::string str;
 	for (const auto& e : excluded) {
-		str += std::to_string(static_cast<uint32_t>(e));
+		str += describe(e);
 		str += ',';
 	}
 	if (!excluded.empty())

--- a/tests/fast/BulkDumping.toml
+++ b/tests/fast/BulkDumping.toml
@@ -1,5 +1,5 @@
 [configuration]
-storageEngineExcludeTypes = [5] #FIXME: remove after allowing to do bulkloading with fetchKey and shardedrocksdb
+storageEngineExcludeTypes = ["ssd-sharded-rocksdb"] #FIXME: remove after allowing to do bulkloading with fetchKey and shardedrocksdb
 
 disableTss = true # TODO(BulkLoad): support TSS. finishMoveShard should wait for TSS if a data move is bulkload data move.
 

--- a/tests/fast/BulkLoading.toml
+++ b/tests/fast/BulkLoading.toml
@@ -1,5 +1,5 @@
 [configuration]
-storageEngineExcludeTypes = [5] #FIXME: remove after allowing to do bulkloading with fetchKey and shardedrocksdb
+storageEngineExcludeTypes = ["ssd-sharded-rocksdb"] #FIXME: remove after allowing to do bulkloading with fetchKey and shardedrocksdb
 
 disableTss = true # TODO(BulkLoad): support TSS. finishMoveShard should wait for TSS if a data move is bulkload data move.
 

--- a/tests/slow/BackupS3BlobBulkLoadRestore.toml
+++ b/tests/slow/BackupS3BlobBulkLoadRestore.toml
@@ -21,7 +21,7 @@
 testClass = "Backup"
 
 [configuration]
-storageEngineExcludeTypes = [5] # FIXME: remove after allowing bulkloading with fetchKey and shardedrocksdb
+storageEngineExcludeTypes = ["ssd-sharded-rocksdb"] # FIXME: remove after allowing bulkloading with fetchKey and shardedrocksdb
 disableTss = true # TODO(BulkLoad): support TSS
 
 # HA (multi-region) configuration - randomly enabled for test coverage

--- a/tests/slow/BackupS3BlobBulkLoadRestoreMultiRange.toml
+++ b/tests/slow/BackupS3BlobBulkLoadRestoreMultiRange.toml
@@ -20,7 +20,7 @@
 testClass = "Backup"
 
 [configuration]
-storageEngineExcludeTypes = [5] # TODO(BulkLoad): remove after allowing bulkloading with fetchKey and shardedrocksdb
+storageEngineExcludeTypes = ["ssd-sharded-rocksdb"] # TODO(BulkLoad): remove after allowing bulkloading with fetchKey and shardedrocksdb
 disableTss = true # TODO(BulkLoad): support TSS
 
 # HA (multi-region) configuration - randomly enabled for test coverage

--- a/tests/slow/BackupS3BlobBulkLoadRestoreWithChaos.toml
+++ b/tests/slow/BackupS3BlobBulkLoadRestoreWithChaos.toml
@@ -19,7 +19,7 @@
 testClass = "Backup"
 
 [configuration]
-storageEngineExcludeTypes = [5] # TODO(BulkLoad): remove after allowing bulkloading with fetchKey and shardedrocksdb
+storageEngineExcludeTypes = ["ssd-sharded-rocksdb"] # TODO(BulkLoad): remove after allowing bulkloading with fetchKey and shardedrocksdb
 disableTss = true # TODO(BulkLoad): support TSS
 
 # HA (multi-region) configuration - randomly enabled for test coverage

--- a/tests/slow/BulkDumpingS3.toml
+++ b/tests/slow/BulkDumpingS3.toml
@@ -1,5 +1,5 @@
 [configuration]
-storageEngineExcludeTypes = [5] #FIXME: remove after allowing to do bulkloading with fetchKey and shardedrocksdb
+storageEngineExcludeTypes = ["ssd-sharded-rocksdb"] #FIXME: remove after allowing to do bulkloading with fetchKey and shardedrocksdb
 
 disableTss = true # TODO(BulkLoad): support TSS. finishMoveShard should wait for TSS if a data move is bulkload data move.
 

--- a/tests/slow/BulkDumpingS3WithChaos.toml
+++ b/tests/slow/BulkDumpingS3WithChaos.toml
@@ -20,7 +20,7 @@
 # - Don't cause FetchKeys/DataDistribution to hang under stress
 
 [configuration]
-storageEngineExcludeTypes = [5] #FIXME: remove after allowing to do bulkloading with fetchKey and shardedrocksdb
+storageEngineExcludeTypes = ["ssd-sharded-rocksdb"] #FIXME: remove after allowing to do bulkloading with fetchKey and shardedrocksdb
 
 disableTss = true # TODO(BulkLoad): support TSS. finishMoveShard should wait for TSS if a data move is bulkload data move.
 

--- a/tests/slow/DiskFailureCycle.toml
+++ b/tests/slow/DiskFailureCycle.toml
@@ -3,7 +3,7 @@ buggify = false
 minimumReplication = 3
 minimumRegions = 3
 logAntiQuorum = 0
-storageEngineExcludeTypes = [1, 2, 4, 5]
+storageEngineExcludeTypes = ["memory", "memory-radixtree", "ssd-rocksdb-v1", "ssd-sharded-rocksdb"]
 
 [[test]]
 testTitle = 'DiskFailureCycle'


### PR DESCRIPTION
This PR makes test files more readable, by making it immediately clear which storage engines are excluded
