### PR TITLE
fdbcli: add rangelock command for range lock management

### DIFF
--- a/documentation/sphinx/source/rangelock.rst
+++ b/documentation/sphinx/source/rangelock.rst
@@ -80,6 +80,25 @@ Get a range lock owner by uniqueId
 ``ACTOR Future<Optional<RangeLockOwner>> getRangeLockOwner(Database cx, RangeLockOwnerName ownerUniqueID);``
 
 
+Using ``fdbcli``
+----------------
+For ad-hoc operational use — inspecting active locks, releasing a lock left behind by a failed bulkload job, taking a lock for a maintenance window, or driving a perf test — ``fdbcli`` exposes a thin wrapper around the management API:
+
+::
+
+    rangelock register <OWNER_ID> <DESCRIPTION>
+    rangelock unregister <OWNER_ID>
+    rangelock owners
+    rangelock take <BEGIN_KEY> <END_KEY> <OWNER_ID>
+    rangelock release <BEGIN_KEY> <END_KEY> <OWNER_ID>
+    rangelock release-all <OWNER_ID>
+    rangelock list [<BEGIN_KEY> <END_KEY>]
+
+Range locks only take effect when commit proxies are started with ``knob_enable_read_lock_on_range=true``. ``rangelock take`` prints an advisory notice as a reminder, but cannot probe the server-side knob — the take itself succeeds either way; the lock simply has no effect when the knob is off.
+
+The bulkload-specific commands (``bulkload addlockowner`` / ``clearlock`` / ``printlockowner``) remain available; they are a constrained subset of the above scoped to the bulkload workflow.
+
+
 Example usage
 -------------
 When submitting a bulk load task on a range, we block user write traffic to the range.

--- a/documentation/sphinx/source/rangelock.rst
+++ b/documentation/sphinx/source/rangelock.rst
@@ -96,7 +96,7 @@ For ad-hoc operational use — inspecting active locks, releasing a lock left be
 
 Range locks only take effect when commit proxies are started with ``knob_enable_read_lock_on_range=true``. ``rangelock take`` prints an advisory notice as a reminder, but cannot probe the server-side knob — the take itself succeeds either way; the lock simply has no effect when the knob is off.
 
-The bulkload-specific commands (``bulkload addlockowner`` / ``clearlock`` / ``printlockowner``) remain available; they are a constrained subset of the above scoped to the bulkload workflow.
+The bulkload-specific commands (``bulkload addlockowner`` / ``bulkload clearlock`` / ``bulkload printlockowner``) remain available; they are a constrained subset of the above scoped to the bulkload workflow.
 
 
 Example usage

--- a/fdbcli/RangeLockCommand.cpp
+++ b/fdbcli/RangeLockCommand.cpp
@@ -1,0 +1,187 @@
+/*
+ * RangeLockCommand.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "fdbcli/fdbcli.h"
+#include "fdbclient/ManagementAPI.h"
+#include "fdbclient/RangeLock.h"
+#include "flow/Arena.h"
+
+namespace fdb_cli {
+
+static const std::string RANGELOCK_REGISTER_USAGE =
+    "To register an owner: rangelock register <OWNER_ID> <DESCRIPTION>\n";
+static const std::string RANGELOCK_UNREGISTER_USAGE = "To unregister an owner: rangelock unregister <OWNER_ID>\n";
+static const std::string RANGELOCK_OWNERS_USAGE = "To list owners: rangelock owners\n";
+static const std::string RANGELOCK_TAKE_USAGE = "To lock a range: rangelock take <BEGIN_KEY> <END_KEY> <OWNER_ID>\n";
+static const std::string RANGELOCK_RELEASE_USAGE =
+    "To release a lock: rangelock release <BEGIN_KEY> <END_KEY> <OWNER_ID>\n";
+static const std::string RANGELOCK_RELEASE_ALL_USAGE =
+    "To release every lock held by an owner: rangelock release-all <OWNER_ID>\n";
+static const std::string RANGELOCK_LIST_USAGE = "To list locked ranges: rangelock list [<BEGIN_KEY> <END_KEY>]\n";
+
+static const std::string RANGELOCK_HELP_MESSAGE =
+    RANGELOCK_REGISTER_USAGE + RANGELOCK_UNREGISTER_USAGE + RANGELOCK_OWNERS_USAGE + RANGELOCK_TAKE_USAGE +
+    RANGELOCK_RELEASE_USAGE + RANGELOCK_RELEASE_ALL_USAGE + RANGELOCK_LIST_USAGE;
+
+// Range locks only take effect when commit proxies are started with
+// knob_enable_read_lock_on_range=true. The client cannot probe the knob
+// (server knobs aren't exposed to fdbclient), so we print this notice
+// after any operation that the user might assume blocks writes.
+static void printKnobReminder() {
+	fmt::println("NOTE: Range locks take effect only when commit proxies were started with");
+	fmt::println("      knob_enable_read_lock_on_range=true. If that knob is off cluster-wide,");
+	fmt::println("      this operation persists metadata but writes are not actually rejected.");
+	fmt::println("      Verify the knob in commit-proxy startup logs.");
+}
+
+Future<bool> rangeLockCommandActor(Database cx, std::vector<StringRef> tokens) {
+	if (tokens.size() < 2) {
+		fmt::print("{}", RANGELOCK_HELP_MESSAGE);
+		co_return false;
+	}
+
+	if (tokencmp(tokens[1], "register")) {
+		if (tokens.size() != 4) {
+			fmt::print("{}", RANGELOCK_REGISTER_USAGE);
+			co_return false;
+		}
+		std::string ownerId = tokens[2].toString();
+		std::string description = tokens[3].toString();
+		if (ownerId.empty() || description.empty()) {
+			fmt::println("ERROR: Owner ID and description must be non-empty");
+			fmt::print("{}", RANGELOCK_REGISTER_USAGE);
+			co_return false;
+		}
+		co_await registerRangeLockOwner(cx, ownerId, description);
+		fmt::println("Registered range lock owner: {}", ownerId);
+		co_return true;
+	}
+
+	if (tokencmp(tokens[1], "unregister")) {
+		if (tokens.size() != 3) {
+			fmt::print("{}", RANGELOCK_UNREGISTER_USAGE);
+			co_return false;
+		}
+		std::string ownerId = tokens[2].toString();
+		co_await removeRangeLockOwner(cx, ownerId);
+		fmt::println("Unregistered range lock owner: {}", ownerId);
+		co_return true;
+	}
+
+	if (tokencmp(tokens[1], "owners")) {
+		if (tokens.size() != 2) {
+			fmt::print("{}", RANGELOCK_OWNERS_USAGE);
+			co_return false;
+		}
+		std::vector<RangeLockOwner> owners = co_await getAllRangeLockOwners(cx);
+		fmt::println("Total {} range lock owners", owners.size());
+		for (const auto& owner : owners) {
+			fmt::println("  {}", owner.toString());
+		}
+		co_return true;
+	}
+
+	if (tokencmp(tokens[1], "take")) {
+		if (tokens.size() != 5) {
+			fmt::print("{}", RANGELOCK_TAKE_USAGE);
+			co_return false;
+		}
+		Key rangeBegin = tokens[2];
+		Key rangeEnd = tokens[3];
+		std::string ownerId = tokens[4].toString();
+		if (rangeBegin >= rangeEnd || rangeEnd > normalKeys.end) {
+			fmt::println("ERROR: Invalid range {} to {}: must be non-empty within the normal key space",
+			             rangeBegin.toString(),
+			             rangeEnd.toString());
+			co_return false;
+		}
+		KeyRange range = Standalone(KeyRangeRef(rangeBegin, rangeEnd));
+		co_await takeExclusiveReadLockOnRange(cx, range, ownerId);
+		fmt::println("Locked range {} for owner {}", range.toString(), ownerId);
+		printKnobReminder();
+		co_return true;
+	}
+
+	if (tokencmp(tokens[1], "release")) {
+		if (tokens.size() != 5) {
+			fmt::print("{}", RANGELOCK_RELEASE_USAGE);
+			co_return false;
+		}
+		Key rangeBegin = tokens[2];
+		Key rangeEnd = tokens[3];
+		std::string ownerId = tokens[4].toString();
+		if (rangeBegin >= rangeEnd || rangeEnd > normalKeys.end) {
+			fmt::println("ERROR: Invalid range {} to {}: must be non-empty within the normal key space",
+			             rangeBegin.toString(),
+			             rangeEnd.toString());
+			co_return false;
+		}
+		KeyRange range = Standalone(KeyRangeRef(rangeBegin, rangeEnd));
+		co_await releaseExclusiveReadLockOnRange(cx, range, ownerId);
+		fmt::println("Released range {} for owner {}", range.toString(), ownerId);
+		co_return true;
+	}
+
+	if (tokencmp(tokens[1], "release-all")) {
+		if (tokens.size() != 3) {
+			fmt::print("{}", RANGELOCK_RELEASE_ALL_USAGE);
+			co_return false;
+		}
+		std::string ownerId = tokens[2].toString();
+		co_await releaseExclusiveReadLockByUser(cx, ownerId);
+		fmt::println("Released all locks held by owner {}", ownerId);
+		co_return true;
+	}
+
+	if (tokencmp(tokens[1], "list")) {
+		KeyRange range = normalKeys;
+		if (tokens.size() == 4) {
+			Key rangeBegin = tokens[2];
+			Key rangeEnd = tokens[3];
+			if (rangeBegin >= rangeEnd || rangeEnd > normalKeys.end) {
+				fmt::println("ERROR: Invalid range {} to {}: must be non-empty within the normal key space",
+				             rangeBegin.toString(),
+				             rangeEnd.toString());
+				co_return false;
+			}
+			range = Standalone(KeyRangeRef(rangeBegin, rangeEnd));
+		} else if (tokens.size() != 2) {
+			fmt::print("{}", RANGELOCK_LIST_USAGE);
+			co_return false;
+		}
+		std::vector<std::pair<KeyRange, RangeLockState>> locks = co_await findExclusiveReadLockOnRange(cx, range);
+		fmt::println("Total {} locked ranges in {}", locks.size(), range.toString());
+		for (const auto& lock : locks) {
+			fmt::println("  {} -> {}", lock.first.toString(), lock.second.toString());
+		}
+		co_return true;
+	}
+
+	fmt::print("{}", RANGELOCK_HELP_MESSAGE);
+	co_return false;
+}
+
+CommandFactory rangeLockFactory(
+    "rangelock",
+    CommandHelp("rangelock [register|unregister|owners|take|release|release-all|list] [ARGs]",
+                "manage exclusive read locks on key ranges",
+                RANGELOCK_HELP_MESSAGE.c_str()));
+
+} // namespace fdb_cli

--- a/fdbcli/RangeLockCommand.cpp
+++ b/fdbcli/RangeLockCommand.cpp
@@ -34,7 +34,9 @@ static const std::string RANGELOCK_RELEASE_USAGE =
     "To release a lock: rangelock release <BEGIN_KEY> <END_KEY> <OWNER_ID>\n";
 static const std::string RANGELOCK_RELEASE_ALL_USAGE =
     "To release every lock held by an owner: rangelock release-all <OWNER_ID>\n";
-static const std::string RANGELOCK_LIST_USAGE = "To list locked ranges: rangelock list [<BEGIN_KEY> <END_KEY>]\n";
+static const std::string RANGELOCK_LIST_USAGE =
+    "To list locked ranges: rangelock list [<BEGIN_KEY> <END_KEY>]\n"
+    "  Omit both keys to list every locked range. If supplied, BEGIN_KEY and END_KEY must be given together.\n";
 
 static const std::string RANGELOCK_HELP_MESSAGE =
     RANGELOCK_REGISTER_USAGE + RANGELOCK_UNREGISTER_USAGE + RANGELOCK_OWNERS_USAGE + RANGELOCK_TAKE_USAGE +
@@ -49,6 +51,44 @@ static void printKnobReminder() {
 	fmt::println("      knob_enable_read_lock_on_range=true. If that knob is off cluster-wide,");
 	fmt::println("      this operation persists metadata but writes are not actually rejected.");
 	fmt::println("      Verify the knob in commit-proxy startup logs.");
+}
+
+// Validate range bounds and return a Standalone KeyRange. Prints a user-facing
+// error and returns an empty Optional if the range is invalid (empty, inverted,
+// or outside the normal key space).
+static Optional<KeyRange> parseNormalKeyRange(Key rangeBegin, Key rangeEnd) {
+	if (rangeBegin >= rangeEnd) {
+		fmt::println("ERROR: BEGIN_KEY ({}) must be strictly less than END_KEY ({})",
+		             rangeBegin.toString(),
+		             rangeEnd.toString());
+		return {};
+	}
+	KeyRangeRef range(rangeBegin, rangeEnd);
+	if (!normalKeys.contains(range)) {
+		fmt::println("ERROR: Range {} is not within the normal key space [\"\", \\xff)", range.toString());
+		return {};
+	}
+	return Standalone<KeyRangeRef>(range);
+}
+
+// Map a server-side rangelock error to a user-friendly message and return false.
+// actor_cancelled is rethrown by the caller before this is reached.
+static bool reportRangeLockError(const Error& e, std::string_view operation) {
+	switch (e.code()) {
+	case error_code_range_lock_reject:
+		fmt::println("ERROR: cannot {}: range overlaps a lock held by another owner", operation);
+		break;
+	case error_code_range_unlock_reject:
+		fmt::println("ERROR: cannot {}: range is not held by this owner (or held with a different range)", operation);
+		break;
+	case error_code_range_lock_failed:
+		fmt::println("ERROR: cannot {}: invalid range, unregistered owner, or empty argument", operation);
+		break;
+	default:
+		fmt::println("ERROR: cannot {}: {} ({})", operation, e.what(), e.code());
+		break;
+	}
+	return false;
 }
 
 Future<bool> rangeLockCommandActor(Database cx, std::vector<StringRef> tokens) {
@@ -69,7 +109,14 @@ Future<bool> rangeLockCommandActor(Database cx, std::vector<StringRef> tokens) {
 			fmt::print("{}", RANGELOCK_REGISTER_USAGE);
 			co_return false;
 		}
-		co_await registerRangeLockOwner(cx, ownerId, description);
+		try {
+			co_await registerRangeLockOwner(cx, ownerId, description);
+		} catch (Error& e) {
+			if (e.code() == error_code_actor_cancelled) {
+				throw;
+			}
+			co_return reportRangeLockError(e, "register owner");
+		}
 		fmt::println("Registered range lock owner: {}", ownerId);
 		co_return true;
 	}
@@ -80,7 +127,19 @@ Future<bool> rangeLockCommandActor(Database cx, std::vector<StringRef> tokens) {
 			co_return false;
 		}
 		std::string ownerId = tokens[2].toString();
-		co_await removeRangeLockOwner(cx, ownerId);
+		if (ownerId.empty()) {
+			fmt::println("ERROR: Owner ID must be non-empty");
+			fmt::print("{}", RANGELOCK_UNREGISTER_USAGE);
+			co_return false;
+		}
+		try {
+			co_await removeRangeLockOwner(cx, ownerId);
+		} catch (Error& e) {
+			if (e.code() == error_code_actor_cancelled) {
+				throw;
+			}
+			co_return reportRangeLockError(e, "unregister owner");
+		}
 		fmt::println("Unregistered range lock owner: {}", ownerId);
 		co_return true;
 	}
@@ -90,7 +149,15 @@ Future<bool> rangeLockCommandActor(Database cx, std::vector<StringRef> tokens) {
 			fmt::print("{}", RANGELOCK_OWNERS_USAGE);
 			co_return false;
 		}
-		std::vector<RangeLockOwner> owners = co_await getAllRangeLockOwners(cx);
+		std::vector<RangeLockOwner> owners;
+		try {
+			owners = co_await getAllRangeLockOwners(cx);
+		} catch (Error& e) {
+			if (e.code() == error_code_actor_cancelled) {
+				throw;
+			}
+			co_return reportRangeLockError(e, "list owners");
+		}
 		fmt::println("Total {} range lock owners", owners.size());
 		for (const auto& owner : owners) {
 			fmt::println("  {}", owner.toString());
@@ -103,18 +170,25 @@ Future<bool> rangeLockCommandActor(Database cx, std::vector<StringRef> tokens) {
 			fmt::print("{}", RANGELOCK_TAKE_USAGE);
 			co_return false;
 		}
-		Key rangeBegin = tokens[2];
-		Key rangeEnd = tokens[3];
 		std::string ownerId = tokens[4].toString();
-		if (rangeBegin >= rangeEnd || rangeEnd > normalKeys.end) {
-			fmt::println("ERROR: Invalid range {} to {}: must be non-empty within the normal key space",
-			             rangeBegin.toString(),
-			             rangeEnd.toString());
+		if (ownerId.empty()) {
+			fmt::println("ERROR: Owner ID must be non-empty");
+			fmt::print("{}", RANGELOCK_TAKE_USAGE);
 			co_return false;
 		}
-		KeyRange range = Standalone(KeyRangeRef(rangeBegin, rangeEnd));
-		co_await takeExclusiveReadLockOnRange(cx, range, ownerId);
-		fmt::println("Locked range {} for owner {}", range.toString(), ownerId);
+		Optional<KeyRange> range = parseNormalKeyRange(tokens[2], tokens[3]);
+		if (!range.present()) {
+			co_return false;
+		}
+		try {
+			co_await takeExclusiveReadLockOnRange(cx, range.get(), ownerId);
+		} catch (Error& e) {
+			if (e.code() == error_code_actor_cancelled) {
+				throw;
+			}
+			co_return reportRangeLockError(e, "take lock");
+		}
+		fmt::println("Locked range {} for owner {}", range.get().toString(), ownerId);
 		printKnobReminder();
 		co_return true;
 	}
@@ -124,18 +198,25 @@ Future<bool> rangeLockCommandActor(Database cx, std::vector<StringRef> tokens) {
 			fmt::print("{}", RANGELOCK_RELEASE_USAGE);
 			co_return false;
 		}
-		Key rangeBegin = tokens[2];
-		Key rangeEnd = tokens[3];
 		std::string ownerId = tokens[4].toString();
-		if (rangeBegin >= rangeEnd || rangeEnd > normalKeys.end) {
-			fmt::println("ERROR: Invalid range {} to {}: must be non-empty within the normal key space",
-			             rangeBegin.toString(),
-			             rangeEnd.toString());
+		if (ownerId.empty()) {
+			fmt::println("ERROR: Owner ID must be non-empty");
+			fmt::print("{}", RANGELOCK_RELEASE_USAGE);
 			co_return false;
 		}
-		KeyRange range = Standalone(KeyRangeRef(rangeBegin, rangeEnd));
-		co_await releaseExclusiveReadLockOnRange(cx, range, ownerId);
-		fmt::println("Released range {} for owner {}", range.toString(), ownerId);
+		Optional<KeyRange> range = parseNormalKeyRange(tokens[2], tokens[3]);
+		if (!range.present()) {
+			co_return false;
+		}
+		try {
+			co_await releaseExclusiveReadLockOnRange(cx, range.get(), ownerId);
+		} catch (Error& e) {
+			if (e.code() == error_code_actor_cancelled) {
+				throw;
+			}
+			co_return reportRangeLockError(e, "release lock");
+		}
+		fmt::println("Released range {} for owner {}", range.get().toString(), ownerId);
 		co_return true;
 	}
 
@@ -145,7 +226,19 @@ Future<bool> rangeLockCommandActor(Database cx, std::vector<StringRef> tokens) {
 			co_return false;
 		}
 		std::string ownerId = tokens[2].toString();
-		co_await releaseExclusiveReadLockByUser(cx, ownerId);
+		if (ownerId.empty()) {
+			fmt::println("ERROR: Owner ID must be non-empty");
+			fmt::print("{}", RANGELOCK_RELEASE_ALL_USAGE);
+			co_return false;
+		}
+		try {
+			co_await releaseExclusiveReadLockByUser(cx, ownerId);
+		} catch (Error& e) {
+			if (e.code() == error_code_actor_cancelled) {
+				throw;
+			}
+			co_return reportRangeLockError(e, "release all locks");
+		}
 		fmt::println("Released all locks held by owner {}", ownerId);
 		co_return true;
 	}
@@ -153,20 +246,24 @@ Future<bool> rangeLockCommandActor(Database cx, std::vector<StringRef> tokens) {
 	if (tokencmp(tokens[1], "list")) {
 		KeyRange range = normalKeys;
 		if (tokens.size() == 4) {
-			Key rangeBegin = tokens[2];
-			Key rangeEnd = tokens[3];
-			if (rangeBegin >= rangeEnd || rangeEnd > normalKeys.end) {
-				fmt::println("ERROR: Invalid range {} to {}: must be non-empty within the normal key space",
-				             rangeBegin.toString(),
-				             rangeEnd.toString());
+			Optional<KeyRange> parsed = parseNormalKeyRange(tokens[2], tokens[3]);
+			if (!parsed.present()) {
 				co_return false;
 			}
-			range = Standalone(KeyRangeRef(rangeBegin, rangeEnd));
+			range = parsed.get();
 		} else if (tokens.size() != 2) {
 			fmt::print("{}", RANGELOCK_LIST_USAGE);
 			co_return false;
 		}
-		std::vector<std::pair<KeyRange, RangeLockState>> locks = co_await findExclusiveReadLockOnRange(cx, range);
+		std::vector<std::pair<KeyRange, RangeLockState>> locks;
+		try {
+			locks = co_await findExclusiveReadLockOnRange(cx, range);
+		} catch (Error& e) {
+			if (e.code() == error_code_actor_cancelled) {
+				throw;
+			}
+			co_return reportRangeLockError(e, "list locks");
+		}
 		fmt::println("Total {} locked ranges in {}", locks.size(), range.toString());
 		for (const auto& lock : locks) {
 			fmt::println("  {} -> {}", lock.first.toString(), lock.second.toString());

--- a/fdbcli/fdbcli.cpp
+++ b/fdbcli/fdbcli.cpp
@@ -1624,6 +1624,14 @@ Future<int> cli(CLIOptions opt, LineNoise* plinenoise, Reference<ClusterConnecti
 					continue;
 				}
 
+				if (tokencmp(tokens[0], "rangelock")) {
+					bool _result = co_await makeInterruptable(rangeLockCommandActor(localDb, tokens));
+					if (!_result) {
+						is_error = true;
+					}
+					continue;
+				}
+
 				if (tokencmp(tokens[0], "force_recovery_with_data_loss")) {
 					bool _result = co_await makeInterruptable(forceRecoveryWithDataLossCommandActor(db, tokens));
 					if (!_result)

--- a/fdbcli/include/fdbcli/fdbcli.h
+++ b/fdbcli/include/fdbcli/fdbcli.h
@@ -278,6 +278,8 @@ Future<bool> locationMetadataCommandActor(Database cx, std::vector<StringRef> to
 Future<UID> bulkLoadCommandActor(Database cx, std::vector<StringRef> tokens);
 // Bulk dumping command
 Future<UID> bulkDumpCommandActor(Database cx, std::vector<StringRef> tokens);
+// Range lock management command
+Future<bool> rangeLockCommandActor(Database cx, std::vector<StringRef> tokens);
 // force_recovery_with_data_loss command
 Future<bool> forceRecoveryWithDataLossCommandActor(Reference<IDatabase> db, std::vector<StringRef> const& tokens);
 // include command


### PR DESCRIPTION
Bulkload requires rangelock.  As part of productionizing bulkload/rangelock, expose an fdbcli command that allows exploring rangelock state. Wraps the existing range-lock management API (registerRangeLockOwner, takeExclusiveReadLockOnRange, etc.) so SREs can inspect and release locks left behind by failed bulkload jobs without writing a custom client. Subcommands: register, unregister, owners, take, release, release-all, list. The take subcommand prints a notice that locks only take effect when knob_enable_read_lock_on_range is set on commit proxies, since the client cannot probe server knobs.

`  20260605-002815-stack_fdbcli-e2ebcf99fa75b3f8      compressed=True data_size=37197137 duration=2179380 ended=100000 fail=1 fail_fast=10 max_runs=100000 pass=99999 priority=100 remaining=0 runtime=0:36:48 sanity=False started=100000 stopped=20260605-010503 submitted=20260605-002815 timeout=5400 username=stack_fdbcli`

This failed

`RandomSeed="1692941378" SourceVersion="a2d463ece9a139622794bd691e1bd3b7d4528015" Time="1780620139" BuggifyEnabled="1" DeterminismCheck="0" FaultInjectionEnabled="1" TestFile="tests/restarting/to_8.0.0/CycleTestRestart-1.toml"`

Seems unrelated to adding an fdbcli command.