### PR TITLE
fix(sqlite): enable SQLITE_ENABLE_MEMORY_MANAGEMENT so SOFT_HEAP_LIMI…

### DIFF
--- a/contrib/sqlite/CMakeLists.txt
+++ b/contrib/sqlite/CMakeLists.txt
@@ -11,6 +11,7 @@ set_target_properties(sqlite PROPERTIES C_CLANG_TIDY "")
 
 
 target_include_directories(sqlite PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_compile_definitions(sqlite PRIVATE SQLITE_ENABLE_MEMORY_MANAGEMENT)
 # Suppress warnings in sqlite since it's third party
 if(NOT WIN32)
   target_compile_definitions(sqlite PRIVATE $<$<CONFIG:Debug>:NDEBUG>)


### PR DESCRIPTION
Summary
Fixes #13240.

sqlite3_soft_heap_limit64() registers a softHeapLimitEnforcer alarm callback that calls sqlite3_release_memory() when SQLite's heap usage exceeds the configured threshold. Without SQLITE_ENABLE_MEMORY_MANAGEMENT, both sqlite3_release_memory() and the underlying sqlite3PcacheReleaseMemory() are compiled out as no-ops, so the SOFT_HEAP_LIMIT knob (default 300 MB) has never had any effect.

Root Cause
contrib/sqlite/CMakeLists.txt did not define SQLITE_ENABLE_MEMORY_MANAGEMENT, leaving the enforcement path dead:


sqlite3_soft_heap_limit64(300MB)
  → softHeapLimitEnforcer (alarm callback)
      → sqlite3_release_memory()   ← compiled to return 0
          → sqlite3PcacheReleaseMemory()  ← entire function #ifdef'd out
Change
Added one line to contrib/sqlite/CMakeLists.txt:


target_compile_definitions(sqlite PRIVATE SQLITE_ENABLE_MEMORY_MANAGEMENT)
This activates sqlite3PcacheReleaseMemory(), which walks the LRU page list and evicts unpinned pages when the soft heap threshold is crossed.