### PR TITLE
Preserve queued shard splits on destination-team retry

### DIFF
--- a/fdbserver/datadistributor/DDRelocationQueue.cpp
+++ b/fdbserver/datadistributor/DDRelocationQueue.cpp
@@ -82,14 +82,20 @@ RelocateData::RelocateData()
 
 RelocateData::RelocateData(RelocateShard const& rs)
   : parent_range(rs.getParentRange()), keys(rs.keys), priority(rs.priority),
-    boundaryPriority(isBoundaryPriority(rs.priority) ? rs.priority : -1),
-    healthPriority(isHealthPriority(rs.priority) ? rs.priority : -1), reason(rs.reason), dmReason(rs.moveReason),
+    boundaryPriority(rs.retryIntent.present() ? rs.retryIntent.get().boundaryPriority
+                                              : (isBoundaryPriority(rs.priority) ? rs.priority : -1)),
+    healthPriority(rs.retryIntent.present() ? rs.retryIntent.get().healthPriority
+                                            : (isHealthPriority(rs.priority) ? rs.priority : -1)),
+    reason(rs.reason), dmReason(rs.moveReason),
     startTime(now()), randomId(rs.traceId.isValid() ? rs.traceId : deterministicRandom()->randomUniqueID()),
     dataMoveId(rs.dataMoveId), workFactor(0),
-    wantsNewServers(isDataMovementForMountainChopper(rs.moveReason) || isDataMovementForValleyFiller(rs.moveReason) ||
-                    rs.moveReason == DataMovementReason::SPLIT_SHARD ||
-                    rs.moveReason == DataMovementReason::TEAM_REDUNDANT ||
-                    rs.moveReason == DataMovementReason::REBALANCE_STORAGE_QUEUE),
+    wantsNewServers(rs.retryIntent.present()
+                        ? rs.retryIntent.get().wantsNewServers
+                        : (isDataMovementForMountainChopper(rs.moveReason) ||
+                           isDataMovementForValleyFiller(rs.moveReason) ||
+                           rs.moveReason == DataMovementReason::SPLIT_SHARD ||
+                           rs.moveReason == DataMovementReason::TEAM_REDUNDANT ||
+                           rs.moveReason == DataMovementReason::REBALANCE_STORAGE_QUEUE)),
     cancellable(true), interval("QueuedRelocation", randomId), dataMove(rs.dataMove) {
 	if (dataMove != nullptr) {
 		this->src.insert(this->src.end(), dataMove->meta.src.begin(), dataMove->meta.src.end());
@@ -127,6 +133,21 @@ bool RelocateData::operator!=(const RelocateData& rhs) const {
 }
 Optional<KeyRange> RelocateData::getParentRange() const {
 	return parent_range;
+}
+
+static RelocateShard makeDestinationFailureRetry(RelocateData const& rd, UID retryTraceId) {
+	RelocateShard retry(rd.keys, rd.dmReason, rd.reason, retryTraceId);
+	retry.priority = rd.priority;
+	retry.retryIntent = RelocateShard::RetryRelocationIntent{
+		rd.boundaryPriority, rd.healthPriority, rd.wantsNewServers };
+	if (rd.getParentRange().present()) {
+		retry.setParentRange(rd.getParentRange().get());
+	}
+	return retry;
+}
+
+static bool shouldRetryDestinationTeamFailure(bool doBulkLoading, RelocateData const& rd) {
+	return !doBulkLoading && !rd.isRestore();
 }
 
 class ParallelTCInfo final : public ReferenceCounted<ParallelTCInfo>, public IDataDistributionTeam {
@@ -1497,6 +1518,7 @@ Future<Void> dataDistributionRelocator(DDQueue* self,
 	PromiseStream<RelocateData> dataTransferComplete(self->dataTransferComplete);
 	PromiseStream<RelocateData> relocationComplete(self->relocationComplete);
 	bool signalledTransferComplete = false;
+	bool retryAfterDestinationTeamFailure = false;
 	UID distributorId = self->distributorId;
 	ParallelTCInfo healthyDestinations;
 
@@ -2240,6 +2262,8 @@ Future<Void> dataDistributionRelocator(DDQueue* self,
 									rd.bulkLoadTask.get().completeAck.send(
 									    BulkLoadAck(/*unretryableError=*/true, rd.priority));
 								}
+								retryAfterDestinationTeamFailure =
+								    shouldRetryDestinationTeamFailure(doBulkLoading, rd);
 								throw data_move_dest_team_not_found();
 							}
 						}
@@ -2424,6 +2448,19 @@ Future<Void> dataDistributionRelocator(DDQueue* self,
 	}
 	if (!signalledTransferComplete)
 		dataTransferComplete.send(rd);
+
+	if (err.code() == error_code_data_move_dest_team_not_found && retryAfterDestinationTeamFailure) {
+		// randomId participates in RelocateData's queue ordering, so a new attempt needs a new identity.
+		RelocateShard retry = makeDestinationFailureRetry(rd, deterministicRandom()->randomUniqueID());
+		self->output.send(retry);
+		TraceEvent(SevWarnAlways, "RelocateShardRetryDestinationTeamFailure", self->distributorId)
+		    .detail("Range", rd.keys)
+		    .detail("DataMoveID", rd.dataMoveId)
+		    .detail("Priority", rd.priority)
+		    .detail("Reason", rd.reason.toString())
+		    .detail("TraceID", retry.traceId)
+		    .detail("PreviousTraceID", rd.randomId);
+	}
 
 	relocationComplete.send(rd);
 
@@ -3217,4 +3254,51 @@ TEST_CASE("/DataDistribution/DDQueue/BatchDrainRelocationComplete") {
 	ASSERT(self.activeRelocations == 0);
 
 	std::cout << "BatchDrainRelocationComplete: drained " << drained << " of " << N << " completions\n";
+}
+
+TEST_CASE("/DataDistribution/DDQueue/RetryDestinationTeamFailure") {
+	KeyRange keys(KeyRangeRef("a"_sr, "b"_sr));
+	KeyRange parent(KeyRangeRef(""_sr, "z"_sr));
+	RelocateShard original(keys, DataMovementReason::SPLIT_SHARD, RelocateReason::SIZE_SPLIT, UID(1, 2));
+	original.setParentRange(parent);
+	RelocateData rd(original);
+	rd.priority = SERVER_KNOBS->PRIORITY_TEAM_UNHEALTHY;
+	rd.boundaryPriority = SERVER_KNOBS->PRIORITY_SPLIT_SHARD;
+	rd.healthPriority = SERVER_KNOBS->PRIORITY_TEAM_UNHEALTHY;
+	rd.wantsNewServers = true;
+
+	RelocateShard retryRequest = makeDestinationFailureRetry(rd, UID(3, 4));
+	RelocateData retry(retryRequest);
+	ASSERT(retry.keys == keys);
+	ASSERT(retry.priority == rd.priority);
+	ASSERT(retry.boundaryPriority == rd.boundaryPriority);
+	ASSERT(retry.healthPriority == rd.healthPriority);
+	ASSERT(retry.reason == rd.reason);
+	ASSERT(retry.dmReason == rd.dmReason);
+	ASSERT(retry.wantsNewServers == rd.wantsNewServers);
+	ASSERT(retry.randomId == UID(3, 4));
+	ASSERT(retry.randomId != rd.randomId);
+	retry.startTime = rd.startTime;
+	std::set<RelocateData, std::greater<RelocateData>> relocations;
+	relocations.insert(retry);
+	ASSERT(!relocations.contains(rd));
+	relocations.insert(rd);
+	ASSERT(relocations.size() == 2);
+	ASSERT(retry.getParentRange().present());
+	ASSERT(retry.getParentRange().get() == parent);
+	ASSERT(retry.src.empty());
+	ASSERT(retry.completeSources.empty());
+	ASSERT(retry.completeDests.empty());
+	ASSERT(retry.workFactor == 0);
+	ASSERT(retry.cancellable);
+	ASSERT(retry.dataMove == nullptr);
+	ASSERT(retry.dataMoveId == anonymousShardId);
+	ASSERT(!retry.isRestore());
+	ASSERT(!retry.bulkLoadTask.present());
+	ASSERT(shouldRetryDestinationTeamFailure(false, rd));
+	ASSERT(!shouldRetryDestinationTeamFailure(true, rd));
+	RelocateData restore = rd;
+	restore.dataMove = std::make_shared<DataMove>();
+	ASSERT(!shouldRetryDestinationTeamFailure(false, restore));
+	return Void();
 }

--- a/fdbserver/datadistributor/DDRelocationQueue.cpp
+++ b/fdbserver/datadistributor/DDRelocationQueue.cpp
@@ -86,16 +86,15 @@ RelocateData::RelocateData(RelocateShard const& rs)
                                               : (isBoundaryPriority(rs.priority) ? rs.priority : -1)),
     healthPriority(rs.retryIntent.present() ? rs.retryIntent.get().healthPriority
                                             : (isHealthPriority(rs.priority) ? rs.priority : -1)),
-    reason(rs.reason), dmReason(rs.moveReason),
-    startTime(now()), randomId(rs.traceId.isValid() ? rs.traceId : deterministicRandom()->randomUniqueID()),
-    dataMoveId(rs.dataMoveId), workFactor(0),
-    wantsNewServers(rs.retryIntent.present()
-                        ? rs.retryIntent.get().wantsNewServers
-                        : (isDataMovementForMountainChopper(rs.moveReason) ||
-                           isDataMovementForValleyFiller(rs.moveReason) ||
-                           rs.moveReason == DataMovementReason::SPLIT_SHARD ||
-                           rs.moveReason == DataMovementReason::TEAM_REDUNDANT ||
-                           rs.moveReason == DataMovementReason::REBALANCE_STORAGE_QUEUE)),
+    reason(rs.reason), dmReason(rs.moveReason), startTime(now()),
+    randomId(rs.traceId.isValid() ? rs.traceId : deterministicRandom()->randomUniqueID()), dataMoveId(rs.dataMoveId),
+    workFactor(0),
+    wantsNewServers(rs.retryIntent.present() ? rs.retryIntent.get().wantsNewServers
+                                             : (isDataMovementForMountainChopper(rs.moveReason) ||
+                                                isDataMovementForValleyFiller(rs.moveReason) ||
+                                                rs.moveReason == DataMovementReason::SPLIT_SHARD ||
+                                                rs.moveReason == DataMovementReason::TEAM_REDUNDANT ||
+                                                rs.moveReason == DataMovementReason::REBALANCE_STORAGE_QUEUE)),
     cancellable(true), interval("QueuedRelocation", randomId), dataMove(rs.dataMove) {
 	if (dataMove != nullptr) {
 		this->src.insert(this->src.end(), dataMove->meta.src.begin(), dataMove->meta.src.end());
@@ -138,8 +137,8 @@ Optional<KeyRange> RelocateData::getParentRange() const {
 static RelocateShard makeDestinationFailureRetry(RelocateData const& rd, UID retryTraceId) {
 	RelocateShard retry(rd.keys, rd.dmReason, rd.reason, retryTraceId);
 	retry.priority = rd.priority;
-	retry.retryIntent = RelocateShard::RetryRelocationIntent{
-		rd.boundaryPriority, rd.healthPriority, rd.wantsNewServers };
+	retry.retryIntent =
+	    RelocateShard::RetryRelocationIntent{ rd.boundaryPriority, rd.healthPriority, rd.wantsNewServers };
 	if (rd.getParentRange().present()) {
 		retry.setParentRange(rd.getParentRange().get());
 	}
@@ -148,6 +147,11 @@ static RelocateShard makeDestinationFailureRetry(RelocateData const& rd, UID ret
 
 static bool shouldRetryDestinationTeamFailure(bool doBulkLoading, RelocateData const& rd) {
 	return !doBulkLoading && !rd.isRestore();
+}
+
+static bool shouldYieldDestinationFailureRetry(RelocateData const& retry, RelocateData const& queued) {
+	bool isSplit = retry.reason == RelocateReason::SIZE_SPLIT || retry.reason == RelocateReason::WRITE_SPLIT;
+	return isSplit && retry.keys != queued.keys && retry.keys.contains(queued.keys);
 }
 
 class ParallelTCInfo final : public ReferenceCounted<ParallelTCInfo>, public IDataDistributionTeam {
@@ -829,7 +833,31 @@ void DDQueue::queueRelocation(RelocateShard rs, std::set<UID>& serversToLaunchFr
 	//TraceEvent("QueueRelocationBegin").detail("Begin", rd.keys.begin).detail("End", rd.keys.end);
 
 	// remove all items from both queues that are fully contained in the new relocation (i.e. will be overwritten)
+	bool destinationFailureRetry = rs.retryIntent.present();
 	RelocateData rd(rs);
+	if (destinationFailureRetry) {
+		auto ranges = queueMap.intersectingRanges(rd.keys);
+		for (auto r = ranges.begin(); r != ranges.end(); ++r) {
+			RelocateData const& queued = r->value();
+			if (!shouldYieldDestinationFailureRetry(rd, queued)) {
+				continue;
+			}
+
+			bool active = fetchingSourcesQueue.contains(queued);
+			if (!active && !queued.src.empty()) {
+				auto sourceQueue = queue.find(queued.src.front());
+				active = sourceQueue != queue.end() && sourceQueue->second.contains(queued);
+			}
+			if (active) {
+				TraceEvent(SevInfo, "DestinationFailureRetryYieldedToQueuedSplit", distributorId)
+				    .detail("RetryRange", rd.keys)
+				    .detail("RetryTraceID", rd.randomId)
+				    .detail("QueuedRange", queued.keys)
+				    .detail("QueuedTraceID", queued.randomId);
+				return;
+			}
+		}
+	}
 	bool hasHealthPriority = RelocateData::isHealthPriority(rd.priority);
 	bool hasBoundaryPriority = RelocateData::isBoundaryPriority(rd.priority);
 
@@ -2262,8 +2290,7 @@ Future<Void> dataDistributionRelocator(DDQueue* self,
 									rd.bulkLoadTask.get().completeAck.send(
 									    BulkLoadAck(/*unretryableError=*/true, rd.priority));
 								}
-								retryAfterDestinationTeamFailure =
-								    shouldRetryDestinationTeamFailure(doBulkLoading, rd);
+								retryAfterDestinationTeamFailure = shouldRetryDestinationTeamFailure(doBulkLoading, rd);
 								throw data_move_dest_team_not_found();
 							}
 						}
@@ -3297,6 +3324,13 @@ TEST_CASE("/DataDistribution/DDQueue/RetryDestinationTeamFailure") {
 	ASSERT(!retry.bulkLoadTask.present());
 	ASSERT(shouldRetryDestinationTeamFailure(false, rd));
 	ASSERT(!shouldRetryDestinationTeamFailure(true, rd));
+	RelocateData nested(
+	    RelocateShard(KeyRangeRef("a"_sr, "aa"_sr), DataMovementReason::SPLIT_SHARD, RelocateReason::SIZE_SPLIT));
+	ASSERT(shouldYieldDestinationFailureRetry(retry, nested));
+	ASSERT(!shouldYieldDestinationFailureRetry(retry, retry));
+	RelocateData unrelated(
+	    RelocateShard(KeyRangeRef("c"_sr, "d"_sr), DataMovementReason::SPLIT_SHARD, RelocateReason::SIZE_SPLIT));
+	ASSERT(!shouldYieldDestinationFailureRetry(retry, unrelated));
 	RelocateData restore = rd;
 	restore.dataMove = std::make_shared<DataMove>();
 	ASSERT(!shouldRetryDestinationTeamFailure(false, restore));

--- a/fdbserver/datadistributor/DataDistribution.h
+++ b/fdbserver/datadistributor/DataDistribution.h
@@ -126,6 +126,16 @@ struct RelocateShard {
 
 	UID traceId; // track the lifetime of this relocate shard
 
+	struct RetryRelocationIntent {
+		int boundaryPriority;
+		int healthPriority;
+		bool wantsNewServers;
+	};
+
+	// Retry-only overrides used when an in-flight relocation must be recreated without carrying
+	// attempt-specific state. Queue coalescing can update these independently of moveReason.
+	Optional<RetryRelocationIntent> retryIntent;
+
 	// Initialization when define is a better practice. We should avoid assignment of member after definition.
 	// static RelocateShard emptyRelocateShard() { return {}; }
 


### PR DESCRIPTION
## Summary

- retry shard relocations whose destination team disappears after move start while preserving their queue intent
- keep an active nested size/write split from being overwritten by a broader destination-failure retry
- add focused DD queue coverage for retry reconstruction and yielding behavior

## Testing

- `fdbserver_datadistributor_test --test-case /DataDistribution/DDQueue/RetryDestinationTeamFailure`
- exact `fast/MutationLogReaderCorrectness.toml` replay: seed `4216054149`, buggify off, Joshua seed `2447892971056874327` (passed at 448.159 simulated seconds)
- exact d408 reproduction before the fix failed with an oversized splittable shard; the candidate passed and emitted `DestinationFailureRetryYieldedToQueuedSplit`
- `git clang-format --diff origin/main` (no changes)
