### PR TITLE
Keep storage wiggle disabled for MinimumThroughput

### DIFF
--- a/tests/fast/MinimumThroughput.toml
+++ b/tests/fast/MinimumThroughput.toml
@@ -4,6 +4,8 @@ buggify = false
 [[test]]
 testTitle = 'MinimumThroughput'
 connectionFailuresDisableDuration = 100000
+# Restoring perpetual wiggle would force recovery and data movement immediately before this error-free throughput check.
+restorePerpetualWiggleSetting = false
 
     [[test.workload]]
     testName = 'MinimumThroughput'


### PR DESCRIPTION
## Summary

`MinimumThroughput` is intended to measure throughput under error-free conditions. Pre-test quieting disables perpetual storage wiggle, but restoring it immediately before the workload changes the database configuration, forces transaction-system recovery, and can start data movement during the measurement window.

Keep perpetual storage wiggle disabled for this test so the existing throughput requirement measures the intended steady-state behavior. The workload, transaction rate, and minimum-throughput threshold are unchanged.

## Validation

- Reproduced the throughput failure and confirmed the post-quiet configuration restart and storage-wiggle activity in the simulation trace.
- Ran the focused simulation workload across five configurations, including Redwood, SQLite, and ShardedRocksDB with fault injection enabled and buggify disabled: 5 passed / 0 failed.
- Confirmed there were no post-quiet transaction-system restarts, unavailable TLog generations, storage-wiggle starts, or throughput failures in the focused traces.
- `git diff --check`