### PR TITLE
fix: use thread-local mt19937_64 for automatic idempotency ID

### DIFF
--- a/fdbclient/MultiVersionTransaction.actor.cpp
+++ b/fdbclient/MultiVersionTransaction.actor.cpp
@@ -3113,8 +3113,7 @@ void MultiVersionApi::setupNetwork() {
 			}
 
 			if (!bypassMultiClientApi) {
-				transportId =
-				    (uint64_t(uint32_t(platform::getRandomSeed())) << 32) ^ uint32_t(platform::getRandomSeed());
+				platform::getRandomBytes(&transportId, sizeof(transportId));
 				if (transportId <= 1)
 					transportId += 2;
 				localClient->api->setNetworkOption(FDBNetworkOptions::EXTERNAL_CLIENT_TRANSPORT_ID,

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -25,6 +25,7 @@
 #include <iterator>
 #include <limits>
 #include <memory>
+#include <random>
 #include <regex>
 #include <string>
 #include <unordered_set>
@@ -7047,6 +7048,18 @@ Future<Void> Transaction::commit() {
 	return committing;
 }
 
+// Returns a thread-local mt19937_64 seeded once with 32 bytes of OS entropy.
+// Used for AUTOMATIC_IDEMPOTENCY ID generation in non-simulation runs.
+static std::mt19937_64& getIdempotencyRng() {
+	static thread_local std::mt19937_64 rng = []() {
+		uint32_t seed_data[8];
+		platform::getRandomBytes(seed_data, sizeof(seed_data));
+		std::seed_seq seq(seed_data, seed_data + 8);
+		return std::mt19937_64(seq);
+	}();
+	return rng;
+}
+
 void Transaction::setOption(FDBTransactionOptions::Option option, Optional<StringRef> value) {
 	switch (option) {
 	case FDBTransactionOptions::INITIALIZE_NEW_DATABASE:
@@ -7298,9 +7311,15 @@ void Transaction::setOption(FDBTransactionOptions::Option option, Optional<Strin
 	case FDBTransactionOptions::AUTOMATIC_IDEMPOTENCY:
 		validateOptionValueNotPresent(value);
 		if (!tr.idempotencyId.valid()) {
-			tr.idempotencyId = IdempotencyIdRef(
-			    tr.arena,
-			    IdempotencyIdRef(BinaryWriter::toValue(deterministicRandom()->randomUniqueID(), Unversioned())));
+			StringRef id = makeString(16, tr.arena);
+			if (g_network->isSimulated()) {
+				deterministicRandom()->randomBytes(mutateString(id), 16);
+			} else {
+				auto& rng = getIdempotencyRng();
+				uint64_t buf[2] = { rng(), rng() };
+				memcpy(mutateString(id), buf, 16);
+			}
+			tr.idempotencyId = IdempotencyIdRef(id);
 		}
 		trState->automaticIdempotency = true;
 		break;

--- a/flow/Platform.actor.cpp
+++ b/flow/Platform.actor.cpp
@@ -164,6 +164,7 @@ static_assert(std::is_same<boost::asio::ip::address_v6::bytes_type, std::array<u
 
 #ifdef __APPLE__
 /* Needed for cross-platform 'environ' */
+#include <sys/random.h>
 #include <crt_externs.h>
 #include <mach-o/dyld.h>
 #include <mach/mach.h>
@@ -2281,6 +2282,35 @@ int getRandomSeed() {
 #endif
 
 	return randomSeed;
+}
+
+void getRandomBytes(void* buf, size_t len) {
+	INJECT_FAULT(platform_error, "getRandomBytes"); // getting random bytes failed
+	ASSERT(len == 0 || buf != nullptr);
+#ifdef _WIN32
+	size_t pos = 0;
+	while (pos < len) {
+		unsigned int val;
+		if (rand_s(&val) != 0) {
+			TraceEvent(SevError, "WindowsRandomBytesError").log();
+			throw platform_error();
+		}
+		size_t chunk = std::min(sizeof(val), len - pos);
+		memcpy(static_cast<uint8_t*>(buf) + pos, &val, chunk);
+		pos += chunk;
+	}
+#else
+	uint8_t* p = static_cast<uint8_t*>(buf);
+	while (len > 0) {
+		size_t chunk = std::min(len, size_t(256));
+		if (getentropy(p, chunk) != 0) {
+			TraceEvent(SevError, "GetEntropyError").detail("Errno", errno);
+			throw platform_error();
+		}
+		p += chunk;
+		len -= chunk;
+	}
+#endif
 }
 } // namespace platform
 

--- a/flow/include/flow/Platform.h
+++ b/flow/include/flow/Platform.h
@@ -423,6 +423,7 @@ void setCloseOnExec(int fd);
 void outOfMemory();
 
 int getRandomSeed();
+void getRandomBytes(void* buf, size_t len);
 
 bool getEnvironmentVar(const char* name, std::string& value);
 int setEnvironmentVar(const char* name, const char* value, int overwrite);


### PR DESCRIPTION
feat: add platform::getRandomBytes and use it for idempotency IDs

backport of https://github.com/apple/foundationdb/pull/13135 requested by @PierreZ 