### PR TITLE
Refactor `IPeekCursor` and fix `getMaxKnownVersion` bug

### DIFF
--- a/fdbserver/logrouter/LogRouter.cpp
+++ b/fdbserver/logrouter/LogRouter.cpp
@@ -364,7 +364,8 @@ Future<Void> LogRouterData::waitForVersionAndLog(Version ver) {
 	}
 }
 
-Future<Reference<IReplayPeekCursor>> LogRouterData::getPeekCursorData(Reference<IReplayPeekCursor> r, Version beginVersion) {
+Future<Reference<IReplayPeekCursor>> LogRouterData::getPeekCursorData(Reference<IReplayPeekCursor> r,
+                                                                      Version beginVersion) {
 	Reference<IReplayPeekCursor> result = r;
 	bool useSatellite = SERVER_KNOBS->LOG_ROUTER_PEEK_FROM_SATELLITES_PREFERRED;
 	uint32_t noPrimaryPeekLocation = 0;

--- a/fdbserver/logrouter/LogRouter.cpp
+++ b/fdbserver/logrouter/LogRouter.cpp
@@ -240,7 +240,7 @@ struct LogRouterData {
 	// recovery version.
 	Future<Void> pullAsyncData();
 
-	Future<Reference<IPeekCursor>> getPeekCursorData(Reference<IPeekCursor> r, Version beginVersion);
+	Future<Reference<IReplayPeekCursor>> getPeekCursorData(Reference<IReplayPeekCursor> r, Version beginVersion);
 
 	// Future<Void> logRouterPop(const TLogPopRequest& req);
 	Future<Void> cleanupPeekTrackers();
@@ -364,8 +364,8 @@ Future<Void> LogRouterData::waitForVersionAndLog(Version ver) {
 	}
 }
 
-Future<Reference<IPeekCursor>> LogRouterData::getPeekCursorData(Reference<IPeekCursor> r, Version beginVersion) {
-	Reference<IPeekCursor> result = r;
+Future<Reference<IReplayPeekCursor>> LogRouterData::getPeekCursorData(Reference<IReplayPeekCursor> r, Version beginVersion) {
+	Reference<IReplayPeekCursor> result = r;
 	bool useSatellite = SERVER_KNOBS->LOG_ROUTER_PEEK_FROM_SATELLITES_PREFERRED;
 	uint32_t noPrimaryPeekLocation = 0;
 
@@ -402,7 +402,7 @@ Future<Reference<IPeekCursor>> LogRouterData::getPeekCursorData(Reference<IPeekC
 				              .detail("LogID", result->getPrimaryPeekLocation())
 				              .trackLatest(eventCacheHolder->trackingKey);
 			          } else {
-				          result = Reference<IPeekCursor>();
+				          result = Reference<IReplayPeekCursor>();
 			          }
 			          logSystemChanged = logSystem->onChange();
 		          })
@@ -436,7 +436,7 @@ Future<Reference<IPeekCursor>> LogRouterData::getPeekCursorData(Reference<IPeekC
 }
 
 Future<Void> LogRouterData::pullAsyncData() {
-	Reference<IPeekCursor> r;
+	Reference<IReplayPeekCursor> r;
 	Version tagAt = version.get() + 1;
 	Version lastVer = 0;
 	std::vector<int> tags; // an optimization to avoid reallocating vector memory in every loop

--- a/fdbserver/logsystem/LogSystem.cpp
+++ b/fdbserver/logsystem/LogSystem.cpp
@@ -1163,11 +1163,11 @@ Reference<IPeekCursor> LogSystem::peek(UID dbgid,
 }
 
 Reference<IReplayPeekCursor> LogSystem::peekLocal(UID dbgid,
-                                            Tag tag,
-                                            Version begin,
-                                            Version end,
-                                            bool useMergePeekCursors,
-                                            int8_t peekLocality) {
+                                                  Tag tag,
+                                                  Version begin,
+                                                  Version end,
+                                                  bool useMergePeekCursors,
+                                                  int8_t peekLocality) {
 	if (tag.locality >= 0 || tag.locality == tagLocalitySpecial) {
 		peekLocality = tag.locality;
 	}
@@ -1453,9 +1453,9 @@ Reference<IPeekCursor> LogSystem::peekTxs(UID dbgid,
 }
 
 Reference<IReplayPeekCursor> LogSystem::peekSingle(UID dbgid,
-                                             Version begin,
-                                             Tag tag,
-                                             std::vector<std::pair<Version, Tag>> history) {
+                                                   Version begin,
+                                                   Tag tag,
+                                                   std::vector<std::pair<Version, Tag>> history) {
 	while (!history.empty() && begin >= history.back().first) {
 		history.pop_back();
 	}

--- a/fdbserver/logsystem/LogSystem.cpp
+++ b/fdbserver/logsystem/LogSystem.cpp
@@ -875,7 +875,7 @@ void LogSystem::resetBestServerIfNotLocked(
 	}
 }
 
-Reference<IPeekCursor> LogSystem::peekAll(UID dbgid, Version begin, Version end, Tag tag, bool parallelGetMore) {
+Reference<IReplayPeekCursor> LogSystem::peekAll(UID dbgid, Version begin, Version end, Tag tag, bool parallelGetMore) {
 	int bestSet = 0;
 	std::vector<Reference<LogSet>> localSets;
 	Version lastBegin = 0;
@@ -919,7 +919,7 @@ Reference<IPeekCursor> LogSystem::peekAll(UID dbgid, Version begin, Version end,
 		return makeReference<SetPeekCursor>(
 		    localSets, bestSet, bestServer, tag, begin, end, parallelGetMore, bestKnownLockedTLogIds);
 	} else {
-		std::vector<Reference<IPeekCursor>> cursors;
+		std::vector<Reference<IReplayPeekCursor>> cursors;
 		std::vector<LogMessageVersion> epochEnds;
 
 		if (lastBegin < end && !localSets.empty()) {
@@ -1010,7 +1010,7 @@ Reference<IPeekCursor> LogSystem::peekAll(UID dbgid, Version begin, Version end,
 			}
 		}
 
-		return makeReference<MultiCursor>(cursors, epochEnds);
+		return makeReference<ReplayMultiCursor>(cursors, epochEnds);
 	}
 }
 
@@ -1162,7 +1162,7 @@ Reference<IPeekCursor> LogSystem::peek(UID dbgid,
 	return makeReference<BufferedCursor>(cursors, begin, end.present() ? end.get() + 1 : getPeekEnd(), true, false);
 }
 
-Reference<IPeekCursor> LogSystem::peekLocal(UID dbgid,
+Reference<IReplayPeekCursor> LogSystem::peekLocal(UID dbgid,
                                             Tag tag,
                                             Version begin,
                                             Version end,
@@ -1237,7 +1237,7 @@ Reference<IPeekCursor> LogSystem::peekLocal(UID dbgid,
 			    tLogs[bestSet]->logServers[tLogs[bestSet]->bestLocationFor(tag)], tag, begin, end, false, false);
 		}
 	} else {
-		std::vector<Reference<IPeekCursor>> cursors;
+		std::vector<Reference<IReplayPeekCursor>> cursors;
 		std::vector<LogMessageVersion> epochEnds;
 
 		if (tLogs[bestSet]->startVersion < end) {
@@ -1373,7 +1373,7 @@ Reference<IPeekCursor> LogSystem::peekLocal(UID dbgid,
 			}
 		}
 
-		return makeReference<MultiCursor>(cursors, epochEnds);
+		return makeReference<ReplayMultiCursor>(cursors, epochEnds);
 	}
 }
 
@@ -1401,7 +1401,7 @@ Reference<IPeekCursor> LogSystem::peekTxs(UID dbgid,
 	}
 
 	if (peekLocality < 0 || localEnd == invalidVersion || localEnd <= begin) {
-		std::vector<Reference<IPeekCursor>> cursors;
+		std::vector<Reference<IReplayPeekCursor>> cursors;
 		cursors.reserve(maxTxsTags);
 		for (int i = 0; i < maxTxsTags; i++) {
 			cursors.push_back(peekAll(dbgid, begin, end, Tag(tagLocalityTxs, i), true));
@@ -1412,7 +1412,7 @@ Reference<IPeekCursor> LogSystem::peekTxs(UID dbgid,
 
 	try {
 		if (localEnd >= end) {
-			std::vector<Reference<IPeekCursor>> cursors;
+			std::vector<Reference<IReplayPeekCursor>> cursors;
 			cursors.reserve(maxTxsTags);
 			for (int i = 0; i < maxTxsTags; i++) {
 				cursors.push_back(peekLocal(dbgid, Tag(tagLocalityTxs, i), begin, end, true, peekLocality));
@@ -1426,8 +1426,8 @@ Reference<IPeekCursor> LogSystem::peekTxs(UID dbgid,
 
 		cursors.resize(2);
 
-		std::vector<Reference<IPeekCursor>> localCursors;
-		std::vector<Reference<IPeekCursor>> allCursors;
+		std::vector<Reference<IReplayPeekCursor>> localCursors;
+		std::vector<Reference<IReplayPeekCursor>> allCursors;
 		for (int i = 0; i < maxTxsTags; i++) {
 			localCursors.push_back(peekLocal(dbgid, Tag(tagLocalityTxs, i), begin, localEnd, true, peekLocality));
 			allCursors.push_back(peekAll(dbgid, localEnd, end, Tag(tagLocalityTxs, i), true));
@@ -1440,7 +1440,7 @@ Reference<IPeekCursor> LogSystem::peekTxs(UID dbgid,
 		return makeReference<MultiCursor>(cursors, epochEnds);
 	} catch (Error& e) {
 		if (e.code() == error_code_worker_removed) {
-			std::vector<Reference<IPeekCursor>> cursors;
+			std::vector<Reference<IReplayPeekCursor>> cursors;
 			cursors.reserve(maxTxsTags);
 			for (int i = 0; i < maxTxsTags; i++) {
 				cursors.push_back(peekAll(dbgid, begin, end, Tag(tagLocalityTxs, i), true));
@@ -1452,7 +1452,7 @@ Reference<IPeekCursor> LogSystem::peekTxs(UID dbgid,
 	}
 }
 
-Reference<IPeekCursor> LogSystem::peekSingle(UID dbgid,
+Reference<IReplayPeekCursor> LogSystem::peekSingle(UID dbgid,
                                              Version begin,
                                              Tag tag,
                                              std::vector<std::pair<Version, Tag>> history) {
@@ -1464,7 +1464,7 @@ Reference<IPeekCursor> LogSystem::peekSingle(UID dbgid,
 		TraceEvent("TLogPeekSingleNoHistory", dbgid).detail("Tag", tag.toString()).detail("Begin", begin);
 		return peekLocal(dbgid, tag, begin, getPeekEnd(), false);
 	} else {
-		std::vector<Reference<IPeekCursor>> cursors;
+		std::vector<Reference<IReplayPeekCursor>> cursors;
 		std::vector<LogMessageVersion> epochEnds;
 
 		TraceEvent("TLogPeekSingleAddingLocal", dbgid).detail("Tag", tag.toString()).detail("Begin", history[0].first);
@@ -1484,11 +1484,11 @@ Reference<IPeekCursor> LogSystem::peekSingle(UID dbgid,
 			epochEnds.emplace_back(history[i].first);
 		}
 
-		return makeReference<MultiCursor>(cursors, epochEnds);
+		return makeReference<ReplayMultiCursor>(cursors, epochEnds);
 	}
 }
 
-Reference<IPeekCursor> LogSystem::peekLogRouter(
+Reference<IReplayPeekCursor> LogSystem::peekLogRouter(
     UID dbgid,
     Version begin,
     Tag tag,

--- a/fdbserver/logsystem/LogSystemPeekCursor.cpp
+++ b/fdbserver/logsystem/LogSystemPeekCursor.cpp
@@ -99,8 +99,12 @@ ServerPeekCursor::ServerPeekCursor(TLogPeekReply const& results,
 	advanceTo(messageVersion);
 }
 
-Reference<IPeekCursor> ServerPeekCursor::cloneNoMore() {
+Reference<ServerPeekCursor> ServerPeekCursor::cloneServerNoMore() {
 	return makeReference<ServerPeekCursor>(results, messageVersion, end, messageAndTags, hasMsg, poppedVersion, tag);
+}
+
+Reference<IReplayPeekCursor> ServerPeekCursor::cloneNoMore() {
+	return cloneServerNoMore();
 }
 
 void ServerPeekCursor::setProtocolVersion(ProtocolVersion version) {
@@ -658,7 +662,42 @@ static bool canReturnEmptyVersionRange(
 	return false;
 }
 
-MergedPeekCursor::MergedPeekCursor(std::vector<Reference<IPeekCursor>> const& serverCursors, Version begin)
+template <class SelectMessageVersion, class AdvanceAllCursors>
+static bool updateMergedPeekMessage(std::vector<Reference<ServerPeekCursor>>& candidateCursors,
+                                    Optional<LogMessageVersion> const& nextVersion,
+                                    std::vector<std::pair<LogMessageVersion, int>>& sortedVersions,
+                                    LogMessageVersion& messageVersion,
+                                    int& currentCursor,
+                                    SelectMessageVersion selectMessageVersion,
+                                    AdvanceAllCursors advanceAllCursors) {
+	while (true) {
+		sortedVersions.clear();
+		for (int i = 0; i < candidateCursors.size(); i++) {
+			auto& candidateCursor = candidateCursors[i];
+			if (nextVersion.present()) {
+				candidateCursor->advanceTo(nextVersion.get());
+			}
+			sortedVersions.emplace_back(candidateCursor->version(), i);
+		}
+
+		selectMessageVersion(sortedVersions, messageVersion);
+		if (!advanceAllCursors(messageVersion)) {
+			break;
+		}
+	}
+
+	for (int i = 0; i < candidateCursors.size(); i++) {
+		auto& candidateCursor = candidateCursors[i];
+		ASSERT_WE_THINK(!candidateCursor->hasMessage() || candidateCursor->version() >= messageVersion);
+		if (candidateCursor->version() == messageVersion && candidateCursor->hasMessage()) {
+			currentCursor = i;
+			return true;
+		}
+	}
+	return false;
+}
+
+MergedPeekCursor::MergedPeekCursor(std::vector<Reference<ServerPeekCursor>> const& serverCursors, Version begin)
   : serverCursors(serverCursors), tag(invalidTag), bestServer(-1), currentCursor(0), readQuorum(serverCursors.size()),
     messageVersion(begin), hasNextMessage(false), randomID(deterministicRandom()->randomUniqueID()),
     tLogReplicationFactor(0) {
@@ -704,7 +743,7 @@ MergedPeekCursor::MergedPeekCursor(std::vector<Reference<AsyncVar<OptionalInterf
 	sortedVersions.resize(serverCursors.size());
 }
 
-MergedPeekCursor::MergedPeekCursor(std::vector<Reference<IPeekCursor>> const& serverCursors,
+MergedPeekCursor::MergedPeekCursor(std::vector<Reference<ServerPeekCursor>> const& serverCursors,
                                    LogMessageVersion const& messageVersion,
                                    int bestServer,
                                    int readQuorum,
@@ -718,10 +757,10 @@ MergedPeekCursor::MergedPeekCursor(std::vector<Reference<IPeekCursor>> const& se
 	calcHasMessage();
 }
 
-Reference<IPeekCursor> MergedPeekCursor::cloneNoMore() {
-	std::vector<Reference<IPeekCursor>> cursors;
+Reference<IReplayPeekCursor> MergedPeekCursor::cloneNoMore() {
+	std::vector<Reference<ServerPeekCursor>> cursors;
 	for (auto it : serverCursors) {
-		cursors.push_back(it->cloneNoMore());
+		cursors.push_back(it->cloneServerNoMore());
 	}
 	return makeReference<MergedPeekCursor>(
 	    cursors, messageVersion, bestServer, readQuorum, nextVersion, logSet, tLogReplicationFactor);
@@ -775,59 +814,44 @@ void MergedPeekCursor::calcHasMessage() {
 }
 
 void MergedPeekCursor::updateMessage(bool usePolicy) {
-	while (true) {
-		bool advancedPast = false;
-		sortedVersions.clear();
-		for (int i = 0; i < serverCursors.size(); i++) {
-			auto& serverCursor = serverCursors[i];
-			if (nextVersion.present()) {
-				serverCursor->advanceTo(nextVersion.get());
-			}
-			sortedVersions.push_back(std::pair<LogMessageVersion, int>(serverCursor->version(), i));
-		}
-
+	auto selectMessageVersion = [&](auto& versions, LogMessageVersion& selectedVersion) {
 		if (usePolicy) {
 			ASSERT(logSet->tLogPolicy);
-			std::sort(sortedVersions.begin(), sortedVersions.end());
+			std::sort(versions.begin(), versions.end());
 
 			locations.clear();
-			for (auto sortedVersion : sortedVersions) {
+			for (auto sortedVersion : versions) {
 				locations.push_back(logSet->logEntryArray[sortedVersion.second]);
 				if (locations.size() >= tLogReplicationFactor && logSet->satisfiesPolicy(locations)) {
-					messageVersion = sortedVersion.first;
+					selectedVersion = sortedVersion.first;
 					break;
 				}
 			}
 		} else {
-			std::nth_element(sortedVersions.begin(), sortedVersions.end() - readQuorum, sortedVersions.end());
-			messageVersion = sortedVersions[sortedVersions.size() - readQuorum].first;
+			std::nth_element(versions.begin(), versions.end() - readQuorum, versions.end());
+			selectedVersion = versions[versions.size() - readQuorum].first;
 		}
-
-		for (int i = 0; i < serverCursors.size(); i++) {
-			auto& c = serverCursors[i];
-			auto start = c->version();
-			c->advanceTo(messageVersion);
-			if (start <= messageVersion && messageVersion < c->version()) {
+	};
+	auto advanceAllCursors = [&](LogMessageVersion const& selectedVersion) {
+		bool advancedPast = false;
+		for (auto& cursor : serverCursors) {
+			auto start = cursor->version();
+			cursor->advanceTo(selectedVersion);
+			if (start <= selectedVersion && selectedVersion < cursor->version()) {
 				advancedPast = true;
 				CODE_PROBE(true, "Merge peek cursor advanced past desired sequence", probe::decoration::rare);
 			}
 		}
+		return advancedPast;
+	};
 
-		if (!advancedPast) {
-			break;
-		}
-	}
-
-	for (int i = 0; i < serverCursors.size(); i++) {
-		auto& c = serverCursors[i];
-		ASSERT_WE_THINK(!c->hasMessage() ||
-		                c->version() >= messageVersion); // Seems like the loop above makes this unconditionally true
-		if (c->version() == messageVersion && c->hasMessage()) {
-			hasNextMessage = true;
-			currentCursor = i;
-			break;
-		}
-	}
+	hasNextMessage = updateMergedPeekMessage(serverCursors,
+	                                         nextVersion,
+	                                         sortedVersions,
+	                                         messageVersion,
+	                                         currentCursor,
+	                                         selectMessageVersion,
+	                                         advanceAllCursors);
 }
 
 bool MergedPeekCursor::hasMessage() const {
@@ -870,7 +894,8 @@ void MergedPeekCursor::advanceTo(LogMessageVersion n) {
 Future<Void> mergedPeekGetMore(MergedPeekCursor* self, LogMessageVersion startVersion, TaskPriority taskID) {
 	while (true) {
 		//TraceEvent("MPC_GetMoreA", self->randomID).detail("Start", startVersion.toString());
-		if (self->bestServer >= 0 && self->serverCursors[self->bestServer]->isActive()) {
+		if (self->bestServer >= 0 &&
+		    self->serverCursors[self->bestServer]->isActive()) {
 			ASSERT(!self->serverCursors[self->bestServer]->hasMessage());
 			co_await (self->serverCursors[self->bestServer]->getMore(taskID) ||
 			          self->serverCursors[self->bestServer]->onFailed());
@@ -915,16 +940,6 @@ Future<Void> MergedPeekCursor::getMore(TaskPriority taskID) {
 
 	more = mergedPeekGetMore(this, startVersion, taskID);
 	return more;
-}
-
-Future<Void> MergedPeekCursor::onFailed() const {
-	ASSERT(false);
-	return Never();
-}
-
-bool MergedPeekCursor::isActive() const {
-	ASSERT(false);
-	return false;
 }
 
 bool MergedPeekCursor::isExhausted() const {
@@ -994,7 +1009,7 @@ SetPeekCursor::SetPeekCursor(std::vector<Reference<LogSet>> const& logSets,
 }
 
 SetPeekCursor::SetPeekCursor(std::vector<Reference<LogSet>> const& logSets,
-                             std::vector<std::vector<Reference<IPeekCursor>>> const& serverCursors,
+                             std::vector<std::vector<Reference<ServerPeekCursor>>> const& serverCursors,
                              LogMessageVersion const& messageVersion,
                              int bestSet,
                              int bestServer,
@@ -1011,12 +1026,12 @@ SetPeekCursor::SetPeekCursor(std::vector<Reference<LogSet>> const& logSets,
 	calcHasMessage();
 }
 
-Reference<IPeekCursor> SetPeekCursor::cloneNoMore() {
-	std::vector<std::vector<Reference<IPeekCursor>>> cursors;
+Reference<IReplayPeekCursor> SetPeekCursor::cloneNoMore() {
+	std::vector<std::vector<Reference<ServerPeekCursor>>> cursors;
 	cursors.resize(logSets.size());
 	for (int i = 0; i < logSets.size(); i++) {
 		for (int j = 0; j < logSets[i]->logServers.size(); j++) {
-			cursors[i].push_back(serverCursors[i][j]->cloneNoMore());
+			cursors[i].push_back(serverCursors[i][j]->cloneServerNoMore());
 		}
 	}
 	return makeReference<SetPeekCursor>(logSets, cursors, messageVersion, bestSet, bestServer, nextVersion, useBestSet);
@@ -1097,65 +1112,50 @@ void SetPeekCursor::calcHasMessage() {
 }
 
 void SetPeekCursor::updateMessage(int logIdx, bool usePolicy) {
-	while (true) {
-		bool advancedPast = false;
-		sortedVersions.clear();
-		for (int i = 0; i < serverCursors[logIdx].size(); i++) {
-			auto& serverCursor = serverCursors[logIdx][i];
-			if (nextVersion.present())
-				serverCursor->advanceTo(nextVersion.get());
-			sortedVersions.push_back(std::pair<LogMessageVersion, int>(serverCursor->version(), i));
-			//TraceEvent("LPC_Update1").detail("Ver", messageVersion.toString()).detail("Tag", tag.toString()).detail("HasNextMessage", hasNextMessage).detail("ServerVer", serverCursor->version().toString()).detail("I", i);
-		}
-
+	auto selectMessageVersion = [&](auto& versions, LogMessageVersion& selectedVersion) {
 		if (usePolicy) {
-			std::sort(sortedVersions.begin(), sortedVersions.end());
+			std::sort(versions.begin(), versions.end());
 			locations.clear();
-			for (auto sortedVersion : sortedVersions) {
+			for (auto sortedVersion : versions) {
 				locations.push_back(logSets[logIdx]->logEntryArray[sortedVersion.second]);
 				if (locations.size() >= logSets[logIdx]->tLogReplicationFactor &&
 				    logSets[logIdx]->satisfiesPolicy(locations)) {
-					messageVersion = sortedVersion.first;
+					selectedVersion = sortedVersion.first;
 					break;
 				}
 			}
 		} else {
 			//(int)oldLogData[i].logServers.size() + 1 - oldLogData[i].tLogReplicationFactor
-			std::nth_element(sortedVersions.begin(),
-			                 sortedVersions.end() -
-			                     (logSets[logIdx]->logServers.size() + 1 - logSets[logIdx]->tLogReplicationFactor),
-			                 sortedVersions.end());
-			messageVersion = sortedVersions[sortedVersions.size() - (logSets[logIdx]->logServers.size() + 1 -
-			                                                         logSets[logIdx]->tLogReplicationFactor)]
-			                     .first;
+			auto quorum =
+			    logSets[logIdx]->logServers.size() + 1 - logSets[logIdx]->tLogReplicationFactor;
+			std::nth_element(versions.begin(), versions.end() - quorum, versions.end());
+			selectedVersion = versions[versions.size() - quorum].first;
 		}
-
+	};
+	auto advanceAllCursors = [&](LogMessageVersion const& selectedVersion) {
+		bool advancedPast = false;
 		for (auto& cursors : serverCursors) {
-			for (auto& c : cursors) {
-				auto start = c->version();
-				c->advanceTo(messageVersion);
-				if (start <= messageVersion && messageVersion < c->version()) {
+			for (auto& cursor : cursors) {
+				auto start = cursor->version();
+				cursor->advanceTo(selectedVersion);
+				if (start <= selectedVersion && selectedVersion < cursor->version()) {
 					advancedPast = true;
 					CODE_PROBE(true, "Set peek cursor with logIdx advanced past desired sequence");
 				}
 			}
 		}
+		return advancedPast;
+	};
 
-		if (!advancedPast) {
-			break;
-		}
-	}
-
-	for (int i = 0; i < serverCursors[logIdx].size(); i++) {
-		auto& c = serverCursors[logIdx][i];
-		ASSERT_WE_THINK(!c->hasMessage() ||
-		                c->version() >= messageVersion); // Seems like the loop above makes this unconditionally true
-		if (c->version() == messageVersion && c->hasMessage()) {
-			hasNextMessage = true;
-			currentSet = logIdx;
-			currentCursor = i;
-			break;
-		}
+	hasNextMessage = updateMergedPeekMessage(serverCursors[logIdx],
+	                                         nextVersion,
+	                                         sortedVersions,
+	                                         messageVersion,
+	                                         currentCursor,
+	                                         selectMessageVersion,
+	                                         advanceAllCursors);
+	if (hasNextMessage) {
+		currentSet = logIdx;
 	}
 }
 
@@ -1288,16 +1288,6 @@ Future<Void> SetPeekCursor::getMore(TaskPriority taskID) {
 	return more;
 }
 
-Future<Void> SetPeekCursor::onFailed() const {
-	ASSERT(false);
-	return Never();
-}
-
-bool SetPeekCursor::isActive() const {
-	ASSERT(false);
-	return false;
-}
-
 bool SetPeekCursor::isExhausted() const {
 	return serverCursors[currentSet][currentCursor]->isExhausted();
 }
@@ -1334,15 +1324,101 @@ Version SetPeekCursor::popped() const {
 	return poppedVersion;
 }
 
-MultiCursor::MultiCursor(std::vector<Reference<IPeekCursor>> cursors, std::vector<LogMessageVersion> epochEnds)
+ReplayMultiCursor::ReplayMultiCursor(std::vector<Reference<IReplayPeekCursor>> cursors, std::vector<LogMessageVersion> epochEnds)
   : cursors(cursors), epochEnds(epochEnds), poppedVersion(0) {
 	for (int i = 0; i < std::min<int>(cursors.size(), SERVER_KNOBS->MULTI_CURSOR_PRE_FETCH_LIMIT); i++) {
 		cursors[cursors.size() - i - 1]->getMore();
 	}
 }
 
-Reference<IPeekCursor> MultiCursor::cloneNoMore() {
+Reference<IReplayPeekCursor> ReplayMultiCursor::cloneNoMore() {
 	return cursors.back()->cloneNoMore();
+}
+
+void ReplayMultiCursor::setProtocolVersion(ProtocolVersion version) {
+	cursors.back()->setProtocolVersion(version);
+}
+
+Arena& ReplayMultiCursor::arena() {
+	return cursors.back()->arena();
+}
+
+ArenaReader* ReplayMultiCursor::reader() {
+	return cursors.back()->reader();
+}
+
+bool ReplayMultiCursor::hasMessage() const {
+	return cursors.back()->hasMessage();
+}
+
+void ReplayMultiCursor::nextMessage() {
+	cursors.back()->nextMessage();
+}
+
+StringRef ReplayMultiCursor::getMessage() {
+	return cursors.back()->getMessage();
+}
+
+StringRef ReplayMultiCursor::getMessageWithTags() {
+	return cursors.back()->getMessageWithTags();
+}
+
+VectorRef<Tag> ReplayMultiCursor::getTags() const {
+	return cursors.back()->getTags();
+}
+
+void ReplayMultiCursor::advanceTo(LogMessageVersion n) {
+	while (cursors.size() > 1 && n >= epochEnds.back()) {
+		poppedVersion = std::max(poppedVersion, cursors.back()->popped());
+		cursors.pop_back();
+		epochEnds.pop_back();
+	}
+	cursors.back()->advanceTo(n);
+}
+
+Future<Void> ReplayMultiCursor::getMore(TaskPriority taskID) {
+	LogMessageVersion startVersion = cursors.back()->version();
+	while (cursors.size() > 1 && cursors.back()->version() >= epochEnds.back()) {
+		poppedVersion = std::max(poppedVersion, cursors.back()->popped());
+		cursors.pop_back();
+		epochEnds.pop_back();
+	}
+	if (cursors.back()->version() > startVersion) {
+		return Void();
+	}
+	return cursors.back()->getMore(taskID);
+}
+
+bool ReplayMultiCursor::isExhausted() const {
+	return cursors.back()->isExhausted();
+}
+
+const LogMessageVersion& ReplayMultiCursor::version() const {
+	return cursors.back()->version();
+}
+
+Version ReplayMultiCursor::getMinKnownCommittedVersion() const {
+	return cursors.back()->getMinKnownCommittedVersion();
+}
+
+Optional<UID> ReplayMultiCursor::getPrimaryPeekLocation() const {
+	return cursors.back()->getPrimaryPeekLocation();
+}
+
+Optional<UID> ReplayMultiCursor::getCurrentPeekLocation() const {
+	return cursors.back()->getCurrentPeekLocation();
+}
+
+Version ReplayMultiCursor::popped() const {
+	return std::max(poppedVersion, cursors.back()->popped());
+}
+
+MultiCursor::MultiCursor(std::vector<Reference<IPeekCursor>> cursors,
+                                   std::vector<LogMessageVersion> epochEnds)
+  : cursors(cursors), epochEnds(epochEnds), poppedVersion(0) {
+	for (int i = 0; i < std::min<int>(cursors.size(), SERVER_KNOBS->MULTI_CURSOR_PRE_FETCH_LIMIT); i++) {
+		cursors[cursors.size() - i - 1]->getMore();
+	}
 }
 
 void MultiCursor::setProtocolVersion(ProtocolVersion version) {
@@ -1377,15 +1453,6 @@ VectorRef<Tag> MultiCursor::getTags() const {
 	return cursors.back()->getTags();
 }
 
-void MultiCursor::advanceTo(LogMessageVersion n) {
-	while (cursors.size() > 1 && n >= epochEnds.back()) {
-		poppedVersion = std::max(poppedVersion, cursors.back()->popped());
-		cursors.pop_back();
-		epochEnds.pop_back();
-	}
-	cursors.back()->advanceTo(n);
-}
-
 Future<Void> MultiCursor::getMore(TaskPriority taskID) {
 	LogMessageVersion startVersion = cursors.back()->version();
 	while (cursors.size() > 1 && cursors.back()->version() >= epochEnds.back()) {
@@ -1397,14 +1464,6 @@ Future<Void> MultiCursor::getMore(TaskPriority taskID) {
 		return Void();
 	}
 	return cursors.back()->getMore(taskID);
-}
-
-Future<Void> MultiCursor::onFailed() const {
-	return cursors.back()->onFailed();
-}
-
-bool MultiCursor::isActive() const {
-	return cursors.back()->isActive();
 }
 
 bool MultiCursor::isExhausted() const {
@@ -1419,14 +1478,6 @@ Version MultiCursor::getMinKnownCommittedVersion() const {
 	return cursors.back()->getMinKnownCommittedVersion();
 }
 
-Optional<UID> MultiCursor::getPrimaryPeekLocation() const {
-	return cursors.back()->getPrimaryPeekLocation();
-}
-
-Optional<UID> MultiCursor::getCurrentPeekLocation() const {
-	return cursors.back()->getCurrentPeekLocation();
-}
-
 Version MultiCursor::popped() const {
 	return std::max(poppedVersion, cursors.back()->popped());
 }
@@ -1439,6 +1490,25 @@ BufferedCursor::BufferedCursor(std::vector<Reference<IPeekCursor>> cursors,
   : cursors(cursors), messageIndex(0), messageVersion(begin), end(end), hasNextMessage(false), withTags(withTags),
     knownUnique(false), minKnownCommittedVersion(0), poppedVersion(0), initialPoppedVersion(0),
     canDiscardPopped(canDiscardPopped), randomID(deterministicRandom()->randomUniqueID()) {
+	ASSERT(!canDiscardPopped);
+	targetQueueSize = SERVER_KNOBS->DESIRED_OUTSTANDING_MESSAGES / cursors.size();
+	messages.reserve(SERVER_KNOBS->DESIRED_OUTSTANDING_MESSAGES);
+	cursorMessages.resize(cursors.size());
+}
+
+BufferedCursor::BufferedCursor(std::vector<Reference<IReplayPeekCursor>> replayCursors,
+                               Version begin,
+                               Version end,
+                               bool withTags,
+                               bool canDiscardPopped)
+  : discardableCursors(canDiscardPopped ? replayCursors : std::vector<Reference<IReplayPeekCursor>>()),
+    messageIndex(0), messageVersion(begin), end(end), hasNextMessage(false), withTags(withTags), knownUnique(false),
+    minKnownCommittedVersion(0), poppedVersion(0), initialPoppedVersion(0), canDiscardPopped(canDiscardPopped),
+    randomID(deterministicRandom()->randomUniqueID()) {
+	cursors.reserve(replayCursors.size());
+	for (const auto& cursor : replayCursors) {
+		cursors.push_back(cursor);
+	}
 	targetQueueSize = SERVER_KNOBS->DESIRED_OUTSTANDING_MESSAGES / cursors.size();
 	messages.reserve(SERVER_KNOBS->DESIRED_OUTSTANDING_MESSAGES);
 	cursorMessages.resize(cursors.size());
@@ -1459,11 +1529,6 @@ BufferedCursor::BufferedCursor(std::vector<Reference<AsyncVar<OptionalInterface<
 		auto cursor = makeReference<ServerPeekCursor>(logServers[i], tag, begin, end, false, parallelGetMore);
 		cursors.push_back(cursor);
 	}
-}
-
-Reference<IPeekCursor> BufferedCursor::cloneNoMore() {
-	ASSERT(false);
-	return Reference<IPeekCursor>();
 }
 
 void BufferedCursor::setProtocolVersion(ProtocolVersion version) {
@@ -1505,10 +1570,6 @@ StringRef BufferedCursor::getMessageWithTags() {
 VectorRef<Tag> BufferedCursor::getTags() const {
 	ASSERT(withTags);
 	return messages[messageIndex].tags;
-}
-
-void BufferedCursor::advanceTo(LogMessageVersion n) {
-	ASSERT(false);
 }
 
 Future<Void> bufferedGetMoreLoader(BufferedCursor* self, Reference<IPeekCursor> cursor, int idx, TaskPriority taskID) {
@@ -1601,7 +1662,7 @@ Future<Void> bufferedGetMore(BufferedCursor* self, TaskPriority taskID) {
 		    .detail("Version", self->version().version)
 		    .detail("Popped", self->poppedVersion);
 		self->messageVersion = std::max(self->messageVersion, LogMessageVersion(self->poppedVersion));
-		for (auto cursor : self->cursors) {
+		for (auto cursor : self->discardableCursors) {
 			cursor->advanceTo(self->messageVersion);
 		}
 		self->messageIndex = self->messages.size();
@@ -1633,16 +1694,6 @@ Future<Void> BufferedCursor::getMore(TaskPriority taskID) {
 	return more;
 }
 
-Future<Void> BufferedCursor::onFailed() const {
-	ASSERT(false);
-	return Never();
-}
-
-bool BufferedCursor::isActive() const {
-	ASSERT(false);
-	return false;
-}
-
 bool BufferedCursor::isExhausted() const {
 	ASSERT(false);
 	return false;
@@ -1657,14 +1708,6 @@ const LogMessageVersion& BufferedCursor::version() const {
 
 Version BufferedCursor::getMinKnownCommittedVersion() const {
 	return minKnownCommittedVersion;
-}
-
-Optional<UID> BufferedCursor::getPrimaryPeekLocation() const {
-	return Optional<UID>();
-}
-
-Optional<UID> BufferedCursor::getCurrentPeekLocation() const {
-	return Optional<UID>();
 }
 
 Version BufferedCursor::popped() const {

--- a/fdbserver/logsystem/LogSystemPeekCursor.cpp
+++ b/fdbserver/logsystem/LogSystemPeekCursor.cpp
@@ -954,6 +954,10 @@ Version MergedPeekCursor::getMinKnownCommittedVersion() const {
 	return serverCursors[currentCursor]->getMinKnownCommittedVersion();
 }
 
+Version MergedPeekCursor::getMaxKnownVersion() const {
+	return serverCursors[currentCursor]->getMaxKnownVersion();
+}
+
 Optional<UID> MergedPeekCursor::getPrimaryPeekLocation() const {
 	if (bestServer >= 0) {
 		return serverCursors[bestServer]->getPrimaryPeekLocation();
@@ -1300,6 +1304,10 @@ Version SetPeekCursor::getMinKnownCommittedVersion() const {
 	return serverCursors[currentSet][currentCursor]->getMinKnownCommittedVersion();
 }
 
+Version SetPeekCursor::getMaxKnownVersion() const {
+	return serverCursors[currentSet][currentCursor]->getMaxKnownVersion();
+}
+
 Optional<UID> SetPeekCursor::getPrimaryPeekLocation() const {
 	if (bestServer >= 0 && bestSet >= 0) {
 		return serverCursors[bestSet][bestServer]->getPrimaryPeekLocation();
@@ -1399,6 +1407,10 @@ const LogMessageVersion& ReplayMultiCursor::version() const {
 
 Version ReplayMultiCursor::getMinKnownCommittedVersion() const {
 	return cursors.back()->getMinKnownCommittedVersion();
+}
+
+Version ReplayMultiCursor::getMaxKnownVersion() const {
+	return cursors.back()->getMaxKnownVersion();
 }
 
 Optional<UID> ReplayMultiCursor::getPrimaryPeekLocation() const {

--- a/fdbserver/logsystem/LogSystemPeekCursor.cpp
+++ b/fdbserver/logsystem/LogSystemPeekCursor.cpp
@@ -1409,7 +1409,11 @@ Version ReplayMultiCursor::getMinKnownCommittedVersion() const {
 }
 
 Version ReplayMultiCursor::getMaxKnownVersion() const {
-	return cursors.back()->getMaxKnownVersion();
+	Version maxKnownVersion = 0;
+	for (const auto& cursor : cursors) {
+		maxKnownVersion = std::max(maxKnownVersion, cursor->getMaxKnownVersion());
+	}
+	return maxKnownVersion;
 }
 
 Optional<UID> ReplayMultiCursor::getPrimaryPeekLocation() const {

--- a/fdbserver/logsystem/LogSystemPeekCursor.cpp
+++ b/fdbserver/logsystem/LogSystemPeekCursor.cpp
@@ -894,8 +894,7 @@ void MergedPeekCursor::advanceTo(LogMessageVersion n) {
 Future<Void> mergedPeekGetMore(MergedPeekCursor* self, LogMessageVersion startVersion, TaskPriority taskID) {
 	while (true) {
 		//TraceEvent("MPC_GetMoreA", self->randomID).detail("Start", startVersion.toString());
-		if (self->bestServer >= 0 &&
-		    self->serverCursors[self->bestServer]->isActive()) {
+		if (self->bestServer >= 0 && self->serverCursors[self->bestServer]->isActive()) {
 			ASSERT(!self->serverCursors[self->bestServer]->hasMessage());
 			co_await (self->serverCursors[self->bestServer]->getMore(taskID) ||
 			          self->serverCursors[self->bestServer]->onFailed());
@@ -1130,8 +1129,7 @@ void SetPeekCursor::updateMessage(int logIdx, bool usePolicy) {
 			}
 		} else {
 			//(int)oldLogData[i].logServers.size() + 1 - oldLogData[i].tLogReplicationFactor
-			auto quorum =
-			    logSets[logIdx]->logServers.size() + 1 - logSets[logIdx]->tLogReplicationFactor;
+			auto quorum = logSets[logIdx]->logServers.size() + 1 - logSets[logIdx]->tLogReplicationFactor;
 			std::nth_element(versions.begin(), versions.end() - quorum, versions.end());
 			selectedVersion = versions[versions.size() - quorum].first;
 		}
@@ -1332,7 +1330,8 @@ Version SetPeekCursor::popped() const {
 	return poppedVersion;
 }
 
-ReplayMultiCursor::ReplayMultiCursor(std::vector<Reference<IReplayPeekCursor>> cursors, std::vector<LogMessageVersion> epochEnds)
+ReplayMultiCursor::ReplayMultiCursor(std::vector<Reference<IReplayPeekCursor>> cursors,
+                                     std::vector<LogMessageVersion> epochEnds)
   : cursors(cursors), epochEnds(epochEnds), poppedVersion(0) {
 	for (int i = 0; i < std::min<int>(cursors.size(), SERVER_KNOBS->MULTI_CURSOR_PRE_FETCH_LIMIT); i++) {
 		cursors[cursors.size() - i - 1]->getMore();
@@ -1425,8 +1424,7 @@ Version ReplayMultiCursor::popped() const {
 	return std::max(poppedVersion, cursors.back()->popped());
 }
 
-MultiCursor::MultiCursor(std::vector<Reference<IPeekCursor>> cursors,
-                                   std::vector<LogMessageVersion> epochEnds)
+MultiCursor::MultiCursor(std::vector<Reference<IPeekCursor>> cursors, std::vector<LogMessageVersion> epochEnds)
   : cursors(cursors), epochEnds(epochEnds), poppedVersion(0) {
 	for (int i = 0; i < std::min<int>(cursors.size(), SERVER_KNOBS->MULTI_CURSOR_PRE_FETCH_LIMIT); i++) {
 		cursors[cursors.size() - i - 1]->getMore();
@@ -1513,8 +1511,8 @@ BufferedCursor::BufferedCursor(std::vector<Reference<IReplayPeekCursor>> replayC
                                Version end,
                                bool withTags,
                                bool canDiscardPopped)
-  : discardableCursors(canDiscardPopped ? replayCursors : std::vector<Reference<IReplayPeekCursor>>()),
-    messageIndex(0), messageVersion(begin), end(end), hasNextMessage(false), withTags(withTags), knownUnique(false),
+  : discardableCursors(canDiscardPopped ? replayCursors : std::vector<Reference<IReplayPeekCursor>>()), messageIndex(0),
+    messageVersion(begin), end(end), hasNextMessage(false), withTags(withTags), knownUnique(false),
     minKnownCommittedVersion(0), poppedVersion(0), initialPoppedVersion(0), canDiscardPopped(canDiscardPopped),
     randomID(deterministicRandom()->randomUniqueID()) {
 	cursors.reserve(replayCursors.size());

--- a/fdbserver/logsystem/LogSystemPeekCursor.cpp
+++ b/fdbserver/logsystem/LogSystemPeekCursor.cpp
@@ -954,7 +954,11 @@ Version MergedPeekCursor::getMinKnownCommittedVersion() const {
 }
 
 Version MergedPeekCursor::getMaxKnownVersion() const {
-	return serverCursors[currentCursor]->getMaxKnownVersion();
+	Version maxKnownVersion = 0;
+	for (const auto& cursor : serverCursors) {
+		maxKnownVersion = std::max(maxKnownVersion, cursor->getMaxKnownVersion());
+	}
+	return maxKnownVersion;
 }
 
 Optional<UID> MergedPeekCursor::getPrimaryPeekLocation() const {
@@ -1303,7 +1307,13 @@ Version SetPeekCursor::getMinKnownCommittedVersion() const {
 }
 
 Version SetPeekCursor::getMaxKnownVersion() const {
-	return serverCursors[currentSet][currentCursor]->getMaxKnownVersion();
+	Version maxKnownVersion = 0;
+	for (const auto& cursors : serverCursors) {
+		for (const auto& cursor : cursors) {
+			maxKnownVersion = std::max(maxKnownVersion, cursor->getMaxKnownVersion());
+		}
+	}
+	return maxKnownVersion;
 }
 
 Optional<UID> SetPeekCursor::getPrimaryPeekLocation() const {

--- a/fdbserver/logsystem/include/fdbserver/logsystem/LogSystem.h
+++ b/fdbserver/logsystem/include/fdbserver/logsystem/LogSystem.h
@@ -413,11 +413,11 @@ struct LogSystem : ReferenceCounted<LogSystem> {
 	                            bool parallelGetMore);
 
 	Reference<IReplayPeekCursor> peekLocal(UID dbgid,
-	                                        Tag tag,
-	                                        Version begin,
-	                                        Version end,
-	                                        bool useMergePeekCursors,
-	                                        int8_t peekLocality = tagLocalityInvalid);
+	                                       Tag tag,
+	                                       Version begin,
+	                                       Version end,
+	                                       bool useMergePeekCursors,
+	                                       int8_t peekLocality = tagLocalityInvalid);
 
 	Reference<IPeekCursor> peekTxs(UID dbgid,
 	                               Version begin,

--- a/fdbserver/logsystem/include/fdbserver/logsystem/LogSystem.h
+++ b/fdbserver/logsystem/include/fdbserver/logsystem/LogSystem.h
@@ -63,9 +63,8 @@ struct ConnectionResetInfo : public ReferenceCounted<ConnectionResetInfo> {
 	ConnectionResetInfo() : lastReset(now()), resetCheck(Void()), slowReplies(0), fastReplies(0) {}
 };
 
+// Base cursor contract for consuming a sequential log peek stream.
 struct IPeekCursor {
-	virtual Reference<IPeekCursor> cloneNoMore() = 0;
-
 	virtual void setProtocolVersion(ProtocolVersion version) = 0;
 
 	virtual bool hasMessage() const = 0;
@@ -75,19 +74,22 @@ struct IPeekCursor {
 	virtual StringRef getMessage() = 0;
 	virtual StringRef getMessageWithTags() = 0;
 	virtual void nextMessage() = 0;
-	virtual void advanceTo(LogMessageVersion n) = 0;
 	virtual Future<Void> getMore(TaskPriority taskID = TaskPriority::TLogPeekReply) = 0;
-	virtual Future<Void> onFailed() const = 0;
-	virtual bool isActive() const = 0;
 	virtual bool isExhausted() const = 0;
 	virtual const LogMessageVersion& version() const = 0;
 	virtual Version popped() const = 0;
-	virtual Version getMaxKnownVersion() const { return 0; }
 	virtual Version getMinKnownCommittedVersion() const = 0;
-	virtual Optional<UID> getPrimaryPeekLocation() const = 0;
-	virtual Optional<UID> getCurrentPeekLocation() const = 0;
 	virtual void addref() = 0;
 	virtual void delref() = 0;
+};
+
+// Peek cursor that reports log location and can be cloned and repositioned for replay.
+struct IReplayPeekCursor : IPeekCursor {
+	virtual Optional<UID> getPrimaryPeekLocation() const = 0;
+	virtual Optional<UID> getCurrentPeekLocation() const = 0;
+	virtual Version getMaxKnownVersion() const { return 0; }
+	virtual Reference<IReplayPeekCursor> cloneNoMore() = 0;
+	virtual void advanceTo(LogMessageVersion n) = 0;
 };
 
 struct LogPushVersionSet {
@@ -398,7 +400,7 @@ struct LogSystem : ReferenceCounted<LogSystem> {
 	                                Optional<Version> end,
 	                                const Optional<std::map<uint8_t, std::vector<uint16_t>>>& knownLockedTLogIds);
 
-	Reference<IPeekCursor> peekAll(UID dbgid, Version begin, Version end, Tag tag, bool parallelGetMore);
+	Reference<IReplayPeekCursor> peekAll(UID dbgid, Version begin, Version end, Tag tag, bool parallelGetMore);
 
 	Reference<IPeekCursor> peekRemote(UID dbgid, Version begin, Optional<Version> end, Tag tag, bool parallelGetMore);
 
@@ -410,12 +412,12 @@ struct LogSystem : ReferenceCounted<LogSystem> {
 	                            std::vector<Tag> tags,
 	                            bool parallelGetMore);
 
-	Reference<IPeekCursor> peekLocal(UID dbgid,
-	                                 Tag tag,
-	                                 Version begin,
-	                                 Version end,
-	                                 bool useMergePeekCursors,
-	                                 int8_t peekLocality = tagLocalityInvalid);
+	Reference<IReplayPeekCursor> peekLocal(UID dbgid,
+	                                        Tag tag,
+	                                        Version begin,
+	                                        Version end,
+	                                        bool useMergePeekCursors,
+	                                        int8_t peekLocality = tagLocalityInvalid);
 
 	Reference<IPeekCursor> peekTxs(UID dbgid,
 	                               Version begin,
@@ -423,7 +425,7 @@ struct LogSystem : ReferenceCounted<LogSystem> {
 	                               Version localEnd,
 	                               bool canDiscardPopped);
 
-	Reference<IPeekCursor> peekSingle(
+	Reference<IReplayPeekCursor> peekSingle(
 	    UID dbgid,
 	    Version begin,
 	    Tag tag,
@@ -434,13 +436,14 @@ struct LogSystem : ReferenceCounted<LogSystem> {
 	// The returned cursor can peek data at the "tag" from the given "begin" version to that epoch's end version or
 	// the recovery version for the latest old epoch. For the current epoch, the cursor has no end version.
 	// For the old epoch, the cursor is provided an end version.
-	Reference<IPeekCursor> peekLogRouter(UID dbgid,
-	                                     Version begin,
-	                                     Tag tag,
-	                                     bool useSatellite,
-	                                     Optional<Version> end = Optional<Version>(),
-	                                     const Optional<std::map<uint8_t, std::vector<uint16_t>>>& knownStoppedTLogIds =
-	                                         Optional<std::map<uint8_t, std::vector<uint16_t>>>());
+	Reference<IReplayPeekCursor> peekLogRouter(
+	    UID dbgid,
+	    Version begin,
+	    Tag tag,
+	    bool useSatellite,
+	    Optional<Version> end = Optional<Version>(),
+	    const Optional<std::map<uint8_t, std::vector<uint16_t>>>& knownStoppedTLogIds =
+	        Optional<std::map<uint8_t, std::vector<uint16_t>>>());
 
 	Version getKnownCommittedVersion();
 

--- a/fdbserver/logsystem/include/fdbserver/logsystem/LogSystem.h
+++ b/fdbserver/logsystem/include/fdbserver/logsystem/LogSystem.h
@@ -87,7 +87,7 @@ struct IPeekCursor {
 struct IReplayPeekCursor : IPeekCursor {
 	virtual Optional<UID> getPrimaryPeekLocation() const = 0;
 	virtual Optional<UID> getCurrentPeekLocation() const = 0;
-	virtual Version getMaxKnownVersion() const { return 0; }
+	virtual Version getMaxKnownVersion() const = 0;
 	virtual Reference<IReplayPeekCursor> cloneNoMore() = 0;
 	virtual void advanceTo(LogMessageVersion n) = 0;
 };

--- a/fdbserver/logsystem/include/fdbserver/logsystem/LogSystemTypes.h
+++ b/fdbserver/logsystem/include/fdbserver/logsystem/LogSystemTypes.h
@@ -194,6 +194,7 @@ public:
 	const LogMessageVersion& version() const override;
 	Version popped() const override;
 	Version getMinKnownCommittedVersion() const override;
+	Version getMaxKnownVersion() const override;
 	Optional<UID> getPrimaryPeekLocation() const override;
 	Optional<UID> getCurrentPeekLocation() const override;
 	void addref() override { ReferenceCounted<MergedPeekCursor>::addref(); }
@@ -250,6 +251,7 @@ public:
 	const LogMessageVersion& version() const override;
 	Version popped() const override;
 	Version getMinKnownCommittedVersion() const override;
+	Version getMaxKnownVersion() const override;
 	Optional<UID> getPrimaryPeekLocation() const override;
 	Optional<UID> getCurrentPeekLocation() const override;
 	void addref() override { ReferenceCounted<SetPeekCursor>::addref(); }
@@ -280,6 +282,7 @@ public:
 	const LogMessageVersion& version() const override;
 	Version popped() const override;
 	Version getMinKnownCommittedVersion() const override;
+	Version getMaxKnownVersion() const override;
 	Optional<UID> getPrimaryPeekLocation() const override;
 	Optional<UID> getCurrentPeekLocation() const override;
 	void addref() override { ReferenceCounted<ReplayMultiCursor>::addref(); }

--- a/fdbserver/logsystem/include/fdbserver/logsystem/LogSystemTypes.h
+++ b/fdbserver/logsystem/include/fdbserver/logsystem/LogSystemTypes.h
@@ -73,7 +73,8 @@ private:
 	std::vector<int> newLocations;
 };
 
-class ServerPeekCursor final : public IPeekCursor, public ReferenceCounted<ServerPeekCursor> {
+// Leaf replay cursor backed by a single TLog interface.
+class ServerPeekCursor final : public IReplayPeekCursor, public ReferenceCounted<ServerPeekCursor> {
 public:
 	Reference<AsyncVar<OptionalInterface<TLogInterface>>> interf;
 	const Tag tag;
@@ -115,7 +116,8 @@ public:
 	                 Version poppedVersion,
 	                 Tag tag);
 
-	Reference<IPeekCursor> cloneNoMore() override;
+	Reference<ServerPeekCursor> cloneServerNoMore();
+	Reference<IReplayPeekCursor> cloneNoMore() override;
 	void setProtocolVersion(ProtocolVersion version) override;
 	Arena& arena() override;
 	ArenaReader* reader() override;
@@ -126,8 +128,8 @@ public:
 	VectorRef<Tag> getTags() const override;
 	void advanceTo(LogMessageVersion n) override;
 	Future<Void> getMore(TaskPriority taskID = TaskPriority::TLogPeekReply) override;
-	Future<Void> onFailed() const override;
-	bool isActive() const override;
+	Future<Void> onFailed() const;
+	bool isActive() const;
 	bool isExhausted() const override;
 	const LogMessageVersion& version() const override;
 	Version popped() const override;
@@ -139,10 +141,11 @@ public:
 	Version getMaxKnownVersion() const override { return results.maxKnownVersion; }
 };
 
-class MergedPeekCursor final : public IPeekCursor, public ReferenceCounted<MergedPeekCursor> {
+// Replay cursor that reads one logical stream from replicated TLog servers in a log set.
+class MergedPeekCursor final : public IReplayPeekCursor, public ReferenceCounted<MergedPeekCursor> {
 public:
 	Reference<LogSet> logSet;
-	std::vector<Reference<IPeekCursor>> serverCursors;
+	std::vector<Reference<ServerPeekCursor>> serverCursors;
 	std::vector<LocalityEntry> locations;
 	std::vector<std::pair<LogMessageVersion, int>> sortedVersions;
 	Tag tag;
@@ -154,7 +157,7 @@ public:
 	int tLogReplicationFactor;
 	Future<Void> more;
 
-	MergedPeekCursor(std::vector<Reference<IPeekCursor>> const& serverCursors, Version begin);
+	MergedPeekCursor(std::vector<Reference<ServerPeekCursor>> const& serverCursors, Version begin);
 	MergedPeekCursor(std::vector<Reference<AsyncVar<OptionalInterface<TLogInterface>>>> const& logServers,
 	                 int bestServer,
 	                 int readQuorum,
@@ -166,7 +169,7 @@ public:
 	                 Reference<IReplicationPolicy> const tLogPolicy,
 	                 int tLogReplicationFactor,
 	                 const Optional<std::vector<uint16_t>>& knownLockedTLogIds = Optional<std::vector<uint16_t>>());
-	MergedPeekCursor(std::vector<Reference<IPeekCursor>> const& serverCursors,
+	MergedPeekCursor(std::vector<Reference<ServerPeekCursor>> const& serverCursors,
 	                 LogMessageVersion const& messageVersion,
 	                 int bestServer,
 	                 int readQuorum,
@@ -174,7 +177,7 @@ public:
 	                 Reference<LogSet> logSet,
 	                 int tLogReplicationFactor);
 
-	Reference<IPeekCursor> cloneNoMore() override;
+	Reference<IReplayPeekCursor> cloneNoMore() override;
 	void setProtocolVersion(ProtocolVersion version) override;
 	Arena& arena() override;
 	ArenaReader* reader() override;
@@ -187,8 +190,6 @@ public:
 	VectorRef<Tag> getTags() const override;
 	void advanceTo(LogMessageVersion n) override;
 	Future<Void> getMore(TaskPriority taskID = TaskPriority::TLogPeekReply) override;
-	Future<Void> onFailed() const override;
-	bool isActive() const override;
 	bool isExhausted() const override;
 	const LogMessageVersion& version() const override;
 	Version popped() const override;
@@ -199,10 +200,11 @@ public:
 	void delref() override { ReferenceCounted<MergedPeekCursor>::delref(); }
 };
 
-class SetPeekCursor final : public IPeekCursor, public ReferenceCounted<SetPeekCursor> {
+// Replay cursor that reads one logical stream across candidate log sets.
+class SetPeekCursor final : public IReplayPeekCursor, public ReferenceCounted<SetPeekCursor> {
 public:
 	std::vector<Reference<LogSet>> logSets;
-	std::vector<std::vector<Reference<IPeekCursor>>> serverCursors;
+	std::vector<std::vector<Reference<ServerPeekCursor>>> serverCursors;
 	Tag tag;
 	int bestSet, bestServer, currentSet, currentCursor;
 	std::vector<LocalityEntry> locations;
@@ -224,14 +226,14 @@ public:
 	              bool parallelGetMore,
 	              const Optional<std::vector<uint16_t>>& knownLockedTLogIds = Optional<std::vector<uint16_t>>());
 	SetPeekCursor(std::vector<Reference<LogSet>> const& logSets,
-	              std::vector<std::vector<Reference<IPeekCursor>>> const& serverCursors,
+	              std::vector<std::vector<Reference<ServerPeekCursor>>> const& serverCursors,
 	              LogMessageVersion const& messageVersion,
 	              int bestSet,
 	              int bestServer,
 	              Optional<LogMessageVersion> nextVersion,
 	              bool useBestSet);
 
-	Reference<IPeekCursor> cloneNoMore() override;
+	Reference<IReplayPeekCursor> cloneNoMore() override;
 	void setProtocolVersion(ProtocolVersion version) override;
 	Arena& arena() override;
 	ArenaReader* reader() override;
@@ -244,8 +246,6 @@ public:
 	VectorRef<Tag> getTags() const override;
 	void advanceTo(LogMessageVersion n) override;
 	Future<Void> getMore(TaskPriority taskID = TaskPriority::TLogPeekReply) override;
-	Future<Void> onFailed() const override;
-	bool isActive() const override;
 	bool isExhausted() const override;
 	const LogMessageVersion& version() const override;
 	Version popped() const override;
@@ -256,15 +256,16 @@ public:
 	void delref() override { ReferenceCounted<SetPeekCursor>::delref(); }
 };
 
-class MultiCursor final : public IPeekCursor, public ReferenceCounted<MultiCursor> {
+// Replay cursor that stitches together replay-capable cursors from successive history ranges.
+class ReplayMultiCursor final : public IReplayPeekCursor, public ReferenceCounted<ReplayMultiCursor> {
 public:
-	std::vector<Reference<IPeekCursor>> cursors;
+	std::vector<Reference<IReplayPeekCursor>> cursors;
 	std::vector<LogMessageVersion> epochEnds;
 	Version poppedVersion;
 
-	MultiCursor(std::vector<Reference<IPeekCursor>> cursors, std::vector<LogMessageVersion> epochEnds);
+	ReplayMultiCursor(std::vector<Reference<IReplayPeekCursor>> cursors, std::vector<LogMessageVersion> epochEnds);
 
-	Reference<IPeekCursor> cloneNoMore() override;
+	Reference<IReplayPeekCursor> cloneNoMore() override;
 	void setProtocolVersion(ProtocolVersion version) override;
 	Arena& arena() override;
 	ArenaReader* reader() override;
@@ -275,18 +276,43 @@ public:
 	VectorRef<Tag> getTags() const override;
 	void advanceTo(LogMessageVersion n) override;
 	Future<Void> getMore(TaskPriority taskID = TaskPriority::TLogPeekReply) override;
-	Future<Void> onFailed() const override;
-	bool isActive() const override;
 	bool isExhausted() const override;
 	const LogMessageVersion& version() const override;
 	Version popped() const override;
 	Version getMinKnownCommittedVersion() const override;
 	Optional<UID> getPrimaryPeekLocation() const override;
 	Optional<UID> getCurrentPeekLocation() const override;
+	void addref() override { ReferenceCounted<ReplayMultiCursor>::addref(); }
+	void delref() override { ReferenceCounted<ReplayMultiCursor>::delref(); }
+};
+
+// Plain cursor that stitches together sequential ranges without replay-only capabilities.
+class MultiCursor final : public IPeekCursor, public ReferenceCounted<MultiCursor> {
+public:
+	std::vector<Reference<IPeekCursor>> cursors;
+	std::vector<LogMessageVersion> epochEnds;
+	Version poppedVersion;
+
+	MultiCursor(std::vector<Reference<IPeekCursor>> cursors, std::vector<LogMessageVersion> epochEnds);
+
+	void setProtocolVersion(ProtocolVersion version) override;
+	Arena& arena() override;
+	ArenaReader* reader() override;
+	bool hasMessage() const override;
+	void nextMessage() override;
+	StringRef getMessage() override;
+	StringRef getMessageWithTags() override;
+	VectorRef<Tag> getTags() const override;
+	Future<Void> getMore(TaskPriority taskID = TaskPriority::TLogPeekReply) override;
+	bool isExhausted() const override;
+	const LogMessageVersion& version() const override;
+	Version popped() const override;
+	Version getMinKnownCommittedVersion() const override;
 	void addref() override { ReferenceCounted<MultiCursor>::addref(); }
 	void delref() override { ReferenceCounted<MultiCursor>::delref(); }
 };
 
+// Plain cursor that buffers and orders messages pulled from one or more input cursors.
 class BufferedCursor final : public IPeekCursor, public ReferenceCounted<BufferedCursor> {
 public:
 	struct BufferedMessage {
@@ -305,6 +331,7 @@ public:
 	};
 
 	std::vector<Reference<IPeekCursor>> cursors;
+	std::vector<Reference<IReplayPeekCursor>> discardableCursors;
 	std::vector<Deque<BufferedMessage>> cursorMessages;
 	std::vector<BufferedMessage> messages;
 	int messageIndex;
@@ -326,13 +353,17 @@ public:
 	               Version end,
 	               bool withTags,
 	               bool canDiscardPopped);
+	BufferedCursor(std::vector<Reference<IReplayPeekCursor>> cursors,
+	               Version begin,
+	               Version end,
+	               bool withTags,
+	               bool canDiscardPopped);
 	BufferedCursor(std::vector<Reference<AsyncVar<OptionalInterface<TLogInterface>>>> const& logServers,
 	               Tag tag,
 	               Version begin,
 	               Version end,
 	               bool parallelGetMore);
 
-	Reference<IPeekCursor> cloneNoMore() override;
 	void setProtocolVersion(ProtocolVersion version) override;
 	Arena& arena() override;
 	ArenaReader* reader() override;
@@ -341,16 +372,11 @@ public:
 	StringRef getMessage() override;
 	StringRef getMessageWithTags() override;
 	VectorRef<Tag> getTags() const override;
-	void advanceTo(LogMessageVersion n) override;
 	Future<Void> getMore(TaskPriority taskID = TaskPriority::TLogPeekReply) override;
-	Future<Void> onFailed() const override;
-	bool isActive() const override;
 	bool isExhausted() const override;
 	const LogMessageVersion& version() const override;
 	Version popped() const override;
 	Version getMinKnownCommittedVersion() const override;
-	Optional<UID> getPrimaryPeekLocation() const override;
-	Optional<UID> getCurrentPeekLocation() const override;
 	void addref() override { ReferenceCounted<BufferedCursor>::addref(); }
 	void delref() override { ReferenceCounted<BufferedCursor>::delref(); }
 };

--- a/fdbserver/storageserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver/storageserver.actor.cpp
@@ -1178,7 +1178,7 @@ public:
 	ProtocolVersion logProtocol;
 
 	Reference<LogSystem> logSystem;
-	Reference<IPeekCursor> logCursor;
+	Reference<IReplayPeekCursor> logCursor;
 
 	// The version the cluster starts on. This value is not persisted and may
 	// not be valid after a recovery.
@@ -9626,7 +9626,7 @@ Future<Void> update(StorageServer* data, bool* pReceivedUpdate) {
 				co_await data->byteSampleClearsTooLarge.onChange();
 			}
 
-			Reference<IPeekCursor> cursor = data->logCursor;
+			Reference<IReplayPeekCursor> cursor = data->logCursor;
 
 			double beforeTLogCursorReads = now();
 			while (true) {
@@ -9665,7 +9665,7 @@ Future<Void> update(StorageServer* data, bool* pReceivedUpdate) {
 
 			start = now();
 			FetchInjectionInfo fii;
-			Reference<IPeekCursor> cloneCursor2 = cursor->cloneNoMore();
+			Reference<IReplayPeekCursor> cloneCursor2 = cursor->cloneNoMore();
 
 			// Collect eager read keys.
 			while (true) {
@@ -9675,7 +9675,7 @@ Future<Void> update(StorageServer* data, bool* pReceivedUpdate) {
 				bool firstMutation = true;
 				bool dbgLastMessageWasProtocol = false;
 
-				Reference<IPeekCursor> cloneCursor1 = cloneCursor2->cloneNoMore();
+				Reference<IReplayPeekCursor> cloneCursor1 = cloneCursor2->cloneNoMore();
 
 				cloneCursor1->setProtocolVersion(data->logProtocol);
 


### PR DESCRIPTION
Previously, `IPeekCursor` had 5 distinct implementations implementing different subsets of the shared interface, violating the Liskov Substitution Principle:

- `ServerPeekCursor`: Peeks from a single tlog
- `MergedPeekCursor`: Peeks from one replicated set of tlogs
- `SetPeekCursor`: Peeks from multiple replicated sets of tlogs
- `MultiPeekCursor`: Chains multiple tlog generations
- `BufferedCursor`: Buffers messages from multiple cursors peeking multiple tags

This PR decomposes `IPeekCursor` with a new `IReplayPeekCursor` interface. `MultiCursor` is decomposed into `MultiCursor` and `ReplayMultiCursor`, because the old `MultiCursor` was only sometimes used in a replayable context. The new class hierarchy is:

```mermaid
classDiagram
    direction BT

    IReplayPeekCursor --|> IPeekCursor

    ServerPeekCursor --|> IReplayPeekCursor
    MergedPeekCursor --|> IReplayPeekCursor
    SetPeekCursor --|> IReplayPeekCursor
    ReplayMultiCursor --|> IReplayPeekCursor

    MultiCursor --|> IPeekCursor
    BufferedCursor --|> IPeekCursor
```

Lastly, missing `IReplayPeekCursor::getMaxKnownVersion` implementations are added. Previously, several cursor implementations incorrectly returned 0. This could cause storage servers to underestimate their version lag, causing them to prematurely report to ratekeeper that they're accepting requests. This can trigger unnecessary, prolonged, heavy ratekeeper throttling.