### PR TITLE
perf(fdbclient): reduce arena allocations in MutationRef deep-copy constructors

### DIFF
--- a/fdbclient/include/fdbclient/CommitTransaction.h
+++ b/fdbclient/include/fdbclient/CommitTransaction.h
@@ -106,10 +106,33 @@ struct MutationRef {
 
 	MutationRef() : type(MAX_ATOMIC_OP), corrupted(false) {}
 	MutationRef(Type t, StringRef a, StringRef b) : type(t), param1(a), param2(b), corrupted(false) {}
-	MutationRef(Arena& to, Type t, StringRef a, StringRef b)
-	  : type(t), param1(to, a), param2(to, b), corrupted(false) {}
-	MutationRef(Arena& to, const MutationRef& from)
-	  : type(from.type), param1(to, from.param1), param2(to, from.param2), corrupted(false) {}
+
+	MutationRef(Arena& to, Type t, StringRef a, StringRef b) : type(t), corrupted(false) { copyParams(to, a, b); }
+
+	MutationRef(Arena& to, const MutationRef& from) : type(from.type), corrupted(false) {
+		copyParams(to, from.param1, from.param2);
+	}
+
+private:
+	inline void copyParams(Arena& to, StringRef a, StringRef b) {
+		const size_t aSize = a.size();
+		const size_t bSize = b.size();
+		const size_t totalSize = aSize + bSize;
+
+		uint8_t* packed = totalSize ? new (to) uint8_t[totalSize] : nullptr;
+
+		if (aSize) {
+			memcpy(packed, a.begin(), aSize);
+		}
+		if (bSize) {
+			memcpy(packed + aSize, b.begin(), bSize);
+		}
+
+		param1 = StringRef(aSize ? packed : nullptr, aSize);
+		param2 = StringRef(bSize ? packed + aSize : nullptr, bSize);
+	}
+
+public:
 	int totalSize() const {
 		return OVERHEAD_BYTES + param1.size() + param2.size() + (checksum.present() ? sizeof(uint32_t) + 1 : 1) +
 		       (accumulativeChecksumIndex.present() ? sizeof(uint16_t) + 1 : 1);


### PR DESCRIPTION
Closes issue #13269 .

## Summary

Reduce arena allocation overhead in `MutationRef` deep-copy constructors by storing copied mutation payloads in a single arena allocation instead of allocating `param1` and `param2` independently.

## Problem

Previously, both deep-copy constructors performed two separate arena allocations:

```cpp id="l7g1oq"
MutationRef(Arena& to, Type t, StringRef a, StringRef b)
  : type(t), param1(to, a), param2(to, b), corrupted(false) {}

MutationRef(Arena& to, const MutationRef& from)
  : type(from.type), param1(to, from.param1), param2(to, from.param2), corrupted(false) {}
```

Each `StringRef(Arena&, ...)` construction allocates independently inside the arena, causing every deep-copied mutation to perform two separate allocations.

This affects hot paths such as:

* `VectorRef<MutationRef>::emplace_back_deep`
* `VectorRef<MutationRef>::push_back_deep`
* commit batching and mutation construction paths

## Changes

Both deep-copy constructors now:

* allocate a single contiguous arena buffer for both payloads
* copy `param1` and `param2` into that shared allocation
* preserve existing `StringRef` semantics and ownership behavior

Now arena payload allocations are reduced from two allocations per mutation to one allocation per mutation. No public APIs or serialization behavior are changed.

## Benchmark

Benchmarks were run using:

```bash id="zuv2t7"
bin/fdbclient_bench --benchmark_filter='bench_populate' --benchmark_repetitions=10 --benchmark_report_aggregates_only=true
```

Observed trends:

* Speed improvements for high mutation-count workloads with small-to-medium payload sizes
* largest gains occur in allocation-dominated cases where allocator overhead is a significant portion of total runtime
* little to no change for very large payload sizes where memcpy bandwidth dominates

## Testing

```bash id="g5mxyl"
ninja fdbclient_bench
bin/fdbclient_bench --benchmark_filter='bench_populate' --benchmark_repetitions=10 --benchmark_report_aggregates_only=true
```
@akankshamahajan15 and @neethuhaneesha  could you pls run the checks if you have the access to do so and review this PR? thnx