### PR TITLE
Confirm simulated dead regions before repair

### DIFF
--- a/fdbserver/core/QuietDatabase.cpp
+++ b/fdbserver/core/QuietDatabase.cpp
@@ -701,22 +701,25 @@ Future<Void> repairDeadDatacenter(Database cx, Reference<AsyncVar<ServerDBInfo> 
 	if (g_network->isSimulated() && fdbSimulationPolicyState().usableRegions > 1 &&
 	    !fdbSimulationPolicyState().quiesced) {
 		auto& simPolicy = fdbSimulationPolicyState();
+		const auto primaryDcId = simPolicy.primaryDcId;
+		const auto remoteDcId = simPolicy.remoteDcId;
 		bool primaryDead = g_simulator->datacenterDead(simPolicy.primaryDcId);
 		bool remoteDead = g_simulator->datacenterDead(simPolicy.remoteDcId);
 		if (primaryDead || remoteDead) {
 			// A single-replica region can look dead while a workload intentionally reboots its master. Confirm the
-			// failure after the maximum simulated reboot time before making an irreversible region change.
+			// failure after the maximum simulated worker reboot time before making an irreversible region change.
 			TraceEvent("ConfirmingDeadDatacenter")
 			    .detail("Location", context)
 			    .detail("PrimaryDead", primaryDead)
 			    .detail("RemoteDead", remoteDead)
 			    .detail("Delay", SERVER_KNOBS->MAX_REBOOT_TIME);
 			co_await delay(SERVER_KNOBS->MAX_REBOOT_TIME);
-			if (simPolicy.usableRegions <= 1 || simPolicy.quiesced) {
+			if (simPolicy.usableRegions <= 1 || simPolicy.quiesced || simPolicy.primaryDcId != primaryDcId ||
+			    simPolicy.remoteDcId != remoteDcId) {
 				co_return;
 			}
-			primaryDead = g_simulator->datacenterDead(simPolicy.primaryDcId);
-			remoteDead = g_simulator->datacenterDead(simPolicy.remoteDcId);
+			primaryDead = primaryDead && g_simulator->datacenterDead(simPolicy.primaryDcId);
+			remoteDead = remoteDead && g_simulator->datacenterDead(simPolicy.remoteDcId);
 		}
 
 		// FIXME: the primary and remote can both be considered dead because excludes are not handled properly by the

--- a/fdbserver/core/QuietDatabase.cpp
+++ b/fdbserver/core/QuietDatabase.cpp
@@ -703,6 +703,21 @@ Future<Void> repairDeadDatacenter(Database cx, Reference<AsyncVar<ServerDBInfo> 
 		auto& simPolicy = fdbSimulationPolicyState();
 		bool primaryDead = g_simulator->datacenterDead(simPolicy.primaryDcId);
 		bool remoteDead = g_simulator->datacenterDead(simPolicy.remoteDcId);
+		if (primaryDead || remoteDead) {
+			// A single-replica region can look dead while a workload intentionally reboots its master. Confirm the
+			// failure after the maximum simulated reboot time before making an irreversible region change.
+			TraceEvent("ConfirmingDeadDatacenter")
+			    .detail("Location", context)
+			    .detail("PrimaryDead", primaryDead)
+			    .detail("RemoteDead", remoteDead)
+			    .detail("Delay", SERVER_KNOBS->MAX_REBOOT_TIME);
+			co_await delay(SERVER_KNOBS->MAX_REBOOT_TIME);
+			if (simPolicy.usableRegions <= 1 || simPolicy.quiesced) {
+				co_return;
+			}
+			primaryDead = g_simulator->datacenterDead(simPolicy.primaryDcId);
+			remoteDead = g_simulator->datacenterDead(simPolicy.remoteDcId);
+		}
 
 		// FIXME: the primary and remote can both be considered dead because excludes are not handled properly by the
 		// datacenterDead function


### PR DESCRIPTION
## Summary

Confirm that a simulated region remains unavailable before `repairDeadDatacenter` makes an irreversible region change.

A single-replica region can briefly appear dead while a workload deliberately reboots its master. In a two-region `GcGenerations` simulation with satellites and remote logs, the tester's one-shot repair could observe that transient state, disable the primary region, and trigger repeated cross-region recovery attempts until the trace-line limit aborted the simulation.

The confirmation now:

- waits for the maximum simulated worker-reboot interval;
- verifies that the region topology has not changed or quiesced;
- requires the same initially unavailable region to remain unavailable.

This preserves real dead-region repair while allowing intentional transient reboots to recover.

## Validation

- Reproduced the original remote-double/RocksDB/satellite simulation failure with buggify and fault injection enabled.
- The corresponding simulation passes with the fix, retains the original generated configuration and early recovery events, and produces no trace overflow or unexpected errors.
- Three additional `GcGenerations` simulations with buggify and fault injection enabled pass.
- `fdbserver_core_test --ignore /NativeCDC/`: 22 passed, 0 failed.
- `git diff --check` and `git clang-format --diff` are clean.

The existing `GcGenerations` workload can still time out with two old log generations remaining because its `check()` currently returns true unconditionally; this change intentionally does not weaken or otherwise alter that workload coverage.
