### PR TITLE
Mark frequently hit code probes non-rare

### DIFF
--- a/fdbclient/NativeCdc.cpp
+++ b/fdbclient/NativeCdc.cpp
@@ -47,7 +47,7 @@ bool validNativeCdcTagCount(int tagCount) {
 
 void validateNativeCdcEnabled(bool enabled) {
 	if (!enabled) {
-		CODE_PROBE(true, "Native CDC registration rejected while feature disabled", probe::decoration::rare);
+		CODE_PROBE(true, "Native CDC registration rejected while feature disabled");
 		throw client_invalid_operation();
 	}
 }
@@ -791,7 +791,7 @@ Future<CDCConsumeReply> NativeCdcConsumer::consumeImpl(Reference<NativeCdcConsum
 				if (!retryNativeCdcProxyRequest(error)) {
 					throw;
 				}
-				CODE_PROBE(true, "Native CDC consume retries after proxy request failure", probe::decoration::rare);
+				CODE_PROBE(true, "Native CDC consume retries after proxy request failure");
 			}
 			co_await delay(CLIENT_KNOBS->WRONG_SHARD_SERVER_DELAY, self->cx->taskID);
 		}

--- a/fdbserver/cdcproxy/CDCProxy.cpp
+++ b/fdbserver/cdcproxy/CDCProxy.cpp
@@ -598,7 +598,7 @@ void CDCProxy::markTagStreamsBufferLimitExceeded(Reference<CDCBufferedTag> tag, 
 		if (!rawPeekFailureBlocksStream(nextReadVersion, begin)) {
 			continue;
 		}
-		CODE_PROBE(true, "CDC proxy rejects a raw peek larger than its reservation", probe::decoration::rare);
+		CODE_PROBE(true, "CDC proxy rejects a raw peek larger than its reservation");
 		TraceEvent(SevWarn, "CDCProxyRawPeekExceedsBufferLimit", id)
 		    .detail("Tag", tag->tag)
 		    .detail("StreamId", streamId)
@@ -1037,7 +1037,7 @@ Future<CDCBufferTagPassResult> CDCProxy::bufferTagPass(Reference<CDCBufferedTag>
 	const int64_t preferredBufferedBatch = limits.get().preferredBufferedBytes;
 	const int64_t passReservation = limits.get().reservationBytes;
 	if (bufferLock.available() < passReservation) {
-		CODE_PROBE(true, "CDC proxy applies shared buffer backpressure", probe::decoration::rare);
+		CODE_PROBE(true, "CDC proxy applies shared buffer backpressure");
 		peekCapacityContended.trigger();
 	}
 	auto capacity = co_await race(bufferLock.take(TaskPriority::TLogPeekReply, passReservation),
@@ -1090,9 +1090,7 @@ Future<CDCBufferTagPassResult> CDCProxy::bufferTagPass(Reference<CDCBufferedTag>
 
 	const Version peekThroughVersion = cursor->hasMessage() ? cursor->version().version : cursor->version().version - 1;
 	const Version throughVersion = committedPeekThrough(peekThroughVersion, cursor->getMinKnownCommittedVersion());
-	CODE_PROBE(throughVersion < peekThroughVersion,
-	           "CDC proxy waits for peeked mutations to become committed",
-	           probe::decoration::rare);
+	CODE_PROBE(throughVersion < peekThroughVersion, "CDC proxy waits for peeked mutations to become committed");
 	if (throughVersion < begin) {
 		co_return CDCBufferTagPassResult::WAIT_FOR_COMMIT;
 	}
@@ -1294,7 +1292,7 @@ Future<Void> CDCProxy::popAcknowledgedData() {
 		co_return;
 	}
 	while (!logSystem->get()) {
-		CODE_PROBE(true, "CDC proxy defers pops until a log system is available", probe::decoration::rare);
+		CODE_PROBE(true, "CDC proxy defers pops until a log system is available");
 		co_await logSystem->onChange();
 	}
 	Reference<LogSystemConsumer> currentLogSystem = logSystem->get();
@@ -1311,7 +1309,7 @@ Future<Void> CDCProxy::popAcknowledgedData() {
 				co_await popPauseChangedForTesting.onTrigger();
 			}
 		}
-		CODE_PROBE(true, "CDC proxy defers pops until every expected log set is published", probe::decoration::rare);
+		CODE_PROBE(true, "CDC proxy defers pops until every expected log set is published");
 		co_return;
 	}
 	if (!isCurrentCompletePopLogSystem(currentLogSystem, popLogSystemConfig, popLogSystemRecoveryCount)) {
@@ -1331,7 +1329,7 @@ Future<Void> CDCProxy::popAcknowledgedData() {
 		co_return;
 	}
 	if (!isCurrentCompletePopLogSystem(currentLogSystem, popLogSystemConfig, popLogSystemRecoveryCount)) {
-		CODE_PROBE(true, "CDC proxy retries pops after log system topology changes", probe::decoration::rare);
+		CODE_PROBE(true, "CDC proxy retries pops after log system topology changes");
 		requestAcknowledgedDataPop();
 		co_return;
 	}
@@ -1342,7 +1340,7 @@ Future<Void> CDCProxy::popAcknowledgedData() {
 		    stream->second->minVersion >= minVersion) {
 			continue;
 		}
-		CODE_PROBE(true, "CDC proxy scan reconciles a durable stream acknowledgement", probe::decoration::rare);
+		CODE_PROBE(true, "CDC proxy scan reconciles a durable stream acknowledgement");
 		reconcileStreamMinVersion(stream->second, minVersion);
 	}
 	const std::unordered_map<Tag, Version>& safePopVersions = popState.safePopVersions;
@@ -1402,7 +1400,7 @@ Future<Void> CDCProxy::monitorAcknowledgedDataPops() {
 			co_await delay(SERVER_KNOBS->CDC_PROXY_POP_MIN_INTERVAL);
 		}
 		popAcknowledgedDataRequests.consume();
-		CODE_PROBE(periodicScan, "CDC proxy periodically scans durable acknowledgement state", probe::decoration::rare);
+		CODE_PROBE(periodicScan, "CDC proxy periodically scans durable acknowledgement state");
 		++popAttempts;
 		// Acknowledgements only make a completed snapshot more conservative, so they are coalesced for a later pass
 		// instead of canceling this one. A log-system config change can add targeted log sets, so it invalidates
@@ -1488,7 +1486,7 @@ Future<Void> CDCProxy::consume(CDCConsumeRequest request) {
 		if (stream->activeConsumes > 0) {
 			// A stream has one durable acknowledgement frontier, so concurrent logical consumers cannot be
 			// isolated. Reject overlapping server requests rather than duplicating an entire reply arena.
-			CODE_PROBE(true, "CDC proxy rejects concurrent consumers for one stream", probe::decoration::rare);
+			CODE_PROBE(true, "CDC proxy rejects concurrent consumers for one stream");
 			throw client_invalid_operation();
 		}
 		++stream->activeConsumes;
@@ -1497,9 +1495,7 @@ Future<Void> CDCProxy::consume(CDCConsumeRequest request) {
 			--stream->activeConsumes;
 		});
 		const CDCStreamReadState metadata = co_await readCDCStreamState(cx, request.cursor.streamId, id, true);
-		CODE_PROBE(stream->minVersion < metadata.minVersion,
-		           "Native CDC consume reconciles a durable acknowledgement",
-		           probe::decoration::rare);
+		CODE_PROBE(stream->minVersion < metadata.minVersion, "Native CDC consume reconciles a durable acknowledgement");
 		reconcileStreamMinVersion(stream, metadata.minVersion);
 		if (request.cursor.lastConsumedVersion > stream->bufferedThrough) {
 			// A cursor is trusted only when this owner has delivered through it or when it is covered by the durable
@@ -1783,7 +1779,7 @@ Future<Void> CDCProxy::monitorDBInfo(CDCProxyInterface proxy, uint64_t recoveryC
 	while (true) {
 		co_await dbInfo->onChange();
 		if (dbInfo->get().recoveryCount < recoveryCount) {
-			CODE_PROBE(true, "CDC proxy ignores ServerDBInfo from an older recovery", probe::decoration::rare);
+			CODE_PROBE(true, "CDC proxy ignores ServerDBInfo from an older recovery");
 			continue;
 		}
 		const bool isPublished =

--- a/fdbserver/clustercontroller/ClusterController.actor.cpp
+++ b/fdbserver/clustercontroller/ClusterController.actor.cpp
@@ -671,8 +671,7 @@ Future<Void> recruitFailedCDCProxies(ClusterControllerData* self,
 			// replacement endpoint is being published.
 			co_await reassignNativeCdcStreams(self->db.db, failedProxy.id(), replacement.id());
 			CODE_PROBE(replacementIndex + 1 < failedIndexes.size(),
-			           "CDC proxy replacement is published before recruiting another failed proxy",
-			           probe::decoration::rare);
+			           "CDC proxy replacement is published before recruiting another failed proxy");
 		}
 	}
 }
@@ -2237,7 +2236,7 @@ Future<Void> monitorCDCProxyAssignmentsPass(ClusterControllerData* self) {
 						tr.clear(cdcProxyKeyFor(streamId, proxyId));
 						tr.set(cdcProxyKeyFor(streamId, resolvedProxyId), Value());
 						repairedAssignment = true;
-						CODE_PROBE(true, "CDC stream assignment is repaired after owner loss", probe::decoration::rare);
+						CODE_PROBE(true, "CDC stream assignment is repaired after owner loss");
 						TraceEvent("CDCProxyAssignmentRepaired")
 						    .detail("StreamId", streamId)
 						    .detail("OldCDCProxyID", proxyId)
@@ -2277,8 +2276,7 @@ Future<Void> monitorCDCProxyAssignmentsPass(ClusterControllerData* self) {
 			    .detail("ClientAssignmentCount", db->clientInfo->get().streamToCDCProxyId.size());
 
 			if (!streamToCDCProxyId.empty() && availableProxies.empty()) {
-				CODE_PROBE(
-				    true, "CDC assignments wait while no proxy endpoints are published", probe::decoration::rare);
+				CODE_PROBE(true, "CDC assignments wait while no proxy endpoints are published");
 				co_await tr.commit();
 				co_await (endpointChangeFuture || assignmentChangeFuture);
 				co_return;

--- a/fdbserver/clustercontroller/ClusterRecovery.cpp
+++ b/fdbserver/clustercontroller/ClusterRecovery.cpp
@@ -249,8 +249,7 @@ Future<Void> ensureCDCProxies(Reference<ClusterRecoveryData> self, RecruitFromCo
 		co_return;
 	}
 	CODE_PROBE(!CLIENT_KNOBS->ENABLE_NATIVE_CDC && hasDurableCdcState,
-	           "Recovery recruits CDC proxies to drain disabled durable state",
-	           probe::decoration::rare);
+	           "Recovery recruits CDC proxies to drain disabled durable state");
 	auto& cdcProxies = self->controllerData->db.cdcProxies;
 	const size_t reusedCount = cdcProxies.size();
 	if (reusedCount > 0) {
@@ -291,8 +290,7 @@ Future<Void> ensureCDCProxies(Reference<ClusterRecoveryData> self, RecruitFromCo
 	    .detail("Count", newRecruits.size())
 	    .detail("ReusedCount", reusedCount)
 	    .detail("TotalCount", targetCount);
-	CODE_PROBE(
-	    reusedCount > 0, "Recovery expands retained CDC proxies to match GRV proxy count", probe::decoration::rare);
+	CODE_PROBE(reusedCount > 0, "Recovery expands retained CDC proxies to match GRV proxy count");
 	cdcProxies.insert(cdcProxies.end(), newRecruits.begin(), newRecruits.end());
 	self->registrationTrigger.trigger();
 }

--- a/fdbserver/core/MoveKeys.cpp
+++ b/fdbserver/core/MoveKeys.cpp
@@ -1733,7 +1733,7 @@ static Future<bool> reverifyKeysDestAndCommit(Transaction* tr,
 	// than silently expand the commit past the verified end.
 	ASSERT(rereadEnd <= currentKeys->end);
 	if (rereadEnd < currentKeys->end) {
-		CODE_PROBE(true, "finishMoveKeys reread keyServers boundary shorter than planning", probe::decoration::rare);
+		CODE_PROBE(true, "finishMoveKeys reread keyServers boundary shorter than planning");
 		*currentKeys = KeyRangeRef(currentKeys->begin, rereadEnd);
 		*endKey = rereadEnd;
 	}
@@ -2716,7 +2716,7 @@ static Future<ReverifyShardsResult> reverifyShardsAndCommit(Transaction* tr,
 	// end.
 	ASSERT(rereadEnd <= range->end);
 	if (rereadEnd < range->end) {
-		CODE_PROBE(true, "finishMoveShards reread keyServers boundary shorter than planning", probe::decoration::rare);
+		CODE_PROBE(true, "finishMoveShards reread keyServers boundary shorter than planning");
 		*range = KeyRangeRef(range->begin, rereadEnd);
 	}
 

--- a/fdbserver/datadistributor/DDRelocationQueue.cpp
+++ b/fdbserver/datadistributor/DDRelocationQueue.cpp
@@ -2231,8 +2231,7 @@ Future<Void> dataDistributionRelocator(DDQueue* self,
 							}
 							if (SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA) {
 								CODE_PROBE(true,
-								           "Cancel shard-encoded data move after destination team becomes unhealthy",
-								           probe::decoration::rare);
+								           "Cancel shard-encoded data move after destination team becomes unhealthy");
 								TraceEvent(SevWarnAlways, "RelocateShardDestinationTeamUnhealthy", distributorId)
 								    .detail("DataMoveID", rd.dataMoveId)
 								    .detail("Range", rd.keys)

--- a/fdbserver/logsystem/LogSystemPeekCursor.cpp
+++ b/fdbserver/logsystem/LogSystemPeekCursor.cpp
@@ -1077,9 +1077,7 @@ SetPeekCursor::SetPeekCursor(std::vector<Reference<LogSet>> const& logSets,
 	}
 	// Live CDC consumers wait for future mutations; finite recovery and tag-history reads must reach their end.
 	const bool tailingCDC = tag.locality == tagLocalityCDC && end == std::numeric_limits<Version>::max();
-	CODE_PROBE(tag.locality == tagLocalityCDC && !tailingCDC,
-	           "CDC finite-range peek returns without blocking",
-	           probe::decoration::rare);
+	CODE_PROBE(tag.locality == tagLocalityCDC && !tailingCDC, "CDC finite-range peek returns without blocking");
 	serverCursors.resize(logSets.size());
 	int maxServers = 0;
 	for (int i = 0; i < logSets.size(); i++) {
@@ -1529,8 +1527,7 @@ Version ReplayMultiCursor::getMinKnownCommittedVersion() const {
 	// gate delivery on committed progress.
 	const Version completedGenerationCommittedVersion = epochEnds.back().version - 1;
 	CODE_PROBE(cursorCommittedVersion < completedGenerationCommittedVersion,
-	           "Replay cursor advances the committed frontier through a completed generation",
-	           probe::decoration::rare);
+	           "Replay cursor advances the committed frontier through a completed generation");
 	return std::max(cursorCommittedVersion, completedGenerationCommittedVersion);
 }
 

--- a/fdbserver/tlog/TLogServer.cpp
+++ b/fdbserver/tlog/TLogServer.cpp
@@ -2386,7 +2386,7 @@ Future<Void> tLogPeekMessages(PromiseType replyPromise,
 	}
 
 	if (replyVersionTooLarge) {
-		CODE_PROBE(true, "TLog rejects an oversized Native CDC version", probe::decoration::rare);
+		CODE_PROBE(true, "TLog rejects an oversized Native CDC version");
 		TraceEvent(SevWarn, "TLogPeekVersionExceedsByteLimit", logData->logId)
 		    .detail("Tag", reqTag)
 		    .detail("ReqBegin", reqBegin)

--- a/flow/StreamCipher.cpp
+++ b/flow/StreamCipher.cpp
@@ -121,7 +121,7 @@ EncryptionStreamCipher::EncryptionStreamCipher(const StreamCipherKey* key, const
 }
 
 StringRef EncryptionStreamCipher::encrypt(unsigned char const* plaintext, int len, Arena& arena) {
-	CODE_PROBE(true, "Encrypting data with StreamCipher", probe::decoration::rare);
+	CODE_PROBE(true, "Encrypting data with StreamCipher");
 	auto ciphertext = new (arena) unsigned char[len + AES_BLOCK_SIZE];
 	int bytes{ 0 };
 	if (EVP_EncryptUpdate(cipher.getCtx(), ciphertext, &bytes, plaintext, len) != 1) {


### PR DESCRIPTION
All of these code probes were hit at least 5 times in an unfiltered 10k-test ensemble. Leaving them marked incorrectly as "rare" could mask a future code coverage regression.
