### PR TITLE
Allow bulkload restore into a non-empty destination database

### DIFF
--- a/documentation/sphinx/source/bulkload-user.rst
+++ b/documentation/sphinx/source/bulkload-user.rst
@@ -17,6 +17,13 @@ Quickstart
 =============
 Below we run a simple bulkdump, a clear of the cluster, and then a bulkload to repopulate the cluster.
 
+.. note::
+   The ``clearrange`` step below is illustrative — it shows that the cluster starts
+   empty before the bulkload populates it. It is **not required**. BulkLoad clears
+   each shard internally before ingesting SST files (see "Per-Task Range Clear" in
+   :doc:`bulkload`), and ``fdbrestore start --mode bulkload`` is permitted against
+   a non-empty destination.
+
 Start a cluster::
 
     <FDB_SRC_FOLDER>/tests/loopback_cluster/run_custom_cluster.sh . --storage_count 8 \

--- a/documentation/sphinx/source/bulkload.rst
+++ b/documentation/sphinx/source/bulkload.rst
@@ -69,6 +69,27 @@ Workflow
 - Tasks complete and are marked as ``BulkLoadPhase::Complete`` or ``BulkLoadPhase::Error``
 - When all tasks finish, the job is finalized and moved to job history, and the range lock is released
 
+Per-Task Range Clear
+--------------------
+Before ingesting SST files for a task, the storage server clears the target
+shard range and waits for the clear to durably commit. This ensures that
+stale data is not retained when the new SST files are ingested over an
+existing range. The clear-then-ingest sequence is performed per shard inside
+the SS (see ``storageserver.actor.cpp``):
+
+1. ``getKeyValueStore()->clear(keys)`` — clear the target range
+2. Wait on ``durableVersion`` so the clear is committed before ingest
+3. ``compactRange(keys)`` to optimize storage before bulk insert
+4. ``ingestSSTFiles(localBulkLoadFileSets)`` — ingest the new data
+
+Because the SS clears each shard internally, BulkLoad does not require the
+destination cluster or range to be empty when the job starts. The exclusive
+range lock taken during ``submitBulkLoadJob()`` (see below) ensures no
+concurrent writes can race with the clear-and-ingest sequence. As a result,
+``fdbrestore start --mode bulkload`` is permitted to run against a
+non-empty destination database — unlike rangefile restore, which requires
+an empty destination.
+
 Range Locking
 -------------
 BulkLoad uses FoundationDB's range locking mechanism to ensure data consistency:

--- a/fdbclient/FileBackupAgent.cpp
+++ b/fdbclient/FileBackupAgent.cpp
@@ -7397,7 +7397,9 @@ public:
 			oldRestore.clear(tr);
 		}
 
-		if (!onlyApplyMutationLogs) {
+		// Bulkload restore (useRangeFileRestore=false) overwrites each shard via the range-lock
+		// mechanism in DD, so a non-empty destination is expected and required — skip the precheck.
+		if (!onlyApplyMutationLogs && useRangeFileRestore) {
 			int index{ 0 };
 			for (index = 0; index < restoreRanges.size(); index++) {
 				KeyRange restoreIntoRange = KeyRangeRef(restoreRanges[index].begin, restoreRanges[index].end)


### PR DESCRIPTION
submitParallelRestore enforced an empty-destination precheck for all restore modes by reading the first row of each target range. This is correct for rangefile restore but wrong for bulkload: bulkload owns the target range via an exclusive range lock and the storage server clears each shard before SST ingestion, so a non-empty destination is expected. Gate the precheck on useRangeFileRestore so bulkload skips it.

Without this fix, "fdbrestore start --mode bulkload" against a cluster with existing data fails with restore_destination_not_empty (2370). The previous workaround was a manual clearrange before invoking restore, which at large scale (>=4TB) overwhelms storage servers with tombstones and stalls the cluster for hours.

Also document the per-shard clear-then-ingest sequence in bulkload.rst and clarify in bulkload-user.rst that the clearrange in the quickstart example is illustrative, not required.

Validated end-to-end at 100M scale (2026-06-04): bulkload from S3, backup, rangefile baseline restore into validation prefix, bulkload main restore into normal keyspace, marker-key data verification all passed.
