### PR TITLE
Backport overall status timeout budget to release-7.4

### DIFF
--- a/fdbclient/StatusClient.actor.cpp
+++ b/fdbclient/StatusClient.actor.cpp
@@ -422,9 +422,10 @@ ACTOR Future<StatusObject> clientStatusFetcher(Reference<IClusterConnectionRecor
 // Cluster section of json output
 ACTOR Future<Optional<StatusObject>> clusterStatusFetcher(ClusterInterface cI,
                                                           StatusArray* messages,
-                                                          std::string statusField) {
+                                                          std::string statusField,
+                                                          double timeoutSeconds) {
 	state StatusRequest req(statusField);
-	state Future<Void> clusterTimeout = delay(CLIENT_KNOBS->STATUS_TIMEOUT);
+	state Future<Void> clusterTimeout = delay(timeoutSeconds);
 	state Optional<StatusObject> oStatusObj;
 
 	wait(delay(0.0)); // make sure the cluster controller is marked as not failed
@@ -460,6 +461,27 @@ ACTOR Future<Optional<StatusObject>> clusterStatusFetcher(ClusterInterface cI,
 	}
 
 	return oStatusObj;
+}
+
+TEST_CASE("/fdbclient/status/overallTimeoutBudget") {
+	state ClusterInterface clusterInterface;
+	state StatusArray messages;
+	state double overallTimeout = 0.2;
+	state double coordinatorProbeDuration = 0.1;
+	state double startTime = now();
+	state double statusDeadline = startTime + overallTimeout;
+
+	wait(delay(coordinatorProbeDuration));
+	state Optional<StatusObject> status = wait(
+	    clusterStatusFetcher(clusterInterface, &messages, "", std::max(0.0, statusDeadline - now())));
+
+	double elapsed = now() - startTime;
+	ASSERT(!status.present());
+	ASSERT_EQ(messages.size(), 1);
+	ASSERT_EQ(messages.front().get_obj().at("name").get_str(), "status_incomplete_timeout");
+	ASSERT_GE(elapsed, overallTimeout);
+	ASSERT_LT(elapsed, overallTimeout + 0.05);
+	return Void();
 }
 
 // Create and return a database_status section.
@@ -516,6 +538,9 @@ ACTOR Future<StatusObject> statusFetcherImpl(Reference<IClusterConnectionRecord>
 	if (!g_network)
 		throw network_not_setup();
 
+	// Keep the overall status request within STATUS_TIMEOUT, including the client-side coordinator probe that runs
+	// before we ask the cluster controller for its status payload.
+	state double statusDeadline = now() + CLIENT_KNOBS->STATUS_TIMEOUT;
 	state StatusObject statusObj;
 	state StatusObject statusObjClient;
 	state StatusArray clientMessages;
@@ -549,12 +574,15 @@ ACTOR Future<StatusObject> statusFetcherImpl(Reference<IClusterConnectionRecord>
 	if (quorum_reachable) {
 		try {
 
-			state Future<Void> interfaceTimeout = delay(2.0);
+			state Future<Void> interfaceTimeout = delay(std::min(2.0, std::max(0.0, statusDeadline - now())));
 
 			loop {
 				if (clusterInterface->get().present()) {
-					Optional<StatusObject> _statusObjCluster =
-					    wait(clusterStatusFetcher(clusterInterface->get().get(), &clientMessages, statusField));
+					Optional<StatusObject> _statusObjCluster = wait(clusterStatusFetcher(clusterInterface->get().get(),
+					                                                                        &clientMessages,
+					                                                                        statusField,
+					                                                                        std::max(0.0,
+					                                                                                 statusDeadline - now())));
 					if (_statusObjCluster.present()) {
 						statusObjCluster = _statusObjCluster.get();
 						// TODO: this is a temporary fix, getting the number of available coordinators should move to

--- a/fdbclient/StatusClient.actor.cpp
+++ b/fdbclient/StatusClient.actor.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "flow/flow.h"
+#include "fdbclient/ClusterConnectionMemoryRecord.h"
 #include "fdbclient/CoordinationInterface.h"
 #include "fdbclient/MonitorLeader.h"
 #include "fdbclient/ClusterInterface.h"
@@ -305,7 +306,8 @@ void JSONDoc::mergeValueInto(json_spirit::mValue& dst, const json_spirit::mValue
 // Will not throw, will just return non-present Optional if error
 ACTOR Future<Optional<StatusObject>> clientCoordinatorsStatusFetcher(Reference<IClusterConnectionRecord> connRecord,
                                                                      bool* quorum_reachable,
-                                                                     int* coordinatorsFaultTolerance) {
+                                                                     int* coordinatorsFaultTolerance,
+                                                                     double statusDeadline) {
 	try {
 		state ClientCoordinators coord(connRecord);
 		state StatusObject statusObj;
@@ -340,7 +342,7 @@ ACTOR Future<Optional<StatusObject>> clientCoordinatorsStatusFetcher(Reference<I
 
 		wait(smartQuorum(leaderServers, leaderServers.size() / 2 + 1, 1.5) &&
 		         smartQuorum(coordProtocols, coordProtocols.size() / 2 + 1, 1.5) ||
-		     delay(2.0));
+		     delay(std::min(2.0, std::max(0.0, statusDeadline - now()))));
 
 		statusObj["quorum_reachable"] = *quorum_reachable =
 		    quorum(leaderServers, leaderServers.size() / 2 + 1).isReady();
@@ -380,11 +382,12 @@ ACTOR Future<Optional<StatusObject>> clientCoordinatorsStatusFetcher(Reference<I
 ACTOR Future<StatusObject> clientStatusFetcher(Reference<IClusterConnectionRecord> connRecord,
                                                StatusArray* messages,
                                                bool* quorum_reachable,
-                                               int* coordinatorsFaultTolerance) {
+                                               int* coordinatorsFaultTolerance,
+                                               double statusDeadline) {
 	state StatusObject statusObj;
 
 	state Optional<StatusObject> coordsStatusObj =
-	    wait(clientCoordinatorsStatusFetcher(connRecord, quorum_reachable, coordinatorsFaultTolerance));
+	    wait(clientCoordinatorsStatusFetcher(connRecord, quorum_reachable, coordinatorsFaultTolerance, statusDeadline));
 	state bool contentsUpToDate = wait(connRecord->upToDate());
 
 	if (coordsStatusObj.present()) {
@@ -472,8 +475,8 @@ TEST_CASE("/fdbclient/status/overallTimeoutBudget") {
 	state double statusDeadline = startTime + overallTimeout;
 
 	wait(delay(coordinatorProbeDuration));
-	state Optional<StatusObject> status = wait(
-	    clusterStatusFetcher(clusterInterface, &messages, "", std::max(0.0, statusDeadline - now())));
+	state Optional<StatusObject> status =
+	    wait(clusterStatusFetcher(clusterInterface, &messages, "", std::max(0.0, statusDeadline - now())));
 
 	double elapsed = now() - startTime;
 	ASSERT(!status.present());
@@ -481,6 +484,25 @@ TEST_CASE("/fdbclient/status/overallTimeoutBudget") {
 	ASSERT_EQ(messages.front().get_obj().at("name").get_str(), "status_incomplete_timeout");
 	ASSERT_GE(elapsed, overallTimeout);
 	ASSERT_LT(elapsed, overallTimeout + 0.05);
+	return Void();
+}
+
+TEST_CASE("/fdbclient/status/clientCoordinatorTimeoutBudget") {
+	state Reference<IClusterConnectionRecord> connRecord =
+	    makeReference<ClusterConnectionMemoryRecord>(ClusterConnectionString("test:test@127.0.0.1:1"));
+	state bool quorumReachable = false;
+	state int coordinatorsFaultTolerance = 0;
+	state double timeout = 0.2;
+	state double startTime = now();
+
+	state Optional<StatusObject> status = wait(clientCoordinatorsStatusFetcher(
+	    connRecord, &quorumReachable, &coordinatorsFaultTolerance, startTime + timeout));
+
+	double elapsed = now() - startTime;
+	ASSERT(status.present());
+	ASSERT(!quorumReachable);
+	ASSERT_GE(elapsed, timeout);
+	ASSERT_LT(elapsed, timeout + 0.05);
 	return Void();
 }
 
@@ -552,8 +574,8 @@ ACTOR Future<StatusObject> statusFetcherImpl(Reference<IClusterConnectionRecord>
 	try {
 		state int64_t clientTime = g_network->timer();
 
-		StatusObject _statusObjClient =
-		    wait(clientStatusFetcher(connRecord, &clientMessages, &quorum_reachable, &coordinatorsFaultTolerance));
+		StatusObject _statusObjClient = wait(clientStatusFetcher(
+		    connRecord, &clientMessages, &quorum_reachable, &coordinatorsFaultTolerance, statusDeadline));
 		statusObjClient = _statusObjClient;
 
 		if (clientTime != -1)
@@ -578,11 +600,11 @@ ACTOR Future<StatusObject> statusFetcherImpl(Reference<IClusterConnectionRecord>
 
 			loop {
 				if (clusterInterface->get().present()) {
-					Optional<StatusObject> _statusObjCluster = wait(clusterStatusFetcher(clusterInterface->get().get(),
-					                                                                        &clientMessages,
-					                                                                        statusField,
-					                                                                        std::max(0.0,
-					                                                                                 statusDeadline - now())));
+					Optional<StatusObject> _statusObjCluster =
+					    wait(clusterStatusFetcher(clusterInterface->get().get(),
+					                              &clientMessages,
+					                              statusField,
+					                              std::max(0.0, statusDeadline - now())));
 					if (_statusObjCluster.present()) {
 						statusObjCluster = _statusObjCluster.get();
 						// TODO: this is a temporary fix, getting the number of available coordinators should move to


### PR DESCRIPTION
This backports [the original overall-budget commit](https://github.com/apple/foundationdb/commit/79de02031e115e4c2644870be0da85f95d0e7777) and the client-phase correction and tests from [#13759](https://github.com/apple/foundationdb/pull/13759) to `release-7.4`. It is the release-7.4 counterpart to the [release-7.3 backport, #13749](https://github.com/apple/foundationdb/pull/13749).

The original change gave controller discovery and the cluster status RPC one shared deadline, but the earlier client-side coordinator quorum probe retained its fixed two-second timeout. That gap allowed `STATUS_TIMEOUT=0.2` to take two seconds during a coordinator outage. This backport carries the deadline through all three phases and includes separate regression coverage for the client probe and cluster RPC budget.

`release-7.4` still uses actor-based `StatusClient.actor.cpp` and supports filtered status requests, so the semantic cherry-pick keeps the actor state and `statusField` API while preserving the original author and source-commit metadata.

Summary of PRs:

1. https://github.com/apple/foundationdb/pull/13210 - this is the original PR that threaded through the status timeout
2. https://github.com/apple/foundationdb/pull/13759 - a new PR that additionally threads the timeout budget to the client and coordinator fetcher, plus adds the test

Then:

1. https://github.com/apple/foundationdb/pull/13749 - backports the two PRs above to 7.3
2. https://github.com/apple/foundationdb/pull/13760 (this PR) - backports the two PRs above to 7.4


Testing:

- Debug `fdbserver` build: passed
- `fdbserver -r unittests -f /fdbclient/status/`: 2 passed

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
