### PR TITLE
Disable failure workloads for Native CDC reply chunking

### DIFF
--- a/tests/fast/NativeCdcReplyChunking.toml
+++ b/tests/fast/NativeCdcReplyChunking.toml
@@ -18,6 +18,7 @@ testTitle = 'NativeCdcReplyChunking'
 useDB = true
 waitForQuiescenceEnd = false
 connectionFailuresDisableDuration = 1000000
+runFailureWorkloads = false
 
     [[test.workload]]
     testName = 'NativeCdcEndToEnd'


### PR DESCRIPTION
## Description

Disable the generic failure workloads for `NativeCdcReplyChunking`, which is intended to exercise bounded CDC replies in a stable simulation. The test already disables buggify, fault injection, and connection failures, but an injected rollback can still restart commit proxies while the workload is checking its fixed set of expected versions and cause an unrelated assertion.

This matches the other stable Native CDC scenarios and leaves dedicated recovery tests responsible for rollback coverage.

## Testing

- Replayed three previously failing RocksDB and Redwood configurations with buggify and fault injection disabled; all three now pass.
- Confirmed the rollback workload is no longer triggered and CDC reply/recovery coverage still executes.
- Parsed the updated TOML and ran `git diff --check`.
