### PR TITLE
Remove dead cold_cache_server error code left behind by #12486

### DIFF
--- a/bindings/go/src/fdb/error_codes_generated.go
+++ b/bindings/go/src/fdb/error_codes_generated.go
@@ -40,8 +40,6 @@ var (
 	ErrWrongShardServer = Error{Code: 1001}
 	// Operation result no longer necessary
 	ErrOperationObsolete = Error{Code: 1002}
-	// Cache server is not warm for this range
-	ErrColdCacheServer = Error{Code: 1003}
 	// Operation timed out
 	ErrTimedOut = Error{Code: 1004}
 	// Conflict occurred while changing coordination information

--- a/flow/include/flow/error_definitions.h
+++ b/flow/include/flow/error_definitions.h
@@ -36,7 +36,7 @@ ERROR( end_of_stream, 1, "End of stream" )
 ERROR( operation_failed, 1000, "Operation failed")
 ERROR( wrong_shard_server, 1001, "Shard is not available from this server")
 ERROR( operation_obsolete, 1002, "Operation result no longer necessary")
-ERROR( cold_cache_server, 1003, "Cache server is not warm for this range")
+// 1003 removed
 ERROR( timed_out, 1004, "Operation timed out" )
 ERROR( coordinated_state_conflict, 1005, "Conflict occurred while changing coordination information" )
 ERROR( all_alternatives_failed, 1006, "All alternatives failed" )


### PR DESCRIPTION
## Problem
`cold_cache_server` (error code 1003) was tied to the Storage Cache Server feature deleted in #12486. The error is no longer thrown anywhere in the codebase, and no code matches on it. It only exists as a sentinel in the source header and the auto-generated Go binding.

## Solution
Replace the entry in `flow/include/flow/error_definitions.h` with a `// 1003 removed` placeholder so the number slot stays reserved, then regenerate `bindings/go/src/fdb/error_codes_generated.go`. Same pattern as `e50558fd7` ("Remove dead quota throttling error").

## Testing done
- Verified zero references to `cold_cache_server`, `error_code_cold_cache_server`, or `ErrColdCacheServer` anywhere in the tree (other than the two lines being removed).
- Confirmed no other binding (Python, Java, etc.) carries this error code.
- Regenerated the Go bindings file using `go run ./bindings/go/src/internal/gen_errors/main.go`.
