### PR TITLE
Drop stale backup workers during recovery

### DIFF
--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -3094,6 +3094,27 @@ ACTOR Future<Reference<ILogSystem>> TagPartitionedLogSystem::newEpoch(
 		logSystem->expectedLogSets++;
 	}
 
+	// Backup workers are bound to the recovery that recruited them and self-displace when the recovery count
+	// advances. Do not carry their interfaces into this recovery: the master re-recruits any unfinished work from
+	// durable progress, and monitoring an inherited interface would turn expected displacement into
+	// backup_worker_failed.
+	size_t droppedBackupWorkers = 0;
+	auto dropBackupWorkers = [&droppedBackupWorkers](const std::vector<Reference<LogSet>>& logSets) {
+		for (const auto& logSet : logSets) {
+			droppedBackupWorkers += logSet->backupWorkers.size();
+			logSet->backupWorkers.clear();
+		}
+	};
+	dropBackupWorkers(oldLogSystem->tLogs);
+	for (const auto& old : oldLogSystem->oldLogData) {
+		dropBackupWorkers(old.tLogs);
+	}
+	if (droppedBackupWorkers > 0) {
+		TraceEvent("DropPreviousRecoveryBackupWorkers", logSystem->dbgid)
+		    .detail("RecoveryCount", recoveryCount)
+		    .detail("Count", droppedBackupWorkers);
+	}
+
 	if (oldLogSystem->tLogs.size()) {
 		logSystem->oldLogData.emplace_back();
 		logSystem->oldLogData[0].tLogs = oldLogSystem->tLogs;


### PR DESCRIPTION
cherry-pick of #13389 
Backup workers recruited by a previous recovery self-displace when the recovery count advances. The new log system was retaining their interfaces in inherited log sets, causing the expected shutdown to be observed as backup_worker_failed and triggering another recovery.
Drop inherited backup-worker interfaces when creating the next log-system epoch. Unfinished backup work is still re-recruited from durable BackupProgress, while newly recruited workers remain monitored normally.

100k correctness:
20260707-064722-neethu1-f7a1f5e7b1fd7976           compressed=True data_size=60809921 duration=3217361 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:44:02 sanity=False started=100000 stopped=20260707-073124 submitted=20260707-064722 timeout=5400 username=neethu1
