### PR TITLE
DD `finishMoveKeys`: Separate TTO retry budget

### DIFF
--- a/fdbserver/core/MoveKeys.cpp
+++ b/fdbserver/core/MoveKeys.cpp
@@ -54,6 +54,14 @@ double finishMoveKeysBackoff(int retries) {
 	return std::min(base * (0.75 + 0.5 * deterministicRandom()->random01()), 5.0); // jitter: [0.75x, 1.25x], capped
 }
 
+static bool updateFinishMoveKeysTransactionTooOldRetries(int errorCode, int maxRetries, int* consecutiveRetries) {
+	if (errorCode != error_code_transaction_too_old) {
+		*consecutiveRetries = 0;
+		return false;
+	}
+	return ++(*consecutiveRetries) > maxRetries;
+}
+
 // Shared retry tail used by the finishMove* post-wait branches that detect a
 // concurrent change (dest reassigned, data move deleted, phase changed):
 // bumps `retries`, throws finish_move_keys_too_many_retries once the cap is
@@ -1429,6 +1437,10 @@ static Future<Void> finishMoveKeys(Database occ,
 	Key begin = keys.begin;
 	Key endKey;
 	int retries = 0;
+	// Transaction 2 can hit benign not_committed conflicts while adjacent
+	// finishers update KRM ranges. Only consecutive transaction_too_old
+	// failures should exhaust the bailout intended for a stuck TTO loop.
+	int consecutiveTransactionTooOldRetries = 0;
 	FlowLock::Releaser releaser;
 
 	std::unordered_set<UID> tssToIgnore;
@@ -1587,6 +1599,7 @@ static Future<Void> finishMoveKeys(Database occ,
 						    .detail("IterationBegin", begin)
 						    .detail("IterationEnd", endKey);
 						begin = keyServers.end()[-1].key;
+						consecutiveTransactionTooOldRetries = 0;
 						break;
 					}
 
@@ -1766,6 +1779,7 @@ static Future<Void> finishMoveKeys(Database occ,
 							    .detail("KeyBegin", keys.begin)
 							    .detail("KeyEnd", keys.end)
 							    .detail("OrigDest", describe(dest));
+							consecutiveTransactionTooOldRetries = 0;
 							co_await retryAfterPostWaitChange(&retries, &tr);
 							continue;
 						}
@@ -1801,10 +1815,12 @@ static Future<Void> finishMoveKeys(Database occ,
 
 						begin = endKey;
 						retries = 0;
+						consecutiveTransactionTooOldRetries = 0;
 						break;
 					}
 					// This leads to a count of transactions starting that exceeds the sum of
 					// committed or aborted, but this is intentional here.
+					consecutiveTransactionTooOldRetries = 0;
 					retries++;
 					if (retries > SERVER_KNOBS->FINISH_MOVE_KEYS_MAX_RETRIES) {
 						CODE_PROBE(true, "finishMoveKeys giving up due to timeout on dest servers");
@@ -1829,6 +1845,8 @@ static Future<Void> finishMoveKeys(Database occ,
 					throw err;
 				co_await tr.onError(err);
 				retries++;
+				bool tooManyConsecutiveTransactionTooOldRetries = updateFinishMoveKeysTransactionTooOldRetries(
+				    err.code(), SERVER_KNOBS->FINISH_MOVE_KEYS_MAX_RETRIES, &consecutiveTransactionTooOldRetries);
 				// tr.onError delays are short for transaction_too_old. With 15
 				// FlowLock slots all retrying, this creates a retry storm. Add
 				// additional exponential backoff capped at 5s.
@@ -1838,14 +1856,16 @@ static Future<Void> finishMoveKeys(Database occ,
 					TraceEvent("FinishMoveKeysBackoff", relocationIntervalId)
 					    .suppressFor(1.0)
 					    .detail("Retries", retries)
+					    .detail("TransactionTooOldRetries", consecutiveTransactionTooOldRetries)
 					    .detail("BackoffSeconds", backoff);
-					if (retries > SERVER_KNOBS->FINISH_MOVE_KEYS_MAX_RETRIES) {
+					if (tooManyConsecutiveTransactionTooOldRetries) {
 						CODE_PROBE(true, "finishMoveKeys giving up after max retries");
 						TraceEvent(SevWarnAlways, "RelocateShard_FinishMoveKeysGivingUp", relocationIntervalId)
 						    .error(err)
 						    .detail("KeyBegin", keys.begin)
 						    .detail("KeyEnd", keys.end)
-						    .detail("Retries", retries);
+						    .detail("Retries", retries)
+						    .detail("TransactionTooOldRetries", consecutiveTransactionTooOldRetries);
 						throw finish_move_keys_too_many_retries();
 					}
 					co_await delay(backoff);
@@ -3854,6 +3874,27 @@ TEST_CASE("/fdbserver/MoveKeys/finishMoveKeysBackoff") {
 
 	// Verify the retry limit knob exists and is positive
 	ASSERT(SERVER_KNOBS->FINISH_MOVE_KEYS_MAX_RETRIES > 0);
+
+	return Void();
+}
+
+TEST_CASE("/fdbserver/MoveKeys/consecutiveTransactionTooOldRetryBudget") {
+	constexpr int maxRetries = 2;
+	int consecutiveRetries = 0;
+
+	ASSERT(
+	    !updateFinishMoveKeysTransactionTooOldRetries(error_code_transaction_too_old, maxRetries, &consecutiveRetries));
+	ASSERT(consecutiveRetries == 1);
+	ASSERT(!updateFinishMoveKeysTransactionTooOldRetries(error_code_not_committed, maxRetries, &consecutiveRetries));
+	ASSERT(consecutiveRetries == 0);
+
+	ASSERT(
+	    !updateFinishMoveKeysTransactionTooOldRetries(error_code_transaction_too_old, maxRetries, &consecutiveRetries));
+	ASSERT(
+	    !updateFinishMoveKeysTransactionTooOldRetries(error_code_transaction_too_old, maxRetries, &consecutiveRetries));
+	ASSERT(
+	    updateFinishMoveKeysTransactionTooOldRetries(error_code_transaction_too_old, maxRetries, &consecutiveRetries));
+	ASSERT(consecutiveRetries == maxRetries + 1);
 
 	return Void();
 }


### PR DESCRIPTION
Test failure: The original `MoveKeysCycle` configuration stalled DD for about 4200 simulated seconds.

Bug: `finishMoveKeys` consumed its `transaction_too_old` bailout budget across non-consecutive `transaction_too_old` errors, so benign intervening outcomes did not reset the budget.

Fix: Track `transaction_too_old` retries separately and reset that counter after intervening outcomes.

Validation: Exact replay passed in 253.328 simulated seconds versus the original stuck run; 18/18 core tests passed, including the deterministic retry-budget case; focused `DDPipelineSaturation` and `MoveKeysCycle` replays passed with the same seed and Joshua seed; the logic then rode five clean 100k campaigns.
