### PR TITLE
Avoid recovery on old backup worker failure

### DIFF
--- a/fdbserver/logsystem/LogSystem.cpp
+++ b/fdbserver/logsystem/LogSystem.cpp
@@ -681,20 +681,8 @@ Future<Void> LogSystem::onError() const {
 						}
 					}
 				}
-				// Monitor changes of backup workers for old epochs.
-				for (const auto& worker : old.tLogs[0]->backupWorkers) {
-					if (worker->get().present()) {
-						backupFailed.push_back(
-						    waitFailureClient(worker->get().interf().waitFailure,
-						                      /* failureReactionTime */ SERVER_KNOBS->BACKUP_TIMEOUT,
-						                      /* failureReactionSlope */ -SERVER_KNOBS->BACKUP_TIMEOUT /
-						                          SERVER_KNOBS->SECONDS_BEFORE_NO_FAILURE_DELAY,
-						                      /* trace */ true,
-						                      /* traceMsg */ "OldBackupWorkerFailed"_sr));
-					} else {
-						changes.push_back(worker->onChange());
-					}
-				}
+				// Old-generation backup workers are stateless and persist their progress. A failure can retain
+				// this generation, but must not restart transaction-system recovery.
 			}
 		}
 


### PR DESCRIPTION
This PR avoids restarting transaction-system recovery when a Backup V2 worker draining an old log epoch fails.

During recovery, unfinished backup work from earlier epochs is recruited using its persisted progress. Once recruitment completes, `LogSystem::onError()` monitors those old-epoch workers and converts a worker failure into `backup_worker_failed`. If recovery has not yet completed, this starts another recovery generation, which recruits the unfinished work again. Repeated worker failures can therefore prevent the transaction system from completing recovery and make the database unavailable.

Old-epoch backup workers are stateless and persist their progress. A failed worker can cause backup progress to stall and conservatively retain the corresponding old log generation, but it should not restart transaction-system recovery.

This PR removes only the old-epoch backup-worker failure monitor. Current-epoch backup-worker monitoring and initialization failure handling remain unchanged. The old log generation continues to be retained until its backup work completes or is otherwise resolved.
