### PR TITLE
Complete some of function Implementation in BackupWorker V3

### DIFF
--- a/fdbclient/FileBackupAgent.cpp
+++ b/fdbclient/FileBackupAgent.cpp
@@ -4297,14 +4297,18 @@ struct StartFullBackupTaskFunc : BackupTaskFuncBase {
 
 				tr->set(backupStartedKey, encodeBackupStartedValue(ids));
 
+				// Range-partitioned workers do not set BackupConfig.allWorkerStarted, so do not watch
+				// it for that mutation log type.
+				const bool isRangePartitioned = mutationLogType.get().get() == MutationLogType::RANGE_PARTITIONED_LOG;
+
 				// The task may be restarted. Set the watch if started key has NOT been set.
-				if (!taskStarted.get().present()) {
+				if (!isRangePartitioned && !taskStarted.get().present()) {
 					watchFuture = tr->watch(config.allWorkerStarted().key);
 				}
 
 				co_await keepRunning;
 				co_await tr->commit();
-				if (!taskStarted.get().present()) {
+				if (!isRangePartitioned && !taskStarted.get().present()) {
 					co_await watchFuture;
 				}
 				co_return;

--- a/fdbclient/FileBackupAgent.cpp
+++ b/fdbclient/FileBackupAgent.cpp
@@ -4279,7 +4279,7 @@ struct StartFullBackupTaskFunc : BackupTaskFuncBase {
 				co_await (success(started) && success(taskStarted) && success(mutationLogType));
 
 				if (!mutationLogType.get().present() || mutationLogType.get().get() == MutationLogType::DEFAULT) {
-					co_return; // Skip if not using partitioned logs
+					co_return; // Skip if not using partitioned or range partitioned logs
 				}
 
 				std::vector<std::pair<UID, Version>> ids;
@@ -4297,18 +4297,18 @@ struct StartFullBackupTaskFunc : BackupTaskFuncBase {
 
 				tr->set(backupStartedKey, encodeBackupStartedValue(ids));
 
-				// Range-partitioned workers do not set BackupConfig.allWorkerStarted, so do not watch
-				// it for that mutation log type.
-				const bool isRangePartitioned = mutationLogType.get().get() == MutationLogType::RANGE_PARTITIONED_LOG;
+				// Only PartitionedLog workers set BackupConfig.allWorkerStarted, so watch it for that mutation log
+				// type.
+				const bool isPartitionedLog = mutationLogType.get().get() == MutationLogType::PARTITIONED_LOG;
 
 				// The task may be restarted. Set the watch if started key has NOT been set.
-				if (!isRangePartitioned && !taskStarted.get().present()) {
+				if (isPartitionedLog && !taskStarted.get().present()) {
 					watchFuture = tr->watch(config.allWorkerStarted().key);
 				}
 
 				co_await keepRunning;
 				co_await tr->commit();
-				if (!isRangePartitioned && !taskStarted.get().present()) {
+				if (isPartitionedLog && !taskStarted.get().present()) {
 					co_await watchFuture;
 				}
 				co_return;

--- a/fdbserver/backupworker/BackupWorker.cpp
+++ b/fdbserver/backupworker/BackupWorker.cpp
@@ -47,12 +47,10 @@ struct VersionedMessage {
 	StringRef message;
 	VectorRef<Tag> tags;
 	Arena arena; // Keep a reference to the memory containing the message
-	Arena decryptArena; // Arena used for decrypt buffer.
 
 	VersionedMessage(LogMessageVersion v, StringRef m, const VectorRef<Tag>& t, const Arena& a)
 	  : version(v), message(m), tags(t), arena(a) {}
 	Version getVersion() const { return version.version; }
-	uint32_t getSubVersion() const { return version.sub; }
 	// Returns the estimated size of the message in bytes, assuming 6 tags.
 	size_t getEstimatedSize() const { return message.size() + TagsAndMessage::getHeaderSize(6); }
 
@@ -114,7 +112,6 @@ struct BackupData {
 	LogEpoch oldestBackupEpoch = 0; // oldest epoch that still has data on tLogs for backup to pull
 	Version minKnownCommittedVersion;
 	Version savedVersion; // Largest version saved to blob storage
-	Reference<AsyncVar<ServerDBInfo> const> db;
 	AsyncVar<Reference<LogSystemConsumer>> logSystem;
 	Database cx;
 	std::vector<VersionedMessage> messages;
@@ -268,7 +265,7 @@ struct BackupData {
 	explicit BackupData(UID id, Reference<AsyncVar<ServerDBInfo> const> db, const InitializeBackupRequest& req)
 	  : myId(id), tag(req.tag), totalTags(req.totalTags), startVersion(req.startVersion), endVersion(req.endVersion),
 	    recruitedEpoch(req.recruitedEpoch), backupEpoch(req.backupEpoch), minKnownCommittedVersion(invalidVersion),
-	    savedVersion(req.startVersion - 1), db(db), pulledVersion(0), paused(false),
+	    savedVersion(req.startVersion - 1), pulledVersion(0), paused(false),
 	    lock(new FlowLock(SERVER_KNOBS->BACKUP_WORKER_LOCK_BYTES)), cc("BackupWorker", myId.toString()) {
 		cx = openDBOnServer(db, TaskPriority::DefaultEndpoint, LockAware::True);
 

--- a/fdbserver/backupworker/BackupWorkerRangePartitioned.cpp
+++ b/fdbserver/backupworker/BackupWorkerRangePartitioned.cpp
@@ -84,6 +84,9 @@ struct BackupRangePartitionedData {
 	Reference<FlowLock> lock;
 	AsyncTrigger doneTrigger;
 	AsyncTrigger changedTrigger;
+	// Set to true when the worker is shutting down (e.g., worker_removed). Used by uploadData to exit
+	// gracefully via allMessageSaved(), letting in-flight file writes and progress commits finish first.
+	bool stopped = false;
 	Database cx;
 	std::vector<RangePartitionedVersionedMessage> messages;
 	// Key range to partition ID map, used to determine which partition a mutation belongs to based on its key.
@@ -133,7 +136,13 @@ struct BackupRangePartitionedData {
 
 	Version maxPopVersion() const { return endVersion.present() ? endVersion.get() : minKnownCommittedVersion; }
 
-	bool allMessageSaved() const { return (endVersion.present() && savedVersion >= endVersion.get()); }
+	bool allMessageSaved() const { return (endVersion.present() && savedVersion >= endVersion.get()) || stopped; }
+
+	// Tells uploadData to exit: sets stopped (read by allMessageSaved) and wakes it up via doneTrigger.
+	void stop() {
+		stopped = true;
+		doneTrigger.trigger();
+	}
 
 	// Erases messages and updates lock with memory released.
 	void eraseMessages(int num) {
@@ -210,6 +219,21 @@ struct BackupRangePartitionedData {
 		if (!logSystem.get()) {
 			return;
 		}
+		// Defer the pop in two cases, both to avoid losing mutations a future worker might still need:
+		//   1. An older epoch still has work to finish (backupEpoch > oldestBackupEpoch). Wait for that
+		//      older epoch to catch up before popping from this epoch.
+		//   2. We're shutting down (stopped) — our saved progress may not be visible to the next master
+		//      in time, so let the next worker pop after it re-reads progress safely.
+		if (backupEpoch > oldestBackupEpoch || stopped) {
+			TraceEvent("BWRangePartitionedPopDeferred", myId)
+			    .suppressFor(1.0)
+			    .detail("BackupEpoch", backupEpoch)
+			    .detail("OldestEpoch", oldestBackupEpoch)
+			    .detail("Stopped", stopped)
+			    .detail("Version", savedVersion);
+			return;
+		}
+		ASSERT_WE_THINK(backupEpoch == oldestBackupEpoch);
 		logSystem.get()->pop(savedVersion, tag);
 	}
 
@@ -336,7 +360,6 @@ Future<Version> pullPartitionMapFromTLog(BackupRangePartitionedData* self, Parti
 				logSystemChange = self->logSystem.onChange();
 			}
 		}
-		co_await cursor->getMore();
 		if (!cursor->hasMessage()) {
 			continue;
 		}
@@ -346,11 +369,9 @@ Future<Version> pullPartitionMapFromTLog(BackupRangePartitionedData* self, Parti
 			Arena arena = cursor->arena();
 			ArenaReader reader(arena, message, AssumeVersion(g_network->protocolVersion()));
 			if (reader.protocolVersion().hasSpanContext() && SpanContextMessage::isNextIn(reader)) {
-				cursor->nextMessage();
 				continue;
 			}
 			if (reader.protocolVersion().hasOTELSpanContext() && OTELSpanContextMessage::isNextIn(reader)) {
-				cursor->nextMessage();
 				continue;
 			}
 			bool isPartitionMap = PartitionMapMessage::isNextIn(reader);
@@ -783,7 +804,7 @@ static Future<Void> monitorBackupStartedKeyChanges(BackupRangePartitionedData* s
 					}
 				}
 
-				onBackupChanges(self, uidVersions);
+				co_await onBackupChanges(self, uidVersions);
 				Future<Void> watchFuture = tr.watch(backupStartedKey);
 				co_await tr.commit();
 				co_await watchFuture;
@@ -1104,6 +1125,7 @@ Future<Void> backupWorkerRangePartitioned(BackupInterface interf,
 
 	if (err.code() == error_code_worker_removed) {
 		pull = Void(); // cancels pulling
+		self.stop(); // lets uploadData finish its current upload and exit
 		try {
 			co_await done;
 		} catch (Error& shutdownErr) {

--- a/fdbserver/backupworker/BackupWorkerRangePartitioned.cpp
+++ b/fdbserver/backupworker/BackupWorkerRangePartitioned.cpp
@@ -341,15 +341,13 @@ Future<Version> pullPartitionMapFromTLog(BackupRangePartitionedData* self, Parti
 			auto res = co_await race(cursor ? cursor->getMore() : Never(), logSystemChange);
 			if (res.index() == 0) {
 				break;
-			} else if (res.index() == 1) {
+			} else {
 				if (self->logSystem.get()) {
 					cursor = self->logSystem.get()->peekSingle(self->myId, self->startVersion, self->tag);
 				} else {
 					cursor = Reference<IPeekCursor>();
 				}
 				logSystemChange = self->logSystem.onChange();
-			} else {
-				UNREACHABLE();
 			}
 		}
 		co_await cursor->getMore();
@@ -471,7 +469,7 @@ Future<Void> pullAsyncData(BackupRangePartitionedData* self) {
 				    .detail("Tag", self->tag)
 				    .detail("CursorVersion", cursor->version().version);
 				break;
-			} else if (res.index() == 1) {
+			} else {
 				if (self->logSystem.get()) {
 					// TODO akanksha: Use peekSingle as of now instead of peekLogRouter and later confirm if it works as
 					// expected.
@@ -480,8 +478,6 @@ Future<Void> pullAsyncData(BackupRangePartitionedData* self) {
 					cursor = Reference<IPeekCursor>();
 				}
 				logSystemChange = self->logSystem.onChange();
-			} else {
-				UNREACHABLE();
 			}
 		}
 
@@ -1046,13 +1042,31 @@ Future<Void> uploadData(BackupRangePartitionedData* self) {
 	}
 }
 
+// Keeps `self->logSystem` and `self->oldestBackupEpoch` in sync with the latest ServerDBInfo.
+static Future<Void> monitorLogSystemFromDbInfo(Reference<AsyncVar<ServerDBInfo> const> db,
+                                               BackupRangePartitionedData* self) {
+	while (true) {
+		Reference<LogSystem> ls = makeLogSystemFromServerDBInfo(self->myId, db->get(), true);
+		if (ls.isValid()) {
+			self->logSystem.set(ls->makeConsumer());
+			self->oldestBackupEpoch = std::max(self->oldestBackupEpoch, ls->getOldestBackupEpoch());
+			TraceEvent("BWRangePartitionedLogSystemUpdate", self->myId)
+			    .detail("Tag", self->tag.toString())
+			    .detail("TagLocality", self->tag.locality)
+			    .detail("OldestEpoch", self->oldestBackupEpoch);
+		} else {
+			TraceEvent("BWRangePartitionedNoLogSystem", self->myId);
+		}
+		co_await db->onChange();
+	}
+}
+
 Future<Void> backupWorkerRangePartitioned(BackupInterface interf,
                                           InitializeBackupRequest req,
                                           Reference<AsyncVar<ServerDBInfo> const> db) {
 	BackupRangePartitionedData self(interf.id(), db, req);
 	PromiseStream<Future<Void>> addActor;
 	Future<Void> error = actorCollection(addActor.getFuture());
-	Future<Void> dbInfoChange = Void();
 	Future<Void> pull;
 	Future<Void> done;
 	Error err;
@@ -1074,6 +1088,8 @@ Future<Void> backupWorkerRangePartitioned(BackupInterface interf,
 		}
 
 		addActor.send(monitorWorkerPause(&self));
+		// Must be sent before waitAndProcessPartitionMap so logSystem is populated before the partition-map peek.
+		addActor.send(monitorLogSystemFromDbInfo(db, &self));
 
 		// First need to call waitAndProcessPartitionMap before starting to pull data, because we need to know the
 		// partition assignment.
@@ -1091,30 +1107,14 @@ Future<Void> backupWorkerRangePartitioned(BackupInterface interf,
 		done = exitEarly ? Void() : uploadData(&self);
 
 		while (true) {
-			auto res = co_await race(dbInfoChange, done, error);
+			auto res = co_await race(done, error);
 			if (res.index() == 0) {
-				dbInfoChange = db->onChange();
-				Reference<LogSystem> ls = makeLogSystemFromServerDBInfo(self.myId, db->get(), true);
-
-				if (ls.isValid()) {
-					self.logSystem.set(ls->makeConsumer());
-					self.oldestBackupEpoch = std::max(self.oldestBackupEpoch, ls->getOldestBackupEpoch());
-					TraceEvent("BWRangePartitionedLogSystemUpdate", self.myId)
-					    .detail("Tag", self.tag.toString())
-					    .detail("TagLocality", self.tag.locality)
-					    .detail("OldestEpoch", self.oldestBackupEpoch);
-				} else {
-					TraceEvent("BWRangePartitionedNoLogSystem", self.myId);
-				}
-			} else if (res.index() == 1) {
 				TraceEvent("BWRangePartitionedDone", self.myId).detail("BackupEpoch", self.backupEpoch);
 				// Notify master so that this worker can be removed from log system, then this
 				// worker (for an old epoch's unfinished work) can safely exit.
 				co_await brokenPromiseToNever(db->get().clusterInterface.notifyBackupWorkerDone.getReply(
 				    BackupWorkerDoneRequest(self.myId, self.backupEpoch)));
 				break;
-			} else if (res.index() != 2) {
-				UNREACHABLE();
 			}
 		}
 		co_return;

--- a/fdbserver/backupworker/BackupWorkerRangePartitioned.cpp
+++ b/fdbserver/backupworker/BackupWorkerRangePartitioned.cpp
@@ -92,7 +92,6 @@ struct BackupRangePartitionedData {
 	std::unordered_map<int, KeyRange> partitionToKeyRange;
 	// KeyRange to backup UID and partition id map needed to create log files for the right backup and partition.
 	KeyRangeMap<std::vector<std::pair<UID, int32_t>>> keyRangeToBackupAssignment;
-	// TODO akanksha: Once end to end implementation complete, check if stopped need to be added or not.
 
 	struct PerBackupInfo {
 		PerBackupInfo() = default;
@@ -111,20 +110,10 @@ struct BackupRangePartitionedData {
 		Version startVersion = invalidVersion;
 		// The next log's begin version.
 		Version nextFileBeginVersion = invalidVersion;
-		bool stopped = false;
 
-		bool isReady() const { return stopped || (container.isReady() && ranges.isReady()); }
+		bool isBackupReady() const { return container.isReady() && ranges.isReady(); }
 
-		Future<Void> waitReady() {
-			if (stopped) {
-				return Void();
-			}
-			return _waitReady(this);
-		}
-
-		static Future<Void> _waitReady(PerBackupInfo* info) {
-			co_await (success(info->container) && success(info->ranges));
-		}
+		Future<Void> waitBackupReady() { co_await (success(container) && success(ranges)); }
 	};
 
 	// TODO akanksha: Add backups in this map when backup worker receives backup request.
@@ -224,20 +213,17 @@ struct BackupRangePartitionedData {
 		logSystem.get()->pop(savedVersion, tag);
 	}
 
-	static Future<Void> _waitAllInfoReady(BackupRangePartitionedData* self) {
+	Future<Void> waitAllBackupsReady() {
 		std::vector<Future<Void>> all;
-		for (auto it = self->backups.begin(); it != self->backups.end();) {
-			all.push_back(it->second.waitReady());
-			it++;
+		for (auto& [uid, info] : backups) {
+			all.push_back(info.waitBackupReady());
 		}
 		co_await waitForAll(all);
 	}
 
-	Future<Void> waitAllInfoReady() { return _waitAllInfoReady(this); }
-
-	bool isAllInfoReady() const {
+	bool isAllBackupsReady() const {
 		for (const auto& [uid, info] : backups) {
-			if (!info.isReady())
+			if (!info.isBackupReady())
 				return false;
 		}
 		return true;
@@ -247,8 +233,8 @@ struct BackupRangePartitionedData {
 static Future<Void> computeKeyRangeToBackupAssignment(BackupRangePartitionedData* self) {
 	self->keyRangeToBackupAssignment = KeyRangeMap<std::vector<std::pair<UID, int32_t>>>();
 
-	while (!self->isAllInfoReady()) {
-		co_await self->waitAllInfoReady();
+	while (!self->isAllBackupsReady()) {
+		co_await self->waitAllBackupsReady();
 	}
 
 	for (auto& [uid, info] : self->backups) {
@@ -293,11 +279,12 @@ static Future<Void> onBackupChanges(BackupRangePartitionedData* self,
 	}
 
 	// Remove backups that are no longer active.
-	for (auto it = self->backups.begin(); it != self->backups.end(); it++) {
+	for (auto it = self->backups.begin(); it != self->backups.end();) {
 		if (!activeUids.contains(it->first)) {
-			it->second.stopped = true;
 			it = self->backups.erase(it);
 			modified = true;
+		} else {
+			++it;
 		}
 	}
 
@@ -601,8 +588,8 @@ static Future<Void> updateLogBytesWritten(BackupRangePartitionedData* self, std:
 
 Future<Void> saveMutationsToFile(BackupRangePartitionedData* self, Version lastVersionInFile, int numMsg) {
 	// Make sure all backups are ready, otherwise mutations will be lost.
-	while (!self->isAllInfoReady()) {
-		co_await self->waitAllInfoReady();
+	while (!self->isAllBackupsReady()) {
+		co_await self->waitAllBackupsReady();
 	}
 
 	std::vector<RangePartitionedLogFileInfo> activeFiles;

--- a/fdbserver/backupworker/BackupWorkerRangePartitioned.cpp
+++ b/fdbserver/backupworker/BackupWorkerRangePartitioned.cpp
@@ -72,7 +72,6 @@ struct BackupRangePartitionedData {
 	const Optional<Version> endVersion; // old epoch's end version (inclusive), or empty for current epoch
 	const LogEpoch recruitedEpoch; // current epoch whose tLogs are receiving mutations
 	const LogEpoch backupEpoch; // the epoch workers should pull mutations
-	// TODO akanksha: Update oldestBackupEpoch wherever needed.
 	LogEpoch oldestBackupEpoch = 0; // oldest epoch that still has data on tLogs for backup to pull
 	// Minimumum known committed version in StorageServers.
 	Version minKnownCommittedVersion;
@@ -416,9 +415,9 @@ Future<Void> uploadPartitionList(BackupRangePartitionedData* self, PartitionMap 
 // 2. For older epochs with different containers is PartitionMap specific to container or same for all.
 // Right now assumption is that PartitionMap will be passed by TLOG with the first message after start version for both
 // older epochs and newer epochs.
-// 3. Provide implemention for recovery where paritionmap can come any time and won't be the first message.
+// 3. Provide implemention for recovery where partitionmap can come any time and won't be the first message.
 Future<Void> waitAndProcessPartitionMap(BackupRangePartitionedData* self) {
-	TraceEvent("BWRangeParitionedWaitingForPartitionMap", self->myId)
+	TraceEvent("BWRangePartitionedWaitingForPartitionMap", self->myId)
 	    .detail("Tag", self->tag.toString())
 	    .detail("StartVersion", self->startVersion);
 	PartitionMap partitionMap;
@@ -427,7 +426,7 @@ Future<Void> waitAndProcessPartitionMap(BackupRangePartitionedData* self) {
 	self->logFolderBaseVersion = partitionMapVersion + 1;
 
 	ASSERT(partitionMap.contains(self->tag));
-	TraceEvent("BWRangeParitionedPulledPartitionMap", self->myId)
+	TraceEvent("BWRangePartitionedPulledPartitionMap", self->myId)
 	    .detail("Version", partitionMapVersion)
 	    .detail("NumTags", partitionMap.size())
 	    .detail("Tag", self->tag.toString())
@@ -682,7 +681,7 @@ Future<Void> saveMutationsToFile(BackupRangePartitionedData* self, Version lastV
 			continue;
 		}
 
-		DEBUG_MUTATION("BWRangeParitionedAddMutation", message.version.version, m, self->myId)
+		DEBUG_MUTATION("BWRangePartitionedAddMutation", message.version.version, m, self->myId)
 		    .detail("KCV", self->minKnownCommittedVersion)
 		    .detail("SavedVersion", self->savedVersion);
 
@@ -735,7 +734,10 @@ Future<Void> saveMutationsToFile(BackupRangePartitionedData* self, Version lastV
 
 	std::map<UID, int64_t> bytesPerBackup;
 	for (auto& lf : activeFiles) {
-		self->backups[lf.backupUid].nextFileBeginVersion = lastVersionInFile + 1;
+		auto it = self->backups.find(lf.backupUid);
+		if (it != self->backups.end()) {
+			it->second.nextFileBeginVersion = lastVersionInFile + 1;
+		}
 		bytesPerBackup[lf.backupUid] += lf.file->size();
 	}
 

--- a/fdbserver/backupworker/BackupWorkerRangePartitioned.cpp
+++ b/fdbserver/backupworker/BackupWorkerRangePartitioned.cpp
@@ -21,9 +21,7 @@
 #include "fdbclient/BackupAgent.h"
 #include "fdbclient/BackupContainer.h"
 #include "fdbclient/DatabaseContext.h"
-#include "fdbclient/JsonBuilder.h"
 #include "fdbclient/SystemData.h"
-#include "fdbclient/Tracing.h"
 #include "fdbserver/core/BackupPartitionMap.h"
 #include "fdbserver/core/BackupProgress.h"
 #include "fdbserver/core/Knobs.h"
@@ -118,8 +116,9 @@ struct BackupRangePartitionedData {
 		bool isReady() const { return stopped || (container.isReady() && ranges.isReady()); }
 
 		Future<Void> waitReady() {
-			if (stopped)
+			if (stopped) {
 				return Void();
+			}
 			return _waitReady(this);
 		}
 
@@ -285,7 +284,7 @@ static Future<Void> onBackupChanges(BackupRangePartitionedData* self,
 
 	// Add any new backups.
 	for (const auto& [uid, version] : uidVersions) {
-		if (self->backups.find(uid) == self->backups.end()) {
+		if (!self->backups.contains(uid)) {
 			self->backups.emplace(uid, BackupRangePartitionedData::PerBackupInfo(self, uid, version));
 			modified = true;
 			newBackupsMinVersion = std::min(newBackupsMinVersion, version);
@@ -295,7 +294,7 @@ static Future<Void> onBackupChanges(BackupRangePartitionedData* self,
 
 	// Remove backups that are no longer active.
 	for (auto it = self->backups.begin(); it != self->backups.end(); it++) {
-		if (activeUids.find(it->first) == activeUids.end()) {
+		if (!activeUids.contains(it->first)) {
 			it->second.stopped = true;
 			it = self->backups.erase(it);
 			modified = true;
@@ -419,7 +418,7 @@ Future<Void> waitAndProcessPartitionMap(BackupRangePartitionedData* self) {
 	Version partitionMapVersion = co_await pullPartitionMapFromTLog(self, &partitionMap);
 	self->logFolderBaseVersion = partitionMapVersion + 1;
 
-	ASSERT(partitionMap.find(self->tag) != partitionMap.end());
+	ASSERT(partitionMap.contains(self->tag));
 	TraceEvent("BWRangeParitionedPulledPartitionMap", self->myId)
 	    .detail("Version", partitionMapVersion)
 	    .detail("NumTags", partitionMap.size())
@@ -702,7 +701,7 @@ Future<Void> saveMutationsToFile(BackupRangePartitionedData* self, Version lastV
 
 					int fileIdx = it->second;
 					// For ClearRange, we only need to write the full mutation once for each file.
-					if (writtenFiles.find(fileIdx) != writtenFiles.end()) {
+					if (writtenFiles.contains(fileIdx)) {
 						continue;
 					}
 					auto& lf = activeFiles[fileIdx];

--- a/fdbserver/backupworker/BackupWorkerRangePartitioned.cpp
+++ b/fdbserver/backupworker/BackupWorkerRangePartitioned.cpp
@@ -283,7 +283,7 @@ static Future<Void> onBackupChanges(BackupRangePartitionedData* self,
 	bool hasNewBackup = false;
 	Version newBackupsMinVersion = std::numeric_limits<Version>::max();
 
-	// Add any new backups
+	// Add any new backups.
 	for (const auto& [uid, version] : uidVersions) {
 		if (self->backups.find(uid) == self->backups.end()) {
 			self->backups.emplace(uid, BackupRangePartitionedData::PerBackupInfo(self, uid, version));
@@ -823,20 +823,14 @@ Future<Void> setBackupKeys(BackupRangePartitionedData* self, std::map<UID, Versi
 
 			std::vector<Future<Optional<Version>>> prevBackupWorkerSavedVersions;
 			std::vector<BackupConfig> versionConfigs;
-			std::vector<Future<Optional<bool>>> allWorkersReady;
 			for (const auto& [uid, version] : savedLogVersions) {
 				BackupConfig config(uid);
 				versionConfigs.emplace_back(config);
 				prevBackupWorkerSavedVersions.push_back(config.latestBackupWorkerSavedVersion().get(tr));
-				allWorkersReady.push_back(config.allWorkerStarted().get(tr));
 			}
-			co_await (waitForAll(prevBackupWorkerSavedVersions) && waitForAll(allWorkersReady));
+			co_await waitForAll(prevBackupWorkerSavedVersions);
 
 			for (int i = 0; i < prevBackupWorkerSavedVersions.size(); i++) {
-				if (!allWorkersReady[i].get().present() || !allWorkersReady[i].get().get()) {
-					continue;
-				}
-
 				const Version current = savedLogVersions[versionConfigs[i].getUid()];
 				if (prevBackupWorkerSavedVersions[i].get().present()) {
 					const Version prev = prevBackupWorkerSavedVersions[i].get().get();

--- a/fdbserver/core/include/fdbserver/core/BackupPartitionMap.h
+++ b/fdbserver/core/include/fdbserver/core/BackupPartitionMap.h
@@ -38,10 +38,10 @@ struct Partition {
 	}
 };
 
-typedef std::vector<Partition> PartitionList;
+using PartitionList = std::vector<Partition>;
 // NOTE: PartitionMap is ordered by Tag so that multiple backup workers can upload the same content and overwrite to
 // blob storage at the same time without conflicts. If the map is not ordered, then there can be conflicts in blob
 // storage when multiple backup workers upload the partition map at the same time.
-typedef std::map<Tag, PartitionList> PartitionMap;
+using PartitionMap = std::map<Tag, PartitionList>;
 
 std::string serializePartitionListJSON(PartitionMap const& PartitionMap);

--- a/fdbserver/core/include/fdbserver/core/BackupPartitionMap.h
+++ b/fdbserver/core/include/fdbserver/core/BackupPartitionMap.h
@@ -44,4 +44,4 @@ using PartitionList = std::vector<Partition>;
 // storage when multiple backup workers upload the partition map at the same time.
 using PartitionMap = std::map<Tag, PartitionList>;
 
-std::string serializePartitionListJSON(PartitionMap const& PartitionMap);
+std::string serializePartitionListJSON(PartitionMap const& partitionMap);


### PR DESCRIPTION
This PR includes following changes:
1. Initialize `LogSystem` before `PartitionMap` is pulled.  Pulled the `logSystem` update logic into a new `monitorLogSystemFromDbInfo` actor, started via addActor before the partition-map await.

2. Drop `_updateStartedWorkers` and the `BackupConfig` keys it managed
  `startedBackupWorkers` and `allWorkerStarted` existed for Backup V2 readiness gating. Range-partitioned already gates progress on tagVersions.size() == totalTags, so neither key is needed.
  Worker no longer reads/writes either; client skips the watch for RANGE_PARTITIONED_LOG.
  PARTITIONED_LOG and DEFAULT paths unchanged.
     
3.  Fix clang-tidy warnings.

4.  Clean up stopped. Removed the dead `per-backup stopped` field. But kept `worker-level stopped `flag + stop() method so uploadData exits cleanly on worker_removed.

5. Simplify and merge the ready functions The pre-existing pattern used static actor helpers behind public wrapper methods, a Flow convention from before C++20 coroutines. Collapsed both _waitReady/waitReady and _waitAllInfoReady/waitAllInfoReady into single member coroutines. Renamed for clarity.

6.  Remove redundant getMore() and nextMessage() in pullPartitionMapFromTLog

7. Defer pop() for old epochs and on shutdown

8.  Fix iterator double-advance in onBackupChanges

9. Remove unused variables from BackupWorker.cpp 

### Testing
Simulation 100k completed:

` 20260523-013830-ak_bv3-e12f6ac1120c209d            compressed=True data_size=37185082 duration=2642536 ended=100000 fail=1 fail_fast=10 max_runs=100000 pass=99999 priority=100 remaining=0 runtime=0:38:25 sanity=False started=100000 stopped=20260523-021655 submitted=20260523-013830 timeout=5400 username=ak_bv3`
Unrelated failure 