### PR TITLE
Support simulation mode for unit test targets

### DIFF
--- a/documentation/sphinx/source/testing.rst
+++ b/documentation/sphinx/source/testing.rst
@@ -26,6 +26,17 @@ For a while, there was an informal competition within the engineering team to de
 
 Simulation's success has surpassed our expectation and has been vital to our engineering team. It seems unlikely that we would have been able to build FoundationDB without this technology.
 
+Running unit tests in simulation
+--------------------------------
+
+Several standalone unit-test binaries can also run their tests under Simulation. The ``fdbclient_test``, ``fdbrpc_test``, and ``fdbserver_*_test`` targets support the ``--simulation`` flag. For example:
+
+.. code-block:: bash
+
+   ./bin/fdbclient_test --simulation
+
+When a binary is run in simulation mode without an explicit test filter, tests whose names start with ``noSim/`` are skipped. The ``flow_test`` target does not support this option because it is not linked with simulator support.
+
 Performance testing with Circus
 ===============================
 

--- a/fdbclient/fdbclient_test.cpp
+++ b/fdbclient/fdbclient_test.cpp
@@ -21,15 +21,6 @@
 #include "flow/UnitTestRunner.h"
 #include "fdbrpc/simulator.h"
 
-namespace {
-
-void initializeSimulation() {
-	startNewSimulator(false);
-	Sim2FileSystem::newFileSystem();
-}
-
-} // namespace
-
 int main(int argc, char** argv) {
-	return runUnitTests(argc, argv, UnitTestRunnerConfig("fdbclient", initializeSimulation));
+	return runUnitTests(argc, argv, UnitTestRunnerConfig("fdbclient", startUnitTestSimulator));
 }

--- a/fdbclient/fdbclient_test.cpp
+++ b/fdbclient/fdbclient_test.cpp
@@ -19,7 +19,17 @@
  */
 
 #include "flow/UnitTestRunner.h"
+#include "fdbrpc/simulator.h"
+
+namespace {
+
+void initializeSimulation() {
+	startNewSimulator(false);
+	Sim2FileSystem::newFileSystem();
+}
+
+} // namespace
 
 int main(int argc, char** argv) {
-	return runUnitTests(argc, argv, UnitTestRunnerConfig("fdbclient"));
+	return runUnitTests(argc, argv, UnitTestRunnerConfig("fdbclient", initializeSimulation));
 }

--- a/fdbclient/fdbclient_test.cpp
+++ b/fdbclient/fdbclient_test.cpp
@@ -18,9 +18,17 @@
  * limitations under the License.
  */
 
-#include "flow/UnitTestRunner.h"
+#include "fdbclient/Knobs.h"
 #include "fdbrpc/simulator.h"
+#include "flow/UnitTestRunner.h"
+
+namespace {
+Future<Void> initializeSimulation() {
+	resetClientKnobs(Randomize::True, IsSimulated::True);
+	return startUnitTestSimulator();
+}
+} // namespace
 
 int main(int argc, char** argv) {
-	return runUnitTests(argc, argv, UnitTestRunnerConfig("fdbclient", startUnitTestSimulator));
+	return runUnitTests(argc, argv, UnitTestRunnerConfig("fdbclient", initializeSimulation));
 }

--- a/fdbrpc/fdbrpc_test.cpp
+++ b/fdbrpc/fdbrpc_test.cpp
@@ -21,15 +21,6 @@
 #include "flow/UnitTestRunner.h"
 #include "fdbrpc/simulator.h"
 
-namespace {
-
-void initializeSimulation() {
-	startNewSimulator(false);
-	Sim2FileSystem::newFileSystem();
-}
-
-} // namespace
-
 int main(int argc, char** argv) {
-	return runUnitTests(argc, argv, UnitTestRunnerConfig("fdbrpc", initializeSimulation));
+	return runUnitTests(argc, argv, UnitTestRunnerConfig("fdbrpc", startUnitTestSimulator));
 }

--- a/fdbrpc/fdbrpc_test.cpp
+++ b/fdbrpc/fdbrpc_test.cpp
@@ -18,9 +18,21 @@
  * limitations under the License.
  */
 
-#include "flow/UnitTestRunner.h"
 #include "fdbrpc/simulator.h"
+#include "flow/BooleanParam.h"
+#include "flow/Knobs.h"
+#include "flow/UnitTestRunner.h"
+
+FDB_BOOLEAN_PARAM(IsSimulated);
+FDB_BOOLEAN_PARAM(Randomize);
+
+namespace {
+Future<Void> initializeSimulation() {
+	resetFlowKnobs(Randomize::True, IsSimulated::True);
+	return startUnitTestSimulator();
+}
+} // namespace
 
 int main(int argc, char** argv) {
-	return runUnitTests(argc, argv, UnitTestRunnerConfig("fdbrpc", startUnitTestSimulator));
+	return runUnitTests(argc, argv, UnitTestRunnerConfig("fdbrpc", initializeSimulation));
 }

--- a/fdbrpc/fdbrpc_test.cpp
+++ b/fdbrpc/fdbrpc_test.cpp
@@ -19,7 +19,17 @@
  */
 
 #include "flow/UnitTestRunner.h"
+#include "fdbrpc/simulator.h"
+
+namespace {
+
+void initializeSimulation() {
+	startNewSimulator(false);
+	Sim2FileSystem::newFileSystem();
+}
+
+} // namespace
 
 int main(int argc, char** argv) {
-	return runUnitTests(argc, argv, UnitTestRunnerConfig("fdbrpc"));
+	return runUnitTests(argc, argv, UnitTestRunnerConfig("fdbrpc", initializeSimulation));
 }

--- a/fdbrpc/include/fdbrpc/simulator.h
+++ b/fdbrpc/include/fdbrpc/simulator.h
@@ -391,6 +391,7 @@ inline bool simulationPolicyHasCapability(ISimulationPolicy::Capability capabili
 }
 
 void startNewSimulator(bool printSimTime);
+Future<Void> startUnitTestSimulator();
 
 // Parameters used to simulate disk performance
 struct DiskParameters : ReferenceCounted<DiskParameters> {

--- a/fdbrpc/sim2.cpp
+++ b/fdbrpc/sim2.cpp
@@ -53,6 +53,7 @@
 #include "flow/network.h"
 #include "flow/TLSConfig.h"
 #include "fdbrpc/Net2FileSystem.h"
+#include "fdbrpc/FlowTransport.h"
 #include "AsyncFileWriteChecker.h"
 #include "fdbrpc/genericactors.h"
 #include "fdbrpc/WellKnownEndpoints.h"
@@ -2585,6 +2586,50 @@ void startNewSimulator(bool printSimTime) {
 	g_network = g_simulator = new Sim2(printSimTime);
 	g_simulator->connectionFailuresDisableDuration =
 	    deterministicRandom()->coinflip() ? 0 : DISABLE_CONNECTION_FAILURE_FOREVER;
+}
+
+Future<Void> startUnitTestSimulator() {
+	startNewSimulator(false);
+	Standalone<StringRef> processId(deterministicRandom()->randomUniqueID().toString());
+	auto* process = g_simulator->newProcess(
+	    "UnitTest",
+	    IPAddress(0x01010101),
+	    1,
+	    false,
+	    1,
+	    LocalityData(Optional<Standalone<StringRef>>(), processId, processId, Optional<Standalone<StringRef>>()),
+	    ProcessClass(ProcessClass::TesterClass, ProcessClass::CommandLineSource),
+	    "",
+	    "",
+	    currentProtocolVersion(),
+	    false);
+	process->excludeFromRestarts = true;
+
+	Standalone<StringRef> httpProcessId(deterministicRandom()->randomUniqueID().toString());
+	auto* httpProcess = g_simulator->newProcess(
+	    "UnitTestHTTPServer",
+	    IPAddress(0x02020202),
+	    1,
+	    false,
+	    1,
+	    LocalityData(
+	        Optional<Standalone<StringRef>>(), httpProcessId, httpProcessId, Optional<Standalone<StringRef>>()),
+	    ProcessClass(ProcessClass::SimHTTPServerClass, ProcessClass::CommandLineSource),
+	    "",
+	    "",
+	    currentProtocolVersion(),
+	    false);
+	httpProcess->excludeFromRestarts = true;
+	co_await g_simulator->onProcess(httpProcess, TaskPriority::DefaultYield);
+	Sim2FileSystem::newFileSystem();
+	FlowTransport::createInstance(true, 1, WLTOKEN_RESERVED_COUNT);
+	(void)FlowTransport::transport().bind(httpProcess->address, httpProcess->address);
+	g_simulator->addSimHTTPProcess(makeReference<HTTP::SimServerContext>());
+
+	co_await g_simulator->onProcess(process, TaskPriority::DefaultYield);
+	Sim2FileSystem::newFileSystem();
+	FlowTransport::createInstance(true, 1, WLTOKEN_RESERVED_COUNT);
+	(void)FlowTransport::transport().bind(process->address, process->address);
 }
 
 Future<Void> doReboot(Uncancellable, ISimulator::ProcessInfo* p, ISimulator::KillType kt) {

--- a/fdbserver/FDBServerUnitTestMain.cpp
+++ b/fdbserver/FDBServerUnitTestMain.cpp
@@ -19,11 +19,21 @@
  */
 
 #include "flow/UnitTestRunner.h"
+#include "fdbrpc/simulator.h"
 
 #ifndef FDBSERVER_UNIT_TEST_SUITE
 #error "FDBSERVER_UNIT_TEST_SUITE must be defined"
 #endif
 
+namespace {
+
+void initializeSimulation() {
+	startNewSimulator(false);
+	Sim2FileSystem::newFileSystem();
+}
+
+} // namespace
+
 int main(int argc, char** argv) {
-	return runUnitTests(argc, argv, UnitTestRunnerConfig(FDBSERVER_UNIT_TEST_SUITE));
+	return runUnitTests(argc, argv, UnitTestRunnerConfig(FDBSERVER_UNIT_TEST_SUITE, initializeSimulation));
 }

--- a/fdbserver/FDBServerUnitTestMain.cpp
+++ b/fdbserver/FDBServerUnitTestMain.cpp
@@ -18,13 +18,21 @@
  * limitations under the License.
  */
 
-#include "flow/UnitTestRunner.h"
 #include "fdbrpc/simulator.h"
+#include "fdbserver/core/Knobs.h"
+#include "flow/UnitTestRunner.h"
 
 #ifndef FDBSERVER_UNIT_TEST_SUITE
 #error "FDBSERVER_UNIT_TEST_SUITE must be defined"
 #endif
 
+namespace {
+Future<Void> initializeSimulation() {
+	resetServerKnobs(Randomize::True, IsSimulated::True);
+	return startUnitTestSimulator();
+}
+} // namespace
+
 int main(int argc, char** argv) {
-	return runUnitTests(argc, argv, UnitTestRunnerConfig(FDBSERVER_UNIT_TEST_SUITE, startUnitTestSimulator));
+	return runUnitTests(argc, argv, UnitTestRunnerConfig(FDBSERVER_UNIT_TEST_SUITE, initializeSimulation));
 }

--- a/fdbserver/FDBServerUnitTestMain.cpp
+++ b/fdbserver/FDBServerUnitTestMain.cpp
@@ -25,15 +25,6 @@
 #error "FDBSERVER_UNIT_TEST_SUITE must be defined"
 #endif
 
-namespace {
-
-void initializeSimulation() {
-	startNewSimulator(false);
-	Sim2FileSystem::newFileSystem();
-}
-
-} // namespace
-
 int main(int argc, char** argv) {
-	return runUnitTests(argc, argv, UnitTestRunnerConfig(FDBSERVER_UNIT_TEST_SUITE, initializeSimulation));
+	return runUnitTests(argc, argv, UnitTestRunnerConfig(FDBSERVER_UNIT_TEST_SUITE, startUnitTestSimulator));
 }

--- a/fdbserver/mocks3/CMakeLists.txt
+++ b/fdbserver/mocks3/CMakeLists.txt
@@ -3,6 +3,7 @@ fdb_find_sources(FDBSERVER_MOCKS3_SRCS)
 add_flow_target(STATIC_LIBRARY NAME fdbserver_mocks3 SRCS ${FDBSERVER_MOCKS3_SRCS})
 add_fdbserver_unit_test(fdbserver_mocks3_test mocks3
   fdbserver_mocks3
+  fdbserver_core
   fdbclient)
 
 configure_fdbserver_common_includes(fdbserver_mocks3)

--- a/flow/Knobs.cpp
+++ b/flow/Knobs.cpp
@@ -38,6 +38,11 @@ FlowKnobs::FlowKnobs(Randomize randomize, IsSimulated isSimulated) {
 FlowKnobs bootstrapGlobalFlowKnobs(Randomize::False, IsSimulated::False);
 FlowKnobs const* FLOW_KNOBS = &bootstrapGlobalFlowKnobs;
 
+void resetFlowKnobs(Randomize randomize, IsSimulated isSimulated) {
+	bootstrapGlobalFlowKnobs.reset(randomize, isSimulated);
+	FLOW_KNOBS = &bootstrapGlobalFlowKnobs;
+}
+
 #define init(knob, value) INIT_KNOB(knob, value)
 
 // clang-format off

--- a/flow/UnitTestRunner.cpp
+++ b/flow/UnitTestRunner.cpp
@@ -103,7 +103,7 @@ void printUsage(const char* program, const UnitTestRunnerConfig& config) {
 	           "      --max-test-cases N    Stop after N matching tests\n"
 	           "      --no-cleanup          Keep the data directory after each test\n"
 	           "      --list                Print matching test names without running them\n"
-	           "      --simulation          Run using Sim2 (when supported by the target)\n"
+	           "      --simulation          Run using Sim2; skip noSim/ tests unless filtered\n"
 	           "  -h, --help                Show this help\n",
 	           program,
 	           config.suiteName(),
@@ -223,6 +223,10 @@ bool pathComponentMatches(std::string_view path, std::string_view component) {
 
 bool testMatched(const UnitTestRunnerOptions& options, std::string_view testName) {
 	if (!startsWith(testName, options.testPattern)) {
+		return false;
+	}
+
+	if (options.simulation && options.testPattern.empty() && startsWith(testName, "noSim/")) {
 		return false;
 	}
 
@@ -399,6 +403,9 @@ int runUnitTests(int argc, char** argv, const UnitTestRunnerConfig& config) {
 		options.randomSeed = platform::getRandomSeed();
 	}
 	setThreadLocalDeterministicRandomSeed(options.randomSeed);
+	if (options.simulation) {
+		bindDeterministicRandomToOpenssl();
+	}
 	fmt::print(stdout, "Random seed is {}\n", options.randomSeed);
 
 	const std::string traceName = config.traceName();

--- a/flow/UnitTestRunner.cpp
+++ b/flow/UnitTestRunner.cpp
@@ -37,6 +37,7 @@
 #include <exception>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #ifndef _WIN32
@@ -343,7 +344,7 @@ Future<Void> stopNetworkAfter(Future<Void> what, std::string_view traceName, int
 } // namespace
 
 UnitTestRunnerConfig::UnitTestRunnerConfig(std::string_view sourceSubDir, SimulationInitializer simulationInitializer)
-  : sourceSubDir(sourceSubDir), simulationInitializer(simulationInitializer) {}
+  : sourceSubDir(sourceSubDir), simulationInitializer(std::move(simulationInitializer)) {}
 
 std::string_view UnitTestRunnerConfig::suiteName() const {
 	return sourceSubDir;
@@ -358,7 +359,7 @@ std::string UnitTestRunnerConfig::traceName() const {
 }
 
 bool UnitTestRunnerConfig::supportsSimulation() const {
-	return simulationInitializer != nullptr;
+	return static_cast<bool>(simulationInitializer);
 }
 
 void UnitTestRunnerConfig::initializeSimulation() const {

--- a/flow/UnitTestRunner.cpp
+++ b/flow/UnitTestRunner.cpp
@@ -53,6 +53,7 @@ struct UnitTestRunnerOptions {
 	int maxTestCases = -1;
 	bool cleanupAfterTests = true;
 	bool listTests = false;
+	bool simulation = false;
 	bool showHelp = false;
 };
 
@@ -71,6 +72,7 @@ enum UnitTestRunnerOption {
 	OPT_MAX_TEST_CASES,
 	OPT_NO_CLEANUP,
 	OPT_LIST,
+	OPT_SIMULATION,
 };
 
 CSimpleOpt::SOption unitTestRunnerOptions[] = { { OPT_HELP, "-h", SO_NONE },
@@ -83,6 +85,7 @@ CSimpleOpt::SOption unitTestRunnerOptions[] = { { OPT_HELP, "-h", SO_NONE },
 	                                            { OPT_MAX_TEST_CASES, "--max-test-cases", SO_REQ_SEP },
 	                                            { OPT_NO_CLEANUP, "--no-cleanup", SO_NONE },
 	                                            { OPT_LIST, "--list", SO_NONE },
+	                                            { OPT_SIMULATION, "--simulation", SO_NONE },
 	                                            SO_END_OF_OPTIONS };
 
 void printUsage(const char* program, const UnitTestRunnerConfig& config) {
@@ -99,6 +102,7 @@ void printUsage(const char* program, const UnitTestRunnerConfig& config) {
 	           "      --max-test-cases N    Stop after N matching tests\n"
 	           "      --no-cleanup          Keep the data directory after each test\n"
 	           "      --list                Print matching test names without running them\n"
+	           "      --simulation          Run using Sim2 (when supported by the target)\n"
 	           "  -h, --help                Show this help\n",
 	           program,
 	           config.suiteName(),
@@ -180,6 +184,9 @@ bool parseArgs(int argc, char** argv, UnitTestRunnerOptions* options) {
 			break;
 		case OPT_LIST:
 			options->listTests = true;
+			break;
+		case OPT_SIMULATION:
+			options->simulation = true;
 			break;
 		default:
 			fmt::print(stderr, "ERROR: Unknown option id {}\n", args.OptionId());
@@ -335,7 +342,8 @@ Future<Void> stopNetworkAfter(Future<Void> what, std::string_view traceName, int
 
 } // namespace
 
-UnitTestRunnerConfig::UnitTestRunnerConfig(std::string_view sourceSubDir) : sourceSubDir(sourceSubDir) {}
+UnitTestRunnerConfig::UnitTestRunnerConfig(std::string_view sourceSubDir, SimulationInitializer simulationInitializer)
+  : sourceSubDir(sourceSubDir), simulationInitializer(simulationInitializer) {}
 
 std::string_view UnitTestRunnerConfig::suiteName() const {
 	return sourceSubDir;
@@ -347,6 +355,14 @@ std::string UnitTestRunnerConfig::dataDir() const {
 
 std::string UnitTestRunnerConfig::traceName() const {
 	return std::string(sourceSubDir) + "_test";
+}
+
+bool UnitTestRunnerConfig::supportsSimulation() const {
+	return simulationInitializer != nullptr;
+}
+
+void UnitTestRunnerConfig::initializeSimulation() const {
+	simulationInitializer();
 }
 
 int runUnitTests(int argc, char** argv, const UnitTestRunnerConfig& config) {
@@ -365,6 +381,10 @@ int runUnitTests(int argc, char** argv, const UnitTestRunnerConfig& config) {
 		printUsage(argv[0], config);
 		return 0;
 	}
+	if (options.simulation && !config.supportsSimulation()) {
+		fmt::print(stderr, "ERROR: Simulation mode is not supported by the {} test target\n", config.suiteName());
+		return 1;
+	}
 
 	if (options.randomSeed == 0) {
 		options.randomSeed = platform::getRandomSeed();
@@ -381,7 +401,11 @@ int runUnitTests(int argc, char** argv, const UnitTestRunnerConfig& config) {
 		return 1;
 	}
 
-	g_network = newNet2(TLSConfig());
+	if (options.simulation) {
+		config.initializeSimulation();
+	} else {
+		g_network = newNet2(TLSConfig());
+	}
 	openTraceFile({}, 10 << 20, 10 << 20, ".", traceName);
 
 	int exitCode = 0;

--- a/flow/UnitTestRunner.cpp
+++ b/flow/UnitTestRunner.cpp
@@ -325,6 +325,14 @@ Future<Void> runTests(const UnitTestRunnerOptions& options,
 	}
 }
 
+Future<Void> runTestsAfterInitialization(Future<Void> initialization,
+                                         const UnitTestRunnerOptions& options,
+                                         const UnitTestRunnerConfig& config,
+                                         UnitTestRunnerResult* result) {
+	co_await initialization;
+	co_await runTests(options, config, result);
+}
+
 Future<Void> stopNetworkAfter(Future<Void> what, std::string_view traceName, int* exitCode) {
 	try {
 		co_await what;
@@ -362,8 +370,8 @@ bool UnitTestRunnerConfig::supportsSimulation() const {
 	return static_cast<bool>(simulationInitializer);
 }
 
-void UnitTestRunnerConfig::initializeSimulation() const {
-	simulationInitializer();
+Future<Void> UnitTestRunnerConfig::initializeSimulation() const {
+	return simulationInitializer();
 }
 
 int runUnitTests(int argc, char** argv, const UnitTestRunnerConfig& config) {
@@ -402,8 +410,9 @@ int runUnitTests(int argc, char** argv, const UnitTestRunnerConfig& config) {
 		return 1;
 	}
 
+	Future<Void> initialization = Void();
 	if (options.simulation) {
-		config.initializeSimulation();
+		initialization = config.initializeSimulation();
 	} else {
 		g_network = newNet2(TLSConfig());
 	}
@@ -411,7 +420,9 @@ int runUnitTests(int argc, char** argv, const UnitTestRunnerConfig& config) {
 
 	int exitCode = 0;
 	UnitTestRunnerResult result;
-	Future<Void> done = stopNetworkAfter(runTests(options, config, &result), traceName, &exitCode);
+	Future<Void> tests = options.simulation ? runTestsAfterInitialization(initialization, options, config, &result)
+	                                        : runTests(options, config, &result);
+	Future<Void> done = stopNetworkAfter(tests, traceName, &exitCode);
 	g_network->run();
 	flushTraceFileVoid();
 

--- a/flow/include/flow/Knobs.h
+++ b/flow/include/flow/Knobs.h
@@ -397,5 +397,6 @@ public:
 // Flow knobs are needed before the knob collections are available, so a global FlowKnobs object is used to bootstrap
 extern FlowKnobs bootstrapGlobalFlowKnobs;
 extern FlowKnobs const* FLOW_KNOBS;
+void resetFlowKnobs(class Randomize randomize, class IsSimulated isSimulated);
 
 #endif

--- a/flow/include/flow/UnitTestRunner.h
+++ b/flow/include/flow/UnitTestRunner.h
@@ -27,14 +27,19 @@
 
 class UnitTestRunnerConfig {
 public:
-	explicit UnitTestRunnerConfig(std::string_view sourceSubDir);
+	using SimulationInitializer = void (*)();
+
+	explicit UnitTestRunnerConfig(std::string_view sourceSubDir, SimulationInitializer simulationInitializer = nullptr);
 
 	std::string_view suiteName() const;
 	std::string dataDir() const;
 	std::string traceName() const;
+	bool supportsSimulation() const;
+	void initializeSimulation() const;
 
 private:
 	std::string_view sourceSubDir;
+	SimulationInitializer simulationInitializer;
 };
 
 int runUnitTests(int argc, char** argv, const UnitTestRunnerConfig& config);

--- a/flow/include/flow/UnitTestRunner.h
+++ b/flow/include/flow/UnitTestRunner.h
@@ -22,14 +22,15 @@
 #define FLOW_UNIT_TEST_RUNNER_H
 #pragma once
 
+#include <functional>
 #include <string>
 #include <string_view>
 
 class UnitTestRunnerConfig {
 public:
-	using SimulationInitializer = void (*)();
+	using SimulationInitializer = std::function<void()>;
 
-	explicit UnitTestRunnerConfig(std::string_view sourceSubDir, SimulationInitializer simulationInitializer = nullptr);
+	explicit UnitTestRunnerConfig(std::string_view sourceSubDir, SimulationInitializer simulationInitializer = {});
 
 	std::string_view suiteName() const;
 	std::string dataDir() const;

--- a/flow/include/flow/UnitTestRunner.h
+++ b/flow/include/flow/UnitTestRunner.h
@@ -26,9 +26,11 @@
 #include <string>
 #include <string_view>
 
+#include "flow/flow.h"
+
 class UnitTestRunnerConfig {
 public:
-	using SimulationInitializer = std::function<void()>;
+	using SimulationInitializer = std::function<Future<Void>()>;
 
 	explicit UnitTestRunnerConfig(std::string_view sourceSubDir, SimulationInitializer simulationInitializer = {});
 
@@ -36,7 +38,7 @@ public:
 	std::string dataDir() const;
 	std::string traceName() const;
 	bool supportsSimulation() const;
-	void initializeSimulation() const;
+	Future<Void> initializeSimulation() const;
 
 private:
 	std::string_view sourceSubDir;


### PR DESCRIPTION
This PR extends unit test targets (e.g. `fdbserver_commitproxy_test`) to support running unit tests in simulation. This is not possible for `flow_test`, which doesn't have access to the simulator. Validated by running unit test targets with the simulation flag.