### PR TITLE
Simple generic actor coroutine conversions

### DIFF
--- a/flow/genericactors.actor.cpp
+++ b/flow/genericactors.actor.cpp
@@ -46,10 +46,9 @@ ACTOR Future<Void> anyTrue(std::vector<Reference<AsyncVar<bool>>> input, Referen
 	}
 }
 
-Future<Void> cancelOnly(std::vector<Future<Void>> futures) {
+Future<Void> cancelOnly([[maybe_unused]] std::vector<Future<Void>> futures) {
 	// We don't do anything with futures except hold them, we never return, but if we are cancelled we (naturally) drop
 	// the futures
-	(void)futures;
 	co_await Future<Void>(Never());
 }
 

--- a/flow/genericactors.actor.cpp
+++ b/flow/genericactors.actor.cpp
@@ -23,15 +23,13 @@
 #include "genericcoros.h"
 #include "flow/actorcompiler.h" // This must be the last #include.
 
-ACTOR Future<bool> allTrue(std::vector<Future<bool>> all) {
-	state int i = 0;
-	while (i != all.size()) {
-		bool r = wait(all[i]);
+Future<bool> allTrue(std::vector<Future<bool>> all) {
+	for (int i = 0; i != all.size(); ++i) {
+		bool r = co_await all[i];
 		if (!r)
-			return false;
-		i++;
+			co_return false;
 	}
-	return true;
+	co_return true;
 }
 
 ACTOR Future<Void> anyTrue(std::vector<Reference<AsyncVar<bool>>> input, Reference<AsyncVar<bool>> output) {
@@ -48,11 +46,11 @@ ACTOR Future<Void> anyTrue(std::vector<Reference<AsyncVar<bool>>> input, Referen
 	}
 }
 
-ACTOR Future<Void> cancelOnly(std::vector<Future<Void>> futures) {
+Future<Void> cancelOnly(std::vector<Future<Void>> futures) {
 	// We don't do anything with futures except hold them, we never return, but if we are cancelled we (naturally) drop
 	// the futures
-	wait(Never());
-	return Void();
+	(void)futures;
+	co_await Future<Void>(Never());
 }
 
 ACTOR Future<Void> timeoutWarningCollector(FutureStream<Void> input, double logDelay, const char* context, UID id) {
@@ -153,16 +151,13 @@ ACTOR Future<Void> returnIfTrue(Future<bool> f) {
 	throw internal_error();
 }
 
-ACTOR Future<Void> lowPriorityDelay(double waitTime) {
-	state int loopCount = 0;
-	state int totalLoops =
+Future<Void> lowPriorityDelay(double waitTime) {
+	int totalLoops =
 	    std::max<int>(waitTime / FLOW_KNOBS->LOW_PRIORITY_MAX_DELAY, FLOW_KNOBS->LOW_PRIORITY_DELAY_COUNT);
 
-	while (loopCount < totalLoops) {
-		wait(delay(waitTime / totalLoops, TaskPriority::Low));
-		loopCount++;
+	for (int loopCount = 0; loopCount < totalLoops; ++loopCount) {
+		co_await delay(waitTime / totalLoops, TaskPriority::Low);
 	}
-	return Void();
 }
 
 ACTOR Future<Void> delayAfterCleared(Reference<AsyncVar<bool>> condition, double time, TaskPriority taskID) {

--- a/flow/genericactors.actor.cpp
+++ b/flow/genericactors.actor.cpp
@@ -151,8 +151,7 @@ ACTOR Future<Void> returnIfTrue(Future<bool> f) {
 }
 
 Future<Void> lowPriorityDelay(double waitTime) {
-	int totalLoops =
-	    std::max<int>(waitTime / FLOW_KNOBS->LOW_PRIORITY_MAX_DELAY, FLOW_KNOBS->LOW_PRIORITY_DELAY_COUNT);
+	int totalLoops = std::max<int>(waitTime / FLOW_KNOBS->LOW_PRIORITY_MAX_DELAY, FLOW_KNOBS->LOW_PRIORITY_DELAY_COUNT);
 
 	for (int loopCount = 0; loopCount < totalLoops; ++loopCount) {
 		co_await delay(waitTime / totalLoops, TaskPriority::Low);

--- a/flow/include/flow/genericactors.actor.h
+++ b/flow/include/flow/genericactors.actor.h
@@ -862,7 +862,7 @@ Future<Void> setWhenDoneOrError(Future<Void> condition, Reference<AsyncVar<T>> v
 	return Void();
 }
 
-ACTOR Future<Void> lowPriorityDelay(double waitTime);
+Future<Void> lowPriorityDelay(double waitTime);
 
 // Delay after condition is cleared (i.e. equal to false).
 // If during delay, condition changes to true, wait till condition become false again, and repeat.
@@ -873,9 +873,9 @@ ACTOR Future<Void> delayAfterCleared(Reference<AsyncVar<bool>> condition,
 // Same as delayAfterCleared, but use lowPriorityDelay.
 ACTOR Future<Void> lowPriorityDelayAfterCleared(Reference<AsyncVar<bool>> condition, double time);
 
-Future<bool> allTrue(const std::vector<Future<bool>>& all);
+Future<bool> allTrue(std::vector<Future<bool>> all);
 Future<Void> anyTrue(std::vector<Reference<AsyncVar<bool>>> const& input, Reference<AsyncVar<bool>> const& output);
-Future<Void> cancelOnly(std::vector<Future<Void>> const& futures);
+Future<Void> cancelOnly(std::vector<Future<Void>> futures);
 Future<Void> timeoutWarningCollector(FutureStream<Void> const& input,
                                      double const& logDelay,
                                      const char* const& context,


### PR DESCRIPTION
This PR addresses some low-hanging fruit in `genericactors.actor.cpp`, as part of the larger coroutine migration
