### PR TITLE
Ignore stale log-router pops after single-region recovery

### DIFF
--- a/fdbserver/logsystem/LogSystem.cpp
+++ b/fdbserver/logsystem/LogSystem.cpp
@@ -372,7 +372,8 @@ Tag LogSystem::getPseudoPopTag(Tag tag, ProcessClass::ClassType type) const {
 	switch (type) {
 	case ProcessClass::LogRouterClass:
 		if (tag.locality == tagLocalityLogRouter) {
-			ASSERT(pseudoLocalities.contains(tagLocalityLogRouterMapped));
+			// A log router from an earlier multi-region epoch can still forward a delayed pop after the
+			// current epoch becomes single-region. Keep the mapped tag so the TLog can safely discard it.
 			tag.locality = tagLocalityLogRouterMapped;
 		}
 		break;

--- a/fdbserver/logsystem/LogSystemRecoveryTests.cpp
+++ b/fdbserver/logsystem/LogSystemRecoveryTests.cpp
@@ -58,6 +58,16 @@ std::tuple<int, std::vector<TLogLockResult>, bool> makeLogGroupResults(
 
 void forceLinkLogSystemRecoveryTests() {}
 
+TEST_CASE("/LogSystem/GetPseudoPopTag/LogRouterWithoutMappedLocality") {
+	LocalityData locality;
+	auto logSystem = makeReference<LogSystem>(UID(), locality, LogEpoch(1));
+	ASSERT(!logSystem->hasPseudoLocality(tagLocalityLogRouterMapped));
+
+	Tag tag = logSystem->getPseudoPopTag(Tag(tagLocalityLogRouter, 0), ProcessClass::LogRouterClass);
+	ASSERT(tag == Tag(tagLocalityLogRouterMapped, 0));
+	return Void();
+}
+
 TEST_CASE("/LogSystem/PopLogRouter/CurrentGenerationAcceptsPredecessor") {
 	constexpr Version generationStart = 100;
 	constexpr int8_t remoteTLogLocality = 1;


### PR DESCRIPTION
This PR ignores stale log-router pop requests after single-region recovery when the router locality no longer has a pseudo-pop mapping, preventing a `getPseudoPopTag` assertion.

Test failure was originally detected in a `DrUpgradeRestart-1 / DrUpgradeRestart-2` test, and the test now passes with this fix. A `/LogSystem/GetPseudoPopTag/LogRouterWithoutMappedLocality` unit test is added to avoid future regressions.