### PR TITLE
Remove `CommitProxyInterface::getHealthMetrics` field

### DIFF
--- a/fdbclient/include/fdbclient/CommitProxyInterface.h
+++ b/fdbclient/include/fdbclient/CommitProxyInterface.h
@@ -50,9 +50,6 @@ struct CommitProxyInterface {
 	RequestStream<ReplyPromise<Void>> waitFailure;
 
 	RequestStream<struct TxnStateRequest> txnState;
-	// Reserved to preserve the historical adjusted-endpoint numbering for the
-	// commit proxy interface. Health metric requests are served by GrvProxyInterface.
-	RequestStream<struct GetHealthMetricsRequest> legacyGetHealthMetrics;
 	RequestStream<struct ProxySnapRequest> proxySnapReq;
 	RequestStream<struct ExclusionSafetyCheckRequest> exclusionSafetyCheckReq;
 	RequestStream<struct GetDDMetricsRequest> getDDMetrics;
@@ -78,16 +75,14 @@ struct CommitProxyInterface {
 			    RequestStream<struct GetStorageServerRejoinInfoRequest>(commit.getEndpoint().getAdjustedEndpoint(3));
 			waitFailure = RequestStream<ReplyPromise<Void>>(commit.getEndpoint().getAdjustedEndpoint(4));
 			txnState = RequestStream<struct TxnStateRequest>(commit.getEndpoint().getAdjustedEndpoint(5));
-			legacyGetHealthMetrics =
-			    RequestStream<struct GetHealthMetricsRequest>(commit.getEndpoint().getAdjustedEndpoint(6));
-			proxySnapReq = RequestStream<struct ProxySnapRequest>(commit.getEndpoint().getAdjustedEndpoint(7));
+			proxySnapReq = RequestStream<struct ProxySnapRequest>(commit.getEndpoint().getAdjustedEndpoint(6));
 			exclusionSafetyCheckReq =
-			    RequestStream<struct ExclusionSafetyCheckRequest>(commit.getEndpoint().getAdjustedEndpoint(8));
-			getDDMetrics = RequestStream<struct GetDDMetricsRequest>(commit.getEndpoint().getAdjustedEndpoint(9));
+			    RequestStream<struct ExclusionSafetyCheckRequest>(commit.getEndpoint().getAdjustedEndpoint(7));
+			getDDMetrics = RequestStream<struct GetDDMetricsRequest>(commit.getEndpoint().getAdjustedEndpoint(8));
 			expireIdempotencyId =
-			    PublicRequestStream<struct ExpireIdempotencyIdRequest>(commit.getEndpoint().getAdjustedEndpoint(10));
+			    PublicRequestStream<struct ExpireIdempotencyIdRequest>(commit.getEndpoint().getAdjustedEndpoint(9));
 			setThrottledShard =
-			    RequestStream<struct SetThrottledShardRequest>(commit.getEndpoint().getAdjustedEndpoint(13));
+			    RequestStream<struct SetThrottledShardRequest>(commit.getEndpoint().getAdjustedEndpoint(12));
 		}
 	}
 
@@ -100,7 +95,6 @@ struct CommitProxyInterface {
 		streams.push_back(getStorageServerRejoinInfo.getReceiver(TaskPriority::ProxyStorageRejoin));
 		streams.push_back(waitFailure.getReceiver());
 		streams.push_back(txnState.getReceiver());
-		streams.push_back(legacyGetHealthMetrics.getReceiver());
 		streams.push_back(proxySnapReq.getReceiver());
 		streams.push_back(exclusionSafetyCheckReq.getReceiver());
 		streams.push_back(getDDMetrics.getReceiver());

--- a/fdbclient/include/fdbclient/CommitProxyInterface.h
+++ b/fdbclient/include/fdbclient/CommitProxyInterface.h
@@ -50,7 +50,9 @@ struct CommitProxyInterface {
 	RequestStream<ReplyPromise<Void>> waitFailure;
 
 	RequestStream<struct TxnStateRequest> txnState;
-	RequestStream<struct GetHealthMetricsRequest> getHealthMetrics;
+	// Reserved to preserve the historical adjusted-endpoint numbering for the
+	// commit proxy interface. Health metric requests are served by GrvProxyInterface.
+	RequestStream<struct GetHealthMetricsRequest> legacyGetHealthMetrics;
 	RequestStream<struct ProxySnapRequest> proxySnapReq;
 	RequestStream<struct ExclusionSafetyCheckRequest> exclusionSafetyCheckReq;
 	RequestStream<struct GetDDMetricsRequest> getDDMetrics;
@@ -76,7 +78,7 @@ struct CommitProxyInterface {
 			    RequestStream<struct GetStorageServerRejoinInfoRequest>(commit.getEndpoint().getAdjustedEndpoint(3));
 			waitFailure = RequestStream<ReplyPromise<Void>>(commit.getEndpoint().getAdjustedEndpoint(4));
 			txnState = RequestStream<struct TxnStateRequest>(commit.getEndpoint().getAdjustedEndpoint(5));
-			getHealthMetrics =
+			legacyGetHealthMetrics =
 			    RequestStream<struct GetHealthMetricsRequest>(commit.getEndpoint().getAdjustedEndpoint(6));
 			proxySnapReq = RequestStream<struct ProxySnapRequest>(commit.getEndpoint().getAdjustedEndpoint(7));
 			exclusionSafetyCheckReq =
@@ -98,7 +100,7 @@ struct CommitProxyInterface {
 		streams.push_back(getStorageServerRejoinInfo.getReceiver(TaskPriority::ProxyStorageRejoin));
 		streams.push_back(waitFailure.getReceiver());
 		streams.push_back(txnState.getReceiver());
-		streams.push_back(getHealthMetrics.getReceiver());
+		streams.push_back(legacyGetHealthMetrics.getReceiver());
 		streams.push_back(proxySnapReq.getReceiver());
 		streams.push_back(exclusionSafetyCheckReq.getReceiver());
 		streams.push_back(getDDMetrics.getReceiver());
@@ -360,46 +362,6 @@ struct TxnStateRequest {
 	template <class Ar>
 	void serialize(Ar& ar) {
 		serializer(ar, data, sequence, last, broadcastInfo, reply, arena);
-	}
-};
-
-struct GetHealthMetricsReply {
-	constexpr static FileIdentifier file_identifier = 11544290;
-	Standalone<StringRef> serialized;
-	HealthMetrics healthMetrics;
-
-	explicit GetHealthMetricsReply(const HealthMetrics& healthMetrics = HealthMetrics())
-	  : healthMetrics(healthMetrics) {
-		update(healthMetrics, true, true);
-	}
-
-	void update(const HealthMetrics& healthMetrics, bool detailedInput, bool detailedOutput) {
-		this->healthMetrics.update(healthMetrics, detailedInput, detailedOutput);
-		BinaryWriter bw(IncludeVersion());
-		bw << this->healthMetrics;
-		serialized = bw.toValue();
-	}
-
-	template <class Ar>
-	void serialize(Ar& ar) {
-		serializer(ar, serialized);
-		if (ar.isDeserializing) {
-			BinaryReader br(serialized, IncludeVersion());
-			br >> healthMetrics;
-		}
-	}
-};
-
-struct GetHealthMetricsRequest {
-	constexpr static FileIdentifier file_identifier = 11403900;
-	ReplyPromise<struct GetHealthMetricsReply> reply;
-	bool detailed;
-
-	explicit GetHealthMetricsRequest(bool detailed = false) : detailed(detailed) {}
-
-	template <class Ar>
-	void serialize(Ar& ar) {
-		serializer(ar, reply, detailed);
 	}
 };
 

--- a/fdbclient/include/fdbclient/GrvProxyInterface.h
+++ b/fdbclient/include/fdbclient/GrvProxyInterface.h
@@ -141,6 +141,46 @@ struct GetReadVersionRequest : TimedRequest {
 	}
 };
 
+struct GetHealthMetricsReply {
+	constexpr static FileIdentifier file_identifier = 11544290;
+	Standalone<StringRef> serialized;
+	HealthMetrics healthMetrics;
+
+	explicit GetHealthMetricsReply(const HealthMetrics& healthMetrics = HealthMetrics())
+	  : healthMetrics(healthMetrics) {
+		update(healthMetrics, true, true);
+	}
+
+	void update(const HealthMetrics& healthMetrics, bool detailedInput, bool detailedOutput) {
+		this->healthMetrics.update(healthMetrics, detailedInput, detailedOutput);
+		BinaryWriter bw(IncludeVersion());
+		bw << this->healthMetrics;
+		serialized = bw.toValue();
+	}
+
+	template <class Ar>
+	void serialize(Ar& ar) {
+		serializer(ar, serialized);
+		if (ar.isDeserializing) {
+			BinaryReader br(serialized, IncludeVersion());
+			br >> healthMetrics;
+		}
+	}
+};
+
+struct GetHealthMetricsRequest {
+	constexpr static FileIdentifier file_identifier = 11403900;
+	ReplyPromise<struct GetHealthMetricsReply> reply;
+	bool detailed;
+
+	explicit GetHealthMetricsRequest(bool detailed = false) : detailed(detailed) {}
+
+	template <class Ar>
+	void serialize(Ar& ar) {
+		serializer(ar, reply, detailed);
+	}
+};
+
 struct GlobalConfigRefreshReply {
 	constexpr static FileIdentifier file_identifier = 12680327;
 	Arena arena;

--- a/fdbserver/grvproxy/GrvProxyServer.cpp
+++ b/fdbserver/grvproxy/GrvProxyServer.cpp
@@ -27,6 +27,7 @@
 #include "fdbclient/GrvProxyInterface.h"
 #include "fdbclient/VersionVector.h"
 #include "fdbserver/grvproxy/GrvProxyServer.h"
+#include "HealthMetricsRequestServer.h"
 #include "GrvQueueDelay.h"
 #include "GrvTransactionRateInfo.h"
 #include "fdbserver/logsystem/LogSystem.h"
@@ -241,19 +242,6 @@ struct GrvProxyData {
 	}
 };
 
-Future<Void> healthMetricsRequestServer(GrvProxyInterface grvProxy,
-                                        GetHealthMetricsReply* healthMetricsReply,
-                                        GetHealthMetricsReply* detailedHealthMetricsReply) {
-	while (true) {
-		GetHealthMetricsRequest req = co_await grvProxy.getHealthMetrics.getFuture();
-		if (req.detailed) {
-			req.reply.send(*detailedHealthMetricsReply);
-		} else {
-			req.reply.send(*healthMetricsReply);
-		}
-	}
-}
-
 // Older FDB versions used different keys for client profiling data. This
 // function performs a one-time migration of data in these keys to the new
 // global configuration key space.
@@ -387,8 +375,7 @@ Future<Void> getRate(UID myID,
                      GrvTransactionRateInfo* transactionRateInfo,
                      GrvTransactionRateInfo* batchTransactionRateInfo,
                      GrvRateLeaseState* rateLeaseState,
-                     GetHealthMetricsReply* healthMetricsReply,
-                     GetHealthMetricsReply* detailedHealthMetricsReply,
+                     HealthMetricsRequestServer* healthMetricsServer,
                      TransactionTagMap<uint64_t>* transactionTagCounter,
                      PrioritizedTransactionTagMap<ClientTagThrottleLimits>* clientThrottledTags,
                      GrvProxyStats* stats,
@@ -444,9 +431,8 @@ Future<Void> getRate(UID myID,
 			// lastTC = *inTransactionCount;
 			leaseTimeout = delay(rep.leaseDuration);
 			nextRequestTimer = delayJittered(rep.leaseDuration / 2);
-			healthMetricsReply->update(rep.healthMetrics, expectingDetailedReply, true);
+			healthMetricsServer->update(rep.healthMetrics, expectingDetailedReply);
 			if (expectingDetailedReply) {
-				detailedHealthMetricsReply->update(rep.healthMetrics, true, true);
 				lastDetailedReply = now();
 			}
 
@@ -905,8 +891,7 @@ static Future<Void> transactionStarter(GrvProxyInterface proxy,
                                        Reference<AsyncVar<ServerDBInfo> const> db,
                                        PromiseStream<Future<Void>> addActor,
                                        GrvProxyData* grvProxyData,
-                                       GetHealthMetricsReply* healthMetricsReply,
-                                       GetHealthMetricsReply* detailedHealthMetricsReply) {
+                                       HealthMetricsRequestServer* healthMetricsServer) {
 	double lastGRVTime = 0;
 	PromiseStream<Void> GRVTimer;
 	double GRVBatchTime = SERVER_KNOBS->START_TRANSACTION_BATCH_INTERVAL_MIN;
@@ -943,8 +928,7 @@ static Future<Void> transactionStarter(GrvProxyInterface proxy,
 	                      &normalRateInfo,
 	                      &batchRateInfo,
 	                      &rateLeaseState,
-	                      healthMetricsReply,
-	                      detailedHealthMetricsReply,
+	                      healthMetricsServer,
 	                      &transactionTagCounter,
 	                      &clientThrottledTags,
 	                      &grvProxyData->stats,
@@ -1164,8 +1148,7 @@ Future<Void> grvProxyServerCore(GrvProxyInterface proxy,
 	PromiseStream<Future<Void>> addActor;
 	Future<Void> onError = actorCollection(addActor.getFuture());
 
-	GetHealthMetricsReply healthMetricsReply;
-	GetHealthMetricsReply detailedHealthMetricsReply;
+	HealthMetricsRequestServer healthMetricsServer(proxy);
 
 	addActor.send(waitFailureServer(proxy.waitFailure.getFuture()));
 	addActor.send(traceRole(Role::GRV_PROXY, proxy.id()));
@@ -1186,9 +1169,8 @@ Future<Void> grvProxyServerCore(GrvProxyInterface proxy,
 
 	grvProxyData.updateLatencyBandConfig(grvProxyData.db->get().latencyBandConfig);
 
-	addActor.send(transactionStarter(
-	    proxy, grvProxyData.db, addActor, &grvProxyData, &healthMetricsReply, &detailedHealthMetricsReply));
-	addActor.send(healthMetricsRequestServer(proxy, &healthMetricsReply, &detailedHealthMetricsReply));
+	addActor.send(transactionStarter(proxy, grvProxyData.db, addActor, &grvProxyData, &healthMetricsServer));
+	addActor.send(healthMetricsServer.run());
 	addActor.send(globalConfigRequestServer(&grvProxyData, proxy));
 
 	if (SERVER_KNOBS->REQUIRED_MIN_RECOVERY_DURATION > 0) {

--- a/fdbserver/grvproxy/HealthMetricsRequestServer.cpp
+++ b/fdbserver/grvproxy/HealthMetricsRequestServer.cpp
@@ -1,0 +1,41 @@
+/*
+ * HealthMetricsRequestServer.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "HealthMetricsRequestServer.h"
+
+HealthMetricsRequestServer::HealthMetricsRequestServer(GrvProxyInterface grvProxy) : grvProxy(grvProxy) {}
+
+void HealthMetricsRequestServer::update(HealthMetrics const& healthMetrics, bool detailed) {
+	healthMetricsReply.update(healthMetrics, detailed, true);
+	if (detailed) {
+		detailedHealthMetricsReply.update(healthMetrics, true, true);
+	}
+}
+
+Future<Void> HealthMetricsRequestServer::run() {
+	while (true) {
+		GetHealthMetricsRequest req = co_await grvProxy.getHealthMetrics.getFuture();
+		if (req.detailed) {
+			req.reply.send(detailedHealthMetricsReply);
+		} else {
+			req.reply.send(healthMetricsReply);
+		}
+	}
+}

--- a/fdbserver/grvproxy/HealthMetricsRequestServer.h
+++ b/fdbserver/grvproxy/HealthMetricsRequestServer.h
@@ -20,7 +20,6 @@
 
 #pragma once
 
-#include "fdbclient/CommitProxyInterface.h"
 #include "fdbclient/GrvProxyInterface.h"
 #include "flow/flow.h"
 

--- a/fdbserver/grvproxy/HealthMetricsRequestServer.h
+++ b/fdbserver/grvproxy/HealthMetricsRequestServer.h
@@ -1,0 +1,37 @@
+/*
+ * HealthMetricsRequestServer.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "fdbclient/CommitProxyInterface.h"
+#include "fdbclient/GrvProxyInterface.h"
+#include "flow/flow.h"
+
+class HealthMetricsRequestServer {
+	GrvProxyInterface grvProxy;
+	GetHealthMetricsReply healthMetricsReply;
+	GetHealthMetricsReply detailedHealthMetricsReply;
+
+public:
+	explicit HealthMetricsRequestServer(GrvProxyInterface grvProxy);
+
+	void update(HealthMetrics const& healthMetrics, bool detailed);
+	Future<Void> run();
+};

--- a/fdbserver/workloads/PrivateEndpoints.cpp
+++ b/fdbserver/workloads/PrivateEndpoints.cpp
@@ -98,7 +98,6 @@ struct PrivateEndpoints : TestWorkload {
 		// addTestFor(&CommitProxyInterface::getStorageServerRejoinInfo);
 		addTestFor(&CommitProxyInterface::waitFailure);
 		// addTestFor(&CommitProxyInterface::txnState);
-		// addTestFor(&CommitProxyInterface::legacyGetHealthMetrics);
 		// addTestFor(&CommitProxyInterface::proxySnapReq);
 		addTestFor(&CommitProxyInterface::exclusionSafetyCheckReq);
 		// addTestFor(&CommitProxyInterface::getDDMetrics);

--- a/fdbserver/workloads/PrivateEndpoints.cpp
+++ b/fdbserver/workloads/PrivateEndpoints.cpp
@@ -98,7 +98,7 @@ struct PrivateEndpoints : TestWorkload {
 		// addTestFor(&CommitProxyInterface::getStorageServerRejoinInfo);
 		addTestFor(&CommitProxyInterface::waitFailure);
 		// addTestFor(&CommitProxyInterface::txnState);
-		// addTestFor(&CommitProxyInterface::getHealthMetrics);
+		// addTestFor(&CommitProxyInterface::legacyGetHealthMetrics);
 		// addTestFor(&CommitProxyInterface::proxySnapReq);
 		addTestFor(&CommitProxyInterface::exclusionSafetyCheckReq);
 		// addTestFor(&CommitProxyInterface::getDDMetrics);


### PR DESCRIPTION
These requests are served from the GRV proxy, so this field in `CommitProxyInterface` was unused. This PR also cleans up the `healthMetricsRequestServer` coroutine with a new class in `fdbserver/grvproxy`