### PR TITLE
Populate committedVersion on automatic idempotency replay path (#13038)

### DIFF
--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -6850,6 +6850,7 @@ ACTOR static Future<Void> tryCommit(Reference<TransactionState> trState, CommitT
 					    req.transaction.read_snapshot + CLIENT_KNOBS->MAX_WRITE_TRANSACTION_LIFE_VERSIONS,
 					    req.idempotencyId));
 					if (commitResult.present()) {
+						trState->committedVersion = commitResult.get().commitVersion;
 						Standalone<StringRef> ret = makeString(10);
 						placeVersionstamp(
 						    mutateString(ret), commitResult.get().commitVersion, commitResult.get().batchIndex);

--- a/fdbserver/workloads/AutomaticIdempotencyWorkload.actor.cpp
+++ b/fdbserver/workloads/AutomaticIdempotencyWorkload.actor.cpp
@@ -116,12 +116,17 @@ struct AutomaticIdempotencyWorkload : TestWorkload {
 			state Value idempotencyId = makeString(length);
 			deterministicRandom()->randomBytes(mutateString(idempotencyId), length);
 			TraceEvent("IdempotencyIdWorkloadTransaction").detail("Id", idempotencyId);
+			state bool automatic = deterministicRandom()->random01() < self->automaticPercentage;
+			state Reference<ReadYourWritesTransaction> committedTr;
 			wait(runRYWTransaction(
-			    cx, [self = self, idempotencyId = idempotencyId](Reference<ReadYourWritesTransaction> tr) {
+			    cx,
+			    [self = self, idempotencyId = idempotencyId, automatic = automatic, &committedTr = committedTr](
+			        Reference<ReadYourWritesTransaction> tr) {
+				    committedTr = tr;
 				    // If we don't set AUTOMATIC_IDEMPOTENCY the idempotency id won't automatically get cleaned up, so
 				    // it should create work for the cleaner.
 				    tr->setOption(FDBTransactionOptions::IDEMPOTENCY_ID, idempotencyId);
-				    if (deterministicRandom()->random01() < self->automaticPercentage) {
+				    if (automatic) {
 					    // We also want to exercise the automatic idempotency code path.
 					    tr->setOption(FDBTransactionOptions::AUTOMATIC_IDEMPOTENCY);
 				    }
@@ -134,6 +139,12 @@ struct AutomaticIdempotencyWorkload : TestWorkload {
 				                 MutationRef::SetVersionstampedKey);
 				    return Future<Void>(Void());
 			    }));
+			if (committedTr->getCommittedVersion() == invalidVersion) {
+				TraceEvent(SevError, "IdempotencyCommitMissingVersion")
+				    .detail("Id", idempotencyId)
+				    .detail("AutomaticIdempotency", automatic);
+				self->ok = false;
+			}
 		}
 		return Void();
 	}


### PR DESCRIPTION
Backport of #13038 to release-7.4.

When a commit request returns commit_unknown_result for a transaction carrying an idempotency id, determineCommitStatus reads the system keyspace and may discover the original commit succeeded. In that case we reconstruct the versionstamp from CommitResult but previously forgot to record the commit version back on the TransactionState, so callers observing getCommittedVersion() after success would see invalidVersion.

Mirror the normal-path assignment on the replay branch, and add a regression guard in AutomaticIdempotencyWorkload asserting every successful commit reports a non-invalid version. Adapted to the actor-based workload still in use on 7.4.

Tested locally by running AutomaticIdempotencyWorkload.