### PR TITLE
Add clearprefix command to fdbcli for prefix-based key clearing

### DIFF
--- a/fdbcli/fdbcli.cpp
+++ b/fdbcli/fdbcli.cpp
@@ -538,6 +538,12 @@ void initHelp() {
 	    "clear a range of keys from the database",
 	    "All keys between BEGINKEY (inclusive) and ENDKEY (exclusive) are cleared from the database. This command will "
 	    "succeed even if the specified range is empty, but may fail because of conflicts." ESCAPINGK);
+	helpMap["clearprefix"] = CommandHelp(
+	    "clearprefix <PREFIX>",
+	    "clear all keys with the given prefix from the database",
+	    "All keys that start with PREFIX are cleared from the database. This is equivalent to `clearrange <PREFIX> "
+	    "<STRINC(PREFIX)>' but avoids the need to manually compute the end key. This command will succeed even if no "
+	    "keys with the given prefix exist, but may fail because of conflicts." ESCAPINGK);
 	helpMap["exit"] = CommandHelp("exit", "exit the CLI", "");
 	helpMap["quit"] = CommandHelp();
 	helpMap["waitconnected"] = CommandHelp();
@@ -1809,6 +1815,27 @@ Future<int> cli(CLIOptions opt, LineNoise* plinenoise, Reference<ClusterConnecti
 					} else {
 						getTransaction(db, tr, options, intrans);
 						tr->clear(KeyRangeRef(tokens[1], tokens[2]));
+
+						if (!intrans) {
+							co_await commitTransaction(tr);
+						}
+					}
+					continue;
+				}
+
+				if (tokencmp(tokens[0], "clearprefix")) {
+					if (!writeMode) {
+						fprintf(stderr, "ERROR: writemode must be enabled to set or clear keys in the database.\n");
+						is_error = true;
+						continue;
+					}
+
+					if (tokens.size() != 2) {
+						printUsage(tokens[0]);
+						is_error = true;
+					} else {
+						getTransaction(db, tr, options, intrans);
+						tr->clear(prefixRange(tokens[1]));
 
 						if (!intrans) {
 							co_await commitTransaction(tr);

--- a/fdbcli/fdbcli.cpp
+++ b/fdbcli/fdbcli.cpp
@@ -534,16 +534,11 @@ void initHelp() {
 	    "clear a key from the database",
 	    "Clear succeeds even if the specified key is not present, but may fail because of conflicts." ESCAPINGK);
 	helpMap["clearrange"] = CommandHelp(
-	    "clearrange <BEGINKEY> <ENDKEY>",
+	    "clearrange <BEGINKEY> [ENDKEY]",
 	    "clear a range of keys from the database",
-	    "All keys between BEGINKEY (inclusive) and ENDKEY (exclusive) are cleared from the database. This command will "
-	    "succeed even if the specified range is empty, but may fail because of conflicts." ESCAPINGK);
-	helpMap["clearprefix"] = CommandHelp(
-	    "clearprefix <PREFIX>",
-	    "clear all keys with the given prefix from the database",
-	    "All keys that start with PREFIX are cleared from the database. This is equivalent to `clearrange <PREFIX> "
-	    "<STRINC(PREFIX)>' but avoids the need to manually compute the end key. This command will succeed even if no "
-	    "keys with the given prefix exist, but may fail because of conflicts." ESCAPINGK);
+	    "All keys between BEGINKEY (inclusive) and ENDKEY (exclusive) are cleared from the database. If ENDKEY is "
+	    "omitted, then all keys starting with BEGINKEY are cleared. This command will succeed even if the specified "
+	    "range is empty, but may fail because of conflicts." ESCAPINGK);
 	helpMap["exit"] = CommandHelp("exit", "exit the CLI", "");
 	helpMap["quit"] = CommandHelp();
 	helpMap["waitconnected"] = CommandHelp();
@@ -1809,37 +1804,25 @@ Future<int> cli(CLIOptions opt, LineNoise* plinenoise, Reference<ClusterConnecti
 						continue;
 					}
 
-					if (tokens.size() != 3) {
-						printUsage(tokens[0]);
-						is_error = true;
-					} else {
-						getTransaction(db, tr, options, intrans);
-						tr->clear(KeyRangeRef(tokens[1], tokens[2]));
-
-						if (!intrans) {
-							co_await commitTransaction(tr);
-						}
-					}
-					continue;
-				}
-
-				if (tokencmp(tokens[0], "clearprefix")) {
-					if (!writeMode) {
-						fprintf(stderr, "ERROR: writemode must be enabled to set or clear keys in the database.\n");
-						is_error = true;
-						continue;
-					}
-
-					if (tokens.size() != 2) {
-						printUsage(tokens[0]);
-						is_error = true;
-					} else {
+					if (tokens.size() == 2) {
+						// Prefix mode: clear all keys starting with BEGINKEY
 						getTransaction(db, tr, options, intrans);
 						tr->clear(prefixRange(tokens[1]));
 
 						if (!intrans) {
 							co_await commitTransaction(tr);
 						}
+					} else if (tokens.size() == 3) {
+						// Range mode: clear keys in [BEGINKEY, ENDKEY)
+						getTransaction(db, tr, options, intrans);
+						tr->clear(KeyRangeRef(tokens[1], tokens[2]));
+
+						if (!intrans) {
+							co_await commitTransaction(tr);
+						}
+					} else {
+						printUsage(tokens[0]);
+						is_error = true;
 					}
 					continue;
 				}

--- a/fdbcli/tests/fdbcli_tests.py
+++ b/fdbcli/tests/fdbcli_tests.py
@@ -590,6 +590,60 @@ def transaction(logger):
     assert output7 == "`key': not found"
 
 
+@enable_logging()
+def clearprefix(logger):
+    """This test covers the clearprefix fdbcli command."""
+    # Test 1: clearprefix without writemode should fail
+    err1 = run_fdbcli_command_and_get_error("clearprefix", "prefix")
+    assert (
+        err1 == "ERROR: writemode must be enabled to set or clear keys in the database."
+    )
+    # Test 2: set keys with a shared prefix and one without, then clearprefix
+    process = subprocess.Popen(
+        command_template[:-1],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        env=fdbcli_env,
+    )
+    transaction_flow = [
+        "writemode on",
+        "set prefix_aaa val1",
+        "set prefix_bbb val2",
+        "set prefix_ccc val3",
+        "set other_key val4",
+        "clearprefix prefix_",
+        # verify prefix keys are gone
+        "get prefix_aaa",
+        "get prefix_bbb",
+        "get prefix_ccc",
+        # verify non-prefix key is still present
+        "get other_key",
+    ]
+    output1, _ = process.communicate(input="\n".join(transaction_flow).encode())
+    lines = list(filter(len, output1.decode().split("\n")))
+    logger.debug("Output lines: {}".format(lines))
+    # Find the get results (last 4 meaningful lines before the prompt)
+    get_results = [l for l in lines if "not found" in l or "is `" in l]
+    logger.debug("Get results: {}".format(get_results))
+    assert len(get_results) == 4
+    assert get_results[0] == "`prefix_aaa': not found"
+    assert get_results[1] == "`prefix_bbb': not found"
+    assert get_results[2] == "`prefix_ccc': not found"
+    assert get_results[3] == "`other_key' is `val4'"
+    # Cleanup: remove the remaining key
+    process = subprocess.Popen(
+        command_template[:-1],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        env=fdbcli_env,
+    )
+    cleanup_flow = [
+        "writemode on",
+        "clear other_key",
+    ]
+    process.communicate(input="\n".join(cleanup_flow).encode())
+
+
 def get_fdb_process_addresses(logger):
     # get all processes' network addresses
     output = run_fdbcli_command("kill")
@@ -930,6 +984,7 @@ if __name__ == "__main__":
         # TODO: re-enable once stable
         # suspend()
         transaction()
+        clearprefix()
         # TODO: re-enable once stable
         # throttle()
         triggerddteaminfolog()

--- a/fdbcli/tests/fdbcli_tests.py
+++ b/fdbcli/tests/fdbcli_tests.py
@@ -591,14 +591,14 @@ def transaction(logger):
 
 
 @enable_logging()
-def clearprefix(logger):
-    """This test covers the clearprefix fdbcli command."""
-    # Test 1: clearprefix without writemode should fail
-    err1 = run_fdbcli_command_and_get_error("clearprefix", "prefix")
+def clearrange_prefix(logger):
+    """This test covers the clearrange fdbcli command with optional ENDKEY (prefix mode)."""
+    # Test 1: clearrange without writemode should fail
+    err1 = run_fdbcli_command_and_get_error("clearrange", "prefix")
     assert (
         err1 == "ERROR: writemode must be enabled to set or clear keys in the database."
     )
-    # Test 2: set keys with a shared prefix and one without, then clearprefix
+    # Test 2: set keys with a shared prefix and one without, then clearrange with prefix only
     process = subprocess.Popen(
         command_template[:-1],
         stdin=subprocess.PIPE,
@@ -611,7 +611,7 @@ def clearprefix(logger):
         "set prefix_bbb val2",
         "set prefix_ccc val3",
         "set other_key val4",
-        "clearprefix prefix_",
+        "clearrange prefix_",
         # verify prefix keys are gone
         "get prefix_aaa",
         "get prefix_bbb",
@@ -984,7 +984,7 @@ if __name__ == "__main__":
         # TODO: re-enable once stable
         # suspend()
         transaction()
-        clearprefix()
+        clearrange_prefix()
         # TODO: re-enable once stable
         # throttle()
         triggerddteaminfolog()


### PR DESCRIPTION
Currently, deleting all keys under a specific prefix via `fdbcli` is notoriously annoying. Users have to use `clearrange` and manually calculate the exclusive end key in their head . 

This PR adds a `clearprefix <PREFIX>` command to `fdbcli` to solve this. 

It works exactly like `clearrange`, but it uses the existing `prefixRange()` helper from `FDBTypes.h` (which leverages `strinc()`) to automatically compute the correct exclusive end key. It's a small quality-of-life improvement that saves a lot of manual hex math when dealing with raw byte prefixes in the CLI.

Testing done:
- Compiled and tested locally via `fdbcli`. 
- Verified that `clearprefix foo` correctly deletes `foo1`, `foo2`, etc., without touching `fop`.
- Verified error handling (e.g., attempting to run it without `writemode on` correctly throws the standard error).
