### PR TITLE
Fix use-after-free in UDPSimSocket::bind() due to missing addRef

### DIFF
--- a/fdbrpc/sim2.cpp
+++ b/fdbrpc/sim2.cpp
@@ -2441,7 +2441,7 @@ public:
 	    peerAddress(peerAddress), actors(false), _localAddress(localAddress) {
 		g_sim2.addressMap.emplace(_localAddress, process);
 		ASSERT(process->boundUDPSockets.find(localAddress) == process->boundUDPSockets.end());
-		process->boundUDPSockets.emplace(localAddress, this);
+		process->boundUDPSockets.emplace(localAddress, Reference<IUDPSocket>::addRef(this));
 	}
 	~UDPSimSocket() override {
 		if (!closed.getFuture().isReady()) {


### PR DESCRIPTION
The UDPSimSocket constructor stored a raw `this` pointer into process->boundUDPSockets via emplace(), which direct-initializes a Reference<IUDPSocket> from the raw pointer. The explicit Reference(P*) constructor does not call addref — it assumes ownership of the initial refcount. But that initial refcount already belongs to the Reference returned by createUDPSocket(). Result: two Reference objects sharing one refcount.

When bind() erased the old map entry, the refcount dropped to 0 and freed the object. The next line then called addRef(this) on freed memory — a heap-use-after-free.

This was a latent bug that only crashed when buggify altered memory allocation patterns enough for the freed memory to be reused between lines 2531 and 2532. Certain buggify seeds triggered it reliably, causing RandomUnitTests and other simulation tests to segfault.

Found by building with AddressSanitizer (-fsanitize=address), which immediately reported the exact free/use sequence in UDPSimSocket::bind().

(Found by claude debugging simulation failures)