### PR TITLE
Move `GlobalConfigRefresh*` definitions

### DIFF
--- a/fdbclient/include/fdbclient/CommitProxyInterface.h
+++ b/fdbclient/include/fdbclient/CommitProxyInterface.h
@@ -475,38 +475,6 @@ struct ExclusionSafetyCheckRequest {
 	}
 };
 
-struct GlobalConfigRefreshReply {
-	constexpr static FileIdentifier file_identifier = 12680327;
-	Arena arena;
-	Version version;
-	RangeResultRef result;
-
-	GlobalConfigRefreshReply() {}
-	GlobalConfigRefreshReply(Arena const& arena, Version version, RangeResultRef result)
-	  : arena(arena), version(version), result(result) {}
-
-	template <class Ar>
-	void serialize(Ar& ar) {
-		serializer(ar, result, version, arena);
-	}
-};
-
-struct GlobalConfigRefreshRequest {
-	constexpr static FileIdentifier file_identifier = 2828131;
-	Version lastKnown;
-	ReplyPromise<GlobalConfigRefreshReply> reply;
-
-	GlobalConfigRefreshRequest() {}
-	explicit GlobalConfigRefreshRequest(Version lastKnown) : lastKnown(lastKnown) {}
-
-	bool verify() const noexcept { return true; }
-
-	template <class Ar>
-	void serialize(Ar& ar) {
-		serializer(ar, lastKnown, reply);
-	}
-};
-
 struct SetThrottledShardReply {
 	constexpr static FileIdentifier file_identifier = 2828140;
 

--- a/fdbclient/include/fdbclient/GrvProxyInterface.h
+++ b/fdbclient/include/fdbclient/GrvProxyInterface.h
@@ -147,6 +147,38 @@ struct GetReadVersionRequest : TimedRequest {
 	}
 };
 
+struct GlobalConfigRefreshReply {
+	constexpr static FileIdentifier file_identifier = 12680327;
+	Arena arena;
+	Version version;
+	RangeResultRef result;
+
+	GlobalConfigRefreshReply() {}
+	GlobalConfigRefreshReply(Arena const& arena, Version version, RangeResultRef result)
+	  : arena(arena), version(version), result(result) {}
+
+	template <class Ar>
+	void serialize(Ar& ar) {
+		serializer(ar, result, version, arena);
+	}
+};
+
+struct GlobalConfigRefreshRequest {
+	constexpr static FileIdentifier file_identifier = 2828131;
+	Version lastKnown;
+	ReplyPromise<GlobalConfigRefreshReply> reply;
+
+	GlobalConfigRefreshRequest() {}
+	explicit GlobalConfigRefreshRequest(Version lastKnown) : lastKnown(lastKnown) {}
+
+	bool verify() const noexcept { return true; }
+
+	template <class Ar>
+	void serialize(Ar& ar) {
+		serializer(ar, lastKnown, reply);
+	}
+};
+
 // GrvProxy is proxy primarily specializing on serving GetReadVersion. It also
 // serves health metrics since it communicates with RateKeeper to gather health
 // information of the cluster, and handles proxied GlobalConfig requests.


### PR DESCRIPTION
The gcc build was consistently emitting warnings about these structs, and they belong with the GRV proxy interface, because that is where they are used. This PR fixes the warnings and improves separation of concerns.
