### PR TITLE
Add jitter to finishMoveKeys backoff

### DIFF
--- a/fdbserver/MoveKeys.actor.cpp
+++ b/fdbserver/MoveKeys.actor.cpp
@@ -44,7 +44,7 @@ namespace {
 // start is ~0.2s. Jitter prevents FlowLock slots from retrying in lockstep.
 double finishMoveKeysBackoff(int retries) {
 	double base = std::min(0.1 * (1 << std::min(retries, 6)), 5.0);
-	return base * (0.75 + 0.5 * deterministicRandom()->random01()); // jitter: [0.75x, 1.25x]
+	return std::min(base * (0.75 + 0.5 * deterministicRandom()->random01()), 5.0); // jitter: [0.75x, 1.25x], capped
 }
 
 struct Shard {
@@ -3530,9 +3530,9 @@ TEST_CASE("/fdbserver/MoveKeys/finishMoveKeysBackoff") {
 		double v3 = finishMoveKeysBackoff(3);
 		ASSERT(v3 >= 0.8 * 0.75 && v3 <= 0.8 * 1.25);
 		double v6 = finishMoveKeysBackoff(6);
-		ASSERT(v6 >= 5.0 * 0.75 && v6 <= 5.0 * 1.25); // capped at 5.0 base
+		ASSERT(v6 >= 5.0 * 0.75 && v6 <= 5.0); // capped at 5.0
 		double v100 = finishMoveKeysBackoff(100);
-		ASSERT(v100 >= 5.0 * 0.75 && v100 <= 5.0 * 1.25); // still capped
+		ASSERT(v100 >= 5.0 * 0.75 && v100 <= 5.0); // still capped
 	}
 
 	// Verify the retry limit knob exists and is positive

--- a/fdbserver/MoveKeys.actor.cpp
+++ b/fdbserver/MoveKeys.actor.cpp
@@ -38,11 +38,13 @@
 
 namespace {
 
-// Exponential backoff for transaction_too_old retries in finishMoveKeys.
-// Formula: 0.1 * 2^retries, capped at 5.0s. Called with retries >= 1
-// (retries is incremented before the call), so effective start is 0.2s.
+// Exponential backoff with jitter for transaction_too_old retries in finishMoveKeys.
+// Base formula: 0.1 * 2^retries, capped at 5.0s, then jittered to [0.75x, 1.25x].
+// Called with retries >= 1 (retries is incremented before the call), so effective
+// start is ~0.2s. Jitter prevents FlowLock slots from retrying in lockstep.
 double finishMoveKeysBackoff(int retries) {
-	return std::min(0.1 * (1 << std::min(retries, 6)), 5.0);
+	double base = std::min(0.1 * (1 << std::min(retries, 6)), 5.0);
+	return base * (0.75 + 0.5 * deterministicRandom()->random01()); // jitter: [0.75x, 1.25x]
 }
 
 struct Shard {
@@ -3518,17 +3520,20 @@ void seedShardServers(Arena& arena, CommitTransactionRef& tr, std::vector<Storag
 //      finishMoveKeys may not be called if no moves are scheduled
 // So we test the backoff arithmetic directly.
 TEST_CASE("/fdbserver/MoveKeys/finishMoveKeysBackoff") {
-	// Verify exponential backoff: 0.1 * 2^retries, capped at 5.0s.
-	// In production retries >= 1 at call site, so effective start is 0.2s.
-	ASSERT(finishMoveKeysBackoff(0) == 0.1);
-	ASSERT(finishMoveKeysBackoff(1) == 0.2);
-	ASSERT(finishMoveKeysBackoff(2) == 0.4);
-	ASSERT(finishMoveKeysBackoff(3) == 0.8);
-	ASSERT(finishMoveKeysBackoff(4) == 1.6);
-	ASSERT(finishMoveKeysBackoff(5) == 3.2);
-	ASSERT(finishMoveKeysBackoff(6) == 5.0); // capped
-	ASSERT(finishMoveKeysBackoff(7) == 5.0); // still capped
-	ASSERT(finishMoveKeysBackoff(100) == 5.0); // still capped
+	// Verify exponential backoff with jitter: base = 0.1 * 2^retries capped at 5.0s,
+	// then jittered to [0.75x, 1.25x]. In production retries >= 1 at call site.
+	for (int i = 0; i < 100; i++) {
+		double v0 = finishMoveKeysBackoff(0);
+		ASSERT(v0 >= 0.1 * 0.75 && v0 <= 0.1 * 1.25);
+		double v1 = finishMoveKeysBackoff(1);
+		ASSERT(v1 >= 0.2 * 0.75 && v1 <= 0.2 * 1.25);
+		double v3 = finishMoveKeysBackoff(3);
+		ASSERT(v3 >= 0.8 * 0.75 && v3 <= 0.8 * 1.25);
+		double v6 = finishMoveKeysBackoff(6);
+		ASSERT(v6 >= 5.0 * 0.75 && v6 <= 5.0 * 1.25); // capped at 5.0 base
+		double v100 = finishMoveKeysBackoff(100);
+		ASSERT(v100 >= 5.0 * 0.75 && v100 <= 5.0 * 1.25); // still capped
+	}
 
 	// Verify the retry limit knob exists and is positive
 	ASSERT(SERVER_KNOBS->FINISH_MOVE_KEYS_MAX_RETRIES > 0);


### PR DESCRIPTION
Jitter the exponential backoff delay to [0.75x, 1.25x] of the base value. This prevents all 15 FlowLock slots from retrying in lockstep when they all hit transaction_too_old at the same time.

Comes of a review of the forward-port to main branch: https://github.com/apple/foundationdb/pull/13138#pullrequestreview-4224959833