### PR TITLE
Surface degraded multi-region status when failover is stuck waiting on the unavailable remote DC #12071

### DIFF
--- a/fdbcli/StatusCommand.cpp
+++ b/fdbcli/StatusCommand.cpp
@@ -708,10 +708,19 @@ void printStatus(StatusObjectReader statusObj,
 							ASSERT_WE_THINK(availLoss == -1);
 							const bool possiblyLosingData = logEpochsMayBeLosingData(statusObjCluster);
 							if (possiblyLosingData) {
-								outputString += format(
-								    "\n\n  Warning: the database may have data loss and availability loss. Please "
-								    "restart following tlog interfaces, otherwise storage servers may never be able "
-								    "to catch up.\n");
+								const std::string baseMessage =
+								    "Please restart following tlog interfaces, otherwise storage servers "
+								    "may never be able to catch up.\n";
+
+								bool degradedMultiRegion = false;
+								statusObjCluster.get("degraded_multi_region", degradedMultiRegion);
+
+								const std::string header =
+								    !degradedMultiRegion
+								        ? "\n\n  Warning: the database may have data loss and availability loss. "
+								        : "\n\n  ";
+
+								outputString += header + baseMessage;
 							} else {
 								outputString += format(
 								    "\n\n  Warning: the database may have availability loss. The current log state "
@@ -739,7 +748,10 @@ void printStatus(StatusObjectReader statusObj,
 											if (logInterface.get("healthy", healthy) && !healthy) {
 												logInterface.get("id", id);
 												logInterface.get("address", address);
-												missing_log_interfaces += format("%s,%s ", id.c_str(), address.c_str());
+												missing_log_interfaces +=
+												    format("%s,%s ",
+												           id.c_str(),
+												           address.empty() ? "unknown" : address.c_str());
 											}
 										}
 									}

--- a/fdbcli/StatusCommand.cpp
+++ b/fdbcli/StatusCommand.cpp
@@ -714,10 +714,20 @@ void printStatus(StatusObjectReader statusObj,
 							ASSERT_WE_THINK(availLoss == -1);
 							const bool possiblyLosingData = logEpochsMayBeLosingData(statusObjCluster);
 							if (possiblyLosingData) {
-								outputString += format(
-								    "\n\n  Warning: the database may have data loss and availability loss. Please "
-								    "restart following tlog interfaces, otherwise storage servers may never be able "
-								    "to catch up.\n");
+								const std::string baseMessage =
+								    "Please restart following tlog interfaces, otherwise storage servers "
+								    "may never be able to catch up.\n";
+
+								bool degradedMultiRegion = false;
+								statusObjCluster.get("degraded_multi_region", degradedMultiRegion);
+
+								const std::string header =
+								    !degradedMultiRegion
+								        ? "\n\n  Warning: the database may have data loss and availability loss. "
+								        : "\n\n  Warning: one region is unavailable; committed data remains safe in "
+								          "the surviving region. ";
+
+								outputString += header + baseMessage;
 							} else {
 								outputString += format(
 								    "\n\n  Warning: the database may have availability loss. The current log state "

--- a/fdbclient/Schemas.cpp
+++ b/fdbclient/Schemas.cpp
@@ -516,6 +516,7 @@ const KeyRef JSONSchemas::statusSchema = R"statusSchema(
       },
       "active_tss_count":0,
       "degraded_processes":0,
+      "degraded_multi_region":true,
       "database_available":true,
       "database_lock_state": {
          "locked": true,
@@ -1434,6 +1435,7 @@ file is writable and has not been overwritten externally."
       },
       "maintenance_zone":"0ccb4e0fdbdb5583010f6b77d9d10ece",
       "maintenance_seconds_remaining":1.0,
+      "degraded_multi_region":true,
       "data":{
          "least_operating_space_bytes_log_server":0,
          "average_partition_size_bytes":0,

--- a/fdbclient/Schemas.cpp
+++ b/fdbclient/Schemas.cpp
@@ -536,6 +536,7 @@ const KeyRef JSONSchemas::statusSchema = R"statusSchema(
       },
       "active_tss_count":0,
       "degraded_processes":0,
+      "degraded_multi_region":true,
       "database_available":true,
       "database_lock_state": {
          "locked": true,
@@ -1454,6 +1455,7 @@ file is writable and has not been overwritten externally."
       },
       "maintenance_zone":"0ccb4e0fdbdb5583010f6b77d9d10ece",
       "maintenance_seconds_remaining":1.0,
+      "degraded_multi_region":true,
       "data":{
          "least_operating_space_bytes_log_server":0,
          "average_partition_size_bytes":0,

--- a/fdbserver/SimulatedCluster.cpp
+++ b/fdbserver/SimulatedCluster.cpp
@@ -469,6 +469,8 @@ public:
 	Optional<bool> generateFearless, buggify, faultInjection;
 	Optional<std::string> config;
 	Optional<std::string> remoteConfig;
+	// Satellite redundancy mode override applied to all regions (e.g. "one_satellite_single")
+	Optional<std::string> satelliteRedundancyMode;
 	bool randomlyRenameZoneId = false;
 	bool simHTTPServerEnabled = true;
 
@@ -536,6 +538,7 @@ public:
 		    .add("storageEngineType", &storageEngineType)
 		    .add("config", &config)
 		    .add("remoteConfig", &remoteConfig)
+		    .add("satelliteRedundancyMode", &satelliteRedundancyMode)
 		    .add("buggify", &buggify)
 		    .add("faultInjection", &faultInjection)
 		    .add("StderrSeverity", &stderrSeverity)
@@ -1884,7 +1887,10 @@ void SimulationConfig::setRegions(const TestConfig& testConfig) {
 
 	bool needsRemote = generateFearless;
 	if (generateFearless) {
-		if (datacenters > 4) {
+		std::string satelliteRedundancyModeStr;
+		if (testConfig.satelliteRedundancyMode.present()) {
+			satelliteRedundancyModeStr = testConfig.satelliteRedundancyMode.get();
+		} else if (datacenters > 4) {
 			// FIXME: we cannot use one satellite replication with more than one satellite per region because
 			// canKillProcesses does not respect usable_dcs
 			int satellite_replication_type = deterministicRandom()->randomInt(0, 3);
@@ -1900,14 +1906,12 @@ void SimulationConfig::setRegions(const TestConfig& testConfig) {
 			}
 			case 1: {
 				CODE_PROBE(true, "Simulated cluster using two satellite fast redundancy mode");
-				primaryObj["satellite_redundancy_mode"] = "two_satellite_fast";
-				remoteObj["satellite_redundancy_mode"] = "two_satellite_fast";
+				satelliteRedundancyModeStr = "two_satellite_fast";
 				break;
 			}
 			case 2: {
 				CODE_PROBE(true, "Simulated cluster using two satellite safe redundancy mode");
-				primaryObj["satellite_redundancy_mode"] = "two_satellite_safe";
-				remoteObj["satellite_redundancy_mode"] = "two_satellite_safe";
+				satelliteRedundancyModeStr = "two_satellite_safe";
 				break;
 			}
 			default:
@@ -1927,25 +1931,27 @@ void SimulationConfig::setRegions(const TestConfig& testConfig) {
 			}
 			case 2: {
 				CODE_PROBE(true, "Simulated cluster using single satellite redundancy mode");
-				primaryObj["satellite_redundancy_mode"] = "one_satellite_single";
-				remoteObj["satellite_redundancy_mode"] = "one_satellite_single";
+				satelliteRedundancyModeStr = "one_satellite_single";
 				break;
 			}
 			case 3: {
 				CODE_PROBE(true, "Simulated cluster using double satellite redundancy mode");
-				primaryObj["satellite_redundancy_mode"] = "one_satellite_double";
-				remoteObj["satellite_redundancy_mode"] = "one_satellite_double";
+				satelliteRedundancyModeStr = "one_satellite_double";
 				break;
 			}
 			case 4: {
 				CODE_PROBE(true, "Simulated cluster using triple satellite redundancy mode");
-				primaryObj["satellite_redundancy_mode"] = "one_satellite_triple";
-				remoteObj["satellite_redundancy_mode"] = "one_satellite_triple";
+				satelliteRedundancyModeStr = "one_satellite_triple";
 				break;
 			}
 			default:
 				ASSERT(false); // Programmer forgot to adjust cases.
 			}
+		}
+
+		if (!satelliteRedundancyModeStr.empty()) {
+			primaryObj["satellite_redundancy_mode"] = satelliteRedundancyModeStr;
+			remoteObj["satellite_redundancy_mode"] = satelliteRedundancyModeStr;
 		}
 
 		// Calculate the maximum satellite_logs we can support based on available machines

--- a/fdbserver/clustercontroller/ClusterRecovery.cpp
+++ b/fdbserver/clustercontroller/ClusterRecovery.cpp
@@ -514,6 +514,10 @@ Future<Void> trackTlogRecovery(Reference<ClusterRecoveryData> self,
 	DBRecoveryCount recoverCount = self->cstate.myDBState.recoveryCount + 1;
 	DatabaseConfiguration configuration =
 	    self->configuration; // self-configuration can be changed by configurationMonitor so we need a copy
+	// Start of the current remote-region stall, if any. Kept across loop iterations so that
+	// re-emissions of the event on unrelated core-state changes do not reset the reported
+	// stall duration; it grows monotonically until the log set is complete.
+	Optional<double> remoteLogsMissingSince;
 	while (true) {
 		DBCoreState newState;
 		self->logSystem->toCoreState(newState);
@@ -581,6 +585,46 @@ Future<Void> trackTlogRecovery(Reference<ClusterRecoveryData> self,
 			    .trackLatest(self->clusterRecoveryStateEventHolder->trackingKey);
 		}
 
+		// Surface "degraded multi-region" as a first-class signal: with usableRegions > 1, the remote region's
+		// log set has not been recruited (allLogs == false). Committed data is still safe in the surviving
+		// region, so this is distinct from data loss. Note that oldTLogData is deliberately not a
+		// discriminator: when the remote region is down, old log generations cannot be purged (finalUpdate
+		// requires allLogs), so oldTLogData stays non-empty precisely in this stalled state. The value is also
+		// (re)set when all logs are recruited or the cluster fully recovers, so the trackLatest event always
+		// reflects the current state.
+		//
+		// The remote log set is legitimately absent before recovery reaches accepting_commits even during a
+		// normal (non-region-loss) recovery, because remote tlog recruitment is part of the normal recovery
+		// path. Only begin tracking the stall once the cluster is accepting commits: at that point a missing
+		// remote log set is no longer a transient recruiting artifact but a genuine degraded multi-region
+		// condition. Without this gate, StallSeconds accumulates across the pre-accepting_commits recruiting
+		// window and a slow-but-healthy recovery trips degraded_multi_region once the stall exceeds
+		// DEGRADED_MULTI_REGION_MIN_STALL_SECONDS.
+		bool remoteRegionLogsMissing =
+		    configuration.usableRegions > 1 && !allLogs && self->recoveryState >= RecoveryState::ACCEPTING_COMMITS;
+		if (remoteRegionLogsMissing) {
+			if (!remoteLogsMissingSince.present()) {
+				remoteLogsMissingSince = now();
+			}
+		} else {
+			remoteLogsMissingSince = Optional<double>();
+		}
+		// StallSeconds is carried in the event itself rather than derived from the event's
+		// emission Time by status: the event is re-emitted on every core-state change, and
+		// deriving the duration from the latest emission would reset the stall counter while
+		// the stall is still ongoing.
+		double remoteRegionStallSeconds =
+		    remoteLogsMissingSince.present() ? std::max(0.0, now() - remoteLogsMissingSince.get()) : 0.0;
+		TraceEvent(
+		    getRecoveryEventName(ClusterRecoveryEventType::CLUSTER_RECOVERY_REMOTE_REGION_STALL_EVENT_NAME).c_str(),
+		    self->dbgid)
+		    .detail("RemoteRegionLogsMissing", remoteRegionLogsMissing)
+		    .detail("AllLogs", allLogs)
+		    .detail("OldTLogDataSize", newState.oldTLogData.size())
+		    .detail("UsableRegions", configuration.usableRegions)
+		    .detail("StallSeconds", remoteRegionStallSeconds)
+		    .trackLatest(self->clusterRecoveryRemoteRegionStallEventHolder->trackingKey);
+
 		self->registrationTrigger.trigger();
 
 		if (finalUpdate) {
@@ -589,7 +633,15 @@ Future<Void> trackTlogRecovery(Reference<ClusterRecoveryData> self,
 			co_return;
 		}
 
-		co_await changed;
+		// While the remote log set is missing, keep re-emitting the stall event on a fixed cadence so
+		// StallSeconds keeps advancing even when no core-state change would otherwise wake this loop.
+		// Without this, an idle (commits-stalled) cluster would block forever in co_await changed and
+		// the sustained-stall threshold could never be crossed.
+		if (remoteRegionLogsMissing) {
+			co_await (changed || delay(SERVER_KNOBS->DEGRADED_MULTI_REGION_REFRESH_SECONDS));
+		} else {
+			co_await changed;
+		}
 	}
 }
 
@@ -2100,6 +2152,8 @@ const std::string& getRecoveryEventName(ClusterRecoveryEventType type) {
 		                              SERVER_KNOBS->CLUSTER_RECOVERY_EVENT_NAME_PREFIX + "RecoveryAvailable" });
 		recoveryEventNameMap.insert({ ClusterRecoveryEventType::CLUSTER_RECOVERY_METRICS_EVENT_NAME,
 		                              SERVER_KNOBS->CLUSTER_RECOVERY_EVENT_NAME_PREFIX + "RecoveryMetrics" });
+		recoveryEventNameMap.insert({ ClusterRecoveryEventType::CLUSTER_RECOVERY_REMOTE_REGION_STALL_EVENT_NAME,
+		                              SERVER_KNOBS->CLUSTER_RECOVERY_EVENT_NAME_PREFIX + "RecoveryRemoteRegionStall" });
 	}
 
 	auto iter = recoveryEventNameMap.find(type);

--- a/fdbserver/clustercontroller/ClusterRecovery.h
+++ b/fdbserver/clustercontroller/ClusterRecovery.h
@@ -55,6 +55,7 @@ enum ClusterRecoveryEventType {
 	CLUSTER_RECOVERY_COMMIT_EVENT_NAME,
 	CLUSTER_RECOVERY_AVAILABLE_EVENT_NAME,
 	CLUSTER_RECOVERY_METRICS_EVENT_NAME,
+	CLUSTER_RECOVERY_REMOTE_REGION_STALL_EVENT_NAME,
 	CLUSTER_RECOVERY_LAST // Always the last entry
 };
 
@@ -254,6 +255,7 @@ struct ClusterRecoveryData : NonCopyable, ReferenceCounted<ClusterRecoveryData> 
 	Reference<EventCacheHolder> clusterRecoveryGenerationsEventHolder;
 	Reference<EventCacheHolder> clusterRecoveryDurationEventHolder;
 	Reference<EventCacheHolder> clusterRecoveryAvailableEventHolder;
+	Reference<EventCacheHolder> clusterRecoveryRemoteRegionStallEventHolder;
 
 	ClusterRecoveryData(ClusterControllerData* controllerData,
 	                    Reference<AsyncVar<ServerDBInfo> const> const& dbInfo,
@@ -290,6 +292,8 @@ struct ClusterRecoveryData : NonCopyable, ReferenceCounted<ClusterRecoveryData> 
 		    getRecoveryEventName(ClusterRecoveryEventType::CLUSTER_RECOVERY_DURATION_EVENT_NAME));
 		clusterRecoveryAvailableEventHolder = makeReference<EventCacheHolder>(
 		    getRecoveryEventName(ClusterRecoveryEventType::CLUSTER_RECOVERY_AVAILABLE_EVENT_NAME));
+		clusterRecoveryRemoteRegionStallEventHolder = makeReference<EventCacheHolder>(
+		    getRecoveryEventName(ClusterRecoveryEventType::CLUSTER_RECOVERY_REMOTE_REGION_STALL_EVENT_NAME));
 		logger =
 		    cc.traceCounters(getRecoveryEventName(ClusterRecoveryEventType::CLUSTER_RECOVERY_METRICS_EVENT_NAME),
 		                     dbgid,

--- a/fdbserver/clustercontroller/Status.cpp
+++ b/fdbserver/clustercontroller/Status.cpp
@@ -1789,6 +1789,7 @@ static JsonBuilderObject configurationFetcher(Optional<DatabaseConfiguration> co
 
 static AsyncResult<JsonBuilderObject> dataStatusFetcher(WorkerDetails ddWorker,
                                                         DatabaseConfiguration configuration,
+                                                        bool degradedMultiRegion,
                                                         int* minStorageReplicasRemaining) {
 	JsonBuilderObject statusObjData;
 
@@ -1845,7 +1846,11 @@ static AsyncResult<JsonBuilderObject> dataStatusFetcher(WorkerDetails ddWorker,
 		if (startingStats.size() && startingStats.getValue("State") != "Active") {
 			JsonBuilderObject stateSectionObj;
 			stateSectionObj["name"] = "initializing";
-			stateSectionObj["description"] = "Healthy (Re)initializing automatic data distribution";
+			// When operating with a region down (data recovered in the surviving region but recovery is stuck at
+			// accepting_commits waiting for the other region's logs), make the degraded multiregional explicit.
+			stateSectionObj["description"] = degradedMultiRegion
+			                                     ? "Degraded multiregional (Re)initializing automatic data distribution"
+			                                     : "(Re)initializing automatic data distribution";
 			statusObjData["state"] = stateSectionObj;
 			co_return statusObjData;
 		}
@@ -3156,11 +3161,18 @@ static AsyncResult<Void> clusterGetStatusImpl(Reference<ClusterGetStatusState> s
 
 			int minStorageReplicasRemaining = -1;
 			int fullyReplicatedRegions = -1;
+			// The cluster is "degraded multi-region" when it is configured for two usable regions but recovery is
+			// stuck at accepting_commits: the primary region recovered and is committing, but the other region's
+			// logs are missing. Committed data is still safe in the surviving region (and its satellite), so this
+			// is a degraded-but-not-data-losing state.
+			bool degradedMultiRegion = configuration.present() && configuration.get().usableRegions > 1 &&
+			                           statusCode == RecoveryStatus::accepting_commits;
+			statusObj["degraded_multi_region"] = degradedMultiRegion;
 			// NOTE: here we should start all the transaction before wait in order to overlay latency
 			Future<Optional<Value>> primaryDCFO = getActivePrimaryDC(cx, &fullyReplicatedRegions, &messages);
 			std::vector<AsyncResult<JsonBuilderObject>> statusSectionFetchers;
 			statusSectionFetchers.push_back(
-			    dataStatusFetcher(ddWorker, configuration.get(), &minStorageReplicasRemaining));
+			    dataStatusFetcher(ddWorker, configuration.get(), degradedMultiRegion, &minStorageReplicasRemaining));
 			statusSectionFetchers.push_back(workloadStatusFetcher(
 			    db, workers, mWorker, rkWorker, &qos, &dataOverlay, &status_incomplete_reasons, storageServerFuture));
 			statusSectionFetchers.push_back(layerStatusFetcher(cx, &messages, &status_incomplete_reasons));

--- a/fdbserver/clustercontroller/Status.cpp
+++ b/fdbserver/clustercontroller/Status.cpp
@@ -1812,14 +1812,6 @@ static AsyncResult<JsonBuilderObject> dataStatusFetcher(WorkerDetails ddWorker,
 		TraceEventFields startingStats = dataInfo[0];
 		TraceEventFields dataStats = dataInfo[1];
 
-		if (startingStats.size() && startingStats.getValue("State") != "Active") {
-			JsonBuilderObject stateSectionObj;
-			stateSectionObj["name"] = "initializing";
-			stateSectionObj["description"] = "(Re)initializing automatic data distribution";
-			statusObjData["state"] = stateSectionObj;
-			co_return statusObjData;
-		}
-
 		TraceEventFields md = dataInfo[2];
 
 		// If we have a MovingData message, parse it.
@@ -1848,6 +1840,14 @@ static AsyncResult<JsonBuilderObject> dataStatusFetcher(WorkerDetails ddWorker,
 			statusObjData.setKeyRawNumber("total_kv_size_bytes", dataStats.getValue("TotalSizeBytes"));
 			statusObjData.setKeyRawNumber("system_kv_size_bytes", dataStats.getValue("SystemSizeBytes"));
 			statusObjData.setKeyRawNumber("partitions_count", dataStats.getValue("Shards"));
+		}
+
+		if (startingStats.size() && startingStats.getValue("State") != "Active") {
+			JsonBuilderObject stateSectionObj;
+			stateSectionObj["name"] = "initializing";
+			stateSectionObj["description"] = "Healthy (Re)initializing automatic data distribution";
+			statusObjData["state"] = stateSectionObj;
+			co_return statusObjData;
 		}
 
 		JsonBuilderArray teamTrackers;

--- a/fdbserver/clustercontroller/Status.cpp
+++ b/fdbserver/clustercontroller/Status.cpp
@@ -1162,13 +1162,54 @@ static JsonBuilderObject clientStatusFetcher(
 	return clientStatus;
 }
 
+// Parse the recovery-provided remote-region-stall event into a boolean. The event is emitted by
+// trackTlogRecovery when the remote region's log set could not be recruited (allLogs == false with
+// usableRegions > 1). An absent or empty event (e.g. an older server that does not emit it yet) means the
+// signal is not present, so the cluster is not flagged as degraded.
+static bool parseRemoteRegionLogsMissing(const TraceEventFields& remoteRegionStallEvent) {
+	if (remoteRegionStallEvent.size() == 0) {
+		return false;
+	}
+	return remoteRegionStallEvent.getInt("RemoteRegionLogsMissing") != 0;
+}
+
+// Parse the duration (in seconds) for which the remote-region-stall signal has been active. The recovery
+// side carries the duration in the event itself ("StallSeconds") because the event is (re)emitted on every
+// core-state change; deriving the duration from the latest emission time would reset the stall counter
+// while the stall is still ongoing. An absent event, an event reporting that the logs are not missing, or
+// any malformed value conservatively reports 0, which keeps the cluster from being flagged as degraded.
+static double parseRemoteRegionStallSeconds(const TraceEventFields& remoteRegionStallEvent) {
+	try {
+		if (remoteRegionStallEvent.size() == 0) {
+			return 0.0;
+		}
+		if (remoteRegionStallEvent.getInt("RemoteRegionLogsMissing") == 0) {
+			return 0.0;
+		}
+		double stallSeconds = std::stod(remoteRegionStallEvent.getValue("StallSeconds"));
+		return stallSeconds > 0.0 ? stallSeconds : 0.0;
+	} catch (Error& e) {
+		if (e.code() == error_code_actor_cancelled) {
+			throw;
+		}
+		return 0.0;
+	} catch (std::exception&) {
+		// Malformed numeric fields fail safe to "no sustained stall".
+		return 0.0;
+	}
+}
+
 static AsyncResult<JsonBuilderObject> recoveryStateStatusFetcher(Database cx,
                                                                  WorkerDetails ccWorker,
                                                                  WorkerDetails mWorker,
                                                                  int workerCount,
                                                                  std::set<std::string>* incomplete_reasons,
-                                                                 int* statusCode) {
+                                                                 int* statusCode,
+                                                                 bool* remoteRegionLogsMissing,
+                                                                 double* remoteRegionStallSeconds) {
 	JsonBuilderObject message;
+	*remoteRegionLogsMissing = false;
+	*remoteRegionStallSeconds = 0.0;
 	Transaction tr(cx);
 	try {
 		Future<TraceEventFields> mdActiveGensF =
@@ -1183,10 +1224,24 @@ static AsyncResult<JsonBuilderObject> recoveryStateStatusFetcher(Database cx,
 		    timeoutError(ccWorker.interf.eventLogRequest.getReply(EventLogRequest(StringRef(
 		                     getRecoveryEventName(ClusterRecoveryEventType::CLUSTER_RECOVERY_AVAILABLE_EVENT_NAME)))),
 		                 1.0);
+		Future<TraceEventFields> remoteRegionStallF =
+		    timeoutError(ccWorker.interf.eventLogRequest.getReply(EventLogRequest(StringRef(getRecoveryEventName(
+		                     ClusterRecoveryEventType::CLUSTER_RECOVERY_REMOTE_REGION_STALL_EVENT_NAME)))),
+		                 1.0);
 		tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
 		Future<ErrorOr<Version>> rvF = errorOr(timeoutError(tr.getReadVersion(), 1.0));
 
-		co_await (success(mdActiveGensF) && success(mdF) && success(rvF) && success(mDBAvailableF));
+		co_await (success(mdActiveGensF) && success(mdF) && success(rvF) && success(mDBAvailableF) &&
+		          success(remoteRegionStallF));
+
+		// Precisely report whether recovery is stalled because the remote region's log set could not be
+		// recruited (allLogs == false with usableRegions > 1). This replaces the coarser heuristic of matching
+		// on the accepting_commits recovery state, which would also flag a normal transient pass through
+		// accepting_commits as degraded. Additionally report how long the stall has been active, because the
+		// signal is also transiently true during a normal (non-initial) recovery of a healthy multi-region
+		// cluster until the remote epoch is recruited.
+		*remoteRegionLogsMissing = parseRemoteRegionLogsMissing(remoteRegionStallF.get());
+		*remoteRegionStallSeconds = parseRemoteRegionStallSeconds(remoteRegionStallF.get());
 
 		const TraceEventFields& md = mdF.get();
 		int mStatusCode = md.getInt("StatusCode");
@@ -1765,6 +1820,7 @@ static JsonBuilderObject configurationFetcher(Optional<DatabaseConfiguration> co
 
 static AsyncResult<JsonBuilderObject> dataStatusFetcher(WorkerDetails ddWorker,
                                                         DatabaseConfiguration configuration,
+                                                        bool degradedMultiRegion,
                                                         int* minStorageReplicasRemaining) {
 	JsonBuilderObject statusObjData;
 
@@ -1791,7 +1847,9 @@ static AsyncResult<JsonBuilderObject> dataStatusFetcher(WorkerDetails ddWorker,
 		if (startingStats.size() && startingStats.getValue("State") != "Active") {
 			JsonBuilderObject stateSectionObj;
 			stateSectionObj["name"] = "initializing";
-			stateSectionObj["description"] = "(Re)initializing automatic data distribution";
+			stateSectionObj["description"] = degradedMultiRegion
+			                                     ? "Degraded multiregional (Re)initializing automatic data distribution"
+			                                     : "(Re)initializing automatic data distribution";
 			statusObjData["state"] = stateSectionObj;
 			co_return statusObjData;
 		}
@@ -3024,9 +3082,17 @@ static AsyncResult<Void> clusterGetStatusImpl(Reference<ClusterGetStatusState> s
 
 		// construct status information for cluster subsections
 		int statusCode = (int)RecoveryStatus::END;
+		bool remoteRegionLogsMissing = false;
+		double remoteRegionStallSeconds = 0.0;
 		std::vector<AsyncResult<ErrorOr<JsonBuilderObject>>> clusterSubsectionFetchers;
-		clusterSubsectionFetchers.push_back(errorOr(recoveryStateStatusFetcher(
-		    cx, ccWorker, mWorker, workers.size(), &status_incomplete_reasons, &statusCode)));
+		clusterSubsectionFetchers.push_back(errorOr(recoveryStateStatusFetcher(cx,
+		                                                                       ccWorker,
+		                                                                       mWorker,
+		                                                                       workers.size(),
+		                                                                       &status_incomplete_reasons,
+		                                                                       &statusCode,
+		                                                                       &remoteRegionLogsMissing,
+		                                                                       &remoteRegionStallSeconds)));
 		clusterSubsectionFetchers.push_back(errorOr(timeoutError(getIdmpKeyStatus(cx), 5.0)));
 		clusterSubsectionFetchers.push_back(errorOr(versionEpochStatusFetcher(cx, &status_incomplete_reasons)));
 
@@ -3164,9 +3230,22 @@ static AsyncResult<Void> clusterGetStatusImpl(Reference<ClusterGetStatusState> s
 			int fullyReplicatedRegions = -1;
 			// NOTE: here we should start all the transaction before wait in order to overlay latency
 			Future<Optional<Value>> primaryDCFO = getActivePrimaryDC(cx, &fullyReplicatedRegions, &messages);
+			// The cluster is "degraded multi-region" when recovery explicitly reports that it is stalled because
+			// the remote region's log set could not be recruited (allLogs == false with usableRegions > 1) after
+			// accepting commits, and the stall has persisted for a while. Committed data is still safe in the
+			// surviving region (and its satellite), so this is a degraded-but-not-data-losing state. Requiring
+			// the recovery state to be at (or past) accepting_commits avoids the transient phases before the
+			// cluster is actually accepting commits. The sustained-stall requirement avoids the transient window
+			// during a normal (non-initial) recovery of a healthy multi-region cluster, where the remote log set
+			// is legitimately absent at accepting_commits until the remote epoch finishes recruiting.
+			bool degradedMultiRegion =
+			    configuration.present() && statusCode >= RecoveryStatus::accepting_commits &&
+			    configuration.get().usableRegions > 1 && remoteRegionLogsMissing &&
+			    remoteRegionStallSeconds >= SERVER_KNOBS->DEGRADED_MULTI_REGION_MIN_STALL_SECONDS;
+			statusObj["degraded_multi_region"] = degradedMultiRegion;
 			std::vector<AsyncResult<JsonBuilderObject>> statusSectionFetchers;
 			statusSectionFetchers.push_back(
-			    dataStatusFetcher(ddWorker, configuration.get(), &minStorageReplicasRemaining));
+			    dataStatusFetcher(ddWorker, configuration.get(), degradedMultiRegion, &minStorageReplicasRemaining));
 			statusSectionFetchers.push_back(workloadStatusFetcher(
 			    db, workers, mWorker, rkWorker, &qos, &dataOverlay, &status_incomplete_reasons, storageServerFuture));
 			statusSectionFetchers.push_back(layerStatusFetcher(cx, &messages, &status_incomplete_reasons));
@@ -3505,7 +3584,7 @@ StatusReply clusterGetFaultToleranceStatus(const std::string& statusStr) {
 
 		std::string faultToleranceRelatedFields[] = {
 			"fault_tolerance", "data",    "logs", "maintenance_zone", "maintenance_seconds_remaining", "qos",
-			"recovery_state",  "messages"
+			"recovery_state",  "messages", "degraded_multi_region"
 		};
 
 		JsonBuilderObject statusObj;
@@ -3905,6 +3984,86 @@ TEST_CASE("/status/json/merging") {
 	}
 
 	return Void();
+}
+
+// Verify the "degraded multi-region" signal parsing and computation, exercising the actual code paths used by
+// recoveryStateStatusFetcher and clusterGetStatusImpl. A cluster is only considered degraded multi-region when
+// recovery explicitly reports that the remote region's log set could not be recruited (allLogs == false with
+// usableRegions > 1) and the stall has persisted long enough to rule out the transient window that occurs
+// during a normal, non-initial recovery of a healthy multi-region cluster.
+TEST_CASE("/fdbserver/clustercontroller/degradedMultiRegionComputation") {
+	// parseRemoteRegionLogsMissing: event carries the signal.
+	{
+		TraceEventFields remoteRegionStallEvent;
+		remoteRegionStallEvent.addField("RemoteRegionLogsMissing", "1");
+		ASSERT(parseRemoteRegionLogsMissing(remoteRegionStallEvent));
+	}
+	// parseRemoteRegionLogsMissing: event explicitly says logs are not missing (normal recovery progressing).
+	{
+		TraceEventFields remoteRegionStallEvent;
+		remoteRegionStallEvent.addField("RemoteRegionLogsMissing", "0");
+		ASSERT(!parseRemoteRegionLogsMissing(remoteRegionStallEvent));
+	}
+	// parseRemoteRegionLogsMissing: empty event (older server that does not emit the signal) means false.
+	{
+		TraceEventFields remoteRegionStallEvent;
+		ASSERT(!parseRemoteRegionLogsMissing(remoteRegionStallEvent));
+	}
+
+	// Real scenario from production logs: with 2 usable regions, the first region is down, recovery is stalled
+	// and the remote log set has not been recruited (AllLogs=0), while old log generations remain (OldTLogDataSize=2).
+	// This is exactly the "degraded but not data-losing" state the signal is meant to surface.
+	{
+		TraceEventFields remoteRegionStallEvent;
+		remoteRegionStallEvent.addField("RemoteRegionLogsMissing", "1");
+		remoteRegionStallEvent.addField("AllLogs", "0");
+		remoteRegionStallEvent.addField("OldTLogDataSize", "2");
+		remoteRegionStallEvent.addField("UsableRegions", "2");
+		ASSERT(parseRemoteRegionLogsMissing(remoteRegionStallEvent));
+	}
+
+	// parseRemoteRegionStallSeconds: logs not missing -> no active stall, regardless of the carried duration.
+	{
+		TraceEventFields remoteRegionStallEvent;
+		remoteRegionStallEvent.addField("StallSeconds", "3600.0");
+		remoteRegionStallEvent.addField("RemoteRegionLogsMissing", "0");
+		ASSERT_EQ(parseRemoteRegionStallSeconds(remoteRegionStallEvent), 0.0);
+	}
+	// parseRemoteRegionStallSeconds: empty event -> no active stall.
+	{
+		TraceEventFields remoteRegionStallEvent;
+		ASSERT_EQ(parseRemoteRegionStallSeconds(remoteRegionStallEvent), 0.0);
+	}
+	// parseRemoteRegionStallSeconds: sustained stall carries the monotonic duration reported by recovery.
+	{
+		const double threshold = SERVER_KNOBS->DEGRADED_MULTI_REGION_MIN_STALL_SECONDS;
+		TraceEventFields remoteRegionStallEvent;
+		remoteRegionStallEvent.addField("StallSeconds", format("%.6f", threshold + 5.0));
+		remoteRegionStallEvent.addField("RemoteRegionLogsMissing", "1");
+		ASSERT_GE(parseRemoteRegionStallSeconds(remoteRegionStallEvent), threshold);
+	}
+	{
+		const double threshold = SERVER_KNOBS->DEGRADED_MULTI_REGION_MIN_STALL_SECONDS;
+		TraceEventFields remoteRegionStallEvent;
+		remoteRegionStallEvent.addField("StallSeconds", "0.1");
+		remoteRegionStallEvent.addField("RemoteRegionLogsMissing", "1");
+		ASSERT_LT(parseRemoteRegionStallSeconds(remoteRegionStallEvent), threshold);
+	}
+	// parseRemoteRegionStallSeconds: malformed or negative StallSeconds fails safe to 0 (not degraded).
+	{
+		TraceEventFields remoteRegionStallEvent;
+		remoteRegionStallEvent.addField("StallSeconds", "garbage");
+		remoteRegionStallEvent.addField("RemoteRegionLogsMissing", "1");
+		ASSERT_EQ(parseRemoteRegionStallSeconds(remoteRegionStallEvent), 0.0);
+	}
+	{
+		TraceEventFields remoteRegionStallEvent;
+		remoteRegionStallEvent.addField("StallSeconds", "-5.0");
+		remoteRegionStallEvent.addField("RemoteRegionLogsMissing", "1");
+		ASSERT_EQ(parseRemoteRegionStallSeconds(remoteRegionStallEvent), 0.0);
+	}
+
+	co_return;
 }
 
 // Test that clusterGetStatus returns partial results within the specified deadline

--- a/fdbserver/core/ServerKnobs.cpp
+++ b/fdbserver/core/ServerKnobs.cpp
@@ -869,6 +869,8 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	bool shortRecoveryDuration = randomize && buggify();
 	init( ENFORCED_MIN_RECOVERY_DURATION,                       0.085 ); if( shortRecoveryDuration ) ENFORCED_MIN_RECOVERY_DURATION = 0.01;
 	init( REQUIRED_MIN_RECOVERY_DURATION,                       0.080 ); if( shortRecoveryDuration ) REQUIRED_MIN_RECOVERY_DURATION = 0.01;
+	init( DEGRADED_MULTI_REGION_MIN_STALL_SECONDS,               30.0 ); if( isSimulated ) DEGRADED_MULTI_REGION_MIN_STALL_SECONDS = 15.0;
+	init( DEGRADED_MULTI_REGION_REFRESH_SECONDS,                  1.0 );
 	init( ALWAYS_CAUSAL_READ_RISKY,                             false );
 	init( MAX_COMMIT_UPDATES,                                    2000 ); if( randomize && buggify() ) MAX_COMMIT_UPDATES = 1;
 	init( MAX_PROXY_COMPUTE,                                      2.0 );

--- a/fdbserver/core/include/fdbserver/core/Knobs.h
+++ b/fdbserver/core/include/fdbserver/core/Knobs.h
@@ -729,6 +729,12 @@ public:
 	double MIN_CONFIRM_INTERVAL;
 	double ENFORCED_MIN_RECOVERY_DURATION;
 	double REQUIRED_MIN_RECOVERY_DURATION;
+	double DEGRADED_MULTI_REGION_MIN_STALL_SECONDS; // How long the remote region's log set must be missing after
+	                                                // accepting commits before status reports degraded_multi_region.
+	                                                // Filters out the transient window of a normal recovery.
+	double DEGRADED_MULTI_REGION_REFRESH_SECONDS; // Cadence for re-emitting the remote-region-stall event while it is
+	                                              // active, so StallSeconds keeps advancing even without core-state
+	                                              // changes (e.g. an idle cluster with a stalled remote DC).
 	bool ALWAYS_CAUSAL_READ_RISKY;
 	int MAX_COMMIT_UPDATES;
 	double MAX_PROXY_COMPUTE;

--- a/fdbserver/workloads/DegradedMultiRegionStatus.cpp
+++ b/fdbserver/workloads/DegradedMultiRegionStatus.cpp
@@ -1,0 +1,409 @@
+/*
+ * DegradedMultiRegionStatus.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Integration test for the "degraded multi-region" status signal.
+//
+// Setup: a two-usable-region cluster (generateFearless) with primary region "0"
+// (with satellite "2") and remote region "1". Coordinators live in the non-primary
+// regions because minimumRegions > 1.
+//
+// Scenario mirroring production: kill ONLY the primary datacenter "0" of the first
+// region, leaving its satellite "2" and the remote region "1"/"3" alive. The cluster
+// fails over to the remote region, storage servers recover data from the surviving
+// satellite "2", and recovery gets stuck at accepting_commits because the dead
+// primary's log set cannot be recruited (allLogs == false => RemoteRegionLogsMissing=1).
+// After the stall persists past DEGRADED_MULTI_REGION_MIN_STALL_SECONDS the test reads
+// the status JSON and asserts:
+//   - cluster.degraded_multi_region == true
+//   - cluster.data.state.description contains "Degraded multiregional"
+//
+// Before killing the primary DC the test also exercises the false-positive regression
+// from the remote log set being transiently absent at accepting_commits: it verifies
+// (a) a fully healthy cluster is not flagged, and (b) a *normal* recovery of a healthy
+// cluster (triggered by killing only the sequencer, no region loss) keeps
+// degraded_multi_region == false throughout the recovery.
+//
+// Finally it resets usable_regions=1 so subsequent checks are not stuck.
+
+#include "fdbclient/NativeAPI.actor.h"
+#include "fdbserver/core/TesterInterface.h"
+#include "fdbserver/core/WorkerInterface.h"
+#include "fdbserver/tester/workloads.h"
+#include "fdbserver/core/FDBSimulationPolicy.h"
+#include "fdbserver/core/RecoveryState.h"
+#include "fdbserver/core/ServerDBInfo.h"
+#include "fdbrpc/simulator.h"
+#include "fdbclient/ManagementAPI.h"
+#include "flow/CoroUtils.h"
+#include "fdbclient/ReadYourWrites.h"
+#include "fdbclient/json_spirit/json_spirit_value.h"
+
+struct DegradedMultiRegionStatusWorkload : TestWorkload {
+	static constexpr auto NAME = "DegradedMultiRegionStatus";
+	bool enabled;
+	double testDuration;
+	bool testSucceeded;
+
+	explicit DegradedMultiRegionStatusWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
+		enabled = !clientId && g_network->isSimulated();
+		testDuration = getOption(options, "testDuration"_sr, 120.0);
+		testSucceeded = false;
+	}
+
+	void disableFailureInjectionWorkloads(std::set<std::string>& out) const override { out.insert("all"); }
+
+	Future<Void> setup(Database const& cx) override {
+		if (enabled) {
+			return _setup(cx);
+		}
+		return Void();
+	}
+	Future<Void> start(Database const& cx) override {
+		if (enabled) {
+			return killPrimaryKeepSatellites(cx);
+		}
+		return Void();
+	}
+	Future<bool> check(Database const& cx) override { return enabled ? testSucceeded : true; }
+	void getMetrics(std::vector<PerfMetric>& m) override {}
+
+	// Wait until the cluster is fully recovered (stable starting point) before killing anything.
+	Future<Void> _setup(Database cx) {
+		double failedWait = 0.0;
+		while (dbInfo->get().recoveryState < RecoveryState::FULLY_RECOVERED) {
+			if (failedWait >= 300.0) {
+				TraceEvent(SevError, "DegradedMultiRegionStatus_FullRecoveryTimeout")
+				    .detail("Elapsed", failedWait)
+				    .detail("RecoveryState", dbInfo->get().recoveryState);
+				ASSERT(false);
+			}
+			co_await delay(1.0);
+			failedWait += 1.0;
+		}
+		TraceEvent("DegradedMultiRegionStatus_Setup").log();
+	}
+
+	// Read the degraded_multi_region flag from the status JSON. Returns false on any
+	// transient read/parse error (treated as "not degraded") so callers only fail on an
+	// explicit true.
+	Future<bool> readDegradedFlag(Database cx) {
+		ReadYourWritesTransaction tr(cx);
+		try {
+			tr.setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
+			Optional<Value> statusVal = co_await tr.get("\xff\xff/status/json"_sr);
+			if (statusVal.present()) {
+				json_spirit::mValue mv;
+				json_spirit::read_string(statusVal.get().toString(), mv);
+				auto& root = mv.get_obj();
+				if (root.contains("cluster")) {
+					auto& clusterObj = root["cluster"].get_obj();
+					if (clusterObj.contains("degraded_multi_region")) {
+						co_return clusterObj["degraded_multi_region"].get_bool();
+					}
+				}
+			}
+		} catch (Error& e) {
+			if (e.code() == error_code_actor_cancelled) {
+				throw;
+			}
+			// Transient read errors: treat as not degraded.
+		}
+		co_return false;
+	}
+
+	// Verify that a healthy (both regions up) cluster is not falsely flagged as
+	// degraded multi-region while idle.
+	Future<bool> verifyHealthyNotDegraded(Database cx) {
+		double tStart = now();
+		while (true) {
+			bool degraded = co_await readDegradedFlag(cx);
+			if (degraded) {
+				TraceEvent(SevError, "DegradedMultiRegionStatus_HealthyFalsePositive")
+				    .detail("Elapsed", now() - tStart)
+				    .detail("Phase", "idle");
+				co_return false;
+			}
+			if (now() - tStart > 10.0) {
+				co_return true;
+			}
+			co_await delay(1.0);
+		}
+	}
+
+	// Trigger a *normal* recovery with no region loss by killing only the sequencer
+	// (master), then poll the status across the recovery window and assert that
+	// degraded_multi_region stays false the whole time. This exercises the exact
+	// regression where the remote log set is transiently absent at accepting_commits.
+	Future<bool> verifyNormalRecoveryNotDegraded(Database cx) {
+		ASSERT(g_network->isSimulated());
+
+		// Kill the current sequencer to force a recovery while keeping every region alive.
+		NetworkAddress masterAddr = dbInfo->get().master.address();
+		ISimulator::ProcessInfo* masterProcess = g_simulator->getProcessByAddress(masterAddr);
+		if (masterProcess == nullptr) {
+			TraceEvent(SevError, "DegradedMultiRegionStatus_MasterProcessNotFound").detail("Address", masterAddr);
+			co_return false;
+		}
+		LifetimeToken preKillMasterLifetime = dbInfo->get().masterLifetime;
+		TraceEvent("DegradedMultiRegionStatus_KillSequencer").detail("Address", masterAddr);
+		g_simulator->killProcess(masterProcess, ISimulator::KillType::KillInstantly);
+
+		// Wait until the kill is observed as a new recovery start. A changed ServerDBInfo
+		// alone is not a reliable recovery marker (broadcasts also happen for unrelated
+		// reasons), so require either a new masterLifetime or a drop from FULLY_RECOVERED.
+		// onChange() is awaited in a loop because any single change may not belong to
+		// this recovery; without this wait the polling below could pass on the stale
+		// fully-recovered state without ever observing the new accepting_commits window.
+		double observedAt = now();
+		constexpr double observeTimeout = 60.0;
+		while (true) {
+			// isEqual is not const-qualified, so compare against a local copy.
+			LifetimeToken currentMasterLifetime = dbInfo->get().masterLifetime;
+			if (!currentMasterLifetime.isEqual(preKillMasterLifetime) ||
+			    dbInfo->get().recoveryState < RecoveryState::FULLY_RECOVERED) {
+				break; // recovery started: new lifetime or the state dropped
+			}
+			if (now() - observedAt > observeTimeout) {
+				TraceEvent(SevError, "DegradedMultiRegionStatus_NormalRecoveryNotObserved")
+				    .detail("RecoveryState", dbInfo->get().recoveryState);
+				co_return false;
+			}
+			co_await race(dbInfo->onChange(), delay(1.0));
+		}
+
+		double tStart = now();
+		double deadline = 120.0;
+		uint8_t cycles = 10;
+		while (true) {
+			bool degraded = co_await readDegradedFlag(cx);
+			if (degraded) {
+				TraceEvent(SevError, "DegradedMultiRegionStatus_NormalRecoveryFalsePositive")
+				    .detail("Elapsed", now() - tStart)
+				    .detail("RecoveryState", dbInfo->get().recoveryState);
+				co_return false;
+			}
+			if (dbInfo->get().recoveryState >= RecoveryState::ALL_LOGS_RECRUITED) {
+				TraceEvent("DegradedMultiRegionStatus_NormalRecoveryClean")
+				    .detail("Elapsed", now() - tStart)
+				    .detail("RecoveryState", dbInfo->get().recoveryState);
+				if (cycles == 0) {
+					co_return true;
+				}
+				cycles--;
+			} else {
+				cycles = 10; // reset the hold count if recovery is still in progress
+			}
+			if (now() - tStart > deadline) {
+				TraceEvent(SevError, "DegradedMultiRegionStatus_NormalRecoveryTimeout")
+				    .detail("Elapsed", now() - tStart)
+				    .detail("RecoveryState", dbInfo->get().recoveryState);
+				co_return false;
+			}
+			co_await delay(1.0);
+		}
+	}
+
+	// Wait until status JSON reports the desired degraded multi-region state.
+	Future<bool> waitForDegradedStatus(Database cx) {
+		double tStart = now();
+		Optional<double> degradedSince;
+		while (true) {
+			ReadYourWritesTransaction tr(cx);
+			try {
+				tr.setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
+				Optional<Value> statusVal = co_await tr.get("\xff\xff/status/json"_sr);
+				if (statusVal.present()) {
+					json_spirit::mValue mv;
+					json_spirit::read_string(statusVal.get().toString(), mv);
+					auto& root = mv.get_obj();
+					if (root.contains("cluster")) {
+						auto& clusterObj = root["cluster"].get_obj();
+						bool degraded = false;
+						if (clusterObj.contains("degraded_multi_region")) {
+							degraded = clusterObj["degraded_multi_region"].get_bool();
+						}
+						std::string dataStateDesc;
+						if (clusterObj.contains("data") && clusterObj["data"].get_obj().contains("state") &&
+						    clusterObj["data"].get_obj()["state"].get_obj().contains("description")) {
+							dataStateDesc = clusterObj["data"].get_obj()["state"].get_obj()["description"].get_str();
+						}
+
+						bool acceptingCommits =
+						    clusterObj.contains("recovery_state") &&
+						    clusterObj["recovery_state"].get_obj().contains("name") &&
+						    clusterObj["recovery_state"].get_obj()["name"].get_str() == "accepting_commits";
+
+						const bool expectedState = degraded && acceptingCommits &&
+						                           dataStateDesc.find("Degraded multiregional") != std::string::npos;
+
+						std::string recoveryStateJson;
+						if (clusterObj.contains("recovery_state")) {
+							recoveryStateJson = json_spirit::write_string(clusterObj["recovery_state"],
+							                                              json_spirit::Output_options::none);
+						}
+						TraceEvent("DegradedMultiRegionStatus_Probe")
+						    .detail("Degraded", degraded)
+						    .detail("DataStateDesc", dataStateDesc)
+						    .detail("AcceptingCommits", acceptingCommits)
+						    .detail("RecoveryStateJson", recoveryStateJson)
+						    .detail("Elapsed", now() - tStart)
+						    .detail("ExpectedState", expectedState);
+						if (expectedState) {
+							if (!degradedSince.present()) {
+								degradedSince = now();
+								TraceEvent("DegradedMultiRegionStatus_DegradedHoldStarted")
+								    .detail("Elapsed", now() - tStart);
+							}
+
+							const double holdDuration = now() - degradedSince.get();
+							if (holdDuration >= 10.0) {
+								TraceEvent("DegradedMultiRegionStatus_Success")
+								    .detail("Elapsed", now() - tStart)
+								    .detail("Degraded", degraded)
+								    .detail("DataStateDesc", dataStateDesc);
+								printf("\n=== Degraded Multi-Region Status Found ===\n");
+								printf(
+								    "Warning: one region is unavailable; committed data remains safe in the surviving "
+								    "region.\n");
+								printf(
+								    "Please restart following tlog interfaces, otherwise storage servers may never be "
+								    "able to catch up.\n");
+								printf("\nData:\n");
+								printf("  Replication health - %s\n", dataStateDesc.c_str());
+								printf("========================================\n\n");
+								fflush(stdout);
+								co_return true;
+							}
+						} else {
+							if (degradedSince.present()) {
+								TraceEvent("DegradedMultiRegionStatus_DegradedHoldLost")
+								    .detail("Elapsed", now() - tStart)
+								    .detail("HoldDuration", now() - degradedSince.get());
+								co_return false;
+							}
+						}
+					}
+				}
+			} catch (Error& e) {
+				if (e.code() == error_code_actor_cancelled) {
+					throw;
+				}
+				// Transient read errors: keep polling.
+			}
+
+			if (now() - tStart > testDuration) {
+				TraceEvent(SevError, "DegradedMultiRegionStatus_Timeout").detail("Elapsed", now() - tStart);
+				co_return false;
+			}
+			co_await delay(5.0);
+		}
+	}
+
+	Future<Void> killPrimaryKeepSatellites(Database cx) {
+		ASSERT(g_network->isSimulated());
+
+		// The cluster starts fully healthy (both regions up). Confirm it is not
+		// falsely marked degraded while idle.
+		testSucceeded = co_await verifyHealthyNotDegraded(cx);
+		if (!testSucceeded) {
+			co_return;
+		}
+
+		// Trigger a normal recovery with no region loss and confirm the flag stays
+		// false throughout. This guards the transient accepting_commits window.
+		testSucceeded = co_await verifyNormalRecoveryNotDegraded(cx);
+		if (!testSucceeded) {
+			co_return;
+		}
+
+		// Give the cluster a moment to settle back to fully recovered before the
+		// destructive kill below.
+		co_await _setup(cx);
+
+		// The primary region of the first region is datacenter "0" in the fearless
+		// topology (with primary satellite "2"). Kill only "0"; keep "2", "1" and
+		// "3" alive so the remote region can recover data from the surviving
+		// satellite of the (dead) primary region.
+		LifetimeToken previousMasterLifetime = dbInfo->get().masterLifetime;
+		g_simulator->killDataCenter("0"_sr, ISimulator::KillType::KillInstantly, true);
+		TraceEvent("DegradedMultiRegionStatus_KilledPrimaryDC").log();
+
+		bool failoverReady = true;
+
+		try {
+			co_await timeoutError(waitForPrimaryDC(cx, "1"_sr), 120.0);
+		} catch (Error& e) {
+			if (e.code() == error_code_actor_cancelled) {
+				throw;
+			}
+			TraceEvent(SevError, "DegradedMultiRegionStatus_WaitForPrimaryDCFailed").error(e);
+			failoverReady = false;
+		}
+
+		if (failoverReady) {
+			double start = now();
+			LifetimeToken currentMasterLifetime = dbInfo->get().masterLifetime;
+			while (currentMasterLifetime.isEqual(previousMasterLifetime)) {
+				if (now() - start > 120.0) {
+					TraceEvent(SevError, "DegradedMultiRegionStatus_MasterChangeTimeout").log();
+					failoverReady = false;
+					break;
+				}
+				co_await dbInfo->onChange();
+				currentMasterLifetime = dbInfo->get().masterLifetime;
+			}
+		}
+
+		if (failoverReady) {
+			testSucceeded = co_await waitForDegradedStatus(cx);
+		} else {
+			testSucceeded = false;
+		}
+
+		// Unstick the cluster regardless of the assertion outcome: recovery is parked
+		// at accepting_commits while region "0" is dead. A forced recovery in region
+		// "1" runs updateConfigForForcedRecovery, which forces usable_regions=1 and
+		// lets the cluster fully recover, so subsequent workloads/checks do not hang.
+		// This is cleanup, not part of the assertion: a cleanup failure is logged but
+		// does not overwrite the degraded-status result.
+		try {
+			co_await forceRecovery(cx->getConnectionRecord(), "1"_sr);
+			TraceEvent("DegradedMultiRegionStatus_Unstick").log();
+		} catch (Error& e) {
+			if (e.code() == error_code_actor_cancelled) {
+				throw;
+			}
+			TraceEvent(SevWarnAlways, "DegradedMultiRegionStatus_UnstickFailed").error(e);
+		}
+
+		// Safety net in case the forced recovery did not take effect.
+		try {
+			co_await ManagementAPI::changeConfig(cx.getReference(), "usable_regions=1", true);
+			TraceEvent("DegradedMultiRegionStatus_Reset").log();
+		} catch (Error& e) {
+			if (e.code() == error_code_actor_cancelled) {
+				throw;
+			}
+			TraceEvent(SevWarnAlways, "DegradedMultiRegionStatus_ResetFailed").error(e);
+		}
+	}
+};
+
+WorkloadFactory<DegradedMultiRegionStatusWorkload> DegradedMultiRegionStatusWorkloadFactory;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -253,6 +253,7 @@ if(WITH_PYTHON)
     add_fdb_test(TEST_FILES slow/GcGenerations.toml)
     add_fdb_test(TEST_FILES fast/KillRegionCycle.toml)
     add_fdb_test(TEST_FILES rare/ClogRemoteTLog.toml)
+    add_fdb_test(TEST_FILES slow/DegradedMultiRegionStatus.toml)
   endif()
 
   if(WITH_ROCKSDB)

--- a/tests/slow/DegradedMultiRegionStatus.toml
+++ b/tests/slow/DegradedMultiRegionStatus.toml
@@ -1,0 +1,37 @@
+# Integration test for the "degraded multi-region" status signal.
+#
+# Simulated fearless topology (generateFearless=true) with two usable regions:
+#   - region 0 (primary): datacenter "0" (priority 2) + satellite "2" (priority 1)
+#   - region 1 (remote):  datacenter "1" (priority 1) + satellite "3" (priority 1)
+#   - usable_regions=2, coordinators placed in non-primary DCs (minimumRegions=2)
+#
+# The workload kills ONLY datacenter "0" (the primary of the first region), leaving
+# its satellite "2" and the remote region alive. The cluster fails over to region 1,
+# recovers data from the surviving satellite "2", and recovery gets stuck at
+# accepting_commits with the dead primary's log set not recruited
+# (allLogs == false => RemoteRegionLogsMissing=1 => degraded_multi_region=true).
+
+[configuration]
+generateFearless = true
+minimumRegions = 2
+coordinators = 3
+datacenters = 4
+simHTTPServerEnabled = false
+satelliteRedundancyMode = "one_satellite_single"
+config = "single"
+
+[[test]]
+testTitle = 'DegradedMultiRegionStatus'
+clearAfterTest = false
+runFailureWorkloads = false
+runConsistencyCheck = true
+
+    [[test.workload]]
+    testName = 'Cycle'
+    nodeCount = 100
+    transactionsPerSecond = 100.0
+    testDuration = 3.0
+
+    [[test.workload]]
+    testName = 'DegradedMultiRegionStatus'
+    testDuration = 200.0


### PR DESCRIPTION
**Surface degraded multi-region status when failover is stuck waiting on the unavailable remote DC**

This PR introduces observability for #12071. Instead of preventing the stall where recovery waits for an unavailable remote datacenter, this change surfaces the stuck state to improve cluster visibility.

### Key Changes

#### 1. New Status Flag: `cluster.degraded_multi_region`
The flag becomes `true` when all of the following conditions are met:
- The cluster is configured with `usable_regions > 1`.
- Recovery has progressed to or beyond the `accepting_commits` stage.
- The remote region's log set cannot be recruited (signaled by `RemoteRegionLogsMissing` from `trackTlogRecovery`).
- The state persists for longer than `DEGRADED_MULTI_REGION_MIN_STALL_SECONDS` (to avoid false positives during transient windows of normal non-initial recovery).

#### 2. New Trace Event
- Added `ClusterControllerRecoveryRemoteRegionStall` for improved debugging and monitoring. The event carries the stall duration (`StallSeconds`) which is used to determine when the threshold is met.

#### 3. Improved `fdbcli` Output
- The data-loss warning is **softened** when `degraded_multi_region` is `true`, because committed data remains safe in the surviving region. The message now clarifies: *"one region is unavailable; committed data remains safe in the surviving region"*.

#### 4. Enhanced Simulation Testing
- **New Configuration Options:** Added `satelliteRedundancyMode` to `TestConfig`, allowing tests to explicitly set the satellite redundancy mode (e.g., `one_satellite_single`, `two_satellite_fast`). This makes multi-region simulation more deterministic.
- **New Workload:** Added `DegradedMultiRegionStatus` workload and a corresponding `.toml` test (`tests/slow/DegradedMultiRegionStatus.toml`). This integration test simulates a fearless topology, kills the primary datacenter, and verifies the `degraded_multi_region` flag is correctly set and reported.
- **Unit Tests:** Added unit tests for the new signal parsing logic (`parseRemoteRegionLogsMissing`, `parseRemoteRegionStallSeconds`) to ensure robust handling of edge cases.

### Why This Matters

In a multi-region configuration, when one region fails, the second (surviving) region first recovers missing data from the satellite of the first (failed) region, which remains operational. After this data copy completes, recovery proceeds to the `accepting_commits` stage. However, at this point the recovery may stall because the failed region's logs remain unreachable. While this prevents the remote region from fully recovering, the surviving region continues to accept commits, and all committed data remains safe and consistent. The stall only affects the ability to restore the failed region, not the integrity of committed data.

Previously, `fdbcli status` showed a misleading "potential data loss" warning. This PR replaces that with an honest representation of the degraded but non-data-losing state, providing clear visibility into the actual cluster condition.

**Related Issue:** #12071
**Forum Discussion:** [link](https://forums.foundationdb.org/t/3dc2regions-simulating-primary-datacenter-failure/3329/18)

### Summary of Key Implementation Details (from the diff)
*   **Signal Emission:** The `trackTlogRecovery` loop now emits the `ClusterControllerRecoveryRemoteRegionStall` event and maintains a monotonic `StallSeconds` counter, which is re-emitted on a fixed cadence while the stall is active (using `DEGRADED_MULTI_REGION_REFRESH_SECONDS`).
*   **Status Calculation:** The `clusterGetStatusImpl` function now consumes this event and sets `degraded_multi_region` only when `recoveryState >= accepting_commits`, `usableRegions > 1`, and `StallSeconds >= DEGRADED_MULTI_REGION_MIN_STALL_SECONDS`.
*   **CLI Logic:** The `printStatus` function in `Status.cpp` now checks `degraded_multi_region` to adjust the warning message.

