### PR TITLE
Fix external client temp path trace logging

### DIFF
--- a/fdbclient/MultiVersionTransaction.cpp
+++ b/fdbclient/MultiVersionTransaction.cpp
@@ -2020,7 +2020,7 @@ std::vector<std::pair<std::string, bool>> MultiVersionApi::copyExternalLibraryPe
 			TraceEvent("CopyingExternalClient")
 			    .detail("FileName", filename)
 			    .detail("LibraryPath", path)
-			    .detail("TempPath", tempName);
+			    .detail("TempPath", std::string(tempName));
 
 			constexpr size_t buf_sz = 4096;
 			char buf[buf_sz];


### PR DESCRIPTION
## Summary
- Log `CopyingExternalClient.TempPath` as a `std::string` so the stack `mkstemp` buffer is treated as a C string
- Prevent bytes after the NUL terminator from appearing in client trace files

Fixes #12077

## Testing
- `ninja -C build fdbclient`
- `ninja -C build fdbserver`
- `git diff --check`
- `build/bin/fdbserver -r unittests -f /flow/Tracing`

## Notes
- Also ran `build/bin/fdbserver -r unittests -f /flow`; it completed with two local failures unrelated to this trace-site change: `/flow/flow/networked futures` endpoint validity assertion and `/flow/Platform/directoryOps` symlink assertion.