### PR TITLE
backup/restore: operator UX cleanups for CLI flags and status output

### DIFF
--- a/fdbbackup/backup.cpp
+++ b/fdbbackup/backup.cpp
@@ -702,6 +702,8 @@ CSimpleOpt::SOption g_rgRestoreOptions[] = {
 #ifdef _WIN32
 	{ OPT_PARENTPID, "--parentpid", SO_REQ_SEP },
 #endif
+	{ OPT_RESTORE_CLUSTERFILE_DEST, "-C", SO_REQ_SEP },
+	{ OPT_RESTORE_CLUSTERFILE_DEST, "--cluster-file", SO_REQ_SEP },
 	{ OPT_RESTORE_CLUSTERFILE_DEST, "--dest-cluster-file", SO_REQ_SEP },
 	{ OPT_RESTORE_CLUSTERFILE_ORIG, "--orig-cluster-file", SO_REQ_SEP },
 	{ OPT_RESTORE_TIMESTAMP, "--timestamp", SO_REQ_SEP },
@@ -1191,7 +1193,7 @@ static void printRestoreUsage(bool devhelp) {
 	printf(" ACTION OPTIONS:\n");
 	// printf("  FOLDERS        Paths to folders containing the backup files.\n");
 	printf("  Options for all commands:\n\n");
-	printf("  --dest-cluster-file CONNFILE\n");
+	printf("  -C, --cluster-file, --dest-cluster-file CONNFILE\n");
 	printf("                 The cluster file to restore data into.\n");
 	printf("  -t, --tagname TAGNAME\n");
 	printf("                 The restore tag to act on.  Default is 'default'\n");

--- a/fdbcli/fdbcli.cpp
+++ b/fdbcli/fdbcli.cpp
@@ -110,6 +110,7 @@ CSimpleOpt::SOption g_rgOptions[] = { { OPT_CONNFILE, "-C", SO_REQ_SEP },
 	                                  { OPT_DATABASE, "-d", SO_REQ_SEP },
 	                                  { OPT_TRACE, "--log", SO_NONE },
 	                                  { OPT_TRACE_DIR, "--log-dir", SO_REQ_SEP },
+	                                  { OPT_TRACE_DIR, "--logdir", SO_REQ_SEP },
 	                                  { OPT_LOGGROUP, "--log-group", SO_REQ_SEP },
 	                                  { OPT_TIMEOUT, "--timeout", SO_REQ_SEP },
 	                                  { OPT_EXEC, "--exec", SO_REQ_SEP },
@@ -480,7 +481,8 @@ static void printProgramUsage(const char* name) {
 	       "                 then `%s'.\n",
 	       platform::getDefaultClusterFilePath().c_str());
 	printf("  --log          Enables trace file logging for the CLI session.\n"
-	       "  --log-dir PATH Specifies the output directory for trace files. If\n"
+	       "  --log-dir PATH, --logdir PATH\n"
+	       "                 Specifies the output directory for trace files. If\n"
 	       "                 unspecified, defaults to the current directory. Has\n"
 	       "                 no effect unless --log is specified.\n"
 	       "  --log-group LOG_GROUP\n"

--- a/fdbclient/FileBackupAgent.cpp
+++ b/fdbclient/FileBackupAgent.cpp
@@ -4599,8 +4599,16 @@ struct BulkLoadRestoreTaskFunc : RestoreTaskFuncBase {
 				    .detail("RestoreUID", restore.getUid())
 				    .detail("Owner", "BulkLoad");
 
-				// Note: BulkLoad configuration validation (shard_encode_location_metadata, enable_read_lock_on_range)
-				// is performed by the BulkLoad system on the server side when the job is submitted.
+				// TODO(BulkLoad): no precondition validation happens here today.
+				// submitBulkLoadJob() does not check that the cluster has
+				// shard_encode_location_metadata=1 and enable_read_lock_on_range=1, nor
+				// that the storage engine supports SST ingestion. If those preconditions
+				// are not met, setBulkLoadMode + submitBulkLoadJob both succeed but the
+				// Data Distributor never dispatches any tasks, leaving the restore in
+				// "State: running, Tasks: 0/0" indefinitely. Validation needs to live
+				// somewhere with real cluster-side knob visibility (DD or a commit proxy);
+				// it cannot be done from fdbclient because SERVER_KNOBS here are this
+				// process's local defaults, not the running cluster's actual config.
 
 				// Read the original BulkLoad mode from config (saved by StartFullRestoreTaskFunc before task creation).
 				// This is persisted in the database so we can restore the correct mode even after a crash.
@@ -7982,10 +7990,14 @@ public:
 					}
 					statusText += format("Snapshot Mode: %s\n", snapshotModeText.c_str());
 
-					// Check if backup is BulkLoad compatible (has bulkdump_data/)
-					Optional<std::string> bulkDumpJobIdOpt = co_await config.bulkDumpJobId().get(tr);
-					bool bulkLoadCompatible = bulkDumpJobIdOpt.present() && !bulkDumpJobIdOpt.get().empty();
-					statusText += format("BulkLoad Compatible: %s\n", bulkLoadCompatible ? "yes" : "no");
+					// Check if backup is BulkLoad compatible (has bulkdump_data/).
+					// In rangefile mode no bulkdump task ever runs, so the answer is
+					// always "no" and the line carries no information — skip it.
+					if (snapshotModeValue != 0) {
+						Optional<std::string> bulkDumpJobIdOpt = co_await config.bulkDumpJobId().get(tr);
+						bool bulkLoadCompatible = bulkDumpJobIdOpt.present() && !bulkDumpJobIdOpt.get().empty();
+						statusText += format("BulkLoad Compatible: %s\n", bulkLoadCompatible ? "yes" : "no");
+					}
 
 					bool showBulkDump = (snapshotModeValue == 1 || snapshotModeValue == 2);
 					bool showRangeFile = (snapshotModeValue == 0 || snapshotModeValue == 2);

--- a/fdbclient/ManagementAPI.cpp
+++ b/fdbclient/ManagementAPI.cpp
@@ -2886,6 +2886,14 @@ Future<Void> cancelBulkLoadJob(Database cx, UID jobId) {
 Future<Void> submitBulkLoadJob(Database cx, BulkLoadJobState jobState, bool lockAware) {
 	ASSERT(jobState.getPhase() == BulkLoadJobPhase::Submitted);
 
+	// TODO(BulkLoad): validate cluster preconditions before accepting the job.
+	// BulkLoad requires shard_encode_location_metadata=1 and enable_read_lock_on_range=1,
+	// plus a storage engine that supports SST ingestion. Without these, this function and
+	// setBulkLoadMode both succeed, but the Data Distributor never dispatches the job and
+	// any restore that triggered it stalls in "State: running, Tasks: 0/0" forever.
+	// This check must read live cluster knob state — SERVER_KNOBS in fdbclient is the
+	// caller's local defaults and tells us nothing about the cluster.
+
 	Transaction tr(cx);
 	while (true) {
 		Error err;


### PR DESCRIPTION
Four small, independent changes surfaced while running a manual backup/restore demo end to end:

- fdbrestore now accepts -C and --cluster-file as aliases for --dest-cluster-file. Every other tool (fdbcli, fdbbackup, fdbserver, backup_agent) already pairs -C with --cluster-file; fdbrestore was the lone outlier and forced scripts to special-case it.

- fdbcli now accepts --logdir as an alias for --log-dir. Every other tool spells the flag --logdir (no hyphen); the --log-dir form in fdbcli was the outlier here.

- fdbbackup status no longer prints "BulkLoad Compatible: no" when Snapshot Mode is rangefile. In that mode the answer is tautologically derivable from the line above it (no bulkdump task ever runs), so the line carries no information. The field still prints in modes bulkdump and both, where it can flip during an in-progress backup.

- Correct the misleading comment in FileBackupAgent.cpp that claimed submitBulkLoadJob validates cluster preconditions server-side. It does not. A bulkload restore against a cluster missing shard_encode_location_metadata / enable_read_lock_on_range, or with a storage engine that cannot ingest SSTs, succeeds at submission and then silently stalls in "State: running, Tasks: 0/0" forever. Replace the comment with a faithful description of the failure mode and add a matching TODO in submitBulkLoadJob explaining where the real validation needs to live (somewhere with cluster-side knob visibility) and why it cannot be done from fdbclient.