### PR TITLE
Disable large teams in upgrade backup restore test

### DIFF
--- a/tests/restarting/from_7.3.0/UpgradeAndBackupRestore-1.toml
+++ b/tests/restarting/from_7.3.0/UpgradeAndBackupRestore-1.toml
@@ -1,3 +1,6 @@
+[[knobs]]
+dd_max_shards_on_large_teams = 0
+
 [configuration]
 storageEngineExcludeTypes=[3,5]
 tenantModes=['disabled']

--- a/tests/restarting/from_7.3.0/UpgradeAndBackupRestore-2.toml
+++ b/tests/restarting/from_7.3.0/UpgradeAndBackupRestore-2.toml
@@ -1,3 +1,6 @@
+[[knobs]]
+dd_max_shards_on_large_teams = 0
+
 [configuration]
 storageEngineExcludeTypes=[3,5]
 


### PR DESCRIPTION
`UpgradeAndBackupRestore` intentionally drives the cluster down to three machines during its restart phases. With large teams enabled, Data Distribution can fail to quiesce in that topology, leaving `DataDistributionQueueSize` nonzero until `QuietDatabase.cpp:814` times out.

This PR sets `dd_max_shards_on_large_teams = 0` in both halves of the `from_7.3.0/UpgradeAndBackupRestore` restart test. This follows the existing `ExcludeIncludeStorageServers` precedent and keeps the test focused on upgrade, backup, and restore behavior rather than large-team recovery under severe attrition.

## Testing

- Reproduced the exact two-phase failure with official `fdbserver-7.3.43`; phase 2 failed at sim time `3143.528`
- Confirmed the same failure on clean `origin/main`, establishing it as pre-existing.
- Replayed the exact tuple after this change; both phases passed and phase 2 quiesced at sim time `651.021`.
- Ran 100k unfiltered Joshua tests
