### PR TITLE
gha: stale: increase operations-per-run to 80

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -19,6 +19,5 @@ jobs:
           days-before-pr-stale: 150
           days-before-close: 14
           days-before-issue-stale: 5475 # 15 years, basically disabled for issues
-          # throttled to 20 per day
-          operations-per-run: 20
+          operations-per-run: 80 # operating on one PR can use multiple "operations"
           ascending: true


### PR DESCRIPTION
The stale action seems to be working as expected, but processing very old PRs seems to take 4 operations per PR, so let it do more per daily run.

The first run:

```
...
[#2487] 4 operations consumed for this pull request
[#2840] 4 operations consumed for this pull request
...
Statistics:
Processed items: 317
├── Processed issues: 313
└── Processed PRs   : 4
New stale PRs: 4
Added PRs labels: 4
Added PRs comments: 4
Fetched items: 400
Fetched items events: 4
Fetched items comments: 4
Operations performed: 20
Github API rate used: 20
```