### PR TITLE
Set `PerfShardedRocksDB` test timeout in TestSpec

### DIFF
--- a/tests/noSim/PerfShardedRocksDBTest.toml
+++ b/tests/noSim/PerfShardedRocksDBTest.toml
@@ -7,6 +7,7 @@ sharded_rocksdb_histograms_sample_rate=1.0
 
 [[test]]
  testTitle = 'UnitTests'
+ timeout = 3600
  useDB = false
  startDelay = 0
 


### PR DESCRIPTION
With ASAN enabled, this test can hit 1800-second timeouts, so this PR increases the timeout to 3600 seconds