### PR TITLE
Revert "fdb_c wiggle test harness: wait for cluster health and retry progress checks (#13657)"

### DIFF
--- a/tests/TestRunner/fdb_test_runner/local_cluster.py
+++ b/tests/TestRunner/fdb_test_runner/local_cluster.py
@@ -16,14 +16,6 @@ from .test_util import random_alphanum_string
 
 CLUSTER_UPDATE_TIMEOUT_SEC = 10
 EXCLUDE_SERVERS_TIMEOUT_SEC = 120
-# A wiggle re-recruits storage and moves data; the cluster can take a while to
-# become fully healthy again afterwards (recovery + data redistribution), so this
-# wait is bounded generously but returns as soon as the cluster is healthy.
-CLUSTER_HEALTHY_TIMEOUT_SEC = 180
-# The cluster must report healthy this many consecutive checks before we trust it,
-# so we don't latch onto a transient healthy window while recovery is still in
-# progress.
-CLUSTER_HEALTHY_STABLE_CHECKS = 5
 RETRY_INTERVAL_SEC = 0.5
 PORT_LOCK_DIR = Path(tempfile.gettempdir()).joinpath("fdb_local_cluster_port_locks")
 MAX_PORT_ACQUIRE_ATTEMPTS = 1000
@@ -553,102 +545,6 @@ knob_min_trace_severity=5
             timeout, self.active_servers, servers_found
         )
 
-    # Wait until the cluster is fully healthy again: fully recovered, data
-    # replicated to the configured factor, and no data movement in flight. This is
-    # needed after operations like a wiggle that re-recruit storage and move data,
-    # because the process set can be updated (wait_for_server_update) well before
-    # the cluster has finished redistributing data and is able to serve all
-    # workloads. Returns as soon as the cluster has been healthy for a few
-    # consecutive checks (to avoid latching onto a transient healthy window during
-    # recovery); bounded by timeout.
-    def wait_for_cluster_healthy(self, timeout=CLUSTER_HEALTHY_TIMEOUT_SEC):
-        time_limit = time.time() + timeout
-        last_reason = "unknown"
-        consecutive_healthy = 0
-        while time.time() <= time_limit:
-            reason = self.cluster_health_issue()
-            if reason is None:
-                consecutive_healthy += 1
-                if consecutive_healthy >= CLUSTER_HEALTHY_STABLE_CHECKS:
-                    return
-            else:
-                if consecutive_healthy > 0:
-                    # Was briefly healthy then regressed - the cluster is still
-                    # settling, so restart the stability count.
-                    last_reason = "regressed after {} healthy checks: {}".format(
-                        consecutive_healthy, reason
-                    )
-                else:
-                    last_reason = reason
-                consecutive_healthy = 0
-            time.sleep(RETRY_INTERVAL_SEC)
-        assert (
-            False
-        ), "Cluster did not become stably healthy after {}sec. Last issue: {}".format(
-            timeout, last_reason
-        )
-
-    # Return None if the cluster is healthy, otherwise a short string describing
-    # why it is not (used by wait_for_cluster_healthy).
-    def cluster_health_issue(self):
-        try:
-            status = self.get_status()
-        except Exception as e:
-            return "status unavailable: {}".format(e)
-
-        cluster = status.get("cluster", {})
-
-        if "processes" not in cluster:
-            return "no processes in status"
-
-        recovery_state = cluster.get("recovery_state", {}).get("name")
-        if recovery_state != "fully_recovered":
-            return "recovery_state={}".format(recovery_state)
-
-        data = cluster.get("data", {})
-        data_state = data.get("state", {})
-        if not data_state.get("healthy", False):
-            return "data.state={}".format(data_state.get("name", "missing"))
-
-        # No data movement may be in flight.
-        moving = data.get("moving_data", {})
-        in_flight = moving.get("in_flight_bytes")
-        if in_flight is not None and in_flight > 0:
-            return "moving_data.in_flight_bytes={}".format(in_flight)
-        in_queue = moving.get("in_queue_bytes")
-        if in_queue is not None and in_queue > 0:
-            return "moving_data.in_queue_bytes={}".format(in_queue)
-
-        # Every storage team must be fully replicated with no in-flight relocation.
-        for tracker in data.get("team_trackers", []):
-            if not tracker.get("in_flight_bytes", 0) == 0:
-                return "team_tracker.in_flight_bytes={}".format(
-                    tracker.get("in_flight_bytes")
-                )
-            if tracker.get("unhealthy_servers", 0) != 0:
-                return "team_tracker.unhealthy_servers={}".format(
-                    tracker.get("unhealthy_servers")
-                )
-            tracker_state = tracker.get("state", {})
-            if tracker_state and not tracker_state.get("healthy", False):
-                return "team_tracker.state={}".format(
-                    tracker_state.get("name", "missing")
-                )
-
-        # No processes may still be excluded from the cluster (a wiggle excludes
-        # the old servers; they must be gone before we call the cluster healthy).
-        for proc_info in cluster["processes"].values():
-            if proc_info.get("excluded", False):
-                return "excluded_process={}".format(proc_info.get("address"))
-
-        # All expected processes must be present and reporting no excluded servers.
-        if len(cluster["processes"]) != self.process_number:
-            return "process_count={}/{}".format(
-                len(cluster["processes"]), self.process_number
-            )
-
-        return None
-
     # Apply changes to the set of the coordinators, based on the current value of self.coordinators
     def update_coordinators(self):
         urls = [
@@ -748,19 +644,6 @@ knob_min_trace_severity=5
         self.wait_for_server_update()
         print(
             "Old servers successfully removed from the cluster. Time: {}s".format(
-                time.time() - start_time
-            )
-        )
-
-        # Step 5: wait until the cluster is fully healthy again. The steps above
-        # only ensure the process set has been updated; the cluster may still be
-        # recovering and redistributing data onto the new servers. Returning before
-        # that completes lets the subsequent progress check race with an
-        # unavailable cluster and fail spuriously.
-        start_time = time.time()
-        self.wait_for_cluster_healthy()
-        print(
-            "Cluster fully healthy after wiggle. Time: {}s".format(
                 time.time() - start_time
             )
         )

--- a/tests/TestRunner/fdb_test_runner/upgrade_test.py
+++ b/tests/TestRunner/fdb_test_runner/upgrade_test.py
@@ -23,12 +23,6 @@ from .test_util import random_alphanum_string
 CLUSTER_ACTIONS = ["wiggle"]
 HEALTH_CHECK_TIMEOUT_SEC = 5
 PROGRESS_CHECK_TIMEOUT_SEC = 30
-# Number of times a progress check is retried before failing. Tolerates brief
-# post-wiggle/upgrade windows where the cluster is server-side healthy but the
-# client-side (MVC coordinator reconnect, location cache refresh) hasn't caught
-# up yet. wait_for_cluster_healthy covers server-side recovery; these retries
-# cover client-side warmup.
-PROGRESS_CHECK_RETRIES = 3
 TESTER_STATS_INTERVAL_SEC = 5
 TRANSACTION_RETRY_LIMIT = 100
 RUN_WITH_GDB = False
@@ -269,32 +263,17 @@ class UpgradeTest:
                 )
                 os._exit(1)
 
-    # Perform a progress check: Trigger it and wait until it is completed.
-    # Retried PROGRESS_CHECK_RETRIES times: wait_for_cluster_healthy ensures
-    # server-side recovery, but after a coordinator change the MVC client-side
-    # (protocol-version monitor, location cache) can take longer to stabilize.
-    # A CHECK_OK requires all workloads to confirm progress, so a stale
-    # CHECK_OK from a slow-but-not-stuck prior attempt is acceptable evidence
-    # that the workloads were making progress; a genuinely stuck workload never
-    # produces a CHECK_OK regardless of retry count.
+    # Perform a progress check: Trigger it and wait until it is completed
     def progress_check(self):
-        for attempt in range(1, PROGRESS_CHECK_RETRIES + 1):
-            self.progress_event.clear()
-            os.write(self.ctrl_pipe, b"CHECK\n")
-            self.progress_event.wait(
-                None if RUN_WITH_GDB else PROGRESS_CHECK_TIMEOUT_SEC
+        self.progress_event.clear()
+        os.write(self.ctrl_pipe, b"CHECK\n")
+        self.progress_event.wait(None if RUN_WITH_GDB else PROGRESS_CHECK_TIMEOUT_SEC)
+        if self.progress_event.is_set():
+            print("Progress check: OK")
+        else:
+            assert False, "Progress check failed after upgrade to version {}".format(
+                self.cluster_version
             )
-            if self.progress_event.is_set():
-                print("Progress check: OK")
-                return
-            print(
-                "Progress check attempt {}/{} timed out after {}s".format(
-                    attempt, PROGRESS_CHECK_RETRIES, PROGRESS_CHECK_TIMEOUT_SEC
-                )
-            )
-        assert False, "Progress check failed after upgrade to version {}".format(
-            self.cluster_version
-        )
 
     # The main function of a thread for reading and processing
     # the notifications received from the tester


### PR DESCRIPTION
This reverts commit 7e59e02977.

    After #13657 landed, the ctest suite saw increased flakiness (~1/4
    failure rate, various tests failing non-deterministically on each run.
    The changes added significant latency to the upgrade/wiggle tests:

      - wait_for_cluster_healthy() polls for up to 180s after cluster_wiggle()
      - PROGRESS_CHECK_RETRIES=3 extends each progress check from 30s to
        up to 90s worst-case

    Reverting to confirm whether #13657 is the cause. If the failure rate
    returns to baseline the revert will be kept; the underlying reliability
    improvements will be reworked with less impact on test runtime.
    EOF
    )