### PR TITLE
[release-7.3] build: clean-up zstd support in boost, fix zstd build

### DIFF
--- a/cmake/CompileBoost.cmake
+++ b/cmake/CompileBoost.cmake
@@ -1,5 +1,14 @@
-function(compile_boost)
+## Boost
 
+# iostreams can include support for different compression libraries,
+# but this boost build disables them all except for basic zlib.
+# If FLOW_USE_ZSTD enabled then "flow" subdir will build and link
+# the boost iostream zstd implementation, it is not built here.
+
+# To use a separate boost build for fdb, do not build with bzip2/lzma/zstd
+# enabled, or add appropriate link flags via cmake options.
+
+function(compile_boost)
   # Initialize function incoming parameters
   set(options)
   set(oneValueArgs TARGET)
@@ -21,12 +30,6 @@ function(compile_boost)
     set(BOOST_TOOLSET "clang")
   elseif(CLANG)
     set(BOOST_TOOLSET "clang")
-    if(APPLE)
-      # this is to fix a weird macOS issue -- by default
-      # cmake would otherwise pass a compiler that can't
-      # compile boost
-      set(BOOST_CXX_COMPILER "/usr/bin/clang++")
-    endif()
   else()
     set(BOOST_TOOLSET "gcc")
   endif()
@@ -34,7 +37,7 @@ function(compile_boost)
 
   # Configure b2 command
   set(B2_COMMAND "./b2")
-  set(BOOST_COMPILER_FLAGS -fvisibility=hidden -fPIC -std=c++17 -w)
+  set(BOOST_COMPILER_FLAGS -fvisibility=hidden -fPIC -std=c++17 --no-warnings)
   set(BOOST_LINK_FLAGS "")
   if(APPLE OR ICX OR USE_LIBCXX)
     list(APPEND BOOST_COMPILER_FLAGS -stdlib=libc++ -nostdlib++)
@@ -67,11 +70,11 @@ function(compile_boost)
     URL                "https://archives.boost.io/release/1.78.0/source/boost_1_78_0.tar.bz2"
     URL_HASH           SHA256=8681f175d4bdb26c52222665793eef08490d7758529330f98d3b29dd0735bccc
     CONFIGURE_COMMAND  ${BOOTSTRAP_COMMAND}
-                       ${BOOTSTRAP_ARGS}
                        --with-libraries=${BOOTSTRAP_LIBRARIES}
                        --with-toolset=${BOOST_TOOLSET}
     BUILD_COMMAND      ${B2_COMMAND}
                        link=static
+                       -s NO_BZIP2=1 -s NO_LZMA=1 -s NO_ZSTD=1
                        ${COMPILE_BOOST_BUILD_ARGS}
                        --prefix=${BOOST_INSTALL_DIR}
                        ${USER_CONFIG_FLAG} install
@@ -157,19 +160,8 @@ endif()
 find_package(Boost 1.78.0 EXACT QUIET COMPONENTS context filesystem iostreams serialization system CONFIG PATHS ${BOOST_HINT_PATHS})
 set(FORCE_BOOST_BUILD OFF CACHE BOOL "Forces cmake to build boost and ignores any installed boost")
 
-# The precompiled boost silently broke in CI.  While investigating, I considered extending
-# the old check with something like this, so that it would fail loudly if it found a bad
-# pre-existing boost.  It turns out the error messages we get from CMake explain what is
-# wrong with Boost.  Rather than reimplementing that, I just deleted this logic.  This
-# approach is simpler, has better ergonomics and should be easier to maintain.  If the build
-# is picking up your locally installed or partial version of boost, and you don't want
+# If the build is picking up your locally installed or partial version of boost, and you don't want
 # to / cannot fix it, pass in -DFORCE_BOOST_BUILD=on as a workaround.
-#
-#    if(Boost_FOUND AND Boost_filesystem_FOUND AND Boost_context_FOUND AND Boost_iostreams_FOUND AND Boost_system_FOUND AND Boost_serialization_FOUND AND NOT FORCE_BOOST_BUILD)
-#      ...
-#    elseif(Boost_FOUND AND NOT FORCE_BOOST_BUILD)
-#      message(FATAL_ERROR "Unacceptable precompiled boost found")
-#
 if(Boost_FOUND AND NOT FORCE_BOOST_BUILD)
   message(STATUS "Found Boost: ${Boost_DIR}")
   add_library(boost_target INTERFACE)

--- a/cmake/CompileZstd.cmake
+++ b/cmake/CompileZstd.cmake
@@ -1,27 +1,27 @@
 # Compile zstd
+# Only used by flow, only if FLOW_USE_ZSTD
+# see flow/CMakeLists.txt
 
 function(compile_zstd)
-
   include(FetchContent)
 
-  FetchContent_Declare(ZSTD
-    GIT_REPOSITORY https://github.com/facebook/zstd.git
-    GIT_TAG v1.5.2
+  set(ZSTD_BUILD_STATIC ON)
+  set(ZSTD_BUILD_SHARED OFF)
+  set(ZSTD_BUILD_PROGRAMS OFF)
+  set(ZSTD_BUILD_TESTS OFF)
+  set(ZSTD_BUILD_CONTRIB OFF)
+
+  set(CMAKE_POLICY_VERSION_MINIMUM "3.10")
+
+  FetchContent_Declare(zstd
+    URL "https://github.com/facebook/zstd/releases/download/v1.5.2/zstd-1.5.2.tar.gz"
+    URL_HASH "SHA256=7c42d56fac126929a6a85dbc73ff1db2411d04f104fae9bdea51305663a83fd0"
     SOURCE_SUBDIR "build/cmake"
   )
+  FetchContent_MakeAvailable(zstd)
+  target_compile_options(libzstd_static PRIVATE -Wno-error)
 
-  FetchContent_GetProperties(ZSTD)
-  if (NOT zstd_POPULATED)
-    FetchContent_Populate(ZSTD)
-
-    add_subdirectory(${zstd_SOURCE_DIR}/build/cmake ${zstd_BINARY_DIR})
-
-    if (CLANG)
-      target_compile_options(zstd PRIVATE -Wno-array-bounds -Wno-tautological-compare)
-      target_compile_options(libzstd_static PRIVATE -Wno-array-bounds -Wno-tautological-compare)
-      target_compile_options(zstd-frugal PRIVATE -Wno-array-bounds -Wno-tautological-compare)
-    endif()
-  endif()
+  unset(CMAKE_POLICY_VERSION_MINIMUM)
 
   set(ZSTD_LIB_INCLUDE_DIR ${zstd_SOURCE_DIR}/lib CACHE INTERNAL ZSTD_LIB_INCLUDE_DIR)
 endfunction(compile_zstd)

--- a/cmake/FDBComponents.cmake
+++ b/cmake/FDBComponents.cmake
@@ -245,6 +245,7 @@ function(print_components)
   message(STATUS "Configure CTest (depends on Python):  ${WITH_PYTHON}")
   message(STATUS "Build with RocksDB:                   ${WITH_ROCKSDB_EXPERIMENTAL}")
   message(STATUS "Build with AWS SDK:                   ${WITH_AWS_BACKUP}")
+  message(STATUS "Build flow with zstd support:         ${FLOW_USE_ZSTD}")
   message(STATUS "=========================================")
 endfunction()
 

--- a/cmake/user-config.jam.cmake
+++ b/cmake/user-config.jam.cmake
@@ -1,2 +1,1 @@
 using @BOOST_TOOLSET@ : : @BOOST_CXX_COMPILER@ : @BOOST_ADDITIONAL_COMPILE_OPTIONS@ ;
-using zstd : 1.5.2 : <include>/@CMAKE_BINARY_DIR@/zstd/lib <search>/@CMAKE_BINARY_DIR@/lib ;


### PR DESCRIPTION
BACKPORT of https://github.com/apple/foundationdb/pull/13390

 * zstd only used if FLOW_USE_ZSTD
 * boost build should not use zstd (flow includes boost iostreams zstd impl. source/obj)
 * boost should not need to link zstd "just in case" (there are other optional iostreams compression libs, linked automatically if boost was built with them)
 * boost compile flag -w is short for --no-warnings

nicer zstd build:
 * tarball instead of git for zstd is more efficient
 * disable all zstd except static library
 * simpler workarounds, mostly need CMAKE_POLICY_VERSION_MINIMUM
 * show flow zstd enabled in build summary

-----------------

The last 7.3 releases did accidentally dynamically-link liblzma unnecessarily:

```
# readelf -d fdb-7.3.69/fdbserver.x86_64 

Dynamic section at offset 0x5c3be20 contains 31 entries:
  Tag        Type                         Name/Value
 0x0000000000000001 (NEEDED)             Shared library: [librt.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libdl.so.2]
 0x0000000000000001 (NEEDED)             Shared library: [liblzma.so.5]
 0x0000000000000001 (NEEDED)             Shared library: [libz.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libm.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [libpthread.so.0]
 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [ld-linux-x86-64.so.2]
```

```
# readelf -d fdb-7.3.77/fdbserver.x86_64 

Dynamic section at offset 0x5d301c0 contains 31 entries:
  Tag        Type                         Name/Value
 0x0000000000000001 (NEEDED)             Shared library: [librt.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libdl.so.2]
 0x0000000000000001 (NEEDED)             Shared library: [liblzma.so.5]
 0x0000000000000001 (NEEDED)             Shared library: [libz.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libm.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [libpthread.so.0]
 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [ld-linux-x86-64.so.2]
```

(and same for `fdbcli` and `fdbbackup`)

It seems not a huge deal since nobody noticed it, I guess all the linux systems (including the rhel9 / rockylinux9 systems we often run the fdb-7.3.x binaries on) all happen to have liblzma.so.5 installed as part of the "base OS" ... but I think it is very nice to avoid this kind of accidental library link 🤷 

I've run an 100k joshua test, and this had 1 spurious failure, though it really should not affect runtime in any subtle way. I've tested builds on macOS and centos7 both without and with the (default-off) `FLOW_USE_ZSTD` build option.

The macOS builds on the release-build instances will find and use a boost in `/opt` that already has this fix (was built with `-s NO_BZIP2=1 -s NO_LZMA=1 -s NO_ZSTD=1` by our `mac_setup.sh`).

The linux x86_64 build on `release-vm` will use the boost in `/opt` that does not have this fix, there's a lot of persistent setup/state on that old `release-vm` and I haven't updated/refactored it yet, not wanting to disturb anything unexpectedly for fdb-7.3.x releases. So for this I propose renaming `/opt/boost_1_78_0` to `/opt/disable.boost_1_78_0` (tested locally, successfully avoids cmake finding it).

(For the linux arm64 build, it's using a rockylinux9 container from 2024 with clang-15.x and I don't propose doing anything about that.)

If y'all think this is a bad idea, I understand 🙏 