### PR TITLE
DD finishMoveKeys: move waitForShardReady outside transaction

### DIFF
--- a/fdbserver/core/MoveKeys.cpp
+++ b/fdbserver/core/MoveKeys.cpp
@@ -1380,21 +1380,21 @@ static bool destUnchanged(const RangeResult& keyServers,
 		UID checkSrcId, checkDestId;
 		decodeKeyServersValue(uidToTagMap, keyServers[i].value, checkSrc, checkDest, checkSrcId, checkDestId);
 		if (expectedDataMoveId.present()) {
-      // Have checkDestId == expectedDataMoveId — the shards path stamps every assigned
-      // sub-range with its dataMoveId, so any mismatch (including an empty-dest
-      // entry, which decodes to UID()) signals a concurrent reassignment.
+			// Have checkDestId == expectedDataMoveId — the shards path stamps every assigned
+			// sub-range with its dataMoveId, so any mismatch (including an empty-dest
+			// entry, which decodes to UID()) signals a concurrent reassignment.
 			if (checkDestId != expectedDataMoveId.get()) {
 				return false;
 			}
 		} else if (checkDest.empty()) {
-      // Empty-dest entries are tolerated wherever src ⊆ expectedDest. That matches the planning loop's
-      // `alreadyMoved = dest2.empty() && isSubset` branch (see the second planning
-      // loop in finishMoveKeys, around the "first key in iteration sub-range has
-      // already been processed" CODE_PROBE): a sibling iteration of OUR move
-      // already completed this sub-range, src is what was left after team-shrink,
-      // and the upcoming krmSetRangeCoalescing write will collapse it into the
-      // rest. The subset check rules out a foreign completed move whose src is
-      // a different team — clobbering it would overwrite the foreign owner.
+			// Empty-dest entries are tolerated wherever src ⊆ expectedDest. That matches the planning loop's
+			// `alreadyMoved = dest2.empty() && isSubset` branch (see the second planning
+			// loop in finishMoveKeys, around the "first key in iteration sub-range has
+			// already been processed" CODE_PROBE): a sibling iteration of OUR move
+			// already completed this sub-range, src is what was left after team-shrink,
+			// and the upcoming krmSetRangeCoalescing write will collapse it into the
+			// rest. The subset check rules out a foreign completed move whose src is
+			// a different team — clobbering it would overwrite the foreign owner.
 			std::sort(checkSrc.begin(), checkSrc.end());
 			if (!std::includes(expectedDest.begin(), expectedDest.end(), checkSrc.begin(), checkSrc.end())) {
 				return false;
@@ -1740,7 +1740,7 @@ static Future<Void> finishMoveKeys(Database occ,
 						// commit would otherwise clear and rewrite an
 						// unverified-and-possibly-foreign tail. Common under
 						// MOVE_KEYS_KRM_LIMIT buggify (2 rows -- which happens often
-            // in simulation).
+						// in simulation).
 						Key rereadEnd = reread.keyServers.end()[-1].key;
 						// The reread is bounded by `currentKeys` (the upper-bound
 						// passed to readShardState), so a `>` result would mean

--- a/fdbserver/core/MoveKeys.cpp
+++ b/fdbserver/core/MoveKeys.cpp
@@ -54,6 +54,23 @@ double finishMoveKeysBackoff(int retries) {
 	return std::min(base * (0.75 + 0.5 * deterministicRandom()->random01()), 5.0); // jitter: [0.75x, 1.25x], capped
 }
 
+// Shared retry tail used by the finishMove* post-wait branches that detect a
+// concurrent change (dest reassigned, data move deleted, phase changed):
+// bumps `retries`, throws finish_move_keys_too_many_retries once the cap is
+// exceeded, otherwise sleeps the backoff and resets the transaction.
+// The caller still issues `continue;` after awaiting this — keeping the loop-
+// control statement at the call site preserves readability of the retry path.
+// Count-mismatch sites stay inline because they emit a custom giveup
+// TraceEvent with ready/dest-count details that don't fit a generic helper.
+static Future<Void> retryAfterPostWaitChange(int* retries, Transaction* tr) {
+	if (++(*retries) > SERVER_KNOBS->FINISH_MOVE_KEYS_MAX_RETRIES) {
+		throw finish_move_keys_too_many_retries();
+	}
+	co_await delay(finishMoveKeysBackoff(*retries));
+	tr->reset();
+	co_return;
+}
+
 struct Shard {
 	Shard() = default;
 	Shard(KeyRangeRef range, const UID& id) : range(range), id(id) {}
@@ -1297,6 +1314,110 @@ Future<Void> checkFetchingState(Database cx,
 	}
 }
 
+// System-key reads that finishMoveKeys / finishMoveShards depend on for
+// correctness. Used both before the waitForShardReady wait (in the planning
+// transaction that's then discarded) and after the wait (in the verify+write
+// transaction). Centralizing the reads ensures both sides see the same set,
+// so the post-wait verification can detect any change to state the planning
+// phase relied on.
+struct ShardStateReads {
+	RangeResult uidToTagMap;
+	RangeResult keyServers;
+	Optional<DataMoveMetaData> dataMove; // populated iff dataMoveId.present()
+};
+
+// Read the system-key state needed by finishMoveKeys / finishMoveShards.
+// Called twice per attempt:
+//   1. Before waitForShardReady, to plan the wait (which dest interfaces, etc).
+//   2. After the wait, to verify nothing changed; the caller compares the two
+//      results and retries if they differ.
+static Future<ShardStateReads> readShardState(Transaction* tr,
+                                              MoveKeysLock lock,
+                                              const DDEnabledState* ddEnabledState,
+                                              KeyRange range,
+                                              Optional<UID> dataMoveId,
+                                              int krmRowLimit,
+                                              int krmByteLimit) {
+	// Read set scope: moveKeysLock, dataMove (when applicable), serverTags
+	// (uidToTagMap), and keyServers. The original single-transaction code
+	// also read \xff/serverList/ — that's NOT covered here because writes
+	// key off stable UIDs not interfaces, so a serverList change between
+	// read and write can't invalidate the writes. Both code paths (keys and
+	// shards) commit only UID-keyed entries — keyServersValue and
+	// serverKeysValue for finishMoveKeys, plus dataMoveValue for
+	// finishMoveShards — so a serverList change between read and commit
+	// cannot invalidate any persisted state. Server removal is coordinated
+	// under moveKeysLock (re-checked here); dest reassignment is caught by
+	// the caller's dest-UID equality check; an SS that vanished mid-wait
+	// causes the caller's count check to fail before reaching commit. The
+	// serverList read therefore stays inline at the caller (it's needed
+	// once, before the wait, only to build interfaces).
+	co_await checkMoveKeysLock(tr, lock, ddEnabledState);
+
+	ShardStateReads r;
+	if (dataMoveId.present()) {
+		Optional<Value> val = co_await tr->get(dataMoveKeyFor(dataMoveId.get()));
+		if (val.present()) {
+			r.dataMove = decodeDataMoveValue(val.get());
+		}
+	}
+
+	r.uidToTagMap = co_await tr->getRange(serverTagKeys, CLIENT_KNOBS->TOO_MANY);
+	ASSERT(!r.uidToTagMap.more && r.uidToTagMap.size() < CLIENT_KNOBS->TOO_MANY);
+
+	r.keyServers = co_await krmGetRanges(tr, keyServersPrefix, range, krmRowLimit, krmByteLimit);
+
+	co_return r;
+}
+
+// Post-wait verification used by both finishMoveKeys and finishMoveShards.
+//
+// Returns true if every sub-range in `keyServers` still maps to `expectedDest`.
+//
+// When `expectedDataMoveId.present()` (shards path), every sub-range must also
+// have destId == expectedDataMoveId — the shards path stamps every assigned
+// sub-range with its dataMoveId, so any mismatch (including an empty-dest
+// entry, which decodes to UID()) signals a concurrent reassignment.
+//
+// When `expectedDataMoveId` is absent (keys path), empty-dest entries are
+// tolerated wherever src ⊆ expectedDest. That matches the planning loop's
+// `alreadyMoved = dest2.empty() && isSubset` branch (see the second planning
+// loop in finishMoveKeys, around the "first key in iteration sub-range has
+// already been processed" CODE_PROBE): a sibling iteration of OUR move
+// already completed this sub-range, src is what was left after team-shrink,
+// and the upcoming krmSetRangeCoalescing write will collapse it into the
+// rest. The subset check rules out a foreign completed move whose src is
+// a different team — clobbering it would overwrite the foreign owner.
+//
+// Sorts `expectedDest` internally so callers don't have to.
+static bool destUnchanged(const RangeResult& keyServers,
+                          const RangeResult& uidToTagMap,
+                          std::vector<UID> expectedDest,
+                          Optional<UID> expectedDataMoveId) {
+	std::sort(expectedDest.begin(), expectedDest.end());
+	for (int i = 0; i + 1 < keyServers.size(); ++i) {
+		std::vector<UID> checkSrc, checkDest;
+		UID checkSrcId, checkDestId;
+		decodeKeyServersValue(uidToTagMap, keyServers[i].value, checkSrc, checkDest, checkSrcId, checkDestId);
+		if (expectedDataMoveId.present()) {
+			if (checkDestId != expectedDataMoveId.get()) {
+				return false;
+			}
+		} else if (checkDest.empty()) {
+			std::sort(checkSrc.begin(), checkSrc.end());
+			if (!std::includes(expectedDest.begin(), expectedDest.end(), checkSrc.begin(), checkSrc.end())) {
+				return false;
+			}
+			continue;
+		}
+		std::sort(checkDest.begin(), checkDest.end());
+		if (checkDest != expectedDest) {
+			return false;
+		}
+	}
+	return true;
+}
+
 // Set keyServers[keys].src = keyServers[keys].dest and keyServers[keys].dest=[], return when successful
 // keyServers[k].dest must be the same for all k in keys
 // Set serverKeys[dest][keys] = true; serverKeys[src][keys] = false for all src not in dest
@@ -1349,16 +1470,16 @@ static Future<Void> finishMoveKeys(Database occ,
 					co_await finishMoveKeysParallelismLock->take(TaskPriority::DataDistributionLaunch);
 					releaser = FlowLock::Releaser(*finishMoveKeysParallelismLock);
 
-					co_await checkMoveKeysLock(&tr, lock, ddEnabledState);
-
 					KeyRange currentKeys = KeyRangeRef(begin, keys.end);
-					RangeResult UIDtoTagMap = co_await tr.getRange(serverTagKeys, CLIENT_KNOBS->TOO_MANY);
-					ASSERT(!UIDtoTagMap.more && UIDtoTagMap.size() < CLIENT_KNOBS->TOO_MANY);
-					RangeResult keyServers = co_await krmGetRanges(&tr,
-					                                               keyServersPrefix,
-					                                               currentKeys,
-					                                               SERVER_KNOBS->MOVE_KEYS_KRM_LIMIT,
-					                                               SERVER_KNOBS->MOVE_KEYS_KRM_LIMIT_BYTES);
+					ShardStateReads state = co_await readShardState(&tr,
+					                                                lock,
+					                                                ddEnabledState,
+					                                                currentKeys,
+					                                                /*dataMoveId=*/{},
+					                                                SERVER_KNOBS->MOVE_KEYS_KRM_LIMIT,
+					                                                SERVER_KNOBS->MOVE_KEYS_KRM_LIMIT_BYTES);
+					RangeResult& UIDtoTagMap = state.uidToTagMap;
+					RangeResult& keyServers = state.keyServers;
 
 					// Determine the last processed key (which will be the beginning for the next iteration)
 					endKey = keyServers.end()[-1].key;
@@ -1517,29 +1638,39 @@ static Future<Void> finishMoveKeys(Database occ,
 
 					// update client info in case tss mapping changed or server got updated
 
-					// Wait for new destination servers to fetch the keys
+					// Save the read version before dropping the transaction. waitForShardReady
+					// needs a minimum version the dest must reach; saving the older version is
+					// sufficient because servers will already be past it by the time we
+					// re-verify in the second transaction below.
+					Version readVersion = tr.getReadVersion().get();
+
+					// Drop the transaction BEFORE the potentially long wait. The 15-second
+					// SERVER_READY_QUORUM_TIMEOUT exceeds the ~5-second transaction lifetime,
+					// so waiting inside the transaction guarantees transaction_too_old on
+					// commit when destination servers are slow to respond.
+					tr.reset();
+
+					// Wait for new destination servers to fetch the keys (OUTSIDE any transaction)
 
 					serverReady.reserve(storageServerInterfaces.size());
 					tssReady.reserve(storageServerInterfaces.size());
 					tssReadyInterfs.reserve(storageServerInterfaces.size());
 					for (int s = 0; s < storageServerInterfaces.size(); s++) {
-						serverReady.push_back(waitForShardReady(storageServerInterfaces[s],
-						                                        keys,
-						                                        tr.getReadVersion().get(),
-						                                        GetShardStateRequest::READABLE));
+						serverReady.push_back(waitForShardReady(
+						    storageServerInterfaces[s], keys, readVersion, GetShardStateRequest::READABLE));
 
 						auto tssPair = tssMapping.find(storageServerInterfaces[s].id());
 
 						if (tssPair != tssMapping.end() && waitForTSSCounter > 0 &&
 						    !tssToIgnore.contains(tssPair->second.id())) {
 							tssReadyInterfs.push_back(tssPair->second);
-							tssReady.push_back(waitForShardReady(
-							    tssPair->second, keys, tr.getReadVersion().get(), GetShardStateRequest::READABLE));
+							tssReady.push_back(
+							    waitForShardReady(tssPair->second, keys, readVersion, GetShardStateRequest::READABLE));
 						}
 					}
 
 					// Wait for all storage server moves, and explicitly swallow errors for tss ones with
-					// waitForAllReady If this takes too long the transaction will time out and retry, which is ok
+					// waitForAllReady. A long timeout is safe here — no transaction clock is ticking.
 					co_await timeout(waitForAll(serverReady) && waitForAllReady(tssReady),
 					                 SERVER_KNOBS->SERVER_READY_QUORUM_TIMEOUT,
 					                 Void(),
@@ -1593,11 +1724,65 @@ static Future<Void> finishMoveKeys(Database occ,
 					}
 
 					if (count == dest.size()) {
+						// All destination servers are ready. Open a fresh transaction to
+						// re-verify dest hasn't changed during the wait, then commit.
+						tr.trState->taskID = TaskPriority::MoveKeys;
+						tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
+						tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+						ShardStateReads reread = co_await readShardState(&tr,
+						                                                 lock,
+						                                                 ddEnabledState,
+						                                                 currentKeys,
+						                                                 /*dataMoveId=*/{},
+						                                                 SERVER_KNOBS->MOVE_KEYS_KRM_LIMIT,
+						                                                 SERVER_KNOBS->MOVE_KEYS_KRM_LIMIT_BYTES);
+
+						// Re-truncate currentKeys/endKey to the boundary the reread
+						// actually covered. krmGetRanges only emits the synthetic
+						// upper-bound row when its row/byte limit is NOT hit
+						// (see krmDecodeRanges in KeyRangeMap.cpp), so if a
+						// concurrent split or value-size growth pushed the byte
+						// limit forward, reread.keyServers.back().key can be
+						// strictly less than the planning-era currentKeys.end.
+						// The destUnchanged loop below only validates sub-ranges
+						// within reread.keyServers; the krmSetRangeCoalescing
+						// commit would otherwise clear and rewrite an
+						// unverified-and-possibly-foreign tail. Common under
+						// MOVE_KEYS_KRM_LIMIT buggify (2 rows).
+						Key rereadEnd = reread.keyServers.end()[-1].key;
+						// The reread is bounded by `currentKeys` (the upper-bound
+						// passed to readShardState), so a `>` result would mean
+						// readShardState broke its contract — fail loudly rather
+						// than silently expand the commit past the verified end.
+						ASSERT(rereadEnd <= currentKeys.end);
+						if (rereadEnd < currentKeys.end) {
+							CODE_PROBE(true,
+							           "finishMoveKeys reread keyServers boundary shorter than planning",
+							           probe::decoration::rare);
+							currentKeys = KeyRangeRef(currentKeys.begin, rereadEnd);
+							endKey = rereadEnd;
+						}
+
+						// Verify every sub-range still maps to the planned dest (or has
+						// been already-moved-into-empty by a sibling iteration). If
+						// another DD reassigned a sub-range during the wait, retry
+						// rather than clobber its write with our stale plan.
+						if (!destUnchanged(reread.keyServers, reread.uidToTagMap, dest, /*expectedDataMoveId=*/{})) {
+							CODE_PROBE(
+							    true, "finishMoveKeys dest changed during waitForShardReady", probe::decoration::rare);
+							TraceEvent(SevWarn, "FinishMoveKeysDestChanged", relocationIntervalId)
+							    .detail("KeyBegin", keys.begin)
+							    .detail("KeyEnd", keys.end)
+							    .detail("OrigDest", describe(dest));
+							co_await retryAfterPostWaitChange(&retries, &tr);
+							continue;
+						}
+
 						// update keyServers, serverKeys
 						// SOMEDAY: Doing these in parallel is safe because none of them overlap or touch (one per
 						// server)
 						co_await krmSetRangeCoalescing(
-						    &tr, keyServersPrefix, currentKeys, keys, keyServersValue(UIDtoTagMap, dest));
+						    &tr, keyServersPrefix, currentKeys, keys, keyServersValue(reread.uidToTagMap, dest));
 
 						auto asi = allServers.begin();
 						std::vector<Future<Void>> actors;
@@ -2167,8 +2352,11 @@ static Future<Void> finishMoveShards(Database occ,
 	bool cancelDataMove = false;
 	Severity sevDm = static_cast<Severity>(SERVER_KNOBS->PHYSICAL_SHARD_MOVE_LOG_SEVERITY);
 
-	co_await finishMoveKeysParallelismLock->take(TaskPriority::DataDistributionLaunch);
-	FlowLock::Releaser releaser = FlowLock::Releaser(*finishMoveKeysParallelismLock);
+	// Take per-iteration in the loop below (mirroring finishMoveKeys): the lock
+	// must be released before the long waitForShardReady and re-taken on every
+	// retry, so the MOVE_KEYS_PARALLELISM throttle actually bounds concurrency
+	// across attempts rather than only the first one.
+	FlowLock::Releaser releaser;
 	bool runPreCheck = true;
 	bool skipTss = false;
 	double ssReadyTime = std::numeric_limits<double>::max();
@@ -2196,8 +2384,22 @@ static Future<Void> finishMoveShards(Database occ,
 				tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 				tr.setOption(FDBTransactionOptions::LOCK_AWARE);
 
+				releaser.release();
+				co_await finishMoveKeysParallelismLock->take(TaskPriority::DataDistributionLaunch);
+				releaser = FlowLock::Releaser(*finishMoveKeysParallelismLock);
+
 				co_await checkMoveKeysLock(&tr, lock, ddEnabledState);
 
+				// dataMove is read inline (not via readShardState) because:
+				//   1. Its presence/phase drives a possible early-exit write
+				//      (cancelDataMove → set Deleting → commit → throw),
+				//      which can't sit inside the shared read helper.
+				//   2. dataMove.ranges.front() supplies `range`, which the
+				//      readShardState call below needs as input.
+				// The post-cancel safety-relevant reads (serverTags +
+				// keyServers, plus a redundant moveKeysLock check) go through
+				// readShardState so they stay in sync with the post-wait
+				// re-read in txn 2.
 				Optional<Value> val = co_await tr.get(dataMoveKeyFor(dataMoveId));
 				if (val.present()) {
 					dataMove = decodeDataMoveValue(val.get());
@@ -2233,14 +2435,15 @@ static Future<Void> finishMoveShards(Database occ,
 					co_return;
 				}
 
-				RangeResult UIDtoTagMap = co_await tr.getRange(serverTagKeys, CLIENT_KNOBS->TOO_MANY);
-				ASSERT(!UIDtoTagMap.more && UIDtoTagMap.size() < CLIENT_KNOBS->TOO_MANY);
-
-				RangeResult keyServers = co_await krmGetRanges(&tr,
-				                                               keyServersPrefix,
-				                                               range,
-				                                               SERVER_KNOBS->MOVE_SHARD_KRM_ROW_LIMIT,
-				                                               SERVER_KNOBS->MOVE_SHARD_KRM_BYTE_LIMIT);
+				ShardStateReads state = co_await readShardState(&tr,
+				                                                lock,
+				                                                ddEnabledState,
+				                                                range,
+				                                                /*dataMoveId=*/{},
+				                                                SERVER_KNOBS->MOVE_SHARD_KRM_ROW_LIMIT,
+				                                                SERVER_KNOBS->MOVE_SHARD_KRM_BYTE_LIMIT);
+				RangeResult& UIDtoTagMap = state.uidToTagMap;
+				RangeResult& keyServers = state.keyServers;
 				ASSERT(!keyServers.empty());
 				range = KeyRangeRef(range.begin, keyServers.back().key);
 				ASSERT(!range.empty());
@@ -2335,11 +2538,17 @@ static Future<Void> finishMoveShards(Database occ,
 
 				// update client info in case tss mapping changed or server got updated
 
+				// Save the read version before dropping the transaction (mirrors the
+				// pattern in finishMoveKeys above): waitForShardReady needs a minimum
+				// version the dest must reach; servers will already be past it by the
+				// time we re-verify in the second transaction below.
+				Version readVersion = tr.getReadVersion().get();
+
 				// Wait for new destination servers to fetch the data range.
 				serverReady.reserve(storageServerInterfaces.size());
 				for (int s = 0; s < storageServerInterfaces.size(); s++) {
 					serverReady.push_back(waitForShardReady(
-					    storageServerInterfaces[s], range, tr.getReadVersion().get(), GetShardStateRequest::READABLE));
+					    storageServerInterfaces[s], range, readVersion, GetShardStateRequest::READABLE));
 
 					if (skipTss)
 						continue;
@@ -2348,8 +2557,8 @@ static Future<Void> finishMoveShards(Database occ,
 
 					if (tssPair != tssMapping.end()) {
 						tssReadyInterfs.push_back(tssPair->second);
-						tssReady.push_back(waitForShardReady(
-						    tssPair->second, range, tr.getReadVersion().get(), GetShardStateRequest::READABLE));
+						tssReady.push_back(
+						    waitForShardReady(tssPair->second, range, readVersion, GetShardStateRequest::READABLE));
 					}
 				}
 
@@ -2358,8 +2567,15 @@ static Future<Void> finishMoveShards(Database occ,
 				    .detail("NewDestinations", describe(newDestinations))
 				    .detail("DataMove", dataMove.toString());
 
-				// Wait for all storage server moves, and explicitly swallow errors for tss ones with
-				// waitForAllReady If this takes too long the transaction will time out and retry, which is ok
+				// Drop the transaction BEFORE the potentially long wait. The 15 s
+				// SERVER_READY_QUORUM_TIMEOUT exceeds the ~5 s txn lifetime; waiting
+				// inside the transaction guarantees transaction_too_old on commit
+				// when destination servers are slow to respond. Same pattern as in
+				// finishMoveKeys above.
+				tr.reset();
+
+				// Wait OUTSIDE any transaction. A long timeout is safe — no
+				// transaction clock is ticking.
 				co_await timeout(waitForAll(serverReady) && waitForAllReady(tssReady),
 				                 SERVER_KNOBS->SERVER_READY_QUORUM_TIMEOUT,
 				                 Void(),
@@ -2402,6 +2618,84 @@ static Future<Void> finishMoveShards(Database occ,
 
 				if (readyServers.size() == newDestinations.size()) {
 
+					// All destination servers are ready. Open a fresh transaction to
+					// re-verify dataMove and shard assignments haven't changed during
+					// the wait, then commit.
+					tr.trState->taskID = TaskPriority::MoveKeys;
+					tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
+					tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+					tr.setOption(FDBTransactionOptions::LOCK_AWARE);
+					ShardStateReads reread = co_await readShardState(&tr,
+					                                                 lock,
+					                                                 ddEnabledState,
+					                                                 range,
+					                                                 dataMoveId,
+					                                                 SERVER_KNOBS->MOVE_SHARD_KRM_ROW_LIMIT,
+					                                                 SERVER_KNOBS->MOVE_SHARD_KRM_BYTE_LIMIT);
+
+					if (!reread.dataMove.present()) {
+						CODE_PROBE(true,
+						           "finishMoveShards data move deleted during waitForShardReady",
+						           probe::decoration::rare);
+						TraceEvent(SevWarn, "FinishMoveShardsDataMoveDeletedAfterWait", relocationIntervalId)
+						    .detail("DataMoveID", dataMoveId);
+						runPreCheck = false;
+						co_await retryAfterPostWaitChange(&retries, &tr);
+						continue;
+					}
+					if (reread.dataMove.get().getPhase() != DataMoveMetaData::Running) {
+						CODE_PROBE(true,
+						           "finishMoveShards data move phase changed during waitForShardReady",
+						           probe::decoration::rare);
+						TraceEvent(SevWarn, "FinishMoveShardsPhaseChangedAfterWait", relocationIntervalId)
+						    .detail("DataMoveID", dataMoveId)
+						    .detail("Phase", static_cast<int>(reread.dataMove.get().getPhase()));
+						runPreCheck = false;
+						co_await retryAfterPostWaitChange(&retries, &tr);
+						continue;
+					}
+					ASSERT(!reread.keyServers.empty());
+
+					// Re-truncate `range` to the boundary the reread actually
+					// covered. krmGetRanges only emits the synthetic upper-bound
+					// row when its row/byte limit is NOT hit (see krmDecodeRanges
+					// in KeyRangeMap.cpp), so if a concurrent split or value-size
+					// growth pushed the byte limit forward,
+					// reread.keyServers.back().key can be strictly less than the
+					// planning-era range.end. The destUnchanged loop only
+					// validates sub-ranges within reread.keyServers; the
+					// krmSetRangeCoalescing commits below would otherwise clear
+					// and rewrite an unverified-and-possibly-foreign tail.
+					Key rereadEnd = reread.keyServers.back().key;
+					// The reread is bounded by `range`, so a `>` result would
+					// mean readShardState broke its contract — fail loudly
+					// rather than silently expand the commit past the verified
+					// end.
+					ASSERT(rereadEnd <= range.end);
+					if (rereadEnd < range.end) {
+						CODE_PROBE(true,
+						           "finishMoveShards reread keyServers boundary shorter than planning",
+						           probe::decoration::rare);
+						range = KeyRangeRef(range.begin, rereadEnd);
+					}
+
+					if (!destUnchanged(reread.keyServers, reread.uidToTagMap, destServers, dataMoveId)) {
+						CODE_PROBE(
+						    true, "finishMoveShards dest changed during waitForShardReady", probe::decoration::rare);
+						TraceEvent(SevWarn, "FinishMoveShardsDestChanged", relocationIntervalId)
+						    .detail("DataMoveID", dataMoveId)
+						    .detail("Range", range);
+						runPreCheck = false;
+						co_await retryAfterPostWaitChange(&retries, &tr);
+						continue;
+					}
+
+					// Use the freshly-read dataMove snapshot for partial-complete /
+					// checkpoint-deletion / dataMoveValue writes below; the
+					// function-level `dataMove` retains the pre-wait snapshot used
+					// only by the post-loop trace at the end of the function.
+					DataMoveMetaData postWaitDataMove = reread.dataMove.get();
+
 					std::vector<Future<Void>> actors;
 					actors.push_back(krmSetRangeCoalescing(
 					    &tr, keyServersPrefix, range, allKeys, keyServersValue(destServers, {}, dataMoveId, UID())));
@@ -2419,12 +2713,12 @@ static Future<Void> finishMoveShards(Database occ,
 						    .detail("StorageServerID", ssId)
 						    .detail("KeyRange", range)
 						    .detail("ShardID", destHasServer ? dataMoveId : UID())
-						    .detail("DataMove", dataMove.toString());
+						    .detail("DataMove", postWaitDataMove.toString());
 					}
 
 					co_await waitForAll(actors);
 
-					if (range.end == dataMove.ranges.front().end) {
+					if (range.end == postWaitDataMove.ranges.front().end) {
 						if (bulkLoadTaskState.present()) {
 							BulkLoadTaskState newBulkLoadTaskState;
 							try {
@@ -2453,27 +2747,27 @@ static Future<Void> finishMoveShards(Database occ,
 							    .detail("DataMoveID", dataMoveId)
 							    .detail("JobID", newBulkLoadTaskState.getJobId())
 							    .detail("TaskID", newBulkLoadTaskState.getTaskId());
-							dataMove.bulkLoadTaskState = newBulkLoadTaskState;
+							postWaitDataMove.bulkLoadTaskState = newBulkLoadTaskState;
 						}
-						co_await deleteCheckpoints(&tr, dataMove.checkpoints, dataMoveId);
+						co_await deleteCheckpoints(&tr, postWaitDataMove.checkpoints, dataMoveId);
 						tr.clear(dataMoveKeyFor(dataMoveId));
 						TraceEvent(sevDm, "FinishMoveShardsDeleteMetaData", relocationIntervalId)
-						    .detail("DataMove", dataMove.toString());
+						    .detail("DataMove", postWaitDataMove.toString());
 					} else if (!bulkLoadTaskState.present()) {
 						// Bulk Loading data move does not allow partial complete
 						TraceEvent(SevInfo, "FinishMoveShardsPartialComplete", relocationIntervalId)
 						    .detail("DataMoveID", dataMoveId)
 						    .detail("CurrentRange", range)
-						    .detail("NewDataMoveMetaData", dataMove.toString())
-						    .detail("DataMove", dataMove.toString());
-						dataMove.ranges.front() = KeyRangeRef(range.end, dataMove.ranges.front().end);
-						tr.set(dataMoveKeyFor(dataMoveId), dataMoveValue(dataMove));
+						    .detail("NewDataMoveMetaData", postWaitDataMove.toString())
+						    .detail("DataMove", postWaitDataMove.toString());
+						postWaitDataMove.ranges.front() = KeyRangeRef(range.end, postWaitDataMove.ranges.front().end);
+						tr.set(dataMoveKeyFor(dataMoveId), dataMoveValue(postWaitDataMove));
 					}
 
 					co_await tr.commit();
 					counters->committed->increment(1);
 
-					if (range.end == dataMove.ranges.front().end && bulkLoadTaskState.present()) {
+					if (range.end == postWaitDataMove.ranges.front().end && bulkLoadTaskState.present()) {
 						Version commitVersion = tr.getCommittedVersion();
 						TraceEvent(
 						    bulkLoadVerboseEventSev(), "DDBulkLoadTaskPersistCompleteState", relocationIntervalId)
@@ -2484,16 +2778,42 @@ static Future<Void> finishMoveShards(Database occ,
 						    .detail("CommitVersion", commitVersion);
 					}
 
-					if (range.end == dataMove.ranges.front().end) {
+					if (range.end == postWaitDataMove.ranges.front().end) {
 						// Post validate consistency of update of keyServers and serverKeys
 						if (SERVER_KNOBS->AUDIT_DATAMOVE_POST_CHECK) {
-							co_await auditLocationMetadataPostCheck(
-							    occ, dataMove.ranges.front(), "finishMoveShards_postcheck", relocationIntervalId);
+							co_await auditLocationMetadataPostCheck(occ,
+							                                        postWaitDataMove.ranges.front(),
+							                                        "finishMoveShards_postcheck",
+							                                        relocationIntervalId);
 						}
 						break;
 					}
 					continue;
 				} else {
+					// Slow-but-not-stuck dest readiness: do NOT cap with a hard
+					// throw here. The waitForShardReady timeout (15s) bounds
+					// each attempt's wait, and DD's logWarningAfter watchdog
+					// already surfaces the situation if it persists. Bounding
+					// the retry count converts patient progress (e.g. a dest
+					// SS recovering after chaos in tests like ConfigureLocked)
+					// into a DD-stuck loop: each attempt throws after ~50s
+					// of cumulative backoff and DD immediately re-queues the
+					// same move, repeating until QuietDatabase times out.
+					// The three post-wait branches (DestChanged /
+					// DataMoveDeletedAfterWait / PhaseChangedAfterWait)
+					// still use retryAfterPostWaitChange because they detect
+					// real concurrent reassignments, not slowness.
+					++retries;
+					if (retries % 10 == 0) {
+						TraceEvent(SevWarnAlways, "RelocateShard_FinishMoveShardsDestNotReady", relocationIntervalId)
+						    .detail("DataMoveID", dataMoveId)
+						    .detail("Range", range)
+						    .detail("Retries", retries)
+						    .detail("ReadyCount", readyServers.size())
+						    .detail("DestCount", newDestinations.size());
+					}
+					runPreCheck = false;
+					co_await delay(finishMoveKeysBackoff(retries));
 					tr.reset();
 					continue;
 				}

--- a/fdbserver/core/MoveKeys.cpp
+++ b/fdbserver/core/MoveKeys.cpp
@@ -57,11 +57,7 @@ double finishMoveKeysBackoff(int retries) {
 // Shared retry tail used by the finishMove* post-wait branches that detect a
 // concurrent change (dest reassigned, data move deleted, phase changed):
 // bumps `retries`, throws finish_move_keys_too_many_retries once the cap is
-// exceeded, otherwise sleeps the backoff and resets the transaction.
-// The caller still issues `continue;` after awaiting this — keeping the loop-
-// control statement at the call site preserves readability of the retry path.
-// Count-mismatch sites stay inline because they emit a custom giveup
-// TraceEvent with ready/dest-count details that don't fit a generic helper.
+// exceeded, resets the transaction.
 static Future<Void> retryAfterPostWaitChange(int* retries, Transaction* tr) {
 	if (++(*retries) > SERVER_KNOBS->FINISH_MOVE_KEYS_MAX_RETRIES) {
 		throw finish_move_keys_too_many_retries();
@@ -1371,25 +1367,9 @@ static Future<ShardStateReads> readShardState(Transaction* tr,
 }
 
 // Post-wait verification used by both finishMoveKeys and finishMoveShards.
+// Sorts `expectedDest`.
 //
 // Returns true if every sub-range in `keyServers` still maps to `expectedDest`.
-//
-// When `expectedDataMoveId.present()` (shards path), every sub-range must also
-// have destId == expectedDataMoveId — the shards path stamps every assigned
-// sub-range with its dataMoveId, so any mismatch (including an empty-dest
-// entry, which decodes to UID()) signals a concurrent reassignment.
-//
-// When `expectedDataMoveId` is absent (keys path), empty-dest entries are
-// tolerated wherever src ⊆ expectedDest. That matches the planning loop's
-// `alreadyMoved = dest2.empty() && isSubset` branch (see the second planning
-// loop in finishMoveKeys, around the "first key in iteration sub-range has
-// already been processed" CODE_PROBE): a sibling iteration of OUR move
-// already completed this sub-range, src is what was left after team-shrink,
-// and the upcoming krmSetRangeCoalescing write will collapse it into the
-// rest. The subset check rules out a foreign completed move whose src is
-// a different team — clobbering it would overwrite the foreign owner.
-//
-// Sorts `expectedDest` internally so callers don't have to.
 static bool destUnchanged(const RangeResult& keyServers,
                           const RangeResult& uidToTagMap,
                           std::vector<UID> expectedDest,
@@ -1400,10 +1380,21 @@ static bool destUnchanged(const RangeResult& keyServers,
 		UID checkSrcId, checkDestId;
 		decodeKeyServersValue(uidToTagMap, keyServers[i].value, checkSrc, checkDest, checkSrcId, checkDestId);
 		if (expectedDataMoveId.present()) {
+      // Have checkDestId == expectedDataMoveId — the shards path stamps every assigned
+      // sub-range with its dataMoveId, so any mismatch (including an empty-dest
+      // entry, which decodes to UID()) signals a concurrent reassignment.
 			if (checkDestId != expectedDataMoveId.get()) {
 				return false;
 			}
 		} else if (checkDest.empty()) {
+      // Empty-dest entries are tolerated wherever src ⊆ expectedDest. That matches the planning loop's
+      // `alreadyMoved = dest2.empty() && isSubset` branch (see the second planning
+      // loop in finishMoveKeys, around the "first key in iteration sub-range has
+      // already been processed" CODE_PROBE): a sibling iteration of OUR move
+      // already completed this sub-range, src is what was left after team-shrink,
+      // and the upcoming krmSetRangeCoalescing write will collapse it into the
+      // rest. The subset check rules out a foreign completed move whose src is
+      // a different team — clobbering it would overwrite the foreign owner.
 			std::sort(checkSrc.begin(), checkSrc.end());
 			if (!std::includes(expectedDest.begin(), expectedDest.end(), checkSrc.begin(), checkSrc.end())) {
 				return false;
@@ -1748,7 +1739,8 @@ static Future<Void> finishMoveKeys(Database occ,
 						// within reread.keyServers; the krmSetRangeCoalescing
 						// commit would otherwise clear and rewrite an
 						// unverified-and-possibly-foreign tail. Common under
-						// MOVE_KEYS_KRM_LIMIT buggify (2 rows).
+						// MOVE_KEYS_KRM_LIMIT buggify (2 rows -- which happens often
+            // in simulation).
 						Key rereadEnd = reread.keyServers.end()[-1].key;
 						// The reread is bounded by `currentKeys` (the upper-bound
 						// passed to readShardState), so a `>` result would mean

--- a/fdbserver/core/ServerKnobs.cpp
+++ b/fdbserver/core/ServerKnobs.cpp
@@ -1001,7 +1001,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( CC_RERECRUIT_LOG_ROUTER_ENABLED,                      true ); if ( randomize && buggify() ) CC_RERECRUIT_LOG_ROUTER_ENABLED = deterministicRandom()->coinflip();
 
 	//Move Keys
-	init( SHARD_READY_DELAY,                                    0.25 );
+	init( SHARD_READY_DELAY,                                    0.25 ); if( randomize && buggify() ) SHARD_READY_DELAY = 5.0;
 	init( SERVER_READY_QUORUM_INTERVAL,                         std::min(1.0, std::min(MAX_READ_TRANSACTION_LIFE_VERSIONS, MAX_WRITE_TRANSACTION_LIFE_VERSIONS)/(5.0*VERSIONS_PER_SECOND)) );
 	init( SERVER_READY_QUORUM_TIMEOUT,                          15.0 ); if( randomize && buggify() ) SERVER_READY_QUORUM_TIMEOUT = 1.0;
 	init( REMOVE_RETRY_DELAY,                                    1.0 );

--- a/fdbserver/core/ServerKnobs.cpp
+++ b/fdbserver/core/ServerKnobs.cpp
@@ -318,7 +318,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 
 	init( ALLOW_LARGE_SHARD,                                   false ); if( randomize && buggify() )  ALLOW_LARGE_SHARD = true;
 	init( MAX_LARGE_SHARD_BYTES,                          1000000000 ); // 1G
-	init( SHARD_ENCODE_LOCATION_METADATA,                      false ); if( isSimulated ) { bool v = deterministicRandom()->random01() < 0.75; if( !explicitlySetKnobs.count("shard_encode_location_metadata") ) SHARD_ENCODE_LOCATION_METADATA = v; }
+	init( SHARD_ENCODE_LOCATION_METADATA,                      false ); if( isSimulated ) { bool v = deterministicRandom()->random01() < 0.75; if( !explicitlySetKnobs.contains("shard_encode_location_metadata") ) SHARD_ENCODE_LOCATION_METADATA = v; }
 	init( ENABLE_DD_PHYSICAL_SHARD,                            false ); // EXPERIMENTAL; If true, SHARD_ENCODE_LOCATION_METADATA must be true; When true, optimization of data move between DCs is disabled
 	init( DD_PHYSICAL_SHARD_MOVE_PROBABILITY,                    0.0 ); // FIXME: re-enable after ShardedRocksDB is well tested by simulation
 	init( ENABLE_PHYSICAL_SHARD_MOVE_EXPERIMENT,               false ); // FIXME: re-enable after ShardedRocksDB is well tested by simulation


### PR DESCRIPTION
(Forward port of #12981 -- though it needs update to match this version)

SERVER_READY_QUORUM_TIMEOUT (15s) was used inside a transaction that must commit within ~5s (MAX_WRITE_TRANSACTION_LIFE_VERSIONS). When destination servers are slow to respond, the wait alone consumes the txn budget — and the surrounding transaction has additional reads (\xff/serverTags, \xff/keyServers, \xff/dataMoves with the SHARD_ENCODE_LOCATION_METADATA knob ON, serverList per dest) as well as writes. Result: commits start to fail with transaction_too_old as do the retries.

We saw this issue in recent incidents:
- cluster1: SHARD_ENCODE_LOCATION_METADATA=true compounded into a isRestore replay loop after DD died.
- cluster2: same trigger, knob OFF, OOMed but recovered.

DD has TWO finish-move functions, dispatched on the metadata knob in rawFinishMovement: finishMoveKeys (knob OFF) and finishMoveShards (knob ON). cluster1 had the knob ON, so its code path was finishMoveShards. This patch applies the same fix to BOTH.

For each function: split the single transaction into two, with the wait in between:

```
  Transaction 1: read keyServers/serverTags/serverList (and dataMoves
                 metadata for finishMoveShards)
  Save the read version, drop the transaction (tr.reset())
  Wait:          waitForShardReady — runs OUTSIDE any transaction;
                 the 15s timeout is now safe
  Transaction 2: re-verify state hasn't changed (dest still ours,
                 dataMove still in Running phase for finishMoveShards),
                 then commit metadata writes
```

If the destination changed during the wait (another DD reassigned the shard), the inner loop retries from the top — same as today's behaviour on transient errors, just without burning the txn budget on the wait itself.

## Notes

### What finishMoveKeys / finishMoveShards actually does

A single transaction does ~10–14 async round-trips to FDB:

```
Read \xff/dataMoves/<id> — fetch metadata (knob ON only)
Read \xff/serverTags/
Read \xff/keyServers/ range via krmGetRanges
Decode src/dest, validate
waitForShardReady for each destination server
Write updated \xff/keyServers/ via krmSetRangeCoalescing
Write updated \xff/serverKeys/ (~6 servers per move)
Delete checkpoints
Clear \xff/dataMoves/<id> (knob ON only)
Commit
```

On a healthy cluster the whole transaction averages ~1.8 seconds — already 36 % of the 5 s budget, with waitForShardReady returning in milliseconds when the dest is already ready. With the metadata knob ON, steps 1 and 9 add two extra round-trips that further reduce headroom.

waitForShardReady (step 5) polls each dest SS via getShardState at intervals of SHARD_READY_DELAY (default 0.25 s) until a quorum reports ready, with an outer cap of SERVER_READY_QUORUM_TIMEOUT=15 s. The 15 s cap is rarely the trigger in practice — transaction_too_old fires at ~5 s for the whole txn first.

### What happed on cluster1

dest SSes were CPU-saturated from concurrent fetchKeys operations on large shards (100–500 MB). At 80 % CPU the SS event loop couldn't process any RPC promptly. The entire finishMoveShards transaction slowed down, not just step 5: reads (steps 1–3) hit slow SSes, waitForShardReady (step 5) saw more "not ready" responses, writes (steps 6–7) hit the same storage layer. The 1.8 s baseline became 5+ seconds, transaction_too_old fired, retries hit the same wall, and the storm was self-sustaining.

The dest-overload was the trigger; the multi-step transaction with waitForShardReady embedded inside it was the latent bug. With the metadata knob ON, steps 1 and 9 also actively contributed by inflating the critical-path transaction — beyond the well-known restart-fatal-via-isRestore-replay issue.

### What the simulation and the k8s emulation do

We reproduced the 'cascade' of unfinished moves phenomenon in a k8s test rig and in simulation. 
https://github.com/saintstack/foundationdb/tree/dd-pipeline-stall-test is a simulation test that manufactures a cluster1 like situation.  https://github.com/saintstack/fdb-kubernetes-tests/tree/backup_recreate is a k8s test that does a similar reproduction.

Two failure modes emerge from the same recipe:

```
Mode | Trigger | Distinctive error pattern
cluster1 cascade | mako + exclude | 96–99% transaction_too_old
Rebalance overload | mako only | 70% not_committed, 16% transaction_too_old
```

Both converge on the same death: DD OOMs from accumulated actor state, restarts, isRestore replays accumulated \xff/dataMoves/, DD OOMs again.

The convergence-check trace events (FinishMoveShardsDestChanged, *DataMoveDeletedAfterWait, *PhaseChangedAfterWait) fire 0 times in our runs — the safety check is conservative without false-positive retries.


### How we triggered the cascade across rigs

```
Trigger	What slows waitForShardReady
cluster1	Dest SS event loop CPU-saturated → all reads/RPCs slow; getShardState returns not-ready across polls
K8s rig	SHARD_READY_DELAY raised from 0.25 s to 2.5 s → 2 not-ready polls = 5 s
Simulation	buggify_get_shard_state_delay = 2 (concurrency limit) simulates SS event loop saturation
```

All three paths end at the same transaction_too_old. The k8s run with the extended fix exercised the actual production code path (finishMoveShards, knob ON) and showed the cascade trigger eliminated.

### Tests

Here are the k8s test runs synopsized:

```
PR	Mako-only k8s run	Mako+exclude k8s run
PR #12981	—	✅ test-5jmt4wg6: 3 tx_too_old (vs 360,289 in the previous run without the patch), 0 Phase-4 OOMs, 0 cap engagements in Phase 4 ('cap' refers to PR #13112)
PR #13112 alone	Run 34: ✅ 1 restart in 4 h, self-recovered	Run 35: ✅ 2.3 TB drained, 274 cap engagements
```


Running #12981 in Simulation (DDPipelineStall.toml, knob ON): cascade trigger eliminated on the code path; transaction_too_old goes to zero, residual TryFinishMoveShardsError events are not_committed which retry cleanly.

### Why this matters

The latent bug has existed for years. A reasonable concern is whether it's worth the added complexity. Two points of evidence:

Two incidents. Both had this exact trigger. cluster1 plus the metadata knob compounded into a fatal isRestore replay loop on every DD restart.

Admission control complements but doesn't substitute. PR #13112 (cap) and PR #12981 (root cause) work on different parts of the failure chain. Whether the cap alone is sufficient depends on how persistent the trigger is. Intermittent trigger (production team-rebuild bursts → some slow polls → eventual recovery): cap can ride out the burst (Run 35 alone drained 2.3 TB). Sustained trigger (every poll slow because dests stay saturated): simulation shows the cap bounds memory but the queue doesn't drain. Deploying both gives PR #12981 removing the structural anti-pattern and PR #13112 as defense-in-depth.

Why not a simpler fix? Setting SERVER_READY_QUORUM_TIMEOUT below 5 s is two characters in a knob file, but that's not what fires in production. The budget is blown by accumulated 0.25 s polls × N + RPC time well before the 15 s outer timeout, so trimming it changes very little. To cover the real failure mode that way you'd also have to shrink SHARD_READY_DELAY, raising the rate of move failures under transient slowness. The two-transaction restructure costs more lines but eliminates the structural problem regardless of any knob value.