### PR TITLE
Rename routerTag to tag in InitializeBackupRequest and refactor BackupProgress

### DIFF
--- a/fdbclient/include/fdbclient/FDBTypes.h
+++ b/fdbclient/include/fdbclient/FDBTypes.h
@@ -61,6 +61,7 @@ enum {
 	tagLocalityLogRouterMapped = -6, // The pseudo tag used by log routers to pop the real LogRouter tag (i.e., -2)
 	tagLocalityTxs = -7,
 	tagLocalityBackup = -8, // used by backup role to pop from TLogs
+	tagLocalityRangeBackup = -9, // used by range-partitioned backup workers
 	tagLocalityInvalid = -99
 }; // The TLog and LogRouter require these number to be as compact as possible
 

--- a/fdbserver/backupworker/BackupWorker.cpp
+++ b/fdbserver/backupworker/BackupWorker.cpp
@@ -265,10 +265,10 @@ struct BackupData {
 	Future<Void> logger;
 
 	explicit BackupData(UID id, Reference<AsyncVar<ServerDBInfo> const> db, const InitializeBackupRequest& req)
-	  : myId(id), tag(req.routerTag), totalTags(req.totalTags), startVersion(req.startVersion),
-	    endVersion(req.endVersion), recruitedEpoch(req.recruitedEpoch), backupEpoch(req.backupEpoch),
-	    minKnownCommittedVersion(invalidVersion), savedVersion(req.startVersion - 1), db(db), pulledVersion(0),
-	    paused(false), lock(new FlowLock(SERVER_KNOBS->BACKUP_WORKER_LOCK_BYTES)), cc("BackupWorker", myId.toString()) {
+	  : myId(id), tag(req.tag), totalTags(req.totalTags), startVersion(req.startVersion), endVersion(req.endVersion),
+	    recruitedEpoch(req.recruitedEpoch), backupEpoch(req.backupEpoch), minKnownCommittedVersion(invalidVersion),
+	    savedVersion(req.startVersion - 1), db(db), pulledVersion(0), paused(false),
+	    lock(new FlowLock(SERVER_KNOBS->BACKUP_WORKER_LOCK_BYTES)), cc("BackupWorker", myId.toString()) {
 		cx = openDBOnServer(db, TaskPriority::DefaultEndpoint, LockAware::True);
 
 		specialCounter(cc, "SavedVersion", [this]() { return this->savedVersion; });
@@ -1053,7 +1053,7 @@ Future<Void> backupWorker(BackupInterface interf,
 	Error err;
 
 	TraceEvent("BackupWorkerStart", self.myId)
-	    .detail("Tag", req.routerTag.toString())
+	    .detail("Tag", req.tag.toString())
 	    .detail("TotalTags", req.totalTags)
 	    .detail("StartVersion", req.startVersion)
 	    .detail("EndVersion", req.endVersion.present() ? req.endVersion.get() : -1)
@@ -1062,7 +1062,7 @@ Future<Void> backupWorker(BackupInterface interf,
 	try {
 		addActor.send(checkRemoved(db, req.recruitedEpoch, &self));
 		addActor.send(waitFailureServer(interf.waitFailure.getFuture()));
-		if (req.recruitedEpoch == req.backupEpoch && req.routerTag.id == 0) {
+		if (req.recruitedEpoch == req.backupEpoch && req.tag.id == 0) {
 			addActor.send(monitorBackupProgress(&self));
 		}
 		addActor.send(monitorWorkerPause(&self));

--- a/fdbserver/backupworker/BackupWorkerRangePartitioned.cpp
+++ b/fdbserver/backupworker/BackupWorkerRangePartitioned.cpp
@@ -132,10 +132,9 @@ struct BackupRangePartitionedData {
 	explicit BackupRangePartitionedData(UID id,
 	                                    Reference<AsyncVar<ServerDBInfo> const> db,
 	                                    const InitializeBackupRequest& req)
-	  : myId(id), tag(req.routerTag), totalTags(req.totalTags), startVersion(req.startVersion),
-	    endVersion(req.endVersion), recruitedEpoch(req.recruitedEpoch), backupEpoch(req.backupEpoch),
-	    minKnownCommittedVersion(invalidVersion), savedVersion(req.startVersion - 1), pulledVersion(0),
-	    logFolderBaseVersion(invalidVersion), paused(false),
+	  : myId(id), tag(req.tag), totalTags(req.totalTags), startVersion(req.startVersion), endVersion(req.endVersion),
+	    recruitedEpoch(req.recruitedEpoch), backupEpoch(req.backupEpoch), minKnownCommittedVersion(invalidVersion),
+	    savedVersion(req.startVersion - 1), pulledVersion(0), logFolderBaseVersion(invalidVersion), paused(false),
 	    lock(new FlowLock(SERVER_KNOBS->BACKUP_WORKER_LOCK_BYTES)) {
 		cx = openDBOnServer(db, TaskPriority::DefaultEndpoint, LockAware::True);
 	}
@@ -1069,7 +1068,7 @@ Future<Void> backupWorkerRangePartitioned(BackupInterface interf,
 	Error err;
 
 	TraceEvent("BWRangePartitionedStart", self.myId)
-	    .detail("Tag", req.routerTag.toString())
+	    .detail("Tag", req.tag.toString())
 	    .detail("TotalTags", req.totalTags)
 	    .detail("StartVersion", req.startVersion)
 	    .detail("EndVersion", req.endVersion.present() ? req.endVersion.get() : -1)
@@ -1080,7 +1079,7 @@ Future<Void> backupWorkerRangePartitioned(BackupInterface interf,
 		addActor.send(checkRemoved(db, req.recruitedEpoch, &self));
 		addActor.send(waitFailureServer(interf.waitFailure.getFuture()));
 
-		if (req.recruitedEpoch == req.backupEpoch && req.routerTag.id == 0) {
+		if (req.recruitedEpoch == req.backupEpoch && req.tag.id == 0) {
 			addActor.send(monitorBackupRangePartitionedProgress(&self));
 		}
 

--- a/fdbserver/clustercontroller/ClusterRecovery.cpp
+++ b/fdbserver/clustercontroller/ClusterRecovery.cpp
@@ -651,7 +651,7 @@ static Future<Void> recruitBackupWorkers(Reference<ClusterRecoveryData> self, Da
 
 	LogEpoch epoch = self->cstate.myDBState.recoveryCount;
 	Reference<BackupProgress> backupProgress(
-	    new BackupProgress(self->dbgid, self->logSystem->getOldEpochTagsVersionsInfo()));
+	    new BackupProgress(self->dbgid, self->logSystem->getOldEpochLRTagsVersionsInfo()));
 	Future<Void> gotProgress = getBackupProgress(cx, self->dbgid, backupProgress, SevInfo);
 	std::vector<Future<InitializeBackupReply>> initializationReplies;
 
@@ -669,12 +669,12 @@ static Future<Void> recruitBackupWorkers(Reference<ClusterRecoveryData> self, Da
 		InitializeBackupRequest req(idsTags[i].first);
 		req.recruitedEpoch = epoch;
 		req.backupEpoch = epoch;
-		req.routerTag = idsTags[i].second;
+		req.tag = idsTags[i].second;
 		req.totalTags = logRouterTags;
 		req.startVersion = startVersion;
 		TraceEvent("BackupRecruitment", self->dbgid)
 		    .detail("RequestID", req.reqId)
-		    .detail("Tag", req.routerTag.toString())
+		    .detail("Tag", req.tag.toString())
 		    .detail("Epoch", epoch)
 		    .detail("BackupEpoch", epoch)
 		    .detail("StartVersion", req.startVersion);
@@ -690,7 +690,7 @@ static Future<Void> recruitBackupWorkers(Reference<ClusterRecoveryData> self, Da
 	TraceEvent("MinBackupVersion", self->dbgid).detail("Version", minVersion.present() ? minVersion.get() : -1);
 
 	std::map<std::tuple<LogEpoch, Version, int>, std::map<Tag, Version>> toRecruit =
-	    backupProgress->getUnfinishedBackup();
+	    backupProgress->getUnfinishedPartitionedBackup();
 	for (const auto& [epochVersionTags, tagVersions] : toRecruit) {
 		const Version oldEpochEnd = std::get<1>(epochVersionTags);
 		if (!minVersion.present() || minVersion.get() + 1 >= oldEpochEnd) {
@@ -707,13 +707,13 @@ static Future<Void> recruitBackupWorkers(Reference<ClusterRecoveryData> self, Da
 			InitializeBackupRequest req(deterministicRandom()->randomUniqueID());
 			req.recruitedEpoch = epoch;
 			req.backupEpoch = std::get<0>(epochVersionTags);
-			req.routerTag = tag;
+			req.tag = tag;
 			req.totalTags = std::get<2>(epochVersionTags);
 			req.startVersion = version; // savedVersion + 1
 			req.endVersion = std::get<1>(epochVersionTags) - 1;
 			TraceEvent("BackupRecruitment", self->dbgid)
 			    .detail("RequestID", req.reqId)
-			    .detail("Tag", req.routerTag.toString())
+			    .detail("Tag", req.tag.toString())
 			    .detail("Epoch", epoch)
 			    .detail("BackupEpoch", req.backupEpoch)
 			    .detail("StartVersion", req.startVersion)

--- a/fdbserver/core/BackupProgress.cpp
+++ b/fdbserver/core/BackupProgress.cpp
@@ -69,7 +69,17 @@ void BackupProgress::updateTagVersions(std::map<Tag, Version>* tagVersions,
 	}
 }
 
-std::map<std::tuple<LogEpoch, Version, int>, std::map<Tag, Version>> BackupProgress::getUnfinishedBackup() {
+std::map<std::tuple<LogEpoch, Version, int>, std::map<Tag, Version>> BackupProgress::getUnfinishedPartitionedBackup() {
+	return getUnfinishedBackup(tagLocalityLogRouter);
+}
+
+std::map<std::tuple<LogEpoch, Version, int>, std::map<Tag, Version>>
+BackupProgress::getUnfinishedRangePartitionedBackup() {
+	return getUnfinishedBackup(tagLocalityRangeBackup);
+}
+
+std::map<std::tuple<LogEpoch, Version, int>, std::map<Tag, Version>> BackupProgress::getUnfinishedBackup(
+    int8_t locality) {
 	std::map<std::tuple<LogEpoch, Version, int>, std::map<Tag, Version>> toRecruit;
 
 	if (!backupStartedValue.present())
@@ -77,7 +87,7 @@ std::map<std::tuple<LogEpoch, Version, int>, std::map<Tag, Version>> BackupProgr
 
 	Version lastEnd = invalidVersion;
 	for (const auto& [epoch, info] : epochInfos) {
-		std::set<Tag> tags = enumerateLogRouterTags(info.logRouterTags);
+		std::set<Tag> tags = enumerateTags(locality, info.tags);
 		std::map<Tag, Version> tagVersions;
 
 		// Sometimes, an epoch's begin version is lower than the previous epoch's
@@ -117,8 +127,8 @@ std::map<std::tuple<LogEpoch, Version, int>, std::map<Tag, Version>> BackupProgr
 					}
 				}
 				if (savedMore > 0) {
-					// The logRouterTags are the same
-					// ASSERT(info.logRouterTags == epochTags[rit->first]);
+					// The tags are the same
+					// ASSERT(info.tags == epochTags[rit->first]);
 					updateTagVersions(&tagVersions, &tags, rit->second, info.epochEnd, adjustedBeginVersion, epoch);
 					if (tags.empty())
 						break;
@@ -137,7 +147,7 @@ std::map<std::tuple<LogEpoch, Version, int>, std::map<Tag, Version>> BackupProgr
 			    .detail("EndVersion", info.epochEnd);
 		}
 		if (!tagVersions.empty()) {
-			toRecruit[{ epoch, info.epochEnd, info.logRouterTags }] = tagVersions;
+			toRecruit[{ epoch, info.epochEnd, info.tags }] = tagVersions;
 		}
 	}
 	return toRecruit;
@@ -188,7 +198,8 @@ TEST_CASE("/BackupProgress/Unfinished") {
 	BackupProgress progress(UID(0, 0), epochInfos);
 	progress.setBackupStartedValue(Optional<Value>("1"_sr));
 
-	std::map<std::tuple<LogEpoch, Version, int>, std::map<Tag, Version>> unfinished = progress.getUnfinishedBackup();
+	std::map<std::tuple<LogEpoch, Version, int>, std::map<Tag, Version>> unfinished =
+	    progress.getUnfinishedPartitionedBackup();
 	ASSERT(unfinished.size() == 1);
 	for (const auto& [epochVersionCount, tagVersion] : unfinished) {
 		ASSERT(std::get<0>(epochVersionCount) == epoch1 && std::get<1>(epochVersionCount) == end1 &&
@@ -199,7 +210,7 @@ TEST_CASE("/BackupProgress/Unfinished") {
 	const int saved1 = 50, totalTags = 1;
 	WorkerBackupStatus status1(epoch1, saved1, tag1, totalTags);
 	progress.addBackupStatus(status1);
-	unfinished = progress.getUnfinishedBackup();
+	unfinished = progress.getUnfinishedPartitionedBackup();
 	ASSERT(unfinished.size() == 1);
 	for (const auto& [epochVersionCount, tagVersion] : unfinished) {
 		ASSERT(std::get<0>(epochVersionCount) == epoch1 && std::get<1>(epochVersionCount) == end1 &&

--- a/fdbserver/core/include/fdbserver/core/BackupProgress.h
+++ b/fdbserver/core/include/fdbserver/core/BackupProgress.h
@@ -38,7 +38,7 @@ public:
 	// savedVersion is used.
 	void addBackupStatus(const WorkerBackupStatus& status);
 
-	// Returns a map of tuple<Epoch, endVersion, logRouterTags> : std::map<tag, savedVersion>, so that
+	// Returns a map of tuple<Epoch, endVersion, tags> : std::map<tag, savedVersion>, so that
 	// the backup range should be [savedVersion + 1, endVersion) for the "tag" of the "Epoch".
 	//
 	// Specifically, the backup ranges for each old epoch are:
@@ -46,7 +46,8 @@ public:
 	//        backup [epochBegin, endVersion)
 	//    else if savedVersion < endVersion - 1 = knownCommittedVersion
 	//        backup [savedVersion + 1, endVersion)
-	std::map<std::tuple<LogEpoch, Version, int>, std::map<Tag, Version>> getUnfinishedBackup();
+	std::map<std::tuple<LogEpoch, Version, int>, std::map<Tag, Version>> getUnfinishedPartitionedBackup();
+	std::map<std::tuple<LogEpoch, Version, int>, std::map<Tag, Version>> getUnfinishedRangePartitionedBackup();
 
 	// Set the value for "backupStartedKey"
 	void setBackupStartedValue(Optional<Value> value) { backupStartedValue = value; }
@@ -64,10 +65,12 @@ public:
 	void delref() { ReferenceCounted<BackupProgress>::delref(); }
 
 private:
-	std::set<Tag> enumerateLogRouterTags(int logRouterTags) const {
+	std::map<std::tuple<LogEpoch, Version, int>, std::map<Tag, Version>> getUnfinishedBackup(int8_t locality);
+
+	std::set<Tag> enumerateTags(int8_t locality, int count) const {
 		std::set<Tag> tags;
-		for (int i = 0; i < logRouterTags; i++) {
-			tags.insert(Tag(tagLocalityLogRouter, i));
+		for (int i = 0; i < count; i++) {
+			tags.insert(Tag(locality, i));
 		}
 		return tags;
 	}

--- a/fdbserver/core/include/fdbserver/core/BackupProgressTypes.h
+++ b/fdbserver/core/include/fdbserver/core/BackupProgressTypes.h
@@ -23,9 +23,8 @@
 #include "fdbclient/FDBTypes.h"
 
 struct EpochTagsVersionsInfo {
-	int32_t logRouterTags;
+	int32_t tags;
 	Version epochBegin, epochEnd;
 
-	explicit EpochTagsVersionsInfo(int32_t n, Version begin, Version end)
-	  : logRouterTags(n), epochBegin(begin), epochEnd(end) {}
+	explicit EpochTagsVersionsInfo(int32_t n, Version begin, Version end) : tags(n), epochBegin(begin), epochEnd(end) {}
 };

--- a/fdbserver/core/include/fdbserver/core/WorkerInterface.actor.h
+++ b/fdbserver/core/include/fdbserver/core/WorkerInterface.actor.h
@@ -650,7 +650,7 @@ struct InitializeBackupRequest {
 	LogEpoch recruitedEpoch; // The epoch the worker is recruited.
 	LogEpoch backupEpoch; // The epoch the worker should work on. If different from the recruitedEpoch, then it refers
 	                      // to some previous epoch with unfinished work.
-	Tag routerTag;
+	Tag tag;
 	int totalTags;
 	Version startVersion;
 	Optional<Version> endVersion;
@@ -661,7 +661,7 @@ struct InitializeBackupRequest {
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, reqId, recruitedEpoch, backupEpoch, routerTag, totalTags, startVersion, endVersion, reply);
+		serializer(ar, reqId, recruitedEpoch, backupEpoch, tag, totalTags, startVersion, endVersion, reply);
 	}
 };
 

--- a/fdbserver/logsystem/LogSystem.cpp
+++ b/fdbserver/logsystem/LogSystem.cpp
@@ -2134,7 +2134,7 @@ Version LogSystem::getBackupStartVersion() const {
 	return backupStartVersion;
 }
 
-std::map<LogEpoch, EpochTagsVersionsInfo> LogSystem::getOldEpochTagsVersionsInfo() const {
+std::map<LogEpoch, EpochTagsVersionsInfo> LogSystem::getOldEpochLRTagsVersionsInfo() const {
 	std::map<LogEpoch, EpochTagsVersionsInfo> epochInfos;
 	for (const auto& old : oldLogData) {
 		epochInfos.insert({ old.epoch, EpochTagsVersionsInfo(old.logRouterTags, old.epochBegin, old.epochEnd) });

--- a/fdbserver/logsystem/include/fdbserver/logsystem/LogSystem.h
+++ b/fdbserver/logsystem/include/fdbserver/logsystem/LogSystem.h
@@ -516,7 +516,7 @@ struct LogSystem : ReferenceCounted<LogSystem> {
 
 	Version getBackupStartVersion() const;
 
-	std::map<LogEpoch, EpochTagsVersionsInfo> getOldEpochTagsVersionsInfo() const;
+	std::map<LogEpoch, EpochTagsVersionsInfo> getOldEpochLRTagsVersionsInfo() const;
 
 	inline Reference<LogSet> getEpochLogSet(LogEpoch epoch) const;
 


### PR DESCRIPTION
Summary:
 1. Renames InitializeBackupRequest::routerTag → tag (more generic, since it now applies to both log-router and range-partitioned backup workers)
  2. Refactors BackupProgress::getUnfinishedBackup() to be locality-parameterized, exposed through two public wrappers                            
  3. Renames EpochTagsVersionsInfo::logRouterTags → tags to match the new generic field                               
  4. Renames getOldEpochTagsVersionsInfo() → getOldEpochLRTagsVersionsInfo() to be explicit it's log-router-specific                                                                                                                                   
  5. Adds tagLocalityRangeBackup = -9  
  6. getUnfinishedRangePartitionedBackup() is now declared and implemented, no callers in this commit but it will be implemented.
  
  100k correctness running:
  20260513-192441-neethuhaneeshabingi-c12375508f9d6467 compressed=True data_size=41113159 duration=3571705 ended=100000 fail=1  ( unrelated failure)
  