### PR TITLE
Apply LSan suppressions to backup/bulkload/s3 client tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -282,6 +282,12 @@ if(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
   include_directories(/usr/local/include)
 endif()
 
+# Defined here (not in tests/CMakeLists.txt) so that subdirectories processed
+# before tests/ — fdbclient, fdbbackup — can apply it to their add_test() calls.
+set(SANITIZER_OPTIONS
+  "UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1;TSAN_OPTIONS=suppressions=${CMAKE_SOURCE_DIR}/contrib/tsan.suppressions;LSAN_OPTIONS=suppressions=${CMAKE_SOURCE_DIR}/contrib/lsan.suppressions"
+  CACHE STRING "Environment variables setting sanitizer options")
+
 include(CompileBoost)
 include(GetFmt)
 include(GetMsgpack)

--- a/fdbbackup/CMakeLists.txt
+++ b/fdbbackup/CMakeLists.txt
@@ -69,4 +69,6 @@ if (NOT WIN32 AND NOT OPEN_FOR_IDE)
   add_test(NAME blob_backup_restore_tests COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/tests/blob_backup_restore_test.sh ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
   # Note: No --encrypt flag - BulkLoad doesn't support encryption yet
   add_test(NAME s3_backup_bulkdump_bulkload_tests COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/tests/s3_backup_bulkdump_bulkload.sh ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
+  set_tests_properties(dir_backup_tests blob_backup_restore_tests s3_backup_bulkdump_bulkload_tests
+    PROPERTIES ENVIRONMENT "${SANITIZER_OPTIONS}")
 endif()

--- a/fdbclient/CMakeLists.txt
+++ b/fdbclient/CMakeLists.txt
@@ -224,4 +224,6 @@ if (NOT WIN32 AND NOT OPEN_FOR_IDE)
   add_test(NAME s3client_test COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/tests/s3client_test.sh ${CMAKE_BINARY_DIR})
   add_test(NAME gcs_client_test COMMAND ${CMAKE_COMMAND} -E env USE_MOCK_GCS=true ${CMAKE_CURRENT_SOURCE_DIR}/tests/s3client_test.sh ${CMAKE_BINARY_DIR})
   add_test(NAME bulkload_test COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/tests/bulkload_test.sh ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
+  set_tests_properties(s3client_test gcs_client_test bulkload_test
+    PROPERTIES ENVIRONMENT "${SANITIZER_OPTIONS}")
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,7 +10,6 @@ set(TEST_AGGREGATE_TRACES "NONE" CACHE STRING "Create aggregated trace files (NO
 set(TEST_LOG_FORMAT "xml" CACHE STRING "Format for test trace files (xml, json)")
 set(TEST_INCLUDE ".*" CACHE STRING "Include only tests that match the given regex")
 set(TEST_EXCLUDE ".^" CACHE STRING "Exclude all tests matching the given regex")
-set(SANITIZER_OPTIONS "UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1;TSAN_OPTIONS=suppressions=${CMAKE_SOURCE_DIR}/contrib/tsan.suppressions;LSAN_OPTIONS=suppressions=${CMAKE_SOURCE_DIR}/contrib/lsan.suppressions" CACHE STRING "Environment variables setting sanitizer options")
 
 # For the restart test, prefer an installed fdbserver from an older stable release
 # to exercise upgrade paths from existing on-disk state. If it is unavailable,


### PR DESCRIPTION
These tests shell out to fdbcli during cluster setup, which exits non-zero under ASAN due to known shutdown leaks already covered by contrib/lsan.suppressions. They were failing because LSAN_OPTIONS was never propagated to them: their add_test() calls (in fdbclient/ and fdbbackup/) had no ENVIRONMENT property, and SANITIZER_OPTIONS was defined in tests/CMakeLists.txt — processed after fdbclient/ and fdbbackup/, so the variable was empty there on first configure.

Move SANITIZER_OPTIONS to the top-level CMakeLists.txt and apply it to bulkload_test, dir_backup_tests, blob_backup_restore_tests, s3_backup_bulkdump_bulkload_tests, and s3client_test/gcs_client_test.
