### PR TITLE
Add mako_storage_bench.sh CPU benchmark

### DIFF
--- a/contrib/mako_storage_bench-ramdisk-okteto.md
+++ b/contrib/mako_storage_bench-ramdisk-okteto.md
@@ -24,6 +24,12 @@ directory, which on okteto takes a little care.
 contrib/mako_storage_bench.sh build_output4
 ```
 
+> `build_output4` here is just an example build directory (the author's
+> `~/src/fdb4` build tree, i.e. `/root/build_output4` on the dev pod) —
+> substitute your own build root. Note that **mako is not built by default**:
+> configure the build with `-D BUILD_MAKO=ON`, or `build_output4/bin/mako` will
+> be missing.
+
 ## What the script does automatically (and how to override)
 
 - **`WORKDIR`** — the cluster data dir and mako output live under `WORKDIR`. The

--- a/contrib/mako_storage_bench-ramdisk-okteto.md
+++ b/contrib/mako_storage_bench-ramdisk-okteto.md
@@ -1,0 +1,224 @@
+# Running mako_storage_bench.sh on a RAM disk (okteto dev pods)
+
+`mako_storage_bench.sh` is designed to make the **storage-server CPU** the
+bottleneck so it can detect storage-engine CPU regressions. That only holds if
+the cluster's data directory is on fast local storage. On an okteto dev pod it
+is **not**: the pod's filesystem is a container overlay backed by **network
+attached EBS**, so the benchmark is bound by EBS fsync/IO latency, not storage
+CPU. Symptom: throughput plateaus low (≈1.5k TPS on a fresh m7a pod) while the
+storage process sits well under 85% CPU, and commit latency is tens of ms.
+
+The fix is to put the cluster's data on a **tmpfs (RAM-backed) directory** so
+commits no longer pay disk latency and the storage process becomes CPU-bound.
+The script does this for you: when `/mnt/ram` exists and is writable it uses it
+automatically (and adds the tmpfs knob described below), so once the dev pod has
+a `/mnt/ram`, a plain `contrib/mako_storage_bench.sh build_output4` runs
+CPU-bound with no extra flags. The only real work is giving the pod that RAM
+directory, which on okteto takes a little care.
+
+## TL;DR
+
+```bash
+# one-time pod setup (details below): give the dev pod a /mnt/ram tmpfs + headroom.
+# then just run it -- the script auto-detects /mnt/ram and adds the tmpfs knob:
+contrib/mako_storage_bench.sh build_output4
+```
+
+## What the script does automatically (and how to override)
+
+- **`WORKDIR`** — the cluster data dir and mako output live under `WORKDIR`. The
+  script defaults it to `/mnt/ram/mako_storage_bench` when `/mnt/ram` is a
+  writable directory, otherwise `$PWD/mako_storage_bench`. Override by exporting
+  `WORKDIR` (e.g. point it off the RAM disk to force the EBS data dir).
+- **The tmpfs knob** — fdbserver opens its data files with `O_DIRECT` kernel AIO
+  by default, and **tmpfs rejects `O_DIRECT`**, so without a fallback the cluster
+  never starts. When `WORKDIR` is on a tmpfs the script automatically adds
+  `--knob_disable_posix_kernel_aio=1` (flow then uses the EIO buffered path that
+  tmpfs accepts). Pass extra knobs via `KNOBS='...'`; the script appends the
+  tmpfs knob for you if you didn't include it.
+- **Bounded duration** (`SECONDS_RUN`/`WARMUP_SECONDS`) — optional; see *Sizing*.
+
+## Storage engines: redwood (default) vs rocksdb on tmpfs
+
+The default engine is **redwood** (`ssd-redwood-1`); the script's automatic
+tmpfs knob is all it needs, so no `KNOBS` are required.
+
+The **rocksdb** engine (`... build_output4 rocksdb`) needs **two more knobs**.
+RocksDB does its own file I/O, independent of flow, and on `ssd-rocksdb-v1` it
+opens the DB with `O_DIRECT` by default (`ROCKSDB_USE_DIRECT_READS` and
+`ROCKSDB_USE_DIRECT_IO_FLUSH_COMPACTION` both default `true` in ServerKnobs).
+tmpfs rejects `O_DIRECT`, so the storage server fails at `Open`
+(`RocksDBError: "Invalid argument: Direct I/O is not supported by the specified
+DB."`) and **crash-loops** — and because that happens before any data dir is
+created, the bench **hangs at `configure new`** (the script's `BUILD_TIMEOUT`
+only guards the mako build, not cluster startup, so it will not self-abort).
+
+The automatic tmpfs knob does not affect RocksDB; you must disable RocksDB's
+direct I/O separately. These are runtime knobs — **no recompile**. The script
+still auto-adds the flow knob, so you only supply the two `rocksdb_*` knobs:
+
+```bash
+KNOBS='--knob_rocksdb_use_direct_reads=false --knob_rocksdb_use_direct_io_flush_compaction=false' \
+    contrib/mako_storage_bench.sh build_output4 rocksdb
+```
+
+The two `rocksdb_*` knobs are harmless to redwood, so the same `KNOBS` also
+works for a `... build_output4 redwood rocksdb` run.
+
+Observations from a full 300s/600s run on a 24Gi tmpfs (m7a pod): with the
+knobs, rocksdb runs storage-CPU-bound just like redwood (~4.6k vs ~4.8k TPS) and
+its peak footprint was **smaller** (~3.3 GB vs redwood's ~5.5 GB) — i.e. rocksdb
+did **not** blow out the ramdisk. Expect higher per-GET latency and a higher
+conflict rate than redwood, though.
+
+## You cannot just `mount` a tmpfs inside the pod
+
+The dev container has no `CAP_SYS_ADMIN`, so `mount -t tmpfs ...` fails with
+*permission denied*. `/dev/shm` exists but is capped at 64 MB. The large tmpfs
+mounts you may see (`/var/okteto/secret`, etc.) are read-only. So the RAM
+directory has to come from the pod spec as a memory-backed `emptyDir`.
+
+## okteto topology gotcha: patch the BASE deployment, not the clone
+
+`okteto up` does **not** run your deployment directly. For an okteto manifest
+with `name: <dev>` it keeps two deployments:
+
+- **`<dev>`** — the base deployment, scaled to `0/0`. This is the source of
+  truth okteto clones from.
+- **`<dev>-okteto`** — the live clone okteto generates and **actively
+  reconciles**. It runs your pod.
+
+okteto **strips volumes it doesn't own from the clone**, so a
+`kubectl patch deployment <dev>-okteto ...` adding a volume silently disappears.
+But okteto **preserves the base deployment's volumes** when it clones (that is
+how `efs-ccache`, the fdb cluster file, etc. reach the dev pod). So the volume
+must be added to the **base** `<dev>` deployment; `okteto up` then carries it
+into the pod.
+
+(Worked example below uses the deployment name `gglass-dev`; substitute your
+okteto manifest's `name:`.)
+
+## Setup
+
+### 1. Raise the dev container memory limit (okteto.yml)
+
+A memory-backed `emptyDir`'s contents are **charged to the container's memory
+cgroup**, i.e. they count against the `dev` container's memory *limit* (not the
+node's free RAM). So the tmpfs contents **plus** all fdbserver/mako RSS must fit
+under the limit. Raise it in `okteto.yml`:
+
+```yaml
+resources:
+  requests:
+    cpu: "4000m"
+    memory: "24Gi"     # was 16Gi
+  limits:
+    cpu: "8000m"
+    memory: "48Gi"     # was 32Gi -- room for a 24Gi tmpfs + fdbserver/mako RSS
+```
+
+This part *does* persist in `okteto.yml` across `okteto up`.
+
+### 2. Add the tmpfs volume to the base deployment
+
+`okteto.yml` (this manifest format) cannot declare an `emptyDir`, so apply it as
+a strategic-merge patch on the **base** deployment. Save as `fdb-ramdisk.yaml`:
+
+```yaml
+spec:
+  template:
+    spec:
+      volumes:
+        - name: ramdisk
+          emptyDir:
+            medium: Memory
+            sizeLimit: 24Gi
+      containers:
+        - name: dev
+          volumeMounts:
+            - name: ramdisk
+              mountPath: /mnt/ram
+```
+
+Apply it to the base (it is at 0 replicas, so this disturbs nothing running):
+
+```bash
+kubectl patch deployment gglass-dev --patch-file fdb-ramdisk.yaml
+```
+
+> The patch edits the live base deployment. Whatever provisions `gglass-dev`
+> (your dev-pod infra/manifest) will overwrite it on a re-apply. For a permanent
+> setup, add the same `volumes`/`volumeMounts` blocks to that source manifest.
+
+### 3. Re-create the pod
+
+```bash
+okteto up
+```
+
+okteto clones the (now patched) base into `<dev>-okteto`, so the new pod has
+`/mnt/ram` and the 48Gi limit.
+
+### 4. Verify
+
+```bash
+kubectl exec <pod> -c dev -- df -hT /mnt/ram        # want: tmpfs, 24G
+kubectl exec <pod> -c dev -- sh -c 'touch /mnt/ram/.w && rm /mnt/ram/.w && echo ok'
+```
+
+## Sizing the tmpfs
+
+The on-disk footprint grows with **total inserts = TPS x wall-time** (the
+default `g18ui` workload inserts one new key per transaction). RAM-backing
+raises TPS, so the same wall-clock writes *more* than on EBS. As a reference, an
+EBS run that managed ~1.5k TPS for 600 s wrote ~4 GB; the redwood file is the
+bulk and runs roughly ~2 KB per insert including COW/extent overhead.
+
+Two facts make sizing easy:
+
+- A tmpfs `sizeLimit` is a **hard cap** (writes past it get ENOSPC) **and** its
+  usage counts against the container memory limit (over the limit ⇒ OOMKill).
+- Memory is only consumed for bytes actually written, not reserved up front.
+
+Recommendations:
+
+- The full 300s/600s default fits comfortably on a 24Gi tmpfs for redwood
+  (~5.5 GB peak). To bound the footprint for a faster engine or a longer run,
+  shorten it with `SECONDS_RUN=120 WARMUP_SECONDS=60` (a 2-minute measured
+  window is plenty once CPU-bound).
+- `sizeLimit: 24Gi` + `limits.memory: 48Gi` comfortably covers that. For very
+  high TPS or long runs, raise both (e.g. 40Gi tmpfs / 64Gi limit) and confirm
+  the node has the RAM.
+
+## Disabling / reverting
+
+- Remove the volume from the base and re-clone:
+
+  ```bash
+  kubectl patch deployment gglass-dev --type=json \
+    -p '[{"op":"remove","path":"/spec/template/spec/volumes/-"}]'
+  okteto up
+  ```
+
+  (or re-apply your base `gglass-dev` manifest).
+
+- Restore the `okteto.yml` memory limits if you want the original ceiling.
+- The script now **prefers `/mnt/ram` automatically** when it is present, so a
+  plain run uses the RAM disk. To force the EBS data dir without removing the
+  volume, export `WORKDIR=$PWD/mako_storage_bench` (any non-tmpfs path) for that
+  run.
+
+## Other gotchas
+
+- **You will lose `build_output4`.** It lives on the ephemeral container overlay,
+  and both the memory-limit change and the volume patch force a pod rollout.
+  Rebuild with `run-ccmk4` (or your build wrapper) afterward — the ccache is on a
+  persistent EFS volume, so a warm rebuild is minutes, not a cold build.
+- **`mako` links `libfdb_c.so` and is built with `SKIP_BUILD_RPATH`.**
+  `mako_storage_bench.sh` already sets `LD_LIBRARY_PATH=<build>/lib` (and
+  `LD_BIND_NOW=1`) so mako loads the matching client. Unrelated to the RAM disk,
+  but it is why mako runs from the build tree at all.
+- **mako aborts in `_dl_fini` at exit** (a libfdb_c-as-shared-lib teardown issue)
+  after writing all its output. The script judges success by the completed
+  report and disables core dumps (`ulimit -c 0`), so this is harmless — do not
+  be alarmed by the abort message.

--- a/contrib/mako_storage_bench.sh
+++ b/contrib/mako_storage_bench.sh
@@ -89,6 +89,8 @@ function usage {
 Usage: ${0##*/} <build-root> [engine ...]
 
   build-root   FDB build directory containing bin/{fdbserver,fdbcli,mako}.
+               mako is NOT built by default -- configure the build with
+               -D BUILD_MAKO=ON (else bin/mako will be missing here).
   engine       One or more of: redwood rocksdb sharded-rocksdb all
                'all' = redwood + rocksdb (sharded-rocksdb is not included).
                Default: redwood

--- a/contrib/mako_storage_bench.sh
+++ b/contrib/mako_storage_bench.sh
@@ -1,0 +1,239 @@
+#!/bin/bash
+#
+# mako_storage_bench.sh - single-host mako throughput benchmark for catching
+# storage-server CPU regressions.
+#
+# Boots a minimal loopback cluster with exactly one stateless, one log, and one
+# storage process (so the storage role is isolated in its own process and its
+# CPU is the bottleneck), then runs a fixed mako build + run workload against it.
+#
+# Purpose: A/B comparison of experimental FDB changes that execute in the
+# storage server -- not just storage-engine code, but any FDB software
+# infrastructure exercised on the storage server's path (flow, fdbrpc,
+# networking, serialization, common libraries, etc.). Run it once on a baseline
+# build and once on the experimental build to confirm the change does not add
+# significant CPU cost or introduce latency. The two runs must be done on the
+# same machine/instance, back to back (results are only comparable under
+# identical hardware/conditions). Because the storage role is pinned to a
+# single process and effectively a single core, any CPU **overhead** the change
+# adds -- extra work on the hot path -- competes for that one core and will
+# typically show up as a drop in throughput rather than as obvious latency.
+# Watch the TPS delta.
+#
+# Background: the default workload (ssd-redwood-1 single; 1/1/1 server roles;
+# build -p 4; run -p 7 -t 4 --async_xacts 128 --keylen 128 --vallen 512;
+# -x g18ui = 18 GETs + 1 update + 1 insert per txn; 300s warmup, 600s run) comes
+# from a config shared in the FDB working group and used across teams. On a
+# ~32-core single host it produces very low run-to-run noise and has been a
+# reliable detector of storage-server performance regressions. The counts are
+# tuned for that host size: on a much smaller or larger machine, adjust the
+# server/client process counts (env-overridable below) so the storage process
+# stays the bottleneck and the clients can keep it saturated without starving it.
+#
+# Unlike contrib/generate_profile.sh this uses plain Release binaries: no LLVM
+# profile instrumentation, no LLVM_PROFILE_FILE, no llvm-profdata merge. Those
+# distort hot-path CPU and would invalidate throughput numbers. Use an
+# uninstrumented (Release) build here.
+#
+# Process placement is left to the Linux scheduler on purpose -- the storage
+# process is expected to be CPU-hungry and the clients comparatively idle, so no
+# taskset pinning is applied.
+
+set -euo pipefail
+
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+readonly RUN_CLUSTER="${REPO_ROOT}/tests/loopback_cluster/run_custom_cluster.sh"
+
+# --- Fixed workload (override via env if needed) ----------------------------
+# Data spec, shared by build and run.
+readonly ROWS="${ROWS:-100000}"
+readonly KEYLEN="${KEYLEN:-128}"
+readonly VALLEN="${VALLEN:-512}"
+# Build phase: parallelism only.
+readonly BUILD_PROCS="${BUILD_PROCS:-4}"
+# Run phase.
+readonly RUN_PROCS="${RUN_PROCS:-7}"
+readonly RUN_THREADS="${RUN_THREADS:-4}"
+readonly ASYNC_XACTS="${ASYNC_XACTS:-128}"
+readonly TRANSACTION="${TRANSACTION:-g18ui}"   # 18 GETs + 1 update + 1 insert
+readonly WARMUP_SECONDS="${WARMUP_SECONDS:-300}"
+readonly SECONDS_RUN="${SECONDS_RUN:-600}"
+# Bound the build phase so it fails fast instead of hanging if the database
+# never serves. (Does not cover a hang during cluster startup/configure.)
+readonly BUILD_TIMEOUT="${BUILD_TIMEOUT:-180}"
+
+# Where clusters and mako output live. Prefer a RAM disk at /mnt/ram when one is
+# present and writable, so the storage role is CPU-bound rather than disk-IO-
+# bound; otherwise fall back to the current directory.
+if [[ -z "${WORKDIR:-}" && -w /mnt/ram ]]; then
+  WORKDIR=/mnt/ram/mako_storage_bench
+fi
+readonly WORKDIR="${WORKDIR:-${PWD}/mako_storage_bench}"
+
+# Extra fdbserver knobs, forwarded to run_custom_cluster.sh --knobs. A tmpfs
+# WORKDIR rejects fdbserver's default O_DIRECT path, so when WORKDIR is on tmpfs
+# add the EIO-fallback knob automatically. (rocksdb needs more knobs on tmpfs --
+# see mako_storage_bench-ramdisk-okteto.md.)
+KNOBS="${KNOBS:-}"
+if [[ "$(stat -f -c %T "$(dirname "${WORKDIR}")" 2>/dev/null)" == tmpfs \
+      && "${KNOBS}" != *disable_posix_kernel_aio* ]]; then
+  KNOBS="${KNOBS:+${KNOBS} }--knob_disable_posix_kernel_aio=1"
+fi
+readonly KNOBS
+
+CLUSTER_PIDS=""
+
+function usage {
+  cat >&2 <<EOF
+Usage: ${0##*/} <build-root> [engine ...]
+
+  build-root   FDB build directory containing bin/{fdbserver,fdbcli,mako}.
+  engine       One or more of: redwood rocksdb sharded-rocksdb all
+               'all' = redwood + rocksdb (sharded-rocksdb is not included).
+               Default: redwood
+
+Engines map to 'configure new <type> single':
+  redwood          -> ssd-redwood-1
+  rocksdb          -> ssd-rocksdb-v1        (needs a RocksDB-enabled build)
+  sharded-rocksdb  -> ssd-sharded-rocksdb   (needs a RocksDB-enabled build)
+
+Workload (override via env): ROWS=${ROWS} KEYLEN=${KEYLEN} VALLEN=${VALLEN}
+  build: -p ${BUILD_PROCS}
+  run:   -p ${RUN_PROCS} -t ${RUN_THREADS} --async_xacts ${ASYNC_XACTS} \\
+         -x ${TRANSACTION} --warmup_seconds ${WARMUP_SECONDS} --seconds ${SECONDS_RUN}
+
+Example:
+  ${0##*/} /data/build_output redwood rocksdb
+EOF
+  exit 1
+}
+
+function err { echo "$(date -Iseconds) ERROR: $*" >&2; }
+
+# Map a friendly engine name to the storage type understood by 'configure new'.
+function storage_type_for {
+  case "${1}" in
+    redwood)         echo "ssd-redwood-1" ;;
+    rocksdb)         echo "ssd-rocksdb-v1" ;;
+    sharded-rocksdb) echo "ssd-sharded-rocksdb" ;;
+    *) err "unknown engine '${1}'"; usage ;;
+  esac
+}
+
+# Kill whatever the current run_custom_cluster.sh invocation started.
+function teardown_cluster {
+  if [[ -n "${CLUSTER_PIDS}" ]]; then
+    # shellcheck disable=SC2086
+    kill -9 ${CLUSTER_PIDS} 2>/dev/null || true
+    CLUSTER_PIDS=""
+  fi
+}
+trap teardown_cluster EXIT
+
+# Run the full build + run benchmark for a single storage engine.
+function bench_engine {
+  local label="${1}"
+  local storage_type
+  storage_type="$(storage_type_for "${label}")"
+
+  local engine_dir="${WORKDIR}/${label}"
+  local cluster_file="${engine_dir}/loopback-cluster/fdb.cluster"
+  mkdir -p "${engine_dir}"
+
+  echo "============================================================"
+  echo "Engine: ${label} (${storage_type} single)"
+  echo "============================================================"
+
+  # Start a 1 stateless / 1 log / 1 storage cluster, reading PIDS back from a
+  # file. Redirect the launcher to a file rather than capturing with $(...): it
+  # backgrounds long-lived fdbservers that would hold the $(...) pipe open and
+  # deadlock us.
+  local start_log="${engine_dir}/cluster-start.log"
+  local knob_opt=()
+  [[ -n "${KNOBS}" ]] && knob_opt=(--knobs "${KNOBS}")
+  LOOPBACK_DIR="${engine_dir}/loopback-cluster" "${RUN_CLUSTER}" "${BUILD}" \
+    "${knob_opt[@]}" \
+    --stateless_count 1 --logs_count 1 --storage_count 1 \
+    --replication_count 1 \
+    --storage_type "${storage_type}" \
+    --dump_pids on >"${start_log}" 2>&1
+  cat "${start_log}"
+  CLUSTER_PIDS="$(sed -n 's/^PIDS=//p' "${start_log}")"
+
+  # mako does all its work but SIGABRTs in _dl_fini at exit (libfdb_c shared-lib
+  # teardown), so judge the build by its completed report, not the exit code.
+  echo "--- ${label}: mako build ---"
+  timeout "${BUILD_TIMEOUT}" "${MAKO}" --mode build --cluster "${cluster_file}" \
+    --rows "${ROWS}" -p "${BUILD_PROCS}" \
+    --keylen "${KEYLEN}" --vallen "${VALLEN}" \
+    2>&1 | tee "${engine_dir}/mako-build.txt" || true
+  if ! grep -q "Overall TPS" "${engine_dir}/mako-build.txt"; then
+    err "mako build for ${label} (${storage_type}) did not complete within ${BUILD_TIMEOUT}s."
+    case "${label}" in
+      rocksdb|sharded-rocksdb)
+        err "  ${storage_type} needs a RocksDB-enabled build -- is RocksDB compiled into this build?" ;;
+    esac
+    teardown_cluster
+    return 1
+  fi
+
+  echo "--- ${label}: mako run ---"
+  # Also emit structured JSON alongside the teed report: per-second samples +
+  # final stats (--json_report) and the raw latency sketch (--stats_export_path).
+  "${MAKO}" --mode run --cluster "${cluster_file}" \
+    --rows "${ROWS}" -x "${TRANSACTION}" \
+    -p "${RUN_PROCS}" -t "${RUN_THREADS}" --async_xacts "${ASYNC_XACTS}" \
+    --keylen "${KEYLEN}" --vallen "${VALLEN}" \
+    --warmup_seconds "${WARMUP_SECONDS}" --seconds "${SECONDS_RUN}" \
+    --json_report "${engine_dir}/mako.json" \
+    --stats_export_path "${engine_dir}/mako-sketch.json" \
+    2>&1 | tee "${engine_dir}/mako-run.txt"
+
+  teardown_cluster
+  echo "--- ${label}: done (output in ${engine_dir}/mako-run.txt) ---"
+}
+
+# --- main -------------------------------------------------------------------
+if (( $# < 1 )); then usage; fi
+if [[ "${1}" == "-h" || "${1}" == "--help" ]]; then usage; fi
+
+BUILD_ARG="${1}"; shift
+# Resolve to an absolute path so LD_LIBRARY_PATH (set below) and the binary
+# paths are independent of the caller's working directory.
+BUILD="$(cd "${BUILD_ARG}" 2>/dev/null && pwd)" \
+  || { err "build root '${BUILD_ARG}' not found or not a directory"; usage; }
+FDBCLI="${BUILD}/bin/fdbcli"
+MAKO="${BUILD}/bin/mako"
+for bin in "${BUILD}/bin/fdbserver" "${FDBCLI}" "${MAKO}"; do
+  if [[ ! -x "${bin}" ]]; then err "${bin} not found or not executable"; usage; fi
+done
+if [[ ! -x "${RUN_CLUSTER}" ]]; then
+  err "${RUN_CLUSTER} not found"; exit 1
+fi
+
+# mako has no rpath (SKIP_BUILD_RPATH), so point it at this build's libfdb_c.so
+# instead of a mismatched system one. LD_BIND_NOW avoids a lazy symbol-resolution
+# crash in the dynamic linker on mako's first call.
+export LD_LIBRARY_PATH="${BUILD}/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+export LD_BIND_NOW=1
+
+# Suppress the core dump from mako's harmless _dl_fini abort at exit.
+ulimit -c 0
+
+# Resolve the engine list (default: redwood; 'all' expands to every engine).
+ENGINES=("$@")
+if (( ${#ENGINES[@]} == 0 )); then
+  ENGINES=(redwood)
+elif [[ "${ENGINES[*]}" == *all* ]]; then
+  # 'all' covers the common engines; sharded-rocksdb must be requested explicitly.
+  ENGINES=(redwood rocksdb)
+fi
+
+mkdir -p "${WORKDIR}"
+echo "WORKDIR=${WORKDIR}${KNOBS:+   KNOBS=${KNOBS}}"
+status=0
+for engine in "${ENGINES[@]}"; do
+  bench_engine "${engine}" || status=1
+done
+exit "${status}"


### PR DESCRIPTION
A single-host mako throughput benchmark for catching storage-server CPU regressions. It boots a minimal loopback cluster (1 stateless / 1 log / 1 storage) so the storage role is isolated in its own process and its CPU is the bottleneck, then runs a fixed mako build + run workload. Run it on a baseline build and an experimental build back-to-back on the same machine to confirm a change -- anywhere in FDB code that executes in the storage server -- does not add CPU overhead or latency. Because the storage role is effectively single-core, extra work on its hot path typically shows up as a drop in throughput rather than as obvious latency.

To get a CPU-bound (rather than disk-IO-bound) measurement on a dev pod whose data dir is on network-attached EBS, the script auto-detects a /mnt/ram tmpfs and uses it when present, automatically adding the --knob_disable_posix_kernel_aio knob tmpfs requires (it rejects O_DIRECT). WORKDIR / KNOBS / workload counts are env-overridable; rocksdb on tmpfs needs two extra direct-I/O knobs.

Per engine it writes a human-readable report plus structured JSON (per-second samples and the raw latency sketch). It bounds the build phase with a timeout, judges success by the completed report, and suppresses the harmless core dump from mako's _dl_fini abort at exit.

The companion mako_storage_bench-ramdisk-okteto.md documents the one-time okteto pod setup for the /mnt/ram tmpfs (memory-backed emptyDir on the base deployment, container memory headroom, sizing, and disable/revert).
