### PR TITLE
Initialize recovered TLog queue popped versions

### DIFF
--- a/fdbserver/tlog/TLogServer.cpp
+++ b/fdbserver/tlog/TLogServer.cpp
@@ -3871,6 +3871,7 @@ Future<Void> restorePersistentState(TLogData* self,
 		Version ver = BinaryReader::fromStringRef<Version>(fVers.get()[idx].value, Unversioned());
 		logData->persistentDataVersion = ver;
 		logData->persistentDataDurableVersion = ver;
+		logData->queuePoppedVersion = ver;
 		logData->version.set(ver);
 		logData->recoveryCount =
 		    BinaryReader::fromStringRef<DBRecoveryCount>(fRecoverCounts.get()[idx].value, Unversioned());
@@ -4154,6 +4155,7 @@ Future<Void> tLogStart(TLogData* self, InitializeTLogRequest req, LocalityData l
 			logData->persistentDataVersion = logData->unrecoveredBefore - 1;
 			logData->persistentDataDurableVersion = logData->unrecoveredBefore - 1;
 			logData->queueCommittedVersion.set(logData->unrecoveredBefore - 1);
+			logData->queuePoppedVersion = logData->unrecoveredBefore - 1;
 			logData->version.set(logData->unrecoveredBefore - 1);
 
 			logData->unpoppedRecoveredTagCount = req.allTags.size();

--- a/fdbserver/tlog/TLogServer.cpp
+++ b/fdbserver/tlog/TLogServer.cpp
@@ -3904,6 +3904,10 @@ Future<Void> restorePersistentState(TLogData* self,
 				logData->createTagData(
 				    tag, popped, NothingPersistent::False, PoppedRecently::False, UnpoppedRecovered::False);
 				logData->getTagData(tag)->persistentPopped = popped;
+				// Reference-spilled data can still pin disk queue entries before the restored durable version.
+				if (logData->shouldSpillByReference(tag)) {
+					logData->queuePoppedVersion = std::min(logData->queuePoppedVersion, popped);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Initialize the per-TLog queue-popped watermark at the already-durable boundary in both recovery paths:

- network recovery: `unrecoveredBefore - 1`
- persistent-state restore: restored `ver`

`QueuePoppedVersion` is an in-memory watermark; these assignments do not pop or erase the shared disk queue. Real queue pops remain monotonic.

## Failure evidence

- Step 1: `StorefrontTestRestart-1.toml`, seed `793847472`, old `7.4.5` source `27f7192f47c366c7f668f79f1de23e05fecd8959`, simulated `92.1282`, passes
- step 2: seed `793847473`, reaches `Unable to perform consistency check` at simulated `20104.591987`, then `TracedTooManyLines` at `22485.983894`

The trace directly correlates recovery to the false quieting lag: `TLogRecover Unrecovered=482034604` is followed by `TLogMetrics PersistentDataDurableVersion=482034603 QueuePoppedVersion=0`; later recovery reports `Unrecovered=14601779945` with a zero popped version. Quieting repeatedly fails on `MaxTLogPoppedVersionLag`.

A current-main-family replay passes the schedule but still exposes the product behavior (104 zero-popped recovered-log samples, maximum apparent lag 485,926,950), so this is not inferred from a single cross-revision pass. Focused recovery also demonstrated the second path: `TLogPersistentStateRestore Ver=329518666` immediately followed by `TLogMetrics QueuePoppedVersion=0`. Initializing both construction paths removes that reset.