### PR TITLE
Retry transient failures in Java integration test lifecycle methods

### DIFF
--- a/bindings/java/src/integration/com/apple/foundationdb/MappedRangeQueryIntegrationTest.java
+++ b/bindings/java/src/integration/com/apple/foundationdb/MappedRangeQueryIntegrationTest.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicReference;
@@ -49,13 +50,24 @@ class MappedRangeQueryIntegrationTest {
 	@AfterEach
 	void clearDatabase() throws Exception {
 		/*
-		 * Empty the database before and after each run, just in case
+		 * Empty the database before and after each run, just in case.
+		 * Retry the clear operation since on heavily loaded CI the transaction
+		 * may time out during cluster bootstrap or under resource contention.
 		 */
-		try (Database db = openFDB()) {
-			db.run(tr -> {
-				tr.clear(new byte[0], new byte[] { (byte) 0xff });
-				return null;
-			});
+		int maxAttempts = 5;
+		for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+			try (Database db = openFDB()) {
+				db.run(tr -> {
+					tr.clear(new byte[0], new byte[] { (byte)0xff });
+					return null;
+				});
+				return; // success
+			} catch (CompletionException e) {
+				if (attempt == maxAttempts) {
+					throw e;
+				}
+				Thread.sleep(1000);
+			}
 		}
 	}
 

--- a/bindings/java/src/integration/com/apple/foundationdb/RangeQueryIntegrationTest.java
+++ b/bindings/java/src/integration/com/apple/foundationdb/RangeQueryIntegrationTest.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Random;
 import java.util.TreeMap;
+import java.util.concurrent.CompletionException;
 
 import com.apple.foundationdb.async.AsyncIterable;
 import com.apple.foundationdb.async.AsyncIterator;
@@ -47,13 +48,24 @@ class RangeQueryIntegrationTest {
 	@AfterEach
 	void clearDatabase() throws Exception {
 		/*
-		 * Empty the database before and after each run, just in case
+		 * Empty the database before and after each run, just in case.
+		 * Retry the clear operation since on heavily loaded CI the transaction
+		 * may time out during cluster bootstrap or under resource contention.
 		 */
-		try (Database db = fdb.open()) {
-			db.run(tr -> {
-				tr.clear(new byte[0], new byte[] { (byte) 0xff });
-				return null;
-			});
+		int maxAttempts = 5;
+		for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+			try (Database db = fdb.open()) {
+				db.run(tr -> {
+					tr.clear(new byte[0], new byte[] { (byte)0xff });
+					return null;
+				});
+				return; // success
+			} catch (CompletionException e) {
+				if (attempt == maxAttempts) {
+					throw e;
+				}
+				Thread.sleep(1000);
+			}
 		}
 	}
 

--- a/bindings/java/src/integration/com/apple/foundationdb/RequiresDatabase.java
+++ b/bindings/java/src/integration/com/apple/foundationdb/RequiresDatabase.java
@@ -20,7 +20,7 @@
 package com.apple.foundationdb;
 
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
@@ -63,16 +63,23 @@ public class RequiresDatabase implements ExecutionCondition, BeforeAllCallback {
 		}
 	}
 
+	private static final int HEALTH_CHECK_TIMEOUT_MS = 5000;
+	private static final int HEALTH_CHECK_MAX_ATTEMPTS = 10;
+	private static final int HEALTH_CHECK_BACKOFF_MS = 500;
+
 	@Override
 	public void beforeAll(ExtensionContext context) throws Exception {
 		/*
 		 * This is in place to validate that a database is actually running. If it can't connect
-		 * within a pretty short timeout, then the tests automatically fail.
+		 * within a reasonable time, then the tests automatically fail.
 		 *
 		 * This is in place mainly to fail-fast in the event of bad configurations; specifically, if the env flag
 		 * is set to true (or absent), but a backing server isn't actually running. When that happens, this check avoids
 		 * a long hang-time while waiting for the first database connection to finally timeout (which could take a
 		 * while, based on empirical observation)
+		 *
+		 * We retry the health check several times because on heavily loaded CI infrastructure,
+		 * the single-node cluster may still be bootstrapping when tests start.
 		 *
 		 * Note that JUnit will only call this method _after_ calling evaluateExecutionCondition(), so we can safely
 		 * assume that if we are here, then canRunIntegrationTest() is returning true and we don't have to bother
@@ -90,19 +97,22 @@ public class RequiresDatabase implements ExecutionCondition, BeforeAllCallback {
 		}
 
 		try (Database db = fdb.open()) {
-			db.run(tr -> {
-				tr.options().setTimeout(100);
-				CompletableFuture<byte[]> future = tr.get("test".getBytes());
+			for (int attempt = 1; attempt <= HEALTH_CHECK_MAX_ATTEMPTS; attempt++) {
 				try {
-					return future.join();
-				} catch (FDBException e) {
-					if (e.getCode() == 1031) {
+					db.run(tr -> {
+						tr.options().setTimeout(HEALTH_CHECK_TIMEOUT_MS);
+						return tr.get("test".getBytes()).join();
+					});
+					return; // success
+				} catch (CompletionException e) {
+					if (attempt == HEALTH_CHECK_MAX_ATTEMPTS) {
 						Assertions.fail("Test " + context.getDisplayName() +
-						                " failed to start: cannot to database within timeout");
+						                " failed to start: cannot connect to database after " +
+						                HEALTH_CHECK_MAX_ATTEMPTS + " attempts: " + e.getMessage());
 					}
-					throw e;
+					Thread.sleep(HEALTH_CHECK_BACKOFF_MS);
 				}
-			});
+			}
 		}
 	}
 }


### PR DESCRIPTION
066978d6ef added retry handling to the test *methods* in MappedRangeQueryIntegrationTest by letting FDB errors propagate through Database.run() instead of catching them as assertion failures. However, the test still fails in CI because the transaction timeout can also fire in the @BeforeEach/@AfterEach clearDatabase() calls and in the RequiresDatabase.beforeAll() health check — neither of which had any retry logic.

The CI failure shows 22 tests passing then the container failing: this means beforeAll() succeeded but a clearDatabase() call (likely @AfterEach on the last test) timed out under CI load. The stack trace shows FDBTransaction.onError() itself timing out, confirming the transaction timeout was exhausted with no retry budget remaining.

Fix all three sites:

- RequiresDatabase.beforeAll(): increase timeout from 100ms to 5s and retry up to 10 times with 500ms backoff. The original 100ms was too tight for a cluster that may still be bootstrapping on loaded CI.

- MappedRangeQueryIntegrationTest.clearDatabase(): retry the clear operation up to 5 times with 1s backoff.

- RangeQueryIntegrationTest.clearDatabase(): same fix (identical pattern).

Failures were over in #13212