### PR TITLE
[release-7.3] Fix an old exclude failed bug

### DIFF
--- a/fdbserver/MoveKeys.actor.cpp
+++ b/fdbserver/MoveKeys.actor.cpp
@@ -2940,7 +2940,7 @@ ACTOR Future<Void> removeKeysFromFailedServer(Database cx,
 							}
 						}
 
-						const UID shardId = newDataMoveId(
+						state UID shardId = newDataMoveId(
 						    deterministicRandom()->randomUInt64(), AssignEmptyRange::True, DataMoveType::LOGICAL);
 
 						// Assign the shard to teamForDroppedRange in keyServer space.
@@ -2957,20 +2957,22 @@ ACTOR Future<Void> removeKeysFromFailedServer(Database cx,
 							actors.push_back(
 							    krmSetRangeCoalescing(&tr, serverKeysPrefixFor(id), range, allKeys, serverKeysFalse));
 						}
+						wait(waitForAll(actors));
 
 						// Assign the shard to the new team as an empty range.
 						// Note, there could be data loss.
+						std::vector<Future<Void>> emptyRangeActors;
 						for (const UID& id : teamForDroppedRange) {
 							if (SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA) {
-								actors.push_back(krmSetRangeCoalescing(
+								emptyRangeActors.push_back(krmSetRangeCoalescing(
 								    &tr, serverKeysPrefixFor(id), range, allKeys, serverKeysValue(shardId)));
 							} else {
-								actors.push_back(krmSetRangeCoalescing(
+								emptyRangeActors.push_back(krmSetRangeCoalescing(
 								    &tr, serverKeysPrefixFor(id), range, allKeys, serverKeysTrueEmptyRange));
 							}
 						}
 
-						wait(waitForAll(actors));
+						wait(waitForAll(emptyRangeActors));
 
 						TraceEvent trace(SevWarnAlways, "ShardLossAllReplicasDropShard", serverID);
 						trace.detail("Begin", it.key);


### PR DESCRIPTION
Backport of apple/foundationdb#13645 to release-7.3.

In removeKeysFromFailedServer, the writes that unassign a dropped shard from the dest servers (serverKeysFalse) and the writes that reassign it to the new team as an empty range were pushed into a single actors vector and awaited together. krmSetRangeCoalescing performs a read-modify-write on the serverKeys map, so when a server appears in both the dest set and the new team, running the two batches concurrently lets the coalescing reads observe stale state and produce an incorrect serverKeys assignment.

Await the unassign batch first, then run the empty-range assignment in a separate batch, ensuring the serverKey map assignment is correct.

100K results below.

```
$ j list --stopped | grep 20260708-174937-praza-exc-fail-bug-7.3-backport-047bba1366fb
  20260708-174937-praza-exc-fail-bug-7.3-backport-047bba1366fb compressed=True data_size=34947832 duration=3580953 ended=100000 fail=1 fail_fast=10 max_runs=100000 pass=99999 priority=100 remaining=0 runtime=0:44:58 sanity=False started=100000 stopped=20260708-183435 submitted=20260708-174937 timeout=5400 username=praza-exc-fail-bug-7.3-backport-047bba1366fb23c1fc31c07e47cc751564f6515b

# Don't see any failures
$ j tail --xml --errors 20260708-174937-praza-exc-fail-bug-7.3-backport-047bba1366fb
Results for test ensemble: 20260708-174937-praza-exc-fail-bug-7.3-backport-047bba1366fb
<Trace>Ensemble stopped
</Trace>⏎
```