### PR TITLE
Add ROCKSDB_ENABLE_CACHE_USAGE_OVERRIDES knob for charging few memory usage fields under block cache

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -631,7 +631,8 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( ROCKSDB_MEMTABLE_PROTECTION_BYTES_PER_KEY,               0 ); if ( randomize && BUGGIFY ) ROCKSDB_MEMTABLE_PROTECTION_BYTES_PER_KEY = 8; // Default: 0 (disabled). Supported values: 0, 1, 2, 4, 8.
 	// Block cache key-value checksum. Checksum is validated during read, so has non-trivial impact on read performance.
 	init( ROCKSDB_BLOCK_PROTECTION_BYTES_PER_KEY,                  0 ); if ( randomize && BUGGIFY ) ROCKSDB_BLOCK_PROTECTION_BYTES_PER_KEY = 8; // Default: 0 (disabled). Supported values: 0, 1, 2, 4, 8.
-	init( ROCKSDB_ENABLE_NONDETERMINISM,                      false );
+	init( ROCKSDB_ENABLE_CACHE_USAGE_OVERRIDES,                false ); if( isSimulated ) ROCKSDB_ENABLE_CACHE_USAGE_OVERRIDES = deterministicRandom()->coinflip();
+	init( ROCKSDB_ENABLE_NONDETERMINISM,                       false );
 	init( SHARDED_ROCKSDB_ALLOW_WRITE_STALL_ON_FLUSH,          false );	
 	init( SHARDED_ROCKSDB_VALIDATE_MAPPING_RATIO,               0.01 ); if (isSimulated) SHARDED_ROCKSDB_VALIDATE_MAPPING_RATIO = deterministicRandom()->random01();
 	init( SHARD_METADATA_SCAN_BYTES_LIMIT,                  10485760 ); // 10MB

--- a/fdbclient/include/fdbclient/ServerKnobs.h
+++ b/fdbclient/include/fdbclient/ServerKnobs.h
@@ -609,6 +609,7 @@ public:
 	int ROCKSDB_WRITEBATCH_PROTECTION_BYTES_PER_KEY;
 	int ROCKSDB_MEMTABLE_PROTECTION_BYTES_PER_KEY;
 	int ROCKSDB_BLOCK_PROTECTION_BYTES_PER_KEY;
+	bool ROCKSDB_ENABLE_CACHE_USAGE_OVERRIDES;
 	bool ROCKSDB_ENABLE_NONDETERMINISM; // Whether rocksdb nondeterministic behavior should be enabled in simulation.
 	                                    // Note that turning this on in simulation could lead to non-deterministic runs
 	                                    // since we rely on rocksdb metadata. This knob also applies to sharded rocks

--- a/fdbserver/KeyValueStoreRocksDB.actor.cpp
+++ b/fdbserver/KeyValueStoreRocksDB.actor.cpp
@@ -243,6 +243,20 @@ rocksdb::ColumnFamilyOptions SharedRocksDBState::initialCfOptions() {
 		bbOpts.whole_key_filtering = SERVER_KNOBS->ROCKSDB_BLOOM_WHOLE_KEY_FILTERING;
 	}
 
+	if (SERVER_KNOBS->ROCKSDB_ENABLE_CACHE_USAGE_OVERRIDES) {
+		bbOpts.cache_usage_options.options_overrides[rocksdb::CacheEntryRole::kCompressionDictionaryBuildingBuffer]
+		    .charged = rocksdb::CacheEntryRoleOptions::Decision::kEnabled;
+
+		bbOpts.cache_usage_options.options_overrides[rocksdb::CacheEntryRole::kFilterConstruction].charged =
+		    rocksdb::CacheEntryRoleOptions::Decision::kEnabled;
+
+		bbOpts.cache_usage_options.options_overrides[rocksdb::CacheEntryRole::kBlockBasedTableReader].charged =
+		    rocksdb::CacheEntryRoleOptions::Decision::kEnabled;
+
+		bbOpts.cache_usage_options.options_overrides[rocksdb::CacheEntryRole::kFileMetadata].charged =
+		    rocksdb::CacheEntryRoleOptions::Decision::kEnabled;
+	}
+
 	if (SERVER_KNOBS->ROCKSDB_BLOCK_CACHE_SIZE > 0) {
 		bbOpts.block_cache =
 		    rocksdb::NewLRUCache(SERVER_KNOBS->ROCKSDB_BLOCK_CACHE_SIZE,
@@ -1181,6 +1195,7 @@ ACTOR Future<Void> rocksDBMetricLogger(UID id,
 
 	state std::vector<std::pair<const char*, std::string>> strPropertyStats = {
 		{ "LevelStats", rocksdb::DB::Properties::kLevelStats },
+		{ "BlockCacheEntryStats", rocksdb::DB::Properties::kBlockCacheEntryStats },
 	};
 
 	state std::vector<std::pair<const char*, std::string>> levelStrPropertyStats = {


### PR DESCRIPTION
cherry-pick of #13342
Add ROCKSDB_ENABLE_CACHE_USAGE_OVERRIDES knob for charging few memory usage fields under block cache.

Summary:
Enable cache charging for kCompressionDictionaryBuildingBuffer, kFilterConstruction, kBlockBasedTableReader, and kFileMetadata roles so their memory usage is accounted against the block cache capacity.

100K simulation:
20260611-220534-rocks-7.4-c8126fff9e77da1b         compressed=True data_size=60809582 duration=3435750 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:30:32 sanity=False started=100000 stopped=20260611-233606 submitted=20260611-220534 timeout=5400 username=rocks-7.4