### PR TITLE
Document how DD targets disk-byte-capacity balancing

### DIFF
--- a/design/AI-generated/subsystem_08_data_distribution.md
+++ b/design/AI-generated/subsystem_08_data_distribution.md
@@ -158,6 +158,38 @@ Ordering: `(priority desc) → (startTime asc) → (randomId desc)`
 
 ---
 
+## Disk-Capacity Balancing (byte targeting)
+
+DD's disk-rebalancing goal is to equalize the **absolute amount of stored data (used
+logical bytes) per team** -- not equal free bytes, not equal free *percentage*, and not
+capacity-proportional fill. Teams are ranked by `TCTeamInfo::getLoadBytes()`, whose core
+term is the mean of each server's `StorageMetrics.load.bytes` (a sampled estimate of
+bytes stored), with no normalization by disk size. A rebalance move fires only when
+`source.getLoadBytes() - dest.getLoadBytes() > 3 * max(MIN_SHARD_BYTES, shardBytes)`.
+
+Free space enters only as two guardrails on top of that absolute-bytes objective:
+
+1. **Eligibility pivot (dominant).** `updateAvailableSpacePivots()` / `updateTeamEligibility()`
+   compute the cluster-median free-space *ratio* (`available/capacity`), clamped to
+   `[MIN_AVAILABLE_SPACE_RATIO 0.05, TARGET_AVAILABLE_SPACE_RATIO 0.30]`. For destination
+   selection (`PreferLowerDiskUtil`), `getBestTeam` skips any team whose free ratio is below
+   that pivot (and whose free bytes are below `MIN_AVAILABLE_SPACE` = 100 MB). So a
+   relatively-full server stops receiving data once its free *ratio* falls below the
+   cluster median -- no later than the 30%-free mark in a healthy cluster.
+2. **Near-full penalty.** `getLoadBytes()` multiplies by `AVAILABLE_SPACE_RATIO_CUTOFF /
+   max(min(cutoff, freeRatio), eps)` with cutoff `0.05`; this is `1.0` (no effect) above
+   5% free and rises steeply (squared for triple replication) below it.
+
+**Heterogeneous hardware:** because the objective is equal stored bytes, a small and a
+large disk tend toward holding the *same amount of data* until the pivot gate makes the
+smaller (relatively fuller) disk ineligible, at which point new data is steered to the
+emptier/larger disks. DD never targets capacity proportionally (an explicit
+`SOMEDAY: Account for capacity` TODO remains). See
+[`data-distributor-internals.md`](../data-distributor-internals.md) §8, "What disk-capacity
+balancing actually targets," for the full treatment.
+
+---
+
 ## MoveKeys Protocol -- [`fdbserver/core/MoveKeys.cpp`](https://github.com/apple/foundationdb/blob/main/fdbserver/core/MoveKeys.cpp)
 
 Atomic shard ownership transfer using system key transactions.

--- a/design/data-distributor-internals.md
+++ b/design/data-distributor-internals.md
@@ -568,6 +568,107 @@ Source: [`BgDDLoadRebalance`](https://github.com/apple/foundationdb/blob/release
 [`isDataMovementForMountainChopper`](https://github.com/apple/foundationdb/blob/release-7.3/fdbserver/DDRelocationQueue.actor.cpp#L58),
 [`isDataMovementForValleyFiller`](https://github.com/apple/foundationdb/blob/release-7.3/fdbserver/DDRelocationQueue.actor.cpp#L69).
 
+### What disk-capacity balancing actually targets
+
+A common question is whether DD aims to give every storage server an equal amount
+of free space, an equal *percentage* of free space, or something else. The answer is
+**neither directly**: DD's steady-state objective is to equalize the *absolute amount
+of stored data (used logical bytes) per team*, with a separate free-space-*ratio*
+control layered on top that only diverts data away from servers that are relatively
+full. There is no capacity-proportional placement — DD reads each server's real disk
+capacity but does not weight placement by it (the code carries an explicit
+`SOMEDAY: Account for capacity` note in `DDTeamCollection`).
+
+This matters most on **heterogeneous hardware** (storage servers with different
+underlying disk sizes), where "equal used bytes," "equal free bytes," and "equal free
+percentage" are three different outcomes. On a homogeneous fleet they coincide, which
+is why the distinction is usually invisible.
+
+#### The ranking metric: equal stored bytes
+
+Both team selection (`getBestTeam` in `DDTeamCollection`) and the rebalancer rank
+teams by `TCTeamInfo::getLoadBytes()`:
+
+```
+getLoadBytes() ≈ getLoadAverage() * availableSpaceMultiplier
+```
+
+- `getLoadAverage()` is the mean over the team's servers of `TCServerInfo::loadBytes()`,
+  which is the storage server's `StorageMetrics.load.bytes` -- a *sampled estimate of
+  the logical key-value bytes stored on that server*. It is the amount of data held,
+  **not** free space, write bandwidth, or a percentage. There is no normalization by
+  disk capacity. (If a team member's metrics are missing, the sum is conservatively
+  doubled.)
+- A disk-rebalance move (MountainChopper / ValleyFiller) only fires when the source is
+  meaningfully more loaded than the destination, in absolute bytes:
+  `sourceTeam.getLoadBytes() - destTeam.getLoadBytes() > 3 * max(MIN_SHARD_BYTES, shardBytes)`.
+- `PreferLowerDiskUtil` simply means "prefer the team with the lower `getLoadBytes()`."
+
+So, all else equal, DD drives every team toward the **same absolute number of stored
+bytes**. On heterogeneous disks this means a small-capacity and a large-capacity server
+tend toward holding the *same amount of data*, leaving the larger disk's extra capacity
+unused -- until the free-space controls below intervene.
+
+#### Free-space control #1 (dominant): the eligibility pivot
+
+Free space enters first as a hard *eligibility gate*, computed from the real
+filesystem free fraction (`available.bytes / capacity.bytes`, taken as the minimum
+across a team's servers):
+
+- `updateAvailableSpacePivots()` sets `pivotAvailableSpaceRatio` to the free-space ratio
+  at the `AVAILABLE_SPACE_PIVOT_RATIO` (= 0.5, i.e. the median) position among healthy
+  teams, then clamps it to `[MIN_AVAILABLE_SPACE_RATIO (0.05), TARGET_AVAILABLE_SPACE_RATIO (0.30)]`.
+- `updateTeamEligibility()` marks a team as a valid low-disk-util destination only if
+  `hasHealthyAvailableSpace(pivotAvailableSpaceRatio)` holds -- i.e. its free ratio is at
+  or above the cluster pivot, its absolute free space exceeds `MIN_AVAILABLE_SPACE`
+  (100 MB), and every member passes the per-server check (with a `+0.01` safety buffer).
+- For any request with `PreferLowerDiskUtil` set (all disk-rebalance destination picks and
+  new-shard placement), `getBestTeam` skips teams that are not eligible.
+
+The effect: a relatively *fuller* server is removed from the destination pool once its
+free **ratio** drops below the cluster median -- and, because the pivot is clamped to at
+most `TARGET_AVAILABLE_SPACE_RATIO`, this happens no later than the 30%-free mark in a
+healthy cluster (and no earlier than 5%). At that margin the behavior flips from
+"equalize absolute bytes" toward "equalize free *ratio* (up to the pivot)," steering new
+data to emptier -- often larger-capacity -- disks.
+
+#### Free-space control #2 (near-full safety): the penalty multiplier
+
+`getLoadBytes()` also multiplies the stored-bytes figure by:
+
+```
+availableSpaceMultiplier = AVAILABLE_SPACE_RATIO_CUTOFF
+                           / max(min(AVAILABLE_SPACE_RATIO_CUTOFF, freeRatio), epsilon)
+```
+
+With `AVAILABLE_SPACE_RATIO_CUTOFF = 0.05`, this multiplier is exactly `1.0` (no effect)
+for any server with at least 5% free, and rises steeply only below 5% (and is *squared*
+for teams with more than two members, i.e. triple replication). It is a last-resort
+penalty that makes an almost-full team look heavily loaded so DD stops targeting it; it
+is not the primary balancing lever.
+
+#### Summary for heterogeneous hardware
+
+- DD targets **equal absolute stored bytes per team**, not equal free bytes and not equal
+  free percentage; it does **not** fill disks in proportion to their capacity.
+- A free-space-*ratio* eligibility gate (cluster-median free fraction, clamped to
+  `[5%, 30%]` free) prevents relatively-full servers from receiving more data, which on
+  mixed-capacity fleets pushes smaller disks toward the pivot free-ratio and then diverts
+  further writes to emptier/larger disks.
+- A near-full penalty multiplier (below 5% free) provides a final safety margin.
+- Net practical outcome on mixed-capacity hardware: larger disks end up holding more
+  absolute data, but only because the smaller disks become *ineligible* at the pivot --
+  not because DD proportionally targets capacity. The smallest disks effectively bound how
+  much of the larger disks' capacity gets used before the ratio controls engage.
+
+Knobs: `AVAILABLE_SPACE_PIVOT_RATIO` (0.5), `MIN_AVAILABLE_SPACE_RATIO` (0.05),
+`MIN_AVAILABLE_SPACE_RATIO_SAFETY_BUFFER` (0.01), `TARGET_AVAILABLE_SPACE_RATIO` (0.30),
+`AVAILABLE_SPACE_RATIO_CUTOFF` (0.05), `MIN_AVAILABLE_SPACE` (100 MB). Sources:
+`TCTeamInfo::getLoadBytes` / `getLoadAverage` / `getMinAvailableSpaceRatio` /
+`hasHealthyAvailableSpace` in `datadistributor/TCInfo.cpp`; `updateAvailableSpacePivots` /
+`updateTeamEligibility` / `getBestTeam` in `datadistributor/DDTeamCollection.actor.cpp`;
+the rebalance threshold in `datadistributor/DDRelocationQueue.actor.cpp`.
+
 
 ## 9. Team Building
 


### PR DESCRIPTION
Clarify that DD's disk-rebalancing objective is to equalize the absolute amount of stored data (used logical bytes) per team -- not equal free bytes, not equal free percentage, and not capacity-proportional fill. Document the two free-space-ratio guardrails layered on top: the eligibility pivot (cluster-median free fraction, clamped to [5%, 30%]) and the near-full penalty multiplier (<5% free), and spell out the resulting behavior on heterogeneous-capacity hardware.

Adds a "What disk-capacity balancing actually targets" subsection to data-distributor-internals.md and a concise cross-referenced section to the AI-generated data-distribution subsystem doc.

**Caveat:** An earlier version of this had an apparent omission that was caught only by a specifically requested antagonistic side agent.  On this basis we can only register a concern that there may be other gaps.  However I feel this is better than nothing.