### PR TITLE
release-7.4 backport of DeterministicRandom enhancements

### DIFF
--- a/fdbclient/MultiVersionTransaction.actor.cpp
+++ b/fdbclient/MultiVersionTransaction.actor.cpp
@@ -3113,7 +3113,7 @@ void MultiVersionApi::setupNetwork() {
 			}
 
 			if (!bypassMultiClientApi) {
-				platform::getRandomBytes(&transportId, sizeof(transportId));
+				transportId = platform::getRandomSeed();
 				if (transportId <= 1)
 					transportId += 2;
 				localClient->api->setNetworkOption(FDBNetworkOptions::EXTERNAL_CLIENT_TRANSPORT_ID,

--- a/fdbserver/fdbserver.actor.cpp
+++ b/fdbserver/fdbserver.actor.cpp
@@ -1099,7 +1099,7 @@ struct CLIOptions {
 	bool maxLogsSet = false;
 
 	ServerRole role = ServerRole::FDBD;
-	uint32_t randomSeed = platform::getRandomSeed();
+	uint64_t randomSeed = platform::getRandomSeed();
 
 	const char* testFile = "tests/default.txt";
 	std::string kvFile;
@@ -1556,7 +1556,7 @@ private:
 				break;
 			case OPT_RANDOMSEED: {
 				char* end;
-				randomSeed = (uint32_t)strtoul(args.OptionArg(), &end, 0);
+				randomSeed = strtoull(args.OptionArg(), &end, 0);
 				if (*end) {
 					fprintf(stderr, "ERROR: Could not parse random seed `%s'\n", args.OptionArg());
 					printHelpTeaser(argv[0]);
@@ -2037,7 +2037,7 @@ int main(int argc, char* argv[]) {
 		const auto role = opts.role;
 
 		if (role == ServerRole::Simulation) {
-			printf("Random seed is %u...\n", opts.randomSeed);
+			printf("Random seed is %llu...\n", opts.randomSeed);
 			bindDeterministicRandomToOpenssl();
 		}
 

--- a/flow/DeterministicRandom.cpp
+++ b/flow/DeterministicRandom.cpp
@@ -26,14 +26,26 @@
 
 uint64_t DeterministicRandom::gen64() {
 	uint64_t curr = next;
-	next = (uint64_t(random()) << 32) ^ random();
+
+	// RE: the previous implementation of this function: order of
+	// evaluation of arguments to the ^ operator is not specified, so
+	// two rng() calls in the same ^ expression may not produce a
+	// consistent 64-bit value across compilations, because we don't
+	// know if the first call was used for the higher order bits and
+	// the second call for the low order bits, or vice-versa.
+	// See https://en.cppreference.com/w/cpp/language/eval_order.html
+	next = (uint64_t(rng()) << 32);
+	next ^= rng();
 	if (TRACE_SAMPLE())
 		TraceEvent(SevSample, "Random").log();
 	return curr;
 }
 
 DeterministicRandom::DeterministicRandom(uint32_t seed, bool useRandLog)
-  : random((unsigned long)seed), next((uint64_t(random()) << 32) ^ random()), useRandLog(useRandLog) {}
+  : rng((unsigned long)seed), next(0), useRandLog(useRandLog) {
+	next = (uint64_t(rng()) << 32);
+	next ^= rng();
+}
 
 double DeterministicRandom::random01() {
 	double d = gen64() / double(uint64_t(-1));
@@ -94,7 +106,7 @@ uint32_t DeterministicRandom::randomSkewedUInt32(uint32_t min, uint32_t maxPlusO
 	ASSERT_LT(min, maxPlusOne);
 	std::uniform_real_distribution<double> distribution(std::log(std::max<double>(min, 1.0 / M_E)),
 	                                                    std::log(maxPlusOne));
-	double exponent = distribution(random);
+	double exponent = distribution(rng);
 	uint32_t value = static_cast<uint32_t>(std::pow(M_E, exponent));
 	return std::max(std::min(value, maxPlusOne - 1), min);
 }

--- a/flow/DeterministicRandom.cpp
+++ b/flow/DeterministicRandom.cpp
@@ -26,25 +26,14 @@
 
 uint64_t DeterministicRandom::gen64() {
 	uint64_t curr = next;
-
-	// RE: the previous implementation of this function: order of
-	// evaluation of arguments to the ^ operator is not specified, so
-	// two rng() calls in the same ^ expression may not produce a
-	// consistent 64-bit value across compilations, because we don't
-	// know if the first call was used for the higher order bits and
-	// the second call for the low order bits, or vice-versa.
-	// See https://en.cppreference.com/w/cpp/language/eval_order.html
-	next = (uint64_t(rng()) << 32);
-	next ^= rng();
+	next = rng();
 	if (TRACE_SAMPLE())
 		TraceEvent(SevSample, "Random").log();
 	return curr;
 }
 
-DeterministicRandom::DeterministicRandom(uint32_t seed, bool useRandLog)
-  : rng((unsigned long)seed), next(0), useRandLog(useRandLog) {
-	next = (uint64_t(rng()) << 32);
-	next ^= rng();
+DeterministicRandom::DeterministicRandom(uint64_t seed, bool useRandLog) : rng(seed), next(0), useRandLog(useRandLog) {
+	next = rng();
 }
 
 double DeterministicRandom::random01() {

--- a/flow/Platform.actor.cpp
+++ b/flow/Platform.actor.cpp
@@ -174,6 +174,8 @@ static_assert(std::is_same<boost::asio::ip::address_v6::bytes_type, std::array<u
 #include <netinet/in.h>
 #include <sys/mount.h>
 #include <sys/param.h>
+/* Needed for getentropy() */
+#include <sys/random.h>
 #include <sys/sysctl.h>
 #include <sys/syslimits.h>
 #include <sys/uio.h>
@@ -2263,24 +2265,22 @@ void setAffinity(int proc) {
 
 namespace platform {
 
-int getRandomSeed() {
+uint64_t getRandomSeed() {
 	INJECT_FAULT(platform_error, "getRandomSeed"); // getting a random seed failed
-	int randomSeed;
-
+	uint64_t randomSeed;
 #ifdef _WIN32
-	if (rand_s((unsigned int*)&randomSeed) != 0) {
+	uint32_t high, low;
+	if (rand_s(&low) != 0 || rand_s(&high) != 0 {
 		TraceEvent(SevError, "WindowsRandomSeedError").log();
 		throw platform_error();
 	}
+	randomSeed = (uint64_t(high) << 32) | uint64_t(low);
 #else
-	int devRandom = open("/dev/urandom", O_RDONLY | O_CLOEXEC);
-	if (read(devRandom, &randomSeed, sizeof(randomSeed)) != sizeof(randomSeed)) {
-		TraceEvent(SevError, "OpenURandom").GetLastError();
+	if (getentropy(&randomSeed, sizeof(randomSeed)) != 0) {
+		TraceEvent(SevError, "GetEntropyError").GetLastError();
 		throw platform_error();
 	}
-	close(devRandom);
 #endif
-
 	return randomSeed;
 }
 
@@ -2312,6 +2312,7 @@ void getRandomBytes(void* buf, size_t len) {
 	}
 #endif
 }
+
 } // namespace platform
 
 std::string joinPath(std::string const& directory, std::string const& filename) {

--- a/flow/Platform.actor.cpp
+++ b/flow/Platform.actor.cpp
@@ -2270,7 +2270,7 @@ uint64_t getRandomSeed() {
 	uint64_t randomSeed;
 #ifdef _WIN32
 	uint32_t high, low;
-	if (rand_s(&low) != 0 || rand_s(&high) != 0 {
+	if (rand_s(&low) != 0 || rand_s(&high) != 0) {
 		TraceEvent(SevError, "WindowsRandomSeedError").log();
 		throw platform_error();
 	}

--- a/flow/flow.cpp
+++ b/flow/flow.cpp
@@ -107,7 +107,7 @@ Reference<IRandom> seededDebugRandom;
 uint64_t debug_lastLoadBalanceResultEndpointToken = 0;
 bool noUnseed = false;
 
-void setThreadLocalDeterministicRandomSeed(uint32_t seed) {
+void setThreadLocalDeterministicRandomSeed(uint64_t seed) {
 	seededRandom = Reference<IRandom>(new DeterministicRandom(seed, true));
 	seededDebugRandom = Reference<IRandom>(new DeterministicRandom(seed));
 }

--- a/flow/include/flow/DeterministicRandom.h
+++ b/flow/include/flow/DeterministicRandom.h
@@ -22,6 +22,9 @@
 #define FLOW_DETERIMINISTIC_RANDOM_H
 #pragma once
 
+#include <boost/random/mersenne_twister.hpp>
+#include <boost/random/uniform_int_distribution.hpp>
+
 #include <cinttypes>
 #include "flow/IRandom.h"
 #include "flow/Error.h"
@@ -38,7 +41,14 @@
 class SWIFT_CXX_REF_DETERMINISTICRANDOM DeterministicRandom final : public IRandom,
                                                                     public ReferenceCounted<DeterministicRandom> {
 private:
-	std::mt19937 random;
+	// Use boost::random::mt19937 to get consistent output across
+	// different compilers and therefore across different C++ standard
+	// library implementations. In other words, don't rely on the
+	// standard library for this.
+	//
+	// This is not expected to affect performance.  See e.g.
+	// https://chatgpt.com/share/68800ee9-3270-800b-aa84-4567167f02ab
+	boost::random::mt19937 rng;
 	uint64_t next;
 	bool useRandLog;
 

--- a/flow/include/flow/DeterministicRandom.h
+++ b/flow/include/flow/DeterministicRandom.h
@@ -43,19 +43,15 @@ class SWIFT_CXX_REF_DETERMINISTICRANDOM DeterministicRandom final : public IRand
 private:
 	// Use boost::random::mt19937 to get consistent output across
 	// different compilers and therefore across different C++ standard
-	// library implementations. In other words, don't rely on the
-	// standard library for this.
-	//
-	// This is not expected to affect performance.  See e.g.
-	// https://chatgpt.com/share/68800ee9-3270-800b-aa84-4567167f02ab
-	boost::random::mt19937 rng;
+	// library implementations.
+	boost::random::mt19937_64 rng;
 	uint64_t next;
 	bool useRandLog;
 
 	uint64_t gen64();
 
 public:
-	DeterministicRandom(uint32_t seed, bool useRandLog = false);
+	DeterministicRandom(uint64_t seed, bool useRandLog = false);
 	double random01() override;
 	int randomInt(int min, int maxPlusOne) override;
 	int64_t randomInt64(int64_t min, int64_t maxPlusOne) override;

--- a/flow/include/flow/IRandom.h
+++ b/flow/include/flow/IRandom.h
@@ -196,7 +196,7 @@ public:
 extern FILE* randLog;
 
 // Sets the seed for the deterministic random number generator on the current thread
-void setThreadLocalDeterministicRandomSeed(uint32_t seed);
+void setThreadLocalDeterministicRandomSeed(uint64_t seed);
 
 // Returns the random number generator that can be seeded. This generator should only
 // be used in contexts where the choice to call it is deterministic.

--- a/flow/include/flow/Platform.h
+++ b/flow/include/flow/Platform.h
@@ -422,7 +422,7 @@ void setCloseOnExec(int fd);
 // Logs an out of memory error and exits the program
 void outOfMemory();
 
-int getRandomSeed();
+uint64_t getRandomSeed();
 void getRandomBytes(void* buf, size_t len);
 
 bool getEnvironmentVar(const char* name, std::string& value);

--- a/flowbench/BenchIONet2.actor.cpp
+++ b/flowbench/BenchIONet2.actor.cpp
@@ -49,7 +49,7 @@ static inline TaskPriority getRandomTaskPriority(DeterministicRandom& rand) {
 ACTOR static Future<Void> benchIONet2Actor(benchmark::State* benchState) {
 	state size_t actorCount = benchState->range(0);
 	state uint32_t sum;
-	state int seed = platform::getRandomSeed();
+	state uint64_t seed = platform::getRandomSeed();
 	state std::unique_ptr<char[]> data(new char[4096]);
 	memset(data.get(), 0, 4096);
 	while (benchState->KeepRunning()) {

--- a/flowbench/BenchNet2.actor.cpp
+++ b/flowbench/BenchNet2.actor.cpp
@@ -41,7 +41,7 @@ static inline TaskPriority getRandomTaskPriority(DeterministicRandom& rand) {
 ACTOR static Future<Void> benchNet2Actor(benchmark::State* benchState) {
 	state size_t actorCount = benchState->range(0);
 	state uint32_t sum;
-	state int seed = platform::getRandomSeed();
+	state uint64_t seed = platform::getRandomSeed();
 	while (benchState->KeepRunning()) {
 		sum = 0;
 		std::vector<Future<Void>> futures;


### PR DESCRIPTION
Switch to boost implementation, and switch to 64-bit internal engine.

Should be fully compatible, because 32-bit seeds (and often smaller) are still accepted, and the "unseed" output is still the same 5-ish decimal digits: `deterministicRandom()->randomInt(0, 100001)`

Not really needed. But "why not" since the 7.4 branch isn't heavily or widely used yet :)