### PR TITLE
Add fdbbackup initial snapshot interval to help

### DIFF
--- a/fdbbackup/backup.cpp
+++ b/fdbbackup/backup.cpp
@@ -1097,6 +1097,10 @@ static void printBackupUsage(bool devhelp) {
 	       "                 For start or modify operations, specifies the backup's default target snapshot interval "
 	       "as DURATION seconds.  Defaults to %d for start operations.\n",
 	       CLIENT_KNOBS->BACKUP_DEFAULT_SNAPSHOT_INTERVAL_SEC);
+	printf(
+	    "  --initial-snapshot-interval DURATION\n"
+	    "                 For start operations, specifies the duration of the first inconsistent snapshot as DURATION "
+	    "seconds. Defaults to 0, meaning as fast as possible.\n");
 	printf("  --mode MODE    Snapshot mechanism to use: bulkdump, rangefile (default, legacy), or both.\n"
 	       "                 bulkdump: Uses BulkDump SST files for faster restore performance\n"
 	       "                 rangefile: Traditional range files for backward compatibility\n"

--- a/tests/argument_parsing/test_argument_parsing.py
+++ b/tests/argument_parsing/test_argument_parsing.py
@@ -99,6 +99,11 @@ def test_fdbbackup(build_dir):
     check(not is_unknown_knob(run_command(command, ["--knob_min_trace_severity", "5"])))
     check(not is_unknown_knob(run_command(command, ["--knob_min-trace-severity", "5"])))
 
+    start_command = [args.build_dir + "/bin/fdbbackup", "start"]
+    check(
+        "--initial-snapshot-interval DURATION" in run_command(start_command, ["--help"])
+    )
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(


### PR DESCRIPTION
## Summary
- Add `--initial-snapshot-interval DURATION` to `fdbbackup` help output.
- Keep the help text consistent with the existing backup documentation wording.
- Add a command-line argument regression check for `fdbbackup start --help`.

## Testing
- `git diff --check HEAD~1..HEAD`
- `python3 -m py_compile tests/argument_parsing/test_argument_parsing.py`

## Notes
- I could not run a full local CMake build in this environment because required build dependencies are missing, including OpenSSL development headers and mono.