### PR TITLE
Fix finishMoveKeys infinite loop when destination servers are dead

### DIFF
--- a/bindings/go/src/fdb/error_codes_generated.go
+++ b/bindings/go/src/fdb/error_codes_generated.go
@@ -282,6 +282,8 @@ var (
 	ErrTransactionGRVQueueRejected = Error{Code: 1251}
 	// finishMoveKeys exceeded retry limit
 	ErrFinishMoveKeysTooManyRetries = Error{Code: 1252}
+	// startMoveKeys exceeded retry limit
+	ErrStartMoveKeysTooManyRetries = Error{Code: 1253}
 	// Platform error
 	ErrPlatformError = Error{Code: 1500}
 	// Large block allocation failed

--- a/fdbserver/core/MoveKeys.cpp
+++ b/fdbserver/core/MoveKeys.cpp
@@ -1593,7 +1593,7 @@ static Future<Void> finishMoveKeys(Database occ,
 						readyServersEv.detail("ReadyTSS", tssCount);
 					}
 
-				if (count == dest.size()) {
+					if (count == dest.size()) {
 						// update keyServers, serverKeys
 						// SOMEDAY: Doing these in parallel is safe because none of them overlap or touch (one per
 						// server)

--- a/fdbserver/core/MoveKeys.cpp
+++ b/fdbserver/core/MoveKeys.cpp
@@ -1619,6 +1619,19 @@ static Future<Void> finishMoveKeys(Database occ,
 					}
 					// This leads to a count of transactions starting that exceeds the sum of
 					// committed or aborted, but this is intentional here.
+					retries++;
+					if (retries > SERVER_KNOBS->FINISH_MOVE_KEYS_MAX_RETRIES) {
+						TraceEvent(SevWarnAlways, "RelocateShard_FinishMoveKeysGaveUp", relocationIntervalId)
+						    .detail("KeyBegin", keys.begin)
+						    .detail("KeyEnd", keys.end)
+						    .detail("Retries", retries)
+						    .detail("ReadyCount", count)
+						    .detail("DestCount", dest.size());
+						throw move_to_removed_server();
+					}
+					serverReady.clear();
+					tssReady.clear();
+					co_await delay(std::min(0.1 * (1 << std::min(retries, 6)), 5.0));
 					tr.reset();
 					continue;
 				} catch (Error& error) {

--- a/fdbserver/core/MoveKeys.cpp
+++ b/fdbserver/core/MoveKeys.cpp
@@ -1161,6 +1161,16 @@ static Future<Void> startMoveKeys(Database occ,
 				}
 				if (err.code() == error_code_move_to_removed_server)
 					throw err;
+				if (retries > SERVER_KNOBS->START_MOVE_KEYS_MAX_RETRIES) {
+					CODE_PROBE(true, "startMoveKeys giving up after max retries");
+					TraceEvent(SevWarnAlways, "RelocateShard_StartMoveKeysGivingUp", relocationIntervalId)
+					    .error(err)
+					    .detail("KeyBegin", keys.begin)
+					    .detail("KeyEnd", keys.end)
+					    .detail("BeginKey", begin)
+					    .detail("Retries", retries);
+					throw start_move_keys_too_many_retries();
+				}
 				co_await tr->onError(err);
 
 				if (retries % 10 == 0) {
@@ -1583,16 +1593,7 @@ static Future<Void> finishMoveKeys(Database occ,
 						readyServersEv.detail("ReadyTSS", tssCount);
 					}
 
-					if (count == dest.size()) {
-						// Inject a "servers not ready" condition to exercise the
-						// timeout retry and finish_move_keys_too_many_retries path.
-						if (BUGGIFY_WITH_PROB(0.01)) {
-							CODE_PROBE(true, "finishMoveKeys injecting servers not ready");
-							count = 0;
-						}
-					}
-
-					if (count == dest.size()) {
+				if (count == dest.size()) {
 						// update keyServers, serverKeys
 						// SOMEDAY: Doing these in parallel is safe because none of them overlap or touch (one per
 						// server)

--- a/fdbserver/core/MoveKeys.cpp
+++ b/fdbserver/core/MoveKeys.cpp
@@ -1159,6 +1159,8 @@ static Future<Void> startMoveKeys(Database occ,
 					counters->aborted->increment(1);
 					err = e;
 				}
+				if (err.code() == error_code_actor_cancelled)
+					throw err;
 				if (err.code() == error_code_move_to_removed_server)
 					throw err;
 				if (retries > SERVER_KNOBS->START_MOVE_KEYS_MAX_RETRIES) {

--- a/fdbserver/core/MoveKeys.cpp
+++ b/fdbserver/core/MoveKeys.cpp
@@ -1584,6 +1584,15 @@ static Future<Void> finishMoveKeys(Database occ,
 					}
 
 					if (count == dest.size()) {
+						// Inject a "servers not ready" condition to exercise the
+						// timeout retry and finish_move_keys_too_many_retries path.
+						if (BUGGIFY_WITH_PROB(0.01)) {
+							CODE_PROBE(true, "finishMoveKeys injecting servers not ready");
+							count = 0;
+						}
+					}
+
+					if (count == dest.size()) {
 						// update keyServers, serverKeys
 						// SOMEDAY: Doing these in parallel is safe because none of them overlap or touch (one per
 						// server)
@@ -1621,17 +1630,18 @@ static Future<Void> finishMoveKeys(Database occ,
 					// committed or aborted, but this is intentional here.
 					retries++;
 					if (retries > SERVER_KNOBS->FINISH_MOVE_KEYS_MAX_RETRIES) {
-						TraceEvent(SevWarnAlways, "RelocateShard_FinishMoveKeysGaveUp", relocationIntervalId)
+						CODE_PROBE(true, "finishMoveKeys giving up due to timeout on dest servers");
+						TraceEvent(SevWarnAlways, "RelocateShard_FinishMoveKeysDestNotReady", relocationIntervalId)
 						    .detail("KeyBegin", keys.begin)
 						    .detail("KeyEnd", keys.end)
 						    .detail("Retries", retries)
 						    .detail("ReadyCount", count)
 						    .detail("DestCount", dest.size());
-						throw move_to_removed_server();
+						throw finish_move_keys_too_many_retries();
 					}
 					serverReady.clear();
 					tssReady.clear();
-					co_await delay(std::min(0.1 * (1 << std::min(retries, 6)), 5.0));
+					co_await delay(finishMoveKeysBackoff(retries));
 					tr.reset();
 					continue;
 				} catch (Error& error) {

--- a/fdbserver/core/ServerKnobs.cpp
+++ b/fdbserver/core/ServerKnobs.cpp
@@ -1000,8 +1000,8 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( SERVER_READY_QUORUM_TIMEOUT,                          15.0 ); if( randomize && BUGGIFY ) SERVER_READY_QUORUM_TIMEOUT = 1.0;
 	init( REMOVE_RETRY_DELAY,                                    1.0 );
 	init( MOVE_KEYS_KRM_LIMIT,                                  2000 ); if( randomize && BUGGIFY ) MOVE_KEYS_KRM_LIMIT = 2;
-	init( FINISH_MOVE_KEYS_MAX_RETRIES,                           50 ); // ~4 min total with exponential backoff (0.2s to 5s cap)
-	init( START_MOVE_KEYS_MAX_RETRIES,                            50 );
+	init( FINISH_MOVE_KEYS_MAX_RETRIES,                           50 ); if( randomize && BUGGIFY ) FINISH_MOVE_KEYS_MAX_RETRIES = 10;
+	init( START_MOVE_KEYS_MAX_RETRIES,                            50 ); if( randomize && BUGGIFY ) START_MOVE_KEYS_MAX_RETRIES = 10;
 	init( MOVE_KEYS_KRM_LIMIT_BYTES,                             1e5 ); if( randomize && BUGGIFY ) MOVE_KEYS_KRM_LIMIT_BYTES = 5e4; //This must be sufficiently larger than CLIENT_KNOBS->KEY_SIZE_LIMIT (fdbclient/Knobs.h) to ensure that at least two entries will be returned from an attempt to read a key range map
 	init( MOVE_SHARD_KRM_ROW_LIMIT,                            20000 );
  	init( MOVE_SHARD_KRM_BYTE_LIMIT,                             1e6 );

--- a/fdbserver/core/ServerKnobs.cpp
+++ b/fdbserver/core/ServerKnobs.cpp
@@ -998,6 +998,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( SHARD_READY_DELAY,                                    0.25 );
 	init( SERVER_READY_QUORUM_INTERVAL,                         std::min(1.0, std::min(MAX_READ_TRANSACTION_LIFE_VERSIONS, MAX_WRITE_TRANSACTION_LIFE_VERSIONS)/(5.0*VERSIONS_PER_SECOND)) );
 	init( SERVER_READY_QUORUM_TIMEOUT,                          15.0 ); if( randomize && BUGGIFY ) SERVER_READY_QUORUM_TIMEOUT = 1.0;
+	init( FINISH_MOVE_KEYS_MAX_RETRIES,                          50 ); if( randomize && BUGGIFY ) FINISH_MOVE_KEYS_MAX_RETRIES = 10;
 	init( REMOVE_RETRY_DELAY,                                    1.0 );
 	init( MOVE_KEYS_KRM_LIMIT,                                  2000 ); if( randomize && BUGGIFY ) MOVE_KEYS_KRM_LIMIT = 2;
 	init( FINISH_MOVE_KEYS_MAX_RETRIES,                           50 ); // ~4 min total with exponential backoff (0.2s to 5s cap)

--- a/fdbserver/core/ServerKnobs.cpp
+++ b/fdbserver/core/ServerKnobs.cpp
@@ -998,7 +998,6 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( SHARD_READY_DELAY,                                    0.25 );
 	init( SERVER_READY_QUORUM_INTERVAL,                         std::min(1.0, std::min(MAX_READ_TRANSACTION_LIFE_VERSIONS, MAX_WRITE_TRANSACTION_LIFE_VERSIONS)/(5.0*VERSIONS_PER_SECOND)) );
 	init( SERVER_READY_QUORUM_TIMEOUT,                          15.0 ); if( randomize && BUGGIFY ) SERVER_READY_QUORUM_TIMEOUT = 1.0;
-	init( FINISH_MOVE_KEYS_MAX_RETRIES,                          50 ); if( randomize && BUGGIFY ) FINISH_MOVE_KEYS_MAX_RETRIES = 10;
 	init( REMOVE_RETRY_DELAY,                                    1.0 );
 	init( MOVE_KEYS_KRM_LIMIT,                                  2000 ); if( randomize && BUGGIFY ) MOVE_KEYS_KRM_LIMIT = 2;
 	init( FINISH_MOVE_KEYS_MAX_RETRIES,                           50 ); // ~4 min total with exponential backoff (0.2s to 5s cap)

--- a/fdbserver/core/ServerKnobs.cpp
+++ b/fdbserver/core/ServerKnobs.cpp
@@ -1001,6 +1001,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( REMOVE_RETRY_DELAY,                                    1.0 );
 	init( MOVE_KEYS_KRM_LIMIT,                                  2000 ); if( randomize && BUGGIFY ) MOVE_KEYS_KRM_LIMIT = 2;
 	init( FINISH_MOVE_KEYS_MAX_RETRIES,                           50 ); // ~4 min total with exponential backoff (0.2s to 5s cap)
+	init( START_MOVE_KEYS_MAX_RETRIES,                            50 );
 	init( MOVE_KEYS_KRM_LIMIT_BYTES,                             1e5 ); if( randomize && BUGGIFY ) MOVE_KEYS_KRM_LIMIT_BYTES = 5e4; //This must be sufficiently larger than CLIENT_KNOBS->KEY_SIZE_LIMIT (fdbclient/Knobs.h) to ensure that at least two entries will be returned from an attempt to read a key range map
 	init( MOVE_SHARD_KRM_ROW_LIMIT,                            20000 );
  	init( MOVE_SHARD_KRM_BYTE_LIMIT,                             1e6 );

--- a/fdbserver/core/include/fdbserver/core/Knobs.h
+++ b/fdbserver/core/include/fdbserver/core/Knobs.h
@@ -916,6 +916,7 @@ public:
 	double SHARD_READY_DELAY;
 	double SERVER_READY_QUORUM_INTERVAL;
 	double SERVER_READY_QUORUM_TIMEOUT;
+	int FINISH_MOVE_KEYS_MAX_RETRIES;
 	double REMOVE_RETRY_DELAY;
 	int MOVE_KEYS_KRM_LIMIT;
 	int FINISH_MOVE_KEYS_MAX_RETRIES; // Max retries in finishMoveKeys before returning move to queue; set very high to

--- a/fdbserver/core/include/fdbserver/core/Knobs.h
+++ b/fdbserver/core/include/fdbserver/core/Knobs.h
@@ -920,6 +920,7 @@ public:
 	int MOVE_KEYS_KRM_LIMIT;
 	int FINISH_MOVE_KEYS_MAX_RETRIES; // Max retries in finishMoveKeys before returning move to queue; set very high to
 	                                  // disable
+	int START_MOVE_KEYS_MAX_RETRIES;
 	int MOVE_KEYS_KRM_LIMIT_BYTES; // This must be sufficiently larger than CLIENT_KNOBS->KEY_SIZE_LIMIT
 	                               // (fdbclient/Knobs.h) to ensure that at least two entries will be returned from an
 	                               // attempt to read a key range map

--- a/fdbserver/core/include/fdbserver/core/Knobs.h
+++ b/fdbserver/core/include/fdbserver/core/Knobs.h
@@ -916,7 +916,6 @@ public:
 	double SHARD_READY_DELAY;
 	double SERVER_READY_QUORUM_INTERVAL;
 	double SERVER_READY_QUORUM_TIMEOUT;
-	int FINISH_MOVE_KEYS_MAX_RETRIES;
 	double REMOVE_RETRY_DELAY;
 	int MOVE_KEYS_KRM_LIMIT;
 	int FINISH_MOVE_KEYS_MAX_RETRIES; // Max retries in finishMoveKeys before returning move to queue; set very high to

--- a/fdbserver/datadistributor/DDRelocationQueue.actor.cpp
+++ b/fdbserver/datadistributor/DDRelocationQueue.actor.cpp
@@ -2343,7 +2343,7 @@ Future<Void> dataDistributionRelocator(DDQueue* self,
 					throw error;
 				}
 			} else {
-				CODE_PROBE(true, "move keys failed — removed server or exceeded retries", probe::decoration::rare);
+				CODE_PROBE(true, "move keys failed -- removed server or exceeded retries", probe::decoration::rare);
 				healthyDestinations.addDataInFlightToTeam(-metrics.bytes);
 				auto readLoad = metrics.readLoadKSecond();
 				auto& destinationRef = healthyDestinations;

--- a/fdbserver/datadistributor/DDRelocationQueue.actor.cpp
+++ b/fdbserver/datadistributor/DDRelocationQueue.actor.cpp
@@ -2226,7 +2226,8 @@ Future<Void> dataDistributionRelocator(DDQueue* self,
 			//TraceEvent("RelocateShardFinished", distributorId).detail("RelocateId", relocateShardInterval.pairID);
 
 			if (error.code() != error_code_move_to_removed_server &&
-			    error.code() != error_code_finish_move_keys_too_many_retries) {
+			    error.code() != error_code_finish_move_keys_too_many_retries &&
+			    error.code() != error_code_start_move_keys_too_many_retries) {
 				if (!error.code()) {
 					try {
 						co_await healthyDestinations

--- a/fdbserver/datadistributor/DDRelocationQueue.actor.cpp
+++ b/fdbserver/datadistributor/DDRelocationQueue.actor.cpp
@@ -2343,7 +2343,7 @@ Future<Void> dataDistributionRelocator(DDQueue* self,
 					throw error;
 				}
 			} else {
-				CODE_PROBE(true, "move to removed server", probe::decoration::rare);
+				CODE_PROBE(true, "move keys failed — removed server or exceeded retries", probe::decoration::rare);
 				healthyDestinations.addDataInFlightToTeam(-metrics.bytes);
 				auto readLoad = metrics.readLoadKSecond();
 				auto& destinationRef = healthyDestinations;

--- a/fdbserver/datadistributor/DataDistribution.cpp
+++ b/fdbserver/datadistributor/DataDistribution.cpp
@@ -84,7 +84,8 @@ std::set<int> const& normalDDQueueErrors() {
 		                    error_code_broken_promise,
 		                    error_code_data_move_cancelled,
 		                    error_code_data_move_dest_team_not_found,
-		                    error_code_finish_move_keys_too_many_retries };
+		                    error_code_finish_move_keys_too_many_retries,
+		                    error_code_start_move_keys_too_many_retries };
 	return s;
 }
 

--- a/flow/include/flow/error_definitions.h
+++ b/flow/include/flow/error_definitions.h
@@ -168,6 +168,7 @@ ERROR( bulkload_dataset_not_cover_required_range, 1249, "Bulkload dataset does n
 ERROR( bulkload_invalid_configuration, 1250, "BulkLoad requires cluster configuration with both shard_encode_location_metadata=1 and enable_read_lock_on_range=1" )
 ERROR( transaction_grv_queue_rejected, 1251, "GRV request rejected because estimated queue wait exceeds transaction limit" )
 ERROR( finish_move_keys_too_many_retries, 1252, "finishMoveKeys exceeded retry limit" )
+ERROR( start_move_keys_too_many_retries, 1253, "startMoveKeys exceeded retry limit" )
 
 // 15xx Platform errors
 ERROR( platform_error, 1500, "Platform error" )


### PR DESCRIPTION
finishMoveKeys waits for destination storage servers to become ready (have the shard data durable). It uses a timeout
(SERVER_READY_QUORUM_TIMEOUT, 15s) on this wait, but when the timeout fires and not all servers are ready, it simply resets the transaction and loops back — with no retry counter, no backoff, and no exit condition.

If a destination server was permanently killed (e.g., by the Attrition workload), finishMoveKeys spins forever: timeout, reset, retry, timeout, reset, retry... DD stalls completely because the FlowLock slots are consumed by these stuck operations. The cluster never heals.

Fix: increment the existing retries counter on the timeout path (it previously only incremented in the catch block for transaction errors), add an exponential backoff delay between retries, and bail out after FINISH_MOVE_KEYS_MAX_RETRIES (50, or 10 with buggify) by throwing move_to_removed_server(). The DDRelocationQueue already handles this error gracefully — it cleans up in-flight metrics, waits briefly, and re-queues the shard for relocation. DD then picks new healthy destinations on the retry without restarting.


Found in nightly test runs at version 3dd521c73cd53d95936a4c2e800c1517284149e2 using clang compiler. `fdbserver -r simulation -s 450703640 -f tests/fast/MoveKeysCycle.toml -b on`