### PR TITLE
fdb_c wiggle tests: increase process count and add transaction timeouts

### DIFF
--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -385,7 +385,10 @@ if(NOT WIN32)
         --test-file ${CMAKE_SOURCE_DIR}/bindings/c/test/apitester/tests/upgrade/MixedApiWorkloadMultiThr.toml
         --upgrade-path "${FDB_CURRENT_VERSION}" "wiggle"
         --disable-log-dump
-        --process-number 3
+        # A wiggle replaces every storage server; with only 3 processes the cluster
+        # has no spare capacity to recruit the replacements, so recovery can stall
+        # past the progress-check window. 5 processes gives the wiggle headroom.
+        --process-number 5
         --redundancy double
         )
 
@@ -395,7 +398,9 @@ if(NOT WIN32)
         --test-file ${CMAKE_SOURCE_DIR}/bindings/c/test/apitester/tests/upgrade/MixedApiWorkloadMultiThr.toml
         --upgrade-path "${FDB_PREV_RELEASE_VERSION}" "wiggle" "${FDB_CURRENT_VERSION}"
         --disable-log-dump
-        --process-number 3
+        # See fdb_c_wiggle_only: a wiggle needs spare process capacity to recruit
+        # replacement storage servers.
+        --process-number 5
         --redundancy double
         )
 

--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -406,8 +406,11 @@ if(NOT WIN32)
 
       # These tests replace every process in a local cluster. Running them with
       # other CTests can starve recovery long enough to trip the progress check.
+      # Worst-case budget: cluster startup + exclude/remove (120s) +
+      # wait_for_cluster_healthy (180s) + progress checks 3x30s (90s) = ~450s.
+      # Use 900s to leave margin for slow machines.
       set_tests_properties(fdb_c_wiggle_only fdb_c_wiggle_and_upgrade
-        PROPERTIES RUN_SERIAL TRUE)
+        PROPERTIES RUN_SERIAL TRUE TIMEOUT 900)
 
     endif()
   endif()

--- a/bindings/c/test/apitester/tests/upgrade/MixedApiWorkloadMultiThr.toml
+++ b/bindings/c/test/apitester/tests/upgrade/MixedApiWorkloadMultiThr.toml
@@ -1,3 +1,18 @@
+# Mixed workload for the C API upgrade/wiggle tests (fdb_c_wiggle_only,
+# fdb_c_upgrade_from_prev*, fdb_c_wiggle_and_upgrade, fdb_c_upgrade_to_future_version).
+#
+# minTxTimeoutMs/maxTxTimeoutMs give every transactional workload a timeout
+# backstop (which also enables restartOnTimeout in the executor). Without it, a
+# request whose reply never arrives across a wiggle/upgrade (coordinator change +
+# storage re-recruitment can leave an in-flight request targeting a stale endpoint
+# token, which FlowTransport drops silently and never errors) leaves the
+# transaction's future pending forever; the workload stops making progress and the
+# 30s post-step progress check fails (SIGKILL). With a timeout the stuck op fails
+# with timed_out, the executor restarts it (re-resolving locations), and the
+# workload recovers. The range is kept well under the 30s progress-check window so
+# the retry completes in time, and above normal op latency so healthy ops are
+# unaffected.
+
 [[test]]
 title = 'Mixed Workload for Upgrade Tests with a Multi-Threaded Client'
 multiThreaded = true
@@ -22,6 +37,8 @@ maxClients = 8
     initialSize = 100
     runUntilStop = true
     readExistingKeysRatio = 0.9
+    minTxTimeoutMs = 2000
+    maxTxTimeoutMs = 10000
 
     [[test.workload]]
     name = 'CancelTransaction'
@@ -33,13 +50,19 @@ maxClients = 8
     initialSize = 100
     runUntilStop = true
     readExistingKeysRatio = 0.9
+    minTxTimeoutMs = 2000
+    maxTxTimeoutMs = 10000
 
     [[test.workload]]
     name = 'AtomicOpsCorrectness'
     initialSize = 0
     runUntilStop = true
+    minTxTimeoutMs = 2000
+    maxTxTimeoutMs = 10000
 
     [[test.workload]]
     name = 'WatchAndWait'
     initialSize = 0
     runUntilStop = true
+    minTxTimeoutMs = 2000
+    maxTxTimeoutMs = 10000

--- a/bindings/c/test/apitester/tests/upgrade/MixedApiWorkloadMultiThr.toml
+++ b/bindings/c/test/apitester/tests/upgrade/MixedApiWorkloadMultiThr.toml
@@ -64,5 +64,9 @@ maxClients = 8
     name = 'WatchAndWait'
     initialSize = 0
     runUntilStop = true
-    minTxTimeoutMs = 2000
-    maxTxTimeoutMs = 10000
+    # WatchAndWait does not get a timeout: it relies on a concurrent transaction
+    # setting the watched key to fire the watch naturally. A timeout would leave
+    # the watch future orphaned in pre-8.0.0 client libraries (which lack the
+    # cancelWatches fix), causing the workload to hang permanently even on a
+    # stable cluster. The other workloads' timeouts are sufficient to recover
+    # from stale-endpoint hangs during upgrades.


### PR DESCRIPTION
Like #13657, part of the effort at making the wiggle ctest more reliable.

    1. Increase --process-number from 3 to 5 in fdb_c_wiggle_only and
       fdb_c_wiggle_and_upgrade. The wiggle replaces every storage server;
       with only 3 processes the cluster has no spare capacity to recruit
       replacements, so recovery can stall past the 30s progress-check
       window. 5 processes gives the wiggle enough headroom.

    2. Add minTxTimeoutMs=2000 / maxTxTimeoutMs=10000 to every workload
       in MixedApiWorkloadMultiThr.toml. Without a timeout, a request
       whose reply is silently dropped by FlowTransport (stale endpoint
       token across a coordinator change) leaves the transaction future
       pending forever. With a timeout, the stuck op fails with timed_out,
       the executor restarts it re-resolving locations, and the workload
       recovers before the 30s progress-check window.

`
  20260708-000051-stack_configs-29ebdf038c3ff9a8     compressed=True data_size=37350433 duration=2292676 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:43:49 sanity=False started=100000 stopped=20260708-004440 submitted=20260708-000051 timeout=5400 username=stack_configs`


Running wiggle ctests back-to-back, the below helps (not enough though to make them 100% reliable).
