### PR TITLE
Fix GetMappedRange selector pagination assertions

### DIFF
--- a/fdbserver/workloads/GetMappedRange.cpp
+++ b/fdbserver/workloads/GetMappedRange.cpp
@@ -565,31 +565,20 @@ struct GetMappedRangeWorkload : ApiWorkload {
 	Future<Void> checkMappedSelectorBoundaries(Database cx, Key mapper, GetMappedRangeWorkload* self) {
 		Key begin = indexEntryKey(10);
 		Key end = indexEntryKey(20);
-		MappedRangeResult greaterThan =
-		    co_await scanMappedRangeWithLimits(cx,
-		                                       KeySelector(firstGreaterThan(begin), begin.arena()),
-		                                       KeySelector(firstGreaterThan(end), end.arena()),
-		                                       mapper,
-		                                       /*limit=*/100,
-		                                       /*byteLimit=*/100000,
-		                                       /*expectedBeginId=*/11,
-		                                       self,
-		                                       /*allMissing=*/false);
-		ASSERT_EQ(greaterThan.size(), 10);
-		ASSERT(!greaterThan.more);
-
-		MappedRangeResult offsets =
-		    co_await scanMappedRangeWithLimits(cx,
-		                                       KeySelector(firstGreaterOrEqual(begin) + 2, begin.arena()),
-		                                       KeySelector(firstGreaterOrEqual(end) - 2, end.arena()),
-		                                       mapper,
-		                                       /*limit=*/100,
-		                                       /*byteLimit=*/100000,
-		                                       /*expectedBeginId=*/12,
-		                                       self,
-		                                       /*allMissing=*/false);
-		ASSERT_EQ(offsets.size(), 6);
-		ASSERT(!offsets.more);
+		co_await checkMappedSelectorRange(cx,
+		                                  KeySelector(firstGreaterThan(begin), begin.arena()),
+		                                  KeySelector(firstGreaterThan(end), end.arena()),
+		                                  mapper,
+		                                  /*expectedBeginId=*/11,
+		                                  /*expectedEndId=*/21,
+		                                  self);
+		co_await checkMappedSelectorRange(cx,
+		                                  KeySelector(firstGreaterOrEqual(begin) + 2, begin.arena()),
+		                                  KeySelector(firstGreaterOrEqual(end) - 2, end.arena()),
+		                                  mapper,
+		                                  /*expectedBeginId=*/12,
+		                                  /*expectedEndId=*/18,
+		                                  self);
 
 		co_await checkEmptyMappedRangeDoesNotConflict(cx,
 		                                              KeySelector(firstGreaterOrEqual(begin), begin.arena()),
@@ -619,6 +608,39 @@ struct GetMappedRangeWorkload : ApiWorkload {
 		}
 		ASSERT(specialKeyRejected);
 		co_return;
+	}
+
+	Future<Void> checkMappedSelectorRange(Database cx,
+	                                      KeySelector begin,
+	                                      KeySelector end,
+	                                      Key mapper,
+	                                      int expectedBeginId,
+	                                      int expectedEndId,
+	                                      GetMappedRangeWorkload* self) {
+		int expectedId = expectedBeginId;
+		while (true) {
+			MappedRangeResult result = co_await scanMappedRangeWithLimits(cx,
+			                                                              begin,
+			                                                              end,
+			                                                              mapper,
+			                                                              /*limit=*/100,
+			                                                              /*byteLimit=*/100000,
+			                                                              expectedId,
+			                                                              self,
+			                                                              /*allMissing=*/false);
+			expectedId += result.size();
+			ASSERT_LE(expectedId, expectedEndId);
+			if (!result.more) {
+				break;
+			}
+			if (result.readThrough.present()) {
+				begin = KeySelector(firstGreaterOrEqual(result.readThrough.get()), result.arena());
+			} else {
+				ASSERT(!result.empty());
+				begin = KeySelector(firstGreaterThan(result.back().key), result.arena());
+			}
+		}
+		ASSERT_EQ(expectedId, expectedEndId);
 	}
 
 	Future<Void> _start(Database cx, GetMappedRangeWorkload* self) {


### PR DESCRIPTION
## Summary

Fix the GetMappedRange selector-boundary workload so it correctly handles a conservative top-level `MappedRangeResult.more` value. A byte/shard boundary may set `more` even when no keys remain; asserting `!more` after the first page caused a deterministic post-recovery failure.

The selector checks now paginate with `readThrough` or the last returned key, validate every mapped row and secondary range, reject extra rows, and require the exact final ID counts. This preserves the original selector/content coverage.

## Evidence

- Original Joshua job: 858,035 passes, one `tests/fast/GetMappedRange.toml` failure (buggify/fault injection on, remote-double/single-region/satellites/ShardedRocksDB/TSS).
- Exact replay reproduced the failure and showed the first selector page contained all ten valid rows (`indexSize=101`, `size=10`, `more=1`) before `ASSERT(!greaterThan.more)`.
- The `RangeResult` contract explicitly permits `more=true` with no remaining keys (including shard boundaries); the index-prefetch buggify was active. An independent earlier GetMappedRange failure (`RandomSeed=3993203668`) had the same signature.

## Validation

- Patched exact replay: passed with the same topology/recovery shape and demonstrated `10/more=1 -> 0/more=0`; offset selectors returned exactly six rows.
- Focused Joshua job with filter `GetMappedRange\\.toml$`: 49,935 passed, zero failed, 65 long-tail tests still running at publication.
