### PR TITLE
Convert key-backed actor headers to coroutines

### DIFF
--- a/fdbclient/include/fdbclient/KeyBackedRangeMap.actor.h
+++ b/fdbclient/include/fdbclient/KeyBackedRangeMap.actor.h
@@ -287,7 +287,6 @@ public:
 			kbt_debug("RANGEMAP updateRange set end\n");
 			self.kvMap.set(tr, end, original);
 		}
-
 	}
 
 	template <class Transaction>

--- a/fdbclient/include/fdbclient/KeyBackedRangeMap.actor.h
+++ b/fdbclient/include/fdbclient/KeyBackedRangeMap.actor.h
@@ -19,15 +19,9 @@
  */
 #pragma once
 
-#if defined(NO_INTELLISENSE) && !defined(FDBCLIENT_KEYBACKEDRANGEMAP_ACTOR_G_H)
-#define FDBCLIENT_KEYBACKEDRANGEMAP_ACTOR_G_H
-#include "fdbclient/KeyBackedRangeMap.actor.g.h"
-#elif !defined(FDBCLIENT_KEYBACKEDRANGEMAP_ACTOR_H)
-#define FDBCLIENT_KEYBACKEDRANGEMAP_ACTOR_H
-
 #include "flow/FastRef.h"
 #include "fdbclient/KeyBackedTypes.actor.h"
-#include "flow/actorcompiler.h" // This must be the last #include.
+#include "flow/CoroUtils.h"
 
 // A local in-memory representation of a KeyBackedRangeMap snapshot
 // It is invalid to look up a range in this map which not within the range of
@@ -132,19 +126,19 @@ public:
 	  : kvMap(prefix, trigger, valueCodec) {}
 
 	// Get the RangeValue for the range that contains key, if there is a begin and end in the map which contain key
-	ACTOR template <class Transaction>
+	template <class Transaction>
 	static Future<Optional<RangeValue>> getRangeForKey(KeyBackedRangeMap self,
 	                                                   Transaction tr,
 	                                                   KeyType key,
 	                                                   Snapshot snapshot = Snapshot::False) {
-		state Future<Optional<typename Map::KVType>> begin = self.kvMap.seekLessOrEqual(tr, key, snapshot);
-		state Future<Optional<typename Map::KVType>> end = self.kvMap.seekGreaterThan(tr, key, snapshot);
-		wait(success(begin) && success(end));
+		Future<Optional<typename Map::KVType>> begin = self.kvMap.seekLessOrEqual(tr, key, snapshot);
+		Future<Optional<typename Map::KVType>> end = self.kvMap.seekGreaterThan(tr, key, snapshot);
+		co_await (success(begin) && success(end));
 
 		if (begin.get().present() && end.get().present()) {
-			return RangeValue{ { begin.get()->key, end.get()->key }, begin.get()->value };
+			co_return RangeValue{ { begin.get()->key, end.get()->key }, begin.get()->value };
 		}
-		return Optional<RangeValue>();
+		co_return Optional<RangeValue>();
 	}
 
 	template <class Transaction>
@@ -158,7 +152,7 @@ public:
 	// the the range with the given value.
 	// Adjacent ranges that are identical will be coalesced in the update transaction.
 	// Since the transaction type may not be RYW, this method must take care to not rely on reading its own updates.
-	ACTOR template <class Transaction>
+	template <class Transaction>
 	static Future<Void> updateRangeActor(KeyBackedRangeMap self,
 	                                     Transaction tr,
 	                                     KeyType begin,
@@ -176,23 +170,23 @@ public:
 		//     can be removed, which is the case if its value matches the previous boundary's value
 		//   - compare the boundary after the last modified boundary to see if it can be removed because
 		//     its value matches the last modified boundary's value
-		Optional<typename Map::KVType> beginKV = wait(self.kvMap.seekLessThan(tr, begin));
-		state KeySelector rangeBegin = KeySelector::firstGreaterOrEqual(beginKV.present() ? beginKV->key : begin);
+		Optional<typename Map::KVType> beginKV = co_await self.kvMap.seekLessThan(tr, begin);
+		KeySelector rangeBegin = KeySelector::firstGreaterOrEqual(beginKV.present() ? beginKV->key : begin);
 
 		// rangeEnd is past end so the result will include end if it exists
-		state KeySelector rangeEnd = KeySelector::firstGreaterThan(end);
+		KeySelector rangeEnd = KeySelector::firstGreaterThan(end);
 
-		state int readSize = BUGGIFY ? 1 : 100000;
-		state Future<RangeResultType> boundariesFuture =
+		int readSize = BUGGIFY ? 1 : 100000;
+		Future<RangeResultType> boundariesFuture =
 		    self.kvMap.getRange(tr, rangeBegin, rangeEnd, GetRangeLimits(readSize));
 
 		// As we walk through the range boundaries, keep two values about the last visited boundary
-		state ValueType original; // value prior to modification
-		state Optional<ValueType> previous; // value after modification
+		ValueType original{}; // value prior to modification
+		Optional<ValueType> previous; // value after modification
 		// Indicates that begin has been either seen/updated or created.
-		state bool beginDone = false;
+		bool beginDone = false;
 		// Indicates that end was found
-		state bool endFound = false;
+		bool endFound = false;
 
 		// The results will contain
 		//   A) 0 or 1 key < begin    Use this to initialize previous.
@@ -200,9 +194,9 @@ public:
 		//                            Possibly delete it if update matches previous range.
 		//   C) >=0 keys > begin and < end   Update these, delete if they match previous
 		//   D) 0 or 1 key == end.  Delete this key if it matches previous. Set to default if it doesn't exist.
-		loop {
+		while (true) {
 			kbt_debug("RANGEMAP updateRange loop\n");
-			RangeResultType boundaries = wait(boundariesFuture);
+			RangeResultType boundaries = co_await boundariesFuture;
 			for (auto const& bv : boundaries.results) {
 				kbt_debug("RANGEMAP updateRange   result key={} value={}\n", bv.first, bv.second);
 				// Should never see a result past the end key
@@ -294,7 +288,6 @@ public:
 			self.kvMap.set(tr, end, original);
 		}
 
-		return Void();
 	}
 
 	template <class Transaction>
@@ -312,7 +305,7 @@ public:
 		}
 	}
 
-	ACTOR template <class Transaction>
+	template <class Transaction>
 	static Future<Reference<LocalSnapshot>> getSnapshotActor(KeyBackedRangeMap self,
 	                                                         Transaction tr,
 	                                                         KeyType begin,
@@ -322,20 +315,20 @@ public:
 		// The range read should start at KeySelector::lastLessOrEqual(begin) to get the range which covers begin.
 		// However this could touch a key outside of the map subspace which can lead to various errors.
 		// Use seekLessOrEqual() to find a begin key safely.
-		Optional<typename Map::KVType> beginKV = wait(self.kvMap.seekLessOrEqual(tr, begin));
-		state KeySelector rangeBegin = KeySelector::firstGreaterOrEqual(beginKV.present() ? beginKV->key : begin);
+		Optional<typename Map::KVType> beginKV = co_await self.kvMap.seekLessOrEqual(tr, begin);
+		KeySelector rangeBegin = KeySelector::firstGreaterOrEqual(beginKV.present() ? beginKV->key : begin);
 
 		// rangeEnd is past end so the result will include end if it exists
-		state KeySelector rangeEnd = KeySelector::firstGreaterThan(end);
+		KeySelector rangeEnd = KeySelector::firstGreaterThan(end);
 
-		state int readSize = BUGGIFY ? 1 : 100000;
-		state Future<RangeResultType> boundariesFuture =
+		int readSize = BUGGIFY ? 1 : 100000;
+		Future<RangeResultType> boundariesFuture =
 		    self.kvMap.getRange(tr, rangeBegin, rangeEnd, GetRangeLimits(readSize));
 
-		state Reference<LocalSnapshot> result = makeReference<LocalSnapshot>();
-		loop {
+		Reference<LocalSnapshot> result = makeReference<LocalSnapshot>();
+		while (true) {
 			kbt_debug("RANGEMAP snapshot loop\n");
-			RangeResultType boundaries = wait(boundariesFuture);
+			RangeResultType boundaries = co_await boundariesFuture;
 			for (auto const& bv : boundaries.results) {
 				result->map[bv.first] = bv.second;
 			}
@@ -360,7 +353,7 @@ public:
 		}
 
 		kbt_debug("RANGEMAP snapshot end\n");
-		return result;
+		co_return result;
 	}
 
 	// Return a LocalSnapshot of all ranges from the map which cover the range of begin through end.
@@ -380,7 +373,3 @@ public:
 private:
 	Map kvMap;
 };
-
-#include "flow/unactorcompiler.h"
-
-#endif

--- a/fdbclient/include/fdbclient/KeyBackedTypes.actor.h
+++ b/fdbclient/include/fdbclient/KeyBackedTypes.actor.h
@@ -20,12 +20,6 @@
 
 #pragma once
 
-#if defined(NO_INTELLISENSE) && !defined(FDBCLIENT_KEYBACKEDTYPES_ACTOR_G_H)
-#define FDBCLIENT_KEYBACKEDTYPES_ACTOR_G_H
-#include "fdbclient/KeyBackedTypes.actor.g.h"
-#elif !defined(FDBCLIENT_KEYBACKEDTYPES_ACTOR_H)
-#define FDBCLIENT_KEYBACKEDTYPES_ACTOR_H
-
 #include <utility>
 #include <vector>
 #include <ranges>
@@ -40,11 +34,10 @@
 #include "fdbclient/TupleVersionstamp.h"
 #include "flow/ObjectSerializer.h"
 #include "flow/Platform.h"
+#include "flow/CoroUtils.h"
 #include "flow/genericactors.actor.h"
 #include "flow/serialize.h"
 #include "flow/ThreadHelper.actor.h"
-
-#include "flow/actorcompiler.h" // This must be the last #include.
 
 #define KEYBACKEDTYPES_DEBUG 0
 #if KEYBACKEDTYPES_DEBUG || !defined(NO_INTELLISENSE)
@@ -280,21 +273,11 @@ public:
 		return holdWhile(watchFuture, safeThreadFutureToFuture(watchFuture));
 	}
 
-// Forward declaration of this static template actor does not work correctly, so this actor is forward declared
-// in a way that works for both compiling and in IDEs.
-#if defined(NO_INTELLISENSE)
 	template <class DB>
-	static Future<Version> onChangeActor(WatchableTrigger const& self,
-	                                     Reference<DB> const& db,
-	                                     Optional<Version> const& initialVersion,
-	                                     Promise<Version> const& watching);
-#else
-	ACTOR template <class DB>
 	static Future<Version> onChangeActor(WatchableTrigger self,
 	                                     Reference<DB> db,
 	                                     Optional<Version> initialVersion,
 	                                     Promise<Version> watching);
-#endif
 
 	// Watch the trigger until it changes.  The result will be ready when it is observed that the trigger value's
 	// version is greater than initialVersion, and the observed trigger value version will be returned.
@@ -314,42 +297,45 @@ public:
 	}
 };
 
-ACTOR template <class DB>
+template <class DB>
 Future<Version> WatchableTrigger::onChangeActor(WatchableTrigger self,
                                                 Reference<DB> db,
                                                 Optional<Version> initialVersion,
                                                 Promise<Version> watching) {
-	state Reference<typename DB::TransactionT> tr = db->createTransaction();
+	Reference<typename DB::TransactionT> tr = db->createTransaction();
 
-	loop {
+	while (true) {
 		if constexpr (can_set_transaction_options<DB>) {
 			db->setOptions(tr);
 		}
+		Error err;
 		try {
 			// If the initialVersion is not set yet, then initialize it with the read version
 			if (!initialVersion.present()) {
-				wait(store(initialVersion, safeThreadFutureToFuture(tr->getReadVersion())));
+				co_await store(initialVersion, safeThreadFutureToFuture(tr->getReadVersion()));
 			}
 			if (watching.canBeSet()) {
 				watching.send(*initialVersion);
 			}
 
 			// Get the trigger's latest value.
-			Optional<Versionstamp> currentVal = wait(self.get(tr));
+			Optional<Versionstamp> currentVal = co_await self.get(tr);
 
 			// If the trigger has a value and its version is > initialVersion then the trigger has fired so break
 			if (currentVal.present() && currentVal->version > *initialVersion) {
-				return currentVal->version;
+				co_return currentVal->version;
 			}
 
 			// Otherwise, watch the key and repeat the loop once the watch fires
-			state Future<Void> watch = self.watch(tr);
-			wait(safeThreadFutureToFuture(tr->commit()));
-			wait(watch);
+			Future<Void> watch = self.watch(tr);
+			co_await safeThreadFutureToFuture(tr->commit());
+			co_await watch;
 			tr->reset();
+			continue;
 		} catch (Error& e) {
-			wait(safeThreadFutureToFuture(tr->onError(e)));
+			err = e;
 		}
+		co_await safeThreadFutureToFuture(tr->onError(err));
 	}
 }
 
@@ -618,7 +604,7 @@ public:
 		}
 	}
 
-	ACTOR template <class Transaction>
+	template <class Transaction>
 	static Future<RangeResultType> getRangeActor(KeyBackedMap self,
 	                                             Transaction tr,
 	                                             KeySelector begin,
@@ -630,18 +616,18 @@ public:
 		          begin.pack(self.subspace.begin).toString(),
 		          end.pack(self.subspace.begin).toString());
 
-		state ::KeySelector ksBegin = begin.pack(self.subspace.begin);
-		state ::KeySelector ksEnd = end.pack(self.subspace.begin);
-		state typename transaction_future_type<Transaction, RangeResult>::type getRangeFuture =
+		::KeySelector ksBegin = begin.pack(self.subspace.begin);
+		::KeySelector ksEnd = end.pack(self.subspace.begin);
+		typename transaction_future_type<Transaction, RangeResult>::type getRangeFuture =
 		    tr->getRange(ksBegin, ksEnd, limits, snapshot, reverse);
 
 		// Since the getRange result must be filtered to keys within the map subspace, it is possible that the given
 		// TypedKeySelectors and GetRangeLimits yields a result in which no KV pairs are within the map subspace.  If
 		// this happens, we can't return any map KV pairs for the caller to base the next request on, so we will loop
 		// and continue with the next request here.
-		state RangeResultType rangeResult;
-		loop {
-			RangeResult kvs = wait(safeThreadFutureToFuture(getRangeFuture));
+		RangeResultType rangeResult{};
+		while (true) {
+			RangeResult kvs = co_await safeThreadFutureToFuture(getRangeFuture);
 			kbt_debug("MAP GETRANGE KeySelectors {} - {} results={} more={}\n",
 			          begin.pack(self.subspace.begin).toString(),
 			          end.pack(self.subspace.begin).toString(),
@@ -687,7 +673,7 @@ public:
 			getRangeFuture = tr->getRange(ksBegin, ksEnd, limits, snapshot, reverse);
 		}
 
-		return rangeResult;
+		co_return rangeResult;
 	}
 
 	// GetRange with typed KeySelectors
@@ -705,7 +691,7 @@ public:
 	// These operation can be accomplished using KeySelectors however they run the risk of touching keys outside of
 	// map subspace, which can cause problems if this touches an offline range or a key which is unreadable by range
 	// read operations due to having been modified with a version stamp operation in the current transaction.
-	ACTOR template <class Transaction>
+	template <class Transaction>
 	static Future<Optional<KVType>> seek(KeyBackedMap self,
 	                                     Transaction tr,
 	                                     KeyType query,
@@ -734,15 +720,15 @@ public:
 			end = self.subspace.end;
 		}
 
-		state typename transaction_future_type<Transaction, RangeResult>::type getRangeFuture =
+		typename transaction_future_type<Transaction, RangeResult>::type getRangeFuture =
 		    tr->getRange(KeyRangeRef(begin, end), 1, snapshot, Reverse{ lessThan });
 
-		RangeResult kvs = wait(safeThreadFutureToFuture(getRangeFuture));
+		RangeResult kvs = co_await safeThreadFutureToFuture(getRangeFuture);
 		if (kvs.empty()) {
-			return Optional<KVType>();
+			co_return Optional<KVType>();
 		}
 
-		return self.unpackKV(kvs.front());
+		co_return self.unpackKV(kvs.front());
 	}
 
 	template <class Transaction>
@@ -935,7 +921,7 @@ public:
 		                     }));
 	}
 
-	ACTOR template <class Transaction>
+	template <class Transaction>
 	static Future<RangeResultType> getRangeActor(KeyBackedSet self,
 	                                             Transaction tr,
 	                                             KeySelector begin,
@@ -947,18 +933,18 @@ public:
 		          begin.pack(self.subspace.begin).toString(),
 		          end.pack(self.subspace.begin).toString());
 
-		state ::KeySelector ksBegin = begin.pack(self.subspace.begin);
-		state ::KeySelector ksEnd = end.pack(self.subspace.begin);
-		state typename transaction_future_type<Transaction, RangeResult>::type getRangeFuture =
+		::KeySelector ksBegin = begin.pack(self.subspace.begin);
+		::KeySelector ksEnd = end.pack(self.subspace.begin);
+		typename transaction_future_type<Transaction, RangeResult>::type getRangeFuture =
 		    tr->getRange(ksBegin, ksEnd, limits, snapshot, reverse);
 
 		// Since the getRange result must be filtered to keys within the map subspace, it is possible that the given
 		// TypedKeySelectors and GetRangeLimits yields a result in which no KV pairs are within the map subspace.  If
 		// this happens, we can't return any map KV pairs for the caller to base the next request on, so we will loop
 		// and continue with the next request here.
-		state RangeResultType rangeResult;
-		loop {
-			RangeResult kvs = wait(safeThreadFutureToFuture(getRangeFuture));
+		RangeResultType rangeResult{};
+		while (true) {
+			RangeResult kvs = co_await safeThreadFutureToFuture(getRangeFuture);
 			kbt_debug("MAP GETRANGE KeySelectors {} - {} results={} more={}\n",
 			          begin.pack(self.subspace.begin).toString(),
 			          end.pack(self.subspace.begin).toString(),
@@ -1002,7 +988,7 @@ public:
 			getRangeFuture = tr->getRange(ksBegin, ksEnd, limits, snapshot, reverse);
 		}
 
-		return rangeResult;
+		co_return rangeResult;
 	}
 
 	// GetRange with typed KeySelectors
@@ -1020,7 +1006,7 @@ public:
 	// These operation can be accomplished using KeySelectors however they run the risk of touching keys outside of
 	// map subspace, which can cause problems if this touches an offline range or a key which is unreadable by range
 	// read operations due to having been modified with a version stamp operation in the current transaction.
-	ACTOR template <class Transaction>
+	template <class Transaction>
 	static Future<Optional<ValueType>> seek(KeyBackedSet self,
 	                                        Transaction tr,
 	                                        ValueType query,
@@ -1049,15 +1035,15 @@ public:
 			end = self.subspace.end;
 		}
 
-		state typename transaction_future_type<Transaction, RangeResult>::type getRangeFuture =
+		typename transaction_future_type<Transaction, RangeResult>::type getRangeFuture =
 		    tr->getRange(KeyRangeRef(begin, end), 1, snapshot, Reverse{ lessThan });
 
-		RangeResult kvs = wait(safeThreadFutureToFuture(getRangeFuture));
+		RangeResult kvs = co_await safeThreadFutureToFuture(getRangeFuture);
 		if (kvs.empty()) {
-			return Optional<ValueType>();
+			co_return Optional<ValueType>();
 		}
 
-		return self.unpackKey(kvs.front().key);
+		co_return self.unpackKey(kvs.front().key);
 	}
 
 	template <class Transaction>
@@ -1156,7 +1142,3 @@ public:
 	Subspace subspace;
 	WatchableTrigger trigger;
 };
-
-#include "flow/unactorcompiler.h"
-
-#endif


### PR DESCRIPTION
This PR uses the actor rewrite tool to convert `KeyBackedTypes.actor.h` and `KeyBackedRangeMap.actor.h` to standard coroutines. Validated with 10k Joshua tests.