### PR TITLE
Add type annotations to fdb Python bindings (PEP 561)

### DIFF
--- a/bindings/python/fdb/impl.py
+++ b/bindings/python/fdb/impl.py
@@ -38,6 +38,7 @@ import fdb
 from fdb.tuple import pack, int2byte
 
 from fdb import fdboptions as _opts
+from typing import Union
 
 
 _network_thread = None

--- a/bindings/python/fdb/impl.py
+++ b/bindings/python/fdb/impl.py
@@ -20,6 +20,8 @@
 
 # FoundationDB Python API
 
+from __future__ import annotations
+
 import atexit
 import ctypes
 import ctypes.util
@@ -33,12 +35,12 @@ import sys
 import threading
 import traceback
 import weakref
+from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Union
 
 import fdb
 from fdb.tuple import pack, int2byte
 
 from fdb import fdboptions as _opts
-from typing import Union
 
 
 _network_thread = None
@@ -348,20 +350,22 @@ class FDBError(Exception):
 
     """
 
-    def __init__(self, code):
+    code: int
+
+    def __init__(self, code: int) -> None:
         self.code = code
-        self._description = None
+        self._description: Optional[str] = None
 
     @property
-    def description(self):
+    def description(self) -> str:
         if not self._description:
             self._description = _capi.fdb_get_error(self.code)
         return self._description
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "%s (%d)" % (self.description, self.code)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "FDBError(%d)" % self.code
 
 
@@ -377,7 +381,15 @@ class FDBRange(object):
 
     """
 
-    def __init__(self, tr, begin, end, limit, reverse, streaming_mode):
+    def __init__(
+        self,
+        tr: TransactionRead,
+        begin: KeySelector,
+        end: KeySelector,
+        limit: int,
+        reverse: bool,
+        streaming_mode: Any,
+    ) -> None:
         self._tr = tr
 
         self._bsel = begin
@@ -391,7 +403,7 @@ class FDBRange(object):
             begin, end, limit, streaming_mode, 1, reverse
         )
 
-    def to_list(self):
+    def to_list(self) -> List[KeyValue]:
         if self._mode == StreamingMode.iterator:
             if self._limit > 0:
                 mode = StreamingMode.exact
@@ -402,7 +414,7 @@ class FDBRange(object):
 
         return list(self.__iter__(mode=mode))
 
-    def __iter__(self, mode=None):
+    def __iter__(self, mode: Any = None) -> Iterator[KeyValue]:
         if mode is None:
             mode = self._mode
         bsel = self._bsel
@@ -445,26 +457,26 @@ class FDBRange(object):
 
 
 class TransactionRead(_FDBBase):
-    def __init__(self, tpointer, db, snapshot):
+    def __init__(self, tpointer: Any, db: Database, snapshot: bool) -> None:
         self.tpointer = tpointer
         self.db = db
         self._snapshot = snapshot
 
-    def __del__(self):
+    def __del__(self) -> None:
         # print("Destroying transactionread 0x%x" % self.tpointer)
         self.capi.fdb_transaction_destroy(self.tpointer)
 
-    def get_read_version(self):
+    def get_read_version(self) -> FutureInt64:
         """Get the read version of the transaction."""
         return FutureInt64(self.capi.fdb_transaction_get_read_version(self.tpointer))
 
-    def get(self, key):
+    def get(self, key: Union[bytes, FutureString]) -> Value:
         key = keyToBytes(key)
         return Value(
             self.capi.fdb_transaction_get(self.tpointer, key, len(key), self._snapshot)
         )
 
-    def get_key(self, key_selector):
+    def get_key(self, key_selector: KeySelector) -> Key:
         key = keyToBytes(key_selector.key)
 
         return Key(
@@ -478,7 +490,15 @@ class TransactionRead(_FDBBase):
             )
         )
 
-    def _get_range(self, begin, end, limit, streaming_mode, iteration, reverse):
+    def _get_range(
+        self,
+        begin: KeySelector,
+        end: KeySelector,
+        limit: int,
+        streaming_mode: Any,
+        iteration: int,
+        reverse: bool,
+    ) -> FutureKeyValueArray:
         beginKey = keyToBytes(begin.key)
         endKey = keyToBytes(end.key)
 
@@ -502,14 +522,19 @@ class TransactionRead(_FDBBase):
             )
         )
 
-    def _to_selector(self, key_or_selector):
+    def _to_selector(self, key_or_selector: Union[bytes, KeySelector]) -> KeySelector:
         if not isinstance(key_or_selector, KeySelector):
             key_or_selector = KeySelector.first_greater_or_equal(key_or_selector)
         return key_or_selector
 
     def get_range(
-        self, begin, end, limit=0, reverse=False, streaming_mode=StreamingMode.iterator
-    ):
+        self,
+        begin: Optional[Union[bytes, KeySelector]],
+        end: Optional[Union[bytes, KeySelector]],
+        limit: int = 0,
+        reverse: bool = False,
+        streaming_mode: Any = StreamingMode.iterator,
+    ) -> FDBRange:
         if begin is None:
             begin = b""
         if end is None:
@@ -518,16 +543,20 @@ class TransactionRead(_FDBBase):
         end = self._to_selector(end)
         return FDBRange(self, begin, end, limit, reverse, streaming_mode)
 
-    def get_range_startswith(self, prefix, *args, **kwargs):
+    def get_range_startswith(
+        self, prefix: Union[bytes, FutureString], *args: Any, **kwargs: Any
+    ) -> FDBRange:
         prefix = keyToBytes(prefix)
         return self.get_range(prefix, strinc(prefix), *args, **kwargs)
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: Union[bytes, slice]) -> Union[Value, FDBRange]:
         if isinstance(key, slice):
             return self.get_range(key.start, key.stop, reverse=(key.step == -1))
         return self.get(key)
 
-    def get_estimated_range_size_bytes(self, begin_key, end_key):
+    def get_estimated_range_size_bytes(
+        self, begin_key: Optional[bytes], end_key: Optional[bytes]
+    ) -> FutureInt64:
         if begin_key is None or end_key is None:
             if fdb.get_api_version() >= 700:
                 raise Exception("Invalid begin key or end key")
@@ -542,7 +571,9 @@ class TransactionRead(_FDBBase):
             )
         )
 
-    def get_range_split_points(self, begin_key, end_key, chunk_size):
+    def get_range_split_points(
+        self, begin_key: bytes, end_key: bytes, chunk_size: int
+    ) -> FutureKeyArray:
         if begin_key is None or end_key is None or chunk_size <= 0:
             raise Exception("Invalid begin key, end key or chunk size")
         return FutureKeyArray(
@@ -560,22 +591,22 @@ class TransactionRead(_FDBBase):
 class Transaction(TransactionRead):
     """A modifiable snapshot of a Database."""
 
-    def __init__(self, tpointer, db):
+    def __init__(self, tpointer: Any, db: Database) -> None:
         super(Transaction, self).__init__(tpointer, db, False)
         self.options = _TransactionOptions(self)
         self.__snapshot = self.snapshot = TransactionRead(tpointer, db, True)
 
-    def __del__(self):
+    def __del__(self) -> None:
         pass
 
-    def set_read_version(self, version):
+    def set_read_version(self, version: int) -> None:
         """Set the read version of the transaction."""
         self.capi.fdb_transaction_set_read_version(self.tpointer, version)
 
-    def _set_option(self, option, param, length):
+    def _set_option(self, option: int, param: Optional[bytes], length: int) -> None:
         self.capi.fdb_transaction_set_option(self.tpointer, option, param, length)
 
-    def _atomic_operation(self, opcode, key, param):
+    def _atomic_operation(self, opcode: int, key: Union[bytes, FutureString], param: Union[bytes, FutureString]) -> None:
         paramBytes = valueToBytes(param)
         paramLength = len(paramBytes)
         keyBytes = keyToBytes(key)
@@ -584,12 +615,12 @@ class Transaction(TransactionRead):
             self.tpointer, keyBytes, keyLength, paramBytes, paramLength, opcode
         )
 
-    def set(self, key, value):
+    def set(self, key: Union[bytes, FutureString], value: Union[bytes, FutureString]) -> None:
         key = keyToBytes(key)
         value = valueToBytes(value)
         self.capi.fdb_transaction_set(self.tpointer, key, len(key), value, len(value))
 
-    def clear(self, key):
+    def clear(self, key: Union[bytes, KeySelector, FutureString]) -> None:
         if isinstance(key, KeySelector):
             key = self.get_key(key)
 
@@ -597,7 +628,11 @@ class Transaction(TransactionRead):
 
         self.capi.fdb_transaction_clear(self.tpointer, key, len(key))
 
-    def clear_range(self, begin, end):
+    def clear_range(
+        self,
+        begin: Optional[Union[bytes, KeySelector]],
+        end: Optional[Union[bytes, KeySelector]],
+    ) -> None:
         if begin is None:
             begin = b""
         if end is None:
@@ -614,56 +649,56 @@ class Transaction(TransactionRead):
             self.tpointer, begin, len(begin), end, len(end)
         )
 
-    def clear_range_startswith(self, prefix):
+    def clear_range_startswith(self, prefix: Union[bytes, FutureString]) -> None:
         prefix = keyToBytes(prefix)
         return self.clear_range(prefix, strinc(prefix))
 
-    def watch(self, key):
+    def watch(self, key: Union[bytes, FutureString]) -> FutureVoid:
         key = keyToBytes(key)
         return FutureVoid(self.capi.fdb_transaction_watch(self.tpointer, key, len(key)))
 
-    def add_read_conflict_range(self, begin, end):
+    def add_read_conflict_range(self, begin: bytes, end: bytes) -> None:
         begin = keyToBytes(begin)
         end = keyToBytes(end)
         self.capi.fdb_transaction_add_conflict_range(
             self.tpointer, begin, len(begin), end, len(end), ConflictRangeType.read
         )
 
-    def add_read_conflict_key(self, key):
+    def add_read_conflict_key(self, key: bytes) -> None:
         key = keyToBytes(key)
         self.add_read_conflict_range(key, key + b"\x00")
 
-    def add_write_conflict_range(self, begin, end):
+    def add_write_conflict_range(self, begin: bytes, end: bytes) -> None:
         begin = keyToBytes(begin)
         end = keyToBytes(end)
         self.capi.fdb_transaction_add_conflict_range(
             self.tpointer, begin, len(begin), end, len(end), ConflictRangeType.write
         )
 
-    def add_write_conflict_key(self, key):
+    def add_write_conflict_key(self, key: bytes) -> None:
         key = keyToBytes(key)
         self.add_write_conflict_range(key, key + b"\x00")
 
-    def commit(self):
+    def commit(self) -> FutureVoid:
         return FutureVoid(self.capi.fdb_transaction_commit(self.tpointer))
 
-    def get_committed_version(self):
+    def get_committed_version(self) -> int:
         version = ctypes.c_int64()
         self.capi.fdb_transaction_get_committed_version(
             self.tpointer, ctypes.byref(version)
         )
         return version.value
 
-    def get_approximate_size(self):
+    def get_approximate_size(self) -> FutureInt64:
         """Get the approximate commit size of the transaction."""
         return FutureInt64(
             self.capi.fdb_transaction_get_approximate_size(self.tpointer)
         )
 
-    def get_versionstamp(self):
+    def get_versionstamp(self) -> Key:
         return Key(self.capi.fdb_transaction_get_versionstamp(self.tpointer))
 
-    def on_error(self, error):
+    def on_error(self, error: Union[FDBError, int]) -> FutureVoid:
         if isinstance(error, FDBError):
             code = error.code
         elif isinstance(error, int):
@@ -672,16 +707,16 @@ class Transaction(TransactionRead):
             raise error
         return FutureVoid(self.capi.fdb_transaction_on_error(self.tpointer, code))
 
-    def reset(self):
+    def reset(self) -> None:
         self.capi.fdb_transaction_reset(self.tpointer)
 
-    def cancel(self):
+    def cancel(self) -> None:
         self.capi.fdb_transaction_cancel(self.tpointer)
 
-    def __setitem__(self, key, value):
+    def __setitem__(self, key: Union[bytes, FutureString], value: Union[bytes, FutureString]) -> None:
         self.set(key, value)
 
-    def __delitem__(self, key):
+    def __delitem__(self, key: Union[bytes, slice]) -> None:
         if isinstance(key, slice):
             self.clear_range(key.start, key.stop)
         else:
@@ -692,29 +727,29 @@ class Future(_FDBBase):
     Event = threading.Event
     _state = None  # < Hack for trollius
 
-    def __init__(self, fpointer):
+    def __init__(self, fpointer: Any) -> None:
         # print("Creating future 0x%x" % fpointer)
         self.fpointer = fpointer
 
-    def __del__(self):
+    def __del__(self) -> None:
         if self.fpointer:
             # print("Destroying future 0x%x" % self.fpointer)
             self.capi.fdb_future_destroy(self.fpointer)
             self.fpointer = None
 
-    def cancel(self):
+    def cancel(self) -> None:
         self.capi.fdb_future_cancel(self.fpointer)
 
-    def _release_memory(self):
+    def _release_memory(self) -> None:
         self.capi.fdb_future_release_memory(self.fpointer)
 
-    def wait(self):
+    def wait(self) -> Any:
         raise NotImplementedError
 
-    def is_ready(self):
+    def is_ready(self) -> bool:
         return bool(self.capi.fdb_future_is_ready(self.fpointer))
 
-    def block_until_ready(self):
+    def block_until_ready(self) -> None:
         # Checking readiness is faster than using the callback, so it saves us time if we are already
         # ready. It also doesn't add much to the cost of this function
         if not self.is_ready():
@@ -739,8 +774,8 @@ class Future(_FDBBase):
                 )
                 raise
 
-    def on_ready(self, callback):
-        def cb_and_delref(ignore):
+    def on_ready(self, callback: Callable[[Future], None]) -> None:
+        def cb_and_delref(ignore: Any) -> None:
             _unpin_callback(cbfunc[0])
             del cbfunc[:]
             try:
@@ -760,16 +795,16 @@ class Future(_FDBBase):
         self.capi.fdb_future_set_callback(self.fpointer, cbfunc[0], None)
 
     @staticmethod
-    def wait_for_any(*futures):
+    def wait_for_any(*futures: Future) -> int:
         """Does not return until at least one of the given futures is ready.
         Returns the index in the parameter list of a ready future."""
         if not futures:
             raise ValueError("wait_for_any requires at least one future")
-        d = {}
+        d: Dict[str, int] = {}
         ev = futures[0].Event()
         for i, f in enumerate(futures):
 
-            def cb(ignore, i=i):
+            def cb(ignore: Any, i: int = i) -> None:
                 if d.setdefault("i", i) == i:
                     ev.set()
 
@@ -778,7 +813,7 @@ class Future(_FDBBase):
         return d["i"]
 
     # asyncio future protocol
-    def cancelled(self):
+    def cancelled(self) -> bool:
         if not self.done():
             return False
         e = self.exception()
@@ -786,12 +821,12 @@ class Future(_FDBBase):
 
     done = is_ready
 
-    def result(self):
+    def result(self) -> Any:
         if not self.done():
             raise Exception("Future result not available")
         return self.wait()
 
-    def exception(self):
+    def exception(self) -> Optional[BaseException]:
         if not self.done():
             raise Exception("Future result not available")
         try:
@@ -800,22 +835,22 @@ class Future(_FDBBase):
         except BaseException as e:
             return e
 
-    def add_done_callback(self, fn):
+    def add_done_callback(self, fn: Callable[[Future], None]) -> None:
         self.on_ready(lambda f: self.call_soon_threadsafe(fn, f))
 
-    def remove_done_callback(self, fn):
+    def remove_done_callback(self, fn: Callable[[Future], None]) -> None:
         raise NotImplementedError()
 
 
 class FutureVoid(Future):
-    def wait(self):
+    def wait(self) -> None:
         self.block_until_ready()
         self.capi.fdb_future_get_error(self.fpointer)
         return None
 
 
 class FutureInt64(Future):
-    def wait(self):
+    def wait(self) -> int:
         self.block_until_ready()
         value = ctypes.c_int64()
         self.capi.fdb_future_get_int64(self.fpointer, ctypes.byref(value))
@@ -823,7 +858,7 @@ class FutureInt64(Future):
 
 
 class FutureUInt64(Future):
-    def wait(self):
+    def wait(self) -> int:
         self.block_until_ready()
         value = ctypes.c_uint64()
         self.capi.fdb_future_get_uint64(self.fpointer, ctypes.byref(value))
@@ -831,7 +866,7 @@ class FutureUInt64(Future):
 
 
 class FutureKeyValueArray(Future):
-    def wait(self):
+    def wait(self) -> Tuple[List[KeyValue], int, int]:
         self.block_until_ready()
         kvs = ctypes.pointer(KeyValueStruct())
         count = ctypes.c_int()
@@ -858,7 +893,7 @@ class FutureKeyValueArray(Future):
 
 
 class FutureKeyArray(Future):
-    def wait(self):
+    def wait(self) -> List[bytes]:
         self.block_until_ready()
         ks = ctypes.pointer(KeyStruct())
         count = ctypes.c_int()
@@ -869,7 +904,7 @@ class FutureKeyArray(Future):
 
 
 class FutureStringArray(Future):
-    def wait(self):
+    def wait(self) -> List[bytes]:
         self.block_until_ready()
         strings = ctypes.pointer(ctypes.c_char_p())
         count = ctypes.c_int()
@@ -1292,15 +1327,15 @@ class _TransactionCreator(_FDBBase):
 
 
 class Database(_TransactionCreator):
-    def __init__(self, dpointer):
+    def __init__(self, dpointer: Any) -> None:
         self.dpointer = dpointer
         self.options = _DatabaseOptions(self)
 
-    def __del__(self):
+    def __del__(self) -> None:
         # print("Destroying database 0x%x" % self.dpointer)
         self.capi.fdb_database_destroy(self.dpointer)
 
-    def _set_option(self, option, param, length):
+    def _set_option(self, option: int, param: Optional[bytes], length: int) -> None:
         self.capi.fdb_database_set_option(self.dpointer, option, param, length)
 
     # XXX Adding this back temporarily to test C bindings changes to ensure
@@ -1322,12 +1357,12 @@ class Database(_TransactionCreator):
         )
         return None
 
-    def create_transaction(self):
+    def create_transaction(self) -> Transaction:
         pointer = ctypes.c_void_p()
         self.capi.fdb_database_create_transaction(self.dpointer, ctypes.byref(pointer))
         return Transaction(pointer.value, self)
 
-    def get_client_status(self):
+    def get_client_status(self) -> Key:
         return Key(self.capi.fdb_database_get_client_status(self.dpointer))
 
 
@@ -1346,7 +1381,7 @@ class Cluster(_FDBBase):
         return create_database(self.cluster_file)
 
 
-def create_database(cluster_file=None):
+def create_database(cluster_file: Optional[Union[str, bytes]] = None) -> Database:
     pointer = ctypes.c_void_p()
     _FDBBase.capi.fdb_create_database(
         optionalParamToBytes(cluster_file)[0], ctypes.byref(pointer)
@@ -1354,39 +1389,43 @@ def create_database(cluster_file=None):
     return Database(pointer)
 
 
-def create_cluster(cluster_file=None):
+def create_cluster(cluster_file: Optional[Union[str, bytes]] = None) -> Cluster:
     return Cluster(cluster_file)
 
 
 class KeySelector(object):
-    def __init__(self, key, or_equal, offset):
+    key: bytes
+    or_equal: bool
+    offset: int
+
+    def __init__(self, key: bytes, or_equal: bool, offset: int) -> None:
         self.key = key
         self.or_equal = or_equal
         self.offset = offset
 
-    def __add__(self, offset):
+    def __add__(self, offset: int) -> KeySelector:
         return KeySelector(self.key, self.or_equal, self.offset + offset)
 
-    def __sub__(self, offset):
+    def __sub__(self, offset: int) -> KeySelector:
         return KeySelector(self.key, self.or_equal, self.offset - offset)
 
     @classmethod
-    def last_less_than(cls, key):
+    def last_less_than(cls, key: bytes) -> KeySelector:
         return cls(key, False, 0)
 
     @classmethod
-    def last_less_or_equal(cls, key):
+    def last_less_or_equal(cls, key: bytes) -> KeySelector:
         return cls(key, True, 0)
 
     @classmethod
-    def first_greater_than(cls, key):
+    def first_greater_than(cls, key: bytes) -> KeySelector:
         return cls(key, True, 1)
 
     @classmethod
-    def first_greater_or_equal(cls, key):
+    def first_greater_or_equal(cls, key: bytes) -> KeySelector:
         return cls(key, False, 1)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "KeySelector(%r, %r, %r)" % (self.key, self.or_equal, self.offset)
 
 
@@ -1427,14 +1466,17 @@ class KeyStruct(ctypes.Structure):
 
 
 class KeyValue(object):
-    def __init__(self, key, value):
+    key: bytes
+    value: bytes
+
+    def __init__(self, key: bytes, value: bytes) -> None:
         self.key = key
         self.value = value
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "%s: %s" % (repr(self.key), repr(self.value))
 
-    def __iter__(self):
+    def __iter__(self) -> KVIter:
         return KVIter(self)
 
 
@@ -1511,7 +1553,7 @@ else:
             raise Exception("Unable to locate the FoundationDB API shared library!")
 
 
-def keyToBytes(k):
+def keyToBytes(k: Any) -> bytes:
     if hasattr(k, "as_foundationdb_key"):
         k = k.as_foundationdb_key()
     if not isinstance(k, bytes):
@@ -1519,7 +1561,7 @@ def keyToBytes(k):
     return k
 
 
-def valueToBytes(v):
+def valueToBytes(v: Any) -> bytes:
     if hasattr(v, "as_foundationdb_value"):
         v = v.as_foundationdb_value()
     if not isinstance(v, bytes):
@@ -1527,7 +1569,7 @@ def valueToBytes(v):
     return v
 
 
-def paramToBytes(v):
+def paramToBytes(v: Union[bytes, str, FutureString]) -> bytes:
     if isinstance(v, FutureString):
         v = v.value
     if not isinstance(v, bytes) and hasattr(v, "encode"):
@@ -1537,7 +1579,7 @@ def paramToBytes(v):
     return v
 
 
-def optionalParamToBytes(v):
+def optionalParamToBytes(v: Optional[Union[str, bytes]]) -> Tuple[Optional[bytes], int]:
     if v is None:
         return (None, 0)
     else:
@@ -1900,7 +1942,7 @@ else:
     _unpin_callback = _active_callbacks.remove
 
 
-def init(event_model=None):
+def init(event_model: Optional[str] = None) -> None:
     """Initialize the FDB interface.
 
     Consider using open() as a higher-level interface.
@@ -2103,7 +2145,10 @@ open_databases = {}
 cacheLock = threading.Lock()
 
 
-def open(cluster_file=None, event_model=None):
+def open(
+    cluster_file: Optional[Union[str, bytes]] = None,
+    event_model: Optional[str] = None,
+) -> Database:
     """Opens the given database (or the default database of the cluster indicated
     by the fdb.cluster file in a platform-specific location, if no cluster_file
     or database_name is provided).  Initializes the FDB interface as required."""
@@ -2137,7 +2182,7 @@ def _stop_on_exit():
         _network_thread.join()
 
 
-def strinc(key):
+def strinc(key: bytes) -> bytes:
     key = key.rstrip(b"\xff")
     if len(key) == 0:
         raise ValueError("Key must contain at least one byte not equal to 0xFF.")

--- a/bindings/python/fdb/impl.py
+++ b/bindings/python/fdb/impl.py
@@ -36,7 +36,7 @@ import sys
 import threading
 import traceback
 import weakref
-from typing import Any, Callable, Dict, Iterator, List, Optional, Protocol, Tuple, Union
+from typing import Any, Callable, Dict, Iterator, List, Optional, Protocol, Tuple, Union, runtime_checkable
 
 import fdb
 from fdb.tuple import pack, int2byte
@@ -49,6 +49,26 @@ _network_thread_reentrant_lock = threading.RLock()
 _open_file = open
 
 _thread_local_storage = threading.local()
+
+
+@runtime_checkable
+class IFoundationDBKey(Protocol):
+    """Protocol for objects that can be used as FDB keys."""
+
+    def as_foundationdb_key(self) -> bytes: ...
+
+
+@runtime_checkable
+class IFoundationDBValue(Protocol):
+    """Protocol for objects that can be used as FDB values."""
+
+    def as_foundationdb_value(self) -> bytes: ...
+
+
+# A key accepted by the FDB API: either raw bytes or any object implementing IFoundationDBKey
+KeyType = Union[bytes, IFoundationDBKey]
+# A value accepted by the FDB API: either raw bytes or any object implementing IFoundationDBValue
+ValueType = Union[bytes, IFoundationDBValue]
 
 
 class _NetworkOptions(object):
@@ -468,7 +488,7 @@ class TransactionRead(_FDBBase):
         """Get the read version of the transaction."""
         return FutureInt64(self.capi.fdb_transaction_get_read_version(self.tpointer))
 
-    def get(self, key: Any) -> Value:
+    def get(self, key: KeyType) -> Value:
         key = keyToBytes(key)
         return Value(
             self.capi.fdb_transaction_get(self.tpointer, key, len(key), self._snapshot)
@@ -541,7 +561,7 @@ class TransactionRead(_FDBBase):
         end = self._to_selector(end)
         return FDBRange(self, begin, end, limit, reverse, streaming_mode)
 
-    def get_range_startswith(self, prefix: Any, *args: Any, **kwargs: Any) -> FDBRange:
+    def get_range_startswith(self, prefix: KeyType, *args: Any, **kwargs: Any) -> FDBRange:
         prefix = keyToBytes(prefix)
         return self.get_range(prefix, strinc(prefix), *args, **kwargs)
 
@@ -599,7 +619,7 @@ class Transaction(TransactionRead):
     def _set_option(self, option: int, param: Optional[bytes], length: int) -> None:
         self.capi.fdb_transaction_set_option(self.tpointer, option, param, length)
 
-    def _atomic_operation(self, opcode: int, key: Any, param: Any) -> None:
+    def _atomic_operation(self, opcode: int, key: KeyType, param: ValueType) -> None:
         paramBytes = valueToBytes(param)
         paramLength = len(paramBytes)
         keyBytes = keyToBytes(key)
@@ -608,12 +628,12 @@ class Transaction(TransactionRead):
             self.tpointer, keyBytes, keyLength, paramBytes, paramLength, opcode
         )
 
-    def set(self, key: Any, value: Any) -> None:
+    def set(self, key: KeyType, value: ValueType) -> None:
         key = keyToBytes(key)
         value = valueToBytes(value)
         self.capi.fdb_transaction_set(self.tpointer, key, len(key), value, len(value))
 
-    def clear(self, key: Any) -> None:
+    def clear(self, key: Union[KeyType, KeySelector]) -> None:
         if isinstance(key, KeySelector):
             key = self.get_key(key)
 
@@ -642,33 +662,33 @@ class Transaction(TransactionRead):
             self.tpointer, begin, len(begin), end, len(end)
         )
 
-    def clear_range_startswith(self, prefix: Any) -> None:
+    def clear_range_startswith(self, prefix: KeyType) -> None:
         prefix = keyToBytes(prefix)
         return self.clear_range(prefix, strinc(prefix))
 
-    def watch(self, key: Any) -> FutureVoid:
+    def watch(self, key: KeyType) -> FutureVoid:
         key = keyToBytes(key)
         return FutureVoid(self.capi.fdb_transaction_watch(self.tpointer, key, len(key)))
 
-    def add_read_conflict_range(self, begin: Any, end: Any) -> None:
+    def add_read_conflict_range(self, begin: KeyType, end: KeyType) -> None:
         begin = keyToBytes(begin)
         end = keyToBytes(end)
         self.capi.fdb_transaction_add_conflict_range(
             self.tpointer, begin, len(begin), end, len(end), ConflictRangeType.read
         )
 
-    def add_read_conflict_key(self, key: Any) -> None:
+    def add_read_conflict_key(self, key: KeyType) -> None:
         key = keyToBytes(key)
         self.add_read_conflict_range(key, key + b"\x00")
 
-    def add_write_conflict_range(self, begin: Any, end: Any) -> None:
+    def add_write_conflict_range(self, begin: KeyType, end: KeyType) -> None:
         begin = keyToBytes(begin)
         end = keyToBytes(end)
         self.capi.fdb_transaction_add_conflict_range(
             self.tpointer, begin, len(begin), end, len(end), ConflictRangeType.write
         )
 
-    def add_write_conflict_key(self, key: Any) -> None:
+    def add_write_conflict_key(self, key: KeyType) -> None:
         key = keyToBytes(key)
         self.add_write_conflict_range(key, key + b"\x00")
 
@@ -706,7 +726,7 @@ class Transaction(TransactionRead):
     def cancel(self) -> None:
         self.capi.fdb_transaction_cancel(self.tpointer)
 
-    def __setitem__(self, key: Any, value: Any) -> None:
+    def __setitem__(self, key: KeyType, value: ValueType) -> None:
         self.set(key, value)
 
     def __delitem__(self, key: Union[bytes, slice]) -> None:
@@ -767,7 +787,7 @@ class Future(_FDBBase, metaclass=abc.ABCMeta):
                 raise
 
     def on_ready(self, callback: Callable[[Future], None]) -> None:
-        def cb_and_delref(_ignore: Any) -> None:
+        def cb_and_delref(_ignore: object) -> None:
             _unpin_callback(cbfunc[0])
             del cbfunc[:]
             try:
@@ -796,7 +816,7 @@ class Future(_FDBBase, metaclass=abc.ABCMeta):
         ev = futures[0].Event()
         for idx, f in enumerate(futures):
 
-            def cb(_ignore: Any, idx: int = idx) -> None:
+            def cb(_ignore: object, idx: int = idx) -> None:
                 if d.setdefault("i", idx) == idx:
                     ev.set()
 
@@ -830,6 +850,7 @@ class Future(_FDBBase, metaclass=abc.ABCMeta):
     def add_done_callback(self, fn: Callable[[Future], None]) -> None:
         self.on_ready(lambda f: self.call_soon_threadsafe(fn, f))
 
+    @abc.abstractmethod
     def remove_done_callback(self, fn: Callable[[Future], None]) -> None:
         raise NotImplementedError()
 

--- a/bindings/python/fdb/impl.py
+++ b/bindings/python/fdb/impl.py
@@ -593,10 +593,7 @@ class Transaction(TransactionRead):
         super(Transaction, self).__init__(tpointer, db, False)
         self.options = _TransactionOptions(self)
         self.__snapshot = self.snapshot = TransactionRead(tpointer, db, True)
-
-    def __del__(self) -> None:
-        pass
-
+        
     def set_read_version(self, version: int) -> None:
         """Set the read version of the transaction."""
         self.capi.fdb_transaction_set_read_version(self.tpointer, version)

--- a/bindings/python/fdb/impl.py
+++ b/bindings/python/fdb/impl.py
@@ -470,7 +470,7 @@ class TransactionRead(_FDBBase):
         """Get the read version of the transaction."""
         return FutureInt64(self.capi.fdb_transaction_get_read_version(self.tpointer))
 
-    def get(self, key: Union[bytes, FutureString]) -> Value:
+    def get(self, key: Any) -> Value:
         key = keyToBytes(key)
         return Value(
             self.capi.fdb_transaction_get(self.tpointer, key, len(key), self._snapshot)
@@ -544,7 +544,7 @@ class TransactionRead(_FDBBase):
         return FDBRange(self, begin, end, limit, reverse, streaming_mode)
 
     def get_range_startswith(
-        self, prefix: Union[bytes, FutureString], *args: Any, **kwargs: Any
+        self, prefix: Any, *args: Any, **kwargs: Any
     ) -> FDBRange:
         prefix = keyToBytes(prefix)
         return self.get_range(prefix, strinc(prefix), *args, **kwargs)
@@ -572,7 +572,7 @@ class TransactionRead(_FDBBase):
         )
 
     def get_range_split_points(
-        self, begin_key: bytes, end_key: bytes, chunk_size: int
+        self, begin_key: Optional[bytes], end_key: Optional[bytes], chunk_size: int
     ) -> FutureKeyArray:
         if begin_key is None or end_key is None or chunk_size <= 0:
             raise Exception("Invalid begin key, end key or chunk size")
@@ -606,7 +606,7 @@ class Transaction(TransactionRead):
     def _set_option(self, option: int, param: Optional[bytes], length: int) -> None:
         self.capi.fdb_transaction_set_option(self.tpointer, option, param, length)
 
-    def _atomic_operation(self, opcode: int, key: Union[bytes, FutureString], param: Union[bytes, FutureString]) -> None:
+    def _atomic_operation(self, opcode: int, key: Any, param: Any) -> None:
         paramBytes = valueToBytes(param)
         paramLength = len(paramBytes)
         keyBytes = keyToBytes(key)
@@ -615,12 +615,12 @@ class Transaction(TransactionRead):
             self.tpointer, keyBytes, keyLength, paramBytes, paramLength, opcode
         )
 
-    def set(self, key: Union[bytes, FutureString], value: Union[bytes, FutureString]) -> None:
+    def set(self, key: Any, value: Any) -> None:
         key = keyToBytes(key)
         value = valueToBytes(value)
         self.capi.fdb_transaction_set(self.tpointer, key, len(key), value, len(value))
 
-    def clear(self, key: Union[bytes, KeySelector, FutureString]) -> None:
+    def clear(self, key: Any) -> None:
         if isinstance(key, KeySelector):
             key = self.get_key(key)
 
@@ -649,33 +649,33 @@ class Transaction(TransactionRead):
             self.tpointer, begin, len(begin), end, len(end)
         )
 
-    def clear_range_startswith(self, prefix: Union[bytes, FutureString]) -> None:
+    def clear_range_startswith(self, prefix: Any) -> None:
         prefix = keyToBytes(prefix)
         return self.clear_range(prefix, strinc(prefix))
 
-    def watch(self, key: Union[bytes, FutureString]) -> FutureVoid:
+    def watch(self, key: Any) -> FutureVoid:
         key = keyToBytes(key)
         return FutureVoid(self.capi.fdb_transaction_watch(self.tpointer, key, len(key)))
 
-    def add_read_conflict_range(self, begin: bytes, end: bytes) -> None:
+    def add_read_conflict_range(self, begin: Any, end: Any) -> None:
         begin = keyToBytes(begin)
         end = keyToBytes(end)
         self.capi.fdb_transaction_add_conflict_range(
             self.tpointer, begin, len(begin), end, len(end), ConflictRangeType.read
         )
 
-    def add_read_conflict_key(self, key: bytes) -> None:
+    def add_read_conflict_key(self, key: Any) -> None:
         key = keyToBytes(key)
         self.add_read_conflict_range(key, key + b"\x00")
 
-    def add_write_conflict_range(self, begin: bytes, end: bytes) -> None:
+    def add_write_conflict_range(self, begin: Any, end: Any) -> None:
         begin = keyToBytes(begin)
         end = keyToBytes(end)
         self.capi.fdb_transaction_add_conflict_range(
             self.tpointer, begin, len(begin), end, len(end), ConflictRangeType.write
         )
 
-    def add_write_conflict_key(self, key: bytes) -> None:
+    def add_write_conflict_key(self, key: Any) -> None:
         key = keyToBytes(key)
         self.add_write_conflict_range(key, key + b"\x00")
 
@@ -713,7 +713,7 @@ class Transaction(TransactionRead):
     def cancel(self) -> None:
         self.capi.fdb_transaction_cancel(self.tpointer)
 
-    def __setitem__(self, key: Union[bytes, FutureString], value: Union[bytes, FutureString]) -> None:
+    def __setitem__(self, key: Any, value: Any) -> None:
         self.set(key, value)
 
     def __delitem__(self, key: Union[bytes, slice]) -> None:

--- a/bindings/python/fdb/impl.py
+++ b/bindings/python/fdb/impl.py
@@ -388,7 +388,7 @@ class FDBRange(object):
         end: KeySelector,
         limit: int,
         reverse: bool,
-        streaming_mode: Any,
+        streaming_mode: int,
     ) -> None:
         self._tr = tr
 
@@ -414,7 +414,7 @@ class FDBRange(object):
 
         return list(self.__iter__(mode=mode))
 
-    def __iter__(self, mode: Any = None) -> Iterator[KeyValue]:
+    def __iter__(self, mode: Optional[int] = None) -> Iterator[KeyValue]:
         if mode is None:
             mode = self._mode
         bsel = self._bsel
@@ -457,7 +457,7 @@ class FDBRange(object):
 
 
 class TransactionRead(_FDBBase):
-    def __init__(self, tpointer: Any, db: Database, snapshot: bool) -> None:
+    def __init__(self, tpointer: int, db: Database, snapshot: bool) -> None:
         self.tpointer = tpointer
         self.db = db
         self._snapshot = snapshot
@@ -495,7 +495,7 @@ class TransactionRead(_FDBBase):
         begin: KeySelector,
         end: KeySelector,
         limit: int,
-        streaming_mode: Any,
+        streaming_mode: int,
         iteration: int,
         reverse: bool,
     ) -> FutureKeyValueArray:
@@ -533,7 +533,7 @@ class TransactionRead(_FDBBase):
         end: Optional[Union[bytes, KeySelector]],
         limit: int = 0,
         reverse: bool = False,
-        streaming_mode: Any = StreamingMode.iterator,
+        streaming_mode: int = StreamingMode.iterator,
     ) -> FDBRange:
         if begin is None:
             begin = b""
@@ -591,7 +591,7 @@ class TransactionRead(_FDBBase):
 class Transaction(TransactionRead):
     """A modifiable snapshot of a Database."""
 
-    def __init__(self, tpointer: Any, db: Database) -> None:
+    def __init__(self, tpointer: int, db: Database) -> None:
         super(Transaction, self).__init__(tpointer, db, False)
         self.options = _TransactionOptions(self)
         self.__snapshot = self.snapshot = TransactionRead(tpointer, db, True)
@@ -727,7 +727,7 @@ class Future(_FDBBase):
     Event = threading.Event
     _state = None  # < Hack for trollius
 
-    def __init__(self, fpointer: Any) -> None:
+    def __init__(self, fpointer: int) -> None:
         # print("Creating future 0x%x" % fpointer)
         self.fpointer = fpointer
 
@@ -775,7 +775,7 @@ class Future(_FDBBase):
                 raise
 
     def on_ready(self, callback: Callable[[Future], None]) -> None:
-        def cb_and_delref(ignore: Any) -> None:
+        def cb_and_delref(ignore: object) -> None:
             _unpin_callback(cbfunc[0])
             del cbfunc[:]
             try:
@@ -804,7 +804,7 @@ class Future(_FDBBase):
         ev = futures[0].Event()
         for i, f in enumerate(futures):
 
-            def cb(ignore: Any, i: int = i) -> None:
+            def cb(ignore: object, i: int = i) -> None:
                 if d.setdefault("i", i) == i:
                     ev.set()
 
@@ -1327,7 +1327,7 @@ class _TransactionCreator(_FDBBase):
 
 
 class Database(_TransactionCreator):
-    def __init__(self, dpointer: Any) -> None:
+    def __init__(self, dpointer: int) -> None:
         self.dpointer = dpointer
         self.options = _DatabaseOptions(self)
 

--- a/bindings/python/fdb/impl.py
+++ b/bindings/python/fdb/impl.py
@@ -22,6 +22,7 @@
 
 from __future__ import annotations
 
+import abc
 import atexit
 import ctypes
 import ctypes.util
@@ -35,7 +36,7 @@ import sys
 import threading
 import traceback
 import weakref
-from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Iterator, List, Optional, Protocol, Tuple, Union
 
 import fdb
 from fdb.tuple import pack, int2byte
@@ -350,8 +351,6 @@ class FDBError(Exception):
 
     """
 
-    code: int
-
     def __init__(self, code: int) -> None:
         self.code = code
         self._description: Optional[str] = None
@@ -463,7 +462,6 @@ class TransactionRead(_FDBBase):
         self._snapshot = snapshot
 
     def __del__(self) -> None:
-        # print("Destroying transactionread 0x%x" % self.tpointer)
         self.capi.fdb_transaction_destroy(self.tpointer)
 
     def get_read_version(self) -> FutureInt64:
@@ -593,7 +591,7 @@ class Transaction(TransactionRead):
         super(Transaction, self).__init__(tpointer, db, False)
         self.options = _TransactionOptions(self)
         self.__snapshot = self.snapshot = TransactionRead(tpointer, db, True)
-        
+
     def set_read_version(self, version: int) -> None:
         """Set the read version of the transaction."""
         self.capi.fdb_transaction_set_read_version(self.tpointer, version)
@@ -718,17 +716,15 @@ class Transaction(TransactionRead):
             self.clear(key)
 
 
-class Future(_FDBBase):
+class Future(_FDBBase, metaclass=abc.ABCMeta):
     Event = threading.Event
     _state = None  # < Hack for trollius
 
     def __init__(self, fpointer: Any) -> None:
-        # print("Creating future 0x%x" % fpointer)
         self.fpointer = fpointer
 
     def __del__(self) -> None:
         if self.fpointer:
-            # print("Destroying future 0x%x" % self.fpointer)
             self.capi.fdb_future_destroy(self.fpointer)
             self.fpointer = None
 
@@ -738,6 +734,7 @@ class Future(_FDBBase):
     def _release_memory(self) -> None:
         self.capi.fdb_future_release_memory(self.fpointer)
 
+    @abc.abstractmethod
     def wait(self) -> Any:
         raise NotImplementedError
 
@@ -770,7 +767,7 @@ class Future(_FDBBase):
                 raise
 
     def on_ready(self, callback: Callable[[Future], None]) -> None:
-        def cb_and_delref(ignore: object) -> None:
+        def cb_and_delref(_ignore: Any) -> None:
             _unpin_callback(cbfunc[0])
             del cbfunc[:]
             try:
@@ -797,10 +794,10 @@ class Future(_FDBBase):
             raise ValueError("wait_for_any requires at least one future")
         d: Dict[str, int] = {}
         ev = futures[0].Event()
-        for i, f in enumerate(futures):
+        for idx, f in enumerate(futures):
 
-            def cb(ignore: object, i: int = i) -> None:
-                if d.setdefault("i", i) == i:
+            def cb(_ignore: Any, idx: int = idx) -> None:
+                if d.setdefault("i", idx) == idx:
                     ev.set()
 
             f.on_ready(cb)
@@ -1327,7 +1324,6 @@ class Database(_TransactionCreator):
         self.options = _DatabaseOptions(self)
 
     def __del__(self) -> None:
-        # print("Destroying database 0x%x" % self.dpointer)
         self.capi.fdb_database_destroy(self.dpointer)
 
     def _set_option(self, option: int, param: Optional[bytes], length: int) -> None:
@@ -1389,10 +1385,6 @@ def create_cluster(cluster_file: Optional[Union[str, bytes]] = None) -> Cluster:
 
 
 class KeySelector(object):
-    key: bytes
-    or_equal: bool
-    offset: int
-
     def __init__(self, key: bytes, or_equal: bool, offset: int) -> None:
         self.key = key
         self.or_equal = or_equal
@@ -1461,9 +1453,6 @@ class KeyStruct(ctypes.Structure):
 
 
 class KeyValue(object):
-    key: bytes
-    value: bytes
-
     def __init__(self, key: bytes, value: bytes) -> None:
         self.key = key
         self.value = value
@@ -1548,7 +1537,17 @@ else:
             raise Exception("Unable to locate the FoundationDB API shared library!")
 
 
-def keyToBytes(k: Any) -> bytes:
+class IFoundationDBKey(Protocol):
+    def as_foundationdb_key(self) -> bytes:
+        pass
+
+
+class IFoundationDBValue(Protocol):
+    def as_foundationdb_value(self) -> bytes:
+        pass
+
+
+def keyToBytes(k: Union[bytes, IFoundationDBKey]) -> bytes:
     if hasattr(k, "as_foundationdb_key"):
         k = k.as_foundationdb_key()
     if not isinstance(k, bytes):
@@ -1556,7 +1555,7 @@ def keyToBytes(k: Any) -> bytes:
     return k
 
 
-def valueToBytes(v: Any) -> bytes:
+def valueToBytes(v: Union[bytes, IFoundationDBValue]) -> bytes:
     if hasattr(v, "as_foundationdb_value"):
         v = v.as_foundationdb_value()
     if not isinstance(v, bytes):
@@ -1964,7 +1963,6 @@ def init(event_model: Optional[str] = None) -> None:
                         sys.stderr.write(
                             "Unhandled error in FoundationDB network thread: %s\n" % e
                         )
-                    # print("Network stopped")
 
             _network_thread = NetworkThread()
             _network_thread.daemon = True

--- a/bindings/python/fdb/impl.py
+++ b/bindings/python/fdb/impl.py
@@ -42,7 +42,6 @@ from fdb.tuple import pack, int2byte
 
 from fdb import fdboptions as _opts
 
-
 _network_thread = None
 _network_thread_reentrant_lock = threading.RLock()
 
@@ -165,6 +164,7 @@ def add_operation(fname, v):
     )
     setattr(globals()["Database"], fname, f)
     setattr(globals()["Transaction"], fname, f)
+
 
 def fill_operations():
     _dict = getattr(_opts, "MutationType")
@@ -428,7 +428,7 @@ class FDBRange(object):
 
         while not done:
             if future:
-                (kvs, count, more) = future.wait()
+                kvs, count, more = future.wait()
                 index = 0
                 future = None
 
@@ -543,9 +543,7 @@ class TransactionRead(_FDBBase):
         end = self._to_selector(end)
         return FDBRange(self, begin, end, limit, reverse, streaming_mode)
 
-    def get_range_startswith(
-        self, prefix: Any, *args: Any, **kwargs: Any
-    ) -> FDBRange:
+    def get_range_startswith(self, prefix: Any, *args: Any, **kwargs: Any) -> FDBRange:
         prefix = keyToBytes(prefix)
         return self.get_range(prefix, strinc(prefix), *args, **kwargs)
 

--- a/bindings/python/fdb/impl.py
+++ b/bindings/python/fdb/impl.py
@@ -457,7 +457,7 @@ class FDBRange(object):
 
 
 class TransactionRead(_FDBBase):
-    def __init__(self, tpointer: int, db: Database, snapshot: bool) -> None:
+    def __init__(self, tpointer: Any, db: Database, snapshot: bool) -> None:
         self.tpointer = tpointer
         self.db = db
         self._snapshot = snapshot
@@ -591,7 +591,7 @@ class TransactionRead(_FDBBase):
 class Transaction(TransactionRead):
     """A modifiable snapshot of a Database."""
 
-    def __init__(self, tpointer: int, db: Database) -> None:
+    def __init__(self, tpointer: Any, db: Database) -> None:
         super(Transaction, self).__init__(tpointer, db, False)
         self.options = _TransactionOptions(self)
         self.__snapshot = self.snapshot = TransactionRead(tpointer, db, True)
@@ -727,7 +727,7 @@ class Future(_FDBBase):
     Event = threading.Event
     _state = None  # < Hack for trollius
 
-    def __init__(self, fpointer: int) -> None:
+    def __init__(self, fpointer: Any) -> None:
         # print("Creating future 0x%x" % fpointer)
         self.fpointer = fpointer
 
@@ -1327,7 +1327,7 @@ class _TransactionCreator(_FDBBase):
 
 
 class Database(_TransactionCreator):
-    def __init__(self, dpointer: int) -> None:
+    def __init__(self, dpointer: Any) -> None:
         self.dpointer = dpointer
         self.options = _DatabaseOptions(self)
 

--- a/bindings/python/fdb/locality.py
+++ b/bindings/python/fdb/locality.py
@@ -77,7 +77,9 @@ def get_boundary_keys(
     gen = _get_boundary_keys(db_or_tr, begin, end)
     try:
         next(gen)
-    except StopIteration:  # if _get_boundary_keys() never yields a value, e.g. begin > end
+    except (
+        StopIteration
+    ):  # if _get_boundary_keys() never yields a value, e.g. begin > end
         return (x for x in list())
     return gen
 

--- a/bindings/python/fdb/locality.py
+++ b/bindings/python/fdb/locality.py
@@ -23,10 +23,18 @@
 """Documentation for this API can be found at
 https://apple.github.io/foundationdb/api-python.html"""
 
+from __future__ import annotations
+
+from typing import Generator, Iterator, Union
+
 from fdb import impl as _impl
 
 
-def _get_boundary_keys(db_or_tr, begin, end):
+def _get_boundary_keys(
+    db_or_tr: Union[_impl.Database, _impl.Transaction],
+    begin: bytes,
+    end: bytes,
+) -> Generator[bytes, None, None]:
     if isinstance(db_or_tr, _impl.Transaction):
         tr = db_or_tr.db.create_transaction()
         # This does not guarantee transactionality because of the exception handling below,
@@ -58,7 +66,11 @@ def _get_boundary_keys(db_or_tr, begin, end):
                 tr.on_error(e).wait()
 
 
-def get_boundary_keys(db_or_tr, begin, end):
+def get_boundary_keys(
+    db_or_tr: Union[_impl.Database, _impl.Transaction],
+    begin: bytes,
+    end: bytes,
+) -> Iterator[bytes]:
     begin = _impl.keyToBytes(begin)
     end = _impl.keyToBytes(end)
 
@@ -71,7 +83,9 @@ def get_boundary_keys(db_or_tr, begin, end):
 
 
 @_impl.transactional
-def get_addresses_for_key(tr, key):
+def get_addresses_for_key(
+    tr: Union[_impl.Transaction, _impl.TransactionRead], key: bytes
+) -> _impl.FutureStringArray:
     keyBytes = _impl.keyToBytes(key)
     return _impl.FutureStringArray(
         tr.capi.fdb_transaction_get_addresses_for_key(

--- a/bindings/python/fdb/subspace_impl.py
+++ b/bindings/python/fdb/subspace_impl.py
@@ -29,8 +29,6 @@ from fdb.tuple import TupleElement
 
 
 class Subspace(object):
-    rawPrefix: bytes
-
     def __init__(
         self, prefixTuple: Tuple[TupleElement, ...] = tuple(), rawPrefix: bytes = b""
     ) -> None:

--- a/bindings/python/fdb/subspace_impl.py
+++ b/bindings/python/fdb/subspace_impl.py
@@ -20,43 +20,49 @@
 
 # FoundationDB Python API
 
+from __future__ import annotations
+
+from typing import Any, Tuple
+
 import fdb.tuple
 
 
 class Subspace(object):
-    def __init__(self, prefixTuple=tuple(), rawPrefix=b""):
+    rawPrefix: bytes
+
+    def __init__(self, prefixTuple: Tuple[Any, ...] = tuple(), rawPrefix: bytes = b"") -> None:
         self.rawPrefix = fdb.tuple.pack(prefixTuple, prefix=rawPrefix)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "Subspace(rawPrefix=" + repr(self.rawPrefix) + ")"
 
-    def __getitem__(self, name):
+    def __getitem__(self, name: Any) -> Subspace:
         return Subspace((name,), self.rawPrefix)
 
-    def key(self):
+    def key(self) -> bytes:
         return self.rawPrefix
 
-    def pack(self, t=tuple()):
+    def pack(self, t: Tuple[Any, ...] = tuple()) -> bytes:
         return fdb.tuple.pack(t, prefix=self.rawPrefix)
 
-    def pack_with_versionstamp(self, t=tuple()):
+    def pack_with_versionstamp(self, t: Tuple[Any, ...] = tuple()) -> bytes:
         return fdb.tuple.pack_with_versionstamp(t, prefix=self.rawPrefix)
 
-    def unpack(self, key):
+    def unpack(self, key: bytes) -> Tuple[Any, ...]:
         if not self.contains(key):
             raise ValueError("Cannot unpack key that is not in subspace.")
 
         return fdb.tuple.unpack(key, prefix_len=len(self.rawPrefix))
 
-    def range(self, t=tuple()):
+    def range(self, t: Tuple[Any, ...] = tuple()) -> slice:
         p = fdb.tuple.range(t)
         return slice(self.rawPrefix + p.start, self.rawPrefix + p.stop)
 
-    def contains(self, key):
+    def contains(self, key: bytes) -> bool:
         return key.startswith(self.rawPrefix)
 
-    def as_foundationdb_key(self):
+    def as_foundationdb_key(self) -> bytes:
         return self.rawPrefix
 
-    def subspace(self, tuple):
+    def subspace(self, tuple: Tuple[Any, ...]) -> Subspace:
         return Subspace(tuple, self.rawPrefix)

--- a/bindings/python/fdb/subspace_impl.py
+++ b/bindings/python/fdb/subspace_impl.py
@@ -31,7 +31,9 @@ from fdb.tuple import TupleElement
 class Subspace(object):
     rawPrefix: bytes
 
-    def __init__(self, prefixTuple: Tuple[TupleElement, ...] = tuple(), rawPrefix: bytes = b"") -> None:
+    def __init__(
+        self, prefixTuple: Tuple[TupleElement, ...] = tuple(), rawPrefix: bytes = b""
+    ) -> None:
         self.rawPrefix = fdb.tuple.pack(prefixTuple, prefix=rawPrefix)
 
     def __repr__(self) -> str:

--- a/bindings/python/fdb/subspace_impl.py
+++ b/bindings/python/fdb/subspace_impl.py
@@ -22,39 +22,40 @@
 
 from __future__ import annotations
 
-from typing import Any, Tuple
+from typing import Tuple
 
 import fdb.tuple
+from fdb.tuple import TupleElement
 
 
 class Subspace(object):
     rawPrefix: bytes
 
-    def __init__(self, prefixTuple: Tuple[Any, ...] = tuple(), rawPrefix: bytes = b"") -> None:
+    def __init__(self, prefixTuple: Tuple[TupleElement, ...] = tuple(), rawPrefix: bytes = b"") -> None:
         self.rawPrefix = fdb.tuple.pack(prefixTuple, prefix=rawPrefix)
 
     def __repr__(self) -> str:
         return "Subspace(rawPrefix=" + repr(self.rawPrefix) + ")"
 
-    def __getitem__(self, name: Any) -> Subspace:
+    def __getitem__(self, name: TupleElement) -> Subspace:
         return Subspace((name,), self.rawPrefix)
 
     def key(self) -> bytes:
         return self.rawPrefix
 
-    def pack(self, t: Tuple[Any, ...] = tuple()) -> bytes:
+    def pack(self, t: Tuple[TupleElement, ...] = tuple()) -> bytes:
         return fdb.tuple.pack(t, prefix=self.rawPrefix)
 
-    def pack_with_versionstamp(self, t: Tuple[Any, ...] = tuple()) -> bytes:
+    def pack_with_versionstamp(self, t: Tuple[TupleElement, ...] = tuple()) -> bytes:
         return fdb.tuple.pack_with_versionstamp(t, prefix=self.rawPrefix)
 
-    def unpack(self, key: bytes) -> Tuple[Any, ...]:
+    def unpack(self, key: bytes) -> Tuple[TupleElement, ...]:
         if not self.contains(key):
             raise ValueError("Cannot unpack key that is not in subspace.")
 
         return fdb.tuple.unpack(key, prefix_len=len(self.rawPrefix))
 
-    def range(self, t: Tuple[Any, ...] = tuple()) -> slice:
+    def range(self, t: Tuple[TupleElement, ...] = tuple()) -> slice:
         p = fdb.tuple.range(t)
         return slice(self.rawPrefix + p.start, self.rawPrefix + p.stop)
 
@@ -64,5 +65,5 @@ class Subspace(object):
     def as_foundationdb_key(self) -> bytes:
         return self.rawPrefix
 
-    def subspace(self, tuple: Tuple[Any, ...]) -> Subspace:
+    def subspace(self, tuple: Tuple[TupleElement, ...]) -> Subspace:
         return Subspace(tuple, self.rawPrefix)

--- a/bindings/python/fdb/tuple.py
+++ b/bindings/python/fdb/tuple.py
@@ -28,7 +28,7 @@ import struct
 import math
 import functools
 from bisect import bisect_left
-from typing import Any, Iterator, List, Optional, Sequence, Tuple, Union
+from typing import Any, List, Optional, Tuple, Union
 
 import fdb
 

--- a/bindings/python/fdb/tuple.py
+++ b/bindings/python/fdb/tuple.py
@@ -28,12 +28,15 @@ import struct
 import math
 import functools
 from bisect import bisect_left
-from typing import Any, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union
+
+if TYPE_CHECKING:
+    from typing import TypeAlias
 
 import fdb
 
 # Type alias for values that can be packed into a tuple
-TupleElement = Union[
+TupleElement: "TypeAlias" = Union[
     None,
     bytes,
     str,
@@ -93,8 +96,6 @@ def _float_adjust(v, encode):
 
 @functools.total_ordering
 class SingleFloat(object):
-    value: float
-
     def __init__(self, value: Union[float, ctypes.c_float, int]) -> None:
         if isinstance(value, float):
             # Restrict to the first 4 bytes (essentially)
@@ -143,9 +144,6 @@ class Versionstamp(object):
     _MAX_USER_VERSION = (1 << 16) - 1
     _UNSET_TR_VERSION = 10 * int2byte(0xFF)
     _STRUCT_FORMAT_STRING = ">" + str(_TR_VERSION_LEN) + "sH"
-
-    tr_version: Optional[bytes]
-    user_version: int
 
     @classmethod
     def validate_tr_version(cls, tr_version: Optional[bytes]) -> None:

--- a/bindings/python/fdb/tuple.py
+++ b/bindings/python/fdb/tuple.py
@@ -20,14 +20,32 @@
 
 # FoundationDB Python API
 
+from __future__ import annotations
+
 import ctypes
 import uuid
 import struct
 import math
 import functools
 from bisect import bisect_left
+from typing import Any, Iterator, List, Optional, Sequence, Tuple, Union
 
 import fdb
+
+# Type alias for values that can be packed into a tuple
+TupleElement = Union[
+    None,
+    bytes,
+    str,
+    int,
+    float,
+    bool,
+    uuid.UUID,
+    "SingleFloat",
+    "Versionstamp",
+    Tuple[Any, ...],
+    List[Any],
+]
 
 _size_limits = tuple((1 << (i * 8)) - 1 for i in range(9))
 
@@ -75,7 +93,9 @@ def _float_adjust(v, encode):
 
 @functools.total_ordering
 class SingleFloat(object):
-    def __init__(self, value):
+    value: float
+
+    def __init__(self, value: Union[float, ctypes.c_float, int]) -> None:
         if isinstance(value, float):
             # Restrict to the first 4 bytes (essentially)
             self.value = ctypes.c_float(value).value
@@ -89,22 +109,22 @@ class SingleFloat(object):
             )
 
     # Comparisons
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, SingleFloat):
             return _compare_floats(self.value, other.value) == 0
         else:
             return False
 
-    def __lt__(self, other):
+    def __lt__(self, other: SingleFloat) -> bool:
         return _compare_floats(self.value, other.value) < 0
 
-    def __str__(self):
+    def __str__(self) -> str:
         return str(self.value)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "SingleFloat(" + str(self.value) + ")"
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         # Left-circulate the child hash to make hash(self) != hash(self.value)
         v_hash = hash(self.value)
         if v_hash >= 0:
@@ -112,7 +132,7 @@ class SingleFloat(object):
         else:
             return ((v_hash >> 16) + 1) - ((abs(v_hash) & 0xFFFF) << 16)
 
-    def __nonzero__(self):
+    def __nonzero__(self) -> bool:
         return bool(self.value)
 
 
@@ -124,8 +144,11 @@ class Versionstamp(object):
     _UNSET_TR_VERSION = 10 * int2byte(0xFF)
     _STRUCT_FORMAT_STRING = ">" + str(_TR_VERSION_LEN) + "sH"
 
+    tr_version: Optional[bytes]
+    user_version: int
+
     @classmethod
-    def validate_tr_version(cls, tr_version):
+    def validate_tr_version(cls, tr_version: Optional[bytes]) -> None:
         if tr_version is None:
             return
         if not isinstance(tr_version, bytes):
@@ -144,7 +167,7 @@ class Versionstamp(object):
             )
 
     @classmethod
-    def validate_user_version(cls, user_version):
+    def validate_user_version(cls, user_version: int) -> None:
         if not isinstance(user_version, int):
             raise TypeError(
                 "Local version has illegal type "
@@ -158,18 +181,18 @@ class Versionstamp(object):
                 + " which is out of range"
             )
 
-    def __init__(self, tr_version=None, user_version=0):
+    def __init__(self, tr_version: Optional[bytes] = None, user_version: int = 0) -> None:
         Versionstamp.validate_tr_version(tr_version)
         Versionstamp.validate_user_version(user_version)
         self.tr_version = tr_version
         self.user_version = user_version
 
     @staticmethod
-    def incomplete(user_version=0):
+    def incomplete(user_version: int = 0) -> Versionstamp:
         return Versionstamp(user_version=user_version)
 
     @classmethod
-    def from_bytes(cls, v, start=0):
+    def from_bytes(cls, v: bytes, start: int = 0) -> Versionstamp:
         if not isinstance(v, bytes):
             raise TypeError("Cannot parse versionstamp from non-byte string")
         elif len(v) - start < cls.LENGTH:
@@ -188,10 +211,10 @@ class Versionstamp(object):
             )
             return Versionstamp(tr_version, user_version)
 
-    def is_complete(self):
+    def is_complete(self) -> bool:
         return self.tr_version is not None
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             "fdb.tuple.Versionstamp("
             + repr(self.tr_version)
@@ -200,7 +223,7 @@ class Versionstamp(object):
             + ")"
         )
 
-    def __str__(self):
+    def __str__(self) -> str:
         return (
             "Versionstamp("
             + repr(self.tr_version)
@@ -209,7 +232,7 @@ class Versionstamp(object):
             + ")"
         )
 
-    def to_bytes(self):
+    def to_bytes(self) -> bytes:
         tr_version = self.tr_version
         if isinstance(tr_version, fdb.impl.Value):
             tr_version = tr_version.value
@@ -219,14 +242,14 @@ class Versionstamp(object):
             self.user_version,
         )
 
-    def completed(self, new_tr_version):
+    def completed(self, new_tr_version: bytes) -> Versionstamp:
         if self.is_complete():
             raise RuntimeError("Versionstamp already completed")
         else:
             return Versionstamp(new_tr_version, self.user_version)
 
     # Comparisons
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, Versionstamp):
             return (
                 self.tr_version == other.tr_version
@@ -235,7 +258,7 @@ class Versionstamp(object):
         else:
             return False
 
-    def __lt__(self, other):
+    def __lt__(self, other: Versionstamp) -> bool:
         if self.is_complete():
             if other.is_complete():
                 if self.tr_version == other.tr_version:
@@ -252,13 +275,13 @@ class Versionstamp(object):
             else:
                 return self.user_version < other.user_version
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         if self.tr_version is None:
             return hash(self.user_version)
         else:
             return hash(self.tr_version) * 37 ^ hash(self.user_version)
 
-    def __nonzero__(self):
+    def __nonzero__(self) -> bool:
         return self.is_complete()
 
 
@@ -478,7 +501,7 @@ def _pack_maybe_with_versionstamp(t, prefix=None):
 
 
 # packs the specified tuple into a key
-def pack(t, prefix=None):
+def pack(t: Tuple[Any, ...], prefix: Optional[bytes] = None) -> bytes:
     res, version_pos = _pack_maybe_with_versionstamp(t, prefix)
     if version_pos >= 0:
         raise ValueError("Incomplete versionstamp included in vanilla tuple pack")
@@ -486,7 +509,7 @@ def pack(t, prefix=None):
 
 
 # packs the specified tuple into a key for versionstamp operations
-def pack_with_versionstamp(t, prefix=None):
+def pack_with_versionstamp(t: Tuple[Any, ...], prefix: Optional[bytes] = None) -> bytes:
     res, version_pos = _pack_maybe_with_versionstamp(t, prefix)
     if version_pos < 0:
         raise ValueError(
@@ -496,7 +519,7 @@ def pack_with_versionstamp(t, prefix=None):
 
 
 # unpacks the specified key into a tuple
-def unpack(key, prefix_len=0):
+def unpack(key: bytes, prefix_len: int = 0) -> Tuple[Any, ...]:
     pos = prefix_len
     res = []
     while pos < len(key):
@@ -506,8 +529,8 @@ def unpack(key, prefix_len=0):
 
 
 # determines if there is at least one incomplete versionstamp in a tuple
-def has_incomplete_versionstamp(t):
-    def _elem_has_incomplete(item):
+def has_incomplete_versionstamp(t: Union[Tuple[Any, ...], List[Any]]) -> bool:
+    def _elem_has_incomplete(item: Any) -> bool:
         if item is None:
             return False
         elif isinstance(item, Versionstamp):
@@ -523,7 +546,7 @@ def has_incomplete_versionstamp(t):
 _range = range
 
 
-def range(t):
+def range(t: Tuple[Any, ...]) -> slice:
     """Returns a slice of keys that includes all tuples of greater
     length than the specified tuple that that start with the
     specified elements.
@@ -617,7 +640,7 @@ def _compare_values(value1, value2):
 
 
 # compare element by element and return -1 if t1 < t2 or 1 if t1 > t2 or 0 if t1 == t2
-def compare(t1, t2):
+def compare(t1: Union[Tuple[Any, ...], List[Any]], t2: Union[Tuple[Any, ...], List[Any]]) -> int:
     i = 0
     while i < len(t1) and i < len(t2):
         c = _compare_values(t1[i], t2[i])

--- a/bindings/python/fdb/tuple.py
+++ b/bindings/python/fdb/tuple.py
@@ -181,7 +181,9 @@ class Versionstamp(object):
                 + " which is out of range"
             )
 
-    def __init__(self, tr_version: Optional[bytes] = None, user_version: int = 0) -> None:
+    def __init__(
+        self, tr_version: Optional[bytes] = None, user_version: int = 0
+    ) -> None:
         Versionstamp.validate_tr_version(tr_version)
         Versionstamp.validate_user_version(user_version)
         self.tr_version = tr_version
@@ -291,10 +293,10 @@ def _decode(v, pos):
         return None, pos + 1
     elif code == BYTES_CODE:
         end = _find_terminator(v, pos + 1)
-        return v[pos + 1 : end].replace(b"\x00\xFF", b"\x00"), end + 1
+        return v[pos + 1 : end].replace(b"\x00\xff", b"\x00"), end + 1
     elif code == STRING_CODE:
         end = _find_terminator(v, pos + 1)
-        return v[pos + 1 : end].replace(b"\x00\xFF", b"\x00").decode("utf-8"), end + 1
+        return v[pos + 1 : end].replace(b"\x00\xff", b"\x00").decode("utf-8"), end + 1
     elif code >= INT_ZERO_CODE and code < POS_INT_END:
         n = code - 20
         end = pos + 1 + n
@@ -396,13 +398,13 @@ def _encode(value, nested=False):
             return b"".join([int2byte(NULL_CODE)]), -1
     elif isinstance(value, bytes):  # also gets non-None fdb.impl.Value
         return (
-            int2byte(BYTES_CODE) + value.replace(b"\x00", b"\x00\xFF") + b"\x00",
+            int2byte(BYTES_CODE) + value.replace(b"\x00", b"\x00\xff") + b"\x00",
             -1,
         )
     elif isinstance(value, str):
         return (
             int2byte(STRING_CODE)
-            + value.encode("utf-8").replace(b"\x00", b"\x00\xFF")
+            + value.encode("utf-8").replace(b"\x00", b"\x00\xff")
             + b"\x00",
             -1,
         )
@@ -509,7 +511,9 @@ def pack(t: Tuple[TupleElement, ...], prefix: Optional[bytes] = None) -> bytes:
 
 
 # packs the specified tuple into a key for versionstamp operations
-def pack_with_versionstamp(t: Tuple[TupleElement, ...], prefix: Optional[bytes] = None) -> bytes:
+def pack_with_versionstamp(
+    t: Tuple[TupleElement, ...], prefix: Optional[bytes] = None
+) -> bytes:
     res, version_pos = _pack_maybe_with_versionstamp(t, prefix)
     if version_pos < 0:
         raise ValueError(
@@ -529,7 +533,9 @@ def unpack(key: bytes, prefix_len: int = 0) -> Tuple[TupleElement, ...]:
 
 
 # determines if there is at least one incomplete versionstamp in a tuple
-def has_incomplete_versionstamp(t: Union[Tuple[TupleElement, ...], List[TupleElement]]) -> bool:
+def has_incomplete_versionstamp(
+    t: Union[Tuple[TupleElement, ...], List[TupleElement]],
+) -> bool:
     def _elem_has_incomplete(item: TupleElement) -> bool:
         if item is None:
             return False
@@ -640,7 +646,10 @@ def _compare_values(value1, value2):
 
 
 # compare element by element and return -1 if t1 < t2 or 1 if t1 > t2 or 0 if t1 == t2
-def compare(t1: Union[Tuple[TupleElement, ...], List[TupleElement]], t2: Union[Tuple[TupleElement, ...], List[TupleElement]]) -> int:
+def compare(
+    t1: Union[Tuple[TupleElement, ...], List[TupleElement]],
+    t2: Union[Tuple[TupleElement, ...], List[TupleElement]],
+) -> int:
     i = 0
     while i < len(t1) and i < len(t2):
         c = _compare_values(t1[i], t2[i])

--- a/bindings/python/fdb/tuple.py
+++ b/bindings/python/fdb/tuple.py
@@ -28,15 +28,18 @@ import struct
 import math
 import functools
 from bisect import bisect_left
-from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union
+import sys
+from typing import Any, ClassVar, List, Optional, Tuple, Union
 
-if TYPE_CHECKING:
+if sys.version_info >= (3, 10):
     from typing import TypeAlias
+else:
+    from typing_extensions import TypeAlias
 
 import fdb
 
 # Type alias for values that can be packed into a tuple
-TupleElement: "TypeAlias" = Union[
+TupleElement: TypeAlias = Union[
     None,
     bytes,
     str,
@@ -96,6 +99,8 @@ def _float_adjust(v, encode):
 
 @functools.total_ordering
 class SingleFloat(object):
+    value: float
+
     def __init__(self, value: Union[float, ctypes.c_float, int]) -> None:
         if isinstance(value, float):
             # Restrict to the first 4 bytes (essentially)
@@ -139,11 +144,15 @@ class SingleFloat(object):
 
 @functools.total_ordering
 class Versionstamp(object):
-    LENGTH = 12
-    _TR_VERSION_LEN = 10
-    _MAX_USER_VERSION = (1 << 16) - 1
-    _UNSET_TR_VERSION = 10 * int2byte(0xFF)
-    _STRUCT_FORMAT_STRING = ">" + str(_TR_VERSION_LEN) + "sH"
+    LENGTH: ClassVar[int] = 12
+    _TR_VERSION_LEN: ClassVar[int] = 10
+    _MAX_USER_VERSION: ClassVar[int] = (1 << 16) - 1
+    _UNSET_TR_VERSION: ClassVar[bytes] = 10 * int2byte(0xFF)
+    _STRUCT_FORMAT_STRING: ClassVar[str] = ">" + str(_TR_VERSION_LEN) + "sH"
+
+    # Instance variables set in __init__
+    tr_version: Optional[bytes]
+    user_version: int
 
     @classmethod
     def validate_tr_version(cls, tr_version: Optional[bytes]) -> None:

--- a/bindings/python/fdb/tuple.py
+++ b/bindings/python/fdb/tuple.py
@@ -501,7 +501,7 @@ def _pack_maybe_with_versionstamp(t, prefix=None):
 
 
 # packs the specified tuple into a key
-def pack(t: Tuple[Any, ...], prefix: Optional[bytes] = None) -> bytes:
+def pack(t: Tuple[TupleElement, ...], prefix: Optional[bytes] = None) -> bytes:
     res, version_pos = _pack_maybe_with_versionstamp(t, prefix)
     if version_pos >= 0:
         raise ValueError("Incomplete versionstamp included in vanilla tuple pack")
@@ -509,7 +509,7 @@ def pack(t: Tuple[Any, ...], prefix: Optional[bytes] = None) -> bytes:
 
 
 # packs the specified tuple into a key for versionstamp operations
-def pack_with_versionstamp(t: Tuple[Any, ...], prefix: Optional[bytes] = None) -> bytes:
+def pack_with_versionstamp(t: Tuple[TupleElement, ...], prefix: Optional[bytes] = None) -> bytes:
     res, version_pos = _pack_maybe_with_versionstamp(t, prefix)
     if version_pos < 0:
         raise ValueError(
@@ -519,7 +519,7 @@ def pack_with_versionstamp(t: Tuple[Any, ...], prefix: Optional[bytes] = None) -
 
 
 # unpacks the specified key into a tuple
-def unpack(key: bytes, prefix_len: int = 0) -> Tuple[Any, ...]:
+def unpack(key: bytes, prefix_len: int = 0) -> Tuple[TupleElement, ...]:
     pos = prefix_len
     res = []
     while pos < len(key):
@@ -529,8 +529,8 @@ def unpack(key: bytes, prefix_len: int = 0) -> Tuple[Any, ...]:
 
 
 # determines if there is at least one incomplete versionstamp in a tuple
-def has_incomplete_versionstamp(t: Union[Tuple[Any, ...], List[Any]]) -> bool:
-    def _elem_has_incomplete(item: Any) -> bool:
+def has_incomplete_versionstamp(t: Union[Tuple[TupleElement, ...], List[TupleElement]]) -> bool:
+    def _elem_has_incomplete(item: TupleElement) -> bool:
         if item is None:
             return False
         elif isinstance(item, Versionstamp):
@@ -546,7 +546,7 @@ def has_incomplete_versionstamp(t: Union[Tuple[Any, ...], List[Any]]) -> bool:
 _range = range
 
 
-def range(t: Tuple[Any, ...]) -> slice:
+def range(t: Tuple[TupleElement, ...]) -> slice:
     """Returns a slice of keys that includes all tuples of greater
     length than the specified tuple that that start with the
     specified elements.
@@ -640,7 +640,7 @@ def _compare_values(value1, value2):
 
 
 # compare element by element and return -1 if t1 < t2 or 1 if t1 > t2 or 0 if t1 == t2
-def compare(t1: Union[Tuple[Any, ...], List[Any]], t2: Union[Tuple[Any, ...], List[Any]]) -> int:
+def compare(t1: Union[Tuple[TupleElement, ...], List[TupleElement]], t2: Union[Tuple[TupleElement, ...], List[TupleElement]]) -> int:
     i = 0
     while i < len(t1) and i < len(t2):
         c = _compare_values(t1[i], t2[i])

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -28,7 +28,10 @@ classifiers = [
 version = {attr = "fdb.__version__"}
 
 [tool.setuptools.packages.find]
-# It is necessary to restrict the py-modules since in the CMake build directory 
+# It is necessary to restrict the py-modules since in the CMake build directory
 # there is a CMakeFiles subdirectory which will be misidentified by pip as a
 # module.
 include = ["fdb"]
+
+[tool.setuptools.package-data]
+fdb = ["py.typed"]

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -11,6 +11,9 @@ readme = "README.rst"
 keywords = ["database", "key-value store", "acid"]
 urls = {Homepage = "https://www.foundationdb.org", Repository = "https://github.com/apple/foundationdb"}
 requires-python = ">=3.8"
+dependencies = [
+    "typing_extensions>=4.0; python_version < '3.10'",
+]
 classifiers = [
 	'Development Status :: 5 - Production/Stable',
 	'Intended Audience :: Developers',


### PR DESCRIPTION
## Problem

Addresses issue #11331. The `fdb` Python bindings ship without type annotations and without a `py.typed` marker. Downstream users get no help from mypy, pyright, or IDEs when calling the public API, and even if annotations existed they would be ignored by PEP 561-compliant type checkers (which require an explicit `py.typed` file to trust inline annotations from a third-party package).

## Solution

- Add an empty `fdb/py.typed` marker file and wire it into the sdist/wheel via `[tool.setuptools.package-data]` in `pyproject.toml` (PEP 561).
- Annotate the public surface of `fdb/impl.py`, `fdb/tuple.py`, `fdb/subspace_impl.py`, and `fdb/locality.py`.
- Introduce a `TupleElement` type alias in `fdb/tuple.py` covering the values the tuple layer can pack (`None | bytes | str | int | float | bool | uuid.UUID | SingleFloat | Versionstamp | nested tuple/list`), and use it in `pack`, `pack_with_versionstamp`, `unpack`, `range`, `has_incomplete_versionstamp`, `compare`, and across `Subspace`.
- Use `from __future__ import annotations` so all annotations are strings at runtime — zero runtime cost, no import-order issues.

### Where `Any` is intentionally retained

A few annotations remain `Any` on purpose:

- `Future.wait()` / `Future.result()` return type — `Future` is a generic base class; concrete subclasses (`FutureInt64`, `FutureString`, `FutureKeyValueArray`, …) already return narrower types.
- `keyToBytes(k)` / `valueToBytes(v)` parameters — duck-typed via the `as_foundationdb_key` / `as_foundationdb_value` protocol. Tightening these would require introducing a `typing.Protocol`; happy to do that in a follow-up.
- `tpointer` / `fpointer` / `dpointer` constructor params on `TransactionRead`, `Transaction`, `Future`, `Database` — the codebase passes a mix of `int`, `Optional[int]` (from `c_void_p().value`), and raw `ctypes.c_void_p` to these. A single accurate type would require touching call sites, which expands scope.
- `*args: Any, **kwargs: Any` in `Transaction.get_range_startswith` — pure forwarding to `get_range`.

## Testing

Ran mypy against both `main` and this branch using:
