### PR TITLE
Persist partition map history to system keys for recovery

### DIFF
--- a/fdbclient/SystemData.cpp
+++ b/fdbclient/SystemData.cpp
@@ -1060,6 +1060,32 @@ WorkerBackupStatus decodeBackupProgressValue(const ValueRef& value) {
 	return status;
 }
 
+const KeyRangeRef backupPartitionMapHistoryKeys("\xff\x02/backupPartitionmap/"_sr, "\xff\x02/backupPartitionmap0"_sr);
+
+Key backupPartitionMapHistoryKeyFor(LogEpoch epoch, Version version) {
+	BinaryWriter wr(Unversioned());
+	wr.serializeBytes(backupPartitionMapHistoryKeys.begin);
+	wr << bigEndian64(epoch) << bigEndian64(version);
+	return wr.toValue();
+}
+
+KeyRange backupPartitionMapHistoryRangeFor(LogEpoch epoch) {
+	BinaryWriter beginW(Unversioned());
+	beginW.serializeBytes(backupPartitionMapHistoryKeys.begin);
+	beginW << bigEndian64(epoch);
+	BinaryWriter endW(Unversioned());
+	endW.serializeBytes(backupPartitionMapHistoryKeys.begin);
+	endW << bigEndian64(epoch + 1);
+	return KeyRangeRef(beginW.toValue(), endW.toValue());
+}
+
+std::pair<LogEpoch, Version> decodeBackupPartitionMapHistoryKey(const KeyRef& key) {
+	BinaryReader rd(key.removePrefix(backupPartitionMapHistoryKeys.begin), Unversioned());
+	int64_t epoch, version;
+	rd >> epoch >> version;
+	return { fromBigEndian64(epoch), fromBigEndian64(version) };
+}
+
 Value encodeBackupStartedValue(const std::vector<std::pair<UID, Version>>& ids) {
 	BinaryWriter wr(IncludeVersion(ProtocolVersion::withBackupStartValue()));
 	wr << ids;

--- a/fdbclient/SystemData.cpp
+++ b/fdbclient/SystemData.cpp
@@ -1060,7 +1060,7 @@ WorkerBackupStatus decodeBackupProgressValue(const ValueRef& value) {
 	return status;
 }
 
-const KeyRangeRef backupPartitionMapHistoryKeys("\xff\x02/backupPartitionmap/"_sr, "\xff\x02/backupPartitionmap0"_sr);
+const KeyRangeRef backupPartitionMapHistoryKeys("\xff\x02/backupPartitionMap/"_sr, "\xff\x02/backupPartitionMap0"_sr);
 
 Key backupPartitionMapHistoryKeyFor(LogEpoch epoch, Version version) {
 	BinaryWriter wr(Unversioned());

--- a/fdbclient/include/fdbclient/SystemData.h
+++ b/fdbclient/include/fdbclient/SystemData.h
@@ -432,6 +432,14 @@ std::vector<std::pair<UID, Version>> decodeBackupStartedValue(const ValueRef& va
 // 1 = Send a signal to pause/already paused.
 extern const KeyRef backupPausedKey;
 
+//	"\xff\x02/backupPartitionmap/[8-byte epoch][8-byte version]" := "[[PartitionMap]]"
+//	One row per (epoch, version) where a partition map became effective.
+//	Read by catch-up backup workers during recovery.
+extern const KeyRangeRef backupPartitionMapHistoryKeys;
+Key backupPartitionMapHistoryKeyFor(LogEpoch epoch, Version version);
+KeyRange backupPartitionMapHistoryRangeFor(LogEpoch epoch);
+std::pair<LogEpoch, Version> decodeBackupPartitionMapHistoryKey(const KeyRef& key);
+
 //	"\xff/previousCoordinators" = "[[ClusterConnectionString]]"
 //	Set to the encoded structure of the cluster's previous set of coordinators.
 //	Changed when performing quorumChange.

--- a/fdbserver/backupworker/BackupWorkerRangePartitioned.cpp
+++ b/fdbserver/backupworker/BackupWorkerRangePartitioned.cpp
@@ -506,9 +506,32 @@ Future<Void> processPartitionMap(BackupRangePartitionedData* self) {
 
 	PartitionMap partitionMap;
 	Version partitionMapVersion;
+	PartitionMapHistory history;
 
-	if (self->backupEpoch == self->recruitedEpoch) {
-		// Current-epoch worker: receive the partition map via TLog as the first message.
+	if (self->backupEpoch != self->recruitedEpoch) {
+		// Old epoch worker: the partition map for our backupEpoch was persisted by the previous epoch's
+		// workers. Read it from system keys instead of pulling from TLog.
+		// TODO akanksha: Scenario 2 — handle multiple history entries for mid-stream re-partition.
+		// TODO akanksha: Handle Case 3 mentioned in the TODO above.
+		history = co_await loadPartitionMapHistoryFromSS(self, self->backupEpoch);
+		if (!history.empty()) {
+			partitionMapVersion = history[0].first;
+			partitionMap = std::move(history[0].second);
+			auto it = partitionMap.find(self->tag);
+			ASSERT(it != partitionMap.end() && !it->second.empty());
+			TraceEvent("BWRangePartitionedLoadedPartitionMap", self->myId)
+			    .detail("Epoch", self->backupEpoch)
+			    .detail("Version", partitionMapVersion)
+			    .detail("NumTags", partitionMap.size())
+			    .detail("Tag", self->tag.toString())
+			    .detail("NumPartitions", it->second.size());
+		}
+	}
+
+	if (self->backupEpoch == self->recruitedEpoch || history.empty()) {
+		// Current-epoch worker, or old epoch worker with no SS history (recovery happened before the
+		// previous epoch's persistPartitionMapToSS). Receive the partition map via TLog as the first
+		// message, then persist it so the next old epoch worker doesn't hit this case.
 		partitionMapVersion = co_await pullPartitionMapFromTLog(self, &partitionMap);
 		auto it = partitionMap.find(self->tag);
 		ASSERT(it != partitionMap.end() && !it->second.empty());
@@ -518,7 +541,7 @@ Future<Void> processPartitionMap(BackupRangePartitionedData* self) {
 		    .detail("Tag", self->tag.toString())
 		    .detail("NumPartitions", it->second.size());
 
-		// Persist the partition map to system keys so catch-up backup workers can read it during recovery.
+		// Persist the partition map to system keys so old epoch backup workers can read it during recovery.
 		co_await persistPartitionMapToSS(self, partitionMapVersion, partitionMap);
 
 		// Every BW uploads the partition list. Content is deterministic across workers
@@ -531,22 +554,6 @@ Future<Void> processPartitionMap(BackupRangePartitionedData* self) {
 		self->pulledVersion.set(partitionMapVersion);
 		self->savedVersion = partitionMapVersion;
 		self->pop();
-	} else {
-		// Catch-up worker: the partition map for our backupEpoch was persisted by the previous epoch's
-		// workers. Read it from system keys instead of pulling from TLog.
-		// TODO akanksha: Handle Case 3 mentioned in the TODO above.
-		PartitionMapHistory history = co_await loadPartitionMapHistoryFromSS(self, self->backupEpoch);
-		ASSERT(!history.empty());
-		partitionMapVersion = history[0].first;
-		partitionMap = std::move(history[0].second);
-		auto it = partitionMap.find(self->tag);
-		ASSERT(it != partitionMap.end() && !it->second.empty());
-		TraceEvent("BWRangePartitionedLoadedPartitionMap", self->myId)
-		    .detail("Epoch", self->backupEpoch)
-		    .detail("Version", partitionMapVersion)
-		    .detail("NumTags", partitionMap.size())
-		    .detail("Tag", self->tag.toString())
-		    .detail("NumPartitions", it->second.size());
 	}
 
 	self->logFolderBaseVersion = partitionMapVersion + 1;

--- a/fdbserver/backupworker/BackupWorkerRangePartitioned.cpp
+++ b/fdbserver/backupworker/BackupWorkerRangePartitioned.cpp
@@ -385,7 +385,85 @@ Future<Version> pullPartitionMapFromTLog(BackupRangePartitionedData* self, Parti
 	}
 }
 
-// TODO akanksha: Test if concurrent uploads of identical content to the same path in blob storage is safe or not.
+// Persist the (epoch, version) -> PartitionMap row to SS so older epoch backup workers can read it during
+// recovery. Multiple workers may call this concurrently for the same (epoch, version) but only one succeed in writing
+// to SS.
+Future<Void> persistPartitionMapToSS(BackupRangePartitionedData* self,
+                                     Version partitionMapVersion,
+                                     PartitionMap const& partitionMap) {
+	Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(self->cx));
+	Key key = backupPartitionMapHistoryKeyFor(self->backupEpoch, partitionMapVersion);
+
+	BinaryWriter valueWriter(IncludeVersion());
+	valueWriter << partitionMap;
+	Standalone<StringRef> serialized = valueWriter.toValue();
+
+	while (true) {
+		Error err;
+		try {
+			tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+			tr->setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
+			tr->setOption(FDBTransactionOptions::LOCK_AWARE);
+
+			Optional<Value> existing = co_await tr->get(key);
+			if (existing.present()) {
+				co_return;
+			}
+			tr->set(key, serialized);
+			co_await tr->commit();
+			TraceEvent("BWRangePartitionedPMHistoryWritten", self->myId)
+			    .detail("Epoch", self->backupEpoch)
+			    .detail("Version", partitionMapVersion)
+			    .detail("Size", serialized.size());
+			co_return;
+		} catch (Error& e) {
+			err = e;
+		}
+		co_await tr->onError(err);
+	}
+}
+
+// Reads all partition map entries persisted for `epoch` from system keys, returning them in
+// version order. Each entry is the partition map that became effective at its associated version.
+Future<PartitionMapHistory> loadPartitionMapHistoryFromSS(BackupRangePartitionedData* self, LogEpoch epoch) {
+	Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(self->cx));
+	KeyRange range = backupPartitionMapHistoryRangeFor(epoch);
+
+	while (true) {
+		Error err;
+		try {
+			tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+			tr->setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
+			tr->setOption(FDBTransactionOptions::LOCK_AWARE);
+
+			RangeResult rows = co_await tr->getRange(range, CLIENT_KNOBS->TOO_MANY);
+			ASSERT(!rows.more);
+
+			PartitionMapHistory history;
+			history.reserve(rows.size());
+			for (auto const& kv : rows) {
+				auto [decodedEpoch, version] = decodeBackupPartitionMapHistoryKey(kv.key);
+				ASSERT_EQ(decodedEpoch, epoch);
+
+				PartitionMap pm;
+				BinaryReader reader(kv.value, IncludeVersion());
+				reader >> pm;
+				history.emplace_back(version, std::move(pm));
+			}
+			TraceEvent("BWRangePartitionedMapHistoryRead", self->myId)
+			    .detail("Epoch", epoch)
+			    .detail("NumEntries", history.size());
+			co_return history;
+		} catch (Error& e) {
+			err = e;
+		}
+		co_await tr->onError(err);
+	}
+}
+
+// TODO akanksha:
+// 1. Test if concurrent uploads of identical content to the same path in blob storage is safe or not.
+// 2. When folder is advanced to next version, do we upload the partition map again to that version.
 Future<Void> uploadPartitionList(BackupRangePartitionedData* self, PartitionMap partitionMap) {
 	std::vector<Future<Void>> fileFutures;
 	auto it = self->backups.begin();
@@ -411,20 +489,59 @@ Future<Void> uploadPartitionList(BackupRangePartitionedData* self, PartitionMap 
 }
 
 // TODO akanksha -> Need to figure out if
-// 1. For new requests -> PartitionMap in TLOG will be same for all containers
-// 2. For older epochs with different containers is PartitionMap specific to container or same for all.
-// Right now assumption is that PartitionMap will be passed by TLOG with the first message after start version for both
-// older epochs and newer epochs.
-// 3. Provide implemention for recovery where partitionmap can come any time and won't be the first message.
-Future<Void> waitAndProcessPartitionMap(BackupRangePartitionedData* self) {
+// 1. For new requests -> PartitionMap in TLOG will be same for all containers.
+// 2. Provide implemention for recovery where partitionmap can come any time and won't be the first message.
+// 3. Handle Recovery case where backupworker needs to process multiple partition maps for same epoch at different
+// versions.
+Future<Void> processPartitionMap(BackupRangePartitionedData* self) {
 	TraceEvent("BWRangePartitionedWaitingForPartitionMap", self->myId)
 	    .detail("Tag", self->tag.toString())
-	    .detail("StartVersion", self->startVersion);
+	    .detail("StartVersion", self->startVersion)
+	    .detail("BackupEpoch", self->backupEpoch)
+	    .detail("RecruitedEpoch", self->recruitedEpoch);
+
 	PartitionMap partitionMap;
+	Version partitionMapVersion;
 
-	Version partitionMapVersion = co_await pullPartitionMapFromTLog(self, &partitionMap);
+	if (self->backupEpoch == self->recruitedEpoch) {
+		// Current-epoch worker: receive the partition map via TLog as the first message.
+		partitionMapVersion = co_await pullPartitionMapFromTLog(self, &partitionMap);
+		TraceEvent("BWRangeParitionedPulledPartitionMap", self->myId)
+		    .detail("Version", partitionMapVersion)
+		    .detail("NumTags", partitionMap.size())
+		    .detail("Tag", self->tag.toString())
+		    .detail("NumPartitions", partitionMap[self->tag].size());
+
+		// Persist the partition map to system keys so catch-up backup workers can read it during recovery.
+		co_await persistPartitionMapToSS(self, partitionMapVersion, partitionMap);
+
+		// Every BW uploads the partition list. Content is deterministic across workers
+		// through serializePartitionListJSON, so concurrent PUTs of identical bytes are safe.
+		co_await uploadPartitionList(self, partitionMap);
+		TraceEvent("BWRangePartitionedPartitionMapUploaded", self->myId)
+		    .detail("Version", partitionMapVersion)
+		    .detail("NumBackups", self->backups.size());
+
+		self->pulledVersion.set(partitionMapVersion);
+		self->savedVersion = partitionMapVersion;
+		self->pop();
+	} else {
+		// Catch-up worker: the partition map for our backupEpoch was persisted by the previous epoch's
+		// workers. Read it from system keys instead of pulling from TLog.
+		// TODO akanksha: Handle Case 3 mentioned in the TODO above.
+		PartitionMapHistory history = co_await loadPartitionMapHistoryFromSS(self, self->backupEpoch);
+		ASSERT_GT(history.size(), 1);
+		partitionMapVersion = history[0].first;
+		partitionMap = std::move(history[0].second);
+		TraceEvent("BWRangePartitionedLoadedPartitionMap", self->myId)
+		    .detail("Epoch", self->backupEpoch)
+		    .detail("Version", partitionMapVersion)
+		    .detail("NumTags", partitionMap.size())
+		    .detail("Tag", self->tag.toString())
+		    .detail("NumPartitions", partitionMap[self->tag].size());
+	}
+
 	self->logFolderBaseVersion = partitionMapVersion + 1;
-
 	ASSERT(partitionMap.contains(self->tag));
 	TraceEvent("BWRangePartitionedPulledPartitionMap", self->myId)
 	    .detail("Version", partitionMapVersion)
@@ -437,16 +554,6 @@ Future<Void> waitAndProcessPartitionMap(BackupRangePartitionedData* self) {
 	for (auto& partition : partitionMap[self->tag]) {
 		self->keyRangeToPartitionId.insert(partition.ranges, partition.partitionId);
 	}
-
-	// Every BW uploads the partition list. Content is deterministic across workers
-	// through serializePartitionListJSON, so concurrent PUTs of identical bytes are safe.
-	co_await uploadPartitionList(self, partitionMap);
-	TraceEvent("BWRangePartitionedPartitionMapUploaded", self->myId)
-	    .detail("Version", partitionMapVersion)
-	    .detail("NumBackups", self->backups.size());
-	self->pulledVersion.set(partitionMapVersion);
-	self->savedVersion = partitionMapVersion;
-	self->pop();
 	co_await computeKeyRangeToBackupAssignment(self);
 }
 
@@ -1091,12 +1198,12 @@ Future<Void> backupWorkerRangePartitioned(BackupInterface interf,
 		}
 
 		addActor.send(monitorWorkerPause(&self));
-		// Must be sent before waitAndProcessPartitionMap so logSystem is populated before the partition-map peek.
+		// Must be sent before processPartitionMap so logSystem is populated before the partition-map peek.
 		addActor.send(monitorLogSystemFromDbInfo(db, &self));
 
-		// First need to call waitAndProcessPartitionMap before starting to pull data, because we need to know the
+		// First need to call processPartitionMap before starting to pull data, because we need to know the
 		// partition assignment.
-		co_await waitAndProcessPartitionMap(&self);
+		co_await processPartitionMap(&self);
 
 		// If the worker is on an old epoch and all backups starts a version >= the endVersion
 		bool exitEarly = co_await shouldBackupWorkerExitEarly(&self);

--- a/fdbserver/backupworker/BackupWorkerRangePartitioned.cpp
+++ b/fdbserver/backupworker/BackupWorkerRangePartitioned.cpp
@@ -436,19 +436,23 @@ Future<PartitionMapHistory> loadPartitionMapHistoryFromSS(BackupRangePartitioned
 			tr->setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
 			tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 
-			RangeResult rows = co_await tr->getRange(range, CLIENT_KNOBS->TOO_MANY);
-			ASSERT(!rows.more);
-
 			PartitionMapHistory history;
-			history.reserve(rows.size());
-			for (auto const& kv : rows) {
-				auto [decodedEpoch, version] = decodeBackupPartitionMapHistoryKey(kv.key);
-				ASSERT_EQ(decodedEpoch, epoch);
+			Key beginKey = range.begin;
+			while (true) {
+				RangeResult rows = co_await tr->getRange(KeyRangeRef(beginKey, range.end), CLIENT_KNOBS->TOO_MANY);
+				for (auto const& kv : rows) {
+					auto [decodedEpoch, version] = decodeBackupPartitionMapHistoryKey(kv.key);
+					ASSERT_EQ(decodedEpoch, epoch);
 
-				PartitionMap pm;
-				BinaryReader reader(kv.value, IncludeVersion());
-				reader >> pm;
-				history.emplace_back(version, std::move(pm));
+					PartitionMap pm;
+					BinaryReader reader(kv.value, IncludeVersion());
+					reader >> pm;
+					history.emplace_back(version, std::move(pm));
+				}
+				if (!rows.more) {
+					break;
+				}
+				beginKey = keyAfter(rows.back().key);
 			}
 			TraceEvent("BWRangePartitionedMapHistoryRead", self->myId)
 			    .detail("Epoch", epoch)
@@ -506,11 +510,13 @@ Future<Void> processPartitionMap(BackupRangePartitionedData* self) {
 	if (self->backupEpoch == self->recruitedEpoch) {
 		// Current-epoch worker: receive the partition map via TLog as the first message.
 		partitionMapVersion = co_await pullPartitionMapFromTLog(self, &partitionMap);
+		auto it = partitionMap.find(self->tag);
+		ASSERT(it != partitionMap.end() && !it->second.empty());
 		TraceEvent("BWRangeParitionedPulledPartitionMap", self->myId)
 		    .detail("Version", partitionMapVersion)
 		    .detail("NumTags", partitionMap.size())
 		    .detail("Tag", self->tag.toString())
-		    .detail("NumPartitions", partitionMap[self->tag].size());
+		    .detail("NumPartitions", it->second.size());
 
 		// Persist the partition map to system keys so catch-up backup workers can read it during recovery.
 		co_await persistPartitionMapToSS(self, partitionMapVersion, partitionMap);
@@ -530,27 +536,21 @@ Future<Void> processPartitionMap(BackupRangePartitionedData* self) {
 		// workers. Read it from system keys instead of pulling from TLog.
 		// TODO akanksha: Handle Case 3 mentioned in the TODO above.
 		PartitionMapHistory history = co_await loadPartitionMapHistoryFromSS(self, self->backupEpoch);
-		ASSERT_GT(history.size(), 1);
+		ASSERT(!history.empty());
 		partitionMapVersion = history[0].first;
 		partitionMap = std::move(history[0].second);
+		auto it = partitionMap.find(self->tag);
+		ASSERT(it != partitionMap.end() && !it->second.empty());
 		TraceEvent("BWRangePartitionedLoadedPartitionMap", self->myId)
 		    .detail("Epoch", self->backupEpoch)
 		    .detail("Version", partitionMapVersion)
 		    .detail("NumTags", partitionMap.size())
 		    .detail("Tag", self->tag.toString())
-		    .detail("NumPartitions", partitionMap[self->tag].size());
+		    .detail("NumPartitions", it->second.size());
 	}
 
 	self->logFolderBaseVersion = partitionMapVersion + 1;
-	ASSERT(partitionMap.contains(self->tag));
-	TraceEvent("BWRangePartitionedPulledPartitionMap", self->myId)
-	    .detail("Version", partitionMapVersion)
-	    .detail("NumTags", partitionMap.size())
-	    .detail("Tag", self->tag.toString())
-	    .detail("NumPartitions", partitionMap[self->tag].size());
-
 	self->keyRangeToPartitionId.clear();
-	ASSERT_GT(partitionMap[self->tag].size(), 0);
 	for (auto& partition : partitionMap[self->tag]) {
 		self->keyRangeToPartitionId.insert(partition.ranges, partition.partitionId);
 	}

--- a/fdbserver/core/include/fdbserver/core/BackupPartitionMap.h
+++ b/fdbserver/core/include/fdbserver/core/BackupPartitionMap.h
@@ -44,4 +44,8 @@ using PartitionList = std::vector<Partition>;
 // storage when multiple backup workers upload the partition map at the same time.
 using PartitionMap = std::map<Tag, PartitionList>;
 
+// History of partition maps for an epoch: pairs of (effective version, partition map),
+// sorted by version ascending. Multiple entries occur when a re-partition happens mid-epoch.
+using PartitionMapHistory = std::vector<std::pair<Version, PartitionMap>>;
+
 std::string serializePartitionListJSON(PartitionMap const& partitionMap);


### PR DESCRIPTION
This PR adds the persistence and read path for partition map history on storage servers, so catch-up workers during recovery can route old-epoch mutations correctly.

1. New system key: `\xff\x02/backupPartitionMap/[8-byte epoch][8-byte version] := serialized PartitionMap`
2. Implemented `persistPartitionMapToSS`: idempotent write called by current-epoch workers when they receive a new partition map. PartitionMap is persisted to both S3 and SS.
3. Implemented loadPartitionMapHistoryFromSS: used by old epoch backup workers; reads all entries for an epoch in version order after recovery to get partitionMap.
4. If a recovery happens even before the persistPartitionMapToSS, it might not have entries. Then it fall backs to pulling the partitionMap from tlog as first mutation

TODO:  In next PR:
- Logic of switching to multiple partitionmap for same epoch for old epoch backupworkers will be handled in next PR.
   - Example: backup starts at v=1 with PM_A; a re-partition fires at v=90 producing PM_B (still in epoch 1); recovery hits at v=100. A catch-up worker for epoch 1 draining v=80..100 must use PM_A for [80, 90) and PM_B for [90, 100). That
  requires reading multiple history entries and switching maps at the version boundary.
- PartitionMap could be received anytime. Handle that in the code. 


### Dependencies
This PR depends on https://github.com/apple/foundationdb/pull/13245.
This PR includes all changes from https://github.com/apple/foundationdb/pull/13245 plus additions on top.