### PR TITLE
Correct stale code probes

### DIFF
--- a/fdbclient/DatabaseBackupAgent.cpp
+++ b/fdbclient/DatabaseBackupAgent.cpp
@@ -2138,8 +2138,7 @@ struct StartFullBackupTaskFunc : TaskFuncBase {
 						if (uidRange == targetRange) {
 							destUidValue = it.value;
 							found = true;
-							CODE_PROBE(targetRange == getDefaultBackupSharedRange(),
-							           "DR mutation sharing with default backup");
+							CODE_PROBE(isDefaultBackup(backupRanges), "DR mutation sharing with default backup");
 							break;
 						}
 					}

--- a/fdbclient/FileBackupAgent.cpp
+++ b/fdbclient/FileBackupAgent.cpp
@@ -6956,8 +6956,7 @@ public:
 				if (uidRange == targetRange) {
 					destUidValue = it.value;
 					found = true;
-					CODE_PROBE(targetRange == getDefaultBackupSharedRange(),
-					           "Backup mutation sharing with default backup");
+					CODE_PROBE(isDefaultBackup(normalizedRanges), "Backup mutation sharing with default backup");
 					break;
 				}
 			}

--- a/fdbserver/clustercontroller/ClusterController.actor.cpp
+++ b/fdbserver/clustercontroller/ClusterController.actor.cpp
@@ -504,12 +504,9 @@ ACTOR Future<Void> monitorAndRecruitWorkerSet(ClusterControllerData* self,
 			}
 		} catch (Error& e) {
 			if (strcmp(workerName, "LogRouter") == 0) {
-				// the probe macro prefers constant strings, so we can't combine
-				// log router and backup worker into one macro.
 				CODE_PROBE(true, "LogRouter re-recruitment failed");
 			} else {
 				ASSERT(strcmp(workerName, "BackupWorker") == 0);
-				CODE_PROBE(true, "BackupWorker re-recruitment failed");
 			}
 			TraceEvent(SevWarnAlways, (std::string(workerName) + "MonitoringRecruitmentFailed").c_str(), self->id)
 			    .error(e)

--- a/fdbserver/core/StorageMetrics.cpp
+++ b/fdbserver/core/StorageMetrics.cpp
@@ -181,8 +181,6 @@ void StorageServerMetrics::notify(const Key& key, StorageMetrics& metrics) {
 	if (g_network->isSimulated()) {
 		CODE_PROBE(metrics.bytesWrittenPerKSecond != 0, "ShardNotifyMetrics bytes");
 		CODE_PROBE(metrics.iosPerKSecond != 0, "ShardNotifyMetrics ios");
-		CODE_PROBE(metrics.bytesReadPerKSecond != 0, "ShardNotifyMetrics bytesRead");
-		CODE_PROBE(metrics.opsReadPerKSecond != 0, "ShardNotifyMetrics opsRead");
 	}
 
 	double expire = now() + SERVER_KNOBS->STORAGE_METRICS_AVERAGE_INTERVAL;

--- a/fdbserver/tlog/TLogServer.cpp
+++ b/fdbserver/tlog/TLogServer.cpp
@@ -3255,7 +3255,7 @@ static void throwLowDiskTLogRecoveryFailed(TLogData* self,
 	    .detail("QueueDiskBytesTotal", queueBytes.total)
 	    .detail("Version", ver)
 	    .detail("Action", "FailRecoveryAndRecruitNewTLogs");
-	CODE_PROBE(true, "pullAsyncData failed recovery due to TLOG_MIN_AVAILABLE_SPACE_RATIO");
+	CODE_PROBE(true, "pullAsyncData failed recovery due to TLOG_MIN_AVAILABLE_SPACE_RATIO", probe::decoration::rare);
 	throw recruitment_failed();
 }
 
@@ -3287,7 +3287,7 @@ static void failIfTLogCannotAcceptNewData(TLogData* self, Reference<LogData> log
 			return;
 		}
 	}
-	CODE_PROBE(true, "pullAsyncData blocked by TLOG_MIN_AVAILABLE_SPACE_RATIO");
+	CODE_PROBE(true, "pullAsyncData blocked by TLOG_MIN_AVAILABLE_SPACE_RATIO", probe::decoration::rare);
 	// Outside speedUpSimulation, fail recovery and temporarily exclude this worker from TLog recruitment until disk
 	// space recovers.
 	throwLowDiskTLogRecoveryFailed(self, logData, ver, minAvailableSpaceRatio, kvStoreBytes, queueBytes);

--- a/fdbserver/workloads/ConsistencyCheck.cpp
+++ b/fdbserver/workloads/ConsistencyCheck.cpp
@@ -1129,8 +1129,6 @@ struct ConsistencyCheckWorkload : TestWorkload {
 			return true;
 		}
 
-		CODE_PROBE(self->performQuiescentChecks, "Checking for single singletons");
-
 		std::vector<ISimulator::ProcessInfo*> allProcesses = g_simulator->getAllProcesses();
 
 		bool success = true;


### PR DESCRIPTION
This PR cleans up stale and misleading FoundationDB code probes identified in the Joshua coverage audit.

- Correct the two default-backup probe predicates.
- Remove obsolete BackupWorker, ConsistencyCheck, and storage read-metric probes.
- Mark the two genuinely exceptional low-disk TLog probes as rare.

These changes improve the signal from Joshua probe reports without changing runtime behavior.