### PR TITLE
Note that special keys errors must be accessed in the same transaction

### DIFF
--- a/bindings/go/src/fdb/error_codes_generated.go
+++ b/bindings/go/src/fdb/error_codes_generated.go
@@ -458,7 +458,7 @@ var (
 	ErrSpecialKeysNoWriteModuleFound = Error{Code: 2115}
 	// Special key space clear crosses modules
 	ErrSpecialKeysCrossModuleClear = Error{Code: 2116}
-	// Api call through special keys failed. For more information, call get on special key 0xff0xff/error_message to get a json string of the error message.
+	// Api call through special keys failed. For more information, call get - within the same transaction - on special key 0xff0xff/error_message to get a json string of the error message.
 	ErrSpecialKeysAPIFailure = Error{Code: 2117}
 	// Invalid client library metadata.
 	ErrClientLibInvalidMetadata = Error{Code: 2118}

--- a/documentation/sphinx/source/api-error-codes.rst
+++ b/documentation/sphinx/source/api-error-codes.rst
@@ -158,7 +158,7 @@ FoundationDB may return the following error codes from API functions. If you nee
 | special_keys_cross_module_write               | 2116| Special key space clear crosses modules                                        |
 +-----------------------------------------------+-----+--------------------------------------------------------------------------------+
 | special_keys_api_failure                      | 2117| Api call through special keys failed. For more information, read the           |
-|                                               |     | ``0xff0xff/error_message`` key                                                 |
+|                                               |     | ``0xff0xff/error_message`` key within the same transaction.                    |
 +-----------------------------------------------+-----+--------------------------------------------------------------------------------+
 | api_version_unset                             | 2200| API version is not set                                                         |
 +-----------------------------------------------+-----+--------------------------------------------------------------------------------+

--- a/documentation/sphinx/source/special-keys.rst
+++ b/documentation/sphinx/source/special-keys.rst
@@ -238,7 +238,12 @@ Error message module
 
 Each module written to validates the transaction before committing, and this
 validation failing is indicated by a ``special_keys_api_failure`` error.
-More detailed information about why this validation failed can be accessed through the ``\xff\xff/error_message`` key, whose value is a json document with the following schema.
+More detailed information about why this validation failed can be accessed through the ``\xff\xff/error_message`` key.
+
+It must be accessed within the same transaction that the ``special_keys_api_failure`` error is encountered.
+See a Golang implementation of this in the Operator here https://github.com/FoundationDB/fdb-kubernetes-operator/pull/2517
+
+The value of the key is a json document with the following schema:
 
 ========================== ======== ===============
 **Field**                  **Type** **Description**

--- a/flow/include/flow/error_definitions.h
+++ b/flow/include/flow/error_definitions.h
@@ -267,7 +267,7 @@ ERROR( special_keys_no_module_found, 2113, "Special key space range read does no
 ERROR( special_keys_write_disabled, 2114, "Special Key space is not allowed to write by default. Refer to the `special_key_space_enable_writes` transaction option for more details." )
 ERROR( special_keys_no_write_module_found, 2115, "Special key space key or keyrange in set or clear does not intersect a module" )
 ERROR( special_keys_cross_module_clear, 2116, "Special key space clear crosses modules" )
-ERROR( special_keys_api_failure, 2117, "Api call through special keys failed. For more information, call get on special key 0xff0xff/error_message to get a json string of the error message." )
+ERROR( special_keys_api_failure, 2117, "Api call through special keys failed. For more information, call get - within the same transaction - on special key 0xff0xff/error_message to get a json string of the error message." )
 ERROR( client_lib_invalid_metadata, 2118, "Invalid client library metadata." )
 ERROR( client_lib_already_exists, 2119, "Client library with same identifier already exists on the cluster." )
 ERROR( client_lib_not_found, 2120, "Client library for the given identifier not found." )


### PR DESCRIPTION
The special keys error messages cannot be accessed outside of the transaction that encounters the error. 
I was unable to find any documentation referencing this. 
This led to an issue in the operator logic https://github.com/FoundationDB/fdb-kubernetes-operator/issues/2514 (though arguably this is more of a problem in the bindings not handling the error for users)

I did some tests on a small cluster to force the not-enough-storage-data error that goes on these keys and found that the message only is get'able inside the same transaction, and several AI interrogations tell me that this is expected based on the code. It also makes sense since technically it could get overwritten quickly and be hard to trace to your tx's specific error, but this should have a note at least.