### PR TITLE
Fix GcGenerations simulation failure

### DIFF
--- a/fdbserver/workloads/GcGenerations.cpp
+++ b/fdbserver/workloads/GcGenerations.cpp
@@ -139,13 +139,16 @@ struct GcGenerationsWorkload : TestWorkload {
 		       masterProc->locality.dcId() == fdbSimulationPolicyState().remoteDcId;
 	}
 
-	// Wait for the DB to reach ACCEPTING_COMMITS. If the master is in the clogged
-	// remote DC, reboot it to force the CC to elect a primary DC master — otherwise
-	// recovery can never complete and we'd block forever.
-	Future<Void> dbAvailable(GcGenerationsWorkload* self) {
+	// Wait for the DB to reach ACCEPTING_COMMITS. If rebootRemoteDcMaster is true and
+	// the master is in the remote DC, reboot it to force the CC to elect a primary DC
+	// master. This is required when the remote DC is clogged (otherwise recovery can
+	// never complete), but must be disabled once the remote DC is unclogged — otherwise
+	// every CC re-election that lands in the remote DC triggers another reboot, producing
+	// a tight loop that prevents recovery from ever reaching ACCEPTING_COMMITS.
+	Future<Void> dbAvailable(GcGenerationsWorkload* self, bool rebootRemoteDcMaster) {
 		while (self->dbInfo->get().recoveryState < RecoveryState::ACCEPTING_COMMITS) {
 			co_await self->dbInfo->onChange();
-			if (self->dbInfo->get().recoveryState < RecoveryState::ACCEPTING_COMMITS &&
+			if (rebootRemoteDcMaster && self->dbInfo->get().recoveryState < RecoveryState::ACCEPTING_COMMITS &&
 			    self->isMasterInRemoteDc(self)) {
 				auto masterAddr = self->dbInfo->get().master.address();
 				auto* masterProc = g_simulator->getProcessByAddress(masterAddr);
@@ -172,7 +175,7 @@ struct GcGenerationsWorkload : TestWorkload {
 			TraceEvent("WaitingForDbAvailable")
 			    .detail("Iteration", successfulReboots)
 			    .detail("RecoveryState", self->dbInfo->get().recoveryState);
-			co_await self->dbAvailable(self);
+			co_await self->dbAvailable(self, /*rebootRemoteDcMaster=*/true);
 			generationCount = self->dbInfo->get().logSystemConfig.oldTLogs.size();
 
 			// Only reboot the master if it's in the primary DC. If it's in the clogged
@@ -240,13 +243,13 @@ struct GcGenerationsWorkload : TestWorkload {
 		// Note: the remote DC is unclogged now, so any master (including remote DC)
 		// can coordinate recovery. No need for the primary-DC-only guard here.
 		while (self->dbInfo->get().logSystemConfig.oldTLogs.size() > 1) {
-			co_await self->dbAvailable(self);
+			co_await self->dbAvailable(self, /*rebootRemoteDcMaster=*/false);
 			auto masterAddr = self->dbInfo->get().master.address();
 			TraceEvent("RebootMasterForGC").detail("Master", masterAddr);
 			g_simulator->rebootProcess(g_simulator->getProcessByAddress(masterAddr), ISimulator::KillType::Reboot);
 			// Give this recovery cycle time to GC before retrying.
 			co_await delay(60);
-			co_await self->dbAvailable(self);
+			co_await self->dbAvailable(self, /*rebootRemoteDcMaster=*/false);
 			TraceEvent("GcGenerationsWaitingForReduction")
 			    .detail("OldTLogs", self->dbInfo->get().logSystemConfig.oldTLogs.size())
 			    .detail("RecoveryState", self->dbInfo->get().recoveryState);


### PR DESCRIPTION
### Summary

  GcGenerations is a 2-region test that runs in two phases:

  1. Phase 1 — accumulate generations: partition the remote DC and repeatedly reboot the master to pile up old TLog generations.
  2. Phase 2 — observe GC: heal the partition and reboot the master a few more times, expecting oldTLogs to drain.

  Both phases use the same helper dbAvailable() to wait for the cluster to reach ACCEPTING_COMMITS. That helper contains a guard that reboots the master if it lands in the remote DC — a guard that is required in Phase 1 (remote DC is clogged, a remote-DC master cannot drive recovery) but incorrect in Phase 2 (remote DC is unclogged, a remote-DC master is valid).

 When CC happens to elect a remote-DC master during Phase 2, the helper reboots it → CC re-elects → possibly lands in remote DC again → reboot again. The loop never converges. In the failing run, this ran 691 times before the outer test timeout fired.

 The GC-loop comment in the code already acknowledged the guard should not apply in Phase 2:

  ▎ "Note: the remote DC is unclogged now, so any master (including remote DC) can coordinate recovery. No need for the primary-DC-only guard here."

  …but the guard lived inside dbAvailable() itself, so both callers inherited it regardless.

  Root cause

  fdbserver/workloads/GcGenerations.cpp::dbAvailable() unconditionally reboots remote-DC masters while waiting for recovery, with no way for the caller to opt out.

  Fix

  Parameterize dbAvailable() with a bool rebootRemoteDcMaster flag:

  - Phase 1 call site (generateMultipleTxnGenerations) → true (remote clogged, reboot needed)
  - Phase 2 call sites (GC loop in gcGenerationsTestClient, both of them) → false (remote healed, let any master drive recovery)
  
The bug only triggers when CC elects a remote-DC master during Phase 2, which rarely happens because:
  - FDB's CC fitness function strongly prefers primary-DC processes for master role.
  - The config (remote_double) gives the remote DC a thinner footprint with fewer master-eligible processes.
  - Attrition and RandomClogging are disabled for this workload, so chaos is limited.
  - generateFearless = true randomizes which DC is "primary" per seed; only some layouts produce a remote-DC process fit enough to win.
  
  ### TESTING:
  
  Running 100k on one test:

` 20260507-175147-akankshamahajan-2b95d2a916e21dd2   compressed=True data_size=37072360 duration=1068966 ended=6733 fail_fast=10 max_runs=100000 pass=6733 priority=100 remaining=7:48:12 runtime=0:33:48 sanity=False started=8389 submitted=20260507-175147 timeout=5400 username=akankshamahajan`