### PR TITLE
Backport overall status timeout budget to release-7.3

### DIFF
--- a/fdbclient/StatusClient.actor.cpp
+++ b/fdbclient/StatusClient.actor.cpp
@@ -418,9 +418,11 @@ ACTOR Future<StatusObject> clientStatusFetcher(Reference<IClusterConnectionRecor
 }
 
 // Cluster section of json output
-ACTOR Future<Optional<StatusObject>> clusterStatusFetcher(ClusterInterface cI, StatusArray* messages) {
+ACTOR Future<Optional<StatusObject>> clusterStatusFetcher(ClusterInterface cI,
+                                                          StatusArray* messages,
+                                                          double timeoutSeconds) {
 	state StatusRequest req;
-	state Future<Void> clusterTimeout = delay(CLIENT_KNOBS->STATUS_TIMEOUT);
+	state Future<Void> clusterTimeout = delay(timeoutSeconds);
 	state Optional<StatusObject> oStatusObj;
 
 	wait(delay(0.0)); // make sure the cluster controller is marked as not failed
@@ -455,6 +457,27 @@ ACTOR Future<Optional<StatusObject>> clusterStatusFetcher(ClusterInterface cI, S
 	}
 
 	return oStatusObj;
+}
+
+TEST_CASE("/fdbclient/status/overallTimeoutBudget") {
+	state ClusterInterface clusterInterface;
+	state StatusArray messages;
+	state double overallTimeout = 0.2;
+	state double coordinatorProbeDuration = 0.1;
+	state double startTime = now();
+	state double statusDeadline = startTime + overallTimeout;
+
+	wait(delay(coordinatorProbeDuration));
+	state Optional<StatusObject> status =
+	    wait(clusterStatusFetcher(clusterInterface, &messages, std::max(0.0, statusDeadline - now())));
+
+	double elapsed = now() - startTime;
+	ASSERT(!status.present());
+	ASSERT_EQ(messages.size(), 1);
+	ASSERT_EQ(messages.front().get_obj().at("name").get_str(), "status_incomplete_timeout");
+	ASSERT_GE(elapsed, overallTimeout);
+	ASSERT_LT(elapsed, overallTimeout + 0.05);
+	return Void();
 }
 
 // Create and return a database_status section.
@@ -510,6 +533,9 @@ ACTOR Future<StatusObject> statusFetcherImpl(Reference<IClusterConnectionRecord>
 	if (!g_network)
 		throw network_not_setup();
 
+	// Keep the overall status request within STATUS_TIMEOUT, including the client-side coordinator probe that runs
+	// before we ask the cluster controller for its status payload.
+	state double statusDeadline = now() + CLIENT_KNOBS->STATUS_TIMEOUT;
 	state StatusObject statusObj;
 	state StatusObject statusObjClient;
 	state StatusArray clientMessages;
@@ -543,12 +569,12 @@ ACTOR Future<StatusObject> statusFetcherImpl(Reference<IClusterConnectionRecord>
 	if (quorum_reachable) {
 		try {
 
-			state Future<Void> interfaceTimeout = delay(2.0);
+			state Future<Void> interfaceTimeout = delay(std::min(2.0, std::max(0.0, statusDeadline - now())));
 
 			loop {
 				if (clusterInterface->get().present()) {
-					Optional<StatusObject> _statusObjCluster =
-					    wait(clusterStatusFetcher(clusterInterface->get().get(), &clientMessages));
+					Optional<StatusObject> _statusObjCluster = wait(clusterStatusFetcher(
+					    clusterInterface->get().get(), &clientMessages, std::max(0.0, statusDeadline - now())));
 					if (_statusObjCluster.present()) {
 						statusObjCluster = _statusObjCluster.get();
 						// TODO: this is a temporary fix, getting the number of available coordinators should move to

--- a/fdbclient/StatusClient.actor.cpp
+++ b/fdbclient/StatusClient.actor.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "flow/flow.h"
+#include "fdbclient/ClusterConnectionMemoryRecord.h"
 #include "fdbclient/CoordinationInterface.h"
 #include "fdbclient/MonitorLeader.h"
 #include "fdbclient/ClusterInterface.h"
@@ -305,7 +306,8 @@ void JSONDoc::mergeValueInto(json_spirit::mValue& dst, const json_spirit::mValue
 // Will not throw, will just return non-present Optional if error
 ACTOR Future<Optional<StatusObject>> clientCoordinatorsStatusFetcher(Reference<IClusterConnectionRecord> connRecord,
                                                                      bool* quorum_reachable,
-                                                                     int* coordinatorsFaultTolerance) {
+                                                                     int* coordinatorsFaultTolerance,
+                                                                     double statusDeadline) {
 	try {
 		state ClientCoordinators coord(connRecord);
 		state StatusObject statusObj;
@@ -340,7 +342,7 @@ ACTOR Future<Optional<StatusObject>> clientCoordinatorsStatusFetcher(Reference<I
 
 		wait(smartQuorum(leaderServers, leaderServers.size() / 2 + 1, 1.5) &&
 		         smartQuorum(coordProtocols, coordProtocols.size() / 2 + 1, 1.5) ||
-		     delay(2.0));
+		     delay(std::min(2.0, std::max(0.0, statusDeadline - now()))));
 
 		statusObj["quorum_reachable"] = *quorum_reachable =
 		    quorum(leaderServers, leaderServers.size() / 2 + 1).isReady();
@@ -380,11 +382,12 @@ ACTOR Future<Optional<StatusObject>> clientCoordinatorsStatusFetcher(Reference<I
 ACTOR Future<StatusObject> clientStatusFetcher(Reference<IClusterConnectionRecord> connRecord,
                                                StatusArray* messages,
                                                bool* quorum_reachable,
-                                               int* coordinatorsFaultTolerance) {
+                                               int* coordinatorsFaultTolerance,
+                                               double statusDeadline) {
 	state StatusObject statusObj;
 
 	state Optional<StatusObject> coordsStatusObj =
-	    wait(clientCoordinatorsStatusFetcher(connRecord, quorum_reachable, coordinatorsFaultTolerance));
+	    wait(clientCoordinatorsStatusFetcher(connRecord, quorum_reachable, coordinatorsFaultTolerance, statusDeadline));
 	state bool contentsUpToDate = wait(connRecord->upToDate());
 
 	if (coordsStatusObj.present()) {
@@ -480,6 +483,25 @@ TEST_CASE("/fdbclient/status/overallTimeoutBudget") {
 	return Void();
 }
 
+TEST_CASE("/fdbclient/status/clientCoordinatorTimeoutBudget") {
+	state Reference<IClusterConnectionRecord> connRecord =
+	    makeReference<ClusterConnectionMemoryRecord>(ClusterConnectionString("test:test@127.0.0.1:1"));
+	state bool quorumReachable = false;
+	state int coordinatorsFaultTolerance = 0;
+	state double timeout = 0.2;
+	state double startTime = now();
+
+	state Optional<StatusObject> status = wait(clientCoordinatorsStatusFetcher(
+	    connRecord, &quorumReachable, &coordinatorsFaultTolerance, startTime + timeout));
+
+	double elapsed = now() - startTime;
+	ASSERT(status.present());
+	ASSERT(!quorumReachable);
+	ASSERT_GE(elapsed, timeout);
+	ASSERT_LT(elapsed, timeout + 0.05);
+	return Void();
+}
+
 // Create and return a database_status section.
 // Will not throw, will not return an empty section.
 StatusObject getClientDatabaseStatus(StatusObjectReader client, StatusObjectReader cluster) {
@@ -547,8 +569,8 @@ ACTOR Future<StatusObject> statusFetcherImpl(Reference<IClusterConnectionRecord>
 	try {
 		state int64_t clientTime = g_network->timer();
 
-		StatusObject _statusObjClient =
-		    wait(clientStatusFetcher(connRecord, &clientMessages, &quorum_reachable, &coordinatorsFaultTolerance));
+		StatusObject _statusObjClient = wait(clientStatusFetcher(
+		    connRecord, &clientMessages, &quorum_reachable, &coordinatorsFaultTolerance, statusDeadline));
 		statusObjClient = _statusObjClient;
 
 		if (clientTime != -1)


### PR DESCRIPTION
This backports [#13210](https://github.com/apple/foundationdb/pull/13210) ([`79de02031`](https://github.com/apple/foundationdb/commit/79de02031e115e4c2644870be0da85f95d0e7777)) to `release-7.3`, together with the client-phase correction and coverage from [#13759](https://github.com/apple/foundationdb/pull/13759).

Status fetching previously allowed the client-side coordinator quorum probe to consume its fixed two-second timeout before applying `STATUS_TIMEOUT` to later phases. During an outage, `STATUS_TIMEOUT=0.2` could therefore still take two seconds. This semantic backport threads one deadline through the client probe, controller-interface discovery, and cluster status RPC.

The source changes target coroutine-based `fdbclient/StatusClient.cpp`; `release-7.3` still uses `StatusClient.actor.cpp`. The adaptation keeps the deadline in actor state and preserves the original author and source-commit metadata.

Testing:

- Debug `fdbserver` build: passed
- `fdbserver -r unittests -f /fdbclient/status/`: 2 passed
- `tests/fast/StatusDuringOutage.toml`, seed `1337005544`, Buggify enabled: passed (worst status latency: 7.05 seconds)

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
