### PR TITLE
Preserve backup recruitment fitness when preferring reliable workers

### DIFF
--- a/fdbserver/clustercontroller/ClusterController.h
+++ b/fdbserver/clustercontroller/ClusterController.h
@@ -28,6 +28,8 @@
 #include "fdbclient/StorageServerInterface.h"
 #include "fdbrpc/Replication.h"
 #include "fdbrpc/ReplicationUtils.h"
+#include "fdbrpc/SimulatorProcessInfo.h"
+#include "fdbrpc/simulator.h"
 #include "ClusterHealthMonitor.h"
 #include "RatekeeperMonitor.h"
 #include "fdbserver/core/Knobs.h"
@@ -1507,7 +1509,7 @@ public:
 	    std::map<Optional<Standalone<StringRef>>, int> preferredSharing = {},
 	    Optional<WorkerFitnessInfo> minWorker = Optional<WorkerFitnessInfo>(),
 	    bool checkStable = false) {
-		std::map<std::tuple<recruitment::Fitness, int, bool, int>, std::vector<WorkerDetails>> fitness_workers;
+		std::map<std::tuple<recruitment::Fitness, int, bool, bool, int>, std::vector<WorkerDetails>> fitness_workers;
 		std::vector<WorkerDetails> results;
 		if (minWorker.present()) {
 			results.push_back(minWorker.get().worker);
@@ -1527,10 +1529,14 @@ public:
 			      (fitness < minWorker.get().fitness ||
 			       (fitness == minWorker.get().fitness && id_used[it.first] <= minWorker.get().used))))) {
 				auto sharing = preferredSharing.find(it.first);
-				fitness_workers[std::make_tuple(fitness,
-				                                id_used[it.first],
-				                                isLongLivedStateless(it.first),
-				                                sharing != preferredSharing.end() ? sharing->second : 1e6)]
+				fitness_workers[std::make_tuple(
+				                    fitness,
+				                    id_used[it.first],
+				                    role == recruitment::Backup && g_network->isSimulated() &&
+				                        !g_simulator->getProcessByAddress(it.second.details.interf.address())
+				                             ->isReliable(),
+				                    isLongLivedStateless(it.first),
+				                    sharing != preferredSharing.end() ? sharing->second : 1e6)]
 				    .push_back(it.second.details);
 			}
 		}

--- a/fdbserver/clustercontroller/ClusterController.h
+++ b/fdbserver/clustercontroller/ClusterController.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <algorithm>
+#include <compare>
 #include <utility>
 
 #include "fdbclient/DatabaseContext.h"
@@ -1509,7 +1510,17 @@ public:
 	    std::map<Optional<Standalone<StringRef>>, int> preferredSharing = {},
 	    Optional<WorkerFitnessInfo> minWorker = Optional<WorkerFitnessInfo>(),
 	    bool checkStable = false) {
-		std::map<std::tuple<recruitment::Fitness, int, bool, bool, int>, std::vector<WorkerDetails>> fitness_workers;
+		struct WorkerFitnessKey {
+			recruitment::Fitness fitness;
+			int used;
+			bool unreliableBackup;
+			bool longLivedStateless;
+			int sharing;
+
+			std::strong_ordering operator<=>(WorkerFitnessKey const&) const = default;
+		};
+
+		std::map<WorkerFitnessKey, std::vector<WorkerDetails>> fitness_workers;
 		std::vector<WorkerDetails> results;
 		if (minWorker.present()) {
 			results.push_back(minWorker.get().worker);
@@ -1529,14 +1540,13 @@ public:
 			      (fitness < minWorker.get().fitness ||
 			       (fitness == minWorker.get().fitness && id_used[it.first] <= minWorker.get().used))))) {
 				auto sharing = preferredSharing.find(it.first);
-				fitness_workers[std::make_tuple(
-				                    fitness,
-				                    id_used[it.first],
-				                    role == recruitment::Backup && g_network->isSimulated() &&
-				                        !g_simulator->getProcessByAddress(it.second.details.interf.address())
-				                             ->isReliable(),
-				                    isLongLivedStateless(it.first),
-				                    sharing != preferredSharing.end() ? sharing->second : 1e6)]
+				fitness_workers[{ fitness,
+				                  id_used[it.first],
+				                  role == recruitment::Backup && g_network->isSimulated() &&
+				                      !g_simulator->getProcessByAddress(it.second.details.interf.address())
+				                           ->isReliable(),
+				                  isLongLivedStateless(it.first),
+				                  sharing != preferredSharing.end() ? sharing->second : 1'000'000 }]
 				    .push_back(it.second.details);
 			}
 		}


### PR DESCRIPTION
## Summary

A fault-injected simulated machine can remain registered while its local I/O is unreliable. Backup recruitment must avoid that worker when an equivalent healthy candidate exists, but filtering all unreliable workers before normal fitness and process-sharing order can make two recovery recruitments disagree on backup-worker fitness.

Use simulated-worker reliability as a Backup-only tie-breaker after process fitness and usage, before long-lived and sharing preferences. This keeps recruitment fitness deterministic, prefers healthy backup workers, and preserves the normal fallback and requested worker count when reliable capacity is insufficient. Production recruitment is unchanged.

## Testing

- `fdbserver_clustercontroller_test --simulation` (22 passed)
- `slow/BackupAndRestore` with buggify and fault injection (passed)
- `slow/BackupCorrectnessPartitioned` with targeted persistent Attrition fault injection (passed; no post-fault backup-worker failures or recovery retries)
- `fast/BackupCorrectness` with fault injection (passed)
