### PR TITLE
Report remote storage in aggregate health metrics

### DIFF
--- a/fdbserver/ratekeeper/Ratekeeper.cpp
+++ b/fdbserver/ratekeeper/Ratekeeper.cpp
@@ -662,7 +662,18 @@ void Ratekeeper::updateRate(RatekeeperLimits* limits) {
 	// ratio
 	for (auto i = storageQueueInfo.begin(); i != storageQueueInfo.end(); ++i) {
 		auto const& ss = i->value;
-		if (!ss.valid || !ss.acceptingRequests || (remoteDC.present() && ss.locality.dcId() == remoteDC)) {
+		if (!ss.valid || !ss.acceptingRequests) {
+			continue;
+		}
+
+		int64_t storageQueue = ss.getStorageQueueBytes();
+		worstStorageQueueStorageServer = std::max(worstStorageQueueStorageServer, storageQueue);
+
+		int64_t storageDurabilityLag = ss.getDurabilityLag();
+		worstDurabilityLag = std::max(worstDurabilityLag, storageDurabilityLag);
+
+		// Remote storage is reported in health metrics but is not used to rate-limit the primary region.
+		if (remoteDC.present() && ss.locality.dcId() == remoteDC) {
 			continue;
 		}
 		++sscount;
@@ -696,12 +707,6 @@ void Ratekeeper::updateRate(RatekeeperLimits* limits) {
 				    .detail("MinFreeSpace", minFreeSpace);
 			}
 		}
-
-		int64_t storageQueue = ss.getStorageQueueBytes();
-		worstStorageQueueStorageServer = std::max(worstStorageQueueStorageServer, storageQueue);
-
-		int64_t storageDurabilityLag = ss.getDurabilityLag();
-		worstDurabilityLag = std::max(worstDurabilityLag, storageDurabilityLag);
 
 		storageDurabilityLagReverseIndex.insert(std::make_pair(-1 * storageDurabilityLag, &ss));
 


### PR DESCRIPTION
## Summary

Ratekeeper excludes remote-region storage servers before computing the aggregate worst storage queue and durability lag, even though detailed health metrics include them. During two-region recovery this can report `worst_storage_queue=0` while a live remote storage server has more than 100 MB queued, causing `WriteTagThrottling` to fail with `IncorrectHealthMetricsState`.

Compute the two worst-storage aggregates before the remote-region filter while preserving that filter for all rate limiting and limiting metrics. Invalid or non-accepting storage servers remain excluded.

## Validation

- Replayed the exact failed test and seed : reproduced all 8 original errors
- Built the exact candidate plus this patch remotely with clang: `fdbserver` linked successfully
- Replayed `tests/rare/WriteTagThrottling.toml` with the same seed/topology: 2 passed, 0 failed, 0 SevError; identical simulated runtime and transaction metrics, with aggregate queue corrected.
- Passed an adjacent WriteTagThrottling seed and `tests/rare/Throttling.toml` with buggify/fault injection enabled; no error events.