### PR TITLE
Throttle replica comparison warning traces

### DIFF
--- a/fdbrpc/include/fdbrpc/LoadBalance.actor.h
+++ b/fdbrpc/include/fdbrpc/LoadBalance.actor.h
@@ -398,6 +398,7 @@ Future<Void> replicaComparison(Req req,
 			            restOfTeamFutures.size() >= requiredReplicas)) {
 				const char* type = numError ? "ReplicaComparisonReadError" : "ReplicaComparisonTimeoutError";
 				TraceEvent(SevWarnAlways, type)
+				    .suppressFor(1.0)
 				    .detail("TeamSize", restOfTeamFutures.size() + 1)
 				    .detail("RequiredReplies", requiredReplicas)
 				    .detail("SuccessfulReplies", successfulReplies)


### PR DESCRIPTION
In rare simulation tests, if a storage server repeatedly reports `process_behind`, these trace events can be very noisy. There isn't much signal from tracing more than one warning per second, so this PR cleans up the trace output
