### PR TITLE
Reject anonymous shard-encoded data moves

### DIFF
--- a/fdbserver/core/MoveKeys.cpp
+++ b/fdbserver/core/MoveKeys.cpp
@@ -3941,7 +3941,9 @@ Future<Void> rawStartMovement(Database occ,
                               const MoveKeysParams& params,
                               std::map<UID, StorageServerInterface>& tssMapping) {
 	if (SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA) {
-		if (!params.ranges.present()) {
+		// A relocation launched before the knob changed can still carry the old-path sentinel.
+		// Never persist it as a shard-encoded data move; restart DD with the new configuration.
+		if (!params.ranges.present() || params.dataMoveId == anonymousShardId) {
 			throw dd_config_changed();
 		}
 		ASSERT(params.ranges.present());


### PR DESCRIPTION
## Summary

Prevent an old-path relocation carrying `anonymousShardId` from entering the shard-encoded MoveKeys path after `SHARD_ENCODE_LOCATION_METADATA` changes. Restart data distribution with `dd_config_changed` before invalid data-move metadata can be persisted and overlap a replacement move.

## Testing

- Passed 20/20 applicable `fdbserver_core_test` tests.
- Passed the original `ShardEncodeRollback.toml` CI failure with buggify enabled and seed `4166730246` (from https://github.com/apple/foundationdb/pull/13685).