### PR TITLE
Remove unnecessary build directory includes

### DIFF
--- a/fdbserver/commitproxy/CMakeLists.txt
+++ b/fdbserver/commitproxy/CMakeLists.txt
@@ -12,6 +12,5 @@ target_include_directories(fdbserver_commitproxy
     ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_include_directories(fdbserver_commitproxy
   PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_CURRENT_BINARY_DIR})
+    ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(fdbserver_commitproxy PRIVATE fdbserver_core fdbserver_kvstore fdbserver_logsystem)

--- a/fdbserver/coordinator/CMakeLists.txt
+++ b/fdbserver/coordinator/CMakeLists.txt
@@ -15,6 +15,5 @@ target_include_directories(fdbserver_coordinator
   PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/include
   PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_CURRENT_BINARY_DIR})
+    ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(fdbserver_coordinator PRIVATE fdbserver_core fdbserver_kvstore)

--- a/fdbserver/core/CMakeLists.txt
+++ b/fdbserver/core/CMakeLists.txt
@@ -19,8 +19,7 @@ target_include_directories(fdbserver_core
     ${CMAKE_CURRENT_SOURCE_DIR}/include
     ${CMAKE_CURRENT_BINARY_DIR}/include
   PRIVATE
-    ${CMAKE_SOURCE_DIR}/fdbserver/include
-    ${CMAKE_BINARY_DIR}/fdbserver/include)
+    ${CMAKE_SOURCE_DIR}/fdbserver/include)
 target_link_libraries(fdbserver_core PUBLIC fdbclient)
 
 if(WITH_ROCKSDB)

--- a/fdbserver/kvstore/CMakeLists.txt
+++ b/fdbserver/kvstore/CMakeLists.txt
@@ -15,8 +15,7 @@ target_include_directories(fdbserver_kvstore
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_SOURCE_DIR}/contrib/sqlite
-    ${CMAKE_SOURCE_DIR}/fdbserver/include
-    ${CMAKE_BINARY_DIR}/fdbserver/include)
+    ${CMAKE_SOURCE_DIR}/fdbserver/include)
 target_link_libraries(fdbserver_kvstore PUBLIC fdbserver_core sqlite)
 
 if(WITH_ROCKSDB)

--- a/fdbserver/logsystem/CMakeLists.txt
+++ b/fdbserver/logsystem/CMakeLists.txt
@@ -15,6 +15,5 @@ target_include_directories(fdbserver_logsystem
   PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/include
   PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_CURRENT_BINARY_DIR})
+    ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(fdbserver_logsystem PUBLIC fdbserver_core fdbserver_kvstore)

--- a/fdbserver/storageserver/CMakeLists.txt
+++ b/fdbserver/storageserver/CMakeLists.txt
@@ -14,8 +14,6 @@ configure_fdbserver_common_includes(fdbserver_storageserver)
 target_include_directories(fdbserver_storageserver
   PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/include
-    ${CMAKE_CURRENT_BINARY_DIR}/include
   PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_CURRENT_BINARY_DIR})
+    ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(fdbserver_storageserver PRIVATE fdbserver_core fdbserver_kvstore fdbserver_logsystem)

--- a/fdbserver/worker/CMakeLists.txt
+++ b/fdbserver/worker/CMakeLists.txt
@@ -47,11 +47,8 @@ target_include_directories(fdbserver_worker
     ${CMAKE_CURRENT_SOURCE_DIR}/include
   PRIVATE
     ${CMAKE_SOURCE_DIR}/fdbserver/include
-    ${CMAKE_BINARY_DIR}/fdbserver/include
     ${CMAKE_SOURCE_DIR}/fdbctl/include
-    ${CMAKE_BINARY_DIR}/fdbctl/include
-    ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_CURRENT_BINARY_DIR})
+    ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(fdbserver_worker
   PUBLIC
     fdbctl


### PR DESCRIPTION
These build-directory includes were only necessary to access generated `*.actor.g.h` files, but with the coroutine conversion there are many `CMakeLists.txt` files where they can be cleaned up