### PR TITLE
Reduce arena allocations when materializing RocksDB range read results

### DIFF
--- a/fdbclient/include/fdbclient/CommitTransaction.h
+++ b/fdbclient/include/fdbclient/CommitTransaction.h
@@ -106,10 +106,38 @@ struct MutationRef {
 
 	MutationRef() : type(MAX_ATOMIC_OP), corrupted(false) {}
 	MutationRef(Type t, StringRef a, StringRef b) : type(t), param1(a), param2(b), corrupted(false) {}
-	MutationRef(Arena& to, Type t, StringRef a, StringRef b)
-	  : type(t), param1(to, a), param2(to, b), corrupted(false) {}
-	MutationRef(Arena& to, const MutationRef& from)
-	  : type(from.type), param1(to, from.param1), param2(to, from.param2), corrupted(false) {}
+    MutationRef(Arena& to, Type t, StringRef a, StringRef b) : type(t), corrupted(false) {
+	    const int totalSize = a.size() + b.size();
+	    uint8_t* packed = totalSize ? new (to) uint8_t[totalSize] : nullptr;
+
+	    if (a.size()) {
+		    memcpy(packed, a.begin(), a.size());
+	    }
+
+	    if (b.size()) {
+		    memcpy(packed + a.size(), b.begin(), b.size());
+	    }
+
+	    param1 = StringRef(packed, a.size());
+	    param2 = StringRef(packed + a.size(), b.size());
+    }
+
+    MutationRef(Arena& to, const MutationRef& from) : type(from.type), corrupted(false) {
+        const int totalSize = from.param1.size() + from.param2.size();
+	    uint8_t* packed = totalSize ? new (to) uint8_t[totalSize] : nullptr;
+
+	    if (from.param1.size()) {
+		    memcpy(packed, from.param1.begin(), from.param1.size());
+	    }
+
+	    if (from.param2.size()) {
+		    memcpy(packed + from.param1.size(), from.param2.begin(), from.param2.size());
+	    }
+
+	    param1 = StringRef(packed, from.param1.size());
+	    param2 = StringRef(packed + from.param1.size(), from.param2.size());
+    }
+
 	int totalSize() const {
 		return OVERHEAD_BYTES + param1.size() + param2.size() + (checksum.present() ? sizeof(uint32_t) + 1 : 1) +
 		       (accumulativeChecksumIndex.present() ? sizeof(uint16_t) + 1 : 1);

--- a/fdbclient/include/fdbclient/CommitTransaction.h
+++ b/fdbclient/include/fdbclient/CommitTransaction.h
@@ -106,38 +106,10 @@ struct MutationRef {
 
 	MutationRef() : type(MAX_ATOMIC_OP), corrupted(false) {}
 	MutationRef(Type t, StringRef a, StringRef b) : type(t), param1(a), param2(b), corrupted(false) {}
-    MutationRef(Arena& to, Type t, StringRef a, StringRef b) : type(t), corrupted(false) {
-	    const int totalSize = a.size() + b.size();
-	    uint8_t* packed = totalSize ? new (to) uint8_t[totalSize] : nullptr;
-
-	    if (a.size()) {
-		    memcpy(packed, a.begin(), a.size());
-	    }
-
-	    if (b.size()) {
-		    memcpy(packed + a.size(), b.begin(), b.size());
-	    }
-
-	    param1 = StringRef(packed, a.size());
-	    param2 = StringRef(packed + a.size(), b.size());
-    }
-
-    MutationRef(Arena& to, const MutationRef& from) : type(from.type), corrupted(false) {
-        const int totalSize = from.param1.size() + from.param2.size();
-	    uint8_t* packed = totalSize ? new (to) uint8_t[totalSize] : nullptr;
-
-	    if (from.param1.size()) {
-		    memcpy(packed, from.param1.begin(), from.param1.size());
-	    }
-
-	    if (from.param2.size()) {
-		    memcpy(packed + from.param1.size(), from.param2.begin(), from.param2.size());
-	    }
-
-	    param1 = StringRef(packed, from.param1.size());
-	    param2 = StringRef(packed + from.param1.size(), from.param2.size());
-    }
-
+	MutationRef(Arena& to, Type t, StringRef a, StringRef b)
+	  : type(t), param1(to, a), param2(to, b), corrupted(false) {}
+	MutationRef(Arena& to, const MutationRef& from)
+	  : type(from.type), param1(to, from.param1), param2(to, from.param2), corrupted(false) {}
 	int totalSize() const {
 		return OVERHEAD_BYTES + param1.size() + param2.size() + (checksum.present() ? sizeof(uint32_t) + 1 : 1) +
 		       (accumulativeChecksumIndex.present() ? sizeof(uint16_t) + 1 : 1);

--- a/fdbclient/include/fdbclient/FDBTypes.h
+++ b/fdbclient/include/fdbclient/FDBTypes.h
@@ -455,10 +455,23 @@ struct KeyValueRef {
 	KeyRef key;
 	ValueRef value;
 	KeyValueRef() {}
+
 	KeyValueRef(const KeyRef& key, const ValueRef& value) : key(key), value(value) {}
-	KeyValueRef(Arena& a, const KeyValueRef& copyFrom) : key(a, copyFrom.key), value(a, copyFrom.value) {}
+
+	KeyValueRef(Arena& a, const KeyRef& key, const ValueRef& value) {
+		StringRef storage = makeString(key.size() + value.size(), a);
+		uint8_t* dst = mutateString(storage);
+
+		key.copyTo(dst);
+		value.copyTo(dst + key.size());
+
+		this->key = KeyRef(storage.begin(), key.size());
+		this->value = ValueRef(storage.begin() + key.size(), value.size());
+	}
+
+	KeyValueRef(Arena& a, const KeyValueRef& copyFrom) : KeyValueRef(a, copyFrom.key, copyFrom.value) {}
+
 	bool operator==(const KeyValueRef& r) const { return key == r.key && value == r.value; }
-	bool operator!=(const KeyValueRef& r) const { return key != r.key || value != r.value; }
 
 	int expectedSize() const { return key.expectedSize() + value.expectedSize(); }
 

--- a/fdbserver/kvstore/KeyValueStoreRocksDB.actor.cpp
+++ b/fdbserver/kvstore/KeyValueStoreRocksDB.actor.cpp
@@ -1916,9 +1916,11 @@ struct RocksDBKeyValueStore : IKeyValueStore {
 				auto cursor = readIter.iter;
 				cursor->Seek(toSlice(a.keys.begin));
 				while (cursor->Valid() && toStringRef(cursor->key()) < a.keys.end) {
-					KeyValueRef kv(toStringRef(cursor->key()), toStringRef(cursor->value()));
-					accumulatedBytes += sizeof(KeyValueRef) + kv.expectedSize();
-					result.push_back_deep(result.arena(), kv);
+					KeyRef key = toStringRef(cursor->key());
+					ValueRef value = toStringRef(cursor->value());
+
+					accumulatedBytes += sizeof(KeyValueRef) + key.expectedSize() + value.expectedSize();
+					result.emplace_back_deep(result.arena(), key, value);
 					// Calling `cursor->Next()` is potentially expensive, so short-circut here just in case.
 					if (result.size() >= a.rowLimit || accumulatedBytes >= a.byteLimit) {
 						break;
@@ -1949,9 +1951,11 @@ struct RocksDBKeyValueStore : IKeyValueStore {
 					cursor->Prev();
 				}
 				while (cursor->Valid() && toStringRef(cursor->key()) >= a.keys.begin) {
-					KeyValueRef kv(toStringRef(cursor->key()), toStringRef(cursor->value()));
-					accumulatedBytes += sizeof(KeyValueRef) + kv.expectedSize();
-					result.push_back_deep(result.arena(), kv);
+					KeyRef key = toStringRef(cursor->key());
+					ValueRef value = toStringRef(cursor->value());
+
+					accumulatedBytes += sizeof(KeyValueRef) + key.expectedSize() + value.expectedSize();
+					result.emplace_back_deep(result.arena(), key, value);
 					// Calling `cursor->Prev()` is potentially expensive, so short-circut here just in case.
 					if (result.size() >= -a.rowLimit || accumulatedBytes >= a.byteLimit) {
 						break;

--- a/fdbserver/kvstore/KeyValueStoreShardedRocksDB.actor.cpp
+++ b/fdbserver/kvstore/KeyValueStoreShardedRocksDB.actor.cpp
@@ -1111,9 +1111,11 @@ int readRangeInDb(PhysicalShard* shard,
 		auto* cursor = readIter->iter.get();
 		cursor->Seek(toSlice(range.begin));
 		while (cursor->Valid() && toStringRef(cursor->key()) < range.end) {
-			KeyValueRef kv(toStringRef(cursor->key()), toStringRef(cursor->value()));
-			accumulatedBytes += sizeof(KeyValueRef) + kv.expectedSize();
-			result->push_back_deep(result->arena(), kv);
+			KeyRef key = toStringRef(cursor->key());
+			ValueRef value = toStringRef(cursor->value());
+
+			accumulatedBytes += sizeof(KeyValueRef) + key.expectedSize() + value.expectedSize();
+			result->emplace_back_deep(result->arena(), key, value);
 			// Calling `cursor->Next()` is potentially expensive, so short-circut here just in case.
 			if (result->size() >= rowLimit || accumulatedBytes >= byteLimit) {
 				break;
@@ -1128,9 +1130,11 @@ int readRangeInDb(PhysicalShard* shard,
 			cursor->Prev();
 		}
 		while (cursor->Valid() && toStringRef(cursor->key()) >= range.begin) {
-			KeyValueRef kv(toStringRef(cursor->key()), toStringRef(cursor->value()));
-			accumulatedBytes += sizeof(KeyValueRef) + kv.expectedSize();
-			result->push_back_deep(result->arena(), kv);
+			KeyRef key = toStringRef(cursor->key());
+			ValueRef value = toStringRef(cursor->value());
+
+			accumulatedBytes += sizeof(KeyValueRef) + key.expectedSize() + value.expectedSize();
+			result->emplace_back_deep(result->arena(), key, value);
 			// Calling `cursor->Prev()` is potentially expensive, so short-circuit here just in case.
 			if (result->size() >= -rowLimit || accumulatedBytes >= byteLimit) {
 				break;


### PR DESCRIPTION
Closes issue #13272 

## Summary

Reduce arena allocations when materializing RocksDB range read results.

Currently, every `KeyValueRef` deep-copy performs two independent arena allocations:

* one for the key payload,
* one for the value payload.

This PR instead packs both payloads into a single contiguous arena allocation while preserving existing ownership and `StringRef` semantics.

## Changes

Current implementation:

```cpp
KeyValueRef(Arena& a, const KeyValueRef& copyFrom)
  : key(a, copyFrom.key), value(a, copyFrom.value) {}
```

This performs two separate `StringRef(Arena&, ...)` allocations per returned KV pair.

In contrast, my PR introduces a packed-copy path:

```cpp
KeyValueRef(Arena& a, const KeyRef& key, const ValueRef& value)
```

which:

* allocates a single contiguous arena buffer for both payloads,
* copies key/value bytes into that shared allocation,
* constructs `KeyRef` / `ValueRef` views over the packed storage.

The RocksDB range-read paths now use:

```cpp
result.emplace_back_deep(result.arena(), key, value);
```

instead of constructing a temporary `KeyValueRef` followed by generic deep-copy construction.

Overall this reduces arena allocation count from:

```text
2 allocations per KV pair
    ->
1 allocation per KV pair
```

during range-result materialization.

No public APIs, wire formats, or ownership semantics are changed.

## Testing

```bash
ninja -j2 fdbserver_kvstorelinktest

./bin/linktest/fdbserver_kvstorelinktest
```
Note: A full benchmark comparison and large-scale simulation workload validation couldn't be performed locally due to my hardware limitations