### PR TITLE
Keep pre-7.4 snapshot restart tests single-region

### DIFF
--- a/tests/restarting/from_7.3.0_until_7.4.0/SnapCycleRestart-1.toml
+++ b/tests/restarting/from_7.3.0_until_7.4.0/SnapCycleRestart-1.toml
@@ -10,6 +10,7 @@ datacenters=1
 [[test]]
 testTitle="SnapCyclePre"
 clearAfterTest=false
+disabledFailureInjectionWorkloads='Attrition'
 
     [[test.workload]]
     testName="Cycle"

--- a/tests/restarting/from_7.3.0_until_7.4.0/SnapCycleRestart-1.toml
+++ b/tests/restarting/from_7.3.0_until_7.4.0/SnapCycleRestart-1.toml
@@ -3,6 +3,9 @@ storageEngineExcludeTypes=[3,4,5]
 logAntiQuorum=0
 encryptModes=['disabled']
 tenantModes=['disabled']
+# Snapshot restore only supports one region; keep the 7.3 step from creating remote or satellite TLogs.
+generateFearless=false
+datacenters=1
 
 [[test]]
 testTitle="SnapCyclePre"

--- a/tests/restarting/from_7.3.0_until_7.4.0/SnapTestAttrition-1.toml
+++ b/tests/restarting/from_7.3.0_until_7.4.0/SnapTestAttrition-1.toml
@@ -3,10 +3,14 @@ storageEngineExcludeTypes=[3,4,5]
 logAntiQuorum=0
 encryptModes=['disabled']
 tenantModes=['disabled']
+# Snapshot restore only supports one region; keep the 7.3 step from creating remote or satellite TLogs.
+generateFearless=false
+datacenters=1
 
 [[test]]
 testTitle="SnapTestPre"
 clearAfterTest=false
+disabledFailureInjectionWorkloads='Attrition'
 
         [[test.workload]]
         testName="SnapTest"
@@ -17,6 +21,7 @@ clearAfterTest=false
 [[test]]
 testTitle="SnapTestTakeSnap"
 clearAfterTest=false
+disabledFailureInjectionWorkloads='Attrition'
 
         [[test.workload]]
         testName="ReadWrite"
@@ -44,6 +49,7 @@ clearAfterTest=false
 [[test]]
 testTitle="SnapTestPost"
 clearAfterTest=false
+disabledFailureInjectionWorkloads='Attrition'
 
         [[test.workload]]
         testName="SnapTest"

--- a/tests/restarting/from_7.3.0_until_7.4.0/SnapTestRestart-1.toml
+++ b/tests/restarting/from_7.3.0_until_7.4.0/SnapTestRestart-1.toml
@@ -3,10 +3,14 @@ storageEngineExcludeTypes=[3,4,5]
 logAntiQuorum=0
 encryptModes=['disabled']
 tenantModes=['disabled']
+# Snapshot restore only supports one region; keep the 7.3 step from creating remote or satellite TLogs.
+generateFearless=false
+datacenters=1
 
 [[test]]
 testTitle="SnapTestPre"
 clearAfterTest=false
+disabledFailureInjectionWorkloads='Attrition'
 
         [[test.workload]]
         testName="SnapTest"
@@ -17,6 +21,7 @@ clearAfterTest=false
 [[test]]
 testTitle="SnapTestTakeSnap"
 clearAfterTest=false
+disabledFailureInjectionWorkloads='Attrition'
 
         [[test.workload]]
         testName="ReadWrite"
@@ -40,6 +45,7 @@ clearAfterTest=false
 [[test]]
 testTitle="SnapTestPost"
 clearAfterTest=false
+disabledFailureInjectionWorkloads='Attrition'
 
         [[test.workload]]
         testName="SnapTest"

--- a/tests/restarting/from_7.3.0_until_7.4.0/SnapTestSimpleRestart-1.toml
+++ b/tests/restarting/from_7.3.0_until_7.4.0/SnapTestSimpleRestart-1.toml
@@ -3,10 +3,14 @@ storageEngineExcludeTypes=[3,4,5]
 logAntiQuorum=0
 encryptModes=['disabled']
 tenantModes=['disabled']
+# Snapshot restore only supports one region; keep the 7.3 step from creating remote or satellite TLogs.
+generateFearless=false
+datacenters=1
 
 [[test]]
 testTitle="SnapSimplePre"
 clearAfterTest=false
+disabledFailureInjectionWorkloads='Attrition'
 
         [[test.workload]]
         testName="SnapTest"
@@ -17,6 +21,7 @@ clearAfterTest=false
 [[test]]
 testTitle="SnapSimpleTakeSnap"
 clearAfterTest=false
+disabledFailureInjectionWorkloads='Attrition'
 
         [[test.workload]]
         testName="SnapTest"
@@ -27,6 +32,7 @@ clearAfterTest=false
 [[test]]
 testTitle="SnapSimplePost"
 clearAfterTest=false
+disabledFailureInjectionWorkloads='Attrition'
 
         [[test.workload]]
         testName="SnapTest"
@@ -36,6 +42,7 @@ clearAfterTest=false
 
 [[test]]
 testTitle="SnapCreateNotWhitelistedBinaryPath"
+disabledFailureInjectionWorkloads='Attrition'
 
         [[test.workload]]
         testName="SnapTest"


### PR DESCRIPTION
## Summary

Keep the pre-7.4 `SnapCycleRestart` step single-region. FoundationDB 7.3 snapshots deliberately omit satellite and remote TLogs (`allLocalLogs(false)`), while simulated snapshot restore explicitly forces `usable_regions=1`; allowing this test to generate a multi-region topology can therefore leave an unrecoverable TLog generation and time out setting the starting configuration.

`generateFearless=false` and `datacenters=1` are both understood by every supported 7.3 binary and together prevent region generation while retaining ordinary redundancy, engine, buggify, and fault-injection coverage.