### PR TITLE
Fix failing `GrvQueueDelay` unit test

### DIFF
--- a/fdbrpc/include/fdbrpc/TimedRequest.h
+++ b/fdbrpc/include/fdbrpc/TimedRequest.h
@@ -34,6 +34,8 @@ public:
 		return _requestTime;
 	}
 
+	void setRequestTime(double requestTime) { _requestTime = requestTime; }
+
 	TimedRequest() {
 		if (!FlowTransport::isClient()) {
 			_requestTime = g_network->timer();

--- a/fdbserver/grvproxy/GrvQueueDelayTests.cpp
+++ b/fdbserver/grvproxy/GrvQueueDelayTests.cpp
@@ -170,6 +170,7 @@ TEST_CASE("/fdbserver/grvproxy/maxGrvQueueDelay/rejectDecision/table") {
 
 	for (auto const& c : cases) {
 		GetReadVersionRequest req;
+		req.setRequestTime(now());
 		req.maxGrvQueueDelayMS = c.maxDelayMS;
 		req.proxyTagThrottledDuration = c.proxyTagThrottledDuration;
 


### PR DESCRIPTION
This PR addresses the comment here: https://github.com/apple/foundationdb/pull/13085#issuecomment-4390555912. Validated with 100 unit test reruns.