### PR TITLE
Add LSAN suppression for CancelTransactionWorkload shutdown leaks

### DIFF
--- a/contrib/lsan.suppressions
+++ b/contrib/lsan.suppressions
@@ -36,3 +36,17 @@ leak:runNetworkThread
 # onMainThread into the external client's network thread. If that thread
 # has already stopped, the dispatched work leaks.
 leak:monitorProtocolVersion
+
+# CApiCancelTransactionCB drops fdb::Future objects from get() without
+# awaiting them, then calls done() which cancels the transaction. The
+# cancellation propagates asynchronously across the test process's local
+# fdb_c network thread and each external client's network thread. When
+# stopNetwork() runs, whichever Net2 reaches stopImmediately() first does
+# the leak check while the other Net2s' taskQueues are still intact;
+# afterwards taskQueue.clear() drops PromiseTasks (raw pointers, leaked
+# by design — see flow/Net2.cpp). The doOnMainThread actor frames waiting
+# on those Promises never wake, so process-exit LSan reports them. Suppress
+# on the test path so we mask only the test-induced shutdown race, not real
+# leaks on these code paths.
+leak:CancelTransactionWorkload::randomCancelGetTx
+leak:CancelTransactionWorkload::randomCancelAfterFirstResTx


### PR DESCRIPTION
Showed up last night in nightly.

The following tests FAILED:
	 26 - fdb_c_api_test_CApiCancelTransactionCB (Failed)
Errors while running CTest

CApiCancelTransactionCB intermittently fails on nightly CI with 60 allocations / 16640 bytes leaked at process exit. The leaks all trace through CancelTransactionWorkload::randomCancelGetTx, which drops fdb::Future objects without awaiting them and then calls done() to cancel the transaction.

Cancellation propagates asynchronously across the test process's local fdb_c network thread and each external client's network thread. When stopNetwork() runs, whichever Net2 reaches stopImmediately() first does the leak check while the other Net2s' taskQueues are still intact; afterwards taskQueue.clear() drops PromiseTasks (raw pointers, leaked by design per the comment in flow/Net2.cpp). The doOnMainThread actor frames waiting on those Promises never wake, so process-exit LSan reports them.

Suppress on the test path (randomCancelGetTx and the sibling randomCancelAfterFirstResTx, which has the same shutdown-race shape) so we mask only the test-induced race, not real leaks in DLTransaction::get or ThreadSafeTransaction::get themselves.
