### PR TITLE
Fix `LatencySample` median calculation

### DIFF
--- a/fdbrpc/Stats.cpp
+++ b/fdbrpc/Stats.cpp
@@ -243,7 +243,7 @@ void LatencySample::logSample() {
 		return;
 	}
 	double p25 = sketch.percentile(0.25);
-	double p50 = sketch.mean();
+	double p50 = sketch.percentile(0.5);
 	double p90 = sketch.percentile(0.9);
 	double p95 = sketch.percentile(0.95);
 	double p99 = sketch.percentile(0.99);


### PR DESCRIPTION
Previously mean was used instead of median, even though the field was traced as `Median`.