### PR TITLE
[release-7.4] Make getTeamByServers O(1) in time (#12938) (#13012)

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -1021,6 +1021,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( DD_PREFER_LOW_READ_UTIL_TEAM,                          true );
 	init( DD_TRACE_MOVE_BYTES_AVERAGE_INTERVAL,                   120);
 	init( MOVING_WINDOW_SAMPLE_SIZE,                         10000000); // 10MB
+	init( DD_TEAMS_BY_SERVER_IDS_CONSISTENCY_CHECK_PROB_SIM,       0.0 ); if( isSimulated ) DD_TEAMS_BY_SERVER_IDS_CONSISTENCY_CHECK_PROB_SIM = (deterministicRandom()->random01() * 0.4) + 0.1;
 
 	//Storage Server
 	init( STORAGE_LOGGING_DELAY,                                 5.0 );

--- a/fdbclient/include/fdbclient/ServerKnobs.h
+++ b/fdbclient/include/fdbclient/ServerKnobs.h
@@ -1074,6 +1074,9 @@ public:
 	// Rolling window duration over which the average bytes moved by DD is calculated for the 'MovingData' trace event.
 	double DD_TRACE_MOVE_BYTES_AVERAGE_INTERVAL;
 	int64_t MOVING_WINDOW_SAMPLE_SIZE;
+	// Probability of running the consistency check between teams and teamsByServerIDs
+	// in getTeamByServers (simulation only).
+	double DD_TEAMS_BY_SERVER_IDS_CONSISTENCY_CHECK_PROB_SIM;
 
 	// Storage Server
 	double STORAGE_LOGGING_DELAY;

--- a/fdbserver/DDTeamCollection.actor.cpp
+++ b/fdbserver/DDTeamCollection.actor.cpp
@@ -235,13 +235,11 @@ public:
 
 	// Find the team with the exact storage servers as req.src.
 	static void getTeamByServers(DDTeamCollection* self, GetTeamRequest req) {
-		const std::string servers = TCTeamInfo::serversToString(req.src);
+		getTeamByServersConsistencyCheckInSim(self);
 		Optional<Reference<IDataDistributionTeam>> res;
-		for (const auto& team : self->teams) {
-			if (team->getServerIDsStr() == servers) {
-				res = team;
-				break;
-			}
+		auto it = self->teamsByServerIDs.find(TCTeamInfo::serversToString(req.src));
+		if (it != self->teamsByServerIDs.end()) {
+			res = it->second;
 		}
 		req.reply.send(std::make_pair(res, false));
 	}
@@ -378,6 +376,34 @@ public:
 			if (e.code() != error_code_actor_cancelled && req.reply.canBeSet())
 				req.reply.sendError(e);
 			throw;
+		}
+	}
+
+	// Probabilistic consistency check between teams and teamsByServerIDs
+	// Run only in simulation with a probability of DD_TEAMS_BY_SERVER_IDS_CONSISTENCY_CHECK_PROB_SIM
+	// We may need to tune this knob if simulation runs too slowly (in real-time) and results in
+	// ExternalTimeout in Joshua
+	static void getTeamByServersConsistencyCheckInSim(DDTeamCollection* self) {
+		// This check can be expensive in prod so only run it in simulation
+		if (!g_network->isSimulated()) {
+			return;
+		}
+
+		if (deterministicRandom()->random01() < SERVER_KNOBS->DD_TEAMS_BY_SERVER_IDS_CONSISTENCY_CHECK_PROB_SIM) {
+			std::unordered_map<std::string, Reference<TCTeamInfo>> expected;
+			for (const auto& team : self->teams) {
+				expected[team->getServerIDsStr()] = team;
+			}
+			ASSERT(expected.size() == self->teamsByServerIDs.size());
+			for (const auto& [key, value] : expected) {
+				auto it = self->teamsByServerIDs.find(key);
+				ASSERT(it != self->teamsByServerIDs.end());
+				ASSERT(it->second == value);
+			}
+			TraceEvent("TeamByServerIDsConsistencyCheckPassed")
+			    .suppressFor(5.0)
+			    .detail("TeamsSize", self->teams.size())
+			    .detail("MapSize", self->teamsByServerIDs.size());
 		}
 	}
 
@@ -4993,6 +5019,7 @@ void DDTeamCollection::addTeam(const std::vector<Reference<TCServerInfo>>& newTe
 
 	// For a good team, we add it to teams and create machine team for it when necessary
 	teams.push_back(teamInfo);
+	teamsByServerIDs[teamInfo->getServerIDsStr()] = teamInfo;
 	for (auto& server : newTeamServers) {
 		server->addTeam(teamInfo);
 	}
@@ -5918,6 +5945,10 @@ void DDTeamCollection::addServer(StorageServerInterface newServer,
 
 bool DDTeamCollection::removeTeam(Reference<TCTeamInfo> team) {
 	TraceEvent("RemovedServerTeam", distributorId).detail("Team", team->getDesc());
+	auto it = teamsByServerIDs.find(team->getServerIDsStr());
+	if (it != teamsByServerIDs.end()) {
+		teamsByServerIDs.erase(it);
+	}
 	bool found = false;
 	for (int t = 0; t < teams.size(); t++) {
 		if (teams[t] == team) {

--- a/fdbserver/include/fdbserver/DDTeamCollection.h
+++ b/fdbserver/include/fdbserver/DDTeamCollection.h
@@ -684,7 +684,12 @@ public:
 	std::map<Standalone<StringRef>, Reference<TCMachineInfo>> machine_info;
 	std::vector<Reference<TCMachineTeamInfo>> machineTeams; // all machine teams
 
+	// IMPORTANT: teams and teamsByServerIDs MUST be consistent, so any time we
+	// mutate teams, we must also mutate teamsByServerIDs
 	std::vector<Reference<TCTeamInfo>> teams;
+	// O(1) hash map from server ID string to team information
+	// Currently used by getTeamByServers
+	std::unordered_map<std::string, Reference<TCTeamInfo>> teamsByServerIDs;
 
 	std::vector<DDTeamCollection*> teamCollections;
 	AsyncTrigger printDetailedTeamsInfo;


### PR DESCRIPTION
7.4 port of the getTeamByServers O(1) fix.
- 7.3 version: https://github.com/apple/foundationdb/pull/12938
- main version: https://github.com/apple/foundationdb/pull/13012

See those PRs for description of the problem and testing. 

100K (running) against 7.4 (this) version: 20260520-174847-praza-dd-efficient-getTeamB-3b112f8667a6acb2 compressed=True data_size=40454363 duration=3905621 ended=100000 fail=1 fail_fast=10 max_runs=100000 pass=99999 priority=100 remaining=0 runtime=2:13:25 sanity=False started=100000 stopped=20260520-200212 submitted=20260520-174847 timeout=5400 username=praza-dd-efficient-getTeamByServers-74-b113d621add3beba2d0f92a5afbefcdc4815d77c

Reproduced the issue and got relevant traces:

```
$ grep "Severity=\"40\"" trace.0.0.0.0.215216.1779397789.5LkGj8.0.1.xml
<Event Severity="40" ErrorKind="Unset" Time="413.336951" DateTime="2026-05-21T21:10:08Z" Type="TestFailure" Machine="3.4.3.4:1" ID="962b2313b8b517cf" Error="finish_move_keys_too_many_retries" ErrorDescription="finishMoveKeys exceeded retry limit" ErrorCode="1249" Reason="Error starting workload" Workload="DataLossRecovery" ThreadID="11565868101491258025" Backtrace="addr2line -e fdbserver.debug -p -C -f -i 0x63bbc7f 0x63bbf79 0x63b6164 0x39dedf2 0x39e037a 0x20dfc69 0x21943e3 0x20dfc69 0x20dfc69 0x39d1ff1 0x20dfc69 0x4007a4b 0x4001269 0x4001b85 0x40044da 0x20dfc69 0x302d37c 0x20dfc69 0x3026f31 0x3027a83 0x3026a24 0x2045af8 0x5c5f2f7 0x5c5ee20 0x379ad9a 0x7f1a2e3e6610" LogGroup="default" Roles="TS" />
<Event Severity="40" ErrorKind="Unset" Time="413.365026" DateTime="2026-05-21T21:10:08Z" Type="StartFailedForWorkloadDataLossRecovery" Machine="0.0.0.0:0" ID="0000000000000000" Error="operation_failed" ErrorDescription="Operation failed" ErrorCode="1000" ThreadID="11565868101491258025" Backtrace="addr2line -e fdbserver.debug -p -C -f -i 0x63bbc7f 0x63bbf79 0x63b6164 0x3a5b7e7 0x39f26b0 0x39ed88e 0x21ae698 0x223c908 0x2210cb8 0x221130a 0x20dfc69 0x21aa19b 0x21aa91d 0x20dfc69 0x21276e4 0x5b5cbc4 0x5b5c4bc 0x2045af8 0x5c5f2f7 0x5c5ee20 0x379ad9a 0x7f1a2e3e6610" LogGroup="default" />
<Event Severity="40" ErrorKind="Unset" Time="413.365026" DateTime="2026-05-21T21:10:08Z" Type="RunTests" Machine="0.0.0.0:0" ID="0000000000000000" Error="operation_failed" ErrorDescription="Operation failed" ErrorCode="1000" ThreadID="11565868101491258025" Backtrace="addr2line -e fdbserver.debug -p -C -f -i 0x63bbc7f 0x63bbf79 0x63b6164 0x27cdabd 0x27cdd22 0x20dfc69 0x3a3bd2f 0x20dfc69 0x3a3a3f5 0x20dfc69 0x22cfb2f 0x21d6169 0x3a1ce47 0x3a1fe0e 0x3a5aec9 0x3a1d9b4 0x3a5aec9 0x39ed8c4 0x21ae698 0x223c908 0x2210cb8 0x221130a 0x20dfc69 0x21aa19b 0x21aa91d 0x20dfc69 0x21276e4 0x5b5cbc4 0x5b5c4bc 0x2045af8 0x5c5f2f7 0x5c5ee20 0x379ad9a 0x7f1a2e3e6610" LogGroup="default" />
<Event Severity="40" ErrorKind="Unset" Time="413.365026" DateTime="2026-05-21T21:10:08Z" Type="SetupAndRunError" Machine="0.0.0.0:0" ID="0000000000000000" Error="operation_failed" ErrorDescription="Operation failed" ErrorCode="1000" ThreadID="11565868101491258025" Backtrace="addr2line -e fdbserver.debug -p -C -f -i 0x63bbc7f 0x63bbf79 0x63b6164 0x3338474 0x3331f43 0x20dfc69 0x2837044 0x20dfc69 0x3a3f4a7 0x20dfc69 0x27cdaec 0x27cdd22 0x20dfc69 0x3a3bd2f 0x20dfc69 0x3a3a3f5 0x20dfc69 0x22cfb2f 0x21d6169 0x3a1ce47 0x3a1fe0e 0x3a5aec9 0x3a1d9b4 0x3a5aec9 0x39ed8c4 0x21ae698 0x223c908 0x2210cb8 0x221130a 0x20dfc69 0x21aa19b 0x21aa91d 0x20dfc69 0x21276e4 0x5b5cbc4 0x5b5c4bc 0x2045af8 0x5c5f2f7 0x5c5ee20 0x379ad9a 0x7f1a2e3e6610" LogGroup="default" />


$ grep -i "shard_encode_location_metadata" trace.0.0.0.0.215216.1779397789.5LkGj8.0.1.xml
<Event Severity="10" Time="0.000000" DateTime="2026-05-21T21:09:49Z" Type="Knob" Machine="0.0.0.0:0" ID="0000000000000000" Name="shard_encode_location_metadata" Value="0" Atomic="0" ThreadID="11565868101491258025" LogGroup="default" />
```

As can be seen shard_encode_location_metadata is off, so the changes in this PR should not be causing this failure. The failure is `finish_move_keys_too_many_retries`, which is what we added recently. It could be a matter of tuning `SERVER_KNOBS->FINISH_MOVE_KEYS_MAX_RETRIES` for this test. cc @saintstack if you're interested. 