### PR TITLE
Fix peekLogRouter() born-exhausted cursor when begin == oldEnd

### DIFF
--- a/fdbserver/logsystem/LogSystemConsumer.cpp
+++ b/fdbserver/logsystem/LogSystemConsumer.cpp
@@ -747,8 +747,11 @@ Reference<IReplayPeekCursor> LogSystemConsumer::peekLogRouter(
 		}
 		if (found) {
 			Version oldEnd = firstOld && ls.recoveredAt.present() ? ls.recoveredAt.get() + 1 : old.epochEnd;
-			if (begin > oldEnd) {
-				TraceEvent("TLogPeekLogRouterSkipEmptyOldRange", dbgid)
+			if (begin >= oldEnd) {
+				// The LogRouter has already advanced past this old epoch's range.
+				// Skip it without creating a SetPeekCursor with begin >= end (which
+				// would be born exhausted and hang).
+				TraceEvent("TLogPeekLogRouterOldRangeEmpty", dbgid)
 				    .detail("Tag", tag.toString())
 				    .detail("Begin", begin)
 				    .detail("OldEnd", oldEnd)


### PR DESCRIPTION
When begin == oldEnd, the code falls through and creates a SetPeekCursor with begin == end. This cursor is born exhausted -- getMore() returns immediately with no data and no advancement, which can cause LogRouters to hang.

The >= check catches this case and skips the old epoch (same path as begin > oldEnd), preventing the born-exhausted cursor from being created.

This is a defensive correctness fix -- a cursor with begin == end is always wrong. The case is rare and was not directly observed in traced failures, but closing this edge case is warranted.

Here is a 100k run   `20260518-223352-stack_one_liner-58efc5e594c8620e   compressed=True data_size=37007600 duration=3861738 ended=100000 fail=4 fail_fast=10 max_runs=100000 pass=99996 priority=100 remaining=0 runtime=0:52:28 sanity=False started=100000 stopped=20260518-232620 submitted=20260518-223352 timeout=5400 username=stack_one_liner`

Two failures are:

RandomSeed="1027964057" SourceVersion="df7ce9300dd36343d59a4e66c6a1f9622cffdddb" Time="1779145186" BuggifyEnabled="0" DeterminismCheck="0" FaultInjectionEnabled="1" TestFile="tests/fast/Sideband.toml"

and

RandomSeed="762784548" SourceVersion="df7ce9300dd36343d59a4e66c6a1f9622cffdddb" Time="1779145515" BuggifyEnabled="0" DeterminismCheck="0" FaultInjectionEnabled="1" TestFile="tests/fast/Sideband.toml"

These are from an existing 'live-TLog' hang I've been following (multi-region, timed out at 5401s, 0 TracedTooManyLines). I just ran 500k against main and 4 of these Sideband failures showed up there.

This issue comes of the work over in #13228 where I had trouble proving an improvement. This one-liner extracts from that work an obvious (to-me) improvement.

