### PR TITLE
Fix assertion failure in BulkLoad manifest reading during DD cancella…

### DIFF
--- a/fdbserver/core/BulkLoadUtil.cpp
+++ b/fdbserver/core/BulkLoadUtil.cpp
@@ -561,7 +561,7 @@ Future<KeyRange> getBulkLoadJobFileManifestEntryFromJobManifestFile(
 			int64_t bytesToRead = std::min(chunkSize, fileSize - offset);
 			buffer.resize(bytesToRead);
 
-			int bytesRead = co_await file->read(&buffer[0], bytesToRead, offset);
+			int bytesRead = co_await uncancellable(file->read(&buffer[0], bytesToRead, offset));
 			if (bytesRead != bytesToRead) {
 				TraceEvent(SevError, "ReadFileError", logId)
 				    .detail("BytesRead", bytesRead)


### PR DESCRIPTION
…tion

When the Data Distributor exits due to a movekeys_conflict (normal ownership change), all child actors are cancelled. If the BulkLoad job manager is mid-read of the job manifest file, the actor_cancelled error propagates into AsyncFileDetachable::read(), which asserts that reads must not be cancelled (assertOnReadWriteCancel=true), triggering a BugDetected internal_error.

Wrap the file->read() in getBulkLoadJobFileManifestEntryFromJobManifestFile with uncancellable(), matching the pattern already used in readBulkFileBytes in the same file. This prevents the cancellation from reaching the file I/O layer while still allowing the actor to be cancelled after the read completes.

Reproduces with: BulkDumpingS3.toml -s 2030534189