### PR TITLE
Avoid dropped log-router replies in SwizzledCycle

### DIFF
--- a/tests/slow/SwizzledCycleTest.toml
+++ b/tests/slow/SwizzledCycleTest.toml
@@ -1,3 +1,8 @@
+[[knobs]]
+# Dropping a log-router init reply can repeatedly restart recovery and exhaust
+# this test's clear timeout under remote-double Attrition.
+cc_recovery_init_req_allow_drop_in_sim = false
+
 [[test]]
 testTitle = 'SwizzledCycleTest'
 


### PR DESCRIPTION
## Summary

Disable simulated log-router init-reply dropping for `SwizzledCycleTest.toml`. The test already exercises swizzled clogging, two Attrition workloads, and configuration changes; an intentionally dropped old-log-router init reply can repeatedly restart two-region recovery and exhaust post-test database cleanup without exposing a Cycle defect.

## Validation

- Replayed the failing two-region RocksDB configuration with buggify and fault injection enabled: passed with all five workloads retained and database cleanup completed.
- Twelve adjacent randomized simulations passed across mixed storage and region configurations, including another two-region RocksDB case.
- Verified no severe, cleanup, dropped-init-reply, or recovery-initialization-timeout events; TOML parsing and diff checks passed.
