### PR TITLE
Set `desiredStatelessClasses` sufficiently high

### DIFF
--- a/fdbserver/SimulatedCluster.cpp
+++ b/fdbserver/SimulatedCluster.cpp
@@ -2515,6 +2515,12 @@ void setupSimulatedSystem(std::vector<Future<Void>>* systemActors,
 				}
 			}
 
+			if (processClass == ProcessClass::StatelessClass && !desiredStatelessClasses.present()) {
+				desiredStatelessClasses = std::max({ simconfig.db.getDesiredCommitProxies(),
+				                                     simconfig.db.getDesiredGrvProxies(),
+				                                     simconfig.db.getDesiredResolvers() });
+			}
+
 			if (desiredStatelessClasses.present() && actualStatelessClasses < desiredStatelessClasses.get()) {
 				processClass = ProcessClass(ProcessClass::StatelessClass, ProcessClass::CommandLineSource);
 				actualStatelessClasses++;

--- a/fdbserver/SimulatedCluster.cpp
+++ b/fdbserver/SimulatedCluster.cpp
@@ -2484,7 +2484,7 @@ void setupSimulatedSystem(std::vector<Future<Void>>* systemActors,
 		Standalone<StringRef> newZoneId;
 
 		if (!processClassForFifthAssignedMachine.present() && assignClasses && simconfig.db.regions.empty() &&
-		    assignedMachines <= 4 && 4 < assignedMachines + totalMachines) {
+		    assignedMachines <= 4 && 4 < assignedMachines + machines) {
 			processClassForFifthAssignedMachine =
 			    processClassesSubSet[deterministicRandom()->randomInt(0, processClassesSubSet.size())];
 		}
@@ -2494,8 +2494,8 @@ void setupSimulatedSystem(std::vector<Future<Void>>* systemActors,
 		if (testConfig.statelessProcessClassesPerDC.present()) {
 			desiredStatelessClasses = testConfig.statelessProcessClassesPerDC.get();
 		} else if (processClassForFifthAssignedMachine.present() &&
-		           processClassForFifthAssignedMachine.get() == ProcessClass::StatelessClass &&
-		           assignedMachines <= 4 && 4 < assignedMachines + totalMachines) {
+		           processClassForFifthAssignedMachine.get() == ProcessClass::StatelessClass && assignedMachines <= 4 &&
+		           4 < assignedMachines + machines) {
 			desiredStatelessClasses = std::max({ simconfig.db.getDesiredCommitProxies(),
 			                                     simconfig.db.getDesiredGrvProxies(),
 			                                     simconfig.db.getDesiredResolvers() });
@@ -2516,8 +2516,11 @@ void setupSimulatedSystem(std::vector<Future<Void>>* systemActors,
 					processClass = ProcessClass((ProcessClass::ClassType)deterministicRandom()->randomInt(0, 2),
 					                            ProcessClass::CommandLineSource); // Unset or Storage
 				else if (assignedMachines == 4 && simconfig.db.regions.empty())
-					processClass = ProcessClass(processClassForFifthAssignedMachine.get(),
-					                            ProcessClass::CommandLineSource); // Unset or Stateless
+					processClass = ProcessClass(
+					    processClassForFifthAssignedMachine.present()
+					        ? processClassForFifthAssignedMachine.get()
+					        : processClassesSubSet[deterministicRandom()->randomInt(0, processClassesSubSet.size())],
+					    ProcessClass::CommandLineSource); // Unset or Stateless
 				else
 					processClass = ProcessClass((ProcessClass::ClassType)deterministicRandom()->randomInt(0, 3),
 					                            ProcessClass::CommandLineSource); // Unset, Storage, or Transaction

--- a/fdbserver/SimulatedCluster.cpp
+++ b/fdbserver/SimulatedCluster.cpp
@@ -2451,6 +2451,7 @@ void setupSimulatedSystem(std::vector<Future<Void>>* systemActors,
 	bool gradualMigrationPossible = true;
 	std::vector<ProcessClass::ClassType> processClassesSubSet = { ProcessClass::UnsetClass,
 		                                                          ProcessClass::StatelessClass };
+	Optional<ProcessClass::ClassType> processClassForFifthAssignedMachine;
 	for (int dc = 0; dc < dataCenters; dc++) {
 		// FIXME: test unset dcID
 		Optional<Standalone<StringRef>> dcUID = StringRef(format("%d", dc));
@@ -2482,10 +2483,22 @@ void setupSimulatedSystem(std::vector<Future<Void>>* systemActors,
 		Standalone<StringRef> zoneId;
 		Standalone<StringRef> newZoneId;
 
+		if (!processClassForFifthAssignedMachine.present() && assignClasses && simconfig.db.regions.empty() &&
+		    assignedMachines <= 4 && 4 < assignedMachines + totalMachines) {
+			processClassForFifthAssignedMachine =
+			    processClassesSubSet[deterministicRandom()->randomInt(0, processClassesSubSet.size())];
+		}
+
 		Optional<int> desiredStatelessClasses;
 		int actualStatelessClasses = 0;
 		if (testConfig.statelessProcessClassesPerDC.present()) {
 			desiredStatelessClasses = testConfig.statelessProcessClassesPerDC.get();
+		} else if (processClassForFifthAssignedMachine.present() &&
+		           processClassForFifthAssignedMachine.get() == ProcessClass::StatelessClass &&
+		           assignedMachines <= 4 && 4 < assignedMachines + totalMachines) {
+			desiredStatelessClasses = std::max({ simconfig.db.getDesiredCommitProxies(),
+			                                     simconfig.db.getDesiredGrvProxies(),
+			                                     simconfig.db.getDesiredResolvers() });
 		}
 
 		for (int machine = 0; machine < totalMachines; machine++) {
@@ -2503,9 +2516,8 @@ void setupSimulatedSystem(std::vector<Future<Void>>* systemActors,
 					processClass = ProcessClass((ProcessClass::ClassType)deterministicRandom()->randomInt(0, 2),
 					                            ProcessClass::CommandLineSource); // Unset or Storage
 				else if (assignedMachines == 4 && simconfig.db.regions.empty())
-					processClass = ProcessClass(
-					    processClassesSubSet[deterministicRandom()->randomInt(0, processClassesSubSet.size())],
-					    ProcessClass::CommandLineSource); // Unset or Stateless
+					processClass = ProcessClass(processClassForFifthAssignedMachine.get(),
+					                            ProcessClass::CommandLineSource); // Unset or Stateless
 				else
 					processClass = ProcessClass((ProcessClass::ClassType)deterministicRandom()->randomInt(0, 3),
 					                            ProcessClass::CommandLineSource); // Unset, Storage, or Transaction
@@ -2515,13 +2527,8 @@ void setupSimulatedSystem(std::vector<Future<Void>>* systemActors,
 				}
 			}
 
-			if (processClass == ProcessClass::StatelessClass && !desiredStatelessClasses.present()) {
-				desiredStatelessClasses = std::max({ simconfig.db.getDesiredCommitProxies(),
-				                                     simconfig.db.getDesiredGrvProxies(),
-				                                     simconfig.db.getDesiredResolvers() });
-			}
-
-			if (desiredStatelessClasses.present() && actualStatelessClasses < desiredStatelessClasses.get()) {
+			if (machine < machines && desiredStatelessClasses.present() &&
+			    actualStatelessClasses < desiredStatelessClasses.get()) {
 				processClass = ProcessClass(ProcessClass::StatelessClass, ProcessClass::CommandLineSource);
 				actualStatelessClasses++;
 			}


### PR DESCRIPTION
## Summary

Ensure simulated clusters that randomly choose stateless process classes provision enough stateless capacity for the configured stateless-role fanout.

## Problem

A correctness ensemble found a failure in `tests/fast/SpecialKeySpaceRobustness.toml` with seed `1863002324` (with buggify enabled). The test timed out while applying the starting configuration.

## Root cause

The simulator can randomly introduce stateless-class machines while the generated database configuration still requires more stateless-role instances than that random topology can support. In the failing seed, the configuration required 3 commit proxies, but the generated stateless capacity was insufficient, so recovery could not recruit the requested number of commit proxies and the initial configuration never completed.

## Fix

When simulation randomly selects a stateless process class and the test has not explicitly requested a stateless machine count, ensure `desiredStatelessClasses` is at least the maximum configured fanout across:

- commit proxies
- GRV proxies
- resolvers

This keeps randomized simulated topologies internally consistent without overriding explicit `statelessProcessClassesPerDC` test settings.

## Validation

Reproduced the original failure with:

- `tests/fast/SpecialKeySpaceRobustness.toml`
- seed `1863002324`
- buggify enabled

Confirmed the diagnosis by showing that the same seed passes when either:

- `commitProxyCount = 2`, or
- `statelessProcessClassesPerDC = 3`

After the fix, rebuilt and reran the original failing seed unchanged.
