### PR TITLE
fix backups list: include region in backup urls

### DIFF
--- a/fdbclient/BlobStoreCommon.cpp
+++ b/fdbclient/BlobStoreCommon.cpp
@@ -240,6 +240,14 @@ std::string IBlobStoreEndpoint::getResourceURL(std::string resource, std::string
 		params.append(knobParams);
 	}
 
+	if (!region.empty()) {
+		if (!params.empty()) {
+			params.append("&");
+		}
+		params.append("region=");
+		params.append(region);
+	}
+
 	for (const auto& [k, v] : extraHeaders) {
 		if (!params.empty()) {
 			params.append("&");


### PR DESCRIPTION
### What does this PR do?
- Includes the `region` param in the backup urls returned on running backup list

### Why do we need this change?
- Fixes #13014 
- Without this change, when using the `region` param to list backups, the returned backups do not have the `region` param. This makes the backup incorrect as trying to run operations ( e.g start, describe ) on an item of this list will fail
