### PR TITLE
Update TLS docs to reference OpenSSL instead of LibreSSL

### DIFF
--- a/documentation/sphinx/source/tls.rst
+++ b/documentation/sphinx/source/tls.rst
@@ -9,7 +9,7 @@ Introduction
 
 Transport Layer Security (TLS) and its predecessor, Secure Sockets Layer (SSL), are protocols designed to provide communication security over public networks. Users exchange a symmetric session key that is used to encrypt data exchanged between the parties.
 
-By default, a FoundationDB cluster uses *unencrypted* connections among client and server processes. This document describes the `Transport Layer Security <http://en.wikipedia.org/wiki/Transport_Layer_Security>`_ (TLS) capabilities of FoundationDB, which enable security and authentication through a public/private key infrastructure. TLS is compiled into each FoundationDB binary. This document will describe the basic TLS capabilities of FoundationDB and document its implementation, which is based on `LibreSSL <https://www.libressl.org/>`_. TLS-enabled servers will only communicate with other TLS-enabled servers and TLS-enabled clients. Therefore, a cluster's machines must all enable TLS in order for TLS to be used.
+By default, a FoundationDB cluster uses *unencrypted* connections among client and server processes. This document describes the `Transport Layer Security <http://en.wikipedia.org/wiki/Transport_Layer_Security>`_ (TLS) capabilities of FoundationDB, which enable security and authentication through a public/private key infrastructure. TLS is compiled into each FoundationDB binary. This document will describe the basic TLS capabilities of FoundationDB and document its implementation, which is based on `OpenSSL <https://www.openssl.org/>`_. TLS-enabled servers will only communicate with other TLS-enabled servers and TLS-enabled clients. Therefore, a cluster's machines must all enable TLS in order for TLS to be used.
 
 
 Setting Up FoundationDB to use TLS
@@ -160,10 +160,10 @@ The TLS certificate will be automatically refreshed on a configurable cadence. T
 
 The refresh rate is controlled by ``--knob-tls-cert-refresh-delay-seconds``. Setting it to 0 will disable the refresh.
 
-The default LibreSSL-based implementation
-=========================================
+The default OpenSSL-based implementation
+========================================
 
-FoundationDB offers TLS based on the LibreSSL library. By default, it will be enabled automatically when participating in a TLS-enabled cluster.
+FoundationDB offers TLS based on the OpenSSL library. By default, it will be enabled automatically when participating in a TLS-enabled cluster.
 
 For TLS to operate, each process (both server and client) must have an X509 certificate, its corresponding private key, and the certificates with which it was signed. When a process begins to communicate with a FoundationDB server process, the peer's certificate is checked to see if it is trusted and the fields of the peer certificate are verified. Peers must share the same root trusted certificate, and they must both present certificates whose signing chain includes this root certificate.
 
@@ -172,7 +172,7 @@ If the local certificate and chain is invalid, a FoundationDB server process bou
 Formats
 -------
 
-LibreSSL can read certificates and their private keys in base64-encoded DER-formatted X.509 format (which is known as PEM). A PEM file can contain both certificates and a private key or the two can be stored in separate files.
+OpenSSL can read certificates and their private keys in base64-encoded DER-formatted X.509 format (which is known as PEM). A PEM file can contain both certificates and a private key or the two can be stored in separate files.
 
 Required files
 --------------


### PR DESCRIPTION
## Summary

FoundationDB switched its TLS implementation from LibreSSL to OpenSSL in 6.2.0 ([PR #2646](https://github.com/apple/foundationdb/pull/2646)). The README and CMake setup have referenced OpenSSL for years, but `documentation/sphinx/source/tls.rst` — the user-facing Transport Layer Security guide — still describes the implementation as LibreSSL-based in four places:

- Intro paragraph: "its implementation, which is based on `LibreSSL`"
- Section title: "The default LibreSSL-based implementation"
- Section body: "FoundationDB offers TLS based on the LibreSSL library"
- Formats paragraph: "LibreSSL can read certificates..."

This PR updates all four to OpenSSL.

This is the spirit of [#3022](https://github.com/apple/foundationdb/issues/3022), which asked to "Change README to instruct users to install OpenSSL, not LibreSSL". The README itself is already correct today (lines 128 and 167 mention OpenSSL 3.x); the sphinx TLS guide was missed.

## Test plan

- [x] `grep -n LibreSSL\\|libressl documentation/sphinx/source/tls.rst` — exit 1 (no matches remaining).
- [x] Full source-tree search confirms the only remaining `LibreSSL` reference is in `release-notes/release-notes-620.rst`, which is the historical entry documenting the switch itself — intentionally preserved.

## Scope

Documentation-only, five-line change. No code or build behavior touched.