### PR TITLE
Extend PEEK_REPLY_TIMEOUT to parallel peek path (LogRouter fix)

### DIFF
--- a/bindings/c/test/apitester/TesterWorkload.cpp
+++ b/bindings/c/test/apitester/TesterWorkload.cpp
@@ -243,6 +243,7 @@ void WorkloadManager::workloadDone(IWorkload* workload, bool failed) {
 	bool done = workloads.empty();
 	lock.unlock();
 	if (done) {
+		statsStopped.store(true);
 		if (statsTimer) {
 			statsTimer->cancel();
 		}
@@ -291,6 +292,9 @@ void WorkloadManager::readControlInput(std::string pipeName) {
 
 void WorkloadManager::schedulePrintStatistics(int timeIntervalMs) {
 	statsTimer = scheduler->scheduleWithDelay(timeIntervalMs, [this, timeIntervalMs]() {
+		if (statsStopped.load()) {
+			return;
+		}
 		for (const auto& workload : getActiveWorkloads()) {
 			workload->printStats();
 		}

--- a/bindings/c/test/apitester/TesterWorkload.h
+++ b/bindings/c/test/apitester/TesterWorkload.h
@@ -278,6 +278,9 @@ private:
 
 	// Timer for printing statistics in regular intervals
 	std::unique_ptr<ITimer> statsTimer;
+
+	// Flag to stop the stats timer from re-scheduling
+	std::atomic<bool> statsStopped{ false };
 };
 
 // A workload factory

--- a/fdbserver/logsystem/LogSystemPeekCursor.cpp
+++ b/fdbserver/logsystem/LogSystemPeekCursor.cpp
@@ -26,6 +26,16 @@
 #include "flow/DebugTrace.h"
 #include "flow/CoroUtils.h"
 
+// Returns a timeout future for peek reply detection. Used by both the non-parallel
+// (serverPeekGetMoreImpl) and parallel (serverPeekParallelGetMoreImpl) peek paths
+// to detect dead/stale TLog endpoints that silently drop requests. When the timeout
+// fires, the caller re-sends the peek. Set PEEK_REPLY_TIMEOUT to 0 to disable.
+static Future<Void> peekReplyTimeout(ServerPeekCursor const* self) {
+	return (self->interf->get().present() && SERVER_KNOBS->PEEK_REPLY_TIMEOUT > 0)
+	           ? delay(SERVER_KNOBS->PEEK_REPLY_TIMEOUT)
+	           : Never();
+}
+
 Future<Void> tryEstablishPeekStreamImpl(ServerPeekCursor* self) {
 	co_await IFailureMonitor::failureMonitor().onStateEqual(
 	    self->interf->get().interf().peekStreamMessages.getEndpoint(), FailureStatus(false));
@@ -306,7 +316,8 @@ Future<Void> serverPeekParallelGetMoreImpl(ServerPeekCursor* self, TaskPriority 
 				co_return;
 
 			Future<TLogPeekReply> peekReply = self->interf->get().present() ? self->futureResults.front() : Never();
-			auto res = co_await race(peekReply, self->interfaceChanged);
+			// See peekReplyTimeout() and serverPeekGetMoreImpl for the non-parallel equivalent.
+			auto res = co_await race(peekReply, self->interfaceChanged, peekReplyTimeout(self));
 			if (res.index() == 0) {
 				TLogPeekReply reply = std::get<0>(std::move(res));
 
@@ -327,6 +338,15 @@ Future<Void> serverPeekParallelGetMoreImpl(ServerPeekCursor* self, TaskPriority 
 				self->randomID = deterministicRandom()->randomUniqueID();
 				self->sequence = 0;
 				self->onlySpilled = false;
+				self->futureResults.clear();
+			} else if (res.index() == 2) {
+				// Timeout fired — no reply within PEEK_REPLY_TIMEOUT. Re-send the peek.
+				// This handles dead/stale TLog endpoints that silently drop requests.
+				DebugLogTraceEvent("PeekParallelReplyTimeout", self->randomID)
+				    .detail("Tag", self->tag.toString())
+				    .detail("Version", self->messageVersion.version);
+				self->randomID = deterministicRandom()->randomUniqueID();
+				self->sequence = 0;
 				self->futureResults.clear();
 			} else {
 				UNREACHABLE();
@@ -477,16 +497,9 @@ Future<Void> serverPeekGetMoreImpl(ServerPeekCursor* self, TaskPriority taskID) 
 				                                                       taskID));
 			}
 			// Race between: (1) peek reply, (2) interface change, and optionally
-			// (3) sender-side timeout if PEEK_REPLY_TIMEOUT > 0 and a request is in-flight.
-			// The timeout detects dead TLogs that silently drop requests after rebooting
-			// with new endpoint tokens. Without this, the sender waits forever because
-			// FlowTransport silently discards packets to unknown endpoints.
-			// Set PEEK_REPLY_TIMEOUT to 0 to disable and restore the old wait-forever behavior.
-			// Only enable timeout when interface is present (i.e., a peek was actually sent).
-			Future<Void> timeoutFuture = (self->interf->get().present() && SERVER_KNOBS->PEEK_REPLY_TIMEOUT > 0)
-			                                 ? delay(SERVER_KNOBS->PEEK_REPLY_TIMEOUT)
-			                                 : Never();
-			auto res = co_await race(peekReply, self->interf->onChange(), timeoutFuture);
+			// (3) sender-side timeout — see peekReplyTimeout() and
+			// serverPeekParallelGetMoreImpl for the parallel equivalent.
+			auto res = co_await race(peekReply, self->interf->onChange(), peekReplyTimeout(self));
 			if (res.index() == 0) {
 				TLogPeekReply reply = std::get<0>(std::move(res));
 


### PR DESCRIPTION
The sender-side peek timeout added in 446079cc (#13248) only covers the non-parallel peek path (serverPeekGetMoreImpl), used by storage servers. LogRouters use the parallel peek path (serverPeekParallelGetMoreImpl) via peekLogRouter/SetPeekCursor, which still had the old wait-forever behavior.

Add the same PEEK_REPLY_TIMEOUT race branch to serverPeekParallelGetMoreImpl. When the timeout fires, clear the pending futures and re-send the peek (same retry-without-throw approach as the non-parallel path).

Extract peekReplyTimeout() helper used by both paths to compute the timeout future consistently. Both sites cross-reference each other in comments.

This fixes the live-TLog LogRouter hang where a TLog is re-recruited with new endpoint tokens. The LogRouter's peek request is silently dropped (same root cause as the dead-TLog hang), but the parallel path never detected it.

Seed 408543238 (TxnStateStoreCycleTest.toml, buggify=on) reproduces on x86_64 linux. Passes with this fix (206s vs 24000+ hang).