### PR TITLE
Avoid dropped log-router init replies in HTTP key-value-store test

### DIFF
--- a/tests/fast/HTTPKeyValueStore.toml
+++ b/tests/fast/HTTPKeyValueStore.toml
@@ -2,6 +2,11 @@
 # [[ knobs ]]
 # http_request_id_header=1
 
+[[knobs]]
+# Dropping a log-router init reply can repeatedly restart recovery and exhaust
+# this test's timeout under remote-double Attrition.
+cc_recovery_init_req_allow_drop_in_sim = false
+
 [[test]]
 testTitle = 'HTTPKeyValueStoreTest'
 timeout = 1000
@@ -27,4 +32,3 @@ timeout = 1000
     machinesToLeave = 3
     reboot = true
     testDuration = 30.0
-


### PR DESCRIPTION
## Summary

Disable simulated log-router init-reply dropping for `HTTPKeyValueStore.toml`. The test already exercises two Attrition workloads and clogging; an intentionally dropped init reply can repeatedly restart recovery and consume the test timeout without exposing an HTTP-store defect.

## Root cause

A two-region remote-double/RocksDB simulation with buggify and fault injection enabled reproduced a tester timeout. Three simulated init-reply drops each stalled transaction-system recovery, while the HTTP workload checks subsequently completed. This is the same narrow simulation-knob pattern used by #13727 for backup-restart coverage and is distinct from #13745's simulated dead-region confirmation path.

## Validation

- Replayed the originally failing configuration with buggify and fault injection enabled: passed.
- Four adjacent randomized simulations passed.
- An explicit `RandomRangeLock` plus remote-double/RocksDB simulation passed.
- All six runs retained Attrition and reported no severe events, dropped init replies, or recovery-init timeouts.
- TOML parse, `git diff --check`, and formatting checks passed.
