### PR TITLE
Expose Version Vector metrics to status json

### DIFF
--- a/fdbserver/grvproxy/GrvProxyServer.cpp
+++ b/fdbserver/grvproxy/GrvProxyServer.cpp
@@ -62,6 +62,8 @@ struct GrvProxyStats {
 	int systemGRVQueueSize;
 	int defaultGRVQueueSize;
 	int batchGRVQueueSize;
+	int versionVectorSize;
+	int versionVectorEncodedBytes;
 	double transactionRateAllowed;
 	double batchTransactionRateAllowed;
 	double transactionLimit;
@@ -125,10 +127,10 @@ struct GrvProxyStats {
 	    txnDefaultPriorityStartIn("TxnDefaultPriorityStartIn", cc),
 	    txnDefaultPriorityStartOut("TxnDefaultPriorityStartOut", cc), txnThrottled("TxnThrottled", cc),
 	    updatesFromRatekeeper("UpdatesFromRatekeeper", cc), leaseTimeouts("LeaseTimeouts", cc), systemGRVQueueSize(0),
-	    defaultGRVQueueSize(0), batchGRVQueueSize(0), transactionRateAllowed(0), batchTransactionRateAllowed(0),
-	    transactionLimit(0), batchTransactionLimit(0), percentageOfDefaultGRVQueueProcessed(0),
-	    percentageOfBatchGRVQueueProcessed(0), lastBatchQueueThrottled(false), lastDefaultQueueThrottled(false),
-	    batchThrottleStartTime(0.0), defaultThrottleStartTime(0.0),
+	    defaultGRVQueueSize(0), batchGRVQueueSize(0), versionVectorSize(0), versionVectorEncodedBytes(0),
+	    transactionRateAllowed(0), batchTransactionRateAllowed(0), transactionLimit(0), batchTransactionLimit(0),
+	    percentageOfDefaultGRVQueueProcessed(0), percentageOfBatchGRVQueueProcessed(0), lastBatchQueueThrottled(false),
+	    lastDefaultQueueThrottled(false), batchThrottleStartTime(0.0), defaultThrottleStartTime(0.0),
 	    defaultTxnGRVTimeInQueue("DefaultTxnGRVTimeInQueue",
 	                             id,
 	                             SERVER_KNOBS->LATENCY_METRICS_LOGGING_INTERVAL,
@@ -156,6 +158,10 @@ struct GrvProxyStats {
 		specialCounter(cc, "SystemGRVQueueSize", [this]() { return this->systemGRVQueueSize; });
 		specialCounter(cc, "DefaultGRVQueueSize", [this]() { return this->defaultGRVQueueSize; });
 		specialCounter(cc, "BatchGRVQueueSize", [this]() { return this->batchGRVQueueSize; });
+		if (SERVER_KNOBS->ENABLE_VERSION_VECTOR) {
+			specialCounter(cc, "VersionVectorSize", [this]() { return this->versionVectorSize; });
+			specialCounter(cc, "VersionVectorEncodedBytes", [this]() { return this->versionVectorEncodedBytes; });
+		}
 		specialCounter(
 		    cc, "SystemAndDefaultTxnRateAllowed", [this]() { return int64_t(this->transactionRateAllowed); });
 		specialCounter(
@@ -728,8 +734,9 @@ Future<GetReadVersionReply> getLiveCommittedVersion(std::vector<SpanContext> spa
 	grvProxyData->minKnownCommittedVersion =
 	    std::max(grvProxyData->minKnownCommittedVersion, repFromMaster.minKnownCommittedVersion);
 	if (SERVER_KNOBS->ENABLE_VERSION_VECTOR) {
-		// TODO add to "status json"
 		grvProxyData->ssVersionVectorCache.applyDelta(repFromMaster.ssVersionVectorDelta);
+		grvProxyData->stats.versionVectorSize = grvProxyData->ssVersionVectorCache.size();
+		grvProxyData->stats.versionVectorEncodedBytes = grvProxyData->ssVersionVectorCache.getEncodedSize();
 	}
 	grvProxyData->stats.grvGetCommittedVersionRpcDist->sampleSeconds(now() - grvConfirmEpochLive);
 	GetReadVersionReply rep;


### PR DESCRIPTION
* The problem: There was a lingering `TODO` in `GrvProxyServer.cpp` to expose the GRV proxy's Version Vector cache metrics to `status json`. Because this was missing, we had no way to monitor the size or the encoded bytes of the version vector cache when the `ENABLE_VERSION_VECTOR` knob is enabled, making it harder to observe telemetry on memory and network overhead.

 * The solution: Added two new counters, `versionVectorSize` and `versionVectorEncodedBytes`, to the `GrvProxyStats` structure. I registered these as `specialCounter`s so they are automatically pulled by the cluster controller and populated into `status json`. This registration is correctly guarded by the `SERVER_KNOBS->ENABLE_VERSION_VECTOR` flag. I also updated `getLiveCommittedVersion()` to actually populate these counters right after applying the version vector delta from the master.

* Testing done: Relying on standard FoundationDB simulation tests to exercise the GRV proxy path.

@renish-patel thanks for knocking this out.
