### PR TITLE
Fix `tryCommit` handling of `never_reply` errors

### DIFF
--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -4509,7 +4509,8 @@ ACTOR static Future<Void> tryCommit(Reference<TransactionState> trState, CommitT
 			}
 		}
 	} catch (Error& e) {
-		if (e.code() == error_code_request_maybe_delivered || e.code() == error_code_commit_unknown_result) {
+		if (e.code() == error_code_request_maybe_delivered || e.code() == error_code_commit_unknown_result ||
+		    e.code() == error_code_never_reply) {
 			// We don't know if the commit happened, and it might even still be in flight.
 
 			if (!trState->options.causalWriteRisky || req.idempotencyId.valid()) {


### PR DESCRIPTION
During recovery, provisional commits intentionally use `req.reply.send(Never())` so clients observe an unknown commit result. Remote replies already suppress `never_reply`, but a same-process caller can observe it directly, which allowed `tryCommit` to treat it as an unexpected fatal error.

Bug was uncovered on commit `15a3e11783370b1ccb138ff7e65eda8d1638351c` with test:
```
fdbserver -r simulation --crash --logsize 1024MB \
  -f tests/fast/StatusDuringOutage.toml \
  --buggify on --seed 987285765
```

Testing with the same seed after applying this PR's change to the failing commit verified that the error was properly suppressed.