### PR TITLE
Handle broken promises during shard metric reads

### DIFF
--- a/fdbserver/datadistributor/DDShardTracker.cpp
+++ b/fdbserver/datadistributor/DDShardTracker.cpp
@@ -1087,7 +1087,7 @@ Future<Void> fetchTopKShardMetrics_impl(DataDistributionTracker* self, GetTopKMe
 				for (auto t : self->shards->intersectingRanges(range)) {
 					auto& stats = t.value().stats;
 					if (!stats->get().present()) {
-						onChange = stats->onChange();
+						onChange = brokenPromiseToReady(stats->onChange());
 						break;
 					}
 					metrics += t.value().stats->get().get().metrics;
@@ -1153,7 +1153,7 @@ Future<Void> fetchShardMetrics_impl(DataDistributionTracker* self, GetMetricsReq
 			for (auto t : self->shards->intersectingRanges(req.keys)) {
 				auto& stats = t.value().stats;
 				if (!stats->get().present()) {
-					onChange = stats->onChange();
+					onChange = brokenPromiseToReady(stats->onChange());
 					break;
 				}
 				returnMetrics += t.value().stats->get().get().metrics;
@@ -1197,7 +1197,7 @@ Future<Void> fetchShardMetricsList_impl(DataDistributionTracker* self, GetMetric
 			for (auto t = beginIter; t != endIter; ++t) {
 				auto& stats = t.value().stats;
 				if (!stats->get().present()) {
-					onChange = stats->onChange();
+					onChange = brokenPromiseToReady(stats->onChange());
 					break;
 				}
 				result.push_back_deep(result.arena(),


### PR DESCRIPTION
This PR fixes a CI failure uncovered on https://github.com/apple/foundationdb/pull/13194.

Failure details:

- Test: `tests/fast/BulkLoading.toml`
- Buggify: On
- Seed 492476736
- Commit: 1b5ef8df16dd9b8adc810c1acf286166f5ed33f4

This test hit a segfault, because bulk-load shard splitting replaced shard metric trackers, while request-side metrics waiters continued to wait on old `stats->onChange` futures. This caused `createShardToBulkLoad` to continue working with torn-down shard state. The fix is to use a `brokenPromiseToReady` wrapper, swallowing the `broken_promise` errors. Thus, the request loop wakes up, looks at the current shard map again, and follows the new tracker instead of turning a routine shard-boundary replacement into a fatal DD failure.

Validated by rerunning the same test with the fix (it now passes).