### PR TITLE
More AST-grep linting

### DIFF
--- a/bindings/c/test/apitester/TesterApiWorkload.h
+++ b/bindings/c/test/apitester/TesterApiWorkload.h
@@ -105,7 +105,7 @@ protected:
 	// In-memory store maintaining expected database state
 	std::unordered_map<std::optional<int>, KeyValueStore> stores;
 
-	ApiWorkload(const WorkloadConfig& config);
+	explicit ApiWorkload(const WorkloadConfig& config);
 
 	// Methods for generating random keys and values
 	fdb::Key randomKeyName();

--- a/bindings/c/test/apitester/TesterAtomicOpsCorrectnessWorkload.cpp
+++ b/bindings/c/test/apitester/TesterAtomicOpsCorrectnessWorkload.cpp
@@ -34,7 +34,7 @@ using fdb::ValueRef;
 
 class AtomicOpsCorrectnessWorkload : public ApiWorkload {
 public:
-	AtomicOpsCorrectnessWorkload(const WorkloadConfig& config) : ApiWorkload(config) {}
+	explicit AtomicOpsCorrectnessWorkload(const WorkloadConfig& config) : ApiWorkload(config) {}
 
 private:
 	using IntAtomicOpFunction = std::function<uint64_t(uint64_t, uint64_t)>;

--- a/bindings/c/test/apitester/TesterCancelTransactionWorkload.cpp
+++ b/bindings/c/test/apitester/TesterCancelTransactionWorkload.cpp
@@ -25,7 +25,7 @@ namespace FdbApiTester {
 
 class CancelTransactionWorkload : public ApiWorkload {
 public:
-	CancelTransactionWorkload(const WorkloadConfig& config) : ApiWorkload(config) {}
+	explicit CancelTransactionWorkload(const WorkloadConfig& config) : ApiWorkload(config) {}
 
 private:
 	enum OpType { OP_CANCEL_GET, OP_CANCEL_AFTER_FIRST_GET, OP_LAST = OP_CANCEL_AFTER_FIRST_GET };

--- a/bindings/c/test/apitester/TesterCorrectnessWorkload.cpp
+++ b/bindings/c/test/apitester/TesterCorrectnessWorkload.cpp
@@ -27,7 +27,7 @@ namespace FdbApiTester {
 
 class ApiCorrectnessWorkload : public ApiWorkload {
 public:
-	ApiCorrectnessWorkload(const WorkloadConfig& config) : ApiWorkload(config) {}
+	explicit ApiCorrectnessWorkload(const WorkloadConfig& config) : ApiWorkload(config) {}
 
 private:
 	enum OpType {

--- a/bindings/c/test/apitester/TesterExampleWorkload.cpp
+++ b/bindings/c/test/apitester/TesterExampleWorkload.cpp
@@ -28,7 +28,7 @@ public:
 	fdb::Key keyPrefix;
 	Random random;
 
-	SetAndGetWorkload(const WorkloadConfig& config) : WorkloadBase(config) {
+	explicit SetAndGetWorkload(const WorkloadConfig& config) : WorkloadBase(config) {
 		keyPrefix = fdb::toBytesRef(fmt::format("{}/", workloadId));
 	}
 

--- a/bindings/c/test/apitester/TesterScheduler.cpp
+++ b/bindings/c/test/apitester/TesterScheduler.cpp
@@ -43,7 +43,7 @@ public:
 
 class AsioScheduler : public IScheduler {
 public:
-	AsioScheduler(int numThreads) : numThreads(numThreads) {}
+	explicit AsioScheduler(int numThreads) : numThreads(numThreads) {}
 
 	void start() override {
 		work = require(io_ctx.get_executor(), execution::outstanding_work.tracked);

--- a/bindings/c/test/apitester/TesterTransactionExecutor.cpp
+++ b/bindings/c/test/apitester/TesterTransactionExecutor.cpp
@@ -640,7 +640,7 @@ protected:
  */
 class TransactionExecutorBase : public ITransactionExecutor {
 public:
-	TransactionExecutorBase(const TransactionExecutorOptions& options) : options(options), scheduler(nullptr) {}
+	explicit TransactionExecutorBase(const TransactionExecutorOptions& options) : options(options), scheduler(nullptr) {}
 
 	~TransactionExecutorBase() override {
 		if (tamperClusterFileThread.joinable()) {
@@ -752,7 +752,7 @@ protected:
  */
 class DBPoolTransactionExecutor : public TransactionExecutorBase {
 public:
-	DBPoolTransactionExecutor(const TransactionExecutorOptions& options) : TransactionExecutorBase(options) {}
+	explicit DBPoolTransactionExecutor(const TransactionExecutorOptions& options) : TransactionExecutorBase(options) {}
 
 	~DBPoolTransactionExecutor() override { release(); }
 
@@ -780,7 +780,7 @@ private:
  */
 class DBPerTransactionExecutor : public TransactionExecutorBase {
 public:
-	DBPerTransactionExecutor(const TransactionExecutorOptions& options) : TransactionExecutorBase(options) {}
+	explicit DBPerTransactionExecutor(const TransactionExecutorOptions& options) : TransactionExecutorBase(options) {}
 
 	fdb::Database selectDatabase() override { return fdb::Database(clusterFile.c_str()); }
 };

--- a/bindings/c/test/apitester/TesterTransactionExecutor.cpp
+++ b/bindings/c/test/apitester/TesterTransactionExecutor.cpp
@@ -640,7 +640,8 @@ protected:
  */
 class TransactionExecutorBase : public ITransactionExecutor {
 public:
-	explicit TransactionExecutorBase(const TransactionExecutorOptions& options) : options(options), scheduler(nullptr) {}
+	explicit TransactionExecutorBase(const TransactionExecutorOptions& options)
+	  : options(options), scheduler(nullptr) {}
 
 	~TransactionExecutorBase() override {
 		if (tamperClusterFileThread.joinable()) {

--- a/bindings/c/test/apitester/TesterWatchAndWaitWorkload.cpp
+++ b/bindings/c/test/apitester/TesterWatchAndWaitWorkload.cpp
@@ -27,7 +27,7 @@ using fdb::Value;
 
 class WatchAndWaitWorkload : public ApiWorkload {
 public:
-	WatchAndWaitWorkload(const WorkloadConfig& config) : ApiWorkload(config) {}
+	explicit WatchAndWaitWorkload(const WorkloadConfig& config) : ApiWorkload(config) {}
 	int getMaxSelfBlockingFutures() override {
 		// One watch future running concurrently waits for a commit of a transaction which sets the value.
 		return 1;

--- a/bindings/c/test/apitester/TesterWorkload.h
+++ b/bindings/c/test/apitester/TesterWorkload.h
@@ -106,7 +106,7 @@ struct WorkloadConfig {
 // Tracks if workload is active, notifies the workload manager when the workload completes
 class WorkloadBase : public IWorkload {
 public:
-	WorkloadBase(const WorkloadConfig& config);
+	explicit WorkloadBase(const WorkloadConfig& config);
 
 	// Initialize the workload
 	void init(WorkloadManager* manager) override;
@@ -301,7 +301,7 @@ struct IWorkloadFactory {
  */
 template <class WorkloadType>
 struct WorkloadFactory : IWorkloadFactory {
-	WorkloadFactory(const char* name) { factories()[name] = this; }
+	explicit WorkloadFactory(const char* name) { factories()[name] = this; }
 	std::shared_ptr<IWorkload> create(const WorkloadConfig& config) override {
 		return std::make_shared<WorkloadType>(config);
 	}

--- a/bindings/flow/DirectoryLayer.h
+++ b/bindings/flow/DirectoryLayer.h
@@ -31,8 +31,8 @@ namespace FDB {
 class DirectoryLayer : public IDirectory {
 public:
 	explicit DirectoryLayer(Subspace nodeSubspace = DEFAULT_NODE_SUBSPACE,
-	               Subspace contentSubspace = DEFAULT_CONTENT_SUBSPACE,
-	               bool allowManualPrefixes = false);
+	                        Subspace contentSubspace = DEFAULT_CONTENT_SUBSPACE,
+	                        bool allowManualPrefixes = false);
 
 	Future<Reference<DirectorySubspace>> create(
 	    Reference<Transaction> const& tr,

--- a/bindings/flow/DirectoryLayer.h
+++ b/bindings/flow/DirectoryLayer.h
@@ -30,7 +30,7 @@
 namespace FDB {
 class DirectoryLayer : public IDirectory {
 public:
-	DirectoryLayer(Subspace nodeSubspace = DEFAULT_NODE_SUBSPACE,
+	explicit DirectoryLayer(Subspace nodeSubspace = DEFAULT_NODE_SUBSPACE,
 	               Subspace contentSubspace = DEFAULT_CONTENT_SUBSPACE,
 	               bool allowManualPrefixes = false);
 

--- a/bindings/flow/HighContentionAllocator.h
+++ b/bindings/flow/HighContentionAllocator.h
@@ -28,7 +28,7 @@
 namespace FDB {
 class HighContentionAllocator {
 public:
-	HighContentionAllocator(Subspace subspace) : counters(subspace.get(0)), recent(subspace.get(1)) {}
+	explicit HighContentionAllocator(Subspace subspace) : counters(subspace.get(0)), recent(subspace.get(1)) {}
 	Future<Standalone<StringRef>> allocate(Reference<Transaction> const& tr) const;
 
 	static int64_t windowSize(int64_t start);

--- a/bindings/flow/Subspace.h
+++ b/bindings/flow/Subspace.h
@@ -30,8 +30,8 @@
 namespace FDB {
 class Subspace {
 public:
-	Subspace(Tuple const& tuple = Tuple(), StringRef const& rawPrefix = StringRef());
-	Subspace(StringRef const& rawPrefix);
+	explicit Subspace(Tuple const& tuple = Tuple(), StringRef const& rawPrefix = StringRef());
+	explicit Subspace(StringRef const& rawPrefix);
 
 	virtual ~Subspace();
 

--- a/bindings/flow/Tuple.h
+++ b/bindings/flow/Tuple.h
@@ -32,7 +32,7 @@ namespace FDB {
 struct Uuid {
 	const static size_t SIZE;
 
-	Uuid(StringRef const& data);
+	explicit Uuid(StringRef const& data);
 
 	StringRef getData() const;
 
@@ -118,7 +118,7 @@ private:
 	// It has additional 2 bytes user code than the internal VERSIONTAMP of size 10 bytes
 	static const uint8_t VERSIONSTAMP_96_CODE;
 
-	Tuple(const StringRef& data);
+	explicit Tuple(const StringRef& data);
 	Tuple(Standalone<VectorRef<uint8_t>> data, std::vector<size_t> offsets);
 	Standalone<VectorRef<uint8_t>> data;
 	std::vector<size_t> offsets;

--- a/bindings/flow/fdb_flow.cpp
+++ b/bindings/flow/fdb_flow.cpp
@@ -277,7 +277,7 @@ bool API::evaluatePredicate(FDBErrorPredicate pred, Error const& e) {
 Reference<Database> API::createDatabase(std::string const& connFilename) {
 	FDBDatabase* db;
 	throw_on_error(fdb_create_database(connFilename.c_str(), &db));
-	return makeReference<DatabaseImpl>(db);
+	return Reference<Database>(new DatabaseImpl(db));
 }
 
 int API::getAPIVersion() const {
@@ -285,7 +285,7 @@ int API::getAPIVersion() const {
 }
 
 Reference<Transaction> DatabaseImpl::createTransaction() {
-	return makeReference<TransactionImpl>(db);
+	return Reference<Transaction>(new TransactionImpl(db));
 }
 
 void DatabaseImpl::setDatabaseOption(FDBDatabaseOption option, Optional<StringRef> value) {

--- a/bindings/flow/fdb_flow.cpp
+++ b/bindings/flow/fdb_flow.cpp
@@ -277,7 +277,7 @@ bool API::evaluatePredicate(FDBErrorPredicate pred, Error const& e) {
 Reference<Database> API::createDatabase(std::string const& connFilename) {
 	FDBDatabase* db;
 	throw_on_error(fdb_create_database(connFilename.c_str(), &db));
-	return Reference<Database>(new DatabaseImpl(db));
+	return makeReference<DatabaseImpl>(db);
 }
 
 int API::getAPIVersion() const {
@@ -285,7 +285,7 @@ int API::getAPIVersion() const {
 }
 
 Reference<Transaction> DatabaseImpl::createTransaction() {
-	return Reference<Transaction>(new TransactionImpl(db));
+	return makeReference<TransactionImpl>(db);
 }
 
 void DatabaseImpl::setDatabaseOption(FDBDatabaseOption option, Optional<StringRef> value) {

--- a/bindings/flow/fdb_flow.h
+++ b/bindings/flow/fdb_flow.h
@@ -165,7 +165,7 @@ public:
 private:
 	static API* instance;
 
-	API(int version);
+	explicit API(int version);
 	int version;
 };
 } // namespace FDB

--- a/bindings/java/JavaWorkload.cpp
+++ b/bindings/java/JavaWorkload.cpp
@@ -165,7 +165,7 @@ jlong getSharedRandomNumber(JNIEnv* env, jclass, jlong self) {
 
 struct JavaPromise {
 	GenericPromise<bool> impl;
-	JavaPromise(GenericPromise<bool>&& promise) : impl(std::move(promise)) {}
+	explicit JavaPromise(GenericPromise<bool>&& promise) : impl(std::move(promise)) {}
 
 	void send(bool val) {
 		impl.send(val);
@@ -235,7 +235,7 @@ struct JVM {
 		}
 	}
 
-	JVM(FDBLogger* log) : log(log) {
+	explicit JVM(FDBLogger* log) : log(log) {
 		try {
 			log->trace(FDBSeverity::Debug, "InitializeJVM", {});
 			JavaVMInitArgs args;
@@ -604,7 +604,7 @@ struct JavaWorkload final : FDBWorkload {
 struct JavaWorkloadFactory : FDBWorkloadFactory {
 	FDBLogger* log;
 	std::weak_ptr<JVM> jvm;
-	JavaWorkloadFactory(FDBLogger* log) : log(log) {}
+	explicit JavaWorkloadFactory(FDBLogger* log) : log(log) {}
 	JavaWorkloadFactory(const JavaWorkloadFactory&) = delete;
 	JavaWorkloadFactory& operator=(const JavaWorkloadFactory&) = delete;
 	std::shared_ptr<FDBWorkload> create(const std::string& name) override {

--- a/fdbclient/ReadYourWrites.actor.cpp
+++ b/fdbclient/ReadYourWrites.actor.cpp
@@ -1340,7 +1340,7 @@ public:
 		// would already have a read version. We need to get a read version too, otherwise committing a conflicting
 		// transaction may not ensure this transaction is no longer in-flight, since this transaction could get a read
 		// version _after_.
-		co_await success(ryw->getReadVersion());
+		co_await ryw->getReadVersion();
 		if (!ryw->resetPromise.isSet())
 			ryw->resetPromise.sendError(transaction_timed_out());
 		co_await delay(deterministicRandom()->random01() * 5);

--- a/fdbclient/include/fdbclient/KeyBackedRangeMap.h
+++ b/fdbclient/include/fdbclient/KeyBackedRangeMap.h
@@ -324,7 +324,7 @@ public:
 		Future<RangeResultType> boundariesFuture =
 		    self.kvMap.getRange(tr, rangeBegin, rangeEnd, GetRangeLimits(readSize));
 
-		Reference<LocalSnapshot> result = makeReference<LocalSnapshot>();
+		auto result = makeReference<LocalSnapshot>();
 		while (true) {
 			kbt_debug("RANGEMAP snapshot loop\n");
 			RangeResultType boundaries = co_await boundariesFuture;

--- a/fdbclient/include/fdbclient/KeyBackedTypes.h
+++ b/fdbclient/include/fdbclient/KeyBackedTypes.h
@@ -312,7 +312,7 @@ Future<Version> WatchableTrigger::onChangeActor(WatchableTrigger self,
 		try {
 			// If the initialVersion is not set yet, then initialize it with the read version
 			if (!initialVersion.present()) {
-				co_await store(initialVersion, safeThreadFutureToFuture(tr->getReadVersion()));
+				initialVersion = co_await safeThreadFutureToFuture(tr->getReadVersion());
 			}
 			if (watching.canBeSet()) {
 				watching.send(*initialVersion);

--- a/fdbclient/include/fdbclient/PImpl.h
+++ b/fdbclient/include/fdbclient/PImpl.h
@@ -27,7 +27,7 @@ class PImpl {
 	std::unique_ptr<T> impl;
 	struct ConstructorTag {};
 	template <class... Args>
-	PImpl(ConstructorTag, Args&&... args) : impl(std::make_unique<T>(std::forward<Args>(args)...)) {}
+	explicit PImpl(ConstructorTag, Args&&... args) : impl(std::make_unique<T>(std::forward<Args>(args)...)) {}
 
 public:
 	PImpl() = default;

--- a/fdbserver/clustercontroller/ClusterRecovery.cpp
+++ b/fdbserver/clustercontroller/ClusterRecovery.cpp
@@ -1160,7 +1160,8 @@ Future<Void> updateLocalityForDcId(Optional<Key> dcId,
 Future<Void> readTransactionSystemState(Reference<ClusterRecoveryData> self,
                                         Reference<LogSystem> oldLogSystem,
                                         Version txsPoppedVersion) {
-	auto myLocality = makeReference<AsyncVar<PeekTxsInfo>>(PeekTxsInfo(tagLocalityInvalid, tagLocalityInvalid, invalidVersion));
+	auto myLocality =
+	    makeReference<AsyncVar<PeekTxsInfo>>(PeekTxsInfo(tagLocalityInvalid, tagLocalityInvalid, invalidVersion));
 	Future<Void> localityUpdater =
 	    updateLocalityForDcId(self->masterInterface.locality.dcId(), oldLogSystem, myLocality);
 	// Peek the txnStateTag in oldLogSystem and recover self->txnStateStore

--- a/fdbserver/clustercontroller/ClusterRecovery.cpp
+++ b/fdbserver/clustercontroller/ClusterRecovery.cpp
@@ -1160,8 +1160,7 @@ Future<Void> updateLocalityForDcId(Optional<Key> dcId,
 Future<Void> readTransactionSystemState(Reference<ClusterRecoveryData> self,
                                         Reference<LogSystem> oldLogSystem,
                                         Version txsPoppedVersion) {
-	Reference<AsyncVar<PeekTxsInfo>> myLocality =
-	    makeReference<AsyncVar<PeekTxsInfo>>(PeekTxsInfo(tagLocalityInvalid, tagLocalityInvalid, invalidVersion));
+	auto myLocality = makeReference<AsyncVar<PeekTxsInfo>>(PeekTxsInfo(tagLocalityInvalid, tagLocalityInvalid, invalidVersion));
 	Future<Void> localityUpdater =
 	    updateLocalityForDcId(self->masterInterface.locality.dcId(), oldLogSystem, myLocality);
 	// Peek the txnStateTag in oldLogSystem and recover self->txnStateStore

--- a/fdbserver/commitproxy/CommitProxyServer.cpp
+++ b/fdbserver/commitproxy/CommitProxyServer.cpp
@@ -3078,7 +3078,7 @@ public:
 		addActor.send(idempotencyIdsExpireServer.run());
 
 		// wait for txnStateStore recovery
-		co_await success(commitData.txnStateStore->readValue(StringRef()));
+		co_await commitData.txnStateStore->readValue(StringRef());
 
 		int commitBatchByteLimit =
 		    (int)std::min<double>(SERVER_KNOBS->COMMIT_TRANSACTION_BATCH_BYTES_MAX,

--- a/fdbserver/workloads/MaxGrvQueueDelay.cpp
+++ b/fdbserver/workloads/MaxGrvQueueDelay.cpp
@@ -48,7 +48,7 @@ struct MaxGrvQueueDelayWorkload : TestWorkload {
 	PerfIntCounter rejected;
 	PerfIntCounter unexpectedErrors;
 
-	MaxGrvQueueDelayWorkload(WorkloadContext const& wcx)
+	explicit MaxGrvQueueDelayWorkload(WorkloadContext const& wcx)
 	  : TestWorkload(wcx), requests("Requests"), successes("Successes"), rejected("Rejected"),
 	    unexpectedErrors("UnexpectedErrors") {
 		requestCount = getOption(options, "requestCount"_sr, 50);

--- a/flow/include/flow/Arena.h
+++ b/flow/include/flow/Arena.h
@@ -394,10 +394,10 @@ public:
 	// constructor — which is the actual use-after-free case this guards against.
 	// Precondition: str is not null.
 	explicit StringRef(const char* str) : StringRef(str, strlen(str)) {}
-	StringRef(std::nullptr_t) = delete;
+	explicit StringRef(std::nullptr_t) = delete;
 	// Reject integer literals (e.g. StringRef(0)), which would otherwise pick the const char*
 	// overload via null-pointer conversion and crash in strlen.
-	StringRef(int) = delete;
+	explicit StringRef(int) = delete;
 	explicit(false) StringRef(const std::string& s) : data((const uint8_t*)s.c_str()), length((int)s.size()) {
 		if (s.size() > std::numeric_limits<int>::max())
 			abort();

--- a/flow/include/flow/TDMetric.h
+++ b/flow/include/flow/TDMetric.h
@@ -409,7 +409,7 @@ template <size_t N>
 struct FixedString {
 	std::array<char, N> value{};
 
-	constexpr FixedString(const char (&str)[N]) {
+	explicit(false) constexpr FixedString(const char (&str)[N]) {
 		for (size_t i = 0; i < N; ++i) {
 			value[i] = str[i];
 		}

--- a/flow/include/flow/genericactors.actor.h
+++ b/flow/include/flow/genericactors.actor.h
@@ -1530,7 +1530,7 @@ AsyncResult<std::vector<T>> getAllAsync(std::vector<AsyncResult<T>> input) {
 	if (input.empty())
 		co_return std::vector<T>();
 
-	Reference<GetAllAsyncResultState<T>> aggregateState = makeReference<GetAllAsyncResultState<T>>(input.size());
+	auto aggregateState = makeReference<GetAllAsyncResultState<T>>(input.size());
 	aggregateState->attach(input);
 	co_await aggregateState->completion.getFuture();
 

--- a/flow/include/flow/swift/Basic/FlagSet.h
+++ b/flow/include/flow/swift/Basic/FlagSet.h
@@ -45,7 +45,7 @@ protected:
 		return lowMaskFor<BitWidth>() << FirstBit;
 	}
 
-	constexpr FlagSet(IntType bits = 0) : Bits(bits) {}
+	explicit constexpr FlagSet(IntType bits = 0) : Bits(bits) {}
 
 	/// Read a single-bit flag.
 	template <unsigned Bit>


### PR DESCRIPTION
This PR uses AST-grep to:

- Make single-argument constructors explicit
- Expand `makeReference` usage
- Expand `auto` usage
- Replace an unnecessary `store` call