### PR TITLE
ci: add github action to check clang-format

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -26,9 +26,11 @@ jobs:
           sudo apt-get install clang-format-19
 
       - name: clang-format
+        # skip contrib dir, find all files named *.c/h/cpp/hpp,
+        # run clang-format 19.x on each file, in-place modifications
         run: |
-          find . -type f '(' -name \*.c -or -name \*.cpp -or -name \*.h -or -name \*.hpp ')' \
-                 -not -name sqlite3.amalgamation.c \
-                 -exec clang-format-19 -i '{}' ';'
+          find . -name contrib -prune -or -type f \
+                 '(' -name \*.c -or -name \*.cpp -or -name \*.h -or -name \*.hpp ')' \
+                 -exec clang-format-19 -i '{}' \;
 
           git diff --exit-code

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -25,7 +25,7 @@ jobs:
           clang-format --version
 
       - name: clang-format
-        run:
+        run: |
           find . -type f '(' -name \*.c -or -name \*.cpp -or -name \*.h -or -name \*.hpp ')' \
                  -not -name sqlite3.amalgamation.c \
                  -exec clang-format -i '{}' ';'

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 jobs:
-  clang-format-tidy:
+  clang-format:
     runs-on: ubuntu-24.04
 
     steps:
@@ -26,7 +26,8 @@ jobs:
 
       - name: clang-format
         run:
-          find -E . -type f -regex '.*\.(c|h|cpp|hpp)' -not -name sqlite3.amalgamation.c \
-               -exec clang-format -i '{}' ';'
+          find . -type f '(' -name \*.c -or -name \*.cpp -or -name \*.h -or -name \*.hpp ')' \
+                 -not -name sqlite3.amalgamation.c \
+                 -exec clang-format -i '{}' ';'
 
           git diff --exit-code

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -22,12 +22,13 @@ jobs:
 
       - name: tool versions
         run: |
-          clang-format --version
+          sudo apt-get update
+          sudo apt-get install clang-format-19
 
       - name: clang-format
         run: |
           find . -type f '(' -name \*.c -or -name \*.cpp -or -name \*.h -or -name \*.hpp ')' \
                  -not -name sqlite3.amalgamation.c \
-                 -exec clang-format -i '{}' ';'
+                 -exec clang-format-19 -i '{}' ';'
 
           git diff --exit-code

--- a/.github/workflows/tidy.yaml
+++ b/.github/workflows/tidy.yaml
@@ -1,0 +1,32 @@
+name: clang-format
+
+on:
+  pull_request:
+    branches:
+      - main
+      - release-7.4
+
+permissions:
+  contents: read
+
+jobs:
+  clang-format-tidy:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          # by default PR virtual "merge" commit is checked-out
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: tool versions
+        run: |
+          clang-format --version
+
+      - name: clang-format
+        run:
+          find -E . -type f -regex '.*\.(c|h|cpp|hpp)' -not -name sqlite3.amalgamation.c \
+               -exec clang-format -i '{}' ';'
+
+          git diff --exit-code


### PR DESCRIPTION
should be faster and clearer feedback than when the main foundationdb build/test fails due to clang-format check

I expect this to get clang-format 18.x from the ubuntu-24.04 runner image ...