### PR TITLE
ctest: java-integration (Failed): Reduce MappedRangeQueryIntegrationTest record count to fix CI flakiness

### DIFF
--- a/bindings/java/src/integration/com/apple/foundationdb/MappedRangeQueryIntegrationTest.java
+++ b/bindings/java/src/integration/com/apple/foundationdb/MappedRangeQueryIntegrationTest.java
@@ -104,7 +104,10 @@ class MappedRangeQueryIntegrationTest {
 		test.clearDatabase();
 	}
 
-	int numRecords = 10000;
+	// Keep numRecords modest so transactions complete within the 5s timeout
+	// even on heavily loaded CI infrastructure (e.g., CodeBuild running
+	// compilation and tests concurrently on the same instance).
+	int numRecords = 1000;
 	int numQueries = 1;
 	int numRecordsPerQuery = 100;
 	boolean validate = true;


### PR DESCRIPTION
The MappedRangeQueryIntegrationTest has been frequently timing out in CI (transaction_timed_out error 1031). The test inserts 10,000 records (40,000 keys) which seemingly can exceed the 5s transaction timeout when the CodeBuild instance is under heavy load from concurrent compilation and other tests.

Reduce numRecords from 10,000 to 1,000. This still validates the mapped range query functionality (1,000 records with 3 splits each = 4,000 keys, querying 100 at a time) hopefully completing well within the transaction timeout on loaded infrastructure.

If this doesn't work, will have to go deeper.
