### PR TITLE
Resolve the epoch seconds for expiredEndVersion and unreliableEndVersion

### DIFF
--- a/fdbclient/BackupContainer.cpp
+++ b/fdbclient/BackupContainer.cpp
@@ -127,6 +127,10 @@ Future<Void> BackupDescription::resolveVersionTimes(Database cx) {
 		versionTimeMap[minRestorableVersion.get()];
 	if (maxRestorableVersion.present())
 		versionTimeMap[maxRestorableVersion.get()];
+	if (expiredEndVersion.present())
+		versionTimeMap[expiredEndVersion.get()];
+	if (unreliableEndVersion.present())
+		versionTimeMap[unreliableEndVersion.get()];
 
 	return runRYWTransaction(cx,
 	                         [=](Reference<ReadYourWritesTransaction> tr) { return fetchTimes(tr, &versionTimeMap); });


### PR DESCRIPTION
Before this change the `expiredEndVersion` and `unreliableEndVersion` were not resolved to their epoch seconds. One additional timestamp to resolve should be fine from a cost perspective but will help a human operator or tooling to understand up until which timestamp the data is expired.