### PR TITLE
Add GCM Authentication Tag to Encrypted Backup Files

### DIFF
--- a/fdbclient/BackupContainerFileSystem.actor.cpp
+++ b/fdbclient/BackupContainerFileSystem.actor.cpp
@@ -613,6 +613,9 @@ public:
 		std::pair<bool, int> encryptionMeta = wait(readEncryptionMetadata(bc));
 		fileLevelEncryptionEnabled = encryptionMeta.first;
 		encryptionBlockSize = encryptionMeta.second;
+		if (fileLevelEncryptionEnabled) {
+			bc->setEncryptionBlockSize(encryptionBlockSize);
+		}
 
 		TraceEvent("BackupContainerDescribe2")
 		    .detail("URL", bc->getURL())
@@ -2151,6 +2154,28 @@ TEST_CASE("/backup/containers/localdir/encrypted") {
 	wait(testBackupContainer(format("file://%s/fdb_backups/%llx", params.getDataDir().c_str(), timer_int()),
 	                         {},
 	                         format("%s/test_encryption_key", params.getDataDir().c_str())));
+	return Void();
+}
+
+TEST_CASE("/backup/containers/localdir/encryptedDescribeWithoutBlockSize") {
+	state std::string url = fmt::format("file://{}/fdb_backups/{:x}", params.getDataDir(), timer_int());
+	state std::string keyFile = fmt::format("{}/test_encryption_key_describe", params.getDataDir());
+	wait(BackupContainerFileSystem::createTestEncryptionKeyFile(keyFile));
+
+	state Reference<IBackupContainer> c = IBackupContainer::openContainer(url, {}, keyFile, 4096);
+	wait(c->create());
+	wait(c->writeEncryptionMetadata(4096));
+	state Reference<IBackupFile> log = wait(c->writeLogFile(1, 2, 1));
+	uint8_t value = 1;
+	wait(log->append(&value, 1));
+	wait(log->finish());
+
+	c->setEncryptionBlockSize(0);
+	BackupDescription desc = wait(c->describeBackup(true));
+	ASSERT(desc.fileLevelEncryption);
+	ASSERT_EQ(desc.encryptionBlockSize, 4096);
+	ASSERT_EQ(c->getEncryptionBlockSize(), 4096);
+	wait(c->deleteContainer());
 	return Void();
 }
 

--- a/fdbclient/BackupContainerFileSystem.actor.cpp
+++ b/fdbclient/BackupContainerFileSystem.actor.cpp
@@ -28,6 +28,7 @@
 #include "fdbclient/BackupContainerLocalDirectory.h"
 #include "fdbclient/BackupContainerS3BlobStore.h"
 #include "fdbclient/JsonBuilder.h"
+#include "fdbrpc/AsyncFileEncrypted.h"
 #include "flow/StreamCipher.h"
 #include "flow/UnitTest.h"
 
@@ -1516,16 +1517,22 @@ Future<std::vector<LogFile>> BackupContainerFileSystem::listLogFiles(Version beg
 		       (cleaned > firstPath && cleaned < lastPath);
 	};
 
-	return map(listFiles((partitioned ? "plogs/" : "logs/"), pathFilter), [=](const FilesAndSizesT& files) {
-		std::vector<LogFile> results;
-		LogFile lf;
-		for (auto& f : files) {
-			if (BackupContainerFileSystemImpl::pathToLogFile(lf, f.first, f.second) && lf.endVersion > beginVersion &&
-			    lf.beginVersion <= targetVersion)
-				results.push_back(lf);
-		}
-		return results;
-	});
+	return map(listFiles((partitioned ? "plogs/" : "logs/"), pathFilter),
+	           [=, self = Reference<BackupContainerFileSystem>::addRef(this)](const FilesAndSizesT& files) {
+		           std::vector<LogFile> results;
+		           LogFile lf;
+		           for (auto& f : files) {
+			           if (BackupContainerFileSystemImpl::pathToLogFile(lf, f.first, f.second) &&
+			               lf.endVersion > beginVersion && lf.beginVersion <= targetVersion) {
+				           if (self->usesEncryption()) {
+					           lf.fileSize =
+					               AsyncFileEncrypted::rawToLogicalSize(lf.fileSize, self->encryptionBlockSize);
+				           }
+				           results.push_back(lf);
+			           }
+		           }
+		           return results;
+	           });
 }
 
 Future<std::vector<RangeFile>> BackupContainerFileSystem::old_listRangeFiles(Version beginVersion, Version endVersion) {
@@ -1544,16 +1551,22 @@ Future<std::vector<RangeFile>> BackupContainerFileSystem::old_listRangeFiles(Ver
 		       (cleaned > firstPath && cleaned < lastPath);
 	};
 
-	return map(listFiles("ranges/", pathFilter), [=](const FilesAndSizesT& files) {
-		std::vector<RangeFile> results;
-		RangeFile rf;
-		for (auto& f : files) {
-			if (BackupContainerFileSystemImpl::pathToRangeFile(rf, f.first, f.second) && rf.version >= beginVersion &&
-			    rf.version <= endVersion)
-				results.push_back(rf);
-		}
-		return results;
-	});
+	return map(listFiles("ranges/", pathFilter),
+	           [=, self = Reference<BackupContainerFileSystem>::addRef(this)](const FilesAndSizesT& files) {
+		           std::vector<RangeFile> results;
+		           RangeFile rf;
+		           for (auto& f : files) {
+			           if (BackupContainerFileSystemImpl::pathToRangeFile(rf, f.first, f.second) &&
+			               rf.version >= beginVersion && rf.version <= endVersion) {
+				           if (self->usesEncryption()) {
+					           rf.fileSize =
+					               AsyncFileEncrypted::rawToLogicalSize(rf.fileSize, self->encryptionBlockSize);
+				           }
+				           results.push_back(rf);
+			           }
+		           }
+		           return results;
+	           });
 }
 
 Future<std::vector<RangeFile>> BackupContainerFileSystem::listRangeFiles(Version beginVersion, Version endVersion) {
@@ -1566,16 +1579,22 @@ Future<std::vector<RangeFile>> BackupContainerFileSystem::listRangeFiles(Version
 		return BackupContainerFileSystemImpl::extractSnapshotBeginVersion(path) <= endVersion;
 	};
 
-	Future<std::vector<RangeFile>> newFiles = map(listFiles("kvranges/", pathFilter), [=](const FilesAndSizesT& files) {
-		std::vector<RangeFile> results;
-		RangeFile rf;
-		for (auto& f : files) {
-			if (BackupContainerFileSystemImpl::pathToRangeFile(rf, f.first, f.second) && rf.version >= beginVersion &&
-			    rf.version <= endVersion)
-				results.push_back(rf);
-		}
-		return results;
-	});
+	Future<std::vector<RangeFile>> newFiles =
+	    map(listFiles("kvranges/", pathFilter),
+	        [=, self = Reference<BackupContainerFileSystem>::addRef(this)](const FilesAndSizesT& files) {
+		        std::vector<RangeFile> results;
+		        RangeFile rf;
+		        for (auto& f : files) {
+			        if (BackupContainerFileSystemImpl::pathToRangeFile(rf, f.first, f.second) &&
+			            rf.version >= beginVersion && rf.version <= endVersion) {
+				        if (self->usesEncryption()) {
+					        rf.fileSize = AsyncFileEncrypted::rawToLogicalSize(rf.fileSize, self->encryptionBlockSize);
+				        }
+				        results.push_back(rf);
+			        }
+		        }
+		        return results;
+	        });
 
 	return map(success(oldFiles) && success(newFiles), [=](Void _) {
 		std::vector<RangeFile> results = std::move(newFiles.get());

--- a/fdbrpc/AsyncFileEncrypted.actor.cpp
+++ b/fdbrpc/AsyncFileEncrypted.actor.cpp
@@ -45,22 +45,30 @@ public:
 		return iv;
 	}
 
-	// Read a single block of size encryptionBlockSize bytes, and decrypt.
+	// Read a single block of encryptionBlockSize bytes plus the trailing GCM tag, verify tag, and decrypt.
 	ACTOR static Future<Standalone<StringRef>> readBlock(AsyncFileEncrypted* self, uint32_t block) {
 		state Arena arena;
-		state unsigned char* encrypted = new (arena) unsigned char[self->encryptionBlockSize];
-		int bytes = wait(uncancellable(holdWhile(
-		    arena, self->file->read(encrypted, self->encryptionBlockSize, self->encryptionBlockSize * block))));
+		state int rawBlockSize = self->encryptionBlockSize + GCM_TAG_LEN;
+		state unsigned char* encrypted = new (arena) unsigned char[rawBlockSize];
+		int bytes = wait(
+		    uncancellable(holdWhile(arena, self->file->read(encrypted, rawBlockSize, int64_t(rawBlockSize) * block))));
+		if (bytes < GCM_TAG_LEN) {
+			throw restore_corrupted_data();
+		}
+		int ciphertextLen = bytes - GCM_TAG_LEN;
+		const uint8_t* tag = encrypted + ciphertextLen;
 		StreamCipherKey const* cipherKey = StreamCipherKey::getGlobalCipherKey();
 		DecryptionStreamCipher decryptor(cipherKey, self->getIV(block));
-		auto decrypted = decryptor.decrypt(encrypted, bytes, arena);
+		auto decrypted = decryptor.decrypt(encrypted, ciphertextLen, arena);
+		// Throws restore_corrupted_data if the tag does not verify.
+		decryptor.finish(tag, arena);
 		return Standalone<StringRef>(decrypted, arena);
 	}
 
 	ACTOR static Future<int> read(Reference<AsyncFileEncrypted> self, void* data, int length, int64_t offset) {
 		if (self->fileSize == -1) {
-			state int64_t fileSize = wait(self->file->size());
-			self->fileSize = fileSize;
+			state int64_t rawSize = wait(self->file->size());
+			self->fileSize = AsyncFileEncrypted::rawToLogicalSize(rawSize, self->encryptionBlockSize);
 		}
 		if (offset >= self->fileSize) {
 			return 0;
@@ -106,10 +114,7 @@ public:
 		state unsigned char const* input = reinterpret_cast<unsigned char const*>(data);
 		while (length > 0) {
 			const auto chunkSize = std::min(length, self->encryptionBlockSize - self->offsetInBlock);
-			Arena arena;
-			auto encrypted = self->encryptor->encrypt(input, chunkSize, arena);
-			std::copy(encrypted.begin(), encrypted.end(), &self->writeBuffer[self->offsetInBlock]);
-			offset += encrypted.size();
+			std::copy(input, input + chunkSize, &self->writeBuffer[self->offsetInBlock]);
 			self->offsetInBlock += chunkSize;
 			length -= chunkSize;
 			input += chunkSize;
@@ -118,8 +123,6 @@ public:
 				self->offsetInBlock = 0;
 				ASSERT_LT(self->currentBlock, std::numeric_limits<uint32_t>::max());
 				++self->currentBlock;
-				self->encryptor = std::make_unique<EncryptionStreamCipher>(StreamCipherKey::getGlobalCipherKey(),
-				                                                           self->getIV(self->currentBlock));
 			}
 		}
 		return Void();
@@ -127,7 +130,9 @@ public:
 
 	ACTOR static Future<Void> sync(Reference<AsyncFileEncrypted> self) {
 		ASSERT(self->mode == AsyncFileEncrypted::Mode::APPEND_ONLY);
-		wait(self->writeLastBlockToFile());
+		if (self->offsetInBlock > 0) {
+			wait(self->writeLastBlockToFile());
+		}
 		wait(self->file->sync());
 		return Void();
 	}
@@ -148,8 +153,6 @@ AsyncFileEncrypted::AsyncFileEncrypted(Reference<IAsyncFile> file, Mode mode, in
 	ASSERT(encryptionBlockSize > 0);
 	firstBlockIV = AsyncFileEncryptedImpl::getFirstBlockIV(file->getFilename());
 	if (mode == Mode::APPEND_ONLY) {
-		encryptor =
-		    std::make_unique<EncryptionStreamCipher>(StreamCipherKey::getGlobalCipherKey(), getIV(currentBlock));
 		writeBuffer = std::vector<unsigned char>(encryptionBlockSize, 0);
 	}
 }
@@ -160,6 +163,29 @@ void AsyncFileEncrypted::addref() {
 
 void AsyncFileEncrypted::delref() {
 	ReferenceCounted<AsyncFileEncrypted>::delref();
+}
+
+int64_t AsyncFileEncrypted::rawToLogicalSize(int64_t rawSize, int blockSize) {
+	const int64_t rawBlockSize = int64_t(blockSize) + GCM_TAG_LEN;
+	const int64_t fullBlocks = rawSize / rawBlockSize;
+	const int64_t trailing = rawSize % rawBlockSize;
+	int64_t logical = fullBlocks * blockSize;
+	if (trailing > 0) {
+		ASSERT(trailing > GCM_TAG_LEN);
+		logical += trailing - GCM_TAG_LEN;
+	}
+	return logical;
+}
+
+int64_t AsyncFileEncrypted::logicalToRawSize(int64_t logicalSize, int blockSize) {
+	const int64_t rawBlockSize = int64_t(blockSize) + GCM_TAG_LEN;
+	const int64_t fullBlocks = logicalSize / blockSize;
+	const int64_t trailing = logicalSize % blockSize;
+	int64_t raw = fullBlocks * rawBlockSize;
+	if (trailing > 0) {
+		raw += trailing + GCM_TAG_LEN;
+	}
+	return raw;
 }
 
 Future<int> AsyncFileEncrypted::read(void* data, int length, int64_t offset) {
@@ -176,7 +202,7 @@ Future<Void> AsyncFileEncrypted::zeroRange(int64_t offset, int64_t length) {
 
 Future<Void> AsyncFileEncrypted::truncate(int64_t size) {
 	ASSERT(mode == Mode::APPEND_ONLY);
-	return file->truncate(size);
+	return file->truncate(logicalToRawSize(size, encryptionBlockSize));
 }
 
 Future<Void> AsyncFileEncrypted::sync() {
@@ -191,7 +217,8 @@ Future<Void> AsyncFileEncrypted::flush() {
 
 Future<int64_t> AsyncFileEncrypted::size() const {
 	ASSERT(mode == Mode::READ_ONLY);
-	return file->size();
+	int blockSize = encryptionBlockSize;
+	return map(file->size(), [blockSize](int64_t raw) { return rawToLogicalSize(raw, blockSize); });
 }
 
 std::string AsyncFileEncrypted::getFilename() const {
@@ -221,10 +248,17 @@ StreamCipher::IV AsyncFileEncrypted::getIV(uint32_t block) const {
 }
 
 Future<Void> AsyncFileEncrypted::writeLastBlockToFile() {
-	// The source buffer for the write is owned by *this so this must be kept alive by reference count until the write
-	// is finished.
-	return uncancellable(holdWhile(Reference<AsyncFileEncrypted>::addRef(this),
-	                               file->write(&writeBuffer[0], offsetInBlock, currentBlock * encryptionBlockSize)));
+	Arena arena;
+	EncryptionStreamCipher encryptor(StreamCipherKey::getGlobalCipherKey(), getIV(currentBlock));
+	auto ciphertext = encryptor.encrypt(&writeBuffer[0], offsetInBlock, arena);
+	auto tag = encryptor.finish(arena);
+	const int rawBlockSize = encryptionBlockSize + GCM_TAG_LEN;
+	auto* outBuf = new (arena) unsigned char[offsetInBlock + GCM_TAG_LEN];
+	std::copy(ciphertext.begin(), ciphertext.end(), outBuf);
+	std::copy(tag.begin(), tag.end(), outBuf + ciphertext.size());
+	return uncancellable(holdWhile(
+	    Reference<AsyncFileEncrypted>::addRef(this),
+	    holdWhile(arena, file->write(outBuf, offsetInBlock + GCM_TAG_LEN, int64_t(rawBlockSize) * currentBlock))));
 }
 
 // This test writes random data into an encrypted file in random increments,

--- a/fdbrpc/include/fdbrpc/AsyncFileEncrypted.h
+++ b/fdbrpc/include/fdbrpc/AsyncFileEncrypted.h
@@ -43,7 +43,6 @@ private:
 	int64_t fileSize = -1;
 
 	// Writing (append only):
-	std::unique_ptr<EncryptionStreamCipher> encryptor;
 	uint32_t currentBlock{ 0 };
 	int offsetInBlock{ 0 };
 	std::vector<unsigned char> writeBuffer;
@@ -65,4 +64,11 @@ public:
 	Future<Void> readZeroCopy(void** data, int* length, int64_t offset) override;
 	void releaseZeroCopy(void* data, int length, int64_t offset) override;
 	int64_t debugFD() const override;
+
+	// Convert raw on-disk file size (including per-block GCM tags) to logical plaintext size.
+	// Pure math, no I/O. blockSize is the plaintext block size (encryptionBlockSize).
+	static int64_t rawToLogicalSize(int64_t rawSize, int blockSize);
+
+	// Inverse of rawToLogicalSize: given a logical plaintext size, return the raw on-disk size.
+	static int64_t logicalToRawSize(int64_t logicalSize, int blockSize);
 };

--- a/flow/StreamCipher.cpp
+++ b/flow/StreamCipher.cpp
@@ -124,15 +124,22 @@ StringRef EncryptionStreamCipher::encrypt(unsigned char const* plaintext, int le
 	CODE_PROBE(true, "Encrypting data with StreamCipher");
 	auto ciphertext = new (arena) unsigned char[len + AES_BLOCK_SIZE];
 	int bytes{ 0 };
-	EVP_EncryptUpdate(cipher.getCtx(), ciphertext, &bytes, plaintext, len);
+	if (EVP_EncryptUpdate(cipher.getCtx(), ciphertext, &bytes, plaintext, len) != 1) {
+		throw encrypt_ops_error();
+	}
 	return StringRef(ciphertext, bytes);
 }
 
 StringRef EncryptionStreamCipher::finish(Arena& arena) {
-	auto ciphertext = new (arena) unsigned char[AES_BLOCK_SIZE];
+	auto ciphertext = new (arena) unsigned char[AES_BLOCK_SIZE + GCM_TAG_LEN];
 	int bytes{ 0 };
-	EVP_EncryptFinal_ex(cipher.getCtx(), ciphertext, &bytes);
-	return StringRef(ciphertext, bytes);
+	if (EVP_EncryptFinal_ex(cipher.getCtx(), ciphertext, &bytes) != 1) {
+		throw encrypt_ops_error();
+	}
+	if (EVP_CIPHER_CTX_ctrl(cipher.getCtx(), EVP_CTRL_GCM_GET_TAG, GCM_TAG_LEN, ciphertext + bytes) != 1) {
+		throw encrypt_ops_error();
+	}
+	return StringRef(ciphertext, bytes + GCM_TAG_LEN);
 }
 
 DecryptionStreamCipher::DecryptionStreamCipher(const StreamCipherKey* key, const StreamCipher::IV& iv)
@@ -146,16 +153,22 @@ StringRef DecryptionStreamCipher::decrypt(unsigned char const* ciphertext, int l
 	CODE_PROBE(true, "Decrypting data with StreamCipher");
 	auto plaintext = new (arena) unsigned char[len];
 	int bytesDecrypted{ 0 };
-	EVP_DecryptUpdate(cipher.getCtx(), plaintext, &bytesDecrypted, ciphertext, len);
-	int finalBlockBytes{ 0 };
-	EVP_DecryptFinal_ex(cipher.getCtx(), plaintext + bytesDecrypted, &finalBlockBytes);
-	return StringRef(plaintext, bytesDecrypted + finalBlockBytes);
+	if (EVP_DecryptUpdate(cipher.getCtx(), plaintext, &bytesDecrypted, ciphertext, len) != 1) {
+		throw encrypt_ops_error();
+	}
+	return StringRef(plaintext, bytesDecrypted);
 }
 
-StringRef DecryptionStreamCipher::finish(Arena& arena) {
+StringRef DecryptionStreamCipher::finish(const uint8_t* tag, Arena& arena) {
+	if (EVP_CIPHER_CTX_ctrl(cipher.getCtx(), EVP_CTRL_GCM_SET_TAG, GCM_TAG_LEN, const_cast<uint8_t*>(tag)) != 1) {
+		throw encrypt_ops_error();
+	}
 	auto plaintext = new (arena) unsigned char[AES_BLOCK_SIZE];
 	int finalBlockBytes{ 0 };
-	EVP_DecryptFinal_ex(cipher.getCtx(), plaintext, &finalBlockBytes);
+	if (EVP_DecryptFinal_ex(cipher.getCtx(), plaintext, &finalBlockBytes) != 1) {
+		TraceEvent(SevWarn, "DecryptGcmTagMismatch").log();
+		throw restore_corrupted_data();
+	}
 	return StringRef(plaintext, finalBlockBytes);
 }
 
@@ -206,17 +219,18 @@ TEST_CASE("flow/StreamCipher") {
 			encryptedOffset += encrypted.size();
 			index += chunkSize;
 		}
+		ciphertext.resize(encryptedOffset + GCM_TAG_LEN);
 		const auto encrypted = encryptor.finish(arena);
 		std::copy(encrypted.begin(), encrypted.end(), &ciphertext[encryptedOffset]);
-		ciphertext.resize(encryptedOffset + encrypted.size());
 	}
 
 	{
 		DecryptionStreamCipher decryptor(key, iv);
 		int index = 0;
 		int decryptedOffset = 0;
-		while (index < plaintext.size()) {
-			const auto chunkSize = std::min<int>(deterministicRandom()->randomInt(1, 101), plaintext.size() - index);
+		const int payloadSize = ciphertext.size() - GCM_TAG_LEN;
+		while (index < payloadSize) {
+			const auto chunkSize = std::min<int>(deterministicRandom()->randomInt(1, 101), payloadSize - index);
 			const auto decrypted = decryptor.decrypt(&ciphertext[index], chunkSize, arena);
 			TraceEvent("StreamCipherTestDecryptedChunk")
 			    .detail("DecryptedSize", decrypted.size())
@@ -226,7 +240,7 @@ TEST_CASE("flow/StreamCipher") {
 			decryptedOffset += decrypted.size();
 			index += chunkSize;
 		}
-		const auto decrypted = decryptor.finish(arena);
+		const auto decrypted = decryptor.finish(&ciphertext[payloadSize], arena);
 		std::copy(decrypted.begin(), decrypted.end(), &decryptedtext[decryptedOffset]);
 		ASSERT_EQ(decryptedOffset + decrypted.size(), plaintext.size());
 		decryptedtext.resize(decryptedOffset + decrypted.size());

--- a/flow/include/flow/StreamCipher.h
+++ b/flow/include/flow/StreamCipher.h
@@ -32,6 +32,7 @@
 #include <vector>
 
 #define AES_256_KEY_LENGTH 32
+#define GCM_TAG_LEN 16
 
 // Wrapper class for openssl implementation of AES GCM
 // encryption/decryption
@@ -93,7 +94,7 @@ class DecryptionStreamCipher final : NonCopyable, public ReferenceCounted<Decryp
 public:
 	DecryptionStreamCipher(const StreamCipherKey* key, const StreamCipher::IV& iv);
 	StringRef decrypt(unsigned char const* ciphertext, int len, Arena&);
-	StringRef finish(Arena&);
+	StringRef finish(const uint8_t* tag, Arena&);
 };
 
 class HmacSha256StreamCipher final : NonCopyable, public ReferenceCounted<HmacSha256StreamCipher> {


### PR DESCRIPTION
1. Cherrypick https://github.com/apple/foundationdb/pull/13661 
2. Cherrypick https://github.com/apple/foundationdb/pull/13689
3.  Cherrypick https://github.com/apple/foundationdb/pull/13751 (Pending - In Review)

### Testing
100k Simulation test completed:
`  20260709-175029-ak_enc_7.3_1-21638a200a52ac48      compressed=True data_size=34703010 duration=3439821 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:28:51 sanity=False started=100000 stopped=20260709-181920 submitted=20260709-175029 timeout=5400 username=ak_enc_7.3_1`