### PR TITLE
Fix Redwood commit cancellation lifetime crash

### DIFF
--- a/fdbrpc/FlowTests.actor.cpp
+++ b/fdbrpc/FlowTests.actor.cpp
@@ -30,6 +30,7 @@
 #include "flow/IThreadPool.h"
 #include "flow/WriteOnlySet.h"
 #include "fdbrpc/fdbrpc.h"
+#include "fdbrpc/AsyncFileNonDurable.h"
 #include "flow/IAsyncFile.h"
 #include "flow/TLSConfig.h"
 #include "fdbrpc/grpc/AsyncTaskExecutor.h"
@@ -337,6 +338,17 @@ TEST_CASE("/flow/flow/cancel1") {
 	       test.isError() && test.getError().code() == error_code_actor_cancelled);
 	ASSERT(p.getPromiseReferenceCount() == 1 && p.getFutureReferenceCount() == 0);
 
+	return Void();
+}
+
+TEST_CASE("/fdbrpc/asyncFileNonDurable/sendErrorOnShutdownCancellation") {
+	Promise<Void> input;
+	Future<Void> wrapped = sendErrorOnShutdown(input.getFuture());
+	ASSERT(input.getFutureReferenceCount() > 0);
+	wrapped.cancel();
+	ASSERT(wrapped.isReady() && wrapped.isError() && wrapped.getError().code() == error_code_actor_cancelled);
+	ASSERT_EQ(input.getFutureReferenceCount(), 0);
+	input.send(Void());
 	return Void();
 }
 

--- a/fdbrpc/include/fdbrpc/AsyncFileNonDurable.h
+++ b/fdbrpc/include/fdbrpc/AsyncFileNonDurable.h
@@ -39,7 +39,7 @@ extern Future<Void> waitShutdownSignal();
 template <class T>
 Future<T> sendErrorOnShutdown(Future<T> in, bool assertOnCancel = false) {
 	try {
-		auto res = co_await race(waitShutdownSignal(), in);
+		auto res = co_await race(waitShutdownSignal(), std::move(in));
 		if (res.index() == 0) {
 			throw io_error().asInjectedFault();
 		} else {

--- a/flow/CoroTests.cpp
+++ b/flow/CoroTests.cpp
@@ -2878,6 +2878,8 @@ TEST_CASE("/flow/coro/raceSuccess") {
 	auto result = co_await raced;
 	ASSERT_EQ(result.index(), 1);
 	ASSERT_EQ(std::get<1>(result), "winner");
+	ASSERT_EQ(intPromise.getFutureReferenceCount(), 0);
+	ASSERT_EQ(stringPromise.getFutureReferenceCount(), 0);
 	co_return;
 }
 
@@ -2903,6 +2905,8 @@ TEST_CASE("/flow/coro/raceError") {
 	} catch (Error const& e) {
 		ASSERT_EQ(e.code(), error_code_io_error);
 	}
+	ASSERT_EQ(intPromise.getFutureReferenceCount(), 0);
+	ASSERT_EQ(stringPromise.getFutureReferenceCount(), 0);
 	co_return;
 }
 
@@ -2914,6 +2918,8 @@ TEST_CASE("/flow/coro/raceCancel") {
 	ASSERT(raced.isReady());
 	ASSERT(raced.isError());
 	ASSERT_EQ(raced.getError().code(), error_code_actor_cancelled);
+	ASSERT_EQ(intPromise.getFutureReferenceCount(), 0);
+	ASSERT_EQ(stringPromise.getFutureReferenceCount(), 0);
 	intPromise.send(1);
 	stringPromise.send("late");
 	ASSERT_EQ(raced.getError().code(), error_code_actor_cancelled);

--- a/flow/include/flow/CoroUtils.h
+++ b/flow/include/flow/CoroUtils.h
@@ -348,14 +348,21 @@ struct RaceImplActor final : Actor<Result>,
 
 	template <std::size_t Idx, class T>
 	void finish(T&& value) {
+		Result result(std::in_place_index<Idx>, std::forward<T>(value));
 		this->actor_wait_state = ACTOR_WAIT_STATE_NOT_WAITING;
 		RaceImplCallback<RaceImplActor<Result, Futures...>, 0, Futures...>::removeCallbacks();
-		this->SAV<Result>::sendAndDelPromiseRef(Result(std::in_place_index<Idx>, std::forward<T>(value)));
+		{
+			auto futuresToRelease = std::move(futures);
+		}
+		this->SAV<Result>::sendAndDelPromiseRef(std::move(result));
 	}
 
 	void fail(Error e) {
 		this->actor_wait_state = ACTOR_WAIT_STATE_NOT_WAITING;
 		RaceImplCallback<RaceImplActor<Result, Futures...>, 0, Futures...>::removeCallbacks();
+		{
+			auto futuresToRelease = std::move(futures);
+		}
 		this->SAV<Result>::sendErrorAndDelPromiseRef(e);
 	}
 
@@ -364,6 +371,9 @@ struct RaceImplActor final : Actor<Result>,
 		this->actor_wait_state = ACTOR_WAIT_STATE_CANCELLED;
 		if (actorWaitStateIsWaiting(waitState)) {
 			RaceImplCallback<RaceImplActor<Result, Futures...>, 0, Futures...>::removeCallbacks();
+			{
+				auto futuresToRelease = std::move(futures);
+			}
 			this->SAV<Result>::sendErrorAndDelPromiseRef(actor_cancelled());
 		}
 	}


### PR DESCRIPTION
This PR fixes a Redwood segfault caused by coroutine race inputs outliving pager/cache teardown.

The fix is to release race-input futures before notifying continuations and move the async-file future into the race, preventing stale eviction callbacks after cancellation.

Validation:
- Coroutine race and async-file cancellation tests pass
- Focused Redwood tests pass
- Previously failing `WriteTagThrottling` seed passes