### PR TITLE
Apply multiple partition maps during old-epoch backup worker processing

### DIFF
--- a/fdbserver/backupworker/BackupWorkerRangePartitioned.cpp
+++ b/fdbserver/backupworker/BackupWorkerRangePartitioned.cpp
@@ -83,12 +83,6 @@ struct BackupRangePartitionedData {
 	Reference<FlowLock> lock;
 	AsyncTrigger doneTrigger;
 	AsyncTrigger changedTrigger;
-	// Pending partition maps to apply, in version order. Two sources fill this:
-	//   - At startup, an old-epoch worker preloads its remaining history from SS.
-	//   - During pulling, the current-epoch worker pushes any new partition map it sees in the TLog stream.
-	// uploadData picks them up: when its current batch of mutations reaches a queued version, it
-	// finishes saving the mutations under the old map, switches to the new map, and continues.
-	std::deque<std::pair<Version, PartitionMap>> pmUpdateQueue;
 	// Set to true when the worker is shutting down (e.g., worker_removed). Used by uploadData to exit gracefully via
 	// allMessageSaved(), letting in-flight file writes and progress commits finish first.
 	bool stopped = false;
@@ -429,12 +423,12 @@ Future<Void> persistPartitionMapToSS(BackupRangePartitionedData* self,
 	}
 }
 
-// Reads partition map entries persisted for `epoch` from system keys, starting from the entry active at
-// `startVersion` (the largest version <= startVersion). Earlier entries don't apply to mutations the worker
-// will process, so we skip them at the SS read.
-Future<PartitionMapHistory> loadPartitionMapHistoryFromSS(BackupRangePartitionedData* self,
-                                                          LogEpoch epoch,
-                                                          Version startVersion) {
+// Reads the partition map active at `startVersion` for `epoch` from system keys. Any later re-partitions
+// in this epoch arrive via the TLog cursor like a current-epoch worker, so we only need this one entry.
+// Returns empty if no entry exists for this epoch (e.g., recovery happened before persistPartitionMapToSS).
+Future<Optional<std::pair<Version, PartitionMap>>> loadActivePartitionMapFromSS(BackupRangePartitionedData* self,
+                                                                                LogEpoch epoch,
+                                                                                Version startVersion) {
 	Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(self->cx));
 	KeyRange range = backupPartitionMapHistoryRangeFor(epoch);
 
@@ -445,35 +439,54 @@ Future<PartitionMapHistory> loadPartitionMapHistoryFromSS(BackupRangePartitioned
 			tr->setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
 			tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 
-			// Find the entry active at startVersion for this worker. If none exists at or before that
-			// version, fall back to the first entry of this epoch.
-			// e.g., startVersion for this worker=80 with entries at versions [1, 50, 90, 95]: starts from 50.
-			Key probedBegin =
-			    co_await tr->getKey(lastLessOrEqual(backupPartitionMapHistoryKeyFor(epoch, startVersion)));
-			Key beginKey = probedBegin >= range.begin ? probedBegin : Key(range.begin);
-
-			PartitionMapHistory history;
-			while (true) {
-				RangeResult rows = co_await tr->getRange(KeyRangeRef(beginKey, range.end), CLIENT_KNOBS->TOO_MANY);
-				for (auto const& kv : rows) {
-					auto [decodedEpoch, version] = decodeBackupPartitionMapHistoryKey(kv.key);
-					ASSERT_EQ(decodedEpoch, epoch);
-
-					PartitionMap pm;
-					BinaryReader reader(kv.value, IncludeVersion());
-					reader >> pm;
-					history.emplace_back(version, std::move(pm));
-				}
-				if (!rows.more) {
-					break;
-				}
-				beginKey = keyAfter(rows.back().key);
+			// Goal: find the partition map that was active at this worker's startVersion within `epoch`.
+			//
+			// Example: epoch=5, startVersion=80. SS has entries at:
+			//   [epoch=5, v=1], [epoch=5, v=50], [epoch=5, v=90], [epoch=5, v=95]
+			// We want the entry at v=50 (largest version <= 80 in epoch 5).
+			//
+			// getRange is used here so we get both the key and the value back in a single round trip
+			//   - begin = lastLessOrEqual([epoch=5, v=80])
+			//             "find the largest actual key in the DB <= this target".
+			//             For our example, FDB resolves it to [epoch=5, v=50].
+			//   - end   = firstGreaterOrEqual(range.end)
+			//             range.end = [epoch=6, v=0] (one past this epoch's keys), so the search
+			//             never reads beyond this epoch.
+			//   - limit = 1
+			//             We only need that one entry.
+			RangeResult rows =
+			    co_await tr->getRange(lastLessOrEqual(backupPartitionMapHistoryKeyFor(epoch, startVersion)),
+			                          firstGreaterOrEqual(range.end),
+			                          /*limit=*/1);
+			if (rows.empty()) {
+				TraceEvent("BWRangePartitionedActivePMNotFound", self->myId)
+				    .detail("Epoch", epoch)
+				    .detail("StartVersion", startVersion);
+				co_return Optional<std::pair<Version, PartitionMap>>();
 			}
-			TraceEvent("BWRangePartitionedMapHistoryRead", self->myId)
+
+			// If no entry exists in our epoch at or before startVersion, lastLessOrEqual lands on a key from a previous
+			// epoch. We detect that by checking the decoded epoch on the result and treat it as "no entry". The caller
+			// falls back to pulling the partition map from TLog.
+			auto [decodedEpoch, version] = decodeBackupPartitionMapHistoryKey(rows[0].key);
+			if (decodedEpoch != epoch) {
+				TraceEvent("BWRangePartitionedActivePMNotFound", self->myId)
+				    .detail("Epoch", epoch)
+				    .detail("DecodedEpoch", decodedEpoch)
+				    .detail("DecodedVersion", version)
+				    .detail("StartVersion", startVersion);
+				co_return Optional<std::pair<Version, PartitionMap>>();
+			}
+
+			PartitionMap pm;
+			BinaryReader reader(rows[0].value, IncludeVersion());
+			reader >> pm;
+
+			TraceEvent("BWRangePartitionedActivePMRead", self->myId)
 			    .detail("Epoch", epoch)
 			    .detail("StartVersion", startVersion)
-			    .detail("NumEntries", history.size());
-			co_return history;
+			    .detail("PMVersion", version);
+			co_return std::make_pair(version, std::move(pm));
 		} catch (Error& e) {
 			err = e;
 		}
@@ -541,15 +554,16 @@ Future<Void> processPartitionMap(BackupRangePartitionedData* self) {
 
 	PartitionMap partitionMap;
 	Version partitionMapVersion;
-	PartitionMapHistory history;
+	Optional<std::pair<Version, PartitionMap>> startPMFromHistory;
 
 	if (self->backupEpoch != self->recruitedEpoch) {
-		// Old epoch worker: the partition map for our backupEpoch was persisted by the previous epoch's
-		// workers. Read it from system keys instead of pulling from TLog.
-		history = co_await loadPartitionMapHistoryFromSS(self, self->backupEpoch, self->startVersion);
-		if (!history.empty()) {
-			partitionMapVersion = history[0].first;
-			partitionMap = std::move(history[0].second);
+		// Old epoch worker: the partition map active at our startVersion was persisted by the previous
+		// epoch's workers. Read just that one from system keys; any later re-partitions in this epoch
+		// will arrive via the TLog cursor like a current-epoch worker.
+		startPMFromHistory = co_await loadActivePartitionMapFromSS(self, self->backupEpoch, self->startVersion);
+		if (startPMFromHistory.present()) {
+			partitionMapVersion = startPMFromHistory.get().first;
+			partitionMap = std::move(startPMFromHistory.get().second);
 			auto it = partitionMap.find(self->tag);
 			ASSERT(it != partitionMap.end() && !it->second.empty());
 			TraceEvent("BWRangePartitionedLoadedPartitionMap", self->myId)
@@ -558,16 +572,10 @@ Future<Void> processPartitionMap(BackupRangePartitionedData* self) {
 			    .detail("NumTags", partitionMap.size())
 			    .detail("Tag", self->tag.toString())
 			    .detail("NumPartitions", it->second.size());
-
-			// history[0] is applied as the initial active partition map (above). Remaining entries
-			// are queued for uploadData to swap to as it crosses each version.
-			self->pmUpdateQueue.insert(self->pmUpdateQueue.end(),
-			                           std::make_move_iterator(history.begin() + 1),
-			                           std::make_move_iterator(history.end()));
 		}
 	}
 
-	if (self->backupEpoch == self->recruitedEpoch || history.empty()) {
+	if (self->backupEpoch == self->recruitedEpoch || !startPMFromHistory.present()) {
 		// Current-epoch worker, or old epoch worker with no SS history (recovery happened before the
 		// previous epoch's persistPartitionMapToSS). Receive the partition map via TLog as the first
 		// message, then persist it so the next old epoch worker doesn't hit this case.
@@ -663,21 +671,20 @@ Future<Void> pullAsyncData(BackupRangePartitionedData* self) {
 			}
 
 			// Mid-stream PartitionMap update (re-partition). Persist + upload the new map immediately so
-			// future old-epoch workers can find it, then queue it for uploadData to apply at the right
-			// version boundary.
+			// future old-epoch workers can find it. The raw message bytes fall through to be buffered
+			// into self->messages like any other cursor message; uploadData detects it during its batch
+			// and calls setActivePartitionMap at the right version boundary.
+			// Do not `cursor->nextMessage()` or `continue` — fall through to buffer this message.
 			if (PartitionMapMessage::isNextIn(reader)) {
 				Version pmVersion = cursor->version().version;
 				PartitionMapMessage pmMsg;
 				reader >> pmMsg;
-				cursor->nextMessage();
 
 				co_await persistAndUploadPartitionMap(self, pmVersion, pmMsg.partitionMap);
-				self->pmUpdateQueue.emplace_back(pmVersion, std::move(pmMsg.partitionMap));
 
-				TraceEvent("BWRangePartitionedQueuedMidStreamPM", self->myId)
+				TraceEvent("BWRangePartitionedReceivedMidStreamPM", self->myId)
 				    .detail("Version", pmVersion)
 				    .detail("NumPartitions", pmMsg.partitionMap[self->tag].size());
-				continue;
 			}
 
 			auto msg = RangePartitionedVersionedMessage(cursor->version(), rawMessage, cursor->getTags(), msgArena);
@@ -1195,36 +1202,45 @@ Future<Void> uploadData(BackupRangePartitionedData* self) {
 			    .detail("NumMsg", numMsg)
 			    .detail("MsgQ", self->messages.size());
 
-			// Apply any queued partition maps whose version is reached by this batch. For each one,
-			// flush the messages with versions older than that map's version under the current map,
-			// then switch to the new map before continuing.
-			while (!self->pmUpdateQueue.empty() && self->pmUpdateQueue.front().first <= popVersion) {
-				Version pmV = self->pmUpdateQueue.front().first;
-				PartitionMap newPM = std::move(self->pmUpdateQueue.front().second);
-				self->pmUpdateQueue.pop_front();
-
-				int numMsgsBeforePM = 0;
-				for (int i = 0; i < numMsg; i++) {
-					if (self->messages[i].getVersion() >= pmV) {
-						break;
-					}
-					numMsgsBeforePM++;
+			// Walk the batch and look for any PartitionMapMessage. Whenever we hit one, flush all the
+			// mutations before it under the current map, switch to the new map, and drop the message.
+			int idx = 0;
+			while (idx < numMsg) {
+				ArenaReader reader(self->messages[idx].arena,
+				                   self->messages[idx].message,
+				                   AssumeVersion(g_network->protocolVersion()));
+				if (!PartitionMapMessage::isNextIn(reader)) {
+					idx++;
+					continue;
 				}
 
-				if (numMsgsBeforePM > 0) {
-					co_await saveMutationsToFile(self, pmV - 1, numMsgsBeforePM);
-					self->eraseMessages(numMsgsBeforePM);
-					numMsg -= numMsgsBeforePM;
+				Version pmV = self->messages[idx].getVersion();
+				if (idx > 0) {
+					co_await saveMutationsToFile(self, pmV - 1, idx);
+					self->eraseMessages(idx);
+					numMsg -= idx;
 				}
 
-				co_await setActivePartitionMap(self, pmV, newPM);
+				// PartitionMapMessage is now at index 0. Decode, apply, drop.
+				ArenaReader pmReader(
+				    self->messages[0].arena, self->messages[0].message, AssumeVersion(g_network->protocolVersion()));
+				PartitionMapMessage pmMsg;
+				pmReader >> pmMsg;
+				co_await setActivePartitionMap(self, pmV, pmMsg.partitionMap);
+				self->eraseMessages(1);
+				numMsg -= 1;
 
-				TraceEvent("BWRangePartitionedAppliedQueuedPM", self->myId)
+				TraceEvent("BWRangePartitionedAppliedMidStreamPM", self->myId)
 				    .detail("Version", pmV)
-				    .detail("NumPartitions", newPM[self->tag].size());
+				    .detail("NumPartitions", pmMsg.partitionMap[self->tag].size());
+
+				idx = 0;
 			}
 
-			// save an empty file for old epochs so that log file versions are continuous
+			// Even if numMsg is 0 (pullFinished with nothing left to save), write a final file at endVersion. Restore
+			// checks each tag's log files form a continuous range; without this marker, restore would stop at the last
+			// real file and miss the tail of this epoch. In-between empty ranges (gaps within [startVersion,
+			// endVersion)) are fine — restore only needs the worker's continuous range to extend through endVersion.
 			co_await saveMutationsToFile(self, popVersion, numMsg);
 			self->eraseMessages(numMsg);
 		}

--- a/fdbserver/backupworker/BackupWorkerRangePartitioned.cpp
+++ b/fdbserver/backupworker/BackupWorkerRangePartitioned.cpp
@@ -429,9 +429,12 @@ Future<Void> persistPartitionMapToSS(BackupRangePartitionedData* self,
 	}
 }
 
-// Reads all partition map entries persisted for `epoch` from system keys, returning them in
-// version order. Each entry is the partition map that became effective at its associated version.
-Future<PartitionMapHistory> loadPartitionMapHistoryFromSS(BackupRangePartitionedData* self, LogEpoch epoch) {
+// Reads partition map entries persisted for `epoch` from system keys, starting from the entry active at
+// `startVersion` (the largest version <= startVersion). Earlier entries don't apply to mutations the worker
+// will process, so we skip them at the SS read.
+Future<PartitionMapHistory> loadPartitionMapHistoryFromSS(BackupRangePartitionedData* self,
+                                                          LogEpoch epoch,
+                                                          Version startVersion) {
 	Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(self->cx));
 	KeyRange range = backupPartitionMapHistoryRangeFor(epoch);
 
@@ -442,8 +445,14 @@ Future<PartitionMapHistory> loadPartitionMapHistoryFromSS(BackupRangePartitioned
 			tr->setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
 			tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 
+			// Find the entry active at startVersion for this worker. If none exists at or before that
+			// version, fall back to the first entry of this epoch.
+			// e.g., startVersion for this worker=80 with entries at versions [1, 50, 90, 95]: starts from 50.
+			Key probedBegin =
+			    co_await tr->getKey(lastLessOrEqual(backupPartitionMapHistoryKeyFor(epoch, startVersion)));
+			Key beginKey = probedBegin >= range.begin ? probedBegin : Key(range.begin);
+
 			PartitionMapHistory history;
-			Key beginKey = range.begin;
 			while (true) {
 				RangeResult rows = co_await tr->getRange(KeyRangeRef(beginKey, range.end), CLIENT_KNOBS->TOO_MANY);
 				for (auto const& kv : rows) {
@@ -462,6 +471,7 @@ Future<PartitionMapHistory> loadPartitionMapHistoryFromSS(BackupRangePartitioned
 			}
 			TraceEvent("BWRangePartitionedMapHistoryRead", self->myId)
 			    .detail("Epoch", epoch)
+			    .detail("StartVersion", startVersion)
 			    .detail("NumEntries", history.size());
 			co_return history;
 		} catch (Error& e) {
@@ -536,7 +546,7 @@ Future<Void> processPartitionMap(BackupRangePartitionedData* self) {
 	if (self->backupEpoch != self->recruitedEpoch) {
 		// Old epoch worker: the partition map for our backupEpoch was persisted by the previous epoch's
 		// workers. Read it from system keys instead of pulling from TLog.
-		history = co_await loadPartitionMapHistoryFromSS(self, self->backupEpoch);
+		history = co_await loadPartitionMapHistoryFromSS(self, self->backupEpoch, self->startVersion);
 		if (!history.empty()) {
 			partitionMapVersion = history[0].first;
 			partitionMap = std::move(history[0].second);

--- a/fdbserver/backupworker/BackupWorkerRangePartitioned.cpp
+++ b/fdbserver/backupworker/BackupWorkerRangePartitioned.cpp
@@ -83,15 +83,12 @@ struct BackupRangePartitionedData {
 	Reference<FlowLock> lock;
 	AsyncTrigger doneTrigger;
 	AsyncTrigger changedTrigger;
-	// Signals pullAsyncData that uploadData has flushed self->messages, so it can apply a new
-	// partition map. pullAsyncData resets it to false before opening the barrier; uploadData sets
-	// it to true once the flush completes.
-	AsyncVar<bool> messagesFlushedForPMM{ false };
-	// Set by pullAsyncData while waiting for previous Partition Map's mutations to flush. Tells uploadData to bypass
-	// the version-boundary trim (no more messages will arrive to unstick the last buffered version) and flush
-	// everything currently in self->messages so that new partition map can be applied and new messages can be correctly
-	// buffered under the new partition map.
-	bool flushBeforePMApply = false;
+	// Pending partition maps to apply, in version order. Two sources fill this:
+	//   - At startup, an old-epoch worker preloads its remaining history from SS.
+	//   - During pulling, the current-epoch worker pushes any new partition map it sees in the TLog stream.
+	// uploadData picks them up: when its current batch of mutations reaches a queued version, it
+	// finishes saving the mutations under the old map, switches to the new map, and continues.
+	std::deque<std::pair<Version, PartitionMap>> pmUpdateQueue;
 	// Set to true when the worker is shutting down (e.g., worker_removed). Used by uploadData to exit gracefully via
 	// allMessageSaved(), letting in-flight file writes and progress commits finish first.
 	bool stopped = false;
@@ -514,7 +511,7 @@ Future<Void> persistAndUploadPartitionMap(BackupRangePartitionedData* self,
 Future<Void> setActivePartitionMap(BackupRangePartitionedData* self,
                                    Version pmVersion,
                                    PartitionMap const& partitionMap) {
-	self->logFolderBaseVersion = pmVersion + 1;
+	self->logFolderBaseVersion = pmVersion;
 	ASSERT(partitionMap.contains(self->tag));
 	const auto& tagPartitions = partitionMap.at(self->tag);
 	ASSERT_GT(tagPartitions.size(), 0);
@@ -525,11 +522,6 @@ Future<Void> setActivePartitionMap(BackupRangePartitionedData* self,
 	co_await computeKeyRangeToBackupAssignment(self);
 }
 
-// TODO akanksha -> Need to figure out if
-// 1. For new requests -> PartitionMap in TLOG will be same for all containers.
-// 2. Provide implemention for recovery where partitionmap can come any time and won't be the first message.
-// 3. Handle Recovery case where backupworker needs to process multiple partition maps for same epoch at different
-// versions.
 Future<Void> processPartitionMap(BackupRangePartitionedData* self) {
 	TraceEvent("BWRangePartitionedWaitingForPartitionMap", self->myId)
 	    .detail("Tag", self->tag.toString())
@@ -544,8 +536,6 @@ Future<Void> processPartitionMap(BackupRangePartitionedData* self) {
 	if (self->backupEpoch != self->recruitedEpoch) {
 		// Old epoch worker: the partition map for our backupEpoch was persisted by the previous epoch's
 		// workers. Read it from system keys instead of pulling from TLog.
-		// TODO akanksha: Scenario 2 — handle multiple history entries for mid-stream re-partition.
-		// TODO akanksha: Handle Case 3 mentioned in the TODO above.
 		history = co_await loadPartitionMapHistoryFromSS(self, self->backupEpoch);
 		if (!history.empty()) {
 			partitionMapVersion = history[0].first;
@@ -558,6 +548,12 @@ Future<Void> processPartitionMap(BackupRangePartitionedData* self) {
 			    .detail("NumTags", partitionMap.size())
 			    .detail("Tag", self->tag.toString())
 			    .detail("NumPartitions", it->second.size());
+
+			// history[0] is applied as the initial active partition map (above). Remaining entries
+			// are queued for uploadData to swap to as it crosses each version.
+			self->pmUpdateQueue.insert(self->pmUpdateQueue.end(),
+			                           std::make_move_iterator(history.begin() + 1),
+			                           std::make_move_iterator(history.end()));
 		}
 	}
 
@@ -596,7 +592,6 @@ Future<Void> pullAsyncData(BackupRangePartitionedData* self) {
 	Reference<IPeekCursor> cursor;
 
 	Version tagAt = std::max({ self->pulledVersion.get(), self->startVersion, self->savedVersion });
-
 	TraceEvent("BWRangePartitionedPull", self->myId)
 	    .detail("Tag", self->tag)
 	    .detail("Version", tagAt)
@@ -617,8 +612,6 @@ Future<Void> pullAsyncData(BackupRangePartitionedData* self) {
 				break;
 			} else {
 				if (self->logSystem.get()) {
-					// TODO akanksha: Use peekSingle as of now instead of peekLogRouter and later confirm if it works as
-					// expected.
 					cursor = self->logSystem.get()->peekSingle(self->myId, tagAt, self->tag);
 				} else {
 					cursor = Reference<IPeekCursor>();
@@ -659,48 +652,19 @@ Future<Void> pullAsyncData(BackupRangePartitionedData* self) {
 				continue;
 			}
 
-			// Mid-stream PartitionMap update (re-partition). Flush existing Partition Map's mutations, persist
-			// the new map, then swap local routing state before pulling further messages.
+			// Mid-stream PartitionMap update (re-partition). Persist + upload the new map immediately so
+			// future old-epoch workers can find it, then queue it for uploadData to apply at the right
+			// version boundary.
 			if (PartitionMapMessage::isNextIn(reader)) {
 				Version pmVersion = cursor->version().version;
 				PartitionMapMessage pmMsg;
 				reader >> pmMsg;
 				cursor->nextMessage();
 
-				// Push everything buffered into self->messages to flush them.
-				if (peekedBytes > 0) {
-					TraceEvent(SevDebugMemory, "BWRangePartitionedMemory", self->myId)
-					    .detail("Take", peekedBytes)
-					    .detail("Current", self->lock->activePermits());
-					co_await self->lock->take(TaskPriority::DefaultYield, peekedBytes);
-					self->messages.insert(self->messages.end(),
-					                      std::make_move_iterator(tmpMessages.begin()),
-					                      std::make_move_iterator(tmpMessages.end()));
-					tmpMessages.clear();
-					peekedBytes = 0;
-				}
-
-				// Wait for uploadData to flush all messages before new PartitionMap.
-				self->messagesFlushedForPMM.set(false);
-				self->flushBeforePMApply = true;
-				self->doneTrigger.trigger();
-				while (!self->messagesFlushedForPMM.get()) {
-					co_await self->messagesFlushedForPMM.onChange();
-				}
-
 				co_await persistAndUploadPartitionMap(self, pmVersion, pmMsg.partitionMap);
-				co_await setActivePartitionMap(self, pmVersion, pmMsg.partitionMap);
+				self->pmUpdateQueue.emplace_back(pmVersion, std::move(pmMsg.partitionMap));
 
-				self->flushBeforePMApply = false;
-
-				// Advance savedVersion past the PM message so TLog can pop it.
-				if (pmVersion > self->savedVersion) {
-					self->savedVersion = pmVersion;
-					self->pop();
-				}
-				self->pulledVersion.set(std::max(self->pulledVersion.get(), pmVersion));
-
-				TraceEvent("BWRangePartitionedAppliedMidStreamPM", self->myId)
+				TraceEvent("BWRangePartitionedQueuedMidStreamPM", self->myId)
 				    .detail("Version", pmVersion)
 				    .detail("NumPartitions", pmMsg.partitionMap[self->tag].size());
 				continue;
@@ -1202,12 +1166,6 @@ Future<Void> uploadData(BackupRangePartitionedData* self) {
 		}
 		if (self->pullFinished()) {
 			popVersion = self->endVersion.get();
-		} else if (self->flushBeforePMApply) {
-			// pullAsyncData has paused for a PartitionMap apply. No further messages will
-			// arrive at the last buffered version, so flush every queued message instead of
-			// holding the last version back for boundary alignment.
-			popVersion = self->messages.empty() ? popVersion : self->messages.back().getVersion();
-			numMsg = self->messages.size();
 		} else {
 			// make sure file is saved on version boundary
 			popVersion = lastVersion;
@@ -1226,14 +1184,39 @@ Future<Void> uploadData(BackupRangePartitionedData* self) {
 			    .detail("SavedVersion", self->savedVersion)
 			    .detail("NumMsg", numMsg)
 			    .detail("MsgQ", self->messages.size());
+
+			// Apply any queued partition maps whose version is reached by this batch. For each one,
+			// flush the messages with versions older than that map's version under the current map,
+			// then switch to the new map before continuing.
+			while (!self->pmUpdateQueue.empty() && self->pmUpdateQueue.front().first <= popVersion) {
+				Version pmV = self->pmUpdateQueue.front().first;
+				PartitionMap newPM = std::move(self->pmUpdateQueue.front().second);
+				self->pmUpdateQueue.pop_front();
+
+				int numMsgsBeforePM = 0;
+				for (int i = 0; i < numMsg; i++) {
+					if (self->messages[i].getVersion() >= pmV) {
+						break;
+					}
+					numMsgsBeforePM++;
+				}
+
+				if (numMsgsBeforePM > 0) {
+					co_await saveMutationsToFile(self, pmV - 1, numMsgsBeforePM);
+					self->eraseMessages(numMsgsBeforePM);
+					numMsg -= numMsgsBeforePM;
+				}
+
+				co_await setActivePartitionMap(self, pmV, newPM);
+
+				TraceEvent("BWRangePartitionedAppliedQueuedPM", self->myId)
+				    .detail("Version", pmV)
+				    .detail("NumPartitions", newPM[self->tag].size());
+			}
+
 			// save an empty file for old epochs so that log file versions are continuous
 			co_await saveMutationsToFile(self, popVersion, numMsg);
 			self->eraseMessages(numMsg);
-		}
-
-		// Unblock pullAsyncData once the buffer is flushed for a pending PartitionMap apply.
-		if (self->flushBeforePMApply) {
-			self->messagesFlushedForPMM.set(true);
 		}
 
 		if (popVersion > self->savedVersion) {

--- a/fdbserver/core/include/fdbserver/core/BackupPartitionMap.h
+++ b/fdbserver/core/include/fdbserver/core/BackupPartitionMap.h
@@ -45,10 +45,6 @@ using PartitionList = std::vector<Partition>;
 // storage when multiple backup workers upload the partition map at the same time.
 using PartitionMap = std::map<Tag, PartitionList>;
 
-// History of partition maps for an epoch: pairs of (effective version, partition map),
-// sorted by version ascending. Multiple entries occur when a re-partition happens mid-epoch.
-using PartitionMapHistory = std::vector<std::pair<Version, PartitionMap>>;
-
 std::string serializePartitionListJSON(PartitionMap const& partitionMap);
 
 // Partitions the user keyspace into balanced contiguous KeyRanges using shard byte sizes.


### PR DESCRIPTION
  ### Summary
  - Old epoch BackupWorker can now apply the right PartitionMap when processing mutations from
    an epoch where a re-partition happened mid-epoch (otherwise mutations from different version
    ranges would have been routed under the wrong map).
  - On startup, the old epoch worker reads from system keys just the PartitionMap that was active
    at its startVersion (the largest entry whose version <= startVersion). Any later re-partitions
    in that epoch arrive via the TLog cursor — same path as a current-epoch worker.
  - Moved partition map application from pullAsyncData to uploadData. pullAsyncData no longer
    swaps the map inline — it persists the new map and pushes it onto a shared queue. uploadData
    picks it up and applies it when its current batch reaches that version while saving messages.
  - Removes the cross-actor barrier (`messagesFlushedForPMM`, `flushBeforePMApply`) — pullAsyncData
    no longer has to wait for uploadData to flush before swapping.
     - uploadData is the right place because that's where the partition map is actually used (to
    decide which file each mutation goes to).
    
   ### Testing 
   100k simulation running
   
`     20260603-210922-ak_bk_multiple_pm-792cf4f1766a4306 compressed=True data_size=37189476 duration=1 ended=1 fail_fast=10 max_runs=100000 pass=1 priority=100 remaining=11 days, 13:46:30 runtime=0:00:10 sanity=False started=607 submitted=20260603-210922 timeout=5400 username=ak_bk_multiple_pm`