### PR TITLE
Cancel shard moves after destination team becomes unhealthy

### DIFF
--- a/fdbserver/datadistributor/DDRelocationQueue.cpp
+++ b/fdbserver/datadistributor/DDRelocationQueue.cpp
@@ -2160,7 +2160,7 @@ Future<Void> dataDistributionRelocator(DDQueue* self,
 				                                                        : Optional<BulkLoadTaskState>());
 			}
 			Future<Void> doMoveKeys = self->txnProcessor->moveKeys(*params);
-			Future<Void> pollHealth = signalledTransferComplete
+			Future<Void> pollHealth = signalledTransferComplete && !SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA
 			                              ? Never()
 			                              : delay(SERVER_KNOBS->HEALTH_POLL_TIME, TaskPriority::DataDistributionLaunch);
 			try {
@@ -2229,8 +2229,22 @@ Future<Void> dataDistributionRelocator(DDQueue* self,
 								signalledTransferComplete = true;
 								self->dataTransferComplete.send(rd);
 							}
+							if (SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA) {
+								CODE_PROBE(true,
+								           "Cancel shard-encoded data move after destination team becomes unhealthy",
+								           probe::decoration::rare);
+								TraceEvent(SevWarnAlways, "RelocateShardDestinationTeamUnhealthy", distributorId)
+								    .detail("DataMoveID", rd.dataMoveId)
+								    .detail("Range", rd.keys)
+								    .detail("Dest", describe(destIds));
+								if (doBulkLoading && rd.bulkLoadTask.get().completeAck.canBeSet()) {
+									rd.bulkLoadTask.get().completeAck.send(
+									    BulkLoadAck(/*unretryableError=*/true, rd.priority));
+								}
+								throw data_move_dest_team_not_found();
+							}
 						}
-						pollHealth = signalledTransferComplete
+						pollHealth = signalledTransferComplete && !SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA
 						                 ? Never()
 						                 : delay(SERVER_KNOBS->HEALTH_POLL_TIME, TaskPriority::DataDistributionLaunch);
 					} else if (res.index() == 2) {


### PR DESCRIPTION
This PR fixes a data distribution bug found by the `DDPipelineSaturation.toml` test.

The failing run hit a state where a shard move’s destination team became unhealthy after the data move had already signaled transfer completion. For shard-encoded moves, `relocateShard` stopped polling destination health once `signalledTransferComplete` became true, so the relocation could continue without cancelling the underlying data move even though the destination team was no longer usable.

This PR changes `relocateShard` to keep checking destination-team health for shard-encoded moves and throw the existing `data_move_dest_team_not_found` error when the destination team becomes unhealthy. That routes through the existing cleanup path, which cancels the data move. Legacy/non-shard-encoded behavior is unchanged.

Confirmed by replaying the failing seed and running a full 100k-test unfiltered ensemble with the fix.