### PR TITLE
ci: add github action to check clang-format (release-7.3)

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,35 @@
+name: clang-format
+
+on:
+  pull_request:
+    branches:
+      - release-7.3
+
+permissions:
+  contents: read
+
+jobs:
+  clang-format:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          # by default PR virtual "merge" commit is checked-out
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: tool versions
+        run: |
+          sudo apt-get update
+          sudo apt-get install clang-format-15
+
+      - name: clang-format
+        # skip contrib dir, find all files named *.c/h/cpp/hpp,
+        # run clang-format on each file, in-place modifications
+        run: |
+          find . -name contrib -prune -or -type f \
+                 '(' -name \*.c -or -name \*.cpp -or -name \*.h -or -name \*.hpp ')' \
+                 -exec clang-format-15 -i '{}' \;
+
+          git diff --exit-code

--- a/fdbclient/S3BlobStore.actor.cpp
+++ b/fdbclient/S3BlobStore.actor.cpp
@@ -2009,9 +2009,7 @@ TEST_CASE("/backup/s3/parseErrorCodeFromS3") {
 	}
 
 	// Empty response — should return ""
-	{
-		ASSERT(parseErrorCodeFromS3("") == "");
-	}
+	{ ASSERT(parseErrorCodeFromS3("") == ""); }
 
 	// HTML error page from load balancer (502/503) — should return "", not throw
 	{
@@ -2020,19 +2018,13 @@ TEST_CASE("/backup/s3/parseErrorCodeFromS3") {
 	}
 
 	// Completely invalid / garbage — should return "", not throw
-	{
-		ASSERT(parseErrorCodeFromS3("not xml at all {{{") == "");
-	}
+	{ ASSERT(parseErrorCodeFromS3("not xml at all {{{") == ""); }
 
 	// Partial XML — should return "", not throw
-	{
-		ASSERT(parseErrorCodeFromS3("<Error><Code>Incomple") == "");
-	}
+	{ ASSERT(parseErrorCodeFromS3("<Error><Code>Incomple") == ""); }
 
 	// Plain text error — should return "", not throw
-	{
-		ASSERT(parseErrorCodeFromS3("Internal Server Error") == "");
-	}
+	{ ASSERT(parseErrorCodeFromS3("Internal Server Error") == ""); }
 
 	return Void();
 }

--- a/fdbserver/BackupWorker.actor.cpp
+++ b/fdbserver/BackupWorker.actor.cpp
@@ -952,7 +952,8 @@ ACTOR Future<Void> uploadData(BackupData* self) {
 ACTOR Future<Void> pullAsyncData(BackupData* self) {
 	state Future<Void> logSystemChange = Void();
 	state Reference<ILogSystem::IPeekCursor> r;
-	state Version tagAt = std::max( self->popVersion, std::max(self->pulledVersion.get(), std::max(self->startVersion, self->savedVersion)));
+	state Version tagAt = std::max(
+	    self->popVersion, std::max(self->pulledVersion.get(), std::max(self->startVersion, self->savedVersion)));
 	state Arena prev;
 
 	TraceEvent("BackupWorkerPull", self->myId).log();

--- a/fdbserver/DDRelocationQueue.actor.cpp
+++ b/fdbserver/DDRelocationQueue.actor.cpp
@@ -2452,8 +2452,7 @@ struct DDQueueImpl {
 		state KeyRange keysToLaunchFrom;
 		state RelocateData launchData;
 		state Future<Void> recordMetrics = delay(SERVER_KNOBS->DD_QUEUE_LOGGING_INTERVAL);
-		state Future<Void> recordRelocatorLatency =
-		    delay(SERVER_KNOBS->DD_RELOCATOR_LATENCY_LOGGING_INTERVAL);
+		state Future<Void> recordRelocatorLatency = delay(SERVER_KNOBS->DD_RELOCATOR_LATENCY_LOGGING_INTERVAL);
 
 		state std::vector<Future<Void>> ddQueueFutures;
 

--- a/fdbserver/workloads/AtomicRestore.actor.cpp
+++ b/fdbserver/workloads/AtomicRestore.actor.cpp
@@ -50,8 +50,7 @@ struct AtomicRestoreWorkload : TestWorkload {
 			// Fast restore doesn't support multiple ranges yet
 			backupRanges.push_back_deep(backupRanges.arena(), normalKeys);
 		}
-		usePartitionedLogs.set(
-		    getOption(options, "usePartitionedLogs"_sr, false));
+		usePartitionedLogs.set(getOption(options, "usePartitionedLogs"_sr, false));
 
 		addPrefix = getOption(options, "addPrefix"_sr, ""_sr);
 		removePrefix = getOption(options, "removePrefix"_sr, ""_sr);

--- a/flow/Trace.cpp
+++ b/flow/Trace.cpp
@@ -1789,6 +1789,8 @@ TEST_CASE("noSim/traceEventXMLHandling") {
 	// Verify that TraceEvent handles large XML strings (like S3 API responses) without breaking.
 	// Tests the full pipeline: detail() -> field truncation -> XML/JSON formatting.
 
+	// clang-format off
+
 	// Minimal S3-style XML
 	std::string smallXml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
 	                        "<Error><Code>NoSuchKey</Code>"
@@ -1831,6 +1833,8 @@ TEST_CASE("noSim/traceEventXMLHandling") {
 	                        "\"10.0.0.0/8\"}</Detail>\n"
 	                        "</Error>";
 	TraceEvent("TestNastyXml").detail("ResponseDetails", nastyXml);
+
+	// clang-format on
 
 	// Verify XML formatter handles the content without crashing
 	{


### PR DESCRIPTION
should be faster and clearer feedback than when the main foundationdb build/test fails due to clang-format check

(release-7.3 branch version with clang-format-15)

-------

back-port from main branch https://github.com/apple/foundationdb/pull/13315

I found that clang-format-15 causes least diff with the current state of the release-7.3 branch, little enough that we can simply let it run across the whole repo instead of limiting it to the lines touched by a PR.