### PR TITLE
Add LSAN suppression for ThreadSafeTransaction indirect leaks

### DIFF
--- a/contrib/lsan.suppressions
+++ b/contrib/lsan.suppressions
@@ -19,6 +19,7 @@ leak:ConnectionReaderActorState
 # cannot execute after the network stops. This covers the transaction objects
 # and all their owned state (TransactionState, WriteMap, ReadVersion actors).
 leak:ThreadSafeDatabase::createTransaction
+leak:ThreadSafeTransaction::ThreadSafeTransaction
 
 # External client libraries (loaded via MultiVersionApi) create DatabaseContext
 # objects whose cleanup is deferred via onMainThreadVoid in ~ThreadSafeDatabase.


### PR DESCRIPTION
The existing leak:ThreadSafeDatabase::createTransaction (added in #13278) only catches the direct ThreadSafeTransaction allocation (2x2048 bytes). Indirect leaks from transaction operations (TransactionState, extractReadVersion, WriteMap entries) are attributed to their own allocation sites, which have ThreadSafeTransaction methods in the call stack but don't match the createTransaction suppression.

This causes the ASAN nightly to report 10,296 bytes in 48 allocations across multiple fdb_c_api_test_* tests even with the fix from #13278 applied.

Related:
- #13188 — Initial LSAN suppressions + gRPC use-after-return fix
- #13242 — Remove explicit __lsan_do_leak_check() (symbolizer deadlock)
- #13255 — Client-side shutdown leak suppressions (30+ entries)
- #13278 — Fix root causes: TaskQueue::clear() + DatabaseContext destructor
- #13288 — Increase upgrade test shutdown timeout for ASAN
