### PR TITLE
[main] Release notes for 7.3.{76,77} 

### DIFF
--- a/documentation/sphinx/source/release-notes/release-notes-730.rst
+++ b/documentation/sphinx/source/release-notes/release-notes-730.rst
@@ -2,6 +2,16 @@
 Release Notes
 #############
 
+7.3.77
+======
+* Same as 7.3.76 release with AVX enabled.
+
+7.3.76
+======
+* Fixed peer disconnect detection in waitValueOrSignal so dead connections are detected immediately instead of hanging indefinitely. `(PR #12935) <https://github.com/apple/foundationdb/pull/12935>`_
+* Made getTeamByServers O(1) in time which was sometimes causing Data Distributor (DD) to get stuck during initialization when shard_encode_location_metadata was enabled. `(PR #12938) <https://github.com/apple/foundationdb/pull/12938>`_
+* Added miscellaneous observability improvements for CPU and memory usage, DD startup, and S3 backup subsystems. `(PR #12937) <https://github.com/apple/foundationdb/pull/12937>`_, `(PR #12913) <https://github.com/apple/foundationdb/pull/12913>`_, and `(PR #12997) <https://github.com/apple/foundationdb/pull/12997>`_
+
 7.3.75
 ======
 * Same as 7.3.74 release with AVX enabled.


### PR DESCRIPTION
Forward port 7.3.{76,77} release notes (https://github.com/apple/foundationdb/pull/13003) to main branch
