### PR TITLE
BulkDumping: raise jobSubmitTimeout to 600s for fast/BulkDumping.toml

### DIFF
--- a/tests/fast/BulkDumping.toml
+++ b/tests/fast/BulkDumping.toml
@@ -40,3 +40,9 @@ waitForQuiescence = false
     testName = 'BulkDumpingWorkload'
     # 1 is BulkLoadTransportMethod::CP
     bulkLoadTransportMethod = 1
+    # The default 60s is too short under this test's fault injection: a CommitProxy failure
+    # plus a rebooting process in a (possibly 2-region) cluster can leave the database
+    # unavailable for >60s while recovery hits no_more_servers, so the submitBulkDumpJob
+    # transaction can't commit in time and start() fails with timed_out. Raise the cap well
+    # above worst-case recovery; the submit still retries underneath.
+    jobSubmitTimeout = 600.0


### PR DESCRIPTION
tests/fast/BulkDumping.toml intermittently failed at start() with "Error starting workload" / timed_out (1004). The failure is in the job *submit*, not the dump: the workload logs "Submitting Dump Job" but never "Dump Job Submitted", and the failure lands exactly 60s later --

    co_await timeoutError(submitBulkDumpJob(cx, bulkDumpJob), jobSubmitTimeout);

with jobSubmitTimeout defaulting to 60s (BulkDumping.cpp).

Root cause is cluster unavailability, not bulk dump: shortly after the submit began, a CommitProxy failed and triggered recovery. With this test's fault injection enabled and a (possibly 2-region) config, a concurrently rebooting process left recovery unable to recruit a full transaction system -- repeated no_more_servers (1008) and TLogGenerationUnavailable (needs 2 TLogs, 0-1 present). Recovery stalled and the database stayed unavailable for well over 60s, so the submit transaction could not commit and the 60s cap fired. Any transaction would have failed the same way during that window; nothing is bulk-dump specific.

60s is simply too short for worst-case recovery under fault injection. The two slow/BulkDumpingS3* tests avoid this by pinning usable_regions=1 and disabling fault injection; this fast test does neither. Raise jobSubmitTimeout to 600s so the submit rides out a transient recovery outage (it still retries underneath, and the separate 1800s jobCompletionTimeout already tolerates long outages for the actual dump/load). Scope is this one test only.

Repro (fails before, passes after):
    fdbserver -r simulation -f tests/fast/BulkDumping.toml -s 2083858518 -b on