### PR TITLE
Fix incorrect can_clean_bounce

### DIFF
--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -3164,7 +3164,6 @@ ACTOR static Future<Void> clusterGetStatusImpl(JsonBuilderObject* pStatusObj,
 
 		statusObj["protocol_version"] = format("%" PRIx64, g_network->protocolVersion().version());
 		statusObj["connection_string"] = coordinators.ccr->getConnectionString().toString();
-		statusObj["bounce_impact"] = getBounceImpactInfo(statusCode);
 
 		state Future<ErrorOr<JsonBuilderObject>> idmpKeyStatusFuture = errorOr(timeoutError(getIdmpKeyStatus(cx), 5.0));
 
@@ -3172,6 +3171,8 @@ ACTOR static Future<Void> clusterGetStatusImpl(JsonBuilderObject* pStatusObj,
 		    versionEpochStatusFetcher(cx, &status_incomplete_reasons);
 
 		wait(success(recoveryStateStatusFuture) && success(idmpKeyStatusFuture) && success(versionEpochStatusFuture));
+
+		statusObj["bounce_impact"] = getBounceImpactInfo(statusCode);
 
 		state JsonBuilderObject recoveryStateStatus = recoveryStateStatusFuture.get();
 		state JsonBuilderObject idmpKeyStatus;


### PR DESCRIPTION
`bounce_impact.can_clean_bounce` was computed by `getBounceImpactInfo(statusCode)` before `recoveryStateStatusFuture` was awaited. `statusCode` is populated inside` recoveryStateStatusFetcher` only after that actor's first `wait()`, so at the call site `statusCode` was still its initial `RecoveryStatus::END` value. As a result, `can_clean_bounce` was reported as false (reason "cluster hasn't fully recovered yet") on every status build, even for a fully recovered cluster (problematic because it blocks the kubernetes operator from performing bounces).

This ordering was introduced when PR #12940 was backported to release-7.3 in PR #13068; main is unaffected. 

Move the bounce_impact computation to after the wait so statusCode reflects the real recovery status.

Before on fresh cluster:

```
"bounce_impact" : {
    "can_clean_bounce" : false,
    "reason" : "cluster hasn't fully recovered yet"
},
```

After on fresh cluster:

```
"bounce_impact" : {
    "can_clean_bounce" : true
},
```

