### PR TITLE
fdbcli audit_storage metadata_encoding: fix counting of format-neutral entries

### DIFF
--- a/fdbcli/CheckMetadataEncodingCommand.cpp
+++ b/fdbcli/CheckMetadataEncodingCommand.cpp
@@ -115,7 +115,7 @@ Future<bool> checkMetadataEncodingCommandActor(Database cx, std::vector<StringRe
 	}
 
 	// Count dataMoves
-	{
+	loop {
 		Transaction tr(cx);
 		tr.setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
 		tr.setOption(FDBTransactionOptions::READ_LOCK_AWARE);
@@ -124,12 +124,11 @@ Future<bool> checkMetadataEncodingCommandActor(Database cx, std::vector<StringRe
 		try {
 			RangeResult result = co_await tr.getRange(dataMoveKeys, CLIENT_KNOBS->TOO_MANY);
 			dataMovesCount = result.size();
+			break;
 		} catch (Error& e) {
 			err = e;
 		}
-		if (err.isValid()) {
-			co_await tr.onError(err);
-		}
+		co_await tr.onError(err);
 	}
 
 	// Report

--- a/fdbcli/CheckMetadataEncodingCommand.cpp
+++ b/fdbcli/CheckMetadataEncodingCommand.cpp
@@ -32,7 +32,12 @@ Future<bool> checkMetadataEncodingCommandActor(Database cx, std::vector<StringRe
 	int64_t serverKeysOld = 0, serverKeysNew = 0;
 	int64_t dataMovesCount = 0;
 
-	// Scan keyServers
+	// Scan keyServers.
+	// Empty-value entries are KRM boundary sentinels — they mark the
+	// edges between adjacent same-valued ranges and do not carry any
+	// keyServers assignment. Skip them; counting them as either format
+	// leaves a permanent residual that makes the FORWARD COMPLETE
+	// terminal state unreachable on any real cluster.
 	{
 		Key begin = keyServersPrefix;
 		Key end = keyServersEnd;
@@ -46,7 +51,6 @@ Future<bool> checkMetadataEncodingCommandActor(Database cx, std::vector<StringRe
 				RangeResult result = co_await tr.getRange(KeyRangeRef(begin, end), 1000);
 				for (const auto& kv : result) {
 					if (kv.value.empty()) {
-						keyServersOld++;
 						continue;
 					}
 					BinaryReader rd(kv.value, IncludeVersion());
@@ -68,7 +72,15 @@ Future<bool> checkMetadataEncodingCommandActor(Database cx, std::vector<StringRe
 		}
 	}
 
-	// Scan serverKeys
+	// Scan serverKeys.
+	// Uses classifiers from SystemData.h to distinguish format-neutral
+	// entries (empty sentinels + serverKeysFalse "not assigned") from
+	// old-format assignments (serverKeysTrue / serverKeysTrueEmptyRange)
+	// from new-format assignments (any other non-empty value: a
+	// UID-encoded dataMoveId). Previously all three category buckets
+	// were merged into "old", making the FORWARD COMPLETE terminal
+	// state unreachable — any running cluster always has serverKeysFalse
+	// entries as range-boundary markers around assigned ranges.
 	{
 		Key begin = serverKeysPrefix;
 		Key end = strinc(serverKeysPrefix);
@@ -81,8 +93,10 @@ Future<bool> checkMetadataEncodingCommandActor(Database cx, std::vector<StringRe
 			try {
 				RangeResult result = co_await tr.getRange(KeyRangeRef(begin, end), 1000);
 				for (const auto& kv : result) {
-					if (kv.value == serverKeysTrue || kv.value == serverKeysFalse ||
-					    kv.value == serverKeysTrueEmptyRange) {
+					if (isServerKeysUnassigned(kv.value)) {
+						continue;
+					}
+					if (isServerKeysOldFormatAssigned(kv.value)) {
 						serverKeysOld++;
 					} else {
 						serverKeysNew++;

--- a/fdbclient/SystemData.cpp
+++ b/fdbclient/SystemData.cpp
@@ -538,6 +538,18 @@ bool serverHasKey(ValueRef storedValue) {
 	return assigned;
 }
 
+// See declaration in SystemData.h.
+bool isServerKeysUnassigned(const ValueRef& value) {
+	// Empty values are KRM boundary sentinels. serverKeysFalse ("not
+	// assigned") is written by both flavors on the drop-side of a move.
+	return value.empty() || value == serverKeysFalse;
+}
+
+// See declaration in SystemData.h.
+bool isServerKeysOldFormatAssigned(const ValueRef& value) {
+	return value == serverKeysTrue || value == serverKeysTrueEmptyRange;
+}
+
 Value serverKeysValue(const UID& id) {
 	if (!id.isValid()) {
 		return serverKeysFalse;

--- a/fdbclient/include/fdbclient/SystemData.h
+++ b/fdbclient/include/fdbclient/SystemData.h
@@ -181,6 +181,17 @@ DataMoveMetaData decodeDataMoveValue(const ValueRef& value);
 extern const KeyRangeRef serverKeysRange;
 extern const KeyRef serverKeysPrefix;
 extern const ValueRef serverKeysTrue, serverKeysTrueEmptyRange, serverKeysFalse;
+// Returns true iff `value` is a format-neutral serverKeys entry — i.e.
+// serverKeysFalse ("this server does not own this range") or the empty
+// value that KRM uses as a range-boundary sentinel. Both are written by
+// both the tag-based (finishMoveKeys) and the shard-encoded
+// (finishMoveShards) paths, so they carry no format signal.
+bool isServerKeysUnassigned(const ValueRef& value);
+// Returns true iff `value` is an old-format (tag-based) serverKeys
+// "assigned" marker. Excludes serverKeysFalse and empty (see
+// isServerKeysUnassigned). New-format entries encode a UID and won't
+// equal these constants.
+bool isServerKeysOldFormatAssigned(const ValueRef& value);
 UID newDataMoveId(const uint64_t physicalShardId,
                   AssignEmptyRange assignEmptyRange,
                   const DataMoveType type,

--- a/fdbserver/workloads/CheckMetadataEncoding.cpp
+++ b/fdbserver/workloads/CheckMetadataEncoding.cpp
@@ -35,11 +35,24 @@ struct CheckMetadataEncodingWorkload : TestWorkload {
 	bool shardEncodeExpected;
 	bool allowMixedFormats; // True in rollback scenarios where old entries remain
 	bool requireKnobFalse; // If true, assert that SHARD_ENCODE is actually false
+	// If true (in a knob=true phase), require the FORWARD COMPLETE condition:
+	// zero old-format assigned entries in both keyServers and serverKeys.
+	// Uses the same counting logic as fdbcli's `audit_storage
+	// metadata_encoding` command, so this option gates on the same
+	// terminal state that command reports.
+	bool requireForwardComplete;
+	// If true (in a knob=false phase), require the ROLLBACK COMPLETE
+	// condition: zero new-format entries in both keyServers and
+	// serverKeys, AND no dataMoves entries. Same condition the fdbcli
+	// audit tool uses to report "safe to downgrade binary".
+	bool requireRollbackComplete;
 
 	explicit CheckMetadataEncodingWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
 		shardEncodeExpected = SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA;
 		allowMixedFormats = getOption(options, "allowMixedFormats"_sr, false);
 		requireKnobFalse = getOption(options, "requireKnobFalse"_sr, false);
+		requireForwardComplete = getOption(options, "requireForwardComplete"_sr, false);
+		requireRollbackComplete = getOption(options, "requireRollbackComplete"_sr, false);
 	}
 
 	Future<Void> setup(Database const& cx) override {
@@ -65,8 +78,12 @@ struct CheckMetadataEncodingWorkload : TestWorkload {
 	Future<Void> _start(CheckMetadataEncodingWorkload* self, Database cx) {
 		int64_t keyServersOld = 0, keyServersNew = 0;
 		int64_t serverKeysOld = 0, serverKeysNew = 0;
+		int64_t dataMovesCount = 0;
 
-		// Scan keyServers
+		// Scan keyServers.
+		// Empty-value entries are KRM boundary sentinels — format-neutral,
+		// skipped for the same reason the fdbcli audit tool skips them
+		// (see fdbcli/CheckMetadataEncodingCommand.cpp).
 		{
 			Key begin = keyServersPrefix;
 			Key end = keyServersEnd;
@@ -79,7 +96,6 @@ struct CheckMetadataEncodingWorkload : TestWorkload {
 					RangeResult result = co_await tr.getRange(KeyRangeRef(begin, end), 1000);
 					for (const auto& kv : result) {
 						if (kv.value.empty()) {
-							keyServersOld++;
 							continue;
 						}
 						BinaryReader rd(kv.value, IncludeVersion());
@@ -102,7 +118,12 @@ struct CheckMetadataEncodingWorkload : TestWorkload {
 			}
 		}
 
-		// Scan serverKeys
+		// Scan serverKeys.
+		// Uses the same classifiers as the fdbcli audit tool: format-
+		// neutral entries (empty sentinels + serverKeysFalse) are
+		// skipped, old-format assignments (serverKeysTrue /
+		// serverKeysTrueEmptyRange) and new-format assignments
+		// (UID-encoded) are counted separately.
 		{
 			Key begin = serverKeysPrefix;
 			Key end = strinc(serverKeysPrefix);
@@ -114,8 +135,10 @@ struct CheckMetadataEncodingWorkload : TestWorkload {
 				try {
 					RangeResult result = co_await tr.getRange(KeyRangeRef(begin, end), 1000);
 					for (const auto& kv : result) {
-						if (kv.value == serverKeysTrue || kv.value == serverKeysFalse ||
-						    kv.value == serverKeysTrueEmptyRange) {
+						if (isServerKeysUnassigned(kv.value)) {
+							continue;
+						}
+						if (isServerKeysOldFormatAssigned(kv.value)) {
 							serverKeysOld++;
 						} else {
 							serverKeysNew++;
@@ -134,12 +157,42 @@ struct CheckMetadataEncodingWorkload : TestWorkload {
 			}
 		}
 
-		TraceEvent("CheckMetadataEncodingResult")
-		    .detail("ShardEncodeExpected", self->shardEncodeExpected)
+		// Count in-flight data moves. Needed for the ROLLBACK COMPLETE
+		// terminal condition (same as the fdbcli audit tool). Only scan
+		// when the assertion actually needs the count — the scan is
+		// otherwise wasted I/O and the trace event below distinguishes
+		// "not scanned" from "0 entries" by omitting the DataMoves detail.
+		bool dataMovesScanned = false;
+		if (self->requireRollbackComplete) {
+			loop {
+				Transaction tr(cx);
+				tr.setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
+				tr.setOption(FDBTransactionOptions::READ_LOCK_AWARE);
+				Error err;
+				try {
+					RangeResult result = co_await tr.getRange(dataMoveKeys, CLIENT_KNOBS->TOO_MANY);
+					ASSERT(!result.more && result.size() < CLIENT_KNOBS->TOO_MANY);
+					dataMovesCount = result.size();
+					dataMovesScanned = true;
+					break;
+				} catch (Error& e) {
+					err = e;
+				}
+				co_await tr.onError(err);
+			}
+		}
+
+		auto resultEvent = TraceEvent("CheckMetadataEncodingResult");
+		resultEvent.detail("ShardEncodeExpected", self->shardEncodeExpected)
 		    .detail("KeyServersOld", keyServersOld)
 		    .detail("KeyServersNew", keyServersNew)
 		    .detail("ServerKeysOld", serverKeysOld)
-		    .detail("ServerKeysNew", serverKeysNew);
+		    .detail("ServerKeysNew", serverKeysNew)
+		    .detail("RequireForwardComplete", self->requireForwardComplete)
+		    .detail("RequireRollbackComplete", self->requireRollbackComplete);
+		if (dataMovesScanned) {
+			resultEvent.detail("DataMoves", dataMovesCount);
+		}
 
 		if (self->shardEncodeExpected) {
 			// With SHARD_ENCODE=true and moves having occurred, we expect new-format entries.
@@ -171,6 +224,48 @@ struct CheckMetadataEncodingWorkload : TestWorkload {
 				    .detail("Reason", "Expected all old-format serverKeys but found new-format entries")
 				    .detail("ServerKeysOld", serverKeysOld)
 				    .detail("ServerKeysNew", serverKeysNew);
+			}
+		}
+
+		// Terminal-state assertions are independent of shardEncodeExpected:
+		// if the caller requested one, the corresponding assertion must
+		// always run — otherwise a knob-override failure would silently
+		// bypass the check. Mismatched-mode combinations (e.g.
+		// requireForwardComplete=true while knob is false) are treated as
+		// misconfiguration and fail loudly.
+		if (self->requireForwardComplete) {
+			if (!self->shardEncodeExpected) {
+				TraceEvent(SevError, "CheckMetadataEncodingFailed")
+				    .detail("Reason", "requireForwardComplete set but SHARD_ENCODE_LOCATION_METADATA is false")
+				    .detail("ShardEncodeExpected", self->shardEncodeExpected);
+			} else if (keyServersOld != 0 || serverKeysOld != 0) {
+				// FORWARD COMPLETE: no old-format assigned entries remain.
+				// Same condition fdbcli's audit tool reports as
+				// "FORWARD COMPLETE".
+				TraceEvent(SevError, "CheckMetadataEncodingFailed")
+				    .detail("Reason", "FORWARD COMPLETE required but old-format entries remain")
+				    .detail("KeyServersOld", keyServersOld)
+				    .detail("KeyServersNew", keyServersNew)
+				    .detail("ServerKeysOld", serverKeysOld)
+				    .detail("ServerKeysNew", serverKeysNew);
+			}
+		}
+		if (self->requireRollbackComplete) {
+			if (self->shardEncodeExpected) {
+				TraceEvent(SevError, "CheckMetadataEncodingFailed")
+				    .detail("Reason", "requireRollbackComplete set but SHARD_ENCODE_LOCATION_METADATA is true")
+				    .detail("ShardEncodeExpected", self->shardEncodeExpected);
+			} else if (keyServersNew != 0 || serverKeysNew != 0 || dataMovesCount != 0) {
+				// ROLLBACK COMPLETE: no new-format entries and no data
+				// moves. Same condition fdbcli's audit tool reports as
+				// "ROLLBACK COMPLETE — safe to downgrade binary".
+				TraceEvent(SevError, "CheckMetadataEncodingFailed")
+				    .detail("Reason", "ROLLBACK COMPLETE required but state not yet drained")
+				    .detail("KeyServersOld", keyServersOld)
+				    .detail("KeyServersNew", keyServersNew)
+				    .detail("ServerKeysOld", serverKeysOld)
+				    .detail("ServerKeysNew", serverKeysNew)
+				    .detail("DataMoves", dataMovesCount);
 			}
 		}
 

--- a/tests/fast/CheckMetadataEncodingForward.toml
+++ b/tests/fast/CheckMetadataEncodingForward.toml
@@ -15,3 +15,10 @@ testTitle = 'CheckMetadataEncodingForward'
 
     [[test.workload]]
     testName = 'CheckMetadataEncoding'
+    # Assert the same FORWARD COMPLETE terminal condition that fdbcli's
+    # `audit_storage metadata_encoding` reports. Without the counting
+    # fix in CheckMetadataEncoding.cpp / CheckMetadataEncodingCommand.cpp,
+    # KRM range-boundary sentinels (empty keyServers values) and
+    # serverKeysFalse markers are miscounted as old-format entries, so
+    # this assertion fails on any fresh SHARD_ENCODE=true cluster.
+    requireForwardComplete = true


### PR DESCRIPTION
This is the first bug found in a test that enables and disables SHARD_ENCODE_LOCATION_METADATA on a cluster at scale to exercise the facility added by #13310..  The  audit tool was amended to report status of the SHARD_ENCODE_LOCATION_METADATA migrtion, both rolling on to the knob and also rolling back.

The audit tool's status line reported MIGRATION IN PROGRESS indefinitely on any running cluster in the FORWARD direction — the FORWARD COMPLETE terminal state was unreachable. Root cause: two categories of format-neutral entries were being counted as old-format:

1. Empty-value keyServers entries. These are KRM boundary sentinels (see krmDecodeRanges in fdbclient/KeyRangeMap.cpp:70-84 for how they are emitted at range ends). They mark the edge between adjacent same-valued ranges and do not carry any keyServers assignment. Every cluster has some — they cannot be migrated away.

2. serverKeysFalse ("this server does not own this range"). Written by both finishMoveKeys (old format, MoveKeys.cpp:1787) AND finishMoveShards (new format, MoveKeys.cpp:2138) on the drop-side of any move. Also written as range boundary markers around every assigned range (see unassignServerKeys in MoveKeys.cpp:91,127). Every running cluster has many — they cannot be migrated away.

Under the old counting logic, keyServersOld and serverKeysOld were therefore never zero, and the terminal-state condition (keyServersOld == 0 && serverKeysOld == 0) that gates FORWARD COMPLETE never triggered. ROLLBACK COMPLETE was unaffected because its condition looks at *New* counts.

Fix: exclude format-neutral entries from the counts. keyServers skips empty values. serverKeys uses two new small helpers added to SystemData.h/cpp:

  isServerKeysUnassigned(value)      — true for empty + serverKeysFalse
  isServerKeysOldFormatAssigned(value) — true for serverKeysTrue +
                                         serverKeysTrueEmptyRange

Not caught earlier because the audit command has no automated callers — it is a manual operator command, and manual users would see MIGRATION IN PROGRESS and assume DD needed more time. The first automated consumer that asserts the FORWARD terminal state is the k8s test test_shardencode_rollover_load, which hangs indefinitely without this fix.

Other fixes coming soon.


`  20260709-212014-stack-empppty-b2c9dbd86764827b     compressed=True data_size=37469639 duration=2960743 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:59:15 sanity=False started=100000 stopped=20260709-221929 submitted=20260709-212014 timeout=5400 username=stack-empppty`