### PR TITLE
Coalesce encrypted blobstore backup reads

### DIFF
--- a/fdbclient/BackupContainerBlobStore.cpp
+++ b/fdbclient/BackupContainerBlobStore.cpp
@@ -198,15 +198,15 @@ void BackupContainerBlobStore::validateBackupUrl(const std::string& resource) {
 Future<Reference<IAsyncFile>> BackupContainerBlobStore::readFile(const std::string& path) {
 	Reference<IAsyncFile> f = makeReference<AsyncFileBlobStoreRead>(m_bstore, m_bucket, dataPath(path));
 
-	if (usesEncryption() && !StringRef(path).startsWith("properties/"_sr)) {
-		f = makeReference<AsyncFileEncrypted>(f, AsyncFileEncrypted::Mode::READ_ONLY, encryptionBlockSize);
-	}
 	if (m_bstore->knobs.enable_read_cache) {
 		f = makeReference<AsyncFileReadAheadCache>(f,
 		                                           m_bstore->knobs.read_block_size,
 		                                           m_bstore->knobs.read_ahead_blocks,
 		                                           m_bstore->knobs.concurrent_reads_per_file,
 		                                           m_bstore->knobs.read_cache_blocks_per_file);
+	}
+	if (usesEncryption() && !StringRef(path).startsWith("properties/"_sr)) {
+		f = makeReference<AsyncFileEncrypted>(f, AsyncFileEncrypted::Mode::READ_ONLY, encryptionBlockSize);
 	}
 	return f;
 }


### PR DESCRIPTION
## Problem

Encrypted blobstore backups previously defaulted to 4,096-byte encryption blocks, while the blobstore read cache used 1,048,576-byte blocks. Because the cache wrapped `AsyncFileEncrypted`, a 1 MiB restore read was split into roughly 256 small S3 requests before reaching the cache.

The current encryption default is 1 MiB, which gives a 1:1 ratio with the default cache block. Existing backups and new backups configured with `--encryption-block-size` below 1 MiB still encounter the amplification.

## Change

Cache ciphertext between `AsyncFileEncrypted` and `AsyncFileBlobStoreRead`, allowing adjacent encryption-block reads to share larger object-store range reads. Unencrypted reads, writes, and files under `properties/` are unchanged.

## Validation

With 4 KiB encryption blocks, we observed approximately 256 times fewer S3 requests. A sample restore improved from 123 minutes to 103 minutes, primarily from removing S3 request overhead. The same result was achieved with default concurrent-read and blobstore-connection settings, removing the tuning previously needed to absorb the inflated request volume.

- `git diff --check`
- `clang-format --dry-run --Werror fdbclient/BackupContainerBlobStore.cpp`
