### PR TITLE
Miscellaneous `AGENTS.md` updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,7 +111,7 @@ Runtime-tunable parameters are declared in `fdbserver/core/include/fdbserver/cor
 
 ## Compatibility
 
-Before changing a serialized type that crosses process boundaries or persists on disk, inspect its `serializer()` and adjacent protocol-version or downgrade comments. Do not reorder, remove, or change encoded fields without the appropriate version gate or migration and compatibility coverage.
+Before changing a serialized type that persists on disk, inspect its `serializer()` and adjacent versioning or downgrade comments. Do not reorder, remove, or change encoded fields without the appropriate version gate or migration and compatibility coverage.
 
 ## Naming Conventions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,22 +24,22 @@ Linux with Clang: `CC=clang CXX=clang++ cmake -DUSE_LD=LLD -DUSE_LIBCXX=1 -G Nin
 
 **Unit tests** use `TEST_CASE("/path/to/test")` macros (defined in `flow/include/flow/UnitTest.h`):
 ```bash
-build/bin/fdbserver -r unittests                           # all unit tests
-build/bin/fdbserver -r unittests -f "/flow/DNSCache"       # single test by prefix
+bin/fdbserver -r unittests                           # all unit tests
+bin/fdbserver -r unittests -f "/flow/DNSCache"       # single test by prefix
 ```
 
 **Simulation tests** use TOML workload definitions in `tests/fast/`, `tests/slow/`, etc.:
 ```bash
-build/bin/fdbserver -r simulation -f tests/fast/CycleTest.toml
+bin/fdbserver -r simulation -f tests/fast/CycleTest.toml
 ```
-
-Configure with `-DENABLE_SIMULATION_TESTS=ON` to register simulation tests with ctest.
 
 **Via ctest:**
 ```bash
-ctest --test-dir build -L fast                    # all fast tests
-ctest --test-dir build -R "StatusDuringOutage"    # by name pattern
+ctest -L fast                    # all fast tests
+ctest -R "StatusDuringOutage"    # by name pattern
 ```
+
+Enable simulation tests in cmake: `-DENABLE_SIMULATION_TESTS=ON`
 
 **Adding new tests:**
 - For a new otherwise-unreferenced translation unit containing `TEST_CASE`, add a `forceLinkXxxTests()` stub and call it from `fdbserver/workloads/UnitTests.cpp`, or the linker can drop the tests.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,11 +4,12 @@ This file provides guidance to AI coding agents working in this repository.
 
 ## Build
 
+The commands below assume the repository root as the current directory and use an out-of-source `build/` directory.
+
 ```bash
-mkdir build && cd build
-cmake -G Ninja <SOURCE_DIR>
-ninja
-# or: ninja fdbserver fdbcli fdbclient  (specific targets)
+cmake -S . -B build -G Ninja
+cmake --build build
+# or: cmake --build build --target fdbserver fdbcli fdbclient
 ```
 
 Key cmake options:
@@ -18,32 +19,32 @@ Key cmake options:
 
 macOS: add `-DBUILD_SWIFT_BINDING=OFF` if Swift issues arise.
 
-Linux with Clang: `CC=clang CXX=clang++ cmake -DUSE_LD=LLD -DUSE_LIBCXX=1 -G Ninja ..`
+Linux with Clang: `CC=clang CXX=clang++ cmake -S . -B build -DUSE_LD=LLD -DUSE_LIBCXX=1 -G Ninja`
 
 ## Testing
 
 **Unit tests** use `TEST_CASE("/path/to/test")` macros (defined in `flow/include/flow/UnitTest.h`):
 ```bash
-bin/fdbserver -r unittests                           # all unit tests
-bin/fdbserver -r unittests -f "/flow/DNSCache"       # single test by prefix
+build/bin/fdbserver -r unittests                           # all unit tests
+build/bin/fdbserver -r unittests -f "/flow/DNSCache"       # single test by prefix
 ```
 
 **Simulation tests** use TOML workload definitions in `tests/fast/`, `tests/slow/`, etc.:
 ```bash
-bin/fdbserver -r simulation -f tests/fast/Cycle.toml
+build/bin/fdbserver -r simulation -f tests/fast/CycleTest.toml
 ```
+
+Configure with `-DENABLE_SIMULATION_TESTS=ON` to register simulation tests with ctest.
 
 **Via ctest:**
 ```bash
-ctest -L fast                    # all fast tests
-ctest -R "StatusDuringOutage"    # by name pattern
+ctest --test-dir build -L fast                    # all fast tests
+ctest --test-dir build -R "StatusDuringOutage"    # by name pattern
 ```
 
-Enable simulation tests in cmake: `-DENABLE_SIMULATION_TESTS=ON`
-
-**Adding new tests** (silent failure modes — the test compiles but never runs):
-- New `.cpp` files containing `TEST_CASE` need a `forceLinkXxxTests()` stub, called from `fdbserver/workloads/UnitTests.cpp`, or the linker drops them.
-- New simulation TOMLs under `tests/` must be registered in `tests/CMakeLists.txt` via `add_fdb_test`, otherwise `ctest` won't see them.
+**Adding new tests:**
+- For a new otherwise-unreferenced translation unit containing `TEST_CASE`, add a `forceLinkXxxTests()` stub and call it from `fdbserver/workloads/UnitTests.cpp`, or the linker can drop the tests.
+- Register new `.toml` or `.txt` tests under `tests/` in `tests/CMakeLists.txt` via `add_fdb_test`. `configure_testing(... ERROR_ON_ADDITIONAL_FILES)` and `verify_testing()` should catch unregistered files during CMake configuration.
 
 **Joshua**: bulk correctness/simulation testing runs on the internal Joshua cluster against optimized Release builds. Local `fdbserver -r simulation` runs are for iteration; large-scale shake-out happens on Joshua.
 
@@ -58,7 +59,7 @@ FoundationDB is a distributed ordered key-value store with strict serializabilit
 FDB uses cooperative single-threaded concurrency. Code is written using either:
 
 - **Flow actors** (`.actor.cpp` / `.actor.h` files): A custom preprocessor (`actorcompiler`) translates `ACTOR`, `state`, `wait()`, `choose/when` syntax into generated C++ state machines. The `#include "flow/actorcompiler.h"` must be the **last** include in actor files.
-- **C++ coroutines** (regular `.cpp` files): Newer code uses `co_await`, `co_return`, `while(true)` instead of `wait()`, `return`, `loop`. Migration from actors to coroutines is ongoing.
+- **C++ coroutines**: Newer code uses `co_await` and `co_return` instead of `wait()` and actor-style `return`. Coroutines can appear in regular `.cpp` files and in `.actor.cpp` files that still contain actorcompiler input; actors and coroutines can be mixed. New code should use coroutines; see `design/coroutines.md`.
 
 Key types: `Future<T>`, `Promise<T>`, `PromiseStream<T>`, `Reference<T>` (ref-counted pointer), `Optional<T>`, `ErrorOr<T>`, `Arena` (region-based allocation).
 
@@ -94,11 +95,11 @@ Client read → Storage Server (serves from MVCC versioned data or underlying st
 
 ### Recovery
 
-When the transaction system fails, the Cluster Controller drives a 10-phase recovery state machine (`RecoveryState` 0-9 in `RecoveryState.h`) that reads coordinated state from coordinators, locks old TLogs, recruits a new transaction system, and replays uncommitted mutations.
+When the transaction system fails, the Cluster Controller drives nine recovery phases (`READING_CSTATE` through `FULLY_RECOVERED`; `UNINITIALIZED` is state 0) defined in `fdbserver/core/include/fdbserver/core/RecoveryState.h`. Recovery reads coordinated state from coordinators, locks old TLogs, recruits the next transaction system, and recovers durable mutations from old log generations.
 
 ### Coordinator Consensus
 
-Coordinators implement single-decree Paxos via generation registers (`localGenerationReg()` in `Coordination.actor.cpp`). The `CoordinatedState` layer adds quorum voting. This is used only for ~1KB of cluster metadata (who is CC, log system config), never for transaction commits.
+Coordinators implement generation registers in `fdbserver/coordinator/Coordination.cpp`. `CoordinatedState` in `fdbserver/core/CoordinatedState.cpp` performs quorum reads and writes over them for recovery metadata. Coordinators separately participate in leader election, but transaction commits use the resolver/TLog pipeline instead.
 
 ### Simulation Testing
 
@@ -106,7 +107,11 @@ Coordinators implement single-decree Paxos via generation registers (`localGener
 
 ### Knobs
 
-Runtime-tunable parameters are in `ServerKnobs.h`/`ClientKnobs.h`/`FlowKnobs.h` (UPPER_CASE names). Accessed via `SERVER_KNOBS->KNOB_NAME`. Some are buggified in simulation. The matching `*Knobs.cpp` files contain `init(KNOB_NAME, value)` calls — these are the source of truth for default values and buggification ranges, complementing the `.h` declarations.
+Runtime-tunable parameters are declared in `fdbserver/core/include/fdbserver/core/Knobs.h`, `fdbclient/include/fdbclient/Knobs.h`, and `flow/include/flow/Knobs.h` (UPPER_CASE names). Access them via `SERVER_KNOBS`, `CLIENT_KNOBS`, or `FLOW_KNOBS`. Defaults and buggification ranges live in `fdbserver/core/ServerKnobs.cpp`, `fdbclient/ClientKnobs.cpp`, and `flow/Knobs.cpp`.
+
+## Compatibility
+
+Before changing a serialized type that crosses process boundaries or persists on disk, inspect its `serializer()` and adjacent protocol-version or downgrade comments. Do not reorder, remove, or change encoded fields without the appropriate version gate or migration and compatibility coverage.
 
 ## Naming Conventions
 
@@ -118,6 +123,8 @@ Runtime-tunable parameters are in `ServerKnobs.h`/`ClientKnobs.h`/`FlowKnobs.h` 
 ## Code Formatting
 
 `clang-format` is used. Python code uses `black` and `flake8` (pre-commit hooks: `pip install pre-commit && pre-commit install`).
+
+Edit `.actor.cpp` and `.actor.h` sources, not actorcompiler-generated output under the build directory.
 
 ## Branching
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,12 +4,11 @@ This file provides guidance to AI coding agents working in this repository.
 
 ## Build
 
-The commands below assume the repository root as the current directory and use an out-of-source `build/` directory.
-
 ```bash
-cmake -S . -B build -G Ninja
-cmake --build build
-# or: cmake --build build --target fdbserver fdbcli fdbclient
+mkdir build && cd build
+cmake -G Ninja <SOURCE_DIR>
+ninja
+# or: ninja fdbserver fdbcli fdbclient  (specific targets)
 ```
 
 Key cmake options:
@@ -19,7 +18,7 @@ Key cmake options:
 
 macOS: add `-DBUILD_SWIFT_BINDING=OFF` if Swift issues arise.
 
-Linux with Clang: `CC=clang CXX=clang++ cmake -S . -B build -DUSE_LD=LLD -DUSE_LIBCXX=1 -G Ninja`
+Linux with Clang: `CC=clang CXX=clang++ cmake -DUSE_LD=LLD -DUSE_LIBCXX=1 -G Ninja ..`
 
 ## Testing
 


### PR DESCRIPTION
This PR does a pass over `AGENTS.md`, adding some clarifications and fixing several inconsistencies (e.g. number of recovery steps and `CycleTest.toml` test file name).
