### PR TITLE
Fix buggify check in `runTest`

### DIFF
--- a/fdbserver/tester/test.cpp
+++ b/fdbserver/tester/test.cpp
@@ -280,7 +280,7 @@ Future<bool> runTest(Database cx,
 
 		// Run the consistency check workload
 		if (spec.runConsistencyCheck) {
-			bool quiescent = g_network->isSimulated() ? !BUGGIFY : spec.waitForQuiescenceEnd;
+			bool quiescent = g_network->isSimulated() ? !isGeneralBuggifyEnabled() : spec.waitForQuiescenceEnd;
 			try {
 				if (quiescent) {
 					printf("Running urgent consistency check...\n");


### PR DESCRIPTION
`BUGGIFY` is not deterministic, it produces a random value with each invocation, whenever `isGeneralBuggifyEnabled()` is true. This PR fixes the check in `runTest` of whether buggification is enabled. This issue was uncovered in CI for https://github.com/apple/foundationdb/pull/13183:

- Test: `tests/fast/SidebandSingle.toml`
- Seed: 460166982
- Buggify: On
- Commit: `143ca0c242d01b267c08633fb915492cea79b544`

Validated by rerunning this test with the fix (it now passes).
