### PR TITLE
Remove explicit __lsan_do_leak_check() from stopImmediately()

### DIFF
--- a/flow/Net2.cpp
+++ b/flow/Net2.cpp
@@ -307,7 +307,7 @@ public:
 		// timeouts in CI because the symbolizer (llvm-addr2line) can take
 		// 45+ seconds to resolve stacks from dynamically loaded external
 		// client libraries (libfdb_c_external.so), exceeding the ctest timeout.
-		// The original deadlock (multiple threads calling __lsan_do_leak_check
+		// The original deadlock (multiple threads calling __lsan_do_leak_check()
 		// concurrently) was fixed in #13224 but the single-thread symbolizer
 		// slowness remains.
 #endif

--- a/flow/Net2.cpp
+++ b/flow/Net2.cpp
@@ -302,13 +302,14 @@ public:
 	void trackAtPriority(TaskPriority priority, double now);
 	void stopImmediately() {
 #ifdef ADDRESS_SANITIZER
-		// Only run leak check from the main network thread to avoid deadlocking
-		// when multiple network threads (from multiversion client) all call
-		// __lsan_do_leak_check() concurrently — one blocks on the symbolizer
-		// while others wait on __lsan::global_mutex, causing a timeout.
-		if (thread_network == this) {
-			__lsan_do_leak_check();
-		}
+		// Intentionally NOT calling __lsan_do_leak_check() here.
+		// LSAN will still run at process exit. Calling it explicitly causes
+		// timeouts in CI because the symbolizer (llvm-addr2line) can take
+		// 45+ seconds to resolve stacks from dynamically loaded external
+		// client libraries (libfdb_c_external.so), exceeding the ctest timeout.
+		// The original deadlock (multiple threads calling __lsan_do_leak_check
+		// concurrently) was fixed in #13224 but the single-thread symbolizer
+		// slowness remains.
 #endif
 		stopped = true;
 		taskQueue.clear();


### PR DESCRIPTION
fdb_c_upgrade_to_future_version failed again in the nightlies.

The fix in #13224 (guarding with thread_network == this) resolved the multi-thread deadlock but the test still times out because the single main thread's __lsan_do_leak_check() call takes 45+ seconds. The symbolizer (llvm-addr2line) is slow when resolving stacks through dynamically loaded external client libraries (libfdb_c_external.so).

Remove the explicit call entirely. LSAN still performs its leak check automatically at process exit (via the ASAN runtime atexit hook) so leaks are still detected and reported. Unsuppressed leaks still cause non-zero exit and fail the test. The suppressions file (contrib/lsan.suppressions) covers known shutdown-time leaks (connectionKeeper, connectionMonitor, etc.).

The only behavioral change is that we no longer distinguish "leaks before intentional shutdown cleanup" from "leaks during shutdown" -- but that distinction was not being used (suppressions cover both).

Verified: ran fdb_c_upgrade_to_future_version with USE_ASAN=ON. Before fix: hangs 45+ seconds after "Stopping FDB network thread", killed by ctest timeout. After fix: "FDB network thread successfully stopped" immediately, test completes cleanly.
