### PR TITLE
Fix bulkdump simulation failure

### DIFF
--- a/fdbserver/workloads/BulkDumping.cpp
+++ b/fdbserver/workloads/BulkDumping.cpp
@@ -493,17 +493,25 @@ struct BulkDumping : TestWorkload {
 		// Submit a bulk dump job
 		int oldBulkDumpMode = 0;
 		TraceEvent("BulkDumpingWorkLoad").detail("Phase", "Setting BulkDump Mode");
-		try {
-			oldBulkDumpMode = co_await timeoutError(setBulkDumpMode(cx, 1), modeSetTimeout); // Enable bulkDump
-			TraceEvent("BulkDumpingWorkLoad").detail("Phase", "BulkDump Mode Set").detail("OldMode", oldBulkDumpMode);
-		} catch (Error& e) {
-			if (e.code() == error_code_timed_out) {
-				TraceEvent(SevWarnAlways, "BulkDumpingWorkLoadSetDumpModeTimeout")
-				    .detail("TimeoutSeconds", modeSetTimeout);
-				throw;
+		double setDumpModeDeadline = now() + 300.0;
+		while (true) {
+			Error captured;
+			try {
+				oldBulkDumpMode = co_await timeoutError(setBulkDumpMode(cx, 1), modeSetTimeout); // Enable bulkDump
+				break;
+			} catch (Error& e) {
+				captured = e;
 			}
-			throw;
+			if (captured.code() != error_code_timed_out || now() >= setDumpModeDeadline) {
+				if (captured.code() == error_code_timed_out) {
+					TraceEvent(SevWarnAlways, "BulkDumpingWorkLoadSetDumpModeTimeout")
+					    .detail("TimeoutSeconds", modeSetTimeout);
+				}
+				throw captured;
+			}
+			co_await delay(1.0);
 		}
+		TraceEvent("BulkDumpingWorkLoad").detail("Phase", "BulkDump Mode Set").detail("OldMode", oldBulkDumpMode);
 		std::string dumpFolder = jobRoot.empty() ? simulationBulkDumpFolder : jobRoot;
 		BulkDumpState bulkDumpJob =
 		    createBulkDumpJob(bulkDumpJobRange, dumpFolder, BulkLoadType::SST, bulkLoadTransportMethod);
@@ -528,18 +536,26 @@ struct BulkDumping : TestWorkload {
 		TraceEvent("BulkDumpingWorkLoad")
 		    .detail("Phase", "Setting BulkLoad Mode")
 		    .detail("Job", bulkDumpJob.toString());
-		try {
-			oldBulkLoadMode = co_await timeoutError(setBulkLoadMode(cx, 1), modeSetTimeout); // Enable bulkLoad
-			TraceEvent("BulkDumpingWorkLoad").detail("Phase", "BulkLoad Mode Set").detail("OldMode", oldBulkLoadMode);
-		} catch (Error& e) {
-			if (e.code() == error_code_timed_out) {
-				TraceEvent(SevWarnAlways, "BulkDumpingWorkLoadSetModeTimeout")
-				    .detail("Job", bulkDumpJob.toString())
-				    .detail("TimeoutSeconds", modeSetTimeout);
-				throw;
+		double setLoadModeDeadline = now() + 300.0;
+		while (true) {
+			Error captured;
+			try {
+				oldBulkLoadMode = co_await timeoutError(setBulkLoadMode(cx, 1), modeSetTimeout); // Enable bulkLoad
+				break;
+			} catch (Error& e) {
+				captured = e;
 			}
-			throw;
+			if (captured.code() != error_code_timed_out || now() >= setLoadModeDeadline) {
+				if (captured.code() == error_code_timed_out) {
+					TraceEvent(SevWarnAlways, "BulkDumpingWorkLoadSetModeTimeout")
+					    .detail("Job", bulkDumpJob.toString())
+					    .detail("TimeoutSeconds", modeSetTimeout);
+				}
+				throw captured;
+			}
+			co_await delay(1.0);
 		}
+		TraceEvent("BulkDumpingWorkLoad").detail("Phase", "BulkLoad Mode Set").detail("OldMode", oldBulkLoadMode);
 		while (true) {
 			// We randomly injects the job cancellation when waiting for the job completion to test the job
 			// cancellation. If the job is cancelled, we should re-submit the job.

--- a/fdbserver/workloads/BulkDumping.cpp
+++ b/fdbserver/workloads/BulkDumping.cpp
@@ -53,7 +53,6 @@ struct BulkDumping : TestWorkload {
 
 	// Timeout configuration
 	double jobCompletionTimeout = 1800.0; // Timeout for waiting on bulk dump/load job completion
-	double modeSetTimeout = 60.0; // Timeout for setBulkLoadMode/setBulkDumpMode operations
 	double jobSubmitTimeout = 60.0; // Timeout for submitBulkDumpJob/submitBulkLoadJob operations
 
 	// This workload is not compatible with following workload because they will race in changing the DD mode
@@ -89,7 +88,6 @@ struct BulkDumping : TestWorkload {
 
 		// Initialize timeout options
 		jobCompletionTimeout = getOption(options, "jobCompletionTimeout"_sr, 1800.0);
-		modeSetTimeout = getOption(options, "modeSetTimeout"_sr, 60.0);
 		jobSubmitTimeout = getOption(options, "jobSubmitTimeout"_sr, 60.0);
 	}
 
@@ -493,23 +491,11 @@ struct BulkDumping : TestWorkload {
 		// Submit a bulk dump job
 		int oldBulkDumpMode = 0;
 		TraceEvent("BulkDumpingWorkLoad").detail("Phase", "Setting BulkDump Mode");
-		double setDumpModeDeadline = now() + 300.0;
-		while (true) {
-			Error captured;
-			try {
-				oldBulkDumpMode = co_await timeoutError(setBulkDumpMode(cx, 1), modeSetTimeout); // Enable bulkDump
-				break;
-			} catch (Error& e) {
-				captured = e;
-			}
-			if (captured.code() != error_code_timed_out || now() >= setDumpModeDeadline) {
-				if (captured.code() == error_code_timed_out) {
-					TraceEvent(SevWarnAlways, "BulkDumpingWorkLoadSetDumpModeTimeout")
-					    .detail("TimeoutSeconds", modeSetTimeout);
-				}
-				throw captured;
-			}
-			co_await delay(1.0);
+		try {
+			oldBulkDumpMode = co_await setBulkDumpMode(cx, 1); // Enable bulkDump
+		} catch (Error& e) {
+			TraceEvent(SevWarnAlways, "BulkDumpingWorkLoadSetDumpModeFailed").error(e);
+			throw;
 		}
 		TraceEvent("BulkDumpingWorkLoad").detail("Phase", "BulkDump Mode Set").detail("OldMode", oldBulkDumpMode);
 		std::string dumpFolder = jobRoot.empty() ? simulationBulkDumpFolder : jobRoot;
@@ -536,24 +522,13 @@ struct BulkDumping : TestWorkload {
 		TraceEvent("BulkDumpingWorkLoad")
 		    .detail("Phase", "Setting BulkLoad Mode")
 		    .detail("Job", bulkDumpJob.toString());
-		double setLoadModeDeadline = now() + 300.0;
-		while (true) {
-			Error captured;
-			try {
-				oldBulkLoadMode = co_await timeoutError(setBulkLoadMode(cx, 1), modeSetTimeout); // Enable bulkLoad
-				break;
-			} catch (Error& e) {
-				captured = e;
-			}
-			if (captured.code() != error_code_timed_out || now() >= setLoadModeDeadline) {
-				if (captured.code() == error_code_timed_out) {
-					TraceEvent(SevWarnAlways, "BulkDumpingWorkLoadSetModeTimeout")
-					    .detail("Job", bulkDumpJob.toString())
-					    .detail("TimeoutSeconds", modeSetTimeout);
-				}
-				throw captured;
-			}
-			co_await delay(1.0);
+		try {
+			oldBulkLoadMode = co_await setBulkLoadMode(cx, 1); // Enable bulkLoad
+		} catch (Error& e) {
+			TraceEvent(SevWarnAlways, "BulkDumpingWorkLoadSetLoadModeFailed")
+			    .error(e)
+			    .detail("Job", bulkDumpJob.toString());
+			throw;
 		}
 		TraceEvent("BulkDumpingWorkLoad").detail("Phase", "BulkLoad Mode Set").detail("OldMode", oldBulkLoadMode);
 		while (true) {


### PR DESCRIPTION
### Problem

  BulkDumpingWorkload sometimes fails in simulation with a timed_out error while trying to enable bulk-dump mode:

  TestFailure ErrorCode=1004 (timed_out) Reason="Error starting workload"
  BulkDumpingWorkLoadSetDumpModeTimeout TimeoutSeconds=60

#### What's happening

 When the workload starts, it calls setBulkDumpMode(cx, 1) to enable bulk-dump mode. This has to commit a transaction through a commit proxy.

 In the failing run, the cluster was in the middle of a recovery (a commit proxy had just died, TLogs were unavailable) when the workload started. The transaction couldn't go through while recovery was in progress, and the workload's 60-second timeout fired before the cluster came back. That's an environmental flake, not a real bug in bulk dumping.

 #### Fix
  Two places in fdbserver/workloads/BulkDumping.cpp get a simple retry loop:
  - Each attempt still has the same 60-second timeout as before.
  - If it times out, wait 1 second and try again.
  - Give up after 5 minutes total.
  - Any error that isn't timed_out fails the test immediately (unchanged).


 #### Why this is safe
  - The workload's job is to verify bulk dump/load round-trips data correctly. setBulkDumpMode is just setup — not the thing we're testing.
  - setBulkDumpMode is idempotent (reads the current mode, only writes if it's different), so retrying can't corrupt state.
  - The overall workload timeout is 15000s, so 5 minutes is well within budget.
  - Non-timeout errors still fail fast, so real bugs aren't masked.
  
  ### Testing
  Ran single failing tests/fast/BulkDumping.toml 100K times which was failing 3 times before the fix when run 100k
  
`  20260511-035017-akankshamahajan-34462800f0ef6018   compressed=True data_size=36966139 duration=1855714 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:04:36 sanity=False started=100000 stopped=20260511-045453 submitted=20260511-035017 timeout=5400 username=akankshamahajan`

100k on all the tests:
` 20260511-060509-ak_bulkdump-a40716b830df26db       compressed=True data_size=36950888 duration=4842198 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:09:23 sanity=False started=100000 stopped=20260511-071432 submitted=20260511-060509 timeout=5400 username=ak_bulkdump
`