### PR TITLE
Add ROCKSDB_ENABLE_CACHE_USAGE_OVERRIDES knob for charging few memory usage fields under block cache

### DIFF
--- a/fdbserver/core/ServerKnobs.cpp
+++ b/fdbserver/core/ServerKnobs.cpp
@@ -744,8 +744,9 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( ROCKSDB_MEMTABLE_PROTECTION_BYTES_PER_KEY,               0 ); if ( randomize && buggify() ) ROCKSDB_MEMTABLE_PROTECTION_BYTES_PER_KEY = 8; // Default: 0 (disabled). Supported values: 0, 1, 2, 4, 8.
 	// Block cache key-value checksum. Checksum is validated during read, so has non-trivial impact on read performance.
 	init( ROCKSDB_BLOCK_PROTECTION_BYTES_PER_KEY,                  0 ); if ( randomize && buggify() ) ROCKSDB_BLOCK_PROTECTION_BYTES_PER_KEY = 8; // Default: 0 (disabled). Supported values: 0, 1, 2, 4, 8.
-	init( ROCKSDB_ENABLE_NONDETERMINISM,                      false );
-	init( SHARDED_ROCKSDB_ALLOW_MULTIPLE_RANGES,              false );
+	init( ROCKSDB_ENABLE_CACHE_USAGE_OVERRIDES,                false ); if( isSimulated ) ROCKSDB_ENABLE_CACHE_USAGE_OVERRIDES = deterministicRandom()->coinflip();
+	init( ROCKSDB_ENABLE_NONDETERMINISM,                       false );
+	init( SHARDED_ROCKSDB_ALLOW_MULTIPLE_RANGES,               false );
 	init( SHARDED_ROCKSDB_ALLOW_WRITE_STALL_ON_FLUSH,          false );	
 	init( SHARDED_ROCKSDB_VALIDATE_MAPPING_RATIO,               0.01 ); if (isSimulated) SHARDED_ROCKSDB_VALIDATE_MAPPING_RATIO = deterministicRandom()->random01();
 	init( SHARD_METADATA_SCAN_BYTES_LIMIT,                  10485760 ); // 10MB

--- a/fdbserver/core/include/fdbserver/core/Knobs.h
+++ b/fdbserver/core/include/fdbserver/core/Knobs.h
@@ -616,6 +616,7 @@ public:
 	int ROCKSDB_WRITEBATCH_PROTECTION_BYTES_PER_KEY;
 	int ROCKSDB_MEMTABLE_PROTECTION_BYTES_PER_KEY;
 	int ROCKSDB_BLOCK_PROTECTION_BYTES_PER_KEY;
+	bool ROCKSDB_ENABLE_CACHE_USAGE_OVERRIDES;
 	bool ROCKSDB_ENABLE_NONDETERMINISM; // Whether rocksdb nondeterministic behavior should be enabled in simulation.
 	                                    // Note that turning this on in simulation could lead to non-deterministic runs
 	                                    // since we rely on rocksdb metadata. This knob also applies to sharded rocks

--- a/fdbserver/kvstore/KeyValueStoreRocksDB.actor.cpp
+++ b/fdbserver/kvstore/KeyValueStoreRocksDB.actor.cpp
@@ -222,6 +222,20 @@ rocksdb::ColumnFamilyOptions SharedRocksDBState::initialCfOptions() {
 		bbOpts.whole_key_filtering = SERVER_KNOBS->ROCKSDB_BLOOM_WHOLE_KEY_FILTERING;
 	}
 
+	if (SERVER_KNOBS->ROCKSDB_ENABLE_CACHE_USAGE_OVERRIDES) {
+		bbOpts.cache_usage_options.options_overrides[rocksdb::CacheEntryRole::kCompressionDictionaryBuildingBuffer]
+		    .charged = rocksdb::CacheEntryRoleOptions::Decision::kEnabled;
+
+		bbOpts.cache_usage_options.options_overrides[rocksdb::CacheEntryRole::kFilterConstruction].charged =
+		    rocksdb::CacheEntryRoleOptions::Decision::kEnabled;
+
+		bbOpts.cache_usage_options.options_overrides[rocksdb::CacheEntryRole::kBlockBasedTableReader].charged =
+		    rocksdb::CacheEntryRoleOptions::Decision::kEnabled;
+
+		bbOpts.cache_usage_options.options_overrides[rocksdb::CacheEntryRole::kFileMetadata].charged =
+		    rocksdb::CacheEntryRoleOptions::Decision::kEnabled;
+	}
+
 	if (SERVER_KNOBS->ROCKSDB_BLOCK_CACHE_SIZE > 0) {
 		bbOpts.block_cache =
 		    rocksdb::NewLRUCache(SERVER_KNOBS->ROCKSDB_BLOCK_CACHE_SIZE,


### PR DESCRIPTION
Add ROCKSDB_ENABLE_CACHE_USAGE_OVERRIDES knob for charging few memory usage fields under block cache.

Summary:
 Enable cache charging for kCompressionDictionaryBuildingBuffer, kFilterConstruction, kBlockBasedTableReader, and kFileMetadata roles so their memory usage is accounted against the block cache capacity.
 
 
 100K simulation run:
 20260611-094115-rocksdb1-352496daee925dfc          compressed=True data_size=41243616 duration=2709575 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:52:17 sanity=False started=100000 stopped=20260611-113332 submitted=20260611-094115 timeout=5400 username=rocksdb1
