### PR TITLE
Convert `WorkerInterface.actor.h` to standard coroutines

### DIFF
--- a/design/AI-generated/FDB_NETWORK_PROTOCOL.md
+++ b/design/AI-generated/FDB_NETWORK_PROTOCOL.md
@@ -1457,7 +1457,7 @@ Serializes all endpoints directly: `waitFailure`, `getRateInfo`, `haltRatekeeper
 
 ## 13. Worker Protocol
 
-**Source:** `fdbserver/core/include/fdbserver/core/WorkerInterface.actor.h`
+**Source:** `fdbserver/core/include/fdbserver/core/WorkerInterface.h`
 
 Workers host server roles. The cluster controller sends initialization requests.
 

--- a/design/AI-generated/foundationdb_subsystem_map.md
+++ b/design/AI-generated/foundationdb_subsystem_map.md
@@ -107,7 +107,7 @@ Plus supporting code: [`fdbserver/worker/`](https://github.com/apple/foundationd
 - `ServerDBInfo` is the cluster-wide configuration broadcast. Contains: master interface, proxy lists, log system config, recovery state, latency band config.
 - Updated by CC and distributed to all workers. Workers react to changes (e.g., new proxy set).
 
-**Principal files:** [`ClusterController.actor.cpp`](https://github.com/apple/foundationdb/blob/main/fdbserver/clustercontroller/ClusterController.actor.cpp), `ClusterController.h`, [`Coordination.cpp`](https://github.com/apple/foundationdb/blob/main/fdbserver/coordinator/Coordination.cpp), [`LeaderElection.cpp`](https://github.com/apple/foundationdb/blob/main/fdbserver/core/LeaderElection.cpp), [`CoordinatedState.cpp`](https://github.com/apple/foundationdb/blob/main/fdbserver/core/CoordinatedState.cpp), [`WorkerInterface.actor.h`](https://github.com/apple/foundationdb/blob/main/fdbserver/core/include/fdbserver/core/WorkerInterface.actor.h)
+**Principal files:** [`ClusterController.actor.cpp`](https://github.com/apple/foundationdb/blob/main/fdbserver/clustercontroller/ClusterController.actor.cpp), `ClusterController.h`, [`Coordination.cpp`](https://github.com/apple/foundationdb/blob/main/fdbserver/coordinator/Coordination.cpp), [`LeaderElection.cpp`](https://github.com/apple/foundationdb/blob/main/fdbserver/core/LeaderElection.cpp), [`CoordinatedState.cpp`](https://github.com/apple/foundationdb/blob/main/fdbserver/core/CoordinatedState.cpp), [`WorkerInterface.h`](https://github.com/apple/foundationdb/blob/main/fdbserver/core/include/fdbserver/core/WorkerInterface.h)
 
 ---
 

--- a/design/AI-generated/subsystem_04_cluster_controller.md
+++ b/design/AI-generated/subsystem_04_cluster_controller.md
@@ -294,7 +294,7 @@ struct ServerDBInfo {
 
 ---
 
-## WorkerInterface -- [`WorkerInterface.actor.h`](https://github.com/apple/foundationdb/blob/main/fdbserver/core/include/fdbserver/core/WorkerInterface.actor.h)`:45-126`
+## WorkerInterface -- [`WorkerInterface.h`](https://github.com/apple/foundationdb/blob/main/fdbserver/core/include/fdbserver/core/WorkerInterface.h)`:45-126`
 
 RPCs exposed by every worker process:
 
@@ -315,5 +315,5 @@ RPCs exposed by every worker process:
 | [`fdbserver/coordinator/Coordination.cpp`](https://github.com/apple/foundationdb/blob/main/fdbserver/coordinator/Coordination.cpp) | leaderRegister, generation register, coordination |
 | [`fdbserver/core/LeaderElection.cpp`](https://github.com/apple/foundationdb/blob/main/fdbserver/core/LeaderElection.cpp) | tryBecomeLeaderInternal, candidacy, heartbeat |
 | [`fdbserver/core/CoordinatedState.cpp`](https://github.com/apple/foundationdb/blob/main/fdbserver/core/CoordinatedState.cpp) | Replicated read/write over generation registers |
-| [`fdbserver/core/include/fdbserver/core/WorkerInterface.actor.h`](https://github.com/apple/foundationdb/blob/main/fdbserver/core/include/fdbserver/core/WorkerInterface.actor.h) | WorkerInterface, ClusterControllerFullInterface |
+| [`fdbserver/core/include/fdbserver/core/WorkerInterface.h`](https://github.com/apple/foundationdb/blob/main/fdbserver/core/include/fdbserver/core/WorkerInterface.h) | WorkerInterface, ClusterControllerFullInterface |
 | `fdbserver/core/include/fdbserver/core/ServerDBInfo.h` | ServerDBInfo structure and broadcasting |

--- a/fdbserver/SimulatedCluster.cpp
+++ b/fdbserver/SimulatedCluster.cpp
@@ -39,7 +39,7 @@
 #include "fdbclient/DatabaseContext.h"
 #include "fdbserver/tester/tester.h"
 #include "fdbserver/core/FDBSimulatorProcessInfo.h"
-#include "fdbserver/core/WorkerInterface.actor.h"
+#include "fdbserver/core/WorkerInterface.h"
 #include "fdbserver/worker/Worker.h"
 #include "fdbclient/ClusterInterface.h"
 #include "fdbserver/core/Knobs.h"

--- a/fdbserver/backupworker/BackupWorker.cpp
+++ b/fdbserver/backupworker/BackupWorker.cpp
@@ -34,7 +34,7 @@
 #include "fdbserver/core/ServerDBInfo.h"
 #include "fdbserver/core/WaitFailure.h"
 #include "fdbserver/backupworker/BackupWorker.h"
-#include "fdbserver/core/WorkerInterface.actor.h"
+#include "fdbserver/core/WorkerInterface.h"
 #include "flow/Error.h"
 
 #include "flow/IRandom.h"

--- a/fdbserver/cdcproxy/CDCProxy.cpp
+++ b/fdbserver/cdcproxy/CDCProxy.cpp
@@ -37,7 +37,7 @@
 #include "fdbserver/core/ServerDBInfo.h"
 #include "fdbserver/core/SpanContextMessage.h"
 #include "fdbserver/core/WaitFailure.h"
-#include "fdbserver/core/WorkerInterface.actor.h"
+#include "fdbserver/core/WorkerInterface.h"
 #include "fdbserver/logsystem/LogSystemConsumer.h"
 #include "fdbserver/logsystem/LogSystemFactory.h"
 #include "flow/ActorCollection.h"

--- a/fdbserver/clustercontroller/ClusterController.actor.cpp
+++ b/fdbserver/clustercontroller/ClusterController.actor.cpp
@@ -36,7 +36,7 @@
 #include "fdbrpc/Locality.h"
 #include "fdbserver/core/Knobs.h"
 #include "fdbserver/core/ProcessClassRecruitment.h"
-#include "fdbserver/core/WorkerInterface.actor.h"
+#include "fdbserver/core/WorkerInterface.h"
 #include "flow/ActorCollection.h"
 #include "fdbclient/ClusterConnectionMemoryRecord.h"
 #include "fdbclient/NativeAPI.actor.h"

--- a/fdbserver/clustercontroller/ClusterController.h
+++ b/fdbserver/clustercontroller/ClusterController.h
@@ -32,7 +32,7 @@
 #include "RatekeeperMonitor.h"
 #include "fdbserver/core/Knobs.h"
 #include "fdbserver/core/ProcessClassRecruitment.h"
-#include "fdbserver/core/WorkerInterface.actor.h"
+#include "fdbserver/core/WorkerInterface.h"
 #include "fdbrpc/Locality.h"
 #include "flow/CoroUtils.h"
 #include "flow/NetworkAddress.h"

--- a/fdbserver/clustercontroller/ClusterRecovery.h
+++ b/fdbserver/clustercontroller/ClusterRecovery.h
@@ -35,7 +35,7 @@
 #include "fdbserver/logsystem/LogSystem.h"
 #include "fdbserver/core/LogSystemConfig.h"
 #include "fdbserver/logsystem/LogSystemDiskQueueAdapter.h"
-#include "fdbserver/core/WorkerInterface.actor.h"
+#include "fdbserver/core/WorkerInterface.h"
 #include "flow/CoroUtils.h"
 #include "flow/Error.h"
 #include "flow/SystemMonitor.h"

--- a/fdbserver/clustercontroller/Status.cpp
+++ b/fdbserver/clustercontroller/Status.cpp
@@ -32,7 +32,7 @@
 #include "fdbclient/SystemData.h"
 #include "fdbclient/ReadYourWrites.h"
 #include "fdbserver/core/WorkerEvents.h"
-#include "fdbserver/core/WorkerInterface.actor.h"
+#include "fdbserver/core/WorkerInterface.h"
 #include <time.h>
 #include "ClusterRecovery.h"
 #include "fdbclient/ClusterConnectionMemoryRecord.h"

--- a/fdbserver/clustercontroller/Status.h
+++ b/fdbserver/clustercontroller/Status.h
@@ -22,7 +22,7 @@
 
 #include "fdbrpc/fdbrpc.h"
 #include "fdbserver/core/CoordinationInterface.h"
-#include "fdbserver/core/WorkerInterface.actor.h"
+#include "fdbserver/core/WorkerInterface.h"
 #include "fdbserver/core/MasterInterface.h"
 #include "fdbclient/ClusterInterface.h"
 

--- a/fdbserver/commitproxy/CommitProxyServer.cpp
+++ b/fdbserver/commitproxy/CommitProxyServer.cpp
@@ -56,7 +56,7 @@
 #include "fdbserver/core/ServerDBInfo.h"
 #include "fdbserver/core/WaitFailure.h"
 #include "fdbserver/commitproxy/CommitProxyServer.h"
-#include "fdbserver/core/WorkerInterface.actor.h"
+#include "fdbserver/core/WorkerInterface.h"
 #include "flow/ActorCollection.h"
 #include "flow/CodeProbe.h"
 #include "flow/CoroUtils.h"

--- a/fdbserver/consistencyscan/ConsistencyScan.cpp
+++ b/fdbserver/consistencyscan/ConsistencyScan.cpp
@@ -25,7 +25,7 @@
 #include "fdbclient/json_spirit/json_spirit_writer_template.h"
 #include "fdbserver/consistencyscan/ConsistencyScan.h"
 #include "fdbserver/core/FDBSimulationPolicy.h"
-#include "fdbserver/core/WorkerInterface.actor.h"
+#include "fdbserver/core/WorkerInterface.h"
 #include "flow/IRandom.h"
 #include "flow/IndexedSet.h"
 #include "fdbrpc/FailureMonitor.h"

--- a/fdbserver/coordinator/Coordination.cpp
+++ b/fdbserver/coordinator/Coordination.cpp
@@ -23,7 +23,7 @@
 #include "fdbserver/coordinator/CoordinationServer.h"
 #include "fdbserver/core/Knobs.h"
 #include "OnDemandStore.h"
-#include "fdbserver/core/WorkerInterface.actor.h"
+#include "fdbserver/core/WorkerInterface.h"
 #include "flow/ActorCollection.h"
 #include "flow/ProtocolVersion.h"
 #include "flow/UnitTest.h"

--- a/fdbserver/core/OpenDatabase.cpp
+++ b/fdbserver/core/OpenDatabase.cpp
@@ -22,7 +22,7 @@
 #include "fdbclient/DatabaseContext.h"
 #include "fdbclient/GlobalConfig.h"
 #include "fdbclient/MonitorLeader.h"
-#include "fdbserver/core/WorkerInterface.actor.h"
+#include "fdbserver/core/WorkerInterface.h"
 
 static Future<Void> extractClientInfo(Reference<AsyncVar<ServerDBInfo> const> db,
                                       Reference<AsyncVar<ClientDBInfo>> info) {

--- a/fdbserver/core/QuietDatabase.cpp
+++ b/fdbserver/core/QuietDatabase.cpp
@@ -37,7 +37,7 @@
 #include "fdbclient/RunRYWTransaction.h"
 #include "fdbserver/core/Knobs.h"
 #include "fdbserver/core/QuietDatabase.h"
-#include "fdbserver/core/WorkerInterface.actor.h"
+#include "fdbserver/core/WorkerInterface.h"
 #include "fdbserver/core/FDBSimulationPolicy.h"
 #include "fdbclient/ManagementAPI.h"
 #include "flow/CoroUtils.h"

--- a/fdbserver/core/WorkerInterface.cpp
+++ b/fdbserver/core/WorkerInterface.cpp
@@ -18,7 +18,7 @@
  * limitations under the License.
  */
 
-#include "fdbserver/core/WorkerInterface.actor.h"
+#include "fdbserver/core/WorkerInterface.h"
 
 Future<Void> extractClusterInterface(Reference<AsyncVar<Optional<ClusterControllerFullInterface>> const> in,
                                      Reference<AsyncVar<Optional<ClusterInterface>>> out) {

--- a/fdbserver/core/WorkerInterfaceTests.cpp
+++ b/fdbserver/core/WorkerInterfaceTests.cpp
@@ -18,7 +18,7 @@
  * limitations under the License.
  */
 
-#include "fdbserver/core/WorkerInterface.actor.h"
+#include "fdbserver/core/WorkerInterface.h"
 
 #include "flow/ObjectSerializer.h"
 #include "flow/UnitTest.h"

--- a/fdbserver/core/include/fdbserver/core/QuietDatabase.h
+++ b/fdbserver/core/include/fdbserver/core/QuietDatabase.h
@@ -24,7 +24,7 @@
 #include "fdbclient/FDBTypes.h"
 #include "fdbclient/NativeAPI.actor.h"
 #include "fdbserver/core/TesterInterface.h"
-#include "fdbserver/core/WorkerInterface.actor.h"
+#include "fdbserver/core/WorkerInterface.h"
 
 Future<int64_t> getDataInFlight(Database cx, Reference<AsyncVar<struct ServerDBInfo> const> dbInfo);
 Future<std::pair<int64_t, int64_t>> getTLogQueueInfo(Database cx,

--- a/fdbserver/core/include/fdbserver/core/ServerDBInfo.h
+++ b/fdbserver/core/include/fdbserver/core/ServerDBInfo.h
@@ -29,7 +29,7 @@
 #include "fdbserver/core/MasterInterface.h"
 #include "fdbserver/core/RatekeeperInterface.h"
 #include "fdbserver/core/RecoveryState.h"
-#include "fdbserver/core/WorkerInterface.actor.h"
+#include "fdbserver/core/WorkerInterface.h"
 
 struct ServerDBInfo {
 	constexpr static FileIdentifier file_identifier = 13838807;

--- a/fdbserver/core/include/fdbserver/core/WorkerEvents.h
+++ b/fdbserver/core/include/fdbserver/core/WorkerEvents.h
@@ -25,7 +25,7 @@
 #include <string>
 
 #include "flow/ITrace.h"
-#include "fdbserver/core/WorkerInterface.actor.h"
+#include "fdbserver/core/WorkerInterface.h"
 
 struct WorkerEvents : std::map<NetworkAddress, TraceEventFields> {};
 

--- a/fdbserver/core/include/fdbserver/core/WorkerInterface.actor.h
+++ b/fdbserver/core/include/fdbserver/core/WorkerInterface.actor.h
@@ -19,11 +19,6 @@
  */
 
 #pragma once
-#if defined(NO_INTELLISENSE) && !defined(FDBSERVER_WORKERINTERFACE_ACTOR_G_H)
-#define FDBSERVER_WORKERINTERFACE_ACTOR_G_H
-#include "fdbserver/core/WorkerInterface.actor.g.h"
-#elif !defined(FDBSERVER_WORKERINTERFACE_ACTOR_H)
-#define FDBSERVER_WORKERINTERFACE_ACTOR_H
 
 #include "fdbserver/core/BackupInterface.h"
 #include "fdbserver/core/DataDistributorInterface.h"
@@ -43,7 +38,7 @@
 #include "fdbrpc/MultiInterface.h"
 #include "fdbclient/ClientWorkerInterface.h"
 #include "fdbserver/core/RecoveryState.h"
-#include "flow/actorcompiler.h"
+#include "flow/CoroUtils.h"
 
 struct WorkerInterface {
 	constexpr static FileIdentifier file_identifier = 14712718;
@@ -1174,42 +1169,44 @@ bool addressInDbAndRemoteDc(
 
 extern bool isSimulatorProcessUnreliable();
 
-ACTOR template <class T>
-Future<T> ioTimeoutError(Future<T> what, double time, const char* context = nullptr) {
+template <class T>
+Future<T> ioTimeoutError(Future<T> what, double time, const char* context = nullptr, ExplicitVoid = {}) {
 	// Before simulation is sped up, IO operations can take a very long time so limit timeouts
 	// to not end until at least time after simulation is sped up.
-	state double orig = now();
-	state std::string trace = platform::get_backtrace();
+	double orig = now();
+	std::string trace = platform::get_backtrace();
 	if (g_network->isSimulated() && !g_simulator->speedUpSimulation) {
 		time += std::max(0.0, FLOW_KNOBS->SIM_SPEEDUP_AFTER_SECONDS - now());
 	}
 	Future<Void> end = lowPriorityDelay(time);
-	choose {
-		when(T t = wait(what)) {
-			return t;
+	auto res = co_await race(what, end);
+	if (res.index() == 0) {
+		T t = std::get<0>(std::move(res));
+		co_return t;
+	} else if (res.index() == 1) {
+		Error err = io_timeout();
+		if (isSimulatorProcessUnreliable()) {
+			err = err.asInjectedFault();
 		}
-		when(wait(end)) {
-			Error err = io_timeout();
-			if (isSimulatorProcessUnreliable()) {
-				err = err.asInjectedFault();
-			}
-			TraceEvent e(SevError, "IoTimeoutError");
-			e.error(err);
-			if (context != nullptr) {
-				e.detail("Context", context);
-			}
-			e.detail("OrigTime", orig).detail("OrigTrace", trace).log();
-			throw err;
+		TraceEvent e(SevError, "IoTimeoutError");
+		e.error(err);
+		if (context != nullptr) {
+			e.detail("Context", context);
 		}
+		e.detail("OrigTime", orig).detail("OrigTrace", trace).log();
+		throw err;
+	} else {
+		UNREACHABLE();
 	}
 }
 
-ACTOR template <class T>
+template <class T>
 Future<T> ioDegradedOrTimeoutError(Future<T> what,
                                    double errTime,
                                    Reference<AsyncVar<bool>> degraded,
                                    double degradedTime,
-                                   const char* context = nullptr) {
+                                   const char* context = nullptr,
+                                   ExplicitVoid = {}) {
 	// Before simulation is sped up, IO operations can take a very long time so limit timeouts
 	// to not end until at least time after simulation is sped up.
 	if (g_network->isSimulated() && !g_simulator->speedUpSimulation) {
@@ -1220,39 +1217,39 @@ Future<T> ioDegradedOrTimeoutError(Future<T> what,
 
 	if (degradedTime < errTime) {
 		Future<Void> degradedEnd = lowPriorityDelay(degradedTime);
-		choose {
-			when(T t = wait(what)) {
-				return t;
-			}
-			when(wait(degradedEnd)) {
-				CODE_PROBE(true, "TLog degraded", probe::func::deduplicate);
-				TraceEvent(SevWarnAlways, "IoDegraded").log();
-				degraded->set(true);
-			}
+		auto res = co_await race(what, degradedEnd);
+		if (res.index() == 0) {
+			T t = std::get<0>(std::move(res));
+			co_return t;
+		} else if (res.index() == 1) {
+			CODE_PROBE(true, "TLog degraded", probe::func::deduplicate);
+			TraceEvent(SevWarnAlways, "IoDegraded").log();
+			degraded->set(true);
+		} else {
+			UNREACHABLE();
 		}
 	}
 
 	Future<Void> end = lowPriorityDelay(errTime - degradedTime);
-	choose {
-		when(T t = wait(what)) {
-			return t;
+	auto res = co_await race(what, end);
+	if (res.index() == 0) {
+		T t = std::get<0>(std::move(res));
+		co_return t;
+	} else if (res.index() == 1) {
+		Error err = io_timeout();
+		if (isSimulatorProcessUnreliable()) {
+			err = err.asInjectedFault();
 		}
-		when(wait(end)) {
-			Error err = io_timeout();
-			if (isSimulatorProcessUnreliable()) {
-				err = err.asInjectedFault();
-			}
-			TraceEvent e(SevError, "IoTimeoutError");
-			e.error(err);
-			if (context != nullptr) {
-				e.detail("Context", context);
-			}
-			e.log();
-			throw err;
+		TraceEvent e(SevError, "IoTimeoutError");
+		e.error(err);
+		if (context != nullptr) {
+			e.detail("Context", context);
 		}
+		e.log();
+		throw err;
+	} else {
+		UNREACHABLE();
 	}
 }
 
-#include "flow/unactorcompiler.h"
 #include "fdbserver/core/ServerDBInfo.h"
-#endif

--- a/fdbserver/core/include/fdbserver/core/WorkerInterface.h
+++ b/fdbserver/core/include/fdbserver/core/WorkerInterface.h
@@ -1,5 +1,5 @@
 /*
- * WorkerInterface.actor.h
+ * WorkerInterface.h
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdbserver/core/include/fdbserver/core/WorkerInterface.h
+++ b/fdbserver/core/include/fdbserver/core/WorkerInterface.h
@@ -78,7 +78,7 @@ struct WorkerInterface {
 	NetworkAddressList addresses() const { return tLog.getEndpoint().addresses; }
 	Optional<NetworkAddress> grpcAddress() const { return clientInterface.grpcAddress; }
 
-	WorkerInterface() {}
+	WorkerInterface() = default;
 	explicit(false) WorkerInterface(const LocalityData& locality) : locality(locality) {}
 
 	void initEndpoints() {
@@ -366,7 +366,7 @@ struct RecruitFromConfigurationRequest {
 	int maxOldLogRouters;
 	ReplyPromise<RecruitFromConfigurationReply> reply;
 
-	RecruitFromConfigurationRequest() {}
+	RecruitFromConfigurationRequest() = default;
 	explicit RecruitFromConfigurationRequest(DatabaseConfiguration const& configuration,
 	                                         bool recruitSeedServers,
 	                                         int maxOldLogRouters)
@@ -399,7 +399,7 @@ struct RecruitRemoteFromConfigurationRequest {
 	Optional<UID> dbgId;
 	ReplyPromise<RecruitRemoteFromConfigurationReply> reply;
 
-	RecruitRemoteFromConfigurationRequest() {}
+	RecruitRemoteFromConfigurationRequest() = default;
 	RecruitRemoteFromConfigurationRequest(DatabaseConfiguration const& configuration,
 	                                      Optional<Key> const& dcId,
 	                                      int logRouterCount,
@@ -545,7 +545,7 @@ struct TLogRejoinRequest {
 	TLogInterface myInterface;
 	ReplyPromise<TLogRejoinReply> reply;
 
-	TLogRejoinRequest() {}
+	TLogRejoinRequest() = default;
 	explicit TLogRejoinRequest(const TLogInterface& interf) : myInterface(interf) {}
 	template <class Ar>
 	void serialize(Ar& ar) {
@@ -586,7 +586,7 @@ struct GetEncryptionAtRestModeRequest {
 	UID tlogId;
 	ReplyPromise<GetEncryptionAtRestModeResponse> reply;
 
-	GetEncryptionAtRestModeRequest() {}
+	GetEncryptionAtRestModeRequest() = default;
 	explicit(false) GetEncryptionAtRestModeRequest(UID tId) : tlogId(tId) {}
 
 	template <class Ar>
@@ -841,7 +841,7 @@ struct InitializeDataDistributorRequest {
 	UID reqId;
 	ReplyPromise<DataDistributorInterface> reply;
 
-	InitializeDataDistributorRequest() {}
+	InitializeDataDistributorRequest() = default;
 	explicit InitializeDataDistributorRequest(UID uid) : reqId(uid) {}
 	template <class Ar>
 	void serialize(Ar& ar) {
@@ -854,7 +854,7 @@ struct InitializeRatekeeperRequest {
 	UID reqId;
 	ReplyPromise<RatekeeperInterface> reply;
 
-	InitializeRatekeeperRequest() {}
+	InitializeRatekeeperRequest() = default;
 	explicit InitializeRatekeeperRequest(UID uid) : reqId(uid) {}
 	template <class Ar>
 	void serialize(Ar& ar) {
@@ -867,7 +867,7 @@ struct InitializeConsistencyScanRequest {
 	UID reqId;
 	ReplyPromise<ConsistencyScanInterface> reply;
 
-	InitializeConsistencyScanRequest() {}
+	InitializeConsistencyScanRequest() = default;
 	explicit InitializeConsistencyScanRequest(UID uid) : reqId(uid) {}
 	template <class Ar>
 	void serialize(Ar& ar) {
@@ -1039,7 +1039,7 @@ struct DebugEntryRef {
 	StringRef context;
 	Version version;
 	MutationRef mutation;
-	DebugEntryRef() {}
+	DebugEntryRef() = default;
 	DebugEntryRef(const char* c, Version v, MutationRef const& m)
 	  : time(now()), address(g_network->getLocalAddress()), context((const uint8_t*)c, strlen(c)), version(v),
 	    mutation(m) {}

--- a/fdbserver/fdbserver.cpp
+++ b/fdbserver/fdbserver.cpp
@@ -65,7 +65,7 @@
 #include "fdbserver/core/FDBSimulationPolicy.h"
 #include "fdbserver/tester/TestEncryptionUtils.h"
 #include "fdbserver/tester/tester.h"
-#include "fdbserver/core/WorkerInterface.actor.h"
+#include "fdbserver/core/WorkerInterface.h"
 #include "fdbserver/worker/Worker.h"
 #include "fdbserver/mocks3/MockS3Server.h"
 #ifdef WITH_ROCKSDB

--- a/fdbserver/grvproxy/GrvProxyServer.cpp
+++ b/fdbserver/grvproxy/GrvProxyServer.cpp
@@ -35,7 +35,7 @@
 #include "fdbserver/logsystem/LogSystemFactory.h"
 #include "fdbserver/logsystem/LogSystemDiskQueueAdapter.h"
 #include "fdbserver/core/WaitFailure.h"
-#include "fdbserver/core/WorkerInterface.actor.h"
+#include "fdbserver/core/WorkerInterface.h"
 #include "fdbrpc/sim_validation.h"
 #include "flow/Buggify.h"
 #include "flow/IRandom.h"

--- a/fdbserver/kvstore/VersionedBTree.actor.cpp
+++ b/fdbserver/kvstore/VersionedBTree.actor.cpp
@@ -30,7 +30,7 @@
 #include "fdbserver/core/Knobs.h"
 #include "fdbserver/core/FDBSimulationPolicy.h"
 #include "VersionedBTreeDebug.h"
-#include "fdbserver/core/WorkerInterface.actor.h"
+#include "fdbserver/core/WorkerInterface.h"
 #include "flow/ActorCollection.h"
 #include "flow/CoroUtils.h"
 #include "flow/Error.h"

--- a/fdbserver/logrouter/LogRouter.cpp
+++ b/fdbserver/logrouter/LogRouter.cpp
@@ -24,7 +24,7 @@
 #include "fdbserver/logsystem/LogSystemConsumer.h"
 #include "fdbserver/logrouter/LogRouter.h"
 #include "fdbserver/logsystem/LogSystemFactory.h"
-#include "fdbserver/core/WorkerInterface.actor.h"
+#include "fdbserver/core/WorkerInterface.h"
 #include "fdbserver/core/RecoveryState.h"
 #include "fdbserver/core/TLogInterface.h"
 #include "flow/ActorCollection.h"

--- a/fdbserver/logsystem/include/fdbserver/logsystem/LogSystem.h
+++ b/fdbserver/logsystem/include/fdbserver/logsystem/LogSystem.h
@@ -41,7 +41,7 @@
 #include "fdbserver/core/OTELSpanContextMessage.h"
 #include "fdbserver/core/SpanContextMessage.h"
 #include "fdbserver/core/TLogInterface.h"
-#include "fdbserver/core/WorkerInterface.actor.h"
+#include "fdbserver/core/WorkerInterface.h"
 #include "flow/Arena.h"
 #include "flow/Error.h"
 #include "flow/ActorCollection.h"

--- a/fdbserver/resolver/Resolver.cpp
+++ b/fdbserver/resolver/Resolver.cpp
@@ -40,7 +40,7 @@
 #include "fdbserver/core/StorageMetrics.h"
 #include "fdbserver/core/WaitFailure.h"
 #include "fdbserver/resolver/Resolver.h"
-#include "fdbserver/core/WorkerInterface.actor.h"
+#include "fdbserver/core/WorkerInterface.h"
 #include "ConflictSet.h"
 #include "flow/ActorCollection.h"
 #include "flow/Error.h"

--- a/fdbserver/storageserver/storageserver.cpp
+++ b/fdbserver/storageserver/storageserver.cpp
@@ -96,7 +96,7 @@
 #include "fdbserver/core/ServerDBInfo.h"
 #include "fdbserver/core/DataMovement.h"
 #include "fdbserver/storageserver/StorageServer.h"
-#include "fdbserver/core/WorkerInterface.actor.h"
+#include "fdbserver/core/WorkerInterface.h"
 #include "StorageServerUtils.h"
 #include "flow/CoroUtils.h"
 #include "flow/TDMetric.h"

--- a/fdbserver/tester/ConsistencyChecker.cpp
+++ b/fdbserver/tester/ConsistencyChecker.cpp
@@ -36,7 +36,7 @@
 #include "fdbserver/core/Knobs.h"
 #include "fdbserver/core/MoveKeys.h"
 #include "fdbserver/core/QuietDatabase.h"
-#include "fdbserver/core/WorkerInterface.actor.h"
+#include "fdbserver/core/WorkerInterface.h"
 #include "ConsistencyChecker.h"
 #include "fdbserver/tester/workloads.h"
 

--- a/fdbserver/tester/TesterServer.cpp
+++ b/fdbserver/tester/TesterServer.cpp
@@ -34,7 +34,7 @@
 #include "fdbserver/core/FDBSimulatorProcessInfo.h"
 #include "fdbclient/NativeAPI.actor.h"
 #include "fdbserver/core/ServerDBInfo.h"
-#include "fdbserver/core/WorkerInterface.actor.h"
+#include "fdbserver/core/WorkerInterface.h"
 #include "TesterServer.h"
 #include "fdbserver/tester/workloads.h"
 

--- a/fdbserver/tester/test.cpp
+++ b/fdbserver/tester/test.cpp
@@ -41,7 +41,7 @@
 #include "fdbclient/NativeAPI.actor.h"
 #include "fdbserver/core/Knobs.h"
 #include "fdbserver/core/QuietDatabase.h"
-#include "fdbserver/core/WorkerInterface.actor.h"
+#include "fdbserver/core/WorkerInterface.h"
 #include "fdbserver/core/FDBSimulationPolicy.h"
 #include "KnobProtectiveGroups.h"
 #include "ConsistencyChecker.h"

--- a/fdbserver/tlog/TLogServer.cpp
+++ b/fdbserver/tlog/TLogServer.cpp
@@ -36,7 +36,7 @@
 #include "fdbserver/core/TLogInterface.h"
 #include "fdbserver/core/WaitFailure.h"
 #include "fdbserver/tlog/TLogServer.h"
-#include "fdbserver/core/WorkerInterface.actor.h"
+#include "fdbserver/core/WorkerInterface.h"
 #include "flow/ActorCollection.h"
 #include "fdbrpc/FailureMonitor.h"
 #include "fdbrpc/sim_validation.h"

--- a/fdbserver/tlog/TestTLogServer.cpp
+++ b/fdbserver/tlog/TestTLogServer.cpp
@@ -30,7 +30,7 @@
 #include "fdbserver/core/Knobs.h"
 #include "fdbserver/core/TLogInterface.h"
 #include "fdbserver/tlog/TLogServer.h"
-#include "fdbserver/core/WorkerInterface.actor.h"
+#include "fdbserver/core/WorkerInterface.h"
 #include "fdbserver/logsystem/LogSystem.h"
 #include "fdbserver/logsystem/LogSystemFactory.h"
 #include "flow/IRandom.h"

--- a/fdbserver/worker/RoleLineage.h
+++ b/fdbserver/worker/RoleLineage.h
@@ -22,7 +22,7 @@
 #include "fdbclient/ActorLineageProfiler.h"
 #include "fdbclient/ProcessClass.h"
 #include "fdbserver/core/ProcessClassRecruitment.h"
-#include "fdbserver/core/WorkerInterface.actor.h"
+#include "fdbserver/core/WorkerInterface.h"
 
 #include <any>
 #include <optional>

--- a/fdbserver/worker/worker.cpp
+++ b/fdbserver/worker/worker.cpp
@@ -60,7 +60,7 @@
 #include "fdbserver/logrouter/LogRouter.h"
 #include "fdbserver/core/BackupInterface.h"
 #include "RoleLineage.h"
-#include "fdbserver/core/WorkerInterface.actor.h"
+#include "fdbserver/core/WorkerInterface.h"
 #include "fdbserver/CoroFlow.h"
 #include "fdbserver/worker/Worker.h"
 #include "fdbserver/kvstore/IKeyValueStore.h"

--- a/fdbserver/workloads/DiskFailureInjection.cpp
+++ b/fdbserver/workloads/DiskFailureInjection.cpp
@@ -22,7 +22,7 @@
 #include "fdbserver/core/TesterInterface.h"
 #include "fdbserver/tester/workloads.h"
 #include "fdbrpc/simulator.h"
-#include "fdbserver/core/WorkerInterface.actor.h"
+#include "fdbserver/core/WorkerInterface.h"
 #include "fdbserver/core/QuietDatabase.h"
 #include "fdbserver/core/WorkerEvents.h"
 

--- a/fdbserver/workloads/ExcludeIncludeStorageServersWorkload.cpp
+++ b/fdbserver/workloads/ExcludeIncludeStorageServersWorkload.cpp
@@ -20,7 +20,7 @@
 
 #include "fdbclient/NativeAPI.actor.h"
 #include "fdbserver/core/TesterInterface.h"
-#include "fdbserver/core/WorkerInterface.actor.h"
+#include "fdbserver/core/WorkerInterface.h"
 #include "fdbserver/core/FDBSimulationPolicy.h"
 #include "fdbserver/tester/workloads.h"
 #include "fdbrpc/simulator.h"

--- a/fdbserver/workloads/FailoverWithSSLag.cpp
+++ b/fdbserver/workloads/FailoverWithSSLag.cpp
@@ -20,7 +20,7 @@
 
 #include "fdbclient/NativeAPI.actor.h"
 #include "fdbserver/core/TesterInterface.h"
-#include "fdbserver/core/WorkerInterface.actor.h"
+#include "fdbserver/core/WorkerInterface.h"
 #include "fdbserver/tester/workloads.h"
 #include "fdbserver/core/Knobs.h"
 #include "fdbserver/core/FDBSimulationPolicy.h"

--- a/fdbserver/workloads/HealthMetricsApi.cpp
+++ b/fdbserver/workloads/HealthMetricsApi.cpp
@@ -20,7 +20,7 @@
 
 #include "fdbserver/core/TesterInterface.h"
 #include "fdbserver/tester/workloads.h"
-#include "fdbserver/core/WorkerInterface.actor.h"
+#include "fdbserver/core/WorkerInterface.h"
 
 // NOTE: it might be simpler to test health metrics via something
 // other than simulation. Testing equivalent to what this workload does can

--- a/fdbserver/workloads/KillRegion.cpp
+++ b/fdbserver/workloads/KillRegion.cpp
@@ -20,7 +20,7 @@
 
 #include "fdbclient/NativeAPI.actor.h"
 #include "fdbserver/core/TesterInterface.h"
-#include "fdbserver/core/WorkerInterface.actor.h"
+#include "fdbserver/core/WorkerInterface.h"
 #include "fdbserver/tester/workloads.h"
 #include "fdbserver/core/FDBSimulationPolicy.h"
 #include "fdbserver/core/RecoveryState.h"

--- a/fdbserver/workloads/LogMetrics.cpp
+++ b/fdbserver/workloads/LogMetrics.cpp
@@ -25,7 +25,7 @@
 #include "fdbrpc/simulator.h"
 #include "fdbserver/core/MasterInterface.h"
 #include "fdbclient/SystemData.h"
-#include "fdbserver/core/WorkerInterface.actor.h"
+#include "fdbserver/core/WorkerInterface.h"
 #include "fdbserver/core/QuietDatabase.h"
 #include "fdbserver/core/ServerDBInfo.h"
 

--- a/fdbserver/workloads/MachineAttrition.cpp
+++ b/fdbserver/workloads/MachineAttrition.cpp
@@ -23,7 +23,7 @@
 #include "fdbclient/CoordinationInterface.h"
 #include "fdbserver/core/TesterInterface.h"
 #include "fdbserver/core/FDBSimulationPolicy.h"
-#include "fdbserver/core/WorkerInterface.actor.h"
+#include "fdbserver/core/WorkerInterface.h"
 #include "fdbserver/tester/workloads.h"
 #include "fdbrpc/simulator.h"
 #include "fdbserver/core/FDBSimulatorProcessInfo.h"

--- a/fdbserver/workloads/Ping.cpp
+++ b/fdbserver/workloads/Ping.cpp
@@ -22,7 +22,7 @@
 #include "fdbclient/NativeAPI.actor.h"
 #include "fdbserver/core/TesterInterface.h"
 #include "fdbserver/tester/workloads.h"
-#include "fdbserver/core/WorkerInterface.actor.h"
+#include "fdbserver/core/WorkerInterface.h"
 #include "fdbserver/core/QuietDatabase.h"
 
 struct PingWorkloadInterface {

--- a/fdbserver/workloads/ReadWrite.cpp
+++ b/fdbserver/workloads/ReadWrite.cpp
@@ -26,7 +26,7 @@
 #include "fdbrpc/DDSketch.h"
 #include "fdbclient/NativeAPI.actor.h"
 #include "fdbserver/core/TesterInterface.h"
-#include "fdbserver/core/WorkerInterface.actor.h"
+#include "fdbserver/core/WorkerInterface.h"
 #include "fdbserver/tester/workloads.h"
 #include "BulkSetup.h"
 #include "ReadWriteWorkload.h"

--- a/fdbserver/workloads/RemoveServersSafely.cpp
+++ b/fdbserver/workloads/RemoveServersSafely.cpp
@@ -21,7 +21,7 @@
 #include "fdbclient/NativeAPI.actor.h"
 #include "fdbserver/core/FDBSimulatorProcessInfo.h"
 #include "fdbserver/core/TesterInterface.h"
-#include "fdbserver/core/WorkerInterface.actor.h"
+#include "fdbserver/core/WorkerInterface.h"
 #include "fdbserver/core/FDBSimulationPolicy.h"
 #include "fdbserver/tester/workloads.h"
 #include "fdbrpc/simulator.h"

--- a/fdbserver/workloads/SkewedReadWrite.cpp
+++ b/fdbserver/workloads/SkewedReadWrite.cpp
@@ -25,7 +25,7 @@
 #include "fdbrpc/DDSketch.h"
 #include "fdbclient/NativeAPI.actor.h"
 #include "fdbserver/core/TesterInterface.h"
-#include "fdbserver/core/WorkerInterface.actor.h"
+#include "fdbserver/core/WorkerInterface.h"
 #include "fdbserver/tester/workloads.h"
 #include "BulkSetup.h"
 #include "ReadWriteWorkload.h"

--- a/fdbserver/workloads/SnapTest.cpp
+++ b/fdbserver/workloads/SnapTest.cpp
@@ -26,7 +26,7 @@
 #include "fdbclient/SimpleIni.h"
 #include "fdbserver/core/Knobs.h"
 #include "fdbserver/core/TesterInterface.h"
-#include "fdbserver/core/WorkerInterface.actor.h"
+#include "fdbserver/core/WorkerInterface.h"
 #include "fdbserver/core/FDBSimulationPolicy.h"
 #include "BulkSetup.h"
 #include "fdbserver/tester/workloads.h"

--- a/fdbserver/workloads/TargetedKill.cpp
+++ b/fdbserver/workloads/TargetedKill.cpp
@@ -24,7 +24,7 @@
 #include "fdbrpc/simulator.h"
 #include "fdbserver/core/MasterInterface.h"
 #include "fdbclient/SystemData.h"
-#include "fdbserver/core/WorkerInterface.actor.h"
+#include "fdbserver/core/WorkerInterface.h"
 #include "fdbserver/core/ServerDBInfo.h"
 #include "fdbserver/core/QuietDatabase.h"
 

--- a/fdbserver/workloads/Throughput.cpp
+++ b/fdbserver/workloads/Throughput.cpp
@@ -21,7 +21,7 @@
 #include "fdbrpc/DDSketch.h"
 #include "fdbclient/NativeAPI.actor.h"
 #include "fdbserver/core/TesterInterface.h"
-#include "fdbserver/core/WorkerInterface.actor.h"
+#include "fdbserver/core/WorkerInterface.h"
 #include "fdbserver/tester/workloads.h"
 #include "flow/ActorCollection.h"
 #include "fdbrpc/Smoother.h"

--- a/fdbserver/workloads/WorkerErrors.cpp
+++ b/fdbserver/workloads/WorkerErrors.cpp
@@ -22,7 +22,7 @@
 #include "fdbclient/NativeAPI.actor.h"
 #include "fdbserver/core/TesterInterface.h"
 #include "fdbserver/tester/workloads.h"
-#include "fdbserver/core/WorkerInterface.actor.h"
+#include "fdbserver/core/WorkerInterface.h"
 #include "fdbserver/core/QuietDatabase.h"
 #include "fdbserver/core/ServerDBInfo.h"
 

--- a/fdbserver/workloads/WriteBandwidth.cpp
+++ b/fdbserver/workloads/WriteBandwidth.cpp
@@ -23,7 +23,7 @@
 #include "fdbrpc/DDSketch.h"
 #include "fdbclient/NativeAPI.actor.h"
 #include "fdbserver/core/TesterInterface.h"
-#include "fdbserver/core/WorkerInterface.actor.h"
+#include "fdbserver/core/WorkerInterface.h"
 #include "fdbserver/tester/workloads.h"
 #include "BulkSetup.h"
 

--- a/fdbserver/workloads/WriteTagThrottling.cpp
+++ b/fdbserver/workloads/WriteTagThrottling.cpp
@@ -21,7 +21,7 @@
 #include "fdbserver/core/TesterInterface.h"
 #include "fdbserver/tester/workloads.h"
 #include "BulkSetup.h"
-#include "fdbserver/core/WorkerInterface.actor.h"
+#include "fdbserver/core/WorkerInterface.h"
 #include "fdbclient/NativeAPI.actor.h"
 #include "fdbclient/TagThrottle.h"
 


### PR DESCRIPTION
This PR uses the actor rewrite tool to convert `WorkerInterface.actor.h` actors to standard coroutines. Validated with 50k unfiltered Joshua tests.