### PR TITLE
docs: fix typos in macOS build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Building FoundationDB requires at least 8GB of memory. More memory is needed whe
 
 ### macOS
 
-The build under macOS will work the same way as on Linux. [Homebrew](https://brew.sh/) can be used to install the `boost` library and the `ninja` build tool. Be carefull, curent main branch use boost 1.86, do install this version or just let cmake download one. Also, if swift binding is not interest, use -DBUILD_SWIFT_BINDING=OFF.
+The build under macOS will work the same way as on Linux. [Homebrew](https://brew.sh/) can be used to install the `boost` library and the `ninja` build tool. Be careful, current main branch uses boost 1.86, do install this version or just let cmake download one. Also, if the Swift binding is not of interest, use -DBUILD_SWIFT_BINDING=OFF.
 
 ```sh
 cmake -G Ninja <FDB_SOURCE_DIR> -B <BUILD_DIR>


### PR DESCRIPTION
Noticed a few typos in the macOS section of the README. Fixed four clear errors on line 143:

`carefull` → `careful`
`curent` → `current`
`use` → `uses` (subject is singular)
`if swift binding is not interest` → `if the Swift binding is not of interest` (also capitalized "Swift" for consistency with the rest of the README)

Kept the change minimal, only obvious errors, and no stylistic edits.