### PR TITLE
Handle finish_move_keys_too_many_retries as retryable error in test workloads

### DIFF
--- a/fdbserver/workloads/DataLossRecovery.actor.cpp
+++ b/fdbserver/workloads/DataLossRecovery.actor.cpp
@@ -253,8 +253,10 @@ struct DataLossRecoveryWorkload : TestWorkload {
 				break;
 			} catch (Error& e) {
 				TraceEvent("DataLossRecovery").error(e).detail("Phase", "MoveRangeError");
-				if (e.code() == error_code_movekeys_conflict) {
+				if (e.code() == error_code_movekeys_conflict ||
+				    e.code() == error_code_finish_move_keys_too_many_retries) {
 					// Conflict on moveKeysLocks with the current running DD is expected, just retry.
+					// finish_move_keys_too_many_retries is also retryable here.
 					tr.reset();
 				} else {
 					wait(tr.onError(e));

--- a/fdbserver/workloads/IDDTxnProcessorApiCorrectness.actor.cpp
+++ b/fdbserver/workloads/IDDTxnProcessorApiCorrectness.actor.cpp
@@ -312,7 +312,8 @@ struct IDDTxnProcessorApiWorkload : TestWorkload {
 				wait(self->real->testRawFinishMovement(params, emptyTssMapping));
 				break;
 			} catch (Error& e) {
-				if (e.code() != error_code_movekeys_conflict)
+				if (e.code() != error_code_movekeys_conflict &&
+				    e.code() != error_code_finish_move_keys_too_many_retries)
 					throw;
 				wait(delay(FLOW_KNOBS->PREVENT_FAST_SPIN_DELAY));
 				// Keep trying to get the moveKeysLock
@@ -397,7 +398,8 @@ struct IDDTxnProcessorApiWorkload : TestWorkload {
 				wait(self->real->moveKeys(params));
 				break;
 			} catch (Error& e) {
-				if (e.code() != error_code_movekeys_conflict)
+				if (e.code() != error_code_movekeys_conflict &&
+				    e.code() != error_code_finish_move_keys_too_many_retries)
 					throw;
 				wait(delay(FLOW_KNOBS->PREVENT_FAST_SPIN_DELAY));
 				// Keep trying to get the moveKeysLock

--- a/fdbserver/workloads/PhysicalShardMove.actor.cpp
+++ b/fdbserver/workloads/PhysicalShardMove.actor.cpp
@@ -609,8 +609,10 @@ struct PhysicalShardMoveWorkLoad : TestWorkload {
 				                             CancelConflictingDataMoves::False)));
 				break;
 			} catch (Error& e) {
-				if (e.code() == error_code_movekeys_conflict) {
+				if (e.code() == error_code_movekeys_conflict ||
+				    e.code() == error_code_finish_move_keys_too_many_retries) {
 					// Conflict on moveKeysLocks with the current running DD is expected, just retry.
+					// finish_move_keys_too_many_retries is also retryable here.
 					tr.reset();
 				} else {
 					wait(tr.onError(e));

--- a/fdbserver/workloads/RandomMoveKeys.actor.cpp
+++ b/fdbserver/workloads/RandomMoveKeys.actor.cpp
@@ -254,7 +254,7 @@ struct MoveKeysWorkload : FailureInjectionWorkload {
 					}
 				}
 			} catch (Error& e) {
-				if (e.code() != error_code_movekeys_conflict && e.code() != error_code_finish_move_keys_too_many_retries && e.code() != error_code_operation_failed)
+				if (e.code() != error_code_movekeys_conflict && e.code() != error_code_operation_failed)
 					throw;
 				wait(delay(FLOW_KNOBS->PREVENT_FAST_SPIN_DELAY));
 				// Keep trying to get the moveKeysLock

--- a/fdbserver/workloads/RandomMoveKeys.actor.cpp
+++ b/fdbserver/workloads/RandomMoveKeys.actor.cpp
@@ -254,7 +254,7 @@ struct MoveKeysWorkload : FailureInjectionWorkload {
 					}
 				}
 			} catch (Error& e) {
-				if (e.code() != error_code_movekeys_conflict && e.code() != error_code_operation_failed)
+				if (e.code() != error_code_movekeys_conflict && e.code() != error_code_finish_move_keys_too_many_retries && e.code() != error_code_operation_failed)
 					throw;
 				wait(delay(FLOW_KNOBS->PREVENT_FAST_SPIN_DELAY));
 				// Keep trying to get the moveKeysLock

--- a/tests/fast/DataLossRecovery.toml
+++ b/tests/fast/DataLossRecovery.toml
@@ -5,6 +5,7 @@ processesPerMachine = 2
 coordinators = 3
 machineCount = 45
 asanMachineCount = 20
+minimumRegions = 1
 allowDefaultTenant = false
 
 [[test]]


### PR DESCRIPTION
Add error_code_finish_move_keys_too_many_retries added by #12991 alongside existing movekeys_conflict handling in DataLossRecovery, IDDTxnProcessorApiCorrectness, and PhysicalShardMove workloads. Also add minimumRegions=1 to DataLossRecovery test config to prevent buggify from enabling multi-DC topology.

This failed on centos and head of 7.3:

`/build_output/bin/fdbserver -r simulation -f /root/src/foundationdb/tests/fast/DataLossRecovery.toml --buggify on --seed 3623064723 --logsize 1GiB --logdir ~/src/foundationdb/logs/`

DD never quiesces. The test times out at 4000s with `DatacenterVersionDifference` stuck at 27B (53K `VersionDifferenceOldLarge` events).

The test TOML sets `generateFearless = false` but does **not** set `minimumRegions`. Since `minimumRegions` defaults to 0, buggify can force a 2-DC topology through this path in `SimulatedCluster.actor.cpp:1964-1972`:

```cpp
if (testConfig.minimumRegions <= 1 &&
    (deterministicRandom()->random01() < 0.25 ||
     SERVER_KNOBS->MAX_READ_TRANSACTION_LIFE_VERSIONS < SERVER_KNOBS->VERSIONS_PER_SECOND)) {
    needsRemote = false;   // single region
} else {
    db.usableRegions = 2;  // TWO regions — despite generateFearless=false!
}
```

But then I saw error_code_finish_move_keys_too_many_retries fails after fixing above.