### PR TITLE
Coordinate Attrition targets within a test phase

### DIFF
--- a/fdbserver/workloads/MachineAttrition.cpp
+++ b/fdbserver/workloads/MachineAttrition.cpp
@@ -32,6 +32,9 @@
 #include "flow/DeterministicRandom.h"
 #include "fdbrpc/SimulatorProcessInfo.h"
 
+#include <algorithm>
+#include <memory>
+
 static std::set<int> const& normalAttritionErrors() {
 	static std::set<int> s;
 	if (s.empty()) {
@@ -65,6 +68,73 @@ Future<bool> ignoreSSFailuresForDuration(Database cx, double duration) {
 	}
 }
 
+class MachineAttritionPhase {
+public:
+	using Owner = uint64_t;
+
+	static std::shared_ptr<MachineAttritionPhase> get(int64_t phaseId) {
+		static std::map<int64_t, std::weak_ptr<MachineAttritionPhase>> phases;
+		for (auto it = phases.begin(); it != phases.end();) {
+			if (it->second.expired()) {
+				it = phases.erase(it);
+			} else {
+				++it;
+			}
+		}
+
+		auto& phase = phases[phaseId];
+		if (auto existing = phase.lock()) {
+			return existing;
+		}
+		auto created = std::shared_ptr<MachineAttritionPhase>(new MachineAttritionPhase());
+		phase = created;
+		return created;
+	}
+
+	Owner registerWorkload(int machinesToLeave) {
+		this->machinesToLeave = std::max(this->machinesToLeave, machinesToLeave);
+		return nextOwner++;
+	}
+
+	void observe(std::vector<LocalityData> const& machines) {
+		for (auto const& machine : machines) {
+			knownZones.insert(machine.zoneId());
+		}
+	}
+
+	bool prepareTargets(std::vector<LocalityData>& machines, Owner owner) const {
+		bool canClaimNew =
+		    static_cast<int64_t>(knownZones.size()) - static_cast<int64_t>(targetOwners.size()) > machinesToLeave;
+		machines.erase(std::remove_if(machines.begin(),
+		                              machines.end(),
+		                              [this, owner, canClaimNew](LocalityData const& machine) {
+			                              auto target = targetOwners.find(machine.zoneId());
+			                              return (target != targetOwners.end() && target->second != owner) ||
+			                                     (target == targetOwners.end() && !canClaimNew);
+		                              }),
+		               machines.end());
+		return !machines.empty();
+	}
+
+	void claim(LocalityData const& machine, Owner owner) {
+		auto target = targetOwners.find(machine.zoneId());
+		if (target != targetOwners.end()) {
+			ASSERT(target->second == owner);
+			return;
+		}
+		ASSERT(static_cast<int64_t>(knownZones.size()) - static_cast<int64_t>(targetOwners.size()) > machinesToLeave);
+		targetOwners.emplace(machine.zoneId(), owner);
+	}
+
+private:
+	MachineAttritionPhase() = default;
+
+	Owner nextOwner = 1;
+	int machinesToLeave = 0;
+	std::set<Optional<Standalone<StringRef>>> knownZones;
+	std::map<Optional<Standalone<StringRef>>, Owner> targetOwners;
+};
+
 struct MachineAttritionWorkload : FailureInjectionWorkload {
 	static constexpr auto NAME = "Attrition";
 	bool enabled;
@@ -88,11 +158,17 @@ struct MachineAttritionWorkload : FailureInjectionWorkload {
 
 	// This is set in setup from the list of workers when the cluster is started
 	std::vector<LocalityData> machines;
+	std::shared_ptr<MachineAttritionPhase> phase;
+	MachineAttritionPhase::Owner phaseOwner = 0;
 
 	MachineAttritionWorkload(WorkloadContext const& wcx, NoOptions) : FailureInjectionWorkload(wcx) {
 		enabled = !clientId && g_network->isSimulated() && faultInjectionActivated;
 		suspendDuration = 10.0;
 		iterate = true;
+		if (enabled) {
+			phase = MachineAttritionPhase::get(wcx.sharedRandomNumber);
+			phaseOwner = phase->registerWorkload(machinesToLeave);
+		}
 	}
 
 	explicit MachineAttritionWorkload(WorkloadContext const& wcx) : FailureInjectionWorkload(wcx) {
@@ -120,6 +196,10 @@ struct MachineAttritionWorkload : FailureInjectionWorkload {
 		replacement = getOption(options, "replacement"_sr, reboot && deterministicRandom()->random01() < 0.5);
 		waitForVersion = getOption(options, "waitForVersion"_sr, waitForVersion);
 		allowFaultInjection = getOption(options, "allowFaultInjection"_sr, allowFaultInjection);
+		if (enabled) {
+			phase = MachineAttritionPhase::get(wcx.sharedRandomNumber);
+			phaseOwner = phase->registerWorkload(machinesToLeave);
+		}
 	}
 
 	bool shouldInject(DeterministicRandom& random,
@@ -182,6 +262,7 @@ struct MachineAttritionWorkload : FailureInjectionWorkload {
 			for (auto it = machineIDMap.begin(); it != machineIDMap.end(); ++it) {
 				machines.push_back(it->second);
 			}
+			phase->observe(machines);
 			deterministicRandom()->randomShuffle(machines);
 			double meanDelay = testDuration / machinesToKill;
 			TraceEvent("AttritionStarting")
@@ -382,7 +463,7 @@ struct MachineAttritionWorkload : FailureInjectionWorkload {
 				g_simulator->toggleGlobalSwitchCluster();
 			} else {
 				int killedMachines = 0;
-				while (killedMachines < machinesToKill && machines.size() > machinesToLeave) {
+				while (killedMachines < machinesToKill && phase->prepareTargets(machines, phaseOwner)) {
 					TraceEvent("WorkerKillBegin")
 					    .detail("KilledMachines", killedMachines)
 					    .detail("MachinesToKill", machinesToKill)
@@ -411,7 +492,11 @@ struct MachineAttritionWorkload : FailureInjectionWorkload {
 					}
 
 					// decide on a machine to kill
+					if (!phase->prepareTargets(machines, phaseOwner)) {
+						break;
+					}
 					LocalityData targetMachine = machines.back();
+					phase->claim(targetMachine, phaseOwner);
 					if (buggify(0.01)) {
 						CODE_PROBE(true, "Marked a zone for maintenance before killing it");
 						co_await setHealthyZone(
@@ -493,6 +578,54 @@ struct MachineAttritionWorkload : FailureInjectionWorkload {
 			throw please_reboot();
 	}
 };
+
+TEST_CASE("/fdbserver/workloads/MachineAttrition/phaseCoordination") {
+	auto locality = [](StringRef zone) {
+		return LocalityData(Optional<Standalone<StringRef>>(),
+		                    Standalone<StringRef>(zone),
+		                    Standalone<StringRef>(zone),
+		                    Optional<Standalone<StringRef>>());
+	};
+	std::vector<LocalityData> allMachines = {
+		locality("zone0"_sr), locality("zone1"_sr), locality("zone2"_sr), locality("zone3"_sr), locality("zone4"_sr)
+	};
+
+	auto phase = MachineAttritionPhase::get(-1);
+	auto firstOwner = phase->registerWorkload(1);
+	auto secondOwner = phase->registerWorkload(3);
+	auto thirdOwner = phase->registerWorkload(0);
+	phase->observe(allMachines);
+
+	auto firstTargets = allMachines;
+	ASSERT(phase->prepareTargets(firstTargets, firstOwner));
+	LocalityData firstTarget = firstTargets.back();
+	phase->claim(firstTarget, firstOwner);
+	firstTargets.pop_back();
+
+	auto secondTargets = allMachines;
+	ASSERT(phase->prepareTargets(secondTargets, secondOwner));
+	LocalityData secondTarget = secondTargets.back();
+	ASSERT(secondTarget.zoneId() != firstTarget.zoneId());
+	phase->claim(secondTarget, secondOwner);
+
+	ASSERT(phase->prepareTargets(secondTargets, secondOwner));
+	ASSERT(secondTargets.size() == 1);
+	ASSERT(secondTargets.back().zoneId() == secondTarget.zoneId());
+	phase->claim(secondTargets.back(), secondOwner);
+	ASSERT(!phase->prepareTargets(firstTargets, firstOwner));
+	auto thirdTargets = allMachines;
+	ASSERT(!phase->prepareTargets(thirdTargets, thirdOwner));
+
+	auto nextPhase = MachineAttritionPhase::get(-2);
+	auto nextOwner = nextPhase->registerWorkload(0);
+	auto nextTargets = allMachines;
+	nextPhase->observe(nextTargets);
+	ASSERT(phase.get() != nextPhase.get());
+	ASSERT(nextPhase->prepareTargets(nextTargets, nextOwner));
+	ASSERT(nextTargets.size() == allMachines.size());
+
+	return Void();
+}
 
 WorkloadFactory<MachineAttritionWorkload> MachineAttritionWorkloadFactory;
 FailureInjectorFactory<MachineAttritionWorkload> MachineAttritionFailureWorkloadFactory;

--- a/fdbserver/workloads/MachineAttrition.cpp
+++ b/fdbserver/workloads/MachineAttrition.cpp
@@ -165,10 +165,6 @@ struct MachineAttritionWorkload : FailureInjectionWorkload {
 		enabled = !clientId && g_network->isSimulated() && faultInjectionActivated;
 		suspendDuration = 10.0;
 		iterate = true;
-		if (enabled) {
-			phase = MachineAttritionPhase::get(wcx.sharedRandomNumber);
-			phaseOwner = phase->registerWorkload(machinesToLeave);
-		}
 	}
 
 	explicit MachineAttritionWorkload(WorkloadContext const& wcx) : FailureInjectionWorkload(wcx) {
@@ -198,6 +194,13 @@ struct MachineAttritionWorkload : FailureInjectionWorkload {
 		allowFaultInjection = getOption(options, "allowFaultInjection"_sr, allowFaultInjection);
 		if (enabled) {
 			phase = MachineAttritionPhase::get(wcx.sharedRandomNumber);
+			phaseOwner = phase->registerWorkload(machinesToLeave);
+		}
+	}
+
+	void initFailureInjectionMode(DeterministicRandom&) override {
+		if (enabled) {
+			phase = MachineAttritionPhase::get(sharedRandomNumber);
 			phaseOwner = phase->registerWorkload(machinesToLeave);
 		}
 	}
@@ -623,6 +626,40 @@ TEST_CASE("/fdbserver/workloads/MachineAttrition/phaseCoordination") {
 	ASSERT(phase.get() != nextPhase.get());
 	ASSERT(nextPhase->prepareTargets(nextTargets, nextOwner));
 	ASSERT(nextTargets.size() == allMachines.size());
+
+	return Void();
+}
+
+TEST_CASE("/fdbserver/workloads/MachineAttrition/failureInjectorSelection") {
+	WorkloadContext wcx;
+	wcx.clientId = 0;
+	wcx.clientCount = 1;
+	wcx.sharedRandomNumber = -3;
+
+	auto phase = MachineAttritionPhase::get(wcx.sharedRandomNumber);
+	auto explicitOwner = phase->registerWorkload(0);
+	std::vector<LocalityData> machines = { LocalityData(Optional<Standalone<StringRef>>(),
+		                                                Standalone<StringRef>("zone0"_sr),
+		                                                Standalone<StringRef>("zone0"_sr),
+		                                                Optional<Standalone<StringRef>>()) };
+	phase->observe(machines);
+
+	TestWorkloadImpl<MachineAttritionWorkload, true> unselected(wcx, NoOptions{});
+	ASSERT(!unselected.phase);
+	ASSERT(unselected.phaseOwner == 0);
+	auto unselectedTargets = machines;
+	ASSERT(phase->prepareTargets(unselectedTargets, explicitOwner));
+	ASSERT(unselectedTargets.size() == 1);
+
+	TestWorkloadImpl<MachineAttritionWorkload, true> selected(wcx, NoOptions{});
+	ASSERT(!selected.phase);
+	selected.enabled = true;
+	DeterministicRandom random(wcx.sharedRandomNumber);
+	selected.initFailureInjectionMode(random);
+	ASSERT(selected.phase == phase);
+	ASSERT(selected.phaseOwner != 0);
+	auto selectedTargets = machines;
+	ASSERT(!phase->prepareTargets(selectedTargets, explicitOwner));
 
 	return Void();
 }


### PR DESCRIPTION
## Summary

Coordinate machine Attrition targets within a test phase so concurrent Attrition workloads share the strongest `machinesToLeave` floor and cannot claim the same zone. Recheck immediately before killing, while allowing a replacement workload to revisit its own zone, and add a focused lifecycle/floor/replacement regression.

## Failure evidence

Managed correctness job failed `tests/slow/SwizzledDdBalance.toml` once in 190,859 runs with RandomSeed `1023295228`, JoshuaSeed `978392406014025441`, buggify and fault injection enabled. Immutable artifact:

The exact artifact replay reproduced the timeout and 1,000,001-line trace overflow. Three explicit Attrition workloads independently targeted all five zones despite two declaring `machinesToLeave=3`, leaving recovery unavailable while `ChangeConfig` attempted a coordinator move. This is a harness availability failure, distinct from the earlier old-TLog QuietDatabase assertion family.

## Validation

Managed clang `-Werror` compile/link and the focused `/fdbserver/workloads/MachineAttrition/phaseCoordination` regression passed on both integrated revision `e86c1a7e64346cd7aa4d9e445189cac79b7ccad3` and upstream base `1ae8e7f2383bbd79aa860940507db6ec0754055d`.

Exact-seed patched replays passed on both binaries. Trace audits show only two unique killed zones (preserving the three-zone floor), successful `ChangeConfig` completion, and zero `TestFailure`, `TestUnexpectedlyNotFinished`, or `TracedTooManyLines` events. Additional managed smoke runs passed:

- `slow/SwizzledDdBalance.toml --seed 1023295229 --buggify on -fi on`
- `fast/StatusDuringOutage.toml --seed 2456305 --buggify on -fi on`
- `fast/CycleTest.toml --seed 4101 --buggify on -fi on`

The managed build wrapper reported a post-link nonzero status because the worker image lacks `sccache`; compilation/link, binary execution, source-hash identity, and focused tests were verified explicitly.