### PR TITLE
Drop stale backup workers during recovery

### DIFF
--- a/fdbserver/logsystem/LogSystem.cpp
+++ b/fdbserver/logsystem/LogSystem.cpp
@@ -2616,6 +2616,27 @@ Future<Reference<LogSystem>> LogSystem::newEpoch(Reference<LogSystem> oldLogSyst
 		logSystem->expectedLogSets++;
 	}
 
+	// Backup workers are bound to the recovery that recruited them and self-displace when the recovery count
+	// advances. Do not carry their interfaces into this recovery: the master re-recruits any unfinished work from
+	// durable progress, and monitoring an inherited interface would turn expected displacement into
+	// backup_worker_failed.
+	size_t droppedBackupWorkers = 0;
+	auto dropBackupWorkers = [&droppedBackupWorkers](const std::vector<Reference<LogSet>>& logSets) {
+		for (const auto& logSet : logSets) {
+			droppedBackupWorkers += logSet->backupWorkers.size();
+			logSet->backupWorkers.clear();
+		}
+	};
+	dropBackupWorkers(oldLogSystem->tLogs);
+	for (const auto& old : oldLogSystem->oldLogData) {
+		dropBackupWorkers(old.tLogs);
+	}
+	if (droppedBackupWorkers > 0) {
+		TraceEvent("DropPreviousRecoveryBackupWorkers", logSystem->dbgid)
+		    .detail("RecoveryCount", recoveryCount)
+		    .detail("Count", droppedBackupWorkers);
+	}
+
 	if (!oldLogSystem->tLogs.empty()) {
 		logSystem->oldLogData.emplace_back();
 		logSystem->oldLogData[0].tLogs = oldLogSystem->tLogs;


### PR DESCRIPTION
Backup workers recruited by a previous recovery self-displace when the recovery count advances. The new log system was retaining their interfaces in inherited log sets, causing the expected shutdown to be observed as `backup_worker_failed` and triggering another recovery.

Drop inherited backup-worker interfaces when creating the next log-system epoch. Unfinished backup work is still re-recruited from durable BackupProgress, while newly recruited workers remain monitored normally.

Validation:
- fdbserver_logsystem_test: 10/10 passed
- Joshua correctness: 10,000 passed, 0 failed
