### PR TITLE
fix: platform::getRandomSeed() win32 code missing parenthesis

### DIFF
--- a/flow/Platform.cpp
+++ b/flow/Platform.cpp
@@ -2209,7 +2209,7 @@ uint64_t getRandomSeed() {
 	uint64_t randomSeed;
 #ifdef _WIN32
 	uint32_t high, low;
-	if (rand_s(&low) != 0 || rand_s(&high) != 0 {
+	if (rand_s(&low) != 0 || rand_s(&high) != 0) {
 		TraceEvent(SevError, "WindowsRandomSeedError").log();
 		throw platform_error();
 	}


### PR DESCRIPTION
bug introduced in #13136 

... and we do not have any windows compile tests at the moment 😬 - only caught by the actor-compiler on the release-7.4 branch