### PR TITLE
Provide exclusion headroom for ExcludeIncludeStorageServers

### DIFF
--- a/tests/slow/ExcludeIncludeStorageServers.toml
+++ b/tests/slow/ExcludeIncludeStorageServers.toml
@@ -1,3 +1,7 @@
+[configuration]
+# Keep one spare machine per datacenter so excluding a storage server cannot exhaust a replicated team.
+extraMachineCountDC = 1
+
 [[knobs]]
 dd_max_shards_on_large_teams=0
 


### PR DESCRIPTION
## Summary

`ExcludeIncludeStorageServers` repeatedly removes one storage-server process and waits for data distribution to evacuate it. A generated two-region configuration can place a triple-replicated region on only three storage machines; excluding any one leaves two distinct machines for a three-server team, so data distribution cannot build a healthy destination and every exclusion times out.

Reserve one additional machine per datacenter for this test. This preserves storage-server churn, failure injection, and multi-region coverage while preventing an impossible team composition.

## Testing

- Reproduced the generated two-region, satellite, Redwood configuration with buggify and fault injection enabled: data distribution repeatedly reported two available machines for a three-server team and exclusions timed out until the simulation exhausted its trace-line limit.
- Ran the corrected-topology simulation plus historical log-router, triple-replication, and adjacent two-region Redwood seeds: 33 exclusions completed with no exclusion timeouts or trace overflow.
- Ran adjacent `GcGenerations` and `ConfigureStorageMigrationTest` simulation coverage.
