### PR TITLE
Add 2 more `clang-tidy` warnings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -5,6 +5,7 @@ Checks: >
   bugprone-shared-ptr-array-mismatch,
   bugprone-sizeof-expression,
   bugprone-string-constructor,
+  bugprone-stringview-nullptr,
   bugprone-suspicious-memory-comparison,
   bugprone-suspicious-memset-usage,
   bugprone-suspicious-semicolon,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,7 @@
 ---
 Checks: >
   -*,
+  bugprone-dangling-handle,
   bugprone-shared-ptr-array-mismatch,
   bugprone-sizeof-expression,
   bugprone-string-constructor,

--- a/documentation/sphinx/source/clang-tidy.rst
+++ b/documentation/sphinx/source/clang-tidy.rst
@@ -10,10 +10,10 @@ This guide explains how to run ``clang-tidy`` locally so you can fix issues befo
 What clang-tidy checks
 ======================
 
-FoundationDB enables 22 checks configured in the ``.clang-tidy`` file at the repository root. The
+FoundationDB enables 23 checks configured in the ``.clang-tidy`` file at the repository root. The
 intent is to enable more as we go forward. Here are some example rules:
 
-* **10 Bugprone rules** -- catch potential runtime errors (e.g., ``bugprone-use-after-move``, ``bugprone-suspicious-memory-comparison``)
+* **11 Bugprone rules** -- catch potential runtime errors (e.g., ``bugprone-use-after-move``, ``bugprone-suspicious-memory-comparison``)
 * **4 Modernize rules** -- encourage modern C++ practices (e.g., ``modernize-use-auto``, ``modernize-use-override``)
 * **2 Performance rules** -- avoid unnecessary copies and pointless moves (e.g., ``performance-for-range-copy``, ``performance-move-const-arg``)
 * **6 Readability rules** -- improve code clarity (e.g., ``readability-container-contains``, ``readability-container-size-empty``)

--- a/documentation/sphinx/source/clang-tidy.rst
+++ b/documentation/sphinx/source/clang-tidy.rst
@@ -10,10 +10,10 @@ This guide explains how to run ``clang-tidy`` locally so you can fix issues befo
 What clang-tidy checks
 ======================
 
-FoundationDB enables 21 checks configured in the ``.clang-tidy`` file at the repository root. The
+FoundationDB enables 22 checks configured in the ``.clang-tidy`` file at the repository root. The
 intent is to enable more as we go forward. Here are some example rules:
 
-* **9 Bugprone rules** -- catch potential runtime errors (e.g., ``bugprone-use-after-move``, ``bugprone-suspicious-memory-comparison``)
+* **10 Bugprone rules** -- catch potential runtime errors (e.g., ``bugprone-use-after-move``, ``bugprone-suspicious-memory-comparison``)
 * **4 Modernize rules** -- encourage modern C++ practices (e.g., ``modernize-use-auto``, ``modernize-use-override``)
 * **2 Performance rules** -- avoid unnecessary copies and pointless moves (e.g., ``performance-for-range-copy``, ``performance-move-const-arg``)
 * **6 Readability rules** -- improve code clarity (e.g., ``readability-container-contains``, ``readability-container-size-empty``)


### PR DESCRIPTION
These warnings address `std::string_view` usage, which we don't have much of, but they're still helpful