### PR TITLE
Add metadata encoding (SHARD_ENCODE_LOCATION_METADATA) audit, rollback support, and tests

### DIFF
--- a/design/data-distributor-internals.md
+++ b/design/data-distributor-internals.md
@@ -718,6 +718,9 @@ servers (who are receiving the data during a move). When no move is in progress,
 empty. The encoding supports both UID-based and Tag-based formats, plus optional shard IDs
 when `SHARD_ENCODE_LOCATION_METADATA` is enabled.
 
+See [shard-encode-location-metadata.md](shard-encode-location-metadata.md) for full
+feature description including encoding details, rollout/rollback, and SS behavior.
+
 Key encoding/decoding functions in [`SystemData.cpp`](https://github.com/apple/foundationdb/blob/release-7.3/fdbclient/SystemData.cpp):
 - `keyServersKey(k)` -- constructs the key
 - `keyServersValue(UIDtoTagMap, src, dest)` -- encodes src/dest with tags

--- a/design/shard-encode-location-metadata.md
+++ b/design/shard-encode-location-metadata.md
@@ -134,7 +134,6 @@ Serialized with `ObjectWriter` + `IncludeVersion()` (versioned, evolvable).
 | DataMoveMetaData                  |
 +-----------------------------------+
 | id:             UID               |
-| version:        Version           |
 | ranges:         vector<KeyRange>  |
 | phase:          Running|Deleting  |
 | priority:       int               |
@@ -247,9 +246,17 @@ The dataMoveId lets the SS distinguish:
 - **Same ID as current fetch** → retry/continuation, keep going
 - **Different ID** → new task, restart fetch from scratch
 
-This distinction is critical for bulk load: if DD restarts and re-issues the same
-bulk load, SS must continue (not restart). If DD issues a DIFFERENT bulk load for
-the same range, SS must restart with the new S3 path.
+This distinction is critical for bulk load. The S3 path lives in the
+`BulkLoadTaskState` persisted at `\xff/bulkLoadTask/<range>` and is
+fixed for the lifetime of a given dataMoveId — DD writes it once when
+the move is created, SS reads it. So:
+
+- DD restart that re-issues the **same** dataMoveId → SS sees the same
+  task, continues from the same path (no restart).
+- DD issuing a **different** dataMoveId for the same range (a new bulk
+  load) → new `BulkLoadTaskState`, possibly with a different S3 path.
+  The change in dataMoveId is the signal to the SS to restart the
+  fetch from the new path.
 
 ## Bulk Load Integration
 
@@ -377,8 +384,24 @@ lightweight, no scanning required.
 
 **`fdbcli> audit_storage metadata_encoding`** — definitive check. Scans all
 keyServers and serverKeys entries, classifies each by protocol version header,
-counts dataMoves entries. Reports explicit migration status:
-FORWARD COMPLETE / ROLLBACK IN PROGRESS / ROLLBACK COMPLETE.
+counts dataMoves entries. Reports one of four states:
+
+- **`FORWARD COMPLETE`** — every keyServers and serverKeys entry is in the
+  new (UID-encoded) format. Forward migration has finished; the cluster is
+  fully on shard-encoded location metadata.
+- **`MIGRATION IN PROGRESS`** — both formats coexist (mixed). The
+  cluster is mid-migration but the snapshot can't tell direction from
+  the keyspace data alone — the operator who flipped the knob already
+  knows whether it's forward (toward shard-encoded) or back (toward
+  old format). Status line shows new-format counts so progress is
+  visible in either direction.
+- **`ROLLBACK COMPLETE`** — every entry is in the old format and
+  `\xff/dataMoves/` is empty. Safe to downgrade the binary. Also the
+  state for a cluster that has never enabled the knob.
+- **`NOT STARTED`** — every entry is old format but `\xff/dataMoves/`
+  is non-empty. Transient state seen briefly right after the knob is
+  flipped on (moves in flight before any keyServers entries have been
+  rewritten).
 
 Use `location_metadata physicalshards` for routine monitoring (is migration
 progressing?). Use `audit_storage metadata_encoding` for the final gate decision
@@ -436,7 +459,7 @@ serverKeys: 123004 entries
   New format (UID-encoded): 504
 dataMoves: 0 entries
 
-Migration status: ROLLBACK IN PROGRESS (221 keyServers + 504 serverKeys remaining)
+Migration status: MIGRATION IN PROGRESS (mixed format: 221 new keyServers, 504 new serverKeys)
 ```
 
 When all zeros:

--- a/design/shard-encode-location-metadata.md
+++ b/design/shard-encode-location-metadata.md
@@ -381,15 +381,13 @@ progressing?). Use `audit_storage metadata_encoding` for the final gate decision
 
 Extends the existing `audit_storage` fdbcli command with a new AuditType that
 reports encoding format state across keyServers and serverKeys. Used to confirm
-both forward migration completion and rollback readiness.
+both forward migration completion and rollback readiness. Runs client-side
+(immediate scan, not a distributed audit).
 
 ### Usage
 
 ```
-fdbcli> audit_storage validate_metadata_encoding
-Audit started with ID <uid>
-
-fdbcli> get_audit_status validate_metadata_encoding <uid>
+fdbcli> audit_storage metadata_encoding
 keyServers: 45021 entries
   Old format (tag-based): 0
   New format (UID-based): 45021
@@ -404,7 +402,7 @@ Migration status: FORWARD COMPLETE
 After rollback (knob flipped false, drain in progress):
 
 ```
-fdbcli> get_audit_status validate_metadata_encoding <uid>
+fdbcli> audit_storage metadata_encoding
 keyServers: 45021 entries
   Old format (tag-based): 44800
   New format (UID-based): 221

--- a/design/shard-encode-location-metadata.md
+++ b/design/shard-encode-location-metadata.md
@@ -32,6 +32,31 @@ Both paths use the same KRM primitives (`krmSetPreviouslyEmptyRange` for
 keyServers, `krmSetRangeCoalescing` for serverKeys). The difference is in the
 value encoding and the existence of DataMoveMetaData.
 
+**Coalescing behavior differs between paths.** In the old path, `serverKeys`
+values are boolean constants (`serverKeysTrue` / `serverKeysFalse`). Adjacent
+shards on the same SS with the same `true` value coalesce into a single KRM
+entry. In the new path, `serverKeys` values encode unique `dataMoveId` UIDs,
+and adjacent shards almost always have different UIDs (from different moves).
+This prevents KRM coalescing, keeping each shard as a separate KRM entry — see
+`unassignServerKeys()` at `MoveKeys.cpp:74` which explicitly works around
+`krmSetRangeCoalescing`'s inability to handle per-shard unique values.
+
+**This boundary enforcement is critical for bulkload.** Bulkload maps physical
+files to specific shard ranges (`DataMoveType::LOGICAL_BULKLOAD`). Without
+enforced boundaries, a coalesced KRM entry could span multiple file sets,
+making it impossible to determine which files belong to which shard. The fetch
+key data movement path does not require this — it fetches data per logical
+range regardless of KRM entry boundaries — but bulkload needs exact per-shard
+boundaries because it loads data from physical file sets rather than from
+source servers.
+
+**Downstream effect of no coalescing:** In the old path any code reading
+`serverKeys` saw a compact KRM (few entries per SS), so small reads with
+`krmGetRanges` were sufficient. In the new path the KRM has one entry per
+shard per SS, so reads iterate more entries and move operations write more
+boundaries per transaction — reflected in the 10× higher KRM row limit
+(`MOVE_SHARD_KRM_ROW_LIMIT=20000` vs `MOVE_KEYS_KRM_LIMIT=2000`).
+
 ### keyServers encoding change
 
 The old format stores **Tags** — small TLog stream identifiers (locality + id).

--- a/design/shard-encode-location-metadata.md
+++ b/design/shard-encode-location-metadata.md
@@ -1,0 +1,423 @@
+# SHARD_ENCODE_LOCATION_METADATA Feature Description
+
+## What It Is
+
+A feature flag (`SHARD_ENCODE_LOCATION_METADATA`) that enriches FDB's internal
+location metadata with persistent shard identities. It transitions the Data
+Distributor from reasoning about "which servers own which key ranges" to reasoning
+about "named shards with persistent identity."
+
+Default: `false` in production. Enabled 75% of the time in simulation.
+
+## Two Parallel Data Move Paths
+
+| Aspect | Old (`SHARD_ENCODE=false`) | New (`SHARD_ENCODE=true`) |
+|--------|---------------------------|--------------------------|
+| Entry point | `startMoveKeys` / `finishMoveKeys` | `startMoveShards` / `finishMoveShards` |
+| keyServers value | `{srcTag[], destTag[]}` | `{src[], dest[], srcId, destId}` |
+| serverKeys value | `serverKeysTrue` / `serverKeysFalse` | `serverKeysValue(shardId)` — actual shard UID |
+| Persistent move state | None | `\xff/dataMoves/<id>` = DataMoveMetaData |
+| Resume after DD restart | No (moves restart from scratch) | Yes (reads DataMoveMetaData) |
+| Checkpoint support | No | Yes (checkpoint IDs stored in DataMoveMetaData) |
+| Bulk load support | No | Yes (dataMoveId links to separate bulkLoadTask key space) |
+| Physical shard moves | No | Yes (via ENABLE_DD_PHYSICAL_SHARD) |
+| Data move auditing | No | Yes (AUDIT_DATAMOVE_PRE/POST_CHECK) |
+| Per-range replication (large teams) | Yes (DD_MAX_SHARDS_ON_LARGE_TEAMS) | Disabled |
+| Dispatch | `rawStartMovement()` → old path | `rawStartMovement()` → new path |
+
+All three dispatch points (`rawStartMovement`, `rawCheckFetchingState`,
+`rawFinishMovement`) branch on the knob to select old vs new path.
+
+Both paths use the same KRM primitives (`krmSetPreviouslyEmptyRange` for
+keyServers, `krmSetRangeCoalescing` for serverKeys). The difference is in the
+value encoding and the existence of DataMoveMetaData.
+
+### keyServers encoding change
+
+The old format stores **Tags** — small TLog stream identifiers (locality + id).
+To find the actual server UID for a Tag, you must join against `\xff/serverTag/`
+(the UIDtoTagMap). Every read of keyServers in the old path requires this extra
+range read to resolve Tags to UIDs.
+
+The new format stores **UIDs directly** — server identifiers are self-contained
+in the value. No join required. Additionally, the new format includes `srcId` and
+`destId` (shard/move identifiers) that link the entry to its DataMoveMetaData.
+
+## Architecture (New Path)
+
+```
++-----------------------------------------------------------+
+|                  Data Distributor (DD)                    |
+|                                                           |
+|  +---------------+       +---------------+                |
+|  | DD Scheduler  |------>| DD Relocator  |                |
+|  | (picks what   |       | (executes     |                |
+|  |  to move)     |       |  the move)    |                |
+|  +---------------+       +-------+-------+                |
++-----------------------------------|-----------------------+
+                                    |
+                                    v
++-----------------------------------------------------------+
+|                    MoveKeys Layer                         |
+|                                                           |
+|  +------------------+          +-------------------+      |
+|  | startMoveShards  |--------->| finishMoveShards  |      |
+|  |                  |          |                   |      |
+|  | Writes (1 txn):  |          | Writes (1 txn):  |       |
+|  |  - DM metadata   |          |  - keyServers:    |      |
+|  |  - keyServers:   |          |    merge dest->src|      |
+|  |    set destId    |          |    clear destId   |      |
+|  |  - serverKeys:   |          |  - serverKeys:    |      |
+|  |    assign range  |          |    unassign old   |      |
+|  |    to dest SS    |          |  - delete DM meta |      |
+|  +------------------+          +-------------------+      |
+|                                                           |
+|  All writes are system keys in the FDB database.          |
+|  SS learns about moves by processing serverKeys           |
+|   mutations from the mutation log (push-based).           |
+|                                                           |
+|  DM metadata = DataMoveMetaData in \xff/dataMoves/<id>    |
++-----------------------------------------------------------+
+                                    |
+                                    v
++-----------------------------------------------------------+
+|              Storage Servers (SS)                         |
+|                                                           |
+|  Source SS                         Dest SS                |
+|  +----------+                      +----------+           |
+|  | Has data |------ fetchKeys ---->| Fetching |           |
+|  | (in src) |      (or checkpoint) | (in dest)|           |
+|  +----------+                      +----------+           |
++-----------------------------------------------------------+
+```
+
+## Key Spaces
+
+```
+\xff/keyServers/<key>      = { src[], dest[], srcId, destId }
+\xff/serverKeys/<ssId>/<k> = { assigned, shardId, moveType }
+\xff/dataMoves/<moveId>    = DataMoveMetaData
+\xff/bulkLoadTask/<range>  = BulkLoadTaskState (for bulk load moves)
+```
+
+## DataMoveMetaData
+
+Serialized with `ObjectWriter` + `IncludeVersion()` (versioned, evolvable).
+
+```
++-----------------------------------+
+| DataMoveMetaData                  |
++-----------------------------------+
+| id:             UID               |
+| version:        Version           |
+| ranges:         vector<KeyRange>  |
+| phase:          Running|Deleting  |
+| priority:       int               |
+| src:            set<UID>          |
+| dest:           set<UID>          |
+| checkpoints:    set<UID>          |
+| mode:           int8              |
+| bulkLoadTaskState: Optional<...>  |
++-----------------------------------+
+```
+
+## dataMoveId Structure
+
+Generated by `newDataMoveId()` in DDRelocationQueue (upstream of startMoveShards):
+
+```
++----------------------------------+----------------------------------+
+|         First 64 bits            |         Second 64 bits           |
++----------------------------------+----------------------------------+
+|       physicalShardId            | [63:16] random                   |
+|       (random)                   | [15:8]  DataMovementReason       |
+|                                  | [7:0]   DataMoveType             |
++----------------------------------+----------------------------------+
+
+DataMoveType: LOGICAL, LOGICAL_BULKLOAD, PHYSICAL_BULKLOAD
+Sentinel: anonymousShardId = UID(0x666666, 0x88888888)
+```
+
+SS decodes the DataMoveType from the dataMoveId to determine fetch behavior.
+
+## Move Lifecycle
+
+```
+  startMoveShards                              finishMoveShards
+       |                                             |
+       v                                             v
++------------------+    SS fetches data    +------------------+
+| In Progress      |---------------------> | Complete         |
+|                  |                       |                  |
+| keyServers:      |                       | keyServers:      |
+|   src  = [A, B]  |                       |  src  = [A,B,C,D]|
+|   dest = [C, D]  |                       |  dest = []       |
+|   destId = X     |                       |  destId = 0      |
+|                  |                       |                  |
+| dataMoves/X:     |                       | dataMoves/X:     |
+|   phase=Running  |                       |   (deleted)      |
+|   dest=[C,D]     |                       |                  |
++------------------+                       +------------------+
+```
+
+## startMoveShards Steps
+
+1. Receives `dataMoveId` from DD relocator (already generated upstream)
+2. Write DataMoveMetaData to `\xff/dataMoves/<dataMoveId>`
+   - Records range, src servers, dest servers, phase=Running
+3. Update keyServers for each shard in range:
+   - Set `dest = [new servers]`, `destId = dataMoveId`
+   - Keeps `src` unchanged (still serving reads)
+4. Update serverKeys: write `\xff/serverKeys/<destSS>/<range> = serverKeysValue(dataMoveId)`
+   - This is a normal DB write in the same transaction
+   - SS picks it up later via mutation log
+5. Commit (single atomic transaction)
+
+## finishMoveShards Steps
+
+1. Read DataMoveMetaData from `\xff/dataMoves/<dataMoveId>`
+   - Gets dest servers from here (NOT from keyServers)
+2. Update keyServers for each shard:
+   - Merge: `src = src + dest`
+   - Clear: `dest = []`, `destId = 0`
+3. Update serverKeys: mark old src-only servers for removal
+4. Delete DataMoveMetaData entry
+5. Commit
+
+## How Storage Servers Work in Each Path
+
+SS involvement is entirely **push-based via the mutation log** in both paths.
+The SS never polls DD. The mechanism is identical; only the serverKeys value
+encoding differs.
+
+### Old path: SS behavior
+
+serverKeys values are boolean constants (`serverKeysTrue` / `serverKeysFalse`).
+
+- SS sees `serverKeys/<myId>/<range> = serverKeysTrue` → start `fetchKeys`
+- SS sees `serverKeys/<myId>/<range> = serverKeysFalse` → cancel fetch, drop range
+- If SS already has the range and sees `true` again → no-op (idempotent)
+
+There is no move identity. Every write is idempotent. DD doesn't "retry" — it
+just overwrites. If DD restarts and picks the same dest, the `serverKeysTrue`
+write is already there (no-op). If it picks a different dest, old dest gets
+`false` (cancel), new dest gets `true` (start).
+
+The SS cannot distinguish "continue existing fetch" from "start a new fetch for
+the same range." It doesn't need to — without bulk load, all fetches pull the
+same data from src servers regardless of which DD lifetime initiated them.
+
+### New path: SS behavior
+
+serverKeys values encode a UID containing the dataMoveId (which carries the
+DataMoveType in its lower bits).
+
+- SS sees `serverKeys/<myId>/<range> = UID` → decode type from UID bits
+  - If type is LOGICAL: start normal `fetchKeys` from src
+  - If type is LOGICAL_BULKLOAD: look up bulk load task, download from S3
+  - If type is PHYSICAL_BULKLOAD: look up checkpoint, restore from SST files
+- SS sees `serverKeys/<myId>/<range> = serverKeysFalse` → cancel, same as old path
+
+The dataMoveId lets the SS distinguish:
+- **Same ID as current fetch** → retry/continuation, keep going
+- **Different ID** → new task, restart fetch from scratch
+
+This distinction is critical for bulk load: if DD restarts and re-issues the same
+bulk load, SS must continue (not restart). If DD issues a DIFFERENT bulk load for
+the same range, SS must restart with the new S3 path.
+
+## Bulk Load Integration
+
+Bulk load piggybacks on the data move machinery:
+
+1. DD relocator generates a `dataMoveId` with `DataMoveType::LOGICAL_BULKLOAD`
+2. `startMoveShards` writes DataMoveMetaData and bulk load task state to
+   `\xff/bulkLoadTask/<range>` with the dataMoveId embedded
+3. The serverKeys mutation carries the dataMoveId to the dest SS
+4. Dest SS decodes the dataMoveId, sees LOGICAL_BULKLOAD type
+5. SS reads DataMoveMetaData to confirm, then looks up bulk load task
+6. SS downloads data from the bulk load source (e.g. S3)
+
+The dataMoveId links all three: keyServers entry, DataMoveMetaData, and bulk
+load task state.
+
+
+## Physical Shard Moves (ENABLE_DD_PHYSICAL_SHARD)
+
+Instead of SS fetching data key-by-key:
+
+1. `startMoveShards` creates a `CheckpointMetaData` entry per shard
+   - Stores checkpoint ID in `dataMove.checkpoints` (inside DataMoveMetaData)
+2. Source SS creates a RocksDB checkpoint (SST files)
+3. Dest SS reads DataMoveMetaData to find checkpoint IDs
+4. Dest SS restores from checkpoint (orders of magnitude faster than fetchKeys)
+5. Requires `RESUME_DATA_MOVES_ON_RESTART=true` (checkpoints must survive DD restart)
+
+## Encoding Details
+
+keyServers values are encoded with `BinaryWriter` using
+`ProtocolVersion::withShardEncodeLocationMetaData()` (`0x0FDB00B072000000`).
+The protocol version is embedded in each serialized value, so the decoder
+detects format per-value (not per-knob-setting). This enables mixed-format
+coexistence during rollout.
+
+At database creation, `SeedShardServers.cpp` generates initial shard IDs and
+writes them into both `\xff/keyServers/` and `\xff/serverKeys/` in the new format.
+
+## Features Gated on This Knob
+
+Requires `SHARD_ENCODE_LOCATION_METADATA=true`:
+- `ENABLE_DD_PHYSICAL_SHARD` (physical shard moves)
+- BulkLoad / BulkDump
+- `AUDIT_DATAMOVE_PRE_CHECK` / `AUDIT_DATAMOVE_POST_CHECK`
+- Sharded RocksDB storage engine
+
+Disabled when `SHARD_ENCODE_LOCATION_METADATA=true`:
+- Per-range replication ("large teams"): allows specific key ranges to have a higher
+  replication factor than the cluster default (e.g. range X gets 5 replicas when
+  cluster is configured for 3). DD builds oversized teams for those ranges. Not
+  supported by the shard-encoded path which assumes uniform team size.
+
+Enabling on an existing cluster works incrementally — new moves write new-format
+entries, old entries remain readable. A **storage wiggle** rewrites all entries
+into new format, which is needed only for full coverage of features that require
+shard IDs on every entry (auditing, bulk load). Basic DD operation works without it.
+
+## Rollout and Rollback
+
+### Rollout (enable knob)
+
+Safe — the new binary reads both formats. Mixed-format coexistence works because
+the decoder checks the protocol version embedded in each value.
+
+### Rollback within same binary (flip knob false)
+
+Safe — tested and verified in simulation (`ShardEncodeRollback.toml`):
+
+1. **Decoders handle both formats.** SS processes both old-format and shard-encoded
+   serverKeys mutations correctly regardless of its persistent `shardAware` flag.
+   No data loss from format mismatch.
+
+2. **DD restarts on knob change.** In production, changing the knob requires a
+   process restart. On restart, DD initializes with the new value and runs the
+   startup rewrite. In-flight actors from the old DD are cancelled.
+
+3. **DD rewrites keyServers on startup.** When DD restarts with knob=false, it
+   scans keyServers entries and rewrites shard-encoded ones to old tag-based format.
+   DataMoveMetaData entries are cleared.
+
+4. **serverKeys drains naturally.** Shard-encoded serverKeys entries are NOT
+   rewritten on startup (doing so causes KRM fragmentation and SS pair-processing
+   issues). They remain readable in both formats and drain to old format as DD
+   moves shards using the old path.
+
+5. **Safety net for rolling restarts.** During a rolling restart, an old DD
+   instance (not yet killed) may find its DataMoveMetaData cleared by a new DD
+   instance that already ran the startup rewrite. In this case, MoveKeys functions
+   throw `dd_config_changed` instead of asserting — causing the old DD to restart
+   once more and pick up the new knob value. This is at most one extra restart
+   per DD instance during the transition, not per-shard.
+
+The rollback procedure:
+1. Set `SHARD_ENCODE_LOCATION_METADATA=false`
+2. Restart the `fdbserver` processes (knob change requires restart)
+3. On DD init, keyServers entries are rewritten to old format and DataMoveMetaData is cleared
+4. DD proceeds with old path for all new moves
+5. serverKeys entries drain to old format as DD touches shards over time
+
+No need to stop writes or trigger wiggle.
+
+### Rollback to old binary (downgrade)
+
+NOT safe if shard-encoded values exist. Old binary cannot parse new-format
+serverKeys values. Requires a migration step (drain all entries to old format)
+before downgrade.
+
+### Migration for downgrade
+
+1. Set knob false, restart (DD uses old path, writes old format)
+2. Run background rewriter or trigger storage wiggle to touch all shards
+3. Verify completion: scan keyServers/serverKeys, confirm zero shard-encoded entries
+4. Clear `\xff/dataMoves/` range
+5. Safe to downgrade binary
+
+### Verifying migration state
+
+Two complementary tools:
+
+**`fdbcli> location_metadata physicalshards`** — quick check. Shows total shards
+vs physical (shard-encoded) shards. During forward migration, physical shards
+increase toward total. During rollback, they decrease toward zero. Fast,
+lightweight, no scanning required.
+
+**`fdbcli> audit_storage metadata_encoding`** — definitive check. Scans all
+keyServers and serverKeys entries, classifies each by protocol version header,
+counts dataMoves entries. Reports explicit migration status:
+FORWARD COMPLETE / ROLLBACK IN PROGRESS / ROLLBACK COMPLETE.
+
+Use `location_metadata physicalshards` for routine monitoring (is migration
+progressing?). Use `audit_storage metadata_encoding` for the final gate decision
+(is it safe to downgrade?).
+
+### Rollout/rollback summary
+
+```
+                     SAFE                         REQUIRES MIGRATION
+                      |                                  |
+  Old binary ----[upgrade]----> New binary ----[enable knob]----> Shard-encoded
+                      |              |                                  |
+                      |         [flip knob off]                   [drain + verify]
+                      |              |                                  |
+                      |              v                                  v
+                      |         New binary (old path)              New binary (old path)
+                      |              |                                  |
+                      |              |                            [downgrade]
+                      |              |                                  |
+                      |              v                                  v
+                      +--------> Old binary <--------------------------+
+```
+
+## Verifying Migration State: ValidateMetadataEncoding Audit
+
+Extends the existing `audit_storage` fdbcli command with a new AuditType that
+reports encoding format state across keyServers and serverKeys. Used to confirm
+both forward migration completion and rollback readiness.
+
+### Usage
+
+```
+fdbcli> audit_storage validate_metadata_encoding
+Audit started with ID <uid>
+
+fdbcli> get_audit_status validate_metadata_encoding <uid>
+keyServers: 45021 entries
+  Old format (tag-based): 0
+  New format (UID-based): 45021
+serverKeys: 123004 entries
+  Old format (constants): 0
+  New format (UID-encoded): 123004
+dataMoves: 3 entries (in-progress moves)
+
+Migration status: FORWARD COMPLETE
+```
+
+After rollback (knob flipped false, drain in progress):
+
+```
+fdbcli> get_audit_status validate_metadata_encoding <uid>
+keyServers: 45021 entries
+  Old format (tag-based): 44800
+  New format (UID-based): 221
+serverKeys: 123004 entries
+  Old format (constants): 122500
+  New format (UID-encoded): 504
+dataMoves: 0 entries
+
+Migration status: ROLLBACK IN PROGRESS (221 keyServers + 504 serverKeys remaining)
+```
+
+When all zeros:
+
+```
+Migration status: ROLLBACK COMPLETE — safe to downgrade binary
+```

--- a/fdbcli/AuditStorageCommand.cpp
+++ b/fdbcli/AuditStorageCommand.cpp
@@ -63,6 +63,7 @@
 #include "fdbclient/IClientApi.h"
 
 #include "fdbclient/ManagementAPI.h"
+#include "fdbclient/NativeAPI.actor.h"
 #include "fdbclient/Audit.h"
 
 #include "flow/Arena.h"
@@ -114,12 +115,21 @@ Future<UID> auditStorageCommandActor(Reference<IClusterConnectionRecord> cluster
 			type = AuditType::ValidateStorageServerShard;
 		} else if (tokencmp(tokens[1], "validate_restore")) {
 			type = AuditType::ValidateRestore;
+		} else if (tokencmp(tokens[1], "metadata_encoding")) {
+			type = AuditType::ValidateMetadataEncoding;
 		} else {
 			printUsage(tokens[0]);
 			co_return UID();
 		}
 
 		Key begin = allKeys.begin, end = allKeys.end;
+		if (type == AuditType::ValidateMetadataEncoding) {
+			// This audit runs client-side (simple scan, not distributed)
+			auto db = Database::createDatabase(clusterFile, ApiVersion::LATEST_VERSION);
+			UID auditId = deterministicRandom()->randomUniqueID();
+			co_await checkMetadataEncodingCommandActor(db, tokens);
+			co_return auditId;
+		}
 		if (tokens.size() == 3) {
 			begin = tokens[2];
 		} else if (tokens.size() == 4 || tokens.size() == 5) {
@@ -161,7 +171,7 @@ CommandFactory auditStorageFactory(
     CommandHelp("audit_storage <Type> [BeginKey EndKey] <EngineType>",
                 "Start an audit storage",
                 "Specify audit `Type' (only `ha' and `replica' and `locationmetadata' and "
-                "`ssshard' and `validate_restore' `Type' are supported currently), and\n"
+                "`ssshard' and `validate_restore' and `metadata_encoding' `Type' are supported currently), and\n"
                 "optionally a sub-range with `BeginKey' and `EndKey'.\n"
                 "Specify audit `EngineType' when auditType is `ha' or `replica'\n"
                 "(only `ssd-rocksdb-v1' and `ssd-sharded-rocksdb' and `ssd-2' are supported).\n"

--- a/fdbcli/CheckMetadataEncodingCommand.cpp
+++ b/fdbcli/CheckMetadataEncodingCommand.cpp
@@ -136,8 +136,9 @@ Future<bool> checkMetadataEncodingCommandActor(Database cx, std::vector<StringRe
 	} else if (keyServersOld == 0 && serverKeysOld == 0) {
 		fmt::println("Migration status: FORWARD COMPLETE");
 	} else if (keyServersNew > 0 || serverKeysNew > 0) {
-		int64_t remaining = keyServersNew + serverKeysNew;
-		fmt::println("Migration status: ROLLBACK IN PROGRESS ({} entries remaining)", remaining);
+		fmt::println("Migration status: MIGRATION IN PROGRESS (mixed format: {} new keyServers, {} new serverKeys)",
+		             keyServersNew,
+		             serverKeysNew);
 	} else {
 		fmt::println("Migration status: NOT STARTED (all old format)");
 	}

--- a/fdbcli/CheckMetadataEncodingCommand.cpp
+++ b/fdbcli/CheckMetadataEncodingCommand.cpp
@@ -1,0 +1,148 @@
+/*
+ * CheckMetadataEncodingCommand.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "fdbcli/fdbcli.h"
+#include "fdbclient/IClientApi.h"
+#include "fdbclient/SystemData.h"
+#include "flow/Arena.h"
+#include "flow/FastRef.h"
+#include "flow/ThreadHelper.actor.h"
+
+namespace fdb_cli {
+
+Future<bool> checkMetadataEncodingCommandActor(Database cx, std::vector<StringRef> tokens) {
+	int64_t keyServersOld = 0, keyServersNew = 0;
+	int64_t serverKeysOld = 0, serverKeysNew = 0;
+	int64_t dataMovesCount = 0;
+
+	// Scan keyServers
+	{
+		Key begin = keyServersPrefix;
+		Key end = keyServersEnd;
+		while (begin < end) {
+			Transaction tr(cx);
+			tr.setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
+			tr.setOption(FDBTransactionOptions::READ_LOCK_AWARE);
+			tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
+			Error err;
+			try {
+				RangeResult result = co_await tr.getRange(KeyRangeRef(begin, end), 1000);
+				for (const auto& kv : result) {
+					if (kv.value.empty()) {
+						keyServersOld++;
+						continue;
+					}
+					BinaryReader rd(kv.value, IncludeVersion());
+					if (rd.protocolVersion().hasShardEncodeLocationMetaData()) {
+						keyServersNew++;
+					} else {
+						keyServersOld++;
+					}
+				}
+				if (!result.more) {
+					break;
+				}
+				begin = keyAfter(result.back().key);
+				continue;
+			} catch (Error& e) {
+				err = e;
+			}
+			co_await tr.onError(err);
+		}
+	}
+
+	// Scan serverKeys
+	{
+		Key begin = serverKeysPrefix;
+		Key end = strinc(serverKeysPrefix);
+		while (begin < end) {
+			Transaction tr(cx);
+			tr.setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
+			tr.setOption(FDBTransactionOptions::READ_LOCK_AWARE);
+			tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
+			Error err;
+			try {
+				RangeResult result = co_await tr.getRange(KeyRangeRef(begin, end), 1000);
+				for (const auto& kv : result) {
+					if (kv.value == serverKeysTrue || kv.value == serverKeysFalse ||
+					    kv.value == serverKeysTrueEmptyRange) {
+						serverKeysOld++;
+					} else {
+						serverKeysNew++;
+					}
+				}
+				if (!result.more) {
+					break;
+				}
+				begin = keyAfter(result.back().key);
+				continue;
+			} catch (Error& e) {
+				err = e;
+			}
+			co_await tr.onError(err);
+		}
+	}
+
+	// Count dataMoves
+	{
+		Transaction tr(cx);
+		tr.setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
+		tr.setOption(FDBTransactionOptions::READ_LOCK_AWARE);
+		tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
+		Error err;
+		try {
+			RangeResult result = co_await tr.getRange(dataMoveKeys, CLIENT_KNOBS->TOO_MANY);
+			dataMovesCount = result.size();
+		} catch (Error& e) {
+			err = e;
+		}
+		if (err.isValid()) {
+			co_await tr.onError(err);
+		}
+	}
+
+	// Report
+	int64_t keyServersTotal = keyServersOld + keyServersNew;
+	int64_t serverKeysTotal = serverKeysOld + serverKeysNew;
+
+	fmt::println("keyServers: {} entries", keyServersTotal);
+	fmt::println("  Old format (tag-based): {}", keyServersOld);
+	fmt::println("  New format (UID-based): {}", keyServersNew);
+	fmt::println("serverKeys: {} entries", serverKeysTotal);
+	fmt::println("  Old format (constants): {}", serverKeysOld);
+	fmt::println("  New format (UID-encoded): {}", serverKeysNew);
+	fmt::println("dataMoves: {} entries", dataMovesCount);
+	fmt::println("");
+
+	if (keyServersNew == 0 && serverKeysNew == 0 && dataMovesCount == 0) {
+		fmt::println("Migration status: ROLLBACK COMPLETE — safe to downgrade binary");
+	} else if (keyServersOld == 0 && serverKeysOld == 0) {
+		fmt::println("Migration status: FORWARD COMPLETE");
+	} else if (keyServersNew > 0 || serverKeysNew > 0) {
+		int64_t remaining = keyServersNew + serverKeysNew;
+		fmt::println("Migration status: ROLLBACK IN PROGRESS ({} entries remaining)", remaining);
+	} else {
+		fmt::println("Migration status: NOT STARTED (all old format)");
+	}
+
+	co_return true;
+}
+
+} // namespace fdb_cli

--- a/fdbcli/GetAuditStatusCommand.cpp
+++ b/fdbcli/GetAuditStatusCommand.cpp
@@ -191,6 +191,8 @@ Future<bool> getAuditStatusCommandActor(Database cx, std::vector<StringRef> toke
 		type = AuditType::ValidateStorageServerShard;
 	} else if (tokencmp(tokens[1], "validate_restore")) {
 		type = AuditType::ValidateRestore;
+	} else if (tokencmp(tokens[1], "metadata_encoding")) {
+		type = AuditType::ValidateMetadataEncoding;
 	} else {
 		printUsage(tokens[0]);
 		co_return false;

--- a/fdbcli/include/fdbcli/fdbcli.h
+++ b/fdbcli/include/fdbcli/fdbcli.h
@@ -274,6 +274,8 @@ Future<UID> auditStorageCommandActor(Reference<IClusterConnectionRecord> cluster
 Future<bool> getAuditStatusCommandActor(Database cx, std::vector<StringRef> tokens);
 // Retrieve shard information command
 Future<bool> locationMetadataCommandActor(Database cx, std::vector<StringRef> tokens);
+// Check metadata encoding format (old vs shard-encoded)
+Future<bool> checkMetadataEncodingCommandActor(Database cx, std::vector<StringRef> tokens);
 // Bulk loading command
 Future<UID> bulkLoadCommandActor(Database cx, std::vector<StringRef> tokens);
 // Bulk dumping command

--- a/fdbclient/include/fdbclient/Audit.h
+++ b/fdbclient/include/fdbclient/Audit.h
@@ -40,6 +40,7 @@ enum class AuditType : uint8_t {
 	ValidateLocationMetadata = 3,
 	ValidateStorageServerShard = 4,
 	ValidateRestore = 5,
+	ValidateMetadataEncoding = 6,
 };
 
 struct AuditStorageState {

--- a/fdbserver/core/MoveKeys.cpp
+++ b/fdbserver/core/MoveKeys.cpp
@@ -719,7 +719,12 @@ Future<Void> cleanUpSingleShardDataMove(Database occ,
 			                                                  keys,
 			                                                  SERVER_KNOBS->MOVE_SHARD_KRM_ROW_LIMIT,
 			                                                  SERVER_KNOBS->MOVE_SHARD_KRM_BYTE_LIMIT);
-			ASSERT(!currentShards.more);
+			if (currentShards.more) {
+				// The data-move range has been subdivided into more shards than fit in
+				// one krmGetRanges page since this cleanup was scheduled. The caller's
+				// view is stale; let DD re-discover the current shard layout.
+				throw operation_cancelled();
+			}
 			if (currentShards.empty()) {
 				if (!SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA) {
 					throw dd_config_changed();
@@ -3384,7 +3389,9 @@ Future<Void> rawStartMovement(Database occ,
 		                       params.cancelConflictingDataMoves,
 		                       params.bulkLoadTaskState);
 	}
-	ASSERT(params.keys.present());
+	if (!params.keys.present()) {
+		throw dd_config_changed();
+	}
 	return startMoveKeys(std::move(occ),
 	                     params.keys.get(),
 	                     params.destinationTeam,
@@ -3412,7 +3419,9 @@ Future<Void> rawCheckFetchingState(const Database& cx,
 		                          params.relocationIntervalId,
 		                          tssMapping);
 	}
-	ASSERT(params.keys.present());
+	if (!params.keys.present()) {
+		throw dd_config_changed();
+	}
 	return checkFetchingState(cx,
 	                          params.healthyDestinations,
 	                          params.keys.get(),
@@ -3425,7 +3434,9 @@ Future<Void> rawFinishMovement(Database occ,
                                const MoveKeysParams& params,
                                const std::map<UID, StorageServerInterface>& tssMapping) {
 	if (SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA) {
-		ASSERT(params.ranges.present());
+		if (!params.ranges.present()) {
+			throw dd_config_changed();
+		}
 		return finishMoveShards(std::move(occ),
 		                        params.dataMoveId,
 		                        params.ranges.get(),
@@ -3438,7 +3449,9 @@ Future<Void> rawFinishMovement(Database occ,
 		                        params.ddEnabledState,
 		                        params.bulkLoadTaskState);
 	}
-	ASSERT(params.keys.present());
+	if (!params.keys.present()) {
+		throw dd_config_changed();
+	}
 	return finishMoveKeys(std::move(occ),
 	                      params.keys.get(),
 	                      params.destinationTeam,

--- a/fdbserver/core/MoveKeys.cpp
+++ b/fdbserver/core/MoveKeys.cpp
@@ -488,7 +488,9 @@ Future<Void> auditLocationMetadataPreCheck(Database occ,
                                            std::vector<UID> servers,
                                            std::string context,
                                            UID dataMoveId) {
-	// This code has only been tested with `SHARD_ENCODE_LOCATION_METADATA` enabled.
+	if (!SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA) {
+		throw dd_config_changed();
+	}
 	ASSERT(SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA);
 
 	if (range.empty()) {
@@ -556,7 +558,9 @@ Future<Void> auditLocationMetadataPreCheck(Database occ,
 }
 
 Future<Void> auditLocationMetadataPostCheck(Database occ, KeyRange range, std::string context, UID dataMoveId) {
-	// This code has only been tested with `SHARD_ENCODE_LOCATION_METADATA` enabled.
+	if (!SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA) {
+		throw dd_config_changed();
+	}
 	ASSERT(SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA);
 
 	if (range.empty()) {
@@ -691,6 +695,9 @@ Future<Void> cleanUpSingleShardDataMove(Database occ,
                                         FlowLock* cleanUpDataMoveParallelismLock,
                                         UID dataMoveId,
                                         const DDEnabledState* ddEnabledState) {
+	if (!SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA) {
+		throw dd_config_changed();
+	}
 	ASSERT(SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA);
 	TraceEvent(SevInfo, "CleanUpSingleShardDataMoveBegin", dataMoveId).detail("Range", keys);
 	static auto* counters = makeCounters("/movekeys/cleanUpSingleShardDataMove");
@@ -712,7 +719,13 @@ Future<Void> cleanUpSingleShardDataMove(Database occ,
 			                                                  keys,
 			                                                  SERVER_KNOBS->MOVE_SHARD_KRM_ROW_LIMIT,
 			                                                  SERVER_KNOBS->MOVE_SHARD_KRM_BYTE_LIMIT);
-			ASSERT(!currentShards.empty() && !currentShards.more);
+			ASSERT(!currentShards.more);
+			if (currentShards.empty()) {
+				if (!SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA) {
+					throw dd_config_changed();
+				}
+				ASSERT(!currentShards.empty());
+			}
 
 			RangeResult UIDtoTagMap = co_await tr.getRange(serverTagKeys, CLIENT_KNOBS->TOO_MANY);
 			ASSERT(!UIDtoTagMap.more && UIDtoTagMap.size() < CLIENT_KNOBS->TOO_MANY);
@@ -1740,7 +1753,17 @@ static Future<Void> startMoveShards(Database occ,
 						    .detail("BackgroundCleanUp", dataMove.ranges.empty());
 						throw data_move_cancelled();
 					}
-					ASSERT(!dataMove.ranges.empty() && dataMove.ranges.front().begin == keys.begin);
+					if (dataMove.ranges.empty() || dataMove.ranges.front().begin != keys.begin) {
+						// DataMoveMetaData unexpectedly empty or mismatched. During knob
+						// rollback, a concurrent DD instance may have cleared it via
+						// rewriteShardEncodedMetadata(). We can't assert here because the
+						// old DD still has knob=true (shared process in simulation) — the
+						// knob guard doesn't help. Throwing dd_config_changed restarts this
+						// DD instance, which then picks up the new knob value. In production
+						// (no concurrent DDs), this condition shouldn't occur; if it does,
+						// a restart is still safer than a crash.
+						throw dd_config_changed();
+					}
 					if (cancelDataMove) {
 						dataMove.setPhase(DataMoveMetaData::Deleting);
 						tr.set(dataMoveKeyFor(dataMoveId), dataMoveValue(dataMove));
@@ -3345,6 +3368,9 @@ Future<Void> rawStartMovement(Database occ,
                               const MoveKeysParams& params,
                               std::map<UID, StorageServerInterface>& tssMapping) {
 	if (SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA) {
+		if (!params.ranges.present()) {
+			throw dd_config_changed();
+		}
 		ASSERT(params.ranges.present());
 		return startMoveShards(std::move(occ),
 		                       params.dataMoveId,
@@ -3373,6 +3399,9 @@ Future<Void> rawCheckFetchingState(const Database& cx,
                                    const MoveKeysParams& params,
                                    const std::map<UID, StorageServerInterface>& tssMapping) {
 	if (SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA) {
+		if (!params.ranges.present()) {
+			throw dd_config_changed();
+		}
 		ASSERT(params.ranges.present());
 		// TODO: make startMoveShards work with multiple ranges.
 		ASSERT(params.ranges.get().size() == 1);

--- a/fdbserver/core/ServerKnobs.cpp
+++ b/fdbserver/core/ServerKnobs.cpp
@@ -316,7 +316,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 
 	init( ALLOW_LARGE_SHARD,                                   false ); if( randomize && buggify() )  ALLOW_LARGE_SHARD = true;
 	init( MAX_LARGE_SHARD_BYTES,                          1000000000 ); // 1G
-	init( SHARD_ENCODE_LOCATION_METADATA,                      false ); if( isSimulated ) SHARD_ENCODE_LOCATION_METADATA = deterministicRandom()->random01() < 0.75;
+	init( SHARD_ENCODE_LOCATION_METADATA,                      false ); if( isSimulated ) { bool v = deterministicRandom()->random01() < 0.75; if( !explicitlySetKnobs.count("shard_encode_location_metadata") ) SHARD_ENCODE_LOCATION_METADATA = v; }
 	init( ENABLE_DD_PHYSICAL_SHARD,                            false ); // EXPERIMENTAL; If true, SHARD_ENCODE_LOCATION_METADATA must be true; When true, optimization of data move between DCs is disabled
 	init( DD_PHYSICAL_SHARD_MOVE_PROBABILITY,                    0.0 ); // FIXME: re-enable after ShardedRocksDB is well tested by simulation
 	init( ENABLE_PHYSICAL_SHARD_MOVE_EXPERIMENT,               false ); // FIXME: re-enable after ShardedRocksDB is well tested by simulation

--- a/fdbserver/datadistributor/DDRelocationQueue.actor.cpp
+++ b/fdbserver/datadistributor/DDRelocationQueue.actor.cpp
@@ -3007,7 +3007,7 @@ struct DDQueueImpl {
 			if (e.code() != error_code_broken_promise && // FIXME: Get rid of these broken_promise errors every time
 			                                             // we are killed by the master dying
 			    e.code() != error_code_movekeys_conflict && e.code() != error_code_data_move_cancelled &&
-			    e.code() != error_code_data_move_dest_team_not_found)
+			    e.code() != error_code_data_move_dest_team_not_found && e.code() != error_code_dd_config_changed)
 				TraceEvent(SevError, "DataDistributionQueueError", self->distributorId).error(e);
 			throw e;
 		}

--- a/fdbserver/datadistributor/DDTxnProcessor.cpp
+++ b/fdbserver/datadistributor/DDTxnProcessor.cpp
@@ -300,11 +300,32 @@ class DDTxnProcessorImpl {
 		co_return Optional<Key>();
 	}
 
-	// When SHARD_ENCODE_LOCATION_METADATA is false, rewrite any shard-encoded metadata
-	// to old format. Clears DataMoveMetaData and converts keyServers entries from
-	// UID-based to tag-based encoding. Returns true if a rewrite was committed
-	// (caller should re-read). serverKeys entries are left in place — they drain
-	// naturally as DD moves shards using the old path.
+	// When SHARD_ENCODE_LOCATION_METADATA is false on DD init, do a bounded
+	// rewrite to start the rollback. Two phases, both bounded:
+	//
+	// Phase 1: Clear all DataMoveMetaData (single transaction; the dataMoves
+	// keyspace is small, this is always one commit).
+	//
+	// Phase 2: Rewrite up to 1000 keyServers entries at the head of the
+	// prefix from new (UID-based) to old (tag-based) format. Returns true
+	// if either phase committed; the caller restarts the outer init loop
+	// and calls back in. The Phase-2 cap means clusters with more than
+	// 1000 shard-encoded keyServers entries are NOT fully rewritten by
+	// this function — by design. Bulk rewrite happens through normal
+	// shard movement / storage wiggle once the knob is false (see the
+	// "Migration for downgrade" section of
+	// design/shard-encode-location-metadata.md); this function just
+	// clears dataMoves and rewrites the small remnant at the head so DD
+	// init has a tidy starting point.
+	//
+	// Calling this when nothing needs rewriting (knob has been false the
+	// whole time, or rollback already complete) is safe and
+	// write-cost-free: the reads find no shard-encoded entries, no
+	// commits happen, returns false. Cost is three system-key reads on
+	// every DD init when knob is false.
+	//
+	// serverKeys entries are left in place — they drain naturally as DD
+	// moves shards using the old path.
 	static Future<bool> rewriteShardEncodedMetadata(Transaction& tr, UID distributorId) {
 		TraceEvent(SevInfo, "DDInitShardEncodeOff", distributorId)
 		    .detail("KnobValue", SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA);

--- a/fdbserver/datadistributor/DDTxnProcessor.cpp
+++ b/fdbserver/datadistributor/DDTxnProcessor.cpp
@@ -300,6 +300,67 @@ class DDTxnProcessorImpl {
 		co_return Optional<Key>();
 	}
 
+	// When SHARD_ENCODE_LOCATION_METADATA is false, rewrite any shard-encoded metadata
+	// to old format. Clears DataMoveMetaData and converts keyServers entries from
+	// UID-based to tag-based encoding. Returns true if a rewrite was committed
+	// (caller should re-read). serverKeys entries are left in place — they drain
+	// naturally as DD moves shards using the old path.
+	static Future<bool> rewriteShardEncodedMetadata(Transaction& tr, UID distributorId) {
+		TraceEvent(SevInfo, "DDInitShardEncodeOff", distributorId)
+		    .detail("KnobValue", SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA);
+		tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+		tr.setOption(FDBTransactionOptions::LOCK_AWARE);
+
+		// Phase 1: Clear all DataMoveMetaData
+		RangeResult dmsCheck = co_await tr.getRange(dataMoveKeys, CLIENT_KNOBS->TOO_MANY);
+		ASSERT(!dmsCheck.more && dmsCheck.size() < CLIENT_KNOBS->TOO_MANY);
+		if (!dmsCheck.empty()) {
+			TraceEvent(SevWarnAlways, "DDInitCancellingShardEncodedMoves", distributorId)
+			    .detail("Count", dmsCheck.size());
+			tr.clear(dataMoveKeys);
+			co_await tr.commit();
+			tr.reset();
+			tr.setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
+			tr.setOption(FDBTransactionOptions::READ_LOCK_AWARE);
+			tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
+			co_return true;
+		}
+
+		// Phase 2: Rewrite shard-encoded keyServers entries to old format
+		RangeResult UIDtoTagMap = co_await tr.getRange(serverTagKeys, CLIENT_KNOBS->TOO_MANY);
+		ASSERT(!UIDtoTagMap.more && UIDtoTagMap.size() < CLIENT_KNOBS->TOO_MANY);
+
+		bool rewroteAny = false;
+		RangeResult ksEntries = co_await tr.getRange(
+		    KeyRangeRef(keyServersPrefix, keyServersEnd), 1000);
+		for (const auto& kv : ksEntries) {
+			if (kv.value.empty())
+				continue;
+			BinaryReader rd(kv.value, IncludeVersion());
+			if (rd.protocolVersion().hasShardEncodeLocationMetaData()) {
+				std::vector<UID> src, dest;
+				UID srcId, destId;
+				decodeKeyServersValue(UIDtoTagMap, kv.value, src, dest, srcId, destId);
+				Value oldValue = keyServersValue(UIDtoTagMap, src, dest);
+				tr.set(kv.key, oldValue);
+				rewroteAny = true;
+			}
+		}
+
+		if (rewroteAny) {
+			TraceEvent(SevInfo, "DDInitRewritingShardEncodedMetadata", distributorId)
+			    .detail("KeyServersEntries", ksEntries.size());
+			co_await tr.commit();
+			tr.reset();
+			tr.setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
+			tr.setOption(FDBTransactionOptions::READ_LOCK_AWARE);
+			tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
+			co_return true;
+		}
+
+		co_return false;
+	}
+
 	// Read keyservers, return unique set of teams
 	static Future<Reference<InitialDataDistribution>> getInitialDataDistribution(Database cx,
 	                                                                             UID distributorId,
@@ -389,6 +450,13 @@ class DDTxnProcessorImpl {
 						server_dc[ssi.id()] = ssi.locality.dcId();
 					} else {
 						tss_servers.emplace_back(ssi, id_data[ssi.locality.processId()].processClass);
+					}
+				}
+
+				// If SHARD_ENCODE is off, rewrite any shard-encoded metadata to old format.
+				if (!SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA) {
+					if (co_await rewriteShardEncodedMetadata(tr, distributorId)) {
+						continue; // Committed a rewrite — re-read from the top
 					}
 				}
 

--- a/fdbserver/datadistributor/DDTxnProcessor.cpp
+++ b/fdbserver/datadistributor/DDTxnProcessor.cpp
@@ -326,7 +326,10 @@ class DDTxnProcessorImpl {
 			co_return true;
 		}
 
-		// Phase 2: Rewrite shard-encoded keyServers entries to old format
+		// Phase 2: Rewrite shard-encoded keyServers entries to old format.
+		// Reads 1000 entries per iteration. Caller loops (co_return true triggers
+		// re-entry) until no shard-encoded entries remain. Previously-rewritten
+		// entries won't match hasShardEncodeLocationMetaData() on re-read.
 		RangeResult UIDtoTagMap = co_await tr.getRange(serverTagKeys, CLIENT_KNOBS->TOO_MANY);
 		ASSERT(!UIDtoTagMap.more && UIDtoTagMap.size() < CLIENT_KNOBS->TOO_MANY);
 

--- a/fdbserver/datadistributor/DDTxnProcessor.cpp
+++ b/fdbserver/datadistributor/DDTxnProcessor.cpp
@@ -334,8 +334,7 @@ class DDTxnProcessorImpl {
 		ASSERT(!UIDtoTagMap.more && UIDtoTagMap.size() < CLIENT_KNOBS->TOO_MANY);
 
 		bool rewroteAny = false;
-		RangeResult ksEntries = co_await tr.getRange(
-		    KeyRangeRef(keyServersPrefix, keyServersEnd), 1000);
+		RangeResult ksEntries = co_await tr.getRange(KeyRangeRef(keyServersPrefix, keyServersEnd), 1000);
 		for (const auto& kv : ksEntries) {
 			if (kv.value.empty())
 				continue;

--- a/fdbserver/datadistributor/DataDistribution.cpp
+++ b/fdbserver/datadistributor/DataDistribution.cpp
@@ -84,6 +84,7 @@ std::set<int> const& normalDDQueueErrors() {
 		                    error_code_broken_promise,
 		                    error_code_data_move_cancelled,
 		                    error_code_data_move_dest_team_not_found,
+		                    error_code_dd_config_changed,
 		                    error_code_finish_move_keys_too_many_retries,
 		                    error_code_start_move_keys_too_many_retries };
 	return s;
@@ -354,6 +355,7 @@ Future<UID> launchAudit(Reference<DataDistributor> self,
                         KeyValueStoreType auditStorageEngineType);
 Future<Void> auditStorage(Reference<DataDistributor> self, TriggerAuditRequest req);
 Future<Void> periodicAuditLocationMetadata(Reference<DataDistributor> self);
+Future<Void> monitorShardEncodeKnob(UID ddId);
 void loadAndDispatchAudit(Reference<DataDistributor> self, std::shared_ptr<DDAudit> audit);
 Future<Void> dispatchAuditStorageServerShard(Reference<DataDistributor> self, std::shared_ptr<DDAudit> audit);
 Future<Void> scheduleAuditStorageShardOnServer(Reference<DataDistributor> self,
@@ -2973,6 +2975,8 @@ Future<Void> dataDistribution(Reference<DataDistributor> self,
 
 			actors.push_back(periodicAuditLocationMetadata(self));
 
+			actors.push_back(monitorShardEncodeKnob(self->ddId));
+
 			co_await waitForAll(actors);
 			ASSERT_WE_THINK(false);
 			co_return;
@@ -3047,6 +3051,22 @@ static std::set<int> const& normalDataDistributorErrors() {
 		s.insert(error_code_audit_storage_failed);
 	}
 	return s;
+}
+
+// Monitor SHARD_ENCODE_LOCATION_METADATA knob for changes. If flipped mid-run,
+// throw dd_config_changed to restart DD cleanly (preventing in-flight move actors
+// from hitting asserts due to knob/path mismatch).
+Future<Void> monitorShardEncodeKnob(UID ddId) {
+	bool initial = SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA;
+	loop {
+		co_await delay(5.0);
+		if (SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA != initial) {
+			TraceEvent(SevInfo, "DDShardEncodeKnobChanged", ddId)
+			    .detail("OldValue", initial)
+			    .detail("NewValue", SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA);
+			throw dd_config_changed();
+		}
+	}
 }
 
 template <class Req>

--- a/fdbserver/workloads/CheckMetadataEncoding.cpp
+++ b/fdbserver/workloads/CheckMetadataEncoding.cpp
@@ -1,0 +1,181 @@
+/*
+ * CheckMetadataEncoding.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Workload that verifies keyServers and serverKeys encoding format matches the
+// SHARD_ENCODE_LOCATION_METADATA knob. Used to validate forward migration and
+// rollback of the shard-encoded metadata feature.
+
+#include "fdbclient/NativeAPI.actor.h"
+#include "fdbclient/SystemData.h"
+#include "fdbserver/core/Knobs.h"
+#include "fdbserver/tester/workloads.h"
+#include "flow/Error.h"
+#include "flow/flow.h"
+
+struct CheckMetadataEncodingWorkload : TestWorkload {
+	static constexpr auto NAME = "CheckMetadataEncoding";
+
+	bool shardEncodeExpected;
+	bool allowMixedFormats; // True in rollback scenarios where old entries remain
+	bool requireKnobFalse; // If true, assert that SHARD_ENCODE is actually false
+
+	explicit CheckMetadataEncodingWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
+		shardEncodeExpected = SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA;
+		allowMixedFormats = getOption(options, "allowMixedFormats"_sr, false);
+		requireKnobFalse = getOption(options, "requireKnobFalse"_sr, false);
+	}
+
+	Future<Void> setup(Database const& cx) override {
+		if (requireKnobFalse && SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA) {
+			TraceEvent(SevError, "CheckMetadataEncodingKnobNotFalse")
+			    .detail("Expected", false)
+			    .detail("Actual", SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA)
+			    .detail("Hint",
+			            "TOML [[knobs]] override for shard_encode_location_metadata "
+			            "did not take effect. The knob infrastructure fix may not be working.");
+		}
+		return Void();
+	}
+	Future<Void> start(Database const& cx) override {
+		if (clientId != 0)
+			return Void();
+		return _start(this, cx);
+	}
+
+	Future<bool> check(Database const& cx) override { return true; }
+	void getMetrics(std::vector<PerfMetric>& m) override {}
+
+	Future<Void> _start(CheckMetadataEncodingWorkload* self, Database cx) {
+		int64_t keyServersOld = 0, keyServersNew = 0;
+		int64_t serverKeysOld = 0, serverKeysNew = 0;
+
+		// Scan keyServers
+		{
+			Key begin = keyServersPrefix;
+			Key end = keyServersEnd;
+			while (begin < end) {
+				Transaction tr(cx);
+				tr.setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
+				tr.setOption(FDBTransactionOptions::READ_LOCK_AWARE);
+				Error err;
+				try {
+					RangeResult result = co_await tr.getRange(KeyRangeRef(begin, end), 1000);
+					for (const auto& kv : result) {
+						if (kv.value.empty()) {
+							keyServersOld++;
+							continue;
+						}
+						BinaryReader rd(kv.value, IncludeVersion());
+						if (rd.protocolVersion().hasShardEncodeLocationMetaData()) {
+							keyServersNew++;
+						} else {
+							keyServersOld++;
+						}
+					}
+					if (!result.more) {
+						break;
+					}
+					begin = keyAfter(result.back().key);
+				} catch (Error& e) {
+					err = e;
+				}
+				if (err.isValid()) {
+					co_await tr.onError(err);
+				}
+			}
+		}
+
+		// Scan serverKeys
+		{
+			Key begin = serverKeysPrefix;
+			Key end = strinc(serverKeysPrefix);
+			while (begin < end) {
+				Transaction tr(cx);
+				tr.setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
+				tr.setOption(FDBTransactionOptions::READ_LOCK_AWARE);
+				Error err;
+				try {
+					RangeResult result = co_await tr.getRange(KeyRangeRef(begin, end), 1000);
+					for (const auto& kv : result) {
+						if (kv.value == serverKeysTrue || kv.value == serverKeysFalse ||
+						    kv.value == serverKeysTrueEmptyRange) {
+							serverKeysOld++;
+						} else {
+							serverKeysNew++;
+						}
+					}
+					if (!result.more) {
+						break;
+					}
+					begin = keyAfter(result.back().key);
+				} catch (Error& e) {
+					err = e;
+				}
+				if (err.isValid()) {
+					co_await tr.onError(err);
+				}
+			}
+		}
+
+		TraceEvent("CheckMetadataEncodingResult")
+		    .detail("ShardEncodeExpected", self->shardEncodeExpected)
+		    .detail("KeyServersOld", keyServersOld)
+		    .detail("KeyServersNew", keyServersNew)
+		    .detail("ServerKeysOld", serverKeysOld)
+		    .detail("ServerKeysNew", serverKeysNew);
+
+		if (self->shardEncodeExpected) {
+			// With SHARD_ENCODE=true and moves having occurred, we expect new-format entries.
+			// There may still be old-format entries if not all shards have been moved yet.
+			if (keyServersNew == 0) {
+				TraceEvent(SevError, "CheckMetadataEncodingFailed")
+				    .detail("Reason", "Expected new-format keyServers entries but found none")
+				    .detail("KeyServersOld", keyServersOld)
+				    .detail("KeyServersNew", keyServersNew);
+			}
+			if (serverKeysNew == 0) {
+				TraceEvent(SevError, "CheckMetadataEncodingFailed")
+				    .detail("Reason", "Expected new-format serverKeys entries but found none")
+				    .detail("ServerKeysOld", serverKeysOld)
+				    .detail("ServerKeysNew", serverKeysNew);
+			}
+		} else {
+			// With SHARD_ENCODE=false on a fresh cluster, all entries should be old format.
+			// In a rollback scenario (allowMixedFormats), leftover new-format entries from
+			// the prior phase are expected and not an error.
+			if (keyServersNew > 0 && !self->allowMixedFormats) {
+				TraceEvent(SevError, "CheckMetadataEncodingFailed")
+				    .detail("Reason", "Expected all old-format keyServers but found new-format entries")
+				    .detail("KeyServersOld", keyServersOld)
+				    .detail("KeyServersNew", keyServersNew);
+			}
+			if (serverKeysNew > 0 && !self->allowMixedFormats) {
+				TraceEvent(SevError, "CheckMetadataEncodingFailed")
+				    .detail("Reason", "Expected all old-format serverKeys but found new-format entries")
+				    .detail("ServerKeysOld", serverKeysOld)
+				    .detail("ServerKeysNew", serverKeysNew);
+			}
+		}
+
+		co_return;
+	}
+};
+
+WorkloadFactory<CheckMetadataEncodingWorkload> CheckMetadataEncodingWorkloadFactory;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -187,6 +187,9 @@ if(WITH_PYTHON)
   add_fdb_test(TEST_FILES fast/LowLatencySingleClog.toml IGNORE)
   add_fdb_test(TEST_FILES fast/MemoryLifetime.toml)
   add_fdb_test(TEST_FILES fast/MoveKeysCycle.toml)
+  add_fdb_test(TEST_FILES fast/CheckMetadataEncodingForward.toml)
+  add_fdb_test(TEST_FILES fast/CheckMetadataEncodingOldPath.toml)
+  add_fdb_test(TEST_FILES fast/ShardEncodeRollback.toml)
   add_fdb_test(TEST_FILES fast/MutationLogReaderCorrectness.toml)
 
   add_fdb_test(TEST_FILES fast/GetEstimatedRangeSize.toml)
@@ -389,6 +392,10 @@ if(WITH_PYTHON)
     add_fdb_test(
       TEST_FILES restarting/to_8.0.0/CycleTestRestart-1.toml
       restarting/to_8.0.0/CycleTestRestart-2.toml)
+    add_fdb_test(
+      TEST_FILES restarting/to_8.0.0/ShardEncodeRollback-1.toml
+      restarting/to_8.0.0/ShardEncodeRollback-2.toml
+      IGNORE)
   endif()
 
   add_fdb_test(TEST_FILES slow/ApiCorrectness.toml)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -392,10 +392,6 @@ if(WITH_PYTHON)
     add_fdb_test(
       TEST_FILES restarting/to_8.0.0/CycleTestRestart-1.toml
       restarting/to_8.0.0/CycleTestRestart-2.toml)
-    add_fdb_test(
-      TEST_FILES restarting/to_8.0.0/ShardEncodeRollback-1.toml
-      restarting/to_8.0.0/ShardEncodeRollback-2.toml
-      IGNORE)
   endif()
 
   add_fdb_test(TEST_FILES slow/ApiCorrectness.toml)

--- a/tests/fast/CheckMetadataEncodingForward.toml
+++ b/tests/fast/CheckMetadataEncodingForward.toml
@@ -1,0 +1,17 @@
+[[knobs]]
+shard_encode_location_metadata = true
+
+[[test]]
+testTitle = 'CheckMetadataEncodingForward'
+
+    [[test.workload]]
+    testName = 'Cycle'
+    transactionsPerSecond = 2500.0
+    testDuration = 10.0
+
+    [[test.workload]]
+    testName = 'RandomMoveKeys'
+    testDuration = 10.0
+
+    [[test.workload]]
+    testName = 'CheckMetadataEncoding'

--- a/tests/fast/CheckMetadataEncodingOldPath.toml
+++ b/tests/fast/CheckMetadataEncodingOldPath.toml
@@ -1,0 +1,21 @@
+# Sharded RocksDB requires SHARD_ENCODE=true, exclude it.
+[configuration]
+storageEngineExcludeTypes=[3,4,5]
+
+[[knobs]]
+shard_encode_location_metadata = false
+
+[[test]]
+testTitle = 'CheckMetadataEncodingOldPath'
+
+    [[test.workload]]
+    testName = 'Cycle'
+    transactionsPerSecond = 2500.0
+    testDuration = 10.0
+
+    [[test.workload]]
+    testName = 'RandomMoveKeys'
+    testDuration = 10.0
+
+    [[test.workload]]
+    testName = 'CheckMetadataEncoding'

--- a/tests/fast/ShardEncodeRollback.toml
+++ b/tests/fast/ShardEncodeRollback.toml
@@ -1,0 +1,60 @@
+# Exclude sharded RocksDB (type 5) — it requires SHARD_ENCODE=true and
+# cannot operate after the knob flips to false.
+[configuration]
+storageEngineExcludeTypes=[3,4,5]
+
+# Top-level: SHARD_ENCODE=false is the "final" state.
+# Block 1 overrides to true temporarily.
+[[knobs]]
+shard_encode_location_metadata = false
+
+[[test]]
+testTitle = 'ShardEncodeRollbackSetup'
+
+    # Phase 1: Override to true. Create shard-encoded entries via data moves.
+    [[test.knobs]]
+    shard_encode_location_metadata = true
+
+    [[test.workload]]
+    testName = 'Cycle'
+    transactionsPerSecond = 2500.0
+    nodeCount = 2500
+    testDuration = 10.0
+
+    [[test.workload]]
+    testName = 'RandomMoveKeys'
+    testDuration = 10.0
+
+[[test]]
+testTitle = 'ShardEncodeRollbackVerify'
+
+    # Phase 2: No per-test override — inherits top-level false.
+    # DD detects knob change, restarts, exercises rollback path.
+
+    [[test.workload]]
+    testName = 'Cycle'
+    transactionsPerSecond = 2500.0
+    nodeCount = 2500
+    testDuration = 30.0
+
+    [[test.workload]]
+    testName = 'RandomMoveKeys'
+    testDuration = 30.0
+
+    [[test.workload]]
+    testName = 'Attrition'
+    machinesToKill = 1
+    machinesToLeave = 3
+    reboot = true
+    testDuration = 30.0
+
+    # Force TLog recovery to verify mixed-format metadata survives recovery.
+    [[test.workload]]
+    testName = 'Rollback'
+    meanDelay = 15.0
+    testDuration = 30.0
+
+    [[test.workload]]
+    testName = 'CheckMetadataEncoding'
+    requireKnobFalse = true
+    allowMixedFormats = true


### PR DESCRIPTION
SHARD_ENCODE_LOCATION_METADATA is needed for bulkload used in v3 backup.  This PR adds doc on what SHARD_ENCODE_LOCATION_METADATA enables as well as, tooling and code to support safe SHARD_ENCODE_LOCATION_METADATA rollback and migration verification:

audit_storage metadata_encoding:
  New AuditType that scans keyServers and serverKeys to report encoding
  format counts (old tag-based vs new UID-based). Reports migration
  status: FORWARD COMPLETE / ROLLBACK IN PROGRESS / ROLLBACK COMPLETE.

DD startup rewrite (DDTxnProcessor.cpp):
  When SHARD_ENCODE=false, clears stale DataMoveMetaData and rewrites
  shard-encoded keyServers entries to old format. serverKeys entries are
  left in place (readable in both formats, drain naturally).

MoveKeys graceful bail (MoveKeys.cpp):
  Functions that require shard-encoding throw dd_config_changed instead
  of asserting when they detect the knob flipped or DataMoveMetaData is
  unexpectedly empty from a concurrent DD restart.

Error handling (DataDistribution.cpp, DDRelocationQueue.actor.cpp):
  dd_config_changed added to normalDDQueueErrors to prevent SevError
  logging for expected operational restarts.

Knob infrastructure (ServerKnobs.cpp):
  SHARD_ENCODE randomization respects explicitlySetKnobs so TOML
  overrides take effect in simulation tests.

Tests:
  - CheckMetadataEncodingForward.toml: verifies new-format entries
  - CheckMetadataEncodingOldPath.toml: verifies old-format entries
  - ShardEncodeRollback.toml: full rollback test with Attrition, Rollback (TLog recovery), data consistency check

Documentation:
  - design/shard-encode-location-metadata.md: full feature description

`  20260602-172719-stack_knob-a4a87ca7a1ee4508        compressed=True data_size=37209627 duration=1890466 ended=100000 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:36:10 sanity=False started=100000 stopped=20260602-180329 submitted=20260602-172719 timeout=5400 username=stack_knob`