### PR TITLE
Add coordination between Backupagent and Backupworkers for V3

### DIFF
--- a/fdbclient/FileBackupAgent.cpp
+++ b/fdbclient/FileBackupAgent.cpp
@@ -3894,7 +3894,33 @@ struct StartFullBackupTaskFunc : BackupTaskFuncBase {
 			}
 		}
 
-		// Get start version after backup worker are enabled
+		// Request the PartitionMap before reading the backup's start version, so the PartitionMap is more likely
+		// to be committed first. backupPartitionListKey absent = no PartitionMap exists yet on this cluster.
+		while (true) {
+			Error err;
+			try {
+				tr->reset();
+				tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+				tr->setOption(FDBTransactionOptions::LOCK_AWARE);
+
+				Future<Optional<MutationLogType>> mlt = config.mutationLogType().get(tr);
+				Future<Optional<Value>> partitionList = tr->get(backupPartitionListKey);
+				co_await (success(mlt) && success(partitionList));
+
+				if (mlt.get().present() && mlt.get().get() == MutationLogType::RANGE_PARTITIONED_LOG &&
+				    !partitionList.get().present()) {
+					tr->set(backupPartitionRequiredKey, backupPartitionRequiredValue(1));
+					co_await tr->commit();
+				}
+				break;
+			} catch (Error& e) {
+				err = e;
+			}
+			co_await tr->onError(err);
+		}
+
+		// Get a start version to pass as backup's start version in UID of backup in backupStartedKey after backup
+		// workers are enabled.
 		while (true) {
 			Error err;
 			try {
@@ -3912,7 +3938,37 @@ struct StartFullBackupTaskFunc : BackupTaskFuncBase {
 			co_await tr->onError(err);
 		}
 
-		// Set the "backupStartedKey" and wait for all backup worker started
+		// Coordinate between BackupAgent and BackupWorkers using two paired keys, so neither gets stuck if a watch is
+		// silently lost.
+		//
+		//   - backupStartedKey: BackupAgent writes the new UID; BackupWorkers watch this key. Tells workers a new
+		//   backup exists.
+		//   - BackupConfig(uid).allWorkerStarted: workers set this once they've all registered the backup; BackupAgent
+		//   watches it. Tells BackupAgent it's safe to snapshot.
+		//
+		// Why both are needed: each side needs to know the other has acted before proceeding. If only one key existed,
+		// a lost watch on EITHER side would leave one party stuck — BackupAgent snapshotting too early (worker hasn't
+		// registered yet -> gap, backup not restorable) or BackupAgent never snapshotting (worker registered but
+		// BackupAgent has no signal). With both keys, each side has a separate signal it can poll/retry, so a lost
+		// watch only delays progress, never breaks it.
+		//
+		// Watch-loss recovery:
+		//   (1) Worker misses its watch on backupStartedKey:
+		//       Workers never register the backup, so allWorkerStarted is never set.
+		//       BackupAgent's task times out, gets reassigned, re-reads backupStartedKey, keeps
+		//       the original version and waits again.
+		//
+		//   (2) BackupAgent misses its watch on allWorkerStarted:
+		//       Workers already set the key, but BackupAgent stays parked. Task times out and
+		//       retries; the new exec finds allWorkerStarted already true, skips the watch, and
+		//       the snapshot reads at the cluster's current version when it actually runs.
+		//
+		// beginVersion (stored in backupStartedKey) stays the same across retries — it's a
+		// logical marker, not where the snapshot reads. The snapshot task does its own
+		// getReadVersion() when it runs, so the actual snapshot version moves forward across
+		// retries. Restorability depends on the snapshot version: by the time the snapshot
+		// runs, workers have already registered the backup and their mutation logs cover the
+		// snapshot's range, so the backup is restorable.
 		tr->reset();
 		while (true) {
 			Future<Void> watchFuture;
@@ -3936,11 +3992,7 @@ struct StartFullBackupTaskFunc : BackupTaskFuncBase {
 					ids = decodeBackupStartedValue(started.get().get());
 				}
 
-				// First range-partitioned backup on this cluster: ask DD to compute the partition list.
-				if (ids.empty() && mutationLogType.get().get() == MutationLogType::RANGE_PARTITIONED_LOG) {
-					tr->set(backupPartitionRequiredKey, backupPartitionRequiredValue(1));
-				}
-
+				// Add this backup's UID and start version to backupStartedKey.
 				const UID uid = config.getUid();
 				auto it = std::find_if(
 				    ids.begin(), ids.end(), [uid](const std::pair<UID, Version>& p) { return p.first == uid; });
@@ -3949,21 +4001,16 @@ struct StartFullBackupTaskFunc : BackupTaskFuncBase {
 				} else {
 					Params.beginVersion().set(task, it->second);
 				}
-
 				tr->set(backupStartedKey, encodeBackupStartedValue(ids));
 
-				// Only PartitionedLog workers set BackupConfig.allWorkerStarted, so watch it for that mutation log
-				// type.
-				const bool isPartitionedLog = mutationLogType.get().get() == MutationLogType::PARTITIONED_LOG;
-
 				// The task may be restarted. Set the watch if started key has NOT been set.
-				if (isPartitionedLog && !taskStarted.get().present()) {
+				if (!taskStarted.get().present()) {
 					watchFuture = tr->watch(config.allWorkerStarted().key);
 				}
 
 				co_await keepRunning;
 				co_await tr->commit();
-				if (isPartitionedLog && !taskStarted.get().present()) {
+				if (!taskStarted.get().present()) {
 					co_await watchFuture;
 				}
 				co_return;

--- a/fdbclient/FileBackupAgent.cpp
+++ b/fdbclient/FileBackupAgent.cpp
@@ -3894,29 +3894,34 @@ struct StartFullBackupTaskFunc : BackupTaskFuncBase {
 			}
 		}
 
-		// Request the PartitionMap before reading the backup's start version, so the PartitionMap is more likely
-		// to be committed first. backupPartitionListKey absent = no PartitionMap exists yet on this cluster.
-		while (true) {
-			Error err;
-			try {
-				tr->reset();
-				tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
-				tr->setOption(FDBTransactionOptions::LOCK_AWARE);
+		// Wait for backupPartitionListKey to appear before reading the backup's start version. Not strictly
+		// required for restore correctness (restore uses snapshotBeginVersion, which is set later in _finish
+		// via initNewSnapshot; by then workers are up via backupStartedKey/allWorkerStarted coordination, so
+		// snapshotBeginVersion >= PartitionMap version). But this keeps Params.beginVersion in backupStartedKey
+		// honest about when workers actually start capturing mutations.
+		if (mutationLogType.get().present() && mutationLogType.get().get() == MutationLogType::RANGE_PARTITIONED_LOG) {
+			while (true) {
+				Error err;
+				Future<Void> watchFuture;
+				try {
+					tr->reset();
+					tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+					tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 
-				Future<Optional<MutationLogType>> mlt = config.mutationLogType().get(tr);
-				Future<Optional<Value>> partitionList = tr->get(backupPartitionListKey);
-				co_await (success(mlt) && success(partitionList));
+					Optional<Value> partitionList = co_await tr->get(backupPartitionListKey);
+					if (partitionList.present()) {
+						break;
+					}
 
-				if (mlt.get().present() && mlt.get().get() == MutationLogType::RANGE_PARTITIONED_LOG &&
-				    !partitionList.get().present()) {
 					tr->set(backupPartitionRequiredKey, backupPartitionRequiredValue(1));
+					watchFuture = tr->watch(backupPartitionListKey);
 					co_await tr->commit();
+					co_await watchFuture;
+				} catch (Error& e) {
+					err = e;
 				}
-				break;
-			} catch (Error& e) {
-				err = e;
+				co_await tr->onError(err);
 			}
-			co_await tr->onError(err);
 		}
 
 		// Get a start version to pass as backup's start version in UID of backup in backupStartedKey after backup

--- a/fdbserver/backupworker/RangePartitionedBackupWorker.cpp
+++ b/fdbserver/backupworker/RangePartitionedBackupWorker.cpp
@@ -129,7 +129,7 @@ struct RangePartitionedBackupData {
 		// StartFullBackupTaskFunc::_execute is blocked on (in FileBackupAgent.cpp), letting BackupAgent proceed with
 		// the snapshot. See StartFullBackupTaskFunc::_execute for the full handshake (why both keys are needed,
 		// watch-loss recovery, idempotency on retry).
-		static Future<Void> _updateStartedWorkers(PerBackupInfo* info, BackupRangePartitionedData* self, UID uid) {
+		static Future<Void> _updateStartedWorkers(PerBackupInfo* info, RangePartitionedBackupData* self, UID uid) {
 			BackupConfig config(uid);
 			Future<Void> watchFuture;
 			bool updated = false;

--- a/fdbserver/backupworker/RangePartitionedBackupWorker.cpp
+++ b/fdbserver/backupworker/RangePartitionedBackupWorker.cpp
@@ -103,6 +103,10 @@ struct RangePartitionedBackupData {
 			BackupConfig config(uid);
 			container = config.backupContainer().get(data->cx.getReference());
 			ranges = config.backupRanges().get(data->cx.getReference());
+			if (self->backupEpoch == self->recruitedEpoch) {
+				// Only current epoch's worker update the number of backup workers.
+				updateWorker = _updateStartedWorkers(this, data, uid);
+			}
 			TraceEvent("RangePartitionedBWAddBackup", data->myId).detail("BackupID", uid).detail("Version", v);
 		}
 
@@ -113,13 +117,102 @@ struct RangePartitionedBackupData {
 		Version startVersion = invalidVersion;
 		// The next log's begin version.
 		Version nextFileBeginVersion = invalidVersion;
+		Future<Void> updateWorker;
 
 		bool isBackupReady() const { return container.isReady() && ranges.isReady(); }
 
 		Future<Void> waitBackupReady() { co_await (success(container) && success(ranges)); }
+
+		// Each backup worker writes (epoch, tag.id) into BackupConfig(uid).startedBackupWorkers to announce it has
+		// registered the backup. Worker 0 watches the key, and once all expected workers for the current epoch have
+		// written, sets BackupConfig(uid).allWorkerStarted = true. That flips the watch
+		// StartFullBackupTaskFunc::_execute is blocked on (in FileBackupAgent.cpp), letting BackupAgent proceed with
+		// the snapshot. See StartFullBackupTaskFunc::_execute for the full handshake (why both keys are needed,
+		// watch-loss recovery, idempotency on retry).
+		static Future<Void> _updateStartedWorkers(PerBackupInfo* info, BackupRangePartitionedData* self, UID uid) {
+			BackupConfig config(uid);
+			Future<Void> watchFuture;
+			bool updated = false;
+			const bool firstWorker = info->self->tag.id == 0;
+			bool allUpdated = false;
+			Optional<std::vector<std::pair<int64_t, int64_t>>> workers;
+			Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(self->cx));
+
+			while (true) {
+				Error err;
+				try {
+					tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+					tr->setOption(FDBTransactionOptions::LOCK_AWARE);
+					tr->setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
+
+					workers = co_await config.startedBackupWorkers().get(tr);
+					if (!updated) {
+						if (workers.present()) {
+							workers.get().emplace_back(self->recruitedEpoch, (int64_t)self->tag.id);
+						} else {
+							std::vector<std::pair<int64_t, int64_t>> v(1, { self->recruitedEpoch, self->tag.id });
+							workers = Optional<std::vector<std::pair<int64_t, int64_t>>>(v);
+						}
+					}
+
+					if (firstWorker) {
+						if (!workers.present()) {
+							TraceEvent("RangePartitionedBWDetectAbortedJob", self->myId).detail("BackupID", uid);
+							co_return;
+						}
+						ASSERT(workers.present() && !workers.get().empty());
+						auto& v = workers.get();
+						v.erase(std::remove_if(v.begin(),
+						                       v.end(),
+						                       [epoch = self->recruitedEpoch](const std::pair<int64_t, int64_t>& p) {
+							                       return p.first != epoch;
+						                       }),
+						        v.end());
+						std::set<int64_t> tags;
+						for (const auto& p : v) {
+							tags.insert(p.second);
+						}
+						if (self->totalTags == tags.size()) {
+							config.allWorkerStarted().set(tr, true);
+							allUpdated = true;
+						} else {
+							// Monitor all workers' updates.
+							watchFuture = tr->watch(config.startedBackupWorkers().key);
+						}
+						ASSERT(workers.present() && !workers.get().empty());
+						if (!updated) {
+							config.startedBackupWorkers().set(tr, workers.get());
+						}
+						for (const auto& p : workers.get()) {
+							TraceEvent("RangePartitionedBWDebugTag", self->myId)
+							    .detail("Epoch", p.first)
+							    .detail("TagID", p.second);
+						}
+						co_await tr->commit();
+
+						updated = true; // Only set to true after commit.
+						if (allUpdated) {
+							break;
+						}
+						co_await watchFuture;
+						tr->reset();
+						continue;
+					} else {
+						ASSERT(workers.present() && !workers.get().empty());
+						config.startedBackupWorkers().set(tr, workers.get());
+						co_await tr->commit();
+						break;
+					}
+				} catch (Error& e) {
+					err = e;
+					allUpdated = false;
+				}
+				co_await tr->onError(err);
+			}
+			TraceEvent("RangePartitionedBWSetReady", self->myId).detail("BackupID", uid).detail("TagId", self->tag.id);
+		}
 	};
 
-	// TODO akanksha: Add backups in this map when backup worker receives backup request.
 	std::unordered_map<UID, PerBackupInfo> backups; // Backup UID to infos
 
 	explicit RangePartitionedBackupData(UID id,
@@ -1013,15 +1106,21 @@ Future<Void> setBackupKeys(RangePartitionedBackupData* self, std::map<UID, Versi
 			tr->setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
 
 			std::vector<Future<Optional<Version>>> prevBackupWorkerSavedVersions;
+			std::vector<Future<Optional<bool>>> allWorkersReady;
 			std::vector<BackupConfig> versionConfigs;
 			for (const auto& [uid, version] : savedLogVersions) {
 				BackupConfig config(uid);
 				versionConfigs.emplace_back(config);
 				prevBackupWorkerSavedVersions.push_back(config.latestBackupWorkerSavedVersion().get(tr));
+				allWorkersReady.push_back(config.allWorkerStarted().get(tr));
 			}
-			co_await waitForAll(prevBackupWorkerSavedVersions);
+			co_await (waitForAll(prevBackupWorkerSavedVersions) && waitForAll(allWorkersReady));
 
 			for (int i = 0; i < prevBackupWorkerSavedVersions.size(); i++) {
+				// Skip backups where not all workers have ack'd registration yet.
+				if (!allWorkersReady[i].get().present() || !allWorkersReady[i].get().get()) {
+					continue;
+				}
 				const Version current = savedLogVersions[versionConfigs[i].getUid()];
 				if (prevBackupWorkerSavedVersions[i].get().present()) {
 					const Version prev = prevBackupWorkerSavedVersions[i].get().get();

--- a/fdbserver/datadistributor/DataDistribution.cpp
+++ b/fdbserver/datadistributor/DataDistribution.cpp
@@ -400,12 +400,13 @@ Future<Void> monitorBackupPartitionRequired(Database cx, KeyRangeMap<ShardTracke
 						tr.set(backupPartitionListKey, encodeBackupPartitionListValue(partitions));
 						tr.clear(backupPartitionRequiredKey);
 						co_await tr.commit();
-						TraceEvent("DDBackupPartitionsComputed", ddId).detail("NumPartitions", partitions.size());
+						TraceEvent("RangePartitionedBWPartitionsComputedByDD", ddId)
+						    .detail("NumPartitions", partitions.size());
 					} else {
 						tr.clear(backupPartitionListKey);
 						tr.clear(backupPartitionRequiredKey);
 						co_await tr.commit();
-						TraceEvent("DDBackupPartitionsCleared", ddId);
+						TraceEvent("RangePartitionedBWPartitionsClearedByDD", ddId);
 					}
 					break;
 				} catch (Error& e) {


### PR DESCRIPTION
### Summary
  - BackupAgent and range-partitioned BackupWorkers now confirm each other are ready before backup starts. BackupAgent writes `backupStartedKey`, workers write back to `allWorkerStarted` once they've registered. If either side's watch is lost, the other side retries instead of getting stuck.
  - BackupAgent asks for the PartitionMap first, then reads the backup's start version. This gives DD and CP a head start so the PartitionMap is usually ready by the time we pick the start version. Skipped if a range-partitioned backup is already running.
  - Renamed two DD trace events to use the `RangePartitionedBW` prefix.