### PR TITLE
Fix peekLogRouter() skip logic that breaks multi-region recovery

### DIFF
--- a/fdbserver/logsystem/LogSystem.cpp
+++ b/fdbserver/logsystem/LogSystem.cpp
@@ -1594,8 +1594,11 @@ Reference<IPeekCursor> LogSystem::peekLogRouter(
 		}
 		if (found) {
 			Version oldEnd = firstOld && recoveredAt.present() ? recoveredAt.get() + 1 : old.epochEnd;
-			if (begin > oldEnd) {
-				TraceEvent("TLogPeekLogRouterSkipEmptyOldRange", dbgid)
+			if (begin >= oldEnd) {
+				// The LogRouter has already advanced past this old epoch's range.
+				// Skip it without creating a SetPeekCursor with begin >= end (which
+				// would be born exhausted and hang).
+				TraceEvent("TLogPeekLogRouterOldRangeEmpty", dbgid)
 				    .detail("Tag", tag.toString())
 				    .detail("Begin", begin)
 				    .detail("OldEnd", oldEnd)


### PR DESCRIPTION
The skip logic added in #13163 c4fcecc788 ("Skip empty old log router ranges") used `continue` to skip old epochs where begin >= oldEnd. This disrupted the `firstOld` flag invariant: subsequent epochs would compute wrong version bounds, and if no further epoch matched, the LogRouter would fall through to an empty null-interface cursor — hanging forever.

The follow-up 5a63d1132f relaxed the check to begin > oldEnd but kept the `continue`, so the fundamental problem remained.

The original bug that c4fcecc788 fixed was real: creating a SetPeekCursor with begin >= end produces an exhausted cursor that hangs. But the fix must not `continue` past the epoch, as this corrupts state for the remaining iteration.

Fix: when begin >= oldEnd, return an empty ServerPeekCursor immediately (same as the end-of-loop fallback). This avoids both the exhausted SetPeekCursor and the corrupted-iteration hang.

Validated with:
 - Seed 3487728063, AutomaticIdempotency.toml, buggify=on (the regression)
 - Seed 3182378863, Sideband.toml, buggify=on (the original bug c4fcecc788 fixed)
Both pass.

#13227 addressed a particular instance found in nightly run but on running 100k with the fix applied, the same failure showed in other tests.  Reverting #13163 fixed these failures.