### PR TITLE
Test mapped-range selector boundaries

### DIFF
--- a/fdbserver/workloads/GetMappedRange.cpp
+++ b/fdbserver/workloads/GetMappedRange.cpp
@@ -533,6 +533,94 @@ struct GetMappedRangeWorkload : ApiWorkload {
 		}
 	}
 
+	Future<Void> checkEmptyMappedRangeDoesNotConflict(Database cx,
+	                                                  KeySelector begin,
+	                                                  KeySelector end,
+	                                                  Key mapper,
+	                                                  GetRangeLimits limits) {
+		while (true) {
+			ReadYourWritesTransaction reader(cx);
+			Transaction writer(cx);
+			Error err;
+			try {
+				co_await reader.getReadVersion();
+				MappedRangeResult result =
+				    co_await reader.getMappedRange(begin, end, mapper, limits, Snapshot::False, Reverse::False);
+				ASSERT(result.empty());
+				ASSERT(!result.more);
+
+				writer.set(indexEntryKey(15), EMPTY);
+				co_await writer.commit();
+				reader.set("mapped-range-empty-no-conflict"_sr, "written"_sr);
+				co_await reader.commit();
+				co_return;
+			} catch (Error& e) {
+				err = e;
+			}
+			ASSERT_NE(err.code(), error_code_not_committed);
+			co_await reader.onError(err);
+		}
+	}
+
+	Future<Void> checkMappedSelectorBoundaries(Database cx, Key mapper, GetMappedRangeWorkload* self) {
+		Key begin = indexEntryKey(10);
+		Key end = indexEntryKey(20);
+		MappedRangeResult greaterThan =
+		    co_await scanMappedRangeWithLimits(cx,
+		                                       KeySelector(firstGreaterThan(begin), begin.arena()),
+		                                       KeySelector(firstGreaterThan(end), end.arena()),
+		                                       mapper,
+		                                       100,
+		                                       100000,
+		                                       11,
+		                                       self,
+		                                       false);
+		ASSERT_EQ(greaterThan.size(), 10);
+		ASSERT(!greaterThan.more);
+
+		MappedRangeResult offsets =
+		    co_await scanMappedRangeWithLimits(cx,
+		                                       KeySelector(firstGreaterOrEqual(begin) + 2, begin.arena()),
+		                                       KeySelector(firstGreaterOrEqual(end) - 2, end.arena()),
+		                                       mapper,
+		                                       100,
+		                                       100000,
+		                                       12,
+		                                       self,
+		                                       false);
+		ASSERT_EQ(offsets.size(), 6);
+		ASSERT(!offsets.more);
+
+		co_await checkEmptyMappedRangeDoesNotConflict(cx,
+		                                              KeySelector(firstGreaterOrEqual(begin), begin.arena()),
+		                                              KeySelector(firstGreaterOrEqual(end), end.arena()),
+		                                              mapper,
+		                                              GetRangeLimits(0, 1000));
+		co_await checkEmptyMappedRangeDoesNotConflict(cx,
+		                                              KeySelector(firstGreaterThan(end), end.arena()),
+		                                              KeySelector(firstGreaterOrEqual(begin), begin.arena()),
+		                                              mapper,
+		                                              GetRangeLimits(100, 100000));
+
+		bool specialKeyRejected = false;
+		try {
+			ReadYourWritesTransaction tr(cx);
+			co_await tr.getMappedRange(KeySelector(firstGreaterOrEqual(specialKeys.begin)),
+			                           KeySelector(firstGreaterOrEqual(specialKeys.end)),
+			                           mapper,
+			                           GetRangeLimits(100, 100000),
+			                           Snapshot::False,
+			                           Reverse::False);
+		} catch (Error& e) {
+			if (e.code() != error_code_client_invalid_operation) {
+				throw;
+			}
+			specialKeyRejected = true;
+		}
+		ASSERT(specialKeyRejected);
+		co_return;
+	}
+
 	Future<Void> _start(Database cx, GetMappedRangeWorkload* self) {
 		TraceEvent("GetMappedRangeWorkloadConfig").detail("BadMapper", self->BAD_MAPPER);
 
@@ -543,6 +631,7 @@ struct GetMappedRangeWorkload : ApiWorkload {
 			self->snapshot = Snapshot::True;
 		} else if (self->transactionType == READ_YOUR_WRITES) {
 			self->snapshot = Snapshot::False;
+			co_await self->checkMappedSelectorBoundaries(cx, getMapper(false), self);
 			const double rand = deterministicRandom()->random01();
 			if (rand < 0.1) {
 				co_await self->testSerializableConflicts(self);
@@ -555,6 +644,9 @@ struct GetMappedRangeWorkload : ApiWorkload {
 			}
 		} else {
 			UNREACHABLE();
+		}
+		if (self->transactionType == NATIVE) {
+			co_await self->checkMappedSelectorBoundaries(cx, getMapper(false), self);
 		}
 
 		std::cout << "Test configuration: transactionType:" << self->transactionType << " snapshot:" << self->snapshot

--- a/fdbserver/workloads/GetMappedRange.cpp
+++ b/fdbserver/workloads/GetMappedRange.cpp
@@ -570,11 +570,11 @@ struct GetMappedRangeWorkload : ApiWorkload {
 		                                       KeySelector(firstGreaterThan(begin), begin.arena()),
 		                                       KeySelector(firstGreaterThan(end), end.arena()),
 		                                       mapper,
-		                                       100,
-		                                       100000,
-		                                       11,
+		                                       /*limit=*/100,
+		                                       /*byteLimit=*/100000,
+		                                       /*expectedBeginId=*/11,
 		                                       self,
-		                                       false);
+		                                       /*allMissing=*/false);
 		ASSERT_EQ(greaterThan.size(), 10);
 		ASSERT(!greaterThan.more);
 
@@ -583,11 +583,11 @@ struct GetMappedRangeWorkload : ApiWorkload {
 		                                       KeySelector(firstGreaterOrEqual(begin) + 2, begin.arena()),
 		                                       KeySelector(firstGreaterOrEqual(end) - 2, end.arena()),
 		                                       mapper,
-		                                       100,
-		                                       100000,
-		                                       12,
+		                                       /*limit=*/100,
+		                                       /*byteLimit=*/100000,
+		                                       /*expectedBeginId=*/12,
 		                                       self,
-		                                       false);
+		                                       /*allMissing=*/false);
 		ASSERT_EQ(offsets.size(), 6);
 		ASSERT(!offsets.more);
 
@@ -595,12 +595,12 @@ struct GetMappedRangeWorkload : ApiWorkload {
 		                                              KeySelector(firstGreaterOrEqual(begin), begin.arena()),
 		                                              KeySelector(firstGreaterOrEqual(end), end.arena()),
 		                                              mapper,
-		                                              GetRangeLimits(0, 1000));
+		                                              GetRangeLimits(/*rowLimit=*/0, /*byteLimit=*/1000));
 		co_await checkEmptyMappedRangeDoesNotConflict(cx,
 		                                              KeySelector(firstGreaterThan(end), end.arena()),
 		                                              KeySelector(firstGreaterOrEqual(begin), begin.arena()),
 		                                              mapper,
-		                                              GetRangeLimits(100, 100000));
+		                                              GetRangeLimits(/*rowLimit=*/100, /*byteLimit=*/100000));
 
 		bool specialKeyRejected = false;
 		try {
@@ -608,7 +608,7 @@ struct GetMappedRangeWorkload : ApiWorkload {
 			co_await tr.getMappedRange(KeySelector(firstGreaterOrEqual(specialKeys.begin)),
 			                           KeySelector(firstGreaterOrEqual(specialKeys.end)),
 			                           mapper,
-			                           GetRangeLimits(100, 100000),
+			                           GetRangeLimits(/*rowLimit=*/100, /*byteLimit=*/100000),
 			                           Snapshot::False,
 			                           Reverse::False);
 		} catch (Error& e) {


### PR DESCRIPTION
## Summary

Expand `GetMappedRange` simulation coverage for previously missed selector-boundary paths. This coverage gap missed code probes in a 100k-test ensemble.

- Test `firstGreaterThan` and positive/negative selector offsets.
- Verify zero-row and inverted ranges return empty results without introducing read conflicts.
- Verify mapped reads reject special-key ranges.
- Exercise the checks through both native and read-your-writes transaction paths.
