### PR TITLE
Warm up MaxGrvQueueDelay before measuring queue rejection

### DIFF
--- a/fdbserver/workloads/MaxGrvQueueDelay.cpp
+++ b/fdbserver/workloads/MaxGrvQueueDelay.cpp
@@ -36,6 +36,8 @@ struct MaxGrvQueueDelayWorkload : TestWorkload {
 	int minRejected;
 	int64_t maxQueueDelayMS;
 	int64_t permissiveMaxQueueDelayMS;
+	int warmupRequestCount;
+	double warmupDelay;
 	double startAfter;
 	double testTimeout;
 
@@ -53,6 +55,8 @@ struct MaxGrvQueueDelayWorkload : TestWorkload {
 		minRejected = getOption(options, "minRejected"_sr, 1);
 		maxQueueDelayMS = getOption(options, "maxQueueDelayMS"_sr, int64_t{ 0 });
 		permissiveMaxQueueDelayMS = getOption(options, "permissiveMaxQueueDelayMS"_sr, int64_t{ 60000 });
+		warmupRequestCount = getOption(options, "warmupRequestCount"_sr, 0);
+		warmupDelay = getOption(options, "warmupDelay"_sr, 0.0);
 		startAfter = getOption(options, "startAfter"_sr, 5.0);
 		testTimeout = getOption(options, "testTimeout"_sr, 30.0);
 	}
@@ -67,6 +71,8 @@ struct MaxGrvQueueDelayWorkload : TestWorkload {
 		    .detail("MinRejected", minRejected)
 		    .detail("MaxQueueDelayMS", maxQueueDelayMS)
 		    .detail("PermissiveMaxQueueDelayMS", permissiveMaxQueueDelayMS)
+		    .detail("WarmupRequestCount", warmupRequestCount)
+		    .detail("WarmupDelay", warmupDelay)
 		    .detail("StartAfter", startAfter)
 		    .detail("TestTimeout", testTimeout);
 		return Void();
@@ -145,6 +151,15 @@ struct MaxGrvQueueDelayWorkload : TestWorkload {
 		if (failed) {
 			done = true;
 			co_return;
+		}
+
+		std::vector<Future<ErrorOr<Version>>> warmupFutures;
+		warmupFutures.reserve(warmupRequestCount);
+		for (int i = 0; i < warmupRequestCount; ++i) {
+			warmupFutures.push_back(errorOr(getReadVersion(cx, Optional<int64_t>())));
+		}
+		if (warmupDelay > 0.0) {
+			co_await delay(warmupDelay);
 		}
 
 		std::vector<Future<ErrorOr<Version>>> futures;

--- a/tests/fast/MaxGrvQueueDelay.toml
+++ b/tests/fast/MaxGrvQueueDelay.toml
@@ -1,6 +1,6 @@
 [[knobs]]
-# Keep GRV ratekeeper capacity low enough that thresholded requests observe
-# proxy-side queue-delay rejection without throttling cluster setup.
+# Keep GRV ratekeeper capacity low enough that the warmup burst creates
+# queueing without throttling cluster setup.
 ratekeeper_default_limit = 100
 ratekeeper_max_rate = 100
 
@@ -9,11 +9,11 @@ testTitle = 'MaxGrvQueueDelay'
 
     [[test.workload]]
     testName = 'MaxGrvQueueDelay'
-    # Run before idle GRV admission credit accumulates, otherwise the burst can
-    # be admitted without queueing on some randomized simulator seeds.
     startAfter = 0.0
     testTimeout = 30.0
     requestCount = 250
     minRejected = 1
     maxQueueDelayMS = 0
     permissiveMaxQueueDelayMS = 60000
+    warmupRequestCount = 10000
+    warmupDelay = 0.1


### PR DESCRIPTION
This PR fixes a flaky `MaxGrvQueueDelay` test, using warmup requests in the workload to create more predictable behavior. Validated with 10k targeted tests.
