### PR TITLE
Clip read-ahead cache reads to file size for small/last blocks

### DIFF
--- a/fdbrpc/include/fdbrpc/AsyncFileReadAhead.h
+++ b/fdbrpc/include/fdbrpc/AsyncFileReadAhead.h
@@ -95,7 +95,9 @@ public:
 			// If not found, start the read.
 			if (i == f->m_blocks.end() || (i->second.isValid() && i->second.isError())) {
 				// printf("starting read of %s block %d\n", f->getFilename().c_str(), blockNum);
-				fblock = readBlock(f.getPtr(), f->m_block_size, (int64_t)f->m_block_size * blockNum);
+				int64_t blockStart = (int64_t)blockNum * f->m_block_size;
+				int readLength = std::min<int64_t>(f->m_block_size, fileSize - blockStart);
+				fblock = readBlock(f.getPtr(), readLength, blockStart);
 				f->m_blocks[blockNum] = fblock;
 			} else
 				fblock = i->second;


### PR DESCRIPTION
## Problem
`AsyncFileReadAheadCache::read_impl` issues every block read with `length = m_block_size`, regardless of where the block sits in the file. `readBlock` then allocates a `CacheBlock` of exactly that size and calls `m_f->read(..., m_block_size, offset)`.

For a file smaller than one block, or the trailing block of any file, this means:

- The cache over-allocates: e.g. a 100-byte file with `m_block_size = 1 MiB` allocates a full 1 MiB buffer.
- The underlying `IAsyncFile::read` is asked for bytes past EOF. Most backends tolerate this (they return a short read), but some, notably HTTP-range blob store reads, can reject or misbehave on a range that extends past the object's end, surfacing as a spurious read failure on small files.

The function already clips the overall request to fileSize - offset near the top, but the per-block reads still happen at the full `m_block_size`.

## Solution

Clip each per-block read to the bytes remaining in the file, matching the `blockStart/std::min` pattern already used a few lines further down in the copy loop:

```cpp
int64_t blockStart = (int64_t)blockNum * f->m_block_size;
int readLength = std::min<int64_t>(f->m_block_size, fileSize - blockStart);
fblock = readBlock(f.getPtr(), readLength, blockStart);
```
`fileSize` is captured at the top of the function and `lastBlockToStart` is already clamped to `lastBlockNumInFile`, so `fileSize - blockStart` is strictly positive within this loop. `readLength` is bounded above by `m_block_size (int)`, so the narrowing into `readBlock(..., int length, ...)`  is safe.

---

I would also like to backport this to 7.3 (and 7.4) if it is acceptable, since we have run into an issue with the blob store reads failing.