### PR TITLE
Add LSAN suppressions for client-side shutdown leaks

### DIFF
--- a/contrib/lsan.suppressions
+++ b/contrib/lsan.suppressions
@@ -42,10 +42,12 @@ leak:statusFetcherImpl
 leak:clientStatusFetcher
 leak:cli(CLIOptions
 
-# Recurring actors started during DatabaseContext construction (periodic
-# metrics like updateLatencyBandConfig). Leaked because DatabaseContext
-# is never cleanly destroyed at shutdown.
-leak:recurring<std::__1::__bind_front_t<void (DatabaseContext::
+# Recurring actor started during DatabaseContext construction (currently
+# throttleExpirer, which binds DatabaseContext::expireThrottles). Leaked
+# because DatabaseContext is never cleanly destroyed at shutdown.
+# Suppress the stable FDB symbol rather than the toolchain-specific
+# bind_front/recurring instantiation for portability.
+leak:DatabaseContext::expireThrottles
 
 # Thread-safe transaction destructor dispatches cleanup to the network
 # thread via onMainThreadVoid. If the network is shutting down, the

--- a/contrib/lsan.suppressions
+++ b/contrib/lsan.suppressions
@@ -14,3 +14,40 @@ leak:TransportData::getOrOpenPeer
 leak:Peer::Peer
 leak:connectionKeeper
 leak:connectionMonitor
+
+# Client-side background actors that are still running when fdbcli/client
+# processes exit. These are not cleaned up because the network thread is
+# stopped without cancelling all outstanding actors. Each suppression targets
+# a specific actor or infrastructure function to avoid masking real leaks.
+leak:tssLogger
+leak:databaseLogger
+leak:monitorNetworkBusyness
+leak:multiVersionCleanupWorker
+leak:pingLatencyLogger
+leak:logTimeOffset
+leak:startMemoryUsageMonitor
+leak:GlobalConfig::updater
+leak:GlobalConfig::refresh
+leak:monitorProxiesOneGeneration
+leak:DatabaseContext::updateProxies
+leak:makeReference<TransactionState
+leak:ModelInterface<CommitProxyInterface>::ModelInterface
+leak:ModelInterface<GrvProxyInterface>::ModelInterface
+leak:timeWarning
+leak:ManagementAPI::changeConfig
+leak:clientCoordinatorsStatusFetcher
+leak:clusterStatusFetcher
+leak:timeoutMonitorLeader
+leak:statusFetcherImpl
+leak:clientStatusFetcher
+leak:cli(CLIOptions
+
+# Recurring actors started during DatabaseContext construction (periodic
+# metrics like updateLatencyBandConfig). Leaked because DatabaseContext
+# is never cleanly destroyed at shutdown.
+leak:recurring<std::__1::__bind_front_t<void (DatabaseContext::
+
+# Thread-safe transaction destructor dispatches cleanup to the network
+# thread via onMainThreadVoid. If the network is shutting down, the
+# callback's Promise allocation is leaked.
+leak:ThreadSafeTransaction::~ThreadSafeTransaction

--- a/contrib/lsan.suppressions
+++ b/contrib/lsan.suppressions
@@ -30,7 +30,6 @@ leak:GlobalConfig::updater
 leak:GlobalConfig::refresh
 leak:monitorProxiesOneGeneration
 leak:DatabaseContext::updateProxies
-leak:makeReference<TransactionState
 leak:ModelInterface<CommitProxyInterface>::ModelInterface
 leak:ModelInterface<GrvProxyInterface>::ModelInterface
 leak:timeWarning
@@ -43,11 +42,10 @@ leak:clientStatusFetcher
 leak:cli(CLIOptions
 
 # Recurring actor started during DatabaseContext construction (currently
-# throttleExpirer, which binds DatabaseContext::expireThrottles). Leaked
-# because DatabaseContext is never cleanly destroyed at shutdown.
-# Suppress the stable FDB symbol rather than the toolchain-specific
-# bind_front/recurring instantiation for portability.
-leak:DatabaseContext::expireThrottles
+# throttleExpirer via bind_front(DatabaseContext::expireThrottles)).
+# The function name is mangled away by bind_front so we suppress via
+# Database::createDatabase which is the stable FDB frame in the stack.
+leak:Database::createDatabase
 
 # Thread-safe transaction destructor dispatches cleanup to the network
 # thread via onMainThreadVoid. If the network is shutting down, the


### PR DESCRIPTION
Follow-on to b0055b88fe ("Remove explicit __lsan_do_leak_check() from stopImmediately()"). That change fixed the LSAN deadlock/timeout but LSAN still runs at process exit and reports unsuppressed shutdown leaks (12,792 bytes in 84 allocations), causing ctests to fail.

Add targeted suppressions for each specific actor function that leaks at shutdown. These are all background actors (recurring timers, proxy monitors, status fetchers, etc.) that are still running when the process exits because FDB does not cancel all actors during shutdown.

Each suppression names the exact function in the stack to avoid masking real leaks. A real leak (e.g., per-request allocation that grows unboundedly) would have application-specific functions in the stack that would not match any of these suppressions.

Verified: with these suppressions, LSAN reports zero unsuppressed leaks in fdb_c_upgrade_to_future_version and multi_process_fdbcli_tests with USE_ASAN=ON. The tests still fail due to a separate pre-existing issue: ASAN makecontext/swapcontext warning logged as Severity=40 by fdbmonitor, which the test runner treats as a test failure.
