### PR TITLE
Make fdbcli ignore client threads env option

### DIFF
--- a/fdbcli/fdbcli.cpp
+++ b/fdbcli/fdbcli.cpp
@@ -2091,6 +2091,9 @@ int main(int argc, char** argv) {
 	if (opt.exit_code != -1)
 		return opt.exit_code;
 
+	// fdbcli connects to one cluster, so multiple client threads per version have no effect.
+	MultiVersionApi::api->ignoreEnvironmentVariableNetworkOption(FDBNetworkOptions::CLIENT_THREADS_PER_VERSION);
+
 	if (opt.trace) {
 		if (opt.traceDir.empty())
 			setNetworkOption(FDBNetworkOptions::TRACE_ENABLE);

--- a/fdbcli/tests/fdbcli_tests.py
+++ b/fdbcli/tests/fdbcli_tests.py
@@ -898,6 +898,22 @@ def integer_options():
     assert error_output == b""
 
 
+def client_threads_per_version_env_ignored():
+    test_env = fdbcli_env.copy()
+    test_env["FDB_NETWORK_OPTION_CLIENT_THREADS_PER_VERSION"] = "not_an_integer"
+    process = subprocess.run(
+        command_template + ["status minimal"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=test_env,
+    )
+    assert process.returncode == 0
+    assert (
+        b"Environment variable network option could not be set"
+        not in process.stderr
+    )
+
+
 def tls_address_suffix():
     # fdbcli shall prevent a non-TLS fdbcli run from connecting to an all-TLS cluster
     preamble = "eNW1yf1M:eNW1yf1M@"
@@ -999,6 +1015,7 @@ if __name__ == "__main__":
         tls_address_suffix()
         status_json_file_region_failover_message()
         idempotency_ids()
+        client_threads_per_version_env_ignored()
     else:
         assert args.process_number > 1, "Process number should be positive"
         coordinators()

--- a/fdbclient/MultiVersionTransaction.cpp
+++ b/fdbclient/MultiVersionTransaction.cpp
@@ -1903,6 +1903,18 @@ const char* MultiVersionApi::getClientVersion() {
 	return localClient->api->getClientVersion();
 }
 
+void MultiVersionApi::ignoreEnvironmentVariableNetworkOption(FDBNetworkOptions::Option option) {
+	if (FDBNetworkOptions::optionInfo.find(option) == FDBNetworkOptions::optionInfo.end()) {
+		throw invalid_option();
+	}
+
+	MutexHolder holder(lock);
+	if (envOptionsLoaded) {
+		throw invalid_option();
+	}
+	ignoredEnvOptions.insert(option);
+}
+
 void MultiVersionApi::useFutureProtocolVersion() {
 	localClient->api->useFutureProtocolVersion();
 }
@@ -2604,6 +2616,13 @@ void MultiVersionApi::loadEnvironmentVariableNetworkOptions() {
 
 	for (const auto& option : FDBNetworkOptions::optionInfo) {
 		if (!option.second.hidden) {
+			{
+				MutexHolder holder(lock);
+				if (ignoredEnvOptions.contains(option.first)) {
+					continue;
+				}
+			}
+
 			std::string valueStr;
 			try {
 				if (platform::getEnvironmentVar(("FDB_NETWORK_OPTION_" + option.second.name).c_str(), valueStr)) {

--- a/fdbclient/include/fdbclient/MultiVersionTransaction.h
+++ b/fdbclient/include/fdbclient/MultiVersionTransaction.h
@@ -802,6 +802,7 @@ public:
 	bool hasNonFailedExternalClients();
 
 	void updateSupportedVersions();
+	void ignoreEnvironmentVariableNetworkOption(FDBNetworkOptions::Option option);
 
 	bool callbackOnMainThread;
 	bool localClientDisabled;
@@ -860,6 +861,7 @@ private:
 	Mutex lock;
 	std::vector<std::pair<FDBNetworkOptions::Option, Optional<Standalone<StringRef>>>> options;
 	std::map<FDBNetworkOptions::Option, std::set<Standalone<StringRef>>> setEnvOptions;
+	std::set<FDBNetworkOptions::Option> ignoredEnvOptions;
 	volatile bool envOptionsLoaded;
 
 	friend struct MultiVersionDatabase::DatabaseState;


### PR DESCRIPTION
## Summary
- Add a multiversion client hook to skip selected `FDB_NETWORK_OPTION_*` variables when loading network options from the environment
- Have `fdbcli` ignore `FDB_NETWORK_OPTION_CLIENT_THREADS_PER_VERSION`, since it only connects to one cluster
- Add an fdbcli regression test that sets the option to an invalid value and verifies the CLI still runs

Fixes #11129

## Testing
- `ninja -C build fdbclient fdbcli`
- `env FDB_NETWORK_OPTION_CLIENT_THREADS_PER_VERSION=not_an_integer build/bin/fdbcli -C /private/tmp/fdb-no-such.cluster --exec "status minimal"`
- `ninja -C build python_binding`
- `ninja -C build fdbmonitor`
- `ctest -R single_process_fdbcli_tests --output-on-failure`
- `ninja -C build fdbserver`
- `build/bin/fdbserver -r unittests -f /fdbclient/multiversionclient/`
- `git diff --check`