### PR TITLE
Remove unpopulated StorageServer::cachedRangeMap left behind by #12486

### DIFF
--- a/fdbserver/storageserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver/storageserver.actor.cpp
@@ -1139,8 +1139,6 @@ public:
 	KeyRangeMap<SSBulkLoadMetadata> ssBulkLoadMetadataMap; // store the latest bulkload task on ranges
 	uint64_t shardChangeCounter; // max( shards->changecounter )
 
-	KeyRangeMap<bool> cachedRangeMap; // indicates if a key-range is being cached
-
 	// newestAvailableVersion[k]
 	//   == invalidVersion -> k is unavailable at all versions
 	//   <= storageVersion -> k is unavailable at all versions (but might be read anyway from storage if we are in the
@@ -2247,12 +2245,7 @@ Future<Void> getValueQ(StorageServer* data, GetValueRequest req) {
 			                      req.options.get().debugID.get().first(),
 			                      "getValueQ.AfterRead"); //.detail("TaskID", g_network->getCurrentTask());
 
-		// Check if the desired key might be cached
-		auto cached = data->cachedRangeMap[req.key];
-		// if (cached)
-		//	TraceEvent(SevDebug, "SSGetValueCached").detail("Key", req.key);
-
-		GetValueReply reply(v, cached);
+		GetValueReply reply(v, /*cached=*/false);
 		reply.penalty = data->getPenalty();
 		req.reply.send(reply);
 	} catch (Error& e) {
@@ -2882,15 +2875,6 @@ Future<GetKeyValuesReply> readRange(StorageServer* data,
 
 	// for remembering the position in the resultCache
 	int pos = 0;
-
-	// Check if the desired key-range is cached
-	auto containingRange = data->cachedRangeMap.rangeContaining(range.begin);
-	if (containingRange.value() && containingRange->range().end >= range.end) {
-		//TraceEvent(SevDebug, "SSReadRangeCached").detail("Size",data->cachedRangeMap.size()).detail("ContainingRangeBegin",containingRange->range().begin).detail("ContainingRangeEnd",containingRange->range().end).
-		//	detail("Begin", range.begin).detail("End",range.end);
-		result.cached = true;
-	} else
-		result.cached = false;
 
 	// if (limit >= 0) we are reading forward, else backward
 	if (limit >= 0) {
@@ -6046,13 +6030,7 @@ Future<Void> getKeyQ(StorageServer* data, GetKeyRequest req) {
 		data->counters.bytesQueried += resultSize;
 		++data->counters.rowsQueried;
 
-		// Check if the desired key might be cached
-		auto cached = data->cachedRangeMap[absoluteKey];
-		// if (cached)
-		//	TraceEvent(SevDebug, "SSGetKeyCached").detail("Key", k).detail("Begin",
-		// shard.begin).detail("End", shard.end);
-
-		GetKeyReply reply(updated, cached);
+		GetKeyReply reply(updated, /*cached=*/false);
 		reply.penalty = data->getPenalty();
 
 		req.reply.send(reply);

--- a/fdbserver/storageserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver/storageserver.actor.cpp
@@ -2876,6 +2876,8 @@ Future<GetKeyValuesReply> readRange(StorageServer* data,
 	// for remembering the position in the resultCache
 	int pos = 0;
 
+	result.cached = false;
+
 	// if (limit >= 0) we are reading forward, else backward
 	if (limit >= 0) {
 		// We might care about a clear beginning before start that


### PR DESCRIPTION
## Problem
Follow-up to #13326. `StorageServer::cachedRangeMap` is declared but never written by anything in the tree - `KeyRangeMap<bool>` defaults to `false`, so every read produces `false`.

## Solution
Delete `cachedRangeMap` from `StorageServer` and simplify the three read sites in `getValueQ`, `readRange`, and `getKeyQ` to pass `cached=false` directly.

Addresses items 1 and 3 from @gxglass's [follow-up review on #13326](https://github.com/apple/foundationdb/pull/13326#pullrequestreview-4460540009). The wire-format `cached` field on the reply structs (his item 2) is intentionally left for a separate compat-aware PR.

## Testing done
Verified by grep that no references to `cachedRangeMap` remain in `fdbserver/`, `fdbclient/`, or `flow/`. No behavior change - every removed path produced `false` already. Relying on CI for validation; macOS host can't run the simulation harness locally