### PR TITLE
Prefer `makeReference` for polymorphic references

### DIFF
--- a/bindings/flow/DirectoryLayer.cpp
+++ b/bindings/flow/DirectoryLayer.cpp
@@ -95,8 +95,7 @@ Reference<DirectorySubspace> DirectoryLayer::contentsOfNode(Subspace const& node
 	Standalone<StringRef> prefix = nodeSubspace.unpack(node.key()).getString(0);
 
 	if (layer == PARTITION_LAYER) {
-		return Reference<DirectorySubspace>(
-		    new DirectoryPartition(toAbsolutePath(path), prefix, Reference<DirectoryLayer>::addRef(this)));
+		return makeReference<DirectoryPartition>(toAbsolutePath(path), prefix, Reference<DirectoryLayer>::addRef(this));
 	} else {
 		return makeReference<DirectorySubspace>(
 		    toAbsolutePath(path), prefix, Reference<DirectoryLayer>::addRef(this), layer);

--- a/bindings/flow/fdb_flow.cpp
+++ b/bindings/flow/fdb_flow.cpp
@@ -277,7 +277,7 @@ bool API::evaluatePredicate(FDBErrorPredicate pred, Error const& e) {
 Reference<Database> API::createDatabase(std::string const& connFilename) {
 	FDBDatabase* db;
 	throw_on_error(fdb_create_database(connFilename.c_str(), &db));
-	return makeReference<DatabaseImpl>(db);
+	return Reference<Database>(new DatabaseImpl(db));
 }
 
 int API::getAPIVersion() const {
@@ -285,7 +285,7 @@ int API::getAPIVersion() const {
 }
 
 Reference<Transaction> DatabaseImpl::createTransaction() {
-	return makeReference<TransactionImpl>(db);
+	return Reference<Transaction>(new TransactionImpl(db));
 }
 
 void DatabaseImpl::setDatabaseOption(FDBDatabaseOption option, Optional<StringRef> value) {

--- a/bindings/flow/fdb_flow.cpp
+++ b/bindings/flow/fdb_flow.cpp
@@ -277,7 +277,7 @@ bool API::evaluatePredicate(FDBErrorPredicate pred, Error const& e) {
 Reference<Database> API::createDatabase(std::string const& connFilename) {
 	FDBDatabase* db;
 	throw_on_error(fdb_create_database(connFilename.c_str(), &db));
-	return Reference<Database>(new DatabaseImpl(db));
+	return makeReference<DatabaseImpl>(db);
 }
 
 int API::getAPIVersion() const {
@@ -285,7 +285,7 @@ int API::getAPIVersion() const {
 }
 
 Reference<Transaction> DatabaseImpl::createTransaction() {
-	return Reference<Transaction>(new TransactionImpl(db));
+	return makeReference<TransactionImpl>(db);
 }
 
 void DatabaseImpl::setDatabaseOption(FDBDatabaseOption option, Optional<StringRef> value) {

--- a/bindings/flow/tester/DirectoryTester.cpp
+++ b/bindings/flow/tester/DirectoryTester.cpp
@@ -139,7 +139,7 @@ struct DirectoryCreateLayerFunc : InstructionFunc {
 			             nodeSubspace->key().printable().c_str(),
 			             allowManualPrefixes));
 			data->directoryData.push(
-			    Reference<IDirectory>(new DirectoryLayer(*nodeSubspace, *contentSubspace, allowManualPrefixes)));
+			    makeReference<DirectoryLayer>(*nodeSubspace, *contentSubspace, allowManualPrefixes));
 		}
 	}
 };

--- a/bindings/flow/tester/DirectoryTester.cpp
+++ b/bindings/flow/tester/DirectoryTester.cpp
@@ -138,8 +138,8 @@ struct DirectoryCreateLayerFunc : InstructionFunc {
 			             index2,
 			             nodeSubspace->key().printable().c_str(),
 			             allowManualPrefixes));
-			data->directoryData.push(
-			    makeReference<DirectoryLayer>(*nodeSubspace, *contentSubspace, allowManualPrefixes));
+			data->directoryData.push(Reference<IDirectory>(
+			    makeReference<DirectoryLayer>(*nodeSubspace, *contentSubspace, allowManualPrefixes)));
 		}
 	}
 };

--- a/bindings/flow/tester/Tester.h
+++ b/bindings/flow/tester/Tester.h
@@ -165,7 +165,8 @@ struct DirectoryTesterData {
 	}
 
 	DirectoryTesterData() : directoryListIndex(0), directoryErrorIndex(0) {
-		directoryList.push_back(DirectoryOrSubspace(makeReference<FDB::DirectoryLayer>()));
+		directoryList.push_back(
+		    DirectoryOrSubspace(Reference<FDB::IDirectory>(makeReference<FDB::DirectoryLayer>())));
 	}
 
 	template <class T>

--- a/bindings/flow/tester/Tester.h
+++ b/bindings/flow/tester/Tester.h
@@ -165,7 +165,7 @@ struct DirectoryTesterData {
 	}
 
 	DirectoryTesterData() : directoryListIndex(0), directoryErrorIndex(0) {
-		directoryList.push_back(DirectoryOrSubspace(Reference<FDB::IDirectory>(new FDB::DirectoryLayer())));
+		directoryList.push_back(DirectoryOrSubspace(makeReference<FDB::DirectoryLayer>()));
 	}
 
 	template <class T>

--- a/bindings/flow/tester/Tester.h
+++ b/bindings/flow/tester/Tester.h
@@ -165,8 +165,7 @@ struct DirectoryTesterData {
 	}
 
 	DirectoryTesterData() : directoryListIndex(0), directoryErrorIndex(0) {
-		directoryList.push_back(
-		    DirectoryOrSubspace(Reference<FDB::IDirectory>(makeReference<FDB::DirectoryLayer>())));
+		directoryList.push_back(DirectoryOrSubspace(Reference<FDB::IDirectory>(makeReference<FDB::DirectoryLayer>())));
 	}
 
 	template <class T>

--- a/fdbclient/BackupContainerLocalDirectory.cpp
+++ b/fdbclient/BackupContainerLocalDirectory.cpp
@@ -280,7 +280,7 @@ Future<Reference<IAsyncFile>> BackupContainerLocalDirectory::readFile(const std:
 		}
 		ASSERT(blockSize > 0);
 
-		return map(f, [=](Reference<IAsyncFile> fr) {
+		return map(f, [=](Reference<IAsyncFile> fr) -> Reference<IAsyncFile> {
 			int readAhead = deterministicRandom()->randomInt(0, 3);
 			int reads = deterministicRandom()->randomInt(1, 3);
 			int cacheSize = deterministicRandom()->randomInt(0, 3);
@@ -307,8 +307,9 @@ Future<Reference<IBackupFile>> BackupContainerLocalDirectory::writeFile(const st
 			    makeReference<AsyncFileEncrypted>(r, AsyncFileEncrypted::Mode::APPEND_ONLY, encBlockSize));
 		});
 	}
-	return map(
-	    f, [=](Reference<IAsyncFile> file) { return makeReference<BackupFile>(path, file, fullPath); });
+	return map(f, [=](Reference<IAsyncFile> file) -> Reference<IBackupFile> {
+		return makeReference<BackupFile>(path, file, fullPath);
+	});
 }
 
 Future<Void> BackupContainerLocalDirectory::writeEntireFile(const std::string& path, const std::string& contents) {

--- a/fdbclient/BackupContainerLocalDirectory.cpp
+++ b/fdbclient/BackupContainerLocalDirectory.cpp
@@ -284,7 +284,7 @@ Future<Reference<IAsyncFile>> BackupContainerLocalDirectory::readFile(const std:
 			int readAhead = deterministicRandom()->randomInt(0, 3);
 			int reads = deterministicRandom()->randomInt(1, 3);
 			int cacheSize = deterministicRandom()->randomInt(0, 3);
-			return Reference<IAsyncFile>(new AsyncFileReadAheadCache(fr, blockSize, readAhead, reads, cacheSize));
+			return makeReference<AsyncFileReadAheadCache>(fr, blockSize, readAhead, reads, cacheSize);
 		});
 	}
 
@@ -308,7 +308,7 @@ Future<Reference<IBackupFile>> BackupContainerLocalDirectory::writeFile(const st
 		});
 	}
 	return map(
-	    f, [=](Reference<IAsyncFile> file) { return Reference<IBackupFile>(new BackupFile(path, file, fullPath)); });
+	    f, [=](Reference<IAsyncFile> file) { return makeReference<BackupFile>(path, file, fullPath); });
 }
 
 Future<Void> BackupContainerLocalDirectory::writeEntireFile(const std::string& path, const std::string& contents) {

--- a/fdbclient/DatabaseConfiguration.cpp
+++ b/fdbclient/DatabaseConfiguration.cpp
@@ -137,24 +137,24 @@ void parse(std::vector<RegionInfo>* regions, ValueRef const& v) {
 					info.satelliteTLogReplicationFactor = 4;
 					info.satelliteTLogUsableDcs = 2;
 					info.satelliteTLogWriteAntiQuorum = 0;
-					info.satelliteTLogPolicy = makeReference<PolicyAcross>(2,
-					                     "dcid",
-					                     makeReference<PolicyAcross>(2, "zoneid", makeReference<PolicyOne>()));
+					info.satelliteTLogPolicy = makeReference<PolicyAcross>(
+					    2, "dcid", makeReference<PolicyAcross>(2, "zoneid", makeReference<PolicyOne>()));
 					info.satelliteTLogReplicationFactorFallback = 2;
 					info.satelliteTLogUsableDcsFallback = 1;
 					info.satelliteTLogWriteAntiQuorumFallback = 0;
-					info.satelliteTLogPolicyFallback = makeReference<PolicyAcross>(2, "zoneid", makeReference<PolicyOne>());
+					info.satelliteTLogPolicyFallback =
+					    makeReference<PolicyAcross>(2, "zoneid", makeReference<PolicyOne>());
 				} else if (satelliteReplication == "two_satellite_fast") {
 					info.satelliteTLogReplicationFactor = 4;
 					info.satelliteTLogUsableDcs = 2;
 					info.satelliteTLogWriteAntiQuorum = 2;
-					info.satelliteTLogPolicy = makeReference<PolicyAcross>(2,
-					                     "dcid",
-					                     makeReference<PolicyAcross>(2, "zoneid", makeReference<PolicyOne>()));
+					info.satelliteTLogPolicy = makeReference<PolicyAcross>(
+					    2, "dcid", makeReference<PolicyAcross>(2, "zoneid", makeReference<PolicyOne>()));
 					info.satelliteTLogReplicationFactorFallback = 2;
 					info.satelliteTLogUsableDcsFallback = 1;
 					info.satelliteTLogWriteAntiQuorumFallback = 0;
-					info.satelliteTLogPolicyFallback = makeReference<PolicyAcross>(2, "zoneid", makeReference<PolicyOne>());
+					info.satelliteTLogPolicyFallback =
+					    makeReference<PolicyAcross>(2, "zoneid", makeReference<PolicyOne>());
 				} else {
 					throw invalid_option();
 				}
@@ -182,14 +182,17 @@ void DatabaseConfiguration::setDefaultReplicationPolicy() {
 		tLogPolicy = makeReference<PolicyAcross>(tLogReplicationFactor, "zoneid", makeReference<PolicyOne>());
 	}
 	if (remoteTLogReplicationFactor > 0 && !remoteTLogPolicy) {
-		remoteTLogPolicy = makeReference<PolicyAcross>(remoteTLogReplicationFactor, "zoneid", makeReference<PolicyOne>());
+		remoteTLogPolicy =
+		    makeReference<PolicyAcross>(remoteTLogReplicationFactor, "zoneid", makeReference<PolicyOne>());
 	}
 	for (auto& r : regions) {
 		if (r.satelliteTLogReplicationFactor > 0 && !r.satelliteTLogPolicy) {
-			r.satelliteTLogPolicy = makeReference<PolicyAcross>(r.satelliteTLogReplicationFactor, "zoneid", makeReference<PolicyOne>());
+			r.satelliteTLogPolicy =
+			    makeReference<PolicyAcross>(r.satelliteTLogReplicationFactor, "zoneid", makeReference<PolicyOne>());
 		}
 		if (r.satelliteTLogReplicationFactorFallback > 0 && !r.satelliteTLogPolicyFallback) {
-			r.satelliteTLogPolicyFallback = makeReference<PolicyAcross>(r.satelliteTLogReplicationFactorFallback, "zoneid", makeReference<PolicyOne>());
+			r.satelliteTLogPolicyFallback = makeReference<PolicyAcross>(
+			    r.satelliteTLogReplicationFactorFallback, "zoneid", makeReference<PolicyOne>());
 		}
 	}
 }

--- a/fdbclient/DatabaseConfiguration.cpp
+++ b/fdbclient/DatabaseConfiguration.cpp
@@ -122,47 +122,39 @@ void parse(std::vector<RegionInfo>* regions, ValueRef const& v) {
 					info.satelliteTLogReplicationFactor = 1;
 					info.satelliteTLogUsableDcs = 1;
 					info.satelliteTLogWriteAntiQuorum = 0;
-					info.satelliteTLogPolicy = Reference<IReplicationPolicy>(new PolicyOne());
+					info.satelliteTLogPolicy = makeReference<PolicyOne>();
 				} else if (satelliteReplication == "one_satellite_double") {
 					info.satelliteTLogReplicationFactor = 2;
 					info.satelliteTLogUsableDcs = 1;
 					info.satelliteTLogWriteAntiQuorum = 0;
-					info.satelliteTLogPolicy = Reference<IReplicationPolicy>(
-					    new PolicyAcross(2, "zoneid", Reference<IReplicationPolicy>(new PolicyOne())));
+					info.satelliteTLogPolicy = makeReference<PolicyAcross>(2, "zoneid", makeReference<PolicyOne>());
 				} else if (satelliteReplication == "one_satellite_triple") {
 					info.satelliteTLogReplicationFactor = 3;
 					info.satelliteTLogUsableDcs = 1;
 					info.satelliteTLogWriteAntiQuorum = 0;
-					info.satelliteTLogPolicy = Reference<IReplicationPolicy>(
-					    new PolicyAcross(3, "zoneid", Reference<IReplicationPolicy>(new PolicyOne())));
+					info.satelliteTLogPolicy = makeReference<PolicyAcross>(3, "zoneid", makeReference<PolicyOne>());
 				} else if (satelliteReplication == "two_satellite_safe") {
 					info.satelliteTLogReplicationFactor = 4;
 					info.satelliteTLogUsableDcs = 2;
 					info.satelliteTLogWriteAntiQuorum = 0;
-					info.satelliteTLogPolicy = Reference<IReplicationPolicy>(
-					    new PolicyAcross(2,
+					info.satelliteTLogPolicy = makeReference<PolicyAcross>(2,
 					                     "dcid",
-					                     Reference<IReplicationPolicy>(new PolicyAcross(
-					                         2, "zoneid", Reference<IReplicationPolicy>(new PolicyOne())))));
+					                     makeReference<PolicyAcross>(2, "zoneid", makeReference<PolicyOne>()));
 					info.satelliteTLogReplicationFactorFallback = 2;
 					info.satelliteTLogUsableDcsFallback = 1;
 					info.satelliteTLogWriteAntiQuorumFallback = 0;
-					info.satelliteTLogPolicyFallback = Reference<IReplicationPolicy>(
-					    new PolicyAcross(2, "zoneid", Reference<IReplicationPolicy>(new PolicyOne())));
+					info.satelliteTLogPolicyFallback = makeReference<PolicyAcross>(2, "zoneid", makeReference<PolicyOne>());
 				} else if (satelliteReplication == "two_satellite_fast") {
 					info.satelliteTLogReplicationFactor = 4;
 					info.satelliteTLogUsableDcs = 2;
 					info.satelliteTLogWriteAntiQuorum = 2;
-					info.satelliteTLogPolicy = Reference<IReplicationPolicy>(
-					    new PolicyAcross(2,
+					info.satelliteTLogPolicy = makeReference<PolicyAcross>(2,
 					                     "dcid",
-					                     Reference<IReplicationPolicy>(new PolicyAcross(
-					                         2, "zoneid", Reference<IReplicationPolicy>(new PolicyOne())))));
+					                     makeReference<PolicyAcross>(2, "zoneid", makeReference<PolicyOne>()));
 					info.satelliteTLogReplicationFactorFallback = 2;
 					info.satelliteTLogUsableDcsFallback = 1;
 					info.satelliteTLogWriteAntiQuorumFallback = 0;
-					info.satelliteTLogPolicyFallback = Reference<IReplicationPolicy>(
-					    new PolicyAcross(2, "zoneid", Reference<IReplicationPolicy>(new PolicyOne())));
+					info.satelliteTLogPolicyFallback = makeReference<PolicyAcross>(2, "zoneid", makeReference<PolicyOne>());
 				} else {
 					throw invalid_option();
 				}
@@ -184,25 +176,20 @@ void parse(std::vector<RegionInfo>* regions, ValueRef const& v) {
 
 void DatabaseConfiguration::setDefaultReplicationPolicy() {
 	if (!storagePolicy) {
-		storagePolicy = Reference<IReplicationPolicy>(
-		    new PolicyAcross(storageTeamSize, "zoneid", Reference<IReplicationPolicy>(new PolicyOne())));
+		storagePolicy = makeReference<PolicyAcross>(storageTeamSize, "zoneid", makeReference<PolicyOne>());
 	}
 	if (!tLogPolicy) {
-		tLogPolicy = Reference<IReplicationPolicy>(
-		    new PolicyAcross(tLogReplicationFactor, "zoneid", Reference<IReplicationPolicy>(new PolicyOne())));
+		tLogPolicy = makeReference<PolicyAcross>(tLogReplicationFactor, "zoneid", makeReference<PolicyOne>());
 	}
 	if (remoteTLogReplicationFactor > 0 && !remoteTLogPolicy) {
-		remoteTLogPolicy = Reference<IReplicationPolicy>(
-		    new PolicyAcross(remoteTLogReplicationFactor, "zoneid", Reference<IReplicationPolicy>(new PolicyOne())));
+		remoteTLogPolicy = makeReference<PolicyAcross>(remoteTLogReplicationFactor, "zoneid", makeReference<PolicyOne>());
 	}
 	for (auto& r : regions) {
 		if (r.satelliteTLogReplicationFactor > 0 && !r.satelliteTLogPolicy) {
-			r.satelliteTLogPolicy = Reference<IReplicationPolicy>(new PolicyAcross(
-			    r.satelliteTLogReplicationFactor, "zoneid", Reference<IReplicationPolicy>(new PolicyOne())));
+			r.satelliteTLogPolicy = makeReference<PolicyAcross>(r.satelliteTLogReplicationFactor, "zoneid", makeReference<PolicyOne>());
 		}
 		if (r.satelliteTLogReplicationFactorFallback > 0 && !r.satelliteTLogPolicyFallback) {
-			r.satelliteTLogPolicyFallback = Reference<IReplicationPolicy>(new PolicyAcross(
-			    r.satelliteTLogReplicationFactorFallback, "zoneid", Reference<IReplicationPolicy>(new PolicyOne())));
+			r.satelliteTLogPolicyFallback = makeReference<PolicyAcross>(r.satelliteTLogReplicationFactorFallback, "zoneid", makeReference<PolicyOne>());
 		}
 	}
 }

--- a/fdbclient/ManagementAPI.cpp
+++ b/fdbclient/ManagementAPI.cpp
@@ -283,32 +283,27 @@ std::map<std::string, std::string> configForToken(std::string const& mode) {
 	} else if (mode == "three_datacenter" || mode == "multi_dc") {
 		redundancy = "6";
 		log_replicas = "4";
-		storagePolicy = makeReference<PolicyAcross>(3,
-		                     "dcid",
-		                     makeReference<PolicyAcross>(2, "zoneid", makeReference<PolicyOne>()));
-		tLogPolicy = makeReference<PolicyAcross>(2,
-		                     "dcid",
-		                     makeReference<PolicyAcross>(2, "zoneid", makeReference<PolicyOne>()));
+		storagePolicy = makeReference<PolicyAcross>(
+		    3, "dcid", makeReference<PolicyAcross>(2, "zoneid", makeReference<PolicyOne>()));
+		tLogPolicy = makeReference<PolicyAcross>(
+		    2, "dcid", makeReference<PolicyAcross>(2, "zoneid", makeReference<PolicyOne>()));
 	} else if (mode == "three_datacenter_fallback") {
 		redundancy = "4";
 		log_replicas = "4";
-		storagePolicy = tLogPolicy = makeReference<PolicyAcross>(2,
-		                     "dcid",
-		                     makeReference<PolicyAcross>(2, "zoneid", makeReference<PolicyOne>()));
+		storagePolicy = tLogPolicy = makeReference<PolicyAcross>(
+		    2, "dcid", makeReference<PolicyAcross>(2, "zoneid", makeReference<PolicyOne>()));
 	} else if (mode == "three_data_hall") {
 		redundancy = "3";
 		log_replicas = "4";
 		storagePolicy = makeReference<PolicyAcross>(3, "data_hall", makeReference<PolicyOne>());
-		tLogPolicy = makeReference<PolicyAcross>(2,
-		                     "data_hall",
-		                     makeReference<PolicyAcross>(2, "zoneid", makeReference<PolicyOne>()));
+		tLogPolicy = makeReference<PolicyAcross>(
+		    2, "data_hall", makeReference<PolicyAcross>(2, "zoneid", makeReference<PolicyOne>()));
 	} else if (mode == "three_data_hall_fallback") {
 		redundancy = "2";
 		log_replicas = "4";
 		storagePolicy = makeReference<PolicyAcross>(2, "data_hall", makeReference<PolicyOne>());
-		tLogPolicy = makeReference<PolicyAcross>(2,
-		                     "data_hall",
-		                     makeReference<PolicyAcross>(2, "zoneid", makeReference<PolicyOne>()));
+		tLogPolicy = makeReference<PolicyAcross>(
+		    2, "data_hall", makeReference<PolicyAcross>(2, "zoneid", makeReference<PolicyOne>()));
 	} else
 		redundancySpecified = false;
 	if (redundancySpecified) {
@@ -348,9 +343,8 @@ std::map<std::string, std::string> configForToken(std::string const& mode) {
 	} else if (mode == "remote_three_data_hall") { // FIXME: not tested in simulation
 		remote_redundancy = "3";
 		remote_log_replicas = "4";
-		remoteTLogPolicy = makeReference<PolicyAcross>(2,
-		                     "data_hall",
-		                     makeReference<PolicyAcross>(2, "zoneid", makeReference<PolicyOne>()));
+		remoteTLogPolicy = makeReference<PolicyAcross>(
+		    2, "data_hall", makeReference<PolicyAcross>(2, "zoneid", makeReference<PolicyOne>()));
 	} else
 		remoteRedundancySpecified = false;
 	if (remoteRedundancySpecified) {
@@ -389,7 +383,8 @@ ConfigurationResult buildConfiguration(std::vector<StringRef> const& modeTokens,
 	auto p = configKeysPrefix.toString();
 	if (!outConf.contains(p + "storage_replication_policy") && outConf.contains(p + "storage_replicas")) {
 		int storageCount = stoi(outConf[p + "storage_replicas"]);
-		Reference<IReplicationPolicy> storagePolicy = makeReference<PolicyAcross>(storageCount, "zoneid", makeReference<PolicyOne>());
+		Reference<IReplicationPolicy> storagePolicy =
+		    makeReference<PolicyAcross>(storageCount, "zoneid", makeReference<PolicyOne>());
 		BinaryWriter policyWriter(IncludeVersion(ProtocolVersion::withReplicationPolicy()));
 		serializeReplicationPolicy(policyWriter, storagePolicy);
 		outConf[p + "storage_replication_policy"] = policyWriter.toValue().toString();
@@ -397,7 +392,8 @@ ConfigurationResult buildConfiguration(std::vector<StringRef> const& modeTokens,
 
 	if (!outConf.contains(p + "log_replication_policy") && outConf.contains(p + "log_replicas")) {
 		int logCount = stoi(outConf[p + "log_replicas"]);
-		Reference<IReplicationPolicy> logPolicy = makeReference<PolicyAcross>(logCount, "zoneid", makeReference<PolicyOne>());
+		Reference<IReplicationPolicy> logPolicy =
+		    makeReference<PolicyAcross>(logCount, "zoneid", makeReference<PolicyOne>());
 		BinaryWriter policyWriter(IncludeVersion(ProtocolVersion::withReplicationPolicy()));
 		serializeReplicationPolicy(policyWriter, logPolicy);
 		outConf[p + "log_replication_policy"] = policyWriter.toValue().toString();

--- a/fdbclient/ManagementAPI.cpp
+++ b/fdbclient/ManagementAPI.cpp
@@ -270,59 +270,45 @@ std::map<std::string, std::string> configForToken(std::string const& mode) {
 	if (mode == "single") {
 		redundancy = "1";
 		log_replicas = "1";
-		storagePolicy = tLogPolicy = Reference<IReplicationPolicy>(new PolicyOne());
+		storagePolicy = tLogPolicy = makeReference<PolicyOne>();
 
 	} else if (mode == "double" || mode == "fast_recovery_double") {
 		redundancy = "2";
 		log_replicas = "2";
-		storagePolicy = tLogPolicy = Reference<IReplicationPolicy>(
-		    new PolicyAcross(2, "zoneid", Reference<IReplicationPolicy>(new PolicyOne())));
+		storagePolicy = tLogPolicy = makeReference<PolicyAcross>(2, "zoneid", makeReference<PolicyOne>());
 	} else if (mode == "triple" || mode == "fast_recovery_triple") {
 		redundancy = "3";
 		log_replicas = "3";
-		storagePolicy = tLogPolicy = Reference<IReplicationPolicy>(
-		    new PolicyAcross(3, "zoneid", Reference<IReplicationPolicy>(new PolicyOne())));
+		storagePolicy = tLogPolicy = makeReference<PolicyAcross>(3, "zoneid", makeReference<PolicyOne>());
 	} else if (mode == "three_datacenter" || mode == "multi_dc") {
 		redundancy = "6";
 		log_replicas = "4";
-		storagePolicy = Reference<IReplicationPolicy>(
-		    new PolicyAcross(3,
+		storagePolicy = makeReference<PolicyAcross>(3,
 		                     "dcid",
-		                     Reference<IReplicationPolicy>(
-		                         new PolicyAcross(2, "zoneid", Reference<IReplicationPolicy>(new PolicyOne())))));
-		tLogPolicy = Reference<IReplicationPolicy>(
-		    new PolicyAcross(2,
+		                     makeReference<PolicyAcross>(2, "zoneid", makeReference<PolicyOne>()));
+		tLogPolicy = makeReference<PolicyAcross>(2,
 		                     "dcid",
-		                     Reference<IReplicationPolicy>(
-		                         new PolicyAcross(2, "zoneid", Reference<IReplicationPolicy>(new PolicyOne())))));
+		                     makeReference<PolicyAcross>(2, "zoneid", makeReference<PolicyOne>()));
 	} else if (mode == "three_datacenter_fallback") {
 		redundancy = "4";
 		log_replicas = "4";
-		storagePolicy = tLogPolicy = Reference<IReplicationPolicy>(
-		    new PolicyAcross(2,
+		storagePolicy = tLogPolicy = makeReference<PolicyAcross>(2,
 		                     "dcid",
-		                     Reference<IReplicationPolicy>(
-		                         new PolicyAcross(2, "zoneid", Reference<IReplicationPolicy>(new PolicyOne())))));
+		                     makeReference<PolicyAcross>(2, "zoneid", makeReference<PolicyOne>()));
 	} else if (mode == "three_data_hall") {
 		redundancy = "3";
 		log_replicas = "4";
-		storagePolicy = Reference<IReplicationPolicy>(
-		    new PolicyAcross(3, "data_hall", Reference<IReplicationPolicy>(new PolicyOne())));
-		tLogPolicy = Reference<IReplicationPolicy>(
-		    new PolicyAcross(2,
+		storagePolicy = makeReference<PolicyAcross>(3, "data_hall", makeReference<PolicyOne>());
+		tLogPolicy = makeReference<PolicyAcross>(2,
 		                     "data_hall",
-		                     Reference<IReplicationPolicy>(
-		                         new PolicyAcross(2, "zoneid", Reference<IReplicationPolicy>(new PolicyOne())))));
+		                     makeReference<PolicyAcross>(2, "zoneid", makeReference<PolicyOne>()));
 	} else if (mode == "three_data_hall_fallback") {
 		redundancy = "2";
 		log_replicas = "4";
-		storagePolicy = Reference<IReplicationPolicy>(
-		    new PolicyAcross(2, "data_hall", Reference<IReplicationPolicy>(new PolicyOne())));
-		tLogPolicy = Reference<IReplicationPolicy>(
-		    new PolicyAcross(2,
+		storagePolicy = makeReference<PolicyAcross>(2, "data_hall", makeReference<PolicyOne>());
+		tLogPolicy = makeReference<PolicyAcross>(2,
 		                     "data_hall",
-		                     Reference<IReplicationPolicy>(
-		                         new PolicyAcross(2, "zoneid", Reference<IReplicationPolicy>(new PolicyOne())))));
+		                     makeReference<PolicyAcross>(2, "zoneid", makeReference<PolicyOne>()));
 	} else
 		redundancySpecified = false;
 	if (redundancySpecified) {
@@ -350,25 +336,21 @@ std::map<std::string, std::string> configForToken(std::string const& mode) {
 	} else if (mode == "remote_single") {
 		remote_redundancy = "1";
 		remote_log_replicas = "1";
-		remoteTLogPolicy = Reference<IReplicationPolicy>(new PolicyOne());
+		remoteTLogPolicy = makeReference<PolicyOne>();
 	} else if (mode == "remote_double") {
 		remote_redundancy = "2";
 		remote_log_replicas = "2";
-		remoteTLogPolicy = Reference<IReplicationPolicy>(
-		    new PolicyAcross(2, "zoneid", Reference<IReplicationPolicy>(new PolicyOne())));
+		remoteTLogPolicy = makeReference<PolicyAcross>(2, "zoneid", makeReference<PolicyOne>());
 	} else if (mode == "remote_triple") {
 		remote_redundancy = "3";
 		remote_log_replicas = "3";
-		remoteTLogPolicy = Reference<IReplicationPolicy>(
-		    new PolicyAcross(3, "zoneid", Reference<IReplicationPolicy>(new PolicyOne())));
+		remoteTLogPolicy = makeReference<PolicyAcross>(3, "zoneid", makeReference<PolicyOne>());
 	} else if (mode == "remote_three_data_hall") { // FIXME: not tested in simulation
 		remote_redundancy = "3";
 		remote_log_replicas = "4";
-		remoteTLogPolicy = Reference<IReplicationPolicy>(
-		    new PolicyAcross(2,
+		remoteTLogPolicy = makeReference<PolicyAcross>(2,
 		                     "data_hall",
-		                     Reference<IReplicationPolicy>(
-		                         new PolicyAcross(2, "zoneid", Reference<IReplicationPolicy>(new PolicyOne())))));
+		                     makeReference<PolicyAcross>(2, "zoneid", makeReference<PolicyOne>()));
 	} else
 		remoteRedundancySpecified = false;
 	if (remoteRedundancySpecified) {
@@ -407,8 +389,7 @@ ConfigurationResult buildConfiguration(std::vector<StringRef> const& modeTokens,
 	auto p = configKeysPrefix.toString();
 	if (!outConf.contains(p + "storage_replication_policy") && outConf.contains(p + "storage_replicas")) {
 		int storageCount = stoi(outConf[p + "storage_replicas"]);
-		Reference<IReplicationPolicy> storagePolicy = Reference<IReplicationPolicy>(
-		    new PolicyAcross(storageCount, "zoneid", Reference<IReplicationPolicy>(new PolicyOne())));
+		Reference<IReplicationPolicy> storagePolicy = makeReference<PolicyAcross>(storageCount, "zoneid", makeReference<PolicyOne>());
 		BinaryWriter policyWriter(IncludeVersion(ProtocolVersion::withReplicationPolicy()));
 		serializeReplicationPolicy(policyWriter, storagePolicy);
 		outConf[p + "storage_replication_policy"] = policyWriter.toValue().toString();
@@ -416,8 +397,7 @@ ConfigurationResult buildConfiguration(std::vector<StringRef> const& modeTokens,
 
 	if (!outConf.contains(p + "log_replication_policy") && outConf.contains(p + "log_replicas")) {
 		int logCount = stoi(outConf[p + "log_replicas"]);
-		Reference<IReplicationPolicy> logPolicy = Reference<IReplicationPolicy>(
-		    new PolicyAcross(logCount, "zoneid", Reference<IReplicationPolicy>(new PolicyOne())));
+		Reference<IReplicationPolicy> logPolicy = makeReference<PolicyAcross>(logCount, "zoneid", makeReference<PolicyOne>());
 		BinaryWriter policyWriter(IncludeVersion(ProtocolVersion::withReplicationPolicy()));
 		serializeReplicationPolicy(policyWriter, logPolicy);
 		outConf[p + "log_replication_policy"] = policyWriter.toValue().toString();
@@ -1173,7 +1153,7 @@ struct NameQuorumChange final : IQuorumChange {
 	std::string getDesiredClusterKeyName() const override { return newName; }
 };
 Reference<IQuorumChange> nameQuorumChange(std::string const& name, Reference<IQuorumChange> const& other) {
-	return Reference<IQuorumChange>(new NameQuorumChange(name, other));
+	return makeReference<NameQuorumChange>(name, other);
 }
 
 struct AutoQuorumChange final : IQuorumChange {
@@ -1412,7 +1392,7 @@ struct AutoQuorumChange final : IQuorumChange {
 	}
 };
 Reference<IQuorumChange> autoQuorumChange(int desired) {
-	return Reference<IQuorumChange>(new AutoQuorumChange(desired));
+	return makeReference<AutoQuorumChange>(desired);
 }
 
 Future<Void> excludeServers(Transaction* tr, std::vector<AddressExclusion> servers, bool failed) {

--- a/fdbclient/MultiVersionTransaction.cpp
+++ b/fdbclient/MultiVersionTransaction.cpp
@@ -409,7 +409,7 @@ ThreadFuture<Void> DLDatabase::onReady() {
 Reference<ITransaction> DLDatabase::createTransaction() {
 	FdbCApi::FDBTransaction* tr;
 	throwIfError(api->databaseCreateTransaction(db, &tr));
-	return Reference<ITransaction>(new DLTransaction(api, tr));
+	return makeReference<DLTransaction>(api, tr);
 }
 
 void DLDatabase::setOption(FDBDatabaseOptions::Option option, Optional<StringRef> value) {
@@ -805,7 +805,7 @@ Reference<IDatabase> DLApi::createDatabase(const char* clusterFilePath) {
 	if (headerVersion >= 610) {
 		FdbCApi::FDBDatabase* db;
 		throwIfError(api->createDatabase(clusterFilePath, &db));
-		return Reference<IDatabase>(new DLDatabase(api, db));
+		return makeReference<DLDatabase>(api, db);
 	} else {
 		return DLApi::createDatabase609(clusterFilePath);
 	}
@@ -818,7 +818,7 @@ Reference<IDatabase> DLApi::createDatabaseFromConnectionString(const char* conne
 
 	FdbCApi::FDBDatabase* db;
 	throwIfError(api->createDatabaseFromConnectionString(connectionString, &db));
-	return Reference<IDatabase>(new DLDatabase(api, db));
+	return makeReference<DLDatabase>(api, db);
 }
 
 void DLApi::addNetworkThreadCompletionHook(void (*hook)(void*), void* hookParameter) {
@@ -1371,13 +1371,11 @@ MultiVersionDatabase::~MultiVersionDatabase() {
 // Create a MultiVersionDatabase that wraps an already created IDatabase object
 // For internal use in testing
 Reference<IDatabase> MultiVersionDatabase::debugCreateFromExistingDatabase(Reference<IDatabase> db) {
-	return Reference<IDatabase>(new MultiVersionDatabase(
-	    MultiVersionApi::api, 0, ClusterConnectionRecord::fromConnectionString(""), db, db, false));
+	return makeReference<MultiVersionDatabase>(MultiVersionApi::api, 0, ClusterConnectionRecord::fromConnectionString(""), db, db, false);
 }
 
 Reference<ITransaction> MultiVersionDatabase::createTransaction() {
-	return Reference<ITransaction>(
-	    new MultiVersionTransaction(Reference<MultiVersionDatabase>::addRef(this), dbState->transactionDefaultOptions));
+	return makeReference<MultiVersionTransaction>(Reference<MultiVersionDatabase>::addRef(this), dbState->transactionDefaultOptions);
 }
 
 void MultiVersionDatabase::setOption(FDBDatabaseOptions::Option option, Optional<StringRef> value) {
@@ -2432,8 +2430,7 @@ Reference<IDatabase> MultiVersionApi::createDatabase(ClusterConnectionRecord con
 		lock.leave();
 
 		Reference<IDatabase> localDb = connectionRecord.createDatabase(localClient->api);
-		return Reference<IDatabase>(
-		    new MultiVersionDatabase(this, threadIdx, connectionRecord, Reference<IDatabase>(), localDb));
+		return makeReference<MultiVersionDatabase>(this, threadIdx, connectionRecord, Reference<IDatabase>(), localDb);
 	}
 
 	lock.leave();
@@ -2444,8 +2441,7 @@ Reference<IDatabase> MultiVersionApi::createDatabase(ClusterConnectionRecord con
 	if (bypassMultiClientApi) {
 		return localDb;
 	} else {
-		return Reference<IDatabase>(
-		    new MultiVersionDatabase(this, 0, connectionRecord, Reference<IDatabase>(), localDb));
+		return makeReference<MultiVersionDatabase>(this, 0, connectionRecord, Reference<IDatabase>(), localDb);
 	}
 }
 

--- a/fdbclient/MultiVersionTransaction.cpp
+++ b/fdbclient/MultiVersionTransaction.cpp
@@ -1371,11 +1371,13 @@ MultiVersionDatabase::~MultiVersionDatabase() {
 // Create a MultiVersionDatabase that wraps an already created IDatabase object
 // For internal use in testing
 Reference<IDatabase> MultiVersionDatabase::debugCreateFromExistingDatabase(Reference<IDatabase> db) {
-	return makeReference<MultiVersionDatabase>(MultiVersionApi::api, 0, ClusterConnectionRecord::fromConnectionString(""), db, db, false);
+	return makeReference<MultiVersionDatabase>(
+	    MultiVersionApi::api, 0, ClusterConnectionRecord::fromConnectionString(""), db, db, false);
 }
 
 Reference<ITransaction> MultiVersionDatabase::createTransaction() {
-	return makeReference<MultiVersionTransaction>(Reference<MultiVersionDatabase>::addRef(this), dbState->transactionDefaultOptions);
+	return makeReference<MultiVersionTransaction>(Reference<MultiVersionDatabase>::addRef(this),
+	                                              dbState->transactionDefaultOptions);
 }
 
 void MultiVersionDatabase::setOption(FDBDatabaseOptions::Option option, Optional<StringRef> value) {

--- a/fdbclient/ThreadSafeTransaction.cpp
+++ b/fdbclient/ThreadSafeTransaction.cpp
@@ -46,12 +46,12 @@ ThreadFuture<Reference<IDatabase>> ThreadSafeDatabase::createFromExistingDatabas
 		db->checkDeferredError();
 		DatabaseContext* cx = db.getPtr();
 		cx->addref();
-		return Future<Reference<IDatabase>>(Reference<IDatabase>(new ThreadSafeDatabase(cx)));
+		return Future<Reference<IDatabase>>(makeReference<ThreadSafeDatabase>(cx));
 	});
 }
 
 Reference<ITransaction> ThreadSafeDatabase::createTransaction() {
-	return Reference<ITransaction>(new ThreadSafeTransaction(db));
+	return makeReference<ThreadSafeTransaction>(db);
 }
 
 void ThreadSafeDatabase::setOption(FDBDatabaseOptions::Option option, Optional<StringRef> value) {
@@ -142,8 +142,7 @@ ThreadSafeDatabase::ThreadSafeDatabase(ConnectionRecordType connectionRecordType
 			Reference<IClusterConnectionRecord> connectionRecord =
 			    connectionRecordType == ConnectionRecordType::FILE
 			        ? Reference<IClusterConnectionRecord>(ClusterConnectionFile::openOrDefault(connectionRecordString))
-			        : Reference<IClusterConnectionRecord>(
-			              new ClusterConnectionMemoryRecord(ClusterConnectionString(connectionRecordString)));
+			        : makeReference<ClusterConnectionMemoryRecord>(ClusterConnectionString(connectionRecordString));
 
 			Database::createDatabase(connectionRecord, apiVersion, IsInternal::False, LocalityData(), db).extractPtr();
 		} catch (Error& e) {
@@ -592,13 +591,11 @@ void ThreadSafeApi::stopNetwork() {
 }
 
 Reference<IDatabase> ThreadSafeApi::createDatabase(const char* clusterFilePath) {
-	return Reference<IDatabase>(
-	    new ThreadSafeDatabase(ThreadSafeDatabase::ConnectionRecordType::FILE, clusterFilePath, apiVersion.version()));
+	return makeReference<ThreadSafeDatabase>(ThreadSafeDatabase::ConnectionRecordType::FILE, clusterFilePath, apiVersion.version());
 }
 
 Reference<IDatabase> ThreadSafeApi::createDatabaseFromConnectionString(const char* connectionString) {
-	return Reference<IDatabase>(new ThreadSafeDatabase(
-	    ThreadSafeDatabase::ConnectionRecordType::CONNECTION_STRING, connectionString, apiVersion.version()));
+	return makeReference<ThreadSafeDatabase>(ThreadSafeDatabase::ConnectionRecordType::CONNECTION_STRING, connectionString, apiVersion.version());
 }
 
 void ThreadSafeApi::addNetworkThreadCompletionHook(void (*hook)(void*), void* hookParameter) {

--- a/fdbclient/ThreadSafeTransaction.cpp
+++ b/fdbclient/ThreadSafeTransaction.cpp
@@ -591,11 +591,13 @@ void ThreadSafeApi::stopNetwork() {
 }
 
 Reference<IDatabase> ThreadSafeApi::createDatabase(const char* clusterFilePath) {
-	return makeReference<ThreadSafeDatabase>(ThreadSafeDatabase::ConnectionRecordType::FILE, clusterFilePath, apiVersion.version());
+	return makeReference<ThreadSafeDatabase>(
+	    ThreadSafeDatabase::ConnectionRecordType::FILE, clusterFilePath, apiVersion.version());
 }
 
 Reference<IDatabase> ThreadSafeApi::createDatabaseFromConnectionString(const char* connectionString) {
-	return makeReference<ThreadSafeDatabase>(ThreadSafeDatabase::ConnectionRecordType::CONNECTION_STRING, connectionString, apiVersion.version());
+	return makeReference<ThreadSafeDatabase>(
+	    ThreadSafeDatabase::ConnectionRecordType::CONNECTION_STRING, connectionString, apiVersion.version());
 }
 
 void ThreadSafeApi::addNetworkThreadCompletionHook(void (*hook)(void*), void* hookParameter) {

--- a/fdbclient/ThreadSafeTransaction.cpp
+++ b/fdbclient/ThreadSafeTransaction.cpp
@@ -142,8 +142,8 @@ ThreadSafeDatabase::ThreadSafeDatabase(ConnectionRecordType connectionRecordType
 			Reference<IClusterConnectionRecord> connectionRecord =
 			    connectionRecordType == ConnectionRecordType::FILE
 			        ? Reference<IClusterConnectionRecord>(ClusterConnectionFile::openOrDefault(connectionRecordString))
-			        : Reference<IClusterConnectionRecord>(
-			              makeReference<ClusterConnectionMemoryRecord>(ClusterConnectionString(connectionRecordString)));
+			        : Reference<IClusterConnectionRecord>(makeReference<ClusterConnectionMemoryRecord>(
+			              ClusterConnectionString(connectionRecordString)));
 
 			Database::createDatabase(connectionRecord, apiVersion, IsInternal::False, LocalityData(), db).extractPtr();
 		} catch (Error& e) {

--- a/fdbclient/ThreadSafeTransaction.cpp
+++ b/fdbclient/ThreadSafeTransaction.cpp
@@ -142,7 +142,8 @@ ThreadSafeDatabase::ThreadSafeDatabase(ConnectionRecordType connectionRecordType
 			Reference<IClusterConnectionRecord> connectionRecord =
 			    connectionRecordType == ConnectionRecordType::FILE
 			        ? Reference<IClusterConnectionRecord>(ClusterConnectionFile::openOrDefault(connectionRecordString))
-			        : makeReference<ClusterConnectionMemoryRecord>(ClusterConnectionString(connectionRecordString));
+			        : Reference<IClusterConnectionRecord>(
+			              makeReference<ClusterConnectionMemoryRecord>(ClusterConnectionString(connectionRecordString)));
 
 			Database::createDatabase(connectionRecord, apiVersion, IsInternal::False, LocalityData(), db).extractPtr();
 		} catch (Error& e) {

--- a/fdbrpc/AsyncFileEIO.h
+++ b/fdbrpc/AsyncFileEIO.h
@@ -104,7 +104,7 @@ public:
 			throw lock_file_failure();
 		}
 
-		co_return Reference<IAsyncFile>(new AsyncFileEIO(r->result, flags, filename));
+		co_return makeReference<AsyncFileEIO>(r->result, flags, filename);
 	}
 	static Future<Void> deleteFile(std::string filename, bool mustBeDurable) {
 		::deleteFile(filename);

--- a/fdbrpc/AsyncFileEIO.h
+++ b/fdbrpc/AsyncFileEIO.h
@@ -104,7 +104,7 @@ public:
 			throw lock_file_failure();
 		}
 
-		co_return makeReference<AsyncFileEIO>(r->result, flags, filename);
+		co_return Reference<IAsyncFile>(makeReference<AsyncFileEIO>(r->result, flags, filename));
 	}
 	static Future<Void> deleteFile(std::string filename, bool mustBeDurable) {
 		::deleteFile(filename);
@@ -234,6 +234,9 @@ public:
 	~AsyncFileEIO() override { close_impl(Uncancellable(), fd); }
 
 private:
+	template <class P, class... Args>
+	friend Reference<P> makeReference(Args&&... args);
+
 	struct ErrorInfo : ReferenceCounted<ErrorInfo>, FastAllocated<ErrorInfo> {
 		Error err;
 		void set(const Error& e) {

--- a/fdbrpc/AsyncFileWinASIO.h
+++ b/fdbrpc/AsyncFileWinASIO.h
@@ -69,7 +69,7 @@ public:
 			    .detail("Mode", mode);
 			return e;
 		}
-		return makeReference<AsyncFileWinASIO>(*ios, h, flags, filename);
+		return Reference<IAsyncFile>(makeReference<AsyncFileWinASIO>(*ios, h, flags, filename));
 	}
 	static Future<Void> deleteFile(std::string filename, bool mustBeDurable) {
 		::deleteFile(filename);
@@ -197,6 +197,9 @@ public:
 	~AsyncFileWinASIO() {}
 
 private:
+	template <class P, class... Args>
+	friend Reference<P> makeReference(Args&&... args);
+
 	boost::asio::windows::random_access_handle file;
 	int flags;
 	std::string filename;

--- a/fdbrpc/AsyncFileWinASIO.h
+++ b/fdbrpc/AsyncFileWinASIO.h
@@ -69,7 +69,7 @@ public:
 			    .detail("Mode", mode);
 			return e;
 		}
-		return Reference<IAsyncFile>(new AsyncFileWinASIO(*ios, h, flags, filename));
+		return makeReference<AsyncFileWinASIO>(*ios, h, flags, filename);
 	}
 	static Future<Void> deleteFile(std::string filename, bool mustBeDurable) {
 		::deleteFile(filename);

--- a/fdbrpc/FlowTransport.cpp
+++ b/fdbrpc/FlowTransport.cpp
@@ -1049,8 +1049,8 @@ Peer::Peer(TransportData* transport, NetworkAddress const& destination)
     bytesReceived(0), bytesSent(0), lastDataPacketSentTime(now()), outstandingReplies(0),
     pingLatencies(destination.isPublic() ? FLOW_KNOBS->PING_SKETCH_ACCURACY : 0.1), lastLoggedTime(0.0),
     lastLoggedBytesReceived(0), lastLoggedBytesSent(0), timeoutCount(0),
-    protocolVersion(makeReference<AsyncVar<Optional<ProtocolVersion>>>()),
-    connectOutgoingCount(0), connectIncomingCount(0), connectFailedCount(0),
+    protocolVersion(makeReference<AsyncVar<Optional<ProtocolVersion>>>()), connectOutgoingCount(0),
+    connectIncomingCount(0), connectFailedCount(0),
     connectLatencies(destination.isPublic() ? FLOW_KNOBS->PING_SKETCH_ACCURACY : 0.1) {
 	IFailureMonitor::failureMonitor().setStatus(destination, FailureStatus(false));
 }

--- a/fdbrpc/FlowTransport.cpp
+++ b/fdbrpc/FlowTransport.cpp
@@ -449,7 +449,7 @@ Future<Void> connectionHistoryLogger(TransportData* self) {
 
 	// One thread ensures async serialized execution on the log file.
 	if (g_network->isSimulated()) {
-		self->connectionLogWriterThread = Reference<IThreadPool>(new DummyThreadPool());
+		self->connectionLogWriterThread = makeReference<DummyThreadPool>();
 	} else {
 		self->connectionLogWriterThread = createGenericThreadPool();
 	}
@@ -1049,7 +1049,7 @@ Peer::Peer(TransportData* transport, NetworkAddress const& destination)
     bytesReceived(0), bytesSent(0), lastDataPacketSentTime(now()), outstandingReplies(0),
     pingLatencies(destination.isPublic() ? FLOW_KNOBS->PING_SKETCH_ACCURACY : 0.1), lastLoggedTime(0.0),
     lastLoggedBytesReceived(0), lastLoggedBytesSent(0), timeoutCount(0),
-    protocolVersion(Reference<AsyncVar<Optional<ProtocolVersion>>>(new AsyncVar<Optional<ProtocolVersion>>())),
+    protocolVersion(makeReference<AsyncVar<Optional<ProtocolVersion>>>()),
     connectOutgoingCount(0), connectIncomingCount(0), connectFailedCount(0),
     connectLatencies(destination.isPublic() ? FLOW_KNOBS->PING_SKETCH_ACCURACY : 0.1) {
 	IFailureMonitor::failureMonitor().setStatus(destination, FailureStatus(false));

--- a/fdbrpc/Net2FileSystem.cpp
+++ b/fdbrpc/Net2FileSystem.cpp
@@ -165,9 +165,13 @@ Future<Reference<class IAsyncFile>> Net2FileSystem::open(const std::string& file
 		    mode,
 		    static_cast<boost::asio::io_service*>((void*)g_network->global(INetwork::enASIOService)));
 	if (FLOW_KNOBS->PAGE_WRITE_CHECKSUM_HISTORY > 0)
-		f = map(f, [=](Reference<IAsyncFile> r) { return makeReference<AsyncFileWriteChecker>(r); });
+		f = map(f, [=](Reference<IAsyncFile> r) -> Reference<IAsyncFile> {
+			return makeReference<AsyncFileWriteChecker>(r);
+		});
 	if (FLOW_KNOBS->ENABLE_CHAOS_FEATURES)
-		f = map(f, [=](Reference<IAsyncFile> r) { return makeReference<AsyncFileChaos>(r); });
+		f = map(f, [=](Reference<IAsyncFile> r) -> Reference<IAsyncFile> {
+			return makeReference<AsyncFileChaos>(r);
+		});
 	return f;
 }
 

--- a/fdbrpc/Net2FileSystem.cpp
+++ b/fdbrpc/Net2FileSystem.cpp
@@ -165,9 +165,9 @@ Future<Reference<class IAsyncFile>> Net2FileSystem::open(const std::string& file
 		    mode,
 		    static_cast<boost::asio::io_service*>((void*)g_network->global(INetwork::enASIOService)));
 	if (FLOW_KNOBS->PAGE_WRITE_CHECKSUM_HISTORY > 0)
-		f = map(f, [=](Reference<IAsyncFile> r) { return Reference<IAsyncFile>(new AsyncFileWriteChecker(r)); });
+		f = map(f, [=](Reference<IAsyncFile> r) { return makeReference<AsyncFileWriteChecker>(r); });
 	if (FLOW_KNOBS->ENABLE_CHAOS_FEATURES)
-		f = map(f, [=](Reference<IAsyncFile> r) { return Reference<IAsyncFile>(new AsyncFileChaos(r)); });
+		f = map(f, [=](Reference<IAsyncFile> r) { return makeReference<AsyncFileChaos>(r); });
 	return f;
 }
 

--- a/fdbrpc/Net2FileSystem.cpp
+++ b/fdbrpc/Net2FileSystem.cpp
@@ -169,9 +169,7 @@ Future<Reference<class IAsyncFile>> Net2FileSystem::open(const std::string& file
 			return makeReference<AsyncFileWriteChecker>(r);
 		});
 	if (FLOW_KNOBS->ENABLE_CHAOS_FEATURES)
-		f = map(f, [=](Reference<IAsyncFile> r) -> Reference<IAsyncFile> {
-			return makeReference<AsyncFileChaos>(r);
-		});
+		f = map(f, [=](Reference<IAsyncFile> r) -> Reference<IAsyncFile> { return makeReference<AsyncFileChaos>(r); });
 	return f;
 }
 

--- a/fdbrpc/ReplicationPolicy.cpp
+++ b/fdbrpc/ReplicationPolicy.cpp
@@ -349,17 +349,14 @@ void testPolicySerialization(Reference<IReplicationPolicy>& policy) {
 }
 
 void testReplicationPolicy(int nTests) {
-	Reference<IReplicationPolicy> policy =
-	    makeReference<PolicyAcross>(1, "data_hall", makeReference<PolicyOne>());
+	Reference<IReplicationPolicy> policy = makeReference<PolicyAcross>(1, "data_hall", makeReference<PolicyOne>());
 	testPolicySerialization(policy);
 
-	policy = Reference<IReplicationPolicy>(
-	    new PolicyAnd({ makeReference<PolicyAcross>(2,
-	                                         "data_center",
-	                                         makeReference<PolicyAcross>(3, "rack", makeReference<PolicyOne>())),
-	                    makeReference<PolicyAcross>(2,
-	                                         "data_center",
-	                                         makeReference<PolicyAcross>(2, "data_hall", makeReference<PolicyOne>())) }));
+	policy = Reference<IReplicationPolicy>(new PolicyAnd(
+	    { makeReference<PolicyAcross>(
+	          2, "data_center", makeReference<PolicyAcross>(3, "rack", makeReference<PolicyOne>())),
+	      makeReference<PolicyAcross>(
+	          2, "data_center", makeReference<PolicyAcross>(2, "data_hall", makeReference<PolicyOne>())) }));
 
 	testPolicySerialization(policy);
 }

--- a/fdbrpc/ReplicationPolicy.cpp
+++ b/fdbrpc/ReplicationPolicy.cpp
@@ -350,20 +350,16 @@ void testPolicySerialization(Reference<IReplicationPolicy>& policy) {
 
 void testReplicationPolicy(int nTests) {
 	Reference<IReplicationPolicy> policy =
-	    Reference<IReplicationPolicy>(new PolicyAcross(1, "data_hall", Reference<IReplicationPolicy>(new PolicyOne())));
+	    makeReference<PolicyAcross>(1, "data_hall", makeReference<PolicyOne>());
 	testPolicySerialization(policy);
 
 	policy = Reference<IReplicationPolicy>(
-	    new PolicyAnd({ Reference<IReplicationPolicy>(
-	                        new PolicyAcross(2,
+	    new PolicyAnd({ makeReference<PolicyAcross>(2,
 	                                         "data_center",
-	                                         Reference<IReplicationPolicy>(new PolicyAcross(
-	                                             3, "rack", Reference<IReplicationPolicy>(new PolicyOne()))))),
-	                    Reference<IReplicationPolicy>(
-	                        new PolicyAcross(2,
+	                                         makeReference<PolicyAcross>(3, "rack", makeReference<PolicyOne>())),
+	                    makeReference<PolicyAcross>(2,
 	                                         "data_center",
-	                                         Reference<IReplicationPolicy>(new PolicyAcross(
-	                                             2, "data_hall", Reference<IReplicationPolicy>(new PolicyOne()))))) }));
+	                                         makeReference<PolicyAcross>(2, "data_hall", makeReference<PolicyOne>())) }));
 
 	testPolicySerialization(policy);
 }

--- a/fdbrpc/ReplicationUtils.cpp
+++ b/fdbrpc/ReplicationUtils.cpp
@@ -638,18 +638,14 @@ std::vector<Reference<IReplicationPolicy>> const& getStaticPolicies() {
 			makeReference<PolicyAcross>(3, "sz", makeReference<PolicyOne>()),
 
 			// 4 'dc^1 x az^3 x 1'
-			makeReference<PolicyAcross>(1,
-			                     "dc",
-			                     makeReference<PolicyAcross>(3, "az", makeReference<PolicyOne>())),
+			makeReference<PolicyAcross>(1, "dc", makeReference<PolicyAcross>(3, "az", makeReference<PolicyOne>())),
 
 			// 5 '(sz^3 x rack^2 x 1) + (dc^2 x az^3 x 1)'
 			Reference<IReplicationPolicy>(
-			    new PolicyAnd({ makeReference<PolicyAcross>(3,
-			                                         "sz",
-			                                         makeReference<PolicyAcross>(2, "rack", makeReference<PolicyOne>())),
-			                    makeReference<PolicyAcross>(2,
-			                        "dc",
-			                        makeReference<PolicyAcross>(3, "az", makeReference<PolicyOne>())) })),
+			    new PolicyAnd({ makeReference<PolicyAcross>(
+			                        3, "sz", makeReference<PolicyAcross>(2, "rack", makeReference<PolicyOne>())),
+			                    makeReference<PolicyAcross>(
+			                        2, "dc", makeReference<PolicyAcross>(3, "az", makeReference<PolicyOne>())) })),
 
 			// 6 '(sz^1 x 1)'
 			makeReference<PolicyAcross>(1, "sz", makeReference<PolicyOne>()),
@@ -665,53 +661,42 @@ std::vector<Reference<IReplicationPolicy>> const& getStaticPolicies() {
 			                    makeReference<PolicyAcross>(2, "sz", makeReference<PolicyOne>()) })),
 
 			// 9 '(dc^1 x sz^2 x 1)'
-			makeReference<PolicyAcross>(1,
-			                     "dc",
-			                     makeReference<PolicyAcross>(2, "sz", makeReference<PolicyOne>())),
+			makeReference<PolicyAcross>(1, "dc", makeReference<PolicyAcross>(2, "sz", makeReference<PolicyOne>())),
 
 			// 10 '(dc^2 x sz^2 x 1)'
-			makeReference<PolicyAcross>(2,
-			                     "dc",
-			                     makeReference<PolicyAcross>(2, "sz", makeReference<PolicyOne>())),
+			makeReference<PolicyAcross>(2, "dc", makeReference<PolicyAcross>(2, "sz", makeReference<PolicyOne>())),
 
 			// 11 '(dc^1 x sz^2 x 1) + (dc^2 x sz^2 x 1)'
-			Reference<IReplicationPolicy>(new PolicyAnd(
-			    { makeReference<PolicyAcross>(1,
-			                           "dc",
-			                           makeReference<PolicyAcross>(2, "sz", makeReference<PolicyOne>())),
-			      makeReference<PolicyAcross>(2,
-			                           "dc",
-			                           makeReference<PolicyAcross>(2, "sz", makeReference<PolicyOne>())) })),
+			Reference<IReplicationPolicy>(
+			    new PolicyAnd({ makeReference<PolicyAcross>(
+			                        1, "dc", makeReference<PolicyAcross>(2, "sz", makeReference<PolicyOne>())),
+			                    makeReference<PolicyAcross>(
+			                        2, "dc", makeReference<PolicyAcross>(2, "sz", makeReference<PolicyOne>())) })),
 
 			// 12 '(dc^2 x sz^2 x 1) + (dc^1 x sz^2 x 1)'
 			Reference<IReplicationPolicy>(
-			    new PolicyAnd({ makeReference<PolicyAcross>(2,
-			                                         "dc",
-			                                         makeReference<PolicyAcross>(2, "sz", makeReference<PolicyOne>())),
-			                    makeReference<PolicyAcross>(1,
-			                        "dc",
-			                        makeReference<PolicyAcross>(2, "sz", makeReference<PolicyOne>())) })),
+			    new PolicyAnd({ makeReference<PolicyAcross>(
+			                        2, "dc", makeReference<PolicyAcross>(2, "sz", makeReference<PolicyOne>())),
+			                    makeReference<PolicyAcross>(
+			                        1, "dc", makeReference<PolicyAcross>(2, "sz", makeReference<PolicyOne>())) })),
 
 			// 13 '(sz^2 x 1) + (dc^1 x sz^2 x 1)'
 			Reference<IReplicationPolicy>(
 			    new PolicyAnd({ makeReference<PolicyAcross>(2, "sz", makeReference<PolicyOne>()),
-			                    makeReference<PolicyAcross>(1,
-			                        "dc",
-			                        makeReference<PolicyAcross>(2, "sz", makeReference<PolicyOne>())) })),
+			                    makeReference<PolicyAcross>(
+			                        1, "dc", makeReference<PolicyAcross>(2, "sz", makeReference<PolicyOne>())) })),
 
 			// 14 '(sz^2 x 1) + (dc^2 x sz^2 x 1)'
 			Reference<IReplicationPolicy>(
 			    new PolicyAnd({ makeReference<PolicyAcross>(2, "sz", makeReference<PolicyOne>()),
-			                    makeReference<PolicyAcross>(2,
-			                        "dc",
-			                        makeReference<PolicyAcross>(2, "sz", makeReference<PolicyOne>())) })),
+			                    makeReference<PolicyAcross>(
+			                        2, "dc", makeReference<PolicyAcross>(2, "sz", makeReference<PolicyOne>())) })),
 
 			// 15 '(sz^3 x 1) + (dc^2 x sz^2 x 1)'
 			Reference<IReplicationPolicy>(
 			    new PolicyAnd({ makeReference<PolicyAcross>(3, "sz", makeReference<PolicyOne>()),
-			                    makeReference<PolicyAcross>(2,
-			                        "dc",
-			                        makeReference<PolicyAcross>(2, "sz", makeReference<PolicyOne>())) })),
+			                    makeReference<PolicyAcross>(
+			                        2, "dc", makeReference<PolicyAcross>(2, "sz", makeReference<PolicyOne>())) })),
 
 			// 16 '(sz^1 x 1) + (sz^2 x 1)'
 			Reference<IReplicationPolicy>(
@@ -741,26 +726,19 @@ std::vector<Reference<IReplicationPolicy>> const& getStaticPolicies() {
 			//"zoneid", Reference<IReplicationPolicy>(new PolicyOne()))) } ) ),
 
 			// 20 '(dc^1 x sz^3 x 1)'
-			makeReference<PolicyAcross>(1,
-			                     "dc",
-			                     makeReference<PolicyAcross>(3, "sz", makeReference<PolicyOne>())),
+			makeReference<PolicyAcross>(1, "dc", makeReference<PolicyAcross>(3, "sz", makeReference<PolicyOne>())),
 
 			// 21 '(dc^2 x sz^3 x 1)'
-			makeReference<PolicyAcross>(2,
-			                     "dc",
-			                     makeReference<PolicyAcross>(3, "sz", makeReference<PolicyOne>())),
+			makeReference<PolicyAcross>(2, "dc", makeReference<PolicyAcross>(3, "sz", makeReference<PolicyOne>())),
 
 			// 22 '(dc^2 x az^3 x 1)'
-			makeReference<PolicyAcross>(2,
-			                     "dc",
-			                     makeReference<PolicyAcross>(3, "az", makeReference<PolicyOne>())),
+			makeReference<PolicyAcross>(2, "dc", makeReference<PolicyAcross>(3, "az", makeReference<PolicyOne>())),
 
 			// 23 '(sz^1 x 1) + (dc^2 x az^3 x 1)'
 			Reference<IReplicationPolicy>(
 			    new PolicyAnd({ makeReference<PolicyAcross>(1, "sz", makeReference<PolicyOne>()),
-			                    makeReference<PolicyAcross>(2,
-			                        "dc",
-			                        makeReference<PolicyAcross>(3, "az", makeReference<PolicyOne>())) })),
+			                    makeReference<PolicyAcross>(
+			                        2, "dc", makeReference<PolicyAcross>(3, "az", makeReference<PolicyOne>())) })),
 
 			// 'dc^1 x (az^2 x 1) + (sz^2 x 1)'
 			//	Reference<IReplicationPolicy>( new PolicyAcross(1, "dc", Reference<IReplicationPolicy>(new
@@ -769,14 +747,10 @@ std::vector<Reference<IReplicationPolicy>> const& getStaticPolicies() {
 			// PolicyOne())))}))) ),
 
 			// 24 Require backtracking
-			makeReference<PolicyAcross>(8,
-			    "zoneid",
-			    makeReference<PolicyAcross>(1, "az", makeReference<PolicyOne>())),
+			makeReference<PolicyAcross>(8, "zoneid", makeReference<PolicyAcross>(1, "az", makeReference<PolicyOne>())),
 
 			// 25
-			makeReference<PolicyAcross>(8,
-			    "zoneid",
-			    makeReference<PolicyAcross>(1, "sz", makeReference<PolicyOne>()))
+			makeReference<PolicyAcross>(8, "zoneid", makeReference<PolicyAcross>(1, "sz", makeReference<PolicyOne>()))
 		};
 	}
 	return staticPolicies;

--- a/fdbrpc/ReplicationUtils.cpp
+++ b/fdbrpc/ReplicationUtils.cpp
@@ -375,7 +375,7 @@ bool validateAllCombinations(std::vector<LocalityData>& offendingCombo,
 		bValid = false;
 	} else {
 		bool bIsValidGroup;
-		Reference<LocalitySet> localSet = Reference<LocalitySet>(new LocalityGroup());
+		Reference<LocalitySet> localSet = makeReference<LocalityGroup>();
 		auto* localGroup = (LocalityGroup*)localSet.getPtr();
 		localGroup->deep_copy(localitySet);
 
@@ -626,153 +626,113 @@ std::vector<Reference<IReplicationPolicy>> const& getStaticPolicies() {
 	if (staticPolicies.empty()) {
 		staticPolicies = {
 
-			Reference<IReplicationPolicy>(new PolicyOne()),
+			makeReference<PolicyOne>(),
 
 			// 1 'dc^2 x 1'
-			Reference<IReplicationPolicy>(new PolicyAcross(2, "dc", Reference<IReplicationPolicy>(new PolicyOne()))),
+			makeReference<PolicyAcross>(2, "dc", makeReference<PolicyOne>()),
 
 			// 2 'dc^3 x 1'
-			Reference<IReplicationPolicy>(new PolicyAcross(3, "dc", Reference<IReplicationPolicy>(new PolicyOne()))),
+			makeReference<PolicyAcross>(3, "dc", makeReference<PolicyOne>()),
 
 			// 3 'sz^3 x 1'
-			Reference<IReplicationPolicy>(new PolicyAcross(3, "sz", Reference<IReplicationPolicy>(new PolicyOne()))),
+			makeReference<PolicyAcross>(3, "sz", makeReference<PolicyOne>()),
 
 			// 4 'dc^1 x az^3 x 1'
-			Reference<IReplicationPolicy>(
-			    new PolicyAcross(1,
+			makeReference<PolicyAcross>(1,
 			                     "dc",
-			                     Reference<IReplicationPolicy>(
-			                         new PolicyAcross(3, "az", Reference<IReplicationPolicy>(new PolicyOne()))))),
+			                     makeReference<PolicyAcross>(3, "az", makeReference<PolicyOne>())),
 
 			// 5 '(sz^3 x rack^2 x 1) + (dc^2 x az^3 x 1)'
 			Reference<IReplicationPolicy>(
-			    new PolicyAnd({ Reference<IReplicationPolicy>(
-			                        new PolicyAcross(3,
+			    new PolicyAnd({ makeReference<PolicyAcross>(3,
 			                                         "sz",
-			                                         Reference<IReplicationPolicy>(new PolicyAcross(
-			                                             2, "rack", Reference<IReplicationPolicy>(new PolicyOne()))))),
-			                    Reference<IReplicationPolicy>(new PolicyAcross(
-			                        2,
+			                                         makeReference<PolicyAcross>(2, "rack", makeReference<PolicyOne>())),
+			                    makeReference<PolicyAcross>(2,
 			                        "dc",
-			                        Reference<IReplicationPolicy>(new PolicyAcross(
-			                            3, "az", Reference<IReplicationPolicy>(new PolicyOne()))))) })),
+			                        makeReference<PolicyAcross>(3, "az", makeReference<PolicyOne>())) })),
 
 			// 6 '(sz^1 x 1)'
-			Reference<IReplicationPolicy>(new PolicyAcross(1, "sz", Reference<IReplicationPolicy>(new PolicyOne()))),
+			makeReference<PolicyAcross>(1, "sz", makeReference<PolicyOne>()),
 
 			// 7 '(sz^1 x 1) + (sz^1 x 1)'
 			Reference<IReplicationPolicy>(
-			    new PolicyAnd({ Reference<IReplicationPolicy>(
-			                        new PolicyAcross(1, "sz", Reference<IReplicationPolicy>(new PolicyOne()))),
-			                    Reference<IReplicationPolicy>(
-			                        new PolicyAcross(1, "sz", Reference<IReplicationPolicy>(new PolicyOne()))) })),
+			    new PolicyAnd({ makeReference<PolicyAcross>(1, "sz", makeReference<PolicyOne>()),
+			                    makeReference<PolicyAcross>(1, "sz", makeReference<PolicyOne>()) })),
 
 			// 8 '(sz^2 x 1) + (sz^2 x 1)'
 			Reference<IReplicationPolicy>(
-			    new PolicyAnd({ Reference<IReplicationPolicy>(
-			                        new PolicyAcross(2, "sz", Reference<IReplicationPolicy>(new PolicyOne()))),
-			                    Reference<IReplicationPolicy>(
-			                        new PolicyAcross(2, "sz", Reference<IReplicationPolicy>(new PolicyOne()))) })),
+			    new PolicyAnd({ makeReference<PolicyAcross>(2, "sz", makeReference<PolicyOne>()),
+			                    makeReference<PolicyAcross>(2, "sz", makeReference<PolicyOne>()) })),
 
 			// 9 '(dc^1 x sz^2 x 1)'
-			Reference<IReplicationPolicy>(
-			    new PolicyAcross(1,
+			makeReference<PolicyAcross>(1,
 			                     "dc",
-			                     Reference<IReplicationPolicy>(
-			                         new PolicyAcross(2, "sz", Reference<IReplicationPolicy>(new PolicyOne()))))),
+			                     makeReference<PolicyAcross>(2, "sz", makeReference<PolicyOne>())),
 
 			// 10 '(dc^2 x sz^2 x 1)'
-			Reference<IReplicationPolicy>(
-			    new PolicyAcross(2,
+			makeReference<PolicyAcross>(2,
 			                     "dc",
-			                     Reference<IReplicationPolicy>(
-			                         new PolicyAcross(2, "sz", Reference<IReplicationPolicy>(new PolicyOne()))))),
+			                     makeReference<PolicyAcross>(2, "sz", makeReference<PolicyOne>())),
 
 			// 11 '(dc^1 x sz^2 x 1) + (dc^2 x sz^2 x 1)'
 			Reference<IReplicationPolicy>(new PolicyAnd(
-			    { Reference<IReplicationPolicy>(
-			          new PolicyAcross(1,
+			    { makeReference<PolicyAcross>(1,
 			                           "dc",
-			                           Reference<IReplicationPolicy>(
-			                               new PolicyAcross(2, "sz", Reference<IReplicationPolicy>(new PolicyOne()))))),
-			      Reference<IReplicationPolicy>(
-			          new PolicyAcross(2,
+			                           makeReference<PolicyAcross>(2, "sz", makeReference<PolicyOne>())),
+			      makeReference<PolicyAcross>(2,
 			                           "dc",
-			                           Reference<IReplicationPolicy>(new PolicyAcross(
-			                               2, "sz", Reference<IReplicationPolicy>(new PolicyOne()))))) })),
+			                           makeReference<PolicyAcross>(2, "sz", makeReference<PolicyOne>())) })),
 
 			// 12 '(dc^2 x sz^2 x 1) + (dc^1 x sz^2 x 1)'
 			Reference<IReplicationPolicy>(
-			    new PolicyAnd({ Reference<IReplicationPolicy>(
-			                        new PolicyAcross(2,
+			    new PolicyAnd({ makeReference<PolicyAcross>(2,
 			                                         "dc",
-			                                         Reference<IReplicationPolicy>(new PolicyAcross(
-			                                             2, "sz", Reference<IReplicationPolicy>(new PolicyOne()))))),
-			                    Reference<IReplicationPolicy>(new PolicyAcross(
-			                        1,
+			                                         makeReference<PolicyAcross>(2, "sz", makeReference<PolicyOne>())),
+			                    makeReference<PolicyAcross>(1,
 			                        "dc",
-			                        Reference<IReplicationPolicy>(new PolicyAcross(
-			                            2, "sz", Reference<IReplicationPolicy>(new PolicyOne()))))) })),
+			                        makeReference<PolicyAcross>(2, "sz", makeReference<PolicyOne>())) })),
 
 			// 13 '(sz^2 x 1) + (dc^1 x sz^2 x 1)'
 			Reference<IReplicationPolicy>(
-			    new PolicyAnd({ Reference<IReplicationPolicy>(
-			                        new PolicyAcross(2, "sz", Reference<IReplicationPolicy>(new PolicyOne()))),
-			                    Reference<IReplicationPolicy>(new PolicyAcross(
-			                        1,
+			    new PolicyAnd({ makeReference<PolicyAcross>(2, "sz", makeReference<PolicyOne>()),
+			                    makeReference<PolicyAcross>(1,
 			                        "dc",
-			                        Reference<IReplicationPolicy>(new PolicyAcross(
-			                            2, "sz", Reference<IReplicationPolicy>(new PolicyOne()))))) })),
+			                        makeReference<PolicyAcross>(2, "sz", makeReference<PolicyOne>())) })),
 
 			// 14 '(sz^2 x 1) + (dc^2 x sz^2 x 1)'
 			Reference<IReplicationPolicy>(
-			    new PolicyAnd({ Reference<IReplicationPolicy>(
-			                        new PolicyAcross(2, "sz", Reference<IReplicationPolicy>(new PolicyOne()))),
-			                    Reference<IReplicationPolicy>(new PolicyAcross(
-			                        2,
+			    new PolicyAnd({ makeReference<PolicyAcross>(2, "sz", makeReference<PolicyOne>()),
+			                    makeReference<PolicyAcross>(2,
 			                        "dc",
-			                        Reference<IReplicationPolicy>(new PolicyAcross(
-			                            2, "sz", Reference<IReplicationPolicy>(new PolicyOne()))))) })),
+			                        makeReference<PolicyAcross>(2, "sz", makeReference<PolicyOne>())) })),
 
 			// 15 '(sz^3 x 1) + (dc^2 x sz^2 x 1)'
 			Reference<IReplicationPolicy>(
-			    new PolicyAnd({ Reference<IReplicationPolicy>(
-			                        new PolicyAcross(3, "sz", Reference<IReplicationPolicy>(new PolicyOne()))),
-			                    Reference<IReplicationPolicy>(new PolicyAcross(
-			                        2,
+			    new PolicyAnd({ makeReference<PolicyAcross>(3, "sz", makeReference<PolicyOne>()),
+			                    makeReference<PolicyAcross>(2,
 			                        "dc",
-			                        Reference<IReplicationPolicy>(new PolicyAcross(
-			                            2, "sz", Reference<IReplicationPolicy>(new PolicyOne()))))) })),
+			                        makeReference<PolicyAcross>(2, "sz", makeReference<PolicyOne>())) })),
 
 			// 16 '(sz^1 x 1) + (sz^2 x 1)'
 			Reference<IReplicationPolicy>(
-			    new PolicyAnd({ Reference<IReplicationPolicy>(
-			                        new PolicyAcross(1, "sz", Reference<IReplicationPolicy>(new PolicyOne()))),
-			                    Reference<IReplicationPolicy>(
-			                        new PolicyAcross(2, "sz", Reference<IReplicationPolicy>(new PolicyOne()))) })),
+			    new PolicyAnd({ makeReference<PolicyAcross>(1, "sz", makeReference<PolicyOne>()),
+			                    makeReference<PolicyAcross>(2, "sz", makeReference<PolicyOne>()) })),
 
 			// 17 '(sz^2 x 1) + (sz^3 x 1)'
 			Reference<IReplicationPolicy>(
-			    new PolicyAnd({ Reference<IReplicationPolicy>(
-			                        new PolicyAcross(2, "sz", Reference<IReplicationPolicy>(new PolicyOne()))),
-			                    Reference<IReplicationPolicy>(
-			                        new PolicyAcross(3, "sz", Reference<IReplicationPolicy>(new PolicyOne()))) })),
+			    new PolicyAnd({ makeReference<PolicyAcross>(2, "sz", makeReference<PolicyOne>()),
+			                    makeReference<PolicyAcross>(3, "sz", makeReference<PolicyOne>()) })),
 
 			// 18 '(sz^1 x 1) + (sz^2 x 1) + (sz^3 x 1)'
 			Reference<IReplicationPolicy>(
-			    new PolicyAnd({ Reference<IReplicationPolicy>(
-			                        new PolicyAcross(1, "sz", Reference<IReplicationPolicy>(new PolicyOne()))),
-			                    Reference<IReplicationPolicy>(
-			                        new PolicyAcross(2, "sz", Reference<IReplicationPolicy>(new PolicyOne()))),
-			                    Reference<IReplicationPolicy>(
-			                        new PolicyAcross(3, "sz", Reference<IReplicationPolicy>(new PolicyOne()))) })),
+			    new PolicyAnd({ makeReference<PolicyAcross>(1, "sz", makeReference<PolicyOne>()),
+			                    makeReference<PolicyAcross>(2, "sz", makeReference<PolicyOne>()),
+			                    makeReference<PolicyAcross>(3, "sz", makeReference<PolicyOne>()) })),
 
 			// 19 '(sz^1 x 1) + (machine^1 x 1)'
 			Reference<IReplicationPolicy>(
-			    new PolicyAnd({ Reference<IReplicationPolicy>(
-			                        new PolicyAcross(1, "sz", Reference<IReplicationPolicy>(new PolicyOne()))),
-			                    Reference<IReplicationPolicy>(
-			                        new PolicyAcross(1, "zoneid", Reference<IReplicationPolicy>(new PolicyOne()))) })),
+			    new PolicyAnd({ makeReference<PolicyAcross>(1, "sz", makeReference<PolicyOne>()),
+			                    makeReference<PolicyAcross>(1, "zoneid", makeReference<PolicyOne>()) })),
 
 			// '(dc^1 x 1) + (sz^1 x 1) + (machine^1 x 1)'
 			//	Reference<IReplicationPolicy>( new PolicyAnd( { Reference<IReplicationPolicy>(new PolicyAcross(1, "dc",
@@ -781,35 +741,26 @@ std::vector<Reference<IReplicationPolicy>> const& getStaticPolicies() {
 			//"zoneid", Reference<IReplicationPolicy>(new PolicyOne()))) } ) ),
 
 			// 20 '(dc^1 x sz^3 x 1)'
-			Reference<IReplicationPolicy>(
-			    new PolicyAcross(1,
+			makeReference<PolicyAcross>(1,
 			                     "dc",
-			                     Reference<IReplicationPolicy>(
-			                         new PolicyAcross(3, "sz", Reference<IReplicationPolicy>(new PolicyOne()))))),
+			                     makeReference<PolicyAcross>(3, "sz", makeReference<PolicyOne>())),
 
 			// 21 '(dc^2 x sz^3 x 1)'
-			Reference<IReplicationPolicy>(
-			    new PolicyAcross(2,
+			makeReference<PolicyAcross>(2,
 			                     "dc",
-			                     Reference<IReplicationPolicy>(
-			                         new PolicyAcross(3, "sz", Reference<IReplicationPolicy>(new PolicyOne()))))),
+			                     makeReference<PolicyAcross>(3, "sz", makeReference<PolicyOne>())),
 
 			// 22 '(dc^2 x az^3 x 1)'
-			Reference<IReplicationPolicy>(
-			    new PolicyAcross(2,
+			makeReference<PolicyAcross>(2,
 			                     "dc",
-			                     Reference<IReplicationPolicy>(
-			                         new PolicyAcross(3, "az", Reference<IReplicationPolicy>(new PolicyOne()))))),
+			                     makeReference<PolicyAcross>(3, "az", makeReference<PolicyOne>())),
 
 			// 23 '(sz^1 x 1) + (dc^2 x az^3 x 1)'
 			Reference<IReplicationPolicy>(
-			    new PolicyAnd({ Reference<IReplicationPolicy>(
-			                        new PolicyAcross(1, "sz", Reference<IReplicationPolicy>(new PolicyOne()))),
-			                    Reference<IReplicationPolicy>(new PolicyAcross(
-			                        2,
+			    new PolicyAnd({ makeReference<PolicyAcross>(1, "sz", makeReference<PolicyOne>()),
+			                    makeReference<PolicyAcross>(2,
 			                        "dc",
-			                        Reference<IReplicationPolicy>(new PolicyAcross(
-			                            3, "az", Reference<IReplicationPolicy>(new PolicyOne()))))) })),
+			                        makeReference<PolicyAcross>(3, "az", makeReference<PolicyOne>())) })),
 
 			// 'dc^1 x (az^2 x 1) + (sz^2 x 1)'
 			//	Reference<IReplicationPolicy>( new PolicyAcross(1, "dc", Reference<IReplicationPolicy>(new
@@ -818,18 +769,14 @@ std::vector<Reference<IReplicationPolicy>> const& getStaticPolicies() {
 			// PolicyOne())))}))) ),
 
 			// 24 Require backtracking
-			Reference<IReplicationPolicy>(new PolicyAcross(
-			    8,
+			makeReference<PolicyAcross>(8,
 			    "zoneid",
-			    Reference<IReplicationPolicy>(
-			        new PolicyAcross(1, "az", Reference<IReplicationPolicy>(new PolicyOne()))))),
+			    makeReference<PolicyAcross>(1, "az", makeReference<PolicyOne>())),
 
 			// 25
-			Reference<IReplicationPolicy>(new PolicyAcross(
-			    8,
+			makeReference<PolicyAcross>(8,
 			    "zoneid",
-			    Reference<IReplicationPolicy>(
-			        new PolicyAcross(1, "sz", Reference<IReplicationPolicy>(new PolicyOne())))))
+			    makeReference<PolicyAcross>(1, "sz", makeReference<PolicyOne>()))
 		};
 	}
 	return staticPolicies;
@@ -896,7 +843,7 @@ Reference<IReplicationPolicy> randomAcrossPolicy(LocalitySet const& serverSet) {
 			valueTotal = deterministicRandom()->randomInt(1, valueSet.size() + 2);
 			if ((valueTotal > maxValueTotal) && (deterministicRandom()->random01() > .25))
 				valueTotal = maxValueTotal;
-			policy = Reference<IReplicationPolicy>(new PolicyAcross(valueTotal, keyText, policy));
+			policy = makeReference<PolicyAcross>(valueTotal, keyText, policy);
 			if (g_replicationdebug > 1) {
 				printf("  item%3d: (%3d =>%3d) %-10s  =>%4d\n",
 				       keysUsed + 1,

--- a/fdbrpc/SimExternalConnection.cpp
+++ b/fdbrpc/SimExternalConnection.cpp
@@ -68,7 +68,7 @@ public:
 		if (err) {
 			co_return Reference<IConnection>();
 		} else {
-			co_return Reference<IConnection>(new SimExternalConnection(std::move(socket)));
+			co_return makeReference<SimExternalConnection>(std::move(socket));
 		}
 	}
 };

--- a/fdbrpc/SimExternalConnection.cpp
+++ b/fdbrpc/SimExternalConnection.cpp
@@ -68,7 +68,7 @@ public:
 		if (err) {
 			co_return Reference<IConnection>();
 		} else {
-			co_return makeReference<SimExternalConnection>(std::move(socket));
+			co_return Reference<IConnection>(makeReference<SimExternalConnection>(std::move(socket)));
 		}
 	}
 };

--- a/fdbrpc/SimExternalConnection.h
+++ b/fdbrpc/SimExternalConnection.h
@@ -36,6 +36,8 @@ class SimExternalConnection final : public IConnection, public ReferenceCounted<
 	std::deque<uint8_t> readBuffer;
 	AsyncTrigger onReadableTrigger;
 	friend class SimExternalConnectionImpl;
+	template <class P, class... Args>
+	friend Reference<P> makeReference(Args&&... args);
 
 public:
 	void addref() override { return ReferenceCounted<SimExternalConnection>::addref(); }

--- a/fdbrpc/bench/BenchSelectReplicas.cpp
+++ b/fdbrpc/bench/BenchSelectReplicas.cpp
@@ -27,8 +27,7 @@
 
 static void bench_select_replicas(int repCount, benchmark::State& state) {
 
-	Reference<IReplicationPolicy> policy = Reference<IReplicationPolicy>(
-	    new PolicyAcross(repCount, "rack", Reference<IReplicationPolicy>(new PolicyOne())));
+	Reference<IReplicationPolicy> policy = makeReference<PolicyAcross>(repCount, "rack", makeReference<PolicyOne>());
 
 	// Pre-warm the depth cache to avoid measuring lazy initialization overhead
 	policy->depth();
@@ -47,7 +46,7 @@ static void bench_select_replicas(int repCount, benchmark::State& state) {
 	    createTestLocalityMap(indexes, dcTotal, szTotal, rackTotal, slotTotal, independentItems, independentTotal);
 	LocalityGroup* fromServersGroup = (LocalityGroup*)fromServersSet.getPtr();
 
-	const Reference<LocalitySet> alreadyServersSet = Reference<LocalitySet>(new LocalityGroup());
+	const Reference<LocalitySet> alreadyServersSet = makeReference<LocalityGroup>();
 
 	alreadyServersSet->deep_copy(*fromServersGroup);
 	std::vector<LocalityEntry> localityGroupEntries;

--- a/fdbrpc/sim2.cpp
+++ b/fdbrpc/sim2.cpp
@@ -1452,7 +1452,7 @@ public:
 		auto* m = new ProcessInfo(name, locality, startingClass, addresses, this, dataFolder, coordinationFolder);
 		for (int processPort = port; processPort < port + listenPerProcess; ++processPort) {
 			NetworkAddress address(ip, processPort, true, sslEnabled && processPort == port);
-			m->listenerMap[address] = Reference<IListener>(new Sim2Listener(m, address));
+			m->listenerMap[address] = makeReference<Sim2Listener>(m, address);
 			addressMap[address] = m;
 		}
 		m->machine = &machine;
@@ -2176,7 +2176,7 @@ public:
 			                                     handlerContext->port,
 			                                     true /* isPublic*/,
 			                                     false /*isTLS*/);
-			process->listenerMap[addr] = Reference<IListener>(new Sim2Listener(process, addr));
+			process->listenerMap[addr] = makeReference<Sim2Listener>(process, addr);
 			addressMap[addr] = process;
 			handlerContext->addAddress(addr);
 			serverContext->registerNewServer(addr, handlerContext->requestHandler->clone());
@@ -2554,7 +2554,7 @@ Future<Reference<IUDPSocket>> Sim2::createUDPSocket(NetworkAddress toAddr) {
 	while (process->boundUDPSockets.find(localAddress) != process->boundUDPSockets.end()) {
 		localAddress.port = deterministicRandom()->randomInt(40000, 60000);
 	}
-	return Reference<IUDPSocket>(new UDPSimSocket(localAddress, toAddr));
+	return makeReference<UDPSimSocket>(localAddress, toAddr);
 }
 
 Future<Reference<IUDPSocket>> Sim2::createUDPSocket(bool isV6) {
@@ -2788,7 +2788,7 @@ Future<Reference<class IAsyncFile>> Sim2FileSystem::open(const std::string& file
 			f = SimpleFile::open(filename, flags, mode, diskParameters, false);
 			if (FLOW_KNOBS->PAGE_WRITE_CHECKSUM_HISTORY > 0) {
 				f = map(f,
-				        [=](Reference<IAsyncFile> r) { return Reference<IAsyncFile>(new AsyncFileWriteChecker(r)); });
+				        [=](Reference<IAsyncFile> r) { return makeReference<AsyncFileWriteChecker>(r); });
 			}
 
 			f = AsyncFileNonDurable::open(
@@ -2801,7 +2801,7 @@ Future<Reference<class IAsyncFile>> Sim2FileSystem::open(const std::string& file
 
 		f = AsyncFileDetachable::open(f);
 		if (FLOW_KNOBS->ENABLE_CHAOS_FEATURES)
-			f = map(f, [=](Reference<IAsyncFile> r) { return Reference<IAsyncFile>(new AsyncFileChaos(r)); });
+			f = map(f, [=](Reference<IAsyncFile> r) { return makeReference<AsyncFileChaos>(r); });
 		return f;
 	} else
 		return AsyncFileCached::open(filename, flags, mode);

--- a/fdbrpc/sim2.cpp
+++ b/fdbrpc/sim2.cpp
@@ -2802,9 +2802,8 @@ Future<Reference<class IAsyncFile>> Sim2FileSystem::open(const std::string& file
 
 		f = AsyncFileDetachable::open(f);
 		if (FLOW_KNOBS->ENABLE_CHAOS_FEATURES)
-			f = map(f, [=](Reference<IAsyncFile> r) -> Reference<IAsyncFile> {
-				return makeReference<AsyncFileChaos>(r);
-			});
+			f = map(f,
+			        [=](Reference<IAsyncFile> r) -> Reference<IAsyncFile> { return makeReference<AsyncFileChaos>(r); });
 		return f;
 	} else
 		return AsyncFileCached::open(filename, flags, mode);

--- a/fdbrpc/sim2.cpp
+++ b/fdbrpc/sim2.cpp
@@ -2787,8 +2787,9 @@ Future<Reference<class IAsyncFile>> Sim2FileSystem::open(const std::string& file
 
 			f = SimpleFile::open(filename, flags, mode, diskParameters, false);
 			if (FLOW_KNOBS->PAGE_WRITE_CHECKSUM_HISTORY > 0) {
-				f = map(f,
-				        [=](Reference<IAsyncFile> r) { return makeReference<AsyncFileWriteChecker>(r); });
+				f = map(f, [=](Reference<IAsyncFile> r) -> Reference<IAsyncFile> {
+					return makeReference<AsyncFileWriteChecker>(r);
+				});
 			}
 
 			f = AsyncFileNonDurable::open(
@@ -2801,7 +2802,9 @@ Future<Reference<class IAsyncFile>> Sim2FileSystem::open(const std::string& file
 
 		f = AsyncFileDetachable::open(f);
 		if (FLOW_KNOBS->ENABLE_CHAOS_FEATURES)
-			f = map(f, [=](Reference<IAsyncFile> r) { return makeReference<AsyncFileChaos>(r); });
+			f = map(f, [=](Reference<IAsyncFile> r) -> Reference<IAsyncFile> {
+				return makeReference<AsyncFileChaos>(r);
+			});
 		return f;
 	} else
 		return AsyncFileCached::open(filename, flags, mode);

--- a/fdbrpc/sim2.cpp
+++ b/fdbrpc/sim2.cpp
@@ -2554,7 +2554,7 @@ Future<Reference<IUDPSocket>> Sim2::createUDPSocket(NetworkAddress toAddr) {
 	while (process->boundUDPSockets.find(localAddress) != process->boundUDPSockets.end()) {
 		localAddress.port = deterministicRandom()->randomInt(40000, 60000);
 	}
-	return makeReference<UDPSimSocket>(localAddress, toAddr);
+	return Reference<IUDPSocket>(makeReference<UDPSimSocket>(localAddress, toAddr));
 }
 
 Future<Reference<IUDPSocket>> Sim2::createUDPSocket(bool isV6) {

--- a/fdbserver/clustercontroller/ClusterController.h
+++ b/fdbserver/clustercontroller/ClusterController.h
@@ -356,7 +356,7 @@ public:
 	    Optional<Optional<Standalone<StringRef>>> const& dcId = Optional<Optional<Standalone<StringRef>>>()) {
 		std::map<ProcessClass::Fitness, std::vector<WorkerDetails>> fitness_workers;
 		std::vector<WorkerDetails> results;
-		Reference<LocalitySet> logServerSet = Reference<LocalitySet>(new LocalityMap<WorkerDetails>());
+		Reference<LocalitySet> logServerSet = makeReference<LocalityMap<WorkerDetails>>();
 		LocalityMap<WorkerDetails>* logServerMap = (LocalityMap<WorkerDetails>*)logServerSet.getPtr();
 		bool bCompleted = false;
 
@@ -997,7 +997,7 @@ public:
 	    const std::vector<UID>& exclusionWorkerIds = {}) {
 		std::map<std::tuple<ProcessClass::Fitness, int, bool, bool>, std::vector<WorkerDetails>> fitness_workers;
 		std::vector<WorkerDetails> results;
-		Reference<LocalitySet> logServerSet = Reference<LocalitySet>(new LocalityMap<WorkerDetails>());
+		Reference<LocalitySet> logServerSet = makeReference<LocalityMap<WorkerDetails>>();
 		LocalityMap<WorkerDetails>* logServerMap = (LocalityMap<WorkerDetails>*)logServerSet.getPtr();
 		bool bCompleted = false;
 		desired = std::max(required, desired);

--- a/fdbserver/clustercontroller/ClusterRecovery.cpp
+++ b/fdbserver/clustercontroller/ClusterRecovery.cpp
@@ -1160,7 +1160,8 @@ Future<Void> updateLocalityForDcId(Optional<Key> dcId,
 Future<Void> readTransactionSystemState(Reference<ClusterRecoveryData> self,
                                         Reference<LogSystem> oldLogSystem,
                                         Version txsPoppedVersion) {
-	Reference<AsyncVar<PeekTxsInfo>> myLocality = makeReference<AsyncVar<PeekTxsInfo>>(PeekTxsInfo(tagLocalityInvalid, tagLocalityInvalid, invalidVersion));
+	Reference<AsyncVar<PeekTxsInfo>> myLocality =
+	    makeReference<AsyncVar<PeekTxsInfo>>(PeekTxsInfo(tagLocalityInvalid, tagLocalityInvalid, invalidVersion));
 	Future<Void> localityUpdater =
 	    updateLocalityForDcId(self->masterInterface.locality.dcId(), oldLogSystem, myLocality);
 	// Peek the txnStateTag in oldLogSystem and recover self->txnStateStore

--- a/fdbserver/clustercontroller/ClusterRecovery.cpp
+++ b/fdbserver/clustercontroller/ClusterRecovery.cpp
@@ -1160,8 +1160,7 @@ Future<Void> updateLocalityForDcId(Optional<Key> dcId,
 Future<Void> readTransactionSystemState(Reference<ClusterRecoveryData> self,
                                         Reference<LogSystem> oldLogSystem,
                                         Version txsPoppedVersion) {
-	Reference<AsyncVar<PeekTxsInfo>> myLocality = Reference<AsyncVar<PeekTxsInfo>>(
-	    new AsyncVar<PeekTxsInfo>(PeekTxsInfo(tagLocalityInvalid, tagLocalityInvalid, invalidVersion)));
+	Reference<AsyncVar<PeekTxsInfo>> myLocality = makeReference<AsyncVar<PeekTxsInfo>>(PeekTxsInfo(tagLocalityInvalid, tagLocalityInvalid, invalidVersion));
 	Future<Void> localityUpdater =
 	    updateLocalityForDcId(self->masterInterface.locality.dcId(), oldLogSystem, myLocality);
 	// Peek the txnStateTag in oldLogSystem and recover self->txnStateStore

--- a/fdbserver/consistencyscan/ConsistencyScan.cpp
+++ b/fdbserver/consistencyscan/ConsistencyScan.cpp
@@ -696,7 +696,7 @@ Future<Void> consistencyScanCore(Database db, Reference<ConsistencyScanMemorySta
 				if (DEBUG_SCAN_PROGRESS) {
 					TraceEvent("ConsistencyScan_ChangeRate", memState->csId).detail("RateBytes", readRateLimit);
 				}
-				readRateControl = Reference<IRateControl>(new SpeedLimit(readRateLimit, 1));
+				readRateControl = makeReference<SpeedLimit>(readRateLimit, 1);
 				memState->stats.targetRate = configuredRate;
 			}
 
@@ -1548,7 +1548,7 @@ Future<Void> checkDataConsistency(Database cx,
 	    .detail("TargetInterval", targetInterval)
 	    .detail("MaxRate", maxRate);
 	ASSERT(rateLimitForThisRound >= 0 && rateLimitForThisRound <= maxRate);
-	Reference<IRateControl> rateLimiter = Reference<IRateControl>(new SpeedLimit(rateLimitForThisRound, 1));
+	Reference<IRateControl> rateLimiter = makeReference<SpeedLimit>(rateLimitForThisRound, 1);
 	double rateLimiterStartTime = now();
 	int64_t bytesReadInthisRound = 0;
 	double rateLimiterCumulatedWaitTime = 0;
@@ -1918,7 +1918,7 @@ Future<Void> checkDataConsistency(Database cx,
 						// Set ratelimit to max allowed if current round has been going on for a while
 						if (now() - rateLimiterStartTime > 1.1 * targetInterval && rateLimitForThisRound != maxRate) {
 							rateLimitForThisRound = maxRate;
-							rateLimiter = Reference<IRateControl>(new SpeedLimit(rateLimitForThisRound, 1));
+							rateLimiter = makeReference<SpeedLimit>(rateLimitForThisRound, 1);
 							rateLimiterStartTime = now();
 							TraceEvent(SevInfo, "ConsistencyCheck_RateLimitSetMaxForThisRound")
 							    .detail("RateLimit", rateLimitForThisRound);

--- a/fdbserver/datadistributor/DDTeamCollection.actor.cpp
+++ b/fdbserver/datadistributor/DDTeamCollection.actor.cpp
@@ -6342,7 +6342,8 @@ public:
 		int desiredTeams = SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER * processSize;
 		int maxTeams = SERVER_KNOBS->MAX_TEAMS_PER_SERVER * processSize;
 
-		Reference<IReplicationPolicy> policy = makeReference<PolicyAcross>(teamSize, "zoneid", makeReference<PolicyOne>());
+		Reference<IReplicationPolicy> policy =
+		    makeReference<PolicyAcross>(teamSize, "zoneid", makeReference<PolicyOne>());
 		std::unique_ptr<DDTeamCollection> collection = testMachineTeamCollection(teamSize, policy, processSize);
 
 		collection->addTeamsBestOf(30, desiredTeams, maxTeams);
@@ -6358,7 +6359,8 @@ public:
 		int desiredTeams = SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER * processSize;
 		int maxTeams = SERVER_KNOBS->MAX_TEAMS_PER_SERVER * processSize;
 
-		Reference<IReplicationPolicy> policy = makeReference<PolicyAcross>(teamSize, "zoneid", makeReference<PolicyOne>());
+		Reference<IReplicationPolicy> policy =
+		    makeReference<PolicyAcross>(teamSize, "zoneid", makeReference<PolicyOne>());
 		std::unique_ptr<DDTeamCollection> collection = testMachineTeamCollection(teamSize, policy, processSize);
 
 		if (collection == nullptr) {

--- a/fdbserver/datadistributor/DDTeamCollection.actor.cpp
+++ b/fdbserver/datadistributor/DDTeamCollection.actor.cpp
@@ -723,7 +723,7 @@ public:
 		int idx = 0;
 		std::vector<Reference<TCServerInfo>> servers;
 		std::vector<UID> serverIds;
-		Reference<LocalitySet> tempSet = Reference<LocalitySet>(new LocalityMap<UID>());
+		Reference<LocalitySet> tempSet = makeReference<LocalityMap<UID>>();
 		LocalityMap<UID>* tempMap = nullptr;
 		std::vector<Reference<TCTeamInfo>> largeOrBadTeams = self->badTeams;
 		largeOrBadTeams.insert(largeOrBadTeams.end(), self->largeTeams.begin(), self->largeTeams.end());
@@ -4415,7 +4415,7 @@ Future<Void> DDTeamCollection::updateStorageMetadata(TCServerInfo* server) {
 }
 
 void DDTeamCollection::resetLocalitySet() {
-	storageServerSet = Reference<LocalitySet>(new LocalityMap<UID>());
+	storageServerSet = makeReference<LocalityMap<UID>>();
 	auto* storageServerMap = static_cast<LocalityMap<UID>*>(storageServerSet.getPtr());
 
 	for (auto& it : server_info) {
@@ -4853,7 +4853,7 @@ Reference<TCTeamInfo> DDTeamCollection::buildLargeTeam(int teamSize) {
 		    .detail("SatisfiesPolicy", satisfiesPolicy(candidateTeam));
 		return Reference<TCTeamInfo>();
 	} else if (candidateTeam.size() > teamSize) {
-		Reference<LocalitySet> tempSet = Reference<LocalitySet>(new LocalityMap<UID>());
+		Reference<LocalitySet> tempSet = makeReference<LocalityMap<UID>>();
 		auto* tempMap = static_cast<LocalityMap<UID>*>(tempSet.getPtr());
 		tempSet->clear();
 		for (auto& it : candidateTeam) {
@@ -6220,7 +6220,7 @@ public:
 	    Reference<ShardsAffectedByTeamFailure> shardsAffectedByTeamFailure) {
 		Database database = DatabaseContext::create(
 		    makeReference<AsyncVar<ClientDBInfo>>(), Never(), LocalityData(), EnableLocalityLoadBalance::False);
-		auto txnProcessor = Reference<IDDTxnProcessor>(new DDTxnProcessor(database));
+		auto txnProcessor = makeReference<DDTxnProcessor>(database);
 		DatabaseConfiguration conf;
 		conf.storageTeamSize = teamSize;
 		conf.storagePolicy = policy;
@@ -6275,7 +6275,7 @@ public:
 	                                                                   int processCount) {
 		Database database = DatabaseContext::create(
 		    makeReference<AsyncVar<ClientDBInfo>>(), Never(), LocalityData(), EnableLocalityLoadBalance::False);
-		auto txnProcessor = Reference<IDDTxnProcessor>(new DDTxnProcessor(database));
+		auto txnProcessor = makeReference<DDTxnProcessor>(database);
 		DatabaseConfiguration conf;
 		conf.storageTeamSize = teamSize;
 		conf.storagePolicy = policy;
@@ -6342,8 +6342,7 @@ public:
 		int desiredTeams = SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER * processSize;
 		int maxTeams = SERVER_KNOBS->MAX_TEAMS_PER_SERVER * processSize;
 
-		Reference<IReplicationPolicy> policy = Reference<IReplicationPolicy>(
-		    new PolicyAcross(teamSize, "zoneid", Reference<IReplicationPolicy>(new PolicyOne())));
+		Reference<IReplicationPolicy> policy = makeReference<PolicyAcross>(teamSize, "zoneid", makeReference<PolicyOne>());
 		std::unique_ptr<DDTeamCollection> collection = testMachineTeamCollection(teamSize, policy, processSize);
 
 		collection->addTeamsBestOf(30, desiredTeams, maxTeams);
@@ -6359,8 +6358,7 @@ public:
 		int desiredTeams = SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER * processSize;
 		int maxTeams = SERVER_KNOBS->MAX_TEAMS_PER_SERVER * processSize;
 
-		Reference<IReplicationPolicy> policy = Reference<IReplicationPolicy>(
-		    new PolicyAcross(teamSize, "zoneid", Reference<IReplicationPolicy>(new PolicyOne())));
+		Reference<IReplicationPolicy> policy = makeReference<PolicyAcross>(teamSize, "zoneid", makeReference<PolicyOne>());
 		std::unique_ptr<DDTeamCollection> collection = testMachineTeamCollection(teamSize, policy, processSize);
 
 		if (collection == nullptr) {
@@ -7155,7 +7153,7 @@ TEST_CASE("/DataDistribution/StorageWiggler/NextIdWithMinAge") {
 
 TEST_CASE("/DataDistribution/StorageWiggler/NextIdWithTSS") {
 	state std::unique_ptr<DDTeamCollection> collection =
-	    DDTeamCollectionUnitTest::testMachineTeamCollection(1, Reference<IReplicationPolicy>(new PolicyOne()), 5);
+	    DDTeamCollectionUnitTest::testMachineTeamCollection(1, makeReference<PolicyOne>(), 5);
 	state Reference<StorageWiggler> wiggler = makeReference<StorageWiggler>(collection.get());
 
 	std::cout << "Test when need TSS ... \n";

--- a/fdbserver/datadistributor/DataDistribution.cpp
+++ b/fdbserver/datadistributor/DataDistribution.cpp
@@ -2741,7 +2741,7 @@ Future<Void> dataDistribution(Reference<DataDistributor> self,
 	if (!isMocked) {
 		Database cx = openDBOnServer(self->dbInfo, TaskPriority::DataDistributionLaunch, LockAware::True);
 		cx->locationCacheSize = SERVER_KNOBS->DD_LOCATION_CACHE_SIZE;
-		self->txnProcessor = Reference<IDDTxnProcessor>(new DDTxnProcessor(cx));
+		self->txnProcessor = makeReference<DDTxnProcessor>(cx);
 	} else {
 		ASSERT(self->txnProcessor.isValid() && self->txnProcessor->isMocked());
 	}
@@ -4922,7 +4922,7 @@ Future<Void> doAuditLocationMetadata(Reference<DataDistributor> self,
 	int64_t cumulatedValidatedServerKeysNum = 0;
 	int64_t cumulatedValidatedKeyServersNum = 0;
 	Reference<IRateControl> rateLimiter =
-	    Reference<IRateControl>(new SpeedLimit(SERVER_KNOBS->AUDIT_STORAGE_RATE_PER_SERVER_MAX, 1));
+	    makeReference<SpeedLimit>(SERVER_KNOBS->AUDIT_STORAGE_RATE_PER_SERVER_MAX, 1);
 	int64_t remoteReadBytes = 0;
 	double lastRateLimiterWaitTime = 0;
 	double rateLimiterBeforeWaitTime = 0;

--- a/fdbserver/datadistributor/DataDistribution.cpp
+++ b/fdbserver/datadistributor/DataDistribution.cpp
@@ -4921,8 +4921,7 @@ Future<Void> doAuditLocationMetadata(Reference<DataDistributor> self,
 	KeyRangeRef rangeToRead;
 	int64_t cumulatedValidatedServerKeysNum = 0;
 	int64_t cumulatedValidatedKeyServersNum = 0;
-	Reference<IRateControl> rateLimiter =
-	    makeReference<SpeedLimit>(SERVER_KNOBS->AUDIT_STORAGE_RATE_PER_SERVER_MAX, 1);
+	Reference<IRateControl> rateLimiter = makeReference<SpeedLimit>(SERVER_KNOBS->AUDIT_STORAGE_RATE_PER_SERVER_MAX, 1);
 	int64_t remoteReadBytes = 0;
 	double lastRateLimiterWaitTime = 0;
 	double rateLimiterBeforeWaitTime = 0;

--- a/fdbserver/logsystem/LogSet.cpp
+++ b/fdbserver/logsystem/LogSet.cpp
@@ -72,7 +72,7 @@ void LogSet::populateSatelliteTagLocations(int logRouterTags, int oldLogRouterTa
 		used_servers.insert(std::make_pair(0, i));
 	}
 
-	Reference<LocalitySet> serverSet = Reference<LocalitySet>(new LocalityMap<std::pair<int, int>>());
+	Reference<LocalitySet> serverSet = makeReference<LocalityMap<std::pair<int, int>>>();
 	auto* serverMap = (LocalityMap<std::pair<int, int>>*)serverSet.getPtr();
 	std::vector<std::pair<int, int>> resultPairs;
 	for (int loc = 0; loc < satelliteTagLocations.size(); loc++) {
@@ -187,7 +187,7 @@ int LogSet::bestLocationFor(Tag tag) {
 void LogSet::updateLocalitySet(std::vector<LocalityData> const& localities) {
 	LocalityMap<int>* logServerMap;
 
-	logServerSet = Reference<LocalitySet>(new LocalityMap<int>());
+	logServerSet = makeReference<LocalityMap<int>>();
 	logServerMap = (LocalityMap<int>*)logServerSet.getPtr();
 
 	logEntryArray.clear();

--- a/fdbserver/storageserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver/storageserver.actor.cpp
@@ -3824,8 +3824,7 @@ Future<Void> auditStorageServerShardQ(StorageServer* data, AuditStorageRequest r
 	int retryCount = 0;
 	int64_t cumulatedValidatedLocalShardsNum = 0;
 	int64_t cumulatedValidatedServerKeysNum = 0;
-	Reference<IRateControl> rateLimiter =
-	    makeReference<SpeedLimit>(SERVER_KNOBS->AUDIT_STORAGE_RATE_PER_SERVER_MAX, 1);
+	Reference<IRateControl> rateLimiter = makeReference<SpeedLimit>(SERVER_KNOBS->AUDIT_STORAGE_RATE_PER_SERVER_MAX, 1);
 	int64_t remoteReadBytes = 0;
 	double startTime = now();
 	double lastRateLimiterWaitTime = 0;
@@ -4527,8 +4526,7 @@ Future<Void> auditRestoreQ(StorageServer* data, AuditStorageRequest req) {
 	int64_t lastPersistBytes = 0; // Track when we last persisted progress
 	bool complete = false;
 	double startTime = now();
-	Reference<IRateControl> rateLimiter =
-	    makeReference<SpeedLimit>(SERVER_KNOBS->AUDIT_STORAGE_RATE_PER_SERVER_MAX, 1);
+	Reference<IRateControl> rateLimiter = makeReference<SpeedLimit>(SERVER_KNOBS->AUDIT_STORAGE_RATE_PER_SERVER_MAX, 1);
 
 	{
 		Optional<Error> err;
@@ -4769,8 +4767,7 @@ Future<Void> auditStorageShardReplicaQ(StorageServer* data, AuditStorageRequest 
 	double lastRateLimiterWaitTime = 0;
 	double rateLimiterBeforeWaitTime = 0;
 	double rateLimiterTotalWaitTime = 0;
-	Reference<IRateControl> rateLimiter =
-	    makeReference<SpeedLimit>(SERVER_KNOBS->AUDIT_STORAGE_RATE_PER_SERVER_MAX, 1);
+	Reference<IRateControl> rateLimiter = makeReference<SpeedLimit>(SERVER_KNOBS->AUDIT_STORAGE_RATE_PER_SERVER_MAX, 1);
 	try {
 		while (true) {
 			{

--- a/fdbserver/storageserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver/storageserver.actor.cpp
@@ -3825,7 +3825,7 @@ Future<Void> auditStorageServerShardQ(StorageServer* data, AuditStorageRequest r
 	int64_t cumulatedValidatedLocalShardsNum = 0;
 	int64_t cumulatedValidatedServerKeysNum = 0;
 	Reference<IRateControl> rateLimiter =
-	    Reference<IRateControl>(new SpeedLimit(SERVER_KNOBS->AUDIT_STORAGE_RATE_PER_SERVER_MAX, 1));
+	    makeReference<SpeedLimit>(SERVER_KNOBS->AUDIT_STORAGE_RATE_PER_SERVER_MAX, 1);
 	int64_t remoteReadBytes = 0;
 	double startTime = now();
 	double lastRateLimiterWaitTime = 0;
@@ -4528,7 +4528,7 @@ Future<Void> auditRestoreQ(StorageServer* data, AuditStorageRequest req) {
 	bool complete = false;
 	double startTime = now();
 	Reference<IRateControl> rateLimiter =
-	    Reference<IRateControl>(new SpeedLimit(SERVER_KNOBS->AUDIT_STORAGE_RATE_PER_SERVER_MAX, 1));
+	    makeReference<SpeedLimit>(SERVER_KNOBS->AUDIT_STORAGE_RATE_PER_SERVER_MAX, 1);
 
 	{
 		Optional<Error> err;
@@ -4770,7 +4770,7 @@ Future<Void> auditStorageShardReplicaQ(StorageServer* data, AuditStorageRequest 
 	double rateLimiterBeforeWaitTime = 0;
 	double rateLimiterTotalWaitTime = 0;
 	Reference<IRateControl> rateLimiter =
-	    Reference<IRateControl>(new SpeedLimit(SERVER_KNOBS->AUDIT_STORAGE_RATE_PER_SERVER_MAX, 1));
+	    makeReference<SpeedLimit>(SERVER_KNOBS->AUDIT_STORAGE_RATE_PER_SERVER_MAX, 1);
 	try {
 		while (true) {
 			{

--- a/fdbserver/tester/test.cpp
+++ b/fdbserver/tester/test.cpp
@@ -459,7 +459,8 @@ Future<Void> initializeSimConfig(Database db, bool restartingTest) {
 			if (foundSharedDcId) {
 				int totalRequired = std::max(dbConfig.tLogReplicationFactor, dbConfig.remoteTLogReplicationFactor) +
 				                    maxSatelliteReplication;
-				setFDBSimulationPolicyRemoteTLogPolicy(makeReference<PolicyAcross>(totalRequired, "zoneid", makeReference<PolicyOne>()));
+				setFDBSimulationPolicyRemoteTLogPolicy(
+				    makeReference<PolicyAcross>(totalRequired, "zoneid", makeReference<PolicyOne>()));
 				TraceEvent("ChangingSimTLogPolicyForSharedRemote")
 				    .detail("TotalRequired", totalRequired)
 				    .detail("MaxSatelliteReplication", maxSatelliteReplication)

--- a/fdbserver/tester/test.cpp
+++ b/fdbserver/tester/test.cpp
@@ -459,8 +459,7 @@ Future<Void> initializeSimConfig(Database db, bool restartingTest) {
 			if (foundSharedDcId) {
 				int totalRequired = std::max(dbConfig.tLogReplicationFactor, dbConfig.remoteTLogReplicationFactor) +
 				                    maxSatelliteReplication;
-				setFDBSimulationPolicyRemoteTLogPolicy(Reference<IReplicationPolicy>(
-				    new PolicyAcross(totalRequired, "zoneid", Reference<IReplicationPolicy>(new PolicyOne()))));
+				setFDBSimulationPolicyRemoteTLogPolicy(makeReference<PolicyAcross>(totalRequired, "zoneid", makeReference<PolicyOne>()));
 				TraceEvent("ChangingSimTLogPolicyForSharedRemote")
 				    .detail("TotalRequired", totalRequired)
 				    .detail("MaxSatelliteReplication", maxSatelliteReplication)

--- a/fdbserver/tlog/TestTLogServer.cpp
+++ b/fdbserver/tlog/TestTLogServer.cpp
@@ -388,7 +388,7 @@ Future<Void> buildTLogSet(Reference<TLogTestContext> pTLogTestContext) {
 	TLogSet tLogSet;
 
 	tLogSet.tLogLocalities.push_back(LocalityData());
-	tLogSet.tLogPolicy = Reference<IReplicationPolicy>(new PolicyOne());
+	tLogSet.tLogPolicy = makeReference<PolicyOne>();
 	tLogSet.locality = pTLogTestContext->primaryLocality;
 	tLogSet.isLocal = true;
 	tLogSet.tLogVersion = TLogVersion::V6;

--- a/fdbserver/workloads/ApiWorkload.cpp
+++ b/fdbserver/workloads/ApiWorkload.cpp
@@ -57,8 +57,7 @@ Future<Void> ApiWorkload::clearKeyspace() {
 }
 
 Future<Void> setup(Database cx, ApiWorkload* self) {
-	self->transactionFactory = Reference<TransactionFactoryInterface>(
-	    new TransactionFactory<FlowTransactionWrapper<Transaction>, const Database>(cx, cx, false));
+	self->transactionFactory = makeReference<TransactionFactory<FlowTransactionWrapper<Transaction>, const Database>>(cx, cx, false);
 
 	// Clear keyspace before running
 	co_await timeoutError(self->clearKeyspace(), 600);
@@ -323,28 +322,22 @@ Future<Void> chooseTransactionFactory(Database cx, std::vector<TransactionType> 
 
 	if (transactionType == NATIVE) {
 		printf("client %d: Running NativeAPI Transactions\n", self->clientPrefixInt);
-		self->transactionFactory = Reference<TransactionFactoryInterface>(
-		    new TransactionFactory<FlowTransactionWrapper<Transaction>, const Database>(
-		        cx, self->extraDB, self->useExtraDB));
+		self->transactionFactory = makeReference<TransactionFactory<FlowTransactionWrapper<Transaction>, const Database>>(cx, self->extraDB, self->useExtraDB);
 	} else if (transactionType == READ_YOUR_WRITES) {
 		printf("client %d: Running ReadYourWrites Transactions\n", self->clientPrefixInt);
-		self->transactionFactory = Reference<TransactionFactoryInterface>(
-		    new TransactionFactory<FlowTransactionWrapper<ReadYourWritesTransaction>, const Database>(
-		        cx, self->extraDB, self->useExtraDB));
+		self->transactionFactory = makeReference<TransactionFactory<FlowTransactionWrapper<ReadYourWritesTransaction>, const Database>>(cx, self->extraDB, self->useExtraDB);
 	} else if (transactionType == THREAD_SAFE) {
 		printf("client %d: Running ThreadSafe Transactions\n", self->clientPrefixInt);
 		Reference<IDatabase> dbHandle =
 		    co_await unsafeThreadFutureToFuture(ThreadSafeDatabase::createFromExistingDatabase(cx));
-		self->transactionFactory = Reference<TransactionFactoryInterface>(
-		    new TransactionFactory<ThreadTransactionWrapper, Reference<IDatabase>>(dbHandle, dbHandle, false));
+		self->transactionFactory = makeReference<TransactionFactory<ThreadTransactionWrapper, Reference<IDatabase>>>(dbHandle, dbHandle, false);
 	} else if (transactionType == MULTI_VERSION) {
 		printf("client %d: Running Multi-Version Transactions\n", self->clientPrefixInt);
 		MultiVersionApi::api->selectApiVersion(cx->apiVersion.version());
 		Reference<IDatabase> threadSafeHandle =
 		    co_await unsafeThreadFutureToFuture(ThreadSafeDatabase::createFromExistingDatabase(cx));
 		Reference<IDatabase> dbHandle = MultiVersionDatabase::debugCreateFromExistingDatabase(threadSafeHandle);
-		self->transactionFactory = Reference<TransactionFactoryInterface>(
-		    new TransactionFactory<ThreadTransactionWrapper, Reference<IDatabase>>(dbHandle, dbHandle, false));
+		self->transactionFactory = makeReference<TransactionFactory<ThreadTransactionWrapper, Reference<IDatabase>>>(dbHandle, dbHandle, false);
 	}
 }
 

--- a/fdbserver/workloads/ApiWorkload.cpp
+++ b/fdbserver/workloads/ApiWorkload.cpp
@@ -57,7 +57,8 @@ Future<Void> ApiWorkload::clearKeyspace() {
 }
 
 Future<Void> setup(Database cx, ApiWorkload* self) {
-	self->transactionFactory = makeReference<TransactionFactory<FlowTransactionWrapper<Transaction>, const Database>>(cx, cx, false);
+	self->transactionFactory =
+	    makeReference<TransactionFactory<FlowTransactionWrapper<Transaction>, const Database>>(cx, cx, false);
 
 	// Clear keyspace before running
 	co_await timeoutError(self->clearKeyspace(), 600);
@@ -322,22 +323,28 @@ Future<Void> chooseTransactionFactory(Database cx, std::vector<TransactionType> 
 
 	if (transactionType == NATIVE) {
 		printf("client %d: Running NativeAPI Transactions\n", self->clientPrefixInt);
-		self->transactionFactory = makeReference<TransactionFactory<FlowTransactionWrapper<Transaction>, const Database>>(cx, self->extraDB, self->useExtraDB);
+		self->transactionFactory =
+		    makeReference<TransactionFactory<FlowTransactionWrapper<Transaction>, const Database>>(
+		        cx, self->extraDB, self->useExtraDB);
 	} else if (transactionType == READ_YOUR_WRITES) {
 		printf("client %d: Running ReadYourWrites Transactions\n", self->clientPrefixInt);
-		self->transactionFactory = makeReference<TransactionFactory<FlowTransactionWrapper<ReadYourWritesTransaction>, const Database>>(cx, self->extraDB, self->useExtraDB);
+		self->transactionFactory =
+		    makeReference<TransactionFactory<FlowTransactionWrapper<ReadYourWritesTransaction>, const Database>>(
+		        cx, self->extraDB, self->useExtraDB);
 	} else if (transactionType == THREAD_SAFE) {
 		printf("client %d: Running ThreadSafe Transactions\n", self->clientPrefixInt);
 		Reference<IDatabase> dbHandle =
 		    co_await unsafeThreadFutureToFuture(ThreadSafeDatabase::createFromExistingDatabase(cx));
-		self->transactionFactory = makeReference<TransactionFactory<ThreadTransactionWrapper, Reference<IDatabase>>>(dbHandle, dbHandle, false);
+		self->transactionFactory = makeReference<TransactionFactory<ThreadTransactionWrapper, Reference<IDatabase>>>(
+		    dbHandle, dbHandle, false);
 	} else if (transactionType == MULTI_VERSION) {
 		printf("client %d: Running Multi-Version Transactions\n", self->clientPrefixInt);
 		MultiVersionApi::api->selectApiVersion(cx->apiVersion.version());
 		Reference<IDatabase> threadSafeHandle =
 		    co_await unsafeThreadFutureToFuture(ThreadSafeDatabase::createFromExistingDatabase(cx));
 		Reference<IDatabase> dbHandle = MultiVersionDatabase::debugCreateFromExistingDatabase(threadSafeHandle);
-		self->transactionFactory = makeReference<TransactionFactory<ThreadTransactionWrapper, Reference<IDatabase>>>(dbHandle, dbHandle, false);
+		self->transactionFactory = makeReference<TransactionFactory<ThreadTransactionWrapper, Reference<IDatabase>>>(
+		    dbHandle, dbHandle, false);
 	}
 }
 

--- a/fdbserver/workloads/ApiWorkload.h
+++ b/fdbserver/workloads/ApiWorkload.h
@@ -259,7 +259,7 @@ struct TransactionFactory : public TransactionFactoryInterface {
 
 	// Creates a new transaction
 	Reference<TransactionWrapper> createTransaction() override {
-		return Reference<TransactionWrapper>(new T(dbHandle, extraDbHandle, useExtraDB));
+		return makeReference<T>(dbHandle, extraDbHandle, useExtraDB);
 	}
 };
 

--- a/fdbserver/workloads/ConsistencyCheckUrgent.cpp
+++ b/fdbserver/workloads/ConsistencyCheckUrgent.cpp
@@ -182,7 +182,7 @@ struct ConsistencyCheckUrgentWorkload : TestWorkload {
 
 		// Do consistency check shard by shard
 		Reference<IRateControl> rateLimiter =
-		    Reference<IRateControl>(new SpeedLimit(CLIENT_KNOBS->CONSISTENCY_CHECK_RATE_LIMIT_MAX, 1));
+		    makeReference<SpeedLimit>(CLIENT_KNOBS->CONSISTENCY_CHECK_RATE_LIMIT_MAX, 1);
 		KeyRangeMap<bool> failedRanges; // Used to collect failed ranges in the current checkDataConsistency
 		failedRanges.insert(allKeys, false); // Initialized with false and will set any failed range as true later
 		// Which will be used to start the next consistencyCheckEpoch of the checkDataConsistency

--- a/fdbserver/workloads/Throughput.cpp
+++ b/fdbserver/workloads/Throughput.cpp
@@ -334,38 +334,37 @@ struct ThroughputWorkload : TestWorkload {
 		double sweepDelay = getOption(options, "sweepDelay"_sr, 0);
 		double zeroPaddingRatio = getOption(options, "zeroPaddingRatio"_sr, 0.15);
 
-		auto AType = Reference<ITransactor>(new RWTransactor(getOption(options, "readsPerTransactionA"_sr, 10),
+		auto AType = makeReference<RWTransactor>(getOption(options, "readsPerTransactionA"_sr, 10),
 		                                                     getOption(options, "writesPerTransactionA"_sr, 0),
 		                                                     keyCount,
 		                                                     keyBytes,
 		                                                     minValueBytes,
 		                                                     maxValueBytes,
-		                                                     zeroPaddingRatio));
-		auto BType = Reference<ITransactor>(new RWTransactor(getOption(options, "readsPerTransactionB"_sr, 5),
+		                                                     zeroPaddingRatio);
+		auto BType = makeReference<RWTransactor>(getOption(options, "readsPerTransactionB"_sr, 5),
 		                                                     getOption(options, "writesPerTransactionB"_sr, 5),
 		                                                     keyCount,
 		                                                     keyBytes,
 		                                                     minValueBytes,
 		                                                     maxValueBytes,
-		                                                     zeroPaddingRatio));
+		                                                     zeroPaddingRatio);
 
 		if (sweepDuration > 0) {
-			op = Reference<ITransactor>(new SweepTransactor(sweepDuration, sweepDelay, AType, BType));
+			op = makeReference<SweepTransactor>(sweepDuration, sweepDelay, AType, BType);
 		} else {
-			op = Reference<ITransactor>(new ABTransactor(getOption(options, "alpha"_sr, 0.1), AType, BType));
+			op = makeReference<ABTransactor>(getOption(options, "alpha"_sr, 0.1), AType, BType);
 		}
 
 		double measureDelay = getOption(options, "measureDelay"_sr, 50.0);
 		double measureDuration = getOption(options, "measureDuration"_sr, 10.0);
-		multi->ms.push_back(Reference<IMeasurer>(new MeasureSinglePeriod(measureDelay, measureDuration)));
+		multi->ms.push_back(makeReference<MeasureSinglePeriod>(measureDelay, measureDuration));
 
 		double measurePeriod = getOption(options, "measurePeriod"_sr, 0.0);
 		std::vector<std::string> periodicMetrics =
 		    getOption(options, "measurePeriodicMetrics"_sr, std::vector<std::string>());
 		if (measurePeriod) {
 			ASSERT(!periodicMetrics.empty());
-			multi->ms.push_back(Reference<IMeasurer>(new MeasurePeriodically(
-			    measurePeriod, std::set<std::string>(periodicMetrics.begin(), periodicMetrics.end()))));
+			multi->ms.push_back(makeReference<MeasurePeriodically>(measurePeriod, std::set<std::string>(periodicMetrics.begin(), periodicMetrics.end())));
 		}
 
 		Pgain = getOption(options, "ProportionalGain"_sr, 0.1);

--- a/fdbserver/workloads/Throughput.cpp
+++ b/fdbserver/workloads/Throughput.cpp
@@ -335,19 +335,19 @@ struct ThroughputWorkload : TestWorkload {
 		double zeroPaddingRatio = getOption(options, "zeroPaddingRatio"_sr, 0.15);
 
 		auto AType = makeReference<RWTransactor>(getOption(options, "readsPerTransactionA"_sr, 10),
-		                                                     getOption(options, "writesPerTransactionA"_sr, 0),
-		                                                     keyCount,
-		                                                     keyBytes,
-		                                                     minValueBytes,
-		                                                     maxValueBytes,
-		                                                     zeroPaddingRatio);
+		                                         getOption(options, "writesPerTransactionA"_sr, 0),
+		                                         keyCount,
+		                                         keyBytes,
+		                                         minValueBytes,
+		                                         maxValueBytes,
+		                                         zeroPaddingRatio);
 		auto BType = makeReference<RWTransactor>(getOption(options, "readsPerTransactionB"_sr, 5),
-		                                                     getOption(options, "writesPerTransactionB"_sr, 5),
-		                                                     keyCount,
-		                                                     keyBytes,
-		                                                     minValueBytes,
-		                                                     maxValueBytes,
-		                                                     zeroPaddingRatio);
+		                                         getOption(options, "writesPerTransactionB"_sr, 5),
+		                                         keyCount,
+		                                         keyBytes,
+		                                         minValueBytes,
+		                                         maxValueBytes,
+		                                         zeroPaddingRatio);
 
 		if (sweepDuration > 0) {
 			op = makeReference<SweepTransactor>(sweepDuration, sweepDelay, AType, BType);
@@ -364,7 +364,8 @@ struct ThroughputWorkload : TestWorkload {
 		    getOption(options, "measurePeriodicMetrics"_sr, std::vector<std::string>());
 		if (measurePeriod) {
 			ASSERT(!periodicMetrics.empty());
-			multi->ms.push_back(makeReference<MeasurePeriodically>(measurePeriod, std::set<std::string>(periodicMetrics.begin(), periodicMetrics.end())));
+			multi->ms.push_back(makeReference<MeasurePeriodically>(
+			    measurePeriod, std::set<std::string>(periodicMetrics.begin(), periodicMetrics.end())));
 		}
 
 		Pgain = getOption(options, "ProportionalGain"_sr, 0.1);

--- a/flow/IThreadPool.cpp
+++ b/flow/IThreadPool.cpp
@@ -138,7 +138,7 @@ public:
 };
 
 Reference<IThreadPool> createGenericThreadPool(int stackSize, int pri) {
-	return Reference<IThreadPool>(new ThreadPool(stackSize, pri));
+	return makeReference<ThreadPool>(stackSize, pri);
 }
 
 thread_local IThreadPoolReceiver* ThreadPool::Thread::threadUserObject;

--- a/flow/Net2.cpp
+++ b/flow/Net2.cpp
@@ -2191,9 +2191,9 @@ Reference<IListener> Net2::listen(NetworkAddress localAddr) {
 	try {
 		if (localAddr.isTLS()) {
 			initTLS(ETLSInitState::LISTEN);
-			return Reference<IListener>(new SSLListener(reactor.ios, &this->sslContextVar, localAddr));
+			return makeReference<SSLListener>(reactor.ios, &this->sslContextVar, localAddr);
 		}
-		return Reference<IListener>(new Listener(reactor.ios, localAddr));
+		return makeReference<Listener>(reactor.ios, localAddr);
 	} catch (boost::system::system_error const& e) {
 		Error x;
 		if (e.code().value() == EADDRINUSE)

--- a/flow/Trace.cpp
+++ b/flow/Trace.cpp
@@ -325,7 +325,7 @@ public:
 		    issues));
 
 		if (g_network->isSimulated())
-			writer = Reference<IThreadPool>(new DummyThreadPool());
+			writer = makeReference<DummyThreadPool>();
 		else
 			writer = createGenericThreadPool();
 		writer->addThread(new WriterThread(barriers, logWriter, formatter), "fdb-trace-log");
@@ -682,17 +682,17 @@ bool traceFormatImpl(std::string& format) {
 	std::transform(format.begin(), format.end(), format.begin(), ::tolower);
 	if (format == "xml") {
 		if (!validate) {
-			g_traceLog.formatter = Reference<ITraceLogFormatter>(new XmlTraceLogFormatter());
+			g_traceLog.formatter = makeReference<XmlTraceLogFormatter>();
 		}
 		return true;
 	} else if (format == "json") {
 		if (!validate) {
-			g_traceLog.formatter = Reference<ITraceLogFormatter>(new JsonTraceLogFormatter());
+			g_traceLog.formatter = makeReference<JsonTraceLogFormatter>();
 		}
 		return true;
 	} else {
 		if (!validate) {
-			g_traceLog.formatter = Reference<ITraceLogFormatter>(new XmlTraceLogFormatter());
+			g_traceLog.formatter = makeReference<XmlTraceLogFormatter>();
 		}
 		return false;
 	}

--- a/flow/flow.cpp
+++ b/flow/flow.cpp
@@ -109,8 +109,8 @@ uint64_t debug_lastLoadBalanceResultEndpointToken = 0;
 bool noUnseed = false;
 
 void setThreadLocalDeterministicRandomSeed(uint64_t seed) {
-	seededRandom = Reference<IRandom>(new DeterministicRandom(seed, true));
-	seededDebugRandom = Reference<IRandom>(new DeterministicRandom(seed));
+	seededRandom = makeReference<DeterministicRandom>(seed, true);
+	seededDebugRandom = makeReference<DeterministicRandom>(seed);
 }
 
 Reference<IRandom> debugRandom() {
@@ -119,7 +119,7 @@ Reference<IRandom> debugRandom() {
 
 Reference<IRandom> deterministicRandom() {
 	if (!seededRandom) {
-		seededRandom = Reference<IRandom>(new DeterministicRandom(platform::getRandomSeed(), true));
+		seededRandom = makeReference<DeterministicRandom>(platform::getRandomSeed(), true);
 	}
 	return seededRandom;
 }
@@ -127,7 +127,7 @@ Reference<IRandom> deterministicRandom() {
 Reference<IRandom> nondeterministicRandom() {
 	static thread_local Reference<IRandom> random;
 	if (!random) {
-		random = Reference<IRandom>(new DeterministicRandom(platform::getRandomSeed()));
+		random = makeReference<DeterministicRandom>(platform::getRandomSeed());
 	}
 	return random;
 }


### PR DESCRIPTION
This change, implemented with AST-grep, makes `Reference` creations less verbose.