### PR TITLE
ctest: 43 - fdb_c_upgrade_to_future_version (Failed): Fix LSAN deadlock during shutdown with multiversion client

### DIFF
--- a/flow/Net2.cpp
+++ b/flow/Net2.cpp
@@ -302,8 +302,13 @@ public:
 	void trackAtPriority(TaskPriority priority, double now);
 	void stopImmediately() {
 #ifdef ADDRESS_SANITIZER
-		// Do leak check before intentionally leaking a bunch of memory
-		__lsan_do_leak_check();
+		// Only run leak check from the main network thread to avoid deadlocking
+		// when multiple network threads (from multiversion client) all call
+		// __lsan_do_leak_check() concurrently — one blocks on the symbolizer
+		// while others wait on __lsan::global_mutex, causing a timeout.
+		if (thread_network == this) {
+			__lsan_do_leak_check();
+		}
 #endif
 		stopped = true;
 		taskQueue.clear();


### PR DESCRIPTION
The multiversion client spawns multiple FDB network threads. When the process exits, each thread calls stopImmediately() which calls __lsan_do_leak_check(). LSAN uses a global mutex internally, and the first thread to acquire it blocks while reading from the symbolizer process (llvm-addr2line). The other threads wait on the mutex forever, causing the test to timeout.

This manifests as fdb_c_upgrade_to_future_version (and similar tests using the multiversion client) timing out at ~45 seconds despite all workloads completing successfully.

Fix: only call __lsan_do_leak_check() from the main network thread (thread_network == this). The secondary threads skip it since LSAN will still check them during process exit anyway.

The __lsan_do_leak_check() in stopImmediately() was added in 2021 (commit a76c7b9754 — "Fix several memory leaks and a thread leak").

Here is LSAN output for failed test that I fed local LLM:

```

42/44 Test #44: fdb_c_shim_library_tests ..........................   Passed   40.00 sec
43/44 Test #43: fdb_c_upgrade_to_future_version ...................***Failed   44.58 sec
Database created
Workload ApiCorrectness0 added
Workload ApiCorrectness1 added
Workload CancelTransaction0 added
Workload CancelTransaction1 added
Workload AtomicOpsCorrectness0 added
Workload AtomicOpsCorrectness1 added
Workload WatchAndWait0 added
Workload WatchAndWait1 added
Opening pipe /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/tmp/tmUyWopKTZ2W6zXG/output.mXgCpVa9 for writing
Opening pipe /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/tmp/tmUyWopKTZ2W6zXG/input.L7PsW7kr for reading
[AtomicOpsCorrectness0] Data population completed
[WatchAndWait0] Data population completed
[AtomicOpsCorrectness1] Data population completed
[WatchAndWait1] Data population completed
[CancelTransaction0] Data population completed
[ApiCorrectness1] Data population completed
[ApiCorrectness0] Data population completed
[CancelTransaction1] Data population completed
Received CHECK command
[CancelTransaction0] Progress confirmed
[CancelTransaction1] Progress confirmed
[ApiCorrectness0] Progress confirmed
[ApiCorrectness1] Progress confirmed
[WatchAndWait1] Progress confirmed
[WatchAndWait0] Progress confirmed
[AtomicOpsCorrectness1] Progress confirmed
[AtomicOpsCorrectness0] Progress confirmed
Received CHECK command
[CancelTransaction1] Progress confirmed
[CancelTransaction0] Progress confirmed
[ApiCorrectness1] Progress confirmed
[ApiCorrectness0] Progress confirmed
[WatchAndWait0] Progress confirmed
[WatchAndWait1] Progress confirmed
[AtomicOpsCorrectness0] Progress confirmed
[AtomicOpsCorrectness1] Progress confirmed
[WatchAndWait1] 224 transactions completed
[AtomicOpsCorrectness1] 117 transactions completed
[AtomicOpsCorrectness0] 151 transactions completed
[CancelTransaction1] 398 transactions completed
[ApiCorrectness1] 206 transactions completed
[WatchAndWait0] 194 transactions completed
[CancelTransaction0] 395 transactions completed
[ApiCorrectness0] 176 transactions completed
Received CHECK command
[CancelTransaction0] Progress confirmed
[CancelTransaction1] Progress confirmed
[ApiCorrectness1] Progress confirmed
[ApiCorrectness0] Progress confirmed
[WatchAndWait1] Progress confirmed
[AtomicOpsCorrectness1] Progress confirmed
[AtomicOpsCorrectness0] Progress confirmed
[WatchAndWait0] Progress confirmed
Received STOP command
[CancelTransaction1] Workload successfully completed
[CancelTransaction0] Workload successfully completed
[ApiCorrectness0] Workload successfully completed
[WatchAndWait1] Workload successfully completed
[WatchAndWait0] Workload successfully completed
[AtomicOpsCorrectness0] Workload successfully completed
[AtomicOpsCorrectness1] Workload successfully completed
[ApiCorrectness1] Workload successfully completed
All workloads successfully completed
Stopping FDB network thread
Thread 19 (Thread 0x7fc2afe0f640 (LWP 20005) "fdb_c_api_teste"):
#0  __sanitizer::internal_iserror (rverrno=<synthetic pointer>, retval=18446744073709551104) at /tmp/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_syscall_linux_x86_64.inc:84
#1  __sanitizer::internal_read (fd=42, buf=0x7fc2cc690000, count=count@entry=4096) at /tmp/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp:297
#2  0x0000000000412fff in __sanitizer::ReadFromFile (fd=<optimized out>, buff=<optimized out>, buff_size=buff_size@entry=4096, bytes_read=bytes_read@entry=0x7fc2afe09dc8, error_p=error_p@entry=0x0) at /tmp/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_posix.cpp:186
#3  0x000000000042c707 in __sanitizer::SymbolizerProcess::ReadFromSymbolizer (this=0x7fc2cc683018) at /tmp/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_libcdep.cpp:544
#4  0x000000000042b2ab in __sanitizer::SymbolizerProcess::SendCommandImpl (command=<optimized out>, this=0x7fc2cc683018) at /tmp/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_libcdep.cpp:522
#5  __sanitizer::SymbolizerProcess::SendCommand (this=0x7fc2cc683018, command=0x7fc2cc67f018 "CODE \"/codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/tmp/tmUyWopKTZ2W6zXG/libfdb_c.so-x3Yi7b\" 0xbd2616\n") at /tmp/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_libcdep.cpp:506
#6  0x000000000042b5d6 in __sanitizer::LLVMSymbolizer::SymbolizePC (stack=0x7fc2ca901810, addr=<optimized out>, this=0x7fc2cc67f000) at /tmp/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_libcdep.cpp:425
#7  __sanitizer::Symbolizer::SymbolizePC (this=0x7fc2cc683058, addr=addr@entry=140474270967318) at /tmp/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_libcdep.cpp:95
#8  0x00000000004304c8 in __lsan::LeakSuppressionContext::GetSuppressionForAddr (this=this@entry=0x10f3240 <__lsan::suppression_placeholder>, addr=140474270967318) at /tmp/llvm-project/compiler-rt/lib/lsan/lsan_common.cpp:158
#9  0x0000000000431cf0 in __lsan::LeakSuppressionContext::SuppressByRule (total_size=<optimized out>, hit_count=<optimized out>, stack=..., this=<optimized out>) at /tmp/llvm-project/compiler-rt/lib/lsan/lsan_common.cpp:217
#10 __lsan::LeakSuppressionContext::Suppress (total_size=512, hit_count=1, stack_trace_id=<optimized out>, this=0x10f3240 <__lsan::suppression_placeholder>) at /tmp/llvm-project/compiler-rt/lib/lsan/lsan_common.cpp:232
#11 __lsan::LeakReport::ApplySuppressions (this=this@entry=0x7fc2afe09f80) at /tmp/llvm-project/compiler-rt/lib/lsan/lsan_common.cpp:966
#12 0x0000000000433ba4 in __lsan::CheckForLeaks () at /tmp/llvm-project/compiler-rt/lib/lsan/lsan_common.cpp:797
#13 0x00000000004344e8 in __lsan::DoLeakCheck () at /tmp/llvm-project/compiler-rt/lib/lsan/lsan_common.cpp:825
#14 __lsan_do_leak_check () at /tmp/llvm-project/compiler-rt/lib/lsan/lsan_common.cpp:1081
#15 0x00007fc2cf996b23 in stopImmediately () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/Net2.cpp:306
#16 operator() () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/Net2.cpp:203
#17 a_body1cont1 () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/include/flow/ThreadHelper.actor.h:45
#18 0x00007fc2cf997033 in a_body1when1 () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/flow/include/flow/ThreadHelper.actor.g.h.py_gen:130
#19 a_callback_fire () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/flow/include/flow/ThreadHelper.actor.g.h.py_gen:155
#20 0x00007fc2cf8e9cf0 in send<Void> () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/include/flow/flow.h:771
#21 send<Void> () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/include/flow/flow.h:1095
#22 operator() () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/Net2.cpp:292
#23 run () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/Net2.cpp:1705
#24 0x00007fc2cdab345b in runNetwork () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/fdbclient/NativeAPI.actor.cpp:942
#25 0x00007fc2cf28cf49 in runNetwork () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/fdbclient/ThreadSafeTransaction.cpp:559
#26 0x00007fc2cd951617 in runNetwork () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/fdbclient/MultiVersionTransaction.cpp:2373
#27 0x00007fc2cd825a1c in fdb_run_network () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/bindings/c/fdb_c.cpp:166
#28 0x0000000000448044 in run () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/bindings/c/test/fdb_api.hpp:332
#29 operator() () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/bindings/c/test/apitester/fdb_c_api_tester.cpp:430
#30 __invoke<(lambda at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/bindings/c/test/apitester/fdb_c_api_tester.cpp:430:31)> () at /usr/local/bin/../include/c++/v1/__type_traits/invoke.h:149
#31 __thread_execute<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, (lambda at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/bindings/c/test/apitester/fdb_c_api_tester.cpp:430:31)> () at /usr/local/bin/../include/c++/v1/__thread/thread.h:192
#32 __thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, (lambda at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/bindings/c/test/apitester/fdb_c_api_tester.cpp:430:31)> >(void) () at /usr/local/bin/../include/c++/v1/__thread/thread.h:201
#33 0x0000000000325774 in asan_thread_start (arg=0x7fc2ca80e000) at /tmp/llvm-project/compiler-rt/lib/asan/asan_interceptors.cpp:239
#34 0x00007fc2ccb082ea in start_thread () from /lib64/libc.so.6
#35 0x00007fc2ccb8c5f4 in clone () from /lib64/libc.so.6

Thread 18 (Thread 0x7fc2ab5fc640 (LWP 20006) "fdb-8.0.0-0"):
#0  0x00000000004117ba in __sanitizer::FutexWait (p=p@entry=0x10f3308 <__lsan::global_mutex+8>, cmp=cmp@entry=0) at /tmp/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp:787
#1  0x0000000000412cc2 in __sanitizer::Semaphore::Wait (this=this@entry=0x10f3308 <__lsan::global_mutex+8>) at /tmp/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_mutex.cpp:35
#2  0x00000000004346b8 in __sanitizer::Mutex::Lock (this=0x10f3300 <__lsan::global_mutex>) at /tmp/llvm-project/compiler-rt/lib/lsan/../sanitizer_common/sanitizer_mutex.h:196
#3  __sanitizer::GenericScopedLock<__sanitizer::Mutex>::GenericScopedLock (mu=0x10f3300 <__lsan::global_mutex>, this=<synthetic pointer>) at /tmp/llvm-project/compiler-rt/lib/lsan/../sanitizer_common/sanitizer_mutex.h:383
#4  __lsan::DoLeakCheck () at /tmp/llvm-project/compiler-rt/lib/lsan/lsan_common.cpp:820
#5  __lsan_do_leak_check () at /tmp/llvm-project/compiler-rt/lib/lsan/lsan_common.cpp:1081
#6  0x00007fc2c91ddb23 in stopImmediately () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/Net2.cpp:306
#7  operator() () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/Net2.cpp:203
#8  a_body1cont1 () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/include/flow/ThreadHelper.actor.h:45
#9  0x00007fc2c91de033 in a_body1when1 () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/flow/include/flow/ThreadHelper.actor.g.h.py_gen:130
#10 a_callback_fire () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/flow/include/flow/ThreadHelper.actor.g.h.py_gen:155
#11 0x00007fc2c9130cf0 in send<Void> () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/include/flow/flow.h:771
#12 send<Void> () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/include/flow/flow.h:1095
#13 operator() () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/Net2.cpp:292
#14 run () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/Net2.cpp:1705
#15 0x00007fc2c72fa45b in runNetwork () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/fdbclient/NativeAPI.actor.cpp:942
#16 0x00007fc2c8ad3f49 in runNetwork () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/fdbclient/ThreadSafeTransaction.cpp:559
#17 0x00007fc2c7198617 in runNetwork () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/fdbclient/MultiVersionTransaction.cpp:2373
#18 0x00007fc2c706ca1c in fdb_run_network () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/bindings/c/fdb_c.cpp:166
#19 0x00007fc2cd9253c4 in runNetwork () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/fdbclient/MultiVersionTransaction.cpp:745
#20 0x00007fc2cd950e0d in runNetworkThread () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/fdbclient/MultiVersionTransaction.cpp:2335
#21 0x00007fc2cf9d8e7b in runFunc () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/Platform.cpp:2902
#22 0x0000000000325774 in asan_thread_start (arg=0x7fc2ca4c0000) at /tmp/llvm-project/compiler-rt/lib/asan/asan_interceptors.cpp:239
#23 0x00007fc2ccb082ea in start_thread () from /lib64/libc.so.6
#24 0x00007fc2ccb8c5f4 in clone () from /lib64/libc.so.6

Thread 17 (Thread 0x7fc2a78f2640 (LWP 20007) "fdb-8.0.0-0"):
#0  0x00000000004117ba in __sanitizer::FutexWait (p=p@entry=0x10f3308 <__lsan::global_mutex+8>, cmp=cmp@entry=0) at /tmp/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp:787
#1  0x0000000000412cc2 in __sanitizer::Semaphore::Wait (this=this@entry=0x10f3308 <__lsan::global_mutex+8>) at /tmp/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_mutex.cpp:35
#2  0x00000000004346b8 in __sanitizer::Mutex::Lock (this=0x10f3300 <__lsan::global_mutex>) at /tmp/llvm-project/compiler-rt/lib/lsan/../sanitizer_common/sanitizer_mutex.h:196
#3  __sanitizer::GenericScopedLock<__sanitizer::Mutex>::GenericScopedLock (mu=0x10f3300 <__lsan::global_mutex>, this=<synthetic pointer>) at /tmp/llvm-project/compiler-rt/lib/lsan/../sanitizer_common/sanitizer_mutex.h:383
#4  __lsan::DoLeakCheck () at /tmp/llvm-project/compiler-rt/lib/lsan/lsan_common.cpp:820
#5  __lsan_do_leak_check () at /tmp/llvm-project/compiler-rt/lib/lsan/lsan_common.cpp:1081
#6  0x00007fc2c5ea3b23 in stopImmediately () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/Net2.cpp:306
#7  operator() () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/Net2.cpp:203
#8  a_body1cont1 () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/include/flow/ThreadHelper.actor.h:45
#9  0x00007fc2c5ea4033 in a_body1when1 () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/flow/include/flow/ThreadHelper.actor.g.h.py_gen:130
#10 a_callback_fire () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/flow/include/flow/ThreadHelper.actor.g.h.py_gen:155
#11 0x00007fc2c5df6cf0 in send<Void> () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/include/flow/flow.h:771
#12 send<Void> () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/include/flow/flow.h:1095
#13 operator() () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/Net2.cpp:292
#14 run () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/Net2.cpp:1705
#15 0x00007fc2c3fc045b in runNetwork () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/fdbclient/NativeAPI.actor.cpp:942
#16 0x00007fc2c5799f49 in runNetwork () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/fdbclient/ThreadSafeTransaction.cpp:559
#17 0x00007fc2c3e5e617 in runNetwork () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/fdbclient/MultiVersionTransaction.cpp:2373
#18 0x00007fc2c3d32a1c in fdb_run_network () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/bindings/c/fdb_c.cpp:166
#19 0x00007fc2cd9253c4 in runNetwork () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/fdbclient/MultiVersionTransaction.cpp:745
#20 0x00007fc2cd950e0d in runNetworkThread () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/fdbclient/MultiVersionTransaction.cpp:2335
#21 0x00007fc2cf9d8e7b in runFunc () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/Platform.cpp:2902
#22 0x0000000000325774 in asan_thread_start (arg=0x7fc2ca4b2000) at /tmp/llvm-project/compiler-rt/lib/asan/asan_interceptors.cpp:239
#23 0x00007fc2ccb082ea in start_thread () from /lib64/libc.so.6
#24 0x00007fc2ccb8c5f4 in clone () from /lib64/libc.so.6

Thread 16 (Thread 0x7fc2a3be8640 (LWP 20008) "fdb-8.0.0-1"):
#0  0x00000000004117ba in __sanitizer::FutexWait (p=p@entry=0x10f3308 <__lsan::global_mutex+8>, cmp=cmp@entry=0) at /tmp/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp:787
#1  0x0000000000412cc2 in __sanitizer::Semaphore::Wait (this=this@entry=0x10f3308 <__lsan::global_mutex+8>) at /tmp/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_mutex.cpp:35
#2  0x00000000004346b8 in __sanitizer::Mutex::Lock (this=0x10f3300 <__lsan::global_mutex>) at /tmp/llvm-project/compiler-rt/lib/lsan/../sanitizer_common/sanitizer_mutex.h:196
#3  __sanitizer::GenericScopedLock<__sanitizer::Mutex>::GenericScopedLock (mu=0x10f3300 <__lsan::global_mutex>, this=<synthetic pointer>) at /tmp/llvm-project/compiler-rt/lib/lsan/../sanitizer_common/sanitizer_mutex.h:383
#4  __lsan::DoLeakCheck () at /tmp/llvm-project/compiler-rt/lib/lsan/lsan_common.cpp:820
#5  __lsan_do_leak_check () at /tmp/llvm-project/compiler-rt/lib/lsan/lsan_common.cpp:1081
#6  0x00007fc2c2b69b23 in stopImmediately () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/Net2.cpp:306
#7  operator() () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/Net2.cpp:203
#8  a_body1cont1 () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/include/flow/ThreadHelper.actor.h:45
#9  0x00007fc2c2b6a033 in a_body1when1 () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/flow/include/flow/ThreadHelper.actor.g.h.py_gen:130
#10 a_callback_fire () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/flow/include/flow/ThreadHelper.actor.g.h.py_gen:155
#11 0x00007fc2c2abccf0 in send<Void> () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/include/flow/flow.h:771
#12 send<Void> () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/include/flow/flow.h:1095
#13 operator() () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/Net2.cpp:292
#14 run () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/Net2.cpp:1705
#15 0x00007fc2c0c8645b in runNetwork () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/fdbclient/NativeAPI.actor.cpp:942
#16 0x00007fc2c245ff49 in runNetwork () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/fdbclient/ThreadSafeTransaction.cpp:559
#17 0x00007fc2c0b24617 in runNetwork () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/fdbclient/MultiVersionTransaction.cpp:2373
#18 0x00007fc2c09f8a1c in fdb_run_network () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/bindings/c/fdb_c.cpp:166
#19 0x00007fc2cd9253c4 in runNetwork () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/fdbclient/MultiVersionTransaction.cpp:745
#20 0x00007fc2cd950e0d in runNetworkThread () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/fdbclient/MultiVersionTransaction.cpp:2335
#21 0x00007fc2cf9d8e7b in runFunc () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/Platform.cpp:2902
#22 0x0000000000325774 in asan_thread_start (arg=0x7fc2ca4a4000) at /tmp/llvm-project/compiler-rt/lib/asan/asan_interceptors.cpp:239
#23 0x00007fc2ccb082ea in start_thread () from /lib64/libc.so.6
#24 0x00007fc2ccb8c5f4 in clone () from /lib64/libc.so.6

Thread 15 (Thread 0x7fc29e8cc640 (LWP 20009) "fdb-8.0.0-1"):
#0  0x00000000004117ba in __sanitizer::FutexWait (p=p@entry=0x10f3308 <__lsan::global_mutex+8>, cmp=cmp@entry=0) at /tmp/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp:787
#1  0x0000000000412cc2 in __sanitizer::Semaphore::Wait (this=this@entry=0x10f3308 <__lsan::global_mutex+8>) at /tmp/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_mutex.cpp:35
#2  0x00000000004346b8 in __sanitizer::Mutex::Lock (this=0x10f3300 <__lsan::global_mutex>) at /tmp/llvm-project/compiler-rt/lib/lsan/../sanitizer_common/sanitizer_mutex.h:196
#3  __sanitizer::GenericScopedLock<__sanitizer::Mutex>::GenericScopedLock (mu=0x10f3300 <__lsan::global_mutex>, this=<synthetic pointer>) at /tmp/llvm-project/compiler-rt/lib/lsan/../sanitizer_common/sanitizer_mutex.h:383
#4  __lsan::DoLeakCheck () at /tmp/llvm-project/compiler-rt/lib/lsan/lsan_common.cpp:820
#5  __lsan_do_leak_check () at /tmp/llvm-project/compiler-rt/lib/lsan/lsan_common.cpp:1081
#6  0x00007fc2bf82fb23 in stopImmediately () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/Net2.cpp:306
#7  operator() () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/Net2.cpp:203
#8  a_body1cont1 () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/include/flow/ThreadHelper.actor.h:45
#9  0x00007fc2bf830033 in a_body1when1 () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/flow/include/flow/ThreadHelper.actor.g.h.py_gen:130
#10 a_callback_fire () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/flow/include/flow/ThreadHelper.actor.g.h.py_gen:155
#11 0x00007fc2bf782cf0 in send<Void> () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/include/flow/flow.h:771
#12 send<Void> () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/include/flow/flow.h:1095
#13 operator() () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/Net2.cpp:292
#14 run () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/Net2.cpp:1705
#15 0x00007fc2bd94c45b in runNetwork () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/fdbclient/NativeAPI.actor.cpp:942
#16 0x00007fc2bf125f49 in runNetwork () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/fdbclient/ThreadSafeTransaction.cpp:559
#17 0x00007fc2bd7ea617 in runNetwork () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/fdbclient/MultiVersionTransaction.cpp:2373
#18 0x00007fc2bd6bea1c in fdb_run_network () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/bindings/c/fdb_c.cpp:166
#19 0x00007fc2cd9253c4 in runNetwork () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/fdbclient/MultiVersionTransaction.cpp:745
#20 0x00007fc2cd950e0d in runNetworkThread () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/fdbclient/MultiVersionTransaction.cpp:2335
#21 0x00007fc2cf9d8e7b in runFunc () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/Platform.cpp:2902
#22 0x0000000000325774 in asan_thread_start (arg=0x7fc2ca496000) at /tmp/llvm-project/compiler-rt/lib/asan/asan_interceptors.cpp:239
#23 0x00007fc2ccb082ea in start_thread () from /lib64/libc.so.6
#24 0x00007fc2ccb8c5f4 in clone () from /lib64/libc.so.6

Thread 14 (Thread 0x7fc29abc2640 (LWP 20010) "fdb-8.0.0-2"):
#0  0x00000000004117ba in __sanitizer::FutexWait (p=p@entry=0x10f3308 <__lsan::global_mutex+8>, cmp=cmp@entry=0) at /tmp/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp:787
#1  0x0000000000412cc2 in __sanitizer::Semaphore::Wait (this=this@entry=0x10f3308 <__lsan::global_mutex+8>) at /tmp/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_mutex.cpp:35
#2  0x00000000004346b8 in __sanitizer::Mutex::Lock (this=0x10f3300 <__lsan::global_mutex>) at /tmp/llvm-project/compiler-rt/lib/lsan/../sanitizer_common/sanitizer_mutex.h:196
#3  __sanitizer::GenericScopedLock<__sanitizer::Mutex>::GenericScopedLock (mu=0x10f3300 <__lsan::global_mutex>, this=<synthetic pointer>) at /tmp/llvm-project/compiler-rt/lib/lsan/../sanitizer_common/sanitizer_mutex.h:383
#4  __lsan::DoLeakCheck () at /tmp/llvm-project/compiler-rt/lib/lsan/lsan_common.cpp:820
#5  __lsan_do_leak_check () at /tmp/llvm-project/compiler-rt/lib/lsan/lsan_common.cpp:1081
#6  0x00007fc2bc3d5b23 in stopImmediately () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/Net2.cpp:306
#7  operator() () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/Net2.cpp:203
#8  a_body1cont1 () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/include/flow/ThreadHelper.actor.h:45
#9  0x00007fc2bc3d6033 in a_body1when1 () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/flow/include/flow/ThreadHelper.actor.g.h.py_gen:130
#10 a_callback_fire () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/flow/include/flow/ThreadHelper.actor.g.h.py_gen:155
#11 0x00007fc2bc328cf0 in send<Void> () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/include/flow/flow.h:771
#12 send<Void> () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/include/flow/flow.h:1095
#13 operator() () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/Net2.cpp:292
#14 run () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/Net2.cpp:1705
#15 0x00007fc2ba4f245b in runNetwork () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/fdbclient/NativeAPI.actor.cpp:942
#16 0x00007fc2bbccbf49 in runNetwork () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/fdbclient/ThreadSafeTransaction.cpp:559
#17 0x00007fc2ba390617 in runNetwork () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/fdbclient/MultiVersionTransaction.cpp:2373
#18 0x00007fc2ba264a1c in fdb_run_network () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/bindings/c/fdb_c.cpp:166
#19 0x00007fc2cd9253c4 in runNetwork () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/fdbclient/MultiVersionTransaction.cpp:745
#20 0x00007fc2cd950e0d in runNetworkThread () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/fdbclient/MultiVersionTransaction.cpp:2335
#21 0x00007fc2cf9d8e7b in runFunc () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/Platform.cpp:2902
#22 0x0000000000325774 in asan_thread_start (arg=0x7fc2ca46e000) at /tmp/llvm-project/compiler-rt/lib/asan/asan_interceptors.cpp:239
#23 0x00007fc2ccb082ea in start_thread () from /lib64/libc.so.6
#24 0x00007fc2ccb8c5f4 in clone () from /lib64/libc.so.6

Thread 13 (Thread 0x7fc2963af640 (LWP 20011) "fdb-8.0.0-2"):
#0  0x00000000004117ba in __sanitizer::FutexWait (p=p@entry=0x10f3308 <__lsan::global_mutex+8>, cmp=cmp@entry=0) at /tmp/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp:787
#1  0x0000000000412cc2 in __sanitizer::Semaphore::Wait (this=this@entry=0x10f3308 <__lsan::global_mutex+8>) at /tmp/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_mutex.cpp:35
#2  0x00000000004346b8 in __sanitizer::Mutex::Lock (this=0x10f3300 <__lsan::global_mutex>) at /tmp/llvm-project/compiler-rt/lib/lsan/../sanitizer_common/sanitizer_mutex.h:196
#3  __sanitizer::GenericScopedLock<__sanitizer::Mutex>::GenericScopedLock (mu=0x10f3300 <__lsan::global_mutex>, this=<synthetic pointer>) at /tmp/llvm-project/compiler-rt/lib/lsan/../sanitizer_common/sanitizer_mutex.h:383
#4  __lsan::DoLeakCheck () at /tmp/llvm-project/compiler-rt/lib/lsan/lsan_common.cpp:820
#5  __lsan_do_leak_check () at /tmp/llvm-project/compiler-rt/lib/lsan/lsan_common.cpp:1081
#6  0x00007fc2b909bb23 in stopImmediately () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/Net2.cpp:306
#7  operator() () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/Net2.cpp:203
#8  a_body1cont1 () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/include/flow/ThreadHelper.actor.h:45
#9  0x00007fc2b909c033 in a_body1when1 () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/flow/include/flow/ThreadHelper.actor.g.h.py_gen:130
#10 a_callback_fire () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/flow/include/flow/ThreadHelper.actor.g.h.py_gen:155
#11 0x00007fc2b8feecf0 in send<Void> () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/include/flow/flow.h:771
#12 send<Void> () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/include/flow/flow.h:1095
#13 operator() () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/Net2.cpp:292
#14 run () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/Net2.cpp:1705
#15 0x00007fc2b71b845b in runNetwork () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/fdbclient/NativeAPI.actor.cpp:942
#16 0x00007fc2b8991f49 in runNetwork () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/fdbclient/ThreadSafeTransaction.cpp:559
#17 0x00007fc2b7056617 in runNetwork () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/fdbclient/MultiVersionTransaction.cpp:2373
#18 0x00007fc2b6f2aa1c in fdb_run_network () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/bindings/c/fdb_c.cpp:166
#19 0x00007fc2cd9253c4 in runNetwork () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/fdbclient/MultiVersionTransaction.cpp:745
#20 0x00007fc2cd950e0d in runNetworkThread () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/fdbclient/MultiVersionTransaction.cpp:2335
#21 0x00007fc2cf9d8e7b in runFunc () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/Platform.cpp:2902
#22 0x0000000000325774 in asan_thread_start (arg=0x7fc2ca453000) at /tmp/llvm-project/compiler-rt/lib/asan/asan_interceptors.cpp:239
#23 0x00007fc2ccb082ea in start_thread () from /lib64/libc.so.6
#24 0x00007fc2ccb8c5f4 in clone () from /lib64/libc.so.6

Thread 12 (Thread 0x7fc2926a5640 (LWP 20012) "fdb-8.0.0-3"):
#0  0x00000000004117ba in __sanitizer::FutexWait (p=p@entry=0x10f3308 <__lsan::global_mutex+8>, cmp=cmp@entry=0) at /tmp/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp:787
#1  0x0000000000412cc2 in __sanitizer::Semaphore::Wait (this=this@entry=0x10f3308 <__lsan::global_mutex+8>) at /tmp/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_mutex.cpp:35
#2  0x00000000004346b8 in __sanitizer::Mutex::Lock (this=0x10f3300 <__lsan::global_mutex>) at /tmp/llvm-project/compiler-rt/lib/lsan/../sanitizer_common/sanitizer_mutex.h:196
#3  __sanitizer::GenericScopedLock<__sanitizer::Mutex>::GenericScopedLock (mu=0x10f3300 <__lsan::global_mutex>, this=<synthetic pointer>) at /tmp/llvm-project/compiler-rt/lib/lsan/../sanitizer_common/sanitizer_mutex.h:383
#4  __lsan::DoLeakCheck () at /tmp/llvm-project/compiler-rt/lib/lsan/lsan_common.cpp:820
#5  __lsan_do_leak_check () at /tmp/llvm-project/compiler-rt/lib/lsan/lsan_common.cpp:1081
#6  0x00007fc2b5d61b23 in stopImmediately () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/Net2.cpp:306
#7  operator() () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/Net2.cpp:203
#8  a_body1cont1 () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/include/flow/ThreadHelper.actor.h:45
#9  0x00007fc2b5d62033 in a_body1when1 () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/flow/include/flow/ThreadHelper.actor.g.h.py_gen:130
#10 a_callback_fire () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/flow/include/flow/ThreadHelper.actor.g.h.py_gen:155
#11 0x00007fc2b5cb4cf0 in send<Void> () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/include/flow/flow.h:771
#12 send<Void> () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/include/flow/flow.h:1095
#13 operator() () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/Net2.cpp:292
#14 run () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/Net2.cpp:1705
#15 0x00007fc2b3e7e45b in runNetwork () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/fdbclient/NativeAPI.actor.cpp:942
#16 0x00007fc2b5657f49 in runNetwork () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/fdbclient/ThreadSafeTransaction.cpp:559
#17 0x00007fc2b3d1c617 in runNetwork () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/fdbclient/MultiVersionTransaction.cpp:2373
#18 0x00007fc2b3bf0a1c in fdb_run_network () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/bindings/c/fdb_c.cpp:166
#19 0x00007fc2cd9253c4 in runNetwork () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/fdbclient/MultiVersionTransaction.cpp:745
#20 0x00007fc2cd950e0d in runNetworkThread () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/fdbclient/MultiVersionTransaction.cpp:2335
#21 0x00007fc2cf9d8e7b in runFunc () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/Platform.cpp:2902
#22 0x0000000000325774 in asan_thread_start (arg=0x7fc2ca445000) at /tmp/llvm-project/compiler-rt/lib/asan/asan_interceptors.cpp:239
#23 0x00007fc2ccb082ea in start_thread () from /lib64/libc.so.6
#24 0x00007fc2ccb8c5f4 in clone () from /lib64/libc.so.6

Thread 11 (Thread 0x7fc28de92640 (LWP 20013) "fdb-8.0.0-3"):
#0  0x00000000004117ba in __sanitizer::FutexWait (p=p@entry=0x10f3308 <__lsan::global_mutex+8>, cmp=cmp@entry=0) at /tmp/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp:787
#1  0x0000000000412cc2 in __sanitizer::Semaphore::Wait (this=this@entry=0x10f3308 <__lsan::global_mutex+8>) at /tmp/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_mutex.cpp:35
#2  0x00000000004346b8 in __sanitizer::Mutex::Lock (this=0x10f3300 <__lsan::global_mutex>) at /tmp/llvm-project/compiler-rt/lib/lsan/../sanitizer_common/sanitizer_mutex.h:196
#3  __sanitizer::GenericScopedLock<__sanitizer::Mutex>::GenericScopedLock (mu=0x10f3300 <__lsan::global_mutex>, this=<synthetic pointer>) at /tmp/llvm-project/compiler-rt/lib/lsan/../sanitizer_common/sanitizer_mutex.h:383
#4  __lsan::DoLeakCheck () at /tmp/llvm-project/compiler-rt/lib/lsan/lsan_common.cpp:820
#5  __lsan_do_leak_check () at /tmp/llvm-project/compiler-rt/lib/lsan/lsan_common.cpp:1081
#6  0x00007fc2b2a27b23 in stopImmediately () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/Net2.cpp:306
#7  operator() () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/Net2.cpp:203
#8  a_body1cont1 () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/include/flow/ThreadHelper.actor.h:45
#9  0x00007fc2b2a28033 in a_body1when1 () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/flow/include/flow/ThreadHelper.actor.g.h.py_gen:130
#10 a_callback_fire () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/flow/include/flow/ThreadHelper.actor.g.h.py_gen:155
#11 0x00007fc2b297acf0 in send<Void> () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/include/flow/flow.h:771
#12 send<Void> () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/include/flow/flow.h:1095
#13 operator() () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/Net2.cpp:292
#14 run () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/Net2.cpp:1705
#15 0x00007fc2b0b4445b in runNetwork () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/fdbclient/NativeAPI.actor.cpp:942
#16 0x00007fc2b231df49 in runNetwork () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/fdbclient/ThreadSafeTransaction.cpp:559
#17 0x00007fc2b09e2617 in runNetwork () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/fdbclient/MultiVersionTransaction.cpp:2373
#18 0x00007fc2b08b6a1c in fdb_run_network () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/bindings/c/fdb_c.cpp:166
#19 0x00007fc2cd9253c4 in runNetwork () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/fdbclient/MultiVersionTransaction.cpp:745
#20 0x00007fc2cd950e0d in runNetworkThread () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/fdbclient/MultiVersionTransaction.cpp:2335
#21 0x00007fc2cf9d8e7b in runFunc () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/Platform.cpp:2902
#22 0x0000000000325774 in asan_thread_start (arg=0x7fc2ca42a000) at /tmp/llvm-project/compiler-rt/lib/asan/asan_interceptors.cpp:239
#23 0x00007fc2ccb082ea in start_thread () from /lib64/libc.so.6
#24 0x00007fc2ccb8c5f4 in clone () from /lib64/libc.so.6

Thread 10 (Thread 0x7fc287464640 (LWP 20014) "fdb-trace-log"):
#0  0x00007fc2ccb0537a in __futex_abstimed_wait_common () from /lib64/libc.so.6
#1  0x00007fc2ccb078d2 in pthread_cond_wait@@GLIBC_2.3.2 () from /lib64/libc.so.6
#2  0x00007fc2c4e73984 in wait<boost::asio::detail::conditionally_enabled_mutex::scoped_lock> () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/boost_install/include/boost/asio/detail/posix_event.hpp:119
#3  wait () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/boost_install/include/boost/asio/detail/conditionally_enabled_event.hpp:97
#4  do_run_one () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/boost_install/include/boost/asio/detail/impl/scheduler.ipp:502
#5  0x00007fc2c5db0cf8 in run_one () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/boost_install/include/boost/asio/detail/impl/scheduler.ipp:231
#6  0x00007fc2c5db061b in run_one () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/boost_install/include/boost/asio/impl/io_context.ipp:79
#7  run () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/IThreadPool.cpp:53
#8  0x00007fc2c5daff29 in ThreadPool::start(void*) () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/IThreadPool.cpp:64
#9  0x00007fc2c5ee5e7b in runFunc () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/Platform.cpp:2902
#10 0x0000000000325774 in asan_thread_start (arg=0x7fc2ca2e5000) at /tmp/llvm-project/compiler-rt/lib/asan/asan_interceptors.cpp:239
#11 0x00007fc2ccb082ea in start_thread () from /lib64/libc.so.6
#12 0x00007fc2ccb8c5f4 in clone () from /lib64/libc.so.6

Thread 9 (Thread 0x7fc276a2a640 (LWP 20018) "fdb-trace-log"):
#0  0x00007fc2ccb0537a in __futex_abstimed_wait_common () from /lib64/libc.so.6
#1  0x00007fc2ccb078d2 in pthread_cond_wait@@GLIBC_2.3.2 () from /lib64/libc.so.6
#2  0x00007fc2bb3a5984 in wait<boost::asio::detail::conditionally_enabled_mutex::scoped_lock> () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/boost_install/include/boost/asio/detail/posix_event.hpp:119
#3  wait () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/boost_install/include/boost/asio/detail/conditionally_enabled_event.hpp:97
#4  do_run_one () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/boost_install/include/boost/asio/detail/impl/scheduler.ipp:502
#5  0x00007fc2bc2e2cf8 in run_one () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/boost_install/include/boost/asio/detail/impl/scheduler.ipp:231
#6  0x00007fc2bc2e261b in run_one () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/boost_install/include/boost/asio/impl/io_context.ipp:79
#7  run () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/IThreadPool.cpp:53
#8  0x00007fc2bc2e1f29 in ThreadPool::start(void*) () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/IThreadPool.cpp:64
#9  0x00007fc2bc417e7b in runFunc () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/Platform.cpp:2902
#10 0x0000000000325774 in asan_thread_start (arg=0x7fc2ca285000) at /tmp/llvm-project/compiler-rt/lib/asan/asan_interceptors.cpp:239
#11 0x00007fc2ccb082ea in start_thread () from /lib64/libc.so.6
#12 0x00007fc2ccb8c5f4 in clone () from /lib64/libc.so.6

Thread 8 (Thread 0x7fc27170e640 (LWP 20019) "fdb-trace-log"):
#0  0x00007fc2ccb0537a in __futex_abstimed_wait_common () from /lib64/libc.so.6
#1  0x00007fc2ccb078d2 in pthread_cond_wait@@GLIBC_2.3.2 () from /lib64/libc.so.6
#2  0x00007fc2c1b39984 in wait<boost::asio::detail::conditionally_enabled_mutex::scoped_lock> () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/boost_install/include/boost/asio/detail/posix_event.hpp:119
#3  wait () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/boost_install/include/boost/asio/detail/conditionally_enabled_event.hpp:97
#4  do_run_one () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/boost_install/include/boost/asio/detail/impl/scheduler.ipp:502
#5  0x00007fc2c2a76cf8 in run_one () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/boost_install/include/boost/asio/detail/impl/scheduler.ipp:231
#6  0x00007fc2c2a7661b in run_one () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/boost_install/include/boost/asio/impl/io_context.ipp:79
#7  run () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/IThreadPool.cpp:53
#8  0x00007fc2c2a75f29 in ThreadPool::start(void*) () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/IThreadPool.cpp:64
#9  0x00007fc2c2babe7b in runFunc () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/Platform.cpp:2902
#10 0x0000000000325774 in asan_thread_start (arg=0x7fc2ca293000) at /tmp/llvm-project/compiler-rt/lib/asan/asan_interceptors.cpp:239
#11 0x00007fc2ccb082ea in start_thread () from /lib64/libc.so.6
#12 0x00007fc2ccb8c5f4 in clone () from /lib64/libc.so.6

Thread 7 (Thread 0x7fc26da04640 (LWP 20020) "fdb-trace-log"):
#0  0x00007fc2ccb0537a in __futex_abstimed_wait_common () from /lib64/libc.so.6
#1  0x00007fc2ccb078d2 in pthread_cond_wait@@GLIBC_2.3.2 () from /lib64/libc.so.6
#2  0x00007fc2ce966984 in wait<boost::asio::detail::conditionally_enabled_mutex::scoped_lock> () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/boost_install/include/boost/asio/detail/posix_event.hpp:119
#3  wait () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/boost_install/include/boost/asio/detail/conditionally_enabled_event.hpp:97
#4  do_run_one () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/boost_install/include/boost/asio/detail/impl/scheduler.ipp:502
#5  0x00007fc2cf8a3cf8 in run_one () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/boost_install/include/boost/asio/detail/impl/scheduler.ipp:231
#6  0x00007fc2cf8a361b in run_one () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/boost_install/include/boost/asio/impl/io_context.ipp:79
#7  run () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/IThreadPool.cpp:53
#8  0x00007fc2cf8a2f29 in ThreadPool::start(void*) () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/IThreadPool.cpp:64
#9  0x00007fc2cf9d8e7b in runFunc () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/Platform.cpp:2902
#10 0x0000000000325774 in asan_thread_start (arg=0x7fc2ca25d000) at /tmp/llvm-project/compiler-rt/lib/asan/asan_interceptors.cpp:239
#11 0x00007fc2ccb082ea in start_thread () from /lib64/libc.so.6
#12 0x00007fc2ccb8c5f4 in clone () from /lib64/libc.so.6

Thread 6 (Thread 0x7fc269cfa640 (LWP 20022) "fdb-trace-log"):
#0  0x00007fc2ccb0537a in __futex_abstimed_wait_common () from /lib64/libc.so.6
#1  0x00007fc2ccb078d2 in pthread_cond_wait@@GLIBC_2.3.2 () from /lib64/libc.so.6
#2  0x00007fc2b806b984 in wait<boost::asio::detail::conditionally_enabled_mutex::scoped_lock> () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/boost_install/include/boost/asio/detail/posix_event.hpp:119
#3  wait () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/boost_install/include/boost/asio/detail/conditionally_enabled_event.hpp:97
#4  do_run_one () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/boost_install/include/boost/asio/detail/impl/scheduler.ipp:502
#5  0x00007fc2b8fa8cf8 in run_one () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/boost_install/include/boost/asio/detail/impl/scheduler.ipp:231
#6  0x00007fc2b8fa861b in run_one () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/boost_install/include/boost/asio/impl/io_context.ipp:79
#7  run () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/IThreadPool.cpp:53
#8  0x00007fc2b8fa7f29 in ThreadPool::start(void*) () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/IThreadPool.cpp:64
#9  0x00007fc2b90dde7b in runFunc () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/Platform.cpp:2902
#10 0x0000000000325774 in asan_thread_start (arg=0x7fc2ca24f000) at /tmp/llvm-project/compiler-rt/lib/asan/asan_interceptors.cpp:239
#11 0x00007fc2ccb082ea in start_thread () from /lib64/libc.so.6
#12 0x00007fc2ccb8c5f4 in clone () from /lib64/libc.so.6

Thread 5 (Thread 0x7fc2654e7640 (LWP 20023) "fdb-trace-log"):
#0  0x00007fc2ccb0537a in __futex_abstimed_wait_common () from /lib64/libc.so.6
#1  0x00007fc2ccb078d2 in pthread_cond_wait@@GLIBC_2.3.2 () from /lib64/libc.so.6
#2  0x00007fc2be7ff984 in wait<boost::asio::detail::conditionally_enabled_mutex::scoped_lock> () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/boost_install/include/boost/asio/detail/posix_event.hpp:119
#3  wait () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/boost_install/include/boost/asio/detail/conditionally_enabled_event.hpp:97
#4  do_run_one () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/boost_install/include/boost/asio/detail/impl/scheduler.ipp:502
#5  0x00007fc2bf73ccf8 in run_one () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/boost_install/include/boost/asio/detail/impl/scheduler.ipp:231
#6  0x00007fc2bf73c61b in run_one () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/boost_install/include/boost/asio/impl/io_context.ipp:79
#7  run () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/IThreadPool.cpp:53
#8  0x00007fc2bf73bf29 in ThreadPool::start(void*) () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/IThreadPool.cpp:64
#9  0x00007fc2bf871e7b in runFunc () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/Platform.cpp:2902
#10 0x0000000000325774 in asan_thread_start (arg=0x7fc2ca241000) at /tmp/llvm-project/compiler-rt/lib/asan/asan_interceptors.cpp:239
#11 0x00007fc2ccb082ea in start_thread () from /lib64/libc.so.6
#12 0x00007fc2ccb8c5f4 in clone () from /lib64/libc.so.6

Thread 4 (Thread 0x7fc2617dd640 (LWP 20024) "fdb-trace-log"):
#0  0x00007fc2ccb0537a in __futex_abstimed_wait_common () from /lib64/libc.so.6
#1  0x00007fc2ccb078d2 in pthread_cond_wait@@GLIBC_2.3.2 () from /lib64/libc.so.6
#2  0x00007fc2c81ad984 in wait<boost::asio::detail::conditionally_enabled_mutex::scoped_lock> () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/boost_install/include/boost/asio/detail/posix_event.hpp:119
#3  wait () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/boost_install/include/boost/asio/detail/conditionally_enabled_event.hpp:97
#4  do_run_one () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/boost_install/include/boost/asio/detail/impl/scheduler.ipp:502
#5  0x00007fc2c90eacf8 in run_one () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/boost_install/include/boost/asio/detail/impl/scheduler.ipp:231
#6  0x00007fc2c90ea61b in run_one () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/boost_install/include/boost/asio/impl/io_context.ipp:79
#7  run () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/IThreadPool.cpp:53
#8  0x00007fc2c90e9f29 in ThreadPool::start(void*) () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/IThreadPool.cpp:64
#9  0x00007fc2c921fe7b in runFunc () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/Platform.cpp:2902
#10 0x0000000000325774 in asan_thread_start (arg=0x7fc2ca233000) at /tmp/llvm-project/compiler-rt/lib/asan/asan_interceptors.cpp:239
#11 0x00007fc2ccb082ea in start_thread () from /lib64/libc.so.6
#12 0x00007fc2ccb8c5f4 in clone () from /lib64/libc.so.6

Thread 3 (Thread 0x7fc25a371640 (LWP 20025) "fdb-trace-log"):
#0  0x00007fc2ccb0537a in __futex_abstimed_wait_common () from /lib64/libc.so.6
#1  0x00007fc2ccb078d2 in pthread_cond_wait@@GLIBC_2.3.2 () from /lib64/libc.so.6
#2  0x00007fc2b4d31984 in wait<boost::asio::detail::conditionally_enabled_mutex::scoped_lock> () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/boost_install/include/boost/asio/detail/posix_event.hpp:119
#3  wait () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/boost_install/include/boost/asio/detail/conditionally_enabled_event.hpp:97
#4  do_run_one () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/boost_install/include/boost/asio/detail/impl/scheduler.ipp:502
#5  0x00007fc2b5c6ecf8 in run_one () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/boost_install/include/boost/asio/detail/impl/scheduler.ipp:231
#6  0x00007fc2b5c6e61b in run_one () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/boost_install/include/boost/asio/impl/io_context.ipp:79
#7  run () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/IThreadPool.cpp:53
#8  0x00007fc2b5c6df29 in ThreadPool::start(void*) () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/IThreadPool.cpp:64
#9  0x00007fc2b5da3e7b in runFunc () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/Platform.cpp:2902
#10 0x0000000000325774 in asan_thread_start (arg=0x7fc25a372000) at /tmp/llvm-project/compiler-rt/lib/asan/asan_interceptors.cpp:239
#11 0x00007fc2ccb082ea in start_thread () from /lib64/libc.so.6
#12 0x00007fc2ccb8c5f4 in clone () from /lib64/libc.so.6

Thread 2 (Thread 0x7fc256659640 (LWP 20026) "fdb-trace-log"):
#0  0x00007fc2ccb0537a in __futex_abstimed_wait_common () from /lib64/libc.so.6
#1  0x00007fc2ccb078d2 in pthread_cond_wait@@GLIBC_2.3.2 () from /lib64/libc.so.6
#2  0x00007fc2b19f7984 in wait<boost::asio::detail::conditionally_enabled_mutex::scoped_lock> () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/boost_install/include/boost/asio/detail/posix_event.hpp:119
#3  wait () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/boost_install/include/boost/asio/detail/conditionally_enabled_event.hpp:97
#4  do_run_one () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/boost_install/include/boost/asio/detail/impl/scheduler.ipp:502
#5  0x00007fc2b2934cf8 in run_one () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/boost_install/include/boost/asio/detail/impl/scheduler.ipp:231
#6  0x00007fc2b293461b in run_one () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/build_output/boost_install/include/boost/asio/impl/io_context.ipp:79
#7  run () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/IThreadPool.cpp:53
#8  0x00007fc2b2933f29 in ThreadPool::start(void*) () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/IThreadPool.cpp:64
#9  0x00007fc2b2a69e7b in runFunc () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/flow/Platform.cpp:2902
#10 0x0000000000325774 in asan_thread_start (arg=0x7fc25665a000) at /tmp/llvm-project/compiler-rt/lib/asan/asan_interceptors.cpp:239
#11 0x00007fc2ccb082ea in start_thread () from /lib64/libc.so.6
#12 0x00007fc2ccb8c5f4 in clone () from /lib64/libc.so.6

Thread 1 (Thread 0x7fc2cca60d80 (LWP 20002) "fdb_c_api_teste"):
#0  0x00007fc2ccb0537a in __futex_abstimed_wait_common () from /lib64/libc.so.6
#1  0x00007fc2ccb09df4 in __pthread_clockjoin_ex () from /lib64/libc.so.6
#2  0x00000000003eb552 in operator() (__closure=<optimized out>) at /tmp/llvm-project/compiler-rt/lib/asan/asan_interceptors.cpp:293
#3  __sanitizer::ThreadArgRetval::Join<___interceptor_pthread_join(void*, void**)::<lambda()> > (fn=..., thread=140474151138880, this=0x7b1e70 <__asan::InitThreads()::thread_data_placeholder>) at /tmp/llvm-project/compiler-rt/lib/asan/../sanitizer_common/sanitizer_thread_arg_retval.h:75
#4  ___interceptor_pthread_join (thread=0x7fc2afe0f640, retval=0x0) at /tmp/llvm-project/compiler-rt/lib/asan/asan_interceptors.cpp:292
#5  0x0000000000472e83 in std::__1::thread::join() ()
#6  0x000000000044590e in main () at /codebuild/output/src1268715600/src/github.com/apple/foundationdb/bindings/c/test/apitester/fdb_c_api_tester.cpp:438
```