### PR TITLE
release-7.3 fixes for gcc-13 and clang-19 on rhel9

### DIFF
--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -413,7 +413,21 @@ set_target_properties(c_workloads PROPERTIES
 target_link_libraries(c_workloads PUBLIC fdb_c)
 
 if(NOT WIN32 AND NOT APPLE AND NOT OPEN_FOR_IDE)
-  target_link_options(c_workloads PRIVATE "LINKER:--version-script=${CMAKE_CURRENT_SOURCE_DIR}/external_workload.map,-z,nodelete")
+  # Add the -Wl,--undefined-version flag to the linker command to allow
+  # undefined symbols in version scripts. Clang 19 doesn't allow this and would
+  # complain with "symbol not defined" errors.
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "19.0.0")
+    target_link_options(c_workloads PRIVATE
+      "LINKER:--version-script=${CMAKE_CURRENT_SOURCE_DIR}/external_workload.map"
+      "LINKER:-z,nodelete"
+      "LINKER:--undefined-version"
+    )
+  else()
+    target_link_options(c_workloads PRIVATE
+      "LINKER:--version-script=${CMAKE_CURRENT_SOURCE_DIR}/external_workload.map"
+      "LINKER:-z,nodelete"
+    )
+  endif()
 endif()
 
 # Generate shim library in Linux builds

--- a/bindings/c/test/fdb_api.hpp
+++ b/bindings/c/test/fdb_api.hpp
@@ -39,6 +39,51 @@
 // introduce the option enums
 #include <fdb_c_options.g.h>
 
+namespace std {
+template <>
+struct char_traits<uint8_t> {
+	using char_type = uint8_t;
+	using int_type = int;
+	using off_type = streamoff;
+	using pos_type = streampos;
+	using state_type = mbstate_t;
+
+	static void assign(char_type& c1, const char_type& c2) noexcept { c1 = c2; }
+	static bool eq(char_type c1, char_type c2) noexcept { return c1 == c2; }
+	static bool lt(char_type c1, char_type c2) noexcept { return c1 < c2; }
+
+	static int compare(const char_type* s1, const char_type* s2, size_t n) { return memcmp(s1, s2, n); }
+
+	static size_t length(const char_type* s) { return strlen(reinterpret_cast<const char*>(s)); }
+
+	static const char_type* find(const char_type* s, size_t n, const char_type& a) {
+		return reinterpret_cast<const char_type*>(memchr(s, a, n));
+	}
+
+	static char_type* move(char_type* s1, const char_type* s2, size_t n) {
+		return reinterpret_cast<char_type*>(memmove(s1, s2, n));
+	}
+
+	static char_type* copy(char_type* s1, const char_type* s2, size_t n) {
+		return reinterpret_cast<char_type*>(memcpy(s1, s2, n));
+	}
+
+	static char_type* assign(char_type* s, size_t n, char_type a) {
+		return reinterpret_cast<char_type*>(memset(s, a, n));
+	}
+
+	static int_type not_eof(int_type c) noexcept { return (c == eof()) ? 0 : c; }
+
+	static char_type to_char_type(int_type c) noexcept { return static_cast<char_type>(c); }
+
+	static int_type to_int_type(char_type c) noexcept { return static_cast<int_type>(c); }
+
+	static bool eq_int_type(int_type c1, int_type c2) noexcept { return c1 == c2; }
+
+	static int_type eof() noexcept { return static_cast<int_type>(EOF); }
+};
+} // namespace std
+
 namespace fdb {
 
 // hide C API to discourage mixing C/C++ API

--- a/cmake/CompileBoost.cmake
+++ b/cmake/CompileBoost.cmake
@@ -45,9 +45,7 @@ function(compile_boost)
     # Remove this after boost 1.81 or above is used
     # avoid unary_function errors with macOS 26 toolchain using c++17:
     #  > no template named 'unary_function' in namespace 'std'; did you mean '__unary_function'?
-    if (APPLE)
-      list(APPEND BOOST_COMPILER_FLAGS -D_LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION)
-    endif()
+    list(APPEND BOOST_COMPILER_FLAGS -D_LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION)
   endif()
 
   # Update the user-config.jam

--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -91,6 +91,7 @@ set(CMAKE_REQUIRED_INCLUDES stdlib.h malloc.h)
 set(CMAKE_REQUIRED_LIBRARIES c)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 
@@ -364,6 +365,8 @@ else()
       -Wno-unused-command-line-argument
       # Disable C++ 20 warning for ambiguous operator.
       -Wno-ambiguous-reversed-operator
+      # Disable for clang 19
+      -Wno-vla-cxx-extension
       )
     if (USE_CCACHE)
       add_compile_options(
@@ -394,6 +397,7 @@ else()
     # Needed for gcc 13
     #add_compile_options($<${is_cxx_compile}:-Wno-missing-template-keyword>)
     add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-missing-template-keyword>)
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-free-nonheap-object>)
   endif()
   add_compile_options(-Wno-error=format
     -Wunused-variable

--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -75,7 +75,7 @@ if(WIN32)
   add_definitions(-D_USE_MATH_DEFINES) # Math constants
 endif()
 
-if(APPLE)
+if(APPLE OR USE_LIBCXX)
 # Remove this after boost 1.81 or above is used
 add_definitions(-D_LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION)
 endif()

--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -391,6 +391,9 @@ else()
     # Otherwise `state [[maybe_unused]] int x;` will issue a warning.
     # https://stackoverflow.com/questions/50646334/maybe-unused-on-member-variable-gcc-warns-incorrectly-that-attribute-is
     add_compile_options(-Wno-attributes)
+    # Needed for gcc 13
+    #add_compile_options($<${is_cxx_compile}:-Wno-missing-template-keyword>)
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-missing-template-keyword>)
   endif()
   add_compile_options(-Wno-error=format
     -Wunused-variable

--- a/cmake/Findjemalloc.cmake
+++ b/cmake/Findjemalloc.cmake
@@ -133,7 +133,7 @@ endif()
 # Manual find jemalloc by hand
 find_path(
   jemalloc_INCLUDE_DIRS
-  NAMES jemalloc.h
+  NAMES jemalloc/jemalloc.h
   PATH_SUFFIXES jemalloc jemalloc/include
   HINTS ${jemalloc_ROOT})
 if(NOT jemalloc_INCLUDE_DIRS)

--- a/cmake/awssdk.cmake
+++ b/cmake/awssdk.cmake
@@ -9,7 +9,7 @@ endif()
 include(ExternalProject)
 ExternalProject_Add(awssdk_project
   GIT_REPOSITORY https://github.com/aws/aws-sdk-cpp.git
-  GIT_TAG e4b4b310d8631bc7e9a797b6ac03a73c6f210bf6 # v1.9.331
+  GIT_TAG 94d02db44730b0a5cef98ce33deedf43f5333700 # v1.9.379
   SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/awssdk-src"
   BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/awssdk-build"
   GIT_CONFIG advice.detachedHead=false

--- a/fdbmonitor/fdbmonitor.cpp
+++ b/fdbmonitor/fdbmonitor.cpp
@@ -471,9 +471,7 @@ public:
 	Command(const CSimpleIni& ini, std::string _section, ProcessID id, fdb_fd_set fds, int* maxfd)
 	  : fds(fds), argv(nullptr), section(_section), fork_retry_time(-1), quiet(false), delete_envvars(nullptr),
 	    deconfigured(false), kill_on_configuration_change(true), memory_rss(0) {
-		char _ssection[strlen(section.c_str()) + 22];
-		snprintf(_ssection, strlen(section.c_str()) + 22, "%s", id.c_str());
-		ssection = _ssection;
+		ssection = id;
 
 		for (auto p : pipes) {
 			if ((pipe(p) == 0)) {

--- a/fdbserver/KeyValueStoreShardedRocksDB.actor.cpp
+++ b/fdbserver/KeyValueStoreShardedRocksDB.actor.cpp
@@ -54,7 +54,6 @@ static_assert((ROCKSDB_MAJOR == FDB_ROCKSDB_MAJOR && ROCKSDB_MINOR == FDB_ROCKSD
                ROCKSDB_PATCH == FDB_ROCKSDB_PATCH),
               "Unsupported rocksdb version.");
 
-const std::string rocksDataFolderSuffix = "-data";
 const std::string METADATA_SHARD_ID = "kvs-metadata";
 const std::string DEFAULT_CF_NAME = "default"; // `specialKeys` is stored in this culoumn family.
 const std::string manifestFilePrefix = "MANIFEST-";

--- a/fdbserver/worker.actor.cpp
+++ b/fdbserver/worker.actor.cpp
@@ -4018,7 +4018,7 @@ ACTOR Future<Void> serveProcess() {
 
 				std::vector<SerializedSample> serializedSamples;
 				for (const auto& samplePtr : samples) {
-					auto serialized = SerializedSample{ .time = samplePtr->time };
+					auto serialized = SerializedSample{ .time = samplePtr->time, .data = {} };
 					for (const auto& [waitState, pair] : samplePtr->data) {
 						if (waitState >= req.waitStateStart && waitState <= req.waitStateEnd) {
 							serialized.data[waitState] = std::string(pair.first, pair.second);

--- a/flow/include/flow/Arena.h
+++ b/flow/include/flow/Arena.h
@@ -499,9 +499,12 @@ public:
 	int expectedSize() const { return size(); }
 
 	int compare(StringRef const& other) const {
-		auto minSize = static_cast<int>(std::min(size(), other.size()));
+		int minSize = static_cast<int>(std::min(size(), other.size()));
 		if (minSize != 0) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-overread"
 			int c = memcmp(begin(), other.begin(), minSize);
+#pragma GCC diagnostic pop
 			if (c != 0)
 				return c;
 		}

--- a/flow/include/flow/CompressedInt.h
+++ b/flow/include/flow/CompressedInt.h
@@ -124,9 +124,13 @@ struct CompressedInt {
 				buf[ih] |= b;
 				b >>= 1;
 			}
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
 			if (neg) // If negative, bit flip the entire encoded thing
 				for (int i = iStart; i < sizeof(buf); ++i)
 					buf[i] = ~buf[i];
+#pragma GCC diagnostic pop
 
 			ar.serializeBytes(buf + iStart, encodedLen);
 		}


### PR DESCRIPTION
Please see commit descriptions. This will enable us to test release-7.3 with the rhel9 (rockylinux:9) PR build/test as well.

I'll run a 100k test with centos7 build to ensure these minor adjustments have no unexpected effects there.