### PR TITLE
Add RESUME_DATA_MOVES_ON_RESTART knob

### DIFF
--- a/fdbserver/core/MoveKeys.cpp
+++ b/fdbserver/core/MoveKeys.cpp
@@ -1867,14 +1867,18 @@ static Future<Void> startMoveShards(Database occ,
 								    occ, rangeIntersectKeys, lock, startMoveKeysLock, dataMoveId, ddEnabledState);
 								throw retry();
 							} else {
-								if (cancelConflictingDataMoves) {
+								if (cancelConflictingDataMoves || !SERVER_KNOBS->RESUME_DATA_MOVES_ON_RESTART) {
 									TraceEvent(
 									    SevWarn, "StartMoveShardsCancelConflictingDataMove", relocationIntervalId)
 									    .detail("Range", rangeIntersectKeys)
 									    .detail("DataMoveID", dataMoveId.toString())
 									    .detail("ExistingDataMoveID", destId.toString());
-									co_await cleanUpDataMove(
-									    occ, destId, lock, startMoveKeysLock, keys, ddEnabledState);
+									co_await cleanUpDataMove(occ,
+									                         destId,
+									                         lock,
+									                         cancelConflictingDataMoves ? startMoveKeysLock : nullptr,
+									                         keys,
+									                         ddEnabledState);
 									throw retry();
 								} else {
 									Optional<Value> val = co_await tr.get(dataMoveKeyFor(destId));
@@ -3077,8 +3081,11 @@ Future<Void> cleanUpDataMoveBackground(Database occ,
 	TraceEvent(SevDebug, "CleanUpDataMoveBackgroundBegin", dataMoveId)
 	    .detail("DataMoveID", dataMoveId)
 	    .detail("Range", keys);
-	co_await cleanUpDataMoveParallelismLock->take(TaskPriority::DataDistributionLaunch);
-	FlowLock::Releaser releaser = FlowLock::Releaser(*cleanUpDataMoveParallelismLock);
+	Optional<FlowLock::Releaser> releaser;
+	if (cleanUpDataMoveParallelismLock) {
+		co_await cleanUpDataMoveParallelismLock->take(TaskPriority::DataDistributionLaunch);
+		releaser = FlowLock::Releaser(*cleanUpDataMoveParallelismLock);
+	}
 	DataMoveMetaData dataMove;
 	Transaction tr(occ);
 	while (true) {
@@ -3127,8 +3134,11 @@ Future<Void> cleanUpDataMoveCore(Database occ,
 	Error lastError;
 	bool runPreCheck = true;
 
-	co_await cleanUpDataMoveParallelismLock->take(TaskPriority::DataDistributionLaunch);
-	FlowLock::Releaser releaser = FlowLock::Releaser(*cleanUpDataMoveParallelismLock);
+	Optional<FlowLock::Releaser> releaser;
+	if (cleanUpDataMoveParallelismLock) {
+		co_await cleanUpDataMoveParallelismLock->take(TaskPriority::DataDistributionLaunch);
+		releaser = FlowLock::Releaser(*cleanUpDataMoveParallelismLock);
+	}
 
 	try {
 		while (true) {

--- a/fdbserver/core/ServerKnobs.cpp
+++ b/fdbserver/core/ServerKnobs.cpp
@@ -317,7 +317,9 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( ALLOW_LARGE_SHARD,                                   false ); if( randomize && BUGGIFY )  ALLOW_LARGE_SHARD = true;
 	init( MAX_LARGE_SHARD_BYTES,                          1000000000 ); // 1G
 	init( SHARD_ENCODE_LOCATION_METADATA,                      false ); if( isSimulated ) SHARD_ENCODE_LOCATION_METADATA = deterministicRandom()->random01() < 0.75;
+	init( RESUME_DATA_MOVES_ON_RESTART,                         true );
 	init( ENABLE_DD_PHYSICAL_SHARD,                            false ); // EXPERIMENTAL; If true, SHARD_ENCODE_LOCATION_METADATA must be true; When true, optimization of data move between DCs is disabled
+	if( ENABLE_DD_PHYSICAL_SHARD ) RESUME_DATA_MOVES_ON_RESTART = true; // Physical shard moves need checkpoint persistence
 	init( DD_PHYSICAL_SHARD_MOVE_PROBABILITY,                    0.0 ); // FIXME: re-enable after ShardedRocksDB is well tested by simulation
 	init( ENABLE_PHYSICAL_SHARD_MOVE_EXPERIMENT,               false ); // FIXME: re-enable after ShardedRocksDB is well tested by simulation
 	init( MAX_PHYSICAL_SHARD_BYTES,                         10000000 ); // 10 MB; for ENABLE_DD_PHYSICAL_SHARD; smaller leads to larger number of physicalShard per storage server

--- a/fdbserver/core/include/fdbserver/core/Knobs.h
+++ b/fdbserver/core/include/fdbserver/core/Knobs.h
@@ -246,6 +246,11 @@ public:
 	int MAX_LARGE_SHARD_BYTES;
 
 	bool SHARD_ENCODE_LOCATION_METADATA; // If true, location metadata will contain shard ID.
+	bool RESUME_DATA_MOVES_ON_RESTART; // If false, DD skips reading DataMoveMetaData on restart (does not resume
+	                                   // stale moves). DataMoveMetaData is still written within a DD lifetime
+	                                   // (needed by finishMoveShards). Only relevant when
+	                                   // SHARD_ENCODE_LOCATION_METADATA=true; the old path never touches
+	                                   // DataMoveMetaData regardless of this flag.
 	bool ENABLE_DD_PHYSICAL_SHARD; // EXPERIMENTAL; If true, SHARD_ENCODE_LOCATION_METADATA must be true.
 	double DD_PHYSICAL_SHARD_MOVE_PROBABILITY; // Percentage of physical shard move, in the range of [0, 1].
 	bool ENABLE_PHYSICAL_SHARD_MOVE_EXPERIMENT;

--- a/fdbserver/datadistributor/DDTxnProcessor.cpp
+++ b/fdbserver/datadistributor/DDTxnProcessor.cpp
@@ -393,55 +393,61 @@ class DDTxnProcessorImpl {
 				}
 
 				double dataMoveReadStart = now();
-				RangeResult dms = co_await tr.getRange(dataMoveKeys, CLIENT_KNOBS->TOO_MANY);
-				if (now() - dataMoveReadStart > 5.0) {
-					TraceEvent(SevWarn, "DDInitSlowDataMoveRead", distributorId)
-					    .detail("ElapsedSeconds", now() - dataMoveReadStart);
-				}
-				ASSERT(!dms.more && dms.size() < CLIENT_KNOBS->TOO_MANY);
-				// For each data move, find out the src or dst servers are in primary or remote DC.
-				for (int i = 0; i < dms.size(); ++i) {
-					auto dataMove = std::make_shared<DataMove>(decodeDataMoveValue(dms[i].value), true);
-					const DataMoveMetaData& meta = dataMove->meta;
-					if (meta.ranges.empty()) {
-						// Any persisted datamove with an empty range must be an tombstone persisted by
-						// a background cleanup (with retry_clean_up_datamove_tombstone_added),
-						// and this datamove must be in DataMoveMetaData::Deleting state
-						// A datamove without processed by a background cleanup must have a non-empty range
-						// For this case, we simply clear the range when dd init
-						ASSERT(meta.getPhase() == DataMoveMetaData::Deleting);
-						result->toCleanDataMoveTombstone.push_back(meta.id);
-						continue;
+				if (SERVER_KNOBS->RESUME_DATA_MOVES_ON_RESTART) {
+					RangeResult dms = co_await tr.getRange(dataMoveKeys, CLIENT_KNOBS->TOO_MANY);
+					if (now() - dataMoveReadStart > 5.0) {
+						TraceEvent(SevWarn, "DDInitSlowDataMoveRead", distributorId)
+						    .detail("ElapsedSeconds", now() - dataMoveReadStart);
 					}
-					ASSERT(!meta.ranges.empty());
-					for (const UID& id : meta.src) {
-						auto& dc = server_dc[id];
-						if (std::find(remoteDcIds.begin(), remoteDcIds.end(), dc) != remoteDcIds.end()) {
-							dataMove->remoteSrc.push_back(id);
-						} else {
-							dataMove->primarySrc.push_back(id);
+					ASSERT(!dms.more && dms.size() < CLIENT_KNOBS->TOO_MANY);
+					// For each data move, find out the src or dst servers are in primary or remote DC.
+					for (int i = 0; i < dms.size(); ++i) {
+						auto dataMove = std::make_shared<DataMove>(decodeDataMoveValue(dms[i].value), true);
+						const DataMoveMetaData& meta = dataMove->meta;
+						if (meta.ranges.empty()) {
+							// Any persisted datamove with an empty range must be an tombstone persisted by
+							// a background cleanup (with retry_clean_up_datamove_tombstone_added),
+							// and this datamove must be in DataMoveMetaData::Deleting state
+							// A datamove without processed by a background cleanup must have a non-empty range
+							// For this case, we simply clear the range when dd init
+							ASSERT(meta.getPhase() == DataMoveMetaData::Deleting);
+							result->toCleanDataMoveTombstone.push_back(meta.id);
+							continue;
 						}
-					}
-					for (const UID& id : meta.dest) {
-						auto& dc = server_dc[id];
-						if (std::find(remoteDcIds.begin(), remoteDcIds.end(), dc) != remoteDcIds.end()) {
-							dataMove->remoteDest.push_back(id);
-						} else {
-							dataMove->primaryDest.push_back(id);
+						ASSERT(!meta.ranges.empty());
+						for (const UID& id : meta.src) {
+							auto& dc = server_dc[id];
+							if (std::find(remoteDcIds.begin(), remoteDcIds.end(), dc) != remoteDcIds.end()) {
+								dataMove->remoteSrc.push_back(id);
+							} else {
+								dataMove->primarySrc.push_back(id);
+							}
 						}
-					}
-					std::sort(dataMove->primarySrc.begin(), dataMove->primarySrc.end());
-					std::sort(dataMove->remoteSrc.begin(), dataMove->remoteSrc.end());
-					std::sort(dataMove->primaryDest.begin(), dataMove->primaryDest.end());
-					std::sort(dataMove->remoteDest.begin(), dataMove->remoteDest.end());
+						for (const UID& id : meta.dest) {
+							auto& dc = server_dc[id];
+							if (std::find(remoteDcIds.begin(), remoteDcIds.end(), dc) != remoteDcIds.end()) {
+								dataMove->remoteDest.push_back(id);
+							} else {
+								dataMove->primaryDest.push_back(id);
+							}
+						}
+						std::sort(dataMove->primarySrc.begin(), dataMove->primarySrc.end());
+						std::sort(dataMove->remoteSrc.begin(), dataMove->remoteSrc.end());
+						std::sort(dataMove->primaryDest.begin(), dataMove->primaryDest.end());
+						std::sort(dataMove->remoteDest.begin(), dataMove->remoteDest.end());
 
-					auto ranges = result->dataMoveMap.intersectingRanges(meta.ranges.front());
-					for (auto& r : ranges) {
-						ASSERT(!r.value()->valid);
+						auto ranges = result->dataMoveMap.intersectingRanges(meta.ranges.front());
+						for (auto& r : ranges) {
+							ASSERT(!r.value()->valid);
+						}
+						result->dataMoveMap.insert(meta.ranges.front(), std::move(dataMove));
+						++numDataMoves;
 					}
-					result->dataMoveMap.insert(meta.ranges.front(), dataMove);
-					++numDataMoves;
-				}
+				} // if RESUME_DATA_MOVES_ON_RESTART
+				// When false: stale DataMoveMetaData rows (including Deleting tombstones and
+				// bulk-load entries) remain in \xff/dataMoves/ until cleanUpDataMove removes
+				// them reactively when startMoveShards encounters a conflicting destId. This
+				// is harmless — the rows are small and don't affect correctness.
 
 				succeeded = true;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -186,6 +186,7 @@ if(WITH_PYTHON)
   add_fdb_test(TEST_FILES fast/LowLatencySingleClog.toml IGNORE)
   add_fdb_test(TEST_FILES fast/MemoryLifetime.toml)
   add_fdb_test(TEST_FILES fast/MoveKeysCycle.toml)
+  add_fdb_test(TEST_FILES fast/MoveKeysCycleNoResumeDataMoves.toml)
   add_fdb_test(TEST_FILES fast/MutationLogReaderCorrectness.toml)
 
   add_fdb_test(TEST_FILES fast/GetEstimatedRangeSize.toml)

--- a/tests/fast/MoveKeysCycleNoResumeDataMoves.toml
+++ b/tests/fast/MoveKeysCycleNoResumeDataMoves.toml
@@ -1,0 +1,30 @@
+[[knobs]]
+resume_data_moves_on_restart = false
+shard_encode_location_metadata = true
+
+[[test]]
+testTitle = 'MoveKeysCycleNoResumeDataMoves'
+
+    [[test.workload]]
+    testName = 'Cycle'
+    transactionsPerSecond = 2500.0
+    testDuration = 10.0
+    expectedRate = 0.025
+
+    [[test.workload]]
+    testName = 'RandomMoveKeys'
+    testDuration = 10.0
+
+    [[test.workload]]
+    testName = 'Attrition'
+    machinesToKill = 1
+    machinesToLeave = 3
+    reboot = true
+    testDuration = 10.0
+
+    [[test.workload]]
+    testName = 'Attrition'
+    machinesToKill = 1
+    machinesToLeave = 3
+    reboot = true
+    testDuration = 10.0


### PR DESCRIPTION
With SHARD_ENCODE_LOCATION_METADATA =true, DD reads all in-progress DataMoveMetaData on restart and resumes them. In rare cases with many in-flight moves, this can cause a thundering herd where all N moves launch simultaneously, overwhelming DD. RESUME_DATA_MOVES_ON_RESTART=false is a defensive option: DD skips reading DataMoveMetaData on restart, re-evaluates from current cluster state, and cleans up stale destIds reactively when encountered.

When false, DD skips reading DataMoveMetaData on restart — it does not resume stale in-progress moves. DataMoveMetaData is still written within a DD lifetime (needed by finishMoveShards). Stale destIds in keyServers are cleaned up reactively via cleanUpDataMove when encountered by startMoveShards.

Only relevant when SHARD_ENCODE_LOCATION_METADATA=true; the old path never touches DataMoveMetaData regardless of this flag.


`  20260528-061420-stack_persist-01104fd47415b444     compressed=True data_size=37178294 duration=2332491 ended=100000 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:32:35 sanity=False started=100000 stopped=20260528-064655 submitted=20260528-061420 timeout=5400 username=stack_persist`


This PR comes of my failed attempt at making bulkload work without a dependency on SHARD_ENCODE_LOCATION_METADATA=true. In the end there ended up being too many edge cases:  system unable to distinguish normal fetchkeys and a bulkload fetch from s3 especially on failure; KRM coalescing requires fixed-width values, but the SS needs a unique per-task identifier to distinguish retries from new tasks; and so on. Every workaround ended up reimplementing parts of the shard-aware path.  Thereafter I tried to make a lightweight version of SHARD_ENCODE_LOCATION_METADATA with less persistence in metadata but similar issues. I ended up here with a little flag/feature that could come in handy in a crisis .