### PR TITLE
Serialize DD relocation queue handlers

### DIFF
--- a/fdbserver/datadistributor/DDRelocationQueue.cpp
+++ b/fdbserver/datadistributor/DDRelocationQueue.cpp
@@ -41,6 +41,7 @@
 #include "flow/DebugTrace.h"
 #include "DDRelocationQueue.h"
 #include "flow/CoroUtils.h"
+#include "flow/genericactors.actor.h"
 #include "flow/SimpleCounter.h"
 
 #define WORK_FULL_UTILIZATION 10000 // This is not a knob; it is a fixed point scaling factor!
@@ -2845,6 +2846,9 @@ struct DDQueueImpl {
 		FutureStream<RelocateData> completedRelocations;
 		PromiseStream<KeyRange> rangesComplete;
 		PromiseStream<Void> launchQueuedWorkTrigger;
+		// These handlers were a single choose loop before the coroutine conversion. Keep queue
+		// mutations serialized so inline stream callbacks cannot observe partially updated state.
+		FlowLock queueMutationLock;
 	};
 
 	static void validate(RunState* state) { state->self->validate(); }
@@ -2854,6 +2858,8 @@ struct DDQueueImpl {
 	static Future<Void> processGatedRelocations(RunState* state, FutureStream<RelocateShard> input) {
 		while (true) {
 			RelocateShard rs = co_await input;
+			co_await state->queueMutationLock.take(TaskPriority::DataDistributionLaunch);
+			FlowLock::Releaser lockGuard(state->queueMutationLock);
 			state->self->pendingGateRelocations--;
 			state->self->updatePipelineFull();
 			if (rs.isRestore()) {
@@ -2878,6 +2884,8 @@ struct DDQueueImpl {
 		while (true) {
 			co_await trigger;
 			co_await delay(0, TaskPriority::DataDistributionLaunch);
+			co_await state->queueMutationLock.take(TaskPriority::DataDistributionLaunch);
+			FlowLock::Releaser lockGuard(state->queueMutationLock);
 			state->self->launchQueuedWork(state->serversToLaunchFrom, state->self->ddEnabledState);
 			state->serversToLaunchFrom.clear();
 			validate(state);
@@ -2887,6 +2895,8 @@ struct DDQueueImpl {
 	static Future<Void> processFetchedSourceServers(RunState* state, FutureStream<RelocateData> input) {
 		while (true) {
 			RelocateData results = co_await input;
+			co_await state->queueMutationLock.take(TaskPriority::DataDistributionLaunch);
+			FlowLock::Releaser lockGuard(state->queueMutationLock);
 			// This stream is triggered by queueRelocation(), which is triggered by sending self->input.
 			state->self->completeSourceFetch(results);
 			validate(state);
@@ -2899,9 +2909,8 @@ struct DDQueueImpl {
 	static Future<Void> processCompletedDataTransfers(RunState* state, FutureStream<RelocateData> input) {
 		while (true) {
 			RelocateData done = co_await input;
-			// Relocator cancellation sends this stream inline from launchQueuedWork().
-			// Yield before mutating queue state so launchQueuedWork() can finish repairing its maps.
-			co_await delay(0, TaskPriority::DataDistributionLaunch);
+			co_await state->queueMutationLock.take(TaskPriority::DataDistributionLaunch);
+			FlowLock::Releaser lockGuard(state->queueMutationLock);
 			complete(done, state->self->busymap, state->self->destBusymap);
 			bool wasEmpty = state->serversToLaunchFrom.empty();
 			state->serversToLaunchFrom.insert(done.src.begin(), done.src.end());
@@ -2915,9 +2924,8 @@ struct DDQueueImpl {
 	static Future<Void> processCompletedRelocations(RunState* state) {
 		while (true) {
 			RelocateData done = co_await state->completedRelocations;
-			// Relocator cancellation sends this stream inline from launchQueuedWork().
-			// Yield before mutating queue state so launchQueuedWork() can finish repairing its maps.
-			co_await delay(0, TaskPriority::DataDistributionLaunch);
+			co_await state->queueMutationLock.take(TaskPriority::DataDistributionLaunch);
+			FlowLock::Releaser lockGuard(state->queueMutationLock);
 			state->self->processRelocationComplete(done);
 			// self->logRelocation( done, "ShardRelocatorDone" );
 			auto scheduleRangesComplete = [&](KeyRange keys) {
@@ -2949,6 +2957,8 @@ struct DDQueueImpl {
 		FutureStream<KeyRange> rangesComplete = state->rangesComplete.getFuture();
 		while (true) {
 			KeyRange done = co_await rangesComplete;
+			co_await state->queueMutationLock.take(TaskPriority::DataDistributionLaunch);
+			FlowLock::Releaser lockGuard(state->queueMutationLock);
 			validate(state);
 			if (!done.empty()) {
 				state->self->launchQueuedWork(done, state->self->ddEnabledState);
@@ -3033,6 +3043,8 @@ struct DDQueueImpl {
 		while (true) {
 			co_await next;
 			next = delay(SERVER_KNOBS->DD_QUEUE_LOGGING_INTERVAL, TaskPriority::FlushTrace);
+			co_await state->queueMutationLock.take(TaskPriority::FlushTrace);
+			FlowLock::Releaser lockGuard(state->queueMutationLock);
 			traceMovingData(state->self.getPtr());
 			validate(state);
 		}
@@ -3041,6 +3053,8 @@ struct DDQueueImpl {
 	static Future<Void> answerUnhealthyRelocationCount(RunState* state, FutureStream<Promise<int>> requests) {
 		while (true) {
 			Promise<int> request = co_await requests;
+			co_await state->queueMutationLock.take();
+			FlowLock::Releaser lockGuard(state->queueMutationLock);
 			request.send(state->self->getUnhealthyRelocationCount());
 			validate(state);
 		}
@@ -3048,6 +3062,8 @@ struct DDQueueImpl {
 
 	static Future<Void> waitAndValidate(RunState* state, Future<Void> future) {
 		co_await future;
+		co_await state->queueMutationLock.take();
+		FlowLock::Releaser lockGuard(state->queueMutationLock);
 		validate(state);
 	}
 

--- a/fdbserver/datadistributor/DDRelocationQueue.cpp
+++ b/fdbserver/datadistributor/DDRelocationQueue.cpp
@@ -2846,8 +2846,7 @@ struct DDQueueImpl {
 		FutureStream<RelocateData> completedRelocations;
 		PromiseStream<KeyRange> rangesComplete;
 		PromiseStream<Void> launchQueuedWorkTrigger;
-		// These handlers were a single choose loop before the coroutine conversion. Keep queue
-		// mutations serialized so inline stream callbacks cannot observe partially updated state.
+		// Serialize queue mutations so inline stream callbacks cannot observe partially updated state.
 		FlowLock queueMutationLock;
 	};
 

--- a/fdbserver/datadistributor/DDRelocationQueue.cpp
+++ b/fdbserver/datadistributor/DDRelocationQueue.cpp
@@ -2897,6 +2897,17 @@ struct DDQueueImpl {
 			RelocateData results = co_await input;
 			co_await state->queueMutationLock.take(TaskPriority::DataDistributionLaunch);
 			FlowLock::Releaser lockGuard(state->queueMutationLock);
+			// A source-fetch actor can finish after an overlapping relocation has already cancelled and
+			// replaced the item it was fetching for. The old serialized choose loop could not observe that
+			// completion after the replacement had been processed, but the coroutine split can.
+			if (!state->self->fetchingSourcesQueue.contains(results)) {
+				DebugRelocationTraceEvent("StaleSourceFetchResult", state->self->distributorId)
+				    .detail("KeyBegin", results.keys.begin)
+				    .detail("KeyEnd", results.keys.end)
+				    .detail("Priority", results.priority)
+				    .detail("RandomID", results.randomId);
+				continue;
+			}
 			// This stream is triggered by queueRelocation(), which is triggered by sending self->input.
 			state->self->completeSourceFetch(results);
 			validate(state);


### PR DESCRIPTION
This PR fixes a bug introduced in the decomposition of `DDQueueImpl::run` from https://github.com/apple/foundationdb/pull/13675. Handlers are now serialized using `FlowLock`, fixing race conditions that were previously causing simulation failures.
