### PR TITLE
Protect `Transaction#close` in `Database#runAsync` from cancellation

### DIFF
--- a/bindings/java/src/junit/com/apple/foundationdb/AsyncTransactionCloseTest.java
+++ b/bindings/java/src/junit/com/apple/foundationdb/AsyncTransactionCloseTest.java
@@ -1,0 +1,82 @@
+/*
+ * AsyncTransactionCloseTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.apple.foundationdb;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that transactions opened by `Database#runAsync` are always closed.
+ *
+ * These tests do _not_ require a running FDB server to function. Instead, we
+ * are operating on a good-faith "The underlying native library is correct"
+ * functionality. For end-to-end tests which require a running server, see the
+ * src/tests source folder.
+ */
+class AsyncTransactionCloseTest {
+	private static Executor EXECUTOR = new Executor() {
+			@Override
+			public void execute(Runnable command) {
+				command.run();
+			}
+		};
+
+	private static Database makeFakeDatabase(final AtomicBoolean transactionClosed) {
+		final AtomicReference<Database> db = new AtomicReference<>();
+
+		db.set(new FDBDatabase(0, EXECUTOR) {
+			@Override
+			public Transaction createTransaction(final Executor e) {
+				return new FakeFDBTransaction(List.<KeyValue>of(), 0, db.get(), e) {
+					@Override
+					public void close() {
+						transactionClosed.set(true);
+					}
+				};
+			}
+
+			@Override
+			public void setOption(int code, byte[] value) {
+			}
+		});
+
+		return db.get();
+	}
+
+	@Test
+	public void asyncTransactionClose() {
+		final AtomicBoolean transactionClosed = new AtomicBoolean(false);
+
+		final Database db = makeFakeDatabase(transactionClosed);
+		final CompletableFuture<Void> someLongOperation = new CompletableFuture<>();
+		final CompletableFuture<Void> runFuture = db.runAsync(t -> someLongOperation);
+		runFuture.cancel(true);
+		someLongOperation.complete(null);
+
+		assertTrue(transactionClosed.get());
+	}
+}

--- a/bindings/java/src/main/com/apple/foundationdb/FDBDatabase.java
+++ b/bindings/java/src/main/com/apple/foundationdb/FDBDatabase.java
@@ -102,8 +102,8 @@ class FDBDatabase extends NativeObjectWrapper implements Database, OptionConsume
 					});
 				}, e);
 		}, e)
-		.thenApply(o -> returnValue.get())
-		.whenComplete((v, t) -> trRef.get().close());
+		.whenComplete((v, t) -> trRef.get().close())
+		.thenApply(o -> returnValue.get());
 	}
 
 	@Override

--- a/bindings/java/src/tests.cmake
+++ b/bindings/java/src/tests.cmake
@@ -34,6 +34,7 @@ set(JAVA_JUNIT_TESTS
   src/junit/com/apple/foundationdb/tuple/TupleSerializationTest.java
   src/junit/com/apple/foundationdb/RangeQueryTest.java
   src/junit/com/apple/foundationdb/EventKeeperTest.java
+  src/junit/com/apple/foundationdb/AsyncTransactionCloseTest.java
   )
 
 # Resources that are used in unit testing, but are not explicitly test files (JUnit rules, utility


### PR DESCRIPTION
`FDBDatabase#runAsync` returns a future on a complicated chain of retry and cleanup logic to create a transaction, run the user-supplied closure, commit the transaction, and close it. The final future actually returned is the result of `CompletableFuture#whenComplete(/* close the open transaction */)`.

Unfortunately, this means that if the returned future is cancelled, the `whenComplete` callback is also not called, resulting in the last-opened transaction not being closed, and in turn `Transaction not closed` warnings appearing on stderr.

This change fixes that problem by swapping the order of two `CompletableFuture` method calls, moving the `whenComplete` above a `CompletableFuture#thenApply` call that fixes up the return value to what `runAsync`'s future is expected to supply. Cancelling *that* future is not a problem, since the fixed-up return value would be clobbered by the resulting `CancellationException` anyway, and `CompletableFuture` cancellation does not propagate to parent futures' tasks.

We also add a unit test verifying the behavior of `db.runAsync(something).cancel(true)` with respect to closing opened transactions. This test reliably fails without the change to `FDBDatabase` and passes with it.