### PR TITLE
fix: missing break statements in CounterCollection::logToTraceEvent

### DIFF
--- a/fdbrpc/Stats.cpp
+++ b/fdbrpc/Stats.cpp
@@ -106,12 +106,14 @@ void CounterCollection::logToTraceEvent(TraceEvent& te) {
 				metrics->sumMap[c->id].points.back().addAttribute("ip", ip_str);
 				metrics->sumMap[c->id].points.back().addAttribute("port", port_str);
 				metrics->sumMap[c->id].points.back().startTime = logTime;
+				break;
 			}
 			case MetricsDataModel::STATSD: {
 				std::vector<std::pair<std::string, std::string>> statsd_attributes{ { "ip", ip_str },
 					                                                                { "port", port_str } };
 				metrics->statsd_message.push_back(createStatsdMessage(
 				    c->getName(), StatsDMetric::COUNTER, std::to_string(val) /*, statsd_attributes*/));
+				break;
 			}
 			case MetricsDataModel::NONE:
 			default: {
@@ -288,6 +290,7 @@ void LatencySample::logSample() {
 			createOtelGauge(p95id, name + "p95", p95);
 			createOtelGauge(p99id, name + "p99", p99);
 			createOtelGauge(p999id, name + "p99_9", p99_9);
+			break;
 		}
 		case MetricsDataModel::STATSD: {
 			std::vector<std::pair<std::string, std::string>> statsd_attributes{ { "ip", ip_str },
@@ -302,6 +305,7 @@ void LatencySample::logSample() {
 			    createStatsdMessage(name + "p99", StatsDMetric::GAUGE, std::to_string(p99) /*, statsd_attributes*/);
 			auto p999_gauge =
 			    createStatsdMessage(name + "p99.9", StatsDMetric::GAUGE, std::to_string(p99_9) /*, statsd_attributes*/);
+			break;
 		}
 		case MetricsDataModel::NONE:
 		default: {


### PR DESCRIPTION
## Problem

`CounterCollection::logToTraceEvent` has a switch on `c->model` with no
`break` statements between the `OTLP` and `STATSD` cases. When a counter
is configured with `model=OTLP`, the OTLP branch correctly populates
`MetricCollection::sumMap`, but control then falls through to the STATSD
branch and silently pushes to `MetricCollection::statsd_message`. A
deployment configured for OTLP metrics is also emitting StatsD-format
data on every counter log cycle, regardless of the operator's intent.

I encountered this while studying the metrics path referenced in #12679.

## Solution

Add explicit `break` statements after the `OTLP` and `STATSD` cases.
The `NONE`/`default` case is last and does not require a break.

## Testing

Added unit test `/fdbrpc/Stats/CounterCollectionFallthrough` in
`Stats.cpp` that forces `METRICS_DATA_MODEL=otel`, logs a counter,
and asserts that `sumMap` is populated and `statsd_message` is empty.

Verified:
- Without the fix: test fails on `ASSERT_EQ(statsd_message.size(), 0)` (`Test Cases Failed = 1`)
- With the fix: test passes (`Test Cases Failed = 0`)

Run with:
./bin/fdbserver -r unittests -f /fdbrpc/Stats/CounterCollectionFallthrough

