### PR TITLE
Remove dead client-side storage cache code left behind by #12486

### DIFF
--- a/fdbclient/DatabaseContext.cpp
+++ b/fdbclient/DatabaseContext.cpp
@@ -914,41 +914,6 @@ static Future<Void> monitorClientDBInfoChange(DatabaseContext* cx,
 	}
 }
 
-void updateLocationCacheWithCaches(DatabaseContext* self,
-                                   const std::map<UID, StorageServerInterface>& removed,
-                                   const std::map<UID, StorageServerInterface>& added) {
-	// TODO: this needs to be more clever in the future
-	auto ranges = self->locationCache.ranges();
-	for (auto iter = ranges.begin(); iter != ranges.end(); ++iter) {
-		if (iter->value() && iter->value()->hasCaches) {
-			auto& val = iter->value();
-			std::vector<Reference<ReferencedInterface<StorageServerInterface>>> interfaces;
-			interfaces.reserve(val->size() - removed.size() + added.size());
-			for (int i = 0; i < val->size(); ++i) {
-				const auto& interf = (*val)[i];
-				if (!removed.contains(interf->interf.id())) {
-					interfaces.emplace_back(interf);
-				}
-			}
-			for (const auto& p : added) {
-				interfaces.push_back(makeReference<ReferencedInterface<StorageServerInterface>>(p.second));
-			}
-			iter->value() = makeReference<LocationInfo>(interfaces, true);
-		}
-	}
-}
-
-Reference<LocationInfo> addCaches(const Reference<LocationInfo>& loc,
-                                  const std::vector<Reference<ReferencedInterface<StorageServerInterface>>>& other) {
-	std::vector<Reference<ReferencedInterface<StorageServerInterface>>> interfaces;
-	interfaces.reserve(loc->size() + other.size());
-	for (int i = 0; i < loc->size(); ++i) {
-		interfaces.emplace_back((*loc)[i]);
-	}
-	interfaces.insert(interfaces.end(), other.begin(), other.end());
-	return makeReference<LocationInfo>(interfaces, true);
-}
-
 static Future<Void> handleTssMismatches(DatabaseContext* cx) {
 	Reference<ReadYourWritesTransaction> tr;
 	KeyBackedMap<UID, UID> tssMapDB = KeyBackedMap<UID, UID>(tssMappingKeys.begin);

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -1576,7 +1576,7 @@ namespace {
 
 template <class Interface, class Request, bool P>
 Future<REPLY_TYPE(Request)> loadBalance(
-    DatabaseContext* ctx,
+    DatabaseContext* /* ctx */,
     const Reference<LocationInfo> alternatives,
     RequestStream<Request, P> Interface::* channel,
     const Request& request = Request(),
@@ -1586,19 +1586,8 @@ Future<REPLY_TYPE(Request)> loadBalance(
     QueueModel* model = nullptr,
     bool compareReplicas = false,
     int requiredReplicas = 0) {
-	if (alternatives->hasCaches) {
-		return loadBalance(
-		    alternatives->locations(), channel, request, taskID, atMostOnce, model, compareReplicas, requiredReplicas);
-	}
-	return fmap(
-	    [ctx](auto const& res) {
-		    if (res.cached) {
-			    ctx->updateCache.trigger();
-		    }
-		    return res;
-	    },
-	    loadBalance(
-	        alternatives->locations(), channel, request, taskID, atMostOnce, model, compareReplicas, requiredReplicas));
+	return loadBalance(
+	    alternatives->locations(), channel, request, taskID, atMostOnce, model, compareReplicas, requiredReplicas);
 }
 } // namespace
 

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -1572,25 +1572,6 @@ Future<Void> Transaction::warmRange(KeyRange keys) {
 	return warmRange_impl(trState, keys);
 }
 
-namespace {
-
-template <class Interface, class Request, bool P>
-Future<REPLY_TYPE(Request)> loadBalance(
-    DatabaseContext* /* ctx */,
-    const Reference<LocationInfo> alternatives,
-    RequestStream<Request, P> Interface::* channel,
-    const Request& request = Request(),
-    TaskPriority taskID = TaskPriority::DefaultPromiseEndpoint,
-    AtMostOnce atMostOnce =
-        AtMostOnce::False, // if true, throws request_maybe_delivered() instead of retrying automatically
-    QueueModel* model = nullptr,
-    bool compareReplicas = false,
-    int requiredReplicas = 0) {
-	return loadBalance(
-	    alternatives->locations(), channel, request, taskID, atMostOnce, model, compareReplicas, requiredReplicas);
-}
-} // namespace
-
 ACTOR Future<Optional<Value>> getValue(Reference<TransactionState> trState,
                                        Key key,
                                        TransactionRecordLogInfo recordLogInfo) {
@@ -1643,8 +1624,7 @@ ACTOR Future<Optional<Value>> getValue(Reference<TransactionState> trState,
 						throw transaction_too_old();
 					}
 					when(GetValueReply _reply = wait(
-					         loadBalance(trState->cx.getPtr(),
-					                     locationInfo.locations,
+					         loadBalance(locationInfo.locations->locations(),
 					                     &StorageServerInterface::getValue,
 					                     GetValueRequest(span.context,
 					                                     key,
@@ -1772,8 +1752,7 @@ ACTOR Future<Key> getKey(Reference<TransactionState> trState, KeySelector k) {
 						throw transaction_too_old();
 					}
 					when(GetKeyReply _reply = wait(
-					         loadBalance(trState->cx.getPtr(),
-					                     locationInfo.locations,
+					         loadBalance(locationInfo.locations->locations(),
 					                     &StorageServerInterface::getKey,
 					                     req,
 					                     TaskPriority::DefaultPromiseEndpoint,
@@ -1915,8 +1894,7 @@ ACTOR Future<Version> watchValue(Database cx, Reference<const WatchParameters> p
 			state WatchValueReply resp;
 			choose {
 				when(WatchValueReply r = wait(
-				         loadBalance(cx.getPtr(),
-				                     locationInfo.locations,
+				         loadBalance(locationInfo.locations->locations(),
 				                     &StorageServerInterface::watchValue,
 				                     WatchValueRequest(span.context,
 				                                       parameters->key,
@@ -2268,8 +2246,7 @@ Future<RangeResultFamily> getExactRange(Reference<TransactionState> trState,
 							throw transaction_too_old();
 						}
 						when(GetKeyValuesFamilyReply _rep = wait(loadBalance(
-						         trState->cx.getPtr(),
-						         locations[shard].locations,
+						         locations[shard].locations->locations(),
 						         getRangeRequestStream<GetKeyValuesFamilyRequest>(),
 						         req,
 						         TaskPriority::DefaultPromiseEndpoint,
@@ -2654,8 +2631,7 @@ Future<RangeResultFamily> getRange(Reference<TransactionState> trState,
 					}
 					// state AnnotateActor annotation(currentLineage);
 					GetKeyValuesFamilyReply _rep =
-					    wait(loadBalance(trState->cx.getPtr(),
-					                     beginServer.locations,
+					    wait(loadBalance(beginServer.locations->locations(),
 					                     getRangeRequestStream<GetKeyValuesFamilyRequest>(),
 					                     req,
 					                     TaskPriority::DefaultPromiseEndpoint,

--- a/fdbclient/include/fdbclient/DatabaseContext.h
+++ b/fdbclient/include/fdbclient/DatabaseContext.h
@@ -65,13 +65,10 @@ struct LocationInfo : MultiInterface<ReferencedInterface<StorageServerInterface>
 	using Locations = MultiInterface<ReferencedInterface<StorageServerInterface>>;
 	explicit LocationInfo(const std::vector<Reference<ReferencedInterface<StorageServerInterface>>>& v)
 	  : Locations(v) {}
-	LocationInfo(const std::vector<Reference<ReferencedInterface<StorageServerInterface>>>& v, bool hasCaches)
-	  : Locations(v), hasCaches(hasCaches) {}
 	LocationInfo(const LocationInfo&) = delete;
 	LocationInfo(LocationInfo&&) = delete;
 	LocationInfo& operator=(const LocationInfo&) = delete;
 	LocationInfo& operator=(LocationInfo&&) = delete;
-	bool hasCaches = false;
 	Reference<Locations> locations() { return Reference<Locations>::addRef(this); }
 };
 
@@ -547,8 +544,6 @@ public:
 
 	UniqueOrderedOptionList<FDBTransactionOptions> transactionDefaults;
 
-	Future<Void> cacheListMonitor;
-	AsyncTrigger updateCache;
 	std::vector<std::unique_ptr<SpecialKeyRangeReadImpl>> specialKeySpaceModules;
 	std::unique_ptr<SpecialKeySpace> specialKeySpace;
 	void registerSpecialKeysImpl(SpecialKeySpace::MODULE module,


### PR DESCRIPTION
## Problem

PR #12486 deleted the Storage Cache Server feature in Oct 2025. PR #13119 later swept up similar dead code left over from the blob worker, change feed, and metacluster deletions, but the storage-cache cleanup never got its own follow-up. A small island of unreachable client-side code still sits on `main`.

## Solution

Remove the leftover symbols and the dead control flow that referenced them.

**Dead members removed (`fdbclient/include/fdbclient/DatabaseContext.h`):**
- `LocationInfo::hasCaches` field and its 2-argument constructor. The only producers that set `hasCaches=true` were `addCaches()` and `updateLocationCacheWithCaches()`, both of which had zero callers.
- `DatabaseContext::cacheListMonitor` (`Future<Void>`). Declared but never assigned anywhere in the repo. Its sole producer was the `updateCachedRanges()` actor, deleted in #12486.
- `DatabaseContext::updateCache` (`AsyncTrigger`). Only `.trigger()` callers remained; the only `.onTrigger()` consumer was inside `updateCachedRanges()`, also deleted in #12486.

**Dead functions removed (`fdbclient/DatabaseContext.cpp`):**
- `addCaches()` - zero callers.
- `updateLocationCacheWithCaches()` - zero callers.

**Dead control flow removed (`fdbclient/NativeAPI.actor.cpp`):**
- The `if (alternatives->hasCaches)` branch in the `loadBalance()` wrapper - unreachable, since every `LocationInfo` is now constructed with `hasCaches=false`.
- The `fmap`-wrapped `ctx->updateCache.trigger()` call - fires a trigger with no consumer.

**Intentionally not touched:**
- The serialized `bool cached` fields on storage server reply types (`GetValueReply`, `GetKeyValuesReply`, etc.). Those are wire-format and removing them would be a protocol change, out of scope for a dead-code cleanup.

## Testing done

Verified by grep that no references remain to any removed symbol. No behavior change is intended: every removed code path was statically unreachable on `main` prior to this PR. Unable to run the full FDB test suite locally on macOS (the test harness is Linux-only); relying on CI for validation.
