### PR TITLE
Disable buggify for DataLossRecovery test

### DIFF
--- a/tests/fast/DataLossRecovery.toml
+++ b/tests/fast/DataLossRecovery.toml
@@ -1,4 +1,11 @@
 [configuration]
+# Disable buggify for this test. The workload disables DD and manually moves
+# shards via startMoveKeys. With buggify enabled, injected delays cause
+# transaction_too_old on every retry (transaction body exceeds the 5-second
+# read version window), while BUGGIFY also reduces START_MOVE_KEYS_MAX_RETRIES
+# from 50 to 10. The combination is self-defeating: the test exhausts retries
+# before DD recognizes it has been disabled and releases the move keys lock.
+buggify = false
 generateFearless = false
 config = 'triple'
 processesPerMachine = 2


### PR DESCRIPTION
The DataLossRecovery workload disables DD and manually moves shards via startMoveKeys. With buggify enabled, two effects combine to cause spurious test failures:

1. Injected delays make the startMoveKeys transaction exceed the 5-second read version window, causing transaction_too_old on every retry attempt.

2. BUGGIFY reduces START_MOVE_KEYS_MAX_RETRIES from 50 to 10, giving insufficient attempts to outlast the DD lock conflict.

The result: the test exhausts retries before DD recognizes it has been disabled and releases the move keys lock. This is not a real bug -- it is a self-defeating BUGGIFY interaction where fault injection both slows the operation and reduces tolerance for slowness.

Seed 188763139 reproduces the failure deterministically.
