### PR TITLE
Add focused unit tests to cover several missed code probes

### DIFF
--- a/fdbserver/clustercontroller/ClusterController.actor.cpp
+++ b/fdbserver/clustercontroller/ClusterController.actor.cpp
@@ -3486,6 +3486,7 @@ TEST_CASE("/fdbserver/clustercontroller/ignoreStaleWorkerRegistration") {
 	worker.initEndpoints();
 	worker.storage.getEndpoint(TaskPriority::Worker);
 
+	// Establish the newer registration and its DB-info endpoint before delivering an older update.
 	RegisterWorkerRequest current;
 	current.wi = worker;
 	current.initialClass = ProcessClass(ProcessClass::StorageClass, ProcessClass::CommandLineSource);
@@ -3501,6 +3502,7 @@ TEST_CASE("/fdbserver/clustercontroller/ignoreStaleWorkerRegistration") {
 	ASSERT(data.id_worker.contains(processId));
 	ASSERT(data.updateDBInfoEndpoints.contains(worker.updateServerDBInfo.getEndpoint()));
 
+	// Contradict every mutable field so accepting the stale generation would be observable.
 	RegisterWorkerRequest stale;
 	stale.wi = worker;
 	stale.initialClass = ProcessClass(ProcessClass::LogClass, ProcessClass::CommandLineSource);

--- a/fdbserver/clustercontroller/ClusterController.actor.cpp
+++ b/fdbserver/clustercontroller/ClusterController.actor.cpp
@@ -3474,6 +3474,57 @@ void addProcessesToSameDC(ClusterControllerData& self, const std::vector<Network
 	}
 }
 
+TEST_CASE("/fdbserver/clustercontroller/ignoreStaleWorkerRegistration") {
+	ClusterControllerData data(ClusterControllerFullInterface(),
+	                           LocalityData(),
+	                           ServerCoordinators(Reference<IClusterConnectionRecord>(
+	                               new ClusterConnectionMemoryRecord(ClusterConnectionString()))),
+	                           makeReference<AsyncVar<Optional<UID>>>());
+	LocalityData workerLocality;
+	workerLocality.set(LocalityData::keyProcessId, Standalone<StringRef>(std::string{ "registered-worker" }));
+	WorkerInterface worker(workerLocality);
+	worker.initEndpoints();
+	worker.storage.getEndpoint(TaskPriority::Worker);
+
+	RegisterWorkerRequest current;
+	current.wi = worker;
+	current.initialClass = ProcessClass(ProcessClass::StorageClass, ProcessClass::CommandLineSource);
+	current.processClass = current.initialClass;
+	current.generation = 2;
+	current.degraded = false;
+	current.recoveredDiskFiles = true;
+	current.issues.push_back_deep(current.issues.arena(), "current-issue"_sr);
+	registerWorker(current, &data);
+
+	const auto processId = worker.locality.processId();
+	ASSERT(processId.present());
+	ASSERT(data.id_worker.contains(processId));
+	ASSERT(data.updateDBInfoEndpoints.contains(worker.updateServerDBInfo.getEndpoint()));
+
+	RegisterWorkerRequest stale;
+	stale.wi = worker;
+	stale.initialClass = ProcessClass(ProcessClass::LogClass, ProcessClass::CommandLineSource);
+	stale.processClass = stale.initialClass;
+	stale.generation = 1;
+	stale.degraded = true;
+	stale.recoveredDiskFiles = false;
+	stale.issues.push_back_deep(stale.issues.arena(), "stale-issue"_sr);
+	registerWorker(stale, &data);
+
+	auto& registered = data.id_worker[processId];
+	ASSERT_EQ(registered.gen, current.generation);
+	ASSERT(registered.details.interf.id() == worker.id());
+	ASSERT(registered.initialClass == current.initialClass);
+	ASSERT(registered.details.processClass == current.processClass);
+	ASSERT(!registered.details.degraded);
+	ASSERT(registered.details.recoveredDiskFiles);
+	ASSERT_EQ(registered.issues.size(), 1);
+	ASSERT(registered.issues[0] == "current-issue"_sr);
+	ASSERT(data.updateDBInfoEndpoints.contains(worker.updateServerDBInfo.getEndpoint()));
+	ASSERT(!data.removedDBInfoEndpoints.contains(worker.updateServerDBInfo.getEndpoint()));
+	return Void();
+}
+
 // Tests `ClusterControllerData::updateWorkerHealth()` can update `ClusterControllerData::workerHealth`
 // based on `UpdateWorkerHealth` request correctly.
 TEST_CASE("/fdbserver/clustercontroller/updateWorkerHealth") {

--- a/fdbserver/commitproxy/CMakeLists.txt
+++ b/fdbserver/commitproxy/CMakeLists.txt
@@ -5,6 +5,10 @@ add_fdbserver_link_test(fdbserver_commitproxylinktest
   fdbserver_commitproxy
   fdbserver_logsystem
   fdbserver_core)
+add_fdbserver_unit_test(fdbserver_commitproxy_test commitproxy
+  fdbserver_commitproxy
+  fdbserver_logsystem
+  fdbserver_core)
 
 configure_fdbserver_common_includes(fdbserver_commitproxy)
 target_include_directories(fdbserver_commitproxy

--- a/fdbserver/commitproxy/CommitProxyServer.cpp
+++ b/fdbserver/commitproxy/CommitProxyServer.cpp
@@ -65,6 +65,7 @@
 #include "flow/IRandom.h"
 #include "flow/Knobs.h"
 #include "flow/Trace.h"
+#include "flow/UnitTest.h"
 #include "flow/network.h"
 
 using WriteMutationRefVar = std::variant<MutationRef, VectorRef<MutationRef>>;
@@ -2667,6 +2668,47 @@ public:
 
 	Future<Void> run() { co_await race(receiveExpireRequests(), receiveExpectedCounts(), purgeOldEntries()); }
 };
+
+TEST_CASE("/fdbserver/commitproxy/IdempotencyIdsExpireServer/ExpireBeforeExpectedCount") {
+	constexpr Version version = 100;
+	constexpr uint8_t firstBatch = 1;
+	constexpr uint8_t secondBatch = 2;
+	PublicRequestStream<ExpireIdempotencyIdRequest> expireRequests;
+	PromiseStream<ExpectedIdempotencyIdCountForKey> expectedCounts;
+	Standalone<VectorRef<MutationRef>> clears;
+	IdempotencyIdsExpireServer expireServer(expireRequests, expectedCounts, &clears);
+	Future<Void> server = expireServer.run();
+
+	expireRequests.send(ExpireIdempotencyIdRequest(version, firstBatch));
+	expireRequests.send(ExpireIdempotencyIdRequest(version, firstBatch));
+	expireRequests.send(ExpireIdempotencyIdRequest(version, secondBatch));
+	co_await yield();
+	ASSERT(!server.isReady());
+	ASSERT(clears.empty());
+
+	expectedCounts.send(ExpectedIdempotencyIdCountForKey(version, 2, firstBatch));
+	expectedCounts.send(ExpectedIdempotencyIdCountForKey(version, 2, secondBatch));
+	co_await yield();
+	ASSERT(!server.isReady());
+	ASSERT_EQ(clears.size(), 1);
+
+	Arena expectedArena;
+	auto firstRange = makeIdempotencySingleKeyRange(expectedArena, version, firstBatch);
+	ASSERT_EQ(clears[0].type, MutationRef::ClearRange);
+	ASSERT(clears[0].param1 == firstRange.begin);
+	ASSERT(clears[0].param2 == firstRange.end);
+
+	expireRequests.send(ExpireIdempotencyIdRequest(version, secondBatch));
+	co_await yield();
+	ASSERT(!server.isReady());
+	ASSERT_EQ(clears.size(), 2);
+
+	auto secondRange = makeIdempotencySingleKeyRange(expectedArena, version, secondBatch);
+	ASSERT_EQ(clears[1].type, MutationRef::ClearRange);
+	ASSERT(clears[1].param1 == secondRange.begin);
+	ASSERT(clears[1].param2 == secondRange.end);
+	server.cancel();
+}
 
 struct TransactionStateResolveContext {
 	// Maximum sequence for txnStateRequest, this is defined when the request last flag is set.

--- a/fdbserver/commitproxy/CommitProxyServer.cpp
+++ b/fdbserver/commitproxy/CommitProxyServer.cpp
@@ -2679,6 +2679,7 @@ TEST_CASE("/fdbserver/commitproxy/IdempotencyIdsExpireServer/ExpireBeforeExpecte
 	IdempotencyIdsExpireServer expireServer(expireRequests, expectedCounts, &clears);
 	Future<Void> server = expireServer.run();
 
+	// Expire requests can arrive before their expected counts; neither batch may be cleared yet.
 	expireRequests.send(ExpireIdempotencyIdRequest(version, firstBatch));
 	expireRequests.send(ExpireIdempotencyIdRequest(version, firstBatch));
 	expireRequests.send(ExpireIdempotencyIdRequest(version, secondBatch));
@@ -2686,6 +2687,7 @@ TEST_CASE("/fdbserver/commitproxy/IdempotencyIdsExpireServer/ExpireBeforeExpecte
 	ASSERT(!server.isReady());
 	ASSERT(clears.empty());
 
+	// The first batch is complete once counts arrive, while the second is still one request short.
 	expectedCounts.send(ExpectedIdempotencyIdCountForKey(version, 2, firstBatch));
 	expectedCounts.send(ExpectedIdempotencyIdCountForKey(version, 2, secondBatch));
 	co_await yield();
@@ -2698,6 +2700,7 @@ TEST_CASE("/fdbserver/commitproxy/IdempotencyIdsExpireServer/ExpireBeforeExpecte
 	ASSERT(clears[0].param1 == firstRange.begin);
 	ASSERT(clears[0].param2 == firstRange.end);
 
+	// Completing the second batch must emit its distinct clear range.
 	expireRequests.send(ExpireIdempotencyIdRequest(version, secondBatch));
 	co_await yield();
 	ASSERT(!server.isReady());

--- a/fdbserver/kvstore/KeyValueStoreSQLite.cpp
+++ b/fdbserver/kvstore/KeyValueStoreSQLite.cpp
@@ -27,7 +27,10 @@
 #include "fdbserver/CoroFlow.h"
 #include "fdbserver/core/Knobs.h"
 #include "flow/Hash3.h"
+#include "flow/UnitTest.h"
 #include "flow/xxhash.h"
+
+#include <array>
 
 // for unprintable
 #include "fdbclient/NativeAPI.actor.h"
@@ -251,6 +254,39 @@ struct PageChecksumCodec {
 		delete self;
 	}
 };
+
+TEST_CASE("/fdbserver/kvstore/SQLite/PageChecksum/LegacyCRC32") {
+	constexpr int pageSize = 4096;
+	constexpr int checksumSize = sizeof(PageChecksumCodec::SumType);
+	constexpr int dataSize = pageSize - checksumSize;
+	alignas(PageChecksumCodec::SumType) std::array<uint8_t, pageSize> page{};
+	for (int i = 0; i < dataSize; ++i) {
+		page[i] = static_cast<uint8_t>((i * 37 + 11) & 0xff);
+	}
+
+	auto* checksum = reinterpret_cast<PageChecksumCodec::SumType*>(page.data() + dataSize);
+	checksum->part1 = 0;
+	checksum->part2 = crc32c_append(0xfdbeefdb, page.data(), dataSize);
+
+	PageChecksumCodec codec("legacy-crc32-page.sqlite");
+	codec.pageSize = pageSize;
+	codec.reserveSize = checksumSize;
+	codec.silent = true;
+
+	ASSERT(PageChecksumCodec::codec(&codec, page.data(), 2, 3) == page.data());
+
+	page[dataSize / 2] ^= 0xff;
+	ASSERT(PageChecksumCodec::codec(&codec, page.data(), 2, 3) == nullptr);
+	page[dataSize / 2] ^= 0xff;
+	ASSERT(PageChecksumCodec::codec(&codec, page.data(), 2, 3) == page.data());
+
+	ASSERT(PageChecksumCodec::codec(&codec, page.data(), 2, 6) == page.data());
+	const auto xxHash3 = XXH3_64bits(page.data(), dataSize);
+	ASSERT_EQ(checksum->part1, static_cast<uint32_t>((xxHash3 >> 32) & 0x00ffffff));
+	ASSERT_EQ(checksum->part2, static_cast<uint32_t>(xxHash3 & 0xffffffff));
+	ASSERT(PageChecksumCodec::codec(&codec, page.data(), 2, 3) == page.data());
+	return Void();
+}
 
 struct SQLiteDB : NonCopyable {
 	std::string filename;

--- a/fdbserver/kvstore/KeyValueStoreSQLite.cpp
+++ b/fdbserver/kvstore/KeyValueStoreSQLite.cpp
@@ -264,6 +264,7 @@ TEST_CASE("/fdbserver/kvstore/SQLite/PageChecksum/LegacyCRC32") {
 		page[i] = static_cast<uint8_t>((i * 37 + 11) & 0xff);
 	}
 
+	// A zero high word identifies the legacy CRC32 format on an existing SQLite page.
 	auto* checksum = reinterpret_cast<PageChecksumCodec::SumType*>(page.data() + dataSize);
 	checksum->part1 = 0;
 	checksum->part2 = crc32c_append(0xfdbeefdb, page.data(), dataSize);
@@ -275,11 +276,13 @@ TEST_CASE("/fdbserver/kvstore/SQLite/PageChecksum/LegacyCRC32") {
 
 	ASSERT(PageChecksumCodec::codec(&codec, page.data(), 2, 3) == page.data());
 
+	// Corruption must be rejected without preventing the restored legacy page from being read.
 	page[dataSize / 2] ^= 0xff;
 	ASSERT(PageChecksumCodec::codec(&codec, page.data(), 2, 3) == nullptr);
 	page[dataSize / 2] ^= 0xff;
 	ASSERT(PageChecksumCodec::codec(&codec, page.data(), 2, 3) == page.data());
 
+	// Rewriting a valid legacy page upgrades its checksum to the current xxHash3 format.
 	ASSERT(PageChecksumCodec::codec(&codec, page.data(), 2, 6) == page.data());
 	const auto xxHash3 = XXH3_64bits(page.data(), dataSize);
 	ASSERT_EQ(checksum->part1, static_cast<uint32_t>((xxHash3 >> 32) & 0x00ffffff));


### PR DESCRIPTION
This PR adds 3 unit tests to hit 3 code probes that were previously missed in a 100k-test Joshua ensemble:

- `/fdbserver/clustercontroller/ignoreStaleWorkerRegistration`
- `/fdbserver/commitproxy/IdempotencyIdsExpireServer/ExpireBeforeExpectedCount`
- `/fdbserver/kvstore/SQLite/PageChecksum/LegacyCRC32`
