### PR TITLE
Backport: drop Cycle workload rate check, add MinimumThroughput (PR 13297)

### DIFF
--- a/fdbserver/workloads/Cycle.actor.cpp
+++ b/fdbserver/workloads/Cycle.actor.cpp
@@ -57,7 +57,7 @@ struct CycleWorkload : TestWorkload, CycleMembers<MultiTenancy> {
 	static constexpr auto NAME = MultiTenancy ? "TenantCycle" : "Cycle";
 	static constexpr auto TenantEnabled = MultiTenancy;
 	int actorCount, nodeCount;
-	double testDuration, transactionsPerSecond, minExpectedTransactionsPerSecond, traceParentProbability;
+	double testDuration, transactionsPerSecond, traceParentProbability;
 	bool unseedCheck{ true };
 	bool skipSetup{ false }; // Useful for restarting tests
 	Key keyPrefix;
@@ -75,7 +75,6 @@ struct CycleWorkload : TestWorkload, CycleMembers<MultiTenancy> {
 		nodeCount = getOption(options, "nodeCount"_sr, transactionsPerSecond * clientCount);
 		keyPrefix = unprintable(getOption(options, "keyPrefix"_sr, ""_sr).toString());
 		traceParentProbability = getOption(options, "traceParentProbability"_sr, 0.01);
-		minExpectedTransactionsPerSecond = transactionsPerSecond * getOption(options, "expectedRate"_sr, 0.7);
 		unseedCheck = getOption(options, "unseedCheck"_sr, true);
 		skipSetup = getOption(options, "skipSetup"_sr, false);
 		if constexpr (MultiTenancy) {
@@ -311,19 +310,6 @@ struct CycleWorkload : TestWorkload, CycleMembers<MultiTenancy> {
 	}
 
 	ACTOR Future<bool> cycleCheck(Database cx, CycleWorkload* self, bool ok) {
-		if (self->transactions.getMetric().value() < self->testDuration * self->minExpectedTransactionsPerSecond) {
-			TraceEvent(SevWarnAlways, "TestFailure")
-			    .detail("Reason", "Rate below desired rate")
-			    .detail("File", __FILE__)
-			    .detail(
-			        "Details",
-			        format("%.2f",
-			               self->transactions.getMetric().value() / (self->transactionsPerSecond * self->testDuration)))
-			    .detail("TransactionsAchieved", self->transactions.getMetric().value())
-			    .detail("MinTransactionsExpected", self->testDuration * self->minExpectedTransactionsPerSecond)
-			    .detail("TransactionGoal", self->transactionsPerSecond * self->testDuration);
-			ok = false;
-		}
 		if (!self->clientId) {
 			// One client checks the validity of the cycle
 			state Transaction tr(cx);

--- a/fdbserver/workloads/MinimumThroughput.cpp
+++ b/fdbserver/workloads/MinimumThroughput.cpp
@@ -1,0 +1,126 @@
+/*
+ * MinimumThroughput.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "fdbclient/NativeAPI.actor.h"
+#include "fdbserver/TesterInterface.actor.h"
+#include "fdbserver/workloads/workloads.actor.h"
+#include "flow/Coroutines.h"
+
+// NOTE: Do not mix this with Attrition or similar error injection workloads.
+// Its purpose is to ensure a basic level of transaction throughput in error-free
+// circumstances.
+struct MinimumThroughputWorkload : TestWorkload {
+	static constexpr auto NAME = "MinimumThroughput";
+
+	int actorCount, nodeCount;
+	double testDuration, transactionsPerSecond, minExpectedTransactionsPerSecond, readFraction;
+
+	std::vector<Future<Void>> clients;
+	PerfIntCounter transactions, retries;
+	PerfDoubleCounter totalLatency;
+
+	explicit MinimumThroughputWorkload(WorkloadContext const& wcx)
+	  : TestWorkload(wcx), transactions("Transactions"), retries("Retries"), totalLatency("Latency") {
+		testDuration = getOption(options, "testDuration"_sr, 30.0);
+		transactionsPerSecond = getOption(options, "transactionsPerSecond"_sr, 200.0) / clientCount;
+		actorCount = getOption(options, "actorsPerClient"_sr, std::max(1, int(transactionsPerSecond / 5)));
+		nodeCount = getOption(options, "nodeCount"_sr, 100000);
+		readFraction = getOption(options, "readFraction"_sr, 0.5);
+		minExpectedTransactionsPerSecond = transactionsPerSecond * getOption(options, "expectedRate"_sr, 0.8);
+	}
+
+	Future<Void> setup(Database const& cx) override { return Void(); }
+
+	Future<Void> start(Database const& cx) override {
+		for (int c = 0; c < actorCount; c++) {
+			clients.push_back(
+			    timeout(client(cx->clone(), this, actorCount / transactionsPerSecond), testDuration, Void()));
+		}
+		return delay(testDuration);
+	}
+
+	Future<bool> check(Database const& cx) override {
+		int errors = 0;
+		for (auto& c : clients)
+			errors += c.isError();
+		clients.clear();
+		if (errors) {
+			TraceEvent(SevError, "TestFailure").detail("Reason", "There were client errors.");
+			return false;
+		}
+		int64_t achieved = transactions.getMetric().value();
+		int64_t minRequired = (int64_t)(testDuration * minExpectedTransactionsPerSecond);
+		int64_t target = (int64_t)(testDuration * transactionsPerSecond);
+		if (achieved < minRequired) {
+			TraceEvent(SevError, "TestFailure")
+			    .detail("Reason", "Throughput below minimum")
+			    .detail("Achieved", achieved)
+			    .detail("MinRequired", minRequired)
+			    .detail("Target", target);
+			return false;
+		}
+		return true;
+	}
+
+	void disableFailureInjectionWorkloads(std::set<std::string>& out) const override { out.insert("all"); }
+
+	void getMetrics(std::vector<PerfMetric>& m) override {
+		m.push_back(transactions.getMetric());
+		m.push_back(retries.getMetric());
+		m.emplace_back("Avg Latency (ms)", 1000 * totalLatency.getValue() / transactions.getValue(), Averaged::True);
+	}
+
+	static Key keyForIndex(int i) { return StringRef(format("MTP/%08d", i)); }
+
+	Future<Void> client(Database cx, MinimumThroughputWorkload* self, double delay) {
+		double lastTime = now();
+		try {
+			while (true) {
+				co_await poisson(&lastTime, delay);
+				double tstart = now();
+				Key key = keyForIndex(deterministicRandom()->randomInt(0, self->nodeCount));
+				bool readOnly = deterministicRandom()->random01() < self->readFraction;
+				Transaction tr(cx);
+				while (true) {
+					Error err;
+					try {
+						co_await tr.get(key);
+						if (!readOnly) {
+							tr.set(key, "x"_sr);
+							co_await tr.commit();
+						}
+						break;
+					} catch (Error& e) {
+						err = e;
+					}
+					co_await tr.onError(err);
+					++self->retries;
+				}
+				++self->transactions;
+				self->totalLatency += now() - tstart;
+			}
+		} catch (Error& e) {
+			TraceEvent(SevError, "MinimumThroughputClient").error(e);
+			throw;
+		}
+	}
+};
+
+WorkloadFactory<MinimumThroughputWorkload> MinimumThroughputWorkloadFactory;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -193,6 +193,7 @@ if(WITH_PYTHON)
   # TODO: Fix failures and reenable this test:
   add_fdb_test(TEST_FILES fast/LowLatencySingleClog.toml IGNORE)
   add_fdb_test(TEST_FILES fast/MemoryLifetime.toml)
+  add_fdb_test(TEST_FILES fast/MinimumThroughput.toml)
   add_fdb_test(TEST_FILES fast/MoveKeysCycle.toml)
   add_fdb_test(TEST_FILES fast/MutationLogReaderCorrectness.toml)
 

--- a/tests/DataDistributionMetrics.txt
+++ b/tests/DataDistributionMetrics.txt
@@ -8,7 +8,6 @@ testTitle=DataDistributionMetricsCorrectness
     testName=Cycle
     transactionsPerSecond=2500.0
     testDuration=10.0
-    expectedRate=0.025
 
     testName=Mako
     testDuration=10.0

--- a/tests/Happy.txt
+++ b/tests/Happy.txt
@@ -2,5 +2,4 @@ testTitle=Unclogged
     testName=Cycle
     transactionsPerSecond=3500.0
     testDuration=2.0
-    expectedRate=0.80
     startDelay=0

--- a/tests/SampleNoSimAttrition.txt
+++ b/tests/SampleNoSimAttrition.txt
@@ -2,7 +2,6 @@ testTitle=Temp
     testName=Cycle
     transactionsPerSecond=2500.0
     testDuration=10.0
-    expectedRate=0
 
     testName=Attrition
     killDc=true

--- a/tests/default.txt
+++ b/tests/default.txt
@@ -20,7 +20,6 @@ testTitle=CloggedCycleTest
     testName=Cycle
     transactionsPerSecond=5000.0
     testDuration=30.0
-    expectedRate=0.5
 
     testName=RandomClogging
     testDuration=30.0
@@ -46,7 +45,6 @@ testTitle=SwizzledRollbackTimeLapse
     transactionsPerSecond=500.0
     testDuration=300.0
     nodeCount=10000
-    expectedRate=0.0
 
     testName=RandomClogging
     testDuration=300.0

--- a/tests/fail.txt
+++ b/tests/fail.txt
@@ -3,4 +3,3 @@ testTitle=AlwaysFails
     transactionsPerSecond=2500.0
     testDuration=5.0
     nodeCount=10000.0
-    expectedRate=2.0

--- a/tests/fast/BackupAzureBlobCorrectness.toml
+++ b/tests/fast/BackupAzureBlobCorrectness.toml
@@ -9,7 +9,6 @@ simBackupAgents = 'BackupToFile'
     testName = 'Cycle'
     nodeCount = 3000
     testDuration = 10.0
-    expectedRate = 0
     
     [[test.workload]]
     testName = 'RandomClogging'
@@ -108,4 +107,3 @@ checkOnly = 'true'
     [[test.workload]]
     testName = 'Cycle'
     nodeCount = 3000
-    expectedRate = 0

--- a/tests/fast/BackupCorrectness.toml
+++ b/tests/fast/BackupCorrectness.toml
@@ -10,7 +10,6 @@ simBackupAgents = 'BackupToFile'
     nodeCount = 30000
     transactionsPerSecond = 2500.0
     testDuration = 30.0
-    expectedRate = 0
 
     [[test.workload]]
     testName = 'BackupAndRestoreCorrectness'

--- a/tests/fast/BackupCorrectnessClean.toml
+++ b/tests/fast/BackupCorrectnessClean.toml
@@ -10,21 +10,18 @@ simBackupAgents = 'BackupToFile'
     testName = 'Cycle'
     transactionsPerSecond = 250.0
     testDuration = 20.0
-    expectedRate = 0
     keyPrefix = 'a'
 
     [[test.workload]]
     testName = 'Cycle'
     transactionsPerSecond = 250.0
     testDuration = 30.0
-    expectedRate = 0
     keyPrefix = 'A'
 
     [[test.workload]]
     testName = 'Cycle'
     transactionsPerSecond = 250.0
     testDuration = 40.0
-    expectedRate = 0
     keyPrefix = 'm'
 
     [[test.workload]]

--- a/tests/fast/BackupS3BlobCorrectness.toml
+++ b/tests/fast/BackupS3BlobCorrectness.toml
@@ -9,7 +9,6 @@ simBackupAgents = 'BackupToFile'
     testName = 'Cycle'
     nodeCount = 3000
     testDuration = 10.0
-    expectedRate = 0
     
     [[test.workload]]
     testName = 'RandomClogging'
@@ -108,4 +107,3 @@ checkOnly = 'true'
     [[test.workload]]
     testName = 'Cycle'
     nodeCount = 3000
-    expectedRate = 0

--- a/tests/fast/BackupToDBCorrectness.toml
+++ b/tests/fast/BackupToDBCorrectness.toml
@@ -15,7 +15,6 @@ simBackupAgents = 'BackupToDB'
     nodeCount = 30000
     transactionsPerSecond = 2500.0
     testDuration = 30.0
-    expectedRate = 0
 
     [[test.workload]]
     testName = 'BackupToDBCorrectness'

--- a/tests/fast/BackupToDBCorrectnessClean.toml
+++ b/tests/fast/BackupToDBCorrectnessClean.toml
@@ -14,21 +14,18 @@ simBackupAgents = 'BackupToDB'
     testName = 'Cycle'
     transactionsPerSecond = 500.0
     testDuration = 20.0
-    expectedRate = 0
     keyPrefix = 'a'
 
     [[test.workload]]
     testName = 'Cycle'
     transactionsPerSecond = 500.0
     testDuration = 30.0
-    expectedRate = 0
     keyPrefix = 'A'
 
     [[test.workload]]
     testName = 'Cycle'
     transactionsPerSecond = 500.0
     testDuration = 40.0
-    expectedRate = 0
     keyPrefix = 'm'
 
     [[test.workload]]

--- a/tests/fast/CacheTest.toml
+++ b/tests/fast/CacheTest.toml
@@ -15,5 +15,4 @@ testTitle = 'Cycle'
     testName = 'Cycle'
     transactionsPerSecond = 2500.0
     testDuration = 10.0
-    expectedRate = 0.01
     keyPrefix = 'foo/'

--- a/tests/fast/CycleAndLock.toml
+++ b/tests/fast/CycleAndLock.toml
@@ -5,7 +5,6 @@ testTitle = 'Clogged'
     testName = 'Cycle'
     transactionsPerSecond = 2500.0
     testDuration = 60.0
-    expectedRate = 0
 
     [[test.workload]]
     testName = 'LockDatabase'

--- a/tests/fast/CycleTest.toml
+++ b/tests/fast/CycleTest.toml
@@ -5,7 +5,6 @@ testTitle = 'Clogged'
     testName = 'Cycle'
     transactionsPerSecond = 2500.0
     testDuration = 10.0
-    expectedRate = 0
 
     [[test.workload]]
     testName = 'RandomClogging'
@@ -37,4 +36,3 @@ testTitle = 'Unclogged'
     testName = 'Cycle'
     transactionsPerSecond = 250.0
     testDuration = 10.0
-    expectedRate = 0.80

--- a/tests/fast/IncrementalBackup.toml
+++ b/tests/fast/IncrementalBackup.toml
@@ -19,7 +19,6 @@ simBackupAgents = 'BackupToFile'
     nodeCount = 3000
     transactionsPerSecond = 3000.0
     testDuration = 10.0
-    expectedRate = 0
 
     [[test.workload]]
     testName = 'IncrementalBackup'
@@ -47,4 +46,3 @@ checkOnly = true
     nodeCount = 3000
     transactionsPerSecond = 3000.0
     testDuration = 10.0
-    expectedRate = 0

--- a/tests/fast/KillRegionCycle.toml
+++ b/tests/fast/KillRegionCycle.toml
@@ -13,7 +13,6 @@ clearAfterTest = false
     nodeCount = 30000
     transactionsPerSecond = 2500.0
     testDuration = 30.0
-    expectedRate = 0
 
     [[test.workload]]
     testName = 'KillRegion'

--- a/tests/fast/LowLatency.toml
+++ b/tests/fast/LowLatency.toml
@@ -10,7 +10,6 @@ connectionFailuresDisableDuration = 100000
     testName = 'Cycle'
     transactionsPerSecond = 1000.0
     testDuration = 30.0
-    expectedRate = 0
 
     [[test.workload]]
     testName = 'LowLatency'

--- a/tests/fast/LowLatencySingleClog.toml
+++ b/tests/fast/LowLatencySingleClog.toml
@@ -10,7 +10,6 @@ connectionFailuresDisableDuration = 100000
     testName = 'Cycle'
     transactionsPerSecond = 1000.0
     testDuration = 60.0
-    expectedRate = 0
 
     [[test.workload]]
     testName = 'LowLatency'

--- a/tests/fast/MinimumThroughput.toml
+++ b/tests/fast/MinimumThroughput.toml
@@ -1,0 +1,14 @@
+[configuration]
+buggify = false
+
+[[test]]
+testTitle = 'MinimumThroughput'
+connectionFailuresDisableDuration = 100000
+
+    [[test.workload]]
+    testName = 'MinimumThroughput'
+    testDuration = 30.0
+    transactionsPerSecond = 200.0
+    nodeCount = 100000
+    readFraction = 0.5
+    expectedRate = 0.8

--- a/tests/fast/MoveKeysCycle.toml
+++ b/tests/fast/MoveKeysCycle.toml
@@ -5,7 +5,6 @@ testTitle = 'MoveKeysCycle'
     testName = 'Cycle'
     transactionsPerSecond = 2500.0
     testDuration = 10.0
-    expectedRate = 0.025
 
     [[test.workload]]
     testName = 'RandomMoveKeys'

--- a/tests/fast/RangeLockCycle.toml
+++ b/tests/fast/RangeLockCycle.toml
@@ -16,7 +16,6 @@ testTitle = 'RangeLockCycle'
     nodeCount = 30000
     transactionsPerSecond = 1000.0
     testDuration = 30.0
-    expectedRate = 0
 
     [[test.workload]]
     testName = 'RandomRangeLock'

--- a/tests/fast/RestoreValidation.toml
+++ b/tests/fast/RestoreValidation.toml
@@ -28,7 +28,6 @@ runFailureWorkloads = false
     nodeCount = 100
     transactionsPerSecond = 10.0
     testDuration = 10.0
-    expectedRate = 0
 
     [[test.workload]]
     testName = 'BackupAndRestoreValidation'

--- a/tests/fast/RocksdbNondeterministicTest.toml
+++ b/tests/fast/RocksdbNondeterministicTest.toml
@@ -11,7 +11,6 @@ testTitle = 'Clogged'
 testName = 'Cycle'
 transactionsPerSecond = 2500.0
 testDuration = 10.0
-expectedRate = 0
 unseedCheck = false
 
 [[test.workload]]
@@ -44,5 +43,4 @@ testTitle = 'Unclogged'
 testName = 'Cycle'
 transactionsPerSecond = 250.0
 testDuration = 10.0
-expectedRate = 0.80
 unseedCheck = false

--- a/tests/fast/ShardedRocksNondeterministicTest.toml
+++ b/tests/fast/ShardedRocksNondeterministicTest.toml
@@ -13,7 +13,6 @@ testTitle = 'Clogged'
 testName = 'Cycle'
 transactionsPerSecond = 2500.0
 testDuration = 10.0
-expectedRate = 0
 unseedCheck = false
 
 [[test.workload]]
@@ -46,5 +45,4 @@ testTitle = 'Unclogged'
 testName = 'Cycle'
 transactionsPerSecond = 250.0
 testDuration = 10.0
-expectedRate = 0.80
 unseedCheck = false

--- a/tests/fast/SystemRebootTestCycle.toml
+++ b/tests/fast/SystemRebootTestCycle.toml
@@ -6,7 +6,6 @@ clearAfterTest = false
     testName = 'Cycle'
     transactionsPerSecond = 250.0
     testDuration = 20.0
-    expectedRate = 0.01
     nodeCount = 50000
 
     [[test.workload]]
@@ -38,4 +37,3 @@ runSetup = false
     nodeCount = 50000
     transactionsPerSecond = 250.0
     testDuration = 10.0
-    expectedRate = 0.70

--- a/tests/fast/TxnStateStoreCycleTest.toml
+++ b/tests/fast/TxnStateStoreCycleTest.toml
@@ -18,7 +18,6 @@ testTitle = 'Clogged'
     testName = 'Cycle'
     transactionsPerSecond = 2500.0
     testDuration = 10.0
-    expectedRate = 0
     keyPrefix = '\xff/TESTONLYtxnStateStore/'
 
     [[test.workload]]

--- a/tests/latency.txt
+++ b/tests/latency.txt
@@ -2,7 +2,6 @@ testTitle=CycleTest
     testName=Cycle
     transactionsPerSecond=2500.0
     testDuration=10.0
-    expectedRate=0.8
     nodeCount=50000
 
     testName=Ping

--- a/tests/rare/ChangeFeeds.toml
+++ b/tests/rare/ChangeFeeds.toml
@@ -12,7 +12,6 @@ testTitle = 'ChangeFeed'
     testName = 'Cycle'
     transactionsPerSecond = 250.0
     testDuration = 60.0
-    expectedRate = 0
 
     [[test.workload]]
     testName = 'ChangeFeeds'

--- a/tests/rare/ClogRemoteTLog.toml
+++ b/tests/rare/ClogRemoteTLog.toml
@@ -33,7 +33,6 @@ testName = 'Cycle'
 nodeCount = 30
 transactionsPerSecond = 250.0
 testDuration = 360.0
-expectedRate = 0
 
 [[test.workload]]
 testName = 'ClogRemoteTLog'

--- a/tests/rare/ClogTlog.toml
+++ b/tests/rare/ClogTlog.toml
@@ -23,7 +23,6 @@ testTitle = 'ClogTlog'
     nodeCount = 30000
     transactionsPerSecond = 2500.0
     testDuration = 60.0
-    expectedRate = 0
 
     [[test.workload]]
     testName = 'ClogTlog'

--- a/tests/rare/ClogUnclog.toml
+++ b/tests/rare/ClogUnclog.toml
@@ -5,7 +5,6 @@ testTitle = 'CloggedCycleTest'
     testName = 'Cycle'
     transactionsPerSecond = 5000.0
     testDuration = 5.0
-    expectedRate = 0
 
     [[test.workload]]
     testName = 'RandomClogging'
@@ -24,7 +23,6 @@ testTitle = 'UncloggedCycleTest'
     testName = 'Cycle'
     transactionsPerSecond = 5000.0
     testDuration = 5.0
-    expectedRate = 0.25
 
 [[test]]
 testTitle = 'CloggedCycleTest'
@@ -33,7 +31,6 @@ testTitle = 'CloggedCycleTest'
     testName = 'Cycle'
     transactionsPerSecond = 5000.0
     testDuration = 5.0
-    expectedRate = 0
 
     [[test.workload]]
     testName = 'RandomClogging'
@@ -52,4 +49,3 @@ testTitle = 'UncloggedCycleTest'
     testName = 'Cycle'
     transactionsPerSecond = 5000.0
     testDuration = 5.0
-    expectedRate = 0.25

--- a/tests/rare/CloggedCycleWithKills.toml
+++ b/tests/rare/CloggedCycleWithKills.toml
@@ -9,7 +9,6 @@ testTitle = 'CloggedCycleTestWithKills'
     testName = 'Cycle'
     transactionsPerSecond = 5000.0
     testDuration = 30.0
-    expectedRate = 0.01
 
     [[test.workload]]
     testName = 'RandomClogging'

--- a/tests/rare/CycleRollbackClogged.toml
+++ b/tests/rare/CycleRollbackClogged.toml
@@ -9,7 +9,6 @@ testTitle = 'RollbackCycleTest'
     testName = 'Cycle'
     transactionsPerSecond = 2500.0
     testDuration = 30.0
-    expectedRate = 0
 
     [[test.workload]]
     testName = 'Rollback'

--- a/tests/rare/CycleWithDeadHall.toml
+++ b/tests/rare/CycleWithDeadHall.toml
@@ -28,7 +28,6 @@ testTitle = 'Two out of Three Data Halls'
     testName = 'Cycle'
     transactionsPerSecond = 2500.0
     testDuration = 30.0
-    expectedRate = 0.01
 
     # Immediately take down a data hall.
     [[test.workload]]

--- a/tests/rare/CycleWithKills.toml
+++ b/tests/rare/CycleWithKills.toml
@@ -9,7 +9,6 @@ testTitle = 'CycleTestWithKills'
     testName = 'Cycle'
     transactionsPerSecond = 2500.0
     testDuration = 30.0
-    expectedRate = 0
 
     [[test.workload]]
     testName = 'Attrition'

--- a/tests/rare/DcLag.toml
+++ b/tests/rare/DcLag.toml
@@ -12,7 +12,6 @@ testTitle = 'DcLag'
     nodeCount = 3000
     transactionsPerSecond = 250.0
     testDuration = 200.0
-    expectedRate = 0
 
     [[test.workload]]
     testName = 'DcLag'

--- a/tests/rare/FailoverWithSSLag.toml
+++ b/tests/rare/FailoverWithSSLag.toml
@@ -12,7 +12,6 @@ testTitle = 'FailoverWithSSLag'
     nodeCount = 3000
     transactionsPerSecond = 250.0
     testDuration = 200.0
-    expectedRate = 0
 
     [[test.workload]]
     testName = 'FailoverWithSSLagWorkload'

--- a/tests/rare/ThroughputQuota.toml
+++ b/tests/rare/ThroughputQuota.toml
@@ -10,4 +10,3 @@ testTitle='ThroughputQuotaTest'
   testName = 'Cycle'
   transactionsPerSecond = 250.0
   testDuration = 30.0
-  expectedRate = 0

--- a/tests/restarting/from_7.1.0_until_7.2.0/DrUpgradeRestart-1.txt
+++ b/tests/restarting/from_7.1.0_until_7.2.0/DrUpgradeRestart-1.txt
@@ -9,7 +9,6 @@ simBackupAgents=BackupToDB
     nodeCount=30000
     transactionsPerSecond=1000.0
     testDuration=30.0
-    expectedRate=0
 
     testName=BackupToDBUpgrade
     backupAfter=10.0

--- a/tests/restarting/from_7.1.0_until_7.2.0/DrUpgradeRestart-2.txt
+++ b/tests/restarting/from_7.1.0_until_7.2.0/DrUpgradeRestart-2.txt
@@ -10,7 +10,6 @@ waitForQuiescenceBegin=false
     nodeCount=30000
     transactionsPerSecond=1000.0
     testDuration=30.0
-    expectedRate=0
 
     testName=BackupToDBUpgrade
     backupAfter=10.0

--- a/tests/restarting/from_7.1.0_until_7.2.0/SnapIncrementalRestore-1.txt
+++ b/tests/restarting/from_7.1.0_until_7.2.0/SnapIncrementalRestore-1.txt
@@ -38,7 +38,6 @@ clearAfterTest=true
     nodeCount=3000
     transactionsPerSecond=3000.0
     testDuration=10.0
-    expectedRate=0
 
     testName=IncrementalBackup
     tag=default

--- a/tests/restarting/from_7.1.0_until_7.2.0/SnapIncrementalRestore-2.txt
+++ b/tests/restarting/from_7.1.0_until_7.2.0/SnapIncrementalRestore-2.txt
@@ -17,6 +17,5 @@ checkOnly=true
     nodeCount=3000
     transactionsPerSecond=3000.0
     testDuration=10.0
-    expectedRate=0
 
     testName=SimpleAtomicAdd

--- a/tests/restarting/from_7.1.0_until_7.2.0/UpgradeAndBackupRestore-1.toml
+++ b/tests/restarting/from_7.1.0_until_7.2.0/UpgradeAndBackupRestore-1.toml
@@ -22,7 +22,6 @@ runConsistencyCheck = false
     nodeCount = 30000
     transactionsPerSecond = 2500.0
     testDuration = 30.0
-    expectedRate = 0
     keyPrefix = 'BeforeRestart'
 
     [[test.workload]]

--- a/tests/restarting/from_7.1.0_until_7.2.0/UpgradeAndBackupRestore-2.toml
+++ b/tests/restarting/from_7.1.0_until_7.2.0/UpgradeAndBackupRestore-2.toml
@@ -9,7 +9,6 @@ runConsistencyCheck=false
     nodeCount = 30000
     transactionsPerSecond = 2500.0
     testDuration = 30.0
-    expectedRate = 0
     keyPrefix = 'AfterRestart'
 
     [[test.workload]]
@@ -52,10 +51,8 @@ checkOnly=true
     testName = 'Cycle'
     nodeCount=30000
     keyPrefix = 'AfterRestart'
-    expectedRate=0
 
     [[test.workload]]
     testName = 'Cycle'
     nodeCount = 30000
     keyPrefix= 'BeforeRestart'
-    expectedRate = 0

--- a/tests/restarting/from_7.1.0_until_7.3.0/CycleTestRestart-1.txt
+++ b/tests/restarting/from_7.1.0_until_7.3.0/CycleTestRestart-1.txt
@@ -6,7 +6,6 @@ clearAfterTest=false
     transactionsPerSecond=500.0
     nodeCount=2500
     testDuration=10.0
-    expectedRate=0
 
     testName=RandomClogging
     testDuration=10.0

--- a/tests/restarting/from_7.1.0_until_7.3.0/CycleTestRestart-2.txt
+++ b/tests/restarting/from_7.1.0_until_7.3.0/CycleTestRestart-2.txt
@@ -5,7 +5,6 @@ runSetup=false
     transactionsPerSecond=2500.0
     nodeCount=2500
     testDuration=10.0
-    expectedRate=0
 
     testName=RandomClogging
     testDuration=10.0

--- a/tests/restarting/from_7.2.0_until_7.3.0/DrUpgradeRestart-1.toml
+++ b/tests/restarting/from_7.2.0_until_7.3.0/DrUpgradeRestart-1.toml
@@ -14,7 +14,6 @@ simBackupAgents = "BackupToDB"
     nodeCount = 30000
     transactionsPerSecond = 1000.0
     testDuration = 30.0
-    expectedRate = 0
 
     [[test.workload]]
     testName = "BackupToDBUpgrade"

--- a/tests/restarting/from_7.2.0_until_7.3.0/DrUpgradeRestart-2.toml
+++ b/tests/restarting/from_7.2.0_until_7.3.0/DrUpgradeRestart-2.toml
@@ -13,7 +13,6 @@ waitForQuiescenceBegin = false
     nodeCount = 30000
     transactionsPerSecond = 1000.0
     testDuration = 30.0
-    expectedRate = 0
 
     [[test.workload]]
     testName = "BackupToDBUpgrade"

--- a/tests/restarting/from_7.2.4_until_7.3.0/UpgradeAndBackupRestore-1.toml
+++ b/tests/restarting/from_7.2.4_until_7.3.0/UpgradeAndBackupRestore-1.toml
@@ -32,7 +32,6 @@ disabledFailureInjectionWorkloads = 'Attrition'
     nodeCount = 30000
     transactionsPerSecond = 2500.0
     testDuration = 30.0
-    expectedRate = 0
     keyPrefix = 'BeforeRestart'
 
     [[test.workload]]

--- a/tests/restarting/from_7.2.4_until_7.3.0/UpgradeAndBackupRestore-2.toml
+++ b/tests/restarting/from_7.2.4_until_7.3.0/UpgradeAndBackupRestore-2.toml
@@ -9,7 +9,6 @@ runConsistencyCheck=false
     nodeCount = 30000
     transactionsPerSecond = 2500.0
     testDuration = 30.0
-    expectedRate = 0
     keyPrefix = 'AfterRestart'
     
     [[test.workload]]
@@ -52,10 +51,8 @@ checkOnly=true
     testName = 'Cycle'
     nodeCount=30000
     keyPrefix = 'AfterRestart'
-    expectedRate=0
      
     [[test.workload]]
     testName = 'Cycle'
     nodeCount = 30000
     keyPrefix= 'BeforeRestart'
-    expectedRate = 0

--- a/tests/restarting/from_7.3.0/DrUpgradeRestart-1.toml
+++ b/tests/restarting/from_7.3.0/DrUpgradeRestart-1.toml
@@ -16,7 +16,6 @@ simBackupAgents = "BackupToDB"
     nodeCount = 30000
     transactionsPerSecond = 1000.0
     testDuration = 30.0
-    expectedRate = 0
 
     [[test.workload]]
     testName = "BackupToDBUpgrade"

--- a/tests/restarting/from_7.3.0/DrUpgradeRestart-2.toml
+++ b/tests/restarting/from_7.3.0/DrUpgradeRestart-2.toml
@@ -13,7 +13,6 @@ waitForQuiescenceBegin = false
     nodeCount = 30000
     transactionsPerSecond = 1000.0
     testDuration = 30.0
-    expectedRate = 0
 
     [[test.workload]]
     testName = "BackupToDBUpgrade"

--- a/tests/restarting/from_7.3.0/UpgradeAndBackupRestore-1.toml
+++ b/tests/restarting/from_7.3.0/UpgradeAndBackupRestore-1.toml
@@ -32,7 +32,6 @@ disabledFailureInjectionWorkloads = 'Attrition'
     nodeCount = 30000
     transactionsPerSecond = 2500.0
     testDuration = 30.0
-    expectedRate = 0
     keyPrefix = 'BeforeRestart'
 
     [[test.workload]]

--- a/tests/restarting/from_7.3.0/UpgradeAndBackupRestore-2.toml
+++ b/tests/restarting/from_7.3.0/UpgradeAndBackupRestore-2.toml
@@ -9,7 +9,6 @@ runConsistencyCheck=false
     nodeCount = 30000
     transactionsPerSecond = 2500.0
     testDuration = 30.0
-    expectedRate = 0
     keyPrefix = 'AfterRestart'
     
     [[test.workload]]
@@ -52,10 +51,8 @@ checkOnly=true
     testName = 'Cycle'
     nodeCount=30000
     keyPrefix = 'AfterRestart'
-    expectedRate=0
      
     [[test.workload]]
     testName = 'Cycle'
     nodeCount = 30000
     keyPrefix= 'BeforeRestart'
-    expectedRate = 0

--- a/tests/restarting/from_7.3.0/VersionVectorDisableRestart-1.toml
+++ b/tests/restarting/from_7.3.0/VersionVectorDisableRestart-1.toml
@@ -15,7 +15,6 @@ clearAfterTest=false
     transactionsPerSecond=2500.0
     nodeCount=1000
     testDuration=30.0
-    expectedRate=0
     keyPrefix = 'cycle'
 
     [[test.workload]]
@@ -23,7 +22,6 @@ clearAfterTest=false
     nodeCount = 1000
     transactionsPerSecond = 2500.0
     testDuration = 30.0
-    expectedRate = 0
     keyPrefix = '!'
 
     [[test.workload]]
@@ -31,7 +29,6 @@ clearAfterTest=false
     nodeCount = 1000
     transactionsPerSecond = 2500.0
     testDuration = 30.0
-    expectedRate = 0
     keyPrefix = 'ZZZ'
 
     [[test.workload]]

--- a/tests/restarting/from_7.3.0/VersionVectorDisableRestart-2.toml
+++ b/tests/restarting/from_7.3.0/VersionVectorDisableRestart-2.toml
@@ -11,7 +11,6 @@ runSetup=false
     transactionsPerSecond=2500.0
     nodeCount=1000
     testDuration=30.0
-    expectedRate=0
     keyPrefix = 'cycle'
 
     [[test.workload]]
@@ -19,7 +18,6 @@ runSetup=false
     nodeCount = 1000
     transactionsPerSecond = 2500.0
     testDuration = 30.0
-    expectedRate = 0
     keyPrefix = '!'
 
     [[test.workload]]
@@ -27,7 +25,6 @@ runSetup=false
     nodeCount = 1000
     transactionsPerSecond = 2500.0
     testDuration = 30.0
-    expectedRate = 0
     keyPrefix = 'ZZZ'
 
     [[test.workload]]

--- a/tests/restarting/from_7.3.0/VersionVectorEnableRestart-1.toml
+++ b/tests/restarting/from_7.3.0/VersionVectorEnableRestart-1.toml
@@ -14,7 +14,6 @@ clearAfterTest=false
     transactionsPerSecond=2500.0
     nodeCount=1000
     testDuration=30.0
-    expectedRate=0
     keyPrefix = 'cycle'
 
     [[test.workload]]
@@ -22,7 +21,6 @@ clearAfterTest=false
     nodeCount = 1000
     transactionsPerSecond = 2500.0
     testDuration = 30.0
-    expectedRate = 0
     keyPrefix = '!'
 
     [[test.workload]]
@@ -30,7 +28,6 @@ clearAfterTest=false
     nodeCount = 1000
     transactionsPerSecond = 2500.0
     testDuration = 30.0
-    expectedRate = 0
     keyPrefix = 'ZZZ'
 
     [[test.workload]]

--- a/tests/restarting/from_7.3.0/VersionVectorEnableRestart-2.toml
+++ b/tests/restarting/from_7.3.0/VersionVectorEnableRestart-2.toml
@@ -12,7 +12,6 @@ runSetup=false
     transactionsPerSecond=2500.0
     nodeCount=1000
     testDuration=30.0
-    expectedRate=0
     keyPrefix = 'cycle'
 
     [[test.workload]]
@@ -20,7 +19,6 @@ runSetup=false
     nodeCount = 1000
     transactionsPerSecond = 2500.0
     testDuration = 30.0
-    expectedRate = 0
     keyPrefix = '!'
 
     [[test.workload]]
@@ -28,7 +26,6 @@ runSetup=false
     nodeCount = 1000
     transactionsPerSecond = 2500.0
     testDuration = 30.0
-    expectedRate = 0
     keyPrefix = 'ZZZ'
 
     [[test.workload]]

--- a/tests/restarting/from_7.3.0_until_7.4.0/SnapCycleRestart-1.toml
+++ b/tests/restarting/from_7.3.0_until_7.4.0/SnapCycleRestart-1.toml
@@ -12,7 +12,6 @@ clearAfterTest=false
     transactionsPerSecond=2500.0
     nodeCount=2500
     testDuration=10.0
-    expectedRate=0
 
     [[test.workload]]
     testName="SnapTest"

--- a/tests/restarting/from_7.3.0_until_7.4.0/SnapCycleRestart-2.toml
+++ b/tests/restarting/from_7.3.0_until_7.4.0/SnapCycleRestart-2.toml
@@ -11,5 +11,4 @@ runSetup=false
     transactionsPerSecond=2500.0
     nodeCount=2500
     testDuration=10.0
-    expectedRate=0
     enableDD=true

--- a/tests/restarting/from_7.3.29/CycleTestRestart-1.toml
+++ b/tests/restarting/from_7.3.29/CycleTestRestart-1.toml
@@ -11,7 +11,6 @@ clearAfterTest=false
     transactionsPerSecond=500.0
     nodeCount=2500
     testDuration=10.0
-    expectedRate=0
 
     [[test.workload]]
     testName="RandomClogging"

--- a/tests/restarting/from_7.3.29/CycleTestRestart-2.toml
+++ b/tests/restarting/from_7.3.29/CycleTestRestart-2.toml
@@ -8,7 +8,6 @@ runSetup=false
     nodeCount=2500
     testDuration=10.0
     skipSetup=true
-    expectedRate=0
 
     [[test.workload]]
     testName="RandomClogging"

--- a/tests/restarting/from_7.3.5_until_7.3.29/CycleTestRestart-1.toml
+++ b/tests/restarting/from_7.3.5_until_7.3.29/CycleTestRestart-1.toml
@@ -14,7 +14,6 @@ clearAfterTest=false
     transactionsPerSecond=500.0
     nodeCount=2500
     testDuration=10.0
-    expectedRate=0
 
     [[test.workload]]
     testName="RandomClogging"

--- a/tests/restarting/from_7.3.5_until_7.3.29/CycleTestRestart-2.toml
+++ b/tests/restarting/from_7.3.5_until_7.3.29/CycleTestRestart-2.toml
@@ -7,7 +7,6 @@ runSetup=false
     transactionsPerSecond=2500.0
     nodeCount=2500
     testDuration=10.0
-    expectedRate=0
 
     [[test.workload]]
     testName="RandomClogging"

--- a/tests/restarting/from_7.4.0/SnapCycleRestart-1.toml
+++ b/tests/restarting/from_7.4.0/SnapCycleRestart-1.toml
@@ -15,7 +15,6 @@ clearAfterTest=false
     transactionsPerSecond=2500.0
     nodeCount=2500
     testDuration=10.0
-    expectedRate=0
 
     [[test.workload]]
     testName="SnapTest"

--- a/tests/restarting/from_7.4.0/SnapCycleRestart-2.toml
+++ b/tests/restarting/from_7.4.0/SnapCycleRestart-2.toml
@@ -11,5 +11,4 @@ runSetup=false
     transactionsPerSecond=2500.0
     nodeCount=2500
     testDuration=10.0
-    expectedRate=0
     enableDD=true

--- a/tests/restarting/to_7.1.0_until_7.2.0/CycleTestRestart-1.toml
+++ b/tests/restarting/to_7.1.0_until_7.2.0/CycleTestRestart-1.toml
@@ -21,7 +21,6 @@ clearAfterTest = false
     transactionsPerSecond = 500.0
     nodeCount = 2500
     testDuration = 10.0
-    expectedRate = 0
 
     [[test.workload]]
     testName = 'RandomClogging'

--- a/tests/restarting/to_7.1.0_until_7.2.0/CycleTestRestart-2.toml
+++ b/tests/restarting/to_7.1.0_until_7.2.0/CycleTestRestart-2.toml
@@ -12,7 +12,6 @@ runSetup = false
     transactionsPerSecond = 2500.0
     nodeCount = 2500
     testDuration = 10.0
-    expectedRate = 0
 
     [[test.workload]]
     testName = 'RandomClogging'

--- a/tests/restarting/to_7.3.0_until_7.3.51/CycleTestRestart-1.toml
+++ b/tests/restarting/to_7.3.0_until_7.3.51/CycleTestRestart-1.toml
@@ -21,7 +21,6 @@ clearAfterTest = false
     transactionsPerSecond = 500.0
     nodeCount = 2500
     testDuration = 10.0
-    expectedRate = 0
 
     [[test.workload]]
     testName = 'RandomClogging'

--- a/tests/restarting/to_7.3.0_until_7.3.51/CycleTestRestart-2.toml
+++ b/tests/restarting/to_7.3.0_until_7.3.51/CycleTestRestart-2.toml
@@ -20,7 +20,6 @@ runSetup = false
     transactionsPerSecond = 2500.0
     nodeCount = 2500
     testDuration = 10.0
-    expectedRate = 0
 
     [[test.workload]]
     testName = 'RandomClogging'

--- a/tests/restarting/to_7.3.51_until_7.4.0/CycleTestRestart-1.toml
+++ b/tests/restarting/to_7.3.51_until_7.4.0/CycleTestRestart-1.toml
@@ -13,7 +13,6 @@ clearAfterTest = false
     transactionsPerSecond = 500.0
     nodeCount = 2500
     testDuration = 10.0
-    expectedRate = 0
 
     [[test.workload]]
     testName = 'RandomClogging'

--- a/tests/restarting/to_7.3.51_until_7.4.0/CycleTestRestart-2.toml
+++ b/tests/restarting/to_7.3.51_until_7.4.0/CycleTestRestart-2.toml
@@ -17,7 +17,6 @@ runSetup = false
     transactionsPerSecond = 2500.0
     nodeCount = 2500
     testDuration = 10.0
-    expectedRate = 0
 
     [[test.workload]]
     testName = 'RandomClogging'

--- a/tests/restarting/to_7.4.0/CycleTestRestart-1.toml
+++ b/tests/restarting/to_7.4.0/CycleTestRestart-1.toml
@@ -12,7 +12,6 @@ clearAfterTest = false
     transactionsPerSecond = 500.0
     nodeCount = 2500
     testDuration = 10.0
-    expectedRate = 0
 
     [[test.workload]]
     testName = 'RandomClogging'

--- a/tests/restarting/to_7.4.0/CycleTestRestart-2.toml
+++ b/tests/restarting/to_7.4.0/CycleTestRestart-2.toml
@@ -17,7 +17,6 @@ runSetup = false
     skipSetup = true
     nodeCount = 2500
     testDuration = 10.0
-    expectedRate = 0
 
     [[test.workload]]
     testName = 'RandomClogging'

--- a/tests/slow/BackupAndRestore.toml
+++ b/tests/slow/BackupAndRestore.toml
@@ -16,7 +16,6 @@ simBackupAgents = 'BackupToFile'
     nodeCount = 3000
     transactionsPerSecond = 2500.0
     testDuration = 30.0
-    expectedRate = 0
 
     [[test.workload]]
     testName = 'Backup'
@@ -44,4 +43,3 @@ testTitle = 'CycleAfterRestore'
     transactionsPerSecond = 2500.0
     testDuration = 10.0
     skipSetup = true
-    expectedRate = 0

--- a/tests/slow/BackupCorrectnessPartitioned.toml
+++ b/tests/slow/BackupCorrectnessPartitioned.toml
@@ -14,7 +14,6 @@ simBackupAgents = 'BackupToFile'
     nodeCount = 3000
     transactionsPerSecond = 2500.0
     testDuration = 30.0
-    expectedRate = 0
 
     [[test.workload]]
     testName = 'BackupAndRestorePartitionedCorrectness'

--- a/tests/slow/BackupNewAndOldRestore.toml
+++ b/tests/slow/BackupNewAndOldRestore.toml
@@ -14,7 +14,6 @@ simBackupAgents = 'BackupToFile'
     nodeCount = 3000
     transactionsPerSecond = 2500.0
     testDuration = 30.0
-    expectedRate = 0
 
     [[test.workload]]
     testName = 'Backup'
@@ -36,7 +35,6 @@ simBackupAgents = 'BackupToFile'
     transactionsPerSecond = 2500.0
     testDuration = 30.0
     skipSetup = true
-    expectedRate = 0
 
     [[test.workload]]
     testName = 'Backup'
@@ -68,4 +66,3 @@ testTitle = 'CycleAfterRestore'
     transactionsPerSecond = 2500.0
     testDuration = 10.0
     skipSetup = true
-    expectedRate = 0

--- a/tests/slow/BackupOldAndNewRestore.toml
+++ b/tests/slow/BackupOldAndNewRestore.toml
@@ -16,7 +16,6 @@ simBackupAgents = 'BackupToFile'
     nodeCount = 3000
     transactionsPerSecond = 2500.0
     testDuration = 30.0
-    expectedRate = 0
 
     [[test.workload]]
     testName = 'Backup'
@@ -38,7 +37,6 @@ simBackupAgents = 'BackupToFile'
     transactionsPerSecond = 2500.0
     testDuration = 30.0
     skipSetup = true
-    expectedRate = 0
 
     [[test.workload]]
     testName = 'Backup'
@@ -70,4 +68,3 @@ testTitle = 'CycleAfterRestore'
     transactionsPerSecond = 2500.0
     testDuration = 10.0
     skipSetup = true
-    expectedRate = 0

--- a/tests/slow/ClogWithRollbacks.toml
+++ b/tests/slow/ClogWithRollbacks.toml
@@ -5,7 +5,6 @@ testTitle = 'CloggedCycleTest'
     testName = 'Cycle'
     transactionsPerSecond = 5000.0
     testDuration = 5.0
-    expectedRate = 0
 
     [[test.workload]]
     testName = 'RandomClogging'
@@ -38,7 +37,6 @@ testTitle = 'UncloggedRollbackCycleTest'
     testName = 'Cycle'
     transactionsPerSecond = 5000.0
     testDuration = 5.0
-    expectedRate = 0
 
     [[test.workload]]
     testName = 'Rollback'
@@ -52,7 +50,6 @@ testTitle = 'CloggedRollbackCycleTest'
     testName = 'Cycle'
     transactionsPerSecond = 5000.0
     testDuration = 5.0
-    expectedRate = 0
 
     [[test.workload]]
     testName = 'RandomClogging'
@@ -90,4 +87,3 @@ testTitle = 'UncloggedCycleTest'
     testName = 'Cycle'
     transactionsPerSecond = 5000.0
     testDuration = 10.0
-    expectedRate = 0.3

--- a/tests/slow/CloggedCycleTest.toml
+++ b/tests/slow/CloggedCycleTest.toml
@@ -5,7 +5,6 @@ testTitle = 'CloggedCycleTest'
     testName = 'Cycle'
     transactionsPerSecond = 1250.0
     testDuration = 30.0
-    expectedRate = 0.005
 
     [[test.workload]]
     testName = 'RandomClogging'

--- a/tests/slow/CycleRollbackPlain.toml
+++ b/tests/slow/CycleRollbackPlain.toml
@@ -5,7 +5,6 @@ testTitle = 'UncloggedRollbackCycleTest'
     testName = 'Cycle'
     transactionsPerSecond = 5000.0
     testDuration = 30.0
-    expectedRate = 0.05
 
     [[test.workload]]
     testName = 'Rollback'

--- a/tests/slow/DiskFailureCycle.toml
+++ b/tests/slow/DiskFailureCycle.toml
@@ -13,7 +13,6 @@ testTitle = 'DiskFailureCycle'
     testName = 'Cycle'
     transactionsPerSecond = 2500.0
     testDuration = 30.0
-    expectedRate = 0
 
     [[test.workload]]
     testName = 'DiskFailureInjection'

--- a/tests/slow/GcGenerations.toml
+++ b/tests/slow/GcGenerations.toml
@@ -22,7 +22,6 @@ testTitle = 'GcGenerations'
     nodeCount = 3000
     transactionsPerSecond = 250.0
     testDuration = 300.0
-    expectedRate = 0
 
     [[test.workload]]
     testName = 'GcGenerations'

--- a/tests/slow/LongRunning.toml
+++ b/tests/slow/LongRunning.toml
@@ -8,7 +8,6 @@ testTitle = 'CycleTestWithKills'
     testName = 'Cycle'
     transactionsPerSecond = 2500.0
     testDuration = 10000.0
-    expectedRate = 0
 
     [[test.workload]]
     testName = 'Attrition'

--- a/tests/slow/LowLatencyWithFailures.toml
+++ b/tests/slow/LowLatencyWithFailures.toml
@@ -9,7 +9,6 @@ connectionFailuresDisableDuration = 60
     testName = 'Cycle'
     transactionsPerSecond = 1000.0
     testDuration = 300.0
-    expectedRate = 0
 
     [[test.workload]]
     testName = 'LowLatency'

--- a/tests/slow/ParallelRestoreNewBackupCorrectnessCycle.toml
+++ b/tests/slow/ParallelRestoreNewBackupCorrectnessCycle.toml
@@ -16,7 +16,6 @@ timeout = 360000
     #    transactionsPerSecond=500.0
     transactionsPerSecond = 2500.0
     testDuration = 30.0
-    expectedRate = 0
     #	keyPrefix=!
     # Each testName=RunRestoreWorkerWorkload creates a restore worker
     # We need at least 3 restore workers: master, loader, and applier

--- a/tests/slow/ParallelRestoreNewBackupCorrectnessMultiCycles.toml
+++ b/tests/slow/ParallelRestoreNewBackupCorrectnessMultiCycles.toml
@@ -15,7 +15,6 @@ timeout = 360000
     nodeCount = 1000
     transactionsPerSecond = 2500.0
     testDuration = 30.0
-    expectedRate = 0
     keyPrefix = '!'
 
     [[test.workload]]
@@ -23,7 +22,6 @@ timeout = 360000
     nodeCount = 1000
     transactionsPerSecond = 2500.0
     testDuration = 30.0
-    expectedRate = 0
     keyPrefix = 'z'
 
     [[test.workload]]
@@ -31,7 +29,6 @@ timeout = 360000
     nodeCount = 1000
     transactionsPerSecond = 2500.0
     testDuration = 30.0
-    expectedRate = 0
     keyPrefix = 'A'
 
     [[test.workload]]
@@ -39,7 +36,6 @@ timeout = 360000
     nodeCount = 1000
     transactionsPerSecond = 2500.0
     testDuration = 30.0
-    expectedRate = 0
     keyPrefix = 'Z'
     # Each testName=RunRestoreWorkerWorkload creates a restore worker
     # We need at least 3 restore workers: master, loader, and applier

--- a/tests/slow/ParallelRestoreOldBackupCorrectnessCycle.toml
+++ b/tests/slow/ParallelRestoreOldBackupCorrectnessCycle.toml
@@ -16,7 +16,6 @@ timeout = 360000
     #    transactionsPerSecond=500.0
     transactionsPerSecond = 2500.0
     testDuration = 30.0
-    expectedRate = 0
     #	keyPrefix=!
     # Each testName=RunRestoreWorkerWorkload creates a restore worker
     # We need at least 3 restore workers: master, loader, and applier

--- a/tests/slow/ParallelRestoreOldBackupCorrectnessMultiCycles.toml
+++ b/tests/slow/ParallelRestoreOldBackupCorrectnessMultiCycles.toml
@@ -15,7 +15,6 @@ timeout = 360000
     nodeCount = 1000
     transactionsPerSecond = 2500.0
     testDuration = 30.0
-    expectedRate = 0
     keyPrefix = '!'
 
     [[test.workload]]
@@ -23,7 +22,6 @@ timeout = 360000
     nodeCount = 1000
     transactionsPerSecond = 2500.0
     testDuration = 30.0
-    expectedRate = 0
     keyPrefix = 'z'
 
     [[test.workload]]
@@ -31,7 +29,6 @@ timeout = 360000
     nodeCount = 1000
     transactionsPerSecond = 2500.0
     testDuration = 30.0
-    expectedRate = 0
     keyPrefix = 'A'
 
     [[test.workload]]
@@ -39,7 +36,6 @@ timeout = 360000
     nodeCount = 1000
     transactionsPerSecond = 2500.0
     testDuration = 30.0
-    expectedRate = 0
     keyPrefix = 'Z'
     # Each testName=RunRestoreWorkerWorkload creates a restore worker
     # We need at least 3 restore workers: master, loader, and applier

--- a/tests/slow/SharedBackupCorrectness.toml
+++ b/tests/slow/SharedBackupCorrectness.toml
@@ -13,7 +13,6 @@ simBackupAgents = 'BackupToFileAndDB'
     nodeCount = 3000
     transactionsPerSecond = 500.0
     testDuration = 30.0
-    expectedRate = 0
 
     [[test.workload]]
     testName = 'BackupAndRestoreCorrectness'

--- a/tests/slow/SharedBackupToDBCorrectness.toml
+++ b/tests/slow/SharedBackupToDBCorrectness.toml
@@ -13,7 +13,6 @@ simBackupAgents = 'BackupToFileAndDB'
     nodeCount = 3000
     transactionsPerSecond = 500.0
     testDuration = 30.0
-    expectedRate = 0
 
     [[test.workload]]
     testName = 'BackupAndRestoreCorrectness'

--- a/tests/slow/SharedDefaultBackupCorrectness.toml
+++ b/tests/slow/SharedDefaultBackupCorrectness.toml
@@ -13,7 +13,6 @@ simBackupAgents = 'BackupToFileAndDB'
     nodeCount = 3000
     transactionsPerSecond = 500.0
     testDuration = 30.0
-    expectedRate = 0
 
     [[test.workload]]
     testName = 'BackupAndRestoreCorrectness'

--- a/tests/slow/SwizzledCycleTest.toml
+++ b/tests/slow/SwizzledCycleTest.toml
@@ -5,7 +5,6 @@ testTitle = 'SwizzledCycleTest'
     testName = 'Cycle'
     transactionsPerSecond = 5000.0
     testDuration = 30.0
-    expectedRate = 0.01
 
     [[test.workload]]
     testName = 'RandomClogging'

--- a/tests/slow/SwizzledRollbackTimeLapse.toml
+++ b/tests/slow/SwizzledRollbackTimeLapse.toml
@@ -6,7 +6,6 @@ testTitle = 'SwizzledRollbackTimeLapse'
     transactionsPerSecond = 500.0
     testDuration = 300.0
     nodeCount = 10000
-    expectedRate = 0.0
 
     [[test.workload]]
     testName = 'RandomClogging'


### PR DESCRIPTION
I ran into a failure from this while preparing PR #13411.

Testing in progress:

  20260629-220454-gglass-5fbf451921b8b3e5            compressed=True data_size=41551852 duration=814445 ended=25029 fail_fast=10 max_runs=100000 pass=25029 priority=100 remaining=0:24:27 runtime=0:08:10 sanity=False started=30025 submitted=20260629-220454 timeout=5400 username=gglass
