### PR TITLE
Add timeout to QuietDatabase recovery wait loop

### DIFF
--- a/fdbserver/core/QuietDatabase.cpp
+++ b/fdbserver/core/QuietDatabase.cpp
@@ -999,7 +999,26 @@ Future<Void> waitForQuietDatabase(Database cx,
 
 	TraceEvent("QuietDatabaseWaitingOnFullRecovery").detail("Phase", phase).log();
 	while (dbInfo->get().recoveryState != RecoveryState::FULLY_RECOVERED) {
-		co_await dbInfo->onChange();
+		// Bound the recovery wait by the same budget the quiet-database checks below use. If the
+		// cluster never returns to FULLY_RECOVERED (e.g. a wedged remote-region log router that can
+		// never find a primary peek location, so an old TLog generation never drains and recovery
+		// stalls at all_logs_recruited), fail fast here with a clear reason instead of blocking
+		// indefinitely until the simulator's trace-line cap aborts the run tens of thousands of
+		// seconds later. The (delay) ensures the deadline is re-checked even if dbInfo stops
+		// changing.
+		if (now() - checker.start > checker.maxDDRunTime) {
+			TraceEvent(g_network->isSimulated() ? SevError : SevWarnAlways, "QuietDatabaseNeverFullyRecovered")
+			    .detail("Phase", phase)
+			    .detail("RecoveryState", (int)dbInfo->get().recoveryState)
+			    .detail("WaitedFor", now() - checker.start)
+			    .detail("Timeout", checker.maxDDRunTime);
+			// Mirror the ddGotStuck assertion below: in simulation, a cluster that cannot fully
+			// recover within the budget is a failure we want surfaced quickly. On a real cluster,
+			// fall through and let the checks below keep retrying.
+			ASSERT(!g_network->isSimulated());
+			break;
+		}
+		co_await (dbInfo->onChange() || delay(5.0));
 	}
 
 	// The quiet database check (which runs at the end of every test) will always time out due to active data movement.


### PR DESCRIPTION
The waitForQuietDatabase recovery loop waits indefinitely for dbInfo->onChange() to signal FULLY_RECOVERED state. In simulation tests with RandomClogging and Attrition workloads, the tester process can lose its connection to the cluster controller after the test workload completes. When this happens, the AsyncVar<ServerDBInfo> never receives another update, causing dbInfo->onChange() to block forever. This leads to the simulation running for 22,000+ seconds producing over 1M trace lines until TracedTooManyLines kills it.

Fix by polling with a 5-second delay and breaking out after 300 seconds. The subsequent quiet database checks will handle retries if recovery has not actually completed.

Fixes: Sideband.toml simulation failure with seed 2881621233 and gcc

`  20260529-054545-stack_QuietDatabaseRetry-7b72a8e39b781a9c compressed=True data_size=41247877 duration=2329457 ended=100000 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:46:29 sanity=False started=100000 stopped=20260529-063214 submitted=20260529-054545 timeout=5400 username=stack_QuietDatabaseRetry`