### PR TITLE
Enable additional `clang-tidy` correctness checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,6 +2,7 @@
 Checks: >
   -*,
   bugprone-dangling-handle,
+  bugprone-implicit-widening-of-multiplication-result,
   bugprone-redundant-branch-condition,
   bugprone-shared-ptr-array-mismatch,
   bugprone-sizeof-container,
@@ -14,9 +15,12 @@ Checks: >
   bugprone-suspicious-semicolon,
   bugprone-suspicious-string-compare,
   bugprone-suspicious-stringview-data-usage,
+  bugprone-too-small-loop-variable,
   bugprone-unique-ptr-array-mismatch,
   bugprone-use-after-move,
+  cppcoreguidelines-avoid-capturing-lambda-coroutines,
   misc-coroutine-hostile-raii,
+  misc-redundant-expression,
   modernize-use-auto,
   modernize-use-equals-default,
   modernize-use-override,
@@ -31,6 +35,8 @@ Checks: >
   readability-duplicate-include,
   readability-inconsistent-ifelse-braces
 CheckOptions:
+  - key: bugprone-dangling-handle.HandleClasses
+    value: 'std::basic_string_view;std::experimental::basic_string_view;std::span;StringRef'
   - key: modernize-use-auto.MinTypeNameLength
     value: '11'
   - key: readability-braces-around-statements.ShortStatementLines

--- a/documentation/sphinx/source/clang-tidy.rst
+++ b/documentation/sphinx/source/clang-tidy.rst
@@ -10,11 +10,12 @@ This guide explains how to run ``clang-tidy`` locally so you can fix issues befo
 What clang-tidy checks
 ======================
 
-FoundationDB enables 29 checks configured in the ``.clang-tidy`` file at the repository root. The
+FoundationDB enables 33 checks configured in the ``.clang-tidy`` file at the repository root. The
 intent is to enable more as we go forward. Here are some example rules:
 
-* **15 Bugprone rules** -- catch potential runtime errors (e.g., ``bugprone-use-after-move``, ``bugprone-suspicious-memory-comparison``)
-* **1 Misc rule** -- catch RAII objects held across coroutine suspension points (``misc-coroutine-hostile-raii``)
+* **17 Bugprone rules** -- catch potential runtime errors (e.g., ``bugprone-too-small-loop-variable``, ``bugprone-implicit-widening-of-multiplication-result``)
+* **1 C++ Core Guidelines rule** -- catch unsafe captures in coroutine lambdas (``cppcoreguidelines-avoid-capturing-lambda-coroutines``)
+* **2 Misc rules** -- catch redundant expressions and RAII objects held across coroutine suspension points
 * **4 Modernize rules** -- encourage modern C++ practices (e.g., ``modernize-use-auto``, ``modernize-use-override``)
 * **2 Performance rules** -- avoid unnecessary copies and pointless moves (e.g., ``performance-for-range-copy``, ``performance-move-const-arg``)
 * **7 Readability rules** -- improve code clarity (e.g., ``readability-container-contains``, ``readability-container-size-empty``)

--- a/fdbclient/BackupContainerFileSystem.cpp
+++ b/fdbclient/BackupContainerFileSystem.cpp
@@ -1619,7 +1619,8 @@ Future<std::vector<LogFile>> BackupContainerFileSystem::listLogFiles(Version beg
 	std::string firstPath =
 	    BackupContainerFileSystemImpl::cleanFolderString(BackupContainerFileSystemImpl::logVersionFolderString(
 	        std::max<Version>(0,
-	                          beginVersion - CLIENT_KNOBS->BACKUP_MAX_LOG_RANGES * CLIENT_KNOBS->LOG_RANGE_BLOCK_SIZE),
+	                          beginVersion - static_cast<Version>(CLIENT_KNOBS->BACKUP_MAX_LOG_RANGES) *
+	                                             CLIENT_KNOBS->LOG_RANGE_BLOCK_SIZE),
 	        mutationLogType));
 	std::string lastPath = BackupContainerFileSystemImpl::cleanFolderString(
 	    BackupContainerFileSystemImpl::logVersionFolderString(targetVersion, mutationLogType));

--- a/fdbclient/FileBackupAgent.cpp
+++ b/fdbclient/FileBackupAgent.cpp
@@ -1087,7 +1087,7 @@ PartitionedLogIteratorSimple::PartitionedLogIteratorSimple(Reference<IBackupCont
                                                            std::vector<RestoreConfig::RestoreFile> _files,
                                                            std::vector<Version> _endVersions)
   : bc(_bc), tag(_tag), endVersions(_endVersions), files(std::move(_files)), bufferOffset(0) {
-	bufferCapacity = BATCH_READ_BLOCK_COUNT * BLOCK_SIZE;
+	bufferCapacity = static_cast<size_t>(BATCH_READ_BLOCK_COUNT) * BLOCK_SIZE;
 	buffer = std::shared_ptr<char[]>(new char[bufferCapacity]());
 	fileOffset = 0;
 	fileIndex = 0;
@@ -3174,9 +3174,10 @@ struct BackupLogsDispatchTask : BackupTaskFuncBase {
 			co_return;
 		}
 
-		Version endVersion = std::max<Version>(tr->getReadVersion().get() + 1,
-		                                       beginVersion + (CLIENT_KNOBS->BACKUP_MAX_LOG_RANGES - 1) *
-		                                                          CLIENT_KNOBS->LOG_RANGE_BLOCK_SIZE);
+		Version endVersion =
+		    std::max<Version>(tr->getReadVersion().get() + 1,
+		                      beginVersion + static_cast<Version>(CLIENT_KNOBS->BACKUP_MAX_LOG_RANGES - 1) *
+		                                         CLIENT_KNOBS->LOG_RANGE_BLOCK_SIZE);
 
 		TraceEvent("FileBackupLogDispatch")
 		    .suppressFor(60)

--- a/fdbclient/ReadYourWrites.cpp
+++ b/fdbclient/ReadYourWrites.cpp
@@ -144,7 +144,7 @@ public:
 			    co_await getRangeValue(ryw, read.key, firstGreaterOrEqual(ryw->getMaxReadKey()), GetRangeLimits(1), it);
 			if (result.readToBegin)
 				co_return allKeys.begin;
-			if (result.readThroughEnd || !result.size())
+			if (result.readThroughEnd || result.empty())
 				co_return ryw->getMaxReadKey();
 			co_return result[0].key;
 		} else {
@@ -153,7 +153,7 @@ public:
 			    co_await getRangeValueBack(ryw, firstGreaterOrEqual(allKeys.begin), read.key, GetRangeLimits(1), it);
 			if (result.readThroughEnd)
 				co_return ryw->getMaxReadKey();
-			if (result.readToBegin || !result.size())
+			if (result.readToBegin || result.empty())
 				co_return allKeys.begin;
 			co_return result[0].key;
 		}
@@ -201,7 +201,7 @@ public:
 		RangeResult v = co_await ryw->tr.getRange(
 		    read.begin, read.end, read.limits, snapshot, backwards ? Reverse::True : Reverse::False);
 		KeyRef maxKey = ryw->getMaxReadKey();
-		if (v.size() > 0) {
+		if (!v.empty()) {
 			if (!backwards && v[v.size() - 1].key >= maxKey) {
 				RangeResult _v = v;
 				int i = _v.size() - 2;
@@ -229,14 +229,15 @@ public:
 
 	static void addConflictRange(ReadYourWritesTransaction* ryw, GetKeyReq read, WriteMap::iterator& it, Key result) {
 		KeyRangeRef readRange;
-		if (read.key.offset <= 0)
+		if (read.key.offset <= 0) {
 			readRange = KeyRangeRef(KeyRef(ryw->arena, result),
 			                        read.key.orEqual ? keyAfter(read.key.getKey(), ryw->arena)
 			                                         : KeyRef(ryw->arena, read.key.getKey()));
-		else
+		} else {
 			readRange = KeyRangeRef(read.key.orEqual ? keyAfter(read.key.getKey(), ryw->arena)
 			                                         : KeyRef(ryw->arena, read.key.getKey()),
 			                        keyAfter(result, ryw->arena));
+		}
 
 		it.skip(readRange.begin);
 		ryw->updateConflictMap(readRange, it);
@@ -476,7 +477,7 @@ public:
 		if (data.readThroughEnd)
 			endKey = allKeys.end;
 
-		if (data.size()) {
+		if (!data.empty()) {
 			beginKey = std::min(beginKey, data[0].key);
 			if (data.readThrough.present()) {
 				endKey = std::max<ExtStringRef>(endKey, data.readThrough.get());
@@ -511,8 +512,9 @@ public:
 					return singleEmpty;
 				}
 				singleEmpty++;
-			} else
+			} else {
 				b = e;
+			}
 			++it;
 			e = it.endKey();
 		}
@@ -541,8 +543,9 @@ public:
 				singleEmpty++;
 				if (singleEmpty >= maxClears)
 					return maxClears;
-			} else
+			} else {
 				b = e;
+			}
 			++it;
 			e = it.endKey();
 		}
@@ -633,7 +636,7 @@ public:
 			    .detail("Unknown", it.is_unknown_range())
 			    .detail("Requests", requestCount);*/
 
-			if (!result.size() && actualBeginOffset >= actualEndOffset && begin.getKey() >= end.getKey()) {
+			if (result.empty() && actualBeginOffset >= actualEndOffset && begin.getKey() >= end.getKey()) {
 				co_return RangeResultRef(false, false);
 			}
 
@@ -645,7 +648,7 @@ public:
 			    (begin.offset >= 1 && begin.getKey() >= ryw->getMaxReadKey())) {
 				if (end.isFirstGreaterOrEqual())
 					break;
-				if (!result.size())
+				if (result.empty())
 					break;
 				Key resolvedEnd = co_await read(
 				    ryw,
@@ -673,7 +676,7 @@ public:
 				break;
 
 			if (it.is_unknown_range()) {
-				if (limits.hasByteLimit() && limits.hasSatisfiedMinRows() && result.size() &&
+				if (limits.hasByteLimit() && limits.hasSatisfiedMinRows() && !result.empty() &&
 				    itemsPastEnd >= 1 - end.offset) {
 					result.more = true;
 					break;
@@ -775,8 +778,9 @@ public:
 				if (count)
 					result.append(result.arena(), start, count);
 				++it;
-			} else
+			} else {
 				++it;
+			}
 		}
 
 		result.more = result.more || limits.isReached();
@@ -805,7 +809,7 @@ public:
 		if (data.readThroughEnd)
 			endKey = allKeys.end;
 
-		if (data.size()) {
+		if (!data.empty()) {
 			if (data.readThrough.present()) {
 				beginKey = std::min(data.readThrough.get(), beginKey);
 			} else {
@@ -840,8 +844,9 @@ public:
 					return singleEmpty;
 				}
 				singleEmpty++;
-			} else
+			} else {
 				e = b;
+			}
 			--it;
 			b = it.beginKey();
 		}
@@ -868,8 +873,9 @@ public:
 				singleEmpty++;
 				if (singleEmpty >= maxClears)
 					return maxClears;
-			} else
+			} else {
 				e = b;
+			}
 			--it;
 			b = it.beginKey();
 		}
@@ -937,7 +943,7 @@ public:
 			    .detail("Kv", it.is_kv())
 			    .detail("Requests", requestCount);*/
 
-			if (!result.size() && actualBeginOffset >= actualEndOffset && begin.getKey() >= end.getKey()) {
+			if (result.empty() && actualBeginOffset >= actualEndOffset && begin.getKey() >= end.getKey()) {
 				co_return RangeResultRef(false, false);
 			}
 
@@ -949,7 +955,7 @@ public:
 			    (end.offset <= 1 && end.getKey() == allKeys.begin)) {
 				if (begin.isFirstGreaterOrEqual())
 					break;
-				if (!result.size())
+				if (result.empty())
 					break;
 				Key resolvedBegin = co_await read(
 				    ryw,
@@ -980,7 +986,7 @@ public:
 			}
 
 			if (it.is_unknown_range()) {
-				if (limits.hasByteLimit() && result.size() && itemsPastBegin >= begin.offset - 1) {
+				if (limits.hasByteLimit() && !result.empty() && itemsPastBegin >= begin.offset - 1) {
 					result.more = true;
 					break;
 				}
@@ -1227,7 +1233,7 @@ public:
 			auto itCopy = it;
 			++it;
 
-			ASSERT(itCopy->value.size());
+			ASSERT(!itCopy->value.empty());
 			CODE_PROBE(itCopy->value.size() > 1, "Multiple watches on the same key triggered by RYOW");
 
 			for (int i = 0; i < itCopy->value.size(); i++) {
@@ -1248,7 +1254,7 @@ public:
 				}
 			}
 
-			if (itCopy->value.size() == 0)
+			if (itCopy->value.empty())
 				ryw->watchMap.erase(itCopy);
 		}
 	}
@@ -1342,11 +1348,12 @@ public:
 				ryw->nativeReadRanges = ryw->tr.readConflictRanges();
 				ryw->nativeWriteRanges = ryw->tr.writeConflictRanges();
 				for (const auto& f : ryw->tr.getExtraReadConflictRanges()) {
-					if (f.isReady() && f.get().first < f.get().second)
+					if (f.isReady() && f.get().first < f.get().second) {
 						ryw->nativeReadRanges.push_back(
 						    ryw->nativeReadRanges.arena(),
 						    KeyRangeRef(f.get().first, f.get().second)
 						        .withPrefix(readConflictRangeKeysRange.begin, ryw->nativeReadRanges.arena()));
+					}
 				}
 
 				if (ryw->resetPromise.isSet())
@@ -1481,7 +1488,7 @@ public:
 	}
 
 	static Future<Void> onError(ReadYourWritesTransaction* ryw, Error e) {
-		if (ryw->debugTraces.size() > 0 || ryw->debugMessages.size() > 0) {
+		if (!ryw->debugTraces.empty() || !ryw->debugMessages.empty()) {
 			// printDebugMessages returns a future but will not block if called with an empty second argument
 			ASSERT(printDebugMessages(ryw, {}, e).isReady());
 		}
@@ -2044,10 +2051,11 @@ RangeResult ReadYourWritesTransaction::getReadConflictRangeIntersecting(KeyRange
 		for (const auto& range : nativeReadRanges)
 			readConflicts.insert(range.withPrefix(readConflictRangeKeysRange.begin, result.arena()), "1"_sr);
 		for (const auto& f : tr.getExtraReadConflictRanges()) {
-			if (f.isReady() && f.get().first < f.get().second)
+			if (f.isReady() && f.get().first < f.get().second) {
 				readConflicts.insert(KeyRangeRef(f.get().first, f.get().second)
 				                         .withPrefix(readConflictRangeKeysRange.begin, result.arena()),
 				                     "1"_sr);
+			}
 		}
 		auto beginIter = readConflicts.rangeContaining(kr.begin);
 		if (beginIter->begin() != kr.begin)
@@ -2074,11 +2082,12 @@ RangeResult ReadYourWritesTransaction::getWriteConflictRangeIntersecting(KeyRang
 		if (it.beginKey() > allKeys.begin)
 			--it;
 		for (; it.beginKey() < strippedWriteRangePrefix.end; ++it) {
-			if (it.is_conflict_range())
+			if (it.is_conflict_range()) {
 				writeConflicts.insert(
 				    KeyRangeRef(it.beginKey().toArena(result.arena()), it.endKey().toArena(result.arena()))
 				        .withPrefix(writeConflictRangeKeysRange.begin, result.arena()),
 				    "1"_sr);
+			}
 		}
 	} else {
 		for (const auto& range : tr.writeConflictRanges())
@@ -2410,7 +2419,7 @@ Future<Void> ReadYourWritesTransaction::commit() {
 		result = RYWImpl::commit(this);
 	}
 
-	return debugMessages.size() > 0 || debugTraces.size() > 0 ? RYWImpl::printDebugMessages(this, result) : result;
+	return !debugMessages.empty() || !debugTraces.empty() ? RYWImpl::printDebugMessages(this, result) : result;
 }
 
 Future<Standalone<StringRef>> ReadYourWritesTransaction::getVersionstamp() {
@@ -2533,7 +2542,7 @@ void ReadYourWritesTransaction::operator=(ReadYourWritesTransaction&& r) noexcep
 	reading = std::move(r.reading);
 	resetPromise = std::move(r.resetPromise);
 	r.resetPromise = Promise<Void>();
-	deferredError = std::move(r.deferredError);
+	deferredError = r.deferredError;
 	retries = r.retries;
 	approximateSize = r.approximateSize;
 	timeoutActor = r.timeoutActor;
@@ -2554,11 +2563,10 @@ void ReadYourWritesTransaction::operator=(ReadYourWritesTransaction&& r) noexcep
 }
 
 ReadYourWritesTransaction::ReadYourWritesTransaction(ReadYourWritesTransaction&& r) noexcept
-  : deferredError(std::move(r.deferredError)), arena(std::move(r.arena)), cache(std::move(r.cache)),
-    writes(std::move(r.writes)), resetPromise(std::move(r.resetPromise)), reading(std::move(r.reading)),
-    retries(r.retries), approximateSize(r.approximateSize), timeoutActor(std::move(r.timeoutActor)),
-    creationTime(r.creationTime), commitStarted(r.commitStarted), transactionDebugInfo(r.transactionDebugInfo),
-    options(r.options) {
+  : deferredError(r.deferredError), arena(std::move(r.arena)), cache(std::move(r.cache)), writes(std::move(r.writes)),
+    resetPromise(std::move(r.resetPromise)), reading(std::move(r.reading)), retries(r.retries),
+    approximateSize(r.approximateSize), timeoutActor(std::move(r.timeoutActor)), creationTime(r.creationTime),
+    commitStarted(r.commitStarted), transactionDebugInfo(r.transactionDebugInfo), options(r.options) {
 	cache.arena = &arena;
 	writes.arena = &arena;
 	tr = std::move(r.tr);
@@ -2637,7 +2645,7 @@ void ReadYourWritesTransaction::cancel() {
 }
 
 void ReadYourWritesTransaction::reset() {
-	if (debugTraces.size() > 0 || debugMessages.size() > 0) {
+	if (!debugTraces.empty() || !debugMessages.empty()) {
 		// printDebugMessages returns a future but will not block if called with an empty second argument
 		ASSERT(RYWImpl::printDebugMessages(this, {}).isReady());
 	}
@@ -2676,7 +2684,7 @@ ReadYourWritesTransaction::~ReadYourWritesTransaction() {
 	if (!resetPromise.isSet())
 		resetPromise.sendError(transaction_cancelled());
 
-	if (debugTraces.size() || debugMessages.size()) {
+	if (!debugTraces.empty() || !debugMessages.empty()) {
 		// printDebugMessages returns a future but will not block if called with an empty second argument
 		[[maybe_unused]] Future<Void> f = RYWImpl::printDebugMessages(this, {});
 	}
@@ -2700,14 +2708,15 @@ void ReadYourWritesTransaction::debugLogRetries(Optional<Error> error) {
 			if (!transactionDebugInfo->transactionName.empty())
 				transactionNameStr =
 				    format(" in transaction '%s'", printable(StringRef(transactionDebugInfo->transactionName)).c_str());
-			if (!g_network->isSimulated()) // Fuzz workload turns this on, but we do not want stderr output in
-			                               // simulation
+			if (!g_network->isSimulated()) { // Fuzz workload turns this on, but we do not want stderr output in
+				                             // simulation
 				fprintf(stderr,
 				        "fdb WARNING: long transaction (%.2fs elapsed%s, %d retries, %s)\n",
 				        elapsed,
 				        transactionNameStr.c_str(),
 				        retries,
 				        committed ? "committed" : error.get().what());
+			}
 			{
 				TraceEvent trace = TraceEvent("LongTransaction");
 				if (error.present())

--- a/fdbclient/ReadYourWrites.cpp
+++ b/fdbclient/ReadYourWrites.cpp
@@ -2188,7 +2188,7 @@ void ReadYourWritesTransaction::atomicOp(const KeyRef& key, const ValueRef& oper
 	}
 
 	approximateSize += k.expectedSize() + v.expectedSize() + sizeof(MutationRef) +
-	                   (addWriteConflict ? sizeof(KeyRangeRef) + 2 * key.expectedSize() + 1 : 0);
+	                   (addWriteConflict ? sizeof(KeyRangeRef) + 2ULL * key.expectedSize() + 1 : 0);
 	if (options.readYourWritesDisabled) {
 		return tr.atomicOp(k, v, (MutationRef::Type)operationType, addWriteConflict);
 	}
@@ -2236,7 +2236,7 @@ void ReadYourWritesTransaction::set(const KeyRef& key, const ValueRef& value) {
 		throw key_outside_legal_range();
 
 	approximateSize += key.expectedSize() + value.expectedSize() + sizeof(MutationRef) +
-	                   (addWriteConflict ? sizeof(KeyRangeRef) + 2 * key.expectedSize() + 1 : 0);
+	                   (addWriteConflict ? sizeof(KeyRangeRef) + 2ULL * key.expectedSize() + 1 : 0);
 	if (options.readYourWritesDisabled) {
 		return tr.set(key, value, addWriteConflict);
 	}

--- a/fdbclient/StorageServerInterface.cpp
+++ b/fdbclient/StorageServerInterface.cpp
@@ -228,7 +228,7 @@ static void traceKeyValuesSummary(TraceEvent& event,
 // convert a StringRef to Hex string
 static std::string hexStringRef(const StringRef& s) {
 	std::string result;
-	result.reserve(s.size() * 2);
+	result.reserve(static_cast<size_t>(s.size()) * 2);
 	for (int i = 0; i < s.size(); i++) {
 		result.append(format("%02x", s[i]));
 	}

--- a/fdbclient/Subspace.cpp
+++ b/fdbclient/Subspace.cpp
@@ -21,7 +21,7 @@
 #include "fdbclient/Subspace.h"
 
 Subspace::Subspace(Tuple const& tuple, StringRef const& rawPrefix) {
-	StringRef packed = tuple.pack();
+	Standalone<StringRef> packed = tuple.pack();
 
 	this->rawPrefix.reserve(this->rawPrefix.arena(), rawPrefix.size() + packed.size());
 	this->rawPrefix.append(this->rawPrefix.arena(), rawPrefix.begin(), rawPrefix.size());

--- a/fdbrpc/FlowTransport.cpp
+++ b/fdbrpc/FlowTransport.cpp
@@ -417,7 +417,7 @@ struct ConnectionLogWriter : IThreadPoolReceiver {
 			throw io_error();
 		}
 
-		if (file.tellg() > 100 * 1024 * 1024 /* 100 MB */) {
+		if (file.tellg() > 100LL * 1024 * 1024 /* 100 MB */) {
 			file.close();
 			fileName = newFileName();
 			TraceEvent("RollConnectionLog").detail("FileName", fileName);

--- a/fdbrpc/Net2FileSystem.cpp
+++ b/fdbrpc/Net2FileSystem.cpp
@@ -57,10 +57,11 @@ Future<Void> runAsyncFileKAIOTestOps(Reference<IAsyncFile> f, int numIterations,
 		std::vector<Future<Void>> futures;
 		for (int numOps = deterministicRandom()->randomInt(1, 20); numOps > 0; --numOps) {
 			if (deterministicRandom()->coinflip()) {
-				futures.push_back(
-				    success(f->read(buf, 4096, deterministicRandom()->randomInt(0, fileSize) / 4096 * 4096)));
+				futures.push_back(success(f->read(
+				    buf, 4096, static_cast<int64_t>(deterministicRandom()->randomInt(0, fileSize)) / 4096 * 4096)));
 			} else {
-				futures.push_back(f->write(buf, 4096, deterministicRandom()->randomInt(0, fileSize) / 4096 * 4096));
+				futures.push_back(f->write(
+				    buf, 4096, static_cast<int64_t>(deterministicRandom()->randomInt(0, fileSize)) / 4096 * 4096));
 			}
 		}
 		for (int fIndex = 0; fIndex < futures.size(); ++fIndex) {

--- a/fdbrpc/tests/AuthzTlsTest.cpp
+++ b/fdbrpc/tests/AuthzTlsTest.cpp
@@ -352,7 +352,7 @@ int runHost(TLSCreds creds, int addrPipe, int completionPipe, Result expect) {
 Result getExpectedResult(ChainLength serverChainLen, ChainLength clientChainLen) {
 	auto expect = Result::ERROR;
 	if (serverChainLen > 0) {
-		if (clientChainLen == NO_TLS || clientChainLen < 0) {
+		if (clientChainLen < 0) {
 			expect = Result::TIMEOUT;
 		} else if (clientChainLen > 0) {
 			expect = Result::TRUSTED;

--- a/fdbserver/consistencyscan/ConsistencyScan.cpp
+++ b/fdbserver/consistencyscan/ConsistencyScan.cpp
@@ -1687,8 +1687,9 @@ Future<Void> checkDataConsistency(Database cx,
 		if (firstClient && performQuiescentChecks &&
 		    ((configuration.usableRegions == 1 && (sourceStorageServers.size() > expectedReplicas ||
 		                                           sourceStorageServers.size() < configuration.storageTeamSize)) ||
-		     sourceStorageServers.size() < configuration.usableRegions * configuration.storageTeamSize ||
-		     sourceStorageServers.size() > configuration.usableRegions * expectedReplicas)) {
+		     sourceStorageServers.size() <
+		         static_cast<size_t>(configuration.usableRegions) * configuration.storageTeamSize ||
+		     sourceStorageServers.size() > static_cast<size_t>(configuration.usableRegions) * expectedReplicas)) {
 			TraceEvent("ConsistencyCheck_InvalidTeamSize")
 			    .detail("ShardBegin", printable(range.begin))
 			    .detail("ShardEnd", printable(range.end))

--- a/fdbserver/coordinator/Coordination.cpp
+++ b/fdbserver/coordinator/Coordination.cpp
@@ -713,7 +713,7 @@ class LeaderServer {
 				info.forward = forward.get().serializedInfo;
 				req.reply.send(CachedSerialization<ClientDBInfo>(info));
 			} else {
-				StringRef clusterName = ccr->getConnectionString().clusterKeyName();
+				Key clusterName = ccr->getConnectionString().clusterKeyName();
 				if (!SERVER_KNOBS->ENABLE_CROSS_CLUSTER_SUPPORT &&
 				    getClusterDescriptor(req.clusterKey).compare(clusterName)) {
 					TraceEvent(SevWarn, "CCRMismatch")
@@ -736,7 +736,7 @@ class LeaderServer {
 			if (forward.present()) {
 				req.reply.send(forward.get());
 			} else {
-				StringRef clusterName = ccr->getConnectionString().clusterKeyName();
+				Key clusterName = ccr->getConnectionString().clusterKeyName();
 				if (!SERVER_KNOBS->ENABLE_CROSS_CLUSTER_SUPPORT && getClusterDescriptor(req.key).compare(clusterName)) {
 					TraceEvent(SevWarn, "CCRMismatch")
 					    .detail("RequestType", "ElectionResultRequest")
@@ -759,7 +759,7 @@ class LeaderServer {
 			if (forward.present())
 				req.reply.send(forward.get());
 			else {
-				StringRef clusterName = ccr->getConnectionString().clusterKeyName();
+				Key clusterName = ccr->getConnectionString().clusterKeyName();
 				if (!SERVER_KNOBS->ENABLE_CROSS_CLUSTER_SUPPORT && getClusterDescriptor(req.key).compare(clusterName)) {
 					TraceEvent(SevWarn, "CCRMismatch")
 					    .detail("RequestType", "GetLeaderRequest")
@@ -781,7 +781,7 @@ class LeaderServer {
 			if (forward.present())
 				req.reply.send(forward.get());
 			else {
-				StringRef clusterName = ccr->getConnectionString().clusterKeyName();
+				Key clusterName = ccr->getConnectionString().clusterKeyName();
 				if (!SERVER_KNOBS->ENABLE_CROSS_CLUSTER_SUPPORT && getClusterDescriptor(req.key).compare(clusterName)) {
 					TraceEvent(SevWarn, "CCRMismatch")
 					    .detail("RequestType", "CandidacyRequest")
@@ -802,7 +802,7 @@ class LeaderServer {
 			if (forward.present())
 				req.reply.send(LeaderHeartbeatReply{ false });
 			else {
-				StringRef clusterName = ccr->getConnectionString().clusterKeyName();
+				Key clusterName = ccr->getConnectionString().clusterKeyName();
 				if (!SERVER_KNOBS->ENABLE_CROSS_CLUSTER_SUPPORT && getClusterDescriptor(req.key).compare(clusterName)) {
 					TraceEvent(SevWarn, "CCRMismatch")
 					    .detail("RequestType", "LeaderHeartbeatRequest")
@@ -823,7 +823,7 @@ class LeaderServer {
 			if (forward.present()) {
 				req.reply.send(Void());
 			} else {
-				StringRef clusterName = ccr->getConnectionString().clusterKeyName();
+				Key clusterName = ccr->getConnectionString().clusterKeyName();
 				if (!SERVER_KNOBS->ENABLE_CROSS_CLUSTER_SUPPORT && getClusterDescriptor(req.key).compare(clusterName)) {
 					TraceEvent(SevWarn, "CCRMismatch")
 					    .detail("RequestType", "ForwardRequest")

--- a/fdbserver/core/BulkLoadUtil.cpp
+++ b/fdbserver/core/BulkLoadUtil.cpp
@@ -575,7 +575,7 @@ Future<KeyRange> getBulkLoadJobFileManifestEntryFromJobManifestFile(
 		throw file_too_large();
 	}
 
-	int64_t chunkSize = 64 * 1024; // 64KB chunks
+	int64_t chunkSize = 64LL * 1024; // 64KB chunks
 	std::string buffer;
 	int64_t offset = 0;
 	std::string leftover;

--- a/fdbserver/core/ServerKnobs.cpp
+++ b/fdbserver/core/ServerKnobs.cpp
@@ -358,7 +358,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( MAX_SHARD_BYTES,                                 500000000 );
 	init( KEY_SERVER_SHARD_BYTES,                          500000000 );
 
-	init( SHARD_MAX_READ_OPS_PER_KSEC,                  45000 * 1000 );
+	init( SHARD_MAX_READ_OPS_PER_KSEC,                45000LL * 1000 );
     init( SHARD_READ_OPS_CHANGE_THRESHOLD, SHARD_MAX_READ_OPS_PER_KSEC / 4); if(randomize && buggify()) SHARD_READ_OPS_CHANGE_THRESHOLD = 2000;
  	/*
  	 * The assumption is when the read ops reach to 45k/s the Storage Server instance will be CPU-saturated.
@@ -367,7 +367,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	/*
 		The bytesRead/byteSize radio. Will be declared as read hot when larger than this. 8.0 was chosen to avoid reporting table scan as read hot.
 	*/
-	init ( SHARD_READ_HOT_BANDWIDTH_MIN_PER_KSECONDS,      1666667 * 1000);
+	init ( SHARD_READ_HOT_BANDWIDTH_MIN_PER_KSECONDS,    1666667LL * 1000);
 	/*
 		The read bandwidth of a given shard needs to be larger than this value in order to be evaluated if it's read hot. The roughly 1.67MB per second is calculated as following:
 			- Heuristic data suggests that each storage process can do max 500K read operations per second
@@ -389,7 +389,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 		team indefinitely, limiting performance.
 		*/
 
-	init( SHARD_MIN_BYTES_PER_KSEC,                100 * 1000 * 1000 ); if( buggifySmallBandwidthSplit ) SHARD_MIN_BYTES_PER_KSEC = 20*1000*1000;
+	init( SHARD_MIN_BYTES_PER_KSEC,              100LL * 1000 * 1000 ); if( buggifySmallBandwidthSplit ) SHARD_MIN_BYTES_PER_KSEC = 20LL*1000*1000;
 	/* 100*1KB/sec * 1000sec/ksec
 		Shards with more than this bandwidth will not be merged.
 		Obviously this needs to be significantly less than SHARD_MAX_BYTES_PER_KSEC, else we will repeatedly merge and split.
@@ -403,7 +403,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 		BYTES_WRITTEN_UNITS_PER_SAMPLE.  If this number is too low, the storage server needs to spend more memory and time on sampling.
 		*/
 
-	init( SHARD_SPLIT_BYTES_PER_KSEC,              250 * 1000 * 1000 ); if( buggifySmallBandwidthSplit ) SHARD_SPLIT_BYTES_PER_KSEC = 50 * 1000 * 1000;
+	init( SHARD_SPLIT_BYTES_PER_KSEC,            250LL * 1000 * 1000 ); if( buggifySmallBandwidthSplit ) SHARD_SPLIT_BYTES_PER_KSEC = 50LL * 1000 * 1000;
 	/* 250*1KB/sec * 1000sec/ksec
 		When splitting a shard, it is split into pieces with less than this bandwidth.
 		Obviously this should be less than half of SHARD_MAX_BYTES_PER_KSEC.
@@ -529,7 +529,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( DD_BULKDUMP_PARALLELISM,                                50 ); if( randomize && buggify() ) DD_BULKDUMP_PARALLELISM = deterministicRandom()->randomInt(1, 5);
 	init( DD_BULKDUMP_BUILD_JOB_MANIFEST_BATCH_SIZE,           10000 ); if( isSimulated ) DD_BULKDUMP_BUILD_JOB_MANIFEST_BATCH_SIZE = deterministicRandom()->randomInt(1, 100);
 	init( SS_SERVE_BULKDUMP_PARALLELISM,                           1 ); // TODO(BulkDump): Do not set to 1 after SS can resolve the file folder conflict
-	init( SS_BULKDUMP_BATCH_BYTES,                     100*1024*1024 ); if( isSimulated ) SS_BULKDUMP_BATCH_BYTES = deterministicRandom()->randomInt(1000, 10000);
+	init( SS_BULKDUMP_BATCH_BYTES,                   100LL*1024*1024 ); if( isSimulated ) SS_BULKDUMP_BATCH_BYTES = deterministicRandom()->randomInt(1000, 10000);
 	init( SS_BULKDUMP_BATCH_COUNT_MAX_PER_REQUEST,                10 ); if( isSimulated ) SS_BULKDUMP_BATCH_COUNT_MAX_PER_REQUEST = deterministicRandom()->randomInt(1, 10);
 
 	// TeamRemover
@@ -629,7 +629,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( ROCKSDB_PERIODIC_COMPACTION_SECONDS,                     0 ); if( isSimulated ) ROCKSDB_PERIODIC_COMPACTION_SECONDS = deterministicRandom()->randomInt(5*60, 24*60*60);
 	init( ROCKSDB_TTL_COMPACTION_SECONDS,                    2160000 ); if( isSimulated ) ROCKSDB_TTL_COMPACTION_SECONDS = deterministicRandom()->randomInt(5*60, 24*60*60);
 	int64_t maxCompactionBytes = 160LL * 64 * 1024 * 1024;
-	init( ROCKSDB_MAX_COMPACTION_BYTES,                            0 ); /* default = 25*64MB */ if( randomize && buggify() ) ROCKSDB_MAX_COMPACTION_BYTES = deterministicRandom()->randomInt64(5*64*1024*1024, maxCompactionBytes);
+	init( ROCKSDB_MAX_COMPACTION_BYTES,                            0 ); /* default = 25*64MB */ if( randomize && buggify() ) ROCKSDB_MAX_COMPACTION_BYTES = deterministicRandom()->randomInt64(5LL*64*1024*1024, maxCompactionBytes);
 	init( ROCKSDB_PREFIX_LEN,                                     11 ); if( randomize && buggify() )  ROCKSDB_PREFIX_LEN = deterministicRandom()->randomInt(1, 20);
 	init( ROCKSDB_MEMTABLE_PREFIX_BLOOM_SIZE_RATIO,              0.1 );
 	init( ROCKSDB_BLOOM_BITS_PER_KEY,                             10 );
@@ -920,7 +920,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	// Backup Worker
 	init( BACKUP_TIMEOUT,                                        0.4 );
 	init( BACKUP_FILE_BLOCK_BYTES,                       1024 * 1024 );
-	init( BACKUP_WORKER_LOCK_BYTES,                              3e9 ); if(randomize && buggify()) BACKUP_WORKER_LOCK_BYTES = deterministicRandom()->randomInt(2048, 4096) * 4096;
+	init( BACKUP_WORKER_LOCK_BYTES,                              3e9 ); if(randomize && buggify()) BACKUP_WORKER_LOCK_BYTES = deterministicRandom()->randomInt(2048, 4096) * 4096LL;
 	init( BACKUP_UPLOAD_DELAY,                                  10.0 ); if(randomize && buggify()) BACKUP_UPLOAD_DELAY = deterministicRandom()->random01() * 60;
 
 	//Cluster Controller
@@ -1068,7 +1068,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( CONSISTENCY_CHECK_BACKWARD_READ,                    false ); if (isSimulated) CONSISTENCY_CHECK_BACKWARD_READ = deterministicRandom()->coinflip();
 	init (STORAGE_FETCH_KEYS_DELAY,	                             0.0 ); if ( randomize && buggify() ) { STORAGE_FETCH_KEYS_DELAY = deterministicRandom()->random01() * 5.0; }
 	init (STORAGE_FETCH_KEYS_USE_COMMIT_BUDGET,                false ); if (isSimulated) STORAGE_FETCH_KEYS_USE_COMMIT_BUDGET = deterministicRandom()->coinflip();
-	init (STORAGE_FETCH_KEYS_RATE_LIMIT,             			   0 ); if (isSimulated && buggify()) STORAGE_FETCH_KEYS_RATE_LIMIT = 100 * 1024 * deterministicRandom()->randomInt(1, 10);  // In MB/s
+	init (STORAGE_FETCH_KEYS_RATE_LIMIT,             			   0 ); if (isSimulated && buggify()) STORAGE_FETCH_KEYS_RATE_LIMIT = 100LL * 1024 * deterministicRandom()->randomInt(1, 10);  // In MB/s
 	init (STORAGE_ROCKSDB_LOG_CLEAN_UP_DELAY,               3600 * 2 ); if (isSimulated) STORAGE_ROCKSDB_LOG_CLEAN_UP_DELAY = 20.0;
 	init (STORAGE_ROCKSDB_LOG_TTL,                    3600 * 24 * 15 ); if (isSimulated) STORAGE_ROCKSDB_LOG_TTL = 3600.0;
 
@@ -1321,7 +1321,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 
 	// Timekeeper
 	init( TIME_KEEPER_DELAY,                                      10 );
-	init( TIME_KEEPER_MAX_ENTRIES,                3600 * 24 * 30 * 6 ); if( randomize && buggify() ) { TIME_KEEPER_MAX_ENTRIES = 2; }
+	init( TIME_KEEPER_MAX_ENTRIES,              3600LL * 24 * 30 * 6 ); if( randomize && buggify() ) { TIME_KEEPER_MAX_ENTRIES = 2; }
 
 	init( REDWOOD_DEFAULT_PAGE_SIZE,                            8192 );
 	init( REDWOOD_DEFAULT_EXTENT_SIZE,              32 * 1024 * 1024 );

--- a/fdbserver/core/StorageMetrics.cpp
+++ b/fdbserver/core/StorageMetrics.cpp
@@ -357,8 +357,8 @@ void StorageServerMetrics::splitMetrics(SplitMetricsRequest req) const {
 		//TraceEvent("SplitMetrics").detail("Begin", req.keys.begin).detail("End", req.keys.end).detail("Remaining", remaining.bytes).detail("Used", used.bytes).detail("MinSplitBytes", minSplitBytes);
 
 		while (true) {
-			if (remaining.bytes < 2 * minSplitBytes && (!SERVER_KNOBS->ENABLE_WRITE_BASED_SHARD_SPLIT ||
-			                                            remaining.bytesWrittenPerKSecond < minSplitWriteTraffic))
+			if (remaining.bytes < 2LL * minSplitBytes && (!SERVER_KNOBS->ENABLE_WRITE_BASED_SHARD_SPLIT ||
+			                                              remaining.bytesWrittenPerKSecond < minSplitWriteTraffic))
 				break;
 			KeyRef key = req.keys.end;
 			bool hasUsed = used.bytes != 0 || used.bytesWrittenPerKSecond != 0 || used.iosPerKSecond != 0;

--- a/fdbserver/kvstore/DiskQueue.cpp
+++ b/fdbserver/kvstore/DiskQueue.cpp
@@ -172,9 +172,10 @@ public:
 	    readingPage(-1), writingPos(-1), fileExtensionBytes(SERVER_KNOBS->DISK_QUEUE_FILE_EXTENSION_BYTES),
 	    fileShrinkBytes(SERVER_KNOBS->DISK_QUEUE_FILE_SHRINK_BYTES) {
 		if (buggify())
-			fileExtensionBytes = _PAGE_SIZE * deterministicRandom()->randomSkewedUInt32(1, 10 << 10);
+			fileExtensionBytes =
+			    static_cast<int64_t>(_PAGE_SIZE) * deterministicRandom()->randomSkewedUInt32(1, 10 << 10);
 		if (buggify())
-			fileShrinkBytes = _PAGE_SIZE * deterministicRandom()->randomSkewedUInt32(1, 10 << 10);
+			fileShrinkBytes = static_cast<int64_t>(_PAGE_SIZE) * deterministicRandom()->randomSkewedUInt32(1, 10 << 10);
 		files[0].dbgFilename = filename(0);
 		files[1].dbgFilename = filename(1);
 		// We issue reads into firstPages, so it needs to be 4k aligned.

--- a/fdbserver/kvstore/FDBExecHelper.cpp
+++ b/fdbserver/kvstore/FDBExecHelper.cpp
@@ -63,7 +63,7 @@ void ExecCmdValueString::setCmdValueString(StringRef pCmdValueString) {
 }
 
 StringRef ExecCmdValueString::getCmdValueString() const {
-	return cmdValueString.toString();
+	return cmdValueString;
 }
 
 StringRef ExecCmdValueString::getBinaryPath() const {

--- a/fdbserver/kvstore/KeyValueStoreRocksDB.cpp
+++ b/fdbserver/kvstore/KeyValueStoreRocksDB.cpp
@@ -1307,7 +1307,7 @@ struct RocksDBKeyValueStore : IKeyValueStore {
 		    rateLimiter(SERVER_KNOBS->ROCKSDB_WRITE_RATE_LIMITER_BYTES_PER_SEC > 0
 		                    ? rocksdb::NewGenericRateLimiter(
 		                          SERVER_KNOBS->ROCKSDB_WRITE_RATE_LIMITER_BYTES_PER_SEC, // rate_bytes_per_sec
-		                          100 * 1000, // refill_period_us
+		                          100LL * 1000, // refill_period_us
 		                          SERVER_KNOBS->ROCKSDB_WRITE_RATE_LIMITER_FAIRNESS, // fairness
 		                          rocksdb::RateLimiter::Mode::kAllIo,
 		                          SERVER_KNOBS->ROCKSDB_WRITE_RATE_LIMITER_AUTO_TUNE)

--- a/fdbserver/kvstore/KeyValueStoreSQLite.cpp
+++ b/fdbserver/kvstore/KeyValueStoreSQLite.cpp
@@ -159,7 +159,7 @@ struct PageChecksumCodec {
 			if (g_network->isSimulated()) {
 				// Calculate file offsets for the read/write operation space
 				// Operation starts at a 1-based pageNumber and is of size pageLen
-				int64_t fileOffsetStart = (pageNumber - 1) * pageLen;
+				int64_t fileOffsetStart = static_cast<int64_t>(pageNumber - 1) * pageLen;
 				// End refers to the offset after the operation, not the last byte.
 				int64_t fileOffsetEnd = fileOffsetStart + pageLen;
 

--- a/fdbserver/kvstore/KeyValueStoreShardedRocksDB.cpp
+++ b/fdbserver/kvstore/KeyValueStoreShardedRocksDB.cpp
@@ -1244,7 +1244,7 @@ public:
 
 			auto rateLimiter =
 			    rocksdb::NewGenericRateLimiter(SERVER_KNOBS->SHARDED_ROCKSDB_WRITE_RATE_LIMITER_BYTES_PER_SEC,
-			                                   100 * 1000, // refill_period_us
+			                                   100LL * 1000, // refill_period_us
 			                                   10, // fairness
 			                                   mode,
 			                                   SERVER_KNOBS->ROCKSDB_WRITE_RATE_LIMITER_AUTO_TUNE);

--- a/fdbserver/logsystem/LogSystem.cpp
+++ b/fdbserver/logsystem/LogSystem.cpp
@@ -363,7 +363,7 @@ UID LogSystem::getDebugID() const {
 void LogSystem::addPseudoLocality(int8_t locality) {
 	ASSERT(locality < 0);
 	pseudoLocalities.insert(locality);
-	for (uint16_t i = 0; i < logRouterTags; i++) {
+	for (int i = 0; i < logRouterTags; i++) {
 		pseudoLocalityPopVersion[Tag(locality, i)] = 0;
 	}
 }
@@ -1597,7 +1597,7 @@ void getTLogLocIds(const std::vector<Reference<LogSet>>& tLogs,
 		if (!it->isLocal) {
 			continue;
 		}
-		for (uint16_t i = 0; i < it->logServers.size(); i++) {
+		for (size_t i = 0; i < it->logServers.size(); i++) {
 			if (it->logServers[i]->get().present()) {
 				interfLocMap[it->logServers[i]->get().interf().id()] = location;
 			}

--- a/fdbserver/resolver/ConflictSet.cpp
+++ b/fdbserver/resolver/ConflictSet.cpp
@@ -431,8 +431,9 @@ public:
 
 	void addConflictRanges(const Finger* fingers, int rangeCount, Version version) {
 		for (int r = rangeCount - 1; r >= 0; r--) {
-			const Finger& startF = fingers[r * 2];
-			const Finger& endF = fingers[r * 2 + 1];
+			const size_t fingerIndex = static_cast<size_t>(r) * 2;
+			const Finger& startF = fingers[fingerIndex];
+			const Finger& endF = fingers[fingerIndex + 1];
 
 			if (endF.found() == nullptr)
 				insert(endF, endF.finger[0]->getMaxVersion(0));
@@ -1018,7 +1019,7 @@ void ConflictBatch::addConflictRanges(Version now,
 
 	int ss = stringCount - (stripes - 1) * stripeSize;
 	for (int s = stripes - 1; s >= 0; s--) {
-		part->find(&strings[s * stripeSize], fingers, temp, ss);
+		part->find(&strings[static_cast<size_t>(s) * stripeSize], fingers, temp, ss);
 		part->addConflictRanges(fingers, ss / 2, now);
 		ss = stripeSize;
 	}

--- a/fdbserver/storageserver/storageserver.cpp
+++ b/fdbserver/storageserver/storageserver.cpp
@@ -3496,7 +3496,8 @@ Future<Void> getKeyValuesQ(StorageServer* data, GetKeyValuesRequest req)
 
 			if (req.taskID.present() && req.taskID.get() == TaskPriority::FetchKeys) {
 				data->counters.kvFetchServed += r.data.size();
-				data->counters.kvFetchBytesServed += (totalByteSize + (8 - (int)sizeof(KeyValueRef)) * r.data.size());
+				data->counters.kvFetchBytesServed +=
+				    totalByteSize + (8LL - static_cast<int64_t>(sizeof(KeyValueRef))) * r.data.size();
 			}
 
 			if (totalByteSize > 0 && SERVER_KNOBS->READ_SAMPLING_ENABLED) {

--- a/fdbserver/tester/ConsistencyChecker.cpp
+++ b/fdbserver/tester/ConsistencyChecker.cpp
@@ -544,8 +544,9 @@ std::unordered_map<int, std::vector<KeyRange>> makeTaskAssignment(Database cx,
 
 	int batchSize = CLIENT_KNOBS->CONSISTENCY_CHECK_URGENT_BATCH_SHARD_COUNT;
 	int startingPoint = 0;
-	if (shardsToCheck.size() > batchSize * testersCount) {
-		startingPoint = deterministicRandom()->randomInt(0, shardsToCheck.size() - batchSize * testersCount);
+	const size_t batchShardCount = static_cast<size_t>(batchSize) * testersCount;
+	if (shardsToCheck.size() > batchShardCount) {
+		startingPoint = deterministicRandom()->randomInt(0, shardsToCheck.size() - batchShardCount);
 		// We randomly pick a set of successive shards:
 		// (1) We want to retry for different shards to avoid repeated failure on the same shards
 		// (2) We want to check successive shards to avoid inefficiency incurred by fragments

--- a/fdbserver/tlog/TestTLogServer.cpp
+++ b/fdbserver/tlog/TestTLogServer.cpp
@@ -247,7 +247,7 @@ Future<Void> TLogTestContext::sendPushMessages(TLogTestContext* pTLogTestContext
 
 	TraceEvent("TestTLogServerEnterPush", pTLogTestContext->workerID);
 
-	for (uint16_t logID = 0; logID < pTLogTestContext->numLogServers; ++logID) {
+	for (uint32_t logID = 0; logID < pTLogTestContext->numLogServers; ++logID) {
 		Reference<TLogContext> pTLogContext = pTLogTestContext->pTLogContextList[logID];
 		bool tLogReady = co_await pTLogContext->TLogStarted.getFuture();
 		ASSERT_EQ(tLogReady, true);
@@ -393,7 +393,7 @@ Future<Void> buildTLogSet(Reference<TLogTestContext> pTLogTestContext) {
 	tLogSet.isLocal = true;
 	tLogSet.tLogVersion = TLogVersion::V6;
 	tLogSet.tLogReplicationFactor = 1;
-	for (uint16_t processID = 0; processID < pTLogTestContext->numLogServers; ++processID) {
+	for (uint32_t processID = 0; processID < pTLogTestContext->numLogServers; ++processID) {
 		Reference<TLogContext> pTLogContext = pTLogTestContext->pTLogContextList[processID];
 		bool isCreated = co_await pTLogContext->TLogCreated.getFuture();
 		ASSERT_EQ(isCreated, true);
@@ -401,7 +401,7 @@ Future<Void> buildTLogSet(Reference<TLogTestContext> pTLogTestContext) {
 		tLogSet.tLogs.push_back(OptionalInterface<TLogInterface>(pTLogContext->TestTLogInterface));
 	}
 	pTLogTestContext->dbInfo.logSystemConfig.tLogs.push_back(tLogSet);
-	for (uint16_t processID = 0; processID < pTLogTestContext->numLogServers; ++processID) {
+	for (uint32_t processID = 0; processID < pTLogTestContext->numLogServers; ++processID) {
 		Reference<TLogContext> pTLogContext = pTLogTestContext->pTLogContextList[processID];
 		// start transactions
 		pTLogContext->TLogStarted.send(true);
@@ -420,7 +420,7 @@ Future<Void> startTestsTLogRecoveryActors(TestTLogOptions params) {
 
 	FlowTransport::createInstance(false, 1, WLTOKEN_RESERVED_COUNT);
 
-	uint16_t tLogIdx = 0;
+	uint32_t tLogIdx = 0;
 
 	TraceEvent("TestTLogServerEnterRecoveryTest");
 

--- a/fdbserver/workloads/AsyncFileCorrectness.cpp
+++ b/fdbserver/workloads/AsyncFileCorrectness.cpp
@@ -295,8 +295,9 @@ struct AsyncFileCorrectnessWorkload : public AsyncFileWorkload {
 				do {
 					// Generate random length and offset
 					if (unbufferedIO) {
-						info.length =
-						    deterministicRandom()->randomInt(1, maxOperationSize / _PAGE_SIZE + 1) * _PAGE_SIZE;
+						info.length = static_cast<uint64_t>(
+						                  deterministicRandom()->randomInt(1, maxOperationSize / _PAGE_SIZE + 1)) *
+						              _PAGE_SIZE;
 						info.offset =
 						    (int64_t)(deterministicRandom()->random01() * maxOffset / _PAGE_SIZE) * _PAGE_SIZE;
 					} else {

--- a/fdbserver/workloads/AsyncFileRead.cpp
+++ b/fdbserver/workloads/AsyncFileRead.cpp
@@ -307,7 +307,7 @@ struct AsyncFileReadWorkload : public AsyncFileWorkload {
 			}
 
 			co_await waitForAll(self->readFutures);
-			self->bytesRead += self->readSize * self->numParallelReads;
+			self->bytesRead += static_cast<int64_t>(self->readSize) * self->numParallelReads;
 
 			self->readFutures.clear();
 

--- a/fdbserver/workloads/AsyncFileWrite.cpp
+++ b/fdbserver/workloads/AsyncFileWrite.cpp
@@ -136,7 +136,7 @@ struct AsyncFileWriteWorkload : public AsyncFileWorkload {
 
 			self->writeFutures.clear();
 
-			self->bytesWritten += self->writeSize * self->numParallelWrites;
+			self->bytesWritten += static_cast<int64_t>(self->writeSize) * self->numParallelWrites;
 		}
 	}
 

--- a/fdbserver/workloads/BackupCorrectness.cpp
+++ b/fdbserver/workloads/BackupCorrectness.cpp
@@ -116,7 +116,7 @@ struct BackupAndRestoreCorrectnessWorkload : TestWorkload {
 		} else {
 			// Add backup ranges
 			std::set<std::string> rangeEndpoints;
-			while (rangeEndpoints.size() < backupRangesCount * 2) {
+			while (rangeEndpoints.size() < static_cast<size_t>(backupRangesCount) * 2) {
 				rangeEndpoints.insert(deterministicRandom()->randomAlphaNumeric(
 				    deterministicRandom()->randomInt(1, backupRangeLengthMax + 1)));
 			}

--- a/fdbserver/workloads/BackupCorrectnessPartitioned.cpp
+++ b/fdbserver/workloads/BackupCorrectnessPartitioned.cpp
@@ -114,7 +114,7 @@ struct BackupAndRestorePartitionedCorrectnessWorkload : TestWorkload {
 		} else {
 			// Add backup ranges
 			std::set<std::string> rangeEndpoints;
-			while (rangeEndpoints.size() < backupRangesCount * 2) {
+			while (rangeEndpoints.size() < static_cast<size_t>(backupRangesCount) * 2) {
 				rangeEndpoints.insert(deterministicRandom()->randomAlphaNumeric(
 				    deterministicRandom()->randomInt(1, backupRangeLengthMax + 1)));
 			}

--- a/fdbserver/workloads/BackupS3BlobCorrectness.cpp
+++ b/fdbserver/workloads/BackupS3BlobCorrectness.cpp
@@ -221,7 +221,7 @@ struct BackupS3BlobCorrectnessWorkload : TestWorkload {
 		} else {
 			// Add backup ranges
 			std::set<std::string> rangeEndpoints;
-			while (rangeEndpoints.size() < backupRangesCount * 2) {
+			while (rangeEndpoints.size() < static_cast<size_t>(backupRangesCount) * 2) {
 				rangeEndpoints.insert(deterministicRandom()->randomAlphaNumeric(
 				    deterministicRandom()->randomInt(1, backupRangeLengthMax + 1)));
 			}

--- a/fdbserver/workloads/DDBalance.cpp
+++ b/fdbserver/workloads/DDBalance.cpp
@@ -200,7 +200,7 @@ struct DDBalanceWorkload : TestWorkload {
 
 			tr = Transaction();
 			if (self->shouldRecord(clientBegin)) {
-				self->operations += 3 * moves;
+				self->operations += 3LL * moves;
 				double latency = now() - tstart;
 				self->latencies.addSample(latency);
 			}

--- a/fdbserver/workloads/DiskDurability.cpp
+++ b/fdbserver/workloads/DiskDurability.cpp
@@ -85,7 +85,7 @@ struct DiskDurabilityWorkload : public AsyncFileWorkload {
 	explicit DiskDurabilityWorkload(WorkloadContext const& wcx) : AsyncFileWorkload(wcx) {
 		writers = getOption(options, "writers"_sr, 1);
 		filePages = getOption(options, "filePages"_sr, 1000000);
-		fileSize = filePages * _PAGE_SIZE;
+		fileSize = static_cast<int64_t>(filePages) * _PAGE_SIZE;
 		unbufferedIO = true;
 		uncachedIO = true;
 		fillRandom = false;

--- a/fdbserver/workloads/DiskDurabilityTest.cpp
+++ b/fdbserver/workloads/DiskDurabilityTest.cpp
@@ -78,7 +78,7 @@ struct DiskDurabilityTest : TestWorkload {
 		    IAsyncFile::OPEN_CREATE | IAsyncFile::OPEN_READWRITE | IAsyncFile::OPEN_UNBUFFERED |
 		        IAsyncFile::OPEN_UNCACHED | IAsyncFile::OPEN_LOCK,
 		    0600);
-		std::vector<uint8_t> pagedata(4096 * 128);
+		std::vector<uint8_t> pagedata(size_t{ 4096 } * 128);
 		uint8_t* page = (uint8_t*)((intptr_t(&pagedata[0]) | intptr_t(4095)) + 1);
 
 		int64_t size = co_await file->size();
@@ -162,7 +162,7 @@ struct DiskDurabilityTest : TestWorkload {
 			std::vector<Future<Void>> fresults;
 
 			for (int i = 0; i < targetPages.size(); i++) {
-				uint8_t* p = page + 4096 * i;
+				uint8_t* p = page + size_t{ 4096 } * i;
 				encodePage(p, targetValues[i]);
 				fresults.push_back(file->write(p, 4096, targetPages[i] * 4096));
 			}

--- a/fdbserver/workloads/GetEstimatedRangeSize.cpp
+++ b/fdbserver/workloads/GetEstimatedRangeSize.cpp
@@ -86,7 +86,8 @@ struct GetEstimatedRangeSizeWorkload : TestWorkload {
 		int nodeSize = key(0).size() + value(0).size();
 		// We use a wide range to avoid flakiness because the underlying function
 		// is making an estimation.
-		return size > nodeCount * nodeSize / 2 && size < nodeCount * nodeSize * 5;
+		return size > static_cast<int64_t>(nodeCount) * nodeSize / 2 &&
+		       size < static_cast<int64_t>(nodeCount) * nodeSize * 5;
 	}
 
 	Future<int64_t> getSize(Database cx) {

--- a/fdbserver/workloads/S3ClientWorkload.cpp
+++ b/fdbserver/workloads/S3ClientWorkload.cpp
@@ -260,8 +260,8 @@ private:
 
 		// Compare the contents of the original and downloaded files
 		// Paths are now inside uniqueRunDir
-		std::string originalContent = readFileBytes(credentials, 1024 * 1024); // 1MB max size
-		std::string downloadedContent = readFileBytes(download, 1024 * 1024); // 1MB max size
+		std::string originalContent = readFileBytes(credentials, size_t{ 1024 } * 1024); // 1MB max size
+		std::string downloadedContent = readFileBytes(download, size_t{ 1024 } * 1024); // 1MB max size
 		if (originalContent != downloadedContent) {
 			TraceEvent(SevError, "S3ClientWorkloadContentMismatch")
 			    .detailf("OriginalSize", "%zu", originalContent.size())

--- a/fdbserver/workloads/SimpleAtomicAdd.cpp
+++ b/fdbserver/workloads/SimpleAtomicAdd.cpp
@@ -108,7 +108,7 @@ struct SimpleAtomicAddWorkload : TestWorkload {
 
 	Future<bool> _check(Database cx) {
 		ReadYourWritesTransaction tr(cx);
-		uint64_t expectedValue = addValue * iterations;
+		uint64_t expectedValue = static_cast<uint64_t>(addValue) * iterations;
 		if (initialize) {
 			expectedValue += initialValue;
 		}

--- a/fdbserver/workloads/Watches.cpp
+++ b/fdbserver/workloads/Watches.cpp
@@ -106,21 +106,22 @@ struct WatchesWorkload : TestWorkload {
 		return result;
 	}
 
+	static Future<Void> watcherInitTransaction(Transaction* tr, Key watchKey, int* extraLoc, int extraNodes) {
+		for (int i = 0; i < 1000 && *extraLoc + i < extraNodes; i++) {
+			Key extraKey = KeyRef(watchKey.toString() + format("%d", *extraLoc + i));
+			Value extraValue = ValueRef(std::string(100, '.'));
+			tr->set(extraKey, extraValue);
+		}
+		co_await tr->commit();
+		*extraLoc += 1000;
+		CODE_PROBE(true, "Watches workload initial setup");
+	}
+
 	Future<Void> watcherInit(Database cx, Key watchKey, Key setKey, int extraNodes) {
 		int extraLoc = 0;
 		while (extraLoc < extraNodes) {
-			co_await cx.run([&](Transaction* tr) -> Future<Void> {
-				for (int i = 0; i < 1000 && extraLoc + i < extraNodes; i++) {
-					Key extraKey = KeyRef(watchKey.toString() + format("%d", extraLoc + i));
-					Value extraValue = ValueRef(std::string(100, '.'));
-					tr->set(extraKey, extraValue);
-					// TraceEvent("WatcherInitialSetupExtra").detail("Key", extraKey).detail("Value", extraValue);
-				}
-				co_await tr->commit();
-				extraLoc += 1000;
-				CODE_PROBE(true, "Watches workload initial setup");
-				// TraceEvent("WatcherInitialSetup").detail("Watch", watchKey).detail("Ver", tr->getCommittedVersion());
-			});
+			co_await cx.run(
+			    [&](Transaction* tr) { return watcherInitTransaction(tr, watchKey, &extraLoc, extraNodes); });
 		}
 	}
 
@@ -178,6 +179,63 @@ struct WatchesWorkload : TestWorkload {
 		}
 	}
 
+	static Future<Void> setWatchValue(Transaction* tr,
+	                                  Key startKey,
+	                                  Value assignedValue,
+	                                  bool isValue,
+	                                  Optional<Value>* startValue,
+	                                  Optional<Value>* expectedValue,
+	                                  bool* firstAttempt) {
+		co_await tr->getReadVersion();
+		Optional<Value> observedStartValue = co_await tr->get(startKey);
+		if (*firstAttempt) {
+			*startValue = observedStartValue;
+			*firstAttempt = false;
+		}
+		*expectedValue = Optional<Value>();
+		if (startValue->present()) {
+			if (isValue)
+				*expectedValue = assignedValue;
+		} else {
+			*expectedValue = assignedValue;
+		}
+
+		if (expectedValue->present())
+			tr->set(startKey, expectedValue->get());
+		else
+			tr->clear(startKey);
+
+		co_await tr->commit();
+		CODE_PROBE(expectedValue->present(), "watches workload set a key");
+		CODE_PROBE(!expectedValue->present(), "watches workload clear a key");
+	}
+
+	static Future<Void> waitForWatchValue(Transaction* tr,
+	                                      Key endKey,
+	                                      Optional<Value> startValue,
+	                                      Optional<Value> expectedValue,
+	                                      bool* firstAttempt,
+	                                      bool* finished) {
+		Optional<Value> endValue = co_await tr->get(endKey);
+		if (endValue == expectedValue) {
+			*finished = true;
+			co_return;
+		}
+		if (!*firstAttempt || endValue != startValue) {
+			TraceEvent(SevError, "WatcherError")
+			    .detail("FirstAttempt", *firstAttempt)
+			    .detail("StartValue", printable(startValue))
+			    .detail("EndValue", printable(endValue))
+			    .detail("ExpectedValue", printable(expectedValue))
+			    .detail("EndVersion", tr->getReadVersion().get());
+		}
+		Future<Void> watchFuture = tr->watch(makeReference<Watch>(endKey, startValue));
+		co_await tr->commit();
+		co_await watchFuture;
+		CODE_PROBE(true, "watcher workload watch fired");
+		*firstAttempt = false;
+	}
+
 	Future<Void> watchesWorker(Database cx, WatchesWorkload* self) {
 		Key startKey = self->keyForIndex(self->nodeOrder[0]);
 		Key endKey = self->keyForIndex(self->nodeOrder[self->nodes]);
@@ -189,55 +247,16 @@ struct WatchesWorkload : TestWorkload {
 			bool isValue = deterministicRandom()->random01() > 0.5;
 			Value assignedValue = Value(deterministicRandom()->randomUniqueID().toString());
 			bool firstAttempt = true;
-			co_await cx.run([&](Transaction* tr) -> Future<Void> {
-				co_await tr->getReadVersion();
-				Optional<Value> _startValue = co_await tr->get(startKey);
-				if (firstAttempt) {
-					startValue = _startValue;
-					firstAttempt = false;
-				}
-				expectedValue = Optional<Value>();
-				if (startValue.present()) {
-					if (isValue)
-						expectedValue = assignedValue;
-				} else {
-					expectedValue = assignedValue;
-				}
-
-				if (expectedValue.present())
-					tr->set(startKey, expectedValue.get());
-				else
-					tr->clear(startKey);
-
-				co_await tr->commit();
-				CODE_PROBE(expectedValue.present(), "watches workload set a key");
-				CODE_PROBE(!expectedValue.present(), "watches workload clear a key");
-				co_return;
+			co_await cx.run([&](Transaction* tr) {
+				return setWatchValue(tr, startKey, assignedValue, isValue, &startValue, &expectedValue, &firstAttempt);
 			});
 
 			chainStartTime = now();
 			firstAttempt = true;
 			bool finished = false;
 			while (!finished) {
-				co_await cx.run([&](Transaction* tr2) -> Future<Void> {
-					Optional<Value> endValue = co_await tr2->get(endKey);
-					if (endValue == expectedValue) {
-						finished = true;
-						co_return;
-					}
-					if (!firstAttempt || endValue != startValue) {
-						TraceEvent(SevError, "WatcherError")
-						    .detail("FirstAttempt", firstAttempt)
-						    .detail("StartValue", printable(startValue))
-						    .detail("EndValue", printable(endValue))
-						    .detail("ExpectedValue", printable(expectedValue))
-						    .detail("EndVersion", tr2->getReadVersion().get());
-					}
-					Future<Void> watchFuture = tr2->watch(makeReference<Watch>(endKey, startValue));
-					co_await tr2->commit();
-					co_await watchFuture;
-					CODE_PROBE(true, "watcher workload watch fired");
-					firstAttempt = false;
+				co_await cx.run([&](Transaction* tr) {
+					return waitForWatchValue(tr, endKey, startValue, expectedValue, &firstAttempt, &finished);
 				});
 			}
 			self->cycleLatencies.addSample(now() - chainStartTime);

--- a/fdbserver/workloads/pubsub.cpp
+++ b/fdbserver/workloads/pubsub.cpp
@@ -212,7 +212,7 @@ Future<bool> PubSub::createSubscription(uint64_t feed, uint64_t inbox) {
 //  the highest-numbered inbox that we've cleared from the watchers list and
 //  make sure that further requests start after this inbox.
 Future<Void> updateFeedWatchers(Transaction* tr, uint64_t feed) {
-	StringRef watcherPrefix = keyForFeedWatcherPrefix(feed);
+	Key watcherPrefix = keyForFeedWatcherPrefix(feed);
 	uint64_t highestInbox{ 0 };
 	bool first = true;
 	while (true) {
@@ -333,7 +333,7 @@ Future<int> singlePassInboxCacheUpdate(Database cx, uint64_t inbox, int swath) {
 			if (staleFeeds.empty())
 				// If there are no stale feeds, return.
 				co_return 0;
-			StringRef stalePrefix = keyForInboxStalePrefix(inbox);
+			Key stalePrefix = keyForInboxStalePrefix(inbox);
 			for (int idx = 0; idx < staleFeeds.size(); idx++) {
 				StringRef feedStr = staleFeeds[idx].key.removePrefix(stalePrefix);
 				// printf("  --> clearing stale entry: %s\n", feedStr.toString().c_str());
@@ -388,7 +388,7 @@ Future<MessageId> getFeedLatestAtOrAfter(Transaction* tr, Feed feed, MessageId p
 	if (lastMessageRange.empty())
 		co_return uint64_t(0);
 	KeyValueRef m = lastMessageRange[0];
-	StringRef prefix = keyForFeedMessagePrefix(feed);
+	Key prefix = keyForFeedMessagePrefix(feed);
 	StringRef mIdStr = m.key.removePrefix(prefix);
 	co_return valueToUInt64(mIdStr);
 }
@@ -409,7 +409,7 @@ Future<std::vector<Message>> _listInboxMessages(Database cx, uint64_t inbox, int
 Future<std::vector<Message>> _listInboxMessages(Database cx, uint64_t inbox, int count, uint64_t cursor) {
 	TraceEvent("PubSubListInbox").detail("Inbox", inbox).detail("Count", count).detail("Cursor", cursor);
 	co_await updateInboxCache(cx, inbox);
-	StringRef perIdPrefix = keyForInboxCacheByIDPrefix(inbox);
+	Key perIdPrefix = keyForInboxCacheByIDPrefix(inbox);
 	while (true) {
 		Transaction tr(cx);
 		std::vector<Message> messages;

--- a/flow/Arena.cpp
+++ b/flow/Arena.cpp
@@ -146,7 +146,7 @@ std::string StringRef::toHexString(int limit) const {
 		}
 		rv = substr(0, limit).toHexString() + format("...[%d]", length);
 	} else {
-		rv.reserve(length * 7);
+		rv.reserve(static_cast<size_t>(length) * 7);
 		for (int i = 0; i < length; i++) {
 			uint8_t b = (*this)[i];
 			if (isalnum(b))
@@ -163,7 +163,7 @@ std::string StringRef::toHexString(int limit) const {
 
 std::string StringRef::toFullHexStringPlain() const {
 	std::string s;
-	s.reserve(length * 7);
+	s.reserve(static_cast<size_t>(length) * 7);
 	for (int i = 0; i < length; i++) {
 		uint8_t b = (*this)[i];
 		s.append(format("%02x ", b));

--- a/flow/FastAlloc.cpp
+++ b/flow/FastAlloc.cpp
@@ -635,17 +635,20 @@ void FastAllocator<Size>::getMagazine() {
 #endif
 	// NOTE: rely on lower level metrics in allocate() (and whatever it calls)
 	// for accounting the allocations it does.
-	block = (void**)::allocate(magazine_size * Size, /*allowLargePages*/ false, includeGuardPages);
+	block = (void**)::allocate(static_cast<size_t>(magazine_size) * Size, /*allowLargePages*/ false, includeGuardPages);
 #endif
 
 	// void** block = new void*[ magazine_size * PSize ];
 	for (int i = 0; i < magazine_size - 1; i++) {
-		block[i * PSize + 1] = block[i * PSize] = &block[(i + 1) * PSize];
-		check(&block[i * PSize], false);
+		const size_t offset = static_cast<size_t>(i) * PSize;
+		const size_t nextOffset = static_cast<size_t>(i + 1) * PSize;
+		block[offset + 1] = block[offset] = &block[nextOffset];
+		check(&block[offset], false);
 	}
 
-	block[(magazine_size - 1) * PSize + 1] = block[(magazine_size - 1) * PSize] = nullptr;
-	check(&block[(magazine_size - 1) * PSize], false);
+	const size_t lastOffset = static_cast<size_t>(magazine_size - 1) * PSize;
+	block[lastOffset + 1] = block[lastOffset] = nullptr;
+	check(&block[lastOffset], false);
 	thr.freelist = block;
 	thr.count = magazine_size;
 }
@@ -714,7 +717,7 @@ TEST_CASE("/jemalloc/4k_aligned_usable_size") {
 		// Check that we can allocate 4k aligned up to 16k with no internal
 		// fragmentation
 		for (int i = 1; i < 4; ++i) {
-			ptr = aligned_alloc(4096, i * 4096);
+			ptr = aligned_alloc(4096, static_cast<size_t>(i) * 4096);
 			ASSERT_EQ(malloc_usable_size(ptr), i * 4096);
 			aligned_free(ptr);
 			ptr = nullptr;

--- a/flow/Knobs.cpp
+++ b/flow/Knobs.cpp
@@ -324,7 +324,7 @@ void FlowKnobs::initialize(Randomize randomize, IsSimulated isSimulated) {
 
 	// Encryption
 	init( ENCRYPT_CIPHER_KEY_CACHE_TTL, isSimulated ? 5 * 60 : 10 * 60 );
-	if ( randomize && buggify()) { ENCRYPT_CIPHER_KEY_CACHE_TTL = deterministicRandom()->randomInt(2, 10) * 60; }
+	if ( randomize && buggify()) { ENCRYPT_CIPHER_KEY_CACHE_TTL = deterministicRandom()->randomInt(2, 10) * 60LL; }
 	init( ENCRYPT_KEY_REFRESH_INTERVAL,   isSimulated ? 60 : 8 * 60 );
 	if ( randomize && buggify()) { ENCRYPT_KEY_REFRESH_INTERVAL = deterministicRandom()->randomInt(2, 10); }
 	init( ENCRYPT_KEY_HEALTH_CHECK_INTERVAL,                    10 );

--- a/flow/MkCert.cpp
+++ b/flow/MkCert.cpp
@@ -264,7 +264,7 @@ CertSpecRef CertSpecRef::make(Arena& arena, CertKind kind) {
 	auto spec = CertSpecRef{};
 	spec.serialNumber = static_cast<long>(deterministicRandom()->randomInt64(0, 1e10));
 	spec.offsetNotBefore = 0; // now
-	spec.offsetNotAfter = 60 * 60 * 24 * 365; // 1 year from now
+	spec.offsetNotAfter = 60L * 60 * 24 * 365; // 1 year from now
 	auto& subject = spec.subjectName;
 	subject.push_back(arena, { "countryName"_sr, "DE"_sr });
 	subject.push_back(arena, { "localityName"_sr, "Berlin"_sr });

--- a/flow/flow.cpp
+++ b/flow/flow.cpp
@@ -246,9 +246,9 @@ Optional<uint64_t> parseDuration(std::string const& str, std::string const& defa
 	} else if (!unit.compare("m")) {
 		ret *= 60;
 	} else if (!unit.compare("h")) {
-		ret *= 60 * 60;
+		ret *= 60ULL * 60;
 	} else if (!unit.compare("d")) {
-		ret *= 24 * 60 * 60;
+		ret *= 24ULL * 60 * 60;
 	} else {
 		return Optional<uint64_t>();
 	}


### PR DESCRIPTION
This PR enforces 4 new `clang-tidy` rules:

- `bugprone-implicit-widening-of-multiplication-result`
- `bugprone-too-small-loop-variable`
- `cppcoreguidelines-avoid-capturing-lambda-coroutines`
- `misc-redundant-expression`

and expands the classes covered by `bugprone-dangling-handle`. Existing violations of these rules are fixed.