### PR TITLE
(Backport to 7.4): DD finishMoveKeys: move waitForShardReady outside transaction (#13364)

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -870,7 +870,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( TRACK_TLOG_RECOVERY,                                  true ); if ( randomize && BUGGIFY ) TRACK_TLOG_RECOVERY = deterministicRandom()->coinflip();
 
 	//Move Keys
-	init( SHARD_READY_DELAY,                                    0.25 );
+	init( SHARD_READY_DELAY,                                    0.25 ); if( randomize && BUGGIFY ) SHARD_READY_DELAY = 5.0;
 	init( SERVER_READY_QUORUM_INTERVAL,                         std::min(1.0, std::min(MAX_READ_TRANSACTION_LIFE_VERSIONS, MAX_WRITE_TRANSACTION_LIFE_VERSIONS)/(5.0*VERSIONS_PER_SECOND)) );
 	init( SERVER_READY_QUORUM_TIMEOUT,                          15.0 ); if( randomize && BUGGIFY ) SERVER_READY_QUORUM_TIMEOUT = 1.0;
 	init( REMOVE_RETRY_DELAY,                                    1.0 );

--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -873,7 +873,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( TRACK_TLOG_RECOVERY,                                  true ); if ( randomize && BUGGIFY ) TRACK_TLOG_RECOVERY = deterministicRandom()->coinflip();
 
 	//Move Keys
-	init( SHARD_READY_DELAY,                                    0.25 );
+	init( SHARD_READY_DELAY,                                    0.25 ); if( randomize && BUGGIFY ) SHARD_READY_DELAY = 5.0;
 	init( SERVER_READY_QUORUM_INTERVAL,                         std::min(1.0, std::min(MAX_READ_TRANSACTION_LIFE_VERSIONS, MAX_WRITE_TRANSACTION_LIFE_VERSIONS)/(5.0*VERSIONS_PER_SECOND)) );
 	init( SERVER_READY_QUORUM_TIMEOUT,                          15.0 ); if( randomize && BUGGIFY ) SERVER_READY_QUORUM_TIMEOUT = 1.0;
 	init( REMOVE_RETRY_DELAY,                                    1.0 );

--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -878,7 +878,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( SERVER_READY_QUORUM_TIMEOUT,                          15.0 ); if( randomize && BUGGIFY ) SERVER_READY_QUORUM_TIMEOUT = 1.0;
 	init( REMOVE_RETRY_DELAY,                                    1.0 );
 	init( MOVE_KEYS_KRM_LIMIT,                                  2000 ); if( randomize && BUGGIFY ) MOVE_KEYS_KRM_LIMIT = 2;
-	init( FINISH_MOVE_KEYS_MAX_RETRIES,                           50 ); // ~4 min total with exponential backoff (0.2s to 5s cap)
+	init( FINISH_MOVE_KEYS_MAX_RETRIES,                           50 ); if( randomize && BUGGIFY ) FINISH_MOVE_KEYS_MAX_RETRIES = 10; // ~4 min total with exponential backoff (0.2s to 5s cap); ~31s buggified
 	init( START_MOVE_KEYS_MAX_RETRIES,                            50 ); if( randomize && BUGGIFY ) START_MOVE_KEYS_MAX_RETRIES = 10;
 	init( MOVE_KEYS_KRM_LIMIT_BYTES,                             1e5 ); if( randomize && BUGGIFY ) MOVE_KEYS_KRM_LIMIT_BYTES = 5e4; //This must be sufficiently larger than CLIENT_KNOBS->KEY_SIZE_LIMIT (fdbclient/Knobs.h) to ensure that at least two entries will be returned from an attempt to read a key range map
 	init( MOVE_SHARD_KRM_ROW_LIMIT,                            20000 );

--- a/fdbclient/include/fdbclient/SystemData.h
+++ b/fdbclient/include/fdbclient/SystemData.h
@@ -203,6 +203,17 @@ void decodeStorageCacheValue(const ValueRef& value, std::vector<uint16_t>& serve
 //	Using the serverID as a prefix, then followed by the beginning of the shard range
 //	as the key, the value indicates whether the shard does or does not exist on the server.
 //	These values can be changed as data movement occurs.
+//
+//	INVARIANT: serverKeys and keyServers are two views of one fact -- who owns a range. A
+//	transaction that changes a server's ownership of a range in serverKeys MUST write the
+//	corresponding keyServers entry for that range in the SAME transaction. Every writer today does
+//	(startMoveKeys/removeOldDestinations, finishMoveKeys, finishMoveShards,
+//	cleanUpSingleShardDataMove, cleanUpDataMoveCore, both branches of removeKeysFromFailedServer,
+//	prepareBlobRestore, seedShardServers), and readers rely on it: finishMove* re-reads keyServers
+//	after dropping its planning transaction in order to detect concurrent reassignment, so a
+//	one-sided serverKeys writer would be invisible to it and its revocation would be resurrected.
+//	See the tr.reset() comments in finishMoveKeys/finishMoveShards for which window depends on this.
+//	auditLocationMetadataPreCheck/PostCheck cross-validate the two maps.
 extern const KeyRangeRef serverKeysRange;
 extern const KeyRef serverKeysPrefix;
 extern const ValueRef serverKeysTrue, serverKeysTrueEmptyRange, serverKeysFalse;

--- a/fdbserver/MoveKeys.actor.cpp
+++ b/fdbserver/MoveKeys.actor.cpp
@@ -57,6 +57,19 @@ double finishMoveKeysBackoff(int retries) {
 	return std::min(base * (0.75 + 0.5 * deterministicRandom()->random01()), 5.0); // jitter: [0.75x, 1.25x], capped
 }
 
+// Shared retry tail used by the finishMove* post-wait branches that detect a
+// concurrent change (dest reassigned, data move deleted, phase changed):
+// bumps `retries`, throws finish_move_keys_too_many_retries once the cap is
+// exceeded, resets the transaction.
+ACTOR static Future<Void> retryAfterPostWaitChange(int* retries, Transaction* tr) {
+	if (++(*retries) > SERVER_KNOBS->FINISH_MOVE_KEYS_MAX_RETRIES) {
+		throw finish_move_keys_too_many_retries();
+	}
+	wait(delay(finishMoveKeysBackoff(*retries)));
+	tr->reset();
+	return Void();
+}
+
 struct Shard {
 	Shard() = default;
 	Shard(KeyRangeRef range, const UID& id) : range(range), id(id) {}
@@ -1305,6 +1318,107 @@ ACTOR Future<Void> checkFetchingState(Database cx,
 	}
 }
 
+// System-key reads that finishMoveKeys / finishMoveShards depend on for
+// correctness. Used both before the waitForShardReady wait (in the planning
+// transaction that's then discarded) and after the wait (in the verify+write
+// transaction). Centralizing the reads ensures both sides see the same set,
+// so the post-wait verification can detect any change to state the planning
+// phase relied on.
+struct ShardStateReads {
+	RangeResult uidToTagMap;
+	RangeResult keyServers;
+	Optional<DataMoveMetaData> dataMove; // populated iff dataMoveId.present()
+};
+
+// Read the system-key state needed by finishMoveKeys / finishMoveShards.
+// Called twice per attempt:
+//   1. Before waitForShardReady, to plan the wait (which dest interfaces, etc).
+//   2. After the wait, to verify nothing changed; the caller compares the two
+//      results and retries if they differ.
+ACTOR static Future<ShardStateReads> readShardState(Transaction* tr,
+                                                    MoveKeysLock lock,
+                                                    const DDEnabledState* ddEnabledState,
+                                                    KeyRange range,
+                                                    Optional<UID> dataMoveId,
+                                                    int krmRowLimit,
+                                                    int krmByteLimit) {
+	// Read set scope: moveKeysLock, dataMove (when applicable), serverTags
+	// (uidToTagMap), and keyServers. The original single-transaction code
+	// also read \xff/serverList/ — that's NOT covered here because writes
+	// key off stable UIDs not interfaces, so a serverList change between
+	// read and write can't invalidate the writes. Both code paths (keys and
+	// shards) commit only UID-keyed entries — keyServersValue and
+	// serverKeysValue for finishMoveKeys, plus dataMoveValue for
+	// finishMoveShards — so a serverList change between read and commit
+	// cannot invalidate any persisted state. Server removal is coordinated
+	// under moveKeysLock (re-checked here); dest reassignment is caught by
+	// the caller's dest-UID equality check; an SS that vanished mid-wait
+	// causes the caller's count check to fail before reaching commit. The
+	// serverList read therefore stays inline at the caller (it's needed
+	// once, before the wait, only to build interfaces).
+	wait(checkMoveKeysLock(tr, lock, ddEnabledState));
+
+	state ShardStateReads r;
+	if (dataMoveId.present()) {
+		Optional<Value> val = wait(tr->get(dataMoveKeyFor(dataMoveId.get())));
+		if (val.present()) {
+			r.dataMove = decodeDataMoveValue(val.get());
+		}
+	}
+
+	RangeResult uidToTagMap = wait(tr->getRange(serverTagKeys, CLIENT_KNOBS->TOO_MANY));
+	ASSERT(!uidToTagMap.more && uidToTagMap.size() < CLIENT_KNOBS->TOO_MANY);
+	r.uidToTagMap = uidToTagMap;
+
+	RangeResult keyServers = wait(krmGetRanges(tr, keyServersPrefix, range, krmRowLimit, krmByteLimit));
+	r.keyServers = keyServers;
+
+	return r;
+}
+
+// Post-wait verification used by both finishMoveKeys and finishMoveShards.
+// Sorts `expectedDest`.
+//
+// Returns true if every sub-range in `keyServers` still maps to `expectedDest`.
+static bool destUnchanged(const RangeResult& keyServers,
+                          const RangeResult& uidToTagMap,
+                          std::vector<UID> expectedDest,
+                          Optional<UID> expectedDataMoveId) {
+	std::sort(expectedDest.begin(), expectedDest.end());
+	for (int i = 0; i + 1 < keyServers.size(); ++i) {
+		std::vector<UID> checkSrc, checkDest;
+		UID checkSrcId, checkDestId;
+		decodeKeyServersValue(uidToTagMap, keyServers[i].value, checkSrc, checkDest, checkSrcId, checkDestId);
+		if (expectedDataMoveId.present()) {
+			// Have checkDestId == expectedDataMoveId — the shards path stamps every assigned
+			// sub-range with its dataMoveId, so any mismatch (including an empty-dest
+			// entry, which decodes to UID()) signals a concurrent reassignment.
+			if (checkDestId != expectedDataMoveId.get()) {
+				return false;
+			}
+		} else if (checkDest.empty()) {
+			// Empty-dest entries are tolerated wherever src ⊆ expectedDest. That matches the planning loop's
+			// `alreadyMoved = dest2.empty() && isSubset` branch (see the second planning
+			// loop in finishMoveKeys, around the "first key in iteration sub-range has
+			// already been processed" CODE_PROBE): a sibling iteration of OUR move
+			// already completed this sub-range, src is what was left after team-shrink,
+			// and the upcoming krmSetRangeCoalescing write will collapse it into the
+			// rest. The subset check rules out a foreign completed move whose src is
+			// a different team — clobbering it would overwrite the foreign owner.
+			std::sort(checkSrc.begin(), checkSrc.end());
+			if (!std::includes(expectedDest.begin(), expectedDest.end(), checkSrc.begin(), checkSrc.end())) {
+				return false;
+			}
+			continue;
+		}
+		std::sort(checkDest.begin(), checkDest.end());
+		if (checkDest != expectedDest) {
+			return false;
+		}
+	}
+	return true;
+}
+
 // Set keyServers[keys].src = keyServers[keys].dest and keyServers[keys].dest=[], return when successful
 // keyServers[k].dest must be the same for all k in keys
 // Set serverKeys[dest][keys] = true; serverKeys[src][keys] = false for all src not in dest
@@ -1372,16 +1486,16 @@ ACTOR static Future<Void> finishMoveKeys(Database occ,
 					wait(finishMoveKeysParallelismLock->take(TaskPriority::DataDistributionLaunch));
 					releaser = FlowLock::Releaser(*finishMoveKeysParallelismLock);
 
-					wait(checkMoveKeysLock(&tr, lock, ddEnabledState));
-
 					state KeyRange currentKeys = KeyRangeRef(begin, keys.end);
-					state RangeResult UIDtoTagMap = wait(tr.getRange(serverTagKeys, CLIENT_KNOBS->TOO_MANY));
-					ASSERT(!UIDtoTagMap.more && UIDtoTagMap.size() < CLIENT_KNOBS->TOO_MANY);
-					state RangeResult keyServers = wait(krmGetRanges(&tr,
-					                                                 keyServersPrefix,
-					                                                 currentKeys,
-					                                                 SERVER_KNOBS->MOVE_KEYS_KRM_LIMIT,
-					                                                 SERVER_KNOBS->MOVE_KEYS_KRM_LIMIT_BYTES));
+					state ShardStateReads planningState = wait(readShardState(&tr,
+					                                                          lock,
+					                                                          ddEnabledState,
+					                                                          currentKeys,
+					                                                          {},
+					                                                          SERVER_KNOBS->MOVE_KEYS_KRM_LIMIT,
+					                                                          SERVER_KNOBS->MOVE_KEYS_KRM_LIMIT_BYTES));
+					state RangeResult UIDtoTagMap = planningState.uidToTagMap;
+					state RangeResult keyServers = planningState.keyServers;
 
 					// Determine the last processed key (which will be the beginning for the next iteration)
 					endKey = keyServers.end()[-1].key;
@@ -1540,16 +1654,26 @@ ACTOR static Future<Void> finishMoveKeys(Database occ,
 
 					// update client info in case tss mapping changed or server got updated
 
-					// Wait for new destination servers to fetch the keys
+					// Save the read version before dropping the transaction. waitForShardReady
+					// needs a minimum version the dest must reach; saving the older version is
+					// sufficient because servers will already be past it by the time we
+					// re-verify in the second transaction below.
+					state Version readVersion = tr.getReadVersion().get();
+
+					// Drop the transaction BEFORE the potentially long wait. The 15-second
+					// SERVER_READY_QUORUM_TIMEOUT exceeds the ~5-second transaction lifetime,
+					// so waiting inside the transaction guarantees transaction_too_old on
+					// commit when destination servers are slow to respond.
+					tr.reset();
+
+					// Wait for new destination servers to fetch the keys (OUTSIDE any transaction)
 
 					serverReady.reserve(storageServerInterfaces.size());
 					tssReady.reserve(storageServerInterfaces.size());
 					tssReadyInterfs.reserve(storageServerInterfaces.size());
 					for (int s = 0; s < storageServerInterfaces.size(); s++) {
-						serverReady.push_back(waitForShardReady(storageServerInterfaces[s],
-						                                        keys,
-						                                        tr.getReadVersion().get(),
-						                                        GetShardStateRequest::READABLE));
+						serverReady.push_back(waitForShardReady(
+						    storageServerInterfaces[s], keys, readVersion, GetShardStateRequest::READABLE));
 
 						auto tssPair = tssMapping.find(storageServerInterfaces[s].id());
 
@@ -1557,12 +1681,12 @@ ACTOR static Future<Void> finishMoveKeys(Database occ,
 						    !tssToIgnore.contains(tssPair->second.id())) {
 							tssReadyInterfs.push_back(tssPair->second);
 							tssReady.push_back(waitForShardReady(
-							    tssPair->second, keys, tr.getReadVersion().get(), GetShardStateRequest::READABLE));
+							    tssPair->second, keys, readVersion, GetShardStateRequest::READABLE));
 						}
 					}
 
 					// Wait for all storage server moves, and explicitly swallow errors for tss ones with
-					// waitForAllReady If this takes too long the transaction will time out and retry, which is ok
+					// waitForAllReady. A long timeout is safe here — no transaction clock is ticking.
 					wait(timeout(waitForAll(serverReady) && waitForAllReady(tssReady),
 					             SERVER_KNOBS->SERVER_READY_QUORUM_TIMEOUT,
 					             Void(),
@@ -1616,11 +1740,66 @@ ACTOR static Future<Void> finishMoveKeys(Database occ,
 					}
 
 					if (count == dest.size()) {
+						// All destination servers are ready. Open a fresh transaction to
+						// re-verify dest hasn't changed during the wait, then commit.
+						tr.trState->taskID = TaskPriority::MoveKeys;
+						tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
+						tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+						state ShardStateReads reread = wait(readShardState(&tr,
+						                                                   lock,
+						                                                   ddEnabledState,
+						                                                   currentKeys,
+						                                                   {},
+						                                                   SERVER_KNOBS->MOVE_KEYS_KRM_LIMIT,
+						                                                   SERVER_KNOBS->MOVE_KEYS_KRM_LIMIT_BYTES));
+
+						// Re-truncate currentKeys/endKey to the boundary the reread
+						// actually covered. krmGetRanges only emits the synthetic
+						// upper-bound row when its row/byte limit is NOT hit
+						// (see krmDecodeRanges in KeyRangeMap.cpp), so if a
+						// concurrent split or value-size growth pushed the byte
+						// limit forward, reread.keyServers.back().key can be
+						// strictly less than the planning-era currentKeys.end.
+						// The destUnchanged loop below only validates sub-ranges
+						// within reread.keyServers; the krmSetRangeCoalescing
+						// commit would otherwise clear and rewrite an
+						// unverified-and-possibly-foreign tail. Common under
+						// MOVE_KEYS_KRM_LIMIT buggify (2 rows -- which happens often
+						// in simulation).
+						state Key rereadEnd = reread.keyServers.end()[-1].key;
+						// The reread is bounded by `currentKeys` (the upper-bound
+						// passed to readShardState), so a `>` result would mean
+						// readShardState broke its contract — fail loudly rather
+						// than silently expand the commit past the verified end.
+						ASSERT(rereadEnd <= currentKeys.end);
+						if (rereadEnd < currentKeys.end) {
+							CODE_PROBE(true,
+							           "finishMoveKeys reread keyServers boundary shorter than planning",
+							           probe::decoration::rare);
+							currentKeys = KeyRangeRef(currentKeys.begin, rereadEnd);
+							endKey = rereadEnd;
+						}
+
+						// Verify every sub-range still maps to the planned dest (or has
+						// been already-moved-into-empty by a sibling iteration). If
+						// another DD reassigned a sub-range during the wait, retry
+						// rather than clobber its write with our stale plan.
+						if (!destUnchanged(reread.keyServers, reread.uidToTagMap, dest, /*expectedDataMoveId=*/{})) {
+							CODE_PROBE(
+							    true, "finishMoveKeys dest changed during waitForShardReady", probe::decoration::rare);
+							TraceEvent(SevWarn, "FinishMoveKeysDestChanged", relocationIntervalId)
+							    .detail("KeyBegin", keys.begin)
+							    .detail("KeyEnd", keys.end)
+							    .detail("OrigDest", describe(dest));
+							wait(retryAfterPostWaitChange(&retries, &tr));
+							continue;
+						}
+
 						// update keyServers, serverKeys
 						// SOMEDAY: Doing these in parallel is safe because none of them overlap or touch (one per
 						// server)
 						wait(krmSetRangeCoalescing(
-						    &tr, keyServersPrefix, currentKeys, keys, keyServersValue(UIDtoTagMap, dest)));
+						    &tr, keyServersPrefix, currentKeys, keys, keyServersValue(reread.uidToTagMap, dest)));
 
 						std::set<UID>::iterator asi = allServers.begin();
 						std::vector<Future<Void>> actors;
@@ -1649,8 +1828,11 @@ ACTOR static Future<Void> finishMoveKeys(Database occ,
 						retries = 0;
 						break;
 					}
-					// This leads to a count of transactions starting that exceeds the sum of
-					// committed or aborted, but this is intentional here.
+					// Not all destination servers ready yet — no hard cap on retries.
+					// The waitForShardReady timeout (15s) bounds each attempt's wait,
+					// and DD's logWarningAfter watchdog surfaces the situation if it
+					// persists. Bounding the retry count converts patient progress
+					// (e.g. a dest SS recovering after chaos) into a DD-stuck loop.
 					tr.reset();
 				} catch (Error& error) {
 					txnAborted->increment(1);
@@ -2194,8 +2376,11 @@ ACTOR static Future<Void> finishMoveShards(Database occ,
 	state bool cancelDataMove = false;
 	state Severity sevDm = static_cast<Severity>(SERVER_KNOBS->PHYSICAL_SHARD_MOVE_LOG_SEVERITY);
 
-	wait(finishMoveKeysParallelismLock->take(TaskPriority::DataDistributionLaunch));
-	state FlowLock::Releaser releaser = FlowLock::Releaser(*finishMoveKeysParallelismLock);
+	// Take per-iteration in the loop below (mirroring finishMoveKeys): the lock
+	// must be released before the long waitForShardReady and re-taken on every
+	// retry, so the MOVE_KEYS_PARALLELISM throttle actually bounds concurrency
+	// across attempts rather than only the first one.
+	state FlowLock::Releaser releaser;
 	state bool runPreCheck = true;
 	state bool skipTss = false;
 	state double ssReadyTime = std::numeric_limits<double>::max();
@@ -2222,8 +2407,20 @@ ACTOR static Future<Void> finishMoveShards(Database occ,
 				tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 				tr.setOption(FDBTransactionOptions::LOCK_AWARE);
 
-				wait(checkMoveKeysLock(&tr, lock, ddEnabledState));
+				releaser.release();
+				wait(finishMoveKeysParallelismLock->take(TaskPriority::DataDistributionLaunch));
+				releaser = FlowLock::Releaser(*finishMoveKeysParallelismLock);
 
+				// dataMove is read inline (not via readShardState) because:
+				//   1. Its presence/phase drives a possible early-exit write
+				//      (cancelDataMove -> set Deleting -> commit -> throw),
+				//      which can't sit inside the shared read helper.
+				//   2. dataMove.ranges.front() supplies `range`, which the
+				//      readShardState call below needs as input.
+				// The post-cancel safety-relevant reads (serverTags +
+				// keyServers, plus a redundant moveKeysLock check) go through
+				// readShardState so they stay in sync with the post-wait
+				// re-read in txn 2.
 				Optional<Value> val = wait(tr.get(dataMoveKeyFor(dataMoveId)));
 				if (val.present()) {
 					dataMove = decodeDataMoveValue(val.get());
@@ -2260,14 +2457,15 @@ ACTOR static Future<Void> finishMoveShards(Database occ,
 					return Void();
 				}
 
-				state RangeResult UIDtoTagMap = wait(tr.getRange(serverTagKeys, CLIENT_KNOBS->TOO_MANY));
-				ASSERT(!UIDtoTagMap.more && UIDtoTagMap.size() < CLIENT_KNOBS->TOO_MANY);
-
-				state RangeResult keyServers = wait(krmGetRanges(&tr,
-				                                                 keyServersPrefix,
-				                                                 range,
-				                                                 SERVER_KNOBS->MOVE_SHARD_KRM_ROW_LIMIT,
-				                                                 SERVER_KNOBS->MOVE_SHARD_KRM_BYTE_LIMIT));
+				state ShardStateReads planningState = wait(readShardState(&tr,
+			                                                          lock,
+			                                                          ddEnabledState,
+			                                                          range,
+			                                                          /*dataMoveId=*/{},
+			                                                          SERVER_KNOBS->MOVE_SHARD_KRM_ROW_LIMIT,
+			                                                          SERVER_KNOBS->MOVE_SHARD_KRM_BYTE_LIMIT));
+				state RangeResult UIDtoTagMap = planningState.uidToTagMap;
+				state RangeResult keyServers = planningState.keyServers;
 				ASSERT(!keyServers.empty());
 				range = KeyRangeRef(range.begin, keyServers.back().key);
 				ASSERT(!range.empty());
@@ -2362,11 +2560,17 @@ ACTOR static Future<Void> finishMoveShards(Database occ,
 
 				// update client info in case tss mapping changed or server got updated
 
+				// Save the read version before dropping the transaction (mirrors the
+				// pattern in finishMoveKeys above): waitForShardReady needs a minimum
+				// version the dest must reach; servers will already be past it by the
+				// time we re-verify in the second transaction below.
+				state Version readVersion = tr.getReadVersion().get();
+
 				// Wait for new destination servers to fetch the data range.
 				serverReady.reserve(storageServerInterfaces.size());
 				for (int s = 0; s < storageServerInterfaces.size(); s++) {
 					serverReady.push_back(waitForShardReady(
-					    storageServerInterfaces[s], range, tr.getReadVersion().get(), GetShardStateRequest::READABLE));
+					    storageServerInterfaces[s], range, readVersion, GetShardStateRequest::READABLE));
 
 					if (skipTss)
 						continue;
@@ -2376,7 +2580,7 @@ ACTOR static Future<Void> finishMoveShards(Database occ,
 					if (tssPair != tssMapping.end()) {
 						tssReadyInterfs.push_back(tssPair->second);
 						tssReady.push_back(waitForShardReady(
-						    tssPair->second, range, tr.getReadVersion().get(), GetShardStateRequest::READABLE));
+						    tssPair->second, range, readVersion, GetShardStateRequest::READABLE));
 					}
 				}
 
@@ -2385,8 +2589,15 @@ ACTOR static Future<Void> finishMoveShards(Database occ,
 				    .detail("NewDestinations", describe(newDestinations))
 				    .detail("DataMove", dataMove.toString());
 
-				// Wait for all storage server moves, and explicitly swallow errors for tss ones with
-				// waitForAllReady If this takes too long the transaction will time out and retry, which is ok
+				// Drop the transaction BEFORE the potentially long wait. The 15 s
+				// SERVER_READY_QUORUM_TIMEOUT exceeds the ~5 s txn lifetime; waiting
+				// inside the transaction guarantees transaction_too_old on commit
+				// when destination servers are slow to respond. Same pattern as in
+				// finishMoveKeys above.
+				tr.reset();
+
+				// Wait OUTSIDE any transaction. A long timeout is safe — no
+				// transaction clock is ticking.
 				wait(timeout(waitForAll(serverReady) && waitForAllReady(tssReady),
 				             SERVER_KNOBS->SERVER_READY_QUORUM_TIMEOUT,
 				             Void(),
@@ -2429,6 +2640,84 @@ ACTOR static Future<Void> finishMoveShards(Database occ,
 
 				if (readyServers.size() == newDestinations.size()) {
 
+					// All destination servers are ready. Open a fresh transaction to
+					// re-verify dataMove and shard assignments haven't changed during
+					// the wait, then commit.
+					tr.trState->taskID = TaskPriority::MoveKeys;
+					tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
+					tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+					tr.setOption(FDBTransactionOptions::LOCK_AWARE);
+					state ShardStateReads reread = wait(readShardState(&tr,
+					                                                   lock,
+					                                                   ddEnabledState,
+					                                                   range,
+					                                                   dataMoveId,
+					                                                   SERVER_KNOBS->MOVE_SHARD_KRM_ROW_LIMIT,
+					                                                   SERVER_KNOBS->MOVE_SHARD_KRM_BYTE_LIMIT));
+
+					if (!reread.dataMove.present()) {
+						CODE_PROBE(true,
+						           "finishMoveShards data move deleted during waitForShardReady",
+						           probe::decoration::rare);
+						TraceEvent(SevWarn, "FinishMoveShardsDataMoveDeletedAfterWait", relocationIntervalId)
+						    .detail("DataMoveID", dataMoveId);
+						runPreCheck = false;
+						wait(retryAfterPostWaitChange(&retries, &tr));
+						continue;
+					}
+					if (reread.dataMove.get().getPhase() != DataMoveMetaData::Running) {
+						CODE_PROBE(true,
+						           "finishMoveShards data move phase changed during waitForShardReady",
+						           probe::decoration::rare);
+						TraceEvent(SevWarn, "FinishMoveShardsPhaseChangedAfterWait", relocationIntervalId)
+						    .detail("DataMoveID", dataMoveId)
+						    .detail("Phase", static_cast<int>(reread.dataMove.get().getPhase()));
+						runPreCheck = false;
+						wait(retryAfterPostWaitChange(&retries, &tr));
+						continue;
+					}
+					ASSERT(!reread.keyServers.empty());
+
+					// Re-truncate `range` to the boundary the reread actually
+					// covered. krmGetRanges only emits the synthetic upper-bound
+					// row when its row/byte limit is NOT hit (see krmDecodeRanges
+					// in KeyRangeMap.cpp), so if a concurrent split or value-size
+					// growth pushed the byte limit forward,
+					// reread.keyServers.back().key can be strictly less than the
+					// planning-era range.end. The destUnchanged loop only
+					// validates sub-ranges within reread.keyServers; the
+					// krmSetRangeCoalescing commits below would otherwise clear
+					// and rewrite an unverified-and-possibly-foreign tail.
+					state Key rereadEnd = reread.keyServers.back().key;
+					// The reread is bounded by `range`, so a `>` result would
+					// mean readShardState broke its contract — fail loudly
+					// rather than silently expand the commit past the verified
+					// end.
+					ASSERT(rereadEnd <= range.end);
+					if (rereadEnd < range.end) {
+						CODE_PROBE(true,
+						           "finishMoveShards reread keyServers boundary shorter than planning",
+						           probe::decoration::rare);
+						range = KeyRangeRef(range.begin, rereadEnd);
+					}
+
+					if (!destUnchanged(reread.keyServers, reread.uidToTagMap, destServers, dataMoveId)) {
+						CODE_PROBE(
+						    true, "finishMoveShards dest changed during waitForShardReady", probe::decoration::rare);
+						TraceEvent(SevWarn, "FinishMoveShardsDestChanged", relocationIntervalId)
+						    .detail("DataMoveID", dataMoveId)
+						    .detail("Range", range);
+						runPreCheck = false;
+						wait(retryAfterPostWaitChange(&retries, &tr));
+						continue;
+					}
+
+					// Use the freshly-read dataMove snapshot for partial-complete /
+					// checkpoint-deletion / dataMoveValue writes below; the
+					// function-level `dataMove` retains the pre-wait snapshot used
+					// only by the post-loop trace at the end of the function.
+					state DataMoveMetaData postWaitDataMove = reread.dataMove.get();
+
 					std::vector<Future<Void>> actors;
 					actors.push_back(krmSetRangeCoalescing(
 					    &tr, keyServersPrefix, range, allKeys, keyServersValue(destServers, {}, dataMoveId, UID())));
@@ -2446,12 +2735,12 @@ ACTOR static Future<Void> finishMoveShards(Database occ,
 						    .detail("StorageServerID", ssId)
 						    .detail("KeyRange", range)
 						    .detail("ShardID", destHasServer ? dataMoveId : UID())
-						    .detail("DataMove", dataMove.toString());
+						    .detail("DataMove", postWaitDataMove.toString());
 					}
 
 					wait(waitForAll(actors));
 
-					if (range.end == dataMove.ranges.front().end) {
+					if (range.end == postWaitDataMove.ranges.front().end) {
 						if (bulkLoadTaskState.present()) {
 							state BulkLoadTaskState newBulkLoadTaskState;
 							try {
@@ -2480,27 +2769,27 @@ ACTOR static Future<Void> finishMoveShards(Database occ,
 							    .detail("DataMoveID", dataMoveId)
 							    .detail("JobID", newBulkLoadTaskState.getJobId())
 							    .detail("TaskID", newBulkLoadTaskState.getTaskId());
-							dataMove.bulkLoadTaskState = newBulkLoadTaskState;
+							postWaitDataMove.bulkLoadTaskState = newBulkLoadTaskState;
 						}
-						wait(deleteCheckpoints(&tr, dataMove.checkpoints, dataMoveId));
+						wait(deleteCheckpoints(&tr, postWaitDataMove.checkpoints, dataMoveId));
 						tr.clear(dataMoveKeyFor(dataMoveId));
 						TraceEvent(sevDm, "FinishMoveShardsDeleteMetaData", relocationIntervalId)
-						    .detail("DataMove", dataMove.toString());
+						    .detail("DataMove", postWaitDataMove.toString());
 					} else if (!bulkLoadTaskState.present()) {
 						// Bulk Loading data move does not allow partial complete
 						TraceEvent(SevInfo, "FinishMoveShardsPartialComplete", relocationIntervalId)
 						    .detail("DataMoveID", dataMoveId)
 						    .detail("CurrentRange", range)
-						    .detail("NewDataMoveMetaData", dataMove.toString())
-						    .detail("DataMove", dataMove.toString());
-						dataMove.ranges.front() = KeyRangeRef(range.end, dataMove.ranges.front().end);
-						tr.set(dataMoveKeyFor(dataMoveId), dataMoveValue(dataMove));
+						    .detail("NewDataMoveMetaData", postWaitDataMove.toString())
+						    .detail("DataMove", postWaitDataMove.toString());
+						postWaitDataMove.ranges.front() = KeyRangeRef(range.end, postWaitDataMove.ranges.front().end);
+						tr.set(dataMoveKeyFor(dataMoveId), dataMoveValue(postWaitDataMove));
 					}
 
 					wait(tr.commit());
 					txnCommitted->increment(1);
 
-					if (range.end == dataMove.ranges.front().end && bulkLoadTaskState.present()) {
+					if (range.end == postWaitDataMove.ranges.front().end && bulkLoadTaskState.present()) {
 						Version commitVersion = tr.getCommittedVersion();
 						TraceEvent(
 						    bulkLoadVerboseEventSev(), "DDBulkLoadTaskPersistCompleteState", relocationIntervalId)
@@ -2511,16 +2800,42 @@ ACTOR static Future<Void> finishMoveShards(Database occ,
 						    .detail("CommitVersion", commitVersion);
 					}
 
-					if (range.end == dataMove.ranges.front().end) {
+					if (range.end == postWaitDataMove.ranges.front().end) {
 						// Post validate consistency of update of keyServers and serverKeys
 						if (SERVER_KNOBS->AUDIT_DATAMOVE_POST_CHECK) {
 							wait(auditLocationMetadataPostCheck(
-							    occ, dataMove.ranges.front(), "finishMoveShards_postcheck", relocationIntervalId));
+							    occ, postWaitDataMove.ranges.front(), "finishMoveShards_postcheck", relocationIntervalId));
 						}
 						break;
 					}
+					continue;
 				} else {
+					// Slow-but-not-stuck dest readiness: do NOT cap with a hard
+					// throw here. The waitForShardReady timeout (15s) bounds
+					// each attempt's wait, and DD's logWarningAfter watchdog
+					// already surfaces the situation if it persists. Bounding
+					// the retry count converts patient progress (e.g. a dest
+					// SS recovering after chaos in tests like ConfigureLocked)
+					// into a DD-stuck loop: each attempt throws after ~50s
+					// of cumulative backoff and DD immediately re-queues the
+					// same move, repeating until QuietDatabase times out.
+					// The three post-wait branches (DestChanged /
+					// DataMoveDeletedAfterWait / PhaseChangedAfterWait)
+					// still use retryAfterPostWaitChange because they detect
+					// real concurrent reassignments, not slowness.
+					++retries;
+					if (retries % 10 == 0) {
+						TraceEvent(SevWarnAlways, "RelocateShard_FinishMoveShardsDestNotReady", relocationIntervalId)
+						    .detail("DataMoveID", dataMoveId)
+						    .detail("Range", range)
+						    .detail("Retries", retries)
+						    .detail("ReadyCount", readyServers.size())
+						    .detail("DestCount", newDestinations.size());
+					}
+					runPreCheck = false;
+					wait(delay(finishMoveKeysBackoff(retries)));
 					tr.reset();
+					continue;
 				}
 			} catch (Error& error) {
 				txnAborted->increment(1);

--- a/fdbserver/MoveKeys.actor.cpp
+++ b/fdbserver/MoveKeys.actor.cpp
@@ -1680,8 +1680,8 @@ ACTOR static Future<Void> finishMoveKeys(Database occ,
 						if (tssPair != tssMapping.end() && waitForTSSCounter > 0 &&
 						    !tssToIgnore.contains(tssPair->second.id())) {
 							tssReadyInterfs.push_back(tssPair->second);
-							tssReady.push_back(waitForShardReady(
-							    tssPair->second, keys, readVersion, GetShardStateRequest::READABLE));
+							tssReady.push_back(
+							    waitForShardReady(tssPair->second, keys, readVersion, GetShardStateRequest::READABLE));
 						}
 					}
 
@@ -2458,12 +2458,12 @@ ACTOR static Future<Void> finishMoveShards(Database occ,
 				}
 
 				state ShardStateReads planningState = wait(readShardState(&tr,
-			                                                          lock,
-			                                                          ddEnabledState,
-			                                                          range,
-			                                                          /*dataMoveId=*/{},
-			                                                          SERVER_KNOBS->MOVE_SHARD_KRM_ROW_LIMIT,
-			                                                          SERVER_KNOBS->MOVE_SHARD_KRM_BYTE_LIMIT));
+				                                                          lock,
+				                                                          ddEnabledState,
+				                                                          range,
+				                                                          /*dataMoveId=*/{},
+				                                                          SERVER_KNOBS->MOVE_SHARD_KRM_ROW_LIMIT,
+				                                                          SERVER_KNOBS->MOVE_SHARD_KRM_BYTE_LIMIT));
 				state RangeResult UIDtoTagMap = planningState.uidToTagMap;
 				state RangeResult keyServers = planningState.keyServers;
 				ASSERT(!keyServers.empty());
@@ -2579,8 +2579,8 @@ ACTOR static Future<Void> finishMoveShards(Database occ,
 
 					if (tssPair != tssMapping.end()) {
 						tssReadyInterfs.push_back(tssPair->second);
-						tssReady.push_back(waitForShardReady(
-						    tssPair->second, range, readVersion, GetShardStateRequest::READABLE));
+						tssReady.push_back(
+						    waitForShardReady(tssPair->second, range, readVersion, GetShardStateRequest::READABLE));
 					}
 				}
 
@@ -2803,8 +2803,10 @@ ACTOR static Future<Void> finishMoveShards(Database occ,
 					if (range.end == postWaitDataMove.ranges.front().end) {
 						// Post validate consistency of update of keyServers and serverKeys
 						if (SERVER_KNOBS->AUDIT_DATAMOVE_POST_CHECK) {
-							wait(auditLocationMetadataPostCheck(
-							    occ, postWaitDataMove.ranges.front(), "finishMoveShards_postcheck", relocationIntervalId));
+							wait(auditLocationMetadataPostCheck(occ,
+							                                    postWaitDataMove.ranges.front(),
+							                                    "finishMoveShards_postcheck",
+							                                    relocationIntervalId));
 						}
 						break;
 					}

--- a/fdbserver/MoveKeys.actor.cpp
+++ b/fdbserver/MoveKeys.actor.cpp
@@ -95,6 +95,11 @@ public:
 // finish_move_keys_too_many_retries once it is exhausted, resets the transaction.
 ACTOR static Future<Void> retryAfterPostWaitChange(FinishMoveRetryBudget* budget, Transaction* tr) {
 	if (budget->recordRetry(SERVER_KNOBS->FINISH_MOVE_KEYS_MAX_RETRIES)) {
+		// Marked rare because all three call sites are rare: reaching them needs a concurrent
+		// reassignment to land inside the waitForShardReady window. Without this probe there is
+		// no way to tell whether the post-wait give-up path is exercised at all, which matters
+		// because FINISH_MOVE_KEYS_MAX_RETRIES is buggified down to 10 in simulation.
+		CODE_PROBE(true, "finishMove* giving up after a post-wait change", probe::decoration::rare);
 		throw finish_move_keys_too_many_retries();
 	}
 	wait(delay(finishMoveKeysBackoff(budget->attempts())));

--- a/fdbserver/MoveKeys.actor.cpp
+++ b/fdbserver/MoveKeys.actor.cpp
@@ -1433,6 +1433,18 @@ static bool destUnchanged(const RangeResult& keyServers,
                           const RangeResult& uidToTagMap,
                           std::vector<UID> expectedDest,
                           Optional<UID> expectedDataMoveId) {
+	// Force the post-wait dest-changed branch in simulation. Buggifying
+	// FINISH_MOVE_KEYS_MAX_RETRIES cannot reach it: taking that branch requires a concurrent
+	// reassignment to land inside the waitForShardReady window, which no knob makes more likely
+	// (a 100k campaign with the cap buggified to 10 left all four post-wait branches at zero
+	// hits). Returning false here is a branch the callers already handle -- they retry the whole
+	// iteration -- so it is safe to inject. Deliberately low probability: every hit costs a
+	// re-read plus finishMoveKeysBackoff() before the iteration is retried.
+	if (BUGGIFY_WITH_PROB(0.01)) {
+		CODE_PROBE(true, "finishMove* injecting a post-wait dest change");
+		return false;
+	}
+
 	std::sort(expectedDest.begin(), expectedDest.end());
 	for (int i = 0; i + 1 < keyServers.size(); ++i) {
 		std::vector<UID> checkSrc, checkDest;
@@ -1842,9 +1854,7 @@ ACTOR static Future<Void> finishMoveKeys(Database occ,
 						// than silently expand the commit past the verified end.
 						ASSERT(rereadEnd <= currentKeys.end);
 						if (rereadEnd < currentKeys.end) {
-							CODE_PROBE(true,
-							           "finishMoveKeys reread keyServers boundary shorter than planning",
-							           probe::decoration::rare);
+							CODE_PROBE(true, "finishMoveKeys reread keyServers boundary shorter than planning");
 							currentKeys = KeyRangeRef(currentKeys.begin, rereadEnd);
 							endKey = rereadEnd;
 						}
@@ -2767,9 +2777,7 @@ ACTOR static Future<Void> finishMoveShards(Database occ,
 					// end.
 					ASSERT(rereadEnd <= range.end);
 					if (rereadEnd < range.end) {
-						CODE_PROBE(true,
-						           "finishMoveShards reread keyServers boundary shorter than planning",
-						           probe::decoration::rare);
+						CODE_PROBE(true, "finishMoveShards reread keyServers boundary shorter than planning");
 						range = KeyRangeRef(range.begin, rereadEnd);
 					}
 

--- a/fdbserver/MoveKeys.actor.cpp
+++ b/fdbserver/MoveKeys.actor.cpp
@@ -1716,6 +1716,23 @@ ACTOR static Future<Void> finishMoveKeys(Database occ,
 					// SERVER_READY_QUORUM_TIMEOUT exceeds the ~5-second transaction lifetime,
 					// so waiting inside the transaction guarantees transaction_too_old on
 					// commit when destination servers are slow to respond.
+					//
+					// This also discards txn1's read conflict ranges. With V1 = this
+					// transaction's read version, V2 = txn2's, and C = txn2's commit version,
+					// the metadata is protected across the wait as follows:
+					//   keyServers (V1,V2]  txn2 re-reads at V2 and destUnchanged() compares.
+					//   keyServers (V2,C]   txn2's krmGetRanges is a non-snapshot read.
+					//   serverKeys (V2,C]   krmSetRangeCoalescing adds explicit read conflict
+					//                       ranges of its own (see KeyRangeMap.cpp); note this
+					//                       is where the pre-#13364 serverKeys coverage came
+					//                       from, not from the keyServers read, since
+					//                       finishMoveKeys never reads serverKeys.
+					//   serverKeys (V1,V2]  NOT covered by the resolver. Safe only because
+					//                       every writer that revokes a server's ownership in
+					//                       serverKeys also writes keyServers for the same
+					//                       range in the same transaction, which the V2 re-read
+					//                       therefore sees. See the INVARIANT note on
+					//                       serverKeysRange in SystemData.h.
 					tr.reset();
 
 					// Wait for new destination servers to fetch the keys (OUTSIDE any transaction)
@@ -2645,7 +2662,10 @@ ACTOR static Future<Void> finishMoveShards(Database occ,
 				// SERVER_READY_QUORUM_TIMEOUT exceeds the ~5 s txn lifetime; waiting
 				// inside the transaction guarantees transaction_too_old on commit
 				// when destination servers are slow to respond. Same pattern as in
-				// finishMoveKeys above.
+				// finishMoveKeys above, including the read-conflict-range coverage
+				// table at that tr.reset(): serverKeys over (V1,V2] is not covered by
+				// the resolver and relies on the INVARIANT note on serverKeysRange in
+				// SystemData.h.
 				tr.reset();
 
 				// Wait OUTSIDE any transaction. A long timeout is safe — no

--- a/fdbserver/MoveKeys.actor.cpp
+++ b/fdbserver/MoveKeys.actor.cpp
@@ -57,6 +57,19 @@ double finishMoveKeysBackoff(int retries) {
 	return std::min(base * (0.75 + 0.5 * deterministicRandom()->random01()), 5.0); // jitter: [0.75x, 1.25x], capped
 }
 
+// Shared retry tail used by the finishMove* post-wait branches that detect a
+// concurrent change (dest reassigned, data move deleted, phase changed):
+// bumps `retries`, throws finish_move_keys_too_many_retries once the cap is
+// exceeded, resets the transaction.
+ACTOR static Future<Void> retryAfterPostWaitChange(int* retries, Transaction* tr) {
+	if (++(*retries) > SERVER_KNOBS->FINISH_MOVE_KEYS_MAX_RETRIES) {
+		throw finish_move_keys_too_many_retries();
+	}
+	wait(delay(finishMoveKeysBackoff(*retries)));
+	tr->reset();
+	return Void();
+}
+
 struct Shard {
 	Shard() = default;
 	Shard(KeyRangeRef range, const UID& id) : range(range), id(id) {}
@@ -1317,6 +1330,107 @@ ACTOR Future<Void> checkFetchingState(Database cx,
 	}
 }
 
+// System-key reads that finishMoveKeys / finishMoveShards depend on for
+// correctness. Used both before the waitForShardReady wait (in the planning
+// transaction that's then discarded) and after the wait (in the verify+write
+// transaction). Centralizing the reads ensures both sides see the same set,
+// so the post-wait verification can detect any change to state the planning
+// phase relied on.
+struct ShardStateReads {
+	RangeResult uidToTagMap;
+	RangeResult keyServers;
+	Optional<DataMoveMetaData> dataMove; // populated iff dataMoveId.present()
+};
+
+// Read the system-key state needed by finishMoveKeys / finishMoveShards.
+// Called twice per attempt:
+//   1. Before waitForShardReady, to plan the wait (which dest interfaces, etc).
+//   2. After the wait, to verify nothing changed; the caller compares the two
+//      results and retries if they differ.
+ACTOR static Future<ShardStateReads> readShardState(Transaction* tr,
+                                                    MoveKeysLock lock,
+                                                    const DDEnabledState* ddEnabledState,
+                                                    KeyRange range,
+                                                    Optional<UID> dataMoveId,
+                                                    int krmRowLimit,
+                                                    int krmByteLimit) {
+	// Read set scope: moveKeysLock, dataMove (when applicable), serverTags
+	// (uidToTagMap), and keyServers. The original single-transaction code
+	// also read \xff/serverList/ — that's NOT covered here because writes
+	// key off stable UIDs not interfaces, so a serverList change between
+	// read and write can't invalidate the writes. Both code paths (keys and
+	// shards) commit only UID-keyed entries — keyServersValue and
+	// serverKeysValue for finishMoveKeys, plus dataMoveValue for
+	// finishMoveShards — so a serverList change between read and commit
+	// cannot invalidate any persisted state. Server removal is coordinated
+	// under moveKeysLock (re-checked here); dest reassignment is caught by
+	// the caller's dest-UID equality check; an SS that vanished mid-wait
+	// causes the caller's count check to fail before reaching commit. The
+	// serverList read therefore stays inline at the caller (it's needed
+	// once, before the wait, only to build interfaces).
+	wait(checkMoveKeysLock(tr, lock, ddEnabledState));
+
+	state ShardStateReads r;
+	if (dataMoveId.present()) {
+		Optional<Value> val = wait(tr->get(dataMoveKeyFor(dataMoveId.get())));
+		if (val.present()) {
+			r.dataMove = decodeDataMoveValue(val.get());
+		}
+	}
+
+	RangeResult uidToTagMap = wait(tr->getRange(serverTagKeys, CLIENT_KNOBS->TOO_MANY));
+	ASSERT(!uidToTagMap.more && uidToTagMap.size() < CLIENT_KNOBS->TOO_MANY);
+	r.uidToTagMap = uidToTagMap;
+
+	RangeResult keyServers = wait(krmGetRanges(tr, keyServersPrefix, range, krmRowLimit, krmByteLimit));
+	r.keyServers = keyServers;
+
+	return r;
+}
+
+// Post-wait verification used by both finishMoveKeys and finishMoveShards.
+// Sorts `expectedDest`.
+//
+// Returns true if every sub-range in `keyServers` still maps to `expectedDest`.
+static bool destUnchanged(const RangeResult& keyServers,
+                          const RangeResult& uidToTagMap,
+                          std::vector<UID> expectedDest,
+                          Optional<UID> expectedDataMoveId) {
+	std::sort(expectedDest.begin(), expectedDest.end());
+	for (int i = 0; i + 1 < keyServers.size(); ++i) {
+		std::vector<UID> checkSrc, checkDest;
+		UID checkSrcId, checkDestId;
+		decodeKeyServersValue(uidToTagMap, keyServers[i].value, checkSrc, checkDest, checkSrcId, checkDestId);
+		if (expectedDataMoveId.present()) {
+			// Have checkDestId == expectedDataMoveId — the shards path stamps every assigned
+			// sub-range with its dataMoveId, so any mismatch (including an empty-dest
+			// entry, which decodes to UID()) signals a concurrent reassignment.
+			if (checkDestId != expectedDataMoveId.get()) {
+				return false;
+			}
+		} else if (checkDest.empty()) {
+			// Empty-dest entries are tolerated wherever src ⊆ expectedDest. That matches the planning loop's
+			// `alreadyMoved = dest2.empty() && isSubset` branch (see the second planning
+			// loop in finishMoveKeys, around the "first key in iteration sub-range has
+			// already been processed" CODE_PROBE): a sibling iteration of OUR move
+			// already completed this sub-range, src is what was left after team-shrink,
+			// and the upcoming krmSetRangeCoalescing write will collapse it into the
+			// rest. The subset check rules out a foreign completed move whose src is
+			// a different team — clobbering it would overwrite the foreign owner.
+			std::sort(checkSrc.begin(), checkSrc.end());
+			if (!std::includes(expectedDest.begin(), expectedDest.end(), checkSrc.begin(), checkSrc.end())) {
+				return false;
+			}
+			continue;
+		}
+		std::sort(checkDest.begin(), checkDest.end());
+		if (checkDest != expectedDest) {
+			return false;
+		}
+	}
+	return true;
+}
+
 // Set keyServers[keys].src = keyServers[keys].dest and keyServers[keys].dest=[], return when successful
 // keyServers[k].dest must be the same for all k in keys
 // Set serverKeys[dest][keys] = true; serverKeys[src][keys] = false for all src not in dest
@@ -1384,16 +1498,16 @@ ACTOR static Future<Void> finishMoveKeys(Database occ,
 					wait(finishMoveKeysParallelismLock->take(TaskPriority::DataDistributionLaunch));
 					releaser = FlowLock::Releaser(*finishMoveKeysParallelismLock);
 
-					wait(checkMoveKeysLock(&tr, lock, ddEnabledState));
-
 					state KeyRange currentKeys = KeyRangeRef(begin, keys.end);
-					state RangeResult UIDtoTagMap = wait(tr.getRange(serverTagKeys, CLIENT_KNOBS->TOO_MANY));
-					ASSERT(!UIDtoTagMap.more && UIDtoTagMap.size() < CLIENT_KNOBS->TOO_MANY);
-					state RangeResult keyServers = wait(krmGetRanges(&tr,
-					                                                 keyServersPrefix,
-					                                                 currentKeys,
-					                                                 SERVER_KNOBS->MOVE_KEYS_KRM_LIMIT,
-					                                                 SERVER_KNOBS->MOVE_KEYS_KRM_LIMIT_BYTES));
+					state ShardStateReads planningState = wait(readShardState(&tr,
+					                                                          lock,
+					                                                          ddEnabledState,
+					                                                          currentKeys,
+					                                                          {},
+					                                                          SERVER_KNOBS->MOVE_KEYS_KRM_LIMIT,
+					                                                          SERVER_KNOBS->MOVE_KEYS_KRM_LIMIT_BYTES));
+					state RangeResult UIDtoTagMap = planningState.uidToTagMap;
+					state RangeResult keyServers = planningState.keyServers;
 
 					// Determine the last processed key (which will be the beginning for the next iteration)
 					endKey = keyServers.end()[-1].key;
@@ -1552,16 +1666,26 @@ ACTOR static Future<Void> finishMoveKeys(Database occ,
 
 					// update client info in case tss mapping changed or server got updated
 
-					// Wait for new destination servers to fetch the keys
+					// Save the read version before dropping the transaction. waitForShardReady
+					// needs a minimum version the dest must reach; saving the older version is
+					// sufficient because servers will already be past it by the time we
+					// re-verify in the second transaction below.
+					state Version readVersion = tr.getReadVersion().get();
+
+					// Drop the transaction BEFORE the potentially long wait. The 15-second
+					// SERVER_READY_QUORUM_TIMEOUT exceeds the ~5-second transaction lifetime,
+					// so waiting inside the transaction guarantees transaction_too_old on
+					// commit when destination servers are slow to respond.
+					tr.reset();
+
+					// Wait for new destination servers to fetch the keys (OUTSIDE any transaction)
 
 					serverReady.reserve(storageServerInterfaces.size());
 					tssReady.reserve(storageServerInterfaces.size());
 					tssReadyInterfs.reserve(storageServerInterfaces.size());
 					for (int s = 0; s < storageServerInterfaces.size(); s++) {
-						serverReady.push_back(waitForShardReady(storageServerInterfaces[s],
-						                                        keys,
-						                                        tr.getReadVersion().get(),
-						                                        GetShardStateRequest::READABLE));
+						serverReady.push_back(waitForShardReady(
+						    storageServerInterfaces[s], keys, readVersion, GetShardStateRequest::READABLE));
 
 						auto tssPair = tssMapping.find(storageServerInterfaces[s].id());
 
@@ -1569,12 +1693,12 @@ ACTOR static Future<Void> finishMoveKeys(Database occ,
 						    !tssToIgnore.contains(tssPair->second.id())) {
 							tssReadyInterfs.push_back(tssPair->second);
 							tssReady.push_back(waitForShardReady(
-							    tssPair->second, keys, tr.getReadVersion().get(), GetShardStateRequest::READABLE));
+							    tssPair->second, keys, readVersion, GetShardStateRequest::READABLE));
 						}
 					}
 
 					// Wait for all storage server moves, and explicitly swallow errors for tss ones with
-					// waitForAllReady If this takes too long the transaction will time out and retry, which is ok
+					// waitForAllReady. A long timeout is safe here — no transaction clock is ticking.
 					wait(timeout(waitForAll(serverReady) && waitForAllReady(tssReady),
 					             SERVER_KNOBS->SERVER_READY_QUORUM_TIMEOUT,
 					             Void(),
@@ -1628,11 +1752,66 @@ ACTOR static Future<Void> finishMoveKeys(Database occ,
 					}
 
 					if (count == dest.size()) {
+						// All destination servers are ready. Open a fresh transaction to
+						// re-verify dest hasn't changed during the wait, then commit.
+						tr.trState->taskID = TaskPriority::MoveKeys;
+						tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
+						tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+						state ShardStateReads reread = wait(readShardState(&tr,
+						                                                   lock,
+						                                                   ddEnabledState,
+						                                                   currentKeys,
+						                                                   {},
+						                                                   SERVER_KNOBS->MOVE_KEYS_KRM_LIMIT,
+						                                                   SERVER_KNOBS->MOVE_KEYS_KRM_LIMIT_BYTES));
+
+						// Re-truncate currentKeys/endKey to the boundary the reread
+						// actually covered. krmGetRanges only emits the synthetic
+						// upper-bound row when its row/byte limit is NOT hit
+						// (see krmDecodeRanges in KeyRangeMap.cpp), so if a
+						// concurrent split or value-size growth pushed the byte
+						// limit forward, reread.keyServers.back().key can be
+						// strictly less than the planning-era currentKeys.end.
+						// The destUnchanged loop below only validates sub-ranges
+						// within reread.keyServers; the krmSetRangeCoalescing
+						// commit would otherwise clear and rewrite an
+						// unverified-and-possibly-foreign tail. Common under
+						// MOVE_KEYS_KRM_LIMIT buggify (2 rows -- which happens often
+						// in simulation).
+						state Key rereadEnd = reread.keyServers.end()[-1].key;
+						// The reread is bounded by `currentKeys` (the upper-bound
+						// passed to readShardState), so a `>` result would mean
+						// readShardState broke its contract — fail loudly rather
+						// than silently expand the commit past the verified end.
+						ASSERT(rereadEnd <= currentKeys.end);
+						if (rereadEnd < currentKeys.end) {
+							CODE_PROBE(true,
+							           "finishMoveKeys reread keyServers boundary shorter than planning",
+							           probe::decoration::rare);
+							currentKeys = KeyRangeRef(currentKeys.begin, rereadEnd);
+							endKey = rereadEnd;
+						}
+
+						// Verify every sub-range still maps to the planned dest (or has
+						// been already-moved-into-empty by a sibling iteration). If
+						// another DD reassigned a sub-range during the wait, retry
+						// rather than clobber its write with our stale plan.
+						if (!destUnchanged(reread.keyServers, reread.uidToTagMap, dest, /*expectedDataMoveId=*/{})) {
+							CODE_PROBE(
+							    true, "finishMoveKeys dest changed during waitForShardReady", probe::decoration::rare);
+							TraceEvent(SevWarn, "FinishMoveKeysDestChanged", relocationIntervalId)
+							    .detail("KeyBegin", keys.begin)
+							    .detail("KeyEnd", keys.end)
+							    .detail("OrigDest", describe(dest));
+							wait(retryAfterPostWaitChange(&retries, &tr));
+							continue;
+						}
+
 						// update keyServers, serverKeys
 						// SOMEDAY: Doing these in parallel is safe because none of them overlap or touch (one per
 						// server)
 						wait(krmSetRangeCoalescing(
-						    &tr, keyServersPrefix, currentKeys, keys, keyServersValue(UIDtoTagMap, dest)));
+						    &tr, keyServersPrefix, currentKeys, keys, keyServersValue(reread.uidToTagMap, dest)));
 
 						std::set<UID>::iterator asi = allServers.begin();
 						std::vector<Future<Void>> actors;
@@ -1661,8 +1840,11 @@ ACTOR static Future<Void> finishMoveKeys(Database occ,
 						retries = 0;
 						break;
 					}
-					// This leads to a count of transactions starting that exceeds the sum of
-					// committed or aborted, but this is intentional here.
+					// Not all destination servers ready yet — no hard cap on retries.
+					// The waitForShardReady timeout (15s) bounds each attempt's wait,
+					// and DD's logWarningAfter watchdog surfaces the situation if it
+					// persists. Bounding the retry count converts patient progress
+					// (e.g. a dest SS recovering after chaos) into a DD-stuck loop.
 					tr.reset();
 				} catch (Error& error) {
 					txnAborted->increment(1);
@@ -2206,8 +2388,11 @@ ACTOR static Future<Void> finishMoveShards(Database occ,
 	state bool cancelDataMove = false;
 	state Severity sevDm = static_cast<Severity>(SERVER_KNOBS->PHYSICAL_SHARD_MOVE_LOG_SEVERITY);
 
-	wait(finishMoveKeysParallelismLock->take(TaskPriority::DataDistributionLaunch));
-	state FlowLock::Releaser releaser = FlowLock::Releaser(*finishMoveKeysParallelismLock);
+	// Take per-iteration in the loop below (mirroring finishMoveKeys): the lock
+	// must be released before the long waitForShardReady and re-taken on every
+	// retry, so the MOVE_KEYS_PARALLELISM throttle actually bounds concurrency
+	// across attempts rather than only the first one.
+	state FlowLock::Releaser releaser;
 	state bool runPreCheck = true;
 	state bool skipTss = false;
 	state double ssReadyTime = std::numeric_limits<double>::max();
@@ -2234,8 +2419,20 @@ ACTOR static Future<Void> finishMoveShards(Database occ,
 				tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 				tr.setOption(FDBTransactionOptions::LOCK_AWARE);
 
-				wait(checkMoveKeysLock(&tr, lock, ddEnabledState));
+				releaser.release();
+				wait(finishMoveKeysParallelismLock->take(TaskPriority::DataDistributionLaunch));
+				releaser = FlowLock::Releaser(*finishMoveKeysParallelismLock);
 
+				// dataMove is read inline (not via readShardState) because:
+				//   1. Its presence/phase drives a possible early-exit write
+				//      (cancelDataMove -> set Deleting -> commit -> throw),
+				//      which can't sit inside the shared read helper.
+				//   2. dataMove.ranges.front() supplies `range`, which the
+				//      readShardState call below needs as input.
+				// The post-cancel safety-relevant reads (serverTags +
+				// keyServers, plus a redundant moveKeysLock check) go through
+				// readShardState so they stay in sync with the post-wait
+				// re-read in txn 2.
 				Optional<Value> val = wait(tr.get(dataMoveKeyFor(dataMoveId)));
 				if (val.present()) {
 					dataMove = decodeDataMoveValue(val.get());
@@ -2272,14 +2469,15 @@ ACTOR static Future<Void> finishMoveShards(Database occ,
 					return Void();
 				}
 
-				state RangeResult UIDtoTagMap = wait(tr.getRange(serverTagKeys, CLIENT_KNOBS->TOO_MANY));
-				ASSERT(!UIDtoTagMap.more && UIDtoTagMap.size() < CLIENT_KNOBS->TOO_MANY);
-
-				state RangeResult keyServers = wait(krmGetRanges(&tr,
-				                                                 keyServersPrefix,
-				                                                 range,
-				                                                 SERVER_KNOBS->MOVE_SHARD_KRM_ROW_LIMIT,
-				                                                 SERVER_KNOBS->MOVE_SHARD_KRM_BYTE_LIMIT));
+				state ShardStateReads planningState = wait(readShardState(&tr,
+			                                                          lock,
+			                                                          ddEnabledState,
+			                                                          range,
+			                                                          /*dataMoveId=*/{},
+			                                                          SERVER_KNOBS->MOVE_SHARD_KRM_ROW_LIMIT,
+			                                                          SERVER_KNOBS->MOVE_SHARD_KRM_BYTE_LIMIT));
+				state RangeResult UIDtoTagMap = planningState.uidToTagMap;
+				state RangeResult keyServers = planningState.keyServers;
 				ASSERT(!keyServers.empty());
 				range = KeyRangeRef(range.begin, keyServers.back().key);
 				ASSERT(!range.empty());
@@ -2374,11 +2572,17 @@ ACTOR static Future<Void> finishMoveShards(Database occ,
 
 				// update client info in case tss mapping changed or server got updated
 
+				// Save the read version before dropping the transaction (mirrors the
+				// pattern in finishMoveKeys above): waitForShardReady needs a minimum
+				// version the dest must reach; servers will already be past it by the
+				// time we re-verify in the second transaction below.
+				state Version readVersion = tr.getReadVersion().get();
+
 				// Wait for new destination servers to fetch the data range.
 				serverReady.reserve(storageServerInterfaces.size());
 				for (int s = 0; s < storageServerInterfaces.size(); s++) {
 					serverReady.push_back(waitForShardReady(
-					    storageServerInterfaces[s], range, tr.getReadVersion().get(), GetShardStateRequest::READABLE));
+					    storageServerInterfaces[s], range, readVersion, GetShardStateRequest::READABLE));
 
 					if (skipTss)
 						continue;
@@ -2388,7 +2592,7 @@ ACTOR static Future<Void> finishMoveShards(Database occ,
 					if (tssPair != tssMapping.end()) {
 						tssReadyInterfs.push_back(tssPair->second);
 						tssReady.push_back(waitForShardReady(
-						    tssPair->second, range, tr.getReadVersion().get(), GetShardStateRequest::READABLE));
+						    tssPair->second, range, readVersion, GetShardStateRequest::READABLE));
 					}
 				}
 
@@ -2397,8 +2601,15 @@ ACTOR static Future<Void> finishMoveShards(Database occ,
 				    .detail("NewDestinations", describe(newDestinations))
 				    .detail("DataMove", dataMove.toString());
 
-				// Wait for all storage server moves, and explicitly swallow errors for tss ones with
-				// waitForAllReady If this takes too long the transaction will time out and retry, which is ok
+				// Drop the transaction BEFORE the potentially long wait. The 15 s
+				// SERVER_READY_QUORUM_TIMEOUT exceeds the ~5 s txn lifetime; waiting
+				// inside the transaction guarantees transaction_too_old on commit
+				// when destination servers are slow to respond. Same pattern as in
+				// finishMoveKeys above.
+				tr.reset();
+
+				// Wait OUTSIDE any transaction. A long timeout is safe — no
+				// transaction clock is ticking.
 				wait(timeout(waitForAll(serverReady) && waitForAllReady(tssReady),
 				             SERVER_KNOBS->SERVER_READY_QUORUM_TIMEOUT,
 				             Void(),
@@ -2441,6 +2652,84 @@ ACTOR static Future<Void> finishMoveShards(Database occ,
 
 				if (readyServers.size() == newDestinations.size()) {
 
+					// All destination servers are ready. Open a fresh transaction to
+					// re-verify dataMove and shard assignments haven't changed during
+					// the wait, then commit.
+					tr.trState->taskID = TaskPriority::MoveKeys;
+					tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
+					tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+					tr.setOption(FDBTransactionOptions::LOCK_AWARE);
+					state ShardStateReads reread = wait(readShardState(&tr,
+					                                                   lock,
+					                                                   ddEnabledState,
+					                                                   range,
+					                                                   dataMoveId,
+					                                                   SERVER_KNOBS->MOVE_SHARD_KRM_ROW_LIMIT,
+					                                                   SERVER_KNOBS->MOVE_SHARD_KRM_BYTE_LIMIT));
+
+					if (!reread.dataMove.present()) {
+						CODE_PROBE(true,
+						           "finishMoveShards data move deleted during waitForShardReady",
+						           probe::decoration::rare);
+						TraceEvent(SevWarn, "FinishMoveShardsDataMoveDeletedAfterWait", relocationIntervalId)
+						    .detail("DataMoveID", dataMoveId);
+						runPreCheck = false;
+						wait(retryAfterPostWaitChange(&retries, &tr));
+						continue;
+					}
+					if (reread.dataMove.get().getPhase() != DataMoveMetaData::Running) {
+						CODE_PROBE(true,
+						           "finishMoveShards data move phase changed during waitForShardReady",
+						           probe::decoration::rare);
+						TraceEvent(SevWarn, "FinishMoveShardsPhaseChangedAfterWait", relocationIntervalId)
+						    .detail("DataMoveID", dataMoveId)
+						    .detail("Phase", static_cast<int>(reread.dataMove.get().getPhase()));
+						runPreCheck = false;
+						wait(retryAfterPostWaitChange(&retries, &tr));
+						continue;
+					}
+					ASSERT(!reread.keyServers.empty());
+
+					// Re-truncate `range` to the boundary the reread actually
+					// covered. krmGetRanges only emits the synthetic upper-bound
+					// row when its row/byte limit is NOT hit (see krmDecodeRanges
+					// in KeyRangeMap.cpp), so if a concurrent split or value-size
+					// growth pushed the byte limit forward,
+					// reread.keyServers.back().key can be strictly less than the
+					// planning-era range.end. The destUnchanged loop only
+					// validates sub-ranges within reread.keyServers; the
+					// krmSetRangeCoalescing commits below would otherwise clear
+					// and rewrite an unverified-and-possibly-foreign tail.
+					state Key rereadEnd = reread.keyServers.back().key;
+					// The reread is bounded by `range`, so a `>` result would
+					// mean readShardState broke its contract — fail loudly
+					// rather than silently expand the commit past the verified
+					// end.
+					ASSERT(rereadEnd <= range.end);
+					if (rereadEnd < range.end) {
+						CODE_PROBE(true,
+						           "finishMoveShards reread keyServers boundary shorter than planning",
+						           probe::decoration::rare);
+						range = KeyRangeRef(range.begin, rereadEnd);
+					}
+
+					if (!destUnchanged(reread.keyServers, reread.uidToTagMap, destServers, dataMoveId)) {
+						CODE_PROBE(
+						    true, "finishMoveShards dest changed during waitForShardReady", probe::decoration::rare);
+						TraceEvent(SevWarn, "FinishMoveShardsDestChanged", relocationIntervalId)
+						    .detail("DataMoveID", dataMoveId)
+						    .detail("Range", range);
+						runPreCheck = false;
+						wait(retryAfterPostWaitChange(&retries, &tr));
+						continue;
+					}
+
+					// Use the freshly-read dataMove snapshot for partial-complete /
+					// checkpoint-deletion / dataMoveValue writes below; the
+					// function-level `dataMove` retains the pre-wait snapshot used
+					// only by the post-loop trace at the end of the function.
+					state DataMoveMetaData postWaitDataMove = reread.dataMove.get();
+
 					std::vector<Future<Void>> actors;
 					actors.push_back(krmSetRangeCoalescing(
 					    &tr, keyServersPrefix, range, allKeys, keyServersValue(destServers, {}, dataMoveId, UID())));
@@ -2458,12 +2747,12 @@ ACTOR static Future<Void> finishMoveShards(Database occ,
 						    .detail("StorageServerID", ssId)
 						    .detail("KeyRange", range)
 						    .detail("ShardID", destHasServer ? dataMoveId : UID())
-						    .detail("DataMove", dataMove.toString());
+						    .detail("DataMove", postWaitDataMove.toString());
 					}
 
 					wait(waitForAll(actors));
 
-					if (range.end == dataMove.ranges.front().end) {
+					if (range.end == postWaitDataMove.ranges.front().end) {
 						if (bulkLoadTaskState.present()) {
 							state BulkLoadTaskState newBulkLoadTaskState;
 							try {
@@ -2492,27 +2781,27 @@ ACTOR static Future<Void> finishMoveShards(Database occ,
 							    .detail("DataMoveID", dataMoveId)
 							    .detail("JobID", newBulkLoadTaskState.getJobId())
 							    .detail("TaskID", newBulkLoadTaskState.getTaskId());
-							dataMove.bulkLoadTaskState = newBulkLoadTaskState;
+							postWaitDataMove.bulkLoadTaskState = newBulkLoadTaskState;
 						}
-						wait(deleteCheckpoints(&tr, dataMove.checkpoints, dataMoveId));
+						wait(deleteCheckpoints(&tr, postWaitDataMove.checkpoints, dataMoveId));
 						tr.clear(dataMoveKeyFor(dataMoveId));
 						TraceEvent(sevDm, "FinishMoveShardsDeleteMetaData", relocationIntervalId)
-						    .detail("DataMove", dataMove.toString());
+						    .detail("DataMove", postWaitDataMove.toString());
 					} else if (!bulkLoadTaskState.present()) {
 						// Bulk Loading data move does not allow partial complete
 						TraceEvent(SevInfo, "FinishMoveShardsPartialComplete", relocationIntervalId)
 						    .detail("DataMoveID", dataMoveId)
 						    .detail("CurrentRange", range)
-						    .detail("NewDataMoveMetaData", dataMove.toString())
-						    .detail("DataMove", dataMove.toString());
-						dataMove.ranges.front() = KeyRangeRef(range.end, dataMove.ranges.front().end);
-						tr.set(dataMoveKeyFor(dataMoveId), dataMoveValue(dataMove));
+						    .detail("NewDataMoveMetaData", postWaitDataMove.toString())
+						    .detail("DataMove", postWaitDataMove.toString());
+						postWaitDataMove.ranges.front() = KeyRangeRef(range.end, postWaitDataMove.ranges.front().end);
+						tr.set(dataMoveKeyFor(dataMoveId), dataMoveValue(postWaitDataMove));
 					}
 
 					wait(tr.commit());
 					txnCommitted->increment(1);
 
-					if (range.end == dataMove.ranges.front().end && bulkLoadTaskState.present()) {
+					if (range.end == postWaitDataMove.ranges.front().end && bulkLoadTaskState.present()) {
 						Version commitVersion = tr.getCommittedVersion();
 						TraceEvent(
 						    bulkLoadVerboseEventSev(), "DDBulkLoadTaskPersistCompleteState", relocationIntervalId)
@@ -2523,16 +2812,42 @@ ACTOR static Future<Void> finishMoveShards(Database occ,
 						    .detail("CommitVersion", commitVersion);
 					}
 
-					if (range.end == dataMove.ranges.front().end) {
+					if (range.end == postWaitDataMove.ranges.front().end) {
 						// Post validate consistency of update of keyServers and serverKeys
 						if (SERVER_KNOBS->AUDIT_DATAMOVE_POST_CHECK) {
 							wait(auditLocationMetadataPostCheck(
-							    occ, dataMove.ranges.front(), "finishMoveShards_postcheck", relocationIntervalId));
+							    occ, postWaitDataMove.ranges.front(), "finishMoveShards_postcheck", relocationIntervalId));
 						}
 						break;
 					}
+					continue;
 				} else {
+					// Slow-but-not-stuck dest readiness: do NOT cap with a hard
+					// throw here. The waitForShardReady timeout (15s) bounds
+					// each attempt's wait, and DD's logWarningAfter watchdog
+					// already surfaces the situation if it persists. Bounding
+					// the retry count converts patient progress (e.g. a dest
+					// SS recovering after chaos in tests like ConfigureLocked)
+					// into a DD-stuck loop: each attempt throws after ~50s
+					// of cumulative backoff and DD immediately re-queues the
+					// same move, repeating until QuietDatabase times out.
+					// The three post-wait branches (DestChanged /
+					// DataMoveDeletedAfterWait / PhaseChangedAfterWait)
+					// still use retryAfterPostWaitChange because they detect
+					// real concurrent reassignments, not slowness.
+					++retries;
+					if (retries % 10 == 0) {
+						TraceEvent(SevWarnAlways, "RelocateShard_FinishMoveShardsDestNotReady", relocationIntervalId)
+						    .detail("DataMoveID", dataMoveId)
+						    .detail("Range", range)
+						    .detail("Retries", retries)
+						    .detail("ReadyCount", readyServers.size())
+						    .detail("DestCount", newDestinations.size());
+					}
+					runPreCheck = false;
+					wait(delay(finishMoveKeysBackoff(retries)));
 					tr.reset();
+					continue;
 				}
 			} catch (Error& error) {
 				txnAborted->increment(1);

--- a/fdbserver/MoveKeys.actor.cpp
+++ b/fdbserver/MoveKeys.actor.cpp
@@ -57,15 +57,47 @@ double finishMoveKeysBackoff(int retries) {
 	return std::min(base * (0.75 + 0.5 * deterministicRandom()->random01()), 5.0); // jitter: [0.75x, 1.25x], capped
 }
 
+// Per-chunk retry budget shared by the finishMove* loops.
+//
+// Both finishMoveKeys and finishMoveShards process one data move in KRM-sized
+// chunks, committing each chunk in its own transaction.
+// FINISH_MOVE_KEYS_MAX_RETRIES is meant to bound "this chunk is stuck", not
+// "this move is large", so finishing a chunk has to restore the full budget.
+// Without that reset the chunk count pollutes the counter: a move split into N
+// chunks that each hit a few benign conflicts drains a budget no individual
+// chunk was straining, and a late chunk then aborts the whole move on the first
+// concurrent reassignment it sees.
+class FinishMoveRetryBudget {
+	int attemptsSpent = 0;
+
+public:
+	// Failed attempts spent on the current chunk. Read-only on purpose: tracing
+	// and backoff consume this without being able to perturb the budget.
+	int attempts() const { return attemptsSpent; }
+
+	// Record a failed attempt at the current chunk. Returns true once this chunk
+	// has spent more attempts than `maxRetries` allows.
+	[[nodiscard]] bool recordRetry(int maxRetries) { return ++attemptsSpent > maxRetries; }
+
+	// Record a failed attempt at the current chunk without enforcing any cap.
+	// Used by the finishMoveShards paths that deliberately retry indefinitely
+	// (see the comments there) but still want the count for backoff and tracing.
+	void recordRetryUncapped() { ++attemptsSpent; }
+
+	// The current chunk is finished — it committed, or it turned out to need no
+	// work. The next chunk starts with a full budget.
+	void chunkCompleted() { attemptsSpent = 0; }
+};
+
 // Shared retry tail used by the finishMove* post-wait branches that detect a
 // concurrent change (dest reassigned, data move deleted, phase changed):
-// bumps `retries`, throws finish_move_keys_too_many_retries once the cap is
-// exceeded, resets the transaction.
-ACTOR static Future<Void> retryAfterPostWaitChange(int* retries, Transaction* tr) {
-	if (++(*retries) > SERVER_KNOBS->FINISH_MOVE_KEYS_MAX_RETRIES) {
+// spends one attempt from the current chunk's budget, throws
+// finish_move_keys_too_many_retries once it is exhausted, resets the transaction.
+ACTOR static Future<Void> retryAfterPostWaitChange(FinishMoveRetryBudget* budget, Transaction* tr) {
+	if (budget->recordRetry(SERVER_KNOBS->FINISH_MOVE_KEYS_MAX_RETRIES)) {
 		throw finish_move_keys_too_many_retries();
 	}
-	wait(delay(finishMoveKeysBackoff(*retries)));
+	wait(delay(finishMoveKeysBackoff(budget->attempts())));
 	tr->reset();
 	return Void();
 }
@@ -1464,7 +1496,7 @@ ACTOR static Future<Void> finishMoveKeys(Database occ,
 	state SimpleCounter<int64_t>* txnAborted = counterFinishMoveKeysAborted();
 	state Key begin = keys.begin;
 	state Key endKey;
-	state int retries = 0;
+	state FinishMoveRetryBudget retryBudget;
 	state FlowLock::Releaser releaser;
 
 	state std::unordered_set<UID> tssToIgnore;
@@ -1624,6 +1656,9 @@ ACTOR static Future<Void> finishMoveKeys(Database occ,
 						    .detail("IterationBegin", begin)
 						    .detail("IterationEnd", endKey);
 						begin = keyServers.end()[-1].key;
+						// This chunk needed no work, so it is finished: the next one
+						// starts with a full budget.
+						retryBudget.chunkCompleted();
 						break;
 					}
 
@@ -1803,7 +1838,7 @@ ACTOR static Future<Void> finishMoveKeys(Database occ,
 							    .detail("KeyBegin", keys.begin)
 							    .detail("KeyEnd", keys.end)
 							    .detail("OrigDest", describe(dest));
-							wait(retryAfterPostWaitChange(&retries, &tr));
+							wait(retryAfterPostWaitChange(&retryBudget, &tr));
 							continue;
 						}
 
@@ -1837,7 +1872,7 @@ ACTOR static Future<Void> finishMoveKeys(Database occ,
 						txnCommitted->increment(1);
 
 						begin = endKey;
-						retries = 0;
+						retryBudget.chunkCompleted();
 						break;
 					}
 					// Not all destination servers ready yet — no hard cap on retries.
@@ -1852,30 +1887,30 @@ ACTOR static Future<Void> finishMoveKeys(Database occ,
 						throw;
 					state Error err = error;
 					wait(tr.onError(error));
-					retries++;
+					bool budgetExhausted = retryBudget.recordRetry(SERVER_KNOBS->FINISH_MOVE_KEYS_MAX_RETRIES);
 					// tr.onError delays are short for transaction_too_old. With 15
 					// FlowLock slots all retrying, this creates a retry storm. Add
 					// additional exponential backoff capped at 5s.
 					if (err.code() == error_code_transaction_too_old) {
-						double backoff = finishMoveKeysBackoff(retries);
+						double backoff = finishMoveKeysBackoff(retryBudget.attempts());
 						CODE_PROBE(true, "finishMoveKeys transaction_too_old backoff");
 						TraceEvent("FinishMoveKeysBackoff", relocationIntervalId)
 						    .suppressFor(1.0)
-						    .detail("Retries", retries)
+						    .detail("Retries", retryBudget.attempts())
 						    .detail("BackoffSeconds", backoff);
-						if (retries > SERVER_KNOBS->FINISH_MOVE_KEYS_MAX_RETRIES) {
+						if (budgetExhausted) {
 							CODE_PROBE(true, "finishMoveKeys giving up after max retries");
 							TraceEvent(SevWarnAlways, "RelocateShard_FinishMoveKeysGivingUp", relocationIntervalId)
 							    .error(err)
 							    .detail("KeyBegin", keys.begin)
 							    .detail("KeyEnd", keys.end)
-							    .detail("Retries", retries);
+							    .detail("Retries", retryBudget.attempts());
 							throw finish_move_keys_too_many_retries();
 						}
 						wait(delay(backoff));
 					}
-					if (retries % 10 == 0) {
-						TraceEvent(retries == 20 ? SevWarnAlways : SevWarn,
+					if (retryBudget.attempts() % 10 == 0) {
+						TraceEvent(retryBudget.attempts() == 20 ? SevWarnAlways : SevWarn,
 						           "RelocateShard_FinishMoveKeysRetrying",
 						           relocationIntervalId)
 						    .error(err)
@@ -2383,7 +2418,7 @@ ACTOR static Future<Void> finishMoveShards(Database occ,
 	state SimpleCounter<int64_t>* txnStarted = counterFinishMoveShardsStarted();
 	state SimpleCounter<int64_t>* txnCommitted = counterFinishMoveShardsCommitted();
 	state SimpleCounter<int64_t>* txnAborted = counterFinishMoveShardsAborted();
-	state int retries = 0;
+	state FinishMoveRetryBudget retryBudget;
 	state DataMoveMetaData dataMove;
 	state bool cancelDataMove = false;
 	state Severity sevDm = static_cast<Severity>(SERVER_KNOBS->PHYSICAL_SHARD_MOVE_LOG_SEVERITY);
@@ -2674,7 +2709,7 @@ ACTOR static Future<Void> finishMoveShards(Database occ,
 						TraceEvent(SevWarn, "FinishMoveShardsDataMoveDeletedAfterWait", relocationIntervalId)
 						    .detail("DataMoveID", dataMoveId);
 						runPreCheck = false;
-						wait(retryAfterPostWaitChange(&retries, &tr));
+						wait(retryAfterPostWaitChange(&retryBudget, &tr));
 						continue;
 					}
 					if (reread.dataMove.get().getPhase() != DataMoveMetaData::Running) {
@@ -2685,7 +2720,7 @@ ACTOR static Future<Void> finishMoveShards(Database occ,
 						    .detail("DataMoveID", dataMoveId)
 						    .detail("Phase", static_cast<int>(reread.dataMove.get().getPhase()));
 						runPreCheck = false;
-						wait(retryAfterPostWaitChange(&retries, &tr));
+						wait(retryAfterPostWaitChange(&retryBudget, &tr));
 						continue;
 					}
 					ASSERT(!reread.keyServers.empty());
@@ -2720,7 +2755,7 @@ ACTOR static Future<Void> finishMoveShards(Database occ,
 						    .detail("DataMoveID", dataMoveId)
 						    .detail("Range", range);
 						runPreCheck = false;
-						wait(retryAfterPostWaitChange(&retries, &tr));
+						wait(retryAfterPostWaitChange(&retryBudget, &tr));
 						continue;
 					}
 
@@ -2801,6 +2836,15 @@ ACTOR static Future<Void> finishMoveShards(Database occ,
 					wait(tr.commit());
 					txnCommitted->increment(1);
 
+					// This chunk committed, so it is finished and the next one starts
+					// with a full budget (mirroring finishMoveKeys, which resets on
+					// the same event). Without this the chunk count of a large move
+					// drains a budget no individual chunk was straining; since the
+					// budget is only consulted by the post-wait-change branches
+					// below, the symptom would be a late chunk aborting the whole
+					// move on the first concurrent reassignment it sees.
+					retryBudget.chunkCompleted();
+
 					if (range.end == postWaitDataMove.ranges.front().end && bulkLoadTaskState.present()) {
 						Version commitVersion = tr.getCommittedVersion();
 						TraceEvent(
@@ -2837,17 +2881,17 @@ ACTOR static Future<Void> finishMoveShards(Database occ,
 					// DataMoveDeletedAfterWait / PhaseChangedAfterWait)
 					// still use retryAfterPostWaitChange because they detect
 					// real concurrent reassignments, not slowness.
-					++retries;
-					if (retries % 10 == 0) {
+					retryBudget.recordRetryUncapped();
+					if (retryBudget.attempts() % 10 == 0) {
 						TraceEvent(SevWarnAlways, "RelocateShard_FinishMoveShardsDestNotReady", relocationIntervalId)
 						    .detail("DataMoveID", dataMoveId)
 						    .detail("Range", range)
-						    .detail("Retries", retries)
+						    .detail("Retries", retryBudget.attempts())
 						    .detail("ReadyCount", readyServers.size())
 						    .detail("DestCount", newDestinations.size());
 					}
 					runPreCheck = false;
-					wait(delay(finishMoveKeysBackoff(retries)));
+					wait(delay(finishMoveKeysBackoff(retryBudget.attempts())));
 					tr.reset();
 					continue;
 				}
@@ -2860,7 +2904,7 @@ ACTOR static Future<Void> finishMoveShards(Database occ,
 					throw location_metadata_corruption();
 				} else if (error.code() == error_code_retry) {
 					runPreCheck = false;
-					++retries;
+					retryBudget.recordRetryUncapped();
 					wait(delay(1));
 				} else if (error.code() == error_code_actor_cancelled) {
 					throw;
@@ -2868,9 +2912,9 @@ ACTOR static Future<Void> finishMoveShards(Database occ,
 					state Error err = error;
 					runPreCheck = false;
 					wait(tr.onError(err));
-					retries++;
-					if (retries % 10 == 0) {
-						TraceEvent(retries == 20 ? SevWarnAlways : SevWarn,
+					retryBudget.recordRetryUncapped();
+					if (retryBudget.attempts() % 10 == 0) {
+						TraceEvent(retryBudget.attempts() == 20 ? SevWarnAlways : SevWarn,
 						           "RelocateShard_FinishMoveShardsRetrying",
 						           relocationIntervalId)
 						    .error(err)
@@ -4082,6 +4126,43 @@ TEST_CASE("/fdbserver/MoveKeys/finishMoveKeysBackoff") {
 
 	// Verify the retry limit knob exists and is positive
 	ASSERT(SERVER_KNOBS->FINISH_MOVE_KEYS_MAX_RETRIES > 0);
+
+	return Void();
+}
+
+TEST_CASE("/fdbserver/MoveKeys/finishMoveRetryBudgetIsPerChunk") {
+	constexpr int maxRetries = 5;
+
+	// A chunk may spend maxRetries attempts before the budget is exhausted; the
+	// next attempt is the one that reports exhaustion.
+	FinishMoveRetryBudget budget;
+	for (int i = 0; i < maxRetries; ++i) {
+		ASSERT(!budget.recordRetry(maxRetries));
+		ASSERT(budget.attempts() == i + 1);
+	}
+	ASSERT(budget.recordRetry(maxRetries));
+
+	// The budget bounds "this chunk is stuck", not "this move is large": a move
+	// split into many chunks that each need a few retries must never exhaust it,
+	// even though the total attempt count far exceeds maxRetries.
+	budget = FinishMoveRetryBudget();
+	for (int chunk = 0; chunk < 10; ++chunk) {
+		for (int i = 0; i < maxRetries; ++i) {
+			ASSERT(!budget.recordRetry(maxRetries));
+		}
+		budget.chunkCompleted();
+		ASSERT(budget.attempts() == 0);
+	}
+
+	// The uncapped variant still advances the count (callers use it for backoff
+	// and tracing) and is still cleared by finishing a chunk.
+	budget = FinishMoveRetryBudget();
+	for (int i = 0; i < maxRetries * 3; ++i) {
+		budget.recordRetryUncapped();
+	}
+	ASSERT(budget.attempts() == maxRetries * 3);
+	budget.chunkCompleted();
+	ASSERT(budget.attempts() == 0);
 
 	return Void();
 }

--- a/fdbserver/MoveKeys.actor.cpp
+++ b/fdbserver/MoveKeys.actor.cpp
@@ -3917,6 +3917,18 @@ Future<Void> rawFinishMovement(Database occ,
 	                      params.ddEnabledState);
 }
 
+bool retryableDataMoveError(const Error& e) {
+	switch (e.code()) {
+	case error_code_finish_move_keys_too_many_retries:
+	case error_code_start_move_keys_too_many_retries:
+	case error_code_data_move_cancelled:
+	case error_code_data_move_dest_team_not_found:
+		return true;
+	default:
+		return false;
+	}
+}
+
 ACTOR Future<Void> moveKeys(Database occ, MoveKeysParams params) {
 	ASSERT(params.destinationTeam.size());
 	std::sort(params.destinationTeam.begin(), params.destinationTeam.end());

--- a/fdbserver/MoveKeys.actor.cpp
+++ b/fdbserver/MoveKeys.actor.cpp
@@ -1692,8 +1692,8 @@ ACTOR static Future<Void> finishMoveKeys(Database occ,
 						if (tssPair != tssMapping.end() && waitForTSSCounter > 0 &&
 						    !tssToIgnore.contains(tssPair->second.id())) {
 							tssReadyInterfs.push_back(tssPair->second);
-							tssReady.push_back(waitForShardReady(
-							    tssPair->second, keys, readVersion, GetShardStateRequest::READABLE));
+							tssReady.push_back(
+							    waitForShardReady(tssPair->second, keys, readVersion, GetShardStateRequest::READABLE));
 						}
 					}
 
@@ -2470,12 +2470,12 @@ ACTOR static Future<Void> finishMoveShards(Database occ,
 				}
 
 				state ShardStateReads planningState = wait(readShardState(&tr,
-			                                                          lock,
-			                                                          ddEnabledState,
-			                                                          range,
-			                                                          /*dataMoveId=*/{},
-			                                                          SERVER_KNOBS->MOVE_SHARD_KRM_ROW_LIMIT,
-			                                                          SERVER_KNOBS->MOVE_SHARD_KRM_BYTE_LIMIT));
+				                                                          lock,
+				                                                          ddEnabledState,
+				                                                          range,
+				                                                          /*dataMoveId=*/{},
+				                                                          SERVER_KNOBS->MOVE_SHARD_KRM_ROW_LIMIT,
+				                                                          SERVER_KNOBS->MOVE_SHARD_KRM_BYTE_LIMIT));
 				state RangeResult UIDtoTagMap = planningState.uidToTagMap;
 				state RangeResult keyServers = planningState.keyServers;
 				ASSERT(!keyServers.empty());
@@ -2591,8 +2591,8 @@ ACTOR static Future<Void> finishMoveShards(Database occ,
 
 					if (tssPair != tssMapping.end()) {
 						tssReadyInterfs.push_back(tssPair->second);
-						tssReady.push_back(waitForShardReady(
-						    tssPair->second, range, readVersion, GetShardStateRequest::READABLE));
+						tssReady.push_back(
+						    waitForShardReady(tssPair->second, range, readVersion, GetShardStateRequest::READABLE));
 					}
 				}
 
@@ -2815,8 +2815,10 @@ ACTOR static Future<Void> finishMoveShards(Database occ,
 					if (range.end == postWaitDataMove.ranges.front().end) {
 						// Post validate consistency of update of keyServers and serverKeys
 						if (SERVER_KNOBS->AUDIT_DATAMOVE_POST_CHECK) {
-							wait(auditLocationMetadataPostCheck(
-							    occ, postWaitDataMove.ranges.front(), "finishMoveShards_postcheck", relocationIntervalId));
+							wait(auditLocationMetadataPostCheck(occ,
+							                                    postWaitDataMove.ranges.front(),
+							                                    "finishMoveShards_postcheck",
+							                                    relocationIntervalId));
 						}
 						break;
 					}

--- a/fdbserver/include/fdbserver/MoveKeys.actor.h
+++ b/fdbserver/include/fdbserver/MoveKeys.actor.h
@@ -163,6 +163,27 @@ Future<Void> rawFinishMovement(Database occ,
 // When dataMoveId.isValid(), the keyrange will be moved to a shard designated as dataMoveId.
 ACTOR Future<Void> moveKeys(Database occ, MoveKeysParams params);
 
+// True for errors from moveKeys() that mean "this move did not happen, issue it again" rather than
+// "the cluster is broken". The data distributor already treats exactly these as normal and simply
+// reissues the relocation -- see normalDDQueueErrors() in DataDistribution.actor.cpp and the
+// matching suppression in DDRelocationQueue.actor.cpp.
+//
+// Callers that drive moveKeys() directly (the workloads) must handle these explicitly: none of them
+// are retryable transaction errors, so Transaction::onError() rethrows and kills the caller. Bound
+// any reissue loop by a count rather than a deadline -- one moveKeys() call can spend minutes inside
+// finishMoveKeys()/finishMoveShards() exhausting FINISH_MOVE_KEYS_MAX_RETRIES.
+//
+// movekeys_conflict is deliberately NOT included: it means another DD holds the lock, which callers
+// retry without consuming a reissue budget. broken_promise is likewise excluded so a genuinely dead
+// process still surfaces.
+bool retryableDataMoveError(const Error& e);
+
+// How many times a direct moveKeys() caller should reissue after a retryableDataMoveError() before
+// letting the error propagate. A count, not a wall-clock budget: one moveKeys() call can spend
+// minutes inside finishMoveKeys()/finishMoveShards() exhausting FINISH_MOVE_KEYS_MAX_RETRIES, which
+// blows any sane deadline before the first reissue.
+constexpr int MOVE_MAX_REISSUES = 3;
+
 // Cancels a data move designated by dataMoveId.
 ACTOR Future<Void> cleanUpDataMove(
     Database occ,

--- a/fdbserver/workloads/DataLossRecovery.actor.cpp
+++ b/fdbserver/workloads/DataLossRecovery.actor.cpp
@@ -57,28 +57,6 @@ struct DataLossRecoveryWorkload : TestWorkload {
 	// propagated and the test fails exactly as it did before.
 	static constexpr double READ_RETRY_DEADLINE = 300.0;
 
-	// The setup move below can also fail for reasons that mean "that move did not happen, issue it
-	// again" rather than "the cluster is broken". FDB's own data distributor treats exactly this set as
-	// normal and simply reissues the relocation -- see normalDDQueueErrors() in
-	// DataDistribution.actor.cpp, and the matching suppression in DDRelocationQueue.actor.cpp. None of
-	// them are retryable transaction errors, so tr.onError() would rethrow and kill the workload during
-	// start(). Reissue the move instead, at most this many times, after which the error propagates so a
-	// cluster that genuinely cannot move a shard is still reported. This is a bounded count and not a
-	// wall-clock budget because one moveKeys() call can spend minutes inside finishMoveKeys()
-	// exhausting FINISH_MOVE_KEYS_MAX_RETRIES, which blows any sane deadline before the first reissue.
-	static constexpr int MOVE_MAX_REISSUES = 3;
-
-	static bool retryableDataMoveError(const Error& e) {
-		switch (e.code()) {
-		case error_code_finish_move_keys_too_many_retries:
-		case error_code_data_move_cancelled:
-		case error_code_data_move_dest_team_not_found:
-			return true;
-		default:
-			return false;
-		}
-	}
-
 	FlowLock startMoveKeysParallelismLock;
 	FlowLock finishMoveKeysParallelismLock;
 	const bool enabled;

--- a/fdbserver/workloads/IDDTxnProcessorApiCorrectness.actor.cpp
+++ b/fdbserver/workloads/IDDTxnProcessorApiCorrectness.actor.cpp
@@ -402,6 +402,10 @@ struct IDDTxnProcessorApiWorkload : TestWorkload {
 
 		state MoveKeysParams mockParams = realParams;
 		mockParams.dataMovementComplete = Promise<Void>();
+		// The real moveKeys() can fail with errors that mean "this move did not happen, issue it
+		// again"; see retryableDataMoveError(). Bound the reissues so a cluster that genuinely
+		// cannot move a shard still fails the test.
+		state int moveReissues = 0;
 
 		loop {
 			realParams.dataMovementComplete.reset();
@@ -413,10 +417,21 @@ struct IDDTxnProcessorApiWorkload : TestWorkload {
 				self->testAll++;
 				break;
 			} catch (Error& e) {
-				if (e.code() != error_code_movekeys_conflict)
-					throw;
+				if (e.code() != error_code_movekeys_conflict) {
+					if (!retryableDataMoveError(e) || moveReissues >= MOVE_MAX_REISSUES) {
+						throw;
+					}
+					// The real move did not happen, so reissue it. Re-running the mock move with the
+					// same params is idempotent and the real move converges on the same final state,
+					// so the verifyInitDataEqual() below still compares like with like.
+					++moveReissues;
+					TraceEvent(SevWarn, "IDDTxnProcessorApiMoveKeysReissuing", relocateShardInterval.pairID)
+					    .error(e)
+					    .detail("Reissue", moveReissues)
+					    .detail("Limit", MOVE_MAX_REISSUES);
+				}
 				wait(delay(FLOW_KNOBS->PREVENT_FAST_SPIN_DELAY));
-				// Keep trying to get the moveKeysLock
+				// Keep trying: either to get the moveKeysLock, or to reissue the move.
 			}
 		}
 

--- a/fdbserver/workloads/PhysicalShardMove.actor.cpp
+++ b/fdbserver/workloads/PhysicalShardMove.actor.cpp
@@ -593,6 +593,10 @@ struct PhysicalShardMoveWorkLoad : TestWorkload {
 		state DDEnabledState ddEnabledState;
 
 		state Transaction tr(cx);
+		// moveKeys() can fail with errors that mean "this move did not happen, issue it again"; see
+		// retryableDataMoveError(). Bound the reissues so a cluster that genuinely cannot move a
+		// shard still fails the test.
+		state int moveReissues = 0;
 
 		loop {
 			try {
@@ -647,6 +651,17 @@ struct PhysicalShardMoveWorkLoad : TestWorkload {
 			} catch (Error& e) {
 				if (e.code() == error_code_movekeys_conflict) {
 					// Conflict on moveKeysLocks with the current running DD is expected, just retry.
+					tr.reset();
+				} else if (retryableDataMoveError(e) && moveReissues < MOVE_MAX_REISSUES) {
+					// The move did not happen; reissue it rather than letting tr.onError() rethrow.
+					// finish_move_keys_too_many_retries reaches here from finishMoveShards, which is
+					// the path this workload always takes.
+					++moveReissues;
+					TraceEvent(SevWarn, "TestMoveShardReissuing")
+					    .error(e)
+					    .detail("DataMoveID", dataMoveId)
+					    .detail("Reissue", moveReissues)
+					    .detail("Limit", MOVE_MAX_REISSUES);
 					tr.reset();
 				} else {
 					wait(tr.onError(e));


### PR DESCRIPTION
Backport 0887ae6d29 from main to release-7.4

```
  ## Backport notes

  - Branch `release-7.4` uses Flow actors (`.actor.cpp`, `state`
    keyword, `wait()` macro) rather than main's C++20 coroutines
    (`co_await`). Local variables that need to cross a `wait()` point
    are declared with `state`; return statements use `return`, not
    `co_return`.
  - `constexpr` is not compatible with `state` variables on 7.4.
  - Otherwise the change is behavior-identical to the main PR.
```

DD finishMove*: drop the transaction across waitForShardReady

SERVER_READY_QUORUM_TIMEOUT (15s) was used inside a transaction with a ~5s lifetime (MAX_WRITE_TRANSACTION_LIFE_VERSIONS). When destination servers were slow to respond, the wait alone consumed the txn budget, and commits failed with transaction_too_old — retries too, cascading into the DD pipeline stalls observed in incidents.

Restructure both finish-move functions (finishMoveKeys / finishMoveShards, dispatched on SHARD_ENCODE_LOCATION_METADATA) into a two-transaction pattern with the wait in between:

  Transaction 1: read keyServers / serverTags / serverList (and dataMove
                 metadata for finishMoveShards) via the new
                 readShardState() helper. Save the read version and
                 drop the transaction (tr.reset()).
  Wait:          waitForShardReady — runs OUTSIDE any transaction;
                 the 15s timeout is now safe.
  Transaction 2: re-verify via destUnchanged() (dest hasn't changed,
                 dataMove still in Running phase for finishMoveShards),
                 then commit metadata writes.

If the destination changed during the wait, the inner loop retries from the top — same as today's behaviour on transient errors, just without burning the txn budget on the wait itself.

Verification & retry details:

* destUnchanged() loops every sub-range, not just keyServers[0]. The keys-flavor (`expectedDataMoveId={}`) tolerates empty-dest entries whose src ⊆ expectedDest — matching the planning loop's `alreadyMoved = dest2.empty() && isSubset` branch, which lets sibling iterations of OUR move that already completed pass through. A foreign src on an empty-dest entry signals a different move owns the range and forces a retry to avoid clobbering it. The shards-flavor uses the dataMoveId stamp as the per-sub-range invariant.

* All retry paths (dest-changed, data-move-deleted, phase-changed, plus the count-mismatch else-branch in finishMoveShards) are bounded by FINISH_MOVE_KEYS_MAX_RETRIES and back off via finishMoveKeysBackoff(). Without the cap the dest-changed branch could livelock; the shards- side count-mismatch path was previously unbounded.

* Txn 2's writes use the post-wait snapshot: keyServersValue uses reread.uidToTagMap; finishMoveShards introduces a postWaitDataMove local so the partial-complete / deleteCheckpoints / dataMoveValue writes reflect the fresh dataMove state.

* runPreCheck=false is set inline on each retry path. The partial-complete success-continue deliberately leaves runPreCheck alone so chunks 2..N of a multi-transaction move each get their own AUDIT_DATAMOVE_PRE_CHECK.

* finishMoveShards now takes finishMoveKeysParallelismLock per iteration (mirroring finishMoveKeys). The lock had been function- scoped and released mid-iteration before the wait, so retries ran lockless and silently exceeded MOVE_KEYS_PARALLELISM.

* taskID = TaskPriority::MoveKeys is restored on txn 2 in both functions (tr.reset() drops it).

* New CODE_PROBEs ("dest changed", "data move deleted", "phase changed") are marked probe::decoration::rare; reaching them requires a concurrent reassignment racing into the wait window.

* SHARD_READY_DELAY is buggified to 5.0s to exercise the slow-dest scenario in simulation.

Validation:

* k8s rig: 3 transaction_too_old events vs 360,289 in the prior run without the patch; 0 OOMs.
* Simulation (DDPipelineStall.toml, knob ON): cascade trigger eliminated; transaction_too_old goes to zero; residual TryFinishMoveShardsError events are not_committed which retry cleanly.

`  20260701-232737-stack-backport-74-028aaba11a9b3a30 compressed=True data_size=41562049 duration=3423521 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:29:46 sanity=False started=100000 stopped=20260701-235723 submitted=20260701-232737 timeout=5400 username=stack-backport-74

`