### PR TITLE
Select modal leader priority across coordinators

### DIFF
--- a/fdbclient/MonitorLeader.cpp
+++ b/fdbclient/MonitorLeader.cpp
@@ -29,6 +29,8 @@
 #include "flow/IConnection.h"
 #include "flow/CoroUtils.h"
 
+#include <compare>
+
 namespace {
 
 std::string trim(std::string const& connectionString) {
@@ -544,6 +546,8 @@ Optional<std::pair<LeaderInfo, bool>> getLeader(const std::vector<Optional<Leade
 		UID maskedChangeID;
 		UID changeID;
 		int nomineeIndex;
+
+		std::strong_ordering operator<=>(MaskedNominee const&) const = default;
 	};
 
 	std::vector<MaskedNominee> maskedNominees;
@@ -560,12 +564,7 @@ Optional<std::pair<LeaderInfo, bool>> getLeader(const std::vector<Optional<Leade
 	if (maskedNominees.empty())
 		return Optional<std::pair<LeaderInfo, bool>>();
 
-	std::sort(maskedNominees.begin(), maskedNominees.end(), [](const MaskedNominee& l, const MaskedNominee& r) {
-		if (l.maskedChangeID != r.maskedChangeID) {
-			return l.maskedChangeID < r.maskedChangeID;
-		}
-		return l.changeID < r.changeID;
-	});
+	std::sort(maskedNominees.begin(), maskedNominees.end());
 
 	int bestCount = 1;
 	int bestIdx = 0;

--- a/fdbclient/MonitorLeader.cpp
+++ b/fdbclient/MonitorLeader.cpp
@@ -532,36 +532,47 @@ Future<Void> monitorNominee(Key key,
 
 // Also used in fdbserver/core/LeaderElection.cpp!
 // bool represents if the LeaderInfo is a majority answer or not.
-// This function also masks the first 7 bits of changeId of the nominees and returns the Leader with masked changeId
+// Group nominees by changeID with the priority bits masked, then return the most common full changeID in the winning
+// group.
 Optional<std::pair<LeaderInfo, bool>> getLeader(const std::vector<Optional<LeaderInfo>>& nominees) {
 	// If any coordinator says that the quorum is forwarded, then it is
 	for (int i = 0; i < nominees.size(); i++)
 		if (nominees[i].present() && nominees[i].get().forward)
 			return std::pair<LeaderInfo, bool>(nominees[i].get(), true);
 
-	std::vector<std::pair<UID, int>> maskedNominees;
+	struct MaskedNominee {
+		UID maskedChangeID;
+		UID changeID;
+		int nomineeIndex;
+	};
+
+	std::vector<MaskedNominee> maskedNominees;
 	maskedNominees.reserve(nominees.size());
 	for (int i = 0; i < nominees.size(); i++) {
 		if (nominees[i].present()) {
-			maskedNominees.emplace_back(
-			    UID(nominees[i].get().changeID.first() & LeaderInfo::changeIDMask, nominees[i].get().changeID.second()),
-			    i);
+			maskedNominees.push_back({ UID(nominees[i].get().changeID.first() & LeaderInfo::changeIDMask,
+			                               nominees[i].get().changeID.second()),
+			                           nominees[i].get().changeID,
+			                           i });
 		}
 	}
 
 	if (maskedNominees.empty())
 		return Optional<std::pair<LeaderInfo, bool>>();
 
-	std::sort(maskedNominees.begin(),
-	          maskedNominees.end(),
-	          [](const std::pair<UID, int>& l, const std::pair<UID, int>& r) { return l.first < r.first; });
+	std::sort(maskedNominees.begin(), maskedNominees.end(), [](const MaskedNominee& l, const MaskedNominee& r) {
+		if (l.maskedChangeID != r.maskedChangeID) {
+			return l.maskedChangeID < r.maskedChangeID;
+		}
+		return l.changeID < r.changeID;
+	});
 
 	int bestCount = 1;
 	int bestIdx = 0;
 	int currentIdx = 0;
 	int curCount = 1;
 	for (int i = 1; i < maskedNominees.size(); i++) {
-		if (maskedNominees[currentIdx].first == maskedNominees[i].first) {
+		if (maskedNominees[currentIdx].maskedChangeID == maskedNominees[i].maskedChangeID) {
 			curCount++;
 		} else {
 			currentIdx = i;
@@ -573,8 +584,84 @@ Optional<std::pair<LeaderInfo, bool>> getLeader(const std::vector<Optional<Leade
 		}
 	}
 
+	// Coordinators can agree on the leader identity while reporting different priority bits. Select the modal full
+	// changeID so that one stale coordinator cannot pin the aggregate to an obsolete priority. The sort order and
+	// strict count comparison deterministically prefer the fitter (lower) changeID when variant counts tie.
+	int representativeIdx = maskedNominees[bestIdx].nomineeIndex;
+	int bestVariantCount = 1;
+	currentIdx = bestIdx;
+	curCount = 1;
+	for (int i = bestIdx + 1; i < bestIdx + bestCount; i++) {
+		if (maskedNominees[currentIdx].changeID == maskedNominees[i].changeID) {
+			curCount++;
+		} else {
+			currentIdx = i;
+			curCount = 1;
+		}
+		if (curCount > bestVariantCount) {
+			representativeIdx = maskedNominees[currentIdx].nomineeIndex;
+			bestVariantCount = curCount;
+		}
+	}
+
 	bool majority = bestCount >= nominees.size() / 2 + 1;
-	return std::pair<LeaderInfo, bool>(nominees[maskedNominees[bestIdx].second].get(), majority);
+	return std::pair<LeaderInfo, bool>(nominees[representativeIdx].get(), majority);
+}
+
+TEST_CASE("/fdbclient/MonitorLeader/getLeader/priorityVariants") {
+	auto makeLeader = [](UID internalID, ClusterControllerPriorityInfo::DCFitness dcFitness) {
+		LeaderInfo leader(internalID);
+		ClusterControllerPriorityInfo priority;
+		priority.dcFitness = dcFitness;
+		leader.updateChangeID(priority);
+		return leader;
+	};
+	auto assertLeader =
+	    [](const std::vector<Optional<LeaderInfo>>& nominees, LeaderInfo const& expected, bool majority) {
+		    auto result = getLeader(nominees);
+		    ASSERT(result.present());
+		    ASSERT(result.get().first.changeID == expected.changeID);
+		    ASSERT(result.get().second == majority);
+	    };
+
+	UID internalID(1, 2);
+	LeaderInfo primary = makeLeader(internalID, ClusterControllerPriorityInfo::FitnessPrimary);
+	LeaderInfo remote = makeLeader(internalID, ClusterControllerPriorityInfo::FitnessRemote);
+	LeaderInfo unknown = makeLeader(internalID, ClusterControllerPriorityInfo::FitnessUnknown);
+
+	for (int staleIndex = 0; staleIndex < 10; staleIndex++) {
+		std::vector<Optional<LeaderInfo>> nominees(10, remote);
+		nominees[staleIndex] = primary;
+		assertLeader(nominees, remote, true);
+
+		nominees.assign(10, primary);
+		nominees[staleIndex] = remote;
+		assertLeader(nominees, primary, true);
+	}
+
+	std::vector<Optional<LeaderInfo>> nominees(5, primary);
+	nominees.insert(nominees.end(), 5, remote);
+	assertLeader(nominees, primary, true);
+
+	nominees.assign(6, remote);
+	nominees.insert(nominees.end(), 4, primary);
+	assertLeader(nominees, remote, true);
+
+	nominees.assign(5, unknown);
+	nominees.insert(nominees.end(), 5, remote);
+	assertLeader(nominees, remote, true);
+
+	LeaderInfo other = makeLeader(UID(3, 4), ClusterControllerPriorityInfo::FitnessPrimary);
+	nominees.assign(3, primary);
+	nominees.insert(nominees.end(), 3, remote);
+	nominees.insert(nominees.end(), 4, other);
+	assertLeader(nominees, primary, true);
+
+	nominees.assign(5, primary);
+	nominees.insert(nominees.end(), 5, other);
+	assertLeader(nominees, primary, false);
+
+	return Void();
 }
 
 // Leader is the process that will be elected by coordinators as the cluster controller


### PR DESCRIPTION
Coordinators can agree on a leader identity while temporarily reporting different priority bits. Previously, `getLeader()` could select a stale priority from an arbitrary coordinator. This caused a simulation failure on `tests/fast/AtomicOpsApiCorrectness.toml` due to a recovery stall.

This PR updates this logic to select the most frequently reported full change ID within the winning leader group, with deterministic tie-breaking favoring the most fit priority. A `/fdbclient/MonitorLeader/getLeader/priorityVariants` unit test is added to test this logic.
