### PR TITLE
Add mako Docker image for performance testing

### DIFF
--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -230,6 +230,9 @@ if(NOT WIN32)
   # do not set RPATH for mako
   set_property(TARGET mako PROPERTY SKIP_BUILD_RPATH TRUE)
   target_link_libraries(mako PRIVATE fdb_c fdbclient fmt::fmt Threads::Threads fdb_cpp boost_target rapidjson)
+  if(NOT OPEN_FOR_IDE)
+    strip_debug_symbols(mako)
+  endif()
 
   if(NOT OPEN_FOR_IDE)
     # Make sure that fdb_c.h is compatible with c90

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -201,6 +201,31 @@ ENV FDB_CLUSTER_FILE_CONTENTS=""
 ENV FDB_PROCESS_CLASS=unset
 ENTRYPOINT ["/usr/bin/tini", "-g", "--", "/var/fdb/scripts/fdb.bash"]
 
+FROM foundationdb-base AS mako
+
+ARG FDB_VERSION=7.3.63
+ARG TARGETARCH
+COPY website/${FDB_VERSION}/mako.* /tmp/
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
+        FDB_ARCH=x86_64; \
+    elif [ "$TARGETARCH" = "arm64" ]; then \
+        FDB_ARCH=aarch64; \
+    else \
+        echo "ERROR: unsupported architecture $TARGETARCH" 1>&2; \
+        exit 1; \
+    fi; \
+    cp "/tmp/mako.${FDB_ARCH}" /usr/bin/mako && \
+    chmod +x /usr/bin/mako && \
+    rm -rf /tmp/*
+
+RUN mkdir -p /var/log/fdb-trace-logs && \
+    chown -R fdb:fdb /var/log/fdb-trace-logs
+USER fdb
+WORKDIR /var/fdb
+ENV FDB_CLUSTER_FILE=/var/fdb/fdb.cluster
+ENV LD_LIBRARY_PATH=/var/dynamic-conf/lib/
+ENTRYPOINT ["/usr/bin/mako"]
+
 FROM foundationdb-base AS ycsb
 
 RUN microdnf -y install \

--- a/packaging/docker/build-images.sh
+++ b/packaging/docker/build-images.sh
@@ -35,6 +35,9 @@ function create_fake_website_directory () {
     fi
     local stripped_binaries_and_from_where="${1}"
     fdb_binaries=( 'fdbbackup' 'fdbcli' 'fdbserver' 'fdbmonitor' )
+    if [ "${BUILD_MAKO:-0}" -eq 1 ]; then
+        fdb_binaries+=( 'mako' )
+    fi
     logg "PREPARING WEBSITE"
     website_directory="${script_dir}/website"
     rm -rf "${website_directory}"
@@ -208,6 +211,7 @@ function build_and_push_images () {
               [ "${image}" == 'foundationdb-kubernetes-sidecar' ] || \
               [ "${image}" == 'fdb-aws-s3-credentials-fetcher-sidecar' ] || \
               [ "${image}" == 'ycsb' ] || \
+              [ "${image}" == 'mako' ] || \
               [ "${image}" == 'fdb-kubernetes-monitor' ]; then
             tags_to_push+=("${image_tag}")
         fi
@@ -262,6 +266,9 @@ image_list=(
     'foundationdb-kubernetes-sidecar'
     'ycsb'
 )
+if [ "${BUILD_MAKO:-0}" -eq 1 ]; then
+    image_list+=( 'mako' )
+fi
 registry=""
 tag_base="foundationdb/"
 


### PR DESCRIPTION
Add an opt-in mako Docker image target to the build system. The mako benchmark binary is packaged into a minimal container for use in k8s performance regression tests. Build with BUILD_MAKO=1 to include it.

- Add mako stage to Dockerfile
- Add mako to build-images.sh (gated on BUILD_MAKO=1)
- Strip debug symbols from mako binary

(Mako is FDB's native C benchmark tool. It's a simple load generator that connects directly to FDB using the C client library and runs configurable workloads — random reads, writes, inserts, range scans — against a keyspace. It's built from source in bindings/c/test/mako/. Compared to YCSB (Java-based), mako is lighter weight, lower overhead, no JVM, and already part of the FDB codebase.)