### PR TITLE
[release-7.3] build: find_package fmt 8.1.1 EXACT

### DIFF
--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_library(rapidjson INTERFACE)
 target_include_directories(rapidjson INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/rapidjson)
 
-find_package(fmt 8.1.1 GLOBAL)
+find_package(fmt 8.1.1 EXACT GLOBAL)
 if(NOT fmt_FOUND)
   add_subdirectory(fmt-8.1.1)
 endif()


### PR DESCRIPTION
avoid cmake trying to use the system installed c++ lib "fmt" if it is newer and probably not compatible
(e.g. fmt-12.x via homebrew on macOS)

------------------

I happened to have fmt-12.2.2 installed on my macOS system via homebrew, as a transitive dependency for node. That was being used by a release-7.3 branch build, resulting in this compile error:
                                                                                                                                                                                   
    fdbrpc/IPAllowList.cpp:35:36: error: no member named 'join' in namespace 'fmt'                                                                                                             
      35 |         return fmt::format("{:02x}", fmt::join(addr, ":"));                                                                                                                        

I could avoid that by `brew unlink fmt`, but this is a more robust and broad fix.

The `release-7.4` and `main` branches of foundationdb already match EXACT version of fmt (although they provide a vendored copy of the desired version differently).

The `GLOBAL` option is a bit weird, the `release-7.4` and `main` branches don't use it, and `release-7.3` does seem to build fine *without* it, but it seems harmless so might as well leave it in this stable-maintenance branch. It means:

> New in version 3.24: Specifying the GLOBAL keyword will promote all imported targets to a global scope in the importing project. Alternatively, this functionality can be enabled by setting the [CMAKE_FIND_PACKAGE_TARGETS_GLOBAL](https://cmake.org/cmake/help/v3.24/variable/CMAKE_FIND_PACKAGE_TARGETS_GLOBAL.html#variable:CMAKE_FIND_PACKAGE_TARGETS_GLOBAL) variable.

(Our oldest release-vm and centos7 build image have cmake 3.26)