### PR TITLE
Recruit partial replacement log routers

### DIFF
--- a/fdbserver/clustercontroller/ClusterController.actor.cpp
+++ b/fdbserver/clustercontroller/ClusterController.actor.cpp
@@ -302,12 +302,19 @@ Future<Void> recruitFailedLogRouters(ClusterControllerData* cluster,
 	std::vector<WorkerDetails> workers =
 	    cluster->getWorkersForRoleInDatacenter(targetDcId, ProcessClass::LogRouter, tagIds.size(), db->config, id_used);
 
-	if (workers.size() < tagIds.size()) {
+	if (workers.empty()) {
 		TraceEvent(SevWarn, "NotEnoughWorkersForLogRouters", cluster->id)
 		    .detail("Required", tagIds.size())
 		    .detail("Available", workers.size())
 		    .detail("TargetDcId", targetDcId);
 		throw recruitment_failed();
+	}
+	if (workers.size() < tagIds.size()) {
+		TraceEvent(SevWarn, "PartialWorkersForLogRouters", cluster->id)
+		    .detail("Required", tagIds.size())
+		    .detail("Available", workers.size())
+		    .detail("TargetDcId", targetDcId);
+		tagIds.resize(workers.size());
 	}
 
 	// Replacement log routers will determine their own start version by querying

--- a/fdbserver/clustercontroller/ClusterController.actor.cpp
+++ b/fdbserver/clustercontroller/ClusterController.actor.cpp
@@ -310,6 +310,7 @@ Future<Void> recruitFailedLogRouters(ClusterControllerData* cluster,
 		throw recruitment_failed();
 	}
 	if (workers.size() < tagIds.size()) {
+		CODE_PROBE(true, "Recruit partial replacement log routers");
 		TraceEvent(SevWarn, "PartialWorkersForLogRouters", cluster->id)
 		    .detail("Required", tagIds.size())
 		    .detail("Available", workers.size())


### PR DESCRIPTION
Test failure: `tests/fast/TxnStateStoreCycleTest.toml`; the failing artifact rejected usable workers 27,465 times and aborted at simulated time 27,832.

Bug: Replacement recruitment discarded all available workers whenever fewer workers than failed log-router tags were eligible, causing an infinite retry loop.

Fix: Recruit the available subset, publish those interfaces, and let the monitor recruit remaining failed tags in later rounds.

Validation: Exact cycle-33 replay passed in 10.1 seconds at simulated time 449.368; its trace showed 4→3 partial-set progress, tags 0/2/3, then final tag 5 before QuietDatabaseEndDone; 19/19 cluster-controller tests passed.
