### PR TITLE
Fix `MockDD` startup with production-only actors

### DIFF
--- a/fdbserver/datadistributor/DataDistribution.cpp
+++ b/fdbserver/datadistributor/DataDistribution.cpp
@@ -3029,8 +3029,7 @@ Future<Void> dataDistribution(Reference<DataDistributor> self,
 
 			actors.push_back(self->pollMoveKeysLock());
 			if (!isMocked) {
-				actors.push_back(
-				    monitorBackupPartitionRequired(self->txnProcessor->context(), &shards, self->ddId));
+				actors.push_back(monitorBackupPartitionRequired(self->txnProcessor->context(), &shards, self->ddId));
 			}
 
 			self->context->tracker = makeReference<DataDistributionTracker>(

--- a/fdbserver/datadistributor/DataDistribution.cpp
+++ b/fdbserver/datadistributor/DataDistribution.cpp
@@ -2916,11 +2916,7 @@ Future<Void> bulkDumpCore(Reference<DataDistributor> self, Future<Void> readyToS
 
 // These actors read or write system keys through a real Database and are not part of MockDD's transaction
 // processor contract.
-void addProductionOnlyDataDistributionActors(Reference<DataDistributor> self,
-                                             KeyRangeMap<ShardTrackedData>* shards,
-                                             std::vector<Future<Void>>& actors) {
-	actors.push_back(monitorBackupPartitionRequired(self->txnProcessor->context(), shards, self->ddId));
-
+void addProductionOnlyDataDistributionActors(Reference<DataDistributor> self, std::vector<Future<Void>>& actors) {
 	if (bulkLoadIsEnabled(self->initData->bulkLoadMode)) {
 		TraceEvent(SevInfo, "DDBulkLoadModeEnabled", self->ddId)
 		    .detail("UsableRegions", self->configuration.usableRegions);
@@ -3032,6 +3028,10 @@ Future<Void> dataDistribution(Reference<DataDistributor> self,
 			}
 
 			actors.push_back(self->pollMoveKeysLock());
+			if (!isMocked) {
+				actors.push_back(
+				    monitorBackupPartitionRequired(self->txnProcessor->context(), &shards, self->ddId));
+			}
 
 			self->context->tracker = makeReference<DataDistributionTracker>(
 			    DataDistributionTrackerInitParams{ .db = self->txnProcessor,
@@ -3161,7 +3161,7 @@ Future<Void> dataDistribution(Reference<DataDistributor> self,
 			if (isMocked) {
 				self->bulkLoadTaskCollection->removeBulkLoadJobRange();
 			} else {
-				addProductionOnlyDataDistributionActors(self, &shards, actors);
+				addProductionOnlyDataDistributionActors(self, actors);
 			}
 
 			actors.push_back(monitorShardEncodeKnob(self->ddId));

--- a/fdbserver/datadistributor/DataDistribution.cpp
+++ b/fdbserver/datadistributor/DataDistribution.cpp
@@ -2914,6 +2914,45 @@ Future<Void> bulkDumpCore(Reference<DataDistributor> self, Future<Void> readyToS
 	}
 }
 
+// These actors read or write system keys through a real Database and are not part of MockDD's transaction
+// processor contract.
+void addProductionOnlyDataDistributionActors(Reference<DataDistributor> self,
+                                             KeyRangeMap<ShardTrackedData>* shards,
+                                             std::vector<Future<Void>>& actors) {
+	actors.push_back(monitorBackupPartitionRequired(self->txnProcessor->context(), shards, self->ddId));
+
+	if (bulkLoadIsEnabled(self->initData->bulkLoadMode)) {
+		TraceEvent(SevInfo, "DDBulkLoadModeEnabled", self->ddId)
+		    .detail("UsableRegions", self->configuration.usableRegions);
+		self->bulkLoadEnabled = true;
+		if (self->configuration.usableRegions > 1) {
+			// The core actor to handle bulkload tasks
+			actors.push_back(bulkLoadTaskCore(self, self->initialized.getFuture() && remoteRecovered(self->dbInfo)));
+			// The core actor to convert a bulkload job to tasks which are executed by bulkLoadTaskCore
+			actors.push_back(bulkLoadJobCore(self, self->initialized.getFuture() && remoteRecovered(self->dbInfo)));
+		} else {
+			actors.push_back(bulkLoadTaskCore(self, self->initialized.getFuture()));
+			actors.push_back(bulkLoadJobCore(self, self->initialized.getFuture()));
+		}
+	} else {
+		self->bulkLoadTaskCollection->removeBulkLoadJobRange();
+		// Monitor for bulkLoadMode changes and spawn actors dynamically.
+		// This is critical for restore operations which set bulkLoadMode=1 after DD starts.
+		actors.push_back(monitorBulkLoadModeAndSpawnActors(self, self->initialized.getFuture()));
+	}
+
+	// Always spawn bulkDumpCore for production DD - it will dynamically check the mode
+	// NOTE: BulkDump does NOT require remoteRecovered() in HA configurations.
+	// BulkDump is read-only: it reads from primary DC and writes to external storage (S3).
+	// Waiting for remoteRecovered() caused hangs when remote DC couldn't form teams.
+	TraceEvent(SevInfo, "DDBulkDumpCoreSpawned", self->ddId)
+	    .detail("UsableRegions", self->configuration.usableRegions)
+	    .detail("InitialMode", self->initData->bulkDumpMode);
+	actors.push_back(bulkDumpCore(self, self->initialized.getFuture()));
+
+	actors.push_back(periodicAuditLocationMetadata(self));
+}
+
 // Runs the data distribution algorithm for FDB, including the DD Queue, DD tracker, and DD team collection
 Future<Void> dataDistribution(Reference<DataDistributor> self,
                               PromiseStream<GetMetricsListRequest> getShardMetricsList,
@@ -2993,9 +3032,6 @@ Future<Void> dataDistribution(Reference<DataDistributor> self,
 			}
 
 			actors.push_back(self->pollMoveKeysLock());
-			if (!isMocked) {
-				actors.push_back(monitorBackupPartitionRequired(self->txnProcessor->context(), &shards, self->ddId));
-			}
 
 			self->context->tracker = makeReference<DataDistributionTracker>(
 			    DataDistributionTrackerInitParams{ .db = self->txnProcessor,
@@ -3122,42 +3158,11 @@ Future<Void> dataDistribution(Reference<DataDistributor> self,
 				actors.push_back(monitorPhysicalShardStatus(self->physicalShardCollection));
 			}
 
-			if (bulkLoadIsEnabled(self->initData->bulkLoadMode)) {
-				TraceEvent(SevInfo, "DDBulkLoadModeEnabled", self->ddId)
-				    .detail("UsableRegions", self->configuration.usableRegions);
-				self->bulkLoadEnabled = true;
-				if (self->configuration.usableRegions > 1) {
-					// The core actor to handle bulkload tasks
-					actors.push_back(
-					    bulkLoadTaskCore(self, self->initialized.getFuture() && remoteRecovered(self->dbInfo)));
-					// The core actor to convert a bulkload job to tasks which are executed by bulkLoadTaskCore
-					actors.push_back(
-					    bulkLoadJobCore(self, self->initialized.getFuture() && remoteRecovered(self->dbInfo)));
-				} else {
-					actors.push_back(bulkLoadTaskCore(self, self->initialized.getFuture()));
-					actors.push_back(bulkLoadJobCore(self, self->initialized.getFuture()));
-				}
-			} else {
+			if (isMocked) {
 				self->bulkLoadTaskCollection->removeBulkLoadJobRange();
-				// Monitor for bulkLoadMode changes and spawn actors dynamically.
-				// This is critical for restore operations which set bulkLoadMode=1 after DD starts.
-				if (!isMocked) {
-					actors.push_back(monitorBulkLoadModeAndSpawnActors(self, self->initialized.getFuture()));
-				}
+			} else {
+				addProductionOnlyDataDistributionActors(self, &shards, actors);
 			}
-
-			// Always spawn bulkDumpCore for production DD - it will dynamically check the mode
-			// NOTE: BulkDump does NOT require remoteRecovered() in HA configurations.
-			// BulkDump is read-only: it reads from primary DC and writes to external storage (S3).
-			// Waiting for remoteRecovered() caused hangs when remote DC couldn't form teams.
-			if (!isMocked) {
-				TraceEvent(SevInfo, "DDBulkDumpCoreSpawned", self->ddId)
-				    .detail("UsableRegions", self->configuration.usableRegions)
-				    .detail("InitialMode", self->initData->bulkDumpMode);
-				actors.push_back(bulkDumpCore(self, self->initialized.getFuture()));
-			}
-
-			actors.push_back(periodicAuditLocationMetadata(self));
 
 			actors.push_back(monitorShardEncodeKnob(self->ddId));
 

--- a/fdbserver/datadistributor/DataDistribution.cpp
+++ b/fdbserver/datadistributor/DataDistribution.cpp
@@ -2993,7 +2993,9 @@ Future<Void> dataDistribution(Reference<DataDistributor> self,
 			}
 
 			actors.push_back(self->pollMoveKeysLock());
-			actors.push_back(monitorBackupPartitionRequired(self->txnProcessor->context(), &shards, self->ddId));
+			if (!isMocked) {
+				actors.push_back(monitorBackupPartitionRequired(self->txnProcessor->context(), &shards, self->ddId));
+			}
 
 			self->context->tracker = makeReference<DataDistributionTracker>(
 			    DataDistributionTrackerInitParams{ .db = self->txnProcessor,
@@ -3139,17 +3141,21 @@ Future<Void> dataDistribution(Reference<DataDistributor> self,
 				self->bulkLoadTaskCollection->removeBulkLoadJobRange();
 				// Monitor for bulkLoadMode changes and spawn actors dynamically.
 				// This is critical for restore operations which set bulkLoadMode=1 after DD starts.
-				actors.push_back(monitorBulkLoadModeAndSpawnActors(self, self->initialized.getFuture()));
+				if (!isMocked) {
+					actors.push_back(monitorBulkLoadModeAndSpawnActors(self, self->initialized.getFuture()));
+				}
 			}
 
-			// Always spawn bulkDumpCore - it will dynamically check the mode
+			// Always spawn bulkDumpCore for production DD - it will dynamically check the mode
 			// NOTE: BulkDump does NOT require remoteRecovered() in HA configurations.
 			// BulkDump is read-only: it reads from primary DC and writes to external storage (S3).
 			// Waiting for remoteRecovered() caused hangs when remote DC couldn't form teams.
-			TraceEvent(SevInfo, "DDBulkDumpCoreSpawned", self->ddId)
-			    .detail("UsableRegions", self->configuration.usableRegions)
-			    .detail("InitialMode", self->initData->bulkDumpMode);
-			actors.push_back(bulkDumpCore(self, self->initialized.getFuture()));
+			if (!isMocked) {
+				TraceEvent(SevInfo, "DDBulkDumpCoreSpawned", self->ddId)
+				    .detail("UsableRegions", self->configuration.usableRegions)
+				    .detail("InitialMode", self->initData->bulkDumpMode);
+				actors.push_back(bulkDumpCore(self, self->initialized.getFuture()));
+			}
 
 			actors.push_back(periodicAuditLocationMetadata(self));
 

--- a/tests/fast/MockDDReadWrite.toml
+++ b/tests/fast/MockDDReadWrite.toml
@@ -3,7 +3,7 @@ testClass = 'MockDD'
 
 [[knobs]]
 enable_dd_physical_shard = false
-storage_quota_enabled = false
+shard_encode_location_metadata = false
 
 [[test]]
 testTitle = 'MockDDTracker'


### PR DESCRIPTION
This PR fixes a `tests/fast/MockDDReadWrite.toml` test failure.

Mock data distribution uses `DDMockTxnProcessor`, whose `context()` method is intentionally unreachable because `MockDD` does not have a real `Database` context.

`dataDistribution()` nevertheless started several production-only actors for `MockDD`:

- `monitorBackupPartitionRequired`
- `monitorBulkLoadModeAndSpawnActors`
- `bulkDumpCore`

These actors require a real database context. A `MockDD` correctness run therefore aborted when backup-partition monitoring called `DDMockTxnProcessor::context()`. After guarding that actor, deterministic replay exposed the same issue in dynamic bulk-load monitoring.

`MockDDReadWrite.toml` also retained the removed `storage_quota_enabled` knob and allowed shard-location metadata encoding to be randomly enabled, even though that path is unsupported by `MockDD`.
