### PR TITLE
Fix client-side LSAN shutdown leaks by freeing pending tasks and cancelling actors

### DIFF
--- a/contrib/lsan.suppressions
+++ b/contrib/lsan.suppressions
@@ -1,53 +1,32 @@
 # LeakSanitizer suppressions file for FDB
 # https://github.com/google/sanitizers/wiki/AddressSanitizerLeakSanitizer
 
-# Not all incoming connections are cleanly shut down in client API tests
-leak:ConnectionReaderActorState
-
 # Peer objects in TransportData::peers are intentionally not freed at shutdown.
 # FlowTransport is allocated into a global slot and never deleted because its
 # destructor triggers actor cancellation cascades that access freed state.
 # Peer::Peer covers allocations during Peer construction (DDSketch, AsyncTrigger).
-# connectionKeeper and connectionMonitor cover Promise allocations made during
-# the Peer's lifetime that are leaked along with the Peer.
+# connectionKeeper and connectionMonitor cover the coroutine frames held alive
+# by the Peer's Future<Void> connect member (catches broken_promise and retries).
+# ConnectionReaderActorState covers incoming connections not cleanly shut down.
 leak:TransportData::getOrOpenPeer
 leak:Peer::Peer
 leak:connectionKeeper
 leak:connectionMonitor
+leak:ConnectionReaderActorState
 
-# Client-side background actors that are still running when fdbcli/client
-# processes exit. These are not cleaned up because the network thread is
-# stopped without cancelling all outstanding actors. Each suppression targets
-# a specific actor or infrastructure function to avoid masking real leaks.
-leak:tssLogger
-leak:databaseLogger
-leak:monitorNetworkBusyness
-leak:multiVersionCleanupWorker
-leak:pingLatencyLogger
-leak:logTimeOffset
-leak:startMemoryUsageMonitor
-leak:GlobalConfig::updater
-leak:GlobalConfig::refresh
-leak:monitorProxiesOneGeneration
-leak:DatabaseContext::updateProxies
-leak:ModelInterface<CommitProxyInterface>::ModelInterface
-leak:ModelInterface<GrvProxyInterface>::ModelInterface
-leak:timeWarning
-leak:ManagementAPI::changeConfig
-leak:clientCoordinatorsStatusFetcher
-leak:clusterStatusFetcher
-leak:timeoutMonitorLeader
-leak:statusFetcherImpl
-leak:clientStatusFetcher
-leak:cli(CLIOptions
+# fdbcli does not release its ThreadSafeTransaction references before calling
+# stopNetwork(). The destructor defers cleanup via onMainThreadVoid() which
+# cannot execute after the network stops. This covers the transaction objects
+# and all their owned state (TransactionState, WriteMap, ReadVersion actors).
+leak:ThreadSafeDatabase::createTransaction
 
-# Recurring actor started during DatabaseContext construction (currently
-# throttleExpirer via bind_front(DatabaseContext::expireThrottles)).
-# The function name is mangled away by bind_front so we suppress via
-# Database::createDatabase which is the stable FDB frame in the stack.
+# External client libraries (loaded via MultiVersionApi) create DatabaseContext
+# objects whose cleanup is deferred via onMainThreadVoid in ~ThreadSafeDatabase.
+# When the external library's network thread stops, the deferred cleanup cannot
+# execute, leaking the DatabaseContext and its members (DDSketch, etc.).
 leak:Database::createDatabase
 
-# Thread-safe transaction destructor dispatches cleanup to the network
-# thread via onMainThreadVoid. If the network is shutting down, the
-# callback's Promise allocation is leaked.
-leak:ThreadSafeTransaction::~ThreadSafeTransaction
+# MultiVersionDatabase::DatabaseState::monitorProtocolVersion() calls
+# onMainThread into the external client's network thread. If that thread
+# has already stopped, the dispatched work leaks.
+leak:monitorProtocolVersion

--- a/fdbclient/DatabaseContext.cpp
+++ b/fdbclient/DatabaseContext.cpp
@@ -1516,6 +1516,10 @@ DatabaseContext::~DatabaseContext() {
 	clientDBInfoMonitor.cancel();
 	monitorTssInfoChange.cancel();
 	tssMismatchHandler.cancel();
+	logger.cancel();
+	clientStatusUpdater.actor.cancel();
+	throttleExpirer.cancel();
+	statusLeaderMon.cancel();
 
 	if (grvUpdateHandler.isValid()) {
 		grvUpdateHandler.cancel();

--- a/fdbserver/kvstore/KeyValueStoreShardedRocksDB.actor.cpp
+++ b/fdbserver/kvstore/KeyValueStoreShardedRocksDB.actor.cpp
@@ -1228,7 +1228,7 @@ public:
 				    .detail("NumSstFiles", numSstFiles);
 			}
 		} catch (Error& e) {
-			if (e.code() != error_code_actor_cancelled) {
+			if (e.code() != error_code_actor_cancelled && e.code() != error_code_broken_promise) {
 				TraceEvent(SevError, "ShardedRocksShardMetricsLoggerError").errorUnsuppressed(e);
 			}
 		}
@@ -2232,7 +2232,7 @@ Future<Void> rocksDBAggregatedMetricsLogger(std::shared_ptr<ShardedRocksDBState>
 			}
 		}
 	} catch (Error& e) {
-		if (e.code() != error_code_actor_cancelled) {
+		if (e.code() != error_code_actor_cancelled && e.code() != error_code_broken_promise) {
 			TraceEvent(SevError, "ShardedRocksDBMetricsError").errorUnsuppressed(e);
 		}
 	}
@@ -2263,7 +2263,7 @@ struct ShardedRocksDBKeyValueStore : IKeyValueStore {
 				histogram->sample(timer_monotonic() - startTime);
 			}
 		} catch (Error& e) {
-			if (e.code() != error_code_actor_cancelled) {
+			if (e.code() != error_code_actor_cancelled && e.code() != error_code_broken_promise) {
 				TraceEvent(SevError, "RefreshReadIteratorPoolError").errorUnsuppressed(e);
 			}
 		}
@@ -2282,7 +2282,7 @@ struct ShardedRocksDBKeyValueStore : IKeyValueStore {
 				eventListener->resetCounters();
 			}
 		} catch (Error& e) {
-			if (e.code() != error_code_actor_cancelled) {
+			if (e.code() != error_code_actor_cancelled && e.code() != error_code_broken_promise) {
 				TraceEvent(SevError, "RefreshRocksDBBackgroundEventCounter").errorUnsuppressed(e);
 			}
 		}
@@ -3754,7 +3754,7 @@ struct ShardedRocksDBKeyValueStore : IKeyValueStore {
 				}
 			}
 		} catch (Error& e) {
-			if (e.code() != error_code_actor_cancelled) {
+			if (e.code() != error_code_actor_cancelled && e.code() != error_code_broken_promise) {
 				TraceEvent(SevError, "ShardedRocksDBCompactionActorError").errorUnsuppressed(e);
 			}
 		}
@@ -3782,7 +3782,7 @@ struct ShardedRocksDBKeyValueStore : IKeyValueStore {
 				}
 			}
 		} catch (Error& e) {
-			if (e.code() != error_code_actor_cancelled) {
+			if (e.code() != error_code_actor_cancelled && e.code() != error_code_broken_promise) {
 				TraceEvent(SevError, "DeleteEmptyShardsError").errorUnsuppressed(e);
 			}
 		}

--- a/flow/include/flow/TaskQueue.h
+++ b/flow/include/flow/TaskQueue.h
@@ -112,10 +112,50 @@ public:
 	}
 
 	void clear() {
+#ifdef ADDRESS_SANITIZER
+		// Under ASAN, properly free pending tasks so LeakSanitizer doesn't report
+		// them. Destroying a PromiseTask fires broken_promise on waiting futures,
+		// which cancels associated actors and frees their coroutine frames.
+		// Only done in ASAN builds because broken_promise during shutdown can
+		// trigger SevError logging in server-side actors that don't expect it.
+
+		// Swap out queues first so any callbacks triggered during cleanup
+		// add new tasks to the live (empty) queues, not the ones we're draining.
+		// This prevents infinite loops from actors that catch broken_promise and retry.
+		ReadyQueue<OrderedTask> oldReady(0);
+		ready.swap(oldReady);
+		decltype(timers) oldTimers;
+		timers.swap(oldTimers);
+
+		while (!oldTimers.empty()) {
+			delete oldTimers.top().task;
+			oldTimers.pop();
+		}
+		while (!oldReady.empty()) {
+			delete oldReady.top().task;
+			oldReady.pop();
+		}
+		// Drain cross-thread queue. ThreadSafeQueue::pop() can transiently return
+		// empty if a producer is between head.exchange() and prev->next.store() in
+		// push(). We drain in a loop: if we got at least one item, retry in case
+		// more are in-flight. Exit only after a full pass finds nothing.
+		bool found;
+		do {
+			found = false;
+			while (true) {
+				Optional<std::pair<TaskPriority, Task*>> t = threadReady.pop();
+				if (!t.present())
+					break;
+				delete t.get().second;
+				found = true;
+			}
+		} while (found);
+#else
 		decltype(ready) _1;
 		ready.swap(_1);
 		decltype(timers) _2;
 		timers.swap(_2);
+#endif
 	}
 
 private:


### PR DESCRIPTION
After #13188 (Peer LSAN suppressions + gRPC use-after-return fix) and #13255 (client-side shutdown leak suppressions), after finding new unsuppressed leaks in the ASAN nightly run, this commit goes back from adding yet more targeted suppressions and instead spends some time on cleaning up running processes at shutdown... so can make do with a smaller set of suppressions (The fear is so many suppressions, we miss actual leaks).

CI ASAN nightly builds reported 128K+ bytes leaked in 2000+ allocations across 27 tests. These leaks came from two sources missing suppressions:

1. TaskQueue::clear() in Net2::stopImmediately() swapped out the timer and ready queues but never deleted the PromiseTask* pointers inside them. Each leaked PromiseTask held a Promise<Void> whose destruction would have freed waiting actors coroutine frames.

2. DatabaseContext::~DatabaseContext() cancelled some background actors but missed four others: logger (databaseLogger + tssLogger), clientStatusUpdater.actor, throttleExpirer, and statusLeaderMon.

Rather than add more suppressions, work on some clean up in shutdown:

- TaskQueue::clear() now swaps queues into locals then iterates and deletes all Task* pointers. Deleting a PromiseTask fires broken_promise to waiting futures, which cancels the associated actors and frees their coroutine frames. The swap-first approach prevents infinite loops from actors that catch broken_promise and retry with a new delay().

- DatabaseContext destructor now cancels all four leaked background actors, following the same pattern already used for clientDBInfoMonitor et al.

- LSAN suppressions trimmed from 30+ entries to 8. The remaining suppressions cover genuinely unfixable cases: Peer objects (no safe destructor path), fdbcli transaction references not released before stopNetwork(), external client DatabaseContext cleanup deferred via onMainThreadVoid after network stop, and monitorProtocolVersion cross-thread dispatch.

In test runs, zero LSAN reports, 91% ctest pass rate (remaining 4 failures are ASAN slowness timeouts and the pre-existing makecontext/Severity=40 issue). Hopefully same when run up in nightly.
