### PR TITLE
Backport status sub-fetcher timeout isolation to release-7.3

### DIFF
--- a/documentation/sphinx/source/mr-status-json-schemas.rst.inc
+++ b/documentation/sphinx/source/mr-status-json-schemas.rst.inc
@@ -559,10 +559,7 @@
                   "primary_dc_missing",
                   "fetch_primary_dc_timeout",
                   "fetch_storage_wiggler_stats_timeout",
-                  "fetch_consistency_scan_info_timeout",
-                  "fetch_coordinator_addresses",
-                  "fetch_blob_granule_status_timed_out",
-                  "fetch_blob_restore_status_timed_out"
+                  "fetch_consistency_scan_info_timeout"
                ]
             },
             "issues":[

--- a/documentation/sphinx/source/mr-status-json-schemas.rst.inc
+++ b/documentation/sphinx/source/mr-status-json-schemas.rst.inc
@@ -559,7 +559,10 @@
                   "primary_dc_missing",
                   "fetch_primary_dc_timeout",
                   "fetch_storage_wiggler_stats_timeout",
-                  "fetch_consistency_scan_info_timeout"
+                  "fetch_consistency_scan_info_timeout",
+                  "fetch_coordinator_addresses",
+                  "fetch_blob_granule_status_timed_out",
+                  "fetch_blob_restore_status_timed_out"
                ]
             },
             "issues":[

--- a/documentation/sphinx/source/mr-status-json-schemas.rst.inc
+++ b/documentation/sphinx/source/mr-status-json-schemas.rst.inc
@@ -558,6 +558,9 @@
                   "duplicate_mutation_fetch_timeout",
                   "primary_dc_missing",
                   "fetch_primary_dc_timeout",
+                  "fetch_coordinator_addresses",
+                  "fetch_blob_granule_status_timed_out",
+                  "fetch_blob_restore_status_timed_out",
                   "fetch_storage_wiggler_stats_timeout",
                   "fetch_consistency_scan_info_timeout"
                ]

--- a/fdbclient/Schemas.cpp
+++ b/fdbclient/Schemas.cpp
@@ -595,10 +595,7 @@ const KeyRef JSONSchemas::statusSchema = R"statusSchema(
                   "primary_dc_missing",
                   "fetch_primary_dc_timeout",
                   "fetch_storage_wiggler_stats_timeout",
-                  "fetch_consistency_scan_info_timeout",
-                  "fetch_coordinator_addresses",
-                  "fetch_blob_granule_status_timed_out",
-                  "fetch_blob_restore_status_timed_out"
+                  "fetch_consistency_scan_info_timeout"
                ]
             },
             "issues":[

--- a/fdbclient/Schemas.cpp
+++ b/fdbclient/Schemas.cpp
@@ -595,7 +595,10 @@ const KeyRef JSONSchemas::statusSchema = R"statusSchema(
                   "primary_dc_missing",
                   "fetch_primary_dc_timeout",
                   "fetch_storage_wiggler_stats_timeout",
-                  "fetch_consistency_scan_info_timeout"
+                  "fetch_consistency_scan_info_timeout",
+                  "fetch_coordinator_addresses",
+                  "fetch_blob_granule_status_timed_out",
+                  "fetch_blob_restore_status_timed_out"
                ]
             },
             "issues":[

--- a/fdbclient/Schemas.cpp
+++ b/fdbclient/Schemas.cpp
@@ -594,6 +594,9 @@ const KeyRef JSONSchemas::statusSchema = R"statusSchema(
                   "duplicate_mutation_fetch_timeout",
                   "primary_dc_missing",
                   "fetch_primary_dc_timeout",
+                  "fetch_coordinator_addresses",
+                  "fetch_blob_granule_status_timed_out",
+                  "fetch_blob_restore_status_timed_out",
                   "fetch_storage_wiggler_stats_timeout",
                   "fetch_consistency_scan_info_timeout"
                ]

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -2512,6 +2512,19 @@ ACTOR static Future<JsonBuilderObject> blobRestoreStatusFetcher(Database db, std
 	return statusObj;
 }
 
+template <class T>
+static Optional<T> statusFetcherResultOrMessage(ErrorOr<T> result,
+                                                JsonBuilderArray* messages,
+                                                const char* messageName,
+                                                const char* messageDescription) {
+	if (result.present()) {
+		return Optional<T>(std::move(result.get()));
+	}
+
+	messages->push_back(JsonString::makeMessage(messageName, messageDescription));
+	return Optional<T>();
+}
+
 static JsonBuilderObject tlogFetcher(int* logFaultTolerance,
                                      const std::vector<TLogSet>& tLogs,
                                      std::unordered_map<NetworkAddress, WorkerInterface> const& address_workers) {
@@ -3340,9 +3353,16 @@ ACTOR static Future<Void> clusterGetStatusImpl(JsonBuilderObject* pStatusObj,
 				statusObj["active_primary_dc"] = primaryDCFO.get().get();
 			}
 
-			std::vector<NetworkAddress> addresses =
-			    wait(timeoutError(coordinators.ccr->getConnectionString().tryResolveHostnames(), 5.0));
-			coordinatorAddresses = std::move(addresses);
+			ErrorOr<std::vector<NetworkAddress>> addresses =
+			    wait(errorOr(timeoutError(coordinators.ccr->getConnectionString().tryResolveHostnames(), 5.0)));
+			Optional<std::vector<NetworkAddress>> resolvedAddresses =
+			    statusFetcherResultOrMessage(std::move(addresses),
+			                                 &messages,
+			                                 "fetch_coordinator_addresses",
+			                                 "Fetching coordinator addresses timed out");
+			if (resolvedAddresses.present()) {
+				coordinatorAddresses = std::move(resolvedAddresses.get());
+			}
 
 			int logFaultTolerance = 100;
 			if (db->get().recoveryState >= RecoveryState::ACCEPTING_COMMITS) {
@@ -3483,14 +3503,29 @@ ACTOR static Future<Void> clusterGetStatusImpl(JsonBuilderObject* pStatusObj,
 		statusObj["processes"] = processStatus;
 
 		if (configuration.present() && configuration.get().blobGranulesEnabled) {
-			JsonBuilderObject blobGranuelsStatus =
-			    wait(timeoutError(blobGranulesStatusFetcher(
-			                          db->get().blobManager, blobWorkers, address_workers, &status_incomplete_reasons),
-			                      2.0));
-			statusObj["blob_granules"] = blobGranuelsStatus;
-			JsonBuilderObject blobRestoreStatus =
-			    wait(timeoutError(blobRestoreStatusFetcher(cx, &status_incomplete_reasons), 2.0));
-			statusObj["blob_restore"] = blobRestoreStatus;
+			ErrorOr<JsonBuilderObject> blobGranulesResult = wait(errorOr(
+			    timeoutError(blobGranulesStatusFetcher(
+			                     db->get().blobManager, blobWorkers, address_workers, &status_incomplete_reasons),
+			                 2.0)));
+			Optional<JsonBuilderObject> blobGranulesStatus =
+			    statusFetcherResultOrMessage(std::move(blobGranulesResult),
+			                                 &messages,
+			                                 "fetch_blob_granule_status_timed_out",
+			                                 "Fetch BlobGranule status timed out.");
+			if (blobGranulesStatus.present()) {
+				statusObj["blob_granules"] = blobGranulesStatus.get();
+			}
+
+			ErrorOr<JsonBuilderObject> blobRestoreResult =
+			    wait(errorOr(timeoutError(blobRestoreStatusFetcher(cx, &status_incomplete_reasons), 2.0)));
+			Optional<JsonBuilderObject> blobRestoreStatus =
+			    statusFetcherResultOrMessage(std::move(blobRestoreResult),
+			                                 &messages,
+			                                 "fetch_blob_restore_status_timed_out",
+			                                 "Fetch BlobRestore status timed out.");
+			if (blobRestoreStatus.present()) {
+				statusObj["blob_restore"] = blobRestoreStatus.get();
+			}
 		}
 
 		int activeTSSCount = 0;
@@ -3971,6 +4006,51 @@ TEST_CASE("/status/json/merging") {
 		       result.c_str());
 		ASSERT(false);
 	}
+
+	return Void();
+}
+
+TEST_CASE("/fdbserver/clustercontroller/statusFetcherTimeoutIsolation") {
+	JsonBuilderArray messages;
+
+	Optional<std::vector<NetworkAddress>> coordinatorAddresses =
+	    statusFetcherResultOrMessage(ErrorOr<std::vector<NetworkAddress>>(timed_out()),
+	                                 &messages,
+	                                 "fetch_coordinator_addresses",
+	                                 "Fetching coordinator addresses timed out");
+	Optional<JsonBuilderObject> blobGranulesStatus =
+	    statusFetcherResultOrMessage(ErrorOr<JsonBuilderObject>(timed_out()),
+	                                 &messages,
+	                                 "fetch_blob_granule_status_timed_out",
+	                                 "Fetch BlobGranule status timed out.");
+	Optional<JsonBuilderObject> blobRestoreStatus =
+	    statusFetcherResultOrMessage(ErrorOr<JsonBuilderObject>(timed_out()),
+	                                 &messages,
+	                                 "fetch_blob_restore_status_timed_out",
+	                                 "Fetch BlobRestore status timed out.");
+
+	ASSERT(!coordinatorAddresses.present());
+	ASSERT(!blobGranulesStatus.present());
+	ASSERT(!blobRestoreStatus.present());
+	ASSERT_EQ(messages.size(), 3);
+
+	auto messagesArray = readJSONStrictly(messages.getJson()).get_array();
+	ASSERT_EQ(messagesArray[0].get_obj()["name"].get_str(), "fetch_coordinator_addresses");
+	ASSERT_EQ(messagesArray[0].get_obj()["description"].get_str(), "Fetching coordinator addresses timed out");
+	ASSERT_EQ(messagesArray[1].get_obj()["name"].get_str(), "fetch_blob_granule_status_timed_out");
+	ASSERT_EQ(messagesArray[1].get_obj()["description"].get_str(), "Fetch BlobGranule status timed out.");
+	ASSERT_EQ(messagesArray[2].get_obj()["name"].get_str(), "fetch_blob_restore_status_timed_out");
+	ASSERT_EQ(messagesArray[2].get_obj()["description"].get_str(), "Fetch BlobRestore status timed out.");
+
+	std::vector<NetworkAddress> expectedAddresses{ NetworkAddress(IPAddress(0x01010101), 1) };
+	Optional<std::vector<NetworkAddress>> successfulAddresses =
+	    statusFetcherResultOrMessage(ErrorOr<std::vector<NetworkAddress>>(expectedAddresses),
+	                                 &messages,
+	                                 "fetch_coordinator_addresses",
+	                                 "Fetching coordinator addresses timed out");
+	ASSERT(successfulAddresses.present());
+	ASSERT_EQ(successfulAddresses.get(), expectedAddresses);
+	ASSERT_EQ(messages.size(), 3);
 
 	return Void();
 }

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -2505,7 +2505,7 @@ ACTOR static Future<JsonBuilderObject> blobRestoreStatusFetcher(Database db, std
 		}
 
 	} catch (Error& e) {
-		if (e.code() == error_code_actor_cancelled)
+		if (e.code() == error_code_actor_cancelled || e.code() == error_code_timed_out)
 			throw;
 		incompleteReason->insert("Unable to query blob restore status");
 	}
@@ -2519,6 +2519,9 @@ static Optional<T> statusFetcherResultOrMessage(ErrorOr<T> result,
                                                 const char* messageDescription) {
 	if (result.present()) {
 		return Optional<T>(std::move(result.get()));
+	}
+	if (result.getError().code() != error_code_timed_out) {
+		throw result.getError();
 	}
 
 	messages->push_back(JsonString::makeMessage(messageName, messageDescription));
@@ -3518,6 +3521,9 @@ ACTOR static Future<Void> clusterGetStatusImpl(JsonBuilderObject* pStatusObj,
 
 			ErrorOr<JsonBuilderObject> blobRestoreResult =
 			    wait(errorOr(timeoutError(blobRestoreStatusFetcher(cx, &status_incomplete_reasons), 2.0)));
+			if (blobRestoreResult.isError()) {
+				status_incomplete_reasons.insert("Unable to query blob restore status");
+			}
 			Optional<JsonBuilderObject> blobRestoreStatus =
 			    statusFetcherResultOrMessage(std::move(blobRestoreResult),
 			                                 &messages,
@@ -4011,7 +4017,7 @@ TEST_CASE("/status/json/merging") {
 }
 
 TEST_CASE("/fdbserver/clustercontroller/statusFetcherTimeoutIsolation") {
-	JsonBuilderArray messages;
+	state JsonBuilderArray messages;
 
 	Optional<std::vector<NetworkAddress>> coordinatorAddresses =
 	    statusFetcherResultOrMessage(ErrorOr<std::vector<NetworkAddress>>(timed_out()),
@@ -4052,6 +4058,53 @@ TEST_CASE("/fdbserver/clustercontroller/statusFetcherTimeoutIsolation") {
 	ASSERT_EQ(successfulAddresses.get(), expectedAddresses);
 	ASSERT_EQ(messages.size(), 3);
 
+	state bool nonTimeoutErrorRethrown = false;
+	try {
+		statusFetcherResultOrMessage(ErrorOr<JsonBuilderObject>(operation_failed()),
+		                             &messages,
+		                             "fetch_blob_restore_status_timed_out",
+		                             "Fetch BlobRestore status timed out.");
+	} catch (Error& e) {
+		ASSERT_EQ(e.code(), error_code_operation_failed);
+		nonTimeoutErrorRethrown = true;
+	}
+	ASSERT(nonTimeoutErrorRethrown);
+	ASSERT_EQ(messages.size(), 3);
+
+	return Void();
+}
+
+TEST_CASE("/fdbserver/clustercontroller/blobRestoreTimeoutIsolation") {
+	NetworkAddress proxyAddr(IPAddress(0x07070707), 1);
+	UID testUID(1, 2);
+
+	ServerDBInfo testDbInfo;
+	GrvProxyInterface proxyInterf;
+	proxyInterf.getConsistentReadVersion =
+	    PublicRequestStream<struct GetReadVersionRequest>(Endpoint({ proxyAddr }, testUID));
+	testDbInfo.client.grvProxies.push_back(proxyInterf);
+	testDbInfo.recoveryState = RecoveryState::ACCEPTING_COMMITS;
+
+	state Reference<AsyncVar<ServerDBInfo>> db = makeReference<AsyncVar<ServerDBInfo>>(testDbInfo);
+	state Database cx = openDBOnServer(db, TaskPriority::DefaultEndpoint, LockAware::True);
+	state std::set<std::string> incompleteReasons;
+	state JsonBuilderArray messages;
+
+	ErrorOr<JsonBuilderObject> result =
+	    wait(errorOr(timeoutError(blobRestoreStatusFetcher(cx, &incompleteReasons), 2.0)));
+	if (result.isError()) {
+		incompleteReasons.insert("Unable to query blob restore status");
+	}
+	Optional<JsonBuilderObject> status = statusFetcherResultOrMessage(std::move(result),
+	                                                                &messages,
+	                                                                "fetch_blob_restore_status_timed_out",
+	                                                                "Fetch BlobRestore status timed out.");
+
+	ASSERT(!status.present());
+	ASSERT_EQ(messages.size(), 1);
+	ASSERT_EQ(incompleteReasons.count("Unable to query blob restore status"), 1);
+	auto messagesArray = readJSONStrictly(messages.getJson()).get_array();
+	ASSERT_EQ(messagesArray[0].get_obj()["name"].get_str(), "fetch_blob_restore_status_timed_out");
 	return Void();
 }
 

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -2512,19 +2512,6 @@ ACTOR static Future<JsonBuilderObject> blobRestoreStatusFetcher(Database db, std
 	return statusObj;
 }
 
-template <class T>
-static Optional<T> statusFetcherResultOrMessage(ErrorOr<T> result,
-                                                JsonBuilderArray* messages,
-                                                const char* messageName,
-                                                const char* messageDescription) {
-	if (result.present()) {
-		return Optional<T>(std::move(result.get()));
-	}
-
-	messages->push_back(JsonString::makeMessage(messageName, messageDescription));
-	return Optional<T>();
-}
-
 static JsonBuilderObject tlogFetcher(int* logFaultTolerance,
                                      const std::vector<TLogSet>& tLogs,
                                      std::unordered_map<NetworkAddress, WorkerInterface> const& address_workers) {
@@ -3355,13 +3342,11 @@ ACTOR static Future<Void> clusterGetStatusImpl(JsonBuilderObject* pStatusObj,
 
 			ErrorOr<std::vector<NetworkAddress>> addresses =
 			    wait(errorOr(timeoutError(coordinators.ccr->getConnectionString().tryResolveHostnames(), 5.0)));
-			Optional<std::vector<NetworkAddress>> resolvedAddresses =
-			    statusFetcherResultOrMessage(std::move(addresses),
-			                                 &messages,
-			                                 "fetch_coordinator_addresses",
-			                                 "Fetching coordinator addresses timed out");
-			if (resolvedAddresses.present()) {
-				coordinatorAddresses = std::move(resolvedAddresses.get());
+			if (addresses.present()) {
+				coordinatorAddresses = std::move(addresses.get());
+			} else {
+				messages.push_back(
+				    JsonString::makeMessage("fetch_coordinator_addresses", "Fetching coordinator addresses timed out"));
 			}
 
 			int logFaultTolerance = 100;
@@ -3503,28 +3488,24 @@ ACTOR static Future<Void> clusterGetStatusImpl(JsonBuilderObject* pStatusObj,
 		statusObj["processes"] = processStatus;
 
 		if (configuration.present() && configuration.get().blobGranulesEnabled) {
-			ErrorOr<JsonBuilderObject> blobGranulesResult = wait(errorOr(
+			ErrorOr<JsonBuilderObject> blobGranulesStatus = wait(errorOr(
 			    timeoutError(blobGranulesStatusFetcher(
 			                     db->get().blobManager, blobWorkers, address_workers, &status_incomplete_reasons),
 			                 2.0)));
-			Optional<JsonBuilderObject> blobGranulesStatus =
-			    statusFetcherResultOrMessage(std::move(blobGranulesResult),
-			                                 &messages,
-			                                 "fetch_blob_granule_status_timed_out",
-			                                 "Fetch BlobGranule status timed out.");
 			if (blobGranulesStatus.present()) {
 				statusObj["blob_granules"] = blobGranulesStatus.get();
+			} else {
+				messages.push_back(JsonString::makeMessage("fetch_blob_granule_status_timed_out",
+				                                           "Fetch BlobGranule status timed out."));
 			}
 
-			ErrorOr<JsonBuilderObject> blobRestoreResult =
+			ErrorOr<JsonBuilderObject> blobRestoreStatus =
 			    wait(errorOr(timeoutError(blobRestoreStatusFetcher(cx, &status_incomplete_reasons), 2.0)));
-			Optional<JsonBuilderObject> blobRestoreStatus =
-			    statusFetcherResultOrMessage(std::move(blobRestoreResult),
-			                                 &messages,
-			                                 "fetch_blob_restore_status_timed_out",
-			                                 "Fetch BlobRestore status timed out.");
 			if (blobRestoreStatus.present()) {
 				statusObj["blob_restore"] = blobRestoreStatus.get();
+			} else {
+				messages.push_back(JsonString::makeMessage("fetch_blob_restore_status_timed_out",
+				                                           "Fetch BlobRestore status timed out."));
 			}
 		}
 
@@ -4006,51 +3987,6 @@ TEST_CASE("/status/json/merging") {
 		       result.c_str());
 		ASSERT(false);
 	}
-
-	return Void();
-}
-
-TEST_CASE("/fdbserver/clustercontroller/statusFetcherTimeoutIsolation") {
-	JsonBuilderArray messages;
-
-	Optional<std::vector<NetworkAddress>> coordinatorAddresses =
-	    statusFetcherResultOrMessage(ErrorOr<std::vector<NetworkAddress>>(timed_out()),
-	                                 &messages,
-	                                 "fetch_coordinator_addresses",
-	                                 "Fetching coordinator addresses timed out");
-	Optional<JsonBuilderObject> blobGranulesStatus =
-	    statusFetcherResultOrMessage(ErrorOr<JsonBuilderObject>(timed_out()),
-	                                 &messages,
-	                                 "fetch_blob_granule_status_timed_out",
-	                                 "Fetch BlobGranule status timed out.");
-	Optional<JsonBuilderObject> blobRestoreStatus =
-	    statusFetcherResultOrMessage(ErrorOr<JsonBuilderObject>(timed_out()),
-	                                 &messages,
-	                                 "fetch_blob_restore_status_timed_out",
-	                                 "Fetch BlobRestore status timed out.");
-
-	ASSERT(!coordinatorAddresses.present());
-	ASSERT(!blobGranulesStatus.present());
-	ASSERT(!blobRestoreStatus.present());
-	ASSERT_EQ(messages.size(), 3);
-
-	auto messagesArray = readJSONStrictly(messages.getJson()).get_array();
-	ASSERT_EQ(messagesArray[0].get_obj()["name"].get_str(), "fetch_coordinator_addresses");
-	ASSERT_EQ(messagesArray[0].get_obj()["description"].get_str(), "Fetching coordinator addresses timed out");
-	ASSERT_EQ(messagesArray[1].get_obj()["name"].get_str(), "fetch_blob_granule_status_timed_out");
-	ASSERT_EQ(messagesArray[1].get_obj()["description"].get_str(), "Fetch BlobGranule status timed out.");
-	ASSERT_EQ(messagesArray[2].get_obj()["name"].get_str(), "fetch_blob_restore_status_timed_out");
-	ASSERT_EQ(messagesArray[2].get_obj()["description"].get_str(), "Fetch BlobRestore status timed out.");
-
-	std::vector<NetworkAddress> expectedAddresses{ NetworkAddress(IPAddress(0x01010101), 1) };
-	Optional<std::vector<NetworkAddress>> successfulAddresses =
-	    statusFetcherResultOrMessage(ErrorOr<std::vector<NetworkAddress>>(expectedAddresses),
-	                                 &messages,
-	                                 "fetch_coordinator_addresses",
-	                                 "Fetching coordinator addresses timed out");
-	ASSERT(successfulAddresses.present());
-	ASSERT_EQ(successfulAddresses.get(), expectedAddresses);
-	ASSERT_EQ(messages.size(), 3);
 
 	return Void();
 }

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -2505,7 +2505,7 @@ ACTOR static Future<JsonBuilderObject> blobRestoreStatusFetcher(Database db, std
 		}
 
 	} catch (Error& e) {
-		if (e.code() == error_code_actor_cancelled || e.code() == error_code_timed_out)
+		if (e.code() == error_code_actor_cancelled)
 			throw;
 		incompleteReason->insert("Unable to query blob restore status");
 	}
@@ -2519,9 +2519,6 @@ static Optional<T> statusFetcherResultOrMessage(ErrorOr<T> result,
                                                 const char* messageDescription) {
 	if (result.present()) {
 		return Optional<T>(std::move(result.get()));
-	}
-	if (result.getError().code() != error_code_timed_out) {
-		throw result.getError();
 	}
 
 	messages->push_back(JsonString::makeMessage(messageName, messageDescription));
@@ -3521,9 +3518,6 @@ ACTOR static Future<Void> clusterGetStatusImpl(JsonBuilderObject* pStatusObj,
 
 			ErrorOr<JsonBuilderObject> blobRestoreResult =
 			    wait(errorOr(timeoutError(blobRestoreStatusFetcher(cx, &status_incomplete_reasons), 2.0)));
-			if (blobRestoreResult.isError()) {
-				status_incomplete_reasons.insert("Unable to query blob restore status");
-			}
 			Optional<JsonBuilderObject> blobRestoreStatus =
 			    statusFetcherResultOrMessage(std::move(blobRestoreResult),
 			                                 &messages,
@@ -4017,7 +4011,7 @@ TEST_CASE("/status/json/merging") {
 }
 
 TEST_CASE("/fdbserver/clustercontroller/statusFetcherTimeoutIsolation") {
-	state JsonBuilderArray messages;
+	JsonBuilderArray messages;
 
 	Optional<std::vector<NetworkAddress>> coordinatorAddresses =
 	    statusFetcherResultOrMessage(ErrorOr<std::vector<NetworkAddress>>(timed_out()),
@@ -4058,53 +4052,6 @@ TEST_CASE("/fdbserver/clustercontroller/statusFetcherTimeoutIsolation") {
 	ASSERT_EQ(successfulAddresses.get(), expectedAddresses);
 	ASSERT_EQ(messages.size(), 3);
 
-	state bool nonTimeoutErrorRethrown = false;
-	try {
-		statusFetcherResultOrMessage(ErrorOr<JsonBuilderObject>(operation_failed()),
-		                             &messages,
-		                             "fetch_blob_restore_status_timed_out",
-		                             "Fetch BlobRestore status timed out.");
-	} catch (Error& e) {
-		ASSERT_EQ(e.code(), error_code_operation_failed);
-		nonTimeoutErrorRethrown = true;
-	}
-	ASSERT(nonTimeoutErrorRethrown);
-	ASSERT_EQ(messages.size(), 3);
-
-	return Void();
-}
-
-TEST_CASE("/fdbserver/clustercontroller/blobRestoreTimeoutIsolation") {
-	NetworkAddress proxyAddr(IPAddress(0x07070707), 1);
-	UID testUID(1, 2);
-
-	ServerDBInfo testDbInfo;
-	GrvProxyInterface proxyInterf;
-	proxyInterf.getConsistentReadVersion =
-	    PublicRequestStream<struct GetReadVersionRequest>(Endpoint({ proxyAddr }, testUID));
-	testDbInfo.client.grvProxies.push_back(proxyInterf);
-	testDbInfo.recoveryState = RecoveryState::ACCEPTING_COMMITS;
-
-	state Reference<AsyncVar<ServerDBInfo>> db = makeReference<AsyncVar<ServerDBInfo>>(testDbInfo);
-	state Database cx = openDBOnServer(db, TaskPriority::DefaultEndpoint, LockAware::True);
-	state std::set<std::string> incompleteReasons;
-	state JsonBuilderArray messages;
-
-	ErrorOr<JsonBuilderObject> result =
-	    wait(errorOr(timeoutError(blobRestoreStatusFetcher(cx, &incompleteReasons), 2.0)));
-	if (result.isError()) {
-		incompleteReasons.insert("Unable to query blob restore status");
-	}
-	Optional<JsonBuilderObject> status = statusFetcherResultOrMessage(std::move(result),
-	                                                                &messages,
-	                                                                "fetch_blob_restore_status_timed_out",
-	                                                                "Fetch BlobRestore status timed out.");
-
-	ASSERT(!status.present());
-	ASSERT_EQ(messages.size(), 1);
-	ASSERT_EQ(incompleteReasons.count("Unable to query blob restore status"), 1);
-	auto messagesArray = readJSONStrictly(messages.getJson()).get_array();
-	ASSERT_EQ(messagesArray[0].get_obj()["name"].get_str(), "fetch_blob_restore_status_timed_out");
 	return Void();
 }
 

--- a/fdbserver/workloads/StatusWorkload.actor.cpp
+++ b/fdbserver/workloads/StatusWorkload.actor.cpp
@@ -247,3 +247,23 @@ TEST_CASE("/fdbserver/status/schema/basic") {
 
 	return Void();
 }
+
+TEST_CASE("/fdbserver/status/schema/timeout_messages") {
+	json_spirit::mValue schema = readJSONStrictly(JSONSchemas::statusSchema.toString());
+	json_spirit::mValue status = readJSONStrictly(R"json(
+{
+	"cluster": {
+		"messages": [
+			{ "name": "fetch_coordinator_addresses" },
+			{ "name": "fetch_blob_granule_status_timed_out" },
+			{ "name": "fetch_blob_restore_status_timed_out" }
+		]
+	}
+}
+)json");
+
+	std::string errorStr;
+	ASSERT(schemaMatch(schema.get_obj(), status.get_obj(), errorStr, SevError, true));
+
+	return Void();
+}


### PR DESCRIPTION
This backports [#10791](https://github.com/apple/foundationdb/pull/10791) ([`22ddb8a92`](https://github.com/apple/foundationdb/commit/22ddb8a92d473aafb18f15c436bb8cce17e562ee)) to `release-7.3`.

The async status backport in #13068 can still let coordinator DNS, blob-granule, or blob-restore sub-fetcher timeouts escape the status actor. That aborts status collection and can bubble the timeout to the cluster controller instead of returning the partial status document. 

While working on this, the agent highlighted that some of the blob granule timeout messages are not correctly propagated out, but it seems that this feature is not in main anymore, so I opted to not fix those issues here.

#10791 is already on `release-7.4` and doesn't need a backport to that version.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
