### PR TITLE
Retry baseline check in MaxGrvQueueDelay workload

### DIFF
--- a/fdbserver/workloads/MaxGrvQueueDelay.cpp
+++ b/fdbserver/workloads/MaxGrvQueueDelay.cpp
@@ -120,15 +120,20 @@ struct MaxGrvQueueDelayWorkload : TestWorkload {
 	}
 
 	Future<Void> verifyBaseline(Database cx) {
-		// Retry baseline a few times — the system may still be settling after
-		// recovery, with GRV queues temporarily backed up from rate limiting.
-		for (int attempt = 0; attempt < 5; ++attempt) {
+		// Retry baseline for transient GRV queue backlog after recovery.
+		// Keep backoff short (1s) to avoid consuming the 30s testTimeout budget.
+		static constexpr int maxBaselineAttempts = 5;
+		static constexpr double baselineRetryDelay = 1.0;
+
+		for (int attempt = 0; attempt < maxBaselineAttempts; ++attempt) {
 			if (attempt > 0) {
-				co_await delay(5.0);
+				co_await delay(baselineRetryDelay);
 			}
+			bool lastAttempt = (attempt == maxBaselineAttempts - 1);
+
 			ErrorOr<Version> withoutOption = co_await errorOr(getReadVersion(cx, Optional<int64_t>()));
 			if (withoutOption.isError()) {
-				if (attempt < 4) {
+				if (!lastAttempt && withoutOption.getError().code() == error_code_transaction_grv_queue_rejected) {
 					continue;
 				}
 				failed = true;
@@ -143,7 +148,7 @@ struct MaxGrvQueueDelayWorkload : TestWorkload {
 			ErrorOr<Version> permissive =
 			    co_await errorOr(getReadVersion(cx, Optional<int64_t>(permissiveMaxQueueDelayMS)));
 			if (permissive.isError()) {
-				if (attempt < 4) {
+				if (!lastAttempt && permissive.getError().code() == error_code_transaction_grv_queue_rejected) {
 					continue;
 				}
 				failed = true;

--- a/fdbserver/workloads/MaxGrvQueueDelay.cpp
+++ b/fdbserver/workloads/MaxGrvQueueDelay.cpp
@@ -120,29 +120,43 @@ struct MaxGrvQueueDelayWorkload : TestWorkload {
 	}
 
 	Future<Void> verifyBaseline(Database cx) {
-		ErrorOr<Version> withoutOption = co_await errorOr(getReadVersion(cx, Optional<int64_t>()));
-		if (withoutOption.isError()) {
-			failed = true;
-			++unexpectedErrors;
-			TraceEvent(SevError, "MaxGrvQueueDelayBaselineFailed")
-			    .error(withoutOption.getError())
-			    .detail("HasOption", false);
-			co_return;
-		}
-		++successes;
+		// Retry baseline a few times — the system may still be settling after
+		// recovery, with GRV queues temporarily backed up from rate limiting.
+		for (int attempt = 0; attempt < 5; ++attempt) {
+			if (attempt > 0) {
+				co_await delay(5.0);
+			}
+			ErrorOr<Version> withoutOption = co_await errorOr(getReadVersion(cx, Optional<int64_t>()));
+			if (withoutOption.isError()) {
+				if (attempt < 4) {
+					continue;
+				}
+				failed = true;
+				++unexpectedErrors;
+				TraceEvent(SevError, "MaxGrvQueueDelayBaselineFailed")
+				    .error(withoutOption.getError())
+				    .detail("HasOption", false);
+				co_return;
+			}
+			++successes;
 
-		ErrorOr<Version> permissive =
-		    co_await errorOr(getReadVersion(cx, Optional<int64_t>(permissiveMaxQueueDelayMS)));
-		if (permissive.isError()) {
-			failed = true;
-			++unexpectedErrors;
-			TraceEvent(SevError, "MaxGrvQueueDelayBaselineFailed")
-			    .error(permissive.getError())
-			    .detail("HasOption", true)
-			    .detail("MaxQueueDelayMS", permissiveMaxQueueDelayMS);
-			co_return;
+			ErrorOr<Version> permissive =
+			    co_await errorOr(getReadVersion(cx, Optional<int64_t>(permissiveMaxQueueDelayMS)));
+			if (permissive.isError()) {
+				if (attempt < 4) {
+					continue;
+				}
+				failed = true;
+				++unexpectedErrors;
+				TraceEvent(SevError, "MaxGrvQueueDelayBaselineFailed")
+				    .error(permissive.getError())
+				    .detail("HasOption", true)
+				    .detail("MaxQueueDelayMS", permissiveMaxQueueDelayMS);
+				co_return;
+			}
+			++successes;
+			co_return; // baseline passed
 		}
-		++successes;
 	}
 
 	Future<Void> run(Database cx) {


### PR DESCRIPTION
The MaxGrvQueueDelay test sets intentionally low rate keeper limits (ratekeeper_default_limit=100, ratekeeper_max_rate=100) to create GRV queueing. However, the baseline verification runs immediately after quietDatabase completes, when the system may still be settling from recovery. The GRV queue can be temporarily backed up, causing the baseline's permissive 60-second max queue delay check to be rejected.

This manifests as MaxGrvQueueDelayBaselineFailed with error transaction_grv_queue_rejected seen often in 100k simulation runs.

Fix: retry the baseline check up to 5 times with a 5-second delay between attempts. This gives the rate keeper time to drain the queue after recovery without changing the test's actual validation logic.

Seed 2782761830 with buggify=off reproduces on x86_64 linux.

Happened in clang nightly on 'main'.

