### PR TITLE
Preserve Native CDC configuration during controller failover

### DIFF
--- a/fdbclient/NativeCdc.cpp
+++ b/fdbclient/NativeCdc.cpp
@@ -394,10 +394,12 @@ Future<CDCStreamId> registerNativeCdcStream(Database cx, Key name, KeyRange keys
 
 			// Disabling CDC stops new admission, but existing registrations and
 			// owner repair must remain available so durable streams can drain.
-			validateNativeCdcEnabled(cx->clientInfo->get().nativeCdcEnabled);
+			const bool nativeCdcEnabled = cx->clientInfo->get().nativeCdcEnabled;
+			const int nativeCdcTagCount = cx->clientInfo->get().nativeCdcTagCount;
+			validateNativeCdcEnabled(nativeCdcEnabled);
 			NativeCdcIdentifierAllocator allocator;
 			co_await observeNativeCdcMetadata(&tr, &allocator);
-			const auto [streamId, tag] = allocator.allocate(cx->clientInfo->get().nativeCdcTagCount);
+			const auto [streamId, tag] = allocator.allocate(nativeCdcTagCount);
 			// The read version is a conservative lower bound for tag routing.
 			// The versionstamped minimum below is the commit version, and stream
 			// initialization takes their maximum before exposing mutations.

--- a/fdbserver/clustercontroller/ClusterController.actor.cpp
+++ b/fdbserver/clustercontroller/ClusterController.actor.cpp
@@ -124,6 +124,8 @@ ClusterControllerData::ClusterControllerData(ClusterControllerFullInterface cons
 	serverInfo.masterLifetime.ccID = id;
 	serverInfo.clusterInterface = ccInterface;
 	serverInfo.myLocality = locality;
+	serverInfo.client.nativeCdcEnabled = CLIENT_KNOBS->ENABLE_NATIVE_CDC;
+	serverInfo.client.nativeCdcTagCount = CLIENT_KNOBS->NATIVE_CDC_TAG_COUNT;
 	db.serverInfo->set(serverInfo);
 	cx = openDBOnServer(db.serverInfo, TaskPriority::DefaultEndpoint, LockAware::True);
 
@@ -3476,6 +3478,18 @@ void addProcessesToSameDC(ClusterControllerData& self, const std::vector<Network
 		const bool added = self.addr_locality.insert({ process, locality }).second;
 		ASSERT(added);
 	}
+}
+
+TEST_CASE("/NativeCDC/ClusterControllerBootstrapPublishesConfiguration") {
+	ClusterControllerData data(ClusterControllerFullInterface(),
+	                           LocalityData(),
+	                           ServerCoordinators(Reference<IClusterConnectionRecord>(
+	                               new ClusterConnectionMemoryRecord(ClusterConnectionString()))),
+	                           makeReference<AsyncVar<Optional<UID>>>());
+
+	ASSERT_EQ(data.db.serverInfo->get().client.nativeCdcEnabled, CLIENT_KNOBS->ENABLE_NATIVE_CDC);
+	ASSERT_EQ(data.db.serverInfo->get().client.nativeCdcTagCount, CLIENT_KNOBS->NATIVE_CDC_TAG_COUNT);
+	return Void();
 }
 
 TEST_CASE("/fdbserver/clustercontroller/ignoreStaleWorkerRegistration") {

--- a/fdbserver/clustercontroller/ClusterController.actor.cpp
+++ b/fdbserver/clustercontroller/ClusterController.actor.cpp
@@ -3480,18 +3480,6 @@ void addProcessesToSameDC(ClusterControllerData& self, const std::vector<Network
 	}
 }
 
-TEST_CASE("/NativeCDC/ClusterControllerBootstrapPublishesConfiguration") {
-	ClusterControllerData data(ClusterControllerFullInterface(),
-	                           LocalityData(),
-	                           ServerCoordinators(Reference<IClusterConnectionRecord>(
-	                               new ClusterConnectionMemoryRecord(ClusterConnectionString()))),
-	                           makeReference<AsyncVar<Optional<UID>>>());
-
-	ASSERT_EQ(data.db.serverInfo->get().client.nativeCdcEnabled, CLIENT_KNOBS->ENABLE_NATIVE_CDC);
-	ASSERT_EQ(data.db.serverInfo->get().client.nativeCdcTagCount, CLIENT_KNOBS->NATIVE_CDC_TAG_COUNT);
-	return Void();
-}
-
 TEST_CASE("/fdbserver/clustercontroller/ignoreStaleWorkerRegistration") {
 	ClusterControllerData data(ClusterControllerFullInterface(),
 	                           LocalityData(),


### PR DESCRIPTION
## Summary

This PR fixes a Native CDC startup race during cluster-controller failover. A freshly elected controller can broadcast bootstrap `ServerDBInfo` with `nativeCdcTagCount=0` while an existing CDC proxy is registering a stream; registration checks `nativeCdcEnabled`, awaits metadata, then previously reread the replacement tag count and failed with `invalid_option_value` (2006).

- seed the bootstrap server-side CDC fields from the configured client knobs
- snapshot enabled/tag-count together before the registration await
- add a focused bootstrap regression without weakening shared-tag coverage

## Failure and validation

Reproduced failed Joshua test `20260718-104347-joshua-proxy-9ab21403d3930b23` using the exact `NativeCdcSharedTag.toml` tuple.

The original binary deterministically failed at the second controller change; the fixed binary passed the identical generated configuration three times (`Ok=1`, 234.454 simulated seconds), with no `invalid_option_value`, 2006, or workload-start failures. Managed validation also passed all 23 `/NativeCDC/` unit cases and all 23 `/fdbserver/clustercontroller` cases.