### PR TITLE
[release-7.3] Process ranges in chunks when evicting stale peers

### DIFF
--- a/fdbclient/ClientKnobs.cpp
+++ b/fdbclient/ClientKnobs.cpp
@@ -103,6 +103,7 @@ void ClientKnobs::initialize(Randomize randomize, IsSimulated isSimulated) {
 	init( LOCATION_CACHE_PEER_EVICTOR_ENABLED,          false ); if( randomize && isSimulated ) LOCATION_CACHE_PEER_EVICTOR_ENABLED = deterministicRandom()->coinflip();
 	init( LOCATION_CACHE_PEER_EVICTOR_DELAY,                    60.0 );
 	init( LOCATION_CACHE_PEER_EVICTOR_FAILED_THRESHOLD,      0 );
+	init( LOCATION_CACHE_PEER_EVICTOR_SCAN_CHUNK,         1000000 ); if( randomize && BUGGIFY ) LOCATION_CACHE_PEER_EVICTOR_SCAN_CHUNK = deterministicRandom()->randomInt(1, 11);
 
 	init( GET_RANGE_SHARD_LIMIT,                     2 );
 	init( WARM_RANGE_SHARD_LIMIT,                  100 );

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -1161,6 +1161,124 @@ ACTOR Future<Void> updateCachedRanges(DatabaseContext* self, std::map<UID, Stora
 	}
 }
 
+// Evicts cached ranges mapping to any server address in the input addresses set
+// Yields every LOCATION_CACHE_PEER_EVICTOR_SCAN_CHUNK ranges
+ACTOR static Future<Void> invalidateCacheByAddresses(DatabaseContext* self,
+                                                     std::unordered_set<NetworkAddress> addresses) {
+	// Initial checks
+	if (addresses.empty()) {
+		return Void();
+	}
+	state int rangeChunkThreshold = CLIENT_KNOBS->LOCATION_CACHE_PEER_EVICTOR_SCAN_CHUNK;
+	ASSERT(rangeChunkThreshold >= 1);
+
+	// State across phase 1 and phase 2 below
+	state std::vector<KeyRange> rangesToInvalidate;
+	state double startT = now();
+
+	// Phase 1: scan the cache in chunks, and compute invalid ranges
+	TraceEvent("LocationCacheInvalidatedByAddresses_Phase1_Begin")
+	    .detail("DbId", self->dbId)
+	    .detail("AddressCount", addresses.size());
+	state Key cursor = allKeys.begin;
+	state int phase1RangesScanned = 0;
+	state int phase1Yields = 0;
+
+	loop {
+		TraceEvent("LocationCacheInvalidatedByAddresses_Phase1_ChunkIter")
+		    .suppressFor(5.0)
+		    .detail("DbId", self->dbId)
+		    .detail("AddressCount", addresses.size())
+		    .detail("InvalidatedRanges", rangesToInvalidate.size())
+		    .detail("RangeChunkThreshold", rangeChunkThreshold)
+		    .detail("Phase1RangesScanned", phase1RangesScanned)
+		    .detail("Phase1Yields", phase1Yields);
+
+		// Process as many ranges as possible within chunk threshold
+		auto iter = self->locationCache.rangeContaining(cursor);
+		auto endIter = self->locationCache.ranges().end();
+		bool rangesRemaining = false;
+		int currRangesScanned = 0;
+		for (; iter != endIter; ++iter) {
+			if (currRangesScanned >= rangeChunkThreshold) {
+				rangesRemaining = true;
+				break;
+			}
+			++currRangesScanned;
+			cursor = iter->end();
+			if (!iter->value()) {
+				continue;
+			}
+			auto& loc = iter->value();
+			for (int i = 0; i < loc->size(); ++i) {
+				if (addresses.contains(loc->getInterface(i).address())) {
+					rangesToInvalidate.push_back(KeyRange(KeyRangeRef(iter->begin(), iter->end())));
+					break;
+				}
+			}
+		}
+		phase1RangesScanned += currRangesScanned;
+
+		if (!rangesRemaining) {
+			TraceEvent("LocationCacheInvalidatedByAddresses_Phase1_End")
+			    .detail("DbId", self->dbId)
+			    .detail("AddressCount", addresses.size())
+			    .detail("InvalidatedRanges", rangesToInvalidate.size())
+			    .detail("RangeChunkThreshold", rangeChunkThreshold)
+			    .detail("Phase1RangesScanned", phase1RangesScanned)
+			    .detail("Phase1Yields", phase1Yields)
+			    .detail("Phase1Duration", now() - startT);
+			break;
+		}
+
+		++phase1Yields;
+		TraceEvent("LocationCacheInvalidatedByAddresses_Phase1_Yield")
+		    .suppressFor(5.0)
+		    .detail("DbId", self->dbId)
+		    .detail("AddressCount", addresses.size())
+		    .detail("InvalidatedRanges", rangesToInvalidate.size())
+		    .detail("RangeChunkThreshold", rangeChunkThreshold)
+		    .detail("Phase1RangesScanned", phase1RangesScanned)
+		    .detail("Phase1Yields", phase1Yields);
+		wait(yield());
+	}
+
+	// Phase 2: invalidate the cache based on invalid ranges computed in Phase 1
+	TraceEvent("LocationCacheInvalidatedByAddresses_Phase2_Begin")
+	    .detail("DbId", self->dbId)
+	    .detail("AddressCount", addresses.size())
+	    .detail("InvalidatedRanges", rangesToInvalidate.size());
+	state int phase2Idx = 0;
+	state int phase2Yields = 0;
+	state double phase2StartT = now();
+	for (; phase2Idx < rangesToInvalidate.size(); phase2Idx++) {
+		self->locationCache.insert(rangesToInvalidate[phase2Idx], Reference<LocationInfo>());
+		if ((phase2Idx + 1) % rangeChunkThreshold == 0) {
+			++phase2Yields;
+			TraceEvent("LocationCacheInvalidatedByAddresses_Phase2_Yield")
+			    .suppressFor(5.0)
+			    .detail("DbId", self->dbId)
+			    .detail("AddressCount", addresses.size())
+			    .detail("InvalidatedRanges", rangesToInvalidate.size())
+			    .detail("RangeChunkThreshold", rangeChunkThreshold)
+			    .detail("Phase2RangesScanned", phase2Idx + 1)
+			    .detail("Phase2Yields", phase2Yields);
+			wait(yield());
+		}
+	}
+	TraceEvent("LocationCacheInvalidatedByAddresses_Phase2_End")
+	    .detail("DbId", self->dbId)
+	    .detail("AddressCount", addresses.size())
+	    .detail("InvalidatedRanges", rangesToInvalidate.size())
+	    .detail("RangeChunkThreshold", rangeChunkThreshold)
+	    .detail("Phase2RangesScanned", phase2Idx + 1)
+	    .detail("Phase2Yields", phase2Yields)
+	    .detail("Phase2Duration", now() - phase2StartT)
+	    .detail("OverallDuration", now() - startT);
+
+	return Void();
+}
+
 // Periodically samples FlowTransport's persistent per-address connect-failed
 // counter and evicts any address whose count advanced since the previous tick
 // (a "flap"). This is a direct ConnectionTimeout (CTO) signal: every connect failure increments
@@ -1225,7 +1343,7 @@ ACTOR static Future<Void> locationCachePeerEvictorActor(DatabaseContext* cx) {
 				    .detail("DbId", cx->dbId)
 				    .detail("DeadAddrSetSize", deadAddressSet.size());
 			}
-			cx->invalidateCacheByAddresses(deadAddressSet);
+			wait(invalidateCacheByAddresses(cx, deadAddressSet));
 		} catch (Error& e) {
 			// actor_cancelled must propagate so ~DatabaseContext can tear down the
 			// evictor; any other error should not kill the loop (that would stop the
@@ -2132,34 +2250,6 @@ void DatabaseContext::invalidateCache(const Optional<KeyRef>& tenantPrefix, cons
 	Key begin = rs.begin().begin(),
 	    end = rs.end().begin(); // insert invalidates rs, so can't be passed a mere reference into it
 	locationCache.insert(KeyRangeRef(begin, end), Reference<LocationInfo>());
-}
-
-void DatabaseContext::invalidateCacheByAddresses(const std::unordered_set<NetworkAddress>& addresses) {
-	if (addresses.empty()) {
-		return;
-	}
-	std::vector<KeyRange> rangesToInvalidate;
-	auto ranges = locationCache.ranges();
-	for (auto iter = ranges.begin(); iter != ranges.end(); ++iter) {
-		if (!iter->value())
-			continue;
-		auto& loc = iter->value();
-		for (int i = 0; i < loc->size(); i++) {
-			if (addresses.contains(loc->getInterface(i).address())) {
-				rangesToInvalidate.push_back(KeyRange(KeyRangeRef(iter->begin(), iter->end())));
-				break;
-			}
-		}
-	}
-
-	for (const auto& range : rangesToInvalidate) {
-		locationCache.insert(range, Reference<LocationInfo>());
-	}
-
-	TraceEvent("LocationCacheInvalidatedByAddresses")
-	    .detail("DbId", dbId)
-	    .detail("AddressCount", addresses.size())
-	    .detail("InvalidatedRanges", rangesToInvalidate.size());
 }
 
 void DatabaseContext::setFailedEndpointOnHealthyServer(const Endpoint& endpoint) {

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -1271,7 +1271,7 @@ ACTOR static Future<Void> invalidateCacheByAddresses(DatabaseContext* self,
 	    .detail("AddressCount", addresses.size())
 	    .detail("InvalidatedRanges", rangesToInvalidate.size())
 	    .detail("RangeChunkThreshold", rangeChunkThreshold)
-	    .detail("Phase2RangesScanned", phase2Idx + 1)
+	    .detail("Phase2RangesScanned", phase2Idx)
 	    .detail("Phase2Yields", phase2Yields)
 	    .detail("Phase2Duration", now() - phase2StartT)
 	    .detail("OverallDuration", now() - startT);

--- a/fdbclient/include/fdbclient/ClientKnobs.h
+++ b/fdbclient/include/fdbclient/ClientKnobs.h
@@ -126,6 +126,12 @@ public:
 	// Expected failures per interval ~ LOCATION_CACHE_PEER_EVICTOR_DELAY /
 	//                                   (SERVER_REQUEST_INTERVAL + CONNECTION_MONITOR_TIMEOUT)
 	int LOCATION_CACHE_PEER_EVICTOR_FAILED_THRESHOLD;
+	// Number of location cache ranges the address-based invalidation scan processes
+	// before yielding to the main event loop.
+	// Value must be >= 1 (evictor will assert otherwise).
+	// If this value is > LOCATION_CACHE_EVICTION_SIZE, then this will boil down to blocking
+	// invalidation without any yields in between.
+	int LOCATION_CACHE_PEER_EVICTOR_SCAN_CHUNK;
 
 	int GET_RANGE_SHARD_LIMIT;
 	int WARM_RANGE_SHARD_LIMIT;

--- a/fdbclient/include/fdbclient/DatabaseContext.h
+++ b/fdbclient/include/fdbclient/DatabaseContext.h
@@ -309,7 +309,6 @@ public:
 	Reference<LocationInfo> setCachedLocation(const KeyRangeRef&, const std::vector<struct StorageServerInterface>&);
 	void invalidateCache(const Optional<KeyRef>& tenantPrefix, const KeyRef& key, Reverse isBackward = Reverse::False);
 	void invalidateCache(const Optional<KeyRef>& tenantPrefix, const KeyRangeRef& keys);
-	void invalidateCacheByAddresses(const std::unordered_set<NetworkAddress>& addresses);
 
 	// Records that `endpoint` is failed on a healthy server.
 	void setFailedEndpointOnHealthyServer(const Endpoint& endpoint);

--- a/tests/fast/StalePeerTest.toml
+++ b/tests/fast/StalePeerTest.toml
@@ -22,6 +22,7 @@ coordinators = 3
 location_cache_peer_evictor_enabled = true
 location_cache_peer_evictor_failed_threshold = 0
 location_cache_peer_evictor_delay = 5.0
+location_cache_peer_evictor_scan_chunk = 2
 
 # Ensure stale commit/grv proxies are also cleaned up
 shrink_proxy_list_clear_cache_below_threshold = true


### PR DESCRIPTION
Problem: On every sweep of the eviction actor, invalidateCacheByAddresses is called, which invalidates all cached ranges mapping to stale servers. However, invalidateCacheByAddresses was a blocking call with runtime complexity O(|cached ranges|), which can be as high as 600K (based on the LOCATION_CACHE_EVICTION_SIZE knob default). It is unclear whether this is actually a problem in practice e.g., hogging the main event loop for too long could prevent other critical tasks from making progress. This change is a preemptive fix in case invalidateCacheByAddresses turns out to be too expensive for realistic workloads.

Solution: Introduce a chunk-size knob. invalidateCacheByAddresses now processes ranges in chunks of up to this knob value, yielding before processing the next chunk.

Testing: Simulation testing was done to ensure correctness i.e., that this does not break general DB functionality, and that we continue to fix the stale peer issue. See results below.

Ran 250K general test suite: 20260702-221148-praza-stalepeer-chunkRanges-v2-on7.3.77-25f8 compressed=True data_size=34949681 duration=5923005 ended=250000 fail=2 fail_fast=10 max_runs=250000 pass=249998 priority=100 remaining=0 runtime=1:13:55 sanity=False started=250000 stopped=20260702-232543 submitted=20260702-221148 timeout=5400 username=praza-stalepeer-chunkRanges-v2-on7.3.77-25f80264e08efbc72f892955dd2604ef87d3c46f. Both failures are not related. 

Ran StalePeerTest specifically 10K times: 20260702-221157-praza-stalepeer-chunkRanges-v2-on7.3.77-25f8 compressed=True data_size=34984822 duration=340545 ended=10000 fail_fast=100 max_runs=10000 pass=10000 priority=100 remaining=0 runtime=0:10:22 sanity=False started=10000 stopped=20260702-222219 submitted=20260702-221157 timeout=5400 username=praza-stalepeer-chunkRanges-v2-on7.3.77-25f80264e08efbc72f892955dd2604ef87d3c46f