### PR TITLE
chore: declare contents: read on windows-boost-test workflow

### DIFF
--- a/.github/workflows/windows-boost-test.yml
+++ b/.github/workflows/windows-boost-test.yml
@@ -8,6 +8,9 @@ on:
       - 'boost-*'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test-windows-boost:
     name: Test Boost CONFIG Mode on Windows


### PR DESCRIPTION
`windows-boost-test.yml` runs the Boost test suite on Windows. `linux.yml` in this repo already declares workflow-level `permissions: contents: read`; this PR matches that style for the remaining CI workflow.