### PR TITLE
Require minimumReplication=2 for AutomaticIdempotency test

### DIFF
--- a/tests/fast/AutomaticIdempotency.toml
+++ b/tests/fast/AutomaticIdempotency.toml
@@ -1,3 +1,6 @@
+[configuration]
+minimumReplication = 2
+
 [[test]]
 testTitle = 'AutomaticIdempotency'
 


### PR DESCRIPTION
High-level, when simulation (randomly) chooses replication==1, the test passes but gets stuck on waiting on the post-test quietDatabase (TracedTooManyLines, crash). The test is about testing the idempotency id feature in fdb api, not about surviving interesting scenarios when replication is set to 1.

With single redundancy (replication=1) in a multi-region simulation, a KillType=6 (reboot_and_delete) can permanently destroy the only copy of an old TLog's data. After the machine reboots at the same address with new endpoints, the system enters a deadlock:

- Storage servers and LogRouters attempt to peek from the dead TLog
- Requests are silently dropped => old endpoint token doesn't exist on the rebooted process, but failure monitor reports address as available
- The cluster never reaches FULLY_RECOVERED because old TLog generations cannot be fully popped (It does reach the less state of ALL_LOGS_RECRUITED which is enough for the test to complete)
- quietDatabase(End) waits forever, hitting TracedTooManyLines

This scenario cannot occur with replication >= 2 since a single machine kill cannot destroy all copies of TLog data. Setting minimumReplication=2 under [configuration] prevents the simulation from choosing single redundancy mode for this test.

Seed 3487728063 with buggify=on reproduces the hang on x86_64 linux built with clang.
