### PR TITLE
Stop WaitStorageMetricsHandleError SevWarn spam during long stalls

### DIFF
--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -5895,9 +5895,16 @@ Future<std::pair<Optional<StorageMetrics>, int>> waitStorageMetrics(Database cx,
 			err = e;
 		}
 		retryCount++;
-		// Upgrade from SevDebug to SevWarn after 60 seconds of retrying
-		Severity sev = (now() - startTime > 60.0) ? SevWarn : SevDebug;
-		TraceEvent(sev, "WaitStorageMetricsHandleError")
+		// Stays at SevDebug. The previous SevDebug→SevWarn upgrade after 60s
+		// elapsed didn't actually filter for stuck shards: the SS-side
+		// waitMetrics is a long-poll with a STORAGE_METRIC_TIMEOUT of 600s,
+		// and on timeout the SS deliberately returns wrong_shard_server with
+		// WAIT_METRICS_WRONG_SHARD_CHANCE = 0.1 to force clients to refresh
+		// their location cache. So most calls that ever hit this catch are
+		// already past 60s elapsed by design, and the SevWarn was firing on
+		// normal cluster operation. DD-init stall visibility lives on the
+		// DDInit* events instead (PR #12913).
+		TraceEvent(SevDebug, "WaitStorageMetricsHandleError")
 		    .error(err)
 		    .detail("Keys", keys)
 		    .detail("Elapsed", now() - startTime)


### PR DESCRIPTION
PR #12913 upgraded WaitStorageMetricsHandleError from SevDebug to SevWarn after 60s of retrying, to give operators visibility into the kind of DD init stall described in that PR. The threshold is captured once per waitStorageMetrics() call (startTime), so once a single call crosses 60s, every subsequent retry inside that call logs at SevWarn. The retry delay for wrong_shard_server / all_alternatives_failed is 10ms (WRONG_SHARD_SERVER_DELAY), so a single stuck shard can produce ~100 SevWarn events per second until the call finally succeeds. In prod this puts WaitStorageMetricsHandleError in the top 35 most frequent TraceEvents.

Switch to a one-shot model:

- Per-retry log stays at SevDebug under the existing name, filtered out by prod trace levels.
- One-shot SevWarn (same WaitStorageMetricsHandleError name, so existing dashboards keep matching) fires on the transition past 60s.
- New SevInfo WaitStorageMetricsRecovered fires when the call finally succeeds after we'd warned, so dashboards can close out the alert.

The operator-actionable signal is the transition into and out of the stall, not the steady state. One pair of events per stuck shard instead of thousands.

Also rethrow actor_cancelled before treating it as an error in the catch. Cancellation is normal lifecycle (DD restart, shard split/merge replacing the tracker actor); the previous code logged it via the fall-through SevError WaitStorageMetricsError before rethrowing, producing one spurious SevError per cancelled tracker.
