### PR TITLE
Fix dead TLog hang with sender-side peek timeout

### DIFF
--- a/fdbserver/core/ServerKnobs.cpp
+++ b/fdbserver/core/ServerKnobs.cpp
@@ -231,6 +231,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( ENABLE_TLOG_TEMP_TAG_MESSAGES_RESERVE,               false );
 	init( TLOG_POPPED_VER_LAG_THRESHOLD_FOR_TLOGPOP_TRACE,     250e6 );
 	init( BLOCKING_PEEK_TIMEOUT,                                 0.4 );
+	init( PEEK_REPLY_TIMEOUT,                                   30.0 ); // Sender-side timeout for non-parallel peek; re-sends peek to detect dead TLogs that silently drop requests. Set to 0 to disable (restores old wait-forever behavior).
 	init( ENABLE_DETAILED_TLOG_POP_TRACE,                      false ); if ( randomize && BUGGIFY ) ENABLE_DETAILED_TLOG_POP_TRACE = true;
 	init( PEEK_BATCHING_EMPTY_MSG,                              true ); if ( randomize && BUGGIFY ) PEEK_BATCHING_EMPTY_MSG = false;
 	init( PEEK_BATCHING_EMPTY_MSG_INTERVAL,                    0.005 ); if ( randomize && BUGGIFY ) PEEK_BATCHING_EMPTY_MSG_INTERVAL = 0.01;

--- a/fdbserver/core/include/fdbserver/core/Knobs.h
+++ b/fdbserver/core/include/fdbserver/core/Knobs.h
@@ -126,6 +126,7 @@ public:
 	int TLOG_POP_BATCH_SIZE;
 	bool ENABLE_TLOG_TEMP_TAG_MESSAGES_RESERVE;
 	double BLOCKING_PEEK_TIMEOUT;
+	double PEEK_REPLY_TIMEOUT; // Sender-side timeout for non-parallel peek requests; 0 disables (old wait-forever behavior)
 	bool PEEK_BATCHING_EMPTY_MSG;
 	double PEEK_BATCHING_EMPTY_MSG_INTERVAL;
 	double POP_FROM_LOG_DELAY;

--- a/fdbserver/core/include/fdbserver/core/Knobs.h
+++ b/fdbserver/core/include/fdbserver/core/Knobs.h
@@ -126,7 +126,8 @@ public:
 	int TLOG_POP_BATCH_SIZE;
 	bool ENABLE_TLOG_TEMP_TAG_MESSAGES_RESERVE;
 	double BLOCKING_PEEK_TIMEOUT;
-	double PEEK_REPLY_TIMEOUT; // Sender-side timeout for non-parallel peek requests; 0 disables (old wait-forever behavior)
+	double PEEK_REPLY_TIMEOUT; // Sender-side timeout for non-parallel peek requests; 0 disables (old wait-forever
+	                           // behavior)
 	bool PEEK_BATCHING_EMPTY_MSG;
 	double PEEK_BATCHING_EMPTY_MSG_INTERVAL;
 	double POP_FROM_LOG_DELAY;

--- a/fdbserver/core/include/fdbserver/core/Knobs.h
+++ b/fdbserver/core/include/fdbserver/core/Knobs.h
@@ -126,8 +126,7 @@ public:
 	int TLOG_POP_BATCH_SIZE;
 	bool ENABLE_TLOG_TEMP_TAG_MESSAGES_RESERVE;
 	double BLOCKING_PEEK_TIMEOUT;
-	double PEEK_REPLY_TIMEOUT; // Sender-side timeout for non-parallel peek requests; 0 disables (old wait-forever
-	                           // behavior)
+	double PEEK_REPLY_TIMEOUT; // Sender-side timeout for non-parallel peek requests; 0 disables (old wait-forever behavior)
 	bool PEEK_BATCHING_EMPTY_MSG;
 	double PEEK_BATCHING_EMPTY_MSG_INTERVAL;
 	double POP_FROM_LOG_DELAY;

--- a/fdbserver/core/include/fdbserver/core/Knobs.h
+++ b/fdbserver/core/include/fdbserver/core/Knobs.h
@@ -126,7 +126,7 @@ public:
 	int TLOG_POP_BATCH_SIZE;
 	bool ENABLE_TLOG_TEMP_TAG_MESSAGES_RESERVE;
 	double BLOCKING_PEEK_TIMEOUT;
-	double PEEK_REPLY_TIMEOUT; // Sender-side timeout for non-parallel peek requests; 0 disables (old wait-forever behavior)
+	double PEEK_REPLY_TIMEOUT; // Sender-side timeout for non-parallel peek; 0 disables (old wait-forever behavior)
 	bool PEEK_BATCHING_EMPTY_MSG;
 	double PEEK_BATCHING_EMPTY_MSG_INTERVAL;
 	double POP_FROM_LOG_DELAY;

--- a/fdbserver/logsystem/LogSystemPeekCursor.cpp
+++ b/fdbserver/logsystem/LogSystemPeekCursor.cpp
@@ -476,7 +476,18 @@ Future<Void> serverPeekGetMoreImpl(ServerPeekCursor* self, TaskPriority taskID) 
 				                                                                       self->returnEmptyIfStopped),
 				                                                       taskID));
 			}
-			auto res = co_await race(peekReply, self->interf->onChange());
+			// Race between: (1) peek reply, (2) interface change, and optionally
+			// (3) sender-side timeout if PEEK_REPLY_TIMEOUT > 0 and a request is in-flight.
+			// The timeout detects dead TLogs that silently drop requests after rebooting
+			// with new endpoint tokens. Without this, the sender waits forever because
+			// FlowTransport silently discards packets to unknown endpoints.
+			// Set PEEK_REPLY_TIMEOUT to 0 to disable and restore the old wait-forever behavior.
+			// Only enable timeout when interface is present (i.e., a peek was actually sent).
+			Future<Void> timeoutFuture =
+			    (self->interf->get().present() && SERVER_KNOBS->PEEK_REPLY_TIMEOUT > 0)
+			    ? delay(SERVER_KNOBS->PEEK_REPLY_TIMEOUT)
+			    : Never();
+			auto res = co_await race(peekReply, self->interf->onChange(), timeoutFuture);
 			if (res.index() == 0) {
 				TLogPeekReply reply = std::get<0>(std::move(res));
 
@@ -489,6 +500,21 @@ Future<Void> serverPeekGetMoreImpl(ServerPeekCursor* self, TaskPriority taskID) 
 				co_return;
 			} else if (res.index() == 1) {
 				self->onlySpilled = false;
+			} else if (res.index() == 2) {
+				// Sender-side timeout fired — no reply received within PEEK_REPLY_TIMEOUT.
+				// Don't throw — just retry the peek. This handles both cases:
+				// - Dead TLog: the retry will also timeout, but eventually the interface
+				//   will change (cluster controller detects the failure) and we'll break
+				//   out via interf->onChange().
+				// - Clogged TLog: the retry may succeed if the clog clears, or timeout
+				//   again harmlessly.
+				// The key benefit: this resets the brokenPromiseToNever future, allowing
+				// the peek to be re-sent. Without this, a peek to a dead endpoint would
+				// wait forever because the original future is permanently stuck.
+				DebugLogTraceEvent("PeekReplyTimeout", self->randomID)
+				    .detail("Tag", self->tag.toString())
+				    .detail("Version", self->messageVersion.version);
+				continue;
 			} else {
 				UNREACHABLE();
 			}

--- a/fdbserver/logsystem/LogSystemPeekCursor.cpp
+++ b/fdbserver/logsystem/LogSystemPeekCursor.cpp
@@ -483,10 +483,9 @@ Future<Void> serverPeekGetMoreImpl(ServerPeekCursor* self, TaskPriority taskID) 
 			// FlowTransport silently discards packets to unknown endpoints.
 			// Set PEEK_REPLY_TIMEOUT to 0 to disable and restore the old wait-forever behavior.
 			// Only enable timeout when interface is present (i.e., a peek was actually sent).
-			Future<Void> timeoutFuture =
-			    (self->interf->get().present() && SERVER_KNOBS->PEEK_REPLY_TIMEOUT > 0)
-			    ? delay(SERVER_KNOBS->PEEK_REPLY_TIMEOUT)
-			    : Never();
+			Future<Void> timeoutFuture = (self->interf->get().present() && SERVER_KNOBS->PEEK_REPLY_TIMEOUT > 0)
+			                                 ? delay(SERVER_KNOBS->PEEK_REPLY_TIMEOUT)
+			                                 : Never();
 			auto res = co_await race(peekReply, self->interf->onChange(), timeoutFuture);
 			if (res.index() == 0) {
 				TLogPeekReply reply = std::get<0>(std::move(res));


### PR DESCRIPTION
_One fix for a category of problems that I've labelled 'dead TLog' where tests pass but fail anyways because the database never quiesces; the cluster has been damaged in simulation such it can't recover. #13227 is one and mentions a few other case. The below mentions others._

BEHAVIOR CHANGE: Non-parallel TLog peek requests now have a sender-side timeout (PEEK_REPLY_TIMEOUT knob, default 30s). Previously, a peek would wait indefinitely for a reply or an interface change. Now, if no reply arrives within PEEK_REPLY_TIMEOUT seconds, the peek is re-sent. Set PEEK_REPLY_TIMEOUT to 0 to disable and restore the old wait-forever behavior.

Problem: when a TLog is killed with data destruction (KillType=6) and reboots at the same address, FlowTransport silently drops requests to old endpoint tokens. The sender (LogRouter/SS/consistency checker) waits forever because:
- The connection is healthy (same address, process is alive)
- No ENDPOINT_NOT_FOUND is sent (non-stream unknown endpoints are silently discarded by scanPackets in FlowTransport.cpp)
- The interface does not change (same address)

This manifests as simulation timeouts (5400s) in multi-region configs with single replication after datacenter kills. Seen in recent gcc nightlies (tests: AtomicOps.toml seed 309473476, DataLossRecovery.toml seed 3721859193, MaxGrvQueueDelay.toml seed 3023304950, TxnStateStoreCycleTest.toml seed 2843566457) and in local reproduction.

Fix: in LogSystemPeekCursor::serverPeekGetMoreImpl, the existing race(peekReply, interf->onChange()) now includes a third branch: delay(PEEK_REPLY_TIMEOUT). When the timeout fires, the loop continues (re-sends the peek request) rather than throwing.

Why retry (continue) instead of throw: throwing timed_out() propagated up and killed the storage server (SSUpdateError/StorageServerFailed), causing false failures in clog tests (ClogRemoteTLog, GcGenerations) where TLogs are intentionally unreachable for extended periods.

Why this approach over receiver-side ENDPOINT_NOT_FOUND: a receiver- side fix was attempted (sending ENDPOINT_NOT_FOUND for unknown tokens) but abandoned because the receiver cannot distinguish "dead endpoint" from "clogged endpoint" -- both appear as packets to an unknown token. This caused widespread false failures (71/6760 runs, 1%) in tests that inject network clogging (ClogRemoteTLog, DcLag, GcGenerations).

How the fix resolves the dead TLog hang:
1. Peek request sent to dead TLog -> silently dropped
2. 30s timeout fires -> peek re-sent (new request, same dead endpoint)
3. Also silently dropped -> timeout fires again
4. Meanwhile, cluster controller detects the dead TLog
5. Interface updated -> interf->onChange() fires -> cursor gets new TLog endpoint -> recovery/consistency check proceeds

Tested: 100,000 Joshua correctness runs, 99,997 passed. 3 failures all unrelated (RocksDB file lock bug, TracedTooManyLines in long test).


`  20260520-001835-stack_dead_tlog-ea137360b7a91210   compressed=True data_size=41116969 duration=3731822 ended=100000 fail=3 max_runs=100000 pass=99997 priority=100 remaining=0 runtime=2:27:48 sanity=False started=100000 stopped=20260520-024623 submitted=20260520-001835 timeout=5400 username=stack_dead_tlog`

RandomSeed="1774749498" SourceVersion="b1fc4d938d0e6ac09ca2a11fc11459ff31f9798e" Time="1779240835" BuggifyEnabled="1" DeterminismCheck="0" FaultInjectionEnabled="1" TestFile="tests/slow/GcGenerations.toml"
RandomSeed="1680132275" SourceVersion="b1fc4d938d0e6ac09ca2a11fc11459ff31f9798e" Time="1779242782" BuggifyEnabled="1" DeterminismCheck="0" FaultInjectionEnabled="1" TestFile="tests/slow/SwizzledCycleTest.toml"
RandomSeed="2248809336" SourceVersion="b1fc4d938d0e6ac09ca2a11fc11459ff31f9798e" Time="1779243800" BuggifyEnabled="0" DeterminismCheck="0" FaultInjectionEnabled="1" TestFile="tests/fast/MaxGrvQueueDelay.toml"



