### PR TITLE
Disable buggify for TxnTimeout test

### DIFF
--- a/tests/fast/TxnTimeout.toml
+++ b/tests/fast/TxnTimeout.toml
@@ -17,6 +17,9 @@
 #   - Transactions consistently stay open for the target duration (7 seconds)
 #   - Test passes even with concurrent Cycle workload providing background load
 
+[configuration]
+buggify = false
+
 [[knobs]]
 # Configure transaction lifetime to 15 seconds
 # At 1M versions/second rate, this equals 15,000,000 versions


### PR DESCRIPTION
`TxnTimeout::runTest` returns false when buggification is enabled, so those test runs aren't useful. This PR improves the efficiency of Joshua ensembles.