### PR TITLE
BulkLoad: reject path-traversal in manifest file paths

### DIFF
--- a/fdbclient/include/fdbclient/BulkLoading.h
+++ b/fdbclient/include/fdbclient/BulkLoading.h
@@ -160,6 +160,30 @@ private:
 	std::string checksumValue = "";
 };
 
+// Returns false if `path` could escape a trusted root when appended to it:
+// i.e. it is absolute (leading '/') or contains a ".." component. Bulk-load
+// manifest fields (relativePath, dataFileName, byteSampleFileName,
+// manifestFileName) are read verbatim from an operator-supplied object store
+// and then joined onto the local staging root (see BulkLoadFileSet::getFolder).
+// Without this check a crafted manifest such as
+// "[RelativePath]: ../../../../var/lib/foundationdb" would make getFolder()
+// resolve outside the staging root and drive eraseDirectoryRecursive()/file
+// writes there. An empty path is allowed (callers treat empty fields as absent).
+inline bool bulkLoadPathIsContained(const std::string& path) {
+	if (path.empty()) {
+		return true;
+	}
+	if (path[0] == '/') {
+		return false; // absolute path escapes the root
+	}
+	for (const auto& component : splitString(path, "/")) {
+		if (component == "..") {
+			return false; // traversal component escapes the root
+		}
+	}
+	return true;
+}
+
 // Definition of bulkload/dump files metadata
 // Each bulkload/dump task has exactly one range.
 // The range of the data is included in the Folder = RootPath + RelativePath.
@@ -214,6 +238,14 @@ public:
 		}
 		if (!hasDataFile() && hasByteSampleFile()) {
 			// If bytes sample file exists, the data file must exist.
+			return false;
+		}
+		// Reject manifest-supplied path fields that could escape the local
+		// staging root via absolute paths or ".." traversal. getFolder() joins
+		// relativePath onto rootPath, and the file-name fields are appended to
+		// that folder, so any of them can drive a path traversal at the sink.
+		if (!bulkLoadPathIsContained(relativePath) || !bulkLoadPathIsContained(manifestFileName) ||
+		    !bulkLoadPathIsContained(dataFileName) || !bulkLoadPathIsContained(byteSampleFileName)) {
 			return false;
 		}
 		return true;

--- a/fdbserver/core/BulkLoadUtil.cpp
+++ b/fdbserver/core/BulkLoadUtil.cpp
@@ -27,6 +27,7 @@
 #include "fdbserver/core/RocksDBCheckpointUtils.h"
 #include "fdbserver/core/StorageMetrics.h"
 #include "flow/genericactors.actor.h"
+#include "flow/UnitTest.h"
 
 Future<Void> readBulkFileBytes(std::string path, int64_t maxLength, std::shared_ptr<std::string> output) {
 	try {
@@ -271,11 +272,37 @@ void resetFileFolder(const std::string& folderPath) {
 	return;
 }
 
+// Defense-in-depth guard for the bulk-load sink. Before we wipe and repopulate
+// the local staging folder, verify it resolves to a location at or under the
+// (operator-supplied) local root. Parse-time validation in BulkLoadFileSet
+// already rejects ".."/absolute manifest fields; this is the last-resort check
+// right before eraseDirectoryRecursive() so that any traversal that slips
+// through cannot drive the wipe/writes to an arbitrary path (e.g. the FDB data
+// directory or TLS material). Throws rather than proceed.
+void assertLocalFolderContained(const BulkLoadFileSet& localFileSet, const UID& logId) {
+	std::string resolvedRoot = abspath(localFileSet.getRootPath());
+	std::string resolvedFolder = abspath(localFileSet.getFolder());
+	// Compare against root + separator so a sibling like "/data-evil" is not
+	// accepted for root "/data"; the exact-root case is allowed on its own.
+	std::string rootWithSep = resolvedRoot + "/";
+	bool contained = resolvedFolder == resolvedRoot ||
+	                 (resolvedFolder.size() >= rootWithSep.size() &&
+	                  resolvedFolder.compare(0, rootWithSep.size(), rootWithSep) == 0);
+	if (!contained) {
+		TraceEvent(SevError, "BulkLoadLocalFolderEscapesRoot", logId)
+		    .detail("ResolvedRoot", resolvedRoot)
+		    .detail("ResolvedFolder", resolvedFolder)
+		    .detail("FileSet", localFileSet.toString());
+		throw bulkload_fileset_invalid_filepath();
+	}
+}
+
 Future<Void> bulkLoadTransportCP_impl(BulkLoadFileSet fromRemoteFileSet,
                                       BulkLoadFileSet toLocalFileSet,
                                       size_t fileBytesMax,
                                       UID logId) {
 	// Clear existing local folder
+	assertLocalFolderContained(toLocalFileSet, logId);
 	resetFileFolder(abspath(toLocalFileSet.getFolder()));
 	// Copy data file
 	co_await copyBulkFile(
@@ -294,6 +321,7 @@ Future<Void> bulkLoadTransportBlobstore_impl(BulkLoadFileSet fromRemoteFileSet,
                                              size_t fileBytesMax,
                                              UID logId) {
 	// Clear existing local folder
+	assertLocalFolderContained(toLocalFileSet, logId);
 	resetFileFolder(abspath(toLocalFileSet.getFolder()));
 	TraceEvent(SevDebug, "BulkLoadBlobstoreTransportStart", logId)
 	    .detail("FromRemote", fromRemoteFileSet.toString())
@@ -641,4 +669,26 @@ Future<BulkLoadManifestSet> getBulkLoadManifestMetadataFromEntry(
 		ASSERT(manifests.addManifest(manifest));
 	}
 	co_return manifests;
+}
+
+TEST_CASE("/fdbserver/BulkLoad/bulkLoadPathIsContained") {
+	// Safe: relative paths, nested dirs, empty, dotfiles, and names that merely
+	// contain dots without a standalone ".." component.
+	ASSERT(bulkLoadPathIsContained(""));
+	ASSERT(bulkLoadPathIsContained("data.sst"));
+	ASSERT(bulkLoadPathIsContained("a/b/c"));
+	ASSERT(bulkLoadPathIsContained("5676202155931feac1bbd501d491170b/0/data.sst"));
+	ASSERT(bulkLoadPathIsContained("a/.hidden/b"));
+	ASSERT(bulkLoadPathIsContained("a..b/c"));
+	ASSERT(bulkLoadPathIsContained("..."));
+
+	// Unsafe: absolute path, or a ".." component anywhere in the path.
+	ASSERT(!bulkLoadPathIsContained("/var/lib/foundationdb"));
+	ASSERT(!bulkLoadPathIsContained(".."));
+	ASSERT(!bulkLoadPathIsContained("../x"));
+	ASSERT(!bulkLoadPathIsContained("../../../../var/lib/foundationdb"));
+	ASSERT(!bulkLoadPathIsContained("a/../../etc"));
+	ASSERT(!bulkLoadPathIsContained("a/b/.."));
+
+	return Void();
 }

--- a/fdbserver/core/BulkLoadUtil.cpp
+++ b/fdbserver/core/BulkLoadUtil.cpp
@@ -284,10 +284,7 @@ void assertLocalFolderContained(const BulkLoadFileSet& localFileSet, const UID& 
 	std::string resolvedFolder = abspath(localFileSet.getFolder());
 	// Compare against root + separator so a sibling like "/data-evil" is not
 	// accepted for root "/data"; the exact-root case is allowed on its own.
-	std::string rootWithSep = resolvedRoot + "/";
-	bool contained =
-	    resolvedFolder == resolvedRoot || (resolvedFolder.size() >= rootWithSep.size() &&
-	                                       resolvedFolder.compare(0, rootWithSep.size(), rootWithSep) == 0);
+	bool contained = resolvedFolder == resolvedRoot || resolvedFolder.starts_with(resolvedRoot + "/");
 	if (!contained) {
 		TraceEvent(SevError, "BulkLoadLocalFolderEscapesRoot", logId)
 		    .detail("ResolvedRoot", resolvedRoot)

--- a/fdbserver/core/BulkLoadUtil.cpp
+++ b/fdbserver/core/BulkLoadUtil.cpp
@@ -285,9 +285,9 @@ void assertLocalFolderContained(const BulkLoadFileSet& localFileSet, const UID& 
 	// Compare against root + separator so a sibling like "/data-evil" is not
 	// accepted for root "/data"; the exact-root case is allowed on its own.
 	std::string rootWithSep = resolvedRoot + "/";
-	bool contained = resolvedFolder == resolvedRoot ||
-	                 (resolvedFolder.size() >= rootWithSep.size() &&
-	                  resolvedFolder.compare(0, rootWithSep.size(), rootWithSep) == 0);
+	bool contained =
+	    resolvedFolder == resolvedRoot || (resolvedFolder.size() >= rootWithSep.size() &&
+	                                       resolvedFolder.compare(0, rootWithSep.size(), rootWithSep) == 0);
 	if (!contained) {
 		TraceEvent(SevError, "BulkLoadLocalFolderEscapesRoot", logId)
 		    .detail("ResolvedRoot", resolvedRoot)


### PR DESCRIPTION
A crafted bulk-load manifest could set [RelativePath], [DataFileName], or [ByteSampleFileName] to an absolute path or one containing ".." components. getFolder() joins these onto the local staging root and the result flows into abspath() -> eraseDirectoryRecursive() (and subsequent file writes), so a manifest such as "[RelativePath]: ../../../../var/lib/foundationdb" could make every storage server running the job wipe and overwrite an arbitrary directory (e.g. the FDB data directory or TLS material).

Add two layers of validation:

- Parse/construction time: BulkLoadFileSet::isValid() now rejects relativePath, manifestFileName, dataFileName, and byteSampleFileName that are absolute or contain a ".." component (bulkLoadPathIsContained). Bad manifests are refused before any local path is constructed.

- Sink guard: assertLocalFolderContained() verifies the resolved staging folder is at or under the resolved local root immediately before resetFileFolder(), in both bulkLoadTransportCP_impl and bulkLoadTransportBlobstore_impl.

Was reported by an internal scan as possible issue.

`  20260709-172507-stack_path-4ce2adc78bd6e033        compressed=True data_size=37468593 duration=3124600 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:32:32 sanity=False started=100000 stopped=20260709-175739 submitted=20260709-172507 timeout=5400 username=stack_path`