### PR TITLE
Increase upgrade test tester shutdown timeout from 5s to 30s

### DIFF
--- a/tests/TestRunner/fdb_test_runner/upgrade_test.py
+++ b/tests/TestRunner/fdb_test_runner/upgrade_test.py
@@ -349,7 +349,8 @@ class UpgradeTest:
             print(traceback.format_exc())
             self.kill_tester_if_alive(workload_thread, False)
         finally:
-            workload_thread.join(5)
+            # 30s to allow ASAN builds time to complete shutdown cleanup
+            workload_thread.join(30)
             reader_thread.join(5)
             self.kill_tester_if_alive(workload_thread, True)
             if test_retcode == 0:


### PR DESCRIPTION
Under ASAN, TaskQueue::clear() fires broken_promise to actors across multiple external client network threads. The cascading cleanup takes longer than the previous 5-second timeout, causing the test harness to SIGKILL the tester and report failure.

See in last nights' nightly.  All tests pass but the cleanup on the end is timing out.