### PR TITLE
 Add backward-compatible format versioning for encrypted backup

### DIFF
--- a/fdbclient/BackupContainerBlobStore.cpp
+++ b/fdbclient/BackupContainerBlobStore.cpp
@@ -199,7 +199,10 @@ Future<Reference<IAsyncFile>> BackupContainerBlobStore::readFile(const std::stri
 	Reference<IAsyncFile> f = makeReference<AsyncFileBlobStoreRead>(m_bstore, m_bucket, dataPath(path));
 
 	if (usesEncryption() && !StringRef(path).startsWith("properties/"_sr)) {
-		f = makeReference<AsyncFileEncrypted>(f, AsyncFileEncrypted::Mode::READ_ONLY, encryptionBlockSize);
+		co_await encryptionSetupComplete();
+		co_await ensureEncryptionPropertiesLoaded();
+		f = makeReference<AsyncFileEncrypted>(
+		    f, AsyncFileEncrypted::Mode::READ_ONLY, encryptionBlockSize, encryptionFormatVersion);
 	}
 	if (m_bstore->knobs.enable_read_cache) {
 		f = makeReference<AsyncFileReadAheadCache>(f,
@@ -208,7 +211,7 @@ Future<Reference<IAsyncFile>> BackupContainerBlobStore::readFile(const std::stri
 		                                           m_bstore->knobs.concurrent_reads_per_file,
 		                                           m_bstore->knobs.read_cache_blocks_per_file);
 	}
-	return f;
+	co_return f;
 }
 
 Future<std::vector<std::string>> BackupContainerBlobStore::listURLs(Reference<IBlobStoreEndpoint> bstore,
@@ -219,9 +222,11 @@ Future<std::vector<std::string>> BackupContainerBlobStore::listURLs(Reference<IB
 Future<Reference<IBackupFile>> BackupContainerBlobStore::writeFile(const std::string& path) {
 	Reference<IAsyncFile> f = makeReference<AsyncFileBlobStoreWrite>(m_bstore, m_bucket, dataPath(path));
 	if (usesEncryption() && !StringRef(path).startsWith("properties/"_sr)) {
-		f = makeReference<AsyncFileEncrypted>(f, AsyncFileEncrypted::Mode::APPEND_ONLY, encryptionBlockSize);
+		co_await encryptionSetupComplete();
+		f = makeReference<AsyncFileEncrypted>(
+		    f, AsyncFileEncrypted::Mode::APPEND_ONLY, encryptionBlockSize, CURRENT_FORMAT_VERSION);
 	}
-	return Future<Reference<IBackupFile>>(makeReference<BackupContainerBlobStoreImpl::BackupFile>(path, f));
+	co_return makeReference<BackupContainerBlobStoreImpl::BackupFile>(path, f);
 }
 
 Future<Void> BackupContainerBlobStore::writeEntireFile(const std::string& path, const std::string& fileContents) {

--- a/fdbclient/BackupContainerFileSystem.cpp
+++ b/fdbclient/BackupContainerFileSystem.cpp
@@ -587,8 +587,8 @@ public:
 		return prevEnd;
 	}
 
-	// Read encryption metadata from JSON file
-	static Future<std::pair<bool, int>> readEncryptionMetadata(Reference<BackupContainerFileSystem> bc) {
+	// Read encryption metadata from JSON file.
+	static Future<bool> readEncryptionMetadata(Reference<BackupContainerFileSystem> bc) {
 		try {
 			Reference<IAsyncFile> f = co_await bc->readFile(BackupContainerFileSystem::encryptionMetadataFileName());
 			int64_t size = co_await f->size();
@@ -615,6 +615,18 @@ public:
 				bool enabled = obj.at("is_encryption_enabled").get_bool();
 				int blockSize = obj.at("encryption_block_size").get_int();
 
+				FormatVersion formatVersion = FormatVersion::V1;
+				if (obj.contains("encryption_format_version")) {
+					if (obj.at("encryption_format_version").type() != json_spirit::int_type) {
+						fprintf(stderr, "ERROR: encryption_format_version field has wrong type.\n");
+						TraceEvent(SevError, "BackupContainerReadEncryptionMetadataMalformed")
+						    .detail("URL", bc->getURL())
+						    .detail("File", BackupContainerFileSystem::encryptionMetadataFileName());
+						throw file_corrupt();
+					}
+					formatVersion = static_cast<FormatVersion>(obj.at("encryption_format_version").get_int());
+				}
+
 				if ((enabled && blockSize <= 0) || (!enabled && blockSize != 0)) {
 					fprintf(stderr,
 					        "ERROR: Encryption metadata is inconsistent (enabled=%d, blockSize=%d).\n",
@@ -630,8 +642,14 @@ public:
 				TraceEvent("BackupContainerReadEncryptionMetadata")
 				    .detail("URL", bc->getURL())
 				    .detail("IsEncryptionEnabled", enabled)
-				    .detail("EncryptionBlockSize", blockSize);
-				co_return std::make_pair(enabled, blockSize);
+				    .detail("EncryptionBlockSize", blockSize)
+				    .detail("EncryptionFormatVersion", static_cast<int>(formatVersion));
+
+				if (enabled) {
+					bc->setEncryptionBlockSize(blockSize);
+					bc->setEncryptionFormatVersion(formatVersion);
+				}
+				co_return enabled;
 			} else {
 				// If the file is malformed, throw an error.
 				fprintf(stderr, "ERROR: Failed to read encryption_metadata file due to incorrect format\n");
@@ -646,7 +664,7 @@ public:
 				TraceEvent(SevWarn, "BackupContainerEncryptionMetadataNotFound")
 				    .detail("URL", bc->getURL())
 				    .detail("File", BackupContainerFileSystem::encryptionMetadataFileName());
-				co_return std::make_pair(false, 0);
+				co_return false;
 			}
 			fprintf(stderr, "ERROR: Failed to read encryption_metadata file due to an error.\n");
 			TraceEvent(SevError, "BackupContainerReadEncryptionMetadataError")
@@ -706,11 +724,10 @@ public:
 
 		co_await waitForAll(metaReads);
 
-		std::pair<bool, int> encryptionMeta = co_await readEncryptionMetadata(bc);
-		fileLevelEncryptionEnabled = encryptionMeta.first;
-		encryptionBlockSize = encryptionMeta.second;
+		fileLevelEncryptionEnabled = co_await bc->ensureEncryptionPropertiesLoaded();
 		if (fileLevelEncryptionEnabled) {
-			bc->setEncryptionBlockSize(encryptionBlockSize);
+			encryptionBlockSize = bc->getEncryptionBlockSize();
+			desc.encryptionFormatVersion = bc->getEncryptionFormatVersion();
 		}
 
 		TraceEvent("BackupContainerDescribe2")
@@ -722,7 +739,8 @@ public:
 		    .detail("LogEndVersion", metaLogEnd.orDefault(invalidVersion))
 		    .detail("LogType", metaLogType.orDefault(-1))
 		    .detail("FileLevelEncryption", fileLevelEncryptionEnabled)
-		    .detail("EncryptionBlockSize", encryptionBlockSize);
+		    .detail("EncryptionBlockSize", encryptionBlockSize)
+		    .detail("EncryptionFormatVersion", static_cast<int>(bc->getEncryptionFormatVersion()));
 
 		// If the logStartVersionOverride is positive (not relative) then ensure that unreliableEndVersion is equal or
 		// greater
@@ -1545,11 +1563,14 @@ public:
 			co_await bc->create();
 		}
 
-		// Write JSON with encryption metadata
+		// Write JSON with encryption metadata.
 		bool enabled = bc->encryptionKeyFileName.present();
 		JsonBuilderObject doc;
 		doc.setKey("is_encryption_enabled", enabled);
 		doc.setKey("encryption_block_size", encryptionBlockSize);
+		if (enabled) {
+			doc.setKey("encryption_format_version", static_cast<int>(CURRENT_FORMAT_VERSION));
+		}
 
 		std::string jsonStr = doc.getJson();
 		TraceEvent("WriteEncryptionMetadataCompleted").detail("URL", bc->getURL()).detail("JSON", jsonStr);
@@ -1663,22 +1684,25 @@ Future<std::vector<LogFile>> BackupContainerFileSystem::listLogFiles(Version beg
 		       (cleaned > firstPath && cleaned < lastPath);
 	};
 
-	return map(listFiles((mutationLogType == MutationLogType::PARTITIONED_LOG ? "plogs/" : "logs/"), pathFilter),
-	           [=, self = Reference<BackupContainerFileSystem>::addRef(this)](const FilesAndSizesT& files) {
-		           std::vector<LogFile> results;
-		           LogFile lf;
-		           for (auto& f : files) {
-			           if (BackupContainerFileSystemImpl::pathToLogFile(lf, f.first, f.second) &&
-			               lf.endVersion > beginVersion && lf.beginVersion <= targetVersion) {
-				           if (self->usesEncryption()) {
-					           lf.fileSize =
-					               AsyncFileEncrypted::rawToLogicalSize(lf.fileSize, self->encryptionBlockSize);
-				           }
-				           results.push_back(lf);
-			           }
-		           }
-		           return results;
-	           });
+	return mapAsync(listFiles((mutationLogType == MutationLogType::PARTITIONED_LOG ? "plogs/" : "logs/"), pathFilter),
+	                [=, self = Reference<BackupContainerFileSystem>::addRef(this)](
+	                    const FilesAndSizesT& files) -> Future<std::vector<LogFile>> {
+		                return map(self->ensureEncryptionPropertiesLoaded(), [=](bool) {
+			                std::vector<LogFile> results;
+			                LogFile lf;
+			                for (auto& f : files) {
+				                if (BackupContainerFileSystemImpl::pathToLogFile(lf, f.first, f.second) &&
+				                    lf.endVersion > beginVersion && lf.beginVersion <= targetVersion) {
+					                if (self->usesEncryption() && self->encryptionFormatVersion != FormatVersion::V1) {
+						                lf.fileSize = AsyncFileEncrypted::rawToLogicalSize(lf.fileSize,
+						                                                                   self->encryptionBlockSize);
+					                }
+					                results.push_back(lf);
+				                }
+			                }
+			                return results;
+		                });
+	                });
 }
 
 Future<std::vector<RangeFile>> BackupContainerFileSystem::old_listRangeFiles(Version beginVersion, Version endVersion) {
@@ -1697,22 +1721,25 @@ Future<std::vector<RangeFile>> BackupContainerFileSystem::old_listRangeFiles(Ver
 		       (cleaned > firstPath && cleaned < lastPath);
 	};
 
-	return map(listFiles("ranges/", pathFilter),
-	           [=, self = Reference<BackupContainerFileSystem>::addRef(this)](const FilesAndSizesT& files) {
-		           std::vector<RangeFile> results;
-		           RangeFile rf;
-		           for (auto& f : files) {
-			           if (BackupContainerFileSystemImpl::pathToRangeFile(rf, f.first, f.second) &&
-			               rf.version >= beginVersion && rf.version <= endVersion) {
-				           if (self->usesEncryption()) {
-					           rf.fileSize =
-					               AsyncFileEncrypted::rawToLogicalSize(rf.fileSize, self->encryptionBlockSize);
-				           }
-				           results.push_back(rf);
-			           }
-		           }
-		           return results;
-	           });
+	return mapAsync(listFiles("ranges/", pathFilter),
+	                [=, self = Reference<BackupContainerFileSystem>::addRef(this)](
+	                    const FilesAndSizesT& files) -> Future<std::vector<RangeFile>> {
+		                return map(self->ensureEncryptionPropertiesLoaded(), [=](bool) {
+			                std::vector<RangeFile> results;
+			                RangeFile rf;
+			                for (auto& f : files) {
+				                if (BackupContainerFileSystemImpl::pathToRangeFile(rf, f.first, f.second) &&
+				                    rf.version >= beginVersion && rf.version <= endVersion) {
+					                if (self->usesEncryption() && self->encryptionFormatVersion != FormatVersion::V1) {
+						                rf.fileSize = AsyncFileEncrypted::rawToLogicalSize(rf.fileSize,
+						                                                                   self->encryptionBlockSize);
+					                }
+					                results.push_back(rf);
+				                }
+			                }
+			                return results;
+		                });
+	                });
 }
 
 Future<std::vector<RangeFile>> BackupContainerFileSystem::listRangeFiles(Version beginVersion, Version endVersion) {
@@ -1726,21 +1753,25 @@ Future<std::vector<RangeFile>> BackupContainerFileSystem::listRangeFiles(Version
 	};
 
 	Future<std::vector<RangeFile>> newFiles =
-	    map(listFiles("kvranges/", pathFilter),
-	        [=, self = Reference<BackupContainerFileSystem>::addRef(this)](const FilesAndSizesT& files) {
-		        std::vector<RangeFile> results;
-		        RangeFile rf;
-		        for (auto& f : files) {
-			        if (BackupContainerFileSystemImpl::pathToRangeFile(rf, f.first, f.second) &&
-			            rf.version >= beginVersion && rf.version <= endVersion) {
-				        if (self->usesEncryption()) {
-					        rf.fileSize = AsyncFileEncrypted::rawToLogicalSize(rf.fileSize, self->encryptionBlockSize);
-				        }
-				        results.push_back(rf);
-			        }
-		        }
-		        return results;
-	        });
+	    mapAsync(listFiles("kvranges/", pathFilter),
+	             [=, self = Reference<BackupContainerFileSystem>::addRef(this)](
+	                 const FilesAndSizesT& files) -> Future<std::vector<RangeFile>> {
+		             return map(self->ensureEncryptionPropertiesLoaded(), [=](bool) {
+			             std::vector<RangeFile> results;
+			             RangeFile rf;
+			             for (auto& f : files) {
+				             if (BackupContainerFileSystemImpl::pathToRangeFile(rf, f.first, f.second) &&
+				                 rf.version >= beginVersion && rf.version <= endVersion) {
+					             if (self->usesEncryption() && self->encryptionFormatVersion != FormatVersion::V1) {
+						             rf.fileSize =
+						                 AsyncFileEncrypted::rawToLogicalSize(rf.fileSize, self->encryptionBlockSize);
+					             }
+					             results.push_back(rf);
+				             }
+			             }
+			             return results;
+		             });
+	             });
 
 	return map(success(oldFiles) && success(newFiles), [=](Void _) {
 		std::vector<RangeFile> results = newFiles.get();
@@ -1922,6 +1953,14 @@ bool BackupContainerFileSystem::usesEncryption() const {
 }
 Future<Void> BackupContainerFileSystem::encryptionSetupComplete() const {
 	return encryptionSetupFuture;
+}
+
+Future<bool> BackupContainerFileSystem::ensureEncryptionPropertiesLoaded() {
+	if (!encryptionPropertiesLoadFuture.isValid()) {
+		encryptionPropertiesLoadFuture =
+		    BackupContainerFileSystemImpl::readEncryptionMetadata(Reference<BackupContainerFileSystem>::addRef(this));
+	}
+	return encryptionPropertiesLoadFuture;
 }
 
 Future<Void> BackupContainerFileSystem::writeEntireFileFallback(const std::string& fileName,
@@ -2198,6 +2237,76 @@ TEST_CASE("/backup/containers/localdir/encryptedDescribeWithoutBlockSize") {
 	ASSERT(desc.fileLevelEncryption);
 	ASSERT_EQ(desc.encryptionBlockSize, 4096);
 	ASSERT_EQ(c->getEncryptionBlockSize(), 4096);
+	co_await c->deleteContainer();
+}
+
+TEST_CASE("/backup/containers/localdir/encryptedV1FormatRestore") {
+	std::string containerPath = fmt::format("{}/fdb_backups/{:x}", params.getDataDir(), timer_int());
+	std::string url = fmt::format("file://{}", containerPath);
+	std::string keyFile = fmt::format("{}/test_encryption_key_legacy", params.getDataDir());
+	co_await BackupContainerFileSystem::createTestEncryptionKeyFile(keyFile);
+
+	int encryptionBlockSize = 4096;
+	Reference<IBackupContainer> c = IBackupContainer::openContainer(url, {}, keyFile, encryptionBlockSize);
+	co_await c->create();
+	Reference<BackupContainerFileSystem> bcfs = c.castTo<BackupContainerFileSystem>();
+
+	const int bytes = encryptionBlockSize + 100; // Spans two blocks; the second is partial.
+	std::vector<unsigned char> plaintext(bytes, 0);
+	deterministicRandom()->randomBytes(plaintext.data(), bytes);
+
+	Reference<IBackupFile> outFile = co_await c->writeLogFile(1, 2, encryptionBlockSize);
+	const std::string relPath = outFile->getFileName();
+	co_await outFile->append(plaintext.data(), bytes);
+	co_await outFile->finish();
+
+	// Remove each block's trailing GCM tag to convert the on-disk file into V1 format.
+	std::string fullPath = joinPath(containerPath, relPath);
+	int flags =
+	    IAsyncFile::OPEN_READWRITE | IAsyncFile::OPEN_UNBUFFERED | IAsyncFile::OPEN_UNCACHED | IAsyncFile::OPEN_NO_AIO;
+	Reference<IAsyncFile> rawFile = co_await IAsyncFileSystem::filesystem()->open(fullPath, flags, 0644);
+	int64_t rawSize = co_await rawFile->size();
+	std::vector<unsigned char> rawBytes(rawSize, 0);
+	int r = co_await rawFile->read(rawBytes.data(), rawSize, 0);
+	ASSERT_EQ(r, rawSize);
+
+	const int rawBlockSize = encryptionBlockSize + GCM_TAG_LEN;
+	std::vector<unsigned char> v1FileBytes;
+	v1FileBytes.reserve(bytes);
+	int64_t offset = 0;
+	while (offset < rawSize) {
+		int64_t blockLen = std::min<int64_t>(rawBlockSize, rawSize - offset);
+		int64_t ciphertextLen = blockLen - GCM_TAG_LEN;
+		ASSERT(ciphertextLen > 0);
+		v1FileBytes.insert(v1FileBytes.end(), rawBytes.begin() + offset, rawBytes.begin() + offset + ciphertextLen);
+		offset += blockLen;
+	}
+	ASSERT_EQ(v1FileBytes.size(), bytes);
+
+	co_await rawFile->truncate(0);
+	co_await rawFile->write(v1FileBytes.data(), v1FileBytes.size(), 0);
+	co_await rawFile->sync();
+	rawFile.clear();
+
+	// Overwrite the encryption metadata to look like a pre-versioning container.
+	JsonBuilderObject doc;
+	doc.setKey("is_encryption_enabled", true);
+	doc.setKey("encryption_block_size", encryptionBlockSize);
+	co_await bcfs->writeEntireFile("properties/encryption_metadata", doc.getJson());
+
+	BackupDescription desc = co_await c->describeBackup(true);
+	ASSERT(desc.fileLevelEncryption);
+	ASSERT(desc.encryptionFormatVersion == FormatVersion::V1);
+	ASSERT(c->getEncryptionFormatVersion() == FormatVersion::V1);
+
+	Reference<IAsyncFile> file = co_await c->readFile(relPath);
+	int64_t fileSize = co_await file->size();
+	ASSERT_EQ(fileSize, bytes);
+	std::vector<unsigned char> readBuffer(bytes, 0);
+	int bytesRead = co_await file->read(readBuffer.data(), bytes, 0);
+	ASSERT_EQ(bytesRead, bytes);
+	ASSERT(plaintext == readBuffer);
+
 	co_await c->deleteContainer();
 }
 

--- a/fdbclient/BackupContainerLocalDirectory.cpp
+++ b/fdbclient/BackupContainerLocalDirectory.cpp
@@ -235,7 +235,7 @@ Future<Reference<IAsyncFile>> BackupContainerLocalDirectory::readFile(const std:
 	int flags = IAsyncFile::OPEN_NO_AIO | IAsyncFile::OPEN_READONLY | IAsyncFile::OPEN_UNCACHED;
 	INJECT_BLOB_FAULT(http_request_failed, "BackupContainerLocalDirectory::readFile");
 	// Simulation does not properly handle opening the same file from multiple machines using a shared filesystem,
-	// so create a symbolic link to make each file opening appear to be unique.  This could also work in production
+	// so create a symbolic link to make each file opening appear to be unique. This could also work in production
 	// but only if the source directory is writeable which shouldn't be required for a restore.
 	std::string fullPath = joinPath(m_path, path);
 #ifndef _WIN32
@@ -253,16 +253,22 @@ Future<Reference<IAsyncFile>> BackupContainerLocalDirectory::readFile(const std:
 		fullPath = uniquePath;
 	}
 // Opening cached mode forces read/write mode at a lower level, overriding the readonly request.  So cached mode
-// can't be used because backup files are read-only.  Cached mode can only help during restore task retries handled
+// can't be used because backup files are read-only. Cached mode can only help during restore task retries handled
 // by the same process that failed the first task execution anyway, which is a very rare case.
 #endif
 	Future<Reference<IAsyncFile>> f = IAsyncFileSystem::filesystem()->open(fullPath, flags, 0644);
 	// Skip encryption for properties/ folder
 	if (usesEncryption() && !StringRef(path).startsWith("properties/"_sr)) {
-		int encBlockSize = encryptionBlockSize;
-		f = map(f, [encBlockSize](Reference<IAsyncFile> r) {
-			return Reference<IAsyncFile>(
-			    makeReference<AsyncFileEncrypted>(r, AsyncFileEncrypted::Mode::READ_ONLY, encBlockSize));
+		Reference<BackupContainerLocalDirectory> self = Reference<BackupContainerLocalDirectory>::addRef(this);
+		f = mapAsync(f, [self](Reference<IAsyncFile> r) -> Future<Reference<IAsyncFile>> {
+			return mapAsync(self->encryptionSetupComplete(), [self, r](Void) {
+				return map(self->ensureEncryptionPropertiesLoaded(), [self, r](bool) {
+					return Reference<IAsyncFile>(makeReference<AsyncFileEncrypted>(r,
+					                                                               AsyncFileEncrypted::Mode::READ_ONLY,
+					                                                               self->encryptionBlockSize,
+					                                                               self->encryptionFormatVersion));
+				});
+			});
 		});
 	}
 
@@ -302,10 +308,12 @@ Future<Reference<IBackupFile>> BackupContainerLocalDirectory::writeFile(const st
 	Future<Reference<IAsyncFile>> f = IAsyncFileSystem::filesystem()->open(temp, flags, 0644);
 	// Skip encryption for properties/ folder
 	if (usesEncryption() && !StringRef(path).startsWith("properties/"_sr)) {
-		int encBlockSize = encryptionBlockSize;
-		f = map(f, [encBlockSize](Reference<IAsyncFile> r) {
-			return Reference<IAsyncFile>(
-			    makeReference<AsyncFileEncrypted>(r, AsyncFileEncrypted::Mode::APPEND_ONLY, encBlockSize));
+		Reference<BackupContainerLocalDirectory> self = Reference<BackupContainerLocalDirectory>::addRef(this);
+		f = mapAsync(f, [self](Reference<IAsyncFile> r) -> Future<Reference<IAsyncFile>> {
+			return map(self->encryptionSetupComplete(), [self, r](Void) {
+				return Reference<IAsyncFile>(makeReference<AsyncFileEncrypted>(
+				    r, AsyncFileEncrypted::Mode::APPEND_ONLY, self->encryptionBlockSize, CURRENT_FORMAT_VERSION));
+			});
 		});
 	}
 	return map(f, [=](Reference<IAsyncFile> file) -> Reference<IBackupFile> {

--- a/fdbclient/include/fdbclient/BackupContainer.h
+++ b/fdbclient/include/fdbclient/BackupContainer.h
@@ -27,6 +27,7 @@
 #include "fdbclient/FDBTypes.h"
 #include "fdbclient/NativeAPI.actor.h"
 #include "fdbclient/ReadYourWrites.h"
+#include "flow/EncryptionFormatVersion.h"
 #include <vector>
 
 FDB_BOOLEAN_PARAM(IncludeKeyRangeMap);
@@ -232,6 +233,8 @@ struct BackupDescription {
 	MutationLogType mutationLogType;
 	bool fileLevelEncryption; // If this backup contains encrypted files.
 	int encryptionBlockSize; // Block size used for file encryption, 0 if not encrypted.
+	// Format version of the encrypted backup.
+	FormatVersion encryptionFormatVersion = CURRENT_FORMAT_VERSION;
 
 	// Resolves the versions above to timestamps using a given database's TimeKeeper data.
 	// toString will use this information if present.
@@ -391,6 +394,9 @@ public:
 
 	virtual int getEncryptionBlockSize() const { return 0; }
 	virtual void setEncryptionBlockSize(int blockSize) {}
+
+	virtual FormatVersion getEncryptionFormatVersion() const { return CURRENT_FORMAT_VERSION; }
+	virtual void setEncryptionFormatVersion(FormatVersion v) {}
 
 	// TODO: change the following back to `private` once blob obj access is refactored
 protected:

--- a/fdbclient/include/fdbclient/BackupContainerFileSystem.h
+++ b/fdbclient/include/fdbclient/BackupContainerFileSystem.h
@@ -173,8 +173,13 @@ public:
 	// Waits for encryption initialization to complete by reading encryption key file during container opening.
 	Future<Void> encryptionSetupComplete() const override;
 
+	Future<bool> ensureEncryptionPropertiesLoaded();
+
 	int getEncryptionBlockSize() const override { return encryptionBlockSize; }
 	void setEncryptionBlockSize(int blockSize) override { encryptionBlockSize = blockSize; }
+
+	FormatVersion getEncryptionFormatVersion() const override { return encryptionFormatVersion; }
+	void setEncryptionFormatVersion(FormatVersion v) override { encryptionFormatVersion = v; }
 
 protected:
 	// Returns true if an encryption key file was provided.
@@ -185,6 +190,7 @@ protected:
 	Future<Void> writeEntireFileFallback(const std::string& fileName, const std::string& fileContents);
 
 	int encryptionBlockSize = 0;
+	FormatVersion encryptionFormatVersion = CURRENT_FORMAT_VERSION;
 
 private:
 	struct VersionProperty {
@@ -223,6 +229,7 @@ private:
 	friend class BackupContainerFileSystemImpl;
 
 	Future<Void> encryptionSetupFuture;
+	Future<bool> encryptionPropertiesLoadFuture;
 };
 
 #endif

--- a/fdbrpc/AsyncFileEncrypted.cpp
+++ b/fdbrpc/AsyncFileEncrypted.cpp
@@ -44,9 +44,19 @@ public:
 		return iv;
 	}
 
-	// Read a single block of encryptionBlockSize bytes plus the trailing GCM tag, verify tag, and decrypt.
+	// Read a single encrypted block from disk and return the decrypted plaintext.
 	static Future<Standalone<StringRef>> readBlock(AsyncFileEncrypted* self, uint32_t block) {
 		Arena arena;
+		if (self->formatVersion == FormatVersion::V1) {
+			auto* encrypted = new (arena) unsigned char[self->encryptionBlockSize];
+			int bytes = co_await uncancellable(holdWhile(
+			    arena,
+			    self->file->read(encrypted, self->encryptionBlockSize, int64_t(self->encryptionBlockSize) * block)));
+			StreamCipherKey const* cipherKey = StreamCipherKey::getGlobalCipherKey();
+			DecryptionStreamCipher decryptor(cipherKey, self->getIV(block));
+			auto decrypted = decryptor.decrypt(encrypted, bytes, arena);
+			co_return Standalone<StringRef>(decrypted, arena);
+		}
 		const int rawBlockSize = self->encryptionBlockSize + GCM_TAG_LEN;
 		auto* encrypted = new (arena) unsigned char[rawBlockSize];
 		int bytes = co_await uncancellable(
@@ -67,7 +77,9 @@ public:
 	static Future<int> read(Reference<AsyncFileEncrypted> self, void* data, int length, int64_t offset) {
 		if (self->fileSize == -1) {
 			int64_t rawSize = co_await self->file->size();
-			self->fileSize = AsyncFileEncrypted::rawToLogicalSize(rawSize, self->encryptionBlockSize);
+			self->fileSize = (self->formatVersion == FormatVersion::V1)
+			                     ? rawSize
+			                     : AsyncFileEncrypted::rawToLogicalSize(rawSize, self->encryptionBlockSize);
 		}
 		if (offset >= self->fileSize) {
 			co_return 0;
@@ -143,9 +155,14 @@ public:
 	}
 };
 
-AsyncFileEncrypted::AsyncFileEncrypted(Reference<IAsyncFile> file, Mode mode, int encryptionBlockSize)
-  : file(file), mode(mode), currentBlock(0), encryptionBlockSize(encryptionBlockSize) {
+AsyncFileEncrypted::AsyncFileEncrypted(Reference<IAsyncFile> file,
+                                       Mode mode,
+                                       int encryptionBlockSize,
+                                       FormatVersion formatVersion)
+  : file(file), mode(mode), currentBlock(0), encryptionBlockSize(encryptionBlockSize), formatVersion(formatVersion) {
 	ASSERT(encryptionBlockSize > 0);
+	// Assert if writing (APPEND_ONLY) is attempted on a legacy (v1) file. Writes always use CURRENT_FORMAT_VERSION.
+	ASSERT(mode != Mode::APPEND_ONLY || formatVersion == CURRENT_FORMAT_VERSION);
 	firstBlockIV = AsyncFileEncryptedImpl::getFirstBlockIV(file->getFilename());
 	if (mode == Mode::APPEND_ONLY) {
 		writeBuffer = std::vector<unsigned char>(encryptionBlockSize, 0);
@@ -197,6 +214,7 @@ Future<Void> AsyncFileEncrypted::zeroRange(int64_t offset, int64_t length) {
 
 Future<Void> AsyncFileEncrypted::truncate(int64_t size) {
 	ASSERT(mode == Mode::APPEND_ONLY);
+	// Writes always use CURRENT_FORMAT_VERSION.
 	return file->truncate(logicalToRawSize(size, encryptionBlockSize));
 }
 
@@ -212,6 +230,9 @@ Future<Void> AsyncFileEncrypted::flush() {
 
 Future<int64_t> AsyncFileEncrypted::size() const {
 	ASSERT(mode == Mode::READ_ONLY);
+	if (formatVersion == FormatVersion::V1) {
+		return file->size();
+	}
 	int blockSize = encryptionBlockSize;
 	return map(file->size(), [blockSize](int64_t raw) { return rawToLogicalSize(raw, blockSize); });
 }
@@ -272,8 +293,8 @@ TEST_CASE("fdbrpc/AsyncFileEncrypted") {
 	            IAsyncFile::OPEN_UNBUFFERED | IAsyncFile::OPEN_UNCACHED | IAsyncFile::OPEN_NO_AIO;
 	Reference<IAsyncFile> rawFile = co_await IAsyncFileSystem::filesystem()->open(
 	    joinPath(params.getDataDir(), "test-encrypted-file"), flags, 0600);
-	Reference<IAsyncFile> file =
-	    makeReference<AsyncFileEncrypted>(rawFile, AsyncFileEncrypted::Mode::APPEND_ONLY, encryptionBlockSize);
+	Reference<IAsyncFile> file = makeReference<AsyncFileEncrypted>(
+	    rawFile, AsyncFileEncrypted::Mode::APPEND_ONLY, encryptionBlockSize, CURRENT_FORMAT_VERSION);
 	int bytesWritten = 0;
 	int chunkSize;
 	while (bytesWritten < bytes) {
@@ -282,7 +303,8 @@ TEST_CASE("fdbrpc/AsyncFileEncrypted") {
 		bytesWritten += chunkSize;
 	}
 	co_await file->sync();
-	file = makeReference<AsyncFileEncrypted>(rawFile, AsyncFileEncrypted::Mode::READ_ONLY, encryptionBlockSize);
+	file = makeReference<AsyncFileEncrypted>(
+	    rawFile, AsyncFileEncrypted::Mode::READ_ONLY, encryptionBlockSize, CURRENT_FORMAT_VERSION);
 	int bytesRead = 0;
 	while (bytesRead < bytes) {
 		chunkSize = std::min(deterministicRandom()->randomInt(0, 100), bytes - bytesRead);

--- a/fdbrpc/include/fdbrpc/AsyncFileEncrypted.h
+++ b/fdbrpc/include/fdbrpc/AsyncFileEncrypted.h
@@ -25,10 +25,12 @@
 #include "flow/flow.h"
 #include "flow/IRandom.h"
 #include "flow/StreamCipher.h"
+#include "flow/EncryptionFormatVersion.h"
 
 /*
  * Append-only file encrypted using AES-256-GCM.
- * */
+ *
+ */
 class AsyncFileEncrypted : public IAsyncFile, public ReferenceCounted<AsyncFileEncrypted> {
 public:
 	enum class Mode { APPEND_ONLY, READ_ONLY };
@@ -49,10 +51,11 @@ private:
 	int offsetInBlock{ 0 };
 	std::vector<unsigned char> writeBuffer;
 	int encryptionBlockSize{ 0 };
+	FormatVersion formatVersion{ CURRENT_FORMAT_VERSION };
 	Future<Void> initialize();
 
 public:
-	AsyncFileEncrypted(Reference<IAsyncFile>, Mode, int);
+	AsyncFileEncrypted(Reference<IAsyncFile>, Mode, int, FormatVersion);
 	void addref() override;
 	void delref() override;
 	Future<int> read(void* data, int length, int64_t offset) override;
@@ -67,10 +70,14 @@ public:
 	void releaseZeroCopy(void* data, int length, int64_t offset) override;
 	int64_t debugFD() const override;
 
+	FormatVersion getFormatVersion() const { return formatVersion; }
+
 	// Convert raw on-disk file size (including per-block GCM tags) to logical plaintext size.
 	// Pure math, no I/O. blockSize is the plaintext block size (encryptionBlockSize).
+	// Only meaningful for formatVersion >= V2. For V1, raw size equals logical size.
 	static int64_t rawToLogicalSize(int64_t rawSize, int blockSize);
 
 	// Inverse of rawToLogicalSize: given a logical plaintext size, return the raw on-disk size.
+	// Only meaningful for formatVersion >= V2. For V1, raw size equals logical size.
 	static int64_t logicalToRawSize(int64_t logicalSize, int blockSize);
 };

--- a/flow/include/flow/EncryptionFormatVersion.h
+++ b/flow/include/flow/EncryptionFormatVersion.h
@@ -1,0 +1,30 @@
+/*
+ * EncryptionFormatVersion.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+enum class FormatVersion : int {
+	// Each block is exactly encryptionBlockSize bytes of ciphertext.
+	V1 = 1,
+	// Each block is exactly encryptionBlockSize bytes of ciphertext, followed by a 16-byte
+	// GCM authentication tag.
+	V2 = 2,
+};
+constexpr FormatVersion CURRENT_FORMAT_VERSION = FormatVersion::V2;


### PR DESCRIPTION
###  Summary
A previous fix  https://github.com/apple/foundationdb/pull/13661 corrected encrypted backups to actually verify their authentication tag. That fix changes the on-disk layout of encrypted files, which breaks restoring any backup written before it.

This PR adds backward compatibility so it can restore from backups without tags (old format). 
It introduces a FormatVersion which is stored in properties folder, with the current version being V2, so that any future change that breaks compatibility can be added as a new version and handled explicitly.

During restore, we read the properties file once and use that data (format version, block size) wherever needed through `ensureEncryptionPropertiesLoaded` which can be extended later to new entries if needed. 

> **Note: This does not support ongoing (already-running) encrypted backups. 
> If a running backup is upgraded to this fix, it will end up with a mix of files with and without tags, making it difficult to restore. (Will call this out in the release notes for 7.4, and for 7.3 if this is backported there.)**

### Testing
- 100k simulation completed 
`  20260723-043802-ak_backward_compat_14-3907b4853b3951b4 compressed=True data_size=38421275 duration=2827666 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:33:00 sanity=False started=100000 stopped=20260723-051102 submitted=20260723-043802 timeout=5400 username=ak_backward_compat_14`

error in tests/fast/SimpleAtomicAdd.toml unrelated to this change.
- Added unit test to verify the change
- Also tested manually by modifying  the ctest script to backup using 7.4.6 (without tag) and restore and verified data restored using main + this PR.