### PR TITLE
Add GCM Authentication Tag to Encrypted Backup Files

### DIFF
--- a/fdbclient/BackupContainerFileSystem.cpp
+++ b/fdbclient/BackupContainerFileSystem.cpp
@@ -29,6 +29,7 @@
 #include "BackupContainerLocalDirectory.h"
 #include "BackupContainerBlobStore.h"
 #include "fdbclient/JsonBuilder.h"
+#include "fdbrpc/AsyncFileEncrypted.h"
 #include "flow/StreamCipher.h"
 #include "flow/UnitTest.h"
 
@@ -1619,13 +1620,18 @@ Future<std::vector<LogFile>> BackupContainerFileSystem::listLogFiles(Version beg
 	};
 
 	return map(listFiles((mutationLogType == MutationLogType::PARTITIONED_LOG ? "plogs/" : "logs/"), pathFilter),
-	           [=](const FilesAndSizesT& files) {
+	           [=, self = Reference<BackupContainerFileSystem>::addRef(this)](const FilesAndSizesT& files) {
 		           std::vector<LogFile> results;
 		           LogFile lf;
 		           for (auto& f : files) {
 			           if (BackupContainerFileSystemImpl::pathToLogFile(lf, f.first, f.second) &&
-			               lf.endVersion > beginVersion && lf.beginVersion <= targetVersion)
+			               lf.endVersion > beginVersion && lf.beginVersion <= targetVersion) {
+				           if (self->usesEncryption()) {
+					           lf.fileSize =
+					               AsyncFileEncrypted::rawToLogicalSize(lf.fileSize, self->encryptionBlockSize);
+				           }
 				           results.push_back(lf);
+			           }
 		           }
 		           return results;
 	           });
@@ -1647,16 +1653,22 @@ Future<std::vector<RangeFile>> BackupContainerFileSystem::old_listRangeFiles(Ver
 		       (cleaned > firstPath && cleaned < lastPath);
 	};
 
-	return map(listFiles("ranges/", pathFilter), [=](const FilesAndSizesT& files) {
-		std::vector<RangeFile> results;
-		RangeFile rf;
-		for (auto& f : files) {
-			if (BackupContainerFileSystemImpl::pathToRangeFile(rf, f.first, f.second) && rf.version >= beginVersion &&
-			    rf.version <= endVersion)
-				results.push_back(rf);
-		}
-		return results;
-	});
+	return map(listFiles("ranges/", pathFilter),
+	           [=, self = Reference<BackupContainerFileSystem>::addRef(this)](const FilesAndSizesT& files) {
+		           std::vector<RangeFile> results;
+		           RangeFile rf;
+		           for (auto& f : files) {
+			           if (BackupContainerFileSystemImpl::pathToRangeFile(rf, f.first, f.second) &&
+			               rf.version >= beginVersion && rf.version <= endVersion) {
+				           if (self->usesEncryption()) {
+					           rf.fileSize =
+					               AsyncFileEncrypted::rawToLogicalSize(rf.fileSize, self->encryptionBlockSize);
+				           }
+				           results.push_back(rf);
+			           }
+		           }
+		           return results;
+	           });
 }
 
 Future<std::vector<RangeFile>> BackupContainerFileSystem::listRangeFiles(Version beginVersion, Version endVersion) {
@@ -1669,16 +1681,22 @@ Future<std::vector<RangeFile>> BackupContainerFileSystem::listRangeFiles(Version
 		return BackupContainerFileSystemImpl::extractSnapshotBeginVersion(path) <= endVersion;
 	};
 
-	Future<std::vector<RangeFile>> newFiles = map(listFiles("kvranges/", pathFilter), [=](const FilesAndSizesT& files) {
-		std::vector<RangeFile> results;
-		RangeFile rf;
-		for (auto& f : files) {
-			if (BackupContainerFileSystemImpl::pathToRangeFile(rf, f.first, f.second) && rf.version >= beginVersion &&
-			    rf.version <= endVersion)
-				results.push_back(rf);
-		}
-		return results;
-	});
+	Future<std::vector<RangeFile>> newFiles =
+	    map(listFiles("kvranges/", pathFilter),
+	        [=, self = Reference<BackupContainerFileSystem>::addRef(this)](const FilesAndSizesT& files) {
+		        std::vector<RangeFile> results;
+		        RangeFile rf;
+		        for (auto& f : files) {
+			        if (BackupContainerFileSystemImpl::pathToRangeFile(rf, f.first, f.second) &&
+			            rf.version >= beginVersion && rf.version <= endVersion) {
+				        if (self->usesEncryption()) {
+					        rf.fileSize = AsyncFileEncrypted::rawToLogicalSize(rf.fileSize, self->encryptionBlockSize);
+				        }
+				        results.push_back(rf);
+			        }
+		        }
+		        return results;
+	        });
 
 	return map(success(oldFiles) && success(newFiles), [=](Void _) {
 		std::vector<RangeFile> results = newFiles.get();

--- a/fdbrpc/AsyncFileEncrypted.cpp
+++ b/fdbrpc/AsyncFileEncrypted.cpp
@@ -44,22 +44,30 @@ public:
 		return iv;
 	}
 
-	// Read a single block of size encryptionBlockSize bytes, and decrypt.
+	// Read a single block of encryptionBlockSize bytes plus the trailing GCM tag, verify tag, and decrypt.
 	static Future<Standalone<StringRef>> readBlock(AsyncFileEncrypted* self, uint32_t block) {
 		Arena arena;
-		auto* encrypted = new (arena) unsigned char[self->encryptionBlockSize];
-		int bytes = co_await uncancellable(holdWhile(
-		    arena, self->file->read(encrypted, self->encryptionBlockSize, self->encryptionBlockSize * block)));
+		const int rawBlockSize = self->encryptionBlockSize + GCM_TAG_LEN;
+		auto* encrypted = new (arena) unsigned char[rawBlockSize];
+		int bytes = co_await uncancellable(
+		    holdWhile(arena, self->file->read(encrypted, rawBlockSize, int64_t(rawBlockSize) * block)));
+		if (bytes < GCM_TAG_LEN) {
+			throw restore_corrupted_data();
+		}
+		const int ciphertextLen = bytes - GCM_TAG_LEN;
+		const uint8_t* tag = encrypted + ciphertextLen;
 		StreamCipherKey const* cipherKey = StreamCipherKey::getGlobalCipherKey();
 		DecryptionStreamCipher decryptor(cipherKey, self->getIV(block));
-		auto decrypted = decryptor.decrypt(encrypted, bytes, arena);
+		auto decrypted = decryptor.decrypt(encrypted, ciphertextLen, arena);
+		// Throws restore_corrupted_data if the tag does not verify.
+		decryptor.finish(tag, arena);
 		co_return Standalone<StringRef>(decrypted, arena);
 	}
 
 	static Future<int> read(Reference<AsyncFileEncrypted> self, void* data, int length, int64_t offset) {
 		if (self->fileSize == -1) {
-			int64_t fileSize = co_await self->file->size();
-			self->fileSize = fileSize;
+			int64_t rawSize = co_await self->file->size();
+			self->fileSize = AsyncFileEncrypted::rawToLogicalSize(rawSize, self->encryptionBlockSize);
 		}
 		if (offset >= self->fileSize) {
 			co_return 0;
@@ -104,10 +112,7 @@ public:
 		auto const* input = reinterpret_cast<unsigned char const*>(data);
 		while (length > 0) {
 			const auto chunkSize = std::min(length, self->encryptionBlockSize - self->offsetInBlock);
-			Arena arena;
-			auto encrypted = self->encryptor->encrypt(input, chunkSize, arena);
-			std::copy(encrypted.begin(), encrypted.end(), &self->writeBuffer[self->offsetInBlock]);
-			offset += encrypted.size();
+			std::copy(input, input + chunkSize, &self->writeBuffer[self->offsetInBlock]);
 			self->offsetInBlock += chunkSize;
 			length -= chunkSize;
 			input += chunkSize;
@@ -116,15 +121,15 @@ public:
 				self->offsetInBlock = 0;
 				ASSERT_LT(self->currentBlock, std::numeric_limits<uint32_t>::max());
 				++self->currentBlock;
-				self->encryptor = std::make_unique<EncryptionStreamCipher>(StreamCipherKey::getGlobalCipherKey(),
-				                                                           self->getIV(self->currentBlock));
 			}
 		}
 	}
 
 	static Future<Void> sync(Reference<AsyncFileEncrypted> self) {
 		ASSERT(self->mode == AsyncFileEncrypted::Mode::APPEND_ONLY);
-		co_await self->writeLastBlockToFile();
+		if (self->offsetInBlock > 0) {
+			co_await self->writeLastBlockToFile();
+		}
 		co_await self->file->sync();
 	}
 
@@ -143,8 +148,6 @@ AsyncFileEncrypted::AsyncFileEncrypted(Reference<IAsyncFile> file, Mode mode, in
 	ASSERT(encryptionBlockSize > 0);
 	firstBlockIV = AsyncFileEncryptedImpl::getFirstBlockIV(file->getFilename());
 	if (mode == Mode::APPEND_ONLY) {
-		encryptor =
-		    std::make_unique<EncryptionStreamCipher>(StreamCipherKey::getGlobalCipherKey(), getIV(currentBlock));
 		writeBuffer = std::vector<unsigned char>(encryptionBlockSize, 0);
 	}
 }
@@ -155,6 +158,29 @@ void AsyncFileEncrypted::addref() {
 
 void AsyncFileEncrypted::delref() {
 	ReferenceCounted<AsyncFileEncrypted>::delref();
+}
+
+int64_t AsyncFileEncrypted::rawToLogicalSize(int64_t rawSize, int blockSize) {
+	const int64_t rawBlockSize = int64_t(blockSize) + GCM_TAG_LEN;
+	const int64_t fullBlocks = rawSize / rawBlockSize;
+	const int64_t trailing = rawSize % rawBlockSize;
+	int64_t logical = fullBlocks * blockSize;
+	if (trailing > 0) {
+		ASSERT(trailing > GCM_TAG_LEN);
+		logical += trailing - GCM_TAG_LEN;
+	}
+	return logical;
+}
+
+int64_t AsyncFileEncrypted::logicalToRawSize(int64_t logicalSize, int blockSize) {
+	const int64_t rawBlockSize = int64_t(blockSize) + GCM_TAG_LEN;
+	const int64_t fullBlocks = logicalSize / blockSize;
+	const int64_t trailing = logicalSize % blockSize;
+	int64_t raw = fullBlocks * rawBlockSize;
+	if (trailing > 0) {
+		raw += trailing + GCM_TAG_LEN;
+	}
+	return raw;
 }
 
 Future<int> AsyncFileEncrypted::read(void* data, int length, int64_t offset) {
@@ -171,7 +197,7 @@ Future<Void> AsyncFileEncrypted::zeroRange(int64_t offset, int64_t length) {
 
 Future<Void> AsyncFileEncrypted::truncate(int64_t size) {
 	ASSERT(mode == Mode::APPEND_ONLY);
-	return file->truncate(size);
+	return file->truncate(logicalToRawSize(size, encryptionBlockSize));
 }
 
 Future<Void> AsyncFileEncrypted::sync() {
@@ -186,7 +212,8 @@ Future<Void> AsyncFileEncrypted::flush() {
 
 Future<int64_t> AsyncFileEncrypted::size() const {
 	ASSERT(mode == Mode::READ_ONLY);
-	return file->size();
+	int blockSize = encryptionBlockSize;
+	return map(file->size(), [blockSize](int64_t raw) { return rawToLogicalSize(raw, blockSize); });
 }
 
 std::string AsyncFileEncrypted::getFilename() const {
@@ -216,10 +243,17 @@ StreamCipher::IV AsyncFileEncrypted::getIV(uint32_t block) const {
 }
 
 Future<Void> AsyncFileEncrypted::writeLastBlockToFile() {
-	// The source buffer for the write is owned by *this so this must be kept alive by reference count until the write
-	// is finished.
-	return uncancellable(holdWhile(Reference<AsyncFileEncrypted>::addRef(this),
-	                               file->write(&writeBuffer[0], offsetInBlock, currentBlock * encryptionBlockSize)));
+	Arena arena;
+	EncryptionStreamCipher encryptor(StreamCipherKey::getGlobalCipherKey(), getIV(currentBlock));
+	auto ciphertext = encryptor.encrypt(&writeBuffer[0], offsetInBlock, arena);
+	auto tag = encryptor.finish(arena);
+	const int rawBlockSize = encryptionBlockSize + GCM_TAG_LEN;
+	auto* outBuf = new (arena) unsigned char[offsetInBlock + GCM_TAG_LEN];
+	std::copy(ciphertext.begin(), ciphertext.end(), outBuf);
+	std::copy(tag.begin(), tag.end(), outBuf + ciphertext.size());
+	return uncancellable(holdWhile(
+	    Reference<AsyncFileEncrypted>::addRef(this),
+	    holdWhile(arena, file->write(outBuf, offsetInBlock + GCM_TAG_LEN, int64_t(rawBlockSize) * currentBlock))));
 }
 
 // This test writes random data into an encrypted file in random increments,

--- a/fdbrpc/include/fdbrpc/AsyncFileEncrypted.h
+++ b/fdbrpc/include/fdbrpc/AsyncFileEncrypted.h
@@ -45,7 +45,6 @@ private:
 	int64_t fileSize = -1;
 
 	// Writing (append only):
-	std::unique_ptr<EncryptionStreamCipher> encryptor;
 	uint32_t currentBlock{ 0 };
 	int offsetInBlock{ 0 };
 	std::vector<unsigned char> writeBuffer;
@@ -67,4 +66,11 @@ public:
 	Future<Void> readZeroCopy(void** data, int* length, int64_t offset) override;
 	void releaseZeroCopy(void* data, int length, int64_t offset) override;
 	int64_t debugFD() const override;
+
+	// Convert raw on-disk file size (including per-block GCM tags) to logical plaintext size.
+	// Pure math, no I/O. blockSize is the plaintext block size (encryptionBlockSize).
+	static int64_t rawToLogicalSize(int64_t rawSize, int blockSize);
+
+	// Inverse of rawToLogicalSize: given a logical plaintext size, return the raw on-disk size.
+	static int64_t logicalToRawSize(int64_t logicalSize, int blockSize);
 };

--- a/flow/StreamCipher.cpp
+++ b/flow/StreamCipher.cpp
@@ -124,15 +124,22 @@ StringRef EncryptionStreamCipher::encrypt(unsigned char const* plaintext, int le
 	CODE_PROBE(true, "Encrypting data with StreamCipher", probe::decoration::rare);
 	auto ciphertext = new (arena) unsigned char[len + AES_BLOCK_SIZE];
 	int bytes{ 0 };
-	EVP_EncryptUpdate(cipher.getCtx(), ciphertext, &bytes, plaintext, len);
+	if (EVP_EncryptUpdate(cipher.getCtx(), ciphertext, &bytes, plaintext, len) != 1) {
+		throw encrypt_ops_error();
+	}
 	return StringRef(ciphertext, bytes);
 }
 
 StringRef EncryptionStreamCipher::finish(Arena& arena) {
-	auto ciphertext = new (arena) unsigned char[AES_BLOCK_SIZE];
+	auto ciphertext = new (arena) unsigned char[AES_BLOCK_SIZE + GCM_TAG_LEN];
 	int bytes{ 0 };
-	EVP_EncryptFinal_ex(cipher.getCtx(), ciphertext, &bytes);
-	return StringRef(ciphertext, bytes);
+	if (EVP_EncryptFinal_ex(cipher.getCtx(), ciphertext, &bytes) != 1) {
+		throw encrypt_ops_error();
+	}
+	if (EVP_CIPHER_CTX_ctrl(cipher.getCtx(), EVP_CTRL_GCM_GET_TAG, GCM_TAG_LEN, ciphertext + bytes) != 1) {
+		throw encrypt_ops_error();
+	}
+	return StringRef(ciphertext, bytes + GCM_TAG_LEN);
 }
 
 DecryptionStreamCipher::DecryptionStreamCipher(const StreamCipherKey* key, const StreamCipher::IV& iv)
@@ -146,16 +153,22 @@ StringRef DecryptionStreamCipher::decrypt(unsigned char const* ciphertext, int l
 	CODE_PROBE(true, "Decrypting data with StreamCipher");
 	auto plaintext = new (arena) unsigned char[len];
 	int bytesDecrypted{ 0 };
-	EVP_DecryptUpdate(cipher.getCtx(), plaintext, &bytesDecrypted, ciphertext, len);
-	int finalBlockBytes{ 0 };
-	EVP_DecryptFinal_ex(cipher.getCtx(), plaintext + bytesDecrypted, &finalBlockBytes);
-	return StringRef(plaintext, bytesDecrypted + finalBlockBytes);
+	if (EVP_DecryptUpdate(cipher.getCtx(), plaintext, &bytesDecrypted, ciphertext, len) != 1) {
+		throw encrypt_ops_error();
+	}
+	return StringRef(plaintext, bytesDecrypted);
 }
 
-StringRef DecryptionStreamCipher::finish(Arena& arena) {
+StringRef DecryptionStreamCipher::finish(const uint8_t* tag, Arena& arena) {
+	if (EVP_CIPHER_CTX_ctrl(cipher.getCtx(), EVP_CTRL_GCM_SET_TAG, GCM_TAG_LEN, const_cast<uint8_t*>(tag)) != 1) {
+		throw encrypt_ops_error();
+	}
 	auto plaintext = new (arena) unsigned char[AES_BLOCK_SIZE];
 	int finalBlockBytes{ 0 };
-	EVP_DecryptFinal_ex(cipher.getCtx(), plaintext, &finalBlockBytes);
+	if (EVP_DecryptFinal_ex(cipher.getCtx(), plaintext, &finalBlockBytes) != 1) {
+		TraceEvent(SevWarn, "DecryptGcmTagMismatch").log();
+		throw restore_corrupted_data();
+	}
 	return StringRef(plaintext, finalBlockBytes);
 }
 
@@ -206,17 +219,18 @@ TEST_CASE("flow/StreamCipher") {
 			encryptedOffset += encrypted.size();
 			index += chunkSize;
 		}
+		ciphertext.resize(encryptedOffset + GCM_TAG_LEN);
 		const auto encrypted = encryptor.finish(arena);
 		std::copy(encrypted.begin(), encrypted.end(), &ciphertext[encryptedOffset]);
-		ciphertext.resize(encryptedOffset + encrypted.size());
 	}
 
 	{
 		DecryptionStreamCipher decryptor(key, iv);
 		int index = 0;
 		int decryptedOffset = 0;
-		while (index < plaintext.size()) {
-			const auto chunkSize = std::min<int>(deterministicRandom()->randomInt(1, 101), plaintext.size() - index);
+		const int payloadSize = ciphertext.size() - GCM_TAG_LEN;
+		while (index < payloadSize) {
+			const auto chunkSize = std::min<int>(deterministicRandom()->randomInt(1, 101), payloadSize - index);
 			const auto decrypted = decryptor.decrypt(&ciphertext[index], chunkSize, arena);
 			TraceEvent("StreamCipherTestDecryptedChunk")
 			    .detail("DecryptedSize", decrypted.size())
@@ -226,7 +240,7 @@ TEST_CASE("flow/StreamCipher") {
 			decryptedOffset += decrypted.size();
 			index += chunkSize;
 		}
-		const auto decrypted = decryptor.finish(arena);
+		const auto decrypted = decryptor.finish(&ciphertext[payloadSize], arena);
 		std::copy(decrypted.begin(), decrypted.end(), &decryptedtext[decryptedOffset]);
 		ASSERT_EQ(decryptedOffset + decrypted.size(), plaintext.size());
 		decryptedtext.resize(decryptedOffset + decrypted.size());

--- a/flow/include/flow/StreamCipher.h
+++ b/flow/include/flow/StreamCipher.h
@@ -32,6 +32,7 @@
 #include <vector>
 
 #define AES_256_KEY_LENGTH 32
+#define GCM_TAG_LEN 16
 
 // Wrapper class for openssl implementation of AES GCM
 // encryption/decryption
@@ -93,7 +94,7 @@ class DecryptionStreamCipher final : NonCopyable, public ReferenceCounted<Decryp
 public:
 	DecryptionStreamCipher(const StreamCipherKey* key, const StreamCipher::IV& iv);
 	StringRef decrypt(unsigned char const* ciphertext, int len, Arena&);
-	StringRef finish(Arena&);
+	StringRef finish(const uint8_t* tag, Arena&);
 };
 
 class HmacSha256StreamCipher final : NonCopyable, public ReferenceCounted<HmacSha256StreamCipher> {


### PR DESCRIPTION
### Summary

WHAT CHANGED

AsyncFileEncrypted now writes and verifies a 16-byte GCM authentication tag per encryption block. 

Previously, the code declared AES-256-GCM but never called EVP_CIPHER_CTX_ctrl(..., EVP_CTRL_GCM_GET_TAG, ...) on encrypt or EVP_CTRL_GCM_SET_TAG on decrypt, and discarded the return value of EVP_DecryptFinal_ex - silently degrading to unauthenticated AES-CTR.

The tag is a cryptographic seal on each encrypted block: when we verify it on decrypt, we know the ciphertext hasn't been altered since encryption. Without it, an attacker can flip bits in the ciphertext and the corresponding plaintext flips slip through decryption undetected.

ON-DISK LAYOUT

  Before:

      File on disk:
      +---------------+---------------+---------------+---------+
      |  ciphertext   |  ciphertext   |  ciphertext   |  ct     |
      |  block 0      |  block 1      |  block 2      | partial |
      |  (4096 B)     |  (4096 B)     |  (4096 B)     |         |
      +---------------+---------------+---------------+---------+
         No tag. Any bit-flip in ciphertext produces a matching
         bit-flip in plaintext. Decryption always "succeeds" -
         restore silently accepts tampered data.
         
    
 After:

      File on disk:
      +--------------+----+--------------+----+--------------+----+--------+----+
      |  ciphertext  |tag |  ciphertext  |tag |  ciphertext  |tag |  ct    |tag |
      |  block 0     |16 B|  block 1     |16 B|  block 2     |16 B|partial |16 B|
      |  4096 B      |    |  4096 B      |    |  4096 B      |    |        |    |
      +--------------+----+--------------+----+--------------+----+--------+----+
         Each block has its own GCM tag. Any tamper (ciphertext or tag)
         fails verification -> throws restore_corrupted_data -> restore
         aborts loudly.


WRITE AND READ FLOWS

      WRITE path                           READ path
      ----------                           ---------

      Caller: write(plaintext)             Caller: read(offset, length)
             |                                    |
             v                                    v
      Buffer plaintext                     For each encryption block in range:
             |                                    |
      Buffer full (or sync)?                      v
             |                             Read raw block: [ciphertext | tag]
             v                                    |
      Fresh cipher (per-block IV)                 v
             |                             Fresh cipher (per-block IV)
      encrypt(plaintext) -> ciphertext            |
             |                             decrypt(ciphertext) -> plaintext (unverified)
      finish() -> 16-byte tag                     |
             |                             finish(tag)
      Write [ciphertext | tag] to disk            +-- verify OK   -> return plaintext
                                                  +-- verify FAIL -> throw


>  Not backward compatible. Old encrypted backups (written without tags) cannot be read by the new code and vice versa

### Testing

- 100k Simulation test completed
- ctest on s3 and local dir passed
