### PR TITLE
Fix valgrind and long-running Joshua scripts missing --run-temp-dir

### DIFF
--- a/contrib/Joshua/scripts/longRunningCorrectnessTest.sh
+++ b/contrib/Joshua/scripts/longRunningCorrectnessTest.sh
@@ -6,11 +6,18 @@
 # Simulation currently has memory leaks. We need to investigate before we can enable leak detection in joshua.
 export ASAN_OPTIONS="detect_leaks=0"
 
+if [ -z "${JOSHUA_SEED}" ]; then
+    echo "FATAL: JOSHUA_SEED environment variable is required" >&2
+    echo '<Test Ok="0" Error="InternalError"><JoshuaMessage Severity="40" Message="JOSHUA_SEED environment variable is not set"/></Test>'
+    exit 1
+fi
+
 OLDBINDIR="${OLDBINDIR:-/app/deploy/global_data/oldBinaries}"
 
 # Setup run temp directory (required by TestHarness2)
-RUN_TEMP_DIR="/tmp/th_longrunning_${JOSHUA_SEED}"
-mkdir -p "${RUN_TEMP_DIR}"
+TH_OUTPUT_BASE_DIR="${TH_OUTPUT_DIR:-${DIAG_LOG_DIR:-/tmp}}"
+RUN_TEMP_DIR="${TH_OUTPUT_BASE_DIR}/th_longrunning_${JOSHUA_SEED}"
+mkdir -p "${RUN_TEMP_DIR}" || { echo "FATAL: Failed to create ${RUN_TEMP_DIR}" >&2; exit 1; }
 
 python3 -m test_harness.app \
     --joshua-seed "${JOSHUA_SEED}" \

--- a/contrib/Joshua/scripts/longRunningCorrectnessTest.sh
+++ b/contrib/Joshua/scripts/longRunningCorrectnessTest.sh
@@ -1,22 +1,20 @@
-#!/bin/sh
+#!/bin/bash
+
+# Long-running correctness test wrapper for Joshua/TestHarness2
+# Runs long-running simulation tests (extended duration, no sim speedup).
 
 # Simulation currently has memory leaks. We need to investigate before we can enable leak detection in joshua.
 export ASAN_OPTIONS="detect_leaks=0"
 
 OLDBINDIR="${OLDBINDIR:-/app/deploy/global_data/oldBinaries}"
-#mono bin/TestHarness.exe joshua-run "${OLDBINDIR}" false
 
-# Capture output to check if TestHarness produces anything
-OUTPUT_FILE="/tmp/th_output_${JOSHUA_SEED}.txt"
-python3 -m test_harness.app -s ${JOSHUA_SEED} --old-binaries-path ${OLDBINDIR} --long-running 2>&1 | tee "${OUTPUT_FILE}"
-PYTHON_EXIT_CODE=$?
+# Setup run temp directory (required by TestHarness2)
+RUN_TEMP_DIR="/tmp/th_longrunning_${JOSHUA_SEED}"
+mkdir -p "${RUN_TEMP_DIR}"
 
-# If no output was produced, generate fallback XML
-if [ ! -s "${OUTPUT_FILE}" ]; then
-    echo "WARNING: TestHarness2 produced no output - generating fallback XML" >&2
-    echo "<Test TestFile=\"UNKNOWN\" RandomSeed=\"UNKNOWN\" BuggifyEnabled=\"UNKNOWN\" FaultInjectionEnabled=\"UNKNOWN\" JoshuaSeed=\"${JOSHUA_SEED}\" Ok=\"0\" CrashReason=\"TestHarnessProducedNoOutput\" PythonExitCode=\"${PYTHON_EXIT_CODE}\"><JoshuaMessage Severity=\"40\" Message=\"TestHarness2 crashed or timed out before producing any output.\"/></Test>"
-fi
-
-rm -f "${OUTPUT_FILE}"
-
-exit ${PYTHON_EXIT_CODE}
+python3 -m test_harness.app \
+    --joshua-seed "${JOSHUA_SEED}" \
+    --old-binaries-path "${OLDBINDIR}" \
+    --long-running \
+    --run-temp-dir "${RUN_TEMP_DIR}" \
+    2> "${RUN_TEMP_DIR}/python_app_stderr.log"

--- a/contrib/Joshua/scripts/valgrindTest.sh
+++ b/contrib/Joshua/scripts/valgrindTest.sh
@@ -1,3 +1,17 @@
-#!/bin/sh
+#!/bin/bash
+
+# Valgrind test wrapper for Joshua/TestHarness2
+# Runs simulation tests under valgrind for memory error detection.
+
 OLDBINDIR="${OLDBINDIR:-/app/deploy/global_data/oldBinaries}"
-python3 -m test_harness.app -s ${JOSHUA_SEED} --old-binaries-path ${OLDBINDIR} --use-valgrind
+
+# Setup run temp directory (required by TestHarness2)
+RUN_TEMP_DIR="/tmp/th_valgrind_${JOSHUA_SEED}"
+mkdir -p "${RUN_TEMP_DIR}"
+
+python3 -m test_harness.app \
+    --joshua-seed "${JOSHUA_SEED}" \
+    --old-binaries-path "${OLDBINDIR}" \
+    --use-valgrind \
+    --run-temp-dir "${RUN_TEMP_DIR}" \
+    2> "${RUN_TEMP_DIR}/python_app_stderr.log"

--- a/contrib/Joshua/scripts/valgrindTest.sh
+++ b/contrib/Joshua/scripts/valgrindTest.sh
@@ -3,11 +3,18 @@
 # Valgrind test wrapper for Joshua/TestHarness2
 # Runs simulation tests under valgrind for memory error detection.
 
+if [ -z "${JOSHUA_SEED}" ]; then
+    echo "FATAL: JOSHUA_SEED environment variable is required" >&2
+    echo '<Test Ok="0" Error="InternalError"><JoshuaMessage Severity="40" Message="JOSHUA_SEED environment variable is not set"/></Test>'
+    exit 1
+fi
+
 OLDBINDIR="${OLDBINDIR:-/app/deploy/global_data/oldBinaries}"
 
 # Setup run temp directory (required by TestHarness2)
-RUN_TEMP_DIR="/tmp/th_valgrind_${JOSHUA_SEED}"
-mkdir -p "${RUN_TEMP_DIR}"
+TH_OUTPUT_BASE_DIR="${TH_OUTPUT_DIR:-${DIAG_LOG_DIR:-/tmp}}"
+RUN_TEMP_DIR="${TH_OUTPUT_BASE_DIR}/th_valgrind_${JOSHUA_SEED}"
+mkdir -p "${RUN_TEMP_DIR}" || { echo "FATAL: Failed to create ${RUN_TEMP_DIR}" >&2; exit 1; }
 
 python3 -m test_harness.app \
     --joshua-seed "${JOSHUA_SEED}" \


### PR DESCRIPTION
dda204da5d ("Add doc, more options around log archiving, and facility debugging joshua (#12231)"), a commit made by me a year ago, made --run-temp-dir a required argument for TestHarness2 and updated correctnessTest.sh, but missed updating valgrindTest.sh and longRunningCorrectnessTest.sh. This caused all valgrind nightly tests on main to fail with "TestHarness2 terminated abnormally before generating test output" (EmergencyFallback).

The longRunningCorrectnessTest.sh diff is large but the only functional change is adding --run-temp-dir. The rest is removing shell-level plumbing that is now redundant because the same commit (dda204da5d) added equivalent handling inside app.py:

- Shell fallback XML removed: app.py lines 92-103 now have a finally block that guarantees XML output (EmergencyFallback) even if Python crashes before TestRunner.run() completes. The shell fallback was added as a stopgap before this existed.

- tee/OUTPUT_FILE removed: Joshua reads XML from stdout directly. The tee was only needed to detect empty output for the shell fallback above. No longer needed.

- exit code handling removed: Python already exits non-zero on test failure (app.py line 80). The shell just propagates it naturally.

stderr is redirected to python_app_stderr.log in the run temp dir so it remains available for debugging without being lost.

valgrindTest.sh has a smaller diff (was only 3 lines) -- just adds the required --run-temp-dir argument and stderr capture.

To reproduce the failure (before fix):
  cd contrib/TestHarness2
  python3 -m test_harness.app -s 3716189889 --use-valgrind
  // -> error: the following arguments are required: --run-temp-dir

To verify the fix:
  cd /path/to/foundationdb
  PYTHONPATH=contrib/TestHarness2 python3 -m test_harness.app \
    -s 3716189889 --use-valgrind --run-temp-dir /tmp/th_test \
    --binary bin/fdbserver
