### PR TITLE
Add microbenchmarks for thread helpers

### DIFF
--- a/flow/bench/BenchThreadHelper.cpp
+++ b/flow/bench/BenchThreadHelper.cpp
@@ -71,6 +71,40 @@ Future<Void> benchUnsafeThreadFutureToFutureReadyIntActor(benchmark::State* stat
 	state->SetItemsProcessed(static_cast<int64_t>(state->iterations()));
 }
 
+Future<Void> benchSafeThreadFutureToFuturePendingIntActor(benchmark::State* state) {
+	int64_t sink = 0;
+
+	while (state->KeepRunning()) {
+		auto* sav = new ThreadSingleAssignmentVar<int>;
+		ThreadFuture<int> threadFuture(sav);
+		Future<int> f = safeThreadFutureToFuture(threadFuture);
+		sav->send(7);
+		sink += co_await f;
+		benchmark::DoNotOptimize(f);
+		benchmark::ClobberMemory();
+	}
+
+	benchmark::DoNotOptimize(sink);
+	state->SetItemsProcessed(static_cast<int64_t>(state->iterations()));
+}
+
+Future<Void> benchUnsafeThreadFutureToFuturePendingIntActor(benchmark::State* state) {
+	int64_t sink = 0;
+
+	while (state->KeepRunning()) {
+		auto* sav = new ThreadSingleAssignmentVar<int>;
+		ThreadFuture<int> threadFuture(sav);
+		Future<int> f = unsafeThreadFutureToFuture(threadFuture);
+		sav->send(7);
+		sink += co_await f;
+		benchmark::DoNotOptimize(f);
+		benchmark::ClobberMemory();
+	}
+
+	benchmark::DoNotOptimize(sink);
+	state->SetItemsProcessed(static_cast<int64_t>(state->iterations()));
+}
+
 void benchOnMainThreadReadyInt(benchmark::State& state) {
 	int64_t sink = 0;
 
@@ -90,7 +124,7 @@ void benchOnMainThreadReadyVoid(benchmark::State& state) {
 	for (auto _ : state) {
 		benchmark::DoNotOptimize(_);
 		ThreadFuture<Void> result = onMainThread([] { return readyVoidFuture(); });
-		result.blockUntilReady();
+		result.getBlocking();
 		benchmark::ClobberMemory();
 	}
 
@@ -120,11 +154,11 @@ void benchOnMainThreadVoidEnqueue(benchmark::State& state) {
 
 void benchOnMainThreadVoidEnqueueWithErrorMember(benchmark::State& state) {
 	const int batchSize = state.range(0);
+	ErrorSlot slot;
 
 	for (auto _ : state) {
 		benchmark::DoNotOptimize(_);
 		std::atomic<int> completed{ 0 };
-		ErrorSlot slot;
 
 		for (int i = 0; i < batchSize; ++i) {
 			onMainThreadVoid(
@@ -135,24 +169,37 @@ void benchOnMainThreadVoidEnqueueWithErrorMember(benchmark::State& state) {
 		while (completed.load(std::memory_order_acquire) != batchSize) {
 			std::this_thread::yield();
 		}
-		state.ResumeTiming();
-
 		ASSERT(slot.error.code() == invalid_error_code);
+		state.ResumeTiming();
 	}
 
 	state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) * batchSize);
 }
 
 void benchSafeThreadFutureToFutureReadyInt(benchmark::State& state) {
-	onMainThread([&state] { return benchSafeThreadFutureToFutureReadyIntActor(&state); }).blockUntilReady();
+	onMainThread([&state] { return benchSafeThreadFutureToFutureReadyIntActor(&state); }).getBlocking();
 }
 
 void benchUnsafeThreadFutureToFutureReadyInt(benchmark::State& state) {
-	onMainThread([&state] { return benchUnsafeThreadFutureToFutureReadyIntActor(&state); }).blockUntilReady();
+	onMainThread([&state] { return benchUnsafeThreadFutureToFutureReadyIntActor(&state); }).getBlocking();
 }
 
-BENCHMARK(benchOnMainThreadReadyInt)->Name("ThreadHelper/onMainThread/ready_int")->ReportAggregatesOnly(true);
-BENCHMARK(benchOnMainThreadReadyVoid)->Name("ThreadHelper/onMainThread/ready_void")->ReportAggregatesOnly(true);
+void benchSafeThreadFutureToFuturePendingInt(benchmark::State& state) {
+	onMainThread([&state] { return benchSafeThreadFutureToFuturePendingIntActor(&state); }).getBlocking();
+}
+
+void benchUnsafeThreadFutureToFuturePendingInt(benchmark::State& state) {
+	onMainThread([&state] { return benchUnsafeThreadFutureToFuturePendingIntActor(&state); }).getBlocking();
+}
+
+BENCHMARK(benchOnMainThreadReadyInt)
+    ->Name("ThreadHelper/onMainThread/ready_int")
+    ->UseRealTime()
+    ->ReportAggregatesOnly(true);
+BENCHMARK(benchOnMainThreadReadyVoid)
+    ->Name("ThreadHelper/onMainThread/ready_void")
+    ->UseRealTime()
+    ->ReportAggregatesOnly(true);
 
 BENCHMARK(benchOnMainThreadVoidEnqueue)
     ->Name("ThreadHelper/onMainThreadVoid/enqueue")
@@ -172,6 +219,14 @@ BENCHMARK(benchSafeThreadFutureToFutureReadyInt)
 
 BENCHMARK(benchUnsafeThreadFutureToFutureReadyInt)
     ->Name("ThreadHelper/unsafeThreadFutureToFuture/ready_int")
+    ->ReportAggregatesOnly(true);
+
+BENCHMARK(benchSafeThreadFutureToFuturePendingInt)
+    ->Name("ThreadHelper/safeThreadFutureToFuture/pending_int")
+    ->ReportAggregatesOnly(true);
+
+BENCHMARK(benchUnsafeThreadFutureToFuturePendingInt)
+    ->Name("ThreadHelper/unsafeThreadFutureToFuture/pending_int")
     ->ReportAggregatesOnly(true);
 
 } // namespace

--- a/flow/bench/BenchThreadHelper.cpp
+++ b/flow/bench/BenchThreadHelper.cpp
@@ -1,0 +1,177 @@
+/*
+ * BenchThreadHelper.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "benchmark/benchmark.h"
+
+#include "flow/ThreadHelper.actor.h"
+#include "flow/flow.h"
+
+#include <atomic>
+#include <cstdint>
+#include <thread>
+
+namespace {
+
+struct ErrorSlot {
+	Error error;
+};
+
+Future<int> readyIntFuture(int value) {
+	co_return value;
+}
+
+Future<Void> readyVoidFuture() {
+	co_return;
+}
+
+Future<Void> benchSafeThreadFutureToFutureReadyIntActor(benchmark::State* state) {
+	ThreadFuture<int> threadFuture(7);
+	int64_t sink = 0;
+
+	while (state->KeepRunning()) {
+		Future<int> f = safeThreadFutureToFuture(threadFuture);
+		sink += co_await f;
+		benchmark::DoNotOptimize(f);
+		benchmark::ClobberMemory();
+	}
+
+	benchmark::DoNotOptimize(sink);
+	state->SetItemsProcessed(static_cast<int64_t>(state->iterations()));
+}
+
+Future<Void> benchUnsafeThreadFutureToFutureReadyIntActor(benchmark::State* state) {
+	ThreadFuture<int> threadFuture(7);
+	int64_t sink = 0;
+
+	while (state->KeepRunning()) {
+		Future<int> f = unsafeThreadFutureToFuture(threadFuture);
+		sink += co_await f;
+		benchmark::DoNotOptimize(f);
+		benchmark::ClobberMemory();
+	}
+
+	benchmark::DoNotOptimize(sink);
+	state->SetItemsProcessed(static_cast<int64_t>(state->iterations()));
+}
+
+void benchOnMainThreadReadyInt(benchmark::State& state) {
+	int64_t sink = 0;
+
+	for (auto _ : state) {
+		benchmark::DoNotOptimize(_);
+		ThreadFuture<int> result = onMainThread([] { return readyIntFuture(7); });
+		result.blockUntilReady();
+		sink += result.get();
+		benchmark::ClobberMemory();
+	}
+
+	benchmark::DoNotOptimize(sink);
+	state.SetItemsProcessed(static_cast<int64_t>(state.iterations()));
+}
+
+void benchOnMainThreadReadyVoid(benchmark::State& state) {
+	for (auto _ : state) {
+		benchmark::DoNotOptimize(_);
+		ThreadFuture<Void> result = onMainThread([] { return readyVoidFuture(); });
+		result.blockUntilReady();
+		benchmark::ClobberMemory();
+	}
+
+	state.SetItemsProcessed(static_cast<int64_t>(state.iterations()));
+}
+
+void benchOnMainThreadVoidEnqueue(benchmark::State& state) {
+	const int batchSize = state.range(0);
+
+	for (auto _ : state) {
+		benchmark::DoNotOptimize(_);
+		std::atomic<int> completed{ 0 };
+
+		for (int i = 0; i < batchSize; ++i) {
+			onMainThreadVoid([&completed] { completed.fetch_add(1, std::memory_order_release); });
+		}
+
+		state.PauseTiming();
+		while (completed.load(std::memory_order_acquire) != batchSize) {
+			std::this_thread::yield();
+		}
+		state.ResumeTiming();
+	}
+
+	state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) * batchSize);
+}
+
+void benchOnMainThreadVoidEnqueueWithErrorMember(benchmark::State& state) {
+	const int batchSize = state.range(0);
+
+	for (auto _ : state) {
+		benchmark::DoNotOptimize(_);
+		std::atomic<int> completed{ 0 };
+		ErrorSlot slot;
+
+		for (int i = 0; i < batchSize; ++i) {
+			onMainThreadVoid(
+			    [&completed] { completed.fetch_add(1, std::memory_order_release); }, &slot, &ErrorSlot::error);
+		}
+
+		state.PauseTiming();
+		while (completed.load(std::memory_order_acquire) != batchSize) {
+			std::this_thread::yield();
+		}
+		state.ResumeTiming();
+
+		ASSERT(slot.error.code() == invalid_error_code);
+	}
+
+	state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) * batchSize);
+}
+
+void benchSafeThreadFutureToFutureReadyInt(benchmark::State& state) {
+	onMainThread([&state] { return benchSafeThreadFutureToFutureReadyIntActor(&state); }).blockUntilReady();
+}
+
+void benchUnsafeThreadFutureToFutureReadyInt(benchmark::State& state) {
+	onMainThread([&state] { return benchUnsafeThreadFutureToFutureReadyIntActor(&state); }).blockUntilReady();
+}
+
+BENCHMARK(benchOnMainThreadReadyInt)->Name("ThreadHelper/onMainThread/ready_int")->ReportAggregatesOnly(true);
+BENCHMARK(benchOnMainThreadReadyVoid)->Name("ThreadHelper/onMainThread/ready_void")->ReportAggregatesOnly(true);
+
+BENCHMARK(benchOnMainThreadVoidEnqueue)
+    ->Name("ThreadHelper/onMainThreadVoid/enqueue")
+    ->RangeMultiplier(4)
+    ->Range(1, 1 << 10)
+    ->ReportAggregatesOnly(true);
+
+BENCHMARK(benchOnMainThreadVoidEnqueueWithErrorMember)
+    ->Name("ThreadHelper/onMainThreadVoid/enqueue_error_member")
+    ->RangeMultiplier(4)
+    ->Range(1, 1 << 10)
+    ->ReportAggregatesOnly(true);
+
+BENCHMARK(benchSafeThreadFutureToFutureReadyInt)
+    ->Name("ThreadHelper/safeThreadFutureToFuture/ready_int")
+    ->ReportAggregatesOnly(true);
+
+BENCHMARK(benchUnsafeThreadFutureToFutureReadyInt)
+    ->Name("ThreadHelper/unsafeThreadFutureToFuture/ready_int")
+    ->ReportAggregatesOnly(true);
+
+} // namespace


### PR DESCRIPTION
This PR is motivated by the upcoming coroutine conversion of `ThreadHelper.actor.h`. These microbenchmarks provide a performance baseline to try to beat. Baseline numbers are:


Benchmark | Batch | Real time | CPU time | Iterations | Throughput
-- | -- | -- | -- | -- | --
onMainThread/ready_int | — | 2,746.76 ns | 2,745.16 ns | 253,649 | 364.28k ops/s
onMainThread/ready_void | — | 2,758.19 ns | 2,757.98 ns | 249,793 | 362.58k ops/s
onMainThreadVoid/enqueue | 1 | 1,138.98 ns | 1,230.22 ns | 577,917 | 812.86k ops/s
onMainThreadVoid/enqueue | 4 | 1,566.25 ns | 1,662.55 ns | 409,212 | 2.41M ops/s
onMainThreadVoid/enqueue | 16 | 3,218.43 ns | 3,316.53 ns | 216,513 | 4.82M ops/s
onMainThreadVoid/enqueue | 64 | 10,722.20 ns | 10,876.64 ns | 65,370 | 5.88M ops/s
onMainThreadVoid/enqueue | 256 | 43,172.78 ns | 43,326.02 ns | 16,095 | 5.91M ops/s
onMainThreadVoid/enqueue | 1,024 | 161,692.09 ns | 161,884.66 ns | 4,322 | 6.33M ops/s
onMainThreadVoid/enqueue_error_member | 1 | 1,180.97 ns | 1,254.17 ns | 526,023 | 797.34k ops/s
onMainThreadVoid/enqueue_error_member | 4 | 1,612.24 ns | 1,758.13 ns | 409,179 | 2.28M ops/s
onMainThreadVoid/enqueue_error_member | 16 | 3,276.56 ns | 3,419.70 ns | 211,850 | 4.68M ops/s
onMainThreadVoid/enqueue_error_member | 64 | 9,807.97 ns | 9,980.08 ns | 68,425 | 6.41M ops/s
onMainThreadVoid/enqueue_error_member | 256 | 39,144.61 ns | 39,252.62 ns | 17,883 | 6.52M ops/s
onMainThreadVoid/enqueue_error_member | 1,024 | 147,009.46 ns | 147,147.26 ns | 4,740 | 6.96M ops/s
safeThreadFutureToFuture/ready_int | — | 181.04 ns | 181.03 ns | 3,877,637 | 5.52M ops/s
unsafeThreadFutureToFuture/ready_int | — | 62.78 ns | 62.78 ns | 11,152,659 | 15.93M ops/s
