### PR TITLE
Rename `LoadBalance.actor.cpp`

### DIFF
--- a/fdbrpc/LoadBalance.cpp
+++ b/fdbrpc/LoadBalance.cpp
@@ -1,5 +1,5 @@
 /*
- * LoadBalance.actor.cpp
+ * LoadBalance.cpp
  *
  * This source file is part of the FoundationDB open source project
  *


### PR DESCRIPTION
`ACTOR`s were previously removed from this file, but the name was not updated accordingly
