### PR TITLE
Recheck DD team health after storage failure suppression

### DIFF
--- a/fdbserver/datadistributor/DDTeamCollection.actor.cpp
+++ b/fdbserver/datadistributor/DDTeamCollection.actor.cpp
@@ -1099,6 +1099,10 @@ public:
 				if (!self->initialFailureReactionDelay.isReady()) {
 					change.push_back(self->initialFailureReactionDelay);
 				}
+				if (!badTeam) {
+					// SS failure suppression changes effective team health without changing server status.
+					change.push_back(self->healthyZone.onChange());
+				}
 				change.push_back(self->zeroHealthyTeams->onChange());
 
 				bool healthy = !badTeam && !anyUndesired && serversLeft == team->size();
@@ -7124,6 +7128,32 @@ public:
 		recruitment.cancel();
 		co_await delay(0);
 	}
+
+	static Future<Void> TeamTracker_RechecksHealthyZone() {
+		Reference<IReplicationPolicy> policy = makeReference<PolicyAcross>(3, "zoneid", makeReference<PolicyOne>());
+		auto collection = testTeamCollection(3, policy, 3);
+		const UID failedServer(1, 0);
+
+		collection->healthyZone.set(ignoreSSFailuresZoneString);
+		collection->server_status.set(
+		    failedServer,
+		    ServerStatus(IsFailed::True,
+		                 IsUndesired::False,
+		                 IsWiggling::False,
+		                 collection->server_info[failedServer]->getLastKnownInterface().locality));
+		collection->addTeam(std::set<UID>({ failedServer, UID(2, 0), UID(3, 0) }), IsInitialTeam::True);
+		co_await delay(0.1);
+
+		ASSERT_EQ(collection->teams.size(), 1);
+		ASSERT(collection->teams.front()->isHealthy());
+		ASSERT_EQ(collection->teams.front()->getPriority(), SERVER_KNOBS->PRIORITY_TEAM_HEALTHY);
+
+		collection->healthyZone.set(Optional<Key>());
+		co_await delay(0.1);
+
+		ASSERT(!collection->teams.front()->isHealthy());
+		ASSERT_EQ(collection->teams.front()->getPriority(), SERVER_KNOBS->PRIORITY_TEAM_2_LEFT);
+	}
 };
 
 TEST_CASE("DataDistribution/AddTeamsBestOf/UseMachineID") {
@@ -7285,5 +7315,10 @@ TEST_CASE("/DataDistribution/GetTeam/PreferWithinShardRange") {
 
 TEST_CASE("/DataDistribution/Recruitment/RecruitmentFailedCooldownReleasesId") {
 	wait(DDTeamCollectionUnitTest::InitializeStorage_RecruitmentFailedCooldownReleasesId());
+	return Void();
+}
+
+TEST_CASE("/DataDistribution/TeamTracker/RechecksHealthyZone") {
+	wait(DDTeamCollectionUnitTest::TeamTracker_RechecksHealthyZone());
 	return Void();
 }


### PR DESCRIPTION
## Summary

`TaskBucketCorrectness.toml` seed `2822800647` can leave DD stuck after storage-server-failure suppression clears. A removing storage server remains failed in `server_status`, but teams that were recomputed while `ignoreSSFailures` was active stay marked healthy because `teamTracker` never waits on `healthyZone.onChange()`. DD can then select the failed server as a destination and wait indefinitely for 2 of 3 destinations; its tags never pop, the old TLog generation remains, and recovery times out in `ALL_LOGS_RECRUITED`.

Wake normal team trackers whenever the healthy zone changes, and add a regression that keeps one member failed across suppression clearing and verifies the team immediately returns to `PRIORITY_TEAM_2_LEFT`.

## Evidence

The original managed artifact and the current integrated artifact both reproduced the same execution: data move `a806dea072a89702`, failed destination `8e6e1505377c8603`, repeated `FinishMoveShardsDestNotReady ReadyCount=2 DestCount=3`, tags `0:2,0:7` unpopped, and the state-7 QuietDatabase timeout.

```text
-f fast/TaskBucketCorrectness.toml -s 2822800647 -b on
JOSHUA_SEED=5182354897112460822
```

BUGGIFY and fault injection were enabled with the same triple/ssd-2/single-region configuration. The replay passed (`TestUID=5264773e-d556-4691-ae5b-bb56b7c97b12`, simulated 128.876s, runtime 6.44s). The trace shows all 15 teams containing the failed server transition priority 140 -> 709 immediately after suppression clears, a new full-range move selects three healthy destinations and finishes, both tags pop, and `TrackTLogRecovery FinalUpdate=1 NewState.OldTLogs=0`.

## Validation

- Managed Clang/Release/Werror DD compilation and actorcompiler_py/mono comparison completed successfully.
- `fdbserver_datadistributor_test --filter /DataDistribution/TeamTracker/RechecksHealthyZone --seed 10626704996795760097`: **1/1 passed**.
- `fdbserver -r unittests -f /DataDistribution/TeamTracker/RechecksHealthyZone`: **1/1 passed**.
- `fdbserver -r unittests -f /DataDistribution/Recruitment/RecruitmentFailedCooldownReleasesId`: **1/1 passed**.
- `fdbserver_datadistributor_test --filter /DataDistribution/DDQueue`: **5/5 passed** (seed `15598930838175719756`).
- Exact managed Joshua tuple above: **passed**.

The generic managed build wrapper on this worker reports exit 1 after a successful link because its post-build/cache bookkeeping path is faulty; the directly verified managed binaries and exact replay are the source-level validation.
