### PR TITLE
Fix ASAN shutdown leaks and gRPC use-after-return crash

### DIFF
--- a/contrib/lsan.suppressions
+++ b/contrib/lsan.suppressions
@@ -3,3 +3,14 @@
 
 # Not all incoming connections are cleanly shut down in client API tests
 leak:ConnectionReaderActorState
+
+# Peer objects in TransportData::peers are intentionally not freed at shutdown.
+# FlowTransport is allocated into a global slot and never deleted because its
+# destructor triggers actor cancellation cascades that access freed state.
+# Peer::Peer covers allocations during Peer construction (DDSketch, AsyncTrigger).
+# connectionKeeper and connectionMonitor cover Promise allocations made during
+# the Peer's lifetime that are leaked along with the Peer.
+leak:TransportData::getOrOpenPeer
+leak:Peer::Peer
+leak:connectionKeeper
+leak:connectionMonitor

--- a/fdbrpc/FlowGrpc.cpp
+++ b/fdbrpc/FlowGrpc.cpp
@@ -200,7 +200,7 @@ void GrpcServer::registerRoleServices(const UID& owner_id, const ServiceList& se
 	on_services_changed_.trigger();
 }
 
-Future<Void> GrpcServer::deregisterRoleServices(const UID& owner_id) {
+Future<Void> GrpcServer::deregisterRoleServices(UID owner_id) {
 	ASSERT(g_network->isOnMainThread());
 	co_await stopServer();
 	registered_services_.erase(owner_id);

--- a/fdbrpc/include/fdbrpc/FlowGrpc.h
+++ b/fdbrpc/include/fdbrpc/FlowGrpc.h
@@ -150,9 +150,9 @@ public:
 	void registerService(std::shared_ptr<grpc::Service> service);
 	void registerRoleServices(const UID& owner_id, const ServiceList& services);
 
-	// Removes services associated with given `owner_id` from the server. Returns future that is fulfilled onced the
+	// Removes services associated with given `owner_id` from the server. Returns future that is fulfilled once the
 	// services are no longer alive (however, server may not have restarted yet).
-	Future<Void> deregisterRoleServices(const UID& owner_id);
+	Future<Void> deregisterRoleServices(UID owner_id);
 	void deregisterRoleServicesSync(const UID& owner_id);
 
 	// Returns `true` if TLS is enabled.

--- a/fdbserver/worker/worker.actor.cpp
+++ b/fdbserver/worker/worker.actor.cpp
@@ -209,7 +209,7 @@ Future<Void> handleIOErrors(Future<Void> actor, IClosable* store, UID id, Future
 	return handleIOErrors(actor, storeError, id, onClosed);
 }
 
-Future<Void> deregisterGrpcService(const UID& id) {
+Future<Void> deregisterGrpcService(UID id) {
 #ifdef FLOW_GRPC_ENABLED
 	if (g_network->isSimulated()) {
 		return Void();


### PR DESCRIPTION
Two issues addressed:

1. LSan reports 4648+ bytes leaked per Peer object at shutdown in fdb_c_api_tester and unit_tests. FlowTransport is allocated into a global slot and never deleted; deleting it triggers actor cancellation cascades that access freed state. Add suppressions for the known shutdown-time Peer/DDSketch/connectionKeeper leaks.

2. GrpcServer::deregisterRoleServices() takes a const UID& then co_awaits stopServer(). The caller passes interf.id() which becomes a dangling reference after the coroutine suspends (the caller actor frame can be reclaimed). This causes a stack-use-after-return crash detected by ASAN, manifesting as a segfault in fdbcli during configure new. Fix by passing UID by value at both call sites.

`  20260511-165553-stack-034f0b9d67223a7a             compressed=True data_size=36949840 duration=5027086 ended=100000 fail=1 fail_fast=10 max_runs=100000 pass=99999 priority=100 remaining=0:00:00 runtime=0:59:35 sanity=False started=100000 submitted=20260511-165553 timeout=5400 username=stack`



Each nightly ASAN run has about 11 of these in ctest runs.... 


```

=================================================================
==20156==ERROR: LeakSanitizer: detected memory leaks

Indirect leak of 1672 byte(s) in 1 object(s) allocated from:
    #0 0x000000533a2c in malloc /tmp/llvm-project/compiler-rt/lib/asan/asan_malloc_linux.cpp:68:3
    #1 0x7f0d4b5984a3 in operator new(unsigned long) stdlib_new_delete.cpp
    #2 0x7f0d49e5061c in resize /usr/local/bin/../include/c++/v1/vector:1805:11
    #3 0x7f0d49e5061c in setBucketSize /codebuild/output/src41032683/src/github.com/apple/foundationdb/fdbrpc/include/fdbrpc/DDSketch.h:213:48
    #4 0x7f0d49e5061c in DDSketch<double>::DDSketch(double) /codebuild/output/src41032683/src/github.com/apple/foundationdb/fdbrpc/include/fdbrpc/DDSketch.h:226:9
    #5 0x7f0d4aae6ab3 in Peer::Peer(TransportData*, NetworkAddress const&) /codebuild/output/src41032683/src/github.com/apple/foundationdb/fdbrpc/FlowTransport.cpp:1057:5
    #6 0x7f0d4aae9758 in makeReference<Peer, TransportData *, const NetworkAddress &> /codebuild/output/src41032683/src/github.com/apple/foundationdb/flow/include/flow/FastRef.h:195:26
    #7 0x7f0d4aae9758 in TransportData::getOrOpenPeer(NetworkAddress const&, bool) /codebuild/output/src41032683/src/github.com/apple/foundationdb/fdbrpc/FlowTransport.cpp:1750:10
    #8 0x7f0d4aaee1c9 in FlowTransport::addPeerReference(Endpoint const&, bool) /codebuild/output/src41032683/src/github.com/apple/foundationdb/fdbrpc/FlowTransport.cpp:1897:31
    #9 0x7f0d49fcd79c in FlowReceiver /codebuild/output/src41032683/src/github.com/apple/foundationdb/fdbrpc/include/fdbrpc/fdbrpc.h:48:30
    #10 0x7f0d49fcd79c in NetNotifiedQueue<GetLeaderRequest, true>::NetNotifiedQueue(int, int, Endpoint const&) /codebuild/output/src41032683/src/github.com/apple/foundationdb/fdbrpc/include/fdbrpc/fdbrpc.h:701:43
    #11 0x7f0d49ec43cb in RequestStream /codebuild/output/src41032683/src/github.com/apple/foundationdb/fdbrpc/include/fdbrpc/fdbrpc.h:900:63
    #12 0x7f0d49ec43cb in ClientLeaderRegInterface::ClientLeaderRegInterface(NetworkAddress) /codebuild/output/src41032683/src/github.com/apple/foundationdb/fdbclient/MonitorLeader.cpp:474:5
    #13 0x7f0d49ee079a in monitorProxiesOneGeneration(Reference<IClusterConnectionRecord>, Reference<AsyncVar<ClientDBInfo>>, Reference<AsyncVar<Optional<ClientLeaderRegInterface>>>, MonitorLeaderInfo, Reference<ReferencedObject<Standalone<VectorRef<ClientVersionRef, (VecSerStrategy)0>>>>, Standalone<StringRef>, IsInternal) /codebuild/output/src41032683/src/github.com/apple/foundationdb/fdbclient/MonitorLeader.cpp:862:33
    #14 0x7f0d49eea1c6 in monitorProxies(Reference<AsyncVar<Reference<IClusterConnectionRecord>>>, Reference<AsyncVar<ClientDBInfo>>, Reference<AsyncVar<Optional<ClientLeaderRegInterface>>>, Reference<ReferencedObject<Standalone<VectorRef<ClientVersionRef, (VecSerStrategy)0>>>>, Standalone<StringRef>, IsInternal) /codebuild/output/src41032683/src/github.com/apple/foundationdb/fdbclient/MonitorLeader.cpp:991:7
    #15 0x7f0d491d78bf in Database::createDatabase(Reference<IClusterConnectionRecord>, int, IsInternal, LocalityData const&, DatabaseContext*) /codebuild/output/src41032683/src/github.com/apple/foundationdb/fdbclient/NativeAPI.actor.cpp:577:35
    #16 0x7f0d4a9d6ca0 in operator() /codebuild/output/src41032683/src/github.com/apple/foundationdb/fdbclient/ThreadSafeTransaction.cpp:148:4
    #17 0x7f0d4a9d6ca0 in a_body1cont1 /codebuild/output/src41032683/src/github.com/apple/foundationdb/flow/include/flow/ThreadHelper.actor.h:45:2
    #18 0x7f0d4a9d6ca0 in internal_thread_helper::DoOnMainThreadVoidActorState<ThreadSafeDatabase::ThreadSafeDatabase(ThreadSafeDatabase::ConnectionRecordType, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, int)::$_0, internal_thread_helper::DoOnMainThreadVoidActor<ThreadSafeDatabase::ThreadSafeDatabase(ThreadSafeDatabase::ConnectionRecordType, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, int)::$_0>>::a_body1when1(Void const&, int) /codebuild/output/src41032683/src/github.com/apple/foundationdb/build_output/flow/include/flow/ThreadHelper.actor.g.h.py_gen:130:15
    #19 0x7f0d4a9d647d in a_callback_fire /codebuild/output/src41032683/src/github.com/apple/foundationdb/build_output/flow/include/flow/ThreadHelper.actor.g.h.py_gen:155:4
    #20 0x7f0d4a9d647d in ActorCallback<internal_thread_helper::DoOnMainThreadVoidActor<ThreadSafeDatabase::ThreadSafeDatabase(ThreadSafeDatabase::ConnectionRecordType, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, int)::$_0>, 0, Void>::fire(Void const&) /codebuild/output/src41032683/src/github.com/apple/foundationdb/flow/include/flow/flow.h:1538:34
    #21 0x7f0d4b021cef in send<Void> /codebuild/output/src41032683/src/github.com/apple/foundationdb/flow/include/flow/flow.h:771:23
    #22 0x7f0d4b021cef in send<Void> /codebuild/output/src41032683/src/github.com/apple/foundationdb/flow/include/flow/flow.h:1094:8
    #23 0x7f0d4b021cef in operator() /codebuild/output/src41032683/src/github.com/apple/foundationdb/flow/Net2.cpp:292:12
    #24 0x7f0d4b021cef in N2::Net2::run() /codebuild/output/src41032683/src/github.com/apple/foundationdb/flow/Net2.cpp:1705:5
    #25 0x7f0d491e117a in runNetwork() /codebuild/output/src41032683/src/github.com/apple/foundationdb/fdbclient/NativeAPI.actor.cpp:942:13
    #26 0x7f0d4a9c3148 in ThreadSafeApi::runNetwork() /codebuild/output/src41032683/src/github.com/apple/foundationdb/fdbclient/ThreadSafeTransaction.cpp:559:3
    #27 0x7f0d4907fb86 in MultiVersionApi::runNetwork() /codebuild/output/src41032683/src/github.com/apple/foundationdb/fdbclient/MultiVersionTransaction.cpp:2373:21
    #28 0x7f0d48f53a1b in fdb_run_network /codebuild/output/src41032683/src/github.com/apple/foundationdb/bindings/c/fdb_c.cpp:166:45
    #29 0x00000062fab3 in operator() /codebuild/output/src41032683/src/github.com/apple/foundationdb/bindings/c/test/unit/unit_tests.cpp:2629:45
    #30 0x00000062fab3 in __invoke<(lambda at /codebuild/output/src41032683/src/github.com/apple/foundationdb/bindings/c/test/unit/unit_tests.cpp:2629:30)> /usr/local/bin/../include/c++/v1/__type_traits/invoke.h:149:25
    #31 0x00000062fab3 in __thread_execute<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, (lambda at /codebuild/output/src41032683/src/github.com/apple/foundationdb/bindings/c/test/unit/unit_tests.cpp:2629:30)> /usr/local/bin/../include/c++/v1/__thread/thread.h:192:3
    #32 0x00000062fab3 in void* std::__1::__thread_proxy[abi:ne190105]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, main::$_0>>(void*) /usr/local/bin/../include/c++/v1/__thread/thread.h:201:3
    #33 0x000000465a03 in asan_thread_start(void*) /tmp/llvm-project/compiler-rt/lib/asan/asan_interceptors.cpp:239:43

Indirect leak of 1672 byte(s) in 1 object(s) allocated from:
    #0 0x000000533a2c in malloc /tmp/llvm-project/compiler-rt/lib/asan/asan_malloc_linux.cpp:68:3
    #1 0x7f0d4b5984a3 in operator new(unsigned long) stdlib_new_delete.cpp
    #2 0x7f0d49e5061c in resize /usr/local/bin/../include/c++/v1/vector:1805:11
    #3 0x7f0d49e5061c in setBucketSize /codebuild/output/src41032683/src/github.com/apple/foundationdb/fdbrpc/include/fdbrpc/DDSketch.h:213:48
    #4 0x7f0d49e5061c in DDSketch<double>::DDSketch(double) /codebuild/output/src41032683/src/github.com/apple/foundationdb/fdbrpc/include/fdbrpc/DDSketch.h:226:9
    #5 0x7f0d4aae6828 in Peer::Peer(TransportData*, NetworkAddress const&) /codebuild/output/src41032683/src/github.com/apple/foundationdb/fdbrpc/FlowTransport.cpp:1053:5
    #6 0x7f0d4aae9758 in makeReference<Peer, TransportData *, const NetworkAddress &> /codebuild/output/src41032683/src/github.com/apple/foundationdb/flow/include/flow/FastRef.h:195:26
    #7 0x7f0d4aae9758 in TransportData::getOrOpenPeer(NetworkAddress const&, bool) /codebuild/output/src41032683/src/github.com/apple/foundationdb/fdbrpc/FlowTransport.cpp:1750:10
    #8 0x7f0d4aaee1c9 in FlowTransport::addPeerReference(Endpoint const&, bool) /codebuild/output/src41032683/src/github.com/apple/foundationdb/fdbrpc/FlowTransport.cpp:1897:31
    #9 0x7f0d49fcd79c in FlowReceiver /codebuild/output/src41032683/src/github.com/apple/foundationdb/fdbrpc/include/fdbrpc/fdbrpc.h:48:30
    #10 0x7f0d49fcd79c in NetNotifiedQueue<GetLeaderRequest, true>::NetNotifiedQueue(int, int, Endpoint const&) /codebuild/output/src41032683/src/github.com/apple/foundationdb/fdbrpc/include/fdbrpc/fdbrpc.h:701:43
    #11 0x7f0d49ec43cb in RequestStream /codebuild/output/src41032683/src/github.com/apple/foundationdb/fdbrpc/include/fdbrpc/fdbrpc.h:900:63
    #12 0x7f0d49ec43cb in ClientLeaderRegInterface::ClientLeaderRegInterface(NetworkAddress) /codebuild/output/src41032683/src/github.com/apple/foundationdb/fdbclient/MonitorLeader.cpp:474:5
    #13 0x7f0d49ee079a in monitorProxiesOneGeneration(Reference<IClusterConnectionRecord>, Reference<AsyncVar<ClientDBInfo>>, Reference<AsyncVar<Optional<ClientLeaderRegInterface>>>, MonitorLeaderInfo, Reference<ReferencedObject<Standalone<VectorRef<ClientVersionRef, (VecSerStrategy)0>>>>, Standalone<StringRef>, IsInternal) /codebuild/output/src41032683/src/github.com/apple/foundationdb/fdbclient/MonitorLeader.cpp:862:33
    #14 0x7f0d49eea1c6 in monitorProxies(Reference<AsyncVar<Reference<IClusterConnectionRecord>>>, Reference<AsyncVar<ClientDBInfo>>, Reference<AsyncVar<Optional<ClientLeaderRegInterface>>>, Reference<ReferencedObject<Standalone<VectorRef<ClientVersionRef, (VecSerStrategy)0>>>>, Standalone<StringRef>, IsInternal) /codebuild/output/src41032683/src/github.com/apple/foundationdb/fdbclient/MonitorLeader.cpp:991:7
    #15 0x7f0d491d78bf in Database::createDatabase(Reference<IClusterConnectionRecord>, int, IsInternal, LocalityData const&, DatabaseContext*) /codebuild/output/src41032683/src/github.com/apple/foundationdb/fdbclient/NativeAPI.actor.cpp:577:35
    #16 0x7f0d4a9d6ca0 in operator() /codebuild/output/src41032683/src/github.com/apple/foundationdb/fdbclient/ThreadSafeTransaction.cpp:148:4
    #17 0x7f0d4a9d6ca0 in a_body1cont1 /codebuild/output/src41032683/src/github.com/apple/foundationdb/flow/include/flow/ThreadHelper.actor.h:45:2
    #18 0x7f0d4a9d6ca0 in internal_thread_helper::DoOnMainThreadVoidActorState<ThreadSafeDatabase::ThreadSafeDatabase(ThreadSafeDatabase::ConnectionRecordType, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, int)::$_0, 


... etc.
```

