### PR TITLE
bindings/python: use venv to build python package

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -84,10 +84,13 @@ set(wheel_package_file ${CMAKE_BINARY_DIR}/packages/foundationdb-${FDB_VERSION}$
 
 # Build both source distribution and wheel
 # Note: foundationdb is a pure Python package (uses ctypes), so wheel is py3-none-any
+set(PYPKG_VENV_DIR "${CMAKE_BINARY_DIR}/pypkg-venv")
+set(PYPKG_PY3      "${PYPKG_VENV_DIR}/bin/python3")
 add_custom_command(OUTPUT ${package_file} ${wheel_package_file}
-  COMMAND $<TARGET_FILE:Python3::Interpreter> -m ensurepip
-  COMMAND $<TARGET_FILE:Python3::Interpreter> -m pip install --upgrade build
-  COMMAND $<TARGET_FILE:Python3::Interpreter> -m build
+  COMMAND $<TARGET_FILE:Python3::Interpreter> -m venv "${PYPKG_VENV_DIR}"
+  COMMAND ${PYPKG_PY3} -m ensurepip
+  COMMAND ${PYPKG_PY3} -m pip install --upgrade build
+  COMMAND ${PYPKG_PY3} -m build
   COMMAND ${CMAKE_COMMAND} -E copy_if_different dist/${setup_file_name} ${package_file}
   COMMAND ${CMAKE_COMMAND} -E copy_if_different dist/${wheel_file_name} ${wheel_package_file}
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}

--- a/documentation/CMakeLists.txt
+++ b/documentation/CMakeLists.txt
@@ -16,7 +16,6 @@ if(NOT Sphinx_FOUND)
     NO_DEFAULT_PATH NO_CACHE
     DOC "Checking Python3 executable in virtual environment")
   execute_process(COMMAND "${VENV_Python3_EXECUTABLE}" -m ensurepip COMMAND_ERROR_IS_FATAL ANY)
-  execute_process(COMMAND "${VENV_Python3_EXECUTABLE}" -m pip install --upgrade pip COMMAND_ERROR_IS_FATAL ANY)
   execute_process(COMMAND "${VENV_Python3_EXECUTABLE}" -m pip install -r "${SPHINX_DOCUMENT_DIR}/requirements.txt" COMMAND_ERROR_IS_FATAL ANY)
   set(Sphinx_ROOT "${SPHINX_VENV_DIR}")
   unset(Sphinx_FOUND)

--- a/flow/CMakeLists.txt
+++ b/flow/CMakeLists.txt
@@ -57,8 +57,6 @@ if(NOT Jinja2_FOUND)
     DOC "Checking Python3 executable in virtual environment")
   execute_process(COMMAND "${VENV_Python3_EXECUTABLE}" -m ensurepip
                           COMMAND_ERROR_IS_FATAL ANY)
-  execute_process(COMMAND "${VENV_Python3_EXECUTABLE}" -m pip install --upgrade
-                          pip COMMAND_ERROR_IS_FATAL ANY)
   execute_process(
     COMMAND
       "${VENV_Python3_EXECUTABLE}" -m pip install -r


### PR DESCRIPTION
All the other uses of python in the build system already create a venv to install their python dependencies in. This is generally needed with modern pip, otherwise you get errors like:

> error: externally-managed-environment
> You may restore the old behavior of pip by passing
> the '--break-system-packages' flag to pip

This problem can also be avoided by creating/activating a venv manually, before running the foundationdb cmake config, and that does not cause problems for this cmake build to create and use more venvs.

Also, no need to upgrade pip all the time, any remotely supported python3 version install has a good-enough pip (good enough to upgrade itself!)