### PR TITLE
Document repair-coalesce in README

### DIFF
--- a/contrib/metadata_audit/README.md
+++ b/contrib/metadata_audit/README.md
@@ -3,6 +3,12 @@
 Tools for diagnosing and recovering from FoundationDB metadata corruption
 (serverList, keyServers, serverKeys).
 
+**You should never need these tools under normal operation.** They exist to
+address rare metadata inconsistencies found in older versions of FDB (7.3)
+due to bugs in shard movement that should now be fixed. If you find yourself
+needing them on a current release, something unexpected has happened — please
+be sure to file a bug.
+
 ## Quick Start
 
 ```bash
@@ -65,20 +71,21 @@ package installed), you only need the cluster file:
 ### `check` — Corruption Diagnostics
 
 Reads all three metadata spaces and cross-references them to detect:
+- Uncoalesced adjacent entries (keyServers and serverKeys)
+- Dead server references (servers not in serverList)
+- keyServers/serverKeys disagreements (wrong_shard_server)
 - Orphaned serverKeys entries (server not in serverList)
-- Missing serverKeys entries (keyServers references server with no serverKeys)
-- keyServers/serverKeys disagreements
-- Non-contiguous keyServers ranges (gaps or overlaps)
+- Empty source servers in keyServers
 - Ranges assigned to zero servers
+- SS shard probing (actual reads to detect missing data)
 
 ```bash
 ./metadata-audit.sh check -C fdb.cluster
 ./metadata-audit.sh check -C fdb.cluster --output report.txt
 ```
 
-**Note:** The check output is verbose and not heavily curated — it dumps
-everything it finds. Expect noise; focus on the summary sections and
-error counts at the end.
+**Note:** The check output is verbose — it dumps everything it finds.
+Focus on the FINDINGS and EXECUTIVE SUMMARY sections at the end.
 
 ### `backup` — Snapshot Metadata to JSON
 
@@ -110,6 +117,71 @@ after a failed repair attempt.
 **Important limitations:** Restoring `serverKeys` only works if the same
 storage servers are still running (same UIDs). See comments in
 `restore_metadata.py` for details.
+
+### `repair-coalesce` — Fix Uncoalesced Entries
+
+**This is a rare condition.** Under normal operation, FDB's Data Distributor
+coalesces KRM entries automatically. Uncoalesced entries can occur after bugs
+in shard movement, interrupted data moves, or metadata corruption.
+
+**When you need this:** DD fails to start (crash-loops with an assertion in
+`MoveKeys.cpp`) because it encounters adjacent serverKeys entries with the
+same value during a shard move. The `check` command will report uncoalesced
+entries. This tool deletes the redundant entries so DD can operate normally.
+
+Removes redundant adjacent KRM entries with the same value. This is safe and
+idempotent — running it on a healthy cluster finds nothing to delete, and
+running it multiple times is harmless.
+
+**Background:** KRM (Key Range Map) entries define where a value starts. If
+two adjacent entries have the same value, the second is redundant and wastes
+space. Uncoalesced entries on live servers can trigger assertions during active
+shard moves; on dead servers they are inert garbage.
+
+```bash
+# Dry run — read-only, shows what would be deleted
+./metadata-audit.sh repair-coalesce --type serverKeys --dry-run -C fdb.cluster
+
+# Dry run for a single server
+./metadata-audit.sh repair-coalesce --type serverKeys --server <UID_HEX> --dry-run -C fdb.cluster
+
+# Actually fix (requires confirmation flag)
+./metadata-audit.sh repair-coalesce --type serverKeys --yes-i-am-sure -C fdb.cluster
+
+# Fix a single server only (smallest blast radius for first test)
+./metadata-audit.sh repair-coalesce --type serverKeys --server <UID_HEX> --yes-i-am-sure -C fdb.cluster
+
+# Fix keyServers entries
+./metadata-audit.sh repair-coalesce --type keyServers --dry-run -C fdb.cluster
+./metadata-audit.sh repair-coalesce --type keyServers --yes-i-am-sure -C fdb.cluster
+```
+
+**Options:**
+- `--type serverKeys|keyServers` — which metadata to coalesce (required)
+- `--server UID` — limit to a specific server (hex UID, serverKeys only)
+- `--key-prefix HEX` — limit to keys with this prefix (keyServers only)
+- `--dry-run` — show what would be deleted without making changes
+- `--yes-i-am-sure` — required to actually write (mutually exclusive with `--dry-run`)
+- `--keep-dd-disabled` — don't re-enable DD after repair (use when chaining multiple repairs)
+
+**What it does:**
+1. Disables Data Distribution and takes the MoveKeysLock
+2. Reads all entries in the target range
+3. Identifies runs of adjacent entries with the same value
+4. Deletes redundant entries in batches (keeps the first entry in each run)
+5. Re-enables DD and releases the lock
+
+**Safety:**
+- DD is disabled during writes — no conflicts with shard moves
+- Only deletes redundant boundaries — KRM semantics are unchanged
+- Idempotent — running again after repair finds 0 entries to delete
+- Verify with `status details` after repair — DD should reinitialize and show "Healthy"
+
+**After running repair**, confirm DD is healthy:
+```bash
+fdbcli -C fdb.cluster --exec "status details"
+```
+Look for `Replication health - Healthy` and `Moving data` showing a value (not "unknown").
 
 ## Environment Setup (Manual)
 

--- a/contrib/metadata_audit/README.md
+++ b/contrib/metadata_audit/README.md
@@ -75,8 +75,7 @@ Reads all three metadata spaces and cross-references them to detect:
 - Dead server references (servers not in serverList)
 - keyServers/serverKeys disagreements (wrong_shard_server)
 - Orphaned serverKeys entries (server not in serverList)
-- Empty source servers in keyServers
-- Ranges assigned to zero servers
+- Empty source servers / ranges assigned to zero servers
 - SS shard probing (actual reads to detect missing data)
 
 ```bash
@@ -124,10 +123,11 @@ storage servers are still running (same UIDs). See comments in
 coalesces KRM entries automatically. Uncoalesced entries can occur after bugs
 in shard movement, interrupted data moves, or metadata corruption.
 
-**When you need this:** DD fails to start (crash-loops with an assertion in
-`MoveKeys.cpp`) because it encounters adjacent serverKeys entries with the
-same value during a shard move. The `check` command will report uncoalesced
-entries. This tool deletes the redundant entries so DD can operate normally.
+**When you need this:** DD crash-loops on an assertion in `MoveKeys.cpp`
+(function `unassignServerKeys`) while attempting a shard move, because it
+encounters adjacent serverKeys entries with the same value. The `check` command
+will report uncoalesced entries. This tool deletes the redundant entries so DD
+can operate normally.
 
 Removes redundant adjacent KRM entries with the same value. This is safe and
 idempotent — running it on a healthy cluster finds nothing to delete, and
@@ -161,8 +161,8 @@ shard moves; on dead servers they are inert garbage.
 - `--server UID` — limit to a specific server (hex UID, serverKeys only)
 - `--key-prefix HEX` — limit to keys with this prefix (keyServers only)
 - `--dry-run` — show what would be deleted without making changes
-- `--yes-i-am-sure` — required to actually write (mutually exclusive with `--dry-run`)
-- `--keep-dd-disabled` — don't re-enable DD after repair (use when chaining multiple repairs)
+- `--yes-i-am-sure` — required to actually write; ignored if `--dry-run` is also set
+- `--keep-dd-disabled` — don't re-enable DD after repair (use when chaining multiple repairs; remember to re-enable DD manually when done)
 
 **What it does:**
 1. Disables Data Distribution and takes the MoveKeysLock
@@ -175,6 +175,8 @@ shard moves; on dead servers they are inert garbage.
 - DD is disabled during writes — no conflicts with shard moves
 - Only deletes redundant boundaries — KRM semantics are unchanged
 - Idempotent — running again after repair finds 0 entries to delete
+- If interrupted (ctrl-C, crash), DD remains disabled. Re-enable manually:
+  `fdbcli --exec "option on ACCESS_SYSTEM_KEYS; writemode on; set \xff/dataDistributionMode \x01\x00\x00\x00"`
 - Verify with `status details` after repair — DD should reinitialize and show "Healthy"
 
 **After running repair**, confirm DD is healthy:

--- a/contrib/metadata_audit/check_krm_corruption.py
+++ b/contrib/metadata_audit/check_krm_corruption.py
@@ -5014,7 +5014,7 @@ def main():
             print(f"\n  {severity}: {len(sk_issues['uncoalesced'])} uncoalesced adjacent entries!")
             if live_uncoalesced:
                 print(f"            Live server entries may trigger ASSERT during shard moves")
-                print(f"            (MoveKeys.cpp:176 asserts no adjacent duplicates when writing)")
+                print(f"            (MoveKeys.cpp unassignServerKeys asserts no adjacent duplicates when writing)")
             else:
                 print(f"            All on dead servers — will NOT crash DD (dead servers are never read)")
             print(f"\n    Breakdown:")
@@ -5054,7 +5054,7 @@ def main():
         if sk_issues['dead_servers']:
             dead_unique = set(i['server_id'] for i in sk_issues['dead_servers'])
             print(f"\n  WARNING: {len(sk_issues['dead_servers'])} entries for {len(dead_unique)} dead servers")
-            print(f"           (Dead server refs won't crash DD immediately but cause issues)")
+            print(f"           (Dead server refs are inert — DD never reads serverKeys for servers not in serverList)")
             total_issues += len(sk_issues['dead_servers'])
             for srv in list(dead_unique)[:5]:
                 print(f"    - {decode_uid(srv)}")
@@ -5634,9 +5634,9 @@ def main():
                 print("  Impact:")
                 print("    - keyServers: Wastes memory in DD shard map (no crash)")
                 print("    - serverKeys (live): May trigger ASSERT during active shard moves")
-                print("      (MoveKeys.cpp:176 asserts no adjacent duplicates when writing)")
+                print("      (MoveKeys.cpp unassignServerKeys asserts no adjacent duplicates when writing)")
                 print("    - serverKeys (dead): Inert garbage, never read by DD")
-                print("\n  Fix: Run repair_coalesce.py to delete redundant entries (idempotent)")
+                print("\n  Fix: Run ./metadata-audit.sh repair-coalesce to delete redundant entries (idempotent)")
 
             if has_dead_refs:
                 print("\nDEAD SERVER REFERENCES DETECTED:")

--- a/contrib/metadata_audit/check_krm_corruption.py
+++ b/contrib/metadata_audit/check_krm_corruption.py
@@ -4951,7 +4951,7 @@ def main():
             if len(ks_issues['uncoalesced']) > 10:
                 print(f"    ... and {len(ks_issues['uncoalesced']) - 10} more")
         else:
-            print("  No uncoalesced entries found (KeyRangeMap.actor.cpp:297 OK)")
+            print("  No uncoalesced keyServers entries found")
 
         if ks_issues['dead_servers']:
             dead_unique = set(i['dead_server'] for i in ks_issues['dead_servers'])
@@ -5010,14 +5010,22 @@ def main():
             live_servers_affected = set(u['server_id'] for u in live_uncoalesced)
             dead_servers_affected = set(u['server_id'] for u in dead_uncoalesced)
 
-            print(f"\n  CRITICAL: {len(sk_issues['uncoalesced'])} uncoalesced adjacent entries!")
-            print(f"            (This triggers ASSERT at MoveKeys.actor.cpp:158)")
+            severity = "CRITICAL" if live_uncoalesced else "WARNING"
+            print(f"\n  {severity}: {len(sk_issues['uncoalesced'])} uncoalesced adjacent entries!")
+            if live_uncoalesced:
+                print(f"            Live server entries may trigger ASSERT during shard moves")
+                print(f"            (MoveKeys.cpp:176 asserts no adjacent duplicates when writing)")
+            else:
+                print(f"            All on dead servers — will NOT crash DD (dead servers are never read)")
             print(f"\n    Breakdown:")
             print(f"      Live servers: {len(live_uncoalesced)} entries across {len(live_servers_affected)} servers")
             print(f"      Dead servers: {len(dead_uncoalesced)} entries across {len(dead_servers_affected)} servers")
-            print(f"\n    FULL KEYSPACE entries (b'' -> b'\\xff\\xff') - VERY WRONG:")
-            print(f"      Live servers: {len(full_ks_live)}")
-            print(f"      Dead servers: {len(full_ks_dead)}")
+            if full_keyspace:
+                print(f"\n    FULL KEYSPACE entries (b'' -> b'\\xff\\xff') — orphaned dead server state:")
+                print(f"      Live servers: {len(full_ks_live)}")
+                print(f"      Dead servers: {len(full_ks_dead)}")
+            print(f"\n    NOTE: DD only reads serverKeys for servers in serverList (live servers).")
+            print(f"          Dead server entries are inert garbage — safe to clean up but not urgent.")
 
             total_issues += len(sk_issues['uncoalesced'])
 
@@ -5041,7 +5049,7 @@ def main():
                 if len(dead_uncoalesced) > 5:
                     print(f"      ... and {len(dead_uncoalesced) - 5} more dead server entries")
         else:
-            print("  No uncoalesced entries found (MoveKeys.actor.cpp:158 OK)")
+            print("  No uncoalesced serverKeys entries found")
 
         if sk_issues['dead_servers']:
             dead_unique = set(i['server_id'] for i in sk_issues['dead_servers'])
@@ -5623,10 +5631,12 @@ def main():
             if has_uncoalesced:
                 print("\nUNCOALESCED ENTRIES DETECTED:")
                 print("  Adjacent KRM entries with the same value should be merged.")
-                print("  This triggers DD assertions at:")
-                print("    - KeyRangeMap.actor.cpp:297 (keyServers)")
-                print("    - MoveKeys.actor.cpp:158 (serverKeys)")
-                print("\n  Potential fix: Delete the redundant entries to coalesce ranges")
+                print("  Impact:")
+                print("    - keyServers: Wastes memory in DD shard map (no crash)")
+                print("    - serverKeys (live): May trigger ASSERT during active shard moves")
+                print("      (MoveKeys.cpp:176 asserts no adjacent duplicates when writing)")
+                print("    - serverKeys (dead): Inert garbage, never read by DD")
+                print("\n  Fix: Run repair_coalesce.py to delete redundant entries (idempotent)")
 
             if has_dead_refs:
                 print("\nDEAD SERVER REFERENCES DETECTED:")

--- a/contrib/metadata_audit/repair_coalesce.py
+++ b/contrib/metadata_audit/repair_coalesce.py
@@ -8,7 +8,7 @@ Running it multiple times is safe.
 The algorithm:
 1. Scan entries in key order
 2. Find runs of adjacent entries with equivalent values
-3. Delete all but the LAST entry in each run (keeping the boundary)
+3. Delete all but the FIRST entry in each run (it defines where the range starts)
 
 For serverKeys:
   Adjacent entries with same value (TRUE or FALSE) are redundant.

--- a/contrib/metadata_audit/repair_coalesce.py
+++ b/contrib/metadata_audit/repair_coalesce.py
@@ -337,7 +337,7 @@ def main():
             if args.keep_dd_disabled:
                 print("\n[4] Keeping DD disabled (--keep-dd-disabled flag)")
                 print("    DD remains disabled for subsequent repairs")
-                print("    Re-enable manually with: fdbcli --exec \"writemode on; set \\xff/dataDistributionMode \\x01\"")
+                print("    Re-enable manually with: fdbcli --exec \"option on ACCESS_SYSTEM_KEYS; writemode on; set \\xff/dataDistributionMode \\x01\\x00\\x00\\x00\"")
             else:
                 print("\n[4] Re-enabling DD and releasing MoveKeysLock...")
                 try:


### PR DESCRIPTION
Add full documentation for the repair-coalesce command including when it is needed (rare DD assertion failures from uncoalesced KRM entries), usage examples, options, safety notes, and post-repair verification. Also update the check command description to match current functionality.

Also fix some of the report text; was alarming when not necessary.