### PR TITLE
Avoid transient region repair during upgrade restart test

### DIFF
--- a/tests/restarting/from_7.3.0/UpgradeAndBackupRestore-1.toml
+++ b/tests/restarting/from_7.3.0/UpgradeAndBackupRestore-1.toml
@@ -1,5 +1,8 @@
 [[knobs]]
 dd_max_shards_on_large_teams = 0
+# Give the old tester's one-shot dead-region repair the maximum reboot interval
+# before it can exclude a region that Attrition is intentionally restarting.
+sim_speedup_after_seconds = 470.0
 
 [configuration]
 storageEngineExcludeTypes=[3,5]


### PR DESCRIPTION
## Summary

Keep the old-binary leg of `UpgradeAndBackupRestore` from mistaking an intentionally rebooting single-replica region for a permanently dead region.

The older tester makes a one-shot dead-region decision when its simulation speedup window ends. If that decision lands during the final Attrition reboot, it can exclude the entire remote region and interrupt repopulation at restart. Extend that window by the maximum randomized worker-reboot interval so the region can recover before the decision. This preserves the generated topology, connection-failure coverage, and every Attrition workload.

## Validation

- Reproduced the affected two-step, two-region triple-satellite simulation with buggify and fault injection enabled; both restart legs pass with the change and no region exclusions or zero-machine team failures occur.
- Ran eight additional adjacent randomized two-step simulations with buggify and fault injection enabled: all sixteen restart legs passed.
- Built the clang `package_tests_u` correctness archive, verified its integrity and packaged test content, and reran the affected two-step simulation from that archive successfully.
- `git diff --check` and TOML parsing pass.
