### PR TITLE
Serialize C API wiggle tests

### DIFF
--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -399,6 +399,11 @@ if(NOT WIN32)
         --redundancy double
         )
 
+      # These tests replace every process in a local cluster. Running them with
+      # other CTests can starve recovery long enough to trip the progress check.
+      set_tests_properties(fdb_c_wiggle_only fdb_c_wiggle_and_upgrade
+        PROPERTIES RUN_SERIAL TRUE)
+
     endif()
   endif()
 


### PR DESCRIPTION
The C API wiggle tests intermittently fail their 30-second progress check under parallel CI load, despite passing in isolation. Serialize these resource-heavy tests to prevent contention-related flakes without relaxing their assertions or timeouts.
