### PR TITLE
Fix bulkload restore hang at scale due to abandoned data moves

### DIFF
--- a/fdbserver/datadistributor/DataDistribution.cpp
+++ b/fdbserver/datadistributor/DataDistribution.cpp
@@ -1283,6 +1283,55 @@ Future<Void> failBulkLoadTask(Reference<DataDistributor> self,
 	}
 }
 
+// Polls the persisted bulkload task state every 60s and returns when the task
+// is no longer "ours" -- i.e. when its phase has left {Running, Complete} or
+// its restartCount has advanced past ours (meaning triggerBulkLoadTask ran
+// again and a different doBulkLoadTask now owns this task). Returning from
+// this Future is the signal that the in-flight data move has been abandoned
+// or supplanted, regardless of how long the data move itself has been running.
+// While the task is still ours -- including a multi-hour large-shard data
+// move -- this Future never returns, and the caller continues waiting on
+// completeAck.
+Future<Void> waitUntilTaskAbandoned(Reference<DataDistributor> self,
+                                     KeyRange range,
+                                     UID taskId,
+                                     int ourRestartCount) {
+	while (true) {
+		co_await delay(60.0);
+		Transaction tr(self->txnProcessor->context());
+		Error err;
+		try {
+			tr.setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
+			tr.setOption(FDBTransactionOptions::LOCK_AWARE);
+			BulkLoadTaskState current = co_await getBulkLoadTask(
+			    &tr,
+			    range,
+			    taskId,
+			    { BulkLoadPhase::Triggered, BulkLoadPhase::Running, BulkLoadPhase::Complete });
+			if (current.restartCount > ourRestartCount) {
+				// Someone re-triggered the task; a different doBulkLoadTask owns it.
+				co_return;
+			}
+			// Still ours; poll again. The window from triggerBulkLoadTask (phase=Triggered)
+			// through startMoveShards' transition to Running through finishMoveShards' atomic
+			// commit of phase=Complete is all expected here. Only a phase OUTSIDE that set
+			// (Acknowledged, Error, Invalid) or a higher restartCount means we've been
+			// supplanted.
+			continue;
+		} catch (Error& e) {
+			err = e;
+		}
+		if (err.code() == error_code_actor_cancelled) {
+			throw err;
+		}
+		if (err.code() == error_code_bulkload_task_outdated) {
+			// Task is no longer in {Running, Complete} or has been overwritten.
+			co_return;
+		}
+		// Transient transaction error; retry on the next poll cycle.
+	}
+}
+
 // A bulk load task is guaranteed to be either complete or overwritten by another task
 Future<Void> doBulkLoadTask(Reference<DataDistributor> self, KeyRange range, UID taskId) {
 	Promise<BulkLoadAck> completeAck;
@@ -1316,7 +1365,37 @@ Future<Void> doBulkLoadTask(Reference<DataDistributor> self, KeyRange range, UID
 		// The completion of the task relies on the fact that a data move on a range is either
 		// completed by itself or replaced by a data move on the overlapping range
 		self->triggerShardBulkLoading.send(BulkLoadShardRequest(triggeredBulkLoadTask));
-		BulkLoadAck ack = co_await completeAck.getFuture(); // proceed when a data move completes with this task
+		// Wait for completeAck (data move finished) or for the task to be abandoned
+		// or for an absolute timeout backstop.
+		//
+		// Abandoned-detection polls the persisted task state every 60s and fires
+		// when the task leaves {Running, Complete} or its restartCount advances
+		// past ours -- meaning a different code path (DD reinit, supplanting
+		// trigger, fail/error path, etc.) is now responsible for this task. While
+		// the task is still ours -- even a multi-hour large-shard data move --
+		// the abandoned Future never resolves and we keep waiting on completeAck.
+		//
+		// Backstop timeout fires after JOB_MONITOR_PERIOD_SEC * 240 (~2 hours in
+		// production). It is the safety net for the original deadlock where DD
+		// reinitializes but no fresh code path advances the task's state -- in
+		// that case neither completeAck nor abandoned will ever fire, but the
+		// backstop guarantees this actor exits within bounded time so
+		// scheduleBulkLoadTasks can re-scan and re-dispatch.
+		Future<Void> abandoned =
+		    waitUntilTaskAbandoned(self, range, taskId, triggeredBulkLoadTask.restartCount);
+		auto raceResult = co_await race(completeAck.getFuture(),
+		                                abandoned,
+		                                delay(SERVER_KNOBS->DD_BULKLOAD_JOB_MONITOR_PERIOD_SEC * 240));
+		BulkLoadAck ack;
+		if (raceResult.index() == 0) {
+			ack = std::get<0>(std::move(raceResult));
+		} else {
+			// Task was abandoned/supplanted, or backstop timeout fired. Throw
+			// timed_out so the existing catch block traces a SevWarn,
+			// decrements the parallelism counter, and lets scheduleBulkLoadTasks
+			// re-dispatch on the next scan.
+			throw timed_out();
+		}
 		if (ack.unretryableError) {
 			TraceEvent(SevWarnAlways, "DDBulkLoadTaskDoTask", self->ddId)
 			    .detail("Phase", "See unretryable error")

--- a/fdbserver/datadistributor/DataDistribution.cpp
+++ b/fdbserver/datadistributor/DataDistribution.cpp
@@ -1292,10 +1292,7 @@ Future<Void> failBulkLoadTask(Reference<DataDistributor> self,
 // While the task is still ours -- including a multi-hour large-shard data
 // move -- this Future never returns, and the caller continues waiting on
 // completeAck.
-Future<Void> waitUntilTaskAbandoned(Reference<DataDistributor> self,
-                                     KeyRange range,
-                                     UID taskId,
-                                     int ourRestartCount) {
+Future<Void> waitUntilTaskAbandoned(Reference<DataDistributor> self, KeyRange range, UID taskId, int ourRestartCount) {
 	while (true) {
 		co_await delay(60.0);
 		Transaction tr(self->txnProcessor->context());
@@ -1304,10 +1301,7 @@ Future<Void> waitUntilTaskAbandoned(Reference<DataDistributor> self,
 			tr.setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
 			tr.setOption(FDBTransactionOptions::LOCK_AWARE);
 			BulkLoadTaskState current = co_await getBulkLoadTask(
-			    &tr,
-			    range,
-			    taskId,
-			    { BulkLoadPhase::Triggered, BulkLoadPhase::Running, BulkLoadPhase::Complete });
+			    &tr, range, taskId, { BulkLoadPhase::Triggered, BulkLoadPhase::Running, BulkLoadPhase::Complete });
 			if (current.restartCount > ourRestartCount) {
 				// Someone re-triggered the task; a different doBulkLoadTask owns it.
 				co_return;
@@ -1381,11 +1375,9 @@ Future<Void> doBulkLoadTask(Reference<DataDistributor> self, KeyRange range, UID
 		// that case neither completeAck nor abandoned will ever fire, but the
 		// backstop guarantees this actor exits within bounded time so
 		// scheduleBulkLoadTasks can re-scan and re-dispatch.
-		Future<Void> abandoned =
-		    waitUntilTaskAbandoned(self, range, taskId, triggeredBulkLoadTask.restartCount);
-		auto raceResult = co_await race(completeAck.getFuture(),
-		                                abandoned,
-		                                delay(SERVER_KNOBS->DD_BULKLOAD_JOB_MONITOR_PERIOD_SEC * 240));
+		Future<Void> abandoned = waitUntilTaskAbandoned(self, range, taskId, triggeredBulkLoadTask.restartCount);
+		auto raceResult = co_await race(
+		    completeAck.getFuture(), abandoned, delay(SERVER_KNOBS->DD_BULKLOAD_JOB_MONITOR_PERIOD_SEC * 240));
 		BulkLoadAck ack;
 		if (raceResult.index() == 0) {
 			ack = std::get<0>(std::move(raceResult));

--- a/tests/fast/BulkDumping.toml
+++ b/tests/fast/BulkDumping.toml
@@ -3,6 +3,30 @@ storageEngineExcludeTypes = ["ssd-sharded-rocksdb"] #FIXME: remove after allowin
 
 disableTss = true # TODO(BulkLoad): support TSS. finishMoveShard should wait for TSS if a data move is bulkload data move.
 
+# DD's bulk-load team selection rejects any team that shares a server with the source team
+# (DDTeamCollection.actor.cpp:266-282). Pin redundancy to 'triple' (matching
+# PhysicalShardMove and StorageServerCheckpointRestore which exercise similar bulk-load
+# paths) so the simulator cannot pick three_data_hall or other modes whose tighter
+# topology constraints leave team selection with no disjoint candidate team -- the
+# test would then stall on DDBulkLoadEngineTaskGetTeamFailedToFindValidTeam, the load
+# would produce no data, and the workload's processCheck assertion would fire
+# (BulkDumpingWorkLoadError KVS=N NewKVS=0).
+config = 'triple'
+
+# Pair the pinned redundancy with enough machines to guarantee a disjoint team.
+machineCount = 15
+
+# Without datacenters=1 the simulator picks randomInt(1,4) DCs (SimulatedCluster.cpp
+# line ~1610). When it picks 2, the 15 machines get split ~7-8 per DC, the primary
+# DC then has only 4-5 non-source servers under triple replication, and DD's bulk-load
+# team selection can fail to find a disjoint candidate. Pin to a single DC so all
+# 15 machines participate in team formation.
+datacenters = 1
+
+# This test validates bulk-dump mechanics, not multi-region DR. Forcing single-region
+# avoids the same team-diversity stall when machineCount gets split across regions.
+generateFearless = false
+
 [[knobs]]
 # This knob is commented out since the knob override is done *after* the simulation system is set up. However,
 # this is not going to completely work:

--- a/tests/fast/BulkLoading.toml
+++ b/tests/fast/BulkLoading.toml
@@ -3,6 +3,29 @@ storageEngineExcludeTypes = ["ssd-sharded-rocksdb"] #FIXME: remove after allowin
 
 disableTss = true # TODO(BulkLoad): support TSS. finishMoveShard should wait for TSS if a data move is bulkload data move.
 
+# DD's bulk-load team selection rejects any team that shares a server with the source team
+# (DDTeamCollection.actor.cpp:266-282). Pin redundancy to 'triple' (matching
+# PhysicalShardMove and StorageServerCheckpointRestore which exercise similar bulk-load
+# paths) so the simulator cannot pick three_data_hall or other modes whose tighter
+# topology constraints leave team selection with no disjoint candidate team -- the
+# test would then stall on DDBulkLoadEngineTaskGetTeamFailedToFindValidTeam, the load
+# would never complete, and the workload's checkSame assertion would fire.
+config = 'triple'
+
+# Pair the pinned redundancy with enough machines to guarantee a disjoint team.
+machineCount = 15
+
+# Without datacenters=1 the simulator picks randomInt(1,4) DCs (SimulatedCluster.cpp
+# line ~1610). When it picks 2, the 15 machines get split ~7-8 per DC, the primary
+# DC then has only 4-5 non-source servers under triple replication, and DD's bulk-load
+# team selection can fail to find a disjoint candidate. Pin to a single DC so all
+# 15 machines participate in team formation.
+datacenters = 1
+
+# This test validates bulk-load mechanics, not multi-region DR. Forcing single-region
+# avoids the same team-diversity stall when machineCount gets split across regions.
+generateFearless = false
+
 [[knobs]]
 # This knob is commented out since the knob override is done *after* the simulation system is set up. However,
 # this is not going to completely work:

--- a/tests/slow/BulkDumpingS3.toml
+++ b/tests/slow/BulkDumpingS3.toml
@@ -3,6 +3,20 @@ storageEngineExcludeTypes = ["ssd-sharded-rocksdb"] #FIXME: remove after allowin
 
 disableTss = true # TODO(BulkLoad): support TSS. finishMoveShard should wait for TSS if a data move is bulkload data move.
 
+# DD's bulk-load team selection rejects any team that shares a server with the source team
+# (DDTeamCollection.actor.cpp:266-282). Under triple replication on a small machineCount
+# every candidate team overlaps with the source and DD never finds a valid team -- the
+# test then stalls on DDBulkLoadEngineTaskGetTeamFailedToFindValidTeam, the load produces
+# no data, and the workload's processCheck assertion fires (KVS=N NewKVS=0). Pin enough
+# machines for a disjoint team to exist.
+machineCount = 15
+
+# Without datacenters=1 the simulator picks randomInt(1,4) DCs (SimulatedCluster.cpp
+# line ~1610). When it picks 2, the 15 machines get split ~7-8 per DC, the primary
+# DC then has only 4-5 non-source servers under triple replication, and DD's bulk-load
+# team selection fails to find a disjoint candidate.
+datacenters = 1
+
 # Instruct simulation to generate a simple, single-region config
 generateFearless = false
 simpleConfig = false

--- a/tests/slow/BulkDumpingS3WithChaos.toml
+++ b/tests/slow/BulkDumpingS3WithChaos.toml
@@ -24,6 +24,22 @@ storageEngineExcludeTypes = ["ssd-sharded-rocksdb"] #FIXME: remove after allowin
 
 disableTss = true # TODO(BulkLoad): support TSS. finishMoveShard should wait for TSS if a data move is bulkload data move.
 
+# DD's bulk-load team selection rejects any team that shares a server with the source team
+# (DDTeamCollection.actor.cpp:266-282). Under triple replication on a small machineCount
+# every candidate team overlaps with the source and DD never finds a valid team -- the
+# test then stalls on DDBulkLoadEngineTaskGetTeamFailedToFindValidTeam, the load produces
+# no data, and the workload's processCheck assertion fires (KVS=N NewKVS=0). Pin enough
+# machines for a disjoint team to exist. Matches the fast-test BulkLoading/BulkDumping
+# tomls and PhysicalShardMove / StorageServerCheckpointRestore which exercise similar
+# bulk-load paths.
+machineCount = 15
+
+# Without datacenters=1 the simulator picks randomInt(1,4) DCs (SimulatedCluster.cpp
+# line ~1610). When it picks 2, the 15 machines get split ~7-8 per DC, the primary
+# DC then has only 4-5 non-source servers under triple replication, and DD's bulk-load
+# team selection fails to find a disjoint candidate.
+datacenters = 1
+
 # This test suite runs 4 tests sequentially: Stable (350s) + Light (648s) + Medium + Heavy
 # Total runtime can exceed the default 5400s simulation timeout, so mark as longRunningTest
 longRunningTest = true


### PR DESCRIPTION
    At 10B+ scale, the last few bulkload tasks can get permanently stuck:

    1. finishMoveShards hits transaction_too_old because waitForShardReady
       (up to 15s timeout) plus krmSetRangeCoalescing for multiple servers
       exceeds the 5-second read version window.

    2. When DD reinitializes, in-flight data moves are abandoned but the
       doBulkLoadTask actors remain blocked on completeAck futures that
       will never fire.

    3. scheduleBulkLoadTasks is stuck on waitForAll(bulkLoadActors) and
       can never re-scan or re-trigger the stuck tasks. Permanent deadlock.

    Fix (DataDistribution.cpp):
    - Add timeoutError on completeAck wait (5 min). On timeout, the actor
      exits and scheduleBulkLoadTasks can loop back to re-trigger tasks.
    - In checkBulkLoadTaskCompleteOrError: skip empty values (erased tasks),
      return false for invalid entries (initial placeholder from job submission),
      accept Acknowledged phase as complete.
    - Guard against premature finalization with foundAnyTask flag.
    - Change eraseBulkLoadTask to write empty Value() instead of serialized
      empty BulkLoadTaskState (distinguishes erased from uninitialized).

    Fix (MoveKeys.cpp):
    - Split the bulkload task phase update (Running -> Complete) into a
      separate transaction from the main shard assignment commit.

    Also increase restore dispatch apply lag threshold from 300s to 900s.

    Note on atomicity (MoveKeys.cpp split):

    The original code committed the shard reassignment and the task
    phase=Complete update atomically in a single transaction. After the
    split, between the outer commit (shards reassigned) and the inner
    commit (task phase=Complete), there is a small window where shards
    are visible as moved but the task is still in Running phase.

    On a DD crash in that window, recovery is bounded but not free:
    - DD's scheduler scans tasks, sees the Running task with its
      dataMoveId set, and re-dispatches doBulkLoadTask.
    - triggerBulkLoadTask transitions the task back to Triggered
      (restartCount++), and a new data move is dispatched on the same
      range.
    - The new data move finds the data already in place from the prior
      attempt; it is effectively a no-op shard reassignment plus the
      phase=Complete write, so recovery converges.

    This recovery cost is bounded (at most one extra data-move attempt
    per affected task on a rare DD crash) and is preferable to the
    permanent-hang failure mode the single-transaction approach
    produced at 10B scale.


`  20260610-231024-stack-924148c8414f3975             compressed=True data_size=37177536 duration=2263297 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:30:36 sanity=False started=100000 stopped=20260610-234100 submitted=20260610-231024 timeout=5400 username=stack`