### PR TITLE
Fix more `clang-tidy` warnings

### DIFF
--- a/fdbserver/clustercontroller/ClusterController.actor.cpp
+++ b/fdbserver/clustercontroller/ClusterController.actor.cpp
@@ -73,8 +73,8 @@
 #include "flow/actorcompiler.h" // This must be the last #include.
 
 ClusterControllerData::DBInfo::DBInfo()
-  : clientInfo(new AsyncVar<ClientDBInfo>()), serverInfo(new AsyncVar<ServerDBInfo>()),
-    masterRegistrationCount(0), dbInfoCount(0), recoveryStalled(false), forceRecovery(false),
+  : clientInfo(new AsyncVar<ClientDBInfo>()), serverInfo(new AsyncVar<ServerDBInfo>()), masterRegistrationCount(0),
+    dbInfoCount(0), recoveryStalled(false), forceRecovery(false),
     db(DatabaseContext::create(clientInfo,
                                Future<Void>(),
                                LocalityData(),

--- a/fdbserver/clustercontroller/ClusterController.actor.cpp
+++ b/fdbserver/clustercontroller/ClusterController.actor.cpp
@@ -72,6 +72,21 @@
 
 #include "flow/actorcompiler.h" // This must be the last #include.
 
+ClusterControllerData::DBInfo::DBInfo()
+  : clientInfo(new AsyncVar<ClientDBInfo>()), serverInfo(new AsyncVar<ServerDBInfo>()),
+    masterRegistrationCount(0), dbInfoCount(0), recoveryStalled(false), forceRecovery(false),
+    db(DatabaseContext::create(clientInfo,
+                               Future<Void>(),
+                               LocalityData(),
+                               EnableLocalityLoadBalance::True,
+                               TaskPriority::DefaultEndpoint,
+                               LockAware::True)), // SOMEDAY: Locality!
+    unfinishedRecoveries(0), cachePopulated(false), clientCount(0) {
+	clientCounter = countClients(this);
+}
+
+ClusterControllerData::DBInfo::~DBInfo() = default;
+
 static bool storageTeamOneReplicaLeftIsCritical(DatabaseConfiguration const& configuration) {
 	return configuration.initialized && configuration.storageTeamSize == 3;
 }

--- a/fdbserver/clustercontroller/ClusterController.h
+++ b/fdbserver/clustercontroller/ClusterController.h
@@ -145,18 +145,8 @@ public:
 		ClusterType clusterType = ClusterType::STANDALONE;
 		Reference<ClusterRecoveryData> recoveryData;
 
-		DBInfo()
-		  : clientInfo(new AsyncVar<ClientDBInfo>()), serverInfo(new AsyncVar<ServerDBInfo>()),
-		    masterRegistrationCount(0), dbInfoCount(0), recoveryStalled(false), forceRecovery(false),
-		    db(DatabaseContext::create(clientInfo,
-		                               Future<Void>(),
-		                               LocalityData(),
-		                               EnableLocalityLoadBalance::True,
-		                               TaskPriority::DefaultEndpoint,
-		                               LockAware::True)), // SOMEDAY: Locality!
-		    unfinishedRecoveries(0), cachePopulated(false), clientCount(0) {
-			clientCounter = countClients(this);
-		}
+		DBInfo();
+		~DBInfo();
 
 		void setDistributor(const DataDistributorInterface& interf) {
 			auto newInfo = serverInfo->get();

--- a/fdbserver/logsystem/include/fdbserver/logsystem/LogSystem.h
+++ b/fdbserver/logsystem/include/fdbserver/logsystem/LogSystem.h
@@ -54,44 +54,7 @@ struct LocalityData;
 struct LogSystem;
 struct LogSystemConsumer;
 class LogSet;
-
-struct ConnectionResetInfo : public ReferenceCounted<ConnectionResetInfo> {
-	double lastReset;
-	Future<Void> resetCheck;
-	int slowReplies;
-	int fastReplies;
-
-	ConnectionResetInfo() : lastReset(now()), resetCheck(Void()), slowReplies(0), fastReplies(0) {}
-};
-
-// Base cursor contract for consuming a sequential log peek stream.
-struct IPeekCursor {
-	virtual void setProtocolVersion(ProtocolVersion version) = 0;
-
-	virtual bool hasMessage() const = 0;
-	virtual VectorRef<Tag> getTags() const = 0;
-	virtual Arena& arena() = 0;
-	virtual ArenaReader* reader() = 0;
-	virtual StringRef getMessage() = 0;
-	virtual StringRef getMessageWithTags() = 0;
-	virtual void nextMessage() = 0;
-	virtual Future<Void> getMore(TaskPriority taskID = TaskPriority::TLogPeekReply) = 0;
-	virtual bool isExhausted() const = 0;
-	virtual const LogMessageVersion& version() const = 0;
-	virtual Version popped() const = 0;
-	virtual Version getMinKnownCommittedVersion() const = 0;
-	virtual void addref() = 0;
-	virtual void delref() = 0;
-};
-
-// Peek cursor that reports log location and can be cloned and repositioned for replay.
-struct IReplayPeekCursor : IPeekCursor {
-	virtual Optional<UID> getPrimaryPeekLocation() const = 0;
-	virtual Optional<UID> getCurrentPeekLocation() const = 0;
-	virtual Version getMaxKnownVersion() const = 0;
-	virtual Reference<IReplayPeekCursor> cloneNoMore() = 0;
-	virtual void advanceTo(LogMessageVersion n) = 0;
-};
+struct ConnectionResetInfo;
 
 struct LogPushVersionSet {
 	Version prevVersion;

--- a/fdbserver/logsystem/include/fdbserver/logsystem/LogSystemTypes.h
+++ b/fdbserver/logsystem/include/fdbserver/logsystem/LogSystemTypes.h
@@ -22,8 +22,47 @@
 #define FDBSERVER_LOGSYSTEM_LOGSYSTEMTYPES_H
 #pragma once
 
+#include "fdbrpc/Replication.h"
 #include "fdbserver/core/LogSystemConfig.h"
 #include "fdbserver/core/DBCoreState.h"
+
+struct ConnectionResetInfo : public ReferenceCounted<ConnectionResetInfo> {
+	double lastReset;
+	Future<Void> resetCheck;
+	int slowReplies;
+	int fastReplies;
+
+	ConnectionResetInfo() : lastReset(now()), resetCheck(Void()), slowReplies(0), fastReplies(0) {}
+};
+
+// Base cursor contract for consuming a sequential log peek stream.
+struct IPeekCursor {
+	virtual void setProtocolVersion(ProtocolVersion version) = 0;
+
+	virtual bool hasMessage() const = 0;
+	virtual VectorRef<Tag> getTags() const = 0;
+	virtual Arena& arena() = 0;
+	virtual ArenaReader* reader() = 0;
+	virtual StringRef getMessage() = 0;
+	virtual StringRef getMessageWithTags() = 0;
+	virtual void nextMessage() = 0;
+	virtual Future<Void> getMore(TaskPriority taskID = TaskPriority::TLogPeekReply) = 0;
+	virtual bool isExhausted() const = 0;
+	virtual const LogMessageVersion& version() const = 0;
+	virtual Version popped() const = 0;
+	virtual Version getMinKnownCommittedVersion() const = 0;
+	virtual void addref() = 0;
+	virtual void delref() = 0;
+};
+
+// Peek cursor that reports log location and can be cloned and repositioned for replay.
+struct IReplayPeekCursor : IPeekCursor {
+	virtual Optional<UID> getPrimaryPeekLocation() const = 0;
+	virtual Optional<UID> getCurrentPeekLocation() const = 0;
+	virtual Version getMaxKnownVersion() const = 0;
+	virtual Reference<IReplayPeekCursor> cloneNoMore() = 0;
+	virtual void advanceTo(LogMessageVersion n) = 0;
+};
 
 class LogSet : NonCopyable, public ReferenceCounted<LogSet> {
 public:


### PR DESCRIPTION
This PR fixes some warnings missed by https://github.com/apple/foundationdb/pull/13656
