### PR TITLE
give github stale-action permission actions:write

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,6 +4,7 @@ on:
     - cron: '15 20 * * *' # 20:15 UTC
 
 permissions:
+  actions: write
   issues: write
   pull-requests: write
 


### PR DESCRIPTION
needed for it to manage its github actions cache state:

> Warning: Error delete _state: [403] Resource not accessible by integration

It needs this _state cache because:

> If the action ends because of operations-per-run then the next run will
> start from the first unprocessed issue skipping the issues processed
> during the previous run(s). The state is reset when all the issues are processed.

It seems like actions:write permits a lot of stuff, like triggering other actions, that it would be nice to avoid permitting. It also seems like a github action should not need so much permissions just to use the github actions cache. But because this tries to *delete* its own cache, this seems to be the permission it needs. (It is mostly working, just not starting at the best place in the list of issues/PRs.)

---------

Thinking about this more ... typically an action cache item would be immutable, with a key that changes if the contents should change, like a hash of requirements.txt or similar. But in this case the action wants to update a single cache key to store changing state.