### PR TITLE
Make port collision detection more robust in fdb_cluster_fixture

### DIFF
--- a/fdbclient/tests/fdb_cluster_fixture.sh
+++ b/fdbclient/tests/fdb_cluster_fixture.sh
@@ -136,7 +136,7 @@ function start_fdb_cluster {
       --storage_count "${ss_count}" --storage_type ssd-rocksdb-v1 \
       --dump_pids on \
       > >(tee "${output}") \
-      2> >(tee "${output}" >&2)
+      2> >(tee "${output}.stderr" >&2)
     status="$?"
     # Restore exit on error.
     set -o errexit  # a.k.a. set -e
@@ -171,13 +171,14 @@ function start_fdb_cluster {
       fi
       break;
     fi
-    # Otherwise, look for 'Local address in use' and if found retry with different ports.
-    # Use grep -a to treat binary files as text
-    if grep -a 'Local address in use' "${output}"; then
-      log "Ports in use; retry cluster start but with different ports"
+    # Check stderr (separate file to avoid tee process substitution race) for
+    # port-in-use error. Only retry on port collision; fail on anything else.
+    if grep -a 'Local address in use' "${output}.stderr"; then
+      log "Port ${port_prefix} in use, retrying with next port"
       continue
     fi
-    err "Failed to start fdb cluster"
+    err "Failed to start fdb cluster (stderr follows):"
+    cat "${output}.stderr" >&2
     return 1
   done
 }

--- a/fdbclient/tests/fdb_cluster_fixture.sh
+++ b/fdbclient/tests/fdb_cluster_fixture.sh
@@ -117,9 +117,7 @@ function start_fdb_cluster {
   local port_prefix=1500
   while : ; do
     port_prefix="$(( port_prefix + 100 ))"
-    # Disable exit on error temporarily so can capture result from run cluster.
-    # Then redirect the output of the run_customer_cluster.sh via tee via
-    # 'process substitution'; piping to tee hangs on success.
+    # Disable exit on error temporarily so we can capture the exit status.
     set +o errexit  # a.k.a. set +e
     set +o noclobber
     # In the below $knobs will pick up single quotes -- its what bash does when it
@@ -135,8 +133,7 @@ function start_fdb_cluster {
       --stateless_count 1 --replication_count 1 --logs_count 1 \
       --storage_count "${ss_count}" --storage_type ssd-rocksdb-v1 \
       --dump_pids on \
-      > >(tee "${output}") \
-      2> >(tee "${output}.stderr" >&2)
+      > "${output}" 2> "${output}.stderr"
     status="$?"
     # Restore exit on error.
     set -o errexit  # a.k.a. set -e
@@ -171,8 +168,8 @@ function start_fdb_cluster {
       fi
       break;
     fi
-    # Check stderr (separate file to avoid tee process substitution race) for
-    # port-in-use error. Only retry on port collision; fail on anything else.
+    # Check stderr for port-in-use error. Only retry on port collision;
+    # fail on anything else.
     if grep -a 'Local address in use' "${output}.stderr"; then
       log "Port ${port_prefix} in use, retrying with next port"
       continue


### PR DESCRIPTION
This ctest failed in last night's nightly run. The blob_backup_restore_tests ctest fails on busy CI instances when ports are already in use by parallel tests. The existing loop retried on port-in-use errors by grepping the output file for 'Local address in use', but both stdout and stderr were tee'd to the same output file via async process substitution, causing races where the grep misses the error string and the loop exits prematurely.

Fix: tee stderr to a separate file (output.stderr) so the grep for 'Local address in use' is reliable and not corrupted by interleaved stdout. Non-port-in-use failures still fail immediately with stderr printed for debugging.

Here is from the nightly failure (mocks3 retries a few ports and so does fdb but it only tries two ports.... before failing)

```

....
2026-05-20T07:30:58+00:00 Testing against MockS3Server
Starting MockS3Server on 127.0.0.1:8080 (attempt 1/10)
Starting MockS3Server on 127.0.0.1:8080
Port 8080 already in use, trying next port
Starting MockS3Server on 127.0.0.1:8081 (attempt 2/10)
Starting MockS3Server on 127.0.0.1:8081
Port 8081 already in use, trying next port
Starting MockS3Server on 127.0.0.1:8082 (attempt 3/10)
Starting MockS3Server on 127.0.0.1:8082
Port 8082 already in use, trying next port
Starting MockS3Server on 127.0.0.1:8083 (attempt 4/10)
Starting MockS3Server on 127.0.0.1:8083
Port 8083 already in use, trying next port
Starting MockS3Server on 127.0.0.1:8084 (attempt 5/10)
Starting MockS3Server on 127.0.0.1:8084
MockS3Server ready on port 8084
Starting Cluster:  test1:testdb1@127.0.0.1:1601
Error initializing networking with public address 127.0.0.1:1601 and listen address 127.0.0.1:1601 (Local address in use)
Try `/codebuild/output/src4209381410/src/github.com/apple/foundationdb/build_output/bin/fdbserver --help' for more information.
2026-05-20T07:31:07+00:00 ERROR: Failed to start server on port 1601
2026-05-20T07:31:07+00:00 ERROR: Failed to start DC1 stateless
Retrying PID extraction (attempt 1/5)...
Retrying PID extraction (attempt 2/5)...
Retrying PID extraction (attempt 3/5)...
Retrying PID extraction (attempt 4/5)...
Retrying PID extraction (attempt 5/5)...
WARNING: No FDB PIDs found for tracking
Error initializing networking with public address 127.0.0.1:1601 and listen address 127.0.0.1:1601 (Local address in use)
2026-05-20T07:31:10+00:00 Ports in use; retry cluster start but with different ports
Error initializing networking with public address 127.0.0.1:1701 and listen address 127.0.0.1:1701 (Local address in use)
Try `/codebuild/output/src4209381410/src/github.com/apple/foundationdb/build_output/bin/fdbserver --help' for more information.
Starting Cluster:  test1:testdb1@127.0.0.1:1701
2026-05-20T07:31:11+00:00 ERROR: Failed to start server on port 1701
2026-05-20T07:31:11+00:00 ERROR: Failed to start DC1 stateless
....

```